### PR TITLE
gh-109216: Fix possible memory leak in `BUILD_MAP`

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2023-09-11-12-41-42.gh-issue-109216.60QOSb.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2023-09-11-12-41-42.gh-issue-109216.60QOSb.rst
@@ -1,0 +1,1 @@
+Fix possible memory leak in :opcode:`BUILD_MAP`.

--- a/Python/bytecodes.c
+++ b/Python/bytecodes.c
@@ -1600,9 +1600,6 @@ dummy_func(
                     values, 2,
                     values+1, 2,
                     oparg);
-            if (map == NULL)
-                goto error;
-
             DECREF_INPUTS();
             ERROR_IF(map == NULL, error);
         }

--- a/Python/executor_cases.c.h
+++ b/Python/executor_cases.c.h
@@ -1433,9 +1433,6 @@
                     values, 2,
                     values+1, 2,
                     oparg);
-            if (map == NULL)
-                goto error;
-
             for (int _i = oparg*2; --_i >= 0;) {
                 Py_DECREF(values[_i]);
             }

--- a/Python/generated_cases.c.h
+++ b/Python/generated_cases.c.h
@@ -2077,9 +2077,6 @@
                     values, 2,
                     values+1, 2,
                     oparg);
-            if (map == NULL)
-                goto error;
-
             for (int _i = oparg*2; --_i >= 0;) {
                 Py_DECREF(values[_i]);
             }


### PR DESCRIPTION
`_PyDict_FromItems` can only fail with `MemoryError` and several other errors which can be considered as disasters, not a regular control flow.

But, it should be now in sync with `BUILD_CONST_KEY_MAP`

<!-- gh-issue-number: gh-109216 -->
* Issue: gh-109216
<!-- /gh-issue-number -->
