### PR TITLE
GH-106008: Fix refleak when peepholing `None` comparisons

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2023-07-03-11-38-43.gh-issue-106008.HDf1zd.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2023-07-03-11-38-43.gh-issue-106008.HDf1zd.rst
@@ -1,0 +1,2 @@
+Fix possible reference leaks when failing to optimize comparisons with
+:const:`None` in the bytecode compiler.

--- a/Python/flowgraph.c
+++ b/Python/flowgraph.c
@@ -1377,9 +1377,9 @@ optimize_basic_block(PyObject *const_cache, basicblock *bb, PyObject *consts)
                             goto error;
                         }
                         if (!Py_IsNone(cnt)) {
+                            Py_DECREF(cnt);
                             break;
                         }
-                        Py_DECREF(cnt);
                         if (bb->b_iused <= i + 2) {
                             break;
                         }


### PR DESCRIPTION


<!-- gh-issue-number: gh-106008 -->
* Issue: gh-106008
<!-- /gh-issue-number -->
