### PR TITLE
gh-106320: Remove private pylifecycle.h functions

### DIFF
--- a/Include/cpython/pylifecycle.h
+++ b/Include/cpython/pylifecycle.h
@@ -19,13 +19,13 @@ PyAPI_FUNC(PyStatus) Py_PreInitializeFromArgs(
     Py_ssize_t argc,
     wchar_t **argv);
 
-PyAPI_FUNC(int) _Py_IsCoreInitialized(void);
-
 
 /* Initialization and finalization */
 
 PyAPI_FUNC(PyStatus) Py_InitializeFromConfig(
     const PyConfig *config);
+
+// Python 3.8 provisional API (PEP 587)
 PyAPI_FUNC(PyStatus) _Py_InitializeMain(void);
 
 PyAPI_FUNC(int) Py_RunMain(void);
@@ -33,31 +33,8 @@ PyAPI_FUNC(int) Py_RunMain(void);
 
 PyAPI_FUNC(void) _Py_NO_RETURN Py_ExitStatusException(PyStatus err);
 
-/* Restore signals that the interpreter has called SIG_IGN on to SIG_DFL. */
-PyAPI_FUNC(void) _Py_RestoreSignals(void);
-
 PyAPI_FUNC(int) Py_FdIsInteractive(FILE *, const char *);
-PyAPI_FUNC(int) _Py_FdIsInteractive(FILE *fp, PyObject *filename);
-
-PyAPI_FUNC(const char *) _Py_gitidentifier(void);
-PyAPI_FUNC(const char *) _Py_gitversion(void);
-
-PyAPI_FUNC(int) _Py_IsFinalizing(void);
-PyAPI_FUNC(int) _Py_IsInterpreterFinalizing(PyInterpreterState *interp);
-
-/* Random */
-PyAPI_FUNC(int) _PyOS_URandom(void *buffer, Py_ssize_t size);
-PyAPI_FUNC(int) _PyOS_URandomNonblock(void *buffer, Py_ssize_t size);
-
-/* Legacy locale support */
-PyAPI_FUNC(int) _Py_CoerceLegacyLocale(int warn);
-PyAPI_FUNC(int) _Py_LegacyLocaleDetected(int warn);
-PyAPI_FUNC(char *) _Py_SetLocaleFromEnv(int category);
 
 PyAPI_FUNC(PyStatus) Py_NewInterpreterFromConfig(
     PyThreadState **tstate_p,
     const PyInterpreterConfig *config);
-
-typedef void (*atexit_datacallbackfunc)(void *);
-PyAPI_FUNC(int) _Py_AtExit(
-        PyInterpreterState *, atexit_datacallbackfunc, void *);

--- a/Include/internal/pycore_atexit.h
+++ b/Include/internal/pycore_atexit.h
@@ -25,7 +25,8 @@ struct _atexit_runtime_state {
 //###################
 // interpreter atexit
 
-struct atexit_callback;
+typedef void (*atexit_datacallbackfunc)(void *);
+
 typedef struct atexit_callback {
     atexit_datacallbackfunc func;
     void *data;
@@ -50,6 +51,10 @@ struct atexit_state {
     int callback_len;
 };
 
+PyAPI_FUNC(int) _Py_AtExit(
+    PyInterpreterState *interp,
+    atexit_datacallbackfunc func,
+    void *data);
 
 #ifdef __cplusplus
 }

--- a/Include/internal/pycore_pylifecycle.h
+++ b/Include/internal/pycore_pylifecycle.h
@@ -23,7 +23,7 @@ extern PyStatus _PyUnicode_InitEncodings(PyThreadState *tstate);
 extern int _PyUnicode_EnableLegacyWindowsFSEncoding(void);
 #endif
 
-PyAPI_FUNC(int) _Py_IsLocaleCoercionTarget(const char *ctype_loc);
+extern int _Py_IsLocaleCoercionTarget(const char *ctype_loc);
 
 /* Various one-time initializers */
 
@@ -67,29 +67,48 @@ extern PyStatus _PyGILState_Init(PyInterpreterState *interp);
 extern PyStatus _PyGILState_SetTstate(PyThreadState *tstate);
 extern void _PyGILState_Fini(PyInterpreterState *interp);
 
-PyAPI_FUNC(void) _PyGC_DumpShutdownStats(PyInterpreterState *interp);
+extern void _PyGC_DumpShutdownStats(PyInterpreterState *interp);
 
-PyAPI_FUNC(PyStatus) _Py_PreInitializeFromPyArgv(
+extern PyStatus _Py_PreInitializeFromPyArgv(
     const PyPreConfig *src_config,
     const struct _PyArgv *args);
-PyAPI_FUNC(PyStatus) _Py_PreInitializeFromConfig(
+extern PyStatus _Py_PreInitializeFromConfig(
     const PyConfig *config,
     const struct _PyArgv *args);
 
-PyAPI_FUNC(wchar_t *) _Py_GetStdlibDir(void);
+extern wchar_t * _Py_GetStdlibDir(void);
 
-PyAPI_FUNC(int) _Py_HandleSystemExit(int *exitcode_p);
+extern int _Py_HandleSystemExit(int *exitcode_p);
 
-PyAPI_FUNC(PyObject*) _PyErr_WriteUnraisableDefaultHook(PyObject *unraisable);
+extern PyObject* _PyErr_WriteUnraisableDefaultHook(PyObject *unraisable);
 
-PyAPI_FUNC(void) _PyErr_Print(PyThreadState *tstate);
-PyAPI_FUNC(void) _PyErr_Display(PyObject *file, PyObject *exception,
+extern void _PyErr_Print(PyThreadState *tstate);
+extern void _PyErr_Display(PyObject *file, PyObject *exception,
                                 PyObject *value, PyObject *tb);
-PyAPI_FUNC(void) _PyErr_DisplayException(PyObject *file, PyObject *exc);
+extern void _PyErr_DisplayException(PyObject *file, PyObject *exc);
 
-PyAPI_FUNC(void) _PyThreadState_DeleteCurrent(PyThreadState *tstate);
+extern void _PyThreadState_DeleteCurrent(PyThreadState *tstate);
 
 extern void _PyAtExit_Call(PyInterpreterState *interp);
+
+extern int _Py_IsCoreInitialized(void);
+
+extern int _Py_FdIsInteractive(FILE *fp, PyObject *filename);
+
+extern const char* _Py_gitidentifier(void);
+extern const char* _Py_gitversion(void);
+
+extern int _Py_IsFinalizing(void);
+PyAPI_FUNC(int) _Py_IsInterpreterFinalizing(PyInterpreterState *interp);
+
+/* Random */
+extern int _PyOS_URandom(void *buffer, Py_ssize_t size);
+PyAPI_FUNC(int) _PyOS_URandomNonblock(void *buffer, Py_ssize_t size);
+
+/* Legacy locale support */
+extern int _Py_CoerceLegacyLocale(int warn);
+extern int _Py_LegacyLocaleDetected(int warn);
+PyAPI_FUNC(char*) _Py_SetLocaleFromEnv(int category);
 
 #ifdef __cplusplus
 }

--- a/Include/internal/pycore_signal.h
+++ b/Include/internal/pycore_signal.h
@@ -11,9 +11,11 @@ extern "C" {
 #endif
 
 #include "pycore_atomic.h"         // _Py_atomic_address
-
 #include <signal.h>                // NSIG
 
+
+/* Restore signals that the interpreter has called SIG_IGN on to SIG_DFL. */
+PyAPI_FUNC(void) _Py_RestoreSignals(void);
 
 #ifdef _SIG_MAXSIG
    // gh-91145: On FreeBSD, <signal.h> defines NSIG as 32: it doesn't include

--- a/Modules/_asynciomodule.c
+++ b/Modules/_asynciomodule.c
@@ -3,10 +3,11 @@
 #endif
 
 #include "Python.h"
+#include "pycore_moduleobject.h"  // _PyModule_GetState()
 #include "pycore_pyerrors.h"      // _PyErr_ClearExcState()
+#include "pycore_pylifecycle.h"   // _Py_IsInterpreterFinalizing()
 #include "pycore_pystate.h"       // _PyThreadState_GET()
 #include "pycore_runtime_init.h"  // _Py_ID()
-#include "pycore_moduleobject.h"  // _PyModule_GetState()
 #include "structmember.h"         // PyMemberDef
 #include <stddef.h>               // offsetof()
 

--- a/Modules/_io/bufferedio.c
+++ b/Modules/_io/bufferedio.c
@@ -11,6 +11,7 @@
 #include "pycore_call.h"          // _PyObject_CallNoArgs()
 #include "pycore_object.h"
 #include "pycore_pyerrors.h"      // _Py_FatalErrorFormat()
+#include "pycore_pylifecycle.h"   // _Py_IsInterpreterFinalizing()
 #include "structmember.h"         // PyMemberDef
 #include "_iomodule.h"
 

--- a/Modules/_posixsubprocess.c
+++ b/Modules/_posixsubprocess.c
@@ -6,6 +6,7 @@
 #include "Python.h"
 #include "pycore_fileutils.h"
 #include "pycore_pystate.h"
+#include "pycore_signal.h"        // _Py_RestoreSignals()
 #if defined(HAVE_PIPE2) && !defined(_GNU_SOURCE)
 # define _GNU_SOURCE
 #endif
@@ -739,8 +740,9 @@ child_exec(char *const exec_array[],
     if (child_umask >= 0)
         umask(child_umask);  /* umask() always succeeds. */
 
-    if (restore_signals)
+    if (restore_signals) {
         _Py_RestoreSignals();
+    }
 
 #ifdef VFORK_USABLE
     if (child_sigmask) {

--- a/Modules/_randommodule.c
+++ b/Modules/_randommodule.c
@@ -72,6 +72,7 @@
 
 #include "Python.h"
 #include "pycore_moduleobject.h"  // _PyModule_GetState()
+#include "pycore_pylifecycle.h"   // _PyOS_URandomNonblock()
 #include "pycore_runtime.h"
 #ifdef HAVE_PROCESS_H
 #  include <process.h>            // getpid()

--- a/Modules/_sqlite/connection.c
+++ b/Modules/_sqlite/connection.c
@@ -34,6 +34,7 @@
 #include "prepare_protocol.h"
 #include "util.h"
 #include "pycore_import.h"        // _PyImport_GetModuleAttrString()
+#include "pycore_pylifecycle.h"   // _Py_IsInterpreterFinalizing()
 #include "pycore_weakref.h"       // _PyWeakref_IS_DEAD()
 
 #include <stdbool.h>

--- a/Modules/_testcapimodule.c
+++ b/Modules/_testcapimodule.c
@@ -3293,37 +3293,6 @@ function_set_kw_defaults(PyObject *self, PyObject *args)
     Py_RETURN_NONE;
 }
 
-struct atexit_data {
-    int called;
-};
-
-static void
-callback(void *data)
-{
-    ((struct atexit_data *)data)->called += 1;
-}
-
-static PyObject *
-test_atexit(PyObject *self, PyObject *Py_UNUSED(args))
-{
-    PyThreadState *oldts = PyThreadState_Swap(NULL);
-    PyThreadState *tstate = Py_NewInterpreter();
-
-    struct atexit_data data = {0};
-    int res = _Py_AtExit(tstate->interp, callback, (void *)&data);
-    Py_EndInterpreter(tstate);
-    PyThreadState_Swap(oldts);
-    if (res < 0) {
-        return NULL;
-    }
-    if (data.called == 0) {
-        PyErr_SetString(PyExc_RuntimeError, "atexit callback not called");
-        return NULL;
-    }
-    Py_RETURN_NONE;
-}
-
-
 static PyObject *
 check_pyimport_addmodule(PyObject *self, PyObject *args)
 {
@@ -3613,7 +3582,6 @@ static PyMethodDef TestMethods[] = {
     {"function_set_defaults", function_set_defaults, METH_VARARGS, NULL},
     {"function_get_kw_defaults", function_get_kw_defaults, METH_O, NULL},
     {"function_set_kw_defaults", function_set_kw_defaults, METH_VARARGS, NULL},
-    {"test_atexit", test_atexit, METH_NOARGS},
     {"check_pyimport_addmodule", check_pyimport_addmodule, METH_VARARGS},
     {"test_weakref_capi", test_weakref_capi, METH_NOARGS},
     {NULL, NULL} /* sentinel */

--- a/Modules/_xxinterpchannelsmodule.c
+++ b/Modules/_xxinterpchannelsmodule.c
@@ -1,9 +1,13 @@
-
 /* interpreters module */
 /* low-level access to interpreter primitives */
 
+#ifndef Py_BUILD_CORE_BUILTIN
+#  define Py_BUILD_CORE_MODULE 1
+#endif
+
 #include "Python.h"
 #include "interpreteridobject.h"
+#include "pycore_atexit.h"        // _Py_AtExit()
 
 
 /*

--- a/Modules/getbuildinfo.c
+++ b/Modules/getbuildinfo.c
@@ -1,4 +1,5 @@
 #include "Python.h"
+#include "pycore_pylifecycle.h"   // _Py_gitidentifier()
 
 #ifndef DONT_HAVE_STDIO_H
 #include <stdio.h>

--- a/Modules/getbuildinfo.c
+++ b/Modules/getbuildinfo.c
@@ -1,3 +1,7 @@
+#ifndef Py_BUILD_CORE_BUILTIN
+#  define Py_BUILD_CORE_MODULE 1
+#endif
+
 #include "Python.h"
 #include "pycore_pylifecycle.h"   // _Py_gitidentifier()
 

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -19,6 +19,7 @@
 #include "pycore_initconfig.h"    // _PyStatus_EXCEPTION()
 #include "pycore_moduleobject.h"  // _PyModule_GetState()
 #include "pycore_object.h"        // _PyObject_LookupSpecial()
+#include "pycore_pylifecycle.h"   // _PyOS_URandom()
 #include "pycore_pystate.h"       // _PyInterpreterState_GET()
 #include "pycore_signal.h"        // Py_NSIG
 

--- a/Modules/readline.c
+++ b/Modules/readline.c
@@ -4,8 +4,13 @@
  * recently, it was largely rewritten by Guido van Rossum.
  */
 
+#ifndef Py_BUILD_CORE_BUILTIN
+#  define Py_BUILD_CORE_MODULE 1
+#endif
+
 /* Standard definitions */
 #include "Python.h"
+#include "pycore_pylifecycle.h"   // _Py_SetLocaleFromEnv()
 
 #include <errno.h>
 #include <signal.h>

--- a/Modules/signalmodule.c
+++ b/Modules/signalmodule.c
@@ -13,7 +13,7 @@
 #include "pycore_moduleobject.h"  // _PyModule_GetState()
 #include "pycore_pyerrors.h"      // _PyErr_SetString()
 #include "pycore_pystate.h"       // _PyThreadState_GET()
-#include "pycore_signal.h"        // Py_NSIG
+#include "pycore_signal.h"        // _Py_RestoreSignals()
 
 #ifndef MS_WINDOWS
 #  include "posixmodule.h"

--- a/Python/_warnings.c
+++ b/Python/_warnings.c
@@ -1,10 +1,11 @@
 #include "Python.h"
+#include "pycore_frame.h"
 #include "pycore_initconfig.h"
 #include "pycore_interp.h"        // PyInterpreterState.warnings
 #include "pycore_long.h"          // _PyLong_GetZero()
 #include "pycore_pyerrors.h"
+#include "pycore_pylifecycle.h"   // _Py_IsInterpreterFinalizing()
 #include "pycore_pystate.h"       // _PyThreadState_GET()
-#include "pycore_frame.h"
 #include "clinic/_warnings.c.h"
 
 #define MODULE_NAME "_warnings"

--- a/Python/bootstrap_hash.c
+++ b/Python/bootstrap_hash.c
@@ -1,6 +1,7 @@
 #include "Python.h"
-#include "pycore_initconfig.h"
 #include "pycore_fileutils.h"     // _Py_fstat_noraise()
+#include "pycore_initconfig.h"
+#include "pycore_pylifecycle.h"   // _PyOS_URandomNonblock()
 #include "pycore_runtime.h"       // _PyRuntime
 
 #ifdef MS_WINDOWS

--- a/Python/preconfig.c
+++ b/Python/preconfig.c
@@ -2,6 +2,7 @@
 #include "pycore_fileutils.h"     // DECODE_LOCALE_ERR
 #include "pycore_getopt.h"        // _PyOS_GetOpt()
 #include "pycore_initconfig.h"    // _PyArgv
+#include "pycore_pylifecycle.h"   // _Py_LegacyLocaleDetected()
 #include "pycore_pymem.h"         // _PyMem_GetAllocatorName()
 #include "pycore_runtime.h"       // _PyRuntime_Initialize()
 


### PR DESCRIPTION
Remove private pylifecycle.h functions: move them to the internal C API ( pycore_atexit.h, pycore_pylifecycle.h and pycore_signal.h). No longer export most of these functions.

Move _testcapi.test_atexit() to _testinternalcapi.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-106320 -->
* Issue: gh-106320
<!-- /gh-issue-number -->
