### PR TITLE
[3.12] gh-107091: Fix some uses of :func: role (GH-107378)

### DIFF
--- a/Doc/whatsnew/2.0.rst
+++ b/Doc/whatsnew/2.0.rst
@@ -664,7 +664,7 @@ extra set of parentheses to pass both values as a tuple:  ``L.append( (1,2) )``.
 
 The earlier versions of these methods were more forgiving because they used an
 old function in Python's C interface to parse their arguments; 2.0 modernizes
-them to use :func:`PyArg_ParseTuple`, the current argument parsing function,
+them to use :c:func:`PyArg_ParseTuple`, the current argument parsing function,
 which provides more helpful error messages and treats multi-argument calls as
 errors.  If you absolutely must use 2.0 but can't fix your code, you can edit
 :file:`Objects/listobject.c` and define the preprocessor symbol
@@ -766,7 +766,7 @@ file, :file:`Include/pyport.h`.
 
 Vladimir Marangozov's long-awaited malloc restructuring was completed, to make
 it easy to have the Python interpreter use a custom allocator instead of C's
-standard :func:`malloc`.  For documentation, read the comments in
+standard :c:func:`malloc`.  For documentation, read the comments in
 :file:`Include/pymem.h` and :file:`Include/objimpl.h`.  For the lengthy
 discussions during which the interface was hammered out, see the web archives of
 the 'patches' and 'python-dev' lists at python.org.
@@ -794,15 +794,15 @@ are generating Python code would run into this limit.  A patch by Charles G.
 Waldman raises the limit from ``2**16`` to ``2**32``.
 
 Three new convenience functions intended for adding constants to a module's
-dictionary at module initialization time were added: :func:`PyModule_AddObject`,
-:func:`PyModule_AddIntConstant`, and :func:`PyModule_AddStringConstant`.  Each
+dictionary at module initialization time were added: :c:func:`PyModule_AddObject`,
+:c:func:`PyModule_AddIntConstant`, and :c:func:`PyModule_AddStringConstant`.  Each
 of these functions takes a module object, a null-terminated C string containing
 the name to be added, and a third argument for the value to be assigned to the
 name.  This third argument is, respectively, a Python object, a C long, or a C
 string.
 
-A wrapper API was added for Unix-style signal handlers. :func:`PyOS_getsig` gets
-a signal handler and :func:`PyOS_setsig` will set a new handler.
+A wrapper API was added for Unix-style signal handlers. :c:func:`PyOS_getsig` gets
+a signal handler and :c:func:`PyOS_setsig` will set a new handler.
 
 .. ======================================================================
 

--- a/Doc/whatsnew/2.1.rst
+++ b/Doc/whatsnew/2.1.rst
@@ -692,8 +692,8 @@ applied, and 136 bugs fixed; both figures are likely to be underestimates.  Some
 of the more notable changes are:
 
 * A specialized object allocator is now optionally available, that should be
-  faster than the system :func:`malloc` and have less memory overhead.  The
-  allocator uses C's :func:`malloc` function to get large pools of memory, and
+  faster than the system :c:func:`malloc` and have less memory overhead.  The
+  allocator uses C's :c:func:`!malloc` function to get large pools of memory, and
   then fulfills smaller memory requests from these pools.  It can be enabled by
   providing the :option:`!--with-pymalloc` option to the :program:`configure`
   script; see :file:`Objects/obmalloc.c` for the implementation details.
@@ -701,13 +701,13 @@ of the more notable changes are:
   Authors of C extension modules should test their code with the object allocator
   enabled, because some incorrect code may break, causing core dumps at runtime.
   There are a bunch of memory allocation functions in Python's C API that have
-  previously been just aliases for the C library's :func:`malloc` and
-  :func:`free`, meaning that if you accidentally called mismatched functions, the
+  previously been just aliases for the C library's :c:func:`malloc` and
+  :c:func:`free`, meaning that if you accidentally called mismatched functions, the
   error wouldn't be noticeable.  When the object allocator is enabled, these
-  functions aren't aliases of :func:`malloc` and :func:`free` any more, and
+  functions aren't aliases of :c:func:`!malloc` and :c:func:`!free` any more, and
   calling the wrong function to free memory will get you a core dump.  For
-  example, if memory was allocated using :func:`PyMem_New`, it has to be freed
-  using :func:`PyMem_Del`, not :func:`free`.  A few modules included with Python
+  example, if memory was allocated using :c:macro:`PyMem_New`, it has to be freed
+  using :c:func:`PyMem_Del`, not :c:func:`!free`.  A few modules included with Python
   fell afoul of this and had to be fixed; doubtless there are more third-party
   modules that will have the same problem.
 
@@ -717,7 +717,7 @@ of the more notable changes are:
   complain about its lack of speed, and because it's often been used as a naïve
   benchmark.  The :meth:`readline` method of file objects has therefore been
   rewritten to be much faster.  The exact amount of the speedup will vary from
-  platform to platform depending on how slow the C library's :func:`getc` was, but
+  platform to platform depending on how slow the C library's :c:func:`!getc` was, but
   is around 66%, and potentially much faster on some particular operating systems.
   Tim Peters did much of the benchmarking and coding for this change, motivated by
   a discussion in comp.lang.python.
@@ -770,7 +770,7 @@ of the more notable changes are:
   reorganization done by Jeremy Hylton.
 
 * C extensions which import other modules have been changed to use
-  :func:`PyImport_ImportModule`, which means that they will use any import hooks
+  :c:func:`PyImport_ImportModule`, which means that they will use any import hooks
   that have been installed.  This is also encouraged for third-party extensions
   that need to import some other module from C code.
 

--- a/Misc/NEWS.d/3.11.0b1.rst
+++ b/Misc/NEWS.d/3.11.0b1.rst
@@ -1799,7 +1799,7 @@ The documentation now lists which members of C structs are part of the
 .. nonce: FIVe9I
 .. section: Documentation
 
-All docstrings in code snippets are now wrapped into :func:`PyDoc_STR` to
+All docstrings in code snippets are now wrapped into :c:macro:`PyDoc_STR` to
 follow the guideline of `PEP 7's Documentation Strings paragraph
 <https://www.python.org/dev/peps/pep-0007/#documentation-strings>`_. Patch
 by Oleg Iarygin.

--- a/Misc/NEWS.d/3.12.0a1.rst
+++ b/Misc/NEWS.d/3.12.0a1.rst
@@ -203,7 +203,7 @@ the interpreter.
 .. nonce: LYAWlE
 .. section: Core and Builtins
 
-Bugfix: :func:`PyFunction_GetAnnotations` should return a borrowed
+Bugfix: :c:func:`PyFunction_GetAnnotations` should return a borrowed
 reference. It was returning a new reference.
 
 ..

--- a/Misc/NEWS.d/3.12.0b1.rst
+++ b/Misc/NEWS.d/3.12.0b1.rst
@@ -1205,7 +1205,7 @@ the future, it will raise a ``KeyError``.
 
 Fixed a bug where :mod:`pdb` crashes when reading source file with different
 encoding by replacing :func:`io.open` with :func:`io.open_code`. The new
-method would also call into the hook set by :func:`PyFile_SetOpenCodeHook`.
+method would also call into the hook set by :c:func:`PyFile_SetOpenCodeHook`.
 
 ..
 

--- a/Misc/NEWS.d/3.9.0a1.rst
+++ b/Misc/NEWS.d/3.9.0a1.rst
@@ -5686,7 +5686,7 @@ positional argument.
 .. nonce: zrmgki
 .. section: C API
 
-Add :func:`PyConfig_SetWideStringList` function.
+Add :c:func:`PyConfig_SetWideStringList` function.
 
 ..
 


### PR DESCRIPTION
:c:func: or :c:macro: should be used instead..
(cherry picked from commit 413ba8943e2f1d896a0568eb571a041b88589440)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-107091 -->
* Issue: gh-107091
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--107416.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->