### PR TITLE
gh-105578: Add more usage examples to `typing.AnyStr` docs

### DIFF
--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -849,15 +849,11 @@ using ``[]``.
       concat(b"foo", b"bar")  # OK, output has type 'bytes'
       concat("foo", b"bar")   # Error, cannot mix str and bytes
 
-   Note that ``AnyStr`` and ``str | bytes`` are different from each other and
-   have different use cases. ``str | bytes`` does allow you to mix str and bytes::
-
-      def concat(a: str | bytes, b: str | bytes) -> str | bytes:
-          return a + b
-
-      concat("foo", b"bar")  # Passes typecheck but raises an error at runtime
-
-   As a type variable, ``AnyStr`` is only used if it's at least part of the input arguments::
+   Note that, despite its name, ``AnyStr`` has nothing to do with the
+   :class:`Any` type, nor does it mean "any string". In particular, ``AnyStr``
+   and ``str | bytes`` are different from each other and have different use
+   cases. If ``AnyStr`` is not part of the input arguments it should not be
+   used::
 
       def greet_bad(cond: bool) -> AnyStr:
           return "hi there!" if cond else b"greetings!"  # Error

--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -863,7 +863,7 @@ using ``[]``.
 
       # The better way of annotating this function:
       def greet_proper(cond: bool) -> str | bytes:
-          return "hi there!" if cond else b"greetings!"  # OK
+          return "hi there!" if cond else b"greetings!"
 
 .. data:: LiteralString
 

--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -852,8 +852,7 @@ using ``[]``.
    Note that, despite its name, ``AnyStr`` has nothing to do with the
    :class:`Any` type, nor does it mean "any string". In particular, ``AnyStr``
    and ``str | bytes`` are different from each other and have different use
-   cases. If ``AnyStr`` is not part of the input arguments it should not be
-   used::
+   cases::
 
       # Invalid use of AnyStr:
       # The type variable is used only once in the function signature,

--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -855,9 +855,13 @@ using ``[]``.
    cases. If ``AnyStr`` is not part of the input arguments it should not be
    used::
 
+      # Invalid use of AnyStr:
+      # The type variable is used only once in the function signature,
+      # so cannot be "solved" by the type checker
       def greet_bad(cond: bool) -> AnyStr:
-          return "hi there!" if cond else b"greetings!"  # Error
+          return "hi there!" if cond else b"greetings!"
 
+      # The better way of annotating this function:
       def greet_proper(cond: bool) -> str | bytes:
           return "hi there!" if cond else b"greetings!"  # OK
 

--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -849,6 +849,22 @@ using ``[]``.
       concat(b"foo", b"bar")  # OK, output has type 'bytes'
       concat("foo", b"bar")   # Error, cannot mix str and bytes
 
+   Note that ``AnyStr`` and ``str | bytes`` are different from each other and
+   have different use cases. ``str | bytes`` does allow you to mix str and bytes::
+
+      def concat(a: str | bytes, b: str | bytes) -> str | bytes:
+          return a + b
+
+      concat("foo", b"bar")  # Passes typecheck but raises an error at runtime
+
+   As a type variable, ``AnyStr`` is only used if it's at least part of the input arguments::
+
+      def greet_bad(cond: bool) -> AnyStr:
+          return "hi there!" if cond else b"greetings!"  # Error
+
+      def greet_proper(cond: bool) -> str | bytes:
+          return "hi there!" if cond else b"greetings!"  # OK
+
 .. data:: LiteralString
 
    Special type that includes only literal strings.


### PR DESCRIPTION
Add more usage examples to `typing.AnyStr`.

In particular, contrast it with `str | bytes`, with examples of where one or the other would be used.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-105578 -->
* Issue: gh-105578
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--107045.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->