### PR TITLE
gh-104584: Fix assert in DEOPT macro -- should fix buildbot

### DIFF
--- a/Python/ceval_macros.h
+++ b/Python/ceval_macros.h
@@ -264,11 +264,12 @@ GETITEM(PyObject *v, Py_ssize_t i) {
 #define UPDATE_MISS_STATS(INSTNAME) ((void)0)
 #endif
 
+// NOTE: in the uops version, opcode may be > 255
 #define DEOPT_IF(COND, INSTNAME)                            \
     if ((COND)) {                                           \
         /* This is only a single jump on release builds! */ \
         UPDATE_MISS_STATS((INSTNAME));                      \
-        assert(_PyOpcode_Deopt[opcode] == (INSTNAME));      \
+        assert(opcode >= 256 || _PyOpcode_Deopt[opcode] == (INSTNAME)); \
         GO_TO_INSTRUCTION(INSTNAME);                        \
     }
 


### PR DESCRIPTION
That's what I get for not running all buildbots for gh-105924.

<!-- gh-issue-number: gh-104584 -->
* Issue: gh-104584
<!-- /gh-issue-number -->
