### PR TITLE
gh-108765: Move standard includes to Python.h

### DIFF
--- a/Include/Python.h
+++ b/Include/Python.h
@@ -5,42 +5,50 @@
 #ifndef Py_PYTHON_H
 #define Py_PYTHON_H
 
-// Since this is a "meta-include" file, no #ifdef __cplusplus / extern "C" {
+// Since this is a "meta-include" file, "#ifdef __cplusplus / extern "C" {"
+// is not needed.
+
 
 // Include Python header files
 #include "patchlevel.h"
 #include "pyconfig.h"
 #include "pymacconfig.h"
 
-#if defined(__sgi) && !defined(_SGI_MP_SOURCE)
-#  define _SGI_MP_SOURCE
-#endif
 
-// stdlib.h, stdio.h, errno.h and string.h headers are not used by Python
-// headers, but kept for backward compatibility. They are excluded from the
-// limited C API of Python 3.11.
-#if !defined(Py_LIMITED_API) || Py_LIMITED_API+0 < 0x030b0000
-#  include <stdlib.h>
-#  include <stdio.h>              // FILE*
-#  include <errno.h>              // errno
-#  include <string.h>             // memcpy()
-#endif
-#ifndef MS_WINDOWS
-#  include <unistd.h>
-#endif
+// Include standard header files
+#include <assert.h>               // assert()
+#include <ctype.h>                // tolower()
+#include <inttypes.h>             // uintptr_t
+#include <limits.h>               // INT_MAX
+#include <stdarg.h>               // va_list
+#include <wchar.h>                // wchar_t
 #ifdef HAVE_STDDEF_H
 #  include <stddef.h>             // size_t
 #endif
+#ifndef MS_WINDOWS
+#  include <unistd.h>             // sysconf()
+#endif
 
-#include <assert.h>               // assert()
-#include <wchar.h>                // wchar_t
+// errno.h, stdio.h, stdlib.h and string.h headers are no longer used by Python
+// headers, but kept for backward compatibility (no introduce new compiler
+// warnings). They are not included by the limited C API version 3.11 and
+// above.
+#if !defined(Py_LIMITED_API) || Py_LIMITED_API+0 < 0x030b0000
+#  include <errno.h>              // errno
+#  include <stdio.h>              // FILE*
+#  include <stdlib.h>             // getenv()
+#  include <string.h>             // memcpy()
+#endif
 
+
+// Include Python header files
 #include "pyport.h"
 #include "pymacro.h"
 #include "pymath.h"
 #include "pymem.h"
 #include "pytypedefs.h"
 #include "pybuffer.h"
+#include "pystats.h"
 #include "object.h"
 #include "objimpl.h"
 #include "typeslots.h"

--- a/Include/bytesobject.h
+++ b/Include/bytesobject.h
@@ -1,13 +1,10 @@
-
-/* Bytes object interface */
+// Bytes object interface
 
 #ifndef Py_BYTESOBJECT_H
 #define Py_BYTESOBJECT_H
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include <stdarg.h>               // va_list
 
 /*
 Type PyBytesObject represents a byte string.  An extra zero byte is

--- a/Include/internal/pycore_condvar.h
+++ b/Include/internal/pycore_condvar.h
@@ -5,7 +5,9 @@
 #  error "this header requires Py_BUILD_CORE define"
 #endif
 
-#include <unistd.h>               // _POSIX_THREADS
+#ifndef MS_WINDOWS
+#  include <unistd.h>             // _POSIX_THREADS
+#endif
 
 #ifndef _POSIX_THREADS
 /* This means pthreads are not implemented in libc headers, hence the macro

--- a/Include/internal/pycore_condvar.h
+++ b/Include/internal/pycore_condvar.h
@@ -5,6 +5,8 @@
 #  error "this header requires Py_BUILD_CORE define"
 #endif
 
+#include <unistd.h>               // _POSIX_THREADS
+
 #ifndef _POSIX_THREADS
 /* This means pthreads are not implemented in libc headers, hence the macro
    not present in unistd.h. But they still can be implemented as an external

--- a/Include/modsupport.h
+++ b/Include/modsupport.h
@@ -1,13 +1,10 @@
+// Module support interface
 
 #ifndef Py_MODSUPPORT_H
 #define Py_MODSUPPORT_H
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-/* Module support interface */
-
-#include <stdarg.h>               // va_list
 
 PyAPI_FUNC(int) PyArg_Parse(PyObject *, const char *, ...);
 PyAPI_FUNC(int) PyArg_ParseTuple(PyObject *, const char *, ...);

--- a/Include/object.h
+++ b/Include/object.h
@@ -51,8 +51,6 @@ A standard interface exists for objects that contain an array of items
 whose size is determined when the object is allocated.
 */
 
-#include "pystats.h"
-
 /* Py_DEBUG implies Py_REF_DEBUG. */
 #if defined(Py_DEBUG) && !defined(Py_REF_DEBUG)
 #  define Py_REF_DEBUG

--- a/Include/objimpl.h
+++ b/Include/objimpl.h
@@ -1,12 +1,8 @@
-/* The PyObject_ memory family:  high-level object memory interfaces.
-   See pymem.h for the low-level PyMem_ family.
-*/
+// The PyObject_ memory family:  high-level object memory interfaces.
+// See pymem.h for the low-level PyMem_ family.
 
 #ifndef Py_OBJIMPL_H
 #define Py_OBJIMPL_H
-
-#include "pymem.h"
-
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -231,4 +227,4 @@ PyAPI_FUNC(int) PyObject_GC_IsFinalized(PyObject *);
 #ifdef __cplusplus
 }
 #endif
-#endif /* !Py_OBJIMPL_H */
+#endif   // !Py_OBJIMPL_H

--- a/Include/pyerrors.h
+++ b/Include/pyerrors.h
@@ -1,12 +1,10 @@
+// Error handling definitions
+
 #ifndef Py_ERRORS_H
 #define Py_ERRORS_H
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include <stdarg.h>               // va_list
-
-/* Error handling definitions */
 
 PyAPI_FUNC(void) PyErr_SetNone(PyObject *);
 PyAPI_FUNC(void) PyErr_SetObject(PyObject *, PyObject *);

--- a/Include/pymem.h
+++ b/Include/pymem.h
@@ -1,12 +1,8 @@
-/* The PyMem_ family:  low-level memory allocation interfaces.
-   See objimpl.h for the PyObject_ memory family.
-*/
+// The PyMem_ family:  low-level memory allocation interfaces.
+// See objimpl.h for the PyObject_ memory family.
 
 #ifndef Py_PYMEM_H
 #define Py_PYMEM_H
-
-#include "pyport.h"
-
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -100,5 +96,4 @@ PyAPI_FUNC(void) PyMem_Free(void *ptr);
 #ifdef __cplusplus
 }
 #endif
-
-#endif /* !Py_PYMEM_H */
+#endif   // !Py_PYMEM_H

--- a/Include/pyport.h
+++ b/Include/pyport.h
@@ -1,13 +1,8 @@
 #ifndef Py_PYPORT_H
 #define Py_PYPORT_H
 
-#include "pyconfig.h" /* include for defines */
-
-#include <inttypes.h>
-
-#include <limits.h>
 #ifndef UCHAR_MAX
-#  error "limits.h must define UCHAR_MAX"
+#  error "<limits.h> header must define UCHAR_MAX"
 #endif
 #if UCHAR_MAX != 255
 #  error "Python's source code assumes C's unsigned char is an 8-bit type"
@@ -769,6 +764,10 @@ extern char * _getpty(int *, int, mode_t, int);
 #if !defined(ALIGNOF_MAX_ALIGN_T) || ALIGNOF_MAX_ALIGN_T == 0
 #   undef ALIGNOF_MAX_ALIGN_T
 #   define ALIGNOF_MAX_ALIGN_T _Alignof(long double)
+#endif
+
+#if defined(__sgi) && !defined(_SGI_MP_SOURCE)
+#  define _SGI_MP_SOURCE
 #endif
 
 #endif /* Py_PYPORT_H */

--- a/Include/unicodeobject.h
+++ b/Include/unicodeobject.h
@@ -1,8 +1,6 @@
 #ifndef Py_UNICODEOBJECT_H
 #define Py_UNICODEOBJECT_H
 
-#include <stdarg.h>               // va_list
-
 /*
 
 Unicode implementation based on original code by Fredrik Lundh,
@@ -55,8 +53,6 @@ Copyright (c) Corporation for National Research Initiatives.
  * OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  * -------------------------------------------------------------------- */
 
-#include <ctype.h>
-
 /* === Internal API ======================================================= */
 
 /* --- Internal Unicode Format -------------------------------------------- */
@@ -91,10 +87,6 @@ Copyright (c) Corporation for National Research Initiatives.
 # ifndef HAVE_WCHAR_H
 #  define HAVE_WCHAR_H
 # endif
-#endif
-
-#ifdef HAVE_WCHAR_H
-#  include <wchar.h>
 #endif
 
 /* Py_UCS4 and Py_UCS2 are typedefs for the respective


### PR DESCRIPTION
* Move <ctype.h>, <limits.h> and <stdarg.h> standard includes to Python.h.
* Move "pystats.h" include from object.h to Python.h.
* Remove redundant "pymem.h" include in objimpl.h and "pyport.h" include in pymem.h; Python.h already includes them earlier.
* Remove redundant <wchar.h> include in unicodeobject.h; Python.h already includes it.
* Move _SGI_MP_SOURCE define from Python.h to pyport.h.
* pycore_condvar.h includes explicitly <unistd.h> for the _POSIX_THREADS macro.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-108765 -->
* Issue: gh-108765
<!-- /gh-issue-number -->
