### PR TITLE
gh-85160: improve performance of singledispatchmethod

### DIFF
--- a/Lib/functools.py
+++ b/Lib/functools.py
@@ -933,7 +933,7 @@ class singledispatchmethod:
 
         self.dispatcher = singledispatch(func)
         self.func = func
-        self.attrname = None
+        self._dispatch_method = None
 
     def register(self, cls, method=None):
         """generic_method.register(cls, func) -> func
@@ -943,6 +943,9 @@ class singledispatchmethod:
         return self.dispatcher.register(cls, func=method)
 
     def __get__(self, obj, cls=None):
+        if self._dispatch_method:
+            return self._dispatch_method
+
         def _method(*args, **kwargs):
             method = self.dispatcher.dispatch(args[0].__class__)
             return method.__get__(obj, cls)(*args, **kwargs)
@@ -950,18 +953,12 @@ class singledispatchmethod:
         _method.__isabstractmethod__ = self.__isabstractmethod__
         _method.register = self.register
         update_wrapper(_method, self.func)
-        if obj is not None:
-            # we set the method directly to the instance
-            obj.__dict__[self.attrname] = _method
         return _method
 
     @property
     def __isabstractmethod__(self):
         return getattr(self.func, '__isabstractmethod__', False)
 
-    def __set_name__(self, owner, name):
-        if self.attrname is None:
-            self.attrname = name
 
 
 ################################################################################

--- a/Lib/functools.py
+++ b/Lib/functools.py
@@ -953,6 +953,7 @@ class singledispatchmethod:
         _method.__isabstractmethod__ = self.__isabstractmethod__
         _method.register = self.register
         update_wrapper(_method, self.func)
+        self._dispatch_method = _method
         return _method
 
     @property

--- a/Lib/functools.py
+++ b/Lib/functools.py
@@ -933,6 +933,7 @@ class singledispatchmethod:
 
         self.dispatcher = singledispatch(func)
         self.func = func
+        self.attrname = None
 
     def register(self, cls, method=None):
         """generic_method.register(cls, func) -> func
@@ -949,11 +950,18 @@ class singledispatchmethod:
         _method.__isabstractmethod__ = self.__isabstractmethod__
         _method.register = self.register
         update_wrapper(_method, self.func)
+        if obj is not None:
+            # we set the method directly to the instance
+            obj.__dict__[self.attrname] = _method
         return _method
 
     @property
     def __isabstractmethod__(self):
         return getattr(self.func, '__isabstractmethod__', False)
+
+    def __set_name__(self, owner, name):
+         if self.attrname is None:
+             self.attrname = name
 
 
 ################################################################################

--- a/Lib/functools.py
+++ b/Lib/functools.py
@@ -960,8 +960,8 @@ class singledispatchmethod:
         return getattr(self.func, '__isabstractmethod__', False)
 
     def __set_name__(self, owner, name):
-         if self.attrname is None:
-             self.attrname = name
+        if self.attrname is None:
+            self.attrname = name
 
 
 ################################################################################

--- a/Lib/functools.py
+++ b/Lib/functools.py
@@ -961,7 +961,6 @@ class singledispatchmethod:
         return getattr(self.func, '__isabstractmethod__', False)
 
 
-
 ################################################################################
 ### cached_property() - computed once per instance, cached as attribute
 ################################################################################

--- a/Lib/test/test_functools.py
+++ b/Lib/test/test_functools.py
@@ -2474,6 +2474,26 @@ class TestSingleDispatch(unittest.TestCase):
         self.assertTrue(A.t(''))
         self.assertEqual(A.t(0.0), 0.0)
 
+    def test_staticmethod__slotted_class(self):
+        class A:
+            __slots__ = ['a']
+            @functools.singledispatchmethod
+            def t(arg):
+                return arg
+            @t.register(int)
+            @staticmethod
+            def _(arg):
+                return isinstance(arg, int)
+            @t.register(str)
+            @staticmethod
+            def _(arg):
+                return isinstance(arg, str)
+        a = A()
+
+        self.assertTrue(A.t(0))
+        self.assertTrue(A.t(''))
+        self.assertEqual(A.t(0.0), 0.0)
+
     def test_classmethod_register(self):
         class A:
             def __init__(self, arg):

--- a/Misc/NEWS.d/next/Library/2023-07-05-11-28-57.gh-issue-85160.t925jm.rst
+++ b/Misc/NEWS.d/next/Library/2023-07-05-11-28-57.gh-issue-85160.t925jm.rst
@@ -1,0 +1,1 @@
+Improve performance of ``functools.singledispatchmethod``.

--- a/Misc/NEWS.d/next/Library/2023-07-05-11-28-57.gh-issue-85160.t925jm.rst
+++ b/Misc/NEWS.d/next/Library/2023-07-05-11-28-57.gh-issue-85160.t925jm.rst
@@ -1,1 +1,1 @@
-Improve performance of ``functools.singledispatchmethod``.
+Improve performance of :class:`functools.singledispatchmethod`.


### PR DESCRIPTION
This PR implements the idea from https://github.com/python/cpython/issues/85160  to improve performance of the singledispatchmethod by caching the generated dispatch method.

(updated) benchmark script:
```
import timeit
class Test:
    @singledispatchmethod
    def normal(self, item, arg):
        print('general')
    
    @normal.register
    def _(self, item:int, arg):
        return item + arg

    @singledispatchmethod
    @staticmethod
    def static(item, arg):
        print('general')
    
    @static.register
    @staticmethod
    def _(item:int, arg):
        return item + arg

class SlotClass():
    __slots__ = ("a", "b")
    
    def __init__(self):
        self.a = "zero"
        self.b = "one"
        
    @singledispatchmethod
    def normal(self, item, arg):
        print('general')
    
    @normal.register
    def _(self, item:int, arg):
        return item + arg
  
print('normal ', timeit.timeit('t.normal(1, 1)', globals={'t': Test()}))
print('static method', timeit.timeit('Test.static(1, 1)', globals={'t': Test(), 'Test': Test}))
print('static method instance', timeit.timeit('t.static(1, 1)', globals={'t': Test()}))
print('slotted class ', timeit.timeit('s.normal(1, 1)', globals={'s': SlotClass()}))
```
Output on main:
```
normal  2.5062581849997514
static method 2.7215049250007723
static method instance 2.922215309999956
slotted class  2.8028633869998885
```
This PR:
```
normal  0.9856528150003214
static method 0.9481567359998735
static method instance 0.9450106439999217
slotted class  0.9822057020001012
```

PR #23213 (alternative implementation)
```
normal  0.79438615700019
static method 3.4307698050006366
static method instance 0.7644647329998406
slotted class  3.4285360860003493
```

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-85160 -->
* Issue: gh-85160
<!-- /gh-issue-number -->
