### PR TITLE
Fix spurious diff if the cases generator is run on Windows

### DIFF
--- a/Tools/cases_generator/generate_cases.py
+++ b/Tools/cases_generator/generate_cases.py
@@ -237,7 +237,7 @@ class Generator(Analyzer):
             except ValueError:
                 # May happen on Windows if root and temp on different volumes
                 pass
-            filenames.append(filename)
+            filenames.append(filename.replace(os.path.sep, posixpath.sep))
         paths = f"\n{self.out.comment}   ".join(filenames)
         return f"{self.out.comment} from:\n{self.out.comment}   {paths}\n"
 


### PR DESCRIPTION
I noticed this while testing #108112 -- if I run `python Tools/cases_generator/generate_cases.py` locally on my Windows machine currently, it produces this spurious diff:

```diff
diff --git a/Include/internal/pycore_opcode_metadata.h b/Include/internal/pycore_opcode_metadata.h
index e35db0c4c5..4879ab1c46 100644
--- a/Include/internal/pycore_opcode_metadata.h
+++ b/Include/internal/pycore_opcode_metadata.h
@@ -1,6 +1,6 @@
 // This file is generated by Tools/cases_generator/generate_cases.py
 // from:
-//   Python/bytecodes.c
+//   Python\bytecodes.c
 // Do not edit!
 
 #ifndef Py_BUILD_CORE
diff --git a/Include/opcode_ids.h b/Include/opcode_ids.h
index cd43716415..b91d8217d6 100644
--- a/Include/opcode_ids.h
+++ b/Include/opcode_ids.h
@@ -1,6 +1,6 @@
 // This file is generated by Tools/cases_generator/generate_cases.py
 // from:
-//   Python/bytecodes.c
+//   Python\bytecodes.c
 // Do not edit!
 
 #ifndef Py_OPCODE_IDS_H
diff --git a/Lib/_opcode_metadata.py b/Lib/_opcode_metadata.py
index b02aa771c3..d053765655 100644
--- a/Lib/_opcode_metadata.py
+++ b/Lib/_opcode_metadata.py
@@ -1,6 +1,6 @@
 # This file is generated by Tools/cases_generator/generate_cases.py
 # from:
-#   Python/bytecodes.c
+#   Python\bytecodes.c
 # Do not edit!
 
 _specializations = {
diff --git a/Python/abstract_interp_cases.c.h b/Python/abstract_interp_cases.c.h
index 1b99b929fa..34153df3d2 100644
--- a/Python/abstract_interp_cases.c.h
+++ b/Python/abstract_interp_cases.c.h
@@ -1,6 +1,6 @@
 // This file is generated by Tools/cases_generator/generate_cases.py
 // from:
-//   Python/bytecodes.c
+//   Python\bytecodes.c
 // Do not edit!
 
         case NOP: {
diff --git a/Python/executor_cases.c.h b/Python/executor_cases.c.h
index 89a5bbfecd..401e6ea4dc 100644
--- a/Python/executor_cases.c.h
+++ b/Python/executor_cases.c.h
@@ -1,6 +1,6 @@
 // This file is generated by Tools/cases_generator/generate_cases.py
 // from:
-//   Python/bytecodes.c
+//   Python\bytecodes.c
 // Do not edit!
 
         case NOP: {
diff --git a/Python/generated_cases.c.h b/Python/generated_cases.c.h
index f6322df566..48d1039495 100644
--- a/Python/generated_cases.c.h
+++ b/Python/generated_cases.c.h
@@ -1,6 +1,6 @@
 // This file is generated by Tools/cases_generator/generate_cases.py
 // from:
-//   Python/bytecodes.c
+//   Python\bytecodes.c
 // Do not edit!
 
         TARGET(NOP) {
```