### PR TITLE
Clarify state of CancelledError in doc

### DIFF
--- a/Doc/library/asyncio-exceptions.rst
+++ b/Doc/library/asyncio-exceptions.rst
@@ -31,7 +31,7 @@ Exceptions
 
    .. versionchanged:: 3.8
 
-      :exc:`CancelledError` is now a subclass of :class:`BaseException`.
+      :exc:`CancelledError` is now a subclass of :class:`BaseException` rather than :class:`Exception`.
 
 
 .. exception:: InvalidStateError


### PR DESCRIPTION
This change makes it explicit that `asyncio.CancelledError` _is not_ a subclass of `Exception`.
The previous wording technically allowed for the interpretation that it _might also_ be an `Exception`, and that this were therefore somehow interpretation-defined.  This change corresponds to the text in the "What's new in 3.8" section.
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--106453.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->