### PR TITLE
[3.11] bpo-44530: Document the change in MAKE_FUNCTION behavior (GH-93189)

### DIFF
--- a/Doc/library/dis.rst
+++ b/Doc/library/dis.rst
@@ -1260,11 +1260,14 @@ iterations of the loop.
    * ``0x02`` a dictionary of keyword-only parameters' default values
    * ``0x04`` a tuple of strings containing parameters' annotations
    * ``0x08`` a tuple containing cells for free variables, making a closure
-   * the code associated with the function (at TOS1)
-   * the :term:`qualified name` of the function (at TOS)
+   * the code associated with the function (at TOS)
 
    .. versionchanged:: 3.10
       Flag value ``0x04`` is a tuple of strings instead of dictionary
+
+   .. versionchanged:: 3.11
+      Qualified name at TOS was removed.
+
 
 .. opcode:: BUILD_SLICE (argc)
 


### PR DESCRIPTION
* bpo-44530: Document the change in MAKE_FUNCTION behavior

Fixes dis module documentation for MAKE_FUNCTION due to https://github.com/python/cpython/commit/2f180ce2cb6e6a7e3c517495e0f4873d6aaf5f2f (bpo-44530, released as part of 3.11) removes the qualified name at TOS. (cherry picked from commit 486b52a3158e0f64fc54efdfa34ed5437b3619f2)


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--105842.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->