### PR TITLE
gh-105736: Sync pure python version of OrderedDict with the C version

### DIFF
--- a/Lib/collections/__init__.py
+++ b/Lib/collections/__init__.py
@@ -46,6 +46,11 @@ else:
     _collections_abc.MutableSequence.register(deque)
 
 try:
+    from _collections import _deque_iterator
+except ImportError:
+    pass
+
+try:
     from _collections import defaultdict
 except ImportError:
     pass

--- a/Lib/collections/__init__.py
+++ b/Lib/collections/__init__.py
@@ -95,10 +95,9 @@ class OrderedDict(dict):
     # Individual links are kept alive by the hard reference in self.__map.
     # Those hard references disappear when a key is deleted from an OrderedDict.
 
-    def __init__(self, other=(), /, **kwds):
-        '''Initialize an ordered dictionary.  The signature is the same as
-        regular dictionaries.  Keyword argument order is preserved.
-        '''
+    def __new__(cls, /, *args, **kwds):
+        "Create the ordered dict object and set up the underlying structures."
+        self = dict.__new__(cls)
         try:
             self.__root
         except AttributeError:
@@ -106,6 +105,12 @@ class OrderedDict(dict):
             self.__root = root = _proxy(self.__hardroot)
             root.prev = root.next = root
             self.__map = {}
+        return self
+
+    def __init__(self, other=(), /, **kwds):
+        '''Initialize an ordered dictionary.  The signature is the same as
+        regular dictionaries.  Keyword argument order is preserved.
+        '''
         self.__update(other, **kwds)
 
     def __setitem__(self, key, value,

--- a/Lib/collections/__init__.py
+++ b/Lib/collections/__init__.py
@@ -98,13 +98,10 @@ class OrderedDict(dict):
     def __new__(cls, /, *args, **kwds):
         "Create the ordered dict object and set up the underlying structures."
         self = dict.__new__(cls)
-        try:
-            self.__root
-        except AttributeError:
-            self.__hardroot = _Link()
-            self.__root = root = _proxy(self.__hardroot)
-            root.prev = root.next = root
-            self.__map = {}
+        self.__hardroot = _Link()
+        self.__root = root = _proxy(self.__hardroot)
+        root.prev = root.next = root
+        self.__map = {}
         return self
 
     def __init__(self, other=(), /, **kwds):

--- a/Lib/collections/__init__.py
+++ b/Lib/collections/__init__.py
@@ -46,11 +46,6 @@ else:
     _collections_abc.MutableSequence.register(deque)
 
 try:
-    from _collections import _deque_iterator
-except ImportError:
-    pass
-
-try:
     from _collections import defaultdict
 except ImportError:
     pass

--- a/Lib/test/test_ordered_dict.py
+++ b/Lib/test/test_ordered_dict.py
@@ -122,6 +122,16 @@ class OrderedDictTests:
         self.OrderedDict(Spam())
         self.assertEqual(calls, ['keys'])
 
+    def test_overridden_init(self):
+        # Sync-up pure Python OD class with C class where
+        # a consistent internal state is created in __new__
+        # rather than __init__.
+        class ODNI:
+            def __init__(*args, **kwargs):
+                pass
+        od = ODNI()
+        od['a'] = 1  # This used to fail because __init__ was bypassed
+
     def test_fromkeys(self):
         OrderedDict = self.OrderedDict
         od = OrderedDict.fromkeys('abc')

--- a/Lib/test/test_ordered_dict.py
+++ b/Lib/test/test_ordered_dict.py
@@ -126,7 +126,8 @@ class OrderedDictTests:
         # Sync-up pure Python OD class with C class where
         # a consistent internal state is created in __new__
         # rather than __init__.
-        class ODNI:
+        OrderedDict = self.OrderedDict
+        class ODNI(OrderedDict):
             def __init__(*args, **kwargs):
                 pass
         od = ODNI()

--- a/Misc/NEWS.d/next/Library/2023-08-17-14-45-25.gh-issue-105736.NJsH7r.rst
+++ b/Misc/NEWS.d/next/Library/2023-08-17-14-45-25.gh-issue-105736.NJsH7r.rst
@@ -1,0 +1,3 @@
+Harmonized the pure Python version of OrderedDict with the C version. Now,
+both versions set up their internal state in `__new__`.  Formerly, the pure
+Python version did the set up in `__init__`.


### PR DESCRIPTION
This solves a problem noticed in the referenced issue.  When `__init__` is overridden, the C version is still usable but the pure Python version fails.   The solution is to have the internal invariants sets up in `__new__` rather than `__init__`.

The original copy/pickle issue still remains.

<!-- gh-issue-number: gh-105736 -->
* Issue: gh-105736
<!-- /gh-issue-number -->
