### PR TITLE
gh-101100: Fix sphinx warnings in `tutorial/classes.rst`

### DIFF
--- a/Doc/tools/.nitignore
+++ b/Doc/tools/.nitignore
@@ -156,7 +156,6 @@ Doc/reference/expressions.rst
 Doc/reference/import.rst
 Doc/reference/simple_stmts.rst
 Doc/tutorial/appendix.rst
-Doc/tutorial/classes.rst
 Doc/tutorial/controlflow.rst
 Doc/tutorial/datastructures.rst
 Doc/tutorial/introduction.rst

--- a/Doc/tutorial/classes.rst
+++ b/Doc/tutorial/classes.rst
@@ -276,7 +276,7 @@ definition looked like this::
 then ``MyClass.i`` and ``MyClass.f`` are valid attribute references, returning
 an integer and a function object, respectively. Class attributes can also be
 assigned to, so you can change the value of ``MyClass.i`` by assignment.
-:attr:`__doc__` is also a valid attribute, returning the docstring belonging to
+:attr:`!__doc__` is also a valid attribute, returning the docstring belonging to
 the class: ``"A simple example class"``.
 
 Class *instantiation* uses function notation.  Just pretend that the class


### PR DESCRIPTION
There was a single warning:

```
/Users/sobolev/Desktop/cpython/Doc/tutorial/classes.rst:276: WARNING: py:attr reference target not found: __doc__
```

<!-- gh-issue-number: gh-101100 -->
* Issue: gh-101100
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--108746.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->