### PR TITLE
gh-71261: Add paragraph on shadowing submodules with star imports

### DIFF
--- a/Doc/tutorial/modules.rst
+++ b/Doc/tutorial/modules.rst
@@ -526,7 +526,7 @@ would only import the two submodules ``echo`` and ``surround``, but *not* the
     ]
 
     def reverse(msg: str):  # <-- this name shadows the 'reverse.py' submodule
-        return msg[::-1]    #     in case of an 'from sound.effects import *'
+        return msg[::-1]    #     in the case of a 'from sound.effects import *'
 
 If ``__all__`` is not defined, the statement ``from sound.effects import *``
 does *not* import all submodules from the package :mod:`sound.effects` into the

--- a/Doc/tutorial/modules.rst
+++ b/Doc/tutorial/modules.rst
@@ -512,6 +512,22 @@ code::
 This would mean that ``from sound.effects import *`` would import the three
 named submodules of the :mod:`sound.effects` package.
 
+Be aware that submodules might become shadowed by locally defined names. For
+example, if you added a ``reverse`` function to the
+:file:`sound/effects/__init__.py` file, the ``from sound.effects import *``
+would only import the two submodules ``echo`` and ``surround``, but *not* the
+``reverse`` submodule, because it is shadowed by the locally defined
+``reverse`` function::
+
+    __all__ = [
+        "echo",      # refers to the 'echo.py' file
+        "surround",  # refers to the 'surround.py' file
+        "reverse",   # !!! refers to the 'reverse' function now !!!
+    ]
+
+    def reverse(msg: str):  # <-- this name shadows the 'reverse.py' submodule
+        return msg[::-1]    #     in case of an 'from sound.effects import *'
+
 If ``__all__`` is not defined, the statement ``from sound.effects import *``
 does *not* import all submodules from the package :mod:`sound.effects` into the
 current namespace; it only ensures that the package :mod:`sound.effects` has


### PR DESCRIPTION
This PR extends the tutorial on modules and packages by adding a paragraph on the `from abc import *` problem in case of duplicate names for submodules and locally defined objects (e.g. functions).

It intends to solve #71261 by providing an example of how a locally defined function breaks the import of submodules.

<!-- gh-issue-number: gh-71261 -->
* Issue: gh-71261
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--107004.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->