### PR TITLE
gh-107421: Clarify `OrderedDict` Examples and Recipes

### DIFF
--- a/Doc/library/collections.rst
+++ b/Doc/library/collections.rst
@@ -1224,7 +1224,7 @@ variants of :func:`functools.lru_cache`:
             result = self.func(*args)
             self.cache[args] = time(), result
             if len(self.cache) > self.maxsize:
-                self.cache.popitem(0)
+                self.cache.popitem(last=False)
             return result
 
 
@@ -1256,12 +1256,12 @@ variants of :func:`functools.lru_cache`:
             if self.requests[args] <= self.cache_after:
                 self.requests.move_to_end(args)
                 if len(self.requests) > self.maxrequests:
-                    self.requests.popitem(0)
+                    self.requests.popitem(last=False)
             else:
                 self.requests.pop(args, None)
                 self.cache[args] = result
                 if len(self.cache) > self.maxsize:
-                    self.cache.popitem(0)
+                    self.cache.popitem(last=False)
             return result
 
 .. doctest::

--- a/Doc/library/collections.rst
+++ b/Doc/library/collections.rst
@@ -1260,7 +1260,7 @@ variants of :func:`functools.lru_cache`:
             else:
                 # no longer need to keep track of how many times this
                 # entry has been seen; in a single-threaded environment,
-                # the `requests` OrderedDict will always contain the value
+                # the self.requests OrderedDict will always contain the value
                 # being removed, but use `pop(args, None)` to reduce
                 # complications in a multi-threaded environment where
                 # a race condition may cause an exception

--- a/Doc/library/collections.rst
+++ b/Doc/library/collections.rst
@@ -1258,7 +1258,9 @@ variants of :func:`functools.lru_cache`:
                 if len(self.requests) > self.maxrequests:
                     self.requests.popitem(last=False)
             else:
-                self.requests.pop(args) # no longer need to keep track of how many times this entry has been seen
+                # no longer need to keep track of how many times this
+                # entry has been seen
+                self.requests.pop(args)
                 if len(self.cache) == self.maxsize:
                     self.cache.popitem(last=False)
                 self.cache[args] = result

--- a/Doc/library/collections.rst
+++ b/Doc/library/collections.rst
@@ -1258,7 +1258,7 @@ variants of :func:`functools.lru_cache`:
                 if len(self.requests) > self.maxrequests:
                     self.requests.popitem(last=False)
             else:
-                self.requests.pop(args, None)
+                self.requests.pop(args)
                 self.cache[args] = result
                 if len(self.cache) > self.maxsize:
                     self.cache.popitem(last=False)

--- a/Doc/library/collections.rst
+++ b/Doc/library/collections.rst
@@ -1252,13 +1252,12 @@ variants of :func:`functools.lru_cache`:
                 self.cache.move_to_end(args)
                 return self.cache[args]
             result = self.func(*args)
-            self.requests[args] = self.requests.get(args, 0) + 1 # increment existing value by 1 if seen before, otherwise set to 1
+            self.requests[args] = self.requests.get(args, 0) + 1
             if self.requests[args] <= self.cache_after:
                 self.requests.move_to_end(args)
                 if len(self.requests) > self.maxrequests:
                     self.requests.popitem(last=False)
             else:
-                # entry has been seen more than cache_after times
                 self.requests.pop(args) # no longer need to keep track of how many times this entry has been seen
                 if len(self.cache) == self.maxsize:
                     self.cache.popitem(last=False)

--- a/Doc/library/collections.rst
+++ b/Doc/library/collections.rst
@@ -1259,8 +1259,12 @@ variants of :func:`functools.lru_cache`:
                     self.requests.popitem(last=False)
             else:
                 # no longer need to keep track of how many times this
-                # entry has been seen
-                self.requests.pop(args)
+                # entry has been seen; in a single-threaded environment,
+                # the `requests` OrderedDict will always contain the value
+                # being removed, but use `pop(args, None)` to reduce
+                # complications in a multi-threaded environment where
+                # a race condition may cause an exception
+                self.requests.pop(args, None)
                 if len(self.cache) == self.maxsize:
                     self.cache.popitem(last=False)
                 self.cache[args] = result

--- a/Doc/library/collections.rst
+++ b/Doc/library/collections.rst
@@ -1265,9 +1265,9 @@ variants of :func:`functools.lru_cache`:
                 # complications in a multi-threaded environment where
                 # a race condition may cause an exception
                 self.requests.pop(args, None)
-                if len(self.cache) == self.maxsize:
-                    self.cache.popitem(last=False)
                 self.cache[args] = result
+                if len(self.cache) > self.maxsize:
+                    self.cache.popitem(last=False)
             return result
 
 .. doctest::

--- a/Doc/library/collections.rst
+++ b/Doc/library/collections.rst
@@ -1252,13 +1252,14 @@ variants of :func:`functools.lru_cache`:
                 self.cache.move_to_end(args)
                 return self.cache[args]
             result = self.func(*args)
-            self.requests[args] = self.requests.get(args, 0) + 1
+            self.requests[args] = self.requests.get(args, 0) + 1 # increment existing value by 1 if seen before, otherwise set to 1
             if self.requests[args] <= self.cache_after:
                 self.requests.move_to_end(args)
                 if len(self.requests) > self.maxrequests:
                     self.requests.popitem(last=False)
             else:
-                self.requests.pop(args)
+                # entry has been seen more than cache_after times
+                self.requests.pop(args) # no longer need to keep track of how many times this entry has been seen
                 self.cache[args] = result
                 if len(self.cache) > self.maxsize:
                     self.cache.popitem(last=False)

--- a/Doc/library/collections.rst
+++ b/Doc/library/collections.rst
@@ -1260,9 +1260,9 @@ variants of :func:`functools.lru_cache`:
             else:
                 # entry has been seen more than cache_after times
                 self.requests.pop(args) # no longer need to keep track of how many times this entry has been seen
-                self.cache[args] = result
-                if len(self.cache) > self.maxsize:
+                if len(self.cache) == self.maxsize:
                     self.cache.popitem(last=False)
+                self.cache[args] = result
             return result
 
 .. doctest::

--- a/Doc/library/collections.rst
+++ b/Doc/library/collections.rst
@@ -1258,12 +1258,6 @@ variants of :func:`functools.lru_cache`:
                 if len(self.requests) > self.maxrequests:
                     self.requests.popitem(last=False)
             else:
-                # no longer need to keep track of how many times this
-                # entry has been seen; in a single-threaded environment,
-                # the self.requests OrderedDict will always contain the value
-                # being removed, but use pop(args, None) to reduce
-                # complications in a multi-threaded environment where
-                # a race condition may cause an exception
                 self.requests.pop(args, None)
                 self.cache[args] = result
                 if len(self.cache) > self.maxsize:

--- a/Doc/library/collections.rst
+++ b/Doc/library/collections.rst
@@ -1261,7 +1261,7 @@ variants of :func:`functools.lru_cache`:
                 # no longer need to keep track of how many times this
                 # entry has been seen; in a single-threaded environment,
                 # the self.requests OrderedDict will always contain the value
-                # being removed, but use `pop(args, None)` to reduce
+                # being removed, but use pop(args, None) to reduce
                 # complications in a multi-threaded environment where
                 # a race condition may cause an exception
                 self.requests.pop(args, None)


### PR DESCRIPTION
<strike>
In addition to updating the documentation to include the changes suggested in https://github.com/python/cpython/issues/107421, this PR also makes a minor fix in commit ff22bac665c0520fc27d16bc254563adf30afc06 to ensure the <code>MultiHitLRUCache</code> never has more than <code>maxsize</code> items in the <code>cache</code> attribute at any given time (see the commit message for more information).
</strike>
<br>

See https://github.com/python/cpython/pull/107613#discussion_r1284124385 for an explanation about why "never [having] more than `maxsize` items in the `cache` attribute at any given time" might not be a good idea.

<!-- gh-issue-number: gh-107421 -->
* Issue: gh-107421
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--107613.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->

Here's the direct link to the preview of the [`OrderedDict` Examples and Recipes section](https://cpython-previews--107613.org.readthedocs.build/en/107613/library/collections.html#ordereddict-examples-and-recipes)