### PR TITLE
gh-106368: Argument clinic tests: improve error message when `expect_success()` fails

### DIFF
--- a/Lib/test/test_clinic.py
+++ b/Lib/test/test_clinic.py
@@ -1680,7 +1680,8 @@ class ClinicExternalTest(TestCase):
 
     def expect_success(self, *args):
         out, err, code = self.run_clinic(*args)
-        self.assertEqual(code, 0, f"Unexpected failure: {args=}")
+        if code != 0:
+            self.fail("\n".join([f"Unexpected failure: {args=}", out, err]))
         self.assertEqual(err, "")
         return out
 


### PR DESCRIPTION
In #107469, we accidentally reintroduced the issue that I previously fixed in #107364, meaning it's once again impossible to figure out why any of the functional tests in `Lib/test/clinic.test.c` are failing (if you make a change locally that causes them to fail)

<!-- gh-issue-number: gh-106368 -->
* Issue: gh-106368
<!-- /gh-issue-number -->
