### PR TITLE
gh-94543: Clarify the `mkstemp` documentation

### DIFF
--- a/Doc/library/tempfile.rst
+++ b/Doc/library/tempfile.rst
@@ -222,8 +222,9 @@ The module defines the following user-callable items:
    the file is executable by no one.  The file descriptor is not inherited
    by child processes.
 
-   Unlike :func:`TemporaryFile`, the user of :func:`mkstemp` is responsible
-   for deleting the temporary file when done with it.
+   Unlike :func:`TemporaryFile`, the user of :func:`mkstemp` is responsible for closing
+   and deleting the temporary file (by e.g. using :func:`os.close` and
+   :func:`os.remove`) when done with it.
 
    If *suffix* is not ``None``, the file name will end with that suffix,
    otherwise there will be no suffix.  :func:`mkstemp` does not put a dot


### PR DESCRIPTION
Clarify the `mkstemp` documentation to explicity describe that the file should be closed and removed.

Originally raised in: https://github.com/python/cpython/issues/94543

<!-- gh-issue-number: gh-94543 -->
* Issue: gh-94543
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--107033.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->