### PR TITLE
[3.11] Change non-integral to non-integer in random docs (GH-106975)

### DIFF
--- a/Doc/library/random.rst
+++ b/Doc/library/random.rst
@@ -141,7 +141,7 @@ Functions for integers
       ``randrange(10)``.  In the future, this will raise a :exc:`TypeError`.
 
    .. deprecated:: 3.10
-      The exception raised for non-integral values such as ``randrange(10.5)``
+      The exception raised for non-integer values such as ``randrange(10.5)``
       or ``randrange('10')`` will be changed from :exc:`ValueError` to
       :exc:`TypeError`.
 


### PR DESCRIPTION
I followed the backport PR instructions, as this PR is made against a different branch than `main`, but it's not a backport in the sense that the changes are not relevant for main (the text in the docs has been removed in 3.12). The original issue, #106975, mentions that 3.11 should be the target branch.


<!-- gh-issue-number: gh-106975 -->
* Issue: gh-106975
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--106985.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->