### PR TITLE
gh-105481: the ENABLE_SPECIALIZATION flag does not need to be generated by the build script, or exposed in opcode.py

### DIFF
--- a/Doc/whatsnew/3.13.rst
+++ b/Doc/whatsnew/3.13.rst
@@ -120,7 +120,7 @@ built on debug mode <debug-build>`.
 opcode
 ------
 
-* Move :data:`opcode.ENABLE_SPECIALIZATION` to :data:`_opcode.ENABLE_SPECIALIZATION`.
+* Move ``opcode.ENABLE_SPECIALIZATION`` to ``_opcode.ENABLE_SPECIALIZATION``.
   This field was added in 3.12, it was never documented and is not intended for
   external usage. (Contributed by Irit Katriel in :gh:`105481`.)
 

--- a/Doc/whatsnew/3.13.rst
+++ b/Doc/whatsnew/3.13.rst
@@ -117,6 +117,13 @@ and only logged in :ref:`Python Development Mode <devmode>` or on :ref:`Python
 built on debug mode <debug-build>`.
 (Contributed by Victor Stinner in :gh:`62948`.)
 
+opcode
+------
+
+* Move :data:`opcode.ENABLE_SPECIALIZATION` to :data:`_opcode.ENABLE_SPECIALIZATION`.
+  This field was added in 3.12, it was never documented and is not intended for
+  external usage. (Contributed by Irit Katriel in :gh:`105481`.)
+
 pathlib
 -------
 

--- a/Include/internal/pycore_code.h
+++ b/Include/internal/pycore_code.h
@@ -229,6 +229,8 @@ extern void _PyLineTable_InitAddressRange(
 extern int _PyLineTable_NextAddressRange(PyCodeAddressRange *range);
 extern int _PyLineTable_PreviousAddressRange(PyCodeAddressRange *range);
 
+#define ENABLE_SPECIALIZATION 1
+
 /* Specialization functions */
 
 extern void _Py_Specialize_LoadSuperAttr(PyObject *global_super, PyObject *cls,

--- a/Include/opcode.h
+++ b/Include/opcode.h
@@ -256,8 +256,6 @@ extern "C" {
 #define NB_INPLACE_TRUE_DIVIDE                  24
 #define NB_INPLACE_XOR                          25
 
-/* Defined in Lib/opcode.py */
-#define ENABLE_SPECIALIZATION 1
 
 #ifdef __cplusplus
 }

--- a/Lib/opcode.py
+++ b/Lib/opcode.py
@@ -16,11 +16,9 @@ import sys
 # The build uses older versions of Python which do not have _opcode_metadata
 if sys.version_info[:2] >= (3, 13):
     from _opcode_metadata import _specializations, _specialized_instructions
+    from _opcode import ENABLE_SPECIALIZATION
 
 cmp_op = ('<', '<=', '==', '!=', '>', '>=')
-
-
-ENABLE_SPECIALIZATION = True
 
 def is_pseudo(op):
     return op >= MIN_PSEUDO_OPCODE and op <= MAX_PSEUDO_OPCODE

--- a/Lib/opcode.py
+++ b/Lib/opcode.py
@@ -16,7 +16,6 @@ import sys
 # The build uses older versions of Python which do not have _opcode_metadata
 if sys.version_info[:2] >= (3, 13):
     from _opcode_metadata import _specializations, _specialized_instructions
-    from _opcode import ENABLE_SPECIALIZATION
 
 cmp_op = ('<', '<=', '==', '!=', '>', '>=')
 

--- a/Lib/test/support/__init__.py
+++ b/Lib/test/support/__init__.py
@@ -6,7 +6,7 @@ if __name__ != 'test.support':
 import contextlib
 import functools
 import getpass
-import opcode
+import _opcode
 import os
 import re
 import stat
@@ -1092,7 +1092,7 @@ def requires_limited_api(test):
 
 def requires_specialization(test):
     return unittest.skipUnless(
-        opcode.ENABLE_SPECIALIZATION, "requires specialization")(test)
+        _opcode.ENABLE_SPECIALIZATION, "requires specialization")(test)
 
 def _filter_suite(suite, pred):
     """Recursively filter test cases in a suite based on a predicate."""

--- a/Misc/NEWS.d/next/Library/2023-08-01-15-17-20.gh-issue-105481.vMbmj_.rst
+++ b/Misc/NEWS.d/next/Library/2023-08-01-15-17-20.gh-issue-105481.vMbmj_.rst
@@ -1,0 +1,1 @@
+:data:`opcode.ENABLE_SPECIALIZATION` (which was added in 3.12 but never documented or intended for external usage) is moved to :data:`_opcode.ENABLE_SPECIALIZATION` where tests can access it.

--- a/Modules/_opcode.c
+++ b/Modules/_opcode.c
@@ -292,7 +292,16 @@ opcode_functions[] =  {
     {NULL, NULL, 0, NULL}
 };
 
+int
+_opcode_exec(PyObject *m) {
+    if (PyModule_AddIntMacro(m, ENABLE_SPECIALIZATION) < 0) {
+        return -1;
+    }
+    return 0;
+}
+
 static PyModuleDef_Slot module_slots[] = {
+    {Py_mod_exec, _opcode_exec},
     {Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
     {0, NULL}
 };

--- a/Tools/build/generate_opcode_h.py
+++ b/Tools/build/generate_opcode_h.py
@@ -73,7 +73,6 @@ def main(opcode_py,
     opname = opcode['opname']
     is_pseudo = opcode['is_pseudo']
 
-    ENABLE_SPECIALIZATION = opcode["ENABLE_SPECIALIZATION"]
     MIN_PSEUDO_OPCODE = opcode["MIN_PSEUDO_OPCODE"]
     MAX_PSEUDO_OPCODE = opcode["MAX_PSEUDO_OPCODE"]
     MIN_INSTRUMENTED_OPCODE = opcode["MIN_INSTRUMENTED_OPCODE"]
@@ -140,10 +139,6 @@ def main(opcode_py,
         fobj.write("\n")
         for i, (op, _) in enumerate(opcode["_nb_ops"]):
             fobj.write(DEFINE.format(op, i))
-
-        fobj.write("\n")
-        fobj.write("/* Defined in Lib/opcode.py */\n")
-        fobj.write(f"#define ENABLE_SPECIALIZATION {int(ENABLE_SPECIALIZATION)}")
 
         iobj.write("\n")
         iobj.write(f"\nextern const char *const _PyOpcode_OpName[{NUM_OPCODES}];\n")


### PR DESCRIPTION
Simplifies the build a little, and hides an internal value.

<!-- gh-issue-number: gh-105481 -->
* Issue: gh-105481
<!-- /gh-issue-number -->
