### PR TITLE
gh-104683: Argument clinic: make `format_docstring()` a method on `Function` objects

### DIFF
--- a/Tools/clinic/clinic.py
+++ b/Tools/clinic/clinic.py
@@ -2665,6 +2665,7 @@ class Function:
     # functions with optional groups because we can't represent
     # those accurately with inspect.Signature in 3.4.
     docstring_only: bool = False
+    forced_text_signature: str | None = None
 
     def __post_init__(self) -> None:
         self.parent = self.cls or self.module
@@ -2724,12 +2725,12 @@ class Function:
         }
         return f
 
-    def format_docstring_signature(self, *, forced_text_signature: str | None) -> str:
+    def format_docstring_signature(self) -> str:
         parameters = self.render_parameters
         text, add, output = _text_accumulator()
         add(self.displayname)
-        if forced_text_signature:
-            add(forced_text_signature)
+        if self.forced_text_signature:
+            add(self.forced_text_signature)
         else:
             add('(')
 
@@ -2898,7 +2899,7 @@ class Function:
                 add('\n')
         return output()
 
-    def format_docstring(self, *, forced_text_signature: str | None) -> None:
+    def format_docstring(self) -> None:
         if self.kind.new_or_init and not self.docstring:
             # don't render a docstring at all, no signature, nothing.
             return
@@ -2938,9 +2939,7 @@ class Function:
 
         # finalize docstring
         parameters = self.format_docstring_parameters()
-        signature = self.format_docstring_signature(
-            forced_text_signature=forced_text_signature
-        )
+        signature = self.format_docstring_signature()
         docstring = "\n".join(lines)
         self.docstring = linear_format(docstring,
                                        signature=signature,
@@ -4803,7 +4802,6 @@ class DSLParser:
     indent: IndentStack
     kind: FunctionKind
     coexist: bool
-    forced_text_signature: str | None
     parameter_continuation: str
     preserve_output: bool
     star_from_version_re = create_regex(
@@ -4840,7 +4838,6 @@ class DSLParser:
         self.indent = IndentStack()
         self.kind = CALLABLE
         self.coexist = False
-        self.forced_text_signature = None
         self.parameter_continuation = ''
         self.preserve_output = False
 
@@ -4982,9 +4979,10 @@ class DSLParser:
         self.coexist = True
 
     def at_text_signature(self, text_signature: str) -> None:
-        if self.forced_text_signature:
+        assert self.function
+        if self.function.forced_text_signature:
             fail("Called @text_signature twice!")
-        self.forced_text_signature = text_signature
+        self.function.forced_text_signature = text_signature
 
     def parse(self, block: Block) -> None:
         self.reset()
@@ -5778,7 +5776,7 @@ class DSLParser:
         if self.deprecated_positional:
             check_remaining("* [from ...]", lambda p: not p.deprecated_positional)
 
-        self.function.format_docstring(forced_text_signature=self.forced_text_signature)
+        self.function.format_docstring()
 
 
 # maps strings to callables.


### PR DESCRIPTION
`format_docstring()` only ever modifies the internal state of the `Function` object that is `self.function` on the `DSLParser`. It makes much more sense for it to be an instance method on `Function` objects rather than `DSLParser` objects.

<!-- gh-issue-number: gh-104683 -->
* Issue: gh-104683
<!-- /gh-issue-number -->
