### PR TITLE
[3.12] Update the expected bytecode magic in test_importlib.test_util

### DIFF
--- a/Lib/test/test_importlib/test_util.py
+++ b/Lib/test/test_importlib/test_util.py
@@ -634,7 +634,7 @@ class MagicNumberTests(unittest.TestCase):
         # stakeholders such as OS package maintainers must be notified
         # in advance. Such exceptional releases will then require an
         # adjustment to this test case.
-        EXPECTED_MAGIC_NUMBER = 3495
+        EXPECTED_MAGIC_NUMBER = 3531
         actual = int.from_bytes(importlib.util.MAGIC_NUMBER[:2], 'little')
 
         msg = (


### PR DESCRIPTION
Update the expected bytecode magic in test_importlib.test_util to the final 3.12 magic number. From now on it's not allowed to change for any 3.12 release.
