### PR TITLE
Clarify documentation about PyVectorcall_Function

### DIFF
--- a/Doc/c-api/call.rst
+++ b/Doc/c-api/call.rst
@@ -140,7 +140,7 @@ Vectorcall Support API
    However, the function ``PyVectorcall_NARGS`` should be used to allow
    for future extensions.
 
-   .. versionadded:: 3.8
+   .. versionadded:: 3.9
 
 .. c:function:: vectorcallfunc PyVectorcall_Function(PyObject *op)
 
@@ -152,7 +152,7 @@ Vectorcall Support API
    This is mostly useful to check whether or not *op* supports vectorcall,
    which can be done by checking ``PyVectorcall_Function(op) != NULL``.
 
-   .. versionadded:: 3.8
+   .. versionadded:: 3.9
 
 .. c:function:: PyObject* PyVectorcall_Call(PyObject *callable, PyObject *tuple, PyObject *dict)
 
@@ -164,7 +164,7 @@ Vectorcall Support API
    It does not check the :c:macro:`Py_TPFLAGS_HAVE_VECTORCALL` flag
    and it does not fall back to ``tp_call``.
 
-   .. versionadded:: 3.8
+   .. versionadded:: 3.9
 
 
 .. _capi-call:

--- a/Doc/c-api/call.rst
+++ b/Doc/c-api/call.rst
@@ -140,7 +140,7 @@ Vectorcall Support API
    However, the function ``PyVectorcall_NARGS`` should be used to allow
    for future extensions.
 
-   .. versionadded:: 3.9
+   .. versionadded:: 3.8
 
 .. c:function:: vectorcallfunc PyVectorcall_Function(PyObject *op)
 
@@ -164,7 +164,7 @@ Vectorcall Support API
    It does not check the :c:macro:`Py_TPFLAGS_HAVE_VECTORCALL` flag
    and it does not fall back to ``tp_call``.
 
-   .. versionadded:: 3.9
+   .. versionadded:: 3.8
 
 
 .. _capi-call:


### PR DESCRIPTION
The documentation implies that PyVectorcall_Function was available in Python 3.8.

This is half-true - it was available under a different name. I think it's clearer to set the "version added" to 3.9

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--107140.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->