### PR TITLE
gh-105699: Use a Thread-Local Variable for PKGCONTEXT

### DIFF
--- a/Tools/c-analyzer/c_parser/parser/_regexes.py
+++ b/Tools/c-analyzer/c_parser/parser/_regexes.py
@@ -58,6 +58,7 @@ _KEYWORD = textwrap.dedent(r'''
             extern |
             register |
             static |
+            _Thread_local |
             typedef |
 
             const |
@@ -137,7 +138,7 @@ COMPOUND_TYPE_KIND = r'(?: \b (?: struct | union | enum ) \b )'
 #######################################
 # variable declarations
 
-_STORAGE = 'auto register static extern'.split()
+_STORAGE = 'auto register static extern _Thread_local'.split()
 STORAGE_CLASS = rf'(?: \b (?: {" | ".join(_STORAGE)} ) \b )'
 TYPE_QUALIFIER = r'(?: \b (?: const | volatile ) \b )'
 PTR_QUALIFIER = rf'(?: [*] (?: \s* {TYPE_QUALIFIER} )? )'

--- a/Tools/c-analyzer/c_parser/preprocessor/gcc.py
+++ b/Tools/c-analyzer/c_parser/preprocessor/gcc.py
@@ -219,6 +219,7 @@ def _strip_directives(line, partial=0):
         line = line[m.end():]
 
     line = re.sub(r'__extension__', '', line)
+    line = re.sub(r'__thread\b', '_Thread_local', line)
 
     while (m := COMPILER_DIRECTIVE_RE.match(line)):
         before, _, _, closed = m.groups()

--- a/Tools/c-analyzer/cpython/ignored.tsv
+++ b/Tools/c-analyzer/cpython/ignored.tsv
@@ -169,6 +169,12 @@ Modules/_xxinterpchannelsmodule.c	-	_globals	-
 Python/pyfpe.c	-	PyFPE_counter	-
 
 ##-----------------------
+## thread-local variables
+
+Python/import.c	-	pkgcontext	-
+Python/pystate.c	-	_Py_tss_tstate	-
+
+##-----------------------
 ## should be const
 # XXX Make them const.
 


### PR DESCRIPTION
This fixes a race during import.  The existing `_PyRuntimeState.imports.pkgcontext` is shared between interpreters, and occasionally this would cause a crash when multiple interpreters were importing extensions modules at the same time.  To solve this we add a thread-local variable for the value.  We also leave the existing state (and infrequent race) in place for platforms that do not support thread-local variables.

<!-- gh-issue-number: gh-105699 -->
* Issue: gh-105699
<!-- /gh-issue-number -->
