### PR TITLE
Docs: Silence 'target not found' warnings for errno markups

### DIFF
--- a/Doc/c-api/complex.rst
+++ b/Doc/c-api/complex.rst
@@ -64,7 +64,7 @@ pointers.  This is consistent throughout the API.
    representation.
 
    If *divisor* is null, this method returns zero and sets
-   :c:data:`errno` to :c:data:`EDOM`.
+   :c:data:`!errno` to :c:data:`EDOM`.
 
 
 .. c:function:: Py_complex _Py_c_pow(Py_complex num, Py_complex exp)
@@ -73,7 +73,7 @@ pointers.  This is consistent throughout the API.
    representation.
 
    If *num* is null and *exp* is not a positive real number,
-   this method returns zero and sets :c:data:`errno` to :c:data:`EDOM`.
+   this method returns zero and sets :c:data:`!errno` to :c:data:`EDOM`.
 
 
 Complex Numbers as Python Objects

--- a/Doc/c-api/exceptions.rst
+++ b/Doc/c-api/exceptions.rst
@@ -9,7 +9,7 @@ Exception Handling
 
 The functions described in this chapter will let you handle and raise Python
 exceptions.  It is important to understand some of the basics of Python
-exception handling.  It works somewhat like the POSIX :c:data:`errno` variable:
+exception handling.  It works somewhat like the POSIX :c:data:`!errno` variable:
 there is a global indicator (per thread) of the last error that occurred.  Most
 C API functions don't clear this on success, but will set it to indicate the
 cause of the error on failure.  Most C API functions also return an error
@@ -161,11 +161,11 @@ For convenience, some of these functions will always return a
    .. index:: single: strerror()
 
    This is a convenience function to raise an exception when a C library function
-   has returned an error and set the C variable :c:data:`errno`.  It constructs a
-   tuple object whose first item is the integer :c:data:`errno` value and whose
+   has returned an error and set the C variable :c:data:`!errno`.  It constructs a
+   tuple object whose first item is the integer :c:data:`!errno` value and whose
    second item is the corresponding error message (gotten from :c:func:`strerror`),
    and then calls ``PyErr_SetObject(type, object)``.  On Unix, when the
-   :c:data:`errno` value is :const:`EINTR`, indicating an interrupted system call,
+   :c:data:`!errno` value is :const:`EINTR`, indicating an interrupted system call,
    this calls :c:func:`PyErr_CheckSignals`, and if that set the error indicator,
    leaves it set to that.  The function always returns ``NULL``, so a wrapper
    function around a system call can write ``return PyErr_SetFromErrno(type);``

--- a/Doc/extending/extending.rst
+++ b/Doc/extending/extending.rst
@@ -146,7 +146,7 @@ of the exception.
 
 Another useful function is :c:func:`PyErr_SetFromErrno`, which only takes an
 exception argument and constructs the associated value by inspection of the
-global variable :c:data:`errno`.  The most general function is
+global variable :c:data:`!errno`.  The most general function is
 :c:func:`PyErr_SetObject`, which takes two object arguments, the exception and
 its associated value.  You don't need to :c:func:`Py_INCREF` the objects passed
 to any of these functions.

--- a/Doc/library/ctypes.rst
+++ b/Doc/library/ctypes.rst
@@ -1447,10 +1447,10 @@ ignored.  On posix systems, RTLD_NOW is always added, and is not
 configurable.
 
 The *use_errno* parameter, when set to true, enables a ctypes mechanism that
-allows accessing the system :data:`errno` error number in a safe way.
-:mod:`ctypes` maintains a thread-local copy of the systems :data:`errno`
+allows accessing the system :c:data:`!errno` error number in a safe way.
+:mod:`ctypes` maintains a thread-local copy of the systems :c:data:`!errno`
 variable; if you call foreign functions created with ``use_errno=True`` then the
-:data:`errno` value before the function call is swapped with the ctypes private
+:c:data:`!errno` value before the function call is swapped with the ctypes private
 copy, the same happens immediately after the function call.
 
 The function :func:`ctypes.get_errno` returns the value of the ctypes private
@@ -1713,7 +1713,7 @@ See :ref:`ctypes-callback-functions` for examples.
    The returned function prototype creates functions that use the standard C
    calling convention.  The function will release the GIL during the call.  If
    *use_errno* is set to true, the ctypes private copy of the system
-   :data:`errno` variable is exchanged with the real :data:`errno` value before
+   :c:data:`!errno` variable is exchanged with the real :c:data:`!errno` value before
    and after the call; *use_last_error* does the same for the Windows error
    code.
 
@@ -2001,7 +2001,7 @@ Utility functions
 .. function:: get_errno()
 
    Returns the current value of the ctypes-private copy of the system
-   :data:`errno` variable in the calling thread.
+   :c:data:`!errno` variable in the calling thread.
 
    .. audit-event:: ctypes.get_errno "" ctypes.get_errno
 
@@ -2052,7 +2052,7 @@ Utility functions
 
 .. function:: set_errno(value)
 
-   Set the current value of the ctypes-private copy of the system :data:`errno`
+   Set the current value of the ctypes-private copy of the system :c:data:`!errno`
    variable in the calling thread to *value* and return the previous value.
 
    .. audit-event:: ctypes.set_errno errno ctypes.set_errno

--- a/Doc/library/exceptions.rst
+++ b/Doc/library/exceptions.rst
@@ -338,7 +338,7 @@ The following exceptions are the exceptions that are usually raised.
 
    .. attribute:: errno
 
-      A numeric error code from the C variable :c:data:`errno`.
+      A numeric error code from the C variable :c:data:`!errno`.
 
    .. attribute:: winerror
 
@@ -659,7 +659,7 @@ depending on the system error code.
 
    Raised when an operation would block on an object (e.g. socket) set
    for non-blocking operation.
-   Corresponds to :c:data:`errno` :py:data:`~errno.EAGAIN`, :py:data:`~errno.EALREADY`,
+   Corresponds to :c:data:`!errno` :py:data:`~errno.EAGAIN`, :py:data:`~errno.EALREADY`,
    :py:data:`~errno.EWOULDBLOCK` and :py:data:`~errno.EINPROGRESS`.
 
    In addition to those of :exc:`OSError`, :exc:`BlockingIOError` can have
@@ -674,7 +674,7 @@ depending on the system error code.
 .. exception:: ChildProcessError
 
    Raised when an operation on a child process failed.
-   Corresponds to :c:data:`errno` :py:data:`~errno.ECHILD`.
+   Corresponds to :c:data:`!errno` :py:data:`~errno.ECHILD`.
 
 .. exception:: ConnectionError
 
@@ -688,40 +688,40 @@ depending on the system error code.
    A subclass of :exc:`ConnectionError`, raised when trying to write on a
    pipe while the other end has been closed, or trying to write on a socket
    which has been shutdown for writing.
-   Corresponds to :c:data:`errno` :py:data:`~errno.EPIPE` and :py:data:`~errno.ESHUTDOWN`.
+   Corresponds to :c:data:`!errno` :py:data:`~errno.EPIPE` and :py:data:`~errno.ESHUTDOWN`.
 
 .. exception:: ConnectionAbortedError
 
    A subclass of :exc:`ConnectionError`, raised when a connection attempt
    is aborted by the peer.
-   Corresponds to :c:data:`errno` :py:data:`~errno.ECONNABORTED`.
+   Corresponds to :c:data:`!errno` :py:data:`~errno.ECONNABORTED`.
 
 .. exception:: ConnectionRefusedError
 
    A subclass of :exc:`ConnectionError`, raised when a connection attempt
    is refused by the peer.
-   Corresponds to :c:data:`errno` :py:data:`~errno.ECONNREFUSED`.
+   Corresponds to :c:data:`!errno` :py:data:`~errno.ECONNREFUSED`.
 
 .. exception:: ConnectionResetError
 
    A subclass of :exc:`ConnectionError`, raised when a connection is
    reset by the peer.
-   Corresponds to :c:data:`errno` :py:data:`~errno.ECONNRESET`.
+   Corresponds to :c:data:`!errno` :py:data:`~errno.ECONNRESET`.
 
 .. exception:: FileExistsError
 
    Raised when trying to create a file or directory which already exists.
-   Corresponds to :c:data:`errno` :py:data:`~errno.EEXIST`.
+   Corresponds to :c:data:`!errno` :py:data:`~errno.EEXIST`.
 
 .. exception:: FileNotFoundError
 
    Raised when a file or directory is requested but doesn't exist.
-   Corresponds to :c:data:`errno` :py:data:`~errno.ENOENT`.
+   Corresponds to :c:data:`!errno` :py:data:`~errno.ENOENT`.
 
 .. exception:: InterruptedError
 
    Raised when a system call is interrupted by an incoming signal.
-   Corresponds to :c:data:`errno` :py:data:`~errno.EINTR`.
+   Corresponds to :c:data:`!errno` :py:data:`~errno.EINTR`.
 
    .. versionchanged:: 3.5
       Python now retries system calls when a syscall is interrupted by a
@@ -732,7 +732,7 @@ depending on the system error code.
 
    Raised when a file operation (such as :func:`os.remove`) is requested
    on a directory.
-   Corresponds to :c:data:`errno` :py:data:`~errno.EISDIR`.
+   Corresponds to :c:data:`!errno` :py:data:`~errno.EISDIR`.
 
 .. exception:: NotADirectoryError
 
@@ -740,13 +740,13 @@ depending on the system error code.
    something which is not a directory.  On most POSIX platforms, it may also be
    raised if an operation attempts to open or traverse a non-directory file as if
    it were a directory.
-   Corresponds to :c:data:`errno` :py:data:`~errno.ENOTDIR`.
+   Corresponds to :c:data:`!errno` :py:data:`~errno.ENOTDIR`.
 
 .. exception:: PermissionError
 
    Raised when trying to run an operation without the adequate access
    rights - for example filesystem permissions.
-   Corresponds to :c:data:`errno` :py:data:`~errno.EACCES`,
+   Corresponds to :c:data:`!errno` :py:data:`~errno.EACCES`,
    :py:data:`~errno.EPERM`, and :py:data:`~errno.ENOTCAPABLE`.
 
    .. versionchanged:: 3.11.1
@@ -756,12 +756,12 @@ depending on the system error code.
 .. exception:: ProcessLookupError
 
    Raised when a given process doesn't exist.
-   Corresponds to :c:data:`errno` :py:data:`~errno.ESRCH`.
+   Corresponds to :c:data:`!errno` :py:data:`~errno.ESRCH`.
 
 .. exception:: TimeoutError
 
    Raised when a system function timed out at the system level.
-   Corresponds to :c:data:`errno` :py:data:`~errno.ETIMEDOUT`.
+   Corresponds to :c:data:`!errno` :py:data:`~errno.ETIMEDOUT`.
 
 .. versionadded:: 3.3
    All the above :exc:`OSError` subclasses were added.

--- a/Doc/library/socket.rst
+++ b/Doc/library/socket.rst
@@ -1447,7 +1447,7 @@ to sockets.
    exception for errors returned by the C-level :c:func:`connect` call (other
    problems, such as "host not found," can still raise exceptions).  The error
    indicator is ``0`` if the operation succeeded, otherwise the value of the
-   :c:data:`errno` variable.  This is useful to support, for example, asynchronous
+   :c:data:`!errno` variable.  This is useful to support, for example, asynchronous
    connects.
 
    .. audit-event:: socket.connect self,address socket.socket.connect_ex


### PR DESCRIPTION


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--106926.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->