### PR TITLE
[3.9] CI: Bump macOS build to use OpenSSL v3.0 (GH-105538)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -160,7 +160,8 @@ jobs:
         CC=clang \
         CPPFLAGS="-I$(brew --prefix gdbm)/include -I$(brew --prefix xz)/include" \
         LDFLAGS="-L$(brew --prefix gdbm)/lib -L$(brew --prefix xz)/lib" \
-        ./configure --with-pydebug \
+        ./configure --prefix=/opt/python-dev \
+            --with-pydebug \
             --with-openssl="$(brew --prefix openssl@3.0)" \
             --with-tcltk-libs="$(pkg-config --libs tk)" \
             --with-tcltk-includes="$(pkg-config --cflags tk)"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -157,6 +157,7 @@ jobs:
       run: brew install pkg-config openssl@3.0 xz gdbm tcl-tk
     - name: Configure CPython
       run: |
+        CC=clang \
         CPPFLAGS="-I$(brew --prefix gdbm)/include -I$(brew --prefix xz)/include" \
         LDFLAGS="-L$(brew --prefix gdbm)/lib -L$(brew --prefix xz)/lib" \
         ./configure --with-pydebug \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -153,15 +153,14 @@ jobs:
       PYTHONSTRICTEXTENSIONBUILD: 1
     steps:
     - uses: actions/checkout@v3
+    - name: Install Homebrew dependencies
+      run: brew install pkg-config openssl@3.0 xz gdbm tcl-tk
     - name: Configure CPython
       run: |
-        brew install pkg-config openssl@1.1 xz gdbm tcl-tk
-        CC=clang \
         CPPFLAGS="-I$(brew --prefix gdbm)/include -I$(brew --prefix xz)/include" \
         LDFLAGS="-L$(brew --prefix gdbm)/lib -L$(brew --prefix xz)/lib" \
-        ./configure --prefix=/opt/python-dev \
-            --with-pydebug \
-            --with-openssl="$(brew --prefix openssl@1.1)" \
+        ./configure --with-pydebug \
+            --with-openssl="$(brew --prefix openssl@3.0)" \
             --with-tcltk-libs="$(pkg-config --libs tk)" \
             --with-tcltk-includes="$(pkg-config --cflags tk)"
     - name: Build CPython


### PR DESCRIPTION
(cherry picked from commit 34e93d3998bab8acd651c50724eb1977f4860a08)

Co-authored-by: Erlend E. Aasland <erlend.aasland@protonmail.com>
