### PR TITLE
Docs: skip python-docs-theme 2023.7 to fix mobile menu

### DIFF
--- a/Doc/requirements.txt
+++ b/Doc/requirements.txt
@@ -15,6 +15,6 @@ sphinxext-opengraph==0.7.5
 
 # The theme used by the documentation is stored separately, so we need
 # to install that as well.
-python-docs-theme>=2023.7
+python-docs-theme>=2023.3.1,!=2023.7
 
 -c constraints.txt


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

Skip python-docs-theme 2023.7 because https://github.com/python/python-docs-theme/pull/141 means the menu doesn't work properly for mobile. Upstream report: https://github.com/python/python-docs-theme/issues/144.

To test:

1. Open docs in mobile view
2. Click the menu at the top left

Expected result: menu opens (https://cpython-previews--107666.org.readthedocs.build/en/107666/)
Actual result: menu doesn't open (https://docs.python.org/3.13/)

<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--107666.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->