### PR TITLE
gh-106023: Remove _PY_FASTCALL_SMALL_STACK constant

### DIFF
--- a/Include/cpython/abstract.h
+++ b/Include/cpython/abstract.h
@@ -2,19 +2,6 @@
 #  error "this header file must not be included directly"
 #endif
 
-/* === Object Protocol ================================================== */
-
-/* Suggested size (number of positional arguments) for arrays of PyObject*
-   allocated on a C stack to avoid allocating memory on the heap memory. Such
-   array is used to pass positional arguments to call functions of the
-   PyObject_Vectorcall() family.
-
-   The size is chosen to not abuse the C stack and so limit the risk of stack
-   overflow. The size is also chosen to allow using the small stack for most
-   function calls of the Python standard library. On 64-bit CPU, it allocates
-   40 bytes on the stack. */
-#define _PY_FASTCALL_SMALL_STACK 5
-
 /* === Vectorcall protocol (PEP 590) ============================= */
 
 // PyVectorcall_NARGS() is exported as a function for the stable ABI.

--- a/Include/internal/pycore_call.h
+++ b/Include/internal/pycore_call.h
@@ -10,6 +10,18 @@ extern "C" {
 
 #include "pycore_pystate.h"       // _PyThreadState_GET()
 
+/* Suggested size (number of positional arguments) for arrays of PyObject*
+   allocated on a C stack to avoid allocating memory on the heap memory. Such
+   array is used to pass positional arguments to call functions of the
+   PyObject_Vectorcall() family.
+
+   The size is chosen to not abuse the C stack and so limit the risk of stack
+   overflow. The size is also chosen to allow using the small stack for most
+   function calls of the Python standard library. On 64-bit CPU, it allocates
+   40 bytes on the stack. */
+#define _PY_FASTCALL_SMALL_STACK 5
+
+
 // Export for shared stdlib extensions like the math extension,
 // function used via inlined _PyObject_VectorcallTstate() function.
 PyAPI_FUNC(PyObject*) _Py_CheckFunctionResult(


### PR DESCRIPTION
Remove _PY_FASTCALL_SMALL_STACK constant from the C API: move it to the internal C API (pycore_call.h).

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-106023 -->
* Issue: gh-106023
<!-- /gh-issue-number -->
