### PR TITLE
Fix dupe word comment typos

### DIFF
--- a/Include/cpython/object.h
+++ b/Include/cpython/object.h
@@ -231,7 +231,7 @@ struct _typeobject {
 };
 
 /* This struct is used by the specializer
- * It should should be treated as an opaque blob
+ * It should be treated as an opaque blob
  * by code other than the specializer and interpreter. */
 struct _specialization_cache {
     // In order to avoid bloating the bytecode with lots of inline caches, the

--- a/Objects/frameobject.c
+++ b/Objects/frameobject.c
@@ -1186,7 +1186,7 @@ frame_get_var(_PyInterpreterFrame *frame, PyCodeObject *co, int i,
                     // (likely) MAKE_CELL must have executed already.
                     value = PyCell_GET(value);
                 }
-                // (likely) Otherwise it it is an arg (kind & CO_FAST_LOCAL),
+                // (likely) Otherwise it is an arg (kind & CO_FAST_LOCAL),
                 // with the initial value set when the frame was created...
                 // (unlikely) ...or it was set to some initial value by
                 // an earlier call to PyFrame_LocalsToFast().

--- a/Python/initconfig.c
+++ b/Python/initconfig.c
@@ -538,7 +538,7 @@ _Py_SetArgcArgv(Py_ssize_t argc, wchar_t * const *argv)
     _PyMem_SetDefaultAllocator(PYMEM_DOMAIN_RAW, &old_alloc);
 
     // XXX _PyRuntime.orig_argv only gets cleared by Py_Main(),
-    // so it it currently leaks for embedders.
+    // so it currently leaks for embedders.
     res = _PyWideStringList_Copy(&_PyRuntime.orig_argv, &argv_list);
 
     PyMem_SetAllocator(PYMEM_DOMAIN_RAW, &old_alloc);


### PR DESCRIPTION
Fixed duplicated word typos in comments. I searched with a regex search and only fixed where it was highly likely to be a typo.