### PR TITLE
gh-108520: Fix bad fork detection in nested multiprocessing use case

### DIFF
--- a/Lib/multiprocessing/synchronize.py
+++ b/Lib/multiprocessing/synchronize.py
@@ -115,7 +115,7 @@ class SemLock(object):
         self._semlock = _multiprocessing.SemLock._rebuild(*state)
         util.debug('recreated blocker with handle %r' % state[0])
         self._make_methods()
-        # Ensure that deserialized SemLock can be serialized again (gh-108568).
+        # Ensure that deserialized SemLock can be serialized again (gh-108520).
         self._is_fork_ctx = False
 
     @staticmethod

--- a/Lib/multiprocessing/synchronize.py
+++ b/Lib/multiprocessing/synchronize.py
@@ -103,7 +103,7 @@ class SemLock(object):
         if sys.platform == 'win32':
             h = context.get_spawning_popen().duplicate_for_child(sl.handle)
         else:
-            if getattr(self, "is_fork_ctx", False):
+            if self.is_fork_ctx:
                 raise RuntimeError('A SemLock created in a fork context is being '
                                    'shared with a process in a spawn context. This is '
                                    'not supported. Please use the same context to create '
@@ -115,6 +115,8 @@ class SemLock(object):
         self._semlock = _multiprocessing.SemLock._rebuild(*state)
         util.debug('recreated blocker with handle %r' % state[0])
         self._make_methods()
+        # SemLock created in fork context cannot be serialized
+        self.is_fork_ctx = False
 
     @staticmethod
     def _make_name():

--- a/Lib/multiprocessing/synchronize.py
+++ b/Lib/multiprocessing/synchronize.py
@@ -103,7 +103,7 @@ class SemLock(object):
         if sys.platform == 'win32':
             h = context.get_spawning_popen().duplicate_for_child(sl.handle)
         else:
-            if self.is_fork_ctx:
+            if getattr(self, "is_fork_ctx", False):
                 raise RuntimeError('A SemLock created in a fork context is being '
                                    'shared with a process in a spawn context. This is '
                                    'not supported. Please use the same context to create '

--- a/Lib/multiprocessing/synchronize.py
+++ b/Lib/multiprocessing/synchronize.py
@@ -115,7 +115,7 @@ class SemLock(object):
         self._semlock = _multiprocessing.SemLock._rebuild(*state)
         util.debug('recreated blocker with handle %r' % state[0])
         self._make_methods()
-        # SemLock created in fork context cannot be serialized
+        # Ensure that deserialized SemLock can be serialized again (gh-108568).
         self._is_fork_ctx = False
 
     @staticmethod

--- a/Lib/multiprocessing/synchronize.py
+++ b/Lib/multiprocessing/synchronize.py
@@ -50,8 +50,8 @@ class SemLock(object):
     def __init__(self, kind, value, maxvalue, *, ctx):
         if ctx is None:
             ctx = context._default_context.get_context()
-        self.is_fork_ctx = ctx.get_start_method() == 'fork'
-        unlink_now = sys.platform == 'win32' or self.is_fork_ctx
+        self._is_fork_ctx = ctx.get_start_method() == 'fork'
+        unlink_now = sys.platform == 'win32' or self._is_fork_ctx
         for i in range(100):
             try:
                 sl = self._semlock = _multiprocessing.SemLock(
@@ -103,7 +103,7 @@ class SemLock(object):
         if sys.platform == 'win32':
             h = context.get_spawning_popen().duplicate_for_child(sl.handle)
         else:
-            if self.is_fork_ctx:
+            if self._is_fork_ctx:
                 raise RuntimeError('A SemLock created in a fork context is being '
                                    'shared with a process in a spawn context. This is '
                                    'not supported. Please use the same context to create '
@@ -116,7 +116,7 @@ class SemLock(object):
         util.debug('recreated blocker with handle %r' % state[0])
         self._make_methods()
         # SemLock created in fork context cannot be serialized
-        self.is_fork_ctx = False
+        self._is_fork_ctx = False
 
     @staticmethod
     def _make_name():

--- a/Misc/NEWS.d/next/Core and Builtins/2023-08-30-15-41-47.gh-issue-108520.u0ZGP_.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2023-08-30-15-41-47.gh-issue-108520.u0ZGP_.rst
@@ -1,0 +1,2 @@
+Rename :attr:`multiprocessing.synchronize.SemLock.is_fork_ctx` to :attr:`multiprocessing.synchronize.SemLock._is_fork_ctx` to avoid exposing it as public API.
+Fix :meth:`multiprocessing.synchronize.SemLock.__setstate__` to properly initialize :attr:`multiprocessing.synchronize.SemLock._is_fork_ctx`.

--- a/Misc/NEWS.d/next/Core and Builtins/2023-08-30-15-41-47.gh-issue-108520.u0ZGP_.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2023-08-30-15-41-47.gh-issue-108520.u0ZGP_.rst
@@ -1,2 +1,3 @@
+Fix :meth:`multiprocessing.synchronize.SemLock.__setstate__` to properly initialize :attr:`multiprocessing.synchronize.SemLock._is_fork_ctx`. This fixes a regression when passing a SemLock accross nested processes.
+
 Rename :attr:`multiprocessing.synchronize.SemLock.is_fork_ctx` to :attr:`multiprocessing.synchronize.SemLock._is_fork_ctx` to avoid exposing it as public API.
-Fix :meth:`multiprocessing.synchronize.SemLock.__setstate__` to properly initialize :attr:`multiprocessing.synchronize.SemLock._is_fork_ctx`.


### PR DESCRIPTION
gh-107275 introduced a regression where a SemLock would fail being passed along nested child processes, as the `is_fork_ctx` attribute would be left missing after the first deserialization.

<!-- gh-issue-number: gh-108520 -->
* Issue: gh-108520
<!-- /gh-issue-number -->
