### PR TITLE
gh-108494: Argument Clinic partial supports of Limited C API

### DIFF
--- a/Lib/test/test_clinic.py
+++ b/Lib/test/test_clinic.py
@@ -13,12 +13,20 @@ import inspect
 import os.path
 import re
 import sys
+import types
 import unittest
 
 test_tools.skip_if_missing('clinic')
 with test_tools.imports_under_tool('clinic'):
     import clinic
     from clinic import DSLParser
+
+
+def default_namespace():
+    ns = types.SimpleNamespace()
+    ns.force = False
+    ns.limited_capi = clinic.DEFAULT_LIMITED_CAPI
+    return ns
 
 
 def _make_clinic(*, filename='clinic_tests'):
@@ -50,6 +58,11 @@ def _expect_failure(tc, parser, code, errmsg, *, filename=None, lineno=None,
     if lineno is not None:
         tc.assertEqual(cm.exception.lineno, lineno)
     return cm.exception
+
+
+class MockClinic:
+    def __init__(self):
+        self.limited_capi = clinic.DEFAULT_LIMITED_CAPI
 
 
 class ClinicWholeFileTest(TestCase):
@@ -691,8 +704,9 @@ class ParseFileUnitTest(TestCase):
         self, *, filename, expected_error, verify=True, output=None
     ):
         errmsg = re.escape(dedent(expected_error).strip())
+        ns = default_namespace()
         with self.assertRaisesRegex(clinic.ClinicError, errmsg):
-            clinic.parse_file(filename)
+            clinic.parse_file(filename, ns=ns)
 
     def test_parse_file_no_extension(self) -> None:
         self.expect_parsing_failure(
@@ -832,8 +846,9 @@ class ClinicBlockParserTest(TestCase):
 
         blocks = list(clinic.BlockParser(input, language))
         writer = clinic.BlockPrinter(language)
+        mock_clinic = MockClinic()
         for block in blocks:
-            writer.print_block(block)
+            writer.print_block(block, clinic=mock_clinic)
         output = writer.f.getvalue()
         assert output == input, "output != input!\n\noutput " + repr(output) + "\n\n input " + repr(input)
 
@@ -3506,6 +3521,27 @@ class ClinicFunctionalTest(unittest.TestCase):
         check("a", "b", c="c", d="d", e="e", f="f", g="g")
         check("a", b="b", c="c", d="d", e="e", f="f", g="g")
         self.assertRaises(TypeError, fn, a="a", b="b", c="c", d="d", e="e", f="f", g="g")
+
+
+try:
+    import _testclinic_limited
+except ImportError:
+    _testclinic_limited = None
+
+@unittest.skipIf(_testclinic_limited is None, "_testclinic_limited is missing")
+class LimitedCAPIFunctionalTest(unittest.TestCase):
+    locals().update((name, getattr(_testclinic_limited, name))
+                    for name in dir(_testclinic_limited) if name.startswith('test_'))
+
+    def test_my_int_func(self):
+        with self.assertRaises(TypeError):
+            _testclinic_limited.my_int_func()
+        self.assertEqual(_testclinic_limited.my_int_func(3), 3)
+        with self.assertRaises(TypeError):
+            _testclinic_limited.my_int_func(1.0)
+        with self.assertRaises(TypeError):
+            _testclinic_limited.my_int_func("xyz")
+
 
 
 class PermutationTests(unittest.TestCase):

--- a/Misc/NEWS.d/next/Tools-Demos/2023-08-25-22-40-12.gh-issue-108494.4RbDdu.rst
+++ b/Misc/NEWS.d/next/Tools-Demos/2023-08-25-22-40-12.gh-issue-108494.4RbDdu.rst
@@ -1,0 +1,2 @@
+:ref:`Argument Clinic <howto-clinic>` now has a partial support of the
+:ref:`Limited API <limited-c-api>`. Patch by Victor Stinner.

--- a/Modules/Setup.stdlib.in
+++ b/Modules/Setup.stdlib.in
@@ -161,6 +161,7 @@
 @MODULE__TESTINTERNALCAPI_TRUE@_testinternalcapi _testinternalcapi.c
 @MODULE__TESTCAPI_TRUE@_testcapi _testcapimodule.c _testcapi/vectorcall.c _testcapi/vectorcall_limited.c _testcapi/heaptype.c _testcapi/abstract.c _testcapi/unicode.c _testcapi/dict.c _testcapi/getargs.c _testcapi/datetime.c _testcapi/docstring.c _testcapi/mem.c _testcapi/watchers.c _testcapi/long.c _testcapi/float.c _testcapi/structmember.c _testcapi/exceptions.c _testcapi/code.c _testcapi/buffer.c _testcapi/pyos.c _testcapi/immortal.c _testcapi/heaptype_relative.c _testcapi/gc.c
 @MODULE__TESTCLINIC_TRUE@_testclinic _testclinic.c
+@MODULE__TESTCLINIC_TRUE@_testclinic_limited _testclinic_limited.c
 
 # Some testing modules MUST be built as shared libraries.
 *shared*

--- a/Modules/_testclinic_limited.c
+++ b/Modules/_testclinic_limited.c
@@ -1,0 +1,69 @@
+// For now, only limited C API 3.13 is supported
+#define Py_LIMITED_API 0x030d0000
+
+/* Always enable assertions */
+#undef NDEBUG
+
+#include "Python.h"
+
+
+#include "clinic/_testclinic_limited.c.h"
+
+
+/*[clinic input]
+module  _testclinic_limited
+[clinic start generated code]*/
+/*[clinic end generated code: output=da39a3ee5e6b4b0d input=dd408149a4fc0dbb]*/
+
+
+/*[clinic input]
+test_empty_function
+
+[clinic start generated code]*/
+
+static PyObject *
+test_empty_function_impl(PyObject *module)
+/*[clinic end generated code: output=0f8aeb3ddced55cb input=0dd7048651ad4ae4]*/
+{
+    Py_RETURN_NONE;
+}
+
+
+/*[clinic input]
+my_int_func -> int
+
+    arg: int
+    /
+
+[clinic start generated code]*/
+
+static int
+my_int_func_impl(PyObject *module, int arg)
+/*[clinic end generated code: output=761cd54582f10e4f input=16eb8bba71d82740]*/
+{
+    return arg;
+}
+
+
+static PyMethodDef tester_methods[] = {
+    TEST_EMPTY_FUNCTION_METHODDEF
+    MY_INT_FUNC_METHODDEF
+    {NULL, NULL}
+};
+
+static struct PyModuleDef _testclinic_module = {
+    PyModuleDef_HEAD_INIT,
+    .m_name = "_testclinic_limited",
+    .m_size = 0,
+    .m_methods = tester_methods,
+};
+
+PyMODINIT_FUNC
+PyInit__testclinic_limited(void)
+{
+    PyObject *m = PyModule_Create(&_testclinic_module);
+    if (m == NULL) {
+        return NULL;
+    }
+    return m;
+}

--- a/Modules/clinic/_testclinic_limited.c.h
+++ b/Modules/clinic/_testclinic_limited.c.h
@@ -1,0 +1,53 @@
+/*[clinic input]
+preserve
+[clinic start generated code]*/
+
+PyDoc_STRVAR(test_empty_function__doc__,
+"test_empty_function($module, /)\n"
+"--\n"
+"\n");
+
+#define TEST_EMPTY_FUNCTION_METHODDEF    \
+    {"test_empty_function", (PyCFunction)test_empty_function, METH_NOARGS, test_empty_function__doc__},
+
+static PyObject *
+test_empty_function_impl(PyObject *module);
+
+static PyObject *
+test_empty_function(PyObject *module, PyObject *Py_UNUSED(ignored))
+{
+    return test_empty_function_impl(module);
+}
+
+PyDoc_STRVAR(my_int_func__doc__,
+"my_int_func($module, arg, /)\n"
+"--\n"
+"\n");
+
+#define MY_INT_FUNC_METHODDEF    \
+    {"my_int_func", (PyCFunction)my_int_func, METH_O, my_int_func__doc__},
+
+static int
+my_int_func_impl(PyObject *module, int arg);
+
+static PyObject *
+my_int_func(PyObject *module, PyObject *arg_)
+{
+    PyObject *return_value = NULL;
+    int arg;
+    int _return_value;
+
+    arg = PyLong_AsInt(arg_);
+    if (arg == -1 && PyErr_Occurred()) {
+        goto exit;
+    }
+    _return_value = my_int_func_impl(module, arg);
+    if ((_return_value == -1) && PyErr_Occurred()) {
+        goto exit;
+    }
+    return_value = PyLong_FromLong((long)_return_value);
+
+exit:
+    return return_value;
+}
+/*[clinic end generated code: output=07e2e8ed6923cd16 input=a9049054013a1b77]*/

--- a/Tools/build/generate_stdlib_module_names.py
+++ b/Tools/build/generate_stdlib_module_names.py
@@ -28,6 +28,7 @@ IGNORE = {
     '_testbuffer',
     '_testcapi',
     '_testclinic',
+    '_testclinic_limited',
     '_testconsole',
     '_testimportmultiple',
     '_testinternalcapi',


### PR DESCRIPTION
Argument Clinic now has a partial support of the
Limited API:

* Add --limited option to clinic.c.
* Add '_testclinic_limited' extension which is built with the limited C API version 3.13.
* For now, hardcode in clinic.py that "_testclinic_limited.c" targets the limited C API.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-108494 -->
* Issue: gh-108494
<!-- /gh-issue-number -->
