### PR TITLE
gh-106320: Remove private _PyType_Lookup() function

### DIFF
--- a/Include/cpython/object.h
+++ b/Include/cpython/object.h
@@ -235,7 +235,6 @@ typedef struct _heaptypeobject {
 } PyHeapTypeObject;
 
 PyAPI_FUNC(const char *) _PyType_Name(PyTypeObject *);
-PyAPI_FUNC(PyObject *) _PyType_Lookup(PyTypeObject *, PyObject *);
 PyAPI_FUNC(PyObject *) PyType_GetModuleByDef(PyTypeObject *, PyModuleDef *);
 PyAPI_FUNC(PyObject *) PyType_GetDict(PyTypeObject *);
 

--- a/Include/internal/pycore_object.h
+++ b/Include/internal/pycore_object.h
@@ -382,6 +382,9 @@ extern PyTypeObject* _PyType_CalculateMetaclass(PyTypeObject *, PyObject *);
 extern PyObject* _PyType_GetDocFromInternalDoc(const char *, const char *);
 extern PyObject* _PyType_GetTextSignatureFromInternalDoc(const char *, const char *, int);
 
+// Export for '_lsprof' shared extension
+PyAPI_DATA(PyObject*) _PyType_Lookup(PyTypeObject *, PyObject *);
+
 extern int _PyObject_InitializeDict(PyObject *obj);
 int _PyObject_InitInlineValues(PyObject *obj, PyTypeObject *tp);
 extern int _PyObject_StoreInstanceAttribute(PyObject *obj, PyDictValues *values,

--- a/Modules/_lsprof.c
+++ b/Modules/_lsprof.c
@@ -5,6 +5,7 @@
 #include "Python.h"
 #include "pycore_call.h"          // _PyObject_CallNoArgs()
 #include "pycore_ceval.h"         // _PyEval_SetProfile()
+#include "pycore_object.h"        // _PyType_Lookup()
 #include "pycore_pystate.h"       // _PyThreadState_GET()
 #include "rotatingtree.h"
 

--- a/Modules/_testcapi/gc.c
+++ b/Modules/_testcapi/gc.c
@@ -1,4 +1,9 @@
+#ifndef Py_BUILD_CORE_BUILTIN
+#  define Py_BUILD_CORE_MODULE 1
+#endif
+
 #include "parts.h"
+#include "pycore_object.h"        // _PyType_Lookup()
 
 static PyObject*
 test_gc_control(PyObject *self, PyObject *Py_UNUSED(ignored))


### PR DESCRIPTION
Move the private function to the internal C API (pycore_object.h).

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-106320 -->
* Issue: gh-106320
<!-- /gh-issue-number -->
