### PR TITLE
gh-106320: Remove private _PyErr C API functions

### DIFF
--- a/Include/cpython/pyerrors.h
+++ b/Include/cpython/pyerrors.h
@@ -91,30 +91,13 @@ typedef PyOSErrorObject PyWindowsErrorObject;
 /* Error handling definitions */
 
 PyAPI_FUNC(void) _PyErr_SetKeyError(PyObject *);
-PyAPI_FUNC(_PyErr_StackItem*) _PyErr_GetTopmostException(PyThreadState *tstate);
-PyAPI_FUNC(PyObject*) _PyErr_GetHandledException(PyThreadState *);
-PyAPI_FUNC(void) _PyErr_SetHandledException(PyThreadState *, PyObject *);
-PyAPI_FUNC(void) _PyErr_GetExcInfo(PyThreadState *, PyObject **, PyObject **, PyObject **);
 
 /* Context manipulation (PEP 3134) */
 
 Py_DEPRECATED(3.12) PyAPI_FUNC(void) _PyErr_ChainExceptions(PyObject *, PyObject *, PyObject *);
 PyAPI_FUNC(void) _PyErr_ChainExceptions1(PyObject *);
 
-/* Like PyErr_Format(), but saves current exception as __context__ and
-   __cause__.
- */
-PyAPI_FUNC(PyObject *) _PyErr_FormatFromCause(
-    PyObject *exception,
-    const char *format,   /* ASCII-encoded string  */
-    ...
-    );
-
 /* In exceptions.c */
-
-PyAPI_FUNC(int) _PyException_AddNote(
-     PyObject *exc,
-     PyObject *note);
 
 PyAPI_FUNC(PyObject*) PyUnstable_Exc_PrepReraiseStar(
      PyObject *orig,
@@ -123,7 +106,6 @@ PyAPI_FUNC(PyObject*) PyUnstable_Exc_PrepReraiseStar(
 /* In signalmodule.c */
 
 int PySignal_SetWakeupFd(int fd);
-PyAPI_FUNC(int) _PyErr_CheckSignals(void);
 
 /* Support for adding program text to SyntaxErrors */
 
@@ -143,18 +125,6 @@ PyAPI_FUNC(PyObject *) PyErr_ProgramTextObject(
     PyObject *filename,
     int lineno);
 
-PyAPI_FUNC(PyObject *) _PyErr_ProgramDecodedTextObject(
-    PyObject *filename,
-    int lineno,
-    const char* encoding);
-
-PyAPI_FUNC(PyObject *) _PyUnicodeTranslateError_Create(
-    PyObject *object,
-    Py_ssize_t start,
-    Py_ssize_t end,
-    const char *reason          /* UTF-8 encoded string */
-    );
-
 PyAPI_FUNC(void) _PyErr_WriteUnraisableMsg(
     const char *err_msg,
     PyObject *obj);
@@ -162,17 +132,5 @@ PyAPI_FUNC(void) _PyErr_WriteUnraisableMsg(
 PyAPI_FUNC(void) _Py_NO_RETURN _Py_FatalErrorFunc(
     const char *func,
     const char *message);
-
-PyAPI_FUNC(void) _Py_NO_RETURN _Py_FatalErrorFormat(
-    const char *func,
-    const char *format,
-    ...);
-
-extern PyObject *_PyErr_SetImportErrorWithNameFrom(
-        PyObject *,
-        PyObject *,
-        PyObject *,
-        PyObject *);
-
 
 #define Py_FatalError(message) _Py_FatalErrorFunc(__func__, (message))

--- a/Include/internal/pycore_pyerrors.h
+++ b/Include/internal/pycore_pyerrors.h
@@ -9,6 +9,54 @@ extern "C" {
 #endif
 
 
+/* Error handling definitions */
+
+PyAPI_FUNC(_PyErr_StackItem*) _PyErr_GetTopmostException(PyThreadState *tstate);
+PyAPI_FUNC(PyObject*) _PyErr_GetHandledException(PyThreadState *);
+PyAPI_FUNC(void) _PyErr_SetHandledException(PyThreadState *, PyObject *);
+PyAPI_FUNC(void) _PyErr_GetExcInfo(PyThreadState *, PyObject **, PyObject **, PyObject **);
+
+/* Like PyErr_Format(), but saves current exception as __context__ and
+   __cause__.
+ */
+PyAPI_FUNC(PyObject *) _PyErr_FormatFromCause(
+    PyObject *exception,
+    const char *format,   /* ASCII-encoded string  */
+    ...
+    );
+
+PyAPI_FUNC(int) _PyException_AddNote(
+     PyObject *exc,
+     PyObject *note);
+
+PyAPI_FUNC(int) _PyErr_CheckSignals(void);
+
+/* Support for adding program text to SyntaxErrors */
+
+PyAPI_FUNC(PyObject *) _PyErr_ProgramDecodedTextObject(
+    PyObject *filename,
+    int lineno,
+    const char* encoding);
+
+PyAPI_FUNC(PyObject *) _PyUnicodeTranslateError_Create(
+    PyObject *object,
+    Py_ssize_t start,
+    Py_ssize_t end,
+    const char *reason          /* UTF-8 encoded string */
+    );
+
+PyAPI_FUNC(void) _Py_NO_RETURN _Py_FatalErrorFormat(
+    const char *func,
+    const char *format,
+    ...);
+
+extern PyObject *_PyErr_SetImportErrorWithNameFrom(
+        PyObject *,
+        PyObject *,
+        PyObject *,
+        PyObject *);
+
+
 /* runtime lifecycle */
 
 extern PyStatus _PyErr_InitTypes(PyInterpreterState *);

--- a/Modules/_io/bufferedio.c
+++ b/Modules/_io/bufferedio.c
@@ -10,6 +10,7 @@
 #include "Python.h"
 #include "pycore_call.h"          // _PyObject_CallNoArgs()
 #include "pycore_object.h"
+#include "pycore_pyerrors.h"      // _Py_FatalErrorFormat()
 #include "structmember.h"         // PyMemberDef
 #include "_iomodule.h"
 

--- a/Modules/_sqlite/cursor.c
+++ b/Modules/_sqlite/cursor.c
@@ -21,10 +21,16 @@
  * 3. This notice may not be removed or altered from any source distribution.
  */
 
+#ifndef Py_BUILD_CORE_BUILTIN
+#  define Py_BUILD_CORE_MODULE 1
+#endif
+
 #include "cursor.h"
 #include "microprotocols.h"
 #include "module.h"
 #include "util.h"
+
+#include "pycore_pyerrors.h"      // _PyErr_FormatFromCause()
 
 typedef enum {
     TYPE_LONG,

--- a/Objects/moduleobject.c
+++ b/Objects/moduleobject.c
@@ -4,9 +4,10 @@
 #include "Python.h"
 #include "pycore_call.h"          // _PyObject_CallNoArgs()
 #include "pycore_interp.h"        // PyInterpreterState.importlib
-#include "pycore_object.h"        // _PyType_AllocNoTrack
-#include "pycore_moduleobject.h"  // _PyModule_GetDef()
 #include "pycore_modsupport.h"    // _PyModule_CreateInitialized()
+#include "pycore_moduleobject.h"  // _PyModule_GetDef()
+#include "pycore_object.h"        // _PyType_AllocNoTrack
+#include "pycore_pyerrors.h"      // _PyErr_FormatFromCause()
 #include "pycore_pystate.h"       // _PyInterpreterState_GET()
 #include "structmember.h"         // PyMemberDef
 

--- a/Objects/obmalloc.c
+++ b/Objects/obmalloc.c
@@ -2,10 +2,10 @@
 
 #include "Python.h"
 #include "pycore_code.h"          // stats
-#include "pycore_pystate.h"       // _PyInterpreterState_GET
-
 #include "pycore_obmalloc.h"
+#include "pycore_pyerrors.h"      // _Py_FatalErrorFormat()
 #include "pycore_pymem.h"
+#include "pycore_pystate.h"       // _PyInterpreterState_GET
 
 #include <stdlib.h>               // malloc()
 #include <stdbool.h>

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -50,6 +50,7 @@ OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #include "pycore_long.h"          // _PyLong_FormatWriter()
 #include "pycore_object.h"        // _PyObject_GC_TRACK(), _Py_FatalRefcountError()
 #include "pycore_pathconfig.h"    // _Py_DumpPathConfig()
+#include "pycore_pyerrors.h"      // _PyUnicodeTranslateError_Create()
 #include "pycore_pylifecycle.h"   // _Py_SetFileSystemEncoding()
 #include "pycore_pystate.h"       // _PyInterpreterState_GET()
 #include "pycore_ucnhash.h"       // _PyUnicode_Name_CAPI

--- a/Parser/pegen_errors.c
+++ b/Parser/pegen_errors.c
@@ -1,6 +1,7 @@
 #include <Python.h>
 #include <errcode.h>
 
+#include "pycore_pyerrors.h"      // _PyErr_ProgramDecodedTextObject()
 #include "tokenizer.h"
 #include "pegen.h"
 

--- a/Python/importdl.c
+++ b/Python/importdl.c
@@ -4,6 +4,7 @@
 #include "Python.h"
 #include "pycore_call.h"
 #include "pycore_import.h"
+#include "pycore_pyerrors.h"      // _PyErr_FormatFromCause()
 #include "pycore_pystate.h"
 #include "pycore_runtime.h"
 


### PR DESCRIPTION
Remove most private _PyErr C API functions: move them to the internal C API (pycore_pyerrors.h).


<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-106320 -->
* Issue: gh-106320
<!-- /gh-issue-number -->
