### PR TITLE
gh-104050: Argument Clinic: Annotate the `Block` class

### DIFF
--- a/Tools/clinic/clinic.py
+++ b/Tools/clinic/clinic.py
@@ -1687,7 +1687,7 @@ class Block:
     indent: str = ''
     preindent: str = ''
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         dsl_name = self.dsl_name or "text"
         def summarize(s):
             s = repr(s)

--- a/Tools/clinic/clinic.py
+++ b/Tools/clinic/clinic.py
@@ -1689,7 +1689,7 @@ class Block:
 
     def __repr__(self) -> str:
         dsl_name = self.dsl_name or "text"
-        def summarize(s):
+        def summarize(s: object) -> str:
             s = repr(s)
             if len(s) > 30:
                 return s[:26] + "..." + s[0]

--- a/Tools/clinic/clinic.py
+++ b/Tools/clinic/clinic.py
@@ -4618,10 +4618,13 @@ class DSLParser:
 
                 if not (existing_function.kind == self.kind and existing_function.coexist == self.coexist):
                     fail("'kind' of function and cloned function don't match!  (@classmethod/@staticmethod/@coexist)")
-                self.function = existing_function.copy(name=function_name, full_name=full_name, module=module, cls=cls, c_basename=c_basename, docstring='')
-                assert self.function is not None
-                self.block.signatures.append(self.function)
-                (cls or module).functions.append(self.function)
+                function = existing_function.copy(
+                    name=function_name, full_name=full_name, module=module,
+                    cls=cls, c_basename=c_basename, docstring=''
+                )
+                self.function = function
+                self.block.signatures.append(function)
+                (cls or module).functions.append(function)
                 self.next(self.state_function_docstring)
                 return
 

--- a/Tools/clinic/clinic.py
+++ b/Tools/clinic/clinic.py
@@ -759,7 +759,7 @@ class CLanguage(Language):
     def render(
             self,
             clinic: Clinic | None,
-            signatures: Iterable[Function]
+            signatures: Iterable[Module | Class | Function]
     ) -> str:
         function = None
         for o in signatures:
@@ -1633,6 +1633,7 @@ def create_regex(
     return re.compile(pattern)
 
 
+@dc.dataclass(slots=True, repr=False)
 class Block:
     r"""
     Represents a single block of text embedded in
@@ -1679,14 +1680,12 @@ class Block:
     "preindent" would be "____" and "indent" would be "__".
 
     """
-    def __init__(self, input, dsl_name=None, signatures=None, output=None, indent='', preindent=''):
-        assert isinstance(input, str)
-        self.input = input
-        self.dsl_name = dsl_name
-        self.signatures = signatures or []
-        self.output = output
-        self.indent = indent
-        self.preindent = preindent
+    input: str
+    dsl_name: str | None = None
+    signatures: list[Module | Class | Function] = dc.field(default_factory=list)
+    output: Any = None  # TODO: Very dynamic; probably untypeable in its current form?
+    indent: str = ''
+    preindent: str = ''
 
     def __repr__(self):
         dsl_name = self.dsl_name or "text"
@@ -4620,7 +4619,7 @@ class DSLParser:
                 if not (existing_function.kind == self.kind and existing_function.coexist == self.coexist):
                     fail("'kind' of function and cloned function don't match!  (@classmethod/@staticmethod/@coexist)")
                 self.function = existing_function.copy(name=function_name, full_name=full_name, module=module, cls=cls, c_basename=c_basename, docstring='')
-
+                assert self.function is not None
                 self.block.signatures.append(self.function)
                 (cls or module).functions.append(self.function)
                 self.next(self.state_function_docstring)


### PR DESCRIPTION
I tried long and hard to see if there was a sane way of annotating the `output` field of the `Block` class. In the end I concluded that, from a typing perspective, the current code is somewhat insane, so there's no sane way of doing it without substantially refactoring the code first 🙃 For now, I propose that we annotate it with `Any` and leave it for another day.

The issue is that `output` usually has type `str | None`, as stated by the docstring here:

https://github.com/python/cpython/blob/363f4f99c524a6d763d1548986a79c42cc7ca292/Tools/clinic/clinic.py#L1659-L1660

_But_ whenever `self.block` is referenced from inside the `DSLParser` class, it's of type `list[str]` (I'm pretty confident `self.block` is an instance of `Block`):

https://github.com/python/cpython/blob/363f4f99c524a6d763d1548986a79c42cc7ca292/Tools/clinic/clinic.py#L4471-L4476

This is because `DSLParser.parse()` sets `block.output` to a list at the beginning of the function, and then sets it back to a string at the end of the function:

https://github.com/python/cpython/blob/363f4f99c524a6d763d1548986a79c42cc7ca292/Tools/clinic/clinic.py#L4502

https://github.com/python/cpython/blob/363f4f99c524a6d763d1548986a79c42cc7ca292/Tools/clinic/clinic.py#L4515-L4518

Needless to say, this makes mypy furious if you give `Block.output` a type that isn't `Any` 🙃

<!-- gh-issue-number: gh-104050 -->
* Issue: gh-104050
<!-- /gh-issue-number -->
