### PR TITLE
gh-108843: fix ast.unparse for f-string with many quotes

### DIFF
--- a/Lib/ast.py
+++ b/Lib/ast.py
@@ -1236,16 +1236,34 @@ class _Unparser(NodeVisitor):
 
         new_fstring_parts = []
         quote_types = list(_ALL_QUOTES)
+        fallback_to_repr = False
         for value, is_constant in fstring_parts:
             if is_constant:
-                value, quote_types = self._str_literal_helper(
+                value, new_quote_types = self._str_literal_helper(
                     value,
                     quote_types=quote_types,
                     escape_special_whitespace=True,
                 )
+                if set(new_quote_types).isdisjoint(quote_types):
+                    fallback_to_repr = True
+                    break
+                quote_types = new_quote_types
             elif "\n" in value:
                 quote_types = [q for q in quote_types if q in _MULTI_QUOTES]
             new_fstring_parts.append(value)
+
+        if fallback_to_repr:
+            # If we weren't able to find a quote type that works for all parts
+            # of the JoinedStr, fallback to using repr and triple single quotes.
+            quote_types = ["'''"]
+            new_fstring_parts.clear()
+            for value, is_constant in fstring_parts:
+                if is_constant:
+                    value = repr('"' + value)  # force repr to use single quotes
+                    expected_prefix = "'\""
+                    assert value.startswith(expected_prefix), repr(value)
+                    value = value[len(expected_prefix):-1]
+                new_fstring_parts.append(value)
 
         value = "".join(new_fstring_parts)
         quote_type = quote_types[0]

--- a/Lib/ast.py
+++ b/Lib/ast.py
@@ -1250,6 +1250,7 @@ class _Unparser(NodeVisitor):
                 quote_types = new_quote_types
             elif "\n" in value:
                 quote_types = [q for q in quote_types if q in _MULTI_QUOTES]
+                assert quote_types
             new_fstring_parts.append(value)
 
         if fallback_to_repr:

--- a/Lib/test/test_unparse.py
+++ b/Lib/test/test_unparse.py
@@ -645,6 +645,10 @@ class CosmeticTestCase(ASTTestCase):
         self.check_ast_roundtrip("""f'""\"{"\\n"}''' """)
         self.check_ast_roundtrip("""f'""\"{"\\n"}""\\"' """)
 
+        self.check_ast_roundtrip("""f'''""\"''\\'{"\\n"}''' """)
+        self.check_ast_roundtrip("""f'''""\"''\\'{"\\n\\"'"}''' """)
+        self.check_ast_roundtrip("""f'''""\"''\\'{""\"\\n\\"'''""\" '''\\n'''}''' """)
+
 
 class ManualASTCreationTestCase(unittest.TestCase):
     """Test that AST nodes created without a type_params field unparse correctly."""

--- a/Lib/test/test_unparse.py
+++ b/Lib/test/test_unparse.py
@@ -635,6 +635,16 @@ class CosmeticTestCase(ASTTestCase):
         self.check_src_roundtrip("[a, b] = [c, d] = [e, f] = g")
         self.check_src_roundtrip("a, b = [c, d] = e, f = g")
 
+    def test_multiquote_joined_string(self):
+        self.check_ast_roundtrip("f\"'''{1}\\\"\\\"\\\"\" ")
+        self.check_ast_roundtrip("""f"'''{1}""\\"" """)
+        self.check_ast_roundtrip("""f'""\"{1}''' """)
+        self.check_ast_roundtrip("""f'""\"{1}""\\"' """)
+
+        self.check_ast_roundtrip("""f"'''{"\\n"}""\\"" """)
+        self.check_ast_roundtrip("""f'""\"{"\\n"}''' """)
+        self.check_ast_roundtrip("""f'""\"{"\\n"}""\\"' """)
+
 
 class ManualASTCreationTestCase(unittest.TestCase):
     """Test that AST nodes created without a type_params field unparse correctly."""

--- a/Misc/NEWS.d/next/Library/2023-09-06-06-17-23.gh-issue-108843.WJMhsS.rst
+++ b/Misc/NEWS.d/next/Library/2023-09-06-06-17-23.gh-issue-108843.WJMhsS.rst
@@ -1,0 +1,1 @@
+Fix an issue in :func:`ast.unparse` when unparsing f-strings containing many quote types.


### PR DESCRIPTION
The core of the issue here is the fallback to `repr` in `_str_literal_helper` when we can't find a workable quote type. This works fine for single strings, but doesn't work well for joined strings (since earlier values of the joined string may have been written assuming a different quote). Therefore, in the bad case, we go back and force use of repr with a single quote for all parts of the joined string. The assert checks that repr continues to work the way we expect it to work.

<!-- gh-issue-number: gh-108843 -->
* Issue: gh-108843
<!-- /gh-issue-number -->
