### PR TITLE
gh-106283: Distribute timeout across resolved hosts

### DIFF
--- a/Lib/socket.py
+++ b/Lib/socket.py
@@ -54,6 +54,7 @@ from _socket import *
 
 import os, sys, io, selectors
 from enum import IntEnum, IntFlag
+from math import floor
 
 try:
     import errno
@@ -823,15 +824,23 @@ def create_connection(address, timeout=_GLOBAL_DEFAULT_TIMEOUT,
     and an ExceptionGroup of all errors if *all_errors* is True.
     """
 
+    MIN_TIMEOUT_PER_ADDR = 2
+    MIN_TIMEOUT_THRESHOLD = 2
+
     host, port = address
     exceptions = []
-    for res in getaddrinfo(host, port, 0, SOCK_STREAM):
+    addrs = getaddrinfo(host, port, 0, SOCK_STREAM)
+    if timeout is not _GLOBAL_DEFAULT_TIMEOUT:
+        per_addr_timeout = max(timeout / len(addrs), MIN_TIMEOUT_PER_ADDR) if timeout >= MIN_TIMEOUT_THRESHOLD else timeout
+    sum_timeouts_so_far = 0
+    for res in addrs:
         af, socktype, proto, canonname, sa = res
         sock = None
         try:
             sock = socket(af, socktype, proto)
             if timeout is not _GLOBAL_DEFAULT_TIMEOUT:
-                sock.settimeout(timeout)
+                sock.settimeout(per_addr_timeout)
+                sum_timeouts_so_far += per_addr_timeout
             if source_address:
                 sock.bind(source_address)
             sock.connect(sa)
@@ -845,6 +854,9 @@ def create_connection(address, timeout=_GLOBAL_DEFAULT_TIMEOUT,
             exceptions.append(exc)
             if sock is not None:
                 sock.close()
+
+        if sum_timeouts_so_far >= timeout:
+            break
 
     if len(exceptions):
         try:

--- a/Misc/NEWS.d/next/Security/2023-07-11-22-56-04.gh-issue-106283.JksSPl.rst
+++ b/Misc/NEWS.d/next/Security/2023-07-11-22-56-04.gh-issue-106283.JksSPl.rst
@@ -1,0 +1,4 @@
+This commit implements what was described in the discussion in #106283, which includes:
+* Distribute the timeout parameter across the entire list of resolved hosts
+* 2 second minimum timeout per resolved host
+* 2 second minimum timeout only enforced if large enough (overriding 2s rule)


### PR DESCRIPTION
This commit works to evenly distribute the timeout parameter across all resolved hosts with a minimum of 2seconds if timeout/n < 2 seconds.

<!-- gh-issue-number: gh-106283 -->
* Issue: gh-106283
<!-- /gh-issue-number -->
