### PR TITLE
gh-106320: Remove _PyIsSelectable_fd() C API

### DIFF
--- a/Include/fileobject.h
+++ b/Include/fileobject.h
@@ -29,14 +29,6 @@ Py_DEPRECATED(3.12) PyAPI_DATA(int) Py_HasFileSystemDefaultEncoding;
 Py_DEPRECATED(3.12) PyAPI_DATA(int) Py_UTF8Mode;
 #endif
 
-/* A routine to check if a file descriptor can be select()-ed. */
-#ifdef _MSC_VER
-    /* On Windows, any socket fd can be select()-ed, no matter how high */
-    #define _PyIsSelectable_fd(FD) (1)
-#else
-    #define _PyIsSelectable_fd(FD) ((unsigned int)(FD) < (unsigned int)FD_SETSIZE)
-#endif
-
 #ifndef Py_LIMITED_API
 #  define Py_CPYTHON_FILEOBJECT_H
 #  include "cpython/fileobject.h"

--- a/Include/internal/pycore_fileutils.h
+++ b/Include/internal/pycore_fileutils.h
@@ -10,6 +10,13 @@ extern "C" {
 
 #include <locale.h>   /* struct lconv */
 
+/* A routine to check if a file descriptor can be select()-ed. */
+#ifdef _MSC_VER
+    /* On Windows, any socket fd can be select()-ed, no matter how high */
+    #define _PyIsSelectable_fd(FD) (1)
+#else
+    #define _PyIsSelectable_fd(FD) ((unsigned int)(FD) < (unsigned int)FD_SETSIZE)
+#endif
 
 struct _fileutils_state {
     int force_ascii;

--- a/Modules/_ssl.c
+++ b/Modules/_ssl.c
@@ -26,6 +26,7 @@
 #define OPENSSL_NO_DEPRECATED 1
 
 #include "Python.h"
+#include "pycore_fileutils.h"     // _PyIsSelectable_fd()
 #include "pycore_weakref.h"       // _PyWeakref_GET_REF()
 
 /* Include symbols from _socket module */


### PR DESCRIPTION
Move _PyIsSelectable_fd() to the internal C API (pycore_fileutils.h).

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-106320 -->
* Issue: gh-106320
<!-- /gh-issue-number -->
