### PR TITLE
[3.12] gh-107801: Improve the docs of the SEEK_* constants (#108099)

### DIFF
--- a/Doc/library/os.rst
+++ b/Doc/library/os.rst
@@ -1180,16 +1180,26 @@ as internal buffering of data.
           SEEK_CUR
           SEEK_END
 
-   Parameters to the :func:`lseek` function. Their values are 0, 1, and 2,
-   respectively.
+   Parameters to the :func:`lseek` function and the :meth:`~io.IOBase.seek`
+   method on :term:`file-like objects <file object>`,
+   for whence to adjust the file position indicator.
+
+   :const:`SEEK_SET`
+      Adjust the file position relative to the beginning of the file.
+   :const:`SEEK_CUR`
+      Adjust the file position relative to the current file position.
+   :const:`SEEK_END`
+      Adjust the file position relative to the end of the file.
+
+   Their values are 0, 1, and 2, respectively.
 
 
 .. data:: SEEK_HOLE
           SEEK_DATA
 
    Parameters to the :func:`lseek` function and the :meth:`~io.IOBase.seek`
-   method on file objects, for seeking file data and holes on sparsely
-   allocated files.
+   method on :term:`file-like objects <file object>`,
+   for seeking file data and holes on sparsely allocated files.
 
    :data:`!SEEK_DATA`
       Adjust the file offset to the next location containing data,


### PR DESCRIPTION
(cherry picked from commit 02079b010c39a89b284e8f0bb6d5f378e554260e)


<!-- gh-issue-number: gh-107801 -->
* Issue: gh-107801
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--108108.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->