### PR TITLE
gh-104683: Improve consistency and test coverage of argument-clinic `__repr__` functions

### DIFF
--- a/Lib/test/test_clinic.py
+++ b/Lib/test/test_clinic.py
@@ -3065,11 +3065,11 @@ class ClinicReprTests(unittest.TestCase):
 
     def test_Module_repr(self):
         module = clinic.Module("foo", FakeClinic())
-        self.assertRegex(repr(module), r"<clinic.Module 'foo' at [a-zA-Z0-9]+>")
+        self.assertRegex(repr(module), r"<clinic.Module 'foo' at \d+>")
 
     def test_Class_repr(self):
         cls = clinic.Class("foo", FakeClinic(), None, 'some_typedef', 'some_type_object')
-        self.assertRegex(repr(cls), r"<clinic.Class 'foo' at [a-zA-Z0-9]+>")
+        self.assertRegex(repr(cls), r"<clinic.Class 'foo' at \d+>")
 
     def test_FunctionKind_repr(self):
         self.assertEqual(
@@ -3103,22 +3103,18 @@ class ClinicReprTests(unittest.TestCase):
 
     def test_Monitor_repr(self):
         monitor = clinic.cpp.Monitor()
-        self.assertRegex(
-            repr(monitor),
-            r"<clinic.Monitor [a-zA-Z0-9]+ line=0 condition=''>"
-        )
+        self.assertRegex(repr(monitor), r"<clinic.Monitor \d+ line=0 condition=''>")
 
         monitor.line_number = 42
         monitor.stack.append(("token1", "condition1"))
         self.assertRegex(
-            repr(monitor),
-            r"<clinic.Monitor [a-zA-Z0-9]+ line=42 condition='condition1'>"
+            repr(monitor), r"<clinic.Monitor \d+ line=42 condition='condition1'>"
         )
 
         monitor.stack.append(("token2", "condition2"))
         self.assertRegex(
             repr(monitor),
-            r"<clinic.Monitor [a-zA-Z0-9]+ line=42 condition='condition1 && condition2'>"
+            r"<clinic.Monitor \d+ line=42 condition='condition1 && condition2'>"
         )
 
 

--- a/Lib/test/test_clinic.py
+++ b/Lib/test/test_clinic.py
@@ -69,7 +69,7 @@ class FakeClinic:
         self.converters = FakeConvertersDict()
         self.legacy_converters = FakeConvertersDict()
         self.language = clinic.CLanguage(None)
-        self.filename = None
+        self.filename = "clinic_tests"
         self.destination_buffers = {}
         self.block_parser = clinic.BlockParser('', self.language)
         self.modules = collections.OrderedDict()
@@ -1849,10 +1849,10 @@ class ClinicParserTest(TestCase):
             self.parse(block)
         # The line numbers are off; this is a known limitation.
         expected = dedent("""\
-            Warning on line 0:
+            Warning in file 'clinic_tests' on line 0:
             Non-ascii characters are not allowed in docstrings: 'á'
 
-            Warning on line 0:
+            Warning in file 'clinic_tests' on line 0:
             Non-ascii characters are not allowed in docstrings: 'ü', 'á', 'ß'
 
         """)
@@ -3028,6 +3028,98 @@ class FormatHelperTests(unittest.TestCase):
         )
         out = clinic.suffix_all_lines(lines, suffix="foo")
         self.assertEqual(out, expected)
+
+
+class ClinicReprTests(unittest.TestCase):
+    def test_Block_repr(self):
+        block = clinic.Block("foo")
+        expected_repr = "<clinic.Block 'text' input='foo' output=None>"
+        self.assertEqual(repr(block), expected_repr)
+
+        block2 = clinic.Block("bar", "baz", [], "eggs", "spam")
+        expected_repr_2 = "<clinic.Block 'baz' input='bar' output='eggs'>"
+        self.assertEqual(repr(block2), expected_repr_2)
+
+        block3 = clinic.Block(
+            input="longboi_" * 100,
+            dsl_name="wow_so_long",
+            signatures=[],
+            output="very_long_" * 100,
+            indent=""
+        )
+        expected_repr_3 = (
+            "<clinic.Block 'wow_so_long' input='longboi_longboi_longboi_l...' output='very_long_very_long_very_...'>"
+        )
+        self.assertEqual(repr(block3), expected_repr_3)
+
+    def test_Destination_repr(self):
+        destination = clinic.Destination(
+            "foo", type="file", clinic=FakeClinic(), args=("eggs",)
+        )
+        self.assertEqual(
+            repr(destination), "<clinic.Destination 'foo' type='file' file='eggs'>"
+        )
+
+        destination2 = clinic.Destination("bar", type="buffer", clinic=FakeClinic())
+        self.assertEqual(repr(destination2), "<clinic.Destination 'bar' type='buffer'>")
+
+    def test_Module_repr(self):
+        module = clinic.Module("foo", FakeClinic())
+        self.assertRegex(repr(module), r"<clinic.Module 'foo' at [a-zA-Z0-9]+>")
+
+    def test_Class_repr(self):
+        cls = clinic.Class("foo", FakeClinic(), None, 'some_typedef', 'some_type_object')
+        self.assertRegex(repr(cls), r"<clinic.Class 'foo' at [a-zA-Z0-9]+>")
+
+    def test_FunctionKind_repr(self):
+        self.assertEqual(
+            repr(clinic.FunctionKind.INVALID), "<clinic.FunctionKind.INVALID>"
+        )
+        self.assertEqual(
+            repr(clinic.FunctionKind.CLASS_METHOD), "<clinic.FunctionKind.CLASS_METHOD>"
+        )
+
+    def test_Function_and_Parameter_reprs(self):
+        function = clinic.Function(
+            name='foo',
+            module=FakeClinic(),
+            cls=None,
+            c_basename=None,
+            full_name='foofoo',
+            return_converter=clinic.init_return_converter(),
+            kind=clinic.FunctionKind.METHOD_INIT,
+            coexist=False
+        )
+        self.assertEqual(repr(function), "<clinic.Function 'foo'>")
+
+        converter = clinic.self_converter('bar', 'bar', function)
+        parameter = clinic.Parameter(
+            "bar",
+            kind=inspect.Parameter.POSITIONAL_OR_KEYWORD,
+            function=function,
+            converter=converter
+        )
+        self.assertEqual(repr(parameter), "<clinic.Parameter 'bar'>")
+
+    def test_Monitor_repr(self):
+        monitor = clinic.cpp.Monitor()
+        self.assertRegex(
+            repr(monitor),
+            r"<clinic.Monitor [a-zA-Z0-9]+ line=0 condition=''>"
+        )
+
+        monitor.line_number = 42
+        monitor.stack.append(("token1", "condition1"))
+        self.assertRegex(
+            repr(monitor),
+            r"<clinic.Monitor [a-zA-Z0-9]+ line=42 condition='condition1'>"
+        )
+
+        monitor.stack.append(("token2", "condition2"))
+        self.assertRegex(
+            repr(monitor),
+            r"<clinic.Monitor [a-zA-Z0-9]+ line=42 condition='condition1 && condition2'>"
+        )
 
 
 if __name__ == "__main__":

--- a/Tools/clinic/clinic.py
+++ b/Tools/clinic/clinic.py
@@ -1728,8 +1728,12 @@ class Block:
             if len(s) > 30:
                 return s[:26] + "..." + s[0]
             return s
-        return "".join((
-            "<Block ", dsl_name, " input=", summarize(self.input), " output=", summarize(self.output), ">"))
+        parts = (
+            repr(dsl_name),
+            f"input={summarize(self.input)}",
+            f"output={summarize(self.output)}"
+        )
+        return f"<clinic.Block {' '.join(parts)}>"
 
 
 class BlockParser:
@@ -2037,10 +2041,10 @@ class Destination:
 
     def __repr__(self) -> str:
         if self.type == 'file':
-            file_repr = " " + repr(self.filename)
+            type_repr = f"type='file' file={self.filename!r}"
         else:
-            file_repr = ''
-        return "".join(("<Destination ", self.name, " ", self.type, file_repr, ">"))
+            type_repr = f"type={self.type!r}"
+        return f"<clinic.Destination {self.name!r} {type_repr}>"
 
     def clear(self) -> None:
         if self.type != 'buffer':
@@ -2500,7 +2504,7 @@ class FunctionKind(enum.Enum):
         return self in {FunctionKind.METHOD_INIT, FunctionKind.METHOD_NEW}
 
     def __repr__(self) -> str:
-        return f"<FunctionKind.{self.name}>"
+        return f"<clinic.FunctionKind.{self.name}>"
 
 
 INVALID: Final = FunctionKind.INVALID
@@ -2577,7 +2581,7 @@ class Function:
         return '|'.join(flags)
 
     def __repr__(self) -> str:
-        return '<clinic.Function ' + self.name + '>'
+        return f'<clinic.Function {self.name!r}>'
 
     def copy(self, **overrides: Any) -> Function:
         f = dc.replace(self, **overrides)
@@ -2605,7 +2609,7 @@ class Parameter:
     right_bracket_count: int = dc.field(init=False, default=0)
 
     def __repr__(self) -> str:
-        return '<clinic.Parameter ' + self.name + '>'
+        return f'<clinic.Parameter {self.name!r}>'
 
     def is_keyword_only(self) -> bool:
         return self.kind == inspect.Parameter.KEYWORD_ONLY

--- a/Tools/clinic/cpp.py
+++ b/Tools/clinic/cpp.py
@@ -43,9 +43,12 @@ class Monitor:
         self.line_number = 0
 
     def __repr__(self) -> str:
-        return (
-            f"<Monitor {id(self)} line={self.line_number} condition={self.condition()!r}>"
+        parts = (
+            str(id(self)),
+            f"line={self.line_number}",
+            f"condition={self.condition()!r}"
         )
+        return f"<clinic.Monitor {' '.join(parts)}>"
 
     def status(self) -> str:
         return str(self.line_number).rjust(4) + ": " + self.condition()


### PR DESCRIPTION
Several of the `__repr__` functions in `Tools/clinic/` have no test coverage at the moment, so this PR started life as an attempt to get some easy coverage improvements. While working on adding coverage for the `__repr__` functions, however, I noticed that the reprs for classes in `Tools/clinic/` can be pretty inconsistent -- e.g. `Function` objects describe themselves as `clinic.Function` objects in their reprs, but `Destination` objects just describe themselves as `Destination` objects. Some classes quoted their `self.name` attribute in their `__repr__` methods; others didn't. This PR therefore also improves the consistency of the `__repr__` methods in `Tools/clinic/`.

Coverage prior to this PR:

```
Name                     Stmts   Miss Branch BrPart  Cover
----------------------------------------------------------
Tools\clinic\clinic.py    2947    135   1236    114    94%
Tools\clinic\cpp.py        102      9     54      2    90%
----------------------------------------------------------
TOTAL                     3049    144   1290    116    94%
```

Coverage with this PR:

```
Name                     Stmts   Miss Branch BrPart  Cover
----------------------------------------------------------
Tools\clinic\clinic.py    2948    119   1236    115    94%
Tools\clinic\cpp.py        103      8     54      2    91%
----------------------------------------------------------
TOTAL                     3051    127   1290    117    94%
```

So, no change to the top-line stat, but a reasonable reduction in uncovered statements.

<!-- gh-issue-number: gh-104683 -->
* Issue: gh-104683
<!-- /gh-issue-number -->
