### PR TITLE
Restore previous behavior of 'make regen-cases'

### DIFF
--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -1544,7 +1544,18 @@ regen-opcode-targets:
 regen-cases:
 	# Regenerate various files from Python/bytecodes.c
 	PYTHONPATH=$(srcdir)/Tools/cases_generator \
-	$(PYTHON_FOR_REGEN) $(srcdir)/Tools/cases_generator/generate_cases.py -l
+	$(PYTHON_FOR_REGEN) \
+	    $(srcdir)/Tools/cases_generator/generate_cases.py \
+		--emit-line-directives \
+		-o $(srcdir)/Python/generated_cases.c.h.new \
+		-m $(srcdir)/Python/opcode_metadata.h.new \
+		-e $(srcdir)/Python/executor_cases.c.h.new \
+		-p $(srcdir)/Lib/_opcode_metadata.py.new \
+		$(srcdir)/Python/bytecodes.c
+	$(UPDATE_FILE) $(srcdir)/Python/generated_cases.c.h $(srcdir)/Python/generated_cases.c.h.new
+	$(UPDATE_FILE) $(srcdir)/Python/opcode_metadata.h $(srcdir)/Python/opcode_metadata.h.new
+	$(UPDATE_FILE) $(srcdir)/Python/executor_cases.c.h $(srcdir)/Python/executor_cases.c.h.new
+	$(UPDATE_FILE) $(srcdir)/Lib/_opcode_metadata.py $(srcdir)/Lib/_opcode_metadata.py.new
 
 Python/compile.o: $(srcdir)/Python/opcode_metadata.h
 


### PR DESCRIPTION
When running 'make regen-cases' just to check whether anything changed, it's annoying that even if nothing changes, the output files are touched, causing an expensiv rebuild of _bootstrap_python and anything it creates.

So use  consistently for all output files.

(No issue, I don't think anyone else cares. Maybe @iritkatriel.)