### PR TITLE
gh-85283: _scproxy uses the limited C API

### DIFF
--- a/Misc/NEWS.d/next/C API/2023-08-28-17-58-46.gh-issue-85283.-4lp73.rst
+++ b/Misc/NEWS.d/next/C API/2023-08-28-17-58-46.gh-issue-85283.-4lp73.rst
@@ -1,0 +1,2 @@
+The ``_scproxy`` (macOS) C extension is now built with the :ref:`limited C API
+<limited-c-api>`. Patch by Victor Stinner.

--- a/Modules/_scproxy.c
+++ b/Modules/_scproxy.c
@@ -2,6 +2,8 @@
  * Helper method for urllib to fetch the proxy configuration settings
  * using the SystemConfiguration framework.
  */
+#define Py_LIMITED_API 0x030d0000
+
 #include <Python.h>
 #include <SystemConfiguration/SystemConfiguration.h>
 

--- a/Modules/_scproxy.c
+++ b/Modules/_scproxy.c
@@ -86,7 +86,7 @@ get_proxy_settings(PyObject* Py_UNUSED(mod), PyObject *Py_UNUSED(ignored))
     if (v == NULL) goto error;
 
     r = PyDict_SetItemString(result, "exclude_simple", v);
-    Py_SETREF(v, NULL);
+    Py_CLEAR(v);
     if (r == -1) goto error;
 
     anArray = CFDictionaryGetValue(proxyDict,


### PR DESCRIPTION
The _scproxy (macOS) C extension is now built with the limited C API.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-85283 -->
* Issue: gh-85283
<!-- /gh-issue-number -->
