### PR TITLE
fix typos

### DIFF
--- a/Objects/bytearrayobject.c
+++ b/Objects/bytearrayobject.c
@@ -1387,7 +1387,7 @@ The bytes objects frm and to must be of the same length.
 
 static PyObject *
 bytearray_maketrans_impl(Py_buffer *frm, Py_buffer *to)
-/*[clinic end generated code: output=1df267d99f56b15e input=5925a81d2fbbf151]*/
+/*[clinic end generated code: output=1df267d99f56b15e input=b10de38c85950a63]*/
 {
     return _Py_bytes_maketrans(frm, to);
 }

--- a/Objects/bytearrayobject.c
+++ b/Objects/bytearrayobject.c
@@ -1377,7 +1377,7 @@ bytearray.maketrans
     to: Py_buffer
     /
 
-Return a translation table useable for the bytes or bytearray translate method.
+Return a translation table usable for the bytes or bytearray translate method.
 
 The returned table will be one where each byte in frm is mapped to the byte at
 the same position in to.

--- a/Objects/bytesobject.c
+++ b/Objects/bytesobject.c
@@ -2154,7 +2154,7 @@ bytes.maketrans
     to: Py_buffer
     /
 
-Return a translation table useable for the bytes or bytearray translate method.
+Return a translation table usable for the bytes or bytearray translate method.
 
 The returned table will be one where each byte in frm is mapped to the byte at
 the same position in to.

--- a/Objects/bytesobject.c
+++ b/Objects/bytesobject.c
@@ -2164,7 +2164,7 @@ The bytes objects frm and to must be of the same length.
 
 static PyObject *
 bytes_maketrans_impl(Py_buffer *frm, Py_buffer *to)
-/*[clinic end generated code: output=a36f6399d4b77f6f input=de7a8fc5632bb8f1]*/
+/*[clinic end generated code: output=a36f6399d4b77f6f input=a3bd00d430a0979f]*/
 {
     return _Py_bytes_maketrans(frm, to);
 }

--- a/Objects/clinic/bytearrayobject.c.h
+++ b/Objects/clinic/bytearrayobject.c.h
@@ -289,7 +289,7 @@ PyDoc_STRVAR(bytearray_maketrans__doc__,
 "maketrans(frm, to, /)\n"
 "--\n"
 "\n"
-"Return a translation table useable for the bytes or bytearray translate method.\n"
+"Return a translation table usable for the bytes or bytearray translate method.\n"
 "\n"
 "The returned table will be one where each byte in frm is mapped to the byte at\n"
 "the same position in to.\n"
@@ -1284,4 +1284,4 @@ bytearray_sizeof(PyByteArrayObject *self, PyObject *Py_UNUSED(ignored))
 {
     return bytearray_sizeof_impl(self);
 }
-/*[clinic end generated code: output=99fb3e3b9c1f4b15 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=0817195f176cd8e3 input=a9049054013a1b77]*/

--- a/Objects/clinic/bytesobject.c.h
+++ b/Objects/clinic/bytesobject.c.h
@@ -476,7 +476,7 @@ PyDoc_STRVAR(bytes_maketrans__doc__,
 "maketrans(frm, to, /)\n"
 "--\n"
 "\n"
-"Return a translation table useable for the bytes or bytearray translate method.\n"
+"Return a translation table usable for the bytes or bytearray translate method.\n"
 "\n"
 "The returned table will be one where each byte in frm is mapped to the byte at\n"
 "the same position in to.\n"
@@ -1060,4 +1060,4 @@ skip_optional_pos:
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=7b6e4e8b5bc4eb57 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=bc4801bf1fa628f4 input=a9049054013a1b77]*/

--- a/Objects/exceptions.c
+++ b/Objects/exceptions.c
@@ -1464,7 +1464,7 @@ PyUnstable_Exc_PrepReraiseStar(PyObject *orig, PyObject *excs)
     }
 
     /* Make sure that orig has something as traceback, in the interpreter
-     * it always does becuase it's a raised exception.
+     * it always does because it's a raised exception.
      */
     PyObject *tb = PyException_GetTraceback(orig);
 

--- a/Objects/object_layout.md
+++ b/Objects/object_layout.md
@@ -45,7 +45,7 @@ pointers are combined into a single tagged pointer:
 
 If the object has no physical dictionary, then the ``dict_or_values``
 has its low bit set to one, and points to the values array.
-If the object has a physical dictioanry, then the ``dict_or_values``
+If the object has a physical dictionary, then the ``dict_or_values``
 has its low bit set to zero, and points to the dictionary.
 
 The untagged form is chosen for the dictionary pointer, rather than

--- a/Python/pytime.c
+++ b/Python/pytime.c
@@ -969,7 +969,7 @@ py_get_system_clock(_PyTime_t *tp, _Py_clock_info_t *info, int raise_exc)
     }
 
 #if defined(HAVE_CLOCK_GETTIME_RUNTIME) && defined(HAVE_CLOCK_GETTIME)
-    } /* end of availibity block */
+    } /* end of availability block */
 #endif
 
 #endif   /* !HAVE_CLOCK_GETTIME */

--- a/Python/sysmodule.c
+++ b/Python/sysmodule.c
@@ -425,7 +425,7 @@ PySys_AddAuditHook(Py_AuditHookFunction hook, void *userData)
     e->userData = userData;
 
     if (runtime->audit_hooks.mutex == NULL) {
-        /* The runtime must not be initailized yet. */
+        /* The runtime must not be initialized yet. */
         add_audit_hook_entry_unlocked(runtime, e);
     }
     else {


### PR DESCRIPTION
Most typos are in comments, but two typos are in docstring.

(I used codespell to find them.)