### PR TITLE
gh-90791: Enable test___all__ on ASAN build

### DIFF
--- a/Lib/test/test___all__.py
+++ b/Lib/test/test___all__.py
@@ -12,10 +12,19 @@ except ModuleNotFoundError:
 
 
 if support.check_sanitizer(address=True, memory=True):
-    # bpo-46633: test___all__ is skipped because importing some modules
-    # directly can trigger known problems with ASAN (like tk).
-    raise unittest.SkipTest("workaround ASAN build issues on loading tests "
-                            "like tk")
+    SKIP_MODULES = frozenset((
+        # gh-90791: Tests involving libX11 can SEGFAULT on ASAN/MSAN builds.
+        # Skip modules, packages and tests using '_tkinter'.
+        '_tkinter',
+        'tkinter',
+        'test_tkinter',
+        'test_ttk',
+        'test_ttk_textonly',
+        'idlelib',
+        'test_idle',
+    ))
+else:
+    SKIP_MODULES = ()
 
 
 class NoAll(RuntimeError):
@@ -83,15 +92,23 @@ class AllTest(unittest.TestCase):
         for fn in sorted(os.listdir(basedir)):
             path = os.path.join(basedir, fn)
             if os.path.isdir(path):
+                if fn in SKIP_MODULES:
+                    continue
                 pkg_init = os.path.join(path, '__init__.py')
                 if os.path.exists(pkg_init):
                     yield pkg_init, modpath + fn
                     for p, m in self.walk_modules(path, modpath + fn + "."):
                         yield p, m
                 continue
-            if not fn.endswith('.py') or fn == '__init__.py':
+
+            if fn == '__init__.py':
                 continue
-            yield path, modpath + fn[:-3]
+            if not fn.endswith('.py'):
+                continue
+            modname = fn.removesuffix('.py')
+            if modname in SKIP_MODULES:
+                continue
+            yield path, modpath + modname
 
     def test_all(self):
         # List of denied modules and packages
@@ -119,14 +136,14 @@ class AllTest(unittest.TestCase):
             if denied:
                 continue
             if support.verbose:
-                print(modname)
+                print(f"Check {modname}", flush=True)
             try:
                 # This heuristic speeds up the process by removing, de facto,
                 # most test modules (and avoiding the auto-executing ones).
                 with open(path, "rb") as f:
                     if b"__all__" not in f.read():
                         raise NoAll(modname)
-                    self.check_all(modname)
+                self.check_all(modname)
             except NoAll:
                 ignored.append(modname)
             except FailedImport:

--- a/Lib/test/test_concurrent_futures.py
+++ b/Lib/test/test_concurrent_futures.py
@@ -34,7 +34,7 @@ import multiprocessing as mp
 
 
 if support.check_sanitizer(address=True, memory=True):
-    # bpo-46633: Skip the test because it is too slow when Python is built
+    # gh-90791: Skip the test because it is too slow when Python is built
     # with ASAN/MSAN: between 5 and 20 minutes on GitHub Actions.
     raise unittest.SkipTest("test too slow on ASAN/MSAN build")
 

--- a/Lib/test/test_idle.py
+++ b/Lib/test/test_idle.py
@@ -3,6 +3,7 @@ from test.support.import_helper import import_module
 from test.support import check_sanitizer
 
 if check_sanitizer(address=True, memory=True):
+    # See gh-90791 for details
     raise unittest.SkipTest("Tests involving libX11 can SEGFAULT on ASAN/MSAN builds")
 
 # Skip test_idle if _tkinter, tkinter, or idlelib are missing.

--- a/Lib/test/test_peg_generator/__init__.py
+++ b/Lib/test/test_peg_generator/__init__.py
@@ -5,7 +5,7 @@ from test.support import load_package_tests
 
 
 if support.check_sanitizer(address=True, memory=True):
-    # bpo-46633: Skip the test because it is too slow when Python is built
+    # gh-90791: Skip the test because it is too slow when Python is built
     # with ASAN/MSAN: between 5 and 20 minutes on GitHub Actions.
     raise unittest.SkipTest("test too slow on ASAN/MSAN build")
 

--- a/Lib/test/test_tkinter/__init__.py
+++ b/Lib/test/test_tkinter/__init__.py
@@ -10,6 +10,7 @@ from test.support import (
 
 
 if check_sanitizer(address=True, memory=True):
+    # See gh-90791 for details
     raise unittest.SkipTest("Tests involving libX11 can SEGFAULT on ASAN/MSAN builds")
 
 # Skip test if _tkinter wasn't built.

--- a/Lib/test/test_tools/__init__.py
+++ b/Lib/test/test_tools/__init__.py
@@ -8,7 +8,7 @@ from test.support import import_helper
 
 
 if support.check_sanitizer(address=True, memory=True):
-    # bpo-46633: Skip the test because it is too slow when Python is built
+    # gh-90791: Skip the test because it is too slow when Python is built
     # with ASAN/MSAN: between 5 and 20 minutes on GitHub Actions.
     raise unittest.SkipTest("test too slow on ASAN/MSAN build")
 


### PR DESCRIPTION
* Only skip modules and tests related to X11 on ASAN builds: run other tests with ASAN.
* Use print(flush=True) to see output earlier when it's redirected to a pipe.
* Update issue reference: replace bpo-46633 with gh-90791.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
