### PR TITLE
gh-96165: Clarify passing ":memory:" in sqlite3.connect().

### DIFF
--- a/Doc/library/sqlite3.rst
+++ b/Doc/library/sqlite3.rst
@@ -266,8 +266,9 @@ Module functions
 
    :param database:
        The path to the database file to be opened.
-       Pass ``":memory:"`` to open a connection to a database that is
-       in RAM instead of on disk.
+       You can pass ``":memory:"`` to create an `SQLite database existing only
+       in memory <https://sqlite.org/inmemorydb.html>`_, and open a connection
+       to it.
    :type database: :term:`path-like object`
 
    :param float timeout:


### PR DESCRIPTION
`":memory:"` is only mentioned in this document, so I think it's enough to clarify it a bit here.

<!-- gh-issue-number: gh-96165 -->
* Issue: gh-96165
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--106451.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->