### PR TITLE
Improve the feature-proposal issue form

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -10,28 +10,26 @@ body:
         You'll need to demonstrate widespread support for your idea among the community.
 
         Major feature proposals should generally be discussed on [Discourse](https://discuss.python.org/c/ideas/6) before opening a GitHub issue. Wait until it's clear that most people support your idea before filling in this form.
-  - type: checkboxes
+  - type: dropdown
     attributes:
       label: Has this already been discussed elsewhere?        
       options:
-        - label: I have already discussed this feature proposal on Discourse
-        - label: This is a minor feature, which does not need previous discussion elsewhere
+        - No response given
+        - I have already discussed this feature proposal on Discourse
+        - This is a minor feature, which does not need previous discussion elsewhere
+      multiple: false
+    validations:
+      required: true
   - type: textarea
     attributes:
       label: "Links to previous discussion of this feature:"
     validations:
       required: false
-  - type: input
-    attributes:
-      label: "Summary of proposal:"
-      description: A one-line summary of your proposal.
-    validations:
-      required: true
   - type: textarea
     attributes:
-      label: "Pitch:"
+      label: "Proposal:"
       description: >
-        Explain why this feature or enhancement should be implemented and how it would be used.
+        Explain what your proposal is, why it should be implemented and how it would be used.
         Add examples, if applicable.
         Put any code blocks inside triple backticks.
       value: |

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -14,7 +14,7 @@ body:
     attributes:
       label: Has this already been discussed elsewhere?
       options:
-        - No response given
+        - None
         - I have already discussed this feature proposal on Discourse
         - This is a minor feature, which does not need previous discussion elsewhere
       multiple: false

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -12,7 +12,7 @@ body:
         Major feature proposals should generally be discussed on [Discourse](https://discuss.python.org/c/ideas/6) before opening a GitHub issue. Wait until it's clear that most people support your idea before filling in this form.
   - type: dropdown
     attributes:
-      label: Has this already been discussed elsewhere?        
+      label: Has this already been discussed elsewhere?
       options:
         - No response given
         - I have already discussed this feature proposal on Discourse

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -14,7 +14,7 @@ body:
     attributes:
       label: Has this already been discussed elsewhere?
       options:
-        - None
+        - No response given
         - I have already discussed this feature proposal on Discourse
         - This is a minor feature, which does not need previous discussion elsewhere
       multiple: false

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -29,7 +29,7 @@ body:
     attributes:
       label: "Proposal:"
       description: >
-        Explain what your proposal is, why it should be implemented and how it would be used.
+        Explain your proposal, why it should be implemented, and how it would be used.
         Add examples, if applicable.
         Put any code blocks inside triple backticks.
       value: |


### PR DESCRIPTION
A small followup to #107920, now we've had a few days' experience of people using the issue forms:
- Convert the "I have/haven't discussed this feature on Discourse" checkbox into a dropdown. It doesn't make sense to check both of these boxes; a dropdown makes more sense here.
- Get rid of the demand that people provide a one-sentence summary of their proposal. This makes sense for some feature proposals, but not for others. For people who want to provide a summary, they can probably just integrate it into the main body of their feature proposal.

As before, I've pushed these changes to the `main` branch of my GitHub form, so you can try creating an issue at https://github.com/AlexWaygood/cpython to see how the form renders.