### PR TITLE
gh-109115: Make virtual environments set the correct interpreter for pydoc3

### DIFF
--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -2365,7 +2365,7 @@ $(SCRIPT_IDLE): $(srcdir)/Tools/scripts/idle3
 
 $(SCRIPT_PYDOC): $(srcdir)/Tools/scripts/pydoc3
 	@$(MKDIR_P) $(BUILD_SCRIPTS_DIR)
-	sed -e "s,/usr/bin/env python3,$(EXENAME)," < $(srcdir)/Tools/scripts/pydoc3 > $@
+	cp $(srcdir)/Tools/scripts/pydoc3 $@
 	@chmod +x $@
 
 .PHONY: scripts

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -1634,6 +1634,7 @@ Stefan Schwarzer
 Dietmar Schwertberger
 Federico Schwindt
 Barry Scott
+Carvell Scott
 Steven Scott
 Nick Seidenman
 Michael Seifert


### PR DESCRIPTION
By default, /usr/bin/pydoc3 always uses the interpreter at /usr/bin/python3.x, which causes pydoc3 to fail to look up modules that are installed in virtual environments.

This change creates a small script to allow pydoc3 to present those modules' documentation correctly.

<!-- gh-issue-number: gh-109115 -->
* Issue: gh-109115
<!-- /gh-issue-number -->
