### PR TITLE
gh-106812: Fix two tiny bugs in analysis.py

### DIFF
--- a/Tools/cases_generator/analysis.py
+++ b/Tools/cases_generator/analysis.py
@@ -297,6 +297,8 @@ class Analyzer:
         def get_var_names(instr: Instruction) -> dict[str, StackEffect]:
             vars: dict[str, StackEffect] = {}
             for eff in instr.input_effects + instr.output_effects:
+                if eff.name == UNUSED:
+                    continue
                 if eff.name in vars:
                     if vars[eff.name] != eff:
                         self.error(
@@ -335,7 +337,7 @@ class Analyzer:
                 copies: list[tuple[StackEffect, StackEffect]] = []
                 while pushes and pops and pushes[-1] == pops[0]:
                     src, dst = pushes.pop(), pops.pop(0)
-                    if src.name == dst.name or dst.name is UNUSED:
+                    if src.name == dst.name or dst.name == UNUSED:
                         continue
                     copies.append((src, dst))
                 reads = set(copy[0].name for copy in copies)


### PR DESCRIPTION
This fixes two tiny defects in analysis.py that I didn't catch on time in #107564:

- `get_var_names` in `check_macro_consistency` should skip `UNUSED` names.
- Fix an occurrence of `is UNUSED` (should be `==`).

I plan to just land this once the tests pass. OTOH I might tack on additional issues if I happen to run into them over the weekend.

<!-- gh-issue-number: gh-106812 -->
* Issue: gh-106812
<!-- /gh-issue-number -->
