### PR TITLE
gh-108394: Fix subclassing annotated generic alias

### DIFF
--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -8490,6 +8490,24 @@ class AnnotatedTests(BaseTestCase):
         class Y2(Annotated[List[int], 'meta']): ...
         self.assertEqual(Y2.__mro__, (Y2, list, Generic, object))
 
+        class Y3(
+            Annotated[
+                Annotated[
+                    list[
+                        Annotated[
+                            list[
+                                Annotated[int, 'm'],
+                            ],
+                            'm',
+                        ],
+                    ],
+                    'm',
+                ],
+                'm',
+            ],
+        ): ...
+        self.assertEqual(Y3.__mro__, (Y3, list, object))
+
         T = TypeVar('T')
         class GenericBase(Generic[T]): ...
         class Mixin: ...

--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -8484,6 +8484,23 @@ class AnnotatedTests(BaseTestCase):
         self.assertEqual(X.__mro__, (X, int, object),
                          "Annotated should be transparent.")
 
+        class Y1(Annotated[list[int], 'meta']): ...
+        self.assertEqual(Y1.__mro__, (Y1, list, object))
+
+        class Y2(Annotated[List[int], 'meta']): ...
+        self.assertEqual(Y2.__mro__, (Y2, list, Generic, object))
+
+        T = TypeVar('T')
+        class GenericBase(Generic[T]): ...
+        class Mixin: ...
+        class Z(Annotated[GenericBase[int], 'meta'], Mixin): ...
+        self.assertEqual(Z.__mro__, (Z, GenericBase, Generic, Mixin, object))
+
+        # Errors:
+        A1 = Annotated[Literal[1], 'meta']
+        with self.assertRaisesRegex(TypeError, 'Cannot subclass typing.Literal'):
+            class C1(A1): ...
+
 
 class TypeAliasTests(BaseTestCase):
     def test_canonical_usage_with_variable_annotation(self):

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -1137,7 +1137,11 @@ class _BaseGenericAlias(_Final, _root=True):
         res = []
         if self.__origin__ not in bases:
             res.append(self.__origin__)
-        i = bases.index(self)
+        try:
+            i = bases.index(self)
+        except ValueError:
+            # It might not be there, if `Annotated[]` is used:
+            i = 0
         for b in bases[i+1:]:
             if isinstance(b, _BaseGenericAlias) or issubclass(b, Generic):
                 break
@@ -1998,6 +2002,8 @@ class _AnnotatedAlias(_NotIterable, _GenericAlias, _root=True):
         return super().__getattr__(attr)
 
     def __mro_entries__(self, bases):
+        if isinstance(self.__origin__, (_GenericAlias, GenericAlias)):
+            return self.__origin__.__mro_entries__(bases)
         return (self.__origin__,)
 
 

--- a/Misc/NEWS.d/next/Library/2023-08-24-11-40-06.gh-issue-108394.V072CN.rst
+++ b/Misc/NEWS.d/next/Library/2023-08-24-11-40-06.gh-issue-108394.V072CN.rst
@@ -1,0 +1,1 @@
+Fix subclassing annotated generic aliases.


### PR DESCRIPTION
I've decided to go in a different direction from the one suggested by @eltoder

Now, we reuse all `__mro__` logic from generic aliases.

<!-- gh-issue-number: gh-108394 -->
* Issue: gh-108394
<!-- /gh-issue-number -->
