### PR TITLE
gh-105834: Add tests for calling `issubclass()` between two protocols

### DIFF
--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -2807,6 +2807,32 @@ class ProtocolTests(BaseTestCase):
         self.assertNotIsSubclass(EmptyProtocol, CallableMembersProto)
         self.assertNotIsSubclass(UnrelatedProtocol, CallableMembersProto)
 
+        # These aren't protocols at all (despite having annotations),
+        # so they should only be considered subclasses of CallableMembersProto
+        # if they *actually have an attribute* matching the `meth` member
+        # (just having an annotation is insufficient)
+
+        class AnnotatedButNotAProtocol:
+            meth: Callable[[], None]
+
+        class NotAProtocolButAnImplicitSubclass:
+            def meth(self): pass
+
+        class NotAProtocolButAnImplicitSubclass2:
+            meth: Callable[[], None]
+            def meth(self): pass
+
+        class NotAProtocolButAnImplicitSubclass3:
+            meth: Callable[[], None]
+            meth2: Callable[[int, str], bool]
+            def meth(self): pass
+            def meth(self, x, y): return True
+
+        self.assertNotIsSubclass(AnnotatedButNotAProtocol, CallableMembersProto)
+        self.assertIsSubclass(NotAProtocolButAnImplicitSubclass, CallableMembersProto)
+        self.assertIsSubclass(NotAProtocolButAnImplicitSubclass2, CallableMembersProto)
+        self.assertIsSubclass(NotAProtocolButAnImplicitSubclass3, CallableMembersProto)
+
     def test_isinstance_checks_not_at_whim_of_gc(self):
         self.addCleanup(gc.enable)
         gc.disable()

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -1925,6 +1925,13 @@ class Protocol(Generic, metaclass=_ProtocolMeta):
                         if base.__dict__[attr] is None:
                             return NotImplemented
                         break
+
+                    # ...or in annotations, if it is a sub-protocol.
+                    annotations = getattr(base, '__annotations__', {})
+                    if (isinstance(annotations, collections.abc.Mapping) and
+                            attr in annotations and
+                            issubclass(other, Generic) and getattr(other, '_is_protocol', False)):
+                        break
                 else:
                     return NotImplemented
             return True

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -1925,13 +1925,6 @@ class Protocol(Generic, metaclass=_ProtocolMeta):
                         if base.__dict__[attr] is None:
                             return NotImplemented
                         break
-
-                    # ...or in annotations, if it is a sub-protocol.
-                    annotations = getattr(base, '__annotations__', {})
-                    if (isinstance(annotations, collections.abc.Mapping) and
-                            attr in annotations and
-                            issubclass(other, Generic) and getattr(other, '_is_protocol', False)):
-                        break
                 else:
                     return NotImplemented
             return True


### PR DESCRIPTION
<!-- gh-issue-number: gh-105834 -->
* Issue: gh-105834
<!-- /gh-issue-number -->
