### PR TITLE
gh-106320: Remove private _PyImport C API functions

### DIFF
--- a/Include/cpython/import.h
+++ b/Include/cpython/import.h
@@ -4,23 +4,6 @@
 
 PyMODINIT_FUNC PyInit__imp(void);
 
-PyAPI_FUNC(int) _PyImport_IsInitialized(PyInterpreterState *);
-
-PyAPI_FUNC(PyObject *) _PyImport_GetModuleId(_Py_Identifier *name);
-PyAPI_FUNC(int) _PyImport_SetModule(PyObject *name, PyObject *module);
-PyAPI_FUNC(int) _PyImport_SetModuleString(const char *name, PyObject* module);
-
-PyAPI_FUNC(void) _PyImport_AcquireLock(PyInterpreterState *interp);
-PyAPI_FUNC(int) _PyImport_ReleaseLock(PyInterpreterState *interp);
-
-PyAPI_FUNC(int) _PyImport_FixupBuiltin(
-    PyObject *mod,
-    const char *name,            /* UTF-8 encoded string */
-    PyObject *modules
-    );
-PyAPI_FUNC(int) _PyImport_FixupExtensionObject(PyObject*, PyObject *,
-                                               PyObject *, PyObject *);
-
 struct _inittab {
     const char *name;           /* ASCII encoded string */
     PyObject* (*initfunc)(void);
@@ -41,6 +24,3 @@ struct _frozen {
    collection of frozen modules: */
 
 PyAPI_DATA(const struct _frozen *) PyImport_FrozenModules;
-
-PyAPI_DATA(PyObject *) _PyImport_GetModuleAttr(PyObject *, PyObject *);
-PyAPI_DATA(PyObject *) _PyImport_GetModuleAttrString(const char *, const char *);

--- a/Include/internal/pycore_import.h
+++ b/Include/internal/pycore_import.h
@@ -7,6 +7,26 @@ extern "C" {
 
 #include "pycore_time.h"          // _PyTime_t
 
+extern int _PyImport_IsInitialized(PyInterpreterState *);
+
+PyAPI_FUNC(PyObject *) _PyImport_GetModuleId(_Py_Identifier *name);
+PyAPI_FUNC(int) _PyImport_SetModule(PyObject *name, PyObject *module);
+PyAPI_FUNC(int) _PyImport_SetModuleString(const char *name, PyObject* module);
+
+extern void _PyImport_AcquireLock(PyInterpreterState *interp);
+extern int _PyImport_ReleaseLock(PyInterpreterState *interp);
+
+extern int _PyImport_FixupBuiltin(
+    PyObject *mod,
+    const char *name,            /* UTF-8 encoded string */
+    PyObject *modules
+    );
+extern int _PyImport_FixupExtensionObject(PyObject*, PyObject *,
+                                          PyObject *, PyObject *);
+
+PyAPI_DATA(PyObject *) _PyImport_GetModuleAttr(PyObject *, PyObject *);
+PyAPI_DATA(PyObject *) _PyImport_GetModuleAttrString(const char *, const char *);
+
 
 struct _import_runtime_state {
     /* The builtin modules (defined in config.c). */

--- a/Modules/_elementtree.c
+++ b/Modules/_elementtree.c
@@ -11,7 +11,12 @@
  *--------------------------------------------------------------------
  */
 
+#ifndef Py_BUILD_CORE_BUILTIN
+#  define Py_BUILD_CORE_MODULE 1
+#endif
+
 #include "Python.h"
+#include "pycore_import.h"        // _PyImport_GetModuleAttrString()
 #include "structmember.h"         // PyMemberDef
 #include "expat.h"
 #include "pyexpat.h"

--- a/Modules/_sqlite/connection.c
+++ b/Modules/_sqlite/connection.c
@@ -33,6 +33,7 @@
 #include "blob.h"
 #include "prepare_protocol.h"
 #include "util.h"
+#include "pycore_import.h"        // _PyImport_GetModuleAttrString()
 #include "pycore_weakref.h"       // _PyWeakref_IS_DEAD()
 
 #include <stdbool.h>

--- a/Modules/_sqlite/module.c
+++ b/Modules/_sqlite/module.c
@@ -21,6 +21,10 @@
  * 3. This notice may not be removed or altered from any source distribution.
  */
 
+#ifndef Py_BUILD_CORE_BUILTIN
+#  define Py_BUILD_CORE_MODULE 1
+#endif
+
 #include "connection.h"
 #include "statement.h"
 #include "cursor.h"
@@ -28,6 +32,8 @@
 #include "microprotocols.h"
 #include "row.h"
 #include "blob.h"
+
+#include "pycore_import.h"        // _PyImport_GetModuleAttrString()
 
 #if SQLITE_VERSION_NUMBER < 3015002
 #error "SQLite 3.15.2 or higher required"

--- a/Modules/_testcapimodule.c
+++ b/Modules/_testcapimodule.c
@@ -1267,9 +1267,15 @@ test_pep3118_obsolete_write_locks(PyObject* self, PyObject *Py_UNUSED(ignored))
     if (ret != -1 || match == 0)
         goto error;
 
+    PyObject *mod_io = PyImport_ImportModule("_io");
+    if (mod_io == NULL) {
+        return NULL;
+    }
+
     /* bytesiobuf_getbuffer() */
-    PyTypeObject *type = (PyTypeObject *)_PyImport_GetModuleAttrString(
-            "_io", "_BytesIOBuffer");
+    PyTypeObject *type = (PyTypeObject *)PyObject_GetAttrString(
+            mod_io, "_BytesIOBuffer");
+    Py_DECREF(mod_io);
     if (type == NULL) {
         return NULL;
     }

--- a/Modules/cjkcodecs/cjkcodecs.h
+++ b/Modules/cjkcodecs/cjkcodecs.h
@@ -13,6 +13,7 @@
 
 #include "Python.h"
 #include "multibytecodec.h"
+#include "pycore_import.h"        // _PyImport_GetModuleAttrString()
 
 
 /* a unicode "undefined" code point */

--- a/Modules/pyexpat.c
+++ b/Modules/pyexpat.c
@@ -1,4 +1,9 @@
+#ifndef Py_BUILD_CORE_BUILTIN
+#  define Py_BUILD_CORE_MODULE 1
+#endif
+
 #include "Python.h"
+#include "pycore_import.h"        // _PyImport_SetModule()
 #include <ctype.h>
 
 #include "structmember.h"         // PyMemberDef


### PR DESCRIPTION
* Remove private _PyImport C API functions: move them to the internal C API (pycore_import.h).
* No longer export most of these private functions.
* _testcapi avoids private _PyImport_GetModuleAttrString().

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-106320 -->
* Issue: gh-106320
<!-- /gh-issue-number -->
