### PR TITLE
gh-105376: Remove logging.warn() and LoggerAdapter.warn()

### DIFF
--- a/Doc/library/logging.rst
+++ b/Doc/library/logging.rst
@@ -1015,6 +1015,10 @@ interchangeably.
    Attribute :attr:`manager` and method :meth:`_log` were added, which
    delegate to the underlying logger and allow adapters to be nested.
 
+.. versionchanged:: 3.13
+   Remove the undocumented ``warn()`` method which was an alias to the
+   ``warning()`` method.
+
 
 Thread Safety
 -------------
@@ -1161,6 +1165,10 @@ functions.
    .. note:: There is an obsolete function ``warn`` which is functionally
       identical to ``warning``. As ``warn`` is deprecated, please do not use
       it - use ``warning`` instead.
+
+   .. versionchanged:: 3.13
+      Remove the undocumented ``warn()`` function which was an alias to the
+      :func:`warning` function.
 
 
 .. function:: error(msg, *args, **kwargs)

--- a/Doc/whatsnew/3.13.rst
+++ b/Doc/whatsnew/3.13.rst
@@ -348,10 +348,11 @@ Removed
   use ``locale.setlocale(locale.LC_ALL, "")`` instead.
   (Contributed by Victor Stinner in :gh:`104783`.)
 
-* Remove the undocumented and untested ``logging.Logger.warn()`` method,
-  deprecated since Python 3.3, which was an alias to the
-  :meth:`logging.Logger.warning` method: use the :meth:`logging.Logger.warning`
-  method instead.
+* :mod:`logging`: Remove undocumented and untested ``Logger.warn()`` and
+  ``LoggerAdapter.warn()`` methods and ``logging.warn()`` function. Deprecated
+  since Python 3.3, they were aliases to the :meth:`logging.Logger.warning`
+  method, :meth:`logging.LoggerAdapter.warning` method and
+  :func:`logging.warning` function.
   (Contributed by Victor Stinner in :gh:`105376`.)
 
 * Remove *cafile*, *capath* and *cadefault* parameters of the

--- a/Doc/whatsnew/3.13.rst
+++ b/Doc/whatsnew/3.13.rst
@@ -351,7 +351,7 @@ Removed
 * :mod:`logging`: Remove undocumented and untested ``Logger.warn()`` and
   ``LoggerAdapter.warn()`` methods and ``logging.warn()`` function. Deprecated
   since Python 3.3, they were aliases to the :meth:`logging.Logger.warning`
-  method, :meth:`logging.LoggerAdapter.warning` method and
+  method, :meth:`!logging.LoggerAdapter.warning` method and
   :func:`logging.warning` function.
   (Contributed by Victor Stinner in :gh:`105376`.)
 

--- a/Lib/logging/__init__.py
+++ b/Lib/logging/__init__.py
@@ -37,7 +37,7 @@ __all__ = ['BASIC_FORMAT', 'BufferingFormatter', 'CRITICAL', 'DEBUG', 'ERROR',
            'captureWarnings', 'critical', 'debug', 'disable', 'error',
            'exception', 'fatal', 'getLevelName', 'getLogger', 'getLoggerClass',
            'info', 'log', 'makeLogRecord', 'setLoggerClass', 'shutdown',
-           'warn', 'warning', 'getLogRecordFactory', 'setLogRecordFactory',
+           'warning', 'getLogRecordFactory', 'setLogRecordFactory',
            'lastResort', 'raiseExceptions', 'getLevelNamesMapping',
            'getHandlerByName', 'getHandlerNames']
 
@@ -1928,11 +1928,6 @@ class LoggerAdapter(object):
         """
         self.log(WARNING, msg, *args, **kwargs)
 
-    def warn(self, msg, *args, **kwargs):
-        warnings.warn("The 'warn' method is deprecated, "
-            "use 'warning' instead", DeprecationWarning, 2)
-        self.warning(msg, *args, **kwargs)
-
     def error(self, msg, *args, **kwargs):
         """
         Delegate an error call to the underlying logger.
@@ -2205,11 +2200,6 @@ def warning(msg, *args, **kwargs):
     if len(root.handlers) == 0:
         basicConfig()
     root.warning(msg, *args, **kwargs)
-
-def warn(msg, *args, **kwargs):
-    warnings.warn("The 'warn' function is deprecated, "
-        "use 'warning' instead", DeprecationWarning, 2)
-    warning(msg, *args, **kwargs)
 
 def info(msg, *args, **kwargs):
     """

--- a/Misc/NEWS.d/next/Library/2023-06-06-15-32-44.gh-issue-105376.W4oDQp.rst
+++ b/Misc/NEWS.d/next/Library/2023-06-06-15-32-44.gh-issue-105376.W4oDQp.rst
@@ -1,5 +1,5 @@
 :mod:`logging`: Remove undocumented and untested ``Logger.warn()`` and
 ``LoggerAdapter.warn()`` methods and ``logging.warn()`` function. Deprecated
 since Python 3.3, they were aliases to the :meth:`logging.Logger.warning`
-method, :meth:`logging.LoggerAdapter.warning` method and
+method, :meth:`!logging.LoggerAdapter.warning` method and
 :func:`logging.warning` function. Patch by Victor Stinner.

--- a/Misc/NEWS.d/next/Library/2023-06-06-15-32-44.gh-issue-105376.W4oDQp.rst
+++ b/Misc/NEWS.d/next/Library/2023-06-06-15-32-44.gh-issue-105376.W4oDQp.rst
@@ -1,4 +1,5 @@
-Remove the undocumented and untested ``logging.Logger.warn()`` method,
-deprecated since Python 3.3, which was an alias to the
-:meth:`logging.Logger.warning` method: use the :meth:`logging.Logger.warning`
-method instead. Patch by Victor Stinner.
+:mod:`logging`: Remove undocumented and untested ``Logger.warn()`` and
+``LoggerAdapter.warn()`` methods and ``logging.warn()`` function. Deprecated
+since Python 3.3, they were aliases to the :meth:`logging.Logger.warning`
+method, :meth:`logging.LoggerAdapter.warning` method and
+:func:`logging.warning` function. Patch by Victor Stinner.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-105376 -->
* Issue: gh-105376
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--106553.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->