### PR TITLE
gh-105751, test_ctypes: Remove disabled tests

### DIFF
--- a/Lib/test/test_ctypes/test_byteswap.py
+++ b/Lib/test/test_ctypes/test_byteswap.py
@@ -25,14 +25,6 @@ def bin(s):
 # For Structures and Unions, these types are created on demand.
 
 class Test(unittest.TestCase):
-    @unittest.skip('test disabled')
-    def test_X(self):
-        print(sys.byteorder, file=sys.stderr)
-        for i in range(32):
-            bits = BITS()
-            setattr(bits, "i%s" % i, 1)
-            dump(bits)
-
     def test_slots(self):
         class BigPoint(BigEndianStructure):
             __slots__ = ()

--- a/Lib/test/test_ctypes/test_callbacks.py
+++ b/Lib/test/test_ctypes/test_callbacks.py
@@ -8,7 +8,7 @@ import unittest
 from _ctypes import CTYPES_MAX_ARGCOUNT
 from ctypes import (CDLL, cdll, Structure, CFUNCTYPE,
                     ArgumentError, POINTER, sizeof,
-                    c_byte, c_ubyte, c_char, c_char_p,
+                    c_byte, c_ubyte, c_char,
                     c_short, c_ushort, c_int, c_uint,
                     c_long, c_longlong, c_ulonglong, c_ulong,
                     c_float, c_double, c_longdouble, py_object)
@@ -91,14 +91,6 @@ class Callbacks(unittest.TestCase):
     def test_char(self):
         self.check_type(c_char, b"x")
         self.check_type(c_char, b"a")
-
-    # disabled: would now (correctly) raise a RuntimeWarning about
-    # a memory leak.  A callback function cannot return a non-integral
-    # C type without causing a memory leak.
-    @unittest.skip('test disabled')
-    def test_char_p(self):
-        self.check_type(c_char_p, "abc")
-        self.check_type(c_char_p, "def")
 
     def test_pyobject(self):
         o = ()

--- a/Lib/test/test_ctypes/test_keeprefs.py
+++ b/Lib/test/test_ctypes/test_keeprefs.py
@@ -1,5 +1,3 @@
-import gc
-import sys
 import unittest
 from ctypes import (Structure, POINTER, pointer,  _pointer_type_cache,
                     c_char_p, c_int)
@@ -99,32 +97,6 @@ class PointerTestCase(unittest.TestCase):
         i = c_int(42)
         x = pointer(i)
         self.assertEqual(x._objects, {'1': i})
-
-
-class DeletePointerTestCase(unittest.TestCase):
-    @unittest.skip('test disabled')
-    def test_X(self):
-        class X(Structure):
-            _fields_ = [("p", POINTER(c_char_p))]
-        x = X()
-        i = c_char_p("abc def")
-        print("2?", sys.getrefcount(i))
-        x.p = pointer(i)
-        print("3?", sys.getrefcount(i))
-        for i in range(320):
-            c_int(99)
-            x.p[0]
-        print(x.p[0])
-        gc.collect()
-        for i in range(320):
-            c_int(99)
-            x.p[0]
-        print(x.p[0])
-        print(x.p.contents)
-
-        x.p[0] = "spam spam"
-        print("+" * 42)
-        print(x._objects)
 
 
 class PointerToStructure(unittest.TestCase):

--- a/Lib/test/test_ctypes/test_numbers.py
+++ b/Lib/test/test_ctypes/test_numbers.py
@@ -3,7 +3,7 @@ import struct
 import sys
 import unittest
 from operator import truth
-from ctypes import (byref, sizeof, alignment, _SimpleCData,
+from ctypes import (byref, sizeof, alignment,
                     c_char, c_byte, c_ubyte, c_short, c_ushort, c_int, c_uint,
                     c_long, c_ulong, c_longlong, c_ulonglong,
                     c_float, c_double, c_longdouble, c_bool)
@@ -69,14 +69,6 @@ class NumberTestCase(unittest.TestCase):
         for t in signed_types + unsigned_types + float_types:
             self.assertRaises(TypeError, t, "")
             self.assertRaises(TypeError, t, None)
-
-    @unittest.skip('test disabled')
-    def test_valid_ranges(self):
-        # invalid values of the correct type
-        # raise ValueError (not OverflowError)
-        for t, (l, h) in zip(unsigned_types, unsigned_ranges):
-            self.assertRaises(ValueError, t, l-1)
-            self.assertRaises(ValueError, t, h+1)
 
     def test_from_param(self):
         # the from_param class method attribute always
@@ -188,17 +180,6 @@ class NumberTestCase(unittest.TestCase):
         a[0] = ord('?')
         self.assertEqual(v.value, b'?')
 
-    # array does not support c_bool / 't'
-    @unittest.skip('test disabled')
-    def test_bool_from_address(self):
-        a = array.array(c_bool._type_, [True])
-        v = t.from_address(a.buffer_info()[0])
-        self.assertEqual(v.value, a[0])
-        self.assertEqual(type(v) is t)
-        a[0] = False
-        self.assertEqual(v.value, a[0])
-        self.assertEqual(type(v) is t)
-
     def test_init(self):
         # c_int() can be initialized from Python's int, and c_int.
         # Not from c_long or so, which seems strange, abc should
@@ -214,63 +195,6 @@ class NumberTestCase(unittest.TestCase):
             if (hasattr(t, "__ctype_le__")):
                 self.assertRaises(OverflowError, t.__ctype_le__, big_int)
 
-    @unittest.skip('test disabled')
-    def test_perf(self):
-        check_perf()
-
-
-class c_int_S(_SimpleCData):
-    _type_ = "i"
-    __slots__ = []
-
-
-def run_test(rep, msg, func, arg=None):
-    items = range(rep)
-    from time import perf_counter as clock
-    if arg is not None:
-        start = clock()
-        for i in items:
-            func(arg); func(arg); func(arg); func(arg); func(arg)
-        stop = clock()
-    else:
-        start = clock()
-        for i in items:
-            func(); func(); func(); func(); func()
-        stop = clock()
-    print("%15s: %.2f us" % (msg, ((stop-start)*1e6/5/rep)))
-
-
-def check_perf():
-    # Construct 5 objects
-
-    REP = 200000
-
-    run_test(REP, "int()", int)
-    run_test(REP, "int(999)", int)
-    run_test(REP, "c_int()", c_int)
-    run_test(REP, "c_int(999)", c_int)
-    run_test(REP, "c_int_S()", c_int_S)
-    run_test(REP, "c_int_S(999)", c_int_S)
-
-# Python 2.3 -OO, win2k, P4 700 MHz:
-#
-#          int(): 0.87 us
-#       int(999): 0.87 us
-#        c_int(): 3.35 us
-#     c_int(999): 3.34 us
-#      c_int_S(): 3.23 us
-#   c_int_S(999): 3.24 us
-
-# Python 2.2 -OO, win2k, P4 700 MHz:
-#
-#          int(): 0.89 us
-#       int(999): 0.89 us
-#        c_int(): 9.99 us
-#     c_int(999): 10.02 us
-#      c_int_S(): 9.87 us
-#   c_int_S(999): 9.85 us
-
 
 if __name__ == '__main__':
-##    check_perf()
     unittest.main()

--- a/Lib/test/test_ctypes/test_structures.py
+++ b/Lib/test/test_ctypes/test_structures.py
@@ -357,15 +357,6 @@ class StructureTestCase(unittest.TestCase):
         except Exception as detail:
             return detail.__class__, str(detail)
 
-    @unittest.skip('test disabled')
-    def test_subclass_creation(self):
-        meta = type(Structure)
-        # same as 'class X(Structure): pass'
-        # fails, since we need either a _fields_ or a _abstract_ attribute
-        cls, msg = self.get_except(meta, "X", (Structure,), {})
-        self.assertEqual((cls, msg),
-                (AttributeError, "class must define a '_fields_' attribute"))
-
     def test_abstract_class(self):
         class X(Structure):
             _abstract_ = "something"


### PR DESCRIPTION
* The following tests were disabled since the initial ctypes commit in 2006, commit babddfca758abe34ff12023f63b18d745fae7ca9:

  * Callbacks.test_char_p()
  * DeletePointerTestCase.test_X()
  * NumberTestCase.test_perf()
  * StructureTestCase.test_subclass_creation()
  * Tests.test_X() of test_byteswap

* NumberTestCase.test_bool_from_address() was disabled in 2007 by commit 5dc4fe09b7648f9801558e766b21a3d3b2dcad3b.
* Remove check_perf() and run_test() of test_numbers.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-105751 -->
* Issue: gh-105751
<!-- /gh-issue-number -->
