### PR TITLE
gh-104527: zippapp will now avoid appending an archive to itself.

### DIFF
--- a/Lib/zipapp.py
+++ b/Lib/zipapp.py
@@ -138,7 +138,7 @@ def create_archive(source, target=None, interpreter=None, main=None,
         with zipfile.ZipFile(fd, 'w', compression=compression) as z:
             for child in sorted(source.rglob('*')):
                 arcname = child.relative_to(source)
-                if filter is None or filter(arcname):
+                if filter is None or filter(arcname) and child.resolve() != arcname.resolve():
                     z.write(child, arcname.as_posix())
             if main_py:
                 z.writestr('__main__.py', main_py.encode('utf-8'))

--- a/Misc/NEWS.d/next/Library/2023-06-25-06-57-24.gh-issue-104527.TJEUkd.rst
+++ b/Misc/NEWS.d/next/Library/2023-06-25-06-57-24.gh-issue-104527.TJEUkd.rst
@@ -1,0 +1,1 @@
+Zipapp will now skip over apending an archive to itself.


### PR DESCRIPTION
While #104857 does add an error message that makes it much easier to figure out what is going wrong when calling zipfile.write, some of the stdlib uses of zipfile will run into this issue when recursively zipping a directory into an archive that is a child of said directory.

Sometimes, esp. in zipapp, the desired behavior is to place the contents of foo into foo/deploy.zip, or something like that. (case in point, I discovered #104527 from a project that was trying to do just that.) In this case, zippapp should not simply throw the error that #104857 is adding, but skip over the target archive.

(should I submit another PR doing the same thing for shutil.make_archive, or should we let that one fail with an error?)

<!-- gh-issue-number: gh-104527 -->
* Issue: gh-104527
<!-- /gh-issue-number -->
