### PR TITLE
gh-103186: Suppress RuntimeWarning about unclosed async iterator in test_sys_settrace

### DIFF
--- a/Lib/test/test_sys_settrace.py
+++ b/Lib/test/test_sys_settrace.py
@@ -41,6 +41,20 @@ async def asynciter(iterable):
     for x in iterable:
         yield x
 
+def clean_asynciter(test):
+    @wraps(test)
+    async def wrapper(*args, **kwargs):
+        cleanups = []
+        def wrapped_asynciter(iterable):
+            it = asynciter(iterable)
+            cleanups.append(it.aclose)
+            return it
+        try:
+            return await test(*args, **kwargs, asynciter=wrapped_asynciter)
+        finally:
+            while cleanups:
+                await cleanups.pop()()
+    return wrapper
 
 # A very basic example.  If this fails, we're in deep trouble.
 def basic():
@@ -1937,7 +1951,11 @@ class JumpTestCase(unittest.TestCase):
 
     def run_test(self, func, jumpFrom, jumpTo, expected, error=None,
                  event='line', decorated=False, warning=None):
-        tracer = JumpTracer(func, jumpFrom, jumpTo, event, decorated)
+        wrapped = func
+        while hasattr(wrapped, '__wrapped__'):
+            wrapped = wrapped.__wrapped__
+
+        tracer = JumpTracer(wrapped, jumpFrom, jumpTo, event, decorated)
         sys.settrace(tracer.trace)
         output = []
 
@@ -1953,7 +1971,11 @@ class JumpTestCase(unittest.TestCase):
 
     def run_async_test(self, func, jumpFrom, jumpTo, expected, error=None,
                  event='line', decorated=False, warning=None):
-        tracer = JumpTracer(func, jumpFrom, jumpTo, event, decorated)
+        wrapped = func
+        while hasattr(wrapped, '__wrapped__'):
+            wrapped = wrapped.__wrapped__
+
+        tracer = JumpTracer(wrapped, jumpFrom, jumpTo, event, decorated)
         sys.settrace(tracer.trace)
         output = []
 
@@ -2024,7 +2046,8 @@ class JumpTestCase(unittest.TestCase):
         output.append(7)
 
     @async_jump_test(4, 5, [3, 5])
-    async def test_jump_out_of_async_for_block_forwards(output):
+    @clean_asynciter
+    async def test_jump_out_of_async_for_block_forwards(output, asynciter):
         for i in [1]:
             async for i in asynciter([1, 2]):
                 output.append(3)
@@ -2032,7 +2055,8 @@ class JumpTestCase(unittest.TestCase):
             output.append(5)
 
     @async_jump_test(5, 2, [2, 4, 2, 4, 5, 6])
-    async def test_jump_out_of_async_for_block_backwards(output):
+    @clean_asynciter
+    async def test_jump_out_of_async_for_block_backwards(output, asynciter):
         for i in [1]:
             output.append(2)
             async for i in asynciter([1]):


### PR DESCRIPTION
```
$ ./python -Wa -m test test_sys_settrace -m test_jump_out_of_async_for_block_forwards -m test_jump_out_of_async_for_block_backwards
...
/home/serhiy/py/cpython/Lib/test/support/__init__.py:758: RuntimeWarning: coroutine method 'aclose' of 'asynciter' was never awaited
  gc.collect()
RuntimeWarning: Enable tracemalloc to get the object allocation traceback
/home/serhiy/py/cpython/Lib/test/support/__init__.py:758: RuntimeWarning: coroutine method 'aclose' of 'asynciter' was never awaited
  gc.collect()
RuntimeWarning: Enable tracemalloc to get the object allocation traceback
```


<!-- gh-issue-number: gh-103186 -->
* Issue: gh-103186
<!-- /gh-issue-number -->
