### PR TITLE
Clarify that PyUnstable macros use "PyUnstable" prefix

### DIFF
--- a/Doc/c-api/stable.rst
+++ b/Doc/c-api/stable.rst
@@ -46,6 +46,9 @@ details, and may change in every minor release (e.g. from 3.9 to 3.10) without
 any deprecation warnings.
 However, it will not change in a bugfix release (e.g. from 3.10.0 to 3.10.1).
 
+The ``PyUnstable`` prefix should be used for all symbols (functions, macros,
+variables, etc.).
+
 It is generally intended for specialized, low-level tools like debuggers.
 
 Projects that use this API are expected to follow


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--108710.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->