### PR TITLE
gh-107298: Document PyAPI_DATA() macro

### DIFF
--- a/Doc/c-api/intro.rst
+++ b/Doc/c-api/intro.rst
@@ -105,6 +105,28 @@ defined closer to where they are useful (e.g. :c:macro:`Py_RETURN_NONE`).
 Others of a more general utility are defined here.  This is not necessarily a
 complete listing.
 
+.. c:macro:: PyAPI_DATA(type)
+
+   Declare a variable of type *type* which should be exported by Python. The
+   macro should only be used in Python C API. Example::
+
+       PyAPI_DATA(const unsigned long) Py_Version;
+
+.. c:macro:: PyAPI_FUNC(type)
+
+   Declare a function with a return type *type* which should be exported by
+   Python. The macro should only be used in Python C API. Example::
+
+       PyAPI_FUNC(PyObject *) PyLong_FromLong(long);
+
+.. c:macro:: PyMODINIT_FUNC
+
+   Declare an extension module ``PyInit`` initialization function. The return
+   type is :c:expr:`PyObject*`. The macro should only be used in Python C API.
+   Example with the ``_ssl`` module::
+
+       PyMODINIT_FUNC PyInit__ssl(void)
+
 .. c:macro:: Py_ABS(x)
 
    Return the absolute value of ``x``.


### PR DESCRIPTION
Document PyAPI_DATA(), and PyAPI_FUNC() and PyMODINIT_FUNC macros in Doc/c-api/intro.rst. This change fix Sphinx warnings in Doc/using/configure.rst.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-107298 -->
* Issue: gh-107298
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--109129.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->