### PR TITLE
gh-108388: regrtest runs slowest tests first

### DIFF
--- a/Lib/test/libregrtest/main.py
+++ b/Lib/test/libregrtest/main.py
@@ -463,8 +463,8 @@ class Regrtest:
         if self.ns.print_slow:
             self.test_times.sort(reverse=True)
             print()
-            print("10 slowest tests:")
-            for test_time, test in self.test_times[:10]:
+            print("20 slowest tests:")
+            for test_time, test in self.test_times[:20]:
                 print("- %s: %s" % (test, format_duration(test_time)))
 
         if self.bad:

--- a/Lib/test/libregrtest/runtest.py
+++ b/Lib/test/libregrtest/runtest.py
@@ -125,24 +125,6 @@ class Timeout(Failed):
 # the test is running in background
 PROGRESS_MIN_TIME = 30.0   # seconds
 
-# small set of tests to determine if we have a basically functioning interpreter
-# (i.e. if any of these fail, then anything else is likely to follow)
-STDTESTS = [
-    'test_grammar',
-    'test_opcodes',
-    'test_dict',
-    'test_builtin',
-    'test_exceptions',
-    'test_types',
-    'test_unittest',
-    'test_doctest',
-    'test_doctest2',
-    'test_support'
-]
-
-# set of tests that we don't want to be executed when using regrtest
-NOTTESTS = set()
-
 #If these test directories are encountered recurse into them and treat each
 # test_ .py or dir as a separate test module. This can increase parallelism.
 # Beware this can't generally be done for any directory with sub-tests as the
@@ -166,22 +148,23 @@ def findtestdir(path=None):
     return path or os.path.dirname(os.path.dirname(__file__)) or os.curdir
 
 
-def findtests(testdir=None, stdtests=STDTESTS, nottests=NOTTESTS, *, split_test_dirs=SPLITTESTDIRS, base_mod=""):
+def findtests(testdir=None, *, exclude=(), split_test_dirs=SPLITTESTDIRS, base_mod=""):
     """Return a list of all applicable test modules."""
     testdir = findtestdir(testdir)
     names = os.listdir(testdir)
     tests = []
-    others = set(stdtests) | nottests
     for name in names:
         mod, ext = os.path.splitext(name)
-        if mod[:5] == "test_" and mod not in others:
-            if mod in split_test_dirs:
-                subdir = os.path.join(testdir, mod)
-                mod = f"{base_mod or 'test'}.{mod}"
-                tests.extend(findtests(subdir, [], nottests, split_test_dirs=split_test_dirs, base_mod=mod))
-            elif ext in (".py", ""):
-                tests.append(f"{base_mod}.{mod}" if base_mod else mod)
-    return stdtests + sorted(tests)
+        if not mod.startswith("test_") or mod in exclude:
+            continue
+
+        if mod in split_test_dirs:
+            subdir = os.path.join(testdir, mod)
+            mod = f"{base_mod or 'test'}.{mod}"
+            tests.extend(findtests(subdir, exclude=exclude, split_test_dirs=split_test_dirs, base_mod=mod))
+        elif ext in (".py", ""):
+            tests.append(f"{base_mod}.{mod}" if base_mod else mod)
+    return sorted(tests)
 
 
 def get_abs_module(ns: Namespace, test_name: str) -> str:

--- a/Lib/test/test_peg_generator/__init__.py
+++ b/Lib/test/test_peg_generator/__init__.py
@@ -4,8 +4,10 @@ from test import support
 from test.support import load_package_tests
 
 
-# Creating a virtual environment and building C extensions is slow
-support.requires('cpu')
+if support.check_sanitizer(address=True, memory=True):
+    # gh-90791: Skip the test because it is too slow when Python is built
+    # with ASAN/MSAN: between 5 and 20 minutes on GitHub Actions.
+    raise unittest.SkipTest("test too slow on ASAN/MSAN build")
 
 
 # Load all tests in package

--- a/Lib/test/test_tools/__init__.py
+++ b/Lib/test/test_tools/__init__.py
@@ -7,6 +7,12 @@ from test import support
 from test.support import import_helper
 
 
+if support.check_sanitizer(address=True, memory=True):
+    # gh-90791: Skip the test because it is too slow when Python is built
+    # with ASAN/MSAN: between 5 and 20 minutes on GitHub Actions.
+    raise unittest.SkipTest("test too slow on ASAN/MSAN build")
+
+
 if not support.has_subprocess_support:
     raise unittest.SkipTest("test module requires subprocess")
 

--- a/Lib/test/test_tools/test_freeze.py
+++ b/Lib/test/test_tools/test_freeze.py
@@ -18,9 +18,6 @@ with imports_under_tool('freeze', 'test'):
 class TestFreeze(unittest.TestCase):
 
     def test_freeze_simple_script(self):
-        # Building Python is slow
-        support.requires('cpu')
-
         script = textwrap.dedent("""
             import sys
             print('running...')

--- a/Misc/NEWS.d/next/Tests/2023-08-24-02-36-15.gh-issue-108388.Z08JFZ.rst
+++ b/Misc/NEWS.d/next/Tests/2023-08-24-02-36-15.gh-issue-108388.Z08JFZ.rst
@@ -1,0 +1,3 @@
+The Python test suite (regrtest) now runs the 20 slowest tests first and
+then other tests, to better use all available CPUs when running tests in
+parallel. Patch Victor Stinner.


### PR DESCRIPTION
The Python test suite (regrtest) now runs the 20 slowest tests first and
then other tests, to better use all available CPUs when running tests in
parallel.

**XXX: for tests, the PR also reverts the commit 7a6cc3eb66805e6515d5db5b79e58e2f76b550c8.**

<!-- gh-issue-number: gh-108388 -->
* Issue: gh-108388
<!-- /gh-issue-number -->
