### PR TITLE
gh-108531: Ignore non-binary properties in DerivedCoreProperties.txt

### DIFF
--- a/Misc/NEWS.d/next/Tools-Demos/2023-08-27-01-59-28.gh-issue-108531.6Vjllh.rst
+++ b/Misc/NEWS.d/next/Tools-Demos/2023-08-27-01-59-28.gh-issue-108531.6Vjllh.rst
@@ -1,0 +1,2 @@
+``makeunicodedata.py`` now supports non-binary character properties when
+processing the ``DerivedCoreProperties.txt`` Unicode data file.

--- a/Tools/unicode/makeunicodedata.py
+++ b/Tools/unicode/makeunicodedata.py
@@ -1105,11 +1105,15 @@ class UnicodeData:
                 table[i].east_asian_width = widths[i]
         self.widths = widths
 
-        for char, (p,) in UcdFile(DERIVED_CORE_PROPERTIES, version).expanded():
+        for char, (propname, *propinfo) in UcdFile(DERIVED_CORE_PROPERTIES, version).expanded():
+            if propinfo:
+                # this is not a binary property, ignore it
+                continue
+
             if table[char]:
                 # Some properties (e.g. Default_Ignorable_Code_Point)
                 # apply to unassigned code points; ignore them
-                table[char].binary_properties.add(p)
+                table[char].binary_properties.add(propname)
 
         for char_range, value in UcdFile(LINE_BREAK, version):
             if value not in MANDATORY_LINE_BREAKS:


### PR DESCRIPTION
This changeset fixes #108531 by skipping non-binary character properties when processing the `DerivedCoreProperties.txt` file in the Unicode Character Database (UCD).

The new non-binary enumeration (`Indic_Conjunct_Break`) introduced by Unicode 15.1.0 is related to changes to text segmentation, for which `unicodedata` provides no functionality (although it has been requested in #74902), so it's okay to ignore this new property.

<!-- gh-issue-number: gh-108531 -->
* Issue: gh-108531
<!-- /gh-issue-number -->

Note that this changeset _does not_ include the `UNIDATA_VERSION` bump and CJK range adjustment necessary to reproduce the error listed in the associated issue, since Unicode 15.1.0 has not yet been released and it seems inappropriate to make those changes in this PR.