### PR TITLE
gh-106217: Truncate the issue body size of `new-bugs-announce-notifier`

### DIFF
--- a/.github/workflows/new-bugs-announce-notifier.yml
+++ b/.github/workflows/new-bugs-announce-notifier.yml
@@ -44,7 +44,7 @@ jobs:
                 // We need to truncate the body size, because the max size for
                 // the whole payload is 16kb. We want to be safe and assume that
                 // body can take up to ~8kb of space.
-                body   : issue.data.body.substring(8000)
+                body   : issue.data.body.substring(0, 8000)
               };
 
               const data = {


### PR DESCRIPTION
Refs https://github.com/python/cpython/pull/106329

<!-- gh-issue-number: gh-106217 -->
* Issue: gh-106217
<!-- /gh-issue-number -->
