### PR TITLE
gh-106529: Silence compiler warning in jump target patching

### DIFF
--- a/Python/optimizer.c
+++ b/Python/optimizer.c
@@ -548,8 +548,8 @@ done:
                 if (trace[i].opcode == _POP_JUMP_IF_FALSE ||
                     trace[i].opcode == _POP_JUMP_IF_TRUE)
                 {
-                    int target = trace[i].operand;
-                    if (target >= max_length) {
+                    uint64_t target = trace[i].operand;
+                    if (target >= (uint64_t)max_length) {
                         target += trace_length - max_length;
                         trace[i].operand = target;
                     }


### PR DESCRIPTION
Sadly, gh-106551 caused a compiler warning about on Windows. This hopefully fixes that without introducing new warnings on other platforms.

<!-- gh-issue-number: gh-106529 -->
* Issue: gh-106529
<!-- /gh-issue-number -->
