### PR TITLE
gh-105626: Change the default return value of `HTTPConnection.get_proxy_response_headers`

### DIFF
--- a/Doc/library/http.client.rst
+++ b/Doc/library/http.client.rst
@@ -390,7 +390,7 @@ HTTPConnection Objects
    Returns a dictionary with the headers of the response received from
    the proxy server to the CONNECT request.
 
-   If the CONNECT request was not sent, the method returns an empty dictionary.
+   If the CONNECT request was not sent, the method returns ``None``.
 
    .. versionadded:: 3.12
 

--- a/Lib/http/client.py
+++ b/Lib/http/client.py
@@ -970,13 +970,12 @@ class HTTPConnection:
         received from the proxy server to the CONNECT request
         sent to set the tunnel.
 
-        If the CONNECT request was not sent, the method returns
-        an empty dictionary.
+        If the CONNECT request was not sent, the method returns None.
         """
         return (
             _parse_header_lines(self._raw_proxy_headers)
             if self._raw_proxy_headers is not None
-            else {}
+            else None
         )
 
     def connect(self):

--- a/Lib/test/test_httplib.py
+++ b/Lib/test/test_httplib.py
@@ -2404,6 +2404,19 @@ class TunnelTests(TestCase):
         headers = self.conn.get_proxy_response_headers()
         self.assertIn(expected_header, headers.items())
 
+    def test_no_proxy_response_headers(self):
+        expected_header = ('X-Dummy', '1')
+        response_text = (
+            'HTTP/1.0 200 OK\r\n'
+            '{0}\r\n\r\n'.format(':'.join(expected_header))
+        )
+
+        self.conn._create_connection = self._create_connection(response_text)
+
+        self.conn.request('PUT', '/', '')
+        headers = self.conn.get_proxy_response_headers()
+        self.assertIsNone(headers)
+
     def test_tunnel_leak(self):
         sock = None
 

--- a/Misc/NEWS.d/next/Library/2023-06-10-12-20-17.gh-issue-105626.XyZein.rst
+++ b/Misc/NEWS.d/next/Library/2023-06-10-12-20-17.gh-issue-105626.XyZein.rst
@@ -1,0 +1,3 @@
+Change the default return value of
+:meth:`http.client.HTTPConnection.get_proxy_response_headers` to be ``None``
+and not ``{}``.


### PR DESCRIPTION
See https://github.com/python/cpython/pull/104248#issuecomment-1585579473
CC @nametkin

<!-- gh-issue-number: gh-105626 -->
* Issue: gh-105626
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--105628.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->