### PR TITLE
[3.11] gh-106948: Update documentation nitpick_ignore for c:identifer domain (#107295)

### DIFF
--- a/Doc/conf.py
+++ b/Doc/conf.py
@@ -148,6 +148,15 @@ nitpick_ignore = [
     ('py:meth', '_SubParsersAction.add_parser'),
 ]
 
+# gh-106948: Copy standard C types declared in the "c:type" domain to the
+# "c:identifier" domain, since "c:function" markup looks for types in the
+# "c:identifier" domain. Use list() to not iterate on items which are being
+# added
+for role, name in list(nitpick_ignore):
+    if role == 'c:type':
+        nitpick_ignore.append(('c:identifier', name))
+del role, name
+
 # Disable Docutils smartquotes for several translations
 smartquotes_excludes = {
     'languages': ['ja', 'fr', 'zh_TW', 'zh_CN'], 'builders': ['man', 'text'],


### PR DESCRIPTION
Update the nitpick_ignore of the documentation configuration to fix Sphinx warnings about standard C types when declaring functions with the "c:function" markups.

Copy standard C types declared in the "c:type" domain to the "c:identifier" domain, since "c:function" markup looks for types in the "c:identifier" domain.

Co-authored-by: Serhiy Storchaka <storchaka@gmail.com>
(cherry picked from commit b1de3807b832b72dfeb66dd5646159d08d2cc74a)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-106948 -->
* Issue: gh-106948
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--107299.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->