### PR TITLE
gh-106969: Indicate no modules were added in 3.10 & 3.12

### DIFF
--- a/Doc/whatsnew/3.10.rst
+++ b/Doc/whatsnew/3.10.rst
@@ -887,7 +887,7 @@ Other Language Changes
 New Modules
 ===========
 
-* None yet.
+* None.
 
 
 Improved Modules

--- a/Doc/whatsnew/3.12.rst
+++ b/Doc/whatsnew/3.12.rst
@@ -486,7 +486,7 @@ Other Language Changes
 New Modules
 ===========
 
-* None yet.
+* None.
 
 
 Improved Modules


### PR DESCRIPTION
The "New Modules" section was left in place to ensure that the anchor link for the "new modules" section still exists:

/whatsnew/3.12.html#new-modules
/whatsnew/3.10.html#new-modules

This means that existing links to this section don't break, and the lack of new modules is explicitly documented.

I couldn't find a good historical precedent, and the structure of the "What's new" document changed over versions.

<!-- gh-issue-number: gh-106969 -->
* Issue: gh-106969
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--106988.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->