### PR TITLE
fixing a typo in docs: Remove redundant back quote

### DIFF
--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -462,7 +462,7 @@ contrast, a variable annotated with ``type[C]`` (or
 themselves -- specifically, it will accept the *class object* of ``C``. For
 example::
 
-   a = 3         # Has type ``int```
+   a = 3         # Has type ``int``
    b = int       # Has type ``type[int]``
    c = type(a)   # Also has type ``type[int]``
 


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

I noticed a trivial change while reading the typing module's documentation.

Writers use double back quotes in the code comments to show the type.
example:

```
``tuple``
```

I noticed there are **triple** back quotes.
https://docs.python.org/3/library/typing.html#the-type-of-class-objects

```python
a = 3         # Has type ``int```
```

I believe we should enclose with two back quotes for a consistent style throughout the document.

<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--108559.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->