### PR TITLE
gh-108267: Dataclasses docs line should have said "object.__setattr__" instead of just "__setattr__"

### DIFF
--- a/Doc/library/dataclasses.rst
+++ b/Doc/library/dataclasses.rst
@@ -609,7 +609,7 @@ methods will raise a :exc:`FrozenInstanceError` when invoked.
 
 There is a tiny performance penalty when using ``frozen=True``:
 :meth:`~object.__init__` cannot use simple assignment to initialize fields, and
-must use :meth:`~object.__setattr__`.
+must use :meth:`!object.__setattr__`.
 
 Inheritance
 -----------


### PR DESCRIPTION
Changed `__setattr__` to `object.__setattr__` in a docs section that was specifically supposed to refer to the `__setattr__` method of the `object` class. Also suppressed the link to the data model docs for `__setattr__`, since we're talking about a specific `__setattr__` implementation, not `__setattr__` methods in general.

<!-- gh-issue-number: gh-108267 -->
* Issue: gh-108267
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--108355.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->