### PR TITLE
Make all instructions macros internally.

### DIFF
--- a/Include/internal/pycore_opcode_metadata.h
+++ b/Include/internal/pycore_opcode_metadata.h
@@ -27,57 +27,59 @@
 
 #define EXIT_TRACE 300
 #define SAVE_IP 301
-#define _GUARD_BOTH_INT 302
-#define _BINARY_OP_MULTIPLY_INT 303
-#define _BINARY_OP_ADD_INT 304
-#define _BINARY_OP_SUBTRACT_INT 305
-#define _GUARD_BOTH_FLOAT 306
-#define _BINARY_OP_MULTIPLY_FLOAT 307
-#define _BINARY_OP_ADD_FLOAT 308
-#define _BINARY_OP_SUBTRACT_FLOAT 309
-#define _GUARD_BOTH_UNICODE 310
-#define _BINARY_OP_ADD_UNICODE 311
-#define _BINARY_OP_INPLACE_ADD_UNICODE 312
-#define _POP_FRAME 313
-#define _LOAD_LOCALS 314
-#define _LOAD_FROM_DICT_OR_GLOBALS 315
-#define _GUARD_GLOBALS_VERSION 316
-#define _GUARD_BUILTINS_VERSION 317
-#define _LOAD_GLOBAL_MODULE 318
-#define _LOAD_GLOBAL_BUILTINS 319
-#define _GUARD_TYPE_VERSION 320
-#define _CHECK_MANAGED_OBJECT_HAS_VALUES 321
-#define _LOAD_ATTR_INSTANCE_VALUE 322
-#define IS_NONE 323
-#define _ITER_CHECK_LIST 324
-#define _ITER_JUMP_LIST 325
-#define _IS_ITER_EXHAUSTED_LIST 326
-#define _ITER_NEXT_LIST 327
-#define _ITER_CHECK_TUPLE 328
-#define _ITER_JUMP_TUPLE 329
-#define _IS_ITER_EXHAUSTED_TUPLE 330
-#define _ITER_NEXT_TUPLE 331
-#define _ITER_CHECK_RANGE 332
-#define _ITER_JUMP_RANGE 333
-#define _IS_ITER_EXHAUSTED_RANGE 334
-#define _ITER_NEXT_RANGE 335
-#define _CHECK_CALL_BOUND_METHOD_EXACT_ARGS 336
-#define _INIT_CALL_BOUND_METHOD_EXACT_ARGS 337
-#define _CHECK_PEP_523 338
-#define _CHECK_FUNCTION_EXACT_ARGS 339
-#define _CHECK_STACK_SPACE 340
-#define _INIT_CALL_PY_EXACT_ARGS 341
-#define _PUSH_FRAME 342
-#define _POP_JUMP_IF_FALSE 343
-#define _POP_JUMP_IF_TRUE 344
-#define JUMP_TO_TOP 345
-#define SAVE_CURRENT_IP 346
+#define _SAVE_CURRENT_IP 302
+#define _GUARD_BOTH_INT 303
+#define _BINARY_OP_MULTIPLY_INT 304
+#define _BINARY_OP_ADD_INT 305
+#define _BINARY_OP_SUBTRACT_INT 306
+#define _GUARD_BOTH_FLOAT 307
+#define _BINARY_OP_MULTIPLY_FLOAT 308
+#define _BINARY_OP_ADD_FLOAT 309
+#define _BINARY_OP_SUBTRACT_FLOAT 310
+#define _GUARD_BOTH_UNICODE 311
+#define _BINARY_OP_ADD_UNICODE 312
+#define _BINARY_OP_INPLACE_ADD_UNICODE 313
+#define _POP_FRAME 314
+#define _LOAD_LOCALS 315
+#define _LOAD_FROM_DICT_OR_GLOBALS 316
+#define _GUARD_GLOBALS_VERSION 317
+#define _GUARD_BUILTINS_VERSION 318
+#define _LOAD_GLOBAL_MODULE 319
+#define _LOAD_GLOBAL_BUILTINS 320
+#define _GUARD_TYPE_VERSION 321
+#define _CHECK_MANAGED_OBJECT_HAS_VALUES 322
+#define _LOAD_ATTR_INSTANCE_VALUE 323
+#define IS_NONE 324
+#define _ITER_CHECK_LIST 325
+#define _ITER_JUMP_LIST 326
+#define _IS_ITER_EXHAUSTED_LIST 327
+#define _ITER_NEXT_LIST 328
+#define _ITER_CHECK_TUPLE 329
+#define _ITER_JUMP_TUPLE 330
+#define _IS_ITER_EXHAUSTED_TUPLE 331
+#define _ITER_NEXT_TUPLE 332
+#define _ITER_CHECK_RANGE 333
+#define _ITER_JUMP_RANGE 334
+#define _IS_ITER_EXHAUSTED_RANGE 335
+#define _ITER_NEXT_RANGE 336
+#define _CHECK_CALL_BOUND_METHOD_EXACT_ARGS 337
+#define _INIT_CALL_BOUND_METHOD_EXACT_ARGS 338
+#define _CHECK_PEP_523 339
+#define _CHECK_FUNCTION_EXACT_ARGS 340
+#define _CHECK_STACK_SPACE 341
+#define _INIT_CALL_PY_EXACT_ARGS 342
+#define _PUSH_FRAME 343
+#define _SIDE_EXIT_IF_FALSE 344
+#define _SIDE_EXIT_IF_TRUE 345
+#define JUMP_TO_TOP 346
 #define INSERT 347
 
 extern int _PyOpcode_num_popped(int opcode, int oparg, bool jump);
 #ifdef NEED_OPCODE_METADATA
 int _PyOpcode_num_popped(int opcode, int oparg, bool jump)  {
     switch(opcode) {
+        case _SAVE_CURRENT_IP:
+            return 0;
         case NOP:
             return 0;
         case RESUME:
@@ -586,15 +588,13 @@ int _PyOpcode_num_popped(int opcode, int oparg, bool jump)  {
             return 0;
         case RESERVED:
             return 0;
-        case _POP_JUMP_IF_FALSE:
+        case _SIDE_EXIT_IF_FALSE:
             return 1;
-        case _POP_JUMP_IF_TRUE:
+        case _SIDE_EXIT_IF_TRUE:
             return 1;
         case JUMP_TO_TOP:
             return 0;
         case SAVE_IP:
-            return 0;
-        case SAVE_CURRENT_IP:
             return 0;
         case EXIT_TRACE:
             return 0;
@@ -610,6 +610,8 @@ extern int _PyOpcode_num_pushed(int opcode, int oparg, bool jump);
 #ifdef NEED_OPCODE_METADATA
 int _PyOpcode_num_pushed(int opcode, int oparg, bool jump)  {
     switch(opcode) {
+        case _SAVE_CURRENT_IP:
+            return 0;
         case NOP:
             return 0;
         case RESUME:
@@ -1118,15 +1120,13 @@ int _PyOpcode_num_pushed(int opcode, int oparg, bool jump)  {
             return 0;
         case RESERVED:
             return 0;
-        case _POP_JUMP_IF_FALSE:
+        case _SIDE_EXIT_IF_FALSE:
             return 0;
-        case _POP_JUMP_IF_TRUE:
+        case _SIDE_EXIT_IF_TRUE:
             return 0;
         case JUMP_TO_TOP:
             return 0;
         case SAVE_IP:
-            return 0;
-        case SAVE_CURRENT_IP:
             return 0;
         case EXIT_TRACE:
             return 0;
@@ -1205,6 +1205,7 @@ struct opcode_macro_expansion {
 extern const struct opcode_metadata _PyOpcode_opcode_metadata[OPCODE_METADATA_SIZE];
 #ifdef NEED_OPCODE_METADATA
 const struct opcode_metadata _PyOpcode_opcode_metadata[OPCODE_METADATA_SIZE] = {
+    [_SAVE_CURRENT_IP] = { true, INSTR_FMT_IX, 0 },
     [NOP] = { true, INSTR_FMT_IX, 0 },
     [RESUME] = { true, INSTR_FMT_IB, HAS_ARG_FLAG | HAS_EVAL_BREAK_FLAG | HAS_ERROR_FLAG },
     [INSTRUMENTED_RESUME] = { true, INSTR_FMT_IB, HAS_ARG_FLAG | HAS_EVAL_BREAK_FLAG | HAS_ERROR_FLAG },
@@ -1463,11 +1464,10 @@ const struct opcode_metadata _PyOpcode_opcode_metadata[OPCODE_METADATA_SIZE] = {
     [EXTENDED_ARG] = { true, INSTR_FMT_IB, HAS_ARG_FLAG },
     [CACHE] = { true, INSTR_FMT_IX, 0 },
     [RESERVED] = { true, INSTR_FMT_IX, 0 },
-    [_POP_JUMP_IF_FALSE] = { true, INSTR_FMT_IB, HAS_ARG_FLAG },
-    [_POP_JUMP_IF_TRUE] = { true, INSTR_FMT_IB, HAS_ARG_FLAG },
+    [_SIDE_EXIT_IF_FALSE] = { true, INSTR_FMT_IB, HAS_ARG_FLAG },
+    [_SIDE_EXIT_IF_TRUE] = { true, INSTR_FMT_IB, HAS_ARG_FLAG },
     [JUMP_TO_TOP] = { true, INSTR_FMT_IX, HAS_EVAL_BREAK_FLAG },
     [SAVE_IP] = { true, INSTR_FMT_IB, HAS_ARG_FLAG },
-    [SAVE_CURRENT_IP] = { true, INSTR_FMT_IX, 0 },
     [EXIT_TRACE] = { true, INSTR_FMT_IX, 0 },
     [INSERT] = { true, INSTR_FMT_IB, HAS_ARG_FLAG },
 };
@@ -1522,8 +1522,8 @@ const struct opcode_macro_expansion _PyOpcode_macro_expansion[OPCODE_MACRO_EXPAN
     [DELETE_SUBSCR] = { .nuops = 1, .uops = { { DELETE_SUBSCR, 0, 0 } } },
     [CALL_INTRINSIC_1] = { .nuops = 1, .uops = { { CALL_INTRINSIC_1, 0, 0 } } },
     [CALL_INTRINSIC_2] = { .nuops = 1, .uops = { { CALL_INTRINSIC_2, 0, 0 } } },
-    [RETURN_VALUE] = { .nuops = 3, .uops = { { SAVE_IP, 7, 0 }, { SAVE_CURRENT_IP, 0, 0 }, { _POP_FRAME, 0, 0 } } },
-    [RETURN_CONST] = { .nuops = 4, .uops = { { LOAD_CONST, 0, 0 }, { SAVE_IP, 7, 0 }, { SAVE_CURRENT_IP, 0, 0 }, { _POP_FRAME, 0, 0 } } },
+    [RETURN_VALUE] = { .nuops = 1, .uops = { { _POP_FRAME, 0, 0 } } },
+    [RETURN_CONST] = { .nuops = 2, .uops = { { LOAD_CONST, 0, 0 }, { _POP_FRAME, 0, 0 } } },
     [GET_AITER] = { .nuops = 1, .uops = { { GET_AITER, 0, 0 } } },
     [GET_ANEXT] = { .nuops = 1, .uops = { { GET_ANEXT, 0, 0 } } },
     [GET_AWAITABLE] = { .nuops = 1, .uops = { { GET_AWAITABLE, 0, 0 } } },
@@ -1586,8 +1586,8 @@ const struct opcode_macro_expansion _PyOpcode_macro_expansion[OPCODE_MACRO_EXPAN
     [GET_YIELD_FROM_ITER] = { .nuops = 1, .uops = { { GET_YIELD_FROM_ITER, 0, 0 } } },
     [WITH_EXCEPT_START] = { .nuops = 1, .uops = { { WITH_EXCEPT_START, 0, 0 } } },
     [PUSH_EXC_INFO] = { .nuops = 1, .uops = { { PUSH_EXC_INFO, 0, 0 } } },
-    [CALL_BOUND_METHOD_EXACT_ARGS] = { .nuops = 9, .uops = { { _CHECK_PEP_523, 0, 0 }, { _CHECK_CALL_BOUND_METHOD_EXACT_ARGS, 0, 0 }, { _INIT_CALL_BOUND_METHOD_EXACT_ARGS, 0, 0 }, { _CHECK_FUNCTION_EXACT_ARGS, 2, 1 }, { _CHECK_STACK_SPACE, 0, 0 }, { _INIT_CALL_PY_EXACT_ARGS, 0, 0 }, { SAVE_IP, 7, 3 }, { SAVE_CURRENT_IP, 0, 0 }, { _PUSH_FRAME, 0, 0 } } },
-    [CALL_PY_EXACT_ARGS] = { .nuops = 7, .uops = { { _CHECK_PEP_523, 0, 0 }, { _CHECK_FUNCTION_EXACT_ARGS, 2, 1 }, { _CHECK_STACK_SPACE, 0, 0 }, { _INIT_CALL_PY_EXACT_ARGS, 0, 0 }, { SAVE_IP, 7, 3 }, { SAVE_CURRENT_IP, 0, 0 }, { _PUSH_FRAME, 0, 0 } } },
+    [CALL_BOUND_METHOD_EXACT_ARGS] = { .nuops = 8, .uops = { { _CHECK_PEP_523, 0, 0 }, { _CHECK_CALL_BOUND_METHOD_EXACT_ARGS, 0, 0 }, { _INIT_CALL_BOUND_METHOD_EXACT_ARGS, 0, 0 }, { _CHECK_FUNCTION_EXACT_ARGS, 2, 1 }, { _CHECK_STACK_SPACE, 0, 0 }, { _INIT_CALL_PY_EXACT_ARGS, 0, 0 }, { _SAVE_CURRENT_IP, 0, 0 }, { _PUSH_FRAME, 0, 0 } } },
+    [CALL_PY_EXACT_ARGS] = { .nuops = 6, .uops = { { _CHECK_PEP_523, 0, 0 }, { _CHECK_FUNCTION_EXACT_ARGS, 2, 1 }, { _CHECK_STACK_SPACE, 0, 0 }, { _INIT_CALL_PY_EXACT_ARGS, 0, 0 }, { _SAVE_CURRENT_IP, 0, 0 }, { _PUSH_FRAME, 0, 0 } } },
     [CALL_NO_KW_TYPE_1] = { .nuops = 1, .uops = { { CALL_NO_KW_TYPE_1, 0, 0 } } },
     [CALL_NO_KW_STR_1] = { .nuops = 1, .uops = { { CALL_NO_KW_STR_1, 0, 0 } } },
     [CALL_NO_KW_TUPLE_1] = { .nuops = 1, .uops = { { CALL_NO_KW_TUPLE_1, 0, 0 } } },
@@ -1616,6 +1616,7 @@ extern const char * const _PyOpcode_uop_name[OPCODE_UOP_NAME_SIZE];
 const char * const _PyOpcode_uop_name[OPCODE_UOP_NAME_SIZE] = {
     [EXIT_TRACE] = "EXIT_TRACE",
     [SAVE_IP] = "SAVE_IP",
+    [_SAVE_CURRENT_IP] = "_SAVE_CURRENT_IP",
     [_GUARD_BOTH_INT] = "_GUARD_BOTH_INT",
     [_BINARY_OP_MULTIPLY_INT] = "_BINARY_OP_MULTIPLY_INT",
     [_BINARY_OP_ADD_INT] = "_BINARY_OP_ADD_INT",
@@ -1657,10 +1658,9 @@ const char * const _PyOpcode_uop_name[OPCODE_UOP_NAME_SIZE] = {
     [_CHECK_STACK_SPACE] = "_CHECK_STACK_SPACE",
     [_INIT_CALL_PY_EXACT_ARGS] = "_INIT_CALL_PY_EXACT_ARGS",
     [_PUSH_FRAME] = "_PUSH_FRAME",
-    [_POP_JUMP_IF_FALSE] = "_POP_JUMP_IF_FALSE",
-    [_POP_JUMP_IF_TRUE] = "_POP_JUMP_IF_TRUE",
+    [_SIDE_EXIT_IF_FALSE] = "_SIDE_EXIT_IF_FALSE",
+    [_SIDE_EXIT_IF_TRUE] = "_SIDE_EXIT_IF_TRUE",
     [JUMP_TO_TOP] = "JUMP_TO_TOP",
-    [SAVE_CURRENT_IP] = "SAVE_CURRENT_IP",
     [INSERT] = "INSERT",
 };
 #endif // NEED_OPCODE_METADATA

--- a/Lib/test/test_capi/test_misc.py
+++ b/Lib/test/test_capi/test_misc.py
@@ -2475,7 +2475,7 @@ class TestUops(unittest.TestCase):
         ex = get_first_executor(testfunc)
         self.assertIsNotNone(ex)
         uops = {opname for opname, _, _ in ex}
-        self.assertIn("_POP_JUMP_IF_FALSE", uops)
+        self.assertIn("_SIDE_EXIT_IF_FALSE", uops)
 
     def test_pop_jump_if_none(self):
         def testfunc(a):
@@ -2490,7 +2490,7 @@ class TestUops(unittest.TestCase):
         ex = get_first_executor(testfunc)
         self.assertIsNotNone(ex)
         uops = {opname for opname, _, _ in ex}
-        self.assertIn("_POP_JUMP_IF_TRUE", uops)
+        self.assertIn("_SIDE_EXIT_IF_TRUE", uops)
 
     def test_pop_jump_if_not_none(self):
         def testfunc(a):
@@ -2505,7 +2505,7 @@ class TestUops(unittest.TestCase):
         ex = get_first_executor(testfunc)
         self.assertIsNotNone(ex)
         uops = {opname for opname, _, _ in ex}
-        self.assertIn("_POP_JUMP_IF_FALSE", uops)
+        self.assertIn("_SIDE_EXIT_IF_FALSE", uops)
 
     def test_pop_jump_if_true(self):
         def testfunc(n):
@@ -2520,7 +2520,7 @@ class TestUops(unittest.TestCase):
         ex = get_first_executor(testfunc)
         self.assertIsNotNone(ex)
         uops = {opname for opname, _, _ in ex}
-        self.assertIn("_POP_JUMP_IF_TRUE", uops)
+        self.assertIn("_SIDE_EXIT_IF_TRUE", uops)
 
     def test_jump_backward(self):
         def testfunc(n):

--- a/Python/abstract_interp_cases.c.h
+++ b/Python/abstract_interp_cases.c.h
@@ -3,6 +3,10 @@
 //   Python/bytecodes.c
 // Do not edit!
 
+        case _SAVE_CURRENT_IP: {
+            break;
+        }
+
         case NOP: {
             break;
         }
@@ -776,12 +780,12 @@
             break;
         }
 
-        case _POP_JUMP_IF_FALSE: {
+        case _SIDE_EXIT_IF_FALSE: {
             STACK_SHRINK(1);
             break;
         }
 
-        case _POP_JUMP_IF_TRUE: {
+        case _SIDE_EXIT_IF_TRUE: {
             STACK_SHRINK(1);
             break;
         }
@@ -791,10 +795,6 @@
         }
 
         case SAVE_IP: {
-            break;
-        }
-
-        case SAVE_CURRENT_IP: {
             break;
         }
 

--- a/Python/executor_cases.c.h
+++ b/Python/executor_cases.c.h
@@ -3,6 +3,17 @@
 //   Python/bytecodes.c
 // Do not edit!
 
+        case _SAVE_CURRENT_IP: {
+            #if TIER_ONE
+            frame->prev_instr = next_instr - 1;
+            #endif
+            #if TIER_TWO
+            /* Should be eliminated in tier 2 */
+            assert(0);
+            #endif
+            break;
+        }
+
         case NOP: {
             break;
         }
@@ -2838,7 +2849,7 @@
             break;
         }
 
-        case _POP_JUMP_IF_FALSE: {
+        case _SIDE_EXIT_IF_FALSE: {
             PyObject *flag;
             flag = stack_pointer[-1];
             if (Py_IsFalse(flag)) {
@@ -2848,7 +2859,7 @@
             break;
         }
 
-        case _POP_JUMP_IF_TRUE: {
+        case _SIDE_EXIT_IF_TRUE: {
             PyObject *flag;
             flag = stack_pointer[-1];
             if (Py_IsTrue(flag)) {
@@ -2866,17 +2877,6 @@
 
         case SAVE_IP: {
             frame->prev_instr = ip_offset + oparg;
-            break;
-        }
-
-        case SAVE_CURRENT_IP: {
-            #if TIER_ONE
-            frame->prev_instr = next_instr - 1;
-            #endif
-            #if TIER_TWO
-            // Relies on a preceding SAVE_IP
-            frame->prev_instr--;
-            #endif
             break;
         }
 

--- a/Tools/cases_generator/generate_cases.py
+++ b/Tools/cases_generator/generate_cases.py
@@ -777,9 +777,7 @@ class Generator(Analyzer):
                     case OverriddenInstructionPlaceHolder():
                         self.write_overridden_instr_place_holder(thing)
                     case parsing.InstDef():
-                        if thing.kind != "op":
-                            n_instrs += 1
-                            self.write_instr(self.instrs[thing.name])
+                        pass
                     case parsing.Macro():
                         n_macros += 1
                         mac = self.macro_instrs[thing.name]
@@ -910,6 +908,7 @@ def main() -> None:
     a = Generator(args.input)
 
     a.parse()  # Raises SyntaxError on failure
+    a.desugar()
     a.analyze()  # Prints messages and sets a.errors on failure
     if a.errors:
         sys.exit(f"Found {a.errors} errors")

--- a/Tools/cases_generator/instructions.py
+++ b/Tools/cases_generator/instructions.py
@@ -45,7 +45,6 @@ TIER_ONE: typing.Final = 1  # Specializing adaptive interpreter (PEP 659)
 TIER_TWO: typing.Final = 2  # Experimental tracing interpreter
 Tiers: typing.TypeAlias = typing.Literal[1, 2]
 
-
 @dataclasses.dataclass
 class Instruction:
     """An instruction with additional data and code."""
@@ -254,6 +253,10 @@ class AbstractInstruction(Instruction):
 class Component:
     instr: Instruction
     active_caches: list[ActiveCacheEffect]
+
+    @property
+    def name(self):
+        return self.instr.name
 
 
 MacroParts = list[Component | parsing.CacheEffect]

--- a/Tools/cases_generator/stacking.py
+++ b/Tools/cases_generator/stacking.py
@@ -368,7 +368,7 @@ def write_macro_instr(
         try:
             next_instr_is_set = write_components(parts, out, TIER_ONE, mac.cache_offset)
         except AssertionError as err:
-            raise AssertionError(f"Error writing macro {mac.name}") from err
+            raise AssertionError(f"Error writing macro {mac.name} {[part.name for part in mac.parts]}") from err
         if not parts[-1].instr.always_exits:
             if not next_instr_is_set and mac.cache_offset:
                 out.emit(f"next_instr += {mac.cache_offset};")
@@ -431,7 +431,7 @@ def write_components(
             # Use clone() since adjust_inverse() mutates final_offset
             mgr.adjust_inverse(mgr.final_offset.clone())
 
-        if mgr.instr.name == "SAVE_CURRENT_IP":
+        if mgr.instr.name == "_SAVE_CURRENT_IP":
             next_instr_is_set = True
             if cache_offset:
                 out.emit(f"next_instr += {cache_offset};")


### PR DESCRIPTION
Adds a de-sugaring pass that converts:
```C
inst(LOAD_FAST, (-- value)) {
    value = GETLOCAL(oparg);
    assert(value != NULL);
    Py_INCREF(value);
}
```
into
```C
op(_LOAD_FAST, (-- value)) {
    value = GETLOCAL(oparg);
    assert(value != NULL);
    Py_INCREF(value);
}
macro(LOAD_FAST) = _SAVE_CURRENT_IP + _LOAD_FAST
```
and converts occurrences of `_SAVE_CURRENT_IP` to `SAVE_IP offset` for the tier 2.
