### PR TITLE
gh-106320: Remove private _PyLong_FileDescriptor_Converter()

### DIFF
--- a/Include/cpython/fileobject.h
+++ b/Include/cpython/fileobject.h
@@ -15,5 +15,3 @@ typedef PyObject * (*Py_OpenCodeHookFunction)(PyObject *, void *);
 PyAPI_FUNC(PyObject *) PyFile_OpenCode(const char *utf8path);
 PyAPI_FUNC(PyObject *) PyFile_OpenCodeObject(PyObject *path);
 PyAPI_FUNC(int) PyFile_SetOpenCodeHook(Py_OpenCodeHookFunction hook, void *userData);
-
-PyAPI_FUNC(int) _PyLong_FileDescriptor_Converter(PyObject *, void *);

--- a/Include/cpython/longobject.h
+++ b/Include/cpython/longobject.h
@@ -2,8 +2,6 @@
 #  error "this header file must not be included directly"
 #endif
 
-PyAPI_FUNC(int) _PyLong_Size_t_Converter(PyObject *, void *);
-
 PyAPI_FUNC(PyObject*) PyLong_FromUnicodeObject(PyObject *u, int base);
 
 /* _PyLong_Sign.  Return 0 if v is 0, -1 if v < 0, +1 if v > 0.

--- a/Include/internal/pycore_fileutils.h
+++ b/Include/internal/pycore_fileutils.h
@@ -312,6 +312,9 @@ extern HRESULT PathCchSkipRoot(const wchar_t *pszPath, const wchar_t **ppszRootE
 #  define _Py_END_SUPPRESS_IPH
 #endif /* _MSC_VER >= 1900 */
 
+// Export for 'select' shared extension (Argument Clinic code)
+PyAPI_FUNC(int) _PyLong_FileDescriptor_Converter(PyObject *, void *);
+
 #ifdef __cplusplus
 }
 #endif

--- a/Include/internal/pycore_long.h
+++ b/Include/internal/pycore_long.h
@@ -187,11 +187,21 @@ extern char* _PyLong_FormatBytesWriter(
     int alternate);
 
 // Argument converters used by Argument Clinic
+
+// Export for 'select' shared extension (Argument Clinic code)
 PyAPI_FUNC(int) _PyLong_UnsignedShort_Converter(PyObject *, void *);
+
+// Export for '_testclinic' shared extension (Argument Clinic code)
 PyAPI_FUNC(int) _PyLong_UnsignedInt_Converter(PyObject *, void *);
+
+// Export for '_blake2' shared extension (Argument Clinic code)
 PyAPI_FUNC(int) _PyLong_UnsignedLong_Converter(PyObject *, void *);
+
+// Export for '_blake2' shared extension (Argument Clinic code)
 PyAPI_FUNC(int) _PyLong_UnsignedLongLong_Converter(PyObject *, void *);
 
+// Export for '_testclinic' shared extension (Argument Clinic code)
+PyAPI_FUNC(int) _PyLong_Size_t_Converter(PyObject *, void *);
 
 /* Long value tag bits:
  * 0-1: Sign bits value = (1-sign), ie. negative=2, positive=0, zero=1.

--- a/Modules/clinic/_winapi.c.h
+++ b/Modules/clinic/_winapi.c.h
@@ -7,6 +7,7 @@ preserve
 #  include "pycore_runtime.h"       // _Py_ID()
 #endif
 
+#include "pycore_long.h"           // _PyLong_Size_t_Converter()
 
 PyDoc_STRVAR(_winapi_Overlapped_GetOverlappedResult__doc__,
 "GetOverlappedResult($self, wait, /)\n"
@@ -1478,4 +1479,4 @@ exit:
 
     return return_value;
 }
-/*[clinic end generated code: output=ff91ab5cae8961dd input=a9049054013a1b77]*/
+/*[clinic end generated code: output=c7e08927e163ef13 input=a9049054013a1b77]*/

--- a/Modules/clinic/fcntlmodule.c.h
+++ b/Modules/clinic/fcntlmodule.c.h
@@ -7,6 +7,7 @@ preserve
 #  include "pycore_runtime.h"       // _Py_ID()
 #endif
 
+#include "pycore_fileutils.h"      // _PyLong_FileDescriptor_Converter()
 
 PyDoc_STRVAR(fcntl_fcntl__doc__,
 "fcntl($module, fd, cmd, arg=0, /)\n"
@@ -249,4 +250,4 @@ skip_optional:
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=705976d5f53f2272 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=5f096e8731fa38be input=a9049054013a1b77]*/

--- a/Modules/clinic/posixmodule.c.h
+++ b/Modules/clinic/posixmodule.c.h
@@ -7,6 +7,7 @@ preserve
 #  include "pycore_runtime.h"       // _Py_ID()
 #endif
 
+#include "pycore_fileutils.h"      // _PyLong_FileDescriptor_Converter()
 #include "pycore_long.h"           // _PyLong_UnsignedInt_Converter()
 
 PyDoc_STRVAR(os_stat__doc__,
@@ -11991,4 +11992,4 @@ exit:
 #ifndef OS_WAITSTATUS_TO_EXITCODE_METHODDEF
     #define OS_WAITSTATUS_TO_EXITCODE_METHODDEF
 #endif /* !defined(OS_WAITSTATUS_TO_EXITCODE_METHODDEF) */
-/*[clinic end generated code: output=a08a47b52da6da0b input=a9049054013a1b77]*/
+/*[clinic end generated code: output=ff0e50316f4ed71a input=a9049054013a1b77]*/

--- a/Modules/clinic/selectmodule.c.h
+++ b/Modules/clinic/selectmodule.c.h
@@ -7,6 +7,7 @@ preserve
 #  include "pycore_runtime.h"       // _Py_ID()
 #endif
 
+#include "pycore_fileutils.h"      // _PyLong_FileDescriptor_Converter()
 #include "pycore_long.h"           // _PyLong_UnsignedShort_Converter()
 
 PyDoc_STRVAR(select_select__doc__,
@@ -1310,4 +1311,4 @@ exit:
 #ifndef SELECT_KQUEUE_CONTROL_METHODDEF
     #define SELECT_KQUEUE_CONTROL_METHODDEF
 #endif /* !defined(SELECT_KQUEUE_CONTROL_METHODDEF) */
-/*[clinic end generated code: output=a19c29946a931dce input=a9049054013a1b77]*/
+/*[clinic end generated code: output=a215af2157f038c7 input=a9049054013a1b77]*/

--- a/Modules/clinic/termios.c.h
+++ b/Modules/clinic/termios.c.h
@@ -7,6 +7,7 @@ preserve
 #  include "pycore_runtime.h"       // _Py_ID()
 #endif
 
+#include "pycore_fileutils.h"      // _PyLong_FileDescriptor_Converter()
 
 PyDoc_STRVAR(termios_tcgetattr__doc__,
 "tcgetattr($module, fd, /)\n"
@@ -292,4 +293,4 @@ termios_tcsetwinsize(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=4c79a3bf87370275 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=434df4394b596e92 input=a9049054013a1b77]*/

--- a/Modules/fcntlmodule.c
+++ b/Modules/fcntlmodule.c
@@ -1,5 +1,9 @@
 /* fcntl module */
 
+#ifndef Py_BUILD_CORE_BUILTIN
+#  define Py_BUILD_CORE_MODULE 1
+#endif
+
 #include "Python.h"
 
 #ifdef HAVE_SYS_FILE_H

--- a/Modules/termios.c
+++ b/Modules/termios.c
@@ -1,5 +1,9 @@
 /* termios.c -- POSIX terminal I/O module implementation.  */
 
+#ifndef Py_BUILD_CORE_BUILTIN
+#  define Py_BUILD_CORE_MODULE 1
+#endif
+
 #include "Python.h"
 
 /* Apparently, on SGI, termios.h won't define CTRL if _XOPEN_SOURCE

--- a/Tools/c-analyzer/c_parser/preprocessor/gcc.py
+++ b/Tools/c-analyzer/c_parser/preprocessor/gcc.py
@@ -12,13 +12,16 @@ NEED_BUILD_CORE = {
     'multibytecodec.h',
     'socketmodule.h',
 
-    # Argument Clinic ".c.h" files
+    # Argument Clinic ".c.h" header files
     '_testclinic.c.h',
     '_testclinic_depr.c.h',
+    '_winapi.c.h',
+    'fcntlmodule.c.h',
     'overlapped.c.h',
     'posixmodule.c.h',
     'selectmodule.c.h',
     'sha3module.c.h',
+    'termios.c.h',
 }
 
 TOOL = 'gcc'

--- a/Tools/clinic/clinic.py
+++ b/Tools/clinic/clinic.py
@@ -3835,6 +3835,10 @@ class size_t_converter(CConverter):
     converter = '_PyLong_Size_t_Converter'
     c_ignored_default = "0"
 
+    def converter_init(self, *, accept: TypeSet = {int, NoneType}) -> None:
+        self.add_include('pycore_long.h',
+                         '_PyLong_Size_t_Converter()')
+
     def parse_arg(self, argname: str, displayname: str) -> str | None:
         if self.format_unit == 'n':
             return """
@@ -3849,6 +3853,10 @@ class size_t_converter(CConverter):
 class fildes_converter(CConverter):
     type = 'int'
     converter = '_PyLong_FileDescriptor_Converter'
+
+    def converter_init(self, *, accept: TypeSet = {int, NoneType}) -> None:
+        self.add_include('pycore_fileutils.h',
+                         '_PyLong_FileDescriptor_Converter()')
 
     def _parse_arg(self, argname: str, displayname: str) -> str | None:
         return """


### PR DESCRIPTION
Move the private _PyLong converter functions to the internal C API

* _PyLong_FileDescriptor_Converter(): moved to pycore_fileutils.h
* _PyLong_Size_t_Converter(): moved to pycore_long.h

Argument Clinic now emits includes for pycore_fileutils.h and pycore_long.h when these functions are used.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-106320 -->
* Issue: gh-106320
<!-- /gh-issue-number -->
