### PR TITLE
gh-107306: Add a Doc Entry for Py_mod_multiple_interpreters

### DIFF
--- a/Doc/c-api/init.rst
+++ b/Doc/c-api/init.rst
@@ -1287,6 +1287,7 @@ function. You can create and destroy them using the following functions:
       in any thread where the sub-interpreter is currently active.
       Otherwise only multi-phase init extension modules
       (see :pep:`489`) may be imported.
+      (Also see :c:macro:`Py_mod_multiple_interpreters`.)
 
       This must be ``1`` (non-zero) if
       :c:member:`~PyInterpreterConfig.use_main_obmalloc` is ``0``.

--- a/Doc/c-api/module.rst
+++ b/Doc/c-api/module.rst
@@ -396,6 +396,9 @@ The available slot types are:
       even when they have their own GIL.
       (See :ref:`isolating-extensions-howto`.)
 
+   This slot determines whether or not importing this module
+   in a subinterpreter will fail.
+
    Multiple ``Py_mod_multiple_interpreters`` slots may not be specified
    in one module definition.
 

--- a/Doc/c-api/module.rst
+++ b/Doc/c-api/module.rst
@@ -376,6 +376,32 @@ The available slot types are:
    If multiple ``Py_mod_exec`` slots are specified, they are processed in the
    order they appear in the *m_slots* array.
 
+.. c:macro:: Py_mod_multiple_interpreters
+
+   Specifies one of the following values:
+
+   .. c:macro:: Py_MOD_MULTIPLE_INTERPRETERS_NOT_SUPPORTED
+
+      The module does not support being imported in subinterpreters.
+
+   .. c:macro:: Py_MOD_MULTIPLE_INTERPRETERS_SUPPORTED
+
+      The module supports being imported in subinterpreters,
+      but only when they share the main interpreter's GIL.
+      (See :ref:`isolating-extensions-howto`.)
+
+   .. c:macro:: Py_MOD_PER_INTERPRETER_GIL_SUPPORTED
+
+      The module supports being imported in subinterpreters,
+      even when they have their own GIL.
+      (See :ref:`isolating-extensions-howto`.)
+
+   Multiple ``Py_mod_multiple_interpreters`` slots may not be specified
+   in one module definition.
+
+   If ``Py_mod_multiple_interpreters`` is not specified, the import
+   machinery defaults to ``Py_MOD_MULTIPLE_INTERPRETERS_NOT_SUPPORTED``.
+
 See :PEP:`489` for more details on multi-phase initialization.
 
 Low-level module creation functions

--- a/Doc/c-api/module.rst
+++ b/Doc/c-api/module.rst
@@ -405,6 +405,8 @@ The available slot types are:
    If ``Py_mod_multiple_interpreters`` is not specified, the import
    machinery defaults to ``Py_MOD_MULTIPLE_INTERPRETERS_NOT_SUPPORTED``.
 
+   .. versionadded:: 3.12
+
 See :PEP:`489` for more details on multi-phase initialization.
 
 Low-level module creation functions

--- a/Doc/howto/isolating-extensions.rst
+++ b/Doc/howto/isolating-extensions.rst
@@ -1,5 +1,7 @@
 .. highlight:: c
 
+.. _isolating-extensions-howto:
+
 ***************************
 Isolating Extension Modules
 ***************************


### PR DESCRIPTION
It was added in 3.12 for PEP 684 (per-interpreter GIL).

<!-- gh-issue-number: gh-107306 -->
* Issue: gh-107306
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--107403.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->