### PR TITLE
Use non alternate name for Kyiv

### DIFF
--- a/Lib/test/test_email/test_utils.py
+++ b/Lib/test/test_email/test_utils.py
@@ -148,7 +148,7 @@ class LocaltimeTests(unittest.TestCase):
     @unittest.skipUnless(os.path.exists('/usr/share/zoneinfo') or
                          os.path.exists('/usr/lib/zoneinfo'),
                          "Can't find the Olson's TZ database")
-    @test.support.run_with_tz('Europe/Kiev')
+    @test.support.run_with_tz('Europe/Kyiv')
     def test_variable_tzname(self):
         t0 = datetime.datetime(1984, 1, 1, tzinfo=datetime.timezone.utc)
         t1 = utils.localtime(t0)


### PR DESCRIPTION
tzdata provides Kiev as an alternative to Kyiv:

https://sources.debian.org/src/tzdata/2023c-10/backward/?hl=314#L314

But Debian moved it to the tzdata-legacy package breaking the test:

https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1050530

This patch switches to the name provided by tzdata.