### PR TITLE
gh-108514: Add config & transform to hide old versionmodified in docs

### DIFF
--- a/Doc/conf.py
+++ b/Doc/conf.py
@@ -68,6 +68,9 @@ highlight_language = 'python3'
 # Minimum version of sphinx required
 needs_sphinx = '3.2'
 
+# Hide versionadded and versionchanged in the output older than this version
+min_version_show_changes = '3.6'
+
 # Ignore any .rst files in the includes/ directory;
 # they're embedded in pages but not rendered individually.
 # Ignore any .rst files in the venv/ directory.

--- a/Doc/tools/extensions/pyspecific.py
+++ b/Doc/tools/extensions/pyspecific.py
@@ -695,7 +695,21 @@ def patch_pairindextypes(app, _env) -> None:
         pairindextypes.clear()
 
 
+def hide_old_versionmodified(app, doctree, fromdocname):
+    """Remove versionmodified nodes (added/changed) older than the minimum."""
+    min_version = app.config.min_version_show_changes
+    if not min_version:
+        return
+    min_version = [int(part) for part in min_version.split(".")]
+    for node in list(doctree.findall(addnodes.versionmodified)):
+        if node['type'] in ('versionadded', 'versionchanged'):
+            node_version = [int(part) for part in node['version'].split(".")]
+            if node_version < min_version:
+                node.parent.remove(node)
+
+
 def setup(app):
+    app.add_config_value('min_version_show_changes', '', 'html')
     app.add_role('issue', issue_role)
     app.add_role('gh', gh_issue_role)
     app.add_role('source', source_role)
@@ -717,6 +731,7 @@ def setup(app):
     app.add_directive('miscnews', MiscNews)
     app.connect('env-check-consistency', patch_pairindextypes)
     app.connect('doctree-resolved', process_audit_events)
+    app.connect('doctree-resolved', hide_old_versionmodified)
     app.connect('env-merge-info', audit_events_merge)
     app.connect('env-purge-doc', audit_events_purge)
     return {'version': '1.0', 'parallel_read_safe': True}


### PR DESCRIPTION
As discussed in #108514 and previously among the core devs, there was some amount of interest in hiding versionadded/versionchanged annotations in the Python docs for old versions of Python. Some favored showing all annotations back to the first feature release of the current major version (3.0), which is currently the case in practice as pre-3.0 annotations were completely removed from the source. Others preferred hiding those for older, long-EOL feature releases, e.g. as recent as a 3.6 minimum.

Whatever approach is decided upon, it seems useful to have the ability to specify a minimum version above which to show versionmodified annotations to implement it—even if its 3.0 for now, so its trivial to change in the future if we release a new major version, the older 3.x versions get too long in the tooth, or our policy evolves.

I used an example version of 3.6 to better demonstrate the effect, but marked this as draft/Do-Not-Merge until a minimum version is decided (with 3.0 being the status quo fallback by default).

<!-- gh-issue-number: gh-108514 -->
* Issue: gh-108514
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--108522.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->