### PR TITLE
gh-82500: Fix asyncio sendfile overflow on 32bit

### DIFF
--- a/Lib/asyncio/unix_events.py
+++ b/Lib/asyncio/unix_events.py
@@ -395,8 +395,7 @@ class _UnixSelectorEventLoop(selector_events.BaseSelectorEventLoop):
                 return
 
         # On 32-bit architectures truncate to 1GiB to avoid OverflowError
-        if sys.maxsize < 2 ** 32:
-            blocksize = min(blocksize, 2 ** 30)
+        blocksize = min(blocksize, sys.maxsize//2 + 1)
 
         try:
             sent = os.sendfile(fd, fileno, offset, blocksize)

--- a/Lib/asyncio/unix_events.py
+++ b/Lib/asyncio/unix_events.py
@@ -394,8 +394,7 @@ class _UnixSelectorEventLoop(selector_events.BaseSelectorEventLoop):
                 fut.set_result(total_sent)
                 return
 
-        # On 32-bit architectures truncate to 1GiB to avoid OverflowError,
-        # see bpo-38319/gh-82500.
+        # On 32-bit architectures truncate to 1GiB to avoid OverflowError
         if sys.maxsize < 2 ** 32:
             blocksize = min(blocksize, 2 ** 30)
 

--- a/Lib/asyncio/unix_events.py
+++ b/Lib/asyncio/unix_events.py
@@ -394,6 +394,11 @@ class _UnixSelectorEventLoop(selector_events.BaseSelectorEventLoop):
                 fut.set_result(total_sent)
                 return
 
+        # On 32-bit architectures truncate to 1GiB to avoid OverflowError,
+        # see bpo-38319/gh-82500.
+        if sys.maxsize < 2 ** 32:
+            blocksize = min(blocksize, 2 ** 30)
+
         try:
             sent = os.sendfile(fd, fileno, offset, blocksize)
         except (BlockingIOError, InterruptedError):

--- a/Misc/NEWS.d/next/Library/2023-07-22-16-44-58.gh-issue-82500.cQYoPj.rst
+++ b/Misc/NEWS.d/next/Library/2023-07-22-16-44-58.gh-issue-82500.cQYoPj.rst
@@ -1,1 +1,1 @@
-Fix overflow on 32-bit systems with :mod:`asyncio` sendfile implemention.
+Fix overflow on 32-bit systems with :mod:`asyncio` :func:`os.sendfile` implemention.

--- a/Misc/NEWS.d/next/Library/2023-07-22-16-44-58.gh-issue-82500.cQYoPj.rst
+++ b/Misc/NEWS.d/next/Library/2023-07-22-16-44-58.gh-issue-82500.cQYoPj.rst
@@ -1,0 +1,1 @@
+Fix overflow on 32-bit systems with :mod:`asyncio` sendfile implemention.


### PR DESCRIPTION
asyncio has the same issue

This is the same patch we have been running for a while with Home Assistant https://raw.githubusercontent.com/home-assistant/docker-base/master/python/3.11/asynctio_unix_events.patch

<!-- gh-issue-number: gh-82500 -->
* Issue: gh-82500
<!-- /gh-issue-number -->


related issue and trace https://github.com/home-assistant/supervisor/issues/4375

```
File "/usr/local/lib/python3.11/site-packages/aiohttp/web_protocol.py", line 458, in _handle_request
   reset = await self.finish_response(request, resp, start_time)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 File "/usr/local/lib/python3.11/site-packages/aiohttp/web_protocol.py", line 611, in finish_response
   await prepare_meth(request)
 File "/usr/local/lib/python3.11/site-packages/aiohttp/web_fileresponse.py", line 286, in prepare
   return await self._sendfile(request, fobj, offset, count)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 File "/usr/local/lib/python3.11/site-packages/aiohttp/web_fileresponse.py", line 99, in _sendfile
   await loop.sendfile(transport, fobj, offset, count)
 File "/usr/local/lib/python3.11/asyncio/base_events.py", line 1185, in sendfile
   return await self._sendfile_native(transport, file,
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 File "/usr/local/lib/python3.11/asyncio/selector_events.py", line 725, in _sendfile_native
   return await self.sock_sendfile(transp._sock, file, offset, count,
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 File "/usr/local/lib/python3.11/asyncio/base_events.py", line 881, in sock_sendfile
   return await self._sock_sendfile_native(sock, file,
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 File "/usr/local/lib/python3.11/asyncio/unix_events.py", line 373, in _sock_sendfile_native
   return await fut
          ^^^^^^^^^
 File "/usr/local/lib/python3.11/asyncio/unix_events.py", line 395, in _sock_sendfile_native_impl
   sent = os.sendfile(fd, fileno, offset, blocksize)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
OverflowError: Python int too large to convert to C ssize_t
```