### PR TITLE
Add more detail on the document of add_signal_handler 

### DIFF
--- a/Doc/library/asyncio-eventloop.rst
+++ b/Doc/library/asyncio-eventloop.rst
@@ -1193,7 +1193,7 @@ Unix signals
 
 .. method:: loop.add_signal_handler(signum, callback, *args)
 
-   Set *callback* as the handler for the *signum* signal.
+   Set or overwrite *callback* as the handler for the *signum* signal.
 
    The callback will be invoked by *loop*, along with other queued callbacks
    and runnable coroutines of that event loop. Unlike signal handlers


### PR DESCRIPTION
I think that the document describes that `add_signal_handler` overwrites the previous handler is more helpful.

<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--108395.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->