### PR TITLE
gh-107467: Restructure Argument Clinic command-line interface

### DIFF
--- a/Lib/test/test_clinic.py
+++ b/Lib/test/test_clinic.py
@@ -1626,7 +1626,7 @@ class ClinicExternalTest(TestCase):
 
     def test_cli_fail_output_and_multiple_files(self):
         _, err = self.expect_failure("-o", "out.c", "input.c", "moreinput.c")
-        msg = "Usage error: can't use -o with multiple filenames"
+        msg = "error: can't use -o with multiple filenames"
         self.assertIn(msg, err)
 
     def test_cli_fail_filename_or_output_and_make(self):
@@ -1638,7 +1638,7 @@ class ClinicExternalTest(TestCase):
 
     def test_cli_fail_make_without_srcdir(self):
         _, err = self.expect_failure("--make", "--srcdir", "")
-        msg = "Usage error: --srcdir must not be empty with --make"
+        msg = "error: --srcdir must not be empty with --make"
         self.assertIn(msg, err)
 
 

--- a/Lib/test/test_clinic.py
+++ b/Lib/test/test_clinic.py
@@ -1391,30 +1391,24 @@ Couldn't find existing function 'fooooooooooooooooooooooo'!
 
 class ClinicExternalTest(TestCase):
     maxDiff = None
-    clinic_py = os.path.join(test_tools.toolsdir, "clinic", "clinic.py")
-
-    def _do_test(self, *args, expect_success=True):
-        with subprocess.Popen(
-            [sys.executable, "-Xutf8", self.clinic_py, *args],
-            encoding="utf-8",
-            bufsize=0,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-        ) as proc:
-            proc.wait()
-            if expect_success and proc.returncode:
-                self.fail("".join([*proc.stdout, *proc.stderr]))
-            stdout = proc.stdout.read()
-            stderr = proc.stderr.read()
-            # Clinic never writes to stderr.
-            self.assertEqual(stderr, "")
-            return stdout
 
     def expect_success(self, *args):
-        return self._do_test(*args)
+        with support.captured_stdout() as out, support.captured_stderr() as err:
+            try:
+                clinic.main(args)
+            except SystemExit as exc:
+                if exc.code != 0:
+                    self.fail(f"unexpected failure: {args=}")
+        self.assertEqual(err.getvalue(), "")
+        return out.getvalue()
 
     def expect_failure(self, *args):
-        return self._do_test(*args, expect_success=False)
+        with support.captured_stdout() as out, support.captured_stderr() as err:
+            with self.assertRaises(SystemExit) as cm:
+                clinic.main(args)
+            if cm.exception.code == 0:
+                self.fail(f"unexpected success: {args=}")
+        return out.getvalue(), err.getvalue()
 
     def test_external(self):
         CLINIC_TEST = 'clinic.test.c'
@@ -1478,8 +1472,9 @@ class ClinicExternalTest(TestCase):
             # First, run the CLI without -f and expect failure.
             # Note, we cannot check the entire fail msg, because the path to
             # the tmp file will change for every run.
-            out = self.expect_failure(fn)
-            self.assertTrue(out.endswith(fail_msg))
+            out, _ = self.expect_failure(fn)
+            self.assertTrue(out.endswith(fail_msg),
+                            f"{out!r} does not end with {fail_msg!r}")
             # Then, force regeneration; success expected.
             out = self.expect_success("-f", fn)
             self.assertEqual(out, "")
@@ -1621,33 +1616,30 @@ class ClinicExternalTest(TestCase):
                 )
 
     def test_cli_fail_converters_and_filename(self):
-        out = self.expect_failure("--converters", "test.c")
-        msg = (
-            "Usage error: can't specify --converters "
-            "and a filename at the same time"
-        )
-        self.assertIn(msg, out)
+        _, err = self.expect_failure("--converters", "test.c")
+        msg = "can't specify --converters and a filename at the same time"
+        self.assertIn(msg, err)
 
     def test_cli_fail_no_filename(self):
-        out = self.expect_failure()
-        self.assertIn("usage: clinic.py", out)
+        _, err = self.expect_failure()
+        self.assertIn("no input files", err)
 
     def test_cli_fail_output_and_multiple_files(self):
-        out = self.expect_failure("-o", "out.c", "input.c", "moreinput.c")
+        _, err = self.expect_failure("-o", "out.c", "input.c", "moreinput.c")
         msg = "Usage error: can't use -o with multiple filenames"
-        self.assertIn(msg, out)
+        self.assertIn(msg, err)
 
     def test_cli_fail_filename_or_output_and_make(self):
+        msg = "can't use -o or filenames with --make"
         for opts in ("-o", "out.c"), ("filename.c",):
             with self.subTest(opts=opts):
-                out = self.expect_failure("--make", *opts)
-                msg = "Usage error: can't use -o or filenames with --make"
-                self.assertIn(msg, out)
+                _, err = self.expect_failure("--make", *opts)
+                self.assertIn(msg, err)
 
     def test_cli_fail_make_without_srcdir(self):
-        out = self.expect_failure("--make", "--srcdir", "")
+        _, err = self.expect_failure("--make", "--srcdir", "")
         msg = "Usage error: --srcdir must not be empty with --make"
-        self.assertIn(msg, out)
+        self.assertIn(msg, err)
 
 
 try:

--- a/Lib/test/test_clinic.py
+++ b/Lib/test/test_clinic.py
@@ -4,14 +4,12 @@
 
 from test import support, test_tools
 from test.support import os_helper
-from test.support import SHORT_TIMEOUT, requires_subprocess
 from test.support.os_helper import TESTFN, unlink
 from textwrap import dedent
 from unittest import TestCase
 import collections
 import inspect
 import os.path
-import subprocess
 import sys
 import unittest
 

--- a/Misc/NEWS.d/next/Tools-Demos/2023-07-30-23-32-16.gh-issue-107467.5O9p3G.rst
+++ b/Misc/NEWS.d/next/Tools-Demos/2023-07-30-23-32-16.gh-issue-107467.5O9p3G.rst
@@ -1,0 +1,2 @@
+The Argument Clinic command-line tool now prints to stderr instead of stdout
+on failure.

--- a/Tools/clinic/clinic.py
+++ b/Tools/clinic/clinic.py
@@ -5756,5 +5756,6 @@ def main(argv: list[str] | None = None) -> None:
         cli.print_usage()
         sys.exit(1)
 
+
 if __name__ == "__main__":
     main()

--- a/Tools/clinic/clinic.py
+++ b/Tools/clinic/clinic.py
@@ -5747,8 +5747,8 @@ def run_clinic(ns: argparse.Namespace) -> None:
 
 def main(argv: list[str] | None = None) -> None:
     cli = create_cli()
+    args = cli.parse_args(argv)
     try:
-        args = cli.parse_args(argv)
         run_clinic(args)
     except CLIError as exc:
         if msg := str(exc):

--- a/Tools/clinic/clinic.py
+++ b/Tools/clinic/clinic.py
@@ -5708,7 +5708,7 @@ def run_clinic(parser: argparse.ArgumentParser, ns: argparse.Namespace) -> None:
             print()
         print("All converters also accept (c_default=None, py_default=None, annotation=None).")
         print("All return converters also accept (py_default=None).")
-        sys.exit(0)
+        return
 
     if ns.make:
         if ns.output or ns.filename:


### PR DESCRIPTION
- Add and use CLIError exception for CLI usage errors
- On CLI error, print to stderr instead of stdout
- Put the entire CLI in main()
- Rework ClinicExternalTest to call main() instead of using subprocesses

<!-- gh-issue-number: gh-107467 -->
* Issue: gh-107467
<!-- /gh-issue-number -->
