### PR TITLE
gh-105751: test_ctypes avoids "from ctypes import *"

### DIFF
--- a/Lib/ctypes/_endian.py
+++ b/Lib/ctypes/_endian.py
@@ -1,5 +1,5 @@
 import sys
-from ctypes import *
+from ctypes import Array, Structure, Union
 
 _array_type = type(Array)
 

--- a/Lib/test/test_ctypes/test_anon.py
+++ b/Lib/test/test_ctypes/test_anon.py
@@ -1,6 +1,6 @@
 import unittest
 import test.support
-from ctypes import *
+from ctypes import c_int, Union, Structure, sizeof
 
 class AnonTest(unittest.TestCase):
 

--- a/Lib/test/test_ctypes/test_array_in_pointer.py
+++ b/Lib/test/test_ctypes/test_array_in_pointer.py
@@ -1,5 +1,5 @@
 import unittest
-from ctypes import *
+from ctypes import c_byte, Structure, POINTER, cast
 from binascii import hexlify
 import re
 

--- a/Lib/test/test_ctypes/test_arrays.py
+++ b/Lib/test/test_ctypes/test_arrays.py
@@ -2,7 +2,10 @@ import ctypes
 import sys
 import unittest
 import warnings
-from ctypes import *
+from ctypes import (Structure, Array, sizeof, addressof,
+                    create_string_buffer, create_unicode_buffer,
+                    c_char, c_wchar, c_byte, c_ubyte, c_short, c_ushort, c_int, c_uint,
+                    c_long, c_ulonglong, c_float, c_double, c_longdouble)
 from test.support import bigmemtest, _2G
 
 from test.test_ctypes import need_symbol

--- a/Lib/test/test_ctypes/test_as_parameter.py
+++ b/Lib/test/test_ctypes/test_as_parameter.py
@@ -1,8 +1,12 @@
-import unittest
-import ctypes
-from ctypes import *
-from test.test_ctypes import need_symbol
 import _ctypes_test
+import ctypes
+import unittest
+from ctypes import (Structure, CDLL, CFUNCTYPE,
+                    POINTER, pointer, byref,
+                    c_short, c_int, c_long, c_longlong,
+                    c_byte, c_wchar, c_float, c_double,
+                    ArgumentError)
+from test.test_ctypes import need_symbol
 
 dll = CDLL(_ctypes_test.__file__)
 

--- a/Lib/test/test_ctypes/test_bitfields.py
+++ b/Lib/test/test_ctypes/test_bitfields.py
@@ -1,4 +1,8 @@
-from ctypes import *
+from ctypes import (CDLL, Structure, sizeof, POINTER, byref, alignment,
+                    LittleEndianStructure, BigEndianStructure,
+                    c_byte, c_ubyte, c_char, c_char_p, c_void_p, c_wchar,
+                    c_uint32, c_uint64,
+                    c_short, c_ushort, c_int, c_uint, c_long, c_ulong, c_longlong, c_ulonglong)
 from test.test_ctypes import need_symbol
 from test import support
 import unittest

--- a/Lib/test/test_ctypes/test_buffers.py
+++ b/Lib/test/test_ctypes/test_buffers.py
@@ -1,4 +1,5 @@
-from ctypes import *
+from ctypes import (create_string_buffer, create_unicode_buffer, sizeof,
+                    c_char, c_wchar)
 from test.test_ctypes import need_symbol
 import unittest
 

--- a/Lib/test/test_ctypes/test_bytes.py
+++ b/Lib/test/test_ctypes/test_bytes.py
@@ -1,7 +1,7 @@
 """Test where byte objects are accepted"""
-import unittest
 import sys
-from ctypes import *
+import unittest
+from ctypes import Structure, c_char, c_char_p, c_wchar, c_wchar_p
 
 class BytesTest(unittest.TestCase):
     def test_c_char(self):

--- a/Lib/test/test_ctypes/test_byteswap.py
+++ b/Lib/test/test_ctypes/test_byteswap.py
@@ -1,7 +1,13 @@
 import sys, unittest, struct, math, ctypes
 from binascii import hexlify
 
-from ctypes import *
+from ctypes import (Structure, Union, LittleEndianUnion, BigEndianUnion,
+                    BigEndianStructure, LittleEndianStructure,
+                    POINTER, sizeof, cast,
+                    c_byte, c_ubyte, c_char, c_wchar, c_void_p,
+                    c_short, c_ushort, c_int, c_uint,
+                    c_long, c_ulong, c_longlong, c_ulonglong,
+                    c_uint32, c_float, c_double)
 
 def bin(s):
     return hexlify(memoryview(s)).decode().upper()

--- a/Lib/test/test_ctypes/test_callbacks.py
+++ b/Lib/test/test_ctypes/test_callbacks.py
@@ -3,7 +3,12 @@ import unittest
 from test import support
 
 import ctypes
-from ctypes import *
+from ctypes import (CDLL, cdll, Structure, CFUNCTYPE,
+                    ArgumentError, POINTER, sizeof,
+                    c_byte, c_ubyte, c_char, c_char_p,
+                    c_short, c_ushort, c_int, c_uint,
+                    c_long, c_longlong, c_ulonglong, c_ulong,
+                    c_float, c_double, c_longdouble, py_object)
 from test.test_ctypes import need_symbol
 from _ctypes import CTYPES_MAX_ARGCOUNT
 import _ctypes_test

--- a/Lib/test/test_ctypes/test_cast.py
+++ b/Lib/test/test_ctypes/test_cast.py
@@ -1,7 +1,9 @@
-from ctypes import *
-from test.test_ctypes import need_symbol
-import unittest
 import sys
+import unittest
+from ctypes import (Structure, Union, POINTER, cast, sizeof, addressof,
+                    c_void_p, c_char_p, c_wchar_p,
+                    c_byte, c_short, c_int)
+from test.test_ctypes import need_symbol
 
 class Test(unittest.TestCase):
 
@@ -12,7 +14,7 @@ class Test(unittest.TestCase):
         ptr = cast(array, POINTER(c_int))
         self.assertEqual([ptr[i] for i in range(3)], [42, 17, 2])
 
-        if 2*sizeof(c_short) == sizeof(c_int):
+        if 2 * sizeof(c_short) == sizeof(c_int):
             ptr = cast(array, POINTER(c_short))
             if sys.byteorder == "little":
                 self.assertEqual([ptr[i] for i in range(6)],

--- a/Lib/test/test_ctypes/test_cfuncs.py
+++ b/Lib/test/test_ctypes/test_cfuncs.py
@@ -1,12 +1,13 @@
-# A lot of failures in these tests on Mac OS X.
-# Byte order related?
-
 import unittest
 import ctypes
-from ctypes import *
+from ctypes import (CDLL,
+                    c_byte, c_ubyte, c_char,
+                    c_short, c_ushort, c_int, c_uint,
+                    c_long, c_ulong, c_longlong, c_ulonglong,
+                    c_float, c_double, c_longdouble)
 from test.test_ctypes import need_symbol
-
 import _ctypes_test
+
 
 class CFunctions(unittest.TestCase):
     _dll = CDLL(_ctypes_test.__file__)
@@ -209,6 +210,7 @@ if hasattr(ctypes, 'WinDLL'):
 
     class stdcallCFunctions(CFunctions):
         _dll = stdcall_dll(_ctypes_test.__file__)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/Lib/test/test_ctypes/test_checkretval.py
+++ b/Lib/test/test_ctypes/test_checkretval.py
@@ -1,14 +1,15 @@
-import unittest
-
 import ctypes
-from ctypes import *
+import unittest
+from ctypes import CDLL, c_int
 from test.test_ctypes import need_symbol
+
 
 class CHECKED(c_int):
     def _check_retval_(value):
         # Receives a CHECKED instance.
         return str(value.value)
     _check_retval_ = staticmethod(_check_retval_)
+
 
 class Test(unittest.TestCase):
 
@@ -31,6 +32,8 @@ class Test(unittest.TestCase):
     def test_oledll(self):
         oleaut32 = ctypes.oledll.oleaut32
         self.assertRaises(OSError, oleaut32.CreateTypeLib2, 0, None, None)
+
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/Lib/test/test_ctypes/test_delattr.py
+++ b/Lib/test/test_ctypes/test_delattr.py
@@ -1,8 +1,10 @@
 import unittest
-from ctypes import *
+from ctypes import Structure, c_char, c_int
+
 
 class X(Structure):
     _fields_ = [("foo", c_int)]
+
 
 class TestCase(unittest.TestCase):
     def test_simple(self):
@@ -16,6 +18,7 @@ class TestCase(unittest.TestCase):
     def test_struct(self):
         self.assertRaises(TypeError,
                           delattr, X(), "foo")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/Lib/test/test_ctypes/test_errno.py
+++ b/Lib/test/test_ctypes/test_errno.py
@@ -2,14 +2,15 @@ import unittest, os, errno
 import threading
 
 import ctypes
-from ctypes import *
+from ctypes import CDLL, c_int, c_char_p, c_wchar_p, get_errno, set_errno
 from ctypes.util import find_library
 
 class Test(unittest.TestCase):
     def test_open(self):
         libc_name = find_library("c")
         if libc_name is None:
-            raise unittest.SkipTest("Unable to find C library")
+            self.skipTest("Unable to find C library")
+
         libc = CDLL(libc_name, use_errno=True)
         if os.name == "nt":
             libc_open = libc._open
@@ -72,6 +73,7 @@ class Test(unittest.TestCase):
         self.assertEqual(ctypes.get_last_error(), 32)
 
         ctypes.set_last_error(0)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/Lib/test/test_ctypes/test_find.py
+++ b/Lib/test/test_ctypes/test_find.py
@@ -1,11 +1,12 @@
-import unittest
-import unittest.mock
 import os.path
 import sys
 import test.support
-from test.support import os_helper
-from ctypes import *
+import unittest
+import unittest.mock
+from ctypes import CDLL, RTLD_GLOBAL
 from ctypes.util import find_library
+from test.support import os_helper
+
 
 # On some systems, loading the OpenGL libraries needs the RTLD_GLOBAL mode.
 class Test_OpenGL_libs(unittest.TestCase):
@@ -36,11 +37,13 @@ class Test_OpenGL_libs(unittest.TestCase):
                 cls.gl = CDLL(lib_gl, mode=RTLD_GLOBAL)
             except OSError:
                 pass
+
         if lib_glu:
             try:
                 cls.glu = CDLL(lib_glu, RTLD_GLOBAL)
             except OSError:
                 pass
+
         if lib_gle:
             try:
                 cls.gle = CDLL(lib_gle)

--- a/Lib/test/test_ctypes/test_frombuffer.py
+++ b/Lib/test/test_ctypes/test_frombuffer.py
@@ -1,7 +1,7 @@
-from ctypes import *
 import array
 import gc
 import unittest
+from ctypes import Structure, Union, Array, sizeof, c_char, c_int
 
 class X(Structure):
     _fields_ = [("c_int", c_int)]

--- a/Lib/test/test_ctypes/test_funcptr.py
+++ b/Lib/test/test_ctypes/test_funcptr.py
@@ -1,6 +1,8 @@
-import unittest
+import _ctypes_test
 import ctypes
-from ctypes import *
+import unittest
+from ctypes import (CDLL, Structure, CFUNCTYPE, sizeof,
+                    c_void_p, c_char_p, c_char, c_int, c_uint, c_long)
 
 try:
     WINFUNCTYPE = ctypes.WINFUNCTYPE
@@ -8,8 +10,8 @@ except AttributeError:
     # fake to enable this test on Linux
     WINFUNCTYPE = CFUNCTYPE
 
-import _ctypes_test
 lib = CDLL(_ctypes_test.__file__)
+
 
 class CFuncPtrTestCase(unittest.TestCase):
     def test_basic(self):
@@ -21,8 +23,8 @@ class CFuncPtrTestCase(unittest.TestCase):
         x = X(func)
         self.assertEqual(x.restype, c_int)
         self.assertEqual(x.argtypes, (c_int, c_int))
-        self.assertEqual(sizeof(x), sizeof(c_voidp))
-        self.assertEqual(sizeof(X), sizeof(c_voidp))
+        self.assertEqual(sizeof(x), sizeof(c_void_p))
+        self.assertEqual(sizeof(X), sizeof(c_void_p))
 
     def test_first(self):
         StdCallback = WINFUNCTYPE(c_int, c_int, c_int)
@@ -128,6 +130,7 @@ class CFuncPtrTestCase(unittest.TestCase):
         from ctypes import _CFuncPtr
 
         self.assertRaises(TypeError, _CFuncPtr, 13, "name", 42, "iid")
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/Lib/test/test_ctypes/test_functions.py
+++ b/Lib/test/test_ctypes/test_functions.py
@@ -6,7 +6,11 @@ Later...
 """
 
 import ctypes
-from ctypes import *
+from ctypes import (CDLL, Structure, Array, CFUNCTYPE,
+                    byref, POINTER, pointer, ArgumentError,
+                    c_char, c_wchar, c_byte, c_char_p,
+                    c_short, c_int, c_long, c_longlong,
+                    c_float, c_double, c_longdouble)
 from test.test_ctypes import need_symbol
 import sys, unittest
 

--- a/Lib/test/test_ctypes/test_incomplete.py
+++ b/Lib/test/test_ctypes/test_incomplete.py
@@ -1,7 +1,7 @@
 import ctypes
 import unittest
 import warnings
-from ctypes import *
+from ctypes import Structure, POINTER, pointer, c_char_p
 
 ################################################################
 #

--- a/Lib/test/test_ctypes/test_init.py
+++ b/Lib/test/test_ctypes/test_init.py
@@ -1,5 +1,6 @@
-from ctypes import *
 import unittest
+from ctypes import Structure, c_int
+
 
 class X(Structure):
     _fields_ = [("a", c_int),
@@ -14,6 +15,7 @@ class X(Structure):
     def __init__(self):
         self.a = 9
         self.b = 12
+
 
 class Y(Structure):
     _fields_ = [("x", X)]
@@ -35,6 +37,7 @@ class InitTest(unittest.TestCase):
         y.x = x
         self.assertEqual((y.x.a, y.x.b), (9, 12))
         self.assertEqual(y.x.new_was_called, False)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/Lib/test/test_ctypes/test_internals.py
+++ b/Lib/test/test_ctypes/test_internals.py
@@ -1,6 +1,6 @@
 # This tests the internal _objects attribute
 import unittest
-from ctypes import *
+from ctypes import Structure, POINTER, c_char_p, c_int
 from sys import getrefcount as grc
 
 # XXX This test must be reviewed for correctness!!!

--- a/Lib/test/test_ctypes/test_keeprefs.py
+++ b/Lib/test/test_ctypes/test_keeprefs.py
@@ -1,4 +1,4 @@
-from ctypes import *
+from ctypes import Structure, POINTER, pointer, c_char_p, c_int
 import unittest
 
 class SimpleTestCase(unittest.TestCase):

--- a/Lib/test/test_ctypes/test_libc.py
+++ b/Lib/test/test_ctypes/test_libc.py
@@ -1,9 +1,12 @@
 import unittest
 
-from ctypes import *
-import _ctypes_test
+from ctypes import (CDLL, CFUNCTYPE, POINTER, create_string_buffer, sizeof,
+                    c_void_p, c_char, c_int, c_double, c_size_t)
 
+
+import _ctypes_test
 lib = CDLL(_ctypes_test.__file__)
+
 
 def three_way_cmp(x, y):
     """Return -1 if x < y, 0 if x == y and 1 if x > y"""

--- a/Lib/test/test_ctypes/test_loading.py
+++ b/Lib/test/test_ctypes/test_loading.py
@@ -1,14 +1,14 @@
-from ctypes import *
 import ctypes
 import os
 import shutil
 import subprocess
 import sys
-import unittest
 import test.support
-from test.support import import_helper
-from test.support import os_helper
+import unittest
+from test.support import import_helper, os_helper
+from ctypes import CDLL, cdll, addressof, c_void_p, c_char_p
 from ctypes.util import find_library
+
 
 libc_name = None
 
@@ -126,6 +126,7 @@ class LoaderTest(unittest.TestCase):
         kernel32.GetProcAddress.restype = c_void_p
         proc = kernel32.GetProcAddress(advapi32._handle, b"CloseEventLog")
         self.assertTrue(proc)
+
         # This is the real test: call the function via 'call_function'
         self.assertEqual(0, call_function(proc, (None,)))
 
@@ -194,7 +195,6 @@ class LoaderTest(unittest.TestCase):
             # User-specified directory should succeed
             should_pass("import os; p = os.add_dll_directory(os.getcwd());" +
                         "WinDLL('_sqlite3.dll'); p.close()")
-
 
 
 if __name__ == "__main__":

--- a/Lib/test/test_ctypes/test_memfunctions.py
+++ b/Lib/test/test_ctypes/test_memfunctions.py
@@ -1,7 +1,11 @@
 import sys
 from test import support
 import unittest
-from ctypes import *
+from ctypes import (POINTER, sizeof, cast,
+                    create_string_buffer, string_at,
+                    create_unicode_buffer, wstring_at,
+                    memmove, memset,
+                    c_char_p, c_byte, c_ubyte, c_wchar)
 from test.test_ctypes import need_symbol
 
 class MemFunctionsTest(unittest.TestCase):

--- a/Lib/test/test_ctypes/test_numbers.py
+++ b/Lib/test/test_ctypes/test_numbers.py
@@ -1,10 +1,13 @@
 import struct
 import sys
 import unittest
+import unittest
 from array import array
 from operator import truth
-from ctypes import *
-from ctypes import _SimpleCData
+from ctypes import (byref, sizeof, alignment, _SimpleCData,
+                    c_byte, c_ubyte, c_short, c_ushort, c_int, c_uint,
+                    c_long, c_ulong, c_longlong, c_ulonglong,
+                    c_float, c_double, c_longdouble, c_bool)
 
 def valid_ranges(*types):
     # given a sequence of numeric types, collect their _type_

--- a/Lib/test/test_ctypes/test_numbers.py
+++ b/Lib/test/test_ctypes/test_numbers.py
@@ -5,7 +5,7 @@ import unittest
 from array import array
 from operator import truth
 from ctypes import (byref, sizeof, alignment, _SimpleCData,
-                    c_byte, c_ubyte, c_short, c_ushort, c_int, c_uint,
+                    c_char, c_byte, c_ubyte, c_short, c_ushort, c_int, c_uint,
                     c_long, c_ulong, c_longlong, c_ulonglong,
                     c_float, c_double, c_longdouble, c_bool)
 

--- a/Lib/test/test_ctypes/test_numbers.py
+++ b/Lib/test/test_ctypes/test_numbers.py
@@ -1,7 +1,6 @@
 import struct
 import sys
 import unittest
-import unittest
 from array import array
 from operator import truth
 from ctypes import (byref, sizeof, alignment, _SimpleCData,

--- a/Lib/test/test_ctypes/test_objects.py
+++ b/Lib/test/test_ctypes/test_objects.py
@@ -11,7 +11,7 @@ is None.
 
 Here is an array of string pointers:
 
->>> from ctypes import *
+>>> from ctypes import Structure, c_int, c_char_p
 >>> array = (c_char_p * 5)()
 >>> print(array._objects)
 None

--- a/Lib/test/test_ctypes/test_pep3118.py
+++ b/Lib/test/test_ctypes/test_pep3118.py
@@ -1,5 +1,10 @@
 import unittest
-from ctypes import *
+from ctypes import (CFUNCTYPE, POINTER, sizeof, Union,
+                    Structure, LittleEndianStructure, BigEndianStructure,
+                    c_char, c_byte, c_ubyte,
+                    c_short, c_ushort, c_int, c_uint,
+                    c_long, c_ulong, c_longlong, c_ulonglong, c_uint64,
+                    c_bool, c_float, c_double, c_longdouble, py_object)
 import re, sys
 
 if sys.byteorder == "little":

--- a/Lib/test/test_ctypes/test_pickling.py
+++ b/Lib/test/test_ctypes/test_pickling.py
@@ -1,8 +1,12 @@
 import unittest
 import pickle
-from ctypes import *
+from ctypes import (CDLL, Structure, CFUNCTYPE, pointer,
+                    c_void_p, c_char_p, c_wchar_p, c_char, c_wchar, c_int, c_double)
+
+
 import _ctypes_test
 dll = CDLL(_ctypes_test.__file__)
+
 
 class X(Structure):
     _fields_ = [("a", c_int), ("b", c_double)]

--- a/Lib/test/test_ctypes/test_pointers.py
+++ b/Lib/test/test_ctypes/test_pointers.py
@@ -1,8 +1,11 @@
-import unittest, sys
-
-import ctypes
-from ctypes import *
 import _ctypes_test
+import ctypes
+import sys
+import unittest
+from ctypes import (CDLL, CFUNCTYPE, Structure, POINTER, pointer, byref, sizeof,
+                    c_void_p, c_char_p,
+                    c_byte, c_ubyte, c_short, c_ushort, c_int, c_uint,
+                    c_long, c_ulong, c_longlong, c_ulonglong, c_float, c_double)
 
 ctype_types = [c_byte, c_ubyte, c_short, c_ushort, c_int, c_uint,
                  c_long, c_ulong, c_longlong, c_ulonglong, c_double, c_float]

--- a/Lib/test/test_ctypes/test_prototypes.py
+++ b/Lib/test/test_ctypes/test_prototypes.py
@@ -1,4 +1,7 @@
-from ctypes import *
+from ctypes import (CDLL, CFUNCTYPE, POINTER, ArgumentError,
+                    pointer, byref, sizeof, addressof,
+                    c_void_p, c_char_p, c_wchar_p, c_char, c_wchar, c_buffer,
+                    c_short, c_int, c_long, c_longlong, c_double)
 from test.test_ctypes import need_symbol
 import unittest
 

--- a/Lib/test/test_ctypes/test_python_api.py
+++ b/Lib/test/test_ctypes/test_python_api.py
@@ -1,6 +1,8 @@
-from ctypes import *
 import unittest
 from test import support
+from ctypes import (pythonapi, POINTER, c_buffer, sizeof,
+                    py_object, c_char_p, c_char, c_long, c_size_t)
+
 
 ################################################################
 # This section should be moved into ctypes\__init__.py, when it's ready.
@@ -81,6 +83,7 @@ class PythonAPITestCase(unittest.TestCase):
         self.assertEqual(repr(py_object()), "py_object(<NULL>)")
         self.assertEqual(repr(py_object(42)), "py_object(42)")
         self.assertEqual(repr(py_object(object)), "py_object(%r)" % object)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/Lib/test/test_ctypes/test_random_things.py
+++ b/Lib/test/test_ctypes/test_random_things.py
@@ -1,9 +1,9 @@
-from ctypes import *
-import ctypes
 import contextlib
-from test import support
-import unittest
+import ctypes
 import sys
+import unittest
+from test import support
+from ctypes import CFUNCTYPE, c_void_p, c_char_p, c_int, c_double
 
 
 def callback_func(arg):

--- a/Lib/test/test_ctypes/test_repr.py
+++ b/Lib/test/test_ctypes/test_repr.py
@@ -1,4 +1,6 @@
-from ctypes import *
+from ctypes import (c_byte, c_short, c_int, c_long, c_longlong,
+                    c_ubyte, c_ushort, c_uint, c_ulong, c_ulonglong,
+                    c_float, c_double, c_longdouble, c_bool, c_char)
 import unittest
 
 subclasses = []
@@ -24,6 +26,7 @@ class ReprTest(unittest.TestCase):
     def test_char(self):
         self.assertEqual("c_char(b'x')", repr(c_char(b'x')))
         self.assertEqual("<X object at", repr(X(b'x'))[:12])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/Lib/test/test_ctypes/test_returnfuncptrs.py
+++ b/Lib/test/test_ctypes/test_returnfuncptrs.py
@@ -1,5 +1,5 @@
 import unittest
-from ctypes import *
+from ctypes import CDLL, CFUNCTYPE, ArgumentError, c_char_p, c_void_p, c_char
 
 import _ctypes_test
 
@@ -61,6 +61,7 @@ class ReturnFuncPtrTestCase(unittest.TestCase):
         self.assertEqual(strchr(b"abcdef", b"x"), None)
         self.assertRaises(ArgumentError, strchr, b"abcdef", 3.0)
         self.assertRaises(TypeError, strchr, b"abcdef")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/Lib/test/test_ctypes/test_simplesubclasses.py
+++ b/Lib/test/test_ctypes/test_simplesubclasses.py
@@ -1,11 +1,13 @@
 import unittest
-from ctypes import *
+from ctypes import Structure, CFUNCTYPE, c_int
+
 
 class MyInt(c_int):
     def __eq__(self, other):
         if type(other) != MyInt:
             return NotImplementedError
         return self.value == other.value
+
 
 class Test(unittest.TestCase):
 
@@ -50,6 +52,7 @@ class Test(unittest.TestCase):
         s.x = MyInt(42)
 
         self.assertEqual(s.x, MyInt(42))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/Lib/test/test_ctypes/test_sizes.py
+++ b/Lib/test/test_ctypes/test_sizes.py
@@ -1,7 +1,9 @@
 # Test specifically-sized containers.
 
-from ctypes import *
-
+from ctypes import (sizeof,
+                    c_int8, c_uint8, c_int16, c_uint16,
+                    c_int32, c_uint32, c_int64, c_uint64,
+                    c_void_p, c_size_t, c_ssize_t, c_time_t, SIZEOF_TIME_T)
 import unittest
 
 

--- a/Lib/test/test_ctypes/test_slicing.py
+++ b/Lib/test/test_ctypes/test_slicing.py
@@ -1,5 +1,6 @@
 import unittest
-from ctypes import *
+from ctypes import (CDLL, POINTER, sizeof,
+                    c_byte, c_short, c_int, c_long, c_char, c_wchar, c_char_p)
 from test.test_ctypes import need_symbol
 
 import _ctypes_test

--- a/Lib/test/test_ctypes/test_stringptr.py
+++ b/Lib/test/test_ctypes/test_stringptr.py
@@ -1,6 +1,6 @@
 import unittest
 from test import support
-from ctypes import *
+from ctypes import CDLL, Structure, POINTER, c_buffer, c_char, c_char_p
 
 import _ctypes_test
 

--- a/Lib/test/test_ctypes/test_strings.py
+++ b/Lib/test/test_ctypes/test_strings.py
@@ -1,5 +1,5 @@
 import unittest
-from ctypes import *
+from ctypes import c_buffer, sizeof, byref, c_char, c_wchar
 from test.test_ctypes import need_symbol
 
 class StringArrayTestCase(unittest.TestCase):

--- a/Lib/test/test_ctypes/test_struct_fields.py
+++ b/Lib/test/test_ctypes/test_struct_fields.py
@@ -1,5 +1,5 @@
 import unittest
-from ctypes import *
+from ctypes import Structure, Union, sizeof, c_char, c_int
 
 class StructFieldsTestCase(unittest.TestCase):
     # Structure/Union classes must get 'finalized' sooner or

--- a/Lib/test/test_ctypes/test_structures.py
+++ b/Lib/test/test_ctypes/test_structures.py
@@ -1,7 +1,11 @@
 import platform
 import sys
 import unittest
-from ctypes import *
+from ctypes import (CDLL, Structure, Union, POINTER, sizeof, byref, alignment,
+                    c_void_p, c_char, c_wchar, c_byte, c_ubyte,
+                    c_uint8, c_uint16, c_uint32,
+                    c_short, c_ushort, c_int, c_uint,
+                    c_long, c_ulong, c_longlong, c_ulonglong, c_float, c_double)
 from test.test_ctypes import need_symbol
 from struct import calcsize
 import _ctypes_test

--- a/Lib/test/test_ctypes/test_unaligned_structures.py
+++ b/Lib/test/test_ctypes/test_unaligned_structures.py
@@ -1,5 +1,8 @@
 import sys, unittest
-from ctypes import *
+from ctypes import (Structure, BigEndianStructure, LittleEndianStructure,
+                    c_byte, c_short, c_int, c_long, c_longlong,
+                    c_float, c_double,
+                    c_ushort, c_uint, c_ulong, c_ulonglong)
 
 structures = []
 byteswapped_structures = []

--- a/Lib/test/test_ctypes/test_values.py
+++ b/Lib/test/test_ctypes/test_values.py
@@ -6,7 +6,7 @@ import _imp
 import importlib.util
 import unittest
 import sys
-from ctypes import *
+from ctypes import Structure, CDLL, POINTER, pythonapi, c_ubyte, c_char_p, c_int
 from test.support import import_helper
 
 import _ctypes_test

--- a/Lib/test/test_ctypes/test_varsize_struct.py
+++ b/Lib/test/test_ctypes/test_varsize_struct.py
@@ -1,4 +1,4 @@
-from ctypes import *
+from ctypes import Structure, sizeof, resize, c_int
 import unittest
 
 class VarSizeTest(unittest.TestCase):

--- a/Lib/test/test_ctypes/test_win32.py
+++ b/Lib/test/test_ctypes/test_win32.py
@@ -1,11 +1,13 @@
 # Windows specific tests
 
+import _ctypes_test
 import ctypes
-from ctypes import *
-import unittest, sys
+import sys
+import unittest
+from ctypes import (CDLL, Structure, POINTER, pointer, sizeof, byref,
+                    c_void_p, c_char, c_int, c_long)
 from test import support
 
-import _ctypes_test
 
 @unittest.skipUnless(sys.platform == "win32", 'Windows-specific test')
 class FunctionCallTestCase(unittest.TestCase):
@@ -94,6 +96,7 @@ class TestWinError(unittest.TestCase):
         self.assertEqual(e.errno, errno.EINVAL)
         self.assertEqual(e.winerror, ERROR_INVALID_PARAMETER)
 
+
 class Structures(unittest.TestCase):
     def test_struct_by_value(self):
         class POINT(Structure):
@@ -135,6 +138,7 @@ class Structures(unittest.TestCase):
         # to not leak references, we must clean _pointer_type_cache
         from ctypes import _pointer_type_cache
         del _pointer_type_cache[RECT]
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/Lib/test/test_ctypes/test_wintypes.py
+++ b/Lib/test/test_ctypes/test_wintypes.py
@@ -5,7 +5,7 @@ import unittest
 
 # also work on POSIX
 
-from ctypes import *
+from ctypes import POINTER, cast, c_int16
 from ctypes import wintypes
 
 


### PR DESCRIPTION
Using "import *" prevents linters like pyflakes to detect symbols (variables, functions) used being imported.

Replace c_voidp with c_void_p.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-105751 -->
* Issue: gh-105751
<!-- /gh-issue-number -->
