### PR TITLE
gh-61215: Rename `wait_until_any_call` to `wait_until_any_call_with`

### DIFF
--- a/Doc/library/unittest.mock.rst
+++ b/Doc/library/unittest.mock.rst
@@ -1126,7 +1126,7 @@ object::
         >>> mock.wait_until_called(timeout=1)
         >>> thread.join()
 
-  .. method:: wait_until_any_call(*args, **kwargs)
+  .. method:: wait_until_any_call_with(*args, **kwargs)
 
       Waits until the the mock is called with the specified arguments.
 
@@ -1136,7 +1136,7 @@ object::
         >>> mock = ThreadingMock()
         >>> thread = threading.Thread(target=mock, args=("arg1", "arg2",), kwargs={"arg": "thing"})
         >>> thread.start()
-        >>> mock.wait_until_any_call("arg1", "arg2", arg="thing")
+        >>> mock.wait_until_any_call_with("arg1", "arg2", arg="thing")
         >>> thread.join()
 
   .. attribute:: DEFAULT_TIMEOUT

--- a/Lib/test/test_unittest/testmock/testthreadingmock.py
+++ b/Lib/test/test_unittest/testmock/testthreadingmock.py
@@ -87,7 +87,7 @@ class TestThreadingMock(unittest.TestCase):
         waitable_mock.timeout = "mytimeout"
         waitable_mock("works")
         waitable_mock.wait_until_called()
-        waitable_mock.wait_until_any_call("works")
+        waitable_mock.wait_until_any_call_with("works")
 
     def test_wait_success(self):
         waitable_mock = self._make_mock(spec=Something)
@@ -96,7 +96,7 @@ class TestThreadingMock(unittest.TestCase):
             something = Something()
             self.run_async(something.method_1, delay=0.01)
             something.method_1.wait_until_called()
-            something.method_1.wait_until_any_call()
+            something.method_1.wait_until_any_call_with()
             something.method_1.assert_called()
 
     def test_wait_success_with_instance_timeout(self):
@@ -106,7 +106,7 @@ class TestThreadingMock(unittest.TestCase):
             something = Something()
             self.run_async(something.method_1, delay=0.01)
             something.method_1.wait_until_called()
-            something.method_1.wait_until_any_call()
+            something.method_1.wait_until_any_call_with()
             something.method_1.assert_called()
 
     def test_wait_failed_with_instance_timeout(self):
@@ -117,7 +117,7 @@ class TestThreadingMock(unittest.TestCase):
             self.run_async(something.method_1, delay=0.5)
             self.assertRaises(AssertionError, waitable_mock.method_1.wait_until_called)
             self.assertRaises(
-                AssertionError, waitable_mock.method_1.wait_until_any_call
+                AssertionError, waitable_mock.method_1.wait_until_any_call_with
             )
 
     def test_wait_success_with_timeout_override(self):
@@ -137,7 +137,7 @@ class TestThreadingMock(unittest.TestCase):
             with self.assertRaises(AssertionError):
                 something.method_1.wait_until_called(timeout=0.05)
             with self.assertRaises(AssertionError):
-                something.method_1.wait_until_any_call(timeout=0.05)
+                something.method_1.wait_until_any_call_with(timeout=0.05)
 
     def test_wait_success_called_before(self):
         waitable_mock = self._make_mock()
@@ -146,7 +146,7 @@ class TestThreadingMock(unittest.TestCase):
             something = Something()
             something.method_1()
             something.method_1.wait_until_called()
-            something.method_1.wait_until_any_call()
+            something.method_1.wait_until_any_call_with()
             something.method_1.assert_called()
 
     def test_wait_magic_method(self):
@@ -158,7 +158,7 @@ class TestThreadingMock(unittest.TestCase):
             something.method_1.__str__.wait_until_called()
             something.method_1.__str__.assert_called()
 
-    def test_wait_until_any_call_positional(self):
+    def test_wait_until_any_call_with_positional(self):
         waitable_mock = self._make_mock(spec=Something)
 
         with patch(f"{__name__}.Something", waitable_mock):
@@ -168,16 +168,16 @@ class TestThreadingMock(unittest.TestCase):
             self.run_async(something.method_1, 3, delay=0.3)
             self.assertNotIn(call(1), something.method_1.mock_calls)
 
-            something.method_1.wait_until_any_call(1)
+            something.method_1.wait_until_any_call_with(1)
             something.method_1.assert_called_with(1)
             self.assertNotIn(call(2), something.method_1.mock_calls)
             self.assertNotIn(call(3), something.method_1.mock_calls)
 
-            something.method_1.wait_until_any_call(3)
+            something.method_1.wait_until_any_call_with(3)
             self.assertIn(call(2), something.method_1.mock_calls)
-            something.method_1.wait_until_any_call(2)
+            something.method_1.wait_until_any_call_with(2)
 
-    def test_wait_until_any_call_keywords(self):
+    def test_wait_until_any_call_with_keywords(self):
         waitable_mock = self._make_mock(spec=Something)
 
         with patch(f"{__name__}.Something", waitable_mock):
@@ -187,16 +187,16 @@ class TestThreadingMock(unittest.TestCase):
             self.run_async(something.method_1, c=3, delay=0.3)
             self.assertNotIn(call(a=1), something.method_1.mock_calls)
 
-            something.method_1.wait_until_any_call(a=1)
+            something.method_1.wait_until_any_call_with(a=1)
             something.method_1.assert_called_with(a=1)
             self.assertNotIn(call(b=2), something.method_1.mock_calls)
             self.assertNotIn(call(c=3), something.method_1.mock_calls)
 
-            something.method_1.wait_until_any_call(c=3)
+            something.method_1.wait_until_any_call_with(c=3)
             self.assertIn(call(b=2), something.method_1.mock_calls)
-            something.method_1.wait_until_any_call(b=2)
+            something.method_1.wait_until_any_call_with(b=2)
 
-    def test_wait_until_any_call_no_argument_fails_when_called_with_arg(self):
+    def test_wait_until_any_call_with_no_argument_fails_when_called_with_arg(self):
         waitable_mock = self._make_mock(timeout=0.01)
 
         with patch(f"{__name__}.Something", waitable_mock):
@@ -205,25 +205,25 @@ class TestThreadingMock(unittest.TestCase):
 
             something.method_1.assert_called_with(1)
             with self.assertRaises(AssertionError):
-                something.method_1.wait_until_any_call()
+                something.method_1.wait_until_any_call_with()
 
             something.method_1()
-            something.method_1.wait_until_any_call()
+            something.method_1.wait_until_any_call_with()
 
-    def test_wait_until_any_call_global_default(self):
+    def test_wait_until_any_call_with_global_default(self):
         with patch.object(ThreadingMock, "DEFAULT_TIMEOUT"):
             ThreadingMock.DEFAULT_TIMEOUT = 0.01
             m = self._make_mock()
             with self.assertRaises(AssertionError):
-                m.wait_until_any_call()
+                m.wait_until_any_call_with()
             with self.assertRaises(AssertionError):
                 m.wait_until_called()
 
             m()
-            m.wait_until_any_call()
+            m.wait_until_any_call_with()
         assert ThreadingMock.DEFAULT_TIMEOUT != 0.01
 
-    def test_wait_until_any_call_change_global_and_override(self):
+    def test_wait_until_any_call_with_change_global_and_override(self):
         with patch.object(ThreadingMock, "DEFAULT_TIMEOUT"):
             ThreadingMock.DEFAULT_TIMEOUT = 0.01
 
@@ -256,10 +256,10 @@ class TestThreadingMock(unittest.TestCase):
         with self.assertRaises(AssertionError):
             m.wait_until_called()
         with self.assertRaises(AssertionError):
-            m.wait_until_any_call()
+            m.wait_until_any_call_with()
         m()
         m.wait_until_called()
-        m.wait_until_any_call()
+        m.wait_until_any_call_with()
         m.assert_called_once()
 
         m.reset_mock()
@@ -267,10 +267,10 @@ class TestThreadingMock(unittest.TestCase):
         with self.assertRaises(AssertionError):
             m.wait_until_called()
         with self.assertRaises(AssertionError):
-            m.wait_until_any_call()
+            m.wait_until_any_call_with()
         m()
         m.wait_until_called()
-        m.wait_until_any_call()
+        m.wait_until_any_call_with()
         m.assert_called_once()
 
 

--- a/Lib/unittest/mock.py
+++ b/Lib/unittest/mock.py
@@ -3070,7 +3070,7 @@ class ThreadingMixin(Base):
                    f" timeout({timeout}).")
             raise AssertionError(msg)
 
-    def wait_until_any_call(self, *args, **kwargs):
+    def wait_until_any_call_with(self, *args, **kwargs):
         """Wait until the mock object is called with given args.
 
         Waits for the timeout in seconds provided in the constructor.


### PR DESCRIPTION
Rename the method to be more explicit that it expects the args and kwargs to wait for.

<!-- gh-issue-number: gh-61215 -->
* Issue: gh-61215
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--106414.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->