### PR TITLE
gh-106947: Emit debug log message when adding handler to a root logger without handlers

### DIFF
--- a/Lib/logging/__init__.py
+++ b/Lib/logging/__init__.py
@@ -2219,6 +2219,10 @@ def debug(msg, *args, **kwargs):
     """
     if len(root.handlers) == 0:
         basicConfig()
+        message = (
+            "The root logger had no handlers; basicConfig() was called"
+            " to add a console handler with a pre-defined format.")
+        root.debug(message, *args, **kwargs)
     root.debug(msg, *args, **kwargs)
 
 def log(level, msg, *args, **kwargs):

--- a/Misc/NEWS.d/next/Library/2023-07-21-11-07-44.gh-issue-106947.1WJkDQ.rst
+++ b/Misc/NEWS.d/next/Library/2023-07-21-11-07-44.gh-issue-106947.1WJkDQ.rst
@@ -1,0 +1,2 @@
+:mod:`logging`: Emit a debug log message when adding console handler
+to a root logger without handlers. Patch by Bjorn Olsen.


### PR DESCRIPTION
<!-- gh-issue-number: gh-106947 -->
* Issue: gh-106947
<!-- /gh-issue-number -->

Manual test 1 against local build:
<img width="1042" alt="image" src="https://github.com/python/cpython/assets/26625123/5924dc8f-9181-4eec-a24f-22e82f373d02">

Manual test 2 against local build:
<img width="1042" alt="image" src="https://github.com/python/cpython/assets/26625123/6971983a-3c28-4885-9cb7-069e02f09a64">
