### PR TITLE
Note that lnotab_notes.txt is only valid before 3.11

### DIFF
--- a/Objects/lnotab_notes.txt
+++ b/Objects/lnotab_notes.txt
@@ -1,4 +1,6 @@
-Description of the internal format of the line number table
+Description of the internal format of the line number table in Python 3.10. 
+
+(For 3.11 onwards, see Objects/locations.md)
 
 Conceptually, the line number table consists of a sequence of triples:
     start-offset (inclusive), end-offset (exclusive), line-number.

--- a/Objects/lnotab_notes.txt
+++ b/Objects/lnotab_notes.txt
@@ -1,4 +1,5 @@
-Description of the internal format of the line number table in Python 3.10. 
+Description of the internal format of the line number table in Python 3.10
+and earlier.
 
 (For 3.11 onwards, see Objects/locations.md)
 


### PR DESCRIPTION
Adds a pointer to Objects/locations.md, the line table document for 3.11+