### PR TITLE
gh-104683: Argument clinic: pass `clinic` as a parameter where possible

### DIFF
--- a/Tools/clinic/clinic.py
+++ b/Tools/clinic/clinic.py
@@ -805,7 +805,8 @@ class CLanguage(Language):
 
     def output_templates(
             self,
-            f: Function
+            f: Function,
+            clinic: Clinic
     ) -> dict[str, str]:
         parameters = list(f.parameters.values())
         assert parameters
@@ -1324,7 +1325,6 @@ class CLanguage(Language):
             cpp_if = "#if " + conditional
             cpp_endif = "#endif /* " + conditional + " */"
 
-            assert clinic is not None
             if methoddef_define and f.full_name not in clinic.ifndef_symbols:
                 clinic.ifndef_symbols.add(f.full_name)
                 methoddef_ifndef = normalize_snippet("""
@@ -1490,7 +1490,7 @@ class CLanguage(Language):
         parameters = f.render_parameters
         converters = [p.converter for p in parameters]
 
-        templates = self.output_templates(f)
+        templates = self.output_templates(f, clinic)
 
         f_self = parameters[0]
         selfless = parameters[1:]
@@ -4614,7 +4614,7 @@ class DSLParser:
         self.next(self.state_terminal)
         self.state(None)
 
-        block.output.extend(self.clinic.language.render(clinic, block.signatures))
+        block.output.extend(self.clinic.language.render(self.clinic, block.signatures))
 
         if self.preserve_output:
             if block.output:


### PR DESCRIPTION
This PR started off life with me wanting to get rid of this at the end of `Clinic.__init__`, which feels like an awful hack to me:

https://github.com/python/cpython/blob/d0dcd27d3a8b8680803510fee59836cd732feb7a/Tools/clinic/clinic.py#L2206-L2207

`clinic` is elsewhere set to `None` in the global namespace in two places:

https://github.com/python/cpython/blob/d0dcd27d3a8b8680803510fee59836cd732feb7a/Tools/clinic/clinic.py#L2085

https://github.com/python/cpython/blob/d0dcd27d3a8b8680803510fee59836cd732feb7a/Tools/clinic/clinic.py#L5621

Unfortunately, removing this hack completely is rather difficult, due to the fact that `warn_or_fail` relies on `clinic` being a global variable! Passing `clinic` as a parameter to `warn_or_fail` would mean that every usage of `warn()` or `fail()` would have to be updated, which would have led to a huge diff.

https://github.com/python/cpython/blob/d0dcd27d3a8b8680803510fee59836cd732feb7a/Tools/clinic/clinic.py#L155-L171

Nonetheless, this PR still feels like a (small) improvement over the current state of affairs. In particular, by passing `clinic` as a parameter to `output_templates`, we remove the need for an `assert clinic is not None` assertion. This PR also reduces the changes that will be required in the future, should we want to move `output_templates` into a separate module...

<!-- gh-issue-number: gh-104683 -->
* Issue: gh-104683
<!-- /gh-issue-number -->
