### PR TITLE
gh-106320: Remove private _PyLong_Sign()

### DIFF
--- a/Include/cpython/longobject.h
+++ b/Include/cpython/longobject.h
@@ -4,21 +4,6 @@
 
 PyAPI_FUNC(PyObject*) PyLong_FromUnicodeObject(PyObject *u, int base);
 
-/* _PyLong_Sign.  Return 0 if v is 0, -1 if v < 0, +1 if v > 0.
-   v must not be NULL, and must be a normalized long.
-   There are no error cases.
-*/
-PyAPI_FUNC(int) _PyLong_Sign(PyObject *v);
-
-/* _PyLong_NumBits.  Return the number of bits needed to represent the
-   absolute value of a long.  For example, this returns 1 for 1 and -1, 2
-   for 2 and -2, and 2 for 3 and -3.  It returns 0 for 0.
-   v must not be NULL, and must be a normalized long.
-   (size_t)-1 is returned and OverflowError set if the true result doesn't
-   fit in a size_t.
-*/
-PyAPI_FUNC(size_t) _PyLong_NumBits(PyObject *v);
-
 PyAPI_FUNC(int) PyUnstable_Long_IsCompact(const PyLongObject* op);
 PyAPI_FUNC(Py_ssize_t) PyUnstable_Long_CompactValue(const PyLongObject* op);
 

--- a/Include/internal/pycore_long.h
+++ b/Include/internal/pycore_long.h
@@ -58,6 +58,23 @@ PyAPI_FUNC(PyLongObject*) _PyLong_FromDigits(
     Py_ssize_t digit_count,
     digit *digits);
 
+// _PyLong_Sign.  Return 0 if v is 0, -1 if v < 0, +1 if v > 0.
+// v must not be NULL, and must be a normalized long.
+// There are no error cases.
+//
+// Export for '_pickle' shared extension.
+PyAPI_FUNC(int) _PyLong_Sign(PyObject *v);
+
+// _PyLong_NumBits.  Return the number of bits needed to represent the
+// absolute value of a long.  For example, this returns 1 for 1 and -1, 2
+// for 2 and -2, and 2 for 3 and -3.  It returns 0 for 0.
+// v must not be NULL, and must be a normalized long.
+// (size_t)-1 is returned and OverflowError set if the true result doesn't
+// fit in a size_t.
+//
+// Export for 'math' shared extension.
+PyAPI_FUNC(size_t) _PyLong_NumBits(PyObject *v);
+
 
 /* runtime lifecycle */
 

--- a/Modules/_io/_iomodule.c
+++ b/Modules/_io/_iomodule.c
@@ -10,6 +10,7 @@
 #include "Python.h"
 #include "pycore_abstract.h"      // _PyNumber_Index()
 #include "pycore_initconfig.h"    // _PyStatus_OK()
+#include "pycore_long.h"          // _PyLong_Sign()
 #include "pycore_pyerrors.h"      // _PyErr_ChainExceptions1()
 #include "pycore_pystate.h"       // _PyInterpreterState_GET()
 

--- a/Modules/_testcapi/long.c
+++ b/Modules/_testcapi/long.c
@@ -1,5 +1,10 @@
+#ifndef Py_BUILD_CORE_BUILTIN
+#  define Py_BUILD_CORE_MODULE 1
+#endif
+
 #include "parts.h"
 #include "clinic/long.c.h"
+#include "pycore_long.h"          // _PyLong_Sign()
 
 /*[clinic input]
 module _testcapi


### PR DESCRIPTION
Move the private _PyLong_Sign() and _PyLong_NumBits() function to the internal C API (pycore_long.h).

Modules/_testcapi/long.c now uses the internal C API.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-106320 -->
* Issue: gh-106320
<!-- /gh-issue-number -->
