### PR TITLE
gh-107298: Fix a few more refs in the C API docs

### DIFF
--- a/Doc/c-api/typeobj.rst
+++ b/Doc/c-api/typeobj.rst
@@ -1403,7 +1403,7 @@ and :c:data:`PyType_Type` effectively act as defaults.)
        are allowed to be removed even if the instance is still alive).
 
    Note that :c:func:`Py_VISIT` requires the *visit* and *arg* parameters to
-   :c:func:`local_traverse` to have these specific names; don't name them just
+   :c:func:`!local_traverse` to have these specific names; don't name them just
    anything.
 
    Instances of :ref:`heap-allocated types <heap-types>` hold a reference to

--- a/Doc/whatsnew/2.6.rst
+++ b/Doc/whatsnew/2.6.rst
@@ -121,7 +121,7 @@ about features that will be removed in Python 3.0.  You can run code
 with this switch to see how much work will be necessary to port
 code to 3.0.  The value of this switch is available
 to Python code as the boolean variable :data:`sys.py3kwarning`,
-and to C extension code as :c:data:`Py_Py3kWarningFlag`.
+and to C extension code as :c:data:`!Py_Py3kWarningFlag`.
 
 .. seealso::
 

--- a/Doc/whatsnew/2.7.rst
+++ b/Doc/whatsnew/2.7.rst
@@ -2155,13 +2155,13 @@ Changes to Python's build process and to the C API include:
   :c:func:`!PyOS_ascii_strtod` and :c:func:`!PyOS_ascii_atof` functions
   are now deprecated.
 
-* New function: :c:func:`PySys_SetArgvEx` sets the value of
+* New function: :c:func:`!PySys_SetArgvEx` sets the value of
   ``sys.argv`` and can optionally update ``sys.path`` to include the
   directory containing the script named by ``sys.argv[0]`` depending
   on the value of an *updatepath* parameter.
 
   This function was added to close a security hole for applications
-  that embed Python.  The old function, :c:func:`PySys_SetArgv`, would
+  that embed Python.  The old function, :c:func:`!PySys_SetArgv`, would
   always update ``sys.path``, and sometimes it would add the current
   directory.  This meant that, if you ran an application embedding
   Python in a directory controlled by someone else, attackers could
@@ -2169,8 +2169,8 @@ Changes to Python's build process and to the C API include:
   :file:`os.py`) that your application would then import and run.
 
   If you maintain a C/C++ application that embeds Python, check
-  whether you're calling :c:func:`PySys_SetArgv` and carefully consider
-  whether the application should be using :c:func:`PySys_SetArgvEx`
+  whether you're calling :c:func:`!PySys_SetArgv` and carefully consider
+  whether the application should be using :c:func:`!PySys_SetArgvEx`
   with *updatepath* set to false.
 
   Security issue reported as `CVE-2008-5983
@@ -2545,11 +2545,11 @@ For C extensions:
 
 For applications that embed Python:
 
-* The :c:func:`PySys_SetArgvEx` function was added, letting
+* The :c:func:`!PySys_SetArgvEx` function was added, letting
   applications close a security hole when the existing
-  :c:func:`PySys_SetArgv` function was used.  Check whether you're
-  calling :c:func:`PySys_SetArgv` and carefully consider whether the
-  application should be using :c:func:`PySys_SetArgvEx` with
+  :c:func:`!PySys_SetArgv` function was used.  Check whether you're
+  calling :c:func:`!PySys_SetArgv` and carefully consider whether the
+  application should be using :c:func:`!PySys_SetArgvEx` with
   *updatepath* set to false.
 
 .. ======================================================================

--- a/Doc/whatsnew/3.4.rst
+++ b/Doc/whatsnew/3.4.rst
@@ -1891,7 +1891,7 @@ Other Build and C API Changes
   allowing retrieval of function pointers from named type slots when using
   the limited API.  (Contributed by Martin von Löwis in :issue:`17162`.)
 
-* The new :c:func:`Py_SetStandardStreamEncoding` pre-initialization API
+* The new :c:func:`!Py_SetStandardStreamEncoding` pre-initialization API
   allows applications embedding the CPython interpreter to reliably force
   a particular encoding and error handler for the standard streams.
   (Contributed by Bastien Montagne and Nick Coghlan in :issue:`16129`.)

--- a/Doc/whatsnew/3.7.rst
+++ b/Doc/whatsnew/3.7.rst
@@ -2495,12 +2495,12 @@ either in embedding applications, or in CPython itself.
 :issue:`22257`, and further updated by Nick, Eric, and Victor Stinner in a
 number of other issues). Some known details affected:
 
-* :c:func:`PySys_AddWarnOptionUnicode` is not currently usable by embedding
+* :c:func:`!PySys_AddWarnOptionUnicode` is not currently usable by embedding
   applications due to the requirement to create a Unicode object prior to
-  calling ``Py_Initialize``. Use :c:func:`PySys_AddWarnOption` instead.
+  calling ``Py_Initialize``. Use :c:func:`!PySys_AddWarnOption` instead.
 
 * warnings filters added by an embedding application with
-  :c:func:`PySys_AddWarnOption` should now more consistently take precedence
+  :c:func:`!PySys_AddWarnOption` should now more consistently take precedence
   over the default filters set by the interpreter
 
 Due to changes in the way the default warnings filters are configured,

--- a/Misc/NEWS.d/3.11.0b1.rst
+++ b/Misc/NEWS.d/3.11.0b1.rst
@@ -2028,8 +2028,8 @@ https://gitlab.com/warsaw/pynche
 .. nonce: 3mQ54t
 .. section: C API
 
-Deprecate the C functions: :c:func:`PySys_SetArgv`,
-:c:func:`PySys_SetArgvEx`, :c:func:`PySys_SetPath`. Patch by Victor Stinner.
+Deprecate the C functions: :c:func:`!PySys_SetArgv`,
+:c:func:`!PySys_SetArgvEx`, :c:func:`!PySys_SetPath`. Patch by Victor Stinner.
 
 ..
 

--- a/Misc/NEWS.d/3.7.0a4.rst
+++ b/Misc/NEWS.d/3.7.0a4.rst
@@ -842,5 +842,5 @@ Moved the pygetopt.h header into internal/, since it has no public APIs.
 .. nonce: LbyQt6
 .. section: C API
 
-:c:func:`Py_SetProgramName` and :c:func:`Py_SetPythonHome` now take the
+:c:func:`!Py_SetProgramName` and :c:func:`!Py_SetPythonHome` now take the
 ``const wchar *`` arguments instead of ``wchar *``.

--- a/Misc/NEWS.d/3.8.0a4.rst
+++ b/Misc/NEWS.d/3.8.0a4.rst
@@ -1344,7 +1344,7 @@ Fix the argument handling in Tools/scripts/lll.py.
 .. nonce: vghb86
 .. section: C API
 
-Fix memory leak in :c:func:`Py_SetStandardStreamEncoding`: release memory if
+Fix memory leak in :c:func:`!Py_SetStandardStreamEncoding`: release memory if
 the function is called twice.
 
 ..


### PR DESCRIPTION


<!-- gh-issue-number: gh-107298 -->
* Issue: gh-107298
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--108361.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->