### PR TITLE
gh-107017: Change Chapter Strings to Texts in the Introduction chapter.

### DIFF
--- a/Doc/tutorial/introduction.rst
+++ b/Doc/tutorial/introduction.rst
@@ -168,10 +168,9 @@ Alternatively, we can use the other type of quotation marks::
    >>> '"Isn\'t," they said.'
    '"Isn\'t," they said.'
 
-In the interactive interpreter, the string definition and output string
-can look different.  The :func:`print` function produces a more
-readable output, by omitting the enclosing quotes and by printing escaped
-and special characters::
+In the Python shell, the string definition and output string can look
+different.  The :func:`print` function produces a more readable output, by
+omitting the enclosing quotes and by printing escaped and special characters::
 
    >>> s = 'First line.\nSecond line.'  # \n means newline
    >>> s  # without print(), special characters are included in the string

--- a/Doc/tutorial/introduction.rst
+++ b/Doc/tutorial/introduction.rst
@@ -138,13 +138,14 @@ and uses the ``j`` or ``J`` suffix to indicate the imaginary part
 
 .. _tut-strings:
 
-Strings
+Texts
 -------
 
-Besides numbers, Python can also manipulate strings, which can be expressed
-in several ways.  They can be enclosed in single quotes (``'...'``) or
-double quotes (``"..."``) with the same result [#]_.  ``\`` can be used
-to escape quotes::
+Different kinds of text have the type :class:`str`.  This includes
+characters "``!``", words "``rabbit``", names "``Paris``", sentences
+"``Got your back.``", etc. "``Yay! :)``".  They can be enclosed in single
+quotes (``'...'``) or double quotes (``"..."``) with the same result [#]_.
+``\`` can be used to escape quotes::
 
    >>> 'spam eggs'  # single quotes
    'spam eggs'

--- a/Doc/tutorial/introduction.rst
+++ b/Doc/tutorial/introduction.rst
@@ -138,17 +138,24 @@ and uses the ``j`` or ``J`` suffix to indicate the imaginary part
 
 .. _tut-strings:
 
-Texts
+Text
 -------
 
-Different kinds of text have the type :class:`str`.  This includes
-characters "``!``", words "``rabbit``", names "``Paris``", sentences
-"``Got your back.``", etc. "``Yay! :)``".  They can be enclosed in single
-quotes (``'...'``) or double quotes (``"..."``) with the same result [#]_.
-``\`` can be used to escape quotes::
+Python can manipulate text (represented by type :class:`str`, so called
+"strings") as well as numbers.  This includes characters "``!``", words
+"``rabbit``", names "``Paris``", sentences "``Got your back.``", etc.
+"``Yay! :)``". They can be enclosed in single quotes (``'...'``) or double
+quotes (``"..."``) with the same result [#]_. 
 
    >>> 'spam eggs'  # single quotes
    'spam eggs'
+   >>> "Paris rabbit got your back :)! Yay!" # double quotes
+   'Paris rabbit got your back :)! Yay!'
+   >>> '1975' # digits and numerals enclosed in quotes are also strings
+   '1975'
+
+To quote a quote, we need to "escape" it, by preceding it with ``\``::
+
    >>> 'doesn\'t'  # use \' to escape the single quote...
    "doesn't"
    >>> "doesn't"  # ...or use double quotes instead

--- a/Doc/tutorial/introduction.rst
+++ b/Doc/tutorial/introduction.rst
@@ -141,7 +141,7 @@ and uses the ``j`` or ``J`` suffix to indicate the imaginary part
 Text
 ----
 
-Python can manipulate text (represented by type :class:`str`, so called
+Python can manipulate text (represented by type :class:`str`, so-called
 "strings") as well as numbers.  This includes characters "``!``", words
 "``rabbit``", names "``Paris``", sentences "``Got your back.``", etc.
 "``Yay! :)``". They can be enclosed in single quotes (``'...'``) or double

--- a/Doc/tutorial/introduction.rst
+++ b/Doc/tutorial/introduction.rst
@@ -151,7 +151,7 @@ quotes (``"..."``) with the same result [#]_.
    'spam eggs'
    >>> "Paris rabbit got your back :)! Yay!" # double quotes
    'Paris rabbit got your back :)! Yay!'
-   >>> '1975' # digits and numerals enclosed in quotes are also strings
+   >>> '1975'  # digits and numerals enclosed in quotes are also strings
    '1975'
 
 To quote a quote, we need to "escape" it, by preceding it with ``\``.

--- a/Doc/tutorial/introduction.rst
+++ b/Doc/tutorial/introduction.rst
@@ -149,7 +149,7 @@ quotes (``"..."``) with the same result [#]_.
 
    >>> 'spam eggs'  # single quotes
    'spam eggs'
-   >>> "Paris rabbit got your back :)! Yay!" # double quotes
+   >>> "Paris rabbit got your back :)! Yay!"  # double quotes
    'Paris rabbit got your back :)! Yay!'
    >>> '1975'  # digits and numerals enclosed in quotes are also strings
    '1975'

--- a/Doc/tutorial/introduction.rst
+++ b/Doc/tutorial/introduction.rst
@@ -145,7 +145,7 @@ Python can manipulate text (represented by type :class:`str`, so called
 "strings") as well as numbers.  This includes characters "``!``", words
 "``rabbit``", names "``Paris``", sentences "``Got your back.``", etc.
 "``Yay! :)``". They can be enclosed in single quotes (``'...'``) or double
-quotes (``"..."``) with the same result [#]_. 
+quotes (``"..."``) with the same result [#]_.
 
    >>> 'spam eggs'  # single quotes
    'spam eggs'
@@ -154,7 +154,8 @@ quotes (``"..."``) with the same result [#]_.
    >>> '1975' # digits and numerals enclosed in quotes are also strings
    '1975'
 
-To quote a quote, we need to "escape" it, by preceding it with ``\``::
+To quote a quote, we need to "escape" it, by preceding it with ``\``.
+Alternatively, we can use the other type of quotation marks::
 
    >>> 'doesn\'t'  # use \' to escape the single quote...
    "doesn't"
@@ -167,23 +168,15 @@ To quote a quote, we need to "escape" it, by preceding it with ``\``::
    >>> '"Isn\'t," they said.'
    '"Isn\'t," they said.'
 
-In the interactive interpreter, the output string is enclosed in quotes and
-special characters are escaped with backslashes.  While this might sometimes
-look different from the input (the enclosing quotes could change), the two
-strings are equivalent.  The string is enclosed in double quotes if
-the string contains a single quote and no double quotes, otherwise it is
-enclosed in single quotes.  The :func:`print` function produces a more
+In the interactive interpreter, the string definition and output string
+can look different.  The :func:`print` function produces a more
 readable output, by omitting the enclosing quotes and by printing escaped
 and special characters::
 
-   >>> '"Isn\'t," they said.'
-   '"Isn\'t," they said.'
-   >>> print('"Isn\'t," they said.')
-   "Isn't," they said.
    >>> s = 'First line.\nSecond line.'  # \n means newline
-   >>> s  # without print(), \n is included in the output
+   >>> s  # without print(), special characters are included in the string
    'First line.\nSecond line.'
-   >>> print(s)  # with print(), \n produces a new line
+   >>> print(s)  # with print(), special characters are interpreted, so \n produces new line
    First line.
    Second line.
 

--- a/Doc/tutorial/introduction.rst
+++ b/Doc/tutorial/introduction.rst
@@ -139,7 +139,7 @@ and uses the ``j`` or ``J`` suffix to indicate the imaginary part
 .. _tut-strings:
 
 Text
--------
+----
 
 Python can manipulate text (represented by type :class:`str`, so called
 "strings") as well as numbers.  This includes characters "``!``", words


### PR DESCRIPTION
While the term "string" is well-known in computer science, it might not resonate with beginners or non-technical individuals. Term Texts emphasize practical application in a similar way to Numbers and Lists chapters. This can make the introduction part less intimidating and more beginner-oriented. On the other hand, people coming from other technologies will not be surprised that text is represented with strings.

<!-- gh-issue-number: gh-107017 -->
* Issue: gh-107017
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--107104.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->