### PR TITLE
gh-108494: AC supports pos-only args in limited C API

### DIFF
--- a/Lib/test/test_clinic.py
+++ b/Lib/test/test_clinic.py
@@ -3542,6 +3542,17 @@ class LimitedCAPIFunctionalTest(unittest.TestCase):
         with self.assertRaises(TypeError):
             _testclinic_limited.my_int_func("xyz")
 
+    def test_my_int_sum(self):
+        with self.assertRaises(TypeError):
+            _testclinic_limited.my_int_sum()
+        with self.assertRaises(TypeError):
+            _testclinic_limited.my_int_sum(1)
+        self.assertEqual(_testclinic_limited.my_int_sum(1, 2), 3)
+        with self.assertRaises(TypeError):
+            _testclinic_limited.my_int_sum(1.0, 2)
+        with self.assertRaises(TypeError):
+            _testclinic_limited.my_int_sum(1, "str")
+
 
 
 class PermutationTests(unittest.TestCase):

--- a/Modules/_testclinic_limited.c
+++ b/Modules/_testclinic_limited.c
@@ -45,9 +45,27 @@ my_int_func_impl(PyObject *module, int arg)
 }
 
 
+/*[clinic input]
+my_int_sum -> int
+
+    x: int
+    y: int
+    /
+
+[clinic start generated code]*/
+
+static int
+my_int_sum_impl(PyObject *module, int x, int y)
+/*[clinic end generated code: output=3e52db9ab5f37e2f input=0edb6796813bf2d3]*/
+{
+    return x + y;
+}
+
+
 static PyMethodDef tester_methods[] = {
     TEST_EMPTY_FUNCTION_METHODDEF
     MY_INT_FUNC_METHODDEF
+    MY_INT_SUM_METHODDEF
     {NULL, NULL}
 };
 

--- a/Modules/clinic/_testclinic_limited.c.h
+++ b/Modules/clinic/_testclinic_limited.c.h
@@ -50,4 +50,36 @@ my_int_func(PyObject *module, PyObject *arg_)
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=07e2e8ed6923cd16 input=a9049054013a1b77]*/
+
+PyDoc_STRVAR(my_int_sum__doc__,
+"my_int_sum($module, x, y, /)\n"
+"--\n"
+"\n");
+
+#define MY_INT_SUM_METHODDEF    \
+    {"my_int_sum", (PyCFunction)my_int_sum, METH_VARARGS, my_int_sum__doc__},
+
+static int
+my_int_sum_impl(PyObject *module, int x, int y);
+
+static PyObject *
+my_int_sum(PyObject *module, PyObject *args)
+{
+    PyObject *return_value = NULL;
+    int x;
+    int y;
+    int _return_value;
+
+    if (!PyArg_ParseTuple(args, "ii:my_int_sum",
+        &x, &y))
+        goto exit;
+    _return_value = my_int_sum_impl(module, x, y);
+    if ((_return_value == -1) && PyErr_Occurred()) {
+        goto exit;
+    }
+    return_value = PyLong_FromLong((long)_return_value);
+
+exit:
+    return return_value;
+}
+/*[clinic end generated code: output=f9f7209255bb969e input=a9049054013a1b77]*/


### PR DESCRIPTION
AC now checks for "#define Py_LIMITED_API" pattern to use the limited C API.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-108494 -->
* Issue: gh-108494
<!-- /gh-issue-number -->
