### PR TITLE
gh-105540: Show source files relative to root

### DIFF
--- a/Tools/cases_generator/generate_cases.py
+++ b/Tools/cases_generator/generate_cases.py
@@ -1154,10 +1154,15 @@ class Analyzer:
         self.out.emit("")
 
     def from_source_files(self) -> str:
-        paths = f"\n{self.out.comment}   ".join(
-            prettify_filename(os.path.relpath(filename, ROOT))
-            for filename in self.input_filenames
-        )
+        filenames = []
+        for filename in self.input_filenames:
+            try:
+                filename = os.path.relpath(filename, ROOT)
+            except ValueError:
+            # May happen on Windows if root and temp on different volumes
+                pass
+            filenames.append(filename)
+        paths = f"\n{self.out.comment}   ".join(filenames)
         return f"{self.out.comment} from:\n{self.out.comment}   {paths}\n"
 
     def write_provenance_header(self):

--- a/Tools/cases_generator/generate_cases.py
+++ b/Tools/cases_generator/generate_cases.py
@@ -17,6 +17,7 @@ import lexer as lx
 import parser
 from parser import StackEffect
 
+
 HERE = os.path.dirname(__file__)
 ROOT = os.path.join(HERE, "../..")
 THIS = os.path.relpath(__file__, ROOT).replace(os.path.sep, posixpath.sep)
@@ -1154,7 +1155,7 @@ class Analyzer:
 
     def from_source_files(self) -> str:
         paths = f"\n{self.out.comment}   ".join(
-            prettify_filename(filename)
+            prettify_filename(os.path.relpath(filename, ROOT))
             for filename in self.input_filenames
         )
         return f"{self.out.comment} from:\n{self.out.comment}   {paths}\n"


### PR DESCRIPTION
This restores a corner case: when the generator is run with working directory set to Tools/cases_generator, the source filenames listed in the generated provenance header should be relative to the repo root directory.

<!-- gh-issue-number: gh-105540 -->
* Issue: gh-105540
<!-- /gh-issue-number -->
