### PR TITLE
[3.11] gh-75371: reformat Makefile.pre.in to accommodate for empty FRAMEWORKALTINSTALLLAST (GH-107035)

### DIFF
--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -1764,8 +1764,7 @@ altinstall: commoninstall
 
 commoninstall:  check-clean-src @FRAMEWORKALTINSTALLFIRST@ \
 		altbininstall libinstall inclinstall libainstall \
-		sharedinstall oldsharedinstall altmaninstall \
-		@FRAMEWORKALTINSTALLLAST@
+		sharedinstall oldsharedinstall altmaninstall @FRAMEWORKALTINSTALLLAST@
 
 # Install shared libraries enabled by Setup
 DESTDIRS=	$(exec_prefix) $(LIBDIR) $(BINLIBDEST) $(DESTSHARED)


### PR DESCRIPTION
in the case of an empty FRAMEWORKALTINSTALLLAST, this patch prevents leaving an astray linebreak and two tabs in the resulting Makefile.

Before change:
```
.PHONY: commoninstall
commoninstall:  check-clean-src  \
		altbininstall libinstall inclinstall libainstall \
		sharedinstall altmaninstall \

```

After change (with empty FRAMEWORKALTINSTALLLAST):
```
.PHONY: commoninstall
commoninstall:  check-clean-src  \
		altbininstall libinstall inclinstall libainstall \
		sharedinstall altmaninstall
```
(cherry picked from commit 9c38206925246ab919cf558ac069ae9458720ba7)


<!-- gh-issue-number: gh-75371 -->
* Issue: gh-75371
<!-- /gh-issue-number -->
