### PR TITLE
gh-65495: Use lowercase `mail from` and `rcpt to` in `smtplib.SMTP`

### DIFF
--- a/Lib/smtplib.py
+++ b/Lib/smtplib.py
@@ -542,7 +542,7 @@ class SMTP:
                     raise SMTPNotSupportedError(
                         'SMTPUTF8 not supported by server')
             optionlist = ' ' + ' '.join(options)
-        self.putcmd("mail", "FROM:%s%s" % (quoteaddr(sender), optionlist))
+        self.putcmd("mail", "from:%s%s" % (quoteaddr(sender), optionlist))
         return self.getreply()
 
     def rcpt(self, recip, options=()):
@@ -550,7 +550,7 @@ class SMTP:
         optionlist = ''
         if options and self.does_esmtp:
             optionlist = ' ' + ' '.join(options)
-        self.putcmd("rcpt", "TO:%s%s" % (quoteaddr(recip), optionlist))
+        self.putcmd("rcpt", "to:%s%s" % (quoteaddr(recip), optionlist))
         return self.getreply()
 
     def data(self, msg):

--- a/Misc/NEWS.d/next/Library/2023-07-22-14-29-34.gh-issue-65495.fw84qM.rst
+++ b/Misc/NEWS.d/next/Library/2023-07-22-14-29-34.gh-issue-65495.fw84qM.rst
@@ -1,0 +1,1 @@
+Use lowercase ``mail from`` and ``rcpt to`` in :class:`smptlib.SMTP`.


### PR DESCRIPTION
SMTP commands are case-insensitive. `smtplib` uses lowercase commands, however it writes `mail FROM` and `rcpt TO`, lacking consistency.

#65495


<!-- gh-issue-number: gh-65495 -->
* Issue: gh-65495
<!-- /gh-issue-number -->
