### PR TITLE
gh-104683: Argument Clinic: refactor format_docstring()

### DIFF
--- a/Tools/clinic/clinic.py
+++ b/Tools/clinic/clinic.py
@@ -5310,8 +5310,8 @@ class DSLParser:
 
     @staticmethod
     def format_docstring_signature(
-            f: Function,
-            parameters: list[Parameter]
+        f: Function,
+        parameters: list[Parameter]
     ) -> str:
         text, add, output = _text_accumulator()
         if f.kind.new_or_init:

--- a/Tools/clinic/clinic.py
+++ b/Tools/clinic/clinic.py
@@ -5504,10 +5504,8 @@ class DSLParser:
 
         self.docstring_append(self.function, line)
 
-    @staticmethod
     def format_docstring_signature(
-        f: Function,
-        parameters: list[Parameter]
+        self, f: Function, parameters: list[Parameter]
     ) -> str:
         text, add, output = _text_accumulator()
         if f.kind.new_or_init:

--- a/Tools/clinic/clinic.py
+++ b/Tools/clinic/clinic.py
@@ -5520,7 +5520,7 @@ class DSLParser:
         # Guido said Clinic should enforce this:
         # http://mail.python.org/pipermail/python-dev/2013-June/127110.html
 
-        lines = [line for line in f.docstring.split('\n')]
+        lines = f.docstring.split('\n')
         if len(lines) >= 2:
             if lines[1]:
                 fail("Docstring for " + f.full_name + " does not have a summary line!\n" +

--- a/Tools/clinic/clinic.py
+++ b/Tools/clinic/clinic.py
@@ -5694,7 +5694,7 @@ class DSLParser:
             add("  ")
             add(param.name)
             add('\n')
-            stripped = rstrip_lines(docstring.rstrip())
+            stripped = rstrip_lines(docstring)
             add(textwrap.indent(stripped, "    "))
         if text:
             add('\n')

--- a/Tools/clinic/clinic.py
+++ b/Tools/clinic/clinic.py
@@ -5520,7 +5520,7 @@ class DSLParser:
         # Guido said Clinic should enforce this:
         # http://mail.python.org/pipermail/python-dev/2013-June/127110.html
 
-        lines = f.docstring.splitlines()
+        lines = [line for line in f.docstring.split('\n')]
         if len(lines) >= 2:
             if lines[1]:
                 fail("Docstring for " + f.full_name + " does not have a summary line!\n" +

--- a/Tools/clinic/clinic.py
+++ b/Tools/clinic/clinic.py
@@ -5520,7 +5520,7 @@ class DSLParser:
         # Guido said Clinic should enforce this:
         # http://mail.python.org/pipermail/python-dev/2013-June/127110.html
 
-        lines = [line for line in f.docstring.split('\n')]
+        lines = f.docstring.splitlines()
         if len(lines) >= 2:
             if lines[1]:
                 fail("Docstring for " + f.full_name + " does not have a summary line!\n" +


### PR DESCRIPTION
Extract helper methods for formatting the signature and parameter
sections, and clean up the remaining function body.


<!-- gh-issue-number: gh-104683 -->
* Issue: gh-104683
<!-- /gh-issue-number -->
