### PR TITLE
gh-105673: Fix uninitialized warning in sysmodule.c

### DIFF
--- a/Python/sysmodule.c
+++ b/Python/sysmodule.c
@@ -3375,7 +3375,7 @@ err_occurred:
 static int
 sys_add_xoption(PyObject *opts, const wchar_t *s)
 {
-    PyObject *name, *value;
+    PyObject *name, *value = NULL;
 
     const wchar_t *name_end = wcschr(s, L'=');
     if (!name_end) {


### PR DESCRIPTION
The simplest possible solution.
Refs https://github.com/python/cpython/pull/105611

<!-- gh-issue-number: gh-105673 -->
* Issue: gh-105673
<!-- /gh-issue-number -->
