### PR TITLE
GH-80789: Get rid of the ``ensurepip`` infra for many wheels

### DIFF
--- a/Lib/ensurepip/__init__.py
+++ b/Lib/ensurepip/__init__.py
@@ -24,15 +24,16 @@ else:
 
 def _find_wheel_pkg_dir_pip():
     if _WHEEL_PKG_DIR is None:
+        # NOTE: The compile-time `WHEEL_PKG_DIR` is unset so there is no place
+        # NOTE: for looking up the wheels.
         return None
 
     dist_matching_wheels = _WHEEL_PKG_DIR.glob('pip-*.whl')
     try:
         last_matching_dist_wheel = sorted(dist_matching_wheels)[-1]
-    except IndexError as index_err:
-        raise LookupError(
-            '`WHEEL_PKG_DIR` does not contain any wheel files for `pip`.',
-        ) from index_err
+    except IndexError:
+        # NOTE: `WHEEL_PKG_DIR` does not contain any wheel files for `pip`.
+        return None
 
     return nullcontext(last_matching_dist_wheel)
 

--- a/Lib/ensurepip/__init__.py
+++ b/Lib/ensurepip/__init__.py
@@ -171,7 +171,7 @@ def _bootstrap(*, root=None, upgrade=False, user=False,
         if verbosity:
             args += ["-" + "v" * verbosity]
 
-        return _run_pip([*args, "pip"], [os.fsencode(tmp_wheel_path)])
+        return _run_pip([*args, "pip"], [str(tmp_wheel_path)])
 
 
 def _uninstall_helper(*, verbosity=0):

--- a/Lib/ensurepip/__init__.py
+++ b/Lib/ensurepip/__init__.py
@@ -5,15 +5,13 @@ import subprocess
 import sys
 import sysconfig
 import tempfile
+from contextlib import suppress
+from functools import cache
 from importlib import resources
 
 
 __all__ = ["version", "bootstrap"]
-_PACKAGE_NAMES = ('pip',)
 _PIP_VERSION = "23.3.2"
-_PROJECTS = [
-    ("pip", _PIP_VERSION, "py3"),
-]
 
 # Packages bundled in ensurepip._bundled have wheel_name set.
 # Packages from WHEEL_PKG_DIR have wheel_path set.
@@ -27,8 +25,13 @@ _Package = collections.namedtuple('Package',
 _WHEEL_PKG_DIR = sysconfig.get_config_var('WHEEL_PKG_DIR')
 
 
-def _find_packages(path):
-    packages = {}
+def _find_packages(path: str | None) -> _Package:
+    if path is None:
+        raise LookupError(
+            'The compile-time `WHEEL_PKG_DIR` is unset so there is '
+            'no place for looking up the wheels.',
+        )
+
     try:
         filenames = os.listdir(path)
     except OSError:
@@ -38,41 +41,39 @@ def _find_packages(path):
     # of the same package, but don't attempt to implement correct version
     # comparison since this case should not happen.
     filenames = sorted(filenames)
+    pip_pkg = None
     for filename in filenames:
         # filename is like 'pip-21.2.4-py3-none-any.whl'
         if not filename.endswith(".whl"):
             continue
-        for name in _PACKAGE_NAMES:
-            prefix = name + '-'
-            if filename.startswith(prefix):
-                break
-        else:
+        if not filename.startswith('pip-'):
             continue
 
         # Extract '21.2.4' from 'pip-21.2.4-py3-none-any.whl'
-        version = filename.removeprefix(prefix).partition('-')[0]
+        discovered_pip_pkg_version = filename.removeprefix(
+            'pip-',
+        ).partition('-')[0]
         wheel_path = os.path.join(path, filename)
-        packages[name] = _Package(version, None, wheel_path)
-    return packages
+        pip_pkg = _Package(discovered_pip_pkg_version, None, wheel_path)
+
+    if pip_pkg is None:
+        raise LookupError(
+            '`WHEEL_PKG_DIR` does not contain any wheel files for `pip`.',
+        )
+
+    return pip_pkg
 
 
-def _get_packages():
-    global _PACKAGES, _WHEEL_PKG_DIR
-    if _PACKAGES is not None:
-        return _PACKAGES
+@cache
+def _get_usable_pip_package() -> _Package:
+    wheel_name = f"pip-{_PIP_VERSION}-py3-none-any.whl"
+    pip_pkg = _Package(_PIP_VERSION, wheel_name, None)
 
-    packages = {}
-    for name, version, py_tag in _PROJECTS:
-        wheel_name = f"{name}-{version}-{py_tag}-none-any.whl"
-        packages[name] = _Package(version, wheel_name, None)
-    if _WHEEL_PKG_DIR:
-        dir_packages = _find_packages(_WHEEL_PKG_DIR)
-        # only used the wheel package directory if all packages are found there
-        if all(name in dir_packages for name in _PACKAGE_NAMES):
-            packages = dir_packages
-    _PACKAGES = packages
-    return packages
-_PACKAGES = None
+    with suppress(LookupError):
+        # only use the wheel package directory if all packages are found there
+        pip_pkg = _find_packages(_WHEEL_PKG_DIR)
+
+    return pip_pkg
 
 
 def _run_pip(args, additional_paths=None):
@@ -105,7 +106,7 @@ def version():
     """
     Returns a string specifying the bundled version of pip.
     """
-    return _get_packages()['pip'].version
+    return _get_usable_pip_package().version
 
 
 def _disable_pip_configuration_settings():
@@ -167,24 +168,21 @@ def _bootstrap(*, root=None, upgrade=False, user=False,
     with tempfile.TemporaryDirectory() as tmpdir:
         # Put our bundled wheels into a temporary directory and construct the
         # additional paths that need added to sys.path
-        additional_paths = []
-        for name, package in _get_packages().items():
-            if package.wheel_name:
-                # Use bundled wheel package
-                wheel_name = package.wheel_name
-                wheel_path = resources.files("ensurepip") / "_bundled" / wheel_name
-                whl = wheel_path.read_bytes()
-            else:
-                # Use the wheel package directory
-                with open(package.wheel_path, "rb") as fp:
-                    whl = fp.read()
-                wheel_name = os.path.basename(package.wheel_path)
+        package = _get_usable_pip_package()
+        if package.wheel_name:
+            # Use bundled wheel package
+            wheel_name = package.wheel_name
+            wheel_path = resources.files("ensurepip") / "_bundled" / wheel_name
+            whl = wheel_path.read_bytes()
+        else:
+            # Use the wheel package directory
+            with open(package.wheel_path, "rb") as fp:
+                whl = fp.read()
+            wheel_name = os.path.basename(package.wheel_path)
 
-            filename = os.path.join(tmpdir, wheel_name)
-            with open(filename, "wb") as fp:
-                fp.write(whl)
-
-            additional_paths.append(filename)
+        filename = os.path.join(tmpdir, wheel_name)
+        with open(filename, "wb") as fp:
+            fp.write(whl)
 
         # Construct the arguments to be passed to the pip command
         args = ["install", "--no-cache-dir", "--no-index", "--find-links", tmpdir]
@@ -197,7 +195,7 @@ def _bootstrap(*, root=None, upgrade=False, user=False,
         if verbosity:
             args += ["-" + "v" * verbosity]
 
-        return _run_pip([*args, *_PACKAGE_NAMES], additional_paths)
+        return _run_pip([*args, "pip"], [filename])
 
 def _uninstall_helper(*, verbosity=0):
     """Helper to support a clean default uninstall process on Windows
@@ -227,7 +225,7 @@ def _uninstall_helper(*, verbosity=0):
     if verbosity:
         args += ["-" + "v" * verbosity]
 
-    return _run_pip([*args, *reversed(_PACKAGE_NAMES)])
+    return _run_pip([*args, "pip"])
 
 
 def _main(argv=None):

--- a/Lib/ensurepip/__init__.py
+++ b/Lib/ensurepip/__init__.py
@@ -172,7 +172,7 @@ def _bootstrap(*, root=None, upgrade=False, user=False,
         if verbosity:
             args += ["-" + "v" * verbosity]
 
-        return _run_pip([*args, "pip"], [str(tmp_wheel_path)])
+        return _run_pip([*args, "pip"], [os.fsdecode(tmp_wheel_path)])
 
 
 def _uninstall_helper(*, verbosity=0):

--- a/Lib/ensurepip/__init__.py
+++ b/Lib/ensurepip/__init__.py
@@ -16,9 +16,10 @@ _PIP_VERSION = "23.3.2"
 # policies recommend against bundling dependencies. For example, Fedora
 # installs wheel packages in the /usr/share/python-wheels/ directory and don't
 # install the ensurepip._bundled package.
-_WHEEL_PKG_DIR = (
-    whl_pkg_dir_str := sysconfig.get_config_var('WHEEL_PKG_DIR')
-) is not None and Path(whl_pkg_dir_str).resolve() or None
+if (_pkg_dir := sysconfig.get_config_var('WHEEL_PKG_DIR')) is not None:
+    _WHEEL_PKG_DIR = Path(_pkg_dir).resolve()
+else:
+    _WHEEL_PKG_DIR = None
 
 
 def _find_wheel_pkg_dir_pip():

--- a/Lib/ensurepip/__init__.py
+++ b/Lib/ensurepip/__init__.py
@@ -3,7 +3,7 @@ import subprocess
 import sys
 import sysconfig
 import tempfile
-from contextlib import nullcontext, suppress
+from contextlib import nullcontext
 from importlib import resources
 from pathlib import Path
 from shutil import copy2
@@ -24,11 +24,7 @@ else:
 
 def _find_wheel_pkg_dir_pip():
     if _WHEEL_PKG_DIR is None:
-        raise LookupError(
-            'The compile-time `WHEEL_PKG_DIR` is unset so there is '
-            'no place for looking up the wheels.',
-        ) from None
-
+        return None
 
     dist_matching_wheels = _WHEEL_PKG_DIR.glob(f'pip-*.whl')
     try:
@@ -43,8 +39,8 @@ def _find_wheel_pkg_dir_pip():
 
 def _get_pip_whl_path_ctx():
     # Prefer pip from the wheel package directory, if present.
-    with suppress(LookupError):
-        return _find_wheel_pkg_dir_pip()
+    if (alternative_pip_wheel_path := _find_wheel_pkg_dir_pip()) is not None:
+        return alternative_pip_wheel_path
 
     return resources.as_file(
         resources.files('ensurepip')

--- a/Lib/ensurepip/__init__.py
+++ b/Lib/ensurepip/__init__.py
@@ -25,7 +25,7 @@ _Package = collections.namedtuple('Package',
 _WHEEL_PKG_DIR = sysconfig.get_config_var('WHEEL_PKG_DIR')
 
 
-def _find_packages(path: str | None) -> _Package:
+def _get_replacement_pip_package(path: str | None) -> _Package:
     if path is None:
         raise LookupError(
             'The compile-time `WHEEL_PKG_DIR` is unset so there is '
@@ -70,8 +70,8 @@ def _get_usable_pip_package() -> _Package:
     pip_pkg = _Package(_PIP_VERSION, wheel_name, None)
 
     with suppress(LookupError):
-        # only use the wheel package directory if all packages are found there
-        pip_pkg = _find_packages(_WHEEL_PKG_DIR)
+        # only use the wheel package directory if pip wheel is found there
+        pip_pkg = _get_replacement_pip_package(_WHEEL_PKG_DIR)
 
     return pip_pkg
 

--- a/Lib/ensurepip/__init__.py
+++ b/Lib/ensurepip/__init__.py
@@ -26,7 +26,7 @@ def _find_wheel_pkg_dir_pip():
     if _WHEEL_PKG_DIR is None:
         return None
 
-    dist_matching_wheels = _WHEEL_PKG_DIR.glob(f'pip-*.whl')
+    dist_matching_wheels = _WHEEL_PKG_DIR.glob('pip-*.whl')
     try:
         last_matching_dist_wheel = sorted(dist_matching_wheels)[-1]
     except IndexError as index_err:

--- a/Lib/test/test_ensurepip.py
+++ b/Lib/test/test_ensurepip.py
@@ -78,7 +78,7 @@ class EnsurepipMixin:
         real_devnull = os.devnull
         os_patch = unittest.mock.patch("ensurepip.os")
         patched_os = os_patch.start()
-        # But expose os.listdir() used by _find_packages()
+        # But expose os.listdir() used by _get_replacement_pip_package()
         patched_os.listdir = os.listdir
         self.addCleanup(os_patch.stop)
         patched_os.devnull = real_devnull

--- a/Lib/test/test_ensurepip.py
+++ b/Lib/test/test_ensurepip.py
@@ -37,8 +37,8 @@ class TestPackages(unittest.TestCase):
             with ensurepip._get_pip_whl_path_ctx() as bundled_wheel_path:
                 self.assertEqual(pip_filename, bundled_wheel_path.name)
 
-    def test_get_pip_info_with_dir(self):
-        # Test _get_pip_info() with a wheel package directory
+    def test_selected_wheel_path_with_dir(self):
+        # Test _get_pip_whl_path_ctx() with a wheel package directory
         pip_filename = "pip-20.2.2-py2.py3-none-any.whl"
 
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/Lib/test/test_ensurepip.py
+++ b/Lib/test/test_ensurepip.py
@@ -78,7 +78,7 @@ class EnsurepipMixin:
         real_devnull = os.devnull
         os_patch = unittest.mock.patch("ensurepip.os")
         patched_os = os_patch.start()
-        # But expose os.listdir() used by _get_replacement_pip_package()
+        # But expose os.listdir() used by _find_wheel_pkg_dir_pip()
         patched_os.listdir = os.listdir
         self.addCleanup(os_patch.stop)
         patched_os.devnull = real_devnull

--- a/Misc/NEWS.d/next/Library/2023-09-10-23-35-20.gh-issue-109245.yCVQbo.rst
+++ b/Misc/NEWS.d/next/Library/2023-09-10-23-35-20.gh-issue-109245.yCVQbo.rst
@@ -1,3 +1,0 @@
-Simplified ``ensurepip`` to stop assuming that it can provision multiple
-wheels. The refreshed implementation now expects to only provision
-a ``pip`` wheel and no other distribution packages.

--- a/Misc/NEWS.d/next/Library/2023-09-10-23-35-20.gh-issue-109245.yCVQbo.rst
+++ b/Misc/NEWS.d/next/Library/2023-09-10-23-35-20.gh-issue-109245.yCVQbo.rst
@@ -1,0 +1,3 @@
+Simplified ``ensurepip`` to stop assuming that it can provision multiple
+wheels. The refreshed implementation now expects to only provision
+a ``pip`` wheel and no other distribution packages.

--- a/Tools/build/verify_ensurepip_wheels.py
+++ b/Tools/build/verify_ensurepip_wheels.py
@@ -14,7 +14,6 @@ import re
 from pathlib import Path
 from urllib.request import urlopen
 
-PACKAGE_NAMES = ("pip",)
 ENSURE_PIP_ROOT = Path(__file__).parent.parent.parent / "Lib/ensurepip"
 WHEEL_DIR = ENSURE_PIP_ROOT / "_bundled"
 ENSURE_PIP_INIT_PY_TEXT = (ENSURE_PIP_ROOT / "__init__.py").read_text(encoding="utf-8")
@@ -97,8 +96,5 @@ def verify_wheel(package_name: str) -> bool:
 
 
 if __name__ == "__main__":
-    exit_status = 0
-    for package_name in PACKAGE_NAMES:
-        if not verify_wheel(package_name):
-            exit_status = 1
+    exit_status = int(not verify_wheel("pip"))
     raise SystemExit(exit_status)


### PR DESCRIPTION
This is a refactoring change that aims to simplify ``ensurepip``. Before it, this module had legacy infrastructure that made an assumption that ``ensurepip`` would be provisioning more then just a single wheel. That assumption is no longer true since [[1]][[2]][[3]].

In this change, the improvement is done around removing unnecessary loops and supporting structures to change the assumptions to expect only the bundled or replacement ``pip`` wheel.

This is a spin-off of https://github.com/python/cpython/pull/12791.

[1]: https://github.com/python/cpython/commit/ece20db
[2]: https://github.com/python/cpython/pull/101039
[3]: https://github.com/python/cpython/issues/95299

<!-- gh-issue-number: gh-80789 -->
* Issue: gh-80789
<!-- /gh-issue-number -->
