### PR TITLE
gh-108696: revert bypassing import cache in test_import helper

### DIFF
--- a/Lib/test/test_import/__init__.py
+++ b/Lib/test/test_import/__init__.py
@@ -25,7 +25,6 @@ from unittest import mock
 import _testinternalcapi
 import _imp
 
-from test.support import import_helper
 from test.support import os_helper
 from test.support import (
     STDLIB_DIR, swap_attr, swap_item, cpython_only, is_emscripten,
@@ -59,7 +58,7 @@ skip_if_dont_write_bytecode = unittest.skipIf(
 
 def _require_loader(module, loader, skip):
     if isinstance(module, str):
-        module = import_helper.import_fresh_module(module)
+        module = __import__(module)
 
     MODULE_KINDS = {
         BuiltinImporter: 'built-in',


### PR DESCRIPTION
Per suggestion from @FFY00 on https://github.com/python/cpython/pull/104186, let's revert this change to get the refleak buildbots green again.

Verified that with this diff, `./python -m test -R: -v test_import` no longer leaks references.

It seems that if we want to bypass this cache, it will require a bit more work to ensure we always dispose of the freshly-imported modules.

<!-- gh-issue-number: gh-108696 -->
* Issue: gh-108696
<!-- /gh-issue-number -->
