### PR TITLE
[3.11] gh-88943: Improve syntax error for non-ASCII character that follows a numerical literal (GH-109081)

### DIFF
--- a/Lib/test/test_grammar.py
+++ b/Lib/test/test_grammar.py
@@ -238,6 +238,10 @@ class TokenTests(unittest.TestCase):
             check(f"[{num}for x in ()]")
             check(f"{num}spam", error=True)
 
+            # gh-88943: Invalid non-ASCII character following a numerical literal.
+            with self.assertRaisesRegex(SyntaxError, r"invalid character '⁄' \(U\+2044\)"):
+                compile(f"{num}⁄7", "<testcase>", "eval")
+
             with warnings.catch_warnings():
                 warnings.filterwarnings('ignore', '"is" with a literal',
                                         SyntaxWarning)

--- a/Misc/NEWS.d/next/Core and Builtins/2023-09-07-16-05-36.gh-issue-88943.rH_X3W.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2023-09-07-16-05-36.gh-issue-88943.rH_X3W.rst
@@ -1,0 +1,3 @@
+Improve syntax error for non-ASCII character that follows a numerical
+literal. It now points on the invalid non-ASCII character, not on the valid
+numerical literal.

--- a/Parser/tokenizer.c
+++ b/Parser/tokenizer.c
@@ -1303,7 +1303,7 @@ verify_end_of_number(struct tok_state *tok, int c, const char *kind)
         tok_nextc(tok);
     }
     else /* In future releases, only error will remain. */
-    if (is_potential_identifier_char(c)) {
+    if (c < 128 && is_potential_identifier_char(c)) {
         tok_backup(tok, c);
         syntaxerror(tok, "invalid %s literal", kind);
         return 0;


### PR DESCRIPTION
It now points on the invalid non-ASCII character, not on the valid numerical literal.

(cherry picked from commit b2729e93e9d73503b1fda4ea4fecd77c58909091)


<!-- gh-issue-number: gh-88943 -->
* Issue: gh-88943
<!-- /gh-issue-number -->
