### PR TITLE
gh-102111: Add link to string escape sequences in re module

### DIFF
--- a/Doc/library/re.rst
+++ b/Doc/library/re.rst
@@ -632,8 +632,8 @@ character ``'$'``.
    single: \x; in regular expressions
    single: \\; in regular expressions
 
-Most of the standard escapes supported by Python string literals are also
-accepted by the regular expression parser::
+Most of the :ref:`standard escapes <escape-sequences>` supported by Python
+string literals are also accepted by the regular expression parser::
 
    \a      \b      \f      \n
    \N      \r      \t      \u

--- a/Doc/library/re.rst
+++ b/Doc/library/re.rst
@@ -632,7 +632,7 @@ character ``'$'``.
    single: \x; in regular expressions
    single: \\; in regular expressions
 
-Most of the :ref:`standard escapes <escape-sequences>` supported by Python
+Most of the :ref:`escape sequences <escape-sequences>` supported by Python
 string literals are also accepted by the regular expression parser::
 
    \a      \b      \f      \n

--- a/Doc/reference/lexical_analysis.rst
+++ b/Doc/reference/lexical_analysis.rst
@@ -549,6 +549,10 @@ retained), except that three unescaped quotes in a row terminate the literal.  (
 
 .. _escape-sequences:
 
+
+Escape sequences
+^^^^^^^^^^^^^^^^
+
 Unless an ``'r'`` or ``'R'`` prefix is present, escape sequences in string and
 bytes literals are interpreted according to rules similar to those used by
 Standard C.  The recognized escape sequences are:


### PR DESCRIPTION
This PR adds a link from the `re` module's documentation where the valid escape sequences are listed to the reference page where the escape sequences are listed together with their meaning and further notes.

<!-- gh-issue-number: gh-102111 -->
* Issue: gh-102111
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--106995.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->