### PR TITLE
gh-106498: Fix an extreme case in `colorsys.rgb_to_hls`

### DIFF
--- a/Lib/colorsys.py
+++ b/Lib/colorsys.py
@@ -78,7 +78,13 @@ def rgb_to_hls(r, g, b):
     sumc = (maxc+minc)
     rangec = (maxc-minc)
     l = sumc/2.0
-    if minc == maxc:
+    # gh-106498
+    # Due to a degree of float precision error, it's possible that maxc != minc
+    # but maxc + minc == 2.0. Which will make (2.0 - sumc) zero, causing the
+    # ZeroDivisionError.
+    # e.g. colorsys.rgb_to_hls(1, 1, 0.9999999999999999)
+    # In this case, it's an extreme near white color so we can just return white
+    if minc == maxc or sumc == 2.0:
         return 0.0, l, 0.0
     if l <= 0.5:
         s = rangec / sumc

--- a/Lib/test/test_colorsys.py
+++ b/Lib/test/test_colorsys.py
@@ -69,6 +69,12 @@ class ColorsysTest(unittest.TestCase):
             self.assertTripleEqual(hls, colorsys.rgb_to_hls(*rgb))
             self.assertTripleEqual(rgb, colorsys.hls_to_rgb(*hls))
 
+    def test_hls_corner_case(self):
+        try:
+            colorsys.rgb_to_hls(1, 1, 0.9999999999999999)
+        except Exception:
+            self.fail("rgb_to_hls(1, 1, 0.9999999999999999) raised an exception!")
+
     def test_yiq_roundtrip(self):
         for r in frange(0.0, 1.0, 0.2):
             for g in frange(0.0, 1.0, 0.2):

--- a/Misc/NEWS.d/next/Library/2023-07-07-19-46-27.gh-issue-106498.ijJ-eH.rst
+++ b/Misc/NEWS.d/next/Library/2023-07-07-19-46-27.gh-issue-106498.ijJ-eH.rst
@@ -1,0 +1,1 @@
+Fixed :func:`colorsys.rgb_to_hls` under an extreme input.


### PR DESCRIPTION
`colorsys.rgb_to_hls(1, 1, 0.9999999999999999)` raises `ZeroDivisionError` now (this probably is the ONLY case). Not sure if it's worth fixing, but I think "correct" in all cases is more important than "very slightly faster in theory".

This optimization is originally introduced in #23306, using the benchmark given in the PR, there's no observable performance regression with the extra check.

<details>
<summary>Benchmark Code</summary>

```python
# /usr/bin/env python

import timeit
import statistics
from Lib.test.test_colorsys import ColorsysTest


if __name__ == '__main__':
    number = 100
    repeat = 100
    results = timeit.repeat('ColorsysTest().test_hls_roundtrip()',
                    setup='from Lib.test.test_colorsys import ColorsysTest',
                    number=number,
                    repeat=repeat)

    running_times = list(sorted(results))

    mean = statistics.mean(running_times)
    std = statistics.stdev(running_times)
    print(f"Running time: {mean} ± {std} ms.  "
    f"(number, repeat) = ({number}, {repeat})")
```

</details>

Another possible implementation is to do a try-except block for the division. As `try` is almost no cost now, it would be theoretically faster than the current one. The return value would be different (a near white color can be represented in many forms in hls space). I prefer the current solution as it's easy to understand with the comment, but I do not oppose the other way.

<!-- gh-issue-number: gh-106498 -->
* Issue: gh-106498
<!-- /gh-issue-number -->
