### PR TITLE
gh-108554: Changing class, methods, and variables, adding comments, fixing grammatical mistakes

### DIFF
--- a/Lib/pdb.py
+++ b/Lib/pdb.py
@@ -12,7 +12,7 @@ To use the debugger in its simplest form:
 The debugger's prompt is '(Pdb) '.  This will stop in the first
 function call in <a statement>.
 
-Alternatively, if a statement terminated with an unhandled exception,
+Alternatively, if a statement is terminated with an unhandled exception,
 you can use pdb's post-mortem facility to inspect the contents of the
 traceback:
 
@@ -40,7 +40,7 @@ When an exception occurs in such a statement, the exception name is
 printed but the debugger's state is not changed.
 
 The debugger supports aliases, which can save typing.  And aliases can
-have parameters (see the alias help entry) which allows one a certain
+have parameters (see the alias help entry) that allow one a certain
 level of adaptability to the context under examination.
 
 Multiple commands may be entered on a single line, separated by the
@@ -64,7 +64,7 @@ Debugger commands
 =================
 
 """
-# NOTE: the actual command documentation is collected from docstrings of the
+# NOTE: The actual command documentation is collected from the docstrings of the
 # commands and is appended to __doc__ after the class has been defined.
 
 import os
@@ -199,7 +199,7 @@ class _ModuleTarget(str):
 
 
 # Interaction prompt line will separate file and call info from code
-# text using value of line_prefix string.  A newline and arrow may
+# text using the value of line_prefix string.  A newline and arrow may
 # be to your liking.  You can set it once pdb is imported using the
 # command "pdb.line_prefix = '\n% '".
 # line_prefix = ': '    # Use this to get the old situation back
@@ -281,7 +281,7 @@ class Pdb(bdb.Bdb, cmd.Cmd):
         self.stack, self.curindex = self.get_stack(f, tb)
         while tb:
             # when setting up post-mortem debugging with a traceback, save all
-            # the original line numbers to be displayed along the current line
+            # the original line numbers are to be displayed along the current line
             # numbers (which can be different, e.g. due to finally clauses)
             lineno = lasti2lineno(tb.tb_frame.f_code, tb.tb_lasti)
             self.tb_lineno[tb.tb_frame] = lineno
@@ -309,7 +309,7 @@ class Pdb(bdb.Bdb, cmd.Cmd):
                 if self.onecmd(line):
                     # if onecmd returns True, the command wants to exit
                     # from the interaction, save leftover rc lines
-                    # to execute before next interaction
+                    # to execute before the next interaction
                     self.rcLines += reversed(rcLines)
                     return True
 
@@ -424,7 +424,7 @@ class Pdb(bdb.Bdb, cmd.Cmd):
             else:
                 Pdb._previous_sigint_handler = None
         if self.setup(frame, traceback):
-            # no interaction desired at this time (happens if .pdbrc contains
+            # no interaction is desired at this time (happens if .pdbrc contains
             # a command like "continue")
             self.forget()
             return
@@ -637,19 +637,19 @@ class Pdb(bdb.Bdb, cmd.Cmd):
         The commands are executed when the breakpoint is hit.
 
         To remove all commands from a breakpoint, type commands and
-        follow it immediately with end; that is, give no commands.
+        follow it immediately with the end; that is, give no commands.
 
-        With no bpnumber argument, commands refers to the last
+        With no bpnumber argument, commands refer to the last
         breakpoint set.
 
         You can use breakpoint commands to start your program up
-        again.  Simply use the continue command, or step, or any other
+        again.  Simply use the continue command, step, or any other
         command that resumes execution.
 
         Specifying any command resuming execution (currently continue,
-        step, next, return, jump, quit and their abbreviations)
+        step, next, return, jump, quit, and their abbreviations)
         terminates the command list (as if that command was
-        immediately followed by end).  This is because any time you
+        immediately followed by the end).  This is because any time you
         resume execution (even with a simple next or step), you may
         encounter another breakpoint -- which could have its own
         command list, leading to ambiguities about which list to
@@ -718,8 +718,8 @@ class Pdb(bdb.Bdb, cmd.Cmd):
         With a line number argument, set a break at this line in the
         current file.  With a function name, set a break at the first
         executable line of that function.  If a second argument is
-        present, it is a string specifying an expression which must
-        evaluate to true before the breakpoint is honored.
+        present, it is a string specifying an expression that must
+        be evaluated to be true before the breakpoint is honored.
 
         The line number may be prefixed with a filename and a colon,
         to specify a breakpoint in another file (probably one that
@@ -887,7 +887,7 @@ class Pdb(bdb.Bdb, cmd.Cmd):
     def do_enable(self, arg):
         """enable bpnumber [bpnumber ...]
 
-        Enables the breakpoints given as a space separated list of
+        Enables the breakpoints given as a space-separated list of
         breakpoint numbers.
         """
         args = arg.split()
@@ -1001,9 +1001,9 @@ class Pdb(bdb.Bdb, cmd.Cmd):
     def do_clear(self, arg):
         """cl(ear) [filename:lineno | bpnumber ...]
 
-        With a space separated list of breakpoint numbers, clear
+        With a space-separated list of breakpoint numbers, clear
         those breakpoints.  Without argument, clear all breaks (but
-        first ask confirmation).  With a filename:lineno argument,
+        first ask for confirmation).  With a filename:lineno argument,
         clear all breaks at that line in that file.
         """
         if not arg:
@@ -1121,7 +1121,7 @@ class Pdb(bdb.Bdb, cmd.Cmd):
         Without argument, continue execution until the line with a
         number greater than the current one is reached.  With a line
         number, continue execution until a line with a number greater
-        or equal to that is reached.  In both cases, also stop when
+        or equal to that is reached.  In both cases, also stops when
         the current frame returns.
         """
         if arg:
@@ -1172,7 +1172,7 @@ class Pdb(bdb.Bdb, cmd.Cmd):
 
         Restart the debugged python program. If a string is supplied
         it is split with "shlex", and the result is used as the new
-        sys.argv.  History, breakpoints, actions and debugger options
+        sys.argv.  History, breakpoints, actions, and debugger options
         are preserved.  "restart" is an alias for "run".
         """
         if arg:
@@ -1384,7 +1384,7 @@ class Pdb(bdb.Bdb, cmd.Cmd):
     def do_list(self, arg):
         """l(ist) [first[, last] | .]
 
-        List source code for the current file.  Without arguments,
+        List the source code for the current file.  Without arguments,
         list 11 lines around the current line or continue the previous
         listing.  With . as argument, list 11 lines around the current
         line.  With one argument, list 11 lines starting at that line.
@@ -1534,7 +1534,7 @@ class Pdb(bdb.Bdb, cmd.Cmd):
     def do_display(self, arg):
         """display [expression]
 
-        Display the value of the expression if it changed, each time execution
+        Display the value of the expression if it changes, each time the execution
         stops in the current frame.
 
         Without expression, list all display expressions for the current frame.
@@ -1559,7 +1559,7 @@ class Pdb(bdb.Bdb, cmd.Cmd):
     def do_undisplay(self, arg):
         """undisplay [expression]
 
-        Do not display the expression any more in the current frame.
+        Do not display the expression anymore in the current frame.
 
         Without expression, clear all display expressions for the current frame.
         """

--- a/Lib/pdb.py
+++ b/Lib/pdb.py
@@ -120,8 +120,6 @@ def lasti2lineno(code, lasti):
             return lineno
     return 0
 
-# Representative string
-
 
 class _repr_str(str):
     """Representative string: a string that doesn't quote its repr."""

--- a/Lib/pdb.py
+++ b/Lib/pdb.py
@@ -12,7 +12,7 @@ To use the debugger in its simplest form:
 The debugger's prompt is '(Pdb) '.  This will stop in the first
 function call in <a statement>.
 
-Alternatively, if a statement is terminated with an unhandled exception,
+Alternatively, if a statement terminated with an unhandled exception,
 you can use pdb's post-mortem facility to inspect the contents of the
 traceback:
 
@@ -40,7 +40,7 @@ When an exception occurs in such a statement, the exception name is
 printed but the debugger's state is not changed.
 
 The debugger supports aliases, which can save typing.  And aliases can
-have parameters (see the alias help entry) that allow one a certain
+have parameters (see the alias help entry) which allows one a certain
 level of adaptability to the context under examination.
 
 Multiple commands may be entered on a single line, separated by the
@@ -64,7 +64,7 @@ Debugger commands
 =================
 
 """
-# NOTE: The actual command documentation is collected from the docstrings of the
+# NOTE: the actual command documentation is collected from docstrings of the
 # commands and is appended to __doc__ after the class has been defined.
 
 import os
@@ -96,19 +96,20 @@ __all__ = ["run", "pm", "Pdb", "runeval", "runctx", "runcall", "set_trace",
            "post_mortem", "help"]
 
 def find_function(funcname, filename):
-    cre = re.compile(r'def\s+%s\s*[(]' % re.escape(funcname))
+    compiled_pattern = re.compile(r'def\s+%s\s*[(]' % re.escape(funcname))
     try:
-        fp = tokenize.open(filename)
+        file_pointer = tokenize.open(filename)
     except OSError:
         return None
     # consumer of this info expects the first line to be 1
-    with fp:
-        for lineno, line in enumerate(fp, start=1):
-            if cre.match(line):
+    with file_pointer:
+        for lineno, line in enumerate(file_pointer, start=1):
+            if compiled_pattern.match(line):
                 return funcname, filename, lineno
     return None
 
 def lasti2lineno(code, lasti):
+    """Get last 2 line number"""
     linestarts = list(dis.findlinestarts(code))
     linestarts.reverse()
     for i, lineno in linestarts:
@@ -116,9 +117,9 @@ def lasti2lineno(code, lasti):
             return lineno
     return 0
 
-
-class _rstr(str):
-    """String that doesn't quote its repr."""
+# Representative string
+class _repr_str(str):
+    """Representative string: a string that doesn't quote its repr."""
     def __repr__(self):
         return self
 
@@ -155,8 +156,8 @@ class _ScriptTarget(str):
 
     @property
     def code(self):
-        with io.open_code(self) as fp:
-            return f"exec(compile({fp.read()!r}, {self!r}, 'exec'))"
+        with io.open_code(self) as file_pointer:
+            return f"exec(compile({file_pointer.read()!r}, {self!r}, 'exec'))"
 
 
 class _ModuleTarget(str):
@@ -199,7 +200,7 @@ class _ModuleTarget(str):
 
 
 # Interaction prompt line will separate file and call info from code
-# text using the value of line_prefix string.  A newline and arrow may
+# text using value of line_prefix string.  A newline and arrow may
 # be to your liking.  You can set it once pdb is imported using the
 # command "pdb.line_prefix = '\n% '".
 # line_prefix = ': '    # Use this to get the old situation back
@@ -221,7 +222,7 @@ class Pdb(bdb.Bdb, cmd.Cmd):
         self.displaying = {}
         self.mainpyfile = ''
         self._wait_for_mainpyfile = False
-        self.tb_lineno = {}
+        self.tb_lineno = {} # traceback line number
         # Try to load readline if it exists
         try:
             import readline
@@ -233,7 +234,7 @@ class Pdb(bdb.Bdb, cmd.Cmd):
         self.nosigint = nosigint
 
         # Read ~/.pdbrc and ./.pdbrc
-        self.rcLines = []
+        self.rcLines = [] # run-command lines
         if readrc:
             try:
                 with open(os.path.expanduser('~/.pdbrc'), encoding='utf-8') as rcFile:
@@ -277,11 +278,12 @@ class Pdb(bdb.Bdb, cmd.Cmd):
         self.tb_lineno.clear()
 
     def setup(self, f, tb):
+        """Inputs: frame, traceback"""
         self.forget()
         self.stack, self.curindex = self.get_stack(f, tb)
         while tb:
             # when setting up post-mortem debugging with a traceback, save all
-            # the original line numbers are to be displayed along the current line
+            # the original line numbers to be displayed along the current line
             # numbers (which can be different, e.g. due to finally clauses)
             lineno = lasti2lineno(tb.tb_frame.f_code, tb.tb_lasti)
             self.tb_lineno[tb.tb_frame] = lineno
@@ -296,6 +298,7 @@ class Pdb(bdb.Bdb, cmd.Cmd):
 
     # Can be executed earlier than 'setup' if desired
     def execRcLines(self):
+        """This function executes the commands in self.rcLines; rc: run commmands"""
         if not self.rcLines:
             return
         # local copy because of recursion
@@ -309,7 +312,7 @@ class Pdb(bdb.Bdb, cmd.Cmd):
                 if self.onecmd(line):
                     # if onecmd returns True, the command wants to exit
                     # from the interaction, save leftover rc lines
-                    # to execute before the next interaction
+                    # to execute before next interaction
                     self.rcLines += reversed(rcLines)
                     return True
 
@@ -424,7 +427,7 @@ class Pdb(bdb.Bdb, cmd.Cmd):
             else:
                 Pdb._previous_sigint_handler = None
         if self.setup(frame, traceback):
-            # no interaction is desired at this time (happens if .pdbrc contains
+            # no interaction desired at this time (happens if .pdbrc contains
             # a command like "continue")
             self.forget()
             return
@@ -637,19 +640,19 @@ class Pdb(bdb.Bdb, cmd.Cmd):
         The commands are executed when the breakpoint is hit.
 
         To remove all commands from a breakpoint, type commands and
-        follow it immediately with the end; that is, give no commands.
+        follow it immediately with end; that is, give no commands.
 
-        With no bpnumber argument, commands refer to the last
+        With no bpnumber argument, commands refers to the last
         breakpoint set.
 
         You can use breakpoint commands to start your program up
-        again.  Simply use the continue command, step, or any other
+        again.  Simply use the continue command, or step, or any other
         command that resumes execution.
 
         Specifying any command resuming execution (currently continue,
-        step, next, return, jump, quit, and their abbreviations)
+        step, next, return, jump, quit and their abbreviations)
         terminates the command list (as if that command was
-        immediately followed by the end).  This is because any time you
+        immediately followed by end).  This is because any time you
         resume execution (even with a simple next or step), you may
         encounter another breakpoint -- which could have its own
         command list, leading to ambiguities about which list to
@@ -718,8 +721,8 @@ class Pdb(bdb.Bdb, cmd.Cmd):
         With a line number argument, set a break at this line in the
         current file.  With a function name, set a break at the first
         executable line of that function.  If a second argument is
-        present, it is a string specifying an expression that must
-        be evaluated to be true before the breakpoint is honored.
+        present, it is a string specifying an expression which must
+        evaluate to true before the breakpoint is honored.
 
         The line number may be prefixed with a filename and a colon,
         to specify a breakpoint in another file (probably one that
@@ -887,7 +890,7 @@ class Pdb(bdb.Bdb, cmd.Cmd):
     def do_enable(self, arg):
         """enable bpnumber [bpnumber ...]
 
-        Enables the breakpoints given as a space-separated list of
+        Enables the breakpoints given as a space separated list of
         breakpoint numbers.
         """
         args = arg.split()
@@ -1001,9 +1004,9 @@ class Pdb(bdb.Bdb, cmd.Cmd):
     def do_clear(self, arg):
         """cl(ear) [filename:lineno | bpnumber ...]
 
-        With a space-separated list of breakpoint numbers, clear
+        With a space separated list of breakpoint numbers, clear
         those breakpoints.  Without argument, clear all breaks (but
-        first ask for confirmation).  With a filename:lineno argument,
+        first ask confirmation).  With a filename:lineno argument,
         clear all breaks at that line in that file.
         """
         if not arg:
@@ -1121,7 +1124,7 @@ class Pdb(bdb.Bdb, cmd.Cmd):
         Without argument, continue execution until the line with a
         number greater than the current one is reached.  With a line
         number, continue execution until a line with a number greater
-        or equal to that is reached.  In both cases, also stops when
+        or equal to that is reached.  In both cases, also stop when
         the current frame returns.
         """
         if arg:
@@ -1172,7 +1175,7 @@ class Pdb(bdb.Bdb, cmd.Cmd):
 
         Restart the debugged python program. If a string is supplied
         it is split with "shlex", and the result is used as the new
-        sys.argv.  History, breakpoints, actions, and debugger options
+        sys.argv.  History, breakpoints, actions and debugger options
         are preserved.  "restart" is an alias for "run".
         """
         if arg:
@@ -1347,7 +1350,7 @@ class Pdb(bdb.Bdb, cmd.Cmd):
             else:
                 return eval(arg, frame.f_globals, frame.f_locals)
         except BaseException as exc:
-            return _rstr('** raised %s **' % self._format_exc(exc))
+            return _repr_str('** raised %s **' % self._format_exc(exc))
 
     def _error_exc(self):
         exc = sys.exception()
@@ -1384,7 +1387,7 @@ class Pdb(bdb.Bdb, cmd.Cmd):
     def do_list(self, arg):
         """l(ist) [first[, last] | .]
 
-        List the source code for the current file.  Without arguments,
+        List source code for the current file.  Without arguments,
         list 11 lines around the current line or continue the previous
         listing.  With . as argument, list 11 lines around the current
         line.  With one argument, list 11 lines starting at that line.
@@ -1534,7 +1537,7 @@ class Pdb(bdb.Bdb, cmd.Cmd):
     def do_display(self, arg):
         """display [expression]
 
-        Display the value of the expression if it changes, each time the execution
+        Display the value of the expression if it changed, each time execution
         stops in the current frame.
 
         Without expression, list all display expressions for the current frame.
@@ -1559,7 +1562,7 @@ class Pdb(bdb.Bdb, cmd.Cmd):
     def do_undisplay(self, arg):
         """undisplay [expression]
 
-        Do not display the expression anymore in the current frame.
+        Do not display the expression any more in the current frame.
 
         Without expression, clear all display expressions for the current frame.
         """
@@ -1768,7 +1771,7 @@ class Pdb(bdb.Bdb, cmd.Cmd):
         try:
             compile(expr, "<stdin>", "eval")
         except SyntaxError as exc:
-            return _rstr(self._format_exc(exc))
+            return _repr_str(self._format_exc(exc))
         return ""
 
     def _getsourcelines(self, obj):

--- a/Lib/pdb.py
+++ b/Lib/pdb.py
@@ -92,8 +92,10 @@ class Restart(Exception):
     """Causes a debugger to be restarted for the debugged python program."""
     pass
 
+
 __all__ = ["run", "pm", "Pdb", "runeval", "runctx", "runcall", "set_trace",
            "post_mortem", "help"]
+
 
 def find_function(funcname, filename):
     compiled_pattern = re.compile(r'def\s+%s\s*[(]' % re.escape(funcname))
@@ -108,6 +110,7 @@ def find_function(funcname, filename):
                 return funcname, filename, lineno
     return None
 
+
 def lasti2lineno(code, lasti):
     """Get last 2 line number"""
     linestarts = list(dis.findlinestarts(code))
@@ -118,8 +121,11 @@ def lasti2lineno(code, lasti):
     return 0
 
 # Representative string
+
+
 class _repr_str(str):
     """Representative string: a string that doesn't quote its repr."""
+
     def __repr__(self):
         return self
 
@@ -206,6 +212,7 @@ class _ModuleTarget(str):
 # line_prefix = ': '    # Use this to get the old situation back
 line_prefix = '\n-> '   # Probably a better default
 
+
 class Pdb(bdb.Bdb, cmd.Cmd):
 
     _previous_sigint_handler = None
@@ -222,7 +229,7 @@ class Pdb(bdb.Bdb, cmd.Cmd):
         self.displaying = {}
         self.mainpyfile = ''
         self._wait_for_mainpyfile = False
-        self.tb_lineno = {} # traceback line number
+        self.tb_lineno = {}  # traceback line number
         # Try to load readline if it exists
         try:
             import readline
@@ -234,7 +241,7 @@ class Pdb(bdb.Bdb, cmd.Cmd):
         self.nosigint = nosigint
 
         # Read ~/.pdbrc and ./.pdbrc
-        self.rcLines = [] # run-command lines
+        self.rcLines = []  # run-command lines
         if readrc:
             try:
                 with open(os.path.expanduser('~/.pdbrc'), encoding='utf-8') as rcFile:
@@ -247,15 +254,15 @@ class Pdb(bdb.Bdb, cmd.Cmd):
             except OSError:
                 pass
 
-        self.commands = {} # associates a command list to breakpoint numbers
-        self.commands_doprompt = {} # for each bp num, tells if the prompt
-                                    # must be disp. after execing the cmd list
-        self.commands_silent = {} # for each bp num, tells if the stack trace
-                                  # must be disp. after execing the cmd list
-        self.commands_defining = False # True while in the process of defining
-                                       # a command list
-        self.commands_bnum = None # The breakpoint number for which we are
-                                  # defining a list
+        self.commands = {}  # associates a command list to breakpoint numbers
+        self.commands_doprompt = {}  # for each bp num, tells if the prompt
+        # must be disp. after execing the cmd list
+        self.commands_silent = {}  # for each bp num, tells if the stack trace
+        # must be disp. after execing the cmd list
+        self.commands_defining = False  # True while in the process of defining
+        # a command list
+        self.commands_bnum = None  # The breakpoint number for which we are
+        # defining a list
 
     def sigint_handler(self, signum, frame):
         if self.allow_kbdint:
@@ -331,7 +338,7 @@ class Pdb(bdb.Bdb, cmd.Cmd):
         """This function is called when we stop or break at this line."""
         if self._wait_for_mainpyfile:
             if (self.mainpyfile != self.canonic(frame.f_code.co_filename)
-                or frame.f_lineno <= 0):
+                    or frame.f_lineno <= 0):
                 return
             self._wait_for_mainpyfile = False
         if self.bp_commands(frame):
@@ -343,9 +350,10 @@ class Pdb(bdb.Bdb, cmd.Cmd):
 
         Returns True if the normal interaction function must be called,
         False otherwise."""
-        # self.currentbp is set in bdb in Bdb.break_here if a breakpoint was hit
+        # self.currentbp is set in bdb in Bdb.break_here if a breakpoint was
+        # hit
         if getattr(self, "currentbp", False) and \
-               self.currentbp in self.commands:
+                self.currentbp in self.commands:
             currentbp = self.currentbp
             self.currentbp = 0
             lastcmd_back = self.lastcmd
@@ -385,7 +393,7 @@ class Pdb(bdb.Bdb, cmd.Cmd):
         # actually occurred in this case. The debugger uses this debug event to
         # stop when the debuggee is returning from such generators.
         prefix = 'Internal ' if (not exc_traceback
-                                    and exc_type is StopIteration) else ''
+                                 and exc_type is StopIteration) else ''
         self.message('%s%s' % (prefix, self._format_exc(exc_value)))
         self.interaction(frame, exc_traceback)
 
@@ -444,15 +452,21 @@ class Pdb(bdb.Bdb, cmd.Cmd):
             self.message(repr(obj))
 
     def default(self, line):
-        if line[:1] == '!': line = line[1:].strip()
+        if line[:1] == '!':
+            line = line[1:].strip()
         locals = self.curframe_locals
         globals = self.curframe.f_globals
         try:
-            if (code := codeop.compile_command(line + '\n', '<stdin>', 'single')) is None:
+            if (code := codeop.compile_command(
+                    line + '\n', '<stdin>', 'single')) is None:
                 # Multi-line mode
                 buffer = line
                 continue_prompt = "...   "
-                while (code := codeop.compile_command(buffer, '<stdin>', 'single')) is None:
+                while (
+                    code := codeop.compile_command(
+                        buffer,
+                        '<stdin>',
+                        'single')) is None:
                     if self.use_rawinput:
                         try:
                             line = input(continue_prompt)
@@ -484,7 +498,7 @@ class Pdb(bdb.Bdb, cmd.Cmd):
                 sys.stdout = save_stdout
                 sys.stdin = save_stdin
                 sys.displayhook = save_displayhook
-        except:
+        except BaseException:
             self._error_exc()
 
     def precmd(self, line):
@@ -497,7 +511,7 @@ class Pdb(bdb.Bdb, cmd.Cmd):
             ii = 1
             for tmpArg in args[1:]:
                 line = line.replace("%" + str(ii),
-                                      tmpArg)
+                                    tmpArg)
                 ii += 1
             line = line.replace("%*", ' '.join(args[1:]))
             args = line.split()
@@ -507,12 +521,15 @@ class Pdb(bdb.Bdb, cmd.Cmd):
             marker = line.find(';;')
             if marker >= 0:
                 # queue up everything after marker
-                next = line[marker+2:].lstrip()
+                next = line[marker + 2:].lstrip()
                 self.cmdqueue.append(next)
                 line = line[:marker].rstrip()
 
         # Replace all the convenience variables
-        line = re.sub(r'\$([a-zA-Z_][a-zA-Z0-9_]*)', r'__pdb_convenience_variables["\1"]', line)
+        line = re.sub(
+            r'\$([a-zA-Z_][a-zA-Z0-9_]*)',
+            r'__pdb_convenience_variables["\1"]',
+            line)
         return line
 
     def onecmd(self, line):
@@ -534,13 +551,13 @@ class Pdb(bdb.Bdb, cmd.Cmd):
             return
         if cmd == 'silent':
             self.commands_silent[self.commands_bnum] = True
-            return # continue to handle other cmd def in the cmd list
+            return  # continue to handle other cmd def in the cmd list
         elif cmd == 'end':
             self.cmdqueue = []
-            return 1 # end of cmd list
+            return 1  # end of cmd list
         cmdlist = self.commands[self.commands_bnum]
         if arg:
-            cmdlist.append(cmd+' '+arg)
+            cmdlist.append(cmd + ' ' + arg)
         else:
             cmdlist.append(cmd)
         # Determine if we must stop
@@ -670,7 +687,7 @@ class Pdb(bdb.Bdb, cmd.Cmd):
         else:
             try:
                 bnum = int(arg)
-            except:
+            except BaseException:
                 self._print_invalid_arg(arg)
                 return
         try:
@@ -713,7 +730,7 @@ class Pdb(bdb.Bdb, cmd.Cmd):
 
     complete_commands = _complete_bpnumber
 
-    def do_break(self, arg, temporary = 0):
+    def do_break(self, arg, temporary=0):
         """b(reak) [ ([filename:]lineno | function) [, condition] ]
 
         Without argument, list all breaks.
@@ -744,7 +761,7 @@ class Pdb(bdb.Bdb, cmd.Cmd):
         comma = arg.find(',')
         if comma > 0:
             # parse stuff after comma: "condition"
-            cond = arg[comma+1:].lstrip()
+            cond = arg[comma + 1:].lstrip()
             if err := self._compile_error_message(cond):
                 self.error('Invalid condition %s: %r' % (cond, err))
                 return
@@ -760,7 +777,7 @@ class Pdb(bdb.Bdb, cmd.Cmd):
                 return
             else:
                 filename = f
-            arg = arg[colon+1:].lstrip()
+            arg = arg[colon + 1:].lstrip()
             try:
                 lineno = int(arg)
             except ValueError:
@@ -775,25 +792,25 @@ class Pdb(bdb.Bdb, cmd.Cmd):
                     func = eval(arg,
                                 self.curframe.f_globals,
                                 self.curframe_locals)
-                except:
+                except BaseException:
                     func = arg
                 try:
                     if hasattr(func, '__func__'):
                         func = func.__func__
                     code = func.__code__
-                    #use co_name to identify the bkpt (function names
-                    #could be aliased, but co_name is invariant)
+                    # use co_name to identify the bkpt (function names
+                    # could be aliased, but co_name is invariant)
                     funcname = code.co_name
                     lineno = code.co_firstlineno
                     filename = code.co_filename
-                except:
+                except BaseException:
                     # last thing to try
                     (ok, filename, ln) = self.lineinfo(arg)
                     if not ok:
                         self.error('The specified object %r is not a function '
                                    'or was not found along sys.path.' % arg)
                         return
-                    funcname = ok # ok contains a function name
+                    funcname = ok  # ok contains a function name
                     lineno = int(ln)
         if not filename:
             filename = self.defaultFile()
@@ -844,7 +861,8 @@ class Pdb(bdb.Bdb, cmd.Cmd):
             id = idstring[1].strip()
         else:
             return failed
-        if id == '': return failed
+        if id == '':
+            return failed
         parts = id.split('.')
         # Protection for derived debuggers
         if parts[0] == 'self':
@@ -882,7 +900,7 @@ class Pdb(bdb.Bdb, cmd.Cmd):
         line = line.strip()
         # Don't allow setting breakpoint at a blank line
         if (not line or (line[0] == '#') or
-             (line[:3] == '"""') or line[:3] == "'''"):
+                (line[:3] == '"""') or line[:3] == "'''"):
             self.error('Blank or comment')
             return 0
         return lineno
@@ -953,7 +971,9 @@ class Pdb(bdb.Bdb, cmd.Cmd):
             if not cond:
                 self.message('Breakpoint %d is now unconditional.' % bp.number)
             else:
-                self.message('New condition set for breakpoint %d.' % bp.number)
+                self.message(
+                    'New condition set for breakpoint %d.' %
+                    bp.number)
 
     complete_condition = _complete_bpnumber
 
@@ -1025,7 +1045,7 @@ class Pdb(bdb.Bdb, cmd.Cmd):
             # Make sure it works for "clear C:\foo\bar.py:12"
             i = arg.rfind(':')
             filename = arg[:i]
-            arg = arg[i+1:]
+            arg = arg[i + 1:]
             try:
                 lineno = int(arg)
             except ValueError:
@@ -1048,7 +1068,7 @@ class Pdb(bdb.Bdb, cmd.Cmd):
             else:
                 self.clear_bpbynumber(i)
                 self.message('Deleted %s' % bp)
-    do_cl = do_clear # 'c' is already an abbreviation for 'continue'
+    do_cl = do_clear  # 'c' is already an abbreviation for 'continue'
 
     complete_clear = _complete_location
     complete_cl = _complete_location
@@ -1312,8 +1332,10 @@ class Pdb(bdb.Bdb, cmd.Cmd):
         co = self.curframe.f_code
         dict = self.curframe_locals
         n = co.co_argcount + co.co_kwonlyargcount
-        if co.co_flags & inspect.CO_VARARGS: n = n+1
-        if co.co_flags & inspect.CO_VARKEYWORDS: n = n+1
+        if co.co_flags & inspect.CO_VARARGS:
+            n = n + 1
+        if co.co_flags & inspect.CO_VARKEYWORDS:
+            n = n + 1
         for i in range(n):
             name = co.co_varnames[i]
             if name in dict:
@@ -1339,7 +1361,7 @@ class Pdb(bdb.Bdb, cmd.Cmd):
     def _getval(self, arg):
         try:
             return eval(arg, self.curframe.f_globals, self.curframe_locals)
-        except:
+        except BaseException:
             self._error_exc()
             raise
 
@@ -1359,11 +1381,11 @@ class Pdb(bdb.Bdb, cmd.Cmd):
     def _msg_val_func(self, arg, func):
         try:
             val = self._getval(arg)
-        except:
+        except BaseException:
             return  # _getval() has displayed the error
         try:
             self.message(func(val))
-        except:
+        except BaseException:
             self._error_exc()
 
     def do_p(self, arg):
@@ -1432,7 +1454,7 @@ class Pdb(bdb.Bdb, cmd.Cmd):
         breaklist = self.get_file_breaks(filename)
         try:
             lines = linecache.getlines(filename, self.curframe.f_globals)
-            self._print_lines(lines[first-1:last], first, breaklist,
+            self._print_lines(lines[first - 1:last], first, breaklist,
                               self.curframe)
             self.lineno = min(last, len(lines))
             if len(lines) < last:
@@ -1466,7 +1488,7 @@ class Pdb(bdb.Bdb, cmd.Cmd):
         """
         try:
             obj = self._getval(arg)
-        except:
+        except BaseException:
             return
         try:
             lines, lineno = self._getsourcelines(obj)
@@ -1505,7 +1527,7 @@ class Pdb(bdb.Bdb, cmd.Cmd):
         """
         try:
             value = self._getval(arg)
-        except:
+        except BaseException:
             # _getval() already printed the error
             return
         code = None
@@ -1527,7 +1549,9 @@ class Pdb(bdb.Bdb, cmd.Cmd):
             return
         # Is it a class?
         if value.__class__ is type:
-            self.message('Class %s.%s' % (value.__module__, value.__qualname__))
+            self.message(
+                'Class %s.%s' %
+                (value.__module__, value.__qualname__))
             return
         # None of the above...
         self.message(type(value))
@@ -1725,10 +1749,10 @@ class Pdb(bdb.Bdb, cmd.Cmd):
         lookupmodule() translates (possibly incomplete) file or module name
         into an absolute file name.
         """
-        if os.path.isabs(filename) and  os.path.exists(filename):
+        if os.path.isabs(filename) and os.path.exists(filename):
             return filename
         f = os.path.join(sys.path[0], filename)
-        if  os.path.exists(f) and self.canonic(f) == self.mainpyfile:
+        if os.path.exists(f) and self.canonic(f) == self.mainpyfile:
             return f
         root, ext = os.path.splitext(filename)
         if ext == '':
@@ -1820,6 +1844,7 @@ class Pdb(bdb.Bdb, cmd.Cmd):
 
 # Collect all command help into docstring, if not run with -OO
 
+
 if __doc__ is not None:
     # unfortunately we can't guess this order from the class definition
     _help_order = [
@@ -1854,6 +1879,7 @@ def run(statement, globals=None, locals=None):
     """
     Pdb().run(statement, globals, locals)
 
+
 def runeval(expression, globals=None, locals=None):
     """Evaluate the *expression* (given as a string or a code object)
     under debugger control.
@@ -1863,9 +1889,11 @@ def runeval(expression, globals=None, locals=None):
     """
     return Pdb().runeval(expression, globals, locals)
 
+
 def runctx(statement, globals, locals):
     # B/W compatibility
     run(statement, globals, locals)
+
 
 def runcall(*args, **kwds):
     """Call the function (a function or method object, not a string)
@@ -1876,6 +1904,7 @@ def runcall(*args, **kwds):
     entered.
     """
     return Pdb().runcall(*args, **kwds)
+
 
 def set_trace(*, header=None):
     """Enter the debugger at the calling stack frame.
@@ -1891,6 +1920,7 @@ def set_trace(*, header=None):
     pdb.set_trace(sys._getframe().f_back)
 
 # Post-Mortem interface
+
 
 def post_mortem(t=None):
     """Enter post-mortem debugging of the given *traceback* object.
@@ -1913,6 +1943,7 @@ def post_mortem(t=None):
     p.reset()
     p.interaction(None, t)
 
+
 def pm():
     """Enter post-mortem debugging of the traceback found in sys.last_traceback."""
     if hasattr(sys, 'last_exc'):
@@ -1926,13 +1957,17 @@ def pm():
 
 TESTCMD = 'import x; x.main()'
 
+
 def test():
     run(TESTCMD)
 
 # print help
+
+
 def help():
     import pydoc
     pydoc.pager(__doc__)
+
 
 _usage = """\
 usage: pdb.py [-c command] ... [-m module | pyfile] [arg] ...

--- a/Misc/NEWS.d/next/Library/2023-08-28-03-42-50.gh-issue-108554.JPMdn8.rst
+++ b/Misc/NEWS.d/next/Library/2023-08-28-03-42-50.gh-issue-108554.JPMdn8.rst
@@ -1,0 +1,9 @@
+On Lib/pdb.py :
+`cre` to `compiled_pattern`
+`fp` to `file_pointer`
+`_rstr` to `_repr_str`
+and comments:
+`#run-command lines` to rcLines
+`"""Inputs: frame, traceback"""` to setup(self, f, tb) due to the vagueness of `f` and `tb`
+`# Representative string` to `_repr_str`
+In order to fix the numerous issues regarding the ambiguity of some code.


### PR DESCRIPTION
# Request to Change Names, Add Comments, and Fix Grammatical Mistakes

```
gh-108554: Summary of the changes made
```
As explained in my issue post, I made these changes to the [PDB](https://github.com/python/cpython/blob/main/Lib/pdb.py) lib:
`cre` to `compiled_pattern`
`fp` to `file_pointer`
`_rstr` to `_repr_str`
and comments:
`#run-command lines` to rcLines
`"""Inputs: frame, traceback"""` to setup(self, f, tb) due to the vagueness of `f` and `tb`
and other comments regarding the ambiguity of some code

In addition, I also linted pdb.py using `autopep8 --in-place --aggressive --aggressive pdb.py`, which fixed some misplaced comments left in the document.

Again, thank you all!👍 