### PR TITLE
gh-106023: Remove _PyObject_FastCall() function

### DIFF
--- a/Doc/whatsnew/3.13.rst
+++ b/Doc/whatsnew/3.13.rst
@@ -597,3 +597,8 @@ Removed
 
   Just remove the underscore prefix to update your code.
   (Contributed by Victor Stinner in :gh:`106084`.)
+
+* Remove private ``_PyObject_FastCall()`` function:
+  use ``PyObject_Vectorcall()`` which is available since Python 3.8
+  (:pep:`590`).
+  (Contributed by Victor Stinner in :gh:`106023`.)

--- a/Include/cpython/abstract.h
+++ b/Include/cpython/abstract.h
@@ -24,12 +24,6 @@ PyAPI_FUNC(PyObject *) PyObject_VectorcallDict(
     size_t nargsf,
     PyObject *kwargs);
 
-// Same as PyObject_Vectorcall(), except without keyword arguments
-PyAPI_FUNC(PyObject *) _PyObject_FastCall(
-    PyObject *func,
-    PyObject *const *args,
-    Py_ssize_t nargs);
-
 PyAPI_FUNC(PyObject *) PyObject_CallOneArg(PyObject *func, PyObject *arg);
 
 static inline PyObject *

--- a/Lib/test/test_call.py
+++ b/Lib/test/test_call.py
@@ -519,19 +519,6 @@ class FastCallTests(unittest.TestCase):
                 expected = (*expected[:-1], result[-1])
         self.assertEqual(result, expected)
 
-    def test_fastcall(self):
-        # Test _PyObject_FastCall()
-
-        for func, args, expected in self.CALLS_POSARGS:
-            with self.subTest(func=func, args=args):
-                result = _testcapi.pyobject_fastcall(func, args)
-                self.check_result(result, expected)
-
-                if not args:
-                    # args=NULL, nargs=0
-                    result = _testcapi.pyobject_fastcall(func, None)
-                    self.check_result(result, expected)
-
     def test_vectorcall_dict(self):
         # Test PyObject_VectorcallDict()
 
@@ -945,11 +932,11 @@ class TestRecursion(unittest.TestCase):
 
         def c_recurse(n):
             if n:
-                _testcapi.pyobject_fastcall(c_recurse, (n-1,))
+                _testcapi.pyobject_vectorcall(c_recurse, (n-1,), ())
 
         def c_py_recurse(m):
             if m:
-                _testcapi.pyobject_fastcall(py_recurse, (1000, m))
+                _testcapi.pyobject_vectorcall(py_recurse, (1000, m), ())
 
         depth = sys.getrecursionlimit()
         sys.setrecursionlimit(100_000)

--- a/Lib/test/test_gdb.py
+++ b/Lib/test/test_gdb.py
@@ -729,13 +729,13 @@ class PyListTests(DebuggerTests):
 
 SAMPLE_WITH_C_CALL = """
 
-from _testcapi import pyobject_fastcall
+from _testcapi import pyobject_vectorcall
 
 def foo(a, b, c):
     bar(a, b, c)
 
 def bar(a, b, c):
-    pyobject_fastcall(baz, (a, b, c))
+    pyobject_vectorcall(baz, (a, b, c), None)
 
 def baz(*args):
     id(42)
@@ -756,7 +756,7 @@ class StackNavigationTests(DebuggerTests):
         self.assertMultilineMatches(bt,
                                     r'''^.*
 #[0-9]+ Frame 0x-?[0-9a-f]+, for file <string>, line 12, in baz \(args=\(1, 2, 3\)\)
-#[0-9]+ <built-in method pyobject_fastcall of module object at remote 0x[0-9a-f]+>
+#[0-9]+ <built-in method pyobject_vectorcall of module object at remote 0x[0-9a-f]+>
 $''')
 
     @unittest.skipUnless(HAS_PYUP_PYDOWN, "test requires py-up/py-down commands")
@@ -785,7 +785,7 @@ $''')
         self.assertMultilineMatches(bt,
                                     r'''^.*
 #[0-9]+ Frame 0x-?[0-9a-f]+, for file <string>, line 12, in baz \(args=\(1, 2, 3\)\)
-#[0-9]+ <built-in method pyobject_fastcall of module object at remote 0x[0-9a-f]+>
+#[0-9]+ <built-in method pyobject_vectorcall of module object at remote 0x[0-9a-f]+>
 #[0-9]+ Frame 0x-?[0-9a-f]+, for file <string>, line 12, in baz \(args=\(1, 2, 3\)\)
 $''')
 

--- a/Misc/NEWS.d/next/C API/2023-06-30-09-33-25.gh-issue-106023.YvYiE4.rst
+++ b/Misc/NEWS.d/next/C API/2023-06-30-09-33-25.gh-issue-106023.YvYiE4.rst
@@ -1,0 +1,2 @@
+Remove private ``_PyObject_FastCall()`` function: use ``PyObject_Vectorcall()``
+which is available since Python 3.8 (:pep:`590`). Patch by Victor Stinner.

--- a/Modules/_testcapi/vectorcall.c
+++ b/Modules/_testcapi/vectorcall.c
@@ -27,23 +27,6 @@ fastcall_args(PyObject *args, PyObject ***stack, Py_ssize_t *nargs)
 
 
 static PyObject *
-test_pyobject_fastcall(PyObject *self, PyObject *args)
-{
-    PyObject *func, *func_args;
-    PyObject **stack;
-    Py_ssize_t nargs;
-
-    if (!PyArg_ParseTuple(args, "OO", &func, &func_args)) {
-        return NULL;
-    }
-
-    if (fastcall_args(func_args, &stack, &nargs) < 0) {
-        return NULL;
-    }
-    return _PyObject_FastCall(func, stack, nargs);
-}
-
-static PyObject *
 test_pyobject_fastcalldict(PyObject *self, PyObject *args)
 {
     PyObject *func, *func_args, *kwargs;
@@ -259,7 +242,6 @@ _testcapi_has_vectorcall_flag_impl(PyObject *module, PyTypeObject *type)
 }
 
 static PyMethodDef TestMethods[] = {
-    {"pyobject_fastcall", test_pyobject_fastcall, METH_VARARGS},
     {"pyobject_fastcalldict", test_pyobject_fastcalldict, METH_VARARGS},
     {"pyobject_vectorcall", test_pyobject_vectorcall, METH_VARARGS},
     {"function_setvectorcall", function_setvectorcall, METH_O},

--- a/Objects/call.c
+++ b/Objects/call.c
@@ -328,14 +328,6 @@ PyObject_Vectorcall(PyObject *callable, PyObject *const *args,
 
 
 PyObject *
-_PyObject_FastCall(PyObject *func, PyObject *const *args, Py_ssize_t nargs)
-{
-    PyThreadState *tstate = _PyThreadState_GET();
-    return _PyObject_FastCallTstate(tstate, func, args, nargs);
-}
-
-
-PyObject *
 _PyObject_Call(PyThreadState *tstate, PyObject *callable,
                PyObject *args, PyObject *kwargs)
 {


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-106023 -->
* Issue: gh-106023
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--106265.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->