### PR TITLE
[3.12] GH-106898: Add the exception as an argument to the `PY_UNWIND` event callback function. (GH-107347)

### DIFF
--- a/Lib/test/test_monitoring.py
+++ b/Lib/test/test_monitoring.py
@@ -665,7 +665,7 @@ class CheckEvents(MonitoringTestBase, unittest.TestCase):
             self.assertIn(r0, ("raise", "reraise"))
             h0 = h[0]
             self.assertIn(h0, ("handled", "unwind"))
-
+            self.assertEqual(r[1], h[1])
 
 
 class StopiterationRecorder(ExceptionRecorder):
@@ -683,8 +683,8 @@ class UnwindRecorder(ExceptionRecorder):
 
     event_type = E.PY_UNWIND
 
-    def __call__(self, *args):
-        self.events.append(("unwind", None))
+    def __call__(self, code, offset, exc):
+        self.events.append(("unwind", type(exc)))
 
 class ExceptionHandledRecorder(ExceptionRecorder):
 

--- a/Misc/NEWS.d/next/Core and Builtins/2023-07-26-21-28-06.gh-issue-106898.8Wjuiv.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2023-07-26-21-28-06.gh-issue-106898.8Wjuiv.rst
@@ -1,0 +1,3 @@
+Add the exception as the third argument to ``PY_UNIND`` callbacks in
+``sys.monitoring``. This makes the ``PY_UNWIND`` callback consistent with
+the other exception hanlding callbacks.

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -2067,7 +2067,7 @@ monitor_unwind(PyThreadState *tstate,
     if (no_tools_for_event(tstate, frame, PY_MONITORING_EVENT_PY_UNWIND)) {
         return;
     }
-    _Py_call_instrumentation_exc0(tstate, PY_MONITORING_EVENT_PY_UNWIND, frame, instr);
+    do_monitor_exc(tstate, frame, instr, PY_MONITORING_EVENT_PY_UNWIND);
 }
 
 

--- a/Python/legacy_tracing.c
+++ b/Python/legacy_tracing.c
@@ -65,6 +65,16 @@ sys_profile_func3(
 }
 
 static PyObject *
+sys_profile_unwind(
+    _PyLegacyEventHandler *self, PyObject *const *args,
+    size_t nargsf, PyObject *kwnames
+) {
+    assert(kwnames == NULL);
+    assert(PyVectorcall_NARGS(nargsf) == 3);
+    return call_profile_func(self, Py_None);
+}
+
+static PyObject *
 sys_profile_call_or_return(
     _PyLegacyEventHandler *self, PyObject *const *args,
     size_t nargsf, PyObject *kwnames
@@ -149,6 +159,16 @@ sys_trace_func2(
 ) {
     assert(kwnames == NULL);
     assert(PyVectorcall_NARGS(nargsf) == 2);
+    return call_trace_func(self, Py_None);
+}
+
+static PyObject *
+sys_trace_unwind(
+    _PyLegacyEventHandler *self, PyObject *const *args,
+    size_t nargsf, PyObject *kwnames
+) {
+    assert(kwnames == NULL);
+    assert(PyVectorcall_NARGS(nargsf) == 3);
     return call_trace_func(self, Py_None);
 }
 
@@ -363,7 +383,7 @@ _PyEval_SetProfile(PyThreadState *tstate, Py_tracefunc func, PyObject *arg)
             return -1;
         }
         if (set_callbacks(PY_MONITORING_SYS_PROFILE_ID,
-            (vectorcallfunc)sys_profile_func2, PyTrace_RETURN,
+            (vectorcallfunc)sys_profile_unwind, PyTrace_RETURN,
                         PY_MONITORING_EVENT_PY_UNWIND, -1)) {
             return -1;
         }
@@ -451,7 +471,7 @@ _PyEval_SetTrace(PyThreadState *tstate, Py_tracefunc func, PyObject *arg)
             return -1;
         }
         if (set_callbacks(PY_MONITORING_SYS_TRACE_ID,
-            (vectorcallfunc)sys_trace_func2, PyTrace_RETURN,
+            (vectorcallfunc)sys_trace_unwind, PyTrace_RETURN,
                         PY_MONITORING_EVENT_PY_UNWIND, -1)) {
             return -1;
         }


### PR DESCRIPTION
@Yhg1s This is number 2 of the 3 fixes for PEP 669 (monitoring).

<!-- gh-issue-number: gh-106898 -->
* Issue: gh-106898
<!-- /gh-issue-number -->
