### PR TITLE
gh-109118: Disallow nested scopes within PEP 695 scopes within classes

### DIFF
--- a/Lib/test/test_type_params.py
+++ b/Lib/test/test_type_params.py
@@ -479,7 +479,7 @@ class TypeParamsAccessTest(unittest.TestCase):
                                     "Cannot use comprehension in annotation scope within class scope"):
             run_code(code)
 
-    def test_lambda_in_generic_alias(self):
+    def test_nested_scope_in_generic_alias(self):
         code = """
             class C[T]:
                 T = "class"

--- a/Lib/test/test_type_params.py
+++ b/Lib/test/test_type_params.py
@@ -412,6 +412,32 @@ class TypeParamsAccessTest(unittest.TestCase):
         func, = T.__bound__
         self.assertEqual(func(), 1)
 
+    def test_gen_exp_in_nested_class(self):
+        class C[T]:
+            T = "class"
+            class Inner(make_base(T for _ in (1,)), make_base(T)):
+                pass
+        T, = C.__type_params__
+        base1, base2 = C.Inner.__bases__
+        self.assertEqual(list(base1.__arg__), [T])
+        self.assertEqual(base2.__arg__, "class")
+
+    def test_gen_exp_in_nested_generic_class(self):
+        class C[T]:
+            T = "class"
+            class Inner[U](make_base(T for _ in (1,)), make_base(T)):
+                pass
+        T, = C.__type_params__
+        base1, base2, _ = C.Inner.__bases__
+        self.assertEqual(list(base1.__arg__), [T])
+        self.assertEqual(base2.__arg__, "class")
+
+
+def make_base(arg):
+    class Base:
+        __arg__ = arg
+    return Base
+
 
 def global_generic_func[T]():
     pass

--- a/Lib/test/test_type_params.py
+++ b/Lib/test/test_type_params.py
@@ -413,23 +413,63 @@ class TypeParamsAccessTest(unittest.TestCase):
         self.assertEqual(func(), 1)
 
     def test_gen_exp_in_nested_class(self):
-        class C[T]:
-            T = "class"
-            class Inner(make_base(T for _ in (1,)), make_base(T)):
-                pass
+        code = """
+            from test.test_type_params import make_base
+
+            class C[T]:
+                T = "class"
+                class Inner(make_base(T for _ in (1,)), make_base(T)):
+                    pass
+        """
+        C = run_code(code)["C"]
         T, = C.__type_params__
         base1, base2 = C.Inner.__bases__
         self.assertEqual(list(base1.__arg__), [T])
         self.assertEqual(base2.__arg__, "class")
 
     def test_gen_exp_in_nested_generic_class(self):
-        class C[T]:
-            T = "class"
-            class Inner[U](make_base(T for _ in (1,)), make_base(T)):
-                pass
+        code = """
+            from test.test_type_params import make_base
+
+            class C[T]:
+                T = "class"
+                class Inner[U](make_base(T for _ in (1,)), make_base(T)):
+                    pass
+        """
+        C = run_code(code)["C"]
         T, = C.__type_params__
         base1, base2, _ = C.Inner.__bases__
         self.assertEqual(list(base1.__arg__), [T])
+        self.assertEqual(base2.__arg__, "class")
+
+    def test_listcomp_in_nested_class(self):
+        code = """
+            from test.test_type_params import make_base
+
+            class C[T]:
+                T = "class"
+                class Inner(make_base([T for _ in (1,)]), make_base(T)):
+                    pass
+        """
+        C = run_code(code)["C"]
+        T, = C.__type_params__
+        base1, base2 = C.Inner.__bases__
+        self.assertEqual(base1.__arg__, [T])
+        self.assertEqual(base2.__arg__, "class")
+
+    def test_listcomp_in_nested_generic_class(self):
+        code = """
+            from test.test_type_params import make_base
+
+            class C[T]:
+                T = "class"
+                class Inner[U](make_base([T for _ in (1,)]), make_base(T)):
+                    pass
+        """
+        C = run_code(code)["C"]
+        T, = C.__type_params__
+        base1, base2, _ = C.Inner.__bases__
+        self.assertEqual(base1.__arg__, [T])
         self.assertEqual(base2.__arg__, "class")
 
 

--- a/Misc/NEWS.d/next/Core and Builtins/2023-09-09-12-49-46.gh-issue-109118.gx0X4h.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2023-09-09-12-49-46.gh-issue-109118.gx0X4h.rst
@@ -1,0 +1,2 @@
+Disallow nested scopes (lambdas, generator expressions, and comprehensions)
+within PEP 695 annotation scopes that are nested within classes.

--- a/Python/symtable.c
+++ b/Python/symtable.c
@@ -2011,6 +2011,17 @@ symtable_visit_expr(struct symtable *st, expr_ty e)
         VISIT(st, expr, e->v.UnaryOp.operand);
         break;
     case Lambda_kind: {
+        if (st->st_cur->ste_can_see_class_scope) {
+            // gh-109118
+            PyErr_Format(PyExc_SyntaxError,
+                         "Cannot use lambda in annotation scope within class scope");
+            PyErr_RangedSyntaxLocationObject(st->st_filename,
+                                              e->lineno,
+                                              e->col_offset + 1,
+                                              e->end_lineno,
+                                              e->end_col_offset + 1);
+            VISIT_QUIT(st, 0);
+        }
         if (e->v.Lambda.args->defaults)
             VISIT_SEQ(st, expr, e->v.Lambda.args->defaults);
         if (e->v.Lambda.args->kw_defaults)
@@ -2460,6 +2471,18 @@ symtable_handle_comprehension(struct symtable *st, expr_ty e,
                               identifier scope_name, asdl_comprehension_seq *generators,
                               expr_ty elt, expr_ty value)
 {
+    if (st->st_cur->ste_can_see_class_scope) {
+        // gh-109118
+        PyErr_Format(PyExc_SyntaxError,
+                     "Cannot use comprehension in annotation scope within class scope");
+        PyErr_RangedSyntaxLocationObject(st->st_filename,
+                                         e->lineno,
+                                         e->col_offset + 1,
+                                         e->end_lineno,
+                                         e->end_col_offset + 1);
+        VISIT_QUIT(st, 0);
+    }
+
     int is_generator = (e->kind == GeneratorExp_kind);
     comprehension_ty outermost = ((comprehension_ty)
                                     asdl_seq_GET(generators, 0));


### PR DESCRIPTION
Fixes #109118. Fixes #109194.

See https://github.com/python/cpython/issues/109118#issuecomment-1712587366.

<!-- gh-issue-number: gh-109118 -->
* Issue: gh-109118
<!-- /gh-issue-number -->
