### PR TITLE
gh-107851: reduce race condition in test_flock and test_lockf

### DIFF
--- a/Lib/test/_test_eintr.py
+++ b/Lib/test/_test_eintr.py
@@ -506,7 +506,9 @@ class FNTLEINTRTest(EINTRBaseTest):
             with open(os_helper.TESTFN, 'wb') as f:
                 # synchronize the subprocess
                 start_time = time.monotonic()
-                for _ in support.sleeping_retry(support.LONG_TIMEOUT, error=False):
+                # make sure to sleep significantly less than sleep_time
+                # between tries, to minimize the race with the subprocess
+                for _ in support.sleeping_retry(support.LONG_TIMEOUT, error=False, max_delay=self.sleep_time / 2):
                     try:
                         lock_func(f, fcntl.LOCK_EX | fcntl.LOCK_NB)
                         lock_func(f, fcntl.LOCK_UN)


### PR DESCRIPTION
Avoid a spurious test failure.  When the parent process sleeps longer
between tries than the subprocess holds the lock, the synchronisation can
fail.


<!-- gh-issue-number: gh-107851 -->
* Issue: gh-107851
<!-- /gh-issue-number -->
