### PR TITLE
gh-108223: Document --disable-gil flag in configure

### DIFF
--- a/Doc/using/configure.rst
+++ b/Doc/using/configure.rst
@@ -185,6 +185,13 @@ General Options
 
    .. versionadded:: 3.11
 
+.. cmdoption:: --disable-gil
+
+   Enables experimental support for running Python without the global
+   interpreter lock (GIL).
+
+   .. versionadded:: 3.13
+
 WebAssembly Options
 -------------------
 

--- a/Doc/using/configure.rst
+++ b/Doc/using/configure.rst
@@ -187,8 +187,8 @@ General Options
 
 .. cmdoption:: --disable-gil
 
-   Enables experimental support for running Python without the global
-   interpreter lock (GIL).
+   Enables experimental support for running Python without the
+   :term:`global interpreter lock` (GIL).
 
    .. versionadded:: 3.13
 

--- a/Doc/using/configure.rst
+++ b/Doc/using/configure.rst
@@ -187,7 +187,7 @@ General Options
 
 .. cmdoption:: --disable-gil
 
-   Enables experimental support for running Python without the
+   Enables **experimental** support for running Python without the
    :term:`global interpreter lock` (GIL).
 
    See :pep:`703` "Making the Global Interpreter Lock Optional in CPython".

--- a/Doc/using/configure.rst
+++ b/Doc/using/configure.rst
@@ -190,6 +190,8 @@ General Options
    Enables experimental support for running Python without the
    :term:`global interpreter lock` (GIL).
 
+   See :pep:`703` "Making the Global Interpreter Lock Optional in CPython".
+
    .. versionadded:: 3.13
 
 WebAssembly Options


### PR DESCRIPTION
Adds an entry in the configure documentation for the `--disable-gil` flag.

<!-- gh-issue-number: gh-108223 -->
* Issue: gh-108223
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--108236.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->