### PR TITLE
Docs: Resolve Sphinx warnings in dis.rst

### DIFF
--- a/Doc/library/dis.rst
+++ b/Doc/library/dis.rst
@@ -43,13 +43,13 @@ interpreter.
       adaptive bytecode can be shown by passing ``adaptive=True``.
 
 
-Example: Given the function :func:`myfunc`::
+Example: Given the function :func:`!myfunc`::
 
    def myfunc(alist):
        return len(alist)
 
 the following command can be used to display the disassembly of
-:func:`myfunc`:
+:func:`!myfunc`:
 
 .. doctest::
 
@@ -851,7 +851,7 @@ iterations of the loop.
 
 .. opcode:: LOAD_BUILD_CLASS
 
-   Pushes :func:`builtins.__build_class__` onto the stack.  It is later called
+   Pushes :func:`!builtins.__build_class__` onto the stack.  It is later called
    to construct a class.
 
 
@@ -909,14 +909,14 @@ iterations of the loop.
 .. opcode:: STORE_NAME (namei)
 
    Implements ``name = STACK.pop()``. *namei* is the index of *name* in the attribute
-   :attr:`co_names` of the code object. The compiler tries to use
-   :opcode:`STORE_FAST` or :opcode:`STORE_GLOBAL` if possible.
+   :attr:`!co_names` of the :ref:`code object <code-objects>`.
+   The compiler tries to use :opcode:`STORE_FAST` or :opcode:`STORE_GLOBAL` if possible.
 
 
 .. opcode:: DELETE_NAME (namei)
 
-   Implements ``del name``, where *namei* is the index into :attr:`co_names`
-   attribute of the code object.
+   Implements ``del name``, where *namei* is the index into :attr:`!co_names`
+   attribute of the :ref:`code object <code-objects>`.
 
 
 .. opcode:: UNPACK_SEQUENCE (count)
@@ -955,7 +955,8 @@ iterations of the loop.
       value = STACK.pop()
       obj.name = value
 
-   where *namei* is the index of name in :attr:`co_names`.
+   where *namei* is the index of name in :attr:`!co_names` of the
+   :ref:`code object <code-objects>`.
 
 .. opcode:: DELETE_ATTR (namei)
 
@@ -964,7 +965,8 @@ iterations of the loop.
       obj = STACK.pop()
       del obj.name
 
-   where *namei* is the index of name into :attr:`co_names`.
+   where *namei* is the index of name into :attr:`!co_names` of the
+   :ref:`code object <code-objects>`.
 
 
 .. opcode:: STORE_GLOBAL (namei)

--- a/Doc/reference/datamodel.rst
+++ b/Doc/reference/datamodel.rst
@@ -953,6 +953,9 @@ Internal types
    definitions may change with future versions of the interpreter, but they are
    mentioned here for completeness.
 
+
+   .. _code-objects:
+
    .. index:: bytecode, object; code, code object
 
    Code objects

--- a/Doc/tools/.nitignore
+++ b/Doc/tools/.nitignore
@@ -57,7 +57,6 @@ Doc/library/dbm.rst
 Doc/library/decimal.rst
 Doc/library/devmode.rst
 Doc/library/difflib.rst
-Doc/library/dis.rst
 Doc/library/doctest.rst
 Doc/library/email.charset.rst
 Doc/library/email.compat32-message.rst


### PR DESCRIPTION
- Link to the code objects reference
- Suppress link to deliberately undocumented builtins.\_\_build_class\_\_
- Suppress links for example methods


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--108476.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->