### PR TITLE
gh-107868 Add an `O(1)` fastpath for `sum(range(...))`

### DIFF
--- a/Lib/test/test_builtin.py
+++ b/Lib/test/test_builtin.py
@@ -1626,7 +1626,7 @@ class BuiltinTest(unittest.TestCase):
 
         self.assertEqual(sum(range(10), 1000), 1045)
         self.assertEqual(sum(range(10), start=1000), 1045)
-        self.assertEqual(sum(range(10), 0.1), 45.1)
+        self.assertAlmostEqual(sum(range(10), 0.1), 45.1)
         self.assertEqual(sum(range(10), 2**31-5), 2**31+40)
         self.assertEqual(sum(range(10), 2**63-5), 2**63+40)
         self.assertEqual(sum(range(-11, 13, 3)), -4)

--- a/Lib/test/test_builtin.py
+++ b/Lib/test/test_builtin.py
@@ -1626,8 +1626,12 @@ class BuiltinTest(unittest.TestCase):
 
         self.assertEqual(sum(range(10), 1000), 1045)
         self.assertEqual(sum(range(10), start=1000), 1045)
+        self.assertEqual(sum(range(10), 0.1), 45.1)
         self.assertEqual(sum(range(10), 2**31-5), 2**31+40)
         self.assertEqual(sum(range(10), 2**63-5), 2**63+40)
+        self.assertEqual(sum(range(-11, 13, 3)), -4)
+        self.assertEqual(sum(range(-11, -131, -2)), -4200)
+        self.assertEqual(sum(range(-100, -200, 13)), 0)
 
         self.assertEqual(sum(i % 2 != 0 for i in range(10)), 5)
         self.assertEqual(sum((i % 2 != 0 for i in range(10)), 2**31-3),

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -350,6 +350,7 @@ Hervé Coatanhay
 Riccardo Coccioli
 Nick Coghlan
 Josh Cogliati
+Marco Cognetta
 Noam Cohen
 Dave Cole
 Terrence Cole

--- a/Misc/NEWS.d/next/Core and Builtins/2023-08-11-16-44-29.gh-issue-107868.BgT7zE.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2023-08-11-16-44-29.gh-issue-107868.BgT7zE.rst
@@ -1,0 +1,1 @@
+Reduce `sum(range(...))` from `O(n)` to `O(1)` time . Patch by Marco Cognetta.

--- a/Misc/NEWS.d/next/Core and Builtins/2023-08-11-16-44-29.gh-issue-107868.BgT7zE.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2023-08-11-16-44-29.gh-issue-107868.BgT7zE.rst
@@ -1,1 +1,1 @@
-Reduce `sum(range(...))` from `O(n)` to `O(1)` time . Patch by Marco Cognetta.
+Reduce ``sum(range(...))`` from ``O(n)`` to ``O(1)`` time . Patch by Marco Cognetta.

--- a/Python/bltinmodule.c
+++ b/Python/bltinmodule.c
@@ -2494,7 +2494,7 @@ static PyObject* range_sum_fastpath(PyObject* module, PyObject *range)
     PyObject* length = builtin_len(module, range);
 
     if (PyObject_RichCompareBool(length, PyLong_FromLong(0), Py_EQ)) {
-        Py_DecRef(length);
+        Py_DECREF(length);
         return PyLong_FromLong(0);
     }
 
@@ -2523,17 +2523,17 @@ static PyObject* range_sum_fastpath(PyObject* module, PyObject *range)
 
     PyObject* result = PyNumber_Add(d, e);
 
-    Py_DecRef(length);
-    Py_DecRef(start);
-    Py_DecRef(step);
+    Py_DECREF(length);
+    Py_DECREF(start);
+    Py_DECREF(step);
 
-    Py_DecRef(one);
-    Py_DecRef(a);
-    Py_DecRef(b);
-    Py_DecRef(two);
-    Py_DecRef(c);
-    Py_DecRef(d);
-    Py_DecRef(e);
+    Py_DECREF(one);
+    Py_DECREF(a);
+    Py_DECREF(b);
+    Py_DECREF(two);
+    Py_DECREF(c);
+    Py_DECREF(d);
+    Py_DECREF(e);
 
     return result;
 }
@@ -2551,7 +2551,7 @@ builtin_sum_impl(PyObject *module, PyObject *iterable, PyObject *start)
         }
         PyObject* rangesum =  range_sum_fastpath(module, iterable);
         result = PyNumber_Add(result, rangesum);
-        Py_DecRef(rangesum);
+        Py_DECREF(rangesum);
         return result;
     }
 


### PR DESCRIPTION
This adds a fastpath for `sum(range(...))`, which takes `O(1)` time. This partially resolves #68264 (but does not address the core issue of why there was a slowdown overall) as well as #107868.

Note: I am still not too familiar with cpython's internals. I believe this is a reasonable place to implement it, but I think the best way would be to add `sum` to `PySequenceMethods`, except that that would break ABI backwards compatibility, right?

The other thing I am worried about is that I did not implement the chain of operators (and their reference decrementing) in the most idiomatic way. Any advice would be appreciated.

------------------------------------------------------------------------------------

Some example timings are below (I do not have python2 on my machine to compare to, but #68264 shows it would be closer to the `main` branch timings than this PR):

Main:
```python
>>> import time
>>> t=time.time();sum(range(1,pow(10,8)+1));print(time.time()-t)
5000000050000000
3.165787696838379
```

This PR:
```python
>>> import time
>>> t=time.time();sum(range(1,pow(10,8)+1));print(time.time()-t)
5000000050000000
7.939338684082031e-05
```


<!-- gh-issue-number: gh-107868 -->
* Issue: gh-107868
<!-- /gh-issue-number -->
