### PR TITLE
gh-106102: Fix MRO resolution for nested generic classes

### DIFF
--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -4804,11 +4804,85 @@ class GenericTests(BaseTestCase):
 
         self.assertEqual(C.__parameters__, (VT, T, KT))
 
+    def test_multiple_inheritance_multiple_layers(self):
+        S = TypeVar('S')
+        class GenericMixin(Generic[S]): ...
+        class GenericBase(Generic[S]): ...
+        class FromGenericAlias(GenericBase[S]): ...
+        class FromConcreteGenericAlias(GenericBase[int]): ...
+
+        # Generic is second:
+        class A1(FromGenericAlias, Generic[S]): ...
+        self.assertEqual(A1.__mro__,
+                         (A1, FromGenericAlias, GenericBase, Generic, object))
+
+        class A2(FromGenericAlias[S], Generic[S]): ...
+        self.assertEqual(A2.__mro__,
+                         (A2, FromGenericAlias, GenericBase, Generic, object))
+
+        class A3(FromGenericAlias[int], Generic[S]): ...
+        self.assertEqual(A3.__mro__,
+                         (A3, FromGenericAlias, GenericBase, Generic, object))
+
+        class A4(FromConcreteGenericAlias, Generic[S]): ...
+        self.assertEqual(A4.__mro__,
+                         (A4, FromConcreteGenericAlias, GenericBase, Generic, object))
+
+        class A5(FromGenericAlias[S], GenericMixin[S], Generic[S]): ...
+        self.assertEqual(A5.__mro__,
+                         (A5, FromGenericAlias, GenericBase, GenericMixin, Generic, object))
+
+        # Generic is first:
+        class B1(Generic[S], FromGenericAlias): ...
+        self.assertEqual(B1.__mro__,
+                         (B1, FromGenericAlias, GenericBase, Generic, object))
+
+        class B2(Generic[S], FromGenericAlias[S]): ...
+        self.assertEqual(B2.__mro__,
+                         (B2, FromGenericAlias, GenericBase, Generic, object))
+
+        class B3(Generic[S], FromGenericAlias[int]): ...
+        self.assertEqual(B3.__mro__,
+                         (B3, FromGenericAlias, GenericBase, Generic, object))
+
+        class B4(Generic[S], FromConcreteGenericAlias): ...
+        self.assertEqual(B4.__mro__,
+                         (B4, FromConcreteGenericAlias, GenericBase, Generic, object))
+
+        class B5(FromGenericAlias[S], GenericMixin[S], Generic[S]): ...
+        self.assertEqual(B5.__mro__,
+                         (B5, FromGenericAlias, GenericBase, GenericMixin, Generic, object))
+
     def test_multiple_inheritance_special(self):
         S = TypeVar('S')
         class B(Generic[S]): ...
         class C(List[int], B): ...
         self.assertEqual(C.__mro__, (C, list, B, Generic, object))
+
+    def test_multiple_inheritance_special_multiple_layers(self):
+        S = TypeVar('S')
+        class L(List[S]): ...
+        class M(Generic[S]): ...
+
+        # Direct subclasses:
+        class D1(List[S], Generic[S]): ...
+        self.assertEqual(D1.__mro__, (D1, list, Generic, object))
+
+        class D2(Generic[S], List[S]): ...
+        self.assertEqual(D2.__mro__, (D2, list, Generic, object))
+
+        # Nested subclasses:
+        class L1(L[S], Generic[S]): ...
+        self.assertEqual(L1.__mro__, (L1, L, list, Generic, object))
+
+        class L2(Generic[S], L[S]): ...
+        self.assertEqual(L2.__mro__, (L2, L, list, Generic, object))
+
+        class L3(L[S], M[S], Generic[S]): ...
+        self.assertEqual(L3.__mro__, (L3, L, list, M, Generic, object))
+
+        class L4(Generic[S], L[S], M[S]): ...
+        self.assertEqual(L4.__mro__, (L4, L, list, M, Generic, object))
 
     def test_init_subclass_super_called(self):
         class FinalException(Exception):

--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -4862,6 +4862,7 @@ class GenericTests(BaseTestCase):
     def test_multiple_inheritance_special_multiple_layers(self):
         S = TypeVar('S')
         class L(List[S]): ...
+        class G(list[S]): ...
         class M(Generic[S]): ...
 
         # Direct subclasses:
@@ -4883,6 +4884,18 @@ class GenericTests(BaseTestCase):
 
         class L4(Generic[S], L[S], M[S]): ...
         self.assertEqual(L4.__mro__, (L4, L, list, M, Generic, object))
+
+        class G1(G[S], Generic[S]): ...
+        self.assertEqual(G1.__mro__, (G1, G, list, Generic, object))
+
+        class G2(Generic[S], G[S]): ...
+        self.assertEqual(G2.__mro__, (G2, Generic, G, list, object))
+
+        class G3(G[S], M[S], Generic[S]): ...
+        self.assertEqual(G3.__mro__, (G3, G, list, M, Generic, object))
+
+        class G4(Generic[S], G[S], M[S]): ...
+        self.assertEqual(G4.__mro__, (G4, G, list, M, Generic, object))
 
     def test_init_subclass_super_called(self):
         class FinalException(Exception):

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -1393,11 +1393,12 @@ class _GenericAlias(_BaseGenericAlias, _root=True):
                 return ()
             i = bases.index(self)
             for b in bases[i+1:]:
-                if (
-                    (isinstance(b, _BaseGenericAlias)
-                        or Generic in getattr(b, '__mro__', ()))
-                    and b is not self
-                ):
+                if b is self:
+                    continue
+                if isinstance(b, _BaseGenericAlias):
+                    return ()
+                if isinstance(b, type) and issubclass(b, Generic):
+                    return ()
                     return ()
         return (self.__origin__,)
 

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -1393,7 +1393,11 @@ class _GenericAlias(_BaseGenericAlias, _root=True):
                 return ()
             i = bases.index(self)
             for b in bases[i+1:]:
-                if isinstance(b, _BaseGenericAlias) and b is not self:
+                if (
+                    (isinstance(b, _BaseGenericAlias)
+                        or Generic in getattr(b, '__mro__', ()))
+                    and b is not self
+                ):
                     return ()
         return (self.__origin__,)
 

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -1399,7 +1399,6 @@ class _GenericAlias(_BaseGenericAlias, _root=True):
                     return ()
                 if isinstance(b, type) and issubclass(b, Generic):
                     return ()
-                    return ()
         return (self.__origin__,)
 
     def __iter__(self):

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -1397,7 +1397,7 @@ class _GenericAlias(_BaseGenericAlias, _root=True):
                     continue
                 if isinstance(b, _BaseGenericAlias):
                     return ()
-                if isinstance(b, type) and issubclass(b, Generic):
+                if Generic in getattr(b, '__mro__', ()):
                     return ()
         return (self.__origin__,)
 

--- a/Misc/NEWS.d/next/Library/2023-08-24-14-50-22.gh-issue-106102.tPC0HR.rst
+++ b/Misc/NEWS.d/next/Library/2023-08-24-14-50-22.gh-issue-106102.tPC0HR.rst
@@ -1,0 +1,1 @@
+Fix mro resolution for nested generic classes.


### PR DESCRIPTION
I went with `Generic in getattr(...)`, because not all types are safe with `issubclass`, some of them might raise `TypeError` there.

<!-- gh-issue-number: gh-106102 -->
* Issue: gh-106102
<!-- /gh-issue-number -->
