### PR TITLE
gh-108342: Break ref cycle in SSLSocket._create() exc

### DIFF
--- a/Lib/ssl.py
+++ b/Lib/ssl.py
@@ -1021,7 +1021,11 @@ class SSLSocket(socket):
                     self.close()
                 except OSError:
                     pass
-                raise notconn_pre_handshake_data_error
+                try:
+                    raise notconn_pre_handshake_data_error
+                finally:
+                    # Break explicitly reference cycle
+                    notconn_pre_handshake_data_error = None
         else:
             connected = True
 

--- a/Lib/ssl.py
+++ b/Lib/ssl.py
@@ -1024,7 +1024,7 @@ class SSLSocket(socket):
                 try:
                     raise notconn_pre_handshake_data_error
                 finally:
-                    # Break explicitly reference cycle
+                    # Explicitly break the reference cycle.
                     notconn_pre_handshake_data_error = None
         else:
             connected = True


### PR DESCRIPTION
Break explicitly a reference cycle when SSLSocket._create() raises an exception. Clear the variable storing the exception, since the exception traceback contains the variables and so creates a reference cycle.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-108342 -->
* Issue: gh-108342
<!-- /gh-issue-number -->
