### PR TITLE
gh-108727: Fix segfault due to missing tp_dealloc definition for CounterOptimizer_Type

### DIFF
--- a/Lib/test/test_capi/test_misc.py
+++ b/Lib/test/test_capi/test_misc.py
@@ -2284,6 +2284,13 @@ def clear_executors(func):
 
 class TestOptimizerAPI(unittest.TestCase):
 
+    def test_get_counter_optimizer_dealloc(self):
+        # See gh-108727
+        def f():
+            _testinternalcapi.get_counter_optimizer()
+
+        f()
+
     def test_get_set_optimizer(self):
         old = _testinternalcapi.get_optimizer()
         opt = _testinternalcapi.get_counter_optimizer()

--- a/Misc/NEWS.d/next/Core and Builtins/2023-08-31-21-29-28.gh-issue-108727.blNRGM.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2023-08-31-21-29-28.gh-issue-108727.blNRGM.rst
@@ -1,0 +1,2 @@
+Define ``tp_dealloc`` for ``CounterOptimizer_Type``. This fixes a segfault
+on deallocation.

--- a/Python/optimizer.c
+++ b/Python/optimizer.c
@@ -289,6 +289,7 @@ static PyTypeObject CounterOptimizer_Type = {
     .tp_itemsize = 0,
     .tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_DISALLOW_INSTANTIATION,
     .tp_methods = counter_methods,
+    .tp_dealloc = (destructor)PyObject_Del,
 };
 
 PyObject *


### PR DESCRIPTION
Fixes #108727.

<!-- gh-issue-number: gh-108727 -->
* Issue: gh-108727
<!-- /gh-issue-number -->
