### PR TITLE
gh-105922: PyImport_AddModule() uses Py_DECREF()

### DIFF
--- a/Modules/_testcapimodule.c
+++ b/Modules/_testcapimodule.c
@@ -3373,6 +3373,26 @@ error:
 
 
 static PyObject *
+test_pyimport_addmodule(PyObject *self, PyObject *args)
+{
+    const char *name;
+    if (!PyArg_ParseTuple(args, "s", &name)) {
+        return NULL;
+    }
+    PyObject *mod = PyImport_AddModule(name);
+    if (mod == NULL) {
+        if (!PyErr_Occurred()) {
+            PyErr_SetString(PyExc_AssertionError,
+                            "PyImport_AddModule returns NULL "
+                            "without setting an exception");
+        }
+        return NULL;
+    }
+    return Py_NewRef(mod);
+}
+
+
+static PyObject *
 test_weakref_capi(PyObject *Py_UNUSED(module), PyObject *Py_UNUSED(args))
 {
     // Create a new heap type, create an instance of this type, and delete the
@@ -3610,6 +3630,7 @@ static PyMethodDef TestMethods[] = {
     {"function_set_kw_defaults", function_set_kw_defaults, METH_VARARGS, NULL},
     {"test_atexit", test_atexit, METH_NOARGS},
     {"check_pyimport_addmodule", check_pyimport_addmodule, METH_VARARGS},
+    {"pyimport_addmodule", test_pyimport_addmodule, METH_VARARGS},
     {"test_weakref_capi", test_weakref_capi, METH_NOARGS},
     {NULL, NULL} /* sentinel */
 };

--- a/Python/import.c
+++ b/Python/import.c
@@ -372,16 +372,7 @@ PyImport_AddModuleObject(PyObject *name)
     if (!mod) {
         return NULL;
     }
-
-    // gh-86160: PyImport_AddModuleObject() returns a borrowed reference
-    PyObject *ref = PyWeakref_NewRef(mod, NULL);
-    Py_DECREF(mod);
-    if (ref == NULL) {
-        return NULL;
-    }
-
-    mod = PyWeakref_GetObject(ref);
-    Py_DECREF(ref);
+    Py_DECREF(mod);  // sys.modules holds a strong reference
     return mod; /* borrowed reference */
 }
 


### PR DESCRIPTION
Rewrite PyImport_AddModule() to simply call Py_DECREF(), rather than creating a weak reference,  to get a borrowed reference to the module.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-105922 -->
* Issue: gh-105922
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--105998.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->