### PR TITLE
gh-107675:Deprecate historic auth mechanism CRAM-MD5 from smtplib

### DIFF
--- a/Doc/library/smtplib.rst
+++ b/Doc/library/smtplib.rst
@@ -369,10 +369,10 @@ An :class:`SMTP` instance has the following methods:
    should return ASCII ``str`` *data* that will be base64 encoded and sent to the
    server.
 
-   The ``SMTP`` class provides ``authobjects`` for the ``CRAM-MD5``, ``PLAIN``,
-   and ``LOGIN`` mechanisms; they are named ``SMTP.auth_cram_md5``,
-   ``SMTP.auth_plain``, and ``SMTP.auth_login`` respectively.  They all require
-   that the ``user`` and ``password`` properties of the ``SMTP`` instance are
+   The ``SMTP`` class provides ``authobjects`` for the ``PLAIN``,
+   and ``LOGIN`` mechanisms; they are named ``SMTP.auth_plain``,
+   and ``SMTP.auth_login`` respectively.  They all require that the
+   ``user`` and ``password`` properties of the ``SMTP`` instance are
    set to appropriate values.
 
    User code does not normally need to call ``auth`` directly, but can instead
@@ -382,6 +382,10 @@ An :class:`SMTP` instance has the following methods:
    directly by :mod:`smtplib`.
 
    .. versionadded:: 3.5
+
+   .. versionchanged:: 3.13
+
+      Historic auth mechanism ``CRAM-MD5`` is removed
 
 
 .. method:: SMTP.starttls(*, context=None)

--- a/Doc/library/smtplib.rst
+++ b/Doc/library/smtplib.rst
@@ -385,7 +385,7 @@ An :class:`SMTP` instance has the following methods:
 
    .. versionchanged:: 3.13
 
-      Historic auth mechanism ``CRAM-MD5`` is removed
+      Historic auth mechanism ``CRAM-MD5`` is deprecated
 
 
 .. method:: SMTP.starttls(*, context=None)

--- a/Doc/library/smtplib.rst
+++ b/Doc/library/smtplib.rst
@@ -369,10 +369,10 @@ An :class:`SMTP` instance has the following methods:
    should return ASCII ``str`` *data* that will be base64 encoded and sent to the
    server.
 
-   The ``SMTP`` class provides ``authobjects`` for the ``PLAIN``,
-   and ``LOGIN`` mechanisms; they are named ``SMTP.auth_plain``,
-   and ``SMTP.auth_login`` respectively.  They all require that the
-   ``user`` and ``password`` properties of the ``SMTP`` instance are
+   The ``SMTP`` class provides ``authobjects`` for the ``CRAM-MD5``, ``PLAIN``,
+   and ``LOGIN`` mechanisms; they are named ``SMTP.auth_cram_md5``,
+   ``SMTP.auth_plain``, and ``SMTP.auth_login`` respectively.  They all require
+   that the ``user`` and ``password`` properties of the ``SMTP`` instance are
    set to appropriate values.
 
    User code does not normally need to call ``auth`` directly, but can instead
@@ -386,7 +386,6 @@ An :class:`SMTP` instance has the following methods:
    .. versionchanged:: 3.13
 
       Historic auth mechanism ``CRAM-MD5`` is deprecated
-
 
 .. method:: SMTP.starttls(*, context=None)
 

--- a/Lib/smtplib.py
+++ b/Lib/smtplib.py
@@ -661,15 +661,6 @@ class SMTP:
             return (code, resp)
         raise SMTPAuthenticationError(code, resp)
 
-    def auth_cram_md5(self, challenge=None):
-        """ Authobject to use with CRAM-MD5 authentication. Requires self.user
-        and self.password to be set."""
-        # CRAM-MD5 does not support initial-response.
-        if challenge is None:
-            return None
-        return self.user + " " + hmac.HMAC(
-            self.password.encode('ascii'), challenge, 'md5').hexdigest()
-
     def auth_plain(self, challenge=None):
         """ Authobject to use with PLAIN authentication. Requires self.user and
         self.password to be set."""
@@ -720,7 +711,7 @@ class SMTP:
         advertised_authlist = self.esmtp_features["auth"].split()
 
         # Authentication methods we can handle in our preferred order:
-        preferred_auths = ['CRAM-MD5', 'PLAIN', 'LOGIN']
+        preferred_auths = ['PLAIN', 'LOGIN']
 
         # We try the supported authentications in our preferred order, if
         # the server supports them.

--- a/Lib/smtplib.py
+++ b/Lib/smtplib.py
@@ -52,6 +52,7 @@ import hmac
 import copy
 import datetime
 import sys
+import warnings
 from email.base64mime import body_encode as encode_base64
 
 __all__ = ["SMTPException", "SMTPNotSupportedError", "SMTPServerDisconnected", "SMTPResponseException",
@@ -661,6 +662,17 @@ class SMTP:
             return (code, resp)
         raise SMTPAuthenticationError(code, resp)
 
+    def auth_cram_md5(self, challenge=None):
+        """ Authobject to use with CRAM-MD5 authentication. Requires self.user
+        and self.password to be set."""
+        # CRAM-MD5 does not support initial-response.
+        warnings.warn("This function is deprecated and will be removed in Python 3.15.",
+                       DeprecationWarning, stacklevel=2)
+        if challenge is None:
+            return None
+        return self.user + " " + hmac.HMAC(
+            self.password.encode('ascii'), challenge, 'md5').hexdigest()
+
     def auth_plain(self, challenge=None):
         """ Authobject to use with PLAIN authentication. Requires self.user and
         self.password to be set."""
@@ -711,7 +723,7 @@ class SMTP:
         advertised_authlist = self.esmtp_features["auth"].split()
 
         # Authentication methods we can handle in our preferred order:
-        preferred_auths = ['PLAIN', 'LOGIN']
+        preferred_auths = ['CRAM-MD5', 'PLAIN', 'LOGIN']
 
         # We try the supported authentications in our preferred order, if
         # the server supports them.

--- a/Lib/test/test_smtplib.py
+++ b/Lib/test/test_smtplib.py
@@ -808,8 +808,6 @@ sim_users = {'Mr.A@somewhere.com':'John A',
             }
 
 sim_auth = ('Mr.A@somewhere.com', 'somepassword')
-sim_cram_md5_challenge = ('PENCeUxFREJoU0NnbmhNWitOMjNGNn'
-                          'dAZWx3b29kLmlubm9zb2Z0LmNvbT4=')
 sim_lists = {'list-1':['Mr.A@somewhere.com','Mrs.C@somewhereesle.com'],
              'list-2':['Ms.B@xn--fo-fka.com',],
             }
@@ -916,24 +914,6 @@ class SimSMTPChannel(smtpd.SMTPChannel):
         # This AUTH mechanism will 'trap' client in a neverending 334
         # base64 encoded 'BuGgYbUgGy'
         self.push('334 QnVHZ1liVWdHeQ==')
-
-    def _auth_cram_md5(self, arg=None):
-        if arg is None:
-            self.push('334 {}'.format(sim_cram_md5_challenge))
-        else:
-            logpass = self._decode_base64(arg)
-            try:
-                user, hashed_pass = logpass.split()
-            except ValueError as e:
-                self.push('535 Splitting response {!r} into user and password '
-                          'failed: {}'.format(logpass, e))
-                return False
-            valid_hashed_pass = hmac.HMAC(
-                sim_auth[1].encode('ascii'),
-                self._decode_base64(sim_cram_md5_challenge).encode('ascii'),
-                'md5').hexdigest()
-            self._authenticated(user, hashed_pass == valid_hashed_pass)
-    # end AUTH related stuff.
 
     def smtp_EHLO(self, arg):
         resp = ('250-testhost\r\n'
@@ -1174,18 +1154,9 @@ class SMTPSimTests(unittest.TestCase):
             smtp.close()
 
     @hashlib_helper.requires_hashdigest('md5', openssl=True)
-    def testAUTH_CRAM_MD5(self):
-        self.serv.add_feature("AUTH CRAM-MD5")
-        smtp = smtplib.SMTP(HOST, self.port, local_hostname='localhost',
-                            timeout=support.LOOPBACK_TIMEOUT)
-        resp = smtp.login(sim_auth[0], sim_auth[1])
-        self.assertEqual(resp, (235, b'Authentication Succeeded'))
-        smtp.close()
-
-    @hashlib_helper.requires_hashdigest('md5', openssl=True)
     def testAUTH_multiple(self):
         # Test that multiple authentication methods are tried.
-        self.serv.add_feature("AUTH BOGUS PLAIN LOGIN CRAM-MD5")
+        self.serv.add_feature("AUTH BOGUS PLAIN LOGIN")
         smtp = smtplib.SMTP(HOST, self.port, local_hostname='localhost',
                             timeout=support.LOOPBACK_TIMEOUT)
         resp = smtp.login(sim_auth[0], sim_auth[1])
@@ -1194,12 +1165,6 @@ class SMTPSimTests(unittest.TestCase):
 
     def test_auth_function(self):
         supported = {'PLAIN', 'LOGIN'}
-        try:
-            hashlib.md5()
-        except ValueError:
-            pass
-        else:
-            supported.add('CRAM-MD5')
         for mechanism in supported:
             self.serv.add_feature("AUTH {}".format(mechanism))
         for mechanism in supported:

--- a/Misc/NEWS.d/next/Library/2023-08-13-07-08-15.gh-issue-107675.zXs1aw.rst
+++ b/Misc/NEWS.d/next/Library/2023-08-13-07-08-15.gh-issue-107675.zXs1aw.rst
@@ -1,0 +1,1 @@
+Remove historic auth mechanism ``CRAM-MD5`` from smtplib

--- a/Misc/NEWS.d/next/Library/2023-08-13-07-08-15.gh-issue-107675.zXs1aw.rst
+++ b/Misc/NEWS.d/next/Library/2023-08-13-07-08-15.gh-issue-107675.zXs1aw.rst
@@ -1,1 +1,1 @@
-Remove historic auth mechanism ``CRAM-MD5`` from smtplib
+Deprecate historic auth mechanism ``CRAM-MD5`` from smtplib


### PR DESCRIPTION


<!-- gh-issue-number: gh-107675 -->
* Issue: gh-107675
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--107911.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->