### PR TITLE
gh-62519: Make pgettext search plurals when translation is not found

### DIFF
--- a/Lib/gettext.py
+++ b/Lib/gettext.py
@@ -446,10 +446,12 @@ class GNUTranslations(NullTranslations):
         missing = object()
         tmsg = self._catalog.get(ctxt_msg_id, missing)
         if tmsg is missing:
-            if self._fallback:
-                return self._fallback.pgettext(context, message)
-            return message
-        return tmsg
+            tmsg = self._catalog.get((ctxt_msg_id, self.plural(1)), missing)
+        if tmsg is not missing:
+            return tmsg
+        if self._fallback:
+            return self._fallback.pgettext(context, message)
+        return message
 
     def npgettext(self, context, msgid1, msgid2, n):
         ctxt_msg_id = self.CONTEXT % (context, msgid1)

--- a/Lib/test/test_gettext.py
+++ b/Lib/test/test_gettext.py
@@ -331,6 +331,8 @@ class PluralFormsTestCase(GettextBaseTest):
         x = gettext.npgettext('With context',
                               'There is %s file', 'There are %s files', 2)
         eq(x, 'Hay %s ficheros (context)')
+        x = gettext.pgettext('With context', 'There is %s file')
+        eq(x, 'Hay %s fichero (context)')
 
     def test_plural_forms2(self):
         eq = self.assertEqual
@@ -353,6 +355,8 @@ class PluralFormsTestCase(GettextBaseTest):
         x = t.npgettext('With context',
                         'There is %s file', 'There are %s files', 2)
         eq(x, 'Hay %s ficheros (context)')
+        x = gettext.pgettext('With context', 'There is %s file')
+        eq(x, 'Hay %s fichero (context)')
 
     # Examples from http://www.gnu.org/software/gettext/manual/gettext.html
 

--- a/Misc/NEWS.d/next/Library/2023-07-23-12-26-23.gh-issue-62519.w8-81X.rst
+++ b/Misc/NEWS.d/next/Library/2023-07-23-12-26-23.gh-issue-62519.w8-81X.rst
@@ -1,0 +1,2 @@
+Make pgettext :func:`gettext.pgettext` search plural definitions when
+translation is not found.

--- a/Misc/NEWS.d/next/Library/2023-07-23-12-26-23.gh-issue-62519.w8-81X.rst
+++ b/Misc/NEWS.d/next/Library/2023-07-23-12-26-23.gh-issue-62519.w8-81X.rst
@@ -1,2 +1,2 @@
-Make pgettext :func:`gettext.pgettext` search plural definitions when
+Make :func:`gettext.pgettext` search plural definitions when
 translation is not found.


### PR DESCRIPTION
Related issue: #62519

Now that `gettext` is fixed, let's also fix `pgettext`.

<!-- gh-issue-number: gh-62519 -->
* Issue: gh-62519
<!-- /gh-issue-number -->
