### PR TITLE
gh-107211: No longer export internal functions (1)

### DIFF
--- a/Include/internal/pycore_call.h
+++ b/Include/internal/pycore_call.h
@@ -22,8 +22,8 @@ extern "C" {
 #define _PY_FASTCALL_SMALL_STACK 5
 
 
-// Export for shared stdlib extensions like the math extension,
-// function used via inlined _PyObject_VectorcallTstate() function.
+// Export for 'math' shared extension, function used
+// via inlined _PyObject_VectorcallTstate() function.
 PyAPI_FUNC(PyObject*) _Py_CheckFunctionResult(
     PyThreadState *tstate,
     PyObject *callable,
@@ -68,7 +68,7 @@ extern PyObject * _PyObject_CallMethodFormat(
     const char *format,
     ...);
 
-// Export for shared stdlib extensions like the array extension
+// Export for 'array' shared extension
 PyAPI_FUNC(PyObject*) _PyObject_CallMethod(
     PyObject *obj,
     PyObject *name,
@@ -120,8 +120,8 @@ _PyObject_CallMethodIdOneArg(PyObject *self, _Py_Identifier *name, PyObject *arg
 // Call callable using tp_call. Arguments are like PyObject_Vectorcall(),
 // except that nargs is plainly the number of arguments without flags.
 //
-// Export for shared stdlib extensions like the math extension,
-// function used via inlined _PyObject_VectorcallTstate() function.
+// Export for 'math' shared extension, function used
+// via inlined _PyObject_VectorcallTstate() function.
 PyAPI_FUNC(PyObject*) _PyObject_MakeTpCall(
     PyThreadState *tstate,
     PyObject *callable,

--- a/Include/internal/pycore_code.h
+++ b/Include/internal/pycore_code.h
@@ -203,8 +203,8 @@ struct _PyCodeConstructor {
 // back to a regular function signature.  Regardless, this approach
 // wouldn't be appropriate if this weren't a strictly internal API.
 // (See the comments in https://github.com/python/cpython/pull/26258.)
-PyAPI_FUNC(int) _PyCode_Validate(struct _PyCodeConstructor *);
-PyAPI_FUNC(PyCodeObject *) _PyCode_New(struct _PyCodeConstructor *);
+extern int _PyCode_Validate(struct _PyCodeConstructor *);
+extern PyCodeObject* _PyCode_New(struct _PyCodeConstructor *);
 
 
 /* Private API */
@@ -274,7 +274,7 @@ extern int _PyStaticCode_Init(PyCodeObject *co);
 #define EVAL_CALL_STAT_INC_IF_FUNCTION(name, callable) \
     do { if (_py_stats && PyFunction_Check(callable)) _py_stats->call_stats.eval_calls[name]++; } while (0)
 
-// Used by the _opcode extension which is built as a shared library
+// Export for stdlib '_opcode' shared extension
 PyAPI_FUNC(PyObject*) _Py_GetSpecializationStats(void);
 
 #else

--- a/Include/internal/pycore_compile.h
+++ b/Include/internal/pycore_compile.h
@@ -11,7 +11,7 @@ extern "C" {
 struct _arena;   // Type defined in pycore_pyarena.h
 struct _mod;     // Type defined in pycore_ast.h
 
-// Export the symbol for test_peg_generator (built as a library)
+// Export for 'test_peg_generator' shared extension
 PyAPI_FUNC(PyCodeObject*) _PyAST_Compile(
     struct _mod *mod,
     PyObject *filename,
@@ -91,6 +91,7 @@ int _PyCompile_ConstCacheMergeOne(PyObject *const_cache, PyObject **obj);
 
 /* Access compiler internals for unit testing */
 
+// Export for '_testinternalcapi' shared extension
 PyAPI_FUNC(PyObject*) _PyCompile_CleanDoc(PyObject *doc);
 
 PyAPI_FUNC(PyObject*) _PyCompile_CodeGen(

--- a/Include/internal/pycore_dtoa.h
+++ b/Include/internal/pycore_dtoa.h
@@ -60,10 +60,10 @@ struct _dtoa_state {
 /* These functions are used by modules compiled as C extension like math:
    they must be exported. */
 
-PyAPI_FUNC(double) _Py_dg_strtod(const char *str, char **ptr);
-PyAPI_FUNC(char *) _Py_dg_dtoa(double d, int mode, int ndigits,
-                        int *decpt, int *sign, char **rve);
-PyAPI_FUNC(void) _Py_dg_freedtoa(char *s);
+extern double _Py_dg_strtod(const char *str, char **ptr);
+extern char* _Py_dg_dtoa(double d, int mode, int ndigits,
+                         int *decpt, int *sign, char **rve);
+extern void _Py_dg_freedtoa(char *s);
 
 #endif // _PY_SHORT_FLOAT_REPR == 1
 

--- a/Include/internal/pycore_fileutils.h
+++ b/Include/internal/pycore_fileutils.h
@@ -52,11 +52,11 @@ PyAPI_FUNC(int) _Py_EncodeLocaleEx(
     int current_locale,
     _Py_error_handler errors);
 
-PyAPI_FUNC(char*) _Py_EncodeLocaleRaw(
+extern char* _Py_EncodeLocaleRaw(
     const wchar_t *text,
     size_t *error_pos);
 
-PyAPI_FUNC(PyObject *) _Py_device_encoding(int);
+extern PyObject* _Py_device_encoding(int);
 
 #if defined(MS_WINDOWS) || defined(__APPLE__)
     /* On Windows, the count parameter of read() is an int (bpo-9015, bpo-9611).
@@ -109,7 +109,7 @@ PyAPI_FUNC(int) _Py_stat(
     PyObject *path,
     struct stat *status);
 
-PyAPI_FUNC(int) _Py_open(
+extern int _Py_open(
     const char *pathname,
     int flags);
 
@@ -117,16 +117,16 @@ PyAPI_FUNC(int) _Py_open_noraise(
     const char *pathname,
     int flags);
 
-PyAPI_FUNC(FILE *) _Py_wfopen(
+extern FILE* _Py_wfopen(
     const wchar_t *path,
     const wchar_t *mode);
 
-PyAPI_FUNC(Py_ssize_t) _Py_read(
+extern Py_ssize_t _Py_read(
     int fd,
     void *buf,
     size_t count);
 
-PyAPI_FUNC(Py_ssize_t) _Py_write(
+extern Py_ssize_t _Py_write(
     int fd,
     const void *buf,
     size_t count);
@@ -137,7 +137,7 @@ PyAPI_FUNC(Py_ssize_t) _Py_write_noraise(
     size_t count);
 
 #ifdef HAVE_READLINK
-PyAPI_FUNC(int) _Py_wreadlink(
+extern int _Py_wreadlink(
     const wchar_t *path,
     wchar_t *buf,
     /* Number of characters of 'buf' buffer
@@ -146,7 +146,7 @@ PyAPI_FUNC(int) _Py_wreadlink(
 #endif
 
 #ifdef HAVE_REALPATH
-PyAPI_FUNC(wchar_t*) _Py_wrealpath(
+extern wchar_t* _Py_wrealpath(
     const wchar_t *path,
     wchar_t *resolved_path,
     /* Number of characters of 'resolved_path' buffer
@@ -154,13 +154,13 @@ PyAPI_FUNC(wchar_t*) _Py_wrealpath(
     size_t resolved_path_len);
 #endif
 
-PyAPI_FUNC(wchar_t*) _Py_wgetcwd(
+extern wchar_t* _Py_wgetcwd(
     wchar_t *buf,
     /* Number of characters of 'buf' buffer
        including the trailing NUL character */
     size_t buflen);
 
-PyAPI_FUNC(int) _Py_get_inheritable(int fd);
+extern int _Py_get_inheritable(int fd);
 
 PyAPI_FUNC(int) _Py_set_inheritable(int fd, int inheritable,
                                     int *atomic_flag_works);
@@ -170,18 +170,18 @@ PyAPI_FUNC(int) _Py_set_inheritable_async_safe(int fd, int inheritable,
 
 PyAPI_FUNC(int) _Py_dup(int fd);
 
-PyAPI_FUNC(int) _Py_get_blocking(int fd);
+extern int _Py_get_blocking(int fd);
 
-PyAPI_FUNC(int) _Py_set_blocking(int fd, int blocking);
+extern int _Py_set_blocking(int fd, int blocking);
 
 #ifdef MS_WINDOWS
-PyAPI_FUNC(void*) _Py_get_osfhandle_noraise(int fd);
+extern void* _Py_get_osfhandle_noraise(int fd);
 
 PyAPI_FUNC(void*) _Py_get_osfhandle(int fd);
 
-PyAPI_FUNC(int) _Py_open_osfhandle_noraise(void *handle, int flags);
+extern int _Py_open_osfhandle_noraise(void *handle, int flags);
 
-PyAPI_FUNC(int) _Py_open_osfhandle(void *handle, int flags);
+extern int _Py_open_osfhandle(void *handle, int flags);
 #endif  /* MS_WINDOWS */
 
 // This is used after getting NULL back from Py_DecodeLocale().
@@ -190,9 +190,9 @@ PyAPI_FUNC(int) _Py_open_osfhandle(void *handle, int flags);
      ? _PyStatus_ERR("cannot decode " NAME) \
      : _PyStatus_NO_MEMORY()
 
-PyAPI_DATA(int) _Py_HasFileSystemDefaultEncodeErrors;
+extern int _Py_HasFileSystemDefaultEncodeErrors;
 
-PyAPI_FUNC(int) _Py_DecodeUTF8Ex(
+extern int _Py_DecodeUTF8Ex(
     const char *arg,
     Py_ssize_t arglen,
     wchar_t **wstr,
@@ -200,7 +200,7 @@ PyAPI_FUNC(int) _Py_DecodeUTF8Ex(
     const char **reason,
     _Py_error_handler errors);
 
-PyAPI_FUNC(int) _Py_EncodeUTF8Ex(
+extern int _Py_EncodeUTF8Ex(
     const wchar_t *text,
     char **str,
     size_t *error_pos,
@@ -208,7 +208,7 @@ PyAPI_FUNC(int) _Py_EncodeUTF8Ex(
     int raw_malloc,
     _Py_error_handler errors);
 
-PyAPI_FUNC(wchar_t*) _Py_DecodeUTF8_surrogateescape(
+extern wchar_t* _Py_DecodeUTF8_surrogateescape(
     const char *arg,
     Py_ssize_t arglen,
     size_t *wlen);
@@ -216,25 +216,25 @@ PyAPI_FUNC(wchar_t*) _Py_DecodeUTF8_surrogateescape(
 extern int
 _Py_wstat(const wchar_t *, struct stat *);
 
-PyAPI_FUNC(int) _Py_GetForceASCII(void);
+extern int _Py_GetForceASCII(void);
 
 /* Reset "force ASCII" mode (if it was initialized).
 
    This function should be called when Python changes the LC_CTYPE locale,
    so the "force ASCII" mode can be detected again on the new locale
    encoding. */
-PyAPI_FUNC(void) _Py_ResetForceASCII(void);
+extern void _Py_ResetForceASCII(void);
 
 
-PyAPI_FUNC(int) _Py_GetLocaleconvNumeric(
+extern int _Py_GetLocaleconvNumeric(
     struct lconv *lc,
     PyObject **decimal_point,
     PyObject **thousands_sep);
 
 PyAPI_FUNC(void) _Py_closerange(int first, int last);
 
-PyAPI_FUNC(wchar_t*) _Py_GetLocaleEncoding(void);
-PyAPI_FUNC(PyObject*) _Py_GetLocaleEncodingObject(void);
+extern wchar_t* _Py_GetLocaleEncoding(void);
+extern PyObject* _Py_GetLocaleEncodingObject(void);
 
 #ifdef HAVE_NON_UNICODE_WCHAR_T_REPRESENTATION
 extern int _Py_LocaleUsesNonUnicodeWchar(void);
@@ -253,13 +253,13 @@ extern int _Py_abspath(const wchar_t *path, wchar_t **abspath_p);
 #ifdef MS_WINDOWS
 extern int _PyOS_getfullpathname(const wchar_t *path, wchar_t **abspath_p);
 #endif
-extern wchar_t * _Py_join_relfile(const wchar_t *dirname,
-                                  const wchar_t *relfile);
+extern wchar_t* _Py_join_relfile(const wchar_t *dirname,
+                                 const wchar_t *relfile);
 extern int _Py_add_relfile(wchar_t *dirname,
                            const wchar_t *relfile,
                            size_t bufsize);
 extern size_t _Py_find_basename(const wchar_t *filename);
-PyAPI_FUNC(wchar_t *) _Py_normpath(wchar_t *path, Py_ssize_t size);
+PyAPI_FUNC(wchar_t*) _Py_normpath(wchar_t *path, Py_ssize_t size);
 
 // The Windows Games API family does not provide these functions
 // so provide our own implementations. Remove them in case they get added

--- a/Include/internal/pycore_floatobject.h
+++ b/Include/internal/pycore_floatobject.h
@@ -55,12 +55,12 @@ struct _Py_float_state {
 void _PyFloat_ExactDealloc(PyObject *op);
 
 
-PyAPI_FUNC(void) _PyFloat_DebugMallocStats(FILE* out);
+extern void _PyFloat_DebugMallocStats(FILE* out);
 
 
 /* Format the object based on the format_spec, as defined in PEP 3101
    (Advanced String Formatting). */
-PyAPI_FUNC(int) _PyFloat_FormatAdvancedWriter(
+extern int _PyFloat_FormatAdvancedWriter(
     _PyUnicodeWriter *writer,
     PyObject *obj,
     PyObject *format_spec,

--- a/Include/internal/pycore_genobject.h
+++ b/Include/internal/pycore_genobject.h
@@ -11,9 +11,9 @@ extern "C" {
 extern PyObject *_PyGen_yf(PyGenObject *);
 extern void _PyGen_Finalize(PyObject *self);
 
-// _asyncio shared extensions uses _PyGen_SetStopIterationValue() and
-// _PyGen_FetchStopIterationValue()
+// Export for '_asyncio' shared extension
 PyAPI_FUNC(int) _PyGen_SetStopIterationValue(PyObject *);
+// Export for '_asyncio' shared extension
 PyAPI_FUNC(int) _PyGen_FetchStopIterationValue(PyObject **);
 
 extern PyObject *_PyCoro_GetAwaitableIter(PyObject *o);

--- a/Include/internal/pycore_import.h
+++ b/Include/internal/pycore_import.h
@@ -9,9 +9,9 @@ extern "C" {
 
 extern int _PyImport_IsInitialized(PyInterpreterState *);
 
-PyAPI_FUNC(PyObject *) _PyImport_GetModuleId(_Py_Identifier *name);
+extern PyObject* _PyImport_GetModuleId(_Py_Identifier *name);
 PyAPI_FUNC(int) _PyImport_SetModule(PyObject *name, PyObject *module);
-PyAPI_FUNC(int) _PyImport_SetModuleString(const char *name, PyObject* module);
+extern int _PyImport_SetModuleString(const char *name, PyObject* module);
 
 extern void _PyImport_AcquireLock(PyInterpreterState *interp);
 extern int _PyImport_ReleaseLock(PyInterpreterState *interp);
@@ -24,8 +24,8 @@ extern int _PyImport_FixupBuiltin(
 extern int _PyImport_FixupExtensionObject(PyObject*, PyObject *,
                                           PyObject *, PyObject *);
 
-PyAPI_FUNC(PyObject *) _PyImport_GetModuleAttr(PyObject *, PyObject *);
-PyAPI_FUNC(PyObject *) _PyImport_GetModuleAttrString(const char *, const char *);
+PyAPI_FUNC(PyObject*) _PyImport_GetModuleAttr(PyObject *, PyObject *);
+PyAPI_FUNC(PyObject*) _PyImport_GetModuleAttrString(const char *, const char *);
 
 
 struct _import_runtime_state {
@@ -192,12 +192,12 @@ PyAPI_DATA(const struct _frozen *) _PyImport_FrozenStdlib;
 PyAPI_DATA(const struct _frozen *) _PyImport_FrozenTest;
 extern const struct _module_alias * _PyImport_FrozenAliases;
 
-PyAPI_FUNC(int) _PyImport_CheckSubinterpIncompatibleExtensionAllowed(
+extern int _PyImport_CheckSubinterpIncompatibleExtensionAllowed(
     const char *name);
 
 
-// for testing
-PyAPI_FUNC(int) _PyImport_ClearExtension(PyObject *name, PyObject *filename);
+// Export for '_testinternalcapi' shared extension
+PyAPI_DATA(int) _PyImport_ClearExtension(PyObject *name, PyObject *filename);
 
 #ifdef __cplusplus
 }

--- a/Include/internal/pycore_initconfig.h
+++ b/Include/internal/pycore_initconfig.h
@@ -49,14 +49,14 @@ struct pyruntimestate;
 #define _PyWideStringList_INIT (PyWideStringList){.length = 0, .items = NULL}
 
 #ifndef NDEBUG
-PyAPI_FUNC(int) _PyWideStringList_CheckConsistency(const PyWideStringList *list);
+extern int _PyWideStringList_CheckConsistency(const PyWideStringList *list);
 #endif
-PyAPI_FUNC(void) _PyWideStringList_Clear(PyWideStringList *list);
-PyAPI_FUNC(int) _PyWideStringList_Copy(PyWideStringList *list,
+extern void _PyWideStringList_Clear(PyWideStringList *list);
+extern int _PyWideStringList_Copy(PyWideStringList *list,
     const PyWideStringList *list2);
-PyAPI_FUNC(PyStatus) _PyWideStringList_Extend(PyWideStringList *list,
+extern PyStatus _PyWideStringList_Extend(PyWideStringList *list,
     const PyWideStringList *list2);
-PyAPI_FUNC(PyObject*) _PyWideStringList_AsList(const PyWideStringList *list);
+extern PyObject* _PyWideStringList_AsList(const PyWideStringList *list);
 
 
 /* --- _PyArgv ---------------------------------------------------- */
@@ -68,28 +68,28 @@ typedef struct _PyArgv {
     wchar_t * const *wchar_argv;
 } _PyArgv;
 
-PyAPI_FUNC(PyStatus) _PyArgv_AsWstrList(const _PyArgv *args,
+extern PyStatus _PyArgv_AsWstrList(const _PyArgv *args,
     PyWideStringList *list);
 
 
 /* --- Helper functions ------------------------------------------- */
 
-PyAPI_FUNC(int) _Py_str_to_int(
+extern int _Py_str_to_int(
     const char *str,
     int *result);
-PyAPI_FUNC(const wchar_t*) _Py_get_xoption(
+extern const wchar_t* _Py_get_xoption(
     const PyWideStringList *xoptions,
     const wchar_t *name);
-PyAPI_FUNC(const char*) _Py_GetEnv(
+extern const char* _Py_GetEnv(
     int use_environment,
     const char *name);
-PyAPI_FUNC(void) _Py_get_env_flag(
+extern void _Py_get_env_flag(
     int use_environment,
     int *flag,
     const char *name);
 
 /* Py_GetArgcArgv() helper */
-PyAPI_FUNC(void) _Py_ClearArgcArgv(void);
+extern void _Py_ClearArgcArgv(void);
 
 
 /* --- _PyPreCmdline ------------------------------------------------- */

--- a/Include/internal/pycore_interp.h
+++ b/Include/internal/pycore_interp.h
@@ -232,11 +232,11 @@ struct _xidregitem {
     crossinterpdatafunc getdata;
 };
 
-PyAPI_FUNC(PyInterpreterState*) _PyInterpreterState_LookUpID(int64_t);
+extern PyInterpreterState* _PyInterpreterState_LookUpID(int64_t);
 
-PyAPI_FUNC(int) _PyInterpreterState_IDInitref(PyInterpreterState *);
-PyAPI_FUNC(int) _PyInterpreterState_IDIncref(PyInterpreterState *);
-PyAPI_FUNC(void) _PyInterpreterState_IDDecref(PyInterpreterState *);
+extern int _PyInterpreterState_IDInitref(PyInterpreterState *);
+extern int _PyInterpreterState_IDIncref(PyInterpreterState *);
+extern void _PyInterpreterState_IDDecref(PyInterpreterState *);
 
 PyAPI_FUNC(PyObject*) _PyInterpreterState_GetMainModule(PyInterpreterState *);
 


### PR DESCRIPTION
No longer export these 52 internal functions:

* _PyArgv_AsWstrList()
* _PyCode_New()
* _PyCode_Validate()
* _PyFloat_DebugMallocStats()
* _PyFloat_FormatAdvancedWriter()
* _PyImport_CheckSubinterpIncompatibleExtensionAllowed()
* _PyImport_ClearExtension()
* _PyImport_GetModuleId()
* _PyImport_SetModuleString()
* _PyInterpreterState_IDDecref()
* _PyInterpreterState_IDIncref()
* _PyInterpreterState_IDInitref()
* _PyInterpreterState_LookUpID()
* _PyWideStringList_AsList()
* _PyWideStringList_CheckConsistency()
* _PyWideStringList_Clear()
* _PyWideStringList_Copy()
* _PyWideStringList_Extend()
* _Py_ClearArgcArgv()
* _Py_DecodeUTF8Ex()
* _Py_DecodeUTF8_surrogateescape()
* _Py_EncodeLocaleRaw()
* _Py_EncodeUTF8Ex()
* _Py_GetEnv()
* _Py_GetForceASCII()
* _Py_GetLocaleEncoding()
* _Py_GetLocaleEncodingObject()
* _Py_GetLocaleconvNumeric()
* _Py_ResetForceASCII()
* _Py_closerange()
* _Py_device_encoding()
* _Py_dg_dtoa()
* _Py_dg_freedtoa()
* _Py_dg_strtod()
* _Py_get_blocking()
* _Py_get_env_flag()
* _Py_get_inheritable()
* _Py_get_osfhandle()
* _Py_get_osfhandle_noraise()
* _Py_get_xoption()
* _Py_open()
* _Py_open_osfhandle()
* _Py_open_osfhandle_noraise()
* _Py_read()
* _Py_set_blocking()
* _Py_stat()
* _Py_str_to_int()
* _Py_wfopen()
* _Py_wgetcwd()
* _Py_wreadlink()
* _Py_wrealpath()
* _Py_write()

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-107211 -->
* Issue: gh-107211
<!-- /gh-issue-number -->
