### PR TITLE
gh-98608: Move PyInterpreterConfig to pylifecycle.h

### DIFF
--- a/Include/cpython/initconfig.h
+++ b/Include/cpython/initconfig.h
@@ -242,45 +242,6 @@ PyAPI_FUNC(PyStatus) PyConfig_SetWideStringList(PyConfig *config,
     Py_ssize_t length, wchar_t **items);
 
 
-/* --- PyInterpreterConfig ------------------------------------ */
-
-#define PyInterpreterConfig_DEFAULT_GIL (0)
-#define PyInterpreterConfig_SHARED_GIL (1)
-#define PyInterpreterConfig_OWN_GIL (2)
-
-typedef struct {
-    // XXX "allow_object_sharing"?  "own_objects"?
-    int use_main_obmalloc;
-    int allow_fork;
-    int allow_exec;
-    int allow_threads;
-    int allow_daemon_threads;
-    int check_multi_interp_extensions;
-    int gil;
-} PyInterpreterConfig;
-
-#define _PyInterpreterConfig_INIT \
-    { \
-        .use_main_obmalloc = 0, \
-        .allow_fork = 0, \
-        .allow_exec = 0, \
-        .allow_threads = 1, \
-        .allow_daemon_threads = 0, \
-        .check_multi_interp_extensions = 1, \
-        .gil = PyInterpreterConfig_OWN_GIL, \
-    }
-
-#define _PyInterpreterConfig_LEGACY_INIT \
-    { \
-        .use_main_obmalloc = 1, \
-        .allow_fork = 1, \
-        .allow_exec = 1, \
-        .allow_threads = 1, \
-        .allow_daemon_threads = 1, \
-        .check_multi_interp_extensions = 0, \
-        .gil = PyInterpreterConfig_SHARED_GIL, \
-    }
-
 /* --- Helper functions --------------------------------------- */
 
 /* Get the original command line arguments, before Python modified them.

--- a/Include/cpython/pylifecycle.h
+++ b/Include/cpython/pylifecycle.h
@@ -35,6 +35,45 @@ PyAPI_FUNC(void) _Py_NO_RETURN Py_ExitStatusException(PyStatus err);
 
 PyAPI_FUNC(int) Py_FdIsInteractive(FILE *, const char *);
 
+/* --- PyInterpreterConfig ------------------------------------ */
+
+#define PyInterpreterConfig_DEFAULT_GIL (0)
+#define PyInterpreterConfig_SHARED_GIL (1)
+#define PyInterpreterConfig_OWN_GIL (2)
+
+typedef struct {
+    // XXX "allow_object_sharing"?  "own_objects"?
+    int use_main_obmalloc;
+    int allow_fork;
+    int allow_exec;
+    int allow_threads;
+    int allow_daemon_threads;
+    int check_multi_interp_extensions;
+    int gil;
+} PyInterpreterConfig;
+
+#define _PyInterpreterConfig_INIT \
+    { \
+        .use_main_obmalloc = 0, \
+        .allow_fork = 0, \
+        .allow_exec = 0, \
+        .allow_threads = 1, \
+        .allow_daemon_threads = 0, \
+        .check_multi_interp_extensions = 1, \
+        .gil = PyInterpreterConfig_OWN_GIL, \
+    }
+
+#define _PyInterpreterConfig_LEGACY_INIT \
+    { \
+        .use_main_obmalloc = 1, \
+        .allow_fork = 1, \
+        .allow_exec = 1, \
+        .allow_threads = 1, \
+        .allow_daemon_threads = 1, \
+        .check_multi_interp_extensions = 0, \
+        .gil = PyInterpreterConfig_SHARED_GIL, \
+    }
+
 PyAPI_FUNC(PyStatus) Py_NewInterpreterFromConfig(
     PyThreadState **tstate_p,
     const PyInterpreterConfig *config);


### PR DESCRIPTION
Move PyInterpreterConfig structure and associated macros from initconfig.h to pylifecycle.h: it's not related to the Python Initialization Configuration.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-98608 -->
* Issue: gh-98608
<!-- /gh-issue-number -->
