### PR TITLE
Fix CookieJar + OpenerDirector interactions and UnhandledExceptionWarning

### DIFF
--- a/Lib/urllib/request.py
+++ b/Lib/urllib/request.py
@@ -404,6 +404,7 @@ class OpenerDirector:
         self.handle_error = {}
         self.process_response = {}
         self.process_request = {}
+        self.req = None
 
     def add_handler(self, handler):
         if not hasattr(handler, "add_parent"):
@@ -467,6 +468,13 @@ class OpenerDirector:
             if result is not None:
                 return result
 
+    def __getattr__(self, attr):
+        dct = self.__dict__
+        if attr in dct:
+            return dct[attr]
+
+        return getattr(self.req, attr)
+    
     def open(self, fullurl, data=None, timeout=socket._GLOBAL_DEFAULT_TIMEOUT):
         # accept a URL or a Request object
         if isinstance(fullurl, str):
@@ -476,6 +484,7 @@ class OpenerDirector:
             if data is not None:
                 req.data = data
 
+        self.req = req
         req.timeout = timeout
         protocol = req.type
 

--- a/Lib/urllib/request.py
+++ b/Lib/urllib/request.py
@@ -474,7 +474,7 @@ class OpenerDirector:
             return dct[attr]
 
         return getattr(self.req, attr)
-    
+
     def open(self, fullurl, data=None, timeout=socket._GLOBAL_DEFAULT_TIMEOUT):
         # accept a URL or a Request object
         if isinstance(fullurl, str):

--- a/Misc/NEWS.d/next/Library/2032-07-31-13-29-00.lib-106925.AAGhrQ.rst
+++ b/Misc/NEWS.d/next/Library/2032-07-31-13-29-00.lib-106925.AAGhrQ.rst
@@ -1,0 +1,1 @@
+Fix CookieJar + OpenerDirector interactions and UnhandledExceptionWarning


### PR DESCRIPTION
If you run the following code against an http server that returns cookies...

```
cookies = http.cookiejar.CookieJar()
opener = urllib.request.build_opener(
    urllib.request.HTTPCookieProcessor(cookies)
)
resp = opener.open(url)
cookies.extract_cookies(resp, opener)
```

You may / will experience the following warning + unhandled exception:

```
/usr/local/lib/python3.11/http/cookiejar.py:1629: UserWarning: http.cookiejar bug! Traceback (most recent call last):
  File "/usr/local/lib/python3.11/http/cookiejar.py", line 1626, in make_cookies
    ns_cookies = self._cookies_from_attrs_set(
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/http/cookiejar.py", line 1583, in _cookies_from_attrs_set
    cookie = self._cookie_from_cookie_tuple(tup, request)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/http/cookiejar.py", line 1532, in _cookie_from_cookie_tuple
    req_host, erhn = eff_request_host(request)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/http/cookiejar.py", line 642, in eff_request_host
    erhn = req_host = request_host(request)
                      ^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/http/cookiejar.py", line 627, in request_host
    url = request.get_full_url()
          ^^^^^^^^^^^^^^^^^^^^
AttributeError: 'OpenerDirector' object has no attribute 'get_full_url'

  _warn_unhandled_exception()
```

Attempting to play whack-a-mole will make you realize that the cookiejar really wants a `BaseRequest`, not an `OpenerDirector`, so we proxy the request data via `__getattr__`, removing the warning.

When I run this to verify the patch locally, I no longer experience the issue in Python 3.11 installs:
```

def patch():
    from urllib import request
    import socket

    def __init__(self):
        client_version = "Python-urllib/%s" % request.__version__
        self.addheaders = [('User-agent', client_version)]
        # self.handlers is retained only for backward compatibility
        self.handlers = []
        # manage the individual handlers
        self.handle_open = {}
        self.handle_error = {}
        self.process_response = {}
        self.process_request = {}
        self.req = None

    request.OpenerDirector.__init__ = __init__

    def __getattr__(self, attr):
        dct = self.__dict__
        if attr in dct:
            return dct[attr]

        return getattr(self.req, attr)
       
    request.OpenerDirector.__getattr__ = __getattr__

    request.OpenerDirector.get_full_url = lambda x: x.full_url

    def open(self, fullurl, data=None, timeout=socket._GLOBAL_DEFAULT_TIMEOUT):
        # accept a URL or a Request object
        if isinstance(fullurl, str):
            req = request.Request(fullurl, data)
        else:
            req = fullurl
            if data is not None:
                req.data = data

        self.req = req
        req.timeout = timeout
        protocol = req.type

        # pre-process request
        meth_name = protocol+"_request"
        for processor in self.process_request.get(protocol, []):
            meth = getattr(processor, meth_name)
            req = meth(req)

        sys.audit('urllib.Request', req.full_url, req.data, req.headers, req.get_method())
        response = self._open(req, data)

        # post-process response
        meth_name = protocol+"_response"
        for processor in self.process_response.get(protocol, []):
            meth = getattr(processor, meth_name)
            response = meth(req, response)

        return response

    request.OpenerDirector.open = open

patch()
```