### PR TITLE
gh-101100: Fix sphinx warnings in `threading.rst`

### DIFF
--- a/Doc/library/threading.rst
+++ b/Doc/library/threading.rst
@@ -285,7 +285,7 @@ thread of control.  There are two ways to specify the activity: by passing a
 callable object to the constructor, or by overriding the :meth:`~Thread.run`
 method in a subclass.  No other methods (except for the constructor) should be
 overridden in a subclass.  In other words, *only*  override the
-``Thread.__init__()`` and :meth:`~Thread.run` methods of this class.
+``__init__()`` and :meth:`~Thread.run` methods of this class.
 
 Once a thread object is created, its activity must be started by calling the
 thread's :meth:`~Thread.start` method.  This invokes the :meth:`~Thread.run`

--- a/Doc/library/threading.rst
+++ b/Doc/library/threading.rst
@@ -272,7 +272,7 @@ The instance's values will be different for separate threads.
    A class that represents thread-local data.
 
    For more details and extensive examples, see the documentation string of the
-   :mod:`_threading_local` module: :source:`Lib/_threading_local.py`.
+   :mod:`!_threading_local` module: :source:`Lib/_threading_local.py`.
 
 
 .. _thread-objects:
@@ -285,7 +285,7 @@ thread of control.  There are two ways to specify the activity: by passing a
 callable object to the constructor, or by overriding the :meth:`~Thread.run`
 method in a subclass.  No other methods (except for the constructor) should be
 overridden in a subclass.  In other words, *only*  override the
-:meth:`~Thread.__init__` and :meth:`~Thread.run` methods of this class.
+``Thread.__init__()`` and :meth:`~Thread.run` methods of this class.
 
 Once a thread object is created, its activity must be started by calling the
 thread's :meth:`~Thread.start` method.  This invokes the :meth:`~Thread.run`
@@ -337,7 +337,7 @@ since it is impossible to detect the termination of alien threads.
    are:
 
    *group* should be ``None``; reserved for future extension when a
-   :class:`ThreadGroup` class is implemented.
+   :class:`!ThreadGroup` class is implemented.
 
    *target* is the callable object to be invoked by the :meth:`run` method.
    Defaults to ``None``, meaning nothing is called.
@@ -1009,7 +1009,7 @@ This class represents an action that should be run only after a certain amount
 of time has passed --- a timer.  :class:`Timer` is a subclass of :class:`Thread`
 and as such also functions as an example of creating custom threads.
 
-Timers are started, as with threads, by calling their :meth:`~Timer.start`
+Timers are started, as with threads, by calling their :meth:`Timer.start <Thread.start>`
 method.  The timer can be stopped (before its action has begun) by calling the
 :meth:`~Timer.cancel` method.  The interval the timer will wait before
 executing its action may not be exactly the same as the interval specified by
@@ -1147,10 +1147,10 @@ As an example, here is a simple way to synchronize a client and server thread::
 Using locks, conditions, and semaphores in the :keyword:`!with` statement
 -------------------------------------------------------------------------
 
-All of the objects provided by this module that have :meth:`acquire` and
-:meth:`release` methods can be used as context managers for a :keyword:`with`
-statement.  The :meth:`acquire` method will be called when the block is
-entered, and :meth:`release` will be called when the block is exited.  Hence,
+All of the objects provided by this module that have ``acquire`` and
+``release`` methods can be used as context managers for a :keyword:`with`
+statement.  The ``acquire`` method will be called when the block is
+entered, and ``release`` will be called when the block is exited.  Hence,
 the following snippet::
 
    with some_lock:

--- a/Doc/tools/.nitignore
+++ b/Doc/tools/.nitignore
@@ -124,7 +124,6 @@ Doc/library/tarfile.rst
 Doc/library/tempfile.rst
 Doc/library/termios.rst
 Doc/library/test.rst
-Doc/library/threading.rst
 Doc/library/time.rst
 Doc/library/tkinter.rst
 Doc/library/tkinter.scrolledtext.rst


### PR DESCRIPTION
Original warnings:

```
/Users/sobolev/Desktop/cpython/Doc/library/threading.rst:274: WARNING: py:mod reference target not found: _threading_local
/Users/sobolev/Desktop/cpython/Doc/library/threading.rst:283: WARNING: py:meth reference target not found: Thread.__init__
/Users/sobolev/Desktop/cpython/Doc/library/threading.rst:339: WARNING: py:class reference target not found: ThreadGroup
/Users/sobolev/Desktop/cpython/Doc/library/threading.rst:1012: WARNING: py:meth reference target not found: Timer.start
/Users/sobolev/Desktop/cpython/Doc/library/threading.rst:1150: WARNING: py:meth reference target not found: acquire
/Users/sobolev/Desktop/cpython/Doc/library/threading.rst:1150: WARNING: py:meth reference target not found: release
/Users/sobolev/Desktop/cpython/Doc/library/threading.rst:1150: WARNING: py:meth reference target not found: acquire
/Users/sobolev/Desktop/cpython/Doc/library/threading.rst:1150: WARNING: py:meth reference target not found: release
```

Couple of comments:
- `_threading_local` module is not documented as a module in sphinx
- `Thread.__init__()` is used the same way in other places as well, `__init__` is not documented in sphinx
- `ThreadGroup` does not exist at the moment
- :meth:`Timer.start <Thread.start>` is used because `Timer` is `Thread` subclass and `Timer.start` is not documented
- `release` and `acquire` are used as general conventions, not exact methods

<!-- gh-issue-number: gh-101100 -->
* Issue: gh-101100
<!-- /gh-issue-number -->
