### PR TITLE
Fix the french used in the email documentation

### DIFF
--- a/Doc/includes/email-alternative.py
+++ b/Doc/includes/email-alternative.py
@@ -8,14 +8,14 @@ from email.utils import make_msgid
 
 # Create the base text message.
 msg = EmailMessage()
-msg['Subject'] = "Ayons asperges pour le déjeuner"
+msg['Subject'] = "Pourquoi pas des asperges pour ce midi?"
 msg['From'] = Address("Pepé Le Pew", "pepe", "example.com")
 msg['To'] = (Address("Penelope Pussycat", "penelope", "example.com"),
              Address("Fabrette Pussycat", "fabrette", "example.com"))
 msg.set_content("""\
 Salut!
 
-Cela ressemble à un excellent recipie[1] déjeuner.
+Cette recette [1] sera sûrement un très bon repas.
 
 [1] http://www.yummly.com/recipe/Roasted-Asparagus-Epicurious-203718
 
@@ -31,10 +31,10 @@ msg.add_alternative("""\
   <head></head>
   <body>
     <p>Salut!</p>
-    <p>Cela ressemble à un excellent
+    <p>Cette
         <a href="http://www.yummly.com/recipe/Roasted-Asparagus-Epicurious-203718">
-            recipie
-        </a> déjeuner.
+            recette
+        </a> sera sûrement un très bon repas.
     </p>
     <img src="cid:{asparagus_cid}" />
   </body>

--- a/Doc/includes/email-alternative.py
+++ b/Doc/includes/email-alternative.py
@@ -8,7 +8,7 @@ from email.utils import make_msgid
 
 # Create the base text message.
 msg = EmailMessage()
-msg['Subject'] = "Pourquoi pas des asperges pour ce midi?"
+msg['Subject'] = "Pourquoi pas des asperges pour ce midi ?"
 msg['From'] = Address("Pepé Le Pew", "pepe", "example.com")
 msg['To'] = (Address("Penelope Pussycat", "penelope", "example.com"),
              Address("Fabrette Pussycat", "fabrette", "example.com"))

--- a/Doc/library/email.examples.rst
+++ b/Doc/library/email.examples.rst
@@ -55,11 +55,11 @@ Up to the prompt, the output from the above is:
 
     To: Penelope Pussycat <penelope@example.com>, Fabrette Pussycat <fabrette@example.com>
     From: Pepé Le Pew <pepe@example.com>
-    Subject: Ayons asperges pour le déjeuner
+    Subject: Pourquoi pas des asperges pour ce midi?
 
     Salut!
 
-    Cela ressemble à un excellent recipie[1] déjeuner.
+    Cette recette [1] sera sûrement un très bon repas.
 
 
 .. rubric:: Footnotes

--- a/Doc/library/email.examples.rst
+++ b/Doc/library/email.examples.rst
@@ -55,7 +55,7 @@ Up to the prompt, the output from the above is:
 
     To: Penelope Pussycat <penelope@example.com>, Fabrette Pussycat <fabrette@example.com>
     From: Pepé Le Pew <pepe@example.com>
-    Subject: Pourquoi pas des asperges pour ce midi?
+    Subject: Pourquoi pas des asperges pour ce midi ?
 
     Salut!
 


### PR DESCRIPTION
The french used in one of the example was either machine translated a while ago or written by someone who does not speak french. Fixed it by using grammatically correct french.

I could also change it to english if this is the preferred approach.

Since it is a trivial doc change, I did not make an issue.
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--106279.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->