### PR TITLE
[3.12] gh-105375: Harden pyexpat initialisation (#105606)

### DIFF
--- a/Misc/NEWS.d/next/Library/2023-06-09-23-00-13.gh-issue-105605.YuwqxY.rst
+++ b/Misc/NEWS.d/next/Library/2023-06-09-23-00-13.gh-issue-105605.YuwqxY.rst
@@ -1,0 +1,3 @@
+Harden :mod:`pyexpat` error handling during module initialisation to prevent
+exceptions from possibly being overwritten, and objects from being
+dereferenced twice.

--- a/Modules/pyexpat.c
+++ b/Modules/pyexpat.c
@@ -1775,14 +1775,18 @@ add_error(PyObject *errors_module, PyObject *codes_dict,
 static int
 add_errors_module(PyObject *mod)
 {
+    // add_submodule() returns a borrowed ref.
     PyObject *errors_module = add_submodule(mod, MODULE_NAME ".errors");
     if (errors_module == NULL) {
         return -1;
     }
 
     PyObject *codes_dict = PyDict_New();
+    if (codes_dict == NULL) {
+        return -1;
+    }
     PyObject *rev_codes_dict = PyDict_New();
-    if (codes_dict == NULL || rev_codes_dict == NULL) {
+    if (rev_codes_dict == NULL) {
         goto error;
     }
 
@@ -1803,17 +1807,17 @@ add_errors_module(PyObject *mod)
         goto error;
     }
 
-    if (PyModule_AddObject(errors_module, "codes", Py_NewRef(codes_dict)) < 0) {
-        Py_DECREF(codes_dict);
-        goto error;
-    }
+    int rc = PyModule_AddObjectRef(errors_module, "codes", codes_dict);
     Py_CLEAR(codes_dict);
-
-    if (PyModule_AddObject(errors_module, "messages", Py_NewRef(rev_codes_dict)) < 0) {
-        Py_DECREF(rev_codes_dict);
+    if (rc < 0) {
         goto error;
     }
+
+    rc = PyModule_AddObjectRef(errors_module, "messages", rev_codes_dict);
     Py_CLEAR(rev_codes_dict);
+    if (rc < 0) {
+        goto error;
+    }
 
     return 0;
 


### PR DESCRIPTION
(cherry picked from commit 20a56d8becba1a5a958b167fdb43b1a1b9228095)

Add proper error handling to add_errors_module() to prevent exceptions
from possibly being overwritten.

Co-authored-by: Erlend E. Aasland <erlend.aasland@protonmail.com>


<!-- gh-issue-number: gh-105375 -->
* Issue: gh-105375
<!-- /gh-issue-number -->
