### PR TITLE
gh-105699: Fix a Crasher Related to a Deprecated Global Variable

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2023-07-20-12-21-37.gh-issue-105699.08ywGV.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2023-07-20-12-21-37.gh-issue-105699.08ywGV.rst
@@ -1,0 +1,4 @@
+Python no longer crashes due to an infrequent race in setting
+``Py_FileSystemDefaultEncoding`` and ``Py_FileSystemDefaultEncodeErrors``
+(both deprecated), when simultaneously initializing two isolated
+subinterpreters.  Now they are only set during runtime initialization.

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -15178,10 +15178,13 @@ init_fs_codec(PyInterpreterState *interp)
 
     /* Set Py_FileSystemDefaultEncoding and Py_FileSystemDefaultEncodeErrors
        global configuration variables. */
-    if (_Py_SetFileSystemEncoding(fs_codec->encoding,
-                                  fs_codec->errors) < 0) {
-        PyErr_NoMemory();
-        return -1;
+    if (_Py_IsMainInterpreter(interp)) {
+
+        if (_Py_SetFileSystemEncoding(fs_codec->encoding,
+                                      fs_codec->errors) < 0) {
+            PyErr_NoMemory();
+            return -1;
+        }
     }
     return 0;
 }


### PR DESCRIPTION
There was a slight race in `_Py_ClearFileSystemEncoding()` (when called from `_Py_SetFileSystemEncoding()`), between freeing the value and setting the variable to `NULL`, which occasionally caused crashes when multiple isolated interpreters were used.  (Notably, I saw at least 10 different, seemingly unrelated spooky-action-at-a-distance, ways this crashed.  Yay, free threading!)  We avoid the problem by only setting the global variables with the main interpreter (i.e. runtime init).

<!-- gh-issue-number: gh-105699 -->
* Issue: gh-105699
<!-- /gh-issue-number -->
