### PR TITLE
gh-107659: ctypes: Add docstrings for `ctypes.pointer` and `ctypes.POINTER`

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2023-08-05-15-45-07.gh-issue-107659.QgtQ5M.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2023-08-05-15-45-07.gh-issue-107659.QgtQ5M.rst
@@ -1,0 +1,1 @@
+Add docstrings for :func:`ctypes.pointer` and :func:`ctypes.POINTER`.

--- a/Modules/_ctypes/callproc.c
+++ b/Modules/_ctypes/callproc.c
@@ -1905,7 +1905,7 @@ _ctypes.POINTER as create_pointer_type
     type as cls: object
     /
 
-Creates and returns a new ctypes pointer type.
+Create and return a new ctypes pointer type.
 
 Pointer types are cached and reused internally, so calling this function
 repeatedly is cheap. 'type' must be a ctypes type.
@@ -1969,7 +1969,7 @@ _ctypes.pointer as create_pointer_inst
     obj as arg: object
     /
 
-Creates a new pointer instance, pointing to 'obj'.
+Create a new pointer instance, pointing to 'obj'.
 
 The returned object is of the type POINTER(type(obj)). Note that if you just
 want to pass a pointer to an object to a foreign function call,

--- a/Modules/_ctypes/callproc.c
+++ b/Modules/_ctypes/callproc.c
@@ -1971,7 +1971,7 @@ _ctypes.pointer as create_pointer_inst
 
 Create a new pointer instance, pointing to 'obj'.
 
-The returned object is of the type POINTER(type(obj)). Note that if you just
+Return an object of type POINTER(type(obj)). Note that if you just
 want to pass a pointer to an object to a foreign function call,
 you should use byref(obj) which is much faster.
 [clinic start generated code]*/

--- a/Modules/_ctypes/callproc.c
+++ b/Modules/_ctypes/callproc.c
@@ -1966,7 +1966,7 @@ create_pointer_type(PyObject *module, PyObject *cls)
 /*[clinic input]
 _ctypes.pointer as create_pointer_inst
 
-    obj: object
+    obj as arg: object
     /
 
 Creates a new pointer instance, pointing to 'obj'.
@@ -1977,23 +1977,23 @@ you should use byref(obj) which is much faster.
 [clinic start generated code]*/
 
 static PyObject *
-create_pointer_inst(PyObject *module, PyObject *obj)
-/*[clinic end generated code: output=1039888809db21a2 input=925d2ec210c75c47]*/
+create_pointer_inst(PyObject *module, PyObject *arg)
+/*[clinic end generated code: output=3b543bc9f0de2180 input=649dec8dad8c0e52]*/
 {
     PyObject *result;
     PyObject *typ;
 
-    typ = PyDict_GetItemWithError(_ctypes_ptrtype_cache, (PyObject *)Py_TYPE(obj));
+    typ = PyDict_GetItemWithError(_ctypes_ptrtype_cache, (PyObject *)Py_TYPE(arg));
     if (typ) {
-        return PyObject_CallOneArg(typ, obj);
+        return PyObject_CallOneArg(typ, arg);
     }
     else if (PyErr_Occurred()) {
         return NULL;
     }
-    typ = create_pointer_type(NULL, (PyObject *)Py_TYPE(obj));
+    typ = create_pointer_type(NULL, (PyObject *)Py_TYPE(arg));
     if (typ == NULL)
         return NULL;
-    result = PyObject_CallOneArg(typ, obj);
+    result = PyObject_CallOneArg(typ, arg);
     Py_DECREF(typ);
     return result;
 }

--- a/Modules/_ctypes/callproc.c
+++ b/Modules/_ctypes/callproc.c
@@ -1972,14 +1972,14 @@ _ctypes.pointer as create_pointer_inst
 
 Create a new pointer instance, pointing to 'obj'.
 
-The returned object is of the type POINTER(type(obj)). Note that if you just
-want to pass a pointer to an object to a foreign function call,
-you should use byref(obj) which is much faster.
+The returned object is of the type POINTER(type(obj)). Note that if you
+just want to pass a pointer to an object to a foreign function call, you
+should use byref(obj) which is much faster.
 [clinic start generated code]*/
 
 static PyObject *
 create_pointer_inst(PyObject *module, PyObject *arg)
-/*[clinic end generated code: output=3b543bc9f0de2180 input=c133818141785580]*/
+/*[clinic end generated code: output=3b543bc9f0de2180 input=713685fdb4d9bc27]*/
 {
     PyObject *result;
     PyObject *typ;

--- a/Modules/_ctypes/callproc.c
+++ b/Modules/_ctypes/callproc.c
@@ -1903,17 +1903,18 @@ error:
 _ctypes.POINTER as create_pointer_type
 
     type as cls: object
+        A ctypes type.
     /
 
 Create and return a new ctypes pointer type.
 
-Pointer types are cached and reused internally, so calling this function
-repeatedly is cheap. 'type' must be a ctypes type.
+Pointer types are cached and reused internally,
+so calling this function repeatedly is cheap.
 [clinic start generated code]*/
 
 static PyObject *
 create_pointer_type(PyObject *module, PyObject *cls)
-/*[clinic end generated code: output=98c3547ab6f4f40b input=ccb867693e635dea]*/
+/*[clinic end generated code: output=98c3547ab6f4f40b input=3b81cff5ff9b9d5b]*/
 {
     PyObject *result;
     PyTypeObject *typ;
@@ -1971,14 +1972,14 @@ _ctypes.pointer as create_pointer_inst
 
 Create a new pointer instance, pointing to 'obj'.
 
-Return an object of type POINTER(type(obj)). Note that if you just
+The returned object is of the type POINTER(type(obj)). Note that if you just
 want to pass a pointer to an object to a foreign function call,
 you should use byref(obj) which is much faster.
 [clinic start generated code]*/
 
 static PyObject *
 create_pointer_inst(PyObject *module, PyObject *arg)
-/*[clinic end generated code: output=3b543bc9f0de2180 input=649dec8dad8c0e52]*/
+/*[clinic end generated code: output=3b543bc9f0de2180 input=c133818141785580]*/
 {
     PyObject *result;
     PyObject *typ;

--- a/Modules/_ctypes/callproc.c
+++ b/Modules/_ctypes/callproc.c
@@ -1902,7 +1902,7 @@ error:
 /*[clinic input]
 _ctypes.POINTER as create_pointer_type
 
-    type: object
+    type as cls: object
     /
 
 Creates and returns a new ctypes pointer type.
@@ -1912,22 +1912,22 @@ repeatedly is cheap. 'type' must be a ctypes type.
 [clinic start generated code]*/
 
 static PyObject *
-create_pointer_type(PyObject *module, PyObject *type)
-/*[clinic end generated code: output=6f3fdd0cf5308ce6 input=fcc2effb05dc7ab5]*/
+create_pointer_type(PyObject *module, PyObject *cls)
+/*[clinic end generated code: output=98c3547ab6f4f40b input=ccb867693e635dea]*/
 {
     PyObject *result;
     PyTypeObject *typ;
     PyObject *key;
 
-    result = PyDict_GetItemWithError(_ctypes_ptrtype_cache, type);
+    result = PyDict_GetItemWithError(_ctypes_ptrtype_cache, cls);
     if (result) {
         return Py_NewRef(result);
     }
     else if (PyErr_Occurred()) {
         return NULL;
     }
-    if (PyUnicode_CheckExact(type)) {
-        PyObject *name = PyUnicode_FromFormat("LP_%U", type);
+    if (PyUnicode_CheckExact(cls)) {
+        PyObject *name = PyUnicode_FromFormat("LP_%U", cls);
         result = PyObject_CallFunction((PyObject *)Py_TYPE(&PyCPointer_Type),
                                        "N(O){}",
                                        name,
@@ -1939,17 +1939,17 @@ create_pointer_type(PyObject *module, PyObject *type)
             Py_DECREF(result);
             return NULL;
         }
-    } else if (PyType_Check(type)) {
-        typ = (PyTypeObject *)type;
+    } else if (PyType_Check(cls)) {
+        typ = (PyTypeObject *)cls;
         PyObject *name = PyUnicode_FromFormat("LP_%s", typ->tp_name);
         result = PyObject_CallFunction((PyObject *)Py_TYPE(&PyCPointer_Type),
                                        "N(O){sO}",
                                        name,
                                        &PyCPointer_Type,
-                                       "_type_", type);
+                                       "_type_", cls);
         if (result == NULL)
             return result;
-        key = Py_NewRef(type);
+        key = Py_NewRef(cls);
     } else {
         PyErr_SetString(PyExc_TypeError, "must be a ctypes type");
         return NULL;

--- a/Modules/_ctypes/clinic/callproc.c.h
+++ b/Modules/_ctypes/clinic/callproc.c.h
@@ -1,0 +1,35 @@
+/*[clinic input]
+preserve
+[clinic start generated code]*/
+
+#if defined(Py_BUILD_CORE) && !defined(Py_BUILD_CORE_MODULE)
+#  include "pycore_gc.h"            // PyGC_Head
+#  include "pycore_runtime.h"       // _Py_ID()
+#endif
+
+
+PyDoc_STRVAR(create_pointer_type__doc__,
+"POINTER($module, type, /)\n"
+"--\n"
+"\n"
+"Creates and returns a new ctypes pointer type.\n"
+"\n"
+"Pointer types are cached and reused internally, so calling this function\n"
+"repeatedly is cheap. \'type\' must be a ctypes type.");
+
+#define CREATE_POINTER_TYPE_METHODDEF    \
+    {"POINTER", (PyCFunction)create_pointer_type, METH_O, create_pointer_type__doc__},
+
+PyDoc_STRVAR(create_pointer_inst__doc__,
+"pointer($module, obj, /)\n"
+"--\n"
+"\n"
+"Creates a new pointer instance, pointing to \'obj\'.\n"
+"\n"
+"The returned object is of the type POINTER(type(obj)). Note that if you just\n"
+"want to pass a pointer to an object to a foreign function call,\n"
+"you should use byref(obj) which is much faster.");
+
+#define CREATE_POINTER_INST_METHODDEF    \
+    {"pointer", (PyCFunction)create_pointer_inst, METH_O, create_pointer_inst__doc__},
+/*[clinic end generated code: output=923c1c75ce2705e3 input=a9049054013a1b77]*/

--- a/Modules/_ctypes/clinic/callproc.c.h
+++ b/Modules/_ctypes/clinic/callproc.c.h
@@ -29,10 +29,10 @@ PyDoc_STRVAR(create_pointer_inst__doc__,
 "\n"
 "Create a new pointer instance, pointing to \'obj\'.\n"
 "\n"
-"The returned object is of the type POINTER(type(obj)). Note that if you just\n"
-"want to pass a pointer to an object to a foreign function call,\n"
-"you should use byref(obj) which is much faster.");
+"The returned object is of the type POINTER(type(obj)). Note that if you\n"
+"just want to pass a pointer to an object to a foreign function call, you\n"
+"should use byref(obj) which is much faster.");
 
 #define CREATE_POINTER_INST_METHODDEF    \
     {"pointer", (PyCFunction)create_pointer_inst, METH_O, create_pointer_inst__doc__},
-/*[clinic end generated code: output=a68a8cf6b8203cf9 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=ae26452a759ba56d input=a9049054013a1b77]*/

--- a/Modules/_ctypes/clinic/callproc.c.h
+++ b/Modules/_ctypes/clinic/callproc.c.h
@@ -12,10 +12,13 @@ PyDoc_STRVAR(create_pointer_type__doc__,
 "POINTER($module, type, /)\n"
 "--\n"
 "\n"
-"Creates and returns a new ctypes pointer type.\n"
+"Create and return a new ctypes pointer type.\n"
 "\n"
-"Pointer types are cached and reused internally, so calling this function\n"
-"repeatedly is cheap. \'type\' must be a ctypes type.");
+"  type\n"
+"    A ctypes type.\n"
+"\n"
+"Pointer types are cached and reused internally,\n"
+"so calling this function repeatedly is cheap.");
 
 #define CREATE_POINTER_TYPE_METHODDEF    \
     {"POINTER", (PyCFunction)create_pointer_type, METH_O, create_pointer_type__doc__},
@@ -24,7 +27,7 @@ PyDoc_STRVAR(create_pointer_inst__doc__,
 "pointer($module, obj, /)\n"
 "--\n"
 "\n"
-"Creates a new pointer instance, pointing to \'obj\'.\n"
+"Create a new pointer instance, pointing to \'obj\'.\n"
 "\n"
 "The returned object is of the type POINTER(type(obj)). Note that if you just\n"
 "want to pass a pointer to an object to a foreign function call,\n"
@@ -32,4 +35,4 @@ PyDoc_STRVAR(create_pointer_inst__doc__,
 
 #define CREATE_POINTER_INST_METHODDEF    \
     {"pointer", (PyCFunction)create_pointer_inst, METH_O, create_pointer_inst__doc__},
-/*[clinic end generated code: output=923c1c75ce2705e3 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=a68a8cf6b8203cf9 input=a9049054013a1b77]*/


### PR DESCRIPTION
Adds docstrings for `ctypes.pointer` and `ctypes.POINTER` and converts both functions to Argument Clinic.
(First time using the AC so I apologize in advance if I missed something :smile: )

<!-- gh-issue-number: gh-107659 -->
* Issue: gh-107659
<!-- /gh-issue-number -->
