### PR TITLE
Trivial: reformat code block in black style to make it easier to read

### DIFF
--- a/Doc/tutorial/errors.rst
+++ b/Doc/tutorial/errors.rst
@@ -535,11 +535,20 @@ of a certain type while letting all other exceptions propagate to
 other clauses and eventually to be reraised. ::
 
    >>> def f():
-   ...     raise ExceptionGroup("group1",
-   ...                          [OSError(1),
-   ...                           SystemError(2),
-   ...                           ExceptionGroup("group2",
-   ...                                          [OSError(3), RecursionError(4)])])
+   ...     raise ExceptionGroup(
+   ...         "group1",
+   ...         [
+   ...             OSError(1),
+   ...             SystemError(2),
+   ...             ExceptionGroup(
+   ...                 "group2",
+   ...                 [
+   ...                     OSError(3),
+   ...                     RecursionError(4)
+   ...                 ]
+   ...             )
+   ...         ]
+   ...     )
    ...
    >>> try:
    ...     f()


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
Simply adjusts the layout of the most code-heavy example in `errors.rst` to be in the style of Black so that it's easier to see how everything is fitting together in the example and to render better on small screens.

<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--106965.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->