### PR TITLE
gh-108767: Convert Py_ISLOWER() macro to static inline function

### DIFF
--- a/Include/cpython/pyctype.h
+++ b/Include/cpython/pyctype.h
@@ -18,19 +18,37 @@ PyAPI_DATA(const unsigned int) _Py_ctype_table[256];
 /* Unlike their C counterparts, the following macros are not meant to
  * handle an int with any of the values [EOF, 0-UCHAR_MAX]. The argument
  * must be a signed/unsigned char. */
-#define Py_ISLOWER(c)  (_Py_ctype_table[Py_CHARMASK(c)] & PY_CTF_LOWER)
-#define Py_ISUPPER(c)  (_Py_ctype_table[Py_CHARMASK(c)] & PY_CTF_UPPER)
-#define Py_ISALPHA(c)  (_Py_ctype_table[Py_CHARMASK(c)] & PY_CTF_ALPHA)
-#define Py_ISDIGIT(c)  (_Py_ctype_table[Py_CHARMASK(c)] & PY_CTF_DIGIT)
-#define Py_ISXDIGIT(c) (_Py_ctype_table[Py_CHARMASK(c)] & PY_CTF_XDIGIT)
-#define Py_ISALNUM(c)  (_Py_ctype_table[Py_CHARMASK(c)] & PY_CTF_ALNUM)
-#define Py_ISSPACE(c)  (_Py_ctype_table[Py_CHARMASK(c)] & PY_CTF_SPACE)
+static inline int Py_ISLOWER(int c) {
+    return (_Py_ctype_table[Py_CHARMASK(c)] & PY_CTF_LOWER);
+}
+static inline int Py_ISUPPER(int c) {
+    return (_Py_ctype_table[Py_CHARMASK(c)] & PY_CTF_UPPER);
+}
+static inline int Py_ISALPHA(int c) {
+    return (_Py_ctype_table[Py_CHARMASK(c)] & PY_CTF_ALPHA);
+}
+static inline int Py_ISDIGIT(int c) {
+    return (_Py_ctype_table[Py_CHARMASK(c)] & PY_CTF_DIGIT);
+}
+static inline int Py_ISXDIGIT(int c) {
+    return (_Py_ctype_table[Py_CHARMASK(c)] & PY_CTF_XDIGIT);
+}
+static inline int Py_ISALNUM(int c) {
+    return (_Py_ctype_table[Py_CHARMASK(c)] & PY_CTF_ALNUM);
+}
+static inline int Py_ISSPACE(int c) {
+    return (_Py_ctype_table[Py_CHARMASK(c)] & PY_CTF_SPACE);
+}
 
 PyAPI_DATA(const unsigned char) _Py_ctype_tolower[256];
 PyAPI_DATA(const unsigned char) _Py_ctype_toupper[256];
 
-#define Py_TOLOWER(c) (_Py_ctype_tolower[Py_CHARMASK(c)])
-#define Py_TOUPPER(c) (_Py_ctype_toupper[Py_CHARMASK(c)])
+static inline int Py_TOLOWER(int c) {
+    return _Py_ctype_tolower[Py_CHARMASK(c)];
+}
+static inline int Py_TOUPPER(int c) {
+    return _Py_ctype_toupper[Py_CHARMASK(c)];
+}
 
 #ifdef __cplusplus
 }

--- a/Include/pymacro.h
+++ b/Include/pymacro.h
@@ -44,7 +44,9 @@
 #define Py_MEMBER_SIZE(type, member) sizeof(((type *)0)->member)
 
 /* Argument must be a char or an int in [-128, 127] or [0, 255]. */
-#define Py_CHARMASK(c) ((unsigned char)((c) & 0xff))
+static inline unsigned char Py_CHARMASK(int c) {
+    return (unsigned char)(c & 0xff);
+}
 
 /* Assert a build-time dependency, as an expression.
 

--- a/Modules/_sre/sre.c
+++ b/Modules/_sre/sre.c
@@ -136,7 +136,7 @@ static unsigned int sre_toupper(unsigned int ch) {
 
 static unsigned int sre_lower_ascii(unsigned int ch)
 {
-    return ((ch) < 128 ? Py_TOLOWER(ch) : ch);
+    return ((ch) < 128 ? (unsigned int)Py_TOLOWER((unsigned char)ch) : ch);
 }
 
 /* locale-specific character predicates */

--- a/Objects/bytearrayobject.c
+++ b/Objects/bytearrayobject.c
@@ -1337,11 +1337,13 @@ bytearray_translate_impl(PyByteArrayObject *self, PyObject *table,
     }
 
     if (table_chars == NULL) {
-        for (i = 0; i < 256; i++)
-            trans_table[i] = Py_CHARMASK(i);
+        for (int ch = 0; ch < 256; ch++) {
+            trans_table[ch] = Py_CHARMASK(ch);
+        }
     } else {
-        for (i = 0; i < 256; i++)
-            trans_table[i] = Py_CHARMASK(table_chars[i]);
+        for (int ch = 0; ch < 256; ch++) {
+            trans_table[ch] = Py_CHARMASK(table_chars[ch]);
+        }
     }
 
     for (i = 0; i < vdel.len; i++)

--- a/Objects/bytesobject.c
+++ b/Objects/bytesobject.c
@@ -2128,11 +2128,13 @@ bytes_translate_impl(PyBytesObject *self, PyObject *table,
     }
 
     if (table_chars == NULL) {
-        for (i = 0; i < 256; i++)
-            trans_table[i] = Py_CHARMASK(i);
+        for (int ch = 0; ch < 256; ch++) {
+            trans_table[ch] = Py_CHARMASK(ch);
+        }
     } else {
-        for (i = 0; i < 256; i++)
-            trans_table[i] = Py_CHARMASK(table_chars[i]);
+        for (int ch = 0; ch < 256; ch++) {
+            trans_table[ch] = Py_CHARMASK(table_chars[ch]);
+        }
     }
     PyBuffer_Release(&table_view);
 


### PR DESCRIPTION
Convert the following macros to static inline functions:

* Py_ISLOWER()
* Py_ISUPPER()
* Py_ISALPHA()
* Py_ISDIGIT()
* Py_ISXDIGIT()
* Py_ISALNUM()
* Py_ISSPACE()
* Py_TOLOWER()
* Py_TOUPPER()
* Py_CHARMASK()

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-108767 -->
* Issue: gh-108767
<!-- /gh-issue-number -->
