### PR TITLE
gh-106320: Remove private float C API functions

### DIFF
--- a/Include/internal/pycore_floatobject.h
+++ b/Include/internal/pycore_floatobject.h
@@ -67,6 +67,13 @@ extern int _PyFloat_FormatAdvancedWriter(
     Py_ssize_t start,
     Py_ssize_t end);
 
+extern PyObject* _Py_string_to_number_with_underscores(
+    const char *str, Py_ssize_t len, const char *what, PyObject *obj, void *arg,
+    PyObject *(*innerfunc)(const char *, Py_ssize_t, void *));
+
+extern double _Py_parse_inf_or_nan(const char *p, char **endptr);
+
+
 #ifdef __cplusplus
 }
 #endif

--- a/Include/pystrtod.h
+++ b/Include/pystrtod.h
@@ -18,15 +18,6 @@ PyAPI_FUNC(char *) PyOS_double_to_string(double val,
                                          int flags,
                                          int *type);
 
-#ifndef Py_LIMITED_API
-PyAPI_FUNC(PyObject *) _Py_string_to_number_with_underscores(
-    const char *str, Py_ssize_t len, const char *what, PyObject *obj, void *arg,
-    PyObject *(*innerfunc)(const char *, Py_ssize_t, void *));
-
-PyAPI_FUNC(double) _Py_parse_inf_or_nan(const char *p, char **endptr);
-#endif
-
-
 /* PyOS_double_to_string's "flags" parameter can be set to 0 or more of: */
 #define Py_DTSF_SIGN      0x01 /* always add the sign */
 #define Py_DTSF_ADD_DOT_0 0x02 /* if the result is an integer add ".0" */


### PR DESCRIPTION
Remove private C API functions:

* _Py_parse_inf_or_nan()
* _Py_string_to_number_with_underscores()

Move these functions to the internal C API and no longer export them.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-106320 -->
* Issue: gh-106320
<!-- /gh-issue-number -->
