### PR TITLE
gh-107422: Remove outdated `TypedDict` example from typing docs

### DIFF
--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -2329,9 +2329,6 @@ types.
 
       class XZ(X, Z): pass  # raises TypeError
 
-      T = TypeVar('T')
-      class XT(X, Generic[T]): pass  # raises TypeError
-
    A ``TypedDict`` can be generic::
 
       class Group[T](TypedDict):


### PR DESCRIPTION
Changed the lines:
``` diff

      class XZ(X, Z): pass  # raises TypeError

-       T = TypeVar('T')
-      class XT(X, Generic[T]): pass  # raises TypeError
-

   A ``TypedDict`` can be generic::

      class Group[T](TypedDict):
          key: T
   
```
this example was redundant as it was explained in deep in the next few lines. So it needed to get removed.

- issue: gh-107422


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--107436.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->