### PR TITLE
Attempt to speed up deepfreeze.py

### DIFF
--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -1253,7 +1253,7 @@ regen-frozen: Tools/build/freeze_modules.py $(FROZEN_FILES_IN)
 .PHONY: regen-deepfreeze
 regen-deepfreeze: $(DEEPFREEZE_OBJS)
 
-DEEPFREEZE_DEPS=$(srcdir)/Tools/build/deepfreeze.py $(FREEZE_MODULE_DEPS) $(FROZEN_FILES_OUT)
+DEEPFREEZE_DEPS=$(srcdir)/Tools/build/deepfreeze.py Include/internal/pycore_global_strings.h $(FREEZE_MODULE_DEPS) $(FROZEN_FILES_OUT)
 
 # BEGIN: deepfreeze modules
 Python/deepfreeze/deepfreeze.c: $(DEEPFREEZE_DEPS)

--- a/Tools/build/deepfreeze.py
+++ b/Tools/build/deepfreeze.py
@@ -457,7 +457,7 @@ def decode_frozen_data(source: str) -> types.CodeType:
     values: list[int] = []
     for line in source.splitlines():
         if re.match(FROZEN_DATA_LINE, line):
-            values.extend(int(x) for x in line.split(",") if x.strip())
+            values.extend([int(x) for x in line.split(",") if x.strip()])
     data = bytes(values)
     return umarshal.loads(data)
 

--- a/Tools/build/deepfreeze.py
+++ b/Tools/build/deepfreeze.py
@@ -6,7 +6,6 @@ On Windows, and in cross-compilation cases, it is executed
 by Python 3.10, and 3.11 features are not available.
 """
 import argparse
-import ast
 import builtins
 import collections
 import contextlib
@@ -455,12 +454,10 @@ def is_frozen_header(source: str) -> bool:
 
 
 def decode_frozen_data(source: str) -> types.CodeType:
-    lines = source.splitlines()
-    while lines and re.match(FROZEN_DATA_LINE, lines[0]) is None:
-        del lines[0]
-    while lines and re.match(FROZEN_DATA_LINE, lines[-1]) is None:
-        del lines[-1]
-    values: Tuple[int, ...] = ast.literal_eval("".join(lines).strip())
+    values: list[int] = []
+    for line in source.splitlines():
+        if re.match(FROZEN_DATA_LINE, line):
+            values.extend(int(x) for x in line.split(",") if x.strip())
     data = bytes(values)
     return umarshal.loads(data)
 


### PR DESCRIPTION
- Instead of calling `get_identifiers_and_strings()`, extract identifiers and strings from pycore_global_strings.h.
- Avoid `ast.literal_eval()`, which speeds up `decode_frozen_data()` tremendously.

On my Mac, the first commit cuts the time to run deepfreeze.py in half, from 9 to 4.5 seconds, and the second and third commits cut more than halve it again, to 1.8 seconds.

I verified that the output is the same.