### PR TITLE
Fix test_capi.test_misc when run with -R::

### DIFF
--- a/Lib/test/test_capi/test_misc.py
+++ b/Lib/test/test_capi/test_misc.py
@@ -2464,36 +2464,40 @@ class TestUops(unittest.TestCase):
 
     def test_extended_arg(self):
         "Check EXTENDED_ARG handling in superblock creation"
-        def many_vars():
-            # 260 vars, so z9 should have index 259
-            a0 = a1 = a2 = a3 = a4 = a5 = a6 = a7 = a8 = a9 = 42
-            b0 = b1 = b2 = b3 = b4 = b5 = b6 = b7 = b8 = b9 = 42
-            c0 = c1 = c2 = c3 = c4 = c5 = c6 = c7 = c8 = c9 = 42
-            d0 = d1 = d2 = d3 = d4 = d5 = d6 = d7 = d8 = d9 = 42
-            e0 = e1 = e2 = e3 = e4 = e5 = e6 = e7 = e8 = e9 = 42
-            f0 = f1 = f2 = f3 = f4 = f5 = f6 = f7 = f8 = f9 = 42
-            g0 = g1 = g2 = g3 = g4 = g5 = g6 = g7 = g8 = g9 = 42
-            h0 = h1 = h2 = h3 = h4 = h5 = h6 = h7 = h8 = h9 = 42
-            i0 = i1 = i2 = i3 = i4 = i5 = i6 = i7 = i8 = i9 = 42
-            j0 = j1 = j2 = j3 = j4 = j5 = j6 = j7 = j8 = j9 = 42
-            k0 = k1 = k2 = k3 = k4 = k5 = k6 = k7 = k8 = k9 = 42
-            l0 = l1 = l2 = l3 = l4 = l5 = l6 = l7 = l8 = l9 = 42
-            m0 = m1 = m2 = m3 = m4 = m5 = m6 = m7 = m8 = m9 = 42
-            n0 = n1 = n2 = n3 = n4 = n5 = n6 = n7 = n8 = n9 = 42
-            o0 = o1 = o2 = o3 = o4 = o5 = o6 = o7 = o8 = o9 = 42
-            p0 = p1 = p2 = p3 = p4 = p5 = p6 = p7 = p8 = p9 = 42
-            q0 = q1 = q2 = q3 = q4 = q5 = q6 = q7 = q8 = q9 = 42
-            r0 = r1 = r2 = r3 = r4 = r5 = r6 = r7 = r8 = r9 = 42
-            s0 = s1 = s2 = s3 = s4 = s5 = s6 = s7 = s8 = s9 = 42
-            t0 = t1 = t2 = t3 = t4 = t5 = t6 = t7 = t8 = t9 = 42
-            u0 = u1 = u2 = u3 = u4 = u5 = u6 = u7 = u8 = u9 = 42
-            v0 = v1 = v2 = v3 = v4 = v5 = v6 = v7 = v8 = v9 = 42
-            w0 = w1 = w2 = w3 = w4 = w5 = w6 = w7 = w8 = w9 = 42
-            x0 = x1 = x2 = x3 = x4 = x5 = x6 = x7 = x8 = x9 = 42
-            y0 = y1 = y2 = y3 = y4 = y5 = y6 = y7 = y8 = y9 = 42
-            z0 = z1 = z2 = z3 = z4 = z5 = z6 = z7 = z8 = z9 = 42
-            while z9 > 0:
-                z9 = z9 - 1
+        ns = {}
+        exec(textwrap.dedent("""
+            def many_vars():
+                # 260 vars, so z9 should have index 259
+                a0 = a1 = a2 = a3 = a4 = a5 = a6 = a7 = a8 = a9 = 42
+                b0 = b1 = b2 = b3 = b4 = b5 = b6 = b7 = b8 = b9 = 42
+                c0 = c1 = c2 = c3 = c4 = c5 = c6 = c7 = c8 = c9 = 42
+                d0 = d1 = d2 = d3 = d4 = d5 = d6 = d7 = d8 = d9 = 42
+                e0 = e1 = e2 = e3 = e4 = e5 = e6 = e7 = e8 = e9 = 42
+                f0 = f1 = f2 = f3 = f4 = f5 = f6 = f7 = f8 = f9 = 42
+                g0 = g1 = g2 = g3 = g4 = g5 = g6 = g7 = g8 = g9 = 42
+                h0 = h1 = h2 = h3 = h4 = h5 = h6 = h7 = h8 = h9 = 42
+                i0 = i1 = i2 = i3 = i4 = i5 = i6 = i7 = i8 = i9 = 42
+                j0 = j1 = j2 = j3 = j4 = j5 = j6 = j7 = j8 = j9 = 42
+                k0 = k1 = k2 = k3 = k4 = k5 = k6 = k7 = k8 = k9 = 42
+                l0 = l1 = l2 = l3 = l4 = l5 = l6 = l7 = l8 = l9 = 42
+                m0 = m1 = m2 = m3 = m4 = m5 = m6 = m7 = m8 = m9 = 42
+                n0 = n1 = n2 = n3 = n4 = n5 = n6 = n7 = n8 = n9 = 42
+                o0 = o1 = o2 = o3 = o4 = o5 = o6 = o7 = o8 = o9 = 42
+                p0 = p1 = p2 = p3 = p4 = p5 = p6 = p7 = p8 = p9 = 42
+                q0 = q1 = q2 = q3 = q4 = q5 = q6 = q7 = q8 = q9 = 42
+                r0 = r1 = r2 = r3 = r4 = r5 = r6 = r7 = r8 = r9 = 42
+                s0 = s1 = s2 = s3 = s4 = s5 = s6 = s7 = s8 = s9 = 42
+                t0 = t1 = t2 = t3 = t4 = t5 = t6 = t7 = t8 = t9 = 42
+                u0 = u1 = u2 = u3 = u4 = u5 = u6 = u7 = u8 = u9 = 42
+                v0 = v1 = v2 = v3 = v4 = v5 = v6 = v7 = v8 = v9 = 42
+                w0 = w1 = w2 = w3 = w4 = w5 = w6 = w7 = w8 = w9 = 42
+                x0 = x1 = x2 = x3 = x4 = x5 = x6 = x7 = x8 = x9 = 42
+                y0 = y1 = y2 = y3 = y4 = y5 = y6 = y7 = y8 = y9 = 42
+                z0 = z1 = z2 = z3 = z4 = z5 = z6 = z7 = z8 = z9 = 42
+                while z9 > 0:
+                    z9 = z9 - 1
+        """), ns, ns)
+        many_vars = ns["many_vars"]
 
         opt = _testinternalcapi.get_uop_optimizer()
         with temporary_optimizer(opt):


### PR DESCRIPTION
This creates a new function each time that test is run, like Victor did for other tests. (I'm unclear why this isn't needed for all tests, but whatever.)

Should fix the buildbot failures.