### PR TITLE
gh-105927: PyWeakref_GetRef() returns 1 on success

### DIFF
--- a/Doc/c-api/weakref.rst
+++ b/Doc/c-api/weakref.rst
@@ -55,9 +55,11 @@ as much as it can.
 
    Get a :term:`strong reference` to the referenced object from a weak
    reference, *ref*, into *\*pobj*.
-   Return 0 on success. Raise an exception and return -1 on error.
 
-   If the referent is no longer live, set *\*pobj* to ``NULL`` and return 0.
+   * On success, set *\*pobj* to a new :term:`strong reference` to the
+     referenced object and return 1.
+   * If the reference is dead, set *\*pobj* to ``NULL`` and return 0.
+   * On error, raise an exception and return -1.
 
    .. versionadded:: 3.13
 

--- a/Modules/_testcapimodule.c
+++ b/Modules/_testcapimodule.c
@@ -3376,7 +3376,7 @@ test_weakref_capi(PyObject *Py_UNUSED(module), PyObject *Py_UNUSED(args))
 
     // test PyWeakref_GetRef(), reference is alive
     PyObject *ref = Py_True;  // marker to check that value was set
-    assert(PyWeakref_GetRef(weakref, &ref) == 0);
+    assert(PyWeakref_GetRef(weakref, &ref) == 1);
     assert(ref == obj);
     assert(Py_REFCNT(obj) == (refcnt + 1));
     Py_DECREF(ref);

--- a/Objects/weakrefobject.c
+++ b/Objects/weakrefobject.c
@@ -913,11 +913,7 @@ PyWeakref_GetRef(PyObject *ref, PyObject **pobj)
         return -1;
     }
     *pobj = _PyWeakref_GET_REF(ref);
-    if (*pobj == NULL) {
-        // The reference is dead
-        return 0;
-    }
-    return 1;
+    return (*pobj != NULL);
 }
 
 

--- a/Objects/weakrefobject.c
+++ b/Objects/weakrefobject.c
@@ -913,7 +913,11 @@ PyWeakref_GetRef(PyObject *ref, PyObject **pobj)
         return -1;
     }
     *pobj = _PyWeakref_GET_REF(ref);
-    return 0;
+    if (*pobj == NULL) {
+        // The reference is dead
+        return 0;
+    }
+    return 1;
 }
 
 


### PR DESCRIPTION
PyWeakref_GetRef() now returns 1 on success, and return 0 if the reference is dead.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-105927 -->
* Issue: gh-105927
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--106561.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->