### PR TITLE
gh-108240: Fix a reference cycle in _socket.CAPI capsule

### DIFF
--- a/Modules/socketmodule.c
+++ b/Modules/socketmodule.c
@@ -7317,7 +7317,6 @@ os_init(void)
 static void
 sock_free_api(PySocketModule_APIObject *capi)
 {
-    Py_DECREF(capi->Sock_Type);
     Py_DECREF(capi->error);
     Py_DECREF(capi->timeout_error);
     PyMem_Free(capi);
@@ -7339,7 +7338,7 @@ sock_get_api(socket_state *state)
         return NULL;
     }
 
-    capi->Sock_Type = (PyTypeObject *)Py_NewRef(state->sock_type);
+    capi->Sock_Type = state->sock_type;
     capi->error = Py_NewRef(PyExc_OSError);
     capi->timeout_error = Py_NewRef(PyExc_TimeoutError);
     return capi;

--- a/Modules/socketmodule.h
+++ b/Modules/socketmodule.h
@@ -382,7 +382,7 @@ typedef struct {
 /* C API for usage by other Python modules.
  * Always add new things to the end for binary compatibility. */
 typedef struct {
-    PyTypeObject *Sock_Type;
+    PyTypeObject *Sock_Type;  // borrowed reference (gh-108240)
     PyObject *error;
     PyObject *timeout_error;
 } PySocketModule_APIObject;


### PR DESCRIPTION
_socket.CAPI capsule contains a strong reference to _socket.socket type. The garbage collector cannot visit this reference and so cannot create the reference cycle involving _socket.socket (a heap type creates a reference cycle to inside, via MRO and methods). At Python, _PyImport_ClearModules() sets _socket attributes to None which works around the issue.

If the module is cleared from sys.modules manually, _PyImport_ClearModules() cannot set _socket.CAPI to None and so the issue cannot be worked around.

Change _socket.CAPI to use a borrowed reference instead of a strong reference to allow clearing _socket.socket in this case.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-108240 -->
* Issue: gh-108240
<!-- /gh-issue-number -->
