### PR TITLE
gh-106033: [docs] Improve C API GetItem & HasAttr notes.

### DIFF
--- a/Doc/c-api/dict.rst
+++ b/Doc/c-api/dict.rst
@@ -101,7 +101,7 @@ Dictionary Objects
    .. caution::
 
       Exceptions that occur while this calls :meth:`~object.__hash__` and
-      :meth:`__eq__` methods are silently ignored.
+      :meth:`~object.__eq__` methods are silently ignored.
       Prefer the :c:func:`PyDict_GetItemWithError` function instead.
 
    .. versionchanged:: 3.10

--- a/Doc/c-api/dict.rst
+++ b/Doc/c-api/dict.rst
@@ -98,9 +98,11 @@ Dictionary Objects
    Return the object from dictionary *p* which has a key *key*.  Return ``NULL``
    if the key *key* is not present, but *without* setting an exception.
 
-   Note that exceptions which occur while calling :meth:`__hash__` and
-   :meth:`__eq__` methods will get suppressed.
-   To get error reporting use :c:func:`PyDict_GetItemWithError()` instead.
+   .. note::
+
+      Exceptions that occur while this calls :meth:`__hash__` and
+      :meth:`__eq__` methods are silently ignored.
+      Prefer the :c:func:`PyDict_GetItemWithError` function instead.
 
    .. versionchanged:: 3.10
       Calling this API without :term:`GIL` held had been allowed for historical
@@ -120,10 +122,13 @@ Dictionary Objects
    This is the same as :c:func:`PyDict_GetItem`, but *key* is specified as a
    :c:expr:`const char*`, rather than a :c:expr:`PyObject*`.
 
-   Note that exceptions which occur while calling :meth:`__hash__` and
-   :meth:`__eq__` methods and creating a temporary string object
-   will get suppressed.
-   To get error reporting use :c:func:`PyDict_GetItemWithError()` instead.
+   .. note::
+
+      Exceptions that occur while this calls :meth:`__hash__` and
+      :meth:`__eq__` methods or while creating the temporary ``str``
+      object are silently ignored.
+      Prefer using the :c:func:`PyDict_GetItemWithError` function with your own
+      :c:func:`PyUnicode_FromString` *key* instead.
 
 
 .. c:function:: PyObject* PyDict_SetDefault(PyObject *p, PyObject *key, PyObject *defaultobj)

--- a/Doc/c-api/dict.rst
+++ b/Doc/c-api/dict.rst
@@ -122,7 +122,7 @@ Dictionary Objects
    This is the same as :c:func:`PyDict_GetItem`, but *key* is specified as a
    :c:expr:`const char*`, rather than a :c:expr:`PyObject*`.
 
-   .. note::
+   .. caution::
 
       Exceptions that occur while this calls :meth:`~object.__hash__` and
       :meth:`~object.__eq__` methods or while creating the temporary :class:`str`

--- a/Doc/c-api/dict.rst
+++ b/Doc/c-api/dict.rst
@@ -98,7 +98,7 @@ Dictionary Objects
    Return the object from dictionary *p* which has a key *key*.  Return ``NULL``
    if the key *key* is not present, but *without* setting an exception.
 
-   .. caution::
+   .. note::
 
       Exceptions that occur while this calls :meth:`~object.__hash__` and
       :meth:`~object.__eq__` methods are silently ignored.
@@ -122,7 +122,7 @@ Dictionary Objects
    This is the same as :c:func:`PyDict_GetItem`, but *key* is specified as a
    :c:expr:`const char*`, rather than a :c:expr:`PyObject*`.
 
-   .. caution::
+   .. note::
 
       Exceptions that occur while this calls :meth:`~object.__hash__` and
       :meth:`~object.__eq__` methods or while creating the temporary :class:`str`

--- a/Doc/c-api/dict.rst
+++ b/Doc/c-api/dict.rst
@@ -124,7 +124,7 @@ Dictionary Objects
 
    .. note::
 
-      Exceptions that occur while this calls :meth:`__hash__` and
+      Exceptions that occur while this calls :meth:`~object.__hash__` and
       :meth:`~object.__eq__` methods or while creating the temporary :class:`str`
       object are silently ignored.
       Prefer using the :c:func:`PyDict_GetItemWithError` function with your own

--- a/Doc/c-api/dict.rst
+++ b/Doc/c-api/dict.rst
@@ -125,7 +125,7 @@ Dictionary Objects
    .. note::
 
       Exceptions that occur while this calls :meth:`__hash__` and
-      :meth:`__eq__` methods or while creating the temporary ``str``
+      :meth:`~object.__eq__` methods or while creating the temporary :class:`str`
       object are silently ignored.
       Prefer using the :c:func:`PyDict_GetItemWithError` function with your own
       :c:func:`PyUnicode_FromString` *key* instead.

--- a/Doc/c-api/dict.rst
+++ b/Doc/c-api/dict.rst
@@ -98,7 +98,7 @@ Dictionary Objects
    Return the object from dictionary *p* which has a key *key*.  Return ``NULL``
    if the key *key* is not present, but *without* setting an exception.
 
-   .. note::
+   .. caution::
 
       Exceptions that occur while this calls :meth:`__hash__` and
       :meth:`__eq__` methods are silently ignored.

--- a/Doc/c-api/dict.rst
+++ b/Doc/c-api/dict.rst
@@ -100,7 +100,7 @@ Dictionary Objects
 
    .. caution::
 
-      Exceptions that occur while this calls :meth:`__hash__` and
+      Exceptions that occur while this calls :meth:`~object.__hash__` and
       :meth:`__eq__` methods are silently ignored.
       Prefer the :c:func:`PyDict_GetItemWithError` function instead.
 

--- a/Doc/c-api/object.rst
+++ b/Doc/c-api/object.rst
@@ -33,9 +33,11 @@ Object Protocol
    is equivalent to the Python expression ``hasattr(o, attr_name)``.  This function
    always succeeds.
 
-   Note that exceptions which occur while calling :meth:`__getattr__` and
-   :meth:`__getattribute__` methods will get suppressed.
-   To get error reporting use :c:func:`PyObject_GetAttr()` instead.
+   .. note::
+
+      Exceptions that occur when this calls :meth:`__getattr__` and
+      :meth:`__getattribute__` methods are silently ignored.
+      For proper error handling, use :c:func:`PyObject_GetAttr` instead.
 
 
 .. c:function:: int PyObject_HasAttrString(PyObject *o, const char *attr_name)
@@ -44,10 +46,12 @@ Object Protocol
    is equivalent to the Python expression ``hasattr(o, attr_name)``.  This function
    always succeeds.
 
-   Note that exceptions which occur while calling :meth:`__getattr__` and
-   :meth:`__getattribute__` methods and creating a temporary string object
-   will get suppressed.
-   To get error reporting use :c:func:`PyObject_GetAttrString()` instead.
+   .. note::
+
+      Exceptions that occur when this calls :meth:`__getattr__` and
+      :meth:`__getattribute__` methods or while creating the temporary ``str``
+      object are silently ignored.
+      For proper error handling, use :c:func:`PyObject_GetAttrString` instead.
 
 
 .. c:function:: PyObject* PyObject_GetAttr(PyObject *o, PyObject *attr_name)

--- a/Doc/c-api/object.rst
+++ b/Doc/c-api/object.rst
@@ -33,7 +33,7 @@ Object Protocol
    is equivalent to the Python expression ``hasattr(o, attr_name)``.  This function
    always succeeds.
 
-   .. note::
+   .. caution::
 
       Exceptions that occur when this calls :meth:`__getattr__` and
       :meth:`__getattribute__` methods are silently ignored.

--- a/Doc/c-api/object.rst
+++ b/Doc/c-api/object.rst
@@ -48,7 +48,7 @@ Object Protocol
 
    .. note::
 
-      Exceptions that occur when this calls :meth:`__getattr__` and
+      Exceptions that occur when this calls :meth:`~object.__getattr__` and
       :meth:`__getattribute__` methods or while creating the temporary ``str``
       object are silently ignored.
       For proper error handling, use :c:func:`PyObject_GetAttrString` instead.

--- a/Doc/c-api/object.rst
+++ b/Doc/c-api/object.rst
@@ -49,7 +49,7 @@ Object Protocol
    .. note::
 
       Exceptions that occur when this calls :meth:`~object.__getattr__` and
-      :meth:`__getattribute__` methods or while creating the temporary ``str``
+      :meth:`~object.__getattribute__` methods or while creating the temporary :class:`str`
       object are silently ignored.
       For proper error handling, use :c:func:`PyObject_GetAttrString` instead.
 

--- a/Doc/c-api/object.rst
+++ b/Doc/c-api/object.rst
@@ -35,7 +35,7 @@ Object Protocol
 
    .. caution::
 
-      Exceptions that occur when this calls :meth:`__getattr__` and
+      Exceptions that occur when this calls :meth:`~object.__getattr__` and
       :meth:`~object.__getattribute__` methods are silently ignored.
       For proper error handling, use :c:func:`PyObject_GetAttr` instead.
 

--- a/Doc/c-api/object.rst
+++ b/Doc/c-api/object.rst
@@ -46,7 +46,7 @@ Object Protocol
    is equivalent to the Python expression ``hasattr(o, attr_name)``.  This function
    always succeeds.
 
-   .. note::
+   .. caution::
 
       Exceptions that occur when this calls :meth:`~object.__getattr__` and
       :meth:`~object.__getattribute__` methods or while creating the temporary :class:`str`

--- a/Doc/c-api/object.rst
+++ b/Doc/c-api/object.rst
@@ -33,7 +33,7 @@ Object Protocol
    is equivalent to the Python expression ``hasattr(o, attr_name)``.  This function
    always succeeds.
 
-   .. caution::
+   .. note::
 
       Exceptions that occur when this calls :meth:`~object.__getattr__` and
       :meth:`~object.__getattribute__` methods are silently ignored.
@@ -46,7 +46,7 @@ Object Protocol
    is equivalent to the Python expression ``hasattr(o, attr_name)``.  This function
    always succeeds.
 
-   .. caution::
+   .. note::
 
       Exceptions that occur when this calls :meth:`~object.__getattr__` and
       :meth:`~object.__getattribute__` methods or while creating the temporary :class:`str`

--- a/Doc/c-api/object.rst
+++ b/Doc/c-api/object.rst
@@ -36,7 +36,7 @@ Object Protocol
    .. caution::
 
       Exceptions that occur when this calls :meth:`__getattr__` and
-      :meth:`__getattribute__` methods are silently ignored.
+      :meth:`~object.__getattribute__` methods are silently ignored.
       For proper error handling, use :c:func:`PyObject_GetAttr` instead.
 
 


### PR DESCRIPTION
This should format the notes and call out the preferred APIs to use in a more visible manner.

<!-- gh-issue-number: gh-106033 -->
* Issue: gh-106033
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--106047.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->