### PR TITLE
gh-105699: Disable the Interpreters Stress Tests

### DIFF
--- a/Lib/test/test_interpreters.py
+++ b/Lib/test/test_interpreters.py
@@ -464,6 +464,7 @@ class TestInterpreterRun(TestBase):
     # test_xxsubinterpreters covers the remaining Interpreter.run() behavior.
 
 
+@unittest.skip('these are crashing, likely just due just to _xxsubinterpreters (see gh-105699)')
 class StressTests(TestBase):
 
     # In these tests we generally want a lot of interpreters,


### PR DESCRIPTION
The two tests are crashing periodically in CI and on buildbots.  I suspect the problem is in the _xxsubinterpreters module.  Regardless, I'm disabling the tests temporarily, to reduce the noise as we approach 3.12rc1.  I'll be investigating the crashes separately.

<!-- gh-issue-number: gh-105699 -->
* Issue: gh-105699
<!-- /gh-issue-number -->
