### PR TITLE
gh-106368: Argument clinic tests: improve failure message when tests in `ClinicExternalTests` fail

### DIFF
--- a/Lib/test/test_clinic.py
+++ b/Lib/test/test_clinic.py
@@ -10,6 +10,7 @@ from textwrap import dedent
 from unittest import TestCase
 import collections
 import inspect
+import itertools
 import os.path
 import subprocess
 import sys
@@ -1386,7 +1387,7 @@ class ClinicExternalTest(TestCase):
         ) as proc:
             proc.wait()
             if expect_success and proc.returncode:
-                self.fail("".join(proc.stderr))
+                self.fail("".join(itertools.chain(proc.stdout, proc.stderr)))
             stdout = proc.stdout.read()
             stderr = proc.stderr.read()
             # Clinic never writes to stderr.

--- a/Lib/test/test_clinic.py
+++ b/Lib/test/test_clinic.py
@@ -10,7 +10,6 @@ from textwrap import dedent
 from unittest import TestCase
 import collections
 import inspect
-import itertools
 import os.path
 import subprocess
 import sys
@@ -1387,7 +1386,7 @@ class ClinicExternalTest(TestCase):
         ) as proc:
             proc.wait()
             if expect_success and proc.returncode:
-                self.fail("".join(itertools.chain(proc.stdout, proc.stderr)))
+                self.fail("".join([*proc.stdout, *proc.stderr]))
             stdout = proc.stdout.read()
             stderr = proc.stderr.read()
             # Clinic never writes to stderr.


### PR DESCRIPTION
Currently, if I apply this diff to `Tools/clinic/clinic.py`...

```diff
--- a/Tools/clinic/clinic.py
+++ b/Tools/clinic/clinic.py
@@ -4702,6 +4702,7 @@ def state_modulename_name(self, line: str | None) -> None:
                 fields = [x.strip() for x in existing.split('.')]
                 function_name = fields.pop()
                 module, cls = self.clinic._module_and_class(fields)
+                1/0

                 for existing_function in (cls or module).functions:
                     if existing_function.name == function_name:
```

...then the argument clinic tests fail for me locally (good!), but the failure message is terrible (bad!):

```pytb
======================================================================
FAIL: test_external (test.test_clinic.ClinicExternalTest.test_external)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "C:\Users\alexw\coding\cpython\Lib\test\test_clinic.py", line 1410, in test_external
    out = self.expect_success("-f", "-o", TESTFN, source)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\alexw\coding\cpython\Lib\test\test_clinic.py", line 1397, in expect_success
    return self._do_test(*args)
           ^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\alexw\coding\cpython\Lib\test\test_clinic.py", line 1389, in _do_test
    self.fail("".join(proc.stderr))
AssertionError

----------------------------------------------------------------------
```

This change makes the error message _much_ more helpful!

```pytb
======================================================================
FAIL: test_external (test.test_clinic.ClinicExternalTest.test_external)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "C:\Users\alexw\coding\cpython\Lib\test\test_clinic.py", line 1411, in test_external
    out = self.expect_success("-f", "-o", TESTFN, source)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\alexw\coding\cpython\Lib\test\test_clinic.py", line 1398, in expect_success
    return self._do_test(*args)
           ^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\alexw\coding\cpython\Lib\test\test_clinic.py", line 1390, in _do_test
    self.fail("".join(itertools.chain(proc.stdout, proc.stderr)))
AssertionError: Error in file "C:\Users\alexw\coding\cpython\Lib\test\clinic.test.c" on line 117:
Exception raised during parsing:
Traceback (most recent call last):
  File "C:\Users\alexw\coding\cpython\Tools\clinic\clinic.py", line 2244, in parse
    parser.parse(block)
  File "C:\Users\alexw\coding\cpython\Tools\clinic\clinic.py", line 4608, in parse
    self.state(line)
  File "C:\Users\alexw\coding\cpython\Tools\clinic\clinic.py", line 4666, in state_dsl_start
    self.next(self.state_modulename_name, line)
  File "C:\Users\alexw\coding\cpython\Tools\clinic\clinic.py", line 4648, in next
    self.state(line)
  File "C:\Users\alexw\coding\cpython\Tools\clinic\clinic.py", line 4705, in state_modulename_name
    1/0
    ~^~
ZeroDivisionError: division by zero


----------------------------------------------------------------------
```

(@erlend-aasland do you see the same thing locally? Am I seeing something different because I'm using a Windows box?)

<!-- gh-issue-number: gh-106368 -->
* Issue: gh-106368
<!-- /gh-issue-number -->
