### PR TITLE
Add Plausible for docs metrics

### DIFF
--- a/Doc/tools/templates/layout.html
+++ b/Doc/tools/templates/layout.html
@@ -26,6 +26,7 @@
 {% endblock %}
 
 {% block extrahead %}
+    <script defer data-domain="docs.python.org" src="https://plausible.io/js/script.js"></script>
     <link rel="canonical" href="https://docs.python.org/3/{{pagename}}.html" />
     {% if builder != "htmlhelp" %}
       {% if pagename == 'whatsnew/changelog' and not embedded %}


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

This is to run a 30-day trial of Plausible to gather metrics on the docs, to help focus translation effort and rewrite/updates.

Re:

* https://discuss.python.org/t/docs-metrics-trial-with-plausible/28896
* https://github.com/python/steering-council/issues/204#issuecomment-1631402396

<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--106644.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->