### PR TITLE
gh-106909: Use role :const: for referencing module constants

### DIFF
--- a/Doc/c-api/exceptions.rst
+++ b/Doc/c-api/exceptions.rst
@@ -666,7 +666,7 @@ Signal Handling
    to interrupt an operation).
 
    If the given signal isn't handled by Python (it was set to
-   :data:`signal.SIG_DFL` or :data:`signal.SIG_IGN`), it will be ignored.
+   :py:const:`signal.SIG_DFL` or :py:const:`signal.SIG_IGN`), it will be ignored.
 
    If *signum* is outside of the allowed range of signal numbers, ``-1``
    is returned.  Otherwise, ``0`` is returned.  The error indicator is

--- a/Doc/c-api/init.rst
+++ b/Doc/c-api/init.rst
@@ -1161,7 +1161,7 @@ All of the following functions must be called after :c:func:`Py_Initialize`.
    function does not steal any references to *exc*. To prevent naive misuse, you
    must write your own C extension to call this.  Must be called with the GIL held.
    Returns the number of thread states modified; this is normally one, but will be
-   zero if the thread id isn't found.  If *exc* is :const:`NULL`, the pending
+   zero if the thread id isn't found.  If *exc* is ``NULL``, the pending
    exception (if any) for the thread is cleared. This raises no exceptions.
 
    .. versionchanged:: 3.7

--- a/Doc/faq/library.rst
+++ b/Doc/faq/library.rst
@@ -566,7 +566,7 @@ use ``p.read(n)``.
    Note on a bug in popen2: unless your program calls ``wait()`` or
    ``waitpid()``, finished child processes are never removed, and eventually
    calls to popen2 will fail because of a limit on the number of child
-   processes.  Calling :func:`os.waitpid` with the :data:`os.WNOHANG` option can
+   processes.  Calling :func:`os.waitpid` with the :const:`os.WNOHANG` option can
    prevent this; a good place to insert such a call would be before calling
    ``popen2`` again.
 

--- a/Doc/install/index.rst
+++ b/Doc/install/index.rst
@@ -313,9 +313,9 @@ install into it.  It is enabled with a simple option::
 
    python setup.py install --user
 
-Files will be installed into subdirectories of :data:`site.USER_BASE` (written
+Files will be installed into subdirectories of :const:`site.USER_BASE` (written
 as :file:`{userbase}` hereafter).  This scheme installs pure Python modules and
-extension modules in the same location (also known as :data:`site.USER_SITE`).
+extension modules in the same location (also known as :const:`site.USER_SITE`).
 Here are the values for UNIX, including macOS:
 
 =============== ===========================================================

--- a/Doc/library/_thread.rst
+++ b/Doc/library/_thread.rst
@@ -70,10 +70,10 @@ This module defines the following constants and functions:
    there is no guarantee that the interruption will happen immediately.
 
    If given, *signum* is the number of the signal to simulate.
-   If *signum* is not given, :data:`signal.SIGINT` is simulated.
+   If *signum* is not given, :const:`signal.SIGINT` is simulated.
 
    If the given signal isn't handled by Python (it was set to
-   :data:`signal.SIG_DFL` or :data:`signal.SIG_IGN`), this function does
+   :const:`signal.SIG_DFL` or :const:`signal.SIG_IGN`), this function does
    nothing.
 
    .. versionchanged:: 3.10

--- a/Doc/library/asyncio-dev.rst
+++ b/Doc/library/asyncio-dev.rst
@@ -34,7 +34,7 @@ There are several ways to enable asyncio debug mode:
 In addition to enabling the debug mode, consider also:
 
 * setting the log level of the :ref:`asyncio logger <asyncio-logger>` to
-  :py:data:`logging.DEBUG`, for example the following snippet of code
+  :py:const:`logging.DEBUG`, for example the following snippet of code
   can be run at startup of the application::
 
     logging.basicConfig(level=logging.DEBUG)
@@ -142,7 +142,7 @@ Logging
 asyncio uses the :mod:`logging` module and all logging is performed
 via the ``"asyncio"`` logger.
 
-The default log level is :py:data:`logging.INFO`, which can be easily
+The default log level is :py:const:`logging.INFO`, which can be easily
 adjusted::
 
    logging.getLogger("asyncio").setLevel(logging.WARNING)

--- a/Doc/library/asyncio-eventloop.rst
+++ b/Doc/library/asyncio-eventloop.rst
@@ -403,11 +403,11 @@ Opening network connections
    Open a streaming transport connection to a given
    address specified by *host* and *port*.
 
-   The socket family can be either :py:data:`~socket.AF_INET` or
-   :py:data:`~socket.AF_INET6` depending on *host* (or the *family*
+   The socket family can be either :py:const:`~socket.AF_INET` or
+   :py:const:`~socket.AF_INET6` depending on *host* (or the *family*
    argument, if provided).
 
-   The socket type will be :py:data:`~socket.SOCK_STREAM`.
+   The socket type will be :py:const:`~socket.SOCK_STREAM`.
 
    *protocol_factory* must be a callable returning an
    :ref:`asyncio protocol <asyncio-protocol>` implementation.
@@ -509,7 +509,7 @@ Opening network connections
 
    .. versionchanged:: 3.6
 
-      The socket option :py:data:`~socket.TCP_NODELAY` is set by default
+      The socket option :py:const:`~socket.TCP_NODELAY` is set by default
       for all TCP connections.
 
    .. versionchanged:: 3.7
@@ -552,11 +552,11 @@ Opening network connections
 
    Create a datagram connection.
 
-   The socket family can be either :py:data:`~socket.AF_INET`,
-   :py:data:`~socket.AF_INET6`, or :py:data:`~socket.AF_UNIX`,
+   The socket family can be either :py:const:`~socket.AF_INET`,
+   :py:const:`~socket.AF_INET6`, or :py:const:`~socket.AF_UNIX`,
    depending on *host* (or the *family* argument, if provided).
 
-   The socket type will be :py:data:`~socket.SOCK_DGRAM`.
+   The socket type will be :py:const:`~socket.SOCK_DGRAM`.
 
    *protocol_factory* must be a callable returning a
    :ref:`protocol <asyncio-protocol>` implementation.
@@ -581,7 +581,7 @@ Opening network connections
    * *reuse_port* tells the kernel to allow this endpoint to be bound to the
      same port as other existing endpoints are bound to, so long as they all
      set this flag when being created. This option is not supported on Windows
-     and some Unixes. If the :py:data:`~socket.SO_REUSEPORT` constant is not
+     and some Unixes. If the :py:const:`~socket.SO_REUSEPORT` constant is not
      defined then this capability is unsupported.
 
    * *allow_broadcast* tells the kernel to allow this endpoint to send
@@ -607,7 +607,7 @@ Opening network connections
 
    .. versionchanged:: 3.8.1
       The *reuse_address* parameter is no longer supported, as using
-      :py:data:`~sockets.SO_REUSEADDR` poses a significant security concern for
+      :py:const:`~sockets.SO_REUSEADDR` poses a significant security concern for
       UDP. Explicitly passing ``reuse_address=True`` will raise an exception.
 
       When multiple processes with differing UIDs assign sockets to an
@@ -616,7 +616,7 @@ Opening network connections
 
       For supported platforms, *reuse_port* can be used as a replacement for
       similar functionality. With *reuse_port*,
-      :py:data:`~sockets.SO_REUSEPORT` is used instead, which specifically
+      :py:const:`~sockets.SO_REUSEPORT` is used instead, which specifically
       prevents processes with differing UIDs from assigning sockets to the same
       socket address.
 
@@ -634,8 +634,8 @@ Opening network connections
 
    Create a Unix connection.
 
-   The socket family will be :py:data:`~socket.AF_UNIX`; socket
-   type will be :py:data:`~socket.SOCK_STREAM`.
+   The socket family will be :py:const:`~socket.AF_UNIX`; socket
+   type will be :py:const:`~socket.SOCK_STREAM`.
 
    A tuple of ``(transport, protocol)`` is returned on success.
 
@@ -671,7 +671,7 @@ Creating network servers
                         ssl_shutdown_timeout=None, \
                         start_serving=True)
 
-   Create a TCP server (socket type :data:`~socket.SOCK_STREAM`) listening
+   Create a TCP server (socket type :const:`~socket.SOCK_STREAM`) listening
    on *port* of the *host* address.
 
    Returns a :class:`Server` object.
@@ -699,10 +699,10 @@ Creating network servers
      be selected (note that if *host* resolves to multiple network interfaces,
      a different random port will be selected for each interface).
 
-   * *family* can be set to either :data:`socket.AF_INET` or
-     :data:`~socket.AF_INET6` to force the socket to use IPv4 or IPv6.
+   * *family* can be set to either :const:`socket.AF_INET` or
+     :const:`~socket.AF_INET6` to force the socket to use IPv4 or IPv6.
      If not set, the *family* will be determined from host name
-     (defaults to :data:`~socket.AF_UNSPEC`).
+     (defaults to :const:`~socket.AF_UNSPEC`).
 
    * *flags* is a bitmask for :meth:`getaddrinfo`.
 
@@ -756,7 +756,7 @@ Creating network servers
    .. versionchanged:: 3.6
 
       Added *ssl_handshake_timeout* and *start_serving* parameters.
-      The socket option :py:data:`~socket.TCP_NODELAY` is set by default
+      The socket option :py:const:`~socket.TCP_NODELAY` is set by default
       for all TCP connections.
 
    .. versionchanged:: 3.11
@@ -777,7 +777,7 @@ Creating network servers
                           start_serving=True)
 
    Similar to :meth:`loop.create_server` but works with the
-   :py:data:`~socket.AF_UNIX` socket family.
+   :py:const:`~socket.AF_UNIX` socket family.
 
    *path* is the name of a Unix domain socket, and is required,
    unless a *sock* argument is provided.  Abstract Unix sockets,

--- a/Doc/library/asyncio-platforms.rst
+++ b/Doc/library/asyncio-platforms.rst
@@ -37,7 +37,7 @@ All event loops on Windows do not support the following methods:
 
 * :meth:`loop.create_unix_connection` and
   :meth:`loop.create_unix_server` are not supported.
-  The :data:`socket.AF_UNIX` socket family is specific to Unix.
+  The :const:`socket.AF_UNIX` socket family is specific to Unix.
 
 * :meth:`loop.add_signal_handler` and
   :meth:`loop.remove_signal_handler` are not supported.

--- a/Doc/library/asyncio-subprocess.rst
+++ b/Doc/library/asyncio-subprocess.rst
@@ -249,7 +249,7 @@ their completion.
 
       Stop the child process.
 
-      On POSIX systems this method sends :py:data:`signal.SIGTERM` to the
+      On POSIX systems this method sends :py:const:`signal.SIGTERM` to the
       child process.
 
       On Windows the Win32 API function :c:func:`TerminateProcess` is

--- a/Doc/library/exceptions.rst
+++ b/Doc/library/exceptions.rst
@@ -659,8 +659,8 @@ depending on the system error code.
 
    Raised when an operation would block on an object (e.g. socket) set
    for non-blocking operation.
-   Corresponds to :c:data:`errno` :py:data:`~errno.EAGAIN`, :py:data:`~errno.EALREADY`,
-   :py:data:`~errno.EWOULDBLOCK` and :py:data:`~errno.EINPROGRESS`.
+   Corresponds to :c:data:`errno` :py:const:`~errno.EAGAIN`, :py:const:`~errno.EALREADY`,
+   :py:const:`~errno.EWOULDBLOCK` and :py:const:`~errno.EINPROGRESS`.
 
    In addition to those of :exc:`OSError`, :exc:`BlockingIOError` can have
    one more attribute:
@@ -674,7 +674,7 @@ depending on the system error code.
 .. exception:: ChildProcessError
 
    Raised when an operation on a child process failed.
-   Corresponds to :c:data:`errno` :py:data:`~errno.ECHILD`.
+   Corresponds to :c:data:`errno` :py:const:`~errno.ECHILD`.
 
 .. exception:: ConnectionError
 
@@ -688,40 +688,40 @@ depending on the system error code.
    A subclass of :exc:`ConnectionError`, raised when trying to write on a
    pipe while the other end has been closed, or trying to write on a socket
    which has been shutdown for writing.
-   Corresponds to :c:data:`errno` :py:data:`~errno.EPIPE` and :py:data:`~errno.ESHUTDOWN`.
+   Corresponds to :c:data:`errno` :py:const:`~errno.EPIPE` and :py:const:`~errno.ESHUTDOWN`.
 
 .. exception:: ConnectionAbortedError
 
    A subclass of :exc:`ConnectionError`, raised when a connection attempt
    is aborted by the peer.
-   Corresponds to :c:data:`errno` :py:data:`~errno.ECONNABORTED`.
+   Corresponds to :c:data:`errno` :py:const:`~errno.ECONNABORTED`.
 
 .. exception:: ConnectionRefusedError
 
    A subclass of :exc:`ConnectionError`, raised when a connection attempt
    is refused by the peer.
-   Corresponds to :c:data:`errno` :py:data:`~errno.ECONNREFUSED`.
+   Corresponds to :c:data:`errno` :py:const:`~errno.ECONNREFUSED`.
 
 .. exception:: ConnectionResetError
 
    A subclass of :exc:`ConnectionError`, raised when a connection is
    reset by the peer.
-   Corresponds to :c:data:`errno` :py:data:`~errno.ECONNRESET`.
+   Corresponds to :c:data:`errno` :py:const:`~errno.ECONNRESET`.
 
 .. exception:: FileExistsError
 
    Raised when trying to create a file or directory which already exists.
-   Corresponds to :c:data:`errno` :py:data:`~errno.EEXIST`.
+   Corresponds to :c:data:`errno` :py:const:`~errno.EEXIST`.
 
 .. exception:: FileNotFoundError
 
    Raised when a file or directory is requested but doesn't exist.
-   Corresponds to :c:data:`errno` :py:data:`~errno.ENOENT`.
+   Corresponds to :c:data:`errno` :py:const:`~errno.ENOENT`.
 
 .. exception:: InterruptedError
 
    Raised when a system call is interrupted by an incoming signal.
-   Corresponds to :c:data:`errno` :py:data:`~errno.EINTR`.
+   Corresponds to :c:data:`errno` :py:const:`~errno.EINTR`.
 
    .. versionchanged:: 3.5
       Python now retries system calls when a syscall is interrupted by a
@@ -732,7 +732,7 @@ depending on the system error code.
 
    Raised when a file operation (such as :func:`os.remove`) is requested
    on a directory.
-   Corresponds to :c:data:`errno` :py:data:`~errno.EISDIR`.
+   Corresponds to :c:data:`errno` :py:const:`~errno.EISDIR`.
 
 .. exception:: NotADirectoryError
 
@@ -740,28 +740,28 @@ depending on the system error code.
    something which is not a directory.  On most POSIX platforms, it may also be
    raised if an operation attempts to open or traverse a non-directory file as if
    it were a directory.
-   Corresponds to :c:data:`errno` :py:data:`~errno.ENOTDIR`.
+   Corresponds to :c:data:`errno` :py:const:`~errno.ENOTDIR`.
 
 .. exception:: PermissionError
 
    Raised when trying to run an operation without the adequate access
    rights - for example filesystem permissions.
-   Corresponds to :c:data:`errno` :py:data:`~errno.EACCES`,
-   :py:data:`~errno.EPERM`, and :py:data:`~errno.ENOTCAPABLE`.
+   Corresponds to :c:data:`errno` :py:const:`~errno.EACCES`,
+   :py:const:`~errno.EPERM`, and :py:const:`~errno.ENOTCAPABLE`.
 
    .. versionchanged:: 3.11.1
-      WASI's :py:data:`~errno.ENOTCAPABLE` is now mapped to
+      WASI's :py:const:`~errno.ENOTCAPABLE` is now mapped to
       :exc:`PermissionError`.
 
 .. exception:: ProcessLookupError
 
    Raised when a given process doesn't exist.
-   Corresponds to :c:data:`errno` :py:data:`~errno.ESRCH`.
+   Corresponds to :c:data:`errno` :py:const:`~errno.ESRCH`.
 
 .. exception:: TimeoutError
 
    Raised when a system function timed out at the system level.
-   Corresponds to :c:data:`errno` :py:data:`~errno.ETIMEDOUT`.
+   Corresponds to :c:data:`errno` :py:const:`~errno.ETIMEDOUT`.
 
 .. versionadded:: 3.3
    All the above :exc:`OSError` subclasses were added.

--- a/Doc/library/fcntl.rst
+++ b/Doc/library/fcntl.rst
@@ -172,9 +172,9 @@ The module defines the following functions:
    which the lock starts, relative to *whence*, and *whence* is as with
    :func:`io.IOBase.seek`, specifically:
 
-   * :const:`0` -- relative to the start of the file (:data:`os.SEEK_SET`)
-   * :const:`1` -- relative to the current buffer position (:data:`os.SEEK_CUR`)
-   * :const:`2` -- relative to the end of the file (:data:`os.SEEK_END`)
+   * :const:`0` -- relative to the start of the file (:const:`os.SEEK_SET`)
+   * :const:`1` -- relative to the current buffer position (:const:`os.SEEK_CUR`)
+   * :const:`2` -- relative to the end of the file (:const:`os.SEEK_END`)
 
    The default for *start* is 0, which means to start at the beginning of the file.
    The default for *len* is 0 which means to lock to the end of the file.  The
@@ -201,7 +201,7 @@ using the :func:`flock` call may be better.
 .. seealso::
 
    Module :mod:`os`
-      If the locking flags :data:`~os.O_SHLOCK` and :data:`~os.O_EXLOCK` are
+      If the locking flags :const:`~os.O_SHLOCK` and :const:`~os.O_EXLOCK` are
       present in the :mod:`os` module (on BSD only), the :func:`os.open`
       function provides an alternative to the :func:`lockf` and :func:`flock`
       functions.

--- a/Doc/library/ftplib.rst
+++ b/Doc/library/ftplib.rst
@@ -105,7 +105,7 @@ The module defines the following items:
    .. versionchanged:: 3.4
       The class now supports hostname check with
       :attr:`ssl.SSLContext.check_hostname` and *Server Name Indication* (see
-      :data:`ssl.HAS_SNI`).
+      :const:`ssl.HAS_SNI`).
 
    .. versionchanged:: 3.9
       If the *timeout* parameter is set to be zero, it will raise a
@@ -441,7 +441,7 @@ FTP_TLS Objects
    .. versionchanged:: 3.4
       The method now supports hostname check with
       :attr:`ssl.SSLContext.check_hostname` and *Server Name Indication* (see
-      :data:`ssl.HAS_SNI`).
+      :const:`ssl.HAS_SNI`).
 
 .. method:: FTP_TLS.ccc()
 

--- a/Doc/library/http.client.rst
+++ b/Doc/library/http.client.rst
@@ -83,7 +83,7 @@ The module provides the following classes:
 
    .. versionchanged:: 3.2
       This class now supports HTTPS virtual hosts if possible (that is,
-      if :data:`ssl.HAS_SNI` is true).
+      if :const:`ssl.HAS_SNI` is true).
 
    .. versionchanged:: 3.4
       The *strict* parameter was removed. HTTP 0.9-style "Simple Responses" are

--- a/Doc/library/imaplib.rst
+++ b/Doc/library/imaplib.rst
@@ -106,7 +106,7 @@ There's also a subclass for secure connections:
    .. versionchanged:: 3.4
       The class now supports hostname check with
       :attr:`ssl.SSLContext.check_hostname` and *Server Name Indication* (see
-      :data:`ssl.HAS_SNI`).
+      :const:`ssl.HAS_SNI`).
 
    .. versionchanged:: 3.9
       The optional *timeout* parameter was added.
@@ -503,7 +503,7 @@ An :class:`IMAP4` instance has the following methods:
    .. versionchanged:: 3.4
       The method now supports hostname check with
       :attr:`ssl.SSLContext.check_hostname` and *Server Name Indication* (see
-      :data:`ssl.HAS_SNI`).
+      :const:`ssl.HAS_SNI`).
 
 
 .. method:: IMAP4.status(mailbox, names)

--- a/Doc/library/io.rst
+++ b/Doc/library/io.rst
@@ -423,7 +423,7 @@ I/O Base Classes
 
       .. versionadded:: 3.3
          Some operating systems could support additional values, like
-         :data:`os.SEEK_HOLE` or :data:`os.SEEK_DATA`. The valid values
+         :const:`os.SEEK_HOLE` or :const:`os.SEEK_DATA`. The valid values
          for a file could depend on it being open in text or binary mode.
 
    .. method:: seekable()

--- a/Doc/library/multiprocessing.rst
+++ b/Doc/library/multiprocessing.rst
@@ -2707,7 +2707,7 @@ handler type) for messages from different processes to get mixed up.
    Returns the logger used by :mod:`multiprocessing`.  If necessary, a new one
    will be created.
 
-   When first created the logger has level :data:`logging.NOTSET` and no
+   When first created the logger has level :const:`logging.NOTSET` and no
    default handler. Messages sent to this logger will not by default propagate
    to the root logger.
 

--- a/Doc/library/optparse.rst
+++ b/Doc/library/optparse.rst
@@ -813,7 +813,7 @@ The first step in using :mod:`optparse` is to create an OptionParser instance.
       help option.  When :mod:`optparse` prints the usage string, it expands
       ``%prog`` to ``os.path.basename(sys.argv[0])`` (or to ``prog`` if you
       passed that keyword argument).  To suppress a usage message, pass the
-      special value :data:`optparse.SUPPRESS_USAGE`.
+      special value :const:`optparse.SUPPRESS_USAGE`.
 
    ``option_list`` (default: ``[]``)
       A list of Option objects to populate the parser with.  The options in
@@ -1079,7 +1079,7 @@ relevant to a particular option, or fail to pass a required option attribute,
    Help text to print for this option when listing all available options after
    the user supplies a :attr:`~Option.help` option (such as ``--help``).  If
    no help text is supplied, the option will be listed without help text.  To
-   hide this option, use the special value :data:`optparse.SUPPRESS_HELP`.
+   hide this option, use the special value :const:`optparse.SUPPRESS_HELP`.
 
 .. attribute:: Option.metavar
 
@@ -1251,7 +1251,7 @@ must specify for any option using that action.
 
   If no :attr:`~Option.help` string is supplied for an option, it will still be
   listed in the help message.  To omit an option entirely, use the special value
-  :data:`optparse.SUPPRESS_HELP`.
+  :const:`optparse.SUPPRESS_HELP`.
 
   :mod:`optparse` automatically adds a :attr:`~Option.help` option to all
   OptionParsers, so you do not normally need to create one.
@@ -1522,7 +1522,7 @@ OptionParser supports several other public methods:
 
    Set the usage string according to the rules described above for the ``usage``
    constructor keyword argument.  Passing ``None`` sets the default usage
-   string; use :data:`optparse.SUPPRESS_USAGE` to suppress a usage message.
+   string; use :const:`optparse.SUPPRESS_USAGE` to suppress a usage message.
 
 .. method:: OptionParser.print_usage(file=None)
 

--- a/Doc/library/os.rst
+++ b/Doc/library/os.rst
@@ -233,7 +233,7 @@ process and user.
    :data:`environ` and :data:`environb` are synchronized (modifying
    :data:`environb` updates :data:`environ`, and vice versa).
 
-   :data:`environb` is only available if :data:`supports_bytes_environ` is
+   :data:`environb` is only available if :const:`supports_bytes_environ` is
    ``True``.
 
    .. versionadded:: 3.2
@@ -331,7 +331,7 @@ process and user.
    future environment changes.
 
 
-   :func:`getenvb` is only available if :data:`supports_bytes_environ`
+   :func:`getenvb` is only available if :const:`supports_bytes_environ`
    is ``True``.
 
    .. availability:: Unix.
@@ -923,7 +923,7 @@ as internal buffering of data.
 
    In Linux kernel older than 5.3, the files pointed by *src* and *dst*
    must reside in the same filesystem, otherwise an :exc:`OSError` is
-   raised with :attr:`~OSError.errno` set to :data:`errno.EXDEV`.
+   raised with :attr:`~OSError.errno` set to :const:`errno.EXDEV`.
 
    This copy is done without the additional cost of transferring data
    from the kernel to user space and then back into the kernel. Additionally,
@@ -1181,7 +1181,7 @@ as internal buffering of data.
 
    .. versionadded:: 3.3
       Some operating systems could support additional values, like
-      :data:`os.SEEK_HOLE` or :data:`os.SEEK_DATA`.
+      :const:`os.SEEK_HOLE` or :const:`os.SEEK_DATA`.
 
 
 .. function:: open(path, flags, mode=0o777, *, dir_fd=None)
@@ -1422,7 +1422,7 @@ or `the MSDN <https://msdn.microsoft.com/en-us/library/z0kc8e3z.aspx>`_ on Windo
 
    If some data was successfully read, it will return the number of bytes read.
    If no bytes were read, it will return ``-1`` and set errno to
-   :data:`errno.EAGAIN`.
+   :const:`errno.EAGAIN`.
 
    .. availability:: Linux >= 4.14.
 
@@ -1627,7 +1627,7 @@ or `the MSDN <https://msdn.microsoft.com/en-us/library/z0kc8e3z.aspx>`_ on Windo
    *offset_dst*. The offset associated to the file descriptor that refers to a
    pipe must be ``None``. The files pointed by *src* and *dst* must reside in
    the same filesystem, otherwise an :exc:`OSError` is raised with
-   :attr:`~OSError.errno` set to :data:`errno.EXDEV`.
+   :attr:`~OSError.errno` set to :const:`errno.EXDEV`.
 
    This copy is done without the additional cost of transferring data
    from the kernel to user space and then back into the kernel. Additionally,
@@ -1960,18 +1960,18 @@ features:
    Set the flags of *path* to the numeric *flags*. *flags* may take a combination
    (bitwise OR) of the following values (as defined in the :mod:`stat` module):
 
-   * :data:`stat.UF_NODUMP`
-   * :data:`stat.UF_IMMUTABLE`
-   * :data:`stat.UF_APPEND`
-   * :data:`stat.UF_OPAQUE`
-   * :data:`stat.UF_NOUNLINK`
-   * :data:`stat.UF_COMPRESSED`
-   * :data:`stat.UF_HIDDEN`
-   * :data:`stat.SF_ARCHIVED`
-   * :data:`stat.SF_IMMUTABLE`
-   * :data:`stat.SF_APPEND`
-   * :data:`stat.SF_NOUNLINK`
-   * :data:`stat.SF_SNAPSHOT`
+   * :const:`stat.UF_NODUMP`
+   * :const:`stat.UF_IMMUTABLE`
+   * :const:`stat.UF_APPEND`
+   * :const:`stat.UF_OPAQUE`
+   * :const:`stat.UF_NOUNLINK`
+   * :const:`stat.UF_COMPRESSED`
+   * :const:`stat.UF_HIDDEN`
+   * :const:`stat.SF_ARCHIVED`
+   * :const:`stat.SF_IMMUTABLE`
+   * :const:`stat.SF_APPEND`
+   * :const:`stat.SF_NOUNLINK`
+   * :const:`stat.SF_SNAPSHOT`
 
    This function can support :ref:`not following symlinks <follow_symlinks>`.
 
@@ -1992,25 +1992,25 @@ features:
    following values (as defined in the :mod:`stat` module) or bitwise ORed
    combinations of them:
 
-   * :data:`stat.S_ISUID`
-   * :data:`stat.S_ISGID`
-   * :data:`stat.S_ENFMT`
-   * :data:`stat.S_ISVTX`
-   * :data:`stat.S_IREAD`
-   * :data:`stat.S_IWRITE`
-   * :data:`stat.S_IEXEC`
-   * :data:`stat.S_IRWXU`
-   * :data:`stat.S_IRUSR`
-   * :data:`stat.S_IWUSR`
-   * :data:`stat.S_IXUSR`
-   * :data:`stat.S_IRWXG`
-   * :data:`stat.S_IRGRP`
-   * :data:`stat.S_IWGRP`
-   * :data:`stat.S_IXGRP`
-   * :data:`stat.S_IRWXO`
-   * :data:`stat.S_IROTH`
-   * :data:`stat.S_IWOTH`
-   * :data:`stat.S_IXOTH`
+   * :const:`stat.S_ISUID`
+   * :const:`stat.S_ISGID`
+   * :const:`stat.S_ENFMT`
+   * :const:`stat.S_ISVTX`
+   * :const:`stat.S_IREAD`
+   * :const:`stat.S_IWRITE`
+   * :const:`stat.S_IEXEC`
+   * :const:`stat.S_IRWXU`
+   * :const:`stat.S_IRUSR`
+   * :const:`stat.S_IWUSR`
+   * :const:`stat.S_IXUSR`
+   * :const:`stat.S_IRWXG`
+   * :const:`stat.S_IRGRP`
+   * :const:`stat.S_IWGRP`
+   * :const:`stat.S_IXGRP`
+   * :const:`stat.S_IRWXO`
+   * :const:`stat.S_IROTH`
+   * :const:`stat.S_IWOTH`
+   * :const:`stat.S_IXOTH`
 
    This function can support :ref:`specifying a file descriptor <path_fd>`,
    :ref:`paths relative to directory descriptors <dir_fd>` and :ref:`not
@@ -4151,8 +4151,8 @@ written in Python, such as a mail server's external command delivery program.
    Send signal *sig* to the process *pid*.  Constants for the specific signals
    available on the host platform are defined in the :mod:`signal` module.
 
-   Windows: The :data:`signal.CTRL_C_EVENT` and
-   :data:`signal.CTRL_BREAK_EVENT` signals are special signals which can
+   Windows: The :const:`signal.CTRL_C_EVENT` and
+   :const:`signal.CTRL_BREAK_EVENT` signals are special signals which can
    only be sent to console processes which share a common console window,
    e.g., some subprocesses. Any other value for *sig* will cause the process
    to be unconditionally killed by the TerminateProcess API, and the exit code
@@ -4205,7 +4205,7 @@ written in Python, such as a mail server's external command delivery program.
       This flag indicates that the file descriptor will be non-blocking.
       If the process referred to by the file descriptor has not yet terminated,
       then an attempt to wait on the file descriptor using :manpage:`waitid(2)`
-      will immediately return the error :data:`~errno.EAGAIN` rather than blocking.
+      will immediately return the error :const:`~errno.EAGAIN` rather than blocking.
 
    .. availability:: Linux >= 5.10
    .. versionadded:: 3.12
@@ -4654,7 +4654,7 @@ written in Python, such as a mail server's external command delivery program.
 
    * :attr:`!si_pid` (process ID)
    * :attr:`!si_uid` (real user ID of the child)
-   * :attr:`!si_signo` (always :data:`~signal.SIGCHLD`)
+   * :attr:`!si_signo` (always :const:`~signal.SIGCHLD`)
    * :attr:`!si_status` (the exit status or signal number, depending on :attr:`!si_code`)
    * :attr:`!si_code` (see :data:`CLD_EXITED` for possible values)
 
@@ -4892,7 +4892,7 @@ used to determine the disposition of a process.
 .. function:: WIFCONTINUED(status)
 
    Return ``True`` if a stopped child has been resumed by delivery of
-   :data:`~signal.SIGCONT` (if the process has been continued from a job
+   :const:`~signal.SIGCONT` (if the process has been continued from a job
    control stop), otherwise return ``False``.
 
    See :data:`WCONTINUED` option.
@@ -5264,7 +5264,7 @@ Random numbers
    ``/dev/urandom`` devices.
 
    The flags argument is a bit mask that can contain zero or more of the
-   following values ORed together: :py:data:`os.GRND_RANDOM` and
+   following values ORed together: :py:const:`os.GRND_RANDOM` and
    :py:data:`GRND_NONBLOCK`.
 
    See also the `Linux getrandom() manual page

--- a/Doc/library/poplib.rst
+++ b/Doc/library/poplib.rst
@@ -77,7 +77,7 @@ The :mod:`poplib` module provides two classes:
    .. versionchanged:: 3.4
       The class now supports hostname check with
       :attr:`ssl.SSLContext.check_hostname` and *Server Name Indication* (see
-      :data:`ssl.HAS_SNI`).
+      :const:`ssl.HAS_SNI`).
 
    .. versionchanged:: 3.9
       If the *timeout* parameter is set to be zero, it will raise a
@@ -240,7 +240,7 @@ A :class:`POP3` instance has the following methods:
 
    This method supports hostname checking via
    :attr:`ssl.SSLContext.check_hostname` and *Server Name Indication* (see
-   :data:`ssl.HAS_SNI`).
+   :const:`ssl.HAS_SNI`).
 
    .. versionadded:: 3.4
 

--- a/Doc/library/shelve.rst
+++ b/Doc/library/shelve.rst
@@ -25,7 +25,7 @@ lots of shared  sub-objects.  The keys are ordinary strings.
    database file is opened for reading and writing.  The optional *flag* parameter
    has the same interpretation as the *flag* parameter of :func:`dbm.open`.
 
-   By default, pickles created with :data:`pickle.DEFAULT_PROTOCOL` are used
+   By default, pickles created with :const:`pickle.DEFAULT_PROTOCOL` are used
    to serialize values.  The version of the pickle protocol can be specified
    with the *protocol* parameter.
 
@@ -42,7 +42,7 @@ lots of shared  sub-objects.  The keys are ordinary strings.
    mutated).
 
    .. versionchanged:: 3.10
-      :data:`pickle.DEFAULT_PROTOCOL` is now used as the default pickle
+      :const:`pickle.DEFAULT_PROTOCOL` is now used as the default pickle
       protocol.
 
    .. versionchanged:: 3.11
@@ -119,7 +119,7 @@ Restrictions
    A subclass of :class:`collections.abc.MutableMapping` which stores pickled
    values in the *dict* object.
 
-   By default, pickles created with :data:`pickle.DEFAULT_PROTOCOL` are used
+   By default, pickles created with :const:`pickle.DEFAULT_PROTOCOL` are used
    to serialize values.  The version of the pickle protocol can be specified
    with the *protocol* parameter.  See the :mod:`pickle` documentation for a
    discussion of the pickle protocols.
@@ -143,7 +143,7 @@ Restrictions
       Added context manager support.
 
    .. versionchanged:: 3.10
-      :data:`pickle.DEFAULT_PROTOCOL` is now used as the default pickle
+      :const:`pickle.DEFAULT_PROTOCOL` is now used as the default pickle
       protocol.
 
 

--- a/Doc/library/smtplib.rst
+++ b/Doc/library/smtplib.rst
@@ -98,7 +98,7 @@ Protocol) and :rfc:`1869` (SMTP Service Extensions).
    .. versionchanged:: 3.4
       The class now supports hostname check with
       :attr:`ssl.SSLContext.check_hostname` and *Server Name Indication* (see
-      :data:`ssl.HAS_SNI`).
+      :const:`ssl.HAS_SNI`).
 
    .. versionchanged:: 3.9
       If the *timeout* parameter is set to be zero, it will raise a
@@ -418,7 +418,7 @@ An :class:`SMTP` instance has the following methods:
    .. versionchanged:: 3.4
       The method now supports hostname check with
       :attr:`SSLContext.check_hostname` and *Server Name Indicator* (see
-      :data:`~ssl.HAS_SNI`).
+      :const:`~ssl.HAS_SNI`).
 
    .. versionchanged:: 3.5
       The error raised for lack of STARTTLS support is now the

--- a/Doc/library/socket.rst
+++ b/Doc/library/socket.rst
@@ -2252,7 +2252,7 @@ This is because the previous execution has left the socket in a ``TIME_WAIT``
 state, and can't be immediately reused.
 
 There is a :mod:`socket` flag to set, in order to prevent this,
-:data:`socket.SO_REUSEADDR`::
+:const:`socket.SO_REUSEADDR`::
 
    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
    s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)

--- a/Doc/library/sqlite3.rst
+++ b/Doc/library/sqlite3.rst
@@ -299,7 +299,7 @@ Module functions
        Can be ``"DEFERRED"`` (default), ``"EXCLUSIVE"`` or ``"IMMEDIATE"``;
        or ``None`` to disable opening transactions implicitly.
        Has no effect unless :attr:`Connection.autocommit` is set to
-       :data:`~sqlite3.LEGACY_TRANSACTION_CONTROL` (the default).
+       :const:`~sqlite3.LEGACY_TRANSACTION_CONTROL` (the default).
    :type isolation_level: str | None
 
    :param bool check_same_thread:
@@ -334,7 +334,7 @@ Module functions
        See :attr:`Connection.autocommit` and
        :ref:`sqlite3-transaction-control-autocommit` for more information.
        *autocommit* currently defaults to
-       :data:`~sqlite3.LEGACY_TRANSACTION_CONTROL`.
+       :const:`~sqlite3.LEGACY_TRANSACTION_CONTROL`.
        The default will change to ``False`` in a future Python release.
    :type autocommit: bool
 
@@ -1818,9 +1818,9 @@ Blob objects
    .. method:: seek(offset, origin=os.SEEK_SET, /)
 
       Set the current access position of the blob to *offset*.  The *origin*
-      argument defaults to :data:`os.SEEK_SET` (absolute blob positioning).
-      Other values for *origin* are :data:`os.SEEK_CUR` (seek relative to the
-      current position) and :data:`os.SEEK_END` (seek relative to the blob’s
+      argument defaults to :const:`os.SEEK_SET` (absolute blob positioning).
+      Other values for *origin* are :const:`os.SEEK_CUR` (seek relative to the
+      current position) and :const:`os.SEEK_END` (seek relative to the blob’s
       end).
 
 

--- a/Doc/library/ssl.rst
+++ b/Doc/library/ssl.rst
@@ -139,7 +139,7 @@ purposes.
    The settings are: :data:`PROTOCOL_TLS_CLIENT` or
    :data:`PROTOCOL_TLS_SERVER`, :data:`OP_NO_SSLv2`, and :data:`OP_NO_SSLv3`
    with high encryption cipher suites without RC4 and
-   without unauthenticated cipher suites. Passing :data:`~Purpose.SERVER_AUTH`
+   without unauthenticated cipher suites. Passing :const:`~Purpose.SERVER_AUTH`
    as *purpose* sets :data:`~SSLContext.verify_mode` to :data:`CERT_REQUIRED`
    and either loads CA certificates (when at least one of *cafile*, *capath* or
    *cadata* is given) or uses :meth:`SSLContext.load_default_certs` to load
@@ -1484,9 +1484,9 @@ to speed up repeated connections from the same clients.
    load CA certificates from other locations, too.
 
    The *purpose* flag specifies what kind of CA certificates are loaded. The
-   default settings :data:`Purpose.SERVER_AUTH` loads certificates, that are
+   default settings :const:`Purpose.SERVER_AUTH` loads certificates, that are
    flagged and trusted for TLS web server authentication (client side
-   sockets). :data:`Purpose.CLIENT_AUTH` loads CA certificates for client
+   sockets). :const:`Purpose.CLIENT_AUTH` loads CA certificates for client
    certificate verification on the server side.
 
    .. versionadded:: 3.4
@@ -1729,7 +1729,7 @@ to speed up repeated connections from the same clients.
    Wrap an existing Python socket *sock* and return an instance of
    :attr:`SSLContext.sslsocket_class` (default :class:`SSLSocket`). The
    returned SSL socket is tied to the context, its settings and certificates.
-   *sock* must be a :data:`~socket.SOCK_STREAM` socket; other
+   *sock* must be a :const:`~socket.SOCK_STREAM` socket; other
    socket types are unsupported.
 
    The parameter ``server_side`` is a boolean which identifies whether

--- a/Doc/library/sys.rst
+++ b/Doc/library/sys.rst
@@ -697,7 +697,7 @@ always available.
    Return the current value of the flags that are used for
    :c:func:`dlopen` calls.  Symbolic names for the flag values can be
    found in the :mod:`os` module (``RTLD_xxx`` constants, e.g.
-   :data:`os.RTLD_LAZY`).
+   :const:`os.RTLD_LAZY`).
 
    .. availability:: Unix.
 
@@ -1368,7 +1368,7 @@ always available.
    ``sys.setdlopenflags(0)``.  To share symbols across extension modules, call as
    ``sys.setdlopenflags(os.RTLD_GLOBAL)``.  Symbolic names for the flag values
    can be found in the :mod:`os` module (``RTLD_xxx`` constants, e.g.
-   :data:`os.RTLD_LAZY`).
+   :const:`os.RTLD_LAZY`).
 
    .. availability:: Unix.
 

--- a/Doc/library/tempfile.rst
+++ b/Doc/library/tempfile.rst
@@ -59,7 +59,7 @@ The module defines the following user-callable items:
    platforms, it is a file-like object whose :attr:`!file` attribute is the
    underlying true file object.
 
-   The :py:data:`os.O_TMPFILE` flag is used if it is available and works
+   The :py:const:`os.O_TMPFILE` flag is used if it is available and works
    (Linux-specific, requires Linux kernel 3.11 or later).
 
    On platforms that are neither Posix nor Cygwin, TemporaryFile is an alias
@@ -69,7 +69,7 @@ The module defines the following user-callable items:
 
    .. versionchanged:: 3.5
 
-      The :py:data:`os.O_TMPFILE` flag is now used if available.
+      The :py:const:`os.O_TMPFILE` flag is now used if available.
 
    .. versionchanged:: 3.8
       Added *errors* parameter.

--- a/Doc/library/test.rst
+++ b/Doc/library/test.rst
@@ -472,7 +472,7 @@ The :mod:`test.support` module defines the following functions:
 
 .. function:: with_pymalloc()
 
-   Return :data:`_testcapi.WITH_PYMALLOC`.
+   Return :const:`_testcapi.WITH_PYMALLOC`.
 
 
 .. function:: requires(resource, msg=None)

--- a/Doc/library/unittest.mock.rst
+++ b/Doc/library/unittest.mock.rst
@@ -2485,7 +2485,7 @@ behaviour you can switch it off by setting the module level switch
 
 Alternatively you can just use ``vars(my_mock)`` (instance members) and
 ``dir(type(my_mock))`` (type members) to bypass the filtering irrespective of
-:data:`mock.FILTER_DIR`.
+:const:`mock.FILTER_DIR`.
 
 
 mock_open

--- a/Doc/library/urllib.request.rst
+++ b/Doc/library/urllib.request.rst
@@ -91,7 +91,7 @@ The :mod:`urllib.request` module defines the following functions:
 
    .. versionchanged:: 3.2
       HTTPS virtual hosts are now supported if possible (that is, if
-      :data:`ssl.HAS_SNI` is true).
+      :const:`ssl.HAS_SNI` is true).
 
    .. versionadded:: 3.2
       *data* can be an iterable object.

--- a/Doc/library/xml.rst
+++ b/Doc/library/xml.rst
@@ -73,7 +73,7 @@ decompression bomb         Safe                Safe                Safe         
 1. Expat 2.4.1 and newer is not vulnerable to the "billion laughs" and
    "quadratic blowup" vulnerabilities. Items still listed as vulnerable due to
    potential reliance on system-provided libraries. Check
-   :data:`pyexpat.EXPAT_VERSION`.
+   :const:`pyexpat.EXPAT_VERSION`.
 2. :mod:`xml.etree.ElementTree` doesn't expand external entities and raises a
    :exc:`ParserError` when an entity occurs.
 3. :mod:`xml.dom.minidom` doesn't expand external entities and simply returns

--- a/Doc/using/configure.rst
+++ b/Doc/using/configure.rst
@@ -97,7 +97,7 @@ General Options
 
 .. cmdoption:: --with-tzpath=<list of absolute paths separated by pathsep>
 
-   Select the default time zone search path for :data:`zoneinfo.TZPATH`.
+   Select the default time zone search path for :const:`zoneinfo.TZPATH`.
    See the :ref:`Compile-time configuration
    <zoneinfo_data_compile_time_config>` of the :mod:`zoneinfo` module.
 
@@ -112,7 +112,7 @@ General Options
    Build the ``_decimal`` extension module using a thread-local context rather
    than a coroutine-local context (default), see the :mod:`decimal` module.
 
-   See :data:`decimal.HAVE_CONTEXTVAR` and the :mod:`contextvars` module.
+   See :const:`decimal.HAVE_CONTEXTVAR` and the :mod:`contextvars` module.
 
    .. versionadded:: 3.9
 

--- a/Doc/whatsnew/2.7.rst
+++ b/Doc/whatsnew/2.7.rst
@@ -1556,9 +1556,9 @@ changes, or look through the Subversion logs for all the details.
   :issue:`8484`.)
 
   The version of OpenSSL being used is now available as the module
-  attributes :data:`ssl.OPENSSL_VERSION` (a string),
-  :data:`ssl.OPENSSL_VERSION_INFO` (a 5-tuple), and
-  :data:`ssl.OPENSSL_VERSION_NUMBER` (an integer).  (Added by Antoine
+  attributes :const:`ssl.OPENSSL_VERSION` (a string),
+  :const:`ssl.OPENSSL_VERSION_INFO` (a 5-tuple), and
+  :const:`ssl.OPENSSL_VERSION_NUMBER` (an integer).  (Added by Antoine
   Pitrou; :issue:`8321`.)
 
 * The :mod:`struct` module will no longer silently ignore overflow

--- a/Doc/whatsnew/3.10.rst
+++ b/Doc/whatsnew/3.10.rst
@@ -1253,8 +1253,8 @@ descriptors without copying between kernel address space and user
 address space, where one of the file descriptors must refer to a
 pipe. (Contributed by Pablo Galindo in :issue:`41625`.)
 
-Add :data:`~os.O_EVTONLY`, :data:`~os.O_FSYNC`, :data:`~os.O_SYMLINK`
-and :data:`~os.O_NOFOLLOW_ANY` for macOS.
+Add :const:`~os.O_EVTONLY`, :const:`~os.O_FSYNC`, :const:`~os.O_SYMLINK`
+and :const:`~os.O_NOFOLLOW_ANY` for macOS.
 (Contributed by Dong-hee Na in :issue:`43106`.)
 
 os.path
@@ -1319,7 +1319,7 @@ objects in the tree returned by :func:`pyclbr.readline` and
 shelve
 ------
 
-The :mod:`shelve` module now uses :data:`pickle.DEFAULT_PROTOCOL` by default
+The :mod:`shelve` module now uses :const:`pickle.DEFAULT_PROTOCOL` by default
 instead of :mod:`pickle` protocol ``3`` when creating shelves.
 (Contributed by Zackery Spytz in :issue:`34204`.)
 
@@ -1356,7 +1356,7 @@ The ssl module requires OpenSSL 1.1.1 or newer.
 (Contributed by Christian Heimes in :pep:`644` and :issue:`43669`.)
 
 The ssl module has preliminary support for OpenSSL 3.0.0 and new option
-:data:`~ssl.OP_IGNORE_UNEXPECTED_EOF`.
+:const:`~ssl.OP_IGNORE_UNEXPECTED_EOF`.
 (Contributed by Christian Heimes in :issue:`38820`, :issue:`43794`,
 :issue:`43788`, :issue:`43791`, :issue:`43799`, :issue:`43920`,
 :issue:`43789`, and :issue:`43811`.)
@@ -1387,7 +1387,7 @@ Add a *timeout* parameter to the :func:`ssl.get_server_certificate` function.
 The ssl module uses heap-types and multi-phase initialization.
 (Contributed by Christian Heimes in :issue:`42333`.)
 
-A new verify flag :data:`~ssl.VERIFY_X509_PARTIAL_CHAIN` has been added.
+A new verify flag :const:`~ssl.VERIFY_X509_PARTIAL_CHAIN` has been added.
 (Contributed by l0x in :issue:`40849`.)
 
 sqlite3
@@ -1413,7 +1413,7 @@ _thread
 -------
 
 :func:`_thread.interrupt_main` now takes an optional signal number to
-simulate (the default is still :data:`signal.SIGINT`).
+simulate (the default is still :const:`signal.SIGINT`).
 (Contributed by Antoine Pitrou in :issue:`43356`.)
 
 threading
@@ -1757,8 +1757,8 @@ Deprecated
   * :data:`~ssl.PROTOCOL_SSLv2`, :data:`~ssl.PROTOCOL_SSLv3`,
     :data:`~ssl.PROTOCOL_SSLv23`, :data:`~ssl.PROTOCOL_TLSv1`,
     :data:`~ssl.PROTOCOL_TLSv1_1`, :data:`~ssl.PROTOCOL_TLSv1_2`, and
-    :data:`~ssl.PROTOCOL_TLS` are deprecated in favor of
-    :data:`~ssl.PROTOCOL_TLS_CLIENT` and :data:`~ssl.PROTOCOL_TLS_SERVER`
+    :const:`~ssl.PROTOCOL_TLS` are deprecated in favor of
+    :const:`~ssl.PROTOCOL_TLS_CLIENT` and :const:`~ssl.PROTOCOL_TLS_SERVER`
 
   * :func:`~ssl.wrap_socket` is replaced by :meth:`ssl.SSLContext.wrap_socket`
 

--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -690,7 +690,7 @@ enum
 * Added the :func:`~enum.global_enum` enum decorator,
   which adjusts :meth:`~object.__repr__` and :meth:`~object.__str__`
   to show values as members of their module rather than the enum class.
-  For example, ``'re.ASCII'`` for the :data:`~re.ASCII` member
+  For example, ``'re.ASCII'`` for the :const:`~re.ASCII` member
   of :class:`re.RegexFlag` rather than ``'RegexFlag.ASCII'``.
 
 * Enhanced :class:`~enum.Flag` to support
@@ -1063,8 +1063,8 @@ threading
 
 * On Unix, if the ``sem_clockwait()`` function is available in the C library
   (glibc 2.30 and newer), the :meth:`threading.Lock.acquire` method now uses
-  the monotonic clock (:data:`time.CLOCK_MONOTONIC`) for the timeout, rather
-  than using the system clock (:data:`time.CLOCK_REALTIME`), to not be affected
+  the monotonic clock (:const:`time.CLOCK_MONOTONIC`) for the timeout, rather
+  than using the system clock (:const:`time.CLOCK_REALTIME`), to not be affected
   by system clock changes.
   (Contributed by Victor Stinner in :issue:`41710`.)
 
@@ -1812,7 +1812,7 @@ Standard Library
   (Contributed by Serhiy Storchaka in :gh:`91760`.)
 
 * In the :mod:`re` module, the :func:`!re.template` function
-  and the corresponding :data:`!re.TEMPLATE` and :data:`!re.T` flags
+  and the corresponding :const:`!re.TEMPLATE` and :const:`!re.T` flags
   are deprecated, as they were undocumented and lacked an obvious purpose.
   They will be removed in Python 3.13.
   (Contributed by Serhiy Storchaka and Miro Hrončok in :gh:`92728`.)

--- a/Doc/whatsnew/3.12.rst
+++ b/Doc/whatsnew/3.12.rst
@@ -555,7 +555,7 @@ calendar
 csv
 ---
 
-* Add :data:`~csv.QUOTE_NOTNULL` and :data:`~csv.QUOTE_STRINGS` flags to
+* Add :const:`~csv.QUOTE_NOTNULL` and :const:`~csv.QUOTE_STRINGS` flags to
   provide finer grained control of ``None`` and empty strings by
   :class:`~csv.writer` objects.
 
@@ -620,7 +620,7 @@ math
 os
 --
 
-* Add :data:`os.PIDFD_NONBLOCK` to open a file descriptor
+* Add :const:`os.PIDFD_NONBLOCK` to open a file descriptor
   for a process with :func:`os.pidfd_open` in non-blocking mode.
   (Contributed by Kumar Aditya in :gh:`93312`.)
 

--- a/Doc/whatsnew/3.2.rst
+++ b/Doc/whatsnew/3.2.rst
@@ -1666,9 +1666,9 @@ for secure (encrypted, authenticated) internet connections:
   algorithm" error.
 
 * The version of OpenSSL being used is now accessible using the module
-  attributes :data:`ssl.OPENSSL_VERSION` (a string),
-  :data:`ssl.OPENSSL_VERSION_INFO` (a 5-tuple), and
-  :data:`ssl.OPENSSL_VERSION_NUMBER` (an integer).
+  attributes :const:`ssl.OPENSSL_VERSION` (a string),
+  :const:`ssl.OPENSSL_VERSION_INFO` (a 5-tuple), and
+  :const:`ssl.OPENSSL_VERSION_NUMBER` (an integer).
 
 (Contributed by Antoine Pitrou in :issue:`8850`, :issue:`1589`, :issue:`8322`,
 :issue:`5639`, :issue:`4870`, :issue:`8484`, and :issue:`8321`.)

--- a/Doc/whatsnew/3.3.rst
+++ b/Doc/whatsnew/3.3.rst
@@ -842,7 +842,7 @@ Builtin functions and types
 
 * :func:`open` gets a new *opener* parameter: the underlying file descriptor
   for the file object is then obtained by calling *opener* with (*file*,
-  *flags*). It can be used to use custom flags like :data:`os.O_CLOEXEC` for
+  *flags*). It can be used to use custom flags like :const:`os.O_CLOEXEC` for
   example. The ``'x'`` mode was added: open for exclusive creation, failing if
   the file already exists.
 * :func:`print`: added the *flush* keyword argument. If the *flush* keyword
@@ -1127,7 +1127,7 @@ Features
 
 * If Python is compiled without threads, the C version automatically
   disables the expensive thread local context machinery. In this case,
-  the variable :data:`~decimal.HAVE_THREADS` is set to ``False``.
+  the variable :const:`~decimal.HAVE_THREADS` is set to ``False``.
 
 API changes
 ~~~~~~~~~~~
@@ -1576,8 +1576,8 @@ os
 --
 
 * The :mod:`os` module has a new :func:`~os.pipe2` function that makes it
-  possible to create a pipe with :data:`~os.O_CLOEXEC` or
-  :data:`~os.O_NONBLOCK` flags set atomically. This is especially useful to
+  possible to create a pipe with :const:`~os.O_CLOEXEC` or
+  :const:`~os.O_NONBLOCK` flags set atomically. This is especially useful to
   avoid race conditions in multi-threaded programs.
 
 * The :mod:`os` module has a new :func:`~os.sendfile` function which provides
@@ -1691,9 +1691,9 @@ os
 * Some platforms now support additional constants for the :func:`~os.lseek`
   function, such as ``os.SEEK_HOLE`` and ``os.SEEK_DATA``.
 
-* New constants :data:`~os.RTLD_LAZY`, :data:`~os.RTLD_NOW`,
-  :data:`~os.RTLD_GLOBAL`, :data:`~os.RTLD_LOCAL`, :data:`~os.RTLD_NODELETE`,
-  :data:`~os.RTLD_NOLOAD`, and :data:`~os.RTLD_DEEPBIND` are available on
+* New constants :const:`~os.RTLD_LAZY`, :const:`~os.RTLD_NOW`,
+  :const:`~os.RTLD_GLOBAL`, :const:`~os.RTLD_LOCAL`, :const:`~os.RTLD_NODELETE`,
+  :const:`~os.RTLD_NOLOAD`, and :const:`~os.RTLD_DEEPBIND` are available on
   platforms that support them.   These are for use with the
   :func:`sys.setdlopenflags` function, and supersede the similar constants
   defined in :mod:`ctypes` and :mod:`DLFCN`.  (Contributed by Victor Stinner
@@ -1995,7 +1995,7 @@ subprocess
 Command strings can now be bytes objects on posix platforms.  (Contributed by
 Victor Stinner in :issue:`8513`.)
 
-A new constant :data:`~subprocess.DEVNULL` allows suppressing output in a
+A new constant :const:`~subprocess.DEVNULL` allows suppressing output in a
 platform-independent fashion.  (Contributed by Ross Lagerwall in
 :issue:`5870`.)
 

--- a/Doc/whatsnew/3.4.rst
+++ b/Doc/whatsnew/3.4.rst
@@ -775,7 +775,7 @@ of a given opcode and argument, information that is not otherwise available.
 doctest
 -------
 
-A new :ref:`option flag <doctest-options>`, :data:`~doctest.FAIL_FAST`, halts
+A new :ref:`option flag <doctest-options>`, :const:`~doctest.FAIL_FAST`, halts
 test running as soon as the first failure is detected.  (Contributed by R.
 David Murray and Daniel Urban in :issue:`16522`.)
 
@@ -841,7 +841,7 @@ for example, if the file might have been changed and re-checked in less time
 than the resolution of a particular filesystem's file modification time field.
 (Contributed by Mark Levitt in :issue:`18149`.)
 
-New module attribute :data:`~filecmp.DEFAULT_IGNORES` provides the list of
+New module attribute :const:`~filecmp.DEFAULT_IGNORES` provides the list of
 directories that are used as the default value for the *ignore* parameter of
 the :func:`~filecmp.dircmp` function.  (Contributed by Eli Bendersky in
 :issue:`15442`.)
@@ -1189,7 +1189,7 @@ Windows).  (Contributed by Brian Curtin in :issue:`11939`.)
 root on Windows.  (Contributed by Tim Golden in :issue:`9035`.)
 
 :func:`os.open` supports two new flags on platforms that provide them,
-:data:`~os.O_PATH` (un-opened file descriptor), and :data:`~os.O_TMPFILE`
+:const:`~os.O_PATH` (un-opened file descriptor), and :const:`~os.O_TMPFILE`
 (unnamed temporary file; as of 3.4.0 release available only on Linux systems
 with a kernel version of 3.11 or newer that have uapi headers).  (Contributed
 by Christian Heimes in :issue:`18673` and Benjamin Peterson, respectively.)
@@ -1238,8 +1238,8 @@ plistlib
 stdlib serialization protocols, with new :func:`~plistlib.load`,
 :func:`~plistlib.dump`, :func:`~plistlib.loads`, and :func:`~plistlib.dumps`
 functions.  (The older API is now deprecated.)  In addition to the already
-supported XML plist format (:data:`~plistlib.FMT_XML`), it also now supports
-the binary plist format (:data:`~plistlib.FMT_BINARY`).  (Contributed by Ronald
+supported XML plist format (:const:`~plistlib.FMT_XML`), it also now supports
+the binary plist format (:const:`~plistlib.FMT_BINARY`).  (Contributed by Ronald
 Oussoren and others in :issue:`14455`.)
 
 
@@ -1388,7 +1388,7 @@ try/except statement by code that only cares whether or not an error occurred.
 socket
 ------
 
-The socket module now supports the :data:`~socket.CAN_BCM` protocol on
+The socket module now supports the :const:`~socket.CAN_BCM` protocol on
 platforms that support it.  (Contributed by Brian Thorne in :issue:`15359`.)
 
 Socket objects have new methods to get or set their :ref:`inheritable flag
@@ -1399,7 +1399,7 @@ The ``socket.AF_*`` and ``socket.SOCK_*`` constants are now enumeration values
 using the new :mod:`enum` module.  This allows meaningful names to be printed
 during debugging, instead of integer "magic numbers".
 
-The :data:`~socket.AF_LINK` constant is now available on BSD and OSX.
+The :const:`~socket.AF_LINK` constant is now available on BSD and OSX.
 
 :func:`~socket.inet_pton` and :func:`~socket.inet_ntop` are now supported
 on Windows.  (Contributed by Atsuo Ishimoto in :issue:`7171`.)
@@ -1460,8 +1460,8 @@ Heimes in :issue:`18147`.)
 If OpenSSL 0.9.8 or later is available, :class:`~ssl.SSLContext` has a new
 attribute :attr:`~ssl.SSLContext.verify_flags` that can be used to control the
 certificate verification process by setting it to some combination of the new
-constants :data:`~ssl.VERIFY_DEFAULT`, :data:`~ssl.VERIFY_CRL_CHECK_LEAF`,
-:data:`~ssl.VERIFY_CRL_CHECK_CHAIN`, or :data:`~ssl.VERIFY_X509_STRICT`.
+constants :const:`~ssl.VERIFY_DEFAULT`, :const:`~ssl.VERIFY_CRL_CHECK_LEAF`,
+:const:`~ssl.VERIFY_CRL_CHECK_CHAIN`, or :const:`~ssl.VERIFY_X509_STRICT`.
 OpenSSL does not do any CRL verification by default.  (Contributed by
 Christien Heimes in :issue:`8813`.)
 

--- a/Doc/whatsnew/3.5.rst
+++ b/Doc/whatsnew/3.5.rst
@@ -478,7 +478,7 @@ not make an additional system call::
 PEP 475: Retry system calls failing with EINTR
 ----------------------------------------------
 
-An :py:data:`errno.EINTR` error code is returned whenever a system call, that
+An :py:const:`errno.EINTR` error code is returned whenever a system call, that
 is waiting for I/O, is interrupted by a signal.  Previously, Python would
 raise :exc:`InterruptedError` in such cases.  This meant that, when writing a
 Python application, the developer had two choices:
@@ -527,7 +527,7 @@ by a signal:
   :func:`~os.writev`;
 
 * special cases: :func:`os.close` and :func:`os.dup2` now ignore
-  :py:data:`~errno.EINTR` errors; the syscall is not retried (see the PEP
+  :py:const:`~errno.EINTR` errors; the syscall is not retried (see the PEP
   for the rationale);
 
 * :mod:`select` functions: :func:`devpoll.poll() <select.devpoll.poll>`,
@@ -1498,7 +1498,7 @@ use ``/dev/urandom`` and avoiding failures due to potential file descriptor
 exhaustion.  (Contributed by Victor Stinner in :issue:`22181`.)
 
 New :func:`~os.get_blocking` and :func:`~os.set_blocking` functions allow
-getting and setting a file descriptor's blocking mode (:data:`~os.O_NONBLOCK`.)
+getting and setting a file descriptor's blocking mode (:const:`~os.O_NONBLOCK`.)
 (Contributed by Victor Stinner in :issue:`22054`.)
 
 The :func:`~os.truncate` and :func:`~os.ftruncate` functions are now supported
@@ -1783,7 +1783,7 @@ the TLS handshake.
 The new
 :meth:`SSLSocket.selected_alpn_protocol() <ssl.SSLSocket.selected_alpn_protocol>`
 returns the protocol that was selected during the TLS handshake.
-The :data:`~ssl.HAS_ALPN` flag indicates whether ALPN support is present.
+The :const:`~ssl.HAS_ALPN` flag indicates whether ALPN support is present.
 
 
 Other Changes
@@ -2476,7 +2476,7 @@ Changes in the Python API
   in Python 3.5, all old ``.pyo`` files from previous versions of Python are
   invalid regardless of this PEP.
 
-* The :mod:`socket` module now exports the :data:`~socket.CAN_RAW_FD_FRAMES`
+* The :mod:`socket` module now exports the :const:`~socket.CAN_RAW_FD_FRAMES`
   constant on linux 3.6 and greater.
 
 * The :func:`ssl.cert_time_to_seconds` function now interprets the input time

--- a/Doc/whatsnew/3.6.rst
+++ b/Doc/whatsnew/3.6.rst
@@ -1404,7 +1404,7 @@ socket
 ------
 
 The :func:`~socket.socket.ioctl` function now supports the
-:data:`~socket.SIO_LOOPBACK_FAST_PATH` control code.
+:const:`~socket.SIO_LOOPBACK_FAST_PATH` control code.
 (Contributed by Daniel Stokes in :issue:`26536`.)
 
 The :meth:`~socket.socket.getsockopt` constants ``SO_DOMAIN``,
@@ -1416,7 +1416,7 @@ The :meth:`~socket.socket.setsockopt` now supports the
 (Contributed by Christian Heimes in :issue:`27744`.)
 
 The socket module now supports the address family
-:data:`~socket.AF_ALG` to interface with Linux Kernel crypto API. ``ALG_*``,
+:const:`~socket.AF_ALG` to interface with Linux Kernel crypto API. ``ALG_*``,
 ``SOL_ALG`` and :meth:`~socket.socket.sendmsg_afalg` were added.
 (Contributed by Christian Heimes in :issue:`27744` with support from
 Victor Stinner.)

--- a/Doc/whatsnew/3.7.rst
+++ b/Doc/whatsnew/3.7.rst
@@ -1280,13 +1280,13 @@ This function should be used instead of :func:`os.close` for better
 compatibility across platforms.
 (Contributed by Christian Heimes in :issue:`32454`.)
 
-The :mod:`socket` module now exposes the :data:`socket.TCP_CONGESTION`
-(Linux 2.6.13), :data:`socket.TCP_USER_TIMEOUT` (Linux 2.6.37), and
-:data:`socket.TCP_NOTSENT_LOWAT` (Linux 3.12) constants.
+The :mod:`socket` module now exposes the :const:`socket.TCP_CONGESTION`
+(Linux 2.6.13), :const:`socket.TCP_USER_TIMEOUT` (Linux 2.6.37), and
+:const:`socket.TCP_NOTSENT_LOWAT` (Linux 3.12) constants.
 (Contributed by Omar Sandoval in :issue:`26273` and
 Nathaniel J. Smith in :issue:`29728`.)
 
-Support for :data:`socket.AF_VSOCK` sockets has been added to allow
+Support for :const:`socket.AF_VSOCK` sockets has been added to allow
 communication between virtual machines and their hosts.
 (Contributed by Cathy Avery in :issue:`27584`.)
 
@@ -1394,7 +1394,7 @@ subprocess
 
 The :func:`subprocess.run` function accepts the new *capture_output*
 keyword argument.  When true, stdout and stderr will be captured.
-This is equivalent to passing :data:`subprocess.PIPE` as *stdout* and
+This is equivalent to passing :const:`subprocess.PIPE` as *stdout* and
 *stderr* arguments.
 (Contributed by Bo Bayles in :issue:`32102`.)
 
@@ -1453,12 +1453,12 @@ time
 
 New clock identifiers have been added:
 
-* :data:`time.CLOCK_BOOTTIME` (Linux): Identical to
-  :data:`time.CLOCK_MONOTONIC`, except it also includes any time that the
+* :const:`time.CLOCK_BOOTTIME` (Linux): Identical to
+  :const:`time.CLOCK_MONOTONIC`, except it also includes any time that the
   system is suspended.
-* :data:`time.CLOCK_PROF` (FreeBSD, NetBSD and OpenBSD): High-resolution
+* :const:`time.CLOCK_PROF` (FreeBSD, NetBSD and OpenBSD): High-resolution
   per-process CPU timer.
-* :data:`time.CLOCK_UPTIME` (FreeBSD, OpenBSD): Time whose absolute value is
+* :const:`time.CLOCK_UPTIME` (FreeBSD, OpenBSD): Time whose absolute value is
   the time the system has been running and not suspended, providing accurate
   uptime measurement.
 

--- a/Doc/whatsnew/3.8.rst
+++ b/Doc/whatsnew/3.8.rst
@@ -1305,7 +1305,7 @@ Zackery Spytz in :issue:`25451`.)
 time
 ----
 
-Added new clock :data:`~time.CLOCK_UPTIME_RAW` for macOS 10.12.
+Added new clock :const:`~time.CLOCK_UPTIME_RAW` for macOS 10.12.
 (Contributed by Joannah Nanjekye in :issue:`35702`.)
 
 

--- a/Doc/whatsnew/3.9.rst
+++ b/Doc/whatsnew/3.9.rst
@@ -427,8 +427,8 @@ digests. It skips MD5 on platforms that block MD5 digest.
 fcntl
 -----
 
-Added constants :data:`~fcntl.F_OFD_GETLK`, :data:`~fcntl.F_OFD_SETLK`
-and :data:`~fcntl.F_OFD_SETLKW`.
+Added constants :const:`~fcntl.F_OFD_GETLK`, :const:`~fcntl.F_OFD_SETLK`
+and :const:`~fcntl.F_OFD_SETLKW`.
 (Contributed by Dong-hee Na in :issue:`38602`.)
 
 ftplib
@@ -593,11 +593,11 @@ a non-blocking socket. (Contributed by Dong-hee Na in :issue:`39259`.)
 os
 --
 
-Added :data:`~os.CLD_KILLED` and :data:`~os.CLD_STOPPED` for :attr:`si_code`.
+Added :const:`~os.CLD_KILLED` and :const:`~os.CLD_STOPPED` for :attr:`si_code`.
 (Contributed by Dong-hee Na in :issue:`38493`.)
 
 Exposed the Linux-specific :func:`os.pidfd_open` (:issue:`38692`) and
-:data:`os.P_PIDFD` (:issue:`38713`) for process management with file
+:const:`os.P_PIDFD` (:issue:`38713`) for process management with file
 descriptors.
 
 The :func:`os.unsetenv` function is now also available on Windows.
@@ -669,11 +669,11 @@ a non-blocking socket. (Contributed by Dong-hee Na in :issue:`39259`.)
 socket
 ------
 
-The :mod:`socket` module now exports the :data:`~socket.CAN_RAW_JOIN_FILTERS`
+The :mod:`socket` module now exports the :const:`~socket.CAN_RAW_JOIN_FILTERS`
 constant on Linux 4.1 and greater.
 (Contributed by Stefan Tatschner and Zackery Spytz in :issue:`25780`.)
 
-The socket module now supports the :data:`~socket.CAN_J1939` protocol on
+The socket module now supports the :const:`~socket.CAN_J1939` protocol on
 platforms that support it.  (Contributed by Karl Ding in :issue:`40291`.)
 
 The socket module now has the :func:`socket.send_fds` and
@@ -1084,7 +1084,7 @@ Changes in the Python API
   ``__VENV_PROMPT__`` is set to ``""``.
 
 * The :meth:`select.epoll.unregister` method no longer ignores the
-  :data:`~errno.EBADF` error.
+  :const:`~errno.EBADF` error.
   (Contributed by Victor Stinner in :issue:`39239`.)
 
 * The *compresslevel* parameter of :class:`bz2.BZ2File` became keyword-only,

--- a/Misc/NEWS.d/3.10.0a1.rst
+++ b/Misc/NEWS.d/3.10.0a1.rst
@@ -2176,7 +2176,7 @@ None.
 .. nonce: YoYoYo
 .. section: Library
 
-Add a new :data:`os.RWF_APPEND` flag for :func:`os.pwritev`.
+Add a new :const:`os.RWF_APPEND` flag for :func:`os.pwritev`.
 
 ..
 
@@ -2304,7 +2304,7 @@ Restored the deprecated :mod:`xml.etree.cElementTree` module.
 .. nonce: ZCk0_c
 .. section: Library
 
-:data:`~mmap.MAP_POPULATE` constant has now been added to the list of
+:const:`~mmap.MAP_POPULATE` constant has now been added to the list of
 exported :mod:`mmap` module flags.
 
 ..

--- a/Misc/NEWS.d/3.10.0a2.rst
+++ b/Misc/NEWS.d/3.10.0a2.rst
@@ -604,7 +604,7 @@ changes the working directory.  PR by Anthony Sottile.
 .. nonce: 9wXTtY
 .. section: Library
 
-The :mod:`shelve` module now uses :data:`pickle.DEFAULT_PROTOCOL` by default
+The :mod:`shelve` module now uses :const:`pickle.DEFAULT_PROTOCOL` by default
 instead of :mod:`pickle` protocol ``3``.
 
 ..

--- a/Misc/NEWS.d/3.10.0a6.rst
+++ b/Misc/NEWS.d/3.10.0a6.rst
@@ -294,8 +294,8 @@ actual dictionary.  This created problems for introspection tools.
 .. nonce: SwcSuU
 .. section: Library
 
-Added :data:`~os.O_EVTONLY`, :data:`~os.O_FSYNC`, :data:`~os.O_SYMLINK` and
-:data:`~os.O_NOFOLLOW_ANY` for macOS. Patch by Dong-hee Na.
+Added :const:`~os.O_EVTONLY`, :const:`~os.O_FSYNC`, :const:`~os.O_SYMLINK` and
+:const:`~os.O_NOFOLLOW_ANY` for macOS. Patch by Dong-hee Na.
 
 ..
 
@@ -304,7 +304,7 @@ Added :data:`~os.O_EVTONLY`, :data:`~os.O_FSYNC`, :data:`~os.O_SYMLINK` and
 .. nonce: a7Dote
 .. section: Library
 
-Adds :data:`resource.RLIMIT_KQUEUES` constant from FreeBSD to the
+Adds :const:`resource.RLIMIT_KQUEUES` constant from FreeBSD to the
 :mod:`resource` module.
 
 ..

--- a/Misc/NEWS.d/3.10.0a7.rst
+++ b/Misc/NEWS.d/3.10.0a7.rst
@@ -713,7 +713,7 @@ this situation.  Also ensures that the :func:`tempfile.gettempdir()` and
 .. section: Library
 
 Expose ``X509_V_FLAG_ALLOW_PROXY_CERTS`` as
-:data:`~ssl.VERIFY_ALLOW_PROXY_CERTS` to allow proxy certificate validation
+:const:`~ssl.VERIFY_ALLOW_PROXY_CERTS` to allow proxy certificate validation
 as explained in
 https://www.openssl.org/docs/man1.1.1/man7/proxy-certificates.html.
 

--- a/Misc/NEWS.d/3.10.0b1.rst
+++ b/Misc/NEWS.d/3.10.0b1.rst
@@ -871,7 +871,7 @@ assert_called_once_with) will unconditionally pass.
 .. nonce: -1XPDH
 .. section: Library
 
-Add :data:`ssl.OP_IGNORE_UNEXPECTED_EOF` constants (OpenSSL 3.0.0)
+Add :const:`ssl.OP_IGNORE_UNEXPECTED_EOF` constants (OpenSSL 3.0.0)
 
 ..
 

--- a/Misc/NEWS.d/3.11.0a1.rst
+++ b/Misc/NEWS.d/3.11.0a1.rst
@@ -1468,8 +1468,8 @@ an installed expat library <= 2.2.0.
 
 On Unix, if the ``sem_clockwait()`` function is available in the C library
 (glibc 2.30 and newer), the :meth:`threading.Lock.acquire` method now uses
-the monotonic clock (:data:`time.CLOCK_MONOTONIC`) for the timeout, rather
-than using the system clock (:data:`time.CLOCK_REALTIME`), to not be
+the monotonic clock (:const:`time.CLOCK_MONOTONIC`) for the timeout, rather
+than using the system clock (:const:`time.CLOCK_REALTIME`), to not be
 affected by system clock changes. Patch by Victor Stinner.
 
 ..
@@ -2087,8 +2087,8 @@ Upgrade bundled pip to 21.2.3 and setuptools to 57.4.0
 .. section: Library
 
 Fix the :func:`os.set_inheritable` function on FreeBSD 14 for file
-descriptor opened with the :data:`~os.O_PATH` flag: ignore the
-:data:`~errno.EBADF` error on ``ioctl()``, fallback on the ``fcntl()``
+descriptor opened with the :const:`~os.O_PATH` flag: ignore the
+:const:`~errno.EBADF` error on ``ioctl()``, fallback on the ``fcntl()``
 implementation. Patch by Victor Stinner.
 
 ..

--- a/Misc/NEWS.d/3.11.0a4.rst
+++ b/Misc/NEWS.d/3.11.0a4.rst
@@ -839,7 +839,7 @@ patch by Kumar Aditya.
 .. nonce: jeiPiX
 .. section: Library
 
-Added :data:`signal.SIGSTKFLT` on platforms where this signal is defined.
+Added :const:`signal.SIGSTKFLT` on platforms where this signal is defined.
 
 ..
 

--- a/Misc/NEWS.d/3.11.0b1.rst
+++ b/Misc/NEWS.d/3.11.0b1.rst
@@ -817,8 +817,8 @@ it is ever needed and document the existing mechanism for ``posix_spawn()``.
 .. nonce: HFtERN
 .. section: Library
 
-Fix :data:`signal.NSIG` value on FreeBSD to accept signal numbers greater
-than 32, like :data:`signal.SIGRTMIN` and :data:`signal.SIGRTMAX`. Patch by
+Fix :const:`signal.NSIG` value on FreeBSD to accept signal numbers greater
+than 32, like :const:`signal.SIGRTMIN` and :const:`signal.SIGRTMAX`. Patch by
 Victor Stinner.
 
 ..

--- a/Misc/NEWS.d/3.12.0a1.rst
+++ b/Misc/NEWS.d/3.12.0a1.rst
@@ -736,7 +736,7 @@ new types.
 .. nonce: 6eoc8k
 .. section: Core and Builtins
 
-On WASI :data:`~errno.ENOTCAPABLE` is now mapped to :exc:`PermissionError`.
+On WASI :const:`~errno.ENOTCAPABLE` is now mapped to :exc:`PermissionError`.
 The :mod:`errno` modules exposes the new error number. ``getpath.py`` now
 ignores :exc:`PermissionError` when it cannot open landmark files
 ``pybuilddir.txt`` and ``pyenv.cfg``.
@@ -2649,7 +2649,7 @@ calling any callbacks. Patch by Kumar Aditya.
 .. nonce: i807-g
 .. section: Library
 
-Fail gracefully if :data:`~errno.EPERM` or :data:`~errno.ENOSYS` is raised
+Fail gracefully if :const:`~errno.EPERM` or :const:`~errno.ENOSYS` is raised
 when loading :mod:`!crypt` methods. This may happen when trying to load
 ``MD5`` on a Linux kernel with :abbr:`FIPS (Federal Information Processing
 Standard)` enabled.
@@ -2698,8 +2698,8 @@ Upgrade bundled pip to 22.2.
 .. nonce: VT34A5
 .. section: Library
 
-Fix check for existence of :data:`os.EFD_CLOEXEC`, :data:`os.EFD_NONBLOCK`
-and :data:`os.EFD_SEMAPHORE` flags on older kernel versions where these
+Fix check for existence of :const:`os.EFD_CLOEXEC`, :const:`os.EFD_NONBLOCK`
+and :const:`os.EFD_SEMAPHORE` flags on older kernel versions where these
 flags are not present. Patch by Kumar Aditya.
 
 ..
@@ -3553,7 +3553,7 @@ Make :class:`multiprocessing.Pool` raise an exception if
 .. nonce: HY0Uzj
 .. section: Library
 
-Add :data:`os.PIDFD_NONBLOCK` flag to open a file descriptor for a process
+Add :const:`os.PIDFD_NONBLOCK` flag to open a file descriptor for a process
 with :func:`os.pidfd_open` in non-blocking mode. Patch by Kumar Aditya.
 
 ..

--- a/Misc/NEWS.d/3.12.0a2.rst
+++ b/Misc/NEWS.d/3.12.0a2.rst
@@ -397,7 +397,7 @@ longobject.c to speed up some operations.
 .. nonce: nSGEkG
 .. section: Core and Builtins
 
-Expose :data:`~socket.ETH_P_ALL` and some of the :ref:`ETHERTYPE_* constants
+Expose :const:`~socket.ETH_P_ALL` and some of the :ref:`ETHERTYPE_* constants
 <socket-ethernet-types>` in :mod:`socket`. Patch by Noam Cohen.
 
 ..

--- a/Misc/NEWS.d/3.12.0a3.rst
+++ b/Misc/NEWS.d/3.12.0a3.rst
@@ -505,7 +505,7 @@ return True from this method; now they correctly return False.
 .. nonce: ZoOY5G
 .. section: Library
 
-Add an :data:`~ssl.OP_ENABLE_KTLS` option for enabling the use of the kernel
+Add an :const:`~ssl.OP_ENABLE_KTLS` option for enabling the use of the kernel
 TLS (kTLS). Patch by Illia Volochii.
 
 ..

--- a/Misc/NEWS.d/3.12.0a4.rst
+++ b/Misc/NEWS.d/3.12.0a4.rst
@@ -317,7 +317,7 @@ Improve performance of ``list.pop`` for small lists.
 .. nonce: yP4Na0
 .. section: Core and Builtins
 
-Add :data:`ssl.OP_LEGACY_SERVER_CONNECT`
+Add :const:`ssl.OP_LEGACY_SERVER_CONNECT`
 
 ..
 
@@ -356,7 +356,7 @@ arrays.
 .. nonce: mHRdQn
 .. section: Library
 
-Add :data:`socket.IP_PKTINFO` constant.
+Add :const:`socket.IP_PKTINFO` constant.
 
 ..
 

--- a/Misc/NEWS.d/3.12.0a6.rst
+++ b/Misc/NEWS.d/3.12.0a6.rst
@@ -303,7 +303,7 @@ Kim.
 .. nonce: Vxz0Mr
 .. section: Library
 
-Add :data:`mmap.MAP_ALIGNED_SUPER` FreeBSD and :data:`mmap.MAP_CONCEAL`
+Add :const:`mmap.MAP_ALIGNED_SUPER` FreeBSD and :const:`mmap.MAP_CONCEAL`
 OpenBSD constants to :mod:`mmap`. Patch by Yeojin Kim.
 
 ..

--- a/Misc/NEWS.d/3.12.0a7.rst
+++ b/Misc/NEWS.d/3.12.0a7.rst
@@ -605,7 +605,7 @@ reported unauthenticated EOFs (i.e. without close_notify) as a clean
 TLS-level EOF. It now raises :exc:`~ssl.SSLEOFError`, matching the behavior
 in previous versions of OpenSSL. The :attr:`~ssl.SSLContext.options`
 attribute on :class:`~ssl.SSLContext` also no longer includes
-:data:`~ssl.OP_IGNORE_UNEXPECTED_EOF` by default. This option may be set to
+:const:`~ssl.OP_IGNORE_UNEXPECTED_EOF` by default. This option may be set to
 specify the previous OpenSSL 3.0 behavior.
 
 ..

--- a/Misc/NEWS.d/3.12.0b1.rst
+++ b/Misc/NEWS.d/3.12.0b1.rst
@@ -842,7 +842,7 @@ filesystem case.
 .. section: Library
 
 Improve performance of :meth:`pathlib.Path.glob` by using
-:data:`re.IGNORECASE` to implement case-insensitive matching.
+:const:`re.IGNORECASE` to implement case-insensitive matching.
 
 ..
 
@@ -1882,7 +1882,7 @@ both cases.
 .. nonce: 564i32
 .. section: Library
 
-Add :data:`~csv.QUOTE_STRINGS` and :data:`~csv.QUOTE_NOTNULL` to the suite
+Add :const:`~csv.QUOTE_STRINGS` and :const:`~csv.QUOTE_NOTNULL` to the suite
 of :mod:`csv` module quoting styles.
 
 ..

--- a/Misc/NEWS.d/3.6.0rc1.rst
+++ b/Misc/NEWS.d/3.6.0rc1.rst
@@ -69,8 +69,8 @@ supported.
 .. nonce: ilNIWN
 .. section: Library
 
-Add new :data:`socket.TCP_CONGESTION` (Linux 2.6.13) and
-:data:`socket.TCP_USER_TIMEOUT` (Linux 2.6.37) constants. Patch written by
+Add new :const:`socket.TCP_CONGESTION` (Linux 2.6.13) and
+:const:`socket.TCP_USER_TIMEOUT` (Linux 2.6.37) constants. Patch written by
 Omar Sandoval.
 
 ..

--- a/Misc/NEWS.d/3.7.0a1.rst
+++ b/Misc/NEWS.d/3.7.0a1.rst
@@ -3274,7 +3274,7 @@ Added support for bytes paths in os.fwalk().
 .. nonce: 37jMwb
 .. section: Library
 
-Add new :data:`socket.TCP_NOTSENT_LOWAT` (Linux 3.12) constant. Patch by
+Add new :const:`socket.TCP_NOTSENT_LOWAT` (Linux 3.12) constant. Patch by
 Nathaniel J. Smith.
 
 ..
@@ -3871,8 +3871,8 @@ as an integer. Function only available on Android.
 .. nonce: ilNIWN
 .. section: Library
 
-Add new :data:`socket.TCP_CONGESTION` (Linux 2.6.13) and
-:data:`socket.TCP_USER_TIMEOUT` (Linux 2.6.37) constants. Patch written by
+Add new :const:`socket.TCP_CONGESTION` (Linux 2.6.13) and
+:const:`socket.TCP_USER_TIMEOUT` (Linux 2.6.37) constants. Patch written by
 Omar Sandoval.
 
 ..

--- a/Misc/NEWS.d/3.7.0a3.rst
+++ b/Misc/NEWS.d/3.7.0a3.rst
@@ -754,8 +754,8 @@ now accepts characters as arguments.  Based on patch by Steve Fink.
 .. nonce: DYQL0g
 .. section: Library
 
-Add 3 new clock identifiers: :data:`time.CLOCK_BOOTTIME`,
-:data:`time.CLOCK_PROF` and :data:`time.CLOCK_UPTIME`.
+Add 3 new clock identifiers: :const:`time.CLOCK_BOOTTIME`,
+:const:`time.CLOCK_PROF` and :const:`time.CLOCK_UPTIME`.
 
 ..
 

--- a/Misc/NEWS.d/3.8.0a1.rst
+++ b/Misc/NEWS.d/3.8.0a1.rst
@@ -1934,7 +1934,7 @@ failure.
 .. nonce: _ct_0H
 .. section: Library
 
-The :data:`time.CLOCK_UPTIME_RAW` constant is now available for macOS 10.12.
+The :const:`time.CLOCK_UPTIME_RAW` constant is now available for macOS 10.12.
 
 ..
 

--- a/Misc/NEWS.d/3.8.0a4.rst
+++ b/Misc/NEWS.d/3.8.0a4.rst
@@ -955,7 +955,7 @@ Add a new :mod:`_testinternalcapi` module to test the internal C API.
 .. section: Tests
 
 Fix ``test_imap4_host_default_value()`` of ``test_imaplib``: catch also
-:data:`errno.ENETUNREACH` error.
+:const:`errno.ENETUNREACH` error.
 
 ..
 

--- a/Misc/NEWS.d/3.9.0a1.rst
+++ b/Misc/NEWS.d/3.9.0a1.rst
@@ -1164,7 +1164,7 @@ defines them with eponymous methods.
 .. nonce: bmhquU
 .. section: Library
 
-Add :data:`os.P_PIDFD` constant, which may be passed to :func:`os.waitid` to
+Add :const:`os.P_PIDFD` constant, which may be passed to :func:`os.waitid` to
 wait on a Linux process file descriptor.
 
 ..
@@ -1193,8 +1193,8 @@ Expose the Linux ``pidfd_open`` syscall as :func:`os.pidfd_open`.
 .. nonce: 7jvYFA
 .. section: Library
 
-Added constants :data:`~fcntl.F_OFD_GETLK`, :data:`~fcntl.F_OFD_SETLK` and
-:data:`~fcntl.F_OFD_SETLKW` to the :mod:`fcntl` module. Patch by Dong-hee
+Added constants :const:`~fcntl.F_OFD_GETLK`, :const:`~fcntl.F_OFD_SETLK` and
+:const:`~fcntl.F_OFD_SETLKW` to the :mod:`fcntl` module. Patch by Dong-hee
 Na.
 
 ..
@@ -1283,7 +1283,7 @@ Fixed erroneous equality comparison in statistics.NormalDist().
 .. nonce: 86ExWB
 .. section: Library
 
-Added :data:`~os.CLD_KILLED` and :data:`~os.CLD_STOPPED` for
+Added :const:`~os.CLD_KILLED` and :const:`~os.CLD_STOPPED` for
 :attr:`si_code`. Patch by Dong-hee Na.
 
 ..
@@ -1355,8 +1355,8 @@ objects, patch by Samuel Colvin.
 .. nonce: 9w-IGF
 .. section: Library
 
-Add missing :data:`stat.S_IFDOOR`, :data:`stat.S_IFPORT`,
-:data:`stat.S_IFWHT`, :func:`stat.S_ISDOOR`, :func:`stat.S_ISPORT`, and
+Add missing :const:`stat.S_IFDOOR`, :const:`stat.S_IFPORT`,
+:const:`stat.S_IFWHT`, :func:`stat.S_ISDOOR`, :func:`stat.S_ISPORT`, and
 :func:`stat.S_ISWHT` values to the Python implementation of :mod:`stat`.
 
 ..
@@ -4983,7 +4983,7 @@ set to CP_UTF7 or CP_UTF8.
 .. nonce: -0g2O3
 .. section: Windows
 
-Make :data:`winreg.REG_MULTI_SZ` support zero-length strings.
+Make :const:`winreg.REG_MULTI_SZ` support zero-length strings.
 
 ..
 

--- a/Misc/NEWS.d/3.9.0a6.rst
+++ b/Misc/NEWS.d/3.9.0a6.rst
@@ -680,7 +680,7 @@ child process, reset the lock to the unlocked state. Rename also the private
 .. nonce: kIjVge
 .. section: Library
 
-Expose :data:`~socket.CAN_RAW_JOIN_FILTERS` in the :mod:`socket` module.
+Expose :const:`~socket.CAN_RAW_JOIN_FILTERS` in the :mod:`socket` module.
 
 ..
 
@@ -735,7 +735,7 @@ number of groups. For other implementations, double the group list size.
 .. nonce: HFpHZS
 .. section: Library
 
-Add :data:`time.CLOCK_TAI` constant if the operating system support it.
+Add :const:`time.CLOCK_TAI` constant if the operating system support it.
 
 ..
 


### PR DESCRIPTION


<!-- gh-issue-number: gh-106909 -->
* Issue: gh-106909
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--106910.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->