### PR TITLE
Fix Sphinx warnings on unknown targets

### DIFF
--- a/Doc/c-api/apiabiversion.rst
+++ b/Doc/c-api/apiabiversion.rst
@@ -60,7 +60,7 @@ See :ref:`stable` for a discussion of API and ABI stability across versions.
 
    Use this for numeric comparisons, e.g. ``#if PY_VERSION_HEX >= ...``.
 
-   This version is also available via the symbol :data:`Py_Version`.
+   This version is also available via the symbol :c:var:`Py_Version`.
 
 .. c:var:: const unsigned long Py_Version
 

--- a/Doc/c-api/arg.rst
+++ b/Doc/c-api/arg.rst
@@ -477,7 +477,7 @@ API Functions
    will be set if there was a failure.
 
    This is an example of the use of this function, taken from the sources for the
-   :mod:`_weakref` helper module for weak references::
+   :mod:`!_weakref` helper module for weak references::
 
       static PyObject *
       weakref_ref(PyObject *self, PyObject *args)
@@ -518,9 +518,9 @@ Building values
    When memory buffers are passed as parameters to supply data to build objects, as
    for the ``s`` and ``s#`` formats, the required data is copied.  Buffers provided
    by the caller are never referenced by the objects created by
-   :c:func:`Py_BuildValue`.  In other words, if your code invokes :c:func:`malloc`
+   :c:func:`Py_BuildValue`.  In other words, if your code invokes :c:func:`!malloc`
    and passes the allocated memory to :c:func:`Py_BuildValue`, your code is
-   responsible for calling :c:func:`free` for that memory once
+   responsible for calling :c:func:`!free` for that memory once
    :c:func:`Py_BuildValue` returns.
 
    In the following description, the quoted form is the format unit; the entry in


### PR DESCRIPTION
Fix warnings like:

* py:data reference target not found: Py_Version
* c:func reference target not found: malloc

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--107164.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->