### PR TITLE
gh-107008: Document the curses module variables LINES and COLS

### DIFF
--- a/Doc/library/curses.rst
+++ b/Doc/library/curses.rst
@@ -641,7 +641,8 @@ The module :mod:`curses` defines the following functions:
 
 .. function:: update_lines_cols()
 
-   Update :envvar:`LINES` and :envvar:`COLS`. Useful for detecting manual screen resize.
+   Update the :const:`LINES` and :const:`COLS` module variables.
+   Useful for detecting manual screen resize.
 
    .. versionadded:: 3.5
 
@@ -1342,10 +1343,27 @@ The :mod:`curses` module defines the following data members:
 .. data:: COLORS
 
    The maximum number of colors the terminal can support.
+   It is defined only after the call to :func:`start_color`.
 
 .. data:: COLOR_PAIRS
 
    The maximum number of color pairs the terminal can support.
+   It is defined only after the call to :func:`start_color`.
+
+.. data:: COLS
+
+   The width of the screen, i.e., the number of columns.
+   It is defined only after the call to :func:`initscr`.
+   Updated by :func:`update_lines_cols`, :func:`resizeterm` and
+   :func:`resize_term`.
+
+.. data:: LINES
+
+   The height of the screen, i.e., the number of lines.
+   It is defined only after the call to :func:`initscr`.
+   Updated by :func:`update_lines_cols`, :func:`resizeterm` and
+   :func:`resize_term`.
+
 
 Some constants are available to specify character cell attributes.
 The exact constants available are system dependent.

--- a/Doc/whatsnew/3.5.rst
+++ b/Doc/whatsnew/3.5.rst
@@ -1045,8 +1045,8 @@ not just sequences.  (Contributed by Serhiy Storchaka in :issue:`23171`.)
 curses
 ------
 
-The new :func:`~curses.update_lines_cols` function updates the :envvar:`LINES`
-and :envvar:`COLS` environment variables.  This is useful for detecting
+The new :func:`~curses.update_lines_cols` function updates the :data:`LINES`
+and :data:`COLS` module variables.  This is useful for detecting
 manual screen resizing.  (Contributed by Arnon Yaari in :issue:`4254`.)
 
 

--- a/Misc/NEWS.d/next/Documentation/2023-07-22-15-14-13.gh-issue-107008.3JQ1Vt.rst
+++ b/Misc/NEWS.d/next/Documentation/2023-07-22-15-14-13.gh-issue-107008.3JQ1Vt.rst
@@ -1,0 +1,2 @@
+Document the :mod:`curses` module variables :const:`~curses.LINES` and
+:const:`~curses.COLS`.


### PR DESCRIPTION
LINES and COLS referred in curses.update_lines_cols() documentations are the module variables, not the environment variables.


<!-- gh-issue-number: gh-107008 -->
* Issue: gh-107008
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--107011.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->