### PR TITLE
gh-106320: Fix _PyImport_GetModuleAttr() declaration

### DIFF
--- a/Include/internal/pycore_import.h
+++ b/Include/internal/pycore_import.h
@@ -24,8 +24,8 @@ extern int _PyImport_FixupBuiltin(
 extern int _PyImport_FixupExtensionObject(PyObject*, PyObject *,
                                           PyObject *, PyObject *);
 
-PyAPI_DATA(PyObject *) _PyImport_GetModuleAttr(PyObject *, PyObject *);
-PyAPI_DATA(PyObject *) _PyImport_GetModuleAttrString(const char *, const char *);
+PyAPI_FUNC(PyObject *) _PyImport_GetModuleAttr(PyObject *, PyObject *);
+PyAPI_FUNC(PyObject *) _PyImport_GetModuleAttrString(const char *, const char *);
 
 
 struct _import_runtime_state {


### PR DESCRIPTION
Replace PyAPI_DATA() with PyAPI_FUNC().

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-106320 -->
* Issue: gh-106320
<!-- /gh-issue-number -->
