### PR TITLE
gh-106762: Add news for `EnumMeta.__getattr__` removal

### DIFF
--- a/Doc/whatsnew/3.12.rst
+++ b/Doc/whatsnew/3.12.rst
@@ -1234,6 +1234,10 @@ Removed
 
   (Contributed by Pradyun Gedam in :gh:`95299`.)
 
+* :mod:`enum`: Remove ``EnumMeta.__getattr__``, which is no longer needed for
+  enum attribute access.
+  (Contributed by Ethan Furman in :gh:`95083`.)
+
 * :mod:`ftplib`: Remove the ``FTP_TLS.ssl_version`` class attribute: use the
   *context* parameter instead.
   (Contributed by Victor Stinner in :gh:`94172`.)

--- a/Misc/NEWS.d/3.12.0a1.rst
+++ b/Misc/NEWS.d/3.12.0a1.rst
@@ -2752,7 +2752,7 @@ by Shin-myoung-serp.
 .. section: Library
 
 Add deprecation warning for enum ``member.member`` access (e.g.
-``Color.RED.BLUE``).
+``Color.RED.BLUE``). Remove ``EnumMeta.__getattr__``.
 
 ..
 


### PR DESCRIPTION
Adds news entry for removal of a documented dunder name.

Affects 3.12 branch.

Closes #106762

<!-- gh-issue-number: gh-106762 -->
* Issue: gh-106762
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--107466.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->