### PR TITLE
gh-106368: Improve coverage reports for argument clinic

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -7,6 +7,11 @@ exclude_lines =
     # Don't complain if non-runnable code isn't run:
     if 0:
     if __name__ == .__main__.:
+    raise AssertionError\(
+
+    # Empty bodies in protocols or abstract methods
+    ^\s*def [a-zA-Z0-9_]+\(.*\)(\s*->.*)?:\s*\.\.\.(\s*#.*)?$
+    ^\s*\.\.\.(\s*#.*)?$
 
     .*# pragma: no cover
     .*# pragma: no branch

--- a/Tools/clinic/clinic.py
+++ b/Tools/clinic/clinic.py
@@ -469,7 +469,7 @@ class Language(metaclass=abc.ABCMeta):
     checksum_line = ""
 
     def __init__(self, filename: str) -> None:
-        pass
+        ...
 
     @abc.abstractmethod
     def render(
@@ -477,10 +477,10 @@ class Language(metaclass=abc.ABCMeta):
             clinic: Clinic | None,
             signatures: Iterable[Module | Class | Function]
     ) -> str:
-        pass
+        ...
 
     def parse_line(self, line: str) -> None:
-        pass
+        ...
 
     def validate(self) -> None:
         def assert_only_one(
@@ -2862,6 +2862,9 @@ class CConverter(metaclass=CConverterAutoRegister):
                     f"Note: accessing self.function inside converter_init is disallowed!"
                 )
             return super().__getattr__(attr)
+    # this branch is just here for coverage reporting
+    else:  # pragma: no cover
+        pass
 
     def converter_init(self) -> None:
         pass
@@ -3990,7 +3993,7 @@ def correct_name_for_self(
         return "void *", "null"
     if f.kind in (CLASS_METHOD, METHOD_NEW):
         return "PyTypeObject *", "type"
-    raise RuntimeError("Unhandled type of function f: " + repr(f.kind))
+    raise AssertionError(f"Unhandled type of function f: {f.kind!r}")
 
 def required_type_for_self_for_parser(
         f: Function

--- a/Tools/clinic/cpp.py
+++ b/Tools/clinic/cpp.py
@@ -178,11 +178,17 @@ class Monitor:
         if self.verbose:
             print(self.status())
 
-if __name__ == '__main__':
-    for filename in sys.argv[1:]:
+
+def _main(filenames: list[str] | None = None) -> None:
+    filenames = filenames or sys.argv[1:]
+    for filename in filenames:
         with open(filename) as f:
             cpp = Monitor(filename, verbose=True)
             print()
             print(filename)
             for line_number, line in enumerate(f.read().split('\n'), 1):
                 cpp.writeline(line)
+
+
+if __name__ == '__main__':
+    _main()


### PR DESCRIPTION
- Use `...` rather than `pass` for empty bodies in abstract methods that are never meant to be executed. Exclude lines consisting solely of `...` in our `.coveragerc` file.
- Use `raise AssertionError` instead of `raise RuntimeError` for an exception that's never meant to be executed -- it would indicate a bug in `Tools/clinic/` itself, rather than an incorrect usage of argument clinic, if that line was ever executed. Exclude `raise AssertionError(` lines in our `.coveragerc` file.
- A reasonably large block of code in `Tools/clinic/cpp.py` was being excluded from coverage reports because it was all inside an `if __name__ == "__main__"` block, and `if __name__ == "__main__"` blocks are excluded in our `.coveragerc` file. That was making our coverage for `cpp.py` look better than it actually was. Move that block inside a `_main()` function so that it's correctly reported as being uncovered in coverage reports.

<!-- gh-issue-number: gh-106368 -->
* Issue: gh-106368
<!-- /gh-issue-number -->
