### PR TITLE
gh-107810: Improve DeprecationWarning for metaclasses with custom tp_new

### DIFF
--- a/Lib/test/test_capi/test_misc.py
+++ b/Lib/test/test_capi/test_misc.py
@@ -611,7 +611,7 @@ class CAPITest(unittest.TestCase):
 
         # Class creation from C
         with warnings_helper.check_warnings(
-                ('.*custom tp_new.*in Python 3.14.*', DeprecationWarning),
+                ('.* _testcapi.Subclass .* custom tp_new.*in Python 3.14.*', DeprecationWarning),
                 ):
             sub = _testcapi.make_type_with_base(Base)
         self.assertTrue(issubclass(sub, Base))

--- a/Misc/NEWS.d/next/C API/2023-08-10-11-12-25.gh-issue-107810.oJ40Qx.rst
+++ b/Misc/NEWS.d/next/C API/2023-08-10-11-12-25.gh-issue-107810.oJ40Qx.rst
@@ -1,1 +1,1 @@
-Improve DeprecationWarning for uses of :c:type:`PyType_Spec` with metaclasses that have custom ``tp_new``.
+Improve :exc:`DeprecationWarning` for uses of :c:type:`PyType_Spec` with metaclasses that have custom ``tp_new``.

--- a/Misc/NEWS.d/next/C API/2023-08-10-11-12-25.gh-issue-107810.oJ40Qx.rst
+++ b/Misc/NEWS.d/next/C API/2023-08-10-11-12-25.gh-issue-107810.oJ40Qx.rst
@@ -1,1 +1,1 @@
-Improve DeprecationWarning for use of :c:func:`PyType_Spec`.
+Improve DeprecationWarning for uses of :c:type:`PyType_Spec` with metaclasses that have custom ``tp_new``.

--- a/Misc/NEWS.d/next/C API/2023-08-10-11-12-25.gh-issue-107810.oJ40Qx.rst
+++ b/Misc/NEWS.d/next/C API/2023-08-10-11-12-25.gh-issue-107810.oJ40Qx.rst
@@ -1,0 +1,1 @@
+Improve DeprecationWarning for use of :c:func:`PyType_Spec`.

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -4264,8 +4264,8 @@ _PyType_FromMetaclass_impl(
         if (_allow_tp_new) {
             if (PyErr_WarnFormat(
                     PyExc_DeprecationWarning, 1,
-                    "Type %s uses PyType_Spec with metaclasses that have custom "
-                    "tp_new is deprecated and will no longer be allowed in "
+                    "Type %s uses PyType_Spec with a metaclass that has custom "
+                    "tp_new. This is deprecated and will no longer be allowed in "
                     "Python 3.14.", spec->name) < 0) {
                 goto finally;
             }

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -4264,9 +4264,9 @@ _PyType_FromMetaclass_impl(
         if (_allow_tp_new) {
             if (PyErr_WarnFormat(
                     PyExc_DeprecationWarning, 1,
-                    "Using PyType_Spec with metaclasses that have custom "
+                    "Type %s uses PyType_Spec with metaclasses that have custom "
                     "tp_new is deprecated and will no longer be allowed in "
-                    "Python 3.14.") < 0) {
+                    "Python 3.14.", spec->name) < 0) {
                 goto finally;
             }
         }


### PR DESCRIPTION
Thanks @Eclips4 for the [idea](https://github.com/python/cpython/issues/107810#issuecomment-1671253942)!
If accepted, it would be great if this change could be backported to `3.12`. If not into `3.12.0`, than `3.12.1`.

As example, for `protobuf` the warning would change as such
```diff
-<frozen importlib._bootstrap>:400
-    DeprecationWarning: Using PyType_Spec with metaclasses that have custom tp_new is deprecated and will no longer be allowed in Python 3.14.

+<frozen importlib._bootstrap>:400:
+    DeprecationWarning: Type google._upb._message.MessageMapContainer uses PyType_Spec with metaclasses that have custom tp_new is deprecated and will no longer be allowed in Python 3.14.
```

<!-- gh-issue-number: gh-107810 -->
* Issue: gh-107810
<!-- /gh-issue-number -->
