### PR TITLE
gh-105857: Document that asyncio subprocess std{in,out,err} can be file handles

### DIFF
--- a/Doc/library/asyncio-eventloop.rst
+++ b/Doc/library/asyncio-eventloop.rst
@@ -1442,6 +1442,7 @@ async/await code consider using the high-level
    * *stdin* can be any of these:
 
      * a file-like object
+     * an existing file descriptor (a positive integer), for example those created with :meth:`os.pipe()`
      * the :const:`subprocess.PIPE` constant (default) which will create a new
        pipe and connect it,
      * the value ``None`` which will make the subprocess inherit the file


### PR DESCRIPTION
In the docs passing a filehandle isn't mentioned as an option. Looking at the underlying code, I see it definitely is supported there's a check for the parameter being an integer and the handle is used directly.

<!-- gh-issue-number: gh-105857 -->
* Issue: gh-105857
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--107986.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->