### PR TITLE
gh-105540: Improve relative paths in `generate_cases.py`

### DIFF
--- a/Tools/cases_generator/generate_cases.py
+++ b/Tools/cases_generator/generate_cases.py
@@ -1154,15 +1154,10 @@ class Analyzer:
         self.out.emit("")
 
     def from_source_files(self) -> str:
-        filenames = []
-        for filename in self.input_filenames:
-            try:
-                filename = os.path.relpath(filename, ROOT)
-            except ValueError:
-            # May happen on Windows if root and temp on different volumes
-                pass
-            filenames.append(filename)
-        paths = f"\n{self.out.comment}   ".join(filenames)
+        paths = f"\n{self.out.comment}   ".join(
+            prettify_filename(filename)
+            for filename in self.input_filenames
+        )
         return f"{self.out.comment} from:\n{self.out.comment}   {paths}\n"
 
     def write_provenance_header(self):
@@ -1614,7 +1609,14 @@ class Analyzer:
 
 def prettify_filename(filename: str) -> str:
     # Make filename more user-friendly and less platform-specific,
-    # it is only used for error reporting at this point.
+    # it is only used:
+    # 1. in a generated file header as a source reference
+    # 2. for error reporting
+    try:
+        filename = os.path.relpath(filename, ROOT)
+    except ValueError:
+        # May happen on Windows if root and temp on different volumes
+        pass
     filename = filename.replace("\\", "/")
     if filename.startswith("./"):
         filename = filename[2:]


### PR DESCRIPTION
In the original code before https://github.com/python/cpython/commit/c41320701b28904064c89a0a29775efed6b6d053#diff-65feee563fa44b472b07751184c6f557699f84b3c2ef79174bfd5d538d748272 there were three places where we had `os.path.relpath` calls. I've changed them to be just `prettify_filename` calls. 

Now I am adding `os.path.relpath` back to all these three places by including it in `prettify_filename`.

Plus, changing a comment that is a bit misleading.

<!-- gh-issue-number: gh-105540 -->
* Issue: gh-105540
<!-- /gh-issue-number -->
