### PR TITLE
Bump some docs dependencies to resolve a Dependabot security alert

### DIFF
--- a/Doc/requirements-oldest-sphinx.txt
+++ b/Doc/requirements-oldest-sphinx.txt
@@ -27,7 +27,6 @@ MarkupSafe==1.1.1
 packaging==23.1
 Pygments==2.15.1
 requests==2.31.0
-setuptools==68.0.0
 snowballstemmer==2.2.0
 Sphinx==3.2.1
 sphinxcontrib-applehelp==1.0.4

--- a/Doc/requirements-oldest-sphinx.txt
+++ b/Doc/requirements-oldest-sphinx.txt
@@ -14,11 +14,10 @@ python-docs-theme>=2022.1
 # Docutils<0.17, Jinja2<3, and MarkupSafe<2 are additionally specified as
 # Sphinx 3.2 is incompatible with newer releases of these packages.
 
-Sphinx==3.2.1
 alabaster==0.7.13
 Babel==2.12.1
-certifi==2022.12.7
-charset-normalizer==3.1.0
+certifi==2023.7.22
+charset-normalizer==3.2.0
 colorama==0.4.6
 docutils==0.16
 idna==3.4
@@ -28,11 +27,13 @@ MarkupSafe==1.1.1
 packaging==23.1
 Pygments==2.15.1
 requests==2.31.0
+setuptools==68.0.0
 snowballstemmer==2.2.0
+Sphinx==3.2.1
 sphinxcontrib-applehelp==1.0.4
 sphinxcontrib-devhelp==1.0.2
 sphinxcontrib-htmlhelp==2.0.1
 sphinxcontrib-jsmath==1.0.1
 sphinxcontrib-qthelp==1.0.3
 sphinxcontrib-serializinghtml==1.1.5
-urllib3==1.26.15
+urllib3==2.0.4


### PR DESCRIPTION
I ran the instructions at the top of `Doc/requirements-oldest-sphinx.txt` to regenerate the dependency pins. This resolves an open Dependabot security alert on the CPython repo: https://github.com/python/cpython/security/dependabot/2

Because I'm using a new version of pip, it looks like `setuptools` is now listed in the `pip freeze` output if you have a virtual environment activated (previously, it was filtered out by pip from the output of `pip freeze`). We probably don't need it pinned for the docs build, so I could remove it and update the instructions in `Doc/requirements-oldest-sphinx.txt`? But it also probably doesn't hurt to include it, and it keeps the instructions for regenerating the file simple to just add it to the dependency pins.

<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--107341.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->