### PR TITLE
gh-106608: make uop trace variable length

### DIFF
--- a/Include/cpython/optimizer.h
+++ b/Include/cpython/optimizer.h
@@ -12,7 +12,7 @@ typedef struct {
 } _PyVMData;
 
 typedef struct _PyExecutorObject {
-    PyObject_HEAD
+    PyObject_VAR_HEAD
     /* WARNING: execute consumes a reference to self. This is necessary to allow executors to tail call into each other. */
     struct _PyInterpreterFrame *(*execute)(struct _PyExecutorObject *self, struct _PyInterpreterFrame *frame, PyObject **stack_pointer);
     _PyVMData vm_data; /* Used by the VM, but opaque to the optimizer */

--- a/Include/internal/pycore_uops.h
+++ b/Include/internal/pycore_uops.h
@@ -18,7 +18,7 @@ typedef struct {
 
 typedef struct {
     _PyExecutorObject base;
-    _PyUOpInstruction trace[_Py_UOP_MAX_TRACE_LENGTH];  // TODO: variable length
+    _PyUOpInstruction trace[1];
 } _PyUOpExecutorObject;
 
 _PyInterpreterFrame *_PyUopExecute(

--- a/Misc/NEWS.d/next/Core and Builtins/2023-08-01-09-41-36.gh-issue-106608.OFZogw.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2023-08-01-09-41-36.gh-issue-106608.OFZogw.rst
@@ -1,0 +1,1 @@
+make ```_PyUOpExecutorObject``` trace variable length

--- a/Misc/NEWS.d/next/Core and Builtins/2023-08-01-09-41-36.gh-issue-106608.OFZogw.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2023-08-01-09-41-36.gh-issue-106608.OFZogw.rst
@@ -1,1 +1,1 @@
-make ```_PyUOpExecutorObject``` trace variable length
+Make ``_PyUOpExecutorObject`` variable length.

--- a/Python/optimizer.c
+++ b/Python/optimizer.c
@@ -368,7 +368,7 @@ PySequenceMethods uop_as_sequence = {
 static PyTypeObject UOpExecutor_Type = {
     PyVarObject_HEAD_INIT(&PyType_Type, 0)
     .tp_name = "uop_executor",
-    .tp_basicsize = sizeof(_PyUOpExecutorObject),
+    .tp_basicsize = sizeof(_PyUOpExecutorObject) - sizeof(_PyUOpInstruction),
     .tp_itemsize = sizeof(_PyUOpInstruction),
     .tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_DISALLOW_INSTANTIATION,
     .tp_dealloc = (destructor)uop_dealloc,

--- a/Python/optimizer.c
+++ b/Python/optimizer.c
@@ -320,13 +320,7 @@ uop_name(int index) {
 static Py_ssize_t
 uop_len(_PyUOpExecutorObject *self)
 {
-    int count = 0;
-    for (; count < _Py_UOP_MAX_TRACE_LENGTH; count++) {
-        if (self->trace[count].opcode == 0) {
-            break;
-        }
-    }
-    return count;
+    return Py_SIZE(self);
 }
 
 static PyObject *
@@ -698,15 +692,12 @@ uop_optimize(
         return trace_length;
     }
     OBJECT_STAT_INC(optimization_traces_created);
-    _PyUOpExecutorObject *executor = PyObject_NewVar(_PyUOpExecutorObject, &UOpExecutor_Type, trace_length+1);
+    _PyUOpExecutorObject *executor = PyObject_NewVar(_PyUOpExecutorObject, &UOpExecutor_Type, trace_length);
     if (executor == NULL) {
         return -1;
     }
     executor->base.execute = _PyUopExecute;
     memcpy(executor->trace, trace, trace_length * sizeof(_PyUOpInstruction));
-        if (trace_length < _Py_UOP_MAX_TRACE_LENGTH) {
-            executor->trace[trace_length].opcode = 0;  // Sentinel
-        }
     *exec_ptr = (_PyExecutorObject *)executor;
     return 1;
 }

--- a/Python/optimizer.c
+++ b/Python/optimizer.c
@@ -369,7 +369,7 @@ static PyTypeObject UOpExecutor_Type = {
     PyVarObject_HEAD_INIT(&PyType_Type, 0)
     .tp_name = "uop_executor",
     .tp_basicsize = sizeof(_PyUOpExecutorObject),
-    .tp_itemsize = 0,
+    .tp_itemsize = sizeof(_PyUOpInstruction),
     .tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_DISALLOW_INSTANTIATION,
     .tp_dealloc = (destructor)uop_dealloc,
     .tp_as_sequence = &uop_as_sequence,
@@ -698,7 +698,7 @@ uop_optimize(
         return trace_length;
     }
     OBJECT_STAT_INC(optimization_traces_created);
-    _PyUOpExecutorObject *executor = PyObject_New(_PyUOpExecutorObject, &UOpExecutor_Type);
+    _PyUOpExecutorObject *executor = PyObject_NewVar(_PyUOpExecutorObject, &UOpExecutor_Type, trace_length+1);
     if (executor == NULL) {
         return -1;
     }


### PR DESCRIPTION
The ```_PyUOpExecutorObject``` was hard-coded to have a length-32 trace buffer of ```_PyUOpInstruction```s. The goal is to allow the buffer to have a variable length which can be determined at runtime.

To do so, I changed the type of the base ```_PyExecutorObject``` to a variable object, and used the PyObject_NewVar function to initialize the object instead.

After using gdb to trace the usage of the ```_PyUOpExecutorObject```, I did not find any use which needed to be modified to work with variable objects, and so I did not make any additional changes.

This is my first time contributing, so please let me know if I made a mistake anywhere!

<!-- gh-issue-number: gh-106608 -->
* Issue: gh-106608
<!-- /gh-issue-number -->
