### PR TITLE
Fix test_regrtest when run with uops always on

### DIFF
--- a/Lib/test/test_regrtest.py
+++ b/Lib/test/test_regrtest.py
@@ -548,7 +548,11 @@ class BaseTestCase(unittest.TestCase):
         return proc
 
     def run_python(self, args, **kw):
-        args = [sys.executable, '-X', 'faulthandler', '-I', *args]
+        extraargs = []
+        if 'uops' in sys._xoptions:
+            # Pass -X uops along
+            extraargs.extend(['-X', 'uops'])
+        args = [sys.executable, *extraargs, '-X', 'faulthandler', '-I', *args]
         proc = self.run_command(args, **kw)
         return proc.stdout
 

--- a/Lib/test/test_regrtest.py
+++ b/Lib/test/test_regrtest.py
@@ -897,12 +897,12 @@ class ArgsTestCase(BaseTestCase):
 
         filename = 'reflog.txt'
         self.addCleanup(os_helper.unlink, filename)
-        output = self.run_tests('--huntrleaks', '3:3:', test,
+        output = self.run_tests('--huntrleaks', '6:3:', test,
                                 exitcode=EXITCODE_BAD_TEST,
                                 stderr=subprocess.STDOUT)
         self.check_executed_tests(output, [test], failed=test)
 
-        line = 'beginning 6 repetitions\n123456\n......\n'
+        line = 'beginning 9 repetitions\n123456789\n.........\n'
         self.check_line(output, re.escape(line))
 
         line2 = '%s leaked [1, 1, 1] %s, sum=3\n' % (test, what)


### PR DESCRIPTION
The fix has two parts:
- When `-X uops` is detected, pass it on to the subprocess created to run the manufactured test.
  I need this so I can run `./python -Xuops -m test test_regrtest` and see it fail without the next fix.
- Use `-R 6:3:` in `ArgsTestCase.test_huntrleaks` instead of `-R 3:3:` -- it takes longer to settle with `-X uops`.

(This is an attempt to make gh-107820 pass all tests. The other failure there is an failing assertion in `test_exceptions`, but I believe that's fixed by gh-108725.)