### PR TITLE
gh-107424: avoid using lambda functions in ``textwrap.indent()``

### DIFF
--- a/Lib/textwrap.py
+++ b/Lib/textwrap.py
@@ -475,18 +475,22 @@ def indent(text, prefix, predicate=None):
     it will default to adding 'prefix' to all non-empty lines that do not
     consist solely of whitespace characters.
     """
+    prefixed_lines = []
+
     if predicate is None:
         # str.splitlines(True) doesn't produce empty string.
         #  ''.splitlines(True) => []
         #  'foo\n'.splitlines(True) => ['foo\n']
-        # So we can use just `not s.isspace()` here.
-        predicate = lambda s: not s.isspace()
-
-    prefixed_lines = []
-    for line in text.splitlines(True):
-        if predicate(line):
-            prefixed_lines.append(prefix)
-        prefixed_lines.append(line)
+        # So we can use just `not line.isspace()` here.
+        for line in text.splitlines(True):
+            if not line.isspace():
+                prefixed_lines.append(prefix)
+            prefixed_lines.append(line)
+    else:
+        for line in text.splitlines(True):
+            if predicate(line):
+                prefixed_lines.append(prefix)
+            prefixed_lines.append(line)
 
     return ''.join(prefixed_lines)
 


### PR DESCRIPTION
As mentioned by https://github.com/python/cpython/pull/107374#issuecomment-1656528150, avoiding the use of a lambda function when no predicate is specified is expected to improve the performances.

The benchmarks reported on the issue corroborate this assumption. However, I would like to know if this is only because my laptop is dying (caching `.append` calls do not seem to help however).

I am waiting for changes to be verified before creating a NEWS entry (should I create it in conjunction to the already created one by @methane ?)

<!-- gh-issue-number: gh-107424 -->
* Issue: gh-107424
<!-- /gh-issue-number -->
