### PR TITLE
Fix a typo in c_annotations.py

### DIFF
--- a/Doc/tools/extensions/c_annotations.py
+++ b/Doc/tools/extensions/c_annotations.py
@@ -42,7 +42,7 @@ REST_ROLE_MAP = {
 }
 
 
-# Monkeypatch nodes.Node.findall for forwards compatability
+# Monkeypatch nodes.Node.findall for forwards compatibility
 # This patch can be dropped when the minimum Sphinx version is 4.4.0
 # or the minimum Docutils version is 0.18.1.
 if docutils.__version_info__ < (0, 18, 1):


### PR DESCRIPTION
This commit corrects a minor typographical error in a comment within the file c_annotations.py. The word "compatability" has been changed to "compatibility" for improved clarity and consistency.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--108773.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->