### PR TITLE
gh-101100: Fix Sphinx warnings in the Logging Cookbook

### DIFF
--- a/Doc/howto/logging-cookbook.rst
+++ b/Doc/howto/logging-cookbook.rst
@@ -761,7 +761,7 @@ printed on the console; on the server side, you should see something like:
 
 Note that there are some security issues with pickle in some scenarios. If
 these affect you, you can use an alternative serialization scheme by overriding
-the :meth:`~handlers.SocketHandler.makePickle` method and implementing your
+the :meth:`~SocketHandler.makePickle` method and implementing your
 alternative there, as well as adapting the above script to use your alternative
 serialization.
 
@@ -834,6 +834,8 @@ To test these files, do the following in a POSIX environment:
 
 You may need to tweak the configuration files in the unlikely event that the
 configured ports clash with something else in your test environment.
+
+.. currentmodule:: logging
 
 .. _context-info:
 
@@ -1546,7 +1548,7 @@ Sometimes you want to let a log file grow to a certain size, then open a new
 file and log to that. You may want to keep a certain number of these files, and
 when that many files have been created, rotate the files so that the number of
 files and the size of the files both remain bounded. For this usage pattern, the
-logging package provides a :class:`~handlers.RotatingFileHandler`::
+logging package provides a :class:`RotatingFileHandler`::
 
    import glob
    import logging
@@ -1593,6 +1595,8 @@ and each time it reaches the size limit it is renamed with the suffix
 
 Obviously this example sets the log length much too small as an extreme
 example.  You would want to set *maxBytes* to an appropriate value.
+
+.. currentmodule:: logging
 
 .. _format-styles:
 
@@ -1840,6 +1844,7 @@ However, it should be borne in mind that each link in the chain adds run-time
 overhead to all logging operations, and the technique should only be used when
 the use of a :class:`Filter` does not provide the desired result.
 
+.. currentmodule:: logging.handlers
 
 .. _zeromq-handlers:
 
@@ -1916,6 +1921,8 @@ of queues, for example a ZeroMQ 'subscribe' socket. Here's an example::
 
    :ref:`A more advanced logging tutorial <logging-advanced-tutorial>`
 
+
+.. currentmodule:: logging
 
 An example dictionary-based configuration
 -----------------------------------------
@@ -3918,8 +3925,8 @@ that in other languages such as Java and C#, loggers are often static class
 attributes. However, this pattern doesn't make sense in Python, where the
 module (and not the class) is the unit of software decomposition.
 
-Adding handlers other than :class:`NullHandler` to a logger in a library
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Adding handlers other than :class:`~logging.NullHandler` to a logger in a library
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Configuring logging by adding handlers, formatters and filters is the
 responsibility of the application developer, not the library developer. If you

--- a/Doc/tools/.nitignore
+++ b/Doc/tools/.nitignore
@@ -26,7 +26,6 @@ Doc/glossary.rst
 Doc/howto/descriptor.rst
 Doc/howto/enum.rst
 Doc/howto/isolating-extensions.rst
-Doc/howto/logging-cookbook.rst
 Doc/howto/logging.rst
 Doc/howto/urllib2.rst
 Doc/library/__future__.rst


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

Fix all 39 Sphinx warnings and remove file from `.nitignore`.

# Before

```console
❯ touch Doc/howto/logging-cookbook.rst; make -C Doc html SPHINXERRORHANDLING=-n 2>&1 | grep "logging-cookbook.*WARNING" | tee >(wc -l)
/Users/hugo/github/cpython/Doc/howto/logging-cookbook.rst:762: WARNING: py:meth reference target not found: handlers.SocketHandler.makePickle
/Users/hugo/github/cpython/Doc/howto/logging-cookbook.rst:843: WARNING: py:class reference target not found: Logger
/Users/hugo/github/cpython/Doc/howto/logging-cookbook.rst:843: WARNING: py:class reference target not found: Logger
/Users/hugo/github/cpython/Doc/howto/logging-cookbook.rst:843: WARNING: py:class reference target not found: Logger
/Users/hugo/github/cpython/Doc/howto/logging-cookbook.rst:860: WARNING: py:class reference target not found: LoggerAdapter
/Users/hugo/github/cpython/Doc/howto/logging-cookbook.rst:860: WARNING: py:class reference target not found: Logger
/Users/hugo/github/cpython/Doc/howto/logging-cookbook.rst:860: WARNING: py:meth reference target not found: debug
/Users/hugo/github/cpython/Doc/howto/logging-cookbook.rst:860: WARNING: py:meth reference target not found: info
/Users/hugo/github/cpython/Doc/howto/logging-cookbook.rst:860: WARNING: py:meth reference target not found: warning
/Users/hugo/github/cpython/Doc/howto/logging-cookbook.rst:860: WARNING: py:meth reference target not found: error
/Users/hugo/github/cpython/Doc/howto/logging-cookbook.rst:860: WARNING: py:meth reference target not found: exception
/Users/hugo/github/cpython/Doc/howto/logging-cookbook.rst:860: WARNING: py:meth reference target not found: critical
/Users/hugo/github/cpython/Doc/howto/logging-cookbook.rst:860: WARNING: py:meth reference target not found: log
/Users/hugo/github/cpython/Doc/howto/logging-cookbook.rst:860: WARNING: py:class reference target not found: Logger
/Users/hugo/github/cpython/Doc/howto/logging-cookbook.rst:868: WARNING: py:class reference target not found: LoggerAdapter
/Users/hugo/github/cpython/Doc/howto/logging-cookbook.rst:868: WARNING: py:class reference target not found: Logger
/Users/hugo/github/cpython/Doc/howto/logging-cookbook.rst:868: WARNING: py:class reference target not found: LoggerAdapter
/Users/hugo/github/cpython/Doc/howto/logging-cookbook.rst:868: WARNING: py:class reference target not found: Logger
/Users/hugo/github/cpython/Doc/howto/logging-cookbook.rst:868: WARNING: py:class reference target not found: LoggerAdapter
/Users/hugo/github/cpython/Doc/howto/logging-cookbook.rst:884: WARNING: py:meth reference target not found: LoggerAdapter.process
/Users/hugo/github/cpython/Doc/howto/logging-cookbook.rst:884: WARNING: py:class reference target not found: LoggerAdapter
/Users/hugo/github/cpython/Doc/howto/logging-cookbook.rst:893: WARNING: py:class reference target not found: LogRecord
/Users/hugo/github/cpython/Doc/howto/logging-cookbook.rst:893: WARNING: py:class reference target not found: Formatter
/Users/hugo/github/cpython/Doc/howto/logging-cookbook.rst:893: WARNING: py:class reference target not found: LoggerAdapter
/Users/hugo/github/cpython/Doc/howto/logging-cookbook.rst:893: WARNING: py:meth reference target not found: LoggerAdapter.process
/Users/hugo/github/cpython/Doc/howto/logging-cookbook.rst:920: WARNING: py:class reference target not found: LoggerAdapter
/Users/hugo/github/cpython/Doc/howto/logging-cookbook.rst:931: WARNING: py:class reference target not found: Filter
/Users/hugo/github/cpython/Doc/howto/logging-cookbook.rst:931: WARNING: py:class reference target not found: Formatter
/Users/hugo/github/cpython/Doc/howto/logging-cookbook.rst:1224: WARNING: py:class reference target not found: Handler
/Users/hugo/github/cpython/Doc/howto/logging-cookbook.rst:1224: WARNING: py:class reference target not found: LogRecord
/Users/hugo/github/cpython/Doc/howto/logging-cookbook.rst:1224: WARNING: py:class reference target not found: LogRecord
/Users/hugo/github/cpython/Doc/howto/logging-cookbook.rst:1253: WARNING: py:class reference target not found: handlers.SocketHandler
/Users/hugo/github/cpython/Doc/howto/logging-cookbook.rst:1266: WARNING: py:class reference target not found: FileHandler
/Users/hugo/github/cpython/Doc/howto/logging-cookbook.rst:1545: WARNING: py:class reference target not found: handlers.RotatingFileHandler
/Users/hugo/github/cpython/Doc/howto/logging-cookbook.rst:1608: WARNING: py:class reference target not found: Formatter
/Users/hugo/github/cpython/Doc/howto/logging-cookbook.rst:1729: WARNING: py:class reference target not found: LoggerAdapter
/Users/hugo/github/cpython/Doc/howto/logging-cookbook.rst:1849: WARNING: py:class reference target not found: QueueHandler
/Users/hugo/github/cpython/Doc/howto/logging-cookbook.rst:1888: WARNING: py:class reference target not found: QueueListener
/Users/hugo/github/cpython/Doc/howto/logging-cookbook.rst:3921: WARNING: py:class reference target not found: NullHandler
      39
```

# After

```console
❯ touch Doc/howto/logging-cookbook.rst; make -C Doc html SPHINXERRORHANDLING=-n 2>&1 | grep "logging-cookbook.*WARNING" | tee >(wc -l)
       0
```

<!-- gh-issue-number: gh-101100 -->
* Issue: gh-101100
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--108678.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->