### PR TITLE
gh-105875: Require SQLite 3.15.2 or newer

### DIFF
--- a/Doc/library/sqlite3.rst
+++ b/Doc/library/sqlite3.rst
@@ -29,7 +29,7 @@ PostgreSQL or Oracle.
 
 The :mod:`!sqlite3` module was written by Gerhard Häring.  It provides an SQL interface
 compliant with the DB-API 2.0 specification described by :pep:`249`, and
-requires SQLite 3.7.15 or newer.
+requires SQLite 3.15.2 or newer.
 
 This document includes four main sections:
 
@@ -733,9 +733,6 @@ Connection objects
           If ``True``, the created SQL function is marked as
           `deterministic <https://sqlite.org/deterministic.html>`_,
           which allows SQLite to perform additional optimizations.
-
-      :raises NotSupportedError:
-          If *deterministic* is used with SQLite versions older than 3.8.3.
 
       .. versionadded:: 3.8
          The *deterministic* parameter.

--- a/Doc/whatsnew/3.13.rst
+++ b/Doc/whatsnew/3.13.rst
@@ -410,6 +410,9 @@ Build Changes
   :file:`!configure`.
   (Contributed by Christian Heimes in :gh:`89886`.)
 
+* SQLite 3.15.2 or newer is required to build the :mod:`sqlite3` extension module.
+  (Contributed by Erlend Aasland in :gh:`105875`.)
+
 
 C API Changes
 =============

--- a/Lib/test/test_sqlite3/test_backup.py
+++ b/Lib/test/test_sqlite3/test_backup.py
@@ -50,8 +50,6 @@ class BackupTests(unittest.TestCase):
         bck.executemany('INSERT INTO bar (key) VALUES (?)', [(3,), (4,)])
         with self.assertRaises(sqlite.OperationalError) as cm:
             self.cx.backup(bck)
-        if sqlite.sqlite_version_info < (3, 8, 8):
-            self.assertEqual(str(cm.exception), 'target is in transaction')
 
     def test_keyword_only_args(self):
         with self.assertRaises(TypeError):

--- a/Lib/test/test_sqlite3/test_dbapi.py
+++ b/Lib/test/test_sqlite3/test_dbapi.py
@@ -165,6 +165,7 @@ class ModuleTests(unittest.TestCase):
             "SQLITE_INTERNAL",
             "SQLITE_INTERRUPT",
             "SQLITE_IOERR",
+            "SQLITE_LIMIT_WORKER_THREADS",
             "SQLITE_LOCKED",
             "SQLITE_MISMATCH",
             "SQLITE_MISUSE",
@@ -172,6 +173,7 @@ class ModuleTests(unittest.TestCase):
             "SQLITE_NOMEM",
             "SQLITE_NOTADB",
             "SQLITE_NOTFOUND",
+            "SQLITE_NOTICE",
             "SQLITE_OK",
             "SQLITE_PERM",
             "SQLITE_PRAGMA",
@@ -179,6 +181,7 @@ class ModuleTests(unittest.TestCase):
             "SQLITE_RANGE",
             "SQLITE_READ",
             "SQLITE_READONLY",
+            "SQLITE_RECURSIVE",
             "SQLITE_REINDEX",
             "SQLITE_ROW",
             "SQLITE_SAVEPOINT",
@@ -187,6 +190,7 @@ class ModuleTests(unittest.TestCase):
             "SQLITE_TOOBIG",
             "SQLITE_TRANSACTION",
             "SQLITE_UPDATE",
+            "SQLITE_WARNING",
             # Run-time limit categories
             "SQLITE_LIMIT_LENGTH",
             "SQLITE_LIMIT_SQL_LENGTH",
@@ -200,32 +204,43 @@ class ModuleTests(unittest.TestCase):
             "SQLITE_LIMIT_VARIABLE_NUMBER",
             "SQLITE_LIMIT_TRIGGER_DEPTH",
         ]
-        if sqlite.sqlite_version_info >= (3, 7, 17):
-            consts += ["SQLITE_NOTICE", "SQLITE_WARNING"]
-        if sqlite.sqlite_version_info >= (3, 8, 3):
-            consts.append("SQLITE_RECURSIVE")
-        if sqlite.sqlite_version_info >= (3, 8, 7):
-            consts.append("SQLITE_LIMIT_WORKER_THREADS")
         consts += ["PARSE_DECLTYPES", "PARSE_COLNAMES"]
         # Extended result codes
         consts += [
             "SQLITE_ABORT_ROLLBACK",
+            "SQLITE_AUTH_USER",
             "SQLITE_BUSY_RECOVERY",
+            "SQLITE_BUSY_SNAPSHOT",
+            "SQLITE_CANTOPEN_CONVPATH",
             "SQLITE_CANTOPEN_FULLPATH",
             "SQLITE_CANTOPEN_ISDIR",
             "SQLITE_CANTOPEN_NOTEMPDIR",
+            "SQLITE_CONSTRAINT_CHECK",
+            "SQLITE_CONSTRAINT_COMMITHOOK",
+            "SQLITE_CONSTRAINT_FOREIGNKEY",
+            "SQLITE_CONSTRAINT_FUNCTION",
+            "SQLITE_CONSTRAINT_NOTNULL",
+            "SQLITE_CONSTRAINT_PRIMARYKEY",
+            "SQLITE_CONSTRAINT_ROWID",
+            "SQLITE_CONSTRAINT_TRIGGER",
+            "SQLITE_CONSTRAINT_UNIQUE",
+            "SQLITE_CONSTRAINT_VTAB",
             "SQLITE_CORRUPT_VTAB",
             "SQLITE_IOERR_ACCESS",
+            "SQLITE_IOERR_AUTH",
             "SQLITE_IOERR_BLOCKED",
             "SQLITE_IOERR_CHECKRESERVEDLOCK",
             "SQLITE_IOERR_CLOSE",
+            "SQLITE_IOERR_CONVPATH",
             "SQLITE_IOERR_DELETE",
             "SQLITE_IOERR_DELETE_NOENT",
             "SQLITE_IOERR_DIR_CLOSE",
             "SQLITE_IOERR_DIR_FSYNC",
             "SQLITE_IOERR_FSTAT",
             "SQLITE_IOERR_FSYNC",
+            "SQLITE_IOERR_GETTEMPPATH",
             "SQLITE_IOERR_LOCK",
+            "SQLITE_IOERR_MMAP",
             "SQLITE_IOERR_NOMEM",
             "SQLITE_IOERR_RDLOCK",
             "SQLITE_IOERR_READ",
@@ -237,50 +252,18 @@ class ModuleTests(unittest.TestCase):
             "SQLITE_IOERR_SHORT_READ",
             "SQLITE_IOERR_TRUNCATE",
             "SQLITE_IOERR_UNLOCK",
+            "SQLITE_IOERR_VNODE",
             "SQLITE_IOERR_WRITE",
             "SQLITE_LOCKED_SHAREDCACHE",
+            "SQLITE_NOTICE_RECOVER_ROLLBACK",
+            "SQLITE_NOTICE_RECOVER_WAL",
+            "SQLITE_OK_LOAD_PERMANENTLY",
             "SQLITE_READONLY_CANTLOCK",
+            "SQLITE_READONLY_DBMOVED",
             "SQLITE_READONLY_RECOVERY",
+            "SQLITE_READONLY_ROLLBACK",
+            "SQLITE_WARNING_AUTOINDEX",
         ]
-        if sqlite.sqlite_version_info >= (3, 7, 16):
-            consts += [
-                "SQLITE_CONSTRAINT_CHECK",
-                "SQLITE_CONSTRAINT_COMMITHOOK",
-                "SQLITE_CONSTRAINT_FOREIGNKEY",
-                "SQLITE_CONSTRAINT_FUNCTION",
-                "SQLITE_CONSTRAINT_NOTNULL",
-                "SQLITE_CONSTRAINT_PRIMARYKEY",
-                "SQLITE_CONSTRAINT_TRIGGER",
-                "SQLITE_CONSTRAINT_UNIQUE",
-                "SQLITE_CONSTRAINT_VTAB",
-                "SQLITE_READONLY_ROLLBACK",
-            ]
-        if sqlite.sqlite_version_info >= (3, 7, 17):
-            consts += [
-                "SQLITE_IOERR_MMAP",
-                "SQLITE_NOTICE_RECOVER_ROLLBACK",
-                "SQLITE_NOTICE_RECOVER_WAL",
-            ]
-        if sqlite.sqlite_version_info >= (3, 8, 0):
-            consts += [
-                "SQLITE_BUSY_SNAPSHOT",
-                "SQLITE_IOERR_GETTEMPPATH",
-                "SQLITE_WARNING_AUTOINDEX",
-            ]
-        if sqlite.sqlite_version_info >= (3, 8, 1):
-            consts += ["SQLITE_CANTOPEN_CONVPATH", "SQLITE_IOERR_CONVPATH"]
-        if sqlite.sqlite_version_info >= (3, 8, 2):
-            consts.append("SQLITE_CONSTRAINT_ROWID")
-        if sqlite.sqlite_version_info >= (3, 8, 3):
-            consts.append("SQLITE_READONLY_DBMOVED")
-        if sqlite.sqlite_version_info >= (3, 8, 7):
-            consts.append("SQLITE_AUTH_USER")
-        if sqlite.sqlite_version_info >= (3, 9, 0):
-            consts.append("SQLITE_IOERR_VNODE")
-        if sqlite.sqlite_version_info >= (3, 10, 0):
-            consts.append("SQLITE_IOERR_AUTH")
-        if sqlite.sqlite_version_info >= (3, 14, 1):
-            consts.append("SQLITE_OK_LOAD_PERMANENTLY")
         if sqlite.sqlite_version_info >= (3, 21, 0):
             consts += [
                 "SQLITE_IOERR_BEGIN_ATOMIC",
@@ -330,8 +313,6 @@ class ModuleTests(unittest.TestCase):
             self.assertEqual(e.sqlite_errorcode, err_code)
             self.assertTrue(e.sqlite_errorname.startswith("SQLITE_CANTOPEN"))
 
-    @unittest.skipIf(sqlite.sqlite_version_info <= (3, 7, 16),
-                     "Requires SQLite 3.7.16 or newer")
     def test_extended_error_code_on_exception(self):
         with memory_database() as con:
             with con:

--- a/Lib/test/test_sqlite3/test_hooks.py
+++ b/Lib/test/test_sqlite3/test_hooks.py
@@ -323,7 +323,7 @@ class TraceCallbackTests(unittest.TestCase):
     )
     def test_trace_too_much_expanded_sql(self):
         # If the expanded string is too large, we'll fall back to the
-        # unexpanded SQL statement (for SQLite 3.14.0 and newer).
+        # unexpanded SQL statement.
         # The resulting string length is limited by the runtime limit
         # SQLITE_LIMIT_LENGTH.
         template = "select 1 as a where a="
@@ -334,8 +334,6 @@ class TraceCallbackTests(unittest.TestCase):
 
             unexpanded_query = template + "?"
             expected = [unexpanded_query]
-            if sqlite.sqlite_version_info < (3, 14, 0):
-                expected = []
             with self.check_stmt_trace(cx, expected):
                 cx.execute(unexpanded_query, (bad_param,))
 

--- a/Lib/test/test_sqlite3/test_types.py
+++ b/Lib/test/test_sqlite3/test_types.py
@@ -371,7 +371,6 @@ class ColNamesTests(unittest.TestCase):
         self.assertIsNone(self.cur.description)
 
 
-@unittest.skipIf(sqlite.sqlite_version_info < (3, 8, 3), "CTEs not supported")
 class CommonTableExpressionTests(unittest.TestCase):
 
     def setUp(self):

--- a/Misc/NEWS.d/next/Build/2023-06-16-23-40-49.gh-issue-105875.naj8v5.rst
+++ b/Misc/NEWS.d/next/Build/2023-06-16-23-40-49.gh-issue-105875.naj8v5.rst
@@ -1,0 +1,2 @@
+SQLite 3.15.2 or newer is required to build the :mod:`sqlite3` extension
+module. Patch by Erlend Aasland.

--- a/Modules/_sqlite/blob.c
+++ b/Modules/_sqlite/blob.c
@@ -108,14 +108,6 @@ static void
 blob_seterror(pysqlite_Blob *self, int rc)
 {
     assert(self->connection != NULL);
-#if SQLITE_VERSION_NUMBER < 3008008
-    // SQLite pre 3.8.8 does not set this blob error on the connection
-    if (rc == SQLITE_ABORT) {
-        PyErr_SetString(self->connection->OperationalError,
-                        "Cannot operate on an expired blob handle");
-        return;
-    }
-#endif
     _pysqlite_seterror(self->connection->state, self->connection->db);
 }
 

--- a/Modules/_sqlite/module.c
+++ b/Modules/_sqlite/module.c
@@ -29,8 +29,8 @@
 #include "row.h"
 #include "blob.h"
 
-#if SQLITE_VERSION_NUMBER < 3007015
-#error "SQLite 3.7.15 or higher required"
+#if SQLITE_VERSION_NUMBER < 3015002
+#error "SQLite 3.15.2 or higher required"
 #endif
 
 #define clinic_state() (pysqlite_get_state(module))
@@ -245,12 +245,6 @@ static PyMethodDef module_methods[] = {
 
 /* SQLite C API result codes. See also:
  * - https://www.sqlite.org/c3ref/c_abort_rollback.html
- * - https://sqlite.org/changes.html#version_3_3_8
- * - https://sqlite.org/changes.html#version_3_7_16
- * - https://sqlite.org/changes.html#version_3_7_17
- * - https://sqlite.org/changes.html#version_3_8_0
- * - https://sqlite.org/changes.html#version_3_8_3
- * - https://sqlite.org/changes.html#version_3_14
  *
  * Note: the SQLite changelogs rarely mention new result codes, so in order to
  * keep the 'error_codes' table in sync with SQLite, we must manually inspect
@@ -294,10 +288,8 @@ static const struct {
     DECLARE_ERROR_CODE(SQLITE_ROW),
     DECLARE_ERROR_CODE(SQLITE_SCHEMA),
     DECLARE_ERROR_CODE(SQLITE_TOOBIG),
-#if SQLITE_VERSION_NUMBER >= 3007017
     DECLARE_ERROR_CODE(SQLITE_NOTICE),
     DECLARE_ERROR_CODE(SQLITE_WARNING),
-#endif
     // Extended result code list
     DECLARE_ERROR_CODE(SQLITE_ABORT_ROLLBACK),
     DECLARE_ERROR_CODE(SQLITE_BUSY_RECOVERY),
@@ -331,7 +323,6 @@ static const struct {
     DECLARE_ERROR_CODE(SQLITE_LOCKED_SHAREDCACHE),
     DECLARE_ERROR_CODE(SQLITE_READONLY_CANTLOCK),
     DECLARE_ERROR_CODE(SQLITE_READONLY_RECOVERY),
-#if SQLITE_VERSION_NUMBER >= 3007016
     DECLARE_ERROR_CODE(SQLITE_CONSTRAINT_CHECK),
     DECLARE_ERROR_CODE(SQLITE_CONSTRAINT_COMMITHOOK),
     DECLARE_ERROR_CODE(SQLITE_CONSTRAINT_FOREIGNKEY),
@@ -342,39 +333,20 @@ static const struct {
     DECLARE_ERROR_CODE(SQLITE_CONSTRAINT_UNIQUE),
     DECLARE_ERROR_CODE(SQLITE_CONSTRAINT_VTAB),
     DECLARE_ERROR_CODE(SQLITE_READONLY_ROLLBACK),
-#endif
-#if SQLITE_VERSION_NUMBER >= 3007017
     DECLARE_ERROR_CODE(SQLITE_IOERR_MMAP),
     DECLARE_ERROR_CODE(SQLITE_NOTICE_RECOVER_ROLLBACK),
     DECLARE_ERROR_CODE(SQLITE_NOTICE_RECOVER_WAL),
-#endif
-#if SQLITE_VERSION_NUMBER >= 3008000
     DECLARE_ERROR_CODE(SQLITE_BUSY_SNAPSHOT),
     DECLARE_ERROR_CODE(SQLITE_IOERR_GETTEMPPATH),
     DECLARE_ERROR_CODE(SQLITE_WARNING_AUTOINDEX),
-#endif
-#if SQLITE_VERSION_NUMBER >= 3008001
     DECLARE_ERROR_CODE(SQLITE_CANTOPEN_CONVPATH),
     DECLARE_ERROR_CODE(SQLITE_IOERR_CONVPATH),
-#endif
-#if SQLITE_VERSION_NUMBER >= 3008002
     DECLARE_ERROR_CODE(SQLITE_CONSTRAINT_ROWID),
-#endif
-#if SQLITE_VERSION_NUMBER >= 3008003
     DECLARE_ERROR_CODE(SQLITE_READONLY_DBMOVED),
-#endif
-#if SQLITE_VERSION_NUMBER >= 3008007
     DECLARE_ERROR_CODE(SQLITE_AUTH_USER),
-#endif
-#if SQLITE_VERSION_NUMBER >= 3009000
     DECLARE_ERROR_CODE(SQLITE_IOERR_VNODE),
-#endif
-#if SQLITE_VERSION_NUMBER >= 3010000
     DECLARE_ERROR_CODE(SQLITE_IOERR_AUTH),
-#endif
-#if SQLITE_VERSION_NUMBER >= 3014001
     DECLARE_ERROR_CODE(SQLITE_OK_LOAD_PERMANENTLY),
-#endif
 #if SQLITE_VERSION_NUMBER >= 3021000
     DECLARE_ERROR_CODE(SQLITE_IOERR_BEGIN_ATOMIC),
     DECLARE_ERROR_CODE(SQLITE_IOERR_COMMIT_ATOMIC),
@@ -481,9 +453,7 @@ add_integer_constants(PyObject *module) {
     ADD_INT(SQLITE_DROP_VTABLE);
     ADD_INT(SQLITE_FUNCTION);
     ADD_INT(SQLITE_SAVEPOINT);
-#if SQLITE_VERSION_NUMBER >= 3008003
     ADD_INT(SQLITE_RECURSIVE);
-#endif
     // Run-time limit categories
     ADD_INT(SQLITE_LIMIT_LENGTH);
     ADD_INT(SQLITE_LIMIT_SQL_LENGTH);
@@ -496,9 +466,7 @@ add_integer_constants(PyObject *module) {
     ADD_INT(SQLITE_LIMIT_LIKE_PATTERN_LENGTH);
     ADD_INT(SQLITE_LIMIT_VARIABLE_NUMBER);
     ADD_INT(SQLITE_LIMIT_TRIGGER_DEPTH);
-#if SQLITE_VERSION_NUMBER >= 3008007
     ADD_INT(SQLITE_LIMIT_WORKER_THREADS);
-#endif
 
     /*
      * Database connection configuration options.
@@ -506,12 +474,8 @@ add_integer_constants(PyObject *module) {
      */
     ADD_INT(SQLITE_DBCONFIG_ENABLE_FKEY);
     ADD_INT(SQLITE_DBCONFIG_ENABLE_TRIGGER);
-#if SQLITE_VERSION_NUMBER >= 3012002
     ADD_INT(SQLITE_DBCONFIG_ENABLE_FTS3_TOKENIZER);
-#endif
-#if SQLITE_VERSION_NUMBER >= 3013000
     ADD_INT(SQLITE_DBCONFIG_ENABLE_LOAD_EXTENSION);
-#endif
 #if SQLITE_VERSION_NUMBER >= 3016000
     ADD_INT(SQLITE_DBCONFIG_NO_CKPT_ON_CLOSE);
 #endif
@@ -678,8 +642,8 @@ do {                                                     \
 static int
 module_exec(PyObject *module)
 {
-    if (sqlite3_libversion_number() < 3007015) {
-        PyErr_SetString(PyExc_ImportError, MODULE_NAME ": SQLite 3.7.15 or higher required");
+    if (sqlite3_libversion_number() < 3015002) {
+        PyErr_SetString(PyExc_ImportError, MODULE_NAME ": SQLite 3.15.2 or higher required");
         return -1;
     }
 

--- a/configure
+++ b/configure
@@ -14552,12 +14552,12 @@ if test -n "$LIBSQLITE3_CFLAGS"; then
     pkg_cv_LIBSQLITE3_CFLAGS="$LIBSQLITE3_CFLAGS"
  elif test -n "$PKG_CONFIG"; then
     if test -n "$PKG_CONFIG" && \
-    { { printf "%s\n" "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"sqlite3 >= 3.7.15\""; } >&5
-  ($PKG_CONFIG --exists --print-errors "sqlite3 >= 3.7.15") 2>&5
+    { { printf "%s\n" "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"sqlite3 >= 3.15.2\""; } >&5
+  ($PKG_CONFIG --exists --print-errors "sqlite3 >= 3.15.2") 2>&5
   ac_status=$?
   printf "%s\n" "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
   test $ac_status = 0; }; then
-  pkg_cv_LIBSQLITE3_CFLAGS=`$PKG_CONFIG --cflags "sqlite3 >= 3.7.15" 2>/dev/null`
+  pkg_cv_LIBSQLITE3_CFLAGS=`$PKG_CONFIG --cflags "sqlite3 >= 3.15.2" 2>/dev/null`
 		      test "x$?" != "x0" && pkg_failed=yes
 else
   pkg_failed=yes
@@ -14569,12 +14569,12 @@ if test -n "$LIBSQLITE3_LIBS"; then
     pkg_cv_LIBSQLITE3_LIBS="$LIBSQLITE3_LIBS"
  elif test -n "$PKG_CONFIG"; then
     if test -n "$PKG_CONFIG" && \
-    { { printf "%s\n" "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"sqlite3 >= 3.7.15\""; } >&5
-  ($PKG_CONFIG --exists --print-errors "sqlite3 >= 3.7.15") 2>&5
+    { { printf "%s\n" "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"sqlite3 >= 3.15.2\""; } >&5
+  ($PKG_CONFIG --exists --print-errors "sqlite3 >= 3.15.2") 2>&5
   ac_status=$?
   printf "%s\n" "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
   test $ac_status = 0; }; then
-  pkg_cv_LIBSQLITE3_LIBS=`$PKG_CONFIG --libs "sqlite3 >= 3.7.15" 2>/dev/null`
+  pkg_cv_LIBSQLITE3_LIBS=`$PKG_CONFIG --libs "sqlite3 >= 3.15.2" 2>/dev/null`
 		      test "x$?" != "x0" && pkg_failed=yes
 else
   pkg_failed=yes
@@ -14595,9 +14595,9 @@ else
         _pkg_short_errors_supported=no
 fi
         if test $_pkg_short_errors_supported = yes; then
-	        LIBSQLITE3_PKG_ERRORS=`$PKG_CONFIG --short-errors --print-errors --cflags --libs "sqlite3 >= 3.7.15" 2>&1`
+	        LIBSQLITE3_PKG_ERRORS=`$PKG_CONFIG --short-errors --print-errors --cflags --libs "sqlite3 >= 3.15.2" 2>&1`
         else
-	        LIBSQLITE3_PKG_ERRORS=`$PKG_CONFIG --print-errors --cflags --libs "sqlite3 >= 3.7.15" 2>&1`
+	        LIBSQLITE3_PKG_ERRORS=`$PKG_CONFIG --print-errors --cflags --libs "sqlite3 >= 3.15.2" 2>&1`
         fi
 	# Put the nasty error message in config.log where it belongs
 	echo "$LIBSQLITE3_PKG_ERRORS" >&5
@@ -14646,8 +14646,8 @@ then :
 
 
         #include <sqlite3.h>
-        #if SQLITE_VERSION_NUMBER < 3007015
-        #  error "SQLite 3.7.15 or higher required"
+        #if SQLITE_VERSION_NUMBER < 3015002
+        #  error "SQLite 3.15.2 or higher required"
         #endif
 
 int

--- a/configure.ac
+++ b/configure.ac
@@ -3952,7 +3952,7 @@ PY_CHECK_EMSCRIPTEN_PORT([LIBSQLITE3], [-sUSE_SQLITE3])
 
 dnl Check for SQLite library. Use pkg-config if available.
 PKG_CHECK_MODULES(
-  [LIBSQLITE3], [sqlite3 >= 3.7.15], [], [
+  [LIBSQLITE3], [sqlite3 >= 3.15.2], [], [
     LIBSQLITE3_CFLAGS=${LIBSQLITE3_CFLAGS-""}
     LIBSQLITE3_LIBS=${LIBSQLITE3_LIBS-"-lsqlite3"}
   ]
@@ -3978,8 +3978,8 @@ dnl hence CPPFLAGS instead of CFLAGS.
     AC_COMPILE_IFELSE([
       AC_LANG_PROGRAM([
         #include <sqlite3.h>
-        #if SQLITE_VERSION_NUMBER < 3007015
-        #  error "SQLite 3.7.15 or higher required"
+        #if SQLITE_VERSION_NUMBER < 3015002
+        #  error "SQLite 3.15.2 or higher required"
         #endif
       ], [])
     ], [


### PR DESCRIPTION
SQLite 3.15.2 was released 2016-11-28.


<!-- gh-issue-number: gh-105875 -->
* Issue: gh-105875
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--105876.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->