### PR TITLE
gh-107959: clarify Unix-availability of `os.lchmod()`

### DIFF
--- a/Doc/library/os.rst
+++ b/Doc/library/os.rst
@@ -2121,7 +2121,11 @@ features:
 
    .. audit-event:: os.chmod path,mode,dir_fd os.lchmod
 
-   .. availability:: Unix.
+   .. availability:: Unix, not Linux, FreeBSD >= 1.3, NetBSD >= 1.3, not OpenBSD
+
+   .. note::
+      ``lchmod()`` is not part of POSIX, but Unix implementations may have it
+      if changing the mode of symbolic links is supported.
 
    .. versionchanged:: 3.6
       Accepts a :term:`path-like object`.

--- a/Doc/library/os.rst
+++ b/Doc/library/os.rst
@@ -2119,13 +2119,12 @@ features:
    for possible values of *mode*.  As of Python 3.3, this is equivalent to
    ``os.chmod(path, mode, follow_symlinks=False)``.
 
+   ``lchmod()`` is not part of POSIX, but Unix implementations may have it if
+   changing the mode of symbolic links is supported.
+
    .. audit-event:: os.chmod path,mode,dir_fd os.lchmod
 
    .. availability:: Unix, not Linux, FreeBSD >= 1.3, NetBSD >= 1.3, not OpenBSD
-
-   .. note::
-      ``lchmod()`` is not part of POSIX, but Unix implementations may have it
-      if changing the mode of symbolic links is supported.
 
    .. versionchanged:: 3.6
       Accepts a :term:`path-like object`.


### PR DESCRIPTION
POSIX specifies that implementations are not required to support changing the file mode of symbolic links, but may do so.
Consequently, `lchmod()` is not part of POSIX (but mentioned for implementations which do support the above).

The current wording of the availability of `os.lchmod()` is rather vague and improved to clearly tell which POSIX/Unix/BSD-like support the function in general (those that support changing the file mode of symbolic links). Further, some examples of major implementations are added.

Data for the BSDs taken from their online manpages.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-107959 -->
* Issue: gh-107959
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--107960.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->