### PR TITLE
gh-106300: Improve `assertRaises(Exception)` usages in tests

### DIFF
--- a/Lib/test/test_abc.py
+++ b/Lib/test/test_abc.py
@@ -448,15 +448,16 @@ def test_factory(abc_ABCMeta, abc_get_cache_token):
 
             # Also check that issubclass() propagates exceptions raised by
             # __subclasses__.
+            class CustomError(Exception): ...
             exc_msg = "exception from __subclasses__"
 
             def raise_exc():
-                raise Exception(exc_msg)
+                raise CustomError(exc_msg)
 
             class S(metaclass=abc_ABCMeta):
                 __subclasses__ = raise_exc
 
-            with self.assertRaisesRegex(Exception, exc_msg):
+            with self.assertRaisesRegex(CustomError, exc_msg):
                 issubclass(int, S)
 
         def test_subclasshook(self):

--- a/Lib/test/test_codecs.py
+++ b/Lib/test/test_codecs.py
@@ -2828,8 +2828,9 @@ class TransformCodecTest(unittest.TestCase):
 
     def test_custom_hex_error_is_noted(self):
         # Check hex codec gives a good error for malformed input
+        import binascii
         msg = "decoding with 'hex_codec' codec failed"
-        with self.assertRaises(zlib.error) as failure:
+        with self.assertRaises(binascii.Error) as failure:
             codecs.decode(b"hello", "hex_codec")
         self.assertEqual(msg, failure.exception.__notes__[0])
 

--- a/Lib/test/test_codecs.py
+++ b/Lib/test/test_codecs.py
@@ -2822,14 +2822,14 @@ class TransformCodecTest(unittest.TestCase):
     def test_custom_zlib_error_is_noted(self):
         # Check zlib codec gives a good error for malformed input
         msg = "decoding with 'zlib_codec' codec failed"
-        with self.assertRaises(Exception) as failure:
+        with self.assertRaises(zlib.error) as failure:
             codecs.decode(b"hello", "zlib_codec")
         self.assertEqual(msg, failure.exception.__notes__[0])
 
     def test_custom_hex_error_is_noted(self):
         # Check hex codec gives a good error for malformed input
         msg = "decoding with 'hex_codec' codec failed"
-        with self.assertRaises(Exception) as failure:
+        with self.assertRaises(zlib.error) as failure:
             codecs.decode(b"hello", "hex_codec")
         self.assertEqual(msg, failure.exception.__notes__[0])
 

--- a/Lib/test/test_email/test_message.py
+++ b/Lib/test/test_email/test_message.py
@@ -696,14 +696,16 @@ class TestEmailMessageBase:
             self.assertIsNone(part['Content-Disposition'])
 
     class _TestSetRaisingContentManager:
+        class CustomError(Exception):
+            pass
         def set_content(self, msg, content, *args, **kw):
-            raise Exception('test')
+            raise self.CustomError('test')
 
     def test_default_content_manager_for_add_comes_from_policy(self):
         cm = self._TestSetRaisingContentManager()
         m = self.message(policy=self.policy.clone(content_manager=cm))
         for method in ('add_related', 'add_alternative', 'add_attachment'):
-            with self.assertRaises(Exception) as ar:
+            with self.assertRaises(self._TestSetRaisingContentManager.CustomError) as ar:
                 getattr(m, method)('')
             self.assertEqual(str(ar.exception), 'test')
 

--- a/Lib/test/test_importlib/test_main.py
+++ b/Lib/test/test_importlib/test_main.py
@@ -68,7 +68,7 @@ class BasicTests(fixtures.DistInfoPkg, unittest.TestCase):
         dict(name=''),
     )
     def test_invalid_inputs_to_from_name(self, name):
-        with self.assertRaises(Exception):
+        with self.assertRaises(ValueError):
             Distribution.from_name(name)
 
 

--- a/Lib/test/test_mailbox.py
+++ b/Lib/test/test_mailbox.py
@@ -116,10 +116,13 @@ class TestMailbox(TestBase):
         self.assertMailboxEmpty()
 
     def test_add_that_raises_leaves_mailbox_empty(self):
+        class CustomError(Exception): ...
+        exc_msg = "a fake error"
+
         def raiser(*args, **kw):
-            raise Exception("a fake error")
+            raise CustomError(exc_msg)
         support.patch(self, email.generator.BytesGenerator, 'flatten', raiser)
-        with self.assertRaises(Exception):
+        with self.assertRaisesRegex(CustomError, exc_msg):
             self._box.add(email.message_from_string("From: Alphöso"))
         self.assertEqual(len(self._box), 0)
         self._box.close()

--- a/Lib/test/test_shutil.py
+++ b/Lib/test/test_shutil.py
@@ -2738,7 +2738,7 @@ class _ZeroCopyFileTest(object):
     def test_same_file(self):
         self.addCleanup(self.reset)
         with self.get_files() as (src, dst):
-            with self.assertRaises(OSError):
+            with self.assertRaises((OSError, _GiveupOnFastCopy)):
                 self.zerocopy_fun(src, src)
         # Make sure src file is not corrupted.
         self.assertEqual(read_file(TESTFN, binary=True), self.FILEDATA)

--- a/Lib/test/test_shutil.py
+++ b/Lib/test/test_shutil.py
@@ -2738,7 +2738,7 @@ class _ZeroCopyFileTest(object):
     def test_same_file(self):
         self.addCleanup(self.reset)
         with self.get_files() as (src, dst):
-            with self.assertRaises(Exception):
+            with self.assertRaises(OSError):
                 self.zerocopy_fun(src, src)
         # Make sure src file is not corrupted.
         self.assertEqual(read_file(TESTFN, binary=True), self.FILEDATA)

--- a/Lib/test/test_unittest/testmock/testasync.py
+++ b/Lib/test/test_unittest/testmock/testasync.py
@@ -459,9 +459,10 @@ class AsyncArguments(IsolatedAsyncioTestCase):
         self.assertEqual(output, 10)
 
     async def test_add_side_effect_exception(self):
+        class CustomError(Exception): pass
         async def addition(var): pass
-        mock = AsyncMock(addition, side_effect=Exception('err'))
-        with self.assertRaises(Exception):
+        mock = AsyncMock(addition, side_effect=CustomError('side-effect'))
+        with self.assertRaisesRegex(CustomError, 'side-effect'):
             await mock(5)
 
     async def test_add_side_effect_coroutine(self):


### PR DESCRIPTION
Things I did:
1. I've used some real exceptions that is raised by stdlib code, where exception is known: `zlib.error` as an example
2. I've added several `CustomError` definitions to be sure that we get what we expect in a custom raising code
3. I've also specified error message with `assertRaisesRegex` where possible

Note that `test_unittest` will have its own PR due to bugs I found in https://github.com/python/cpython/issues/106300#issuecomment-1615601842

This PR does only change semantics, no bugs.

<!-- gh-issue-number: gh-106300 -->
* Issue: gh-106300
<!-- /gh-issue-number -->
