### PR TITLE
gh-104584: Change DEOPT_IF in uops executor

### DIFF
--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -2767,10 +2767,11 @@ void Py_LeaveRecursiveCall(void)
 
 ///////////////////// Experimental UOp Interpreter /////////////////////
 
-// UPDATE_MISS_STATS (called by DEOPT_IF) uses next_instr
-// TODO: Make it do something useful
-#undef UPDATE_MISS_STATS
-#define UPDATE_MISS_STATS(INSTNAME) ((void)0)
+#undef DEOPT_IF
+#define DEOPT_IF(COND, INSTNAME) \
+    if ((COND)) {                \
+        goto deoptimize;         \
+    }
 
 _PyInterpreterFrame *
 _PyUopExecute(_PyExecutorObject *executor, _PyInterpreterFrame *frame, PyObject **stack_pointer)
@@ -2875,12 +2876,7 @@ error:
     Py_DECREF(self);
     return NULL;
 
-PREDICTED(UNPACK_SEQUENCE)
-PREDICTED(COMPARE_OP)
-PREDICTED(LOAD_SUPER_ATTR)
-PREDICTED(STORE_SUBSCR)
-PREDICTED(BINARY_SUBSCR)
-PREDICTED(BINARY_OP)
+deoptimize:
     // On DEOPT_IF we just repeat the last instruction.
     // This presumes nothing was popped from the stack (nor pushed).
 #ifdef LLTRACE

--- a/Python/ceval_macros.h
+++ b/Python/ceval_macros.h
@@ -264,12 +264,11 @@ GETITEM(PyObject *v, Py_ssize_t i) {
 #define UPDATE_MISS_STATS(INSTNAME) ((void)0)
 #endif
 
-// NOTE: in the uops version, opcode may be > 255
 #define DEOPT_IF(COND, INSTNAME)                            \
     if ((COND)) {                                           \
         /* This is only a single jump on release builds! */ \
         UPDATE_MISS_STATS((INSTNAME));                      \
-        assert(opcode >= 256 || _PyOpcode_Deopt[opcode] == (INSTNAME)); \
+        assert(_PyOpcode_Deopt[opcode] == (INSTNAME));      \
         GO_TO_INSTRUCTION(INSTNAME);                        \
     }
 


### PR DESCRIPTION
This effectively reverts bb578a0c30, restoring the original `DEOPT_IF()` macro in ceval_macros.h, and redefining it in the Tier 2 interpreter. We can get rid of the `PREDICTED()` macros there as well!

<!-- gh-issue-number: gh-104584 -->
* Issue: gh-104584
<!-- /gh-issue-number -->
