### PR TITLE
gh-104050: Argument clinic: complete type annotations

### DIFF
--- a/Tools/clinic/clinic.py
+++ b/Tools/clinic/clinic.py
@@ -2382,7 +2382,7 @@ class PythonParser:
 @dc.dataclass(repr=False)
 class Module:
     name: str
-    module: Module | Clinic | None = None
+    module: Module | Clinic
 
     def __post_init__(self) -> None:
         self.parent = self.module

--- a/Tools/clinic/mypy.ini
+++ b/Tools/clinic/mypy.ini
@@ -1,12 +1,15 @@
 [mypy]
+files = Tools/clinic/
+pretty = True
+
 # make sure clinic can still be run on Python 3.10
 python_version = 3.10
-pretty = True
-enable_error_code = ignore-without-code
-disallow_any_generics = True
+
+# be strict...
+strict = True
 strict_concatenate = True
-warn_redundant_casts = True
-warn_unused_ignores = True
-warn_unused_configs = True
+enable_error_code = ignore-without-code,redundant-expr
 warn_unreachable = True
-files = Tools/clinic/
+
+# ...except for one extra rule we can't enable just yet
+warn_return_any = False


### PR DESCRIPTION
Enable mypy `--strict`, ensuring that mypy will from now on complain if new functions without type annotations are added, and, if they are added anyway, will also check functions that don't have type annotations.

<!-- gh-issue-number: gh-104050 -->
* Issue: gh-104050
<!-- /gh-issue-number -->
