### PR TITLE
gh-108933: disallow frame_setlineno on yield events

### DIFF
--- a/Lib/test/test_sys_settrace.py
+++ b/Lib/test/test_sys_settrace.py
@@ -2706,7 +2706,8 @@ output.append(4)
         output.append(1)
         1 / 0
 
-    @jump_test(3, 2, [2, 5], event='return')
+    @jump_test(3, 2, [2], event='return', error=(ValueError,
+               "can only jump from a 'line' trace event"))
     def test_jump_from_yield(output):
         def gen():
             output.append(2)

--- a/Misc/NEWS.d/next/Core and Builtins/2023-09-05-17-02-28.gh-issue-108933.wbUuPe.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2023-09-05-17-02-28.gh-issue-108933.wbUuPe.rst
@@ -1,0 +1,1 @@
+Forbid setting a frame's ``f_lineno`` field during a YIELD trace event.

--- a/Objects/frameobject.c
+++ b/Objects/frameobject.c
@@ -659,7 +659,7 @@ frame_setlineno(PyFrameObject *f, PyObject* p_new_lineno, void *Py_UNUSED(ignore
     /*
      * This code preserves the historical restrictions on
      * setting the line number of a frame.
-     * Jumps are forbidden on a 'return' trace event (except after a yield).
+     * Jumps are forbidden on a 'return' trace event.
      * Jumps from 'call' trace events are also forbidden.
      * In addition, jumps are forbidden when not tracing,
      * as this is a debugging feature.
@@ -675,7 +675,6 @@ frame_setlineno(PyFrameObject *f, PyObject* p_new_lineno, void *Py_UNUSED(ignore
         case PY_MONITORING_EVENT_JUMP:
         case PY_MONITORING_EVENT_BRANCH:
         case PY_MONITORING_EVENT_LINE:
-        case PY_MONITORING_EVENT_PY_YIELD:
             /* Setting f_lineno is allowed for the above events */
             break;
         case PY_MONITORING_EVENT_PY_START:
@@ -692,6 +691,7 @@ frame_setlineno(PyFrameObject *f, PyObject* p_new_lineno, void *Py_UNUSED(ignore
         case PY_MONITORING_EVENT_PY_THROW:
         case PY_MONITORING_EVENT_RAISE:
         case PY_MONITORING_EVENT_C_RAISE:
+        case PY_MONITORING_EVENT_PY_YIELD:
         case PY_MONITORING_EVENT_INSTRUCTION:
         case PY_MONITORING_EVENT_EXCEPTION_HANDLED:
             PyErr_Format(PyExc_ValueError,


### PR DESCRIPTION
Fixes #108933 .

<!-- gh-issue-number: gh-108933 -->
* Issue: gh-108933
<!-- /gh-issue-number -->
