### PR TITLE
gh-109162: libregrtest: fix Logger

### DIFF
--- a/Lib/test/libregrtest/runtest_mp.py
+++ b/Lib/test/libregrtest/runtest_mp.py
@@ -14,6 +14,7 @@ from typing import Literal, TextIO
 from test import support
 from test.support import os_helper
 
+from test.libregrtest.logger import Logger
 from test.libregrtest.main import Regrtest
 from test.libregrtest.result import TestResult, State
 from test.libregrtest.results import TestResults
@@ -360,12 +361,14 @@ def get_running(workers: list[WorkerThread]) -> list[str]:
 
 
 class RunWorkers:
-    def __init__(self, regrtest: Regrtest, runtests: RunTests, num_workers: int) -> None:
-        self.results: TestResults = regrtest.results
-        self.log = regrtest.logger.log
-        self.display_progress = regrtest.display_progress
+    def __init__(self, num_workers: int, runtests: RunTests,
+                 logger: Logger, results: TestResult) -> None:
         self.num_workers = num_workers
         self.runtests = runtests
+        self.log = logger.log
+        self.display_progress = logger.display_progress
+        self.results: TestResults = results
+
         self.output: queue.Queue[QueueOutput] = queue.Queue()
         tests_iter = runtests.iter_tests()
         self.pending = MultiprocessIterator(tests_iter)


### PR DESCRIPTION
* Pass results, quiet and pgo to Logger constructor.
* Move display_progress() method from Regrtest to Logger.
* No longer pass Regrtest to RunWorkers, but logger and results.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-109162 -->
* Issue: gh-109162
<!-- /gh-issue-number -->
