### PR TITLE
faq/library: remove outdated sections

### DIFF
--- a/Doc/faq/library.rst
+++ b/Doc/faq/library.rst
@@ -670,38 +670,6 @@ A summary of available frameworks is maintained by Paul Boddie at
 https://wiki.python.org/moin/WebProgramming\ .
 
 
-How can I mimic CGI form submission (METHOD=POST)?
---------------------------------------------------
-
-I would like to retrieve web pages that are the result of POSTing a form. Is
-there existing code that would let me do this easily?
-
-Yes. Here's a simple example that uses :mod:`urllib.request`::
-
-   #!/usr/local/bin/python
-
-   import urllib.request
-
-   # build the query string
-   qs = "First=Josephine&MI=Q&Last=Public"
-
-   # connect and send the server a path
-   req = urllib.request.urlopen('http://www.some-server.out-there'
-                                '/cgi-bin/some-cgi-script', data=qs)
-   with req:
-       msg, hdrs = req.read(), req.info()
-
-Note that in general for percent-encoded POST operations, query strings must be
-quoted using :func:`urllib.parse.urlencode`.  For example, to send
-``name=Guy Steele, Jr.``::
-
-   >>> import urllib.parse
-   >>> urllib.parse.urlencode({'name': 'Guy Steele, Jr.'})
-   'name=Guy+Steele%2C+Jr.'
-
-.. seealso:: :ref:`urllib-howto` for extensive examples.
-
-
 What module should I use to help with generating HTML?
 ------------------------------------------------------
 

--- a/Doc/faq/library.rst
+++ b/Doc/faq/library.rst
@@ -614,18 +614,6 @@ use ``p.read(n)``.
    <https://pypi.org/project/pexpect/>`_.
 
 
-How do I access the serial (RS232) port?
-----------------------------------------
-
-For Win32, OSX, Linux, BSD, Jython, IronPython:
-
-   https://pypi.org/project/pyserial/
-
-For Unix, see a Usenet post by Mitch Chapman:
-
-   https://groups.google.com/groups?selm=34A04430.CF9@ohioee.com
-
-
 Why doesn't closing sys.stdout (stdin, stderr) really close it?
 ---------------------------------------------------------------
 

--- a/Doc/faq/library.rst
+++ b/Doc/faq/library.rst
@@ -614,6 +614,18 @@ use ``p.read(n)``.
    <https://pypi.org/project/pexpect/>`_.
 
 
+How do I access the serial (RS232) port?
+----------------------------------------
+
+For Win32, OSX, Linux, BSD, Jython, IronPython:
+
+   https://pypi.org/project/pyserial/
+
+For Unix, see a Usenet post by Mitch Chapman:
+
+   https://groups.google.com/groups?selm=34A04430.CF9@ohioee.com
+
+
 Why doesn't closing sys.stdout (stdin, stderr) really close it?
 ---------------------------------------------------------------
 

--- a/Doc/faq/library.rst
+++ b/Doc/faq/library.rst
@@ -669,9 +669,6 @@ and client-side web systems.
 A summary of available frameworks is maintained by Paul Boddie at
 https://wiki.python.org/moin/WebProgramming\ .
 
-Cameron Laird maintains a useful set of pages about Python web technologies at
-https://web.archive.org/web/20210224183619/http://phaseit.net/claird/comp.lang.python/web_python.
-
 
 How can I mimic CGI form submission (METHOD=POST)?
 --------------------------------------------------


### PR DESCRIPTION
I broke it into 3 commits so we can revert some deletion if we wish:
* 1st commit:  I don't know who Cameron Laird is, I have never heard of him in 10 years of web development, never been talked about his website, never ran into it when googling python web develoment stuff, and the website has not been updated in ages. It doesn't even mention Django nor Flask. It's so dead it's not linked directly, it's linked through webarchive.org 
* 2nd commit: nobody mainstream does web using CGI anymore, for years. This has become a very corner case that does not belong in the FAQ
* 3rd commit: I haven't seen a serial port on a computer for at least 12 years. Same thing than above, of course there must be people on earth who still uses this but it does not belong in the FAQ

In a general matter, I think we should remove links preserved through archive.org. That the page went down and that nobody bothered to generate a reliable copy is a clear marker that the page is no longer relevant in today's world.

A good example of this is Joel's [The Absolute Minimum Every Software Developer Absolutely, Positively Must Know About Unicode and Character Sets (No Excuses!)](https://www.joelonsoftware.com/2003/10/08/the-absolute-minimum-every-software-developer-absolutely-positively-must-know-about-unicode-and-character-sets-no-excuses/). It will be 20 years in few weeks. It has been non-stop alive since then because it has always been relevant, until today, 20 years later.

<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--105996.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->