### PR TITLE
Delete the `LandMine` class

### DIFF
--- a/Tools/clinic/clinic.py
+++ b/Tools/clinic/clinic.py
@@ -2831,6 +2831,10 @@ class CConverter(metaclass=CConverterAutoRegister):
         if annotation is not unspecified:
             fail("The 'annotation' parameter is not currently permitted.")
 
+        # Make sure not to set self.function until after converter_init() has been called.
+        # This prevents you from caching information
+        # about the function in converter_init().
+        # (That breaks if we get cloned.)
         self.converter_init(**kwargs)
         self.function = function
 


### PR DESCRIPTION
@erlend-aasland, what do you think about this? It simplifies some of the typing, since now `CConverter.function` is always an instance of `Function`, instead of sometimes being an instance of `LandMine`. I'm not sure why we need to temporarily set `self.function` to be an instance of `LandMine` -- I feel like we can get the same effect by just not setting `self.function` until after `converter_init()` has been called. But I'm a bit wary of Chesterton's Fence here -- I'm not sure I understand fully exactly which problem the `self.function = LandMine()` thing was originally supposed to solve.