### PR TITLE
Improve the sieve() recipe in the itertools docs

### DIFF
--- a/Doc/library/itertools.rst
+++ b/Doc/library/itertools.rst
@@ -1030,13 +1030,16 @@ The following recipes have a more mathematical flavor:
    def sieve(n):
        "Primes less than n."
        # sieve(30) --> 2 3 5 7 11 13 17 19 23 29
+       if n > 2:
+           yield 2
+       start = 3
        data = bytearray((0, 1)) * (n // 2)
-       data[:3] = 0, 0, 0
        limit = math.isqrt(n) + 1
-       for p in compress(range(limit), data):
+       for p in iter_index(data, 1, start, limit):
+           yield from iter_index(data, 1, start, p*p)
            data[p*p : n : p+p] = bytes(len(range(p*p, n, p+p)))
-       data[2] = 1
-       return iter_index(data, 1) if n > 2 else iter([])
+           start = p*p
+       yield from iter_index(data, 1, start)
 
    def factor(n):
        "Prime factors of n."


### PR DESCRIPTION
The old version fully marked the entire primes table before yielding its first value.  Now subsequences of primes are yielded as soon as the subsequence becomes fully marked.  This improves responsiveness — the first call to `next()` returns more quickly.  And since the work is done lazily, the factor() recipe saves work when small factors reduce the search space. For example `factor(12**20)` is now several times faster.

The old version did some perplexing manipulations to the data array, `data[:3] = 0, 0, 0` and `data[2] = 1`.  The new version is straight forward and has clean loop invariants:
* `data[start : p*p]` has valid primes that have not yet been yielded
* `data[p*p : n]` still needs to be marked for multiples of `p`.

The new version is easy experiment with and can be easily changedto the simplest version of the algorithm that isn't lazy and hasn't optimized away the even composites.

```
def sieve(n):
       start = 2
       data = bytearray([1]) * n
       limit = math.isqrt(n) + 1
       for p in iter_index(data, 1, start, limit):
           data[p*p : n : p] = bytes(len(range(p*p, n, p)))
       yield from iter_index(data, 1, start)
```

<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--109199.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->