### PR TITLE
GH-105808: Fix a regression introduced in GH-101251

### DIFF
--- a/Lib/gzip.py
+++ b/Lib/gzip.py
@@ -370,8 +370,9 @@ class GzipFile(_compression.BaseStream):
     def flush(self,zlib_mode=zlib.Z_SYNC_FLUSH):
         self._check_not_closed()
         if self.mode == WRITE:
-            # Ensure the compressor's buffer is flushed
             self._buffer.flush()
+            # Ensure the compressor's buffer is flushed
+            self.fileobj.write(self.compress.flush(zlib_mode))
             self.fileobj.flush()
 
     def fileno(self):

--- a/Misc/NEWS.d/next/Library/2023-06-19-11-31-55.gh-issue-105808.NL-quu.rst
+++ b/Misc/NEWS.d/next/Library/2023-06-19-11-31-55.gh-issue-105808.NL-quu.rst
@@ -1,1 +1,1 @@
-Fix a regression introduced in GH-101251, causing GzipFile.flush() to not flush the compressor (nor pass along the zip_mode argument).
+Fix a regression introduced in GH-101251 for 3.12, causing :meth:`gzip.GzipFile.flush` to not flush the compressor (nor pass along the ``zip_mode`` argument).

--- a/Misc/NEWS.d/next/Library/2023-06-19-11-31-55.gh-issue-105808.NL-quu.rst
+++ b/Misc/NEWS.d/next/Library/2023-06-19-11-31-55.gh-issue-105808.NL-quu.rst
@@ -1,0 +1,1 @@
+Fix a regression introduced in GH-101251, causing GzipFile.flush() to not flush the compressor (nor pass along the zip_mode argument).


### PR DESCRIPTION
Fix a regression introduced in GH-101251, causing GzipFile.flush() to not flush the compressor (nor pass along the zip_mode argument).


<!-- gh-issue-number: gh-105808 -->
* Issue: gh-105808
<!-- /gh-issue-number -->
