### PR TITLE
Remove superflous whitespaces in `layout.html`.

### DIFF
--- a/Doc/tools/templates/layout.html
+++ b/Doc/tools/templates/layout.html
@@ -4,16 +4,16 @@
 {%- if outdated %}
 <div id="outdated-warning" style="padding: .5em; text-align: center; background-color: #FFBABA; color: #6A0E0E;">
     {% trans %}This document is for an old version of Python that is no longer supported.
-    You should upgrade, and read the {% endtrans %}
-    <a href="/3/{{ pagename }}{{ file_suffix }}">{% trans %} Python documentation for the current stable release{% endtrans %}</a>.
+    You should upgrade, and read the{% endtrans %}
+    <a href="/3/{{ pagename }}{{ file_suffix }}">{% trans %}Python documentation for the current stable release{% endtrans %}</a>.
 </div>
 {%- endif %}
 
 {%- if is_deployment_preview %}
 <div id="deployment-preview-warning" style="padding: .5em; text-align: center; background-color: #fff2ba; color: #6a580e;">
   {% trans %}This is a deploy preview created from a <a href="{{ repository_url }}/pull/{{ pr_id }}">pull request</a>.
-  For authoritative documentation, see {% endtrans %}
-  <a href="https://docs.python.org/3/{{ pagename }}{{ file_suffix }}">{% trans %} the current stable release{% endtrans %}</a>.
+  For authoritative documentation, see{% endtrans %}
+  <a href="https://docs.python.org/3/{{ pagename }}{{ file_suffix }}">{% trans %}the current stable release{% endtrans %}</a>.
 </div>
 {%- endif %}
 {% endblock %}


### PR DESCRIPTION
This came up in python/python-docs-zh-tw#496: after adding `sphinx-lint` to the CI workflow it reported 2 errors caused by trailing whitespace:
```
sphinx.po:295: trailing whitespace (trailing-whitespace)
sphinx.po:306: trailing whitespace (trailing-whitespace)
```
These are caused by [two strings in `sphinx.po`](https://github.com/python/python-docs-zh-tw/blob/3.12/sphinx.po#L297-L313) (at line 299 and 313), that are taken from `layout.html`.

This PR remove those spaces from `layout.html` that *should* generate a `.po` without trailing whitespace and fix the issue, even though I wasn't able to test it.

The spaces after the `<a>`s don't create issues but shouldn't be there, whereas the ones before are the problematic ones and I think they can be removed since in both cases there is a newline, which -- once rendered -- should translate to a space before the link in the output.