### PR TITLE
Revert "gh-46376: Return existing pointer when possible in ctypes (#1…

### DIFF
--- a/Lib/test/test_ctypes/test_keeprefs.py
+++ b/Lib/test/test_ctypes/test_keeprefs.py
@@ -98,33 +98,6 @@ class PointerTestCase(unittest.TestCase):
         x = pointer(i)
         self.assertEqual(x._objects, {'1': i})
 
-    def test_pp_ownership(self):
-        d = c_int(123)
-        n = c_int(456)
-
-        p = pointer(d)
-        pp = pointer(p)
-
-        self.assertIs(pp._objects['1'], p)
-        self.assertIs(pp._objects['0']['1'], d)
-
-        pp.contents.contents = n
-
-        self.assertIs(pp._objects['1'], p)
-        self.assertIs(pp._objects['0']['1'], n)
-
-        self.assertIs(p._objects['1'], n)
-        self.assertEqual(len(p._objects), 1)
-
-        del d
-        del p
-
-        self.assertIs(pp._objects['0']['1'], n)
-        self.assertEqual(len(pp._objects), 2)
-
-        del n
-
-        self.assertEqual(len(pp._objects), 2)
 
 class PointerToStructure(unittest.TestCase):
     def test(self):

--- a/Misc/NEWS.d/next/Library/2023-07-24-01-21-16.gh-issue-46376.w-xuDL.rst
+++ b/Misc/NEWS.d/next/Library/2023-07-24-01-21-16.gh-issue-46376.w-xuDL.rst
@@ -1,1 +1,0 @@
-Prevent memory leak and use-after-free when using pointers to pointers with ctypes

--- a/Modules/_ctypes/_ctypes.c
+++ b/Modules/_ctypes/_ctypes.c
@@ -5148,41 +5148,6 @@ Pointer_get_contents(CDataObject *self, void *closure)
 
     stgdict = PyObject_stgdict((PyObject *)self);
     assert(stgdict); /* Cannot be NULL for pointer instances */
-
-    PyObject *keep = GetKeepedObjects(self);
-    if (keep != NULL) {
-        // check if it's a pointer to a pointer:
-        // pointers will have '0' key in the _objects
-        int ptr_probe = PyDict_ContainsString(keep, "0");
-        if (ptr_probe < 0) {
-            return NULL;
-        }
-        if (ptr_probe) {
-            PyObject *item;
-            if (PyDict_GetItemStringRef(keep, "1", &item) < 0) {
-                return NULL;
-            }
-            if (item == NULL) {
-                PyErr_SetString(PyExc_ValueError,
-                                "Unexpected NULL pointer in _objects");
-                return NULL;
-            }
-#ifndef NDEBUG
-            CDataObject *ptr2ptr = (CDataObject *)item;
-            // Don't construct a new object,
-            // return existing one instead to preserve refcount.
-            // Double-check that we are returning the same thing.
-            assert(
-                *(void**) self->b_ptr == ptr2ptr->b_ptr ||
-                *(void**) self->b_value.c == ptr2ptr->b_ptr ||
-                *(void**) self->b_ptr == ptr2ptr->b_value.c ||
-                *(void**) self->b_value.c == ptr2ptr->b_value.c
-            );
-#endif
-            return item;
-        }
-    }
-
     return PyCData_FromBaseObj(stgdict->proto,
                              (PyObject *)self, 0,
                              *(void **)self->b_ptr);


### PR DESCRIPTION
…07131)"

This reverts commit 08447b5deb47e2a0df87fa0a0576d300e5c909b4.

Revert also _ctypes.c changes of the PyDict_ContainsString() change, commit 67266266469fe0e817736227f39537182534c1a5.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-46376 -->
* Issue: gh-46376
<!-- /gh-issue-number -->
