### PR TITLE
gh-104635: Expand optimization for dead store elimination

### DIFF
--- a/Lib/test/test_dis.py
+++ b/Lib/test/test_dis.py
@@ -1029,28 +1029,31 @@ class DisTests(DisTestBase):
             s = ['''\
   1        %*d RESUME                   0
 
+''' % (w, 0)]
+            s += ['''\
   2        %*d LOAD_FAST                0 (x)
            %*d LOAD_CONST               1 (1)
            %*d BINARY_OP                0 (+)
-''' % (w, 0, w, 2, w, 4, w, 6)]
+''' % (w, 2, w, 4, w, 6)]
             s += ['''\
-           %*d STORE_FAST_LOAD_FAST     0 (x, x)
+           %*d POP_TOP
+           %*d LOAD_FAST                0 (x)
            %*d LOAD_CONST               1 (1)
            %*d BINARY_OP                0 (+)
-''' % (w, 8*i + 10, w, 8*i + 12, w, 8*i + 14)
-                 for i in range(count-1)]
+''' % (w, 10*i + 10, w, 10*i + 12, w, 10*i + 14, w, 10*i + 16)
+                  for i in range(count-1)]
             s += ['''\
            %*d STORE_FAST               0 (x)
 
   3        %*d LOAD_FAST                0 (x)
            %*d RETURN_VALUE
-''' % (w, 8*count + 2, w, 8*count + 4, w, 8*count + 6)]
+''' % (w, 10*count, w, 10*count + 2, w, 10*count + 4)]
             return ''.join(s)
 
         for i in range(1, 5):
             self.do_disassembly_test(func(i), expected(i, 4), True)
-        self.do_disassembly_test(func(1200), expected(1200, 4), True)
-        self.do_disassembly_test(func(1300), expected(1300, 5), True)
+        self.do_disassembly_test(func(999), expected(999, 4), True)
+        self.do_disassembly_test(func(1000), expected(1000, 5), True)
 
     def test_disassemble_str(self):
         self.do_disassembly_test(expr_str, dis_expr_str)

--- a/Lib/test/test_peepholer.py
+++ b/Lib/test/test_peepholer.py
@@ -1104,6 +1104,25 @@ class DirectCfgOptimizerTests(CfgOptimizationTestCase):
         ]
         self.cfg_optimization_test(insts, expected_insts, consts=list(range(3)), nlocals=1)
 
+    def test_dead_store_elimination_in_same_lineno_wider(self):
+        insts = [
+            ('LOAD_CONST', 0, 1),
+            ('LOAD_CONST', 1, 2),
+            ('LOAD_CONST', 2, 3),
+            ('STORE_FAST', 1, 4),
+            ('STORE_FAST', 0, 4),
+            ('STORE_FAST', 1, 4),
+            ('RETURN_VALUE', 5)
+        ]
+        expected_insts = [
+            ('LOAD_CONST', 0, 1),
+            ('LOAD_CONST', 1, 2),
+            ('NOP', 0, 3),
+            ('STORE_FAST_STORE_FAST', 1, 4),
+            ('RETURN_VALUE', 5)
+        ]
+        self.cfg_optimization_test(insts, expected_insts, consts=list(range(3)), nlocals=1)
+
     def test_no_dead_store_elimination_in_different_lineno(self):
         insts = [
             ('LOAD_CONST', 0, 1),

--- a/Python/flowgraph.c
+++ b/Python/flowgraph.c
@@ -1324,7 +1324,7 @@ optimize_basic_block(PyObject *const_cache, basicblock *bb, PyObject *consts)
                 last_store_fast_lino = inst->i_loc.lineno;
                 last_i_oparg = inst->i_oparg;
             }
-            else if (inst->i_loc.lineno == last_store_fast_lino) {
+            else if (last_store_fast_lino == inst->i_loc.lineno) {
                 if (last_i_oparg == inst->i_oparg) {
                     inst->i_opcode = POP_TOP;
                     inst->i_oparg = 0;

--- a/Python/flowgraph.c
+++ b/Python/flowgraph.c
@@ -1312,6 +1312,7 @@ remove_redundant_deadstore(basicblock *bb)
             for (int j = i - 1; j >= 0; j--) {
                 cfg_instr *prev = &bb->b_instr[j];
                 if (prev->i_loc.lineno != inst->i_loc.lineno) {
+                    // Invariant condition: lineno is always monotonically increasing.
                     break;
                 }
                 if (prev->i_opcode == STORE_FAST && prev->i_oparg == inst->i_oparg) {

--- a/Python/flowgraph.c
+++ b/Python/flowgraph.c
@@ -1326,7 +1326,7 @@ optimize_basic_block(PyObject *const_cache, basicblock *bb, PyObject *consts)
             }
             else if (inst->i_loc.lineno == last_store_fast_lino) {
                 if (last_i_oparg == inst->i_oparg) {
-                    bb->b_instr[i].i_opcode = POP_TOP;
+                    inst->i_opcode = POP_TOP;
                 }
             }
             else {

--- a/Python/flowgraph.c
+++ b/Python/flowgraph.c
@@ -1327,6 +1327,7 @@ optimize_basic_block(PyObject *const_cache, basicblock *bb, PyObject *consts)
             else if (inst->i_loc.lineno == last_store_fast_lino) {
                 if (last_i_oparg == inst->i_oparg) {
                     inst->i_opcode = POP_TOP;
+                    inst->i_oparg = 0;
                 }
             }
             else {

--- a/Python/flowgraph.c
+++ b/Python/flowgraph.c
@@ -1308,6 +1308,9 @@ remove_redundant_deadstore(basicblock *bb)
 {
     for (int i = bb->b_iused - 1; i >= 0; i--) {
         cfg_instr *inst = &bb->b_instr[i];
+        // Optimize only if the opcode is STORE_FAST and the lineno is same.
+        // The number of STORE_FAST will be decreased if the optimization is success.
+        // So most of case could be skipped.
         if (inst->i_opcode == STORE_FAST) {
             for (int j = i - 1; j >= 0; j--) {
                 cfg_instr *prev = &bb->b_instr[j];


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

## Explain

> We might also want to expand this so it can look more than one instruction ahead for another write to the same location, skipping over an allowlist of instructions that we know don't read that same local, don't execute arbitrary code, and can't raise an exception. E.g. LOAD_FAST of a different local, POP_TOP, NOP, probably others.

This PR is motivated by @carljm 's comment from https://github.com/python/cpython/pull/105040#issuecomment-1570770763
The limitation of https://github.com/python/cpython/pull/105320 is that the optimization only covers the next redundant opcode, but with this patch, the optimization can be applied to more than one instruction ahead for another write to the same location.

## Benchmark

````python

import pyperf

runner = pyperf.Runner()
runner.timeit(name="bench dead_store",
              stmt="""
_, a, b, c, _ = 1, 2, 3, 4, 5
""")

````
````
Mean +- std dev: [base] 13.1 ns +- 0.2 ns -> [opt] 12.6 ns +- 0.2 ns: 1.04x faster
````

## TODO (Done)
- [x] Fix test_dis.py
- [x] Add testcase for this optimization.


<!-- gh-issue-number: gh-104635 -->
* Issue: gh-104635
<!-- /gh-issue-number -->
