### PR TITLE
gh-108732: include comprehension locals in frame.f_locals

### DIFF
--- a/Lib/test/test_listcomps.py
+++ b/Lib/test/test_listcomps.py
@@ -596,6 +596,13 @@ class ListComprehensionTest(unittest.TestCase):
         """
         self._check_in_scopes(code, {"value": [1, None]})
 
+    def test_frame_locals(self):
+        code = """
+            val = [sys._getframe().f_locals for a in [0]][0]["a"]
+        """
+        import sys
+        self._check_in_scopes(code, {"val": 0}, ns={"sys": sys})
+
 
 __test__ = {'doctests' : doctests}
 

--- a/Misc/NEWS.d/next/Core and Builtins/2023-09-06-13-28-42.gh-issue-108732.I6DkEQ.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2023-09-06-13-28-42.gh-issue-108732.I6DkEQ.rst
@@ -1,2 +1,2 @@
 Make iteration variables of module- and class-scoped comprehensions visible
-to pdb again.
+to pdb and other tools that use ``frame.f_locals`` again.

--- a/Misc/NEWS.d/next/Core and Builtins/2023-09-06-13-28-42.gh-issue-108732.I6DkEQ.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2023-09-06-13-28-42.gh-issue-108732.I6DkEQ.rst
@@ -1,0 +1,2 @@
+Make iteration variables of module- and class-scoped comprehensions visible
+to pdb again.

--- a/Objects/frameobject.c
+++ b/Objects/frameobject.c
@@ -25,10 +25,16 @@ static PyMemberDef frame_memberlist[] = {
 static PyObject *
 frame_getlocals(PyFrameObject *f, void *closure)
 {
-    if (PyFrame_FastToLocalsWithError(f) < 0)
-        return NULL;
-    PyObject *locals = f->f_frame->f_locals;
-    return Py_NewRef(locals);
+    if (f == NULL) {
+        PyErr_BadInternalCall();
+        return -1;
+    }
+    assert(!_PyFrame_IsIncomplete(f->f_frame));
+    PyObject *locals = _PyFrame_GetLocals(f->f_frame, 1);
+    if (locals) {
+        f->f_fast_as_locals = 1;
+    }
+    return locals;
 }
 
 int
@@ -1342,11 +1348,11 @@ PyFrame_GetVarString(PyFrameObject *frame, const char *name)
 int
 PyFrame_FastToLocalsWithError(PyFrameObject *f)
 {
-    assert(!_PyFrame_IsIncomplete(f->f_frame));
     if (f == NULL) {
         PyErr_BadInternalCall();
         return -1;
     }
+    assert(!_PyFrame_IsIncomplete(f->f_frame));
     int err = _PyFrame_FastToLocalsWithError(f->f_frame);
     if (err == 0) {
         f->f_fast_as_locals = 1;

--- a/Objects/frameobject.c
+++ b/Objects/frameobject.c
@@ -27,7 +27,7 @@ frame_getlocals(PyFrameObject *f, void *closure)
 {
     if (f == NULL) {
         PyErr_BadInternalCall();
-        return -1;
+        return NULL;
     }
     assert(!_PyFrame_IsIncomplete(f->f_frame));
     PyObject *locals = _PyFrame_GetLocals(f->f_frame, 1);


### PR DESCRIPTION
This applies the same fix that was made for `locals()` in https://github.com/python/cpython/pull/105715 to `sys._getframe().f_locals` as well. This is mostly relevant because pdb uses the latter, so this fix makes these comprehension locals (in module- or class-scope comprehensions) visible to pdb.

I also made one small fix in passing to `PyFrame_FastToLocalsWithError`; the assertion and the null check were in the wrong order, since the assertion would segfault before ever hitting the null check, if `f` were null. (Of course if assertions are turned off, the order doesn't matter either way.)

<!-- gh-issue-number: gh-108732 -->
* Issue: gh-108732
<!-- /gh-issue-number -->
