### PR TITLE
gh-109162: libregrtest: use relative imports

### DIFF
--- a/Lib/test/__main__.py
+++ b/Lib/test/__main__.py
@@ -1,2 +1,2 @@
-from test.libregrtest import main
+from test.libregrtest.main import main
 main()

--- a/Lib/test/autotest.py
+++ b/Lib/test/autotest.py
@@ -1,5 +1,5 @@
 # This should be equivalent to running regrtest.py from the cmdline.
 # It can be especially handy if you're in an interactive shell, e.g.,
 # from test import autotest.
-from test.libregrtest import main
+from test.libregrtest.main import main
 main()

--- a/Lib/test/libregrtest/__init__.py
+++ b/Lib/test/libregrtest/__init__.py
@@ -1,2 +1,0 @@
-from test.libregrtest.cmdline import _parse_args, RESOURCE_NAMES, ALL_RESOURCES
-from test.libregrtest.main import main

--- a/Lib/test/libregrtest/findtests.py
+++ b/Lib/test/libregrtest/findtests.py
@@ -1,6 +1,6 @@
 import os
 
-from test.libregrtest.utils import StrPath, TestName, TestList
+from .utils import StrPath, TestName, TestList
 
 
 # If these test directories are encountered recurse into them and treat each

--- a/Lib/test/libregrtest/logger.py
+++ b/Lib/test/libregrtest/logger.py
@@ -1,12 +1,12 @@
 import os
 import time
 
-from test.libregrtest.results import TestResults
-from test.libregrtest.runtests import RunTests
-from test.libregrtest.utils import print_warning, MS_WINDOWS
+from .results import TestResults
+from .runtests import RunTests
+from .utils import print_warning, MS_WINDOWS
 
 if MS_WINDOWS:
-    from test.libregrtest.win_utils import WindowsLoadTracker
+    from .win_utils import WindowsLoadTracker
 
 
 class Logger:

--- a/Lib/test/libregrtest/main.py
+++ b/Lib/test/libregrtest/main.py
@@ -10,16 +10,16 @@ import unittest
 from test import support
 from test.support import os_helper
 
-from test.libregrtest.cmdline import _parse_args, Namespace
-from test.libregrtest.findtests import findtests, split_test_packages
-from test.libregrtest.logger import Logger
-from test.libregrtest.result import State
-from test.libregrtest.runtests import RunTests, HuntRefleak
-from test.libregrtest.setup import setup_process, setup_test_dir
-from test.libregrtest.single import run_single_test, PROGRESS_MIN_TIME
-from test.libregrtest.pgo import setup_pgo_tests
-from test.libregrtest.results import TestResults
-from test.libregrtest.utils import (
+from .cmdline import _parse_args, Namespace
+from .findtests import findtests, split_test_packages
+from .logger import Logger
+from .result import State
+from .runtests import RunTests, HuntRefleak
+from .setup import setup_process, setup_test_dir
+from .single import run_single_test, PROGRESS_MIN_TIME
+from .pgo import setup_pgo_tests
+from .results import TestResults
+from .utils import (
     StrPath, StrJSON, TestName, TestList, TestTuple, FilterTuple,
     strip_py_suffix, count, format_duration,
     printlist, get_build_info, get_temp_dir, get_work_dir, exit_timeout,
@@ -409,7 +409,7 @@ class Regrtest:
         return state
 
     def _run_tests_mp(self, runtests: RunTests, num_workers: int) -> None:
-        from test.libregrtest.run_workers import RunWorkers
+        from .run_workers import RunWorkers
         RunWorkers(num_workers, runtests, self.logger, self.results).run()
 
     def finalize_tests(self, tracer):

--- a/Lib/test/libregrtest/refleak.py
+++ b/Lib/test/libregrtest/refleak.py
@@ -5,8 +5,8 @@ from inspect import isabstract
 from test import support
 from test.support import os_helper
 
-from test.libregrtest.runtests import HuntRefleak
-from test.libregrtest.utils import clear_caches
+from .runtests import HuntRefleak
+from .utils import clear_caches
 
 try:
     from _abc import _get_dump

--- a/Lib/test/libregrtest/result.py
+++ b/Lib/test/libregrtest/result.py
@@ -4,7 +4,7 @@ from typing import Any
 
 from test.support import TestStats
 
-from test.libregrtest.utils import (
+from .utils import (
     StrJSON, TestName, FilterTuple,
     format_duration, normalize_test_name, print_warning)
 

--- a/Lib/test/libregrtest/results.py
+++ b/Lib/test/libregrtest/results.py
@@ -1,9 +1,9 @@
 import sys
 from test.support import TestStats
 
-from test.libregrtest.runtests import RunTests
-from test.libregrtest.result import State, TestResult
-from test.libregrtest.utils import (
+from .runtests import RunTests
+from .result import State, TestResult
+from .utils import (
     StrPath, TestName, TestTuple, TestList, FilterDict,
     printlist, count, format_duration)
 

--- a/Lib/test/libregrtest/run_workers.py
+++ b/Lib/test/libregrtest/run_workers.py
@@ -14,15 +14,15 @@ from typing import Literal, TextIO
 from test import support
 from test.support import os_helper
 
-from test.libregrtest.logger import Logger
-from test.libregrtest.result import TestResult, State
-from test.libregrtest.results import TestResults
-from test.libregrtest.runtests import RunTests
-from test.libregrtest.single import PROGRESS_MIN_TIME
-from test.libregrtest.utils import (
+from .logger import Logger
+from .result import TestResult, State
+from .results import TestResults
+from .runtests import RunTests
+from .single import PROGRESS_MIN_TIME
+from .utils import (
     StrPath, TestName,
     format_duration, print_warning)
-from test.libregrtest.worker import create_worker_process, USE_PROCESS_GROUP
+from .worker import create_worker_process, USE_PROCESS_GROUP
 
 if sys.platform == 'win32':
     import locale

--- a/Lib/test/libregrtest/runtests.py
+++ b/Lib/test/libregrtest/runtests.py
@@ -2,7 +2,7 @@ import dataclasses
 import json
 from typing import Any
 
-from test.libregrtest.utils import (
+from .utils import (
     StrPath, StrJSON, TestTuple, FilterTuple, FilterDict)
 
 

--- a/Lib/test/libregrtest/save_env.py
+++ b/Lib/test/libregrtest/save_env.py
@@ -3,9 +3,11 @@ import locale
 import os
 import sys
 import threading
+
 from test import support
 from test.support import os_helper
-from test.libregrtest.utils import print_warning
+
+from .utils import print_warning
 
 
 class SkipTestEnvironment(Exception):

--- a/Lib/test/libregrtest/setup.py
+++ b/Lib/test/libregrtest/setup.py
@@ -10,8 +10,8 @@ try:
 except ImportError:
     gc = None
 
-from test.libregrtest.runtests import RunTests
-from test.libregrtest.utils import (
+from .runtests import RunTests
+from .utils import (
     setup_unraisable_hook, setup_threading_excepthook, fix_umask,
     replace_stdout, adjust_rlimit_nofile)
 

--- a/Lib/test/libregrtest/single.py
+++ b/Lib/test/libregrtest/single.py
@@ -12,11 +12,11 @@ from test import support
 from test.support import TestStats
 from test.support import threading_helper
 
-from test.libregrtest.result import State, TestResult
-from test.libregrtest.runtests import RunTests
-from test.libregrtest.save_env import saved_test_environment
-from test.libregrtest.setup import setup_tests
-from test.libregrtest.utils import (
+from .result import State, TestResult
+from .runtests import RunTests
+from .save_env import saved_test_environment
+from .setup import setup_tests
+from .utils import (
     TestName,
     clear_caches, remove_testfn, abs_module_name, print_warning)
 
@@ -40,7 +40,7 @@ def regrtest_runner(result: TestResult, test_func, runtests: RunTests) -> None:
     # Run test_func(), collect statistics, and detect reference and memory
     # leaks.
     if runtests.hunt_refleak:
-        from test.libregrtest.refleak import runtest_refleak
+        from .refleak import runtest_refleak
         refleak, test_result = runtest_refleak(result.test_name, test_func,
                                                runtests.hunt_refleak,
                                                runtests.quiet)

--- a/Lib/test/libregrtest/worker.py
+++ b/Lib/test/libregrtest/worker.py
@@ -6,10 +6,10 @@ from typing import TextIO, NoReturn
 from test import support
 from test.support import os_helper
 
-from test.libregrtest.setup import setup_process, setup_test_dir
-from test.libregrtest.runtests import RunTests
-from test.libregrtest.single import run_single_test
-from test.libregrtest.utils import (
+from .setup import setup_process, setup_test_dir
+from .runtests import RunTests
+from .single import run_single_test
+from .utils import (
     StrPath, StrJSON, FilterTuple,
     get_work_dir, exit_timeout)
 

--- a/Lib/test/regrtest.py
+++ b/Lib/test/regrtest.py
@@ -8,7 +8,7 @@ Run this script with -h or --help for documentation.
 
 import os
 import sys
-from test.libregrtest import main
+from test.libregrtest.main import main
 
 
 # Alias for backward compatibility (just in case)

--- a/Lib/test/test_regrtest.py
+++ b/Lib/test/test_regrtest.py
@@ -18,10 +18,11 @@ import sysconfig
 import tempfile
 import textwrap
 import unittest
-from test import libregrtest
 from test import support
 from test.support import os_helper, TestStats
-from test.libregrtest import utils, setup
+from test.libregrtest import cmdline
+from test.libregrtest import utils
+from test.libregrtest import setup
 from test.libregrtest.utils import normalize_test_name
 
 if not support.has_subprocess_support:
@@ -52,9 +53,13 @@ class ParseArgsTestCase(unittest.TestCase):
     Test regrtest's argument parsing, function _parse_args().
     """
 
+    @staticmethod
+    def parse_args(args):
+        return cmdline._parse_args(args)
+
     def checkError(self, args, msg):
         with support.captured_stderr() as err, self.assertRaises(SystemExit):
-            libregrtest._parse_args(args)
+            self.parse_args(args)
         self.assertIn(msg, err.getvalue())
 
     def test_help(self):
@@ -62,78 +67,78 @@ class ParseArgsTestCase(unittest.TestCase):
             with self.subTest(opt=opt):
                 with support.captured_stdout() as out, \
                      self.assertRaises(SystemExit):
-                    libregrtest._parse_args([opt])
+                    self.parse_args([opt])
                 self.assertIn('Run Python regression tests.', out.getvalue())
 
     def test_timeout(self):
-        ns = libregrtest._parse_args(['--timeout', '4.2'])
+        ns = self.parse_args(['--timeout', '4.2'])
         self.assertEqual(ns.timeout, 4.2)
         self.checkError(['--timeout'], 'expected one argument')
         self.checkError(['--timeout', 'foo'], 'invalid float value')
 
     def test_wait(self):
-        ns = libregrtest._parse_args(['--wait'])
+        ns = self.parse_args(['--wait'])
         self.assertTrue(ns.wait)
 
     def test_start(self):
         for opt in '-S', '--start':
             with self.subTest(opt=opt):
-                ns = libregrtest._parse_args([opt, 'foo'])
+                ns = self.parse_args([opt, 'foo'])
                 self.assertEqual(ns.start, 'foo')
                 self.checkError([opt], 'expected one argument')
 
     def test_verbose(self):
-        ns = libregrtest._parse_args(['-v'])
+        ns = self.parse_args(['-v'])
         self.assertEqual(ns.verbose, 1)
-        ns = libregrtest._parse_args(['-vvv'])
+        ns = self.parse_args(['-vvv'])
         self.assertEqual(ns.verbose, 3)
-        ns = libregrtest._parse_args(['--verbose'])
+        ns = self.parse_args(['--verbose'])
         self.assertEqual(ns.verbose, 1)
-        ns = libregrtest._parse_args(['--verbose'] * 3)
+        ns = self.parse_args(['--verbose'] * 3)
         self.assertEqual(ns.verbose, 3)
-        ns = libregrtest._parse_args([])
+        ns = self.parse_args([])
         self.assertEqual(ns.verbose, 0)
 
     def test_rerun(self):
         for opt in '-w', '--rerun', '--verbose2':
             with self.subTest(opt=opt):
-                ns = libregrtest._parse_args([opt])
+                ns = self.parse_args([opt])
                 self.assertTrue(ns.rerun)
 
     def test_verbose3(self):
         for opt in '-W', '--verbose3':
             with self.subTest(opt=opt):
-                ns = libregrtest._parse_args([opt])
+                ns = self.parse_args([opt])
                 self.assertTrue(ns.verbose3)
 
     def test_quiet(self):
         for opt in '-q', '--quiet':
             with self.subTest(opt=opt):
-                ns = libregrtest._parse_args([opt])
+                ns = self.parse_args([opt])
                 self.assertTrue(ns.quiet)
                 self.assertEqual(ns.verbose, 0)
 
     def test_slowest(self):
         for opt in '-o', '--slowest':
             with self.subTest(opt=opt):
-                ns = libregrtest._parse_args([opt])
+                ns = self.parse_args([opt])
                 self.assertTrue(ns.print_slow)
 
     def test_header(self):
-        ns = libregrtest._parse_args(['--header'])
+        ns = self.parse_args(['--header'])
         self.assertTrue(ns.header)
 
-        ns = libregrtest._parse_args(['--verbose'])
+        ns = self.parse_args(['--verbose'])
         self.assertTrue(ns.header)
 
     def test_randomize(self):
         for opt in '-r', '--randomize':
             with self.subTest(opt=opt):
-                ns = libregrtest._parse_args([opt])
+                ns = self.parse_args([opt])
                 self.assertTrue(ns.randomize)
 
     def test_randseed(self):
-        ns = libregrtest._parse_args(['--randseed', '12345'])
+        ns = self.parse_args(['--randseed', '12345'])
         self.assertEqual(ns.random_seed, 12345)
         self.assertTrue(ns.randomize)
         self.checkError(['--randseed'], 'expected one argument')
@@ -142,7 +147,7 @@ class ParseArgsTestCase(unittest.TestCase):
     def test_fromfile(self):
         for opt in '-f', '--fromfile':
             with self.subTest(opt=opt):
-                ns = libregrtest._parse_args([opt, 'foo'])
+                ns = self.parse_args([opt, 'foo'])
                 self.assertEqual(ns.fromfile, 'foo')
                 self.checkError([opt], 'expected one argument')
                 self.checkError([opt, 'foo', '-s'], "don't go together")
@@ -150,20 +155,20 @@ class ParseArgsTestCase(unittest.TestCase):
     def test_exclude(self):
         for opt in '-x', '--exclude':
             with self.subTest(opt=opt):
-                ns = libregrtest._parse_args([opt])
+                ns = self.parse_args([opt])
                 self.assertTrue(ns.exclude)
 
     def test_single(self):
         for opt in '-s', '--single':
             with self.subTest(opt=opt):
-                ns = libregrtest._parse_args([opt])
+                ns = self.parse_args([opt])
                 self.assertTrue(ns.single)
                 self.checkError([opt, '-f', 'foo'], "don't go together")
 
     def test_ignore(self):
         for opt in '-i', '--ignore':
             with self.subTest(opt=opt):
-                ns = libregrtest._parse_args([opt, 'pattern'])
+                ns = self.parse_args([opt, 'pattern'])
                 self.assertEqual(ns.ignore_tests, ['pattern'])
                 self.checkError([opt], 'expected one argument')
 
@@ -173,7 +178,7 @@ class ParseArgsTestCase(unittest.TestCase):
             print('matchfile2', file=fp)
 
         filename = os.path.abspath(os_helper.TESTFN)
-        ns = libregrtest._parse_args(['-m', 'match',
+        ns = self.parse_args(['-m', 'match',
                                       '--ignorefile', filename])
         self.assertEqual(ns.ignore_tests,
                          ['matchfile1', 'matchfile2'])
@@ -181,11 +186,11 @@ class ParseArgsTestCase(unittest.TestCase):
     def test_match(self):
         for opt in '-m', '--match':
             with self.subTest(opt=opt):
-                ns = libregrtest._parse_args([opt, 'pattern'])
+                ns = self.parse_args([opt, 'pattern'])
                 self.assertEqual(ns.match_tests, ['pattern'])
                 self.checkError([opt], 'expected one argument')
 
-        ns = libregrtest._parse_args(['-m', 'pattern1',
+        ns = self.parse_args(['-m', 'pattern1',
                                       '-m', 'pattern2'])
         self.assertEqual(ns.match_tests, ['pattern1', 'pattern2'])
 
@@ -195,7 +200,7 @@ class ParseArgsTestCase(unittest.TestCase):
             print('matchfile2', file=fp)
 
         filename = os.path.abspath(os_helper.TESTFN)
-        ns = libregrtest._parse_args(['-m', 'match',
+        ns = self.parse_args(['-m', 'match',
                                       '--matchfile', filename])
         self.assertEqual(ns.match_tests,
                          ['match', 'matchfile1', 'matchfile2'])
@@ -203,65 +208,65 @@ class ParseArgsTestCase(unittest.TestCase):
     def test_failfast(self):
         for opt in '-G', '--failfast':
             with self.subTest(opt=opt):
-                ns = libregrtest._parse_args([opt, '-v'])
+                ns = self.parse_args([opt, '-v'])
                 self.assertTrue(ns.failfast)
-                ns = libregrtest._parse_args([opt, '-W'])
+                ns = self.parse_args([opt, '-W'])
                 self.assertTrue(ns.failfast)
                 self.checkError([opt], '-G/--failfast needs either -v or -W')
 
     def test_use(self):
         for opt in '-u', '--use':
             with self.subTest(opt=opt):
-                ns = libregrtest._parse_args([opt, 'gui,network'])
+                ns = self.parse_args([opt, 'gui,network'])
                 self.assertEqual(ns.use_resources, ['gui', 'network'])
 
-                ns = libregrtest._parse_args([opt, 'gui,none,network'])
+                ns = self.parse_args([opt, 'gui,none,network'])
                 self.assertEqual(ns.use_resources, ['network'])
 
-                expected = list(libregrtest.ALL_RESOURCES)
+                expected = list(cmdline.ALL_RESOURCES)
                 expected.remove('gui')
-                ns = libregrtest._parse_args([opt, 'all,-gui'])
+                ns = self.parse_args([opt, 'all,-gui'])
                 self.assertEqual(ns.use_resources, expected)
                 self.checkError([opt], 'expected one argument')
                 self.checkError([opt, 'foo'], 'invalid resource')
 
                 # all + a resource not part of "all"
-                ns = libregrtest._parse_args([opt, 'all,tzdata'])
+                ns = self.parse_args([opt, 'all,tzdata'])
                 self.assertEqual(ns.use_resources,
-                                 list(libregrtest.ALL_RESOURCES) + ['tzdata'])
+                                 list(cmdline.ALL_RESOURCES) + ['tzdata'])
 
                 # test another resource which is not part of "all"
-                ns = libregrtest._parse_args([opt, 'extralargefile'])
+                ns = self.parse_args([opt, 'extralargefile'])
                 self.assertEqual(ns.use_resources, ['extralargefile'])
 
     def test_memlimit(self):
         for opt in '-M', '--memlimit':
             with self.subTest(opt=opt):
-                ns = libregrtest._parse_args([opt, '4G'])
+                ns = self.parse_args([opt, '4G'])
                 self.assertEqual(ns.memlimit, '4G')
                 self.checkError([opt], 'expected one argument')
 
     def test_testdir(self):
-        ns = libregrtest._parse_args(['--testdir', 'foo'])
+        ns = self.parse_args(['--testdir', 'foo'])
         self.assertEqual(ns.testdir, os.path.join(os_helper.SAVEDCWD, 'foo'))
         self.checkError(['--testdir'], 'expected one argument')
 
     def test_runleaks(self):
         for opt in '-L', '--runleaks':
             with self.subTest(opt=opt):
-                ns = libregrtest._parse_args([opt])
+                ns = self.parse_args([opt])
                 self.assertTrue(ns.runleaks)
 
     def test_huntrleaks(self):
         for opt in '-R', '--huntrleaks':
             with self.subTest(opt=opt):
-                ns = libregrtest._parse_args([opt, ':'])
+                ns = self.parse_args([opt, ':'])
                 self.assertEqual(ns.huntrleaks, (5, 4, 'reflog.txt'))
-                ns = libregrtest._parse_args([opt, '6:'])
+                ns = self.parse_args([opt, '6:'])
                 self.assertEqual(ns.huntrleaks, (6, 4, 'reflog.txt'))
-                ns = libregrtest._parse_args([opt, ':3'])
+                ns = self.parse_args([opt, ':3'])
                 self.assertEqual(ns.huntrleaks, (5, 3, 'reflog.txt'))
-                ns = libregrtest._parse_args([opt, '6:3:leaks.log'])
+                ns = self.parse_args([opt, '6:3:leaks.log'])
                 self.assertEqual(ns.huntrleaks, (6, 3, 'leaks.log'))
                 self.checkError([opt], 'expected one argument')
                 self.checkError([opt, '6'],
@@ -272,7 +277,7 @@ class ParseArgsTestCase(unittest.TestCase):
     def test_multiprocess(self):
         for opt in '-j', '--multiprocess':
             with self.subTest(opt=opt):
-                ns = libregrtest._parse_args([opt, '2'])
+                ns = self.parse_args([opt, '2'])
                 self.assertEqual(ns.use_mp, 2)
                 self.checkError([opt], 'expected one argument')
                 self.checkError([opt, 'foo'], 'invalid int value')
@@ -282,13 +287,13 @@ class ParseArgsTestCase(unittest.TestCase):
     def test_coverage(self):
         for opt in '-T', '--coverage':
             with self.subTest(opt=opt):
-                ns = libregrtest._parse_args([opt])
+                ns = self.parse_args([opt])
                 self.assertTrue(ns.trace)
 
     def test_coverdir(self):
         for opt in '-D', '--coverdir':
             with self.subTest(opt=opt):
-                ns = libregrtest._parse_args([opt, 'foo'])
+                ns = self.parse_args([opt, 'foo'])
                 self.assertEqual(ns.coverdir,
                                  os.path.join(os_helper.SAVEDCWD, 'foo'))
                 self.checkError([opt], 'expected one argument')
@@ -296,13 +301,13 @@ class ParseArgsTestCase(unittest.TestCase):
     def test_nocoverdir(self):
         for opt in '-N', '--nocoverdir':
             with self.subTest(opt=opt):
-                ns = libregrtest._parse_args([opt])
+                ns = self.parse_args([opt])
                 self.assertIsNone(ns.coverdir)
 
     def test_threshold(self):
         for opt in '-t', '--threshold':
             with self.subTest(opt=opt):
-                ns = libregrtest._parse_args([opt, '1000'])
+                ns = self.parse_args([opt, '1000'])
                 self.assertEqual(ns.threshold, 1000)
                 self.checkError([opt], 'expected one argument')
                 self.checkError([opt, 'foo'], 'invalid int value')
@@ -311,7 +316,7 @@ class ParseArgsTestCase(unittest.TestCase):
         for opt in '-n', '--nowindows':
             with self.subTest(opt=opt):
                 with contextlib.redirect_stderr(io.StringIO()) as stderr:
-                    ns = libregrtest._parse_args([opt])
+                    ns = self.parse_args([opt])
                 self.assertTrue(ns.nowindows)
                 err = stderr.getvalue()
                 self.assertIn('the --nowindows (-n) option is deprecated', err)
@@ -319,39 +324,39 @@ class ParseArgsTestCase(unittest.TestCase):
     def test_forever(self):
         for opt in '-F', '--forever':
             with self.subTest(opt=opt):
-                ns = libregrtest._parse_args([opt])
+                ns = self.parse_args([opt])
                 self.assertTrue(ns.forever)
 
     def test_unrecognized_argument(self):
         self.checkError(['--xxx'], 'usage:')
 
     def test_long_option__partial(self):
-        ns = libregrtest._parse_args(['--qui'])
+        ns = self.parse_args(['--qui'])
         self.assertTrue(ns.quiet)
         self.assertEqual(ns.verbose, 0)
 
     def test_two_options(self):
-        ns = libregrtest._parse_args(['--quiet', '--exclude'])
+        ns = self.parse_args(['--quiet', '--exclude'])
         self.assertTrue(ns.quiet)
         self.assertEqual(ns.verbose, 0)
         self.assertTrue(ns.exclude)
 
     def test_option_with_empty_string_value(self):
-        ns = libregrtest._parse_args(['--start', ''])
+        ns = self.parse_args(['--start', ''])
         self.assertEqual(ns.start, '')
 
     def test_arg(self):
-        ns = libregrtest._parse_args(['foo'])
+        ns = self.parse_args(['foo'])
         self.assertEqual(ns.args, ['foo'])
 
     def test_option_and_arg(self):
-        ns = libregrtest._parse_args(['--quiet', 'foo'])
+        ns = self.parse_args(['--quiet', 'foo'])
         self.assertTrue(ns.quiet)
         self.assertEqual(ns.verbose, 0)
         self.assertEqual(ns.args, ['foo'])
 
     def test_arg_option_arg(self):
-        ns = libregrtest._parse_args(['test_unaryop', '-v', 'test_binop'])
+        ns = self.parse_args(['test_unaryop', '-v', 'test_binop'])
         self.assertEqual(ns.verbose, 1)
         self.assertEqual(ns.args, ['test_unaryop', 'test_binop'])
 


### PR DESCRIPTION
libregrtest.__init__ no longer exposes any symbol, so "python -m test.libregrtest.worker" imports less modules.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-109162 -->
* Issue: gh-109162
<!-- /gh-issue-number -->
