### PR TITLE
gh-106210 Remove Emscripten import trampoline

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2023-06-28-13-19-20.gh-issue-106210.oE7VMn.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2023-06-28-13-19-20.gh-issue-106210.oE7VMn.rst
@@ -1,0 +1,1 @@
+Removed Emscripten import trampoline

--- a/Misc/NEWS.d/next/Core and Builtins/2023-06-28-13-19-20.gh-issue-106210.oE7VMn.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2023-06-28-13-19-20.gh-issue-106210.oE7VMn.rst
@@ -1,1 +1,1 @@
-Removed Emscripten import trampoline
+Removed Emscripten import trampoline as it was no longer necessary for Pyodide.

--- a/Python/import.c
+++ b/Python/import.c
@@ -839,16 +839,6 @@ _PyImport_ClearExtension(PyObject *name, PyObject *filename)
 }
 
 
-/*******************/
-
-#if defined(__EMSCRIPTEN__) && defined(PY_CALL_TRAMPOLINE)
-#include <emscripten.h>
-EM_JS(PyObject*, _PyImport_InitFunc_TrampolineCall, (PyModInitFunction func), {
-    return wasmTable.get(func)();
-});
-#endif // __EMSCRIPTEN__ && PY_CALL_TRAMPOLINE
-
-
 /*****************************/
 /* single-phase init modules */
 /*****************************/
@@ -1285,7 +1275,7 @@ import_find_extension(PyThreadState *tstate, PyObject *name,
     else {
         if (def->m_base.m_init == NULL)
             return NULL;
-        mod = _PyImport_InitFunc_TrampolineCall(def->m_base.m_init);
+        mod = def->m_base.m_init();
         if (mod == NULL)
             return NULL;
         if (PyObject_SetItem(modules, name, mod) == -1) {
@@ -1400,7 +1390,7 @@ create_builtin(PyThreadState *tstate, PyObject *name, PyObject *spec)
                 /* Cannot re-init internal module ("sys" or "builtins") */
                 return import_add_module(tstate, name);
             }
-            mod = _PyImport_InitFunc_TrampolineCall(*p->initfunc);
+            mod = (*p->initfunc)();
             if (mod == NULL) {
                 return NULL;
             }

--- a/Python/importdl.c
+++ b/Python/importdl.c
@@ -166,7 +166,7 @@ _PyImport_LoadDynamicModuleWithSpec(PyObject *spec, FILE *fp)
 
     /* Package context is needed for single-phase init */
     oldcontext = _PyImport_SwapPackageContext(newcontext);
-    m = _PyImport_InitFunc_TrampolineCall(p0);
+    m = p0();
     _PyImport_SwapPackageContext(oldcontext);
 
     if (m == NULL) {

--- a/Python/importdl.h
+++ b/Python/importdl.h
@@ -12,12 +12,6 @@ extern PyObject *_PyImport_LoadDynamicModuleWithSpec(PyObject *spec, FILE *);
 
 typedef PyObject *(*PyModInitFunction)(void);
 
-#if defined(__EMSCRIPTEN__) && defined(PY_CALL_TRAMPOLINE)
-extern PyObject *_PyImport_InitFunc_TrampolineCall(PyModInitFunction func);
-#else
-#define _PyImport_InitFunc_TrampolineCall(func) (func)()
-#endif
-
 /* Max length of module suffix searched for -- accommodates "module.slb" */
 #define MAXSUFFIXSIZE 12
 


### PR DESCRIPTION
As far as I know this isn't actually needed. It was originally added to work around typos in the CPython test suite, but those typos have since been fixed and I am unaware of any user code that requires the trampoline.

#106210


<!-- gh-issue-number: gh-106210 -->
* Issue: gh-106210
<!-- /gh-issue-number -->
