### PR TITLE
gh-107562: Lib/test: update test certificates to expire far in the future

### DIFF
--- a/Lib/test/certdata/make_ssl_certs.py
+++ b/Lib/test/certdata/make_ssl_certs.py
@@ -9,8 +9,8 @@ import tempfile
 from subprocess import *
 
 startdate = "20180829142316Z"
-enddate_default = "20371028142316Z"
-days_default = "7000"
+enddate_default = "25251028142316Z"
+days_default = "140000"
 
 req_template = """
     [ default ]

--- a/Lib/test/test_ssl.py
+++ b/Lib/test/test_ssl.py
@@ -383,6 +383,7 @@ class BasicSocketTests(unittest.TestCase):
         ssl.RAND_add(bytearray(b"this is a random bytearray object"), 75.0)
 
     def test_parse_cert(self):
+        self.maxDiff = None
         # note that this uses an 'unofficial' function in _ssl.c,
         # provided solely for this test, to exercise the certificate
         # parsing code

--- a/Misc/NEWS.d/next/Tests/2023-08-03-17-26-55.gh-issue-107562.ZnbscS.rst
+++ b/Misc/NEWS.d/next/Tests/2023-08-03-17-26-55.gh-issue-107562.ZnbscS.rst
@@ -1,0 +1,3 @@
+Test certificates have been updated to expire far in the future. This allows
+testing Y2038 with system time set to after that, so that actual Y2038
+issues can be exposed, and not masked by expired certificate errors.


### PR DESCRIPTION
This allows testing Y2038 with system time set to after that, so that actual Y2038 issues can be exposed, and not masked by expired certificate errors.


<!-- gh-issue-number: gh-107562 -->
* Issue: gh-107562
<!-- /gh-issue-number -->
