### PR TITLE
gh-109052: Use the base opcode when comparing code objects

### DIFF
--- a/Lib/test/test_code.py
+++ b/Lib/test/test_code.py
@@ -505,6 +505,25 @@ class CodeTest(unittest.TestCase):
         self.assertNotEqual(c, c1)
         self.assertNotEqual(hash(c), hash(c1))
 
+    @cpython_only
+    def test_code_equal_with_instrumentation(self):
+        """ GH-109052
+
+        Make sure the instrumentation doesn't affect the code equality
+        The validity of this test relies on the fact that "x is x" and
+        "x in x" have only one different instruction and the instructions
+        have the same argument.
+
+        """
+        code1 = compile("x is x", "example.py", "eval")
+        code2 = compile("x in x", "example.py", "eval")
+        sys._getframe().f_trace_opcodes = True
+        sys.settrace(lambda *args: None)
+        exec(code1, {'x': []})
+        exec(code2, {'x': []})
+        self.assertNotEqual(code1, code2)
+        sys.settrace(None)
+
 
 def isinterned(s):
     return s is sys.intern(('_' + s + '_')[1:-1])

--- a/Misc/NEWS.d/next/Core and Builtins/2023-09-07-18-49-01.gh-issue-109052.TBU4nC.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2023-09-07-18-49-01.gh-issue-109052.TBU4nC.rst
@@ -1,0 +1,1 @@
+Use the base opcode when comparing code objects to avoid interference from instrumentation

--- a/Objects/codeobject.c
+++ b/Objects/codeobject.c
@@ -1797,9 +1797,9 @@ code_richcompare(PyObject *self, PyObject *other, int op)
     for (int i = 0; i < Py_SIZE(co); i++) {
         _Py_CODEUNIT co_instr = _PyCode_CODE(co)[i];
         _Py_CODEUNIT cp_instr = _PyCode_CODE(cp)[i];
-        uint8_t co_code = co_instr.op.code;
+        uint8_t co_code = _Py_GetBaseOpcode(co, i);
         uint8_t co_arg = co_instr.op.arg;
-        uint8_t cp_code = cp_instr.op.code;
+        uint8_t cp_code = _Py_GetBaseOpcode(cp, i);
         uint8_t cp_arg = cp_instr.op.arg;
 
         if (co_code == ENTER_EXECUTOR) {

--- a/Objects/codeobject.c
+++ b/Objects/codeobject.c
@@ -1805,20 +1805,18 @@ code_richcompare(PyObject *self, PyObject *other, int op)
         if (co_code == ENTER_EXECUTOR) {
             const int exec_index = co_arg;
             _PyExecutorObject *exec = co->co_executors->executors[exec_index];
-            co_code = exec->vm_data.opcode;
+            co_code = _PyOpcode_Deopt[exec->vm_data.opcode];
             co_arg = exec->vm_data.oparg;
         }
         assert(co_code != ENTER_EXECUTOR);
-        co_code = _PyOpcode_Deopt[co_code];
 
         if (cp_code == ENTER_EXECUTOR) {
             const int exec_index = cp_arg;
             _PyExecutorObject *exec = cp->co_executors->executors[exec_index];
-            cp_code = exec->vm_data.opcode;
+            cp_code = _PyOpcode_Deopt[exec->vm_data.opcode];
             cp_arg = exec->vm_data.oparg;
         }
         assert(cp_code != ENTER_EXECUTOR);
-        cp_code = _PyOpcode_Deopt[cp_code];
 
         if (co_code != cp_code || co_arg != cp_arg) {
             goto unequal;


### PR DESCRIPTION
After instrumentation, the opcode of the code object would become `INSTRUMENTED_LINE` or `INSTRUMENTED_INSTRUCTION`, we should make sure to get the actual opcode when we compare them.

This also belongs to gh-107265.

<!-- gh-issue-number: gh-109052 -->
* Issue: gh-109052
<!-- /gh-issue-number -->
