### PR TITLE
gh-106625 : Add missing code to tutorial 4.6 example

### DIFF
--- a/Doc/tutorial/controlflow.rst
+++ b/Doc/tutorial/controlflow.rst
@@ -306,6 +306,9 @@ If you are using classes to structure your data
 you can use the class name followed by an argument list resembling a
 constructor, but with the ability to capture attributes into variables::
 
+    from dataclasses import dataclass
+    @dataclass
+
     class Point:
         x: int
         y: int

--- a/Doc/tutorial/controlflow.rst
+++ b/Doc/tutorial/controlflow.rst
@@ -306,12 +306,10 @@ If you are using classes to structure your data
 you can use the class name followed by an argument list resembling a
 constructor, but with the ability to capture attributes into variables::
 
-    from dataclasses import dataclass
-
-    @dataclass
     class Point:
-        x: int
-        y: int
+        def __init__(self, x, y):
+            self.x = x
+            self.y = y
 
     def where_is(point):
         match point:

--- a/Doc/tutorial/controlflow.rst
+++ b/Doc/tutorial/controlflow.rst
@@ -307,7 +307,7 @@ you can use the class name followed by an argument list resembling a
 constructor, but with the ability to capture attributes into variables::
 
     from dataclasses import dataclass
-    
+
     @dataclass
     class Point:
         x: int

--- a/Doc/tutorial/controlflow.rst
+++ b/Doc/tutorial/controlflow.rst
@@ -307,6 +307,7 @@ you can use the class name followed by an argument list resembling a
 constructor, but with the ability to capture attributes into variables::
 
     from dataclasses import dataclass
+    
     @dataclass
     class Point:
         x: int

--- a/Doc/tutorial/controlflow.rst
+++ b/Doc/tutorial/controlflow.rst
@@ -308,7 +308,6 @@ constructor, but with the ability to capture attributes into variables::
 
     from dataclasses import dataclass
     @dataclass
-
     class Point:
         x: int
         y: int


### PR DESCRIPTION
This is a pull request for the [sample code in section 4.6](https://docs.python.org/ja/3/tutorial/controlflow.html#match-statements).

I ran the following based on the sample code and got an error.

The sample code in the tutorial may be an excerpt of some code.
However, given that we will try "Point(1, var)" immediately following, I believe the user will easily understand that there is a necessary dataclass import statement.



Executed code : 

```
class Point:
    x: int
    y: int

def where_is(point):
    match point:
        case Point(x=0, y=0):
            print("Origin")
        case Point(x=0, y=y):
            print(f"Y={y}")
        case Point(x=x, y=0):
            print(f"X={x}")
        case Point():
            print("Somewhere else")
        case _:
            print("Not a point")

## Added code
p = Point(1, 1)
```

Errors that occurred :

```
    p = Point(1, 1)
        ^^^^^^^^^^^
TypeError: Point() takes no arguments
```

<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--106623.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->

<!-- gh-issue-number: gh-106625 -->
* Issue: gh-106625
<!-- /gh-issue-number -->
