### PR TITLE
gh-106320: Remove private _PyLong_IsCompact() function

### DIFF
--- a/Doc/c-api/long.rst
+++ b/Doc/c-api/long.rst
@@ -332,7 +332,7 @@ distinguished from a number.  Use :c:func:`PyErr_Occurred` to disambiguate.
    Returns ``NULL`` on error.  Use :c:func:`PyErr_Occurred` to disambiguate.
 
 
-.. c:function:: int PyUnstable_Long_IsCompact(const PyLongObject* op)
+.. c:function:: int PyUnstable_Long_IsCompact(PyLongObject* op)
 
    Return 1 if *op* is compact, 0 otherwise.
 
@@ -347,7 +347,7 @@ distinguished from a number.  Use :c:func:`PyErr_Occurred` to disambiguate.
    Exactly what values are considered compact is an implementation detail
    and is subject to change.
 
-.. c:function:: Py_ssize_t PyUnstable_Long_CompactValue(const PyLongObject* op)
+.. c:function:: Py_ssize_t PyUnstable_Long_CompactValue(PyLongObject* op)
 
    If *op* is compact, as determined by :c:func:`PyUnstable_Long_IsCompact`,
    return its value.

--- a/Include/cpython/longintrepr.h
+++ b/Include/cpython/longintrepr.h
@@ -89,34 +89,6 @@ struct _longobject {
     _PyLongValue long_value;
 };
 
-
-/* Inline some internals for speed. These should be in pycore_long.h
- * if user code didn't need them inlined. */
-
-#define _PyLong_SIGN_MASK 3
-#define _PyLong_NON_SIZE_BITS 3
-
-
-static inline int
-_PyLong_IsCompact(const PyLongObject* op) {
-    assert(PyType_HasFeature((op)->ob_base.ob_type, Py_TPFLAGS_LONG_SUBCLASS));
-    return op->long_value.lv_tag < (2 << _PyLong_NON_SIZE_BITS);
-}
-
-#define PyUnstable_Long_IsCompact _PyLong_IsCompact
-
-static inline Py_ssize_t
-_PyLong_CompactValue(const PyLongObject *op)
-{
-    assert(PyType_HasFeature((op)->ob_base.ob_type, Py_TPFLAGS_LONG_SUBCLASS));
-    assert(PyUnstable_Long_IsCompact(op));
-    Py_ssize_t sign = 1 - (op->long_value.lv_tag & _PyLong_SIGN_MASK);
-    return sign * (Py_ssize_t)op->long_value.ob_digit[0];
-}
-
-#define PyUnstable_Long_CompactValue _PyLong_CompactValue
-
-
 #ifdef __cplusplus
 }
 #endif

--- a/Include/cpython/longobject.h
+++ b/Include/cpython/longobject.h
@@ -4,6 +4,5 @@
 
 PyAPI_FUNC(PyObject*) PyLong_FromUnicodeObject(PyObject *u, int base);
 
-PyAPI_FUNC(int) PyUnstable_Long_IsCompact(const PyLongObject* op);
-PyAPI_FUNC(Py_ssize_t) PyUnstable_Long_CompactValue(const PyLongObject* op);
-
+PyAPI_FUNC(int) PyUnstable_Long_IsCompact(PyLongObject* op);
+PyAPI_FUNC(Py_ssize_t) PyUnstable_Long_CompactValue(PyLongObject* op);

--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -6369,16 +6369,13 @@ _PyLong_FiniTypes(PyInterpreterState *interp)
     _PyStructSequence_FiniBuiltin(interp, &Int_InfoType);
 }
 
-#undef PyUnstable_Long_IsCompact
 
 int
-PyUnstable_Long_IsCompact(const PyLongObject* op) {
+PyUnstable_Long_IsCompact(PyLongObject* op) {
     return _PyLong_IsCompact(op);
 }
 
-#undef PyUnstable_Long_CompactValue
-
 Py_ssize_t
-PyUnstable_Long_CompactValue(const PyLongObject* op) {
+PyUnstable_Long_CompactValue(PyLongObject* op) {
     return _PyLong_CompactValue(op);
 }


### PR DESCRIPTION
Move the private _PyLong_IsCompact() and _PyLong_CompactValue() functions to the internal C API (pycore_long.h). Public PyUnstable_Long_IsCompact() and PyUnstable_Long_CompactValue() functions can be used instead.

Remove "const" qualifier from PyUnstable_Long_IsCompact() and PyUnstable_Long_CompactValue() parameter type.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-106320 -->
* Issue: gh-106320
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--108742.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->