### PR TITLE
gh-109162: libregrtest: rename runtest_mp.py to run_workers.py

### DIFF
--- a/Lib/test/libregrtest/result.py
+++ b/Lib/test/libregrtest/result.py
@@ -5,7 +5,7 @@ from typing import Any
 from test.support import TestStats
 
 from test.libregrtest.utils import (
-    TestName, FilterTuple,
+    StrJSON, TestName, FilterTuple,
     format_duration, normalize_test_name, print_warning)
 
 
@@ -160,7 +160,7 @@ class TestResult:
         json.dump(self, file, cls=_EncodeTestResult)
 
     @staticmethod
-    def from_json(worker_json) -> 'TestResult':
+    def from_json(worker_json: StrJSON) -> 'TestResult':
         return json.loads(worker_json, object_hook=_decode_test_result)
 
 

--- a/Lib/test/libregrtest/results.py
+++ b/Lib/test/libregrtest/results.py
@@ -106,7 +106,7 @@ class TestResults:
 
         xml_data = result.xml_data
         if xml_data:
-            self.add_junit(result.xml_data)
+            self.add_junit(xml_data)
 
     def need_rerun(self):
         return bool(self.bad_results)
@@ -163,7 +163,7 @@ class TestResults:
             for s in ET.tostringlist(root):
                 f.write(s)
 
-    def display_result(self, tests: TestList, quiet: bool, print_slowest: bool):
+    def display_result(self, tests: TestTuple, quiet: bool, print_slowest: bool):
         if self.interrupted:
             print("Test suite interrupted by signal SIGINT.")
 

--- a/Lib/test/libregrtest/run_workers.py
+++ b/Lib/test/libregrtest/run_workers.py
@@ -15,7 +15,6 @@ from test import support
 from test.support import os_helper
 
 from test.libregrtest.logger import Logger
-from test.libregrtest.main import Regrtest
 from test.libregrtest.result import TestResult, State
 from test.libregrtest.results import TestResults
 from test.libregrtest.runtests import RunTests
@@ -154,10 +153,10 @@ class WorkerThread(threading.Thread):
     ) -> MultiprocessResult:
         return MultiprocessResult(test_result, stdout, err_msg)
 
-    def _run_process(self, worker_job, output_file: TextIO,
+    def _run_process(self, runtests: RunTests, output_file: TextIO,
                      tmp_dir: StrPath | None = None) -> int:
         try:
-            popen = create_worker_process(worker_job, output_file, tmp_dir)
+            popen = create_worker_process(runtests, output_file, tmp_dir)
 
             self._killed = False
             self._popen = popen

--- a/Lib/test/libregrtest/runtests.py
+++ b/Lib/test/libregrtest/runtests.py
@@ -27,14 +27,14 @@ class RunTests:
     pgo_extended: bool = False
     output_on_failure: bool = False
     timeout: float | None = None
-    verbose: bool = False
+    verbose: int = 0
     quiet: bool = False
     hunt_refleak: HuntRefleak | None = None
     test_dir: StrPath | None = None
     use_junit: bool = False
     memory_limit: str | None = None
     gc_threshold: int | None = None
-    use_resources: list[str] = None
+    use_resources: list[str] = dataclasses.field(default_factory=list)
     python_cmd: list[str] | None = None
 
     def copy(self, **override):

--- a/Lib/test/libregrtest/setup.py
+++ b/Lib/test/libregrtest/setup.py
@@ -1,4 +1,3 @@
-import atexit
 import faulthandler
 import os
 import signal
@@ -13,7 +12,8 @@ except ImportError:
 
 from test.libregrtest.runtests import RunTests
 from test.libregrtest.utils import (
-    setup_unraisable_hook, setup_threading_excepthook, fix_umask)
+    setup_unraisable_hook, setup_threading_excepthook, fix_umask,
+    replace_stdout, adjust_rlimit_nofile)
 
 
 UNICODE_GUARD_ENV = "PYTHONREGRTEST_UNICODE_GUARD"
@@ -26,19 +26,7 @@ def setup_test_dir(testdir: str | None) -> None:
         sys.path.insert(0, os.path.abspath(testdir))
 
 
-def setup_support(runtests: RunTests):
-    support.PGO = runtests.pgo
-    support.PGO_EXTENDED = runtests.pgo_extended
-    support.set_match_tests(runtests.match_tests, runtests.ignore_tests)
-    support.failfast = runtests.fail_fast
-    support.verbose = runtests.verbose
-    if runtests.use_junit:
-        support.junit_xml_list = []
-    else:
-        support.junit_xml_list = None
-
-
-def setup_tests(runtests):
+def setup_process():
     fix_umask()
 
     try:
@@ -62,7 +50,7 @@ def setup_tests(runtests):
         for signum in signals:
             faulthandler.register(signum, chain=True, file=stderr_fd)
 
-    _adjust_resource_limits()
+    adjust_rlimit_nofile()
     replace_stdout()
     support.record_original_stdout(sys.stdout)
 
@@ -83,19 +71,6 @@ def setup_tests(runtests):
         if getattr(module, '__file__', None):
             module.__file__ = os.path.abspath(module.__file__)
 
-    if runtests.hunt_refleak:
-        unittest.BaseTestSuite._cleanup = False
-
-    if runtests.memory_limit is not None:
-        support.set_memlimit(runtests.memory_limit)
-
-    if runtests.gc_threshold is not None:
-        gc.set_threshold(runtests.gc_threshold)
-
-    support.suppress_msvcrt_asserts(runtests.verbose and runtests.verbose >= 2)
-
-    support.use_resources = runtests.use_resources
-
     if hasattr(sys, 'addaudithook'):
         # Add an auditing hook for all tests to ensure PySys_Audit is tested
         def _test_audit_hook(name, args):
@@ -104,6 +79,36 @@ def setup_tests(runtests):
 
     setup_unraisable_hook()
     setup_threading_excepthook()
+
+    # Ensure there's a non-ASCII character in env vars at all times to force
+    # tests consider this case. See BPO-44647 for details.
+    if TESTFN_UNDECODABLE and os.supports_bytes_environ:
+        os.environb.setdefault(UNICODE_GUARD_ENV.encode(), TESTFN_UNDECODABLE)
+    elif FS_NONASCII:
+        os.environ.setdefault(UNICODE_GUARD_ENV, FS_NONASCII)
+
+
+def setup_tests(runtests: RunTests):
+    support.verbose = runtests.verbose
+    support.failfast = runtests.fail_fast
+    support.PGO = runtests.pgo
+    support.PGO_EXTENDED = runtests.pgo_extended
+
+    support.set_match_tests(runtests.match_tests, runtests.ignore_tests)
+
+    if runtests.use_junit:
+        support.junit_xml_list = []
+        from test.support.testresult import RegressionTestResult
+        RegressionTestResult.USE_XML = True
+    else:
+        support.junit_xml_list = None
+
+    if runtests.memory_limit is not None:
+        support.set_memlimit(runtests.memory_limit)
+
+    support.suppress_msvcrt_asserts(runtests.verbose >= 2)
+
+    support.use_resources = runtests.use_resources
 
     timeout = runtests.timeout
     if timeout is not None:
@@ -117,61 +122,8 @@ def setup_tests(runtests):
         support.SHORT_TIMEOUT = min(support.SHORT_TIMEOUT, timeout)
         support.LONG_TIMEOUT = min(support.LONG_TIMEOUT, timeout)
 
-    if runtests.use_junit:
-        from test.support.testresult import RegressionTestResult
-        RegressionTestResult.USE_XML = True
+    if runtests.hunt_refleak:
+        unittest.BaseTestSuite._cleanup = False
 
-    # Ensure there's a non-ASCII character in env vars at all times to force
-    # tests consider this case. See BPO-44647 for details.
-    if TESTFN_UNDECODABLE and os.supports_bytes_environ:
-        os.environb.setdefault(UNICODE_GUARD_ENV.encode(), TESTFN_UNDECODABLE)
-    elif FS_NONASCII:
-        os.environ.setdefault(UNICODE_GUARD_ENV, FS_NONASCII)
-
-
-def replace_stdout():
-    """Set stdout encoder error handler to backslashreplace (as stderr error
-    handler) to avoid UnicodeEncodeError when printing a traceback"""
-    stdout = sys.stdout
-    try:
-        fd = stdout.fileno()
-    except ValueError:
-        # On IDLE, sys.stdout has no file descriptor and is not a TextIOWrapper
-        # object. Leaving sys.stdout unchanged.
-        #
-        # Catch ValueError to catch io.UnsupportedOperation on TextIOBase
-        # and ValueError on a closed stream.
-        return
-
-    sys.stdout = open(fd, 'w',
-        encoding=stdout.encoding,
-        errors="backslashreplace",
-        closefd=False,
-        newline='\n')
-
-    def restore_stdout():
-        sys.stdout.close()
-        sys.stdout = stdout
-    atexit.register(restore_stdout)
-
-
-def _adjust_resource_limits():
-    """Adjust the system resource limits (ulimit) if needed."""
-    try:
-        import resource
-        from resource import RLIMIT_NOFILE
-    except ImportError:
-        return
-    fd_limit, max_fds = resource.getrlimit(RLIMIT_NOFILE)
-    # On macOS the default fd limit is sometimes too low (256) for our
-    # test suite to succeed.  Raise it to something more reasonable.
-    # 1024 is a common Linux default.
-    desired_fds = 1024
-    if fd_limit < desired_fds and fd_limit < max_fds:
-        new_fd_limit = min(desired_fds, max_fds)
-        try:
-            resource.setrlimit(RLIMIT_NOFILE, (new_fd_limit, max_fds))
-            print(f"Raised RLIMIT_NOFILE: {fd_limit} -> {new_fd_limit}")
-        except (ValueError, OSError) as err:
-            print(f"Unable to raise RLIMIT_NOFILE from {fd_limit} to "
-                  f"{new_fd_limit}: {err}.")
+    if runtests.gc_threshold is not None:
+        gc.set_threshold(runtests.gc_threshold)

--- a/Lib/test/libregrtest/single.py
+++ b/Lib/test/libregrtest/single.py
@@ -15,7 +15,7 @@ from test.support import threading_helper
 from test.libregrtest.result import State, TestResult
 from test.libregrtest.runtests import RunTests
 from test.libregrtest.save_env import saved_test_environment
-from test.libregrtest.setup import setup_support
+from test.libregrtest.setup import setup_tests
 from test.libregrtest.utils import (
     TestName,
     clear_caches, remove_testfn, abs_module_name, print_warning)
@@ -201,7 +201,7 @@ def _runtest(result: TestResult, runtests: RunTests) -> None:
         faulthandler.dump_traceback_later(timeout, exit=True)
 
     try:
-        setup_support(runtests)
+        setup_tests(runtests)
 
         if output_on_failure:
             support.verbose = True

--- a/Lib/test/libregrtest/worker.py
+++ b/Lib/test/libregrtest/worker.py
@@ -6,7 +6,7 @@ from typing import TextIO, NoReturn
 from test import support
 from test.support import os_helper
 
-from test.libregrtest.setup import setup_tests, setup_test_dir
+from test.libregrtest.setup import setup_process, setup_test_dir
 from test.libregrtest.runtests import RunTests
 from test.libregrtest.single import run_single_test
 from test.libregrtest.utils import (
@@ -60,7 +60,7 @@ def worker_process(worker_json: StrJSON) -> NoReturn:
     match_tests: FilterTuple | None = runtests.match_tests
 
     setup_test_dir(runtests.test_dir)
-    setup_tests(runtests)
+    setup_process()
 
     if runtests.rerun:
         if match_tests:


### PR DESCRIPTION
* Rename runtest_mp.py to run_workers.py
* Move exit_timeout() and temp_cwd() context managers from Regrtest.main() to Regrtest.run_tests(). Actions like --list-tests or --list-cases don't need these protections.
* Regrtest: remove selected and tests attributes. Pass 'selected' to list_tests(), list_cases() and run_tests(). display_result() now expects a TestTuple, instead of TestList.
* Rename setup_tests() to setup_process() and rename setup_support() to setup_tests().
* Move _adjust_resource_limits() to utils and rename it to adjust_rlimit_nofile().
* Move replace_stdout() to utils.
* Fix RunTests.verbose type: it's an int.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-109162 -->
* Issue: gh-109162
<!-- /gh-issue-number -->
