### PR TITLE
gh-108765: Python.h no longer includes <sys/time.h>

### DIFF
--- a/Doc/whatsnew/3.13.rst
+++ b/Doc/whatsnew/3.13.rst
@@ -934,6 +934,14 @@ Porting to Python 3.13
   functions: ``close()``, ``getpagesize()``, ``getpid()`` and ``sysconf()``.
   (Contributed by Victor Stinner in :gh:`108765`.)
 
+* ``Python.h`` no longer includes these standard header files: ``<time.h>``,
+  ``<sys/select.h>`` and ``<sys/time.h>``. If needed, they should now be
+  included explicitly. For example, ``<time.h>`` provides the ``clock()`` and
+  ``gmtime()`` functions, ``<sys/select.h>`` provides the ``select()``
+  function, and ``<sys/time.h>`` provides the ``futimes()``, ``gettimeofday()``
+  and ``setitimer()`` functions.
+  (Contributed by Victor Stinner in :gh:`108765`.)
+
 Deprecated
 ----------
 

--- a/Include/pyport.h
+++ b/Include/pyport.h
@@ -184,25 +184,6 @@ typedef Py_ssize_t Py_ssize_clean_t;
 #  define Py_MEMCPY memcpy
 #endif
 
-/********************************************
- * WRAPPER FOR <time.h> and/or <sys/time.h> *
- ********************************************/
-
-#ifdef HAVE_SYS_TIME_H
-#include <sys/time.h>
-#endif
-#include <time.h>
-
-/******************************
- * WRAPPER FOR <sys/select.h> *
- ******************************/
-
-/* NB caller must include <sys/types.h> */
-
-#ifdef HAVE_SYS_SELECT_H
-#include <sys/select.h>
-#endif /* !HAVE_SYS_SELECT_H */
-
 /*******************************
  * stat() and fstat() fiddling *
  *******************************/

--- a/Misc/NEWS.d/next/C API/2023-09-01-18-42-31.gh-issue-108765.IyYNDu.rst
+++ b/Misc/NEWS.d/next/C API/2023-09-01-18-42-31.gh-issue-108765.IyYNDu.rst
@@ -1,0 +1,6 @@
+``Python.h`` no longer includes these standard header files: ``<time.h>``,
+``<sys/select.h>`` and ``<sys/time.h>``. If needed, they should now be included
+explicitly. For example, ``<time.h>`` provides the ``clock()`` and ``gmtime()``
+functions, ``<sys/select.h>`` provides the ``select()`` function, and
+``<sys/time.h>`` provides the ``futimes()``, ``gettimeofday()`` and
+``setitimer()`` functions. Patch by Victor Stinner.

--- a/Modules/_multiprocessing/semaphore.c
+++ b/Modules/_multiprocessing/semaphore.c
@@ -9,6 +9,10 @@
 
 #include "multiprocessing.h"
 
+#ifdef HAVE_SYS_TIME_H
+#  include <sys/time.h>           // gettimeofday()
+#endif
+
 #ifdef HAVE_MP_SEMAPHORE
 
 enum { RECURSIVE_MUTEX, SEMAPHORE };

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -57,6 +57,10 @@
 
 #include <stdio.h>                // ctermid()
 #include <stdlib.h>               // system()
+#ifdef HAVE_SYS_TIME_H
+#  include <sys/time.h>           // futimes()
+#endif
+
 
 // SGI apparently needs this forward declaration
 #ifdef HAVE__GETPTY

--- a/Modules/readline.c
+++ b/Modules/readline.c
@@ -12,14 +12,13 @@
 #include "Python.h"
 #include "pycore_pylifecycle.h"   // _Py_SetLocaleFromEnv()
 
-#include <errno.h>
-#include <signal.h>
-#include <stddef.h>
+#include <errno.h>                // errno
+#include <signal.h>               // SIGWINCH
 #include <stdlib.h>               // free()
-#ifdef HAVE_SYS_TIME_H
-#include <sys/time.h>
+#include <string.h>               // strdup()
+#ifdef HAVE_SYS_SELECT_H
+#  include <sys/select.h>         // select()
 #endif
-#include <time.h>
 
 #if defined(HAVE_SETLOCALE)
 /* GNU readline() mistakenly sets the LC_CTYPE locale.
@@ -27,7 +26,7 @@
  * We must save and restore the locale around the rl_initialize() call.
  */
 #define SAVE_LOCALE
-#include <locale.h>
+#  include <locale.h>             // setlocale()
 #endif
 
 #ifdef SAVE_LOCALE
@@ -1333,7 +1332,8 @@ readline_until_enter_or_signal(const char *prompt, int *signal)
         int has_input = 0, err = 0;
 
         while (!has_input)
-        {               struct timeval timeout = {0, 100000}; /* 0.1 seconds */
+        {
+            struct timeval timeout = {0, 100000};  // 100 ms (0.1 seconds)
 
             /* [Bug #1552726] Only limit the pause if an input hook has been
                defined.  */

--- a/Modules/resource.c
+++ b/Modules/resource.c
@@ -2,10 +2,6 @@
 #include <errno.h>                // errno
 #include <string.h>
 #include <sys/resource.h>         // getrusage()
-#ifdef HAVE_SYS_TIME_H
-#  include <sys/time.h>
-#endif
-#include <time.h>
 #include <unistd.h>               // getpagesize()
 
 /* On some systems, these aren't in any header file.

--- a/Modules/signalmodule.c
+++ b/Modules/signalmodule.c
@@ -16,10 +16,10 @@
 #include "pycore_signal.h"        // _Py_RestoreSignals()
 
 #ifndef MS_WINDOWS
-#  include "posixmodule.h"
+#  include "posixmodule.h"        // _PyLong_FromUid()
 #endif
 #ifdef MS_WINDOWS
-#  include "socketmodule.h"   /* needed for SOCKET_T */
+#  include "socketmodule.h"       // SOCKET_T
 #endif
 
 #ifdef MS_WINDOWS
@@ -29,16 +29,16 @@
 #endif
 
 #ifdef HAVE_SIGNAL_H
-#  include <signal.h>
+#  include <signal.h>             // sigaction()
 #endif
 #ifdef HAVE_SYS_SYSCALL_H
-#  include <sys/syscall.h>
+#  include <sys/syscall.h>        // __NR_pidfd_send_signal
 #endif
 #ifdef HAVE_SYS_STAT_H
 #  include <sys/stat.h>
 #endif
 #ifdef HAVE_SYS_TIME_H
-#  include <sys/time.h>
+#  include <sys/time.h>           // setitimer()
 #endif
 
 #if defined(HAVE_PTHREAD_SIGMASK) && !defined(HAVE_BROKEN_PTHREAD_SIGMASK)

--- a/Modules/timemodule.c
+++ b/Modules/timemodule.c
@@ -7,7 +7,7 @@
 #include "pycore_runtime.h"       // _Py_ID()
 
 #include <ctype.h>
-
+#include <time.h>                 // clock()
 #ifdef HAVE_SYS_TIMES_H
 #  include <sys/times.h>
 #endif

--- a/Modules/xxsubtype.c
+++ b/Modules/xxsubtype.c
@@ -1,5 +1,7 @@
 #include "Python.h"
+
 #include <stddef.h>               // offsetof()
+#include <time.h>                 // clock()
 
 
 PyDoc_STRVAR(xxsubtype__doc__,

--- a/Python/pytime.c
+++ b/Python/pytime.c
@@ -1,5 +1,10 @@
 #include "Python.h"
 #include "pycore_time.h"          // _PyTime_t
+
+#include <time.h>                 // gmtime_r()
+#ifdef HAVE_SYS_TIME_H
+#  include <sys/time.h>           // gettimeofday()
+#endif
 #ifdef MS_WINDOWS
 #  include <winsock2.h>           // struct timeval
 #endif


### PR DESCRIPTION
Python.h no longer includes these standard header files: <time.h>, <sys/select.h> and <sys/time.h>. They should now be included explicitly if needed.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-108765 -->
* Issue: gh-108765
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--108775.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->