### PR TITLE
gh-106320: Fix specialize.c compilation by including pycore_pylifecycle.h

### DIFF
--- a/Python/specialize.c
+++ b/Python/specialize.c
@@ -9,6 +9,7 @@
 #include "pycore_opcode.h"        // _PyOpcode_Caches
 #include "structmember.h"         // struct PyMemberDef, T_OFFSET_EX
 #include "pycore_descrobject.h"
+#include "pycore_pylifecycle.h"   // _PyOS_URandomNonblock()
 
 #include <stdlib.h> // rand()
 


### PR DESCRIPTION
Compilation of Python/specialize.c was broken on macOS for me by gh-106400:
```
Python/specialize.c:233:9: error: call to undeclared function '_PyOS_URandomNonblock'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
        _PyOS_URandomNonblock(rand, 20);
        ^
1 error generated.
```


<!-- gh-issue-number: gh-106320 -->
* Issue: gh-106320
<!-- /gh-issue-number -->
