### PR TITLE
gh-104683: Add --exclude option to Argument Clinic CLI

### DIFF
--- a/Doc/howto/clinic.rst
+++ b/Doc/howto/clinic.rst
@@ -188,7 +188,7 @@ The CLI supports the following options:
 
    The directory tree to walk in :option:`--make` mode.
 
-.. option:: --exclude FILES
+.. option:: --exclude EXCLUDES
 
    Comma-separated list of files to exclude in :option:`--make` mode.
    This option has no effect unless :option:`--make` is also given.

--- a/Doc/howto/clinic.rst
+++ b/Doc/howto/clinic.rst
@@ -188,10 +188,10 @@ The CLI supports the following options:
 
    The directory tree to walk in :option:`--make` mode.
 
-.. option:: --exclude EXCLUDES
+.. option:: --exclude EXCLUDE
 
-   Comma-separated list of files to exclude in :option:`--make` mode.
-   This option has no effect unless :option:`--make` is also given.
+   A file to exclude in :option:`--make` mode.
+   This option can be given multiple times.
 
 .. option:: FILE ...
 

--- a/Doc/howto/clinic.rst
+++ b/Doc/howto/clinic.rst
@@ -188,6 +188,11 @@ The CLI supports the following options:
 
    The directory tree to walk in :option:`--make` mode.
 
+.. option:: --exclude FILES
+
+   Comma-separated list of files to exclude in :option:`--make` mode.
+   This option has no effect unless :option:`--make` is also given.
+
 .. option:: FILE ...
 
    The list of files to process.

--- a/Lib/test/test_clinic.py
+++ b/Lib/test/test_clinic.py
@@ -2136,6 +2136,32 @@ class ClinicExternalTest(TestCase):
                     path = os.path.join(ext_path, filename)
                     self.assertNotIn(path, out)
 
+    def test_cli_make_exclude(self):
+        code = dedent("""
+            /*[clinic input]
+            [clinic start generated code]*/
+        """)
+        with os_helper.temp_dir() as tmp_dir:
+            # add some folders, some C files and a Python file
+            for fn in "file1.c", "file2.c", "file3.c":
+                path = os.path.join(tmp_dir, fn)
+                with open(path, "w", encoding="utf-8") as f:
+                    f.write(code)
+
+            # Run clinic in verbose mode with --make on tmpdir.
+            # Exclude file2.c and file3.c.
+            out = self.expect_success(
+                "-v", "--make", "--srcdir", tmp_dir,
+                "--exclude", os.path.join(tmp_dir, "file2.c"),
+                # The added ./ should be normalised away.
+                "--exclude", os.path.join("./", tmp_dir, "file3.c"),
+            )
+
+            # expect verbose mode to only mention the C files in tmp_dir
+            self.assertIn("file1.c", out)
+            self.assertNotIn("file2.c", out)
+            self.assertNotIn("file3.c", out)
+
     def test_cli_verbose(self):
         with os_helper.temp_dir() as tmp_dir:
             fn = os.path.join(tmp_dir, "test.c")

--- a/Lib/test/test_clinic.py
+++ b/Lib/test/test_clinic.py
@@ -2221,9 +2221,9 @@ class ClinicExternalTest(TestCase):
             /*[clinic input]
             [clinic start generated code]*/
         """)
-        with os_helper.temp_dir() as tmp_dir:
+        with os_helper.temp_dir(quiet=False) as tmp_dir:
             # add some folders, some C files and a Python file
-            for fn in "file1.c", "file2.c", "file3.c":
+            for fn in "file1.c", "file2.c", "file3.c", "file4.c":
                 path = os.path.join(tmp_dir, fn)
                 with open(path, "w", encoding="utf-8") as f:
                     f.write(code)
@@ -2234,13 +2234,16 @@ class ClinicExternalTest(TestCase):
                 "-v", "--make", "--srcdir", tmp_dir,
                 "--exclude", os.path.join(tmp_dir, "file2.c"),
                 # The added ./ should be normalised away.
-                "--exclude", os.path.join("./", tmp_dir, "file3.c"),
+                "--exclude", os.path.join(tmp_dir, "./file3.c"),
+                # Relative paths should also work.
+                "--exclude", "file4.c"
             )
 
             # expect verbose mode to only mention the C files in tmp_dir
             self.assertIn("file1.c", out)
             self.assertNotIn("file2.c", out)
             self.assertNotIn("file3.c", out)
+            self.assertNotIn("file4.c", out)
 
     def test_cli_verbose(self):
         with os_helper.temp_dir() as tmp_dir:

--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -775,7 +775,7 @@ coverage-report: regen-token regen-frozen
 # Run "Argument Clinic" over all source files
 .PHONY: clinic
 clinic: check-clean-src $(srcdir)/Modules/_blake2/blake2s_impl.c
-	$(PYTHON_FOR_REGEN) $(srcdir)/Tools/clinic/clinic.py --make --srcdir $(srcdir)
+	$(PYTHON_FOR_REGEN) $(srcdir)/Tools/clinic/clinic.py --make --exclude Lib/test/clinic.test.c --srcdir $(srcdir)
 	$(PYTHON_FOR_REGEN) $(srcdir)/Tools/build/generate_global_objects.py
 
 # Build the interpreter

--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -778,6 +778,10 @@ clinic: check-clean-src $(srcdir)/Modules/_blake2/blake2s_impl.c
 	$(PYTHON_FOR_REGEN) $(srcdir)/Tools/clinic/clinic.py --make --exclude Lib/test/clinic.test.c --srcdir $(srcdir)
 	$(PYTHON_FOR_REGEN) $(srcdir)/Tools/build/generate_global_objects.py
 
+.PHONY: clinic-tests
+clinic-tests: check-clean-src $(srcdir)/Lib/test/clinic.test.c
+	$(PYTHON_FOR_REGEN) $(srcdir)/Tools/clinic/clinic.py -f $(srcdir)/Lib/test/clinic.test.c
+
 # Build the interpreter
 $(BUILDPYTHON):	Programs/python.o $(LINK_PYTHON_DEPS)
 	$(LINKCC) $(PY_CORE_LDFLAGS) $(LINKFORSHARED) -o $@ Programs/python.o $(LINK_PYTHON_OBJS) $(LIBS) $(MODLIBS) $(SYSLIBS)

--- a/Misc/NEWS.d/next/Tools-Demos/2023-08-08-12-21-41.gh-issue-104683.DRsAQE.rst
+++ b/Misc/NEWS.d/next/Tools-Demos/2023-08-08-12-21-41.gh-issue-104683.DRsAQE.rst
@@ -1,0 +1,1 @@
+Add ``--exclude`` option to Argument Clinic CLI.

--- a/Tools/clinic/clinic.py
+++ b/Tools/clinic/clinic.py
@@ -5832,6 +5832,8 @@ For more information see https://docs.python.org/3/howto/clinic.html""")
                          help="walk --srcdir to run over all relevant files")
     cmdline.add_argument("--srcdir", type=str, default=os.curdir,
                          help="the directory tree to walk in --make mode")
+    cmdline.add_argument("--exclude", type=str,
+                         help="a list of files to exclude --make mode")
     cmdline.add_argument("filename", metavar="FILE", type=str, nargs="*",
                          help="the list of files to process")
     return cmdline
@@ -5903,6 +5905,7 @@ def run_clinic(parser: argparse.ArgumentParser, ns: argparse.Namespace) -> None:
             parser.error("can't use -o or filenames with --make")
         if not ns.srcdir:
             parser.error("--srcdir must not be empty with --make")
+        excludes = [os.path.join(ns.srcdir, f) for f in ns.exclude.split(",")]
         for root, dirs, files in os.walk(ns.srcdir):
             for rcs_dir in ('.svn', '.git', '.hg', 'build', 'externals'):
                 if rcs_dir in dirs:
@@ -5912,6 +5915,8 @@ def run_clinic(parser: argparse.ArgumentParser, ns: argparse.Namespace) -> None:
                 if not filename.endswith(('.c', '.cpp', '.h')):
                     continue
                 path = os.path.join(root, filename)
+                if path in excludes:
+                    continue
                 if ns.verbose:
                     print(path)
                 parse_file(path, verify=not ns.force)

--- a/Tools/clinic/clinic.py
+++ b/Tools/clinic/clinic.py
@@ -5832,7 +5832,7 @@ For more information see https://docs.python.org/3/howto/clinic.html""")
                          help="walk --srcdir to run over all relevant files")
     cmdline.add_argument("--srcdir", type=str, default=os.curdir,
                          help="the directory tree to walk in --make mode")
-    cmdline.add_argument("--exclude", type=str, metavar="EXCLUDES",
+    cmdline.add_argument("--exclude", type=str, default="", metavar="EXCLUDES",
                          help="a comma-separated list of files to exclude in --make mode")
     cmdline.add_argument("filename", metavar="FILE", type=str, nargs="*",
                          help="the list of files to process")

--- a/Tools/clinic/clinic.py
+++ b/Tools/clinic/clinic.py
@@ -5832,8 +5832,8 @@ For more information see https://docs.python.org/3/howto/clinic.html""")
                          help="walk --srcdir to run over all relevant files")
     cmdline.add_argument("--srcdir", type=str, default=os.curdir,
                          help="the directory tree to walk in --make mode")
-    cmdline.add_argument("--exclude", type=str,
-                         help="a list of files to exclude --make mode")
+    cmdline.add_argument("--exclude", type=str, metavar="EXCLUDES",
+                         help="a comma-separated list of files to exclude --make mode")
     cmdline.add_argument("filename", metavar="FILE", type=str, nargs="*",
                          help="the list of files to process")
     return cmdline

--- a/Tools/clinic/clinic.py
+++ b/Tools/clinic/clinic.py
@@ -5833,7 +5833,7 @@ For more information see https://docs.python.org/3/howto/clinic.html""")
     cmdline.add_argument("--srcdir", type=str, default=os.curdir,
                          help="the directory tree to walk in --make mode")
     cmdline.add_argument("--exclude", type=str, metavar="EXCLUDES",
-                         help="a comma-separated list of files to exclude --make mode")
+                         help="a comma-separated list of files to exclude in --make mode")
     cmdline.add_argument("filename", metavar="FILE", type=str, nargs="*",
                          help="the list of files to process")
     return cmdline

--- a/Tools/clinic/clinic.py
+++ b/Tools/clinic/clinic.py
@@ -5922,7 +5922,6 @@ def run_clinic(parser: argparse.ArgumentParser, ns: argparse.Namespace) -> None:
                 path = os.path.join(root, filename)
                 path = os.path.normpath(path)
                 if path in excludes:
-                    print("Excluding", path)
                     continue
                 if ns.verbose:
                     print(path)

--- a/Tools/clinic/clinic.py
+++ b/Tools/clinic/clinic.py
@@ -5832,8 +5832,9 @@ For more information see https://docs.python.org/3/howto/clinic.html""")
                          help="walk --srcdir to run over all relevant files")
     cmdline.add_argument("--srcdir", type=str, default=os.curdir,
                          help="the directory tree to walk in --make mode")
-    cmdline.add_argument("--exclude", type=str, default="", metavar="EXCLUDES",
-                         help="a comma-separated list of files to exclude in --make mode")
+    cmdline.add_argument("--exclude", type=str, action="append",
+                         help=("a file to exclude in --make mode; "
+                               "can be given multiple times"))
     cmdline.add_argument("filename", metavar="FILE", type=str, nargs="*",
                          help="the list of files to process")
     return cmdline
@@ -5905,7 +5906,11 @@ def run_clinic(parser: argparse.ArgumentParser, ns: argparse.Namespace) -> None:
             parser.error("can't use -o or filenames with --make")
         if not ns.srcdir:
             parser.error("--srcdir must not be empty with --make")
-        excludes = [os.path.join(ns.srcdir, f) for f in ns.exclude.split(",")]
+        if ns.exclude:
+            excludes = [os.path.join(ns.srcdir, f) for f in ns.exclude]
+            excludes = [os.path.normpath(f) for f in excludes]
+        else:
+            excludes = []
         for root, dirs, files in os.walk(ns.srcdir):
             for rcs_dir in ('.svn', '.git', '.hg', 'build', 'externals'):
                 if rcs_dir in dirs:
@@ -5915,7 +5920,9 @@ def run_clinic(parser: argparse.ArgumentParser, ns: argparse.Namespace) -> None:
                 if not filename.endswith(('.c', '.cpp', '.h')):
                     continue
                 path = os.path.join(root, filename)
+                path = os.path.normpath(path)
                 if path in excludes:
+                    print("Excluding", path)
                     continue
                 if ns.verbose:
                     print(path)


### PR DESCRIPTION
Explicitly exclude Lib/test/clinic.test.c when running make clinic.


<!-- gh-issue-number: gh-104683 -->
* Issue: gh-104683
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--107770.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->