### PR TITLE
gh-106320: Remove private _PyModule API

### DIFF
--- a/Include/internal/pycore_moduleobject.h
+++ b/Include/internal/pycore_moduleobject.h
@@ -8,6 +8,12 @@ extern "C" {
 #  error "this header requires Py_BUILD_CORE define"
 #endif
 
+extern void _PyModule_Clear(PyObject *);
+extern void _PyModule_ClearDict(PyObject *);
+extern int _PyModuleSpec_IsInitializing(PyObject *);
+
+extern int _PyModule_IsExtension(PyObject *obj);
+
 typedef struct {
     PyObject_HEAD
     PyObject *md_dict;

--- a/Include/moduleobject.h
+++ b/Include/moduleobject.h
@@ -27,11 +27,6 @@ PyAPI_FUNC(PyObject *) PyModule_GetNameObject(PyObject *);
 PyAPI_FUNC(const char *) PyModule_GetName(PyObject *);
 Py_DEPRECATED(3.2) PyAPI_FUNC(const char *) PyModule_GetFilename(PyObject *);
 PyAPI_FUNC(PyObject *) PyModule_GetFilenameObject(PyObject *);
-#ifndef Py_LIMITED_API
-PyAPI_FUNC(void) _PyModule_Clear(PyObject *);
-PyAPI_FUNC(void) _PyModule_ClearDict(PyObject *);
-PyAPI_FUNC(int) _PyModuleSpec_IsInitializing(PyObject *);
-#endif
 PyAPI_FUNC(PyModuleDef*) PyModule_GetDef(PyObject*);
 PyAPI_FUNC(void*) PyModule_GetState(PyObject*);
 
@@ -102,12 +97,6 @@ struct PyModuleDef {
   inquiry m_clear;
   freefunc m_free;
 };
-
-
-// Internal C API
-#ifdef Py_BUILD_CORE
-extern int _PyModule_IsExtension(PyObject *obj);
-#endif
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Move private _PyModule API to the internal C API
(pycore_moduleobject.h):

* _PyModule_Clear()
* _PyModule_ClearDict()
* _PyModuleSpec_IsInitializing()
* _PyModule_IsExtension()

No longer export these functions.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-106320 -->
* Issue: gh-106320
<!-- /gh-issue-number -->
