### PR TITLE
GH-100964: Break cycles involving exception state when returning from generator

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2023-07-30-18-05-11.gh-issue-100964.HluhBJ.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2023-07-30-18-05-11.gh-issue-100964.HluhBJ.rst
@@ -1,0 +1,2 @@
+Clear generators' exception state after ``return`` to break reference
+cycles.

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -1466,6 +1466,7 @@ clear_gen_frame(PyThreadState *tstate, _PyInterpreterFrame * frame)
     tstate->c_recursion_remaining--;
     assert(frame->frame_obj == NULL || frame->frame_obj->f_frame == frame);
     _PyFrame_ClearExceptCode(frame);
+    _PyErr_ClearExcState(&gen->gi_exc_state);
     tstate->c_recursion_remaining++;
     frame->previous = NULL;
 }


### PR DESCRIPTION
This is an attempt to f[]()ix #100964.
Even if it doesn't fix the issue, it seems better to clear the exception state as soon as the generator is exhausted.

If it works we can consider a backport.

<!-- gh-issue-number: gh-100964 -->
* Issue: gh-100964
<!-- /gh-issue-number -->
