### PR TITLE
gh-91960: skip test_gdb when built with clang

### DIFF
--- a/Lib/test/test_gdb.py
+++ b/Lib/test/test_gdb.py
@@ -55,7 +55,7 @@ if gdb_major_version < 7:
 if not sysconfig.is_python_build():
     raise unittest.SkipTest("test_gdb only works on source builds at the moment.")
 
-if 'Clang' in platform.python_compiler() and sys.platform == 'darwin':
+if 'Clang' in platform.python_compiler():
     raise unittest.SkipTest("test_gdb doesn't work correctly when python is"
                             " built with LLVM clang")
 


### PR DESCRIPTION
test_gdb should be skipped on all platforms when CPython is compiled with Clang, not only Darwin.


<!-- gh-issue-number: gh-91960 -->
* Issue: gh-91960
<!-- /gh-issue-number -->
