### PR TITLE
gh-77034: Update struct docstring, slashing most of it

### DIFF
--- a/Modules/_struct.c
+++ b/Modules/_struct.c
@@ -2434,27 +2434,12 @@ in the C struct.\n\
 \n\
 The optional first format char indicates byte order, size and alignment:\n\
   @: native order, size & alignment (default)\n\
-  =: native order, std. size & alignment\n\
-  <: little-endian, std. size & alignment\n\
-  >: big-endian, std. size & alignment\n\
+  =: native order, std. size, no alignment\n\
+  <: little-endian, std. size, no alignment\n\
+  >: big-endian, std. size, no alignment\n\
   !: same as >\n\
 \n\
-The remaining chars indicate types of args and must match exactly;\n\
-these can be preceded by a decimal repeat count:\n\
-  x: pad byte (no data); c:char; b:signed byte; B:unsigned byte;\n\
-  ?: _Bool (requires C99; if not available, char is used instead)\n\
-  h:short; H:unsigned short; i:int; I:unsigned int;\n\
-  l:long; L:unsigned long; f:float; d:double; e:half-float.\n\
-Special cases (preceding decimal count indicates length):\n\
-  s:string (array of char); p: pascal string (with count byte).\n\
-Special cases (only available in native format):\n\
-  n:ssize_t; N:size_t;\n\
-  P:an integer type that is wide enough to hold a pointer.\n\
-Special case (not in native mode unless 'long long' in platform C):\n\
-  q:long long; Q:unsigned long long\n\
-Whitespace between formats is ignored.\n\
-\n\
-The variable struct.error is an exception raised on errors.\n");
+For more details, see the online documentation.\n");
 
 
 static int


### PR DESCRIPTION
The struct docstring is ambiguous on alignment and much lengthier than most other docstrings. The online documentation is much more complete. Fix this docstring by changing the wording on alignment and by removing most of it, referring instead to the online documentation.

<!-- gh-issue-number: gh-77034 -->
* Issue: gh-77034
<!-- /gh-issue-number -->
