### PR TITLE
gh-106320: Remove _PyAnextAwaitable_Type from the public C API

### DIFF
--- a/Include/iterobject.h
+++ b/Include/iterobject.h
@@ -7,9 +7,6 @@ extern "C" {
 
 PyAPI_DATA(PyTypeObject) PySeqIter_Type;
 PyAPI_DATA(PyTypeObject) PyCallIter_Type;
-#ifdef Py_BUILD_CORE
-extern PyTypeObject _PyAnextAwaitable_Type;
-#endif
 
 #define PySeqIter_Check(op) Py_IS_TYPE((op), &PySeqIter_Type)
 

--- a/Objects/object.c
+++ b/Objects/object.c
@@ -2049,11 +2049,12 @@ _PyObject_InitState(PyInterpreterState *interp)
 }
 
 
-extern PyTypeObject _Py_GenericAliasIterType;
-extern PyTypeObject _PyMemoryIter_Type;
-extern PyTypeObject _PyLineIterator;
-extern PyTypeObject _PyPositionsIterator;
+extern PyTypeObject _PyAnextAwaitable_Type;
 extern PyTypeObject _PyLegacyEventHandler_Type;
+extern PyTypeObject _PyLineIterator;
+extern PyTypeObject _PyMemoryIter_Type;
+extern PyTypeObject _PyPositionsIterator;
+extern PyTypeObject _Py_GenericAliasIterType;
 
 static PyTypeObject* static_types[] = {
     // The two most important base types: must be initialized first and

--- a/Tools/c-analyzer/c_parser/preprocessor/gcc.py
+++ b/Tools/c-analyzer/c_parser/preprocessor/gcc.py
@@ -69,7 +69,6 @@ def preprocess(filename,
         cwd = os.path.abspath(cwd or '.')
     filename = _normpath(filename, cwd)
 
-    print(filename)
     postargs = POST_ARGS
     if os.path.basename(filename) not in USE_LIMITED_C_API:
         postargs += ('-DPy_BUILD_CORE=1',)

--- a/Tools/c-analyzer/cpython/globals-to-fix.tsv
+++ b/Tools/c-analyzer/cpython/globals-to-fix.tsv
@@ -57,6 +57,7 @@ Objects/genobject.c	-	_PyCoroWrapper_Type	-
 Objects/interpreteridobject.c	-	PyInterpreterID_Type	-
 Objects/iterobject.c	-	PyCallIter_Type	-
 Objects/iterobject.c	-	PySeqIter_Type	-
+Objects/iterobject.c	-	_PyAnextAwaitable_Type	-
 Objects/listobject.c	-	PyListIter_Type	-
 Objects/listobject.c	-	PyListRevIter_Type	-
 Objects/listobject.c	-	PyList_Type	-
@@ -70,6 +71,7 @@ Objects/moduleobject.c	-	PyModule_Type	-
 Objects/namespaceobject.c	-	_PyNamespace_Type	-
 Objects/object.c	-	_PyNone_Type	-
 Objects/object.c	-	_PyNotImplemented_Type	-
+Objects/object.c 	-	_PyAnextAwaitable_Type	-
 Objects/odictobject.c	-	PyODictItems_Type	-
 Objects/odictobject.c	-	PyODictIter_Type	-
 Objects/odictobject.c	-	PyODictKeys_Type	-
@@ -112,8 +114,6 @@ Objects/codeobject.c	-	_PyLineIterator	-
 # Not in a .h file:
 Objects/codeobject.c	-	_PyPositionsIterator	-
 Objects/genericaliasobject.c	-	_Py_GenericAliasIterType	-
-# Not in a .h file:
-Objects/iterobject.c	-	_PyAnextAwaitable_Type	-
 # Not in a .h file:
 Objects/memoryobject.c	-	_PyMemoryIter_Type	-
 Objects/unicodeobject.c	-	_PyUnicodeASCIIIter_Type	-


### PR DESCRIPTION
It's not needed to declare it in Include/iterobject.h: just use "extern" where it's used (only in object.c).

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-106320 -->
* Issue: gh-106320
<!-- /gh-issue-number -->
