### PR TITLE
gh-108590: Fix sqlite3.iterdump for invalid unicode in text columns.

### DIFF
--- a/Lib/sqlite3/dump.py
+++ b/Lib/sqlite3/dump.py
@@ -18,7 +18,7 @@ def _force_decode(bs, *args, **kwargs):
     try:
         return bs.decode(*args, **kwargs)
     except UnicodeDecodeError:
-        return "".join(chr(c) for c in bs)
+        return "".join([chr(c) for c in bs])
 
 def _iterdump(connection):
     """

--- a/Lib/sqlite3/dump.py
+++ b/Lib/sqlite3/dump.py
@@ -7,7 +7,9 @@
 # future enhancements, you should normally quote any identifier that
 # is an English language word, even if you do not have to."
 
+
 from contextlib import contextmanager
+
 
 def _quote_name(name):
     return '"{0}"'.format(name.replace('"', '""'))
@@ -16,11 +18,14 @@ def _quote_name(name):
 def _quote_value(value):
     return "'{0}'".format(value.replace("'", "''"))
 
+
 def _force_decode(bs, *args, **kwargs):
+    # gh-108590: Don't fail if the database contains invalid Unicode data.
     try:
         return bs.decode(*args, **kwargs)
     except UnicodeDecodeError:
         return "".join([chr(c) for c in bs])
+
 
 @contextmanager
 def _text_factory(con, factory):
@@ -30,6 +35,7 @@ def _text_factory(con, factory):
         yield
     finally:
         con.text_factory = saved_factory
+
 
 def _iterdump(connection):
     """

--- a/Lib/test/test_sqlite3/test_dump.py
+++ b/Lib/test/test_sqlite3/test_dump.py
@@ -134,6 +134,7 @@ class DumpTests(MemoryDatabaseMixin, unittest.TestCase):
         self.assertEqual(expected, actual)
 
     def test_dump_unicode_invalid(self):
+        # gh-108590
         expected = [
             "BEGIN TRANSACTION;",
             "CREATE TABLE foo (data TEXT);",

--- a/Lib/test/test_sqlite3/test_dump.py
+++ b/Lib/test/test_sqlite3/test_dump.py
@@ -133,6 +133,20 @@ class DumpTests(MemoryDatabaseMixin, unittest.TestCase):
         actual = list(self.cx.iterdump())
         self.assertEqual(expected, actual)
 
+    def test_dump_unicode_invalid(self):
+        expected = [
+            "BEGIN TRANSACTION;",
+            "CREATE TABLE foo (data TEXT);",
+            "INSERT INTO \"foo\" VALUES('a\x9f');",
+            "COMMIT;",
+        ]
+        self.cu.executescript("""
+            CREATE TABLE foo (data TEXT);
+            INSERT INTO foo VALUES (CAST(X'619f' AS TEXT));
+        """)
+        actual = list(self.cx.iterdump())
+        self.assertEqual(expected, actual)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/Misc/NEWS.d/next/Library/2023-08-29-22-53-48.gh-issue-108590.6k0pOl.rst
+++ b/Misc/NEWS.d/next/Library/2023-08-29-22-53-48.gh-issue-108590.6k0pOl.rst
@@ -1,0 +1,1 @@
+Fixed an issue causing sqlite3.iterdump to crash when encountering invalid unicode in a TEXT column.

--- a/Misc/NEWS.d/next/Library/2023-08-29-22-53-48.gh-issue-108590.6k0pOl.rst
+++ b/Misc/NEWS.d/next/Library/2023-08-29-22-53-48.gh-issue-108590.6k0pOl.rst
@@ -1,1 +1,1 @@
-Fixed an issue causing sqlite3.iterdump to crash when encountering invalid unicode in a TEXT column.
+Fixed an issue where :meth:`sqlite3.Connection.iterdump` would fail and leave an incomplete SQL dump if a table includes invalid Unicode sequences.

--- a/Misc/NEWS.d/next/Library/2023-08-29-22-53-48.gh-issue-108590.6k0pOl.rst
+++ b/Misc/NEWS.d/next/Library/2023-08-29-22-53-48.gh-issue-108590.6k0pOl.rst
@@ -1,1 +1,1 @@
-Fixed an issue where :meth:`sqlite3.Connection.iterdump` would fail and leave an incomplete SQL dump if a table includes invalid Unicode sequences.
+Fixed an issue where :meth:`sqlite3.Connection.iterdump` would fail and leave an incomplete SQL dump if a table includes invalid Unicode sequences. Patch by Corvin McPherson


### PR DESCRIPTION
Fixes an exception where sqlite3.iterdump would fail to decode if someone stuffed invalid unicode into a database column marked as TEXT (or alias of, like VARCHAR).
See #108590 for more info

<!-- gh-issue-number: gh-108590 -->
* Issue: gh-108590
<!-- /gh-issue-number -->
