### PR TITLE
fix(editorconfig): do not use inline comment

### DIFF
--- a/Tools/wasm/.editorconfig
+++ b/Tools/wasm/.editorconfig
@@ -1,4 +1,5 @@
-root = false  # This extends the root .editorconfig
+# This extends the root .editorconfig
+root = false
 
 [*.{html,js}]
 trim_trailing_whitespace = true


### PR DESCRIPTION
This change is quite trivial, but inline comments are no longer valid since EditorConfig version 0.15.0. See

- <https://spec.editorconfig.org/#no-inline-comments>
- <https://github.com/editorconfig/specification/blob/v0.15/index.rst#no-inline-comments> (source)

Alternatively, the comment can be removed since the meaning is quite obvious.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
