### PR TITLE
gh-105733: Deprecate ctypes SetPointerType() and ARRAY()

### DIFF
--- a/Doc/whatsnew/3.13.rst
+++ b/Doc/whatsnew/3.13.rst
@@ -140,6 +140,12 @@ Deprecated
   Use the ``'w'`` format code instead.
   (contributed by Hugo van Kemenade in :gh:`80480`)
 
+* :mod:`ctypes`: Deprecate undocumented :func:`!ctypes.SetPointerType`
+  and :func:`!ctypes.ARRAY` functions.
+  Replace ``ctypes.SetPointerType(item_type, size)`` with ``item_type * size``.
+  (Contributed by Victor Stinner in :gh:`105733`.)
+
+
 Removed
 =======
 

--- a/Lib/ctypes/__init__.py
+++ b/Lib/ctypes/__init__.py
@@ -302,8 +302,9 @@ def create_unicode_buffer(init, size=None):
     raise TypeError(init)
 
 
-# XXX Deprecated
 def SetPointerType(pointer, cls):
+    import warnings
+    warnings._deprecated("ctypes.SetPointerType", remove=(3, 15))
     if _pointer_type_cache.get(cls, None) is not None:
         raise RuntimeError("This type already exists in the cache")
     if id(pointer) not in _pointer_type_cache:
@@ -312,8 +313,9 @@ def SetPointerType(pointer, cls):
     _pointer_type_cache[cls] = pointer
     del _pointer_type_cache[id(pointer)]
 
-# XXX Deprecated
 def ARRAY(typ, len):
+    import warnings
+    warnings._deprecated("ctypes.ARRAY", remove=(3, 15))
     return typ * len
 
 ################################################################

--- a/Lib/test/test_ctypes/test_arrays.py
+++ b/Lib/test/test_ctypes/test_arrays.py
@@ -1,7 +1,9 @@
-import unittest
-from test.support import bigmemtest, _2G
+import ctypes
 import sys
+import unittest
+import warnings
 from ctypes import *
+from test.support import bigmemtest, _2G
 
 from test.test_ctypes import need_symbol
 
@@ -9,6 +11,14 @@ formats = "bBhHiIlLqQfd"
 
 formats = c_byte, c_ubyte, c_short, c_ushort, c_int, c_uint, \
           c_long, c_ulonglong, c_float, c_double, c_longdouble
+
+
+def ARRAY(*args):
+    # ignore DeprecationWarning in tests
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore', DeprecationWarning)
+        return ctypes.ARRAY(*args)
+
 
 class ArrayTestCase(unittest.TestCase):
     def test_simple(self):
@@ -233,6 +243,11 @@ class ArrayTestCase(unittest.TestCase):
     @bigmemtest(size=_2G, memuse=1, dry_run=False)
     def test_large_array(self, size):
         c_char * size
+
+    def test_deprecation(self):
+        with self.assertWarns(DeprecationWarning):
+            CharArray = ctypes.ARRAY(c_char, 3)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/Lib/test/test_ctypes/test_incomplete.py
+++ b/Lib/test/test_ctypes/test_incomplete.py
@@ -1,4 +1,6 @@
+import ctypes
 import unittest
+import warnings
 from ctypes import *
 
 ################################################################
@@ -6,7 +8,11 @@ from ctypes import *
 # The incomplete pointer example from the tutorial
 #
 
-class MyTestCase(unittest.TestCase):
+class TestSetPointerType(unittest.TestCase):
+
+    def tearDown(self):
+        # to not leak references, we must clean _pointer_type_cache
+        ctypes._reset_cache()
 
     def test_incomplete_example(self):
         lpcell = POINTER("cell")
@@ -14,7 +20,9 @@ class MyTestCase(unittest.TestCase):
             _fields_ = [("name", c_char_p),
                         ("next", lpcell)]
 
-        SetPointerType(lpcell, cell)
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', DeprecationWarning)
+            ctypes.SetPointerType(lpcell, cell)
 
         c1 = cell()
         c1.name = b"foo"
@@ -32,9 +40,14 @@ class MyTestCase(unittest.TestCase):
             p = p.next[0]
         self.assertEqual(result, [b"foo", b"bar"] * 4)
 
-        # to not leak references, we must clean _pointer_type_cache
-        from ctypes import _pointer_type_cache
-        del _pointer_type_cache[cell]
+    def test_deprecation(self):
+        lpcell = POINTER("cell")
+        class cell(Structure):
+            _fields_ = [("name", c_char_p),
+                        ("next", lpcell)]
+
+        with self.assertWarns(DeprecationWarning):
+            ctypes.SetPointerType(lpcell, cell)
 
 ################################################################
 

--- a/Misc/NEWS.d/next/Library/2023-06-13-19-38-12.gh-issue-105733.WOp0mG.rst
+++ b/Misc/NEWS.d/next/Library/2023-06-13-19-38-12.gh-issue-105733.WOp0mG.rst
@@ -1,0 +1,2 @@
+:mod:`ctypes`: Deprecate undocumented :func:`!ctypes.SetPointerType` and
+:func:`!ctypes.ARRAY` functions. Patch by Victor Stinner.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-105733 -->
* Issue: gh-105733
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--105734.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->