### PR TITLE
gh-105530: Support sending HTTP header values with RFC 2047

### DIFF
--- a/Doc/library/http.client.rst
+++ b/Doc/library/http.client.rst
@@ -436,7 +436,8 @@ also send your request step by step, by using the four functions below.
    Send an :rfc:`822`\ -style header to the server.  It sends a line to the server
    consisting of the header, a colon and a space, and the first argument.  If more
    arguments are given, continuation lines are sent, each consisting of a tab and
-   an argument.
+   an argument. If a header's value cannot be encoded with ISO-8859-1 (latin-1),
+   then it will be put into :rfc:`2047` encoded-word format.
 
 
 .. method:: HTTPConnection.endheaders(message_body=None, *, encode_chunked=False)

--- a/Lib/http/client.py
+++ b/Lib/http/client.py
@@ -70,6 +70,7 @@ Req-sent-unread-response       _CS_REQ_SENT       <response_class>
 
 import email.parser
 import email.message
+import email.header
 import errno
 import http
 import io
@@ -1290,7 +1291,11 @@ class HTTPConnection:
         values = list(values)
         for i, one_value in enumerate(values):
             if hasattr(one_value, 'encode'):
-                values[i] = one_value.encode('latin-1')
+                try:
+                    values[i] = one_value.encode('latin-1')
+                except UnicodeEncodeError:
+                    hdr = email.header.Header(one_value, 'utf-8')
+                    values[i] = hdr.encode().encode('ascii')
             elif isinstance(one_value, int):
                 values[i] = str(one_value).encode('ascii')
 

--- a/Lib/test/test_httplib.py
+++ b/Lib/test/test_httplib.py
@@ -243,6 +243,8 @@ class HeaderTests(TestCase):
         self.assertIn(b'Authorization: Bearer mytoken', conn._buffer)
         conn.putheader('IterHeader', 'IterA', 'IterB')
         self.assertIn(b'IterHeader: IterA\r\n\tIterB', conn._buffer)
+        conn.putheader('EncodedWordHeader', 'مثل')
+        self.assertIn(b'EncodedWordHeader: =?utf-8?b?2YXYq9mE?=', conn._buffer)
         conn.putheader('LatinHeader', b'\xFF')
         self.assertIn(b'LatinHeader: \xFF', conn._buffer)
         conn.putheader('Utf8Header', b'\xc3\x80')

--- a/Misc/NEWS.d/next/Library/2023-06-09-20-40-05.gh-issue-105530.-bZQTz.rst
+++ b/Misc/NEWS.d/next/Library/2023-06-09-20-40-05.gh-issue-105530.-bZQTz.rst
@@ -1,0 +1,2 @@
+Send HTTP headers with non-ISO-8859-1 characters as UTF-8 with MIME
+encoded-word syntax (per RFC 2047)


### PR DESCRIPTION
Currently, sending an HTTP header with non-ISO-8859-1 (latin-1) characters will result in a `UnicodeEncodeError` being thrown. This change adds support for such characters in the header values using RFC 2047 encoded-word format.

This change was originally part of #105531, which originally handled RFC 2047 for both receiving and sending. The receiving part could be a breaking change and might be better suited as part of a bigger change. However, this change for the sending part should not make any breaking changes. If an application already supports RFC 2047 encoded-word format, then it will still work.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-105530 -->
* Issue: gh-105530
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--105621.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->