### PR TITLE
GH-104584: Remove `ip_offset` and simplify `EXIT_TRACE`

### DIFF
--- a/Include/internal/pycore_opcode_metadata.h
+++ b/Include/internal/pycore_opcode_metadata.h
@@ -1206,7 +1206,7 @@ extern const struct opcode_metadata _PyOpcode_opcode_metadata[OPCODE_METADATA_SI
 #ifdef NEED_OPCODE_METADATA
 const struct opcode_metadata _PyOpcode_opcode_metadata[OPCODE_METADATA_SIZE] = {
     [NOP] = { true, INSTR_FMT_IX, 0 },
-    [RESUME] = { true, INSTR_FMT_IB, HAS_ARG_FLAG | HAS_EVAL_BREAK_FLAG | HAS_ERROR_FLAG },
+    [RESUME] = { true, INSTR_FMT_IB, HAS_ARG_FLAG | HAS_EVAL_BREAK_FLAG | HAS_DEOPT_FLAG | HAS_ERROR_FLAG },
     [INSTRUMENTED_RESUME] = { true, INSTR_FMT_IB, HAS_ARG_FLAG | HAS_EVAL_BREAK_FLAG | HAS_ERROR_FLAG },
     [LOAD_CLOSURE] = { true, INSTR_FMT_IB, HAS_ARG_FLAG | HAS_LOCAL_FLAG },
     [LOAD_FAST_CHECK] = { true, INSTR_FMT_IB, HAS_ARG_FLAG | HAS_LOCAL_FLAG | HAS_ERROR_FLAG },
@@ -1466,9 +1466,9 @@ const struct opcode_metadata _PyOpcode_opcode_metadata[OPCODE_METADATA_SIZE] = {
     [_POP_JUMP_IF_FALSE] = { true, INSTR_FMT_IB, HAS_ARG_FLAG },
     [_POP_JUMP_IF_TRUE] = { true, INSTR_FMT_IB, HAS_ARG_FLAG },
     [JUMP_TO_TOP] = { true, INSTR_FMT_IX, HAS_EVAL_BREAK_FLAG },
-    [SAVE_IP] = { true, INSTR_FMT_IB, HAS_ARG_FLAG },
+    [SAVE_IP] = { true, INSTR_FMT_IX, 0 },
     [SAVE_CURRENT_IP] = { true, INSTR_FMT_IX, 0 },
-    [EXIT_TRACE] = { true, INSTR_FMT_IX, 0 },
+    [EXIT_TRACE] = { true, INSTR_FMT_IX, HAS_DEOPT_FLAG },
     [INSERT] = { true, INSTR_FMT_IB, HAS_ARG_FLAG },
 };
 #endif // NEED_OPCODE_METADATA

--- a/Python/bytecodes.c
+++ b/Python/bytecodes.c
@@ -3006,6 +3006,7 @@ dummy_func(
             tstate->py_recursion_remaining--;
             LOAD_SP();
             LOAD_IP();
+            frame->prev_instr = _PyCode_CODE(_PyFrame_GetCode(frame));
 #if LLTRACE && TIER_ONE
             lltrace = maybe_lltrace_resume_frame(frame, &entry_frame, GLOBALS());
             if (lltrace < 0) {
@@ -3794,7 +3795,7 @@ dummy_func(
         }
 
         op(SAVE_IP, (--)) {
-            frame->prev_instr = ip_offset + oparg;
+            frame->prev_instr = (_Py_CODEUNIT *)(uintptr_t)operand;
         }
 
         op(SAVE_CURRENT_IP, (--)) {
@@ -3808,10 +3809,7 @@ dummy_func(
         }
 
         op(EXIT_TRACE, (--)) {
-            frame->prev_instr--;  // Back up to just before destination
-            _PyFrame_SetStackPointer(frame, stack_pointer);
-            Py_DECREF(self);
-            return frame;
+            goto deoptimize;
         }
 
         op(INSERT, (unused[oparg], top -- top, unused[oparg])) {

--- a/Python/ceval_macros.h
+++ b/Python/ceval_macros.h
@@ -396,7 +396,7 @@ stack_pointer = _PyFrame_GetStackPointer(frame);
 #if TIER_TWO
 
 #define LOAD_IP() \
-do { ip_offset = (_Py_CODEUNIT *)_PyFrame_GetCode(frame)->co_code_adaptive; } while (0)
+do {} while (0)
 
 #define STORE_SP() \
 _PyFrame_SetStackPointer(frame, stack_pointer)

--- a/Python/executor.c
+++ b/Python/executor.c
@@ -63,7 +63,6 @@ _PyUopExecute(_PyExecutorObject *executor, _PyInterpreterFrame *frame, PyObject 
     CHECK_EVAL_BREAKER();
 
     OBJECT_STAT_INC(optimization_traces_executed);
-    _Py_CODEUNIT *ip_offset = (_Py_CODEUNIT *)_PyFrame_GetCode(frame)->co_code_adaptive;
     int pc = 0;
     int opcode;
     int oparg;

--- a/Python/executor_cases.c.h
+++ b/Python/executor_cases.c.h
@@ -2289,6 +2289,7 @@
             tstate->py_recursion_remaining--;
             LOAD_SP();
             LOAD_IP();
+            frame->prev_instr = _PyCode_CODE(_PyFrame_GetCode(frame));
 #if LLTRACE && TIER_ONE
             lltrace = maybe_lltrace_resume_frame(frame, &entry_frame, GLOBALS());
             if (lltrace < 0) {
@@ -2865,7 +2866,7 @@
         }
 
         case SAVE_IP: {
-            frame->prev_instr = ip_offset + oparg;
+            frame->prev_instr = (_Py_CODEUNIT *)(uintptr_t)operand;
             break;
         }
 
@@ -2881,10 +2882,7 @@
         }
 
         case EXIT_TRACE: {
-            frame->prev_instr--;  // Back up to just before destination
-            _PyFrame_SetStackPointer(frame, stack_pointer);
-            Py_DECREF(self);
-            return frame;
+            goto deoptimize;
             break;
         }
 

--- a/Python/generated_cases.c.h
+++ b/Python/generated_cases.c.h
@@ -3886,6 +3886,7 @@
                 tstate->py_recursion_remaining--;
                 LOAD_SP();
                 LOAD_IP();
+                frame->prev_instr = _PyCode_CODE(_PyFrame_GetCode(frame));
     #if LLTRACE && TIER_ONE
                 lltrace = maybe_lltrace_resume_frame(frame, &entry_frame, GLOBALS());
                 if (lltrace < 0) {
@@ -3965,6 +3966,7 @@
                 tstate->py_recursion_remaining--;
                 LOAD_SP();
                 LOAD_IP();
+                frame->prev_instr = _PyCode_CODE(_PyFrame_GetCode(frame));
     #if LLTRACE && TIER_ONE
                 lltrace = maybe_lltrace_resume_frame(frame, &entry_frame, GLOBALS());
                 if (lltrace < 0) {

--- a/Tools/cases_generator/flags.py
+++ b/Tools/cases_generator/flags.py
@@ -42,7 +42,10 @@ class InstructionFlags:
             )
             and not has_free,
             HAS_EVAL_BREAK_FLAG=variable_used(instr, "CHECK_EVAL_BREAKER"),
-            HAS_DEOPT_FLAG=variable_used(instr, "DEOPT_IF"),
+            HAS_DEOPT_FLAG=(
+                variable_used(instr, "DEOPT_IF")
+                or variable_used(instr, "deoptimize")
+            ),
             HAS_ERROR_FLAG=(
                 variable_used(instr, "ERROR_IF")
                 or variable_used(instr, "error")


### PR DESCRIPTION
We don't need to keep `ip_offset` in a local, since it's known statically during trace construction. The only time that we *don't* know it is when pushing a frame for an unknown code object, so modify `_PUSH_FRAME` to set the `prev_instr` of the frame being pushed (this doesn't have any overhead, since it was always being followed by a `SAVE_IP` anyways). Otherwise, we just set the operand of `SAVE_IP` to the actual pointer that should be stored.

Also, `EXIT_TRACE` behaves the same as an unconditional `goto deoptimize`. Changing it to just do that instead makes things simpler, since all returns from tier two happen at labels (rather than tied up in the uop handlers).

<!-- gh-issue-number: gh-104584 -->
* Issue: gh-104584
<!-- /gh-issue-number -->
