### PR TITLE
gh-107957: Fix `dir()` sample output in `enum` docs

### DIFF
--- a/Doc/howto/enum.rst
+++ b/Doc/howto/enum.rst
@@ -1050,9 +1050,9 @@ If you give your enum subclass extra methods, like the `Planet`_
 class below, those methods will show up in a :func:`dir` of the member,
 but not of the class::
 
-    >>> dir(Planet)
+    >>> dir(Planet)                         # doctest: +SKIP
     ['EARTH', 'JUPITER', 'MARS', 'MERCURY', 'NEPTUNE', 'SATURN', 'URANUS', 'VENUS', '__class__', '__contains__', '__doc__', '__getitem__', '__init_subclass__', '__iter__', '__len__', '__members__', '__module__', '__name__', '__qualname__']
-    >>> dir(Planet.EARTH)
+    >>> dir(Planet.EARTH)                   # doctest: +SKIP
     ['EARTH', 'JUPITER', 'MARS', 'MERCURY', 'NEPTUNE', 'SATURN', 'URANUS', 'VENUS', '__class__', '__doc__', '__eq__', '__hash__', '__module__', 'mass', 'name', 'radius', 'surface_gravity', 'value']
 
 .. versionchanged:: 3.11

--- a/Doc/howto/enum.rst
+++ b/Doc/howto/enum.rst
@@ -1051,9 +1051,13 @@ class below, those methods will show up in a :func:`dir` of the member,
 but not of the class::
 
     >>> dir(Planet)                         # doctest: +SKIP
-    ['EARTH', 'JUPITER', 'MARS', 'MERCURY', 'NEPTUNE', 'SATURN', 'URANUS', 'VENUS', '__class__', '__doc__', '__members__', '__module__']
+    ['EARTH', 'JUPITER', 'MARS', 'MERCURY', 'NEPTUNE', 'SATURN', 'URANUS', 'VENUS', '__class__', '__contains__', '__doc__', '__getitem__', '__init_subclass__', '__iter__', '__len__', '__members__', '__module__', '__name__', '__qualname__']
     >>> dir(Planet.EARTH)                   # doctest: +SKIP
-    ['__class__', '__doc__', '__module__', 'mass', 'name', 'radius', 'surface_gravity', 'value']
+    ['EARTH', 'JUPITER', 'MARS', 'MERCURY', 'NEPTUNE', 'SATURN', 'URANUS', 'VENUS', '__class__', '__doc__', '__eq__', '__hash__', '__module__', 'mass', 'name', 'radius', 'surface_gravity', 'value']
+
+.. versionchanged:: 3.11
+    Additional ``__dunder__`` names are returned for enums and enum members.
+    Calling :func:`dir` on an enum member also returns the other members.
 
 
 Combining members of ``Flag``

--- a/Doc/howto/enum.rst
+++ b/Doc/howto/enum.rst
@@ -1050,9 +1050,9 @@ If you give your enum subclass extra methods, like the `Planet`_
 class below, those methods will show up in a :func:`dir` of the member,
 but not of the class::
 
-    >>> dir(Planet)                         # doctest: +SKIP
+    >>> dir(Planet)
     ['EARTH', 'JUPITER', 'MARS', 'MERCURY', 'NEPTUNE', 'SATURN', 'URANUS', 'VENUS', '__class__', '__contains__', '__doc__', '__getitem__', '__init_subclass__', '__iter__', '__len__', '__members__', '__module__', '__name__', '__qualname__']
-    >>> dir(Planet.EARTH)                   # doctest: +SKIP
+    >>> dir(Planet.EARTH)
     ['EARTH', 'JUPITER', 'MARS', 'MERCURY', 'NEPTUNE', 'SATURN', 'URANUS', 'VENUS', '__class__', '__doc__', '__eq__', '__hash__', '__module__', 'mass', 'name', 'radius', 'surface_gravity', 'value']
 
 .. versionchanged:: 3.11

--- a/Doc/library/enum.rst
+++ b/Doc/library/enum.rst
@@ -207,11 +207,15 @@ Data Types
 
    .. method:: EnumType.__dir__(cls)
 
-      Returns ``['__class__', '__doc__', '__members__', '__module__']`` and the
-      names of the members in *cls*::
+      Returns ``['__class__', '__contains__', '__doc__', '__getitem__', '__iter__', '__len__', '__members__', '__module__', '__name__', '__qualname__']``
+      and the names of the members in *cls*::
 
         >>> dir(Color)
         ['BLUE', 'GREEN', 'RED', '__class__', '__contains__', '__doc__', '__getitem__', '__init_subclass__', '__iter__', '__len__', '__members__', '__module__', '__name__', '__qualname__']
+
+      .. versionchanged:: 3.11
+         '__contains__', '__getitem__', '__iter__', '__len__', '__name__', and
+         '__qualname__' are also returned.
 
    .. method:: EnumType.__getitem__(cls, name)
 
@@ -278,8 +282,8 @@ Data Types
 
    .. method:: Enum.__dir__(self)
 
-      Returns ``['__class__', '__doc__', '__module__', 'name', 'value']`` and
-      any public methods defined on *self.__class__*::
+      Returns ``['__class__', '__doc__', '__eq__', '__hash__', '__module__', 'name', 'value']``,
+      enum members, and any public methods defined on *self.__class__*::
 
          >>> from datetime import date
          >>> class Weekday(Enum):
@@ -295,7 +299,10 @@ Data Types
          ...         print('today is %s' % cls(date.today().isoweekday()).name)
          ...
          >>> dir(Weekday.SATURDAY)
-         ['__class__', '__doc__', '__eq__', '__hash__', '__module__', 'name', 'today', 'value']
+         ['FRIDAY', 'MONDAY', 'SATURDAY', 'SUNDAY', 'THURSDAY', 'TUESDAY', 'WEDNESDAY', '__class__', '__doc__', '__eq__', '__hash__', '__module__', 'name', 'today', 'value']
+
+      .. versionchanged:: 3.11
+         '__eq__', '__hash__', and enum members are also returned.
 
    .. method:: Enum._generate_next_value_(name, start, count, last_values)
 

--- a/Doc/library/enum.rst
+++ b/Doc/library/enum.rst
@@ -207,8 +207,8 @@ Data Types
 
    .. method:: EnumType.__dir__(cls)
 
-      Returns ``['__class__', '__contains__', '__doc__', '__getitem__', '__iter__', '__len__', '__members__', '__module__', '__name__', '__qualname__']``
-      and the names of the members in *cls*::
+      Returns the names of the members in *cls* and
+      ``['__class__', '__contains__', '__doc__', '__getitem__', '__iter__', '__len__', '__members__', '__module__', '__name__', '__qualname__']``::
 
         >>> dir(Color)
         ['BLUE', 'GREEN', 'RED', '__class__', '__contains__', '__doc__', '__getitem__', '__init_subclass__', '__iter__', '__len__', '__members__', '__module__', '__name__', '__qualname__']
@@ -278,8 +278,8 @@ Data Types
 
    .. method:: Enum.__dir__(self)
 
-      Returns ``['__class__', '__doc__', '__eq__', '__hash__', '__module__', 'name', 'value']``,
-      enum members, and any public methods defined on *self.__class__*::
+      Returns the names of the enum members and any public methods defined on
+      *self.__class__*, as well as ``['__class__', '__doc__', '__eq__', '__hash__', '__module__', 'name', 'value']``::
 
          >>> from datetime import date
          >>> class Weekday(Enum):

--- a/Doc/library/enum.rst
+++ b/Doc/library/enum.rst
@@ -213,10 +213,6 @@ Data Types
         >>> dir(Color)
         ['BLUE', 'GREEN', 'RED', '__class__', '__contains__', '__doc__', '__getitem__', '__init_subclass__', '__iter__', '__len__', '__members__', '__module__', '__name__', '__qualname__']
 
-      .. versionchanged:: 3.11
-         '__contains__', '__getitem__', '__iter__', '__len__', '__name__', and
-         '__qualname__' are also returned.
-
    .. method:: EnumType.__getitem__(cls, name)
 
       Returns the Enum member in *cls* matching *name*, or raises a :exc:`KeyError`::

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -1562,6 +1562,7 @@ Liam Routt
 Todd Rovito
 Craig Rowland
 Clinton Roy
+Ujan RoyBandyopadhyay
 Paul Rubin
 Sam Ruby
 Demur Rumed

--- a/Misc/NEWS.d/next/Documentation/2023-08-14-20-38-39.gh-issue-107957.DU3mID.rst
+++ b/Misc/NEWS.d/next/Documentation/2023-08-14-20-38-39.gh-issue-107957.DU3mID.rst
@@ -1,0 +1,1 @@
+Fix sample outputs for :func:`dir()` function in :module:`enum` docs.

--- a/Misc/NEWS.d/next/Documentation/2023-08-14-20-38-39.gh-issue-107957.DU3mID.rst
+++ b/Misc/NEWS.d/next/Documentation/2023-08-14-20-38-39.gh-issue-107957.DU3mID.rst
@@ -1,1 +1,0 @@
-Fix sample outputs for :func:`dir()` function in :mod:`enum` docs.

--- a/Misc/NEWS.d/next/Documentation/2023-08-14-20-38-39.gh-issue-107957.DU3mID.rst
+++ b/Misc/NEWS.d/next/Documentation/2023-08-14-20-38-39.gh-issue-107957.DU3mID.rst
@@ -1,1 +1,1 @@
-Fix sample outputs for :func:`dir()` function in :module:`enum` docs.
+Fix sample outputs for :func:`dir()` function in :mod:`enum` docs.


### PR DESCRIPTION


<!-- gh-issue-number: gh-107957 -->
* Issue: gh-107957
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--107958.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->