### PR TITLE
gh-85283: _stat extension uses the limited C API

### DIFF
--- a/Doc/whatsnew/3.13.rst
+++ b/Doc/whatsnew/3.13.rst
@@ -833,6 +833,10 @@ Build Changes
   :ref:`debug build <debug-build>`.
   (Contributed by Victor Stinner in :gh:`108634`.)
 
+* The ``_stat`` C extension is now built with the :ref:`limited C API
+  <limited-c-api>`.
+  (Contributed by Victor Stinner in :gh:`85283`.)
+
 
 C API Changes
 =============

--- a/Misc/NEWS.d/next/Build/2023-08-29-15-05-09.gh-issue-85283.tlK7G7.rst
+++ b/Misc/NEWS.d/next/Build/2023-08-29-15-05-09.gh-issue-85283.tlK7G7.rst
@@ -1,0 +1,2 @@
+The ``_stat`` C extension is now built with the :ref:`limited C API
+<limited-c-api>`. Patch by Victor Stinner.

--- a/Modules/_stat.c
+++ b/Modules/_stat.c
@@ -8,8 +8,10 @@
  * as int 0.
  *
  * NOTE: POSIX only defines the values of the S_I* permission bits.
- *
  */
+
+// Need limited C API version 3.13 for PyModule_Add() on Windows
+#define Py_LIMITED_API 0x030d0000
 
 #include "Python.h"
 


### PR DESCRIPTION
The _stat C extension is now built with the limited C API.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-85283 -->
* Issue: gh-85283
<!-- /gh-issue-number -->
