### PR TITLE
gh-106320: Remove private _PyThread_at_fork_reinit() function

### DIFF
--- a/Include/cpython/pythread.h
+++ b/Include/cpython/pythread.h
@@ -4,13 +4,6 @@
 
 #define PYTHREAD_INVALID_THREAD_ID ((unsigned long)-1)
 
-#ifdef HAVE_FORK
-/* Private function to reinitialize a lock at fork in the child process.
-   Reset the lock to the unlocked state.
-   Return 0 on success, return -1 on error. */
-PyAPI_FUNC(int) _PyThread_at_fork_reinit(PyThread_type_lock *lock);
-#endif  /* HAVE_FORK */
-
 #ifdef HAVE_PTHREAD_H
     /* Darwin needs pthread.h to know type name the pthread_key_t. */
 #   include <pthread.h>

--- a/Include/internal/pycore_pythread.h
+++ b/Include/internal/pycore_pythread.h
@@ -75,6 +75,14 @@ struct _pythread_runtime_state {
 };
 
 
+#ifdef HAVE_FORK
+/* Private function to reinitialize a lock at fork in the child process.
+   Reset the lock to the unlocked state.
+   Return 0 on success, return -1 on error. */
+extern int _PyThread_at_fork_reinit(PyThread_type_lock *lock);
+#endif  /* HAVE_FORK */
+
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
Move the private function to the internal C API (pycore_pythread.h) and no longer exports it.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-106320 -->
* Issue: gh-106320
<!-- /gh-issue-number -->
