### PR TITLE
gh-107409: set `__wrapped__` attribute in `reprlib.recursive_repr`

### DIFF
--- a/Lib/reprlib.py
+++ b/Lib/reprlib.py
@@ -29,6 +29,7 @@ def recursive_repr(fillvalue='...'):
         wrapper.__name__ = getattr(user_function, '__name__')
         wrapper.__qualname__ = getattr(user_function, '__qualname__')
         wrapper.__annotations__ = getattr(user_function, '__annotations__', {})
+        wrapper.__wrapped__ = user_function
         return wrapper
 
     return decorating_function

--- a/Lib/test/test_reprlib.py
+++ b/Lib/test/test_reprlib.py
@@ -774,7 +774,5 @@ class TestRecursiveRepr(unittest.TestCase):
 
         self.assertIs(X.f, X.__repr__.__wrapped__)
 
-
-
 if __name__ == "__main__":
     unittest.main()

--- a/Lib/test/test_reprlib.py
+++ b/Lib/test/test_reprlib.py
@@ -765,5 +765,16 @@ class TestRecursiveRepr(unittest.TestCase):
         for name in assigned:
             self.assertIs(getattr(wrapper, name), getattr(wrapped, name))
 
+    def test__wrapped__(self):
+        class X:
+            def __repr__(self):
+                return 'X()'
+            f = __repr__ # save reference to check it later
+            __repr__ = recursive_repr()(__repr__)
+
+        self.assertIs(X.f, X.__repr__.__wrapped__)
+
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/Misc/NEWS.d/next/Library/2023-07-29-02-36-50.gh-issue-107409.HG27Nu.rst
+++ b/Misc/NEWS.d/next/Library/2023-07-29-02-36-50.gh-issue-107409.HG27Nu.rst
@@ -1,0 +1,1 @@
+Set `__wrapped__` attribute in `reprlib.recursive_repr`.

--- a/Misc/NEWS.d/next/Library/2023-07-29-02-36-50.gh-issue-107409.HG27Nu.rst
+++ b/Misc/NEWS.d/next/Library/2023-07-29-02-36-50.gh-issue-107409.HG27Nu.rst
@@ -1,1 +1,1 @@
-Set `__wrapped__` attribute in `reprlib.recursive_repr`.
+Set :attr:`!__wrapped__` attribute in :func:`reprlib.recursive_repr`.


### PR DESCRIPTION
fixes #107409

<!-- gh-issue-number: gh-107409 -->
* Issue: gh-107409
<!-- /gh-issue-number -->
