### PR TITLE
[3.12] gh-106917: fix super classmethod calls to non-classmethods (GH-106977).

### DIFF
--- a/Lib/test/test_super.py
+++ b/Lib/test/test_super.py
@@ -5,6 +5,9 @@ from unittest.mock import patch
 from test import shadowed_super
 
 
+ADAPTIVE_WARMUP_DELAY = 2
+
+
 class A:
     def f(self):
         return 'A'
@@ -419,8 +422,47 @@ class TestSuper(unittest.TestCase):
             super(MyType, type(mytype)).__setattr__(mytype, "bar", 1)
             self.assertEqual(mytype.bar, 1)
 
-        test("foo1")
-        test("foo2")
+        for _ in range(ADAPTIVE_WARMUP_DELAY):
+            test("foo1")
+
+    def test_reassigned_new(self):
+        class A:
+            def __new__(cls):
+                pass
+
+            def __init_subclass__(cls):
+                if "__new__" not in cls.__dict__:
+                    cls.__new__ = cls.__new__
+
+        class B(A):
+            pass
+
+        class C(B):
+            def __new__(cls):
+                return super().__new__(cls)
+
+        for _ in range(ADAPTIVE_WARMUP_DELAY):
+            C()
+
+    def test_mixed_staticmethod_hierarchy(self):
+        # This test is just a desugared version of `test_reassigned_new`
+        class A:
+            @staticmethod
+            def some(cls, *args, **kwargs):
+                self.assertFalse(args)
+                self.assertFalse(kwargs)
+
+        class B(A):
+            def some(cls, *args, **kwargs):
+                return super().some(cls, *args, **kwargs)
+
+        class C(B):
+            @staticmethod
+            def some(cls):
+                return super().some(cls)
+
+        for _ in range(ADAPTIVE_WARMUP_DELAY):
+            C.some(C)
 
 
 if __name__ == "__main__":

--- a/Misc/NEWS.d/next/Core and Builtins/2023-07-21-14-37-48.gh-issue-106917.1jWp_m.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2023-07-21-14-37-48.gh-issue-106917.1jWp_m.rst
@@ -1,0 +1,4 @@
+Fix classmethod-style :func:`super` method calls (i.e., where the second
+argument to :func:`super`, or the implied second argument drawn from
+``self/cls`` in the case of zero-arg super, is a type) when the target of
+the call is not a classmethod.

--- a/Python/bytecodes.c
+++ b/Python/bytecodes.c
@@ -1663,7 +1663,7 @@ dummy_func(
             PyTypeObject *cls = (PyTypeObject *)class;
             int method_found = 0;
             res2 = _PySuper_Lookup(cls, self, name,
-                                   cls->tp_getattro == PyObject_GenericGetAttr ? &method_found : NULL);
+                                   Py_TYPE(self)->tp_getattro == PyObject_GenericGetAttr ? &method_found : NULL);
             Py_DECREF(global_super);
             Py_DECREF(class);
             if (res2 == NULL) {

--- a/Python/generated_cases.c.h
+++ b/Python/generated_cases.c.h
@@ -2411,7 +2411,7 @@
             PyTypeObject *cls = (PyTypeObject *)class;
             int method_found = 0;
             res2 = _PySuper_Lookup(cls, self, name,
-                                   cls->tp_getattro == PyObject_GenericGetAttr ? &method_found : NULL);
+                                   Py_TYPE(self)->tp_getattro == PyObject_GenericGetAttr ? &method_found : NULL);
             Py_DECREF(global_super);
             Py_DECREF(class);
             if (res2 == NULL) {


### PR DESCRIPTION
(cherry picked from commit e5d5522612e03af3941db1d270bf6caebf330b8a)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-106917 -->
* Issue: gh-106917
<!-- /gh-issue-number -->
