### PR TITLE
gh-107906 Remove unused `maxsize` argument from `_init` method of `queue.Queue`

### DIFF
--- a/Lib/asyncio/queues.py
+++ b/Lib/asyncio/queues.py
@@ -40,7 +40,7 @@ class Queue(mixins._LoopBoundMixin):
         self._unfinished_tasks = 0
         self._finished = locks.Event()
         self._finished.set()
-        self._init(maxsize)
+        self._init()
 
     # These three are overridable in subclasses.
 

--- a/Lib/asyncio/queues.py
+++ b/Lib/asyncio/queues.py
@@ -44,7 +44,7 @@ class Queue(mixins._LoopBoundMixin):
 
     # These three are overridable in subclasses.
 
-    def _init(self, maxsize):
+    def _init(self):
         self._queue = collections.deque()
 
     def _get(self):
@@ -221,7 +221,7 @@ class PriorityQueue(Queue):
     Entries are typically tuples of the form: (priority number, data).
     """
 
-    def _init(self, maxsize):
+    def _init(self):
         self._queue = []
 
     def _put(self, item, heappush=heapq.heappush):
@@ -234,7 +234,7 @@ class PriorityQueue(Queue):
 class LifoQueue(Queue):
     """A subclass of Queue that retrieves most recently added entries first."""
 
-    def _init(self, maxsize):
+    def _init(self):
         self._queue = []
 
     def _put(self, item):

--- a/Lib/queue.py
+++ b/Lib/queue.py
@@ -33,7 +33,7 @@ class Queue:
 
     def __init__(self, maxsize=0):
         self.maxsize = maxsize
-        self._init(maxsize)
+        self._init()
 
         # mutex must be held whenever the queue is mutating.  All methods
         # that acquire mutex must release it before returning.  mutex
@@ -203,7 +203,7 @@ class Queue:
     # These will only be called with appropriate locks held
 
     # Initialize the queue representation
-    def _init(self, maxsize):
+    def _init(self):
         self.queue = deque()
 
     def _qsize(self):

--- a/Lib/queue.py
+++ b/Lib/queue.py
@@ -226,7 +226,7 @@ class PriorityQueue(Queue):
     Entries are typically tuples of the form:  (priority number, data).
     '''
 
-    def _init(self, maxsize):
+    def _init(self):
         self.queue = []
 
     def _qsize(self):
@@ -242,7 +242,7 @@ class PriorityQueue(Queue):
 class LifoQueue(Queue):
     '''Variant of Queue that retrieves most recently added entries first.'''
 
-    def _init(self, maxsize):
+    def _init(self):
         self.queue = []
 
     def _qsize(self):


### PR DESCRIPTION
Closes #107906

See message in commit bacae73ca5e2f62694c1d2f7875ffc155035e651 for details.

<!-- gh-issue-number: gh-107906 -->
* Issue: gh-107906
<!-- /gh-issue-number -->
