### PR TITLE
GH-107674: Avoid allocating boxed ints for `sys.settrace` line events

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2023-08-05-04-47-18.gh-issue-107674.0sYhR2.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2023-08-05-04-47-18.gh-issue-107674.0sYhR2.rst
@@ -1,0 +1,1 @@
+Fixed performance regression in ``sys.settrace``.

--- a/Python/instrumentation.c
+++ b/Python/instrumentation.c
@@ -1158,14 +1158,14 @@ _Py_call_instrumentation_line(PyThreadState *tstate, _PyInterpreterFrame* frame,
             PyFrameObject *frame_obj = _PyFrame_GetFrameObject(frame);
             if (frame_obj == NULL) {
                 return -1;
-            }
+//             }
             if (frame_obj->f_trace_lines) {
-                /* Set tracing and what_event as we do for
-                 * instrumentation */
+                /* Need to set tracing and what_event as if using
+                 * the instrumentation call. */
                 int old_what = tstate->what_event;
                 tstate->what_event = PY_MONITORING_EVENT_LINE;
                 tstate->tracing++;
-                /* Call c_tracefunc directly */
+                /* Call c_tracefunc directly, having set the line number. */
                 Py_INCREF(frame_obj);
                 frame_obj->f_lineno = line;
                 int err = tstate->c_tracefunc(tstate->c_traceobj, frame_obj, PyTrace_LINE, Py_None);

--- a/Python/instrumentation.c
+++ b/Python/instrumentation.c
@@ -961,7 +961,7 @@ call_instrumentation_vector(
     /* Offset visible to user should be the offset in bytes, as that is the
      * convention for APIs involving code offsets. */
     int bytes_offset = offset * (int)sizeof(_Py_CODEUNIT);
-    PyObject *offset_obj = PyLong_FromSsize_t(bytes_offset);
+    PyObject *offset_obj = PyLong_FromLong(bytes_offset);
     if (offset_obj == NULL) {
         return -1;
     }
@@ -1151,7 +1151,7 @@ _Py_call_instrumentation_line(PyThreadState *tstate, _PyInterpreterFrame* frame,
         (interp->monitors.tools[PY_MONITORING_EVENT_LINE] |
          code->_co_monitoring->local_monitors.tools[PY_MONITORING_EVENT_LINE]
         );
-    PyObject *line_obj = PyLong_FromSsize_t(line);
+    PyObject *line_obj = PyLong_FromLong(line);
     if (line_obj == NULL) {
         return -1;
     }
@@ -1205,7 +1205,7 @@ _Py_call_instrumentation_instruction(PyThreadState *tstate, _PyInterpreterFrame*
          code->_co_monitoring->local_monitors.tools[PY_MONITORING_EVENT_INSTRUCTION]
         );
     int bytes_offset = offset * (int)sizeof(_Py_CODEUNIT);
-    PyObject *offset_obj = PyLong_FromSsize_t(bytes_offset);
+    PyObject *offset_obj = PyLong_FromLong(bytes_offset);
     if (offset_obj == NULL) {
         return -1;
     }

--- a/Python/instrumentation.c
+++ b/Python/instrumentation.c
@@ -1158,7 +1158,7 @@ _Py_call_instrumentation_line(PyThreadState *tstate, _PyInterpreterFrame* frame,
             PyFrameObject *frame_obj = _PyFrame_GetFrameObject(frame);
             if (frame_obj == NULL) {
                 return -1;
-//             }
+            }
             if (frame_obj->f_trace_lines) {
                 /* Need to set tracing and what_event as if using
                  * the instrumentation call. */


### PR DESCRIPTION
The [benchmarks](https://github.com/faster-cpython/benchmarking-public/tree/main/results/bm-20230805-3.13.0a0-83ffca9) are noisy but show a 6% performance increase for coverage.



<!-- gh-issue-number: gh-107674 -->
* Issue: gh-107674
<!-- /gh-issue-number -->
