### PR TITLE
gh-106238: Handle KeyboardInterrupt during logging._acquireLock()

### DIFF
--- a/Lib/logging/__init__.py
+++ b/Lib/logging/__init__.py
@@ -238,7 +238,11 @@ def _acquireLock():
     This should be released with _releaseLock().
     """
     if _lock:
-        _lock.acquire()
+        try:
+            _lock.acquire()
+        except BaseException:
+            _lock.release()
+            raise
 
 def _releaseLock():
     """

--- a/Misc/NEWS.d/next/Library/2023-06-29-12-40-52.gh-issue-106238.VulKb9.rst
+++ b/Misc/NEWS.d/next/Library/2023-06-29-12-40-52.gh-issue-106238.VulKb9.rst
@@ -1,0 +1,1 @@
+Fix rare concurrency bug in lock acquire by the logging library.

--- a/Misc/NEWS.d/next/Library/2023-06-29-12-40-52.gh-issue-106238.VulKb9.rst
+++ b/Misc/NEWS.d/next/Library/2023-06-29-12-40-52.gh-issue-106238.VulKb9.rst
@@ -1,1 +1,1 @@
-Fix rare concurrency bug in lock acquire by the logging library.
+Fix rare concurrency bug in lock acquisition by the logging package.


### PR DESCRIPTION
We've come across a concurrency bug in logging/__init__.py which involves the handling of asynchronous exceptions, such as KeyboardInterrupt, during the execution of logging._acquireLock().

In the current implementation, when threading.RLock.acquire() is executed, there is a possibility for an asynchronous exception to occur during the transition back from native code, even if the lock acquisition is successful.

The typical use of _acquireLock() in the logging library is as follows:

```python
def _loggingMethod(handler):
    """
    Add a handler to the internal cleanup list using a weak reference.
    """
    _acquireLock()
    try:
        # doSomething
    finally:
        _releaseLock()
```
In this pattern, if a KeyboardInterrupt is raised during the lock acquisition, the lock ends up getting abandoned.

When can this happen? One example is during forks. logging/__init__.py registers an at-fork hook, with

```python
os.register_at_fork(before=_acquireLock,
                    after_in_child=_after_at_fork_child_reinit_locks,
                    after_in_parent=_releaseLock)
```
A scenario occurring in our production environment is during a slow fork operation (when the server is under heavy load and performing a multitude of forks). The lock could be held for up to a minute. If this is happening in a secondary thread, and a SIGINT signal is received in the main thread while is waiting to acquire the lock for logging, the lock will be abandoned. This will causes the process to hang during the next _acquireLock() call.

To address this issue, we provide a simple pull request to add a try-except block within _acquireLock(), e.g.:

```python
def _acquireLock():
    if _lock:
        try:
            _lock.acquire()
        except BaseException:
            _lock.release()
            raise
```
This way, if an exception arises during the lock acquisition, the lock will be released, preventing the lock from being abandoned and the process from potentially hanging.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-106238 -->
* Issue: gh-106238
<!-- /gh-issue-number -->
