### PR TITLE
gh-105726: Add `__slots__` to `AbstractContextManager` and `AbstractAsyncContextManager`

### DIFF
--- a/Lib/contextlib.py
+++ b/Lib/contextlib.py
@@ -20,6 +20,8 @@ class AbstractContextManager(abc.ABC):
 
     __class_getitem__ = classmethod(GenericAlias)
 
+    __slots__ = ()
+
     def __enter__(self):
         """Return `self` upon entering the runtime context."""
         return self
@@ -41,6 +43,8 @@ class AbstractAsyncContextManager(abc.ABC):
     """An abstract base class for asynchronous context managers."""
 
     __class_getitem__ = classmethod(GenericAlias)
+
+    __slots__ = ()
 
     async def __aenter__(self):
         """Return `self` upon entering the runtime context."""

--- a/Lib/test/test_contextlib.py
+++ b/Lib/test/test_contextlib.py
@@ -45,7 +45,6 @@ class TestAbstractContextManager(unittest.TestCase):
         class ManagerFromScratch:
             def __enter__(self):
                 return self
-
             def __exit__(self, exc_type, exc_value, traceback):
                 return None
 
@@ -72,13 +71,11 @@ class ContextManagerTestCase(unittest.TestCase):
 
     def test_contextmanager_plain(self):
         state = []
-
         @contextmanager
         def woohoo():
             state.append(1)
             yield 42
             state.append(999)
-
         with woohoo() as x:
             self.assertEqual(state, [1])
             self.assertEqual(x, 42)
@@ -87,7 +84,6 @@ class ContextManagerTestCase(unittest.TestCase):
 
     def test_contextmanager_finally(self):
         state = []
-
         @contextmanager
         def woohoo():
             state.append(1)
@@ -95,7 +91,6 @@ class ContextManagerTestCase(unittest.TestCase):
                 yield 42
             finally:
                 state.append(999)
-
         with self.assertRaises(ZeroDivisionError):
             with woohoo() as x:
                 self.assertEqual(state, [1])
@@ -111,13 +106,13 @@ class ContextManagerTestCase(unittest.TestCase):
 
         try:
             with f():
-                1 / 0
+                1/0
         except ZeroDivisionError as e:
             frames = traceback.extract_tb(e.__traceback__)
 
         self.assertEqual(len(frames), 1)
         self.assertEqual(frames[0].name, 'test_contextmanager_traceback')
-        self.assertEqual(frames[0].line, '1 / 0')
+        self.assertEqual(frames[0].line, '1/0')
 
         # Repeat with RuntimeError (which goes through a different code path)
         class RuntimeErrorSubclass(RuntimeError):
@@ -158,7 +153,6 @@ class ContextManagerTestCase(unittest.TestCase):
         @contextmanager
         def whee():
             yield
-
         ctx = whee()
         ctx.__enter__()
         # Calling __exit__ should not result in an exception
@@ -171,7 +165,6 @@ class ContextManagerTestCase(unittest.TestCase):
                 yield
             except:
                 yield
-
         ctx = whoo()
         ctx.__enter__()
         self.assertRaises(
@@ -180,7 +173,6 @@ class ContextManagerTestCase(unittest.TestCase):
 
     def test_contextmanager_except(self):
         state = []
-
         @contextmanager
         def woohoo():
             state.append(1)
@@ -189,7 +181,6 @@ class ContextManagerTestCase(unittest.TestCase):
             except ZeroDivisionError as e:
                 state.append(e.args[0])
                 self.assertEqual(state, [1, 42, 999])
-
         with woohoo() as x:
             self.assertEqual(state, [1])
             self.assertEqual(x, 42)
@@ -243,7 +234,6 @@ def woohoo():
                 yield
             except Exception as exc:
                 raise RuntimeError('issue29692:Chained') from exc
-
         try:
             with test_issue29692():
                 raise ZeroDivisionError
@@ -263,22 +253,19 @@ def woohoo():
     def _create_contextmanager_attribs(self):
         def attribs(**kw):
             def decorate(func):
-                for k, v in kw.items():
-                    setattr(func, k, v)
+                for k,v in kw.items():
+                    setattr(func,k,v)
                 return func
-
             return decorate
-
         @contextmanager
         @attribs(foo='bar')
         def baz(spam):
             """Whee!"""
-
         return baz
 
     def test_contextmanager_attribs(self):
         baz = self._create_contextmanager_attribs()
-        self.assertEqual(baz.__name__, 'baz')
+        self.assertEqual(baz.__name__,'baz')
         self.assertEqual(baz.foo, 'bar')
 
     @support.requires_docstrings
@@ -296,7 +283,6 @@ def woohoo():
         @contextmanager
         def woohoo(self, func, args, kwds):
             yield (self, func, args, kwds)
-
         with woohoo(self=11, func=22, args=33, kwds=44) as target:
             self.assertEqual(target, (11, 22, 33, 44))
 
@@ -331,7 +317,6 @@ def woohoo():
 
     def test_recursive(self):
         depth = 0
-
         @contextmanager
         def woohoo():
             nonlocal depth
@@ -361,11 +346,9 @@ class ClosingTestCase(unittest.TestCase):
 
     def test_closing(self):
         state = []
-
         class C:
             def close(self):
                 state.append(1)
-
         x = C()
         self.assertEqual(state, [])
         with closing(x) as y:
@@ -374,11 +357,9 @@ class ClosingTestCase(unittest.TestCase):
 
     def test_closing_error(self):
         state = []
-
         class C:
             def close(self):
                 state.append(1)
-
         x = C()
         self.assertEqual(state, [])
         with self.assertRaises(ZeroDivisionError):
@@ -392,7 +373,6 @@ class NullcontextTestCase(unittest.TestCase):
     def test_nullcontext(self):
         class C:
             pass
-
         c = C()
         with nullcontext(c) as c_in:
             self.assertIs(c_in, c)
@@ -418,7 +398,6 @@ class FileContextTestCase(unittest.TestCase):
         finally:
             os_helper.unlink(tfn)
 
-
 class LockContextTestCase(unittest.TestCase):
 
     def boilerPlate(self, lock, locked):
@@ -442,34 +421,28 @@ class LockContextTestCase(unittest.TestCase):
 
     def testWithCondition(self):
         lock = threading.Condition()
-
         def locked():
             return lock._is_owned()
-
         self.boilerPlate(lock, locked)
 
     def testWithSemaphore(self):
         lock = threading.Semaphore()
-
         def locked():
             if lock.acquire(False):
                 lock.release()
                 return False
             else:
                 return True
-
         self.boilerPlate(lock, locked)
 
     def testWithBoundedSemaphore(self):
         lock = threading.BoundedSemaphore()
-
         def locked():
             if lock.acquire(False):
                 lock.release()
                 return False
             else:
                 return True
-
         self.boilerPlate(lock, locked)
 
 
@@ -505,6 +478,7 @@ class TestContextDecorator(unittest.TestCase):
 
         self.assertEqual(context.exc, (None, None, None))
 
+
     def test_contextdecorator_with_exception(self):
         context = mycontext()
 
@@ -521,6 +495,7 @@ class TestContextDecorator(unittest.TestCase):
         self.assertIsNotNone(context.exc)
         self.assertIs(context.exc[0], NameError)
 
+
     def test_decorator(self):
         context = mycontext()
 
@@ -528,9 +503,9 @@ class TestContextDecorator(unittest.TestCase):
         def test():
             self.assertIsNone(context.exc)
             self.assertTrue(context.started)
-
         test()
         self.assertEqual(context.exc, (None, None, None))
+
 
     def test_decorator_with_exception(self):
         context = mycontext()
@@ -545,6 +520,7 @@ class TestContextDecorator(unittest.TestCase):
             test()
         self.assertIsNotNone(context.exc)
         self.assertIs(context.exc[0], NameError)
+
 
     def test_decorating_method(self):
         context = mycontext()
@@ -575,11 +551,11 @@ class TestContextDecorator(unittest.TestCase):
         self.assertEqual(test.a, 1)
         self.assertEqual(test.b, 2)
 
+
     def test_typo_enter(self):
         class mycontext(ContextDecorator):
             def __unter__(self):
                 pass
-
             def __exit__(self, *exc):
                 pass
 
@@ -587,17 +563,18 @@ class TestContextDecorator(unittest.TestCase):
             with mycontext():
                 pass
 
+
     def test_typo_exit(self):
         class mycontext(ContextDecorator):
             def __enter__(self):
                 pass
-
             def __uxit__(self, *exc):
                 pass
 
         with self.assertRaisesRegex(TypeError, 'the context manager.*__exit__'):
             with mycontext():
                 pass
+
 
     def test_contextdecorator_as_mixin(self):
         class somecontext(object):
@@ -615,14 +592,13 @@ class TestContextDecorator(unittest.TestCase):
             pass
 
         context = mycontext()
-
         @context
         def test():
             self.assertIsNone(context.exc)
             self.assertTrue(context.started)
-
         test()
         self.assertEqual(context.exc, (None, None, None))
+
 
     def test_contextmanager_as_decorator(self):
         @contextmanager
@@ -632,12 +608,10 @@ class TestContextDecorator(unittest.TestCase):
             state.append(999)
 
         state = []
-
         @woohoo(1)
         def test(x):
             self.assertEqual(state, [1])
             state.append(x)
-
         test('something')
         self.assertEqual(state, [1, 'something', 999])
 
@@ -665,18 +639,16 @@ class TestBaseExitStack:
         expected = [
             ((), {}),
             ((1,), {}),
-            ((1, 2), {}),
+            ((1,2), {}),
             ((), dict(example=1)),
             ((1,), dict(example=1)),
-            ((1, 2), dict(example=1)),
-            ((1, 2), dict(self=3, callback=4)),
+            ((1,2), dict(example=1)),
+            ((1,2), dict(self=3, callback=4)),
         ]
         result = []
-
         def _exit(*args, **kwds):
             """Test metadata propagation"""
             result.append((args, kwds))
-
         with self.exit_stack() as stack:
             for args, kwds in reversed(expected):
                 if args and kwds:
@@ -706,28 +678,21 @@ class TestBaseExitStack:
 
     def test_push(self):
         exc_raised = ZeroDivisionError
-
         def _expect_exc(exc_type, exc, exc_tb):
             self.assertIs(exc_type, exc_raised)
-
         def _suppress_exc(*exc_details):
             return True
-
         def _expect_ok(exc_type, exc, exc_tb):
             self.assertIsNone(exc_type)
             self.assertIsNone(exc)
             self.assertIsNone(exc_tb)
-
         class ExitCM(object):
             def __init__(self, check_exc):
                 self.check_exc = check_exc
-
             def __enter__(self):
                 self.fail("Should not be called!")
-
             def __exit__(self, *exc_details):
                 self.check_exc(*exc_details)
-
         with self.exit_stack() as stack:
             stack.push(_expect_ok)
             self.assertIs(stack._exit_callbacks[-1][1], _expect_ok)
@@ -743,13 +708,12 @@ class TestBaseExitStack:
             self.assertIs(stack._exit_callbacks[-1][1], _expect_exc)
             stack.push(_expect_exc)
             self.assertIs(stack._exit_callbacks[-1][1], _expect_exc)
-            1 / 0
+            1/0
 
     def test_enter_context(self):
         class TestCM(object):
             def __enter__(self):
                 result.append(1)
-
             def __exit__(self, *exc_details):
                 result.append(3)
 
@@ -759,7 +723,6 @@ class TestBaseExitStack:
             @stack.callback  # Registered first => cleaned up last
             def _exit():
                 result.append(4)
-
             self.assertIsNotNone(_exit)
             stack.enter_context(cm)
             self.assertIs(stack._exit_callbacks[-1][1].__self__, cm)
@@ -769,11 +732,9 @@ class TestBaseExitStack:
     def test_enter_context_errors(self):
         class LacksEnterAndExit:
             pass
-
         class LacksEnter:
             def __exit__(self, *exc_info):
                 pass
-
         class LacksExit:
             def __enter__(self):
                 pass
@@ -793,7 +754,6 @@ class TestBaseExitStack:
             @stack.callback
             def _exit():
                 result.append(1)
-
             self.assertIsNotNone(_exit)
             stack.close()
             result.append(2)
@@ -805,7 +765,6 @@ class TestBaseExitStack:
             @stack.callback
             def _exit():
                 result.append(3)
-
             self.assertIsNotNone(_exit)
             new_stack = stack.pop_all()
             result.append(1)
@@ -817,12 +776,12 @@ class TestBaseExitStack:
         with self.assertRaises(ZeroDivisionError):
             with self.exit_stack() as stack:
                 stack.push(lambda *exc: False)
-                1 / 0
+                1/0
 
     def test_exit_suppress(self):
         with self.exit_stack() as stack:
             stack.push(lambda *exc: True)
-            1 / 0
+            1/0
 
     def test_exit_exception_traceback(self):
         # This test captures the current behavior of ExitStack so that we know
@@ -836,7 +795,7 @@ class TestBaseExitStack:
         try:
             with self.exit_stack() as stack:
                 stack.callback(raise_exc, ValueError)
-                1 / 0
+                1/0
         except ValueError as e:
             exc = e
 
@@ -854,7 +813,7 @@ class TestBaseExitStack:
         self.assertIsInstance(exc.__context__, ZeroDivisionError)
         zde_frames = traceback.extract_tb(exc.__context__.__traceback__)
         self.assertEqual([(f.name, f.line) for f in zde_frames],
-                         [('test_exit_exception_traceback', '1 / 0')])
+                         [('test_exit_exception_traceback', '1/0')])
 
     def test_exit_exception_chaining_reference(self):
         # Sanity check to make sure that ExitStack chaining matches
@@ -862,10 +821,8 @@ class TestBaseExitStack:
         class RaiseExc:
             def __init__(self, exc):
                 self.exc = exc
-
             def __enter__(self):
                 return self
-
             def __exit__(self, *exc_details):
                 raise self.exc
 
@@ -873,10 +830,8 @@ class TestBaseExitStack:
             def __init__(self, outer, inner):
                 self.outer = outer
                 self.inner = inner
-
             def __enter__(self):
                 return self
-
             def __exit__(self, *exc_details):
                 try:
                     raise self.inner
@@ -886,7 +841,6 @@ class TestBaseExitStack:
         class SuppressExc:
             def __enter__(self):
                 return self
-
             def __exit__(self, *exc_details):
                 type(self).saved_details = exc_details
                 return True
@@ -915,7 +869,6 @@ class TestBaseExitStack:
             raise exc
 
         saved_details = None
-
         def suppress_exc(*exc_details):
             nonlocal saved_details
             saved_details = exc_details
@@ -1031,7 +984,7 @@ class TestBaseExitStack:
             self.assertIs(exc.__context__.__context__, exc2)
             self.assertIs(exc.__context__.__context__.__context__, exc1)
             self.assertIsNone(
-                exc.__context__.__context__.__context__.__context__)
+                       exc.__context__.__context__.__context__.__context__)
 
     def test_exit_exception_with_existing_context(self):
         # Addresses a lack of test coverage discovered after checking in a
@@ -1041,7 +994,6 @@ class TestBaseExitStack:
                 raise inner_exc
             finally:
                 raise outer_exc
-
         exc1 = Exception(1)
         exc2 = Exception(2)
         exc3 = Exception(3)
@@ -1058,25 +1010,24 @@ class TestBaseExitStack:
             self.assertIs(exc.__context__.__context__, exc3)
             self.assertIs(exc.__context__.__context__.__context__, exc2)
             self.assertIs(
-                exc.__context__.__context__.__context__.__context__, exc1)
+                 exc.__context__.__context__.__context__.__context__, exc1)
             self.assertIsNone(
                 exc.__context__.__context__.__context__.__context__.__context__)
 
     def test_body_exception_suppress(self):
         def suppress_exc(*exc_details):
             return True
-
         try:
             with self.exit_stack() as stack:
                 stack.push(suppress_exc)
-                1 / 0
+                1/0
         except IndexError as exc:
             self.fail("Expected no exception, got IndexError")
 
     def test_exit_exception_chaining_suppress(self):
         with self.exit_stack() as stack:
             stack.push(lambda *exc: True)
-            stack.push(lambda *exc: 1 / 0)
+            stack.push(lambda *exc: 1/0)
             stack.push(lambda *exc: {}[1])
 
     def test_excessive_nesting(self):
@@ -1087,7 +1038,6 @@ class TestBaseExitStack:
 
     def test_instance_bypass(self):
         class Example(object): pass
-
         cm = Example()
         cm.__enter__ = object()
         cm.__exit__ = object()
@@ -1099,11 +1049,8 @@ class TestBaseExitStack:
 
     def test_dont_reraise_RuntimeError(self):
         # https://bugs.python.org/issue27122
-        class UniqueException(Exception):
-            pass
-
-        class UniqueRuntimeError(RuntimeError):
-            pass
+        class UniqueException(Exception): pass
+        class UniqueRuntimeError(RuntimeError): pass
 
         @contextmanager
         def second():
@@ -1144,6 +1091,7 @@ class TestExitStack(TestBaseExitStack, unittest.TestCase):
 
 
 class TestRedirectStream:
+
     redirect_stream = None
     orig_stream = None
 
@@ -1200,11 +1148,13 @@ class TestRedirectStream:
 
 
 class TestRedirectStdout(TestRedirectStream, unittest.TestCase):
+
     redirect_stream = redirect_stdout
     orig_stream = "stdout"
 
 
 class TestRedirectStderr(TestRedirectStream, unittest.TestCase):
+
     redirect_stream = redirect_stderr
     orig_stream = "stderr"
 
@@ -1237,16 +1187,16 @@ class TestSuppress(ExceptionIsLikeMixin, unittest.TestCase):
     def test_other_exception(self):
         with self.assertRaises(ZeroDivisionError):
             with suppress(TypeError):
-                1 / 0
+                1/0
 
     def test_no_args(self):
         with self.assertRaises(ZeroDivisionError):
             with suppress():
-                1 / 0
+                1/0
 
     def test_multiple_exception_args(self):
         with suppress(ZeroDivisionError, TypeError):
-            1 / 0
+            1/0
         with suppress(ZeroDivisionError, TypeError):
             len(5)
 
@@ -1257,10 +1207,10 @@ class TestSuppress(ExceptionIsLikeMixin, unittest.TestCase):
         with ignore_exceptions:
             len(5)
         with ignore_exceptions:
-            with ignore_exceptions:  # Check nested usage
+            with ignore_exceptions: # Check nested usage
                 len(5)
             outer_continued = True
-            1 / 0
+            1/0
         self.assertTrue(outer_continued)
 
     def test_exception_groups(self):

--- a/Lib/test/test_contextlib_async.py
+++ b/Lib/test/test_contextlib_async.py
@@ -38,6 +38,20 @@ class TestAbstractAsyncContextManager(unittest.TestCase):
             self.assertIs(manager, context)
 
     @_async_test
+    def test_slots(self):
+        class DefaultAsyncContextManager(AbstractAsyncContextManager):
+            __slots__ = ()
+
+            def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *args):
+                await super().__aexit__(*args)
+
+        with self.assertRaises(AttributeError):
+            DefaultAsyncContextManager().var = 42
+
+    @_async_test
     async def test_async_gen_propagates_generator_exit(self):
         # A regression test for https://bugs.python.org/issue33786.
 

--- a/Lib/test/test_contextlib_async.py
+++ b/Lib/test/test_contextlib_async.py
@@ -38,18 +38,16 @@ class TestAbstractAsyncContextManager(unittest.TestCase):
             self.assertIs(manager, context)
 
     @_async_test
-    def test_slots(self):
+    async def test_slots(self):
         class DefaultAsyncContextManager(AbstractAsyncContextManager):
             __slots__ = ()
-
-            def __aenter__(self):
-                return self
 
             async def __aexit__(self, *args):
                 await super().__aexit__(*args)
 
         with self.assertRaises(AttributeError):
-            DefaultAsyncContextManager().var = 42
+            manager = DefaultAsyncContextManager()
+            manager.var = 42
 
     @_async_test
     async def test_async_gen_propagates_generator_exit(self):

--- a/Misc/NEWS.d/next/Library/2023-07-15-12-52-50.gh-issue-105726.NGthO8.rst
+++ b/Misc/NEWS.d/next/Library/2023-07-15-12-52-50.gh-issue-105726.NGthO8.rst
@@ -1,0 +1,2 @@
+Bug fixed: Inheritance from AbstractContextManager and AbstractAsyncContextManager
+specifying slots in the child-class does not lead to the immutability of child-class instance.

--- a/Misc/NEWS.d/next/Library/2023-07-15-12-52-50.gh-issue-105726.NGthO8.rst
+++ b/Misc/NEWS.d/next/Library/2023-07-15-12-52-50.gh-issue-105726.NGthO8.rst
@@ -1,2 +1,3 @@
-Bug fixed: Inheritance from AbstractContextManager and AbstractAsyncContextManager
+Added ``__slots__`` to :class:`contextlib.AbstractContextManager` and :class:`context.AbstractAsyncContextManager`
+so that child classes can use ``__slots__``.
 specifying slots in the child-class does not lead to the immutability of child-class instance.

--- a/Misc/NEWS.d/next/Library/2023-07-15-12-52-50.gh-issue-105726.NGthO8.rst
+++ b/Misc/NEWS.d/next/Library/2023-07-15-12-52-50.gh-issue-105726.NGthO8.rst
@@ -1,3 +1,3 @@
-Added ``__slots__`` to :class:`contextlib.AbstractContextManager` and :class:`context.AbstractAsyncContextManager`
+Added ``__slots__`` to :class:`contextlib.AbstractContextManager` and :class:`contextlib.AbstractAsyncContextManager`
 so that child classes can use ``__slots__``.
 

--- a/Misc/NEWS.d/next/Library/2023-07-15-12-52-50.gh-issue-105726.NGthO8.rst
+++ b/Misc/NEWS.d/next/Library/2023-07-15-12-52-50.gh-issue-105726.NGthO8.rst
@@ -1,3 +1,3 @@
 Added ``__slots__`` to :class:`contextlib.AbstractContextManager` and :class:`context.AbstractAsyncContextManager`
 so that child classes can use ``__slots__``.
-specifying slots in the child-class does not lead to the immutability of child-class instance.
+


### PR DESCRIPTION
Fixing #105726

# Pull Request title

gh-105726: I have added `__slots__` to `AbstractContextManager` and `AbstractAsyncContextManager` and now all their's subclasses can be immutable
