### PR TITLE
[3.10] Revert "[3.10] gh-107077: Raise SSLCertVerificationError even if the error is set via SSL_ERROR_SYSCALL (GH-107586) (#107589)"

### DIFF
--- a/Misc/NEWS.d/next/Library/2023-08-03-12-52-19.gh-issue-107077.-pzHD6.rst
+++ b/Misc/NEWS.d/next/Library/2023-08-03-12-52-19.gh-issue-107077.-pzHD6.rst
@@ -1,6 +1,0 @@
-Seems that in some conditions, OpenSSL will return ``SSL_ERROR_SYSCALL``
-instead of ``SSL_ERROR_SSL`` when a certification verification has failed,
-but the error parameters will still contain ``ERR_LIB_SSL`` and
-``SSL_R_CERTIFICATE_VERIFY_FAILED``. We are now detecting this situation and
-raising the appropiate ``ssl.SSLCertVerificationError``. Patch by Pablo
-Galindo

--- a/Modules/_ssl.c
+++ b/Modules/_ssl.c
@@ -656,10 +656,6 @@ PySSL_SetError(PySSLSocket *sslsock, int ret, const char *filename, int lineno)
                     errstr = "Some I/O error occurred";
                 }
             } else {
-                if (ERR_GET_LIB(e) == ERR_LIB_SSL &&
-                        ERR_GET_REASON(e) == SSL_R_CERTIFICATE_VERIFY_FAILED) {
-                    type = state->PySSLCertVerificationErrorObject;
-                }
                 p = PY_SSL_ERROR_SYSCALL;
             }
             break;


### PR DESCRIPTION
This reverts commit 24d54feafc28a9fb421de852d830cc370fe51db3.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-107077 -->
* Issue: gh-107077
<!-- /gh-issue-number -->
