### PR TITLE
gh-107028: tiny textual changes in logging docs and docstrings

### DIFF
--- a/Doc/library/logging.handlers.rst
+++ b/Doc/library/logging.handlers.rst
@@ -917,8 +917,7 @@ should, then :meth:`flush` is expected to do the flushing.
 
    .. method:: flush()
 
-      You can override this to implement custom flushing behavior. This version
-      just zaps the buffer to empty.
+      For a :class:`BufferHandler`, flushing means that it zaps the buffer to empty. This method can be overwritten to implement more useful flushing behavior.
 
 
    .. method:: shouldFlush(record)
@@ -952,7 +951,7 @@ should, then :meth:`flush` is expected to do the flushing.
 
       For a :class:`MemoryHandler`, flushing means just sending the buffered
       records to the target, if there is one. The buffer is also cleared when
-      this happens. Override if you want different behavior.
+      buffered records are send. Override if you want different behavior.
 
 
    .. method:: setTarget(target)

--- a/Doc/library/logging.handlers.rst
+++ b/Doc/library/logging.handlers.rst
@@ -917,7 +917,7 @@ should, then :meth:`flush` is expected to do the flushing.
 
    .. method:: flush()
 
-      For a :class:`BufferHandler`, flushing means that it zaps the buffer to empty. This method can be overwritten to implement more useful flushing behavior.
+      For a :class:`BufferingHandler` instance, flushing means that it sets the buffer to an empty list. This method can be overwritten to implement more useful flushing behavior.
 
 
    .. method:: shouldFlush(record)

--- a/Doc/library/logging.handlers.rst
+++ b/Doc/library/logging.handlers.rst
@@ -917,7 +917,9 @@ should, then :meth:`flush` is expected to do the flushing.
 
    .. method:: flush()
 
-      For a :class:`BufferingHandler` instance, flushing means that it sets the buffer to an empty list. This method can be overwritten to implement more useful flushing behavior.
+      For a :class:`BufferingHandler` instance, flushing means that it sets the
+      buffer to an empty list. This method can be overwritten to implement more useful
+      flushing behavior.
 
 
    .. method:: shouldFlush(record)

--- a/Doc/library/logging.handlers.rst
+++ b/Doc/library/logging.handlers.rst
@@ -949,7 +949,7 @@ should, then :meth:`flush` is expected to do the flushing.
 
    .. method:: flush()
 
-      For a :class:`MemoryHandler`, flushing means just sending the buffered
+      For a :class:`MemoryHandler` instance, flushing means just sending the buffered
       records to the target, if there is one. The buffer is also cleared when
       buffered records are sent to the target. Override if you want different behavior.
 

--- a/Doc/library/logging.handlers.rst
+++ b/Doc/library/logging.handlers.rst
@@ -951,7 +951,7 @@ should, then :meth:`flush` is expected to do the flushing.
 
       For a :class:`MemoryHandler`, flushing means just sending the buffered
       records to the target, if there is one. The buffer is also cleared when
-      buffered records are send. Override if you want different behavior.
+      buffered records are sent to the target. Override if you want different behavior.
 
 
    .. method:: setTarget(target)

--- a/Lib/logging/handlers.py
+++ b/Lib/logging/handlers.py
@@ -1399,7 +1399,7 @@ class MemoryHandler(BufferingHandler):
         records to the target, if there is one. Override if you want
         different behaviour.
 
-        The record buffer is only cleared afterwards, when target was set.
+        The record buffer is only cleared if a target has been set.
         """
         self.acquire()
         try:

--- a/Lib/logging/handlers.py
+++ b/Lib/logging/handlers.py
@@ -1399,7 +1399,7 @@ class MemoryHandler(BufferingHandler):
         records to the target, if there is one. Override if you want
         different behaviour.
 
-        The record buffer is also cleared by this operation.
+        The record buffer is only cleared afterwards, when target was set.
         """
         self.acquire()
         try:


### PR DESCRIPTION
I've done a tiny change in docstrings, to make documentation in line with the actual behavior of the function.

<!-- gh-issue-number: gh-107028 -->
* Issue: gh-107028
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--107029.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->