### PR TITLE
gh-106320: Remove _PyOS_ReadlineTState API

### DIFF
--- a/Include/cpython/pythonrun.h
+++ b/Include/cpython/pythonrun.h
@@ -117,5 +117,4 @@ PyAPI_FUNC(PyObject *) PyRun_FileFlags(FILE *fp, const char *p, int s, PyObject 
 
 /* Stuff with no proper home (yet) */
 PyAPI_FUNC(char *) PyOS_Readline(FILE *, FILE *, const char *);
-PyAPI_DATA(PyThreadState*) _PyOS_ReadlineTState;
 PyAPI_DATA(char) *(*PyOS_ReadlineFunctionPointer)(FILE *, FILE *, const char *);

--- a/Modules/readline.c
+++ b/Modules/readline.c
@@ -1313,6 +1313,9 @@ rlhandler(char *text)
 static char *
 readline_until_enter_or_signal(const char *prompt, int *signal)
 {
+    // Defined in Parser/myreadline.c
+    extern PyThreadState *_PyOS_ReadlineTState;
+
     char * not_done_reading = "";
     fd_set selectset;
 

--- a/Parser/myreadline.c
+++ b/Parser/myreadline.c
@@ -20,7 +20,9 @@
 #endif /* MS_WINDOWS */
 
 
-PyThreadState* _PyOS_ReadlineTState = NULL;
+// Export the symbol since it's used by the readline shared extension
+PyAPI_DATA(PyThreadState*) _PyOS_ReadlineTState;
+PyThreadState *_PyOS_ReadlineTState = NULL;
 
 static PyThread_type_lock _PyOS_ReadlineLock = NULL;
 


### PR DESCRIPTION
Remove _PyOS_ReadlineTState from the public C API. The symbol is still exported for the readline shared extension.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-106320 -->
* Issue: gh-106320
<!-- /gh-issue-number -->
