### PR TITLE
GH-100502: Add `pathlib.PurePath.pathmod` attribute

### DIFF
--- a/Doc/library/pathlib.rst
+++ b/Doc/library/pathlib.rst
@@ -108,7 +108,7 @@ Pure path objects provide path-handling operations which don't actually
 access a filesystem.  There are three ways to access these classes, which
 we also call *flavours*:
 
-.. class:: PurePath(*pathsegments, pathmod=os.path)
+.. class:: PurePath(*pathsegments)
 
    A generic class that represents the system's path flavour (instantiating
    it creates either a :class:`PurePosixPath` or a :class:`PureWindowsPath`)::
@@ -161,15 +161,6 @@ we also call *flavours*:
    (a naïve approach would make ``PurePosixPath('foo/../bar')`` equivalent
    to ``PurePosixPath('bar')``, which is wrong if ``foo`` is a symbolic link
    to another directory)
-
-   The *pathmod* keyword-only argument is available only in user subclasses of
-   :class:`PurePath` and :class:`Path`. It specifies the implementation of
-   :mod:`os.path` to use for low-level path operations. It may be left unset
-   or set to :mod:`os.path` to use the current system's flavour, or set to
-   ``posixpath`` or ``ntpath`` to use POSIX or Windows path semantics.
-
-   .. versionchanged:: 3.13
-      The *pathmod* parameter was added.
 
    Pure path objects implement the :class:`os.PathLike` interface, allowing them
    to be used anywhere the interface is accepted.
@@ -317,7 +308,7 @@ Pure paths provide the following methods and properties:
    The implementation of :mod:`os.path` used for low-level path operations;
    either ``posixpath`` or ``ntpath``.
 
-   .. versionchanged:: 3.13
+   .. versionadded:: 3.13
 
 .. attribute:: PurePath.drive
 
@@ -758,7 +749,7 @@ Concrete paths are subclasses of the pure path classes.  In addition to
 operations provided by the latter, they also provide methods to do system
 calls on path objects.  There are three ways to instantiate concrete paths:
 
-.. class:: Path(*pathsegments, pathmod=os.path)
+.. class:: Path(*pathsegments)
 
    A subclass of :class:`PurePath`, this class represents concrete paths of
    the system's path flavour (instantiating it creates either a
@@ -767,10 +758,7 @@ calls on path objects.  There are three ways to instantiate concrete paths:
       >>> Path('setup.py')
       PosixPath('setup.py')
 
-   *pathsegments* and *pathmod* are specified similarly to :class:`PurePath`.
-
-   .. versionchanged:: 3.13
-      The *pathmod* parameter was added.
+   *pathsegments* is specified similarly to :class:`PurePath`.
 
 .. class:: PosixPath(*pathsegments)
 

--- a/Doc/library/pathlib.rst
+++ b/Doc/library/pathlib.rst
@@ -108,7 +108,7 @@ Pure path objects provide path-handling operations which don't actually
 access a filesystem.  There are three ways to access these classes, which
 we also call *flavours*:
 
-.. class:: PurePath(*pathsegments)
+.. class:: PurePath(*pathsegments, flavour=os.path)
 
    A generic class that represents the system's path flavour (instantiating
    it creates either a :class:`PurePosixPath` or a :class:`PureWindowsPath`)::
@@ -161,6 +161,15 @@ we also call *flavours*:
    (a naïve approach would make ``PurePosixPath('foo/../bar')`` equivalent
    to ``PurePosixPath('bar')``, which is wrong if ``foo`` is a symbolic link
    to another directory)
+
+   The *flavour* keyword-only argument is available only in user subclasses of
+   :class:`PurePath` and :class:`Path`. It specifies the implementation of
+   :mod:`os.path` to use for low-level path operations. It may be left unset
+   or set to :mod:`os.path` to use the current system's flavour, or set to
+   :mod:`posixpath` or :mod:`ntpath` to use POSIX or Windows path semantics.
+
+   .. versionchanged:: 3.13
+      The *flavour* parameter was added.
 
    Pure path objects implement the :class:`os.PathLike` interface, allowing them
    to be used anywhere the interface is accepted.
@@ -302,6 +311,13 @@ Methods and properties
    from pathlib import PurePath, PurePosixPath, PureWindowsPath
 
 Pure paths provide the following methods and properties:
+
+.. attribute:: PurePath.flavour
+
+   The implementation of :mod:`os.path` used for low-level path operations;
+   either :mod:`posixpath` or :mod:`ntpath`.
+
+   .. versionchanged:: 3.13
 
 .. attribute:: PurePath.drive
 
@@ -742,7 +758,7 @@ Concrete paths are subclasses of the pure path classes.  In addition to
 operations provided by the latter, they also provide methods to do system
 calls on path objects.  There are three ways to instantiate concrete paths:
 
-.. class:: Path(*pathsegments)
+.. class:: Path(*pathsegments, flavour=os.path)
 
    A subclass of :class:`PurePath`, this class represents concrete paths of
    the system's path flavour (instantiating it creates either a
@@ -751,7 +767,10 @@ calls on path objects.  There are three ways to instantiate concrete paths:
       >>> Path('setup.py')
       PosixPath('setup.py')
 
-   *pathsegments* is specified similarly to :class:`PurePath`.
+   *pathsegments* and *flavour* are specified similarly to :class:`PurePath`.
+
+   .. versionchanged:: 3.13
+      The *flavour* parameter was added.
 
 .. class:: PosixPath(*pathsegments)
 

--- a/Doc/library/pathlib.rst
+++ b/Doc/library/pathlib.rst
@@ -166,7 +166,7 @@ we also call *flavours*:
    :class:`PurePath` and :class:`Path`. It specifies the implementation of
    :mod:`os.path` to use for low-level path operations. It may be left unset
    or set to :mod:`os.path` to use the current system's flavour, or set to
-   :mod:`posixpath` or :mod:`ntpath` to use POSIX or Windows path semantics.
+   ``posixpath`` or ``ntpath`` to use POSIX or Windows path semantics.
 
    .. versionchanged:: 3.13
       The *flavour* parameter was added.
@@ -315,7 +315,7 @@ Pure paths provide the following methods and properties:
 .. attribute:: PurePath.flavour
 
    The implementation of :mod:`os.path` used for low-level path operations;
-   either :mod:`posixpath` or :mod:`ntpath`.
+   either ``posixpath`` or ``ntpath``.
 
    .. versionchanged:: 3.13
 

--- a/Doc/library/pathlib.rst
+++ b/Doc/library/pathlib.rst
@@ -305,8 +305,8 @@ Pure paths provide the following methods and properties:
 
 .. attribute:: PurePath.pathmod
 
-   The implementation of :mod:`os.path` used for low-level path operations;
-   either ``posixpath`` or ``ntpath``.
+   The implementation of the :mod:`os.path` module used for low-level path
+   operations: either ``posixpath`` or ``ntpath``.
 
    .. versionadded:: 3.13
 

--- a/Doc/library/pathlib.rst
+++ b/Doc/library/pathlib.rst
@@ -108,7 +108,7 @@ Pure path objects provide path-handling operations which don't actually
 access a filesystem.  There are three ways to access these classes, which
 we also call *flavours*:
 
-.. class:: PurePath(*pathsegments, flavour=os.path)
+.. class:: PurePath(*pathsegments, pathmod=os.path)
 
    A generic class that represents the system's path flavour (instantiating
    it creates either a :class:`PurePosixPath` or a :class:`PureWindowsPath`)::
@@ -162,14 +162,14 @@ we also call *flavours*:
    to ``PurePosixPath('bar')``, which is wrong if ``foo`` is a symbolic link
    to another directory)
 
-   The *flavour* keyword-only argument is available only in user subclasses of
+   The *pathmod* keyword-only argument is available only in user subclasses of
    :class:`PurePath` and :class:`Path`. It specifies the implementation of
    :mod:`os.path` to use for low-level path operations. It may be left unset
    or set to :mod:`os.path` to use the current system's flavour, or set to
    ``posixpath`` or ``ntpath`` to use POSIX or Windows path semantics.
 
    .. versionchanged:: 3.13
-      The *flavour* parameter was added.
+      The *pathmod* parameter was added.
 
    Pure path objects implement the :class:`os.PathLike` interface, allowing them
    to be used anywhere the interface is accepted.
@@ -312,7 +312,7 @@ Methods and properties
 
 Pure paths provide the following methods and properties:
 
-.. attribute:: PurePath.flavour
+.. attribute:: PurePath.pathmod
 
    The implementation of :mod:`os.path` used for low-level path operations;
    either ``posixpath`` or ``ntpath``.
@@ -758,7 +758,7 @@ Concrete paths are subclasses of the pure path classes.  In addition to
 operations provided by the latter, they also provide methods to do system
 calls on path objects.  There are three ways to instantiate concrete paths:
 
-.. class:: Path(*pathsegments, flavour=os.path)
+.. class:: Path(*pathsegments, pathmod=os.path)
 
    A subclass of :class:`PurePath`, this class represents concrete paths of
    the system's path flavour (instantiating it creates either a
@@ -767,10 +767,10 @@ calls on path objects.  There are three ways to instantiate concrete paths:
       >>> Path('setup.py')
       PosixPath('setup.py')
 
-   *pathsegments* and *flavour* are specified similarly to :class:`PurePath`.
+   *pathsegments* and *pathmod* are specified similarly to :class:`PurePath`.
 
    .. versionchanged:: 3.13
-      The *flavour* parameter was added.
+      The *pathmod* parameter was added.
 
 .. class:: PosixPath(*pathsegments)
 

--- a/Lib/pathlib.py
+++ b/Lib/pathlib.py
@@ -868,7 +868,7 @@ class Path(PurePath):
         """
         Check if this path is a mount point
         """
-        return self.pathmod.ismount(self)
+        return os.path.ismount(self)
 
     def is_symlink(self):
         """
@@ -889,7 +889,7 @@ class Path(PurePath):
         """
         Whether this path is a junction.
         """
-        return self.pathmod.isjunction(self)
+        return os.path.isjunction(self)
 
     def is_block_device(self):
         """
@@ -964,7 +964,8 @@ class Path(PurePath):
             other_st = other_path.stat()
         except AttributeError:
             other_st = self.with_segments(other_path).stat()
-        return self.pathmod.samestat(st, other_st)
+        return (st.st_ino == other_st.st_ino and
+                st.st_dev == other_st.st_dev)
 
     def open(self, mode='r', buffering=-1, encoding=None,
              errors=None, newline=None):
@@ -1217,7 +1218,7 @@ class Path(PurePath):
             return self
         elif self.drive:
             # There is a CWD on each drive-letter drive.
-            cwd = self.pathmod.abspath(self.drive)
+            cwd = os.path.abspath(self.drive)
         else:
             cwd = os.getcwd()
             # Fast path for "empty" paths, e.g. Path("."), Path("") or Path().
@@ -1243,7 +1244,7 @@ class Path(PurePath):
                 raise RuntimeError("Symlink loop from %r" % e.filename)
 
         try:
-            s = self.pathmod.realpath(self, strict=strict)
+            s = os.path.realpath(self, strict=strict)
         except OSError as e:
             check_eloop(e)
             raise
@@ -1407,7 +1408,7 @@ class Path(PurePath):
         """
         if (not (self.drive or self.root) and
             self._tail and self._tail[0][:1] == '~'):
-            homedir = self.pathmod.expanduser(self._tail[0])
+            homedir = os.path.expanduser(self._tail[0])
             if homedir[:1] == "~":
                 raise RuntimeError("Could not determine home directory.")
             drv, root, tail = self._parse_path(homedir)

--- a/Lib/test/test_pathlib.py
+++ b/Lib/test/test_pathlib.py
@@ -67,9 +67,9 @@ class PurePathTest(unittest.TestCase):
 
     def setUp(self):
         p = self.cls('a')
-        self.flavour = p.flavour
-        self.sep = self.flavour.sep
-        self.altsep = self.flavour.altsep
+        self.pathmod = p.pathmod
+        self.sep = self.pathmod.sep
+        self.altsep = self.pathmod.altsep
 
     def test_constructor_common(self):
         P = self.cls
@@ -94,24 +94,24 @@ class PurePathTest(unittest.TestCase):
         p = self.cls('a')
         self.assertIs(type(p), expected)
 
-    def test_flavour(self):
+    def test_pathmod(self):
         p = self.cls('a')
         if isinstance(p, pathlib.PureWindowsPath):
-            self.assertIs(p.flavour, ntpath)
+            self.assertIs(p.pathmod, ntpath)
         elif isinstance(p, pathlib.PurePosixPath):
-            self.assertIs(p.flavour, posixpath)
+            self.assertIs(p.pathmod, posixpath)
 
-    def test_different_flavours_unequal(self):
+    def test_different_pathmods_unequal(self):
         p = self.cls('a')
-        if p.flavour is posixpath:
+        if p.pathmod is posixpath:
             q = pathlib.PureWindowsPath('a')
         else:
             q = pathlib.PurePosixPath('a')
         self.assertNotEqual(p, q)
 
-    def test_different_flavours_unordered(self):
+    def test_different_pathmods_unordered(self):
         p = self.cls('a')
-        if p.flavour is posixpath:
+        if p.pathmod is posixpath:
             q = pathlib.PureWindowsPath('a')
         else:
             q = pathlib.PurePosixPath('a')
@@ -196,16 +196,16 @@ class PurePathTest(unittest.TestCase):
         return path.drive, path.root, path.parts
 
     def _check_drive_root_parts(self, arg, *expected):
-        sep = self.flavour.sep
+        sep = self.pathmod.sep
         actual = self._get_drive_root_parts([x.replace('/', sep) for x in arg])
         self.assertEqual(actual, expected)
-        if altsep := self.flavour.altsep:
+        if altsep := self.pathmod.altsep:
             actual = self._get_drive_root_parts([x.replace('/', altsep) for x in arg])
             self.assertEqual(actual, expected)
 
     def test_drive_root_parts_common(self):
         check = self._check_drive_root_parts
-        sep = self.flavour.sep
+        sep = self.pathmod.sep
         # Unanchored parts.
         check((),                   '', '', ())
         check(('a',),               '', '', ('a',))
@@ -665,7 +665,7 @@ class PurePathTest(unittest.TestCase):
         self.assertRaises(ValueError, P('a/b').with_suffix, './.d')
         self.assertRaises(ValueError, P('a/b').with_suffix, '.d/.')
         self.assertRaises(ValueError, P('a/b').with_suffix,
-                          (self.flavour.sep, 'd'))
+                          (self.pathmod.sep, 'd'))
 
     def test_relative_to_common(self):
         P = self.cls
@@ -1557,13 +1557,13 @@ class PurePathSubclassTest(PurePathTest):
     # repr() roundtripping is not supported in custom subclass.
     test_repr_roundtrips = None
 
-    def test_set_flavour(self):
-        p = self.cls('a', 'b', flavour=posixpath)
-        self.assertEqual(p.flavour, posixpath)
+    def test_set_pathmod(self):
+        p = self.cls('a', 'b', pathmod=posixpath)
+        self.assertEqual(p.pathmod, posixpath)
         self.assertEqual(str(p), 'a/b')
 
-        q = self.cls('a', 'b', flavour=ntpath)
-        self.assertEqual(q.flavour, ntpath)
+        q = self.cls('a', 'b', pathmod=ntpath)
+        self.assertEqual(q.pathmod, ntpath)
         self.assertEqual(str(q), 'a\\b')
 
 
@@ -2409,7 +2409,7 @@ class PathTest(unittest.TestCase):
         p = self.cls('a')
         self.assertIs(type(p), expected)
 
-    def test_unsupported_flavour(self):
+    def test_unsupported_pathmod(self):
         if issubclass(self.cls, pathlib.PureWindowsPath) and os.name != 'nt':
             self.assertRaises(pathlib.UnsupportedOperation, self.cls)
         elif issubclass(self.cls, pathlib.PurePosixPath) and os.name == 'nt':
@@ -2867,9 +2867,9 @@ class PathTest(unittest.TestCase):
     def test_is_junction(self):
         P = self.cls(BASE)
 
-        with mock.patch.object(P.flavour, 'isjunction'):
-            self.assertEqual(P.is_junction(), P.flavour.isjunction.return_value)
-            P.flavour.isjunction.assert_called_once_with(P)
+        with mock.patch.object(P.pathmod, 'isjunction'):
+            self.assertEqual(P.is_junction(), P.pathmod.isjunction.return_value)
+            P.pathmod.isjunction.assert_called_once_with(P)
 
     @unittest.skipUnless(hasattr(os, "mkfifo"), "os.mkfifo() required")
     @unittest.skipIf(sys.platform == "vxworks",
@@ -3469,11 +3469,11 @@ class PathSubclassTest(PathTest):
     # repr() roundtripping is not supported in custom subclass.
     test_repr_roundtrips = None
 
-    def test_set_flavour_unsupported(self):
+    def test_set_pathmod_unsupported(self):
         self.assertRaises(
             pathlib.UnsupportedOperation,
             self.cls,
-            flavour=posixpath if os.name == 'nt' else ntpath)
+            pathmod=posixpath if os.name == 'nt' else ntpath)
 
 
 class CompatiblePathTest(unittest.TestCase):

--- a/Lib/test/test_pathlib.py
+++ b/Lib/test/test_pathlib.py
@@ -2410,10 +2410,12 @@ class PathTest(unittest.TestCase):
         self.assertIs(type(p), expected)
 
     def test_unsupported_flavour(self):
-        if (os.name == 'nt') == issubclass(self.cls, pathlib.PureWindowsPath):
-            self.skipTest("path flavour is supported")
-        else:
+        if issubclass(self.cls, pathlib.PureWindowsPath) and os.name != 'nt':
             self.assertRaises(pathlib.UnsupportedOperation, self.cls)
+        elif issubclass(self.cls, pathlib.PurePosixPath) and os.name == 'nt':
+            self.assertRaises(pathlib.UnsupportedOperation, self.cls)
+        else:
+            self.skipTest("path flavour is supported")
 
     def _test_cwd(self, p):
         q = self.cls(os.getcwd())

--- a/Misc/NEWS.d/next/Library/2023-07-07-21-15-17.gh-issue-100502.Iici1B.rst
+++ b/Misc/NEWS.d/next/Library/2023-07-07-21-15-17.gh-issue-100502.Iici1B.rst
@@ -1,3 +1,3 @@
 Add :attr:`pathlib.PurePath.flavour` attribute that stores the
 implementation of :mod:`os.path` used for low-level path operations: either
-:mod:`posixpath` or :mod:`ntpath`.
+``posixpath`` or ``ntpath``.

--- a/Misc/NEWS.d/next/Library/2023-07-07-21-15-17.gh-issue-100502.Iici1B.rst
+++ b/Misc/NEWS.d/next/Library/2023-07-07-21-15-17.gh-issue-100502.Iici1B.rst
@@ -1,3 +1,3 @@
-Add :attr:`pathlib.PurePath.flavour` attribute that stores the
+Add :attr:`pathlib.PurePath.pathmod` attribute that stores the
 implementation of :mod:`os.path` used for low-level path operations: either
 ``posixpath`` or ``ntpath``.

--- a/Misc/NEWS.d/next/Library/2023-07-07-21-15-17.gh-issue-100502.Iici1B.rst
+++ b/Misc/NEWS.d/next/Library/2023-07-07-21-15-17.gh-issue-100502.Iici1B.rst
@@ -1,3 +1,3 @@
-Add :attr:`pathlib.PurePath.pathmod` attribute that stores the
+Add :attr:`pathlib.PurePath.pathmod` class attribute that stores the
 implementation of :mod:`os.path` used for low-level path operations: either
 ``posixpath`` or ``ntpath``.

--- a/Misc/NEWS.d/next/Library/2023-07-07-21-15-17.gh-issue-100502.Iici1B.rst
+++ b/Misc/NEWS.d/next/Library/2023-07-07-21-15-17.gh-issue-100502.Iici1B.rst
@@ -1,0 +1,3 @@
+Add :attr:`pathlib.PurePath.flavour` attribute that stores the
+implementation of :mod:`os.path` used for low-level path operations: either
+:mod:`posixpath` or :mod:`ntpath`.


### PR DESCRIPTION
This class attribute stores the implementation of `os.path` used for low-level path operations: either `posixpath` or `ntpath`.

<!-- gh-issue-number: gh-100502 -->
* Issue: gh-100502
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--106533.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->