### PR TITLE
gh-91054: make code watcher tests resilient to other watchers

### DIFF
--- a/Modules/_testcapi/watchers.c
+++ b/Modules/_testcapi/watchers.c
@@ -295,6 +295,7 @@ _testcapi_unwatch_type_impl(PyObject *module, int watcher_id, PyObject *type)
 // Test code object watching
 
 #define NUM_CODE_WATCHERS 2
+static int code_watcher_ids[NUM_CODE_WATCHERS] = {-1, -1};
 static int num_code_object_created_events[NUM_CODE_WATCHERS] = {0, 0};
 static int num_code_object_destroyed_events[NUM_CODE_WATCHERS] = {0, 0};
 
@@ -345,11 +346,13 @@ add_code_watcher(PyObject *self, PyObject *which_watcher)
     long which_l = PyLong_AsLong(which_watcher);
     if (which_l == 0) {
         watcher_id = PyCode_AddWatcher(first_code_object_callback);
+        code_watcher_ids[0] = watcher_id;
         num_code_object_created_events[0] = 0;
         num_code_object_destroyed_events[0] = 0;
     }
     else if (which_l == 1) {
         watcher_id = PyCode_AddWatcher(second_code_object_callback);
+        code_watcher_ids[1] = watcher_id;
         num_code_object_created_events[1] = 0;
         num_code_object_destroyed_events[1] = 0;
     }
@@ -375,9 +378,14 @@ clear_code_watcher(PyObject *self, PyObject *watcher_id)
         return NULL;
     }
     // reset static events counters
-    if (watcher_id_l >= 0 && watcher_id_l < NUM_CODE_WATCHERS) {
-        num_code_object_created_events[watcher_id_l] = 0;
-        num_code_object_destroyed_events[watcher_id_l] = 0;
+    if (watcher_id_l >= 0) {
+        for (int i = 0; i < NUM_CODE_WATCHERS; i++) {
+            if (watcher_id_l == code_watcher_ids[i]) {
+                code_watcher_ids[i] = -1;
+                num_code_object_created_events[i] = 0;
+                num_code_object_destroyed_events[i] = 0;
+            }
+        }
     }
     Py_RETURN_NONE;
 }

--- a/Tools/c-analyzer/cpython/ignored.tsv
+++ b/Tools/c-analyzer/cpython/ignored.tsv
@@ -429,6 +429,7 @@ Modules/_testcapi/watchers.c	-	g_dict_watch_events	-
 Modules/_testcapi/watchers.c	-	g_dict_watchers_installed	-
 Modules/_testcapi/watchers.c	-	g_type_modified_events	-
 Modules/_testcapi/watchers.c	-	g_type_watchers_installed	-
+Modules/_testcapi/watchers.c	-	code_watcher_ids	-
 Modules/_testcapi/watchers.c	-	num_code_object_created_events	-
 Modules/_testcapi/watchers.c	-	num_code_object_destroyed_events	-
 Modules/_testcapi/watchers.c	-	pyfunc_watchers	-


### PR DESCRIPTION
The code watcher tests implicitly assume that the watchers they will register will be numbered `0` and `1`. But this assumption may not hold true if the tests are run with another watcher already active.

This PR fixes the tests to record the actual watcher ID for each "test watcher index" and use that to ensure we clear the correct recorded data when clearing a watcher.

<!-- gh-issue-number: gh-91054 -->
* Issue: gh-91054
<!-- /gh-issue-number -->
