### PR TITLE
gh-106727: Add `__module__` check for `inspect.getsource(cls)`

### DIFF
--- a/Lib/inspect.py
+++ b/Lib/inspect.py
@@ -1078,8 +1078,8 @@ class _ClassFinder(ast.NodeVisitor):
 
             # First, let's see if there are any method definitions
             for member in self.cls.__dict__.values():
-                if isinstance(member, types.FunctionType) and \
-                    member.__module__ == self.cls.__module__:
+                if (isinstance(member, types.FunctionType) and
+                    member.__module__ == self.cls.__module__):
                     for lineno, end_lineno in self.lineno_found:
                         if lineno <= member.__code__.co_firstlineno <= end_lineno:
                             return lineno

--- a/Lib/inspect.py
+++ b/Lib/inspect.py
@@ -1078,7 +1078,8 @@ class _ClassFinder(ast.NodeVisitor):
 
             # First, let's see if there are any method definitions
             for member in self.cls.__dict__.values():
-                if isinstance(member, types.FunctionType):
+                if isinstance(member, types.FunctionType) and \
+                    member.__module__ == self.cls.__module__:
                     for lineno, end_lineno in self.lineno_found:
                         if lineno <= member.__code__.co_firstlineno <= end_lineno:
                             return lineno

--- a/Lib/test/test_inspect.py
+++ b/Lib/test/test_inspect.py
@@ -968,7 +968,7 @@ class TestBuggyCases(GetSourceBase):
         with tempfile.TemporaryDirectory() as tempdir:
             with open(os.path.join(tempdir, 'inspect_actual%spy' % os.extsep),
                       'w', encoding='utf-8') as f:
-                f.write(textwrap.dedent("""\
+                f.write(textwrap.dedent("""
                     import inspect_other
                     class A:
                         def f(self):
@@ -981,7 +981,7 @@ class TestBuggyCases(GetSourceBase):
 
             with open(os.path.join(tempdir, 'inspect_other%spy' % os.extsep),
                       'w', encoding='utf-8') as f:
-                f.write(textwrap.dedent("""\
+                f.write(textwrap.dedent("""
                     class A:
                         def f(self):
                             pass

--- a/Lib/test/test_inspect.py
+++ b/Lib/test/test_inspect.py
@@ -15,6 +15,7 @@ import pickle
 import shutil
 import sys
 import types
+import tempfile
 import textwrap
 import unicodedata
 import unittest
@@ -962,6 +963,33 @@ class TestBuggyCases(GetSourceBase):
         self.assertSourceEqual(mod2.func212(), 213, 214)
         self.assertSourceEqual(mod2.cls213, 218, 222)
         self.assertSourceEqual(mod2.cls213().func219(), 220, 221)
+
+    def test_class_with_method_from_other_module(self):
+        with tempfile.TemporaryDirectory() as tempdir:
+            with open(os.path.join(tempdir, 'inspect_actual%spy' % os.extsep),
+                      'w', encoding='utf-8') as f:
+                f.write(textwrap.dedent("""\
+                    import inspect_other
+                    class A:
+                        def f(self):
+                            pass
+                    class A:
+                        def f(self):
+                            pass  # correct one
+                    A.f = inspect_other.A.f
+                    """))
+
+            with open(os.path.join(tempdir, 'inspect_other%spy' % os.extsep),
+                      'w', encoding='utf-8') as f:
+                f.write(textwrap.dedent("""\
+                    class A:
+                        def f(self):
+                            pass
+                    """))
+
+            with DirsOnSysPath(tempdir):
+                import inspect_actual
+                self.assertIn("correct", inspect.getsource(inspect_actual.A))
 
     @unittest.skipIf(
         support.is_emscripten or support.is_wasi,


### PR DESCRIPTION
In method heuristics, make sure the method we check against comes from the same file as the class. Fixed the issue from #106815

<!-- gh-issue-number: gh-106727 -->
* Issue: gh-106727
<!-- /gh-issue-number -->
