### PR TITLE
gh-107196: Remove _PyArg_VaParseTupleAndKeywordsFast() function

### DIFF
--- a/Include/cpython/modsupport.h
+++ b/Include/cpython/modsupport.h
@@ -52,8 +52,6 @@ PyAPI_FUNC(int) _PyArg_ParseStackAndKeywords(
     PyObject *kwnames,
     struct _PyArg_Parser *,
     ...);
-PyAPI_FUNC(int) _PyArg_VaParseTupleAndKeywordsFast(PyObject *, PyObject *,
-                                                   struct _PyArg_Parser *, va_list);
 PyAPI_FUNC(PyObject * const *) _PyArg_UnpackKeywords(
         PyObject *const *args, Py_ssize_t nargs,
         PyObject *kwargs, PyObject *kwnames,

--- a/Python/getargs.c
+++ b/Python/getargs.c
@@ -1418,20 +1418,6 @@ _PyArg_ParseStackAndKeywords_SizeT(PyObject *const *args, Py_ssize_t nargs, PyOb
 }
 
 
-PyAPI_FUNC(int)
-_PyArg_VaParseTupleAndKeywordsFast(PyObject *args, PyObject *keywords,
-                            struct _PyArg_Parser *parser, va_list va)
-{
-    int retval;
-    va_list lva;
-
-    va_copy(lva, va);
-
-    retval = vgetargskeywordsfast(args, keywords, parser, &lva, 0);
-    va_end(lva);
-    return retval;
-}
-
 static void
 error_unexpected_keyword_arg(PyObject *kwargs, PyObject *kwnames, PyObject *kwtuple, const char *fname)
 {


### PR DESCRIPTION
Remove the private _PyArg_VaParseTupleAndKeywordsFast() function: it is no longer used.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-107196 -->
* Issue: gh-107196
<!-- /gh-issue-number -->
