### PR TITLE
gh-106780: Add __match_args__ to tutorial example

### DIFF
--- a/Doc/tutorial/controlflow.rst
+++ b/Doc/tutorial/controlflow.rst
@@ -343,7 +343,7 @@ Dotted names (like ``foo.bar``), attribute names (the ``x=`` and ``y=`` above) o
 (recognized by the "(...)" next to them like ``Point`` above) are never assigned to.
 
 Patterns can be arbitrarily nested.  For example, if we have a short
-list of Points, with ``__match_args__` added, we could match it like this::
+list of Points, with ``__match_args__`` added, we could match it like this::
 
     class Point:
         __match_args__ = ('x', 'y')

--- a/Doc/tutorial/controlflow.rst
+++ b/Doc/tutorial/controlflow.rst
@@ -343,7 +343,13 @@ Dotted names (like ``foo.bar``), attribute names (the ``x=`` and ``y=`` above) o
 (recognized by the "(...)" next to them like ``Point`` above) are never assigned to.
 
 Patterns can be arbitrarily nested.  For example, if we have a short
-list of points, we could match it like this::
+list of Points, with ``__match_args__` added, we could match it like this::
+
+    class Point:
+        __match_args__ = ('x', 'y')
+        def __init__(self, x, y):
+            self.x = x
+            self.y = y
 
     match points:
         case []:


### PR DESCRIPTION
Add Point definition with this attribute before example that needs it.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-106780 -->
* Issue: gh-106780
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--106784.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->