### PR TITLE
gh-106659: Fix test_embed.test_forced_io_encoding() on Windows

### DIFF
--- a/Doc/whatsnew/3.13.rst
+++ b/Doc/whatsnew/3.13.rst
@@ -941,7 +941,8 @@ Removed
   * ``Py_SetPath()``: set :c:member:`PyConfig.module_search_paths` instead.
   * ``Py_SetProgramName()``: set :c:member:`PyConfig.program_name` instead.
   * ``Py_SetPythonHome()``: set :c:member:`PyConfig.home` instead.
-  * ``Py_SetStandardStreamEncoding()``: set :c:member:`PyConfig.stdio_encoding` instead.
+  * ``Py_SetStandardStreamEncoding()``: set :c:member:`PyConfig.stdio_encoding`
+    instead, and set also maybe :c:member:`PyConfig.legacy_windows_stdio`.
   * ``_Py_SetProgramFullPath()``: set :c:member:`PyConfig.executable` instead.
 
   Use the new :c:type:`PyConfig` API of the :ref:`Python Initialization

--- a/Doc/whatsnew/3.13.rst
+++ b/Doc/whatsnew/3.13.rst
@@ -942,7 +942,8 @@ Removed
   * ``Py_SetProgramName()``: set :c:member:`PyConfig.program_name` instead.
   * ``Py_SetPythonHome()``: set :c:member:`PyConfig.home` instead.
   * ``Py_SetStandardStreamEncoding()``: set :c:member:`PyConfig.stdio_encoding`
-    instead, and set also maybe :c:member:`PyConfig.legacy_windows_stdio`.
+    instead, and set also maybe :c:member:`PyConfig.legacy_windows_stdio` (on
+    Windows).
   * ``_Py_SetProgramFullPath()``: set :c:member:`PyConfig.executable` instead.
 
   Use the new :c:type:`PyConfig` API of the :ref:`Python Initialization

--- a/Programs/_testembed.c
+++ b/Programs/_testembed.c
@@ -237,9 +237,11 @@ static void check_stdio_details(const wchar_t *encoding, const wchar_t *errors)
     if (errors) {
         config_set_string(&config, &config.stdio_errors, errors);
     }
+#ifdef MS_WINDOWS
     // gh-106659: On Windows, don't use _io._WindowsConsoleIO which always
     // announce UTF-8 for sys.stdin.encoding.
     config.legacy_windows_stdio = 1;
+#endif
     config_set_program_name(&config);
     init_from_config_clear(&config);
 

--- a/Programs/_testembed.c
+++ b/Programs/_testembed.c
@@ -237,6 +237,9 @@ static void check_stdio_details(const wchar_t *encoding, const wchar_t *errors)
     if (errors) {
         config_set_string(&config, &config.stdio_errors, errors);
     }
+    // gh-106659: On Windows, don't use _io._WindowsConsoleIO which always
+    // announce UTF-8 for sys.stdin.encoding.
+    config.legacy_windows_stdio = 1;
     config_set_program_name(&config);
     init_from_config_clear(&config);
 


### PR DESCRIPTION
Use config.legacy_windows_stdio=1 to avoid _io._WindowsConsoleIO.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-106659 -->
* Issue: gh-106659
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--108010.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->