### PR TITLE
[3.11] gh-102215: importlib documentation cleanups

### DIFF
--- a/Doc/library/importlib.metadata.rst
+++ b/Doc/library/importlib.metadata.rst
@@ -1,11 +1,11 @@
 .. _using:
 
-=================================
- Using :mod:`!importlib.metadata`
-=================================
+========================================================
+:mod:`!importlib.metadata` -- Accessing package metadata
+========================================================
 
 .. module:: importlib.metadata
-   :synopsis: The implementation of the importlib metadata.
+   :synopsis: Accessing package metadata
 
 .. versionadded:: 3.8
 .. versionchanged:: 3.10
@@ -13,7 +13,7 @@
 
 **Source code:** :source:`Lib/importlib/metadata/__init__.py`
 
-``importlib_metadata`` is a library that provides access to
+``importlib.metadata`` is a library that provides access to
 the metadata of an installed `Distribution Package <https://packaging.python.org/en/latest/glossary/#term-Distribution-Package>`_,
 such as its entry points
 or its top-level names (`Import Package <https://packaging.python.org/en/latest/glossary/#term-Import-Package>`_\s, modules, if any).
@@ -24,7 +24,7 @@ API`_ and `metadata API`_ of ``pkg_resources``.  Along with
 this package can eliminate the need to use the older and less efficient
 ``pkg_resources`` package.
 
-``importlib_metadata`` operates on third-party *distribution packages*
+``importlib.metadata`` operates on third-party *distribution packages*
 installed into Python's ``site-packages`` directory via tools such as
 `pip <https://pypi.org/project/pip/>`_.
 Specifically, it works with distributions with discoverable
@@ -365,7 +365,7 @@ system `finders`_.  To find a distribution package's metadata,
 ``importlib.metadata`` queries the list of :term:`meta path finders <meta path finder>` on
 :data:`sys.meta_path`.
 
-By default ``importlib_metadata`` installs a finder for distribution packages
+By default ``importlib.metadata`` installs a finder for distribution packages
 found on the file system.
 This finder doesn't actually find any *distributions*,
 but it can find their metadata.

--- a/Doc/library/importlib.resources.rst
+++ b/Doc/library/importlib.resources.rst
@@ -1,5 +1,5 @@
-:mod:`importlib.resources` -- Resources
----------------------------------------
+:mod:`importlib.resources` -- Package resource reading, opening and access
+--------------------------------------------------------------------------
 
 .. module:: importlib.resources
     :synopsis: Package resource reading, opening, and access
@@ -79,7 +79,7 @@ for example, a package and its resources can be imported from a zip file using
     .. versionadded:: 3.9
 
 Deprecated functions
---------------------
+^^^^^^^^^^^^^^^^^^^^
 
 An older, deprecated set of functions is still available, but is
 scheduled for removal in a future version of Python.


### PR DESCRIPTION
(cherry picked from commit 4cd95dce0b8d7bb8a16468ec8b5b3429555417f1)



<!-- gh-issue-number: gh-102215 -->
* Issue: gh-102215
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--108056.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->