### PR TITLE
C API tests: use special markers to test that output parameters were set

### DIFF
--- a/Modules/_testcapi/abstract.c
+++ b/Modules/_testcapi/abstract.c
@@ -32,7 +32,7 @@ object_getattrstring(PyObject *self, PyObject *args)
 static PyObject *
 object_getoptionalattr(PyObject *self, PyObject *args)
 {
-    PyObject *obj, *attr_name, *value;
+    PyObject *obj, *attr_name, *value = UNINITIALIZED_PTR;
     if (!PyArg_ParseTuple(args, "OO", &obj, &attr_name)) {
         return NULL;
     }
@@ -57,7 +57,7 @@ object_getoptionalattr(PyObject *self, PyObject *args)
 static PyObject *
 object_getoptionalattrstring(PyObject *self, PyObject *args)
 {
-    PyObject *obj, *value;
+    PyObject *obj, *value = UNINITIALIZED_PTR;
     const char *attr_name;
     Py_ssize_t size;
     if (!PyArg_ParseTuple(args, "Oz#", &obj, &attr_name, &size)) {
@@ -207,7 +207,7 @@ mapping_getitemstring(PyObject *self, PyObject *args)
 static PyObject *
 mapping_getoptionalitem(PyObject *self, PyObject *args)
 {
-    PyObject *obj, *attr_name, *value;
+    PyObject *obj, *attr_name, *value = UNINITIALIZED_PTR;
     if (!PyArg_ParseTuple(args, "OO", &obj, &attr_name)) {
         return NULL;
     }
@@ -232,7 +232,7 @@ mapping_getoptionalitem(PyObject *self, PyObject *args)
 static PyObject *
 mapping_getoptionalitemstring(PyObject *self, PyObject *args)
 {
-    PyObject *obj, *value;
+    PyObject *obj, *value = UNINITIALIZED_PTR;
     const char *attr_name;
     Py_ssize_t size;
     if (!PyArg_ParseTuple(args, "Oz#", &obj, &attr_name, &size)) {

--- a/Modules/_testcapi/code.c
+++ b/Modules/_testcapi/code.c
@@ -1,4 +1,5 @@
 #include "parts.h"
+#include "util.h"
 
 static Py_ssize_t
 get_code_extra_index(PyInterpreterState* interp) {
@@ -75,7 +76,7 @@ test_code_extra(PyObject* self, PyObject *Py_UNUSED(callable))
     }
 
     // Check the value is initially NULL
-    void *extra;
+    void *extra = UNINITIALIZED_PTR;
     int res = PyUnstable_Code_GetExtra(test_func_code, code_extra_index, &extra);
     if (res < 0) {
         goto finally;
@@ -88,6 +89,7 @@ test_code_extra(PyObject* self, PyObject *Py_UNUSED(callable))
         goto finally;
     }
     // Assert it was set correctly
+    extra = UNINITIALIZED_PTR;
     res = PyUnstable_Code_GetExtra(test_func_code, code_extra_index, &extra);
     if (res < 0) {
         goto finally;

--- a/Modules/_testcapi/dict.c
+++ b/Modules/_testcapi/dict.c
@@ -139,7 +139,7 @@ dict_getitemwitherror(PyObject *self, PyObject *args)
 static PyObject *
 dict_getitemref(PyObject *self, PyObject *args)
 {
-    PyObject *obj, *attr_name, *value;
+    PyObject *obj, *attr_name, *value = UNINITIALIZED_PTR;
     if (!PyArg_ParseTuple(args, "OO", &obj, &attr_name)) {
         return NULL;
     }
@@ -164,7 +164,7 @@ dict_getitemref(PyObject *self, PyObject *args)
 static PyObject *
 dict_getitemstringref(PyObject *self, PyObject *args)
 {
-    PyObject *obj, *value;
+    PyObject *obj, *value = UNINITIALIZED_PTR;
     const char *attr_name;
     Py_ssize_t size;
     if (!PyArg_ParseTuple(args, "Oz#", &obj, &attr_name, &size)) {
@@ -276,7 +276,7 @@ dict_items(PyObject *self, PyObject *obj)
 static PyObject *
 dict_next(PyObject *self, PyObject *args)
 {
-    PyObject *mapping, *key, *value;
+    PyObject *mapping, *key = UNINITIALIZED_PTR, *value = UNINITIALIZED_PTR;
     Py_ssize_t pos;
     if (!PyArg_ParseTuple(args, "On", &mapping, &pos)) {
         return NULL;
@@ -286,6 +286,8 @@ dict_next(PyObject *self, PyObject *args)
     if (rc != 0) {
         return Py_BuildValue("inOO", rc, pos, key, value);
     }
+    assert(key == UNINITIALIZED_PTR);
+    assert(value == UNINITIALIZED_PTR);
     if (PyErr_Occurred()) {
         return NULL;
     }

--- a/Modules/_testcapi/exceptions.c
+++ b/Modules/_testcapi/exceptions.c
@@ -120,12 +120,15 @@ _testcapi_exc_set_object_fetch_impl(PyObject *module, PyObject *exc,
                                     PyObject *obj)
 /*[clinic end generated code: output=7a5ff5f6d3cf687f input=77ec686f1f95fa38]*/
 {
-    PyObject *type;
-    PyObject *value;
-    PyObject *tb;
+    PyObject *type = UNINITIALIZED_PTR;
+    PyObject *value = UNINITIALIZED_PTR;
+    PyObject *tb = UNINITIALIZED_PTR;
 
     PyErr_SetObject(exc, obj);
     PyErr_Fetch(&type, &value, &tb);
+    assert(type != UNINITIALIZED_PTR);
+    assert(value != UNINITIALIZED_PTR);
+    assert(tb != UNINITIALIZED_PTR);
     Py_XDECREF(type);
     Py_XDECREF(tb);
     return value;
@@ -244,7 +247,7 @@ _testcapi_set_exc_info_impl(PyObject *module, PyObject *new_type,
                             PyObject *new_value, PyObject *new_tb)
 /*[clinic end generated code: output=b55fa35dec31300e input=ea9f19e0f55fe5b3]*/
 {
-    PyObject *type, *value, *tb;
+    PyObject *type = UNINITIALIZED_PTR, *value = UNINITIALIZED_PTR, *tb = UNINITIALIZED_PTR;
     PyErr_GetExcInfo(&type, &value, &tb);
 
     Py_INCREF(new_type);

--- a/Modules/_testcapi/unicode.c
+++ b/Modules/_testcapi/unicode.c
@@ -490,7 +490,7 @@ static PyObject *
 unicode_aswidecharstring(PyObject *self, PyObject *args)
 {
     PyObject *unicode, *result;
-    Py_ssize_t size = 100;
+    Py_ssize_t size = UNINITIALIZED_SIZE;
     wchar_t *buffer;
 
     if (!PyArg_ParseTuple(args, "O", &unicode))
@@ -498,8 +498,10 @@ unicode_aswidecharstring(PyObject *self, PyObject *args)
 
     NULLABLE(unicode);
     buffer = PyUnicode_AsWideCharString(unicode, &size);
-    if (buffer == NULL)
+    if (buffer == NULL) {
+        assert(size == UNINITIALIZED_SIZE);
         return NULL;
+    }
 
     result = PyUnicode_FromWideChar(buffer, size + 1);
     PyMem_Free(buffer);
@@ -624,15 +626,17 @@ unicode_asutf8andsize(PyObject *self, PyObject *args)
     PyObject *unicode;
     Py_ssize_t buflen;
     const char *s;
-    Py_ssize_t size = -100;
+    Py_ssize_t size = UNINITIALIZED_SIZE;
 
     if (!PyArg_ParseTuple(args, "On", &unicode, &buflen))
         return NULL;
 
     NULLABLE(unicode);
     s = PyUnicode_AsUTF8AndSize(unicode, &size);
-    if (s == NULL)
+    if (s == NULL) {
+        assert(size == UNINITIALIZED_SIZE);
         return NULL;
+    }
 
     return Py_BuildValue("(y#n)", s, buflen, size);
 }
@@ -726,7 +730,7 @@ unicode_decodeutf7stateful(PyObject *self, PyObject *args)
     const char *data;
     Py_ssize_t size;
     const char *errors = NULL;
-    Py_ssize_t consumed;
+    Py_ssize_t consumed = UNINITIALIZED_SIZE;
     PyObject *result;
 
     if (!PyArg_ParseTuple(args, "y#|z", &data, &size, &errors))
@@ -734,6 +738,7 @@ unicode_decodeutf7stateful(PyObject *self, PyObject *args)
 
     result = PyUnicode_DecodeUTF7Stateful(data, size, errors, &consumed);
     if (!result) {
+        assert(consumed == UNINITIALIZED_SIZE);
         return NULL;
     }
     return Py_BuildValue("(Nn)", result, consumed);
@@ -760,7 +765,7 @@ unicode_decodeutf8stateful(PyObject *self, PyObject *args)
     const char *data;
     Py_ssize_t size;
     const char *errors = NULL;
-    Py_ssize_t consumed = 123456789;
+    Py_ssize_t consumed = UNINITIALIZED_SIZE;
     PyObject *result;
 
     if (!PyArg_ParseTuple(args, "y#|z", &data, &size, &errors))
@@ -768,6 +773,7 @@ unicode_decodeutf8stateful(PyObject *self, PyObject *args)
 
     result = PyUnicode_DecodeUTF8Stateful(data, size, errors, &consumed);
     if (!result) {
+        assert(consumed == UNINITIALIZED_SIZE);
         return NULL;
     }
     return Py_BuildValue("(Nn)", result, consumed);
@@ -788,7 +794,7 @@ unicode_decodeutf32(PyObject *self, PyObject *args)
     const char *data;
     Py_ssize_t size;
     const char *errors = NULL;
-    int byteorder;
+    int byteorder = UNINITIALIZED_INT;
     PyObject *result;
 
     if (!PyArg_ParseTuple(args, "iy#|z", &byteorder, &data, &size, &errors))
@@ -808,8 +814,8 @@ unicode_decodeutf32stateful(PyObject *self, PyObject *args)
     const char *data;
     Py_ssize_t size;
     const char *errors = NULL;
-    int byteorder;
-    Py_ssize_t consumed;
+    int byteorder = UNINITIALIZED_INT;
+    Py_ssize_t consumed = UNINITIALIZED_SIZE;
     PyObject *result;
 
     if (!PyArg_ParseTuple(args, "iy#|z", &byteorder, &data, &size, &errors))
@@ -817,6 +823,7 @@ unicode_decodeutf32stateful(PyObject *self, PyObject *args)
 
     result = PyUnicode_DecodeUTF32Stateful(data, size, errors, &byteorder, &consumed);
     if (!result) {
+        assert(consumed == UNINITIALIZED_SIZE);
         return NULL;
     }
     return Py_BuildValue("(iNn)", byteorder, result, consumed);
@@ -837,7 +844,7 @@ unicode_decodeutf16(PyObject *self, PyObject *args)
     const char *data;
     Py_ssize_t size;
     const char *errors = NULL;
-    int byteorder = 0;
+    int byteorder = UNINITIALIZED_INT;
     PyObject *result;
 
     if (!PyArg_ParseTuple(args, "iy#|z", &byteorder, &data, &size, &errors))
@@ -857,8 +864,8 @@ unicode_decodeutf16stateful(PyObject *self, PyObject *args)
     const char *data;
     Py_ssize_t size;
     const char *errors = NULL;
-    int byteorder;
-    Py_ssize_t consumed;
+    int byteorder = UNINITIALIZED_INT;
+    Py_ssize_t consumed = UNINITIALIZED_SIZE;
     PyObject *result;
 
     if (!PyArg_ParseTuple(args, "iy#|z", &byteorder, &data, &size, &errors))
@@ -866,6 +873,7 @@ unicode_decodeutf16stateful(PyObject *self, PyObject *args)
 
     result = PyUnicode_DecodeUTF16Stateful(data, size, errors, &byteorder, &consumed);
     if (!result) {
+        assert(consumed == UNINITIALIZED_SIZE);
         return NULL;
     }
     return Py_BuildValue("(iNn)", byteorder, result, consumed);
@@ -1019,7 +1027,7 @@ unicode_decodembcsstateful(PyObject *self, PyObject *args)
     const char *data;
     Py_ssize_t size;
     const char *errors = NULL;
-    Py_ssize_t consumed;
+    Py_ssize_t consumed = UNINITIALIZED_SIZE;
     PyObject *result;
 
     if (!PyArg_ParseTuple(args, "y#|z", &data, &size, &errors))
@@ -1027,6 +1035,7 @@ unicode_decodembcsstateful(PyObject *self, PyObject *args)
 
     result = PyUnicode_DecodeMBCSStateful(data, size, errors, &consumed);
     if (!result) {
+        assert(consumed == UNINITIALIZED_SIZE);
         return NULL;
     }
     return Py_BuildValue("(Nn)", result, consumed);
@@ -1040,7 +1049,7 @@ unicode_decodecodepagestateful(PyObject *self, PyObject *args)
     const char *data;
     Py_ssize_t size;
     const char *errors = NULL;
-    Py_ssize_t consumed;
+    Py_ssize_t consumed = UNINITIALIZED_SIZE;
     PyObject *result;
 
     if (!PyArg_ParseTuple(args, "iy#|z", &code_page, &data, &size, &errors))
@@ -1048,6 +1057,7 @@ unicode_decodecodepagestateful(PyObject *self, PyObject *args)
 
     result = PyUnicode_DecodeCodePageStateful(code_page, data, size, errors, &consumed);
     if (!result) {
+        assert(consumed == UNINITIALIZED_SIZE);
         return NULL;
     }
     return Py_BuildValue("(Nn)", result, consumed);

--- a/Modules/_testcapi/util.h
+++ b/Modules/_testcapi/util.h
@@ -23,3 +23,10 @@
         assert(!PyErr_Occurred());          \
         return PyLong_FromSsize_t(_ret);    \
     } while (0)
+
+/* Marker to check that pointer value was set. */
+#define UNINITIALIZED_PTR ((void *)"uninitialized")
+/* Marker to check that Py_ssize_t value was set. */
+#define UNINITIALIZED_SIZE ((Py_ssize_t)987654321)
+/* Marker to check that integer value was set. */
+#define UNINITIALIZED_INT (123456789)

--- a/Modules/_testcapi/util.h
+++ b/Modules/_testcapi/util.h
@@ -27,6 +27,6 @@
 /* Marker to check that pointer value was set. */
 #define UNINITIALIZED_PTR ((void *)"uninitialized")
 /* Marker to check that Py_ssize_t value was set. */
-#define UNINITIALIZED_SIZE ((Py_ssize_t)987654321)
+#define UNINITIALIZED_SIZE ((Py_ssize_t)236892191)
 /* Marker to check that integer value was set. */
-#define UNINITIALIZED_INT (123456789)
+#define UNINITIALIZED_INT (63256717)

--- a/Modules/_testcapimodule.c
+++ b/Modules/_testcapimodule.c
@@ -217,10 +217,13 @@ test_dict_inner(int count)
         Py_DECREF(v);
     }
 
+    k = v = UNINITIALIZED_PTR;
     while (PyDict_Next(dict, &pos, &k, &v)) {
         PyObject *o;
         iterations++;
 
+        assert(k != UNINITIALIZED_PTR);
+        assert(v != UNINITIALIZED_PTR);
         i = PyLong_AS_LONG(v) + 1;
         o = PyLong_FromLong(i);
         if (o == NULL)
@@ -230,7 +233,10 @@ test_dict_inner(int count)
             return -1;
         }
         Py_DECREF(o);
+        k = v = UNINITIALIZED_PTR;
     }
+    assert(k == UNINITIALIZED_PTR);
+    assert(v == UNINITIALIZED_PTR);
 
     Py_DECREF(dict);
 
@@ -3118,7 +3124,7 @@ test_weakref_capi(PyObject *Py_UNUSED(module), PyObject *Py_UNUSED(args))
     assert(Py_REFCNT(obj) == refcnt);
 
     // test PyWeakref_GetRef(), reference is alive
-    PyObject *ref = Py_True;  // marker to check that value was set
+    PyObject *ref = UNINITIALIZED_PTR;
     assert(PyWeakref_GetRef(weakref, &ref) == 1);
     assert(ref == obj);
     assert(Py_REFCNT(obj) == (refcnt + 1));
@@ -3140,7 +3146,7 @@ test_weakref_capi(PyObject *Py_UNUSED(module), PyObject *Py_UNUSED(args))
     assert(PyWeakref_GET_OBJECT(weakref) == Py_None);
 
     // test PyWeakref_GetRef(), reference is dead
-    ref = Py_True;
+    ref = UNINITIALIZED_PTR;
     assert(PyWeakref_GetRef(weakref, &ref) == 0);
     assert(ref == NULL);
 
@@ -3152,7 +3158,7 @@ test_weakref_capi(PyObject *Py_UNUSED(module), PyObject *Py_UNUSED(args))
 
     // test PyWeakref_GetRef(), invalid type
     assert(!PyErr_Occurred());
-    ref = Py_True;
+    ref = UNINITIALIZED_PTR;
     assert(PyWeakref_GetRef(invalid_weakref, &ref) == -1);
     assert(PyErr_ExceptionMatches(PyExc_TypeError));
     PyErr_Clear();
@@ -3164,7 +3170,7 @@ test_weakref_capi(PyObject *Py_UNUSED(module), PyObject *Py_UNUSED(args))
     PyErr_Clear();
 
     // test PyWeakref_GetRef(NULL)
-    ref = Py_True;  // marker to check that value was set
+    ref = UNINITIALIZED_PTR;
     assert(PyWeakref_GetRef(NULL, &ref) == -1);
     assert(PyErr_ExceptionMatches(PyExc_SystemError));
     assert(ref == NULL);


### PR DESCRIPTION
Extended extraction from #108797. It will be backported, unlike to the main part of #108797.