### PR TITLE
gh-106023: Rename _PyObject_FastCallDictTstate()

### DIFF
--- a/Include/internal/pycore_call.h
+++ b/Include/internal/pycore_call.h
@@ -49,7 +49,7 @@ extern PyObject* _PyObject_Call_Prepend(
     PyObject *args,
     PyObject *kwargs);
 
-extern PyObject* _PyObject_FastCallDictTstate(
+extern PyObject* _PyObject_VectorcallDictTstate(
     PyThreadState *tstate,
     PyObject *callable,
     PyObject *const *args,

--- a/Objects/call.c
+++ b/Objects/call.c
@@ -106,9 +106,9 @@ PyObject_CallNoArgs(PyObject *func)
 
 
 PyObject *
-_PyObject_FastCallDictTstate(PyThreadState *tstate, PyObject *callable,
-                             PyObject *const *args, size_t nargsf,
-                             PyObject *kwargs)
+_PyObject_VectorcallDictTstate(PyThreadState *tstate, PyObject *callable,
+                               PyObject *const *args, size_t nargsf,
+                               PyObject *kwargs)
 {
     assert(callable != NULL);
 
@@ -154,7 +154,7 @@ PyObject_VectorcallDict(PyObject *callable, PyObject *const *args,
                        size_t nargsf, PyObject *kwargs)
 {
     PyThreadState *tstate = _PyThreadState_GET();
-    return _PyObject_FastCallDictTstate(tstate, callable, args, nargsf, kwargs);
+    return _PyObject_VectorcallDictTstate(tstate, callable, args, nargsf, kwargs);
 }
 
 static void
@@ -453,7 +453,8 @@ PyEval_CallObjectWithKeywords(PyObject *callable,
     }
 
     if (args == NULL) {
-        return _PyObject_FastCallDictTstate(tstate, callable, NULL, 0, kwargs);
+        return _PyObject_VectorcallDictTstate(tstate, callable,
+                                              NULL, 0, kwargs);
     }
     else {
         return _PyObject_Call(tstate, callable, args, kwargs);
@@ -506,9 +507,9 @@ _PyObject_Call_Prepend(PyThreadState *tstate, PyObject *callable,
            _PyTuple_ITEMS(args),
            argcount * sizeof(PyObject *));
 
-    PyObject *result = _PyObject_FastCallDictTstate(tstate, callable,
-                                                    stack, argcount + 1,
-                                                    kwargs);
+    PyObject *result = _PyObject_VectorcallDictTstate(tstate, callable,
+                                                      stack, argcount + 1,
+                                                      kwargs);
     if (stack != small_stack) {
         PyMem_Free(stack);
     }


### PR DESCRIPTION
Rename internal function _PyObject_FastCallDictTstate() to
_PyObject_VectorcallDictTstate().

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-106023 -->
* Issue: gh-106023
<!-- /gh-issue-number -->
