### PR TITLE
GH-104584: Fix incorrect uoperands

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2023-07-29-22-01-30.gh-issue-104584.tINuoA.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2023-07-29-22-01-30.gh-issue-104584.tINuoA.rst
@@ -1,2 +1,2 @@
-Fix an issue which caused incorrect inline values to be used when running
+Fix an issue which caused incorrect inline caches to be read when running
 with :envvar:`PYTHONUOPS` or :option:`-X uops <-X>` enabled.

--- a/Misc/NEWS.d/next/Core and Builtins/2023-07-29-22-01-30.gh-issue-104584.tINuoA.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2023-07-29-22-01-30.gh-issue-104584.tINuoA.rst
@@ -1,0 +1,2 @@
+Fix an issue which caused incorrect inline values to be used when running
+with :envvar:`PYTHONUOPS` or :option:`-X uops <-X>` enabled.

--- a/Python/optimizer.c
+++ b/Python/optimizer.c
@@ -579,7 +579,8 @@ pop_jump_if_bool:
                     for (int i = 0; i < nuops; i++) {
                         oparg = orig_oparg;
                         uint64_t operand = 0;
-                        int offset = expansion->uops[i].offset;
+                        // Add one to account for the actual opcode/oparg pair:
+                        int offset = expansion->uops[i].offset + 1;
                         switch (expansion->uops[i].size) {
                             case OPARG_FULL:
                                 if (extras && OPCODE_HAS_JUMP(opcode)) {


### PR DESCRIPTION
There's currently an off-by-one error during trace construction that causes incorrect values to be loaded from the inline caches.

This fix results in a significant reduction in deoptimization events, and a dramatic improvement in our ability to stay on trace!

<!-- gh-issue-number: gh-104584 -->
* Issue: gh-104584
<!-- /gh-issue-number -->
