### PR TITLE
gh-108946: correctly calculate most specific metaclass

### DIFF
--- a/Lib/types.py
+++ b/Lib/types.py
@@ -128,7 +128,7 @@ def prepare_class(name, bases=(), kwds=None):
 
 def _calculate_meta(meta, bases):
     """Calculate the most derived metaclass."""
-    
+
     def get_most_specific_types(candidates, new_candidate):
         if any(issubclass(candidate, new_candidate) for candidate in candidates):
             return candidates

--- a/Lib/types.py
+++ b/Lib/types.py
@@ -2,6 +2,7 @@
 Define names for built-in types that aren't directly accessible as a builtin.
 """
 import sys
+import functools
 
 # Iterators in Python aren't a matter of type but of protocol.  A large
 # and changing number of builtin types implement *some* flavor of

--- a/Lib/types.py
+++ b/Lib/types.py
@@ -129,7 +129,7 @@ def prepare_class(name, bases=(), kwds=None):
 def _calculate_meta(meta, bases):
     """Calculate the most derived metaclass."""
 
-    candidates = (type, )
+    candidates = (meta, )
     for base in bases:
         new_candidate = type(base)
         if any(issubclass(candidate, new_candidate) for candidate in candidates):

--- a/Lib/types.py
+++ b/Lib/types.py
@@ -2,7 +2,6 @@
 Define names for built-in types that aren't directly accessible as a builtin.
 """
 import sys
-import functools
 
 # Iterators in Python aren't a matter of type but of protocol.  A large
 # and changing number of builtin types implement *some* flavor of
@@ -130,11 +129,13 @@ def prepare_class(name, bases=(), kwds=None):
 def _calculate_meta(meta, bases):
     """Calculate the most derived metaclass."""
 
-    def get_most_specific_types(candidates, new_candidate):
+    candidates = (type, )
+    for base in bases:
+        new_candidate = type(base)
         if any(issubclass(candidate, new_candidate) for candidate in candidates):
-            return candidates
+            continue
         else:
-            return (
+            candidates = (
                 *(
                     candidate
                     for candidate in candidates
@@ -142,13 +143,8 @@ def _calculate_meta(meta, bases):
                 ),
                 new_candidate,
             )
-    winners = functools.reduce(
-        get_most_specific_types,
-        map(type, bases),
-        (type, ),
-    )
 
-    match winners:
+    match candidates:
         case (winner,):
             return winner
         case _:

--- a/Misc/NEWS.d/next/Library/2023-09-05-16-59-26.gh-issue-108946.GqlL9k.rst
+++ b/Misc/NEWS.d/next/Library/2023-09-05-16-59-26.gh-issue-108946.GqlL9k.rst
@@ -1,1 +1,1 @@
-Fix a bug where `types.new_class` cannot find the most specific metaclass even when it exists
+Fix a bug where :func:`types.new_class` cannot find the most specific metaclass even when it exists.

--- a/Misc/NEWS.d/next/Library/2023-09-05-16-59-26.gh-issue-108946.GqlL9k.rst
+++ b/Misc/NEWS.d/next/Library/2023-09-05-16-59-26.gh-issue-108946.GqlL9k.rst
@@ -1,0 +1,1 @@
+Fix a bug where `types.new_class` cannot find the most specific metaclass even when it exists


### PR DESCRIPTION
This PR fixes #108946 by finding the most specific single metaclass among all `bases`, instead of raising an exception in the middle of the `_calculate_meta`

<!-- gh-issue-number: gh-108946 -->
* Issue: gh-108946
<!-- /gh-issue-number -->
