### PR TITLE
gh-105196: Fix indentations of section headings in C API docs

### DIFF
--- a/Doc/c-api/float.rst
+++ b/Doc/c-api/float.rst
@@ -3,7 +3,7 @@
 .. _floatobjects:
 
 Floating Point Objects
-----------------------
+======================
 
 .. index:: pair: object; floating point
 
@@ -79,7 +79,7 @@ Floating Point Objects
 
 
 Pack and Unpack functions
-=========================
+-------------------------
 
 The pack and unpack functions provide an efficient platform-independent way to
 store floating-point values as byte strings. The Pack routines produce a bytes
@@ -104,7 +104,7 @@ happens in such cases is partly accidental (alas).
 .. versionadded:: 3.11
 
 Pack functions
---------------
+^^^^^^^^^^^^^^
 
 The pack routines write 2, 4 or 8 bytes, starting at *p*. *le* is an
 :c:expr:`int` argument, non-zero if you want the bytes string in little-endian
@@ -135,7 +135,7 @@ There are two problems on non-IEEE platforms:
 
 
 Unpack functions
-----------------
+^^^^^^^^^^^^^^^^
 
 The unpack routines read 2, 4 or 8 bytes, starting at *p*.  *le* is an
 :c:expr:`int` argument, non-zero if the bytes string is in little-endian format

--- a/Doc/c-api/frame.rst
+++ b/Doc/c-api/frame.rst
@@ -134,7 +134,7 @@ See also :ref:`Reflection <reflection>`.
 
 
 Internal Frames
----------------
+^^^^^^^^^^^^^^^
 
 Unless using :pep:`523`, you will not need this.
 

--- a/Doc/c-api/slice.rst
+++ b/Doc/c-api/slice.rst
@@ -113,7 +113,7 @@ Slice Objects
 
 
 Ellipsis Object
----------------
+^^^^^^^^^^^^^^^
 
 
 .. c:var:: PyObject *Py_Ellipsis


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

Changes Made:

- In the C-api documentation index, Pack Functions and Unpack Functions are indented under Pack and Unpack Functions
- In the C-api documentation index, Ellipsis Object is indented under Slice Objects
- In the C-api documentation index, Internal Frames is indented under Frame Objects

Thank you


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--105672.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->

<!-- gh-issue-number: gh-105196 -->
* Issue: gh-105196
<!-- /gh-issue-number -->
