### PR TITLE
GH-61215: threadingmock: Remove unused branch for `timeout`

### DIFF
--- a/Lib/unittest/mock.py
+++ b/Lib/unittest/mock.py
@@ -3012,9 +3012,7 @@ class ThreadingMixin(Base):
     DEFAULT_TIMEOUT = None
 
     def _get_child_mock(self, /, **kw):
-        if "timeout" in kw:
-            kw["timeout"] = kw.pop("timeout")
-        elif isinstance(kw.get("parent"), ThreadingMixin):
+        if isinstance(kw.get("parent"), ThreadingMixin):
             kw["timeout"] = kw["parent"]._mock_wait_timeout
         elif isinstance(kw.get("_new_parent"), ThreadingMixin):
             kw["timeout"] = kw["_new_parent"]._mock_wait_timeout


### PR DESCRIPTION
Issue: https://github.com/python/cpython/issues/61215

<!-- gh-issue-number: gh-61215 -->
* Issue: gh-61215
<!-- /gh-issue-number -->
