### PR TITLE
clarify distinction between datetime module and class in deprecation messages

### DIFF
--- a/Modules/_datetimemodule.c
+++ b/Modules/_datetimemodule.c
@@ -5136,9 +5136,9 @@ static PyObject *
 datetime_utcnow(PyObject *cls, PyObject *dummy)
 {
     if (PyErr_WarnEx(PyExc_DeprecationWarning,
-        "datetime.utcnow() is deprecated and scheduled for removal in a "
+        "datetime.datetime.utcnow() is deprecated and scheduled for removal in a "
         "future version. Use timezone-aware objects to represent datetimes "
-        "in UTC: datetime.now(datetime.UTC).", 1))
+        "in UTC: datetime.datetime.now(datetime.UTC).", 1))
     {
         return NULL;
     }
@@ -5179,9 +5179,9 @@ static PyObject *
 datetime_utcfromtimestamp(PyObject *cls, PyObject *args)
 {
     if (PyErr_WarnEx(PyExc_DeprecationWarning,
-        "datetime.utcfromtimestamp() is deprecated and scheduled for removal "
+        "datetime.datetime.utcfromtimestamp() is deprecated and scheduled for removal "
         "in a future version. Use timezone-aware objects to represent "
-        "datetimes in UTC: datetime.fromtimestamp(timestamp, datetime.UTC).", 1))
+        "datetimes in UTC: datetime.datetime.fromtimestamp(timestamp, datetime.UTC).", 1))
     {
         return NULL;
     }


### PR DESCRIPTION
I noticed this deprecation warning used `datetime` to refer to the *module* and the *class* on the same line (`UTC` is a module level constant while `fromtimestamp` is a class method).
