### PR TITLE
gh-106670: Fix Pdb handling of chained Exceptions with no stacks.

### DIFF
--- a/Lib/pdb.py
+++ b/Lib/pdb.py
@@ -2018,6 +2018,14 @@ def post_mortem(t=None):
     If `t` is an exception object, the `exceptions` command makes it possible to
     list and inspect its chained exceptions (if any).
     """
+    return _post_mortem(t, Pdb())
+
+
+def _post_mortem(t, pdb_instance):
+    """
+    Private version of post_mortem, which allow to pass a pdb instance
+    for testing purposes.
+    """
     # handling the default
     if t is None:
         exc = sys.exception()
@@ -2031,6 +2039,7 @@ def post_mortem(t=None):
     p = Pdb()
     p.reset()
     p.interaction(None, t)
+
 
 def pm():
     """Enter post-mortem debugging of the traceback found in sys.last_exc."""

--- a/Lib/pdb.py
+++ b/Lib/pdb.py
@@ -2041,9 +2041,8 @@ def _post_mortem(t, pdb_instance):
         raise ValueError("A valid traceback must be passed if no "
                          "exception is being handled")
 
-    p = Pdb()
-    p.reset()
-    p.interaction(None, t)
+    pdb_instance.reset()
+    pdb_instance.interaction(None, t)
 
 
 def pm():

--- a/Lib/pdb.py
+++ b/Lib/pdb.py
@@ -491,14 +491,9 @@ class Pdb(bdb.Bdb, cmd.Cmd):
                 Pdb._previous_sigint_handler = None
 
         _chained_exceptions, tb = self._get_tb_and_exceptions(tb_or_exc)
+        if isinstance(tb_or_exc, BaseException):
+            assert tb is not None, "main exception must have a traceback"
         with self._hold_exceptions(_chained_exceptions):
-            if isinstance(tb_or_exc, BaseException) and tb is None:
-                for ix, exc in reversed(list(enumerate(_chained_exceptions))):
-                    if exc.__traceback__:
-                        tb = exc.__traceback__
-                        self._chained_exception_index = ix
-                        break
-
             if self.setup(frame, tb):
                 # no interaction desired at this time (happens if .pdbrc contains
                 # a command like "continue")

--- a/Lib/pdb.py
+++ b/Lib/pdb.py
@@ -492,9 +492,7 @@ class Pdb(bdb.Bdb, cmd.Cmd):
 
         _chained_exceptions, tb = self._get_tb_and_exceptions(tb_or_exc)
         if not _chained_exceptions and isinstance(tb_or_exc, BaseException):
-            raise ValueError(
-                "A valid traceback must be passed if no exception is being handled"
-            )
+            raise ValueError("No exception traceback to inspect")
         with self._hold_exceptions(_chained_exceptions):
             if self.setup(frame, tb):
                 # no interaction desired at this time (happens if .pdbrc contains

--- a/Lib/pdb.py
+++ b/Lib/pdb.py
@@ -438,7 +438,7 @@ class Pdb(bdb.Bdb, cmd.Cmd):
             traceback, current = tb_or_exc.__traceback__, tb_or_exc
 
             while current is not None:
-                if current in _exceptions or not current:
+                if current in _exceptions:
                     break
                 _exceptions.append(current)
                 if current.__cause__ is not None:

--- a/Lib/pdb.py
+++ b/Lib/pdb.py
@@ -1182,7 +1182,7 @@ class Pdb(bdb.Bdb, cmd.Cmd):
                 return
             if 0 <= number < len(self._chained_exceptions):
                 if self._chained_exceptions[number].__traceback__ is None:
-                    self.error("This exception has not traceback, cannot jump to it")
+                    self.error("This exception does not have a traceback, cannot jump to it")
                     return
 
                 self._chained_exception_index = number

--- a/Lib/pdb.py
+++ b/Lib/pdb.py
@@ -491,9 +491,14 @@ class Pdb(bdb.Bdb, cmd.Cmd):
                 Pdb._previous_sigint_handler = None
 
         _chained_exceptions, tb = self._get_tb_and_exceptions(tb_or_exc)
-        if isinstance(tb_or_exc, BaseException) and tb is None:
-            raise ValueError("No exception traceback to inspect")
         with self._hold_exceptions(_chained_exceptions):
+            if isinstance(tb_or_exc, BaseException) and tb is None:
+                for ix, exc in reversed(list(enumerate(_chained_exceptions))):
+                    if exc.__traceback__:
+                        tb = exc.__traceback__
+                        self._chained_exception_index = ix
+                        break
+
             if self.setup(frame, tb):
                 # no interaction desired at this time (happens if .pdbrc contains
                 # a command like "continue")

--- a/Lib/pdb.py
+++ b/Lib/pdb.py
@@ -438,7 +438,7 @@ class Pdb(bdb.Bdb, cmd.Cmd):
             traceback, current = tb_or_exc.__traceback__, tb_or_exc
 
             while current is not None:
-                if current in _exceptions:
+                if current in _exceptions or not current.__traceback__:
                     break
                 _exceptions.append(current)
                 if current.__cause__ is not None:
@@ -491,6 +491,10 @@ class Pdb(bdb.Bdb, cmd.Cmd):
                 Pdb._previous_sigint_handler = None
 
         _chained_exceptions, tb = self._get_tb_and_exceptions(tb_or_exc)
+        if not _chained_exceptions and isinstance(tb_or_exc, BaseException):
+            raise ValueError(
+                "A valid traceback must be passed if no exception is being handled"
+            )
         with self._hold_exceptions(_chained_exceptions):
             if self.setup(frame, tb):
                 # no interaction desired at this time (happens if .pdbrc contains

--- a/Lib/pdb.py
+++ b/Lib/pdb.py
@@ -491,7 +491,11 @@ class Pdb(bdb.Bdb, cmd.Cmd):
                 Pdb._previous_sigint_handler = None
 
         _chained_exceptions, tb = self._get_tb_and_exceptions(tb_or_exc)
-        if not _chained_exceptions and isinstance(tb_or_exc, BaseException):
+        if (
+            not _chained_exceptions
+            and isinstance(tb_or_exc, BaseException)
+            and tb is None
+        ):
             raise ValueError("No exception traceback to inspect")
         with self._hold_exceptions(_chained_exceptions):
             if self.setup(frame, tb):

--- a/Lib/test/test_pdb.py
+++ b/Lib/test/test_pdb.py
@@ -848,9 +848,7 @@ def test_post_mortem_chained():
     ...     try:
     ...         test_function_reraise()
     ...     except Exception as e:
-    ...         # same as pdb.post_mortem(e), but with custom pdb instance.
-    ...         instance.reset()
-    ...         instance.interaction(None, e)
+    ...         pdb._post_mortem(e, instance)
 
     >>> with PdbTestInput([  # doctest: +ELLIPSIS, +NORMALIZE_WHITESPACE
     ...     'exceptions',
@@ -926,9 +924,7 @@ def test_post_mortem_cause_no_context():
     ...     try:
     ...         main()
     ...     except Exception as e:
-    ...         # same as pdb.post_mortem(e), but with custom pdb instance.
-    ...         instance.reset()
-    ...         instance.interaction(None, e)
+    ...         pdb._post_mortem(e, instance)
 
     >>> with PdbTestInput([  # doctest: +ELLIPSIS, +NORMALIZE_WHITESPACE
     ...     'exceptions',
@@ -982,9 +978,7 @@ def test_post_mortem_context_of_the_cause():
     ...     try:
     ...         main()
     ...     except Exception as e:
-    ...         # same as pdb.post_mortem(e), but with custom pdb instance.
-    ...         instance.reset()
-    ...         instance.interaction(None, e)
+    ...         pdb._post_mortem(e, instance)
 
     >>> with PdbTestInput([  # doctest: +ELLIPSIS, +NORMALIZE_WHITESPACE
     ...     'exceptions',
@@ -1057,9 +1051,7 @@ def test_post_mortem_from_none():
     ...     try:
     ...         main()
     ...     except Exception as e:
-    ...         # same as pdb.post_mortem(e), but with custom pdb instance.
-    ...         instance.reset()
-    ...         instance.interaction(None, e)
+    ...         pdb._post_mortem(e, instance)
 
     >>> with PdbTestInput([  # doctest: +ELLIPSIS, +NORMALIZE_WHITESPACE
     ...     'exceptions',
@@ -1092,9 +1084,7 @@ def test_post_mortem_from_no_stack():
     ...     try:
     ...         main()
     ...     except Exception as e:
-    ...         # same as pdb.post_mortem(e), but with custom pdb instance.
-    ...         instance.reset()
-    ...         instance.interaction(None, e)
+    ...         pdb._post_mortem(e, instance)
 
     >>> with PdbTestInput(  # doctest: +ELLIPSIS, +NORMALIZE_WHITESPACE
     ...     ["exceptions",
@@ -1125,9 +1115,7 @@ def test_post_mortem_single_no_stack():
     ...     instance = pdb.Pdb(nosigint=True, readrc=False)
     ...     import sys
     ...     sys.last_exc = Exception()
-    ...     # same as pdb.post_mortem(e), but with custom pdb instance.
-    ...     instance.reset()
-    ...     instance.interaction(None, sys.last_exc)
+    ...     pdb._post_mortem(sys.last_exc, instance)
 
     >>> with PdbTestInput(  # doctest: +ELLIPSIS, +NORMALIZE_WHITESPACE
     ...     []
@@ -1136,7 +1124,7 @@ def test_post_mortem_single_no_stack():
     ...        test_function()
     ...    except ValueError as e:
     ...        print(e)
-    No exception traceback to inspect
+    A valid traceback must be passed if no exception is being handled
     """
 
 
@@ -1204,9 +1192,7 @@ def test_post_mortem_complex():
     ...     try:
     ...         main()
     ...     except Exception as e:
-    ...         # same as pdb.post_mortem(e), but with custom pdb instance.
-    ...         instance.reset()
-    ...         instance.interaction(None, e)
+    ...         pdb._post_mortem(e, instance)
 
     >>> with PdbTestInput(  # doctest: +ELLIPSIS, +NORMALIZE_WHITESPACE
     ...     ["exceptions",

--- a/Lib/test/test_pdb.py
+++ b/Lib/test/test_pdb.py
@@ -1127,52 +1127,6 @@ def test_post_mortem_single_no_stack():
     A valid traceback must be passed if no exception is being handled
     """
 
-
-def test_post_mortem_base_no_stack():
-    """Test post mortem called when base exception has no stack
-
-    >>> def test_function():
-    ...     import pdb;
-    ...     import sys
-    ...     instance = pdb.Pdb(nosigint=True, readrc=False)
-    ...     try:
-    ...         raise ValueError('stack') from TypeError('no-stack')
-    ...     except ValueError as e:
-    ...         sub_exc = e
-    ...     exc = Exception('base-no-stack')
-    ...     exc.__cause__ = sub_exc
-    ...     instance.reset()
-    ...     instance.interaction(None, exc)
-
-    >>> with PdbTestInput(  # doctest: +ELLIPSIS, +NORMALIZE_WHITESPACE
-    ...     [
-    ...      "exceptions",
-    ...      "exceptions 0",
-    ...      "exceptions",
-    ...      "exit"
-    ...     ]
-    ... ):
-    ...    try:
-    ...        test_function()
-    ...    except ValueError as e:
-    ...        print(e)
-    > <doctest test.test_pdb.test_post_mortem_base_no_stack[0]>(6)test_function()
-    -> raise ValueError('stack') from TypeError('no-stack')
-    (Pdb) exceptions
-        - TypeError('no-stack')
-    >   1 ValueError('stack')
-        - Exception('base-no-stack')
-    (Pdb) exceptions 0
-    *** This exception does not have a traceback, cannot jump to it
-    (Pdb) exceptions
-        - TypeError('no-stack')
-    >   1 ValueError('stack')
-        - Exception('base-no-stack')
-    (Pdb) exit
-
-    """
-
-
 def test_post_mortem_complex():
     """Test post mortem traceback debugging of chained exception
 

--- a/Lib/test/test_pdb.py
+++ b/Lib/test/test_pdb.py
@@ -1098,6 +1098,7 @@ def test_post_mortem_from_no_stack():
 
     >>> with PdbTestInput(  # doctest: +ELLIPSIS, +NORMALIZE_WHITESPACE
     ...     ["exceptions",
+    ...      "exceptions 0",
     ...     "exit"],
     ... ):
     ...    try:
@@ -1107,7 +1108,10 @@ def test_post_mortem_from_no_stack():
     > <doctest test.test_pdb.test_post_mortem_from_no_stack[0]>(2)main()
     -> raise Exception() from Exception()
     (Pdb) exceptions
-    >   0 Exception()
+        - Exception()
+    >   1 Exception()
+    (Pdb) exceptions 0
+    *** This exception has not traceback, cannot jump to it
     (Pdb) exit
     """
 

--- a/Lib/test/test_pdb.py
+++ b/Lib/test/test_pdb.py
@@ -1072,7 +1072,7 @@ def test_post_mortem_from_none():
 def test_post_mortem_from_no_stack():
     """Test post mortem traceback debugging of chained exception
 
-    especially when one exception has not stack.
+    especially when one exception has no stack.
 
     >>> def main():
     ...     raise Exception() from Exception()
@@ -1101,13 +1101,13 @@ def test_post_mortem_from_no_stack():
         - Exception()
     >   1 Exception()
     (Pdb) exceptions 0
-    *** This exception has not traceback, cannot jump to it
+    *** This exception does not have a traceback, cannot jump to it
     (Pdb) exit
     """
 
 
 def test_post_mortem_single_no_stack():
-    """Test post mortem called when origin exception has not stack
+    """Test post mortem called when origin exception has no stack
 
 
     >>> def test_function():
@@ -1129,7 +1129,7 @@ def test_post_mortem_single_no_stack():
 
 
 def test_post_mortem_base_no_stack():
-    """Test post mortem called when base exception has not stack
+    """Test post mortem called when base exception has no stack
 
     >>> def test_function():
     ...     import pdb;
@@ -1163,7 +1163,7 @@ def test_post_mortem_base_no_stack():
     >   1 ValueError('stack')
         - Exception('base-no-stack')
     (Pdb) exceptions 0
-    *** This exception has not traceback, cannot jump to it
+    *** This exception does not have a traceback, cannot jump to it
     (Pdb) exceptions
         - TypeError('no-stack')
     >   1 ValueError('stack')

--- a/Lib/test/test_pdb.py
+++ b/Lib/test/test_pdb.py
@@ -1132,7 +1132,7 @@ def test_post_mortem_single_no_stack():
     ...        test_function()
     ...    except ValueError as e:
     ...        print(e)
-    A valid traceback must be passed if no exception is being handled
+    No exception traceback to inspect
     """
 
 

--- a/Lib/test/test_pdb.py
+++ b/Lib/test/test_pdb.py
@@ -907,7 +907,7 @@ def test_post_mortem_chained():
 def test_post_mortem_cause_no_context():
     """Test post mortem traceback debugging of chained exception
 
-    >>> def make_ex_with_stack(type_, *content, from_=None):
+    >>> def make_exc_with_stack(type_, *content, from_=None):
     ...     try:
     ...         raise type_(*content) from from_
     ...     except Exception as out:
@@ -918,7 +918,7 @@ def test_post_mortem_cause_no_context():
     ...     try:
     ...         raise ValueError('Context Not Shown')
     ...     except Exception as e1:
-    ...         raise ValueError("With Cause") from make_ex_with_stack(TypeError,'The Cause')
+    ...         raise ValueError("With Cause") from make_exc_with_stack(TypeError,'The Cause')
 
     >>> def test_function():
     ...     import pdb;
@@ -943,22 +943,22 @@ def test_post_mortem_cause_no_context():
     ...    except ValueError:
     ...        print('Ok.')
     > <doctest test.test_pdb.test_post_mortem_cause_no_context[1]>(5)main()
-    -> raise ValueError("With Cause") from make_ex_with_stack(TypeError,'The Cause')
+    -> raise ValueError("With Cause") from make_exc_with_stack(TypeError,'The Cause')
     (Pdb) exceptions
         0 TypeError('The Cause')
     >   1 ValueError('With Cause')
     (Pdb) exceptions 0
-    > <doctest test.test_pdb.test_post_mortem_cause_no_context[0]>(3)make_ex_with_stack()
+    > <doctest test.test_pdb.test_post_mortem_cause_no_context[0]>(3)make_exc_with_stack()
     -> raise type_(*content) from from_
     (Pdb) exceptions 1
     > <doctest test.test_pdb.test_post_mortem_cause_no_context[1]>(5)main()
-    -> raise ValueError("With Cause") from make_ex_with_stack(TypeError,'The Cause')
+    -> raise ValueError("With Cause") from make_exc_with_stack(TypeError,'The Cause')
     (Pdb) up
     > <doctest test.test_pdb.test_post_mortem_cause_no_context[2]>(5)test_function()
     -> main()
     (Pdb) down
     > <doctest test.test_pdb.test_post_mortem_cause_no_context[1]>(5)main()
-    -> raise ValueError("With Cause") from make_ex_with_stack(TypeError,'The Cause')
+    -> raise ValueError("With Cause") from make_exc_with_stack(TypeError,'The Cause')
     (Pdb) exit"""
 
 

--- a/Lib/test/test_pdb.py
+++ b/Lib/test/test_pdb.py
@@ -1128,6 +1128,51 @@ def test_post_mortem_single_no_stack():
     """
 
 
+def test_post_mortem_base_no_stack():
+    """Test post mortem called when base exception has not stack
+
+    >>> def test_function():
+    ...     import pdb;
+    ...     import sys
+    ...     instance = pdb.Pdb(nosigint=True, readrc=False)
+    ...     try:
+    ...         raise ValueError('stack') from TypeError('no-stack')
+    ...     except ValueError as e:
+    ...         sub_exc = e
+    ...     exc = Exception('base-no-stack')
+    ...     exc.__cause__ = sub_exc
+    ...     instance.reset()
+    ...     instance.interaction(None, exc)
+
+    >>> with PdbTestInput(  # doctest: +ELLIPSIS, +NORMALIZE_WHITESPACE
+    ...     [
+    ...      "exceptions",
+    ...      "exceptions 0",
+    ...      "exceptions",
+    ...      "exit"
+    ...     ]
+    ... ):
+    ...    try:
+    ...        test_function()
+    ...    except ValueError as e:
+    ...        print(e)
+    > <doctest test.test_pdb.test_post_mortem_base_no_stack[0]>(6)test_function()
+    -> raise ValueError('stack') from TypeError('no-stack')
+    (Pdb) exceptions
+        - TypeError('no-stack')
+    >   1 ValueError('stack')
+        - Exception('base-no-stack')
+    (Pdb) exceptions 0
+    *** This exception has not traceback, cannot jump to it
+    (Pdb) exceptions
+        - TypeError('no-stack')
+    >   1 ValueError('stack')
+        - Exception('base-no-stack')
+    (Pdb) exit
+
+    """
+
+
 def test_post_mortem_complex():
     """Test post mortem traceback debugging of chained exception
 


### PR DESCRIPTION
The introduction of chained exception in gh-106676 would sometime lead to

    File .../Lib/pdb.py", line 298, in setup
      self.curframe = self.stack[self.curindex][0]
                     ~~~~~~~~~~^^^^^^^^^^^^^^^
    IndexError: list index out of range

This fixes that by filtering exceptions that that do not have a stack/traceback. Update tests to not use stack-less exceptions when testing another feature, and add an explicit test on how we handle stackless exceptions.

<!-- gh-issue-number: gh-106670 -->
* Issue: gh-106670
<!-- /gh-issue-number -->
