### PR TITLE
gh-105699: Re-enable the Multiple-Interpreters Stress Tests

### DIFF
--- a/Lib/test/test_interpreters.py
+++ b/Lib/test/test_interpreters.py
@@ -464,7 +464,6 @@ class TestInterpreterRun(TestBase):
     # test_xxsubinterpreters covers the remaining Interpreter.run() behavior.
 
 
-@unittest.skip('these are crashing, likely just due just to _xxsubinterpreters (see gh-105699)')
 class StressTests(TestBase):
 
     # In these tests we generally want a lot of interpreters,


### PR DESCRIPTION
We disabled them due to crashes (which weren't clearly due to the actual CPython runtime).

(At the very least I'm using the PR to evaluate the status of the crashes on buildbots, since I cannot reproduce them locally.)

<!-- gh-issue-number: gh-105699 -->
* Issue: gh-105699
<!-- /gh-issue-number -->
