### PR TITLE
Docs: clean up Argument Clinic howto's

### DIFF
--- a/Doc/howto/clinic.rst
+++ b/Doc/howto/clinic.rst
@@ -1932,11 +1932,10 @@ Example from :source:`Objects/codeobject.c`::
 
 The generated docstring ends up looking like this::
 
-   Doc_STRVAR(code_replace__doc__,
-   "replace($self, /, **changes)\n"
-   "--\n"
-   "\n"
-   "Return a copy of the code object with new values for the specified fields.");
+   replace($self, /, **changes)
+   --
+
+   Return a copy of the code object with new values for the specified fields.
 
 
 .. _clinic-howto-deprecate-positional:
@@ -1968,7 +1967,7 @@ whenever the *b* parameter is passed positionally,
 and we'll be allowed to make it keyword-only in Python 3.14 at the earliest.
 
 We can use Argument Clinic to emit the desired deprecation warnings
-using the ``* [from ...]``` syntax,
+using the ``* [from ...]`` syntax,
 by adding the line ``* [from 3.14]`` right above the *b* parameter::
 
    /*[clinic input]
@@ -2000,12 +1999,12 @@ Luckily for us, compiler warnings are now generated:
 .. code-block:: none
 
    In file included from Modules/foomodule.c:139:
-   Modules/clinic/foomodule.c.h:83:8: warning: Update 'b' in 'myfunc' in 'foomodule.c' to be keyword-only. [-W#warnings]
-    #    warning "Update 'b' in 'myfunc' in 'foomodule.c' to be keyword-only."
+   Modules/clinic/foomodule.c.h:139:8: warning: In 'foomodule.c', update parameter(s) 'a' and 'b' in the clinic input of 'mymod.myfunc' to be keyword-only. [-W#warnings]
+    #    warning "In 'foomodule.c', update parameter(s) 'a' and 'b' in the clinic input of 'mymod.myfunc' to be keyword-only. [-W#warnings]"
          ^
 
 We now close the deprecation phase by making *b* keyword-only;
-replace the ``* [from ...]``` line above *b*
+replace the ``* [from ...]`` line above *b*
 with the ``*`` from the line above *c*::
 
    /*[clinic input]

--- a/Doc/howto/clinic.rst
+++ b/Doc/howto/clinic.rst
@@ -1930,7 +1930,7 @@ Example from :source:`Objects/codeobject.c`::
        Return a copy of the code object with new values for the specified fields.
    [clinic start generated output]*/
 
-The generated docstring ends up looking like this::
+The generated docstring ends up looking like this:
 
 .. code-block:: none
 

--- a/Doc/howto/clinic.rst
+++ b/Doc/howto/clinic.rst
@@ -1932,6 +1932,8 @@ Example from :source:`Objects/codeobject.c`::
 
 The generated docstring ends up looking like this::
 
+.. code-block:: none
+
    replace($self, /, **changes)
    --
 

--- a/Misc/NEWS.d/next/Tools-Demos/2023-08-07-16-30-48.gh-issue-95065.-im4R5.rst
+++ b/Misc/NEWS.d/next/Tools-Demos/2023-08-07-16-30-48.gh-issue-95065.-im4R5.rst
@@ -1,2 +1,2 @@
 Argument Clinic now supports overriding automatically generated signature by
-using directive `@text_signature`. See :ref:`clinic-howto-override-signature`.
+using directive ``@text_signature``. See :ref:`clinic-howto-override-signature`.


### PR DESCRIPTION
- fix example in @text_signature howto

- fix example and remove extra backticks from deprecate-positionals howto


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--107797.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->