### PR TITLE
Fix typo in `uuid.rst`

### DIFF
--- a/Doc/library/uuid.rst
+++ b/Doc/library/uuid.rst
@@ -119,7 +119,7 @@ which relays any information about the UUID's safety, using this enumeration:
      - The last 48 bits of the UUID.
 
    * - .. attribute:: UUID.time
-     - The the 60-bit timestamp.
+     - The 60-bit timestamp.
 
    * - .. attribute:: UUID.clock_seq
      - The 14-bit sequence number.


### PR DESCRIPTION
Refs https://github.com/python/cpython/pull/108805

<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--108809.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->