### PR TITLE
gh-104683: Argument clinic: cleanup `state_modulename_name()`

### DIFF
--- a/Lib/test/test_clinic.py
+++ b/Lib/test/test_clinic.py
@@ -679,6 +679,32 @@ class ClinicParserTest(_ParserBase):
         """)
         self.assertIsInstance(function.return_converter, clinic.int_return_converter)
 
+    def test_return_converter_invalid_syntax(self):
+        stdout = self.parse_function_should_fail("""
+            module os
+            os.stat -> invalid syntax
+        """)
+        expected_error = "Badly formed annotation for os.stat: 'invalid syntax'"
+        self.assertIn(expected_error, stdout)
+
+    def test_legacy_converter_disallowed_in_return_annotation(self):
+        stdout = self.parse_function_should_fail("""
+            module os
+            os.stat -> "s"
+        """)
+        expected_error = "Legacy converter 's' not allowed as a return converter"
+        self.assertIn(expected_error, stdout)
+
+    def test_unknown_return_converter(self):
+        stdout = self.parse_function_should_fail("""
+            module os
+            os.stat -> foooooooooooooooooooooooo
+        """)
+        expected_error = (
+            "No available return converter called 'foooooooooooooooooooooooo'"
+        )
+        self.assertIn(expected_error, stdout)
+
     def test_star(self):
         function = self.parse_function("""
             module os

--- a/Tools/clinic/clinic.py
+++ b/Tools/clinic/clinic.py
@@ -4730,6 +4730,7 @@ class DSLParser:
                 return
 
         line, _, returns = line.partition('->')
+        returns = returns.strip()
 
         full_name, _, c_basename = line.partition(' as ')
         full_name = full_name.strip()
@@ -4746,7 +4747,7 @@ class DSLParser:
             try:
                 module_node = ast.parse(ast_input)
             except SyntaxError:
-                fail(f"Badly-formed annotation for {full_name}: {returns}")
+                fail(f"Badly formed annotation for {full_name}: {returns!r}")
             function_node = module_node.body[0]
             assert isinstance(function_node, ast.FunctionDef)
             try:
@@ -4757,7 +4758,7 @@ class DSLParser:
                     fail(f"No available return converter called {name!r}")
                 return_converter = return_converters[name](**kwargs)
             except ValueError:
-                fail(f"Badly-formed annotation for {full_name}: {returns}")
+                fail(f"Badly formed annotation for {full_name}: {returns!r}")
 
         fields = [x.strip() for x in full_name.split('.')]
         function_name = fields.pop()

--- a/Tools/clinic/clinic.py
+++ b/Tools/clinic/clinic.py
@@ -4743,23 +4743,21 @@ class DSLParser:
         return_converter = None
         if returns:
             ast_input = f"def x() -> {returns}: pass"
-            module = None
             try:
-                module = ast.parse(ast_input)
+                module_node = ast.parse(ast_input)
             except SyntaxError:
-                pass
-            if not module:
                 fail("Badly-formed annotation for " + full_name + ": " + returns)
+            function_node = module_node.body[0]
+            assert isinstance(function_node, ast.FunctionDef)
             try:
-                name, legacy, kwargs = self.parse_converter(module.body[0].returns)
+                name, legacy, kwargs = self.parse_converter(function_node.returns)
                 if legacy:
-                    fail("Legacy converter {!r} not allowed as a return converter"
-                         .format(name))
+                    fail(f"Legacy converter {name!r} not allowed as a return converter")
                 if name not in return_converters:
-                    fail("No available return converter called " + repr(name))
+                    fail(f"No available return converter called {name!r}")
                 return_converter = return_converters[name](**kwargs)
             except ValueError:
-                fail("Badly-formed annotation for " + full_name + ": " + returns)
+                fail(f"Badly-formed annotation for {full_name}: {returns}")
 
         fields = [x.strip() for x in full_name.split('.')]
         function_name = fields.pop()

--- a/Tools/clinic/clinic.py
+++ b/Tools/clinic/clinic.py
@@ -4746,7 +4746,7 @@ class DSLParser:
             try:
                 module_node = ast.parse(ast_input)
             except SyntaxError:
-                fail("Badly-formed annotation for " + full_name + ": " + returns)
+                fail(f"Badly-formed annotation for {full_name}: {returns}")
             function_node = module_node.body[0]
             assert isinstance(function_node, ast.FunctionDef)
             try:


### PR DESCRIPTION
The `state_modulename_name()` function has two variables named `module`, that have different purposes and that are assigned to objects of different types:

https://github.com/python/cpython/blob/6e850c30bb7085c80a97982d00c9c20e7d23ff84/Tools/clinic/clinic.py#L4718

https://github.com/python/cpython/blob/6e850c30bb7085c80a97982d00c9c20e7d23ff84/Tools/clinic/clinic.py#L4746-L4750

If we give the second variable a different name, it makes the code easier to understand for mypy and for humans. I also made some incidental changes to nearby lines to use f-strings rather than string concatenation using `+`.

(This PR is required in order to add type hints to the last remaining untyped function in `clinic.py`, `_module_and_class()`.)

<!-- gh-issue-number: gh-104683 -->
* Issue: gh-104683
<!-- /gh-issue-number -->
