### PR TITLE
gh-109033: Return filename with os.utime errors

### DIFF
--- a/Lib/test/test_os.py
+++ b/Lib/test/test_os.py
@@ -913,6 +913,13 @@ class UtimeTests(unittest.TestCase):
             os.utime(self.fname, None)
         self._test_utime_current(set_time)
 
+    def test_utime_nonexistent(self):
+        now = time.time()
+        filename = 'nonexistent'
+        with self.assertRaises(FileNotFoundError) as cm:
+            os.utime(filename, (now, now))
+        self.assertEqual(cm.exception.filename, filename)
+
     def get_file_system(self, path):
         if sys.platform == 'win32':
             root = os.path.splitdrive(os.path.abspath(path))[0] + '\\'

--- a/Misc/NEWS.d/next/Library/2023-09-06-14-47-28.gh-issue-109033.piUzDx.rst
+++ b/Misc/NEWS.d/next/Library/2023-09-06-14-47-28.gh-issue-109033.piUzDx.rst
@@ -1,0 +1,2 @@
+Exceptions raised by os.utime builtin function now include the related
+filename

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -6307,11 +6307,7 @@ os_utime_impl(PyObject *module, path_t *path, PyObject *times, PyObject *ns,
         _Py_time_t_to_FILE_TIME(utime.mtime_s, utime.mtime_ns, &mtime);
     }
     if (!SetFileTime(hFile, NULL, &atime, &mtime)) {
-        /* Avoid putting the file name into the error here,
-           as that may confuse the user into believing that
-           something is wrong with the file, when it also
-           could be the time stamp that gives a problem. */
-        PyErr_SetFromWindowsErr(0);
+        path_error(path);
         CloseHandle(hFile);
         return NULL;
     }
@@ -6351,8 +6347,7 @@ os_utime_impl(PyObject *module, path_t *path, PyObject *times, PyObject *ns,
 #endif
 
     if (result < 0) {
-        /* see previous comment about not putting filename in error here */
-        posix_error();
+        path_error(path);
         return NULL;
     }
 


### PR DESCRIPTION
The filename was previously intentionally omitted from exception becuase "it might confuse the user". Uncaught exceptions are not generally a replacement for user-facing error messages, so obscuring this information only has the effect of making the programmer's life more difficult.

<!-- gh-issue-number: gh-109033 -->
* Issue: gh-109033
<!-- /gh-issue-number -->
