### PR TITLE
gh-91051: fix type watcher test to be robust to existing watcher

### DIFF
--- a/Lib/test/test_capi/test_watchers.py
+++ b/Lib/test/test_capi/test_watchers.py
@@ -353,7 +353,7 @@ class TestTypeWatchers(unittest.TestCase):
     def test_no_more_ids_available(self):
         with self.assertRaisesRegex(RuntimeError, r"no more type watcher IDs"):
             with ExitStack() as stack:
-                while True:
+                for _ in range(self.TYPE_MAX_WATCHERS + 1):
                     stack.enter_context(self.watcher())
 
 

--- a/Lib/test/test_capi/test_watchers.py
+++ b/Lib/test/test_capi/test_watchers.py
@@ -351,12 +351,10 @@ class TestTypeWatchers(unittest.TestCase):
             self.clear_watcher(1)
 
     def test_no_more_ids_available(self):
-        contexts = [self.watcher() for i in range(self.TYPE_MAX_WATCHERS)]
-        with ExitStack() as stack:
-            for ctx in contexts:
-                stack.enter_context(ctx)
-            with self.assertRaisesRegex(RuntimeError, r"no more type watcher IDs"):
-                self.add_watcher()
+        with self.assertRaisesRegex(RuntimeError, r"no more type watcher IDs"):
+            with ExitStack() as stack:
+                while True:
+                    stack.enter_context(self.watcher())
 
 
 class TestCodeObjectWatchers(unittest.TestCase):


### PR DESCRIPTION
One more case of a watcher test spuriously failing because a watcher is already installed. I think this should be the last one.

<!-- gh-issue-number: gh-91051 -->
* Issue: gh-91051
<!-- /gh-issue-number -->
