### PR TITLE
gh-106104: Use public weakref APIs in sqlite3

### DIFF
--- a/Modules/_sqlite/blob.c
+++ b/Modules/_sqlite/blob.c
@@ -1,10 +1,5 @@
-#ifndef Py_BUILD_CORE_BUILTIN
-#  define Py_BUILD_CORE_MODULE 1
-#endif
-
 #include "blob.h"
 #include "util.h"
-#include "pycore_weakref.h"       // _PyWeakref_GET_REF()
 
 #define clinic_state() (pysqlite_get_state_by_type(Py_TYPE(self)))
 #include "clinic/blob.c.h"
@@ -102,12 +97,18 @@ pysqlite_close_all_blobs(pysqlite_Connection *self)
 {
     for (int i = 0; i < PyList_GET_SIZE(self->blobs); i++) {
         PyObject *weakref = PyList_GET_ITEM(self->blobs, i);
-        PyObject *blob = _PyWeakref_GET_REF(weakref);
-        if (blob == NULL) {
+        PyObject *blob;
+        if (!PyWeakref_Check(weakref)) {
             continue;
         }
-        close_blob((pysqlite_Blob *)blob);
-        Py_DECREF(blob);
+        if (PyWeakref_GetRef(weakref, &blob) < 0) {
+            PyErr_WriteUnraisable((PyObject *)self);
+            continue;
+        }
+        if (blob) {
+            close_blob((pysqlite_Blob *)blob);
+            Py_DECREF(blob);
+        }
     }
 }
 

--- a/Modules/_sqlite/blob.c
+++ b/Modules/_sqlite/blob.c
@@ -97,10 +97,10 @@ pysqlite_close_all_blobs(pysqlite_Connection *self)
 {
     for (int i = 0; i < PyList_GET_SIZE(self->blobs); i++) {
         PyObject *weakref = PyList_GET_ITEM(self->blobs, i);
-        PyObject *blob;
         if (!PyWeakref_Check(weakref)) {
             continue;
         }
+        PyObject *blob;
         if (PyWeakref_GetRef(weakref, &blob) < 0) {
             PyErr_WriteUnraisable((PyObject *)self);
             continue;

--- a/Modules/_sqlite/connection.c
+++ b/Modules/_sqlite/connection.c
@@ -983,10 +983,10 @@ static void _pysqlite_drop_unused_cursor_references(pysqlite_Connection* self)
 
     for (Py_ssize_t i = 0; i < PyList_Size(self->cursors); i++) {
         PyObject *weakref = PyList_GetItem(self->cursors, i);
-        PyObject *item;
         if (!PyWeakref_Check(weakref)) {
             continue;
         }
+        PyObject *item;
         if (PyWeakref_GetRef(weakref, &item) < 0) {
             PyErr_WriteUnraisable((PyObject *)self);
             continue;


### PR DESCRIPTION
The sqlite3 extension module should be built using the public API, so
we're removing the Py_BUILD_CORE_MODULE define that was introduced as
part of the gh-105927 changes.


<!-- gh-issue-number: gh-106104 -->
* Issue: gh-106104
<!-- /gh-issue-number -->
