### PR TITLE
gh-108455: peg_generator: enable mypy's `--warn-unreachable` setting and `redundant-expr` error code

### DIFF
--- a/Tools/peg_generator/mypy.ini
+++ b/Tools/peg_generator/mypy.ini
@@ -8,8 +8,16 @@ python_version = 3.10
 
 # Be strict...
 strict = True
-enable_error_code = truthy-bool,ignore-without-code
+warn_unreachable = True
+enable_error_code = truthy-bool,ignore-without-code,redundant-expr
 
-# except for a few settings that can't yet be enabled:
+# This causes *many* false positives on the peg_generator
+# due to pegen.grammar.GrammarVisitor returning Any from visit() and generic_visit().
+# It would be possible to workaround the false positives using asserts,
+# but it would be pretty tedious, and probably isn't worth it.
 warn_return_any = False
-warn_unreachable = False
+
+# Not all of the strictest settings can be enabled
+# on generated Python code yet:
+[mypy-pegen.grammar_parser.*]
+disable_error_code = redundant-expr

--- a/Tools/peg_generator/pegen/ast_dump.py
+++ b/Tools/peg_generator/pegen/ast_dump.py
@@ -66,6 +66,4 @@ def ast_dump(
 
     if all(cls.__name__ != "AST" for cls in node.__class__.__mro__):
         raise TypeError("expected AST, got %r" % node.__class__.__name__)
-    if indent is not None and not isinstance(indent, str):
-        indent = " " * indent
     return _format(node)[0]

--- a/Tools/peg_generator/pegen/grammar.py
+++ b/Tools/peg_generator/pegen/grammar.py
@@ -112,8 +112,7 @@ class Leaf:
         return self.value
 
     def __iter__(self) -> Iterable[str]:
-        if False:
-            yield
+        yield from ()
 
 
 class NameLeaf(Leaf):
@@ -335,8 +334,7 @@ class Cut:
         return f"~"
 
     def __iter__(self) -> Iterator[Tuple[str, str]]:
-        if False:
-            yield
+        yield from ()
 
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, Cut):


### PR DESCRIPTION
Closes #108455

The changes to the `.py` files are all due to branches that mypy flagged as being unreachable.

<!-- gh-issue-number: gh-108455 -->
* Issue: gh-108455
<!-- /gh-issue-number -->
