### PR TITLE
remove prev_instr manipulation from _Py_call_instrumentation_jump

### DIFF
--- a/Python/instrumentation.c
+++ b/Python/instrumentation.c
@@ -1078,7 +1078,6 @@ _Py_call_instrumentation_jump(
            event == PY_MONITORING_EVENT_BRANCH);
     assert(frame->prev_instr == instr);
     /* Event should occur after the jump */
-    frame->prev_instr = target;
     PyCodeObject *code = _PyFrame_GetCode(frame);
     int to = (int)(target - _PyCode_CODE(code));
     PyObject *to_obj = PyLong_FromLong(to * (int)sizeof(_Py_CODEUNIT));
@@ -1091,12 +1090,10 @@ _Py_call_instrumentation_jump(
     if (err) {
         return NULL;
     }
-    if (frame->prev_instr != target) {
+    if (frame->prev_instr != instr) {
         /* The callback has caused a jump (by setting the line number) */
         return frame->prev_instr;
     }
-    /* Reset prev_instr for INSTRUMENTED_LINE */
-    frame->prev_instr = instr;
     return target;
 }
 


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
