### PR TITLE
gh-108558: Add a couple more sqlite Row.keys() tests

### DIFF
--- a/Lib/test/test_sqlite3/test_factory.py
+++ b/Lib/test/test_sqlite3/test_factory.py
@@ -267,6 +267,7 @@ class RowFactoryTests(MemoryDatabaseMixin, unittest.TestCase):
         # and values. Assert the keys values are the same too.
         row_1 = self.con.execute("select 1 as a, 2 as b").fetchone()
         row_2 = self.con.execute("select 1 as a, 2 as b").fetchone()
+        self.assertEqual(row_1, row_2)
         self.assertEqual(row_1.keys(), row_2.keys())
 
     def test_fake_cursor_class(self):

--- a/Lib/test/test_sqlite3/test_factory.py
+++ b/Lib/test/test_sqlite3/test_factory.py
@@ -256,7 +256,7 @@ class RowFactoryTests(MemoryDatabaseMixin, unittest.TestCase):
             row = self.con.execute("select 1 as a where a == 'THISDOESNOTEXIST'").fetchone()
             row.keys()
 
-        # docs.python.org: "Immediately after a query, it is 
+        # docs.python.org: "Immediately after a query, it is
         # the first member of each tuple in Cursor.description."
         cur = self.con.cursor(factory=MyCursor)
         cur.execute("select 1 as a")

--- a/Lib/test/test_sqlite3/test_factory.py
+++ b/Lib/test/test_sqlite3/test_factory.py
@@ -246,16 +246,18 @@ class RowFactoryTests(MemoryDatabaseMixin, unittest.TestCase):
         self.assertEqual(list(reversed(row)), list(reversed(as_tuple)))
         self.assertIsInstance(row, Sequence)
 
-    def test_sqlite_row_keys(self):
+    def test_sqlite_row_keys_return_columns_as_strings(self):
         # Checks if the row object can return a list of columns as strings.
         row = self.con.execute("select 1 as a, 2 as b").fetchone()
         self.assertEqual(row.keys(), ['a', 'b'])
 
+    def test_sqlite_row_keys_raises_exception_on_empty_sql_query(self):
         # Test exception raised on an empty sql query result
         with self.assertRaises(AttributeError):
             row = self.con.execute("select 1 as a where a == 'THISDOESNOTEXIST'").fetchone()
             row.keys()
 
+    def test_sqlite_row_keys_returns_first_value_from_cursor_description(self):
         # docs.python.org: "Immediately after a query, it is
         # the first member of each tuple in Cursor.description."
         cur = self.con.cursor(factory=MyCursor)
@@ -263,6 +265,7 @@ class RowFactoryTests(MemoryDatabaseMixin, unittest.TestCase):
         row = cur.fetchone()
         self.assertEqual(cur.description[0][0], row.keys()[0])
 
+    def test_sqlite_row_keys_are_equal_if_rows_are_equal(self):
         # Two Row objects compare equal if they have identical column names
         # and values. Assert the keys values are the same too.
         row_1 = self.con.execute("select 1 as a, 2 as b").fetchone()

--- a/Lib/test/test_sqlite3/test_factory.py
+++ b/Lib/test/test_sqlite3/test_factory.py
@@ -251,6 +251,24 @@ class RowFactoryTests(MemoryDatabaseMixin, unittest.TestCase):
         row = self.con.execute("select 1 as a, 2 as b").fetchone()
         self.assertEqual(row.keys(), ['a', 'b'])
 
+        # Test exception raised on an empty sql query result
+        with self.assertRaises(AttributeError):
+            row = self.con.execute("select 1 as a where a == 'THISDOESNOTEXIST'").fetchone()
+            row.keys()
+
+        # docs.python.org: "Immediately after a query, it is 
+        # the first member of each tuple in Cursor.description."
+        cur = self.con.cursor(factory=MyCursor)
+        cur.execute("select 1 as a")
+        row = cur.fetchone()
+        self.assertEqual(cur.description[0][0], row.keys()[0])
+
+        # Two Row objects compare equal if they have identical column names
+        # and values. Assert the keys values are the same too.
+        row_1 = self.con.execute("select 1 as a, 2 as b").fetchone()
+        row_2 = self.con.execute("select 1 as a, 2 as b").fetchone()
+        self.assertEqual(row_1.keys(), row_2.keys())
+
     def test_fake_cursor_class(self):
         # Issue #24257: Incorrect use of PyObject_IsInstance() caused
         # segmentation fault.


### PR DESCRIPTION
* Fix for https://github.com/python/cpython/issues/108558, adding additional test coverage for sqlite3.Row.keys() which currently only has one test already implicitly tested elsewhere. 
* Specifically, test `.keys()` on an empty row, check the documented statement that `keys()` return the first value from the description tuple, and the (possibly trivial) fact that `.keys()` are equal when the `Row` is equal. 

<!-- gh-issue-number: gh-108558 -->
* Issue: gh-108558
<!-- /gh-issue-number -->
