### PR TITLE
Revert "gh-103224: Use the realpath of the Python executable in `test_venv` (GH-103243)"

### DIFF
--- a/Lib/test/test_venv.py
+++ b/Lib/test/test_venv.py
@@ -208,8 +208,7 @@ class BasicTest(BaseTest):
     def test_upgrade_dependencies(self):
         builder = venv.EnvBuilder()
         bin_path = 'Scripts' if sys.platform == 'win32' else 'bin'
-        python_exe_realpath = os.path.realpath(sys._base_executable)
-        python_exe = os.path.split(python_exe_realpath)[1]
+        python_exe = os.path.split(sys.executable)[1]
         with tempfile.TemporaryDirectory() as fake_env_dir:
             expect_exe = os.path.normcase(
                 os.path.join(fake_env_dir, bin_path, python_exe)
@@ -552,8 +551,7 @@ class BasicTest(BaseTest):
         self.addCleanup(rmtree, non_installed_dir)
         bindir = os.path.join(non_installed_dir, self.bindir)
         os.mkdir(bindir)
-        python_exe_realpath = os.path.realpath(sys._base_executable)
-        shutil.copy2(python_exe_realpath, bindir)
+        shutil.copy2(sys.executable, bindir)
         libdir = os.path.join(non_installed_dir, platlibdir, self.lib[1])
         os.makedirs(libdir)
         landmark = os.path.join(libdir, "os.py")
@@ -597,7 +595,7 @@ class BasicTest(BaseTest):
         # libpython.so
         ld_library_path = sysconfig.get_config_var("LIBDIR")
         if not ld_library_path or sysconfig.is_python_build():
-            ld_library_path = os.path.abspath(os.path.dirname(python_exe_realpath))
+            ld_library_path = os.path.abspath(os.path.dirname(sys.executable))
         if sys.platform == 'darwin':
             ld_library_path_env = "DYLD_LIBRARY_PATH"
         else:


### PR DESCRIPTION
This reverts commit 85b0b0cd947c5218260fb2bc2014c8c8de172d33.

It broke builtbots.


<!-- gh-issue-number: gh-103224 -->
* Issue: gh-103224
<!-- /gh-issue-number -->
