### PR TITLE
gh-106320: Document private C API removal in What's New 3.13

### DIFF
--- a/Doc/whatsnew/3.13.rst
+++ b/Doc/whatsnew/3.13.rst
@@ -838,6 +838,13 @@ Deprecated
 Removed
 -------
 
+* Remove many APIs (functions, macros, variables) with names prefixed by
+  ``_Py`` or ``_PY`` (considered as private API). If your project is affected
+  by one of these removals and you consider that the removed API should remain
+  available, please open a new issue to request a public C API and
+  add ``cc @vstinner`` to the issue to notify Victor Stinner.
+  (Contributed by Victor Stinner in :gh:`106320`.)
+
 * Remove functions deprecated in Python 3.9.
 
   * ``PyEval_CallObject()``, ``PyEval_CallObjectWithKeywords()``: use


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-106320 -->
* Issue: gh-106320
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--107027.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->