### PR TITLE
gh-108638: Fix tests when _stat extension is missing

### DIFF
--- a/Lib/test/test_inspect.py
+++ b/Lib/test/test_inspect.py
@@ -1186,7 +1186,7 @@ class TestClassesAndFunctions(unittest.TestCase):
 
         cls = _testcapi.DocStringNoSignatureTest
         obj = _testcapi.DocStringNoSignatureTest()
-        for builtin, template in [
+        tests = [
             (_testcapi.docstring_no_signature_noargs, meth_noargs),
             (_testcapi.docstring_no_signature_o, meth_o),
             (cls.meth_noargs, meth_self_noargs),
@@ -1201,7 +1201,6 @@ class TestClassesAndFunctions(unittest.TestCase):
             (cls.meth_o_coexist, meth_self_o),
 
             (time.time, meth_noargs),
-            (stat.S_IMODE, meth_o),
             (str.lower, meth_self_noargs),
             (''.lower, meth_self_noargs),
             (set.add, meth_self_o),
@@ -1212,7 +1211,16 @@ class TestClassesAndFunctions(unittest.TestCase):
             (datetime.datetime.utcnow, meth_type_noargs),
             (dict.__dict__['__class_getitem__'], meth_type_o),
             (dict.__class_getitem__, meth_type_o),
-        ]:
+        ]
+        try:
+            import _stat
+        except ImportError:
+            # if the _stat extension is not available, stat.S_IMODE() is
+            # implemented in Python, not in C
+            pass
+        else:
+            tests.append((stat.S_IMODE, meth_o))
+        for builtin, template in tests:
             with self.subTest(builtin):
                 self.assertEqual(inspect.getfullargspec(builtin),
                                  inspect.getfullargspec(template))
@@ -2934,7 +2942,7 @@ class TestSignatureObject(unittest.TestCase):
 
         cls = _testcapi.DocStringNoSignatureTest
         obj = _testcapi.DocStringNoSignatureTest()
-        for builtin, template in [
+        tests = [
             (_testcapi.docstring_no_signature_noargs, meth_noargs),
             (_testcapi.docstring_no_signature_o, meth_o),
             (cls.meth_noargs, meth_self_noargs),
@@ -2949,7 +2957,6 @@ class TestSignatureObject(unittest.TestCase):
             (cls.meth_o_coexist, meth_self_o),
 
             (time.time, meth_noargs),
-            (stat.S_IMODE, meth_o),
             (str.lower, meth_self_noargs),
             (''.lower, meth_noargs),
             (set.add, meth_self_o),
@@ -2960,7 +2967,16 @@ class TestSignatureObject(unittest.TestCase):
             (datetime.datetime.utcnow, meth_noargs),
             (dict.__dict__['__class_getitem__'], meth_type_o),
             (dict.__class_getitem__, meth_o),
-        ]:
+        ]
+        try:
+            import _stat
+        except ImportError:
+            # if the _stat extension is not available, stat.S_IMODE() is
+            # implemented in Python, not in C
+            pass
+        else:
+            tests.append((stat.S_IMODE, meth_o))
+        for builtin, template in tests:
             with self.subTest(builtin):
                 self.assertEqual(inspect.signature(builtin),
                                  inspect.signature(template))

--- a/Lib/test/test_pydoc.py
+++ b/Lib/test/test_pydoc.py
@@ -1187,7 +1187,13 @@ class TestDescriptions(unittest.TestCase):
             "time()")
 
     def test_module_level_callable_o(self):
-        self.assertEqual(self._get_summary_line(stat.S_IMODE),
+        try:
+            import _stat
+        except ImportError:
+            # stat.S_IMODE() and _stat.S_IMODE() have a different signature
+            self.skipTest('_stat extension is missing')
+
+        self.assertEqual(self._get_summary_line(_stat.S_IMODE),
             "S_IMODE(object, /)")
 
     def test_unbound_builtin_method_noargs(self):


### PR DESCRIPTION
Fix test_inspect and test_pydoc when the _stat extension is missing. Skip tests relying on _stat when _stat is missing.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-108638 -->
* Issue: gh-108638
<!-- /gh-issue-number -->
