### PR TITLE
gh-108455: peg_generator: make the mypy config slightly stricter

### DIFF
--- a/Tools/peg_generator/mypy.ini
+++ b/Tools/peg_generator/mypy.ini
@@ -8,6 +8,7 @@ python_version = 3.10
 
 # Be strict...
 strict = True
+enable_error_code = truthy-bool
 
 # except for a few settings that can't yet be enabled:
 warn_return_any = False

--- a/Tools/peg_generator/mypy.ini
+++ b/Tools/peg_generator/mypy.ini
@@ -8,7 +8,7 @@ python_version = 3.10
 
 # Be strict...
 strict = True
-enable_error_code = truthy-bool
+enable_error_code = truthy-bool,ignore-without-code
 
 # except for a few settings that can't yet be enabled:
 warn_return_any = False

--- a/Tools/peg_generator/mypy.ini
+++ b/Tools/peg_generator/mypy.ini
@@ -11,7 +11,6 @@ strict = True
 
 # except for a few settings that can't yet be enabled:
 warn_return_any = False
-no_implicit_reexport = False
 
 [mypy-pegen.grammar_parser]
 strict_optional = False

--- a/Tools/peg_generator/mypy.ini
+++ b/Tools/peg_generator/mypy.ini
@@ -12,6 +12,7 @@ enable_error_code = truthy-bool,ignore-without-code
 
 # except for a few settings that can't yet be enabled:
 warn_return_any = False
+warn_unreachable = False
 
 [mypy-pegen.grammar_parser]
 strict_optional = False

--- a/Tools/peg_generator/pegen/__main__.py
+++ b/Tools/peg_generator/pegen/__main__.py
@@ -12,7 +12,10 @@ import token
 import traceback
 from typing import Tuple
 
-from pegen.build import Grammar, Parser, ParserGenerator, Tokenizer
+from pegen.grammar import Grammar
+from pegen.parser import Parser
+from pegen.parser_generator import ParserGenerator
+from pegen.tokenizer import Tokenizer
 from pegen.validator import validate_grammar
 
 

--- a/Tools/peg_generator/pegen/parser.py
+++ b/Tools/peg_generator/pegen/parser.py
@@ -32,7 +32,7 @@ def logger(method: F) -> F:
         print(f"{fill}... {method_name}({argsr}) --> {tree!s:.200}")
         return tree
 
-    logger_wrapper.__wrapped__ = method  # type: ignore
+    logger_wrapper.__wrapped__ = method  # type: ignore[attr-defined]
     return cast(F, logger_wrapper)
 
 
@@ -69,7 +69,7 @@ def memoize(method: F) -> F:
             self._reset(endmark)
         return tree
 
-    memoize_wrapper.__wrapped__ = method  # type: ignore
+    memoize_wrapper.__wrapped__ = method  # type: ignore[attr-defined]
     return cast(F, memoize_wrapper)
 
 
@@ -153,7 +153,7 @@ def memoize_left_rec(
                 self._reset(endmark)
         return tree
 
-    memoize_left_rec_wrapper.__wrapped__ = method  # type: ignore
+    memoize_left_rec_wrapper.__wrapped__ = method  # type: ignore[attr-defined]
     return memoize_left_rec_wrapper
 
 

--- a/Tools/peg_generator/pegen/testutil.py
+++ b/Tools/peg_generator/pegen/testutil.py
@@ -37,7 +37,7 @@ def generate_parser(grammar: Grammar) -> Type[Parser]:
 
 def run_parser(file: IO[bytes], parser_class: Type[Parser], *, verbose: bool = False) -> Any:
     # Run a parser on a file (stream).
-    tokenizer = Tokenizer(tokenize.generate_tokens(file.readline))  # type: ignore # typeshed issue #3515
+    tokenizer = Tokenizer(tokenize.generate_tokens(file.readline))  # type: ignore[arg-type] # typeshed issue #3515
     parser = parser_class(tokenizer, verbose=verbose)
     result = parser.start()
     if result is None:
@@ -52,7 +52,7 @@ def parse_string(
     if dedent:
         source = textwrap.dedent(source)
     file = io.StringIO(source)
-    return run_parser(file, parser_class, verbose=verbose)  # type: ignore # typeshed issue #3515
+    return run_parser(file, parser_class, verbose=verbose)  # type: ignore[arg-type] # typeshed issue #3515
 
 
 def make_parser(source: str) -> Type[Parser]:
@@ -116,7 +116,7 @@ def generate_parser_c_extension(
 def print_memstats() -> bool:
     MiB: Final = 2**20
     try:
-        import psutil  # type: ignore
+        import psutil  # type: ignore[import]
     except ImportError:
         return False
     print("Memory stats:")


### PR DESCRIPTION
This picks some low-hanging fruit when it comes to the mypy config, enabling various stricter settings that don't require large code changes:

- Enable `--no-explicit-reexport`
- Enable the `truthy-bool` and `ignore-without-code` error codes
- Explicitly note in our config file that `--warn-unreachable` can't yet be enabled. (It would take several code changes before we could enable it; it's deferred for now.)

<!-- gh-issue-number: gh-108455 -->
* Issue: gh-108455
<!-- /gh-issue-number -->
