### PR TITLE
gh-107080: Fix Py_TRACE_REFS Crashes Under Isolated Subinterpreters

### DIFF
--- a/Include/internal/pycore_object.h
+++ b/Include/internal/pycore_object.h
@@ -292,8 +292,9 @@ extern void _PyDebug_PrintTotalRefs(void);
 
 #ifdef Py_TRACE_REFS
 extern void _Py_AddToAllObjects(PyObject *op, int force);
-extern void _Py_PrintReferences(FILE *);
-extern void _Py_PrintReferenceAddresses(FILE *);
+extern void _Py_PrintReferences(PyInterpreterState *, FILE *);
+extern void _Py_PrintReferenceAddresses(PyObject *, FILE *);
+extern void _Py_StealRefchain(PyInterpreterState *, PyObject *);
 #endif
 
 

--- a/Include/internal/pycore_object.h
+++ b/Include/internal/pycore_object.h
@@ -293,8 +293,7 @@ extern void _PyDebug_PrintTotalRefs(void);
 #ifdef Py_TRACE_REFS
 extern void _Py_AddToAllObjects(PyObject *op, int force);
 extern void _Py_PrintReferences(PyInterpreterState *, FILE *);
-extern void _Py_PrintReferenceAddresses(PyObject *, FILE *);
-extern void _Py_StealRefchain(PyInterpreterState *, PyObject *);
+extern void _Py_PrintReferenceAddresses(PyInterpreterState *, FILE *);
 #endif
 
 

--- a/Include/internal/pycore_object_state.h
+++ b/Include/internal/pycore_object_state.h
@@ -11,9 +11,15 @@ extern "C" {
 struct _py_object_runtime_state {
 #ifdef Py_REF_DEBUG
     Py_ssize_t interpreter_leaks;
-#else
-    int _not_used;
 #endif
+#ifdef Py_TRACE_REFS
+    /* Head of circular doubly-linked list of all objects.  These are linked
+     * together via the _ob_prev and _ob_next members of a PyObject, which
+     * exist only in a Py_TRACE_REFS build.
+     */
+    PyObject refchain;
+#endif
+    int _not_used;
 };
 
 struct _py_object_state {

--- a/Include/internal/pycore_object_state.h
+++ b/Include/internal/pycore_object_state.h
@@ -12,6 +12,13 @@ struct _py_object_runtime_state {
 #ifdef Py_REF_DEBUG
     Py_ssize_t interpreter_leaks;
 #endif
+    int _not_used;
+};
+
+struct _py_object_state {
+#ifdef Py_REF_DEBUG
+    Py_ssize_t reftotal;
+#endif
 #ifdef Py_TRACE_REFS
     /* Head of circular doubly-linked list of all objects.  These are linked
      * together via the _ob_prev and _ob_next members of a PyObject, which
@@ -20,14 +27,6 @@ struct _py_object_runtime_state {
     PyObject refchain;
 #endif
     int _not_used;
-};
-
-struct _py_object_state {
-#ifdef Py_REF_DEBUG
-    Py_ssize_t reftotal;
-#else
-    int _not_used;
-#endif
 };
 
 

--- a/Include/internal/pycore_runtime_init.h
+++ b/Include/internal/pycore_runtime_init.h
@@ -108,7 +108,6 @@ extern PyTypeObject _PyExc_MemoryError;
         }, \
         .faulthandler = _faulthandler_runtime_state_INIT, \
         .tracemalloc = _tracemalloc_runtime_state_INIT, \
-        .object_state = _py_object_runtime_state_INIT(runtime), \
         .float_state = { \
             .float_format = _py_float_format_unknown, \
             .double_format = _py_float_format_unknown, \
@@ -158,6 +157,7 @@ extern PyTypeObject _PyExc_MemoryError;
                 { .threshold = 10, }, \
             }, \
         }, \
+        .object_state = _py_object_state_INIT(INTERP), \
         .dtoa = _dtoa_state_INIT(&(INTERP)), \
         .dict_state = _dict_state_INIT, \
         .func_state = { \
@@ -188,12 +188,12 @@ extern PyTypeObject _PyExc_MemoryError;
     }
 
 #ifdef Py_TRACE_REFS
-# define _py_object_runtime_state_INIT(runtime) \
+# define _py_object_state_INIT(INTERP) \
     { \
-        .refchain = {&runtime.object_state.refchain, &runtime.object_state.refchain}, \
+        .refchain = {&INTERP.object_state.refchain, &INTERP.object_state.refchain}, \
     }
 #else
-# define _py_object_runtime_state_INIT(runtime) \
+# define _py_object_state_INIT(INTERP) \
     { 0 }
 #endif
 

--- a/Include/internal/pycore_runtime_init.h
+++ b/Include/internal/pycore_runtime_init.h
@@ -108,6 +108,7 @@ extern PyTypeObject _PyExc_MemoryError;
         }, \
         .faulthandler = _faulthandler_runtime_state_INIT, \
         .tracemalloc = _tracemalloc_runtime_state_INIT, \
+        .object_state = _py_object_runtime_state_INIT(runtime), \
         .float_state = { \
             .float_format = _py_float_format_unknown, \
             .double_format = _py_float_format_unknown, \
@@ -185,6 +186,16 @@ extern PyTypeObject _PyExc_MemoryError;
         .py_recursion_limit = Py_DEFAULT_RECURSION_LIMIT, \
         .context_ver = 1, \
     }
+
+#ifdef Py_TRACE_REFS
+# define _py_object_runtime_state_INIT(runtime) \
+    { \
+        .refchain = {&runtime.object_state.refchain, &runtime.object_state.refchain}, \
+    }
+#else
+# define _py_object_runtime_state_INIT(runtime) \
+    { 0 }
+#endif
 
 
 // global objects

--- a/Misc/NEWS.d/next/Core and Builtins/2023-08-02-12-24-51.gh-issue-107080.PNolFU.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2023-08-02-12-24-51.gh-issue-107080.PNolFU.rst
@@ -1,0 +1,4 @@
+Trace refs builds (``--with-trace-refs``) were crashing when used with
+isolated subinterpreters.  The problematic global state has been isolated to
+each interpreter.  Other fixing the crashes, this change does not affect
+users.

--- a/Objects/object.c
+++ b/Objects/object.c
@@ -2316,10 +2316,11 @@ _Py_GetObjects(PyObject *self, PyObject *args)
     int i, n;
     PyObject *t = NULL;
     PyObject *res, *op;
+    PyInterpreterState *interp = _PyInterpreterState_GET();
 
     if (!PyArg_ParseTuple(args, "i|O", &n, &t))
         return NULL;
-    PyObject *refchain = REFCHAIN(_PyInterpreterState_GET());
+    PyObject *refchain = REFCHAIN(interp);
     op = refchain->_ob_next;
     res = PyList_New(0);
     if (res == NULL)

--- a/Objects/object.c
+++ b/Objects/object.c
@@ -2253,28 +2253,6 @@ _Py_ForgetReference(PyObject *op)
     op->_ob_next = op->_ob_prev = NULL;
 }
 
-void
-_Py_StealRefchain(PyInterpreterState *interp, PyObject *refchain)
-{
-    assert(refchain != NULL
-           && (refchain->_ob_prev == NULL || refchain->_ob_prev == refchain)
-           && (refchain->_ob_next == NULL || refchain->_ob_next == refchain));
-    if (interp == NULL) {
-        interp = _PyInterpreterState_Main();
-    }
-    PyObject *old = REFCHAIN(interp);
-    if (old->_ob_prev == old) {
-        assert(old->_ob_next == old);
-        refchain->_ob_prev = refchain;
-        refchain->_ob_next = refchain;
-        return;
-    }
-    refchain->_ob_prev = old->_ob_prev;
-    refchain->_ob_prev->_ob_next = refchain;
-    refchain->_ob_next = old->_ob_next;
-    refchain->_ob_next->_ob_prev = refchain;
-}
-
 /* Print all live objects.  Because PyObject_Print is called, the
  * interpreter must be in a healthy state.
  */

--- a/Objects/object.c
+++ b/Objects/object.c
@@ -2299,10 +2299,15 @@ _Py_PrintReferences(PyInterpreterState *interp, FILE *fp)
 /* Print the addresses of all live objects.  Unlike _Py_PrintReferences, this
  * doesn't make any calls to the Python C API, so is always safe to call.
  */
+// XXX This function is not safe to use if the interpreter has been
+// freed or is in an unhealthy state (e.g. late in finalization).
+// The call in Py_FinalizeEx() is okay since the main interpreter
+// is statically allocated.
 void
-_Py_PrintReferenceAddresses(PyObject *refchain, FILE *fp)
+_Py_PrintReferenceAddresses(PyInterpreterState *interp, FILE *fp)
 {
     PyObject *op;
+    PyObject *refchain = REFCHAIN(interp);
     fprintf(fp, "Remaining object addresses:\n");
     for (op = refchain->_ob_next; op != refchain; op = op->_ob_next)
         fprintf(fp, "%p [%zd] %s\n", (void *)op,

--- a/Objects/object.c
+++ b/Objects/object.c
@@ -159,11 +159,8 @@ _PyDebug_PrintTotalRefs(void) {
    Do not call them otherwise, they do not initialize the object! */
 
 #ifdef Py_TRACE_REFS
-/* Head of circular doubly-linked list of all objects.  These are linked
- * together via the _ob_prev and _ob_next members of a PyObject, which
- * exist only in a Py_TRACE_REFS build.
- */
-static PyObject refchain = {&refchain, &refchain};
+
+# define refchain _PyRuntime.object_state.refchain
 
 /* Insert op at the front of the list of all objects.  If force is true,
  * op is added even if _ob_prev and _ob_next are non-NULL already.  If

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -1927,9 +1927,6 @@ Py_FinalizeEx(void)
     if (dump_refs_fp != NULL) {
         _Py_PrintReferences(tstate->interp, dump_refs_fp);
     }
-
-    PyObject refchain = { 0 };
-    _Py_StealRefchain(tstate->interp, &refchain);
 #endif /* Py_TRACE_REFS */
 
     /* At this point there's almost no other Python code that will run,
@@ -1964,11 +1961,11 @@ Py_FinalizeEx(void)
      */
 
     if (dump_refs) {
-        _Py_PrintReferenceAddresses(&refchain, stderr);
+        _Py_PrintReferenceAddresses(tstate->interp, stderr);
     }
 
     if (dump_refs_fp != NULL) {
-        _Py_PrintReferenceAddresses(&refchain, dump_refs_fp);
+        _Py_PrintReferenceAddresses(tstate->interp, dump_refs_fp);
         fclose(dump_refs_fp);
     }
 #endif /* Py_TRACE_REFS */

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -1921,12 +1921,15 @@ Py_FinalizeEx(void)
     }
 
     if (dump_refs) {
-        _Py_PrintReferences(stderr);
+        _Py_PrintReferences(tstate->interp, stderr);
     }
 
     if (dump_refs_fp != NULL) {
-        _Py_PrintReferences(dump_refs_fp);
+        _Py_PrintReferences(tstate->interp, dump_refs_fp);
     }
+
+    PyObject refchain = { 0 };
+    _Py_StealRefchain(tstate->interp, &refchain);
 #endif /* Py_TRACE_REFS */
 
     /* At this point there's almost no other Python code that will run,
@@ -1961,11 +1964,11 @@ Py_FinalizeEx(void)
      */
 
     if (dump_refs) {
-        _Py_PrintReferenceAddresses(stderr);
+        _Py_PrintReferenceAddresses(&refchain, stderr);
     }
 
     if (dump_refs_fp != NULL) {
-        _Py_PrintReferenceAddresses(dump_refs_fp);
+        _Py_PrintReferenceAddresses(&refchain, dump_refs_fp);
         fclose(dump_refs_fp);
     }
 #endif /* Py_TRACE_REFS */


### PR DESCRIPTION
The linked list of objects was a global variable, which broke isolation between interpreters, causing crashes.  To solve this, we've moved the linked list to each interpreter.

<!-- gh-issue-number: gh-107080 -->
* Issue: gh-107080
<!-- /gh-issue-number -->
