### PR TITLE
gh-105927: finalize_modules_clear_weaklist() uses _PyWeakref_GET_REF()

### DIFF
--- a/Include/internal/pycore_moduleobject.h
+++ b/Include/internal/pycore_moduleobject.h
@@ -33,7 +33,7 @@ static inline PyObject* _PyModule_GetDict(PyObject *mod) {
     PyObject *dict = ((PyModuleObject *)mod) -> md_dict;
     // _PyModule_GetDict(mod) must not be used after calling module_clear(mod)
     assert(dict != NULL);
-    return dict;
+    return dict;  // borrowed reference
 }
 
 PyObject* _Py_module_getattro_impl(PyModuleObject *m, PyObject *name, int suppress);

--- a/Objects/moduleobject.c
+++ b/Objects/moduleobject.c
@@ -504,7 +504,7 @@ PyModule_GetDict(PyObject *m)
         PyErr_BadInternalCall();
         return NULL;
     }
-    return _PyModule_GetDict(m);
+    return _PyModule_GetDict(m);  // borrowed reference
 }
 
 PyObject*


### PR DESCRIPTION
finalize_modules_clear_weaklist() now holds a strong reference to the module longer than before: replace PyWeakref_GET_OBJECT() with _PyWeakref_GET_REF().

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-105927 -->
* Issue: gh-105927
<!-- /gh-issue-number -->
