### PR TITLE
gh-105960: Prevent stack overflows when using itertools.chain.from_iterable

### DIFF
--- a/Lib/test/test_itertools.py
+++ b/Lib/test/test_itertools.py
@@ -2432,6 +2432,14 @@ class RegressionTests(unittest.TestCase):
         for j in range(2):
             next(g, None)  # shouldn't crash
 
+    def test_infinite_recursion_chain(self):
+        # See gh-105960 for more information
+        def f(xs):
+            m = map(f, xs)
+            return chain.from_iterable(m)
+        with self.assertRaises(RecursionError):
+            list(f("a"))
+
 
 class SubclassWithKwargsTest(unittest.TestCase):
     def test_keywords_in_subclass(self):

--- a/Misc/NEWS.d/next/Core and Builtins/2023-06-21-12-00-15.gh-issue-105960.yGe5OF.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2023-06-21-12-00-15.gh-issue-105960.yGe5OF.rst
@@ -1,0 +1,2 @@
+Fix a bug with :func:`itertools.chain.from_iterable` that can caused it to
+stack overflow when called recursively. Patch by Pablo Galindo


### PR DESCRIPTION


<!-- gh-issue-number: gh-105960 -->
* Issue: gh-105960
<!-- /gh-issue-number -->
