### PR TITLE
[3.11] gh-107442: Document all valid types for ctypes `_as_parameter_` (GH-107443)

### DIFF
--- a/Doc/library/ctypes.rst
+++ b/Doc/library/ctypes.rst
@@ -399,9 +399,10 @@ Calling functions with your own custom data types
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 You can also customize :mod:`ctypes` argument conversion to allow instances of
-your own classes be used as function arguments.  :mod:`ctypes` looks for an
-:attr:`_as_parameter_` attribute and uses this as the function argument.  Of
-course, it must be one of integer, string, or bytes::
+your own classes be used as function arguments. :mod:`ctypes` looks for an
+:attr:`!_as_parameter_` attribute and uses this as the function argument. The
+attribute must be an integer, string, bytes, a :mod:`ctypes` instance, or an
+object with an :attr:`!_as_parameter_` attribute::
 
    >>> class Bottles:
    ...     def __init__(self, number):


### PR DESCRIPTION


<!-- gh-issue-number: gh-107442 -->
* Issue: gh-107442
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--107718.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->