### PR TITLE
gh-109136: Fix summarize_stats.py script

### DIFF
--- a/Tools/scripts/summarize_stats.py
+++ b/Tools/scripts/summarize_stats.py
@@ -430,7 +430,7 @@ def emit_comparative_specialization_overview(base_opcode_stats, base_total, head
         )
 
 def get_stats_defines():
-    stats_path = os.path.join(os.path.dirname(__file__), "../../Include/pystats.h")
+    stats_path = os.path.join(os.path.dirname(__file__), "../../Include/cpython/pystats.h")
     with open(stats_path) as stats_src:
         defines = parse_kinds(stats_src, prefix="EVAL_CALL")
     return defines


### PR DESCRIPTION
The defines about some stats were moved from `Include/pystats.h` to `Include/cpython/pystats.h`, but the path was not updated in this script.

<!-- gh-issue-number: gh-109136 -->
* Issue: gh-109136
<!-- /gh-issue-number -->
