### PR TITLE
gh-105993: Add possible None return type to start_tls() docs

### DIFF
--- a/Doc/library/asyncio-eventloop.rst
+++ b/Doc/library/asyncio-eventloop.rst
@@ -895,6 +895,9 @@ TLS Upgrade
    object only because the coder caches *protocol*-side data and sporadically
    exchanges extra TLS session packets with *transport*.
 
+   In some situations (e.g. when the passed transport is already closing) this
+   may return ``None``.
+
    Parameters:
 
    * *transport* and *protocol* instances that methods like


### PR DESCRIPTION
Feel free to edit and make it more precise, I'm not too clear exactly when `None` can or can't occur.

<!-- gh-issue-number: gh-105993 -->
* Issue: gh-105993
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--105995.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->