### PR TITLE
GH-106684: raise ResourceWarning when StreamWriter is not closed

### DIFF
--- a/Lib/asyncio/streams.py
+++ b/Lib/asyncio/streams.py
@@ -5,6 +5,7 @@ __all__ = (
 import collections
 import socket
 import sys
+import warnings
 import weakref
 
 if hasattr(socket, 'AF_UNIX'):
@@ -392,6 +393,11 @@ class StreamWriter:
         self._transport = new_transport
         protocol._replace_writer(self)
 
+    def __del__(self, warnings=warnings):
+        if not self._transport.is_closing():
+            self.close()
+            warnings.warn(f"unclosed {self!r}", ResourceWarning)
+
 
 class StreamReader:
 
@@ -746,3 +752,4 @@ class StreamReader:
         if val == b'':
             raise StopAsyncIteration
         return val
+

--- a/Lib/asyncio/streams.py
+++ b/Lib/asyncio/streams.py
@@ -752,4 +752,3 @@ class StreamReader:
         if val == b'':
             raise StopAsyncIteration
         return val
-

--- a/Misc/NEWS.d/next/Library/2023-08-05-05-10-41.gh-issue-106684.P9zRXb.rst
+++ b/Misc/NEWS.d/next/Library/2023-08-05-05-10-41.gh-issue-106684.P9zRXb.rst
@@ -1,0 +1,1 @@
+Raise :exc:`ResourceWarning` when :class:`asyncio.StreamWriter` is not closed leading to memory leaks. Patch by Kumar Aditya.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-106684 -->
* Issue: gh-106684
<!-- /gh-issue-number -->
