### PR TITLE
gh-107091: Fix some uses of :const: role

### DIFF
--- a/Doc/library/fcntl.rst
+++ b/Doc/library/fcntl.rst
@@ -172,9 +172,9 @@ The module defines the following functions:
    which the lock starts, relative to *whence*, and *whence* is as with
    :func:`io.IOBase.seek`, specifically:
 
-   * :const:`0` -- relative to the start of the file (:const:`os.SEEK_SET`)
-   * :const:`1` -- relative to the current buffer position (:const:`os.SEEK_CUR`)
-   * :const:`2` -- relative to the end of the file (:const:`os.SEEK_END`)
+   * ``0`` -- relative to the start of the file (:const:`os.SEEK_SET`)
+   * ``1`` -- relative to the current buffer position (:const:`os.SEEK_CUR`)
+   * ``2`` -- relative to the end of the file (:const:`os.SEEK_END`)
 
    The default for *start* is 0, which means to start at the beginning of the file.
    The default for *len* is 0 which means to lock to the end of the file.  The

--- a/Doc/library/fractions.rst
+++ b/Doc/library/fractions.rst
@@ -25,7 +25,7 @@ another rational number, or from a string.
 
    The first version requires that *numerator* and *denominator* are instances
    of :class:`numbers.Rational` and returns a new :class:`Fraction` instance
-   with value ``numerator/denominator``. If *denominator* is :const:`0`, it
+   with value ``numerator/denominator``. If *denominator* is ``0``, it
    raises a :exc:`ZeroDivisionError`. The second version requires that
    *other_fraction* is an instance of :class:`numbers.Rational` and returns a
    :class:`Fraction` instance with the same value.  The next two versions accept

--- a/Doc/library/logging.handlers.rst
+++ b/Doc/library/logging.handlers.rst
@@ -97,7 +97,7 @@ sends logging output to a disk file.  It inherits the output functionality from
 
    Returns a new instance of the :class:`FileHandler` class. The specified file is
    opened and used as the stream for logging. If *mode* is not specified,
-   :const:`'a'` is used.  If *encoding* is not ``None``, it is used to open the file
+   ``'a'`` is used.  If *encoding* is not ``None``, it is used to open the file
    with that encoding.  If *delay* is true, then file opening is deferred until the
    first call to :meth:`emit`. By default, the file grows indefinitely. If
    *errors* is specified, it's used to determine how encoding errors are handled.
@@ -182,7 +182,7 @@ for this value.
 
    Returns a new instance of the :class:`WatchedFileHandler` class. The specified
    file is opened and used as the stream for logging. If *mode* is not specified,
-   :const:`'a'` is used.  If *encoding* is not ``None``, it is used to open the file
+   ``'a'`` is used.  If *encoding* is not ``None``, it is used to open the file
    with that encoding.  If *delay* is true, then file opening is deferred until the
    first call to :meth:`emit`.  By default, the file grows indefinitely. If
    *errors* is provided, it determines how encoding errors are handled.

--- a/Doc/library/os.rst
+++ b/Doc/library/os.rst
@@ -401,11 +401,11 @@ process and user.
 
       On macOS, :func:`getgroups` behavior differs somewhat from
       other Unix platforms. If the Python interpreter was built with a
-      deployment target of :const:`10.5` or earlier, :func:`getgroups` returns
+      deployment target of ``10.5`` or earlier, :func:`getgroups` returns
       the list of effective group ids associated with the current user process;
       this list is limited to a system-defined number of entries, typically 16,
       and may be modified by calls to :func:`setgroups` if suitably privileged.
-      If built with a deployment target greater than :const:`10.5`,
+      If built with a deployment target greater than ``10.5``,
       :func:`getgroups` returns the current group access list for the user
       associated with the effective user id of the process; the group access
       list may change over the lifetime of the process, it is not affected by

--- a/Doc/library/signal.rst
+++ b/Doc/library/signal.rst
@@ -656,7 +656,7 @@ The :mod:`signal` module defines the following functions:
 .. function:: sigtimedwait(sigset, timeout)
 
    Like :func:`sigwaitinfo`, but takes an additional *timeout* argument
-   specifying a timeout. If *timeout* is specified as :const:`0`, a poll is
+   specifying a timeout. If *timeout* is specified as ``0``, a poll is
    performed. Returns :const:`None` if a timeout occurs.
 
    .. availability:: Unix.

--- a/Doc/library/ssl.rst
+++ b/Doc/library/ssl.rst
@@ -320,7 +320,7 @@ Random generation
 
    Mix the given *bytes* into the SSL pseudo-random number generator.  The
    parameter *entropy* (a float) is a lower bound on the entropy contained in
-   string (so you can always use :const:`0.0`).  See :rfc:`1750` for more
+   string (so you can always use ``0.0``).  See :rfc:`1750` for more
    information on sources of entropy.
 
    .. versionchanged:: 3.5

--- a/Doc/library/subprocess.rst
+++ b/Doc/library/subprocess.rst
@@ -465,9 +465,9 @@ functions.
    :func:`open` function when creating the stdin/stdout/stderr pipe
    file objects:
 
-   - :const:`0` means unbuffered (read and write are one
+   - ``0`` means unbuffered (read and write are one
      system call and can return short)
-   - :const:`1` means line buffered
+   - ``1`` means line buffered
      (only usable if ``text=True`` or ``universal_newlines=True``)
    - any other positive value means use a buffer of approximately that
      size
@@ -477,7 +477,7 @@ functions.
    .. versionchanged:: 3.3.1
       *bufsize* now defaults to -1 to enable buffering by default to match the
       behavior that most code expects.  In versions prior to Python 3.2.4 and
-      3.3.1 it incorrectly defaulted to :const:`0` which was unbuffered
+      3.3.1 it incorrectly defaulted to ``0`` which was unbuffered
       and allowed short reads.  This was unintentional and did not match the
       behavior of Python 2 as most code expected.
 
@@ -541,8 +541,8 @@ functions.
       :exc:`RuntimeError`. The new restriction may affect applications that
       are deployed in mod_wsgi, uWSGI, and other embedded environments.
 
-   If *close_fds* is true, all file descriptors except :const:`0`, :const:`1` and
-   :const:`2` will be closed before the child process is executed.  Otherwise
+   If *close_fds* is true, all file descriptors except ``0``, ``1`` and
+   ``2`` will be closed before the child process is executed.  Otherwise
    when *close_fds* is false, file descriptors obey their inheritable flag
    as described in :ref:`fd_inheritance`.
 

--- a/Doc/library/sys.rst
+++ b/Doc/library/sys.rst
@@ -877,19 +877,19 @@ always available.
    ``sys.getwindowsversion().major``. For compatibility with prior
    versions, only the first 5 elements are retrievable by indexing.
 
-   *platform* will be :const:`2 (VER_PLATFORM_WIN32_NT)`.
+   *platform* will be ``2`` (VER_PLATFORM_WIN32_NT).
 
    *product_type* may be one of the following values:
 
    +---------------------------------------+---------------------------------+
    | Constant                              | Meaning                         |
    +=======================================+=================================+
-   | :const:`1 (VER_NT_WORKSTATION)`       | The system is a workstation.    |
+   | ``1`` (VER_NT_WORKSTATION)            | The system is a workstation.    |
    +---------------------------------------+---------------------------------+
-   | :const:`2 (VER_NT_DOMAIN_CONTROLLER)` | The system is a domain          |
+   | ``2`` (VER_NT_DOMAIN_CONTROLLER)      | The system is a domain          |
    |                                       | controller.                     |
    +---------------------------------------+---------------------------------+
-   | :const:`3 (VER_NT_SERVER)`            | The system is a server, but not |
+   | ``3`` (VER_NT_SERVER)                 | The system is a server, but not |
    |                                       | a domain controller.            |
    +---------------------------------------+---------------------------------+
 

--- a/Doc/tools/.nitignore
+++ b/Doc/tools/.nitignore
@@ -90,7 +90,6 @@ Doc/library/faulthandler.rst
 Doc/library/fcntl.rst
 Doc/library/filecmp.rst
 Doc/library/fileinput.rst
-Doc/library/fractions.rst
 Doc/library/ftplib.rst
 Doc/library/functions.rst
 Doc/library/functools.rst

--- a/Doc/whatsnew/3.3.rst
+++ b/Doc/whatsnew/3.3.rst
@@ -1135,20 +1135,20 @@ API changes
 * The C module has the following context limits, depending on the machine
   architecture:
 
-   +-------------------+---------------------+------------------------------+
-   |                   |       32-bit        |            64-bit            |
-   +===================+=====================+==============================+
-   | :const:`MAX_PREC` | :const:`425000000`  | :const:`999999999999999999`  |
-   +-------------------+---------------------+------------------------------+
-   | :const:`MAX_EMAX` | :const:`425000000`  | :const:`999999999999999999`  |
-   +-------------------+---------------------+------------------------------+
-   | :const:`MIN_EMIN` | :const:`-425000000` | :const:`-999999999999999999` |
-   +-------------------+---------------------+------------------------------+
+   +-------------------+----------------+-------------------------+
+   |                   |       32-bit   |            64-bit       |
+   +===================+================+=========================+
+   | :const:`MAX_PREC` | ``425000000``  | ``999999999999999999``  |
+   +-------------------+----------------+-------------------------+
+   | :const:`MAX_EMAX` | ``425000000``  | ``999999999999999999``  |
+   +-------------------+----------------+-------------------------+
+   | :const:`MIN_EMIN` | ``-425000000`` | ``-999999999999999999`` |
+   +-------------------+----------------+-------------------------+
 
 * In the context templates (:class:`~decimal.DefaultContext`,
   :class:`~decimal.BasicContext` and :class:`~decimal.ExtendedContext`)
   the magnitude of :attr:`~decimal.Context.Emax` and
-  :attr:`~decimal.Context.Emin` has changed to :const:`999999`.
+  :attr:`~decimal.Context.Emin` has changed to ``999999``.
 
 * The :class:`~decimal.Decimal` constructor in decimal.py does not observe
   the context limits and converts values with arbitrary exponents or precision


### PR DESCRIPTION
It is for references, not for literals.


<!-- gh-issue-number: gh-107091 -->
* Issue: gh-107091
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--107379.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->