### PR TITLE
gh-106861: Docs: Add availability directives to all Unix-only modules

### DIFF
--- a/Doc/library/fcntl.rst
+++ b/Doc/library/fcntl.rst
@@ -18,7 +18,7 @@ interface to the :c:func:`fcntl` and :c:func:`ioctl` Unix routines.  For a
 complete description of these calls, see :manpage:`fcntl(2)` and
 :manpage:`ioctl(2)` Unix manual pages.
 
-.. include:: ../includes/wasm-notavail.rst
+.. availability:: Unix, not Emscripten, not WASI.
 
 All functions in this module take a file descriptor *fd* as their first
 argument.  This can be an integer file descriptor, such as returned by

--- a/Doc/library/grp.rst
+++ b/Doc/library/grp.rst
@@ -10,7 +10,7 @@
 This module provides access to the Unix group database. It is available on all
 Unix versions.
 
-.. include:: ../includes/wasm-notavail.rst
+.. availability:: Unix, not Emscripten, not WASI.
 
 Group database entries are reported as a tuple-like object, whose attributes
 correspond to the members of the ``group`` structure (Attribute field below, see

--- a/Doc/library/posix.rst
+++ b/Doc/library/posix.rst
@@ -11,6 +11,8 @@ This module provides access to operating system functionality that is
 standardized by the C Standard and the POSIX standard (a thinly disguised Unix
 interface).
 
+.. availability:: Unix.
+
 .. index:: pair: module; os
 
 **Do not import this module directly.**  Instead, import the module :mod:`os`,

--- a/Doc/library/pty.rst
+++ b/Doc/library/pty.rst
@@ -16,6 +16,8 @@ The :mod:`pty` module defines operations for handling the pseudo-terminal
 concept: starting another process and being able to write to and read from its
 controlling terminal programmatically.
 
+.. availability:: Unix.
+
 Pseudo-terminal handling is highly platform dependent. This code is mainly
 tested on Linux, FreeBSD, and macOS (it is supposed to work on other POSIX
 platforms but it's not been thoroughly tested).

--- a/Doc/library/pwd.rst
+++ b/Doc/library/pwd.rst
@@ -10,7 +10,7 @@
 This module provides access to the Unix user account and password database.  It
 is available on all Unix versions.
 
-.. include:: ../includes/wasm-notavail.rst
+.. availability:: Unix, not Emscripten, not WASI.
 
 Password database entries are reported as a tuple-like object, whose attributes
 correspond to the members of the ``passwd`` structure (Attribute field below,

--- a/Doc/library/resource.rst
+++ b/Doc/library/resource.rst
@@ -13,7 +13,7 @@
 This module provides basic mechanisms for measuring and controlling system
 resources utilized by a program.
 
-.. include:: ../includes/wasm-notavail.rst
+.. availability:: Unix, not Emscripten, not WASI.
 
 Symbolic constants are used to specify particular system resources and to
 request usage information about either the current process or its children.

--- a/Doc/library/syslog.rst
+++ b/Doc/library/syslog.rst
@@ -11,11 +11,11 @@ This module provides an interface to the Unix ``syslog`` library routines.
 Refer to the Unix manual pages for a detailed description of the ``syslog``
 facility.
 
+.. availability:: Unix, not Emscripten, not WASI.
+
 This module wraps the system ``syslog`` family of routines.  A pure Python
 library that can speak to a syslog server is available in the
 :mod:`logging.handlers` module as :class:`SysLogHandler`.
-
-.. include:: ../includes/wasm-notavail.rst
 
 The module defines the following functions:
 

--- a/Doc/library/termios.rst
+++ b/Doc/library/termios.rst
@@ -16,6 +16,8 @@ complete description of these calls, see :manpage:`termios(3)` Unix manual
 page.  It is only available for those Unix versions that support POSIX
 *termios* style tty I/O control configured during installation.
 
+.. availability:: Unix.
+
 All functions in this module take a file descriptor *fd* as their first
 argument.  This can be an integer file descriptor, such as returned by
 ``sys.stdin.fileno()``, or a :term:`file object`, such as ``sys.stdin`` itself.

--- a/Doc/library/tty.rst
+++ b/Doc/library/tty.rst
@@ -15,6 +15,8 @@
 The :mod:`tty` module defines functions for putting the tty into cbreak and raw
 modes.
 
+.. availability:: Unix.
+
 Because it requires the :mod:`termios` module, it will work only on Unix.
 
 The :mod:`tty` module defines the following functions:


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

A quick fix to #106861 before #106867 is achieved.

<!-- gh-issue-number: gh-106861 -->
* Issue: gh-106861
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--108975.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->