### PR TITLE
gh-104212: Explain how to port imp code to importlib

### DIFF
--- a/Doc/whatsnew/3.12.rst
+++ b/Doc/whatsnew/3.12.rst
@@ -1379,7 +1379,7 @@ Removed
     ``imp.find_module()``              :func:`importlib.util.find_spec`
     ``imp.get_magic()``                :attr:`importlib.util.MAGIC_NUMBER`
     ``imp.get_suffixes()``             :attr:`importlib.machinery.SOURCE_SUFFIXES`, :attr:`importlib.machinery.EXTENSION_SUFFIXES`, and :attr:`importlib.machinery.BYTECODE_SUFFIXES`
-    ``imp.get_tag()``                  :attr:`sys.implementation.cache_tag`
+    ``imp.get_tag()``                  :attr:`sys.implementation.cache_tag <sys.implementation>`
     ``imp.load_module()``              :func:`importlib.import_module`
     ``imp.new_module(name)``           ``types.ModuleType(name)``.
     ``imp.reload()``                   :func:`importlib.reload`
@@ -1398,7 +1398,7 @@ Removed
 
     * ``imp.lock_held()``, ``imp.acquire_lock()``, ``imp.release_lock()``:
       the locking scheme has changed in Python 3.3 to per-module locks.
-    * :func:`find_module` constants: ``SEARCH_ERROR``, ``PY_SOURCE``,
+    * ``imp.find_module()`` constants: ``SEARCH_ERROR``, ``PY_SOURCE``,
       ``PY_COMPILED``, ``C_EXTENSION``, ``PY_RESOURCE``, ``PKG_DIRECTORY``,
       ``C_BUILTIN``, ``PY_FROZEN``, ``PY_CODERESOURCE``, ``IMP_HOOK``.
 

--- a/Doc/whatsnew/3.12.rst
+++ b/Doc/whatsnew/3.12.rst
@@ -1381,7 +1381,7 @@ Removed
     ``imp.get_suffixes()``             :attr:`importlib.machinery.SOURCE_SUFFIXES`, :attr:`importlib.machinery.EXTENSION_SUFFIXES`, and :attr:`importlib.machinery.BYTECODE_SUFFIXES`
     ``imp.get_tag()``                  :attr:`sys.implementation.cache_tag <sys.implementation>`
     ``imp.load_module()``              :func:`importlib.import_module`
-    ``imp.new_module(name)``           ``types.ModuleType(name)``.
+    ``imp.new_module(name)``           ``types.ModuleType(name)``
     ``imp.reload()``                   :func:`importlib.reload`
     ``imp.source_from_cache()``        :func:`importlib.util.source_from_cache`
     =================================  =======================================

--- a/Doc/whatsnew/3.12.rst
+++ b/Doc/whatsnew/3.12.rst
@@ -1369,7 +1369,38 @@ Removed
   * The :mod:`!imp` module has been removed.  (Contributed by Barry Warsaw in
     :gh:`98040`.)
 
-  * Replace ``imp.new_module(name)`` with ``types.ModuleType(name)``.
+  * Replace removed :mod:`!imp` functions with :mod:`importlib` functions:
+
+    =================================  =======================================
+       imp                                importlib
+    =================================  =======================================
+    ``imp.NullImporter``               Insert ``None`` into ``sys.path_importer_cache``
+    ``imp.cache_from_source()``        :func:`importlib.util.cache_from_source`
+    ``imp.find_module()``              :func:`importlib.util.find_spec`
+    ``imp.get_magic()``                :attr:`importlib.util.MAGIC_NUMBER`
+    ``imp.get_suffixes()``             :attr:`importlib.machinery.SOURCE_SUFFIXES`, :attr:`importlib.machinery.EXTENSION_SUFFIXES`, and :attr:`importlib.machinery.BYTECODE_SUFFIXES`
+    ``imp.get_tag()``                  :attr:`sys.implementation.cache_tag`
+    ``imp.load_module()``              :func:`importlib.import_module`
+    ``imp.new_module(name)``           ``types.ModuleType(name)``.
+    ``imp.reload()``                   :func:`importlib.reload`
+    ``imp.source_from_cache()``        :func:`importlib.util.source_from_cache`
+    =================================  =======================================
+
+  * Removed :mod:`!imp` functions and attributes with no replacements:
+
+    * undocumented functions:
+
+      * ``imp.init_builtin()``
+      * ``imp.load_compiled()``
+      * ``imp.load_dynamic()``
+      * ``imp.load_package()``
+      * ``imp.load_source()``
+
+    * ``imp.lock_held()``, ``imp.acquire_lock()``, ``imp.release_lock()``:
+      the locking scheme has changed in Python 3.3 to per-module locks.
+    * :func:`find_module` constants: ``SEARCH_ERROR``, ``PY_SOURCE``,
+      ``PY_COMPILED``, ``C_EXTENSION``, ``PY_RESOURCE``, ``PKG_DIRECTORY``,
+      ``C_BUILTIN``, ``PY_FROZEN``, ``PY_CODERESOURCE``, ``IMP_HOOK``.
 
 * Removed the ``suspicious`` rule from the documentation Makefile, and
   removed ``Doc/tools/rstlint.py``, both in favor of `sphinx-lint


### PR DESCRIPTION
Explain in What's New in Python 3.12 how to port existing code using the removed imp to the importlib module.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-104212 -->
* Issue: gh-104212
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--105905.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->