### PR TITLE
Fix test_faulthandler for sanitizers

### DIFF
--- a/Lib/test/test_faulthandler.py
+++ b/Lib/test/test_faulthandler.py
@@ -9,7 +9,6 @@ import sys
 from test import support
 from test.support import os_helper
 from test.support import script_helper, is_android
-from test.support import skip_if_sanitizer
 import tempfile
 import unittest
 from textwrap import dedent
@@ -64,8 +63,13 @@ class FaultHandlerTests(unittest.TestCase):
         pass_fds = []
         if fd is not None:
             pass_fds.append(fd)
+        env = dict(os.environ)
+        for name in ('ASAN_OPTIONS', 'MSAN_OPTIONS', 'UBSAN_OPTIONS'):
+            env[name] = 'handle_segv=0'
         with support.SuppressCrashReport():
-            process = script_helper.spawn_python('-c', code, pass_fds=pass_fds)
+            process = script_helper.spawn_python('-c', code,
+                                                 pass_fds=pass_fds,
+                                                 env=env)
             with process:
                 output, stderr = process.communicate()
                 exitcode = process.wait()
@@ -304,8 +308,6 @@ class FaultHandlerTests(unittest.TestCase):
             3,
             'Segmentation fault')
 
-    @skip_if_sanitizer(memory=True, ub=True, reason="sanitizer "
-                       "builds change crashing process output.")
     @skip_segfault_on_android
     def test_enable_file(self):
         with temporary_filename() as filename:
@@ -321,8 +323,6 @@ class FaultHandlerTests(unittest.TestCase):
 
     @unittest.skipIf(sys.platform == "win32",
                      "subprocess doesn't support pass_fds on Windows")
-    @skip_if_sanitizer(memory=True, ub=True, reason="sanitizer "
-                       "builds change crashing process output.")
     @skip_segfault_on_android
     def test_enable_fd(self):
         with tempfile.TemporaryFile('wb+') as fp:

--- a/Lib/test/test_faulthandler.py
+++ b/Lib/test/test_faulthandler.py
@@ -64,8 +64,15 @@ class FaultHandlerTests(unittest.TestCase):
         if fd is not None:
             pass_fds.append(fd)
         env = dict(os.environ)
+
+        # Sanitizers must not handle SIGSEGV (ex: for test_enable_fd())
+        option = 'handle_segv=0'
         for name in ('ASAN_OPTIONS', 'MSAN_OPTIONS', 'UBSAN_OPTIONS'):
-            env[name] = 'handle_segv=0'
+            if name in env:
+                env[name] += f':{option}'
+            else:
+                env[name] = option
+
         with support.SuppressCrashReport():
             process = script_helper.spawn_python('-c', code,
                                                  pass_fds=pass_fds,


### PR DESCRIPTION
Set environment options to ask sanitizers to not handle SIGSEGV.

This change allows running test_enable_fd() and test_enable_file() with sanitizers. Previously, they were skipped.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
