### PR TITLE
gh-101100: Fix sphinx warnings in `uuid.rst`

### DIFF
--- a/Doc/library/uuid.rst
+++ b/Doc/library/uuid.rst
@@ -95,25 +95,34 @@ which relays any information about the UUID's safety, using this enumeration:
    A tuple of the six integer fields of the UUID, which are also available as six
    individual attributes and two derived attributes:
 
-   +-------------------------------+-------------------------------+
-   | Field                         | Meaning                       |
-   +===============================+===============================+
-   | :attr:`!time_low`             | the first 32 bits of the UUID |
-   +-------------------------------+-------------------------------+
-   | :attr:`!time_mid`             | the next 16 bits of the UUID  |
-   +-------------------------------+-------------------------------+
-   | :attr:`!time_hi_version`      | the next 16 bits of the UUID  |
-   +-------------------------------+-------------------------------+
-   | :attr:`!clock_seq_hi_variant` | the next 8 bits of the UUID   |
-   +-------------------------------+-------------------------------+
-   | :attr:`!clock_seq_low`        | the next 8 bits of the UUID   |
-   +-------------------------------+-------------------------------+
-   | :attr:`!node`                 | the last 48 bits of the UUID  |
-   +-------------------------------+-------------------------------+
-   | :attr:`!time`                 | the 60-bit timestamp          |
-   +-------------------------------+-------------------------------+
-   | :attr:`!clock_seq`            | the 14-bit sequence number    |
-   +-------------------------------+-------------------------------+
+.. list-table::
+
+   * - Field
+     - Meaning
+
+   * - .. attribute:: UUID.time_low
+     - The next 32 bits of the UUID.
+
+   * - .. attribute:: UUID.time_mid
+     - The next 16 bits of the UUID.
+
+   * - .. attribute:: UUID.time_hi_version
+     - The next 16 bits of the UUID.
+
+   * - .. attribute:: UUID.clock_seq_hi_variant
+     - The next 8 bits of the UUID.
+
+   * - .. attribute:: UUID.clock_seq_low
+     - The next 8 bits of the UUID.
+
+   * - .. attribute:: UUID.node
+     - The last 48 bits of the UUID.
+
+   * - .. attribute:: UUID.time
+     - The the 60-bit timestamp.
+
+   * - .. attribute:: UUID.clock_seq
+     - The 14-bit sequence number.
 
 
 .. attribute:: UUID.hex

--- a/Doc/library/uuid.rst
+++ b/Doc/library/uuid.rst
@@ -22,7 +22,7 @@ random UUID.
 Depending on support from the underlying platform, :func:`uuid1` may or may
 not return a "safe" UUID.  A safe UUID is one which is generated using
 synchronization methods that ensure no two processes can obtain the same
-UUID.  All instances of :class:`UUID` have an :attr:`is_safe` attribute
+UUID.  All instances of :class:`UUID` have an :attr:`~UUID.is_safe` attribute
 which relays any information about the UUID's safety, using this enumeration:
 
 .. class:: SafeUUID
@@ -95,25 +95,25 @@ which relays any information about the UUID's safety, using this enumeration:
    A tuple of the six integer fields of the UUID, which are also available as six
    individual attributes and two derived attributes:
 
-   +------------------------------+-------------------------------+
-   | Field                        | Meaning                       |
-   +==============================+===============================+
-   | :attr:`time_low`             | the first 32 bits of the UUID |
-   +------------------------------+-------------------------------+
-   | :attr:`time_mid`             | the next 16 bits of the UUID  |
-   +------------------------------+-------------------------------+
-   | :attr:`time_hi_version`      | the next 16 bits of the UUID  |
-   +------------------------------+-------------------------------+
-   | :attr:`clock_seq_hi_variant` | the next 8 bits of the UUID   |
-   +------------------------------+-------------------------------+
-   | :attr:`clock_seq_low`        | the next 8 bits of the UUID   |
-   +------------------------------+-------------------------------+
-   | :attr:`node`                 | the last 48 bits of the UUID  |
-   +------------------------------+-------------------------------+
-   | :attr:`time`                 | the 60-bit timestamp          |
-   +------------------------------+-------------------------------+
-   | :attr:`clock_seq`            | the 14-bit sequence number    |
-   +------------------------------+-------------------------------+
+   +-------------------------------+-------------------------------+
+   | Field                         | Meaning                       |
+   +===============================+===============================+
+   | :attr:`!time_low`             | the first 32 bits of the UUID |
+   +-------------------------------+-------------------------------+
+   | :attr:`!time_mid`             | the next 16 bits of the UUID  |
+   +-------------------------------+-------------------------------+
+   | :attr:`!time_hi_version`      | the next 16 bits of the UUID  |
+   +-------------------------------+-------------------------------+
+   | :attr:`!clock_seq_hi_variant` | the next 8 bits of the UUID   |
+   +-------------------------------+-------------------------------+
+   | :attr:`!clock_seq_low`        | the next 8 bits of the UUID   |
+   +-------------------------------+-------------------------------+
+   | :attr:`!node`                 | the last 48 bits of the UUID  |
+   +-------------------------------+-------------------------------+
+   | :attr:`!time`                 | the 60-bit timestamp          |
+   +-------------------------------+-------------------------------+
+   | :attr:`!clock_seq`            | the 14-bit sequence number    |
+   +-------------------------------+-------------------------------+
 
 
 .. attribute:: UUID.hex
@@ -233,7 +233,7 @@ The :mod:`uuid` module defines the following namespace identifiers for use with
    text output format.
 
 The :mod:`uuid` module defines the following constants for the possible values
-of the :attr:`variant` attribute:
+of the :attr:`~UUID.variant` attribute:
 
 
 .. data:: RESERVED_NCS

--- a/Doc/tools/.nitignore
+++ b/Doc/tools/.nitignore
@@ -136,7 +136,6 @@ Doc/library/unittest.mock.rst
 Doc/library/unittest.rst
 Doc/library/urllib.parse.rst
 Doc/library/urllib.request.rst
-Doc/library/uuid.rst
 Doc/library/weakref.rst
 Doc/library/wsgiref.rst
 Doc/library/xml.dom.minidom.rst


### PR DESCRIPTION
Warnings before:

```
/Users/sobolev/Desktop/cpython/Doc/library/uuid.rst:22: WARNING: py:attr reference target not found: is_safe
/Users/sobolev/Desktop/cpython/Doc/library/uuid.rst:102: WARNING: py:attr reference target not found: time_low
/Users/sobolev/Desktop/cpython/Doc/library/uuid.rst:104: WARNING: py:attr reference target not found: time_mid
/Users/sobolev/Desktop/cpython/Doc/library/uuid.rst:106: WARNING: py:attr reference target not found: time_hi_version
/Users/sobolev/Desktop/cpython/Doc/library/uuid.rst:108: WARNING: py:attr reference target not found: clock_seq_hi_variant
/Users/sobolev/Desktop/cpython/Doc/library/uuid.rst:110: WARNING: py:attr reference target not found: clock_seq_low
/Users/sobolev/Desktop/cpython/Doc/library/uuid.rst:112: WARNING: py:attr reference target not found: node
/Users/sobolev/Desktop/cpython/Doc/library/uuid.rst:116: WARNING: py:attr reference target not found: clock_seq
/Users/sobolev/Desktop/cpython/Doc/library/uuid.rst:235: WARNING: py:attr reference target not found: variant
```

Turns out all attributes that are defined in `.fields` are not documented intentionally (as far as I understand from the docs.

<!-- gh-issue-number: gh-101100 -->
* Issue: gh-101100
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--108805.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->