### PR TITLE
Remove unused branches from mock module

### DIFF
--- a/Lib/test/test_unittest/testmock/testthreadingmock.py
+++ b/Lib/test/test_unittest/testmock/testthreadingmock.py
@@ -11,10 +11,10 @@ threading_helper.requires_working_threading(module=True)
 
 class Something:
     def method_1(self):
-        pass
+        pass  # pragma: no cover
 
     def method_2(self):
-        pass
+        pass  # pragma: no cover
 
 
 class TestThreadingMock(unittest.TestCase):

--- a/Lib/unittest/mock.py
+++ b/Lib/unittest/mock.py
@@ -221,8 +221,6 @@ def _set_async_signature(mock, original, instance=False, is_async_mock=False):
     _copy_func_details(func, checksig)
 
     name = original.__name__
-    if not name.isidentifier():
-        name = 'funcopy'
     context = {'_checksig_': checksig, 'mock': mock}
     src = """async def %s(*args, **kwargs):
     _checksig_(*args, **kwargs)

--- a/Lib/unittest/mock.py
+++ b/Lib/unittest/mock.py
@@ -212,10 +212,7 @@ def _set_async_signature(mock, original, instance=False, is_async_mock=False):
     # signature as the original.
 
     skipfirst = isinstance(original, type)
-    result = _get_signature_object(original, instance, skipfirst)
-    if result is None:
-        return mock
-    func, sig = result
+    func, sig = _get_signature_object(original, instance, skipfirst)
     def checksig(*args, **kwargs):
         sig.bind(*args, **kwargs)
     _copy_func_details(func, checksig)


### PR DESCRIPTION
Also exclude a couple of methods from coverage checking in the downstream rolling backport of mock