### PR TITLE
gh-108669: Fix documentation for TestResult.collectedDurations

### DIFF
--- a/Doc/library/unittest.rst
+++ b/Doc/library/unittest.rst
@@ -2017,7 +2017,7 @@ Loading and running tests
 
    .. attribute:: collectedDurations
 
-      A list containing 2-tuples of :class:`TestCase` instances and floats
+      A list containing 2-tuples of test case names and floats
       representing the elapsed time of each test which was run.
 
       .. versionadded:: 3.12

--- a/Misc/NEWS.d/next/Documentation/2023-08-30-10-56-31.gh-issue-108669.sKBEdv.rst
+++ b/Misc/NEWS.d/next/Documentation/2023-08-30-10-56-31.gh-issue-108669.sKBEdv.rst
@@ -1,0 +1,1 @@
+Fix documentation for :attr:`unittest.TestResult.collectedDurations`.

--- a/Misc/NEWS.d/next/Documentation/2023-08-30-10-56-31.gh-issue-108669.sKBEdv.rst
+++ b/Misc/NEWS.d/next/Documentation/2023-08-30-10-56-31.gh-issue-108669.sKBEdv.rst
@@ -1,1 +1,0 @@
-Fix documentation for :attr:`unittest.TestResult.collectedDurations`.


### PR DESCRIPTION


<!-- gh-issue-number: gh-108669 -->
* Issue: gh-108669
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--108670.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->