### PR TITLE
gh-107916: Save the error code before decoding the filename in PyErr_SetFromErrnoWithFilename() etc

### DIFF
--- a/Misc/NEWS.d/next/C API/2023-08-14-10-59-03.gh-issue-107916.KH4Muo.rst
+++ b/Misc/NEWS.d/next/C API/2023-08-14-10-59-03.gh-issue-107916.KH4Muo.rst
@@ -1,0 +1,4 @@
+C API functions :c:func:`PyErr_SetFromErrnoWithFilename`,
+:c:func:`PyErr_SetExcFromWindowsErrWithFilename` and
+:c:func:`PyErr_SetFromWindowsErrWithFilename` save now the error code before
+calling :c:func:`PyUnicode_DecodeFSDefault`.

--- a/Python/errors.c
+++ b/Python/errors.c
@@ -895,10 +895,12 @@ PyErr_SetFromErrnoWithFilename(PyObject *exc, const char *filename)
 {
     PyObject *name = NULL;
     if (filename) {
+        int i = errno;
         name = PyUnicode_DecodeFSDefault(filename);
         if (name == NULL) {
             return NULL;
         }
+        errno = i;
     }
     PyObject *result = PyErr_SetFromErrnoWithFilenameObjects(exc, name, NULL);
     Py_XDECREF(name);
@@ -998,6 +1000,9 @@ PyObject *PyErr_SetExcFromWindowsErrWithFilename(
 {
     PyObject *name = NULL;
     if (filename) {
+        if ((DWORD)ierr == 0) {
+            ierr = (int)GetLastError();
+        }
         name = PyUnicode_DecodeFSDefault(filename);
         if (name == NULL) {
             return NULL;
@@ -1028,6 +1033,9 @@ PyObject *PyErr_SetFromWindowsErrWithFilename(
 {
     PyObject *name = NULL;
     if (filename) {
+        if ((DWORD)ierr == 0) {
+            ierr = (int)GetLastError();
+        }
         name = PyUnicode_DecodeFSDefault(filename);
         if (name == NULL) {
             return NULL;


### PR DESCRIPTION
Depends on #107918.

<!-- gh-issue-number: gh-107916 -->
* Issue: gh-107916
<!-- /gh-issue-number -->
