### PR TITLE
[3.12] gh-96747: Add `passlib` package to `crypt` doc depraction warning (GH-106660)

### DIFF
--- a/Doc/library/crypt.rst
+++ b/Doc/library/crypt.rst
@@ -20,14 +20,7 @@
    The :mod:`crypt` module is deprecated
    (see :pep:`PEP 594 <594#crypt>` for details and alternatives).
    The :mod:`hashlib` module is a potential replacement for certain use cases.
-   The :mod:`passlib` package can replace all use cases of this module.
-
-    >>> import crypt
-    >>> crypt.crypt("cleartext", salt="ab")
-    'ab/GpyA5I.S12'
-    >>> from passlib.hash import des_crypt # doctest: +SKIP
-    >>> des_crypt.hash("cleartext", salt="ab") # doctest: +SKIP
-    'ab/GpyA5I.S12'
+   The `passlib <https://pypi.org/project/passlib/>`_ package can replace all use cases of this module.
 
 --------------
 

--- a/Doc/library/crypt.rst
+++ b/Doc/library/crypt.rst
@@ -20,6 +20,14 @@
    The :mod:`crypt` module is deprecated
    (see :pep:`PEP 594 <594#crypt>` for details and alternatives).
    The :mod:`hashlib` module is a potential replacement for certain use cases.
+   The :mod:`passlib` package can replace all use cases of this module.
+
+    >>> import crypt
+    >>> crypt.crypt("cleartext", salt="ab")
+    'ab/GpyA5I.S12'
+    >>> from passlib.hash import des_crypt # doctest: +SKIP
+    >>> des_crypt.hash("cleartext", salt="ab") # doctest: +SKIP
+    'ab/GpyA5I.S12'
 
 --------------
 


### PR DESCRIPTION
This PR add details about `passlib` package on the `crypt` doc.

I didn't first add this change to `main` branch since this `crypt.rst` file and the module are deleted on 3.11 version.

<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--106660.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->

<!-- gh-issue-number: gh-96747 -->
* Issue: gh-96747
<!-- /gh-issue-number -->
