### PR TITLE
gh-108542: Fix incorrect module name in NEWS entry for gh-105475

### DIFF
--- a/Misc/NEWS.d/next/Library/2023-06-09-21-04-39.gh-issue-105375.bTcqS9.rst
+++ b/Misc/NEWS.d/next/Library/2023-06-09-21-04-39.gh-issue-105375.bTcqS9.rst
@@ -1,1 +1,1 @@
-Fix bugs in :mod:`pickle` where exceptions could be overwritten.
+Fix bugs in :mod:`errno` where exceptions could be overwritten.


### PR DESCRIPTION
Fixes #108542.

I'm not sure if I used the correct commit message. I followed the format for other documentation fixes, rather than the usual one with the `gh-` prefix.

<!-- gh-issue-number: gh-108542 -->
* Issue: gh-108542
<!-- /gh-issue-number -->
