### PR TITLE
gh-105751: test_ctypes: Remove @need_symbol decorator

### DIFF
--- a/Lib/test/test_ctypes/__init__.py
+++ b/Lib/test/test_ctypes/__init__.py
@@ -1,16 +1,10 @@
 import os
-import unittest
 from test import support
 from test.support import import_helper
 
 
-# skip tests if _ctypes was not built
-ctypes = import_helper.import_module('ctypes')
-ctypes_symbols = dir(ctypes)
-
-def need_symbol(name):
-    return unittest.skipUnless(name in ctypes_symbols,
-                               '{!r} is required'.format(name))
+# skip tests if the _ctypes extension was not built
+import_helper.import_module('ctypes')
 
 def load_tests(*args):
     return support.load_package_tests(os.path.dirname(__file__), *args)

--- a/Lib/test/test_ctypes/test_arrays.py
+++ b/Lib/test/test_ctypes/test_arrays.py
@@ -8,7 +8,6 @@ from ctypes import (Structure, Array, sizeof, addressof,
                     c_long, c_ulonglong, c_float, c_double, c_longdouble)
 from test.support import bigmemtest, _2G
 
-from test.test_ctypes import need_symbol
 
 formats = "bBhHiIlLqQfd"
 
@@ -130,7 +129,6 @@ class ArrayTestCase(unittest.TestCase):
         self.assertEqual(sz[1:4:2], b"o")
         self.assertEqual(sz.value, b"foo")
 
-    @need_symbol('create_unicode_buffer')
     def test_from_addressW(self):
         p = create_unicode_buffer("foo")
         sz = (c_wchar * 3).from_address(addressof(p))

--- a/Lib/test/test_ctypes/test_as_parameter.py
+++ b/Lib/test/test_ctypes/test_as_parameter.py
@@ -6,7 +6,7 @@ from ctypes import (Structure, CDLL, CFUNCTYPE,
                     c_short, c_int, c_long, c_longlong,
                     c_byte, c_wchar, c_float, c_double,
                     ArgumentError)
-from test.test_ctypes import need_symbol
+
 
 dll = CDLL(_ctypes_test.__file__)
 
@@ -23,7 +23,6 @@ class BasicWrapTestCase(unittest.TestCase):
     def wrap(self, param):
         return param
 
-    @need_symbol('c_wchar')
     def test_wchar_parm(self):
         f = dll._testfunc_i_bhilfd
         f.argtypes = [c_byte, c_wchar, c_int, c_long, c_float, c_double]
@@ -127,9 +126,7 @@ class BasicWrapTestCase(unittest.TestCase):
         result = f(self.wrap(-10), self.wrap(cb))
         self.assertEqual(result, -18)
 
-    @need_symbol('c_longlong')
     def test_longlong_callbacks(self):
-
         f = dll._testfunc_callback_q_qf
         f.restype = c_longlong
 

--- a/Lib/test/test_ctypes/test_bitfields.py
+++ b/Lib/test/test_ctypes/test_bitfields.py
@@ -3,7 +3,6 @@ from ctypes import (CDLL, Structure, sizeof, POINTER, byref, alignment,
                     c_byte, c_ubyte, c_char, c_char_p, c_void_p, c_wchar,
                     c_uint32, c_uint64,
                     c_short, c_ushort, c_int, c_uint, c_long, c_ulong, c_longlong, c_ulonglong)
-from test.test_ctypes import need_symbol
 from test import support
 import unittest
 import os
@@ -144,7 +143,6 @@ class BitFieldTest(unittest.TestCase):
         result = self.fail_fields(("a", Dummy, 1))
         self.assertEqual(result, (TypeError, 'bit fields not allowed for type Dummy'))
 
-    @need_symbol('c_wchar')
     def test_c_wchar(self):
         result = self.fail_fields(("a", c_wchar, 1))
         self.assertEqual(result,
@@ -249,7 +247,6 @@ class BitFieldTest(unittest.TestCase):
             _anonymous_ = ["_"]
             _fields_ = [("_", X)]
 
-    @need_symbol('c_uint32')
     def test_uint32(self):
         class X(Structure):
             _fields_ = [("a", c_uint32, 32)]
@@ -259,7 +256,6 @@ class BitFieldTest(unittest.TestCase):
         x.a = 0xFDCBA987
         self.assertEqual(x.a, 0xFDCBA987)
 
-    @need_symbol('c_uint64')
     def test_uint64(self):
         class X(Structure):
             _fields_ = [("a", c_uint64, 64)]
@@ -269,7 +265,6 @@ class BitFieldTest(unittest.TestCase):
         x.a = 0xFEDCBA9876543211
         self.assertEqual(x.a, 0xFEDCBA9876543211)
 
-    @need_symbol('c_uint32')
     def test_uint32_swap_little_endian(self):
         # Issue #23319
         class Little(LittleEndianStructure):
@@ -283,7 +278,6 @@ class BitFieldTest(unittest.TestCase):
         x.c = 2
         self.assertEqual(b, b'\xef\xcd\xab\x21')
 
-    @need_symbol('c_uint32')
     def test_uint32_swap_big_endian(self):
         # Issue #23319
         class Big(BigEndianStructure):

--- a/Lib/test/test_ctypes/test_buffers.py
+++ b/Lib/test/test_ctypes/test_buffers.py
@@ -1,6 +1,5 @@
 from ctypes import (create_string_buffer, create_unicode_buffer, sizeof,
                     c_char, c_wchar)
-from test.test_ctypes import need_symbol
 import unittest
 
 class StringBufferTestCase(unittest.TestCase):
@@ -28,7 +27,6 @@ class StringBufferTestCase(unittest.TestCase):
         self.assertEqual(len(bytearray(create_string_buffer(0))), 0)
         self.assertEqual(len(bytearray(create_string_buffer(1))), 1)
 
-    @need_symbol('c_wchar')
     def test_unicode_buffer(self):
         b = create_unicode_buffer(32)
         self.assertEqual(len(b), 32)
@@ -48,7 +46,6 @@ class StringBufferTestCase(unittest.TestCase):
 
         self.assertRaises(TypeError, create_unicode_buffer, b"abc")
 
-    @need_symbol('c_wchar')
     def test_unicode_conversion(self):
         b = create_unicode_buffer("abc")
         self.assertEqual(len(b), 4) # trailing nul char
@@ -61,7 +58,6 @@ class StringBufferTestCase(unittest.TestCase):
         self.assertEqual(b[::2], "ac")
         self.assertEqual(b[::5], "a")
 
-    @need_symbol('c_wchar')
     def test_create_unicode_buffer_non_bmp(self):
         expected = 5 if sizeof(c_wchar) == 2 else 3
         for s in '\U00010000\U00100000', '\U00010000\U0010ffff':

--- a/Lib/test/test_ctypes/test_callbacks.py
+++ b/Lib/test/test_ctypes/test_callbacks.py
@@ -9,9 +9,9 @@ from ctypes import (CDLL, cdll, Structure, CFUNCTYPE,
                     c_short, c_ushort, c_int, c_uint,
                     c_long, c_longlong, c_ulonglong, c_ulong,
                     c_float, c_double, c_longdouble, py_object)
-from test.test_ctypes import need_symbol
 from _ctypes import CTYPES_MAX_ARGCOUNT
 import _ctypes_test
+
 
 class Callbacks(unittest.TestCase):
     functype = CFUNCTYPE
@@ -71,12 +71,10 @@ class Callbacks(unittest.TestCase):
     def test_ulong(self):
         self.check_type(c_ulong, 42)
 
-    @need_symbol('c_longlong')
     def test_longlong(self):
         self.check_type(c_longlong, 42)
         self.check_type(c_longlong, -42)
 
-    @need_symbol('c_ulonglong')
     def test_ulonglong(self):
         self.check_type(c_ulonglong, 42)
 
@@ -90,7 +88,6 @@ class Callbacks(unittest.TestCase):
         self.check_type(c_double, 3.14)
         self.check_type(c_double, -3.14)
 
-    @need_symbol('c_longdouble')
     def test_longdouble(self):
         self.check_type(c_longdouble, 3.14)
         self.check_type(c_longdouble, -3.14)
@@ -156,7 +153,8 @@ class Callbacks(unittest.TestCase):
                 gc.collect()
         CFUNCTYPE(None)(lambda x=Nasty(): None)
 
-    @need_symbol('WINFUNCTYPE')
+    @unittest.skipUnless(hasattr(ctypes, 'WINFUNCTYPE'),
+                         'ctypes.WINFUNCTYPE is required')
     def test_i38748_stackCorruption(self):
         callback_funcType = ctypes.WINFUNCTYPE(c_long, c_long, c_longlong)
         @callback_funcType
@@ -214,7 +212,8 @@ class SampleCallbacksTestCase(unittest.TestCase):
         libc.qsort(array, len(array), sizeof(c_int), cmp_func)
         self.assertEqual(array[:], [1, 5, 7, 33, 99])
 
-    @need_symbol('WINFUNCTYPE')
+    @unittest.skipUnless(hasattr(ctypes, 'WINFUNCTYPE'),
+                         'ctypes.WINFUNCTYPE is required')
     def test_issue_8959_b(self):
         from ctypes.wintypes import BOOL, HWND, LPARAM
         global windowCount

--- a/Lib/test/test_ctypes/test_cast.py
+++ b/Lib/test/test_ctypes/test_cast.py
@@ -3,7 +3,6 @@ import unittest
 from ctypes import (Structure, Union, POINTER, cast, sizeof, addressof,
                     c_void_p, c_char_p, c_wchar_p,
                     c_byte, c_short, c_int)
-from test.test_ctypes import need_symbol
 
 class Test(unittest.TestCase):
 
@@ -78,7 +77,6 @@ class Test(unittest.TestCase):
         self.assertEqual(cast(cast(s, c_void_p), c_char_p).value,
                              b"hiho")
 
-    @need_symbol('c_wchar_p')
     def test_wchar_p(self):
         s = c_wchar_p("hiho")
         self.assertEqual(cast(cast(s, c_void_p), c_wchar_p).value,

--- a/Lib/test/test_ctypes/test_cfuncs.py
+++ b/Lib/test/test_ctypes/test_cfuncs.py
@@ -5,7 +5,6 @@ from ctypes import (CDLL,
                     c_short, c_ushort, c_int, c_uint,
                     c_long, c_ulong, c_longlong, c_ulonglong,
                     c_float, c_double, c_longdouble)
-from test.test_ctypes import need_symbol
 import _ctypes_test
 
 
@@ -113,28 +112,24 @@ class CFunctions(unittest.TestCase):
         self.assertEqual(self._dll.tf_bL(b' ', 4294967295), 1431655765)
         self.assertEqual(self.U(), 4294967295)
 
-    @need_symbol('c_longlong')
     def test_longlong(self):
         self._dll.tf_q.restype = c_longlong
         self._dll.tf_q.argtypes = (c_longlong, )
         self.assertEqual(self._dll.tf_q(-9223372036854775806), -3074457345618258602)
         self.assertEqual(self.S(), -9223372036854775806)
 
-    @need_symbol('c_longlong')
     def test_longlong_plus(self):
         self._dll.tf_bq.restype = c_longlong
         self._dll.tf_bq.argtypes = (c_byte, c_longlong)
         self.assertEqual(self._dll.tf_bq(0, -9223372036854775806), -3074457345618258602)
         self.assertEqual(self.S(), -9223372036854775806)
 
-    @need_symbol('c_ulonglong')
     def test_ulonglong(self):
         self._dll.tf_Q.restype = c_ulonglong
         self._dll.tf_Q.argtypes = (c_ulonglong, )
         self.assertEqual(self._dll.tf_Q(18446744073709551615), 6148914691236517205)
         self.assertEqual(self.U(), 18446744073709551615)
 
-    @need_symbol('c_ulonglong')
     def test_ulonglong_plus(self):
         self._dll.tf_bQ.restype = c_ulonglong
         self._dll.tf_bQ.argtypes = (c_byte, c_ulonglong)
@@ -165,14 +160,12 @@ class CFunctions(unittest.TestCase):
         self.assertEqual(self._dll.tf_bd(0, 42.), 14.)
         self.assertEqual(self.S(), 42)
 
-    @need_symbol('c_longdouble')
     def test_longdouble(self):
         self._dll.tf_D.restype = c_longdouble
         self._dll.tf_D.argtypes = (c_longdouble,)
         self.assertEqual(self._dll.tf_D(42.), 14.)
         self.assertEqual(self.S(), 42)
 
-    @need_symbol('c_longdouble')
     def test_longdouble_plus(self):
         self._dll.tf_bD.restype = c_longdouble
         self._dll.tf_bD.argtypes = (c_byte, c_longdouble)

--- a/Lib/test/test_ctypes/test_checkretval.py
+++ b/Lib/test/test_ctypes/test_checkretval.py
@@ -1,7 +1,6 @@
 import ctypes
 import unittest
 from ctypes import CDLL, c_int
-from test.test_ctypes import need_symbol
 
 
 class CHECKED(c_int):
@@ -28,7 +27,8 @@ class Test(unittest.TestCase):
         del dll._testfunc_p_p.restype
         self.assertEqual(42, dll._testfunc_p_p(42))
 
-    @need_symbol('oledll')
+    @unittest.skipUnless(hasattr(ctypes, 'oledll'),
+                         'ctypes.oledll is required')
     def test_oledll(self):
         oleaut32 = ctypes.oledll.oleaut32
         self.assertRaises(OSError, oleaut32.CreateTypeLib2, 0, None, None)

--- a/Lib/test/test_ctypes/test_functions.py
+++ b/Lib/test/test_ctypes/test_functions.py
@@ -11,7 +11,6 @@ from ctypes import (CDLL, Structure, Array, CFUNCTYPE,
                     c_char, c_wchar, c_byte, c_char_p,
                     c_short, c_int, c_long, c_longlong,
                     c_float, c_double, c_longdouble)
-from test.test_ctypes import need_symbol
 import sys, unittest
 
 try:
@@ -75,8 +74,6 @@ class FunctionTestCase(unittest.TestCase):
                          "argument 1: TypeError: one character bytes, "
                          "bytearray or integer expected")
 
-
-    @need_symbol('c_wchar')
     def test_wchar_parm(self):
         f = dll._testfunc_i_bhilfd
         f.argtypes = [c_byte, c_wchar, c_int, c_long, c_float, c_double]
@@ -96,7 +93,6 @@ class FunctionTestCase(unittest.TestCase):
                          "argument 2: TypeError: one character unicode string "
                          "expected")
 
-    @need_symbol('c_wchar')
     def test_wchar_result(self):
         f = dll._testfunc_i_bhilfd
         f.argtypes = [c_byte, c_short, c_int, c_long, c_float, c_double]
@@ -162,7 +158,6 @@ class FunctionTestCase(unittest.TestCase):
         self.assertEqual(result, -21)
         self.assertEqual(type(result), float)
 
-    @need_symbol('c_longdouble')
     def test_longdoubleresult(self):
         f = dll._testfunc_D_bhilfD
         f.argtypes = [c_byte, c_short, c_int, c_long, c_float, c_longdouble]
@@ -175,7 +170,6 @@ class FunctionTestCase(unittest.TestCase):
         self.assertEqual(result, -21)
         self.assertEqual(type(result), float)
 
-    @need_symbol('c_longlong')
     def test_longlongresult(self):
         f = dll._testfunc_q_bhilfd
         f.restype = c_longlong
@@ -304,7 +298,6 @@ class FunctionTestCase(unittest.TestCase):
         result = f(-10, cb)
         self.assertEqual(result, -18)
 
-    @need_symbol('c_longlong')
     def test_longlong_callbacks(self):
 
         f = dll._testfunc_callback_q_qf

--- a/Lib/test/test_ctypes/test_memfunctions.py
+++ b/Lib/test/test_ctypes/test_memfunctions.py
@@ -6,7 +6,6 @@ from ctypes import (POINTER, sizeof, cast,
                     create_unicode_buffer, wstring_at,
                     memmove, memset,
                     c_char_p, c_byte, c_ubyte, c_wchar)
-from test.test_ctypes import need_symbol
 
 class MemFunctionsTest(unittest.TestCase):
     @unittest.skip('test disabled')
@@ -67,7 +66,6 @@ class MemFunctionsTest(unittest.TestCase):
         self.assertEqual(string_at(b"foo bar", 7), b"foo bar")
         self.assertEqual(string_at(b"foo bar", 3), b"foo")
 
-    @need_symbol('create_unicode_buffer')
     def test_wstring_at(self):
         p = create_unicode_buffer("Hello, World")
         a = create_unicode_buffer(1000000)

--- a/Lib/test/test_ctypes/test_parameters.py
+++ b/Lib/test/test_ctypes/test_parameters.py
@@ -1,5 +1,4 @@
 import unittest
-from test.test_ctypes import need_symbol
 import test.support
 
 class SimpleTypesTestCase(unittest.TestCase):
@@ -36,7 +35,6 @@ class SimpleTypesTestCase(unittest.TestCase):
         self.assertEqual(CVOIDP.from_param("abc"), "abcabc")
         self.assertEqual(CCHARP.from_param("abc"), "abcabcabcabc")
 
-    @need_symbol('c_wchar_p')
     def test_subclasses_c_wchar_p(self):
         from ctypes import c_wchar_p
 
@@ -66,7 +64,6 @@ class SimpleTypesTestCase(unittest.TestCase):
         a = c_char_p(b"123")
         self.assertIs(c_char_p.from_param(a), a)
 
-    @need_symbol('c_wchar_p')
     def test_cw_strings(self):
         from ctypes import c_wchar_p
 
@@ -86,7 +83,6 @@ class SimpleTypesTestCase(unittest.TestCase):
         self.assertEqual(str(cm.exception),
                          "one character bytes, bytearray or integer expected")
 
-    @need_symbol('c_wchar')
     def test_c_wchar(self):
         from ctypes import c_wchar
 

--- a/Lib/test/test_ctypes/test_prototypes.py
+++ b/Lib/test/test_ctypes/test_prototypes.py
@@ -2,7 +2,6 @@ from ctypes import (CDLL, CFUNCTYPE, POINTER, ArgumentError,
                     pointer, byref, sizeof, addressof,
                     c_void_p, c_char_p, c_wchar_p, c_char, c_wchar, c_buffer,
                     c_short, c_int, c_long, c_longlong, c_double)
-from test.test_ctypes import need_symbol
 import unittest
 
 # IMPORTANT INFO:
@@ -142,7 +141,6 @@ class CharPointersTestCase(unittest.TestCase):
         func(pointer(c_int()))
         func((c_int * 3)())
 
-    @need_symbol('c_wchar_p')
     def test_c_void_p_arg_with_c_wchar_p(self):
         func = testdll._testfunc_p_p
         func.restype = c_wchar_p
@@ -164,7 +162,6 @@ class CharPointersTestCase(unittest.TestCase):
         func.argtypes = None
         self.assertEqual(None, func(X()))
 
-@need_symbol('c_wchar')
 class WCharPointersTestCase(unittest.TestCase):
 
     def setUp(self):

--- a/Lib/test/test_ctypes/test_slicing.py
+++ b/Lib/test/test_ctypes/test_slicing.py
@@ -1,7 +1,6 @@
 import unittest
 from ctypes import (CDLL, POINTER, sizeof,
                     c_byte, c_short, c_int, c_long, c_char, c_wchar, c_char_p)
-from test.test_ctypes import need_symbol
 
 import _ctypes_test
 
@@ -127,7 +126,6 @@ class SlicesTestCase(unittest.TestCase):
         self.assertEqual(p[2:5:-3], s[2:5:-3])
 
 
-    @need_symbol('c_wchar')
     def test_wchar_ptr(self):
         s = "abcdefghijklmnopqrstuvwxyz\0"
 

--- a/Lib/test/test_ctypes/test_strings.py
+++ b/Lib/test/test_ctypes/test_strings.py
@@ -1,6 +1,5 @@
 import unittest
 from ctypes import c_buffer, sizeof, byref, c_char, c_wchar
-from test.test_ctypes import need_symbol
 
 class StringArrayTestCase(unittest.TestCase):
     def test(self):
@@ -61,7 +60,6 @@ class StringArrayTestCase(unittest.TestCase):
             del buf.raw
 
 
-@need_symbol('c_wchar')
 class WStringArrayTestCase(unittest.TestCase):
     def test(self):
         BUF = c_wchar * 4
@@ -86,7 +84,6 @@ class WStringArrayTestCase(unittest.TestCase):
         self.assertEqual(w.value, u)
 
 
-@need_symbol('c_wchar')
 class WStringTestCase(unittest.TestCase):
     def test_wchar(self):
         c_wchar("x")

--- a/Lib/test/test_ctypes/test_structures.py
+++ b/Lib/test/test_ctypes/test_structures.py
@@ -6,7 +6,6 @@ from ctypes import (CDLL, Structure, Union, POINTER, sizeof, byref, alignment,
                     c_uint8, c_uint16, c_uint32,
                     c_short, c_ushort, c_int, c_uint,
                     c_long, c_ulong, c_longlong, c_ulonglong, c_float, c_double)
-from test.test_ctypes import need_symbol
 from struct import calcsize
 import _ctypes_test
 from test import support
@@ -307,7 +306,6 @@ class StructureTestCase(unittest.TestCase):
         self.assertEqual(p.phone.number, b"5678")
         self.assertEqual(p.age, 5)
 
-    @need_symbol('c_wchar')
     def test_structures_with_wchar(self):
         class PersonW(Structure):
             _fields_ = [("name", c_wchar * 12),

--- a/Lib/test/test_ctypes/test_unicode.py
+++ b/Lib/test/test_ctypes/test_unicode.py
@@ -1,10 +1,8 @@
 import unittest
 import ctypes
-from test.test_ctypes import need_symbol
 
 import _ctypes_test
 
-@need_symbol('c_wchar')
 class UnicodeTestCase(unittest.TestCase):
     def test_wcslen(self):
         dll = ctypes.CDLL(_ctypes_test.__file__)


### PR DESCRIPTION
Remove the @need_symbol('...') decorator of test.test_ctypes since requested symbols are now always always available in ctypes.

Use directly the @unittest.skipUnless() decorator for the two types only available on Windows:

* ctypes.WINFUNCTYPE
* ctypes.oledll

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-105751 -->
* Issue: gh-105751
<!-- /gh-issue-number -->
