### PR TITLE
gh-91053: make func watcher tests resilient to other func watchers

### DIFF
--- a/Modules/_testcapi/watchers.c
+++ b/Modules/_testcapi/watchers.c
@@ -432,9 +432,9 @@ allocate_too_many_code_watchers(PyObject *self, PyObject *args)
 
 // Test function watchers
 
-#define NUM_FUNC_WATCHERS 2
-static PyObject *pyfunc_watchers[NUM_FUNC_WATCHERS];
-static int func_watcher_ids[NUM_FUNC_WATCHERS] = {-1, -1};
+#define NUM_TEST_FUNC_WATCHERS 2
+static PyObject *pyfunc_watchers[NUM_TEST_FUNC_WATCHERS];
+static int func_watcher_ids[NUM_TEST_FUNC_WATCHERS] = {-1, -1};
 
 static PyObject *
 get_id(PyObject *obj)
@@ -508,7 +508,7 @@ second_func_watcher_callback(PyFunction_WatchEvent event,
     return call_pyfunc_watcher(pyfunc_watchers[1], event, func, new_value);
 }
 
-static PyFunction_WatchCallback func_watcher_callbacks[NUM_FUNC_WATCHERS] = {
+static PyFunction_WatchCallback func_watcher_callbacks[NUM_TEST_FUNC_WATCHERS] = {
     first_func_watcher_callback,
     second_func_watcher_callback
 };
@@ -533,26 +533,25 @@ add_func_watcher(PyObject *self, PyObject *func)
         return NULL;
     }
     int idx = -1;
-    for (int i = 0; i < NUM_FUNC_WATCHERS; i++) {
+    for (int i = 0; i < NUM_TEST_FUNC_WATCHERS; i++) {
         if (func_watcher_ids[i] == -1) {
             idx = i;
             break;
         }
     }
     if (idx == -1) {
-        PyErr_SetString(PyExc_RuntimeError, "no free watchers");
-        return NULL;
-    }
-    PyObject *result = PyLong_FromLong(idx);
-    if (result == NULL) {
+        PyErr_SetString(PyExc_RuntimeError, "no free test watchers");
         return NULL;
     }
     func_watcher_ids[idx] = PyFunction_AddWatcher(func_watcher_callbacks[idx]);
     if (func_watcher_ids[idx] < 0) {
-        Py_DECREF(result);
         return NULL;
     }
     pyfunc_watchers[idx] = Py_NewRef(func);
+    PyObject *result = PyLong_FromLong(func_watcher_ids[idx]);
+    if (result == NULL) {
+        return NULL;
+    }
     return result;
 }
 
@@ -569,7 +568,7 @@ clear_func_watcher(PyObject *self, PyObject *watcher_id_obj)
         return NULL;
     }
     int idx = -1;
-    for (int i = 0; i < NUM_FUNC_WATCHERS; i++) {
+    for (int i = 0; i < NUM_TEST_FUNC_WATCHERS; i++) {
         if (func_watcher_ids[i] == wid) {
             idx = i;
             break;


### PR DESCRIPTION
In order to bridge between the C-only function watchers API and the func watcher tests written in Python, the support code in testcapimodule maintains a mapping between an array of up to two test func watchers (indices 0 and 1) and the real func watcher IDs (returned by `PyFunction_AddWatcher`) corresponding to those test watcher indices.

`add_func_watcher` and `clear_func_watcher` in testcapimodule disagreed about which of those ids should be exposed to the Python test code. `add_func_watcher` returned the "test watcher index" (always 0 or 1), but `clear_func_watcher` expected the real watcher ID.

When the tests are run with no other func watchers active, this confusion doesn't matter, because the ids will always match up exactly; test watchers 0 and 1 will always have the real watcher IDs 0 and 1. But if the tests are run with another func watcher active (e.g. from a third-party JIT), the IDs will no longer match up (test watchers 0 and 1 will have real watcher IDs 1 and 2), and this breaks some tests.

Fix `add_func_watcher` so that we always expose real watcher IDs (not test watcher indices) to the Python tests.

(It's necessary to make the fix in this direction because of `test_clear_unassigned_watcher_id`, which needs to pass an unassigned real watcher ID through to `PyFunction_ClearWatcher`.)

Also rename `NUM_FUNC_WATCHERS` to `NUM_TEST_FUNC_WATCHERS` to help clarify this distinction in the code, and update an error message to be clearer that there are no test watcher indices free; there may still be actual watcher slots free.

<!-- gh-issue-number: gh-91053 -->
* Issue: gh-91053
<!-- /gh-issue-number -->
