### PR TITLE
gh-77377: Ensure multiprocessing SemLock is valid for spawn-based Process before serializing it

### DIFF
--- a/Lib/multiprocessing/synchronize.py
+++ b/Lib/multiprocessing/synchronize.py
@@ -50,8 +50,8 @@ class SemLock(object):
     def __init__(self, kind, value, maxvalue, *, ctx):
         if ctx is None:
             ctx = context._default_context.get_context()
-        name = ctx.get_start_method()
-        unlink_now = sys.platform == 'win32' or name == 'fork'
+        self.is_fork_ctx = ctx.get_start_method() == 'fork'
+        unlink_now = sys.platform == 'win32' or self.is_fork_ctx
         for i in range(100):
             try:
                 sl = self._semlock = _multiprocessing.SemLock(
@@ -103,6 +103,11 @@ class SemLock(object):
         if sys.platform == 'win32':
             h = context.get_spawning_popen().duplicate_for_child(sl.handle)
         else:
+            if self.is_fork_ctx:
+                raise RuntimeError('A SemLock created in a fork context is being '
+                                   'shared with a process in a spawn context. This is '
+                                   'not supported. Please use the same context to create '
+                                   'multiprocessing objects and Process.')
             h = sl.handle
         return (h, sl.kind, sl.maxvalue, sl.name)
 

--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -6201,3 +6201,9 @@ class SemLockTests(unittest.TestCase):
         name = f'test_semlock_subclass-{os.getpid()}'
         s = SemLock(1, 0, 10, name, False)
         _multiprocessing.sem_unlink(name)
+
+    def test_semlock_mixed_context(self):
+        queue = multiprocessing.get_context("fork").Queue()
+        p = multiprocessing.get_context("spawn").Process(target=close_queue, args=(queue,))
+        with self.assertRaisesRegex(RuntimeError, "A SemLock created in a fork"):
+            p.start()

--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -5421,21 +5421,25 @@ class TestStartMethod(unittest.TestCase):
             print(err)
             self.fail("failed spawning forkserver or grandchild")
 
-    @unittest.skipIf(sys.platform == "win32", "Only Spawn on windows so no risk of mixing")
-    @only_run_in_spawn_testsuite("avoids redundant testing since we ignore the global context.")
+    @unittest.skipIf(sys.platform == "win32",
+                     "Only Spawn on windows so no risk of mixing")
+    @only_run_in_spawn_testsuite("avoids redundant testing.")
     def test_mixed_startmethod(self):
         # Fork-based locks cannot be used with spawned process
         for process_method in ["spawn", "forkserver"]:
             queue = multiprocessing.get_context("fork").Queue()
-            p = multiprocessing.get_context(process_method).Process(target=close_queue, args=(queue,))
-            with self.assertRaisesRegex(RuntimeError, "A SemLock created in a fork"):
+            process_ctx = multiprocessing.get_context(process_method)
+            p = process_ctx.Process(target=close_queue, args=(queue,))
+            err_msg = "A SemLock created in a fork"
+            with self.assertRaisesRegex(RuntimeError, err_msg):
                 p.start()
 
         # non-fork-based locks can be used with all other start methods
         for queue_method in ["spawn", "forkserver"]:
             for process_method in multiprocessing.get_all_start_methods():
                 queue = multiprocessing.get_context(queue_method).Queue()
-                p = multiprocessing.get_context(process_method).Process(target=close_queue, args=(queue,))
+                process_ctx = multiprocessing.get_context(process_method)
+                p = process_ctx.Process(target=close_queue, args=(queue,))
                 p.start()
                 p.join()
 

--- a/Misc/NEWS.d/next/Core and Builtins/2023-07-25-22-35-35.gh-issue-77377.EHAbXx.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2023-07-25-22-35-35.gh-issue-77377.EHAbXx.rst
@@ -1,0 +1,1 @@
+Ensure that multiprocessing SemLock object created in a fork context are not send to a different process created in a spawn context. This changes changes a segfault into an actionable RuntimeError in the parent process.

--- a/Misc/NEWS.d/next/Core and Builtins/2023-07-25-22-35-35.gh-issue-77377.EHAbXx.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2023-07-25-22-35-35.gh-issue-77377.EHAbXx.rst
@@ -1,1 +1,1 @@
-Ensure that multiprocessing SemLock object created in a fork context are not send to a different process created in a spawn context. This changes changes a segfault into an actionable RuntimeError in the parent process.
+Ensure that multiprocessing synchronization objects created in a fork context are not sent to a different process created in a spawn context. This changes a segfault into an actionable RuntimeError in the parent process.


### PR DESCRIPTION
This fixes both the example in the initial report https://github.com/python/cpython/issues/77377 and other reports on the PyTorch repo.

Note that as far as I can tell, all objects that lead to segfault with mixed context are all caused by SemLock created with fork sent over a Spawn process. That's why it is the only object updated here and the only pair of ctx covered. Let me know if I'm mistaken and I can find a way to update other objects as well.
Also windows behavior is not changed here (and thus not tested).

Please let me know if the error message and/or the test are not appropriate and I can work on improving them.

<!-- gh-issue-number: gh-77377 -->
* Issue: gh-77377
<!-- /gh-issue-number -->
