### PR TITLE
gh-106368: Argument clinic: Fix minor bug in `state_modulename_name`

### DIFF
--- a/Lib/test/test_clinic.py
+++ b/Lib/test/test_clinic.py
@@ -84,6 +84,7 @@ class FakeClinic:
             ('parser_definition', d('block')),
             ('impl_definition', d('block')),
         ))
+        self.functions = []
 
     def get_destination(self, name):
         d = self.destinations.get(name)
@@ -103,6 +104,9 @@ class FakeClinic:
         self.called_directives[name] = args
 
     _module_and_class = clinic.Clinic._module_and_class
+
+    def __repr__(self):
+        return "<FakeClinic object>"
 
 
 class ClinicWholeFileTest(_ParserBase):
@@ -671,6 +675,19 @@ class ClinicParserTest(_ParserBase):
             os.stat as os_stat_fn
         """)
         self.assertEqual("os_stat_fn", function.c_basename)
+
+    def test_cloning_nonexistent_function_correctly_fails(self):
+        stdout = self.parse_function_should_fail("""
+            cloned = fooooooooooooooooooooooo
+            This is trying to clone a nonexistent function!!
+        """)
+        expected_error = """\
+cls=None, module=<FakeClinic object>, existing='fooooooooooooooooooooooo'
+(cls or module).functions=[]
+Error on line 0:
+Couldn't find existing function 'fooooooooooooooooooooooo'!
+"""
+        self.assertEqual(expected_error, stdout)
 
     def test_return_converter(self):
         function = self.parse_function("""

--- a/Tools/clinic/clinic.py
+++ b/Tools/clinic/clinic.py
@@ -4703,11 +4703,10 @@ class DSLParser:
                 function_name = fields.pop()
                 module, cls = self.clinic._module_and_class(fields)
 
-                try:
-                    existing_function = next(
-                        f for f in (cls or module).functions if f.name == function_name
-                    )
-                except StopIteration:
+                for existing_function in (cls or module).functions:
+                    if existing_function.name == function_name:
+                        break
+                else:
                     print(f"{cls=}, {module=}, {existing=}")
                     print(f"{(cls or module).functions=}")
                     fail(f"Couldn't find existing function {existing!r}!")

--- a/Tools/clinic/clinic.py
+++ b/Tools/clinic/clinic.py
@@ -4703,15 +4703,14 @@ class DSLParser:
                 function_name = fields.pop()
                 module, cls = self.clinic._module_and_class(fields)
 
-                for existing_function in (cls or module).functions:
-                    if existing_function.name == function_name:
-                        break
-                else:
-                    existing_function = None
-                if not existing_function:
-                    print("class", cls, "module", module, "existing", existing)
-                    print("cls. functions", cls.functions)
-                    fail("Couldn't find existing function " + repr(existing) + "!")
+                try:
+                    existing_function = next(
+                        f for f in (cls or module).functions if f.name == function_name
+                    )
+                except StopIteration:
+                    print(f"{cls=}, {module=}, {existing=}")
+                    print(f"{(cls or module).functions=}")
+                    fail(f"Couldn't find existing function {existing!r}!")
 
                 fields = [x.strip() for x in full_name.split('.')]
                 function_name = fields.pop()


### PR DESCRIPTION
`cls` on this line could be `None`, which causes the test case I'm adding in this PR to fail with `AttributeError: 'NoneType' object has no attribute 'functions'` on the `main` branch.

https://github.com/python/cpython/blob/0aa58fa7a62cd0ee7ec27fa87122425aeff0467d/Tools/clinic/clinic.py#L4713

(This failure path is currently not covered by any test cases, as far as I can tell. The bug is flagged by mypy if you add type annotations to the last remaining untyped function in `clinic.py`, `_module_and_class()`.)

@erlend-aasland: this is another one that _could_ be backported, since it's technically a bugfix, but to me feels minor enough to not be worth it.

<!-- gh-issue-number: gh-106368 -->
* Issue: gh-106368
<!-- /gh-issue-number -->
