### PR TITLE
Improve the GitHub issue forms

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -9,11 +9,17 @@ body:
 
         For help or advice on using Python, try one of the following options instead of opening a GitHub issue:
 
-          - Posting on [Discourse](https://discuss.python.org/c/users/7)
+          - Asking on [Discourse](https://discuss.python.org/c/users/7) or [Stack Overflow](https://stackoverflow.com)
           - Reading the [Python tutorial](https://docs.python.org/3/tutorial/)
           - Emailing [python-list](https://mail.python.org/mailman/listinfo/python-list)
 
-        Also make sure to search the [CPython issue tracker](https://github.com/python/cpython/issues?q=is%3Aissue+sort%3Acreated-desc) to check that the bug has not already been reported.
+        **Is this issue new?**
+
+        Make sure to search the [CPython issue tracker](https://github.com/python/cpython/issues?q=is%3Aissue+sort%3Acreated-desc) to check that the bug has not already been reported.
+
+        **Is this a bug in CPython?**
+
+        Only use this form to report bugs in the CPython project itself. Bugs in third-party projects (e.g. ``pip`` or ``requests``) should be reported to that project instead.
   - type: textarea
     attributes:
       label: "Bug description:"

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -12,17 +12,23 @@ body:
           - Posting on [Discourse](https://discuss.python.org/c/users/7)
           - Reading the [Python tutorial](https://docs.python.org/3/tutorial/)
           - Emailing [python-list](https://mail.python.org/mailman/listinfo/python-list)
-  - type: checkboxes
+
+        Also make sure to search the [CPython issue tracker](https://github.com/python/cpython/issues?q=is%3Aissue+sort%3Acreated-desc) to check that the bug has not already been reported.
+  - type: textarea
     attributes:
-      label: Checklist
-      description: A bug in a third-party project (for example, `pip` or `requests`) should be reported to that project's issue tracker, not CPython
-      options:
-        - label: I am confident this is a bug in CPython, not a bug in a third-party project
-          required: false
-        - label: |
-            I have searched the [CPython issue tracker](https://github.com/python/cpython/issues?q=is%3Aissue+sort%3Acreated-desc),
-            and am confident this bug has not been reported before
-          required: false
+      label: "Bug description:"
+      description: >
+        Give a clear and concise description of what happened.
+        Include a [minimal, reproducible example](https://stackoverflow.com/help/minimal-reproducible-example) if possible.
+        Copy and paste code where possible rather than using screenshots,
+        and put any code blocks inside triple backticks.
+
+      value: |
+        ```python
+        # Add a code block here, if required
+        ```
+    validations:
+      required: true
   - type: dropdown
     attributes:
       label: "CPython versions tested on:"
@@ -47,23 +53,3 @@ body:
         - Other
     validations:
       required: false
-  - type: input
-    attributes:
-      label: "Output from running 'python -VV' on the command line:"
-      description: If you tested with multiple operating systems or architectures, feel free to provide details in the main bug description.
-    validations:
-      required: false
-  - type: textarea
-    attributes:
-      label: "A clear and concise description of the bug:"
-      description: >
-        Tell us what happened.
-        Include a [minimal, reproducible example](https://stackoverflow.com/help/minimal-reproducible-example) if possible.
-        Put any code blocks inside triple backticks.
-
-      value: |
-        ```python
-        # Add a code block here, if required
-        ```
-    validations:
-      required: true

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -20,7 +20,7 @@ body:
       description: >
         Give a clear and concise description of what happened.
         Include a [minimal, reproducible example](https://stackoverflow.com/help/minimal-reproducible-example) if possible.
-        Copy and paste code where possible rather than using screenshots,
+        [Copy and paste code where possible rather than using screenshots](https://meta.stackoverflow.com/questions/285551/why-should-i-not-upload-images-of-code-data-errors),
         and put any code blocks inside triple backticks.
 
       value: |

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -13,13 +13,7 @@ body:
           - Reading the [Python tutorial](https://docs.python.org/3/tutorial/)
           - Emailing [python-list](https://mail.python.org/mailman/listinfo/python-list)
 
-        **Is this issue new?**
-
-        Make sure to search the [CPython issue tracker](https://github.com/python/cpython/issues?q=is%3Aissue+sort%3Acreated-desc) to check that the bug has not already been reported.
-
-        **Is this a bug in CPython?**
-
-        Only use this form to report bugs in the CPython project itself. Bugs in third-party projects (e.g. ``pip`` or ``requests``) should be reported to that project instead.
+        Make sure to also search the [CPython issue tracker](https://github.com/python/cpython/issues?q=is%3Aissue+sort%3Acreated-desc) to check that the bug has not already been reported.
   - type: textarea
     attributes:
       label: "Bug description:"

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -20,7 +20,7 @@ body:
       description: >
         Give a clear and concise description of what happened.
         Include a [minimal, reproducible example](https://stackoverflow.com/help/minimal-reproducible-example) if possible.
-        [Copy and paste code where possible rather than using screenshots](https://meta.stackoverflow.com/questions/285551/why-should-i-not-upload-images-of-code-data-errors),
+        [Copy and paste code where possible rather than using screenshots](https://meta.stackoverflow.com/a/285557/13990016),
         and put any code blocks inside triple backticks.
 
       value: |

--- a/.github/ISSUE_TEMPLATE/crash.yml
+++ b/.github/ISSUE_TEMPLATE/crash.yml
@@ -13,7 +13,7 @@ body:
       label: What happened?
       description: >
         Include a [minimal, reproducible example](https://stackoverflow.com/help/minimal-reproducible-example) if possible.
-        [Copy and paste code where possible rather than using screenshots](https://meta.stackoverflow.com/questions/285551/why-should-i-not-upload-images-of-code-data-errors),
+        [Copy and paste code where possible rather than using screenshots](https://meta.stackoverflow.com/a/285557/13990016),
         and put any code blocks inside triple backticks.
 
       value: |

--- a/.github/ISSUE_TEMPLATE/crash.yml
+++ b/.github/ISSUE_TEMPLATE/crash.yml
@@ -8,6 +8,38 @@ body:
           This form is for hard crashes of the Python interpreter, segmentation faults, failed C-level assertions, and similar. Unexpected exceptions raised from Python functions in the standard library count as bugs rather than crashes.
 
           The CPython interpreter is written in a different programming language, C. A "CPython crash" is when Python itself fails, leading to a traceback in the C stack.
+  - type: textarea
+    attributes:
+      label: What happened?
+      description: >
+        Include a [minimal, reproducible example](https://stackoverflow.com/help/minimal-reproducible-example) if possible.
+        Copy and paste code where possible rather than using screenshots,
+        and put any code blocks inside triple backticks.
+
+      value: |
+        ```python
+        # Add a code block here, if required
+        ```
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Error messages
+      description: >
+        Enter any error messages caused by the crash, including a core dump if there is one.
+        Feel free to leave this bit blank if it isn't relevant.
+      placeholder: |
+        Error messages should be formatted like this:
+
+        <details>
+        <summary>Error messages/core dump</summary>
+
+        ```
+        # paste errors here, if you have any
+        ```
+        </details>
+    validations:
+      required: false
   - type: dropdown
     attributes:
       label: "CPython versions tested on:"
@@ -36,36 +68,5 @@ body:
     attributes:
       label: "Output from running 'python -VV' on the command line:"
       description: If you tested with multiple operating systems or architectures, feel free to provide details in the main bug description.
-    validations:
-      required: false
-  - type: textarea
-    attributes:
-      label: What happened?
-      description: >
-        Include a [minimal, reproducible example](https://stackoverflow.com/help/minimal-reproducible-example) if possible.
-        Put any code blocks inside triple backticks.
-
-      value: |
-        ```python
-        # Add a code block here, if required
-        ```
-    validations:
-      required: true
-  - type: textarea
-    attributes:
-      label: Error messages
-      description: >
-        Enter any error messages caused by the crash, including a core dump if there is one.
-        Feel free to leave this bit blank if it isn't relevant.
-      placeholder: |
-        Error messages should be formatted like this:
-
-        <details>
-        <summary>Error messages/core dump</summary>
-
-        ```
-        # paste errors here, if you have any
-        ```
-        </details>
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/crash.yml
+++ b/.github/ISSUE_TEMPLATE/crash.yml
@@ -13,7 +13,7 @@ body:
       label: What happened?
       description: >
         Include a [minimal, reproducible example](https://stackoverflow.com/help/minimal-reproducible-example) if possible.
-        Copy and paste code where possible rather than using screenshots,
+        [Copy and paste code where possible rather than using screenshots](https://meta.stackoverflow.com/questions/285551/why-should-i-not-upload-images-of-code-data-errors),
         and put any code blocks inside triple backticks.
 
       value: |

--- a/.github/ISSUE_TEMPLATE/crash.yml
+++ b/.github/ISSUE_TEMPLATE/crash.yml
@@ -15,8 +15,6 @@ body:
         Include a [minimal, reproducible example](https://stackoverflow.com/help/minimal-reproducible-example) if possible.
         Copy and paste code where possible rather than using screenshots,
         and put any code blocks inside triple backticks.
-        If there were any error messages or core dumps,
-        make sure to copy them here as well.
 
       value: |
         ```python

--- a/.github/ISSUE_TEMPLATE/crash.yml
+++ b/.github/ISSUE_TEMPLATE/crash.yml
@@ -15,6 +15,8 @@ body:
         Include a [minimal, reproducible example](https://stackoverflow.com/help/minimal-reproducible-example) if possible.
         Copy and paste code where possible rather than using screenshots,
         and put any code blocks inside triple backticks.
+        If there were any error messages or core dumps,
+        make sure to copy them here as well.
 
       value: |
         ```python
@@ -22,24 +24,6 @@ body:
         ```
     validations:
       required: true
-  - type: textarea
-    attributes:
-      label: Error messages
-      description: >
-        Enter any error messages caused by the crash, including a core dump if there is one.
-        Feel free to leave this bit blank if it isn't relevant.
-      placeholder: |
-        Error messages should be formatted like this:
-
-        <details>
-        <summary>Error messages/core dump</summary>
-
-        ```
-        # paste errors here, if you have any
-        ```
-        </details>
-    validations:
-      required: false
   - type: dropdown
     attributes:
       label: "CPython versions tested on:"

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -10,6 +10,19 @@ body:
         You'll need to demonstrate widespread support for your idea among the community.
 
         Major feature proposals should generally be discussed on [Discourse](https://discuss.python.org/c/ideas/6) before opening a GitHub issue. Wait until it's clear that most people support your idea before filling in this form.
+  - type: textarea
+    attributes:
+      label: "Proposal:"
+      description: >
+        Explain your proposal, why it should be implemented, and how it would be used.
+        Add examples, if applicable.
+        Put any code blocks inside triple backticks.
+      value: |
+        ```python
+        # Add a code block here, if required
+        ```
+    validations:
+      required: true
   - type: dropdown
     attributes:
       label: Has this already been discussed elsewhere?
@@ -25,16 +38,3 @@ body:
       label: "Links to previous discussion of this feature:"
     validations:
       required: false
-  - type: textarea
-    attributes:
-      label: "Proposal:"
-      description: >
-        Explain your proposal, why it should be implemented, and how it would be used.
-        Add examples, if applicable.
-        Put any code blocks inside triple backticks.
-      value: |
-        ```python
-        # Add a code block here, if required
-        ```
-    validations:
-      required: true


### PR DESCRIPTION
This addresses feedback on the core dev Discord, that it's too hard to read the rendered versions of issues on the tracker now, due to the fact that the "boilerplate-y" fields such as the Python versions tested on are at the top of the template, and these have to be skimmed past before you get to the core bug description itself.

The changes are:
- Move the main issue description so that it's the first field in every issue template. This increases the risk that people will not fill in the other fields, but I think it's a good trade-off. I agree with the criticisms that the current issue templates mean that you have to wade through too much text before you can find out what the issue is actually about.
- Reduce the number of fields in the "bug report" template:
  - Get rid of the checkboxes; just incorporate the "please check the issue tracker for duplicates" note into the MarkDown paragraph at the top
  - Get rid of the field asking for the output of `python -VV`. In some situations this is useful, but most of the time it's not, and this field is adding noise to every rendered issue report. In situations where we actually _need_ this information, we can just ask the reporter for it. I've kept this field in the "crash report" template, though, for two reasons: firstly, this information is more likely to be useful for crash reports; and secondly, we get many fewer crash reports than we do bug reports, so the concern about adding excessive amounts of noise to the issue tracker has much less weight.

As before, these are already merged into the `main` branch on my CPython fork, so you can try out making issues at https://github.com/AlexWaygood/cpython/issues/new/choose to get a feel for what it's like.

Examples of rendered issues:
- Bug: https://github.com/AlexWaygood/cpython/issues/19
- Feature: https://github.com/AlexWaygood/cpython/issues/20
- Crash: https://github.com/AlexWaygood/cpython/issues/22