### PR TITLE
Fix typo in 3.11.4 changelog: urllib.request.Requst -> Request

### DIFF
--- a/Misc/NEWS.d/3.12.0b1.rst
+++ b/Misc/NEWS.d/3.12.0b1.rst
@@ -1955,7 +1955,7 @@ introduced in :pep:`692`.
 .. section: Documentation
 
 Clarifying documentation about the url parameter to urllib.request.urlopen
-and urllib.request.Requst needing to be encoded properly.
+and urllib.request.Request needing to be encoded properly.
 
 ..
 


### PR DESCRIPTION
Minor typo correction in file Misc/NEWS.d/3.12.0b1.rst, under the "Python 3.11.4 final" Documentation subheading. (No associated issue as it is a tiny issue)

urllib.request.Request was misspelled as urllib.request.Requst