### PR TITLE
[3.12] gh-105268: Remove _PyGC_FINALIZED() macro (#105350)

### DIFF
--- a/Doc/whatsnew/3.12.rst
+++ b/Doc/whatsnew/3.12.rst
@@ -2045,3 +2045,10 @@ Removed
 * Remove ``_use_broken_old_ctypes_structure_semantics_`` flag
   from :mod:`ctypes` module.
   (Contributed by Nikita Sobolev in :gh:`99285`.)
+
+* Remove the old private, undocumented and untested ``_PyGC_FINALIZED()`` macro
+  which was kept for backward compatibility with Python 3.8 and older: use
+  :c:func:`PyObject_GC_IsFinalized()` instead. The `pythoncapi-compat project
+  <https://github.com/python/pythoncapi-compat/>`_ can be used to get this
+  function on Python 3.8 and older.
+  (Contributed by Victor Stinner in :gh:`105268`.)

--- a/Include/cpython/objimpl.h
+++ b/Include/cpython/objimpl.h
@@ -78,14 +78,6 @@ PyAPI_FUNC(void) PyObject_SetArenaAllocator(PyObjectArenaAllocator *allocator);
 PyAPI_FUNC(int) PyObject_IS_GC(PyObject *obj);
 
 
-/* Code built with Py_BUILD_CORE must include pycore_gc.h instead which
-   defines a different _PyGC_FINALIZED() macro. */
-#ifndef Py_BUILD_CORE
-   // Kept for backward compatibility with Python 3.8
-#  define _PyGC_FINALIZED(o) PyObject_GC_IsFinalized(o)
-#endif
-
-
 // Test if a type supports weak references
 PyAPI_FUNC(int) PyType_SUPPORTS_WEAKREFS(PyTypeObject *type);
 

--- a/Misc/NEWS.d/next/C API/2023-06-06-10-57-18.gh-issue-105268.OTJUko.rst
+++ b/Misc/NEWS.d/next/C API/2023-06-06-10-57-18.gh-issue-105268.OTJUko.rst
@@ -1,0 +1,3 @@
+Remove the old private, undocumented and untested ``_PyGC_FINALIZED()`` macro
+which was kept for backward compatibility with Python 3.8 and older. Patch by
+Victor Stinner.


### PR DESCRIPTION
Remove the old private, undocumented and untested _PyGC_FINALIZED() macro which was kept for backward compatibility with Python 3.8 and older.

(cherry picked from commit 8ddf0dd264acafda29dc587ab8393387bb9a76ab)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-105268 -->
* Issue: gh-105268
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--107348.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->