### PR TITLE
gh-107211: No longer export internal _PyLong_FromUid()

### DIFF
--- a/Modules/posixmodule.h
+++ b/Modules/posixmodule.h
@@ -2,31 +2,37 @@
 
 #ifndef Py_POSIXMODULE_H
 #define Py_POSIXMODULE_H
+#ifndef Py_LIMITED_API
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 #ifdef HAVE_SYS_TYPES_H
-#include <sys/types.h>
+#  include <sys/types.h>          // uid_t
 #endif
 
-#ifndef Py_LIMITED_API
 #ifndef MS_WINDOWS
-PyAPI_FUNC(PyObject *) _PyLong_FromUid(uid_t);
-PyAPI_FUNC(PyObject *) _PyLong_FromGid(gid_t);
-PyAPI_FUNC(int) _Py_Uid_Converter(PyObject *, uid_t *);
-PyAPI_FUNC(int) _Py_Gid_Converter(PyObject *, gid_t *);
-#endif /* MS_WINDOWS */
+extern PyObject* _PyLong_FromUid(uid_t);
 
-#if defined(PYPTHREAD_SIGMASK) || defined(HAVE_SIGWAIT) || \
-        defined(HAVE_SIGWAITINFO) || defined(HAVE_SIGTIMEDWAIT)
-# define HAVE_SIGSET_T
+// Export for 'grp' shared extension
+PyAPI_FUNC(PyObject*) _PyLong_FromGid(gid_t);
+
+// Export for '_posixsubprocess' shared extension
+PyAPI_FUNC(int) _Py_Uid_Converter(PyObject *, uid_t *);
+
+// Export for 'grp' shared extension
+PyAPI_FUNC(int) _Py_Gid_Converter(PyObject *, gid_t *);
+#endif   // !MS_WINDOWS
+
+#if (defined(PYPTHREAD_SIGMASK) || defined(HAVE_SIGWAIT) \
+     || defined(HAVE_SIGWAITINFO) || defined(HAVE_SIGTIMEDWAIT))
+#  define HAVE_SIGSET_T
 #endif
 
-PyAPI_FUNC(int) _Py_Sigset_Converter(PyObject *, void *);
-#endif /* Py_LIMITED_API */
+extern int _Py_Sigset_Converter(PyObject *, void *);
 
 #ifdef __cplusplus
 }
 #endif
-#endif /* !Py_POSIXMODULE_H */
+#endif   // !Py_LIMITED_API
+#endif   // !Py_POSIXMODULE_H


### PR DESCRIPTION
No longer export _PyLong_FromUid() and _Py_Sigset_Converter() internal C API function.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-107211 -->
* Issue: gh-107211
<!-- /gh-issue-number -->
