### PR TITLE
[3.10] gh-108883: Avoid TypeError when using type as an enum value (fix #108883)

### DIFF
--- a/Lib/enum.py
+++ b/Lib/enum.py
@@ -220,7 +220,7 @@ class EnumMeta(type):
         # save DynamicClassAttribute attributes from super classes so we know
         # if we can take the shortcut of storing members in the class dict
         dynamic_attributes = {
-                k for c in enum_class.mro()
+                k for c in enum_class.__mro__
                 for k, v in c.__dict__.items()
                 if isinstance(v, DynamicClassAttribute)
                 }


### PR DESCRIPTION
This PR can fix #108883 because `type.mro()` would raise an exception but `type.__mro__` works well. Also `type.__mro__` is cached and faster than `type.mro()`.
This fix works on Python 3.10 only because the enum implementation has been refactored in 3.11.

<!-- gh-issue-number: gh-108883 -->
* Issue: gh-108883
<!-- /gh-issue-number -->
