### PR TITLE
gh-107226: PyModule_AddObjectRef() should only be in the limited API 3.10

### DIFF
--- a/Include/modsupport.h
+++ b/Include/modsupport.h
@@ -22,10 +22,12 @@ PyAPI_FUNC(int) PyArg_UnpackTuple(PyObject *, const char *, Py_ssize_t, Py_ssize
 PyAPI_FUNC(PyObject *) Py_BuildValue(const char *, ...);
 PyAPI_FUNC(PyObject *) Py_VaBuildValue(const char *, va_list);
 
+#if !defined(Py_LIMITED_API) || Py_LIMITED_API+0 >= 0x030a0000
 // Add an attribute with name 'name' and value 'obj' to the module 'mod.
 // On success, return 0.
 // On error, raise an exception and return -1.
 PyAPI_FUNC(int) PyModule_AddObjectRef(PyObject *mod, const char *name, PyObject *value);
+#endif   /* Py_LIMITED_API */
 
 #if !defined(Py_LIMITED_API) || Py_LIMITED_API+0 >= 0x030d0000
 // Similar to PyModule_AddObjectRef() but steal a reference to 'value'.

--- a/Misc/NEWS.d/next/C API/2023-07-25-13-41-09.gh-issue-107226.N919zH.rst
+++ b/Misc/NEWS.d/next/C API/2023-07-25-13-41-09.gh-issue-107226.N919zH.rst
@@ -1,0 +1,2 @@
+:c:func:`PyModule_AddObjectRef` is now only available in the limited API
+version 3.10 or later.


### PR DESCRIPTION


<!-- gh-issue-number: gh-107226 -->
* Issue: gh-107226
<!-- /gh-issue-number -->
