### PR TITLE
[3.12] gh-63760: Don't declare gethostname() on Solaris (#108817)

### DIFF
--- a/Include/pyport.h
+++ b/Include/pyport.h
@@ -429,11 +429,6 @@ Please be conservative with adding new ones, document them and enclose them
 in platform-specific #ifdefs.
 **************************************************************************/
 
-#ifdef SOLARIS
-/* Unchecked */
-extern int gethostname(char *, int);
-#endif
-
 #ifdef HAVE__GETPTY
 #include <sys/types.h>          /* we need to import mode_t */
 extern char * _getpty(int *, int, mode_t, int);

--- a/Misc/NEWS.d/next/Build/2023-09-02-18-04-15.gh-issue-63760.r8hJ6q.rst
+++ b/Misc/NEWS.d/next/Build/2023-09-02-18-04-15.gh-issue-63760.r8hJ6q.rst
@@ -1,0 +1,3 @@
+Fix Solaris build: no longer redefine the ``gethostname()`` function. Solaris
+defines the function since 2005. Patch by Victor Stinner, original patch by
+Jakub Kulík.


### PR DESCRIPTION
Since 2005, Solaris defines gethostname(). socketmodule.c no longer has to define gethostname() for Solaris.

Oracle Solaris and OpenSolaris have patches to remove the gethostname() definition in Python:

* https://github.com/oracle/solaris-userland/blob/master/components/python/python37/patches/15-gethostname.patch
* https://github.com/OpenIndiana/oi-userland/blob/oi/hipster/components/python/python37/patches/15-gethostname.patch
* https://github.com/omniosorg/omnios-build/blob/master/build/python27/patches/24-gethostname.patch

Co-authored-by: Jakub Kulík <Kulikjak@gmail.com>
(cherry picked from commit 0e6d582b3b73a88e71cae04327b31a1ee203722c)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-63760 -->
* Issue: gh-63760
<!-- /gh-issue-number -->
