### PR TITLE
gh-104683: Argument Clinic: Remove unreachable code from _module_and_class()

### DIFF
--- a/Tools/clinic/clinic.py
+++ b/Tools/clinic/clinic.py
@@ -2427,8 +2427,6 @@ impl_definition block
                 if child:
                     parent = module = child
                     continue
-            if not hasattr(parent, 'classes'):
-                return module, cls
             child = parent.classes.get(field)
             if not child:
                 fullname = ".".join(so_far)


### PR DESCRIPTION
'not hasattr(parent, "classes")' is always false, since 'parent' is an
instance of either the Module, Class, or Clinic classes, and all of
them has a "classes" attribute.


<!-- gh-issue-number: gh-104683 -->
* Issue: gh-104683
<!-- /gh-issue-number -->
