### PR TITLE
[3.12] gh-107298: Fix Sphinx warnings in the C API doc (GH-107302)

### DIFF
--- a/Doc/c-api/apiabiversion.rst
+++ b/Doc/c-api/apiabiversion.rst
@@ -60,7 +60,7 @@ See :ref:`stable` for a discussion of API and ABI stability across versions.
 
    Use this for numeric comparisons, e.g. ``#if PY_VERSION_HEX >= ...``.
 
-   This version is also available via the symbol :data:`Py_Version`.
+   This version is also available via the symbol :c:var:`Py_Version`.
 
 .. c:var:: const unsigned long Py_Version
 

--- a/Doc/c-api/buffer.rst
+++ b/Doc/c-api/buffer.rst
@@ -44,7 +44,7 @@ the elements exposed by an :class:`array.array` can be multi-byte values.
 
 An example consumer of the buffer interface is the :meth:`~io.BufferedIOBase.write`
 method of file objects: any object that can export a series of bytes through
-the buffer interface can be written to a file.  While :meth:`write` only
+the buffer interface can be written to a file.  While :meth:`!write` only
 needs read-only access to the internal contents of the object passed to it,
 other methods such as :meth:`~io.BufferedIOBase.readinto` need write access
 to the contents of their argument.  The buffer interface allows objects to

--- a/Doc/c-api/bytes.rst
+++ b/Doc/c-api/bytes.rst
@@ -64,39 +64,39 @@ called with a non-bytes parameter.
    +-------------------+---------------+--------------------------------+
    | Format Characters | Type          | Comment                        |
    +===================+===============+================================+
-   | :attr:`%%`        | *n/a*         | The literal % character.       |
+   | ``%%``            | *n/a*         | The literal % character.       |
    +-------------------+---------------+--------------------------------+
-   | :attr:`%c`        | int           | A single byte,                 |
+   | ``%c``            | int           | A single byte,                 |
    |                   |               | represented as a C int.        |
    +-------------------+---------------+--------------------------------+
-   | :attr:`%d`        | int           | Equivalent to                  |
+   | ``%d``            | int           | Equivalent to                  |
    |                   |               | ``printf("%d")``. [1]_         |
    +-------------------+---------------+--------------------------------+
-   | :attr:`%u`        | unsigned int  | Equivalent to                  |
+   | ``%u``            | unsigned int  | Equivalent to                  |
    |                   |               | ``printf("%u")``. [1]_         |
    +-------------------+---------------+--------------------------------+
-   | :attr:`%ld`       | long          | Equivalent to                  |
+   | ``%ld``           | long          | Equivalent to                  |
    |                   |               | ``printf("%ld")``. [1]_        |
    +-------------------+---------------+--------------------------------+
-   | :attr:`%lu`       | unsigned long | Equivalent to                  |
+   | ``%lu``           | unsigned long | Equivalent to                  |
    |                   |               | ``printf("%lu")``. [1]_        |
    +-------------------+---------------+--------------------------------+
-   | :attr:`%zd`       | :c:type:`\    | Equivalent to                  |
+   | ``%zd``           | :c:type:`\    | Equivalent to                  |
    |                   | Py_ssize_t`   | ``printf("%zd")``. [1]_        |
    +-------------------+---------------+--------------------------------+
-   | :attr:`%zu`       | size_t        | Equivalent to                  |
+   | ``%zu``           | size_t        | Equivalent to                  |
    |                   |               | ``printf("%zu")``. [1]_        |
    +-------------------+---------------+--------------------------------+
-   | :attr:`%i`        | int           | Equivalent to                  |
+   | ``%i``            | int           | Equivalent to                  |
    |                   |               | ``printf("%i")``. [1]_         |
    +-------------------+---------------+--------------------------------+
-   | :attr:`%x`        | int           | Equivalent to                  |
+   | ``%x``            | int           | Equivalent to                  |
    |                   |               | ``printf("%x")``. [1]_         |
    +-------------------+---------------+--------------------------------+
-   | :attr:`%s`        | const char\*  | A null-terminated C character  |
+   | ``%s``            | const char\*  | A null-terminated C character  |
    |                   |               | array.                         |
    +-------------------+---------------+--------------------------------+
-   | :attr:`%p`        | const void\*  | The hex representation of a C  |
+   | ``%p``            | const void\*  | The hex representation of a C  |
    |                   |               | pointer. Mostly equivalent to  |
    |                   |               | ``printf("%p")`` except that   |
    |                   |               | it is guaranteed to start with |

--- a/Doc/c-api/cell.rst
+++ b/Doc/c-api/cell.rst
@@ -25,7 +25,7 @@ Cell objects are not likely to be useful elsewhere.
    The type object corresponding to cell objects.
 
 
-.. c:function:: int PyCell_Check(ob)
+.. c:function:: int PyCell_Check(PyObject *ob)
 
    Return true if *ob* is a cell object; *ob* must not be ``NULL``.  This
    function always succeeds.

--- a/Doc/c-api/code.rst
+++ b/Doc/c-api/code.rst
@@ -39,7 +39,7 @@ bound into a function.
    use :c:func:`PyCode_NewEmpty` instead.
 
    Since the definition of the bytecode changes often, calling
-   :c:func:`PyCode_New` directly can bind you to a precise Python version.
+   :c:func:`PyUnstable_Code_New` directly can bind you to a precise Python version.
 
    The many arguments of this function are inter-dependent in complex
    ways, meaning that subtle changes to values are likely to result in incorrect
@@ -58,8 +58,8 @@ bound into a function.
 
 .. c:function:: PyCodeObject* PyUnstable_Code_NewWithPosOnlyArgs(int argcount, int posonlyargcount, int kwonlyargcount, int nlocals, int stacksize, int flags, PyObject *code, PyObject *consts, PyObject *names, PyObject *varnames, PyObject *freevars, PyObject *cellvars, PyObject *filename, PyObject *name, int firstlineno, PyObject *linetable, PyObject *exceptiontable)
 
-   Similar to :c:func:`PyCode_New`, but with an extra "posonlyargcount" for positional-only arguments.
-   The same caveats that apply to ``PyCode_New`` also apply to this function.
+   Similar to :c:func:`PyUnstable_Code_New`, but with an extra "posonlyargcount" for positional-only arguments.
+   The same caveats that apply to ``PyUnstable_Code_New`` also apply to this function.
 
    .. index:: single: PyCode_NewWithPosOnlyArgs
 

--- a/Doc/c-api/gcsupport.rst
+++ b/Doc/c-api/gcsupport.rst
@@ -143,7 +143,7 @@ rules:
 
 .. versionchanged:: 3.8
 
-   The :c:func:`_PyObject_GC_TRACK` and :c:func:`_PyObject_GC_UNTRACK` macros
+   The :c:func:`!_PyObject_GC_TRACK` and :c:func:`!_PyObject_GC_UNTRACK` macros
    have been removed from the public C API.
 
 The :c:member:`~PyTypeObject.tp_traverse` handler accepts a function parameter of this type:

--- a/Doc/c-api/iterator.rst
+++ b/Doc/c-api/iterator.rst
@@ -19,7 +19,7 @@ sentinel value is returned.
    types.
 
 
-.. c:function:: int PySeqIter_Check(op)
+.. c:function:: int PySeqIter_Check(PyObject *op)
 
    Return true if the type of *op* is :c:data:`PySeqIter_Type`.  This function
    always succeeds.
@@ -38,7 +38,7 @@ sentinel value is returned.
    two-argument form of the :func:`iter` built-in function.
 
 
-.. c:function:: int PyCallIter_Check(op)
+.. c:function:: int PyCallIter_Check(PyObject *op)
 
    Return true if the type of *op* is :c:data:`PyCallIter_Type`.  This
    function always succeeds.

--- a/Doc/c-api/type.rst
+++ b/Doc/c-api/type.rst
@@ -480,7 +480,7 @@ The following functions and structs are used to create
       Setting :c:data:`Py_tp_bases` or :c:data:`Py_tp_base` may be
       problematic on some platforms.
       To avoid issues, use the *bases* argument of
-      :py:func:`PyType_FromSpecWithBases` instead.
+      :c:func:`PyType_FromSpecWithBases` instead.
 
      .. versionchanged:: 3.9
 

--- a/Doc/c-api/typehints.rst
+++ b/Doc/c-api/typehints.rst
@@ -35,7 +35,7 @@ two types exist -- :ref:`GenericAlias <types-genericalias>` and
           ...
       }
 
-   .. seealso:: The data model method :meth:`__class_getitem__`.
+   .. seealso:: The data model method :meth:`~object.__class_getitem__`.
 
    .. versionadded:: 3.9
 

--- a/Doc/c-api/unicode.rst
+++ b/Doc/c-api/unicode.rst
@@ -1214,7 +1214,7 @@ This codec is special in that it can be used to implement many different codecs
 (and this is in fact what was done to obtain most of the standard codecs
 included in the :mod:`encodings` package). The codec uses mappings to encode and
 decode characters.  The mapping objects provided must support the
-:meth:`__getitem__` mapping interface; dictionaries and sequences work well.
+:meth:`~object.__getitem__` mapping interface; dictionaries and sequences work well.
 
 These are the mapping codec APIs:
 
@@ -1257,7 +1257,7 @@ The following codec API is special in that maps Unicode to Unicode.
    The mapping table must map Unicode ordinal integers to Unicode ordinal integers
    or ``None`` (causing deletion of the character).
 
-   Mapping tables need only provide the :meth:`__getitem__` interface; dictionaries
+   Mapping tables need only provide the :meth:`~object.__getitem__` interface; dictionaries
    and sequences work well.  Unmapped character ordinals (ones which cause a
    :exc:`LookupError`) are left untouched and are copied as-is.
 

--- a/Doc/c-api/weakref.rst
+++ b/Doc/c-api/weakref.rst
@@ -11,18 +11,18 @@ simple reference object, and the second acts as a proxy for the original object
 as much as it can.
 
 
-.. c:function:: int PyWeakref_Check(ob)
+.. c:function:: int PyWeakref_Check(PyObject *ob)
 
    Return true if *ob* is either a reference or proxy object.  This function
    always succeeds.
 
 
-.. c:function:: int PyWeakref_CheckRef(ob)
+.. c:function:: int PyWeakref_CheckRef(PyObject *ob)
 
    Return true if *ob* is a reference object.  This function always succeeds.
 
 
-.. c:function:: int PyWeakref_CheckProxy(ob)
+.. c:function:: int PyWeakref_CheckProxy(PyObject *ob)
 
    Return true if *ob* is a proxy object.  This function always succeeds.
 
@@ -54,7 +54,7 @@ as much as it can.
 .. c:function:: PyObject* PyWeakref_GetObject(PyObject *ref)
 
    Return the referenced object from a weak reference, *ref*.  If the referent is
-   no longer live, returns :const:`Py_None`.
+   no longer live, returns ``Py_None``.
 
    .. note::
 

--- a/Doc/tools/.nitignore
+++ b/Doc/tools/.nitignore
@@ -4,15 +4,9 @@
 # to help avoid merge conflicts.
 
 Doc/c-api/allocation.rst
-Doc/c-api/apiabiversion.rst
-Doc/c-api/arg.rst
 Doc/c-api/bool.rst
 Doc/c-api/buffer.rst
-Doc/c-api/bytes.rst
 Doc/c-api/capsule.rst
-Doc/c-api/cell.rst
-Doc/c-api/code.rst
-Doc/c-api/codec.rst
 Doc/c-api/complex.rst
 Doc/c-api/conversion.rst
 Doc/c-api/datetime.rst
@@ -26,7 +20,6 @@ Doc/c-api/import.rst
 Doc/c-api/init.rst
 Doc/c-api/init_config.rst
 Doc/c-api/intro.rst
-Doc/c-api/iterator.rst
 Doc/c-api/memory.rst
 Doc/c-api/memoryview.rst
 Doc/c-api/module.rst
@@ -37,11 +30,8 @@ Doc/c-api/stable.rst
 Doc/c-api/structures.rst
 Doc/c-api/sys.rst
 Doc/c-api/type.rst
-Doc/c-api/typehints.rst
 Doc/c-api/typeobj.rst
 Doc/c-api/unicode.rst
-Doc/c-api/veryhigh.rst
-Doc/c-api/weakref.rst
 Doc/extending/embedding.rst
 Doc/extending/extending.rst
 Doc/extending/newtypes.rst


### PR DESCRIPTION
(cherry picked from commit 391e03fa05b80d17a14ac88d30c974fa2fa00adb)


<!-- gh-issue-number: gh-107298 -->
* Issue: gh-107298
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--107375.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->