### PR TITLE
Docs search: Replace jQuery with vanilla JavaScript

### DIFF
--- a/Doc/tools/templates/search.html
+++ b/Doc/tools/templates/search.html
@@ -1,47 +1,61 @@
 {% extends "!search.html" %}
 {% block extrahead %}
     {{ super() }}
+    <meta name="robots" content="noindex">
     <script type="text/javascript">
         var GLOSSARY_PAGE = 'glossary.html';
 
-        jQuery(function() {
-            $.getJSON("_static/glossary.json", function(glossary) {
-                var RESULT_TEMPLATE = '<div style="display: none" class="admonition seealso" id="glossary-result">' +
-                                      '  <p class="topic-title">' +
-                                      '    <a class="glossary-title" href="#"></a>' +
-                                      '  </p>' +
-                                      '  <div class="glossary-body"></div>' +
-                                      '</div>';
-                $("#search-results").prepend(RESULT_TEMPLATE);
+        document.addEventListener('DOMContentLoaded', function() {
+          fetch('_static/glossary.json')
+            .then(function(response) {
+              if (response.ok) {
+                return response.json();
+              } else {
+                throw new Error('Failed to fetch glossary.json');
+              }
+            })
+            .then(function(glossary) {
+              var RESULT_TEMPLATE = '<div style="display: none" class="admonition seealso" id="glossary-result">' +
+                                    '  <p class="topic-title">' +
+                                    '    <a class="glossary-title" href="#"></a>' +
+                                    '  </p>' +
+                                    '  <div class="glossary-body"></div>' +
+                                    '</div>';
+              var searchResults = document.getElementById('search-results');
+              searchResults.insertAdjacentHTML('afterbegin', RESULT_TEMPLATE);
 
-                var params = $.getQueryParameters();
-                if (params.q) {
-                    var search_param = params.q[0].toLowerCase();
-                    var glossary_item = glossary[search_param];
-                    if (glossary_item) {
-                        var resultDiv = $("#glossary-result");
+              var params = new URLSearchParams(document.location.search).get("q");
+              if (params) {
+                var searchParam = params.toLowerCase();
+                var glossaryItem = glossary[searchParam];
+                if (glossaryItem) {
+                  var resultDiv = document.getElementById('glossary-result');
 
-                        // set up the title text with a link to the glossary page
-                        resultDiv.find(".glossary-title").text('Glossary: ' + glossary_item.title);
-                        var link_target = search_param.replace(/ /g, '-');
-                        resultDiv.find(".glossary-title").attr(
-                            'href', GLOSSARY_PAGE + '#term-' + link_target
-                        );
+                  // set up the title text with a link to the glossary page
+                  var glossaryTitle = resultDiv.querySelector('.glossary-title');
+                  glossaryTitle.textContent = 'Glossary: ' + glossaryItem.title;
+                  var linkTarget = searchParam.replace(/ /g, '-');
+                  glossaryTitle.href = GLOSSARY_PAGE + '#term-' + linkTarget;
 
-                        // rewrite any anchor links (to other glossary terms)
-                        // to have a full reference to the glossary page
-                        var body = $(glossary_item.body).children();
-                        body.find("a[href^='#']").each(function() {
-                            var current_url = $(this).attr('href');
-                            $(this).attr('href', GLOSSARY_PAGE + current_url);
-                        });
-                        resultDiv.find(".glossary-body").html(body);
+                  // rewrite any anchor links (to other glossary terms)
+                  // to have a full reference to the glossary page
+                  var body = document.createElement('div');
+                  body.innerHTML = glossaryItem.body;
+                  var anchorLinks = body.querySelectorAll('a[href^="#"]');
+                  anchorLinks.forEach(function(link) {
+                    var currentUrl = link.getAttribute('href');
+                    link.href = GLOSSARY_PAGE + currentUrl;
+                  });
+                  resultDiv.querySelector('.glossary-body').appendChild(body);
 
-                        resultDiv.show();
-                    } else {
-                        $("#glossary-result").hide('');
-                    }
+                  resultDiv.style.display = '';
+                } else {
+                  document.getElementById('glossary-result').style.display = 'none';
                 }
+              }
+            })
+            .catch(function(error) {
+              console.error(error);
             });
         });
     </script>

--- a/Doc/tools/templates/search.html
+++ b/Doc/tools/templates/search.html
@@ -3,7 +3,7 @@
     {{ super() }}
     <meta name="robots" content="noindex">
     <script type="text/javascript">
-        var GLOSSARY_PAGE = 'glossary.html';
+        const GLOSSARY_PAGE = 'glossary.html';
 
         document.addEventListener('DOMContentLoaded', function() {
           fetch('_static/glossary.json')
@@ -15,35 +15,35 @@
               }
             })
             .then(function(glossary) {
-              var RESULT_TEMPLATE = '<div style="display: none" class="admonition seealso" id="glossary-result">' +
-                                    '  <p class="topic-title">' +
-                                    '    <a class="glossary-title" href="#"></a>' +
-                                    '  </p>' +
-                                    '  <div class="glossary-body"></div>' +
-                                    '</div>';
-              var searchResults = document.getElementById('search-results');
+              const RESULT_TEMPLATE = '<div style="display: none" class="admonition seealso" id="glossary-result">' +
+                                      '  <p class="topic-title">' +
+                                      '    <a class="glossary-title" href="#"></a>' +
+                                      '  </p>' +
+                                      '  <div class="glossary-body"></div>' +
+                                      '</div>';
+              let searchResults = document.getElementById('search-results');
               searchResults.insertAdjacentHTML('afterbegin', RESULT_TEMPLATE);
 
-              var params = new URLSearchParams(document.location.search).get("q");
+              const params = new URLSearchParams(document.location.search).get("q");
               if (params) {
-                var searchParam = params.toLowerCase();
-                var glossaryItem = glossary[searchParam];
+                const searchParam = params.toLowerCase();
+                const glossaryItem = glossary[searchParam];
                 if (glossaryItem) {
-                  var resultDiv = document.getElementById('glossary-result');
+                  let resultDiv = document.getElementById('glossary-result');
 
                   // set up the title text with a link to the glossary page
-                  var glossaryTitle = resultDiv.querySelector('.glossary-title');
+                  let glossaryTitle = resultDiv.querySelector('.glossary-title');
                   glossaryTitle.textContent = 'Glossary: ' + glossaryItem.title;
-                  var linkTarget = searchParam.replace(/ /g, '-');
+                  const linkTarget = searchParam.replace(/ /g, '-');
                   glossaryTitle.href = GLOSSARY_PAGE + '#term-' + linkTarget;
 
                   // rewrite any anchor links (to other glossary terms)
                   // to have a full reference to the glossary page
-                  var body = document.createElement('div');
+                  let body = document.createElement('div');
                   body.innerHTML = glossaryItem.body;
-                  var anchorLinks = body.querySelectorAll('a[href^="#"]');
+                  const anchorLinks = body.querySelectorAll('a[href^="#"]');
                   anchorLinks.forEach(function(link) {
-                    var currentUrl = link.getAttribute('href');
+                    const currentUrl = link.getAttribute('href');
                     link.href = GLOSSARY_PAGE + currentUrl;
                   });
                   resultDiv.querySelector('.glossary-body').appendChild(body);


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

# Good

1. Go to https://docs.python.org/3/ (built with Sphinx 4.5.0)
2. Search for "asynchronous generator iterator"

Expected result:

https://docs.python.org/3/search.html?q=asynchronous+generator+iterator&check_keywords=yes&area=default

The glossary item is highlighted:

<img width="1098" alt="image" src="https://github.com/python/cpython/assets/1324225/03378598-28a8-4c03-bbca-de6957175b24">


# Bad

1. Go to https://docs.python.org/3.13/ (built with Sphinx 6.2.0)
2. Open the devtools console (ignore the switchers.js error, that's https://github.com/python/docsbuild-scripts/issues/159)
3. Search for "asynchronous generator iterator"

Actual result:

https://docs.python.org/3.13/search.html?q=asynchronous+generator+iterator

There's no glossary summary, and there are search.html errors in the console:

<img width="1096" alt="image" src="https://github.com/python/cpython/assets/1324225/466243ad-bb9a-44ad-bbe3-4b1d5a826deb">

# Problem

This is because Sphinx 6 removed jQuery:

> [#7405](https://github.com/sphinx-doc/sphinx/issues/7405): Removed the jQuery and underscore.js JavaScript frameworks.
> 
> These frameworks are no longer be automatically injected into themes from Sphinx 6.0. If you develop a theme or extension that uses the `jQuery`, `$`, or `$u` global objects, you need to update your JavaScript to modern standards, or use the mitigation below.

https://www.sphinx-doc.org/en/master/changes.html#release-6-0-0-released-dec-29-2022 has a couple of options on how to re-add jQuery, but it would be better rewrite https://github.com/python/docsbuild-scripts/blob/main/templates/switchers.js to use vanilla JavaScript.

# Fix

Rewrite using vanilla JavaScript.

<img width="1069" alt="image" src="https://github.com/python/cpython/assets/1324225/5d2e2b1c-a5ec-4fc0-b081-e27088ebf53c">


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--106743.org.readthedocs.build/en/106743/search.html?q=asynchronous+generator+iterator

<!-- readthedocs-preview cpython-previews end -->