### PR TITLE
gh-105256: What's New note for comprehension over locals()

### DIFF
--- a/Doc/whatsnew/3.12.rst
+++ b/Doc/whatsnew/3.12.rst
@@ -253,6 +253,12 @@ Inlining does result in a few visible behavior changes:
 * Calling :func:`locals` inside a comprehension now includes variables
   from outside the comprehension, and no longer includes the synthetic ``.0``
   variable for the comprehension "argument".
+* A comprehension iterating directly over ``locals()`` (e.g. ``[k for k in
+  locals()]``) may see "RuntimeError: dictionary changed size during iteration"
+  when run under tracing (e.g. code coverage measurement). This is the same
+  behavior already seen in e.g. ``for k in locals():``. To avoid the error, first
+  create a list of keys to iterate over: ``keys = list(locals()); [k for k in
+  keys]``.
 
 Contributed by Carl Meyer and Vladimir Matveev in :pep:`709`.
 


### PR DESCRIPTION


<!-- gh-issue-number: gh-105256 -->
* Issue: gh-105256
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--106378.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->