### PR TITLE
gh-107995: Fix doctest collection of functools.cached_property objects

### DIFF
--- a/Lib/functools.py
+++ b/Lib/functools.py
@@ -984,6 +984,7 @@ class cached_property:
         self.func = func
         self.attrname = None
         self.__doc__ = func.__doc__
+        self.__module__ = func.__module__
 
     def __set_name__(self, owner, name):
         if self.attrname is None:

--- a/Lib/test/test_doctest.py
+++ b/Lib/test/test_doctest.py
@@ -111,6 +111,14 @@ class SampleClass:
         """
         return cls.a_class_attribute
 
+    @functools.cached_property
+    def a_cached_property(self):
+        """
+        >>> print(SampleClass(29).get())
+        29
+        """
+        return "hello"
+
     class NestedClass:
         """
         >>> x = SampleClass.NestedClass(5)
@@ -515,6 +523,7 @@ methods, classmethods, staticmethods, properties, and nested classes.
      3  SampleClass.NestedClass
      1  SampleClass.NestedClass.__init__
      1  SampleClass.__init__
+     1  SampleClass.a_cached_property
      2  SampleClass.a_classmethod
      1  SampleClass.a_classmethod_property
      1  SampleClass.a_property
@@ -571,6 +580,7 @@ functions, classes, and the `__test__` dictionary, if it exists:
      3  some_module.SampleClass.NestedClass
      1  some_module.SampleClass.NestedClass.__init__
      1  some_module.SampleClass.__init__
+     1  some_module.SampleClass.a_cached_property
      2  some_module.SampleClass.a_classmethod
      1  some_module.SampleClass.a_classmethod_property
      1  some_module.SampleClass.a_property
@@ -613,6 +623,7 @@ By default, an object with no doctests doesn't create any tests:
      3  SampleClass.NestedClass
      1  SampleClass.NestedClass.__init__
      1  SampleClass.__init__
+     1  SampleClass.a_cached_property
      2  SampleClass.a_classmethod
      1  SampleClass.a_classmethod_property
      1  SampleClass.a_property
@@ -634,6 +645,7 @@ displays.
      0  SampleClass.NestedClass.get
      0  SampleClass.NestedClass.square
      1  SampleClass.__init__
+     1  SampleClass.a_cached_property
      2  SampleClass.a_classmethod
      1  SampleClass.a_classmethod_property
      1  SampleClass.a_property

--- a/Lib/test/test_functools.py
+++ b/Lib/test/test_functools.py
@@ -3105,6 +3105,9 @@ class TestCachedProperty(unittest.TestCase):
     def test_doc(self):
         self.assertEqual(CachedCostItem.cost.__doc__, "The cost of the item.")
 
+    def test_module(self):
+        self.assertEqual(CachedCostItem.cost.__module__, CachedCostItem.__module__)
+
     def test_subclass_with___set__(self):
         """Caching still works for a subclass defining __set__."""
         class readonly_cached_property(py_functools.cached_property):

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -1706,6 +1706,7 @@ Roman Skurikhin
 Ville Skyttä
 Michael Sloan
 Nick Sloan
+Tyler Smart
 Radek Smejkal
 Václav Šmilauer
 Casper W. Smet

--- a/Misc/NEWS.d/next/Library/2023-08-16-00-24-07.gh-issue-107995.TlTp5t.rst
+++ b/Misc/NEWS.d/next/Library/2023-08-16-00-24-07.gh-issue-107995.TlTp5t.rst
@@ -1,1 +1,5 @@
-Fix :mod:`doctest` collection of :func:`functools.cached_property` objects.
+The ``__module__`` attribute on instances of :class:`functools.cached_property`
+is now set to the name of the module in which the cached_property is defined,
+rather than "functools". This means that doctests in ``cached_property``
+docstrings are now properly collected by the :mod:`doctest` module. Patch by
+Tyler Smart.

--- a/Misc/NEWS.d/next/Library/2023-08-16-00-24-07.gh-issue-107995.TlTp5t.rst
+++ b/Misc/NEWS.d/next/Library/2023-08-16-00-24-07.gh-issue-107995.TlTp5t.rst
@@ -1,0 +1,1 @@
+Fix :mod:`doctest` collection of :func:`functools.cached_property` objects.


### PR DESCRIPTION
`DocTestFinder` would skip `functools.cached_property` objects because they were not considered to be a part of the module that it is collecting doc tests from. To fix this issue I added a check for `cached_property` that grabs the underlying function, similar to what is done for `staticmethod` and `classmethod`.

<!-- gh-issue-number: gh-107995 -->
* Issue: gh-107995
<!-- /gh-issue-number -->
