### PR TITLE
gh-104683: Argument clinic: Make the `filename` parameter to `Clinic` required

### DIFF
--- a/Tools/clinic/clinic.py
+++ b/Tools/clinic/clinic.py
@@ -2015,7 +2015,6 @@ class Destination:
         if self.type =='file':
             d = {}
             filename = self.clinic.filename
-            assert filename is not None
             d['path'] = filename
             dirname, basename = os.path.split(filename)
             if not dirname:
@@ -2133,8 +2132,8 @@ impl_definition block
             language: CLanguage,
             printer: BlockPrinter | None = None,
             *,
+            filename: str,
             verify: bool = True,
-            filename: str | None = None
     ) -> None:
         # maps strings to Parser objects.
         # (instantiated from the "parsers" global.)


### PR DESCRIPTION
`Clinic` objects are only ever created in one place in `clinic.py`, and the `filename` parameter is passed an object that we know to be a string:

https://github.com/python/cpython/blob/89fd4f4a3fc5fb8076ec064c22a30108480e946b/Tools/clinic/clinic.py#L2355

There's no need for this parameter to be optional. By making it required, we can remove an ugly assertion elsewhere that we added to keep mypy happy.

<!-- gh-issue-number: gh-104683 -->
* Issue: gh-104683
<!-- /gh-issue-number -->
