### PR TITLE
GH-104580: Put `eval_breaker` back at the start of the interpreter state.

### DIFF
--- a/Include/internal/pycore_ceval_state.h
+++ b/Include/internal/pycore_ceval_state.h
@@ -84,7 +84,9 @@ struct _ceval_runtime_state {
 
 struct _ceval_state {
     /* This single variable consolidates all requests to break out of
-       the fast path in the eval loop. */
+     * the fast path in the eval loop.
+     * It is by far the hottest field in this struct and
+     * should be placed at the beginning. */
     _Py_atomic_int eval_breaker;
     /* Request for dropping the GIL */
     _Py_atomic_int gil_drop_request;

--- a/Include/internal/pycore_interp.h
+++ b/Include/internal/pycore_interp.h
@@ -48,6 +48,11 @@ struct _Py_long_state {
    */
 struct _is {
 
+    /* This struct countains the eval_breaker,
+     * which is by far the hottest field in this struct
+     * and should be placed at the beginning. */
+    struct _ceval_state ceval;
+
     PyInterpreterState *next;
 
     int64_t id;
@@ -108,8 +113,6 @@ struct _is {
 
     // Dictionary of the builtins module
     PyObject *builtins;
-
-    struct _ceval_state ceval;
 
     struct _import_state imports;
 


### PR DESCRIPTION
Move the `eval_breaker` back to the start of interpreter state.

People seem to like moving this field, so I've added comments explaining why it should be the first field in the interpreter state.

<!-- gh-issue-number: gh-104580 -->
* Issue: gh-104580
<!-- /gh-issue-number -->
