### PR TITLE
gh-106320: Remove private _PyUnicode_AsString() alias

### DIFF
--- a/Include/cpython/unicodeobject.h
+++ b/Include/cpython/unicodeobject.h
@@ -446,16 +446,11 @@ PyAPI_FUNC(PyObject*) PyUnicode_FromKindAndData(
    Like PyUnicode_AsUTF8AndSize(), this also caches the UTF-8 representation
    in the unicodeobject.
 
-   _PyUnicode_AsString is a #define for PyUnicode_AsUTF8 to
-   support the previous internal function with the same behaviour.
-
    Use of this API is DEPRECATED since no size information can be
    extracted from the returned data.
 */
 
 PyAPI_FUNC(const char *) PyUnicode_AsUTF8(PyObject *unicode);
-
-#define _PyUnicode_AsString PyUnicode_AsUTF8
 
 /* === Characters Type APIs =============================================== */
 

--- a/Misc/NEWS.d/next/C API/2023-07-22-14-40-48.gh-issue-106320.H3u7x4.rst
+++ b/Misc/NEWS.d/next/C API/2023-07-22-14-40-48.gh-issue-106320.H3u7x4.rst
@@ -1,0 +1,5 @@
+Remove private ``_PyUnicode_AsString()`` alias to
+:c:func:`PyUnicode_AsUTF8`. It was kept for backward compatibility with
+Python 3.0 - 3.2. The :c:func:`PyUnicode_AsUTF8` is available since Python
+3.3. The :c:func:`PyUnicode_AsUTF8String` function can be used to keep
+compatibility with Python 3.2 and older. Patch by Victor Stinner.


### PR DESCRIPTION
Remove private _PyUnicode_AsString() alias to PyUnicode_AsUTF8(). It was kept for backward compatibility with Python 3.0 - 3.2.

The PyUnicode_AsUTF8() is available since Python
3.3. The PyUnicode_AsUTF8String() function can be used to keep compatibility with Python 3.2 and older.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-106320 -->
* Issue: gh-106320
<!-- /gh-issue-number -->
