### PR TITLE
[3.11] gh-103186: Fix or catch 'extra' stderr output from unittests (#103196)

### DIFF
--- a/Lib/test/test_cmd_line_script.py
+++ b/Lib/test/test_cmd_line_script.py
@@ -777,7 +777,7 @@ class CmdLineTest(unittest.TestCase):
         with os_helper.temp_dir() as work_dir:
             script_name = _make_test_script(work_dir, 'script.py', script)
             with open(script_name, "r") as fp:
-                p = spawn_python(f"/dev/fd/{fp.fileno()}", close_fds=False, pass_fds=(0,1,2,fp.fileno()))
+                p = spawn_python(f"/dev/fd/{fp.fileno()}", close_fds=True, pass_fds=(0,1,2,fp.fileno()))
                 out, err = p.communicate()
                 self.assertEqual(out, b"12345678912345678912345\n")
 

--- a/Lib/test/test_warnings/__init__.py
+++ b/Lib/test/test_warnings/__init__.py
@@ -388,9 +388,13 @@ class FilterTests(BaseTest):
             with self.module.catch_warnings(
                 module=self.module, action="error", category=FutureWarning
             ):
-                self.module.warn("Other types of warnings are not errors")
-                self.assertRaises(FutureWarning,
-                                  self.module.warn, FutureWarning("msg"))
+                with support.captured_stderr() as stderr:
+                    error_msg = "Other types of warnings are not errors"
+                    self.module.warn(error_msg)
+                    self.assertRaises(FutureWarning,
+                                      self.module.warn, FutureWarning("msg"))
+                    stderr = stderr.getvalue()
+                    self.assertIn(error_msg, stderr)
 
 class CFilterTests(FilterTests, unittest.TestCase):
     module = c_warnings


### PR DESCRIPTION


Reduce test noise by fixing or catching and testing stderr messages from individual tests.

test_cmd_line_script.test_script_as_dev_fd calls spawn_python and hence subprocess.Popen with incompatible arguments. On POSIX, pass_fds forces close_fds to be True (subprocess.py line 848). Correct the call.

test_uuid.test_cli_namespace_required_for_uuid3: when the namespace is omitted, uuid.main calls argparse.Argument_Parser.error, which prints to stderr before calling sys.exit, which raises SystemExit. Unittest assertRaises catches the exception but not the previous output. Catch the output and test it.

test_warnings.test_catchwarnings_with_simplefilter_error similarly prints before raising. Catch the output and test it. ---------

Co-authored-by: Oleg Iarygin <oleg@arhadthedev.net>
(cherry picked from commit 9d582250d8fde240b8e7299b74ba888c574f74a3)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-103186 -->
* Issue: gh-103186
<!-- /gh-issue-number -->
