### PR TITLE
GH-106037: Disarm `os.PathLike` foot-shotgun in `pathlib.PurePath` user subclasses

### DIFF
--- a/Lib/test/test_pathlib.py
+++ b/Lib/test/test_pathlib.py
@@ -1545,6 +1545,15 @@ class PurePathSubclassTest(PurePathTest):
     # repr() roundtripping is not supported in custom subclass.
     test_repr_roundtrips = None
 
+    # PurePath subclass is not automatically path-like
+    def test_fspath_common(self):
+        P = self.cls
+        p = P()
+        self.assertFalse(issubclass(P, os.PathLike))
+        self.assertFalse(isinstance(p, os.PathLike))
+        with self.assertRaises(TypeError):
+            os.fspath(p)
+
 
 @only_posix
 class PosixPathAsPureTest(PurePosixPathTest):

--- a/Misc/NEWS.d/next/Library/2023-06-23-18-23-18.gh-issue-106037.hLb-E3.rst
+++ b/Misc/NEWS.d/next/Library/2023-06-23-18-23-18.gh-issue-106037.hLb-E3.rst
@@ -1,0 +1,3 @@
+Fix misidentification of :class:`pathlib.PurePath` user subclasses as
+:class:`os.PathLike`. Subclasses are free to define an
+:meth:`~os.PathLike.__fspath__` method, but do not inherit one.


### PR DESCRIPTION
We made it possible to subclass `pathlib.PurePath` in a68e585, which landed in 3.12. However, user subclasses automatically inherit an `__fspath__()` method, which may not be appropriate. For example, a user subclass may implement a "virtual" filesystem to provide access to a `.zip` file or FTP server. But it would be highly surprising if `open(FTPPath(...))` attempted to open a *local* file.

This patch makes the `os.PathLike` interface opt-in for `pathlib.PurePath` subclasses. In pathlib itself, we opt into the `os.PathLike` interface for `PurePosixPath`, `PureWindowsPath` and `Path`. As `PurePath` is not instantiable (you always get a `PurePosixPath` or `PureWindowsPath` object back), this is backwards compatible with 3.11.

<!-- gh-issue-number: gh-106037 -->
* Issue: gh-106037
<!-- /gh-issue-number -->
