### PR TITLE
gh-108455: Use `strict_optional=True` for `grammar_parser`

### DIFF
--- a/Tools/peg_generator/mypy.ini
+++ b/Tools/peg_generator/mypy.ini
@@ -13,8 +13,5 @@ strict = True
 warn_return_any = False
 no_implicit_reexport = False
 
-[mypy-pegen.grammar_parser]
-strict_optional = False
-
 [mypy-setuptools.*]
 ignore_missing_imports = True

--- a/Tools/peg_generator/pegen/grammar.py
+++ b/Tools/peg_generator/pegen/grammar.py
@@ -349,7 +349,7 @@ class Cut:
 
 Plain = Union[Leaf, Group]
 Item = Union[Plain, Opt, Repeat, Forced, Lookahead, Rhs, Cut]
-RuleName = Tuple[str, str]
+RuleName = Tuple[str, Optional[str]]
 MetaTuple = Tuple[str, Optional[str]]
 MetaList = List[MetaTuple]
 RuleList = List[Rule]


### PR DESCRIPTION
Just one thing that I had in my version of https://github.com/python/cpython/pull/108620 that was not included in the @AlexWaygood's version.

<!-- gh-issue-number: gh-108455 -->
* Issue: gh-108455
<!-- /gh-issue-number -->
