### PR TITLE
GH-106581: Fix instrumentation in tier 2

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2023-08-10-00-00-48.gh-issue-106581.o7zDty.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2023-08-10-00-00-48.gh-issue-106581.o7zDty.rst
@@ -1,0 +1,2 @@
+Fix possible assertion failures and missing instrumentation events when
+:envvar:`PYTHONUOPS` or :option:`-X uops <-X>` is enabled.

--- a/Python/bytecodes.c
+++ b/Python/bytecodes.c
@@ -133,17 +133,19 @@ dummy_func(
         }
 
         inst(RESUME, (--)) {
-            #if TIER_ONE
             assert(frame == tstate->current_frame);
             /* Possibly combine this with eval breaker */
             if (_PyFrame_GetCode(frame)->_co_instrumentation_version != tstate->interp->monitoring_version) {
                 int err = _Py_Instrument(_PyFrame_GetCode(frame), tstate->interp);
                 ERROR_IF(err, error);
+            #if TIER_ONE
                 next_instr--;
-            }
-            else
             #endif
-            if (oparg < 2) {
+            #if TIER_TWO
+               goto deoptimize;
+            #endif
+            }
+            else if (oparg < 2) {
                 CHECK_EVAL_BREAKER();
             }
         }

--- a/Python/bytecodes.c
+++ b/Python/bytecodes.c
@@ -138,12 +138,12 @@ dummy_func(
             if (_PyFrame_GetCode(frame)->_co_instrumentation_version != tstate->interp->monitoring_version) {
                 int err = _Py_Instrument(_PyFrame_GetCode(frame), tstate->interp);
                 ERROR_IF(err, error);
-            #if TIER_ONE
+                #if TIER_ONE
                 next_instr--;
-            #endif
-            #if TIER_TWO
-               goto deoptimize;
-            #endif
+                #endif
+                #if TIER_TWO
+                goto deoptimize;
+                #endif
             }
             else if (oparg < 2) {
                 CHECK_EVAL_BREAKER();

--- a/Python/executor_cases.c.h
+++ b/Python/executor_cases.c.h
@@ -8,17 +8,19 @@
         }
 
         case RESUME: {
-            #if TIER_ONE
             assert(frame == tstate->current_frame);
             /* Possibly combine this with eval breaker */
             if (_PyFrame_GetCode(frame)->_co_instrumentation_version != tstate->interp->monitoring_version) {
                 int err = _Py_Instrument(_PyFrame_GetCode(frame), tstate->interp);
                 if (err) goto error;
+            #if TIER_ONE
                 next_instr--;
-            }
-            else
             #endif
-            if (oparg < 2) {
+            #if TIER_TWO
+               goto deoptimize;
+            #endif
+            }
+            else if (oparg < 2) {
                 CHECK_EVAL_BREAKER();
             }
             break;

--- a/Python/executor_cases.c.h
+++ b/Python/executor_cases.c.h
@@ -13,12 +13,12 @@
             if (_PyFrame_GetCode(frame)->_co_instrumentation_version != tstate->interp->monitoring_version) {
                 int err = _Py_Instrument(_PyFrame_GetCode(frame), tstate->interp);
                 if (err) goto error;
-            #if TIER_ONE
+                #if TIER_ONE
                 next_instr--;
-            #endif
-            #if TIER_TWO
-               goto deoptimize;
-            #endif
+                #endif
+                #if TIER_TWO
+                goto deoptimize;
+                #endif
             }
             else if (oparg < 2) {
                 CHECK_EVAL_BREAKER();

--- a/Python/generated_cases.c.h
+++ b/Python/generated_cases.c.h
@@ -13,12 +13,12 @@
             if (_PyFrame_GetCode(frame)->_co_instrumentation_version != tstate->interp->monitoring_version) {
                 int err = _Py_Instrument(_PyFrame_GetCode(frame), tstate->interp);
                 if (err) goto error;
-            #if TIER_ONE
+                #if TIER_ONE
                 next_instr--;
-            #endif
-            #if TIER_TWO
-               goto deoptimize;
-            #endif
+                #endif
+                #if TIER_TWO
+                goto deoptimize;
+                #endif
             }
             else if (oparg < 2) {
                 CHECK_EVAL_BREAKER();

--- a/Python/generated_cases.c.h
+++ b/Python/generated_cases.c.h
@@ -8,17 +8,19 @@
         }
 
         TARGET(RESUME) {
-            #if TIER_ONE
             assert(frame == tstate->current_frame);
             /* Possibly combine this with eval breaker */
             if (_PyFrame_GetCode(frame)->_co_instrumentation_version != tstate->interp->monitoring_version) {
                 int err = _Py_Instrument(_PyFrame_GetCode(frame), tstate->interp);
                 if (err) goto error;
+            #if TIER_ONE
                 next_instr--;
-            }
-            else
             #endif
-            if (oparg < 2) {
+            #if TIER_TWO
+               goto deoptimize;
+            #endif
+            }
+            else if (oparg < 2) {
                 CHECK_EVAL_BREAKER();
             }
             DISPATCH();


### PR DESCRIPTION
`RESUME` is currently written in a way that ignores changes in tracing events when running in our tier two executor. This can manifest itself as assertion errors on debug builds and missing/extra events on release builds when changing events just before an inlined call:

```
python: Python/instrumentation.c:1117: _Py_call_instrumentation_line: Assertion `is_version_up_to_date(code, tstate->interp)' failed.
```

This PR modifies `RESUME` to detect this condition and deoptimize back to tier one in these cases.

<!-- gh-issue-number: gh-106581 -->
* Issue: gh-106581
<!-- /gh-issue-number -->
