### PR TITLE
gh-106242: Make ntpath.realpath errors consistent with abspath when there are embedded nulls

### DIFF
--- a/Lib/ntpath.py
+++ b/Lib/ntpath.py
@@ -721,6 +721,14 @@ else:
         try:
             path = _getfinalpathname(path)
             initial_winerror = 0
+        except ValueError as ex:
+            # gh-106242: Raised for embedded null characters
+            # In strict mode, we convert into an OSError.
+            # Non-strict mode returns the path as-is, since we've already
+            # made it absolute.
+            if strict:
+                raise OSError(str(ex)) from None
+            path = normpath(path)
         except OSError as ex:
             if strict:
                 raise
@@ -740,6 +748,10 @@ else:
             try:
                 if _getfinalpathname(spath) == path:
                     path = spath
+            except ValueError as ex:
+                # Unexpected, as an invalid path should not have gained a prefix
+                # at any point, but we ignore this error just in case.
+                pass
             except OSError as ex:
                 # If the path does not exist and originally did not exist, then
                 # strip the prefix anyway.

--- a/Lib/test/test_ntpath.py
+++ b/Lib/test/test_ntpath.py
@@ -394,6 +394,10 @@ class TestNtpath(NtpathTestCase):
         d = drives.pop().encode()
         self.assertEqual(ntpath.realpath(d), d)
 
+        # gh-106242: Embedded nulls and non-strict fallback to abspath
+        self.assertEqual(ABSTFN + "\0spam",
+                         ntpath.realpath(os_helper.TESTFN + "\0spam", strict=False))
+
     @os_helper.skip_unless_symlink
     @unittest.skipUnless(HAVE_GETFINALPATHNAME, 'need _getfinalpathname')
     def test_realpath_strict(self):
@@ -404,6 +408,8 @@ class TestNtpath(NtpathTestCase):
         self.addCleanup(os_helper.unlink, ABSTFN)
         self.assertRaises(FileNotFoundError, ntpath.realpath, ABSTFN, strict=True)
         self.assertRaises(FileNotFoundError, ntpath.realpath, ABSTFN + "2", strict=True)
+        # gh-106242: Embedded nulls should raise OSError (not ValueError)
+        self.assertRaises(OSError, ntpath.realpath, ABSTFN + "\0spam", strict=True)
 
     @os_helper.skip_unless_symlink
     @unittest.skipUnless(HAVE_GETFINALPATHNAME, 'need _getfinalpathname')

--- a/Misc/NEWS.d/next/Windows/2023-08-22-00-36-57.gh-issue-106242.q24ITw.rst
+++ b/Misc/NEWS.d/next/Windows/2023-08-22-00-36-57.gh-issue-106242.q24ITw.rst
@@ -1,3 +1,4 @@
 Fixes :func:`~os.path.realpath` to behave consistently when passed a path
-containing an embedded null character. In strict mode, it now raises
-:exc:`OSError`, and in non-strict mode will make the path absolute.
+containing an embedded null character on Windows. In strict mode, it now
+raises :exc:`OSError` instead of the unexpected :exc:`ValueError`, and in
+non-strict mode will make the path absolute.

--- a/Misc/NEWS.d/next/Windows/2023-08-22-00-36-57.gh-issue-106242.q24ITw.rst
+++ b/Misc/NEWS.d/next/Windows/2023-08-22-00-36-57.gh-issue-106242.q24ITw.rst
@@ -1,0 +1,3 @@
+Fixes :func:`~os.path.realpath` to behave consistently when passed a path
+containing an embedded null character. In strict mode, it now raises
+:exc:`OSError`, and in non-strict mode will make the path absolute.


### PR DESCRIPTION


<!-- gh-issue-number: gh-106242 -->
* Issue: gh-106242
<!-- /gh-issue-number -->
