### PR TITLE
GH-78722: Raise exceptions from `pathlib.Path.iterdir()` without delay.

### DIFF
--- a/Lib/pathlib.py
+++ b/Lib/pathlib.py
@@ -1007,8 +1007,7 @@ class Path(PurePath):
         The children are yielded in arbitrary order, and the
         special entries '.' and '..' are not included.
         """
-        for name in os.listdir(self):
-            yield self._make_child_relpath(name)
+        return (self._make_child_relpath(name) for name in os.listdir(self))
 
     def _scandir(self):
         # bpo-24132: a future version of pathlib will support subclassing of

--- a/Lib/test/test_pathlib.py
+++ b/Lib/test/test_pathlib.py
@@ -1754,7 +1754,7 @@ class PathTest(unittest.TestCase):
         # __iter__ on something that is not a directory.
         p = self.cls(BASE, 'fileA')
         with self.assertRaises(OSError) as cm:
-            next(p.iterdir())
+            p.iterdir()
         # ENOENT or EINVAL under Windows, ENOTDIR otherwise
         # (see issue #12802).
         self.assertIn(cm.exception.errno, (errno.ENOTDIR,

--- a/Misc/NEWS.d/next/Library/2023-07-26-22-52-48.gh-issue-78722.6SKBLt.rst
+++ b/Misc/NEWS.d/next/Library/2023-07-26-22-52-48.gh-issue-78722.6SKBLt.rst
@@ -1,0 +1,2 @@
+Fix issue where :meth:`pathlib.Path.iterdir` did not raise :exc:`OSError`
+until iterated.


### PR DESCRIPTION
`pathlib.Path.iterdir()` now immediately raises any `OSError` exception from `os.listdir()`, rather than waiting until its result is iterated over.


<!-- gh-issue-number: gh-78722 -->
* Issue: gh-78722
<!-- /gh-issue-number -->
