### PR TITLE
GH-107812: extend `socket`'s netlink support to FreeBSD

### DIFF
--- a/Misc/NEWS.d/next/Library/2023-08-09-15-37-20.gh-issue-107812.CflAXa.rst
+++ b/Misc/NEWS.d/next/Library/2023-08-09-15-37-20.gh-issue-107812.CflAXa.rst
@@ -1,0 +1,1 @@
+Extend socket's netlink support to the FreeBSD platform.

--- a/Modules/socketmodule.h
+++ b/Modules/socketmodule.h
@@ -100,6 +100,8 @@ typedef int socklen_t;
 #  include <asm/types.h>
 # endif
 # include <linux/netlink.h>
+#elif defined(HAVE_NETLINK_NETLINK_H)
+# include <netlink/netlink.h>
 #else
 #  undef AF_NETLINK
 #endif

--- a/configure
+++ b/configure
@@ -11153,6 +11153,7 @@ fi
 
 
 # On Linux, netlink.h requires asm/types.h
+# On FreeBSD, netlink.h is located in netlink/netlink.h
 ac_fn_c_check_header_compile "$LINENO" "linux/netlink.h" "ac_cv_header_linux_netlink_h" "
 #ifdef HAVE_ASM_TYPES_H
 #include <asm/types.h>
@@ -11165,6 +11166,20 @@ ac_fn_c_check_header_compile "$LINENO" "linux/netlink.h" "ac_cv_header_linux_net
 if test "x$ac_cv_header_linux_netlink_h" = xyes
 then :
   printf "%s\n" "#define HAVE_LINUX_NETLINK_H 1" >>confdefs.h
+
+fi
+ac_fn_c_check_header_compile "$LINENO" "netlink/netlink.h" "ac_cv_header_netlink_netlink_h" "
+#ifdef HAVE_ASM_TYPES_H
+#include <asm/types.h>
+#endif
+#ifdef HAVE_SYS_SOCKET_H
+#include <sys/socket.h>
+#endif
+
+"
+if test "x$ac_cv_header_netlink_netlink_h" = xyes
+then :
+  printf "%s\n" "#define HAVE_NETLINK_NETLINK_H 1" >>confdefs.h
 
 fi
 

--- a/configure.ac
+++ b/configure.ac
@@ -2880,7 +2880,8 @@ AC_CHECK_HEADERS([net/if.h], [], [],
 ])
 
 # On Linux, netlink.h requires asm/types.h
-AC_CHECK_HEADERS([linux/netlink.h], [], [], [
+# On FreeBSD, netlink.h is located in netlink/netlink.h
+AC_CHECK_HEADERS([linux/netlink.h netlink/netlink.h], [], [], [
 #ifdef HAVE_ASM_TYPES_H
 #include <asm/types.h>
 #endif

--- a/pyconfig.h.in
+++ b/pyconfig.h.in
@@ -841,6 +841,9 @@
 /* Define to 1 if you have the <netinet/in.h> header file. */
 #undef HAVE_NETINET_IN_H
 
+/* Define to 1 if you have the <netlink/netlink.h> header file. */
+#undef HAVE_NETLINK_NETLINK_H
+
 /* Define to 1 if you have the <netpacket/packet.h> header file. */
 #undef HAVE_NETPACKET_PACKET_H
 


### PR DESCRIPTION
On FreeBSD, `netlink.h` lives under the `netlink` directory.
Extend the `AC_CHECK_HEADERS` to look there as well.


<!-- gh-issue-number: gh-107812 -->
* Issue: gh-107812
<!-- /gh-issue-number -->
