### PR TITLE
[3.11] Docs: move sphinx-lint to pre-commit (GH-105750)

### DIFF
--- a/.github/workflows/reusable-docs.yml
+++ b/.github/workflows/reusable-docs.yml
@@ -26,8 +26,6 @@ jobs:
         cache-dependency-path: 'Doc/requirements.txt'
     - name: 'Install build dependencies'
       run: make -C Doc/ venv
-    - name: 'Check documentation'
-      run: make -C Doc/ check
     - name: 'Build HTML documentation'
       run: make -C Doc/ SPHINXOPTS="-q" SPHINXERRORHANDLING="-W --keep-going" html
     - name: 'Upload'
@@ -37,8 +35,6 @@ jobs:
         path: Doc/build/html
 
   # This build doesn't use problem matchers or check annotations
-  # It also does not run 'make check', as sphinx-lint is not installed into the
-  # environment.
   build_doc_oldest_supported_sphinx:
     name: 'Docs (Oldest Sphinx)'
     runs-on: ubuntu-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,3 +5,11 @@ repos:
       - id: check-yaml
       - id: trailing-whitespace
         types_or: [c, python, rst]
+
+  - repo: https://github.com/sphinx-contrib/sphinx-lint
+    rev: v0.6.8
+    hooks:
+      - id: sphinx-lint
+        args: [--enable=default-role]
+        files: ^Doc/
+        types: [rst]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,5 +11,5 @@ repos:
     hooks:
       - id: sphinx-lint
         args: [--enable=default-role]
-        files: ^Doc/
+        files: ^Doc/|^Misc/NEWS.d/next/
         types: [rst]

--- a/Doc/Makefile
+++ b/Doc/Makefile
@@ -214,11 +214,9 @@ dist:
 	rm -r dist/python-$(DISTVERSION)-docs-texinfo
 	rm dist/python-$(DISTVERSION)-docs-texinfo.tar
 
-check:
-	# Check the docs and NEWS files with sphinx-lint.
-	# Ignore the tools and venv dirs and check that the default role is not used.
-	$(SPHINXLINT) -i tools -i $(VENVDIR) --enable default-role
-	$(SPHINXLINT) --enable default-role ../Misc/NEWS.d/next/
+check: venv
+	$(VENVDIR)/bin/python3 -m pre_commit --version > /dev/null || $(VENVDIR)/bin/python3 -m pip install pre-commit
+	$(VENVDIR)/bin/python3 -m pre_commit run --all-files
 
 serve:
 	@echo "The serve target was removed, use htmlview instead (see bpo-36329)"

--- a/Doc/constraints.txt
+++ b/Doc/constraints.txt
@@ -23,7 +23,3 @@ sphinxcontrib-serializinghtml<1.2
 
 # Direct dependencies of Jinja2 (Jinja is a dependency of Sphinx, see above)
 MarkupSafe<2.2
-
-# Direct dependencies of sphinx-lint
-polib<1.3
-regex<2024

--- a/Doc/requirements.txt
+++ b/Doc/requirements.txt
@@ -10,7 +10,6 @@ sphinx==4.5.0
 
 blurb
 
-sphinx-lint==0.6.7
 sphinxext-opengraph>=0.7.1
 
 # The theme used by the documentation is stored separately, so we need


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

Follow on from https://github.com/python/cpython/pull/108215 to make CI/pre-commit consistent across `3.11`-`main`. 

Combined backport of:

* https://github.com/python/cpython/pull/105750
* https://github.com/python/cpython/pull/108212


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--108276.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->