### PR TITLE
Fix c-analyzer for GCC: ignore LANG env var

### DIFF
--- a/Tools/c-analyzer/c_parser/preprocessor/common.py
+++ b/Tools/c-analyzer/c_parser/preprocessor/common.py
@@ -1,6 +1,7 @@
 import contextlib
 import distutils.ccompiler
 import logging
+import os
 import shlex
 import subprocess
 import sys
@@ -40,7 +41,12 @@ def run_cmd(argv, *,
     kw.pop('kwargs')
     kwargs.update(kw)
 
-    proc = subprocess.run(argv, **kwargs)
+    # Remove LANG environment variable: the C parser doesn't support GCC
+    # localized messages
+    env = dict(os.environ)
+    env.pop('LANG', None)
+
+    proc = subprocess.run(argv, env=env, **kwargs)
     return proc.stdout
 
 


### PR DESCRIPTION
The c-analyzer doesn't support GCC localized messages, so just unset the LANG environment variable.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
