### PR TITLE
Fix test_generators: save/restore warnings filters

### DIFF
--- a/Lib/test/test_generators.py
+++ b/Lib/test/test_generators.py
@@ -2258,6 +2258,7 @@ caught ValueError ()
 caught ValueError (xyz)
 
 >>> import warnings
+>>> old_filters = warnings.filters.copy()
 >>> warnings.filterwarnings("ignore", category=DeprecationWarning)
 
 # Filter DeprecationWarning: regarding the (type, val, tb) signature of throw().
@@ -2331,8 +2332,7 @@ Traceback (most recent call last):
   ...
 ValueError: 7
 
->>> warnings.filters.pop(0)
-('ignore', None, <class 'DeprecationWarning'>, None, 0)
+>>> warnings.filters[:] = old_filters
 
 # Re-enable DeprecationWarning: the (type, val, tb) exception representation is deprecated,
 #                               and may be removed in a future version of Python.


### PR DESCRIPTION
Previously, depending on existing filters, the test could modify the warnings and so fail as "env changed".

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
