### PR TITLE
[3.11] Docs: clean up Argument Clinic howto's (#107797)

### DIFF
--- a/Doc/howto/clinic.rst
+++ b/Doc/howto/clinic.rst
@@ -1920,7 +1920,9 @@ Example from :source:`Objects/codeobject.c`::
        Return a copy of the code object with new values for the specified fields.
    [clinic start generated output]*/
 
-The generated docstring ends up looking like this::
+The generated docstring ends up looking like this:
+
+.. code-block:: none
 
    replace($self, /, **changes)
    --


### PR DESCRIPTION
(cherry picked from commit 34cafd35e35dcb44b4347a6478fdbf88b900240c)

- fix formatting in @text_signature howto and NEWS entry


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--107800.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->