### PR TITLE
gh-105059: Use GCC/clang extension for PyObject union

### DIFF
--- a/Include/object.h
+++ b/Include/object.h
@@ -165,6 +165,11 @@ check by comparing the reference count field to the immortality reference count.
  */
 struct _object {
     _PyObject_HEAD_EXTRA
+#if (defined(__GNUC__) || defined(__clang__)) \
+        && !(defined __STDC_VERSION__ && __STDC_VERSION__ >= 201112L)
+    // On C99 and older, anonymous union is a GCC and clang extension
+    __extension__
+#endif
     union {
        Py_ssize_t ob_refcnt;
 #if SIZEOF_VOID_P > 4


### PR DESCRIPTION
Anonymous union is new in C11. To prevent compiler warning, use Clang and GCC extension on C99 and older.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-105059 -->
* Issue: gh-105059
<!-- /gh-issue-number -->
