### PR TITLE
gh-106004: PyDict_GetItemRef() should only be in the limited API 3.13

### DIFF
--- a/Include/dictobject.h
+++ b/Include/dictobject.h
@@ -58,6 +58,7 @@ PyAPI_FUNC(PyObject *) PyDict_GetItemString(PyObject *dp, const char *key);
 PyAPI_FUNC(int) PyDict_SetItemString(PyObject *dp, const char *key, PyObject *item);
 PyAPI_FUNC(int) PyDict_DelItemString(PyObject *dp, const char *key);
 
+#if !defined(Py_LIMITED_API) || Py_LIMITED_API+0 >= 0x030D0000
 // Return the object from dictionary *op* which has a key *key*.
 // - If the key is present, set *result to a new strong reference to the value
 //   and return 1.
@@ -65,6 +66,7 @@ PyAPI_FUNC(int) PyDict_DelItemString(PyObject *dp, const char *key);
 // - On error, raise an exception and return -1.
 PyAPI_FUNC(int) PyDict_GetItemRef(PyObject *mp, PyObject *key, PyObject **result);
 PyAPI_FUNC(int) PyDict_GetItemStringRef(PyObject *mp, const char *key, PyObject **result);
+#endif
 
 #if !defined(Py_LIMITED_API) || Py_LIMITED_API+0 >= 0x030A0000
 PyAPI_FUNC(PyObject *) PyObject_GenericGetDict(PyObject *, void *);


### PR DESCRIPTION


<!-- gh-issue-number: gh-106004 -->
* Issue: gh-106004
<!-- /gh-issue-number -->
