### PR TITLE
gh-108295: Fix crashes with TypeVar weakrefs

### DIFF
--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -544,6 +544,16 @@ class TypeVarTests(BaseTestCase):
                 with self.assertRaises(TypeError):
                     list[T][arg]
 
+    def test_many_weakrefs(self):
+        # gh-108295: this used to segfault
+        for cls in (ParamSpec, TypeVarTuple, TypeVar):
+            with self.subTest(cls=cls):
+                vals = weakref.WeakValueDictionary()
+
+                for x in range(100000):
+                    vals[x] = cls(str(x))
+                del vals
+
 
 def template_replace(templates: list[str], replacements: dict[str, list[str]]) -> list[tuple[str]]:
     """Renders templates with possible combinations of replacements.

--- a/Misc/NEWS.d/next/Library/2023-08-26-08-38-57.gh-issue-108295.Pn0QRM.rst
+++ b/Misc/NEWS.d/next/Library/2023-08-26-08-38-57.gh-issue-108295.Pn0QRM.rst
@@ -1,0 +1,1 @@
+Fix crashes related to use of weakrefs on :data:`typing.TypeVar`.

--- a/Objects/typevarobject.c
+++ b/Objects/typevarobject.c
@@ -201,6 +201,7 @@ typevar_dealloc(PyObject *self)
     Py_XDECREF(tv->constraints);
     Py_XDECREF(tv->evaluate_constraints);
     _PyObject_ClearManagedDict(self);
+    PyObject_ClearWeakRefs(self);
 
     Py_TYPE(self)->tp_free(self);
     Py_DECREF(tp);
@@ -743,6 +744,7 @@ paramspec_dealloc(PyObject *self)
     Py_DECREF(ps->name);
     Py_XDECREF(ps->bound);
     _PyObject_ClearManagedDict(self);
+    PyObject_ClearWeakRefs(self);
 
     Py_TYPE(self)->tp_free(self);
     Py_DECREF(tp);
@@ -1022,6 +1024,7 @@ typevartuple_dealloc(PyObject *self)
 
     Py_DECREF(tvt->name);
     _PyObject_ClearManagedDict(self);
+    PyObject_ClearWeakRefs(self);
 
     Py_TYPE(self)->tp_free(self);
     Py_DECREF(tp);


### PR DESCRIPTION


<!-- gh-issue-number: gh-108295 -->
* Issue: gh-108295
<!-- /gh-issue-number -->
