### PR TITLE
Make test_fcntl quiet

### DIFF
--- a/Lib/test/test_fcntl.py
+++ b/Lib/test/test_fcntl.py
@@ -16,37 +16,6 @@ fcntl = import_module('fcntl')
 
 
 
-def get_lockdata():
-    try:
-        os.O_LARGEFILE
-    except AttributeError:
-        start_len = "ll"
-    else:
-        start_len = "qq"
-
-    if (sys.platform.startswith(('netbsd', 'freebsd', 'openbsd'))
-        or sys.platform == 'darwin'):
-        if struct.calcsize('l') == 8:
-            off_t = 'l'
-            pid_t = 'i'
-        else:
-            off_t = 'lxxxx'
-            pid_t = 'l'
-        lockdata = struct.pack(off_t + off_t + pid_t + 'hh', 0, 0, 0,
-                               fcntl.F_WRLCK, 0)
-    elif sys.platform.startswith('gnukfreebsd'):
-        lockdata = struct.pack('qqihhi', 0, 0, 0, fcntl.F_WRLCK, 0, 0)
-    elif sys.platform in ['hp-uxB', 'unixware7']:
-        lockdata = struct.pack('hhlllii', fcntl.F_WRLCK, 0, 0, 0, 0, 0, 0)
-    else:
-        lockdata = struct.pack('hh'+start_len+'hh', fcntl.F_WRLCK, 0, 0, 0, 0, 0)
-    if lockdata:
-        if verbose:
-            print('struct.pack: ', repr(lockdata))
-    return lockdata
-
-lockdata = get_lockdata()
-
 class BadFile:
     def __init__(self, fn):
         self.fn = fn
@@ -78,12 +47,43 @@ class TestFcntl(unittest.TestCase):
             self.f.close()
         unlink(TESTFN)
 
+    @staticmethod
+    def get_lockdata():
+        try:
+            os.O_LARGEFILE
+        except AttributeError:
+            start_len = "ll"
+        else:
+            start_len = "qq"
+
+        if (sys.platform.startswith(('netbsd', 'freebsd', 'openbsd'))
+            or sys.platform == 'darwin'):
+            if struct.calcsize('l') == 8:
+                off_t = 'l'
+                pid_t = 'i'
+            else:
+                off_t = 'lxxxx'
+                pid_t = 'l'
+            lockdata = struct.pack(off_t + off_t + pid_t + 'hh', 0, 0, 0,
+                                   fcntl.F_WRLCK, 0)
+        elif sys.platform.startswith('gnukfreebsd'):
+            lockdata = struct.pack('qqihhi', 0, 0, 0, fcntl.F_WRLCK, 0, 0)
+        elif sys.platform in ['hp-uxB', 'unixware7']:
+            lockdata = struct.pack('hhlllii', fcntl.F_WRLCK, 0, 0, 0, 0, 0, 0)
+        else:
+            lockdata = struct.pack('hh'+start_len+'hh', fcntl.F_WRLCK, 0, 0, 0, 0, 0)
+        if lockdata:
+            if verbose:
+                print('struct.pack: ', repr(lockdata))
+        return lockdata
+
     def test_fcntl_fileno(self):
         # the example from the library docs
         self.f = open(TESTFN, 'wb')
         rv = fcntl.fcntl(self.f.fileno(), fcntl.F_SETFL, os.O_NONBLOCK)
         if verbose:
             print('Status from fcntl with O_NONBLOCK: ', rv)
+        lockdata = self.get_lockdata()
         rv = fcntl.fcntl(self.f.fileno(), fcntl.F_SETLKW, lockdata)
         if verbose:
             print('String from fcntl with F_SETLKW: ', repr(rv))
@@ -95,6 +95,7 @@ class TestFcntl(unittest.TestCase):
         rv = fcntl.fcntl(self.f, fcntl.F_SETFL, os.O_NONBLOCK)
         if verbose:
             print('Status from fcntl with O_NONBLOCK: ', rv)
+        lockdata = self.get_lockdata()
         rv = fcntl.fcntl(self.f, fcntl.F_SETLKW, lockdata)
         if verbose:
             print('String from fcntl with F_SETLKW: ', repr(rv))


### PR DESCRIPTION
Running test_fcntl logs two "struct.pack: ..." lines because multiprocessing imports test_fcntl twice with
test.support.verbose=1. Move get_lockdata() inside TestFcntl test case and only call it where it's needed, to stop logging these lines.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
