### PR TITLE
fix:  IFPkgFlag typo

### DIFF
--- a/Mac/BuildScript/build-installer.py
+++ b/Mac/BuildScript/build-installer.py
@@ -1490,7 +1490,7 @@ def packageFromRecipe(targetDir, recipe):
                 IFPkgFlagRelocatable=False,
                 IFPkgFlagRestartAction="NoRestart",
                 IFPkgFlagRootVolumeOnly=True,
-                IFPkgFlagUpdateInstalledLangauges=False,
+                IFPkgFlagUpdateInstalledLanguages=False,
             )
         writePlist(pl, os.path.join(packageContents, 'Info.plist'))
 

--- a/Misc/NEWS.d/next/macOS/2023-08-19-14-09-37.gh-issue-0.rMvnQ4.rst
+++ b/Misc/NEWS.d/next/macOS/2023-08-19-14-09-37.gh-issue-0.rMvnQ4.rst
@@ -1,0 +1,4 @@
+Correct usage should be "IFPkgFlagUpdateInstalledLanguages"
+
+Example
+https://opensource.apple.com/source/Heimdal/Heimdal-172.27/packages/mac/Info.plist.auto.html


### PR DESCRIPTION
Correct usage should be "IFPkgFlagUpdateInstalledLanguages"

Example
https://opensource.apple.com/source/Heimdal/Heimdal-172.27/packages/mac/Info.plist.auto.html


<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
