### PR TITLE
gh-105063: Disable test_peg_generator.TestCParser bco. ref leaks

### DIFF
--- a/Lib/test/test_peg_generator/test_c_parser.py
+++ b/Lib/test/test_peg_generator/test_c_parser.py
@@ -74,8 +74,18 @@ unittest.main()
 @support.requires_subprocess()
 class TestCParser(unittest.TestCase):
 
+    _has_run = False
+
     @classmethod
     def setUpClass(cls):
+        if cls._has_run:
+            # Since gh-104798 (Use setuptools in peg-generator and reenable
+            # tests), this test case has been producing ref leaks. Initial
+            # debugging points to bug(s) in setuptools and/or importlib.
+            # See gh-105063 for more info.
+            raise unittest.SkipTest("gh-105063: can not rerun because of ref. leaks")
+        cls._has_run = True
+
         # When running under regtest, a separate tempdir is used
         # as the current directory and watched for left-overs.
         # Reusing that as the base for temporary directories


### PR DESCRIPTION
Since gh-104798 (Use setuptools in peg-generator and reenable
tests), the TestCParser test case has been producing ref leaks.


<!-- gh-issue-number: gh-105063 -->
* Issue: gh-105063
<!-- /gh-issue-number -->
