### PR TITLE
gh-107715: Escape class name in regular expression

### DIFF
--- a/Lib/doctest.py
+++ b/Lib/doctest.py
@@ -1110,7 +1110,7 @@ class DocTestFinder:
             if source_lines is None:
                 return None
             pat = re.compile(r'^\s*class\s*%s\b' %
-                             getattr(obj, '__name__', '-'))
+                             re.escape(getattr(obj, '__name__', '-')))
             for i, line in enumerate(source_lines):
                 if pat.match(line):
                     lineno = i

--- a/Misc/NEWS.d/next/Library/2023-08-07-14-12-07.gh-issue-107715.238r2f.rst
+++ b/Misc/NEWS.d/next/Library/2023-08-07-14-12-07.gh-issue-107715.238r2f.rst
@@ -1,0 +1,1 @@
+Fix `doctest.DocTestFinder.find` in presence of class names with special characters. Patch by Gertjan van Zwieten.


### PR DESCRIPTION
Fixes #107715. This patch escapes the class name before embedding it in the regular expression for `pat` in `doctest.DocTestFinder._find_lineno`. While class names do not ordinarily contain special characters, it is possible to encounter these when a class is created dynamically. Escaping the name will correctly return `None` in this scenario, rather than potentially matching a different class or raising `re.error` depending on the symbols used.

<!-- gh-issue-number: gh-107715 -->
* Issue: gh-107715
<!-- /gh-issue-number -->
