### PR TITLE
gh-108590: Fix sqlite3 iterdump() for table columns containing invalid Unicode sequences

### DIFF
--- a/Lib/sqlite3/dump.py
+++ b/Lib/sqlite3/dump.py
@@ -7,34 +7,12 @@
 # future enhancements, you should normally quote any identifier that
 # is an English language word, even if you do not have to."
 
-
-from contextlib import contextmanager
-
-
 def _quote_name(name):
     return '"{0}"'.format(name.replace('"', '""'))
 
 
 def _quote_value(value):
     return "'{0}'".format(value.replace("'", "''"))
-
-
-def _force_decode(bs, *args, **kwargs):
-    # gh-108590: Don't fail if the database contains invalid Unicode data.
-    try:
-        return bs.decode(*args, **kwargs)
-    except UnicodeDecodeError:
-        return "".join([chr(c) for c in bs])
-
-
-@contextmanager
-def _text_factory(con, factory):
-    saved_factory = con.text_factory
-    con.text_factory = factory
-    try:
-        yield
-    finally:
-        con.text_factory = saved_factory
 
 
 def _iterdump(connection):
@@ -47,6 +25,7 @@ def _iterdump(connection):
     """
 
     writeable_schema = False
+    connection.text_factory = lambda x: str(x, errors='surrogateescape')
     cu = connection.cursor()
     yield('BEGIN TRANSACTION;')
 
@@ -96,9 +75,8 @@ def _iterdump(connection):
             )
         )
         query_res = cu.execute(q)
-        with _text_factory(connection, bytes):
-            for row in query_res:
-                yield("{0};".format(_force_decode(row[0])))
+        for row in query_res:
+            yield("{0};".format(row[0]))
 
     # Now when the type is 'index', 'trigger', or 'view'
     q = """

--- a/Lib/test/test_sqlite3/test_dump.py
+++ b/Lib/test/test_sqlite3/test_dump.py
@@ -138,7 +138,7 @@ class DumpTests(MemoryDatabaseMixin, unittest.TestCase):
         expected = [
             "BEGIN TRANSACTION;",
             "CREATE TABLE foo (data TEXT);",
-            "INSERT INTO \"foo\" VALUES('a\x9f');",
+            "INSERT INTO \"foo\" VALUES('a\udc9f');",
             "COMMIT;",
         ]
         self.cu.executescript("""

--- a/Misc/NEWS.d/next/Library/2023-08-29-22-53-48.gh-issue-108590.6k0pOl.rst
+++ b/Misc/NEWS.d/next/Library/2023-08-29-22-53-48.gh-issue-108590.6k0pOl.rst
@@ -1,1 +1,3 @@
-Fixed an issue where :meth:`sqlite3.Connection.iterdump` would fail and leave an incomplete SQL dump if a table includes invalid Unicode sequences. Patch by Corvin McPherson
+Fixed an issue where :meth:`sqlite3.Connection.iterdump` would fail and leave an
+incomplete SQL dump if a table includes invalid Unicode sequences.
+Patch by Corvin McPherson and Serhiy Storchaka.


### PR DESCRIPTION
This partially reverts 400a1cebc743515e40157ed7af86e48d654290ce, except for the test, which is amended.


<!-- gh-issue-number: gh-108590 -->
* Issue: gh-108590
<!-- /gh-issue-number -->
