### PR TITLE
gh-109237: Fix test_site for non-ASCII working directory

### DIFF
--- a/Lib/test/test_site.py
+++ b/Lib/test/test_site.py
@@ -576,7 +576,7 @@ class _pthFileTests(unittest.TestCase):
                 _pth_file = os.path.splitext(exe_file)[0] + '._pth'
             else:
                 _pth_file = os.path.splitext(dll_file)[0] + '._pth'
-            with open(_pth_file, 'w') as f:
+            with open(_pth_file, 'w', encoding='utf8') as f:
                 for line in lines:
                     print(line, file=f)
             return exe_file
@@ -613,7 +613,7 @@ class _pthFileTests(unittest.TestCase):
             os.path.dirname(exe_file),
             pth_lines)
 
-        output = subprocess.check_output([exe_file, '-c',
+        output = subprocess.check_output([exe_file, '-X', 'utf8', '-c',
             'import sys; print("\\n".join(sys.path) if sys.flags.no_site else "")'
         ], encoding='utf-8', errors='surrogateescape')
         actual_sys_path = output.rstrip().split('\n')

--- a/Misc/NEWS.d/next/Tests/2023-09-10-22-32-20.gh-issue-109237.SvgKwD.rst
+++ b/Misc/NEWS.d/next/Tests/2023-09-10-22-32-20.gh-issue-109237.SvgKwD.rst
@@ -1,0 +1,4 @@
+Fix ``test_site.test_underpth_basic()`` when the working directory contains
+at least one non-ASCII character: encode the ``._pth`` file to UTF-8 and
+enable the UTF-8 Mode to use UTF-8 for the child process stdout. Patch by
+Victor Stinner.


### PR DESCRIPTION
Fix test_site.test_underpth_basic() when the working directory contains at least one non-ASCII character: encode the "._pth" file to UTF-8 and enable the UTF-8 Mode to use UTF-8 for the child process stdout.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-109237 -->
* Issue: gh-109237
<!-- /gh-issue-number -->
