### PR TITLE
gh-105481: remove dependency of _inline_cache_entries on opname

### DIFF
--- a/Include/internal/pycore_opcode.h
+++ b/Include/internal/pycore_opcode.h
@@ -19,20 +19,20 @@ extern const uint8_t _PyOpcode_Deopt[256];
 #ifdef NEED_OPCODE_TABLES
 
 const uint8_t _PyOpcode_Caches[256] = {
-    [TO_BOOL] = 3,
-    [BINARY_SUBSCR] = 1,
-    [STORE_SUBSCR] = 1,
-    [UNPACK_SEQUENCE] = 1,
-    [FOR_ITER] = 1,
-    [STORE_ATTR] = 4,
-    [LOAD_ATTR] = 9,
-    [COMPARE_OP] = 1,
     [LOAD_GLOBAL] = 4,
     [BINARY_OP] = 1,
+    [UNPACK_SEQUENCE] = 1,
+    [COMPARE_OP] = 1,
+    [BINARY_SUBSCR] = 1,
+    [FOR_ITER] = 1,
+    [LOAD_SUPER_ATTR] = 1,
+    [LOAD_ATTR] = 9,
+    [STORE_ATTR] = 4,
+    [CALL] = 3,
+    [STORE_SUBSCR] = 1,
     [SEND] = 1,
     [JUMP_BACKWARD] = 1,
-    [LOAD_SUPER_ATTR] = 1,
-    [CALL] = 3,
+    [TO_BOOL] = 3,
 };
 
 const uint8_t _PyOpcode_Deopt[256] = {

--- a/Lib/opcode.py
+++ b/Lib/opcode.py
@@ -347,6 +347,6 @@ _cache_format = {
     },
 }
 
-_inline_cache_entries = [
-    sum(_cache_format.get(opname[opcode], {}).values()) for opcode in range(256)
-]
+_inline_cache_entries = {
+    name : sum(value.values()) for (name, value) in _cache_format.items()
+}

--- a/Lib/test/test__opcode.py
+++ b/Lib/test/test__opcode.py
@@ -106,7 +106,7 @@ class SpecializationStatsTests(unittest.TestCase):
         specialized_opcodes = [
             op.lower()
             for op in opcode._specializations
-            if opcode._inline_cache_entries[opcode.opmap[op]]
+            if opcode._inline_cache_entries.get(op, 0)
         ]
         self.assertIn('load_attr', specialized_opcodes)
         self.assertIn('binary_subscr', specialized_opcodes)

--- a/Tools/build/generate_opcode_h.py
+++ b/Tools/build/generate_opcode_h.py
@@ -120,9 +120,8 @@ def main(opcode_py,
         iobj.write("\n#ifdef NEED_OPCODE_TABLES\n")
 
         iobj.write("\nconst uint8_t _PyOpcode_Caches[256] = {\n")
-        for i, entries in enumerate(opcode["_inline_cache_entries"]):
-            if entries:
-                iobj.write(f"    [{opname[i]}] = {entries},\n")
+        for name, entries in opcode["_inline_cache_entries"].items():
+            iobj.write(f"    [{name}] = {entries},\n")
         iobj.write("};\n")
 
         deoptcodes = {}


### PR DESCRIPTION

This will make it easier to do the refactor to generate opcodes from bytecodes.c rather than opcode.py.

<!-- gh-issue-number: gh-105481 -->
* Issue: gh-105481
<!-- /gh-issue-number -->
