### PR TITLE
gh-102130: Support a tab completion for Libedit in cmd, site, and pdb.

### DIFF
--- a/Doc/library/cmd.rst
+++ b/Doc/library/cmd.rst
@@ -15,7 +15,7 @@ command interpreters.  These are often useful for test harnesses, administrative
 tools, and prototypes that will later be wrapped in a more sophisticated
 interface.
 
-.. class:: Cmd(completekey='tab', stdin=None, stdout=None)
+.. class:: Cmd(completekey=r'"\t"', stdin=None, stdout=None)
 
    A :class:`Cmd` instance or subclass instance is a line-oriented interpreter
    framework.  There is no good reason to instantiate :class:`Cmd` itself; rather,
@@ -23,7 +23,7 @@ interface.
    to inherit :class:`Cmd`'s methods and encapsulate action methods.
 
    The optional argument *completekey* is the :mod:`readline` name of a completion
-   key; it defaults to :kbd:`Tab`. If *completekey* is not :const:`None` and
+   key; it defaults to "\\t"(:kbd:`tab`). If *completekey* is not :const:`None` and
    :mod:`readline` is available, command completion is done automatically.
 
    The optional arguments *stdin* and *stdout* specify the  input and output file

--- a/Doc/library/pdb.rst
+++ b/Doc/library/pdb.rst
@@ -183,7 +183,7 @@ The ``run*`` functions and :func:`set_trace` are aliases for instantiating the
 :class:`Pdb` class and calling the method of the same name.  If you want to
 access further features, you have to do this yourself:
 
-.. class:: Pdb(completekey='tab', stdin=None, stdout=None, skip=None, \
+.. class:: Pdb(completekey=r'"\t"', stdin=None, stdout=None, skip=None, \
                nosigint=False, readrc=True)
 
    :class:`Pdb` is the debugger class.

--- a/Doc/library/readline.rst
+++ b/Doc/library/readline.rst
@@ -17,6 +17,21 @@ made using  this module affect the behaviour of both the interpreter's
 interactive prompt  and the prompts offered by the built-in :func:`input`
 function.
 
+Compatible keybindings
+----------------------
+
+To support compatible keybindings between GNU readline and Libedit, use the
+following backslashed escape sequences or octal escape sequences in quotes. ::
+
+  \a     bell
+  \b     backspace
+  \f     form feed
+  \n     newline
+  \r     carriage return
+  \t     horizontal tab
+  \v     vertical tab
+  \nnn   octal escape sequences
+
 Readline keybindings may be configured via an initialization file, typically
 ``.inputrc`` in your home directory.  See `Readline Init File
 <https://tiswww.cwru.edu/php/chet/readline/rluserman.html#Readline-Init-File>`_
@@ -39,10 +54,10 @@ Readline library in general.
   If you use *editline*/``libedit`` readline emulation on macOS, the
   initialization file located in your home directory is named
   ``.editrc``. For example, the following content in ``~/.editrc`` will
-  turn ON *vi* keybindings and TAB completion::
+  turn ON *vi* keybindings and "\\t"(:kbd:`tab`) completion::
 
     python:bind -v
-    python:bind ^I rl_complete
+    python:bind "\t" rl_complete
 
 
 Init file
@@ -56,6 +71,16 @@ The following functions relate to the init file and user configuration:
    Execute the init line provided in the *string* argument. This calls
    :c:func:`rl_parse_and_bind` in the underlying library.
 
+.. note::
+   The syntax and command of *string* argument may be different depends on the readline library.
+
+   For GNU readline::
+
+    readline.parse_and_bind(r'"\t": complete')
+
+   For Libedit::
+
+    readline.parse_and_bind(r'bind "\t" rl_complete')
 
 .. function:: read_init_file([filename])
 
@@ -348,7 +373,12 @@ support history save/restore. ::
            self.init_history(histfile)
 
        def init_history(self, histfile):
-           readline.parse_and_bind("tab: complete")
+
+            readline_doc = getattr(readline, '__doc__', '')
+            if readline_doc is not None and 'libedit' in readline_doc:
+                readline.parse_and_bind(r'bind "\t" rl_complete')
+            else:
+               readline.parse_and_bind(r'"\t": complete')
            if hasattr(readline, "read_history_file"):
                try:
                    readline.read_history_file(histfile)

--- a/Doc/library/rlcompleter.rst
+++ b/Doc/library/rlcompleter.rst
@@ -21,7 +21,7 @@ Example::
 
    >>> import rlcompleter
    >>> import readline
-   >>> readline.parse_and_bind("tab: complete")
+   >>> readline.parse_and_bind(r'"\t": complete')
    >>> readline. <TAB PRESSED>
    readline.__doc__          readline.get_line_buffer(  readline.read_init_file(
    readline.__file__         readline.insert_text(      readline.set_completer(

--- a/Lib/cmd.py
+++ b/Lib/cmd.py
@@ -73,7 +73,7 @@ class Cmd:
     nohelp = "*** No help on %s"
     use_rawinput = 1
 
-    def __init__(self, completekey='tab', stdin=None, stdout=None):
+    def __init__(self, completekey='"\t"', stdin=None, stdout=None):
         """Instantiate a line-oriented interpreter framework.
 
         The optional argument 'completekey' is the readline name of a
@@ -108,7 +108,11 @@ class Cmd:
                 import readline
                 self.old_completer = readline.get_completer()
                 readline.set_completer(self.complete)
-                readline.parse_and_bind(self.completekey+": complete")
+                readline_doc = getattr(readline, '__doc__', '')
+                if readline_doc is not None and 'libedit' in readline_doc:
+                    readline.parse_and_bind("bind "+self.completekey+" rl_complete")
+                else:
+                    readline.parse_and_bind(self.completekey+": complete")
             except ImportError:
                 pass
         try:

--- a/Lib/pdb.py
+++ b/Lib/pdb.py
@@ -209,7 +209,7 @@ class Pdb(bdb.Bdb, cmd.Cmd):
 
     _previous_sigint_handler = None
 
-    def __init__(self, completekey='tab', stdin=None, stdout=None, skip=None,
+    def __init__(self, completekey=r'"\t"', stdin=None, stdout=None, skip=None,
                  nosigint=False, readrc=True):
         bdb.Bdb.__init__(self, skip=skip)
         cmd.Cmd.__init__(self, completekey, stdin, stdout)

--- a/Lib/site.py
+++ b/Lib/site.py
@@ -446,9 +446,9 @@ def enablerlcompleter():
         # completion key, so we set one first and then read the file.
         readline_doc = getattr(readline, '__doc__', '')
         if readline_doc is not None and 'libedit' in readline_doc:
-            readline.parse_and_bind('bind ^I rl_complete')
+            readline.parse_and_bind(r'bind "\t" rl_complete')
         else:
-            readline.parse_and_bind('tab: complete')
+            readline.parse_and_bind(r'"\t": complete')
 
         try:
             readline.read_init_file()

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -784,6 +784,7 @@ Thomas Holmes
 Craig Holmquist
 Philip Homburg
 Naofumi Honda
+Constantin Hong
 Weipeng Hong
 Jeffrey Honig
 Rob Hooft

--- a/Misc/NEWS.d/next/Library/2023-08-07-19-57-34.gh-issue-102130._UyI5i.rst
+++ b/Misc/NEWS.d/next/Library/2023-08-07-19-57-34.gh-issue-102130._UyI5i.rst
@@ -1,0 +1,1 @@
+Support a tab completion for Libedit in :mod:`cmd `, :mod:`site`, and :mod:`pdb`.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


After I dug the rabbit hole, I wanted to share something and commit it to cpython. I have my research for the `.python_history` compatibility problem. I will write comments within days.

My commit allows a tab complete in pdb and cmd for Libedit readline and improves compatibility between GNU readline and Libedit.

For better compatibility, Python Documents should suggest using backslashed escape sequences(e.g. `\t`, `\a`) or the ASCII character corresponding to the octal number(or octal excape sequences).(e.g. `\011`,  It's because the only thing GNU readline(`man bash` and `/Readline Key Bindings` to search the part.) and Libedit(`man editrc`) have in common. 

`tab` of `readline.parse_and_bind("tab: complete")` is a symbolic character name. Libedit doesn't support a number of symbolic character names(like TAB, ESC, DEL). 

Also, unlike emacs keybinding,  GNU readline doesn't support control characters of the form '^character' (e.g. '^I' it's a tab). 
Both GNU readline and Libedit support the following backslashed escape sequences.

```
\a     bell
\b     backspace
\f     form feed
\n     newline
\r     carriage return
\t     horizontal tab
\v     vertical tab
\nnn   octal escape sequences
```
GNU readline's predefined commands are in the '/Readline Command Names' of `man bash`.
Libedit's predefined commands are in the section "EDITOR COMMANDS" of `man editrc`. But there are other undocumented commands in its source code.
Or you can get a list by `import readline; readline.parse_and_bind('bind -l')` (Libedit only).


<!-- gh-issue-number: gh-102130 -->
* Issue: gh-102130
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--107738.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->