### PR TITLE
gh-104231: emit warning on `__bytes__` and `__str__` when returning strict subclass

### DIFF
--- a/Lib/test/test_bytes.py
+++ b/Lib/test/test_bytes.py
@@ -1049,10 +1049,16 @@ class BytesTest(BaseBytesTest, unittest.TestCase):
         class A:
             def __bytes__(self):
                 return OtherBytesSubclass(b'abc')
-        self.assertEqual(bytes(A()), b'abc')
-        self.assertIs(type(bytes(A())), OtherBytesSubclass)
-        self.assertEqual(BytesSubclass(A()), b'abc')
-        self.assertIs(type(BytesSubclass(A())), BytesSubclass)
+
+        with self.assertWarns(DeprecationWarning):
+            b = bytes(A())
+        self.assertEqual(b, b'abc')
+        self.assertIs(type(b), OtherBytesSubclass)
+
+        with self.assertWarns(DeprecationWarning):
+            b = BytesSubclass(A())
+        self.assertEqual(b, b'abc')
+        self.assertIs(type(b), BytesSubclass)
 
     # Test PyBytes_FromFormat()
     def test_from_format(self):

--- a/Lib/test/test_str.py
+++ b/Lib/test/test_str.py
@@ -2393,10 +2393,14 @@ class StrTest(string_tests.StringLikeTest,
 
         self.assertEqual(str(ObjectToStr()), "foo")
         self.assertEqual(str(StrSubclassToStr("bar")), "foo")
-        s = str(StrSubclassToStrSubclass("foo"))
+
+        with self.assertWarns(DeprecationWarning):
+            s = str(StrSubclassToStrSubclass("foo"))
         self.assertEqual(s, "foofoo")
         self.assertIs(type(s), StrSubclassToStrSubclass)
-        s = StrSubclass(StrSubclassToStrSubclass("foo"))
+
+        with self.assertWarns(DeprecationWarning):
+            s = StrSubclass(StrSubclassToStrSubclass("foo"))
         self.assertEqual(s, "foofoo")
         self.assertIs(type(s), StrSubclass)
 

--- a/Misc/NEWS.d/next/Core and Builtins/2023-09-02-14-25-35.gh-issue-104231.RUwyfB.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2023-09-02-14-25-35.gh-issue-104231.RUwyfB.rst
@@ -1,0 +1,6 @@
+We deprecated the ability to return strict subclasses of :class:`str` / :class:`bytes`
+at :meth:`__str__` / :meth:`__bytes__`, respectively.
+
+Returning strict subclasses of :class:`str` at :meth:`__str__` can cause unexpected
+behavior, and the same applies for returning strict subclasses of :class:`bytes` at
+:meth:`__bytes__`.

--- a/Objects/object.c
+++ b/Objects/object.c
@@ -609,12 +609,26 @@ PyObject_Str(PyObject *v)
     if (res == NULL) {
         return NULL;
     }
-    if (!PyUnicode_Check(res)) {
-        _PyErr_Format(tstate, PyExc_TypeError,
-                      "__str__ returned non-string (type %.200s)",
-                      Py_TYPE(res)->tp_name);
-        Py_DECREF(res);
-        return NULL;
+    if (!PyUnicode_CheckExact(res)) {
+        if (!PyUnicode_Check(res)) {
+            _PyErr_Format(tstate, PyExc_TypeError,
+                          "__str__ returned non-string (type %.200s)",
+                          Py_TYPE(res)->tp_name);
+            Py_DECREF(res);
+            return NULL;
+        }
+        /* gh-104231: returning a strict subclass of str can cause
+              unexpected behavior */
+        if (PyErr_WarnFormat(
+                PyExc_DeprecationWarning, 1,
+                "__str__ returned non-string (type %.200s).  "
+                "The ability to return an instance of a strict subclass of str "
+                "is deprecated, and may be removed in a future version of "
+                "Python.",
+                Py_TYPE(res)->tp_name)) {
+            Py_DECREF(res);
+            return NULL;
+        }
     }
     assert(_PyUnicode_CheckConsistency(res, 1));
     return res;


### PR DESCRIPTION
Returning strict subclasses at `__str__` can cause unexpected behavior, since other parts of the VM have always assumed `str(x)` to be an instance of `str`, not its strict subclass. The same applies to the `bytes(x)`.

Hence, we deprecated the ability to return strict subclasses of `str`/`bytes` at `__str__`/`__bytes__`, respectively.

<!-- gh-issue-number: gh-104231 -->
* Issue: gh-104231
<!-- /gh-issue-number -->
