### PR TITLE
gh-106152: Add PY_THROW event to cProfile

### DIFF
--- a/Misc/NEWS.d/next/Library/2023-06-27-23-22-37.gh-issue-106152.ya5jBT.rst
+++ b/Misc/NEWS.d/next/Library/2023-06-27-23-22-37.gh-issue-106152.ya5jBT.rst
@@ -1,0 +1,1 @@
+Added PY_THROW event hook for :mod:`cProfile` for generators

--- a/Modules/_lsprof.c
+++ b/Modules/_lsprof.c
@@ -678,6 +678,7 @@ static const struct {
 } callback_table[] = {
     {PY_MONITORING_EVENT_PY_START, "_pystart_callback"},
     {PY_MONITORING_EVENT_PY_RESUME, "_pystart_callback"},
+    {PY_MONITORING_EVENT_PY_THROW, "_pystart_callback"},
     {PY_MONITORING_EVENT_PY_RETURN, "_pyreturn_callback"},
     {PY_MONITORING_EVENT_PY_YIELD, "_pyreturn_callback"},
     {PY_MONITORING_EVENT_PY_UNWIND, "_pyreturn_callback"},


### PR DESCRIPTION
`PY_MONITORING_EVENT_PY_THROW` is missing which caused incorrect profiling for generators that are garbage collected(and maybe in other cases).

<!-- gh-issue-number: gh-106152 -->
* Issue: gh-106152
<!-- /gh-issue-number -->
