### PR TITLE
gh-105908: fix `barry_as_FLUFL` future import

### DIFF
--- a/Lib/test/test_future.py
+++ b/Lib/test/test_future.py
@@ -4,6 +4,7 @@ import __future__
 import ast
 import unittest
 from test.support import import_helper
+from test.support.script_helper import spawn_python, kill_python
 from textwrap import dedent
 import os
 import re
@@ -120,6 +121,13 @@ class FutureTest(unittest.TestCase):
         scope = {}
         exec("from __future__ import unicode_literals; x = ''", {}, scope)
         self.assertIsInstance(scope["x"], str)
+
+    def test_syntactical_future_repl(self):
+        p = spawn_python('-i')
+        p.stdin.write(b"from __future__ import barry_as_FLUFL\n")
+        p.stdin.write(b"2 <> 3\n")
+        out = kill_python(p)
+        self.assertNotIn(b'SyntaxError: invalid syntax', out)
 
 class AnnotationsFutureTestCase(unittest.TestCase):
     template = dedent(

--- a/Misc/NEWS.d/next/Core and Builtins/2023-06-19-11-04-01.gh-issue-105908.7oanny.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2023-06-19-11-04-01.gh-issue-105908.7oanny.rst
@@ -1,1 +1,1 @@
-Fixed bug where gh-99111 breaks future import `barry_as_FLUFL` in the Python REPL.
+Fixed bug where :gh:`99111` breaks future import ``barry_as_FLUFL`` in the Python REPL.

--- a/Misc/NEWS.d/next/Core and Builtins/2023-06-19-11-04-01.gh-issue-105908.7oanny.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2023-06-19-11-04-01.gh-issue-105908.7oanny.rst
@@ -1,0 +1,1 @@
+Fixed bug where gh-99111 breaks future import `barry_as_FLUFL` in the Python REPL.

--- a/Python/compile.c
+++ b/Python/compile.c
@@ -494,7 +494,7 @@ static PyCodeObject *optimize_and_assemble(struct compiler *, int addNone);
 
 static int
 compiler_setup(struct compiler *c, mod_ty mod, PyObject *filename,
-               PyCompilerFlags flags, int optimize, PyArena *arena)
+               PyCompilerFlags *flags, int optimize, PyArena *arena)
 {
     c->c_const_cache = PyDict_New();
     if (!c->c_const_cache) {
@@ -511,10 +511,13 @@ compiler_setup(struct compiler *c, mod_ty mod, PyObject *filename,
     if (!_PyFuture_FromAST(mod, filename, &c->c_future)) {
         return ERROR;
     }
-    int merged = c->c_future.ff_features | flags.cf_flags;
+    if (!flags) {
+        flags = &_PyCompilerFlags_INIT;
+    }
+    int merged = c->c_future.ff_features | flags->cf_flags;
     c->c_future.ff_features = merged;
-    flags.cf_flags = merged;
-    c->c_flags = flags;
+    flags->cf_flags = merged;
+    c->c_flags = *flags;
     c->c_optimize = (optimize == -1) ? _Py_GetConfig()->optimization_level : optimize;
     c->c_nestlevel = 0;
 
@@ -535,12 +538,11 @@ static struct compiler*
 new_compiler(mod_ty mod, PyObject *filename, PyCompilerFlags *pflags,
              int optimize, PyArena *arena)
 {
-    PyCompilerFlags flags = pflags ? *pflags : _PyCompilerFlags_INIT;
     struct compiler *c = PyMem_Calloc(1, sizeof(struct compiler));
     if (c == NULL) {
         return NULL;
     }
-    if (compiler_setup(c, mod, filename, flags, optimize, arena) < 0) {
+    if (compiler_setup(c, mod, filename, pflags, optimize, arena) < 0) {
         compiler_free(c);
         return NULL;
     }

--- a/Python/compile.c
+++ b/Python/compile.c
@@ -496,6 +496,8 @@ static int
 compiler_setup(struct compiler *c, mod_ty mod, PyObject *filename,
                PyCompilerFlags *flags, int optimize, PyArena *arena)
 {
+    PyCompilerFlags local_flags = _PyCompilerFlags_INIT;
+
     c->c_const_cache = PyDict_New();
     if (!c->c_const_cache) {
         return ERROR;
@@ -512,7 +514,7 @@ compiler_setup(struct compiler *c, mod_ty mod, PyObject *filename,
         return ERROR;
     }
     if (!flags) {
-        flags = &_PyCompilerFlags_INIT;
+        flags = &local_flags;
     }
     int merged = c->c_future.ff_features | flags->cf_flags;
     c->c_future.ff_features = merged;


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

In `compiler_setup()`, the `flags` parameter is a local struct that does not reflect changes to the pointer passed to `new_compiler()`. Fix by making the `flags` parameter a pointer to a struct instead of a struct.

<!-- gh-issue-number: gh-105908 -->
* Issue: gh-105908
<!-- /gh-issue-number -->
