### PR TITLE
gh-107211: No longer export internal functions (2)

### DIFF
--- a/Include/internal/pycore_long.h
+++ b/Include/internal/pycore_long.h
@@ -79,9 +79,9 @@ static inline PyObject* _PyLong_FromUnsignedChar(unsigned char i)
     return Py_NewRef((PyObject *)&_PyLong_SMALL_INTS[_PY_NSMALLNEGINTS+i]);
 }
 
-PyObject *_PyLong_Add(PyLongObject *left, PyLongObject *right);
-PyObject *_PyLong_Multiply(PyLongObject *left, PyLongObject *right);
-PyObject *_PyLong_Subtract(PyLongObject *left, PyLongObject *right);
+extern PyObject *_PyLong_Add(PyLongObject *left, PyLongObject *right);
+extern PyObject *_PyLong_Multiply(PyLongObject *left, PyLongObject *right);
+extern PyObject *_PyLong_Subtract(PyLongObject *left, PyLongObject *right);
 
 /* Used by Python/mystrtoul.c, _PyBytes_FromHex(),
    _PyBytes_DecodeEscape(), etc. */
@@ -89,20 +89,20 @@ PyAPI_DATA(unsigned char) _PyLong_DigitValue[256];
 
 /* Format the object based on the format_spec, as defined in PEP 3101
    (Advanced String Formatting). */
-PyAPI_FUNC(int) _PyLong_FormatAdvancedWriter(
+extern int _PyLong_FormatAdvancedWriter(
     _PyUnicodeWriter *writer,
     PyObject *obj,
     PyObject *format_spec,
     Py_ssize_t start,
     Py_ssize_t end);
 
-PyAPI_FUNC(int) _PyLong_FormatWriter(
+extern int _PyLong_FormatWriter(
     _PyUnicodeWriter *writer,
     PyObject *obj,
     int base,
     int alternate);
 
-PyAPI_FUNC(char*) _PyLong_FormatBytesWriter(
+extern char* _PyLong_FormatBytesWriter(
     _PyBytesWriter *writer,
     char *str,
     PyObject *obj,

--- a/Include/internal/pycore_namespace.h
+++ b/Include/internal/pycore_namespace.h
@@ -10,9 +10,9 @@ extern "C" {
 #  error "this header requires Py_BUILD_CORE define"
 #endif
 
-PyAPI_DATA(PyTypeObject) _PyNamespace_Type;
+extern PyTypeObject _PyNamespace_Type;
 
-PyAPI_FUNC(PyObject *) _PyNamespace_New(PyObject *kwds);
+PyAPI_FUNC(PyObject*) _PyNamespace_New(PyObject *kwds);
 
 #ifdef __cplusplus
 }

--- a/Include/internal/pycore_object.h
+++ b/Include/internal/pycore_object.h
@@ -156,8 +156,8 @@ _Py_DECREF_NO_DEALLOC(PyObject *op)
 #endif
 
 
-PyAPI_FUNC(int) _PyType_CheckConsistency(PyTypeObject *type);
-PyAPI_FUNC(int) _PyDict_CheckConsistency(PyObject *mp, int check_content);
+extern int _PyType_CheckConsistency(PyTypeObject *type);
+extern int _PyDict_CheckConsistency(PyObject *mp, int check_content);
 
 /* Update the Python traceback of an object. This function must be called
    when a memory block is reused from a free list.

--- a/Include/internal/pycore_pyarena.h
+++ b/Include/internal/pycore_pyarena.h
@@ -1,4 +1,6 @@
 /* An arena-like memory interface for the compiler.
+ *
+ * Export symbols for test_peg_generator.
  */
 
 #ifndef Py_INTERNAL_PYARENA_H

--- a/Include/internal/pycore_pyerrors.h
+++ b/Include/internal/pycore_pyerrors.h
@@ -11,46 +11,47 @@ extern "C" {
 
 /* Error handling definitions */
 
-PyAPI_FUNC(_PyErr_StackItem*) _PyErr_GetTopmostException(PyThreadState *tstate);
-PyAPI_FUNC(PyObject*) _PyErr_GetHandledException(PyThreadState *);
-PyAPI_FUNC(void) _PyErr_SetHandledException(PyThreadState *, PyObject *);
-PyAPI_FUNC(void) _PyErr_GetExcInfo(PyThreadState *, PyObject **, PyObject **, PyObject **);
+extern _PyErr_StackItem* _PyErr_GetTopmostException(PyThreadState *tstate);
+extern PyObject* _PyErr_GetHandledException(PyThreadState *);
+extern void _PyErr_SetHandledException(PyThreadState *, PyObject *);
+extern void _PyErr_GetExcInfo(PyThreadState *, PyObject **, PyObject **, PyObject **);
 
-/* Like PyErr_Format(), but saves current exception as __context__ and
-   __cause__.
- */
-PyAPI_FUNC(PyObject *) _PyErr_FormatFromCause(
+// Like PyErr_Format(), but saves current exception as __context__ and
+// __cause__.
+// Export for '_sqlite3' shared extension.
+PyAPI_FUNC(PyObject*) _PyErr_FormatFromCause(
     PyObject *exception,
     const char *format,   /* ASCII-encoded string  */
     ...
     );
 
-PyAPI_FUNC(int) _PyException_AddNote(
+extern int _PyException_AddNote(
      PyObject *exc,
      PyObject *note);
 
-PyAPI_FUNC(int) _PyErr_CheckSignals(void);
+extern int _PyErr_CheckSignals(void);
 
 /* Support for adding program text to SyntaxErrors */
 
-PyAPI_FUNC(PyObject *) _PyErr_ProgramDecodedTextObject(
+// Export for test_peg_generator
+PyAPI_FUNC(PyObject*) _PyErr_ProgramDecodedTextObject(
     PyObject *filename,
     int lineno,
     const char* encoding);
 
-PyAPI_FUNC(PyObject *) _PyUnicodeTranslateError_Create(
+extern PyObject* _PyUnicodeTranslateError_Create(
     PyObject *object,
     Py_ssize_t start,
     Py_ssize_t end,
     const char *reason          /* UTF-8 encoded string */
     );
 
-PyAPI_FUNC(void) _Py_NO_RETURN _Py_FatalErrorFormat(
+extern void _Py_NO_RETURN _Py_FatalErrorFormat(
     const char *func,
     const char *format,
     ...);
 
-extern PyObject *_PyErr_SetImportErrorWithNameFrom(
+extern PyObject* _PyErr_SetImportErrorWithNameFrom(
         PyObject *,
         PyObject *,
         PyObject *,
@@ -79,80 +80,79 @@ static inline void _PyErr_ClearExcState(_PyErr_StackItem *exc_state)
     Py_CLEAR(exc_state->exc_value);
 }
 
-PyAPI_FUNC(PyObject*) _PyErr_StackItemToExcInfoTuple(
+extern PyObject* _PyErr_StackItemToExcInfoTuple(
     _PyErr_StackItem *err_info);
 
-PyAPI_FUNC(void) _PyErr_Fetch(
+extern void _PyErr_Fetch(
     PyThreadState *tstate,
     PyObject **type,
     PyObject **value,
     PyObject **traceback);
 
-extern PyObject *
-_PyErr_GetRaisedException(PyThreadState *tstate);
+extern PyObject* _PyErr_GetRaisedException(PyThreadState *tstate);
 
-PyAPI_FUNC(int) _PyErr_ExceptionMatches(
+extern int _PyErr_ExceptionMatches(
     PyThreadState *tstate,
     PyObject *exc);
 
-void
-_PyErr_SetRaisedException(PyThreadState *tstate, PyObject *exc);
+extern void _PyErr_SetRaisedException(PyThreadState *tstate, PyObject *exc);
 
-PyAPI_FUNC(void) _PyErr_Restore(
+extern void _PyErr_Restore(
     PyThreadState *tstate,
     PyObject *type,
     PyObject *value,
     PyObject *traceback);
 
-PyAPI_FUNC(void) _PyErr_SetObject(
+extern void _PyErr_SetObject(
     PyThreadState *tstate,
     PyObject *type,
     PyObject *value);
 
-PyAPI_FUNC(void) _PyErr_ChainStackItem(void);
+extern void _PyErr_ChainStackItem(void);
 
-PyAPI_FUNC(void) _PyErr_Clear(PyThreadState *tstate);
+extern void _PyErr_Clear(PyThreadState *tstate);
 
-PyAPI_FUNC(void) _PyErr_SetNone(PyThreadState *tstate, PyObject *exception);
+extern void _PyErr_SetNone(PyThreadState *tstate, PyObject *exception);
 
-PyAPI_FUNC(PyObject *) _PyErr_NoMemory(PyThreadState *tstate);
+extern PyObject* _PyErr_NoMemory(PyThreadState *tstate);
 
-PyAPI_FUNC(void) _PyErr_SetString(
+extern void _PyErr_SetString(
     PyThreadState *tstate,
     PyObject *exception,
     const char *string);
 
-PyAPI_FUNC(PyObject *) _PyErr_Format(
+extern PyObject* _PyErr_Format(
     PyThreadState *tstate,
     PyObject *exception,
     const char *format,
     ...);
 
-PyAPI_FUNC(void) _PyErr_NormalizeException(
+extern void _PyErr_NormalizeException(
     PyThreadState *tstate,
     PyObject **exc,
     PyObject **val,
     PyObject **tb);
 
-PyAPI_FUNC(PyObject *) _PyErr_FormatFromCauseTstate(
+extern PyObject* _PyErr_FormatFromCauseTstate(
     PyThreadState *tstate,
     PyObject *exception,
     const char *format,
     ...);
 
-PyAPI_FUNC(PyObject *) _PyExc_CreateExceptionGroup(
+extern PyObject* _PyExc_CreateExceptionGroup(
     const char *msg,
     PyObject *excs);
 
-PyAPI_FUNC(PyObject *) _PyExc_PrepReraiseStar(
+extern PyObject* _PyExc_PrepReraiseStar(
     PyObject *orig,
     PyObject *excs);
 
-PyAPI_FUNC(int) _PyErr_CheckSignalsTstate(PyThreadState *tstate);
+extern int _PyErr_CheckSignalsTstate(PyThreadState *tstate);
 
-PyAPI_FUNC(void) _Py_DumpExtensionModules(int fd, PyInterpreterState *interp);
+extern void _Py_DumpExtensionModules(int fd, PyInterpreterState *interp);
 
 extern PyObject* _Py_Offer_Suggestions(PyObject* exception);
+// Export for '_testinternalcapi' shared extension
 PyAPI_FUNC(Py_ssize_t) _Py_UTF8_Edit_Cost(PyObject *str_a, PyObject *str_b,
                                           Py_ssize_t max_cost);
 

--- a/Include/internal/pycore_pymem.h
+++ b/Include/internal/pycore_pymem.h
@@ -48,7 +48,7 @@ struct _pymem_allocators {
 /* Set the memory allocator of the specified domain to the default.
    Save the old allocator into *old_alloc if it's non-NULL.
    Return on success, or return -1 if the domain is unknown. */
-PyAPI_FUNC(int) _PyMem_SetDefaultAllocator(
+extern int _PyMem_SetDefaultAllocator(
     PyMemAllocatorDomain domain,
     PyMemAllocatorEx *old_alloc);
 
@@ -94,14 +94,14 @@ static inline int _PyMem_IsPtrFreed(const void *ptr)
 #endif
 }
 
-PyAPI_FUNC(int) _PyMem_GetAllocatorName(
+extern int _PyMem_GetAllocatorName(
     const char *name,
     PyMemAllocatorName *allocator);
 
 /* Configure the Python memory allocators.
    Pass PYMEM_ALLOCATOR_DEFAULT to use default allocators.
    PYMEM_ALLOCATOR_NOT_SET does nothing. */
-PyAPI_FUNC(int) _PyMem_SetupAllocators(PyMemAllocatorName allocator);
+extern int _PyMem_SetupAllocators(PyMemAllocatorName allocator);
 
 
 #ifdef __cplusplus

--- a/Include/internal/pycore_pystate.h
+++ b/Include/internal/pycore_pystate.h
@@ -121,15 +121,16 @@ static inline PyInterpreterState* _PyInterpreterState_GET(void) {
 
 // PyThreadState functions
 
-PyAPI_FUNC(PyThreadState *) _PyThreadState_New(PyInterpreterState *interp);
-PyAPI_FUNC(void) _PyThreadState_Bind(PyThreadState *tstate);
-PyAPI_FUNC(void) _PyThreadState_DeleteExcept(PyThreadState *tstate);
+extern PyThreadState * _PyThreadState_New(PyInterpreterState *interp);
+extern void _PyThreadState_Bind(PyThreadState *tstate);
+extern void _PyThreadState_DeleteExcept(PyThreadState *tstate);
 
 extern void _PyThreadState_InitDetached(PyThreadState *, PyInterpreterState *);
 extern void _PyThreadState_ClearDetached(PyThreadState *);
 extern void _PyThreadState_BindDetached(PyThreadState *);
 extern void _PyThreadState_UnbindDetached(PyThreadState *);
 
+// Export for '_testinternalcapi' shared extension
 PyAPI_FUNC(PyObject*) _PyThreadState_GetDict(PyThreadState *tstate);
 
 /* The implementation of sys._current_frames()  Returns a dict mapping
@@ -145,25 +146,25 @@ extern PyObject* _PyThread_CurrentExceptions(void);
 
 /* Other */
 
-PyAPI_FUNC(PyThreadState *) _PyThreadState_Swap(
+extern PyThreadState * _PyThreadState_Swap(
     _PyRuntimeState *runtime,
     PyThreadState *newts);
 
-PyAPI_FUNC(PyStatus) _PyInterpreterState_Enable(_PyRuntimeState *runtime);
+extern PyStatus _PyInterpreterState_Enable(_PyRuntimeState *runtime);
 
 #ifdef HAVE_FORK
 extern PyStatus _PyInterpreterState_DeleteExceptMain(_PyRuntimeState *runtime);
 extern void _PySignal_AfterFork(void);
 #endif
 
-
+// Export for the stable ABI
 PyAPI_FUNC(int) _PyState_AddModule(
     PyThreadState *tstate,
     PyObject* module,
     PyModuleDef* def);
 
 
-PyAPI_FUNC(int) _PyOS_InterruptOccurred(PyThreadState *tstate);
+extern int _PyOS_InterruptOccurred(PyThreadState *tstate);
 
 #define HEAD_LOCK(runtime) \
     PyThread_acquire_lock((runtime)->interpreters.mutex, WAIT_LOCK)
@@ -172,6 +173,7 @@ PyAPI_FUNC(int) _PyOS_InterruptOccurred(PyThreadState *tstate);
 
 // Get the configuration of the current interpreter.
 // The caller must hold the GIL.
+// Export for test_peg_generator.
 PyAPI_FUNC(const PyConfig*) _Py_GetConfig(void);
 
 

--- a/Include/internal/pycore_runtime.h
+++ b/Include/internal/pycore_runtime.h
@@ -274,8 +274,8 @@ typedef struct pyruntimestate {
 
 PyAPI_DATA(_PyRuntimeState) _PyRuntime;
 
-PyAPI_FUNC(PyStatus) _PyRuntimeState_Init(_PyRuntimeState *runtime);
-PyAPI_FUNC(void) _PyRuntimeState_Fini(_PyRuntimeState *runtime);
+extern PyStatus _PyRuntimeState_Init(_PyRuntimeState *runtime);
+extern void _PyRuntimeState_Fini(_PyRuntimeState *runtime);
 
 #ifdef HAVE_FORK
 extern PyStatus _PyRuntimeState_ReInitThreads(_PyRuntimeState *runtime);
@@ -283,9 +283,9 @@ extern PyStatus _PyRuntimeState_ReInitThreads(_PyRuntimeState *runtime);
 
 /* Initialize _PyRuntimeState.
    Return NULL on success, or return an error message on failure. */
-PyAPI_FUNC(PyStatus) _PyRuntime_Initialize(void);
+extern PyStatus _PyRuntime_Initialize(void);
 
-PyAPI_FUNC(void) _PyRuntime_Finalize(void);
+extern void _PyRuntime_Finalize(void);
 
 
 static inline PyThreadState*

--- a/Include/internal/pycore_setobject.h
+++ b/Include/internal/pycore_setobject.h
@@ -8,12 +8,14 @@ extern "C" {
 #  error "this header requires Py_BUILD_CORE define"
 #endif
 
-// _pickle shared extension uses _PySet_NextEntry() and _PySet_Update()
+// Export for 'pickle' shared extension
 PyAPI_FUNC(int) _PySet_NextEntry(
     PyObject *set,
     Py_ssize_t *pos,
     PyObject **key,
     Py_hash_t *hash);
+
+// Export for 'pickle' shared extension
 PyAPI_FUNC(int) _PySet_Update(PyObject *set, PyObject *iterable);
 
 // Export _PySet_Dummy for the gdb plugin's benefit

--- a/Include/internal/pycore_signal.h
+++ b/Include/internal/pycore_signal.h
@@ -14,7 +14,8 @@ extern "C" {
 #include <signal.h>                // NSIG
 
 
-/* Restore signals that the interpreter has called SIG_IGN on to SIG_DFL. */
+// Restore signals that the interpreter has called SIG_IGN on to SIG_DFL.
+// Export for '_posixsubprocess' shared extension.
 PyAPI_FUNC(void) _Py_RestoreSignals(void);
 
 #ifdef _SIG_MAXSIG


### PR DESCRIPTION
No longer export these 50 internal C API functions:

* _PyArena_AddPyObject()
* _PyArena_Free()
* _PyArena_Malloc()
* _PyArena_New()
* _PyDict_CheckConsistency()
* _PyErr_ChainStackItem()
* _PyErr_CheckSignals()
* _PyErr_CheckSignalsTstate()
* _PyErr_Clear()
* _PyErr_ExceptionMatches()
* _PyErr_Fetch()
* _PyErr_Format()
* _PyErr_FormatFromCauseTstate()
* _PyErr_GetExcInfo()
* _PyErr_GetHandledException()
* _PyErr_GetTopmostException()
* _PyErr_NoMemory()
* _PyErr_NormalizeException()
* _PyErr_ProgramDecodedTextObject()
* _PyErr_Restore()
* _PyErr_SetHandledException()
* _PyErr_SetNone()
* _PyErr_SetObject()
* _PyErr_SetString()
* _PyErr_StackItemToExcInfoTuple()
* _PyExc_CreateExceptionGroup()
* _PyExc_PrepReraiseStar()
* _PyException_AddNote()
* _PyInterpreterState_Enable()
* _PyLong_FormatAdvancedWriter()
* _PyLong_FormatBytesWriter()
* _PyLong_FormatWriter()
* _PyMem_GetAllocatorName()
* _PyMem_SetDefaultAllocator()
* _PyMem_SetupAllocators()
* _PyOS_InterruptOccurred()
* _PyRuntimeState_Fini()
* _PyRuntimeState_Init()
* _PyRuntime_Finalize()
* _PyRuntime_Initialize()
* _PyState_AddModule()
* _PyThreadState_Bind()
* _PyThreadState_DeleteExcept()
* _PyThreadState_New()
* _PyThreadState_Swap()
* _PyType_CheckConsistency()
* _PyUnicodeTranslateError_Create()
* _Py_DumpExtensionModules()
* _Py_FatalErrorFormat()
* _Py_GetConfig()

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-107211 -->
* Issue: gh-107211
<!-- /gh-issue-number -->
