### PR TITLE
`ast` docs: Fix incorrect link on `keyword`

### DIFF
--- a/Doc/library/ast.rst
+++ b/Doc/library/ast.rst
@@ -585,7 +585,7 @@ Expressions
    :class:`Name` or :class:`Attribute` object. Of the arguments:
 
    * ``args`` holds a list of the arguments passed by position.
-   * ``keywords`` holds a list of :class:`keyword` objects representing
+   * ``keywords`` holds a list of :class:`.keyword` objects representing
      arguments passed by keyword.
 
    When creating a ``Call`` node, ``args`` and ``keywords`` are required, but
@@ -2024,7 +2024,7 @@ Function and class definitions
 
    * ``name`` is a raw string for the class name
    * ``bases`` is a list of nodes for explicitly specified base classes.
-   * ``keywords`` is a list of :class:`keyword` nodes, principally for 'metaclass'.
+   * ``keywords`` is a list of :class:`.keyword` nodes, principally for 'metaclass'.
      Other keywords will be passed to the metaclass, as per `PEP-3115
      <https://peps.python.org/pep-3115/>`_.
    * ``body`` is a list of nodes representing the code within the class


### PR DESCRIPTION
'Grammar-level *keyword*' != 'Function signature *keyword* argument'

From https://devguide.python.org/documentation/markup/#roles :

> Normally, names in these roles are searched first without any further
> qualification, then with the current module name prepended, then with
> the current module and class name (if any) prepended. If you prefix
> the name with a dot, this order is reversed.

So the global `keyword` module was found first; fix by forcing local search.

Check [current docs](https://docs.python.org/3/library/ast.html#ast.Call), where `keyword` contains the wrong link.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--108728.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->