### PR TITLE
gh-102541: Add test case for help() for non_existent_module

### DIFF
--- a/Lib/test/test_pydoc.py
+++ b/Lib/test/test_pydoc.py
@@ -636,11 +636,15 @@ class PydocDocTest(unittest.TestCase):
         fd, name = tempfile.mkstemp()
         self.addCleanup(os_helper.unlink, name)
         with open(fd, "w") as f:
-            f.write("help('abd')")
+            f.write("help()")
         with spawn_python(name) as proc:
-            out, _ = proc.communicate()
-            out = out.decode()
-            expected = missing_pattern % "abd"
+            out, _ = proc.communicate(b"abd")
+            pretty_string = out.decode().replace("help> ", "")
+            pretty_expected = missing_pattern.replace(os.linesep, "")
+            lines = pretty_string.splitlines()
+            last_lines = lines[-10:-6]
+            out = "".join(last_lines)
+            expected = pretty_expected % "abd"
             self.assertEqual(expected, out.strip())
 
     def test_fail_help_output_redirect(self):

--- a/Lib/test/test_pydoc.py
+++ b/Lib/test/test_pydoc.py
@@ -24,9 +24,8 @@ from collections import namedtuple
 from urllib.request import urlopen, urlcleanup
 from test.support import import_helper
 from test.support import os_helper
-from test.support.script_helper import (assert_python_ok, kill_python,
+from test.support.script_helper import (assert_python_ok,
                                         assert_python_failure, spawn_python)
-
 from test.support import threading_helper
 from test.support import (reap_children, captured_output, captured_stdout,
                           captured_stderr, is_emscripten, is_wasi,

--- a/Lib/test/test_pydoc.py
+++ b/Lib/test/test_pydoc.py
@@ -633,19 +633,12 @@ class PydocDocTest(unittest.TestCase):
         self.assertNotIn('Built-in subclasses', text)
 
     def test_fail_help_cli(self):
-        fd, name = tempfile.mkstemp()
-        self.addCleanup(os_helper.unlink, name)
-        with open(fd, "w") as f:
-            f.write("help()")
-        with spawn_python(name) as proc:
+        elines = (missing_pattern % 'abd').splitlines()
+        with spawn_python("-c" "help()") as proc:
             out, _ = proc.communicate(b"abd")
-            pretty_string = out.decode().replace("help> ", "")
-            pretty_expected = missing_pattern.replace(os.linesep, "")
-            lines = pretty_string.splitlines()
-            last_lines = lines[-10:-6]
-            out = "".join(last_lines)
-            expected = pretty_expected % "abd"
-            self.assertEqual(expected, out.strip())
+            olines = out.decode().splitlines()[-9:-6]
+            olines[0] = olines[0].removeprefix('help> ')
+            self.assertEqual(elines, olines)
 
     def test_fail_help_output_redirect(self):
         with StringIO() as buf:


### PR DESCRIPTION
Test fix for when enter, for instance, 'abd' at 'help>' prompt.

<!-- gh-issue-number: gh-102541 -->
* Issue: gh-102541
<!-- /gh-issue-number -->
