### PR TITLE
Remove support for legacy bytecode instructions

### DIFF
--- a/Tools/cases_generator/generate_cases.py
+++ b/Tools/cases_generator/generate_cases.py
@@ -230,7 +230,7 @@ class Instruction:
 
     # Parts of the underlying instruction definition
     inst: parser.InstDef
-    kind: typing.Literal["inst", "op", "legacy"]  # Legacy means no (input -- output)
+    kind: typing.Literal["inst", "op"]
     name: str
     block: parser.Block
     block_text: list[str]  # Block.text, less curlies, less PREDICT() calls
@@ -904,8 +904,6 @@ class Analyzer:
         self, thing: parser.InstDef | parser.Super | parser.Macro | parser.Pseudo
     ) -> tuple[AnyInstruction | None, str, str]:
         def effect_str(effects: list[StackEffect]) -> str:
-            if getattr(thing, "kind", None) == "legacy":
-                return str(-1)
             n_effect, sym_effect = list_effect_size(effects)
             if sym_effect:
                 return f"{sym_effect} + {n_effect}" if n_effect else sym_effect

--- a/Tools/cases_generator/parser.py
+++ b/Tools/cases_generator/parser.py
@@ -101,7 +101,7 @@ UOp = OpName | CacheEffect
 class InstHeader(Node):
     override: bool
     register: bool
-    kind: Literal["inst", "op", "legacy"]  # Legacy means no (inputs -- outputs)
+    kind: Literal["inst", "op"]
     name: str
     inputs: list[InputEffect]
     outputs: list[OutputEffect]
@@ -111,7 +111,7 @@ class InstHeader(Node):
 class InstDef(Node):
     override: bool
     register: bool
-    kind: Literal["inst", "op", "legacy"]
+    kind: Literal["inst", "op"]
     name: str
     inputs: list[InputEffect]
     outputs: list[OutputEffect]
@@ -182,9 +182,6 @@ class Parser(PLexer):
                     if self.expect(lx.RPAREN):
                         if (tkn := self.peek()) and tkn.kind == lx.LBRACE:
                             return InstHeader(override, register, kind, name, inp, outp)
-                elif self.expect(lx.RPAREN) and kind == "inst":
-                    # No legacy stack effect if kind is "op".
-                    return InstHeader(override, register, "legacy", name, [], [])
         return None
 
     def io_effect(self) -> tuple[list[InputEffect], list[OutputEffect]]:

--- a/Tools/cases_generator/test_generator.py
+++ b/Tools/cases_generator/test_generator.py
@@ -62,20 +62,6 @@ def run_cases_test(input: str, expected: str):
     #     print("End")
     assert actual.rstrip() == expected.rstrip()
 
-def test_legacy():
-    input = """
-        inst(OP) {
-            spam();
-        }
-    """
-    output = """
-        TARGET(OP) {
-            spam();
-            DISPATCH();
-        }
-    """
-    run_cases_test(input, output)
-
 def test_inst_no_args():
     input = """
         inst(OP, (--)) {


### PR DESCRIPTION
(A legacy instruction is of the form `instr(FOOBAR)`, i.e. missing the `(... -- ...)` stack/cache effect annotation.)
