### PR TITLE
gh-104584: Replace ENTER_EXECUTOR with the original in trace projection

### DIFF
--- a/Python/optimizer.c
+++ b/Python/optimizer.c
@@ -419,6 +419,12 @@ translate_bytecode_to_trace(
             opcode = instr->op.code;
             oparg = (oparg << 8) | instr->op.arg;
         }
+        if (opcode == ENTER_EXECUTOR) {
+            _PyExecutorObject *executor = (_PyExecutorObject *)code->co_executors->executors[oparg&255];
+            opcode = executor->vm_data.opcode;
+            DPRINTF(2, "  * ENTER_EXECUTOR -> %s\n",  _PyOpcode_OpName[opcode]);
+            oparg = (oparg & 0xffffff00) | executor->vm_data.oparg;
+        }
         switch (opcode) {
             default:
             {


### PR DESCRIPTION
This is a small independent piece lifted from the closed PR gh-106393.

<!-- gh-issue-number: gh-104584 -->
* Issue: gh-104584
<!-- /gh-issue-number -->
