### PR TITLE
[3.11] gh-100700 Remove Date and Release fields in past whatsnews (GH-100728)

### DIFF
--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -2,8 +2,6 @@
   What's New In Python 3.11
 ****************************
 
-:Release: |release|
-:Date: |today|
 :Editor: Pablo Galindo Salgado
 
 .. Rules for maintenance:


### PR DESCRIPTION
Backporting fix to 3.11 branch.

I will open separate PR to fix 3.12 and 3.13 what's new pages because they have "Release" and "Date" as well. 

I will also complete https://github.com/python/release-tools/issues/34 which will stop this from happening in the future.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--106999.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->

<!-- gh-issue-number: gh-100700 -->
* Issue: gh-100700
<!-- /gh-issue-number -->
