### PR TITLE
[3.11] gh-105375: Harden pyexpat initialisation (#105606)

### DIFF
--- a/Misc/NEWS.d/next/Library/2023-06-09-23-00-13.gh-issue-105605.YuwqxY.rst
+++ b/Misc/NEWS.d/next/Library/2023-06-09-23-00-13.gh-issue-105605.YuwqxY.rst
@@ -1,0 +1,3 @@
+Harden :mod:`pyexpat` error handling during module initialisation to prevent
+exceptions from possibly being overwritten, and objects from being
+dereferenced twice.


### PR DESCRIPTION
(cherry picked from commit 20a56d8becba1a5a958b167fdb43b1a1b9228095)

Add proper error handling to add_errors_module() to prevent exceptions
from possibly being overwritten.

Co-authored-by: Erlend E. Aasland <erlend.aasland@protonmail.com>


<!-- gh-issue-number: gh-105375 -->
* Issue: gh-105375
<!-- /gh-issue-number -->
