### PR TITLE
gh-70766: Mention the object getstate caveat in 3.11 What's new.

### DIFF
--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -459,6 +459,10 @@ Other Language Changes
   :class:`collections.OrderedDict`, :class:`collections.deque`,
   :class:`weakref.WeakSet`, and :class:`datetime.tzinfo` now copies and
   pickles instance attributes implemented as :term:`slots <__slots__>`.
+  This change has an unintended side effect: It trips up a small minority
+  of existing Python projects not expecting :meth:`object.__getstate__` to
+  exist. See the later comments on :gh:`70766` for discussions of what
+  workarounds such code may need.
   (Contributed by Serhiy Storchaka in :issue:`26579`.)
 
 .. _whatsnew311-pythonsafepath:


### PR DESCRIPTION
This doc update is just being added to tie the threads together. The behavior isn't going to change again. It wasn't noticed that it caused anyone issues until long after the 3.11 release.

<!-- gh-issue-number: gh-70766 -->
* Issue: gh-70766
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--108379.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->