### PR TITLE
gh-105751: Reenable disable test_ctypes tests

### DIFF
--- a/Lib/test/test_ctypes/test_memfunctions.py
+++ b/Lib/test/test_ctypes/test_memfunctions.py
@@ -9,16 +9,15 @@ from ctypes import (POINTER, sizeof, cast,
 
 
 class MemFunctionsTest(unittest.TestCase):
-    @unittest.skip('test disabled')
     def test_overflow(self):
         # string_at and wstring_at must use the Python calling
         # convention (which acquires the GIL and checks the Python
         # error flag).  Provoke an error and catch it; see also issue
-        # #3554: <http://bugs.python.org/issue3554>
+        # gh-47804.
         self.assertRaises((OverflowError, MemoryError, SystemError),
-                          lambda: wstring_at(u"foo", sys.maxint - 1))
+                          lambda: wstring_at(u"foo", sys.maxsize - 1))
         self.assertRaises((OverflowError, MemoryError, SystemError),
-                          lambda: string_at("foo", sys.maxint - 1))
+                          lambda: string_at("foo", sys.maxsize - 1))
 
     def test_memmove(self):
         # large buffers apparently increase the chance that the memory

--- a/Lib/test/test_ctypes/test_strings.py
+++ b/Lib/test/test_ctypes/test_strings.py
@@ -1,5 +1,6 @@
 import unittest
-from ctypes import create_string_buffer, sizeof, byref, c_char, c_wchar
+from ctypes import (create_string_buffer, create_unicode_buffer,
+                    sizeof, byref, c_char, c_wchar)
 
 
 class StringArrayTestCase(unittest.TestCase):
@@ -91,41 +92,35 @@ class WStringTestCase(unittest.TestCase):
         repr(byref(c_wchar("x")))
         c_wchar("x")
 
-    @unittest.skip('test disabled')
     def test_basic_wstrings(self):
-        cs = c_wstring("abcdef")
-
-        # XXX This behaviour is about to change:
-        # len returns the size of the internal buffer in bytes.
-        # This includes the terminating NUL character.
-        self.assertEqual(sizeof(cs), 14)
-
-        # The value property is the string up to the first terminating NUL.
+        cs = create_unicode_buffer("abcdef")
         self.assertEqual(cs.value, "abcdef")
-        self.assertEqual(c_wstring("abc\000def").value, "abc")
 
-        self.assertEqual(c_wstring("abc\000def").value, "abc")
+        # value can be changed
+        cs.value = "abc"
+        self.assertEqual(cs.value, "abc")
 
-        # The raw property is the total buffer contents:
-        self.assertEqual(cs.raw, "abcdef\000")
-        self.assertEqual(c_wstring("abc\000def").raw, "abc\000def\000")
+        # string is truncated at NUL character
+        cs.value = "def\0z"
+        self.assertEqual(cs.value, "def")
 
-        # We can change the value:
-        cs.value = "ab"
-        self.assertEqual(cs.value, "ab")
-        self.assertEqual(cs.raw, "ab\000\000\000\000\000")
+        self.assertEqual(create_unicode_buffer("abc\0def").value, "abc")
 
-        self.assertRaises(TypeError, c_wstring, "123")
-        self.assertRaises(ValueError, c_wstring, 0)
+        # created with an empty string
+        cs = create_unicode_buffer(3)
+        self.assertEqual(cs.value, "")
 
-    @unittest.skip('test disabled')
+        cs.value = "abc"
+        self.assertEqual(cs.value, "abc")
+
     def test_toolong(self):
-        cs = c_wstring("abcdef")
-        # Much too long string:
-        self.assertRaises(ValueError, setattr, cs, "value", "123456789012345")
+        cs = create_unicode_buffer("abc")
+        with self.assertRaises(ValueError):
+            cs.value = "abcdef"
 
-        # One char too long values:
-        self.assertRaises(ValueError, setattr, cs, "value", "1234567")
+        cs = create_unicode_buffer(4)
+        with self.assertRaises(ValueError):
+            cs.value = "abcdef"
 
 
 def run_test(rep, msg, func, arg):


### PR DESCRIPTION
Reenable 3 tests:

* test_overflow()
* test_basic_wstrings()
* test_toolong()

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-105751 -->
* Issue: gh-105751
<!-- /gh-issue-number -->
