### PR TITLE
gh-104683: Argument clinic: cleanup `DLSParser` `state_foo` methods

### DIFF
--- a/Tools/clinic/clinic.py
+++ b/Tools/clinic/clinic.py
@@ -44,7 +44,6 @@ from typing import (
     NamedTuple,
     NoReturn,
     Protocol,
-    TypeGuard,
     TypeVar,
     cast,
     overload,
@@ -4389,7 +4388,7 @@ class IndentStack:
         return line[indent:]
 
 
-StateKeeper = Callable[[str | None], None]
+StateKeeper = Callable[[str], None]
 ConverterArgs = dict[str, Any]
 
 class ParamState(enum.IntEnum):
@@ -4611,9 +4610,7 @@ class DSLParser:
                 fail('Tab characters are illegal in the Clinic DSL.\n\t' + repr(line), line_number=block_start)
             self.state(line)
 
-        self.next(self.state_terminal)
-        self.state(None)
-
+        self.do_post_block_processing_cleanup()
         block.output.extend(self.clinic.language.render(self.clinic, block.signatures))
 
         if self.preserve_output:
@@ -4622,10 +4619,7 @@ class DSLParser:
             block.output = self.saved_output
 
     @staticmethod
-    def valid_line(line: str | None) -> TypeGuard[str]:
-        if line is None:
-            return False
-
+    def valid_line(line: str) -> bool:
         # ignore comment-only lines
         if line.lstrip().startswith('#'):
             return False
@@ -4651,7 +4645,7 @@ class DSLParser:
         if line is not None:
             self.state(line)
 
-    def state_dsl_start(self, line: str | None) -> None:
+    def state_dsl_start(self, line: str) -> None:
         # self.block = self.ClinicOutputBlock(self)
         if not self.valid_line(line):
             return
@@ -4669,7 +4663,7 @@ class DSLParser:
 
         self.next(self.state_modulename_name, line)
 
-    def state_modulename_name(self, line: str | None) -> None:
+    def state_modulename_name(self, line: str) -> None:
         # looking for declaration, which establishes the leftmost column
         # line should be
         #     modulename.fnname [as c_basename] [-> return annotation]
@@ -4858,7 +4852,7 @@ class DSLParser:
     # separate boolean state variables.)  The states are defined in the
     # ParamState class.
 
-    def state_parameters_start(self, line: str | None) -> None:
+    def state_parameters_start(self, line: str) -> None:
         if not self.valid_line(line):
             return
 
@@ -4880,7 +4874,7 @@ class DSLParser:
             for p in self.function.parameters.values():
                 p.group = -p.group
 
-    def state_parameter(self, line: str | None) -> None:
+    def state_parameter(self, line: str) -> None:
         assert isinstance(self.function, Function)
 
         if not self.valid_line(line):
@@ -5263,7 +5257,7 @@ class DSLParser:
                      "positional-only parameters, which is unsupported.")
             p.kind = inspect.Parameter.POSITIONAL_ONLY
 
-    def state_parameter_docstring_start(self, line: str | None) -> None:
+    def state_parameter_docstring_start(self, line: str) -> None:
         assert self.indent.margin is not None, "self.margin.infer() has not yet been called to set the margin"
         self.parameter_docstring_indent = len(self.indent.margin)
         assert self.indent.depth == 3
@@ -5272,9 +5266,7 @@ class DSLParser:
     # every line of the docstring must start with at least F spaces,
     # where F > P.
     # these F spaces will be stripped.
-    def state_parameter_docstring(self, line: str | None) -> None:
-        assert line is not None
-
+    def state_parameter_docstring(self, line: str) -> None:
         stripped = line.strip()
         if stripped.startswith('#'):
             return
@@ -5302,9 +5294,8 @@ class DSLParser:
         last_parameter.docstring = new_docstring
 
     # the final stanza of the DSL is the docstring.
-    def state_function_docstring(self, line: str | None) -> None:
+    def state_function_docstring(self, line: str) -> None:
         assert self.function is not None
-        assert line is not None
 
         if self.group:
             fail("Function " + self.function.name + " has a ] without a matching [.")
@@ -5573,12 +5564,10 @@ class DSLParser:
 
         return docstring
 
-    def state_terminal(self, line: str | None) -> None:
+    def do_post_block_processing_cleanup(self) -> None:
         """
         Called when processing the block is done.
         """
-        assert not line
-
         if not self.function:
             return
 


### PR DESCRIPTION
The `DSLParser` class has a lot of `state_foo` methods. All of these have to have the same type annotations, because none of them are actually called directly -- they're all called indirectly via the `next()` method:

https://github.com/python/cpython/blob/6ef8f8ca88b925685c6af83a9f0a899e565e1e33/Tools/clinic/clinic.py#L4644-L4652

https://github.com/python/cpython/blob/6ef8f8ca88b925685c6af83a9f0a899e565e1e33/Tools/clinic/clinic.py#L4670

https://github.com/python/cpython/blob/6ef8f8ca88b925685c6af83a9f0a899e565e1e33/Tools/clinic/clinic.py#L4731

(etc. etc.)

All of these are only ever passed a `str` for their `line` parameter, and assume that they're only ever passed a `str` for their `line` parameter. All, that is -- except one! The `state_terminal` method is explicitly passed `None` in the one place that it's called, and will indeed error if it's passed anything that's not `None` or `""`:

https://github.com/python/cpython/blob/6ef8f8ca88b925685c6af83a9f0a899e565e1e33/Tools/clinic/clinic.py#L4614-L4615

https://github.com/python/cpython/blob/6ef8f8ca88b925685c6af83a9f0a899e565e1e33/Tools/clinic/clinic.py#L5576-L5580

As a result of `state_terminal`, all of our `state_foo` methods have to have `str | None` annotations for `line`, which means we need to have many pointless assertions everywhere to keep mypy happy. But since `state_terminal` is special (it's the only one of the `state_foo` methods that expects to be passed `None`, and it's only ever called once, after the entire block has been parsed), we can just... special-case it. If we rename it to `do_post_block_processing_cleanup()`, and call it explicitly after parsing the block rather than indirectly via `next()`, this allows us to greatly simplify the typing across the rest of the `DSLParser` `state_foo` methods, and makes the code generally much more readable for humans as well.

<!-- gh-issue-number: gh-104683 -->
* Issue: gh-104683
<!-- /gh-issue-number -->
