### PR TITLE
gh-104146: Argument clinic: remove unused methods and variables

### DIFF
--- a/Tools/clinic/clinic.py
+++ b/Tools/clinic/clinic.py
@@ -377,8 +377,10 @@ def version_splitter(s: str) -> tuple[int, ...]:
     return tuple(version)
 
 def version_comparitor(version1: str, version2: str) -> Literal[-1, 0, 1]:
-    iterator = itertools.zip_longest(version_splitter(version1), version_splitter(version2), fillvalue=0)
-    for i, (a, b) in enumerate(iterator):
+    iterator = itertools.zip_longest(
+        version_splitter(version1), version_splitter(version2), fillvalue=0
+    )
+    for a, b in iterator:
         if a < b:
             return -1
         if a > b:
@@ -4368,19 +4370,11 @@ class IndentStack:
         """
         return len(self.indents)
 
-    def indent(self, line: str) -> str:
-        """
-        Indents a line by the currently defined margin.
-        """
-        assert self.margin is not None, "Cannot call .indent() before calling .infer()"
-        return self.margin + line
-
     def dedent(self, line: str) -> str:
         """
         Dedents a line by the currently defined margin.
-        (The inverse of 'indent'.)
         """
-        assert self.margin is not None, "Cannot call .indent() before calling .infer()"
+        assert self.margin is not None, "Cannot call .dedent() before calling .infer()"
         margin = self.margin
         indent = self.indents[-1]
         if not line.startswith(margin):
@@ -4640,10 +4634,6 @@ class DSLParser:
             return False
 
         return True
-
-    @staticmethod
-    def calculate_indent(line: str) -> int:
-        return len(line) - len(line.strip())
 
     def next(
             self,

--- a/Tools/clinic/cpp.py
+++ b/Tools/clinic/cpp.py
@@ -65,14 +65,6 @@ class Monitor:
         print("   ", ' '.join(str(x) for x in a))
         sys.exit(-1)
 
-    def close(self) -> None:
-        if self.stack:
-            self.fail("Ended file while still in a preprocessor conditional block!")
-
-    def write(self, s: str) -> None:
-        for line in s.split("\n"):
-            self.writeline(line)
-
     def writeline(self, line: str) -> None:
         self.line_number += 1
         line = line.strip()


### PR DESCRIPTION
- The `i` variable in `version_comparitor` was unused (it was a useless use of `enumerate`; we can just iterate directly over the iterator).
- The methods `IndentStack.indent()`, `DSLParser.calculate_indent()`, `cpp.Monitor.close()` and `cpp.Monitor.write()` all have no test coverage. They are not used or referenced anywhere in `Tools/clinic`; the test suite passes without them; mypy and pyflakes pass without them; and Python builds without them. I think they can all be removed.

<!-- gh-issue-number: gh-104146 -->
* Issue: gh-104146
<!-- /gh-issue-number -->
