### PR TITLE
gh-76913: Add "merge extras" feature to LoggerAdapter

### DIFF
--- a/Doc/library/logging.rst
+++ b/Doc/library/logging.rst
@@ -984,10 +984,14 @@ LoggerAdapter Objects
 information into logging calls. For a usage example, see the section on
 :ref:`adding contextual information to your logging output <context-info>`.
 
-.. class:: LoggerAdapter(logger, extra)
+.. class:: LoggerAdapter(logger, extra, merge_extra=False)
 
    Returns an instance of :class:`LoggerAdapter` initialized with an
-   underlying :class:`Logger` instance and a dict-like object.
+   underlying :class:`Logger` instance, a dict-like object (*extra*), and a
+   boolean (*merge_extra*) indicating whether or not the *extra* argument of
+   individual log calls should be merged with the :class:`LoggerAdapter` extra.
+   The default behavior is to ignore the *extra* argument of individual log
+   calls and only use the one of the :class:`LoggerAdapter` instance
 
    .. method:: process(msg, kwargs)
 
@@ -1018,6 +1022,9 @@ interchangeably.
 .. versionchanged:: 3.13
    Remove the undocumented ``warn()`` method which was an alias to the
    ``warning()`` method.
+
+.. versionchanged:: 3.13
+   The *merge_extra* argument was added.
 
 
 Thread Safety

--- a/Lib/logging/__init__.py
+++ b/Lib/logging/__init__.py
@@ -1899,7 +1899,7 @@ class LoggerAdapter(object):
         over the LoggerAdapter instance extra
 
         .. versionchanged:: 3.13
-           Added the ``merge_extras`` parameter.
+           The *merge_extra* argument was added.
         """
         self.logger = logger
         self.extra = extra

--- a/Lib/logging/__init__.py
+++ b/Lib/logging/__init__.py
@@ -1915,7 +1915,7 @@ class LoggerAdapter(object):
         Normally, you'll only need to override this one method in a
         LoggerAdapter subclass for your specific needs.
         """
-        if self.merge_extras and "extra" in kwargs:
+        if self.merge_extra and "extra" in kwargs:
             kwargs["extra"] = {**self.extra, **kwargs["extra"]}
         else:
             kwargs["extra"] = self.extra

--- a/Lib/logging/__init__.py
+++ b/Lib/logging/__init__.py
@@ -1880,9 +1880,7 @@ class LoggerAdapter(object):
     information in logging output.
     """
 
-    merge_extras = False
-
-    def __init__(self, logger, extra=None, merge_extras=None):
+    def __init__(self, logger, extra=None, merge_extras=False):
         """
         Initialize the adapter with a logger and a dict-like object which
         provides contextual information. This constructor signature allows
@@ -1897,7 +1895,7 @@ class LoggerAdapter(object):
         passed on the individual log calls to use its own instead.
 
         Initializing it with merge_extras=True will instead merge both
-        maps when logging, the indivicual call extra taking precedence
+        maps when logging, the individual call extra taking precedence
         over the LoggerAdapter instance extra
 
         .. versionchanged:: 3.13
@@ -1905,8 +1903,7 @@ class LoggerAdapter(object):
         """
         self.logger = logger
         self.extra = extra
-        if merge_extras is not None:
-            self.merge_extras = merge_extras
+        self.merge_extras = merge_extras
 
     def process(self, msg, kwargs):
         """

--- a/Lib/logging/__init__.py
+++ b/Lib/logging/__init__.py
@@ -1880,7 +1880,7 @@ class LoggerAdapter(object):
     information in logging output.
     """
 
-    def __init__(self, logger, extra=None, merge_extras=False):
+    def __init__(self, logger, extra=None, merge_extra=False):
         """
         Initialize the adapter with a logger and a dict-like object which
         provides contextual information. This constructor signature allows
@@ -1894,7 +1894,7 @@ class LoggerAdapter(object):
         By default, LoggerAdapter objects will drop the "extra" argument
         passed on the individual log calls to use its own instead.
 
-        Initializing it with merge_extras=True will instead merge both
+        Initializing it with merge_extra=True will instead merge both
         maps when logging, the individual call extra taking precedence
         over the LoggerAdapter instance extra
 
@@ -1903,7 +1903,7 @@ class LoggerAdapter(object):
         """
         self.logger = logger
         self.extra = extra
-        self.merge_extras = merge_extras
+        self.merge_extra = merge_extra
 
     def process(self, msg, kwargs):
         """

--- a/Lib/test/test_logging.py
+++ b/Lib/test/test_logging.py
@@ -5452,7 +5452,7 @@ class LoggerAdapterTest(unittest.TestCase):
     def test_extra_merged(self):
         self.adapter = logging.LoggerAdapter(logger=self.logger,
                                              extra={'foo': '1'},
-                                             merge_extras=True)
+                                             merge_extra=True)
 
         self.adapter.critical('foo and bar should be here', extra={'bar': '2'})
         self.assertEqual(len(self.recording.records), 1)
@@ -5465,7 +5465,7 @@ class LoggerAdapterTest(unittest.TestCase):
     def test_extra_merged_log_call_has_precedence(self):
         self.adapter = logging.LoggerAdapter(logger=self.logger,
                                              extra={'foo': '1'},
-                                             merge_extras=True)
+                                             merge_extra=True)
 
         self.adapter.critical('foo shall be min', extra={'foo': '2'})
         self.assertEqual(len(self.recording.records), 1)

--- a/Lib/test/test_logging.py
+++ b/Lib/test/test_logging.py
@@ -5433,6 +5433,46 @@ class LoggerAdapterTest(unittest.TestCase):
         self.assertIs(adapter.manager, orig_manager)
         self.assertIs(self.logger.manager, orig_manager)
 
+    def test_extra_in_records(self):
+        self.adapter = logging.LoggerAdapter(logger=self.logger,
+                                             extra={'foo': '1'})
+
+        self.adapter.critical('foo should be here')
+        self.assertEqual(len(self.recording.records), 1)
+        record = self.recording.records[0]
+        self.assertTrue(hasattr(record, 'foo'))
+        self.assertEqual(record.foo, '1')
+
+    def test_extra_not_merged_by_default(self):
+        self.adapter.critical('foo should NOT be here', extra={'foo': 'nope'})
+        self.assertEqual(len(self.recording.records), 1)
+        record = self.recording.records[0]
+        self.assertFalse(hasattr(record, 'foo'))
+
+    def test_extra_merged(self):
+        self.adapter = logging.LoggerAdapter(logger=self.logger,
+                                             extra={'foo': '1'},
+                                             merge_extras=True)
+
+        self.adapter.critical('foo and bar should be here', extra={'bar': '2'})
+        self.assertEqual(len(self.recording.records), 1)
+        record = self.recording.records[0]
+        self.assertTrue(hasattr(record, 'foo'))
+        self.assertTrue(hasattr(record, 'bar'))
+        self.assertEqual(record.foo, '1')
+        self.assertEqual(record.bar, '2')
+
+    def test_extra_merged_log_call_has_precedence(self):
+        self.adapter = logging.LoggerAdapter(logger=self.logger,
+                                             extra={'foo': '1'},
+                                             merge_extras=True)
+
+        self.adapter.critical('foo shall be min', extra={'foo': '2'})
+        self.assertEqual(len(self.recording.records), 1)
+        record = self.recording.records[0]
+        self.assertTrue(hasattr(record, 'foo'))
+        self.assertEqual(record.foo, '2')
+
 
 class LoggerTest(BaseTest, AssertErrorMessage):
 

--- a/Misc/NEWS.d/next/Library/2023-08-14-17-15-59.gh-issue-76913.LLD0rT.rst
+++ b/Misc/NEWS.d/next/Library/2023-08-14-17-15-59.gh-issue-76913.LLD0rT.rst
@@ -1,0 +1,1 @@
+Add *merge_extra* parameter/feature to :class:`logging.LoggerAdapter`


### PR DESCRIPTION
By default, LoggerAdapter objects ignores all `extra=` parameter used in the individual log methods, which may be confusing for some users.

This commit is aimed at adding an option in the LoggerAdapter class to allow instances / subclasses to merge both the adapter and individual log call extra into a single entry

The default behavior is not changed

For example:

```
log = LoggerAdapter(..., extra={"component": "XYZ"})
log.info("return %r" % ret, extra={"duration": elapsed})
```

<!-- gh-issue-number: gh-76913 -->
* Issue: gh-76913
<!-- /gh-issue-number -->
