### PR TITLE
gh-107471: Fix Refleaks in test_import

### DIFF
--- a/Lib/test/test_import/__init__.py
+++ b/Lib/test/test_import/__init__.py
@@ -2126,7 +2126,7 @@ class SinglephaseInitTests(unittest.TestCase):
             _interpreters.run_string(interpid, textwrap.dedent(f'''
                 name = {self.NAME!r}
                 if name in sys.modules:
-                    sys.modules[name]._clear_globals()
+                    sys.modules.pop(name)._clear_globals()
                 _testinternalcapi.clear_extension(name, {self.FILE!r})
                 '''))
             _interpreters.destroy(interpid)

--- a/Lib/test/test_import/__init__.py
+++ b/Lib/test/test_import/__init__.py
@@ -150,6 +150,7 @@ if _testsinglephase is not None:
     def restore__testsinglephase(*, _orig=_testsinglephase):
         # We started with the module imported and want to restore
         # it to its nominal state.
+        sys.modules.pop('_testsinglephase', None)
         _orig._clear_globals()
         _testinternalcapi.clear_extension('_testsinglephase', _orig.__file__)
         import _testsinglephase

--- a/Python/import.c
+++ b/Python/import.c
@@ -1073,6 +1073,7 @@ _extensions_cache_delete(PyObject *filename, PyObject *name)
        However, this decref would be problematic if the module def were
        dynamically allocated, it were the last ref, and this function
        were called with an interpreter other than the def's owner. */
+    assert(_Py_IsImmortal(entry->value));
     entry->value = NULL;
 
 finally:


### PR DESCRIPTION
gh-107184 introduced a refleak in test_import.SubinterpImportTests (specifically test_singlephase_check_with_setting_and_override and test_single_init_extension_compat).  We fix it here by making sure _testsinglephase is removed from sys.modules whenever we clear the runtime's internal state for the module.

The underlying problem is strictly contained in the internal function `_PyImport_ClearExtension()` (AKA `_testinternalcapi.clear_extension()`), which is only used in tests.

(This also fixes an intermittent segfault introduced in the same place, in test_disallowed_reimport.)

<!-- gh-issue-number: gh-107471 -->
* Issue: gh-107471
<!-- /gh-issue-number -->
