### PR TITLE
gh-90876: Restore the ability to import multiprocessing when `sys.executable` is `None`

### DIFF
--- a/Lib/multiprocessing/spawn.py
+++ b/Lib/multiprocessing/spawn.py
@@ -31,7 +31,7 @@ if sys.platform != 'win32':
     WINSERVICE = False
 else:
     WINEXE = getattr(sys, 'frozen', False)
-    WINSERVICE = sys.executable.lower().endswith("pythonservice.exe")
+    WINSERVICE = sys.executable and sys.executable.lower().endswith("pythonservice.exe")
 
 def set_executable(exe):
     global _python_exe

--- a/Lib/multiprocessing/spawn.py
+++ b/Lib/multiprocessing/spawn.py
@@ -35,7 +35,9 @@ else:
 
 def set_executable(exe):
     global _python_exe
-    if sys.platform == 'win32':
+    if exe is None:
+        _python_exe = exe
+    elif sys.platform == 'win32':
         _python_exe = os.fsdecode(exe)
     else:
         _python_exe = os.fsencode(exe)

--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -5849,6 +5849,18 @@ class MiscTestCase(unittest.TestCase):
         support.check__all__(self, multiprocessing, extra=multiprocessing.__all__,
                              not_exported=['SUBDEBUG', 'SUBWARNING'])
 
+    def test_spawn_set_executable_none(self):
+        # Regression test for a bug introduced in
+        # https://github.com/python/cpython/issues/90876 that caused an
+        # ImportError in multiprocessing when sys.executable (or sys.exec_prefix
+        # on Windows) was None.  This can be true in embedded environments.
+        import multiprocessing.spawn
+        orig_exe = multiprocessing.spawn.get_executable()
+        try:
+            multiprocessing.spawn.set_executable(None)
+        finally:
+            multiprocessing.spawn.set_executable(orig_exe)
+
 
 #
 # Mixins

--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -5878,12 +5878,14 @@ class MiscTestCase(unittest.TestCase):
         # ImportError in multiprocessing when sys.executable was None.
         # This can be true in embedded environments.
         rc, out, err = script_helper.assert_python_ok(
-                "-c", """if 1:
-import sys
-sys.executable = None
-assert "multiprocessing" not in sys.modules, "mp already imported!"
-import multiprocessing
-import multiprocessing.spawn  # This should not fail\n""")
+                "-c",
+                """if 1:
+                import sys
+                sys.executable = None
+                assert "multiprocessing" not in sys.modules, "already imported!"
+                import multiprocessing
+                import multiprocessing.spawn  # This should not fail""",
+        )
         self.assertEqual(rc, 0)
         self.assertEqual(err, b'')
 

--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -201,7 +201,11 @@ def only_run_in_spawn_testsuite(reason):
 class TestInternalDecorators(unittest.TestCase):
     """Logic within a test suite that could errantly skip tests? Test it!"""
 
+    @unittest.skipIf(sys.platform == "win32", "test requires that fork exists.")
     def test_only_run_in_spawn_testsuite(self):
+        if multiprocessing.get_start_method() != "spawn":
+            raise unittest.SkipTest("only run in test_multiprocessing_spawn.")
+
         try:
             @only_run_in_spawn_testsuite("testing this decorator")
             def return_four_if_spawn():
@@ -213,7 +217,7 @@ class TestInternalDecorators(unittest.TestCase):
         try:
             multiprocessing.set_start_method("spawn", force=True)
             self.assertEqual(return_four_if_spawn(), 4)
-            multiprocessing.set_start_method("forkserver", force=True)
+            multiprocessing.set_start_method("fork", force=True)
             with self.assertRaises(unittest.SkipTest) as ctx:
                 return_four_if_spawn()
             self.assertIn("testing this decorator", str(ctx.exception))

--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -186,13 +186,40 @@ def only_run_in_spawn_testsuite(reason):
     """
 
     def decorator(test_item):
+
         @functools.wraps(test_item)
         def spawn_check_wrapper(*args, **kwargs):
             if (start_method := multiprocessing.get_start_method()) != "spawn":
                 raise unittest.SkipTest(f"{start_method=}, not 'spawn'; {reason}")
+            return test_item(*args, **kwargs)
+
         return spawn_check_wrapper
 
     return decorator
+
+
+class TestInternalDecorators(unittest.TestCase):
+    """Logic within a test suite that could errantly skip tests? Test it!"""
+
+    def test_only_run_in_spawn_testsuite(self):
+        try:
+            @only_run_in_spawn_testsuite("testing this decorator")
+            def return_four_if_spawn():
+                return 4
+        except Exception as err:
+            self.fail(f"expected decorated `def` not to raise; caught {err}")
+
+        orig_start_method = multiprocessing.get_start_method(allow_none=True)
+        try:
+            multiprocessing.set_start_method("spawn", force=True)
+            self.assertEqual(return_four_if_spawn(), 4)
+            multiprocessing.set_start_method("forkserver", force=True)
+            with self.assertRaises(unittest.SkipTest) as ctx:
+                return_four_if_spawn()
+            self.assertIn("testing this decorator", str(ctx.exception))
+            self.assertIn("start_method=", str(ctx.exception))
+        finally:
+            multiprocessing.set_start_method(orig_start_method, force=True)
 
 
 #
@@ -5845,24 +5872,23 @@ class TestNamedResource(unittest.TestCase):
         # gh-90549: Check that global named resources in main module
         # will not leak by a subprocess, in spawn context.
         #
-        test_source = """if 1:
-            import multiprocessing as mp
-
-            ctx = mp.get_context('spawn')
-
-            global_resource = ctx.Semaphore()
-
-            def submain(): pass
-
-            if __name__ == '__main__':
-                p = ctx.Process(target=submain)
-                p.start()
-                p.join()
-        """
-        rc, out, err = script_helper.assert_python_ok("-c", test_source)
+        testfn = os_helper.TESTFN
+        self.addCleanup(os_helper.unlink, testfn)
+        with open(testfn, 'w', encoding='utf-8') as f:
+            f.write(textwrap.dedent('''\
+                import multiprocessing as mp
+                ctx = mp.get_context('spawn')
+                global_resource = ctx.Semaphore()
+                def submain(): pass
+                if __name__ == '__main__':
+                    p = ctx.Process(target=submain)
+                    p.start()
+                    p.join()
+            '''))
+        rc, out, err = script_helper.assert_python_ok(testfn)
         # on error, err = 'UserWarning: resource_tracker: There appear to
         # be 1 leaked semaphore objects to clean up at shutdown'
-        self.assertEqual(err, b'')
+        self.assertFalse(err, msg=err.decode('utf-8'))
 
 
 class MiscTestCase(unittest.TestCase):
@@ -5878,16 +5904,16 @@ class MiscTestCase(unittest.TestCase):
         # ImportError in multiprocessing when sys.executable was None.
         # This can be true in embedded environments.
         rc, out, err = script_helper.assert_python_ok(
-                "-c",
-                """if 1:
-                import sys
-                sys.executable = None
-                assert "multiprocessing" not in sys.modules, "already imported!"
-                import multiprocessing
-                import multiprocessing.spawn  # This should not fail""",
+            "-c",
+            """if 1:
+            import sys
+            sys.executable = None
+            assert "multiprocessing" not in sys.modules, "already imported!"
+            import multiprocessing
+            import multiprocessing.spawn  # This should not fail\n""",
         )
         self.assertEqual(rc, 0)
-        self.assertEqual(err, b'')
+        self.assertFalse(err, msg=err.decode('utf-8'))
 
 
 #

--- a/Misc/NEWS.d/next/Library/2023-07-05-13-08-23.gh-issue-90876.Qvlkfl.rst
+++ b/Misc/NEWS.d/next/Library/2023-07-05-13-08-23.gh-issue-90876.Qvlkfl.rst
@@ -1,0 +1,3 @@
+Prevent :mod:`multiprocessing.spawn` from failing to *import* in environments
+where ``sys.executable`` is ``None``.  This regressed in 3.11 with the addition
+of support for path-like objects in multiprocessing.


### PR DESCRIPTION
We could at least _import_ multiprocessing when `sys.executable == None` (embedded things for example) in the past, this regressed in 3.11. This restores the ability to import it.  (obviously spawn and forkserver won't work as is in that environment, but the imports need to work to allow code to construct a workaround for this)

<!-- gh-issue-number: gh-90876 -->
* Issue: gh-90876
<!-- /gh-issue-number -->
