### PR TITLE
gh-106723: forward -Xfrozen_modules option to spawned interpreters

### DIFF
--- a/Lib/subprocess.py
+++ b/Lib/subprocess.py
@@ -346,7 +346,7 @@ def _args_from_interpreter_flags():
     if dev_mode:
         args.extend(('-X', 'dev'))
     for opt in ('faulthandler', 'tracemalloc', 'importtime',
-                'showrefcount', 'utf8'):
+                'frozen_modules', 'showrefcount', 'utf8'):
         if opt in xoptions:
             value = xoptions[opt]
             if value is True:

--- a/Misc/NEWS.d/next/Core and Builtins/2023-07-13-14-55-45.gh-issue-106723.KsMufQ.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2023-07-13-14-55-45.gh-issue-106723.KsMufQ.rst
@@ -1,1 +1,1 @@
-Fix -Xfrozen_modules=off passing to multiprocessing subinterpreters.
+Propagate ``frozen_modules`` to multiprocessing subinterpreters.

--- a/Misc/NEWS.d/next/Core and Builtins/2023-07-13-14-55-45.gh-issue-106723.KsMufQ.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2023-07-13-14-55-45.gh-issue-106723.KsMufQ.rst
@@ -1,1 +1,1 @@
-Propagate ``frozen_modules`` to multiprocessing subinterpreters.
+Propagate ``frozen_modules`` to multiprocessing spawned process interpreters.

--- a/Misc/NEWS.d/next/Core and Builtins/2023-07-13-14-55-45.gh-issue-106723.KsMufQ.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2023-07-13-14-55-45.gh-issue-106723.KsMufQ.rst
@@ -1,0 +1,1 @@
+Fix -Xfrozen_modules=off passing to multiprocessing subinterpreters.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Forward frozen_modules xoption to subinterpreters

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

Fixes https://github.com/python/cpython/issues/106723


<!-- gh-issue-number: gh-106723 -->
* Issue: gh-106723
<!-- /gh-issue-number -->
