### PR TITLE
gh-108388: test_concurrent_futures requires cpu

### DIFF
--- a/Lib/test/test_concurrent_futures.py
+++ b/Lib/test/test_concurrent_futures.py
@@ -33,10 +33,8 @@ import multiprocessing.util
 import multiprocessing as mp
 
 
-if support.check_sanitizer(address=True, memory=True):
-    # gh-90791: Skip the test because it is too slow when Python is built
-    # with ASAN/MSAN: between 5 and 20 minutes on GitHub Actions.
-    raise unittest.SkipTest("test too slow on ASAN/MSAN build")
+# This test spawns many threads and processes and is slow
+support.requires('cpu')
 
 
 def create_future(state=PENDING, exception=None, result=None):

--- a/Lib/test/test_multiprocessing_spawn.py
+++ b/Lib/test/test_multiprocessing_spawn.py
@@ -3,6 +3,9 @@ import test._test_multiprocessing
 
 from test import support
 
+# This test spawns many processes and is slow
+support.requires('cpu')
+
 if support.PGO:
     raise unittest.SkipTest("test is not helpful for PGO")
 

--- a/Misc/NEWS.d/next/Tests/2023-08-24-01-08-04.gh-issue-108388.fhO42m.rst
+++ b/Misc/NEWS.d/next/Tests/2023-08-24-01-08-04.gh-issue-108388.fhO42m.rst
@@ -1,0 +1,6 @@
+The slowest tests are now skipped by default, unless the "cpu" resource is
+enabled: test_concurrent_futures, test_multiprocessing_spawn,
+test_peg_generator and test_tools.test_freeze. Run the test suite with ``-u
+cpu`` or ``-u all`` to run these tests. Moreover, these tests are no longer
+skipped on Python built with ASAN or MSAN sanitizer. Patch by Victor
+Stinner.


### PR DESCRIPTION
The test_concurrent_futures and test_multiprocessing_spawn tests now require the 'cpu' resource. Skip these tests unless the 'cpu' resource is enabled (it is disabled by default).

test_concurrent_futures is no longer skipped if Python is built with ASAN or MSAN sanitizer.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-108388 -->
* Issue: gh-108388
<!-- /gh-issue-number -->
