### PR TITLE
gh-106292: restore checking __dict__ in cached_property.__get__

### DIFF
--- a/Lib/functools.py
+++ b/Lib/functools.py
@@ -960,6 +960,7 @@ class singledispatchmethod:
 ### cached_property() - computed once per instance, cached as attribute
 ################################################################################
 
+_NOT_FOUND = object()
 
 class cached_property:
     def __init__(self, func):
@@ -990,15 +991,17 @@ class cached_property:
                 f"instance to cache {self.attrname!r} property."
             )
             raise TypeError(msg) from None
-        val = self.func(instance)
-        try:
-            cache[self.attrname] = val
-        except TypeError:
-            msg = (
-                f"The '__dict__' attribute on {type(instance).__name__!r} instance "
-                f"does not support item assignment for caching {self.attrname!r} property."
-            )
-            raise TypeError(msg) from None
+        val = cache.get(self.attrname, _NOT_FOUND)
+        if val is _NOT_FOUND:
+            val = self.func(instance)
+            try:
+                cache[self.attrname] = val
+            except TypeError:
+                msg = (
+                    f"The '__dict__' attribute on {type(instance).__name__!r} instance "
+                    f"does not support item assignment for caching {self.attrname!r} property."
+                )
+                raise TypeError(msg) from None
         return val
 
     __class_getitem__ = classmethod(GenericAlias)

--- a/Lib/functools.py
+++ b/Lib/functools.py
@@ -957,7 +957,7 @@ class singledispatchmethod:
 
 
 ################################################################################
-### cached_property() - computed once per instance, cached as attribute
+### cached_property() - property result cached as instance attribute
 ################################################################################
 
 _NOT_FOUND = object()

--- a/Lib/test/test_functools.py
+++ b/Lib/test/test_functools.py
@@ -3037,6 +3037,25 @@ class TestCachedProperty(unittest.TestCase):
     def test_doc(self):
         self.assertEqual(CachedCostItem.cost.__doc__, "The cost of the item.")
 
+    def test_subclass_with___set__(self):
+        """Caching still works for a subclass defining __set__."""
+        class readonly_cached_property(py_functools.cached_property):
+            def __set__(self, obj, value):
+                raise AttributeError("read only property")
+
+        class Test:
+            def __init__(self, prop):
+                self._prop = prop
+
+            @readonly_cached_property
+            def prop(self):
+                return self._prop
+
+        t = Test(1)
+        self.assertEqual(t.prop, 1)
+        t._prop = 999
+        self.assertEqual(t.prop, 1)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/Misc/NEWS.d/next/Library/2023-07-03-15-09-44.gh-issue-106292.3npldV.rst
+++ b/Misc/NEWS.d/next/Library/2023-07-03-15-09-44.gh-issue-106292.3npldV.rst
@@ -1,0 +1,4 @@
+Check for an instance-dict cached value in the ``__get__`` method of
+:func:`functools.cached_property`. This better matches the pre-3.12 behavior
+and improves compatibility for users subclassing
+:func:`functools.cached_property` and adding a ``__set__`` method.

--- a/Misc/NEWS.d/next/Library/2023-07-03-15-09-44.gh-issue-106292.3npldV.rst
+++ b/Misc/NEWS.d/next/Library/2023-07-03-15-09-44.gh-issue-106292.3npldV.rst
@@ -1,4 +1,4 @@
-Check for an instance-dict cached value in the ``__get__`` method of
+Check for an instance-dict cached value in the :meth:`__get__` method of
 :func:`functools.cached_property`. This better matches the pre-3.12 behavior
 and improves compatibility for users subclassing
-:func:`functools.cached_property` and adding a ``__set__`` method.
+:func:`functools.cached_property` and adding a :meth:`__set__` method.


### PR DESCRIPTION
When locking was removed from `functools.cached_property` in https://github.com/python/cpython/pull/101890, the `__get__` method also stopped pre-checking the instance dictionary for a cached value.

This removed pre-check is not necessary for the correct behavior of `cached_property` in and of itself: since it's a non-data descriptor (does not define `__set__` or `__delete__`), the instance dictionary takes precedence over `__get__`, so `__get__` should never be reached if a cached value is set in the instance dictionary.

But it seems that some users (including at least one popular library; see issue for details) are subclassing `cached_property` and adding a `__set__` method, turning it into a data descriptor, which takes precedence over the instance dictionary. Prior to 3.12, this still worked OK (did not recompute the value on every access) because of the additional check for cached value in `__get__`. But with 3.12 as it currently stands, this code would silently stop caching the value due to the added `__set__` method.

Although it's nice and clever for `cached_property` to be maximally efficient by taking advantage of being a non-data descriptor, I think in this case backwards-compatibility and avoiding a footgun is more important. Clearly some people are subclassing `cached_property` and adding `__set__` methods, and it's not realistic to expect every Python user to understand the subtleties of data vs non-data descriptors and how this could break `cached_property`. The cost here is also minimal: just one dictionary lookup, that should only occur once per instance (not on repeated access of the cached property).

<!-- gh-issue-number: gh-106292 -->
* Issue: gh-106292
<!-- /gh-issue-number -->
