### PR TITLE
gh-104683: Argument clinic: remove the `LandMine` class

### DIFF
--- a/Lib/test/test_clinic.py
+++ b/Lib/test/test_clinic.py
@@ -331,8 +331,7 @@ class ClinicWholeFileTest(_ParserBase):
             [clinic start generated code]*/
         """)
         msg = (
-            "Stepped on a land mine, trying to access attribute 'noaccess':\n"
-            "Don't access members of self.function inside converter_init!"
+            "accessing self.function inside converter_init is disallowed!"
         )
         self.assertIn(msg, out)
 


### PR DESCRIPTION
In `Converter.__init__`, `self.function` is temporarily set to be an instance of `LandMine`, for reasons explained in this comment:

https://github.com/python/cpython/blob/6ef8f8ca88b925685c6af83a9f0a899e565e1e33/Tools/clinic/clinic.py#L2847-L2853

However, this approach leads to some complicated typing elsewhere in `clinic`: there are several places where we had to add `assert isinstance(self.function, Function)` assertions in order to keep mypy happy when adding type annotations to `clinic.py`. An approach that works just as well, and makes mypy much more happy, is to delay setting `self.function` at all until after `converter_init()` has run. We can improve the error message if somebody _does_ try to access `self.function` inside a `converter_init()` method by adding a `__getattr__` method that catches the resulting `AttributeError` and adds to the error message the line number in the `clinic` input that caused `clinic` to fail.

<!-- gh-issue-number: gh-104683 -->
* Issue: gh-104683
<!-- /gh-issue-number -->
