### PR TITLE
gh-106882: asyncio.Server add version changed message for exposure from asyncio.base_events.Server

### DIFF
--- a/Doc/library/asyncio-eventloop.rst
+++ b/Doc/library/asyncio-eventloop.rst
@@ -1594,7 +1594,7 @@ Do not instantiate the :class:`Server` class directly.
       Server object is an asynchronous context manager since Python 3.7.
 
    .. versionchanged:: 3.11
-      :class:`base_events.Server` was exposed as :class:`Server` since Python 3.9.11 3.10.3 and 3.11.
+      This class was exposed publicly as ``asyncio.Server`` in Python 3.9.11, 3.10.3 and 3.11.
 
    .. method:: close()
 

--- a/Doc/library/asyncio-eventloop.rst
+++ b/Doc/library/asyncio-eventloop.rst
@@ -1593,6 +1593,9 @@ Do not instantiate the :class:`Server` class directly.
    .. versionchanged:: 3.7
       Server object is an asynchronous context manager since Python 3.7.
 
+   .. versionchanged:: 3.11
+      :class:`base_events.Server` was exposed as :class:`Server` since Python 3.9.11 3.10.3 and 3.11.
+
    .. method:: close()
 
       Stop serving: close listening sockets and set the :attr:`sockets`


### PR DESCRIPTION
## Key Info
This makes sure that the docs clearly show that in earlier versions of Python `asyncio.Server` could not be imported as such and was instead `asyncio.base_events.Server`.
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
##
Related PR's:
#31760 

<!-- gh-issue-number: gh-106882 -->
* Issue: gh-106882
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--106901.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->