### PR TITLE
gh-106320: Remove private _PyGILState_GetInterpreterStateUnsafe()

### DIFF
--- a/Include/cpython/pystate.h
+++ b/Include/cpython/pystate.h
@@ -227,15 +227,6 @@ PyAPI_FUNC(void) PyThreadState_LeaveTracing(PyThreadState *tstate);
    The function returns 1 if _PyGILState_check_enabled is non-zero. */
 PyAPI_FUNC(int) PyGILState_Check(void);
 
-/* Get the single PyInterpreterState used by this process' GILState
-   implementation.
-
-   This function doesn't check for error. Return NULL before _PyGILState_Init()
-   is called and after _PyGILState_Fini() is called.
-
-   See also PyInterpreterState_Get() and _PyInterpreterState_GET(). */
-PyAPI_FUNC(PyInterpreterState *) _PyGILState_GetInterpreterStateUnsafe(void);
-
 /* Routines for advanced debuggers, requested by David Beazley.
    Don't use unless you know what you are doing! */
 PyAPI_FUNC(PyInterpreterState *) PyInterpreterState_Main(void);

--- a/Include/internal/pycore_pystate.h
+++ b/Include/internal/pycore_pystate.h
@@ -174,6 +174,14 @@ extern int _PyOS_InterruptOccurred(PyThreadState *tstate);
 // Export for test_peg_generator.
 PyAPI_FUNC(const PyConfig*) _Py_GetConfig(void);
 
+// Get the single PyInterpreterState used by this process' GILState
+// implementation.
+//
+// This function doesn't check for error. Return NULL before _PyGILState_Init()
+// is called and after _PyGILState_Fini() is called.
+//
+// See also PyInterpreterState_Get() and _PyInterpreterState_GET().
+extern PyInterpreterState* _PyGILState_GetInterpreterStateUnsafe(void);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
The remove private _PyGILState_GetInterpreterStateUnsafe() function from the public C API: move it the internal C API (pycore_pystate.h). No longer export the function.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-106320 -->
* Issue: gh-106320
<!-- /gh-issue-number -->
