### PR TITLE
[3.11] gh-105751, test_ctypes: Remove disabled tests (GH-105826)

### DIFF
--- a/Lib/ctypes/test/test_byteswap.py
+++ b/Lib/ctypes/test/test_byteswap.py
@@ -14,14 +14,6 @@ def bin(s):
 # For Structures and Unions, these types are created on demand.
 
 class Test(unittest.TestCase):
-    @unittest.skip('test disabled')
-    def test_X(self):
-        print(sys.byteorder, file=sys.stderr)
-        for i in range(32):
-            bits = BITS()
-            setattr(bits, "i%s" % i, 1)
-            dump(bits)
-
     def test_slots(self):
         class BigPoint(BigEndianStructure):
             __slots__ = ()

--- a/Lib/ctypes/test/test_callbacks.py
+++ b/Lib/ctypes/test/test_callbacks.py
@@ -93,14 +93,6 @@ class Callbacks(unittest.TestCase):
         self.check_type(c_char, b"x")
         self.check_type(c_char, b"a")
 
-    # disabled: would now (correctly) raise a RuntimeWarning about
-    # a memory leak.  A callback function cannot return a non-integral
-    # C type without causing a memory leak.
-    @unittest.skip('test disabled')
-    def test_char_p(self):
-        self.check_type(c_char_p, "abc")
-        self.check_type(c_char_p, "def")
-
     def test_pyobject(self):
         o = ()
         from sys import getrefcount as grc

--- a/Lib/ctypes/test/test_keeprefs.py
+++ b/Lib/ctypes/test/test_keeprefs.py
@@ -93,37 +93,6 @@ class PointerTestCase(unittest.TestCase):
         x = pointer(i)
         self.assertEqual(x._objects, {'1': i})
 
-class DeletePointerTestCase(unittest.TestCase):
-    @unittest.skip('test disabled')
-    def test_X(self):
-        class X(Structure):
-            _fields_ = [("p", POINTER(c_char_p))]
-        x = X()
-        i = c_char_p("abc def")
-        from sys import getrefcount as grc
-        print("2?", grc(i))
-        x.p = pointer(i)
-        print("3?", grc(i))
-        for i in range(320):
-            c_int(99)
-            x.p[0]
-        print(x.p[0])
-##        del x
-##        print "2?", grc(i)
-##        del i
-        import gc
-        gc.collect()
-        for i in range(320):
-            c_int(99)
-            x.p[0]
-        print(x.p[0])
-        print(x.p.contents)
-##        print x._objects
-
-        x.p[0] = "spam spam"
-##        print x.p[0]
-        print("+" * 42)
-        print(x._objects)
 
 class PointerToStructure(unittest.TestCase):
     def test(self):

--- a/Lib/ctypes/test/test_numbers.py
+++ b/Lib/ctypes/test/test_numbers.py
@@ -82,14 +82,6 @@ class NumberTestCase(unittest.TestCase):
             self.assertRaises(TypeError, t, "")
             self.assertRaises(TypeError, t, None)
 
-    @unittest.skip('test disabled')
-    def test_valid_ranges(self):
-        # invalid values of the correct type
-        # raise ValueError (not OverflowError)
-        for t, (l, h) in zip(unsigned_types, unsigned_ranges):
-            self.assertRaises(ValueError, t, l-1)
-            self.assertRaises(ValueError, t, h+1)
-
     def test_from_param(self):
         # the from_param class method attribute always
         # returns PyCArgObject instances
@@ -205,19 +197,6 @@ class NumberTestCase(unittest.TestCase):
         a[0] = ord('?')
         self.assertEqual(v.value, b'?')
 
-    # array does not support c_bool / 't'
-    @unittest.skip('test disabled')
-    def test_bool_from_address(self):
-        from ctypes import c_bool
-        from array import array
-        a = array(c_bool._type_, [True])
-        v = t.from_address(a.buffer_info()[0])
-        self.assertEqual(v.value, a[0])
-        self.assertEqual(type(v) is t)
-        a[0] = False
-        self.assertEqual(v.value, a[0])
-        self.assertEqual(type(v) is t)
-
     def test_init(self):
         # c_int() can be initialized from Python's int, and c_int.
         # Not from c_long or so, which seems strange, abc should
@@ -234,62 +213,6 @@ class NumberTestCase(unittest.TestCase):
             if (hasattr(t, "__ctype_le__")):
                 self.assertRaises(OverflowError, t.__ctype_le__, big_int)
 
-    @unittest.skip('test disabled')
-    def test_perf(self):
-        check_perf()
-
-from ctypes import _SimpleCData
-class c_int_S(_SimpleCData):
-    _type_ = "i"
-    __slots__ = []
-
-def run_test(rep, msg, func, arg=None):
-##    items = [None] * rep
-    items = range(rep)
-    from time import perf_counter as clock
-    if arg is not None:
-        start = clock()
-        for i in items:
-            func(arg); func(arg); func(arg); func(arg); func(arg)
-        stop = clock()
-    else:
-        start = clock()
-        for i in items:
-            func(); func(); func(); func(); func()
-        stop = clock()
-    print("%15s: %.2f us" % (msg, ((stop-start)*1e6/5/rep)))
-
-def check_perf():
-    # Construct 5 objects
-    from ctypes import c_int
-
-    REP = 200000
-
-    run_test(REP, "int()", int)
-    run_test(REP, "int(999)", int)
-    run_test(REP, "c_int()", c_int)
-    run_test(REP, "c_int(999)", c_int)
-    run_test(REP, "c_int_S()", c_int_S)
-    run_test(REP, "c_int_S(999)", c_int_S)
-
-# Python 2.3 -OO, win2k, P4 700 MHz:
-#
-#          int(): 0.87 us
-#       int(999): 0.87 us
-#        c_int(): 3.35 us
-#     c_int(999): 3.34 us
-#      c_int_S(): 3.23 us
-#   c_int_S(999): 3.24 us
-
-# Python 2.2 -OO, win2k, P4 700 MHz:
-#
-#          int(): 0.89 us
-#       int(999): 0.89 us
-#        c_int(): 9.99 us
-#     c_int(999): 10.02 us
-#      c_int_S(): 9.87 us
-#   c_int_S(999): 9.85 us
 
 if __name__ == '__main__':
-##    check_perf()
     unittest.main()

--- a/Lib/ctypes/test/test_structures.py
+++ b/Lib/ctypes/test/test_structures.py
@@ -359,15 +359,6 @@ class StructureTestCase(unittest.TestCase):
         except Exception as detail:
             return detail.__class__, str(detail)
 
-    @unittest.skip('test disabled')
-    def test_subclass_creation(self):
-        meta = type(Structure)
-        # same as 'class X(Structure): pass'
-        # fails, since we need either a _fields_ or a _abstract_ attribute
-        cls, msg = self.get_except(meta, "X", (Structure,), {})
-        self.assertEqual((cls, msg),
-                (AttributeError, "class must define a '_fields_' attribute"))
-
     def test_abstract_class(self):
         class X(Structure):
             _abstract_ = "something"


### PR DESCRIPTION
* The following tests were disabled since the initial ctypes commit in 2006, commit babddfca758abe34ff12023f63b18d745fae7ca9:

  * Callbacks.test_char_p()
  * DeletePointerTestCase.test_X()
  * NumberTestCase.test_perf()
  * StructureTestCase.test_subclass_creation()
  * Tests.test_X() of test_byteswap

* NumberTestCase.test_bool_from_address() was disabled in 2007 by commit 5dc4fe09b7648f9801558e766b21a3d3b2dcad3b.
* Remove check_perf() and run_test() of test_numbers. (cherry picked from commit 8f10140e74d141a0a894702044e213e6f0690d9c)


<!-- gh-issue-number: gh-105751 -->
* Issue: gh-105751
<!-- /gh-issue-number -->
