### PR TITLE
GH-107724: Fix the signature of `PY_THROW` callback functions.

### DIFF
--- a/Include/internal/pycore_instruments.h
+++ b/Include/internal/pycore_instruments.h
@@ -91,10 +91,6 @@ _Py_call_instrumentation_2args(PyThreadState *tstate, int event,
     _PyInterpreterFrame *frame, _Py_CODEUNIT *instr, PyObject *arg0, PyObject *arg1);
 
 extern void
-_Py_call_instrumentation_exc0(PyThreadState *tstate, int event,
-    _PyInterpreterFrame *frame, _Py_CODEUNIT *instr);
-
-extern void
 _Py_call_instrumentation_exc2(PyThreadState *tstate, int event,
     _PyInterpreterFrame *frame, _Py_CODEUNIT *instr, PyObject *arg0, PyObject *arg1);
 

--- a/Lib/test/test_monitoring.py
+++ b/Lib/test/test_monitoring.py
@@ -709,7 +709,6 @@ class CheckEvents(MonitoringTestBase, unittest.TestCase):
 
     def check_balanced(self, func, recorders):
         events = self.get_events(func, TEST_TOOL, recorders)
-        print("----\n", events, "\n------")
         self.assertEqual(len(events)%2, 0)
         for r, h in zip(events[::2],events[1::2]):
             r0 = r[0]

--- a/Misc/NEWS.d/next/Core and Builtins/2023-08-04-21-25-26.gh-issue-107724.EbBXMr.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2023-08-04-21-25-26.gh-issue-107724.EbBXMr.rst
@@ -1,0 +1,3 @@
+In pre-release versions of 3.12, up to rc1, the sys.monitoring callback
+function for the ``PY_THROW`` event was missing the third, exception
+argument. That is now fixed.

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -2017,7 +2017,7 @@ monitor_throw(PyThreadState *tstate,
     if (no_tools_for_event(tstate, frame, PY_MONITORING_EVENT_PY_THROW)) {
         return;
     }
-    _Py_call_instrumentation_exc0(tstate, PY_MONITORING_EVENT_PY_THROW, frame, instr);
+    do_monitor_exc(tstate, frame, instr, PY_MONITORING_EVENT_PY_THROW);
 }
 
 void

--- a/Python/instrumentation.c
+++ b/Python/instrumentation.c
@@ -1082,16 +1082,6 @@ call_instrumentation_vector_protected(
 }
 
 void
-_Py_call_instrumentation_exc0(
-    PyThreadState *tstate, int event,
-    _PyInterpreterFrame *frame, _Py_CODEUNIT *instr)
-{
-    assert(_PyErr_Occurred(tstate));
-    PyObject *args[3] = { NULL, NULL, NULL };
-    call_instrumentation_vector_protected(tstate, event, frame, instr, 2, args);
-}
-
-void
 _Py_call_instrumentation_exc2(
     PyThreadState *tstate, int event,
     _PyInterpreterFrame *frame, _Py_CODEUNIT *instr, PyObject *arg0, PyObject *arg1)

--- a/Python/legacy_tracing.c
+++ b/Python/legacy_tracing.c
@@ -163,7 +163,7 @@ sys_trace_func2(
 }
 
 static PyObject *
-sys_trace_unwind(
+sys_trace_func3(
     _PyLegacyEventHandler *self, PyObject *const *args,
     size_t nargsf, PyObject *kwnames
 ) {
@@ -445,7 +445,7 @@ _PyEval_SetTrace(PyThreadState *tstate, Py_tracefunc func, PyObject *arg)
             return -1;
         }
         if (set_callbacks(PY_MONITORING_SYS_TRACE_ID,
-            (vectorcallfunc)sys_trace_func2, PyTrace_CALL,
+            (vectorcallfunc)sys_trace_func3, PyTrace_CALL,
                         PY_MONITORING_EVENT_PY_THROW, -1)) {
             return -1;
         }
@@ -470,7 +470,7 @@ _PyEval_SetTrace(PyThreadState *tstate, Py_tracefunc func, PyObject *arg)
             return -1;
         }
         if (set_callbacks(PY_MONITORING_SYS_TRACE_ID,
-            (vectorcallfunc)sys_trace_unwind, PyTrace_RETURN,
+            (vectorcallfunc)sys_trace_func3, PyTrace_RETURN,
                         PY_MONITORING_EVENT_PY_UNWIND, -1)) {
             return -1;
         }


### PR DESCRIPTION
Changes signature from `callback(code: CodeType, offset: int)` to `callback(code: CodeType, offset: int, exc: BaseException)`
to match all the other exception callback functions.

<!-- gh-issue-number: gh-107724 -->
* Issue: gh-107724
<!-- /gh-issue-number -->
