### PR TITLE
gh-106320: Remove private _PyOS_IsMainThread() function

### DIFF
--- a/Include/internal/pycore_signal.h
+++ b/Include/internal/pycore_signal.h
@@ -95,6 +95,15 @@ struct _signals_runtime_state {
     }
 
 
+// Export for '_multiprocessing' shared extension
+PyAPI_FUNC(int) _PyOS_IsMainThread(void);
+
+#ifdef MS_WINDOWS
+// <windows.h> is not included by Python.h so use void* instead of HANDLE.
+// Export for '_multiprocessing' shared extension
+PyAPI_FUNC(void*) _PyOS_SigintEvent(void);
+#endif
+
 #ifdef __cplusplus
 }
 #endif

--- a/Include/intrcheck.h
+++ b/Include/intrcheck.h
@@ -5,6 +5,7 @@ extern "C" {
 #endif
 
 PyAPI_FUNC(int) PyOS_InterruptOccurred(void);
+
 #ifdef HAVE_FORK
 #if !defined(Py_LIMITED_API) || Py_LIMITED_API+0 >= 0x03070000
 PyAPI_FUNC(void) PyOS_BeforeFork(void);
@@ -12,17 +13,9 @@ PyAPI_FUNC(void) PyOS_AfterFork_Parent(void);
 PyAPI_FUNC(void) PyOS_AfterFork_Child(void);
 #endif
 #endif
+
 /* Deprecated, please use PyOS_AfterFork_Child() instead */
 Py_DEPRECATED(3.7) PyAPI_FUNC(void) PyOS_AfterFork(void);
-
-#ifndef Py_LIMITED_API
-PyAPI_FUNC(int) _PyOS_IsMainThread(void);
-
-#ifdef MS_WINDOWS
-/* windows.h is not included by Python.h so use void* instead of HANDLE */
-PyAPI_FUNC(void*) _PyOS_SigintEvent(void);
-#endif
-#endif /* !Py_LIMITED_API */
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Move the following private API to the internal C API (pycore_signal.h):

* _PyOS_IsMainThread()
* _PyOS_SigintEvent()

No longer export these functions.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-106320 -->
* Issue: gh-106320
<!-- /gh-issue-number -->
