### PR TITLE
Docs: Only include Plausible for html, not for epub etc

### DIFF
--- a/Doc/tools/templates/layout.html
+++ b/Doc/tools/templates/layout.html
@@ -26,7 +26,9 @@
 {% endblock %}
 
 {% block extrahead %}
-    <script defer data-domain="docs.python.org" src="https://plausible.io/js/script.js"></script>
+    {% if builder == "html" %}
+      <script defer data-domain="docs.python.org" src="https://plausible.io/js/script.js"></script>
+    {% endif %}
     <link rel="canonical" href="https://docs.python.org/3/{{pagename}}.html" />
     {% if builder != "htmlhelp" %}
       {% if pagename == 'whatsnew/changelog' and not embedded %}


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

Fixes report at:
https://mail.python.org/archives/list/docs@python.org/thread/HSIILYH7LVK4JU5U5GWHHIP4PU34UTNN/

> When I try to open the EPUB version of the Python documentation from Download Python 3.11.4 Documentation https://docs.python.org/3/archives/python-3.11.4-docs.epub using Apple’s Books program, i get the following error on every page. Please advise.

<details>
<summary>Screenshot</summary>
![image](https://github.com/python/cpython/assets/1324225/50ba1008-71c4-479b-97e5-3ab2304ef8ae)
</details>

> This page contains the following errors:
error on line 22 at column
19: Specification mandates value for attribute defer
Below is a rendering of the page up to the first error.



* Reproducible with https://docs.python.org/3/archives/python-3.11.4-docs.epub
* Not reproducible with https://docs.python.org/3/archives/python-3.11.3-docs.epub

We only need to include the Plausible metrics tags for the HTML build, not for epub etc. builds.

To test:

Before:

1. `make -C Doc htmlview`, view source and confirm `<script defer data-domain="docs.python.org" src="https://plausible.io/js/script.js"></script>` is present
2. `make -C Doc epub`, open `Doc/build/epub/Python.epub` in an app such as Books on Mac -> error shown

After:
1. As 1 above, tag is present
2. As 2 above but epub opens and can be read


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--107637.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->