### PR TITLE
gh-107755: Document the correct default value of slice step

### DIFF
--- a/Doc/library/functions.rst
+++ b/Doc/library/functions.rst
@@ -1631,7 +1631,7 @@ are always available.  They are listed here in alphabetical order.
 
 
 .. class:: slice(stop)
-           slice(start, stop, step=1)
+           slice(start, stop, step=None)
 
    Return a :term:`slice` object representing the set of indices specified by
    ``range(start, stop, step)``.  The *start* and *step* arguments default to


### PR DESCRIPTION


<!-- gh-issue-number: gh-107755 -->
* Issue: gh-107755
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--107756.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->