### PR TITLE
[3.11] gh-108915: Removes extra backslashes in str.split docstring (GH-109044)

### DIFF
--- a/Objects/clinic/unicodeobject.c.h
+++ b/Objects/clinic/unicodeobject.c.h
@@ -882,7 +882,7 @@ PyDoc_STRVAR(unicode_split__doc__,
 "    The separator used to split the string.\n"
 "\n"
 "    When set to None (the default value), will split on any whitespace\n"
-"    character (including \\\\n \\\\r \\\\t \\\\f and spaces) and will discard\n"
+"    character (including \\n \\r \\t \\f and spaces) and will discard\n"
 "    empty strings from the result.\n"
 "  maxsplit\n"
 "    Maximum number of splits (starting from the left).\n"
@@ -983,7 +983,7 @@ PyDoc_STRVAR(unicode_rsplit__doc__,
 "    The separator used to split the string.\n"
 "\n"
 "    When set to None (the default value), will split on any whitespace\n"
-"    character (including \\\\n \\\\r \\\\t \\\\f and spaces) and will discard\n"
+"    character (including \\n \\r \\t \\f and spaces) and will discard\n"
 "    empty strings from the result.\n"
 "  maxsplit\n"
 "    Maximum number of splits (starting from the left).\n"
@@ -1353,4 +1353,4 @@ skip_optional_pos:
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=b5dd7cefead9a8e7 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=11519887c1619a4e input=a9049054013a1b77]*/

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -13167,7 +13167,7 @@ str.split as unicode_split
         The separator used to split the string.
 
         When set to None (the default value), will split on any whitespace
-        character (including \\n \\r \\t \\f and spaces) and will discard
+        character (including \n \r \t \f and spaces) and will discard
         empty strings from the result.
     maxsplit: Py_ssize_t = -1
         Maximum number of splits (starting from the left).
@@ -13183,7 +13183,7 @@ the regular expression module.
 
 static PyObject *
 unicode_split_impl(PyObject *self, PyObject *sep, Py_ssize_t maxsplit)
-/*[clinic end generated code: output=3a65b1db356948dc input=906d953b44efc43b]*/
+/*[clinic end generated code: output=3a65b1db356948dc input=07b9040d98c5fe8d]*/
 {
     if (sep == Py_None)
         return split(self, NULL, maxsplit);


### PR DESCRIPTION
(cherry picked from commit e7d5433f944a5725aa82595f9251abfc8a63d333)

<!-- gh-issue-number: gh-108915 -->
* Issue: gh-108915
<!-- /gh-issue-number -->
