### PR TITLE
gh-108223: Add [NOGIL] marker to sys.version

### DIFF
--- a/Python/getversion.c
+++ b/Python/getversion.c
@@ -6,7 +6,7 @@
 #include "patchlevel.h"
 
 static int initialized = 0;
-static char version[250];
+static char version[258];
 
 void _Py_InitVersion(void)
 {
@@ -14,8 +14,13 @@ void _Py_InitVersion(void)
         return;
     }
     initialized = 1;
-    PyOS_snprintf(version, sizeof(version), "%.80s (%.80s) %.80s",
-                  PY_VERSION, Py_GetBuildInfo(), Py_GetCompiler());
+#ifdef Py_NOGIL
+    const char *gil = " [NOGIL]";  // 8 characters
+#else
+    const char *gil = "";
+#endif
+    PyOS_snprintf(version, sizeof(version), "%.80s (%.80s) %.80s%s",
+                  PY_VERSION, Py_GetBuildInfo(), Py_GetCompiler(), gil);
 }
 
 const char *


### PR DESCRIPTION
If Python is configured with --disable-gil, add " [NOGIL]" suffix to sys.version. It should help users to check if they are running a regular Python build with a GIL, or a custom Python build with the new experimental no GIL.

sys.version is commonly requested in bug reports: knowing if Python was configured with --disable-gil should ease debug.

Example on Linux with --disable-gil:

    $ ./python -VV
    Python 3.13.0a0 (heads/main-dirty:d63972e289, Aug 21 2023,
    21:43:45) [GCC 13.2.1 20230728 (Red Hat 13.2.1-1)] [NOGIL]

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-108223 -->
* Issue: gh-108223
<!-- /gh-issue-number -->
