### PR TITLE
[3.11] gh-106970: Fix Argument Clinic 'destination <name> clear' command (#106972)

### DIFF
--- a/Lib/test/clinic.test.c
+++ b/Lib/test/clinic.test.c
@@ -4192,3 +4192,59 @@ Test_meth_coexist(TestObj *self, PyObject *Py_UNUSED(ignored))
 static PyObject *
 Test_meth_coexist_impl(TestObj *self)
 /*[clinic end generated code: output=808a293d0cd27439 input=2a1d75b5e6fec6dd]*/
+
+
+/*[clinic input]
+output push
+output preset buffer
+[clinic start generated code]*/
+/*[clinic end generated code: output=da39a3ee5e6b4b0d input=5bff3376ee0df0b5]*/
+
+/*[clinic input]
+buffer_clear
+  a: int
+We'll call 'destination buffer clear' after this.
+
+Argument Clinic's buffer preset puts most generated code into the
+'buffer' destination, except from 'impl_definition', which is put into
+the 'block' destination, so we should expect everything but
+'impl_definition' to be cleared.
+[clinic start generated code]*/
+
+static PyObject *
+buffer_clear_impl(PyObject *module, int a)
+/*[clinic end generated code: output=f14bba74677e1846 input=a4c308a6fdab043c]*/
+
+/*[clinic input]
+destination buffer clear
+output pop
+[clinic start generated code]*/
+/*[clinic end generated code: output=da39a3ee5e6b4b0d input=f20d06adb8252084]*/
+
+
+/*[clinic input]
+output push
+destination test1 new buffer
+output everything suppress
+output docstring_definition test1
+[clinic start generated code]*/
+/*[clinic end generated code: output=da39a3ee5e6b4b0d input=5a77c454970992fc]*/
+
+/*[clinic input]
+new_dest
+  a: int
+Only this docstring should be outputted to test1.
+[clinic start generated code]*/
+/*[clinic end generated code: output=da39a3ee5e6b4b0d input=da5af421ed8996ed]*/
+
+/*[clinic input]
+dump test1
+output pop
+[clinic start generated code]*/
+
+PyDoc_STRVAR(new_dest__doc__,
+"new_dest($module, /, a)\n"
+"--\n"
+"\n"
+"Only this docstring should be outputted to test1.");
+/*[clinic end generated code: output=9cac703f51d90e84 input=090db8df4945576d]*/

--- a/Misc/NEWS.d/next/Tools-Demos/2023-07-21-23-16-05.gh-issue-106970.NLRnml.rst
+++ b/Misc/NEWS.d/next/Tools-Demos/2023-07-21-23-16-05.gh-issue-106970.NLRnml.rst
@@ -1,0 +1,4 @@
+Fix bugs in the Argument Clinic ``destination <name> clear`` command; the
+destination buffers would never be cleared, and the ``destination``
+directive parser would simply continue to the fault handler after processing
+the command. Patch by Erlend E. Aasland.

--- a/Tools/clinic/clinic.py
+++ b/Tools/clinic/clinic.py
@@ -1798,7 +1798,7 @@ class BufferSeries:
 
     def clear(self):
         for ta in self._array:
-            ta._text.clear()
+            ta.text.clear()
 
     def dump(self):
         texts = [ta.output() for ta in self._array]
@@ -4121,14 +4121,19 @@ class DSLParser:
 
         self.clinic.__dict__[name] = value
 
-    def directive_destination(self, name, command, *args):
-        if command == 'new':
-            self.clinic.add_destination(name, *args)
-            return
-
-        if command == 'clear':
-            self.clinic.get_destination(name).clear()
-        fail("unknown destination command", repr(command))
+    def directive_destination(
+            self,
+            name: str,
+            command: str,
+            *args
+    ) -> None:
+        match command:
+            case "new":
+                self.clinic.add_destination(name, *args)
+            case "clear":
+                self.clinic.get_destination(name).clear()
+            case _:
+                fail("unknown destination command", repr(command))
 
 
     def directive_output(self, command_or_name, destination=''):


### PR DESCRIPTION
Add test for the 'destination <name> clear' command,
and the 'destination' directive in general.

Fix two bugs in 'destination <name> clear' command:

1. The text attribute of the allocator is called 'text', not '_text'
2. Return after processing the 'clear' command,
   instead of proceeding directly to the fail().

(cherry picked from commit 3372bcba9893030e4063a9264ec0b4d1b6166883)


<!-- gh-issue-number: gh-106970 -->
* Issue: gh-106970
<!-- /gh-issue-number -->
