### PR TITLE
Docs: upgrade to python-docs-theme 2023.7

### DIFF
--- a/Doc/requirements.txt
+++ b/Doc/requirements.txt
@@ -7,7 +7,7 @@
 # won't suddenly cause build failures. Updating the version is fine as long
 # as no warnings are raised by doing so.
 # PR #104777: Sphinx 6.2 no longer uses imghdr, removed in Python 3.13.
-sphinx==6.2.0
+sphinx==6.2.1
 
 blurb
 
@@ -15,6 +15,6 @@ sphinxext-opengraph==0.7.5
 
 # The theme used by the documentation is stored separately, so we need
 # to install that as well.
-python-docs-theme>=2022.1
+python-docs-theme==2023.7
 
 -c constraints.txt

--- a/Doc/requirements.txt
+++ b/Doc/requirements.txt
@@ -15,6 +15,6 @@ sphinxext-opengraph==0.7.5
 
 # The theme used by the documentation is stored separately, so we need
 # to install that as well.
-python-docs-theme==2023.7
+python-docs-theme>=2023.7
 
 -c constraints.txt


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

The venv used on the docs server persists between deploys, therefore let's pin the theme so we get the version we want:

* https://github.com/python/python-docs-theme/releases/tag/2023.7

This means we'll get the dark theme for 3.11 (aka the main https://docs.python.org/3/). We've already had it on https://docs.python.org/3.12/ and https://docs.python.org/3.13/ for a few months.

---

Let's also bump Sphinx to include the latest 6.x patch release:

* https://www.sphinx-doc.org/en/master/changes.html#release-6-2-1-released-apr-25-2023

(We have another PR to upgrade Sphinx to 7.x, let's handle that separately: https://github.com/python/cpython/pull/99381)

<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--107617.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->