### PR TITLE
gh-106123: Modules/_sha3 appears to no longer be necessary

### DIFF
--- a/configure
+++ b/configure
@@ -26701,7 +26701,6 @@ SRCDIRS="\
   Modules/_hacl \
   Modules/_io \
   Modules/_multiprocessing \
-  Modules/_sha3 \
   Modules/_sqlite \
   Modules/_sre \
   Modules/_testcapi \
@@ -32093,4 +32092,3 @@ Platform \"$host\" with compiler \"$ac_cv_cc_name\" is not supported by the
 CPython core team, see https://peps.python.org/pep-0011/ for more information.
 " >&2;}
 fi
-

--- a/configure
+++ b/configure
@@ -32092,3 +32092,4 @@ Platform \"$host\" with compiler \"$ac_cv_cc_name\" is not supported by the
 CPython core team, see https://peps.python.org/pep-0011/ for more information.
 " >&2;}
 fi
+

--- a/configure.ac
+++ b/configure.ac
@@ -6643,7 +6643,6 @@ SRCDIRS="\
   Modules/_hacl \
   Modules/_io \
   Modules/_multiprocessing \
-  Modules/_sha3 \
   Modules/_sqlite \
   Modules/_sre \
   Modules/_testcapi \


### PR DESCRIPTION
This is a pretty trivial PR. I'm guessing `Modules/_sha3` was a holdover from before `Modules/_hacl` existed. Perhaps there's a valid reason for it to still exist (used on another platform?), but if so, maybe it should be described in a comment in `configure.ac`

<!-- gh-issue-number: gh-106123 -->
* Issue: gh-106123
<!-- /gh-issue-number -->
