### PR TITLE
gh-106812: Refactor to allow uops with array stack effects

### DIFF
--- a/Include/internal/pycore_opcode_metadata.h
+++ b/Include/internal/pycore_opcode_metadata.h
@@ -944,7 +944,18 @@ _PyOpcode_num_pushed(int opcode, int oparg, bool jump) {
 }
 #endif
 
-enum InstructionFormat { INSTR_FMT_IB, INSTR_FMT_IBC, INSTR_FMT_IBC00, INSTR_FMT_IBC000, INSTR_FMT_IBC00000000, INSTR_FMT_IX, INSTR_FMT_IXC, INSTR_FMT_IXC0, INSTR_FMT_IXC00, INSTR_FMT_IXC000 };
+enum InstructionFormat {
+    INSTR_FMT_IB,
+    INSTR_FMT_IBC,
+    INSTR_FMT_IBC00,
+    INSTR_FMT_IBC000,
+    INSTR_FMT_IBC00000000,
+    INSTR_FMT_IX,
+    INSTR_FMT_IXC,
+    INSTR_FMT_IXC0,
+    INSTR_FMT_IXC00,
+    INSTR_FMT_IXC000,
+};
 
 #define IS_VALID_OPCODE(OP) \
     (((OP) >= 0) && ((OP) < OPCODE_METADATA_SIZE) && \

--- a/Include/internal/pycore_opcode_metadata.h
+++ b/Include/internal/pycore_opcode_metadata.h
@@ -679,9 +679,9 @@ _PyOpcode_num_pushed(int opcode, int oparg, bool jump) {
         case LOAD_GLOBAL:
             return ((oparg & 1) ? 1 : 0) + 1;
         case LOAD_GLOBAL_MODULE:
-            return ((oparg & 1) ? 1 : 0) + 1;
+            return (oparg & 1 ? 1 : 0) + 1;
         case LOAD_GLOBAL_BUILTIN:
-            return ((oparg & 1) ? 1 : 0) + 1;
+            return (oparg & 1 ? 1 : 0) + 1;
         case DELETE_FAST:
             return 0;
         case MAKE_CELL:
@@ -739,7 +739,7 @@ _PyOpcode_num_pushed(int opcode, int oparg, bool jump) {
         case LOAD_METHOD:
             return ((oparg & 1) ? 1 : 0) + 1;
         case LOAD_ATTR_INSTANCE_VALUE:
-            return ((oparg & 1) ? 1 : 0) + 1;
+            return (oparg & 1 ? 1 : 0) + 1;
         case LOAD_ATTR_MODULE:
             return ((oparg & 1) ? 1 : 0) + 1;
         case LOAD_ATTR_WITH_HINT:

--- a/Lib/test/test_generated_cases.py
+++ b/Lib/test/test_generated_cases.py
@@ -422,7 +422,7 @@ class TestGeneratedCases(unittest.TestCase):
             spam(values, oparg);
             STACK_GROW(oparg*3);
             stack_pointer[-1] = above;
-            stack_pointer[-(2 + oparg*3)] = below;
+            stack_pointer[-2 - oparg*3] = below;
             DISPATCH();
         }
     """
@@ -482,8 +482,8 @@ class TestGeneratedCases(unittest.TestCase):
             STACK_SHRINK((((oparg & 1) == 1) ? 1 : 0));
             STACK_GROW(((oparg & 2) ? 1 : 0));
             stack_pointer[-1] = zz;
-            if (oparg & 2) { stack_pointer[-(1 + ((oparg & 2) ? 1 : 0))] = output; }
-            stack_pointer[-(2 + ((oparg & 2) ? 1 : 0))] = xx;
+            if (oparg & 2) { stack_pointer[-1 - (oparg & 2 ? 1 : 0)] = output; }
+            stack_pointer[-2 - (oparg & 2 ? 1 : 0)] = xx;
             DISPATCH();
         }
     """

--- a/Lib/test/test_generated_cases.py
+++ b/Lib/test/test_generated_cases.py
@@ -46,24 +46,6 @@ class TestEffects(unittest.TestCase):
             (2, "(oparg<<1)"),
         )
 
-        self.assertEqual(
-            formatting.string_effect_size(
-                formatting.list_effect_size(input_effects),
-            ), "1 + oparg + oparg*2",
-        )
-        self.assertEqual(
-            formatting.string_effect_size(
-                formatting.list_effect_size(output_effects),
-            ),
-            "2 + oparg*4",
-        )
-        self.assertEqual(
-            formatting.string_effect_size(
-                formatting.list_effect_size(other_effects),
-            ),
-            "2 + (oparg<<1)",
-        )
-
 
 class TestGeneratedCases(unittest.TestCase):
     def setUp(self) -> None:

--- a/Lib/test/test_generated_cases.py
+++ b/Lib/test/test_generated_cases.py
@@ -348,30 +348,26 @@ class TestGeneratedCases(unittest.TestCase):
         }
 
         TARGET(OP) {
-            PyObject *_tmp_1 = stack_pointer[-1];
-            PyObject *_tmp_2 = stack_pointer[-2];
-            PyObject *_tmp_3 = stack_pointer[-3];
+            PyObject *right;
+            PyObject *left;
+            PyObject *arg2;
+            PyObject *res;
+            // OP1
+            right = stack_pointer[-1];
+            left = stack_pointer[-2];
             {
-                PyObject *right = _tmp_1;
-                PyObject *left = _tmp_2;
                 uint16_t counter = read_u16(&next_instr[0].cache);
                 op1(left, right);
-                _tmp_2 = left;
-                _tmp_1 = right;
             }
+            // OP2
+            arg2 = stack_pointer[-3];
             {
-                PyObject *right = _tmp_1;
-                PyObject *left = _tmp_2;
-                PyObject *arg2 = _tmp_3;
-                PyObject *res;
                 uint32_t extra = read_u32(&next_instr[3].cache);
                 res = op2(arg2, left, right);
-                _tmp_3 = res;
             }
             next_instr += 5;
-            static_assert(INLINE_CACHE_ENTRIES_OP == 5, "incorrect cache size");
             STACK_SHRINK(2);
-            stack_pointer[-1] = _tmp_3;
+            stack_pointer[-1] = res;
             DISPATCH();
         }
 
@@ -501,29 +497,28 @@ class TestGeneratedCases(unittest.TestCase):
     """
         output = """
         TARGET(M) {
-            PyObject *_tmp_1 = stack_pointer[-1];
-            PyObject *_tmp_2 = stack_pointer[-2];
-            PyObject *_tmp_3 = stack_pointer[-3];
+            PyObject *right;
+            PyObject *middle;
+            PyObject *left;
+            PyObject *deep;
+            PyObject *extra = NULL;
+            PyObject *res;
+            // A
+            right = stack_pointer[-1];
+            middle = stack_pointer[-2];
+            left = stack_pointer[-3];
             {
-                PyObject *right = _tmp_1;
-                PyObject *middle = _tmp_2;
-                PyObject *left = _tmp_3;
                 # Body of A
             }
+            // B
             {
-                PyObject *deep;
-                PyObject *extra = NULL;
-                PyObject *res;
                 # Body of B
-                _tmp_3 = deep;
-                if (oparg) { _tmp_2 = extra; }
-                _tmp_1 = res;
             }
             STACK_SHRINK(1);
             STACK_GROW((oparg ? 1 : 0));
-            stack_pointer[-1] = _tmp_1;
-            if (oparg) { stack_pointer[-2] = _tmp_2; }
-            stack_pointer[-3] = _tmp_3;
+            stack_pointer[-2 - (oparg ? 1 : 0)] = deep;
+            if (oparg) { stack_pointer[-1 - (oparg ? 1 : 0)] = extra; }
+            stack_pointer[-1] = res;
             DISPATCH();
         }
     """

--- a/Lib/test/test_generated_cases.py
+++ b/Lib/test/test_generated_cases.py
@@ -141,7 +141,8 @@ class TestGeneratedCases(unittest.TestCase):
     """
         output = """
         TARGET(OP) {
-            PyObject *value = stack_pointer[-1];
+            PyObject *value;
+            value = stack_pointer[-1];
             spam();
             STACK_SHRINK(1);
             DISPATCH();
@@ -174,8 +175,9 @@ class TestGeneratedCases(unittest.TestCase):
     """
         output = """
         TARGET(OP) {
-            PyObject *value = stack_pointer[-1];
+            PyObject *value;
             PyObject *res;
+            value = stack_pointer[-1];
             spam();
             stack_pointer[-1] = res;
             DISPATCH();
@@ -191,9 +193,11 @@ class TestGeneratedCases(unittest.TestCase):
     """
         output = """
         TARGET(OP) {
-            PyObject *right = stack_pointer[-1];
-            PyObject *left = stack_pointer[-2];
+            PyObject *right;
+            PyObject *left;
             PyObject *res;
+            right = stack_pointer[-1];
+            left = stack_pointer[-2];
             spam();
             STACK_SHRINK(1);
             stack_pointer[-1] = res;
@@ -210,9 +214,11 @@ class TestGeneratedCases(unittest.TestCase):
     """
         output = """
         TARGET(OP) {
-            PyObject *right = stack_pointer[-1];
-            PyObject *left = stack_pointer[-2];
+            PyObject *right;
+            PyObject *left;
             PyObject *result;
+            right = stack_pointer[-1];
+            left = stack_pointer[-2];
             spam();
             stack_pointer[-1] = result;
             DISPATCH();
@@ -236,8 +242,9 @@ class TestGeneratedCases(unittest.TestCase):
         }
 
         TARGET(OP3) {
-            PyObject *arg = stack_pointer[-1];
+            PyObject *arg;
             PyObject *res;
+            arg = stack_pointer[-1];
             DEOPT_IF(xxx, OP1);
             stack_pointer[-1] = res;
             CHECK_EVAL_BREAKER();
@@ -282,9 +289,11 @@ class TestGeneratedCases(unittest.TestCase):
     """
         output = """
         TARGET(OP) {
-            PyObject *right = stack_pointer[-1];
-            PyObject *left = stack_pointer[-2];
+            PyObject *right;
+            PyObject *left;
             PyObject *res;
+            right = stack_pointer[-1];
+            left = stack_pointer[-2];
             if (cond) goto pop_2_label;
             STACK_SHRINK(1);
             stack_pointer[-1] = res;
@@ -300,7 +309,8 @@ class TestGeneratedCases(unittest.TestCase):
     """
         output = """
         TARGET(OP) {
-            PyObject *value = stack_pointer[-1];
+            PyObject *value;
+            value = stack_pointer[-1];
             uint16_t counter = read_u16(&next_instr[0].cache);
             uint32_t extra = read_u32(&next_instr[1].cache);
             STACK_SHRINK(1);
@@ -339,8 +349,10 @@ class TestGeneratedCases(unittest.TestCase):
     """
         output = """
         TARGET(OP1) {
-            PyObject *right = stack_pointer[-1];
-            PyObject *left = stack_pointer[-2];
+            PyObject *right;
+            PyObject *left;
+            right = stack_pointer[-1];
+            left = stack_pointer[-2];
             uint16_t counter = read_u16(&next_instr[0].cache);
             op1(left, right);
             next_instr += 1;
@@ -365,17 +377,20 @@ class TestGeneratedCases(unittest.TestCase):
                 uint32_t extra = read_u32(&next_instr[3].cache);
                 res = op2(arg2, left, right);
             }
-            next_instr += 5;
             STACK_SHRINK(2);
             stack_pointer[-1] = res;
+            next_instr += 5;
             DISPATCH();
         }
 
         TARGET(OP3) {
-            PyObject *right = stack_pointer[-1];
-            PyObject *left = stack_pointer[-2];
-            PyObject *arg2 = stack_pointer[-3];
+            PyObject *right;
+            PyObject *left;
+            PyObject *arg2;
             PyObject *res;
+            right = stack_pointer[-1];
+            left = stack_pointer[-2];
+            arg2 = stack_pointer[-3];
             res = op3(arg2, left, right);
             STACK_SHRINK(2);
             stack_pointer[-1] = res;
@@ -393,9 +408,12 @@ class TestGeneratedCases(unittest.TestCase):
     """
         output = """
         TARGET(OP) {
-            PyObject *above = stack_pointer[-1];
-            PyObject **values = stack_pointer - 1 - oparg*2;
-            PyObject *below = stack_pointer[-2 - oparg*2];
+            PyObject *above;
+            PyObject **values;
+            PyObject *below;
+            above = stack_pointer[-1];
+            values = stack_pointer - 1 - oparg*2;
+            below = stack_pointer[-2 - oparg*2];
             spam();
             STACK_SHRINK(oparg*2);
             STACK_SHRINK(2);
@@ -413,12 +431,13 @@ class TestGeneratedCases(unittest.TestCase):
         output = """
         TARGET(OP) {
             PyObject *below;
-            PyObject **values = stack_pointer - 1;
+            PyObject **values;
             PyObject *above;
+            values = stack_pointer - 1;
             spam(values, oparg);
             STACK_GROW(oparg*3);
-            stack_pointer[-1] = above;
             stack_pointer[-2 - oparg*3] = below;
+            stack_pointer[-1] = above;
             DISPATCH();
         }
     """
@@ -432,8 +451,9 @@ class TestGeneratedCases(unittest.TestCase):
     """
         output = """
         TARGET(OP) {
-            PyObject **values = stack_pointer - oparg;
+            PyObject **values;
             PyObject *above;
+            values = stack_pointer - oparg;
             spam(values, oparg);
             STACK_GROW(1);
             stack_pointer[-1] = above;
@@ -450,8 +470,10 @@ class TestGeneratedCases(unittest.TestCase):
     """
         output = """
         TARGET(OP) {
-            PyObject **values = stack_pointer - oparg;
-            PyObject *extra = stack_pointer[-1 - oparg];
+            PyObject **values;
+            PyObject *extra;
+            values = stack_pointer - oparg;
+            extra = stack_pointer[-1 - oparg];
             if (oparg == 0) { STACK_SHRINK(oparg); goto pop_1_somewhere; }
             STACK_SHRINK(oparg);
             STACK_SHRINK(1);
@@ -468,18 +490,21 @@ class TestGeneratedCases(unittest.TestCase):
     """
         output = """
         TARGET(OP) {
-            PyObject *cc = stack_pointer[-1];
-            PyObject *input = (oparg & 1) == 1 ? stack_pointer[-1 - ((oparg & 1) == 1 ? 1 : 0)] : NULL;
-            PyObject *aa = stack_pointer[-2 - ((oparg & 1) == 1 ? 1 : 0)];
+            PyObject *cc;
+            PyObject *input = NULL;
+            PyObject *aa;
             PyObject *xx;
             PyObject *output = NULL;
             PyObject *zz;
+            cc = stack_pointer[-1];
+            if ((oparg & 1) == 1) { input = stack_pointer[-1 - ((oparg & 1) == 1 ? 1 : 0)]; }
+            aa = stack_pointer[-2 - ((oparg & 1) == 1 ? 1 : 0)];
             output = spam(oparg, input);
             STACK_SHRINK((((oparg & 1) == 1) ? 1 : 0));
             STACK_GROW(((oparg & 2) ? 1 : 0));
-            stack_pointer[-1] = zz;
-            if (oparg & 2) { stack_pointer[-1 - (oparg & 2 ? 1 : 0)] = output; }
             stack_pointer[-2 - (oparg & 2 ? 1 : 0)] = xx;
+            if (oparg & 2) { stack_pointer[-1 - (oparg & 2 ? 1 : 0)] = output; }
+            stack_pointer[-1] = zz;
             DISPATCH();
         }
     """

--- a/Lib/test/test_generated_cases.py
+++ b/Lib/test/test_generated_cases.py
@@ -360,6 +360,7 @@ class TestGeneratedCases(unittest.TestCase):
         }
 
         TARGET(OP) {
+            static_assert(INLINE_CACHE_ENTRIES_OP == 5, "incorrect cache size");
             PyObject *right;
             PyObject *left;
             PyObject *arg2;

--- a/Lib/test/test_generated_cases.py
+++ b/Lib/test/test_generated_cases.py
@@ -68,6 +68,7 @@ class TestEffects(unittest.TestCase):
 class TestGeneratedCases(unittest.TestCase):
     def setUp(self) -> None:
         super().setUp()
+        self.maxDiff = None
 
         self.temp_dir = tempfile.gettempdir()
         self.temp_input_filename = os.path.join(self.temp_dir, "input.txt")
@@ -397,8 +398,8 @@ class TestGeneratedCases(unittest.TestCase):
         output = """
         TARGET(OP) {
             PyObject *above = stack_pointer[-1];
-            PyObject **values = (stack_pointer - (1 + oparg*2));
-            PyObject *below = stack_pointer[-(2 + oparg*2)];
+            PyObject **values = stack_pointer - 1 - oparg*2;
+            PyObject *below = stack_pointer[-2 - oparg*2];
             spam();
             STACK_SHRINK(oparg*2);
             STACK_SHRINK(2);
@@ -416,7 +417,7 @@ class TestGeneratedCases(unittest.TestCase):
         output = """
         TARGET(OP) {
             PyObject *below;
-            PyObject **values = stack_pointer - (2) + 1;
+            PyObject **values = stack_pointer - 1;
             PyObject *above;
             spam(values, oparg);
             STACK_GROW(oparg*3);
@@ -435,7 +436,7 @@ class TestGeneratedCases(unittest.TestCase):
     """
         output = """
         TARGET(OP) {
-            PyObject **values = (stack_pointer - oparg);
+            PyObject **values = stack_pointer - oparg;
             PyObject *above;
             spam(values, oparg);
             STACK_GROW(1);
@@ -453,8 +454,8 @@ class TestGeneratedCases(unittest.TestCase):
     """
         output = """
         TARGET(OP) {
-            PyObject **values = (stack_pointer - oparg);
-            PyObject *extra = stack_pointer[-(1 + oparg)];
+            PyObject **values = stack_pointer - oparg;
+            PyObject *extra = stack_pointer[-1 - oparg];
             if (oparg == 0) { STACK_SHRINK(oparg); goto pop_1_somewhere; }
             STACK_SHRINK(oparg);
             STACK_SHRINK(1);
@@ -472,8 +473,8 @@ class TestGeneratedCases(unittest.TestCase):
         output = """
         TARGET(OP) {
             PyObject *cc = stack_pointer[-1];
-            PyObject *input = ((oparg & 1) == 1) ? stack_pointer[-(1 + (((oparg & 1) == 1) ? 1 : 0))] : NULL;
-            PyObject *aa = stack_pointer[-(2 + (((oparg & 1) == 1) ? 1 : 0))];
+            PyObject *input = (oparg & 1) == 1 ? stack_pointer[-1 - ((oparg & 1) == 1 ? 1 : 0)] : NULL;
+            PyObject *aa = stack_pointer[-2 - ((oparg & 1) == 1 ? 1 : 0)];
             PyObject *xx;
             PyObject *output = NULL;
             PyObject *zz;

--- a/Lib/test/test_generated_cases.py
+++ b/Lib/test/test_generated_cases.py
@@ -6,9 +6,9 @@ from test import test_tools
 
 test_tools.skip_if_missing('cases_generator')
 with test_tools.imports_under_tool('cases_generator'):
+    import generate_cases
     import analysis
     import formatting
-    import generate_cases
     from parsing import StackEffect
 
 

--- a/Python/executor_cases.c.h
+++ b/Python/executor_cases.c.h
@@ -464,7 +464,7 @@
 
         case LIST_APPEND: {
             PyObject *v = stack_pointer[-1];
-            PyObject *list = stack_pointer[-(2 + (oparg-1))];
+            PyObject *list = stack_pointer[-2 - (oparg-1)];
             if (_PyList_AppendTakeRef((PyListObject *)list, v) < 0) goto pop_1_error;
             STACK_SHRINK(1);
             break;
@@ -472,7 +472,7 @@
 
         case SET_ADD: {
             PyObject *v = stack_pointer[-1];
-            PyObject *set = stack_pointer[-(2 + (oparg-1))];
+            PyObject *set = stack_pointer[-2 - (oparg-1)];
             int err = PySet_Add(set, v);
             Py_DECREF(v);
             if (err) goto pop_1_error;
@@ -790,7 +790,7 @@
 
         case UNPACK_SEQUENCE_TWO_TUPLE: {
             PyObject *seq = stack_pointer[-1];
-            PyObject **values = stack_pointer - (1);
+            PyObject **values = stack_pointer - 1;
             DEOPT_IF(!PyTuple_CheckExact(seq), UNPACK_SEQUENCE);
             DEOPT_IF(PyTuple_GET_SIZE(seq) != 2, UNPACK_SEQUENCE);
             assert(oparg == 2);
@@ -805,7 +805,7 @@
 
         case UNPACK_SEQUENCE_TUPLE: {
             PyObject *seq = stack_pointer[-1];
-            PyObject **values = stack_pointer - (1);
+            PyObject **values = stack_pointer - 1;
             DEOPT_IF(!PyTuple_CheckExact(seq), UNPACK_SEQUENCE);
             DEOPT_IF(PyTuple_GET_SIZE(seq) != oparg, UNPACK_SEQUENCE);
             STAT_INC(UNPACK_SEQUENCE, hit);
@@ -821,7 +821,7 @@
 
         case UNPACK_SEQUENCE_LIST: {
             PyObject *seq = stack_pointer[-1];
-            PyObject **values = stack_pointer - (1);
+            PyObject **values = stack_pointer - 1;
             DEOPT_IF(!PyList_CheckExact(seq), UNPACK_SEQUENCE);
             DEOPT_IF(PyList_GET_SIZE(seq) != oparg, UNPACK_SEQUENCE);
             STAT_INC(UNPACK_SEQUENCE, hit);
@@ -1148,7 +1148,7 @@
         }
 
         case BUILD_STRING: {
-            PyObject **pieces = (stack_pointer - oparg);
+            PyObject **pieces = stack_pointer - oparg;
             PyObject *str;
             str = _PyUnicode_JoinArray(&_Py_STR(empty), pieces, oparg);
             for (int _i = oparg; --_i >= 0;) {
@@ -1162,7 +1162,7 @@
         }
 
         case BUILD_TUPLE: {
-            PyObject **values = (stack_pointer - oparg);
+            PyObject **values = stack_pointer - oparg;
             PyObject *tup;
             tup = _PyTuple_FromArraySteal(values, oparg);
             if (tup == NULL) { STACK_SHRINK(oparg); goto error; }
@@ -1173,7 +1173,7 @@
         }
 
         case BUILD_LIST: {
-            PyObject **values = (stack_pointer - oparg);
+            PyObject **values = stack_pointer - oparg;
             PyObject *list;
             list = _PyList_FromArraySteal(values, oparg);
             if (list == NULL) { STACK_SHRINK(oparg); goto error; }
@@ -1185,7 +1185,7 @@
 
         case LIST_EXTEND: {
             PyObject *iterable = stack_pointer[-1];
-            PyObject *list = stack_pointer[-(2 + (oparg-1))];
+            PyObject *list = stack_pointer[-2 - (oparg-1)];
             PyObject *none_val = _PyList_Extend((PyListObject *)list, iterable);
             if (none_val == NULL) {
                 if (_PyErr_ExceptionMatches(tstate, PyExc_TypeError) &&
@@ -1207,7 +1207,7 @@
 
         case SET_UPDATE: {
             PyObject *iterable = stack_pointer[-1];
-            PyObject *set = stack_pointer[-(2 + (oparg-1))];
+            PyObject *set = stack_pointer[-2 - (oparg-1)];
             int err = _PySet_Update(set, iterable);
             Py_DECREF(iterable);
             if (err < 0) goto pop_1_error;
@@ -1216,7 +1216,7 @@
         }
 
         case BUILD_SET: {
-            PyObject **values = (stack_pointer - oparg);
+            PyObject **values = stack_pointer - oparg;
             PyObject *set;
             set = PySet_New(NULL);
             if (set == NULL)
@@ -1239,7 +1239,7 @@
         }
 
         case BUILD_MAP: {
-            PyObject **values = (stack_pointer - oparg*2);
+            PyObject **values = stack_pointer - oparg*2;
             PyObject *map;
             map = _PyDict_FromItems(
                     values, 2,
@@ -1301,7 +1301,7 @@
 
         case BUILD_CONST_KEY_MAP: {
             PyObject *keys = stack_pointer[-1];
-            PyObject **values = (stack_pointer - (1 + oparg));
+            PyObject **values = stack_pointer - 1 - oparg;
             PyObject *map;
             if (!PyTuple_CheckExact(keys) ||
                 PyTuple_GET_SIZE(keys) != (Py_ssize_t)oparg) {
@@ -1981,9 +1981,9 @@
         }
 
         case CALL_NO_KW_TYPE_1: {
-            PyObject **args = (stack_pointer - oparg);
-            PyObject *callable = stack_pointer[-(1 + oparg)];
-            PyObject *null = stack_pointer[-(2 + oparg)];
+            PyObject **args = stack_pointer - oparg;
+            PyObject *callable = stack_pointer[-1 - oparg];
+            PyObject *null = stack_pointer[-2 - oparg];
             PyObject *res;
             ASSERT_KWNAMES_IS_NULL();
             assert(oparg == 1);
@@ -2001,9 +2001,9 @@
         }
 
         case CALL_NO_KW_STR_1: {
-            PyObject **args = (stack_pointer - oparg);
-            PyObject *callable = stack_pointer[-(1 + oparg)];
-            PyObject *null = stack_pointer[-(2 + oparg)];
+            PyObject **args = stack_pointer - oparg;
+            PyObject *callable = stack_pointer[-1 - oparg];
+            PyObject *null = stack_pointer[-2 - oparg];
             PyObject *res;
             ASSERT_KWNAMES_IS_NULL();
             assert(oparg == 1);
@@ -2023,9 +2023,9 @@
         }
 
         case CALL_NO_KW_TUPLE_1: {
-            PyObject **args = (stack_pointer - oparg);
-            PyObject *callable = stack_pointer[-(1 + oparg)];
-            PyObject *null = stack_pointer[-(2 + oparg)];
+            PyObject **args = stack_pointer - oparg;
+            PyObject *callable = stack_pointer[-1 - oparg];
+            PyObject *null = stack_pointer[-2 - oparg];
             PyObject *res;
             ASSERT_KWNAMES_IS_NULL();
             assert(oparg == 1);
@@ -2058,9 +2058,9 @@
         }
 
         case CALL_NO_KW_BUILTIN_O: {
-            PyObject **args = (stack_pointer - oparg);
-            PyObject *callable = stack_pointer[-(1 + oparg)];
-            PyObject *method = stack_pointer[-(2 + oparg)];
+            PyObject **args = stack_pointer - oparg;
+            PyObject *callable = stack_pointer[-1 - oparg];
+            PyObject *method = stack_pointer[-2 - oparg];
             PyObject *res;
             /* Builtin METH_O functions */
             ASSERT_KWNAMES_IS_NULL();
@@ -2097,9 +2097,9 @@
         }
 
         case CALL_NO_KW_BUILTIN_FAST: {
-            PyObject **args = (stack_pointer - oparg);
-            PyObject *callable = stack_pointer[-(1 + oparg)];
-            PyObject *method = stack_pointer[-(2 + oparg)];
+            PyObject **args = stack_pointer - oparg;
+            PyObject *callable = stack_pointer[-1 - oparg];
+            PyObject *method = stack_pointer[-2 - oparg];
             PyObject *res;
             /* Builtin METH_FASTCALL functions, without keywords */
             ASSERT_KWNAMES_IS_NULL();
@@ -2140,9 +2140,9 @@
         }
 
         case CALL_NO_KW_LEN: {
-            PyObject **args = (stack_pointer - oparg);
-            PyObject *callable = stack_pointer[-(1 + oparg)];
-            PyObject *method = stack_pointer[-(2 + oparg)];
+            PyObject **args = stack_pointer - oparg;
+            PyObject *callable = stack_pointer[-1 - oparg];
+            PyObject *method = stack_pointer[-2 - oparg];
             PyObject *res;
             ASSERT_KWNAMES_IS_NULL();
             /* len(o) */
@@ -2175,9 +2175,9 @@
         }
 
         case CALL_NO_KW_ISINSTANCE: {
-            PyObject **args = (stack_pointer - oparg);
-            PyObject *callable = stack_pointer[-(1 + oparg)];
-            PyObject *method = stack_pointer[-(2 + oparg)];
+            PyObject **args = stack_pointer - oparg;
+            PyObject *callable = stack_pointer[-1 - oparg];
+            PyObject *method = stack_pointer[-2 - oparg];
             PyObject *res;
             ASSERT_KWNAMES_IS_NULL();
             /* isinstance(o, o2) */
@@ -2212,8 +2212,8 @@
         }
 
         case CALL_NO_KW_METHOD_DESCRIPTOR_O: {
-            PyObject **args = (stack_pointer - oparg);
-            PyObject *method = stack_pointer[-(2 + oparg)];
+            PyObject **args = stack_pointer - oparg;
+            PyObject *method = stack_pointer[-2 - oparg];
             PyObject *res;
             ASSERT_KWNAMES_IS_NULL();
             int is_meth = method != NULL;
@@ -2253,8 +2253,8 @@
         }
 
         case CALL_NO_KW_METHOD_DESCRIPTOR_NOARGS: {
-            PyObject **args = (stack_pointer - oparg);
-            PyObject *method = stack_pointer[-(2 + oparg)];
+            PyObject **args = stack_pointer - oparg;
+            PyObject *method = stack_pointer[-2 - oparg];
             PyObject *res;
             ASSERT_KWNAMES_IS_NULL();
             assert(oparg == 0 || oparg == 1);
@@ -2292,8 +2292,8 @@
         }
 
         case CALL_NO_KW_METHOD_DESCRIPTOR_FAST: {
-            PyObject **args = (stack_pointer - oparg);
-            PyObject *method = stack_pointer[-(2 + oparg)];
+            PyObject **args = stack_pointer - oparg;
+            PyObject *method = stack_pointer[-2 - oparg];
             PyObject *res;
             ASSERT_KWNAMES_IS_NULL();
             int is_meth = method != NULL;
@@ -2380,9 +2380,9 @@
         }
 
         case BUILD_SLICE: {
-            PyObject *step = (oparg == 3) ? stack_pointer[-(((oparg == 3) ? 1 : 0))] : NULL;
-            PyObject *stop = stack_pointer[-(1 + ((oparg == 3) ? 1 : 0))];
-            PyObject *start = stack_pointer[-(2 + ((oparg == 3) ? 1 : 0))];
+            PyObject *step = oparg == 3 ? stack_pointer[-(oparg == 3 ? 1 : 0)] : NULL;
+            PyObject *stop = stack_pointer[-1 - (oparg == 3 ? 1 : 0)];
+            PyObject *start = stack_pointer[-2 - (oparg == 3 ? 1 : 0)];
             PyObject *slice;
             slice = PySlice_New(start, stop, step);
             Py_DECREF(start);
@@ -2439,7 +2439,7 @@
         }
 
         case COPY: {
-            PyObject *bottom = stack_pointer[-(1 + (oparg-1))];
+            PyObject *bottom = stack_pointer[-1 - (oparg-1)];
             PyObject *top;
             assert(oparg > 0);
             top = Py_NewRef(bottom);
@@ -2477,7 +2477,7 @@
 
         case SWAP: {
             PyObject *top = stack_pointer[-1];
-            PyObject *bottom = stack_pointer[-(2 + (oparg-2))];
+            PyObject *bottom = stack_pointer[-2 - (oparg-2)];
             assert(oparg >= 2);
             stack_pointer[-1] = bottom;
             stack_pointer[-(2 + (oparg-2))] = top;

--- a/Python/executor_cases.c.h
+++ b/Python/executor_cases.c.h
@@ -130,7 +130,6 @@
             value = stack_pointer[-1];
             DEOPT_IF(!PyBool_Check(value), TO_BOOL);
             STAT_INC(TO_BOOL, hit);
-            stack_pointer[-1] = value;
             break;
         }
 
@@ -228,8 +227,6 @@
             left = stack_pointer[-2];
             DEOPT_IF(!PyLong_CheckExact(left), BINARY_OP);
             DEOPT_IF(!PyLong_CheckExact(right), BINARY_OP);
-            stack_pointer[-2] = left;
-            stack_pointer[-1] = right;
             break;
         }
 
@@ -288,8 +285,6 @@
             left = stack_pointer[-2];
             DEOPT_IF(!PyFloat_CheckExact(left), BINARY_OP);
             DEOPT_IF(!PyFloat_CheckExact(right), BINARY_OP);
-            stack_pointer[-2] = left;
-            stack_pointer[-1] = right;
             break;
         }
 
@@ -348,8 +343,6 @@
             left = stack_pointer[-2];
             DEOPT_IF(!PyUnicode_CheckExact(left), BINARY_OP);
             DEOPT_IF(!PyUnicode_CheckExact(right), BINARY_OP);
-            stack_pointer[-2] = left;
-            stack_pointer[-1] = right;
             break;
         }
 
@@ -525,7 +518,6 @@
             list = stack_pointer[-2 - (oparg-1)];
             if (_PyList_AppendTakeRef((PyListObject *)list, v) < 0) goto pop_1_error;
             STACK_SHRINK(1);
-            stack_pointer[-1 - (oparg-1)] = list;
             break;
         }
 
@@ -538,7 +530,6 @@
             Py_DECREF(v);
             if (err) goto pop_1_error;
             STACK_SHRINK(1);
-            stack_pointer[-1 - (oparg-1)] = set;
             break;
         }
 
@@ -740,7 +731,6 @@
                 }
             }
             STACK_GROW(1);
-            stack_pointer[-2] = aiter;
             stack_pointer[-1] = awaitable;
             break;
         }
@@ -1304,7 +1294,6 @@
             assert(Py_IsNone(none_val));
             Py_DECREF(iterable);
             STACK_SHRINK(1);
-            stack_pointer[-1 - (oparg-1)] = list;
             break;
         }
 
@@ -1317,7 +1306,6 @@
             Py_DECREF(iterable);
             if (err < 0) goto pop_1_error;
             STACK_SHRINK(1);
-            stack_pointer[-1 - (oparg-1)] = set;
             break;
         }
 
@@ -1606,7 +1594,6 @@
             PyTypeObject *tp = Py_TYPE(owner);
             assert(type_version != 0);
             DEOPT_IF(tp->tp_version_tag != type_version, LOAD_ATTR);
-            stack_pointer[-1] = owner;
             break;
         }
 
@@ -1617,7 +1604,6 @@
             assert(Py_TYPE(owner)->tp_flags & Py_TPFLAGS_MANAGED_DICT);
             PyDictOrValues dorv = *_PyObject_DictOrValuesPointer(owner);
             DEOPT_IF(!_PyDictOrValues_IsValues(dorv), LOAD_ATTR);
-            stack_pointer[-1] = owner;
             break;
         }
 
@@ -1822,7 +1808,6 @@
             int res = PyErr_GivenExceptionMatches(left, right);
             Py_DECREF(right);
             b = res ? Py_True : Py_False;
-            stack_pointer[-2] = left;
             stack_pointer[-1] = b;
             break;
         }
@@ -1852,7 +1837,6 @@
             len_o = PyLong_FromSsize_t(len_i);
             if (len_o == NULL) goto error;
             STACK_GROW(1);
-            stack_pointer[-2] = obj;
             stack_pointer[-1] = len_o;
             break;
         }
@@ -1891,7 +1875,6 @@
             int match = Py_TYPE(subject)->tp_flags & Py_TPFLAGS_MAPPING;
             res = match ? Py_True : Py_False;
             STACK_GROW(1);
-            stack_pointer[-2] = subject;
             stack_pointer[-1] = res;
             break;
         }
@@ -1903,7 +1886,6 @@
             int match = Py_TYPE(subject)->tp_flags & Py_TPFLAGS_SEQUENCE;
             res = match ? Py_True : Py_False;
             STACK_GROW(1);
-            stack_pointer[-2] = subject;
             stack_pointer[-1] = res;
             break;
         }
@@ -1918,8 +1900,6 @@
             values_or_none = _PyEval_MatchKeys(tstate, subject, keys);
             if (values_or_none == NULL) goto error;
             STACK_GROW(1);
-            stack_pointer[-3] = subject;
-            stack_pointer[-2] = keys;
             stack_pointer[-1] = values_or_none;
             break;
         }
@@ -1972,7 +1952,6 @@
             PyObject *iter;
             iter = stack_pointer[-1];
             DEOPT_IF(Py_TYPE(iter) != &PyListIter_Type, FOR_ITER);
-            stack_pointer[-1] = iter;
             break;
         }
 
@@ -1995,7 +1974,6 @@
                 exhausted = Py_False;
             }
             STACK_GROW(1);
-            stack_pointer[-2] = iter;
             stack_pointer[-1] = exhausted;
             break;
         }
@@ -2011,7 +1989,6 @@
             assert(it->it_index < PyList_GET_SIZE(seq));
             next = Py_NewRef(PyList_GET_ITEM(seq, it->it_index++));
             STACK_GROW(1);
-            stack_pointer[-2] = iter;
             stack_pointer[-1] = next;
             break;
         }
@@ -2020,7 +1997,6 @@
             PyObject *iter;
             iter = stack_pointer[-1];
             DEOPT_IF(Py_TYPE(iter) != &PyTupleIter_Type, FOR_ITER);
-            stack_pointer[-1] = iter;
             break;
         }
 
@@ -2043,7 +2019,6 @@
                 exhausted = Py_False;
             }
             STACK_GROW(1);
-            stack_pointer[-2] = iter;
             stack_pointer[-1] = exhausted;
             break;
         }
@@ -2059,7 +2034,6 @@
             assert(it->it_index < PyTuple_GET_SIZE(seq));
             next = Py_NewRef(PyTuple_GET_ITEM(seq, it->it_index++));
             STACK_GROW(1);
-            stack_pointer[-2] = iter;
             stack_pointer[-1] = next;
             break;
         }
@@ -2069,7 +2043,6 @@
             iter = stack_pointer[-1];
             _PyRangeIterObject *r = (_PyRangeIterObject *)iter;
             DEOPT_IF(Py_TYPE(r) != &PyRangeIter_Type, FOR_ITER);
-            stack_pointer[-1] = iter;
             break;
         }
 
@@ -2081,7 +2054,6 @@
             assert(Py_TYPE(r) == &PyRangeIter_Type);
             exhausted = r->len <= 0 ? Py_True : Py_False;
             STACK_GROW(1);
-            stack_pointer[-2] = iter;
             stack_pointer[-1] = exhausted;
             break;
         }
@@ -2099,7 +2071,6 @@
             next = PyLong_FromLong(value);
             if (next == NULL) goto error;
             STACK_GROW(1);
-            stack_pointer[-2] = iter;
             stack_pointer[-1] = next;
             break;
         }
@@ -2138,9 +2109,6 @@
                     3 | PY_VECTORCALL_ARGUMENTS_OFFSET, NULL);
             if (res == NULL) goto error;
             STACK_GROW(1);
-            stack_pointer[-5] = exit_func;
-            stack_pointer[-4] = lasti;
-            stack_pointer[-2] = val;
             stack_pointer[-1] = res;
             break;
         }
@@ -2667,7 +2635,6 @@
             assert(oparg > 0);
             top = Py_NewRef(bottom);
             STACK_GROW(1);
-            stack_pointer[-2 - (oparg-1)] = bottom;
             stack_pointer[-1] = top;
             break;
         }

--- a/Python/executor_cases.c.h
+++ b/Python/executor_cases.c.h
@@ -1005,7 +1005,7 @@
             STACK_GROW(1);
             STACK_GROW(((oparg & 1) ? 1 : 0));
             stack_pointer[-1] = v;
-            if (oparg & 1) { stack_pointer[-(1 + ((oparg & 1) ? 1 : 0))] = null; }
+            if (oparg & 1) { stack_pointer[-1 - (oparg & 1 ? 1 : 0)] = null; }
             break;
         }
 
@@ -1041,7 +1041,7 @@
             STACK_GROW(1);
             STACK_GROW(((oparg & 1) ? 1 : 0));
             stack_pointer[-1] = res;
-            if (oparg & 1) { stack_pointer[-(1 + ((oparg & 1) ? 1 : 0))] = null; }
+            if (oparg & 1) { stack_pointer[-1 - (oparg & 1 ? 1 : 0)] = null; }
             break;
         }
 
@@ -1059,7 +1059,7 @@
             STACK_GROW(1);
             STACK_GROW(((oparg & 1) ? 1 : 0));
             stack_pointer[-1] = res;
-            if (oparg & 1) { stack_pointer[-(1 + ((oparg & 1) ? 1 : 0))] = null; }
+            if (oparg & 1) { stack_pointer[-1 - (oparg & 1 ? 1 : 0)] = null; }
             break;
         }
 
@@ -1384,7 +1384,7 @@
             STACK_SHRINK(2);
             STACK_GROW(((oparg & 1) ? 1 : 0));
             stack_pointer[-1] = res;
-            if (oparg & 1) { stack_pointer[-(1 + ((oparg & 1) ? 1 : 0))] = res2; }
+            if (oparg & 1) { stack_pointer[-1 - (oparg & 1 ? 1 : 0)] = res2; }
             break;
         }
 
@@ -1474,7 +1474,7 @@
             }
             STACK_GROW(((oparg & 1) ? 1 : 0));
             stack_pointer[-1] = res;
-            if (oparg & 1) { stack_pointer[-(1 + ((oparg & 1) ? 1 : 0))] = res2; }
+            if (oparg & 1) { stack_pointer[-1 - (oparg & 1 ? 1 : 0)] = res2; }
             break;
         }
 
@@ -1510,7 +1510,7 @@
             Py_DECREF(owner);
             STACK_GROW(((oparg & 1) ? 1 : 0));
             stack_pointer[-1] = res;
-            if (oparg & 1) { stack_pointer[-(1 + ((oparg & 1) ? 1 : 0))] = res2; }
+            if (oparg & 1) { stack_pointer[-1 - (oparg & 1 ? 1 : 0)] = res2; }
             break;
         }
 
@@ -2480,7 +2480,7 @@
             PyObject *bottom = stack_pointer[-2 - (oparg-2)];
             assert(oparg >= 2);
             stack_pointer[-1] = bottom;
-            stack_pointer[-(2 + (oparg-2))] = top;
+            stack_pointer[-2 - (oparg-2)] = top;
             break;
         }
 

--- a/Python/executor_cases.c.h
+++ b/Python/executor_cases.c.h
@@ -47,14 +47,16 @@
         }
 
         case STORE_FAST: {
-            PyObject *value = stack_pointer[-1];
+            PyObject *value;
+            value = stack_pointer[-1];
             SETLOCAL(oparg, value);
             STACK_SHRINK(1);
             break;
         }
 
         case POP_TOP: {
-            PyObject *value = stack_pointer[-1];
+            PyObject *value;
+            value = stack_pointer[-1];
             Py_DECREF(value);
             STACK_SHRINK(1);
             break;
@@ -69,8 +71,10 @@
         }
 
         case END_SEND: {
-            PyObject *value = stack_pointer[-1];
-            PyObject *receiver = stack_pointer[-2];
+            PyObject *value;
+            PyObject *receiver;
+            value = stack_pointer[-1];
+            receiver = stack_pointer[-2];
             Py_DECREF(receiver);
             STACK_SHRINK(1);
             stack_pointer[-1] = value;
@@ -78,8 +82,9 @@
         }
 
         case UNARY_NEGATIVE: {
-            PyObject *value = stack_pointer[-1];
+            PyObject *value;
             PyObject *res;
+            value = stack_pointer[-1];
             res = PyNumber_Negative(value);
             Py_DECREF(value);
             if (res == NULL) goto pop_1_error;
@@ -88,8 +93,9 @@
         }
 
         case UNARY_NOT: {
-            PyObject *value = stack_pointer[-1];
+            PyObject *value;
             PyObject *res;
+            value = stack_pointer[-1];
             assert(PyBool_Check(value));
             res = Py_IsFalse(value) ? Py_True : Py_False;
             stack_pointer[-1] = res;
@@ -98,8 +104,9 @@
 
         case TO_BOOL: {
             static_assert(INLINE_CACHE_ENTRIES_TO_BOOL == 3, "incorrect cache size");
-            PyObject *value = stack_pointer[-1];
+            PyObject *value;
             PyObject *res;
+            value = stack_pointer[-1];
             #if ENABLE_SPECIALIZATION
             _PyToBoolCache *cache = (_PyToBoolCache *)next_instr;
             if (ADAPTIVE_COUNTER_IS_ZERO(cache->counter)) {
@@ -119,15 +126,18 @@
         }
 
         case TO_BOOL_BOOL: {
-            PyObject *value = stack_pointer[-1];
+            PyObject *value;
+            value = stack_pointer[-1];
             DEOPT_IF(!PyBool_Check(value), TO_BOOL);
             STAT_INC(TO_BOOL, hit);
+            stack_pointer[-1] = value;
             break;
         }
 
         case TO_BOOL_INT: {
-            PyObject *value = stack_pointer[-1];
+            PyObject *value;
             PyObject *res;
+            value = stack_pointer[-1];
             DEOPT_IF(!PyLong_CheckExact(value), TO_BOOL);
             STAT_INC(TO_BOOL, hit);
             if (_PyLong_IsZero((PyLongObject *)value)) {
@@ -143,8 +153,9 @@
         }
 
         case TO_BOOL_LIST: {
-            PyObject *value = stack_pointer[-1];
+            PyObject *value;
             PyObject *res;
+            value = stack_pointer[-1];
             DEOPT_IF(!PyList_CheckExact(value), TO_BOOL);
             STAT_INC(TO_BOOL, hit);
             res = Py_SIZE(value) ? Py_True : Py_False;
@@ -154,8 +165,9 @@
         }
 
         case TO_BOOL_NONE: {
-            PyObject *value = stack_pointer[-1];
+            PyObject *value;
             PyObject *res;
+            value = stack_pointer[-1];
             // This one is a bit weird, because we expect *some* failures:
             DEOPT_IF(!Py_IsNone(value), TO_BOOL);
             STAT_INC(TO_BOOL, hit);
@@ -165,8 +177,9 @@
         }
 
         case TO_BOOL_STR: {
-            PyObject *value = stack_pointer[-1];
+            PyObject *value;
             PyObject *res;
+            value = stack_pointer[-1];
             DEOPT_IF(!PyUnicode_CheckExact(value), TO_BOOL);
             STAT_INC(TO_BOOL, hit);
             if (value == &_Py_STR(empty)) {
@@ -183,8 +196,9 @@
         }
 
         case TO_BOOL_ALWAYS_TRUE: {
-            PyObject *value = stack_pointer[-1];
+            PyObject *value;
             PyObject *res;
+            value = stack_pointer[-1];
             uint32_t version = (uint32_t)operand;
             // This one is a bit weird, because we expect *some* failures:
             assert(version);
@@ -197,8 +211,9 @@
         }
 
         case UNARY_INVERT: {
-            PyObject *value = stack_pointer[-1];
+            PyObject *value;
             PyObject *res;
+            value = stack_pointer[-1];
             res = PyNumber_Invert(value);
             Py_DECREF(value);
             if (res == NULL) goto pop_1_error;
@@ -207,17 +222,23 @@
         }
 
         case _GUARD_BOTH_INT: {
-            PyObject *right = stack_pointer[-1];
-            PyObject *left = stack_pointer[-2];
+            PyObject *right;
+            PyObject *left;
+            right = stack_pointer[-1];
+            left = stack_pointer[-2];
             DEOPT_IF(!PyLong_CheckExact(left), BINARY_OP);
             DEOPT_IF(!PyLong_CheckExact(right), BINARY_OP);
+            stack_pointer[-2] = left;
+            stack_pointer[-1] = right;
             break;
         }
 
         case _BINARY_OP_MULTIPLY_INT: {
-            PyObject *right = stack_pointer[-1];
-            PyObject *left = stack_pointer[-2];
+            PyObject *right;
+            PyObject *left;
             PyObject *res;
+            right = stack_pointer[-1];
+            left = stack_pointer[-2];
             STAT_INC(BINARY_OP, hit);
             res = _PyLong_Multiply((PyLongObject *)left, (PyLongObject *)right);
             _Py_DECREF_SPECIALIZED(right, (destructor)PyObject_Free);
@@ -229,9 +250,11 @@
         }
 
         case _BINARY_OP_ADD_INT: {
-            PyObject *right = stack_pointer[-1];
-            PyObject *left = stack_pointer[-2];
+            PyObject *right;
+            PyObject *left;
             PyObject *res;
+            right = stack_pointer[-1];
+            left = stack_pointer[-2];
             STAT_INC(BINARY_OP, hit);
             res = _PyLong_Add((PyLongObject *)left, (PyLongObject *)right);
             _Py_DECREF_SPECIALIZED(right, (destructor)PyObject_Free);
@@ -243,9 +266,11 @@
         }
 
         case _BINARY_OP_SUBTRACT_INT: {
-            PyObject *right = stack_pointer[-1];
-            PyObject *left = stack_pointer[-2];
+            PyObject *right;
+            PyObject *left;
             PyObject *res;
+            right = stack_pointer[-1];
+            left = stack_pointer[-2];
             STAT_INC(BINARY_OP, hit);
             res = _PyLong_Subtract((PyLongObject *)left, (PyLongObject *)right);
             _Py_DECREF_SPECIALIZED(right, (destructor)PyObject_Free);
@@ -257,17 +282,23 @@
         }
 
         case _GUARD_BOTH_FLOAT: {
-            PyObject *right = stack_pointer[-1];
-            PyObject *left = stack_pointer[-2];
+            PyObject *right;
+            PyObject *left;
+            right = stack_pointer[-1];
+            left = stack_pointer[-2];
             DEOPT_IF(!PyFloat_CheckExact(left), BINARY_OP);
             DEOPT_IF(!PyFloat_CheckExact(right), BINARY_OP);
+            stack_pointer[-2] = left;
+            stack_pointer[-1] = right;
             break;
         }
 
         case _BINARY_OP_MULTIPLY_FLOAT: {
-            PyObject *right = stack_pointer[-1];
-            PyObject *left = stack_pointer[-2];
+            PyObject *right;
+            PyObject *left;
             PyObject *res;
+            right = stack_pointer[-1];
+            left = stack_pointer[-2];
             STAT_INC(BINARY_OP, hit);
             double dres =
                 ((PyFloatObject *)left)->ob_fval *
@@ -279,9 +310,11 @@
         }
 
         case _BINARY_OP_ADD_FLOAT: {
-            PyObject *right = stack_pointer[-1];
-            PyObject *left = stack_pointer[-2];
+            PyObject *right;
+            PyObject *left;
             PyObject *res;
+            right = stack_pointer[-1];
+            left = stack_pointer[-2];
             STAT_INC(BINARY_OP, hit);
             double dres =
                 ((PyFloatObject *)left)->ob_fval +
@@ -293,9 +326,11 @@
         }
 
         case _BINARY_OP_SUBTRACT_FLOAT: {
-            PyObject *right = stack_pointer[-1];
-            PyObject *left = stack_pointer[-2];
+            PyObject *right;
+            PyObject *left;
             PyObject *res;
+            right = stack_pointer[-1];
+            left = stack_pointer[-2];
             STAT_INC(BINARY_OP, hit);
             double dres =
                 ((PyFloatObject *)left)->ob_fval -
@@ -307,17 +342,23 @@
         }
 
         case _GUARD_BOTH_UNICODE: {
-            PyObject *right = stack_pointer[-1];
-            PyObject *left = stack_pointer[-2];
+            PyObject *right;
+            PyObject *left;
+            right = stack_pointer[-1];
+            left = stack_pointer[-2];
             DEOPT_IF(!PyUnicode_CheckExact(left), BINARY_OP);
             DEOPT_IF(!PyUnicode_CheckExact(right), BINARY_OP);
+            stack_pointer[-2] = left;
+            stack_pointer[-1] = right;
             break;
         }
 
         case _BINARY_OP_ADD_UNICODE: {
-            PyObject *right = stack_pointer[-1];
-            PyObject *left = stack_pointer[-2];
+            PyObject *right;
+            PyObject *left;
             PyObject *res;
+            right = stack_pointer[-1];
+            left = stack_pointer[-2];
             STAT_INC(BINARY_OP, hit);
             res = PyUnicode_Concat(left, right);
             _Py_DECREF_SPECIALIZED(left, _PyUnicode_ExactDealloc);
@@ -330,9 +371,11 @@
 
         case BINARY_SUBSCR: {
             static_assert(INLINE_CACHE_ENTRIES_BINARY_SUBSCR == 1, "incorrect cache size");
-            PyObject *sub = stack_pointer[-1];
-            PyObject *container = stack_pointer[-2];
+            PyObject *sub;
+            PyObject *container;
             PyObject *res;
+            sub = stack_pointer[-1];
+            container = stack_pointer[-2];
             #if ENABLE_SPECIALIZATION
             _PyBinarySubscrCache *cache = (_PyBinarySubscrCache *)next_instr;
             if (ADAPTIVE_COUNTER_IS_ZERO(cache->counter)) {
@@ -353,10 +396,13 @@
         }
 
         case BINARY_SLICE: {
-            PyObject *stop = stack_pointer[-1];
-            PyObject *start = stack_pointer[-2];
-            PyObject *container = stack_pointer[-3];
+            PyObject *stop;
+            PyObject *start;
+            PyObject *container;
             PyObject *res;
+            stop = stack_pointer[-1];
+            start = stack_pointer[-2];
+            container = stack_pointer[-3];
             PyObject *slice = _PyBuildSlice_ConsumeRefs(start, stop);
             // Can't use ERROR_IF() here, because we haven't
             // DECREF'ed container yet, and we still own slice.
@@ -375,10 +421,14 @@
         }
 
         case STORE_SLICE: {
-            PyObject *stop = stack_pointer[-1];
-            PyObject *start = stack_pointer[-2];
-            PyObject *container = stack_pointer[-3];
-            PyObject *v = stack_pointer[-4];
+            PyObject *stop;
+            PyObject *start;
+            PyObject *container;
+            PyObject *v;
+            stop = stack_pointer[-1];
+            start = stack_pointer[-2];
+            container = stack_pointer[-3];
+            v = stack_pointer[-4];
             PyObject *slice = _PyBuildSlice_ConsumeRefs(start, stop);
             int err;
             if (slice == NULL) {
@@ -396,9 +446,11 @@
         }
 
         case BINARY_SUBSCR_LIST_INT: {
-            PyObject *sub = stack_pointer[-1];
-            PyObject *list = stack_pointer[-2];
+            PyObject *sub;
+            PyObject *list;
             PyObject *res;
+            sub = stack_pointer[-1];
+            list = stack_pointer[-2];
             DEOPT_IF(!PyLong_CheckExact(sub), BINARY_SUBSCR);
             DEOPT_IF(!PyList_CheckExact(list), BINARY_SUBSCR);
 
@@ -418,9 +470,11 @@
         }
 
         case BINARY_SUBSCR_TUPLE_INT: {
-            PyObject *sub = stack_pointer[-1];
-            PyObject *tuple = stack_pointer[-2];
+            PyObject *sub;
+            PyObject *tuple;
             PyObject *res;
+            sub = stack_pointer[-1];
+            tuple = stack_pointer[-2];
             DEOPT_IF(!PyLong_CheckExact(sub), BINARY_SUBSCR);
             DEOPT_IF(!PyTuple_CheckExact(tuple), BINARY_SUBSCR);
 
@@ -440,9 +494,11 @@
         }
 
         case BINARY_SUBSCR_DICT: {
-            PyObject *sub = stack_pointer[-1];
-            PyObject *dict = stack_pointer[-2];
+            PyObject *sub;
+            PyObject *dict;
             PyObject *res;
+            sub = stack_pointer[-1];
+            dict = stack_pointer[-2];
             DEOPT_IF(!PyDict_CheckExact(dict), BINARY_SUBSCR);
             STAT_INC(BINARY_SUBSCR, hit);
             res = PyDict_GetItemWithError(dict, sub);
@@ -463,28 +519,37 @@
         }
 
         case LIST_APPEND: {
-            PyObject *v = stack_pointer[-1];
-            PyObject *list = stack_pointer[-2 - (oparg-1)];
+            PyObject *v;
+            PyObject *list;
+            v = stack_pointer[-1];
+            list = stack_pointer[-2 - (oparg-1)];
             if (_PyList_AppendTakeRef((PyListObject *)list, v) < 0) goto pop_1_error;
             STACK_SHRINK(1);
+            stack_pointer[-1 - (oparg-1)] = list;
             break;
         }
 
         case SET_ADD: {
-            PyObject *v = stack_pointer[-1];
-            PyObject *set = stack_pointer[-2 - (oparg-1)];
+            PyObject *v;
+            PyObject *set;
+            v = stack_pointer[-1];
+            set = stack_pointer[-2 - (oparg-1)];
             int err = PySet_Add(set, v);
             Py_DECREF(v);
             if (err) goto pop_1_error;
             STACK_SHRINK(1);
+            stack_pointer[-1 - (oparg-1)] = set;
             break;
         }
 
         case STORE_SUBSCR: {
             static_assert(INLINE_CACHE_ENTRIES_STORE_SUBSCR == 1, "incorrect cache size");
-            PyObject *sub = stack_pointer[-1];
-            PyObject *container = stack_pointer[-2];
-            PyObject *v = stack_pointer[-3];
+            PyObject *sub;
+            PyObject *container;
+            PyObject *v;
+            sub = stack_pointer[-1];
+            container = stack_pointer[-2];
+            v = stack_pointer[-3];
             #if ENABLE_SPECIALIZATION
             _PyStoreSubscrCache *cache = (_PyStoreSubscrCache *)next_instr;
             if (ADAPTIVE_COUNTER_IS_ZERO(cache->counter)) {
@@ -506,9 +571,12 @@
         }
 
         case STORE_SUBSCR_LIST_INT: {
-            PyObject *sub = stack_pointer[-1];
-            PyObject *list = stack_pointer[-2];
-            PyObject *value = stack_pointer[-3];
+            PyObject *sub;
+            PyObject *list;
+            PyObject *value;
+            sub = stack_pointer[-1];
+            list = stack_pointer[-2];
+            value = stack_pointer[-3];
             DEOPT_IF(!PyLong_CheckExact(sub), STORE_SUBSCR);
             DEOPT_IF(!PyList_CheckExact(list), STORE_SUBSCR);
 
@@ -530,9 +598,12 @@
         }
 
         case STORE_SUBSCR_DICT: {
-            PyObject *sub = stack_pointer[-1];
-            PyObject *dict = stack_pointer[-2];
-            PyObject *value = stack_pointer[-3];
+            PyObject *sub;
+            PyObject *dict;
+            PyObject *value;
+            sub = stack_pointer[-1];
+            dict = stack_pointer[-2];
+            value = stack_pointer[-3];
             DEOPT_IF(!PyDict_CheckExact(dict), STORE_SUBSCR);
             STAT_INC(STORE_SUBSCR, hit);
             int err = _PyDict_SetItem_Take2((PyDictObject *)dict, sub, value);
@@ -543,8 +614,10 @@
         }
 
         case DELETE_SUBSCR: {
-            PyObject *sub = stack_pointer[-1];
-            PyObject *container = stack_pointer[-2];
+            PyObject *sub;
+            PyObject *container;
+            sub = stack_pointer[-1];
+            container = stack_pointer[-2];
             /* del container[sub] */
             int err = PyObject_DelItem(container, sub);
             Py_DECREF(container);
@@ -555,8 +628,9 @@
         }
 
         case CALL_INTRINSIC_1: {
-            PyObject *value = stack_pointer[-1];
+            PyObject *value;
             PyObject *res;
+            value = stack_pointer[-1];
             assert(oparg <= MAX_INTRINSIC_1);
             res = _PyIntrinsics_UnaryFunctions[oparg].func(tstate, value);
             Py_DECREF(value);
@@ -566,9 +640,11 @@
         }
 
         case CALL_INTRINSIC_2: {
-            PyObject *value1 = stack_pointer[-1];
-            PyObject *value2 = stack_pointer[-2];
+            PyObject *value1;
+            PyObject *value2;
             PyObject *res;
+            value1 = stack_pointer[-1];
+            value2 = stack_pointer[-2];
             assert(oparg <= MAX_INTRINSIC_2);
             res = _PyIntrinsics_BinaryFunctions[oparg].func(tstate, value2, value1);
             Py_DECREF(value2);
@@ -580,8 +656,9 @@
         }
 
         case GET_AITER: {
-            PyObject *obj = stack_pointer[-1];
+            PyObject *obj;
             PyObject *iter;
+            obj = stack_pointer[-1];
             unaryfunc getter = NULL;
             PyTypeObject *type = Py_TYPE(obj);
 
@@ -617,8 +694,9 @@
         }
 
         case GET_ANEXT: {
-            PyObject *aiter = stack_pointer[-1];
+            PyObject *aiter;
             PyObject *awaitable;
+            aiter = stack_pointer[-1];
             unaryfunc getter = NULL;
             PyObject *next_iter = NULL;
             PyTypeObject *type = Py_TYPE(aiter);
@@ -662,13 +740,15 @@
                 }
             }
             STACK_GROW(1);
+            stack_pointer[-2] = aiter;
             stack_pointer[-1] = awaitable;
             break;
         }
 
         case GET_AWAITABLE: {
-            PyObject *iterable = stack_pointer[-1];
+            PyObject *iterable;
             PyObject *iter;
+            iterable = stack_pointer[-1];
             iter = _PyCoro_GetAwaitableIter(iterable);
 
             if (iter == NULL) {
@@ -697,7 +777,8 @@
         }
 
         case POP_EXCEPT: {
-            PyObject *exc_value = stack_pointer[-1];
+            PyObject *exc_value;
+            exc_value = stack_pointer[-1];
             _PyErr_StackItem *exc_info = tstate->exc_info;
             Py_XSETREF(exc_info->exc_value, exc_value);
             STACK_SHRINK(1);
@@ -726,7 +807,8 @@
         }
 
         case STORE_NAME: {
-            PyObject *v = stack_pointer[-1];
+            PyObject *v;
+            v = stack_pointer[-1];
             PyObject *name = GETITEM(FRAME_CO_NAMES, oparg);
             PyObject *ns = LOCALS();
             int err;
@@ -768,7 +850,8 @@
 
         case UNPACK_SEQUENCE: {
             static_assert(INLINE_CACHE_ENTRIES_UNPACK_SEQUENCE == 1, "incorrect cache size");
-            PyObject *seq = stack_pointer[-1];
+            PyObject *seq;
+            seq = stack_pointer[-1];
             #if ENABLE_SPECIALIZATION
             _PyUnpackSequenceCache *cache = (_PyUnpackSequenceCache *)next_instr;
             if (ADAPTIVE_COUNTER_IS_ZERO(cache->counter)) {
@@ -789,8 +872,10 @@
         }
 
         case UNPACK_SEQUENCE_TWO_TUPLE: {
-            PyObject *seq = stack_pointer[-1];
-            PyObject **values = stack_pointer - 1;
+            PyObject *seq;
+            PyObject **values;
+            seq = stack_pointer[-1];
+            values = stack_pointer - 1;
             DEOPT_IF(!PyTuple_CheckExact(seq), UNPACK_SEQUENCE);
             DEOPT_IF(PyTuple_GET_SIZE(seq) != 2, UNPACK_SEQUENCE);
             assert(oparg == 2);
@@ -804,8 +889,10 @@
         }
 
         case UNPACK_SEQUENCE_TUPLE: {
-            PyObject *seq = stack_pointer[-1];
-            PyObject **values = stack_pointer - 1;
+            PyObject *seq;
+            PyObject **values;
+            seq = stack_pointer[-1];
+            values = stack_pointer - 1;
             DEOPT_IF(!PyTuple_CheckExact(seq), UNPACK_SEQUENCE);
             DEOPT_IF(PyTuple_GET_SIZE(seq) != oparg, UNPACK_SEQUENCE);
             STAT_INC(UNPACK_SEQUENCE, hit);
@@ -820,8 +907,10 @@
         }
 
         case UNPACK_SEQUENCE_LIST: {
-            PyObject *seq = stack_pointer[-1];
-            PyObject **values = stack_pointer - 1;
+            PyObject *seq;
+            PyObject **values;
+            seq = stack_pointer[-1];
+            values = stack_pointer - 1;
             DEOPT_IF(!PyList_CheckExact(seq), UNPACK_SEQUENCE);
             DEOPT_IF(PyList_GET_SIZE(seq) != oparg, UNPACK_SEQUENCE);
             STAT_INC(UNPACK_SEQUENCE, hit);
@@ -836,7 +925,8 @@
         }
 
         case UNPACK_EX: {
-            PyObject *seq = stack_pointer[-1];
+            PyObject *seq;
+            seq = stack_pointer[-1];
             int totalargs = 1 + (oparg & 0xFF) + (oparg >> 8);
             PyObject **top = stack_pointer + totalargs - 1;
             int res = _PyEval_UnpackIterable(tstate, seq, oparg & 0xFF, oparg >> 8, top);
@@ -848,8 +938,10 @@
 
         case STORE_ATTR: {
             static_assert(INLINE_CACHE_ENTRIES_STORE_ATTR == 4, "incorrect cache size");
-            PyObject *owner = stack_pointer[-1];
-            PyObject *v = stack_pointer[-2];
+            PyObject *owner;
+            PyObject *v;
+            owner = stack_pointer[-1];
+            v = stack_pointer[-2];
             #if ENABLE_SPECIALIZATION
             _PyAttrCache *cache = (_PyAttrCache *)next_instr;
             if (ADAPTIVE_COUNTER_IS_ZERO(cache->counter)) {
@@ -871,7 +963,8 @@
         }
 
         case DELETE_ATTR: {
-            PyObject *owner = stack_pointer[-1];
+            PyObject *owner;
+            owner = stack_pointer[-1];
             PyObject *name = GETITEM(FRAME_CO_NAMES, oparg);
             int err = PyObject_DelAttr(owner, name);
             Py_DECREF(owner);
@@ -881,7 +974,8 @@
         }
 
         case STORE_GLOBAL: {
-            PyObject *v = stack_pointer[-1];
+            PyObject *v;
+            v = stack_pointer[-1];
             PyObject *name = GETITEM(FRAME_CO_NAMES, oparg);
             int err = PyDict_SetItem(GLOBALS(), name, v);
             Py_DECREF(v);
@@ -920,8 +1014,9 @@
         }
 
         case _LOAD_FROM_DICT_OR_GLOBALS: {
-            PyObject *mod_or_class_dict = stack_pointer[-1];
+            PyObject *mod_or_class_dict;
             PyObject *v;
+            mod_or_class_dict = stack_pointer[-1];
             PyObject *name = GETITEM(FRAME_CO_NAMES, oparg);
             if (PyMapping_GetOptionalItem(mod_or_class_dict, name, &v) < 0) {
                 Py_DECREF(mod_or_class_dict);
@@ -1004,8 +1099,8 @@
             null = NULL;
             STACK_GROW(1);
             STACK_GROW(((oparg & 1) ? 1 : 0));
-            stack_pointer[-1] = v;
             if (oparg & 1) { stack_pointer[-1 - (oparg & 1 ? 1 : 0)] = null; }
+            stack_pointer[-1] = v;
             break;
         }
 
@@ -1040,8 +1135,8 @@
             null = NULL;
             STACK_GROW(1);
             STACK_GROW(((oparg & 1) ? 1 : 0));
-            stack_pointer[-1] = res;
             if (oparg & 1) { stack_pointer[-1 - (oparg & 1 ? 1 : 0)] = null; }
+            stack_pointer[-1] = res;
             break;
         }
 
@@ -1058,8 +1153,8 @@
             null = NULL;
             STACK_GROW(1);
             STACK_GROW(((oparg & 1) ? 1 : 0));
-            stack_pointer[-1] = res;
             if (oparg & 1) { stack_pointer[-1 - (oparg & 1 ? 1 : 0)] = null; }
+            stack_pointer[-1] = res;
             break;
         }
 
@@ -1085,8 +1180,9 @@
         }
 
         case LOAD_FROM_DICT_OR_DEREF: {
-            PyObject *class_dict = stack_pointer[-1];
+            PyObject *class_dict;
             PyObject *value;
+            class_dict = stack_pointer[-1];
             PyObject *name;
             assert(class_dict);
             assert(oparg >= 0 && oparg < _PyFrame_GetCode(frame)->co_nlocalsplus);
@@ -1124,7 +1220,8 @@
         }
 
         case STORE_DEREF: {
-            PyObject *v = stack_pointer[-1];
+            PyObject *v;
+            v = stack_pointer[-1];
             PyObject *cell = GETLOCAL(oparg);
             PyObject *oldobj = PyCell_GET(cell);
             PyCell_SET(cell, v);
@@ -1148,8 +1245,9 @@
         }
 
         case BUILD_STRING: {
-            PyObject **pieces = stack_pointer - oparg;
+            PyObject **pieces;
             PyObject *str;
+            pieces = stack_pointer - oparg;
             str = _PyUnicode_JoinArray(&_Py_STR(empty), pieces, oparg);
             for (int _i = oparg; --_i >= 0;) {
                 Py_DECREF(pieces[_i]);
@@ -1162,8 +1260,9 @@
         }
 
         case BUILD_TUPLE: {
-            PyObject **values = stack_pointer - oparg;
+            PyObject **values;
             PyObject *tup;
+            values = stack_pointer - oparg;
             tup = _PyTuple_FromArraySteal(values, oparg);
             if (tup == NULL) { STACK_SHRINK(oparg); goto error; }
             STACK_SHRINK(oparg);
@@ -1173,8 +1272,9 @@
         }
 
         case BUILD_LIST: {
-            PyObject **values = stack_pointer - oparg;
+            PyObject **values;
             PyObject *list;
+            values = stack_pointer - oparg;
             list = _PyList_FromArraySteal(values, oparg);
             if (list == NULL) { STACK_SHRINK(oparg); goto error; }
             STACK_SHRINK(oparg);
@@ -1184,8 +1284,10 @@
         }
 
         case LIST_EXTEND: {
-            PyObject *iterable = stack_pointer[-1];
-            PyObject *list = stack_pointer[-2 - (oparg-1)];
+            PyObject *iterable;
+            PyObject *list;
+            iterable = stack_pointer[-1];
+            list = stack_pointer[-2 - (oparg-1)];
             PyObject *none_val = _PyList_Extend((PyListObject *)list, iterable);
             if (none_val == NULL) {
                 if (_PyErr_ExceptionMatches(tstate, PyExc_TypeError) &&
@@ -1202,22 +1304,27 @@
             assert(Py_IsNone(none_val));
             Py_DECREF(iterable);
             STACK_SHRINK(1);
+            stack_pointer[-1 - (oparg-1)] = list;
             break;
         }
 
         case SET_UPDATE: {
-            PyObject *iterable = stack_pointer[-1];
-            PyObject *set = stack_pointer[-2 - (oparg-1)];
+            PyObject *iterable;
+            PyObject *set;
+            iterable = stack_pointer[-1];
+            set = stack_pointer[-2 - (oparg-1)];
             int err = _PySet_Update(set, iterable);
             Py_DECREF(iterable);
             if (err < 0) goto pop_1_error;
             STACK_SHRINK(1);
+            stack_pointer[-1 - (oparg-1)] = set;
             break;
         }
 
         case BUILD_SET: {
-            PyObject **values = stack_pointer - oparg;
+            PyObject **values;
             PyObject *set;
+            values = stack_pointer - oparg;
             set = PySet_New(NULL);
             if (set == NULL)
                 goto error;
@@ -1239,8 +1346,9 @@
         }
 
         case BUILD_MAP: {
-            PyObject **values = stack_pointer - oparg*2;
+            PyObject **values;
             PyObject *map;
+            values = stack_pointer - oparg*2;
             map = _PyDict_FromItems(
                     values, 2,
                     values+1, 2,
@@ -1300,9 +1408,11 @@
         }
 
         case BUILD_CONST_KEY_MAP: {
-            PyObject *keys = stack_pointer[-1];
-            PyObject **values = stack_pointer - 1 - oparg;
+            PyObject *keys;
+            PyObject **values;
             PyObject *map;
+            keys = stack_pointer[-1];
+            values = stack_pointer - 1 - oparg;
             if (!PyTuple_CheckExact(keys) ||
                 PyTuple_GET_SIZE(keys) != (Py_ssize_t)oparg) {
                 _PyErr_SetString(tstate, PyExc_SystemError,
@@ -1323,7 +1433,8 @@
         }
 
         case DICT_UPDATE: {
-            PyObject *update = stack_pointer[-1];
+            PyObject *update;
+            update = stack_pointer[-1];
             PyObject *dict = PEEK(oparg + 1);  // update is still on the stack
             if (PyDict_Update(dict, update) < 0) {
                 if (_PyErr_ExceptionMatches(tstate, PyExc_AttributeError)) {
@@ -1340,7 +1451,8 @@
         }
 
         case DICT_MERGE: {
-            PyObject *update = stack_pointer[-1];
+            PyObject *update;
+            update = stack_pointer[-1];
             PyObject *dict = PEEK(oparg + 1);  // update is still on the stack
 
             if (_PyDict_MergeEx(dict, update, 2) < 0) {
@@ -1354,8 +1466,10 @@
         }
 
         case MAP_ADD: {
-            PyObject *value = stack_pointer[-1];
-            PyObject *key = stack_pointer[-2];
+            PyObject *value;
+            PyObject *key;
+            value = stack_pointer[-1];
+            key = stack_pointer[-2];
             PyObject *dict = PEEK(oparg + 2);  // key, value are still on the stack
             assert(PyDict_CheckExact(dict));
             /* dict[key] = value */
@@ -1366,11 +1480,14 @@
         }
 
         case LOAD_SUPER_ATTR_ATTR: {
-            PyObject *self = stack_pointer[-1];
-            PyObject *class = stack_pointer[-2];
-            PyObject *global_super = stack_pointer[-3];
+            PyObject *self;
+            PyObject *class;
+            PyObject *global_super;
             PyObject *res2 = NULL;
             PyObject *res;
+            self = stack_pointer[-1];
+            class = stack_pointer[-2];
+            global_super = stack_pointer[-3];
             assert(!(oparg & 1));
             DEOPT_IF(global_super != (PyObject *)&PySuper_Type, LOAD_SUPER_ATTR);
             DEOPT_IF(!PyType_Check(class), LOAD_SUPER_ATTR);
@@ -1383,17 +1500,20 @@
             if (res == NULL) goto pop_3_error;
             STACK_SHRINK(2);
             STACK_GROW(((oparg & 1) ? 1 : 0));
-            stack_pointer[-1] = res;
             if (oparg & 1) { stack_pointer[-1 - (oparg & 1 ? 1 : 0)] = res2; }
+            stack_pointer[-1] = res;
             break;
         }
 
         case LOAD_SUPER_ATTR_METHOD: {
-            PyObject *self = stack_pointer[-1];
-            PyObject *class = stack_pointer[-2];
-            PyObject *global_super = stack_pointer[-3];
+            PyObject *self;
+            PyObject *class;
+            PyObject *global_super;
             PyObject *res2;
             PyObject *res;
+            self = stack_pointer[-1];
+            class = stack_pointer[-2];
+            global_super = stack_pointer[-3];
             assert(oparg & 1);
             DEOPT_IF(global_super != (PyObject *)&PySuper_Type, LOAD_SUPER_ATTR);
             DEOPT_IF(!PyType_Check(class), LOAD_SUPER_ATTR);
@@ -1417,16 +1537,17 @@
                 res2 = NULL;
             }
             STACK_SHRINK(1);
-            stack_pointer[-1] = res;
             stack_pointer[-2] = res2;
+            stack_pointer[-1] = res;
             break;
         }
 
         case LOAD_ATTR: {
             static_assert(INLINE_CACHE_ENTRIES_LOAD_ATTR == 9, "incorrect cache size");
-            PyObject *owner = stack_pointer[-1];
+            PyObject *owner;
             PyObject *res2 = NULL;
             PyObject *res;
+            owner = stack_pointer[-1];
             #if ENABLE_SPECIALIZATION
             _PyAttrCache *cache = (_PyAttrCache *)next_instr;
             if (ADAPTIVE_COUNTER_IS_ZERO(cache->counter)) {
@@ -1473,33 +1594,38 @@
                 if (res == NULL) goto pop_1_error;
             }
             STACK_GROW(((oparg & 1) ? 1 : 0));
-            stack_pointer[-1] = res;
             if (oparg & 1) { stack_pointer[-1 - (oparg & 1 ? 1 : 0)] = res2; }
+            stack_pointer[-1] = res;
             break;
         }
 
         case _GUARD_TYPE_VERSION: {
-            PyObject *owner = stack_pointer[-1];
+            PyObject *owner;
+            owner = stack_pointer[-1];
             uint32_t type_version = (uint32_t)operand;
             PyTypeObject *tp = Py_TYPE(owner);
             assert(type_version != 0);
             DEOPT_IF(tp->tp_version_tag != type_version, LOAD_ATTR);
+            stack_pointer[-1] = owner;
             break;
         }
 
         case _CHECK_MANAGED_OBJECT_HAS_VALUES: {
-            PyObject *owner = stack_pointer[-1];
+            PyObject *owner;
+            owner = stack_pointer[-1];
             assert(Py_TYPE(owner)->tp_dictoffset < 0);
             assert(Py_TYPE(owner)->tp_flags & Py_TPFLAGS_MANAGED_DICT);
             PyDictOrValues dorv = *_PyObject_DictOrValuesPointer(owner);
             DEOPT_IF(!_PyDictOrValues_IsValues(dorv), LOAD_ATTR);
+            stack_pointer[-1] = owner;
             break;
         }
 
         case _LOAD_ATTR_INSTANCE_VALUE: {
-            PyObject *owner = stack_pointer[-1];
+            PyObject *owner;
             PyObject *res2 = NULL;
             PyObject *res;
+            owner = stack_pointer[-1];
             uint16_t index = (uint16_t)operand;
             PyDictOrValues dorv = *_PyObject_DictOrValuesPointer(owner);
             res = _PyDictOrValues_GetValues(dorv)->values[index];
@@ -1509,16 +1635,18 @@
             res2 = NULL;
             Py_DECREF(owner);
             STACK_GROW(((oparg & 1) ? 1 : 0));
-            stack_pointer[-1] = res;
             if (oparg & 1) { stack_pointer[-1 - (oparg & 1 ? 1 : 0)] = res2; }
+            stack_pointer[-1] = res;
             break;
         }
 
         case COMPARE_OP: {
             static_assert(INLINE_CACHE_ENTRIES_COMPARE_OP == 1, "incorrect cache size");
-            PyObject *right = stack_pointer[-1];
-            PyObject *left = stack_pointer[-2];
+            PyObject *right;
+            PyObject *left;
             PyObject *res;
+            right = stack_pointer[-1];
+            left = stack_pointer[-2];
             #if ENABLE_SPECIALIZATION
             _PyCompareOpCache *cache = (_PyCompareOpCache *)next_instr;
             if (ADAPTIVE_COUNTER_IS_ZERO(cache->counter)) {
@@ -1546,9 +1674,11 @@
         }
 
         case COMPARE_OP_FLOAT: {
-            PyObject *right = stack_pointer[-1];
-            PyObject *left = stack_pointer[-2];
+            PyObject *right;
+            PyObject *left;
             PyObject *res;
+            right = stack_pointer[-1];
+            left = stack_pointer[-2];
             DEOPT_IF(!PyFloat_CheckExact(left), COMPARE_OP);
             DEOPT_IF(!PyFloat_CheckExact(right), COMPARE_OP);
             STAT_INC(COMPARE_OP, hit);
@@ -1566,9 +1696,11 @@
         }
 
         case COMPARE_OP_INT: {
-            PyObject *right = stack_pointer[-1];
-            PyObject *left = stack_pointer[-2];
+            PyObject *right;
+            PyObject *left;
             PyObject *res;
+            right = stack_pointer[-1];
+            left = stack_pointer[-2];
             DEOPT_IF(!PyLong_CheckExact(left), COMPARE_OP);
             DEOPT_IF(!PyLong_CheckExact(right), COMPARE_OP);
             DEOPT_IF(!_PyLong_IsCompact((PyLongObject *)left), COMPARE_OP);
@@ -1590,9 +1722,11 @@
         }
 
         case COMPARE_OP_STR: {
-            PyObject *right = stack_pointer[-1];
-            PyObject *left = stack_pointer[-2];
+            PyObject *right;
+            PyObject *left;
             PyObject *res;
+            right = stack_pointer[-1];
+            left = stack_pointer[-2];
             DEOPT_IF(!PyUnicode_CheckExact(left), COMPARE_OP);
             DEOPT_IF(!PyUnicode_CheckExact(right), COMPARE_OP);
             STAT_INC(COMPARE_OP, hit);
@@ -1611,9 +1745,11 @@
         }
 
         case IS_OP: {
-            PyObject *right = stack_pointer[-1];
-            PyObject *left = stack_pointer[-2];
+            PyObject *right;
+            PyObject *left;
             PyObject *b;
+            right = stack_pointer[-1];
+            left = stack_pointer[-2];
             int res = Py_Is(left, right) ^ oparg;
             Py_DECREF(left);
             Py_DECREF(right);
@@ -1624,9 +1760,11 @@
         }
 
         case CONTAINS_OP: {
-            PyObject *right = stack_pointer[-1];
-            PyObject *left = stack_pointer[-2];
+            PyObject *right;
+            PyObject *left;
             PyObject *b;
+            right = stack_pointer[-1];
+            left = stack_pointer[-2];
             int res = PySequence_Contains(right, left);
             Py_DECREF(left);
             Py_DECREF(right);
@@ -1638,10 +1776,12 @@
         }
 
         case CHECK_EG_MATCH: {
-            PyObject *match_type = stack_pointer[-1];
-            PyObject *exc_value = stack_pointer[-2];
+            PyObject *match_type;
+            PyObject *exc_value;
             PyObject *rest;
             PyObject *match;
+            match_type = stack_pointer[-1];
+            exc_value = stack_pointer[-2];
             if (_PyEval_CheckExceptStarTypeValid(tstate, match_type) < 0) {
                 Py_DECREF(exc_value);
                 Py_DECREF(match_type);
@@ -1662,15 +1802,17 @@
             if (!Py_IsNone(match)) {
                 PyErr_SetHandledException(match);
             }
-            stack_pointer[-1] = match;
             stack_pointer[-2] = rest;
+            stack_pointer[-1] = match;
             break;
         }
 
         case CHECK_EXC_MATCH: {
-            PyObject *right = stack_pointer[-1];
-            PyObject *left = stack_pointer[-2];
+            PyObject *right;
+            PyObject *left;
             PyObject *b;
+            right = stack_pointer[-1];
+            left = stack_pointer[-2];
             assert(PyExceptionInstance_Check(left));
             if (_PyEval_CheckExceptTypeValid(tstate, right) < 0) {
                  Py_DECREF(right);
@@ -1680,13 +1822,15 @@
             int res = PyErr_GivenExceptionMatches(left, right);
             Py_DECREF(right);
             b = res ? Py_True : Py_False;
+            stack_pointer[-2] = left;
             stack_pointer[-1] = b;
             break;
         }
 
         case IS_NONE: {
-            PyObject *value = stack_pointer[-1];
+            PyObject *value;
             PyObject *b;
+            value = stack_pointer[-1];
             if (Py_IsNone(value)) {
                 b = Py_True;
             }
@@ -1699,23 +1843,28 @@
         }
 
         case GET_LEN: {
-            PyObject *obj = stack_pointer[-1];
+            PyObject *obj;
             PyObject *len_o;
+            obj = stack_pointer[-1];
             // PUSH(len(TOS))
             Py_ssize_t len_i = PyObject_Length(obj);
             if (len_i < 0) goto error;
             len_o = PyLong_FromSsize_t(len_i);
             if (len_o == NULL) goto error;
             STACK_GROW(1);
+            stack_pointer[-2] = obj;
             stack_pointer[-1] = len_o;
             break;
         }
 
         case MATCH_CLASS: {
-            PyObject *names = stack_pointer[-1];
-            PyObject *type = stack_pointer[-2];
-            PyObject *subject = stack_pointer[-3];
+            PyObject *names;
+            PyObject *type;
+            PyObject *subject;
             PyObject *attrs;
+            names = stack_pointer[-1];
+            type = stack_pointer[-2];
+            subject = stack_pointer[-3];
             // Pop TOS and TOS1. Set TOS to a tuple of attributes on success, or
             // None on failure.
             assert(PyTuple_CheckExact(names));
@@ -1736,40 +1885,49 @@
         }
 
         case MATCH_MAPPING: {
-            PyObject *subject = stack_pointer[-1];
+            PyObject *subject;
             PyObject *res;
+            subject = stack_pointer[-1];
             int match = Py_TYPE(subject)->tp_flags & Py_TPFLAGS_MAPPING;
             res = match ? Py_True : Py_False;
             STACK_GROW(1);
+            stack_pointer[-2] = subject;
             stack_pointer[-1] = res;
             break;
         }
 
         case MATCH_SEQUENCE: {
-            PyObject *subject = stack_pointer[-1];
+            PyObject *subject;
             PyObject *res;
+            subject = stack_pointer[-1];
             int match = Py_TYPE(subject)->tp_flags & Py_TPFLAGS_SEQUENCE;
             res = match ? Py_True : Py_False;
             STACK_GROW(1);
+            stack_pointer[-2] = subject;
             stack_pointer[-1] = res;
             break;
         }
 
         case MATCH_KEYS: {
-            PyObject *keys = stack_pointer[-1];
-            PyObject *subject = stack_pointer[-2];
+            PyObject *keys;
+            PyObject *subject;
             PyObject *values_or_none;
+            keys = stack_pointer[-1];
+            subject = stack_pointer[-2];
             // On successful match, PUSH(values). Otherwise, PUSH(None).
             values_or_none = _PyEval_MatchKeys(tstate, subject, keys);
             if (values_or_none == NULL) goto error;
             STACK_GROW(1);
+            stack_pointer[-3] = subject;
+            stack_pointer[-2] = keys;
             stack_pointer[-1] = values_or_none;
             break;
         }
 
         case GET_ITER: {
-            PyObject *iterable = stack_pointer[-1];
+            PyObject *iterable;
             PyObject *iter;
+            iterable = stack_pointer[-1];
             /* before: [obj]; after [getiter(obj)] */
             iter = PyObject_GetIter(iterable);
             Py_DECREF(iterable);
@@ -1779,8 +1937,9 @@
         }
 
         case GET_YIELD_FROM_ITER: {
-            PyObject *iterable = stack_pointer[-1];
+            PyObject *iterable;
             PyObject *iter;
+            iterable = stack_pointer[-1];
             /* before: [obj]; after [getiter(obj)] */
             if (PyCoro_CheckExact(iterable)) {
                 /* `iterable` is a coroutine */
@@ -1810,14 +1969,17 @@
         }
 
         case _ITER_CHECK_LIST: {
-            PyObject *iter = stack_pointer[-1];
+            PyObject *iter;
+            iter = stack_pointer[-1];
             DEOPT_IF(Py_TYPE(iter) != &PyListIter_Type, FOR_ITER);
+            stack_pointer[-1] = iter;
             break;
         }
 
         case _IS_ITER_EXHAUSTED_LIST: {
-            PyObject *iter = stack_pointer[-1];
+            PyObject *iter;
             PyObject *exhausted;
+            iter = stack_pointer[-1];
             _PyListIterObject *it = (_PyListIterObject *)iter;
             assert(Py_TYPE(iter) == &PyListIter_Type);
             PyListObject *seq = it->it_seq;
@@ -1833,13 +1995,15 @@
                 exhausted = Py_False;
             }
             STACK_GROW(1);
+            stack_pointer[-2] = iter;
             stack_pointer[-1] = exhausted;
             break;
         }
 
         case _ITER_NEXT_LIST: {
-            PyObject *iter = stack_pointer[-1];
+            PyObject *iter;
             PyObject *next;
+            iter = stack_pointer[-1];
             _PyListIterObject *it = (_PyListIterObject *)iter;
             assert(Py_TYPE(iter) == &PyListIter_Type);
             PyListObject *seq = it->it_seq;
@@ -1847,19 +2011,23 @@
             assert(it->it_index < PyList_GET_SIZE(seq));
             next = Py_NewRef(PyList_GET_ITEM(seq, it->it_index++));
             STACK_GROW(1);
+            stack_pointer[-2] = iter;
             stack_pointer[-1] = next;
             break;
         }
 
         case _ITER_CHECK_TUPLE: {
-            PyObject *iter = stack_pointer[-1];
+            PyObject *iter;
+            iter = stack_pointer[-1];
             DEOPT_IF(Py_TYPE(iter) != &PyTupleIter_Type, FOR_ITER);
+            stack_pointer[-1] = iter;
             break;
         }
 
         case _IS_ITER_EXHAUSTED_TUPLE: {
-            PyObject *iter = stack_pointer[-1];
+            PyObject *iter;
             PyObject *exhausted;
+            iter = stack_pointer[-1];
             _PyTupleIterObject *it = (_PyTupleIterObject *)iter;
             assert(Py_TYPE(iter) == &PyTupleIter_Type);
             PyTupleObject *seq = it->it_seq;
@@ -1875,13 +2043,15 @@
                 exhausted = Py_False;
             }
             STACK_GROW(1);
+            stack_pointer[-2] = iter;
             stack_pointer[-1] = exhausted;
             break;
         }
 
         case _ITER_NEXT_TUPLE: {
-            PyObject *iter = stack_pointer[-1];
+            PyObject *iter;
             PyObject *next;
+            iter = stack_pointer[-1];
             _PyTupleIterObject *it = (_PyTupleIterObject *)iter;
             assert(Py_TYPE(iter) == &PyTupleIter_Type);
             PyTupleObject *seq = it->it_seq;
@@ -1889,31 +2059,37 @@
             assert(it->it_index < PyTuple_GET_SIZE(seq));
             next = Py_NewRef(PyTuple_GET_ITEM(seq, it->it_index++));
             STACK_GROW(1);
+            stack_pointer[-2] = iter;
             stack_pointer[-1] = next;
             break;
         }
 
         case _ITER_CHECK_RANGE: {
-            PyObject *iter = stack_pointer[-1];
+            PyObject *iter;
+            iter = stack_pointer[-1];
             _PyRangeIterObject *r = (_PyRangeIterObject *)iter;
             DEOPT_IF(Py_TYPE(r) != &PyRangeIter_Type, FOR_ITER);
+            stack_pointer[-1] = iter;
             break;
         }
 
         case _IS_ITER_EXHAUSTED_RANGE: {
-            PyObject *iter = stack_pointer[-1];
+            PyObject *iter;
             PyObject *exhausted;
+            iter = stack_pointer[-1];
             _PyRangeIterObject *r = (_PyRangeIterObject *)iter;
             assert(Py_TYPE(r) == &PyRangeIter_Type);
             exhausted = r->len <= 0 ? Py_True : Py_False;
             STACK_GROW(1);
+            stack_pointer[-2] = iter;
             stack_pointer[-1] = exhausted;
             break;
         }
 
         case _ITER_NEXT_RANGE: {
-            PyObject *iter = stack_pointer[-1];
+            PyObject *iter;
             PyObject *next;
+            iter = stack_pointer[-1];
             _PyRangeIterObject *r = (_PyRangeIterObject *)iter;
             assert(Py_TYPE(r) == &PyRangeIter_Type);
             assert(r->len > 0);
@@ -1923,15 +2099,19 @@
             next = PyLong_FromLong(value);
             if (next == NULL) goto error;
             STACK_GROW(1);
+            stack_pointer[-2] = iter;
             stack_pointer[-1] = next;
             break;
         }
 
         case WITH_EXCEPT_START: {
-            PyObject *val = stack_pointer[-1];
-            PyObject *lasti = stack_pointer[-3];
-            PyObject *exit_func = stack_pointer[-4];
+            PyObject *val;
+            PyObject *lasti;
+            PyObject *exit_func;
             PyObject *res;
+            val = stack_pointer[-1];
+            lasti = stack_pointer[-3];
+            exit_func = stack_pointer[-4];
             /* At the top of the stack are 4 values:
                - val: TOP = exc_info()
                - unused: SECOND = previous exception
@@ -1958,13 +2138,17 @@
                     3 | PY_VECTORCALL_ARGUMENTS_OFFSET, NULL);
             if (res == NULL) goto error;
             STACK_GROW(1);
+            stack_pointer[-5] = exit_func;
+            stack_pointer[-4] = lasti;
+            stack_pointer[-2] = val;
             stack_pointer[-1] = res;
             break;
         }
 
         case PUSH_EXC_INFO: {
-            PyObject *new_exc = stack_pointer[-1];
+            PyObject *new_exc;
             PyObject *prev_exc;
+            new_exc = stack_pointer[-1];
             _PyErr_StackItem *exc_info = tstate->exc_info;
             if (exc_info->exc_value != NULL) {
                 prev_exc = exc_info->exc_value;
@@ -1975,16 +2159,19 @@
             assert(PyExceptionInstance_Check(new_exc));
             exc_info->exc_value = Py_NewRef(new_exc);
             STACK_GROW(1);
-            stack_pointer[-1] = new_exc;
             stack_pointer[-2] = prev_exc;
+            stack_pointer[-1] = new_exc;
             break;
         }
 
         case CALL_NO_KW_TYPE_1: {
-            PyObject **args = stack_pointer - oparg;
-            PyObject *callable = stack_pointer[-1 - oparg];
-            PyObject *null = stack_pointer[-2 - oparg];
+            PyObject **args;
+            PyObject *callable;
+            PyObject *null;
             PyObject *res;
+            args = stack_pointer - oparg;
+            callable = stack_pointer[-1 - oparg];
+            null = stack_pointer[-2 - oparg];
             ASSERT_KWNAMES_IS_NULL();
             assert(oparg == 1);
             DEOPT_IF(null != NULL, CALL);
@@ -2001,10 +2188,13 @@
         }
 
         case CALL_NO_KW_STR_1: {
-            PyObject **args = stack_pointer - oparg;
-            PyObject *callable = stack_pointer[-1 - oparg];
-            PyObject *null = stack_pointer[-2 - oparg];
+            PyObject **args;
+            PyObject *callable;
+            PyObject *null;
             PyObject *res;
+            args = stack_pointer - oparg;
+            callable = stack_pointer[-1 - oparg];
+            null = stack_pointer[-2 - oparg];
             ASSERT_KWNAMES_IS_NULL();
             assert(oparg == 1);
             DEOPT_IF(null != NULL, CALL);
@@ -2023,10 +2213,13 @@
         }
 
         case CALL_NO_KW_TUPLE_1: {
-            PyObject **args = stack_pointer - oparg;
-            PyObject *callable = stack_pointer[-1 - oparg];
-            PyObject *null = stack_pointer[-2 - oparg];
+            PyObject **args;
+            PyObject *callable;
+            PyObject *null;
             PyObject *res;
+            args = stack_pointer - oparg;
+            callable = stack_pointer[-1 - oparg];
+            null = stack_pointer[-2 - oparg];
             ASSERT_KWNAMES_IS_NULL();
             assert(oparg == 1);
             DEOPT_IF(null != NULL, CALL);
@@ -2045,7 +2238,8 @@
         }
 
         case EXIT_INIT_CHECK: {
-            PyObject *should_be_none = stack_pointer[-1];
+            PyObject *should_be_none;
+            should_be_none = stack_pointer[-1];
             assert(STACK_LEVEL() == 2);
             if (should_be_none != Py_None) {
                 PyErr_Format(PyExc_TypeError,
@@ -2058,10 +2252,13 @@
         }
 
         case CALL_NO_KW_BUILTIN_O: {
-            PyObject **args = stack_pointer - oparg;
-            PyObject *callable = stack_pointer[-1 - oparg];
-            PyObject *method = stack_pointer[-2 - oparg];
+            PyObject **args;
+            PyObject *callable;
+            PyObject *method;
             PyObject *res;
+            args = stack_pointer - oparg;
+            callable = stack_pointer[-1 - oparg];
+            method = stack_pointer[-2 - oparg];
             /* Builtin METH_O functions */
             ASSERT_KWNAMES_IS_NULL();
             int is_meth = method != NULL;
@@ -2097,10 +2294,13 @@
         }
 
         case CALL_NO_KW_BUILTIN_FAST: {
-            PyObject **args = stack_pointer - oparg;
-            PyObject *callable = stack_pointer[-1 - oparg];
-            PyObject *method = stack_pointer[-2 - oparg];
+            PyObject **args;
+            PyObject *callable;
+            PyObject *method;
             PyObject *res;
+            args = stack_pointer - oparg;
+            callable = stack_pointer[-1 - oparg];
+            method = stack_pointer[-2 - oparg];
             /* Builtin METH_FASTCALL functions, without keywords */
             ASSERT_KWNAMES_IS_NULL();
             int is_meth = method != NULL;
@@ -2140,10 +2340,13 @@
         }
 
         case CALL_NO_KW_LEN: {
-            PyObject **args = stack_pointer - oparg;
-            PyObject *callable = stack_pointer[-1 - oparg];
-            PyObject *method = stack_pointer[-2 - oparg];
+            PyObject **args;
+            PyObject *callable;
+            PyObject *method;
             PyObject *res;
+            args = stack_pointer - oparg;
+            callable = stack_pointer[-1 - oparg];
+            method = stack_pointer[-2 - oparg];
             ASSERT_KWNAMES_IS_NULL();
             /* len(o) */
             int is_meth = method != NULL;
@@ -2175,10 +2378,13 @@
         }
 
         case CALL_NO_KW_ISINSTANCE: {
-            PyObject **args = stack_pointer - oparg;
-            PyObject *callable = stack_pointer[-1 - oparg];
-            PyObject *method = stack_pointer[-2 - oparg];
+            PyObject **args;
+            PyObject *callable;
+            PyObject *method;
             PyObject *res;
+            args = stack_pointer - oparg;
+            callable = stack_pointer[-1 - oparg];
+            method = stack_pointer[-2 - oparg];
             ASSERT_KWNAMES_IS_NULL();
             /* isinstance(o, o2) */
             int is_meth = method != NULL;
@@ -2212,9 +2418,11 @@
         }
 
         case CALL_NO_KW_METHOD_DESCRIPTOR_O: {
-            PyObject **args = stack_pointer - oparg;
-            PyObject *method = stack_pointer[-2 - oparg];
+            PyObject **args;
+            PyObject *method;
             PyObject *res;
+            args = stack_pointer - oparg;
+            method = stack_pointer[-2 - oparg];
             ASSERT_KWNAMES_IS_NULL();
             int is_meth = method != NULL;
             int total_args = oparg;
@@ -2253,9 +2461,11 @@
         }
 
         case CALL_NO_KW_METHOD_DESCRIPTOR_NOARGS: {
-            PyObject **args = stack_pointer - oparg;
-            PyObject *method = stack_pointer[-2 - oparg];
+            PyObject **args;
+            PyObject *method;
             PyObject *res;
+            args = stack_pointer - oparg;
+            method = stack_pointer[-2 - oparg];
             ASSERT_KWNAMES_IS_NULL();
             assert(oparg == 0 || oparg == 1);
             int is_meth = method != NULL;
@@ -2292,9 +2502,11 @@
         }
 
         case CALL_NO_KW_METHOD_DESCRIPTOR_FAST: {
-            PyObject **args = stack_pointer - oparg;
-            PyObject *method = stack_pointer[-2 - oparg];
+            PyObject **args;
+            PyObject *method;
             PyObject *res;
+            args = stack_pointer - oparg;
+            method = stack_pointer[-2 - oparg];
             ASSERT_KWNAMES_IS_NULL();
             int is_meth = method != NULL;
             int total_args = oparg;
@@ -2330,8 +2542,9 @@
         }
 
         case MAKE_FUNCTION: {
-            PyObject *codeobj = stack_pointer[-1];
+            PyObject *codeobj;
             PyObject *func;
+            codeobj = stack_pointer[-1];
 
             PyFunctionObject *func_obj = (PyFunctionObject *)
                 PyFunction_New(codeobj, GLOBALS());
@@ -2348,8 +2561,10 @@
         }
 
         case SET_FUNCTION_ATTRIBUTE: {
-            PyObject *func = stack_pointer[-1];
-            PyObject *attr = stack_pointer[-2];
+            PyObject *func;
+            PyObject *attr;
+            func = stack_pointer[-1];
+            attr = stack_pointer[-2];
             assert(PyFunction_Check(func));
             PyFunctionObject *func_obj = (PyFunctionObject *)func;
             switch(oparg) {
@@ -2380,10 +2595,13 @@
         }
 
         case BUILD_SLICE: {
-            PyObject *step = oparg == 3 ? stack_pointer[-(oparg == 3 ? 1 : 0)] : NULL;
-            PyObject *stop = stack_pointer[-1 - (oparg == 3 ? 1 : 0)];
-            PyObject *start = stack_pointer[-2 - (oparg == 3 ? 1 : 0)];
+            PyObject *step = NULL;
+            PyObject *stop;
+            PyObject *start;
             PyObject *slice;
+            if (oparg == 3) { step = stack_pointer[-(oparg == 3 ? 1 : 0)]; }
+            stop = stack_pointer[-1 - (oparg == 3 ? 1 : 0)];
+            start = stack_pointer[-2 - (oparg == 3 ? 1 : 0)];
             slice = PySlice_New(start, stop, step);
             Py_DECREF(start);
             Py_DECREF(stop);
@@ -2396,8 +2614,9 @@
         }
 
         case CONVERT_VALUE: {
-            PyObject *value = stack_pointer[-1];
+            PyObject *value;
             PyObject *result;
+            value = stack_pointer[-1];
             convertion_func_ptr  conv_fn;
             assert(oparg >= FVC_STR && oparg <= FVC_ASCII);
             conv_fn = CONVERSION_FUNCTIONS[oparg];
@@ -2409,8 +2628,9 @@
         }
 
         case FORMAT_SIMPLE: {
-            PyObject *value = stack_pointer[-1];
+            PyObject *value;
             PyObject *res;
+            value = stack_pointer[-1];
             /* If value is a unicode object, then we know the result
              * of format(value) is value itself. */
             if (!PyUnicode_CheckExact(value)) {
@@ -2426,9 +2646,11 @@
         }
 
         case FORMAT_WITH_SPEC: {
-            PyObject *fmt_spec = stack_pointer[-1];
-            PyObject *value = stack_pointer[-2];
+            PyObject *fmt_spec;
+            PyObject *value;
             PyObject *res;
+            fmt_spec = stack_pointer[-1];
+            value = stack_pointer[-2];
             res = PyObject_Format(value, fmt_spec);
             Py_DECREF(value);
             Py_DECREF(fmt_spec);
@@ -2439,20 +2661,24 @@
         }
 
         case COPY: {
-            PyObject *bottom = stack_pointer[-1 - (oparg-1)];
+            PyObject *bottom;
             PyObject *top;
+            bottom = stack_pointer[-1 - (oparg-1)];
             assert(oparg > 0);
             top = Py_NewRef(bottom);
             STACK_GROW(1);
+            stack_pointer[-2 - (oparg-1)] = bottom;
             stack_pointer[-1] = top;
             break;
         }
 
         case BINARY_OP: {
             static_assert(INLINE_CACHE_ENTRIES_BINARY_OP == 1, "incorrect cache size");
-            PyObject *rhs = stack_pointer[-1];
-            PyObject *lhs = stack_pointer[-2];
+            PyObject *rhs;
+            PyObject *lhs;
             PyObject *res;
+            rhs = stack_pointer[-1];
+            lhs = stack_pointer[-2];
             #if ENABLE_SPECIALIZATION
             _PyBinaryOpCache *cache = (_PyBinaryOpCache *)next_instr;
             if (ADAPTIVE_COUNTER_IS_ZERO(cache->counter)) {
@@ -2476,16 +2702,19 @@
         }
 
         case SWAP: {
-            PyObject *top = stack_pointer[-1];
-            PyObject *bottom = stack_pointer[-2 - (oparg-2)];
+            PyObject *top;
+            PyObject *bottom;
+            top = stack_pointer[-1];
+            bottom = stack_pointer[-2 - (oparg-2)];
             assert(oparg >= 2);
-            stack_pointer[-1] = bottom;
             stack_pointer[-2 - (oparg-2)] = top;
+            stack_pointer[-1] = bottom;
             break;
         }
 
         case _POP_JUMP_IF_FALSE: {
-            PyObject *flag = stack_pointer[-1];
+            PyObject *flag;
+            flag = stack_pointer[-1];
             if (Py_IsFalse(flag)) {
                 pc = oparg;
             }
@@ -2494,7 +2723,8 @@
         }
 
         case _POP_JUMP_IF_TRUE: {
-            PyObject *flag = stack_pointer[-1];
+            PyObject *flag;
+            flag = stack_pointer[-1];
             if (Py_IsTrue(flag)) {
                 pc = oparg;
             }

--- a/Python/generated_cases.c.h
+++ b/Python/generated_cases.c.h
@@ -1635,6 +1635,7 @@
             PyObject *res;
             // _GUARD_GLOBALS_VERSION
             {
+                uint16_t version = read_u16(&next_instr[1].cache);
                 PyDictObject *dict = (PyDictObject *)GLOBALS();
                 DEOPT_IF(!PyDict_CheckExact(dict), LOAD_GLOBAL);
                 DEOPT_IF(dict->ma_keys->dk_version != version, LOAD_GLOBAL);
@@ -1642,6 +1643,7 @@
             }
             // _LOAD_GLOBAL_MODULE
             {
+                uint16_t index = read_u16(&next_instr[3].cache);
                 PyDictObject *dict = (PyDictObject *)GLOBALS();
                 PyDictUnicodeEntry *entries = DK_UNICODE_ENTRIES(dict->ma_keys);
                 res = entries[index].me_value;
@@ -1662,6 +1664,7 @@
             PyObject *res;
             // _GUARD_GLOBALS_VERSION
             {
+                uint16_t version = read_u16(&next_instr[1].cache);
                 PyDictObject *dict = (PyDictObject *)GLOBALS();
                 DEOPT_IF(!PyDict_CheckExact(dict), LOAD_GLOBAL);
                 DEOPT_IF(dict->ma_keys->dk_version != version, LOAD_GLOBAL);
@@ -1669,6 +1672,7 @@
             }
             // _GUARD_BUILTINS_VERSION
             {
+                uint16_t version = read_u16(&next_instr[2].cache);
                 PyDictObject *dict = (PyDictObject *)BUILTINS();
                 DEOPT_IF(!PyDict_CheckExact(dict), LOAD_GLOBAL);
                 DEOPT_IF(dict->ma_keys->dk_version != version, LOAD_GLOBAL);
@@ -1676,6 +1680,7 @@
             }
             // _LOAD_GLOBAL_BUILTINS
             {
+                uint16_t index = read_u16(&next_instr[3].cache);
                 PyDictObject *bdict = (PyDictObject *)BUILTINS();
                 PyDictUnicodeEntry *entries = DK_UNICODE_ENTRIES(bdict->ma_keys);
                 res = entries[index].me_value;
@@ -2201,6 +2206,7 @@
             // _GUARD_TYPE_VERSION
             owner = stack_pointer[-1];
             {
+                uint32_t type_version = read_u32(&next_instr[1].cache);
                 PyTypeObject *tp = Py_TYPE(owner);
                 assert(type_version != 0);
                 DEOPT_IF(tp->tp_version_tag != type_version, LOAD_ATTR);
@@ -2214,6 +2220,7 @@
             }
             // _LOAD_ATTR_INSTANCE_VALUE
             {
+                uint16_t index = read_u16(&next_instr[3].cache);
                 PyDictOrValues dorv = *_PyObject_DictOrValuesPointer(owner);
                 res = _PyDictOrValues_GetValues(dorv)->values[index];
                 DEOPT_IF(res == NULL, LOAD_ATTR);

--- a/Python/generated_cases.c.h
+++ b/Python/generated_cases.c.h
@@ -271,7 +271,6 @@
             value = stack_pointer[-1];
             DEOPT_IF(!PyBool_Check(value), TO_BOOL);
             STAT_INC(TO_BOOL, hit);
-            stack_pointer[-1] = value;
             next_instr += 3;
             DISPATCH();
         }
@@ -774,7 +773,6 @@
             list = stack_pointer[-2 - (oparg-1)];
             if (_PyList_AppendTakeRef((PyListObject *)list, v) < 0) goto pop_1_error;
             STACK_SHRINK(1);
-            stack_pointer[-1 - (oparg-1)] = list;
             DISPATCH();
         }
 
@@ -787,7 +785,6 @@
             Py_DECREF(v);
             if (err) goto pop_1_error;
             STACK_SHRINK(1);
-            stack_pointer[-1 - (oparg-1)] = set;
             DISPATCH();
         }
 
@@ -1110,7 +1107,6 @@
                 }
             }
             STACK_GROW(1);
-            stack_pointer[-2] = aiter;
             stack_pointer[-1] = awaitable;
             DISPATCH();
         }
@@ -1200,7 +1196,6 @@
                 }
             }
             Py_DECREF(v);
-            stack_pointer[-2] = receiver;
             stack_pointer[-1] = retval;
             next_instr += 1;
             DISPATCH();
@@ -1226,7 +1221,6 @@
             tstate->exc_info = &gen->gi_exc_state;
             SKIP_OVER(INLINE_CACHE_ENTRIES_SEND);
             DISPATCH_INLINED(gen_frame);
-            stack_pointer[-2] = receiver;
         }
 
         TARGET(INSTRUMENTED_YIELD_VALUE) {
@@ -1285,7 +1279,6 @@
             PyObject *exc;
             PyObject **values;
             exc = stack_pointer[-1];
-            values = stack_pointer - 1 - oparg;
             values = stack_pointer - 1 - oparg;
             assert(oparg >= 0 && oparg <= 2);
             if (oparg) {
@@ -1960,7 +1953,6 @@
             assert(Py_IsNone(none_val));
             Py_DECREF(iterable);
             STACK_SHRINK(1);
-            stack_pointer[-1 - (oparg-1)] = list;
             DISPATCH();
         }
 
@@ -1973,7 +1965,6 @@
             Py_DECREF(iterable);
             if (err < 0) goto pop_1_error;
             STACK_SHRINK(1);
-            stack_pointer[-1 - (oparg-1)] = set;
             DISPATCH();
         }
 
@@ -2844,7 +2835,6 @@
             int res = PyErr_GivenExceptionMatches(left, right);
             Py_DECREF(right);
             b = res ? Py_True : Py_False;
-            stack_pointer[-2] = left;
             stack_pointer[-1] = b;
             DISPATCH();
         }
@@ -2873,7 +2863,6 @@
             res = import_from(tstate, from, name);
             if (res == NULL) goto error;
             STACK_GROW(1);
-            stack_pointer[-2] = from;
             stack_pointer[-1] = res;
             DISPATCH();
         }
@@ -3017,7 +3006,6 @@
             len_o = PyLong_FromSsize_t(len_i);
             if (len_o == NULL) goto error;
             STACK_GROW(1);
-            stack_pointer[-2] = obj;
             stack_pointer[-1] = len_o;
             DISPATCH();
         }
@@ -3056,7 +3044,6 @@
             int match = Py_TYPE(subject)->tp_flags & Py_TPFLAGS_MAPPING;
             res = match ? Py_True : Py_False;
             STACK_GROW(1);
-            stack_pointer[-2] = subject;
             stack_pointer[-1] = res;
             DISPATCH();
         }
@@ -3068,7 +3055,6 @@
             int match = Py_TYPE(subject)->tp_flags & Py_TPFLAGS_SEQUENCE;
             res = match ? Py_True : Py_False;
             STACK_GROW(1);
-            stack_pointer[-2] = subject;
             stack_pointer[-1] = res;
             DISPATCH();
         }
@@ -3083,8 +3069,6 @@
             values_or_none = _PyEval_MatchKeys(tstate, subject, keys);
             if (values_or_none == NULL) goto error;
             STACK_GROW(1);
-            stack_pointer[-3] = subject;
-            stack_pointer[-2] = keys;
             stack_pointer[-1] = values_or_none;
             DISPATCH();
         }
@@ -3171,7 +3155,6 @@
             }
             // Common case: no jump, leave it to the code generator
             STACK_GROW(1);
-            stack_pointer[-2] = iter;
             stack_pointer[-1] = next;
             next_instr += 1;
             DISPATCH();
@@ -3243,7 +3226,6 @@
                 next = Py_NewRef(PyList_GET_ITEM(seq, it->it_index++));
             }
             STACK_GROW(1);
-            stack_pointer[-2] = iter;
             stack_pointer[-1] = next;
             next_instr += 1;
             DISPATCH();
@@ -3286,7 +3268,6 @@
                 next = Py_NewRef(PyTuple_GET_ITEM(seq, it->it_index++));
             }
             STACK_GROW(1);
-            stack_pointer[-2] = iter;
             stack_pointer[-1] = next;
             next_instr += 1;
             DISPATCH();
@@ -3327,7 +3308,6 @@
                 if (next == NULL) goto error;
             }
             STACK_GROW(1);
-            stack_pointer[-2] = iter;
             stack_pointer[-1] = next;
             next_instr += 1;
             DISPATCH();
@@ -3352,7 +3332,6 @@
                    next_instr[oparg].op.code == INSTRUMENTED_END_FOR);
             DISPATCH_INLINED(gen_frame);
             STACK_GROW(1);
-            stack_pointer[-2] = iter;
         }
 
         TARGET(BEFORE_ASYNC_WITH) {
@@ -3472,9 +3451,6 @@
                     3 | PY_VECTORCALL_ARGUMENTS_OFFSET, NULL);
             if (res == NULL) goto error;
             STACK_GROW(1);
-            stack_pointer[-5] = exit_func;
-            stack_pointer[-4] = lasti;
-            stack_pointer[-2] = val;
             stack_pointer[-1] = res;
             DISPATCH();
         }
@@ -4686,7 +4662,6 @@
             assert(oparg > 0);
             top = Py_NewRef(bottom);
             STACK_GROW(1);
-            stack_pointer[-2 - (oparg-1)] = bottom;
             stack_pointer[-1] = top;
             DISPATCH();
         }

--- a/Python/generated_cases.c.h
+++ b/Python/generated_cases.c.h
@@ -91,8 +91,8 @@
             Py_INCREF(value1);
             Py_INCREF(value2);
             STACK_GROW(2);
-            stack_pointer[-1] = value2;
             stack_pointer[-2] = value1;
+            stack_pointer[-1] = value2;
             DISPATCH();
         }
 
@@ -106,15 +106,17 @@
         }
 
         TARGET(STORE_FAST) {
-            PyObject *value = stack_pointer[-1];
+            PyObject *value;
+            value = stack_pointer[-1];
             SETLOCAL(oparg, value);
             STACK_SHRINK(1);
             DISPATCH();
         }
 
         TARGET(STORE_FAST_LOAD_FAST) {
-            PyObject *value1 = stack_pointer[-1];
+            PyObject *value1;
             PyObject *value2;
+            value1 = stack_pointer[-1];
             uint32_t oparg1 = oparg >> 4;
             uint32_t oparg2 = oparg & 15;
             SETLOCAL(oparg1, value1);
@@ -125,8 +127,10 @@
         }
 
         TARGET(STORE_FAST_STORE_FAST) {
-            PyObject *value1 = stack_pointer[-1];
-            PyObject *value2 = stack_pointer[-2];
+            PyObject *value1;
+            PyObject *value2;
+            value1 = stack_pointer[-1];
+            value2 = stack_pointer[-2];
             uint32_t oparg1 = oparg >> 4;
             uint32_t oparg2 = oparg & 15;
             SETLOCAL(oparg1, value1);
@@ -136,7 +140,8 @@
         }
 
         TARGET(POP_TOP) {
-            PyObject *value = stack_pointer[-1];
+            PyObject *value;
+            value = stack_pointer[-1];
             Py_DECREF(value);
             STACK_SHRINK(1);
             DISPATCH();
@@ -167,8 +172,10 @@
         }
 
         TARGET(INSTRUMENTED_END_FOR) {
-            PyObject *value = stack_pointer[-1];
-            PyObject *receiver = stack_pointer[-2];
+            PyObject *value;
+            PyObject *receiver;
+            value = stack_pointer[-1];
+            receiver = stack_pointer[-2];
             /* Need to create a fake StopIteration error here,
              * to conform to PEP 380 */
             if (PyGen_Check(receiver)) {
@@ -185,8 +192,10 @@
         }
 
         TARGET(END_SEND) {
-            PyObject *value = stack_pointer[-1];
-            PyObject *receiver = stack_pointer[-2];
+            PyObject *value;
+            PyObject *receiver;
+            value = stack_pointer[-1];
+            receiver = stack_pointer[-2];
             Py_DECREF(receiver);
             STACK_SHRINK(1);
             stack_pointer[-1] = value;
@@ -194,8 +203,10 @@
         }
 
         TARGET(INSTRUMENTED_END_SEND) {
-            PyObject *value = stack_pointer[-1];
-            PyObject *receiver = stack_pointer[-2];
+            PyObject *value;
+            PyObject *receiver;
+            value = stack_pointer[-1];
+            receiver = stack_pointer[-2];
             if (PyGen_Check(receiver) || PyCoro_CheckExact(receiver)) {
                 PyErr_SetObject(PyExc_StopIteration, value);
                 if (monitor_stop_iteration(tstate, frame, next_instr-1)) {
@@ -210,8 +221,9 @@
         }
 
         TARGET(UNARY_NEGATIVE) {
-            PyObject *value = stack_pointer[-1];
+            PyObject *value;
             PyObject *res;
+            value = stack_pointer[-1];
             res = PyNumber_Negative(value);
             Py_DECREF(value);
             if (res == NULL) goto pop_1_error;
@@ -220,8 +232,9 @@
         }
 
         TARGET(UNARY_NOT) {
-            PyObject *value = stack_pointer[-1];
+            PyObject *value;
             PyObject *res;
+            value = stack_pointer[-1];
             assert(PyBool_Check(value));
             res = Py_IsFalse(value) ? Py_True : Py_False;
             stack_pointer[-1] = res;
@@ -231,8 +244,9 @@
         TARGET(TO_BOOL) {
             PREDICTED(TO_BOOL);
             static_assert(INLINE_CACHE_ENTRIES_TO_BOOL == 3, "incorrect cache size");
-            PyObject *value = stack_pointer[-1];
+            PyObject *value;
             PyObject *res;
+            value = stack_pointer[-1];
             #if ENABLE_SPECIALIZATION
             _PyToBoolCache *cache = (_PyToBoolCache *)next_instr;
             if (ADAPTIVE_COUNTER_IS_ZERO(cache->counter)) {
@@ -253,16 +267,19 @@
         }
 
         TARGET(TO_BOOL_BOOL) {
-            PyObject *value = stack_pointer[-1];
+            PyObject *value;
+            value = stack_pointer[-1];
             DEOPT_IF(!PyBool_Check(value), TO_BOOL);
             STAT_INC(TO_BOOL, hit);
+            stack_pointer[-1] = value;
             next_instr += 3;
             DISPATCH();
         }
 
         TARGET(TO_BOOL_INT) {
-            PyObject *value = stack_pointer[-1];
+            PyObject *value;
             PyObject *res;
+            value = stack_pointer[-1];
             DEOPT_IF(!PyLong_CheckExact(value), TO_BOOL);
             STAT_INC(TO_BOOL, hit);
             if (_PyLong_IsZero((PyLongObject *)value)) {
@@ -279,8 +296,9 @@
         }
 
         TARGET(TO_BOOL_LIST) {
-            PyObject *value = stack_pointer[-1];
+            PyObject *value;
             PyObject *res;
+            value = stack_pointer[-1];
             DEOPT_IF(!PyList_CheckExact(value), TO_BOOL);
             STAT_INC(TO_BOOL, hit);
             res = Py_SIZE(value) ? Py_True : Py_False;
@@ -291,8 +309,9 @@
         }
 
         TARGET(TO_BOOL_NONE) {
-            PyObject *value = stack_pointer[-1];
+            PyObject *value;
             PyObject *res;
+            value = stack_pointer[-1];
             // This one is a bit weird, because we expect *some* failures:
             DEOPT_IF(!Py_IsNone(value), TO_BOOL);
             STAT_INC(TO_BOOL, hit);
@@ -303,8 +322,9 @@
         }
 
         TARGET(TO_BOOL_STR) {
-            PyObject *value = stack_pointer[-1];
+            PyObject *value;
             PyObject *res;
+            value = stack_pointer[-1];
             DEOPT_IF(!PyUnicode_CheckExact(value), TO_BOOL);
             STAT_INC(TO_BOOL, hit);
             if (value == &_Py_STR(empty)) {
@@ -322,8 +342,9 @@
         }
 
         TARGET(TO_BOOL_ALWAYS_TRUE) {
-            PyObject *value = stack_pointer[-1];
+            PyObject *value;
             PyObject *res;
+            value = stack_pointer[-1];
             uint32_t version = read_u32(&next_instr[1].cache);
             // This one is a bit weird, because we expect *some* failures:
             assert(version);
@@ -337,8 +358,9 @@
         }
 
         TARGET(UNARY_INVERT) {
-            PyObject *value = stack_pointer[-1];
+            PyObject *value;
             PyObject *res;
+            value = stack_pointer[-1];
             res = PyNumber_Invert(value);
             Py_DECREF(value);
             if (res == NULL) goto pop_1_error;
@@ -365,9 +387,9 @@
                 _Py_DECREF_SPECIALIZED(left, (destructor)PyObject_Free);
                 if (res == NULL) goto pop_2_error;
             }
-            next_instr += 1;
             STACK_SHRINK(1);
             stack_pointer[-1] = res;
+            next_instr += 1;
             DISPATCH();
         }
 
@@ -390,9 +412,9 @@
                 _Py_DECREF_SPECIALIZED(left, (destructor)PyObject_Free);
                 if (res == NULL) goto pop_2_error;
             }
-            next_instr += 1;
             STACK_SHRINK(1);
             stack_pointer[-1] = res;
+            next_instr += 1;
             DISPATCH();
         }
 
@@ -415,9 +437,9 @@
                 _Py_DECREF_SPECIALIZED(left, (destructor)PyObject_Free);
                 if (res == NULL) goto pop_2_error;
             }
-            next_instr += 1;
             STACK_SHRINK(1);
             stack_pointer[-1] = res;
+            next_instr += 1;
             DISPATCH();
         }
 
@@ -440,9 +462,9 @@
                     ((PyFloatObject *)right)->ob_fval;
                 DECREF_INPUTS_AND_REUSE_FLOAT(left, right, dres, res);
             }
-            next_instr += 1;
             STACK_SHRINK(1);
             stack_pointer[-1] = res;
+            next_instr += 1;
             DISPATCH();
         }
 
@@ -465,9 +487,9 @@
                     ((PyFloatObject *)right)->ob_fval;
                 DECREF_INPUTS_AND_REUSE_FLOAT(left, right, dres, res);
             }
-            next_instr += 1;
             STACK_SHRINK(1);
             stack_pointer[-1] = res;
+            next_instr += 1;
             DISPATCH();
         }
 
@@ -490,9 +512,9 @@
                     ((PyFloatObject *)right)->ob_fval;
                 DECREF_INPUTS_AND_REUSE_FLOAT(left, right, dres, res);
             }
-            next_instr += 1;
             STACK_SHRINK(1);
             stack_pointer[-1] = res;
+            next_instr += 1;
             DISPATCH();
         }
 
@@ -515,9 +537,9 @@
                 _Py_DECREF_SPECIALIZED(right, _PyUnicode_ExactDealloc);
                 if (res == NULL) goto pop_2_error;
             }
-            next_instr += 1;
             STACK_SHRINK(1);
             stack_pointer[-1] = res;
+            next_instr += 1;
             DISPATCH();
         }
 
@@ -564,9 +586,11 @@
         TARGET(BINARY_SUBSCR) {
             PREDICTED(BINARY_SUBSCR);
             static_assert(INLINE_CACHE_ENTRIES_BINARY_SUBSCR == 1, "incorrect cache size");
-            PyObject *sub = stack_pointer[-1];
-            PyObject *container = stack_pointer[-2];
+            PyObject *sub;
+            PyObject *container;
             PyObject *res;
+            sub = stack_pointer[-1];
+            container = stack_pointer[-2];
             #if ENABLE_SPECIALIZATION
             _PyBinarySubscrCache *cache = (_PyBinarySubscrCache *)next_instr;
             if (ADAPTIVE_COUNTER_IS_ZERO(cache->counter)) {
@@ -588,10 +612,13 @@
         }
 
         TARGET(BINARY_SLICE) {
-            PyObject *stop = stack_pointer[-1];
-            PyObject *start = stack_pointer[-2];
-            PyObject *container = stack_pointer[-3];
+            PyObject *stop;
+            PyObject *start;
+            PyObject *container;
             PyObject *res;
+            stop = stack_pointer[-1];
+            start = stack_pointer[-2];
+            container = stack_pointer[-3];
             PyObject *slice = _PyBuildSlice_ConsumeRefs(start, stop);
             // Can't use ERROR_IF() here, because we haven't
             // DECREF'ed container yet, and we still own slice.
@@ -610,10 +637,14 @@
         }
 
         TARGET(STORE_SLICE) {
-            PyObject *stop = stack_pointer[-1];
-            PyObject *start = stack_pointer[-2];
-            PyObject *container = stack_pointer[-3];
-            PyObject *v = stack_pointer[-4];
+            PyObject *stop;
+            PyObject *start;
+            PyObject *container;
+            PyObject *v;
+            stop = stack_pointer[-1];
+            start = stack_pointer[-2];
+            container = stack_pointer[-3];
+            v = stack_pointer[-4];
             PyObject *slice = _PyBuildSlice_ConsumeRefs(start, stop);
             int err;
             if (slice == NULL) {
@@ -631,9 +662,11 @@
         }
 
         TARGET(BINARY_SUBSCR_LIST_INT) {
-            PyObject *sub = stack_pointer[-1];
-            PyObject *list = stack_pointer[-2];
+            PyObject *sub;
+            PyObject *list;
             PyObject *res;
+            sub = stack_pointer[-1];
+            list = stack_pointer[-2];
             DEOPT_IF(!PyLong_CheckExact(sub), BINARY_SUBSCR);
             DEOPT_IF(!PyList_CheckExact(list), BINARY_SUBSCR);
 
@@ -654,9 +687,11 @@
         }
 
         TARGET(BINARY_SUBSCR_TUPLE_INT) {
-            PyObject *sub = stack_pointer[-1];
-            PyObject *tuple = stack_pointer[-2];
+            PyObject *sub;
+            PyObject *tuple;
             PyObject *res;
+            sub = stack_pointer[-1];
+            tuple = stack_pointer[-2];
             DEOPT_IF(!PyLong_CheckExact(sub), BINARY_SUBSCR);
             DEOPT_IF(!PyTuple_CheckExact(tuple), BINARY_SUBSCR);
 
@@ -677,9 +712,11 @@
         }
 
         TARGET(BINARY_SUBSCR_DICT) {
-            PyObject *sub = stack_pointer[-1];
-            PyObject *dict = stack_pointer[-2];
+            PyObject *sub;
+            PyObject *dict;
             PyObject *res;
+            sub = stack_pointer[-1];
+            dict = stack_pointer[-2];
             DEOPT_IF(!PyDict_CheckExact(dict), BINARY_SUBSCR);
             STAT_INC(BINARY_SUBSCR, hit);
             res = PyDict_GetItemWithError(dict, sub);
@@ -701,8 +738,10 @@
         }
 
         TARGET(BINARY_SUBSCR_GETITEM) {
-            PyObject *sub = stack_pointer[-1];
-            PyObject *container = stack_pointer[-2];
+            PyObject *sub;
+            PyObject *container;
+            sub = stack_pointer[-1];
+            container = stack_pointer[-2];
             DEOPT_IF(tstate->interp->eval_frame, BINARY_SUBSCR);
             PyTypeObject *tp = Py_TYPE(container);
             DEOPT_IF(!PyType_HasFeature(tp, Py_TPFLAGS_HEAPTYPE), BINARY_SUBSCR);
@@ -725,32 +764,42 @@
             SKIP_OVER(INLINE_CACHE_ENTRIES_BINARY_SUBSCR);
             frame->return_offset = 0;
             DISPATCH_INLINED(new_frame);
+            STACK_SHRINK(1);
         }
 
         TARGET(LIST_APPEND) {
-            PyObject *v = stack_pointer[-1];
-            PyObject *list = stack_pointer[-2 - (oparg-1)];
+            PyObject *v;
+            PyObject *list;
+            v = stack_pointer[-1];
+            list = stack_pointer[-2 - (oparg-1)];
             if (_PyList_AppendTakeRef((PyListObject *)list, v) < 0) goto pop_1_error;
             STACK_SHRINK(1);
+            stack_pointer[-1 - (oparg-1)] = list;
             DISPATCH();
         }
 
         TARGET(SET_ADD) {
-            PyObject *v = stack_pointer[-1];
-            PyObject *set = stack_pointer[-2 - (oparg-1)];
+            PyObject *v;
+            PyObject *set;
+            v = stack_pointer[-1];
+            set = stack_pointer[-2 - (oparg-1)];
             int err = PySet_Add(set, v);
             Py_DECREF(v);
             if (err) goto pop_1_error;
             STACK_SHRINK(1);
+            stack_pointer[-1 - (oparg-1)] = set;
             DISPATCH();
         }
 
         TARGET(STORE_SUBSCR) {
             PREDICTED(STORE_SUBSCR);
             static_assert(INLINE_CACHE_ENTRIES_STORE_SUBSCR == 1, "incorrect cache size");
-            PyObject *sub = stack_pointer[-1];
-            PyObject *container = stack_pointer[-2];
-            PyObject *v = stack_pointer[-3];
+            PyObject *sub;
+            PyObject *container;
+            PyObject *v;
+            sub = stack_pointer[-1];
+            container = stack_pointer[-2];
+            v = stack_pointer[-3];
             #if ENABLE_SPECIALIZATION
             _PyStoreSubscrCache *cache = (_PyStoreSubscrCache *)next_instr;
             if (ADAPTIVE_COUNTER_IS_ZERO(cache->counter)) {
@@ -773,9 +822,12 @@
         }
 
         TARGET(STORE_SUBSCR_LIST_INT) {
-            PyObject *sub = stack_pointer[-1];
-            PyObject *list = stack_pointer[-2];
-            PyObject *value = stack_pointer[-3];
+            PyObject *sub;
+            PyObject *list;
+            PyObject *value;
+            sub = stack_pointer[-1];
+            list = stack_pointer[-2];
+            value = stack_pointer[-3];
             DEOPT_IF(!PyLong_CheckExact(sub), STORE_SUBSCR);
             DEOPT_IF(!PyList_CheckExact(list), STORE_SUBSCR);
 
@@ -798,9 +850,12 @@
         }
 
         TARGET(STORE_SUBSCR_DICT) {
-            PyObject *sub = stack_pointer[-1];
-            PyObject *dict = stack_pointer[-2];
-            PyObject *value = stack_pointer[-3];
+            PyObject *sub;
+            PyObject *dict;
+            PyObject *value;
+            sub = stack_pointer[-1];
+            dict = stack_pointer[-2];
+            value = stack_pointer[-3];
             DEOPT_IF(!PyDict_CheckExact(dict), STORE_SUBSCR);
             STAT_INC(STORE_SUBSCR, hit);
             int err = _PyDict_SetItem_Take2((PyDictObject *)dict, sub, value);
@@ -812,8 +867,10 @@
         }
 
         TARGET(DELETE_SUBSCR) {
-            PyObject *sub = stack_pointer[-1];
-            PyObject *container = stack_pointer[-2];
+            PyObject *sub;
+            PyObject *container;
+            sub = stack_pointer[-1];
+            container = stack_pointer[-2];
             /* del container[sub] */
             int err = PyObject_DelItem(container, sub);
             Py_DECREF(container);
@@ -824,8 +881,9 @@
         }
 
         TARGET(CALL_INTRINSIC_1) {
-            PyObject *value = stack_pointer[-1];
+            PyObject *value;
             PyObject *res;
+            value = stack_pointer[-1];
             assert(oparg <= MAX_INTRINSIC_1);
             res = _PyIntrinsics_UnaryFunctions[oparg].func(tstate, value);
             Py_DECREF(value);
@@ -835,9 +893,11 @@
         }
 
         TARGET(CALL_INTRINSIC_2) {
-            PyObject *value1 = stack_pointer[-1];
-            PyObject *value2 = stack_pointer[-2];
+            PyObject *value1;
+            PyObject *value2;
             PyObject *res;
+            value1 = stack_pointer[-1];
+            value2 = stack_pointer[-2];
             assert(oparg <= MAX_INTRINSIC_2);
             res = _PyIntrinsics_BinaryFunctions[oparg].func(tstate, value2, value1);
             Py_DECREF(value2);
@@ -849,7 +909,8 @@
         }
 
         TARGET(RAISE_VARARGS) {
-            PyObject **args = stack_pointer - oparg;
+            PyObject **args;
+            args = stack_pointer - oparg;
             PyObject *cause = NULL, *exc = NULL;
             switch (oparg) {
             case 2:
@@ -871,10 +932,12 @@
                 break;
             }
             if (true) { STACK_SHRINK(oparg); goto error; }
+            STACK_SHRINK(oparg);
         }
 
         TARGET(INTERPRETER_EXIT) {
-            PyObject *retval = stack_pointer[-1];
+            PyObject *retval;
+            retval = stack_pointer[-1];
             assert(frame == &entry_frame);
             assert(_PyFrame_IsIncomplete(frame));
             /* Restore previous cframe and return. */
@@ -883,10 +946,12 @@
             assert(!_PyErr_Occurred(tstate));
             _Py_LeaveRecursiveCallTstate(tstate);
             return retval;
+            STACK_SHRINK(1);
         }
 
         TARGET(RETURN_VALUE) {
-            PyObject *retval = stack_pointer[-1];
+            PyObject *retval;
+            retval = stack_pointer[-1];
             STACK_SHRINK(1);
             assert(EMPTY());
             _PyFrame_SetStackPointer(frame, stack_pointer);
@@ -899,10 +964,12 @@
             frame->prev_instr += frame->return_offset;
             _PyFrame_StackPush(frame, retval);
             goto resume_frame;
+            STACK_SHRINK(1);
         }
 
         TARGET(INSTRUMENTED_RETURN_VALUE) {
-            PyObject *retval = stack_pointer[-1];
+            PyObject *retval;
+            retval = stack_pointer[-1];
             int err = _Py_call_instrumentation_arg(
                     tstate, PY_MONITORING_EVENT_PY_RETURN,
                     frame, next_instr-1, retval);
@@ -919,6 +986,7 @@
             frame->prev_instr += frame->return_offset;
             _PyFrame_StackPush(frame, retval);
             goto resume_frame;
+            STACK_SHRINK(1);
         }
 
         TARGET(RETURN_CONST) {
@@ -958,8 +1026,9 @@
         }
 
         TARGET(GET_AITER) {
-            PyObject *obj = stack_pointer[-1];
+            PyObject *obj;
             PyObject *iter;
+            obj = stack_pointer[-1];
             unaryfunc getter = NULL;
             PyTypeObject *type = Py_TYPE(obj);
 
@@ -995,8 +1064,9 @@
         }
 
         TARGET(GET_ANEXT) {
-            PyObject *aiter = stack_pointer[-1];
+            PyObject *aiter;
             PyObject *awaitable;
+            aiter = stack_pointer[-1];
             unaryfunc getter = NULL;
             PyObject *next_iter = NULL;
             PyTypeObject *type = Py_TYPE(aiter);
@@ -1040,13 +1110,15 @@
                 }
             }
             STACK_GROW(1);
+            stack_pointer[-2] = aiter;
             stack_pointer[-1] = awaitable;
             DISPATCH();
         }
 
         TARGET(GET_AWAITABLE) {
-            PyObject *iterable = stack_pointer[-1];
+            PyObject *iterable;
             PyObject *iter;
+            iterable = stack_pointer[-1];
             iter = _PyCoro_GetAwaitableIter(iterable);
 
             if (iter == NULL) {
@@ -1077,9 +1149,11 @@
         TARGET(SEND) {
             PREDICTED(SEND);
             static_assert(INLINE_CACHE_ENTRIES_SEND == 1, "incorrect cache size");
-            PyObject *v = stack_pointer[-1];
-            PyObject *receiver = stack_pointer[-2];
+            PyObject *v;
+            PyObject *receiver;
             PyObject *retval;
+            v = stack_pointer[-1];
+            receiver = stack_pointer[-2];
             #if ENABLE_SPECIALIZATION
             _PySendCache *cache = (_PySendCache *)next_instr;
             if (ADAPTIVE_COUNTER_IS_ZERO(cache->counter)) {
@@ -1126,14 +1200,17 @@
                 }
             }
             Py_DECREF(v);
+            stack_pointer[-2] = receiver;
             stack_pointer[-1] = retval;
             next_instr += 1;
             DISPATCH();
         }
 
         TARGET(SEND_GEN) {
-            PyObject *v = stack_pointer[-1];
-            PyObject *receiver = stack_pointer[-2];
+            PyObject *v;
+            PyObject *receiver;
+            v = stack_pointer[-1];
+            receiver = stack_pointer[-2];
             DEOPT_IF(tstate->interp->eval_frame, SEND);
             PyGenObject *gen = (PyGenObject *)receiver;
             DEOPT_IF(Py_TYPE(gen) != &PyGen_Type &&
@@ -1149,10 +1226,12 @@
             tstate->exc_info = &gen->gi_exc_state;
             SKIP_OVER(INLINE_CACHE_ENTRIES_SEND);
             DISPATCH_INLINED(gen_frame);
+            stack_pointer[-2] = receiver;
         }
 
         TARGET(INSTRUMENTED_YIELD_VALUE) {
-            PyObject *retval = stack_pointer[-1];
+            PyObject *retval;
+            retval = stack_pointer[-1];
             assert(frame != &entry_frame);
             assert(oparg >= 0); /* make the generator identify this as HAS_ARG */
             PyGenObject *gen = _PyFrame_GetGenerator(frame);
@@ -1173,7 +1252,8 @@
         }
 
         TARGET(YIELD_VALUE) {
-            PyObject *retval = stack_pointer[-1];
+            PyObject *retval;
+            retval = stack_pointer[-1];
             // NOTE: It's important that YIELD_VALUE never raises an exception!
             // The compiler treats any exception raised here as a failed close()
             // or throw() call.
@@ -1193,7 +1273,8 @@
         }
 
         TARGET(POP_EXCEPT) {
-            PyObject *exc_value = stack_pointer[-1];
+            PyObject *exc_value;
+            exc_value = stack_pointer[-1];
             _PyErr_StackItem *exc_info = tstate->exc_info;
             Py_XSETREF(exc_info->exc_value, exc_value);
             STACK_SHRINK(1);
@@ -1201,8 +1282,11 @@
         }
 
         TARGET(RERAISE) {
-            PyObject *exc = stack_pointer[-1];
-            PyObject **values = stack_pointer - 1 - oparg;
+            PyObject *exc;
+            PyObject **values;
+            exc = stack_pointer[-1];
+            values = stack_pointer - 1 - oparg;
+            values = stack_pointer - 1 - oparg;
             assert(oparg >= 0 && oparg <= 2);
             if (oparg) {
                 PyObject *lasti = values[0];
@@ -1221,11 +1305,14 @@
             _PyErr_SetRaisedException(tstate, exc);
             monitor_reraise(tstate, frame, next_instr-1);
             goto exception_unwind;
+            STACK_SHRINK(1);
         }
 
         TARGET(END_ASYNC_FOR) {
-            PyObject *exc = stack_pointer[-1];
-            PyObject *awaitable = stack_pointer[-2];
+            PyObject *exc;
+            PyObject *awaitable;
+            exc = stack_pointer[-1];
+            awaitable = stack_pointer[-2];
             assert(exc && PyExceptionInstance_Check(exc));
             if (PyErr_GivenExceptionMatches(exc, PyExc_StopAsyncIteration)) {
                 Py_DECREF(awaitable);
@@ -1242,11 +1329,14 @@
         }
 
         TARGET(CLEANUP_THROW) {
-            PyObject *exc_value = stack_pointer[-1];
-            PyObject *last_sent_val = stack_pointer[-2];
-            PyObject *sub_iter = stack_pointer[-3];
+            PyObject *exc_value;
+            PyObject *last_sent_val;
+            PyObject *sub_iter;
             PyObject *none;
             PyObject *value;
+            exc_value = stack_pointer[-1];
+            last_sent_val = stack_pointer[-2];
+            sub_iter = stack_pointer[-3];
             assert(throwflag);
             assert(exc_value && PyExceptionInstance_Check(exc_value));
             if (PyErr_GivenExceptionMatches(exc_value, PyExc_StopIteration)) {
@@ -1262,8 +1352,8 @@
                 goto exception_unwind;
             }
             STACK_SHRINK(1);
-            stack_pointer[-1] = value;
             stack_pointer[-2] = none;
+            stack_pointer[-1] = value;
             DISPATCH();
         }
 
@@ -1289,7 +1379,8 @@
         }
 
         TARGET(STORE_NAME) {
-            PyObject *v = stack_pointer[-1];
+            PyObject *v;
+            v = stack_pointer[-1];
             PyObject *name = GETITEM(FRAME_CO_NAMES, oparg);
             PyObject *ns = LOCALS();
             int err;
@@ -1332,7 +1423,8 @@
         TARGET(UNPACK_SEQUENCE) {
             PREDICTED(UNPACK_SEQUENCE);
             static_assert(INLINE_CACHE_ENTRIES_UNPACK_SEQUENCE == 1, "incorrect cache size");
-            PyObject *seq = stack_pointer[-1];
+            PyObject *seq;
+            seq = stack_pointer[-1];
             #if ENABLE_SPECIALIZATION
             _PyUnpackSequenceCache *cache = (_PyUnpackSequenceCache *)next_instr;
             if (ADAPTIVE_COUNTER_IS_ZERO(cache->counter)) {
@@ -1354,8 +1446,10 @@
         }
 
         TARGET(UNPACK_SEQUENCE_TWO_TUPLE) {
-            PyObject *seq = stack_pointer[-1];
-            PyObject **values = stack_pointer - 1;
+            PyObject *seq;
+            PyObject **values;
+            seq = stack_pointer[-1];
+            values = stack_pointer - 1;
             DEOPT_IF(!PyTuple_CheckExact(seq), UNPACK_SEQUENCE);
             DEOPT_IF(PyTuple_GET_SIZE(seq) != 2, UNPACK_SEQUENCE);
             assert(oparg == 2);
@@ -1370,8 +1464,10 @@
         }
 
         TARGET(UNPACK_SEQUENCE_TUPLE) {
-            PyObject *seq = stack_pointer[-1];
-            PyObject **values = stack_pointer - 1;
+            PyObject *seq;
+            PyObject **values;
+            seq = stack_pointer[-1];
+            values = stack_pointer - 1;
             DEOPT_IF(!PyTuple_CheckExact(seq), UNPACK_SEQUENCE);
             DEOPT_IF(PyTuple_GET_SIZE(seq) != oparg, UNPACK_SEQUENCE);
             STAT_INC(UNPACK_SEQUENCE, hit);
@@ -1387,8 +1483,10 @@
         }
 
         TARGET(UNPACK_SEQUENCE_LIST) {
-            PyObject *seq = stack_pointer[-1];
-            PyObject **values = stack_pointer - 1;
+            PyObject *seq;
+            PyObject **values;
+            seq = stack_pointer[-1];
+            values = stack_pointer - 1;
             DEOPT_IF(!PyList_CheckExact(seq), UNPACK_SEQUENCE);
             DEOPT_IF(PyList_GET_SIZE(seq) != oparg, UNPACK_SEQUENCE);
             STAT_INC(UNPACK_SEQUENCE, hit);
@@ -1404,7 +1502,8 @@
         }
 
         TARGET(UNPACK_EX) {
-            PyObject *seq = stack_pointer[-1];
+            PyObject *seq;
+            seq = stack_pointer[-1];
             int totalargs = 1 + (oparg & 0xFF) + (oparg >> 8);
             PyObject **top = stack_pointer + totalargs - 1;
             int res = _PyEval_UnpackIterable(tstate, seq, oparg & 0xFF, oparg >> 8, top);
@@ -1417,8 +1516,10 @@
         TARGET(STORE_ATTR) {
             PREDICTED(STORE_ATTR);
             static_assert(INLINE_CACHE_ENTRIES_STORE_ATTR == 4, "incorrect cache size");
-            PyObject *owner = stack_pointer[-1];
-            PyObject *v = stack_pointer[-2];
+            PyObject *owner;
+            PyObject *v;
+            owner = stack_pointer[-1];
+            v = stack_pointer[-2];
             #if ENABLE_SPECIALIZATION
             _PyAttrCache *cache = (_PyAttrCache *)next_instr;
             if (ADAPTIVE_COUNTER_IS_ZERO(cache->counter)) {
@@ -1441,7 +1542,8 @@
         }
 
         TARGET(DELETE_ATTR) {
-            PyObject *owner = stack_pointer[-1];
+            PyObject *owner;
+            owner = stack_pointer[-1];
             PyObject *name = GETITEM(FRAME_CO_NAMES, oparg);
             int err = PyObject_DelAttr(owner, name);
             Py_DECREF(owner);
@@ -1451,7 +1553,8 @@
         }
 
         TARGET(STORE_GLOBAL) {
-            PyObject *v = stack_pointer[-1];
+            PyObject *v;
+            v = stack_pointer[-1];
             PyObject *name = GETITEM(FRAME_CO_NAMES, oparg);
             int err = PyDict_SetItem(GLOBALS(), name, v);
             Py_DECREF(v);
@@ -1477,16 +1580,13 @@
 
         TARGET(LOAD_LOCALS) {
             PyObject *locals;
-            // _LOAD_LOCALS
-            {
-                locals = LOCALS();
-                if (locals == NULL) {
-                    _PyErr_SetString(tstate, PyExc_SystemError,
-                                     "no locals found");
-                    if (true) goto error;
-                }
-                Py_INCREF(locals);
+            locals = LOCALS();
+            if (locals == NULL) {
+                _PyErr_SetString(tstate, PyExc_SystemError,
+                                 "no locals found");
+                if (true) goto error;
             }
+            Py_INCREF(locals);
             STACK_GROW(1);
             stack_pointer[-1] = locals;
             DISPATCH();
@@ -1544,33 +1644,30 @@
         TARGET(LOAD_FROM_DICT_OR_GLOBALS) {
             PyObject *mod_or_class_dict;
             PyObject *v;
-            // _LOAD_FROM_DICT_OR_GLOBALS
             mod_or_class_dict = stack_pointer[-1];
-            {
-                PyObject *name = GETITEM(FRAME_CO_NAMES, oparg);
-                if (PyMapping_GetOptionalItem(mod_or_class_dict, name, &v) < 0) {
-                    Py_DECREF(mod_or_class_dict);
+            PyObject *name = GETITEM(FRAME_CO_NAMES, oparg);
+            if (PyMapping_GetOptionalItem(mod_or_class_dict, name, &v) < 0) {
+                Py_DECREF(mod_or_class_dict);
+                goto error;
+            }
+            Py_DECREF(mod_or_class_dict);
+            if (v == NULL) {
+                v = PyDict_GetItemWithError(GLOBALS(), name);
+                if (v != NULL) {
+                    Py_INCREF(v);
+                }
+                else if (_PyErr_Occurred(tstate)) {
                     goto error;
                 }
-                Py_DECREF(mod_or_class_dict);
-                if (v == NULL) {
-                    v = PyDict_GetItemWithError(GLOBALS(), name);
-                    if (v != NULL) {
-                        Py_INCREF(v);
-                    }
-                    else if (_PyErr_Occurred(tstate)) {
+                else {
+                    if (PyMapping_GetOptionalItem(BUILTINS(), name, &v) < 0) {
                         goto error;
                     }
-                    else {
-                        if (PyMapping_GetOptionalItem(BUILTINS(), name, &v) < 0) {
-                            goto error;
-                        }
-                        if (v == NULL) {
-                            _PyEval_FormatExcCheckArg(
-                                        tstate, PyExc_NameError,
-                                        NAME_ERROR_MSG, name);
-                            goto error;
-                        }
+                    if (v == NULL) {
+                        _PyEval_FormatExcCheckArg(
+                                    tstate, PyExc_NameError,
+                                    NAME_ERROR_MSG, name);
+                        goto error;
                     }
                 }
             }
@@ -1631,8 +1728,8 @@
             null = NULL;
             STACK_GROW(1);
             STACK_GROW(((oparg & 1) ? 1 : 0));
-            stack_pointer[-1] = v;
             if (oparg & 1) { stack_pointer[-1 - (oparg & 1 ? 1 : 0)] = null; }
+            stack_pointer[-1] = v;
             next_instr += 4;
             DISPATCH();
         }
@@ -1659,11 +1756,11 @@
                 STAT_INC(LOAD_GLOBAL, hit);
                 null = NULL;
             }
-            next_instr += 4;
             STACK_GROW(1);
             STACK_GROW(((oparg & 1) ? 1 : 0));
             if (oparg & 1) { stack_pointer[-1 - (oparg & 1 ? 1 : 0)] = null; }
             stack_pointer[-1] = res;
+            next_instr += 4;
             DISPATCH();
         }
 
@@ -1697,11 +1794,11 @@
                 STAT_INC(LOAD_GLOBAL, hit);
                 null = NULL;
             }
-            next_instr += 4;
             STACK_GROW(1);
             STACK_GROW(((oparg & 1) ? 1 : 0));
             if (oparg & 1) { stack_pointer[-1 - (oparg & 1 ? 1 : 0)] = null; }
             stack_pointer[-1] = res;
+            next_instr += 4;
             DISPATCH();
         }
 
@@ -1739,8 +1836,9 @@
         }
 
         TARGET(LOAD_FROM_DICT_OR_DEREF) {
-            PyObject *class_dict = stack_pointer[-1];
+            PyObject *class_dict;
             PyObject *value;
+            class_dict = stack_pointer[-1];
             PyObject *name;
             assert(class_dict);
             assert(oparg >= 0 && oparg < _PyFrame_GetCode(frame)->co_nlocalsplus);
@@ -1778,7 +1876,8 @@
         }
 
         TARGET(STORE_DEREF) {
-            PyObject *v = stack_pointer[-1];
+            PyObject *v;
+            v = stack_pointer[-1];
             PyObject *cell = GETLOCAL(oparg);
             PyObject *oldobj = PyCell_GET(cell);
             PyCell_SET(cell, v);
@@ -1802,8 +1901,9 @@
         }
 
         TARGET(BUILD_STRING) {
-            PyObject **pieces = stack_pointer - oparg;
+            PyObject **pieces;
             PyObject *str;
+            pieces = stack_pointer - oparg;
             str = _PyUnicode_JoinArray(&_Py_STR(empty), pieces, oparg);
             for (int _i = oparg; --_i >= 0;) {
                 Py_DECREF(pieces[_i]);
@@ -1816,8 +1916,9 @@
         }
 
         TARGET(BUILD_TUPLE) {
-            PyObject **values = stack_pointer - oparg;
+            PyObject **values;
             PyObject *tup;
+            values = stack_pointer - oparg;
             tup = _PyTuple_FromArraySteal(values, oparg);
             if (tup == NULL) { STACK_SHRINK(oparg); goto error; }
             STACK_SHRINK(oparg);
@@ -1827,8 +1928,9 @@
         }
 
         TARGET(BUILD_LIST) {
-            PyObject **values = stack_pointer - oparg;
+            PyObject **values;
             PyObject *list;
+            values = stack_pointer - oparg;
             list = _PyList_FromArraySteal(values, oparg);
             if (list == NULL) { STACK_SHRINK(oparg); goto error; }
             STACK_SHRINK(oparg);
@@ -1838,8 +1940,10 @@
         }
 
         TARGET(LIST_EXTEND) {
-            PyObject *iterable = stack_pointer[-1];
-            PyObject *list = stack_pointer[-2 - (oparg-1)];
+            PyObject *iterable;
+            PyObject *list;
+            iterable = stack_pointer[-1];
+            list = stack_pointer[-2 - (oparg-1)];
             PyObject *none_val = _PyList_Extend((PyListObject *)list, iterable);
             if (none_val == NULL) {
                 if (_PyErr_ExceptionMatches(tstate, PyExc_TypeError) &&
@@ -1856,22 +1960,27 @@
             assert(Py_IsNone(none_val));
             Py_DECREF(iterable);
             STACK_SHRINK(1);
+            stack_pointer[-1 - (oparg-1)] = list;
             DISPATCH();
         }
 
         TARGET(SET_UPDATE) {
-            PyObject *iterable = stack_pointer[-1];
-            PyObject *set = stack_pointer[-2 - (oparg-1)];
+            PyObject *iterable;
+            PyObject *set;
+            iterable = stack_pointer[-1];
+            set = stack_pointer[-2 - (oparg-1)];
             int err = _PySet_Update(set, iterable);
             Py_DECREF(iterable);
             if (err < 0) goto pop_1_error;
             STACK_SHRINK(1);
+            stack_pointer[-1 - (oparg-1)] = set;
             DISPATCH();
         }
 
         TARGET(BUILD_SET) {
-            PyObject **values = stack_pointer - oparg;
+            PyObject **values;
             PyObject *set;
+            values = stack_pointer - oparg;
             set = PySet_New(NULL);
             if (set == NULL)
                 goto error;
@@ -1893,8 +2002,9 @@
         }
 
         TARGET(BUILD_MAP) {
-            PyObject **values = stack_pointer - oparg*2;
+            PyObject **values;
             PyObject *map;
+            values = stack_pointer - oparg*2;
             map = _PyDict_FromItems(
                     values, 2,
                     values+1, 2,
@@ -1954,9 +2064,11 @@
         }
 
         TARGET(BUILD_CONST_KEY_MAP) {
-            PyObject *keys = stack_pointer[-1];
-            PyObject **values = stack_pointer - 1 - oparg;
+            PyObject *keys;
+            PyObject **values;
             PyObject *map;
+            keys = stack_pointer[-1];
+            values = stack_pointer - 1 - oparg;
             if (!PyTuple_CheckExact(keys) ||
                 PyTuple_GET_SIZE(keys) != (Py_ssize_t)oparg) {
                 _PyErr_SetString(tstate, PyExc_SystemError,
@@ -1977,7 +2089,8 @@
         }
 
         TARGET(DICT_UPDATE) {
-            PyObject *update = stack_pointer[-1];
+            PyObject *update;
+            update = stack_pointer[-1];
             PyObject *dict = PEEK(oparg + 1);  // update is still on the stack
             if (PyDict_Update(dict, update) < 0) {
                 if (_PyErr_ExceptionMatches(tstate, PyExc_AttributeError)) {
@@ -1994,7 +2107,8 @@
         }
 
         TARGET(DICT_MERGE) {
-            PyObject *update = stack_pointer[-1];
+            PyObject *update;
+            update = stack_pointer[-1];
             PyObject *dict = PEEK(oparg + 1);  // update is still on the stack
 
             if (_PyDict_MergeEx(dict, update, 2) < 0) {
@@ -2008,8 +2122,10 @@
         }
 
         TARGET(MAP_ADD) {
-            PyObject *value = stack_pointer[-1];
-            PyObject *key = stack_pointer[-2];
+            PyObject *value;
+            PyObject *key;
+            value = stack_pointer[-1];
+            key = stack_pointer[-2];
             PyObject *dict = PEEK(oparg + 2);  // key, value are still on the stack
             assert(PyDict_CheckExact(dict));
             /* dict[key] = value */
@@ -2025,16 +2141,21 @@
             // don't want to specialize instrumented instructions
             INCREMENT_ADAPTIVE_COUNTER(cache->counter);
             GO_TO_INSTRUCTION(LOAD_SUPER_ATTR);
+            STACK_SHRINK(2);
+            STACK_GROW(((oparg & 1) ? 1 : 0));
         }
 
         TARGET(LOAD_SUPER_ATTR) {
             PREDICTED(LOAD_SUPER_ATTR);
             static_assert(INLINE_CACHE_ENTRIES_LOAD_SUPER_ATTR == 1, "incorrect cache size");
-            PyObject *self = stack_pointer[-1];
-            PyObject *class = stack_pointer[-2];
-            PyObject *global_super = stack_pointer[-3];
+            PyObject *self;
+            PyObject *class;
+            PyObject *global_super;
             PyObject *res2 = NULL;
             PyObject *res;
+            self = stack_pointer[-1];
+            class = stack_pointer[-2];
+            global_super = stack_pointer[-3];
             PyObject *name = GETITEM(FRAME_CO_NAMES, oparg >> 2);
             int load_method = oparg & 1;
             #if ENABLE_SPECIALIZATION
@@ -2085,18 +2206,21 @@
             if (res == NULL) goto pop_3_error;
             STACK_SHRINK(2);
             STACK_GROW(((oparg & 1) ? 1 : 0));
-            stack_pointer[-1] = res;
             if (oparg & 1) { stack_pointer[-1 - (oparg & 1 ? 1 : 0)] = res2; }
+            stack_pointer[-1] = res;
             next_instr += 1;
             DISPATCH();
         }
 
         TARGET(LOAD_SUPER_ATTR_ATTR) {
-            PyObject *self = stack_pointer[-1];
-            PyObject *class = stack_pointer[-2];
-            PyObject *global_super = stack_pointer[-3];
+            PyObject *self;
+            PyObject *class;
+            PyObject *global_super;
             PyObject *res2 = NULL;
             PyObject *res;
+            self = stack_pointer[-1];
+            class = stack_pointer[-2];
+            global_super = stack_pointer[-3];
             assert(!(oparg & 1));
             DEOPT_IF(global_super != (PyObject *)&PySuper_Type, LOAD_SUPER_ATTR);
             DEOPT_IF(!PyType_Check(class), LOAD_SUPER_ATTR);
@@ -2109,18 +2233,21 @@
             if (res == NULL) goto pop_3_error;
             STACK_SHRINK(2);
             STACK_GROW(((oparg & 1) ? 1 : 0));
-            stack_pointer[-1] = res;
             if (oparg & 1) { stack_pointer[-1 - (oparg & 1 ? 1 : 0)] = res2; }
+            stack_pointer[-1] = res;
             next_instr += 1;
             DISPATCH();
         }
 
         TARGET(LOAD_SUPER_ATTR_METHOD) {
-            PyObject *self = stack_pointer[-1];
-            PyObject *class = stack_pointer[-2];
-            PyObject *global_super = stack_pointer[-3];
+            PyObject *self;
+            PyObject *class;
+            PyObject *global_super;
             PyObject *res2;
             PyObject *res;
+            self = stack_pointer[-1];
+            class = stack_pointer[-2];
+            global_super = stack_pointer[-3];
             assert(oparg & 1);
             DEOPT_IF(global_super != (PyObject *)&PySuper_Type, LOAD_SUPER_ATTR);
             DEOPT_IF(!PyType_Check(class), LOAD_SUPER_ATTR);
@@ -2144,8 +2271,8 @@
                 res2 = NULL;
             }
             STACK_SHRINK(1);
-            stack_pointer[-1] = res;
             stack_pointer[-2] = res2;
+            stack_pointer[-1] = res;
             next_instr += 1;
             DISPATCH();
         }
@@ -2153,9 +2280,10 @@
         TARGET(LOAD_ATTR) {
             PREDICTED(LOAD_ATTR);
             static_assert(INLINE_CACHE_ENTRIES_LOAD_ATTR == 9, "incorrect cache size");
-            PyObject *owner = stack_pointer[-1];
+            PyObject *owner;
             PyObject *res2 = NULL;
             PyObject *res;
+            owner = stack_pointer[-1];
             #if ENABLE_SPECIALIZATION
             _PyAttrCache *cache = (_PyAttrCache *)next_instr;
             if (ADAPTIVE_COUNTER_IS_ZERO(cache->counter)) {
@@ -2202,8 +2330,8 @@
                 if (res == NULL) goto pop_1_error;
             }
             STACK_GROW(((oparg & 1) ? 1 : 0));
-            stack_pointer[-1] = res;
             if (oparg & 1) { stack_pointer[-1 - (oparg & 1 ? 1 : 0)] = res2; }
+            stack_pointer[-1] = res;
             next_instr += 9;
             DISPATCH();
         }
@@ -2238,17 +2366,18 @@
                 res2 = NULL;
                 Py_DECREF(owner);
             }
-            next_instr += 9;
             STACK_GROW(((oparg & 1) ? 1 : 0));
             if (oparg & 1) { stack_pointer[-1 - (oparg & 1 ? 1 : 0)] = res2; }
             stack_pointer[-1] = res;
+            next_instr += 9;
             DISPATCH();
         }
 
         TARGET(LOAD_ATTR_MODULE) {
-            PyObject *owner = stack_pointer[-1];
+            PyObject *owner;
             PyObject *res2 = NULL;
             PyObject *res;
+            owner = stack_pointer[-1];
             uint32_t type_version = read_u32(&next_instr[1].cache);
             uint16_t index = read_u16(&next_instr[3].cache);
             DEOPT_IF(!PyModule_CheckExact(owner), LOAD_ATTR);
@@ -2265,16 +2394,17 @@
             res2 = NULL;
             Py_DECREF(owner);
             STACK_GROW(((oparg & 1) ? 1 : 0));
-            stack_pointer[-1] = res;
             if (oparg & 1) { stack_pointer[-1 - (oparg & 1 ? 1 : 0)] = res2; }
+            stack_pointer[-1] = res;
             next_instr += 9;
             DISPATCH();
         }
 
         TARGET(LOAD_ATTR_WITH_HINT) {
-            PyObject *owner = stack_pointer[-1];
+            PyObject *owner;
             PyObject *res2 = NULL;
             PyObject *res;
+            owner = stack_pointer[-1];
             uint32_t type_version = read_u32(&next_instr[1].cache);
             uint16_t index = read_u16(&next_instr[3].cache);
             PyTypeObject *tp = Py_TYPE(owner);
@@ -2305,16 +2435,17 @@
             res2 = NULL;
             Py_DECREF(owner);
             STACK_GROW(((oparg & 1) ? 1 : 0));
-            stack_pointer[-1] = res;
             if (oparg & 1) { stack_pointer[-1 - (oparg & 1 ? 1 : 0)] = res2; }
+            stack_pointer[-1] = res;
             next_instr += 9;
             DISPATCH();
         }
 
         TARGET(LOAD_ATTR_SLOT) {
-            PyObject *owner = stack_pointer[-1];
+            PyObject *owner;
             PyObject *res2 = NULL;
             PyObject *res;
+            owner = stack_pointer[-1];
             uint32_t type_version = read_u32(&next_instr[1].cache);
             uint16_t index = read_u16(&next_instr[3].cache);
             PyTypeObject *tp = Py_TYPE(owner);
@@ -2328,16 +2459,17 @@
             res2 = NULL;
             Py_DECREF(owner);
             STACK_GROW(((oparg & 1) ? 1 : 0));
-            stack_pointer[-1] = res;
             if (oparg & 1) { stack_pointer[-1 - (oparg & 1 ? 1 : 0)] = res2; }
+            stack_pointer[-1] = res;
             next_instr += 9;
             DISPATCH();
         }
 
         TARGET(LOAD_ATTR_CLASS) {
-            PyObject *cls = stack_pointer[-1];
+            PyObject *cls;
             PyObject *res2 = NULL;
             PyObject *res;
+            cls = stack_pointer[-1];
             uint32_t type_version = read_u32(&next_instr[1].cache);
             PyObject *descr = read_obj(&next_instr[5].cache);
 
@@ -2353,14 +2485,15 @@
             Py_INCREF(res);
             Py_DECREF(cls);
             STACK_GROW(((oparg & 1) ? 1 : 0));
-            stack_pointer[-1] = res;
             if (oparg & 1) { stack_pointer[-1 - (oparg & 1 ? 1 : 0)] = res2; }
+            stack_pointer[-1] = res;
             next_instr += 9;
             DISPATCH();
         }
 
         TARGET(LOAD_ATTR_PROPERTY) {
-            PyObject *owner = stack_pointer[-1];
+            PyObject *owner;
+            owner = stack_pointer[-1];
             uint32_t type_version = read_u32(&next_instr[1].cache);
             uint32_t func_version = read_u32(&next_instr[3].cache);
             PyObject *fget = read_obj(&next_instr[5].cache);
@@ -2387,10 +2520,12 @@
             SKIP_OVER(INLINE_CACHE_ENTRIES_LOAD_ATTR);
             frame->return_offset = 0;
             DISPATCH_INLINED(new_frame);
+            STACK_GROW(((oparg & 1) ? 1 : 0));
         }
 
         TARGET(LOAD_ATTR_GETATTRIBUTE_OVERRIDDEN) {
-            PyObject *owner = stack_pointer[-1];
+            PyObject *owner;
+            owner = stack_pointer[-1];
             uint32_t type_version = read_u32(&next_instr[1].cache);
             uint32_t func_version = read_u32(&next_instr[3].cache);
             PyObject *getattribute = read_obj(&next_instr[5].cache);
@@ -2419,11 +2554,14 @@
             SKIP_OVER(INLINE_CACHE_ENTRIES_LOAD_ATTR);
             frame->return_offset = 0;
             DISPATCH_INLINED(new_frame);
+            STACK_GROW(((oparg & 1) ? 1 : 0));
         }
 
         TARGET(STORE_ATTR_INSTANCE_VALUE) {
-            PyObject *owner = stack_pointer[-1];
-            PyObject *value = stack_pointer[-2];
+            PyObject *owner;
+            PyObject *value;
+            owner = stack_pointer[-1];
+            value = stack_pointer[-2];
             uint32_t type_version = read_u32(&next_instr[1].cache);
             uint16_t index = read_u16(&next_instr[3].cache);
             PyTypeObject *tp = Py_TYPE(owner);
@@ -2449,8 +2587,10 @@
         }
 
         TARGET(STORE_ATTR_WITH_HINT) {
-            PyObject *owner = stack_pointer[-1];
-            PyObject *value = stack_pointer[-2];
+            PyObject *owner;
+            PyObject *value;
+            owner = stack_pointer[-1];
+            value = stack_pointer[-2];
             uint32_t type_version = read_u32(&next_instr[1].cache);
             uint16_t hint = read_u16(&next_instr[3].cache);
             PyTypeObject *tp = Py_TYPE(owner);
@@ -2497,8 +2637,10 @@
         }
 
         TARGET(STORE_ATTR_SLOT) {
-            PyObject *owner = stack_pointer[-1];
-            PyObject *value = stack_pointer[-2];
+            PyObject *owner;
+            PyObject *value;
+            owner = stack_pointer[-1];
+            value = stack_pointer[-2];
             uint32_t type_version = read_u32(&next_instr[1].cache);
             uint16_t index = read_u16(&next_instr[3].cache);
             PyTypeObject *tp = Py_TYPE(owner);
@@ -2518,9 +2660,11 @@
         TARGET(COMPARE_OP) {
             PREDICTED(COMPARE_OP);
             static_assert(INLINE_CACHE_ENTRIES_COMPARE_OP == 1, "incorrect cache size");
-            PyObject *right = stack_pointer[-1];
-            PyObject *left = stack_pointer[-2];
+            PyObject *right;
+            PyObject *left;
             PyObject *res;
+            right = stack_pointer[-1];
+            left = stack_pointer[-2];
             #if ENABLE_SPECIALIZATION
             _PyCompareOpCache *cache = (_PyCompareOpCache *)next_instr;
             if (ADAPTIVE_COUNTER_IS_ZERO(cache->counter)) {
@@ -2549,9 +2693,11 @@
         }
 
         TARGET(COMPARE_OP_FLOAT) {
-            PyObject *right = stack_pointer[-1];
-            PyObject *left = stack_pointer[-2];
+            PyObject *right;
+            PyObject *left;
             PyObject *res;
+            right = stack_pointer[-1];
+            left = stack_pointer[-2];
             DEOPT_IF(!PyFloat_CheckExact(left), COMPARE_OP);
             DEOPT_IF(!PyFloat_CheckExact(right), COMPARE_OP);
             STAT_INC(COMPARE_OP, hit);
@@ -2570,9 +2716,11 @@
         }
 
         TARGET(COMPARE_OP_INT) {
-            PyObject *right = stack_pointer[-1];
-            PyObject *left = stack_pointer[-2];
+            PyObject *right;
+            PyObject *left;
             PyObject *res;
+            right = stack_pointer[-1];
+            left = stack_pointer[-2];
             DEOPT_IF(!PyLong_CheckExact(left), COMPARE_OP);
             DEOPT_IF(!PyLong_CheckExact(right), COMPARE_OP);
             DEOPT_IF(!_PyLong_IsCompact((PyLongObject *)left), COMPARE_OP);
@@ -2595,9 +2743,11 @@
         }
 
         TARGET(COMPARE_OP_STR) {
-            PyObject *right = stack_pointer[-1];
-            PyObject *left = stack_pointer[-2];
+            PyObject *right;
+            PyObject *left;
             PyObject *res;
+            right = stack_pointer[-1];
+            left = stack_pointer[-2];
             DEOPT_IF(!PyUnicode_CheckExact(left), COMPARE_OP);
             DEOPT_IF(!PyUnicode_CheckExact(right), COMPARE_OP);
             STAT_INC(COMPARE_OP, hit);
@@ -2617,9 +2767,11 @@
         }
 
         TARGET(IS_OP) {
-            PyObject *right = stack_pointer[-1];
-            PyObject *left = stack_pointer[-2];
+            PyObject *right;
+            PyObject *left;
             PyObject *b;
+            right = stack_pointer[-1];
+            left = stack_pointer[-2];
             int res = Py_Is(left, right) ^ oparg;
             Py_DECREF(left);
             Py_DECREF(right);
@@ -2630,9 +2782,11 @@
         }
 
         TARGET(CONTAINS_OP) {
-            PyObject *right = stack_pointer[-1];
-            PyObject *left = stack_pointer[-2];
+            PyObject *right;
+            PyObject *left;
             PyObject *b;
+            right = stack_pointer[-1];
+            left = stack_pointer[-2];
             int res = PySequence_Contains(right, left);
             Py_DECREF(left);
             Py_DECREF(right);
@@ -2644,10 +2798,12 @@
         }
 
         TARGET(CHECK_EG_MATCH) {
-            PyObject *match_type = stack_pointer[-1];
-            PyObject *exc_value = stack_pointer[-2];
+            PyObject *match_type;
+            PyObject *exc_value;
             PyObject *rest;
             PyObject *match;
+            match_type = stack_pointer[-1];
+            exc_value = stack_pointer[-2];
             if (_PyEval_CheckExceptStarTypeValid(tstate, match_type) < 0) {
                 Py_DECREF(exc_value);
                 Py_DECREF(match_type);
@@ -2668,15 +2824,17 @@
             if (!Py_IsNone(match)) {
                 PyErr_SetHandledException(match);
             }
-            stack_pointer[-1] = match;
             stack_pointer[-2] = rest;
+            stack_pointer[-1] = match;
             DISPATCH();
         }
 
         TARGET(CHECK_EXC_MATCH) {
-            PyObject *right = stack_pointer[-1];
-            PyObject *left = stack_pointer[-2];
+            PyObject *right;
+            PyObject *left;
             PyObject *b;
+            right = stack_pointer[-1];
+            left = stack_pointer[-2];
             assert(PyExceptionInstance_Check(left));
             if (_PyEval_CheckExceptTypeValid(tstate, right) < 0) {
                  Py_DECREF(right);
@@ -2686,14 +2844,17 @@
             int res = PyErr_GivenExceptionMatches(left, right);
             Py_DECREF(right);
             b = res ? Py_True : Py_False;
+            stack_pointer[-2] = left;
             stack_pointer[-1] = b;
             DISPATCH();
         }
 
         TARGET(IMPORT_NAME) {
-            PyObject *fromlist = stack_pointer[-1];
-            PyObject *level = stack_pointer[-2];
+            PyObject *fromlist;
+            PyObject *level;
             PyObject *res;
+            fromlist = stack_pointer[-1];
+            level = stack_pointer[-2];
             PyObject *name = GETITEM(FRAME_CO_NAMES, oparg);
             res = import_name(tstate, frame, name, fromlist, level);
             Py_DECREF(level);
@@ -2705,12 +2866,14 @@
         }
 
         TARGET(IMPORT_FROM) {
-            PyObject *from = stack_pointer[-1];
+            PyObject *from;
             PyObject *res;
+            from = stack_pointer[-1];
             PyObject *name = GETITEM(FRAME_CO_NAMES, oparg);
             res = import_from(tstate, from, name);
             if (res == NULL) goto error;
             STACK_GROW(1);
+            stack_pointer[-2] = from;
             stack_pointer[-1] = res;
             DISPATCH();
         }
@@ -2767,7 +2930,8 @@
         }
 
         TARGET(POP_JUMP_IF_FALSE) {
-            PyObject *cond = stack_pointer[-1];
+            PyObject *cond;
+            cond = stack_pointer[-1];
             assert(PyBool_Check(cond));
             JUMPBY(oparg * Py_IsFalse(cond));
             STACK_SHRINK(1);
@@ -2775,7 +2939,8 @@
         }
 
         TARGET(POP_JUMP_IF_TRUE) {
-            PyObject *cond = stack_pointer[-1];
+            PyObject *cond;
+            cond = stack_pointer[-1];
             assert(PyBool_Check(cond));
             JUMPBY(oparg * Py_IsTrue(cond));
             STACK_SHRINK(1);
@@ -2843,23 +3008,28 @@
         }
 
         TARGET(GET_LEN) {
-            PyObject *obj = stack_pointer[-1];
+            PyObject *obj;
             PyObject *len_o;
+            obj = stack_pointer[-1];
             // PUSH(len(TOS))
             Py_ssize_t len_i = PyObject_Length(obj);
             if (len_i < 0) goto error;
             len_o = PyLong_FromSsize_t(len_i);
             if (len_o == NULL) goto error;
             STACK_GROW(1);
+            stack_pointer[-2] = obj;
             stack_pointer[-1] = len_o;
             DISPATCH();
         }
 
         TARGET(MATCH_CLASS) {
-            PyObject *names = stack_pointer[-1];
-            PyObject *type = stack_pointer[-2];
-            PyObject *subject = stack_pointer[-3];
+            PyObject *names;
+            PyObject *type;
+            PyObject *subject;
             PyObject *attrs;
+            names = stack_pointer[-1];
+            type = stack_pointer[-2];
+            subject = stack_pointer[-3];
             // Pop TOS and TOS1. Set TOS to a tuple of attributes on success, or
             // None on failure.
             assert(PyTuple_CheckExact(names));
@@ -2880,40 +3050,49 @@
         }
 
         TARGET(MATCH_MAPPING) {
-            PyObject *subject = stack_pointer[-1];
+            PyObject *subject;
             PyObject *res;
+            subject = stack_pointer[-1];
             int match = Py_TYPE(subject)->tp_flags & Py_TPFLAGS_MAPPING;
             res = match ? Py_True : Py_False;
             STACK_GROW(1);
+            stack_pointer[-2] = subject;
             stack_pointer[-1] = res;
             DISPATCH();
         }
 
         TARGET(MATCH_SEQUENCE) {
-            PyObject *subject = stack_pointer[-1];
+            PyObject *subject;
             PyObject *res;
+            subject = stack_pointer[-1];
             int match = Py_TYPE(subject)->tp_flags & Py_TPFLAGS_SEQUENCE;
             res = match ? Py_True : Py_False;
             STACK_GROW(1);
+            stack_pointer[-2] = subject;
             stack_pointer[-1] = res;
             DISPATCH();
         }
 
         TARGET(MATCH_KEYS) {
-            PyObject *keys = stack_pointer[-1];
-            PyObject *subject = stack_pointer[-2];
+            PyObject *keys;
+            PyObject *subject;
             PyObject *values_or_none;
+            keys = stack_pointer[-1];
+            subject = stack_pointer[-2];
             // On successful match, PUSH(values). Otherwise, PUSH(None).
             values_or_none = _PyEval_MatchKeys(tstate, subject, keys);
             if (values_or_none == NULL) goto error;
             STACK_GROW(1);
+            stack_pointer[-3] = subject;
+            stack_pointer[-2] = keys;
             stack_pointer[-1] = values_or_none;
             DISPATCH();
         }
 
         TARGET(GET_ITER) {
-            PyObject *iterable = stack_pointer[-1];
+            PyObject *iterable;
             PyObject *iter;
+            iterable = stack_pointer[-1];
             /* before: [obj]; after [getiter(obj)] */
             iter = PyObject_GetIter(iterable);
             Py_DECREF(iterable);
@@ -2923,8 +3102,9 @@
         }
 
         TARGET(GET_YIELD_FROM_ITER) {
-            PyObject *iterable = stack_pointer[-1];
+            PyObject *iterable;
             PyObject *iter;
+            iterable = stack_pointer[-1];
             /* before: [obj]; after [getiter(obj)] */
             if (PyCoro_CheckExact(iterable)) {
                 /* `iterable` is a coroutine */
@@ -2956,8 +3136,9 @@
         TARGET(FOR_ITER) {
             PREDICTED(FOR_ITER);
             static_assert(INLINE_CACHE_ENTRIES_FOR_ITER == 1, "incorrect cache size");
-            PyObject *iter = stack_pointer[-1];
+            PyObject *iter;
             PyObject *next;
+            iter = stack_pointer[-1];
             #if ENABLE_SPECIALIZATION
             _PyForIterCache *cache = (_PyForIterCache *)next_instr;
             if (ADAPTIVE_COUNTER_IS_ZERO(cache->counter)) {
@@ -2990,6 +3171,7 @@
             }
             // Common case: no jump, leave it to the code generator
             STACK_GROW(1);
+            stack_pointer[-2] = iter;
             stack_pointer[-1] = next;
             next_instr += 1;
             DISPATCH();
@@ -3060,10 +3242,10 @@
                 assert(it->it_index < PyList_GET_SIZE(seq));
                 next = Py_NewRef(PyList_GET_ITEM(seq, it->it_index++));
             }
-            next_instr += 1;
             STACK_GROW(1);
             stack_pointer[-2] = iter;
             stack_pointer[-1] = next;
+            next_instr += 1;
             DISPATCH();
         }
 
@@ -3103,10 +3285,10 @@
                 assert(it->it_index < PyTuple_GET_SIZE(seq));
                 next = Py_NewRef(PyTuple_GET_ITEM(seq, it->it_index++));
             }
-            next_instr += 1;
             STACK_GROW(1);
             stack_pointer[-2] = iter;
             stack_pointer[-1] = next;
+            next_instr += 1;
             DISPATCH();
         }
 
@@ -3144,15 +3326,16 @@
                 next = PyLong_FromLong(value);
                 if (next == NULL) goto error;
             }
-            next_instr += 1;
             STACK_GROW(1);
             stack_pointer[-2] = iter;
             stack_pointer[-1] = next;
+            next_instr += 1;
             DISPATCH();
         }
 
         TARGET(FOR_ITER_GEN) {
-            PyObject *iter = stack_pointer[-1];
+            PyObject *iter;
+            iter = stack_pointer[-1];
             DEOPT_IF(tstate->interp->eval_frame, FOR_ITER);
             PyGenObject *gen = (PyGenObject *)iter;
             DEOPT_IF(Py_TYPE(gen) != &PyGen_Type, FOR_ITER);
@@ -3168,12 +3351,15 @@
             assert(next_instr[oparg].op.code == END_FOR ||
                    next_instr[oparg].op.code == INSTRUMENTED_END_FOR);
             DISPATCH_INLINED(gen_frame);
+            STACK_GROW(1);
+            stack_pointer[-2] = iter;
         }
 
         TARGET(BEFORE_ASYNC_WITH) {
-            PyObject *mgr = stack_pointer[-1];
+            PyObject *mgr;
             PyObject *exit;
             PyObject *res;
+            mgr = stack_pointer[-1];
             PyObject *enter = _PyObject_LookupSpecial(mgr, &_Py_ID(__aenter__));
             if (enter == NULL) {
                 if (!_PyErr_Occurred(tstate)) {
@@ -3204,15 +3390,16 @@
                 if (true) goto pop_1_error;
             }
             STACK_GROW(1);
-            stack_pointer[-1] = res;
             stack_pointer[-2] = exit;
+            stack_pointer[-1] = res;
             DISPATCH();
         }
 
         TARGET(BEFORE_WITH) {
-            PyObject *mgr = stack_pointer[-1];
+            PyObject *mgr;
             PyObject *exit;
             PyObject *res;
+            mgr = stack_pointer[-1];
             /* pop the context manager, push its __exit__ and the
              * value returned from calling its __enter__
              */
@@ -3246,16 +3433,19 @@
                 if (true) goto pop_1_error;
             }
             STACK_GROW(1);
-            stack_pointer[-1] = res;
             stack_pointer[-2] = exit;
+            stack_pointer[-1] = res;
             DISPATCH();
         }
 
         TARGET(WITH_EXCEPT_START) {
-            PyObject *val = stack_pointer[-1];
-            PyObject *lasti = stack_pointer[-3];
-            PyObject *exit_func = stack_pointer[-4];
+            PyObject *val;
+            PyObject *lasti;
+            PyObject *exit_func;
             PyObject *res;
+            val = stack_pointer[-1];
+            lasti = stack_pointer[-3];
+            exit_func = stack_pointer[-4];
             /* At the top of the stack are 4 values:
                - val: TOP = exc_info()
                - unused: SECOND = previous exception
@@ -3282,13 +3472,17 @@
                     3 | PY_VECTORCALL_ARGUMENTS_OFFSET, NULL);
             if (res == NULL) goto error;
             STACK_GROW(1);
+            stack_pointer[-5] = exit_func;
+            stack_pointer[-4] = lasti;
+            stack_pointer[-2] = val;
             stack_pointer[-1] = res;
             DISPATCH();
         }
 
         TARGET(PUSH_EXC_INFO) {
-            PyObject *new_exc = stack_pointer[-1];
+            PyObject *new_exc;
             PyObject *prev_exc;
+            new_exc = stack_pointer[-1];
             _PyErr_StackItem *exc_info = tstate->exc_info;
             if (exc_info->exc_value != NULL) {
                 prev_exc = exc_info->exc_value;
@@ -3299,15 +3493,16 @@
             assert(PyExceptionInstance_Check(new_exc));
             exc_info->exc_value = Py_NewRef(new_exc);
             STACK_GROW(1);
-            stack_pointer[-1] = new_exc;
             stack_pointer[-2] = prev_exc;
+            stack_pointer[-1] = new_exc;
             DISPATCH();
         }
 
         TARGET(LOAD_ATTR_METHOD_WITH_VALUES) {
-            PyObject *self = stack_pointer[-1];
+            PyObject *self;
             PyObject *res2;
             PyObject *res;
+            self = stack_pointer[-1];
             uint32_t type_version = read_u32(&next_instr[1].cache);
             uint32_t keys_version = read_u32(&next_instr[3].cache);
             PyObject *descr = read_obj(&next_instr[5].cache);
@@ -3328,16 +3523,17 @@
             assert(_PyType_HasFeature(Py_TYPE(res2), Py_TPFLAGS_METHOD_DESCRIPTOR));
             res = self;
             STACK_GROW(1);
-            stack_pointer[-1] = res;
             stack_pointer[-2] = res2;
+            stack_pointer[-1] = res;
             next_instr += 9;
             DISPATCH();
         }
 
         TARGET(LOAD_ATTR_METHOD_NO_DICT) {
-            PyObject *self = stack_pointer[-1];
+            PyObject *self;
             PyObject *res2;
             PyObject *res;
+            self = stack_pointer[-1];
             uint32_t type_version = read_u32(&next_instr[1].cache);
             PyObject *descr = read_obj(&next_instr[5].cache);
             assert(oparg & 1);
@@ -3350,15 +3546,16 @@
             res2 = Py_NewRef(descr);
             res = self;
             STACK_GROW(1);
-            stack_pointer[-1] = res;
             stack_pointer[-2] = res2;
+            stack_pointer[-1] = res;
             next_instr += 9;
             DISPATCH();
         }
 
         TARGET(LOAD_ATTR_NONDESCRIPTOR_WITH_VALUES) {
-            PyObject *self = stack_pointer[-1];
+            PyObject *self;
             PyObject *res;
+            self = stack_pointer[-1];
             uint32_t type_version = read_u32(&next_instr[1].cache);
             uint32_t keys_version = read_u32(&next_instr[3].cache);
             PyObject *descr = read_obj(&next_instr[5].cache);
@@ -3382,8 +3579,9 @@
         }
 
         TARGET(LOAD_ATTR_NONDESCRIPTOR_NO_DICT) {
-            PyObject *self = stack_pointer[-1];
+            PyObject *self;
             PyObject *res;
+            self = stack_pointer[-1];
             uint32_t type_version = read_u32(&next_instr[1].cache);
             PyObject *descr = read_obj(&next_instr[5].cache);
             assert((oparg & 1) == 0);
@@ -3401,9 +3599,10 @@
         }
 
         TARGET(LOAD_ATTR_METHOD_LAZY_DICT) {
-            PyObject *self = stack_pointer[-1];
+            PyObject *self;
             PyObject *res2;
             PyObject *res;
+            self = stack_pointer[-1];
             uint32_t type_version = read_u32(&next_instr[1].cache);
             PyObject *descr = read_obj(&next_instr[5].cache);
             assert(oparg & 1);
@@ -3420,8 +3619,8 @@
             res2 = Py_NewRef(descr);
             res = self;
             STACK_GROW(1);
-            stack_pointer[-1] = res;
             stack_pointer[-2] = res2;
+            stack_pointer[-1] = res;
             next_instr += 9;
             DISPATCH();
         }
@@ -3451,10 +3650,13 @@
         TARGET(CALL) {
             PREDICTED(CALL);
             static_assert(INLINE_CACHE_ENTRIES_CALL == 3, "incorrect cache size");
-            PyObject **args = stack_pointer - oparg;
-            PyObject *callable = stack_pointer[-1 - oparg];
-            PyObject *method = stack_pointer[-2 - oparg];
+            PyObject **args;
+            PyObject *callable;
+            PyObject *method;
             PyObject *res;
+            args = stack_pointer - oparg;
+            callable = stack_pointer[-1 - oparg];
+            method = stack_pointer[-2 - oparg];
             int is_meth = method != NULL;
             int total_args = oparg;
             if (is_meth) {
@@ -3545,8 +3747,10 @@
         }
 
         TARGET(CALL_BOUND_METHOD_EXACT_ARGS) {
-            PyObject *callable = stack_pointer[-1 - oparg];
-            PyObject *method = stack_pointer[-2 - oparg];
+            PyObject *callable;
+            PyObject *method;
+            callable = stack_pointer[-1 - oparg];
+            method = stack_pointer[-2 - oparg];
             DEOPT_IF(method != NULL, CALL);
             DEOPT_IF(Py_TYPE(callable) != &PyMethod_Type, CALL);
             STAT_INC(CALL, hit);
@@ -3556,13 +3760,18 @@
             PEEK(oparg + 2) = Py_NewRef(meth);  // method
             Py_DECREF(callable);
             GO_TO_INSTRUCTION(CALL_PY_EXACT_ARGS);
+            STACK_SHRINK(oparg);
+            STACK_SHRINK(1);
         }
 
         TARGET(CALL_PY_EXACT_ARGS) {
             PREDICTED(CALL_PY_EXACT_ARGS);
-            PyObject **args = stack_pointer - oparg;
-            PyObject *callable = stack_pointer[-1 - oparg];
-            PyObject *method = stack_pointer[-2 - oparg];
+            PyObject **args;
+            PyObject *callable;
+            PyObject *method;
+            args = stack_pointer - oparg;
+            callable = stack_pointer[-1 - oparg];
+            method = stack_pointer[-2 - oparg];
             uint32_t func_version = read_u32(&next_instr[1].cache);
             ASSERT_KWNAMES_IS_NULL();
             DEOPT_IF(tstate->interp->eval_frame, CALL);
@@ -3589,12 +3798,17 @@
             SKIP_OVER(INLINE_CACHE_ENTRIES_CALL);
             frame->return_offset = 0;
             DISPATCH_INLINED(new_frame);
+            STACK_SHRINK(oparg);
+            STACK_SHRINK(1);
         }
 
         TARGET(CALL_PY_WITH_DEFAULTS) {
-            PyObject **args = stack_pointer - oparg;
-            PyObject *callable = stack_pointer[-1 - oparg];
-            PyObject *method = stack_pointer[-2 - oparg];
+            PyObject **args;
+            PyObject *callable;
+            PyObject *method;
+            args = stack_pointer - oparg;
+            callable = stack_pointer[-1 - oparg];
+            method = stack_pointer[-2 - oparg];
             uint32_t func_version = read_u32(&next_instr[1].cache);
             ASSERT_KWNAMES_IS_NULL();
             DEOPT_IF(tstate->interp->eval_frame, CALL);
@@ -3631,13 +3845,18 @@
             SKIP_OVER(INLINE_CACHE_ENTRIES_CALL);
             frame->return_offset = 0;
             DISPATCH_INLINED(new_frame);
+            STACK_SHRINK(oparg);
+            STACK_SHRINK(1);
         }
 
         TARGET(CALL_NO_KW_TYPE_1) {
-            PyObject **args = stack_pointer - oparg;
-            PyObject *callable = stack_pointer[-1 - oparg];
-            PyObject *null = stack_pointer[-2 - oparg];
+            PyObject **args;
+            PyObject *callable;
+            PyObject *null;
             PyObject *res;
+            args = stack_pointer - oparg;
+            callable = stack_pointer[-1 - oparg];
+            null = stack_pointer[-2 - oparg];
             ASSERT_KWNAMES_IS_NULL();
             assert(oparg == 1);
             DEOPT_IF(null != NULL, CALL);
@@ -3655,10 +3874,13 @@
         }
 
         TARGET(CALL_NO_KW_STR_1) {
-            PyObject **args = stack_pointer - oparg;
-            PyObject *callable = stack_pointer[-1 - oparg];
-            PyObject *null = stack_pointer[-2 - oparg];
+            PyObject **args;
+            PyObject *callable;
+            PyObject *null;
             PyObject *res;
+            args = stack_pointer - oparg;
+            callable = stack_pointer[-1 - oparg];
+            null = stack_pointer[-2 - oparg];
             ASSERT_KWNAMES_IS_NULL();
             assert(oparg == 1);
             DEOPT_IF(null != NULL, CALL);
@@ -3678,10 +3900,13 @@
         }
 
         TARGET(CALL_NO_KW_TUPLE_1) {
-            PyObject **args = stack_pointer - oparg;
-            PyObject *callable = stack_pointer[-1 - oparg];
-            PyObject *null = stack_pointer[-2 - oparg];
+            PyObject **args;
+            PyObject *callable;
+            PyObject *null;
             PyObject *res;
+            args = stack_pointer - oparg;
+            callable = stack_pointer[-1 - oparg];
+            null = stack_pointer[-2 - oparg];
             ASSERT_KWNAMES_IS_NULL();
             assert(oparg == 1);
             DEOPT_IF(null != NULL, CALL);
@@ -3701,9 +3926,12 @@
         }
 
         TARGET(CALL_NO_KW_ALLOC_AND_ENTER_INIT) {
-            PyObject **args = stack_pointer - oparg;
-            PyObject *callable = stack_pointer[-1 - oparg];
-            PyObject *null = stack_pointer[-2 - oparg];
+            PyObject **args;
+            PyObject *callable;
+            PyObject *null;
+            args = stack_pointer - oparg;
+            callable = stack_pointer[-1 - oparg];
+            null = stack_pointer[-2 - oparg];
             /* This instruction does the following:
              * 1. Creates the object (by calling ``object.__new__``)
              * 2. Pushes a shim frame to the frame stack (to cleanup after ``__init__``)
@@ -3754,10 +3982,13 @@
              * as it will be checked after start_frame */
             tstate->py_recursion_remaining--;
             goto start_frame;
+            STACK_SHRINK(oparg);
+            STACK_SHRINK(1);
         }
 
         TARGET(EXIT_INIT_CHECK) {
-            PyObject *should_be_none = stack_pointer[-1];
+            PyObject *should_be_none;
+            should_be_none = stack_pointer[-1];
             assert(STACK_LEVEL() == 2);
             if (should_be_none != Py_None) {
                 PyErr_Format(PyExc_TypeError,
@@ -3770,10 +4001,13 @@
         }
 
         TARGET(CALL_BUILTIN_CLASS) {
-            PyObject **args = stack_pointer - oparg;
-            PyObject *callable = stack_pointer[-1 - oparg];
-            PyObject *method = stack_pointer[-2 - oparg];
+            PyObject **args;
+            PyObject *callable;
+            PyObject *method;
             PyObject *res;
+            args = stack_pointer - oparg;
+            callable = stack_pointer[-1 - oparg];
+            method = stack_pointer[-2 - oparg];
             int is_meth = method != NULL;
             int total_args = oparg;
             if (is_meth) {
@@ -3804,10 +4038,13 @@
         }
 
         TARGET(CALL_NO_KW_BUILTIN_O) {
-            PyObject **args = stack_pointer - oparg;
-            PyObject *callable = stack_pointer[-1 - oparg];
-            PyObject *method = stack_pointer[-2 - oparg];
+            PyObject **args;
+            PyObject *callable;
+            PyObject *method;
             PyObject *res;
+            args = stack_pointer - oparg;
+            callable = stack_pointer[-1 - oparg];
+            method = stack_pointer[-2 - oparg];
             /* Builtin METH_O functions */
             ASSERT_KWNAMES_IS_NULL();
             int is_meth = method != NULL;
@@ -3844,10 +4081,13 @@
         }
 
         TARGET(CALL_NO_KW_BUILTIN_FAST) {
-            PyObject **args = stack_pointer - oparg;
-            PyObject *callable = stack_pointer[-1 - oparg];
-            PyObject *method = stack_pointer[-2 - oparg];
+            PyObject **args;
+            PyObject *callable;
+            PyObject *method;
             PyObject *res;
+            args = stack_pointer - oparg;
+            callable = stack_pointer[-1 - oparg];
+            method = stack_pointer[-2 - oparg];
             /* Builtin METH_FASTCALL functions, without keywords */
             ASSERT_KWNAMES_IS_NULL();
             int is_meth = method != NULL;
@@ -3888,10 +4128,13 @@
         }
 
         TARGET(CALL_BUILTIN_FAST_WITH_KEYWORDS) {
-            PyObject **args = stack_pointer - oparg;
-            PyObject *callable = stack_pointer[-1 - oparg];
-            PyObject *method = stack_pointer[-2 - oparg];
+            PyObject **args;
+            PyObject *callable;
+            PyObject *method;
             PyObject *res;
+            args = stack_pointer - oparg;
+            callable = stack_pointer[-1 - oparg];
+            method = stack_pointer[-2 - oparg];
             /* Builtin METH_FASTCALL | METH_KEYWORDS functions */
             int is_meth = method != NULL;
             int total_args = oparg;
@@ -3932,10 +4175,13 @@
         }
 
         TARGET(CALL_NO_KW_LEN) {
-            PyObject **args = stack_pointer - oparg;
-            PyObject *callable = stack_pointer[-1 - oparg];
-            PyObject *method = stack_pointer[-2 - oparg];
+            PyObject **args;
+            PyObject *callable;
+            PyObject *method;
             PyObject *res;
+            args = stack_pointer - oparg;
+            callable = stack_pointer[-1 - oparg];
+            method = stack_pointer[-2 - oparg];
             ASSERT_KWNAMES_IS_NULL();
             /* len(o) */
             int is_meth = method != NULL;
@@ -3968,10 +4214,13 @@
         }
 
         TARGET(CALL_NO_KW_ISINSTANCE) {
-            PyObject **args = stack_pointer - oparg;
-            PyObject *callable = stack_pointer[-1 - oparg];
-            PyObject *method = stack_pointer[-2 - oparg];
+            PyObject **args;
+            PyObject *callable;
+            PyObject *method;
             PyObject *res;
+            args = stack_pointer - oparg;
+            callable = stack_pointer[-1 - oparg];
+            method = stack_pointer[-2 - oparg];
             ASSERT_KWNAMES_IS_NULL();
             /* isinstance(o, o2) */
             int is_meth = method != NULL;
@@ -4006,9 +4255,12 @@
         }
 
         TARGET(CALL_NO_KW_LIST_APPEND) {
-            PyObject **args = stack_pointer - oparg;
-            PyObject *self = stack_pointer[-1 - oparg];
-            PyObject *method = stack_pointer[-2 - oparg];
+            PyObject **args;
+            PyObject *self;
+            PyObject *method;
+            args = stack_pointer - oparg;
+            self = stack_pointer[-1 - oparg];
+            method = stack_pointer[-2 - oparg];
             ASSERT_KWNAMES_IS_NULL();
             assert(oparg == 1);
             assert(method != NULL);
@@ -4026,12 +4278,16 @@
             SKIP_OVER(INLINE_CACHE_ENTRIES_CALL + 1);
             assert(next_instr[-1].op.code == POP_TOP);
             DISPATCH();
+            STACK_SHRINK(oparg);
+            STACK_SHRINK(1);
         }
 
         TARGET(CALL_NO_KW_METHOD_DESCRIPTOR_O) {
-            PyObject **args = stack_pointer - oparg;
-            PyObject *method = stack_pointer[-2 - oparg];
+            PyObject **args;
+            PyObject *method;
             PyObject *res;
+            args = stack_pointer - oparg;
+            method = stack_pointer[-2 - oparg];
             ASSERT_KWNAMES_IS_NULL();
             int is_meth = method != NULL;
             int total_args = oparg;
@@ -4071,9 +4327,11 @@
         }
 
         TARGET(CALL_METHOD_DESCRIPTOR_FAST_WITH_KEYWORDS) {
-            PyObject **args = stack_pointer - oparg;
-            PyObject *method = stack_pointer[-2 - oparg];
+            PyObject **args;
+            PyObject *method;
             PyObject *res;
+            args = stack_pointer - oparg;
+            method = stack_pointer[-2 - oparg];
             int is_meth = method != NULL;
             int total_args = oparg;
             if (is_meth) {
@@ -4111,9 +4369,11 @@
         }
 
         TARGET(CALL_NO_KW_METHOD_DESCRIPTOR_NOARGS) {
-            PyObject **args = stack_pointer - oparg;
-            PyObject *method = stack_pointer[-2 - oparg];
+            PyObject **args;
+            PyObject *method;
             PyObject *res;
+            args = stack_pointer - oparg;
+            method = stack_pointer[-2 - oparg];
             ASSERT_KWNAMES_IS_NULL();
             assert(oparg == 0 || oparg == 1);
             int is_meth = method != NULL;
@@ -4151,9 +4411,11 @@
         }
 
         TARGET(CALL_NO_KW_METHOD_DESCRIPTOR_FAST) {
-            PyObject **args = stack_pointer - oparg;
-            PyObject *method = stack_pointer[-2 - oparg];
+            PyObject **args;
+            PyObject *method;
             PyObject *res;
+            args = stack_pointer - oparg;
+            method = stack_pointer[-2 - oparg];
             ASSERT_KWNAMES_IS_NULL();
             int is_meth = method != NULL;
             int total_args = oparg;
@@ -4195,10 +4457,13 @@
 
         TARGET(CALL_FUNCTION_EX) {
             PREDICTED(CALL_FUNCTION_EX);
-            PyObject *kwargs = oparg & 1 ? stack_pointer[-(oparg & 1 ? 1 : 0)] : NULL;
-            PyObject *callargs = stack_pointer[-1 - (oparg & 1 ? 1 : 0)];
-            PyObject *func = stack_pointer[-2 - (oparg & 1 ? 1 : 0)];
+            PyObject *kwargs = NULL;
+            PyObject *callargs;
+            PyObject *func;
             PyObject *result;
+            if (oparg & 1) { kwargs = stack_pointer[-(oparg & 1 ? 1 : 0)]; }
+            callargs = stack_pointer[-1 - (oparg & 1 ? 1 : 0)];
+            func = stack_pointer[-2 - (oparg & 1 ? 1 : 0)];
             // DICT_MERGE is called before this opcode if there are kwargs.
             // It converts all dict subtypes in kwargs into regular dicts.
             assert(kwargs == NULL || PyDict_CheckExact(kwargs));
@@ -4273,8 +4538,9 @@
         }
 
         TARGET(MAKE_FUNCTION) {
-            PyObject *codeobj = stack_pointer[-1];
+            PyObject *codeobj;
             PyObject *func;
+            codeobj = stack_pointer[-1];
 
             PyFunctionObject *func_obj = (PyFunctionObject *)
                 PyFunction_New(codeobj, GLOBALS());
@@ -4291,8 +4557,10 @@
         }
 
         TARGET(SET_FUNCTION_ATTRIBUTE) {
-            PyObject *func = stack_pointer[-1];
-            PyObject *attr = stack_pointer[-2];
+            PyObject *func;
+            PyObject *attr;
+            func = stack_pointer[-1];
+            attr = stack_pointer[-2];
             assert(PyFunction_Check(func));
             PyFunctionObject *func_obj = (PyFunctionObject *)func;
             switch(oparg) {
@@ -4346,10 +4614,13 @@
         }
 
         TARGET(BUILD_SLICE) {
-            PyObject *step = oparg == 3 ? stack_pointer[-(oparg == 3 ? 1 : 0)] : NULL;
-            PyObject *stop = stack_pointer[-1 - (oparg == 3 ? 1 : 0)];
-            PyObject *start = stack_pointer[-2 - (oparg == 3 ? 1 : 0)];
+            PyObject *step = NULL;
+            PyObject *stop;
+            PyObject *start;
             PyObject *slice;
+            if (oparg == 3) { step = stack_pointer[-(oparg == 3 ? 1 : 0)]; }
+            stop = stack_pointer[-1 - (oparg == 3 ? 1 : 0)];
+            start = stack_pointer[-2 - (oparg == 3 ? 1 : 0)];
             slice = PySlice_New(start, stop, step);
             Py_DECREF(start);
             Py_DECREF(stop);
@@ -4362,8 +4633,9 @@
         }
 
         TARGET(CONVERT_VALUE) {
-            PyObject *value = stack_pointer[-1];
+            PyObject *value;
             PyObject *result;
+            value = stack_pointer[-1];
             convertion_func_ptr  conv_fn;
             assert(oparg >= FVC_STR && oparg <= FVC_ASCII);
             conv_fn = CONVERSION_FUNCTIONS[oparg];
@@ -4375,8 +4647,9 @@
         }
 
         TARGET(FORMAT_SIMPLE) {
-            PyObject *value = stack_pointer[-1];
+            PyObject *value;
             PyObject *res;
+            value = stack_pointer[-1];
             /* If value is a unicode object, then we know the result
              * of format(value) is value itself. */
             if (!PyUnicode_CheckExact(value)) {
@@ -4392,9 +4665,11 @@
         }
 
         TARGET(FORMAT_WITH_SPEC) {
-            PyObject *fmt_spec = stack_pointer[-1];
-            PyObject *value = stack_pointer[-2];
+            PyObject *fmt_spec;
+            PyObject *value;
             PyObject *res;
+            fmt_spec = stack_pointer[-1];
+            value = stack_pointer[-2];
             res = PyObject_Format(value, fmt_spec);
             Py_DECREF(value);
             Py_DECREF(fmt_spec);
@@ -4405,11 +4680,13 @@
         }
 
         TARGET(COPY) {
-            PyObject *bottom = stack_pointer[-1 - (oparg-1)];
+            PyObject *bottom;
             PyObject *top;
+            bottom = stack_pointer[-1 - (oparg-1)];
             assert(oparg > 0);
             top = Py_NewRef(bottom);
             STACK_GROW(1);
+            stack_pointer[-2 - (oparg-1)] = bottom;
             stack_pointer[-1] = top;
             DISPATCH();
         }
@@ -4417,9 +4694,11 @@
         TARGET(BINARY_OP) {
             PREDICTED(BINARY_OP);
             static_assert(INLINE_CACHE_ENTRIES_BINARY_OP == 1, "incorrect cache size");
-            PyObject *rhs = stack_pointer[-1];
-            PyObject *lhs = stack_pointer[-2];
+            PyObject *rhs;
+            PyObject *lhs;
             PyObject *res;
+            rhs = stack_pointer[-1];
+            lhs = stack_pointer[-2];
             #if ENABLE_SPECIALIZATION
             _PyBinaryOpCache *cache = (_PyBinaryOpCache *)next_instr;
             if (ADAPTIVE_COUNTER_IS_ZERO(cache->counter)) {
@@ -4444,11 +4723,13 @@
         }
 
         TARGET(SWAP) {
-            PyObject *top = stack_pointer[-1];
-            PyObject *bottom = stack_pointer[-2 - (oparg-2)];
+            PyObject *top;
+            PyObject *bottom;
+            top = stack_pointer[-1];
+            bottom = stack_pointer[-2 - (oparg-2)];
             assert(oparg >= 2);
-            stack_pointer[-1] = bottom;
             stack_pointer[-2 - (oparg-2)] = top;
+            stack_pointer[-1] = bottom;
             DISPATCH();
         }
 

--- a/Python/generated_cases.c.h
+++ b/Python/generated_cases.c.h
@@ -365,6 +365,7 @@
                 _Py_DECREF_SPECIALIZED(left, (destructor)PyObject_Free);
                 if (res == NULL) goto pop_2_error;
             }
+            next_instr += 1;
             STACK_SHRINK(1);
             stack_pointer[-1] = res;
             DISPATCH();
@@ -389,6 +390,7 @@
                 _Py_DECREF_SPECIALIZED(left, (destructor)PyObject_Free);
                 if (res == NULL) goto pop_2_error;
             }
+            next_instr += 1;
             STACK_SHRINK(1);
             stack_pointer[-1] = res;
             DISPATCH();
@@ -413,6 +415,7 @@
                 _Py_DECREF_SPECIALIZED(left, (destructor)PyObject_Free);
                 if (res == NULL) goto pop_2_error;
             }
+            next_instr += 1;
             STACK_SHRINK(1);
             stack_pointer[-1] = res;
             DISPATCH();
@@ -437,6 +440,7 @@
                     ((PyFloatObject *)right)->ob_fval;
                 DECREF_INPUTS_AND_REUSE_FLOAT(left, right, dres, res);
             }
+            next_instr += 1;
             STACK_SHRINK(1);
             stack_pointer[-1] = res;
             DISPATCH();
@@ -461,6 +465,7 @@
                     ((PyFloatObject *)right)->ob_fval;
                 DECREF_INPUTS_AND_REUSE_FLOAT(left, right, dres, res);
             }
+            next_instr += 1;
             STACK_SHRINK(1);
             stack_pointer[-1] = res;
             DISPATCH();
@@ -485,6 +490,7 @@
                     ((PyFloatObject *)right)->ob_fval;
                 DECREF_INPUTS_AND_REUSE_FLOAT(left, right, dres, res);
             }
+            next_instr += 1;
             STACK_SHRINK(1);
             stack_pointer[-1] = res;
             DISPATCH();
@@ -509,6 +515,7 @@
                 _Py_DECREF_SPECIALIZED(right, _PyUnicode_ExactDealloc);
                 if (res == NULL) goto pop_2_error;
             }
+            next_instr += 1;
             STACK_SHRINK(1);
             stack_pointer[-1] = res;
             DISPATCH();
@@ -1652,6 +1659,7 @@
                 STAT_INC(LOAD_GLOBAL, hit);
                 null = NULL;
             }
+            next_instr += 4;
             STACK_GROW(1);
             STACK_GROW(((oparg & 1) ? 1 : 0));
             if (oparg & 1) { stack_pointer[-1 - (oparg & 1 ? 1 : 0)] = null; }
@@ -1689,6 +1697,7 @@
                 STAT_INC(LOAD_GLOBAL, hit);
                 null = NULL;
             }
+            next_instr += 4;
             STACK_GROW(1);
             STACK_GROW(((oparg & 1) ? 1 : 0));
             if (oparg & 1) { stack_pointer[-1 - (oparg & 1 ? 1 : 0)] = null; }
@@ -2229,6 +2238,7 @@
                 res2 = NULL;
                 Py_DECREF(owner);
             }
+            next_instr += 9;
             STACK_GROW(1);
             STACK_GROW(((oparg & 1) ? 1 : 0));
             if (oparg & 1) { stack_pointer[-1 - (oparg & 1 ? 1 : 0)] = res2; }
@@ -3051,6 +3061,7 @@
                 assert(it->it_index < PyList_GET_SIZE(seq));
                 next = Py_NewRef(PyList_GET_ITEM(seq, it->it_index++));
             }
+            next_instr += 1;
             STACK_GROW(2);
             stack_pointer[-2] = iter;
             stack_pointer[-1] = next;
@@ -3093,6 +3104,7 @@
                 assert(it->it_index < PyTuple_GET_SIZE(seq));
                 next = Py_NewRef(PyTuple_GET_ITEM(seq, it->it_index++));
             }
+            next_instr += 1;
             STACK_GROW(2);
             stack_pointer[-2] = iter;
             stack_pointer[-1] = next;
@@ -3133,6 +3145,7 @@
                 next = PyLong_FromLong(value);
                 if (next == NULL) goto error;
             }
+            next_instr += 1;
             STACK_GROW(2);
             stack_pointer[-2] = iter;
             stack_pointer[-1] = next;

--- a/Python/generated_cases.c.h
+++ b/Python/generated_cases.c.h
@@ -2239,7 +2239,6 @@
                 Py_DECREF(owner);
             }
             next_instr += 9;
-            STACK_GROW(1);
             STACK_GROW(((oparg & 1) ? 1 : 0));
             if (oparg & 1) { stack_pointer[-1 - (oparg & 1 ? 1 : 0)] = res2; }
             stack_pointer[-1] = res;
@@ -3062,7 +3061,7 @@
                 next = Py_NewRef(PyList_GET_ITEM(seq, it->it_index++));
             }
             next_instr += 1;
-            STACK_GROW(2);
+            STACK_GROW(1);
             stack_pointer[-2] = iter;
             stack_pointer[-1] = next;
             DISPATCH();
@@ -3105,7 +3104,7 @@
                 next = Py_NewRef(PyTuple_GET_ITEM(seq, it->it_index++));
             }
             next_instr += 1;
-            STACK_GROW(2);
+            STACK_GROW(1);
             stack_pointer[-2] = iter;
             stack_pointer[-1] = next;
             DISPATCH();
@@ -3146,7 +3145,7 @@
                 if (next == NULL) goto error;
             }
             next_instr += 1;
-            STACK_GROW(2);
+            STACK_GROW(1);
             stack_pointer[-2] = iter;
             stack_pointer[-1] = next;
             DISPATCH();

--- a/Python/generated_cases.c.h
+++ b/Python/generated_cases.c.h
@@ -1655,7 +1655,7 @@
             STACK_GROW(1);
             STACK_GROW(((oparg & 1) ? 1 : 0));
             stack_pointer[-1] = v;
-            if (oparg & 1) { stack_pointer[-(1 + ((oparg & 1) ? 1 : 0))] = null; }
+            if (oparg & 1) { stack_pointer[-1 - (oparg & 1 ? 1 : 0)] = null; }
             next_instr += 4;
             DISPATCH();
         }
@@ -2112,7 +2112,7 @@
             STACK_SHRINK(2);
             STACK_GROW(((oparg & 1) ? 1 : 0));
             stack_pointer[-1] = res;
-            if (oparg & 1) { stack_pointer[-(1 + ((oparg & 1) ? 1 : 0))] = res2; }
+            if (oparg & 1) { stack_pointer[-1 - (oparg & 1 ? 1 : 0)] = res2; }
             next_instr += 1;
             DISPATCH();
         }
@@ -2136,7 +2136,7 @@
             STACK_SHRINK(2);
             STACK_GROW(((oparg & 1) ? 1 : 0));
             stack_pointer[-1] = res;
-            if (oparg & 1) { stack_pointer[-(1 + ((oparg & 1) ? 1 : 0))] = res2; }
+            if (oparg & 1) { stack_pointer[-1 - (oparg & 1 ? 1 : 0)] = res2; }
             next_instr += 1;
             DISPATCH();
         }
@@ -2229,7 +2229,7 @@
             }
             STACK_GROW(((oparg & 1) ? 1 : 0));
             stack_pointer[-1] = res;
-            if (oparg & 1) { stack_pointer[-(1 + ((oparg & 1) ? 1 : 0))] = res2; }
+            if (oparg & 1) { stack_pointer[-1 - (oparg & 1 ? 1 : 0)] = res2; }
             next_instr += 9;
             DISPATCH();
         }
@@ -2296,7 +2296,7 @@
             Py_DECREF(owner);
             STACK_GROW(((oparg & 1) ? 1 : 0));
             stack_pointer[-1] = res;
-            if (oparg & 1) { stack_pointer[-(1 + ((oparg & 1) ? 1 : 0))] = res2; }
+            if (oparg & 1) { stack_pointer[-1 - (oparg & 1 ? 1 : 0)] = res2; }
             next_instr += 9;
             DISPATCH();
         }
@@ -2336,7 +2336,7 @@
             Py_DECREF(owner);
             STACK_GROW(((oparg & 1) ? 1 : 0));
             stack_pointer[-1] = res;
-            if (oparg & 1) { stack_pointer[-(1 + ((oparg & 1) ? 1 : 0))] = res2; }
+            if (oparg & 1) { stack_pointer[-1 - (oparg & 1 ? 1 : 0)] = res2; }
             next_instr += 9;
             DISPATCH();
         }
@@ -2359,7 +2359,7 @@
             Py_DECREF(owner);
             STACK_GROW(((oparg & 1) ? 1 : 0));
             stack_pointer[-1] = res;
-            if (oparg & 1) { stack_pointer[-(1 + ((oparg & 1) ? 1 : 0))] = res2; }
+            if (oparg & 1) { stack_pointer[-1 - (oparg & 1 ? 1 : 0)] = res2; }
             next_instr += 9;
             DISPATCH();
         }
@@ -2384,7 +2384,7 @@
             Py_DECREF(cls);
             STACK_GROW(((oparg & 1) ? 1 : 0));
             stack_pointer[-1] = res;
-            if (oparg & 1) { stack_pointer[-(1 + ((oparg & 1) ? 1 : 0))] = res2; }
+            if (oparg & 1) { stack_pointer[-1 - (oparg & 1 ? 1 : 0)] = res2; }
             next_instr += 9;
             DISPATCH();
         }
@@ -3344,7 +3344,7 @@
 
         TARGET(LOAD_ATTR_METHOD_WITH_VALUES) {
             PyObject *self = stack_pointer[-1];
-            PyObject *res2 = NULL;
+            PyObject *res2;
             PyObject *res;
             uint32_t type_version = read_u32(&next_instr[1].cache);
             uint32_t keys_version = read_u32(&next_instr[3].cache);
@@ -3374,7 +3374,7 @@
 
         TARGET(LOAD_ATTR_METHOD_NO_DICT) {
             PyObject *self = stack_pointer[-1];
-            PyObject *res2 = NULL;
+            PyObject *res2;
             PyObject *res;
             uint32_t type_version = read_u32(&next_instr[1].cache);
             PyObject *descr = read_obj(&next_instr[5].cache);
@@ -3440,7 +3440,7 @@
 
         TARGET(LOAD_ATTR_METHOD_LAZY_DICT) {
             PyObject *self = stack_pointer[-1];
-            PyObject *res2 = NULL;
+            PyObject *res2;
             PyObject *res;
             uint32_t type_version = read_u32(&next_instr[1].cache);
             PyObject *descr = read_obj(&next_instr[5].cache);
@@ -4486,7 +4486,7 @@
             PyObject *bottom = stack_pointer[-2 - (oparg-2)];
             assert(oparg >= 2);
             stack_pointer[-1] = bottom;
-            stack_pointer[-(2 + (oparg-2))] = top;
+            stack_pointer[-2 - (oparg-2)] = top;
             DISPATCH();
         }
 

--- a/Python/generated_cases.c.h
+++ b/Python/generated_cases.c.h
@@ -151,14 +151,15 @@
         }
 
         TARGET(END_FOR) {
-            PyObject *_tmp_1 = stack_pointer[-1];
-            PyObject *_tmp_2 = stack_pointer[-2];
+            PyObject *value;
+            // POP_TOP
+            value = stack_pointer[-1];
             {
-                PyObject *value = _tmp_1;
                 Py_DECREF(value);
             }
+            // POP_TOP
+            value = stack_pointer[-2];
             {
-                PyObject *value = _tmp_2;
                 Py_DECREF(value);
             }
             STACK_SHRINK(2);
@@ -346,215 +347,185 @@
         }
 
         TARGET(BINARY_OP_MULTIPLY_INT) {
-            PyObject *_tmp_1 = stack_pointer[-1];
-            PyObject *_tmp_2 = stack_pointer[-2];
+            PyObject *right;
+            PyObject *left;
+            PyObject *res;
+            // _GUARD_BOTH_INT
+            right = stack_pointer[-1];
+            left = stack_pointer[-2];
             {
-                PyObject *right = _tmp_1;
-                PyObject *left = _tmp_2;
                 DEOPT_IF(!PyLong_CheckExact(left), BINARY_OP);
                 DEOPT_IF(!PyLong_CheckExact(right), BINARY_OP);
-                _tmp_2 = left;
-                _tmp_1 = right;
             }
+            // _BINARY_OP_MULTIPLY_INT
             {
-                PyObject *right = _tmp_1;
-                PyObject *left = _tmp_2;
-                PyObject *res;
                 STAT_INC(BINARY_OP, hit);
                 res = _PyLong_Multiply((PyLongObject *)left, (PyLongObject *)right);
                 _Py_DECREF_SPECIALIZED(right, (destructor)PyObject_Free);
                 _Py_DECREF_SPECIALIZED(left, (destructor)PyObject_Free);
                 if (res == NULL) goto pop_2_error;
-                _tmp_2 = res;
             }
-            next_instr += 1;
             STACK_SHRINK(1);
-            stack_pointer[-1] = _tmp_2;
+            stack_pointer[-1] = res;
             DISPATCH();
         }
 
         TARGET(BINARY_OP_ADD_INT) {
-            PyObject *_tmp_1 = stack_pointer[-1];
-            PyObject *_tmp_2 = stack_pointer[-2];
+            PyObject *right;
+            PyObject *left;
+            PyObject *res;
+            // _GUARD_BOTH_INT
+            right = stack_pointer[-1];
+            left = stack_pointer[-2];
             {
-                PyObject *right = _tmp_1;
-                PyObject *left = _tmp_2;
                 DEOPT_IF(!PyLong_CheckExact(left), BINARY_OP);
                 DEOPT_IF(!PyLong_CheckExact(right), BINARY_OP);
-                _tmp_2 = left;
-                _tmp_1 = right;
             }
+            // _BINARY_OP_ADD_INT
             {
-                PyObject *right = _tmp_1;
-                PyObject *left = _tmp_2;
-                PyObject *res;
                 STAT_INC(BINARY_OP, hit);
                 res = _PyLong_Add((PyLongObject *)left, (PyLongObject *)right);
                 _Py_DECREF_SPECIALIZED(right, (destructor)PyObject_Free);
                 _Py_DECREF_SPECIALIZED(left, (destructor)PyObject_Free);
                 if (res == NULL) goto pop_2_error;
-                _tmp_2 = res;
             }
-            next_instr += 1;
             STACK_SHRINK(1);
-            stack_pointer[-1] = _tmp_2;
+            stack_pointer[-1] = res;
             DISPATCH();
         }
 
         TARGET(BINARY_OP_SUBTRACT_INT) {
-            PyObject *_tmp_1 = stack_pointer[-1];
-            PyObject *_tmp_2 = stack_pointer[-2];
+            PyObject *right;
+            PyObject *left;
+            PyObject *res;
+            // _GUARD_BOTH_INT
+            right = stack_pointer[-1];
+            left = stack_pointer[-2];
             {
-                PyObject *right = _tmp_1;
-                PyObject *left = _tmp_2;
                 DEOPT_IF(!PyLong_CheckExact(left), BINARY_OP);
                 DEOPT_IF(!PyLong_CheckExact(right), BINARY_OP);
-                _tmp_2 = left;
-                _tmp_1 = right;
             }
+            // _BINARY_OP_SUBTRACT_INT
             {
-                PyObject *right = _tmp_1;
-                PyObject *left = _tmp_2;
-                PyObject *res;
                 STAT_INC(BINARY_OP, hit);
                 res = _PyLong_Subtract((PyLongObject *)left, (PyLongObject *)right);
                 _Py_DECREF_SPECIALIZED(right, (destructor)PyObject_Free);
                 _Py_DECREF_SPECIALIZED(left, (destructor)PyObject_Free);
                 if (res == NULL) goto pop_2_error;
-                _tmp_2 = res;
             }
-            next_instr += 1;
             STACK_SHRINK(1);
-            stack_pointer[-1] = _tmp_2;
+            stack_pointer[-1] = res;
             DISPATCH();
         }
 
         TARGET(BINARY_OP_MULTIPLY_FLOAT) {
-            PyObject *_tmp_1 = stack_pointer[-1];
-            PyObject *_tmp_2 = stack_pointer[-2];
+            PyObject *right;
+            PyObject *left;
+            PyObject *res;
+            // _GUARD_BOTH_FLOAT
+            right = stack_pointer[-1];
+            left = stack_pointer[-2];
             {
-                PyObject *right = _tmp_1;
-                PyObject *left = _tmp_2;
                 DEOPT_IF(!PyFloat_CheckExact(left), BINARY_OP);
                 DEOPT_IF(!PyFloat_CheckExact(right), BINARY_OP);
-                _tmp_2 = left;
-                _tmp_1 = right;
             }
+            // _BINARY_OP_MULTIPLY_FLOAT
             {
-                PyObject *right = _tmp_1;
-                PyObject *left = _tmp_2;
-                PyObject *res;
                 STAT_INC(BINARY_OP, hit);
                 double dres =
                     ((PyFloatObject *)left)->ob_fval *
                     ((PyFloatObject *)right)->ob_fval;
                 DECREF_INPUTS_AND_REUSE_FLOAT(left, right, dres, res);
-                _tmp_2 = res;
             }
-            next_instr += 1;
             STACK_SHRINK(1);
-            stack_pointer[-1] = _tmp_2;
+            stack_pointer[-1] = res;
             DISPATCH();
         }
 
         TARGET(BINARY_OP_ADD_FLOAT) {
-            PyObject *_tmp_1 = stack_pointer[-1];
-            PyObject *_tmp_2 = stack_pointer[-2];
+            PyObject *right;
+            PyObject *left;
+            PyObject *res;
+            // _GUARD_BOTH_FLOAT
+            right = stack_pointer[-1];
+            left = stack_pointer[-2];
             {
-                PyObject *right = _tmp_1;
-                PyObject *left = _tmp_2;
                 DEOPT_IF(!PyFloat_CheckExact(left), BINARY_OP);
                 DEOPT_IF(!PyFloat_CheckExact(right), BINARY_OP);
-                _tmp_2 = left;
-                _tmp_1 = right;
             }
+            // _BINARY_OP_ADD_FLOAT
             {
-                PyObject *right = _tmp_1;
-                PyObject *left = _tmp_2;
-                PyObject *res;
                 STAT_INC(BINARY_OP, hit);
                 double dres =
                     ((PyFloatObject *)left)->ob_fval +
                     ((PyFloatObject *)right)->ob_fval;
                 DECREF_INPUTS_AND_REUSE_FLOAT(left, right, dres, res);
-                _tmp_2 = res;
             }
-            next_instr += 1;
             STACK_SHRINK(1);
-            stack_pointer[-1] = _tmp_2;
+            stack_pointer[-1] = res;
             DISPATCH();
         }
 
         TARGET(BINARY_OP_SUBTRACT_FLOAT) {
-            PyObject *_tmp_1 = stack_pointer[-1];
-            PyObject *_tmp_2 = stack_pointer[-2];
+            PyObject *right;
+            PyObject *left;
+            PyObject *res;
+            // _GUARD_BOTH_FLOAT
+            right = stack_pointer[-1];
+            left = stack_pointer[-2];
             {
-                PyObject *right = _tmp_1;
-                PyObject *left = _tmp_2;
                 DEOPT_IF(!PyFloat_CheckExact(left), BINARY_OP);
                 DEOPT_IF(!PyFloat_CheckExact(right), BINARY_OP);
-                _tmp_2 = left;
-                _tmp_1 = right;
             }
+            // _BINARY_OP_SUBTRACT_FLOAT
             {
-                PyObject *right = _tmp_1;
-                PyObject *left = _tmp_2;
-                PyObject *res;
                 STAT_INC(BINARY_OP, hit);
                 double dres =
                     ((PyFloatObject *)left)->ob_fval -
                     ((PyFloatObject *)right)->ob_fval;
                 DECREF_INPUTS_AND_REUSE_FLOAT(left, right, dres, res);
-                _tmp_2 = res;
             }
-            next_instr += 1;
             STACK_SHRINK(1);
-            stack_pointer[-1] = _tmp_2;
+            stack_pointer[-1] = res;
             DISPATCH();
         }
 
         TARGET(BINARY_OP_ADD_UNICODE) {
-            PyObject *_tmp_1 = stack_pointer[-1];
-            PyObject *_tmp_2 = stack_pointer[-2];
+            PyObject *right;
+            PyObject *left;
+            PyObject *res;
+            // _GUARD_BOTH_UNICODE
+            right = stack_pointer[-1];
+            left = stack_pointer[-2];
             {
-                PyObject *right = _tmp_1;
-                PyObject *left = _tmp_2;
                 DEOPT_IF(!PyUnicode_CheckExact(left), BINARY_OP);
                 DEOPT_IF(!PyUnicode_CheckExact(right), BINARY_OP);
-                _tmp_2 = left;
-                _tmp_1 = right;
             }
+            // _BINARY_OP_ADD_UNICODE
             {
-                PyObject *right = _tmp_1;
-                PyObject *left = _tmp_2;
-                PyObject *res;
                 STAT_INC(BINARY_OP, hit);
                 res = PyUnicode_Concat(left, right);
                 _Py_DECREF_SPECIALIZED(left, _PyUnicode_ExactDealloc);
                 _Py_DECREF_SPECIALIZED(right, _PyUnicode_ExactDealloc);
                 if (res == NULL) goto pop_2_error;
-                _tmp_2 = res;
             }
-            next_instr += 1;
             STACK_SHRINK(1);
-            stack_pointer[-1] = _tmp_2;
+            stack_pointer[-1] = res;
             DISPATCH();
         }
 
         TARGET(BINARY_OP_INPLACE_ADD_UNICODE) {
-            PyObject *_tmp_1 = stack_pointer[-1];
-            PyObject *_tmp_2 = stack_pointer[-2];
+            PyObject *right;
+            PyObject *left;
+            // _GUARD_BOTH_UNICODE
+            right = stack_pointer[-1];
+            left = stack_pointer[-2];
             {
-                PyObject *right = _tmp_1;
-                PyObject *left = _tmp_2;
                 DEOPT_IF(!PyUnicode_CheckExact(left), BINARY_OP);
                 DEOPT_IF(!PyUnicode_CheckExact(right), BINARY_OP);
-                _tmp_2 = left;
-                _tmp_1 = right;
             }
+            // _BINARY_OP_INPLACE_ADD_UNICODE
             {
-                PyObject *right = _tmp_1;
-                PyObject *left = _tmp_2;
                 _Py_CODEUNIT true_next = next_instr[INLINE_CACHE_ENTRIES_BINARY_OP];
                 assert(true_next.op.code == STORE_FAST);
                 PyObject **target_local = &GETLOCAL(true_next.op.arg);
@@ -1498,9 +1469,9 @@
         }
 
         TARGET(LOAD_LOCALS) {
-            PyObject *_tmp_1;
+            PyObject *locals;
+            // _LOAD_LOCALS
             {
-                PyObject *locals;
                 locals = LOCALS();
                 if (locals == NULL) {
                     _PyErr_SetString(tstate, PyExc_SystemError,
@@ -1508,17 +1479,18 @@
                     if (true) goto error;
                 }
                 Py_INCREF(locals);
-                _tmp_1 = locals;
             }
             STACK_GROW(1);
-            stack_pointer[-1] = _tmp_1;
+            stack_pointer[-1] = locals;
             DISPATCH();
         }
 
         TARGET(LOAD_NAME) {
-            PyObject *_tmp_1;
+            PyObject *locals;
+            PyObject *mod_or_class_dict;
+            PyObject *v;
+            // _LOAD_LOCALS
             {
-                PyObject *locals;
                 locals = LOCALS();
                 if (locals == NULL) {
                     _PyErr_SetString(tstate, PyExc_SystemError,
@@ -1526,11 +1498,10 @@
                     if (true) goto error;
                 }
                 Py_INCREF(locals);
-                _tmp_1 = locals;
             }
+            // _LOAD_FROM_DICT_OR_GLOBALS
+            mod_or_class_dict = locals;
             {
-                PyObject *mod_or_class_dict = _tmp_1;
-                PyObject *v;
                 PyObject *name = GETITEM(FRAME_CO_NAMES, oparg);
                 if (PyMapping_GetOptionalItem(mod_or_class_dict, name, &v) < 0) {
                     Py_DECREF(mod_or_class_dict);
@@ -1557,18 +1528,18 @@
                         }
                     }
                 }
-                _tmp_1 = v;
             }
             STACK_GROW(1);
-            stack_pointer[-1] = _tmp_1;
+            stack_pointer[-1] = v;
             DISPATCH();
         }
 
         TARGET(LOAD_FROM_DICT_OR_GLOBALS) {
-            PyObject *_tmp_1 = stack_pointer[-1];
+            PyObject *mod_or_class_dict;
+            PyObject *v;
+            // _LOAD_FROM_DICT_OR_GLOBALS
+            mod_or_class_dict = stack_pointer[-1];
             {
-                PyObject *mod_or_class_dict = _tmp_1;
-                PyObject *v;
                 PyObject *name = GETITEM(FRAME_CO_NAMES, oparg);
                 if (PyMapping_GetOptionalItem(mod_or_class_dict, name, &v) < 0) {
                     Py_DECREF(mod_or_class_dict);
@@ -1595,9 +1566,8 @@
                         }
                     }
                 }
-                _tmp_1 = v;
             }
-            stack_pointer[-1] = _tmp_1;
+            stack_pointer[-1] = v;
             DISPATCH();
         }
 
@@ -1661,19 +1631,17 @@
         }
 
         TARGET(LOAD_GLOBAL_MODULE) {
-            PyObject *_tmp_1;
-            PyObject *_tmp_2;
+            PyObject *null = NULL;
+            PyObject *res;
+            // _GUARD_GLOBALS_VERSION
             {
-                uint16_t version = read_u16(&next_instr[1].cache);
                 PyDictObject *dict = (PyDictObject *)GLOBALS();
                 DEOPT_IF(!PyDict_CheckExact(dict), LOAD_GLOBAL);
                 DEOPT_IF(dict->ma_keys->dk_version != version, LOAD_GLOBAL);
                 assert(DK_IS_UNICODE(dict->ma_keys));
             }
+            // _LOAD_GLOBAL_MODULE
             {
-                PyObject *null = NULL;
-                PyObject *res;
-                uint16_t index = read_u16(&next_instr[3].cache);
                 PyDictObject *dict = (PyDictObject *)GLOBALS();
                 PyDictUnicodeEntry *entries = DK_UNICODE_ENTRIES(dict->ma_keys);
                 res = entries[index].me_value;
@@ -1681,38 +1649,33 @@
                 Py_INCREF(res);
                 STAT_INC(LOAD_GLOBAL, hit);
                 null = NULL;
-                if (oparg & 1) { _tmp_2 = null; }
-                _tmp_1 = res;
             }
-            next_instr += 4;
             STACK_GROW(1);
             STACK_GROW(((oparg & 1) ? 1 : 0));
-            stack_pointer[-1] = _tmp_1;
-            if (oparg & 1) { stack_pointer[-2] = _tmp_2; }
+            if (oparg & 1) { stack_pointer[-1 - (oparg & 1 ? 1 : 0)] = null; }
+            stack_pointer[-1] = res;
             DISPATCH();
         }
 
         TARGET(LOAD_GLOBAL_BUILTIN) {
-            PyObject *_tmp_1;
-            PyObject *_tmp_2;
+            PyObject *null = NULL;
+            PyObject *res;
+            // _GUARD_GLOBALS_VERSION
             {
-                uint16_t version = read_u16(&next_instr[1].cache);
                 PyDictObject *dict = (PyDictObject *)GLOBALS();
                 DEOPT_IF(!PyDict_CheckExact(dict), LOAD_GLOBAL);
                 DEOPT_IF(dict->ma_keys->dk_version != version, LOAD_GLOBAL);
                 assert(DK_IS_UNICODE(dict->ma_keys));
             }
+            // _GUARD_BUILTINS_VERSION
             {
-                uint16_t version = read_u16(&next_instr[2].cache);
                 PyDictObject *dict = (PyDictObject *)BUILTINS();
                 DEOPT_IF(!PyDict_CheckExact(dict), LOAD_GLOBAL);
                 DEOPT_IF(dict->ma_keys->dk_version != version, LOAD_GLOBAL);
                 assert(DK_IS_UNICODE(dict->ma_keys));
             }
+            // _LOAD_GLOBAL_BUILTINS
             {
-                PyObject *null = NULL;
-                PyObject *res;
-                uint16_t index = read_u16(&next_instr[3].cache);
                 PyDictObject *bdict = (PyDictObject *)BUILTINS();
                 PyDictUnicodeEntry *entries = DK_UNICODE_ENTRIES(bdict->ma_keys);
                 res = entries[index].me_value;
@@ -1720,14 +1683,11 @@
                 Py_INCREF(res);
                 STAT_INC(LOAD_GLOBAL, hit);
                 null = NULL;
-                if (oparg & 1) { _tmp_2 = null; }
-                _tmp_1 = res;
             }
-            next_instr += 4;
             STACK_GROW(1);
             STACK_GROW(((oparg & 1) ? 1 : 0));
-            stack_pointer[-1] = _tmp_1;
-            if (oparg & 1) { stack_pointer[-2] = _tmp_2; }
+            if (oparg & 1) { stack_pointer[-1 - (oparg & 1 ? 1 : 0)] = null; }
+            stack_pointer[-1] = res;
             DISPATCH();
         }
 
@@ -2235,29 +2195,25 @@
         }
 
         TARGET(LOAD_ATTR_INSTANCE_VALUE) {
-            PyObject *_tmp_1;
-            PyObject *_tmp_2 = stack_pointer[-1];
+            PyObject *owner;
+            PyObject *res2 = NULL;
+            PyObject *res;
+            // _GUARD_TYPE_VERSION
+            owner = stack_pointer[-1];
             {
-                PyObject *owner = _tmp_2;
-                uint32_t type_version = read_u32(&next_instr[1].cache);
                 PyTypeObject *tp = Py_TYPE(owner);
                 assert(type_version != 0);
                 DEOPT_IF(tp->tp_version_tag != type_version, LOAD_ATTR);
-                _tmp_2 = owner;
             }
+            // _CHECK_MANAGED_OBJECT_HAS_VALUES
             {
-                PyObject *owner = _tmp_2;
                 assert(Py_TYPE(owner)->tp_dictoffset < 0);
                 assert(Py_TYPE(owner)->tp_flags & Py_TPFLAGS_MANAGED_DICT);
                 PyDictOrValues dorv = *_PyObject_DictOrValuesPointer(owner);
                 DEOPT_IF(!_PyDictOrValues_IsValues(dorv), LOAD_ATTR);
-                _tmp_2 = owner;
             }
+            // _LOAD_ATTR_INSTANCE_VALUE
             {
-                PyObject *owner = _tmp_2;
-                PyObject *res2 = NULL;
-                PyObject *res;
-                uint16_t index = read_u16(&next_instr[3].cache);
                 PyDictOrValues dorv = *_PyObject_DictOrValuesPointer(owner);
                 res = _PyDictOrValues_GetValues(dorv)->values[index];
                 DEOPT_IF(res == NULL, LOAD_ATTR);
@@ -2265,13 +2221,11 @@
                 Py_INCREF(res);
                 res2 = NULL;
                 Py_DECREF(owner);
-                if (oparg & 1) { _tmp_2 = res2; }
-                _tmp_1 = res;
             }
-            next_instr += 9;
+            STACK_GROW(1);
             STACK_GROW(((oparg & 1) ? 1 : 0));
-            stack_pointer[-1] = _tmp_1;
-            if (oparg & 1) { stack_pointer[-2] = _tmp_2; }
+            if (oparg & 1) { stack_pointer[-1 - (oparg & 1 ? 1 : 0)] = res2; }
+            stack_pointer[-1] = res;
             DISPATCH();
         }
 
@@ -2813,10 +2767,12 @@
         }
 
         TARGET(POP_JUMP_IF_NONE) {
-            PyObject *_tmp_1 = stack_pointer[-1];
+            PyObject *value;
+            PyObject *b;
+            PyObject *cond;
+            // IS_NONE
+            value = stack_pointer[-1];
             {
-                PyObject *value = _tmp_1;
-                PyObject *b;
                 if (Py_IsNone(value)) {
                     b = Py_True;
                 }
@@ -2824,10 +2780,10 @@
                     b = Py_False;
                     Py_DECREF(value);
                 }
-                _tmp_1 = b;
             }
+            // POP_JUMP_IF_TRUE
+            cond = b;
             {
-                PyObject *cond = _tmp_1;
                 assert(PyBool_Check(cond));
                 JUMPBY(oparg * Py_IsTrue(cond));
             }
@@ -2836,10 +2792,12 @@
         }
 
         TARGET(POP_JUMP_IF_NOT_NONE) {
-            PyObject *_tmp_1 = stack_pointer[-1];
+            PyObject *value;
+            PyObject *b;
+            PyObject *cond;
+            // IS_NONE
+            value = stack_pointer[-1];
             {
-                PyObject *value = _tmp_1;
-                PyObject *b;
                 if (Py_IsNone(value)) {
                     b = Py_True;
                 }
@@ -2847,10 +2805,10 @@
                     b = Py_False;
                     Py_DECREF(value);
                 }
-                _tmp_1 = b;
             }
+            // POP_JUMP_IF_FALSE
+            cond = b;
             {
-                PyObject *cond = _tmp_1;
                 assert(PyBool_Check(cond));
                 JUMPBY(oparg * Py_IsFalse(cond));
             }
@@ -3051,15 +3009,15 @@
         }
 
         TARGET(FOR_ITER_LIST) {
-            PyObject *_tmp_1;
-            PyObject *_tmp_2 = stack_pointer[-1];
+            PyObject *iter;
+            PyObject *next;
+            // _ITER_CHECK_LIST
+            iter = stack_pointer[-1];
             {
-                PyObject *iter = _tmp_2;
                 DEOPT_IF(Py_TYPE(iter) != &PyListIter_Type, FOR_ITER);
-                _tmp_2 = iter;
             }
+            // _ITER_JUMP_LIST
             {
-                PyObject *iter = _tmp_2;
                 _PyListIterObject *it = (_PyListIterObject *)iter;
                 assert(Py_TYPE(iter) == &PyListIter_Type);
                 STAT_INC(FOR_ITER, hit);
@@ -3076,37 +3034,32 @@
                     JUMPBY(oparg + 1);
                     DISPATCH();
                 }
-                _tmp_2 = iter;
             }
+            // _ITER_NEXT_LIST
             {
-                PyObject *iter = _tmp_2;
-                PyObject *next;
                 _PyListIterObject *it = (_PyListIterObject *)iter;
                 assert(Py_TYPE(iter) == &PyListIter_Type);
                 PyListObject *seq = it->it_seq;
                 assert(seq);
                 assert(it->it_index < PyList_GET_SIZE(seq));
                 next = Py_NewRef(PyList_GET_ITEM(seq, it->it_index++));
-                _tmp_2 = iter;
-                _tmp_1 = next;
             }
-            next_instr += 1;
-            STACK_GROW(1);
-            stack_pointer[-1] = _tmp_1;
-            stack_pointer[-2] = _tmp_2;
+            STACK_GROW(2);
+            stack_pointer[-2] = iter;
+            stack_pointer[-1] = next;
             DISPATCH();
         }
 
         TARGET(FOR_ITER_TUPLE) {
-            PyObject *_tmp_1;
-            PyObject *_tmp_2 = stack_pointer[-1];
+            PyObject *iter;
+            PyObject *next;
+            // _ITER_CHECK_TUPLE
+            iter = stack_pointer[-1];
             {
-                PyObject *iter = _tmp_2;
                 DEOPT_IF(Py_TYPE(iter) != &PyTupleIter_Type, FOR_ITER);
-                _tmp_2 = iter;
             }
+            // _ITER_JUMP_TUPLE
             {
-                PyObject *iter = _tmp_2;
                 _PyTupleIterObject *it = (_PyTupleIterObject *)iter;
                 assert(Py_TYPE(iter) == &PyTupleIter_Type);
                 STAT_INC(FOR_ITER, hit);
@@ -3123,38 +3076,33 @@
                     JUMPBY(oparg + 1);
                     DISPATCH();
                 }
-                _tmp_2 = iter;
             }
+            // _ITER_NEXT_TUPLE
             {
-                PyObject *iter = _tmp_2;
-                PyObject *next;
                 _PyTupleIterObject *it = (_PyTupleIterObject *)iter;
                 assert(Py_TYPE(iter) == &PyTupleIter_Type);
                 PyTupleObject *seq = it->it_seq;
                 assert(seq);
                 assert(it->it_index < PyTuple_GET_SIZE(seq));
                 next = Py_NewRef(PyTuple_GET_ITEM(seq, it->it_index++));
-                _tmp_2 = iter;
-                _tmp_1 = next;
             }
-            next_instr += 1;
-            STACK_GROW(1);
-            stack_pointer[-1] = _tmp_1;
-            stack_pointer[-2] = _tmp_2;
+            STACK_GROW(2);
+            stack_pointer[-2] = iter;
+            stack_pointer[-1] = next;
             DISPATCH();
         }
 
         TARGET(FOR_ITER_RANGE) {
-            PyObject *_tmp_1;
-            PyObject *_tmp_2 = stack_pointer[-1];
+            PyObject *iter;
+            PyObject *next;
+            // _ITER_CHECK_RANGE
+            iter = stack_pointer[-1];
             {
-                PyObject *iter = _tmp_2;
                 _PyRangeIterObject *r = (_PyRangeIterObject *)iter;
                 DEOPT_IF(Py_TYPE(r) != &PyRangeIter_Type, FOR_ITER);
-                _tmp_2 = iter;
             }
+            // _ITER_JUMP_RANGE
             {
-                PyObject *iter = _tmp_2;
                 _PyRangeIterObject *r = (_PyRangeIterObject *)iter;
                 assert(Py_TYPE(r) == &PyRangeIter_Type);
                 STAT_INC(FOR_ITER, hit);
@@ -3166,11 +3114,9 @@
                     JUMPBY(oparg + 1);
                     DISPATCH();
                 }
-                _tmp_2 = iter;
             }
+            // _ITER_NEXT_RANGE
             {
-                PyObject *iter = _tmp_2;
-                PyObject *next;
                 _PyRangeIterObject *r = (_PyRangeIterObject *)iter;
                 assert(Py_TYPE(r) == &PyRangeIter_Type);
                 assert(r->len > 0);
@@ -3179,13 +3125,10 @@
                 r->len--;
                 next = PyLong_FromLong(value);
                 if (next == NULL) goto error;
-                _tmp_2 = iter;
-                _tmp_1 = next;
             }
-            next_instr += 1;
-            STACK_GROW(1);
-            stack_pointer[-1] = _tmp_1;
-            stack_pointer[-2] = _tmp_2;
+            STACK_GROW(2);
+            stack_pointer[-2] = iter;
+            stack_pointer[-1] = next;
             DISPATCH();
         }
 

--- a/Tools/cases_generator/analysis.py
+++ b/Tools/cases_generator/analysis.py
@@ -460,7 +460,7 @@ class Analyzer:
                         eff.size for eff in instr.input_effects + instr.output_effects
                     ):
                         # TODO: Eventually this will be needed, at least for macros.
-                        self.error(
+                        self.warning(
                             f"Instruction {instr.name!r} has variable-sized stack effect, "
                             "which are not supported in macro instructions",
                             instr.inst,  # TODO: Pass name+location of macro

--- a/Tools/cases_generator/analysis.py
+++ b/Tools/cases_generator/analysis.py
@@ -34,11 +34,12 @@ class Analyzer:
 
     input_filenames: list[str]
     errors: int = 0
+    warnings: int = 0
 
     def __init__(self, input_filenames: list[str]):
         self.input_filenames = input_filenames
 
-    def error(self, msg: str, node: parsing.Node) -> None:
+    def message(self, msg: str, node: parsing.Node) -> None:
         lineno = 0
         filename = "<unknown file>"
         if context := node.context:
@@ -49,7 +50,17 @@ class Analyzer:
                 if token.kind != "COMMENT":
                     break
         print(f"{filename}:{lineno}: {msg}", file=sys.stderr)
+
+    def error(self, msg: str, node: parsing.Node) -> None:
+        self.message("error: " + msg, node)
         self.errors += 1
+
+    def warning(self, msg: str, node: parsing.Node) -> None:
+        self.message("warning: " + msg, node)
+        self.warnings += 1
+
+    def note(self, msg: str, node: parsing.Node) -> None:
+        self.message("note: " + msg, node)
 
     everything: list[
         parsing.InstDef

--- a/Tools/cases_generator/analysis.py
+++ b/Tools/cases_generator/analysis.py
@@ -83,8 +83,15 @@ class Analyzer:
             self.parse_file(filename, instrs_idx)
 
         files = " + ".join(self.input_filenames)
+        n_instrs = 0
+        n_ops = 0
+        for instr in self.instrs.values():
+            if instr.kind == "op":
+                n_ops += 1
+            else:
+                n_instrs += 1
         print(
-            f"Read {len(self.instrs)} instructions/ops, "
+            f"Read {n_instrs} instructions, {n_ops} ops, "
             f"{len(self.macros)} macros, {len(self.pseudos)} pseudos, "
             f"and {len(self.families)} families from {files}",
             file=sys.stderr,

--- a/Tools/cases_generator/analysis.py
+++ b/Tools/cases_generator/analysis.py
@@ -2,6 +2,8 @@ import re
 import sys
 import typing
 
+import stacking  # Do this before import from instructions (import cycle)
+
 from flags import InstructionFlags, variable_used
 from formatting import prettify_filename, UNUSED
 from instructions import (

--- a/Tools/cases_generator/analysis.py
+++ b/Tools/cases_generator/analysis.py
@@ -2,8 +2,6 @@ import re
 import sys
 import typing
 
-import stacking  # Do this before import from instructions (import cycle)
-
 from flags import InstructionFlags, variable_used
 from formatting import prettify_filename, UNUSED
 from instructions import (
@@ -339,8 +337,6 @@ class Analyzer:
                     if src.name == dst.name or dst.name is UNUSED:
                         continue
                     copies.append((src, dst))
-                # if copies:
-                #     print("--", mac.name, "--", prevop.name, "--", part.instr.name, "--", copies)
                 reads = set(copy[0].name for copy in copies)
                 writes = set(copy[1].name for copy in copies)
                 if reads & writes:

--- a/Tools/cases_generator/flags.py
+++ b/Tools/cases_generator/flags.py
@@ -49,9 +49,9 @@ class InstructionFlags:
             if value:
                 setattr(self, name, value)
 
-    def names(self, value=None):
+    def names(self, value=None) -> list[str]:
         if value is None:
-            return dataclasses.asdict(self).keys()
+            return list(dataclasses.asdict(self).keys())
         return [n for n, v in dataclasses.asdict(self).items() if v == value]
 
     def bitmap(self) -> int:

--- a/Tools/cases_generator/formatting.py
+++ b/Tools/cases_generator/formatting.py
@@ -203,13 +203,3 @@ def parenthesize_cond(cond: str) -> str:
     if "?" in cond:
         cond = f"({cond})"
     return cond
-
-
-def string_effect_size(arg: tuple[int, str]) -> str:
-    numeric, symbolic = arg
-    if numeric and symbolic:
-        return f"{numeric} + {symbolic}"
-    elif symbolic:
-        return symbolic
-    else:
-        return str(numeric)

--- a/Tools/cases_generator/formatting.py
+++ b/Tools/cases_generator/formatting.py
@@ -110,9 +110,6 @@ class Formatter:
     def assign(self, dst: StackEffect, src: StackEffect):
         if src.name == UNUSED or dst.name == UNUSED:
             return
-        # if src.size:
-        #     # Don't write sized arrays -- it's up to the user code.
-        #     return
         cast = self.cast(dst, src)
         if re.match(r"^REG\(oparg(\d+)\)$", dst.name):
             self.emit(f"Py_XSETREF({dst.name}, {cast}{src.name});")

--- a/Tools/cases_generator/formatting.py
+++ b/Tools/cases_generator/formatting.py
@@ -108,11 +108,11 @@ class Formatter:
         self.emit(f"{typ}{sepa}{dst.name}{init};")
 
     def assign(self, dst: StackEffect, src: StackEffect):
-        if src.name == UNUSED:
+        if src.name == UNUSED or dst.name == UNUSED:
             return
-        if src.size:
-            # Don't write sized arrays -- it's up to the user code.
-            return
+        # if src.size:
+        #     # Don't write sized arrays -- it's up to the user code.
+        #     return
         cast = self.cast(dst, src)
         if re.match(r"^REG\(oparg(\d+)\)$", dst.name):
             self.emit(f"Py_XSETREF({dst.name}, {cast}{src.name});")

--- a/Tools/cases_generator/formatting.py
+++ b/Tools/cases_generator/formatting.py
@@ -96,8 +96,13 @@ class Formatter:
         typ = f"{dst.type}" if dst.type else "PyObject *"
         if src:
             cast = self.cast(dst, src)
-            init = f" = {cast}{src.name}"
-        elif dst.cond:
+            initexpr = f"{cast}{src.name}"
+            # TODO: Enable these lines
+            # (cannot yet because they currently mess up macros)
+            # if src.cond and src.cond != "1":
+            #     initexpr = f"{parenthesize_cond(src.cond)} ? {initexpr} : NULL"
+            init = f" = {initexpr}"
+        elif dst.cond and dst.cond != "1":
             init = " = NULL"
         else:
             init = ""
@@ -179,6 +184,13 @@ def maybe_parenthesize(sym: str) -> str:
         return sym
     else:
         return f"({sym})"
+
+
+def parenthesize_cond(cond: str) -> str:
+    """Parenthesize a condition, but only if it contains ?: itself."""
+    if "?" in cond:
+        cond = f"({cond})"
+    return cond
 
 
 def string_effect_size(arg: tuple[int, str]) -> str:

--- a/Tools/cases_generator/formatting.py
+++ b/Tools/cases_generator/formatting.py
@@ -97,10 +97,8 @@ class Formatter:
         if src:
             cast = self.cast(dst, src)
             initexpr = f"{cast}{src.name}"
-            # TODO: Enable these lines
-            # (cannot yet because they currently mess up macros)
-            # if src.cond and src.cond != "1":
-            #     initexpr = f"{parenthesize_cond(src.cond)} ? {initexpr} : NULL"
+            if src.cond and src.cond != "1":
+                initexpr = f"{parenthesize_cond(src.cond)} ? {initexpr} : NULL"
             init = f" = {initexpr}"
         elif dst.cond and dst.cond != "1":
             init = " = NULL"

--- a/Tools/cases_generator/formatting.py
+++ b/Tools/cases_generator/formatting.py
@@ -19,8 +19,11 @@ class Formatter:
     nominal_filename: str
 
     def __init__(
-            self, stream: typing.TextIO, indent: int,
-                  emit_line_directives: bool = False, comment: str = "//",
+        self,
+        stream: typing.TextIO,
+        indent: int,
+        emit_line_directives: bool = False,
+        comment: str = "//",
     ) -> None:
         self.stream = stream
         self.prefix = " " * indent

--- a/Tools/cases_generator/generate_cases.py
+++ b/Tools/cases_generator/generate_cases.py
@@ -468,7 +468,15 @@ class Generator(Analyzer):
             if isinstance(part, Component):
                 # All component instructions must be viable uops
                 if not part.instr.is_viable_uop():
-                    print(f"NOTE: Part {part.instr.name} of {name} is not a viable uop")
+                    # This note just reminds us about macros that cannot
+                    # be expanded to Tier 2 uops. It is not an error.
+                    # It is sometimes emitted for macros that have a
+                    # manual translation in translate_bytecode_to_trace()
+                    # in Python/optimizer.c.
+                    self.note(
+                        f"Part {part.instr.name} of {name} is not a viable uop",
+                        part.instr.inst,
+                    )
                     return
                 if not part.active_caches:
                     size, offset = OPARG_SIZES["OPARG_FULL"], 0

--- a/Tools/cases_generator/generate_cases.py
+++ b/Tools/cases_generator/generate_cases.py
@@ -550,7 +550,9 @@ class Generator(Analyzer):
                             self.write_instr(self.instrs[thing.name])
                     case parsing.Macro():
                         n_macros += 1
-                        self.write_macro(self.macro_instrs[thing.name])
+                        mac = self.macro_instrs[thing.name]
+                        stacking.write_macro_instr(mac, self.out)
+                        # self.write_macro(self.macro_instrs[thing.name])
                     case parsing.Pseudo():
                         pass
                     case _:

--- a/Tools/cases_generator/generate_cases.py
+++ b/Tools/cases_generator/generate_cases.py
@@ -343,7 +343,7 @@ class Generator(Analyzer):
                             # Since an 'op' is not a bytecode, it has no expansion; but 'inst' is
                             if instr.kind == "inst" and instr.is_viable_uop():
                                 # Construct a dummy Component -- input/output mappings are not used
-                                part = Component(instr, [], [], instr.active_caches)
+                                part = Component(instr, instr.active_caches)
                                 self.write_macro_expansions(instr.name, [part])
                             elif instr.kind == "inst" and variable_used(
                                 instr.inst, "oparg1"

--- a/Tools/cases_generator/generate_cases.py
+++ b/Tools/cases_generator/generate_cases.py
@@ -551,7 +551,7 @@ class Generator(Analyzer):
                     case parsing.Macro():
                         n_macros += 1
                         mac = self.macro_instrs[thing.name]
-                        stacking.write_macro_instr(mac, self.out)
+                        stacking.write_macro_instr(mac, self.out, self.families.get(mac.name))
                         # self.write_macro(self.macro_instrs[thing.name])
                     case parsing.Pseudo():
                         pass

--- a/Tools/cases_generator/generate_cases.py
+++ b/Tools/cases_generator/generate_cases.py
@@ -661,15 +661,9 @@ class Generator(Analyzer):
             if cache_adjust:
                 self.out.emit(f"next_instr += {cache_adjust};")
 
-            if (
-                (family := self.families.get(mac.name))
-                and mac.name == family.name
-                and (cache_size := family.size)
-            ):
-                self.out.emit(
-                    f"static_assert({cache_size} == "
-                    f'{cache_adjust}, "incorrect cache size");'
-                )
+            self.out.static_assert_family_size(
+                mac.name, self.families.get(mac.name), cache_adjust
+            )
 
             self.out.stack_adjust(ieffects[: mac.initial_sp], mac.stack[: mac.final_sp])
 

--- a/Tools/cases_generator/generate_cases.py
+++ b/Tools/cases_generator/generate_cases.py
@@ -489,7 +489,7 @@ class Generator(Analyzer):
         instr2 = self.instrs[name2]
         assert not instr1.active_caches, f"{name1} has active caches"
         assert not instr2.active_caches, f"{name2} has active caches"
-        expansions = [
+        expansions: list[tuple[str, int, int]] = [
             (name1, OPARG_SIZES["OPARG_TOP"], 0),
             (name2, OPARG_SIZES["OPARG_BOTTOM"], 0),
         ]

--- a/Tools/cases_generator/generate_cases.py
+++ b/Tools/cases_generator/generate_cases.py
@@ -258,7 +258,8 @@ class Generator(Analyzer):
                 case _:
                     typing.assert_never(thing)
             all_formats.add(format)
-        # Turn it into a list of enum definitions.
+
+        # Turn it into a sorted list of enum values.
         format_enums = [INSTR_FMT_PREFIX + format for format in sorted(all_formats)]
 
         with open(metadata_filename, "w") as f:
@@ -276,8 +277,10 @@ class Generator(Analyzer):
 
             self.write_stack_effect_functions()
 
-            # Write type definitions
-            self.out.emit(f"enum InstructionFormat {{ {', '.join(format_enums)} }};")
+            # Write the enum definition for instruction formats.
+            with self.out.block("enum InstructionFormat", ";"):
+                for enum in format_enums:
+                    self.out.emit(enum + ",")
 
             self.out.emit("")
             self.out.emit(

--- a/Tools/cases_generator/instructions.py
+++ b/Tools/cases_generator/instructions.py
@@ -155,71 +155,10 @@ class Instruction:
 
         # Write input stack effect variable declarations and initializations
         stacking.write_single_instr(self, out, tier)
-        # ieffects = list(reversed(self.input_effects))
-        # for i, ieffect in enumerate(ieffects):
-        #     isize = string_effect_size(
-        #         list_effect_size([ieff for ieff in ieffects[: i + 1]])
-        #     )
-        #     if ieffect.size:
-        #         src = StackEffect(
-        #             f"(stack_pointer - {maybe_parenthesize(isize)})", "PyObject **"
-        #         )
-        #     elif ieffect.cond:
-        #         src = StackEffect(
-        #             f"({ieffect.cond}) ? stack_pointer[-{maybe_parenthesize(isize)}] : NULL",
-        #             "",
-        #         )
-        #     else:
-        #         src = StackEffect(f"stack_pointer[-{maybe_parenthesize(isize)}]", "")
-        #     out.declare(ieffect, src)
-
-        # # Write output stack effect variable declarations
-        # isize = string_effect_size(list_effect_size(self.input_effects))
-        # input_names = {ieffect.name for ieffect in self.input_effects}
-        # for i, oeffect in enumerate(self.output_effects):
-        #     if oeffect.name not in input_names:
-        #         if oeffect.size:
-        #             osize = string_effect_size(
-        #                 list_effect_size([oeff for oeff in self.output_effects[:i]])
-        #             )
-        #             offset = "stack_pointer"
-        #             if isize != osize:
-        #                 if isize != "0":
-        #                     offset += f" - ({isize})"
-        #                 if osize != "0":
-        #                     offset += f" + {osize}"
-        #             src = StackEffect(offset, "PyObject **")
-        #             out.declare(oeffect, src)
-        #         else:
-        #             out.declare(oeffect, None)
-
-        self.write_body(out, 0, self.active_caches, tier=tier)
 
         # Skip the rest if the block always exits
         if self.always_exits:
             return
-
-        # Write net stack growth/shrinkage
-        out.stack_adjust(
-            [ieff for ieff in self.input_effects],
-            [oeff for oeff in self.output_effects],
-        )
-
-        # Write output stack effect assignments
-        oeffects = list(reversed(self.output_effects))
-        for i, oeffect in enumerate(oeffects):
-            if oeffect.name in self.unmoved_names:
-                continue
-            osize = string_effect_size(
-                list_effect_size([oeff for oeff in oeffects[: i + 1]])
-            )
-            if oeffect.size:
-                dst = StackEffect(
-                    f"stack_pointer - {maybe_parenthesize(osize)}", "PyObject **"
-                )
-            else:
-                dst = StackEffect(f"stack_pointer[-{maybe_parenthesize(osize)}]", "")
-            out.assign(dst, oeffect)
 
         # Write cache effect
         if tier == TIER_ONE and self.cache_offset:

--- a/Tools/cases_generator/instructions.py
+++ b/Tools/cases_generator/instructions.py
@@ -2,7 +2,7 @@ import dataclasses
 import re
 import typing
 
-from flags import InstructionFlags, variable_used_unspecialized
+from flags import InstructionFlags, variable_used, variable_used_unspecialized
 from formatting import (
     Formatter,
     UNUSED,
@@ -61,6 +61,7 @@ class Instruction:
 
     # Computed by constructor
     always_exits: bool
+    has_deopt: bool
     cache_offset: int
     cache_effects: list[parsing.CacheEffect]
     input_effects: list[StackEffect]
@@ -83,6 +84,7 @@ class Instruction:
             self.block
         )
         self.always_exits = always_exits(self.block_text)
+        self.has_deopt = variable_used(self.inst, "DEOPT_IF")
         self.cache_effects = [
             effect for effect in inst.inputs if isinstance(effect, parsing.CacheEffect)
         ]

--- a/Tools/cases_generator/instructions.py
+++ b/Tools/cases_generator/instructions.py
@@ -246,29 +246,12 @@ class Instruction:
 
 
 InstructionOrCacheEffect = Instruction | parsing.CacheEffect
-StackEffectMapping = list[tuple[StackEffect, StackEffect]]
 
 
 @dataclasses.dataclass
 class Component:
     instr: Instruction
-    input_mapping: StackEffectMapping
-    output_mapping: StackEffectMapping
     active_caches: list[ActiveCacheEffect]
-
-    def write_body(self, out: Formatter) -> None:
-        with out.block(""):
-            input_names = {ieffect.name for _, ieffect in self.input_mapping}
-            for var, ieffect in self.input_mapping:
-                out.declare(ieffect, var)
-            for _, oeffect in self.output_mapping:
-                if oeffect.name not in input_names:
-                    out.declare(oeffect, None)
-
-            self.instr.write_body(out, -4, self.active_caches)
-
-            for var, oeffect in self.output_mapping:
-                out.assign(var, oeffect)
 
 
 MacroParts = list[Component | parsing.CacheEffect]
@@ -279,9 +262,6 @@ class MacroInstruction:
     """A macro instruction."""
 
     name: str
-    stack: list[StackEffect]
-    initial_sp: int
-    final_sp: int
     instr_fmt: str
     instr_flags: InstructionFlags
     macro: parsing.Macro

--- a/Tools/cases_generator/instructions.py
+++ b/Tools/cases_generator/instructions.py
@@ -6,9 +6,7 @@ from flags import InstructionFlags, variable_used, variable_used_unspecialized
 from formatting import (
     Formatter,
     UNUSED,
-    string_effect_size,
     list_effect_size,
-    maybe_parenthesize,
 )
 import lexer as lx
 import parsing

--- a/Tools/cases_generator/instructions.py
+++ b/Tools/cases_generator/instructions.py
@@ -145,6 +145,7 @@ class Instruction:
     def write(self, out: Formatter, tier: Tiers = TIER_ONE) -> None:
         """Write one instruction, sans prologue and epilogue."""
         # Write a static assertion that a family's cache size is correct
+        # TODO: Move into helper method/function
         if family := self.family:
             if self.name == family.name:
                 if cache_size := family.size:

--- a/Tools/cases_generator/instructions.py
+++ b/Tools/cases_generator/instructions.py
@@ -144,15 +144,9 @@ class Instruction:
 
     def write(self, out: Formatter, tier: Tiers = TIER_ONE) -> None:
         """Write one instruction, sans prologue and epilogue."""
+
         # Write a static assertion that a family's cache size is correct
-        # TODO: Move into helper method/function
-        if family := self.family:
-            if self.name == family.name:
-                if cache_size := family.size:
-                    out.emit(
-                        f"static_assert({cache_size} == "
-                        f'{self.cache_offset}, "incorrect cache size");'
-                    )
+        out.static_assert_family_size(self.name, self.family, self.cache_offset)
 
         # Write input stack effect variable declarations and initializations
         stacking.write_single_instr(self, out, tier)

--- a/Tools/cases_generator/instructions.py
+++ b/Tools/cases_generator/instructions.py
@@ -93,7 +93,7 @@ class Instruction:
         self.output_effects = inst.outputs  # For consistency/completeness
         unmoved_names: set[str] = set()
         for ieffect, oeffect in zip(self.input_effects, self.output_effects):
-            if ieffect.name == oeffect.name:
+            if ieffect == oeffect and ieffect.name == oeffect.name:
                 unmoved_names.add(ieffect.name)
             else:
                 break
@@ -274,7 +274,12 @@ class Instruction:
                 # These aren't DECREF'ed so they can stay.
                 ieffs = list(self.input_effects)
                 oeffs = list(self.output_effects)
-                while ieffs and oeffs and ieffs[0] == oeffs[0]:
+                while (
+                    ieffs
+                    and oeffs
+                    and ieffs[0] == oeffs[0]
+                    and ieffs[0].name == oeffs[0].name
+                ):
                     ieffs.pop(0)
                     oeffs.pop(0)
                 ninputs, symbolic = list_effect_size(ieffs)

--- a/Tools/cases_generator/parsing.py
+++ b/Tools/cases_generator/parsing.py
@@ -75,6 +75,12 @@ class StackEffect(Node):
     size: str = ""  # Optional `[size]`
     # Note: size cannot be combined with type or cond
 
+    def __repr__(self):
+        items = [self.name, self.type, self.cond, self.size]
+        while items and items[-1] == "":
+            del items[-1]
+        return f"StackEffect({', '.join(repr(item) for item in items)})"
+
 
 @dataclass
 class Expression(Node):

--- a/Tools/cases_generator/parsing.py
+++ b/Tools/cases_generator/parsing.py
@@ -136,6 +136,7 @@ class Family(Node):
     size: str  # Variable giving the cache size in code units
     members: list[str]
 
+
 @dataclass
 class Pseudo(Node):
     name: str
@@ -160,7 +161,13 @@ class Parser(PLexer):
         if hdr := self.inst_header():
             if block := self.block():
                 return InstDef(
-                    hdr.override, hdr.register, hdr.kind, hdr.name, hdr.inputs, hdr.outputs, block
+                    hdr.override,
+                    hdr.register,
+                    hdr.kind,
+                    hdr.name,
+                    hdr.inputs,
+                    hdr.outputs,
+                    block,
                 )
             raise self.make_syntax_error("Expected block")
         return None
@@ -377,9 +384,7 @@ class Parser(PLexer):
                                 raise self.make_syntax_error("Expected {")
                             if members := self.members():
                                 if self.expect(lx.RBRACE) and self.expect(lx.SEMI):
-                                    return Pseudo(
-                                        tkn.text, members
-                                    )
+                                    return Pseudo(tkn.text, members)
         return None
 
     def members(self) -> list[str] | None:

--- a/Tools/cases_generator/parsing.py
+++ b/Tools/cases_generator/parsing.py
@@ -69,7 +69,7 @@ class Block(Node):
 
 @dataclass
 class StackEffect(Node):
-    name: str
+    name: str = field(compare=False)  # __eq__ only uses type, cond, size
     type: str = ""  # Optional `:type`
     cond: str = ""  # Optional `if (cond)`
     size: str = ""  # Optional `[size]`

--- a/Tools/cases_generator/plexer.py
+++ b/Tools/cases_generator/plexer.py
@@ -1,4 +1,5 @@
 import lexer as lx
+
 Token = lx.Token
 
 
@@ -64,7 +65,9 @@ class PLexer:
         tkn = self.next()
         if tkn is not None and tkn.kind == kind:
             return tkn
-        raise self.make_syntax_error(f"Expected {kind!r} but got {tkn and tkn.text!r}", tkn)
+        raise self.make_syntax_error(
+            f"Expected {kind!r} but got {tkn and tkn.text!r}", tkn
+        )
 
     def extract_line(self, lineno: int) -> str:
         # Return source line `lineno` (1-based)
@@ -73,18 +76,20 @@ class PLexer:
             return ""
         return lines[lineno - 1]
 
-    def make_syntax_error(self, message: str, tkn: Token|None = None) -> SyntaxError:
+    def make_syntax_error(self, message: str, tkn: Token | None = None) -> SyntaxError:
         # Construct a SyntaxError instance from message and token
         if tkn is None:
             tkn = self.peek()
         if tkn is None:
             tkn = self.tokens[-1]
-        return lx.make_syntax_error(message,
-            self.filename, tkn.line, tkn.column, self.extract_line(tkn.line))
+        return lx.make_syntax_error(
+            message, self.filename, tkn.line, tkn.column, self.extract_line(tkn.line)
+        )
 
 
 if __name__ == "__main__":
     import sys
+
     if sys.argv[1:]:
         filename = sys.argv[1]
         if filename == "-c" and sys.argv[2:]:

--- a/Tools/cases_generator/stacking.py
+++ b/Tools/cases_generator/stacking.py
@@ -1,0 +1,230 @@
+from abc import abstractmethod
+import dataclasses
+
+from formatting import Formatter, UNUSED, list_effect_size, maybe_parenthesize
+from instructions import Instruction, Tiers, TIER_ONE, TIER_TWO
+from parsing import StackEffect
+
+
+def parenthesize_cond(cond: str) -> str:
+    """Parenthesize a condition, but only if it contains ?: itself."""
+    if "?" in cond:
+        cond = f"({cond})"
+    return cond
+
+
+@dataclasses.dataclass
+class StackOffset:
+    """Represent the stack offset for a PEEK or POKE.
+
+    - If at the top of the stack (PEEK(-1) or POKE(-1)),
+      both deep and high are empty.
+    - If some number of items below stack top, only deep is non-empty.
+    - If some number of items above stack top, only high is non-empty.
+    - If accessing the entry would require some popping and then some
+      pushing, both deep and high are non-empty.
+
+    All this would be much simpler if all stack entries were the same
+    size, but with conditional and array effects, they aren't.
+    The offsets are each represented by a list of StackEffect objects.
+    The name in the StackEffects is unused.
+
+    TODO: Maybe this should *include* the size of the accessed entry.
+    """
+
+    deep: list[StackEffect]
+    high: list[StackEffect]
+
+    def deeper(self, eff: StackEffect) -> None:
+        if eff in self.high:
+            self.high.remove(eff)
+        else:
+            self.deep.append(eff)
+
+    def higher(self, eff: StackEffect) -> None:
+        if eff in self.deep:
+            self.deep.remove(eff)
+        else:
+            self.high.append(eff)
+
+    @abstractmethod
+    def itself(self) -> StackEffect:
+        """Implemented by subclasses PeekEffect, PokeEffect."""
+        raise NotImplementedError("itself() not implemented")
+
+    def as_variable(self) -> str:
+        """Return e.g. stack_pointer[-1]."""
+        temp = StackOffset(list(self.deep), list(self.high))
+        me = self.itself()
+        temp.deeper(me)
+        num = 0
+        terms: list[tuple[str, str]] = []
+        for eff in temp.deep:
+            if eff.size:
+                terms.append(("-", maybe_parenthesize(eff.size)))
+            elif eff.cond:
+                terms.append(("-", f"({parenthesize_cond(eff.cond)} ? 1 : 0)"))
+            else:
+                num -= 1
+        for eff in temp.high:
+            if eff.size:
+                terms.append(("+", maybe_parenthesize(eff.size)))
+            elif eff.cond:
+                terms.append(("+", f"({parenthesize_cond(eff.cond)} ? 1 : 0)"))
+            else:
+                num += 1
+
+        if num < 0:
+            terms.insert(0, ("-", str(-num)))
+        elif num > 0:
+            terms.append(("+", str(num)))
+        if me.size:
+            terms.insert(0, ("+", "stack_pointer"))
+
+        # Produce an index expression from the terms honoring PEP 8,
+        # surrounding binary ops with spaces but not unary minus
+        index = ""
+        for sign, term in terms:
+            if index:
+                index += f" {sign} {term}"
+            elif sign == "+":
+                index = term
+            else:
+                index = sign + term
+
+        if me.size:
+            return index
+        else:
+            variable = f"stack_pointer[{index}]"
+            if me.cond:
+                variable = f"{parenthesize_cond(me.cond)} ? {variable} : NULL"
+            return variable
+
+
+@dataclasses.dataclass
+class PeekEffect(StackOffset):
+    dst: StackEffect
+
+    def itself(self) -> StackEffect:
+        return self.dst
+
+
+@dataclasses.dataclass
+class PokeEffect(StackOffset):
+    src: StackEffect
+
+    def itself(self) -> StackEffect:
+        return self.src
+
+
+@dataclasses.dataclass
+class CopyEffect:
+    src: StackEffect
+    dst: StackEffect
+
+
+class AllStackEffects:
+    """Represent all stack effects for an instruction."""
+
+    # List things in order of execution
+    copies: list[CopyEffect]  # See merge()
+    peeks: list[PeekEffect]
+    instr: Instruction
+    pokes: list[PokeEffect]
+    frozen: bool
+
+    def __init__(self, instr: Instruction):
+        self.copies = []
+        self.peeks = []
+        self.instr = instr
+        self.pokes = []
+        self.frozen = True
+        for eff in reversed(instr.input_effects):
+            new_peek = PeekEffect([], [], eff)
+            for peek in self.peeks:
+                new_peek.deeper(peek.dst)
+            self.peeks.append(new_peek)
+        for eff in instr.output_effects:
+            new_poke = PokeEffect([], [], eff)
+            for peek in self.peeks:
+                new_poke.deeper(peek.dst)
+            for poke in self.pokes:
+                new_poke.higher(poke.src)
+            new_poke.higher(eff)  # Account for the new poke itself (!)
+            self.pokes.append(new_poke)
+
+    def copy(self) -> "AllStackEffects":
+        new = AllStackEffects(self.instr)  # Just recompute peeks/pokes
+        new.frozen = False  # Make the copy mergeable
+        return new
+
+    def merge(self, follow: "AllStackEffects") -> None:
+        assert not self.frozen  # Only copies can be merged
+        assert not follow.frozen
+        sources: set[str] = set()
+        destinations: set[str] = set()
+        while self.pokes and follow.peeks and self.pokes[-1] == follow.peeks[0]:
+            src = self.pokes.pop(-1).src
+            dst = follow.peeks.pop(0).dst
+            if dst.name != UNUSED:
+                if dst.name != src.name:
+                    sources.add(src.name)
+                destinations.add(dst.name)
+            follow.copies.append(CopyEffect(src, dst))
+        # TODO: Turn this into an error (pass an Analyzer instance?)
+        assert sources & destinations == set(), (
+            self.instr.name,
+            follow.instr.name,
+            sources,
+            destinations,
+        )
+        self.frozen = True  # Can only merge once
+
+    def collect_vars(self) -> set[StackEffect]:
+        vars: set[StackEffect] = set()
+        for copy in self.copies:
+            if copy.dst.name != UNUSED:
+                vars.add(copy.dst)
+        for peek in self.peeks:
+            if peek.dst.name != UNUSED:
+                vars.add(peek.dst)
+        for poke in self.pokes:
+            if poke.src.name != UNUSED:
+                vars.add(poke.src)
+        return vars
+
+
+def write_single_instr(
+    instr: Instruction, out: Formatter, tier: Tiers = TIER_ONE
+) -> None:
+    """Replace (most of) Instruction.write()."""
+    effects = AllStackEffects(instr)
+    assert not effects.copies
+    input_vars: set[str] = set()
+    for peek in effects.peeks:
+        if peek.dst.name != UNUSED:
+            input_vars.add(peek.dst.name)
+            src = StackEffect(
+                peek.as_variable(), peek.dst.type, peek.dst.cond, peek.dst.size
+            )
+            out.declare(peek.dst, src)
+    for poke in effects.pokes:
+        if poke.src.name != UNUSED and poke.src.name not in input_vars:
+            if not poke.src.size:
+                dst = None
+            else:
+                dst = StackEffect(
+                    poke.as_variable(), poke.src.type, poke.src.cond, poke.src.size
+                )
+            out.declare(poke.src, dst)
+
+
+# Plan:
+# - Do this for single (non-macro) instructions
+#   - declare all vars
+#     - emit all peeks
+#     - emit special cases for array output effects
+#     - emit the instruction
+#     - emit all pokes
+# - Do it for macro instructions
+# - Write tests that show e.g. CALL can be split into uops

--- a/Tools/cases_generator/stacking.py
+++ b/Tools/cases_generator/stacking.py
@@ -285,11 +285,6 @@ def write_single_instr(
         if peek.dst.name != UNUSED:
             input_vars.add(peek.dst.name)
             variable = peek.as_variable()
-            # TODO: Move this to Formatter.declare() (see TODO there)
-            if peek.dst.cond and peek.dst.cond != "1":
-                variable = f"{parenthesize_cond(peek.dst.cond)} ? {variable} : NULL"
-            elif peek.dst.cond == "0":
-                variable = "NULL"
             src = StackEffect(variable, peek.dst.type, peek.dst.cond, peek.dst.size)
             out.declare(peek.dst, src)
 

--- a/Tools/cases_generator/stacking.py
+++ b/Tools/cases_generator/stacking.py
@@ -292,7 +292,7 @@ def write_single_instr(
     instr: Instruction, out: Formatter, tier: Tiers = TIER_ONE
 ) -> None:
     write_components(
-        [Component(instr, [], [], instr.active_caches)],
+        [Component(instr, instr.active_caches)],
         out,
         tier,
     )

--- a/Tools/cases_generator/stacking.py
+++ b/Tools/cases_generator/stacking.py
@@ -368,7 +368,7 @@ def write_components(
             )
         # Initialize array outputs
         for poke in mgr.pokes:
-            if poke.effect.size:
+            if poke.effect.size and poke.effect.name not in mgr.instr.unmoved_names:
                 out.assign(
                     poke.effect,
                     StackEffect(
@@ -391,7 +391,7 @@ def write_components(
             mgr.adjust_inverse(mgr.final_offset.clone())
 
         for poke in mgr.pokes:
-            if not poke.effect.size:
+            if not poke.effect.size and poke.effect.name not in mgr.instr.unmoved_names:
                 out.assign(
                     StackEffect(
                         poke.as_variable(),

--- a/Tools/cases_generator/stacking.py
+++ b/Tools/cases_generator/stacking.py
@@ -16,7 +16,7 @@ from instructions import (
     Tiers,
     TIER_ONE,
 )
-from parsing import StackEffect, CacheEffect
+from parsing import StackEffect, CacheEffect, Family
 
 
 @dataclasses.dataclass
@@ -298,7 +298,9 @@ def write_single_instr(
     )
 
 
-def write_macro_instr(mac: MacroInstruction, out: Formatter) -> None:
+def write_macro_instr(
+    mac: MacroInstruction, out: Formatter, family: Family | None
+) -> None:
     parts = [part for part in mac.parts if isinstance(part, Component)]
     cache_adjust = 0
     for part in mac.parts:
@@ -314,6 +316,7 @@ def write_macro_instr(mac: MacroInstruction, out: Formatter) -> None:
     with out.block(f"TARGET({mac.name})"):
         if mac.predicted:
             out.emit(f"PREDICTED({mac.name});")
+        out.static_assert_family_size(mac.name, family, cache_adjust)
         write_components(parts, out, TIER_ONE)
         if cache_adjust:
             out.emit(f"next_instr += {cache_adjust};")

--- a/Tools/cases_generator/stacking.py
+++ b/Tools/cases_generator/stacking.py
@@ -1,4 +1,3 @@
-from abc import abstractmethod
 import dataclasses
 import typing
 


### PR DESCRIPTION
This adds a new file, stacking.py, which tracks pushes and pops across the uops comprising a macro. Instruction writing for non-macro instructions is also unified with this.

The generated files look quite different, but I have carefully verified that everything works. (And usually if it doesn't, it won't even build. :-)

**TODO:**
- [ ] (If possible) Clean up circular import between instructions.py and stacking.py
- [ ] Pass `Analyzer` around and turn a few asserts into error messages
- [ ] Remove redundant `Analyzer.check_macro_consistency` (fold into write_components)
- [x] Remove errors from `Analyzer.stack_analysis` that are no longer errors
- [x] Remove commented-out lines from ``Formatter.assign`
- [x] Change `StackItem` so the effect itself is included in `deep`/`high`
- [x] (Maybe) Change `StackItem` to have a `StackOffset` member instead of inheriting it
- [ ] (Probably not) Change `StackOffset` operations to use `__add__`, `__sub__` etc.

<!-- gh-issue-number: gh-106812 -->
* Issue: gh-106812
<!-- /gh-issue-number -->
