### PR TITLE
Add missing PyDoc_STR to GenericAlias.__parameters__

### DIFF
--- a/Objects/genericaliasobject.c
+++ b/Objects/genericaliasobject.c
@@ -814,7 +814,7 @@ ga_unpacked_tuple_args(PyObject *self, void *unused)
 }
 
 static PyGetSetDef ga_properties[] = {
-    {"__parameters__", ga_parameters, (setter)NULL, "Type variables in the GenericAlias.", NULL},
+    {"__parameters__", ga_parameters, (setter)NULL, PyDoc_STR("Type variables in the GenericAlias."), NULL},
     {"__typing_unpacked_tuple_args__", ga_unpacked_tuple_args, (setter)NULL, NULL},
     {0}
 };


### PR DESCRIPTION
I don't think this needs news or an issue