### PR TITLE
gh-75743: Restore test_timeout.testConnectTimeout()

### DIFF
--- a/Lib/test/test_timeout.py
+++ b/Lib/test/test_timeout.py
@@ -183,12 +183,11 @@ class TCPTimeoutTestCase(TimeoutTestCase):
         #
         # -A INPUT -p tcp --destination-port 56666 -j DROP
         # -A INPUT -p udp --destination-port 56666 -j DROP
-        # -A INPUT -p tcp --destination-port 56667 -j RETURN
-        # -A INPUT -p udp --destination-port 56667 -j RETURN
+        # -A INPUT -p tcp --destination-port 56667 -j REJECT
+        # -A INPUT -p udp --destination-port 56667 -j REJECT
         #
-        # See pillar/base/firewall/snakebite.sls in
-        # https://github.com/python/psf-salt for the current configuration.
-        #
+        # See https://github.com/python/psf-salt/blob/main/pillar/base/firewall/snakebite.sls
+        # for the current configuration.
 
         skip = True
         sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)

--- a/Lib/test/test_timeout.py
+++ b/Lib/test/test_timeout.py
@@ -148,13 +148,12 @@ class TCPTimeoutTestCase(TimeoutTestCase):
     def tearDown(self):
         self.sock.close()
 
-    @unittest.skipIf(True, 'need to replace these hosts; see bpo-35518')
     def testConnectTimeout(self):
         # Testing connect timeout is tricky: we need to have IP connectivity
         # to a host that silently drops our packets.  We can't simulate this
         # from Python because it's a function of the underlying TCP/IP stack.
-        # So, the following Snakebite host has been defined:
-        blackhole = resolve_address('blackhole.snakebite.net', 56666)
+        # So, the following port on the pythontest.net host has been defined:
+        blackhole = resolve_address('pythontest.net', 56666)
 
         # Blackhole has been configured to silently drop any incoming packets.
         # No RSTs (for TCP) or ICMP UNREACH (for UDP/ICMP) will be sent back
@@ -166,7 +165,7 @@ class TCPTimeoutTestCase(TimeoutTestCase):
         # to firewalling or general network configuration.  In order to improve
         # our confidence in testing the blackhole, a corresponding 'whitehole'
         # has also been set up using one port higher:
-        whitehole = resolve_address('whitehole.snakebite.net', 56667)
+        whitehole = resolve_address('pythontest.net', 56667)
 
         # This address has been configured to immediately drop any incoming
         # packets as well, but it does it respectfully with regards to the
@@ -180,19 +179,15 @@ class TCPTimeoutTestCase(TimeoutTestCase):
         # timeframe).
 
         # For the records, the whitehole/blackhole configuration has been set
-        # up using the 'pf' firewall (available on BSDs), using the following:
+        # up using the 'iptables' firewall, using the following rules:
         #
-        #   ext_if="bge0"
+        # -A INPUT -p tcp --destination-port 56666 -j DROP
+        # -A INPUT -p udp --destination-port 56666 -j DROP
+        # -A INPUT -p tcp --destination-port 56667 -j RETURN
+        # -A INPUT -p udp --destination-port 56667 -j RETURN
         #
-        #   blackhole_ip="35.8.247.6"
-        #   whitehole_ip="35.8.247.6"
-        #   blackhole_port="56666"
-        #   whitehole_port="56667"
-        #
-        #   block return in log quick on $ext_if proto { tcp udp } \
-        #       from any to $whitehole_ip port $whitehole_port
-        #   block drop in log quick on $ext_if proto { tcp udp } \
-        #       from any to $blackhole_ip port $blackhole_port
+        # See pillar/base/firewall/snakebite.sls in
+        # https://github.com/python/psf-salt for the current configuration.
         #
 
         skip = True


### PR DESCRIPTION
This un-skips this test now that pythontest.net implements appropriate firewall rules for it.

Alternative to #109060

<!-- gh-issue-number: gh-75743 -->
* Issue: gh-75743
<!-- /gh-issue-number -->
