### PR TITLE
[3.12] Bump sphinx-lint to 0.6.8 (gh-106978)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
         types_or: [c, python, rst]
 
   - repo: https://github.com/sphinx-contrib/sphinx-lint
-    rev: v0.6.7
+    rev: v0.6.8
     hooks:
       - id: sphinx-lint
         args: [--enable=default-role]


### PR DESCRIPTION
Backport bump sphinx-lint to 0.6.8 in .pre-commit-config.yaml

original PR: https://github.com/python/cpython/pull/106990

<!-- gh-issue-number: gh-106978 -->
* Issue: gh-106978
<!-- /gh-issue-number -->
