### PR TITLE
gh-75371: reformat Makefile.pre.in to accommodate for empty FRAMEWORKALTINSTALLLAST

### DIFF
--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -1939,8 +1939,7 @@ altinstall: commoninstall
 .PHONY: commoninstall
 commoninstall:  check-clean-src @FRAMEWORKALTINSTALLFIRST@ \
 		altbininstall libinstall inclinstall libainstall \
-		sharedinstall altmaninstall \
-		@FRAMEWORKALTINSTALLLAST@
+		sharedinstall altmaninstall @FRAMEWORKALTINSTALLLAST@
 
 # Install shared libraries enabled by Setup
 DESTDIRS=	$(exec_prefix) $(LIBDIR) $(BINLIBDEST) $(DESTSHARED)


### PR DESCRIPTION
in the case of an empty FRAMEWORKALTINSTALLLAST, this patch prevents leaving an astray linebreak and two tabs in the resulting Makefile.

Before change:
```
.PHONY: commoninstall
commoninstall:  check-clean-src  \
		altbininstall libinstall inclinstall libainstall \
		sharedinstall altmaninstall \
<tab><tab>
```

After change (with empty FRAMEWORKALTINSTALLLAST):
```
.PHONY: commoninstall
commoninstall:  check-clean-src  \
		altbininstall libinstall inclinstall libainstall \
		sharedinstall altmaninstall 
```

<!-- gh-issue-number: gh-75371 -->
* Issue: gh-75371
<!-- /gh-issue-number -->
