### PR TITLE
test_peg_generator and test_freeze require cpu

### DIFF
--- a/Lib/test/test_peg_generator/__init__.py
+++ b/Lib/test/test_peg_generator/__init__.py
@@ -4,10 +4,8 @@ from test import support
 from test.support import load_package_tests
 
 
-if support.check_sanitizer(address=True, memory=True):
-    # gh-90791: Skip the test because it is too slow when Python is built
-    # with ASAN/MSAN: between 5 and 20 minutes on GitHub Actions.
-    raise unittest.SkipTest("test too slow on ASAN/MSAN build")
+# Creating a virtual environment and building C extensions is slow
+support.requires('cpu')
 
 
 # Load all tests in package

--- a/Lib/test/test_tools/__init__.py
+++ b/Lib/test/test_tools/__init__.py
@@ -7,12 +7,6 @@ from test import support
 from test.support import import_helper
 
 
-if support.check_sanitizer(address=True, memory=True):
-    # gh-90791: Skip the test because it is too slow when Python is built
-    # with ASAN/MSAN: between 5 and 20 minutes on GitHub Actions.
-    raise unittest.SkipTest("test too slow on ASAN/MSAN build")
-
-
 if not support.has_subprocess_support:
     raise unittest.SkipTest("test module requires subprocess")
 

--- a/Lib/test/test_tools/test_freeze.py
+++ b/Lib/test/test_tools/test_freeze.py
@@ -18,6 +18,9 @@ with imports_under_tool('freeze', 'test'):
 class TestFreeze(unittest.TestCase):
 
     def test_freeze_simple_script(self):
+        # Building Python is slow
+        support.requires('cpu')
+
         script = textwrap.dedent("""
             import sys
             print('running...')


### PR DESCRIPTION
The test_peg_generator and test_tools.test_freeze tests now require the 'cpu' resource. Skip these tests unless the 'cpu' resource is enabled (it is disabled by default).

These tests are no longer skipped if Python is built with ASAN or MSAN sanitizer.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
