### PR TITLE
gh-86493: Use PyModule_Add() instead of PyModule_AddObjectRef()

### DIFF
--- a/Modules/_ctypes/_ctypes.c
+++ b/Modules/_ctypes/_ctypes.c
@@ -5740,15 +5740,9 @@ _ctypes_add_objects(PyObject *mod)
 {
 #define MOD_ADD(name, expr) \
     do { \
-        PyObject *obj = (expr); \
-        if (obj == NULL) { \
+        if (PyModule_Add(mod, name, (expr)) < 0) { \
             return -1; \
         } \
-        if (PyModule_AddObjectRef(mod, name, obj) < 0) { \
-            Py_DECREF(obj); \
-            return -1; \
-        } \
-        Py_DECREF(obj); \
     } while (0)
 
     MOD_ADD("_pointer_type_cache", Py_NewRef(_ctypes_ptrtype_cache));

--- a/Modules/_hashopenssl.c
+++ b/Modules/_hashopenssl.c
@@ -2189,7 +2189,6 @@ hashlib_init_constructors(PyObject *module)
      */
     PyModuleDef *mdef;
     PyMethodDef *fdef;
-    PyObject *proxy;
     PyObject *func, *name_obj;
     _hashlibstate *state = get_hashlib_state(module);
 
@@ -2224,17 +2223,8 @@ hashlib_init_constructors(PyObject *module)
         }
     }
 
-    proxy = PyDictProxy_New(state->constructs);
-    if (proxy == NULL) {
-        return -1;
-    }
-
-    int rc = PyModule_AddObjectRef(module, "_constructors", proxy);
-    Py_DECREF(proxy);
-    if (rc < 0) {
-        return -1;
-    }
-    return 0;
+    return PyModule_Add(module, "_constructors",
+                        PyDictProxy_New(state->constructs));
 }
 
 static int

--- a/Modules/_json.c
+++ b/Modules/_json.c
@@ -1756,22 +1756,12 @@ static int
 _json_exec(PyObject *module)
 {
     PyObject *PyScannerType = PyType_FromSpec(&PyScannerType_spec);
-    if (PyScannerType == NULL) {
-        return -1;
-    }
-    int rc = PyModule_AddObjectRef(module, "make_scanner", PyScannerType);
-    Py_DECREF(PyScannerType);
-    if (rc < 0) {
+    if (PyModule_Add(module, "make_scanner", PyScannerType) < 0) {
         return -1;
     }
 
     PyObject *PyEncoderType = PyType_FromSpec(&PyEncoderType_spec);
-    if (PyEncoderType == NULL) {
-        return -1;
-    }
-    rc = PyModule_AddObjectRef(module, "make_encoder", PyEncoderType);
-    Py_DECREF(PyEncoderType);
-    if (rc < 0) {
+    if (PyModule_Add(module, "make_encoder", PyEncoderType) < 0) {
         return -1;
     }
 

--- a/Modules/_sre/sre.c
+++ b/Modules/_sre/sre.c
@@ -3195,12 +3195,7 @@ do {                                                                \
 
 #define ADD_ULONG_CONSTANT(module, name, value)           \
     do {                                                  \
-        PyObject *o = PyLong_FromUnsignedLong(value);     \
-        if (!o)                                           \
-            goto error;                                   \
-        int res = PyModule_AddObjectRef(module, name, o); \
-        Py_DECREF(o);                                     \
-        if (res < 0) {                                    \
+        if (PyModule_Add(module, name, PyLong_FromUnsignedLong(value)) < 0) { \
             goto error;                                   \
         }                                                 \
 } while (0)

--- a/Modules/_ssl.c
+++ b/Modules/_ssl.c
@@ -5773,13 +5773,7 @@ static int
 sslmodule_add_option(PyObject *m, const char *name, uint64_t value)
 {
     Py_BUILD_ASSERT(sizeof(unsigned long long) >= sizeof(value));
-    PyObject *obj = PyLong_FromUnsignedLongLong(value);
-    if (obj == NULL) {
-        return -1;
-    }
-    int res = PyModule_AddObjectRef(m, name, obj);
-    Py_DECREF(obj);
-    return res;
+    return PyModule_Add(m, name, PyLong_FromUnsignedLongLong(value));
 }
 
 

--- a/Modules/_testcapi/mem.c
+++ b/Modules/_testcapi/mem.c
@@ -692,13 +692,11 @@ _PyTestCapi_Init_Mem(PyObject *mod)
 
     PyObject *v;
 #ifdef WITH_PYMALLOC
-    v = Py_NewRef(Py_True);
+    v = Py_True;
 #else
-    v = Py_NewRef(Py_False);
+    v = Py_False;
 #endif
-    int rc = PyModule_AddObjectRef(mod, "WITH_PYMALLOC", v);
-    Py_DECREF(v);
-    if (rc < 0) {
+    if (PyModule_AddObjectRef(mod, "WITH_PYMALLOC", v) < 0) {
         return -1;
     }
 

--- a/Modules/_testcapi/watchers.c
+++ b/Modules/_testcapi/watchers.c
@@ -516,13 +516,7 @@ static PyFunction_WatchCallback func_watcher_callbacks[NUM_TEST_FUNC_WATCHERS] =
 static int
 add_func_event(PyObject *module, const char *name, PyFunction_WatchEvent event)
 {
-    PyObject *value = PyLong_FromLong(event);
-    if (value == NULL) {
-        return -1;
-    }
-    int ok = PyModule_AddObjectRef(module, name, value);
-    Py_DECREF(value);
-    return ok;
+    return PyModule_Add(module, name, PyLong_FromLong(event));
 }
 
 static PyObject *

--- a/Modules/_testsinglephase.c
+++ b/Modules/_testsinglephase.c
@@ -137,13 +137,7 @@ init_module(PyObject *module, module_state *state)
     }
 
     double d = _PyTime_AsSecondsDouble(state->initialized);
-    PyObject *initialized = PyFloat_FromDouble(d);
-    if (initialized == NULL) {
-        return -1;
-    }
-    int rc = PyModule_AddObjectRef(module, "_module_initialized", initialized);
-    Py_DECREF(initialized);
-    if (rc < 0) {
+    if (PyModule_Add(module, "_module_initialized", PyFloat_FromDouble(d)) < 0) {
         return -1;
     }
 

--- a/Modules/pyexpat.c
+++ b/Modules/pyexpat.c
@@ -1812,16 +1812,13 @@ add_errors_module(PyObject *mod)
         goto error;
     }
 
-    int rc = PyModule_AddObjectRef(errors_module, "codes", codes_dict);
-    Py_CLEAR(codes_dict);
-    if (rc < 0) {
-        goto error;
+    if (PyModule_Add(errors_module, "codes", codes_dict) < 0) {
+        Py_DECREF(rev_codes_dict);
+        return -1;
     }
 
-    rc = PyModule_AddObjectRef(errors_module, "messages", rev_codes_dict);
-    Py_CLEAR(rev_codes_dict);
-    if (rc < 0) {
-        goto error;
+    if (PyModule_Add(errors_module, "messages", rev_codes_dict) < 0) {
+        return -1;
     }
 
     return 0;

--- a/Modules/socketmodule.c
+++ b/Modules/socketmodule.c
@@ -7425,9 +7425,7 @@ socket_exec(PyObject *m)
         sock_free_api(capi);
         goto error;
     }
-    int rc = PyModule_AddObjectRef(m, PySocket_CAPI_NAME, capsule);
-    Py_DECREF(capsule);
-    if (rc < 0) {
+    if (PyModule_Add(m, PySocket_CAPI_NAME, capsule) < 0) {
         goto error;
     }
 
@@ -8818,13 +8816,7 @@ socket_exec(PyObject *m)
         };
         int i;
         for (i = 0; i < Py_ARRAY_LENGTH(codes); ++i) {
-            PyObject *tmp = PyLong_FromUnsignedLong(codes[i]);
-            if (tmp == NULL) {
-                goto error;
-            }
-            int rc = PyModule_AddObjectRef(m, names[i], tmp);
-            Py_DECREF(tmp);
-            if (rc < 0) {
+            if (PyModule_Add(m, names[i], PyLong_FromUnsignedLong(codes[i])) < 0) {
                 goto error;
             }
         }

--- a/Modules/unicodedata.c
+++ b/Modules/unicodedata.c
@@ -1496,13 +1496,7 @@ unicodedata_exec(PyObject *module)
     }
 
     /* Export C API */
-    PyObject *capsule = unicodedata_create_capi();
-    if (capsule == NULL) {
-        return -1;
-    }
-    int rc = PyModule_AddObjectRef(module, "_ucnhash_CAPI", capsule);
-    Py_DECREF(capsule);
-    if (rc < 0) {
+    if (PyModule_Add(module, "_ucnhash_CAPI", unicodedata_create_capi()) < 0) {
         return -1;
     }
     return 0;

--- a/PC/msvcrtmodule.c
+++ b/PC/msvcrtmodule.c
@@ -565,15 +565,9 @@ static struct PyMethodDef msvcrt_functions[] = {
 };
 
 static int
-insertptr(PyObject *mod, char *name, void *value)
+insertptr(PyObject *mod, const char *name, void *value)
 {
-    PyObject *v = PyLong_FromVoidPtr(value);
-    if (v == NULL) {
-        return -1;
-    }
-    int rc = PyModule_AddObjectRef(mod, name, v);
-    Py_DECREF(v);
-    return rc;
+    return PyModule_Add(mod, name, PyLong_FromVoidPtr(value));
 }
 
 #define INSERTINT(MOD, NAME, VAL) do {                  \
@@ -646,12 +640,7 @@ exec_module(PyObject* m)
                                              _VC_CRT_MINOR_VERSION,
                                              _VC_CRT_BUILD_VERSION,
                                              _VC_CRT_RBUILD_VERSION);
-    if (version == NULL) {
-        return -1;
-    }
-    int st = PyModule_AddObjectRef(m, "CRT_ASSEMBLY_VERSION", version);
-    Py_DECREF(version);
-    if (st < 0) {
+    if (PyModule_Add(m, "CRT_ASSEMBLY_VERSION", version) < 0) {
         return -1;
     }
 #endif

--- a/PC/winreg.c
+++ b/PC/winreg.c
@@ -2079,15 +2079,9 @@ static struct PyMethodDef winreg_methods[] = {
 } while (0)
 
 static int
-inskey(PyObject *mod, char *name, HKEY key)
+inskey(PyObject *mod, const char *name, HKEY key)
 {
-    PyObject *v = PyLong_FromVoidPtr(key);
-    if (v == NULL) {
-        return -1;
-    }
-    int rc = PyModule_AddObjectRef(mod, name, v);
-    Py_DECREF(v);
-    return rc;
+    return PyModule_Add(mod, name, PyLong_FromVoidPtr(key));
 }
 
 #define ADD_KEY(VAL) do {           \

--- a/Python/import.c
+++ b/Python/import.c
@@ -3844,14 +3844,9 @@ imp_module_exec(PyObject *module)
 {
     const wchar_t *mode = _Py_GetConfig()->check_hash_pycs_mode;
     PyObject *pyc_mode = PyUnicode_FromWideChar(mode, -1);
-    if (pyc_mode == NULL) {
+    if (PyModule_Add(module, "check_hash_based_pycs", pyc_mode) < 0) {
         return -1;
     }
-    if (PyModule_AddObjectRef(module, "check_hash_based_pycs", pyc_mode) < 0) {
-        Py_DECREF(pyc_mode);
-        return -1;
-    }
-    Py_DECREF(pyc_mode);
 
     return 0;
 }


### PR DESCRIPTION
If `PyModule_AddObjectRef()` followed by `Py_DECREF()` of the added value, the code can be simplified by using `PyModule_Add()` which was designed specially for such cases.

<!-- gh-issue-number: gh-86493 -->
* Issue: gh-86493
<!-- /gh-issue-number -->
