### PR TITLE
gh-99079: Update Windows build to use OpenSSL 3.0.9

### DIFF
--- a/Misc/NEWS.d/next/Windows/2023-07-11-20-48-17.gh-issue-99079.CIMftz.rst
+++ b/Misc/NEWS.d/next/Windows/2023-07-11-20-48-17.gh-issue-99079.CIMftz.rst
@@ -1,0 +1,1 @@
+Update Windows build to use OpenSSL 3.0.9

--- a/PCbuild/get_externals.bat
+++ b/PCbuild/get_externals.bat
@@ -53,7 +53,7 @@ echo.Fetching external libraries...
 set libraries=
 set libraries=%libraries%                                       bzip2-1.0.8
 if NOT "%IncludeLibffiSrc%"=="false" set libraries=%libraries%  libffi-3.4.4
-if NOT "%IncludeSSLSrc%"=="false" set libraries=%libraries%     openssl-1.1.1u
+if NOT "%IncludeSSLSrc%"=="false" set libraries=%libraries%     openssl-3.0.9
 set libraries=%libraries%                                       sqlite-3.42.0.0
 if NOT "%IncludeTkinterSrc%"=="false" set libraries=%libraries% tcl-core-8.6.13.0
 if NOT "%IncludeTkinterSrc%"=="false" set libraries=%libraries% tk-8.6.13.0
@@ -76,7 +76,7 @@ echo.Fetching external binaries...
 
 set binaries=
 if NOT "%IncludeLibffi%"=="false"  set binaries=%binaries% libffi-3.4.4
-if NOT "%IncludeSSL%"=="false"     set binaries=%binaries% openssl-bin-1.1.1u
+if NOT "%IncludeSSL%"=="false"     set binaries=%binaries% openssl-bin-3.0.9
 if NOT "%IncludeTkinter%"=="false" set binaries=%binaries% tcltk-8.6.13.0
 if NOT "%IncludeSSLSrc%"=="false"  set binaries=%binaries% nasm-2.11.06
 

--- a/PCbuild/openssl.props
+++ b/PCbuild/openssl.props
@@ -10,10 +10,10 @@
     </Link>
   </ItemDefinitionGroup>
   <PropertyGroup>
-    <_DLLSuffix>-1_1</_DLLSuffix>
+    <_DLLSuffix>-3</_DLLSuffix>
     <_DLLSuffix Condition="$(Platform) == 'ARM'">$(_DLLSuffix)-arm</_DLLSuffix>
     <_DLLSuffix Condition="$(Platform) == 'ARM64'">$(_DLLSuffix)-arm64</_DLLSuffix>
-    <OpenSSLDLLSuffix>$(_DLLSuffix)</OpenSSLDLLSuffix>
+    <OpenSSLDLLSuffix Condition="$(OpenSSLDLLSuffix) == ''">$(_DLLSuffix)</OpenSSLDLLSuffix>
   </PropertyGroup>
   <ItemGroup>
     <_SSLDLL Include="$(opensslOutDir)\libcrypto$(_DLLSuffix).dll" />

--- a/PCbuild/python.props
+++ b/PCbuild/python.props
@@ -74,8 +74,8 @@
     <libffiDir Condition="$(libffiDir) == ''">$(ExternalsDir)libffi-3.4.4\</libffiDir>
     <libffiOutDir Condition="$(libffiOutDir) == ''">$(libffiDir)$(ArchName)\</libffiOutDir>
     <libffiIncludeDir Condition="$(libffiIncludeDir) == ''">$(libffiOutDir)include</libffiIncludeDir>
-    <opensslDir Condition="$(opensslDir) == ''">$(ExternalsDir)openssl-1.1.1u\</opensslDir>
-    <opensslOutDir Condition="$(opensslOutDir) == ''">$(ExternalsDir)openssl-bin-1.1.1u\$(ArchName)\</opensslOutDir>
+    <opensslDir Condition="$(opensslDir) == ''">$(ExternalsDir)openssl-3.0.9\</opensslDir>
+    <opensslOutDir Condition="$(opensslOutDir) == ''">$(ExternalsDir)openssl-bin-3.0.9\$(ArchName)\</opensslOutDir>
     <opensslIncludeDir Condition="$(opensslIncludeDir) == ''">$(opensslOutDir)include</opensslIncludeDir>
     <nasmDir Condition="$(nasmDir) == ''">$(ExternalsDir)\nasm-2.11.06\</nasmDir>
     <zlibDir Condition="$(zlibDir) == ''">$(ExternalsDir)\zlib-1.2.13\</zlibDir>

--- a/PCbuild/readme.txt
+++ b/PCbuild/readme.txt
@@ -168,7 +168,7 @@ _lzma
     Homepage:
         https://tukaani.org/xz/
 _ssl
-    Python wrapper for version 1.1.1u of the OpenSSL secure sockets
+    Python wrapper for version 3.0 of the OpenSSL secure sockets
     library, which is downloaded from our binaries repository at
     https://github.com/python/cpython-bin-deps.
 

--- a/PCbuild/regen.targets
+++ b/PCbuild/regen.targets
@@ -104,8 +104,9 @@
     <_LicenseSources Include="$(PySourcePath)LICENSE;
                               $(PySourcePath)PC\crtlicense.txt;
                               $(bz2Dir)LICENSE;
-                              $(opensslOutDir)LICENSE;
                               $(libffiDir)LICENSE;" />
+    <_LicenseSources Include="$(opensslOutDir)LICENSE.txt" Condition="Exists('$(opensslOutDir)LICENSE.txt')" />
+    <_LicenseSources Include="$(opensslOutDir)LICENSE" Condition="!Exists('$(opensslOutDir)LICENSE.txt')" />
     <_LicenseSources Include="$(tcltkDir)tcllicense.terms;
                               $(tcltkDir)tklicense.terms" Condition="$(IncludeTkinter)" />
   </ItemGroup>


### PR DESCRIPTION
Doesn't seem to need any other changes, but we'll see in CI

<!-- gh-issue-number: gh-99079 -->
* Issue: gh-99079
<!-- /gh-issue-number -->
