### PR TITLE
[3.12] Remove superflous whitespaces in `layout.html`. (GH-107067)

### DIFF
--- a/Doc/tools/templates/layout.html
+++ b/Doc/tools/templates/layout.html
@@ -4,16 +4,16 @@
 {%- if outdated %}
 <div id="outdated-warning" style="padding: .5em; text-align: center; background-color: #FFBABA; color: #6A0E0E;">
     {% trans %}This document is for an old version of Python that is no longer supported.
-    You should upgrade, and read the {% endtrans %}
-    <a href="/3/{{ pagename }}{{ file_suffix }}">{% trans %} Python documentation for the current stable release{% endtrans %}</a>.
+    You should upgrade, and read the{% endtrans %}
+    <a href="/3/{{ pagename }}{{ file_suffix }}">{% trans %}Python documentation for the current stable release{% endtrans %}</a>.
 </div>
 {%- endif %}
 
 {%- if is_deployment_preview %}
 <div id="deployment-preview-warning" style="padding: .5em; text-align: center; background-color: #fff2ba; color: #6a580e;">
   {% trans %}This is a deploy preview created from a <a href="{{ repository_url }}/pull/{{ pr_id }}">pull request</a>.
-  For authoritative documentation, see the {% endtrans %}
-  <a href="https://docs.python.org/3/{{ pagename }}{{ file_suffix }}">{% trans %} the current stable release{% endtrans %}</a>.
+  For authoritative documentation, see{% endtrans %}
+  <a href="https://docs.python.org/3/{{ pagename }}{{ file_suffix }}">{% trans %}the current stable release{% endtrans %}</a>.
 </div>
 {%- endif %}
 {% endblock %}


### PR DESCRIPTION
This is a backport of #107067.  It also includes [part of #104100](https://github.com/python/cpython/commit/c3204ed72755042f4727754903e9e6d53b424bb1#diff-abd77e29f1ff6d74ae538e4c07866587819a5c838e138b76c15ce8a402309a5aR15) to avoid conflicts caused by an extra "the".

<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--107251.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->