### PR TITLE
gh-107461 ctypes: Add a testcase for nested `_as_parameter_` lookup

### DIFF
--- a/Lib/test/test_ctypes/test_as_parameter.py
+++ b/Lib/test/test_ctypes/test_as_parameter.py
@@ -221,5 +221,16 @@ class AsParamPropertyWrapperTestCase(BasicWrapTestCase):
     wrap = AsParamPropertyWrapper
 
 
+class AsParamNestedWrapperTestCase(BasicWrapTestCase):
+    """Test that _as_parameter_ is evaluated recursively.
+
+    The _as_parameter_ attribute can be another object which
+    defines its own _as_parameter_ attribute.
+    """
+
+    def wrap(self, param):
+        return AsParamWrapper(AsParamWrapper(AsParamWrapper(param)))
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Adds a testcase for a nested lookup of the `_as_parameter_` attribute when converting a custom object to a `ctypes` type.

<!-- gh-issue-number: gh-107461 -->
* Issue: gh-107461
<!-- /gh-issue-number -->
