### PR TITLE
gh-105375: Harden error handling in `_testcapi/heaptype.c`

### DIFF
--- a/Modules/_testcapi/heaptype.c
+++ b/Modules/_testcapi/heaptype.c
@@ -661,8 +661,11 @@ heapctypesubclasswithfinalizer_finalize(PyObject *self)
         goto cleanup_finalize;
     }
     oldtype = PyObject_GetAttrString(m, "HeapCTypeSubclassWithFinalizer");
+    if (oldtype == NULL) {
+        goto cleanup_finalize;
+    }
     newtype = PyObject_GetAttrString(m, "HeapCTypeSubclass");
-    if (oldtype == NULL || newtype == NULL) {
+    if (newtype == NULL) {
         goto cleanup_finalize;
     }
 


### PR DESCRIPTION
Bail on first error in heapctypesubclasswithfinalizer_finalize()


<!-- gh-issue-number: gh-105375 -->
* Issue: gh-105375
<!-- /gh-issue-number -->
