### PR TITLE
gh-106831: Fix `NULL` check of `d2i_SSL_SESSION` result in `_ssl.c`

### DIFF
--- a/Misc/NEWS.d/next/Library/2023-07-17-21-45-15.gh-issue-106831.RqVq9X.rst
+++ b/Misc/NEWS.d/next/Library/2023-07-17-21-45-15.gh-issue-106831.RqVq9X.rst
@@ -1,0 +1,2 @@
+Fix potential missing ``NULL`` check of ``d2i_SSL_SESSION`` result in
+``_ssl.c``.

--- a/Modules/_ssl.c
+++ b/Modules/_ssl.c
@@ -2808,7 +2808,7 @@ _ssl_session_dup(SSL_SESSION *session) {
     /* get length */
     slen = i2d_SSL_SESSION(session, NULL);
     if (slen == 0 || slen > 0xFF00) {
-        PyErr_SetString(PyExc_ValueError, "i2d() failed.");
+        PyErr_SetString(PyExc_ValueError, "i2d() failed");
         goto error;
     }
     if ((senc = PyMem_Malloc(slen)) == NULL) {
@@ -2817,13 +2817,13 @@ _ssl_session_dup(SSL_SESSION *session) {
     }
     p = senc;
     if (!i2d_SSL_SESSION(session, &p)) {
-        PyErr_SetString(PyExc_ValueError, "i2d() failed.");
+        PyErr_SetString(PyExc_ValueError, "i2d() failed");
         goto error;
     }
     const_p = senc;
     newsession = d2i_SSL_SESSION(NULL, &const_p, slen);
     if (newsession == NULL) {
-        PyErr_SetString(PyExc_ValueError, "d2i() failed.");
+        PyErr_SetString(PyExc_ValueError, "d2i() failed");
         goto error;
     }
     PyMem_Free(senc);

--- a/Modules/_ssl.c
+++ b/Modules/_ssl.c
@@ -2822,7 +2822,8 @@ _ssl_session_dup(SSL_SESSION *session) {
     }
     const_p = senc;
     newsession = d2i_SSL_SESSION(NULL, &const_p, slen);
-    if (session == NULL) {
+    if (newsession == NULL) {
+        PyErr_SetString(PyExc_ValueError, "d2i() failed.");
         goto error;
     }
     PyMem_Free(senc);


### PR DESCRIPTION
@vstinner you've recently commited to this module, would you have time to take a look at the fix I am proposing? :)

<!-- gh-issue-number: gh-106831 -->
* Issue: gh-106831
<!-- /gh-issue-number -->
