### PR TITLE
gh-63760: Don't declare gethostname() on Solaris

### DIFF
--- a/Misc/NEWS.d/next/Build/2023-09-02-18-04-15.gh-issue-63760.r8hJ6q.rst
+++ b/Misc/NEWS.d/next/Build/2023-09-02-18-04-15.gh-issue-63760.r8hJ6q.rst
@@ -1,0 +1,3 @@
+Fix Solaris build: no longer redefine the ``gethostname()`` function. Solaris
+defines the function since 2005. Patch by Victor Stinner, original patch by
+Jakub Kulík.

--- a/Modules/socketmodule.c
+++ b/Modules/socketmodule.c
@@ -111,11 +111,6 @@ Local naming conventions:
 #include "pycore_fileutils.h"     // _Py_set_inheritable()
 #include "pycore_moduleobject.h"  // _PyModule_GetState
 
-// gethostname() prototype missing from Solaris standard header files
-#ifdef __sun
-extern int gethostname(char *, int);
-#endif
-
 #ifdef _Py_MEMORY_SANITIZER
 #  include <sanitizer/msan_interface.h>
 #endif


### PR DESCRIPTION
Since at least 2013, Oracle Solaris defines gethostname(). socketmodule.c no longer has to define gethostname() for Solaris.

Oracle Solaris and OpenSolaris have patches to remove the gethostname() definition in Python:

* https://github.com/oracle/solaris-userland/blob/master/components/python/python37/patches/15-gethostname.patch
* https://github.com/OpenIndiana/oi-userland/blob/oi/hipster/components/python/python37/patches/15-gethostname.patch
* https://github.com/omniosorg/omnios-build/blob/master/build/python27/patches/24-gethostname.patch

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-63760 -->
* Issue: gh-63760
<!-- /gh-issue-number -->
