### PR TITLE
GH-107585: fix the stable API .lib file name in debug builds on MSVC

### DIFF
--- a/Misc/NEWS.d/next/Build/2023-08-08-05-48-33.gh-issue-107585.GbieTV.rst
+++ b/Misc/NEWS.d/next/Build/2023-08-08-05-48-33.gh-issue-107585.GbieTV.rst
@@ -1,0 +1,2 @@
+Fix the libpython ``.lib`` name when targetting the stable ABI in debug
+builds on MSVC.

--- a/PC/pyconfig.h
+++ b/PC/pyconfig.h
@@ -307,13 +307,19 @@ Py_NO_ENABLE_SHARED to find out.  Also support MS_NO_COREDLL for b/w compat */
                         /* So MSVC users need not specify the .lib
                         file in their Makefile (other compilers are
                         generally taken care of by distutils.) */
-#                       if defined(_DEBUG)
-#                               pragma comment(lib,"python313_d.lib")
-#                       elif defined(Py_LIMITED_API)
-#                               pragma comment(lib,"python3.lib")
+#                       if defined(Py_LIMITED_API)
+#                               define PINNED_VER "3"
 #                       else
-#                               pragma comment(lib,"python313.lib")
+#                               define PINNED_VER "313"
+#                       endif /* Py_LIMITED_API */
+#                       if defined(_DEBUG)
+#                               define DEBUG_SUFFIX "_d"
+#                       else
+#                               define DEBUG_SUFFIX ""
 #                       endif /* _DEBUG */
+#                       pragma comment(lib, "python" PINNED_VER DEBUG_SUFFIX ".lib")
+#                       undef PINNED_VER
+#                       undef DEBUG_SUFFIX
 #               endif /* _MSC_VER */
 #       endif /* Py_BUILD_CORE */
 #endif /* MS_COREDLL */


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-107585 -->
* Issue: gh-107585
<!-- /gh-issue-number -->
