### PR TITLE
_ctypes callbacks.c uses _Py_COMP_DIAG_IGNORE_DEPR_DECLS

### DIFF
--- a/Modules/_ctypes/callbacks.c
+++ b/Modules/_ctypes/callbacks.c
@@ -416,25 +416,28 @@ CThunkObject *_ctypes_alloc_callback(PyObject *callable,
         PyErr_Format(PyExc_NotImplementedError, "ffi_prep_closure_loc() is missing");
         goto error;
 #else
-#if defined(__clang__)
-        #pragma clang diagnostic push
-        #pragma clang diagnostic ignored "-Wdeprecated-declarations"
-#endif
-#if defined(__GNUC__) && ((__GNUC__ > 4) || ((__GNUC__ == 4) && (__GNUC_MINOR__ > 5)))
-        #pragma GCC diagnostic push
-        #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-#endif
+        // GH-85272, GH-23327, GH-100540: On macOS,
+        // HAVE_FFI_PREP_CLOSURE_LOC_RUNTIME is
+        // checked at runtime. Even if ffi_prep_closure_loc() is called in
+        // practice, the deprecated ffi_prep_closure() code path is needed if
+        // HAVE_FFI_PREP_CLOSURE_LOC_RUNTIME is false.
+        //
+        // On non-macOS platforms, even if HAVE_FFI_PREP_CLOSURE_LOC_RUNTIME is
+        // defined as 1 and ffi_prep_closure_loc() is used in practice, this
+        // code path is still compiled and emits a compiler warning. The
+        // deprecated code path is likely to be removed by a simple
+        // optimization pass.
+        //
+        // Ignore the compiler warning on the ffi_prep_closure() deprecation,
+        // rather than using complex #if/#else code paths for the different
+        // platforms.
+        _Py_COMP_DIAG_PUSH
+        _Py_COMP_DIAG_IGNORE_DEPR_DECLS
         result = ffi_prep_closure(p->pcl_write, &p->cif, closure_fcn, p);
-
-#if defined(__clang__)
-        #pragma clang diagnostic pop
-#endif
-#if defined(__GNUC__) && ((__GNUC__ > 4) || ((__GNUC__ == 4) && (__GNUC_MINOR__ > 5)))
-        #pragma GCC diagnostic pop
-#endif
-
+        _Py_COMP_DIAG_POP
 #endif
     }
+
     if (result != FFI_OK) {
         PyErr_Format(PyExc_RuntimeError,
                      "ffi_prep_closure failed with %d", result);

--- a/Modules/_ctypes/callbacks.c
+++ b/Modules/_ctypes/callbacks.c
@@ -417,9 +417,10 @@ CThunkObject *_ctypes_alloc_callback(PyObject *callable,
         goto error;
 #else
         // GH-85272, GH-23327, GH-100540: On macOS,
-        // HAVE_FFI_PREP_CLOSURE_LOC_RUNTIME is
-        // checked at runtime. Even if ffi_prep_closure_loc() is called in
-        // practice, the deprecated ffi_prep_closure() code path is needed if
+        // HAVE_FFI_PREP_CLOSURE_LOC_RUNTIME is checked at runtime because the
+        // symbol might not be available at runtime when targeting macOS 10.14
+        // or earlier. Even if ffi_prep_closure_loc() is called in practice,
+        // the deprecated ffi_prep_closure() code path is needed if
         // HAVE_FFI_PREP_CLOSURE_LOC_RUNTIME is false.
         //
         // On non-macOS platforms, even if HAVE_FFI_PREP_CLOSURE_LOC_RUNTIME is


### PR DESCRIPTION
Replace #pragma with _Py_COMP_DIAG_PUSH,
_Py_COMP_DIAG_IGNORE_DEPR_DECLS and _Py_COMP_DIAG_POP to ease Python maintenance. Also add a comment explaining why callbacks.c ignores a deprecation warning.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
