### PR TITLE
gh-109054: Don't use libatomic on cross-compilation

### DIFF
--- a/configure
+++ b/configure
@@ -27774,7 +27774,7 @@ then :
 else $as_nop
   if test "$cross_compiling" = yes
 then :
-  ac_cv_libatomic_needed=yes
+    ac_cv_libatomic_needed=no
 else $as_nop
   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
@@ -27811,16 +27811,13 @@ int main()
 _ACEOF
 if ac_fn_c_try_run "$LINENO"
 then :
-
   ac_cv_libatomic_needed=no
-
 else $as_nop
-  ac_cv_libatomic_needed=yes
+    ac_cv_libatomic_needed=yes
 fi
 rm -f core *.core core.conftest.* gmon.out bb.out conftest$ac_exeext \
   conftest.$ac_objext conftest.beam conftest.$ac_ext
 fi
-
 
 fi
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_libatomic_needed" >&5

--- a/configure.ac
+++ b/configure.ac
@@ -7007,9 +7007,10 @@ int main()
     }
     return 0; // all good
 }
-]])],[
-  ac_cv_libatomic_needed=no
-],[ac_cv_libatomic_needed=yes],[ac_cv_libatomic_needed=yes])
+]])],
+  [ac_cv_libatomic_needed=no],  dnl build succeeded
+  [ac_cv_libatomic_needed=yes], dnl build failed
+  [ac_cv_libatomic_needed=no])  dnl cross compilation
 ])
 
 AS_VAR_IF([ac_cv_libatomic_needed], [yes],


### PR DESCRIPTION
configure no longer uses libatomic by default when Python is cross-compiled. The LIBATOMIC variable can be set manually in this case:

    ./configure LIBATOMIC="-latomic" (...)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-109054 -->
* Issue: gh-109054
<!-- /gh-issue-number -->
