### PR TITLE
gh-107249: Implement Py_UNUSED() for MSVC

### DIFF
--- a/Include/pymacro.h
+++ b/Include/pymacro.h
@@ -118,6 +118,15 @@
  */
 #if defined(__GNUC__) || defined(__clang__)
 #  define Py_UNUSED(name) _unused_ ## name __attribute__((unused))
+#elif defined(_MSC_VER)
+   // Disable warning C4100: unreferenced formal parameter,
+   // declare the parameter,
+   // restore old compiler warnings.
+#  define Py_UNUSED(name) \
+        __pragma(warning(push)) \
+        __pragma(warning(suppress: 4100)) \
+        _unused_ ## name \
+        __pragma(warning(pop))
 #else
 #  define Py_UNUSED(name) _unused_ ## name
 #endif

--- a/Misc/NEWS.d/next/C API/2023-07-25-17-23-08.gh-issue-107249.xqk2ke.rst
+++ b/Misc/NEWS.d/next/C API/2023-07-25-17-23-08.gh-issue-107249.xqk2ke.rst
@@ -1,0 +1,2 @@
+Implement the :c:macro:`Py_UNUSED` macro for Windows MSVC compiler. Patch by
+Victor Stinner.


### PR DESCRIPTION
Fix warnings C4100 in Py_UNUSED() when Python is built with "cl /W4".

Example with this function included by Python.h:

    static inline unsigned int
    PyUnicode_IS_READY(PyObject* Py_UNUSED(op))
    { return 1; }

Without this change, building a C program with "cl /W4" which just includes Python.h emits the warning:

    Include\cpython/unicodeobject.h(199):
    warning C4100: '_unused_op': unreferenced formal parameter

This change fix this warning.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-107249 -->
* Issue: gh-107249
<!-- /gh-issue-number -->
