### PR TITLE
gh-106529: Generate uops for POP_JUMP_IF_[NOT_]NONE

### DIFF
--- a/Lib/test/test_capi/test_misc.py
+++ b/Lib/test/test_capi/test_misc.py
@@ -2532,6 +2532,36 @@ class TestUops(unittest.TestCase):
         uops = {opname for opname, _ in ex}
         self.assertIn("_POP_JUMP_IF_FALSE", uops)
 
+    def test_pop_jump_if_none(self):
+        def testfunc(a):
+            for x in a:
+                if x is None:
+                    x = 0
+
+        opt = _testinternalcapi.get_uop_optimizer()
+        with temporary_optimizer(opt):
+            testfunc([1, 2, 3])
+
+        ex = get_first_executor(testfunc)
+        self.assertIsNotNone(ex)
+        uops = {opname for opname, _ in ex}
+        self.assertIn("_POP_JUMP_IF_TRUE", uops)
+
+    def test_pop_jump_if_not_none(self):
+        def testfunc(a):
+            for x in a:
+                if x is not None:
+                    x = 0
+
+        opt = _testinternalcapi.get_uop_optimizer()
+        with temporary_optimizer(opt):
+            testfunc([1, 2, 3])
+
+        ex = get_first_executor(testfunc)
+        self.assertIsNotNone(ex)
+        uops = {opname for opname, _ in ex}
+        self.assertIn("_POP_JUMP_IF_FALSE", uops)
+
     def test_pop_jump_if_true(self):
         def testfunc(n):
             i = 0

--- a/Python/optimizer.c
+++ b/Python/optimizer.c
@@ -464,9 +464,26 @@ translate_bytecode_to_trace(
 
         switch (opcode) {
 
+            case POP_JUMP_IF_NONE:
+            {
+                RESERVE(2, 2);
+                ADD_TO_TRACE(IS_NONE, 0);
+                opcode = POP_JUMP_IF_TRUE;
+                goto pop_jump_if_bool;
+            }
+
+            case POP_JUMP_IF_NOT_NONE:
+            {
+                RESERVE(2, 2);
+                ADD_TO_TRACE(IS_NONE, 0);
+                opcode = POP_JUMP_IF_FALSE;
+                goto pop_jump_if_bool;
+            }
+
             case POP_JUMP_IF_FALSE:
             case POP_JUMP_IF_TRUE:
             {
+pop_jump_if_bool:
                 // Assume jump unlikely (TODO: handle jump likely case)
                 RESERVE(1, 2);
                 _Py_CODEUNIT *target_instr =


### PR DESCRIPTION
These aren't automatically translated because (ironically) they are macros deferring to POP_JUMP_IF_{TRUE,FALSE}, which are not viable uops (being manually translated).

The hack is that we emit IS_NONE and then set opcode and jump to the POP_JUMP_IF_{TRUE,FALSE} translation code.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-106529 -->
* Issue: gh-106529
<!-- /gh-issue-number -->
