### PR TITLE
stdtypes.rst: remove a period

### DIFF
--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -52,7 +52,7 @@ objects considered false:
      single: None (Built-in object)
      single: False (Built-in object)
 
-* constants defined to be false: ``None`` and ``False``.
+* constants defined to be false: ``None`` and ``False``
 
 * zero of any numeric type: ``0``, ``0.0``, ``0j``, ``Decimal(0)``,
   ``Fraction(0, 1)``


### PR DESCRIPTION
1 character change for consistency: other lines of the enumeration do not end with a period.

<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--105959.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->