### PR TITLE
gh-107298: Fix references to deprecated and removed PyUnicode C API

### DIFF
--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -2591,22 +2591,22 @@ Pending Removal in Python 3.12
 The following C APIs have been deprecated in earlier Python releases,
 and will be removed in Python 3.12.
 
-* :c:func:`PyUnicode_AS_DATA`
-* :c:func:`PyUnicode_AS_UNICODE`
-* :c:func:`PyUnicode_AsUnicodeAndSize`
-* :c:func:`PyUnicode_AsUnicode`
-* :c:func:`PyUnicode_FromUnicode`
-* :c:func:`PyUnicode_GET_DATA_SIZE`
-* :c:func:`PyUnicode_GET_SIZE`
-* :c:func:`PyUnicode_GetSize`
+* :c:func:`!PyUnicode_AS_DATA`
+* :c:func:`!PyUnicode_AS_UNICODE`
+* :c:func:`!PyUnicode_AsUnicodeAndSize`
+* :c:func:`!PyUnicode_AsUnicode`
+* :c:func:`!PyUnicode_FromUnicode`
+* :c:func:`!PyUnicode_GET_DATA_SIZE`
+* :c:func:`!PyUnicode_GET_SIZE`
+* :c:func:`!PyUnicode_GetSize`
 * :c:func:`PyUnicode_IS_COMPACT`
 * :c:func:`PyUnicode_IS_READY`
 * :c:func:`PyUnicode_READY`
-* :c:func:`Py_UNICODE_WSTR_LENGTH`
-* :c:func:`_PyUnicode_AsUnicode`
-* :c:macro:`PyUnicode_WCHAR_KIND`
+* :c:func:`!PyUnicode_WSTR_LENGTH`
+* :c:func:`!_PyUnicode_AsUnicode`
+* :c:macro:`!PyUnicode_WCHAR_KIND`
 * :c:type:`PyUnicodeObject`
-* :c:func:`PyUnicode_InternImmortal()`
+* :c:func:`!PyUnicode_InternImmortal`
 
 
 .. _whatsnew311-c-api-removed:
@@ -2614,7 +2614,7 @@ and will be removed in Python 3.12.
 Removed
 -------
 
-* :c:func:`PyFrame_BlockSetup` and :c:func:`PyFrame_BlockPop` have been
+* :c:func:`!PyFrame_BlockSetup` and :c:func:`!PyFrame_BlockPop` have been
   removed.
   (Contributed by Mark Shannon in :issue:`40222`.)
 

--- a/Doc/whatsnew/3.3.rst
+++ b/Doc/whatsnew/3.3.rst
@@ -249,7 +249,7 @@ Changes introduced by :pep:`393` are the following:
     non-BMP code points.
 
 * The value of :data:`sys.maxunicode` is now always ``1114111`` (``0x10FFFF``
-  in hexadecimal).  The :c:func:`PyUnicode_GetMax` function still returns
+  in hexadecimal).  The :c:func:`!PyUnicode_GetMax` function still returns
   either ``0xFFFF`` or ``0x10FFFF`` for backward compatibility, and it should
   not be used with the new Unicode API (see :issue:`13054`).
 
@@ -2196,7 +2196,7 @@ Changes to Python's build process and to the C API include:
     * :c:macro:`PyUnicode_DATA`, :c:macro:`PyUnicode_1BYTE_DATA`,
       :c:macro:`PyUnicode_2BYTE_DATA`, :c:macro:`PyUnicode_4BYTE_DATA`
     * :c:macro:`PyUnicode_KIND` with :c:enum:`PyUnicode_Kind` enum:
-      :c:data:`PyUnicode_WCHAR_KIND`, :c:data:`PyUnicode_1BYTE_KIND`,
+      :c:data:`!PyUnicode_WCHAR_KIND`, :c:data:`PyUnicode_1BYTE_KIND`,
       :c:data:`PyUnicode_2BYTE_KIND`, :c:data:`PyUnicode_4BYTE_KIND`
     * :c:macro:`PyUnicode_READ`, :c:macro:`PyUnicode_READ_CHAR`, :c:macro:`PyUnicode_WRITE`
     * :c:macro:`PyUnicode_MAX_CHAR_VALUE`
@@ -2270,58 +2270,58 @@ removed in Python 4. All functions using this type are deprecated:
 Unicode functions and methods using :c:type:`Py_UNICODE` and
 :c:expr:`Py_UNICODE*` types:
 
-* :c:macro:`PyUnicode_FromUnicode`: use :c:func:`PyUnicode_FromWideChar` or
+* :c:macro:`!PyUnicode_FromUnicode`: use :c:func:`PyUnicode_FromWideChar` or
   :c:func:`PyUnicode_FromKindAndData`
-* :c:macro:`PyUnicode_AS_UNICODE`, :c:func:`PyUnicode_AsUnicode`,
-  :c:func:`PyUnicode_AsUnicodeAndSize`: use :c:func:`PyUnicode_AsWideCharString`
-* :c:macro:`PyUnicode_AS_DATA`: use :c:macro:`PyUnicode_DATA` with
+* :c:macro:`!PyUnicode_AS_UNICODE`, :c:func:`!PyUnicode_AsUnicode`,
+  :c:func:`!PyUnicode_AsUnicodeAndSize`: use :c:func:`PyUnicode_AsWideCharString`
+* :c:macro:`!PyUnicode_AS_DATA`: use :c:macro:`PyUnicode_DATA` with
   :c:macro:`PyUnicode_READ` and :c:macro:`PyUnicode_WRITE`
-* :c:macro:`PyUnicode_GET_SIZE`, :c:func:`PyUnicode_GetSize`: use
+* :c:macro:`!PyUnicode_GET_SIZE`, :c:func:`!PyUnicode_GetSize`: use
   :c:macro:`PyUnicode_GET_LENGTH` or :c:func:`PyUnicode_GetLength`
-* :c:macro:`PyUnicode_GET_DATA_SIZE`: use
+* :c:macro:`!PyUnicode_GET_DATA_SIZE`: use
   ``PyUnicode_GET_LENGTH(str) * PyUnicode_KIND(str)`` (only work on ready
   strings)
-* :c:func:`PyUnicode_AsUnicodeCopy`: use :c:func:`PyUnicode_AsUCS4Copy` or
+* :c:func:`!PyUnicode_AsUnicodeCopy`: use :c:func:`PyUnicode_AsUCS4Copy` or
   :c:func:`PyUnicode_AsWideCharString`
-* :c:func:`PyUnicode_GetMax`
+* :c:func:`!PyUnicode_GetMax`
 
 
 Functions and macros manipulating Py_UNICODE* strings:
 
-* :c:macro:`Py_UNICODE_strlen`: use :c:func:`PyUnicode_GetLength` or
+* :c:macro:`!Py_UNICODE_strlen()`: use :c:func:`PyUnicode_GetLength` or
   :c:macro:`PyUnicode_GET_LENGTH`
-* :c:macro:`Py_UNICODE_strcat`: use :c:func:`PyUnicode_CopyCharacters` or
+* :c:macro:`!Py_UNICODE_strcat()`: use :c:func:`PyUnicode_CopyCharacters` or
   :c:func:`PyUnicode_FromFormat`
-* :c:macro:`Py_UNICODE_strcpy`, :c:macro:`Py_UNICODE_strncpy`,
-  :c:macro:`Py_UNICODE_COPY`: use :c:func:`PyUnicode_CopyCharacters` or
+* :c:macro:`!Py_UNICODE_strcpy()`, :c:macro:`!Py_UNICODE_strncpy()`,
+  :c:macro:`!Py_UNICODE_COPY()`: use :c:func:`PyUnicode_CopyCharacters` or
   :c:func:`PyUnicode_Substring`
-* :c:macro:`Py_UNICODE_strcmp`: use :c:func:`PyUnicode_Compare`
-* :c:macro:`Py_UNICODE_strncmp`: use :c:func:`PyUnicode_Tailmatch`
-* :c:macro:`Py_UNICODE_strchr`, :c:macro:`Py_UNICODE_strrchr`: use
+* :c:macro:`!Py_UNICODE_strcmp()`: use :c:func:`PyUnicode_Compare`
+* :c:macro:`!Py_UNICODE_strncmp()`: use :c:func:`PyUnicode_Tailmatch`
+* :c:macro:`!Py_UNICODE_strchr()`, :c:macro:`!Py_UNICODE_strrchr()`: use
   :c:func:`PyUnicode_FindChar`
-* :c:macro:`Py_UNICODE_FILL`: use :c:func:`PyUnicode_Fill`
-* :c:macro:`Py_UNICODE_MATCH`
+* :c:macro:`!Py_UNICODE_FILL()`: use :c:func:`PyUnicode_Fill`
+* :c:macro:`!Py_UNICODE_MATCH`
 
 Encoders:
 
-* :c:func:`PyUnicode_Encode`: use :c:func:`PyUnicode_AsEncodedObject`
-* :c:func:`PyUnicode_EncodeUTF7`
-* :c:func:`PyUnicode_EncodeUTF8`: use :c:func:`PyUnicode_AsUTF8` or
+* :c:func:`!PyUnicode_Encode`: use :c:func:`PyUnicode_AsEncodedObject`
+* :c:func:`!PyUnicode_EncodeUTF7`
+* :c:func:`!PyUnicode_EncodeUTF8`: use :c:func:`PyUnicode_AsUTF8` or
   :c:func:`PyUnicode_AsUTF8String`
-* :c:func:`PyUnicode_EncodeUTF32`
-* :c:func:`PyUnicode_EncodeUTF16`
-* :c:func:`PyUnicode_EncodeUnicodeEscape` use
+* :c:func:`!PyUnicode_EncodeUTF32`
+* :c:func:`!PyUnicode_EncodeUTF16`
+* :c:func:`!PyUnicode_EncodeUnicodeEscape` use
   :c:func:`PyUnicode_AsUnicodeEscapeString`
-* :c:func:`PyUnicode_EncodeRawUnicodeEscape` use
+* :c:func:`!PyUnicode_EncodeRawUnicodeEscape` use
   :c:func:`PyUnicode_AsRawUnicodeEscapeString`
-* :c:func:`PyUnicode_EncodeLatin1`: use :c:func:`PyUnicode_AsLatin1String`
-* :c:func:`PyUnicode_EncodeASCII`: use :c:func:`PyUnicode_AsASCIIString`
-* :c:func:`PyUnicode_EncodeCharmap`
-* :c:func:`PyUnicode_TranslateCharmap`
-* :c:func:`PyUnicode_EncodeMBCS`: use :c:func:`PyUnicode_AsMBCSString` or
+* :c:func:`!PyUnicode_EncodeLatin1`: use :c:func:`PyUnicode_AsLatin1String`
+* :c:func:`!PyUnicode_EncodeASCII`: use :c:func:`PyUnicode_AsASCIIString`
+* :c:func:`!PyUnicode_EncodeCharmap`
+* :c:func:`!PyUnicode_TranslateCharmap`
+* :c:func:`!PyUnicode_EncodeMBCS`: use :c:func:`PyUnicode_AsMBCSString` or
   :c:func:`PyUnicode_EncodeCodePage` (with ``CP_ACP`` code_page)
-* :c:func:`PyUnicode_EncodeDecimal`,
-  :c:func:`PyUnicode_TransformDecimalToASCII`
+* :c:func:`!PyUnicode_EncodeDecimal`,
+  :c:func:`!PyUnicode_TransformDecimalToASCII`
 
 
 Deprecated features

--- a/Doc/whatsnew/3.6.rst
+++ b/Doc/whatsnew/3.6.rst
@@ -2066,9 +2066,9 @@ environment.  (Contributed by Brett Cannon in :issue:`25154`.)
 Deprecated functions and types of the C API
 -------------------------------------------
 
-Undocumented functions :c:func:`PyUnicode_AsEncodedObject`,
-:c:func:`PyUnicode_AsDecodedObject`, :c:func:`PyUnicode_AsEncodedUnicode`
-and :c:func:`PyUnicode_AsDecodedUnicode` are deprecated now.
+Undocumented functions :c:func:`!PyUnicode_AsEncodedObject`,
+:c:func:`!PyUnicode_AsDecodedObject`, :c:func:`!PyUnicode_AsEncodedUnicode`
+and :c:func:`!PyUnicode_AsDecodedUnicode` are deprecated now.
 Use the :ref:`generic codec based API <codec-registry>` instead.
 
 

--- a/Doc/whatsnew/3.9.rst
+++ b/Doc/whatsnew/3.9.rst
@@ -1370,8 +1370,8 @@ Porting to Python 3.9
   (Contributed by Victor Stinner in :issue:`40241`.)
 
 * The ``Py_UNICODE_COPY``, ``Py_UNICODE_FILL``, ``PyUnicode_WSTR_LENGTH``,
-  :c:func:`PyUnicode_FromUnicode`, :c:func:`PyUnicode_AsUnicode`,
-  ``_PyUnicode_AsUnicode``, and :c:func:`PyUnicode_AsUnicodeAndSize` are
+  :c:func:`!PyUnicode_FromUnicode`, :c:func:`!PyUnicode_AsUnicode`,
+  ``_PyUnicode_AsUnicode``, and :c:func:`!PyUnicode_AsUnicodeAndSize` are
   marked as deprecated in C.  They have been deprecated by :pep:`393` since
   Python 3.3.
   (Contributed by Inada Naoki in :issue:`36346`.)

--- a/Misc/NEWS.d/3.11.0b1.rst
+++ b/Misc/NEWS.d/3.11.0b1.rst
@@ -2068,9 +2068,9 @@ casts when the Python C API is used in C++. Patch by Victor Stinner.
 .. nonce: Cx-95G
 .. section: C API
 
-Mark functions as deprecated by :pep:`623`: :c:func:`PyUnicode_AS_DATA`,
-:c:func:`PyUnicode_AS_UNICODE`, :c:func:`PyUnicode_GET_DATA_SIZE`,
-:c:func:`PyUnicode_GET_SIZE`. Patch by Victor Stinner.
+Mark functions as deprecated by :pep:`623`: :c:func:`!PyUnicode_AS_DATA`,
+:c:func:`!PyUnicode_AS_UNICODE`, :c:func:`!PyUnicode_GET_DATA_SIZE`,
+:c:func:`!PyUnicode_GET_SIZE`. Patch by Victor Stinner.
 
 ..
 


### PR DESCRIPTION


<!-- gh-issue-number: gh-107298 -->
* Issue: gh-107298
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--108077.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->