### PR TITLE
GH-101291: Add warning to "what's new" that `PyLongObject` internals have changed.

### DIFF
--- a/Doc/whatsnew/3.12.rst
+++ b/Doc/whatsnew/3.12.rst
@@ -1865,6 +1865,17 @@ Porting to Python 3.12
   subinterpreter that they don't support (or haven't yet been loaded in). See
   :gh:`104668` for more info.
 
+* :c:struct:`PyLongObject` has had its internals changed for better performance.
+  Although the internals of :c:struct:`PyLongObject` are private, they are used
+  by some extension modules.
+  The internal fields should no longer be accessed directly, instead the API
+  functions beginning ``PyLong_...`` should be used instead.
+  Two new *unstable* API functions are provided for efficient access to the
+  value of :c:struct:`PyLongObject`\s which fit into a single machine word:
+
+  * :c:func:`PyUnstable_Long_IsCompact`
+  * :c:func:`PyUnstable_Long_CompactValue`
+
 Deprecated
 ----------
 


### PR DESCRIPTION


<!-- gh-issue-number: gh-101291 -->
* Issue: gh-101291
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--107388.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->