### PR TITLE
GH-104584: Fix test_capi.test_counter_optimizer() when run twice

### DIFF
--- a/Lib/test/test_capi/test_misc.py
+++ b/Lib/test/test_capi/test_misc.py
@@ -2372,10 +2372,14 @@ class TestOptimizerAPI(unittest.TestCase):
         self.assertEqual(_testinternalcapi.get_optimizer(), None)
 
     def test_counter_optimizer(self):
-
-        def loop():
-            for _ in range(1000):
-                pass
+        # Generate a new function at each call
+        ns = {}
+        exec(textwrap.dedent("""
+            def loop():
+                for _ in range(1000):
+                    pass
+        """), ns, ns)
+        loop = ns['loop']
 
         for repeat in range(5):
             opt = _testinternalcapi.get_counter_optimizer()
@@ -2388,18 +2392,23 @@ class TestOptimizerAPI(unittest.TestCase):
     def test_long_loop(self):
         "Check that we aren't confused by EXTENDED_ARG"
 
-        def nop():
-            pass
+        # Generate a new function at each call
+        ns = {}
+        exec(textwrap.dedent("""
+            def nop():
+                pass
 
-        def long_loop():
-            for _ in range(10):
-                nop(); nop(); nop(); nop(); nop(); nop(); nop(); nop();
-                nop(); nop(); nop(); nop(); nop(); nop(); nop(); nop();
-                nop(); nop(); nop(); nop(); nop(); nop(); nop(); nop();
-                nop(); nop(); nop(); nop(); nop(); nop(); nop(); nop();
-                nop(); nop(); nop(); nop(); nop(); nop(); nop(); nop();
-                nop(); nop(); nop(); nop(); nop(); nop(); nop(); nop();
-                nop(); nop(); nop(); nop(); nop(); nop(); nop(); nop();
+            def long_loop():
+                for _ in range(10):
+                    nop(); nop(); nop(); nop(); nop(); nop(); nop(); nop();
+                    nop(); nop(); nop(); nop(); nop(); nop(); nop(); nop();
+                    nop(); nop(); nop(); nop(); nop(); nop(); nop(); nop();
+                    nop(); nop(); nop(); nop(); nop(); nop(); nop(); nop();
+                    nop(); nop(); nop(); nop(); nop(); nop(); nop(); nop();
+                    nop(); nop(); nop(); nop(); nop(); nop(); nop(); nop();
+                    nop(); nop(); nop(); nop(); nop(); nop(); nop(); nop();
+        """), ns, ns)
+        long_loop = ns['long_loop']
 
         opt = _testinternalcapi.get_counter_optimizer()
         with self.temporary_optimizer(opt):


### PR DESCRIPTION
test_counter_optimizer() and test_long_loop() of test_capi now create a new function at each call. Otherwise, the optimizer counters are not the expected values when the test is run more than once.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-104584 -->
* Issue: gh-104584
<!-- /gh-issue-number -->
