### PR TITLE
gh-91960: Skip test_gdb if gdb cannot retrive Python frames

### DIFF
--- a/Lib/test/test_gdb.py
+++ b/Lib/test/test_gdb.py
@@ -55,10 +55,6 @@ if gdb_major_version < 7:
 if not sysconfig.is_python_build():
     raise unittest.SkipTest("test_gdb only works on source builds at the moment.")
 
-if 'Clang' in platform.python_compiler() and sys.platform == 'darwin':
-    raise unittest.SkipTest("test_gdb doesn't work correctly when python is"
-                            " built with LLVM clang")
-
 if ((sysconfig.get_config_var('PGO_PROF_USE_FLAG') or 'xxx') in
     (sysconfig.get_config_var('PY_CORE_CFLAGS') or '')):
     raise unittest.SkipTest("test_gdb is not reliable on PGO builds")
@@ -247,6 +243,9 @@ class DebuggerTests(unittest.TestCase):
         for pattern in (
             '(frame information optimized out)',
             'Unable to read information on python frame',
+            # gh-91960: On Python built with "clang -Og", gdb gets
+            # "frame=<optimized out>" for _PyEval_EvalFrameDefault() parameter
+            '(unable to read python frame information)',
         ):
             if pattern in out:
                 raise unittest.SkipTest(f"{pattern!r} found in gdb output")

--- a/Misc/NEWS.d/next/Tests/2023-09-06-15-36-51.gh-issue-91960.P3nD5v.rst
+++ b/Misc/NEWS.d/next/Tests/2023-09-06-15-36-51.gh-issue-91960.P3nD5v.rst
@@ -1,0 +1,7 @@
+Skip ``test_gdb`` if gdb is unable to retrieve Python frame objects: if a
+frame is ``<optimized out>``. When Python is built with "clang -Og", gdb can
+fail to retrive the *frame* parameter of ``_PyEval_EvalFrameDefault()``. In
+this case, tests like ``py_bt()`` are likely to fail. Without getting access
+to Python frames, ``python-gdb.py`` is mostly clueless on retrieving the
+Python traceback. Moreover, ``test_gdb`` is no longer skipped on macOS if
+Python is built with Clang. Patch by Victor Stinner.


### PR DESCRIPTION
When Python is built with "clang -Og", gdb can fail to retrive the 'frame' parameter of _PyEval_EvalFrameDefault(). In this case, tests like py_bt() are likely to fail. Without getting access to Python frames, python-gdb.py is mostly clueless on retrieving the Python traceback.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-91960 -->
* Issue: gh-91960
<!-- /gh-issue-number -->
