### PR TITLE
[3.11] gh-105776: Fix test_cppext when CC contains -std=c11 option (#108343)

### DIFF
--- a/Lib/test/test_cppext/setup.py
+++ b/Lib/test/test_cppext/setup.py
@@ -1,7 +1,9 @@
 # gh-91321: Build a basic C++ test extension to check that the Python C API is
 # compatible with C++ and does not emit C++ compiler warnings.
 import os.path
+import shlex
 import sys
+import sysconfig
 
 from setuptools import setup, Extension
 
@@ -35,6 +37,17 @@ def main():
         name = '_testcpp11ext'
 
     cppflags = [*CPPFLAGS, f'-std={std}']
+
+    # gh-105776: When "gcc -std=11" is used as the C++ compiler, -std=c11
+    # option emits a C++ compiler warning. Remove "-std11" option from the
+    # CC command.
+    cmd = (sysconfig.get_config_var('CC') or '')
+    if cmd is not None:
+        cmd = shlex.split(cmd)
+        cmd = [arg for arg in cmd if not arg.startswith('-std=')]
+        cmd = shlex.join(cmd)
+        # CC env var overrides sysconfig CC variable in setuptools
+        os.environ['CC'] = cmd
 
     cpp_ext = Extension(
         name,

--- a/Misc/NEWS.d/next/Tests/2023-08-23-04-08-18.gh-issue-105776.oE6wp_.rst
+++ b/Misc/NEWS.d/next/Tests/2023-08-23-04-08-18.gh-issue-105776.oE6wp_.rst
@@ -1,0 +1,2 @@
+Fix test_cppext when the C compiler command ``-std=c11`` option: remove
+``-std=`` options from the compiler command. Patch by Victor Stinner.


### PR DESCRIPTION
Fix test_cppext when the C compiler command has the "-std=c11" option. Remove "-std=" options from the compiler command.

(cherry picked from commit 9173b2bbe13aeccc075b571da05c653a2a91de1b)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-105776 -->
* Issue: gh-105776
<!-- /gh-issue-number -->
