### PR TITLE
gh-108487: Move assert(self != NULL) down beyond DEOPT_IF()

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2023-08-26-04-31-01.gh-issue-108487.1Gbr9k.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2023-08-26-04-31-01.gh-issue-108487.1Gbr9k.rst
@@ -1,0 +1,1 @@
+Move an assert that would cause a spurious crash in a devious case that should only trigger deoptimization.

--- a/Python/bytecodes.c
+++ b/Python/bytecodes.c
@@ -3344,9 +3344,9 @@ dummy_func(
         inst(CALL_NO_KW_LIST_APPEND, (unused/1, unused/2, callable, self, args[oparg] -- unused)) {
             ASSERT_KWNAMES_IS_NULL();
             assert(oparg == 1);
-            assert(self != NULL);
             PyInterpreterState *interp = tstate->interp;
             DEOPT_IF(callable != interp->callable_cache.list_append, CALL);
+            assert(self != NULL);
             DEOPT_IF(!PyList_Check(self), CALL);
             STAT_INC(CALL, hit);
             if (_PyList_AppendTakeRef((PyListObject *)self, args[0]) < 0) {

--- a/Python/generated_cases.c.h
+++ b/Python/generated_cases.c.h
@@ -4410,9 +4410,9 @@
             callable = stack_pointer[-2 - oparg];
             ASSERT_KWNAMES_IS_NULL();
             assert(oparg == 1);
-            assert(self != NULL);
             PyInterpreterState *interp = tstate->interp;
             DEOPT_IF(callable != interp->callable_cache.list_append, CALL);
+            assert(self != NULL);
             DEOPT_IF(!PyList_Check(self), CALL);
             STAT_INC(CALL, hit);
             if (_PyList_AppendTakeRef((PyListObject *)self, args[0]) < 0) {


### PR DESCRIPTION
Here's the 3.13 (main) version of gh-108509.

<!-- gh-issue-number: gh-108487 -->
* Issue: gh-108487
<!-- /gh-issue-number -->
