### PR TITLE
Typing docs: clarify the effect in subclasses of using `Self` as a return type

### DIFF
--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -990,7 +990,7 @@ using ``[]``.
    In general, if something returns ``self``, as in the above examples, you
    should use ``Self`` as the return annotation. If ``Foo.return_self`` was
    annotated as returning ``"Foo"``, then the type checker would infer the
-   object returned from ``SubclassOfFoo.return_self`` as being of type ``Foo`
+   object returned from ``SubclassOfFoo.return_self`` as being of type ``Foo``
    rather than ``SubclassOfFoo``.
 
    Other common use cases include:

--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -963,7 +963,7 @@ using ``[]``.
 
    For example::
 
-      from typing import Self
+      from typing import Self, reveal_type
 
       class Foo:
           def return_self(self) -> Self:

--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -970,6 +970,10 @@ using ``[]``.
               ...
               return self
 
+      class SubclassOfFoo(Foo): pass
+
+      reveal_type(Foo().return_self())  # Revealed type is "Foo"
+      reveal_type(SubclassOfFoo().return_self())  # Revealed type is "SubclassOfFoo"
 
    This annotation is semantically equivalent to the following,
    albeit in a more succinct fashion::
@@ -983,29 +987,15 @@ using ``[]``.
               ...
               return self
 
-   In general if something currently follows the pattern of::
+   In general if something returns ``self``::
 
       class Foo:
           def return_self(self) -> "Foo":
               ...
               return self
 
-   You should use :data:`Self`. This way the return type of the
-   method will be the type of ``self``, even in subclasses::
-
-      class Foo:
-          def return_self(self) -> Self:
-              ...
-              return self
-
-      class SubclassOfFoo(Foo):
-            ...
-
-      reveal_type(Foo().return_self())  # Revealed type is "Foo"
-      reveal_type(SubclassOfFoo().return_self())  # Revealed type is "SubclassOfFoo"
-
-   Otherwise, the return type of ``SubclassOfFoo().return_self()`` is
-   ``Foo``, which may not be what you wanted.
+   You should use :data:`Self` as calls to ``SubclassOfFoo.return_self`` would have
+   ``Foo`` as the return type and not ``SubclassOfFoo``.
 
    Other common use cases include:
 

--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -987,21 +987,28 @@ using ``[]``.
               ...
               return self
 
-   In general if something returns ``self``::
-
-      class Foo:
-          def return_self(self) -> "Foo":
-              ...
-              return self
-
-   You should use :data:`Self` as calls to ``SubclassOfFoo.return_self`` would have
-   ``Foo`` as the return type and not ``SubclassOfFoo``.
+   In general, if something returns ``self``, as in the above examples, you
+   should use ``Self`` as the return annotation. If ``Foo.return_self`` was
+   annotated as returning ``"Foo"``, then the type checker would infer the
+   object returned from ``SubclassOfFoo.return_self`` as being ``Foo`` rather
+   than ``SubclassOfFoo``.
 
    Other common use cases include:
 
    - :class:`classmethod`\s that are used as alternative constructors and return instances
      of the ``cls`` parameter.
    - Annotating an :meth:`~object.__enter__` method which returns self.
+
+   You should not use ``Self`` as the return annotation if the method is not
+   guaranteed to return an instance of a subclass when the class is
+   subclassed::
+
+      class Eggs:
+          # Self would be an incorrect return annotation here,
+          # as the object returned is always an instance of Eggs,
+          # even in subclasses
+          def returns_eggs(self) -> "Eggs":
+              return Eggs()
 
    See :pep:`673` for more details.
 

--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -990,8 +990,22 @@ using ``[]``.
               ...
               return self
 
-   You should use :data:`Self` as calls to ``SubclassOfFoo.return_self`` would have
-   ``Foo`` as the return type and not ``SubclassOfFoo``.
+   You should use :data:`Self`. This way the return type of the annotated
+   method will be whatever the type of ``self`` is, even in subclasses::
+
+      class Foo:
+          def return_self(self) -> Self:
+              ...
+              return self
+
+      class SubclassOfFoo(Foo):
+            ...
+
+      reveal_type(Foo().return_self())  # Revealed type is "Foo"
+      reveal_type(SubclassOfFoo().return_self())  # Revealed type is "SubclassOfFoo"
+
+   Otherwise the return type of ``SubclassOfFoo().return_self()`` would have
+   been ``Foo`` and that may not be what you wanted.
 
    Other common use cases include:
 

--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -990,8 +990,8 @@ using ``[]``.
               ...
               return self
 
-   You should use :data:`Self`. This way the return type of the annotated
-   method will be whatever the type of ``self`` is, even in subclasses::
+   You should use :data:`Self`. This way the return type of the
+   method will be the type of ``self``, even in subclasses::
 
       class Foo:
           def return_self(self) -> Self:
@@ -1004,8 +1004,8 @@ using ``[]``.
       reveal_type(Foo().return_self())  # Revealed type is "Foo"
       reveal_type(SubclassOfFoo().return_self())  # Revealed type is "SubclassOfFoo"
 
-   Otherwise the return type of ``SubclassOfFoo().return_self()`` would have
-   been ``Foo`` and that may not be what you wanted.
+   Otherwise, the return type of ``SubclassOfFoo().return_self()`` is
+   ``Foo``, which may not be what you wanted.
 
    Other common use cases include:
 

--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -990,8 +990,8 @@ using ``[]``.
    In general, if something returns ``self``, as in the above examples, you
    should use ``Self`` as the return annotation. If ``Foo.return_self`` was
    annotated as returning ``"Foo"``, then the type checker would infer the
-   object returned from ``SubclassOfFoo.return_self`` as being ``Foo`` rather
-   than ``SubclassOfFoo``.
+   object returned from ``SubclassOfFoo.return_self`` as being of type ``Foo`
+   rather than ``SubclassOfFoo``.
 
    Other common use cases include:
 


### PR DESCRIPTION
This is a follow-up to https://github.com/python/mypy/issues/15609 where I seek to improve just a little the docs on `typing.Self`

<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--107511.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->