### PR TITLE
gh-108765: [TEST] Test combined Python.h changes

### DIFF
--- a/Include/Python.h
+++ b/Include/Python.h
@@ -20,6 +20,7 @@
 #include <ctype.h>                // tolower()
 #include <inttypes.h>             // uintptr_t
 #include <limits.h>               // INT_MAX
+#include <math.h>                 // HUGE_VAL
 #include <stdarg.h>               // va_list
 #include <wchar.h>                // wchar_t
 #ifdef HAVE_STDDEF_H

--- a/Include/Python.h
+++ b/Include/Python.h
@@ -26,14 +26,13 @@
 #ifdef HAVE_STDDEF_H
 #  include <stddef.h>             // size_t
 #endif
-#ifndef MS_WINDOWS
-#  include <unistd.h>             // sysconf()
+#ifdef HAVE_SYS_TYPES_H
+#  include <sys/types.h>          // ssize_t
 #endif
 
-// errno.h, stdio.h, stdlib.h and string.h headers are no longer used by Python
-// headers, but kept for backward compatibility (no introduce new compiler
-// warnings). They are not included by the limited C API version 3.11 and
-// above.
+// errno.h, stdio.h, stdlib.h and string.h headers are no longer used by
+// Python, but kept for backward compatibility (avoid compiler warnings).
+// They are no longer included by limited C API version 3.11 and newer.
 #if !defined(Py_LIMITED_API) || Py_LIMITED_API+0 < 0x030b0000
 #  include <errno.h>              // errno
 #  include <stdio.h>              // FILE*

--- a/Include/pyport.h
+++ b/Include/pyport.h
@@ -184,12 +184,6 @@ typedef Py_ssize_t Py_ssize_clean_t;
 #  define Py_MEMCPY memcpy
 #endif
 
-#ifdef HAVE_IEEEFP_H
-#include <ieeefp.h>  /* needed for 'finite' declaration on some platforms */
-#endif
-
-#include <math.h> /* Moved here from the math section, before extern "C" */
-
 /*******************************
  * stat() and fstat() fiddling *
  *******************************/

--- a/Include/pyport.h
+++ b/Include/pyport.h
@@ -190,25 +190,6 @@ typedef Py_ssize_t Py_ssize_clean_t;
 
 #include <math.h> /* Moved here from the math section, before extern "C" */
 
-/********************************************
- * WRAPPER FOR <time.h> and/or <sys/time.h> *
- ********************************************/
-
-#ifdef HAVE_SYS_TIME_H
-#include <sys/time.h>
-#endif
-#include <time.h>
-
-/******************************
- * WRAPPER FOR <sys/select.h> *
- ******************************/
-
-/* NB caller must include <sys/types.h> */
-
-#ifdef HAVE_SYS_SELECT_H
-#include <sys/select.h>
-#endif /* !HAVE_SYS_SELECT_H */
-
 /*******************************
  * stat() and fstat() fiddling *
  *******************************/

--- a/Include/pyport.h
+++ b/Include/pyport.h
@@ -392,32 +392,6 @@ extern "C" {
 #  define Py_NO_INLINE
 #endif
 
-/**************************************************************************
-Prototypes that are missing from the standard include files on some systems
-(and possibly only some versions of such systems.)
-
-Please be conservative with adding new ones, document them and enclose them
-in platform-specific #ifdefs.
-**************************************************************************/
-
-#ifdef SOLARIS
-/* Unchecked */
-extern int gethostname(char *, int);
-#endif
-
-#ifdef HAVE__GETPTY
-#include <sys/types.h>          /* we need to import mode_t */
-extern char * _getpty(int *, int, mode_t, int);
-#endif
-
-/* On QNX 6, struct termio must be declared by including sys/termio.h
-   if TCGETA, TCSETA, TCSETAW, or TCSETAF are used.  sys/termio.h must
-   be included before termios.h or it will generate an error. */
-#if defined(HAVE_SYS_TERMIO_H) && !defined(__hpux)
-#include <sys/termio.h>
-#endif
-
-
 /* On 4.4BSD-descendants, ctype functions serves the whole range of
  * wchar_t character set rather than single byte code points only.
  * This characteristic can break some operations of string object

--- a/Modules/_ctypes/malloc_closure.c
+++ b/Modules/_ctypes/malloc_closure.c
@@ -1,16 +1,17 @@
 #ifndef Py_BUILD_CORE_BUILTIN
 #  define Py_BUILD_CORE_MODULE 1
 #endif
+
 #include <Python.h>
 #include <ffi.h>
 #ifdef MS_WIN32
-#include <windows.h>
+#  include <windows.h>
 #else
-#include <sys/mman.h>
-#include <unistd.h>
-# if !defined(MAP_ANONYMOUS) && defined(MAP_ANON)
-#  define MAP_ANONYMOUS MAP_ANON
-# endif
+#  include <sys/mman.h>
+#  include <unistd.h>
+#  if !defined(MAP_ANONYMOUS) && defined(MAP_ANON)
+#    define MAP_ANONYMOUS MAP_ANON
+#  endif
 #endif
 #include "ctypes.h"
 

--- a/Modules/_multiprocessing/semaphore.c
+++ b/Modules/_multiprocessing/semaphore.c
@@ -9,6 +9,10 @@
 
 #include "multiprocessing.h"
 
+#ifdef HAVE_SYS_TIME_H
+#  include <sys/time.h>           // gettimeofday()
+#endif
+
 #ifdef HAVE_MP_SEMAPHORE
 
 enum { RECURSIVE_MUTEX, SEMAPHORE };

--- a/Modules/_posixsubprocess.c
+++ b/Modules/_posixsubprocess.c
@@ -8,9 +8,9 @@
 #include "pycore_pystate.h"
 #include "pycore_signal.h"        // _Py_RestoreSignals()
 #if defined(HAVE_PIPE2) && !defined(_GNU_SOURCE)
-# define _GNU_SOURCE
+#  define _GNU_SOURCE
 #endif
-#include <unistd.h>
+#include <unistd.h>               // close()
 #include <fcntl.h>
 #ifdef HAVE_SYS_TYPES_H
 #include <sys/types.h>

--- a/Modules/_testcapimodule.c
+++ b/Modules/_testcapimodule.c
@@ -24,9 +24,6 @@
 #include <float.h>                // FLT_MAX
 #include <signal.h>
 #include <stddef.h>               // offsetof()
-#ifndef MS_WINDOWS
-#  include <unistd.h>
-#endif
 
 #ifdef HAVE_SYS_WAIT_H
 #  include <sys/wait.h>           // W_STOPCODE

--- a/Modules/grpmodule.c
+++ b/Modules/grpmodule.c
@@ -4,7 +4,8 @@
 #include "Python.h"
 #include "posixmodule.h"
 
-#include <grp.h>
+#include <grp.h>                  // getgrgid_r()
+#include <unistd.h>               // sysconf()
 
 #include "clinic/grpmodule.c.h"
 /*[clinic input]

--- a/Modules/mmapmodule.c
+++ b/Modules/mmapmodule.c
@@ -28,7 +28,9 @@
 #include "pycore_fileutils.h"     // _Py_stat_struct
 
 #include <stddef.h>               // offsetof()
-#include <unistd.h>               // close()
+#ifndef MS_WINDOWS
+#  include <unistd.h>             // close()
+#endif
 
 // to support MS_WINDOWS_SYSTEM OpenFileMappingA / CreateFileMappingA
 // need to be replaced with OpenFileMappingW / CreateFileMappingW

--- a/Modules/mmapmodule.c
+++ b/Modules/mmapmodule.c
@@ -28,6 +28,7 @@
 #include "pycore_fileutils.h"     // _Py_stat_struct
 
 #include <stddef.h>               // offsetof()
+#include <unistd.h>               // close()
 
 // to support MS_WINDOWS_SYSTEM OpenFileMappingA / CreateFileMappingA
 // need to be replaced with OpenFileMappingW / CreateFileMappingW

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -57,6 +57,10 @@
 
 #include <stdio.h>                // ctermid()
 #include <stdlib.h>               // system()
+#ifdef HAVE_SYS_TIME_H
+#  include <sys/time.h>           // futimes()
+#endif
+
 
 /*
  * A number of APIs are available on macOS from a certain macOS version.

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -289,7 +289,7 @@ corresponding Unix manual entries for more information on calls.");
 #endif
 
 #ifdef HAVE_COPY_FILE_RANGE
-#  include <unistd.h>
+#  include <unistd.h>             // copy_file_range()
 #endif
 
 #if !defined(CPU_ALLOC) && defined(HAVE_SCHED_SETAFFINITY)

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -61,6 +61,12 @@
 #  include <sys/time.h>           // futimes()
 #endif
 
+// SGI apparently needs this forward declaration
+#ifdef HAVE__GETPTY
+#  include <sys/types.h>          // mode_t
+   extern char * _getpty(int *, int, mode_t, int);
+#endif
+
 
 /*
  * A number of APIs are available on macOS from a certain macOS version.

--- a/Modules/pwdmodule.c
+++ b/Modules/pwdmodule.c
@@ -4,7 +4,9 @@
 #include "Python.h"
 #include "posixmodule.h"
 
-#include <pwd.h>
+#include <pwd.h>                  // getpwuid()
+#include <unistd.h>               // sysconf()
+
 
 #include "clinic/pwdmodule.c.h"
 /*[clinic input]

--- a/Modules/pwdmodule.c
+++ b/Modules/pwdmodule.c
@@ -7,7 +7,6 @@
 #include <pwd.h>                  // getpwuid()
 #include <unistd.h>               // sysconf()
 
-
 #include "clinic/pwdmodule.c.h"
 /*[clinic input]
 module pwd

--- a/Modules/resource.c
+++ b/Modules/resource.c
@@ -1,12 +1,11 @@
-
 #include "Python.h"
-#include <sys/resource.h>
+#include <errno.h>                // errno
+#include <string.h>
+#include <sys/resource.h>         // getrusage()
 #ifdef HAVE_SYS_TIME_H
-#include <sys/time.h>
+#  include <sys/time.h>
 #endif
 #include <time.h>
-#include <string.h>
-#include <errno.h>
 #include <unistd.h>
 
 /* On some systems, these aren't in any header file.

--- a/Modules/selectmodule.c
+++ b/Modules/selectmodule.c
@@ -17,6 +17,7 @@
 #include "pycore_time.h"          // _PyTime_t
 
 #include <stddef.h>               // offsetof()
+#include <unistd.h>               // close()
 
 #ifdef HAVE_SYS_DEVPOLL_H
 #include <sys/resource.h>

--- a/Modules/selectmodule.c
+++ b/Modules/selectmodule.c
@@ -17,7 +17,9 @@
 #include "pycore_time.h"          // _PyTime_t
 
 #include <stddef.h>               // offsetof()
-#include <unistd.h>               // close()
+#ifndef MS_WINDOWS
+#  include <unistd.h>             // close()
+#endif
 
 #ifdef HAVE_SYS_DEVPOLL_H
 #include <sys/resource.h>

--- a/Modules/socketmodule.c
+++ b/Modules/socketmodule.c
@@ -269,7 +269,7 @@ shutdown(how) -- shut down traffic in one or both directions\n\
 #ifdef HAVE_NETDB_H
 #  include <netdb.h>
 #endif
-# include <unistd.h>
+#include <unistd.h>               // close()
 
 /* Headers needed for inet_ntoa() and inet_addr() */
 #   include <arpa/inet.h>

--- a/Modules/socketmodule.c
+++ b/Modules/socketmodule.c
@@ -111,9 +111,13 @@ Local naming conventions:
 #include "pycore_fileutils.h"     // _Py_set_inheritable()
 #include "pycore_moduleobject.h"  // _PyModule_GetState
 
+// gethostname() prototype missing from Solaris standard header files
+#ifdef __sun
+extern int gethostname(char *, int);
+#endif
 
 #ifdef _Py_MEMORY_SANITIZER
-# include <sanitizer/msan_interface.h>
+#  include <sanitizer/msan_interface.h>
 #endif
 
 /* Socket object documentation */

--- a/Modules/termios.c
+++ b/Modules/termios.c
@@ -6,10 +6,17 @@
 
 #include "Python.h"
 
-/* Apparently, on SGI, termios.h won't define CTRL if _XOPEN_SOURCE
-   is defined, so we define it here. */
+// On QNX 6, struct termio must be declared by including sys/termio.h
+// if TCGETA, TCSETA, TCSETAW, or TCSETAF are used. sys/termio.h must
+// be included before termios.h or it will generate an error.
+#if defined(HAVE_SYS_TERMIO_H) && !defined(__hpux)
+#  include <sys/termio.h>
+#endif
+
+// Apparently, on SGI, termios.h won't define CTRL if _XOPEN_SOURCE
+// is defined, so we define it here.
 #if defined(__sgi)
-#define CTRL(c) ((c)&037)
+#  define CTRL(c) ((c)&037)
 #endif
 
 #if defined(__sun)

--- a/Modules/timemodule.c
+++ b/Modules/timemodule.c
@@ -7,7 +7,7 @@
 #include "pycore_runtime.h"       // _Py_ID()
 
 #include <ctype.h>
-
+#include <time.h>                 // clock()
 #ifdef HAVE_SYS_TIMES_H
 #  include <sys/times.h>
 #endif

--- a/Modules/xxsubtype.c
+++ b/Modules/xxsubtype.c
@@ -1,5 +1,7 @@
 #include "Python.h"
+
 #include <stddef.h>               // offsetof()
+#include <time.h>                 // clock()
 
 
 PyDoc_STRVAR(xxsubtype__doc__,

--- a/Programs/_freeze_module.c
+++ b/Programs/_freeze_module.c
@@ -19,7 +19,7 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #ifndef MS_WINDOWS
-#include <unistd.h>
+#  include <unistd.h>
 #endif
 
 uint32_t _Py_next_func_version = 1;

--- a/Python/dup2.c
+++ b/Python/dup2.c
@@ -11,9 +11,9 @@
  * Return fd2 if all went well; return BADEXIT otherwise.
  */
 
-#include <errno.h>
-#include <fcntl.h>
-#include <unistd.h>
+#include <errno.h>                // errno
+#include <fcntl.h>                // fcntl()
+#include <unistd.h>               // close()
 
 #define BADEXIT -1
 

--- a/Python/pytime.c
+++ b/Python/pytime.c
@@ -1,5 +1,10 @@
 #include "Python.h"
 #include "pycore_time.h"          // _PyTime_t
+
+#include <time.h>                 // gmtime_r() on Windows
+#ifdef HAVE_SYS_TIME_H
+#  include <sys/time.h>           // gettimeofday()
+#endif
 #ifdef MS_WINDOWS
 #  include <winsock2.h>           // struct timeval
 #endif


### PR DESCRIPTION
PR created to test 4 PRs at once on buildbots:

* PR #108775: Python.h no longer includes <sys/time.h>
* PR #108781: Python.h no longer includes <ieeefp.h>
* PR #108782: Remove old prototypes from pyport.h
* PR #108783: Python.h no longer includes <unistd.h>


<!-- gh-issue-number: gh-108765 -->
* Issue: gh-108765
<!-- /gh-issue-number -->
