### PR TITLE
gh-108623: Fix compile warning in `Modules/_multiprocessing/semaphore.c`

### DIFF
--- a/Modules/_multiprocessing/multiprocessing.h
+++ b/Modules/_multiprocessing/multiprocessing.h
@@ -4,6 +4,7 @@
 #include "Python.h"
 #include "structmember.h"
 #include "pythread.h"
+#include "pycore_signal.h"        // _PyOS_IsMainThread()
 
 /*
  * Platform includes and definitions

--- a/Modules/_multiprocessing/multiprocessing.h
+++ b/Modules/_multiprocessing/multiprocessing.h
@@ -1,6 +1,10 @@
 #ifndef MULTIPROCESSING_H
 #define MULTIPROCESSING_H
 
+#ifndef Py_BUILD_CORE_BUILTIN
+#  define Py_BUILD_CORE_MODULE 1
+#endif
+
 #include "Python.h"
 #include "structmember.h"
 #include "pythread.h"


### PR DESCRIPTION
Looks like all includes are defined in `multiprocessing.h`, so I've decided to keep it there.

Refs https://github.com/python/cpython/commit/fadc2dc7df99501a40171f39b7cd23be732860cc

<!-- gh-issue-number: gh-108623 -->
* Issue: gh-108623
<!-- /gh-issue-number -->
