### PR TITLE
gh-109162: libregrtest: add worker.py

### DIFF
--- a/Lib/test/libregrtest/cmdline.py
+++ b/Lib/test/libregrtest/cmdline.py
@@ -216,7 +216,6 @@ def _create_parser():
     group.add_argument('--wait', action='store_true',
                        help='wait for user input, e.g., allow a debugger '
                             'to be attached')
-    group.add_argument('--worker-json', metavar='ARGS')
     group.add_argument('-S', '--start', metavar='START',
                        help='the name of the test at which to start.' +
                             more_details)

--- a/Lib/test/libregrtest/refleak.py
+++ b/Lib/test/libregrtest/refleak.py
@@ -68,7 +68,6 @@ def runtest_refleak(test_name, test_func,
     warmups = hunt_refleak.warmups
     runs = hunt_refleak.runs
     filename = hunt_refleak.filename
-    filename = os.path.join(os_helper.SAVEDCWD, filename)
     repcount = warmups + runs
 
     # Pre-allocate to ensure that the loop doesn't allocate anything new

--- a/Lib/test/libregrtest/results.py
+++ b/Lib/test/libregrtest/results.py
@@ -2,9 +2,10 @@ import sys
 from test.support import TestStats
 
 from test.libregrtest.runtest import (
-    TestName, TestTuple, TestList, FilterDict, StrPath, State,
+    TestName, TestTuple, TestList, FilterDict, State,
     TestResult, RunTests)
-from test.libregrtest.utils import printlist, count, format_duration
+from test.libregrtest.utils import (
+    printlist, count, format_duration, StrPath)
 
 
 EXITCODE_BAD_TEST = 2

--- a/Lib/test/libregrtest/setup.py
+++ b/Lib/test/libregrtest/setup.py
@@ -11,8 +11,8 @@ try:
 except ImportError:
     gc = None
 
-from test.libregrtest.utils import (setup_unraisable_hook,
-                                    setup_threading_excepthook)
+from test.libregrtest.utils import (
+    setup_unraisable_hook, setup_threading_excepthook, fix_umask)
 
 
 UNICODE_GUARD_ENV = "PYTHONREGRTEST_UNICODE_GUARD"
@@ -26,6 +26,8 @@ def setup_test_dir(testdir: str | None) -> None:
 
 
 def setup_tests(runtests):
+    fix_umask()
+
     try:
         stderr_fd = sys.__stderr__.fileno()
     except (ValueError, AttributeError):
@@ -102,7 +104,7 @@ def setup_tests(runtests):
         support.SHORT_TIMEOUT = min(support.SHORT_TIMEOUT, timeout)
         support.LONG_TIMEOUT = min(support.LONG_TIMEOUT, timeout)
 
-    if runtests.junit_filename:
+    if runtests.use_junit:
         from test.support.testresult import RegressionTestResult
         RegressionTestResult.USE_XML = True
 

--- a/Lib/test/libregrtest/worker.py
+++ b/Lib/test/libregrtest/worker.py
@@ -1,0 +1,93 @@
+import subprocess
+import sys
+import os
+from typing import TextIO, NoReturn
+
+from test import support
+from test.support import os_helper
+
+from test.libregrtest.setup import setup_tests, setup_test_dir
+from test.libregrtest.runtest import (
+    run_single_test, StrJSON, FilterTuple, RunTests)
+from test.libregrtest.utils import get_work_dir, exit_timeout, StrPath
+
+
+USE_PROCESS_GROUP = (hasattr(os, "setsid") and hasattr(os, "killpg"))
+
+
+def create_worker_process(runtests: RunTests,
+                          output_file: TextIO,
+                          tmp_dir: StrPath | None = None) -> subprocess.Popen:
+    python_cmd = runtests.python_cmd
+    worker_json = runtests.as_json()
+
+    if python_cmd is not None:
+        executable = python_cmd
+    else:
+        executable = [sys.executable]
+    cmd = [*executable, *support.args_from_interpreter_flags(),
+           '-u',    # Unbuffered stdout and stderr
+           '-m', 'test.libregrtest.worker',
+           worker_json]
+
+    env = dict(os.environ)
+    if tmp_dir is not None:
+        env['TMPDIR'] = tmp_dir
+        env['TEMP'] = tmp_dir
+        env['TMP'] = tmp_dir
+
+    # Running the child from the same working directory as regrtest's original
+    # invocation ensures that TEMPDIR for the child is the same when
+    # sysconfig.is_python_build() is true. See issue 15300.
+    kw = dict(
+        env=env,
+        stdout=output_file,
+        # bpo-45410: Write stderr into stdout to keep messages order
+        stderr=output_file,
+        text=True,
+        close_fds=(os.name != 'nt'),
+    )
+    if USE_PROCESS_GROUP:
+        kw['start_new_session'] = True
+    return subprocess.Popen(cmd, **kw)
+
+
+def worker_process(worker_json: StrJSON) -> NoReturn:
+    runtests = RunTests.from_json(worker_json)
+    test_name = runtests.tests[0]
+    match_tests: FilterTuple | None = runtests.match_tests
+
+    setup_test_dir(runtests.test_dir)
+    setup_tests(runtests)
+
+    if runtests.rerun:
+        if match_tests:
+            matching = "matching: " + ", ".join(match_tests)
+            print(f"Re-running {test_name} in verbose mode ({matching})", flush=True)
+        else:
+            print(f"Re-running {test_name} in verbose mode", flush=True)
+
+    result = run_single_test(test_name, runtests)
+    print()   # Force a newline (just in case)
+
+    # Serialize TestResult as dict in JSON
+    result.write_json(sys.stdout)
+    sys.stdout.flush()
+    sys.exit(0)
+
+
+def main():
+    if len(sys.argv) != 2:
+        print("usage: python -m test.libregrtest.worker JSON")
+        sys.exit(1)
+    worker_json = sys.argv[1]
+
+    work_dir = get_work_dir(worker=True)
+
+    with exit_timeout():
+        with os_helper.temp_cwd(work_dir, quiet=True):
+            worker_process(worker_json)
+
+
+if __name__ == "__main__":
+    main()

--- a/Lib/test/test_regrtest.py
+++ b/Lib/test/test_regrtest.py
@@ -75,11 +75,6 @@ class ParseArgsTestCase(unittest.TestCase):
         ns = libregrtest._parse_args(['--wait'])
         self.assertTrue(ns.wait)
 
-    def test_worker_json(self):
-        ns = libregrtest._parse_args(['--worker-json', '[[], {}]'])
-        self.assertEqual(ns.worker_json, '[[], {}]')
-        self.checkError(['--worker-json'], 'expected one argument')
-
     def test_start(self):
         for opt in '-S', '--start':
             with self.subTest(opt=opt):


### PR DESCRIPTION
Add new worker.py file:

* Move create_worker_process() and worker_process() to this file.
* Add main() function to worker.py. create_worker_process() now runs the command: "python -m test.libregrtest.worker JSON".
* create_worker_process() now starts the worker process in the current working directory. Regrtest now gets the absolute path of the reflog.txt filename: -R command line option filename.
* Remove --worker-json command line option. Remove test_regrtest.test_worker_json().

Related changes:

* Add write_json() and from_json() methods to TestResult.
* Rename select_temp_dir() to get_temp_dir() and move it to utils.py.
* Rename make_temp_dir() to get_work_dir() and move it to utils.py. It no longer calls os.makedirs(): Regrtest.main() now calls it.
* Move fix_umask() to utils.py. The function is now called by setup_tests().
* Move StrPath to utils.py.
* RunTests: Replace junit_filename (StrPath) with use_junit (bool).

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-109162 -->
* Issue: gh-109162
<!-- /gh-issue-number -->
