### PR TITLE
Fix confusion of `enum _framestate` with `enum _frameowner`

### DIFF
--- a/Include/internal/pycore_frame.h
+++ b/Include/internal/pycore_frame.h
@@ -52,6 +52,7 @@ enum _frameowner {
     FRAME_OWNED_BY_GENERATOR = 1,
     FRAME_OWNED_BY_FRAME_OBJECT = 2,
     FRAME_OWNED_BY_CSTACK = 3,
+    FRAME_OWNED_BY_ACCIDENT = 4,
 };
 
 typedef struct _PyInterpreterFrame {

--- a/Python/frame.c
+++ b/Python/frame.c
@@ -50,13 +50,13 @@ _PyFrame_MakeAndSetFrameObject(_PyInterpreterFrame *frame)
         // Just pretend that we have an owned, cleared frame so frame_dealloc
         // doesn't make the situation worse:
         f->f_frame = (_PyInterpreterFrame *)f->_f_frame_data;
-        f->f_frame->owner = FRAME_CLEARED;
+        f->f_frame->owner = FRAME_OWNED_BY_ACCIDENT;
         f->f_frame->frame_obj = f;
         Py_DECREF(f);
         return frame->frame_obj;
     }
     assert(frame->owner != FRAME_OWNED_BY_FRAME_OBJECT);
-    assert(frame->owner != FRAME_CLEARED);
+    assert(frame->owner != FRAME_OWNED_BY_ACCIDENT);
     f->f_frame = frame;
     frame->frame_obj = f;
     return f;
@@ -79,7 +79,7 @@ take_ownership(PyFrameObject *f, _PyInterpreterFrame *frame)
 {
     assert(frame->owner != FRAME_OWNED_BY_CSTACK);
     assert(frame->owner != FRAME_OWNED_BY_FRAME_OBJECT);
-    assert(frame->owner != FRAME_CLEARED);
+    assert(frame->owner != FRAME_OWNED_BY_ACCIDENT);
     Py_ssize_t size = ((char*)&frame->localsplus[frame->stacktop]) - (char *)frame;
     Py_INCREF(_PyFrame_GetCode(frame));
     memcpy((_PyInterpreterFrame *)f->_f_frame_data, frame, size);


### PR DESCRIPTION
The `owner` field of `_PyInterpreterFrame` is supposed to be a member of `enum _frameowner`, but `FRAME_CLEARED` is a member of `enum _framestate`. Add `FRAME_OWNED_BY_ACCIDENT` to `enum _frameowner` and use that instead. (It happens to have the same numerical value, but we shouldn’t rely on that anywhere.)