### PR TITLE
gh-104496: Use correct Tcl or Tk version in Tkinter tests

### DIFF
--- a/Lib/test/test_tcl.py
+++ b/Lib/test/test_tcl.py
@@ -20,14 +20,6 @@ except ImportError:
 
 tcl_version = tuple(map(int, _tkinter.TCL_VERSION.split('.')))
 
-_tk_patchlevel = None
-def get_tk_patchlevel():
-    global _tk_patchlevel
-    if _tk_patchlevel is None:
-        tcl = Tcl()
-        _tk_patchlevel = tcl.info_patchlevel()
-    return _tk_patchlevel
-
 
 class TkinterTest(unittest.TestCase):
 
@@ -571,7 +563,6 @@ class TclTest(unittest.TestCase):
                 (1, '2', (3.4,)) if self.wantobjects else
                 ('1', '2', '3.4')),
         ]
-        tk_patchlevel = get_tk_patchlevel()
         if not self.wantobjects:
             expected = ('12', '\u20ac', '\xe2\x82\xac', '3.4')
         else:
@@ -580,8 +571,8 @@ class TclTest(unittest.TestCase):
             (call('dict', 'create', 12, '\u20ac', b'\xe2\x82\xac', (3.4,)),
                 expected),
         ]
-        dbg_info = ('want objects? %s, Tcl version: %s, Tk patchlevel: %s'
-                    % (self.wantobjects, tcl_version, tk_patchlevel))
+        dbg_info = ('want objects? %s, Tcl version: %s, Tcl patchlevel: %s'
+                    % (self.wantobjects, tcl_version, self.interp.info_patchlevel()))
         for arg, res in testcases:
             self.assertEqual(splitlist(arg), res,
                              'arg=%a, %s' % (arg, dbg_info))

--- a/Lib/test/test_tkinter/support.py
+++ b/Lib/test/test_tkinter/support.py
@@ -79,28 +79,28 @@ def simulate_mouse_click(widget, x, y):
 
 import _tkinter
 tcl_version = tuple(map(int, _tkinter.TCL_VERSION.split('.')))
+tk_version = tuple(map(int, _tkinter.TK_VERSION.split('.')))
 
-def requires_tcl(*version):
-    if len(version) <= 2:
-        return unittest.skipUnless(tcl_version >= version,
-            'requires Tcl version >= ' + '.'.join(map(str, version)))
+def requires_tk(*version):
+    if len(version) <= 2 and tk_version >= version:
+        return lambda test: test
 
     def deco(test):
         @functools.wraps(test)
         def newtest(self):
-            if get_tk_patchlevel() < version:
-                self.skipTest('requires Tcl version >= ' +
+            root = getattr(self, 'root', None)
+            if get_tk_patchlevel(root) < version:
+                self.skipTest('requires Tk version >= ' +
                                 '.'.join(map(str, version)))
             test(self)
         return newtest
     return deco
 
 _tk_patchlevel = None
-def get_tk_patchlevel():
+def get_tk_patchlevel(root):
     global _tk_patchlevel
     if _tk_patchlevel is None:
-        tcl = tkinter.Tcl()
-        _tk_patchlevel = tcl.info_patchlevel()
+        _tk_patchlevel = tkinter._parse_version(root.tk.globalgetvar('tk_patchLevel'))
     return _tk_patchlevel
 
 units = {

--- a/Lib/test/test_tkinter/test_images.py
+++ b/Lib/test/test_tkinter/test_images.py
@@ -2,7 +2,7 @@ import unittest
 import tkinter
 from test import support
 from test.support import os_helper
-from test.test_tkinter.support import AbstractTkTest, AbstractDefaultRootTest, requires_tcl
+from test.test_tkinter.support import AbstractTkTest, AbstractDefaultRootTest, requires_tk
 
 support.requires('gui')
 
@@ -213,11 +213,11 @@ class PhotoImageTest(AbstractTkTest, unittest.TestCase):
     def test_create_from_gif_data(self):
         self.check_create_from_data('gif')
 
-    @requires_tcl(8, 6)
+    @requires_tk(8, 6)
     def test_create_from_png_file(self):
         self.check_create_from_file('png')
 
-    @requires_tcl(8, 6)
+    @requires_tk(8, 6)
     def test_create_from_png_data(self):
         self.check_create_from_data('png')
 

--- a/Lib/test/test_tkinter/test_widgets.py
+++ b/Lib/test/test_tkinter/test_widgets.py
@@ -4,7 +4,7 @@ from tkinter import TclError
 import os
 from test.support import requires
 
-from test.test_tkinter.support import (requires_tcl,
+from test.test_tkinter.support import (requires_tk,
                                   get_tk_patchlevel, widget_eq,
                                   AbstractDefaultRootTest)
 from test.test_tkinter.widget_tests import (
@@ -613,7 +613,7 @@ class TextTest(AbstractWidgetTest, unittest.TestCase):
         widget = self.create()
         self.checkColorParam(widget, 'inactiveselectbackground')
 
-    @requires_tcl(8, 6)
+    @requires_tk(8, 6)
     def test_configure_insertunfocussed(self):
         widget = self.create()
         self.checkEnumParam(widget, 'insertunfocussed',
@@ -924,7 +924,7 @@ class CanvasTest(AbstractWidgetTest, unittest.TestCase):
         for i in range(4):
             self.assertIsInstance(coords[i], float)
 
-    @requires_tcl(8, 6)
+    @requires_tk(8, 6)
     def test_moveto(self):
         widget = self.create()
         i1 = widget.create_rectangle(1, 1, 20, 20, tags='group')
@@ -969,7 +969,7 @@ class ListboxTest(AbstractWidgetTest, unittest.TestCase):
         self.checkEnumParam(widget, 'activestyle',
                             'dotbox', 'none', 'underline')
 
-    test_configure_justify = requires_tcl(8, 6, 5)(StandardOptionsTests.test_configure_justify)
+    test_configure_justify = requires_tk(8, 6, 5)(StandardOptionsTests.test_configure_justify)
 
     def test_configure_listvariable(self):
         widget = self.create()
@@ -1108,7 +1108,7 @@ class ScaleTest(AbstractWidgetTest, unittest.TestCase):
 
     def test_configure_from(self):
         widget = self.create()
-        conv = float if get_tk_patchlevel() >= (8, 6, 10) else float_round
+        conv = float if get_tk_patchlevel(self.root) >= (8, 6, 10) else float_round
         self.checkFloatParam(widget, 'from', 100, 14.9, 15.1, conv=conv)
 
     def test_configure_label(self):
@@ -1235,19 +1235,19 @@ class PanedWindowTest(AbstractWidgetTest, unittest.TestCase):
         widget = self.create()
         self.checkBooleanParam(widget, 'opaqueresize')
 
-    @requires_tcl(8, 6, 5)
+    @requires_tk(8, 6, 5)
     def test_configure_proxybackground(self):
         widget = self.create()
         self.checkColorParam(widget, 'proxybackground')
 
-    @requires_tcl(8, 6, 5)
+    @requires_tk(8, 6, 5)
     def test_configure_proxyborderwidth(self):
         widget = self.create()
         self.checkPixelsParam(widget, 'proxyborderwidth',
                               0, 1.3, 2.9, 6, -2, '10p',
                               conv=False)
 
-    @requires_tcl(8, 6, 5)
+    @requires_tk(8, 6, 5)
     def test_configure_proxyrelief(self):
         widget = self.create()
         self.checkReliefParam(widget, 'proxyrelief')

--- a/Lib/test/test_tkinter/widget_tests.py
+++ b/Lib/test/test_tkinter/widget_tests.py
@@ -1,7 +1,7 @@
 # Common tests for test_tkinter/test_widgets.py and test_ttk/test_widgets.py
 
 import tkinter
-from test.test_tkinter.support import (AbstractTkTest, tcl_version,
+from test.test_tkinter.support import (AbstractTkTest, tk_version,
                                   pixels_conv, tcl_obj_eq)
 import test.support
 
@@ -22,7 +22,7 @@ class AbstractWidgetTest(AbstractTkTest):
             return self._scaling
 
     def _str(self, value):
-        if not self._stringify and self.wantobjects and tcl_version >= (8, 6):
+        if not self._stringify and self.wantobjects and tk_version >= (8, 6):
             return value
         if isinstance(value, tuple):
             return ' '.join(map(self._str, value))
@@ -156,7 +156,7 @@ class AbstractWidgetTest(AbstractTkTest):
                          'flat', 'groove', 'raised', 'ridge', 'solid', 'sunken')
         errmsg='bad relief "spam": must be '\
                'flat, groove, raised, ridge, solid, or sunken'
-        if tcl_version < (8, 6):
+        if tk_version < (8, 6):
             errmsg = None
         self.checkInvalidParam(widget, name, 'spam',
                 errmsg=errmsg)

--- a/Lib/test/test_ttk/test_style.py
+++ b/Lib/test/test_ttk/test_style.py
@@ -170,7 +170,7 @@ class StyleTest(AbstractTkTest, unittest.TestCase):
                     newname = f'C.{name}'
                     self.assertEqual(style.map(newname), {})
                     style.map(newname, **default)
-                    if theme == 'alt' and name == '.' and get_tk_patchlevel() < (8, 6, 1):
+                    if theme == 'alt' and name == '.' and get_tk_patchlevel(self.root) < (8, 6, 1):
                         default['embossed'] = [('disabled', '1')]
                     self.assertEqual(style.map(newname), default)
                     for key, value in default.items():

--- a/Lib/test/test_ttk/test_widgets.py
+++ b/Lib/test/test_ttk/test_widgets.py
@@ -5,7 +5,7 @@ from test.support import requires, gc_collect
 import sys
 
 from test.test_ttk_textonly import MockTclObj
-from test.test_tkinter.support import (AbstractTkTest, tcl_version, get_tk_patchlevel,
+from test.test_tkinter.support import (AbstractTkTest, tk_version, get_tk_patchlevel,
                                   simulate_mouse_click, AbstractDefaultRootTest)
 from test.test_tkinter.widget_tests import (add_standard_options,
     AbstractWidgetTest, StandardOptionsTests, IntegerSizeTests, PixelSizeTests)
@@ -19,7 +19,7 @@ class StandardTtkOptionsTests(StandardOptionsTests):
         widget = self.create()
         self.assertEqual(widget['class'], '')
         errmsg='attempt to change read-only option'
-        if get_tk_patchlevel() < (8, 6, 0, 'beta', 3):
+        if get_tk_patchlevel(self.root) < (8, 6, 0, 'beta', 3):
             errmsg='Attempt to change read-only option'
         self.checkInvalidParam(widget, 'class', 'Foo', errmsg=errmsg)
         widget2 = self.create(class_='Foo')
@@ -560,7 +560,7 @@ class PanedWindowTest(AbstractWidgetTest, unittest.TestCase):
         widget = self.create()
         self.assertEqual(str(widget['orient']), 'vertical')
         errmsg='attempt to change read-only option'
-        if get_tk_patchlevel() < (8, 6, 0, 'beta', 3):
+        if get_tk_patchlevel(self.root) < (8, 6, 0, 'beta', 3):
             errmsg='Attempt to change read-only option'
         self.checkInvalidParam(widget, 'orient', 'horizontal',
                 errmsg=errmsg)
@@ -1526,7 +1526,7 @@ class TreeviewTest(AbstractWidgetTest, unittest.TestCase):
 
     def test_heading_callback(self):
         def simulate_heading_click(x, y):
-            if tcl_version >= (8, 6):
+            if tk_version >= (8, 6):
                 self.assertEqual(self.tv.identify_column(x), '#0')
                 self.assertEqual(self.tv.identify_region(x, y), 'heading')
             simulate_mouse_click(self.tv, x, y)


### PR DESCRIPTION
In future Tcl and Tk versions can be desynchronized.


<!-- gh-issue-number: gh-107687 -->
* Issue: gh-107687
<!-- /gh-issue-number -->


<!-- gh-issue-number: gh-104496 -->
* Issue: gh-104496
<!-- /gh-issue-number -->
