### PR TITLE
gh-101100: Fix sphinx warnings in `tutorial/appendix.rst`

### DIFF
--- a/Doc/tools/.nitignore
+++ b/Doc/tools/.nitignore
@@ -155,7 +155,6 @@ Doc/reference/datamodel.rst
 Doc/reference/expressions.rst
 Doc/reference/import.rst
 Doc/reference/simple_stmts.rst
-Doc/tutorial/appendix.rst
 Doc/tutorial/classes.rst
 Doc/tutorial/controlflow.rst
 Doc/tutorial/datastructures.rst

--- a/Doc/tutorial/appendix.rst
+++ b/Doc/tutorial/appendix.rst
@@ -101,8 +101,8 @@ in the script::
 The Customization Modules
 -------------------------
 
-Python provides two hooks to let you customize it: :mod:`sitecustomize` and
-:mod:`usercustomize`.  To see how it works, you need first to find the location
+Python provides two hooks to let you customize it: :index:`sitecustomize` and
+:index:`usercustomize`.  To see how it works, you need first to find the location
 of your user site-packages directory.  Start Python and run this code::
 
    >>> import site
@@ -113,9 +113,9 @@ Now you can create a file named :file:`usercustomize.py` in that directory and
 put anything you want in it.  It will affect every invocation of Python, unless
 it is started with the :option:`-s` option to disable the automatic import.
 
-:mod:`sitecustomize` works in the same way, but is typically created by an
+:index:`sitecustomize` works in the same way, but is typically created by an
 administrator of the computer in the global site-packages directory, and is
-imported before :mod:`usercustomize`.  See the documentation of the :mod:`site`
+imported before :index:`usercustomize`.  See the documentation of the :mod:`site`
 module for more details.
 
 


### PR DESCRIPTION
Warnings before:

```
/Users/sobolev/Desktop/cpython/Doc/tutorial/appendix.rst:104: WARNING: py:mod reference target not found: sitecustomize
/Users/sobolev/Desktop/cpython/Doc/tutorial/appendix.rst:104: WARNING: py:mod reference target not found: usercustomize
/Users/sobolev/Desktop/cpython/Doc/tutorial/appendix.rst:116: WARNING: py:mod reference target not found: sitecustomize
/Users/sobolev/Desktop/cpython/Doc/tutorial/appendix.rst:116: WARNING: py:mod reference target not found: usercustomize
```

The problem here is that these module are not documented as `.. module::`, they are documented as `.. index` instead https://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html#directive-index

https://github.com/python/cpython/blob/044b8b3b6a65e6651b161e3badfa5d57c666db19/Doc/library/site.rst#L112-L126

So, I went with [`:index:`](https://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html#role-index) inline role. This way once some location is added to their definitions (a header, probably) they will automatically link there.

<!-- gh-issue-number: gh-101100 -->
* Issue: gh-101100
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--108750.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->