### PR TITLE
[3.9] gh-107565: Update multissltests and GitHub CI workflows to use OpenSSL 1.1.1v, 3.0.10, and 3.1.2.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -178,7 +178,7 @@ jobs:
     needs: check_source
     if: needs.check_source.outputs.run_tests == 'true'
     env:
-      OPENSSL_VER: 1.1.1u
+      OPENSSL_VER: 1.1.1v
       PYTHONSTRICTEXTENSIONBUILD: 1
     steps:
     - uses: actions/checkout@v3
@@ -220,7 +220,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        openssl_ver: [1.0.2u, 1.1.0l, 1.1.1u, 3.0.9, 3.1.1]
+        openssl_ver: [1.0.2u, 1.1.0l, 1.1.1v, 3.0.10, 3.1.2]
     env:
       OPENSSL_VER: ${{ matrix.openssl_ver }}
       MULTISSL_DIR: ${{ github.workspace }}/multissl

--- a/Misc/NEWS.d/next/Tools-Demos/2023-08-12-13-18-15.gh-issue-107565.Tv22Ne.rst
+++ b/Misc/NEWS.d/next/Tools-Demos/2023-08-12-13-18-15.gh-issue-107565.Tv22Ne.rst
@@ -1,0 +1,2 @@
+Update multissltests and GitHub CI workflows to use OpenSSL 1.1.1v, 3.0.10,
+and 3.1.2.

--- a/Tools/ssl/multissltests.py
+++ b/Tools/ssl/multissltests.py
@@ -49,8 +49,8 @@ OPENSSL_OLD_VERSIONS = [
 ]
 
 OPENSSL_RECENT_VERSIONS = [
-    "1.1.1u",
-    "3.0.9",
+    "1.1.1v",
+    "3.0.10",
 ]
 
 LIBRESSL_OLD_VERSIONS = [


### PR DESCRIPTION
(cherry picked from commit 441797d4ffb12acda257370b9e5e19ed8d6e8a71)

<!-- gh-issue-number: gh-107565 -->
* Issue: gh-107565
<!-- /gh-issue-number -->
