### PR TITLE
gh-108494: Argument Clinic: Document how to generate code that uses the limited C API

### DIFF
--- a/Doc/howto/clinic.rst
+++ b/Doc/howto/clinic.rst
@@ -196,7 +196,7 @@ The CLI supports the following options:
 .. option:: --limited
 
     Use the :ref:`Limited API <limited-c-api>` to parse arguments in the generated C code.
-    See :ref:`How to use the Limited C API <clinic-howto-limited-capi>`.
+    See :ref:`clinic-howto-limited-capi`.
 
 .. option:: FILE ...
 

--- a/Doc/howto/clinic.rst
+++ b/Doc/howto/clinic.rst
@@ -1905,6 +1905,17 @@ blocks embedded in Python files look slightly different.  They look like this:
     #/*[python checksum:...]*/
 
 
+How to use the Limited C API
+----------------------------
+
+If a C source code contains ``#define Py_LIMITED_API``, the generated C code
+will use the :ref:`Limited API <limited-c-api>` to parse arguments. Private
+functions are not used in this case and the code parsing arguments can be a
+less efficient depending on the parameters (types, number, etc.).
+
+.. versionadded:: 3.13
+
+
 .. _clinic-howto-override-signature:
 
 How to override the generated signature

--- a/Doc/howto/clinic.rst
+++ b/Doc/howto/clinic.rst
@@ -1917,8 +1917,8 @@ How to use the Limited C API
 
 If a C source code contains ``#define Py_LIMITED_API``, the generated C code
 will use the :ref:`Limited API <limited-c-api>` to parse arguments. Private
-functions are not used in this case. However the code parsing arguments can be
-a less efficient depending on the parameters (types, number, etc.).
+functions are not used in this case. However, the code parsing arguments can be
+less efficient depending on the parameters (types, number, etc.).
 
 .. versionadded:: 3.13
 

--- a/Doc/howto/clinic.rst
+++ b/Doc/howto/clinic.rst
@@ -1915,10 +1915,13 @@ blocks embedded in Python files look slightly different.  They look like this:
 How to use the Limited C API
 ----------------------------
 
-If a C source code contains ``#define Py_LIMITED_API``, the generated C code
-will use the :ref:`Limited API <limited-c-api>` to parse arguments. Private
-functions are not used in this case. However, the code parsing arguments can be
-less efficient depending on the parameters (types, number, etc.).
+If Argument Clinic :term:`input` is located within a C source file
+that contains ``#define Py_LIMITED_API``, Argument Clinic will generate C code
+that uses the :ref:`Limited API <limited-c-api>` to parse arguments. The
+advantage of this is that the generated code will not use private functions.
+However, this *can* result in Argument Clinic generating less efficient code
+in some cases. The extent of the performance penalty will depend
+on the parameters (types, number, etc.).
 
 .. versionadded:: 3.13
 

--- a/Doc/howto/clinic.rst
+++ b/Doc/howto/clinic.rst
@@ -158,7 +158,7 @@ process a single source file, like this:
 The CLI supports the following options:
 
 .. program:: ./Tools/clinic/clinic.py [-h] [-f] [-o OUTPUT] [-v] \
-             [--converters] [--make] [--srcdir SRCDIR] [FILE ...]
+             [--converters] [--make] [--srcdir SRCDIR] [--limited] [FILE ...]
 
 .. option:: -h, --help
 
@@ -192,6 +192,11 @@ The CLI supports the following options:
 
    A file to exclude in :option:`--make` mode.
    This option can be given multiple times.
+
+.. option:: --limited
+
+    Use the :ref:`Limited API <limited-c-api>` to parse arguments in the generated C code.
+    See :ref:`How to use the Limited C API <clinic-howto-limited-capi>`.
 
 .. option:: FILE ...
 
@@ -1905,13 +1910,15 @@ blocks embedded in Python files look slightly different.  They look like this:
     #/*[python checksum:...]*/
 
 
+.. _clinic-howto-limited-capi:
+
 How to use the Limited C API
 ----------------------------
 
 If a C source code contains ``#define Py_LIMITED_API``, the generated C code
 will use the :ref:`Limited API <limited-c-api>` to parse arguments. Private
-functions are not used in this case and the code parsing arguments can be a
-less efficient depending on the parameters (types, number, etc.).
+functions are not used in this case. However the code parsing arguments can be
+a less efficient depending on the parameters (types, number, etc.).
 
 .. versionadded:: 3.13
 

--- a/Misc/NEWS.d/next/Tools-Demos/2023-08-25-22-40-12.gh-issue-108494.4RbDdu.rst
+++ b/Misc/NEWS.d/next/Tools-Demos/2023-08-25-22-40-12.gh-issue-108494.4RbDdu.rst
@@ -1,2 +1,3 @@
 :ref:`Argument Clinic <howto-clinic>` now has a partial support of the
-:ref:`Limited API <limited-c-api>`. Patch by Victor Stinner.
+:ref:`Limited API <limited-c-api>`: see Argument Clinic :ref:`How to use the
+Limited C API <clinic-howto-limited-capi>`. Patch by Victor Stinner.

--- a/Misc/NEWS.d/next/Tools-Demos/2023-08-25-22-40-12.gh-issue-108494.4RbDdu.rst
+++ b/Misc/NEWS.d/next/Tools-Demos/2023-08-25-22-40-12.gh-issue-108494.4RbDdu.rst
@@ -1,3 +1,3 @@
 :ref:`Argument Clinic <howto-clinic>` now has a partial support of the
-:ref:`Limited API <limited-c-api>`: see Argument Clinic :ref:`How to use the
-Limited C API <clinic-howto-limited-capi>`. Patch by Victor Stinner.
+:ref:`Limited API <limited-c-api>`: see :ref:`clinic-howto-limited-capi`.
+Patch by Victor Stinner.


### PR DESCRIPTION
Remove also the --limited command line option. Now the limited C API is only used if the source code contains "#define Py_LIMITED_API".

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-108494 -->
* Issue: gh-108494
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--108584.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->