### PR TITLE
gh-106320: Move private _PyGen API to the internal C API

### DIFF
--- a/Include/cpython/genobject.h
+++ b/Include/cpython/genobject.h
@@ -41,9 +41,6 @@ PyAPI_DATA(PyTypeObject) PyGen_Type;
 PyAPI_FUNC(PyObject *) PyGen_New(PyFrameObject *);
 PyAPI_FUNC(PyObject *) PyGen_NewWithQualName(PyFrameObject *,
     PyObject *name, PyObject *qualname);
-PyAPI_FUNC(int) _PyGen_SetStopIterationValue(PyObject *);
-PyAPI_FUNC(int) _PyGen_FetchStopIterationValue(PyObject **);
-PyAPI_FUNC(void) _PyGen_Finalize(PyObject *self);
 PyAPI_FUNC(PyCodeObject *) PyGen_GetCode(PyGenObject *gen);
 
 
@@ -54,7 +51,6 @@ typedef struct {
 } PyCoroObject;
 
 PyAPI_DATA(PyTypeObject) PyCoro_Type;
-PyAPI_DATA(PyTypeObject) _PyCoroWrapper_Type;
 
 #define PyCoro_CheckExact(op) Py_IS_TYPE((op), &PyCoro_Type)
 PyAPI_FUNC(PyObject *) PyCoro_New(PyFrameObject *,
@@ -69,8 +65,6 @@ typedef struct {
 
 PyAPI_DATA(PyTypeObject) PyAsyncGen_Type;
 PyAPI_DATA(PyTypeObject) _PyAsyncGenASend_Type;
-PyAPI_DATA(PyTypeObject) _PyAsyncGenWrappedValue_Type;
-PyAPI_DATA(PyTypeObject) _PyAsyncGenAThrow_Type;
 
 PyAPI_FUNC(PyObject *) PyAsyncGen_New(PyFrameObject *,
     PyObject *name, PyObject *qualname);

--- a/Include/internal/pycore_genobject.h
+++ b/Include/internal/pycore_genobject.h
@@ -9,8 +9,19 @@ extern "C" {
 #endif
 
 extern PyObject *_PyGen_yf(PyGenObject *);
+extern void _PyGen_Finalize(PyObject *self);
+
+// _asyncio shared extensions uses _PyGen_SetStopIterationValue() and
+// _PyGen_FetchStopIterationValue()
+PyAPI_FUNC(int) _PyGen_SetStopIterationValue(PyObject *);
+PyAPI_FUNC(int) _PyGen_FetchStopIterationValue(PyObject **);
+
 extern PyObject *_PyCoro_GetAwaitableIter(PyObject *o);
 extern PyObject *_PyAsyncGenValueWrapperNew(PyThreadState *state, PyObject *);
+
+extern PyTypeObject _PyCoroWrapper_Type;
+extern PyTypeObject _PyAsyncGenWrappedValue_Type;
+extern PyTypeObject _PyAsyncGenAThrow_Type;
 
 /* runtime lifecycle */
 


### PR DESCRIPTION
Move private _PyGen API to internal C API:

* _PyAsyncGenAThrow_Type
* _PyAsyncGenWrappedValue_Type
* _PyCoroWrapper_Type
* _PyGen_FetchStopIterationValue()
* _PyGen_Finalize()
* _PyGen_SetStopIterationValue()

No longer these symbols, except of the ones by the _asyncio shared extensions.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-106320 -->
* Issue: gh-106320
<!-- /gh-issue-number -->
