### PR TITLE
gh-103082: use IS_VALID_OPCODE instead of _PyOpcode_OpName to check if an opcode is defined

### DIFF
--- a/Python/instrumentation.c
+++ b/Python/instrumentation.c
@@ -7,6 +7,7 @@
 #include "pycore_namespace.h"
 #include "pycore_object.h"
 #include "pycore_opcode.h"
+#include "pycore_opcode_metadata.h" // IS_VALID_OPCODE
 #include "pycore_pyerrors.h"
 #include "pycore_pystate.h"       // _PyInterpreterState_GET()
 
@@ -437,11 +438,10 @@ dump_instrumentation_data(PyCodeObject *code, int star, FILE*out)
 static bool
 valid_opcode(int opcode)
 {
-    if (opcode > 0 &&
+    if (IS_VALID_OPCODE(opcode) &&
+        opcode != CACHE &&
         opcode != RESERVED &&
-        opcode < 255 &&
-        _PyOpcode_OpName[opcode] &&
-        _PyOpcode_OpName[opcode][0] != '<')
+        opcode < 255)
     {
        return true;
     }


### PR DESCRIPTION


<!-- gh-issue-number: gh-103082 -->
* Issue: gh-103082
<!-- /gh-issue-number -->
