### PR TITLE
[3.12] GH-104375: Use `versionchanged` to describe new arguments in pathlib docs (GH-104376).

### DIFF
--- a/Doc/library/pathlib.rst
+++ b/Doc/library/pathlib.rst
@@ -585,8 +585,8 @@ Pure paths provide the following methods and properties:
 
    Set *case_sensitive* to ``True`` or ``False`` to override this behaviour.
 
-   .. versionadded:: 3.12
-      The *case_sensitive* argument.
+   .. versionchanged:: 3.12
+      The *case_sensitive* parameter was added.
 
 
 .. method:: PurePath.relative_to(other, walk_up=False)
@@ -627,8 +627,8 @@ Pure paths provide the following methods and properties:
       are present in the path; call :meth:`~Path.resolve` first if
       necessary to resolve symlinks.
 
-   .. versionadded:: 3.12
-      The *walk_up* argument (old behavior is the same as ``walk_up=False``).
+   .. versionchanged:: 3.12
+      The *walk_up* parameter was added (old behavior is the same as ``walk_up=False``).
 
    .. deprecated-removed:: 3.12 3.14
 
@@ -928,8 +928,9 @@ call fails (for example because the path doesn't exist).
       Return only directories if *pattern* ends with a pathname components
       separator (:data:`~os.sep` or :data:`~os.altsep`).
 
-   .. versionadded:: 3.12
-      The *case_sensitive* argument.
+   .. versionchanged:: 3.12
+      The *case_sensitive* parameter was added.
+
 
 .. method:: Path.group()
 
@@ -1313,8 +1314,8 @@ call fails (for example because the path doesn't exist).
    infinite loop is encountered along the resolution path, :exc:`RuntimeError`
    is raised.
 
-   .. versionadded:: 3.6
-      The *strict* argument (pre-3.6 behavior is strict).
+   .. versionchanged:: 3.6
+      The *strict* parameter was added (pre-3.6 behavior is strict).
 
 .. method:: Path.rglob(pattern, *, case_sensitive=None)
 
@@ -1340,8 +1341,9 @@ call fails (for example because the path doesn't exist).
       Return only directories if *pattern* ends with a pathname components
       separator (:data:`~os.sep` or :data:`~os.altsep`).
 
-   .. versionadded:: 3.12
-      The *case_sensitive* argument.
+   .. versionchanged:: 3.12
+      The *case_sensitive* parameter was added.
+
 
 .. method:: Path.rmdir()
 


### PR DESCRIPTION
(cherry picked from commit 4a6c84fc1ea8f26d84a0fbeeff6f8dedc32263d4)

<!-- gh-issue-number: gh-104375 -->
* Issue: gh-104375
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--106058.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->