### PR TITLE
gh-106320: Remove _PyInterpreterState_HasFeature()

### DIFF
--- a/Include/cpython/pystate.h
+++ b/Include/cpython/pystate.h
@@ -3,38 +3,6 @@
 #endif
 
 
-/*
-Runtime Feature Flags
-
-Each flag indicate whether or not a specific runtime feature
-is available in a given context.  For example, forking the process
-might not be allowed in the current interpreter (i.e. os.fork() would fail).
-*/
-
-/* Set if the interpreter share obmalloc runtime state
-   with the main interpreter. */
-#define Py_RTFLAGS_USE_MAIN_OBMALLOC (1UL << 5)
-
-/* Set if import should check a module for subinterpreter support. */
-#define Py_RTFLAGS_MULTI_INTERP_EXTENSIONS (1UL << 8)
-
-/* Set if threads are allowed. */
-#define Py_RTFLAGS_THREADS (1UL << 10)
-
-/* Set if daemon threads are allowed. */
-#define Py_RTFLAGS_DAEMON_THREADS (1UL << 11)
-
-/* Set if os.fork() is allowed. */
-#define Py_RTFLAGS_FORK (1UL << 15)
-
-/* Set if os.exec*() is allowed. */
-#define Py_RTFLAGS_EXEC (1UL << 16)
-
-
-PyAPI_FUNC(int) _PyInterpreterState_HasFeature(PyInterpreterState *interp,
-                                               unsigned long feature);
-
-
 /* private interpreter helpers */
 
 PyAPI_FUNC(int) _PyInterpreterState_RequiresIDRef(PyInterpreterState *);

--- a/Include/internal/pycore_interp.h
+++ b/Include/internal/pycore_interp.h
@@ -275,6 +275,38 @@ PyAPI_FUNC(int) _PyInterpreterState_GetConfigCopy(
 PyAPI_FUNC(int) _PyInterpreterState_SetConfig(
     const struct PyConfig *config);
 
+
+/*
+Runtime Feature Flags
+
+Each flag indicate whether or not a specific runtime feature
+is available in a given context.  For example, forking the process
+might not be allowed in the current interpreter (i.e. os.fork() would fail).
+*/
+
+/* Set if the interpreter share obmalloc runtime state
+   with the main interpreter. */
+#define Py_RTFLAGS_USE_MAIN_OBMALLOC (1UL << 5)
+
+/* Set if import should check a module for subinterpreter support. */
+#define Py_RTFLAGS_MULTI_INTERP_EXTENSIONS (1UL << 8)
+
+/* Set if threads are allowed. */
+#define Py_RTFLAGS_THREADS (1UL << 10)
+
+/* Set if daemon threads are allowed. */
+#define Py_RTFLAGS_DAEMON_THREADS (1UL << 11)
+
+/* Set if os.fork() is allowed. */
+#define Py_RTFLAGS_FORK (1UL << 15)
+
+/* Set if os.exec*() is allowed. */
+#define Py_RTFLAGS_EXEC (1UL << 16)
+
+extern int _PyInterpreterState_HasFeature(PyInterpreterState *interp,
+                                          unsigned long feature);
+
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
Remove the _PyInterpreterState_HasFeature() function from the C API: move it to the internal C API (pycore_interp.h).

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-106320 -->
* Issue: gh-106320
<!-- /gh-issue-number -->
