### PR TITLE
gh-98040: Fix importbench: use types.ModuleType()

### DIFF
--- a/Doc/whatsnew/3.12.rst
+++ b/Doc/whatsnew/3.12.rst
@@ -1369,6 +1369,8 @@ Removed
   * The :mod:`!imp` module has been removed.  (Contributed by Barry Warsaw in
     :gh:`98040`.)
 
+  * Replace ``imp.new_module(name)`` with ``types.ModuleType(name)``.
+
 * Removed the ``suspicious`` rule from the documentation Makefile, and
   removed ``Doc/tools/rstlint.py``, both in favor of `sphinx-lint
   <https://github.com/sphinx-contrib/sphinx-lint>`_.

--- a/Tools/importbench/importbench.py
+++ b/Tools/importbench/importbench.py
@@ -15,6 +15,7 @@ import py_compile
 import sys
 import tabnanny
 import timeit
+import types
 
 
 def bench(name, cleanup=lambda: None, *, seconds=1, repeat=3):
@@ -40,7 +41,7 @@ def bench(name, cleanup=lambda: None, *, seconds=1, repeat=3):
 def from_cache(seconds, repeat):
     """sys.modules"""
     name = '<benchmark import>'
-    module = imp.new_module(name)
+    module = types.ModuleType(name)
     module.__file__ = '<test>'
     module.__package__ = ''
     with util.uncache(name):


### PR DESCRIPTION
Replace removed imp.new_module(name) with types.ModuleType(name).

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-98040 -->
* Issue: gh-98040
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--105743.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->