### PR TITLE
gh-106508: Improve debugging of the _sre module

### DIFF
--- a/Modules/_sre/sre.c
+++ b/Modules/_sre/sre.c
@@ -49,8 +49,14 @@ static const char copyright[] =
 
 #include <ctype.h>
 
-/* defining this one enables tracing */
-#undef VERBOSE
+/* Defining this one controls tracing:
+ * 0 -- disabled
+ * 1 -- only if the DEBUG flag set
+ * 2 -- always
+ */
+#ifndef VERBOSE
+#  define VERBOSE 0
+#endif
 
 /* -------------------------------------------------------------------- */
 
@@ -70,10 +76,21 @@ static const char copyright[] =
 #define SRE_ERROR_MEMORY -9 /* out of memory */
 #define SRE_ERROR_INTERRUPTED -10 /* signal handler raised exception */
 
-#if defined(VERBOSE)
-#define TRACE(v) printf v
+#if VERBOSE == 0
+#  define INIT_TRACE(state)
+#  define TRACE(v)
+#elif VERBOSE == 1
+#  define INIT_TRACE(state) int _debug = (state)->debug
+#  define TRACE(v) do {     \
+        if (_debug) { \
+            printf v;       \
+        }                   \
+    } while (0)
+#elif VERBOSE == 2
+#  define INIT_TRACE(state)
+#  define TRACE(v) printf v
 #else
-#define TRACE(v)
+#  error VERBOSE must be 0, 1 or 2
 #endif
 
 /* -------------------------------------------------------------------- */
@@ -198,6 +215,7 @@ data_stack_dealloc(SRE_STATE* state)
 static int
 data_stack_grow(SRE_STATE* state, Py_ssize_t size)
 {
+    INIT_TRACE(state);
     Py_ssize_t minsize, cursize;
     minsize = state->data_stack_base+size;
     cursize = state->data_stack_size;
@@ -449,6 +467,7 @@ state_init(SRE_STATE* state, PatternObject* pattern, PyObject* string,
     state->charsize = charsize;
     state->match_all = 0;
     state->must_advance = 0;
+    state->debug = ((pattern->flags & SRE_FLAG_DEBUG) != 0);
 
     state->beginning = ptr;
 
@@ -641,6 +660,7 @@ _sre_SRE_Pattern_match_impl(PatternObject *self, PyTypeObject *cls,
     if (!state_init(&state, (PatternObject *)self, string, pos, endpos))
         return NULL;
 
+    INIT_TRACE(&state);
     state.ptr = state.start;
 
     TRACE(("|%p|%p|MATCH\n", PatternObject_GetCode(self), state.ptr));
@@ -684,6 +704,7 @@ _sre_SRE_Pattern_fullmatch_impl(PatternObject *self, PyTypeObject *cls,
     if (!state_init(&state, self, string, pos, endpos))
         return NULL;
 
+    INIT_TRACE(&state);
     state.ptr = state.start;
 
     TRACE(("|%p|%p|FULLMATCH\n", PatternObject_GetCode(self), state.ptr));
@@ -730,6 +751,7 @@ _sre_SRE_Pattern_search_impl(PatternObject *self, PyTypeObject *cls,
     if (!state_init(&state, self, string, pos, endpos))
         return NULL;
 
+    INIT_TRACE(&state);
     TRACE(("|%p|%p|SEARCH\n", PatternObject_GetCode(self), state.ptr));
 
     status = sre_search(&state, PatternObject_GetCode(self));

--- a/Modules/_sre/sre.h
+++ b/Modules/_sre/sre.h
@@ -84,6 +84,7 @@ typedef struct {
     int charsize; /* character size */
     int match_all;
     int must_advance;
+    int debug;
     /* marks */
     int lastmark;
     int lastindex;

--- a/Modules/_sre/sre_lib.h
+++ b/Modules/_sre/sre_lib.h
@@ -209,6 +209,7 @@ SRE(count)(SRE_STATE* state, const SRE_CODE* pattern, Py_ssize_t maxcount)
     const SRE_CHAR* ptr = (const SRE_CHAR *)state->ptr;
     const SRE_CHAR* end = (const SRE_CHAR *)state->end;
     Py_ssize_t i;
+    INIT_TRACE(state);
 
     /* adjust end */
     if (maxcount < end - ptr && maxcount != SRE_MAXREPEAT)
@@ -567,6 +568,7 @@ SRE(match)(SRE_STATE* state, const SRE_CODE* pattern, int toplevel)
 
     SRE(match_context)* ctx;
     SRE(match_context)* nextctx;
+    INIT_TRACE(state);
 
     TRACE(("|%p|%p|ENTER\n", pattern, state->ptr));
 
@@ -1639,6 +1641,7 @@ SRE(search)(SRE_STATE* state, SRE_CODE* pattern)
     SRE_CODE* charset = NULL;
     SRE_CODE* overlap = NULL;
     int flags = 0;
+    INIT_TRACE(state);
 
     if (ptr > end)
         return 0;


### PR DESCRIPTION
Now the VERBOSE macro can control tracing on per-pattern basis:

* 0 -- disabled
* 1 -- only if the DEBUG flag set
* 2 -- always


<!-- gh-issue-number: gh-106508 -->
* Issue: gh-106508
<!-- /gh-issue-number -->
