### PR TITLE
gh-106320: Remove private _PyLong_New() function

### DIFF
--- a/Include/cpython/longintrepr.h
+++ b/Include/cpython/longintrepr.h
@@ -89,14 +89,6 @@ struct _longobject {
     _PyLongValue long_value;
 };
 
-PyAPI_FUNC(PyLongObject *) _PyLong_New(Py_ssize_t);
-
-/* Return a copy of src. */
-PyAPI_FUNC(PyObject *) _PyLong_Copy(PyLongObject *src);
-
-PyAPI_FUNC(PyLongObject *)
-_PyLong_FromDigits(int negative, Py_ssize_t digit_count, digit *digits);
-
 
 /* Inline some internals for speed. These should be in pycore_long.h
  * if user code didn't need them inlined. */

--- a/Include/internal/pycore_long.h
+++ b/Include/internal/pycore_long.h
@@ -47,6 +47,17 @@ extern "C" {
 # error "_PY_LONG_DEFAULT_MAX_STR_DIGITS smaller than threshold."
 #endif
 
+extern PyLongObject* _PyLong_New(Py_ssize_t);
+
+// Return a copy of src.
+extern PyObject* _PyLong_Copy(PyLongObject *src);
+
+// Export for '_decimal' shared extension
+PyAPI_FUNC(PyLongObject*) _PyLong_FromDigits(
+    int negative,
+    Py_ssize_t digit_count,
+    digit *digits);
+
 
 /* runtime lifecycle */
 


### PR DESCRIPTION
Move the following private API to the internal C API (pycore_long.h):

* _PyLong_Copy()
* _PyLong_FromDigits()
* _PyLong_New()

No longer export most of these functions.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-106320 -->
* Issue: gh-106320
<!-- /gh-issue-number -->
