### PR TITLE
gh-108223: Add --disable-gil to configure

### DIFF
--- a/configure
+++ b/configure
@@ -1103,6 +1103,7 @@ with_openssl_rpath
 with_ssl_default_suites
 with_builtin_hashlib_hashes
 enable_test_modules
+enable_gil
 '
       ac_precious_vars='build_alias
 host_alias
@@ -1803,6 +1804,8 @@ Optional Features:
                           use big digits (30 or 15 bits) for Python longs
                           (default is 30)]
   --disable-test-modules  don't build nor install test modules
+  --disable-gil           enable experimental support for running without the
+                          GIL (default is no)
 
 Optional Packages:
   --with-PACKAGE[=ARG]    use PACKAGE [ARG=yes]
@@ -27903,6 +27906,34 @@ fi
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $TEST_MODULES" >&5
 printf "%s\n" "$TEST_MODULES" >&6; }
 
+
+# Check for --disable-gil
+# --disable-gil
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for --disable-gil" >&5
+printf %s "checking for --disable-gil... " >&6; }
+# Check whether --enable-gil was given.
+if test ${enable_gil+y}
+then :
+  enableval=$enable_gil; if test "x$enable_gil" = xyes
+then :
+  disable_gil=no
+else $as_nop
+  disable_gil=yes
+fi
+else $as_nop
+  disable_gil=no
+
+fi
+
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $disable_gil" >&5
+printf "%s\n" "$disable_gil" >&6; }
+
+if test "$disable_gil" = "yes"
+then
+
+printf "%s\n" "#define Py_NOGIL 1" >>confdefs.h
+
+fi
 
 
 

--- a/configure.ac
+++ b/configure.ac
@@ -7126,6 +7126,21 @@ AC_ARG_ENABLE([test-modules],
 AC_MSG_RESULT([$TEST_MODULES])
 AC_SUBST([TEST_MODULES])
 
+# Check for --disable-gil
+# --disable-gil
+AC_MSG_CHECKING([for --disable-gil])
+AC_ARG_ENABLE([gil],
+  [AS_HELP_STRING([--disable-gil], [enable experimental support for running without the GIL (default is no)])],
+  [AS_VAR_IF([enable_gil], [yes], [disable_gil=no], [disable_gil=yes])], [disable_gil=no]
+)
+AC_MSG_RESULT([$disable_gil])
+
+if test "$disable_gil" = "yes"
+then
+  AC_DEFINE([Py_NOGIL], [1],
+            [Define if you want to disable the GIL])
+fi
+
 AC_DEFUN([PY_STDLIB_MOD_SET_NA], [
   m4_foreach([mod], [$@], [
     AS_VAR_SET([py_cv_module_]mod, [n/a])])

--- a/pyconfig.h.in
+++ b/pyconfig.h.in
@@ -1609,6 +1609,9 @@
    SipHash13: 3, externally defined: 0 */
 #undef Py_HASH_ALGORITHM
 
+/* Define if you want to disable the GIL */
+#undef Py_NOGIL
+
 /* Define if you want to enable internal statistics gathering. */
 #undef Py_STATS
 


### PR DESCRIPTION
The `--disable-gil` flags does not do anything yet other than define the Py_NOGIL macro. This is intended to support setting up additional buildbots by @itamaro.


<!-- gh-issue-number: gh-108223 -->
* Issue: gh-108223
<!-- /gh-issue-number -->
