### PR TITLE
gh-104812: Skip Pending Calls Tests if No Threading

### DIFF
--- a/Lib/test/test_capi/test_misc.py
+++ b/Lib/test/test_capi/test_misc.py
@@ -1406,6 +1406,7 @@ class TestPendingCalls(unittest.TestCase):
             while self.result is None:
                 time.sleep(0.01)
 
+    @threading_helper.requires_working_threading()
     def test_subthreads_can_handle_pending_calls(self):
         payload = 'Spam spam spam spam. Lovely spam! Wonderful spam!'
 
@@ -1421,6 +1422,7 @@ class TestPendingCalls(unittest.TestCase):
 
         self.assertEqual(task.result, payload)
 
+    @threading_helper.requires_working_threading()
     def test_many_subthreads_can_handle_pending_calls(self):
         main_tid = threading.get_ident()
         self.assertEqual(threading.main_thread().ident, main_tid)


### PR DESCRIPTION
This fixes the WASM buildbots.

(I'll fold this into the 3.12 backport of gh-104813: gh-105752.)

<!-- gh-issue-number: gh-104812 -->
* Issue: gh-104812
<!-- /gh-issue-number -->
