### PR TITLE
gh-107544: Add docs about `json.dumps(..., default=)`

### DIFF
--- a/Doc/library/json.rst
+++ b/Doc/library/json.rst
@@ -60,6 +60,17 @@ Pretty printing::
         "6": 7
     }
 
+Specializing JSON object encoding::
+
+   >>> import json
+   >>> def custom_json(obj):
+   ...     if isinstance(obj, complex):
+   ...         return {'__complex__': True, 'real': obj.real, 'imag': obj.imag}
+   ...     raise TypeError(f'Cannot serialize object of {type(obj)}')
+   ...
+   >>> json.dumps(1 + 2j, default=custom_json)
+   '{"__complex__": true, "real": 1.0, "imag": 2.0}'
+
 Decoding JSON::
 
     >>> import json

--- a/Doc/library/json.rst
+++ b/Doc/library/json.rst
@@ -54,7 +54,7 @@ Compact encoding::
 Pretty printing::
 
     >>> import json
-    >>> print(json.dumps({'4': 5, '6': 7}, sort_keys=True, indent=4))
+    >>> print(json.dumps({'6': 7, '4': 5}, sort_keys=True, indent=4))
     {
         "4": 5,
         "6": 7


### PR DESCRIPTION
In my opinion, `default=` is a great alternative to custom `JSONEncoder`, compare how much easier it is than `JSONEncoder`:

```python
    >>> import json
    >>> class ComplexEncoder(json.JSONEncoder):
    ...     def default(self, obj):
    ...         if isinstance(obj, complex):
    ...             return [obj.real, obj.imag]
    ...         # Let the base class default method raise the TypeError
    ...         return json.JSONEncoder.default(self, obj)
    ...
    >>> json.dumps(2 + 1j, cls=ComplexEncoder)
    '[2.0, 1.0]'
```

My example follows the same logic we have for `object_hook` in `json.loads()` part: 

```python
    >>> import json
    >>> def as_complex(dct):
    ...     if '__complex__' in dct:
    ...         return complex(dct['real'], dct['imag'])
    ...     return dct
    ...
    >>> json.loads('{"__complex__": true, "real": 1, "imag": 2}',
    ...     object_hook=as_complex)
    (1+2j)
```

So, now we would have a complete pair: with encoding and decoding.

Plus, this example answers all questions about the signature and features of the `default` function.

<!-- gh-issue-number: gh-107544 -->
* Issue: gh-107544
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--108259.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->