### PR TITLE
Doc: Add missing ref labels to exception groups/notes sections

### DIFF
--- a/Doc/library/exceptions.rst
+++ b/Doc/library/exceptions.rst
@@ -871,6 +871,8 @@ The following exceptions are used as warning categories; see the
    .. versionadded:: 3.2
 
 
+.. _lib-exception-groups:
+
 Exception groups
 ----------------
 

--- a/Doc/tutorial/errors.rst
+++ b/Doc/tutorial/errors.rst
@@ -578,6 +578,8 @@ the following pattern::
    ...
 
 
+.. _tut-exception-notes:
+
 Enriching Exceptions with Notes
 ===============================
 


### PR DESCRIPTION
Currently, the Exception Groups section of the library reference, and (more troublesomely, and unlike all the others there) the Enriching Exceptions with Notes tutorial sections are both missing ref targets labels, so it is not possible to reliably link them either internally or from other docs, PEPs, sites, etc. In particular, this blocks python/peps#3193 as it is not possible to add the required `canonical-doc` banners.

This PR fixes that by simply adding the relevant ref target labels accordingly.

<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--106465.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->