### PR TITLE
gh-107453:  errno documentation missing several constants #107453

### DIFF
--- a/Doc/library/errno.rst
+++ b/Doc/library/errno.rst
@@ -96,9 +96,29 @@ defined by the module.  The specific list of defined symbols is available as
    :exc:`PermissionError`.
 
 
+.. data:: ECANCELED
+
+   Operation canceled
+
+
 .. data:: EFAULT
 
    Bad address
+
+
+.. data:: ENOTSUP
+
+   Operation not supported
+
+
+.. data:: ENOTRECOVERABLE
+
+   State not recoverable
+
+
+.. data:: EOWNERDEAD
+
+   Owner died
 
 
 .. data:: ENOTBLK


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-107453 -->
* Issue: gh-107453
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--108365.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->