### PR TITLE
gh-106194: Rename duplicated tests in `test_curses`

### DIFF
--- a/Lib/test/test_curses.py
+++ b/Lib/test/test_curses.py
@@ -1367,8 +1367,17 @@ class TextboxTest(unittest.TestCase):
         self.mock_win.reset_mock()
 
     def test_move_right(self):
-        """Test moving the cursor left."""
+        """Test moving the cursor right."""
         self.mock_win.reset_mock()
+        self.textbox.do_command(curses.KEY_RIGHT)
+        self.mock_win.move.assert_called_with(1, 2)
+        self.mock_win.reset_mock()
+
+    def test_move_left_and_right(self):
+        """Test moving the cursor left and then right."""
+        self.mock_win.reset_mock()
+        self.textbox.do_command(curses.KEY_LEFT)
+        self.mock_win.move.assert_called_with(1, 0)
         self.textbox.do_command(curses.KEY_RIGHT)
         self.mock_win.move.assert_called_with(1, 2)
         self.mock_win.reset_mock()

--- a/Lib/test/test_curses.py
+++ b/Lib/test/test_curses.py
@@ -1383,14 +1383,14 @@ class TextboxTest(unittest.TestCase):
         self.mock_win.reset_mock()
 
     def test_move_up(self):
-        """Test moving the cursor left."""
+        """Test moving the cursor up."""
         self.mock_win.reset_mock()
         self.textbox.do_command(curses.KEY_UP)
         self.mock_win.move.assert_called_with(0, 1)
         self.mock_win.reset_mock()
 
     def test_move_down(self):
-        """Test moving the cursor left."""
+        """Test moving the cursor down."""
         self.mock_win.reset_mock()
         self.textbox.do_command(curses.KEY_DOWN)
         self.mock_win.move.assert_called_with(2, 1)

--- a/Lib/test/test_curses.py
+++ b/Lib/test/test_curses.py
@@ -1364,11 +1364,9 @@ class TextboxTest(unittest.TestCase):
         self.mock_win.reset_mock()
         self.textbox.do_command(curses.KEY_LEFT)
         self.mock_win.move.assert_called_with(1, 0)
-        self.textbox.do_command(curses.KEY_RIGHT)
-        self.mock_win.move.assert_called_with(1, 2)
         self.mock_win.reset_mock()
 
-    def test_move_left(self):
+    def test_move_right(self):
         """Test moving the cursor left."""
         self.mock_win.reset_mock()
         self.textbox.do_command(curses.KEY_RIGHT)


### PR DESCRIPTION
Based on tests near the problematic ones, we can see `test_move_up` and `test_move_down`.
Source: https://github.com/python/cpython/blob/bbf722dcd39c66418e45991dcf1cdf140c2ce20e/Lib/test/test_curses.py#L1378-L1390

So, I think it is safe to just replace them with `test_move_left` and `test_move_right`.

<!-- gh-issue-number: gh-106194 -->
* Issue: gh-106194
<!-- /gh-issue-number -->
