### PR TITLE
gh-107980: fix doc role for asyncio.timeouts

### DIFF
--- a/Doc/library/asyncio-task.rst
+++ b/Doc/library/asyncio-task.rst
@@ -631,7 +631,7 @@ Shielding From Cancellation
 Timeouts
 ========
 
-.. coroutinefunction:: timeout(delay)
+.. function:: timeout(delay)
 
     An :ref:`asynchronous context manager <async-context-managers>`
     that can be used to limit the amount of time spent waiting on
@@ -724,7 +724,7 @@ Timeouts
 
     .. versionadded:: 3.11
 
-.. coroutinefunction:: timeout_at(when)
+.. function:: timeout_at(when)
 
    Similar to :func:`asyncio.timeout`, except *when* is the absolute time
    to stop waiting, or ``None``.

--- a/Doc/library/asyncio-task.rst
+++ b/Doc/library/asyncio-task.rst
@@ -633,7 +633,7 @@ Timeouts
 
 .. function:: timeout(delay)
 
-    An :ref:`asynchronous context manager <async-context-managers>`
+    Return an :ref:`asynchronous context manager <async-context-managers>`
     that can be used to limit the amount of time spent waiting on
     something.
 


### PR DESCRIPTION
A quick documentation fix: the functions being fixed aren't coroutine functions.

<!-- gh-issue-number: gh-107980 -->
* Issue: gh-107980
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--108126.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->