### PR TITLE
DO NOT MERGE: Always use -Xuops

### DIFF
--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -1231,6 +1231,7 @@ init_interp_main(PyThreadState *tstate)
         if (_Py_get_xoption(&config->xoptions, L"uops") != NULL) {
             enabled = 1;
         }
+        enabled = 1;  // TEMPORARY: always enable
         if (enabled) {
             PyObject *opt = PyUnstable_Optimizer_NewUOpOptimizer();
             if (opt == NULL) {


### PR DESCRIPTION
This exists so we can occasionally assess whether uops work everywhere, and run benchmarks. I will occasionally rebase (not merge!) to the latest main.

Failure of tests bedevere/issue-number and bedever/news, as well as Check labels / DO-NOT-MERGE / unresolved review, is expected and intentional (so I don't accidentally merge this). It is expected to be slower than main.