### PR TITLE
gh-80527: Change support.requires_legacy_unicode_capi()

### DIFF
--- a/Lib/test/support/__init__.py
+++ b/Lib/test/support/__init__.py
@@ -21,11 +21,6 @@ import warnings
 from .testresult import get_test_runner
 
 
-try:
-    from _testcapi import unicode_legacy_string
-except ImportError:
-    unicode_legacy_string = None
-
 __all__ = [
     # globals
     "PIPE_MAX_SIZE", "verbose", "max_memuse", "use_resources", "failfast",
@@ -507,8 +502,14 @@ def has_no_debug_ranges():
 def requires_debug_ranges(reason='requires co_positions / debug_ranges'):
     return unittest.skipIf(has_no_debug_ranges(), reason)
 
-requires_legacy_unicode_capi = unittest.skipUnless(unicode_legacy_string,
-                        'requires legacy Unicode C API')
+def requires_legacy_unicode_capi():
+    try:
+        from _testcapi import unicode_legacy_string
+    except ImportError:
+        unicode_legacy_string = None
+
+    return unittest.skipUnless(unicode_legacy_string,
+                               'requires legacy Unicode C API')
 
 # Is not actually used in tests, but is kept for compatibility.
 is_jython = sys.platform.startswith('java')

--- a/Lib/test/test_capi/test_getargs.py
+++ b/Lib/test/test_capi/test_getargs.py
@@ -1004,7 +1004,7 @@ class String_TestCase(unittest.TestCase):
         buf = bytearray()
         self.assertRaises(ValueError, getargs_et_hash, 'abc\xe9', 'latin1', buf)
 
-    @support.requires_legacy_unicode_capi
+    @support.requires_legacy_unicode_capi()
     def test_u(self):
         from _testcapi import getargs_u
         with self.assertWarns(DeprecationWarning):
@@ -1020,7 +1020,7 @@ class String_TestCase(unittest.TestCase):
         with self.assertWarns(DeprecationWarning):
             self.assertRaises(TypeError, getargs_u, None)
 
-    @support.requires_legacy_unicode_capi
+    @support.requires_legacy_unicode_capi()
     def test_u_hash(self):
         from _testcapi import getargs_u_hash
         with self.assertWarns(DeprecationWarning):
@@ -1036,7 +1036,7 @@ class String_TestCase(unittest.TestCase):
         with self.assertWarns(DeprecationWarning):
             self.assertRaises(TypeError, getargs_u_hash, None)
 
-    @support.requires_legacy_unicode_capi
+    @support.requires_legacy_unicode_capi()
     def test_Z(self):
         from _testcapi import getargs_Z
         with self.assertWarns(DeprecationWarning):
@@ -1052,7 +1052,7 @@ class String_TestCase(unittest.TestCase):
         with self.assertWarns(DeprecationWarning):
             self.assertIsNone(getargs_Z(None))
 
-    @support.requires_legacy_unicode_capi
+    @support.requires_legacy_unicode_capi()
     def test_Z_hash(self):
         from _testcapi import getargs_Z_hash
         with self.assertWarns(DeprecationWarning):

--- a/Lib/test/test_csv.py
+++ b/Lib/test/test_csv.py
@@ -282,7 +282,7 @@ class Test_Csv(unittest.TestCase):
             self.assertRaises(OSError, writer.writerows, BadIterable())
 
     @support.cpython_only
-    @support.requires_legacy_unicode_capi
+    @support.requires_legacy_unicode_capi()
     @warnings_helper.ignore_warnings(category=DeprecationWarning)
     def test_writerows_legacy_strings(self):
         import _testcapi

--- a/Lib/test/test_decimal.py
+++ b/Lib/test/test_decimal.py
@@ -588,7 +588,7 @@ class ExplicitConstructionTest:
             self.assertRaises(InvalidOperation, Decimal, "1_2_\u00003")
 
     @cpython_only
-    @requires_legacy_unicode_capi
+    @requires_legacy_unicode_capi()
     @warnings_helper.ignore_warnings(category=DeprecationWarning)
     def test_from_legacy_strings(self):
         import _testcapi
@@ -2920,7 +2920,7 @@ class ContextAPItests:
                                               Overflow])
 
     @cpython_only
-    @requires_legacy_unicode_capi
+    @requires_legacy_unicode_capi()
     @warnings_helper.ignore_warnings(category=DeprecationWarning)
     def test_from_legacy_strings(self):
         import _testcapi

--- a/Lib/test/test_str.py
+++ b/Lib/test/test_str.py
@@ -813,7 +813,7 @@ class StrTest(string_tests.StringLikeTest,
         self.assertFalse("0".isidentifier())
 
     @support.cpython_only
-    @support.requires_legacy_unicode_capi
+    @support.requires_legacy_unicode_capi()
     @unittest.skipIf(_testcapi is None, 'need _testcapi module')
     def test_isidentifier_legacy(self):
         u = '𝖀𝖓𝖎𝖈𝖔𝖉𝖊'
@@ -2490,7 +2490,7 @@ class StrTest(string_tests.StringLikeTest,
         self.assertEqual(len(args), 1)
 
     @support.cpython_only
-    @support.requires_legacy_unicode_capi
+    @support.requires_legacy_unicode_capi()
     @unittest.skipIf(_testcapi is None, 'need _testcapi module')
     def test_resize(self):
         for length in range(1, 100, 7):


### PR DESCRIPTION
The decorator now requires to be called:

    @support.requires_legacy_unicode_capi()

instead of:

    @support.requires_legacy_unicode_capi

The implementation now only imports _testcapi when the decorator is called, so "import test.support" no longer imports the _testcapi extension.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-80527 -->
* Issue: gh-80527
<!-- /gh-issue-number -->
