### PR TITLE
gh-108494: Don't build _testclinic_limited with TraceRefs

### DIFF
--- a/Modules/Setup.stdlib.in
+++ b/Modules/Setup.stdlib.in
@@ -161,7 +161,7 @@
 @MODULE__TESTINTERNALCAPI_TRUE@_testinternalcapi _testinternalcapi.c
 @MODULE__TESTCAPI_TRUE@_testcapi _testcapimodule.c _testcapi/vectorcall.c _testcapi/vectorcall_limited.c _testcapi/heaptype.c _testcapi/abstract.c _testcapi/unicode.c _testcapi/dict.c _testcapi/getargs.c _testcapi/datetime.c _testcapi/docstring.c _testcapi/mem.c _testcapi/watchers.c _testcapi/long.c _testcapi/float.c _testcapi/structmember.c _testcapi/exceptions.c _testcapi/code.c _testcapi/buffer.c _testcapi/pyos.c _testcapi/immortal.c _testcapi/heaptype_relative.c _testcapi/gc.c
 @MODULE__TESTCLINIC_TRUE@_testclinic _testclinic.c
-@MODULE__TESTCLINIC_TRUE@_testclinic_limited _testclinic_limited.c
+@MODULE__TESTCLINIC_LIMITED_TRUE@_testclinic_limited _testclinic_limited.c
 
 # Some testing modules MUST be built as shared libraries.
 *shared*

--- a/configure
+++ b/configure
@@ -669,6 +669,8 @@ MODULE__TESTBUFFER_FALSE
 MODULE__TESTBUFFER_TRUE
 MODULE__TESTINTERNALCAPI_FALSE
 MODULE__TESTINTERNALCAPI_TRUE
+MODULE__TESTCLINIC_LIMITED_FALSE
+MODULE__TESTCLINIC_LIMITED_TRUE
 MODULE__TESTCLINIC_FALSE
 MODULE__TESTCLINIC_TRUE
 MODULE__TESTCAPI_FALSE
@@ -29955,6 +29957,44 @@ fi
 printf "%s\n" "$py_cv_module__testclinic" >&6; }
 
 
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for stdlib extension module _testclinic_limited" >&5
+printf %s "checking for stdlib extension module _testclinic_limited... " >&6; }
+        if test "$py_cv_module__testclinic_limited" != "n/a"
+then :
+
+    if test "$TEST_MODULES" = yes -a "$with_trace_refs" = "no"
+then :
+  if true
+then :
+  py_cv_module__testclinic_limited=yes
+else $as_nop
+  py_cv_module__testclinic_limited=missing
+fi
+else $as_nop
+  py_cv_module__testclinic_limited=disabled
+fi
+
+fi
+  as_fn_append MODULE_BLOCK "MODULE__TESTCLINIC_LIMITED_STATE=$py_cv_module__testclinic_limited$as_nl"
+  if test "x$py_cv_module__testclinic_limited" = xyes
+then :
+
+
+
+
+fi
+   if test "$py_cv_module__testclinic_limited" = yes; then
+  MODULE__TESTCLINIC_LIMITED_TRUE=
+  MODULE__TESTCLINIC_LIMITED_FALSE='#'
+else
+  MODULE__TESTCLINIC_LIMITED_TRUE='#'
+  MODULE__TESTCLINIC_LIMITED_FALSE=
+fi
+
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $py_cv_module__testclinic_limited" >&5
+printf "%s\n" "$py_cv_module__testclinic_limited" >&6; }
+
+
   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for stdlib extension module _testinternalcapi" >&5
 printf %s "checking for stdlib extension module _testinternalcapi... " >&6; }
         if test "$py_cv_module__testinternalcapi" != "n/a"
@@ -30692,6 +30732,10 @@ Usually this means the macro was only invoked conditionally." "$LINENO" 5
 fi
 if test -z "${MODULE__TESTCLINIC_TRUE}" && test -z "${MODULE__TESTCLINIC_FALSE}"; then
   as_fn_error $? "conditional \"MODULE__TESTCLINIC\" was never defined.
+Usually this means the macro was only invoked conditionally." "$LINENO" 5
+fi
+if test -z "${MODULE__TESTCLINIC_LIMITED_TRUE}" && test -z "${MODULE__TESTCLINIC_LIMITED_FALSE}"; then
+  as_fn_error $? "conditional \"MODULE__TESTCLINIC_LIMITED\" was never defined.
 Usually this means the macro was only invoked conditionally." "$LINENO" 5
 fi
 if test -z "${MODULE__TESTINTERNALCAPI_TRUE}" && test -z "${MODULE__TESTINTERNALCAPI_FALSE}"; then

--- a/configure.ac
+++ b/configure.ac
@@ -7229,6 +7229,7 @@ PY_STDLIB_MOD([_hashlib], [], [test "$ac_cv_working_openssl_hashlib" = yes],
 dnl test modules
 PY_STDLIB_MOD([_testcapi], [test "$TEST_MODULES" = yes])
 PY_STDLIB_MOD([_testclinic], [test "$TEST_MODULES" = yes])
+PY_STDLIB_MOD([_testclinic_limited], [test "$TEST_MODULES" = yes -a "$with_trace_refs" = "no"])
 PY_STDLIB_MOD([_testinternalcapi], [test "$TEST_MODULES" = yes])
 PY_STDLIB_MOD([_testbuffer], [test "$TEST_MODULES" = yes])
 PY_STDLIB_MOD([_testimportmultiple], [test "$TEST_MODULES" = yes], [test "$ac_cv_func_dlopen" = yes])


### PR DESCRIPTION
If Python is built with ./configure --with-trace-refs, don't build the _testclinic_limited extension. The limited C API (Py_LIMITED_API) is not compatible with Py_TRACE_REFS.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-108494 -->
* Issue: gh-108494
<!-- /gh-issue-number -->
