### PR TITLE
gh-107279 Add `<stddef.h>` to `Modules/zlibmodule.c` to fix failing builds

### DIFF
--- a/Modules/zlibmodule.c
+++ b/Modules/zlibmodule.c
@@ -7,6 +7,7 @@
 
 #include "zlib.h"
 #include "stdbool.h"
+#include <stddef.h>               // offsetof()
 
 #if defined(ZLIB_VERNUM) && ZLIB_VERNUM < 0x1221
 #error "At least zlib version 1.2.2.1 is required"


### PR DESCRIPTION
See the message in commit 733d38c1085288af11e975cb40ec2e3cc7619e6d for a quick overview. 

Essentially, it looks like #106871 updated some internal C implementations, but missed adding `<stddef.h>` to the `Modules/zlibmodule.c` file. I noticed this when looking at the output of the build after commit fabcbe9c12688eb9a902a5c89cb720ed373625c5 was merged, and the following 2 commits (6a43cce32b66e0f66992119dd82959069b6f324a and 2b1a81e2cfa740609d48ad82627ae251262e6470) also failed with the same error.

Interestingly, not all platforms seem to fail because of this omission. In commit 2b1a81e2cfa740609d48ad82627ae251262e6470, for example:
- [AMD64 RHEL7 3.x](https://buildbot.python.org/all/#/builders/15/builds/5219) DOES NOT compile
- [AMD64 Debian PGO 3.x](https://buildbot.python.org/all/#/builders/249/builds/5842) DOES compile

This seems a odd to me, but I'm not familiar enough with the CI/build process to offer a suggestion for this discrepancy between platforms.

<!-- gh-issue-number: gh-107279 -->
* Issue: gh-107279
<!-- /gh-issue-number -->
