### PR TITLE
[3.12] Fix sphinx-lint issue now that lint runs on Misc/NEWS.d

### DIFF
--- a/Misc/NEWS.d/next/Library/2023-08-17-14-45-25.gh-issue-105736.NJsH7r.rst
+++ b/Misc/NEWS.d/next/Library/2023-08-17-14-45-25.gh-issue-105736.NJsH7r.rst
@@ -1,3 +1,3 @@
-Harmonized the pure Python version of OrderedDict with the C version. Now,
-both versions set up their internal state in `__new__`.  Formerly, the pure
-Python version did the set up in `__init__`.
+Harmonized the pure Python version of :class:`~collections.OrderedDict` with the C version. Now,
+both versions set up their internal state in ``__new__``.  Formerly, the pure
+Python version did the set up in ``__init__``.


### PR DESCRIPTION
Fix lint warnings in Misc/NEWS.d/next/Library/2023-08-17-14-45-25.gh-issue-105736.NJsH7r.rst now that sphinx-lint is run on Misc/NEWS.d/next. (effectively a backport of GH-108212).
