### PR TITLE
gh-107211: No longer export internal variables

### DIFF
--- a/Include/internal/pycore_import.h
+++ b/Include/internal/pycore_import.h
@@ -187,9 +187,13 @@ struct _module_alias {
     const char *orig;                 /* ASCII encoded string */
 };
 
-PyAPI_DATA(const struct _frozen *) _PyImport_FrozenBootstrap;
-PyAPI_DATA(const struct _frozen *) _PyImport_FrozenStdlib;
-PyAPI_DATA(const struct _frozen *) _PyImport_FrozenTest;
+// Export for test_ctypes
+PyAPI_DATA(const struct _frozen*) _PyImport_FrozenBootstrap;
+// Export for test_ctypes
+PyAPI_DATA(const struct _frozen*) _PyImport_FrozenStdlib;
+// Export for test_ctypes
+PyAPI_DATA(const struct _frozen*) _PyImport_FrozenTest;
+
 extern const struct _module_alias * _PyImport_FrozenAliases;
 
 extern int _PyImport_CheckSubinterpIncompatibleExtensionAllowed(
@@ -197,7 +201,7 @@ extern int _PyImport_CheckSubinterpIncompatibleExtensionAllowed(
 
 
 // Export for '_testinternalcapi' shared extension
-PyAPI_DATA(int) _PyImport_ClearExtension(PyObject *name, PyObject *filename);
+PyAPI_FUNC(int) _PyImport_ClearExtension(PyObject *name, PyObject *filename);
 
 #ifdef __cplusplus
 }

--- a/Include/internal/pycore_long.h
+++ b/Include/internal/pycore_long.h
@@ -83,8 +83,8 @@ extern PyObject *_PyLong_Add(PyLongObject *left, PyLongObject *right);
 extern PyObject *_PyLong_Multiply(PyLongObject *left, PyLongObject *right);
 extern PyObject *_PyLong_Subtract(PyLongObject *left, PyLongObject *right);
 
-/* Used by Python/mystrtoul.c, _PyBytes_FromHex(),
-   _PyBytes_DecodeEscape(), etc. */
+// Used by _PyBytes_FromHex(), _PyBytes_DecodeEscape(), Python/mystrtoul.c.
+// Export for 'binascii' shared extension.
 PyAPI_DATA(unsigned char) _PyLong_DigitValue[256];
 
 /* Format the object based on the format_spec, as defined in PEP 3101

--- a/Include/internal/pycore_object.h
+++ b/Include/internal/pycore_object.h
@@ -33,7 +33,7 @@ extern void _PyDebugAllocatorStats(FILE *out, const char *block_name,
 extern void _PyObject_DebugTypeStats(FILE *out);
 
 // Export for shared _testinternalcapi extension
-PyAPI_DATA(int) _PyObject_IsFreed(PyObject *);
+PyAPI_FUNC(int) _PyObject_IsFreed(PyObject *);
 
 /* We need to maintain an internal copy of Py{Var}Object_HEAD_INIT to avoid
    designated initializer conflicts in C++20. If we use the deinition in
@@ -468,11 +468,14 @@ extern PyObject* _PyCFunctionWithKeywords_TrampolineCall(
     (meth)((self), (args), (kw))
 #endif // __EMSCRIPTEN__ && PY_CALL_TRAMPOLINE
 
-// _pickle shared extension uses _PyNone_Type and _PyNotImplemented_Type
+// Export for '_pickle' shared extension
 PyAPI_DATA(PyTypeObject) _PyNone_Type;
+// Export for '_pickle' shared extension
 PyAPI_DATA(PyTypeObject) _PyNotImplemented_Type;
 
-/* Maps Py_LT to Py_GT, ..., Py_GE to Py_LE.  Defined in Objects/object.c. */
+// Maps Py_LT to Py_GT, ..., Py_GE to Py_LE.
+// Defined in Objects/object.c.
+// Export for the stable ABI.
 PyAPI_DATA(int) _Py_SwappedOp[];
 
 #ifdef __cplusplus

--- a/Include/internal/pycore_pyhash.h
+++ b/Include/internal/pycore_pyhash.h
@@ -74,7 +74,7 @@ typedef union {
     } expat;
 } _Py_HashSecret_t;
 
-// _elementtree shared extension uses _Py_HashSecret.expat
+// Export for '_elementtree' shared extension
 PyAPI_DATA(_Py_HashSecret_t) _Py_HashSecret;
 
 #ifdef Py_DEBUG

--- a/Include/internal/pycore_pystate.h
+++ b/Include/internal/pycore_pystate.h
@@ -66,7 +66,7 @@ _Py_ThreadCanHandleSignals(PyInterpreterState *interp)
 #if defined(HAVE_THREAD_LOCAL) && !defined(Py_BUILD_CORE_MODULE)
 extern _Py_thread_local PyThreadState *_Py_tss_tstate;
 #endif
-PyAPI_DATA(PyThreadState *) _PyThreadState_GetCurrent(void);
+PyAPI_FUNC(PyThreadState *) _PyThreadState_GetCurrent(void);
 
 /* Get the current Python thread state.
 

--- a/Include/internal/pycore_typeobject.h
+++ b/Include/internal/pycore_typeobject.h
@@ -129,18 +129,17 @@ _PyType_IsReady(PyTypeObject *type)
     return _PyType_GetDict(type) != NULL;
 }
 
-PyObject *
-_Py_type_getattro_impl(PyTypeObject *type, PyObject *name, int *suppress_missing_attribute);
-PyObject *
-_Py_type_getattro(PyTypeObject *type, PyObject *name);
+extern PyObject* _Py_type_getattro_impl(PyTypeObject *type, PyObject *name,
+                                        int *suppress_missing_attribute);
+extern PyObject* _Py_type_getattro(PyTypeObject *type, PyObject *name);
 
-PyObject *_Py_slot_tp_getattro(PyObject *self, PyObject *name);
-PyObject *_Py_slot_tp_getattr_hook(PyObject *self, PyObject *name);
+extern PyObject* _Py_slot_tp_getattro(PyObject *self, PyObject *name);
+extern PyObject* _Py_slot_tp_getattr_hook(PyObject *self, PyObject *name);
 
-PyAPI_DATA(PyTypeObject) _PyBufferWrapper_Type;
+extern PyTypeObject _PyBufferWrapper_Type;
 
-PyObject *
-_PySuper_Lookup(PyTypeObject *su_type, PyObject *su_obj, PyObject *name, int *meth_found);
+extern PyObject* _PySuper_Lookup(PyTypeObject *su_type, PyObject *su_obj,
+                                 PyObject *name, int *meth_found);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
No longer export these 5 internal C API variables:

* _PyBufferWrapper_Type
* _PyImport_FrozenBootstrap
* _PyImport_FrozenStdlib
* _PyImport_FrozenTest
* _Py_SwappedOp

Fix definition of these internal functions, replace PyAPI_DATA() with PyAPI_FUNC():

* _PyImport_ClearExtension()
* _PyObject_IsFreed()
* _PyThreadState_GetCurrent()

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-107211 -->
* Issue: gh-107211
<!-- /gh-issue-number -->
