### PR TITLE
gh-108494: Fix AC limited C API for kwargs

### DIFF
--- a/Lib/test/test_clinic.py
+++ b/Lib/test/test_clinic.py
@@ -3534,6 +3534,7 @@ class LimitedCAPIFunctionalTest(unittest.TestCase):
                     for name in dir(_testclinic_limited) if name.startswith('test_'))
 
     def test_my_int_func(self):
+        # METH_O
         with self.assertRaises(TypeError):
             _testclinic_limited.my_int_func()
         self.assertEqual(_testclinic_limited.my_int_func(3), 3)
@@ -3543,6 +3544,7 @@ class LimitedCAPIFunctionalTest(unittest.TestCase):
             _testclinic_limited.my_int_func("xyz")
 
     def test_my_int_sum(self):
+        # PyArg_ParseTuple() with "ii:my_int_sum" format
         with self.assertRaises(TypeError):
             _testclinic_limited.my_int_sum()
         with self.assertRaises(TypeError):
@@ -3552,6 +3554,18 @@ class LimitedCAPIFunctionalTest(unittest.TestCase):
             _testclinic_limited.my_int_sum(1.0, 2)
         with self.assertRaises(TypeError):
             _testclinic_limited.my_int_sum(1, "str")
+
+    def test_my_obj_func(self):
+        # PyArg_ParseTupleAndKeywords() with "OO:my_obj_func" format
+        arg1 = object()
+        arg2 = object()
+        with self.assertRaises(TypeError):
+            _testclinic_limited.my_obj_func()
+        with self.assertRaises(TypeError):
+            _testclinic_limited.my_obj_func(arg1)
+        self.assertIs(_testclinic_limited.my_obj_func(arg1, arg2), arg1)
+        with self.assertRaises(TypeError):
+            _testclinic_limited.my_obj_func(arg1, arg2, "arg3")
 
 
 

--- a/Modules/_testclinic_limited.c
+++ b/Modules/_testclinic_limited.c
@@ -46,6 +46,22 @@ my_int_func_impl(PyObject *module, int arg)
 
 
 /*[clinic input]
+my_obj_func
+
+    arg1: object
+    arg2: object
+
+[clinic start generated code]*/
+
+static PyObject *
+my_obj_func_impl(PyObject *module, PyObject *arg1, PyObject *arg2)
+/*[clinic end generated code: output=7f07d359d2e50436 input=c6f78c836ecab1d6]*/
+{
+    return Py_NewRef(arg1);
+}
+
+
+/*[clinic input]
 my_int_sum -> int
 
     x: int
@@ -66,6 +82,7 @@ static PyMethodDef tester_methods[] = {
     TEST_EMPTY_FUNCTION_METHODDEF
     MY_INT_FUNC_METHODDEF
     MY_INT_SUM_METHODDEF
+    MY_OBJ_FUNC_METHODDEF
     {NULL, NULL}
 };
 

--- a/Modules/clinic/_testclinic_limited.c.h
+++ b/Modules/clinic/_testclinic_limited.c.h
@@ -51,6 +51,34 @@ exit:
     return return_value;
 }
 
+PyDoc_STRVAR(my_obj_func__doc__,
+"my_obj_func($module, /, arg1, arg2)\n"
+"--\n"
+"\n");
+
+#define MY_OBJ_FUNC_METHODDEF    \
+    {"my_obj_func", _PyCFunction_CAST(my_obj_func), METH_VARARGS|METH_KEYWORDS, my_obj_func__doc__},
+
+static PyObject *
+my_obj_func_impl(PyObject *module, PyObject *arg1, PyObject *arg2);
+
+static PyObject *
+my_obj_func(PyObject *module, PyObject *args, PyObject *kwargs)
+{
+    PyObject *return_value = NULL;
+    char* _keywords[] = {"arg1", "arg2", NULL};
+    PyObject *arg1;
+    PyObject *arg2;
+
+    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "OO:my_obj_func", _keywords,
+        &arg1, &arg2))
+        goto exit;
+    return_value = my_obj_func_impl(module, arg1, arg2);
+
+exit:
+    return return_value;
+}
+
 PyDoc_STRVAR(my_int_sum__doc__,
 "my_int_sum($module, x, y, /)\n"
 "--\n"
@@ -82,4 +110,4 @@ my_int_sum(PyObject *module, PyObject *args)
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=f9f7209255bb969e input=a9049054013a1b77]*/
+/*[clinic end generated code: output=7e5151a2029efc21 input=a9049054013a1b77]*/


### PR DESCRIPTION
Fix the limited C API code path in Argument Clinic to parse "positional or keywords" arguments.

Add an unit test in _testclinic_limited.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-108494 -->
* Issue: gh-108494
<!-- /gh-issue-number -->
