### PR TITLE
xmlrpc.client uses datetime.datetime.isoformat()

### DIFF
--- a/Lib/test/test_xmlrpc.py
+++ b/Lib/test/test_xmlrpc.py
@@ -504,9 +504,15 @@ class DateTimeTestCase(unittest.TestCase):
         self.assertEqual(str(t), time.strftime("%Y%m%dT%H:%M:%S", d))
 
     def test_datetime_datetime(self):
+        # naive (no tzinfo)
         d = datetime.datetime(2007,1,2,3,4,5)
         t = xmlrpclib.DateTime(d)
         self.assertEqual(str(t), '20070102T03:04:05')
+
+        # aware (with tzinfo): the timezone is ignored
+        d = datetime.datetime(2023, 6, 12, 13, 30, tzinfo=datetime.UTC)
+        t = xmlrpclib.DateTime(d)
+        self.assertEqual(str(t), '20230612T13:30:00')
 
     def test_repr(self):
         d = datetime.datetime(2007,1,2,3,4,5)

--- a/Lib/xmlrpc/client.py
+++ b/Lib/xmlrpc/client.py
@@ -245,41 +245,12 @@ class Fault(Error):
 
 ##
 # Backwards compatibility
-
 boolean = Boolean = bool
 
-##
-# Wrapper for XML-RPC DateTime values.  This converts a time value to
-# the format used by XML-RPC.
-# <p>
-# The value can be given as a datetime object, as a string in the
-# format "yyyymmddThh:mm:ss", as a 9-item time tuple (as returned by
-# time.localtime()), or an integer value (as returned by time.time()).
-# The wrapper uses time.localtime() to convert an integer to a time
-# tuple.
-#
-# @param value The time, given as a datetime object, an ISO 8601 string,
-#              a time tuple, or an integer time value.
 
-
-# Issue #13305: different format codes across platforms
-_day0 = datetime(1, 1, 1)
-def _try(fmt):
-    try:
-        return _day0.strftime(fmt) == '0001'
-    except ValueError:
-        return False
-if _try('%Y'):      # Mac OS X
-    def _iso8601_format(value):
-        return value.strftime("%Y%m%dT%H:%M:%S")
-elif _try('%4Y'):   # Linux
-    def _iso8601_format(value):
-        return value.strftime("%4Y%m%dT%H:%M:%S")
-else:
-    def _iso8601_format(value):
-        return value.strftime("%Y%m%dT%H:%M:%S").zfill(17)
-del _day0
-del _try
+def _iso8601_format(value):
+    # XML-RPC doesn't use '-' separator in the date part
+    return value.isoformat(timespec='seconds').replace('-', '')
 
 
 def _strftime(value):

--- a/Lib/xmlrpc/client.py
+++ b/Lib/xmlrpc/client.py
@@ -249,6 +249,9 @@ boolean = Boolean = bool
 
 
 def _iso8601_format(value):
+    if value.tzinfo is not None:
+        # XML-RPC only uses the naive portion of the datetime
+        value = value.replace(tzinfo=None)
     # XML-RPC doesn't use '-' separator in the date part
     return value.isoformat(timespec='seconds').replace('-', '')
 


### PR DESCRIPTION
Reimplement _iso8601_format() using the datetime isoformat() method.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
