### PR TITLE
[3.12] Doc: fix section levels of devmode doc (GH-106801)

### DIFF
--- a/Doc/library/devmode.rst
+++ b/Doc/library/devmode.rst
@@ -16,7 +16,7 @@ setting the :envvar:`PYTHONDEVMODE` environment variable to ``1``.
 See also :ref:`Python debug build <debug-build>`.
 
 Effects of the Python Development Mode
-======================================
+--------------------------------------
 
 Enabling the Python Development Mode is similar to the following command, but
 with additional effects described below::
@@ -107,7 +107,7 @@ value can be read from :data:`sys.flags.dev_mode <sys.flags>`.
 
 
 ResourceWarning Example
-=======================
+-----------------------
 
 Example of a script counting the number of lines of the text file specified in
 the command line::
@@ -171,7 +171,7 @@ application more deterministic and more reliable.
 
 
 Bad file descriptor error example
-=================================
+---------------------------------
 
 Script displaying the first line of itself::
 


### PR DESCRIPTION
(cherry picked from commit e58960160fcb4fce63177fcd9ef605f887377767)


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--106809.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->