### PR TITLE
gh-99242 Catch OSError when calling getloadavg in libregrtest

### DIFF
--- a/Lib/test/libregrtest/main.py
+++ b/Lib/test/libregrtest/main.py
@@ -769,7 +769,10 @@ class Regrtest:
             return self.win_load_tracker.getloadavg()
 
         if hasattr(os, 'getloadavg'):
-            return os.getloadavg()[0]
+            try:
+                return os.getloadavg()[0]
+            except OSError:
+                pass
 
         return None
 

--- a/Misc/NEWS.d/next/Tests/2023-07-13-02-14-57.gh-issue-99242.DHVhbD.rst
+++ b/Misc/NEWS.d/next/Tests/2023-07-13-02-14-57.gh-issue-99242.DHVhbD.rst
@@ -1,1 +1,3 @@
-When running regression tests under certain conditions (such as chroot) it was possible that calls to `os.getloadavg` would throw. This PR catches OS errors as reporting load average is optional.
+:func:`os.getloadavg` may throw :exc:`OSError` when running regression tests under
+certain conditions (e.g. chroot). This error is now caught and ignored, since
+reporting load average is optional.

--- a/Misc/NEWS.d/next/Tests/2023-07-13-02-14-57.gh-issue-99242.DHVhbD.rst
+++ b/Misc/NEWS.d/next/Tests/2023-07-13-02-14-57.gh-issue-99242.DHVhbD.rst
@@ -1,0 +1,1 @@
+When running regression tests under certain conditions (such as chroot) it was possible that calls to `os.getloadavg` would throw. This PR catches OS errors as reporting load average is optional.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

Per suggestions in the comments for #99242  I added a try/except around the call to `os.getloadavg`. 

Perhaps a logged warning here is appropriate as well?

<!-- gh-issue-number: gh-99242 -->
* Issue: gh-99242
<!-- /gh-issue-number -->
