### PR TITLE
gh-106535: Soft deprecate the getopt module

### DIFF
--- a/Doc/library/getopt.rst
+++ b/Doc/library/getopt.rst
@@ -7,18 +7,23 @@
 
 **Source code:** :source:`Lib/getopt.py`
 
+.. deprecated:: 3.13
+   The :mod:`getopt` module is :term:`soft deprecated` and will not be
+   developed further; development will continue with the :mod:`argparse`
+   module.
+
 .. note::
 
    The :mod:`getopt` module is a parser for command line options whose API is
-   designed to be familiar to users of the C :c:func:`getopt` function. Users who
-   are unfamiliar with the C :c:func:`getopt` function or who would like to write
+   designed to be familiar to users of the C :c:func:`!getopt` function. Users who
+   are unfamiliar with the C :c:func:`!getopt` function or who would like to write
    less code and get better help and error messages should consider using the
    :mod:`argparse` module instead.
 
 --------------
 
 This module helps scripts to parse the command line arguments in ``sys.argv``.
-It supports the same conventions as the Unix :c:func:`getopt` function (including
+It supports the same conventions as the Unix :c:func:`!getopt` function (including
 the special meanings of arguments of the form '``-``' and '``--``').  Long
 options similar to those supported by GNU software may be used as well via an
 optional third argument.
@@ -33,11 +38,11 @@ exception:
    be parsed, without the leading reference to the running program. Typically, this
    means ``sys.argv[1:]``. *shortopts* is the string of option letters that the
    script wants to recognize, with options that require an argument followed by a
-   colon (``':'``; i.e., the same format that Unix :c:func:`getopt` uses).
+   colon (``':'``; i.e., the same format that Unix :c:func:`!getopt` uses).
 
    .. note::
 
-      Unlike GNU :c:func:`getopt`, after a non-option argument, all further
+      Unlike GNU :c:func:`!getopt`, after a non-option argument, all further
       arguments are considered also non-options. This is similar to the way
       non-GNU Unix systems work.
 
@@ -71,7 +76,7 @@ exception:
    non-option argument is encountered.
 
    If the first character of the option string is ``'+'``, or if the environment
-   variable :envvar:`POSIXLY_CORRECT` is set, then option processing stops as
+   variable :envvar:`!POSIXLY_CORRECT` is set, then option processing stops as
    soon as a non-option argument is encountered.
 
 
@@ -81,9 +86,9 @@ exception:
    an option requiring an argument is given none. The argument to the exception is
    a string indicating the cause of the error.  For long options, an argument given
    to an option which does not require one will also cause this exception to be
-   raised.  The attributes :attr:`msg` and :attr:`opt` give the error message and
+   raised.  The attributes :attr:`!msg` and :attr:`!opt` give the error message and
    related option; if there is no specific option to which the exception relates,
-   :attr:`opt` is an empty string.
+   :attr:`!opt` is an empty string.
 
 .. XXX deprecated?
 .. exception:: error


### PR DESCRIPTION
The getopt module exists since the initial revision of the Python
source code (1990). The optparse module was added to Python 2.3. When
Python 2.7 added the 3rd argparse module, the optparse module was
soft deprecated. Soft deprecate the getopt module.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--105735.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->

<!-- gh-issue-number: gh-106535 -->
* Issue: gh-106535
<!-- /gh-issue-number -->
