### PR TITLE
[3.12] gh-107630: Revert "[3.12] gh-107080: Fix Py_TRACE_REFS Crashes Under Isolated Subinterpreters (gh-107567) (#107599)"

### DIFF
--- a/Include/internal/pycore_object.h
+++ b/Include/internal/pycore_object.h
@@ -271,8 +271,8 @@ extern void _PyDebug_PrintTotalRefs(void);
 
 #ifdef Py_TRACE_REFS
 extern void _Py_AddToAllObjects(PyObject *op, int force);
-extern void _Py_PrintReferences(PyInterpreterState *, FILE *);
-extern void _Py_PrintReferenceAddresses(PyInterpreterState *, FILE *);
+extern void _Py_PrintReferences(FILE *);
+extern void _Py_PrintReferenceAddresses(FILE *);
 #endif
 
 

--- a/Include/internal/pycore_object_state.h
+++ b/Include/internal/pycore_object_state.h
@@ -11,22 +11,17 @@ extern "C" {
 struct _py_object_runtime_state {
 #ifdef Py_REF_DEBUG
     Py_ssize_t interpreter_leaks;
-#endif
+#else
     int _not_used;
+#endif
 };
 
 struct _py_object_state {
 #ifdef Py_REF_DEBUG
     Py_ssize_t reftotal;
-#endif
-#ifdef Py_TRACE_REFS
-    /* Head of circular doubly-linked list of all objects.  These are linked
-     * together via the _ob_prev and _ob_next members of a PyObject, which
-     * exist only in a Py_TRACE_REFS build.
-     */
-    PyObject refchain;
-#endif
+#else
     int _not_used;
+#endif
 };
 
 

--- a/Include/internal/pycore_runtime_init.h
+++ b/Include/internal/pycore_runtime_init.h
@@ -101,7 +101,6 @@ extern PyTypeObject _PyExc_MemoryError;
                 { .threshold = 10, }, \
             }, \
         }, \
-        .object_state = _py_object_state_INIT(INTERP), \
         .dtoa = _dtoa_state_INIT(&(INTERP)), \
         .dict_state = _dict_state_INIT, \
         .func_state = { \
@@ -130,16 +129,6 @@ extern PyTypeObject _PyExc_MemoryError;
         .py_recursion_limit = Py_DEFAULT_RECURSION_LIMIT, \
         .context_ver = 1, \
     }
-
-#ifdef Py_TRACE_REFS
-# define _py_object_state_INIT(INTERP) \
-    { \
-        .refchain = {&INTERP.object_state.refchain, &INTERP.object_state.refchain}, \
-    }
-#else
-# define _py_object_state_INIT(INTERP) \
-    { 0 }
-#endif
 
 
 // global objects

--- a/Misc/NEWS.d/next/Core and Builtins/2023-08-02-12-24-51.gh-issue-107080.PNolFU.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2023-08-02-12-24-51.gh-issue-107080.PNolFU.rst
@@ -1,4 +1,0 @@
-Trace refs builds (``--with-trace-refs``) were crashing when used with
-isolated subinterpreters.  The problematic global state has been isolated to
-each interpreter.  Other fixing the crashes, this change does not affect
-users.

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -1920,11 +1920,11 @@ Py_FinalizeEx(void)
     }
 
     if (dump_refs) {
-        _Py_PrintReferences(tstate->interp, stderr);
+        _Py_PrintReferences(stderr);
     }
 
     if (dump_refs_fp != NULL) {
-        _Py_PrintReferences(tstate->interp, dump_refs_fp);
+        _Py_PrintReferences(dump_refs_fp);
     }
 #endif /* Py_TRACE_REFS */
 
@@ -1960,11 +1960,11 @@ Py_FinalizeEx(void)
      */
 
     if (dump_refs) {
-        _Py_PrintReferenceAddresses(tstate->interp, stderr);
+        _Py_PrintReferenceAddresses(stderr);
     }
 
     if (dump_refs_fp != NULL) {
-        _Py_PrintReferenceAddresses(tstate->interp, dump_refs_fp);
+        _Py_PrintReferenceAddresses(dump_refs_fp);
         fclose(dump_refs_fp);
     }
 #endif /* Py_TRACE_REFS */


### PR DESCRIPTION
This reverts commit 58af2293c52a1ad3754d254690c0e54f787c545b.

<!-- gh-issue-number: gh-107630 -->
* Issue: gh-107630
<!-- /gh-issue-number -->
