### PR TITLE
gh-108927: Fix test_import + test_importlib + test_unittest problem

### DIFF
--- a/Lib/test/test_unittest/test_discovery.py
+++ b/Lib/test/test_unittest/test_discovery.py
@@ -6,7 +6,6 @@ import types
 import pickle
 from test import support
 from test.support import import_helper
-import test.test_importlib.util
 
 import unittest
 import unittest.mock
@@ -826,6 +825,8 @@ class TestDiscovery(unittest.TestCase):
                          'as dotted module names')
 
     def test_discovery_failed_discovery(self):
+        from test.test_importlib import util
+
         loader = unittest.TestLoader()
         package = types.ModuleType('package')
 
@@ -837,7 +838,7 @@ class TestDiscovery(unittest.TestCase):
             # Since loader.discover() can modify sys.path, restore it when done.
             with import_helper.DirsOnSysPath():
                 # Make sure to remove 'package' from sys.modules when done.
-                with test.test_importlib.util.uncache('package'):
+                with util.uncache('package'):
                     with self.assertRaises(TypeError) as cm:
                         loader.discover('package')
                     self.assertEqual(str(cm.exception),


### PR DESCRIPTION
After:

```
» ./python.exe -m test test_import test_importlib test_unittest
0:00:00 load avg: 3.43 Run tests sequentially
0:00:00 load avg: 3.43 [1/3] test_import
0:00:01 load avg: 3.43 [2/3] test_importlib
0:00:05 load avg: 3.55 [3/3] test_unittest

== Tests result: SUCCESS ==

All 3 tests OK.

Total duration: 9.4 sec
Total tests: run=2,413 skipped=11
Total test files: run=3/3
Result: SUCCESS
```

This is more like "hidding things under the carpet" and not a "proper fix", I think.
But, it should be enough to unblock the release.

<!-- gh-issue-number: gh-108927 -->
* Issue: gh-108927
<!-- /gh-issue-number -->
