### PR TITLE
Docs: Fix Sphinx warnings in logging.rst

### DIFF
--- a/Doc/library/logging.rst
+++ b/Doc/library/logging.rst
@@ -1019,14 +1019,14 @@ information into logging calls. For a usage example, see the section on
       'extra'. The return value is a (*msg*, *kwargs*) tuple which has the
       (possibly modified) versions of the arguments passed in.
 
-In addition to the above, :class:`LoggerAdapter` supports the following
-methods of :class:`Logger`: :meth:`~Logger.debug`, :meth:`~Logger.info`,
-:meth:`~Logger.warning`, :meth:`~Logger.error`, :meth:`~Logger.exception`,
-:meth:`~Logger.critical`, :meth:`~Logger.log`, :meth:`~Logger.isEnabledFor`,
-:meth:`~Logger.getEffectiveLevel`, :meth:`~Logger.setLevel` and
-:meth:`~Logger.hasHandlers`. These methods have the same signatures as their
-counterparts in :class:`Logger`, so you can use the two types of instances
-interchangeably.
+   In addition to the above, :class:`LoggerAdapter` supports the following
+   methods of :class:`Logger`: :meth:`~Logger.debug`, :meth:`~Logger.info`,
+   :meth:`~Logger.warning`, :meth:`~Logger.error`, :meth:`~Logger.exception`,
+   :meth:`~Logger.critical`, :meth:`~Logger.log`, :meth:`~Logger.isEnabledFor`,
+   :meth:`~Logger.getEffectiveLevel`, :meth:`~Logger.setLevel` and
+   :meth:`~Logger.hasHandlers`. These methods have the same signatures as their
+   counterparts in :class:`Logger`, so you can use the two types of instances
+   interchangeably.
 
    .. versionchanged:: 3.2
 

--- a/Doc/library/logging.rst
+++ b/Doc/library/logging.rst
@@ -439,7 +439,7 @@ Handler Objects
 
 Handlers have the following attributes and methods. Note that :class:`Handler`
 is never instantiated directly; this class acts as a base for more useful
-subclasses. However, the :meth:`__init__` method in subclasses needs to call
+subclasses. However, the :meth:`!__init__` method in subclasses needs to call
 :meth:`Handler.__init__`.
 
 .. class:: Handler
@@ -1034,12 +1034,12 @@ interchangeably.
    to :class:`LoggerAdapter`.  These methods delegate to the underlying logger.
 
 .. versionchanged:: 3.6
-   Attribute :attr:`manager` and method :meth:`_log` were added, which
+   Attribute :attr:`!manager` and method :meth:`!_log` were added, which
    delegate to the underlying logger and allow adapters to be nested.
 
 .. versionchanged:: 3.13
-   Remove the undocumented ``warn()`` method which was an alias to the
-   ``warning()`` method.
+   Remove the undocumented :meth:`!warn`` method which was an alias to the
+   :meth:`!warning` method.
 
 .. versionchanged:: 3.13
    The *merge_extra* argument was added.
@@ -1430,8 +1430,8 @@ functions.
 .. function:: setLoggerClass(klass)
 
    Tells the logging system to use the class *klass* when instantiating a logger.
-   The class should define :meth:`__init__` such that only a name argument is
-   required, and the :meth:`__init__` should call :meth:`Logger.__init__`. This
+   The class should define :meth:`!__init__` such that only a name argument is
+   required, and the :meth:`!__init__` should call :meth:`!Logger.__init__`. This
    function is typically called before any loggers are instantiated by applications
    which need to use custom logger behavior. After this call, as at any other
    time, do not instantiate loggers directly using the subclass: continue to use

--- a/Doc/library/logging.rst
+++ b/Doc/library/logging.rst
@@ -1028,21 +1028,25 @@ methods of :class:`Logger`: :meth:`~Logger.debug`, :meth:`~Logger.info`,
 counterparts in :class:`Logger`, so you can use the two types of instances
 interchangeably.
 
-.. versionchanged:: 3.2
-   The :meth:`~Logger.isEnabledFor`, :meth:`~Logger.getEffectiveLevel`,
-   :meth:`~Logger.setLevel` and :meth:`~Logger.hasHandlers` methods were added
-   to :class:`LoggerAdapter`.  These methods delegate to the underlying logger.
+   .. versionchanged:: 3.2
 
-.. versionchanged:: 3.6
-   Attribute :attr:`!manager` and method :meth:`!_log` were added, which
-   delegate to the underlying logger and allow adapters to be nested.
+      The :meth:`~Logger.isEnabledFor`, :meth:`~Logger.getEffectiveLevel`,
+      :meth:`~Logger.setLevel` and :meth:`~Logger.hasHandlers` methods were added
+      to :class:`LoggerAdapter`.  These methods delegate to the underlying logger.
 
-.. versionchanged:: 3.13
-   Remove the undocumented :meth:`!warn`` method which was an alias to the
-   :meth:`!warning` method.
+   .. versionchanged:: 3.6
 
-.. versionchanged:: 3.13
-   The *merge_extra* argument was added.
+      Attribute :attr:`!manager` and method :meth:`!_log` were added, which
+      delegate to the underlying logger and allow adapters to be nested.
+
+   .. versionchanged:: 3.13
+
+      Remove the undocumented :meth:`!warn`` method which was an alias to the
+      :meth:`!warning` method.
+
+   .. versionchanged:: 3.13
+
+      The *merge_extra* argument was added.
 
 
 Thread Safety

--- a/Doc/tools/.nitignore
+++ b/Doc/tools/.nitignore
@@ -92,7 +92,6 @@ Doc/library/inspect.rst
 Doc/library/locale.rst
 Doc/library/logging.config.rst
 Doc/library/logging.handlers.rst
-Doc/library/logging.rst
 Doc/library/lzma.rst
 Doc/library/mailbox.rst
 Doc/library/mmap.rst


### PR DESCRIPTION
- Add missing markup to some methods
- Silence links to ``__init__`` methods


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--108139.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->