### PR TITLE
gh-106948: Update documentation nitpick_ignore for c:identifer domain

### DIFF
--- a/Doc/conf.py
+++ b/Doc/conf.py
@@ -153,6 +153,15 @@ nitpick_ignore = [
     ('py:meth', '_SubParsersAction.add_parser'),
 ]
 
+# gh-106948: Copy standard C types declared in the "c:type" domain to the
+# "c:identifier" domain, since "c:function" markup looks for types in the
+# "c:identifier" domain. Use list() to not iterate on items which are being
+# added
+for role, name in list(nitpick_ignore):
+    if role == 'c:type':
+        nitpick_ignore.append(('c:identifier', name))
+del role, name
+
 # Disable Docutils smartquotes for several translations
 smartquotes_excludes = {
     'languages': ['ja', 'fr', 'zh_TW', 'zh_CN'], 'builders': ['man', 'text'],

--- a/Doc/tools/.nitignore
+++ b/Doc/tools/.nitignore
@@ -8,7 +8,6 @@ Doc/c-api/arg.rst
 Doc/c-api/bool.rst
 Doc/c-api/buffer.rst
 Doc/c-api/bytes.rst
-Doc/c-api/call.rst
 Doc/c-api/capsule.rst
 Doc/c-api/cell.rst
 Doc/c-api/code.rst
@@ -26,8 +25,6 @@ Doc/c-api/init.rst
 Doc/c-api/init_config.rst
 Doc/c-api/intro.rst
 Doc/c-api/iterator.rst
-Doc/c-api/long.rst
-Doc/c-api/marshal.rst
 Doc/c-api/memory.rst
 Doc/c-api/memoryview.rst
 Doc/c-api/module.rst


### PR DESCRIPTION
Update the nitpick_ignore of the documentation configuration to fix Sphinx warnings about standard C types when declaring functions with the "c:function" markups.

Copy standard C types declared in the "c:type" domain to the "c:identifier" domain, since "c:function" markup looks for types in the "c:identifier" domain.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-106948 -->
* Issue: gh-106948
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--107295.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->