### PR TITLE
gh-106236: Replace `assert` with `raise RuntimeError` in `threading.py`

### DIFF
--- a/Lib/test/test_threading.py
+++ b/Lib/test/test_threading.py
@@ -253,10 +253,10 @@ class ThreadTests(BaseTestCase):
         self.assertRegex(repr(threading._active[tid]), '_DummyThread')
 
         # Issue gh-106236:
-        with self.assertRaises(AssertionError):
+        with self.assertRaises(RuntimeError):
             threading._active[tid].join()
         threading._active[tid]._started.clear()
-        with self.assertRaises(AssertionError):
+        with self.assertRaises(RuntimeError):
             threading._active[tid].is_alive()
 
         del threading._active[tid]

--- a/Lib/test/test_threading.py
+++ b/Lib/test/test_threading.py
@@ -251,6 +251,14 @@ class ThreadTests(BaseTestCase):
         #Issue 29376
         self.assertTrue(threading._active[tid].is_alive())
         self.assertRegex(repr(threading._active[tid]), '_DummyThread')
+
+        # Issue gh-106236:
+        with self.assertRaises(AssertionError):
+            threading._active[tid].join()
+        threading._active[tid]._started.clear()
+        with self.assertRaises(AssertionError):
+            threading._active[tid].is_alive()
+
         del threading._active[tid]
 
     # PyThreadState_SetAsyncExc() is a CPython-only gimmick, not (currently)

--- a/Lib/threading.py
+++ b/Lib/threading.py
@@ -1453,10 +1453,10 @@ class _DummyThread(Thread):
     def is_alive(self):
         if not self._is_stopped and self._started.is_set():
             return True
-        raise AssertionError("thread is not alive")
+        raise RuntimeError("thread is not alive")
 
     def join(self, timeout=None):
-        raise AssertionError("cannot join a dummy thread")
+        raise RuntimeError("cannot join a dummy thread")
 
 
 # Global API functions

--- a/Lib/threading.py
+++ b/Lib/threading.py
@@ -1451,11 +1451,12 @@ class _DummyThread(Thread):
         pass
 
     def is_alive(self):
-        assert not self._is_stopped and self._started.is_set()
-        return True
+        if not self._is_stopped and self._started.is_set():
+            return True
+        raise AssertionError("thread is not alive")
 
     def join(self, timeout=None):
-        assert False, "cannot join a dummy thread"
+        raise AssertionError("cannot join a dummy thread")
 
 
 # Global API functions

--- a/Misc/NEWS.d/next/Library/2023-06-29-15-10-44.gh-issue-106236.EAIX4l.rst
+++ b/Misc/NEWS.d/next/Library/2023-06-29-15-10-44.gh-issue-106236.EAIX4l.rst
@@ -1,3 +1,2 @@
 Replace ``assert`` statements with ``raise AssertionError`` in
-:mod:`threading`, so the behaviour of ``_DummyThread`` with and without
-``-OO`` is consistent.
+:mod:`threading`, so that ``_DummyThread`` cannot be joined even with ``-OO``.

--- a/Misc/NEWS.d/next/Library/2023-06-29-15-10-44.gh-issue-106236.EAIX4l.rst
+++ b/Misc/NEWS.d/next/Library/2023-06-29-15-10-44.gh-issue-106236.EAIX4l.rst
@@ -1,2 +1,2 @@
-Replace ``assert`` statements with ``raise AssertionError`` in
+Replace ``assert`` statements with ``raise RuntimeError`` in
 :mod:`threading`, so that ``_DummyThread`` cannot be joined even with ``-OO``.

--- a/Misc/NEWS.d/next/Library/2023-06-29-15-10-44.gh-issue-106236.EAIX4l.rst
+++ b/Misc/NEWS.d/next/Library/2023-06-29-15-10-44.gh-issue-106236.EAIX4l.rst
@@ -1,0 +1,3 @@
+Replace ``assert`` statements with ``raise AssertionError`` in
+:mod:`threading`, so the behaviour of ``_DummyThread`` with and without
+``-OO`` is consistent.


### PR DESCRIPTION
I went with `AssertionError` so we maintain 100% backward compatibility. 


<!-- gh-issue-number: gh-106236 -->
* Issue: gh-106236
<!-- /gh-issue-number -->
