### PR TITLE
[3.11] Revert "gh-46376: Return existing pointer when possible in ctypes (GH-107131) (GH-107488)"

### DIFF
--- a/Lib/ctypes/test/test_keeprefs.py
+++ b/Lib/ctypes/test/test_keeprefs.py
@@ -93,33 +93,6 @@ class PointerTestCase(unittest.TestCase):
         x = pointer(i)
         self.assertEqual(x._objects, {'1': i})
 
-    def test_pp_ownership(self):
-        d = c_int(123)
-        n = c_int(456)
-
-        p = pointer(d)
-        pp = pointer(p)
-
-        self.assertIs(pp._objects['1'], p)
-        self.assertIs(pp._objects['0']['1'], d)
-
-        pp.contents.contents = n
-
-        self.assertIs(pp._objects['1'], p)
-        self.assertIs(pp._objects['0']['1'], n)
-
-        self.assertIs(p._objects['1'], n)
-        self.assertEqual(len(p._objects), 1)
-
-        del d
-        del p
-
-        self.assertIs(pp._objects['0']['1'], n)
-        self.assertEqual(len(pp._objects), 2)
-
-        del n
-
-        self.assertEqual(len(pp._objects), 2)
 
 class PointerToStructure(unittest.TestCase):
     def test(self):

--- a/Misc/NEWS.d/next/Library/2023-07-24-01-21-16.gh-issue-46376.w-xuDL.rst
+++ b/Misc/NEWS.d/next/Library/2023-07-24-01-21-16.gh-issue-46376.w-xuDL.rst
@@ -1,1 +1,0 @@
-Prevent memory leak and use-after-free when using pointers to pointers with ctypes

--- a/Modules/_ctypes/_ctypes.c
+++ b/Modules/_ctypes/_ctypes.c
@@ -5158,8 +5158,6 @@ static PyObject *
 Pointer_get_contents(CDataObject *self, void *closure)
 {
     StgDictObject *stgdict;
-    PyObject *keep, *ptr_probe;
-    CDataObject *ptr2ptr;
 
     if (*(void **)self->b_ptr == NULL) {
         PyErr_SetString(PyExc_ValueError,
@@ -5169,33 +5167,6 @@ Pointer_get_contents(CDataObject *self, void *closure)
 
     stgdict = PyObject_stgdict((PyObject *)self);
     assert(stgdict); /* Cannot be NULL for pointer instances */
-
-    keep = GetKeepedObjects(self);
-    if (keep != NULL) {
-        // check if it's a pointer to a pointer:
-        // pointers will have '0' key in the _objects
-        ptr_probe = PyDict_GetItemString(keep, "0");
-
-        if (ptr_probe != NULL) {
-            ptr2ptr = (CDataObject*) PyDict_GetItemString(keep, "1");
-            if (ptr2ptr ==  NULL) {
-                PyErr_SetString(PyExc_ValueError,
-                "Unexpected NULL pointer in _objects");
-                return NULL;
-            }
-            // don't construct a new object,
-            // return existing one instead to preserve refcount
-            assert(
-                *(void**) self->b_ptr == ptr2ptr->b_ptr ||
-                *(void**) self->b_value.c == ptr2ptr->b_ptr ||
-                *(void**) self->b_ptr == ptr2ptr->b_value.c ||
-                *(void**) self->b_value.c == ptr2ptr->b_value.c
-            ); // double-check that we are returning the same thing
-            Py_INCREF(ptr2ptr);
-            return (PyObject *) ptr2ptr;
-        }
-    }
-
     return PyCData_FromBaseObj(stgdict->proto,
                              (PyObject *)self, 0,
                              *(void **)self->b_ptr);


### PR DESCRIPTION
This reverts commit 57f27e444175a8a5ffcd86971e06de61c1c38628.

The fix caused gh-107940. Until we have a bulletproof fix for that, the 3.11 backport needs to be reverted to make way for 3.11.5. 

<!-- gh-issue-number: gh-46376 -->
* Issue: gh-46376
<!-- /gh-issue-number -->
