### PR TITLE
[3.12] gh-64595: Fix regression in file write logic in Argument Clinic (#106449)

### DIFF
--- a/Lib/test/test_clinic.py
+++ b/Lib/test/test_clinic.py
@@ -100,9 +100,8 @@ class ClinicWholeFileTest(TestCase):
         # the last line of the block got corrupted.
         c = clinic.Clinic(clinic.CLanguage(None), filename="file")
         raw = "/*[clinic]\nfoo\n[clinic]*/"
-        cooked, _ = c.parse(raw)
-        lines = cooked.splitlines()
-        end_line = lines[2].rstrip()
+        cooked = c.parse(raw).splitlines()
+        end_line = cooked[2].rstrip()
         # this test is redundant, it's just here explicitly to catch
         # the regression test so we don't forget what it looked like
         self.assertNotEqual(end_line, "[clinic]*/[clinic]*/")
@@ -261,7 +260,7 @@ xyz
         c = clinic.Clinic(language, filename="file")
         c.parsers['inert'] = InertParser(c)
         c.parsers['copy'] = CopyParser(c)
-        computed, _ = c.parse(input)
+        computed = c.parse(input)
         self.assertEqual(output, computed)
 
     def test_clinic_1(self):


### PR DESCRIPTION
Revert the two commits that introduced the regressions:

 - gh-104152
 - gh-104507

(cherry picked from commit 9d1d4f9c73a71192b22ab52a2eb9278737f98ddb)

Co-authored-by: Erlend Aasland <erlend@python.org>


<!-- gh-issue-number: gh-64595 -->
* Issue: gh-64595
<!-- /gh-issue-number -->
