### PR TITLE
gh-108185: Add function to convert file mode string to binary file mode

### DIFF
--- a/Lib/stat.py
+++ b/Lib/stat.py
@@ -165,6 +165,32 @@ def filemode(mode):
             perm.append("-")
     return "".join(perm)
 
+def file_mode_string_to_file_mode(string):
+    """Convert a file mode sting in octal or symbolic notation to its binary
+    representation.
+    """
+    mode = 0
+    if len(string) >= 3 and (not string.rstrip("01234567")):
+        #octal notation:
+        return int(string, 8)
+    elif len(string) in (9, 10):
+        #symbolic notation:
+        if len(string) == 9:
+            start_position = 1
+        else:
+            start_position = 0
+        for (position, (symbol_at_position, filemode_table_for_position)) in enumerate(zip(string, _filemode_table[start_position:], strict=True)):
+            for (mode_bits, symbol) in filemode_table_for_position:
+                if symbol_at_position == symbol:
+                    mode |= mode_bits
+                    break
+            else:
+                if symbol_at_position != "-":
+                    raise ValueError(f"Invalid symbol `{symbol_at_position}` at position {position} of the file mode string `{string}`.")
+    else:
+        raise ValueError(f"Invalid notation of the file mode string `{string}`.")
+    return mode
+
 
 # Windows FILE_ATTRIBUTE constants for interpreting os.stat()'s
 # "st_file_attributes" member


### PR DESCRIPTION
This adds a convenience function that serves as the counterpart to `stat.filemode()` and converts a file mode string to its binary representation.

As of now, it supports two widely used notations:
1) Octal Notation:
   Examples:
   • file mode bits only:
     `644`, `0644`, `000644`, `0o644`, `0O644`
   • file mode bits and (implementation-specific) file type:
     `100644`, `0o100644`, `0O100644`, `40755`

   POSIX specifies concrete values only for the file mode bits but not for the
   file type as part of the file mode.
   Therefore, all but the 4 least significant digits are implementation-
   specific.

2) Symbolic Notation:
   This is the notation that POSIX specifies for the `ls`-utility when invoked
   with the `-l`-option (and/or some others that imply it) with the file type
   being optional and with the “optional alternate access method flag” being not
   supported by this function.
   This is not the “symbolic mode form” that POSIX specifies for the `chmod`-
   utility.

   Examples:
   • file mode bits only:
     `rw-r--r--`
   • file mode bits and file type:
     `-rw-r--r--`, `drwxr-xr-x`

<!-- gh-issue-number: gh-108185 -->
* Issue: gh-108185
<!-- /gh-issue-number -->
