### PR TITLE
Remove newlines from bug template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -19,10 +19,8 @@ labels: "type-bug"
 
 <!-- Bugs in third-party projects (e.g. `requests`) do not belong in the CPython issue tracker -->
 
-- [ ] I am confident this is a bug in CPython,
-      not a bug in a third-party project
-- [ ] I have searched the CPython issue tracker,
-      and am confident this bug has not been reported before
+- [ ] I am confident this is a bug in CPython, not a bug in a third-party project
+- [ ] I have searched the CPython issue tracker, and am confident this bug has not been reported before
 
 ## A clear and concise description of the bug
 


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

Follow on from https://github.com/python/cpython/pull/107150, cc @AlexWaygood.

With Markdown like this:

```md
- [ ] I am confident this is a bug in CPython,
      not a bug in a third-party project
- [ ] I have searched the CPython issue tracker,
      and am confident this bug has not been reported before
```

GitHub correctly elides the newlines out when viewing the [template file directly](https://github.com/python/cpython/blob/79e479c45fc63b6001b206fec832064c31fc1f11/.github/ISSUE_TEMPLATE/bug.md):

<img width="777" alt="image" src="https://github.com/python/cpython/assets/1324225/aed252c5-a4f4-4d30-bfad-0227a38df44e">

But adds hard newlines when rendering it in an issue. For example: https://github.com/python/cpython/issues/107515

<img width="863" alt="image" src="https://github.com/python/cpython/assets/1324225/9b4a1df2-ddfa-43ad-baaa-355e8f0cfd09">

It's looks a bit odd and is not such a problem for desktop layouts, but is worse on mobile:

<img width=50% src=https://github.com/python/cpython/assets/1324225/03ef8745-77fb-4766-91e8-870d4163d20f>
