### PR TITLE
gh-108834: regrtest --fail-rerun exits with code 5

### DIFF
--- a/Lib/test/libregrtest/main.py
+++ b/Lib/test/libregrtest/main.py
@@ -29,9 +29,10 @@ from test.support import threading_helper
 EXIT_TIMEOUT = 120.0
 
 EXITCODE_BAD_TEST = 2
-EXITCODE_INTERRUPTED = 130
 EXITCODE_ENV_CHANGED = 3
 EXITCODE_NO_TESTS_RAN = 4
+EXITCODE_RERUN_FAIL = 5
+EXITCODE_INTERRUPTED = 130
 
 
 class Regrtest:
@@ -847,7 +848,7 @@ class Regrtest:
         elif self.no_tests_run():
             exitcode = EXITCODE_NO_TESTS_RAN
         elif self.rerun and self.ns.fail_rerun:
-            exitcode = EXITCODE_BAD_TEST
+            exitcode = EXITCODE_RERUN_FAIL
         return exitcode
 
     def action_run_tests(self):

--- a/Lib/test/test_regrtest.py
+++ b/Lib/test/test_regrtest.py
@@ -34,6 +34,7 @@ LOG_PREFIX = r'[0-9]+:[0-9]+:[0-9]+ (?:load avg: [0-9]+\.[0-9]{2} )?'
 EXITCODE_BAD_TEST = 2
 EXITCODE_ENV_CHANGED = 3
 EXITCODE_NO_TESTS_RAN = 4
+EXITCODE_RERUN_FAIL = 5
 EXITCODE_INTERRUPTED = 130
 
 TEST_INTERRUPTED = textwrap.dedent("""
@@ -1265,10 +1266,10 @@ class ArgsTestCase(BaseTestCase):
                                   stats=TestStats(3, 1))
         os_helper.unlink(marker_filename)
 
-        # with --fail-rerun, exit code EXITCODE_BAD_TEST
+        # with --fail-rerun, exit code EXITCODE_RERUN_FAIL
         # on "FAILURE then SUCCESS" state.
         output = self.run_tests("--rerun", "--fail-rerun", testname,
-                                exitcode=EXITCODE_BAD_TEST)
+                                exitcode=EXITCODE_RERUN_FAIL)
         self.check_executed_tests(output, [testname],
                                   rerun=Rerun(testname,
                                               match="test_fail_once",


### PR DESCRIPTION
When the --fail-rerun option is used and a test fails and then pass, regrtest now uses exit code 5 ("rerun) instead of 2 ("bad test").

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-108834 -->
* Issue: gh-108834
<!-- /gh-issue-number -->
