### PR TITLE
gh-109182: Fix SyntaxWarning in `test_listcomps.py`

### DIFF
--- a/Lib/test/test_listcomps.py
+++ b/Lib/test/test_listcomps.py
@@ -579,7 +579,7 @@ class ListComprehensionTest(unittest.TestCase):
         code = """
             def f(value):
                 try:
-                    [{func}(value) for value in value]
+                    [(value) for value in value]
                 finally:
                     return value
             ret = f(["a"])


### PR DESCRIPTION
Looks like it was copied from `test_comp_in_try_except`, but since `finally` does not need failing/not failing case, I think it is safe to just remove the missing template param.

<!-- gh-issue-number: gh-109182 -->
* Issue: gh-109182
<!-- /gh-issue-number -->
