### PR TITLE
gh-106084: Remove old PyObject call aliases

### DIFF
--- a/Doc/whatsnew/3.13.rst
+++ b/Doc/whatsnew/3.13.rst
@@ -568,3 +568,17 @@ Removed
   <https://github.com/python/pythoncapi-compat/>`_ can be used to get this
   function on Python 3.8 and older.
   (Contributed by Victor Stinner in :gh:`105268`.)
+
+* Remove the old aliases to functions calling functions which were kept for
+  backward compatibility with Python 3.8 provisional API:
+
+  * ``_PyObject_CallMethodNoArgs()``: use ``PyObject_CallMethodNoArgs()``
+  * ``_PyObject_CallMethodOneArg()``: use ``PyObject_CallMethodOneArg()``
+  * ``_PyObject_CallOneArg()``: use ``PyObject_CallOneArg()``
+  * ``_PyObject_FastCallDict()``: use ``PyObject_VectorcallDict()``
+  * ``_PyObject_Vectorcall()``: use ``PyObject_Vectorcall()``
+  * ``_PyObject_VectorcallMethod()``: use ``PyObject_VectorcallMethod()``
+  * ``_PyVectorcall_Function()``: use ``PyVectorcall_Function()``
+
+  Just remove the underscore prefix to update your code.
+  (Contributed by Victor Stinner in :gh:`106084`.)

--- a/Include/cpython/abstract.h
+++ b/Include/cpython/abstract.h
@@ -58,15 +58,6 @@ _PyVectorcall_NARGS(size_t n)
 
 PyAPI_FUNC(vectorcallfunc) PyVectorcall_Function(PyObject *callable);
 
-// Backwards compatibility aliases for API that was provisional in Python 3.8
-#define _PyObject_Vectorcall PyObject_Vectorcall
-#define _PyObject_VectorcallMethod PyObject_VectorcallMethod
-#define _PyObject_FastCallDict PyObject_VectorcallDict
-#define _PyVectorcall_Function PyVectorcall_Function
-#define _PyObject_CallOneArg PyObject_CallOneArg
-#define _PyObject_CallMethodNoArgs PyObject_CallMethodNoArgs
-#define _PyObject_CallMethodOneArg PyObject_CallMethodOneArg
-
 /* Same as PyObject_Vectorcall except that keyword arguments are passed as
    dict, which may be NULL if there are no keyword arguments. */
 PyAPI_FUNC(PyObject *) PyObject_VectorcallDict(

--- a/Misc/NEWS.d/next/C API/2023-06-25-18-01-27.gh-issue-106084.PEzqU3.rst
+++ b/Misc/NEWS.d/next/C API/2023-06-25-18-01-27.gh-issue-106084.PEzqU3.rst
@@ -1,0 +1,13 @@
+Remove the old aliases to functions calling functions which were kept for
+backward compatibility with Python 3.8 provisional API:
+
+* ``_PyObject_CallMethodNoArgs()``: use ``PyObject_CallMethodNoArgs()``
+* ``_PyObject_CallMethodOneArg()``: use ``PyObject_CallMethodOneArg()``
+* ``_PyObject_CallOneArg()``: use ``PyObject_CallOneArg()``
+* ``_PyObject_FastCallDict()``: use ``PyObject_VectorcallDict()``
+* ``_PyObject_Vectorcall()``: use ``PyObject_Vectorcall()``
+* ``_PyObject_VectorcallMethod()``: use ``PyObject_VectorcallMethod()``
+* ``_PyVectorcall_Function()``: use ``PyVectorcall_Function()``
+
+Just remove the underscore prefix to update your code. Patch by Victor
+Stinner.

--- a/Modules/_functoolsmodule.c
+++ b/Modules/_functoolsmodule.c
@@ -276,7 +276,7 @@ partial_vectorcall(partialobject *pto, PyObject *const *args,
 static void
 partial_setvectorcall(partialobject *pto)
 {
-    if (_PyVectorcall_Function(pto->fn) == NULL) {
+    if (PyVectorcall_Function(pto->fn) == NULL) {
         /* Don't use vectorcall if the underlying function doesn't support it */
         pto->vectorcall = NULL;
     }

--- a/Modules/cjkcodecs/multibytecodec.c
+++ b/Modules/cjkcodecs/multibytecodec.c
@@ -1715,7 +1715,7 @@ mbstreamwriter_iwrite(MultibyteStreamWriterObject *self,
     if (str == NULL)
         return -1;
 
-    wr = _PyObject_CallMethodOneArg(self->stream, str_write, str);
+    wr = PyObject_CallMethodOneArg(self->stream, str_write, str);
     Py_DECREF(str);
     if (wr == NULL)
         return -1;
@@ -1826,7 +1826,7 @@ _multibytecodec_MultibyteStreamWriter_reset_impl(MultibyteStreamWriterObject *se
     if (PyBytes_Size(pwrt) > 0) {
         PyObject *wr;
 
-        wr = _PyObject_CallMethodOneArg(self->stream, state->str_write, pwrt);
+        wr = PyObject_CallMethodOneArg(self->stream, state->str_write, pwrt);
         if (wr == NULL) {
             Py_DECREF(pwrt);
             return NULL;

--- a/Objects/call.c
+++ b/Objects/call.c
@@ -122,7 +122,7 @@ _PyObject_FastCallDictTstate(PyThreadState *tstate, PyObject *callable,
     assert(nargs == 0 || args != NULL);
     assert(kwargs == NULL || PyDict_Check(kwargs));
 
-    vectorcallfunc func = _PyVectorcall_Function(callable);
+    vectorcallfunc func = PyVectorcall_Function(callable);
     if (func == NULL) {
         /* Use tp_call instead */
         return _PyObject_MakeTpCall(tstate, callable, args, nargs, kwargs);
@@ -349,7 +349,7 @@ _PyObject_Call(PyThreadState *tstate, PyObject *callable,
     assert(PyTuple_Check(args));
     assert(kwargs == NULL || PyDict_Check(kwargs));
     EVAL_CALL_STAT_INC_IF_FUNCTION(EVAL_CALL_API, callable);
-    vectorcallfunc vector_func = _PyVectorcall_Function(callable);
+    vectorcallfunc vector_func = PyVectorcall_Function(callable);
     if (vector_func != NULL) {
         return _PyVectorcall_Call(tstate, vector_func, callable, args, kwargs);
     }

--- a/Objects/descrobject.c
+++ b/Objects/descrobject.c
@@ -1110,9 +1110,9 @@ mappingproxy_get(mappingproxyobject *pp, PyObject *const *args, Py_ssize_t nargs
     {
         return NULL;
     }
-    return _PyObject_VectorcallMethod(&_Py_ID(get), newargs,
-                                        3 | PY_VECTORCALL_ARGUMENTS_OFFSET,
-                                        NULL);
+    return PyObject_VectorcallMethod(&_Py_ID(get), newargs,
+                                     3 | PY_VECTORCALL_ARGUMENTS_OFFSET,
+                                     NULL);
 }
 
 static PyObject *

--- a/Python/errors.c
+++ b/Python/errors.c
@@ -1485,7 +1485,7 @@ write_unraisable_exc_file(PyThreadState *tstate, PyObject *exc_type,
     }
 
     /* Explicitly call file.flush() */
-    PyObject *res = _PyObject_CallMethodNoArgs(file, &_Py_ID(flush));
+    PyObject *res = PyObject_CallMethodNoArgs(file, &_Py_ID(flush));
     if (!res) {
         return -1;
     }

--- a/Python/import.c
+++ b/Python/import.c
@@ -278,7 +278,7 @@ import_ensure_initialized(PyInterpreterState *interp, PyObject *mod, PyObject *n
     Py_XDECREF(spec);
     if (busy) {
         /* Wait until module is done importing. */
-        PyObject *value = _PyObject_CallMethodOneArg(
+        PyObject *value = PyObject_CallMethodOneArg(
             IMPORTLIB(interp), &_Py_ID(_lock_unlock_module), name);
         if (value == NULL) {
             return -1;
@@ -1660,7 +1660,7 @@ PyImport_ExecCodeModuleWithPathnames(const char *name, PyObject *co,
         external= PyObject_GetAttrString(IMPORTLIB(interp),
                                          "_bootstrap_external");
         if (external != NULL) {
-            pathobj = _PyObject_CallMethodOneArg(
+            pathobj = PyObject_CallMethodOneArg(
                 external, &_Py_ID(_get_sourcefile), cpathobj);
             Py_DECREF(external);
         }

--- a/Python/marshal.c
+++ b/Python/marshal.c
@@ -1707,7 +1707,7 @@ marshal_dump_impl(PyObject *module, PyObject *value, PyObject *file,
     s = PyMarshal_WriteObjectToString(value, version);
     if (s == NULL)
         return NULL;
-    res = _PyObject_CallMethodOneArg(file, &_Py_ID(write), s);
+    res = PyObject_CallMethodOneArg(file, &_Py_ID(write), s);
     Py_DECREF(s);
     return res;
 }

--- a/Python/pythonrun.c
+++ b/Python/pythonrun.c
@@ -1565,7 +1565,7 @@ _PyErr_Display(PyObject *file, PyObject *unused, PyObject *value, PyObject *tb)
     Py_XDECREF(ctx.seen);
 
     /* Call file.flush() */
-    PyObject *res = _PyObject_CallMethodNoArgs(file, &_Py_ID(flush));
+    PyObject *res = PyObject_CallMethodNoArgs(file, &_Py_ID(flush));
     if (!res) {
         /* Silently ignore file.flush() error */
         PyErr_Clear();
@@ -1677,7 +1677,7 @@ flush_io_stream(PyThreadState *tstate, PyObject *name)
 {
     PyObject *f = _PySys_GetAttr(tstate, name);
     if (f != NULL) {
-        PyObject *r = _PyObject_CallMethodNoArgs(f, &_Py_ID(flush));
+        PyObject *r = PyObject_CallMethodNoArgs(f, &_Py_ID(flush));
         if (r) {
             Py_DECREF(r);
         }

--- a/Python/sysmodule.c
+++ b/Python/sysmodule.c
@@ -3756,7 +3756,7 @@ sys_pyfile_write_unicode(PyObject *unicode, PyObject *file)
     if (file == NULL)
         return -1;
     assert(unicode != NULL);
-    PyObject *result = _PyObject_CallMethodOneArg(file, &_Py_ID(write), unicode);
+    PyObject *result = PyObject_CallMethodOneArg(file, &_Py_ID(write), unicode);
     if (result == NULL) {
         return -1;
     }


### PR DESCRIPTION
Remove old aliases which were kept backwards compatibility with Python 3.8:

* _PyObject_CallMethodNoArgs()
* _PyObject_CallMethodOneArg()
* _PyObject_CallOneArg()
* _PyObject_FastCallDict()
* _PyObject_Vectorcall()
* _PyObject_VectorcallMethod()
* _PyVectorcall_Function()

Update code which used these aliases to use new names.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-106084 -->
* Issue: gh-106084
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--106085.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->