### PR TITLE
[3.11] gh-101100: Fix some broken sphinx references (GH-107095).

### DIFF
--- a/Doc/c-api/iterator.rst
+++ b/Doc/c-api/iterator.rst
@@ -6,7 +6,7 @@ Iterator Objects
 ----------------
 
 Python provides two general-purpose iterator objects.  The first, a sequence
-iterator, works with an arbitrary sequence supporting the :meth:`__getitem__`
+iterator, works with an arbitrary sequence supporting the :meth:`~object.__getitem__`
 method.  The second works with a callable object and a sentinel value, calling
 the callable for each item in the sequence, and ending the iteration when the
 sentinel value is returned.

--- a/Doc/c-api/mapping.rst
+++ b/Doc/c-api/mapping.rst
@@ -13,7 +13,7 @@ See also :c:func:`PyObject_GetItem`, :c:func:`PyObject_SetItem` and
 
    Return ``1`` if the object provides the mapping protocol or supports slicing,
    and ``0`` otherwise.  Note that it returns ``1`` for Python classes with
-   a :meth:`__getitem__` method, since in general it is impossible to
+   a :meth:`~object.__getitem__` method, since in general it is impossible to
    determine what type of keys the class supports. This function always succeeds.
 
 
@@ -60,7 +60,7 @@ See also :c:func:`PyObject_GetItem`, :c:func:`PyObject_SetItem` and
    This is equivalent to the Python expression ``key in o``.
    This function always succeeds.
 
-   Note that exceptions which occur while calling the :meth:`__getitem__`
+   Note that exceptions which occur while calling the :meth:`~object.__getitem__`
    method will get suppressed.
    To get error reporting use :c:func:`PyObject_GetItem()` instead.
 
@@ -71,7 +71,7 @@ See also :c:func:`PyObject_GetItem`, :c:func:`PyObject_SetItem` and
    This is equivalent to the Python expression ``key in o``.
    This function always succeeds.
 
-   Note that exceptions which occur while calling the :meth:`__getitem__`
+   Note that exceptions which occur while calling the :meth:`~object.__getitem__`
    method and creating a temporary string object will get suppressed.
    To get error reporting use :c:func:`PyMapping_GetItemString()` instead.
 

--- a/Doc/c-api/refcounting.rst
+++ b/Doc/c-api/refcounting.rst
@@ -81,7 +81,7 @@ objects.
    .. warning::
 
       The deallocation function can cause arbitrary Python code to be invoked (e.g.
-      when a class instance with a :meth:`__del__` method is deallocated).  While
+      when a class instance with a :meth:`~object.__del__` method is deallocated).  While
       exceptions in such code are not propagated, the executed code has free access to
       all Python global variables.  This means that any object that is reachable from
       a global variable should be in a consistent state before :c:func:`Py_DECREF` is

--- a/Doc/c-api/sequence.rst
+++ b/Doc/c-api/sequence.rst
@@ -9,7 +9,7 @@ Sequence Protocol
 .. c:function:: int PySequence_Check(PyObject *o)
 
    Return ``1`` if the object provides the sequence protocol, and ``0`` otherwise.
-   Note that it returns ``1`` for Python classes with a :meth:`__getitem__`
+   Note that it returns ``1`` for Python classes with a :meth:`~object.__getitem__`
    method, unless they are :class:`dict` subclasses, since in general it
    is impossible to determine what type of keys the class supports.  This
    function always succeeds.

--- a/Doc/howto/functional.rst
+++ b/Doc/howto/functional.rst
@@ -1072,8 +1072,8 @@ write the obvious :keyword:`for` loop::
 
 A related function is :func:`itertools.accumulate(iterable, func=operator.add)
 <itertools.accumulate>`.  It performs the same calculation, but instead of
-returning only the final result, :func:`accumulate` returns an iterator that
-also yields each partial result::
+returning only the final result, :func:`~itertools.accumulate` returns an iterator
+that also yields each partial result::
 
     itertools.accumulate([1, 2, 3, 4, 5]) =>
       1, 3, 6, 10, 15

--- a/Doc/howto/regex.rst
+++ b/Doc/howto/regex.rst
@@ -522,6 +522,8 @@ cache.
 Compilation Flags
 -----------------
 
+.. currentmodule:: re
+
 Compilation flags let you modify some aspects of how regular expressions work.
 Flags are available in the :mod:`re` module under two names, a long name such as
 :const:`IGNORECASE` and a short, one-letter form such as :const:`I`.  (If you're

--- a/Doc/howto/sorting.rst
+++ b/Doc/howto/sorting.rst
@@ -273,7 +273,7 @@ Odds and Ends
 
 * The sort routines use ``<`` when making comparisons
   between two objects. So, it is easy to add a standard sort order to a class by
-  defining an :meth:`__lt__` method:
+  defining an :meth:`~object.__lt__` method:
 
   .. doctest::
 
@@ -281,8 +281,8 @@ Odds and Ends
     >>> sorted(student_objects)
     [('dave', 'B', 10), ('jane', 'B', 12), ('john', 'A', 15)]
 
-  However, note that ``<`` can fall back to using :meth:`__gt__` if
-  :meth:`__lt__` is not implemented (see :func:`object.__lt__`).
+  However, note that ``<`` can fall back to using :meth:`~object.__gt__` if
+  :meth:`~object.__lt__` is not implemented (see :func:`object.__lt__`).
 
 * Key functions need not depend directly on the objects being sorted. A key
   function can also access external resources. For instance, if the student grades

--- a/Doc/howto/unicode.rst
+++ b/Doc/howto/unicode.rst
@@ -424,8 +424,8 @@ lowercase letters 'ss'.
 
 A second tool is the :mod:`unicodedata` module's
 :func:`~unicodedata.normalize` function that converts strings to one
-of several normal forms, where letters followed by a combining
-character are replaced with single characters.  :func:`normalize` can
+of several normal forms, where letters followed by a combining character are
+replaced with single characters.  :func:`~unicodedata.normalize` can
 be used to perform string comparisons that won't falsely report
 inequality if two strings use combining characters differently:
 
@@ -474,8 +474,8 @@ The Unicode Standard also specifies how to do caseless comparisons::
 
     print(compare_caseless(single_char, multiple_chars))
 
-This will print ``True``.  (Why is :func:`NFD` invoked twice?  Because
-there are a few characters that make :meth:`casefold` return a
+This will print ``True``.  (Why is :func:`!NFD` invoked twice?  Because
+there are a few characters that make :meth:`~str.casefold` return a
 non-normalized string, so the result needs to be normalized again. See
 section 3.13 of the Unicode Standard for a discussion and an example.)
 

--- a/Doc/library/_thread.rst
+++ b/Doc/library/_thread.rst
@@ -148,8 +148,8 @@ This module defines the following constants and functions:
 .. data:: TIMEOUT_MAX
 
    The maximum value allowed for the *timeout* parameter of
-   :meth:`Lock.acquire`. Specifying a timeout greater than this value will
-   raise an :exc:`OverflowError`.
+   :meth:`Lock.acquire <threading.Lock.acquire>`. Specifying a timeout greater
+   than this value will raise an :exc:`OverflowError`.
 
    .. versionadded:: 3.2
 
@@ -215,8 +215,9 @@ In addition to these methods, lock objects can also be used via the
 * Calling :func:`sys.exit` or raising the :exc:`SystemExit` exception is
   equivalent to calling :func:`_thread.exit`.
 
-* It is not possible to interrupt the :meth:`acquire` method on a lock --- the
-  :exc:`KeyboardInterrupt` exception will happen after the lock has been acquired.
+* It is not possible to interrupt the :meth:`~threading.Lock.acquire` method on
+  a lock --- the :exc:`KeyboardInterrupt` exception will happen after the lock
+  has been acquired.
 
 * When the main thread exits, it is system defined whether the other threads
   survive.  On most systems, they are killed without executing

--- a/Doc/library/codeop.rst
+++ b/Doc/library/codeop.rst
@@ -58,7 +58,7 @@ To do just the former:
 
 .. class:: Compile()
 
-   Instances of this class have :meth:`__call__` methods identical in signature to
+   Instances of this class have :meth:`~object.__call__` methods identical in signature to
    the built-in function :func:`compile`, but with the difference that if the
    instance compiles program text containing a :mod:`__future__` statement, the
    instance 'remembers' and compiles all subsequent program texts with the
@@ -67,7 +67,7 @@ To do just the former:
 
 .. class:: CommandCompiler()
 
-   Instances of this class have :meth:`__call__` methods identical in signature to
+   Instances of this class have :meth:`~object.__call__` methods identical in signature to
    :func:`compile_command`; the difference is that if the instance compiles program
    text containing a :mod:`__future__` statement, the instance 'remembers' and
    compiles all subsequent program texts with the statement in force.

--- a/Doc/library/constants.rst
+++ b/Doc/library/constants.rst
@@ -22,16 +22,16 @@ A small number of constants live in the built-in namespace.  They are:
    An object frequently used to represent the absence of a value, as when
    default arguments are not passed to a function. Assignments to ``None``
    are illegal and raise a :exc:`SyntaxError`.
-   ``None`` is the sole instance of the :data:`NoneType` type.
+   ``None`` is the sole instance of the :data:`~types.NoneType` type.
 
 
 .. data:: NotImplemented
 
    A special value which should be returned by the binary special methods
-   (e.g. :meth:`__eq__`, :meth:`__lt__`, :meth:`__add__`, :meth:`__rsub__`,
+   (e.g. :meth:`~object.__eq__`, :meth:`~object.__lt__`, :meth:`~object.__add__`, :meth:`~object.__rsub__`,
    etc.) to indicate that the operation is not implemented with respect to
    the other type; may be returned by the in-place binary special methods
-   (e.g. :meth:`__imul__`, :meth:`__iand__`, etc.) for the same purpose.
+   (e.g. :meth:`~object.__imul__`, :meth:`~object.__iand__`, etc.) for the same purpose.
    It should not be evaluated in a boolean context.
    ``NotImplemented`` is the sole instance of the :data:`types.NotImplementedType` type.
 


### PR DESCRIPTION
(cherry picked from commit f5147c0cfbd7943ff10917225448c36a53f9828d)


<!-- gh-issue-number: gh-101100 -->
* Issue: gh-101100
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--107120.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->