### PR TITLE
gh-106052: Fix bug in the matching of possessive quantifiers

### DIFF
--- a/Lib/re/_compiler.py
+++ b/Lib/re/_compiler.py
@@ -100,6 +100,13 @@ def _compile(code, pattern, flags):
                 emit(ANY_ALL)
             else:
                 emit(ANY)
+        elif op is POSSESSIVE_REPEAT:
+            # gh-106052: Possessive quantifiers do not work when the
+            # subpattern contains backtracking, i.e. "(?:ab?c)*+".
+            # Implement it as equivalent greedy qualifier in atomic group.
+            p = [(MAX_REPEAT, av)]
+            p = [(ATOMIC_GROUP, p)]
+            _compile(code, p, flags)
         elif op in REPEATING_CODES:
             if _simple(av[2]):
                 emit(REPEATING_CODES[op][2])

--- a/Lib/test/test_re.py
+++ b/Lib/test/test_re.py
@@ -2398,6 +2398,16 @@ class ReTests(unittest.TestCase):
         self.assertTrue(re.fullmatch(r'(?s:(?>.*?\.).*)\Z', "a.txt")) # reproducer
         self.assertTrue(re.fullmatch(r'(?s:(?=(?P<g0>.*?\.))(?P=g0).*)\Z', "a.txt"))
 
+    def test_bug_gh106052(self):
+        self.assertEqual(re.match("(?>(?:ab?c)+)", "aca").span(), (0, 2))
+        self.assertEqual(re.match("(?:ab?c)++", "aca").span(), (0, 2))
+        self.assertEqual(re.match("(?>(?:ab?c)*)", "aca").span(), (0, 2))
+        self.assertEqual(re.match("(?:ab?c)*+", "aca").span(), (0, 2))
+        self.assertEqual(re.match("(?>(?:ab?c)?)", "a").span(), (0, 0))
+        self.assertEqual(re.match("(?:ab?c)?+", "a").span(), (0, 0))
+        self.assertEqual(re.match("(?>(?:ab?c){1,3})", "aca").span(), (0, 2))
+        self.assertEqual(re.match("(?:ab?c){1,3}+", "aca").span(), (0, 2))
+
     @unittest.skipIf(multiprocessing is None, 'test requires multiprocessing')
     def test_regression_gh94675(self):
         pattern = re.compile(r'(?<=[({}])(((//[^\n]*)?[\n])([\000-\040])*)*'
@@ -2491,6 +2501,7 @@ ATOMIC_GROUP [(LITERAL, 97), (MAX_REPEAT, (0, 1, [(LITERAL, 98)]))]
 17: SUCCESS
 ''')
 
+    @unittest.expectedFailure  # gh-106052
     def test_possesive_repeat_one(self):
         self.assertEqual(get_debug_out(r'a?+'), '''\
 POSSESSIVE_REPEAT 0 1
@@ -2503,6 +2514,7 @@ POSSESSIVE_REPEAT 0 1
 12: SUCCESS
 ''')
 
+    @unittest.expectedFailure  # gh-106052
     def test_possesive_repeat(self):
         self.assertEqual(get_debug_out(r'(?:ab)?+'), '''\
 POSSESSIVE_REPEAT 0 1

--- a/Misc/NEWS.d/next/Library/2023-07-07-14-52-31.gh-issue-106052.ak8nbs.rst
+++ b/Misc/NEWS.d/next/Library/2023-07-07-14-52-31.gh-issue-106052.ak8nbs.rst
@@ -1,0 +1,2 @@
+:mod:`re` module: fix the matching of possessive quantifiers in the case of
+a subpattern containing backtracking.


### PR DESCRIPTION
It did not work in the case of a subpattern containing backtraces.

Temporary implement possessive quantifiers as equivalent greedy qualifiers in atomic groups.


<!-- gh-issue-number: gh-106052 -->
* Issue: gh-106052
<!-- /gh-issue-number -->
