### PR TITLE
GH-106485: Create object's dict-values instead of creating __dict__, when we can.

### DIFF
--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -5762,10 +5762,8 @@ _PyObjectDict_SetItem(PyTypeObject *tp, PyObject **dictptr,
         assert(dictptr != NULL);
         dict = *dictptr;
         if (dict == NULL) {
+            assert(!_PyType_HasFeature(tp, Py_TPFLAGS_MANAGED_DICT));
             dictkeys_incref(cached);
-            if (_PyType_HasFeature(tp, Py_TPFLAGS_MANAGED_DICT)) {
-                OBJECT_STAT_INC(dict_materialized_on_request);
-            }
             dict = new_dict_with_shared_keys(interp, cached);
             if (dict == NULL)
                 return -1;

--- a/Objects/object.c
+++ b/Objects/object.c
@@ -1577,6 +1577,14 @@ _PyObject_GenericSetAttrWithDict(PyObject *obj, PyObject *name,
                 goto error_check;
             }
             dictptr = &dorv_ptr->dict;
+            if (*dictptr == NULL) {
+                if (_PyObject_InitInlineValues(obj, tp)) {
+                    goto done;
+                }
+                res = _PyObject_StoreInstanceAttribute(
+                    obj, _PyDictOrValues_GetValues(*dorv_ptr), name, value);
+                goto error_check;
+            }
         }
         else {
             dictptr = _PyObject_ComputedDictPointer(obj);

--- a/Objects/object.c
+++ b/Objects/object.c
@@ -1578,7 +1578,7 @@ _PyObject_GenericSetAttrWithDict(PyObject *obj, PyObject *name,
             }
             dictptr = &dorv_ptr->dict;
             if (*dictptr == NULL) {
-                if (_PyObject_InitInlineValues(obj, tp)) {
+                if (_PyObject_InitInlineValues(obj, tp) < 0) {
                     goto done;
                 }
                 res = _PyObject_StoreInstanceAttribute(


### PR DESCRIPTION
When assigning to an attribute of an object with `Py_TPFLAGS_MANAGED_DICT` that lacked either a values array or a `__dict__`,
we currently create a `__dict__`.
This PR allocates a values array instead.

In an ideal world, we would allocate the values array when we allocate the object.
But that will require better integration of the VM, allocator and GC. So that's for another PR in the future.

<!-- gh-issue-number: gh-106485 -->
* Issue: gh-106485
<!-- /gh-issue-number -->
