### PR TITLE
gh-110489: Optimise math.ceil for known exact float

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2023-10-06-22-30-25.gh-issue-110489.rI2n8A.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2023-10-06-22-30-25.gh-issue-110489.rI2n8A.rst
@@ -1,0 +1,1 @@
+Optimise :func:`math.ceil` when the input is exactly a float, resulting in about a 10% improvement.

--- a/Modules/mathmodule.c
+++ b/Modules/mathmodule.c
@@ -1130,8 +1130,7 @@ math_ceil(PyObject *module, PyObject *number)
     if (PyFloat_CheckExact(number)) {
         x = PyFloat_AS_DOUBLE(number);
     }
-    else
-    {
+    else {
         math_module_state *state = get_math_module_state(module);
         PyObject *method = _PyObject_LookupSpecial(number, state->str___ceil__);
         if (method != NULL) {
@@ -1200,8 +1199,7 @@ math_floor(PyObject *module, PyObject *number)
     if (PyFloat_CheckExact(number)) {
         x = PyFloat_AS_DOUBLE(number);
     }
-    else
-    {
+    else {
         math_module_state *state = get_math_module_state(module);
         PyObject *method = _PyObject_LookupSpecial(number, state->str___floor__);
         if (method != NULL) {

--- a/Modules/mathmodule.c
+++ b/Modules/mathmodule.c
@@ -1125,8 +1125,13 @@ static PyObject *
 math_ceil(PyObject *module, PyObject *number)
 /*[clinic end generated code: output=6c3b8a78bc201c67 input=2725352806399cab]*/
 {
+    double x;
 
-    if (!PyFloat_CheckExact(number)) {
+    if (PyFloat_CheckExact(number)) {
+        x = PyFloat_AS_DOUBLE(number);
+    }
+    else
+    {
         math_module_state *state = get_math_module_state(module);
         PyObject *method = _PyObject_LookupSpecial(number, state->str___ceil__);
         if (method != NULL) {
@@ -1136,11 +1141,10 @@ math_ceil(PyObject *module, PyObject *number)
         }
         if (PyErr_Occurred())
             return NULL;
+        x = PyFloat_AsDouble(number);
+        if (x == -1.0 && PyErr_Occurred())
+            return NULL;
     }
-    double x = PyFloat_AsDouble(number);
-    if (x == -1.0 && PyErr_Occurred())
-        return NULL;
-
     return PyLong_FromDouble(ceil(x));
 }
 


### PR DESCRIPTION
This matches a similar optimisation done by rhettinger for math.floor in https://github.com/python/cpython/pull/21072

Before:
```
λ ./python.exe -m timeit -r 11 -s 'from math import ceil' -s 'x=3.14' 'ceil(x)'
20000000 loops, best of 11: 13.3 nsec per loop
λ ./python.exe -m timeit -r 11 -s 'from math import ceil' -s 'x=0.0' 'ceil(x)'
20000000 loops, best of 11: 13.3 nsec per loop
λ ./python.exe -m timeit -r 11 -s 'from math import ceil' -s 'x=-3.14E32' 'ceil(x)'
10000000 loops, best of 11: 35.3 nsec per loop
λ ./python.exe -m timeit -r 11 -s 'from math import ceil' -s 'x=-323452345.14' 'ceil(x)'
10000000 loops, best of 11: 21.8 nsec per loop
```

After:
```
λ ./python.exe -m timeit -r 11 -s 'from math import ceil' -s 'x=3.14' 'ceil(x)'
20000000 loops, best of 11: 11.8 nsec per loop
λ ./python.exe -m timeit -r 11 -s 'from math import ceil' -s 'x=0.0' 'ceil(x)'
20000000 loops, best of 11: 11.7 nsec per loop
λ ./python.exe -m timeit -r 11 -s 'from math import ceil' -s 'x=-3.14E32' 'ceil(x)'
10000000 loops, best of 11: 32.7 nsec per loop
λ ./python.exe -m timeit -r 11 -s 'from math import ceil' -s 'x=-323452345.14' 'ceil(x)'
10000000 loops, best of 11: 20.1 nsec per loop
```

<!-- gh-issue-number: gh-110489 -->
* Issue: gh-110489
<!-- /gh-issue-number -->
