### PR TITLE
gh-106886: Ensure f_locals returns a Python object

### DIFF
--- a/Objects/frameobject.c
+++ b/Objects/frameobject.c
@@ -27,6 +27,9 @@ frame_getlocals(PyFrameObject *f, void *closure)
     if (PyFrame_FastToLocalsWithError(f) < 0)
         return NULL;
     PyObject *locals = f->f_frame->f_locals;
+    if (locals == NULL) {
+        Py_RETURN_NONE;
+    }
     return Py_NewRef(locals);
 }
 


### PR DESCRIPTION
According to the comments in [pycore_frame.h](https://github.com/python/cpython/blob/e6f96cf9c62e38514e8f5465a1c43f85d861adb2/Include/internal/pycore_frame.h#L55C30-L55C30), the field `f_locals` of `_PyInterpreterFrame` may be `NULL`. This would result in `frame_getframe`, which is used to implement the `f_locals` attribute on a Python `frame` object, to return `NULL` instead of `Py_None`.

<!-- gh-issue-number: gh-106886 -->
* Issue: gh-106886
<!-- /gh-issue-number -->
