### PR TITLE
Docs: Add link to skip to datetime's format codes

### DIFF
--- a/Doc/library/datetime.rst
+++ b/Doc/library/datetime.rst
@@ -19,6 +19,10 @@ The :mod:`datetime` module supplies classes for manipulating dates and times.
 While date and time arithmetic is supported, the focus of the implementation is
 on efficient attribute extraction for output formatting and manipulation.
 
+.. tip::
+
+    Skip to :ref:`the format codes <format-codes>`.
+
 .. seealso::
 
    Module :mod:`calendar`
@@ -2321,6 +2325,8 @@ versus :meth:`strptime`:
 | Signature      | ``strftime(format)``                                   | ``strptime(date_string, format)``                                            |
 +----------------+--------------------------------------------------------+------------------------------------------------------------------------------+
 
+
+   .. _format-codes:
 
 :meth:`strftime` and :meth:`strptime` Format Codes
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

I often visit the `datetime` docs to look up the format codes, but they're right down near the end of the page.

It would be helpful to add a prominent link at the top, to skip directly to the table of codes.

The `datetime` page is the 5th most visited page, 245k page views per month, compared with 385k for the homepage! I don't know how many are looking for the format codes, but I expect it's a sizeable share.


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--108027.org.readthedocs.build/en/108027/library/datetime.html

<!-- readthedocs-preview cpython-previews end -->