### PR TITLE
gh-106529: Implement JUMP_FORWARD in uops (with test)

### DIFF
--- a/Python/optimizer.c
+++ b/Python/optimizer.c
@@ -472,6 +472,13 @@ translate_bytecode_to_trace(
                 goto done;
             }
 
+            case JUMP_FORWARD:
+            {
+                // This will emit two SAVE_IP instructions; leave it to the optimizer
+                instr += oparg;
+                break;
+            }
+
             default:
             {
                 const struct opcode_macro_expansion *expansion = &_PyOpcode_macro_expansion[opcode];


### PR DESCRIPTION
This is a very simple one. Figuring out how to test it took longer than writing the implementation.

Note that this may generate two `SAVE_IP` uops in a row. As a matter of principle, I don't do anything to avoid that -- removing unneeded `SAVE_IP` uops is the optimizer's job.

I'll probably just merge once the tests pass.

<!-- gh-issue-number: gh-106529 -->
* Issue: gh-106529
<!-- /gh-issue-number -->
