### PR TITLE
Docs: Avoid a DeprecationWarning in `pyspecific.py` when running with Sphinx >=6.1

### DIFF
--- a/Doc/tools/extensions/pyspecific.py
+++ b/Doc/tools/extensions/pyspecific.py
@@ -14,18 +14,15 @@ import io
 from os import getenv, path
 from time import asctime
 from pprint import pformat
+
+from docutils import nodes, utils
 from docutils.io import StringOutput
 from docutils.parsers.rst import Directive
 from docutils.utils import new_document
-
-from docutils import nodes, utils
-
 from sphinx import addnodes
 from sphinx.builders import Builder
-try:
-    from sphinx.errors import NoUri
-except ImportError:
-    from sphinx.environment import NoUri
+from sphinx.domains.python import PyFunction, PyMethod
+from sphinx.errors import NoUri
 from sphinx.locale import _ as sphinx_gettext
 from sphinx.util import logging
 from sphinx.util.docutils import SphinxDirective
@@ -33,15 +30,11 @@ from sphinx.util.nodes import split_explicit_title
 from sphinx.writers.text import TextWriter, TextTranslator
 
 try:
+    # Sphinx 6+
     from sphinx.util.display import status_iterator
 except ImportError:
+    # Deprecated in Sphinx 6.1, will be removed in Sphinx 8
     from sphinx.util import status_iterator
-
-try:
-    from sphinx.domains.python import PyFunction, PyMethod
-except ImportError:
-    from sphinx.domains.python import PyClassmember as PyMethod
-    from sphinx.domains.python import PyModulelevel as PyFunction
 
 
 ISSUE_URI = 'https://bugs.python.org/issue?@action=redirect&bpo=%s'

--- a/Doc/tools/extensions/pyspecific.py
+++ b/Doc/tools/extensions/pyspecific.py
@@ -27,10 +27,15 @@ try:
 except ImportError:
     from sphinx.environment import NoUri
 from sphinx.locale import _ as sphinx_gettext
-from sphinx.util import status_iterator, logging
+from sphinx.util import logging
 from sphinx.util.docutils import SphinxDirective
 from sphinx.util.nodes import split_explicit_title
 from sphinx.writers.text import TextWriter, TextTranslator
+
+try:
+    from sphinx.util.display import status_iterator
+except ImportError:
+    from sphinx.util import status_iterator
 
 try:
     from sphinx.domains.python import PyFunction, PyMethod


### PR DESCRIPTION
Importing `status_iterator` from `sphinx.util` rather than `sphinx.util.display` causes a `DeprecationWarning` to be emitted if you're running with Sphinx >= 6.1. We still support the CPython docs being built with older versions of Sphinx that don't yet have `sphinx.util.display`, however, hence the `try`/`except ImportError` block. You can see this deprecation warning here (though the doctest is also failing on that job, I think for unrelated reasons): https://github.com/python/cpython/actions/runs/5297276975/jobs/9588952949?pr=105882

<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--105886.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->