### PR TITLE
[3.12] GH-108202: Combine documentation of ``calendar`` constants (GH-108492)

### DIFF
--- a/Doc/library/calendar.rst
+++ b/Doc/library/calendar.rst
@@ -28,58 +28,6 @@ interpreted as prescribed by the ISO 8601 standard.  Year 0 is 1 BC, year -1 is
 2 BC, and so on.
 
 
-.. class:: Day
-
-   Enumeration defining the days of the week as integer constants, from 0 to 6.
-
-   .. attribute:: MONDAY
-
-   .. attribute:: TUESDAY
-
-   .. attribute:: WEDNESDAY
-
-   .. attribute:: THURSDAY
-
-   .. attribute:: FRIDAY
-
-   .. attribute:: SATURDAY
-
-   .. attribute:: SUNDAY
-
-   .. versionadded:: 3.12
-
-
-.. class:: Month
-
-   Enumeration defining months of the year as integer constants, from 1 to 12.
-
-   .. attribute:: JANUARY
-
-   .. attribute:: FEBRUARY
-
-   .. attribute:: MARCH
-
-   .. attribute:: APRIL
-
-   .. attribute:: MAY
-
-   .. attribute:: JUNE
-
-   .. attribute:: JULY
-
-   .. attribute:: AUGUST
-
-   .. attribute:: SEPTEMBER
-
-   .. attribute:: OCTOBER
-
-   .. attribute:: NOVEMBER
-
-   .. attribute:: DECEMBER
-
-   .. versionadded:: 3.12
-
-
 .. class:: Calendar(firstweekday=0)
 
    Creates a :class:`Calendar` object. *firstweekday* is an integer specifying the
@@ -446,6 +394,29 @@ The :mod:`calendar` module exports the following data attributes:
    An array that represents the abbreviated days of the week in the current locale.
 
 
+.. data:: MONDAY
+          TUESDAY
+          WEDNESDAY
+          THURSDAY
+          FRIDAY
+          SATURDAY
+          SUNDAY
+
+   Aliases for the days of the week,
+   where ``MONDAY`` is ``0`` and ``SUNDAY`` is ``6``.
+
+   .. versionadded:: 3.12
+
+
+.. class:: Day
+
+   Enumeration defining days of the week as integer constants.
+   The members of this enumeration are exported to the module scope as
+   :data:`MONDAY` through :data:`SUNDAY`.
+
+   .. versionadded:: 3.12
+
+
 .. data:: month_name
 
    An array that represents the months of the year in the current locale.  This
@@ -459,15 +430,33 @@ The :mod:`calendar` module exports the following data attributes:
    locale.  This follows normal convention of January being month number 1, so it
    has a length of 13 and  ``month_abbr[0]`` is the empty string.
 
-.. data:: MONDAY
-          TUESDAY
-          WEDNESDAY
-          THURSDAY
-          FRIDAY
-          SATURDAY
-          SUNDAY
 
-   Aliases for day numbers, where ``MONDAY`` is ``0`` and ``SUNDAY`` is ``6``.
+.. data:: JANUARY
+          FEBRUARY
+          MARCH
+          APRIL
+          MAY
+          JUNE
+          JULY
+          AUGUST
+          SEPTEMBER
+          OCTOBER
+          NOVEMBER
+          DECEMBER
+
+   Aliases for the months of the year,
+   where ``JANUARY`` is ``1`` and ``DECEMBER`` is ``12``.
+
+   .. versionadded:: 3.12
+
+
+.. class:: Month
+
+   Enumeration defining months of the year as integer constants.
+   The members of this enumeration are exported to the module scope as
+   :data:`JANUARY` through :data:`DECEMBER`.
+
+   .. versionadded:: 3.12
 
 
 The :mod:`calendar` module defines the following exceptions:

--- a/Doc/whatsnew/3.12.rst
+++ b/Doc/whatsnew/3.12.rst
@@ -1014,7 +1014,7 @@ Deprecated
   (Contributed by Serhiy Storchaka and Guido van Rossum in :gh:`100160`.)
 
 * :mod:`calendar`: ``calendar.January`` and ``calendar.February`` constants are deprecated and
-  replaced by :data:`calendar.Month.JANUARY` and :data:`calendar.Month.FEBRUARY`.
+  replaced by :data:`calendar.JANUARY` and :data:`calendar.FEBRUARY`.
   (Contributed by Prince Roshan in :gh:`103636`.)
 
 * :mod:`datetime`: :class:`datetime.datetime`'s :meth:`~datetime.datetime.utcnow` and


### PR DESCRIPTION
(cherry picked from commit 5d936b64796261373429c86cdf90b1d8d8acefba)


<!-- gh-issue-number: gh-108202 -->
* Issue: gh-108202
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--108579.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->