### PR TITLE
[3.11] gh-107298: Fix Sphinx warnings in the C API doc (GH-107302)

### DIFF
--- a/Doc/c-api/apiabiversion.rst
+++ b/Doc/c-api/apiabiversion.rst
@@ -60,7 +60,7 @@ See :ref:`stable` for a discussion of API and ABI stability across versions.
 
    Use this for numeric comparisons, e.g. ``#if PY_VERSION_HEX >= ...``.
 
-   This version is also available via the symbol :data:`Py_Version`.
+   This version is also available via the symbol :c:var:`Py_Version`.
 
 .. c:var:: const unsigned long Py_Version
 

--- a/Doc/c-api/buffer.rst
+++ b/Doc/c-api/buffer.rst
@@ -44,7 +44,7 @@ the elements exposed by an :class:`array.array` can be multi-byte values.
 
 An example consumer of the buffer interface is the :meth:`~io.BufferedIOBase.write`
 method of file objects: any object that can export a series of bytes through
-the buffer interface can be written to a file.  While :meth:`write` only
+the buffer interface can be written to a file.  While :meth:`!write` only
 needs read-only access to the internal contents of the object passed to it,
 other methods such as :meth:`~io.BufferedIOBase.readinto` need write access
 to the contents of their argument.  The buffer interface allows objects to

--- a/Doc/c-api/bytes.rst
+++ b/Doc/c-api/bytes.rst
@@ -67,39 +67,39 @@ called with a non-bytes parameter.
    +-------------------+---------------+--------------------------------+
    | Format Characters | Type          | Comment                        |
    +===================+===============+================================+
-   | :attr:`%%`        | *n/a*         | The literal % character.       |
+   | ``%%``            | *n/a*         | The literal % character.       |
    +-------------------+---------------+--------------------------------+
-   | :attr:`%c`        | int           | A single byte,                 |
+   | ``%c``            | int           | A single byte,                 |
    |                   |               | represented as a C int.        |
    +-------------------+---------------+--------------------------------+
-   | :attr:`%d`        | int           | Equivalent to                  |
+   | ``%d``            | int           | Equivalent to                  |
    |                   |               | ``printf("%d")``. [1]_         |
    +-------------------+---------------+--------------------------------+
-   | :attr:`%u`        | unsigned int  | Equivalent to                  |
+   | ``%u``            | unsigned int  | Equivalent to                  |
    |                   |               | ``printf("%u")``. [1]_         |
    +-------------------+---------------+--------------------------------+
-   | :attr:`%ld`       | long          | Equivalent to                  |
+   | ``%ld``           | long          | Equivalent to                  |
    |                   |               | ``printf("%ld")``. [1]_        |
    +-------------------+---------------+--------------------------------+
-   | :attr:`%lu`       | unsigned long | Equivalent to                  |
+   | ``%lu``           | unsigned long | Equivalent to                  |
    |                   |               | ``printf("%lu")``. [1]_        |
    +-------------------+---------------+--------------------------------+
-   | :attr:`%zd`       | :c:type:`\    | Equivalent to                  |
+   | ``%zd``           | :c:type:`\    | Equivalent to                  |
    |                   | Py_ssize_t`   | ``printf("%zd")``. [1]_        |
    +-------------------+---------------+--------------------------------+
-   | :attr:`%zu`       | size_t        | Equivalent to                  |
+   | ``%zu``           | size_t        | Equivalent to                  |
    |                   |               | ``printf("%zu")``. [1]_        |
    +-------------------+---------------+--------------------------------+
-   | :attr:`%i`        | int           | Equivalent to                  |
+   | ``%i``            | int           | Equivalent to                  |
    |                   |               | ``printf("%i")``. [1]_         |
    +-------------------+---------------+--------------------------------+
-   | :attr:`%x`        | int           | Equivalent to                  |
+   | ``%x``            | int           | Equivalent to                  |
    |                   |               | ``printf("%x")``. [1]_         |
    +-------------------+---------------+--------------------------------+
-   | :attr:`%s`        | const char\*  | A null-terminated C character  |
+   | ``%s``            | const char\*  | A null-terminated C character  |
    |                   |               | array.                         |
    +-------------------+---------------+--------------------------------+
-   | :attr:`%p`        | const void\*  | The hex representation of a C  |
+   | ``%p``            | const void\*  | The hex representation of a C  |
    |                   |               | pointer. Mostly equivalent to  |
    |                   |               | ``printf("%p")`` except that   |
    |                   |               | it is guaranteed to start with |

--- a/Doc/c-api/cell.rst
+++ b/Doc/c-api/cell.rst
@@ -25,7 +25,7 @@ Cell objects are not likely to be useful elsewhere.
    The type object corresponding to cell objects.
 
 
-.. c:function:: int PyCell_Check(ob)
+.. c:function:: int PyCell_Check(PyObject *ob)
 
    Return true if *ob* is a cell object; *ob* must not be ``NULL``.  This
    function always succeeds.

--- a/Doc/c-api/gcsupport.rst
+++ b/Doc/c-api/gcsupport.rst
@@ -124,7 +124,7 @@ rules:
 
 .. versionchanged:: 3.8
 
-   The :c:func:`_PyObject_GC_TRACK` and :c:func:`_PyObject_GC_UNTRACK` macros
+   The :c:func:`!_PyObject_GC_TRACK` and :c:func:`!_PyObject_GC_UNTRACK` macros
    have been removed from the public C API.
 
 The :c:member:`~PyTypeObject.tp_traverse` handler accepts a function parameter of this type:

--- a/Doc/c-api/iterator.rst
+++ b/Doc/c-api/iterator.rst
@@ -19,7 +19,7 @@ sentinel value is returned.
    types.
 
 
-.. c:function:: int PySeqIter_Check(op)
+.. c:function:: int PySeqIter_Check(PyObject *op)
 
    Return true if the type of *op* is :c:data:`PySeqIter_Type`.  This function
    always succeeds.
@@ -38,7 +38,7 @@ sentinel value is returned.
    two-argument form of the :func:`iter` built-in function.
 
 
-.. c:function:: int PyCallIter_Check(op)
+.. c:function:: int PyCallIter_Check(PyObject *op)
 
    Return true if the type of *op* is :c:data:`PyCallIter_Type`.  This
    function always succeeds.

--- a/Doc/c-api/type.rst
+++ b/Doc/c-api/type.rst
@@ -292,7 +292,7 @@ The following functions and structs are used to create
       Setting :c:data:`Py_tp_bases` or :c:data:`Py_tp_base` may be
       problematic on some platforms.
       To avoid issues, use the *bases* argument of
-      :py:func:`PyType_FromSpecWithBases` instead.
+      :c:func:`PyType_FromSpecWithBases` instead.
 
      .. versionchanged:: 3.9
 

--- a/Doc/c-api/typehints.rst
+++ b/Doc/c-api/typehints.rst
@@ -35,7 +35,7 @@ two types exist -- :ref:`GenericAlias <types-genericalias>` and
           ...
       }
 
-   .. seealso:: The data model method :meth:`__class_getitem__`.
+   .. seealso:: The data model method :meth:`~object.__class_getitem__`.
 
    .. versionadded:: 3.9
 

--- a/Doc/c-api/unicode.rst
+++ b/Doc/c-api/unicode.rst
@@ -1306,7 +1306,7 @@ This codec is special in that it can be used to implement many different codecs
 (and this is in fact what was done to obtain most of the standard codecs
 included in the :mod:`encodings` package). The codec uses mappings to encode and
 decode characters.  The mapping objects provided must support the
-:meth:`__getitem__` mapping interface; dictionaries and sequences work well.
+:meth:`~object.__getitem__` mapping interface; dictionaries and sequences work well.
 
 These are the mapping codec APIs:
 
@@ -1349,7 +1349,7 @@ The following codec API is special in that maps Unicode to Unicode.
    The mapping table must map Unicode ordinal integers to Unicode ordinal integers
    or ``None`` (causing deletion of the character).
 
-   Mapping tables need only provide the :meth:`__getitem__` interface; dictionaries
+   Mapping tables need only provide the :meth:`~object.__getitem__` interface; dictionaries
    and sequences work well.  Unmapped character ordinals (ones which cause a
    :exc:`LookupError`) are left untouched and are copied as-is.
 

--- a/Doc/c-api/weakref.rst
+++ b/Doc/c-api/weakref.rst
@@ -11,18 +11,18 @@ simple reference object, and the second acts as a proxy for the original object
 as much as it can.
 
 
-.. c:function:: int PyWeakref_Check(ob)
+.. c:function:: int PyWeakref_Check(PyObject *ob)
 
    Return true if *ob* is either a reference or proxy object.  This function
    always succeeds.
 
 
-.. c:function:: int PyWeakref_CheckRef(ob)
+.. c:function:: int PyWeakref_CheckRef(PyObject *ob)
 
    Return true if *ob* is a reference object.  This function always succeeds.
 
 
-.. c:function:: int PyWeakref_CheckProxy(ob)
+.. c:function:: int PyWeakref_CheckProxy(PyObject *ob)
 
    Return true if *ob* is a proxy object.  This function always succeeds.
 
@@ -54,7 +54,7 @@ as much as it can.
 .. c:function:: PyObject* PyWeakref_GetObject(PyObject *ref)
 
    Return the referenced object from a weak reference, *ref*.  If the referent is
-   no longer live, returns :const:`Py_None`.
+   no longer live, returns ``Py_None``.
 
    .. note::
 


### PR DESCRIPTION
(cherry picked from commit 391e03fa05b80d17a14ac88d30c974fa2fa00adb)


<!-- gh-issue-number: gh-107298 -->
* Issue: gh-107298
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--107373.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->