### PR TITLE
gh-107082: Fix instruction size computation for ENTER_EXECUTOR

### DIFF
--- a/Python/instrumentation.c
+++ b/Python/instrumentation.c
@@ -277,7 +277,8 @@ _PyInstruction_GetLength(PyCodeObject *code, int offset)
     assert(opcode != 0);
     assert(!is_instrumented(opcode));
     if (opcode == ENTER_EXECUTOR) {
-        _PyExecutorObject *exec = code->co_executors->executors[_PyCode_CODE(code)[offset].op.arg];
+        int exec_index = _PyCode_CODE(code)[offset].op.arg;
+        _PyExecutorObject *exec = code->co_executors->executors[exec_index];
         opcode = exec->vm_data.opcode;
 
     }

--- a/Python/instrumentation.c
+++ b/Python/instrumentation.c
@@ -276,6 +276,12 @@ _PyInstruction_GetLength(PyCodeObject *code, int offset)
     }
     assert(opcode != 0);
     assert(!is_instrumented(opcode));
+    if (opcode == ENTER_EXECUTOR) {
+        _PyExecutorObject *exec = code->co_executors->executors[_PyCode_CODE(code)[offset].op.arg];
+        opcode = exec->vm_data.opcode;
+
+    }
+    assert(opcode != ENTER_EXECUTOR);
     assert(opcode == _PyOpcode_Deopt[opcode]);
     return 1 + _PyOpcode_Caches[opcode];
 }


### PR DESCRIPTION
If this fixes the big-endian buildbots it should also fix gh-107083.

<!-- gh-issue-number: gh-107082 -->
* Issue: gh-107082
<!-- /gh-issue-number -->
