### PR TITLE
GH-105840: Fix assertion failures when specializing calls with too many `__defaults__`

### DIFF
--- a/Lib/test/test_opcache.py
+++ b/Lib/test/test_opcache.py
@@ -452,6 +452,35 @@ class TestLoadMethodCache(unittest.TestCase):
             self.assertFalse(f())
 
 
+class TestCallCache(unittest.TestCase):
+    def test_too_many_defaults_0(self):
+        def f():
+            pass
+
+        f.__defaults__ = (None,)
+        for _ in range(1025):
+            f()
+
+    def test_too_many_defaults_1(self):
+        def f(x):
+            pass
+
+        f.__defaults__ = (None, None)
+        for _ in range(1025):
+            f(None)
+            f()
+
+    def test_too_many_defaults_2(self):
+        def f(x, y):
+            pass
+
+        f.__defaults__ = (None, None, None)
+        for _ in range(1025):
+            f(None, None)
+            f(None)
+            f()
+
+
 if __name__ == "__main__":
     import unittest
     unittest.main()

--- a/Misc/NEWS.d/next/Core and Builtins/2023-06-15-22-11-43.gh-issue-105840.Fum_g_.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2023-06-15-22-11-43.gh-issue-105840.Fum_g_.rst
@@ -1,0 +1,2 @@
+Fix possible crashes when specializing function calls with too many
+``__defaults__``.

--- a/Python/specialize.c
+++ b/Python/specialize.c
@@ -1647,9 +1647,9 @@ specialize_py_call(PyFunctionObject *func, _Py_CODEUNIT *instr, int nargs,
     }
     int argcount = code->co_argcount;
     int defcount = func->func_defaults == NULL ? 0 : (int)PyTuple_GET_SIZE(func->func_defaults);
-    assert(defcount <= argcount);
     int min_args = argcount-defcount;
-    if (nargs > argcount || nargs < min_args) {
+    // GH-105840: min_args is negative when somebody sets too many __defaults__!
+    if (min_args < 0 || nargs > argcount || nargs < min_args) {
         SPECIALIZATION_FAIL(CALL, SPEC_FAIL_WRONG_NUMBER_ARGUMENTS);
         return -1;
     }


### PR DESCRIPTION


<!-- gh-issue-number: gh-105840 -->
* Issue: gh-105840
<!-- /gh-issue-number -->
