### PR TITLE
gh-108346: Fix failed benchmark in decimal

### DIFF
--- a/Modules/_decimal/tests/bench.py
+++ b/Modules/_decimal/tests/bench.py
@@ -7,6 +7,8 @@
 
 
 import time
+import sys
+from functools import wraps
 from test.support.import_helper import import_fresh_module
 
 C = import_fresh_module('decimal', fresh=['_decimal'])
@@ -64,66 +66,85 @@ def factorial(n, m):
     else:
         return factorial(n, (n+m)//2) * factorial((n+m)//2 + 1, m)
 
+# Fix failed test cases caused by CVE-2020-10735 patch.
+# See gh-95778 for details.
+def increase_int_max_str_digits(maxdigits):
+    def _increase_int_max_str_digits(func, maxdigits=maxdigits):
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            previous_int_limit = sys.get_int_max_str_digits()
+            sys.set_int_max_str_digits(maxdigits)
+            ans = func(*args, **kwargs)
+            sys.set_int_max_str_digits(previous_int_limit)
+            return ans
+        return wrapper
+    return _increase_int_max_str_digits
 
-print("\n# ======================================================================")
-print("#                   Calculating pi, 10000 iterations")
-print("# ======================================================================\n")
+def test_calc_pi():
+    print("\n# ======================================================================")
+    print("#                   Calculating pi, 10000 iterations")
+    print("# ======================================================================\n")
 
-to_benchmark = [pi_float, pi_decimal]
-if C is not None:
-    to_benchmark.insert(1, pi_cdecimal)
+    to_benchmark = [pi_float, pi_decimal]
+    if C is not None:
+        to_benchmark.insert(1, pi_cdecimal)
 
-for prec in [9, 19]:
-    print("\nPrecision: %d decimal digits\n" % prec)
-    for func in to_benchmark:
-        start = time.time()
-        if C is not None:
-            C.getcontext().prec = prec
-        P.getcontext().prec = prec
-        for i in range(10000):
-            x = func()
-        print("%s:" % func.__name__.replace("pi_", ""))
-        print("result: %s" % str(x))
-        print("time: %fs\n" % (time.time()-start))
+    for prec in [9, 19]:
+        print("\nPrecision: %d decimal digits\n" % prec)
+        for func in to_benchmark:
+            start = time.time()
+            if C is not None:
+                C.getcontext().prec = prec
+            P.getcontext().prec = prec
+            for i in range(10000):
+                x = func()
+            print("%s:" % func.__name__.replace("pi_", ""))
+            print("result: %s" % str(x))
+            print("time: %fs\n" % (time.time()-start))
 
-
-print("\n# ======================================================================")
-print("#                               Factorial")
-print("# ======================================================================\n")
-
-if C is not None:
-    c = C.getcontext()
-    c.prec = C.MAX_PREC
-    c.Emax = C.MAX_EMAX
-    c.Emin = C.MIN_EMIN
-
-for n in [100000, 1000000]:
-
-    print("n = %d\n" % n)
+@increase_int_max_str_digits(maxdigits=10000000)
+def test_factorial():
+    print("\n# ======================================================================")
+    print("#                               Factorial")
+    print("# ======================================================================\n")
 
     if C is not None:
-        # C version of decimal
+        c = C.getcontext()
+        c.prec = C.MAX_PREC
+        c.Emax = C.MAX_EMAX
+        c.Emin = C.MIN_EMIN
+
+    for n in [100000, 1000000]:
+
+        print("n = %d\n" % n)
+
+        if C is not None:
+            # C version of decimal
+            start_calc = time.time()
+            x = factorial(C.Decimal(n), 0)
+            end_calc = time.time()
+            start_conv = time.time()
+            sx = str(x)
+            end_conv = time.time()
+            print("cdecimal:")
+            print("calculation time: %fs" % (end_calc-start_calc))
+            print("conversion time: %fs\n" % (end_conv-start_conv))
+
+        # Python integers
         start_calc = time.time()
-        x = factorial(C.Decimal(n), 0)
+        y = factorial(n, 0)
         end_calc = time.time()
         start_conv = time.time()
-        sx = str(x)
-        end_conv = time.time()
-        print("cdecimal:")
+        sy = str(y)
+        end_conv =  time.time()
+
+        print("int:")
         print("calculation time: %fs" % (end_calc-start_calc))
-        print("conversion time: %fs\n" % (end_conv-start_conv))
+        print("conversion time: %fs\n\n" % (end_conv-start_conv))
 
-    # Python integers
-    start_calc = time.time()
-    y = factorial(n, 0)
-    end_calc = time.time()
-    start_conv = time.time()
-    sy = str(y)
-    end_conv =  time.time()
+        if C is not None:
+            assert(sx == sy)
 
-    print("int:")
-    print("calculation time: %fs" % (end_calc-start_calc))
-    print("conversion time: %fs\n\n" % (end_conv-start_conv))
-
-    if C is not None:
-        assert(sx == sy)
+if __name__ == "__main__":
+    test_calc_pi()
+    test_factorial()


### PR DESCRIPTION
* Add a decorator to change the limit of the maximum digits that can be converted within the function.
* Move the origin code in the bench.py into `test_calc_pi` and `test_factorial` function (no code changes here other than adding a decorator to `test_factorial`)
<details><summary>Details</summary>
<p>

```shell
# After changes

# ======================================================================
#                               Factorial
# ======================================================================

n = 100000

cdecimal:
calculation time: 0.884838s
conversion time: 0.002756s

./Modules/_decimal/libmpdec/context.c:56: warning: mpd_setminalloc: ignoring request to set MPD_MINALLOC a second time

int:
calculation time: 0.515127s
conversion time: 0.477298s


n = 1000000

cdecimal:
calculation time: 13.878487s
conversion time: 0.035031s

int:
calculation time: 20.497053s
conversion time: 10.807741s
```

</p>
</details> 
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-108346 -->
* Issue: gh-108346
<!-- /gh-issue-number -->
