### PR TITLE
gh-105375: Improve _decimal error handling

### DIFF
--- a/Misc/NEWS.d/next/Library/2023-06-09-22-52-45.gh-issue-105375.6igkhn.rst
+++ b/Misc/NEWS.d/next/Library/2023-06-09-22-52-45.gh-issue-105375.6igkhn.rst
@@ -1,0 +1,1 @@
+Fix bug in :mod:`decimal` where an exception could end up being overwritten.

--- a/Modules/_decimal/_decimal.c
+++ b/Modules/_decimal/_decimal.c
@@ -3611,9 +3611,13 @@ dec_as_integer_ratio(PyObject *self, PyObject *args UNUSED)
             goto error;
         }
         Py_SETREF(numerator, _py_long_floor_divide(numerator, tmp));
+        if (numerator == NULL) {
+            Py_DECREF(tmp);
+            goto error;
+        }
         Py_SETREF(denominator, _py_long_floor_divide(denominator, tmp));
         Py_DECREF(tmp);
-        if (numerator == NULL || denominator == NULL) {
+        if (denominator == NULL) {
             goto error;
         }
     }


### PR DESCRIPTION
Fix a bug where an exception could end up being overwritten.


<!-- gh-issue-number: gh-105375 -->
* Issue: gh-105375
<!-- /gh-issue-number -->
