### PR TITLE
gh-91051: fix segfault when using all 8 type watchers

### DIFF
--- a/Doc/c-api/typeobj.rst
+++ b/Doc/c-api/typeobj.rst
@@ -147,7 +147,7 @@ Quick Reference
    +------------------------------------------------+-----------------------------------+-------------------+---+---+---+---+
    | :c:member:`~PyTypeObject.tp_vectorcall`        | :c:type:`vectorcallfunc`          |                   |   |   |   |   |
    +------------------------------------------------+-----------------------------------+-------------------+---+---+---+---+
-   | [:c:member:`~PyTypeObject.tp_watched`]         | char                              |                   |   |   |   |   |
+   | [:c:member:`~PyTypeObject.tp_watched`]         | unsigned char                     |                   |   |   |   |   |
    +------------------------------------------------+-----------------------------------+-------------------+---+---+---+---+
 
 .. [#slots]
@@ -2141,7 +2141,7 @@ and :c:data:`PyType_Type` effectively act as defaults.)
    .. versionadded:: 3.9 (the field exists since 3.8 but it's only used since 3.9)
 
 
-.. c:member:: char PyTypeObject.tp_watched
+.. c:member:: unsigned char PyTypeObject.tp_watched
 
    Internal. Do not use.
 

--- a/Doc/includes/typestruct.h
+++ b/Doc/includes/typestruct.h
@@ -82,5 +82,5 @@ typedef struct _typeobject {
     vectorcallfunc tp_vectorcall;
 
     /* bitset of which type-watchers care about this type */
-    char tp_watched;
+    unsigned char tp_watched;
 } PyTypeObject;

--- a/Include/cpython/object.h
+++ b/Include/cpython/object.h
@@ -227,7 +227,7 @@ struct _typeobject {
     vectorcallfunc tp_vectorcall;
 
     /* bitset of which type-watchers care about this type */
-    char tp_watched;
+    unsigned char tp_watched;
 };
 
 /* This struct is used by the specializer

--- a/Lib/test/test_capi/test_watchers.py
+++ b/Lib/test/test_capi/test_watchers.py
@@ -298,6 +298,8 @@ class TestTypeWatchers(unittest.TestCase):
         class C: pass
         with ExitStack() as stack:
             last_wid = -1
+            # don't make assumptions about how many watchers are already
+            # registered, just go until we reach the max ID
             while last_wid < self.TYPE_MAX_WATCHERS - 1:
                 last_wid = stack.enter_context(self.watcher())
             self.watch(last_wid, C)

--- a/Lib/test/test_capi/test_watchers.py
+++ b/Lib/test/test_capi/test_watchers.py
@@ -294,6 +294,16 @@ class TestTypeWatchers(unittest.TestCase):
                 C2.hmm = "baz"
                 self.assert_events([C1, [C2]])
 
+    def test_all_watchers(self):
+        class C: pass
+        with ExitStack() as stack:
+            last_wid = -1
+            while last_wid < self.TYPE_MAX_WATCHERS - 1:
+                last_wid = stack.enter_context(self.watcher())
+            self.watch(last_wid, C)
+            C.foo = "bar"
+            self.assert_events([C])
+
     def test_watch_non_type(self):
         with self.watcher() as wid:
             with self.assertRaisesRegex(ValueError, r"Cannot watch non-type"):

--- a/Misc/NEWS.d/next/Core and Builtins/2023-08-10-17-36-27.gh-issue-91051.LfaeNW.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2023-08-10-17-36-27.gh-issue-91051.LfaeNW.rst
@@ -1,0 +1,2 @@
+Fix abort / segfault when using all eight type watcher slots, on platforms
+where ``char`` is signed by default.


### PR DESCRIPTION
The type watcher implementation adds `char tp_watched;` to the `PyTypeObject` struct, and then in `PyType_Modified` it assigns `int bits = type->tp_watched;` and then treats `bits` as a bitset, expecting that only the low 8 bits should ever be set.

On platforms where `char` is signed (e.g. x86), if the top bit in `tp_watched` is set, the cast to `int bits` will sign-extend with 1s, and we will thus have a lot of high bits set in `bits` that are not supposed to ever be set.

On x86 in a debug build, without the fix in this PR, the new test hits the assertion in `PyType_Modified` that only bit positions `< TYPE_MAX_WATCHERS` should be set, and aborts.

The fix is simple: `tp_watched` should be defined as `unsigned char` so that it is zero-extended, not sign-extended.

Note that the test is carefully designed to not assume there are no type watchers already active. It doesn't attempt to register a fixed number of type watchers, instead it just registers type watchers until it reaches `TYPE_MAX_WATCHERS - 1`, the last available slot and the one that can trigger this bug (since it will set the highest bit in `tp_watched` when watching a type.)

<!-- gh-issue-number: gh-91051 -->
* Issue: gh-91051
<!-- /gh-issue-number -->
