### PR TITLE
gh-108976: Make sure instrumentation line returns the correct opcode when instruction instrumentation is stripped

### DIFF
--- a/Lib/test/test_monitoring.py
+++ b/Lib/test/test_monitoring.py
@@ -1152,6 +1152,15 @@ class TestLineAndInstructionEvents(CheckEvents):
             ('instruction', 'func1', 14),
             ('line', 'get_events', 11)])
 
+    def test_gh108976(self):
+        sys.monitoring.use_tool_id(0, "test")
+        sys.monitoring.set_events(0, 0)
+        sys.monitoring.register_callback(0, E.LINE, lambda *args: sys.monitoring.set_events(0, 0))
+        sys.monitoring.register_callback(0, E.INSTRUCTION, lambda *args: 0)
+        sys.monitoring.set_events(0, E.LINE | E.INSTRUCTION)
+        sys.monitoring.set_events(0, 0)
+
+
 class TestInstallIncrementallly(MonitoringTestBase, unittest.TestCase):
 
     def check_events(self, func, must_include, tool=TEST_TOOL, recorders=(ExceptionRecorder,)):

--- a/Lib/test/test_pdb.py
+++ b/Lib/test/test_pdb.py
@@ -2198,6 +2198,27 @@ def test_pdb_issue_gh_101517():
     (Pdb) continue
     """
 
+def test_pdb_issue_gh_108976():
+    """See GH-108976
+
+    Make sure setting f_trace_opcodes = True won't crash pdb
+
+    >>> def test_function():
+    ...     import sys
+    ...     sys._getframe().f_trace_opcodes = True
+    ...     import pdb; pdb.Pdb(nosigint=True, readrc=False).set_trace()
+    ...     a = 1
+
+    >>> with PdbTestInput([  # doctest: +NORMALIZE_WHITESPACE
+    ...     'continue'
+    ... ]):
+    ...    test_function()
+    bdb.Bdb.dispatch: unknown debugging event: 'opcode'
+    > <doctest test.test_pdb.test_pdb_issue_gh_108976[0]>(5)test_function()
+    -> a = 1
+    (Pdb) continue
+    """
+
 def test_pdb_ambiguous_statements():
     """See GH-104301
 

--- a/Misc/NEWS.d/next/Core and Builtins/2023-09-07-00-22-55.gh-issue-108976.RivVn6.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2023-09-07-00-22-55.gh-issue-108976.RivVn6.rst
@@ -1,0 +1,1 @@
+Make sure instrumentation line returns the correct opcode when instruction instrumentation is stripped

--- a/Python/instrumentation.c
+++ b/Python/instrumentation.c
@@ -1190,6 +1190,14 @@ _Py_call_instrumentation_line(PyThreadState *tstate, _PyInterpreterFrame* frame,
                 if (err) {
                     return -1;
                 }
+                // If trace is disabled in trace function, we need to recalculate the original opcode
+                // of the current instruction because it might be INSTRUMENTED_INSTRUCTION before the
+                // trace function.
+                if (tstate->interp->sys_tracing_threads == 0) {
+                    if (original_opcode == INSTRUMENTED_INSTRUCTION) {
+                        original_opcode = instr->op.code;
+                    }
+                }
             }
         }
         tools &= (255 - (1 << PY_MONITORING_SYS_TRACE_ID));


### PR DESCRIPTION
`_Py_call_instrumentation_line` curently tries to get the original opcode before executing the trace function. The opcode can be `INSTRUMENT_INSTRUCTION` if instruction event is set. However, the trace function/monitoring callbacks can turn off the instruction event inside the function, which would invalidate the orignal opcode.

`line_data->original_opcode` won't help in this case as it will still store `INSTRUMENT_INSTRUCTION` - it won't be refreshed. So, in this case, we use the opcode directly if INSTRUCTION event is turned off on the code object entirely.

<!-- gh-issue-number: gh-108976 -->
* Issue: gh-108976
<!-- /gh-issue-number -->
