### PR TITLE
gh-107149: Rename _PyUnstable_GetUnaryIntrinsicName() function

### DIFF
--- a/Include/cpython/compile.h
+++ b/Include/cpython/compile.h
@@ -78,5 +78,5 @@ PyAPI_FUNC(int) PyUnstable_OpcodeHasFree(int opcode);
 PyAPI_FUNC(int) PyUnstable_OpcodeHasLocal(int opcode);
 PyAPI_FUNC(int) PyUnstable_OpcodeHasExc(int opcode);
 
-PyAPI_FUNC(PyObject*) _PyUnstable_GetUnaryIntrinsicName(int index);
-PyAPI_FUNC(PyObject*) _PyUnstable_GetBinaryIntrinsicName(int index);
+PyAPI_FUNC(PyObject*) PyUnstable_GetUnaryIntrinsicName(int index);
+PyAPI_FUNC(PyObject*) PyUnstable_GetBinaryIntrinsicName(int index);

--- a/Modules/_opcode.c
+++ b/Modules/_opcode.c
@@ -310,7 +310,7 @@ _opcode_get_intrinsic1_descs_impl(PyObject *module)
         return NULL;
     }
     for (int i=0; i <= MAX_INTRINSIC_1; i++) {
-        PyObject *name = _PyUnstable_GetUnaryIntrinsicName(i);
+        PyObject *name = PyUnstable_GetUnaryIntrinsicName(i);
         if (name == NULL) {
             Py_DECREF(list);
             return NULL;
@@ -337,7 +337,7 @@ _opcode_get_intrinsic2_descs_impl(PyObject *module)
         return NULL;
     }
     for (int i=0; i <= MAX_INTRINSIC_2; i++) {
-        PyObject *name = _PyUnstable_GetBinaryIntrinsicName(i);
+        PyObject *name = PyUnstable_GetBinaryIntrinsicName(i);
         if (name == NULL) {
             Py_DECREF(list);
             return NULL;

--- a/Python/intrinsics.c
+++ b/Python/intrinsics.c
@@ -268,7 +268,7 @@ _PyIntrinsics_BinaryFunctions[] = {
 #undef INTRINSIC_FUNC_ENTRY
 
 PyObject*
-_PyUnstable_GetUnaryIntrinsicName(int index)
+PyUnstable_GetUnaryIntrinsicName(int index)
 {
     if (index < 0 || index > MAX_INTRINSIC_1) {
         return NULL;
@@ -277,7 +277,7 @@ _PyUnstable_GetUnaryIntrinsicName(int index)
 }
 
 PyObject*
-_PyUnstable_GetBinaryIntrinsicName(int index)
+PyUnstable_GetBinaryIntrinsicName(int index)
 {
     if (index < 0 || index > MAX_INTRINSIC_2) {
         return NULL;


### PR DESCRIPTION
* Rename _PyUnstable_GetUnaryIntrinsicName() to PyUnstable_GetUnaryIntrinsicName()
* Rename _PyUnstable_GetBinaryIntrinsicName() to PyUnstable_GetBinaryIntrinsicName().

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-107149 -->
* Issue: gh-107149
<!-- /gh-issue-number -->
