### PR TITLE
gh-104050: Argument clinic: enable mypy's `--warn-return-any` setting

### DIFF
--- a/Tools/clinic/clinic.py
+++ b/Tools/clinic/clinic.py
@@ -4283,6 +4283,11 @@ class float_return_converter(double_return_converter):
     cast = '(double)'
 
 
+# What do we do in this function?
+# We take an arbitrary AST node, compile the node into a function object,
+# call that function with 0 arguments, and return whatever the call returns.
+# The only possible return annotations here would be `object` or `Any`,
+# and `object` would be too annoying. Return `Any`!
 def eval_ast_expr(
         node: ast.expr,
         globals: dict[str, Any],

--- a/Tools/clinic/clinic.py
+++ b/Tools/clinic/clinic.py
@@ -4290,8 +4290,9 @@ def eval_ast_expr(
         filename: str = '-'
 ) -> Any:
     """
-    Takes an ast.Expr node.  Compiles and evaluates it.
-    Returns the result of the expression.
+    Takes an ast.Expr node.  Compiles it into a function object,
+    then calls the function object with 0 arguments.
+    Returns the result of that function call.
 
     globals represents the globals dict the expression
     should see.  (There's no equivalent for "locals" here.)

--- a/Tools/clinic/clinic.py
+++ b/Tools/clinic/clinic.py
@@ -4288,7 +4288,7 @@ def eval_ast_expr(
         globals: dict[str, Any],
         *,
         filename: str = '-'
-) -> FunctionType:
+) -> Any:
     """
     Takes an ast.Expr node.  Compiles and evaluates it.
     Returns the result of the expression.

--- a/Tools/clinic/clinic.py
+++ b/Tools/clinic/clinic.py
@@ -4283,11 +4283,6 @@ class float_return_converter(double_return_converter):
     cast = '(double)'
 
 
-# What do we do in this function?
-# We take an arbitrary AST node, compile the node into a function object,
-# call that function with 0 arguments, and return whatever the call returns.
-# The only possible return annotations here would be `object` or `Any`,
-# and `object` would be too annoying. Return `Any`!
 def eval_ast_expr(
         node: ast.expr,
         globals: dict[str, Any],

--- a/Tools/clinic/mypy.ini
+++ b/Tools/clinic/mypy.ini
@@ -5,11 +5,8 @@ pretty = True
 # make sure clinic can still be run on Python 3.10
 python_version = 3.10
 
-# be strict...
+# and be strict!
 strict = True
 strict_concatenate = True
 enable_error_code = ignore-without-code,redundant-expr
 warn_unreachable = True
-
-# ...except for one extra rule we can't enable just yet
-warn_return_any = False


### PR DESCRIPTION
Mypy's `--warn-return-any` check flags when a function is declared to return a specific type, but mypy can't verify whether it's _actually_ returning that type or not -- it can only infer a vague, unsafe `Any` type as the returned type. This can often lead to bugs slipping beneath the radar.

In the case of argument clinic, the check only flags a single function. _But_, turns out that it's a true positive! The function is incorrectly annotated at the moment -- the annotation says that it returns a `FunctionType`, but that's not true. The function creates a `FunctionType` _instance_ `fn`, and then returns whatever calling `fn` returns returns. Therefore, the proper return annotation for this function is `-> Any`, not `-> FunctionType`.

Closes #104050!

<!-- gh-issue-number: gh-104050 -->
* Issue: gh-104050
<!-- /gh-issue-number -->
