### PR TITLE
gh-106186: Don't report MultipartInvariantViolationDefect for valid multipart emails when parsing header only

### DIFF
--- a/Lib/email/feedparser.py
+++ b/Lib/email/feedparser.py
@@ -189,7 +189,7 @@ class FeedParser:
         assert not self._msgstack
         # Look for final set of defects
         if root.get_content_maintype() == 'multipart' \
-               and not root.is_multipart():
+               and not root.is_multipart() and not self._headersonly:
             defect = errors.MultipartInvariantViolationDefect()
             self.policy.handle_defect(root, defect)
         return root

--- a/Lib/test/test_email/data/msg_47.txt
+++ b/Lib/test/test_email/data/msg_47.txt
@@ -1,0 +1,14 @@
+Date: 01 Jan 2001 00:01+0000
+From: arthur@example.example
+MIME-Version: 1.0
+Content-Type: multipart/mixed; boundary=foo
+
+--foo
+Content-Type: text/plain
+bar
+
+--foo
+Content-Type: text/html
+<html><body><p>baz</p></body></html>
+
+--foo--

--- a/Lib/test/test_email/test_email.py
+++ b/Lib/test/test_email/test_email.py
@@ -3712,6 +3712,16 @@ class TestParsers(TestEmailBase):
         self.assertIsInstance(msg.get_payload(), str)
         self.assertIsInstance(msg.get_payload(decode=True), bytes)
 
+    def test_header_parser_multipart_is_valid(self):
+        # Don't flag valid multipart emails as having defects
+        with openfile('msg_47.txt', encoding="utf-8") as fp:
+            msgdata = fp.read()
+
+        parser = email.parser.Parser(policy=email.policy.default)
+        parsed_msg = parser.parsestr(msgdata, headersonly=True)
+
+        self.assertEqual(parsed_msg.defects, [])
+
     def test_bytes_parser_does_not_close_file(self):
         with openfile('msg_02.txt', 'rb') as fp:
             email.parser.BytesParser().parse(fp)

--- a/Lib/test/test_email/test_parser.py
+++ b/Lib/test/test_email/test_parser.py
@@ -3,7 +3,7 @@ import email
 import unittest
 from email.message import Message, EmailMessage
 from email.policy import default
-from test.test_email import TestEmailBase
+from test.test_email import openfile, TestEmailBase
 
 
 class TestCustomMessage(TestEmailBase):
@@ -66,6 +66,15 @@ class TestParserBase:
                     ("Paragraph-Separator", "not\u2029broken"),
                 ])
                 self.assertEqual(msg.get_payload(), "")
+
+    def test_headers_only_multipart(self):
+        with openfile('msg_47.txt', encoding="utf-8") as fp:
+            msgdata = fp.read()
+
+        parser = email.parser.Parser(policy=email.policy.default)
+        parsed_msg = parser.parsestr(msgdata, headersonly=True)
+
+        self.assertEqual(parsed_msg.defects, [])
 
     class MyMessage(EmailMessage):
         pass

--- a/Lib/test/test_email/test_parser.py
+++ b/Lib/test/test_email/test_parser.py
@@ -67,14 +67,6 @@ class TestParserBase:
                 ])
                 self.assertEqual(msg.get_payload(), "")
 
-    def test_headers_only_multipart(self):
-        with openfile('msg_47.txt', encoding="utf-8") as fp:
-            msgdata = fp.read()
-
-        parser = email.parser.Parser(policy=email.policy.default)
-        parsed_msg = parser.parsestr(msgdata, headersonly=True)
-
-        self.assertEqual(parsed_msg.defects, [])
 
     class MyMessage(EmailMessage):
         pass

--- a/Lib/test/test_email/test_parser.py
+++ b/Lib/test/test_email/test_parser.py
@@ -3,7 +3,7 @@ import email
 import unittest
 from email.message import Message, EmailMessage
 from email.policy import default
-from test.test_email import openfile, TestEmailBase
+from test.test_email import TestEmailBase
 
 
 class TestCustomMessage(TestEmailBase):
@@ -66,7 +66,6 @@ class TestParserBase:
                     ("Paragraph-Separator", "not\u2029broken"),
                 ])
                 self.assertEqual(msg.get_payload(), "")
-
 
     class MyMessage(EmailMessage):
         pass

--- a/Misc/NEWS.d/next/Library/2023-07-22-13-09-28.gh-issue-106186.EIsUNG.rst
+++ b/Misc/NEWS.d/next/Library/2023-07-22-13-09-28.gh-issue-106186.EIsUNG.rst
@@ -1,0 +1,3 @@
+Do not report ``MultipartInvariantViolationDefect`` defect
+when the :class:`email.parser.Parser` class is used
+to parse emails with ``headersonly=True``.


### PR DESCRIPTION

The following code used to report a MultipartInvariantViolationDefect.  However, the message body is not parsed when `headersonly=True`, so the parsing required for `is_multipart()` to work is not carried out.  Add this as a case to ignore when validating the message body in `close()`

```
import email.parser
import email.policy

email_str = '''\
Date: 01 Jan 2001 00:01+0000
From: arthur@example.example
MIME-Version: 1.0
Content-Type: multipart/mixed; boundary=autocracy

--autocracy
Content-Type: text/plain

By hanging on to outdated imperialist dogma which perpetuates the economic and
social differences in our society.

--autocracy
Content-Type: text/html

<html><body><p>By hanging on to outdated imperialist dogma which perpetuates
the economic and social differences in our society.</p></body></html>

--autocracy--
'''

full_parser = email.parser.Parser(policy=email.policy.default)
parsed_email_full = full_parser.parsestr(email_str)
print(parsed_email_full.defects)  # Prints [] as expected

header_parser = email.parser.HeaderParser(policy=email.policy.default)
parsed_email_headers_only = header_parser.parsestr(email_str)
print(parsed_email_headers_only.defects)  # Used to print [MultipartInvariantViolationDefect()].  Now prints []
```

<!-- gh-issue-number: gh-106186 -->
* Issue: gh-106186
<!-- /gh-issue-number -->
