### PR TITLE
gh-105987: Fix reference counting issue in `_asyncio._swap_current_task`

### DIFF
--- a/Lib/test/test_asyncio/test_eager_task_factory.py
+++ b/Lib/test/test_asyncio/test_eager_task_factory.py
@@ -10,7 +10,6 @@ from test.test_asyncio import utils as test_utils
 import test.support
 from test.support.script_helper import assert_python_ok
 
-
 MOCK_ANY = mock.ANY
 
 

--- a/Lib/test/test_asyncio/test_eager_task_factory.py
+++ b/Lib/test/test_asyncio/test_eager_task_factory.py
@@ -7,6 +7,9 @@ import unittest
 from unittest import mock
 from asyncio import tasks
 from test.test_asyncio import utils as test_utils
+import test.support
+from test.support.script_helper import assert_python_ok
+
 
 MOCK_ANY = mock.ANY
 
@@ -222,6 +225,23 @@ class PyEagerTaskFactoryLoopTests(EagerTaskFactoryLoopTests, test_utils.TestCase
 class CEagerTaskFactoryLoopTests(EagerTaskFactoryLoopTests, test_utils.TestCase):
     Task = getattr(tasks, '_CTask', None)
 
+    def test_issue105987(self):
+        code = """if 1:
+        from _asyncio import _swap_current_task
+
+        class DummyTask:
+            pass
+
+        class DummyLoop:
+            pass
+
+        l = DummyLoop()
+        _swap_current_task(l, DummyTask())
+        t = _swap_current_task(l, None)
+        """
+
+        _, out, err = assert_python_ok("-c", code)
+        self.assertFalse(err)
 
 class AsyncTaskCounter:
     def __init__(self, loop, *, task_class, eager):

--- a/Misc/NEWS.d/next/Library/2023-06-22-15-21-11.gh-issue-105987.T7Kzrb.rst
+++ b/Misc/NEWS.d/next/Library/2023-06-22-15-21-11.gh-issue-105987.T7Kzrb.rst
@@ -1,0 +1,1 @@
+Fix crash due to improper reference counting in :mod:`asyncio` eager task factory internal routines.

--- a/Modules/_asynciomodule.c
+++ b/Modules/_asynciomodule.c
@@ -2040,7 +2040,7 @@ swap_current_task(asyncio_state *state, PyObject *loop, PyObject *task)
         return NULL;
     }
 
-    prev_task = _PyDict_GetItem_KnownHash(state->current_tasks, loop, hash);
+    prev_task = Py_XNewRef(_PyDict_GetItem_KnownHash(state->current_tasks, loop, hash));
     if (prev_task == NULL) {
         if (PyErr_Occurred()) {
             return NULL;
@@ -2050,17 +2050,19 @@ swap_current_task(asyncio_state *state, PyObject *loop, PyObject *task)
 
     if (task == Py_None) {
         if (_PyDict_DelItem_KnownHash(state->current_tasks, loop, hash) == -1) {
-            return NULL;
+            goto error;
         }
     } else {
         if (_PyDict_SetItem_KnownHash(state->current_tasks, loop, task, hash) == -1) {
-            return NULL;
+            goto error;
         }
     }
 
-    Py_INCREF(prev_task);
-
     return prev_task;
+
+error:
+    Py_DECREF(prev_task);
+    return NULL;
 }
 
 /* ----- Task */

--- a/Modules/_asynciomodule.c
+++ b/Modules/_asynciomodule.c
@@ -2040,13 +2040,14 @@ swap_current_task(asyncio_state *state, PyObject *loop, PyObject *task)
         return NULL;
     }
 
-    prev_task = Py_XNewRef(_PyDict_GetItem_KnownHash(state->current_tasks, loop, hash));
+    prev_task = _PyDict_GetItem_KnownHash(state->current_tasks, loop, hash);
     if (prev_task == NULL) {
         if (PyErr_Occurred()) {
             return NULL;
         }
         prev_task = Py_None;
     }
+    Py_INCREF(prev_task);
 
     if (task == Py_None) {
         if (_PyDict_DelItem_KnownHash(state->current_tasks, loop, hash) == -1) {


### PR DESCRIPTION
Fixes #105987 

`_PyDict_GetItem_KnownHash` returns borrowed reference to previous task object, so call to `_PyDict_DelItem_KnownHash`/`_PyDict_SetItem_KnownHash` can deallocate it before it will be returned from `swap_current_task` function


<!-- gh-issue-number: gh-105987 -->
* Issue: gh-105987
<!-- /gh-issue-number -->
