### PR TITLE
gh-106865: Improve `difflib.find_longest_match` performance with cache

### DIFF
--- a/Misc/NEWS.d/next/Library/2023-07-18-23-45-19.gh-issue-106865.dxO3Qr.rst
+++ b/Misc/NEWS.d/next/Library/2023-07-18-23-45-19.gh-issue-106865.dxO3Qr.rst
@@ -1,0 +1,1 @@
+Improve performance of :func:`difflib.SequenceMatcher.find_longest_match` with a cache on hot path


### PR DESCRIPTION
`difflib.SequenceMatcher` does not perform well on large input. This patch tries to improve it by doing some micro optimization on hot path.

When dealing with large inputs, for example, large files, almost all the time is spent in `find_longest_match`, and the hottest code is the nested for loop:

```python
      for i in range(alo, ahi):
          # look at all instances of a[i] in b; note that because
          # b2j has no junk keys, the loop is skipped if a[i] is junk
          j2lenget = j2len.get
          newj2len = {}
          for j in b2j.get(a[i], nothing):
              # a[i] matches b[j]
              if j < blo:
                  continue
              if j >= bhi:
                  break
              k = newj2len[j] = j2lenget(j-1, 0) + 1
              if k > bestsize:
                  besti, bestj, bestsize = i-k+1, j-k+1, k
```

The content in the for loop will execute `(ahi - alo) * len(b2j[a[i]])` times. Any optimization in the loop could potentially be a large improvement.

The patch runs the same loop for the first time `a[i]` is found, except that it creates a cache for the valid `b2j` list - list with `j` inside the range `(blo, bhi)`. If `a[i]` already appears before, then the cached list would be used - then the two if checks can be removed.

Also, if `a[i]` already appears before and there is at least one valid content in the list, `bestsize` would be already set to at least `1` - we can then only do the `if k > bestsize` check when `k` is greater than `1` - which happens to be already checked if we use `if` to check whether `j-1` is in the dict.

In this way, we eliminated plenty of code on the cached path. This optimization is significant when the cached path is hit frequently, or the "item"s in `a` repeats frequently. This is the case for any large file (especially file with smaller vocabulary like ascii).

I tried this on some of files by hand - a c source file and a README file.

<details>
<summary>
benchmark code
</summary>

```python
import difflib
import time

with open("../viztracer/src/viztracer/modules/snaptrace.c") as f:
    code = f.read()

with open("../viztracer/README.md") as f:
    readme = f.read()

s = difflib.SequenceMatcher(None, code, code)

start = time.time()
s.get_opcodes()
print(time.time() - start)

s = difflib.SequenceMatcher(None, code, readme)

start = time.time()
s.get_opcodes()
print(time.time() - start)

s = difflib.SequenceMatcher(None, readme, code)

start = time.time()
s.get_opcodes()
print(time.time() - start)
```

</details>
<Summary>

The time spent improvement was significant:

```
0.6531200408935547
0.21375417709350586
0.7097032070159912
```

to

```
0.20792889595031738
0.11065959930419922
0.28839802742004395
```

This patch will have a small negative performance impact on smaller test cases and cases where none of the items in `a` duplicates. For example, it is significantly slower in `test_recursion_limit`:

```python
def test_recursion_limit(self):
        # Check if the problem described in patch #1413711 exists.
        limit = sys.getrecursionlimit()
        old = [(i%2 and "K:%d" or "V:A:%d") % i for i in range(limit*2)]
        new = [(i%2 and "K:%d" or "V:B:%d") % i for i in range(limit*2)]
        difflib.SequenceMatcher(None, old, new).get_opcodes()
```

However, in real world scenario, it does not make much sense to diff/match two sequences with a giant vocabulary, so in almost all actual use cases this should improve the performance. Especially on large sequences.

We can, however, check the vocabulary (`set(a) / len(a)`) and determine whether we want to do this optimization. Extra overhead, potentially better perf on worst case.

P.S. changing `cache.append` to `cacheappend = cache.append` does not have a observable impact, but I can do that if that's needed.

<!-- gh-issue-number: gh-106865 -->
* Issue: gh-106865
<!-- /gh-issue-number -->
