### PR TITLE
[3.11] Fix misc doc typos (GH-108592)

### DIFF
--- a/Doc/library/idle.rst
+++ b/Doc/library/idle.rst
@@ -479,7 +479,7 @@ Search and Replace
 
 Any selection becomes a search target.  However, only selections within
 a line work because searches are only performed within lines with the
-terminal newline removed.  If ``[x] Regular expresion`` is checked, the
+terminal newline removed.  If ``[x] Regular expression`` is checked, the
 target is interpreted according to the Python re module.
 
 .. _completions:

--- a/Doc/library/sqlite3.rst
+++ b/Doc/library/sqlite3.rst
@@ -1380,7 +1380,7 @@ Cursor objects
 
       :raises ProgrammingError:
          If *sql* contains more than one SQL statement,
-         or is not a DML statment.
+         or is not a DML statement.
 
       Example:
 

--- a/Doc/library/statistics.rst
+++ b/Doc/library/statistics.rst
@@ -1026,7 +1026,6 @@ The final prediction goes to the largest posterior. This is known as the
   >>> 'male' if posterior_male > posterior_female else 'female'
   'female'
 
-
 ..
    # This modelines must appear within the last ten lines of the file.
    kate: indent-width 3; remove-trailing-space on; replace-tabs on; encoding utf-8;

--- a/Doc/library/statistics.rst
+++ b/Doc/library/statistics.rst
@@ -1026,6 +1026,7 @@ The final prediction goes to the largest posterior. This is known as the
   >>> 'male' if posterior_male > posterior_female else 'female'
   'female'
 
+
 ..
    # This modelines must appear within the last ten lines of the file.
    kate: indent-width 3; remove-trailing-space on; replace-tabs on; encoding utf-8;

--- a/Doc/library/tkinter.rst
+++ b/Doc/library/tkinter.rst
@@ -352,7 +352,7 @@ Understanding How Tkinter Wraps Tcl/Tk
 
 When your application uses Tkinter's classes and methods, internally Tkinter
 is assembling strings representing Tcl/Tk commands, and executing those
-commands in the Tcl interpreter attached to your applicaton's :class:`Tk`
+commands in the Tcl interpreter attached to your application's :class:`Tk`
 instance.
 
 Whether it's trying to navigate reference documentation, trying to find

--- a/Doc/using/configure.rst
+++ b/Doc/using/configure.rst
@@ -179,7 +179,7 @@ Install Options
    Install architecture-independent files in PREFIX. On Unix, it
    defaults to :file:`/usr/local`.
 
-   This value can be retrived at runtime using :data:`sys.prefix`.
+   This value can be retrieved at runtime using :data:`sys.prefix`.
 
    As an example, one can use ``--prefix="$HOME/.local/"`` to install
    a Python in its home directory.
@@ -188,7 +188,7 @@ Install Options
 
    Install architecture-dependent files in EPREFIX, defaults to :option:`--prefix`.
 
-   This value can be retrived at runtime using :data:`sys.exec_prefix`.
+   This value can be retrieved at runtime using :data:`sys.exec_prefix`.
 
 .. cmdoption:: --disable-test-modules
 


### PR DESCRIPTION
(cherry picked from commit 88f1c5b454c34efc167a94b5e2d67ec042834e5b)

Co-authored-by: xzmeng <aumo@foxmail.com>

<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--108613.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->