### PR TITLE
gh-106359: Fix corner case bugs in Argument Clinic converter parser

### DIFF
--- a/Lib/test/test_clinic.py
+++ b/Lib/test/test_clinic.py
@@ -815,8 +815,8 @@ Annotations must be either a name, a function call, or a string.
 
     def test_kwarg_splats_disallowed_in_function_call_annotations(self):
         expected_error_msg = (
-            "Error on line 0\n"
-            "Cannot use a kwarg splat in a function-call annotation"
+            "Error on line 0:\n"
+            "Cannot use a kwarg splat in a function-call annotation\n"
         )
         dataset = (
             'module fo\nfo.barbaz\n   o: bool(**{None: "bang!"})',

--- a/Lib/test/test_clinic.py
+++ b/Lib/test/test_clinic.py
@@ -797,21 +797,18 @@ Annotations must be either a name, a function call, or a string.
 Error on line 0:
 Annotations must be either a name, a function call, or a string.
 """
-
-        s = self.parse_function_should_fail(
-            'module os\nos.access\n   path: {"some": "dictionary"}'
+        dataset = (
+            'module os\nos.access\n   path: {"some": "dictionary"}',
+            'module os\nos.access\n   path: ["list", "of", "strings"]',
+            'module os\nos.access\n   path: (x for x in range(42))',
+            'module fo\nfo.barbaz\n   o: bool(**{None: "bang!"})',
+            'module fo\nfo.barbaz -> bool(**{None: "bang!"})',
         )
-        self.assertEqual(s, expected_failure_message)
 
-        s = self.parse_function_should_fail(
-            'module os\nos.access\n   path: ["list", "of", "strings"]'
-        )
-        self.assertEqual(s, expected_failure_message)
-
-        s = self.parse_function_should_fail(
-            'module os\nos.access\n   path: (x for x in range(42))'
-        )
-        self.assertEqual(s, expected_failure_message)
+        for fn in dataset:
+            with self.subTest(fn=fn):
+                actual = self.parse_function_should_fail(fn)
+                self.assertEqual(actual, expected_failure_message)
 
     def test_unused_param(self):
         block = self.parse("""

--- a/Lib/test/test_clinic.py
+++ b/Lib/test/test_clinic.py
@@ -821,8 +821,8 @@ Annotations must be either a name, a function call, or a string.
         dataset = (
             'module fo\nfo.barbaz\n   o: bool(**{None: "bang!"})',
             'module fo\nfo.barbaz -> bool(**{None: "bang!"})',
-            'module fo\nfo.barbaz -> bool(**{bang: 42})',
-            'module fo\nfo.barbaz\n   o: bool(**{bang: None})',
+            'module fo\nfo.barbaz -> bool(**{"bang": 42})',
+            'module fo\nfo.barbaz\n   o: bool(**{"bang": None})',
         )
         for fn in dataset:
             with self.subTest(fn=fn):

--- a/Lib/test/test_clinic.py
+++ b/Lib/test/test_clinic.py
@@ -814,7 +814,10 @@ Annotations must be either a name, a function call, or a string.
         self.assertEqual(s, expected_failure_message)
 
     def test_bizarre_parseable_annotations(self):
-        msg = "Cannot use a kwarg splat in a function-call annotation"
+        expected_error_msg = (
+            "Error on line 0\n"
+            "Cannot use a kwarg splat in a function-call annotation"
+        )
         dataset = (
             'module fo\nfo.barbaz\n   o: bool(**{None: "bang!"})',
             'module fo\nfo.barbaz -> bool(**{None: "bang!"})',
@@ -822,8 +825,7 @@ Annotations must be either a name, a function call, or a string.
         for fn in dataset:
             with self.subTest(fn=fn):
                 out = self.parse_function_should_fail(fn)
-                self.assertTrue(out.startswith("Error on line 0"))
-                self.assertIn(msg, out)
+                self.assertEqual(out, expected_error_msg)
 
     def test_unused_param(self):
         block = self.parse("""

--- a/Lib/test/test_clinic.py
+++ b/Lib/test/test_clinic.py
@@ -821,7 +821,7 @@ Annotations must be either a name, a function call, or a string.
         dataset = (
             'module fo\nfo.barbaz\n   o: bool(**{None: "bang!"})',
             'module fo\nfo.barbaz -> bool(**{None: "bang!"})',
-            'module fo\nfo.barbaz -> bool(**{bang: None})',
+            'module fo\nfo.barbaz -> bool(**{bang: 42})',
             'module fo\nfo.barbaz\n   o: bool(**{bang: None})',
         )
         for fn in dataset:

--- a/Lib/test/test_clinic.py
+++ b/Lib/test/test_clinic.py
@@ -821,6 +821,8 @@ Annotations must be either a name, a function call, or a string.
         dataset = (
             'module fo\nfo.barbaz\n   o: bool(**{None: "bang!"})',
             'module fo\nfo.barbaz -> bool(**{None: "bang!"})',
+            'module fo\nfo.barbaz -> bool(**{bang: None})',
+            'module fo\nfo.barbaz\n   o: bool(**{bang: None})',
         )
         for fn in dataset:
             with self.subTest(fn=fn):

--- a/Lib/test/test_clinic.py
+++ b/Lib/test/test_clinic.py
@@ -814,7 +814,7 @@ Annotations must be either a name, a function call, or a string.
         self.assertEqual(s, expected_failure_message)
 
     def test_bizarre_parseable_annotations(self):
-        msg = "Annotation dicts must have str keys"
+        msg = "Cannot use a kwarg splat in a function-call annotation"
         dataset = (
             'module fo\nfo.barbaz\n   o: bool(**{None: "bang!"})',
             'module fo\nfo.barbaz -> bool(**{None: "bang!"})',

--- a/Lib/test/test_clinic.py
+++ b/Lib/test/test_clinic.py
@@ -797,18 +797,33 @@ Annotations must be either a name, a function call, or a string.
 Error on line 0:
 Annotations must be either a name, a function call, or a string.
 """
+
+        s = self.parse_function_should_fail(
+            'module os\nos.access\n   path: {"some": "dictionary"}'
+        )
+        self.assertEqual(s, expected_failure_message)
+
+        s = self.parse_function_should_fail(
+            'module os\nos.access\n   path: ["list", "of", "strings"]'
+        )
+        self.assertEqual(s, expected_failure_message)
+
+        s = self.parse_function_should_fail(
+            'module os\nos.access\n   path: (x for x in range(42))'
+        )
+        self.assertEqual(s, expected_failure_message)
+
+    def test_bizarre_parseable_annotations(self):
+        msg = "Annotation dicts must have str keys"
         dataset = (
-            'module os\nos.access\n   path: {"some": "dictionary"}',
-            'module os\nos.access\n   path: ["list", "of", "strings"]',
-            'module os\nos.access\n   path: (x for x in range(42))',
             'module fo\nfo.barbaz\n   o: bool(**{None: "bang!"})',
             'module fo\nfo.barbaz -> bool(**{None: "bang!"})',
         )
-
         for fn in dataset:
             with self.subTest(fn=fn):
-                actual = self.parse_function_should_fail(fn)
-                self.assertEqual(actual, expected_failure_message)
+                out = self.parse_function_should_fail(fn)
+                self.assertTrue(out.startswith("Error on line 0"))
+                self.assertIn(msg, out)
 
     def test_unused_param(self):
         block = self.parse("""

--- a/Lib/test/test_clinic.py
+++ b/Lib/test/test_clinic.py
@@ -813,7 +813,7 @@ Annotations must be either a name, a function call, or a string.
         )
         self.assertEqual(s, expected_failure_message)
 
-    def test_bizarre_parseable_annotations(self):
+    def test_kwarg_splats_disallowed_in_function_call_annotations(self):
         expected_error_msg = (
             "Error on line 0\n"
             "Cannot use a kwarg splat in a function-call annotation"

--- a/Misc/NEWS.d/next/Tools-Demos/2023-07-03-14-06-19.gh-issue-106359.RfJuR0.rst
+++ b/Misc/NEWS.d/next/Tools-Demos/2023-07-03-14-06-19.gh-issue-106359.RfJuR0.rst
@@ -1,1 +1,2 @@
-Fix bizarre bugs.
+Argument Clinic now explicitly require that keys are string if the provided
+parameter annotation is a dict.

--- a/Misc/NEWS.d/next/Tools-Demos/2023-07-03-14-06-19.gh-issue-106359.RfJuR0.rst
+++ b/Misc/NEWS.d/next/Tools-Demos/2023-07-03-14-06-19.gh-issue-106359.RfJuR0.rst
@@ -1,2 +1,2 @@
-Argument Clinic now explicitly forbids "kwarg splats" in function calls used as 
+Argument Clinic now explicitly forbids "kwarg splats" in function calls used as
 annotations.

--- a/Misc/NEWS.d/next/Tools-Demos/2023-07-03-14-06-19.gh-issue-106359.RfJuR0.rst
+++ b/Misc/NEWS.d/next/Tools-Demos/2023-07-03-14-06-19.gh-issue-106359.RfJuR0.rst
@@ -1,2 +1,2 @@
-Argument Clinic now explicitly require that keys are string if the provided
-parameter annotation is a dict.
+Argument Clinic now explicitly forbids "kwarg splats" in function calls used as 
+annotations

--- a/Misc/NEWS.d/next/Tools-Demos/2023-07-03-14-06-19.gh-issue-106359.RfJuR0.rst
+++ b/Misc/NEWS.d/next/Tools-Demos/2023-07-03-14-06-19.gh-issue-106359.RfJuR0.rst
@@ -1,2 +1,2 @@
 Argument Clinic now explicitly forbids "kwarg splats" in function calls used as 
-annotations
+annotations.

--- a/Misc/NEWS.d/next/Tools-Demos/2023-07-03-14-06-19.gh-issue-106359.RfJuR0.rst
+++ b/Misc/NEWS.d/next/Tools-Demos/2023-07-03-14-06-19.gh-issue-106359.RfJuR0.rst
@@ -1,0 +1,1 @@
+Fix bizarre bugs.

--- a/Tools/clinic/clinic.py
+++ b/Tools/clinic/clinic.py
@@ -5038,7 +5038,6 @@ class DSLParser:
     def parse_converter(
             annotation: ast.expr | None
     ) -> tuple[str, bool, ConverterArgs]:
-        msg = "Annotations must be either a name, a function call, or a string."
         match annotation:
             case ast.Constant(value=str() as value):
                 return value, True, {}
@@ -5049,11 +5048,13 @@ class DSLParser:
                 kwargs: ConverterArgs = {}
                 for node in annotation.keywords:
                     if not isinstance(node.arg, str):
-                        fail(msg)
+                        fail("Annotation dicts must have str keys")
                     kwargs[node.arg] = eval_ast_expr(node.value, symbols)
                 return name, False, kwargs
             case _:
-                fail(msg)
+                fail(
+                    "Annotations must be either a name, a function call, or a string."
+                )
 
     def parse_special_symbol(self, symbol):
         if symbol == '*':

--- a/Tools/clinic/clinic.py
+++ b/Tools/clinic/clinic.py
@@ -5048,7 +5048,7 @@ class DSLParser:
                 kwargs: ConverterArgs = {}
                 for node in annotation.keywords:
                     if not isinstance(node.arg, str):
-                        fail("Annotation dicts must have str keys")
+                        fail("Cannot use a kwarg splat in a function-call annotation")
                     kwargs[node.arg] = eval_ast_expr(node.value, symbols)
                 return name, False, kwargs
             case _:

--- a/Tools/clinic/clinic.py
+++ b/Tools/clinic/clinic.py
@@ -4291,6 +4291,7 @@ class IndentStack:
 
 
 StateKeeper = Callable[[str | None], None]
+ConverterArgs = dict[str, Any]
 
 class DSLParser:
     function: Function | None
@@ -5033,10 +5034,10 @@ class DSLParser:
         key = f"{parameter_name}_as_{c_name}" if c_name else parameter_name
         self.function.parameters[key] = p
 
-    KwargDict = dict[str, Any]
-
     @staticmethod
-    def parse_converter(annotation: ast.expr | None) -> tuple[str, bool, KwargDict]:
+    def parse_converter(
+            annotation: ast.expr | None
+    ) -> tuple[str, bool, ConverterArgs]:
         msg = "Annotations must be either a name, a function call, or a string."
         match annotation:
             case ast.Constant(value=str() as value):
@@ -5045,7 +5046,7 @@ class DSLParser:
                 return name, False, {}
             case ast.Call(func=ast.Name(name)):
                 symbols = globals()
-                kwargs: dict[str, Any] = {}
+                kwargs: ConverterArgs = {}
                 for node in annotation.keywords:
                     if not isinstance(node.arg, str):
                         fail(msg)

--- a/Tools/clinic/clinic.py
+++ b/Tools/clinic/clinic.py
@@ -5051,7 +5051,6 @@ class DSLParser:
                     if not isinstance(node.arg, str):
                         fail(msg)
                     kwargs[node.arg] = eval_ast_expr(node.value, symbols)
-                    print(kwargs)
                 return name, False, kwargs
             case _:
                 fail(msg)


### PR DESCRIPTION
DSLParser.parse_converter() could return unusable kwdicts in some rare cases


<!-- gh-issue-number: gh-106359 -->
* Issue: gh-106359
<!-- /gh-issue-number -->
