### PR TITLE
[3.12] gh-105751: Remove obsolete `object` base class in some ctypes tests (GH-107460)

### DIFF
--- a/Lib/test/test_ctypes/test_as_parameter.py
+++ b/Lib/test/test_ctypes/test_as_parameter.py
@@ -194,7 +194,7 @@ class BasicWrapTestCase(unittest.TestCase):
     def test_recursive_as_param(self):
         from ctypes import c_int
 
-        class A(object):
+        class A:
             pass
 
         a = A()
@@ -205,7 +205,7 @@ class BasicWrapTestCase(unittest.TestCase):
 
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-class AsParamWrapper(object):
+class AsParamWrapper:
     def __init__(self, param):
         self._as_parameter_ = param
 
@@ -214,7 +214,7 @@ class AsParamWrapperTestCase(BasicWrapTestCase):
 
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-class AsParamPropertyWrapper(object):
+class AsParamPropertyWrapper:
     def __init__(self, param):
         self._param = param
 

--- a/Lib/test/test_ctypes/test_callbacks.py
+++ b/Lib/test/test_ctypes/test_callbacks.py
@@ -122,7 +122,7 @@ class Callbacks(unittest.TestCase):
     def test_issue_7959(self):
         proto = self.functype.__func__(None)
 
-        class X(object):
+        class X:
             def func(self): pass
             def __init__(self):
                 self.v = proto(self.func)

--- a/Lib/test/test_ctypes/test_numbers.py
+++ b/Lib/test/test_ctypes/test_numbers.py
@@ -98,7 +98,7 @@ class NumberTestCase(unittest.TestCase):
     def test_floats(self):
         # c_float and c_double can be created from
         # Python int and float
-        class FloatLike(object):
+        class FloatLike:
             def __float__(self):
                 return 2.0
         f = FloatLike()
@@ -109,15 +109,15 @@ class NumberTestCase(unittest.TestCase):
             self.assertEqual(t(f).value, 2.0)
 
     def test_integers(self):
-        class FloatLike(object):
+        class FloatLike:
             def __float__(self):
                 return 2.0
         f = FloatLike()
-        class IntLike(object):
+        class IntLike:
             def __int__(self):
                 return 2
         d = IntLike()
-        class IndexLike(object):
+        class IndexLike:
             def __index__(self):
                 return 2
         i = IndexLike()

--- a/Lib/test/test_ctypes/test_parameters.py
+++ b/Lib/test/test_ctypes/test_parameters.py
@@ -167,7 +167,7 @@ class SimpleTypesTestCase(unittest.TestCase):
         # TypeError: has no from_param method
         self.assertRaises(TypeError, setattr, func, "argtypes", (object,))
 
-        class Adapter(object):
+        class Adapter:
             def from_param(cls, obj):
                 return None
 
@@ -175,7 +175,7 @@ class SimpleTypesTestCase(unittest.TestCase):
         self.assertEqual(func(None), None)
         self.assertEqual(func(object()), None)
 
-        class Adapter(object):
+        class Adapter:
             def from_param(cls, obj):
                 return obj
 
@@ -184,7 +184,7 @@ class SimpleTypesTestCase(unittest.TestCase):
         self.assertRaises(ArgumentError, func, object())
         self.assertEqual(func(c_void_p(42)), 42)
 
-        class Adapter(object):
+        class Adapter:
             def from_param(cls, obj):
                 raise ValueError(obj)
 


### PR DESCRIPTION
(cherry picked from commit 520efecfc3aed34d3a44545c7cd872d1aea8c7dc)


<!-- gh-issue-number: gh-105751 -->
* Issue: gh-105751
<!-- /gh-issue-number -->
