### PR TITLE
gh-107630: Fix Remaining Subinterpreters Crashes on Py_TRACE_REFS Builds

### DIFF
--- a/Lib/test/test_import/__init__.py
+++ b/Lib/test/test_import/__init__.py
@@ -2555,6 +2555,12 @@ class SinglephaseInitTests(unittest.TestCase):
     def test_basic_multiple_interpreters_deleted_no_reset(self):
         # without resetting; already loaded in a deleted interpreter
 
+        if hasattr(sys, 'getobjects'):
+            # It's a Py_TRACE_REFS build.
+            # This test breaks interpreter isolation a little,
+            # which causes problems on Py_TRACE_REF builds.
+            raise unittest.SkipTest('crashes on Py_TRACE_REFS builds')
+
         # At this point:
         #  * alive in 0 interpreters
         #  * module def may or may not be loaded already


### PR DESCRIPTION
This is a follow-up to gh-107567 and gh-107733

<!-- gh-issue-number: gh-107630 -->
* Issue: gh-107630
<!-- /gh-issue-number -->
