### PR TITLE
[3.11] gh-107298: Docs: add targets for some :c:member: and :c:macro: references (GH-107316)

### DIFF
--- a/Doc/c-api/tuple.rst
+++ b/Doc/c-api/tuple.rst
@@ -144,20 +144,21 @@ type.
 
    Contains the meta information of a struct sequence type to create.
 
-   +-------------------+------------------------------+--------------------------------------+
-   | Field             | C Type                       | Meaning                              |
-   +===================+==============================+======================================+
-   | ``name``          | ``const char *``             | name of the struct sequence type     |
-   +-------------------+------------------------------+--------------------------------------+
-   | ``doc``           | ``const char *``             | pointer to docstring for the type    |
-   |                   |                              | or ``NULL`` to omit                  |
-   +-------------------+------------------------------+--------------------------------------+
-   | ``fields``        | ``PyStructSequence_Field *`` | pointer to ``NULL``-terminated array |
-   |                   |                              | with field names of the new type     |
-   +-------------------+------------------------------+--------------------------------------+
-   | ``n_in_sequence`` | ``int``                      | number of fields visible to the      |
-   |                   |                              | Python side (if used as tuple)       |
-   +-------------------+------------------------------+--------------------------------------+
+   .. c:member:: const char *name
+
+      Name of the struct sequence type.
+
+   .. c:member:: const char *doc
+
+      Pointer to docstring for the type or ``NULL`` to omit.
+
+   .. c:member:: PyStructSequence_Field *fields
+
+      Pointer to ``NULL``-terminated array with field names of the new type.
+
+   .. c:member:: int n_in_sequence
+
+      Number of fields visible to the Python side (if used as tuple).
 
 
 .. c:type:: PyStructSequence_Field
@@ -167,16 +168,14 @@ type.
    :attr:`fields` array of the :c:type:`PyStructSequence_Desc` determines which
    field of the struct sequence is described.
 
-   +-----------+------------------+-----------------------------------------+
-   | Field     | C Type           | Meaning                                 |
-   +===========+==================+=========================================+
-   | ``name``  | ``const char *`` | name for the field or ``NULL`` to end   |
-   |           |                  | the list of named fields, set to        |
-   |           |                  | :c:data:`PyStructSequence_UnnamedField` |
-   |           |                  | to leave unnamed                        |
-   +-----------+------------------+-----------------------------------------+
-   | ``doc``   | ``const char *`` | field docstring or ``NULL`` to omit     |
-   +-----------+------------------+-----------------------------------------+
+   .. c:member:: const char *name
+
+      Name for the field or ``NULL`` to end the list of named fields,
+      set to :c:data:`PyStructSequence_UnnamedField` to leave unnamed.
+
+   .. c:member:: const char *doc
+
+      Field docstring or ``NULL`` to omit.
 
 
 .. c:var:: const char * const PyStructSequence_UnnamedField

--- a/Doc/c-api/typeobj.rst
+++ b/Doc/c-api/typeobj.rst
@@ -1449,21 +1449,23 @@ and :c:data:`PyType_Type` effectively act as defaults.)
    The following constants are defined to be used as the third argument for
    :c:member:`~PyTypeObject.tp_richcompare` and for :c:func:`PyObject_RichCompare`:
 
-   +------------------+------------+
-   | Constant         | Comparison |
-   +==================+============+
-   | :c:macro:`Py_LT` | ``<``      |
-   +------------------+------------+
-   | :c:macro:`Py_LE` | ``<=``     |
-   +------------------+------------+
-   | :c:macro:`Py_EQ` | ``==``     |
-   +------------------+------------+
-   | :c:macro:`Py_NE` | ``!=``     |
-   +------------------+------------+
-   | :c:macro:`Py_GT` | ``>``      |
-   +------------------+------------+
-   | :c:macro:`Py_GE` | ``>=``     |
-   +------------------+------------+
+   .. c:namespace:: NULL
+
+   +--------------------+------------+
+   | Constant           | Comparison |
+   +====================+============+
+   | .. c:macro:: Py_LT | ``<``      |
+   +--------------------+------------+
+   | .. c:macro:: Py_LE | ``<=``     |
+   +--------------------+------------+
+   | .. c:macro:: Py_EQ | ``==``     |
+   +--------------------+------------+
+   | .. c:macro:: Py_NE | ``!=``     |
+   +--------------------+------------+
+   | .. c:macro:: Py_GT | ``>``      |
+   +--------------------+------------+
+   | .. c:macro:: Py_GE | ``>=``     |
+   +--------------------+------------+
 
    The following macro is defined to ease writing rich comparison functions:
 


### PR DESCRIPTION
Add targets for PyStructSequence_Desc and PyStructSequence_Field members and macros like Py_EQ.
Fix target for Py_RETURN_RICHCOMPARE.
(cherry picked from commit abec9a1b20b70d8ced401d59fc4f02b331c6568b)


<!-- gh-issue-number: gh-107298 -->
* Issue: gh-107298
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--107333.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->