### PR TITLE
Run `mypy` when `Tools/requirements-dev.txt` changes

### DIFF
--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -9,6 +9,7 @@ on:
     paths:
       - "Tools/clinic/**"
       - "Tools/cases_generator/**"
+      - "Tools/requirements-dev.txt"
       - ".github/workflows/mypy.yml"
   workflow_dispatch:
 


### PR DESCRIPTION
Right now changing `Tools/requirements-dev.txt` won't trigger `mypy` workflow. But, it must be triggered.