### PR TITLE
gh-106320: Remove private _PyLong converter functions

### DIFF
--- a/Include/cpython/longobject.h
+++ b/Include/cpython/longobject.h
@@ -2,10 +2,6 @@
 #  error "this header file must not be included directly"
 #endif
 
-PyAPI_FUNC(int) _PyLong_UnsignedShort_Converter(PyObject *, void *);
-PyAPI_FUNC(int) _PyLong_UnsignedInt_Converter(PyObject *, void *);
-PyAPI_FUNC(int) _PyLong_UnsignedLong_Converter(PyObject *, void *);
-PyAPI_FUNC(int) _PyLong_UnsignedLongLong_Converter(PyObject *, void *);
 PyAPI_FUNC(int) _PyLong_Size_t_Converter(PyObject *, void *);
 
 PyAPI_FUNC(PyObject*) PyLong_FromUnicodeObject(PyObject *u, int base);

--- a/Include/internal/pycore_long.h
+++ b/Include/internal/pycore_long.h
@@ -186,6 +186,13 @@ extern char* _PyLong_FormatBytesWriter(
     int base,
     int alternate);
 
+// Argument converters used by Argument Clinic
+PyAPI_FUNC(int) _PyLong_UnsignedShort_Converter(PyObject *, void *);
+PyAPI_FUNC(int) _PyLong_UnsignedInt_Converter(PyObject *, void *);
+PyAPI_FUNC(int) _PyLong_UnsignedLong_Converter(PyObject *, void *);
+PyAPI_FUNC(int) _PyLong_UnsignedLongLong_Converter(PyObject *, void *);
+
+
 /* Long value tag bits:
  * 0-1: Sign bits value = (1-sign), ie. negative=2, positive=0, zero=1.
  * 2: Reserved for immortality bit

--- a/Modules/_blake2/clinic/blake2b_impl.c.h
+++ b/Modules/_blake2/clinic/blake2b_impl.c.h
@@ -7,6 +7,7 @@ preserve
 #  include "pycore_runtime.h"       // _Py_ID()
 #endif
 
+#include "pycore_long.h"           // _PyLong_UnsignedLong_Converter()
 
 PyDoc_STRVAR(py_blake2b_new__doc__,
 "blake2b(data=b\'\', /, *, digest_size=_blake2.blake2b.MAX_DIGEST_SIZE,\n"
@@ -276,4 +277,4 @@ _blake2_blake2b_hexdigest(BLAKE2bObject *self, PyObject *Py_UNUSED(ignored))
 {
     return _blake2_blake2b_hexdigest_impl(self);
 }
-/*[clinic end generated code: output=76bbcf5f220511b9 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=48128782266b7b8e input=a9049054013a1b77]*/

--- a/Modules/_blake2/clinic/blake2s_impl.c.h
+++ b/Modules/_blake2/clinic/blake2s_impl.c.h
@@ -7,6 +7,7 @@ preserve
 #  include "pycore_runtime.h"       // _Py_ID()
 #endif
 
+#include "pycore_long.h"           // _PyLong_UnsignedLong_Converter()
 
 PyDoc_STRVAR(py_blake2s_new__doc__,
 "blake2s(data=b\'\', /, *, digest_size=_blake2.blake2s.MAX_DIGEST_SIZE,\n"
@@ -276,4 +277,4 @@ _blake2_blake2s_hexdigest(BLAKE2sObject *self, PyObject *Py_UNUSED(ignored))
 {
     return _blake2_blake2s_hexdigest_impl(self);
 }
-/*[clinic end generated code: output=af69b321be0b4a77 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=2188af9910a45497 input=a9049054013a1b77]*/

--- a/Modules/clinic/_testclinic.c.h
+++ b/Modules/clinic/_testclinic.c.h
@@ -7,6 +7,7 @@ preserve
 #  include "pycore_runtime.h"       // _Py_ID()
 #endif
 
+#include "pycore_long.h"           // _PyLong_UnsignedShort_Converter()
 
 PyDoc_STRVAR(test_empty_function__doc__,
 "test_empty_function($module, /)\n"
@@ -3069,4 +3070,4 @@ skip_optional_pos:
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=86396cbed6eb8b65 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=41f439aab0cb809d input=a9049054013a1b77]*/

--- a/Modules/clinic/_testclinic_depr.c.h
+++ b/Modules/clinic/_testclinic_depr.c.h
@@ -7,6 +7,7 @@ preserve
 #  include "pycore_runtime.h"       // _Py_ID()
 #endif
 
+#include "pycore_long.h"           // _PyLong_UnsignedShort_Converter()
 
 PyDoc_STRVAR(depr_star_new__doc__,
 "DeprStarNew(a=None)\n"
@@ -2391,4 +2392,4 @@ depr_multi(PyObject *module, PyObject *const *args, Py_ssize_t nargs, PyObject *
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=ee8b1933e4bf4dc4 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=22b59d92d517a8ec input=a9049054013a1b77]*/

--- a/Modules/clinic/overlapped.c.h
+++ b/Modules/clinic/overlapped.c.h
@@ -7,6 +7,7 @@ preserve
 #  include "pycore_runtime.h"       // _Py_ID()
 #endif
 
+#include "pycore_long.h"           // _PyLong_UnsignedLong_Converter()
 
 PyDoc_STRVAR(_overlapped_CreateIoCompletionPort__doc__,
 "CreateIoCompletionPort($module, handle, port, key, concurrency, /)\n"
@@ -1262,4 +1263,4 @@ exit:
 
     return return_value;
 }
-/*[clinic end generated code: output=9fbc01f706562dea input=a9049054013a1b77]*/
+/*[clinic end generated code: output=994ad727b827ff87 input=a9049054013a1b77]*/

--- a/Modules/clinic/posixmodule.c.h
+++ b/Modules/clinic/posixmodule.c.h
@@ -7,6 +7,7 @@ preserve
 #  include "pycore_runtime.h"       // _Py_ID()
 #endif
 
+#include "pycore_long.h"           // _PyLong_UnsignedInt_Converter()
 
 PyDoc_STRVAR(os_stat__doc__,
 "stat($module, /, path, *, dir_fd=None, follow_symlinks=True)\n"
@@ -11990,4 +11991,4 @@ exit:
 #ifndef OS_WAITSTATUS_TO_EXITCODE_METHODDEF
     #define OS_WAITSTATUS_TO_EXITCODE_METHODDEF
 #endif /* !defined(OS_WAITSTATUS_TO_EXITCODE_METHODDEF) */
-/*[clinic end generated code: output=5e839ce21678ea66 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=a08a47b52da6da0b input=a9049054013a1b77]*/

--- a/Modules/clinic/selectmodule.c.h
+++ b/Modules/clinic/selectmodule.c.h
@@ -7,6 +7,7 @@ preserve
 #  include "pycore_runtime.h"       // _Py_ID()
 #endif
 
+#include "pycore_long.h"           // _PyLong_UnsignedShort_Converter()
 
 PyDoc_STRVAR(select_select__doc__,
 "select($module, rlist, wlist, xlist, timeout=None, /)\n"
@@ -1309,4 +1310,4 @@ exit:
 #ifndef SELECT_KQUEUE_CONTROL_METHODDEF
     #define SELECT_KQUEUE_CONTROL_METHODDEF
 #endif /* !defined(SELECT_KQUEUE_CONTROL_METHODDEF) */
-/*[clinic end generated code: output=7521d757ef9e63e8 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=a19c29946a931dce input=a9049054013a1b77]*/

--- a/Modules/clinic/sha3module.c.h
+++ b/Modules/clinic/sha3module.c.h
@@ -7,6 +7,7 @@ preserve
 #  include "pycore_runtime.h"       // _Py_ID()
 #endif
 
+#include "pycore_long.h"           // _PyLong_UnsignedLong_Converter()
 
 PyDoc_STRVAR(py_sha3_new__doc__,
 "sha3_224(data=b\'\', /, *, usedforsecurity=True)\n"
@@ -193,4 +194,4 @@ _sha3_shake_128_hexdigest(SHA3object *self, PyObject *arg)
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=907cb475f3dc9ee0 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=5188d9ae4af48c6d input=a9049054013a1b77]*/

--- a/Modules/overlapped.c
+++ b/Modules/overlapped.c
@@ -7,8 +7,11 @@
 /* XXX check overflow and DWORD <-> Py_ssize_t conversions
    Check itemsize */
 
-#include "Python.h"
+#ifndef Py_BUILD_CORE_BUILTIN
+#  define Py_BUILD_CORE_MODULE 1
+#endif
 
+#include "Python.h"
 
 #define WINDOWS_LEAN_AND_MEAN
 #include <winsock2.h>

--- a/PC/clinic/winreg.c.h
+++ b/PC/clinic/winreg.c.h
@@ -7,6 +7,7 @@ preserve
 #  include "pycore_runtime.h"       // _Py_ID()
 #endif
 
+#include "pycore_long.h"           // _PyLong_UnsignedLong_Converter()
 
 #if (defined(MS_WINDOWS_DESKTOP) || defined(MS_WINDOWS_SYSTEM) || defined(MS_WINDOWS_GAMES))
 
@@ -1788,4 +1789,4 @@ exit:
 #ifndef WINREG_QUERYREFLECTIONKEY_METHODDEF
     #define WINREG_QUERYREFLECTIONKEY_METHODDEF
 #endif /* !defined(WINREG_QUERYREFLECTIONKEY_METHODDEF) */
-/*[clinic end generated code: output=4d0ec3e43e1b28f4 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=00343ee8da923da8 input=a9049054013a1b77]*/

--- a/Tools/c-analyzer/c_parser/preprocessor/gcc.py
+++ b/Tools/c-analyzer/c_parser/preprocessor/gcc.py
@@ -7,9 +7,18 @@ from . import common as _common
 # macro. Usually it's defined by the C file which includes it.
 # Other header files have a similar issue.
 NEED_BUILD_CORE = {
+    # Header ".h" files
     'cjkcodecs.h',
     'multibytecodec.h',
     'socketmodule.h',
+
+    # Argument Clinic ".c.h" files
+    '_testclinic.c.h',
+    '_testclinic_depr.c.h',
+    'overlapped.c.h',
+    'posixmodule.c.h',
+    'selectmodule.c.h',
+    'sha3module.c.h',
 }
 
 TOOL = 'gcc'

--- a/Tools/clinic/clinic.py
+++ b/Tools/clinic/clinic.py
@@ -3629,6 +3629,8 @@ class unsigned_short_converter(CConverter):
             self.format_unit = 'H'
         else:
             self.converter = '_PyLong_UnsignedShort_Converter'
+            self.add_include('pycore_long.h',
+                             '_PyLong_UnsignedShort_Converter()')
 
     def parse_arg(self, argname: str, displayname: str) -> str | None:
         if self.format_unit == 'H':
@@ -3690,6 +3692,8 @@ class unsigned_int_converter(CConverter):
             self.format_unit = 'I'
         else:
             self.converter = '_PyLong_UnsignedInt_Converter'
+            self.add_include('pycore_long.h',
+                             '_PyLong_UnsignedInt_Converter()')
 
     def parse_arg(self, argname: str, displayname: str) -> str | None:
         if self.format_unit == 'I':
@@ -3727,6 +3731,8 @@ class unsigned_long_converter(CConverter):
             self.format_unit = 'k'
         else:
             self.converter = '_PyLong_UnsignedLong_Converter'
+            self.add_include('pycore_long.h',
+                             '_PyLong_UnsignedLong_Converter()')
 
     def parse_arg(self, argname: str, displayname: str) -> str | None:
         if self.format_unit == 'k':
@@ -3766,6 +3772,8 @@ class unsigned_long_long_converter(CConverter):
             self.format_unit = 'K'
         else:
             self.converter = '_PyLong_UnsignedLongLong_Converter'
+            self.add_include('pycore_long.h',
+                             '_PyLong_UnsignedLongLong_Converter()')
 
     def parse_arg(self, argname: str, displayname: str) -> str | None:
         if self.format_unit == 'K':


### PR DESCRIPTION
Move private functions to the internal C API (pycore_traceback.h):

Argument Clinic now emits #include "pycore_long.h" when using these functions.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-106320 -->
* Issue: gh-106320
<!-- /gh-issue-number -->
