### PR TITLE
[3.11] gh-106303: Use _PyObject_LookupAttr() instead of PyObject_GetAttr() (GH-106304)

### DIFF
--- a/Include/internal/pycore_global_strings.h
+++ b/Include/internal/pycore_global_strings.h
@@ -142,6 +142,7 @@ struct _Py_global_strings {
         STRUCT_FOR_ID(__lshift__)
         STRUCT_FOR_ID(__lt__)
         STRUCT_FOR_ID(__main__)
+        STRUCT_FOR_ID(__match_args__)
         STRUCT_FOR_ID(__matmul__)
         STRUCT_FOR_ID(__missing__)
         STRUCT_FOR_ID(__mod__)

--- a/Include/internal/pycore_runtime_init.h
+++ b/Include/internal/pycore_runtime_init.h
@@ -765,6 +765,7 @@ extern "C" {
                 INIT_ID(__lshift__), \
                 INIT_ID(__lt__), \
                 INIT_ID(__main__), \
+                INIT_ID(__match_args__), \
                 INIT_ID(__matmul__), \
                 INIT_ID(__missing__), \
                 INIT_ID(__mod__), \

--- a/Objects/funcobject.c
+++ b/Objects/funcobject.c
@@ -801,17 +801,12 @@ PyTypeObject PyFunction_Type = {
 static int
 functools_copy_attr(PyObject *wrapper, PyObject *wrapped, PyObject *name)
 {
-    PyObject *value = PyObject_GetAttr(wrapped, name);
-    if (value == NULL) {
-        if (PyErr_ExceptionMatches(PyExc_AttributeError)) {
-            PyErr_Clear();
-            return 0;
-        }
-        return -1;
+    PyObject *value;
+    int res = _PyObject_LookupAttr(wrapped, name, &value);
+    if (value != NULL) {
+        res = PyObject_SetAttr(wrapper, name, value);
+        Py_DECREF(value);
     }
-
-    int res = PyObject_SetAttr(wrapper, name, value);
-    Py_DECREF(value);
     return res;
 }
 

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -1001,10 +1001,8 @@ match_class_attr(PyThreadState *tstate, PyObject *subject, PyObject *type,
         }
         return NULL;
     }
-    PyObject *attr = PyObject_GetAttr(subject, name);
-    if (attr == NULL && _PyErr_ExceptionMatches(tstate, PyExc_AttributeError)) {
-        _PyErr_Clear(tstate);
-    }
+    PyObject *attr;
+    (void)_PyObject_LookupAttr(subject, name, &attr);
     return attr;
 }
 
@@ -1039,7 +1037,9 @@ match_class(PyThreadState *tstate, PyObject *subject, PyObject *type,
     // First, the positional subpatterns:
     if (nargs) {
         int match_self = 0;
-        match_args = PyObject_GetAttrString(type, "__match_args__");
+        if (_PyObject_LookupAttr(type, &_Py_ID(__match_args__), &match_args) < 0) {
+            goto fail;
+        }
         if (match_args) {
             if (!PyTuple_CheckExact(match_args)) {
                 const char *e = "%s.__match_args__ must be a tuple (got %s)";
@@ -1049,8 +1049,7 @@ match_class(PyThreadState *tstate, PyObject *subject, PyObject *type,
                 goto fail;
             }
         }
-        else if (_PyErr_ExceptionMatches(tstate, PyExc_AttributeError)) {
-            _PyErr_Clear(tstate);
+        else {
             // _Py_TPFLAGS_MATCH_SELF is only acknowledged if the type does not
             // define __match_args__. This is natural behavior for subclasses:
             // it's as if __match_args__ is some "magic" value that is lost as
@@ -1058,9 +1057,6 @@ match_class(PyThreadState *tstate, PyObject *subject, PyObject *type,
             match_args = PyTuple_New(0);
             match_self = PyType_HasFeature((PyTypeObject*)type,
                                             _Py_TPFLAGS_MATCH_SELF);
-        }
-        else {
-            goto fail;
         }
         assert(PyTuple_CheckExact(match_args));
         Py_ssize_t allowed = match_self ? 1 : PyTuple_GET_SIZE(match_args);


### PR DESCRIPTION
It simplifies and speed up the code.
(cherry picked from commit 93d292c2b3f8e85ef562c37f59678c639b9b8fcb)


<!-- gh-issue-number: gh-106303 -->
* Issue: gh-106303
<!-- /gh-issue-number -->
