### PR TITLE
Add end-of-file-fixer to pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,8 @@ repos:
     hooks:
       - id: check-yaml
       - id: end-of-file-fixer
-        types_or: [python]
+        types: [python]
+        exclude: Lib/test/coding20731.py
       - id: trailing-whitespace
         types_or: [c, python, rst]
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,6 +3,8 @@ repos:
     rev: v4.4.0
     hooks:
       - id: check-yaml
+      - id: end-of-file-fixer
+        types_or: [python]
       - id: trailing-whitespace
         types_or: [c, python, rst]
 

--- a/Lib/test/coding20731.py
+++ b/Lib/test/coding20731.py
@@ -1,1 +1,4 @@
 #coding:latin1
+
+
+

--- a/Lib/test/coding20731.py
+++ b/Lib/test/coding20731.py
@@ -1,4 +1,1 @@
 #coding:latin1
-
-
-


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

Follow on from https://github.com/python/cpython/pull/104275.

This adds a check that is part of `make patchcheck`'s `normalize_whitespace(python_files)` to pre-commit, which showed up in PR https://github.com/python/cpython/pull/105984:

```
Getting base branch for PR ... origin/main
Getting the list of files that have been added/changed ... 3 files
Fixing Python file whitespace ... 1 file:
  Lib/test/test_webbrowser.py
Fixing C file whitespace ... 0 files
Fixing docs whitespace ... 0 files
Please fix the 1 file(s) with whitespace issues
(on UNIX you can run `make patchcheck` to make the fixes)
##[error]Bash exited with code '1'.
```

https://dev.azure.com/Python/cpython/_build/results?buildId=130810&view=logs&j=256d7e09-002a-52d7-8661-29ee3960640e&t=3d7276d3-4e8d-5309-55ad-fb0b172d9925

Adding here will make the failure more visible, and show the actual change needed.

I'll push another temporary commit to demonstrate.