### PR TITLE
gh-107137: Add _PyTuple_NewNoTrack() internal C API

### DIFF
--- a/Include/internal/pycore_tuple.h
+++ b/Include/internal/pycore_tuple.h
@@ -11,6 +11,11 @@ extern "C" {
 extern void _PyTuple_MaybeUntrack(PyObject *);
 extern void _PyTuple_DebugMallocStats(FILE *out);
 
+// Similar to PyTuple_New() and _PyTuple_Resize(), but don't track the tuple
+// by the GC.
+extern PyObject* _PyTuple_NewNoTrack(Py_ssize_t size);
+extern int _PyTuple_ResizeNoTrack(PyObject **pv, Py_ssize_t newsize);
+
 /* runtime lifecycle */
 
 extern PyStatus _PyTuple_InitGlobalObjects(PyInterpreterState *);

--- a/Misc/NEWS.d/next/C API/2023-07-24-18-51-27.gh-issue-107137.zk8it0.rst
+++ b/Misc/NEWS.d/next/C API/2023-07-24-18-51-27.gh-issue-107137.zk8it0.rst
@@ -1,0 +1,4 @@
+Fix a crash in :c:func:`PySequence_Tuple` when the tuple which is being
+initialized was accessed via GC introspection, like the
+:func:`gc.get_referrers` function. Now the function only tracks the tuple by
+the GC once it's fully initialized. Patch by Victor Stinner.

--- a/Objects/tupleobject.c
+++ b/Objects/tupleobject.c
@@ -65,22 +65,36 @@ tuple_get_empty(void)
     return Py_NewRef(&_Py_SINGLETON(tuple_empty));
 }
 
-PyObject *
-PyTuple_New(Py_ssize_t size)
+
+static inline PyObject *
+tuple_new_capi(Py_ssize_t size, int track)
 {
-    PyTupleObject *op;
     if (size == 0) {
         return tuple_get_empty();
     }
-    op = tuple_alloc(size);
+    PyTupleObject *op = tuple_alloc(size);
     if (op == NULL) {
         return NULL;
     }
     for (Py_ssize_t i = 0; i < size; i++) {
         op->ob_item[i] = NULL;
     }
-    _PyObject_GC_TRACK(op);
+    if (track) {
+        _PyObject_GC_TRACK(op);
+    }
     return (PyObject *) op;
+}
+
+PyObject *
+_PyTuple_NewNoTrack(Py_ssize_t size)
+{
+    return tuple_new_capi(size, 0);
+}
+
+PyObject *
+PyTuple_New(Py_ssize_t size)
+{
+    return tuple_new_capi(size, 1);
 }
 
 Py_ssize_t
@@ -894,8 +908,8 @@ PyTypeObject PyTuple_Type = {
    efficiently.  In any case, don't use this if the tuple may already be
    known to some other part of the code. */
 
-int
-_PyTuple_Resize(PyObject **pv, Py_ssize_t newsize)
+static int
+tuple_resize(PyObject **pv, Py_ssize_t newsize, int track)
 {
     PyTupleObject *v;
     PyTupleObject *sv;
@@ -927,7 +941,12 @@ _PyTuple_Resize(PyObject **pv, Py_ssize_t newsize)
         /* The empty tuple is statically allocated so we never
            resize it in-place. */
         Py_DECREF(v);
-        *pv = PyTuple_New(newsize);
+        if (track) {
+            *pv = PyTuple_New(newsize);
+        }
+        else {
+            *pv = _PyTuple_NewNoTrack(newsize);
+        }
         return *pv == NULL ? -1 : 0;
     }
 
@@ -952,12 +971,27 @@ _PyTuple_Resize(PyObject **pv, Py_ssize_t newsize)
     }
     _Py_NewReferenceNoTotal((PyObject *) sv);
     /* Zero out items added by growing */
-    if (newsize > oldsize)
+    if (newsize > oldsize) {
         memset(&sv->ob_item[oldsize], 0,
                sizeof(*sv->ob_item) * (newsize - oldsize));
+    }
     *pv = (PyObject *) sv;
-    _PyObject_GC_TRACK(sv);
+    if (track) {
+        _PyObject_GC_TRACK(*pv);
+    }
     return 0;
+}
+
+int
+_PyTuple_ResizeNoTrack(PyObject **pv, Py_ssize_t newsize)
+{
+    return tuple_resize(pv, newsize, 0);
+}
+
+int
+_PyTuple_Resize(PyObject **pv, Py_ssize_t newsize)
+{
+    return tuple_resize(pv, newsize, 1);
 }
 
 


### PR DESCRIPTION
Fix a crash in PySequence_Tuple() when the tuple which is being initialized was accessed via GC introspection, like the gc.get_referrers() function. Now the function only tracks the tuple by the GC once it's fully initialized.

Add _PyTuple_NewNoTrack() and _PyTuple_ResizeNoTrack() functions to the internal C API: similar to PyTuple_New() and _PyTuple_Resize(), but don't track the tuple by the GC.

Modify PySequence_Tuple() to use these functions.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-107137 -->
* Issue: gh-107137
<!-- /gh-issue-number -->
