### PR TITLE
gh-107603: Argument Clinic can emit includes

### DIFF
--- a/Tools/clinic/clinic.py
+++ b/Tools/clinic/clinic.py
@@ -2131,9 +2131,8 @@ class BlockPrinter:
             self,
             block: Block,
             *,
+            clinic: Clinic,
             core_includes: bool = False,
-            # needed if core_includes is true
-            clinic: Clinic | None = None,
     ) -> None:
         input = block.input
         output = block.output
@@ -2162,18 +2161,15 @@ class BlockPrinter:
         write("\n")
 
         output = ''
-        if clinic:
-            limited_capi = clinic.limited_capi
-        else:
-            limited_capi = DEFAULT_LIMITED_CAPI
-        if core_includes and not limited_capi:
-            output += textwrap.dedent("""
-                #if defined(Py_BUILD_CORE) && !defined(Py_BUILD_CORE_MODULE)
-                #  include "pycore_gc.h"            // PyGC_Head
-                #  include "pycore_runtime.h"       // _Py_ID()
-                #endif
+        if core_includes:
+            if not clinic.limited_capi:
+                output += textwrap.dedent("""
+                    #if defined(Py_BUILD_CORE) && !defined(Py_BUILD_CORE_MODULE)
+                    #  include "pycore_gc.h"            // PyGC_Head
+                    #  include "pycore_runtime.h"       // _Py_ID()
+                    #endif
 
-            """)
+                """)
 
             if clinic is not None:
                 # Emit optional includes

--- a/Tools/clinic/clinic.py
+++ b/Tools/clinic/clinic.py
@@ -1075,6 +1075,11 @@ class CLanguage(Language):
             del parameters[0]
         converters = [p.converter for p in parameters]
 
+        # Copy includes from parameters to Clinic
+        for converter in converters:
+            if converter.include:
+                clinic.add_include(*converter.include)
+
         has_option_groups = parameters and (parameters[0].group or parameters[-1].group)
         default_return_converter = f.return_converter.type == 'PyObject *'
         new_or_init = f.kind.new_or_init
@@ -2127,6 +2132,7 @@ class BlockPrinter:
             block: Block,
             *,
             core_includes: bool = False,
+            # needed if core_includes is true
             clinic: Clinic | None = None,
     ) -> None:
         input = block.input
@@ -2168,6 +2174,13 @@ class BlockPrinter:
                 #endif
 
             """)
+
+            if clinic:
+                # Emit optional includes
+                for include, reason in sorted(clinic.includes.items()):
+                    line = f'#include "{include}"'
+                    line = line.ljust(35) + f'// {reason}\n'
+                    output += line
 
         input = ''.join(block.input)
         output += ''.join(block.output)
@@ -2311,7 +2324,7 @@ class Parser(Protocol):
     def parse(self, block: Block) -> None: ...
 
 
-clinic = None
+clinic : Clinic | None = None
 class Clinic:
 
     presets_text = """
@@ -2379,6 +2392,9 @@ impl_definition block
         self.modules: ModuleDict = {}
         self.classes: ClassDict = {}
         self.functions: list[Function] = []
+        # dict: include name => reason
+        # Example: 'pycore_long.h' => '_PyLong_UnsignedShort_Converter()'
+        self.includes: dict[str, str] = {}
 
         self.line_prefix = self.line_suffix = ''
 
@@ -2436,6 +2452,12 @@ impl_definition block
 
         global clinic
         clinic = self
+
+    def add_include(self, name: str, reason: str) -> None:
+        if name in self.includes:
+            # Mention a single reason is enough, no need to list all of them
+            return
+        self.includes[name] = reason
 
     def add_destination(
             self,
@@ -3066,6 +3088,9 @@ class CConverter(metaclass=CConverterAutoRegister):
     # Only set by self_converter.
     signature_name: str | None = None
 
+    # Optional #include "name"  // reason
+    include: tuple[str, str] | None = None
+
     # keep in sync with self_converter.__init__!
     def __init__(self,
              # Positional args:
@@ -3369,6 +3394,11 @@ class CConverter(metaclass=CConverterAutoRegister):
             return CLINIC_PREFIX + self.name
         else:
             return self.name
+
+    def add_include(self, name: str, reason: str) -> None:
+        if self.include:
+            raise ValueError("a converter only supports a single include")
+        self.include = (name, reason)
 
 type_checks = {
     '&PyLong_Type': ('PyLong_Check', 'int'),
@@ -5987,9 +6017,6 @@ parsers: dict[str, Callable[[Clinic], Parser]] = {
     'clinic': DSLParser,
     'python': PythonParser,
 }
-
-
-clinic = None
 
 
 def create_cli() -> argparse.ArgumentParser:

--- a/Tools/clinic/clinic.py
+++ b/Tools/clinic/clinic.py
@@ -2175,7 +2175,7 @@ class BlockPrinter:
 
             """)
 
-            if clinic:
+            if clinic is not None:
                 # Emit optional includes
                 for include, reason in sorted(clinic.includes.items()):
                     line = f'#include "{include}"'
@@ -2324,7 +2324,7 @@ class Parser(Protocol):
     def parse(self, block: Block) -> None: ...
 
 
-clinic : Clinic | None = None
+clinic: Clinic | None = None
 class Clinic:
 
     presets_text = """
@@ -3088,7 +3088,8 @@ class CConverter(metaclass=CConverterAutoRegister):
     # Only set by self_converter.
     signature_name: str | None = None
 
-    # Optional #include "name"  // reason
+    # Optional (name, reason) include which generate a line like:
+    # "#include "name"     // reason"
     include: tuple[str, str] | None = None
 
     # keep in sync with self_converter.__init__!
@@ -3396,7 +3397,7 @@ class CConverter(metaclass=CConverterAutoRegister):
             return self.name
 
     def add_include(self, name: str, reason: str) -> None:
-        if self.include:
+        if self.include is not None:
             raise ValueError("a converter only supports a single include")
         self.include = (name, reason)
 


### PR DESCRIPTION
Remove _PyLong_UnsignedShort_Converter() from the public C API: move the function to the internal pycore_long.h header.

* Add Clinic.add_include() method
* Add CConverter.include and CConverter.add_include()
* Printer.print_block() gets a second parameter: clinic.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-107603 -->
* Issue: gh-107603
<!-- /gh-issue-number -->
