### PR TITLE
[3.11] gh-106052: Fix bug in the matching of possessive quantifiers (gh-106515)

### DIFF
--- a/Lib/re/_compiler.py
+++ b/Lib/re/_compiler.py
@@ -100,6 +100,13 @@ def _compile(code, pattern, flags):
                 emit(ANY_ALL)
             else:
                 emit(ANY)
+        elif op is POSSESSIVE_REPEAT:
+            # gh-106052: Possessive quantifiers do not work when the
+            # subpattern contains backtracking, i.e. "(?:ab?c)*+".
+            # Implement it as equivalent greedy qualifier in atomic group.
+            p = [(MAX_REPEAT, av)]
+            p = [(ATOMIC_GROUP, p)]
+            _compile(code, p, flags)
         elif op in REPEATING_CODES:
             if flags & SRE_FLAG_TEMPLATE:
                 raise error("internal: unsupported template operator %r" % (op,))

--- a/Lib/test/test_re.py
+++ b/Lib/test/test_re.py
@@ -2396,6 +2396,16 @@ class ReTests(unittest.TestCase):
         self.assertTrue(template_re1.match('ahoy'))
         self.assertFalse(template_re1.match('nope'))
 
+    def test_bug_gh106052(self):
+        self.assertEqual(re.match("(?>(?:ab?c)+)", "aca").span(), (0, 2))
+        self.assertEqual(re.match("(?:ab?c)++", "aca").span(), (0, 2))
+        self.assertEqual(re.match("(?>(?:ab?c)*)", "aca").span(), (0, 2))
+        self.assertEqual(re.match("(?:ab?c)*+", "aca").span(), (0, 2))
+        self.assertEqual(re.match("(?>(?:ab?c)?)", "a").span(), (0, 0))
+        self.assertEqual(re.match("(?:ab?c)?+", "a").span(), (0, 0))
+        self.assertEqual(re.match("(?>(?:ab?c){1,3})", "aca").span(), (0, 2))
+        self.assertEqual(re.match("(?:ab?c){1,3}+", "aca").span(), (0, 2))
+
     @unittest.skipIf(multiprocessing is None, 'test requires multiprocessing')
     def test_regression_gh94675(self):
         pattern = re.compile(r'(?<=[({}])(((//[^\n]*)?[\n])([\000-\040])*)*'
@@ -2492,6 +2502,7 @@ ATOMIC_GROUP
 17: SUCCESS
 ''')
 
+    @unittest.expectedFailure  # gh-106052
     def test_possesive_repeat_one(self):
         self.assertEqual(get_debug_out(r'a?+'), '''\
 POSSESSIVE_REPEAT 0 1
@@ -2504,6 +2515,7 @@ POSSESSIVE_REPEAT 0 1
 12: SUCCESS
 ''')
 
+    @unittest.expectedFailure  # gh-106052
     def test_possesive_repeat(self):
         self.assertEqual(get_debug_out(r'(?:ab)?+'), '''\
 POSSESSIVE_REPEAT 0 1

--- a/Misc/NEWS.d/next/Library/2023-07-07-14-52-31.gh-issue-106052.ak8nbs.rst
+++ b/Misc/NEWS.d/next/Library/2023-07-07-14-52-31.gh-issue-106052.ak8nbs.rst
@@ -1,0 +1,2 @@
+:mod:`re` module: fix the matching of possessive quantifiers in the case of
+a subpattern containing backtracking.


### PR DESCRIPTION
It did not work in the case of a subpattern containing backtracking.

Temporary implement possessive quantifiers as equivalent greedy qualifiers in atomic groups.
(cherry picked from commit 7b6e34e5baeb4162815ffa4d943b09a58e3f6580)


<!-- gh-issue-number: gh-106052 -->
* Issue: gh-106052
<!-- /gh-issue-number -->
