### PR TITLE
gh-107369: optimize textwrap.indent()

### DIFF
--- a/Doc/whatsnew/3.13.rst
+++ b/Doc/whatsnew/3.13.rst
@@ -144,7 +144,8 @@ typing
 Optimizations
 =============
 
-
+* :func:`textwrap.indent` is now ~25% faster than before for large input.
+  (Contributed by Inada Naoki in :gh:`107369`.)
 
 
 Deprecated

--- a/Doc/whatsnew/3.13.rst
+++ b/Doc/whatsnew/3.13.rst
@@ -144,7 +144,7 @@ typing
 Optimizations
 =============
 
-* :func:`textwrap.indent` is now ~25% faster than before for large input.
+* :func:`textwrap.indent` is now ~30% faster than before for large input.
   (Contributed by Inada Naoki in :gh:`107369`.)
 
 

--- a/Lib/textwrap.py
+++ b/Lib/textwrap.py
@@ -476,6 +476,10 @@ def indent(text, prefix, predicate=None):
     consist solely of whitespace characters.
     """
     if predicate is None:
+        # str.splitlines(True) doesn't produce empty string.
+        #  ''.splitlines(True) => []
+        #  'foo\n'.splitlines(True) => ['foo\n']
+        # So we can use just `not s.isspace()` here.
         predicate = lambda s: not s.isspace()
 
     prefixed_lines = []

--- a/Lib/textwrap.py
+++ b/Lib/textwrap.py
@@ -476,13 +476,16 @@ def indent(text, prefix, predicate=None):
     consist solely of whitespace characters.
     """
     if predicate is None:
-        def predicate(line):
-            return line.strip()
+        predicate = str.strip
 
-    def prefixed_lines():
-        for line in text.splitlines(True):
-            yield (prefix + line if predicate(line) else line)
-    return ''.join(prefixed_lines())
+    prefixed_lines = []
+    for line in text.splitlines(True):
+        if predicate(line):
+            prefixed_lines.extend((prefix, line))
+        else:
+            prefixed_lines.append(line)
+
+    return ''.join(prefixed_lines)
 
 
 if __name__ == "__main__":

--- a/Lib/textwrap.py
+++ b/Lib/textwrap.py
@@ -481,9 +481,8 @@ def indent(text, prefix, predicate=None):
     prefixed_lines = []
     for line in text.splitlines(True):
         if predicate(line):
-            prefixed_lines.extend((prefix, line))
-        else:
-            prefixed_lines.append(line)
+            prefixed_lines.append(prefix)
+        prefixed_lines.append(line)
 
     return ''.join(prefixed_lines)
 

--- a/Lib/textwrap.py
+++ b/Lib/textwrap.py
@@ -476,7 +476,7 @@ def indent(text, prefix, predicate=None):
     consist solely of whitespace characters.
     """
     if predicate is None:
-        predicate = str.lstrip
+        predicate = lambda s: not s.isspace()
 
     prefixed_lines = []
     for line in text.splitlines(True):

--- a/Lib/textwrap.py
+++ b/Lib/textwrap.py
@@ -476,7 +476,7 @@ def indent(text, prefix, predicate=None):
     consist solely of whitespace characters.
     """
     if predicate is None:
-        predicate = str.strip
+        predicate = str.lstrip
 
     prefixed_lines = []
     for line in text.splitlines(True):

--- a/Misc/NEWS.d/next/Library/2023-07-28-14-56-35.gh-issue-107369.bvTq8F.rst
+++ b/Misc/NEWS.d/next/Library/2023-07-28-14-56-35.gh-issue-107369.bvTq8F.rst
@@ -1,2 +1,2 @@
-Optimize :func:`textwrap.indent`. It is ~25% faster for large input. Patch
+Optimize :func:`textwrap.indent`. It is ~30% faster for large input. Patch
 by Inada Naoki.

--- a/Misc/NEWS.d/next/Library/2023-07-28-14-56-35.gh-issue-107369.bvTq8F.rst
+++ b/Misc/NEWS.d/next/Library/2023-07-28-14-56-35.gh-issue-107369.bvTq8F.rst
@@ -1,0 +1,2 @@
+Optimize :func:`textwrap.indent`. It is ~25% faster for large input. Patch
+by Inada Naoki.


### PR DESCRIPTION
indent()-ing `Object/unicodeobject.c` (15332 lines) about 25% faster.

<!-- gh-issue-number: gh-107369 -->
* Issue: gh-107369
<!-- /gh-issue-number -->
