### PR TITLE
[3.11] GH-97950: Fix old-style index directive in Doc/library/imp.rst

### DIFF
--- a/Doc/library/imp.rst
+++ b/Doc/library/imp.rst
@@ -10,7 +10,7 @@
 .. deprecated-removed:: 3.4 3.12
    The :mod:`imp` module is deprecated in favor of :mod:`importlib`.
 
-.. index:: statement: import
+.. index:: pair: statement; import
 
 --------------
 


### PR DESCRIPTION
I found the following message when building 3.11 doc:
```
Warning, treated as error:
'statement' is deprecated for index entries (from entry 'statement: import'). Use 'pair: statement; import' instead.
```
It's part of https://github.com/sphinx-doc/sphinx/pull/11412 and was released with sphinx 7.1.0 yesterday.

@AA-Turner resolved most issues in #104162 (and its 3.11 backport PR is #104163). However, `imp` module was removed in 3.12 before that and the old index directive in `library/imp.rst` seems to be omitted.

<!-- gh-issue-number: gh-97950 -->
* Issue: gh-97950
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--107246.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->