### PR TITLE
gh-105936: Fix frozen dataclasses with slots' `__setattr__` and `__delattr_` 

### DIFF
--- a/Lib/dataclasses.py
+++ b/Lib/dataclasses.py
@@ -635,7 +635,7 @@ def _repr_fn(fields, globals):
     return _recursive_repr(fn)
 
 
-def _frozen_get_del_attr(cls, fields, globals):
+def _frozen_set_del_attr(cls, fields, globals):
     locals = {'cls': cls,
               'FrozenInstanceError': FrozenInstanceError}
     condition = 'type(self) is cls'
@@ -1121,7 +1121,7 @@ def _process_class(cls, init, repr, eq, order, unsafe_hash, frozen,
                                 'functools.total_ordering')
 
     if frozen:
-        for fn in _frozen_get_del_attr(cls, field_list, globals):
+        for fn in _frozen_set_del_attr(cls, field_list, globals):
             if _set_new_attribute(cls, fn.__name__, fn):
                 raise TypeError(f'Cannot overwrite attribute {fn.__name__} '
                                 f'in class {cls.__name__}')

--- a/Lib/dataclasses.py
+++ b/Lib/dataclasses.py
@@ -1055,6 +1055,12 @@ def _process_class(cls, init, repr, eq, order, unsafe_hash, frozen,
     (std_init_fields,
      kw_only_init_fields) = _fields_in_init_order(all_init_fields)
 
+    # It's an error to specify weakref_slot if slots is False.
+    if weakref_slot and not slots:
+        raise TypeError('weakref_slot is True but slots is False')
+    if slots:
+        cls = _add_slots(cls, frozen, weakref_slot)
+
     if init:
         # Does this class have a post-init function?
         has_post_init = hasattr(cls, _POST_INIT_NAME)
@@ -1144,12 +1150,6 @@ def _process_class(cls, init, repr, eq, order, unsafe_hash, frozen,
         # I could probably compute this once
         _set_new_attribute(cls, '__match_args__',
                            tuple(f.name for f in std_init_fields))
-
-    # It's an error to specify weakref_slot if slots is False.
-    if weakref_slot and not slots:
-        raise TypeError('weakref_slot is True but slots is False')
-    if slots:
-        cls = _add_slots(cls, frozen, weakref_slot)
 
     abc.update_abstractmethods(cls)
 

--- a/Lib/test/test_dataclasses.py
+++ b/Lib/test/test_dataclasses.py
@@ -2820,6 +2820,23 @@ class TestFrozen(unittest.TestCase):
         self.assertEqual(c.i, 10)
         with self.assertRaises(FrozenInstanceError):
             c.i = 5
+        with self.assertRaises(FrozenInstanceError):
+            c.j = 5
+
+        self.assertEqual(c.i, 10)
+
+    def test_frozen_with_slots(self):
+        @dataclass(frozen=True, slots=True)
+        class C:
+            i: int
+
+        c = C(10)
+        self.assertEqual(c.i, 10)
+        with self.assertRaises(FrozenInstanceError):
+            c.i = 5
+        with self.assertRaises(FrozenInstanceError):
+            c.j = 5
+
         self.assertEqual(c.i, 10)
 
     def test_frozen_empty(self):
@@ -2937,6 +2954,43 @@ class TestFrozen(unittest.TestCase):
         # See bpo-32953.
 
         @dataclass(frozen=True)
+        class D:
+            x: int
+            y: int = 10
+
+        class S(D):
+            pass
+
+        s = S(3)
+        self.assertEqual(s.x, 3)
+        self.assertEqual(s.y, 10)
+        s.cached = True
+
+        # But can't change the frozen attributes.
+        with self.assertRaises(FrozenInstanceError):
+            s.x = 5
+        with self.assertRaises(FrozenInstanceError):
+            s.y = 5
+        self.assertEqual(s.x, 3)
+        self.assertEqual(s.y, 10)
+        self.assertEqual(s.cached, True)
+
+        with self.assertRaises(FrozenInstanceError):
+            del s.x
+        self.assertEqual(s.x, 3)
+        with self.assertRaises(FrozenInstanceError):
+            del s.y
+        self.assertEqual(s.y, 10)
+        del s.cached
+        self.assertFalse(hasattr(s, 'cached'))
+        with self.assertRaises(AttributeError) as cm:
+            del s.cached
+        self.assertNotIsInstance(cm.exception, FrozenInstanceError)
+
+    def test_non_frozen_normal_derived_with_slots(self):
+        # See bpo-32953.
+
+        @dataclass(frozen=True, slots=True)
         class D:
             x: int
             y: int = 10

--- a/Misc/NEWS.d/next/Library/2023-06-20-10-14-29.gh-issue-105936.7VfFJW.rst
+++ b/Misc/NEWS.d/next/Library/2023-06-20-10-14-29.gh-issue-105936.7VfFJW.rst
@@ -1,0 +1,1 @@
+Fixed frozen dataclasses with slots' ``__setattr__`` and ``__delattr_``.


### PR DESCRIPTION
The problem was that super was called `cls` with the original class instead of the one generated by _add_slots.
The PR moves `_add_slots` to before the generation of other methods for the dataclass that enabling the use of right `cls` everywhere (currently _frozen_get_del_attr was the only place to be affected).

<!-- gh-issue-number: gh-105936 -->
* Issue: gh-105936
<!-- /gh-issue-number -->
