### PR TITLE
Fix the TypeError of roj() in xxlimited_35 and xxmodule.

### DIFF
--- a/Modules/xxlimited_35.c
+++ b/Modules/xxlimited_35.c
@@ -170,8 +170,8 @@ static PyObject *
 xx_roj(PyObject *self, PyObject *args)
 {
     PyObject *a;
-    long b;
-    if (!PyArg_ParseTuple(args, "O#:roj", &a, &b))
+    PyObject *b;
+    if (!PyArg_ParseTuple(args, "OO:roj", &a, &b))
         return NULL;
     return Py_NewRef(Py_None);
 }
@@ -221,7 +221,7 @@ static PyType_Spec Null_Type_spec = {
 
 static PyMethodDef xx_methods[] = {
     {"roj",             xx_roj,         METH_VARARGS,
-        PyDoc_STR("roj(a,b) -> None")},
+        PyDoc_STR("roj(a, b) -> None")},
     {"foo",             xx_foo,         METH_VARARGS,
         xx_foo_doc},
     {"new",             xx_new,         METH_VARARGS,

--- a/Modules/xxmodule.c
+++ b/Modules/xxmodule.c
@@ -202,8 +202,8 @@ static PyObject *
 xx_roj(PyObject *self, PyObject *args)
 {
     PyObject *a;
-    long b;
-    if (!PyArg_ParseTuple(args, "O#:roj", &a, &b))
+    PyObject *b;
+    if (!PyArg_ParseTuple(args, "OO:roj", &a, &b))
         return NULL;
     return Py_NewRef(Py_None);
 }
@@ -319,7 +319,7 @@ static PyTypeObject Null_Type = {
 
 static PyMethodDef xx_methods[] = {
     {"roj",             xx_roj,         METH_VARARGS,
-        PyDoc_STR("roj(a,b) -> None")},
+        PyDoc_STR("roj(a, b) -> None")},
     {"foo",             xx_foo,         METH_VARARGS,
         xx_foo_doc},
     {"new",             xx_new,         METH_VARARGS,


### PR DESCRIPTION
```python
import xxlimited_35 as xx
# Raise the TypeError: roj() takes exactly 1 argument (2 given)
xx.roj(1, 2)
# Raise the SystemError: bad format string: O#:roj
o = object()
xx.roj(o)
```
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:


```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
