### PR TITLE
gh-106498: Revert incorrect colorsys.rgb_to_hls change

### DIFF
--- a/Lib/colorsys.py
+++ b/Lib/colorsys.py
@@ -83,7 +83,7 @@ def rgb_to_hls(r, g, b):
     if l <= 0.5:
         s = rangec / sumc
     else:
-        s = rangec / (2.0-sumc)
+        s = rangec / (2.0-maxc-minc)  # Not always 2.0-sumc: gh-106498.
     rc = (maxc-r) / rangec
     gc = (maxc-g) / rangec
     bc = (maxc-b) / rangec

--- a/Lib/test/test_colorsys.py
+++ b/Lib/test/test_colorsys.py
@@ -69,6 +69,16 @@ class ColorsysTest(unittest.TestCase):
             self.assertTripleEqual(hls, colorsys.rgb_to_hls(*rgb))
             self.assertTripleEqual(rgb, colorsys.hls_to_rgb(*hls))
 
+    def test_hls_nearwhite(self):  # gh-106498
+        values = (
+            # rgb, hls: these do not work in reverse
+            ((0.9999999999999999, 1, 1), (0.5, 1.0, 1.0)),
+            ((1, 0.9999999999999999, 0.9999999999999999), (0.0, 1.0, 1.0)),
+        )
+        for rgb, hls in values:
+            self.assertTripleEqual(hls, colorsys.rgb_to_hls(*rgb))
+            self.assertTripleEqual((1.0, 1.0, 1.0), colorsys.hls_to_rgb(*hls))
+
     def test_yiq_roundtrip(self):
         for r in frange(0.0, 1.0, 0.2):
             for g in frange(0.0, 1.0, 0.2):

--- a/Misc/NEWS.d/next/Library/2023-07-11-09-25-40.gh-issue-106530.VgXrMx.rst
+++ b/Misc/NEWS.d/next/Library/2023-07-11-09-25-40.gh-issue-106530.VgXrMx.rst
@@ -1,0 +1,2 @@
+Revert a change to :func:`colorsys.rgb_to_hls` that caused division by zero
+for certain almost-white inputs.  Patch by Terry Jan Reedy.


### PR DESCRIPTION
gh-86618 assumed a-b-c = a-(b+c) = a-d where d = b+d. For floats 2.0, 1.0, and 0.9999999999999999, this assumption is false.  The net change of 1.1102230246251565e-16 to 0.0 results in division by 0.  Revert the replacement.  Add test.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-106498 -->
* Issue: gh-106498
<!-- /gh-issue-number -->
