### PR TITLE
gh-108525: Clarify stable ABI documentation to exclude internal C libraries

### DIFF
--- a/Doc/c-api/stable.rst
+++ b/Doc/c-api/stable.rst
@@ -18,6 +18,12 @@ way; see :ref:`stable-abi-platform` below).
 So, code compiled for Python 3.10.0 will work on 3.10.8 and vice versa,
 but will need to be compiled separately for 3.9.x and 3.10.x.
 
+ABI compatibility only applies to public API usage (names not prefixed by an
+underscore). Python internal shared libraries (such as the _ssl module) may
+utilize the private API and are not guaranteed to be ABI compatible.
+For example, the internal _ssl shared library compiled from Python 3.11.5 cannot
+be used with a Python 3.11.4 executable.
+
 There are two tiers of C API with different stability exepectations:
 
 - :ref:`Unstable API <unstable-c-api>`, may change in minor versions without


### PR DESCRIPTION
Closes #108525

Please see issue #108525 for background. I could not find any information in the documentation on if ABI compatibility between bugfix release shared objects is a warranty. However, using the private API in the C support libraries like _ssl appears to be common and would cause ABI breakage on private API changes.

If this interpretation is incorrect, please let me know as I think clarification would be helpful regardless.

<!-- gh-issue-number: gh-108525 -->
* Issue: gh-108525
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--108582.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->