### PR TITLE
[3.12] gh-108487: Change assert that should've been DEOPT_IF

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2023-08-26-04-33-18.gh-issue-108487.aUFxqf.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2023-08-26-04-33-18.gh-issue-108487.aUFxqf.rst
@@ -1,0 +1,1 @@
+Change an assert that would cause a spurious crash in a devious case that should only trigger deoptimization.

--- a/Python/bytecodes.c
+++ b/Python/bytecodes.c
@@ -2992,9 +2992,9 @@ dummy_func(
         inst(CALL_NO_KW_LIST_APPEND, (unused/1, unused/2, method, self, args[oparg] -- unused)) {
             assert(kwnames == NULL);
             assert(oparg == 1);
-
             PyInterpreterState *interp = _PyInterpreterState_GET();
             DEOPT_IF(method != interp->callable_cache.list_append, CALL);
+            assert(self != NULL);
             DEOPT_IF(!PyList_Check(self), CALL);
             STAT_INC(CALL, hit);
             if (_PyList_AppendTakeRef((PyListObject *)self, args[0]) < 0) {

--- a/Python/bytecodes.c
+++ b/Python/bytecodes.c
@@ -2992,7 +2992,7 @@ dummy_func(
         inst(CALL_NO_KW_LIST_APPEND, (unused/1, unused/2, method, self, args[oparg] -- unused)) {
             assert(kwnames == NULL);
             assert(oparg == 1);
-            assert(method != NULL);
+
             PyInterpreterState *interp = _PyInterpreterState_GET();
             DEOPT_IF(method != interp->callable_cache.list_append, CALL);
             DEOPT_IF(!PyList_Check(self), CALL);

--- a/Python/generated_cases.c.h
+++ b/Python/generated_cases.c.h
@@ -4248,9 +4248,9 @@
             #line 2993 "Python/bytecodes.c"
             assert(kwnames == NULL);
             assert(oparg == 1);
-
             PyInterpreterState *interp = _PyInterpreterState_GET();
             DEOPT_IF(method != interp->callable_cache.list_append, CALL);
+            assert(self != NULL);
             DEOPT_IF(!PyList_Check(self), CALL);
             STAT_INC(CALL, hit);
             if (_PyList_AppendTakeRef((PyListObject *)self, args[0]) < 0) {

--- a/Python/generated_cases.c.h
+++ b/Python/generated_cases.c.h
@@ -4248,7 +4248,7 @@
             #line 2993 "Python/bytecodes.c"
             assert(kwnames == NULL);
             assert(oparg == 1);
-            assert(method != NULL);
+
             PyInterpreterState *interp = _PyInterpreterState_GET();
             DEOPT_IF(method != interp->callable_cache.list_append, CALL);
             DEOPT_IF(!PyList_Check(self), CALL);


### PR DESCRIPTION
The assert(method != NULL) in CALL_NO_KW_LIST_APPEND is wrong -- this condition should lead to a deoptimization, and indeed there is a DEOPT_IF two lines later that will trigger if method == NULL.

Instead, add a different assert(self != NULL) after the DEOPT_IF().

This would crash in a devious repro scenario (first seen live in boto3 tests) when compiled with assertions enabled. In a production version there is no crash, so impact is limited.

(The crash also appears in main;see gh-108510.)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-108487 -->
* Issue: gh-108487
<!-- /gh-issue-number -->
