### PR TITLE
[doc] Fix misspellings in sysconfig doc

### DIFF
--- a/Doc/library/sysconfig.rst
+++ b/Doc/library/sysconfig.rst
@@ -84,13 +84,13 @@ Python currently supports nine schemes:
   through Distutils and the *user* option is used.  This scheme defines paths
   located under the user home directory.
 - *posix_venv*: scheme for :mod:`Python virtual environments <venv>` on POSIX
-  platforms; by default it is the same as *posix_prefix* .
+  platforms; by default it is the same as *posix_prefix*.
 - *nt*: scheme for NT platforms like Windows.
 - *nt_user*: scheme for NT platforms, when the *user* option is used.
 - *nt_venv*: scheme for :mod:`Python virtual environments <venv>` on NT
-  platforms; by default it is the same as *nt* .
-- *venv*: a scheme with values from ether *posix_venv* or *nt_venv* depending
-  on the platform Python runs on
+  platforms; by default it is the same as *nt*.
+- *venv*: a scheme with values from either *posix_venv* or *nt_venv* depending
+  on the platform Python runs on.
 - *osx_framework_user*: scheme for macOS, when the *user* option is used.
 
 Each scheme is itself composed of a series of paths and each path has a unique
@@ -187,7 +187,7 @@ identifier.  Python currently uses eight paths:
    platform is used.
 
    If *vars* is provided, it must be a dictionary of variables that will update
-   the dictionary return by :func:`get_config_vars`.
+   the dictionary returned by :func:`get_config_vars`.
 
    If *expand* is set to ``False``, the path will not be expanded using the
    variables.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

This should be backported to 3.12 and 3.11 as well.

<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--108156.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->