### PR TITLE
gh-91507: [dataclasses] preserve the order of __post_init__ kwargs

### DIFF
--- a/Lib/test/test_dataclasses.py
+++ b/Lib/test/test_dataclasses.py
@@ -1277,6 +1277,25 @@ class TestCase(unittest.TestCase):
         c = C(init_param=10)
         self.assertEqual(c.x, 20)
 
+    def test_init_var_order(self):
+        @dataclass
+        class C:
+            expected_field_42: int = None
+            init_var_24: InitVar[int] = None
+
+            expected_field_24: int = None
+            init_var_42: InitVar[int] = None
+
+
+            def __post_init__(self, init_var_42, init_var_24):
+                self.expected_field_42 = init_var_42
+                self.expected_field_24 = init_var_24
+
+        c = C(init_var_24=24, init_var_42=42)
+        self.assertEqual(c.expected_field_42, 42)
+        self.assertEqual(c.expected_field_24, 24)
+
+
     def test_init_var_preserve_type(self):
         self.assertEqual(InitVar[int].type, int)
 

--- a/Lib/test/test_dataclasses.py
+++ b/Lib/test/test_dataclasses.py
@@ -525,7 +525,7 @@ class TestCase(unittest.TestCase):
         self.assertEqual(C(5).x, 5)
 
         with self.assertRaisesRegex(TypeError,
-                                    r"__init__\(\) missing 1 required "
+                                    r"__main_init__\(\) missing 1 required "
                                     "positional argument: 'x'"):
             C()
 
@@ -926,7 +926,7 @@ class TestCase(unittest.TestCase):
         class C:
             x: int=field(default=MISSING)
         with self.assertRaisesRegex(TypeError,
-                                    r'__init__\(\) missing 1 required '
+                                    r'__main_init__\(\) missing 1 required '
                                     'positional argument'):
             C()
         self.assertNotIn('x', C.__dict__)
@@ -935,7 +935,7 @@ class TestCase(unittest.TestCase):
         class D:
             x: int
         with self.assertRaisesRegex(TypeError,
-                                    r'__init__\(\) missing 1 required '
+                                    r'__main_init__\(\) missing 1 required '
                                     'positional argument'):
             D()
         self.assertNotIn('x', D.__dict__)
@@ -948,7 +948,7 @@ class TestCase(unittest.TestCase):
         class C:
             x: int=field(default_factory=MISSING)
         with self.assertRaisesRegex(TypeError,
-                                    r'__init__\(\) missing 1 required '
+                                    r'__main_init__\(\) missing 1 required '
                                     'positional argument'):
             C()
         self.assertNotIn('x', C.__dict__)
@@ -957,7 +957,7 @@ class TestCase(unittest.TestCase):
         class D:
             x: int=field(default=MISSING, default_factory=MISSING)
         with self.assertRaisesRegex(TypeError,
-                                    r'__init__\(\) missing 1 required '
+                                    r'__main_init__\(\) missing 1 required '
                                     'positional argument'):
             D()
         self.assertNotIn('x', D.__dict__)
@@ -2189,7 +2189,7 @@ class TestCase(unittest.TestCase):
         ):
             self.assertEqual(getattr(A, function).__qualname__, f"TestCase.test_dataclasses_qualnames.<locals>.A.{function}")
 
-        with self.assertRaisesRegex(TypeError, r"A\.__init__\(\) missing"):
+        with self.assertRaisesRegex(TypeError, r"A\.__main_init__\(\) missing"):
             A()
 
 
@@ -3058,7 +3058,7 @@ class TestSlots(unittest.TestCase):
         #  also have a default value (of type
         #  types.MemberDescriptorType).
         with self.assertRaisesRegex(TypeError,
-                                    r"__init__\(\) missing 1 required positional argument: 'x'"):
+                                    r"__main_init__\(\) missing 1 required positional argument: 'x'"):
             C()
 
         # We can create an instance, and assign to x.
@@ -3998,7 +3998,7 @@ class TestReplace(unittest.TestCase):
         #  if we're also replacing one that does exist.  Test this
         #  here, because setting attributes on frozen instances is
         #  handled slightly differently from non-frozen ones.
-        with self.assertRaisesRegex(TypeError, r"__init__\(\) got an unexpected "
+        with self.assertRaisesRegex(TypeError, r"__main_init__\(\) got an unexpected "
                                              "keyword argument 'a'"):
             c1 = replace(c, x=20, a=5)
 
@@ -4009,7 +4009,7 @@ class TestReplace(unittest.TestCase):
             y: int
 
         c = C(1, 2)
-        with self.assertRaisesRegex(TypeError, r"__init__\(\) got an unexpected "
+        with self.assertRaisesRegex(TypeError, r"__main_init__\(\) got an unexpected "
                                     "keyword argument 'z'"):
             c1 = replace(c, z=3)
 
@@ -4058,7 +4058,7 @@ class TestReplace(unittest.TestCase):
         self.assertEqual(c.y, 1000)
 
         # Trying to replace y is an error: can't replace ClassVars.
-        with self.assertRaisesRegex(TypeError, r"__init__\(\) got an "
+        with self.assertRaisesRegex(TypeError, r"__main_init__\(\) got an "
                                     "unexpected keyword argument 'y'"):
             replace(c, y=30)
 
@@ -4379,7 +4379,7 @@ class TestKeywordArgs(unittest.TestCase):
             b: int
             c: int
         A(3, c=5, b=4)
-        msg = "takes 2 positional arguments but 4 were given"
+        msg = "takes 4 positional arguments but 6 were given"
         with self.assertRaisesRegex(TypeError, msg):
             A(3, 4, 5)
 
@@ -4391,7 +4391,7 @@ class TestKeywordArgs(unittest.TestCase):
             b: int
             c: int
         B(a=3, b=4, c=5)
-        msg = "takes 1 positional argument but 4 were given"
+        msg = "takes 3 positional argument but 6 were given"
         with self.assertRaisesRegex(TypeError, msg):
             B(3, 4, 5)
 
@@ -4427,7 +4427,7 @@ class TestKeywordArgs(unittest.TestCase):
             b: int
             c: int
         A(3, c=5, b=4)
-        msg = "takes 2 positional arguments but 4 were given"
+        msg = "takes 4 positional arguments but 6 were given"
         with self.assertRaisesRegex(TypeError, msg):
             A(3, 4, 5)
 


### PR DESCRIPTION
## Scope

These changes fix the problem described in https://github.com/python/cpython/issues/91507.
The issue was marked as closed but not solved and contains a very relevant discussion.

## In-depth

* [First commit](https://github.com/python/cpython/commit/e94c6c56b06186f1060768406da67be096f35a2e) implements a test to show the problem. The arguments are passed as `kwargs`, but the order is ignored, and the values are assigned unexpectedly.
* [Second commit](https://github.com/python/cpython/commit/7925897ccf1d9513063d4f61633254ad784e2afa) with the fix. After reading a discussion on the issue, both options from the @ericvsmith's  [comment](https://github.com/python/cpython/issues/91507#issuecomment-1098952559) sounded a little bit hacky. Therefore I decided to propose another solution that keeps the compatibility intact. The solution is the change `__init__` method to accept `*args, **kwargs` and move the content of the old implementation to a new `__main_init__`.
* [Last commit](https://github.com/python/cpython/commit/b8ac712fdc7ac6c61b72e4396a9942ceee1ed236) fixes most of the tests. I didn't fix all tests before I understood the proposed solution was appropriate. I decided to fix most of them to highlight the interface changes.

### Side note

Thanks for any guidance and advice.
I'm free to implement suggestions or close this PR if the proposed solution is unacceptable.
I'll sign CLA right after a review.

Best wishes,
Sergei

<!-- gh-issue-number: gh-91507 -->
* Issue: gh-91507
<!-- /gh-issue-number -->
