### PR TITLE
gh-106973: Change non-integral to non-integer in "3.12 What's New"

### DIFF
--- a/Doc/whatsnew/3.12.rst
+++ b/Doc/whatsnew/3.12.rst
@@ -1456,7 +1456,7 @@ Changes in the Python API
 
 * Removed ``randrange()`` functionality deprecated since Python 3.10.  Formerly,
   ``randrange(10.0)`` losslessly converted to ``randrange(10)``. Now, it raises a
-  :exc:`TypeError`. Also, the exception raised for non-integral values such as
+  :exc:`TypeError`. Also, the exception raised for non-integer values such as
   ``randrange(10.5)`` or ``randrange('10')`` has been changed from :exc:`ValueError` to
   :exc:`TypeError`.  This also prevents bugs where ``randrange(1e25)`` would silently
   select from a larger range than ``randrange(10**25)``.


### PR DESCRIPTION
This PR changes the term "non-integral" to "non-integer" on the 3.12 "What's New" page. As mentioned in the issue, `non-integer` is more frequently used in the documentation.


<!-- gh-issue-number: gh-106973 -->
* Issue: gh-106973
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--106984.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->