### PR TITLE
gh-107559: Argument Clinic: complain about non-ascii chars in param docstrings

### DIFF
--- a/Lib/test/test_clinic.py
+++ b/Lib/test/test_clinic.py
@@ -1437,8 +1437,7 @@ Couldn't find existing function 'fooooooooooooooooooooooo'!
         """
         with support.captured_stdout() as stdout:
             self.parse(block)
-        # Only the first match is shown.
-        # Also, the line numbers are off; this is a known limitation.
+        # The line numbers are off; this is a known limitation.
         expected = dedent("""\
             Warning on line 0:
             Non-ascii characters are not allowed in docstrings: 'á'

--- a/Lib/test/test_clinic.py
+++ b/Lib/test/test_clinic.py
@@ -1427,6 +1427,26 @@ Couldn't find existing function 'fooooooooooooooooooooooo'!
         actual = stdout.getvalue()
         self.assertEqual(actual, expected)
 
+    def test_non_ascii_character_in_docstring(self):
+        block = """
+            module test
+            test.fn
+                a: int
+                    á param docstring
+            docstring fü bár baß
+        """
+        with support.captured_stdout() as stdout:
+            self.parse(block)
+        # Only the first match is shown.
+        # Also, the line numbers are off; this is a known limitation.
+        expected = dedent("""\
+            Warning on line 0:
+            Non-ascii characters are not allowed in docstrings: 'á'
+            Warning on line 0:
+            Non-ascii characters are not allowed in docstrings: 'ü'
+        """)
+        self.assertEqual(stdout.getvalue(), expected)
+
 
 class ClinicExternalTest(TestCase):
     maxDiff = None

--- a/Lib/test/test_clinic.py
+++ b/Lib/test/test_clinic.py
@@ -1443,7 +1443,7 @@ Couldn't find existing function 'fooooooooooooooooooooooo'!
             Warning on line 0:
             Non-ascii characters are not allowed in docstrings: 'á'
             Warning on line 0:
-            Non-ascii characters are not allowed in docstrings: 'ü'
+            Non-ascii characters are not allowed in docstrings: 'ü', 'á', 'ß'
         """)
         self.assertEqual(stdout.getvalue(), expected)
 

--- a/Tools/clinic/clinic.py
+++ b/Tools/clinic/clinic.py
@@ -5263,10 +5263,10 @@ class DSLParser:
 
     def docstring_append(self, obj: Function | Parameter, line: str) -> None:
         """Add a rstripped line to the current docstring."""
-        if match := re.search(r'[^\x00-\x7F]', line):
-            offending = match[0]
+        matches = re.finditer(r'[^\x00-\x7F]', line)
+        if offending := ", ".join([repr(m[0]) for m in matches]):
             warn("Non-ascii characters are not allowed in docstrings:",
-                 repr(offending))
+                 offending)
 
         docstring = obj.docstring
         if docstring:

--- a/Tools/clinic/clinic.py
+++ b/Tools/clinic/clinic.py
@@ -785,9 +785,6 @@ class CLanguage(Language):
             self,
             f: Function
     ) -> str:
-        if re.search(r'[^\x00-\x7F]', f.docstring):
-            warn("Non-ascii character appear in docstring.")
-
         text, add, output = _text_accumulator()
         # turn docstring into a properly quoted C string
         for line in f.docstring.split('\n'):
@@ -5266,6 +5263,11 @@ class DSLParser:
 
     def docstring_append(self, obj: Function | Parameter, line: str) -> None:
         """Add a rstripped line to the current docstring."""
+        if match := re.search(r'[^\x00-\x7F]', line):
+            offending = match[0]
+            warn("Non-ascii characters are not allowed in docstrings:",
+                 repr(offending))
+
         docstring = obj.docstring
         if docstring:
             docstring += "\n"


### PR DESCRIPTION
Also, improve the warn() message.


<!-- gh-issue-number: gh-107559 -->
* Issue: gh-107559
<!-- /gh-issue-number -->
