### PR TITLE
gh-106107: document correct error that's raised when a mutable default value for a field is detected

### DIFF
--- a/Doc/library/dataclasses.rst
+++ b/Doc/library/dataclasses.rst
@@ -738,7 +738,7 @@ for ``x`` when creating a class instance will share the same copy
 of ``x``.  Because dataclasses just use normal Python class
 creation they also share this behavior.  There is no general way
 for Data Classes to detect this condition.  Instead, the
-:func:`dataclass` decorator will raise a :exc:`TypeError` if it
+:func:`dataclass` decorator will raise a :exc:`ValueError` if it
 detects an unhashable default parameter.  The assumption is that if
 a value is unhashable, it is mutable.  This is a partial solution,
 but it does protect against many common errors.


### PR DESCRIPTION
Note that incorrect documentation is present in all python versions since the implementation of dataclasses (in 3.7)

<!-- gh-issue-number: gh-106107 -->
* Issue: gh-106107
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--106109.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->