### PR TITLE
gh-85283: _uuid uses the limited C API

### DIFF
--- a/Misc/NEWS.d/next/C API/2023-08-26-04-07-37.gh-issue-85283.TKX77g.rst
+++ b/Misc/NEWS.d/next/C API/2023-08-26-04-07-37.gh-issue-85283.TKX77g.rst
@@ -1,0 +1,2 @@
+The ``_uuid`` C extension is now built with the :ref:`limited C API
+<limited-c-api>`. Patch by Victor Stinner.

--- a/Modules/_uuidmodule.c
+++ b/Modules/_uuidmodule.c
@@ -3,6 +3,8 @@
  * DCE compatible Universally Unique Identifier library.
  */
 
+#define Py_LIMITED_API 0x030d0000
+
 #include "Python.h"
 #if defined(HAVE_UUID_H)
   // AIX, FreeBSD, libuuid with pkgconf


### PR DESCRIPTION
The _uuid C extension is now built with the limited C API.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-85283 -->
* Issue: gh-85283
<!-- /gh-issue-number -->
