### PR TITLE
README: remove unmaintained sections

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -211,30 +211,6 @@ primary version, you would execute ``make install`` in your 3.13 build directory
 and ``make altinstall`` in the others.
 
 
-Issue Tracker and Mailing List
-------------------------------
-
-Bug reports are welcome!  You can use Github to `report bugs
-<https://github.com/python/cpython/issues>`_, and/or `submit pull requests
-<https://github.com/python/cpython/pulls>`_.
-
-You can also follow development discussion on the `python-dev mailing list
-<https://mail.python.org/mailman/listinfo/python-dev/>`_.
-
-
-Proposals for enhancement
--------------------------
-
-If you have a proposal to change Python, you may want to send an email to the
-`comp.lang.python`_ or `python-ideas`_ mailing lists for initial feedback.  A
-Python Enhancement Proposal (PEP) may be submitted if your idea gains ground.
-All current PEPs, as well as guidelines for submitting a new PEP, are listed at
-`peps.python.org <https://peps.python.org/>`_.
-
-.. _python-ideas: https://mail.python.org/mailman/listinfo/python-ideas/
-.. _comp.lang.python: https://mail.python.org/mailman/listinfo/python-list
-
-
 Release Schedule
 ----------------
 


### PR DESCRIPTION
There are three links to mailing lists.

Since README has "Contributing to CPython" section, I don't think these two sections are needed.