### PR TITLE
gh-82900: Allow forcing kw_only dataclass __post_init__

### DIFF
--- a/Lib/dataclasses.py
+++ b/Lib/dataclasses.py
@@ -565,7 +565,7 @@ def _init_param(f):
     return f'{f.name}:__dataclass_type_{f.name}__{default}'
 
 
-def _init_fn(fields, std_fields, kw_only_fields, frozen, has_post_init, kw_only_post_init,
+def _init_fn(fields, std_fields, kw_only_fields, frozen, has_post_init,
              self_name, globals, slots):
     # fields contains both real fields and InitVar pseudo-fields.
 
@@ -602,7 +602,7 @@ def _init_fn(fields, std_fields, kw_only_fields, frozen, has_post_init, kw_only_
     # Does this class have a post-init function?
     if has_post_init:
         # KEYWORD_ONLY (after 'self')
-        if kw_only_post_init:
+        if has_post_init is KW_ONLY:
             params_str = ', '.join(f'{f.name}={f.name}' for f in fields
                                    if f._field_type is _FIELD_INITVAR)
         # POSITIONAL_OR_KEYWORD, or no args other than 'self'
@@ -1066,27 +1066,18 @@ def _process_class(cls, init, repr, eq, order, unsafe_hash, frozen,
         has_post_init = hasattr(cls, _POST_INIT_NAME)
 
         # Does it only accept kwargs?
-        kw_only_post_init = False
         if has_post_init:
 
             # get params
             post_init_sig = inspect.signature(getattr(cls, _POST_INIT_NAME))
             post_init_params = post_init_sig.parameters
 
-            # are there more than 1 POSITIONAL_OR_KEYWORD params?
-            # ('self' is convention, not guaranteed spelling)
-            p_or_k_count = 0
-            for param in post_init_params.values():
-                if param.kind == param.POSITIONAL_OR_KEYWORD:
-                    p_or_k_count += 1
-                    if p_or_k_count > 1:
-                        break
-
-            # set to True if __post_init__ has a '*' after self, forcing
-            # all additional params to KEYWORD_ONLY
-            # eg, def __post_init__(self, *, init_var1, init_var2...
-            if p_or_k_count == 1 and len(post_init_params) > 1:
-                kw_only_post_init = True
+            # does params have any args other than self? is second arg KEYWORD_ONLY?
+            if len(post_init_params) > 1:
+                second_arg = next(itertools.islice(post_init_params.values(), 1, 2))
+                kw_only_post_init = second_arg.kind == second_arg.KEYWORD_ONLY
+                if kw_only_post_init:
+                    has_post_init = KW_ONLY
 
         _set_new_attribute(cls, '__init__',
                            _init_fn(all_init_fields,
@@ -1094,7 +1085,6 @@ def _process_class(cls, init, repr, eq, order, unsafe_hash, frozen,
                                     kw_only_init_fields,
                                     frozen,
                                     has_post_init,
-                                    kw_only_post_init,
                                     # The name to use for the "self"
                                     # param in __init__.  Use "self"
                                     # if possible.


### PR DESCRIPTION
Add ability to force dataclass to pass InitVar's to `__post_init__` as keywords, rather than positional.

Use:
`def __post_init__(self, *, init_var1, init_var2...`

[Per the issue](https://github.com/python/cpython/issues/82900#issuecomment-1636234014), I did not notice a slow-down on the standard `def __post_init__(self, init_var1, init_var2):`
If users opt-in to making args passes as keywords, there is a ~12% slowdown.

I believe this is backwards compatible, since `def __post_init__(self, *, init_var1, init_var2):` is currently not allowed, and any-slowdown is opt-in.

If desirable, I'll look at where to add a small note to dataclass docs to document this ability.


<!-- gh-issue-number: gh-82900 -->
* Issue: gh-82900
<!-- /gh-issue-number -->
