### PR TITLE
[3.12] GH-108976. Keep monitoring data structures valid during de-optimization during callback. (GH-109131)

### DIFF
--- a/Lib/test/test_monitoring.py
+++ b/Lib/test/test_monitoring.py
@@ -1718,3 +1718,11 @@ class TestRegressions(MonitoringTestBase, unittest.TestCase):
             make_foo_optimized_then_set_event()
         finally:
             sys.monitoring.set_events(TEST_TOOL, 0)
+
+    def test_gh108976(self):
+        sys.monitoring.use_tool_id(0, "test")
+        sys.monitoring.set_events(0, 0)
+        sys.monitoring.register_callback(0, E.LINE, lambda *args: sys.monitoring.set_events(0, 0))
+        sys.monitoring.register_callback(0, E.INSTRUCTION, lambda *args: 0)
+        sys.monitoring.set_events(0, E.LINE | E.INSTRUCTION)
+        sys.monitoring.set_events(0, 0)

--- a/Lib/test/test_pdb.py
+++ b/Lib/test/test_pdb.py
@@ -1799,6 +1799,24 @@ def test_pdb_issue_gh_101517():
     (Pdb) continue
     """
 
+def test_pdb_issue_gh_108976():
+    """See GH-108976
+    Make sure setting f_trace_opcodes = True won't crash pdb
+    >>> def test_function():
+    ...     import sys
+    ...     sys._getframe().f_trace_opcodes = True
+    ...     import pdb; pdb.Pdb(nosigint=True, readrc=False).set_trace()
+    ...     a = 1
+    >>> with PdbTestInput([  # doctest: +NORMALIZE_WHITESPACE
+    ...     'continue'
+    ... ]):
+    ...    test_function()
+    bdb.Bdb.dispatch: unknown debugging event: 'opcode'
+    > <doctest test.test_pdb.test_pdb_issue_gh_108976[0]>(5)test_function()
+    -> a = 1
+    (Pdb) continue
+    """
+
 def test_pdb_ambiguous_statements():
     """See GH-104301
 

--- a/Misc/NEWS.d/next/Core and Builtins/2023-09-06-22-50-25.gh-issue-108976.MUKaIJ.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2023-09-06-22-50-25.gh-issue-108976.MUKaIJ.rst
@@ -1,0 +1,2 @@
+Fix crash that occurs after de-instrumenting a code object in a monitoring
+callback.


### PR DESCRIPTION
Manual backport of #109391.

Most of the changes are guarded by `#ifdef INSTRUMENT_DEBUG` which is off even for debug builds.

There are no ABI changes.

@Yhg1s 

<!-- gh-issue-number: gh-108976 -->
* Issue: gh-108976
<!-- /gh-issue-number -->
