### PR TITLE
gh-107082: Remove debug hack from get_first_executor in test_capi.test_misc

### DIFF
--- a/Lib/test/test_capi/test_misc.py
+++ b/Lib/test/test_capi/test_misc.py
@@ -2436,7 +2436,7 @@ def get_first_executor(func):
     co_code = code.co_code
     JUMP_BACKWARD = opcode.opmap["JUMP_BACKWARD"]
     for i in range(0, len(co_code), 2):
-        if co_code[i] == JUMP_BACKWARD or 1:
+        if co_code[i] == JUMP_BACKWARD:
             try:
                 return _testinternalcapi.get_executor(code, i)
             except ValueError:


### PR DESCRIPTION
In order to test this function more thoroughly during debugging I made it call `_testinternalcapi.get_executor()` every time, instead of just when a `JUMP_BACKWARD` opcode is found. This causes it to be called for cache entries, resulting in failing asserts. The fix removes the expression part `or 1` that I had added.

(Is it okay that this function can crash with out of range arguments? Well I suppose it's okay since it's part of `_testinternalcapi`.)

<!-- gh-issue-number: gh-107082 -->
* Issue: gh-107082
<!-- /gh-issue-number -->
