### PR TITLE
[3.11] GH-92584: Remove reference to Distutils in ``cx_Freeze``'s description (GH-108047)

### DIFF
--- a/Doc/using/windows.rst
+++ b/Doc/using/windows.rst
@@ -1233,11 +1233,10 @@ shipped with PyWin32.  It is an embeddable IDE with a built-in debugger.
 cx_Freeze
 ---------
 
-`cx_Freeze <https://cx-freeze.readthedocs.io/en/latest/>`_ is a :mod:`distutils`
-extension (see :ref:`extending-distutils`) which wraps Python scripts into
-executable Windows programs (:file:`{*}.exe` files).  When you have done this,
-you can distribute your application without requiring your users to install
-Python.
+`cx_Freeze <https://cx-freeze.readthedocs.io/en/latest/>`_
+wraps Python scripts into executable Windows programs
+(:file:`{*}.exe` files).  When you have done this, you can distribute your
+application without requiring your users to install Python.
 
 
 Compiling Python on Windows


### PR DESCRIPTION
Remove reference to Distutils in ``cx_Freeze``'s description. (cherry picked from commit 57fcf96e4f21b8955b3ae4b4d70e4b756949712f)


<!-- gh-issue-number: gh-92584 -->
* Issue: gh-92584
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--108061.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->