### PR TITLE
gh-107211: No longer export internal functions (6)

### DIFF
--- a/Include/internal/pycore_interp.h
+++ b/Include/internal/pycore_interp.h
@@ -243,40 +243,40 @@ extern void _PyInterpreterState_IDDecref(PyInterpreterState *);
 
 extern const PyConfig* _PyInterpreterState_GetConfig(PyInterpreterState *interp);
 
-/* Get a copy of the current interpreter configuration.
-
-   Return 0 on success. Raise an exception and return -1 on error.
-
-   The caller must initialize 'config', using PyConfig_InitPythonConfig()
-   for example.
-
-   Python must be preinitialized to call this method.
-   The caller must hold the GIL.
-
-   Once done with the configuration, PyConfig_Clear() must be called to clear
-   it.
-
-   Export for '_testinternalcapi' shared extension. */
+// Get a copy of the current interpreter configuration.
+//
+// Return 0 on success. Raise an exception and return -1 on error.
+//
+// The caller must initialize 'config', using PyConfig_InitPythonConfig()
+// for example.
+//
+// Python must be preinitialized to call this method.
+// The caller must hold the GIL.
+//
+// Once done with the configuration, PyConfig_Clear() must be called to clear
+// it.
+//
+// Export for '_testinternalcapi' shared extension.
 PyAPI_FUNC(int) _PyInterpreterState_GetConfigCopy(
     struct PyConfig *config);
 
-/* Set the configuration of the current interpreter.
-
-   This function should be called during or just after the Python
-   initialization.
-
-   Update the sys module with the new configuration. If the sys module was
-   modified directly after the Python initialization, these changes are lost.
-
-   Some configuration like faulthandler or warnoptions can be updated in the
-   configuration, but don't reconfigure Python (don't enable/disable
-   faulthandler and don't reconfigure warnings filters).
-
-   Return 0 on success. Raise an exception and return -1 on error.
-
-   The configuration should come from _PyInterpreterState_GetConfigCopy().
-
-   Export for '_testinternalcapi' shared extension. */
+// Set the configuration of the current interpreter.
+//
+// This function should be called during or just after the Python
+// initialization.
+//
+// Update the sys module with the new configuration. If the sys module was
+// modified directly after the Python initialization, these changes are lost.
+//
+// Some configuration like faulthandler or warnoptions can be updated in the
+// configuration, but don't reconfigure Python (don't enable/disable
+// faulthandler and don't reconfigure warnings filters).
+//
+// Return 0 on success. Raise an exception and return -1 on error.
+//
+// The configuration should come from _PyInterpreterState_GetConfigCopy().
+//
+// Export for '_testinternalcapi' shared extension.
 PyAPI_FUNC(int) _PyInterpreterState_SetConfig(
     const struct PyConfig *config);
 

--- a/Include/internal/pycore_long.h
+++ b/Include/internal/pycore_long.h
@@ -83,7 +83,6 @@ extern PyObject *_PyLong_Add(PyLongObject *left, PyLongObject *right);
 extern PyObject *_PyLong_Multiply(PyLongObject *left, PyLongObject *right);
 extern PyObject *_PyLong_Subtract(PyLongObject *left, PyLongObject *right);
 
-// Used by _PyBytes_FromHex(), _PyBytes_DecodeEscape(), Python/mystrtoul.c.
 // Export for 'binascii' shared extension.
 PyAPI_DATA(unsigned char) _PyLong_DigitValue[256];
 

--- a/Include/internal/pycore_object.h
+++ b/Include/internal/pycore_object.h
@@ -54,7 +54,7 @@ PyAPI_FUNC(int) _PyObject_IsFreed(PyObject *);
         .ob_size = size                       \
     },
 
-PyAPI_FUNC(void) _Py_NO_RETURN _Py_FatalRefcountErrorFunc(
+extern void _Py_NO_RETURN _Py_FatalRefcountErrorFunc(
     const char *func,
     const char *message);
 
@@ -469,13 +469,11 @@ extern PyObject* _PyCFunctionWithKeywords_TrampolineCall(
     (meth)((self), (args), (kw))
 #endif // __EMSCRIPTEN__ && PY_CALL_TRAMPOLINE
 
-// Export for '_pickle' shared extension
+// Export these 2 symbols for '_pickle' shared extension
 PyAPI_DATA(PyTypeObject) _PyNone_Type;
-// Export for '_pickle' shared extension
 PyAPI_DATA(PyTypeObject) _PyNotImplemented_Type;
 
 // Maps Py_LT to Py_GT, ..., Py_GE to Py_LE.
-// Defined in Objects/object.c.
 // Export for the stable ABI.
 PyAPI_DATA(int) _Py_SwappedOp[];
 

--- a/Include/internal/pycore_obmalloc.h
+++ b/Include/internal/pycore_obmalloc.h
@@ -687,7 +687,7 @@ extern void _PyInterpreterState_FinalizeAllocatedBlocks(PyInterpreterState *);
 
 
 #ifdef WITH_PYMALLOC
-// Export the symbol for the 3rd party guppy3 project
+// Export the symbol for the 3rd party 'guppy3' project
 PyAPI_FUNC(int) _PyObject_DebugMallocStats(FILE *out);
 #endif
 

--- a/Include/internal/pycore_pathconfig.h
+++ b/Include/internal/pycore_pathconfig.h
@@ -10,6 +10,7 @@ extern "C" {
 
 // Export for '_testinternalcapi' shared extension
 PyAPI_FUNC(void) _PyPathConfig_ClearGlobal(void);
+
 extern PyStatus _PyPathConfig_ReadGlobal(PyConfig *config);
 extern PyStatus _PyPathConfig_UpdateGlobal(const PyConfig *config);
 extern const wchar_t * _PyPathConfig_GetGlobalModuleSearchPath(void);

--- a/Include/internal/pycore_pyarena.h
+++ b/Include/internal/pycore_pyarena.h
@@ -37,8 +37,8 @@ typedef struct _arena PyArena;
    XXX block_new(DEFAULT_BLOCK_SIZE) returns NULL, that's passed on but
    XXX an exception is not set in that case).
 */
-PyAPI_FUNC(PyArena*) _PyArena_New(void);
-PyAPI_FUNC(void) _PyArena_Free(PyArena *);
+extern PyArena* _PyArena_New(void);
+extern void _PyArena_Free(PyArena *);
 
 /* Mostly like malloc(), return the address of a block of memory spanning
  * `size` bytes, or return NULL (without setting an exception) if enough
@@ -52,13 +52,13 @@ PyAPI_FUNC(void) _PyArena_Free(PyArena *);
  * until _PyArena_Free(ar) is called, at which point all pointers obtained
  * from the arena `ar` become invalid simultaneously.
  */
-PyAPI_FUNC(void*) _PyArena_Malloc(PyArena *, size_t size);
+extern void* _PyArena_Malloc(PyArena *, size_t size);
 
 /* This routine isn't a proper arena allocation routine.  It takes
  * a PyObject* and records it so that it can be DECREFed when the
  * arena is freed.
  */
-PyAPI_FUNC(int) _PyArena_AddPyObject(PyArena *, PyObject *);
+extern int _PyArena_AddPyObject(PyArena *, PyObject *);
 
 #ifdef __cplusplus
 }

--- a/Include/internal/pycore_pyerrors.h
+++ b/Include/internal/pycore_pyerrors.h
@@ -152,6 +152,7 @@ extern int _PyErr_CheckSignalsTstate(PyThreadState *tstate);
 extern void _Py_DumpExtensionModules(int fd, PyInterpreterState *interp);
 extern PyObject* _Py_CalculateSuggestions(PyObject *dir, PyObject *name);
 extern PyObject* _Py_Offer_Suggestions(PyObject* exception);
+
 // Export for '_testinternalcapi' shared extension
 PyAPI_FUNC(Py_ssize_t) _Py_UTF8_Edit_Cost(PyObject *str_a, PyObject *str_b,
                                           Py_ssize_t max_cost);

--- a/Include/internal/pycore_pyhash.h
+++ b/Include/internal/pycore_pyhash.h
@@ -7,11 +7,14 @@
 
 /* Helpers for hash functions */
 extern Py_hash_t _Py_HashDouble(PyObject *, double);
-// _decimal shared extensions uses _Py_HashPointer()
+
+// Export for '_decimal' shared extension
 PyAPI_FUNC(Py_hash_t) _Py_HashPointer(const void*);
+
 // Similar to _Py_HashPointer(), but don't replace -1 with -2
 extern Py_hash_t _Py_HashPointerRaw(const void*);
-// _datetime shared extension uses _Py_HashBytes()
+
+// Export for '_datetime' shared extension
 PyAPI_FUNC(Py_hash_t) _Py_HashBytes(const void*, Py_ssize_t);
 
 /* Prime multiplier used in string and various other hashes. */


### PR DESCRIPTION
No longer export these 5 internal C API functions:

* _PyArena_AddPyObject()
* _PyArena_Free()
* _PyArena_Malloc()
* _PyArena_New()
* _Py_FatalRefcountErrorFunc()

Change comment style to "// comment" and add comment explaining why other functions have to be exported.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-107211 -->
* Issue: gh-107211
<!-- /gh-issue-number -->
