### PR TITLE
[3.12] gh-101100: Fix sphinx warnings in `unittest.mock-examples.rst` (GH-108810)

### DIFF
--- a/Doc/library/unittest.mock-examples.rst
+++ b/Doc/library/unittest.mock-examples.rst
@@ -579,14 +579,14 @@ Partial mocking
 In some tests I wanted to mock out a call to :meth:`datetime.date.today`
 to return a known date, but I didn't want to prevent the code under test from
 creating new date objects. Unfortunately :class:`datetime.date` is written in C, and
-so I couldn't just monkey-patch out the static :meth:`date.today` method.
+so I couldn't just monkey-patch out the static :meth:`datetime.date.today` method.
 
 I found a simple way of doing this that involved effectively wrapping the date
 class with a mock, but passing through calls to the constructor to the real
 class (and returning real instances).
 
 The :func:`patch decorator <patch>` is used here to
-mock out the ``date`` class in the module under test. The :attr:`side_effect`
+mock out the ``date`` class in the module under test. The :attr:`~Mock.side_effect`
 attribute on the mock date class is then set to a lambda function that returns
 a real date. When the mock date class is called a real date will be
 constructed and returned by ``side_effect``. ::
@@ -766,8 +766,8 @@ mock has a nice API for making assertions about how your mock objects are used.
     >>> mock.foo_bar.assert_called_with('baz', spam='eggs')
 
 If your mock is only being called once you can use the
-:meth:`assert_called_once_with` method that also asserts that the
-:attr:`call_count` is one.
+:meth:`~Mock.assert_called_once_with` method that also asserts that the
+:attr:`~Mock.call_count` is one.
 
     >>> mock.foo_bar.assert_called_once_with('baz', spam='eggs')
     >>> mock.foo_bar()
@@ -835,7 +835,7 @@ One possibility would be for mock to copy the arguments you pass in. This
 could then cause problems if you do assertions that rely on object identity
 for equality.
 
-Here's one solution that uses the :attr:`side_effect`
+Here's one solution that uses the :attr:`~Mock.side_effect`
 functionality. If you provide a ``side_effect`` function for a mock then
 ``side_effect`` will be called with the same args as the mock. This gives us an
 opportunity to copy the arguments and store them for later assertions. In this
@@ -971,7 +971,8 @@ We can do this with :class:`MagicMock`, which will behave like a dictionary,
 and using :data:`~Mock.side_effect` to delegate dictionary access to a real
 underlying dictionary that is under our control.
 
-When the :meth:`__getitem__` and :meth:`__setitem__` methods of our ``MagicMock`` are called
+When the :meth:`~object.__getitem__` and :meth:`~object.__setitem__` methods
+of our ``MagicMock`` are called
 (normal dictionary access) then ``side_effect`` is called with the key (and in
 the case of ``__setitem__`` the value too). We can also control what is returned.
 

--- a/Doc/library/uuid.rst
+++ b/Doc/library/uuid.rst
@@ -95,34 +95,25 @@ which relays any information about the UUID's safety, using this enumeration:
    A tuple of the six integer fields of the UUID, which are also available as six
    individual attributes and two derived attributes:
 
-.. list-table::
-
-   * - Field
-     - Meaning
-
-   * - .. attribute:: UUID.time_low
-     - The first 32 bits of the UUID.
-
-   * - .. attribute:: UUID.time_mid
-     - The next 16 bits of the UUID.
-
-   * - .. attribute:: UUID.time_hi_version
-     - The next 16 bits of the UUID.
-
-   * - .. attribute:: UUID.clock_seq_hi_variant
-     - The next 8 bits of the UUID.
-
-   * - .. attribute:: UUID.clock_seq_low
-     - The next 8 bits of the UUID.
-
-   * - .. attribute:: UUID.node
-     - The last 48 bits of the UUID.
-
-   * - .. attribute:: UUID.time
-     - The 60-bit timestamp.
-
-   * - .. attribute:: UUID.clock_seq
-     - The 14-bit sequence number.
+   +------------------------------+-------------------------------+
+   | Field                        | Meaning                       |
+   +==============================+===============================+
+   | :attr:`time_low`             | the first 32 bits of the UUID |
+   +------------------------------+-------------------------------+
+   | :attr:`time_mid`             | the next 16 bits of the UUID  |
+   +------------------------------+-------------------------------+
+   | :attr:`time_hi_version`      | the next 16 bits of the UUID  |
+   +------------------------------+-------------------------------+
+   | :attr:`clock_seq_hi_variant` | the next 8 bits of the UUID   |
+   +------------------------------+-------------------------------+
+   | :attr:`clock_seq_low`        | the next 8 bits of the UUID   |
+   +------------------------------+-------------------------------+
+   | :attr:`node`                 | the last 48 bits of the UUID  |
+   +------------------------------+-------------------------------+
+   | :attr:`time`                 | the 60-bit timestamp          |
+   +------------------------------+-------------------------------+
+   | :attr:`clock_seq`            | the 14-bit sequence number    |
+   +------------------------------+-------------------------------+
 
 
 .. attribute:: UUID.hex

--- a/Doc/library/uuid.rst
+++ b/Doc/library/uuid.rst
@@ -95,25 +95,34 @@ which relays any information about the UUID's safety, using this enumeration:
    A tuple of the six integer fields of the UUID, which are also available as six
    individual attributes and two derived attributes:
 
-   +------------------------------+-------------------------------+
-   | Field                        | Meaning                       |
-   +==============================+===============================+
-   | :attr:`time_low`             | the first 32 bits of the UUID |
-   +------------------------------+-------------------------------+
-   | :attr:`time_mid`             | the next 16 bits of the UUID  |
-   +------------------------------+-------------------------------+
-   | :attr:`time_hi_version`      | the next 16 bits of the UUID  |
-   +------------------------------+-------------------------------+
-   | :attr:`clock_seq_hi_variant` | the next 8 bits of the UUID   |
-   +------------------------------+-------------------------------+
-   | :attr:`clock_seq_low`        | the next 8 bits of the UUID   |
-   +------------------------------+-------------------------------+
-   | :attr:`node`                 | the last 48 bits of the UUID  |
-   +------------------------------+-------------------------------+
-   | :attr:`time`                 | the 60-bit timestamp          |
-   +------------------------------+-------------------------------+
-   | :attr:`clock_seq`            | the 14-bit sequence number    |
-   +------------------------------+-------------------------------+
+.. list-table::
+
+   * - Field
+     - Meaning
+
+   * - .. attribute:: UUID.time_low
+     - The first 32 bits of the UUID.
+
+   * - .. attribute:: UUID.time_mid
+     - The next 16 bits of the UUID.
+
+   * - .. attribute:: UUID.time_hi_version
+     - The next 16 bits of the UUID.
+
+   * - .. attribute:: UUID.clock_seq_hi_variant
+     - The next 8 bits of the UUID.
+
+   * - .. attribute:: UUID.clock_seq_low
+     - The next 8 bits of the UUID.
+
+   * - .. attribute:: UUID.node
+     - The last 48 bits of the UUID.
+
+   * - .. attribute:: UUID.time
+     - The 60-bit timestamp.
+
+   * - .. attribute:: UUID.clock_seq
+     - The 14-bit sequence number.
 
 
 .. attribute:: UUID.hex

--- a/Doc/tools/.nitignore
+++ b/Doc/tools/.nitignore
@@ -145,7 +145,6 @@ Doc/library/tkinter.ttk.rst
 Doc/library/traceback.rst
 Doc/library/tty.rst
 Doc/library/turtle.rst
-Doc/library/unittest.mock-examples.rst
 Doc/library/unittest.mock.rst
 Doc/library/unittest.rst
 Doc/library/urllib.parse.rst


### PR DESCRIPTION
(cherry picked from commit 5141b1ebe07ad54279e0770b4704eaf76f24951d)


<!-- gh-issue-number: gh-101100 -->
* Issue: gh-101100
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--108813.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->