### PR TITLE
[3.11] gh-64662: Fix virtual table support in sqlite3.Connection.iterdump (#108340)

### DIFF
--- a/Lib/sqlite3/dump.py
+++ b/Lib/sqlite3/dump.py
@@ -49,8 +49,8 @@ def _iterdump(connection):
                 yield('PRAGMA writable_schema=ON;')
             yield("INSERT INTO sqlite_master(type,name,tbl_name,rootpage,sql)"
                   "VALUES('table',{0},{0},0,{1});".format(
-                      _quote_value(table_name),
-                      _quote_value(sql),
+                      table_name.replace("'", "''"),
+                      sql.replace("'", "''"),
                   ))
         else:
             yield('{0};'.format(sql))

--- a/Lib/sqlite3/dump.py
+++ b/Lib/sqlite3/dump.py
@@ -48,7 +48,7 @@ def _iterdump(connection):
                 writeable_schema = True
                 yield('PRAGMA writable_schema=ON;')
             yield("INSERT INTO sqlite_master(type,name,tbl_name,rootpage,sql)"
-                  "VALUES('table',{0!r},{0!r},0,{1!r});".format(
+                  "VALUES('table','{0}','{0}',0,'{1}');".format(
                       table_name.replace("'", "''"),
                       sql.replace("'", "''"),
                   ))

--- a/Lib/sqlite3/dump.py
+++ b/Lib/sqlite3/dump.py
@@ -16,6 +16,7 @@ def _iterdump(connection):
     directly but instead called from the Connection method, iterdump().
     """
 
+    writeable_schema = False
     cu = connection.cursor()
     yield('BEGIN TRANSACTION;')
 
@@ -42,13 +43,15 @@ def _iterdump(connection):
             yield('ANALYZE "sqlite_master";')
         elif table_name.startswith('sqlite_'):
             continue
-        # NOTE: Virtual table support not implemented
-        #elif sql.startswith('CREATE VIRTUAL TABLE'):
-        #    qtable = table_name.replace("'", "''")
-        #    yield("INSERT INTO sqlite_master(type,name,tbl_name,rootpage,sql)"\
-        #        "VALUES('table','{0}','{0}',0,'{1}');".format(
-        #        qtable,
-        #        sql.replace("''")))
+        elif sql.startswith('CREATE VIRTUAL TABLE'):
+            if not writeable_schema:
+                writeable_schema = True
+                yield('PRAGMA writable_schema=ON;')
+            yield("INSERT INTO sqlite_master(type,name,tbl_name,rootpage,sql)"
+                  "VALUES('table',{0},{0},0,{1});".format(
+                      _quote_value(table_name),
+                      _quote_value(sql),
+                  ))
         else:
             yield('{0};'.format(sql))
 
@@ -73,6 +76,9 @@ def _iterdump(connection):
     schema_res = cu.execute(q)
     for name, type, sql in schema_res.fetchall():
         yield('{0};'.format(sql))
+
+    if writeable_schema:
+        yield('PRAGMA writable_schema=OFF;')
 
     # gh-79009: Yield statements concerning the sqlite_sequence table at the
     # end of the transaction.

--- a/Lib/sqlite3/dump.py
+++ b/Lib/sqlite3/dump.py
@@ -48,7 +48,7 @@ def _iterdump(connection):
                 writeable_schema = True
                 yield('PRAGMA writable_schema=ON;')
             yield("INSERT INTO sqlite_master(type,name,tbl_name,rootpage,sql)"
-                  "VALUES('table',{0},{0},0,{1});".format(
+                  "VALUES('table',{0!r},{0!r},0,{1!r});".format(
                       table_name.replace("'", "''"),
                       sql.replace("'", "''"),
                   ))

--- a/Lib/test/test_sqlite3/test_dump.py
+++ b/Lib/test/test_sqlite3/test_dump.py
@@ -117,6 +117,26 @@ class DumpTests(unittest.TestCase):
         got = list(self.cx.iterdump())
         self.assertEqual(expected, got)
 
+    def test_dump_virtual_tables(self):
+        # gh-64662
+        expected = [
+            "BEGIN TRANSACTION;",
+            "PRAGMA writable_schema=ON;",
+            ("INSERT INTO sqlite_master(type,name,tbl_name,rootpage,sql)"
+             "VALUES('table','test','test',0,'CREATE VIRTUAL TABLE test USING fts4(example)');"),
+            "CREATE TABLE 'test_content'(docid INTEGER PRIMARY KEY, 'c0example');",
+            "CREATE TABLE 'test_docsize'(docid INTEGER PRIMARY KEY, size BLOB);",
+            ("CREATE TABLE 'test_segdir'(level INTEGER,idx INTEGER,start_block INTEGER,"
+             "leaves_end_block INTEGER,end_block INTEGER,root BLOB,PRIMARY KEY(level, idx));"),
+            "CREATE TABLE 'test_segments'(blockid INTEGER PRIMARY KEY, block BLOB);",
+            "CREATE TABLE 'test_stat'(id INTEGER PRIMARY KEY, value BLOB);",
+            "PRAGMA writable_schema=OFF;",
+            "COMMIT;"
+        ]
+        self.cu.execute("CREATE VIRTUAL TABLE test USING fts4(example)")
+        actual = list(self.cx.iterdump())
+        self.assertEqual(expected, actual)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/Misc/NEWS.d/next/Library/2023-08-22-22-29-42.gh-issue-64662.jHl_Bt.rst
+++ b/Misc/NEWS.d/next/Library/2023-08-22-22-29-42.gh-issue-64662.jHl_Bt.rst
@@ -1,0 +1,2 @@
+Fix support for virtual tables in :meth:`sqlite3.Connection.iterdump`. Patch
+by Aviv Palivoda.


### PR DESCRIPTION
(cherry picked from commit d0160c7c22c8dff0a61c49b5304244df6e36465e)

Co-authored-by: Aviv Palivoda <palaviv@gmail.com>


<!-- gh-issue-number: gh-64662 -->
* Issue: gh-64662
<!-- /gh-issue-number -->
