### PR TITLE
gh-106320: _testcapi avoids private _PyUnicode_EqualToASCIIString()

### DIFF
--- a/Modules/_testcapi/unicode.c
+++ b/Modules/_testcapi/unicode.c
@@ -1100,7 +1100,7 @@ test_string_from_format(PyObject *self, PyObject *Py_UNUSED(ignored))
     }                                                               \
     else if (result == NULL)                                        \
         return NULL;                                                \
-    else if (!_PyUnicode_EqualToASCIIString(result, EXPECTED)) {    \
+    else if (PyUnicode_CompareWithASCIIString(result, EXPECTED) != 0) { \
         PyErr_Format(PyExc_AssertionError,                          \
                      "test_string_from_format: failed at \"%s\" "   \
                      "expected \"%s\" got \"%s\"",                  \


### PR DESCRIPTION
Replace private _PyUnicode_EqualToASCIIString() with public PyUnicode_CompareWithASCIIString().

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-106320 -->
* Issue: gh-106320
<!-- /gh-issue-number -->
