### PR TITLE
gh-108111: Flush gzip write buffer before seeking, fixing bad writes

### DIFF
--- a/Lib/gzip.py
+++ b/Lib/gzip.py
@@ -401,6 +401,9 @@ class GzipFile(_compression.BaseStream):
 
     def seek(self, offset, whence=io.SEEK_SET):
         if self.mode == WRITE:
+            self._check_not_closed()
+            # Flush buffer to ensure validity of self.offset
+            self._buffer.flush()
             if whence != io.SEEK_SET:
                 if whence == io.SEEK_CUR:
                     offset = self.offset + offset

--- a/Lib/test/test_gzip.py
+++ b/Lib/test/test_gzip.py
@@ -665,6 +665,18 @@ class TestGzip(BaseTest):
         ]
         self.assertEqual(fc.modes, expected_modes)
 
+    def test_write_seek_write(self):
+        # Make sure that offset is up-to-date before seeking
+        # See issue GH-108111
+        b = io.BytesIO()
+        message = b"important message here."
+        with gzip.GzipFile(fileobj=b, mode='w') as f:
+            f.write(message)
+            f.seek(len(message))
+            f.write(message)
+        data = b.getvalue()
+        self.assertEqual(gzip.decompress(data), message * 2)
+
 
 class TestOpen(BaseTest):
     def test_binary_modes(self):

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -1150,6 +1150,7 @@ Colin Marc
 Vincent Marchetti
 David Marek
 Doug Marien
+Chris Markiewicz
 Sven Marnach
 John Marshall
 Alex Martelli

--- a/Misc/NEWS.d/next/Library/2023-08-22-17-27-12.gh-issue-108111.N7a4u_.rst
+++ b/Misc/NEWS.d/next/Library/2023-08-22-17-27-12.gh-issue-108111.N7a4u_.rst
@@ -1,0 +1,2 @@
+Fix a regression introduced in GH-101251 for 3.12, resulting in an incorrect
+offset calculation in :meth:`gzip.GzipFile.seek`.


### PR DESCRIPTION
Issue described in detail in #108111.

Short story: `write(x); seek(len(x)); write(x)` results in `b''.join([x, bytes(len(x)), x])` being written. This is due to buffered writes not updating the `GzipFile.offset()` until flushed. It's possible there could be something more efficient, but this seemed like the simplest solution.

<!-- gh-issue-number: gh-108111 -->
* Issue: gh-108111
<!-- /gh-issue-number -->
