### PR TITLE
gh-106368: Argument clinic: improve coverage for `self.valid_line()` calls

### DIFF
--- a/Lib/test/test_clinic.py
+++ b/Lib/test/test_clinic.py
@@ -1057,6 +1057,38 @@ class ClinicParserTest(TestCase):
             Okay, we're done here.
         """)
 
+    def test_docstring_with_comments(self):
+        function = self.parse_function(dedent("""
+            module foo
+            foo.bar
+              x: int
+                 # We're about to have
+                 # the documentation for x.
+                 Documentation for x.
+                 # We've just had
+                 # the documentation for x.
+              y: int
+
+            # We're about to have
+            # the documentation for foo.
+            This is the documentation for foo.
+            # We've just had
+            # the documentation for foo.
+
+            Okay, we're done here.
+        """))
+        self.checkDocstring(function, """
+            bar($module, /, x, y)
+            --
+
+            This is the documentation for foo.
+
+              x
+                Documentation for x.
+
+            Okay, we're done here.
+        """)
+
     def test_parser_regression_special_character_in_parameter_column_of_docstring_first_line(self):
         function = self.parse_function(dedent("""
             module os

--- a/Tools/clinic/clinic.py
+++ b/Tools/clinic/clinic.py
@@ -4685,9 +4685,7 @@ class DSLParser:
         # this line is permitted to start with whitespace.
         # we'll call this number of spaces F (for "function").
 
-        if not self.valid_line(line):
-            return
-
+        assert self.valid_line(line)
         self.indent.infer(line)
 
         # are we cloning?


### PR DESCRIPTION
The early return in `self.state_modulename_name()` is unreachable, as `state_modulename_name()` is only ever called from `state_dsl_start`, and the first thing `state_dsl_start` does is check whether the `line` is valid:

https://github.com/python/cpython/blob/321f0f79325adfe7656645060c2008d5779e1a7f/Tools/clinic/clinic.py#L4655-L4657

There are two other `if not self.valid_line(line)` branches in `clinic.py` which _are_ reachable, but are uncovered:

https://github.com/python/cpython/blob/321f0f79325adfe7656645060c2008d5779e1a7f/Tools/clinic/clinic.py#L5323-L5330

https://github.com/python/cpython/blob/321f0f79325adfe7656645060c2008d5779e1a7f/Tools/clinic/clinic.py#L5304-L5306

Add a test that covers both of them.

<!-- gh-issue-number: gh-106368 -->
* Issue: gh-106368
<!-- /gh-issue-number -->
