### PR TITLE
gh-109164: Replace `getopt` with `argparse` in pdb

### DIFF
--- a/Lib/pdb.py
+++ b/Lib/pdb.py
@@ -2079,11 +2079,13 @@ def main():
 
     parser = argparse.ArgumentParser(prog="pdb",
                                      description=_usage,
-                                     formatter_class=argparse.RawDescriptionHelpFormatter)
+                                     formatter_class=argparse.RawDescriptionHelpFormatter,
+                                     allow_abbrev=False)
 
-    parser.add_argument('-c', '--command', action='append', default=[])
-    parser.add_argument('-m', action='store_true')
-    parser.add_argument('pyfile', nargs=1)
+    parser.add_argument('-c', '--command', action='append', default=[], metavar='command')
+    grp = parser.add_mutually_exclusive_group(required=True)
+    grp.add_argument('-m', metavar='module')
+    grp.add_argument('pyfile', nargs='?')
     parser.add_argument('args', nargs="*")
 
     if len(sys.argv) == 1:
@@ -2092,12 +2094,16 @@ def main():
 
     opts = parser.parse_args()
 
-    cls = _ModuleTarget if opts.m else _ScriptTarget
-    target = cls(opts.pyfile[0])
+    if opts.m:
+        file = opts.m
+        target = _ModuleTarget(file)
+    else:
+        file = opts.pyfile
+        target = _ScriptTarget(opts.pyfile[0])
 
     target.check()
 
-    sys.argv[:] = opts.pyfile + opts.args  # Hide "pdb.py" and pdb options from argument list
+    sys.argv[:] = [file] + opts.args  # Hide "pdb.py" and pdb options from argument list
 
     # Note on saving/restoring sys.argv: it's a good idea when sys.argv was
     # modified by the script being debugged. It's a bad idea when it was

--- a/Lib/pdb.py
+++ b/Lib/pdb.py
@@ -2083,9 +2083,9 @@ def main():
                                      allow_abbrev=False)
 
     parser.add_argument('-c', '--command', action='append', default=[], metavar='command')
-    grp = parser.add_mutually_exclusive_group(required=True)
-    grp.add_argument('-m', metavar='module')
-    grp.add_argument('pyfile', nargs='?')
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument('-m', metavar='module')
+    group.add_argument('pyfile', nargs='?')
     parser.add_argument('args', nargs="*")
 
     if len(sys.argv) == 1:
@@ -2099,7 +2099,7 @@ def main():
         target = _ModuleTarget(file)
     else:
         file = opts.pyfile
-        target = _ScriptTarget(opts.pyfile[0])
+        target = _ScriptTarget(file)
 
     target.check()
 

--- a/Lib/pdb.py
+++ b/Lib/pdb.py
@@ -2089,8 +2089,8 @@ def main():
     parser.add_argument('args', nargs="*")
 
     if len(sys.argv) == 1:
-        # If no arguments were given (python -m pdb), print help message
-        # Without this check, argparse would only complain about missing required arguments
+        # If no arguments were given (python -m pdb), print the whole help message.
+        # Without this check, argparse would only complain about missing required arguments.
         parser.print_help()
         sys.exit(2)
 

--- a/Lib/pdb.py
+++ b/Lib/pdb.py
@@ -2089,6 +2089,8 @@ def main():
     parser.add_argument('args', nargs="*")
 
     if len(sys.argv) == 1:
+        # If no arguments were given (python -m pdb), print help message
+        # Without this check, argparse would only complain about missing required arguments
         parser.print_help()
         sys.exit(2)
 

--- a/Misc/NEWS.d/next/Library/2023-09-08-22-26-26.gh-issue-109164.-9BFWR.rst
+++ b/Misc/NEWS.d/next/Library/2023-09-08-22-26-26.gh-issue-109164.-9BFWR.rst
@@ -1,0 +1,1 @@
+Replace getopt with argparse for parsing arguments in :mod:`pdb`

--- a/Misc/NEWS.d/next/Library/2023-09-08-22-26-26.gh-issue-109164.-9BFWR.rst
+++ b/Misc/NEWS.d/next/Library/2023-09-08-22-26-26.gh-issue-109164.-9BFWR.rst
@@ -1,1 +1,1 @@
-Replace getopt with argparse for parsing arguments in :mod:`pdb`
+:mod:`pdb`: Replace :mod:`getopt` with :mod:`argparse` for parsing command line arguments.


### PR DESCRIPTION
The behavior is almost identical - except for the minor difference in help message. Switching to `argparse` makes the code cleaner and easier to read (especially to people who are already familiar with `argparse`).

<!-- gh-issue-number: gh-109164 -->
* Issue: gh-109164
<!-- /gh-issue-number -->
