### PR TITLE
make regen-stdlib-module-names rejects test modules

### DIFF
--- a/Tools/build/generate_stdlib_module_names.py
+++ b/Tools/build/generate_stdlib_module_names.py
@@ -43,6 +43,16 @@ IGNORE = {
     'xxsubtype',
 }
 
+ALLOW_TEST_MODULES = {
+    'doctest',
+    'unittest',
+}
+
+# Built-in modules
+def list_builtin_modules(names):
+    names |= set(sys.builtin_module_names)
+
+
 # Pure Python modules (Lib/*.py)
 def list_python_modules(names):
     for filename in os.listdir(STDLIB_PATH):
@@ -93,7 +103,9 @@ def list_frozen(names):
 
 
 def list_modules():
-    names = set(sys.builtin_module_names)
+    names = set()
+
+    list_builtin_modules(names)
     list_modules_setup_extensions(names)
     list_packages(names)
     list_python_modules(names)
@@ -106,9 +118,12 @@ def list_modules():
         if package_name in IGNORE:
             names.discard(name)
 
+    # Sanity checks
     for name in names:
         if "." in name:
-            raise Exception("sub-modules must not be listed")
+            raise Exception(f"sub-modules must not be listed: {name}")
+        if ("test" in name or "xx" in name) and name not in ALLOW_TEST_MODULES:
+            raise Exception(f"test modules must not be listed: {name}")
 
     return names
 


### PR DESCRIPTION
Make sure that sys.stdlib_module_names doesn't contain test modules.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
