### PR TITLE
Improve the GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -29,6 +29,13 @@ labels: "type-bug"
 <!--
   Include a minimal, reproducible example if possible.
   (https://stackoverflow.com/help/minimal-reproducible-example)
+
+  Put any code blocks inside triple backticks:
+
+  ```py
+  your code here
+  ```
+
 -->
 
 

--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -13,6 +13,8 @@ labels: "type-bug"
   - emailing https://mail.python.org/mailman/listinfo/python-list
 -->
 
+# Bug report
+
 ## Checklist
 
 <!-- Bugs in third-party projects (e.g. `requests`) do not belong in the CPython issue tracker -->
@@ -21,8 +23,6 @@ labels: "type-bug"
       not a bug in a third-party project
 - [ ] I have searched the CPython issue tracker,
       and am confident this bug has not been reported before
-
-# Bug report
 
 ## A clear and concise description of the bug
 

--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -5,28 +5,41 @@ labels: "type-bug"
 ---
 
 <!--
-  If you're new to Python and you're not sure whether what you're experiencing is a bug, the CPython issue tracker is not
-  the right place to seek help. Consider the following options instead:
+  New to Python? The issue tracker isn't the right place to get help.
+  Consider instead:
 
   - reading the Python tutorial: https://docs.python.org/3/tutorial/
-  - posting in the "Users" category on discuss.python.org: https://discuss.python.org/c/users/7
-  - emailing the Python-list mailing list: https://mail.python.org/mailman/listinfo/python-list
-  - searching our issue tracker (https://github.com/python/cpython/issues) to see if
-    your problem has already been reported
+  - posting at https://discuss.python.org/c/users/7
+  - emailing https://mail.python.org/mailman/listinfo/python-list
 -->
+
+## Checklist
+
+<!-- Bugs in third-party projects (e.g. `requests`) do not belong in the CPython issue tracker -->
+
+- [ ] I am confident this is a bug in CPython,
+      not a bug in a third-party project
+- [ ] I have searched the CPython issue tracker,
+      and am confident this bug has not been reported before
 
 # Bug report
 
-A clear and concise description of what the bug is.
-Include a minimal, reproducible example (https://stackoverflow.com/help/minimal-reproducible-example), if possible.
+## A clear and concise description of the bug
+
+<!--
+  Include a minimal, reproducible example if possible.
+  (https://stackoverflow.com/help/minimal-reproducible-example)
+-->
+
+
 
 # Your environment
 
-<!-- Include as many relevant details as possible about the environment you experienced the bug in -->
+<!-- Include all relevant details about the environment you experienced the bug in -->
 
 - CPython versions tested on:
 - Operating system and architecture:
 
 <!--
-You can freely edit this text. Remove any lines you believe are unnecessary.
+You can freely edit this form. Remove any lines you believe are unnecessary.
 -->

--- a/.github/ISSUE_TEMPLATE/crash.md
+++ b/.github/ISSUE_TEMPLATE/crash.md
@@ -5,29 +5,37 @@ labels: "type-crash"
 ---
 
 <!--
-  Use this template for hard crashes of the interpreter, segmentation faults, failed C-level assertions, and similar.
-  Do not submit this form if you encounter an exception being unexpectedly raised from a Python function.
-  Most of the time, these should be filed as bugs, rather than crashes.
+  This form is for hard crashes of the Python interpreter, segmentation faults,
+  failed C-level assertions, and similar.
+  Exceptions unexpectedly raised from stdlib Python functions
+  count as bugs rather than crashes.
 
-  The CPython interpreter is itself written in a different programming language, C.
-  For CPython, a "crash" is when Python itself fails, leading to a traceback in the C stack.
+  The CPython interpreter is written in a different programming language, C.
+  A " CPython crash" is when Python itself fails, leading to a traceback in the C stack.
 -->
 
 # Crash report
 
-Tell us what happened, ideally including a minimal, reproducible example (https://stackoverflow.com/help/minimal-reproducible-example).
+<!--
+  Tell us what happened. Ideally, include a minimal, reproducible example.
+  (https://stackoverflow.com/help/minimal-reproducible-example)
+-->
+
+
 
 # Error messages
 
-Enter any relevant error message caused by the crash, including a core dump if there is one.
+<!-- Enter any error messages caused by the crash, including a core dump if there is one -->
+
+
 
 # Your environment
 
-<!-- Include as many relevant details as possible about the environment you experienced the bug in -->
+<!-- Include all relevant details about the environment you experienced the crash in -->
 
 - CPython versions tested on:
 - Operating system and architecture:
 
 <!--
-You can freely edit this text. Remove any lines you believe are unnecessary.
+You can freely edit this form. Remove any lines you believe are unnecessary.
 -->

--- a/.github/ISSUE_TEMPLATE/crash.md
+++ b/.github/ISSUE_TEMPLATE/crash.md
@@ -19,6 +19,13 @@ labels: "type-crash"
 <!--
   Tell us what happened. Ideally, include a minimal, reproducible example.
   (https://stackoverflow.com/help/minimal-reproducible-example)
+
+  Put any code blocks inside triple backticks:
+
+  ```py
+  your code here
+  ```
+
 -->
 
 

--- a/.github/ISSUE_TEMPLATE/crash.md
+++ b/.github/ISSUE_TEMPLATE/crash.md
@@ -11,7 +11,7 @@ labels: "type-crash"
   count as bugs rather than crashes.
 
   The CPython interpreter is written in a different programming language, C.
-  A " CPython crash" is when Python itself fails, leading to a traceback in the C stack.
+  A "CPython crash" is when Python itself fails, leading to a traceback in the C stack.
 -->
 
 # Crash report

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -4,25 +4,40 @@ about: Submit a proposal for a new CPython feature or enhancement
 labels: "type-feature"
 ---
 
+<!--
+  Proposing a new feature for Python?
+  You'll need to demonstrate widespread support for your idea among the community.
+
+  Major feature proposals should generally be discussed at
+  https://discuss.python.org/c/ideas/6 before opening a GitHub issue.
+  Wait until it's clear that most people support your idea
+  before filling in this form.
+-->
+
 # Feature or enhancement
 
-(A clear and concise description of your proposal.)
+<!-- A clear and concise description of your proposal. -->
+
+
 
 # Pitch
 
-(Explain why this feature or enhancement should be implemented and how it would be used.
- Add examples, if applicable.)
+<!--
+  Explain why this feature or enhancement should be implemented and how it would be used.
+  Add examples, if applicable.
+-->
+
+
 
 # Previous discussion
 
 <!--
-  New features to Python should first be discussed elsewhere before creating issues on GitHub,
-  for example in the "ideas" category (https://discuss.python.org/c/ideas/6) of discuss.python.org,
-  or the python-ideas mailing list (https://mail.python.org/mailman3/lists/python-ideas.python.org/).
-  Use this space to post links to the places where you have already discussed this feature proposal:
+  Use this space to post links to the places
+  where you have already discussed your feature proposal:
 -->
 
 
+
 <!--
-You can freely edit this text. Remove any lines you believe are unnecessary.
+You can freely edit this form. Remove any lines you believe are unnecessary.
 -->

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -25,6 +25,13 @@ labels: "type-feature"
 <!--
   Explain why this feature or enhancement should be implemented and how it would be used.
   Add examples, if applicable.
+
+  Put any code blocks inside triple backticks:
+
+  ```py
+  your code here
+  ```
+
 -->
 
 


### PR DESCRIPTION
- Use more concise, and more assertive, language where possible. In particular, make the long intro to the `bug.md` template shorter
- Convert some of the things in the `bug.md` template into a checklist, so that it's clear that these are steps we _expect_ of issue reporters (not optional things-to-consider!)
- Convert some of the directives to the issue reporter into HTML comments
- Make it clearer in the `feature.md` template _why_ we'd like people to post on discuss.python.org before opening a feature request on GitHub (and move the "please post on discuss.python.org" notice to the top of the form).
  - We get quite a few people who open GitHub issues half an hour after opening a discuss.python.org thread, which rather defeats the point.
  - We also get some people who open a thread on discuss.python.org, get a pretty mixed reception to their idea, and then open a GitHub issue anyway. That also defeats the point.