### PR TITLE
gh-108948: tarfile should handle sticky bit in FreeBSD

### DIFF
--- a/Doc/library/tarfile.rst
+++ b/Doc/library/tarfile.rst
@@ -939,6 +939,13 @@ reused in custom filters:
 
    This implements the ``'fully_trusted'`` filter.
 
+   .. note::
+
+      Although the filter preserves all permission bits unchanged, the sticky
+      bit (:const:`~stat.S_ISVTX`) will not be set on extracted files when the
+      system does not allow it. For compatibility reasons, no error is raised
+      in this case.
+
 .. function:: tar_filter(member, path)
 
   Implements the ``'tar'`` filter.

--- a/Doc/library/tarfile.rst
+++ b/Doc/library/tarfile.rst
@@ -942,9 +942,9 @@ reused in custom filters:
    .. note::
 
       Although the filter preserves all permission bits unchanged, the sticky
-      bit (:const:`~stat.S_ISVTX`) will not be set on extracted files when the
-      system does not allow it. For compatibility reasons, no error is raised
-      in this case.
+      bit (:const:`~stat.S_ISVTX`) will not be set on an extracted file if the
+      file system does not allow it. For compatibility reasons, no exception is
+      raised in this case.
 
 .. function:: tar_filter(member, path)
 

--- a/Lib/tarfile.py
+++ b/Lib/tarfile.py
@@ -2586,10 +2586,13 @@ class TarFile(object):
                         # of the ExtractError, but we keep the original error
                         # around for good information.
                         raise exc2 from exc1
+                    else:
+                        # The second chmod() without sticky bit succeeded
+                        pass
                 else:
                     raise
-        except OSError as e:
-            raise ExtractError("could not change mode") from e
+        except OSError as exc3:
+            raise ExtractError("could not change mode") from exc3
 
     def utime(self, tarinfo, targetpath):
         """Set modification time of targetpath according to tarinfo.

--- a/Lib/tarfile.py
+++ b/Lib/tarfile.py
@@ -2577,7 +2577,8 @@ class TarFile(object):
                     os.chmod(targetpath, tarinfo.mode & ~stat.S_ISVTX)
                 except OSError as e:
                     raise ExtractError("could not change mode") from e
-            raise ExtractError("could not change mode") from e
+            else:
+                raise ExtractError("could not change mode") from e
 
     def utime(self, tarinfo, targetpath):
         """Set modification time of targetpath according to tarinfo.

--- a/Lib/tarfile.py
+++ b/Lib/tarfile.py
@@ -2578,6 +2578,7 @@ class TarFile(object):
                 # sticky bit on a file as non-root. But it's a noop in most
                 # other platforms, and we try and match that behavior here.
                 try:
+                    # Retry without the sticky bit
                     os.chmod(targetpath, tarinfo.mode & ~stat.S_ISVTX)
                 except OSError as e2:
                     raise e2 from e

--- a/Lib/test/test_tarfile.py
+++ b/Lib/test/test_tarfile.py
@@ -3848,8 +3848,8 @@ class TestExtractionFilters(unittest.TestCase):
         try:
             os.chmod(tmp_filename, new_mode)
         except OSError as err:
-            # FreeBSD fails with EFTYPE if sticky bit cannot be set, instead
-            # of ignoring it.
+            # gh-108948: FreeBSD fails with EFTYPE if sticky bit cannot be set,
+            # instead of ignoring it.
             if hasattr(errno, "EFTYPE") and err.errno == errno.EFTYPE:
                 os.chmod(tmp_filename, new_mode & ~stat.S_ISVTX)
             else:

--- a/Lib/test/test_tarfile.py
+++ b/Lib/test/test_tarfile.py
@@ -706,7 +706,7 @@ class MiscReadTestBase(CommonReadTest):
         self.addCleanup(os_helper.rmtree, DIR)
         with tar:
             # this should not raise:
-            tar.extract("sticky1", DIR)
+            tar.extract("sticky1", DIR, filter="fully_trusted")
             got_mode = stat.filemode(os.stat(os.path.join(DIR, "sticky1")).st_mode)
             expected_mode = "-rwxrwxrwx" if os.geteuid() != 0 else "-rwxrwxrwt"
             self.assertEqual(got_mode, expected_mode)
@@ -717,7 +717,7 @@ class MiscReadTestBase(CommonReadTest):
                 other_error = OSError(errno.EPERM, "different error")
                 mock.side_effect = [eftype_error, other_error]
                 with self.assertRaises(tarfile.ExtractError) as excinfo:
-                    tar.extract("sticky2", DIR)
+                    tar.extract("sticky2", DIR, filter="fully_trusted")
             self.assertEqual(excinfo.exception.__cause__, other_error)
             self.assertEqual(excinfo.exception.__cause__.__cause__, eftype_error)
 

--- a/Lib/test/test_tarfile.py
+++ b/Lib/test/test_tarfile.py
@@ -696,7 +696,7 @@ class MiscReadTestBase(CommonReadTest):
         # Extracting a file as non-root should skip the sticky bit (gh-108948)
         # even on platforms where chmod fails with EFTYPE (i.e. FreeBSD). But
         # we need to take care that any other error is preserved.
-        mode = "-rw-rw-rwt"
+        mode = "-rwxrwxrwt"
         with ArchiveMaker() as arc:
             arc.add("sticky1", mode=mode)
             arc.add("sticky2", mode=mode)
@@ -708,7 +708,7 @@ class MiscReadTestBase(CommonReadTest):
             # this should not raise:
             tar.extract("sticky1", DIR)
             got_mode = stat.filemode(os.stat(os.path.join(DIR, "sticky1")).st_mode)
-            expected_mode = "-rw-rw-rw-" if os.geteuid() != 0 else "-rw-rw-rwt"
+            expected_mode = "-rwxrwxrwx" if os.geteuid() != 0 else "-rwxrwxrwt"
             self.assertEqual(got_mode, expected_mode)
 
             # but we can create a situation where it does raise:

--- a/Lib/test/test_tarfile.py
+++ b/Lib/test/test_tarfile.py
@@ -3851,6 +3851,7 @@ class TestExtractionFilters(unittest.TestCase):
             # gh-108948: FreeBSD fails with EFTYPE if sticky bit cannot be set,
             # instead of ignoring it.
             if hasattr(errno, "EFTYPE") and err.errno == errno.EFTYPE:
+                # Retry without the sticky bit
                 os.chmod(tmp_filename, new_mode & ~stat.S_ISVTX)
             else:
                 raise

--- a/Misc/NEWS.d/next/Library/2023-09-05-17-11-17.gh-issue-108948.HL1Ttw.rst
+++ b/Misc/NEWS.d/next/Library/2023-09-05-17-11-17.gh-issue-108948.HL1Ttw.rst
@@ -1,1 +1,1 @@
-mod:`tarfile` will not attempt to set the sticky bit on extracted files when it's not possible, matching the behavior of other platforms.
+On FreeBSD, mod:`tarfile` will not attempt to set the sticky bit on extracted files when it's not possible, matching the behavior of other platforms.

--- a/Misc/NEWS.d/next/Library/2023-09-05-17-11-17.gh-issue-108948.HL1Ttw.rst
+++ b/Misc/NEWS.d/next/Library/2023-09-05-17-11-17.gh-issue-108948.HL1Ttw.rst
@@ -1,0 +1,1 @@
+mod:`tarfile` will not attempt to set the sticky bit on extracted files when it's not possible, matching the behavior of other platforms.

--- a/Misc/NEWS.d/next/Library/2023-09-05-17-11-17.gh-issue-108948.HL1Ttw.rst
+++ b/Misc/NEWS.d/next/Library/2023-09-05-17-11-17.gh-issue-108948.HL1Ttw.rst
@@ -1,1 +1,1 @@
-On FreeBSD, mod:`tarfile` will not attempt to set the sticky bit on extracted files when it's not possible, matching the behavior of other platforms.
+On FreeBSD, :mod:`tarfile` will not attempt to set the sticky bit on extracted files when it's not possible, matching the behavior of other platforms.

--- a/Misc/NEWS.d/next/Library/2023-09-05-17-11-17.gh-issue-108948.HL1Ttw.rst
+++ b/Misc/NEWS.d/next/Library/2023-09-05-17-11-17.gh-issue-108948.HL1Ttw.rst
@@ -1,1 +1,1 @@
-On FreeBSD, :mod:`tarfile` will not attempt to set the sticky bit on extracted files when it's not possible, matching the behavior of other platforms.
+:mod:`tarfile`:  On FreeBSD, ``tarfile`` will not attempt to set the sticky bit on extracted files when it's not possible, matching the behavior of other platforms.


### PR DESCRIPTION
Instead of failing on FreeBSD, we emulate the behavior of other platforms. That means that if a file wants to set the sticky bit and we are not root, we just ignore it.


<!-- gh-issue-number: gh-108948 -->
* Issue: gh-108948
<!-- /gh-issue-number -->
