### PR TITLE
gh-106145: Make `end_{lineno,col_offset}` required on `type_param` nodes

### DIFF
--- a/Lib/test/test_unparse.py
+++ b/Lib/test/test_unparse.py
@@ -705,7 +705,7 @@ class DirectoryTestCase(ASTTestCase):
     test_directories = (lib_dir, lib_dir / "test")
     run_always_files = {"test_grammar.py", "test_syntax.py", "test_compile.py",
                         "test_ast.py", "test_asdl_parser.py", "test_fstring.py",
-                        "test_patma.py", "test_type_alias.py"}
+                        "test_patma.py", "test_type_alias.py", "test_type_params.py"}
 
     _files_to_test = None
 

--- a/Lib/test/test_unparse.py
+++ b/Lib/test/test_unparse.py
@@ -705,7 +705,7 @@ class DirectoryTestCase(ASTTestCase):
     test_directories = (lib_dir, lib_dir / "test")
     run_always_files = {"test_grammar.py", "test_syntax.py", "test_compile.py",
                         "test_ast.py", "test_asdl_parser.py", "test_fstring.py",
-                        "test_patma.py"}
+                        "test_patma.py", "test_type_alias.py"}
 
     _files_to_test = None
 

--- a/Misc/NEWS.d/next/Core and Builtins/2023-06-29-09-46-41.gh-issue-106145.QC6-Kq.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2023-06-29-09-46-41.gh-issue-106145.QC6-Kq.rst
@@ -1,0 +1,2 @@
+Make ``end_lineno`` and ``end_col_offset`` required on ``type_param`` ast
+nodes.

--- a/Parser/Python.asdl
+++ b/Parser/Python.asdl
@@ -148,5 +148,5 @@ module Python
     type_param = TypeVar(identifier name, expr? bound)
                | ParamSpec(identifier name)
                | TypeVarTuple(identifier name)
-               attributes (int lineno, int col_offset, int? end_lineno, int? end_col_offset)
+               attributes (int lineno, int col_offset, int end_lineno, int end_col_offset)
 }

--- a/Python/Python-ast.c
+++ b/Python/Python-ast.c
@@ -1902,12 +1902,6 @@ init_types(struct ast_state *state)
     if (!state->type_param_type) return 0;
     if (!add_attributes(state, state->type_param_type, type_param_attributes,
         4)) return 0;
-    if (PyObject_SetAttr(state->type_param_type, state->end_lineno, Py_None) ==
-        -1)
-        return 0;
-    if (PyObject_SetAttr(state->type_param_type, state->end_col_offset,
-        Py_None) == -1)
-        return 0;
     state->TypeVar_type = make_type(state, "TypeVar", state->type_param_type,
                                     TypeVar_fields, 2,
         "TypeVar(identifier name, expr? bound)");
@@ -12500,9 +12494,9 @@ obj2ast_type_param(struct ast_state *state, PyObject* obj, type_param_ty* out,
     if (_PyObject_LookupAttr(obj, state->end_lineno, &tmp) < 0) {
         return 1;
     }
-    if (tmp == NULL || tmp == Py_None) {
-        Py_CLEAR(tmp);
-        end_lineno = lineno;
+    if (tmp == NULL) {
+        PyErr_SetString(PyExc_TypeError, "required field \"end_lineno\" missing from type_param");
+        return 1;
     }
     else {
         int res;
@@ -12517,9 +12511,9 @@ obj2ast_type_param(struct ast_state *state, PyObject* obj, type_param_ty* out,
     if (_PyObject_LookupAttr(obj, state->end_col_offset, &tmp) < 0) {
         return 1;
     }
-    if (tmp == NULL || tmp == Py_None) {
-        Py_CLEAR(tmp);
-        end_col_offset = col_offset;
+    if (tmp == NULL) {
+        PyErr_SetString(PyExc_TypeError, "required field \"end_col_offset\" missing from type_param");
+        return 1;
     }
     else {
         int res;


### PR DESCRIPTION
I've also added `test_type_alias.py` to `test_unparse` to make sure that this new syntax works correctly with `ast.unparse`.

<!-- gh-issue-number: gh-106145 -->
* Issue: gh-106145
<!-- /gh-issue-number -->
