### PR TITLE
[3.11] gh-105375: Harden _ssl initialisation (#105599)

### DIFF
--- a/Misc/NEWS.d/next/Library/2023-06-09-22-16-46.gh-issue-105375.EgVJOP.rst
+++ b/Misc/NEWS.d/next/Library/2023-06-09-22-16-46.gh-issue-105375.EgVJOP.rst
@@ -1,0 +1,2 @@
+Fix bugs in :mod:`!_ssl` initialisation which could lead to leaked
+references and overwritten exceptions.

--- a/Modules/_ssl.c
+++ b/Modules/_ssl.c
@@ -6066,7 +6066,7 @@ sslmodule_init_errorcodes(PyObject *module)
             Py_DECREF(mnemo);
             return -1;
         }
-        int rc = PyDict_SetItem(state->err_codes_to_names, key, mnemo);
+        int rc = PyDict_SetItem(state->err_names_to_codes, mnemo, key);
         Py_DECREF(key);
         Py_DECREF(mnemo);
         if (rc < 0) {

--- a/Modules/_ssl.c
+++ b/Modules/_ssl.c
@@ -6052,17 +6052,26 @@ sslmodule_init_errorcodes(PyObject *module)
 
     errcode = error_codes;
     while (errcode->mnemonic != NULL) {
-        PyObject *mnemo, *key;
-        mnemo = PyUnicode_FromString(errcode->mnemonic);
-        key = Py_BuildValue("ii", errcode->library, errcode->reason);
-        if (mnemo == NULL || key == NULL)
+        PyObject *mnemo = PyUnicode_FromString(errcode->mnemonic);
+        if (mnemo == NULL) {
             return -1;
-        if (PyDict_SetItem(state->err_codes_to_names, key, mnemo))
+        }
+        PyObject *key = Py_BuildValue("ii", errcode->library, errcode->reason);
+        if (key == NULL) {
+            Py_DECREF(mnemo);
             return -1;
-        if (PyDict_SetItem(state->err_names_to_codes, mnemo, key))
+        }
+        if (PyDict_SetItem(state->err_codes_to_names, key, mnemo) < 0) {
+            Py_DECREF(key);
+            Py_DECREF(mnemo);
             return -1;
+        }
+        int rc = PyDict_SetItem(state->err_codes_to_names, key, mnemo);
         Py_DECREF(key);
         Py_DECREF(mnemo);
+        if (rc < 0) {
+            return -1;
+        }
         errcode++;
     }
 


### PR DESCRIPTION
(cherry picked from commit 01f4230460454d4a849a5ba93320142c1a0c93a8)

Add proper error handling to prevent reference leaks and overwritten
exceptions.

Co-authored-by: Erlend E. Aasland <erlend.aasland@protonmail.com>


<!-- gh-issue-number: gh-105375 -->
* Issue: gh-105375
<!-- /gh-issue-number -->
