### PR TITLE
gh-105375: Improve PyErr_WarnExplicit() error handling

### DIFF
--- a/Misc/NEWS.d/next/C API/2023-06-09-23-34-25.gh-issue-105375.n7amiF.rst
+++ b/Misc/NEWS.d/next/C API/2023-06-09-23-34-25.gh-issue-105375.n7amiF.rst
@@ -1,0 +1,2 @@
+Fix a bug in :c:func:`PyErr_WarnExplicit` where an exception could end up
+being overwritten if the API failed internally.

--- a/Python/_warnings.c
+++ b/Python/_warnings.c
@@ -1312,12 +1312,13 @@ PyErr_WarnExplicit(PyObject *category, const char *text,
             goto exit;
     }
 
-    return PyErr_WarnExplicitObject(category, message, filename, lineno,
-                                    module, registry);
+    int ret = PyErr_WarnExplicitObject(category, message, filename, lineno,
+                                       module, registry);
+    Py_XDECREF(module);
+    return ret;
 
  exit:
     Py_XDECREF(message);
-    Py_XDECREF(module);
     Py_XDECREF(filename);
     return -1;
 }

--- a/Python/_warnings.c
+++ b/Python/_warnings.c
@@ -1299,7 +1299,7 @@ PyErr_WarnExplicit(PyObject *category, const char *text,
 {
     PyObject *message = PyUnicode_FromString(text);
     if (message == NULL) {
-        goto exit;
+        return NULL;
     }
     PyObject *filename = PyUnicode_DecodeFSDefault(filename_str);
     if (filename == NULL) {

--- a/Python/_warnings.c
+++ b/Python/_warnings.c
@@ -1299,28 +1299,27 @@ PyErr_WarnExplicit(PyObject *category, const char *text,
 {
     PyObject *message = PyUnicode_FromString(text);
     if (message == NULL) {
-        return NULL;
+        return -1;
     }
     PyObject *filename = PyUnicode_DecodeFSDefault(filename_str);
     if (filename == NULL) {
-        goto exit;
+        Py_DECREF(message);
+        return -1;
     }
     PyObject *module = NULL;
     if (module_str != NULL) {
         module = PyUnicode_FromString(module_str);
-        if (module == NULL)
-            goto exit;
+        if (module == NULL) {
+            Py_DECREF(filename);
+            Py_DECREF(message);
+            return -1;
+        }
     }
 
     int ret = PyErr_WarnExplicitObject(category, message, filename, lineno,
                                        module, registry);
     Py_XDECREF(module);
     return ret;
-
- exit:
-    Py_XDECREF(message);
-    Py_XDECREF(filename);
-    return -1;
 }
 
 int

--- a/Python/_warnings.c
+++ b/Python/_warnings.c
@@ -1319,6 +1319,8 @@ PyErr_WarnExplicit(PyObject *category, const char *text,
     int ret = PyErr_WarnExplicitObject(category, message, filename, lineno,
                                        module, registry);
     Py_XDECREF(module);
+    Py_DECREF(filename);
+    Py_DECREF(message);
     return ret;
 }
 

--- a/Python/_warnings.c
+++ b/Python/_warnings.c
@@ -1298,12 +1298,16 @@ PyErr_WarnExplicit(PyObject *category, const char *text,
                    const char *module_str, PyObject *registry)
 {
     PyObject *message = PyUnicode_FromString(text);
+    if (message == NULL) {
+        goto exit;
+    }
     PyObject *filename = PyUnicode_DecodeFSDefault(filename_str);
+    if (filename == NULL) {
+        goto exit;
+    }
     PyObject *module = NULL;
     int ret = -1;
 
-    if (message == NULL || filename == NULL)
-        goto exit;
     if (module_str != NULL) {
         module = PyUnicode_FromString(module_str);
         if (module == NULL)

--- a/Python/_warnings.c
+++ b/Python/_warnings.c
@@ -1306,22 +1306,20 @@ PyErr_WarnExplicit(PyObject *category, const char *text,
         goto exit;
     }
     PyObject *module = NULL;
-    int ret = -1;
-
     if (module_str != NULL) {
         module = PyUnicode_FromString(module_str);
         if (module == NULL)
             goto exit;
     }
 
-    ret = PyErr_WarnExplicitObject(category, message, filename, lineno,
-                                   module, registry);
+    return PyErr_WarnExplicitObject(category, message, filename, lineno,
+                                    module, registry);
 
  exit:
     Py_XDECREF(message);
     Py_XDECREF(module);
     Py_XDECREF(filename);
-    return ret;
+    return -1;
 }
 
 int


### PR DESCRIPTION
Bail on first error to prevent exceptions from possibly being
overwritten.


<!-- gh-issue-number: gh-105375 -->
* Issue: gh-105375
<!-- /gh-issue-number -->
