### PR TITLE
[3.11] gh-107091: Fix some uses of :c:member: role (GH-107129)

### DIFF
--- a/Doc/c-api/import.rst
+++ b/Doc/c-api/import.rst
@@ -138,7 +138,7 @@ Importing Modules
    :class:`SourceFileLoader` otherwise.
 
    The module's :attr:`__file__` attribute will be set to the code object's
-   :c:member:`co_filename`.  If applicable, :attr:`__cached__` will also
+   :attr:`co_filename`.  If applicable, :attr:`__cached__` will also
    be set.
 
    This function will reload the module if it was already imported.  See

--- a/Doc/c-api/init_config.rst
+++ b/Doc/c-api/init_config.rst
@@ -522,7 +522,7 @@ PyConfig
    Moreover, if :c:func:`PyConfig_SetArgv` or :c:func:`PyConfig_SetBytesArgv`
    is used, this method must be called before other methods, since the
    preinitialization configuration depends on command line arguments (if
-   :c:member:`parse_argv` is non-zero).
+   :c:member:`~PyConfig.parse_argv` is non-zero).
 
    The caller of these methods is responsible to handle exceptions (error or
    exit) using ``PyStatus_Exception()`` and ``Py_ExitStatusException()``.

--- a/Doc/c-api/module.rst
+++ b/Doc/c-api/module.rst
@@ -164,7 +164,7 @@ or request "multi-phase initialization" by returning the definition struct itsel
 
       This memory area is allocated based on *m_size* on module creation,
       and freed when the module object is deallocated, after the
-      :c:member:`m_free` function has been called, if present.
+      :c:member:`~PyModuleDef.m_free` function has been called, if present.
 
       Setting ``m_size`` to ``-1`` means that the module does not support
       sub-interpreters, because it has global state.
@@ -202,7 +202,7 @@ or request "multi-phase initialization" by returning the definition struct itsel
       This function is not called if the module state was requested but is not
       allocated yet. This is the case immediately after the module is created
       and before the module is executed (:c:data:`Py_mod_exec` function). More
-      precisely, this function is not called if :c:member:`m_size` is greater
+      precisely, this function is not called if :c:member:`~PyModuleDef.m_size` is greater
       than 0 and the module state (as returned by :c:func:`PyModule_GetState`)
       is ``NULL``.
 
@@ -217,7 +217,7 @@ or request "multi-phase initialization" by returning the definition struct itsel
       This function is not called if the module state was requested but is not
       allocated yet. This is the case immediately after the module is created
       and before the module is executed (:c:data:`Py_mod_exec` function). More
-      precisely, this function is not called if :c:member:`m_size` is greater
+      precisely, this function is not called if :c:member:`~PyModuleDef.m_size` is greater
       than 0 and the module state (as returned by :c:func:`PyModule_GetState`)
       is ``NULL``.
 
@@ -238,7 +238,7 @@ or request "multi-phase initialization" by returning the definition struct itsel
       This function is not called if the module state was requested but is not
       allocated yet. This is the case immediately after the module is created
       and before the module is executed (:c:data:`Py_mod_exec` function). More
-      precisely, this function is not called if :c:member:`m_size` is greater
+      precisely, this function is not called if :c:member:`~PyModuleDef.m_size` is greater
       than 0 and the module state (as returned by :c:func:`PyModule_GetState`)
       is ``NULL``.
 

--- a/Doc/c-api/structures.rst
+++ b/Doc/c-api/structures.rst
@@ -263,14 +263,16 @@ Implementing functions and methods
 
       points to the contents of the docstring
 
-The :c:member:`ml_meth` is a C function pointer.  The functions may be of different
+The :c:member:`~PyMethodDef.ml_meth` is a C function pointer.
+The functions may be of different
 types, but they always return :c:expr:`PyObject*`.  If the function is not of
 the :c:type:`PyCFunction`, the compiler will require a cast in the method table.
 Even though :c:type:`PyCFunction` defines the first parameter as
 :c:expr:`PyObject*`, it is common that the method implementation uses the
 specific C type of the *self* object.
 
-The :c:member:`ml_flags` field is a bitfield which can include the following flags.
+The :c:member:`~PyMethodDef.ml_flags` field is a bitfield which can include
+the following flags.
 The individual flags indicate either a calling convention or a binding
 convention.
 

--- a/Doc/howto/isolating-extensions.rst
+++ b/Doc/howto/isolating-extensions.rst
@@ -467,7 +467,7 @@ Module State Access from Slot Methods, Getters and Setters
 
 Slot methods—the fast C equivalents for special methods, such as
 :c:member:`~PyNumberMethods.nb_add` for :py:attr:`~object.__add__` or
-:c:member:`~PyType.tp_new` for initialization—have a very simple API that
+:c:member:`~PyTypeObject.tp_new` for initialization—have a very simple API that
 doesn't allow passing in the defining class, unlike with :c:type:`PyCMethod`.
 The same goes for getters and setters defined with
 :c:type:`PyGetSetDef`.

--- a/Doc/whatsnew/3.5.rst
+++ b/Doc/whatsnew/3.5.rst
@@ -2533,7 +2533,7 @@ Changes in the C API
 
 * As part of the :pep:`492` implementation, the ``tp_reserved`` slot of
   :c:type:`PyTypeObject` was replaced with a
-  :c:member:`tp_as_async` slot.  Refer to :ref:`coro-objects` for
+  :c:member:`~PyTypeObject.tp_as_async` slot.  Refer to :ref:`coro-objects` for
   new types, structures and functions.
 
 

--- a/Doc/whatsnew/3.7.rst
+++ b/Doc/whatsnew/3.7.rst
@@ -1674,7 +1674,7 @@ The new :c:func:`import__find__load__start` and
 module imports.
 (Contributed by Christian Heimes in :issue:`31574`.)
 
-The fields :c:member:`name` and :c:member:`doc` of structures
+The fields :c:member:`!name` and :c:member:`!doc` of structures
 :c:type:`PyMemberDef`, :c:type:`PyGetSetDef`,
 :c:type:`PyStructSequence_Field`, :c:type:`PyStructSequence_Desc`,
 and :c:type:`wrapperbase` are now of type ``const char *`` rather of


### PR DESCRIPTION
(cherry picked from commit af61cb9c7837ff3c11da79e3ee1cab3fdd0ba4da)


<!-- gh-issue-number: gh-107091 -->
* Issue: gh-107091
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--107311.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->