### PR TITLE
gh-107576: Ensure `__orig_bases__` are our own in `get_original_bases`

### DIFF
--- a/Lib/test/test_types.py
+++ b/Lib/test/test_types.py
@@ -1420,7 +1420,7 @@ class ClassCreationTests(unittest.TestCase):
         class First_(typing.Generic[T]): pass
         class Second_(typing.Generic[T]): pass
         class H(First_, Second_): pass
-        self.assertEqual(types.get_original_bases(G), (First, Second))
+        self.assertEqual(types.get_original_bases(H), (First_, Second_))
 
         class ClassBasedNamedTuple(typing.NamedTuple):
             x: int

--- a/Lib/test/test_types.py
+++ b/Lib/test/test_types.py
@@ -1397,6 +1397,7 @@ class ClassCreationTests(unittest.TestCase):
         class B(typing.Generic[T]): pass
         class C(B[int]): pass
         class D(B[str], float): pass
+
         self.assertEqual(types.get_original_bases(A), (object,))
         self.assertEqual(types.get_original_bases(B), (typing.Generic[T],))
         self.assertEqual(types.get_original_bases(C), (B[int],))
@@ -1408,6 +1409,18 @@ class ClassCreationTests(unittest.TestCase):
 
         self.assertEqual(types.get_original_bases(E), (list[T],))
         self.assertEqual(types.get_original_bases(F), (list[int],))
+
+        class FirstBase(typing.Generic[T]): pass
+        class SecondBase(typing.Generic[T]): pass
+        class First(FirstBase[int]): pass
+        class Second(SecondBase[int]): pass
+        class G(First, Second): pass
+        self.assertEqual(types.get_original_bases(G), (First, Second))
+
+        class First_(typing.Generic[T]): pass
+        class Second_(typing.Generic[T]): pass
+        class H(First_, Second_): pass
+        self.assertEqual(types.get_original_bases(G), (First, Second))
 
         class ClassBasedNamedTuple(typing.NamedTuple):
             x: int

--- a/Lib/types.py
+++ b/Lib/types.py
@@ -164,15 +164,15 @@ def get_original_bases(cls, /):
         assert get_original_bases(Spam) == (TypedDict,)
         assert get_original_bases(int) == (object,)
     """
-    try:
+    if "__orig_bases__" in cls.__dict__:  # GH-107576: don't return the parent's
         return cls.__orig_bases__
+
+    try:
+        return cls.__bases__
     except AttributeError:
-        try:
-            return cls.__bases__
-        except AttributeError:
-            raise TypeError(
-                f'Expected an instance of type, not {type(cls).__name__!r}'
-            ) from None
+        raise TypeError(
+            f"Expected an instance of type, not {type(cls).__name__!r}"
+        ) from None
 
 
 class DynamicClassAttribute:

--- a/Lib/types.py
+++ b/Lib/types.py
@@ -165,15 +165,7 @@ def get_original_bases(cls, /):
         assert get_original_bases(int) == (object,)
     """
     try:
-        cls_dict = cls.__dict__
-    except AttributeError:
-        pass
-    else:
-        if "__orig_bases__" in cls_dict:  # GH-107576: don't return the parent's
-            return cls.__orig_bases__
-
-    try:
-        return cls.__bases__
+        return cls.__dict__.get("__orig_bases__", cls.__bases__)
     except AttributeError:
         raise TypeError(
             f"Expected an instance of type, not {type(cls).__name__!r}"

--- a/Lib/types.py
+++ b/Lib/types.py
@@ -164,8 +164,13 @@ def get_original_bases(cls, /):
         assert get_original_bases(Spam) == (TypedDict,)
         assert get_original_bases(int) == (object,)
     """
-    if "__orig_bases__" in cls.__dict__:  # GH-107576: don't return the parent's
-        return cls.__orig_bases__
+    try:
+        cls_dict = cls.__dict__
+    except AttributeError:
+        pass
+    else:
+        if "__orig_bases__" in cls_dict:  # GH-107576: don't return the parent's
+            return cls.__orig_bases__
 
     try:
         return cls.__bases__

--- a/Misc/NEWS.d/next/Library/2023-08-03-11-31-11.gh-issue-107576.pO_s9I.rst
+++ b/Misc/NEWS.d/next/Library/2023-08-03-11-31-11.gh-issue-107576.pO_s9I.rst
@@ -1,0 +1,1 @@
+Fix :func:`types.get_original_bases` to only return :attr:`object.__orig_bases__` if it is present on `cls` directly. Patch by James Hilton-Balfe.

--- a/Misc/NEWS.d/next/Library/2023-08-03-11-31-11.gh-issue-107576.pO_s9I.rst
+++ b/Misc/NEWS.d/next/Library/2023-08-03-11-31-11.gh-issue-107576.pO_s9I.rst
@@ -1,1 +1,1 @@
-Fix :func:`types.get_original_bases` to only return :attr:`object.__orig_bases__` if it is present on `cls` directly. Patch by James Hilton-Balfe.
+Fix :func:`types.get_original_bases` to only return :attr:`object.__orig_bases__` if it is present on ``cls`` directly. Patch by James Hilton-Balfe.

--- a/Misc/NEWS.d/next/Library/2023-08-03-11-31-11.gh-issue-107576.pO_s9I.rst
+++ b/Misc/NEWS.d/next/Library/2023-08-03-11-31-11.gh-issue-107576.pO_s9I.rst
@@ -1,3 +1,3 @@
 Fix :func:`types.get_original_bases` to only return
-:attr:`!object.__orig_bases__` if it is present on ``cls`` directly. Patch by
+:attr:`!__orig_bases__` if it is present on ``cls`` directly. Patch by
 James Hilton-Balfe.

--- a/Misc/NEWS.d/next/Library/2023-08-03-11-31-11.gh-issue-107576.pO_s9I.rst
+++ b/Misc/NEWS.d/next/Library/2023-08-03-11-31-11.gh-issue-107576.pO_s9I.rst
@@ -1,1 +1,3 @@
-Fix :func:`types.get_original_bases` to only return :attr:`object.__orig_bases__` if it is present on ``cls`` directly. Patch by James Hilton-Balfe.
+Fix :func:`types.get_original_bases` to only return
+:attr:`!object.__orig_bases__` if it is present on ``cls`` directly. Patch by
+James Hilton-Balfe.


### PR DESCRIPTION


<!-- gh-issue-number: gh-107576 -->
* Issue: gh-107576
<!-- /gh-issue-number -->
