### PR TITLE
gh-106025: Fix incorrect usage of PyUnicode_CompareWithASCIIString in suggestions.c

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2023-06-23-15-03-41.gh-issue-106025.Ij5Bnn.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2023-06-23-15-03-41.gh-issue-106025.Ij5Bnn.rst
@@ -1,0 +1,2 @@
+Fix incorrect usage of :c:func:`PyUnicode_CompareWithASCIIString` in
+``suggestions.c``. Patch by Pablo Galindo

--- a/Python/suggestions.c
+++ b/Python/suggestions.c
@@ -157,7 +157,7 @@ calculate_suggestions(PyObject *dir,
             PyMem_Free(buffer);
             return NULL;
         }
-        if (PyUnicode_CompareWithASCIIString(name, item_str) == 0) {
+        if (PyUnicode_Compare(name, item) == 0) {
             continue;
         }
         // No more than 1/3 of the involved characters should need changed.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-106025 -->
* Issue: gh-106025
<!-- /gh-issue-number -->
