### PR TITLE
gh-109045: Remove remaining LIMITED_API_AVAILABLE checks in tests

### DIFF
--- a/Lib/test/support/__init__.py
+++ b/Lib/test/support/__init__.py
@@ -1090,8 +1090,7 @@ def requires_limited_api(test):
         import _testcapi
     except ImportError:
         return unittest.skip('needs _testcapi module')(test)
-    return unittest.skipUnless(
-        _testcapi.LIMITED_API_AVAILABLE, 'needs Limited API support')(test)
+    return test
 
 def requires_specialization(test):
     return unittest.skipUnless(

--- a/Modules/_testcapi/heaptype_relative.c
+++ b/Modules/_testcapi/heaptype_relative.c
@@ -3,8 +3,6 @@
 #include <stddef.h>               // max_align_t
 #include <string.h>               // memset
 
-#ifdef LIMITED_API_AVAILABLE
-
 static PyType_Slot empty_slots[] = {
     {0, NULL},
 };
@@ -339,5 +337,3 @@ _PyTestCapi_Init_HeaptypeRelative(PyObject *m) {
 
     return 0;
 }
-
-#endif // LIMITED_API_AVAILABLE

--- a/Modules/_testcapi/vectorcall_limited.c
+++ b/Modules/_testcapi/vectorcall_limited.c
@@ -1,10 +1,6 @@
 #define Py_LIMITED_API 0x030c0000 // 3.12
 #include "parts.h"
 
-#ifdef LIMITED_API_AVAILABLE
-
-
-
 /* Test Vectorcall in the limited API */
 
 static PyObject *
@@ -175,5 +171,3 @@ _PyTestCapi_Init_VectorcallLimited(PyObject *m) {
 
     return 0;
 }
-
-#endif // LIMITED_API_AVAILABLE

--- a/Modules/_testcapimodule.c
+++ b/Modules/_testcapimodule.c
@@ -3996,18 +3996,12 @@ PyInit__testcapi(void)
     if (_PyTestCapi_Init_PyAtomic(m) < 0) {
         return NULL;
     }
-
-#ifndef LIMITED_API_AVAILABLE
-    PyModule_AddObjectRef(m, "LIMITED_API_AVAILABLE", Py_False);
-#else
-    PyModule_AddObjectRef(m, "LIMITED_API_AVAILABLE", Py_True);
     if (_PyTestCapi_Init_VectorcallLimited(m) < 0) {
         return NULL;
     }
     if (_PyTestCapi_Init_HeaptypeRelative(m) < 0) {
         return NULL;
     }
-#endif
 
     PyState_AddModule(m, &_testcapimodule);
     return m;


### PR DESCRIPTION
Commit 13a00078b81776b23b0b6add69b848382240d1f2 (#108663) made all Python builds compatible with the Limited API, and removed the `LIMITED_API_AVAILABLE` flag. However, some tests were still checking for that flag, so they were now being incorrectly skipped. Remove these checks to let these tests run again.

Fixes #109045.

<!-- gh-issue-number: gh-109045 -->
* Issue: gh-109045
<!-- /gh-issue-number -->
