### PR TITLE
gh-106521: Remove _PyObject_LookupAttr() function

### DIFF
--- a/Include/cpython/object.h
+++ b/Include/cpython/object.h
@@ -294,7 +294,6 @@ PyAPI_FUNC(int) _PyObject_IsFreed(PyObject *);
 PyAPI_FUNC(int) _PyObject_IsAbstract(PyObject *);
 PyAPI_FUNC(PyObject *) _PyObject_GetAttrId(PyObject *, _Py_Identifier *);
 PyAPI_FUNC(int) _PyObject_SetAttrId(PyObject *, _Py_Identifier *, PyObject *);
-#define _PyObject_LookupAttr PyObject_GetOptionalAttr
 
 PyAPI_FUNC(int) _PyObject_GetMethod(PyObject *obj, PyObject *name, PyObject **method);
 

--- a/Modules/_abc.c
+++ b/Modules/_abc.c
@@ -361,7 +361,7 @@ compute_abstract_methods(PyObject *self)
         PyObject *item = PyTuple_GET_ITEM(bases, pos);  // borrowed
         PyObject *base_abstracts, *iter;
 
-        if (_PyObject_LookupAttr(item, &_Py_ID(__abstractmethods__),
+        if (PyObject_GetOptionalAttr(item, &_Py_ID(__abstractmethods__),
                                  &base_abstracts) < 0) {
             goto error;
         }
@@ -375,7 +375,7 @@ compute_abstract_methods(PyObject *self)
         Py_DECREF(base_abstracts);
         PyObject *key, *value;
         while ((key = PyIter_Next(iter))) {
-            if (_PyObject_LookupAttr(self, key, &value) < 0) {
+            if (PyObject_GetOptionalAttr(self, key, &value) < 0) {
                 Py_DECREF(key);
                 Py_DECREF(iter);
                 goto error;

--- a/Modules/_asynciomodule.c
+++ b/Modules/_asynciomodule.c
@@ -248,7 +248,7 @@ get_future_loop(asyncio_state *state, PyObject *fut)
         return Py_NewRef(loop);
     }
 
-    if (_PyObject_LookupAttr(fut, &_Py_ID(get_loop), &getloop) < 0) {
+    if (PyObject_GetOptionalAttr(fut, &_Py_ID(get_loop), &getloop) < 0) {
         return NULL;
     }
     if (getloop != NULL) {
@@ -2966,7 +2966,7 @@ task_step_handle_result_impl(asyncio_state *state, TaskObj *task, PyObject *resu
     }
 
     /* Check if `result` is a Future-compatible object */
-    if (_PyObject_LookupAttr(result, &_Py_ID(_asyncio_future_blocking), &o) < 0) {
+    if (PyObject_GetOptionalAttr(result, &_Py_ID(_asyncio_future_blocking), &o) < 0) {
         goto fail;
     }
     if (o != NULL && o != Py_None) {

--- a/Modules/_csv.c
+++ b/Modules/_csv.c
@@ -1450,7 +1450,7 @@ csv_writer(PyObject *module, PyObject *args, PyObject *keyword_args)
         Py_DECREF(self);
         return NULL;
     }
-    if (_PyObject_LookupAttr(output_file,
+    if (PyObject_GetOptionalAttr(output_file,
                              module_state->str_write,
                              &self->write) < 0) {
         Py_DECREF(self);

--- a/Modules/_ctypes/_ctypes.c
+++ b/Modules/_ctypes/_ctypes.c
@@ -851,7 +851,7 @@ CDataType_from_param(PyObject *type, PyObject *value)
         return NULL;
     }
 
-    if (_PyObject_LookupAttr(value, &_Py_ID(_as_parameter_), &as_parameter) < 0) {
+    if (PyObject_GetOptionalAttr(value, &_Py_ID(_as_parameter_), &as_parameter) < 0) {
         return NULL;
     }
     if (as_parameter) {
@@ -1495,7 +1495,7 @@ PyCArrayType_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
     stgdict = NULL;
     type_attr = NULL;
 
-    if (_PyObject_LookupAttr((PyObject *)result, &_Py_ID(_length_), &length_attr) < 0) {
+    if (PyObject_GetOptionalAttr((PyObject *)result, &_Py_ID(_length_), &length_attr) < 0) {
         goto error;
     }
     if (!length_attr) {
@@ -1528,7 +1528,7 @@ PyCArrayType_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
         goto error;
     }
 
-    if (_PyObject_LookupAttr((PyObject *)result, &_Py_ID(_type_), &type_attr) < 0) {
+    if (PyObject_GetOptionalAttr((PyObject *)result, &_Py_ID(_type_), &type_attr) < 0) {
         goto error;
     }
     if (!type_attr) {
@@ -1720,7 +1720,7 @@ c_wchar_p_from_param(PyObject *type, PyObject *value)
         }
     }
 
-    if (_PyObject_LookupAttr(value, &_Py_ID(_as_parameter_), &as_parameter) < 0) {
+    if (PyObject_GetOptionalAttr(value, &_Py_ID(_as_parameter_), &as_parameter) < 0) {
         return NULL;
     }
     if (as_parameter) {
@@ -1784,7 +1784,7 @@ c_char_p_from_param(PyObject *type, PyObject *value)
         }
     }
 
-    if (_PyObject_LookupAttr(value, &_Py_ID(_as_parameter_), &as_parameter) < 0) {
+    if (PyObject_GetOptionalAttr(value, &_Py_ID(_as_parameter_), &as_parameter) < 0) {
         return NULL;
     }
     if (as_parameter) {
@@ -1919,7 +1919,7 @@ c_void_p_from_param(PyObject *type, PyObject *value)
         }
     }
 
-    if (_PyObject_LookupAttr(value, &_Py_ID(_as_parameter_), &as_parameter) < 0) {
+    if (PyObject_GetOptionalAttr(value, &_Py_ID(_as_parameter_), &as_parameter) < 0) {
         return NULL;
     }
     if (as_parameter) {
@@ -2054,7 +2054,7 @@ PyCSimpleType_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
     if (result == NULL)
         return NULL;
 
-    if (_PyObject_LookupAttr((PyObject *)result, &_Py_ID(_type_), &proto) < 0) {
+    if (PyObject_GetOptionalAttr((PyObject *)result, &_Py_ID(_type_), &proto) < 0) {
         return NULL;
     }
     if (!proto) {
@@ -2266,7 +2266,7 @@ PyCSimpleType_from_param(PyObject *type, PyObject *value)
     PyObject *exc = PyErr_GetRaisedException();
     Py_DECREF(parg);
 
-    if (_PyObject_LookupAttr(value, &_Py_ID(_as_parameter_), &as_parameter) < 0) {
+    if (PyObject_GetOptionalAttr(value, &_Py_ID(_as_parameter_), &as_parameter) < 0) {
         Py_XDECREF(exc);
         return NULL;
     }
@@ -2429,7 +2429,7 @@ converters_from_argtypes(PyObject *ob)
         }
  */
 
-        if (_PyObject_LookupAttr(tp, &_Py_ID(from_param), &cnv) <= 0) {
+        if (PyObject_GetOptionalAttr(tp, &_Py_ID(from_param), &cnv) <= 0) {
             Py_DECREF(converters);
             Py_DECREF(ob);
             if (!PyErr_Occurred()) {
@@ -2489,7 +2489,7 @@ make_funcptrtype_dict(StgDictObject *stgdict)
             return -1;
         }
         stgdict->restype = Py_NewRef(ob);
-        if (_PyObject_LookupAttr(ob, &_Py_ID(_check_retval_),
+        if (PyObject_GetOptionalAttr(ob, &_Py_ID(_check_retval_),
                                    &stgdict->checker) < 0)
         {
             return -1;
@@ -3275,7 +3275,7 @@ PyCFuncPtr_set_restype(PyCFuncPtrObject *self, PyObject *ob, void *Py_UNUSED(ign
                         "restype must be a type, a callable, or None");
         return -1;
     }
-    if (_PyObject_LookupAttr(ob, &_Py_ID(_check_retval_), &checker) < 0) {
+    if (PyObject_GetOptionalAttr(ob, &_Py_ID(_check_retval_), &checker) < 0) {
         return -1;
     }
     oldchecker = self->checker;

--- a/Modules/_ctypes/callproc.c
+++ b/Modules/_ctypes/callproc.c
@@ -727,7 +727,7 @@ static int ConvParam(PyObject *obj, Py_ssize_t index, struct argument *pa)
 
     {
         PyObject *arg;
-        if (_PyObject_LookupAttr(obj, &_Py_ID(_as_parameter_), &arg) < 0) {
+        if (PyObject_GetOptionalAttr(obj, &_Py_ID(_as_parameter_), &arg) < 0) {
             return -1;
         }
         /* Which types should we exactly allow here?

--- a/Modules/_ctypes/stgdict.c
+++ b/Modules/_ctypes/stgdict.c
@@ -295,7 +295,7 @@ MakeAnonFields(PyObject *type)
     PyObject *anon_names;
     Py_ssize_t i;
 
-    if (_PyObject_LookupAttr(type, &_Py_ID(_anonymous_), &anon) < 0) {
+    if (PyObject_GetOptionalAttr(type, &_Py_ID(_anonymous_), &anon) < 0) {
         return -1;
     }
     if (anon == NULL) {
@@ -385,7 +385,7 @@ PyCStructUnionType_update_stgdict(PyObject *type, PyObject *fields, int isStruct
     if (fields == NULL)
         return 0;
 
-    if (_PyObject_LookupAttr(type, &_Py_ID(_swappedbytes_), &tmp) < 0) {
+    if (PyObject_GetOptionalAttr(type, &_Py_ID(_swappedbytes_), &tmp) < 0) {
         return -1;
     }
     if (tmp) {
@@ -396,7 +396,7 @@ PyCStructUnionType_update_stgdict(PyObject *type, PyObject *fields, int isStruct
         big_endian = PY_BIG_ENDIAN;
     }
 
-    if (_PyObject_LookupAttr(type, &_Py_ID(_pack_), &tmp) < 0) {
+    if (PyObject_GetOptionalAttr(type, &_Py_ID(_pack_), &tmp) < 0) {
         return -1;
     }
     if (tmp) {

--- a/Modules/_datetimemodule.c
+++ b/Modules/_datetimemodule.c
@@ -3791,7 +3791,7 @@ tzinfo_reduce(PyObject *self, PyObject *Py_UNUSED(ignored))
     PyObject *args, *state;
     PyObject *getinitargs;
 
-    if (_PyObject_LookupAttr(self, &_Py_ID(__getinitargs__), &getinitargs) < 0) {
+    if (PyObject_GetOptionalAttr(self, &_Py_ID(__getinitargs__), &getinitargs) < 0) {
         return NULL;
     }
     if (getinitargs != NULL) {

--- a/Modules/_elementtree.c
+++ b/Modules/_elementtree.c
@@ -3530,7 +3530,7 @@ expat_start_doctype_handler(XMLParserObject *self,
                                            sysid_obj, NULL);
         Py_XDECREF(res);
     }
-    else if (_PyObject_LookupAttr((PyObject *)self, st->str_doctype, &res) > 0) {
+    else if (PyObject_GetOptionalAttr((PyObject *)self, st->str_doctype, &res) > 0) {
         (void)PyErr_WarnEx(PyExc_RuntimeWarning,
                 "The doctype() method of XMLParser is ignored.  "
                 "Define doctype() method on the TreeBuilder target.",

--- a/Modules/_io/bufferedio.c
+++ b/Modules/_io/bufferedio.c
@@ -1463,7 +1463,7 @@ buffered_repr(buffered *self)
 {
     PyObject *nameobj, *res;
 
-    if (_PyObject_LookupAttr((PyObject *) self, &_Py_ID(name), &nameobj) < 0) {
+    if (PyObject_GetOptionalAttr((PyObject *) self, &_Py_ID(name), &nameobj) < 0) {
         if (!PyErr_ExceptionMatches(PyExc_ValueError)) {
             return NULL;
         }
@@ -1630,7 +1630,7 @@ _bufferedreader_read_all(buffered *self)
     }
     _bufferedreader_reset_buf(self);
 
-    if (_PyObject_LookupAttr(self->raw, &_Py_ID(readall), &readall) < 0) {
+    if (PyObject_GetOptionalAttr(self->raw, &_Py_ID(readall), &readall) < 0) {
         goto cleanup;
     }
     if (readall) {

--- a/Modules/_io/fileio.c
+++ b/Modules/_io/fileio.c
@@ -1099,7 +1099,7 @@ fileio_repr(fileio *self)
     if (self->fd < 0)
         return PyUnicode_FromFormat("<_io.FileIO [closed]>");
 
-    if (_PyObject_LookupAttr((PyObject *) self, &_Py_ID(name), &nameobj) < 0) {
+    if (PyObject_GetOptionalAttr((PyObject *) self, &_Py_ID(name), &nameobj) < 0) {
         return NULL;
     }
     if (nameobj == NULL) {

--- a/Modules/_io/iobase.c
+++ b/Modules/_io/iobase.c
@@ -148,7 +148,7 @@ iobase_is_closed(PyObject *self)
     int ret;
     /* This gets the derived attribute, which is *not* __IOBase_closed
        in most cases! */
-    ret = _PyObject_LookupAttr(self, &_Py_ID(__IOBase_closed), &res);
+    ret = PyObject_GetOptionalAttr(self, &_Py_ID(__IOBase_closed), &res);
     Py_XDECREF(res);
     return ret;
 }
@@ -196,7 +196,7 @@ iobase_check_closed(PyObject *self)
     int closed;
     /* This gets the derived attribute, which is *not* __IOBase_closed
        in most cases! */
-    closed = _PyObject_LookupAttr(self, &_Py_ID(closed), &res);
+    closed = PyObject_GetOptionalAttr(self, &_Py_ID(closed), &res);
     if (closed > 0) {
         closed = PyObject_IsTrue(res);
         Py_DECREF(res);
@@ -303,7 +303,7 @@ iobase_finalize(PyObject *self)
 
     /* If `closed` doesn't exist or can't be evaluated as bool, then the
        object is probably in an unusable state, so ignore. */
-    if (_PyObject_LookupAttr(self, &_Py_ID(closed), &res) <= 0) {
+    if (PyObject_GetOptionalAttr(self, &_Py_ID(closed), &res) <= 0) {
         PyErr_Clear();
         closed = -1;
     }
@@ -571,7 +571,7 @@ _io__IOBase_readline_impl(PyObject *self, Py_ssize_t limit)
     PyObject *peek, *buffer, *result;
     Py_ssize_t old_size = -1;
 
-    if (_PyObject_LookupAttr(self, &_Py_ID(peek), &peek) < 0) {
+    if (PyObject_GetOptionalAttr(self, &_Py_ID(peek), &peek) < 0) {
         return NULL;
     }
 

--- a/Modules/_io/textio.c
+++ b/Modules/_io/textio.c
@@ -946,7 +946,7 @@ _textiowrapper_set_encoder(textio *self, PyObject *codec_info,
         return -1;
 
     /* Get the normalized named of the codec */
-    if (_PyObject_LookupAttr(codec_info, &_Py_ID(name), &res) < 0) {
+    if (PyObject_GetOptionalAttr(codec_info, &_Py_ID(name), &res) < 0) {
         return -1;
     }
     if (res != NULL && PyUnicode_Check(res)) {
@@ -1202,7 +1202,7 @@ _io_TextIOWrapper___init___impl(textio *self, PyObject *buffer,
         Py_IS_TYPE(buffer, state->PyBufferedWriter_Type) ||
         Py_IS_TYPE(buffer, state->PyBufferedRandom_Type))
     {
-        if (_PyObject_LookupAttr(buffer, &_Py_ID(raw), &raw) < 0)
+        if (PyObject_GetOptionalAttr(buffer, &_Py_ID(raw), &raw) < 0)
             goto error;
         /* Cache the raw FileIO object to speed up 'closed' checks */
         if (raw != NULL) {
@@ -1222,7 +1222,7 @@ _io_TextIOWrapper___init___impl(textio *self, PyObject *buffer,
         goto error;
     self->seekable = self->telling = r;
 
-    r = _PyObject_LookupAttr(buffer, &_Py_ID(read1), &res);
+    r = PyObject_GetOptionalAttr(buffer, &_Py_ID(read1), &res);
     if (r < 0) {
         goto error;
     }
@@ -2897,7 +2897,7 @@ textiowrapper_repr(textio *self)
         }
         goto error;
     }
-    if (_PyObject_LookupAttr((PyObject *) self, &_Py_ID(name), &nameobj) < 0) {
+    if (PyObject_GetOptionalAttr((PyObject *) self, &_Py_ID(name), &nameobj) < 0) {
         if (!PyErr_ExceptionMatches(PyExc_ValueError)) {
             goto error;
         }
@@ -2913,7 +2913,7 @@ textiowrapper_repr(textio *self)
         if (res == NULL)
             goto error;
     }
-    if (_PyObject_LookupAttr((PyObject *) self, &_Py_ID(mode), &modeobj) < 0) {
+    if (PyObject_GetOptionalAttr((PyObject *) self, &_Py_ID(mode), &modeobj) < 0) {
         goto error;
     }
     if (modeobj != NULL) {
@@ -3130,7 +3130,7 @@ textiowrapper_newlines_get(textio *self, void *context)
     PyObject *res;
     CHECK_ATTACHED(self);
     if (self->decoder == NULL ||
-        _PyObject_LookupAttr(self->decoder, &_Py_ID(newlines), &res) == 0)
+        PyObject_GetOptionalAttr(self->decoder, &_Py_ID(newlines), &res) == 0)
     {
         Py_RETURN_NONE;
     }

--- a/Modules/_pickle.c
+++ b/Modules/_pickle.c
@@ -406,7 +406,7 @@ init_method_ref(PyObject *self, PyObject *name,
 
     /* *method_func and *method_self should be consistent.  All refcount decrements
        should be occurred after setting *method_self and *method_func. */
-    ret = _PyObject_LookupAttr(self, name, &func);
+    ret = PyObject_GetOptionalAttr(self, name, &func);
     if (func == NULL) {
         *method_self = NULL;
         Py_CLEAR(*method_func);
@@ -1224,7 +1224,7 @@ static int
 _Pickler_SetOutputStream(PicklerObject *self, PyObject *file)
 {
     assert(file != NULL);
-    if (_PyObject_LookupAttr(file, &_Py_ID(write), &self->write) < 0) {
+    if (PyObject_GetOptionalAttr(file, &_Py_ID(write), &self->write) < 0) {
         return -1;
     }
     if (self->write == NULL) {
@@ -1694,16 +1694,16 @@ static int
 _Unpickler_SetInputStream(UnpicklerObject *self, PyObject *file)
 {
     /* Optional file methods */
-    if (_PyObject_LookupAttr(file, &_Py_ID(peek), &self->peek) < 0) {
+    if (PyObject_GetOptionalAttr(file, &_Py_ID(peek), &self->peek) < 0) {
         goto error;
     }
-    if (_PyObject_LookupAttr(file, &_Py_ID(readinto), &self->readinto) < 0) {
+    if (PyObject_GetOptionalAttr(file, &_Py_ID(readinto), &self->readinto) < 0) {
         goto error;
     }
-    if (_PyObject_LookupAttr(file, &_Py_ID(read), &self->read) < 0) {
+    if (PyObject_GetOptionalAttr(file, &_Py_ID(read), &self->read) < 0) {
         goto error;
     }
-    if (_PyObject_LookupAttr(file, &_Py_ID(readline), &self->readline) < 0) {
+    if (PyObject_GetOptionalAttr(file, &_Py_ID(readline), &self->readline) < 0) {
         goto error;
     }
     if (!self->readline || !self->read) {
@@ -1900,7 +1900,7 @@ get_deep_attribute(PyObject *obj, PyObject *names, PyObject **pparent)
     for (i = 0; i < n; i++) {
         PyObject *name = PyList_GET_ITEM(names, i);
         Py_XSETREF(parent, obj);
-        (void)_PyObject_LookupAttr(parent, name, &obj);
+        (void)PyObject_GetOptionalAttr(parent, name, &obj);
         if (obj == NULL) {
             Py_DECREF(parent);
             return NULL;
@@ -1927,7 +1927,7 @@ getattribute(PyObject *obj, PyObject *name, int allow_qualname)
         Py_DECREF(dotted_path);
     }
     else {
-        (void)_PyObject_LookupAttr(obj, name, &attr);
+        (void)PyObject_GetOptionalAttr(obj, name, &attr);
     }
     if (attr == NULL && !PyErr_Occurred()) {
         PyErr_Format(PyExc_AttributeError,
@@ -1968,7 +1968,7 @@ whichmodule(PyObject *global, PyObject *dotted_path)
     Py_ssize_t i;
     PyObject *modules;
 
-    if (_PyObject_LookupAttr(global, &_Py_ID(__module__), &module_name) < 0) {
+    if (PyObject_GetOptionalAttr(global, &_Py_ID(__module__), &module_name) < 0) {
         return NULL;
     }
     if (module_name) {
@@ -3656,7 +3656,7 @@ save_global(PickleState *st, PicklerObject *self, PyObject *obj,
         global_name = Py_NewRef(name);
     }
     else {
-        if (_PyObject_LookupAttr(obj, &_Py_ID(__qualname__), &global_name) < 0)
+        if (PyObject_GetOptionalAttr(obj, &_Py_ID(__qualname__), &global_name) < 0)
             goto error;
         if (global_name == NULL) {
             global_name = PyObject_GetAttr(obj, &_Py_ID(__name__));
@@ -3979,7 +3979,7 @@ get_class(PyObject *obj)
 {
     PyObject *cls;
 
-    if (_PyObject_LookupAttr(obj, &_Py_ID(__class__), &cls) == 0) {
+    if (PyObject_GetOptionalAttr(obj, &_Py_ID(__class__), &cls) == 0) {
         cls = Py_NewRef(Py_TYPE(obj));
     }
     return cls;
@@ -4062,7 +4062,7 @@ save_reduce(PickleState *st, PicklerObject *self, PyObject *args,
     if (self->proto >= 2) {
         PyObject *name;
 
-        if (_PyObject_LookupAttr(callable, &_Py_ID(__name__), &name) < 0) {
+        if (PyObject_GetOptionalAttr(callable, &_Py_ID(__name__), &name) < 0) {
             return -1;
         }
         if (name != NULL && PyUnicode_Check(name)) {
@@ -4465,7 +4465,7 @@ save(PickleState *st, PicklerObject *self, PyObject *obj, int pers_save)
            don't actually have to check for a __reduce__ method. */
 
         /* Check for a __reduce_ex__ method. */
-        if (_PyObject_LookupAttr(obj, &_Py_ID(__reduce_ex__), &reduce_func) < 0) {
+        if (PyObject_GetOptionalAttr(obj, &_Py_ID(__reduce_ex__), &reduce_func) < 0) {
             goto error;
         }
         if (reduce_func != NULL) {
@@ -4477,7 +4477,7 @@ save(PickleState *st, PicklerObject *self, PyObject *obj, int pers_save)
         }
         else {
             /* Check for a __reduce__ method. */
-            if (_PyObject_LookupAttr(obj, &_Py_ID(__reduce__), &reduce_func) < 0) {
+            if (PyObject_GetOptionalAttr(obj, &_Py_ID(__reduce__), &reduce_func) < 0) {
                 goto error;
             }
             if (reduce_func != NULL) {
@@ -4529,7 +4529,7 @@ dump(PickleState *state, PicklerObject *self, PyObject *obj)
     int status = -1;
     PyObject *tmp;
 
-    if (_PyObject_LookupAttr((PyObject *)self, &_Py_ID(reducer_override),
+    if (PyObject_GetOptionalAttr((PyObject *)self, &_Py_ID(reducer_override),
                              &tmp) < 0) {
       goto error;
     }
@@ -4799,7 +4799,7 @@ _pickle_Pickler___init___impl(PicklerObject *self, PyObject *file,
     if (self->dispatch_table != NULL) {
         return 0;
     }
-    if (_PyObject_LookupAttr((PyObject *)self, &_Py_ID(dispatch_table),
+    if (PyObject_GetOptionalAttr((PyObject *)self, &_Py_ID(dispatch_table),
                              &self->dispatch_table) < 0) {
         return -1;
     }
@@ -5800,7 +5800,7 @@ instantiate(PyObject *cls, PyObject *args)
     assert(PyTuple_Check(args));
     if (!PyTuple_GET_SIZE(args) && PyType_Check(cls)) {
         PyObject *func;
-        if (_PyObject_LookupAttr(cls, &_Py_ID(__getinitargs__), &func) < 0) {
+        if (PyObject_GetOptionalAttr(cls, &_Py_ID(__getinitargs__), &func) < 0) {
             return NULL;
         }
         if (func == NULL) {
@@ -6454,7 +6454,7 @@ do_append(PickleState *state, UnpicklerObject *self, Py_ssize_t x)
     else {
         PyObject *extend_func;
 
-        if (_PyObject_LookupAttr(list, &_Py_ID(extend), &extend_func) < 0) {
+        if (PyObject_GetOptionalAttr(list, &_Py_ID(extend), &extend_func) < 0) {
             return -1;
         }
         if (extend_func != NULL) {
@@ -6640,7 +6640,7 @@ load_build(PickleState *st, UnpicklerObject *self)
 
     inst = self->stack->data[Py_SIZE(self->stack) - 1];
 
-    if (_PyObject_LookupAttr(inst, &_Py_ID(__setstate__), &setstate) < 0) {
+    if (PyObject_GetOptionalAttr(inst, &_Py_ID(__setstate__), &setstate) < 0) {
         Py_DECREF(state);
         return -1;
     }

--- a/Modules/_sqlite/microprotocols.c
+++ b/Modules/_sqlite/microprotocols.c
@@ -98,7 +98,7 @@ pysqlite_microprotocols_adapt(pysqlite_state *state, PyObject *obj,
     }
 
     /* try to have the protocol adapt this object */
-    if (_PyObject_LookupAttr(proto, state->str___adapt__, &adapter) < 0) {
+    if (PyObject_GetOptionalAttr(proto, state->str___adapt__, &adapter) < 0) {
         return NULL;
     }
     if (adapter) {
@@ -117,7 +117,7 @@ pysqlite_microprotocols_adapt(pysqlite_state *state, PyObject *obj,
     }
 
     /* and finally try to have the object adapt itself */
-    if (_PyObject_LookupAttr(obj, state->str___conform__, &adapter) < 0) {
+    if (PyObject_GetOptionalAttr(obj, state->str___conform__, &adapter) < 0) {
         return NULL;
     }
     if (adapter) {

--- a/Modules/_threadmodule.c
+++ b/Modules/_threadmodule.c
@@ -1438,7 +1438,7 @@ thread_excepthook_file(PyObject *file, PyObject *exc_type, PyObject *exc_value,
 
     PyObject *name = NULL;
     if (thread != Py_None) {
-        if (_PyObject_LookupAttr(thread, &_Py_ID(name), &name) < 0) {
+        if (PyObject_GetOptionalAttr(thread, &_Py_ID(name), &name) < 0) {
             return -1;
         }
     }

--- a/Modules/arraymodule.c
+++ b/Modules/arraymodule.c
@@ -2268,7 +2268,7 @@ array_array___reduce_ex___impl(arrayobject *self, PyTypeObject *cls,
     if (protocol == -1 && PyErr_Occurred())
         return NULL;
 
-    if (_PyObject_LookupAttr((PyObject *)self, state->str___dict__, &dict) < 0) {
+    if (PyObject_GetOptionalAttr((PyObject *)self, state->str___dict__, &dict) < 0) {
         return NULL;
     }
     if (dict == NULL) {

--- a/Modules/itertoolsmodule.c
+++ b/Modules/itertoolsmodule.c
@@ -1146,7 +1146,7 @@ itertools_tee_impl(PyObject *module, PyObject *iterable, Py_ssize_t n)
         return NULL;
     }
 
-    if (_PyObject_LookupAttr(it, &_Py_ID(__copy__), &copyfunc) < 0) {
+    if (PyObject_GetOptionalAttr(it, &_Py_ID(__copy__), &copyfunc) < 0) {
         Py_DECREF(it);
         Py_DECREF(result);
         return NULL;

--- a/Modules/pyexpat.c
+++ b/Modules/pyexpat.c
@@ -832,7 +832,7 @@ pyexpat_xmlparser_ParseFile_impl(xmlparseobject *self, PyTypeObject *cls,
 
     pyexpat_state *state = PyType_GetModuleState(cls);
 
-    if (_PyObject_LookupAttr(file, state->str_read, &readmethod) < 0) {
+    if (PyObject_GetOptionalAttr(file, state->str_read, &readmethod) < 0) {
         return NULL;
     }
     if (readmethod == NULL) {

--- a/Objects/abstract.c
+++ b/Objects/abstract.c
@@ -182,7 +182,7 @@ PyObject_GetItem(PyObject *o, PyObject *key)
             return Py_GenericAlias(o, key);
         }
 
-        if (_PyObject_LookupAttr(o, &_Py_ID(__class_getitem__), &meth) < 0) {
+        if (PyObject_GetOptionalAttr(o, &_Py_ID(__class_getitem__), &meth) < 0) {
             return NULL;
         }
         if (meth && meth != Py_None) {
@@ -2512,7 +2512,7 @@ abstract_get_bases(PyObject *cls)
 {
     PyObject *bases;
 
-    (void)_PyObject_LookupAttr(cls, &_Py_ID(__bases__), &bases);
+    (void)PyObject_GetOptionalAttr(cls, &_Py_ID(__bases__), &bases);
     if (bases != NULL && !PyTuple_Check(bases)) {
         Py_DECREF(bases);
         return NULL;
@@ -2596,7 +2596,7 @@ object_isinstance(PyObject *inst, PyObject *cls)
     if (PyType_Check(cls)) {
         retval = PyObject_TypeCheck(inst, (PyTypeObject *)cls);
         if (retval == 0) {
-            retval = _PyObject_LookupAttr(inst, &_Py_ID(__class__), &icls);
+            retval = PyObject_GetOptionalAttr(inst, &_Py_ID(__class__), &icls);
             if (icls != NULL) {
                 if (icls != (PyObject *)(Py_TYPE(inst)) && PyType_Check(icls)) {
                     retval = PyType_IsSubtype(
@@ -2614,7 +2614,7 @@ object_isinstance(PyObject *inst, PyObject *cls)
         if (!check_class(cls,
             "isinstance() arg 2 must be a type, a tuple of types, or a union"))
             return -1;
-        retval = _PyObject_LookupAttr(inst, &_Py_ID(__class__), &icls);
+        retval = PyObject_GetOptionalAttr(inst, &_Py_ID(__class__), &icls);
         if (icls != NULL) {
             retval = abstract_issubclass(icls, cls);
             Py_DECREF(icls);

--- a/Objects/call.c
+++ b/Objects/call.c
@@ -173,7 +173,7 @@ object_is_not_callable(PyThreadState *tstate, PyObject *callable)
             goto basic_type_error;
         }
         PyObject *attr;
-        int res = _PyObject_LookupAttr(callable, name, &attr);
+        int res = PyObject_GetOptionalAttr(callable, name, &attr);
         if (res < 0) {
             _PyErr_Clear(tstate);
         }

--- a/Objects/classobject.c
+++ b/Objects/classobject.c
@@ -275,9 +275,9 @@ method_repr(PyMethodObject *a)
     PyObject *funcname, *result;
     const char *defname = "?";
 
-    if (_PyObject_LookupAttr(func, &_Py_ID(__qualname__), &funcname) < 0 ||
+    if (PyObject_GetOptionalAttr(func, &_Py_ID(__qualname__), &funcname) < 0 ||
         (funcname == NULL &&
-         _PyObject_LookupAttr(func, &_Py_ID(__name__), &funcname) < 0))
+         PyObject_GetOptionalAttr(func, &_Py_ID(__name__), &funcname) < 0))
     {
         return NULL;
     }
@@ -479,7 +479,7 @@ instancemethod_repr(PyObject *self)
         return NULL;
     }
 
-    if (_PyObject_LookupAttr(func, &_Py_ID(__name__), &funcname) < 0) {
+    if (PyObject_GetOptionalAttr(func, &_Py_ID(__name__), &funcname) < 0) {
         return NULL;
     }
     if (funcname != NULL && !PyUnicode_Check(funcname)) {

--- a/Objects/descrobject.c
+++ b/Objects/descrobject.c
@@ -1792,7 +1792,7 @@ property_init_impl(propertyobject *self, PyObject *fget, PyObject *fset,
     }
     /* if no docstring given and the getter has one, use that one */
     else if (fget != NULL) {
-        int rc = _PyObject_LookupAttr(fget, &_Py_ID(__doc__), &prop_doc);
+        int rc = PyObject_GetOptionalAttr(fget, &_Py_ID(__doc__), &prop_doc);
         if (rc <= 0) {
             return rc;
         }

--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -2664,7 +2664,7 @@ dict_update_arg(PyObject *self, PyObject *arg)
         return PyDict_Merge(self, arg, 1);
     }
     PyObject *func;
-    if (_PyObject_LookupAttr(arg, &_Py_ID(keys), &func) < 0) {
+    if (PyObject_GetOptionalAttr(arg, &_Py_ID(keys), &func) < 0) {
         return -1;
     }
     if (func != NULL) {

--- a/Objects/exceptions.c
+++ b/Objects/exceptions.c
@@ -208,7 +208,7 @@ BaseException_add_note(PyObject *self, PyObject *note)
     }
 
     PyObject *notes;
-    if (_PyObject_LookupAttr(self, &_Py_ID(__notes__), &notes) < 0) {
+    if (PyObject_GetOptionalAttr(self, &_Py_ID(__notes__), &notes) < 0) {
         return NULL;
     }
     if (notes == NULL) {
@@ -941,7 +941,7 @@ exceptiongroup_subset(
     PyException_SetCause(eg, PyException_GetCause(orig));
 
     PyObject *notes;
-    if (_PyObject_LookupAttr(orig, &_Py_ID(__notes__), &notes) < 0) {
+    if (PyObject_GetOptionalAttr(orig, &_Py_ID(__notes__), &notes) < 0) {
         goto error;
     }
     if (notes) {

--- a/Objects/fileobject.c
+++ b/Objects/fileobject.c
@@ -176,7 +176,7 @@ PyObject_AsFileDescriptor(PyObject *o)
     if (PyLong_Check(o)) {
         fd = _PyLong_AsInt(o);
     }
-    else if (_PyObject_LookupAttr(o, &_Py_ID(fileno), &meth) < 0) {
+    else if (PyObject_GetOptionalAttr(o, &_Py_ID(fileno), &meth) < 0) {
         return -1;
     }
     else if (meth != NULL) {

--- a/Objects/funcobject.c
+++ b/Objects/funcobject.c
@@ -943,7 +943,7 @@ static int
 functools_copy_attr(PyObject *wrapper, PyObject *wrapped, PyObject *name)
 {
     PyObject *value;
-    int res = _PyObject_LookupAttr(wrapped, name, &value);
+    int res = PyObject_GetOptionalAttr(wrapped, name, &value);
     if (value != NULL) {
         res = PyObject_SetAttr(wrapper, name, value);
         Py_DECREF(value);

--- a/Objects/genericaliasobject.c
+++ b/Objects/genericaliasobject.c
@@ -63,12 +63,12 @@ ga_repr_item(_PyUnicodeWriter *writer, PyObject *p)
         goto done;
     }
 
-    if (_PyObject_LookupAttr(p, &_Py_ID(__origin__), &tmp) < 0) {
+    if (PyObject_GetOptionalAttr(p, &_Py_ID(__origin__), &tmp) < 0) {
         goto done;
     }
     if (tmp != NULL) {
         Py_DECREF(tmp);
-        if (_PyObject_LookupAttr(p, &_Py_ID(__args__), &tmp) < 0) {
+        if (PyObject_GetOptionalAttr(p, &_Py_ID(__args__), &tmp) < 0) {
             goto done;
         }
         if (tmp != NULL) {
@@ -78,13 +78,13 @@ ga_repr_item(_PyUnicodeWriter *writer, PyObject *p)
         }
     }
 
-    if (_PyObject_LookupAttr(p, &_Py_ID(__qualname__), &qualname) < 0) {
+    if (PyObject_GetOptionalAttr(p, &_Py_ID(__qualname__), &qualname) < 0) {
         goto done;
     }
     if (qualname == NULL) {
         goto use_repr;
     }
-    if (_PyObject_LookupAttr(p, &_Py_ID(__module__), &module) < 0) {
+    if (PyObject_GetOptionalAttr(p, &_Py_ID(__module__), &module) < 0) {
         goto done;
     }
     if (module == NULL || module == Py_None) {
@@ -257,7 +257,7 @@ _Py_make_parameters(PyObject *args)
         if (PyType_Check(t)) {
             continue;
         }
-        if (_PyObject_LookupAttr(t, &_Py_ID(__typing_subst__), &subst) < 0) {
+        if (PyObject_GetOptionalAttr(t, &_Py_ID(__typing_subst__), &subst) < 0) {
             Py_DECREF(parameters);
             return NULL;
         }
@@ -267,7 +267,7 @@ _Py_make_parameters(PyObject *args)
         }
         else {
             PyObject *subparams;
-            if (_PyObject_LookupAttr(t, &_Py_ID(__parameters__),
+            if (PyObject_GetOptionalAttr(t, &_Py_ID(__parameters__),
                                      &subparams) < 0) {
                 Py_DECREF(parameters);
                 return NULL;
@@ -310,7 +310,7 @@ subs_tvars(PyObject *obj, PyObject *params,
            PyObject **argitems, Py_ssize_t nargs)
 {
     PyObject *subparams;
-    if (_PyObject_LookupAttr(obj, &_Py_ID(__parameters__), &subparams) < 0) {
+    if (PyObject_GetOptionalAttr(obj, &_Py_ID(__parameters__), &subparams) < 0) {
         return NULL;
     }
     if (subparams && PyTuple_Check(subparams) && PyTuple_GET_SIZE(subparams)) {
@@ -361,7 +361,7 @@ _is_unpacked_typevartuple(PyObject *arg)
     if (PyType_Check(arg)) { // TODO: Add test
         return 0;
     }
-    int res = _PyObject_LookupAttr(arg, &_Py_ID(__typing_is_unpacked_typevartuple__), &tmp);
+    int res = PyObject_GetOptionalAttr(arg, &_Py_ID(__typing_is_unpacked_typevartuple__), &tmp);
     if (res > 0) {
         res = PyObject_IsTrue(tmp);
         Py_DECREF(tmp);
@@ -383,7 +383,7 @@ _unpacked_tuple_args(PyObject *arg)
         return Py_NewRef(result);
     }
 
-    if (_PyObject_LookupAttr(arg, &_Py_ID(__typing_unpacked_tuple_args__), &result) > 0) {
+    if (PyObject_GetOptionalAttr(arg, &_Py_ID(__typing_unpacked_tuple_args__), &result) > 0) {
         if (result == Py_None) {
             Py_DECREF(result);
             return NULL;
@@ -448,7 +448,7 @@ _Py_subs_parameters(PyObject *self, PyObject *args, PyObject *parameters, PyObje
     for (Py_ssize_t i = 0; i < nparams; i++) {
         PyObject *param = PyTuple_GET_ITEM(parameters, i);
         PyObject *prepare, *tmp;
-        if (_PyObject_LookupAttr(param, &_Py_ID(__typing_prepare_subst__), &prepare) < 0) {
+        if (PyObject_GetOptionalAttr(param, &_Py_ID(__typing_prepare_subst__), &prepare) < 0) {
             Py_DECREF(item);
             return NULL;
         }
@@ -503,7 +503,7 @@ _Py_subs_parameters(PyObject *self, PyObject *args, PyObject *parameters, PyObje
             return NULL;
         }
         PyObject *subst;
-        if (_PyObject_LookupAttr(arg, &_Py_ID(__typing_subst__), &subst) < 0) {
+        if (PyObject_GetOptionalAttr(arg, &_Py_ID(__typing_subst__), &subst) < 0) {
             Py_DECREF(newargs);
             Py_DECREF(item);
             return NULL;

--- a/Objects/genobject.c
+++ b/Objects/genobject.c
@@ -317,7 +317,7 @@ gen_close_iter(PyObject *yf)
     }
     else {
         PyObject *meth;
-        if (_PyObject_LookupAttr(yf, &_Py_ID(close), &meth) < 0) {
+        if (PyObject_GetOptionalAttr(yf, &_Py_ID(close), &meth) < 0) {
             PyErr_WriteUnraisable(yf);
         }
         if (meth) {
@@ -492,7 +492,7 @@ _gen_throw(PyGenObject *gen, int close_on_genexit,
         } else {
             /* `yf` is an iterator or a coroutine-like object. */
             PyObject *meth;
-            if (_PyObject_LookupAttr(yf, &_Py_ID(throw), &meth) < 0) {
+            if (PyObject_GetOptionalAttr(yf, &_Py_ID(throw), &meth) < 0) {
                 Py_DECREF(yf);
                 return NULL;
             }

--- a/Objects/moduleobject.c
+++ b/Objects/moduleobject.c
@@ -742,7 +742,7 @@ _PyModuleSpec_IsInitializing(PyObject *spec)
 {
     if (spec != NULL) {
         PyObject *value;
-        int ok = _PyObject_LookupAttr(spec, &_Py_ID(_initializing), &value);
+        int ok = PyObject_GetOptionalAttr(spec, &_Py_ID(_initializing), &value);
         if (ok == 0) {
             return 0;
         }

--- a/Objects/odictobject.c
+++ b/Objects/odictobject.c
@@ -2154,7 +2154,7 @@ mutablemapping_update_arg(PyObject *self, PyObject *arg)
         return res;
     }
     PyObject *func;
-    if (_PyObject_LookupAttr(arg, &_Py_ID(keys), &func) < 0) {
+    if (PyObject_GetOptionalAttr(arg, &_Py_ID(keys), &func) < 0) {
         return -1;
     }
     if (func != NULL) {
@@ -2186,7 +2186,7 @@ mutablemapping_update_arg(PyObject *self, PyObject *arg)
         }
         return 0;
     }
-    if (_PyObject_LookupAttr(arg, &_Py_ID(items), &func) < 0) {
+    if (PyObject_GetOptionalAttr(arg, &_Py_ID(items), &func) < 0) {
         return -1;
     }
     if (func != NULL) {

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -2359,7 +2359,7 @@ static PyObject *
 class_name(PyObject *cls)
 {
     PyObject *name;
-    if (_PyObject_LookupAttr(cls, &_Py_ID(__name__), &name) == 0) {
+    if (PyObject_GetOptionalAttr(cls, &_Py_ID(__name__), &name) == 0) {
         name = PyObject_Repr(cls);
     }
     return name;
@@ -3865,7 +3865,7 @@ type_new_get_bases(type_new_ctx *ctx, PyObject **type)
             continue;
         }
         PyObject *mro_entries;
-        if (_PyObject_LookupAttr(base, &_Py_ID(__mro_entries__),
+        if (PyObject_GetOptionalAttr(base, &_Py_ID(__mro_entries__),
                                  &mro_entries) < 0) {
             return -1;
         }
@@ -5147,7 +5147,7 @@ merge_class_dict(PyObject *dict, PyObject *aclass)
     assert(aclass);
 
     /* Merge in the type's dict (if any). */
-    if (_PyObject_LookupAttr(aclass, &_Py_ID(__dict__), &classdict) < 0) {
+    if (PyObject_GetOptionalAttr(aclass, &_Py_ID(__dict__), &classdict) < 0) {
         return -1;
     }
     if (classdict != NULL) {
@@ -5158,7 +5158,7 @@ merge_class_dict(PyObject *dict, PyObject *aclass)
     }
 
     /* Recursively merge in the base types' (if any) dicts. */
-    if (_PyObject_LookupAttr(aclass, &_Py_ID(__bases__), &bases) < 0) {
+    if (PyObject_GetOptionalAttr(aclass, &_Py_ID(__bases__), &bases) < 0) {
         return -1;
     }
     if (bases != NULL) {
@@ -5984,7 +5984,7 @@ object_getstate_default(PyObject *obj, int required)
             PyObject *name, *value;
 
             name = Py_NewRef(PyList_GET_ITEM(slotnames, i));
-            if (_PyObject_LookupAttr(obj, name, &value) < 0) {
+            if (PyObject_GetOptionalAttr(obj, name, &value) < 0) {
                 Py_DECREF(name);
                 goto error;
             }
@@ -6381,7 +6381,7 @@ object___reduce_ex___impl(PyObject *self, int protocol)
         }
     }
 
-    if (_PyObject_LookupAttr(self, &_Py_ID(__reduce__), &reduce) < 0) {
+    if (PyObject_GetOptionalAttr(self, &_Py_ID(__reduce__), &reduce) < 0) {
         return NULL;
     }
     if (reduce != NULL) {
@@ -6500,7 +6500,7 @@ object___dir___impl(PyObject *self)
     PyObject *itsclass = NULL;
 
     /* Get __dict__ (which may or may not be a real dict...) */
-    if (_PyObject_LookupAttr(self, &_Py_ID(__dict__), &dict) < 0) {
+    if (PyObject_GetOptionalAttr(self, &_Py_ID(__dict__), &dict) < 0) {
         return NULL;
     }
     if (dict == NULL) {
@@ -6520,7 +6520,7 @@ object___dir___impl(PyObject *self)
         goto error;
 
     /* Merge in attrs reachable from its class. */
-    if (_PyObject_LookupAttr(self, &_Py_ID(__class__), &itsclass) < 0) {
+    if (PyObject_GetOptionalAttr(self, &_Py_ID(__class__), &itsclass) < 0) {
         goto error;
     }
     /* XXX(tomer): Perhaps fall back to Py_TYPE(obj) if no
@@ -8393,7 +8393,7 @@ method_is_overloaded(PyObject *left, PyObject *right, PyObject *name)
     PyObject *a, *b;
     int ok;
 
-    if (_PyObject_LookupAttr((PyObject *)(Py_TYPE(right)), name, &b) < 0) {
+    if (PyObject_GetOptionalAttr((PyObject *)(Py_TYPE(right)), name, &b) < 0) {
         return -1;
     }
     if (b == NULL) {
@@ -8401,7 +8401,7 @@ method_is_overloaded(PyObject *left, PyObject *right, PyObject *name)
         return 0;
     }
 
-    if (_PyObject_LookupAttr((PyObject *)(Py_TYPE(left)), name, &a) < 0) {
+    if (PyObject_GetOptionalAttr((PyObject *)(Py_TYPE(left)), name, &a) < 0) {
         Py_DECREF(b);
         return -1;
     }
@@ -10373,7 +10373,7 @@ supercheck(PyTypeObject *type, PyObject *obj)
         /* Try the slow way */
         PyObject *class_attr;
 
-        if (_PyObject_LookupAttr(obj, &_Py_ID(__class__), &class_attr) < 0) {
+        if (PyObject_GetOptionalAttr(obj, &_Py_ID(__class__), &class_attr) < 0) {
             return NULL;
         }
         if (class_attr != NULL &&

--- a/Objects/unionobject.c
+++ b/Objects/unionobject.c
@@ -194,13 +194,13 @@ union_repr_item(_PyUnicodeWriter *writer, PyObject *p)
         return _PyUnicodeWriter_WriteASCIIString(writer, "None", 4);
     }
 
-    if (_PyObject_LookupAttr(p, &_Py_ID(__origin__), &tmp) < 0) {
+    if (PyObject_GetOptionalAttr(p, &_Py_ID(__origin__), &tmp) < 0) {
         goto exit;
     }
 
     if (tmp) {
         Py_DECREF(tmp);
-        if (_PyObject_LookupAttr(p, &_Py_ID(__args__), &tmp) < 0) {
+        if (PyObject_GetOptionalAttr(p, &_Py_ID(__args__), &tmp) < 0) {
             goto exit;
         }
         if (tmp) {
@@ -210,13 +210,13 @@ union_repr_item(_PyUnicodeWriter *writer, PyObject *p)
         }
     }
 
-    if (_PyObject_LookupAttr(p, &_Py_ID(__qualname__), &qualname) < 0) {
+    if (PyObject_GetOptionalAttr(p, &_Py_ID(__qualname__), &qualname) < 0) {
         goto exit;
     }
     if (qualname == NULL) {
         goto use_repr;
     }
-    if (_PyObject_LookupAttr(p, &_Py_ID(__module__), &module) < 0) {
+    if (PyObject_GetOptionalAttr(p, &_Py_ID(__module__), &module) < 0) {
         goto exit;
     }
     if (module == NULL || module == Py_None) {

--- a/Parser/asdl_c.py
+++ b/Parser/asdl_c.py
@@ -629,7 +629,7 @@ class Obj2ModVisitor(PickleVisitor):
 
     def visitField(self, field, name, sum=None, prod=None, depth=0):
         ctype = get_c_type(field.type)
-        line = "if (_PyObject_LookupAttr(obj, state->%s, &tmp) < 0) {"
+        line = "if (PyObject_GetOptionalAttr(obj, state->%s, &tmp) < 0) {"
         self.emit(line % field.name, depth)
         self.emit("return 1;", depth+1)
         self.emit("}", depth)
@@ -813,7 +813,7 @@ ast_type_init(PyObject *self, PyObject *args, PyObject *kw)
     Py_ssize_t i, numfields = 0;
     int res = -1;
     PyObject *key, *value, *fields;
-    if (_PyObject_LookupAttr((PyObject*)Py_TYPE(self), state->_fields, &fields) < 0) {
+    if (PyObject_GetOptionalAttr((PyObject*)Py_TYPE(self), state->_fields, &fields) < 0) {
         goto cleanup;
     }
     if (fields) {
@@ -887,7 +887,7 @@ ast_type_reduce(PyObject *self, PyObject *unused)
     }
 
     PyObject *dict;
-    if (_PyObject_LookupAttr(self, state->__dict__, &dict) < 0) {
+    if (PyObject_GetOptionalAttr(self, state->__dict__, &dict) < 0) {
         return NULL;
     }
     if (dict) {

--- a/Python/Python-ast.c
+++ b/Python/Python-ast.c
@@ -839,7 +839,7 @@ ast_type_init(PyObject *self, PyObject *args, PyObject *kw)
     Py_ssize_t i, numfields = 0;
     int res = -1;
     PyObject *key, *value, *fields;
-    if (_PyObject_LookupAttr((PyObject*)Py_TYPE(self), state->_fields, &fields) < 0) {
+    if (PyObject_GetOptionalAttr((PyObject*)Py_TYPE(self), state->_fields, &fields) < 0) {
         goto cleanup;
     }
     if (fields) {
@@ -913,7 +913,7 @@ ast_type_reduce(PyObject *self, PyObject *unused)
     }
 
     PyObject *dict;
-    if (_PyObject_LookupAttr(self, state->__dict__, &dict) < 0) {
+    if (PyObject_GetOptionalAttr(self, state->__dict__, &dict) < 0) {
         return NULL;
     }
     if (dict) {
@@ -5750,7 +5750,7 @@ obj2ast_mod(struct ast_state *state, PyObject* obj, mod_ty* out, PyArena* arena)
         asdl_stmt_seq* body;
         asdl_type_ignore_seq* type_ignores;
 
-        if (_PyObject_LookupAttr(obj, state->body, &tmp) < 0) {
+        if (PyObject_GetOptionalAttr(obj, state->body, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -5788,7 +5788,7 @@ obj2ast_mod(struct ast_state *state, PyObject* obj, mod_ty* out, PyArena* arena)
             }
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, state->type_ignores, &tmp) < 0) {
+        if (PyObject_GetOptionalAttr(obj, state->type_ignores, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -5838,7 +5838,7 @@ obj2ast_mod(struct ast_state *state, PyObject* obj, mod_ty* out, PyArena* arena)
     if (isinstance) {
         asdl_stmt_seq* body;
 
-        if (_PyObject_LookupAttr(obj, state->body, &tmp) < 0) {
+        if (PyObject_GetOptionalAttr(obj, state->body, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -5888,7 +5888,7 @@ obj2ast_mod(struct ast_state *state, PyObject* obj, mod_ty* out, PyArena* arena)
     if (isinstance) {
         expr_ty body;
 
-        if (_PyObject_LookupAttr(obj, state->body, &tmp) < 0) {
+        if (PyObject_GetOptionalAttr(obj, state->body, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -5918,7 +5918,7 @@ obj2ast_mod(struct ast_state *state, PyObject* obj, mod_ty* out, PyArena* arena)
         asdl_expr_seq* argtypes;
         expr_ty returns;
 
-        if (_PyObject_LookupAttr(obj, state->argtypes, &tmp) < 0) {
+        if (PyObject_GetOptionalAttr(obj, state->argtypes, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -5956,7 +5956,7 @@ obj2ast_mod(struct ast_state *state, PyObject* obj, mod_ty* out, PyArena* arena)
             }
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, state->returns, &tmp) < 0) {
+        if (PyObject_GetOptionalAttr(obj, state->returns, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -6001,7 +6001,7 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
         *out = NULL;
         return 0;
     }
-    if (_PyObject_LookupAttr(obj, state->lineno, &tmp) < 0) {
+    if (PyObject_GetOptionalAttr(obj, state->lineno, &tmp) < 0) {
         return 1;
     }
     if (tmp == NULL) {
@@ -6018,7 +6018,7 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
-    if (_PyObject_LookupAttr(obj, state->col_offset, &tmp) < 0) {
+    if (PyObject_GetOptionalAttr(obj, state->col_offset, &tmp) < 0) {
         return 1;
     }
     if (tmp == NULL) {
@@ -6035,7 +6035,7 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
-    if (_PyObject_LookupAttr(obj, state->end_lineno, &tmp) < 0) {
+    if (PyObject_GetOptionalAttr(obj, state->end_lineno, &tmp) < 0) {
         return 1;
     }
     if (tmp == NULL || tmp == Py_None) {
@@ -6052,7 +6052,7 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
-    if (_PyObject_LookupAttr(obj, state->end_col_offset, &tmp) < 0) {
+    if (PyObject_GetOptionalAttr(obj, state->end_col_offset, &tmp) < 0) {
         return 1;
     }
     if (tmp == NULL || tmp == Py_None) {
@@ -6083,7 +6083,7 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
         string type_comment;
         asdl_type_param_seq* type_params;
 
-        if (_PyObject_LookupAttr(obj, state->name, &tmp) < 0) {
+        if (PyObject_GetOptionalAttr(obj, state->name, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -6100,7 +6100,7 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, state->args, &tmp) < 0) {
+        if (PyObject_GetOptionalAttr(obj, state->args, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -6117,7 +6117,7 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, state->body, &tmp) < 0) {
+        if (PyObject_GetOptionalAttr(obj, state->body, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -6155,7 +6155,7 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
             }
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, state->decorator_list, &tmp) < 0) {
+        if (PyObject_GetOptionalAttr(obj, state->decorator_list, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -6193,7 +6193,7 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
             }
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, state->returns, &tmp) < 0) {
+        if (PyObject_GetOptionalAttr(obj, state->returns, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL || tmp == Py_None) {
@@ -6210,7 +6210,7 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, state->type_comment, &tmp) < 0) {
+        if (PyObject_GetOptionalAttr(obj, state->type_comment, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL || tmp == Py_None) {
@@ -6227,7 +6227,7 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, state->type_params, &tmp) < 0) {
+        if (PyObject_GetOptionalAttr(obj, state->type_params, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -6286,7 +6286,7 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
         string type_comment;
         asdl_type_param_seq* type_params;
 
-        if (_PyObject_LookupAttr(obj, state->name, &tmp) < 0) {
+        if (PyObject_GetOptionalAttr(obj, state->name, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -6303,7 +6303,7 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, state->args, &tmp) < 0) {
+        if (PyObject_GetOptionalAttr(obj, state->args, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -6320,7 +6320,7 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, state->body, &tmp) < 0) {
+        if (PyObject_GetOptionalAttr(obj, state->body, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -6358,7 +6358,7 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
             }
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, state->decorator_list, &tmp) < 0) {
+        if (PyObject_GetOptionalAttr(obj, state->decorator_list, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -6396,7 +6396,7 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
             }
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, state->returns, &tmp) < 0) {
+        if (PyObject_GetOptionalAttr(obj, state->returns, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL || tmp == Py_None) {
@@ -6413,7 +6413,7 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, state->type_comment, &tmp) < 0) {
+        if (PyObject_GetOptionalAttr(obj, state->type_comment, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL || tmp == Py_None) {
@@ -6430,7 +6430,7 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, state->type_params, &tmp) < 0) {
+        if (PyObject_GetOptionalAttr(obj, state->type_params, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -6488,7 +6488,7 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
         asdl_expr_seq* decorator_list;
         asdl_type_param_seq* type_params;
 
-        if (_PyObject_LookupAttr(obj, state->name, &tmp) < 0) {
+        if (PyObject_GetOptionalAttr(obj, state->name, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -6505,7 +6505,7 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, state->bases, &tmp) < 0) {
+        if (PyObject_GetOptionalAttr(obj, state->bases, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -6543,7 +6543,7 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
             }
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, state->keywords, &tmp) < 0) {
+        if (PyObject_GetOptionalAttr(obj, state->keywords, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -6581,7 +6581,7 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
             }
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, state->body, &tmp) < 0) {
+        if (PyObject_GetOptionalAttr(obj, state->body, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -6619,7 +6619,7 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
             }
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, state->decorator_list, &tmp) < 0) {
+        if (PyObject_GetOptionalAttr(obj, state->decorator_list, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -6657,7 +6657,7 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
             }
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, state->type_params, &tmp) < 0) {
+        if (PyObject_GetOptionalAttr(obj, state->type_params, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -6709,7 +6709,7 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
     if (isinstance) {
         expr_ty value;
 
-        if (_PyObject_LookupAttr(obj, state->value, &tmp) < 0) {
+        if (PyObject_GetOptionalAttr(obj, state->value, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL || tmp == Py_None) {
@@ -6739,7 +6739,7 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
     if (isinstance) {
         asdl_expr_seq* targets;
 
-        if (_PyObject_LookupAttr(obj, state->targets, &tmp) < 0) {
+        if (PyObject_GetOptionalAttr(obj, state->targets, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -6792,7 +6792,7 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
         expr_ty value;
         string type_comment;
 
-        if (_PyObject_LookupAttr(obj, state->targets, &tmp) < 0) {
+        if (PyObject_GetOptionalAttr(obj, state->targets, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -6830,7 +6830,7 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
             }
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, state->value, &tmp) < 0) {
+        if (PyObject_GetOptionalAttr(obj, state->value, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -6847,7 +6847,7 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, state->type_comment, &tmp) < 0) {
+        if (PyObject_GetOptionalAttr(obj, state->type_comment, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL || tmp == Py_None) {
@@ -6879,7 +6879,7 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
         asdl_type_param_seq* type_params;
         expr_ty value;
 
-        if (_PyObject_LookupAttr(obj, state->name, &tmp) < 0) {
+        if (PyObject_GetOptionalAttr(obj, state->name, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -6896,7 +6896,7 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, state->type_params, &tmp) < 0) {
+        if (PyObject_GetOptionalAttr(obj, state->type_params, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -6934,7 +6934,7 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
             }
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, state->value, &tmp) < 0) {
+        if (PyObject_GetOptionalAttr(obj, state->value, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -6966,7 +6966,7 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
         operator_ty op;
         expr_ty value;
 
-        if (_PyObject_LookupAttr(obj, state->target, &tmp) < 0) {
+        if (PyObject_GetOptionalAttr(obj, state->target, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -6983,7 +6983,7 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, state->op, &tmp) < 0) {
+        if (PyObject_GetOptionalAttr(obj, state->op, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -7000,7 +7000,7 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, state->value, &tmp) < 0) {
+        if (PyObject_GetOptionalAttr(obj, state->value, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -7033,7 +7033,7 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
         expr_ty value;
         int simple;
 
-        if (_PyObject_LookupAttr(obj, state->target, &tmp) < 0) {
+        if (PyObject_GetOptionalAttr(obj, state->target, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -7050,7 +7050,7 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, state->annotation, &tmp) < 0) {
+        if (PyObject_GetOptionalAttr(obj, state->annotation, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -7067,7 +7067,7 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, state->value, &tmp) < 0) {
+        if (PyObject_GetOptionalAttr(obj, state->value, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL || tmp == Py_None) {
@@ -7084,7 +7084,7 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, state->simple, &tmp) < 0) {
+        if (PyObject_GetOptionalAttr(obj, state->simple, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -7118,7 +7118,7 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
         asdl_stmt_seq* orelse;
         string type_comment;
 
-        if (_PyObject_LookupAttr(obj, state->target, &tmp) < 0) {
+        if (PyObject_GetOptionalAttr(obj, state->target, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -7135,7 +7135,7 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, state->iter, &tmp) < 0) {
+        if (PyObject_GetOptionalAttr(obj, state->iter, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -7152,7 +7152,7 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, state->body, &tmp) < 0) {
+        if (PyObject_GetOptionalAttr(obj, state->body, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -7190,7 +7190,7 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
             }
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, state->orelse, &tmp) < 0) {
+        if (PyObject_GetOptionalAttr(obj, state->orelse, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -7228,7 +7228,7 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
             }
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, state->type_comment, &tmp) < 0) {
+        if (PyObject_GetOptionalAttr(obj, state->type_comment, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL || tmp == Py_None) {
@@ -7262,7 +7262,7 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
         asdl_stmt_seq* orelse;
         string type_comment;
 
-        if (_PyObject_LookupAttr(obj, state->target, &tmp) < 0) {
+        if (PyObject_GetOptionalAttr(obj, state->target, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -7279,7 +7279,7 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, state->iter, &tmp) < 0) {
+        if (PyObject_GetOptionalAttr(obj, state->iter, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -7296,7 +7296,7 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, state->body, &tmp) < 0) {
+        if (PyObject_GetOptionalAttr(obj, state->body, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -7334,7 +7334,7 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
             }
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, state->orelse, &tmp) < 0) {
+        if (PyObject_GetOptionalAttr(obj, state->orelse, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -7372,7 +7372,7 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
             }
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, state->type_comment, &tmp) < 0) {
+        if (PyObject_GetOptionalAttr(obj, state->type_comment, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL || tmp == Py_None) {
@@ -7405,7 +7405,7 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
         asdl_stmt_seq* body;
         asdl_stmt_seq* orelse;
 
-        if (_PyObject_LookupAttr(obj, state->test, &tmp) < 0) {
+        if (PyObject_GetOptionalAttr(obj, state->test, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -7422,7 +7422,7 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, state->body, &tmp) < 0) {
+        if (PyObject_GetOptionalAttr(obj, state->body, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -7460,7 +7460,7 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
             }
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, state->orelse, &tmp) < 0) {
+        if (PyObject_GetOptionalAttr(obj, state->orelse, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -7513,7 +7513,7 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
         asdl_stmt_seq* body;
         asdl_stmt_seq* orelse;
 
-        if (_PyObject_LookupAttr(obj, state->test, &tmp) < 0) {
+        if (PyObject_GetOptionalAttr(obj, state->test, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -7530,7 +7530,7 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, state->body, &tmp) < 0) {
+        if (PyObject_GetOptionalAttr(obj, state->body, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -7568,7 +7568,7 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
             }
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, state->orelse, &tmp) < 0) {
+        if (PyObject_GetOptionalAttr(obj, state->orelse, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -7621,7 +7621,7 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
         asdl_stmt_seq* body;
         string type_comment;
 
-        if (_PyObject_LookupAttr(obj, state->items, &tmp) < 0) {
+        if (PyObject_GetOptionalAttr(obj, state->items, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -7659,7 +7659,7 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
             }
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, state->body, &tmp) < 0) {
+        if (PyObject_GetOptionalAttr(obj, state->body, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -7697,7 +7697,7 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
             }
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, state->type_comment, &tmp) < 0) {
+        if (PyObject_GetOptionalAttr(obj, state->type_comment, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL || tmp == Py_None) {
@@ -7729,7 +7729,7 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
         asdl_stmt_seq* body;
         string type_comment;
 
-        if (_PyObject_LookupAttr(obj, state->items, &tmp) < 0) {
+        if (PyObject_GetOptionalAttr(obj, state->items, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -7767,7 +7767,7 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
             }
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, state->body, &tmp) < 0) {
+        if (PyObject_GetOptionalAttr(obj, state->body, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -7805,7 +7805,7 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
             }
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, state->type_comment, &tmp) < 0) {
+        if (PyObject_GetOptionalAttr(obj, state->type_comment, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL || tmp == Py_None) {
@@ -7836,7 +7836,7 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
         expr_ty subject;
         asdl_match_case_seq* cases;
 
-        if (_PyObject_LookupAttr(obj, state->subject, &tmp) < 0) {
+        if (PyObject_GetOptionalAttr(obj, state->subject, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -7853,7 +7853,7 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, state->cases, &tmp) < 0) {
+        if (PyObject_GetOptionalAttr(obj, state->cases, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -7905,7 +7905,7 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
         expr_ty exc;
         expr_ty cause;
 
-        if (_PyObject_LookupAttr(obj, state->exc, &tmp) < 0) {
+        if (PyObject_GetOptionalAttr(obj, state->exc, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL || tmp == Py_None) {
@@ -7922,7 +7922,7 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, state->cause, &tmp) < 0) {
+        if (PyObject_GetOptionalAttr(obj, state->cause, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL || tmp == Py_None) {
@@ -7955,7 +7955,7 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
         asdl_stmt_seq* orelse;
         asdl_stmt_seq* finalbody;
 
-        if (_PyObject_LookupAttr(obj, state->body, &tmp) < 0) {
+        if (PyObject_GetOptionalAttr(obj, state->body, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -7993,7 +7993,7 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
             }
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, state->handlers, &tmp) < 0) {
+        if (PyObject_GetOptionalAttr(obj, state->handlers, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -8031,7 +8031,7 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
             }
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, state->orelse, &tmp) < 0) {
+        if (PyObject_GetOptionalAttr(obj, state->orelse, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -8069,7 +8069,7 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
             }
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, state->finalbody, &tmp) < 0) {
+        if (PyObject_GetOptionalAttr(obj, state->finalbody, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -8123,7 +8123,7 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
         asdl_stmt_seq* orelse;
         asdl_stmt_seq* finalbody;
 
-        if (_PyObject_LookupAttr(obj, state->body, &tmp) < 0) {
+        if (PyObject_GetOptionalAttr(obj, state->body, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -8161,7 +8161,7 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
             }
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, state->handlers, &tmp) < 0) {
+        if (PyObject_GetOptionalAttr(obj, state->handlers, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -8199,7 +8199,7 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
             }
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, state->orelse, &tmp) < 0) {
+        if (PyObject_GetOptionalAttr(obj, state->orelse, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -8237,7 +8237,7 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
             }
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, state->finalbody, &tmp) < 0) {
+        if (PyObject_GetOptionalAttr(obj, state->finalbody, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -8289,7 +8289,7 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
         expr_ty test;
         expr_ty msg;
 
-        if (_PyObject_LookupAttr(obj, state->test, &tmp) < 0) {
+        if (PyObject_GetOptionalAttr(obj, state->test, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -8306,7 +8306,7 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, state->msg, &tmp) < 0) {
+        if (PyObject_GetOptionalAttr(obj, state->msg, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL || tmp == Py_None) {
@@ -8336,7 +8336,7 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
     if (isinstance) {
         asdl_alias_seq* names;
 
-        if (_PyObject_LookupAttr(obj, state->names, &tmp) < 0) {
+        if (PyObject_GetOptionalAttr(obj, state->names, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -8389,7 +8389,7 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
         asdl_alias_seq* names;
         int level;
 
-        if (_PyObject_LookupAttr(obj, state->module, &tmp) < 0) {
+        if (PyObject_GetOptionalAttr(obj, state->module, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL || tmp == Py_None) {
@@ -8406,7 +8406,7 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, state->names, &tmp) < 0) {
+        if (PyObject_GetOptionalAttr(obj, state->names, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -8444,7 +8444,7 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
             }
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, state->level, &tmp) < 0) {
+        if (PyObject_GetOptionalAttr(obj, state->level, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL || tmp == Py_None) {
@@ -8474,7 +8474,7 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
     if (isinstance) {
         asdl_identifier_seq* names;
 
-        if (_PyObject_LookupAttr(obj, state->names, &tmp) < 0) {
+        if (PyObject_GetOptionalAttr(obj, state->names, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -8525,7 +8525,7 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
     if (isinstance) {
         asdl_identifier_seq* names;
 
-        if (_PyObject_LookupAttr(obj, state->names, &tmp) < 0) {
+        if (PyObject_GetOptionalAttr(obj, state->names, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -8576,7 +8576,7 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
     if (isinstance) {
         expr_ty value;
 
-        if (_PyObject_LookupAttr(obj, state->value, &tmp) < 0) {
+        if (PyObject_GetOptionalAttr(obj, state->value, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -8658,7 +8658,7 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
         *out = NULL;
         return 0;
     }
-    if (_PyObject_LookupAttr(obj, state->lineno, &tmp) < 0) {
+    if (PyObject_GetOptionalAttr(obj, state->lineno, &tmp) < 0) {
         return 1;
     }
     if (tmp == NULL) {
@@ -8675,7 +8675,7 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
-    if (_PyObject_LookupAttr(obj, state->col_offset, &tmp) < 0) {
+    if (PyObject_GetOptionalAttr(obj, state->col_offset, &tmp) < 0) {
         return 1;
     }
     if (tmp == NULL) {
@@ -8692,7 +8692,7 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
-    if (_PyObject_LookupAttr(obj, state->end_lineno, &tmp) < 0) {
+    if (PyObject_GetOptionalAttr(obj, state->end_lineno, &tmp) < 0) {
         return 1;
     }
     if (tmp == NULL || tmp == Py_None) {
@@ -8709,7 +8709,7 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
-    if (_PyObject_LookupAttr(obj, state->end_col_offset, &tmp) < 0) {
+    if (PyObject_GetOptionalAttr(obj, state->end_col_offset, &tmp) < 0) {
         return 1;
     }
     if (tmp == NULL || tmp == Py_None) {
@@ -8735,7 +8735,7 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
         boolop_ty op;
         asdl_expr_seq* values;
 
-        if (_PyObject_LookupAttr(obj, state->op, &tmp) < 0) {
+        if (PyObject_GetOptionalAttr(obj, state->op, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -8752,7 +8752,7 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, state->values, &tmp) < 0) {
+        if (PyObject_GetOptionalAttr(obj, state->values, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -8804,7 +8804,7 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
         expr_ty target;
         expr_ty value;
 
-        if (_PyObject_LookupAttr(obj, state->target, &tmp) < 0) {
+        if (PyObject_GetOptionalAttr(obj, state->target, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -8821,7 +8821,7 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, state->value, &tmp) < 0) {
+        if (PyObject_GetOptionalAttr(obj, state->value, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -8853,7 +8853,7 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
         operator_ty op;
         expr_ty right;
 
-        if (_PyObject_LookupAttr(obj, state->left, &tmp) < 0) {
+        if (PyObject_GetOptionalAttr(obj, state->left, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -8870,7 +8870,7 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, state->op, &tmp) < 0) {
+        if (PyObject_GetOptionalAttr(obj, state->op, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -8887,7 +8887,7 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, state->right, &tmp) < 0) {
+        if (PyObject_GetOptionalAttr(obj, state->right, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -8918,7 +8918,7 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
         unaryop_ty op;
         expr_ty operand;
 
-        if (_PyObject_LookupAttr(obj, state->op, &tmp) < 0) {
+        if (PyObject_GetOptionalAttr(obj, state->op, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -8935,7 +8935,7 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, state->operand, &tmp) < 0) {
+        if (PyObject_GetOptionalAttr(obj, state->operand, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -8966,7 +8966,7 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
         arguments_ty args;
         expr_ty body;
 
-        if (_PyObject_LookupAttr(obj, state->args, &tmp) < 0) {
+        if (PyObject_GetOptionalAttr(obj, state->args, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -8983,7 +8983,7 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, state->body, &tmp) < 0) {
+        if (PyObject_GetOptionalAttr(obj, state->body, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -9015,7 +9015,7 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
         expr_ty body;
         expr_ty orelse;
 
-        if (_PyObject_LookupAttr(obj, state->test, &tmp) < 0) {
+        if (PyObject_GetOptionalAttr(obj, state->test, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -9032,7 +9032,7 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, state->body, &tmp) < 0) {
+        if (PyObject_GetOptionalAttr(obj, state->body, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -9049,7 +9049,7 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, state->orelse, &tmp) < 0) {
+        if (PyObject_GetOptionalAttr(obj, state->orelse, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -9080,7 +9080,7 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
         asdl_expr_seq* keys;
         asdl_expr_seq* values;
 
-        if (_PyObject_LookupAttr(obj, state->keys, &tmp) < 0) {
+        if (PyObject_GetOptionalAttr(obj, state->keys, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -9118,7 +9118,7 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
             }
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, state->values, &tmp) < 0) {
+        if (PyObject_GetOptionalAttr(obj, state->values, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -9169,7 +9169,7 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
     if (isinstance) {
         asdl_expr_seq* elts;
 
-        if (_PyObject_LookupAttr(obj, state->elts, &tmp) < 0) {
+        if (PyObject_GetOptionalAttr(obj, state->elts, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -9221,7 +9221,7 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
         expr_ty elt;
         asdl_comprehension_seq* generators;
 
-        if (_PyObject_LookupAttr(obj, state->elt, &tmp) < 0) {
+        if (PyObject_GetOptionalAttr(obj, state->elt, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -9238,7 +9238,7 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, state->generators, &tmp) < 0) {
+        if (PyObject_GetOptionalAttr(obj, state->generators, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -9290,7 +9290,7 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
         expr_ty elt;
         asdl_comprehension_seq* generators;
 
-        if (_PyObject_LookupAttr(obj, state->elt, &tmp) < 0) {
+        if (PyObject_GetOptionalAttr(obj, state->elt, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -9307,7 +9307,7 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, state->generators, &tmp) < 0) {
+        if (PyObject_GetOptionalAttr(obj, state->generators, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -9360,7 +9360,7 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
         expr_ty value;
         asdl_comprehension_seq* generators;
 
-        if (_PyObject_LookupAttr(obj, state->key, &tmp) < 0) {
+        if (PyObject_GetOptionalAttr(obj, state->key, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -9377,7 +9377,7 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, state->value, &tmp) < 0) {
+        if (PyObject_GetOptionalAttr(obj, state->value, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -9394,7 +9394,7 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, state->generators, &tmp) < 0) {
+        if (PyObject_GetOptionalAttr(obj, state->generators, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -9446,7 +9446,7 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
         expr_ty elt;
         asdl_comprehension_seq* generators;
 
-        if (_PyObject_LookupAttr(obj, state->elt, &tmp) < 0) {
+        if (PyObject_GetOptionalAttr(obj, state->elt, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -9463,7 +9463,7 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, state->generators, &tmp) < 0) {
+        if (PyObject_GetOptionalAttr(obj, state->generators, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -9514,7 +9514,7 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
     if (isinstance) {
         expr_ty value;
 
-        if (_PyObject_LookupAttr(obj, state->value, &tmp) < 0) {
+        if (PyObject_GetOptionalAttr(obj, state->value, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -9544,7 +9544,7 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
     if (isinstance) {
         expr_ty value;
 
-        if (_PyObject_LookupAttr(obj, state->value, &tmp) < 0) {
+        if (PyObject_GetOptionalAttr(obj, state->value, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL || tmp == Py_None) {
@@ -9574,7 +9574,7 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
     if (isinstance) {
         expr_ty value;
 
-        if (_PyObject_LookupAttr(obj, state->value, &tmp) < 0) {
+        if (PyObject_GetOptionalAttr(obj, state->value, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -9606,7 +9606,7 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
         asdl_int_seq* ops;
         asdl_expr_seq* comparators;
 
-        if (_PyObject_LookupAttr(obj, state->left, &tmp) < 0) {
+        if (PyObject_GetOptionalAttr(obj, state->left, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -9623,7 +9623,7 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, state->ops, &tmp) < 0) {
+        if (PyObject_GetOptionalAttr(obj, state->ops, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -9661,7 +9661,7 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
             }
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, state->comparators, &tmp) < 0) {
+        if (PyObject_GetOptionalAttr(obj, state->comparators, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -9714,7 +9714,7 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
         asdl_expr_seq* args;
         asdl_keyword_seq* keywords;
 
-        if (_PyObject_LookupAttr(obj, state->func, &tmp) < 0) {
+        if (PyObject_GetOptionalAttr(obj, state->func, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -9731,7 +9731,7 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, state->args, &tmp) < 0) {
+        if (PyObject_GetOptionalAttr(obj, state->args, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -9769,7 +9769,7 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
             }
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, state->keywords, &tmp) < 0) {
+        if (PyObject_GetOptionalAttr(obj, state->keywords, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -9822,7 +9822,7 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
         int conversion;
         expr_ty format_spec;
 
-        if (_PyObject_LookupAttr(obj, state->value, &tmp) < 0) {
+        if (PyObject_GetOptionalAttr(obj, state->value, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -9839,7 +9839,7 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, state->conversion, &tmp) < 0) {
+        if (PyObject_GetOptionalAttr(obj, state->conversion, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -9856,7 +9856,7 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, state->format_spec, &tmp) < 0) {
+        if (PyObject_GetOptionalAttr(obj, state->format_spec, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL || tmp == Py_None) {
@@ -9887,7 +9887,7 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
     if (isinstance) {
         asdl_expr_seq* values;
 
-        if (_PyObject_LookupAttr(obj, state->values, &tmp) < 0) {
+        if (PyObject_GetOptionalAttr(obj, state->values, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -9939,7 +9939,7 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
         constant value;
         string kind;
 
-        if (_PyObject_LookupAttr(obj, state->value, &tmp) < 0) {
+        if (PyObject_GetOptionalAttr(obj, state->value, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -9956,7 +9956,7 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, state->kind, &tmp) < 0) {
+        if (PyObject_GetOptionalAttr(obj, state->kind, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL || tmp == Py_None) {
@@ -9988,7 +9988,7 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
         identifier attr;
         expr_context_ty ctx;
 
-        if (_PyObject_LookupAttr(obj, state->value, &tmp) < 0) {
+        if (PyObject_GetOptionalAttr(obj, state->value, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -10005,7 +10005,7 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, state->attr, &tmp) < 0) {
+        if (PyObject_GetOptionalAttr(obj, state->attr, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -10022,7 +10022,7 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, state->ctx, &tmp) < 0) {
+        if (PyObject_GetOptionalAttr(obj, state->ctx, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -10054,7 +10054,7 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
         expr_ty slice;
         expr_context_ty ctx;
 
-        if (_PyObject_LookupAttr(obj, state->value, &tmp) < 0) {
+        if (PyObject_GetOptionalAttr(obj, state->value, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -10071,7 +10071,7 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, state->slice, &tmp) < 0) {
+        if (PyObject_GetOptionalAttr(obj, state->slice, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -10088,7 +10088,7 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, state->ctx, &tmp) < 0) {
+        if (PyObject_GetOptionalAttr(obj, state->ctx, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -10119,7 +10119,7 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
         expr_ty value;
         expr_context_ty ctx;
 
-        if (_PyObject_LookupAttr(obj, state->value, &tmp) < 0) {
+        if (PyObject_GetOptionalAttr(obj, state->value, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -10136,7 +10136,7 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, state->ctx, &tmp) < 0) {
+        if (PyObject_GetOptionalAttr(obj, state->ctx, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -10167,7 +10167,7 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
         identifier id;
         expr_context_ty ctx;
 
-        if (_PyObject_LookupAttr(obj, state->id, &tmp) < 0) {
+        if (PyObject_GetOptionalAttr(obj, state->id, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -10184,7 +10184,7 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, state->ctx, &tmp) < 0) {
+        if (PyObject_GetOptionalAttr(obj, state->ctx, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -10215,7 +10215,7 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
         asdl_expr_seq* elts;
         expr_context_ty ctx;
 
-        if (_PyObject_LookupAttr(obj, state->elts, &tmp) < 0) {
+        if (PyObject_GetOptionalAttr(obj, state->elts, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -10253,7 +10253,7 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
             }
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, state->ctx, &tmp) < 0) {
+        if (PyObject_GetOptionalAttr(obj, state->ctx, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -10284,7 +10284,7 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
         asdl_expr_seq* elts;
         expr_context_ty ctx;
 
-        if (_PyObject_LookupAttr(obj, state->elts, &tmp) < 0) {
+        if (PyObject_GetOptionalAttr(obj, state->elts, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -10322,7 +10322,7 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
             }
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, state->ctx, &tmp) < 0) {
+        if (PyObject_GetOptionalAttr(obj, state->ctx, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -10354,7 +10354,7 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
         expr_ty upper;
         expr_ty step;
 
-        if (_PyObject_LookupAttr(obj, state->lower, &tmp) < 0) {
+        if (PyObject_GetOptionalAttr(obj, state->lower, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL || tmp == Py_None) {
@@ -10371,7 +10371,7 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, state->upper, &tmp) < 0) {
+        if (PyObject_GetOptionalAttr(obj, state->upper, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL || tmp == Py_None) {
@@ -10388,7 +10388,7 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, state->step, &tmp) < 0) {
+        if (PyObject_GetOptionalAttr(obj, state->step, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL || tmp == Py_None) {
@@ -10738,7 +10738,7 @@ obj2ast_comprehension(struct ast_state *state, PyObject* obj, comprehension_ty*
     asdl_expr_seq* ifs;
     int is_async;
 
-    if (_PyObject_LookupAttr(obj, state->target, &tmp) < 0) {
+    if (PyObject_GetOptionalAttr(obj, state->target, &tmp) < 0) {
         return 1;
     }
     if (tmp == NULL) {
@@ -10755,7 +10755,7 @@ obj2ast_comprehension(struct ast_state *state, PyObject* obj, comprehension_ty*
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
-    if (_PyObject_LookupAttr(obj, state->iter, &tmp) < 0) {
+    if (PyObject_GetOptionalAttr(obj, state->iter, &tmp) < 0) {
         return 1;
     }
     if (tmp == NULL) {
@@ -10772,7 +10772,7 @@ obj2ast_comprehension(struct ast_state *state, PyObject* obj, comprehension_ty*
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
-    if (_PyObject_LookupAttr(obj, state->ifs, &tmp) < 0) {
+    if (PyObject_GetOptionalAttr(obj, state->ifs, &tmp) < 0) {
         return 1;
     }
     if (tmp == NULL) {
@@ -10810,7 +10810,7 @@ obj2ast_comprehension(struct ast_state *state, PyObject* obj, comprehension_ty*
         }
         Py_CLEAR(tmp);
     }
-    if (_PyObject_LookupAttr(obj, state->is_async, &tmp) < 0) {
+    if (PyObject_GetOptionalAttr(obj, state->is_async, &tmp) < 0) {
         return 1;
     }
     if (tmp == NULL) {
@@ -10852,7 +10852,7 @@ obj2ast_excepthandler(struct ast_state *state, PyObject* obj, excepthandler_ty*
         *out = NULL;
         return 0;
     }
-    if (_PyObject_LookupAttr(obj, state->lineno, &tmp) < 0) {
+    if (PyObject_GetOptionalAttr(obj, state->lineno, &tmp) < 0) {
         return 1;
     }
     if (tmp == NULL) {
@@ -10869,7 +10869,7 @@ obj2ast_excepthandler(struct ast_state *state, PyObject* obj, excepthandler_ty*
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
-    if (_PyObject_LookupAttr(obj, state->col_offset, &tmp) < 0) {
+    if (PyObject_GetOptionalAttr(obj, state->col_offset, &tmp) < 0) {
         return 1;
     }
     if (tmp == NULL) {
@@ -10886,7 +10886,7 @@ obj2ast_excepthandler(struct ast_state *state, PyObject* obj, excepthandler_ty*
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
-    if (_PyObject_LookupAttr(obj, state->end_lineno, &tmp) < 0) {
+    if (PyObject_GetOptionalAttr(obj, state->end_lineno, &tmp) < 0) {
         return 1;
     }
     if (tmp == NULL || tmp == Py_None) {
@@ -10903,7 +10903,7 @@ obj2ast_excepthandler(struct ast_state *state, PyObject* obj, excepthandler_ty*
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
-    if (_PyObject_LookupAttr(obj, state->end_col_offset, &tmp) < 0) {
+    if (PyObject_GetOptionalAttr(obj, state->end_col_offset, &tmp) < 0) {
         return 1;
     }
     if (tmp == NULL || tmp == Py_None) {
@@ -10930,7 +10930,7 @@ obj2ast_excepthandler(struct ast_state *state, PyObject* obj, excepthandler_ty*
         identifier name;
         asdl_stmt_seq* body;
 
-        if (_PyObject_LookupAttr(obj, state->type, &tmp) < 0) {
+        if (PyObject_GetOptionalAttr(obj, state->type, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL || tmp == Py_None) {
@@ -10947,7 +10947,7 @@ obj2ast_excepthandler(struct ast_state *state, PyObject* obj, excepthandler_ty*
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, state->name, &tmp) < 0) {
+        if (PyObject_GetOptionalAttr(obj, state->name, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL || tmp == Py_None) {
@@ -10964,7 +10964,7 @@ obj2ast_excepthandler(struct ast_state *state, PyObject* obj, excepthandler_ty*
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, state->body, &tmp) < 0) {
+        if (PyObject_GetOptionalAttr(obj, state->body, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -11027,7 +11027,7 @@ obj2ast_arguments(struct ast_state *state, PyObject* obj, arguments_ty* out,
     arg_ty kwarg;
     asdl_expr_seq* defaults;
 
-    if (_PyObject_LookupAttr(obj, state->posonlyargs, &tmp) < 0) {
+    if (PyObject_GetOptionalAttr(obj, state->posonlyargs, &tmp) < 0) {
         return 1;
     }
     if (tmp == NULL) {
@@ -11065,7 +11065,7 @@ obj2ast_arguments(struct ast_state *state, PyObject* obj, arguments_ty* out,
         }
         Py_CLEAR(tmp);
     }
-    if (_PyObject_LookupAttr(obj, state->args, &tmp) < 0) {
+    if (PyObject_GetOptionalAttr(obj, state->args, &tmp) < 0) {
         return 1;
     }
     if (tmp == NULL) {
@@ -11103,7 +11103,7 @@ obj2ast_arguments(struct ast_state *state, PyObject* obj, arguments_ty* out,
         }
         Py_CLEAR(tmp);
     }
-    if (_PyObject_LookupAttr(obj, state->vararg, &tmp) < 0) {
+    if (PyObject_GetOptionalAttr(obj, state->vararg, &tmp) < 0) {
         return 1;
     }
     if (tmp == NULL || tmp == Py_None) {
@@ -11120,7 +11120,7 @@ obj2ast_arguments(struct ast_state *state, PyObject* obj, arguments_ty* out,
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
-    if (_PyObject_LookupAttr(obj, state->kwonlyargs, &tmp) < 0) {
+    if (PyObject_GetOptionalAttr(obj, state->kwonlyargs, &tmp) < 0) {
         return 1;
     }
     if (tmp == NULL) {
@@ -11158,7 +11158,7 @@ obj2ast_arguments(struct ast_state *state, PyObject* obj, arguments_ty* out,
         }
         Py_CLEAR(tmp);
     }
-    if (_PyObject_LookupAttr(obj, state->kw_defaults, &tmp) < 0) {
+    if (PyObject_GetOptionalAttr(obj, state->kw_defaults, &tmp) < 0) {
         return 1;
     }
     if (tmp == NULL) {
@@ -11196,7 +11196,7 @@ obj2ast_arguments(struct ast_state *state, PyObject* obj, arguments_ty* out,
         }
         Py_CLEAR(tmp);
     }
-    if (_PyObject_LookupAttr(obj, state->kwarg, &tmp) < 0) {
+    if (PyObject_GetOptionalAttr(obj, state->kwarg, &tmp) < 0) {
         return 1;
     }
     if (tmp == NULL || tmp == Py_None) {
@@ -11213,7 +11213,7 @@ obj2ast_arguments(struct ast_state *state, PyObject* obj, arguments_ty* out,
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
-    if (_PyObject_LookupAttr(obj, state->defaults, &tmp) < 0) {
+    if (PyObject_GetOptionalAttr(obj, state->defaults, &tmp) < 0) {
         return 1;
     }
     if (tmp == NULL) {
@@ -11272,7 +11272,7 @@ obj2ast_arg(struct ast_state *state, PyObject* obj, arg_ty* out, PyArena* arena)
     int end_lineno;
     int end_col_offset;
 
-    if (_PyObject_LookupAttr(obj, state->arg, &tmp) < 0) {
+    if (PyObject_GetOptionalAttr(obj, state->arg, &tmp) < 0) {
         return 1;
     }
     if (tmp == NULL) {
@@ -11289,7 +11289,7 @@ obj2ast_arg(struct ast_state *state, PyObject* obj, arg_ty* out, PyArena* arena)
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
-    if (_PyObject_LookupAttr(obj, state->annotation, &tmp) < 0) {
+    if (PyObject_GetOptionalAttr(obj, state->annotation, &tmp) < 0) {
         return 1;
     }
     if (tmp == NULL || tmp == Py_None) {
@@ -11306,7 +11306,7 @@ obj2ast_arg(struct ast_state *state, PyObject* obj, arg_ty* out, PyArena* arena)
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
-    if (_PyObject_LookupAttr(obj, state->type_comment, &tmp) < 0) {
+    if (PyObject_GetOptionalAttr(obj, state->type_comment, &tmp) < 0) {
         return 1;
     }
     if (tmp == NULL || tmp == Py_None) {
@@ -11323,7 +11323,7 @@ obj2ast_arg(struct ast_state *state, PyObject* obj, arg_ty* out, PyArena* arena)
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
-    if (_PyObject_LookupAttr(obj, state->lineno, &tmp) < 0) {
+    if (PyObject_GetOptionalAttr(obj, state->lineno, &tmp) < 0) {
         return 1;
     }
     if (tmp == NULL) {
@@ -11340,7 +11340,7 @@ obj2ast_arg(struct ast_state *state, PyObject* obj, arg_ty* out, PyArena* arena)
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
-    if (_PyObject_LookupAttr(obj, state->col_offset, &tmp) < 0) {
+    if (PyObject_GetOptionalAttr(obj, state->col_offset, &tmp) < 0) {
         return 1;
     }
     if (tmp == NULL) {
@@ -11357,7 +11357,7 @@ obj2ast_arg(struct ast_state *state, PyObject* obj, arg_ty* out, PyArena* arena)
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
-    if (_PyObject_LookupAttr(obj, state->end_lineno, &tmp) < 0) {
+    if (PyObject_GetOptionalAttr(obj, state->end_lineno, &tmp) < 0) {
         return 1;
     }
     if (tmp == NULL || tmp == Py_None) {
@@ -11374,7 +11374,7 @@ obj2ast_arg(struct ast_state *state, PyObject* obj, arg_ty* out, PyArena* arena)
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
-    if (_PyObject_LookupAttr(obj, state->end_col_offset, &tmp) < 0) {
+    if (PyObject_GetOptionalAttr(obj, state->end_col_offset, &tmp) < 0) {
         return 1;
     }
     if (tmp == NULL || tmp == Py_None) {
@@ -11412,7 +11412,7 @@ obj2ast_keyword(struct ast_state *state, PyObject* obj, keyword_ty* out,
     int end_lineno;
     int end_col_offset;
 
-    if (_PyObject_LookupAttr(obj, state->arg, &tmp) < 0) {
+    if (PyObject_GetOptionalAttr(obj, state->arg, &tmp) < 0) {
         return 1;
     }
     if (tmp == NULL || tmp == Py_None) {
@@ -11429,7 +11429,7 @@ obj2ast_keyword(struct ast_state *state, PyObject* obj, keyword_ty* out,
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
-    if (_PyObject_LookupAttr(obj, state->value, &tmp) < 0) {
+    if (PyObject_GetOptionalAttr(obj, state->value, &tmp) < 0) {
         return 1;
     }
     if (tmp == NULL) {
@@ -11446,7 +11446,7 @@ obj2ast_keyword(struct ast_state *state, PyObject* obj, keyword_ty* out,
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
-    if (_PyObject_LookupAttr(obj, state->lineno, &tmp) < 0) {
+    if (PyObject_GetOptionalAttr(obj, state->lineno, &tmp) < 0) {
         return 1;
     }
     if (tmp == NULL) {
@@ -11463,7 +11463,7 @@ obj2ast_keyword(struct ast_state *state, PyObject* obj, keyword_ty* out,
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
-    if (_PyObject_LookupAttr(obj, state->col_offset, &tmp) < 0) {
+    if (PyObject_GetOptionalAttr(obj, state->col_offset, &tmp) < 0) {
         return 1;
     }
     if (tmp == NULL) {
@@ -11480,7 +11480,7 @@ obj2ast_keyword(struct ast_state *state, PyObject* obj, keyword_ty* out,
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
-    if (_PyObject_LookupAttr(obj, state->end_lineno, &tmp) < 0) {
+    if (PyObject_GetOptionalAttr(obj, state->end_lineno, &tmp) < 0) {
         return 1;
     }
     if (tmp == NULL || tmp == Py_None) {
@@ -11497,7 +11497,7 @@ obj2ast_keyword(struct ast_state *state, PyObject* obj, keyword_ty* out,
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
-    if (_PyObject_LookupAttr(obj, state->end_col_offset, &tmp) < 0) {
+    if (PyObject_GetOptionalAttr(obj, state->end_col_offset, &tmp) < 0) {
         return 1;
     }
     if (tmp == NULL || tmp == Py_None) {
@@ -11535,7 +11535,7 @@ obj2ast_alias(struct ast_state *state, PyObject* obj, alias_ty* out, PyArena*
     int end_lineno;
     int end_col_offset;
 
-    if (_PyObject_LookupAttr(obj, state->name, &tmp) < 0) {
+    if (PyObject_GetOptionalAttr(obj, state->name, &tmp) < 0) {
         return 1;
     }
     if (tmp == NULL) {
@@ -11552,7 +11552,7 @@ obj2ast_alias(struct ast_state *state, PyObject* obj, alias_ty* out, PyArena*
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
-    if (_PyObject_LookupAttr(obj, state->asname, &tmp) < 0) {
+    if (PyObject_GetOptionalAttr(obj, state->asname, &tmp) < 0) {
         return 1;
     }
     if (tmp == NULL || tmp == Py_None) {
@@ -11569,7 +11569,7 @@ obj2ast_alias(struct ast_state *state, PyObject* obj, alias_ty* out, PyArena*
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
-    if (_PyObject_LookupAttr(obj, state->lineno, &tmp) < 0) {
+    if (PyObject_GetOptionalAttr(obj, state->lineno, &tmp) < 0) {
         return 1;
     }
     if (tmp == NULL) {
@@ -11586,7 +11586,7 @@ obj2ast_alias(struct ast_state *state, PyObject* obj, alias_ty* out, PyArena*
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
-    if (_PyObject_LookupAttr(obj, state->col_offset, &tmp) < 0) {
+    if (PyObject_GetOptionalAttr(obj, state->col_offset, &tmp) < 0) {
         return 1;
     }
     if (tmp == NULL) {
@@ -11603,7 +11603,7 @@ obj2ast_alias(struct ast_state *state, PyObject* obj, alias_ty* out, PyArena*
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
-    if (_PyObject_LookupAttr(obj, state->end_lineno, &tmp) < 0) {
+    if (PyObject_GetOptionalAttr(obj, state->end_lineno, &tmp) < 0) {
         return 1;
     }
     if (tmp == NULL || tmp == Py_None) {
@@ -11620,7 +11620,7 @@ obj2ast_alias(struct ast_state *state, PyObject* obj, alias_ty* out, PyArena*
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
-    if (_PyObject_LookupAttr(obj, state->end_col_offset, &tmp) < 0) {
+    if (PyObject_GetOptionalAttr(obj, state->end_col_offset, &tmp) < 0) {
         return 1;
     }
     if (tmp == NULL || tmp == Py_None) {
@@ -11654,7 +11654,7 @@ obj2ast_withitem(struct ast_state *state, PyObject* obj, withitem_ty* out,
     expr_ty context_expr;
     expr_ty optional_vars;
 
-    if (_PyObject_LookupAttr(obj, state->context_expr, &tmp) < 0) {
+    if (PyObject_GetOptionalAttr(obj, state->context_expr, &tmp) < 0) {
         return 1;
     }
     if (tmp == NULL) {
@@ -11671,7 +11671,7 @@ obj2ast_withitem(struct ast_state *state, PyObject* obj, withitem_ty* out,
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
-    if (_PyObject_LookupAttr(obj, state->optional_vars, &tmp) < 0) {
+    if (PyObject_GetOptionalAttr(obj, state->optional_vars, &tmp) < 0) {
         return 1;
     }
     if (tmp == NULL || tmp == Py_None) {
@@ -11705,7 +11705,7 @@ obj2ast_match_case(struct ast_state *state, PyObject* obj, match_case_ty* out,
     expr_ty guard;
     asdl_stmt_seq* body;
 
-    if (_PyObject_LookupAttr(obj, state->pattern, &tmp) < 0) {
+    if (PyObject_GetOptionalAttr(obj, state->pattern, &tmp) < 0) {
         return 1;
     }
     if (tmp == NULL) {
@@ -11722,7 +11722,7 @@ obj2ast_match_case(struct ast_state *state, PyObject* obj, match_case_ty* out,
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
-    if (_PyObject_LookupAttr(obj, state->guard, &tmp) < 0) {
+    if (PyObject_GetOptionalAttr(obj, state->guard, &tmp) < 0) {
         return 1;
     }
     if (tmp == NULL || tmp == Py_None) {
@@ -11739,7 +11739,7 @@ obj2ast_match_case(struct ast_state *state, PyObject* obj, match_case_ty* out,
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
-    if (_PyObject_LookupAttr(obj, state->body, &tmp) < 0) {
+    if (PyObject_GetOptionalAttr(obj, state->body, &tmp) < 0) {
         return 1;
     }
     if (tmp == NULL) {
@@ -11802,7 +11802,7 @@ obj2ast_pattern(struct ast_state *state, PyObject* obj, pattern_ty* out,
         *out = NULL;
         return 0;
     }
-    if (_PyObject_LookupAttr(obj, state->lineno, &tmp) < 0) {
+    if (PyObject_GetOptionalAttr(obj, state->lineno, &tmp) < 0) {
         return 1;
     }
     if (tmp == NULL) {
@@ -11819,7 +11819,7 @@ obj2ast_pattern(struct ast_state *state, PyObject* obj, pattern_ty* out,
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
-    if (_PyObject_LookupAttr(obj, state->col_offset, &tmp) < 0) {
+    if (PyObject_GetOptionalAttr(obj, state->col_offset, &tmp) < 0) {
         return 1;
     }
     if (tmp == NULL) {
@@ -11836,7 +11836,7 @@ obj2ast_pattern(struct ast_state *state, PyObject* obj, pattern_ty* out,
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
-    if (_PyObject_LookupAttr(obj, state->end_lineno, &tmp) < 0) {
+    if (PyObject_GetOptionalAttr(obj, state->end_lineno, &tmp) < 0) {
         return 1;
     }
     if (tmp == NULL) {
@@ -11853,7 +11853,7 @@ obj2ast_pattern(struct ast_state *state, PyObject* obj, pattern_ty* out,
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
-    if (_PyObject_LookupAttr(obj, state->end_col_offset, &tmp) < 0) {
+    if (PyObject_GetOptionalAttr(obj, state->end_col_offset, &tmp) < 0) {
         return 1;
     }
     if (tmp == NULL) {
@@ -11878,7 +11878,7 @@ obj2ast_pattern(struct ast_state *state, PyObject* obj, pattern_ty* out,
     if (isinstance) {
         expr_ty value;
 
-        if (_PyObject_LookupAttr(obj, state->value, &tmp) < 0) {
+        if (PyObject_GetOptionalAttr(obj, state->value, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -11908,7 +11908,7 @@ obj2ast_pattern(struct ast_state *state, PyObject* obj, pattern_ty* out,
     if (isinstance) {
         constant value;
 
-        if (_PyObject_LookupAttr(obj, state->value, &tmp) < 0) {
+        if (PyObject_GetOptionalAttr(obj, state->value, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -11938,7 +11938,7 @@ obj2ast_pattern(struct ast_state *state, PyObject* obj, pattern_ty* out,
     if (isinstance) {
         asdl_pattern_seq* patterns;
 
-        if (_PyObject_LookupAttr(obj, state->patterns, &tmp) < 0) {
+        if (PyObject_GetOptionalAttr(obj, state->patterns, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -11991,7 +11991,7 @@ obj2ast_pattern(struct ast_state *state, PyObject* obj, pattern_ty* out,
         asdl_pattern_seq* patterns;
         identifier rest;
 
-        if (_PyObject_LookupAttr(obj, state->keys, &tmp) < 0) {
+        if (PyObject_GetOptionalAttr(obj, state->keys, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -12029,7 +12029,7 @@ obj2ast_pattern(struct ast_state *state, PyObject* obj, pattern_ty* out,
             }
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, state->patterns, &tmp) < 0) {
+        if (PyObject_GetOptionalAttr(obj, state->patterns, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -12067,7 +12067,7 @@ obj2ast_pattern(struct ast_state *state, PyObject* obj, pattern_ty* out,
             }
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, state->rest, &tmp) < 0) {
+        if (PyObject_GetOptionalAttr(obj, state->rest, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL || tmp == Py_None) {
@@ -12100,7 +12100,7 @@ obj2ast_pattern(struct ast_state *state, PyObject* obj, pattern_ty* out,
         asdl_identifier_seq* kwd_attrs;
         asdl_pattern_seq* kwd_patterns;
 
-        if (_PyObject_LookupAttr(obj, state->cls, &tmp) < 0) {
+        if (PyObject_GetOptionalAttr(obj, state->cls, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -12117,7 +12117,7 @@ obj2ast_pattern(struct ast_state *state, PyObject* obj, pattern_ty* out,
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, state->patterns, &tmp) < 0) {
+        if (PyObject_GetOptionalAttr(obj, state->patterns, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -12155,7 +12155,7 @@ obj2ast_pattern(struct ast_state *state, PyObject* obj, pattern_ty* out,
             }
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, state->kwd_attrs, &tmp) < 0) {
+        if (PyObject_GetOptionalAttr(obj, state->kwd_attrs, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -12193,7 +12193,7 @@ obj2ast_pattern(struct ast_state *state, PyObject* obj, pattern_ty* out,
             }
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, state->kwd_patterns, &tmp) < 0) {
+        if (PyObject_GetOptionalAttr(obj, state->kwd_patterns, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -12245,7 +12245,7 @@ obj2ast_pattern(struct ast_state *state, PyObject* obj, pattern_ty* out,
     if (isinstance) {
         identifier name;
 
-        if (_PyObject_LookupAttr(obj, state->name, &tmp) < 0) {
+        if (PyObject_GetOptionalAttr(obj, state->name, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL || tmp == Py_None) {
@@ -12276,7 +12276,7 @@ obj2ast_pattern(struct ast_state *state, PyObject* obj, pattern_ty* out,
         pattern_ty pattern;
         identifier name;
 
-        if (_PyObject_LookupAttr(obj, state->pattern, &tmp) < 0) {
+        if (PyObject_GetOptionalAttr(obj, state->pattern, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL || tmp == Py_None) {
@@ -12293,7 +12293,7 @@ obj2ast_pattern(struct ast_state *state, PyObject* obj, pattern_ty* out,
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, state->name, &tmp) < 0) {
+        if (PyObject_GetOptionalAttr(obj, state->name, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL || tmp == Py_None) {
@@ -12323,7 +12323,7 @@ obj2ast_pattern(struct ast_state *state, PyObject* obj, pattern_ty* out,
     if (isinstance) {
         asdl_pattern_seq* patterns;
 
-        if (_PyObject_LookupAttr(obj, state->patterns, &tmp) < 0) {
+        if (PyObject_GetOptionalAttr(obj, state->patterns, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -12395,7 +12395,7 @@ obj2ast_type_ignore(struct ast_state *state, PyObject* obj, type_ignore_ty*
         int lineno;
         string tag;
 
-        if (_PyObject_LookupAttr(obj, state->lineno, &tmp) < 0) {
+        if (PyObject_GetOptionalAttr(obj, state->lineno, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -12412,7 +12412,7 @@ obj2ast_type_ignore(struct ast_state *state, PyObject* obj, type_ignore_ty*
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, state->tag, &tmp) < 0) {
+        if (PyObject_GetOptionalAttr(obj, state->tag, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -12457,7 +12457,7 @@ obj2ast_type_param(struct ast_state *state, PyObject* obj, type_param_ty* out,
         *out = NULL;
         return 0;
     }
-    if (_PyObject_LookupAttr(obj, state->lineno, &tmp) < 0) {
+    if (PyObject_GetOptionalAttr(obj, state->lineno, &tmp) < 0) {
         return 1;
     }
     if (tmp == NULL) {
@@ -12474,7 +12474,7 @@ obj2ast_type_param(struct ast_state *state, PyObject* obj, type_param_ty* out,
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
-    if (_PyObject_LookupAttr(obj, state->col_offset, &tmp) < 0) {
+    if (PyObject_GetOptionalAttr(obj, state->col_offset, &tmp) < 0) {
         return 1;
     }
     if (tmp == NULL) {
@@ -12491,7 +12491,7 @@ obj2ast_type_param(struct ast_state *state, PyObject* obj, type_param_ty* out,
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
-    if (_PyObject_LookupAttr(obj, state->end_lineno, &tmp) < 0) {
+    if (PyObject_GetOptionalAttr(obj, state->end_lineno, &tmp) < 0) {
         return 1;
     }
     if (tmp == NULL) {
@@ -12508,7 +12508,7 @@ obj2ast_type_param(struct ast_state *state, PyObject* obj, type_param_ty* out,
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
-    if (_PyObject_LookupAttr(obj, state->end_col_offset, &tmp) < 0) {
+    if (PyObject_GetOptionalAttr(obj, state->end_col_offset, &tmp) < 0) {
         return 1;
     }
     if (tmp == NULL) {
@@ -12534,7 +12534,7 @@ obj2ast_type_param(struct ast_state *state, PyObject* obj, type_param_ty* out,
         identifier name;
         expr_ty bound;
 
-        if (_PyObject_LookupAttr(obj, state->name, &tmp) < 0) {
+        if (PyObject_GetOptionalAttr(obj, state->name, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -12551,7 +12551,7 @@ obj2ast_type_param(struct ast_state *state, PyObject* obj, type_param_ty* out,
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, state->bound, &tmp) < 0) {
+        if (PyObject_GetOptionalAttr(obj, state->bound, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL || tmp == Py_None) {
@@ -12581,7 +12581,7 @@ obj2ast_type_param(struct ast_state *state, PyObject* obj, type_param_ty* out,
     if (isinstance) {
         identifier name;
 
-        if (_PyObject_LookupAttr(obj, state->name, &tmp) < 0) {
+        if (PyObject_GetOptionalAttr(obj, state->name, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -12611,7 +12611,7 @@ obj2ast_type_param(struct ast_state *state, PyObject* obj, type_param_ty* out,
     if (isinstance) {
         identifier name;
 
-        if (_PyObject_LookupAttr(obj, state->name, &tmp) < 0) {
+        if (PyObject_GetOptionalAttr(obj, state->name, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {

--- a/Python/_warnings.c
+++ b/Python/_warnings.c
@@ -223,7 +223,7 @@ get_warnings_attr(PyInterpreterState *interp, PyObject *attr, int try_import)
             return NULL;
     }
 
-    (void)_PyObject_LookupAttr(warnings_module, attr, &obj);
+    (void)PyObject_GetOptionalAttr(warnings_module, attr, &obj);
     Py_DECREF(warnings_module);
     return obj;
 }
@@ -1069,7 +1069,7 @@ get_source_line(PyInterpreterState *interp, PyObject *module_globals, int lineno
     Py_INCREF(module_name);
 
     /* Make sure the loader implements the optional get_source() method. */
-    (void)_PyObject_LookupAttr(loader, &_Py_ID(get_source), &get_source);
+    (void)PyObject_GetOptionalAttr(loader, &_Py_ID(get_source), &get_source);
     Py_DECREF(loader);
     if (!get_source) {
         Py_DECREF(module_name);

--- a/Python/bltinmodule.c
+++ b/Python/bltinmodule.c
@@ -34,7 +34,7 @@ update_bases(PyObject *bases, PyObject *const *args, Py_ssize_t nargs)
             }
             continue;
         }
-        if (_PyObject_LookupAttr(base, &_Py_ID(__mro_entries__), &meth) < 0) {
+        if (PyObject_GetOptionalAttr(base, &_Py_ID(__mro_entries__), &meth) < 0) {
             goto error;
         }
         if (!meth) {
@@ -175,7 +175,7 @@ builtin___build_class__(PyObject *self, PyObject *const *args, Py_ssize_t nargs,
     }
     /* else: meta is not a class, so we cannot do the metaclass
        calculation, so we will use the explicitly given object as it is */
-    if (_PyObject_LookupAttr(meta, &_Py_ID(__prepare__), &prep) < 0) {
+    if (PyObject_GetOptionalAttr(meta, &_Py_ID(__prepare__), &prep) < 0) {
         ns = NULL;
     }
     else if (prep == NULL) {
@@ -1160,7 +1160,7 @@ builtin_getattr_impl(PyObject *module, PyObject *object, PyObject *name,
     PyObject *result;
 
     if (default_value != NULL) {
-        if (_PyObject_LookupAttr(object, name, &result) == 0) {
+        if (PyObject_GetOptionalAttr(object, name, &result) == 0) {
             return Py_NewRef(default_value);
         }
     }
@@ -1209,7 +1209,7 @@ builtin_hasattr_impl(PyObject *module, PyObject *obj, PyObject *name)
 {
     PyObject *v;
 
-    if (_PyObject_LookupAttr(obj, name, &v) < 0) {
+    if (PyObject_GetOptionalAttr(obj, name, &v) < 0) {
         return NULL;
     }
     if (v == NULL) {
@@ -2465,7 +2465,7 @@ builtin_vars_impl(PyObject *module, PyObject *object)
         d = _PyEval_GetFrameLocals();
     }
     else {
-        if (_PyObject_LookupAttr(object, &_Py_ID(__dict__), &d) == 0) {
+        if (PyObject_GetOptionalAttr(object, &_Py_ID(__dict__), &d) == 0) {
             PyErr_SetString(PyExc_TypeError,
                 "vars() argument must have __dict__ attribute");
         }

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -419,7 +419,7 @@ match_class_attr(PyThreadState *tstate, PyObject *subject, PyObject *type,
         return NULL;
     }
     PyObject *attr;
-    (void)_PyObject_LookupAttr(subject, name, &attr);
+    (void)PyObject_GetOptionalAttr(subject, name, &attr);
     return attr;
 }
 
@@ -454,7 +454,7 @@ match_class(PyThreadState *tstate, PyObject *subject, PyObject *type,
     // First, the positional subpatterns:
     if (nargs) {
         int match_self = 0;
-        if (_PyObject_LookupAttr(type, &_Py_ID(__match_args__), &match_args) < 0) {
+        if (PyObject_GetOptionalAttr(type, &_Py_ID(__match_args__), &match_args) < 0) {
             goto fail;
         }
         if (match_args) {
@@ -2414,7 +2414,7 @@ import_from(PyThreadState *tstate, PyObject *v, PyObject *name)
     PyObject *x;
     PyObject *fullmodname, *pkgname, *pkgpath, *pkgname_or_unknown, *errmsg;
 
-    if (_PyObject_LookupAttr(v, name, &x) != 0) {
+    if (PyObject_GetOptionalAttr(v, name, &x) != 0) {
         return x;
     }
     /* Issue #17636: in case this failed because of a circular relative

--- a/Python/codecs.c
+++ b/Python/codecs.c
@@ -516,7 +516,7 @@ PyObject * _PyCodec_LookupTextEncoding(const char *encoding,
      * attribute.
      */
     if (!PyTuple_CheckExact(codec)) {
-        if (_PyObject_LookupAttr(codec, &_Py_ID(_is_text_encoding), &attr) < 0) {
+        if (PyObject_GetOptionalAttr(codec, &_Py_ID(_is_text_encoding), &attr) < 0) {
             Py_DECREF(codec);
             return NULL;
         }

--- a/Python/errors.c
+++ b/Python/errors.c
@@ -1748,7 +1748,7 @@ PyErr_SyntaxLocationObjectEx(PyObject *filename, int lineno, int col_offset,
         }
     }
     if ((PyObject *)Py_TYPE(exc) != PyExc_SyntaxError) {
-        if (_PyObject_LookupAttr(exc, &_Py_ID(msg), &tmp) < 0) {
+        if (PyObject_GetOptionalAttr(exc, &_Py_ID(msg), &tmp) < 0) {
             _PyErr_Clear(tstate);
         }
         else if (tmp) {
@@ -1767,7 +1767,7 @@ PyErr_SyntaxLocationObjectEx(PyObject *filename, int lineno, int col_offset,
             }
         }
 
-        if (_PyObject_LookupAttr(exc, &_Py_ID(print_file_and_line), &tmp) < 0) {
+        if (PyObject_GetOptionalAttr(exc, &_Py_ID(print_file_and_line), &tmp) < 0) {
             _PyErr_Clear(tstate);
         }
         else if (tmp) {

--- a/Python/import.c
+++ b/Python/import.c
@@ -2898,7 +2898,7 @@ PyImport_ImportModuleLevelObject(PyObject *name, PyObject *globals,
     }
     else {
         PyObject *path;
-        if (_PyObject_LookupAttr(mod, &_Py_ID(__path__), &path) < 0) {
+        if (PyObject_GetOptionalAttr(mod, &_Py_ID(__path__), &path) < 0) {
             goto error;
         }
         if (path) {

--- a/Python/intrinsics.c
+++ b/Python/intrinsics.c
@@ -40,11 +40,11 @@ import_all_from(PyThreadState *tstate, PyObject *locals, PyObject *v)
     int skip_leading_underscores = 0;
     int pos, err;
 
-    if (_PyObject_LookupAttr(v, &_Py_ID(__all__), &all) < 0) {
+    if (PyObject_GetOptionalAttr(v, &_Py_ID(__all__), &all) < 0) {
         return -1; /* Unexpected error */
     }
     if (all == NULL) {
-        if (_PyObject_LookupAttr(v, &_Py_ID(__dict__), &dict) < 0) {
+        if (PyObject_GetOptionalAttr(v, &_Py_ID(__dict__), &dict) < 0) {
             return -1;
         }
         if (dict == NULL) {

--- a/Python/pythonrun.c
+++ b/Python/pythonrun.c
@@ -953,7 +953,7 @@ print_exception_file_and_line(struct exception_print_context *ctx,
     PyObject *f = ctx->file;
 
     PyObject *tmp;
-    int res = _PyObject_LookupAttr(*value_p, &_Py_ID(print_file_and_line), &tmp);
+    int res = PyObject_GetOptionalAttr(*value_p, &_Py_ID(print_file_and_line), &tmp);
     if (res <= 0) {
         if (res < 0) {
             PyErr_Clear();
@@ -1132,7 +1132,7 @@ print_exception_notes(struct exception_print_context *ctx, PyObject *value)
     }
 
     PyObject *notes;
-    int res = _PyObject_LookupAttr(value, &_Py_ID(__notes__), &notes);
+    int res = PyObject_GetOptionalAttr(value, &_Py_ID(__notes__), &notes);
     if (res <= 0) {
         return res;
     }

--- a/Python/suggestions.c
+++ b/Python/suggestions.c
@@ -247,7 +247,7 @@ get_suggestions_for_name_error(PyObject* name, PyFrameObject* frame)
         }
 
         PyObject *value;
-        res = _PyObject_LookupAttr(self, name, &value);
+        res = PyObject_GetOptionalAttr(self, name, &value);
         Py_DECREF(locals);
         if (res < 0) {
             goto error;

--- a/Python/sysmodule.c
+++ b/Python/sysmodule.c
@@ -257,7 +257,7 @@ sys_audit_tstate(PyThreadState *ts, const char *event,
         PyThreadState_EnterTracing(ts);
         while ((hook = PyIter_Next(hooks)) != NULL) {
             PyObject *o;
-            int canTrace = _PyObject_LookupAttr(hook, &_Py_ID(__cantrace__), &o);
+            int canTrace = PyObject_GetOptionalAttr(hook, &_Py_ID(__cantrace__), &o);
             if (o) {
                 canTrace = PyObject_IsTrue(o);
                 Py_DECREF(o);
@@ -657,7 +657,7 @@ sys_displayhook_unencodable(PyObject *outf, PyObject *o)
     if (encoded == NULL)
         goto error;
 
-    if (_PyObject_LookupAttr(outf, &_Py_ID(buffer), &buffer) < 0) {
+    if (PyObject_GetOptionalAttr(outf, &_Py_ID(buffer), &buffer) < 0) {
         Py_DECREF(encoded);
         goto error;
     }


### PR DESCRIPTION
It is an automatic replace in C files and `Parser/asdl_c.py`.

<!-- gh-issue-number: gh-106521 -->
* Issue: gh-106521
<!-- /gh-issue-number -->
