### PR TITLE
gh-106320: Remove _PyTuple_MaybeUntrack() C API

### DIFF
--- a/Include/cpython/tupleobject.h
+++ b/Include/cpython/tupleobject.h
@@ -11,7 +11,6 @@ typedef struct {
 } PyTupleObject;
 
 PyAPI_FUNC(int) _PyTuple_Resize(PyObject **, Py_ssize_t);
-PyAPI_FUNC(void) _PyTuple_MaybeUntrack(PyObject *);
 
 /* Cast argument to PyTupleObject* type. */
 #define _PyTuple_CAST(op) \
@@ -37,5 +36,3 @@ PyTuple_SET_ITEM(PyObject *op, Py_ssize_t index, PyObject *value) {
 }
 #define PyTuple_SET_ITEM(op, index, value) \
     PyTuple_SET_ITEM(_PyObject_CAST(op), (index), _PyObject_CAST(value))
-
-PyAPI_FUNC(void) _PyTuple_DebugMallocStats(FILE *out);

--- a/Include/internal/pycore_tuple.h
+++ b/Include/internal/pycore_tuple.h
@@ -8,8 +8,8 @@ extern "C" {
 #  error "this header requires Py_BUILD_CORE define"
 #endif
 
-#include "tupleobject.h"   /* _PyTuple_CAST() */
-
+extern void _PyTuple_MaybeUntrack(PyObject *);
+extern void _PyTuple_DebugMallocStats(FILE *out);
 
 /* runtime lifecycle */
 


### PR DESCRIPTION
Move _PyTuple_MaybeUntrack() and _PyTuple_DebugMallocStats() to the internal C API (pycore_tuple.h).

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-106320 -->
* Issue: gh-106320
<!-- /gh-issue-number -->
