### PR TITLE
gh-95649: Document that asyncio contains uvloop code

### DIFF
--- a/Doc/license.rst
+++ b/Doc/license.rst
@@ -1066,3 +1066,32 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+
+asyncio
+----------
+
+Parts of the :mod:`asyncio` module are incorporated from
+`uvloop 0.16 <https://github.com/MagicStack/uvloop/tree/v0.16.0>`_,
+which is distributed under the MIT license::
+
+  Copyright (c) 2015-2021 MagicStack Inc.  http://magic.io
+
+  Permission is hereby granted, free of charge, to any person obtaining
+  a copy of this software and associated documentation files (the
+  "Software"), to deal in the Software without restriction, including
+  without limitation the rights to use, copy, modify, merge, publish,
+  distribute, sublicense, and/or sell copies of the Software, and to
+  permit persons to whom the Software is furnished to do so, subject to
+  the following conditions:
+
+  The above copyright notice and this permission notice shall be
+  included in all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+  MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+  LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+  OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+  WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/Lib/asyncio/constants.py
+++ b/Lib/asyncio/constants.py
@@ -1,3 +1,7 @@
+# Contains code from https://github.com/MagicStack/uvloop/tree/v0.16.0
+# SPDX-License-Identifier: PSF-2.0 AND (MIT OR Apache-2.0)
+# SPDX-FileCopyrightText: Copyright (c) 2015-2021 MagicStack Inc.  http://magic.io
+
 import enum
 
 # After the connection is lost, log warnings after this many write()s.

--- a/Lib/asyncio/events.py
+++ b/Lib/asyncio/events.py
@@ -1,5 +1,9 @@
 """Event loop and event loop policy."""
 
+# Contains code from https://github.com/MagicStack/uvloop/tree/v0.16.0
+# SPDX-License-Identifier: PSF-2.0 AND (MIT OR Apache-2.0)
+# SPDX-FileCopyrightText: Copyright (c) 2015-2021 MagicStack Inc.  http://magic.io
+
 __all__ = (
     'AbstractEventLoopPolicy',
     'AbstractEventLoop', 'AbstractServer',

--- a/Lib/asyncio/sslproto.py
+++ b/Lib/asyncio/sslproto.py
@@ -1,3 +1,7 @@
+# Contains code from https://github.com/MagicStack/uvloop/tree/v0.16.0
+# SPDX-License-Identifier: PSF-2.0 AND (MIT OR Apache-2.0)
+# SPDX-FileCopyrightText: Copyright (c) 2015-2021 MagicStack Inc.  http://magic.io
+
 import collections
 import enum
 import warnings

--- a/Lib/test/test_asyncio/test_ssl.py
+++ b/Lib/test/test_asyncio/test_ssl.py
@@ -1,3 +1,7 @@
+# Contains code from https://github.com/MagicStack/uvloop/tree/v0.16.0
+# SPDX-License-Identifier: PSF-2.0 AND (MIT OR Apache-2.0)
+# SPDX-FileCopyrightText: Copyright (c) 2015-2021 MagicStack Inc.  http://magic.io
+
 import asyncio
 import contextlib
 import gc

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -963,6 +963,7 @@ Carsten Klein
 Bastian Kleineidam
 Joel Klimont
 Bob Kline
+Alois Klink
 Matthias Klose
 Jeremy Kloth
 Thomas Kluyver

--- a/Misc/NEWS.d/next/Documentation/2023-08-01-13-11-39.gh-issue-95649.F4KhPS.rst
+++ b/Misc/NEWS.d/next/Documentation/2023-08-01-13-11-39.gh-issue-95649.F4KhPS.rst
@@ -1,0 +1,3 @@
+Document that the :mod:`asyncio` module contains code taken from `v0.16.0 of
+the uvloop project <https://github.com/MagicStack/uvloop/tree/v0.16.0>`_, as
+well as the required MIT licensing information.


### PR DESCRIPTION
Some of the asyncio SSL changes in GH-31275 were taken from [v0.16.0 of the uvloop project][1]. In order to comply with the MIT license, we need to just need to document the copyright information.

[1]: https://github.com/MagicStack/uvloop/tree/v0.16.0

### Design decisions

#### How did I pick the files to add licensing info to?

I went through commit https://github.com/python/cpython/commit/13c10bfb777483c7b02877aab029345a056b809c and added the `# SPDX-FileCopyrightText: ...` for changes to any file that has substantial code taken from https://github.com/MagicStack/uvloop/tree/v0.16.0.

The uvloop MIT license copyright text is [`Copyright (c) 2015-present MagicStack Inc.  http://magic.io`](https://github.com/MagicStack/uvloop/blob/3e71ddc3383a8e0546519117c8775323c19eb6d7/LICENSE-MIT#L3), so I changed it to `Copyright (c) 2015-2021 MagicStack Inc.  http://magic.io`, as when https://github.com/python/cpython/commit/13c10bfb777483c7b02877aab029345a056b809c was committed, the uvloop code was last modified in 2021.

#### Why did I use the `# SPDX-...` comment format?

Since there isn't yet a standard way to document licensing/copyright info (see https://github.com/python/devguide/issues/928 for the issue tracking this), I've used the `# SPDX-FileCopyrightText`/`# SPDX-License-Identifier` format since that's the [SPDX spec](https://spdx.github.io/spdx-spec/v2.3/), which is the most common method of doing copyright/licensing information, used by Linux.

Normally, we should also add a `# SPDX-FileCopyrightText: Copyright (c) 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009, 2010,
2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022, 2023 Python Software Foundation;
All Rights Reserved` line, but then we'd have to update the line every year, and I think the [`LICENSE` file](https://github.com/python/cpython/blob/557b05c7a5334de5da3dc94c108c0121f10b9191/LICENSE) already covers this.

#### Why is there no `# Licensed to PSF under a Contributor Agreement.` comment?

As raised in https://github.com/python/cpython/issues/95649, there's no information about whether the contributor actually had the rights to relicense this code under the PSF.

Personally, the changes in `Lib/asyncio` seem to come from uvloop code authored by either @asvetlov, or @MagicStack employees, so it should be pretty easy to relicense these files under the PSF, assuming @Magicstack approves. See https://github.com/MagicStack/uvloop/commits/v0.16.0/uvloop/sslproto.pyx (https://github.com/MagicStack/uvloop/commit/ef29dab2c80e7d5497f288deb7a817b873a188ab is by an author that isn't @MagicStack or @asvetlov, but that change is pretty trivial, so it should still be okay to relicense).

However, [`Lib/test/test_asyncio/test_ssl.py`](https://github.com/python/cpython/blob/557b05c7a5334de5da3dc94c108c0121f10b9191/Lib/test/test_asyncio/test_ssl.py) seems to have a bunch of [different authors from uvloop](https://github.com/MagicStack/uvloop/commits/v0.16.0/tests). And since there doesn't seem to be a uvloop CLA, even if @Magicstack approves, I don't think we can relicense this file under the PSF.



<!-- gh-issue-number: gh-95649 -->
* Issue: gh-95649
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--107536.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->