### PR TITLE
[3.12] gh-108542: Fix incorrect module name in NEWS entry for gh-105475 (#108543)

### DIFF
--- a/Misc/NEWS.d/3.12.0b3.rst
+++ b/Misc/NEWS.d/3.12.0b3.rst
@@ -281,7 +281,7 @@ Fix bugs in :mod:`zoneinfo` where exceptions could be overwritten.
 .. nonce: bTcqS9
 .. section: Library
 
-Fix bugs in :mod:`pickle` where exceptions could be overwritten.
+Fix bugs in :mod:`errno` where exceptions could be overwritten.
 
 ..
 


### PR DESCRIPTION
(cherry picked from commit a429eafef2d86eafc007ac19682e7d372c32da31)


<!-- gh-issue-number: gh-108542 -->
* Issue: gh-108542
<!-- /gh-issue-number -->
