### PR TITLE
[3.11] Doc: devmode: add -Xdev option to example (GH-106253)

### DIFF
--- a/Doc/library/devmode.rst
+++ b/Doc/library/devmode.rst
@@ -198,7 +198,7 @@ descriptor" error when finalizing the file object:
 
 .. code-block:: shell-session
 
-    $ python3 script.py
+    $ python3 -X dev script.py
     import os
     script.py:10: ResourceWarning: unclosed file <_io.TextIOWrapper name='script.py' mode='r' encoding='UTF-8'>
       main()


### PR DESCRIPTION


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--106805.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->