### PR TITLE
Improve cross-references in `runpy` docs

### DIFF
--- a/Doc/library/runpy.rst
+++ b/Doc/library/runpy.rst
@@ -74,7 +74,7 @@ The :mod:`runpy` module provides two functions:
 
    Note that this manipulation of :mod:`sys` is not thread-safe. Other threads
    may see the partially initialised module, as well as the altered list of
-   arguments. It is recommended that the :mod:`sys` module be left alone when
+   arguments. It is recommended that the ``sys`` module be left alone when
    invoking this function from threaded code.
 
    .. seealso::
@@ -115,7 +115,7 @@ The :mod:`runpy` module provides two functions:
    directory), the entry is first added to the beginning of ``sys.path``. The
    function then looks for and executes a :mod:`__main__` module using the
    updated path. Note that there is no special protection against invoking
-   an existing :mod:`__main__` entry located elsewhere on ``sys.path`` if
+   an existing ``__main__`` entry located elsewhere on ``sys.path`` if
    there is no such module at the specified location.
 
    The optional dictionary argument *init_globals* may be used to pre-populate

--- a/Doc/library/runpy.rst
+++ b/Doc/library/runpy.rst
@@ -106,16 +106,16 @@ The :mod:`runpy` module provides two functions:
    Execute the code at the named filesystem location and return the resulting
    module globals dictionary. As with a script name supplied to the CPython
    command line, the supplied path may refer to a Python source file, a
-   compiled bytecode file or a valid ``sys.path`` entry containing a
+   compiled bytecode file or a valid :data:`sys.path` entry containing a
    ``__main__`` module
    (e.g. a zipfile containing a top-level ``__main__.py`` file).
 
    For a simple script, the specified code is simply executed in a fresh
-   module namespace. For a valid ``sys.path`` entry (typically a zipfile or
-   directory), the entry is first added to the beginning of ``sys.path``. The
-   function then looks for and executes a :mod:`__main__` module using the
+   module namespace. For a valid :data:`sys.path` entry (typically a zipfile or
+   directory), the entry is first added to the beginning of :data:`sys.path`.
+   The function then looks for and executes a :mod:`__main__` module using the
    updated path. Note that there is no special protection against invoking
-   an existing :mod:`__main__` entry located elsewhere on ``sys.path`` if
+   an existing :mod:`__main__` entry located elsewhere on :data:`sys.path` if
    there is no such module at the specified location.
 
    The optional dictionary argument *init_globals* may be used to pre-populate
@@ -138,22 +138,22 @@ The :mod:`runpy` module provides two functions:
    supplied path, and ``__spec__``, ``__cached__``, ``__loader__`` and
    ``__package__`` will all be set to :const:`None`.
 
-   If the supplied path is a reference to a valid ``sys.path`` entry, then
+   If the supplied path is a reference to a valid :data:`sys.path` entry, then
    ``__spec__`` will be set appropriately for the imported ``__main__``
    module (that is, ``__spec__.name`` will always be ``__main__``).
    ``__file__``, ``__cached__``, ``__loader__`` and ``__package__`` will be
    :ref:`set as normal <import-mod-attrs>` based on the module spec.
 
    A number of alterations are also made to the :mod:`sys` module. Firstly,
-   ``sys.path`` may be altered as described above. ``sys.argv[0]`` is updated
-   with the value of ``path_name`` and ``sys.modules[__name__]`` is updated
-   with a temporary module object for the module being executed. All
+   :data:`sys.path` may be altered as described above. ``sys.argv[0]``
+   is updated with the value of ``path_name`` and ``sys.modules[__name__]`` is
+   updated with a temporary module object for the module being executed. All
    modifications to items in :mod:`sys` are reverted before the function
    returns.
 
    Note that, unlike :func:`run_module`, the alterations made to :mod:`sys`
    are not optional in this function as these adjustments are essential to
-   allowing the execution of ``sys.path`` entries. As the thread-safety
+   allowing the execution of :data:`sys.path` entries. As the thread-safety
    limitations still apply, use of this function in threaded code should be
    either serialised with the import lock or delegated to a separate process.
 
@@ -166,8 +166,8 @@ The :mod:`runpy` module provides two functions:
    .. versionchanged:: 3.4
       Updated to take advantage of the module spec feature added by
       :pep:`451`. This allows ``__cached__`` to be set correctly in the
-      case where ``__main__`` is imported from a valid ``sys.path`` entry rather
-      than being executed directly.
+      case where ``__main__`` is imported from a valid :data:`sys.path` entry
+      rather than being executed directly.
 
    .. versionchanged:: 3.12
       The setting of ``__cached__``, ``__loader__``, and

--- a/Doc/library/runpy.rst
+++ b/Doc/library/runpy.rst
@@ -112,10 +112,10 @@ The :mod:`runpy` module provides two functions:
 
    For a simple script, the specified code is simply executed in a fresh
    module namespace. For a valid :data:`sys.path` entry (typically a zipfile or
-   directory), the entry is first added to the beginning of :data:`sys.path`.
+   directory), the entry is first added to the beginning of ``sys.path``.
    The function then looks for and executes a :mod:`__main__` module using the
    updated path. Note that there is no special protection against invoking
-   an existing :mod:`__main__` entry located elsewhere on :data:`sys.path` if
+   an existing :mod:`__main__` entry located elsewhere on ``sys.path`` if
    there is no such module at the specified location.
 
    The optional dictionary argument *init_globals* may be used to pre-populate

--- a/Doc/library/runpy.rst
+++ b/Doc/library/runpy.rst
@@ -112,8 +112,8 @@ The :mod:`runpy` module provides two functions:
 
    For a simple script, the specified code is simply executed in a fresh
    module namespace. For a valid :data:`sys.path` entry (typically a zipfile or
-   directory), the entry is first added to the beginning of ``sys.path``.
-   The function then looks for and executes a :mod:`__main__` module using the
+   directory), the entry is first added to the beginning of ``sys.path``. The
+   function then looks for and executes a :mod:`__main__` module using the
    updated path. Note that there is no special protection against invoking
    an existing :mod:`__main__` entry located elsewhere on ``sys.path`` if
    there is no such module at the specified location.
@@ -145,9 +145,9 @@ The :mod:`runpy` module provides two functions:
    :ref:`set as normal <import-mod-attrs>` based on the module spec.
 
    A number of alterations are also made to the :mod:`sys` module. Firstly,
-   :data:`sys.path` may be altered as described above. ``sys.argv[0]``
-   is updated with the value of ``path_name`` and ``sys.modules[__name__]`` is
-   updated with a temporary module object for the module being executed. All
+   :data:`sys.path` may be altered as described above. ``sys.argv[0]`` is updated
+   with the value of ``path_name`` and ``sys.modules[__name__]`` is updated
+   with a temporary module object for the module being executed. All
    modifications to items in :mod:`sys` are reverted before the function
    returns.
 
@@ -166,8 +166,8 @@ The :mod:`runpy` module provides two functions:
    .. versionchanged:: 3.4
       Updated to take advantage of the module spec feature added by
       :pep:`451`. This allows ``__cached__`` to be set correctly in the
-      case where ``__main__`` is imported from a valid :data:`sys.path` entry
-      rather than being executed directly.
+      case where ``__main__`` is imported from a valid :data:`sys.path` entry rather
+      than being executed directly.
 
    .. versionchanged:: 3.12
       The setting of ``__cached__``, ``__loader__``, and

--- a/Doc/library/runpy.rst
+++ b/Doc/library/runpy.rst
@@ -39,7 +39,7 @@ The :mod:`runpy` module provides two functions:
 
    The *mod_name* argument should be an absolute module name.
    If the module name refers to a package rather than a normal
-   module, then that package is imported and the ``__main__`` submodule within
+   module, then that package is imported and the :mod:`__main__` submodule within
    that package is then executed and the resulting module globals dictionary
    returned.
 
@@ -82,7 +82,7 @@ The :mod:`runpy` module provides two functions:
       command line.
 
    .. versionchanged:: 3.1
-      Added ability to execute packages by looking for a ``__main__`` submodule.
+      Added ability to execute packages by looking for a :mod:`__main__` submodule.
 
    .. versionchanged:: 3.2
       Added ``__cached__`` global variable (see :pep:`3147`).
@@ -107,7 +107,7 @@ The :mod:`runpy` module provides two functions:
    module globals dictionary. As with a script name supplied to the CPython
    command line, the supplied path may refer to a Python source file, a
    compiled bytecode file or a valid :data:`sys.path` entry containing a
-   ``__main__`` module
+   :mod:`__main__` module
    (e.g. a zipfile containing a top-level ``__main__.py`` file).
 
    For a simple script, the specified code is simply executed in a fresh
@@ -139,7 +139,7 @@ The :mod:`runpy` module provides two functions:
    ``__package__`` will all be set to :const:`None`.
 
    If the supplied path is a reference to a valid :data:`sys.path` entry, then
-   ``__spec__`` will be set appropriately for the imported ``__main__``
+   ``__spec__`` will be set appropriately for the imported :mod:`__main__`
    module (that is, ``__spec__.name`` will always be ``__main__``).
    ``__file__``, ``__cached__``, ``__loader__`` and ``__package__`` will be
    :ref:`set as normal <import-mod-attrs>` based on the module spec.

--- a/Doc/library/runpy.rst
+++ b/Doc/library/runpy.rst
@@ -107,8 +107,8 @@ The :mod:`runpy` module provides two functions:
    module globals dictionary. As with a script name supplied to the CPython
    command line, the supplied path may refer to a Python source file, a
    compiled bytecode file or a valid ``sys.path`` entry containing a
-   ``__main__`` module (e.g. a zipfile containing a top-level ``__main__.py``
-   file).
+   ``__main__`` module
+   (e.g. a zipfile containing a top-level ``__main__.py`` file).
 
    For a simple script, the specified code is simply executed in a fresh
    module namespace. For a valid ``sys.path`` entry (typically a zipfile or

--- a/Doc/library/runpy.rst
+++ b/Doc/library/runpy.rst
@@ -51,7 +51,7 @@ The :mod:`runpy` module provides two functions:
 
    The special global variables ``__name__``, ``__spec__``, ``__file__``,
    ``__cached__``, ``__loader__`` and ``__package__`` are set in the globals
-   dictionary before the module code is executed (note that this is a
+   dictionary before the module code is executed (Note that this is a
    minimal set of variables - other variables may be set implicitly as an
    interpreter implementation detail).
 
@@ -126,7 +126,7 @@ The :mod:`runpy` module provides two functions:
 
    The special global variables ``__name__``, ``__spec__``, ``__file__``,
    ``__cached__``, ``__loader__`` and ``__package__`` are set in the globals
-   dictionary before the module code is executed (note that this is a
+   dictionary before the module code is executed (Note that this is a
    minimal set of variables - other variables may be set implicitly as an
    interpreter implementation detail).
 

--- a/Doc/library/runpy.rst
+++ b/Doc/library/runpy.rst
@@ -51,7 +51,7 @@ The :mod:`runpy` module provides two functions:
 
    The special global variables ``__name__``, ``__spec__``, ``__file__``,
    ``__cached__``, ``__loader__`` and ``__package__`` are set in the globals
-   dictionary before the module code is executed (Note that this is a
+   dictionary before the module code is executed (note that this is a
    minimal set of variables - other variables may be set implicitly as an
    interpreter implementation detail).
 
@@ -106,11 +106,12 @@ The :mod:`runpy` module provides two functions:
    Execute the code at the named filesystem location and return the resulting
    module globals dictionary. As with a script name supplied to the CPython
    command line, the supplied path may refer to a Python source file, a
-   compiled bytecode file or a valid sys.path entry containing a ``__main__``
-   module (e.g. a zipfile containing a top-level ``__main__.py`` file).
+   compiled bytecode file or a valid ``sys.path`` entry containing a
+   ``__main__`` module (e.g. a zipfile containing a top-level ``__main__.py``
+   file).
 
    For a simple script, the specified code is simply executed in a fresh
-   module namespace. For a valid sys.path entry (typically a zipfile or
+   module namespace. For a valid ``sys.path`` entry (typically a zipfile or
    directory), the entry is first added to the beginning of ``sys.path``. The
    function then looks for and executes a :mod:`__main__` module using the
    updated path. Note that there is no special protection against invoking
@@ -125,7 +126,7 @@ The :mod:`runpy` module provides two functions:
 
    The special global variables ``__name__``, ``__spec__``, ``__file__``,
    ``__cached__``, ``__loader__`` and ``__package__`` are set in the globals
-   dictionary before the module code is executed (Note that this is a
+   dictionary before the module code is executed (note that this is a
    minimal set of variables - other variables may be set implicitly as an
    interpreter implementation detail).
 
@@ -137,7 +138,7 @@ The :mod:`runpy` module provides two functions:
    supplied path, and ``__spec__``, ``__cached__``, ``__loader__`` and
    ``__package__`` will all be set to :const:`None`.
 
-   If the supplied path is a reference to a valid sys.path entry, then
+   If the supplied path is a reference to a valid ``sys.path`` entry, then
    ``__spec__`` will be set appropriately for the imported ``__main__``
    module (that is, ``__spec__.name`` will always be ``__main__``).
    ``__file__``, ``__cached__``, ``__loader__`` and ``__package__`` will be
@@ -152,7 +153,7 @@ The :mod:`runpy` module provides two functions:
 
    Note that, unlike :func:`run_module`, the alterations made to :mod:`sys`
    are not optional in this function as these adjustments are essential to
-   allowing the execution of sys.path entries. As the thread-safety
+   allowing the execution of ``sys.path`` entries. As the thread-safety
    limitations still apply, use of this function in threaded code should be
    either serialised with the import lock or delegated to a separate process.
 
@@ -165,7 +166,7 @@ The :mod:`runpy` module provides two functions:
    .. versionchanged:: 3.4
       Updated to take advantage of the module spec feature added by
       :pep:`451`. This allows ``__cached__`` to be set correctly in the
-      case where ``__main__`` is imported from a valid sys.path entry rather
+      case where ``__main__`` is imported from a valid ``sys.path`` entry rather
       than being executed directly.
 
    .. versionchanged:: 3.12


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

- Added missing ticks around `sys.path` in a few places.
- <s>Lowercased text in parentheses.</s>


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--107673.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->