### PR TITLE
gh-106084: Remove _PyObject_RealIsInstance() function

### DIFF
--- a/Include/cpython/abstract.h
+++ b/Include/cpython/abstract.h
@@ -147,18 +147,10 @@ PyAPI_FUNC(Py_ssize_t) PyObject_LengthHint(PyObject *o, Py_ssize_t);
 
 /* === Mapping protocol ================================================= */
 
-PyAPI_FUNC(int) _PyObject_RealIsInstance(PyObject *inst, PyObject *cls);
-
-PyAPI_FUNC(int) _PyObject_RealIsSubclass(PyObject *derived, PyObject *cls);
-
-/* For internal use by buffer API functions */
-PyAPI_FUNC(void) _Py_add_one_to_index_F(int nd, Py_ssize_t *index,
-                                        const Py_ssize_t *shape);
-PyAPI_FUNC(void) _Py_add_one_to_index_C(int nd, Py_ssize_t *index,
-                                        const Py_ssize_t *shape);
-
-/* Convert Python int to Py_ssize_t. Do nothing if the argument is None. */
+// Convert Python int to Py_ssize_t. Do nothing if the argument is None.
+// Cannot be moved to the internal C API: used by Argument Clinic.
 PyAPI_FUNC(int) _Py_convert_optional_to_ssize_t(PyObject *, void *);
 
-/* Same as PyNumber_Index but can return an instance of a subclass of int. */
+// Same as PyNumber_Index but can return an instance of a subclass of int.
+// Cannot be moved to the internal C API: used by Argument Clinic.
 PyAPI_FUNC(PyObject *) _PyNumber_Index(PyObject *o);

--- a/Include/internal/pycore_abstract.h
+++ b/Include/internal/pycore_abstract.h
@@ -41,6 +41,13 @@ extern int _PyObject_HasLen(PyObject *o);
 extern Py_ssize_t _PySequence_IterSearch(PyObject *seq,
                                          PyObject *obj, int operation);
 
+/* === Mapping protocol ================================================= */
+
+extern int _PyObject_RealIsInstance(PyObject *inst, PyObject *cls);
+
+extern int _PyObject_RealIsSubclass(PyObject *derived, PyObject *cls);
+
+
 #ifdef __cplusplus
 }
 #endif

--- a/Objects/abstract.c
+++ b/Objects/abstract.c
@@ -517,7 +517,7 @@ PyBuffer_GetPointer(const Py_buffer *view, const Py_ssize_t *indices)
 }
 
 
-void
+static void
 _Py_add_one_to_index_F(int nd, Py_ssize_t *index, const Py_ssize_t *shape)
 {
     int k;
@@ -533,7 +533,7 @@ _Py_add_one_to_index_F(int nd, Py_ssize_t *index, const Py_ssize_t *shape)
     }
 }
 
-void
+static void
 _Py_add_one_to_index_C(int nd, Py_ssize_t *index, const Py_ssize_t *shape)
 {
     int k;

--- a/Objects/descrobject.c
+++ b/Objects/descrobject.c
@@ -1,6 +1,7 @@
 /* Descriptors -- a new, flexible way to describe attributes */
 
 #include "Python.h"
+#include "pycore_abstract.h"      // _PyObject_RealIsSubclass()
 #include "pycore_ceval.h"         // _Py_EnterRecursiveCallTstate()
 #include "pycore_object.h"        // _PyObject_GC_UNTRACK()
 #include "pycore_pystate.h"       // _PyThreadState_GET()

--- a/Objects/exceptions.c
+++ b/Objects/exceptions.c
@@ -7,6 +7,7 @@
 #define PY_SSIZE_T_CLEAN
 #include <Python.h>
 #include <stdbool.h>
+#include "pycore_abstract.h"      // _PyObject_RealIsSubclass()
 #include "pycore_ceval.h"         // _Py_EnterRecursiveCall
 #include "pycore_pyerrors.h"      // struct _PyErr_SetRaisedException
 #include "pycore_exceptions.h"    // struct _Py_exc_state


### PR DESCRIPTION
Remove the following functions from the public C API:

* _PyObject_RealIsInstance()
* _PyObject_RealIsSubclass()
* _Py_add_one_to_index_F()
* _Py_add_one_to_index_C()

Move _PyObject_RealIsInstance() and _PyObject_RealIsSubclass() to the internal C API (pycore_abstract.h) and no longer export their symbols (in libpython).

Make _Py_add_one_to_index_F() and _Py_add_one_to_index_C() functions static: no longer export them.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-106084 -->
* Issue: gh-106084
<!-- /gh-issue-number -->
