### PR TITLE
[3.11] gh-106752: Sync with zipp 3.16.2 (GH-106757)

### DIFF
--- a/Lib/test/test_zipfile.py
+++ b/Lib/test/test_zipfile.py
@@ -3444,6 +3444,13 @@ with zipfile.ZipFile(io.BytesIO(), "w") as zf:
         assert e.suffixes == []
 
     @pass_alpharep
+    def test_suffix_no_filename(self, alpharep):
+        alpharep.filename = None
+        root = zipfile.Path(alpharep)
+        assert root.joinpath('example').suffix == ""
+        assert root.joinpath('example').suffixes == []
+
+    @pass_alpharep
     def test_stem(self, alpharep):
         """
         The final path component, without its suffix
@@ -3459,6 +3466,8 @@ with zipfile.ZipFile(io.BytesIO(), "w") as zf:
 
         d = root / "d"
         assert d.stem == "d"
+
+        assert (root / ".gitignore").stem == ".gitignore"
 
     @pass_alpharep
     def test_root_parent(self, alpharep):

--- a/Lib/zipfile.py
+++ b/Lib/zipfile.py
@@ -2420,21 +2420,24 @@ class Path:
         encoding, args, kwargs = _extract_text_encoding(*args, **kwargs)
         return io.TextIOWrapper(stream, encoding, *args, **kwargs)
 
+    def _base(self):
+        return pathlib.PurePosixPath(self.at or self.root.filename)
+
     @property
     def name(self):
-        return pathlib.Path(self.at).name or self.filename.name
+        return self._base().name
 
     @property
     def suffix(self):
-        return pathlib.Path(self.at).suffix or self.filename.suffix
+        return self._base().suffix
 
     @property
     def suffixes(self):
-        return pathlib.Path(self.at).suffixes or self.filename.suffixes
+        return self._base().suffixes
 
     @property
     def stem(self):
-        return pathlib.Path(self.at).stem or self.filename.stem
+        return self._base().stem
 
     @property
     def filename(self):

--- a/Misc/NEWS.d/next/Library/2023-07-14-16-54-13.gh-issue-106752.BT1Yxw.rst
+++ b/Misc/NEWS.d/next/Library/2023-07-14-16-54-13.gh-issue-106752.BT1Yxw.rst
@@ -1,0 +1,5 @@
+Fixed several bugs in zipfile.Path, including: in ``Path.match`, Windows
+separators are no longer honored (and never were meant to be); Fixed
+``name``/``suffix``/``suffixes``/``stem`` operations when no filename is
+present and the Path is not at the root of the zipfile; Reworked glob for
+performance and more correct matching behavior.

--- a/Misc/NEWS.d/next/Library/2023-07-14-16-54-13.gh-issue-106752.BT1Yxw.rst
+++ b/Misc/NEWS.d/next/Library/2023-07-14-16-54-13.gh-issue-106752.BT1Yxw.rst
@@ -1,5 +1,3 @@
-Fixed several bugs in zipfile.Path, including: in ``Path.match`, Windows
-separators are no longer honored (and never were meant to be); Fixed
+Fixed several bug in zipfile.Path in
 ``name``/``suffix``/``suffixes``/``stem`` operations when no filename is
-present and the Path is not at the root of the zipfile; Reworked glob for
-performance and more correct matching behavior.
+present and the Path is not at the root of the zipfile.


### PR DESCRIPTION
Selective backport to correct behavior of `.name`, `.suffix[es]` and `.stem`.

* gh-106752: Sync with zipp 3.16.2

* Add blurb.


(cherry picked from commit 22980dc7c9dcec4b74fea815542601ef582c230e)


Co-authored-by: Jason R. Coombs <jaraco@jaraco.com>