### PR TITLE
gh-107211: No longer export pycore_strhex.h functions

### DIFF
--- a/Include/internal/pycore_strhex.h
+++ b/Include/internal/pycore_strhex.h
@@ -9,21 +9,24 @@ extern "C" {
 #endif
 
 // Returns a str() containing the hex representation of argbuf.
+// Export for '_hashlib' shared extension.
 PyAPI_FUNC(PyObject*) _Py_strhex(const
     char* argbuf,
     const Py_ssize_t arglen);
 
 // Returns a bytes() containing the ASCII hex representation of argbuf.
-PyAPI_FUNC(PyObject*) _Py_strhex_bytes(
+extern PyObject* _Py_strhex_bytes(
     const char* argbuf,
     const Py_ssize_t arglen);
 
 // These variants include support for a separator between every N bytes:
-PyAPI_FUNC(PyObject*) _Py_strhex_with_sep(
+extern PyObject* _Py_strhex_with_sep(
     const char* argbuf,
     const Py_ssize_t arglen,
     PyObject* sep,
     const int bytes_per_group);
+
+// Export for 'binascii' shared extension
 PyAPI_FUNC(PyObject*) _Py_strhex_bytes_with_sep(
     const char* argbuf,
     const Py_ssize_t arglen,


### PR DESCRIPTION
No longer export functions:

* _Py_strhex_bytes()
* _Py_strhex_with_sep()

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-107211 -->
* Issue: gh-107211
<!-- /gh-issue-number -->
