### PR TITLE
gh-107891: Fix typo in 3.12 whatsnew 

### DIFF
--- a/Doc/whatsnew/3.12.rst
+++ b/Doc/whatsnew/3.12.rst
@@ -1576,7 +1576,7 @@ Changes in the Python API
       1,13-1,17:          FSTRING_MIDDLE ' end'
       1,17-1,18:          FSTRING_END    '"'
 
-  Additionally, there may be some minor behavioral changes as a consecuence of the
+  Additionally, there may be some minor behavioral changes as a consequence of the
   changes required to support :pep:`701`. Some of these changes include:
 
   * The ``type`` attribute of the tokens emitted when tokenizing some invalid Python


### PR DESCRIPTION
Fixes typo in 3.12 whatsnew.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-107891 -->
* Issue: gh-107891
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--107892.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->