### PR TITLE
Fix possible refleak in CodeType.replace()

### DIFF
--- a/Objects/codeobject.c
+++ b/Objects/codeobject.c
@@ -2035,6 +2035,7 @@ code_replace_impl(PyCodeObject *self, int co_argcount,
                     co_code, co_filename, co_name, co_argcount,
                     co_posonlyargcount, co_kwonlyargcount, co_nlocals,
                     co_stacksize, co_flags) < 0) {
+        Py_XDECREF(code);
         return NULL;
     }
 


### PR DESCRIPTION
A reference to c_code was leaked if PySys_Audit() failed.