### PR TITLE
gh-108455: peg_generator: install two stubs packages before running mypy

### DIFF
--- a/Tools/peg_generator/mypy.ini
+++ b/Tools/peg_generator/mypy.ini
@@ -15,4 +15,6 @@ warn_return_any = False
 warn_unreachable = False
 
 [mypy-pegen.build]
+# we need this for now due to some missing annotations
+# in typeshed's stubs for setuptools
 disallow_untyped_calls = False

--- a/Tools/peg_generator/mypy.ini
+++ b/Tools/peg_generator/mypy.ini
@@ -14,5 +14,5 @@ enable_error_code = truthy-bool,ignore-without-code
 warn_return_any = False
 warn_unreachable = False
 
-[mypy-setuptools.*]
-ignore_missing_imports = True
+[mypy-pegen.build]
+disallow_untyped_calls = False

--- a/Tools/peg_generator/pegen/testutil.py
+++ b/Tools/peg_generator/pegen/testutil.py
@@ -116,7 +116,7 @@ def generate_parser_c_extension(
 def print_memstats() -> bool:
     MiB: Final = 2**20
     try:
-        import psutil  # type: ignore[import]
+        import psutil
     except ImportError:
         return False
     print("Memory stats:")

--- a/Tools/requirements-dev.txt
+++ b/Tools/requirements-dev.txt
@@ -1,3 +1,7 @@
 # Requirements file for external linters and checks we run on
 # Tools/clinic, Tools/cases_generator/, and Tools/peg_generator/ in CI
 mypy==1.5.1
+
+# needed for peg_generator:
+types-psutil==5.9.5.16
+types-setuptools==68.1.0.0


### PR DESCRIPTION
This means we no longer have to `type: ignore` unresolvable imports from `setuptools` and `psutil`.

I tested the PR locally using `python -m test test_peg_generator -u cpu -v`.

<!-- gh-issue-number: gh-108455 -->
* Issue: gh-108455
<!-- /gh-issue-number -->
