### PR TITLE
[3.11] gh-107422: Remove outdated `TypedDict` example from typing docs (#107436)

### DIFF
--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -2073,9 +2073,6 @@ types.
 
       class XZ(X, Z): pass  # raises TypeError
 
-      T = TypeVar('T')
-      class XT(X, Generic[T]): pass  # raises TypeError
-
    A ``TypedDict`` can be generic:
 
    .. testcode::


### PR DESCRIPTION
(cherry-picked from commit 89fd4f4a3fc5fb8076ec064c22a30108480e946b)

<!-- gh-issue-number: gh-107422 -->
* Issue: gh-107422
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--107438.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->