### PR TITLE
gh-108962: Skip test_tempfile.test_flags() if not supported

### DIFF
--- a/Lib/test/test_tempfile.py
+++ b/Lib/test/test_tempfile.py
@@ -1846,8 +1846,10 @@ class TestTemporaryDirectory(BaseTestCase):
                 os.chflags(filename, flags)
             except OSError as exc:
                 # "OSError: [Errno 45] Operation not supported"
-                self.skipTest("chflags() doesn't support "
-                              "UF_IMMUTABLE|UF_NOUNLINK: {exc}")
+                self.skipTest(f"chflags() doesn't support "
+                              f"UF_IMMUTABLE|UF_NOUNLINK: {exc}")
+            else:
+                os.chflags(filename, 0)
         finally:
             os_helper.unlink(filename)
 

--- a/Lib/test/test_tempfile.py
+++ b/Lib/test/test_tempfile.py
@@ -1837,6 +1837,20 @@ class TestTemporaryDirectory(BaseTestCase):
     @unittest.skipUnless(hasattr(os, 'chflags'), 'requires os.lchflags')
     def test_flags(self):
         flags = stat.UF_IMMUTABLE | stat.UF_NOUNLINK
+
+        # skip the test if these flags are not supported (ex: FreeBSD 13)
+        filename = TESTFN
+        try:
+            open(filename, "w").close()
+            try:
+                os.chflags(filename, flags)
+            except OSError as exc:
+                # "OSError: [Errno 45] Operation not supported"
+                self.skipTest("chflags() doesn't support "
+                              "UF_IMMUTABLE|UF_NOUNLINK: {exc}")
+        finally:
+            support.unlink(filename)
+
         d = self.do_create(recurse=3, dirs=2, files=2)
         with d:
             # Change files and directories flags recursively.

--- a/Lib/test/test_tempfile.py
+++ b/Lib/test/test_tempfile.py
@@ -1834,12 +1834,12 @@ class TestTemporaryDirectory(BaseTestCase):
                     d.cleanup()
                 self.assertFalse(os.path.exists(d.name))
 
-    @unittest.skipUnless(hasattr(os, 'chflags'), 'requires os.lchflags')
+    @unittest.skipUnless(hasattr(os, 'chflags'), 'requires os.chflags')
     def test_flags(self):
         flags = stat.UF_IMMUTABLE | stat.UF_NOUNLINK
 
         # skip the test if these flags are not supported (ex: FreeBSD 13)
-        filename = TESTFN
+        filename = os_helper.TESTFN
         try:
             open(filename, "w").close()
             try:
@@ -1849,7 +1849,7 @@ class TestTemporaryDirectory(BaseTestCase):
                 self.skipTest("chflags() doesn't support "
                               "UF_IMMUTABLE|UF_NOUNLINK: {exc}")
         finally:
-            support.unlink(filename)
+            os_helper.unlink(filename)
 
         d = self.do_create(recurse=3, dirs=2, files=2)
         with d:

--- a/Misc/NEWS.d/next/Tests/2023-09-05-23-00-09.gh-issue-108962.R4NwuU.rst
+++ b/Misc/NEWS.d/next/Tests/2023-09-05-23-00-09.gh-issue-108962.R4NwuU.rst
@@ -1,0 +1,3 @@
+Skip ``test_tempfile.test_flags()`` if ``chflags()`` fails with "OSError:
+[Errno 45] Operation not supported" (ex: on FreeBSD 13). Patch by Victor
+Stinner.


### PR DESCRIPTION
Skip test_tempfile.test_flags() if chflags() fails with "OSError: [Errno 45] Operation not supported" (ex: on FreeBSD 13).

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-108962 -->
* Issue: gh-108962
<!-- /gh-issue-number -->
