### PR TITLE
gh-102613: Bump recursion limit to fix running test_pathlib under Coverage

### DIFF
--- a/Lib/test/test_pathlib.py
+++ b/Lib/test/test_pathlib.py
@@ -2107,7 +2107,7 @@ class _BasePathTest(object):
         self.assertEqual(sorted(base.glob('**/*')), [bad_link])
 
     def test_glob_above_recursion_limit(self):
-        recursion_limit = 40
+        recursion_limit = 50
         # directory_depth > recursion_limit
         directory_depth = recursion_limit + 10
         base = pathlib.Path(os_helper.TESTFN, 'deep')


### PR DESCRIPTION
Coverage adds a few frames and the previous limit was causing irrecoverable exceptions before pathlib got to its own support for recursion limit recovery.

<!-- gh-issue-number: gh-102613 -->
* Issue: gh-102613
<!-- /gh-issue-number -->
