### PR TITLE
Docs: document 'manager' and '_log' attrs of logging.Logging

### DIFF
--- a/Doc/library/logging.rst
+++ b/Doc/library/logging.rst
@@ -1019,6 +1019,14 @@ information into logging calls. For a usage example, see the section on
       'extra'. The return value is a (*msg*, *kwargs*) tuple which has the
       (possibly modified) versions of the arguments passed in.
 
+   .. attribute:: manager
+
+      Delegates to the underlying :attr:`!manager`` on *logger*.
+
+   .. attribute:: _log
+
+      Delegates to the underlying :meth:`!_log`` method on *logger*.
+
 In addition to the above, :class:`LoggerAdapter` supports the following
 methods of :class:`Logger`: :meth:`~Logger.debug`, :meth:`~Logger.info`,
 :meth:`~Logger.warning`, :meth:`~Logger.error`, :meth:`~Logger.exception`,


### PR DESCRIPTION
Authored by @AA-Turner 
<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--108145.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->