### PR TITLE
[3.11] Remove stray reference to PEP-695 in the typing docs

### DIFF
--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -1458,10 +1458,9 @@ for creating generic types.
    Note that type variables can be *bound*, *constrained*, or neither, but
    cannot be both bound *and* constrained.
 
-   Created type variables may be explicitly marked covariant or contravariant by passing
-   ``covariant=True`` or ``contravariant=True``.
-   By default, type variables are invariant.
-   See :pep:`484` and :pep:`695` for more details.
+   Type variables may be marked covariant or contravariant by passing
+   ``covariant=True`` or ``contravariant=True``.  See :pep:`484` for more
+   details.  By default, type variables are invariant.
 
    Bound type variables and constrained type variables have different
    semantics in several important ways. Using a *bound* type variable means


### PR DESCRIPTION
#105007 accidentally backported a reference to PEP-695 to the 3.11 branch. PEP-695 is new in Python 3.12, so it shouldn't be mentioned in the 3.11 typing-module docs.

<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--105655.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->