### PR TITLE
Remove private _PyCodec_Lookup() function

### DIFF
--- a/Include/codecs.h
+++ b/Include/codecs.h
@@ -35,34 +35,6 @@ PyAPI_FUNC(int) PyCodec_Unregister(
        PyObject *search_function
        );
 
-/* Codec registry lookup API.
-
-   Looks up the given encoding and returns a CodecInfo object with
-   function attributes which implement the different aspects of
-   processing the encoding.
-
-   The encoding string is looked up converted to all lower-case
-   characters. This makes encodings looked up through this mechanism
-   effectively case-insensitive.
-
-   If no codec is found, a KeyError is set and NULL returned.
-
-   As side effect, this tries to load the encodings package, if not
-   yet done. This is part of the lazy load strategy for the encodings
-   package.
-
- */
-
-#ifndef Py_LIMITED_API
-PyAPI_FUNC(PyObject *) _PyCodec_Lookup(
-       const char *encoding
-       );
-
-PyAPI_FUNC(int) _PyCodec_Forget(
-       const char *encoding
-       );
-#endif
-
 /* Codec registry encoding check API.
 
    Returns 1/0 depending on whether there is a registered codec for
@@ -106,102 +78,58 @@ PyAPI_FUNC(PyObject *) PyCodec_Decode(
        const char *errors
        );
 
-#ifndef Py_LIMITED_API
-/* Text codec specific encoding and decoding API.
+// --- Codec Lookup APIs --------------------------------------------------
 
-   Checks the encoding against a list of codecs which do not
-   implement a str<->bytes encoding before attempting the
-   operation.
+/* Codec registry lookup API.
 
-   Please note that these APIs are internal and should not
-   be used in Python C extensions.
+   Looks up the given encoding and returns a CodecInfo object with
+   function attributes which implement the different aspects of
+   processing the encoding.
 
-   XXX (ncoghlan): should we make these, or something like them, public
-   in Python 3.5+?
+   The encoding string is looked up converted to all lower-case
+   characters. This makes encodings looked up through this mechanism
+   effectively case-insensitive.
 
+   If no codec is found, a KeyError is set and NULL returned.
+
+   As side effect, this tries to load the encodings package, if not
+   yet done. This is part of the lazy load strategy for the encodings
+   package.
  */
-PyAPI_FUNC(PyObject *) _PyCodec_LookupTextEncoding(
-       const char *encoding,
-       const char *alternate_command
-       );
-
-PyAPI_FUNC(PyObject *) _PyCodec_EncodeText(
-       PyObject *object,
-       const char *encoding,
-       const char *errors
-       );
-
-PyAPI_FUNC(PyObject *) _PyCodec_DecodeText(
-       PyObject *object,
-       const char *encoding,
-       const char *errors
-       );
-
-/* These two aren't actually text encoding specific, but _io.TextIOWrapper
- * is the only current API consumer.
- */
-PyAPI_FUNC(PyObject *) _PyCodecInfo_GetIncrementalDecoder(
-       PyObject *codec_info,
-       const char *errors
-       );
-
-PyAPI_FUNC(PyObject *) _PyCodecInfo_GetIncrementalEncoder(
-       PyObject *codec_info,
-       const char *errors
-       );
-#endif
-
-
-
-/* --- Codec Lookup APIs --------------------------------------------------
-
-   All APIs return a codec object with incremented refcount and are
-   based on _PyCodec_Lookup().  The same comments w/r to the encoding
-   name also apply to these APIs.
-
-*/
 
 /* Get an encoder function for the given encoding. */
 
-PyAPI_FUNC(PyObject *) PyCodec_Encoder(
-       const char *encoding
-       );
+PyAPI_FUNC(PyObject *) PyCodec_Encoder(const char *encoding);
 
 /* Get a decoder function for the given encoding. */
 
-PyAPI_FUNC(PyObject *) PyCodec_Decoder(
-       const char *encoding
-       );
+PyAPI_FUNC(PyObject *) PyCodec_Decoder(const char *encoding);
 
 /* Get an IncrementalEncoder object for the given encoding. */
 
 PyAPI_FUNC(PyObject *) PyCodec_IncrementalEncoder(
-       const char *encoding,
-       const char *errors
-       );
+   const char *encoding,
+   const char *errors);
 
 /* Get an IncrementalDecoder object function for the given encoding. */
 
 PyAPI_FUNC(PyObject *) PyCodec_IncrementalDecoder(
-       const char *encoding,
-       const char *errors
-       );
+   const char *encoding,
+   const char *errors);
 
 /* Get a StreamReader factory function for the given encoding. */
 
 PyAPI_FUNC(PyObject *) PyCodec_StreamReader(
-       const char *encoding,
-       PyObject *stream,
-       const char *errors
-       );
+   const char *encoding,
+   PyObject *stream,
+   const char *errors);
 
 /* Get a StreamWriter factory function for the given encoding. */
 
 PyAPI_FUNC(PyObject *) PyCodec_StreamWriter(
-       const char *encoding,
-       PyObject *stream,
-       const char *errors
-       );
+   const char *encoding,
+   PyObject *stream,
+   const char *errors);
 
 /* Unicode encoding error handling callback registry API */
 

--- a/Include/internal/pycore_codecs.h
+++ b/Include/internal/pycore_codecs.h
@@ -1,0 +1,53 @@
+#ifndef Py_INTERNAL_CODECS_H
+#define Py_INTERNAL_CODECS_H
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+extern PyObject* _PyCodec_Lookup(const char *encoding);
+
+extern int _PyCodec_Forget(const char *encoding);
+
+/* Text codec specific encoding and decoding API.
+
+   Checks the encoding against a list of codecs which do not
+   implement a str<->bytes encoding before attempting the
+   operation.
+
+   Please note that these APIs are internal and should not
+   be used in Python C extensions.
+
+   XXX (ncoghlan): should we make these, or something like them, public
+   in Python 3.5+?
+
+ */
+extern PyObject* _PyCodec_LookupTextEncoding(
+   const char *encoding,
+   const char *alternate_command);
+
+extern PyObject* _PyCodec_EncodeText(
+   PyObject *object,
+   const char *encoding,
+   const char *errors);
+
+extern PyObject* _PyCodec_DecodeText(
+   PyObject *object,
+   const char *encoding,
+   const char *errors);
+
+/* These two aren't actually text encoding specific, but _io.TextIOWrapper
+ * is the only current API consumer.
+ */
+extern PyObject* _PyCodecInfo_GetIncrementalDecoder(
+   PyObject *codec_info,
+   const char *errors);
+
+extern PyObject* _PyCodecInfo_GetIncrementalEncoder(
+   PyObject *codec_info,
+   const char *errors);
+
+
+#ifdef __cplusplus
+}
+#endif
+#endif /* !Py_INTERNAL_CODECS_H */

--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -1732,6 +1732,7 @@ PYTHON_HEADERS= \
 		$(srcdir)/Include/internal/pycore_ceval.h \
 		$(srcdir)/Include/internal/pycore_ceval_state.h \
 		$(srcdir)/Include/internal/pycore_code.h \
+		$(srcdir)/Include/internal/pycore_codecs.h \
 		$(srcdir)/Include/internal/pycore_compile.h \
 		$(srcdir)/Include/internal/pycore_condvar.h \
 		$(srcdir)/Include/internal/pycore_context.h \

--- a/Modules/_codecsmodule.c
+++ b/Modules/_codecsmodule.c
@@ -32,6 +32,7 @@ Copyright (c) Corporation for National Research Initiatives.
 
 #define PY_SSIZE_T_CLEAN
 #include "Python.h"
+#include "pycore_codecs.h"        // _PyCodec_Lookup()
 
 #ifdef MS_WINDOWS
 #include <windows.h>

--- a/Modules/_io/textio.c
+++ b/Modules/_io/textio.c
@@ -9,6 +9,7 @@
 #define PY_SSIZE_T_CLEAN
 #include "Python.h"
 #include "pycore_call.h"          // _PyObject_CallMethod()
+#include "pycore_codecs.h"        // _PyCodecInfo_GetIncrementalDecoder()
 #include "pycore_interp.h"        // PyInterpreterState.fs_codec
 #include "pycore_long.h"          // _PyLong_GetZero()
 #include "pycore_fileutils.h"     // _Py_GetLocaleEncoding()

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -42,8 +42,9 @@ OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #include "Python.h"
 #include "pycore_abstract.h"      // _PyIndex_Check()
 #include "pycore_atomic_funcs.h"  // _Py_atomic_size_get()
-#include "pycore_bytesobject.h"   // _PyBytes_Repeat()
 #include "pycore_bytes_methods.h" // _Py_bytes_lower()
+#include "pycore_bytesobject.h"   // _PyBytes_Repeat()
+#include "pycore_codecs.h"        // _PyCodec_Lookup()
 #include "pycore_format.h"        // F_LJUST
 #include "pycore_initconfig.h"    // _PyStatus_OK()
 #include "pycore_interp.h"        // PyInterpreterState.fs_codec

--- a/PCbuild/pythoncore.vcxproj
+++ b/PCbuild/pythoncore.vcxproj
@@ -209,6 +209,7 @@
     <ClInclude Include="..\Include\internal\pycore_ceval_state.h" />
     <ClInclude Include="..\Include\internal\pycore_cfg.h" />
     <ClInclude Include="..\Include\internal\pycore_code.h" />
+    <ClInclude Include="..\Include\internal\pycore_codecs.h" />
     <ClInclude Include="..\Include\internal\pycore_compile.h" />
     <ClInclude Include="..\Include\internal\pycore_condvar.h" />
     <ClInclude Include="..\Include\internal\pycore_context.h" />

--- a/PCbuild/pythoncore.vcxproj.filters
+++ b/PCbuild/pythoncore.vcxproj.filters
@@ -537,6 +537,9 @@
     <ClInclude Include="..\Include\internal\pycore_code.h">
       <Filter>Include\internal</Filter>
     </ClInclude>
+    <ClInclude Include="..\Include\internal\pycore_codecs.h">
+      <Filter>Include\internal</Filter>
+    </ClInclude>
     <ClInclude Include="..\Include\internal\pycore_compile.h">
       <Filter>Include\internal</Filter>
     </ClInclude>

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -4,6 +4,7 @@
 
 #include "pycore_call.h"          // _PyObject_CallMethod()
 #include "pycore_ceval.h"         // _PyEval_FiniGIL()
+#include "pycore_codecs.h"        // _PyCodec_Lookup()
 #include "pycore_context.h"       // _PyContext_Init()
 #include "pycore_dict.h"          // _PyDict_Fini()
 #include "pycore_exceptions.h"    // _PyExc_InitTypes()


### PR DESCRIPTION
Remove the following private functions of the C API:

* _PyCodecInfo_GetIncrementalDecoder()
* _PyCodecInfo_GetIncrementalEncoder()
* _PyCodec_DecodeText()
* _PyCodec_EncodeText()
* _PyCodec_Forget()
* _PyCodec_Lookup()
* _PyCodec_LookupTextEncoding()

Move these functions to a new pycore_codecs.h internal header file.

These functions are no longer exported.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
