### PR TITLE
gh-107909: Test explicit `object` base in PEP695 generic classes

### DIFF
--- a/Lib/test/test_type_params.py
+++ b/Lib/test/test_type_params.py
@@ -149,7 +149,7 @@ class TypeParamsInvalidTest(unittest.TestCase):
         check_syntax_error(self, "type T = [(x := 3) for _ in range(2)]")
 
     def test_incorrect_mro_explicit_object(self):
-        with self.assertRaisesRegex(TypeError, "(MRO) for bases object, Generic"):
+        with self.assertRaisesRegex(TypeError, r"\(MRO\) for bases object, Generic"):
             class My[X](object): ...
 
 

--- a/Lib/test/test_type_params.py
+++ b/Lib/test/test_type_params.py
@@ -148,6 +148,10 @@ class TypeParamsInvalidTest(unittest.TestCase):
         check_syntax_error(self, "def f[T: [(x := 3) for _ in range(2)]](): pass")
         check_syntax_error(self, "type T = [(x := 3) for _ in range(2)]")
 
+    def test_incorrect_mro_explicit_object(self):
+        with self.assertRaisesRegex(TypeError, "(MRO) for bases object, Generic"):
+            class My[X](object): ...
+
 
 class TypeParamsNonlocalTest(unittest.TestCase):
     def test_nonlocal_disallowed_01(self):


### PR DESCRIPTION


<!-- gh-issue-number: gh-107909 -->
* Issue: gh-107909
<!-- /gh-issue-number -->
