### PR TITLE
GH-103082: Rename PY_MONITORING_EVENTS to _PY_MONITORING_EVENTS

### DIFF
--- a/Include/cpython/code.h
+++ b/Include/cpython/code.h
@@ -10,13 +10,13 @@ extern "C" {
 
 
 /* Count of all "real" monitoring events (not derived from other events) */
-#define PY_MONITORING_UNGROUPED_EVENTS 14
+#define _PY_MONITORING_UNGROUPED_EVENTS 14
 /* Count of all  monitoring events */
-#define PY_MONITORING_EVENTS 16
+#define _PY_MONITORING_EVENTS 16
 
 /* Table of which tools are active for each monitored event. */
 typedef struct _Py_Monitors {
-    uint8_t tools[PY_MONITORING_UNGROUPED_EVENTS];
+    uint8_t tools[_PY_MONITORING_UNGROUPED_EVENTS];
 } _Py_Monitors;
 
 /* Each instruction in a code object is a fixed-width value,

--- a/Include/internal/pycore_interp.h
+++ b/Include/internal/pycore_interp.h
@@ -25,7 +25,7 @@ extern "C" {
 #include "pycore_gc.h"            // struct _gc_runtime_state
 #include "pycore_global_objects.h"  // struct _Py_interp_static_objects
 #include "pycore_import.h"        // struct _import_state
-#include "pycore_instruments.h"   // PY_MONITORING_EVENTS
+#include "pycore_instruments.h"   // _PY_MONITORING_EVENTS
 #include "pycore_list.h"          // struct _Py_list_state
 #include "pycore_object_state.h"   // struct _py_object_state
 #include "pycore_obmalloc.h"      // struct obmalloc_state
@@ -190,7 +190,7 @@ struct _is {
     bool sys_trace_initialized;
     Py_ssize_t sys_profiling_threads; /* Count of threads with c_profilefunc set */
     Py_ssize_t sys_tracing_threads; /* Count of threads with c_tracefunc set */
-    PyObject *monitoring_callables[PY_MONITORING_TOOL_IDS][PY_MONITORING_EVENTS];
+    PyObject *monitoring_callables[PY_MONITORING_TOOL_IDS][_PY_MONITORING_EVENTS];
     PyObject *monitoring_tool_names[PY_MONITORING_TOOL_IDS];
 
     struct _Py_interp_cached_objects cached_objects;

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -1914,7 +1914,7 @@ static int
 do_monitor_exc(PyThreadState *tstate, _PyInterpreterFrame *frame,
                _Py_CODEUNIT *instr, int event)
 {
-    assert(event < PY_MONITORING_UNGROUPED_EVENTS);
+    assert(event < _PY_MONITORING_UNGROUPED_EVENTS);
     PyObject *exc = PyErr_GetRaisedException();
     assert(exc != NULL);
     int err = _Py_call_instrumentation_arg(tstate, event, frame, instr, exc);

--- a/Python/instrumentation.c
+++ b/Python/instrumentation.c
@@ -137,7 +137,7 @@ is_instrumented(int opcode)
 static inline bool
 monitors_equals(_Py_Monitors a, _Py_Monitors b)
 {
-    for (int i = 0; i < PY_MONITORING_UNGROUPED_EVENTS; i++) {
+    for (int i = 0; i < _PY_MONITORING_UNGROUPED_EVENTS; i++) {
         if (a.tools[i] != b.tools[i]) {
             return false;
         }
@@ -150,7 +150,7 @@ static inline _Py_Monitors
 monitors_sub(_Py_Monitors a, _Py_Monitors b)
 {
     _Py_Monitors res;
-    for (int i = 0; i < PY_MONITORING_UNGROUPED_EVENTS; i++) {
+    for (int i = 0; i < _PY_MONITORING_UNGROUPED_EVENTS; i++) {
         res.tools[i] = a.tools[i] & ~b.tools[i];
     }
     return res;
@@ -161,7 +161,7 @@ static inline _Py_Monitors
 monitors_and(_Py_Monitors a, _Py_Monitors b)
 {
     _Py_Monitors res;
-    for (int i = 0; i < PY_MONITORING_UNGROUPED_EVENTS; i++) {
+    for (int i = 0; i < _PY_MONITORING_UNGROUPED_EVENTS; i++) {
         res.tools[i] = a.tools[i] & b.tools[i];
     }
     return res;
@@ -172,7 +172,7 @@ static inline _Py_Monitors
 monitors_or(_Py_Monitors a, _Py_Monitors b)
 {
     _Py_Monitors res;
-    for (int i = 0; i < PY_MONITORING_UNGROUPED_EVENTS; i++) {
+    for (int i = 0; i < _PY_MONITORING_UNGROUPED_EVENTS; i++) {
         res.tools[i] = a.tools[i] | b.tools[i];
     }
     return res;
@@ -181,7 +181,7 @@ monitors_or(_Py_Monitors a, _Py_Monitors b)
 static inline bool
 monitors_are_empty(_Py_Monitors m)
 {
-    for (int i = 0; i < PY_MONITORING_UNGROUPED_EVENTS; i++) {
+    for (int i = 0; i < _PY_MONITORING_UNGROUPED_EVENTS; i++) {
         if (m.tools[i]) {
             return false;
         }
@@ -192,7 +192,7 @@ monitors_are_empty(_Py_Monitors m)
 static inline bool
 multiple_tools(_Py_Monitors *m)
 {
-    for (int i = 0; i < PY_MONITORING_UNGROUPED_EVENTS; i++) {
+    for (int i = 0; i < _PY_MONITORING_UNGROUPED_EVENTS; i++) {
         if (_Py_popcount32(m->tools[i]) > 1) {
             return true;
         }
@@ -204,7 +204,7 @@ static inline _PyMonitoringEventSet
 get_events(_Py_Monitors *m, int tool_id)
 {
     _PyMonitoringEventSet result = 0;
-    for (int e = 0; e < PY_MONITORING_UNGROUPED_EVENTS; e++) {
+    for (int e = 0; e < _PY_MONITORING_UNGROUPED_EVENTS; e++) {
         if ((m->tools[e] >> tool_id) & 1) {
             result |= (1 << e);
         }
@@ -339,7 +339,7 @@ static void
 dump_monitors(const char *prefix, _Py_Monitors monitors, FILE*out)
 {
     fprintf(out, "%s monitors:\n", prefix);
-    for (int event = 0; event < PY_MONITORING_UNGROUPED_EVENTS; event++) {
+    for (int event = 0; event < _PY_MONITORING_UNGROUPED_EVENTS; event++) {
         fprintf(out, "    Event %d: Tools %x\n", event, monitors.tools[event]);
     }
 }
@@ -907,7 +907,7 @@ get_tools_for_instruction(PyCodeObject *code, PyInterpreterState *interp, int i,
     uint8_t tools;
     assert(event != PY_MONITORING_EVENT_LINE);
     assert(event != PY_MONITORING_EVENT_INSTRUCTION);
-    if (event >= PY_MONITORING_UNGROUPED_EVENTS) {
+    if (event >= _PY_MONITORING_UNGROUPED_EVENTS) {
         assert(event == PY_MONITORING_EVENT_C_RAISE ||
                 event == PY_MONITORING_EVENT_C_RETURN);
         event = PY_MONITORING_EVENT_CALL;
@@ -1220,7 +1220,7 @@ _PyMonitoring_RegisterCallback(int tool_id, int event_id, PyObject *obj)
 {
     PyInterpreterState *is = _PyInterpreterState_GET();
     assert(0 <= tool_id && tool_id < PY_MONITORING_TOOL_IDS);
-    assert(0 <= event_id && event_id < PY_MONITORING_EVENTS);
+    assert(0 <= event_id && event_id < _PY_MONITORING_EVENTS);
     PyObject *callback = is->monitoring_callables[tool_id][event_id];
     is->monitoring_callables[tool_id][event_id] = Py_XNewRef(obj);
     return callback;
@@ -1653,7 +1653,7 @@ static void
 set_events(_Py_Monitors *m, int tool_id, _PyMonitoringEventSet events)
 {
     assert(0 <= tool_id && tool_id < PY_MONITORING_TOOL_IDS);
-    for (int e = 0; e < PY_MONITORING_UNGROUPED_EVENTS; e++) {
+    for (int e = 0; e < _PY_MONITORING_UNGROUPED_EVENTS; e++) {
         uint8_t *tools = &m->tools[e];
         int val = (events >> e) & 1;
         *tools &= ~(1 << tool_id);
@@ -1678,7 +1678,7 @@ _PyMonitoring_SetEvents(int tool_id, _PyMonitoringEventSet events)
 {
     assert(0 <= tool_id && tool_id < PY_MONITORING_TOOL_IDS);
     PyInterpreterState *interp = _PyInterpreterState_GET();
-    assert(events < (1 << PY_MONITORING_UNGROUPED_EVENTS));
+    assert(events < (1 << _PY_MONITORING_UNGROUPED_EVENTS));
     if (check_tool(interp, tool_id)) {
         return -1;
     }
@@ -1696,7 +1696,7 @@ _PyMonitoring_SetLocalEvents(PyCodeObject *code, int tool_id, _PyMonitoringEvent
 {
     assert(0 <= tool_id && tool_id < PY_MONITORING_TOOL_IDS);
     PyInterpreterState *interp = _PyInterpreterState_GET();
-    assert(events < (1 << PY_MONITORING_UNGROUPED_EVENTS));
+    assert(events < (1 << _PY_MONITORING_UNGROUPED_EVENTS));
     if (check_tool(interp, tool_id)) {
         return -1;
     }
@@ -1835,7 +1835,7 @@ monitoring_register_callback_impl(PyObject *module, int tool_id, int event,
         return NULL;
     }
     int event_id = _Py_bit_length(event)-1;
-    if (event_id < 0 || event_id >= PY_MONITORING_EVENTS) {
+    if (event_id < 0 || event_id >= _PY_MONITORING_EVENTS) {
         PyErr_Format(PyExc_ValueError, "invalid event %d", event);
         return NULL;
     }
@@ -1885,7 +1885,7 @@ monitoring_set_events_impl(PyObject *module, int tool_id, int event_set)
     if (check_valid_tool(tool_id))  {
         return NULL;
     }
-    if (event_set < 0 || event_set >= (1 << PY_MONITORING_EVENTS)) {
+    if (event_set < 0 || event_set >= (1 << _PY_MONITORING_EVENTS)) {
         PyErr_Format(PyExc_ValueError, "invalid event set 0x%x", event_set);
         return NULL;
     }
@@ -1927,7 +1927,7 @@ monitoring_get_local_events_impl(PyObject *module, int tool_id,
     _PyMonitoringEventSet event_set = 0;
     _PyCoMonitoringData *data = ((PyCodeObject *)code)->_co_monitoring;
     if (data != NULL) {
-        for (int e = 0; e < PY_MONITORING_UNGROUPED_EVENTS; e++) {
+        for (int e = 0; e < _PY_MONITORING_UNGROUPED_EVENTS; e++) {
             if ((data->local_monitors.tools[e] >> tool_id) & 1) {
                 event_set |= (1 << e);
             }
@@ -1961,7 +1961,7 @@ monitoring_set_local_events_impl(PyObject *module, int tool_id,
     if (check_valid_tool(tool_id))  {
         return NULL;
     }
-    if (event_set < 0 || event_set >= (1 << PY_MONITORING_EVENTS)) {
+    if (event_set < 0 || event_set >= (1 << _PY_MONITORING_EVENTS)) {
         PyErr_Format(PyExc_ValueError, "invalid event set 0x%x", event_set);
         return NULL;
     }
@@ -2042,7 +2042,7 @@ monitoring__all_events_impl(PyObject *module)
     if (res == NULL) {
         return NULL;
     }
-    for (int e = 0; e < PY_MONITORING_UNGROUPED_EVENTS; e++) {
+    for (int e = 0; e < _PY_MONITORING_UNGROUPED_EVENTS; e++) {
         uint8_t tools = interp->monitors.tools[e];
         if (tools == 0) {
             continue;
@@ -2101,7 +2101,7 @@ PyObject *_Py_CreateMonitoringObject(void)
     if (err) {
         goto error;
     }
-    for (int i = 0; i < PY_MONITORING_EVENTS; i++) {
+    for (int i = 0; i < _PY_MONITORING_EVENTS; i++) {
         if (add_power2_constant(events, event_names[i], i)) {
             goto error;
         }

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -679,11 +679,11 @@ init_interpreter(PyInterpreterState *interp,
     _PyGC_InitState(&interp->gc);
     PyConfig_InitPythonConfig(&interp->config);
     _PyType_InitCache(interp);
-    for (int i = 0; i < PY_MONITORING_UNGROUPED_EVENTS; i++) {
+    for (int i = 0; i < _PY_MONITORING_UNGROUPED_EVENTS; i++) {
         interp->monitors.tools[i] = 0;
     }
     for (int t = 0; t < PY_MONITORING_TOOL_IDS; t++) {
-        for (int e = 0; e < PY_MONITORING_EVENTS; e++) {
+        for (int e = 0; e < _PY_MONITORING_EVENTS; e++) {
             interp->monitoring_callables[t][e] = NULL;
 
         }
@@ -841,11 +841,11 @@ interpreter_clear(PyInterpreterState *interp, PyThreadState *tstate)
 
     Py_CLEAR(interp->audit_hooks);
 
-    for (int i = 0; i < PY_MONITORING_UNGROUPED_EVENTS; i++) {
+    for (int i = 0; i < _PY_MONITORING_UNGROUPED_EVENTS; i++) {
         interp->monitors.tools[i] = 0;
     }
     for (int t = 0; t < PY_MONITORING_TOOL_IDS; t++) {
-        for (int e = 0; e < PY_MONITORING_EVENTS; e++) {
+        for (int e = 0; e < _PY_MONITORING_EVENTS; e++) {
             Py_CLEAR(interp->monitoring_callables[t][e]);
         }
     }


### PR DESCRIPTION
Rename private C API constants:

* Rename PY_MONITORING_UNGROUPED_EVENTS to _PY_MONITORING_UNGROUPED_EVENTS
* Rename PY_MONITORING_EVENTS to _PY_MONITORING_EVENTS

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-103082 -->
* Issue: gh-103082
<!-- /gh-issue-number -->
