### PR TITLE
gh-106320: Remove _PyBytes_Join() C API

### DIFF
--- a/Include/cpython/bytesobject.h
+++ b/Include/cpython/bytesobject.h
@@ -15,18 +15,6 @@ typedef struct {
 } PyBytesObject;
 
 PyAPI_FUNC(int) _PyBytes_Resize(PyObject **, Py_ssize_t);
-PyAPI_FUNC(PyObject*) _PyBytes_FormatEx(
-    const char *format,
-    Py_ssize_t format_len,
-    PyObject *args,
-    int use_bytearray);
-PyAPI_FUNC(PyObject*) _PyBytes_FromHex(
-    PyObject *string,
-    int use_bytearray);
-
-/* Helper for PyBytes_DecodeEscape that detects invalid escape chars. */
-PyAPI_FUNC(PyObject *) _PyBytes_DecodeEscape(const char *, Py_ssize_t,
-                                             const char *, const char **);
 
 /* Macros and static inline functions, trading safety for speed */
 #define _PyBytes_CAST(op) \
@@ -43,7 +31,3 @@ static inline Py_ssize_t PyBytes_GET_SIZE(PyObject *op) {
     return Py_SIZE(self);
 }
 #define PyBytes_GET_SIZE(self) PyBytes_GET_SIZE(_PyObject_CAST(self))
-
-/* _PyBytes_Join(sep, x) is like sep.join(x).  sep must be PyBytesObject*,
-   x must be an iterable object. */
-PyAPI_FUNC(PyObject *) _PyBytes_Join(PyObject *sep, PyObject *x);

--- a/Include/internal/pycore_bytesobject.h
+++ b/Include/internal/pycore_bytesobject.h
@@ -8,6 +8,24 @@ extern "C" {
 #  error "this header requires Py_BUILD_CORE define"
 #endif
 
+extern PyObject* _PyBytes_FormatEx(
+    const char *format,
+    Py_ssize_t format_len,
+    PyObject *args,
+    int use_bytearray);
+
+extern PyObject* _PyBytes_FromHex(
+    PyObject *string,
+    int use_bytearray);
+
+/* Helper for PyBytes_DecodeEscape that detects invalid escape chars. */
+extern PyObject * _PyBytes_DecodeEscape(const char *, Py_ssize_t,
+                                        const char *, const char **);
+
+/* _PyBytes_Join(sep, x) is like sep.join(x).  sep must be PyBytesObject*,
+   x must be an iterable object. */
+extern PyObject* _PyBytes_Join(PyObject *sep, PyObject *x);
+
 
 /* Substring Search.
 

--- a/Include/internal/pycore_bytesobject.h
+++ b/Include/internal/pycore_bytesobject.h
@@ -18,9 +18,10 @@ extern PyObject* _PyBytes_FromHex(
     PyObject *string,
     int use_bytearray);
 
-/* Helper for PyBytes_DecodeEscape that detects invalid escape chars. */
-extern PyObject * _PyBytes_DecodeEscape(const char *, Py_ssize_t,
-                                        const char *, const char **);
+// Helper for PyBytes_DecodeEscape that detects invalid escape chars.
+// Export for test_peg_generator.
+PyAPI_FUNC(PyObject*) _PyBytes_DecodeEscape(const char *, Py_ssize_t,
+                                            const char *, const char **);
 
 /* _PyBytes_Join(sep, x) is like sep.join(x).  sep must be PyBytesObject*,
    x must be an iterable object. */

--- a/Modules/_io/bufferedio.c
+++ b/Modules/_io/bufferedio.c
@@ -8,8 +8,9 @@
 */
 
 #include "Python.h"
+#include "pycore_bytesobject.h"   // _PyBytes_Join()
 #include "pycore_call.h"          // _PyObject_CallNoArgs()
-#include "pycore_object.h"
+#include "pycore_object.h"        // _PyObject_GC_UNTRACK()
 #include "pycore_pyerrors.h"      // _Py_FatalErrorFormat()
 #include "pycore_pylifecycle.h"   // _Py_IsInterpreterFinalizing()
 #include "structmember.h"         // PyMemberDef

--- a/Parser/string_parser.c
+++ b/Parser/string_parser.c
@@ -1,6 +1,7 @@
 #include <stdbool.h>
 
 #include <Python.h>
+#include "pycore_bytesobject.h"   // _PyBytes_DecodeEscape()
 #include "pycore_unicodeobject.h" // _PyUnicode_DecodeUnicodeEscapeInternal()
 
 #include "tokenizer.h"


### PR DESCRIPTION
Move private _PyBytes functions to the internal C API (pycore_bytesobject.h):

* _PyBytes_DecodeEscape()
* _PyBytes_FormatEx()
* _PyBytes_FromHex()
* _PyBytes_Join()

No longer export these functions.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-106320 -->
* Issue: gh-106320
<!-- /gh-issue-number -->
