### PR TITLE
gh-109002: Ensure only one wheel for each vendored package

### DIFF
--- a/Tools/build/verify_ensurepip_wheels.py
+++ b/Tools/build/verify_ensurepip_wheels.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python3
+#!/usr/bin/env python3
 
 """
 Compare checksums for wheels in :mod:`ensurepip` against the Cheeseshop.
@@ -35,10 +35,16 @@ def print_error(file_path: str, message: str) -> None:
 
 def verify_wheel(package_name: str) -> bool:
     # Find the package on disk
-    package_path = next(WHEEL_DIR.glob(f"{package_name}*.whl"), None)
-    if not package_path:
-        print_error("", f"Could not find a {package_name} wheel on disk.")
+    package_paths = list(WHEEL_DIR.glob(f"{package_name}*.whl"))
+    if len(package_paths) != 1:
+        if package_paths:
+            for p in package_paths:
+                print_error(p, f"Found more than one wheel for package {package_name}.")
+        else:
+            print_error("", f"Could not find a {package_name} wheel on disk.")
         return False
+
+    package_path = package_paths[0]
 
     print(f"Verifying checksum for {package_path}.")
 


### PR DESCRIPTION
Output with one wheel:
```
❯ GITHUB_ACTIONS=true ./Tools/build/verify_ensurepip_wheels.py
Verifying checksum for /Volumes/RAMDisk/cpython/Lib/ensurepip/_bundled/pip-23.2.1-py3-none-any.whl.
Expected digest: 7ccf472345f20d35bdc9d1841ff5f313260c2c33fe417f48c30ac46cccabf5be
Actual digest:   7ccf472345f20d35bdc9d1841ff5f313260c2c33fe417f48c30ac46cccabf5be
::notice file=/Volumes/RAMDisk/cpython/Lib/ensurepip/_bundled/pip-23.2.1-py3-none-any.whl::Successfully verified the checksum of the pip wheel.
```

Output with two wheels:
```
❯ GITHUB_ACTIONS=true ./Tools/build/verify_ensurepip_wheels.py
::error file=/Volumes/RAMDisk/cpython/Lib/ensurepip/_bundled/pip-22.0.4-py3-none-any.whl::Found more than one wheel for package pip.

::error file=/Volumes/RAMDisk/cpython/Lib/ensurepip/_bundled/pip-23.2.1-py3-none-any.whl::Found more than one wheel for package pip.
```

Output without wheels:
```
❯ GITHUB_ACTIONS=true ./Tools/build/verify_ensurepip_wheels.py
::error file=::Could not find a pip wheel on disk.
```

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-109002 -->
* Issue: gh-109002
<!-- /gh-issue-number -->
