### PR TITLE
gh-83006: Document behavior of `shutil.disk_usage` for non-mounted filesystems on Unix

### DIFF
--- a/Doc/library/shutil.rst
+++ b/Doc/library/shutil.rst
@@ -401,9 +401,9 @@ Directory and files operations
 
    .. note::
 
-      Where applicable (e.g. Unix), *path* must point to a path within a
-      **mounted** filesystem partition. On those platforms, CPython doesn't
-      attempt to retrieve disk usage information from non-mounted filesystems.
+      On Unix filesystems, *path* must point to a path within a **mounted**
+      filesystem partition. On those platforms, CPython doesn't attempt to
+      retrieve disk usage information from non-mounted filesystems.
 
    .. versionadded:: 3.3
 

--- a/Doc/library/shutil.rst
+++ b/Doc/library/shutil.rst
@@ -399,6 +399,12 @@ Directory and files operations
    total, used and free space, in bytes. *path* may be a file or a
    directory.
 
+   .. note::
+
+      Where applicable (e.g. Unix), *path* must point to a path within a
+      **mounted** filesystem partition. On those platforms, CPython doesn't
+      attempt to retrieve disk usage information from non-mounted filesystems.
+
    .. versionadded:: 3.3
 
    .. versionchanged:: 3.8

--- a/Misc/NEWS.d/next/Library/2023-07-22-15-51-33.gh-issue-83006.21zaCz.rst
+++ b/Misc/NEWS.d/next/Library/2023-07-22-15-51-33.gh-issue-83006.21zaCz.rst
@@ -1,0 +1,2 @@
+Document behavior of :func:`shutil.disk_usage` for non-mounted filesystems
+on Unix.


### PR DESCRIPTION
#83006

<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--107031.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->