### PR TITLE
gh-105927: _ctypes use PyWeakref_GetRef()

### DIFF
--- a/Modules/_ctypes/_ctypes.c
+++ b/Modules/_ctypes/_ctypes.c
@@ -258,7 +258,7 @@ _PyDict_GetItemProxy(PyObject *dict, PyObject *key, PyObject **presult)
     if (PyWeakref_GetRef(item, &ref) < 0) {
         return -1;
     }
-    // Return NULL if the referenced object was destroyed
+    // ref is NULL if the referenced object was destroyed
     *presult = ref;
     return 0;
 }

--- a/Modules/_ctypes/_ctypes.c
+++ b/Modules/_ctypes/_ctypes.c
@@ -238,20 +238,29 @@ PyDict_SetItemProxy(PyObject *dict, PyObject *key, PyObject *item)
     return result;
 }
 
-PyObject *
-PyDict_GetItemProxy(PyObject *dict, PyObject *key)
+static int
+_PyDict_GetItemProxy(PyObject *dict, PyObject *key, PyObject **presult)
 {
-    PyObject *result;
     PyObject *item = PyDict_GetItemWithError(dict, key);
+    if (item == NULL) {
+        if (PyErr_Occurred()) {
+            return -1;
+        }
+        *presult = NULL;
+        return 0;
+    }
 
-    if (item == NULL)
-        return NULL;
-    if (!PyWeakref_CheckProxy(item))
-        return item;
-    result = PyWeakref_GET_OBJECT(item);
-    if (result == Py_None)
-        return NULL;
-    return result;
+    if (!PyWeakref_CheckProxy(item)) {
+        *presult = Py_NewRef(item);
+        return 0;
+    }
+    PyObject *ref;
+    if (PyWeakref_GetRef(item, &ref) < 0) {
+        return -1;
+    }
+    // Return NULL if the referenced object was destroyed
+    *presult = ref;
+    return 0;
 }
 
 /******************************************************************/
@@ -4832,7 +4841,6 @@ PyCArrayType_from_ctype(PyObject *itemtype, Py_ssize_t length)
 {
     static PyObject *cache;
     PyObject *key;
-    PyObject *result;
     char name[256];
     PyObject *len;
 
@@ -4848,15 +4856,15 @@ PyCArrayType_from_ctype(PyObject *itemtype, Py_ssize_t length)
     Py_DECREF(len);
     if (!key)
         return NULL;
-    result = PyDict_GetItemProxy(cache, key);
-    if (result) {
-        Py_INCREF(result);
-        Py_DECREF(key);
-        return result;
-    }
-    else if (PyErr_Occurred()) {
+
+    PyObject *result;
+    if (_PyDict_GetItemProxy(cache, key, &result) < 0) {
         Py_DECREF(key);
         return NULL;
+    }
+    if (result) {
+        Py_DECREF(key);
+        return result;
     }
 
     if (!PyType_Check(itemtype)) {


### PR DESCRIPTION
Rename PyDict_GetItemProxy() to _PyDict_GetItemProxy() and mark it as static. _PyDict_GetItemProxy() now returns a strong reference, instead of a borrowed reference: replace PyWeakref_GET_OBJECT() with _PyWeakref_GET_REF().

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-105927 -->
* Issue: gh-105927
<!-- /gh-issue-number -->
