### PR TITLE
gh-108557: Fixed socket_getaddrinfo() not to encode IPv6 addresses as IDNA

### DIFF
--- a/Misc/NEWS.d/next/C API/2023-09-05-21-48-41.gh-issue-108557.AGGTFi.rst
+++ b/Misc/NEWS.d/next/C API/2023-09-05-21-48-41.gh-issue-108557.AGGTFi.rst
@@ -1,0 +1,1 @@
+The :c:func:`socket_getaddrinfo` function updated to encode scoped IPV6 address strings as the operating system encoding istead of IDNA.

--- a/Modules/socketmodule.c
+++ b/Modules/socketmodule.c
@@ -6691,7 +6691,8 @@ socket_getaddrinfo(PyObject *self, PyObject *args, PyObject* kwargs)
     int family, socktype, protocol, flags;
     int error;
     PyObject *all = (PyObject *)NULL;
-    PyObject *idna = NULL;
+    PyObject *hbytes = NULL;
+    Py_ssize_t colon;
 
     socktype = protocol = flags = 0;
     family = AF_UNSPEC;
@@ -6703,11 +6704,18 @@ socket_getaddrinfo(PyObject *self, PyObject *args, PyObject* kwargs)
     if (hobj == Py_None) {
         hptr = NULL;
     } else if (PyUnicode_Check(hobj)) {
-        idna = PyUnicode_AsEncodedString(hobj, "idna", NULL);
-        if (!idna)
+        colon = PyUnicode_FindChar(hobj, ':', 0, PyUnicode_GET_LENGTH(hobj), 1);
+        if (colon == -2)
             return NULL;
-        assert(PyBytes_Check(idna));
-        hptr = PyBytes_AS_STRING(idna);
+        if(colon != -1){ // IPv6 address
+            hbytes = PyUnicode_EncodeFSDefault(hobj);
+        } else {
+            hbytes = PyUnicode_AsEncodedString(hobj, "idna", NULL);
+        }
+        if (!hbytes)
+            return NULL;
+        assert(PyBytes_Check(hbytes));
+        hptr = PyBytes_AS_STRING(hbytes);
     } else if (PyBytes_Check(hobj)) {
         hptr = PyBytes_AsString(hobj);
     } else {
@@ -6788,14 +6796,14 @@ socket_getaddrinfo(PyObject *self, PyObject *args, PyObject* kwargs)
         }
         Py_DECREF(single);
     }
-    Py_XDECREF(idna);
+    Py_XDECREF(hbytes);
     Py_XDECREF(pstr);
     if (res0)
         freeaddrinfo(res0);
     return all;
  err:
     Py_XDECREF(all);
-    Py_XDECREF(idna);
+    Py_XDECREF(hbytes);
     Py_XDECREF(pstr);
     if (res0)
         freeaddrinfo(res0);


### PR DESCRIPTION
# gh-108557: Fixed socket_getaddrinfo() not to encode IPv6 addresses as IDNA

socket_getaddrinfo() of socketmodule.c patched to check if a passed host Unicode string represents an IPv6 address by looking for ":" characters in the string. If so, it's encoded in the default operating system encoding rather than IDNA.