### PR TITLE
[3.11] gh-106969: Indicate no modules were added in 3.10 (GH-106988)

### DIFF
--- a/Doc/whatsnew/3.10.rst
+++ b/Doc/whatsnew/3.10.rst
@@ -886,7 +886,7 @@ Other Language Changes
 New Modules
 ===========
 
-* None yet.
+* None.
 
 
 Improved Modules


### PR DESCRIPTION
The "New Modules" section was left in place to ensure that the anchor link for new modules will still exist:

/whatsnew/3.12.htmlGH-new-modules
/whatsnew/3.10.htmlGH-new-modules

This means that existing links to this section don't break.. (cherry picked from commit 6dbffaed17d59079d6a2788d686009f762a3278f)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-106969 -->
* Issue: gh-106969
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--107093.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->