### PR TITLE
[3.12] Convert `doc.yml` workflow to be reusable (GH-103914 + GH-105151)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -89,6 +89,7 @@ jobs:
             Doc/**
             Misc/**
             .github/workflows/reusable-docs.yml
+          format: csv  # works for paths with spaces
       - name: Check for docs changes
         if: >-
           github.event_name == 'pull_request'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}-reusable
   cancel-in-progress: true
 
 jobs:
@@ -37,6 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     outputs:
+      run-docs: ${{ steps.docs-changes.outputs.run-docs || false }}
       run_tests: ${{ steps.check.outputs.run_tests }}
       run_hypothesis: ${{ steps.check.outputs.run_hypothesis }}
       config_hash: ${{ steps.config_hash.outputs.hash }}
@@ -79,6 +80,28 @@ jobs:
         id: config_hash
         run: |
           echo "hash=${{ hashFiles('configure', 'configure.ac', '.github/workflows/build.yml') }}" >> $GITHUB_OUTPUT
+      - name: Get a list of the changed documentation-related files
+        if: github.event_name == 'pull_request'
+        id: changed-docs-files
+        uses: Ana06/get-changed-files@v2.2.0
+        with:
+          filter: |
+            Doc/**
+            Misc/**
+            .github/workflows/reusable-docs.yml
+      - name: Check for docs changes
+        if: >-
+          github.event_name == 'pull_request'
+          && steps.changed-docs-files.outputs.added_modified_renamed != ''
+        id: docs-changes
+        run: |
+          echo "run-docs=true" >> "${GITHUB_OUTPUT}"
+
+  check-docs:
+    name: Docs
+    needs: check_source
+    if: fromJSON(needs.check_source.outputs.run-docs)
+    uses: ./.github/workflows/reusable-docs.yml
 
   check_abi:
     name: 'Check if the ABI has changed'

--- a/.github/workflows/reusable-docs.yml
+++ b/.github/workflows/reusable-docs.yml
@@ -1,31 +1,8 @@
 name: Docs
 
 on:
+  workflow_call:
   workflow_dispatch:
-  #push:
-  #  branches:
-  #  - 'main'
-  #  - '3.12'
-  #  - '3.11'
-  #  - '3.10'
-  #  - '3.9'
-  #  - '3.8'
-  #  - '3.7'
-  #  paths:
-  #  - 'Doc/**'
-  pull_request:
-    branches:
-    - 'main'
-    - '3.12'
-    - '3.11'
-    - '3.10'
-    - '3.9'
-    - '3.8'
-    - '3.7'
-    paths:
-    - 'Doc/**'
-    - 'Misc/**'
-    - '.github/workflows/doc.yml'
 
 permissions:
   contents: read

--- a/.github/workflows/reusable-docs.yml
+++ b/.github/workflows/reusable-docs.yml
@@ -38,12 +38,14 @@ jobs:
       uses: Ana06/get-changed-files@v2.2.0
       with:
         filter: "Doc/**"
+        format: csv  # works for paths with spaces
     - name: 'Build changed files in nit-picky mode'
       if: github.event_name == 'pull_request'
       continue-on-error: true
       run: |
+        set -Eeuo pipefail
         # Mark files the pull request modified
-        touch ${{ steps.changed_files.outputs.added_modified }}
+        python Doc/tools/touch-clean-files.py --clean '${{ steps.changed_files.outputs.added_modified }}'
         # Build docs with the '-n' (nit-picky) option; convert warnings to annotations
         make -C Doc/ PYTHON=../python SPHINXOPTS="-q -n --keep-going" html 2>&1 |
             python Doc/tools/warnings-to-gh-actions.py


### PR DESCRIPTION
Co-authored-by: Adam Turner <9087854+AA-Turner@users.noreply.github.com>
Co-authored-by: Hugo van Kemenade <hugovk@users.noreply.github.com>.
(cherry picked from commit 88d14da76f579fe014cbd7c15e42be4234135fe9)

Use CSV-separated outputs @ get-changed-files @ CI (https://github.com/python/cpython/pull/105151)

Co-authored-by: Hugo van Kemenade <hugovk@users.noreply.github.com>
(cherry picked from commit https://github.com/python/cpython/commit/eaa670228066220f08c8d73f80365c50058d40b8)

<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--107042.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->