### PR TITLE
gh-107089: Improve Shelf.clear method performance

### DIFF
--- a/Lib/shelve.py
+++ b/Lib/shelve.py
@@ -171,26 +171,6 @@ class Shelf(collections.abc.MutableMapping):
         if hasattr(self.dict, 'sync'):
             self.dict.sync()
 
-    def clear(self):
-        """Remove all items from the shelf."""
-        self.cache.clear()
-        try:
-            self.dict.clear()
-        except AttributeError:
-            # dbm objects don't have a clear method, so we need to do
-            # the clearing here.
-            keys = self.dict.keys()
-            if not isinstance(keys, list):
-                # The keys method on dbm objects returns a list.
-                # Typically, the keys method on a mapping returns a
-                # lazy iterator, so we need to watch out for that in
-                # case someone passes in a backing object that behaves
-                # that way.
-                keys = list(keys)
-            for k in keys:
-                del self.dict[k]
-
-
 class BsdDbShelf(Shelf):
     """Shelf implementation using the "BSD" db interface.
 
@@ -244,6 +224,13 @@ class DbfilenameShelf(Shelf):
     def __init__(self, filename, flag='c', protocol=None, writeback=False):
         import dbm
         Shelf.__init__(self, dbm.open(filename, flag), protocol, writeback)
+    
+    def clear(self):
+        """Remove all items from the shelf."""
+        # Call through to the clear method on dbm-backed shelves.
+        # see https://github.com/python/cpython/issues/107089
+        self.cache.clear()
+        self.dict.clear()
 
 
 def open(filename, flag='c', protocol=None, writeback=False):

--- a/Lib/shelve.py
+++ b/Lib/shelve.py
@@ -171,6 +171,7 @@ class Shelf(collections.abc.MutableMapping):
         if hasattr(self.dict, 'sync'):
             self.dict.sync()
 
+
 class BsdDbShelf(Shelf):
     """Shelf implementation using the "BSD" db interface.
 

--- a/Lib/shelve.py
+++ b/Lib/shelve.py
@@ -171,6 +171,25 @@ class Shelf(collections.abc.MutableMapping):
         if hasattr(self.dict, 'sync'):
             self.dict.sync()
 
+    def clear(self):
+        """Remove all items from the shelf."""
+        self.cache.clear()
+        try:
+            self.dict.clear()
+        except AttributeError:
+            # dbm objects don't have a clear method, so we need to do
+            # the clearing here.
+            keys = self.dict.keys()
+            if not isinstance(keys, list):
+                # The keys method on dbm objects returns a list.
+                # Typically, the keys method on a mapping returns a
+                # lazy iterator, so we need to watch out for that in
+                # case someone passes in a backing object that behaves
+                # that way.
+                keys = list(keys)
+            for k in keys:
+                del self.dict[k]
+
 
 class BsdDbShelf(Shelf):
     """Shelf implementation using the "BSD" db interface.

--- a/Lib/shelve.py
+++ b/Lib/shelve.py
@@ -224,7 +224,7 @@ class DbfilenameShelf(Shelf):
     def __init__(self, filename, flag='c', protocol=None, writeback=False):
         import dbm
         Shelf.__init__(self, dbm.open(filename, flag), protocol, writeback)
-    
+
     def clear(self):
         """Remove all items from the shelf."""
         # Call through to the clear method on dbm-backed shelves.

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -289,6 +289,7 @@ Edward Catmur
 Lorenzo M. Catucci
 Bruno Cauet
 Donn Cave
+James Cave
 Charles Cazabon
 Jesús Cea Avión
 Per Cederqvist

--- a/Misc/NEWS.d/next/Library/2023-07-22-21-57-34.gh-issue-107089.Dnget2.rst
+++ b/Misc/NEWS.d/next/Library/2023-07-22-21-57-34.gh-issue-107089.Dnget2.rst
@@ -1,2 +1,2 @@
-The :meth:`Shelf.clear` method in the :mod:`shelve` module is much faster.
-Patch by James Cave.
+Shelves opened with :func:`shelve.open` have a much faster :meth:`clear`
+method. Patch by James Cave.

--- a/Misc/NEWS.d/next/Library/2023-07-22-21-57-34.gh-issue-107089.Dnget2.rst
+++ b/Misc/NEWS.d/next/Library/2023-07-22-21-57-34.gh-issue-107089.Dnget2.rst
@@ -1,0 +1,2 @@
+The :meth:`Shelf.clear` method in the :mod:`shelve` module is much faster.
+Patch by James Cave.


### PR DESCRIPTION
`Shelf` inherits its `clear` method from `MutableMapping`, but the implementation is poorly suited for that class. The `clear` mix-in is implemented by calling `popitem` in a loop. Each call to `popitem` constructs a new iterator over the shelf, which is a generator that does byte-to-str conversion on the keys in the `dbm` object. Unfortunately, `dbm` objects are non-iterable, and their `keys` method simply returns a list of all keys. Since each `popitem` call performs a full scan of the key space, the clear method ends up having O(n²) performance (assuming the delete and read operations amortize to O(1)).

By having the shelf just iterate over the list of dbm keys once, this is avoided.

<!-- gh-issue-number: gh-107089 -->
* Issue: gh-107089
<!-- /gh-issue-number -->
