### PR TITLE
GH-100141: Fix Pdb loops endlessly on empty file

### DIFF
--- a/Lib/pdb.py
+++ b/Lib/pdb.py
@@ -327,8 +327,7 @@ class Pdb(bdb.Bdb, cmd.Cmd):
     def user_line(self, frame):
         """This function is called when we stop or break at this line."""
         if self._wait_for_mainpyfile:
-            if (self.mainpyfile != self.canonic(frame.f_code.co_filename)
-                or frame.f_lineno <= 0):
+            if (self.mainpyfile != self.canonic(frame.f_code.co_filename)):
                 return
             self._wait_for_mainpyfile = False
         if self.bp_commands(frame):

--- a/Misc/NEWS.d/next/Library/2023-07-06-08-28-12.gh-issue-100141.k3l_Z-.rst
+++ b/Misc/NEWS.d/next/Library/2023-07-06-08-28-12.gh-issue-100141.k3l_Z-.rst
@@ -1,0 +1,1 @@
+Fix Pdb infinite loop on empty code


### PR DESCRIPTION
The bug:

```
$ python3.10 -m pdb /dev/null  # good
> /dev/null(1)<module>()
(Pdb) q

$ python3.11 -m pdb /dev/null  # bad
The program finished and will be restarted
The program finished and will be restarted
The program finished and will be restarted
^CTraceback (most recent call last):
  File "/opt/homebrew/Cellar/python@3.11/3.11.2_1/Frameworks/Python.framework/Versions/3.11/lib/python3.11/pdb.py", line 1774, in main
    pdb._run(target)
  File "/opt/homebrew/Cellar/python@3.11/3.11.2_1/Frameworks/Python.framework/Versions/3.11/lib/python3.11/pdb.py", line 1652, in _run
    self.run(target.code)
             ^^^^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.11/3.11.2_1/Frameworks/Python.framework/Versions/3.11/lib/python3.11/pdb.py", line 166, in code
    with io.open(self) as fp:
KeyboardInterrupt
Uncaught exception. Entering post mortem debugging
Running 'cont' or 'step' will restart the program
> /opt/homebrew/Cellar/python@3.11/3.11.2_1/Frameworks/Python.framework/Versions/3.11/lib/python3.11/pdb.py(166)code()
-> with io.open(self) as fp:
(Pdb) q
The program finished and will be restarted
The program finished and will be restarted
...
```

@SnoopJ had a snoop and said the change in behavior between 3.10 and 3.11 appears to be caused by https://github.com/python/cpython/pull/94552, which changes `lineno` for the first opcode in a module from `-1` to `0`, so we immediately suspect this code in `pdb.py`:

```
    def user_line(self, frame):
        """This function is called when we stop or break at this line."""
        if self._wait_for_mainpyfile:
            if (self.mainpyfile != self.canonic(frame.f_code.co_filename)
                or frame.f_lineno <= 0):
                return
            self._wait_for_mainpyfile = False
        if self.bp_commands(frame):
            self.interaction(frame, None)
```

Indeed, that `frame.f_lineno <= 0` makes `pdb` not stop for user input when running with an empty module, and removing it doesn't affect behavior for a nonempty module. It was added in 2004 as part of the `_wait_for_mainpyfile` feature and wasn't touched since - at the time there must have been some other opcode with index `-1` that we _don't_ want to pause on. Honestly, I couldn't figure out why this _doesn't_ manifest in `3.10`.

Still, removing this clause seems safe as far as I can tell, and fixes the bug. @iritkatriel could I ask you to have a look? You opened the pull request that may have sparked this, and you're the one who inspired me yesterday at Pycon to take an evening and try to fix some `pdb` bugs.

<!-- gh-issue-number: gh-100141 -->
* Issue: gh-100141
<!-- /gh-issue-number -->
