### PR TITLE
gh-106084: Remove _PyObject_HasLen() function

### DIFF
--- a/Include/cpython/abstract.h
+++ b/Include/cpython/abstract.h
@@ -133,8 +133,6 @@ _PyObject_CallMethodIdOneArg(PyObject *self, _Py_Identifier *name, PyObject *arg
     return _PyObject_VectorcallMethodId(name, args, nargsf, _Py_NULL);
 }
 
-PyAPI_FUNC(int) _PyObject_HasLen(PyObject *o);
-
 /* Guess the size of object 'o' using len(o) or o.__length_hint__().
    If neither of those return a non-negative value, then return the default
    value.  If one of the calls fails, this function returns -1. */
@@ -146,24 +144,6 @@ PyAPI_FUNC(Py_ssize_t) PyObject_LengthHint(PyObject *o, Py_ssize_t);
    need to be corrected for a negative index. */
 #define PySequence_ITEM(o, i)\
     ( Py_TYPE(o)->tp_as_sequence->sq_item((o), (i)) )
-
-#define PY_ITERSEARCH_COUNT    1
-#define PY_ITERSEARCH_INDEX    2
-#define PY_ITERSEARCH_CONTAINS 3
-
-/* Iterate over seq.
-
-   Result depends on the operation:
-
-   PY_ITERSEARCH_COUNT:  return # of times obj appears in seq; -1 if
-     error.
-   PY_ITERSEARCH_INDEX:  return 0-based index of first occurrence of
-     obj in seq; set ValueError and return -1 if none found;
-     also return -1 on error.
-   PY_ITERSEARCH_CONTAINS:  return 1 if obj in seq, else 0; -1 on
-     error. */
-PyAPI_FUNC(Py_ssize_t) _PySequence_IterSearch(PyObject *seq,
-                                              PyObject *obj, int operation);
 
 /* === Mapping protocol ================================================= */
 

--- a/Include/internal/pycore_abstract.h
+++ b/Include/internal/pycore_abstract.h
@@ -19,6 +19,28 @@ _PyIndex_Check(PyObject *obj)
 PyObject *_PyNumber_PowerNoMod(PyObject *lhs, PyObject *rhs);
 PyObject *_PyNumber_InPlacePowerNoMod(PyObject *lhs, PyObject *rhs);
 
+extern int _PyObject_HasLen(PyObject *o);
+
+/* === Sequence protocol ================================================ */
+
+#define PY_ITERSEARCH_COUNT    1
+#define PY_ITERSEARCH_INDEX    2
+#define PY_ITERSEARCH_CONTAINS 3
+
+/* Iterate over seq.
+
+   Result depends on the operation:
+
+   PY_ITERSEARCH_COUNT:  return # of times obj appears in seq; -1 if
+     error.
+   PY_ITERSEARCH_INDEX:  return 0-based index of first occurrence of
+     obj in seq; set ValueError and return -1 if none found;
+     also return -1 on error.
+   PY_ITERSEARCH_CONTAINS:  return 1 if obj in seq, else 0; -1 on
+     error. */
+extern Py_ssize_t _PySequence_IterSearch(PyObject *seq,
+                                         PyObject *obj, int operation);
+
 #ifdef __cplusplus
 }
 #endif

--- a/Objects/iterobject.c
+++ b/Objects/iterobject.c
@@ -1,6 +1,7 @@
 /* Iterator objects */
 
 #include "Python.h"
+#include "pycore_abstract.h"      // _PyObject_HasLen()
 #include "pycore_call.h"          // _PyObject_CallNoArgs()
 #include "pycore_object.h"        // _PyObject_GC_TRACK()
 

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -1,11 +1,11 @@
 /* Type object implementation */
 
 #include "Python.h"
-#include "pycore_call.h"
+#include "pycore_abstract.h"      // _PySequence_IterSearch()
+#include "pycore_call.h"          // _PyObject_VectorcallTstate()
 #include "pycore_code.h"          // CO_FAST_FREE
 #include "pycore_dict.h"          // _PyDict_KeysSize()
 #include "pycore_frame.h"         // _PyInterpreterFrame
-#include "pycore_initconfig.h"    // _PyStatus_OK()
 #include "pycore_long.h"          // _PyLong_IsNegative()
 #include "pycore_memoryobject.h"  // _PyMemoryView_FromBufferProc()
 #include "pycore_moduleobject.h"  // _PyModule_GetDef()


### PR DESCRIPTION
Remove _PyObject_HasLen() and _PySequence_IterSearch() functions from the public C API: move them to the internal C API
(pycore_abstract.h).

Remove also unused pycore_initconfig.h include in typeobject.c.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-106084 -->
* Issue: gh-106084
<!-- /gh-issue-number -->
