### PR TITLE
[3.12] gh-105375: Improve error handling in _Unpickler_SetInputStream() (#105667)

### DIFF
--- a/Misc/NEWS.d/next/Library/2023-06-11-22-46-06.gh-issue-105375.YkhSNt.rst
+++ b/Misc/NEWS.d/next/Library/2023-06-11-22-46-06.gh-issue-105375.YkhSNt.rst
@@ -1,0 +1,2 @@
+Fix a bug in :c:func:`!_Unpickler_SetInputStream` where an exception could
+end up being overwritten in case of failure.


### PR DESCRIPTION
Prevent exceptions from possibly being overwritten in case of multiple
failures.

(cherry picked from commit 217589d4f3246d67c6ef0eb0be2b1c33987cf260)

Co-authored-by: Erlend E. Aasland <erlend.aasland@protonmail.com>


<!-- gh-issue-number: gh-105375 -->
* Issue: gh-105375
<!-- /gh-issue-number -->
