### PR TITLE
gh-105927: Remove _PyWeakref_GetWeakrefCount()

### DIFF
--- a/Include/cpython/weakrefobject.h
+++ b/Include/cpython/weakrefobject.h
@@ -32,10 +32,6 @@ struct _PyWeakReference {
     vectorcallfunc vectorcall;
 };
 
-PyAPI_FUNC(Py_ssize_t) _PyWeakref_GetWeakrefCount(PyWeakReference *head);
-
-PyAPI_FUNC(void) _PyWeakref_ClearRef(PyWeakReference *self);
-
 static inline PyObject* PyWeakref_GET_OBJECT(PyObject *ref_obj) {
     PyWeakReference *ref;
     PyObject *obj;

--- a/Include/internal/pycore_weakref.h
+++ b/Include/internal/pycore_weakref.h
@@ -46,6 +46,10 @@ static inline int _PyWeakref_IS_DEAD(PyObject *ref_obj) {
     return (Py_REFCNT(obj) == 0);
 }
 
+extern Py_ssize_t _PyWeakref_GetWeakrefCount(PyWeakReference *head);
+
+extern void _PyWeakref_ClearRef(PyWeakReference *self);
+
 #ifdef __cplusplus
 }
 #endif

--- a/Modules/_weakref.c
+++ b/Modules/_weakref.c
@@ -89,25 +89,22 @@ static PyObject *
 _weakref_getweakrefs(PyObject *module, PyObject *object)
 /*[clinic end generated code: output=25c7731d8e011824 input=00c6d0e5d3206693]*/
 {
-    PyObject *result = NULL;
-
-    if (_PyType_SUPPORTS_WEAKREFS(Py_TYPE(object))) {
-        PyWeakReference **list = GET_WEAKREFS_LISTPTR(object);
-        Py_ssize_t count = _PyWeakref_GetWeakrefCount(*list);
-
-        result = PyList_New(count);
-        if (result != NULL) {
-            PyWeakReference *current = *list;
-            Py_ssize_t i;
-            for (i = 0; i < count; ++i) {
-                PyList_SET_ITEM(result, i, (PyObject *) current);
-                Py_INCREF(current);
-                current = current->wr_next;
-            }
-        }
+    if (!_PyType_SUPPORTS_WEAKREFS(Py_TYPE(object))) {
+        return PyList_New(0);
     }
-    else {
-        result = PyList_New(0);
+
+    PyWeakReference **list = GET_WEAKREFS_LISTPTR(object);
+    Py_ssize_t count = _PyWeakref_GetWeakrefCount(*list);
+
+    PyObject *result = PyList_New(count);
+    if (result == NULL) {
+        return NULL;
+    }
+
+    PyWeakReference *current = *list;
+    for (Py_ssize_t i = 0; i < count; ++i) {
+        PyList_SET_ITEM(result, i, Py_NewRef(current));
+        current = current->wr_next;
     }
     return result;
 }

--- a/Modules/gcmodule.c
+++ b/Modules/gcmodule.c
@@ -30,6 +30,7 @@
 #include "pycore_object.h"
 #include "pycore_pyerrors.h"
 #include "pycore_pystate.h"     // _PyThreadState_GET()
+#include "pycore_weakref.h"     // _PyWeakref_ClearRef()
 #include "pydtrace.h"
 
 typedef struct _gc_runtime_state GCState;


### PR DESCRIPTION
Remove _PyWeakref_GetWeakrefCount() and _PyWeakref_ClearRef() from the public C API: move them to the internal C API.

Refactor also _weakref_getweakrefs() code to make it more readable.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-105927 -->
* Issue: gh-105927
<!-- /gh-issue-number -->
