### PR TITLE
gh-105751: test_ctypes avoids the operator module

### DIFF
--- a/Lib/test/test_ctypes/test_arrays.py
+++ b/Lib/test/test_ctypes/test_arrays.py
@@ -47,9 +47,9 @@ class ArrayTestCase(unittest.TestCase):
             with self.assertRaises(IndexError): ia[-alen-1]
 
             # change the items
-            from operator import setitem
             new_values = list(range(42, 42+alen))
-            [setitem(ia, n, new_values[n]) for n in range(alen)]
+            for n in range(alen):
+                ia[n] = new_values[n]
             values = [ia[i] for i in range(alen)]
             self.assertEqual(values, new_values)
 
@@ -79,8 +79,8 @@ class ArrayTestCase(unittest.TestCase):
         self.assertEqual(len(ca), 3)
 
         # cannot delete items
-        from operator import delitem
-        self.assertRaises(TypeError, delitem, ca, 0)
+        with self.assertRaises(TypeError):
+            del ca[0]
 
     def test_step_overflow(self):
         a = (c_int * 5)()

--- a/Lib/test/test_ctypes/test_callbacks.py
+++ b/Lib/test/test_ctypes/test_callbacks.py
@@ -1,4 +1,5 @@
 import functools
+import sys
 import unittest
 from test import support
 
@@ -109,15 +110,14 @@ class Callbacks(unittest.TestCase):
 
     def test_pyobject(self):
         o = ()
-        from sys import getrefcount as grc
         for o in (), [], object():
-            initial = grc(o)
+            initial = sys.getrefcount(o)
             # This call leaks a reference to 'o'...
             self.check_type(py_object, o)
-            before = grc(o)
+            before = sys.getrefcount(o)
             # ...but this call doesn't leak any more.  Where is the refcount?
             self.check_type(py_object, o)
-            after = grc(o)
+            after = sys.getrefcount(o)
             self.assertEqual((after, o), (before, o))
 
     def test_unsupported_restype_1(self):

--- a/Lib/test/test_ctypes/test_delattr.py
+++ b/Lib/test/test_ctypes/test_delattr.py
@@ -8,16 +8,18 @@ class X(Structure):
 
 class TestCase(unittest.TestCase):
     def test_simple(self):
-        self.assertRaises(TypeError,
-                          delattr, c_int(42), "value")
+        with self.assertRaises(TypeError):
+            del c_int(42).value
 
     def test_chararray(self):
-        self.assertRaises(TypeError,
-                          delattr, (c_char * 5)(), "value")
+        chararray = (c_char * 5)()
+        with self.assertRaises(TypeError):
+            del chararray.value
 
     def test_struct(self):
-        self.assertRaises(TypeError,
-                          delattr, X(), "foo")
+        struct = X()
+        with self.assertRaises(TypeError):
+            del struct.foo
 
 
 if __name__ == "__main__":

--- a/Lib/test/test_ctypes/test_internals.py
+++ b/Lib/test/test_ctypes/test_internals.py
@@ -1,7 +1,7 @@
 # This tests the internal _objects attribute
+import sys
 import unittest
 from ctypes import Structure, POINTER, c_char_p, c_int
-from sys import getrefcount as grc
 
 # XXX This test must be reviewed for correctness!!!
 
@@ -20,16 +20,16 @@ class ObjectsTestCase(unittest.TestCase):
 
     def test_ints(self):
         i = 42000123
-        refcnt = grc(i)
+        refcnt = sys.getrefcount(i)
         ci = c_int(i)
-        self.assertEqual(refcnt, grc(i))
+        self.assertEqual(refcnt, sys.getrefcount(i))
         self.assertEqual(ci._objects, None)
 
     def test_c_char_p(self):
         s = b"Hello, World"
-        refcnt = grc(s)
+        refcnt = sys.getrefcount(s)
         cs = c_char_p(s)
-        self.assertEqual(refcnt + 1, grc(s))
+        self.assertEqual(refcnt + 1, sys.getrefcount(s))
         self.assertSame(cs._objects, s)
 
     def test_simple_struct(self):

--- a/Lib/test/test_ctypes/test_keeprefs.py
+++ b/Lib/test/test_ctypes/test_keeprefs.py
@@ -1,5 +1,7 @@
-from ctypes import Structure, POINTER, pointer, c_char_p, c_int
+import sys
 import unittest
+from ctypes import Structure, POINTER, pointer, c_char_p, c_int
+
 
 class SimpleTestCase(unittest.TestCase):
     def test_cint(self):
@@ -100,16 +102,15 @@ class DeletePointerTestCase(unittest.TestCase):
             _fields_ = [("p", POINTER(c_char_p))]
         x = X()
         i = c_char_p("abc def")
-        from sys import getrefcount as grc
-        print("2?", grc(i))
+        print("2?", sys.getrefcount(i))
         x.p = pointer(i)
-        print("3?", grc(i))
+        print("3?", sys.getrefcount(i))
         for i in range(320):
             c_int(99)
             x.p[0]
         print(x.p[0])
 ##        del x
-##        print "2?", grc(i)
+##        print "2?", sys.getrefcount(i)
 ##        del i
         import gc
         gc.collect()

--- a/Lib/test/test_ctypes/test_pointers.py
+++ b/Lib/test/test_ctypes/test_pointers.py
@@ -97,7 +97,6 @@ class PointersTestCase(unittest.TestCase):
 ##        print self.result
 
     def test_basics(self):
-        from operator import delitem
         for ct, pt in zip(ctype_types, python_types):
             i = ct(42)
             p = pointer(i)
@@ -108,7 +107,8 @@ class PointersTestCase(unittest.TestCase):
 ##            self.assertEqual(p.contents, 42)
 ##            self.assertEqual(p[0], 42)
 
-            self.assertRaises(TypeError, delitem, p, 0)
+            with self.assertRaises(TypeError):
+                del p[0]
 
     def test_from_address(self):
         from array import array

--- a/Lib/test/test_ctypes/test_python_api.py
+++ b/Lib/test/test_ctypes/test_python_api.py
@@ -1,4 +1,5 @@
 import unittest
+import sys
 from test import support
 from ctypes import (pythonapi, POINTER, c_buffer, sizeof,
                     py_object, c_char_p, c_char, c_long, c_size_t)
@@ -11,7 +12,6 @@ from _ctypes import PyObj_FromPtr
 
 ################################################################
 
-from sys import getrefcount as grc
 
 class PythonAPITestCase(unittest.TestCase):
 
@@ -29,41 +29,41 @@ class PythonAPITestCase(unittest.TestCase):
         pythonapi.PyBytes_FromString.argtypes = (c_char_p,)
 
         s = b"abc"
-        refcnt = grc(s)
+        refcnt = sys.getrefcount(s)
         pyob = pythonapi.PyBytes_FromString(s)
-        self.assertEqual(grc(s), refcnt)
+        self.assertEqual(sys.getrefcount(s), refcnt)
         self.assertEqual(s, pyob)
         del pyob
-        self.assertEqual(grc(s), refcnt)
+        self.assertEqual(sys.getrefcount(s), refcnt)
 
     @support.refcount_test
     def test_PyLong_Long(self):
-        ref42 = grc(42)
+        ref42 = sys.getrefcount(42)
         pythonapi.PyLong_FromLong.restype = py_object
         self.assertEqual(pythonapi.PyLong_FromLong(42), 42)
 
-        self.assertEqual(grc(42), ref42)
+        self.assertEqual(sys.getrefcount(42), ref42)
 
         pythonapi.PyLong_AsLong.argtypes = (py_object,)
         pythonapi.PyLong_AsLong.restype = c_long
 
         res = pythonapi.PyLong_AsLong(42)
         # Small int refcnts don't change
-        self.assertEqual(grc(res), ref42)
+        self.assertEqual(sys.getrefcount(res), ref42)
         del res
-        self.assertEqual(grc(42), ref42)
+        self.assertEqual(sys.getrefcount(42), ref42)
 
     @support.refcount_test
     def test_PyObj_FromPtr(self):
         s = "abc def ghi jkl"
-        ref = grc(s)
+        ref = sys.getrefcount(s)
         # id(python-object) is the address
         pyobj = PyObj_FromPtr(id(s))
         self.assertIs(s, pyobj)
 
-        self.assertEqual(grc(s), ref + 1)
+        self.assertEqual(sys.getrefcount(s), ref + 1)
         del pyobj
-        self.assertEqual(grc(s), ref)
+        self.assertEqual(sys.getrefcount(s), ref)
 
     def test_PyOS_snprintf(self):
         PyOS_snprintf = pythonapi.PyOS_snprintf

--- a/Lib/test/test_ctypes/test_slicing.py
+++ b/Lib/test/test_ctypes/test_slicing.py
@@ -47,18 +47,21 @@ class SlicesTestCase(unittest.TestCase):
         b[33::-3] = range(12)
         self.assertEqual(a[:], b)
 
-        from operator import setitem
+        # TypeError: int expected instead of str instance
+        with self.assertRaises(TypeError):
+            a[:5] = "abcde"
 
         # TypeError: int expected instead of str instance
-        self.assertRaises(TypeError, setitem, a, slice(0, 5), "abcde")
-        # TypeError: int expected instead of str instance
-        self.assertRaises(TypeError, setitem, a, slice(0, 5),
-                          ["a", "b", "c", "d", "e"])
+        with self.assertRaises(TypeError):
+            a[:5] =  ["a", "b", "c", "d", "e"]
+
         # TypeError: int expected instead of float instance
-        self.assertRaises(TypeError, setitem, a, slice(0, 5),
-                          [1, 2, 3, 4, 3.14])
+        with self.assertRaises(TypeError):
+            a[:5] = [1, 2, 3, 4, 3.14]
+
         # ValueError: Can only assign sequence of same size
-        self.assertRaises(ValueError, setitem, a, slice(0, 5), range(32))
+        with self.assertRaises(ValueError):
+            a[:5] = range(32)
 
     def test_char_ptr(self):
         s = b"abcdefghijklmnopqrstuvwxyz"
@@ -74,18 +77,20 @@ class SlicesTestCase(unittest.TestCase):
         self.assertEqual(res[len(s)-1:5:-7], s[:5:-7])
         self.assertEqual(res[0:-1:-1], s[0::-1])
 
-        import operator
-        self.assertRaises(ValueError, operator.getitem,
-                          res, slice(None, None, None))
-        self.assertRaises(ValueError, operator.getitem,
-                          res, slice(0, None, None))
-        self.assertRaises(ValueError, operator.getitem,
-                          res, slice(None, 5, -1))
-        self.assertRaises(ValueError, operator.getitem,
-                          res, slice(-5, None, None))
+        # get items
+        with self.assertRaises(ValueError):
+            res[:]
+        with self.assertRaises(ValueError):
+            res[0:]
+        with self.assertRaises(ValueError):
+            res[:5:-1]
+        with self.assertRaises(ValueError):
+            res[-5:]
 
-        self.assertRaises(TypeError, operator.setitem,
-                          res, slice(0, 5), "abcde")
+        # set items
+        with self.assertRaises(TypeError):
+            res[:5] = "abcde"
+
         dll.my_free(res)
 
         dll.my_strdup.restype = POINTER(c_byte)
@@ -141,9 +146,8 @@ class SlicesTestCase(unittest.TestCase):
         self.assertEqual(res[len(s)-1:-1:-1], s[::-1])
         self.assertEqual(res[len(s)-1:5:-7], s[:5:-7])
 
-        import operator
-        self.assertRaises(TypeError, operator.setitem,
-                          res, slice(0, 5), "abcde")
+        with self.assertRaises(TypeError):
+            res[:5] = "abcde"
         dll.my_free(res)
 
         if sizeof(c_wchar) == sizeof(c_short):

--- a/Lib/test/test_ctypes/test_stringptr.py
+++ b/Lib/test/test_ctypes/test_stringptr.py
@@ -1,4 +1,5 @@
 import unittest
+import sys
 from test import support
 from ctypes import CDLL, Structure, POINTER, c_buffer, c_char, c_char_p
 
@@ -17,10 +18,9 @@ class StringPtrTestCase(unittest.TestCase):
         # NULL pointer access
         self.assertRaises(ValueError, getattr, x.str, "contents")
         b = c_buffer(b"Hello, World")
-        from sys import getrefcount as grc
-        self.assertEqual(grc(b), 2)
+        self.assertEqual(sys.getrefcount(b), 2)
         x.str = b
-        self.assertEqual(grc(b), 3)
+        self.assertEqual(sys.getrefcount(b), 3)
 
         # POINTER(c_char) and Python string is NOT compatible
         # POINTER(c_char) and c_buffer() is compatible


### PR DESCRIPTION
* Replace operator.delitem(obj, index) with "del obj[index]".
* Replace operator.setitem(obj, index, value) with "obj[index] = value".
* Replace delattr(obj, "attr) with "del obj.attr".
* Replace grc() with sys.getrefcount() for readability.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-105751 -->
* Issue: gh-105751
<!-- /gh-issue-number -->
