### PR TITLE
gh-109276: libregrtest only checks saved_test_environment() once

### DIFF
--- a/Lib/test/libregrtest/save_env.py
+++ b/Lib/test/libregrtest/save_env.py
@@ -36,7 +36,7 @@ class saved_test_environment:
     items is also printed.
     """
 
-    def __init__(self, test_name, verbose=0, quiet=False, *, pgo=False):
+    def __init__(self, test_name, verbose, quiet, *, pgo):
         self.test_name = test_name
         self.verbose = verbose
         self.quiet = quiet

--- a/Lib/test/libregrtest/single.py
+++ b/Lib/test/libregrtest/single.py
@@ -132,9 +132,7 @@ def _runtest_env_changed_exc(result: TestResult, runtests: RunTests,
         support.gc_collect()
 
         with saved_test_environment(test_name,
-                                    runtests.verbose,
-                                    runtests.quiet,
-                                    pgo=runtests.pgo):
+                                    runtests.verbose, quiet, pgo=pgo):
             _load_run_test(result, runtests)
     except support.ResourceDenied as msg:
         if not quiet and not pgo:

--- a/Lib/test/libregrtest/single.py
+++ b/Lib/test/libregrtest/single.py
@@ -68,18 +68,14 @@ def regrtest_runner(result: TestResult, test_func, runtests: RunTests) -> None:
     result.stats = stats
 
 
-def save_env(test_name: TestName, runtests: RunTests):
-    return saved_test_environment(test_name, runtests.verbose, runtests.quiet,
-                                  pgo=runtests.pgo)
-
-
 # Storage of uncollectable GC objects (gc.garbage)
 GC_GARBAGE = []
 
 
 def _load_run_test(result: TestResult, runtests: RunTests) -> None:
-    # Load the test function, run the test function.
-    module_name = abs_module_name(result.test_name, runtests.test_dir)
+    # Load the test module and run the tests.
+    test_name = result.test_name
+    module_name = abs_module_name(test_name, runtests.test_dir)
 
     # Remove the module from sys.module to reload it if it was already imported
     sys.modules.pop(module_name, None)
@@ -88,13 +84,13 @@ def _load_run_test(result: TestResult, runtests: RunTests) -> None:
 
     if hasattr(test_mod, "test_main"):
         # https://github.com/python/cpython/issues/89392
-        raise Exception(f"Module {result.test_name} defines test_main() which is no longer supported by regrtest")
+        raise Exception(f"Module {test_name} defines test_main() which "
+                        f"is no longer supported by regrtest")
     def test_func():
         return run_unittest(test_mod)
 
     try:
-        with save_env(result.test_name, runtests):
-            regrtest_runner(result, test_func, runtests)
+        regrtest_runner(result, test_func, runtests)
     finally:
         # First kill any dangling references to open files etc.
         # This can also issue some ResourceWarnings which would otherwise get
@@ -102,11 +98,11 @@ def _load_run_test(result: TestResult, runtests: RunTests) -> None:
         # failures.
         support.gc_collect()
 
-        remove_testfn(result.test_name, runtests.verbose)
+        remove_testfn(test_name, runtests.verbose)
 
     if gc.garbage:
         support.environment_altered = True
-        print_warning(f"{result.test_name} created {len(gc.garbage)} "
+        print_warning(f"{test_name} created {len(gc.garbage)} "
                       f"uncollectable object(s)")
 
         # move the uncollectable objects somewhere,
@@ -119,7 +115,7 @@ def _load_run_test(result: TestResult, runtests: RunTests) -> None:
 
 def _runtest_env_changed_exc(result: TestResult, runtests: RunTests,
                              display_failure: bool = True) -> None:
-    # Detect environment changes, handle exceptions.
+    # Handle exceptions, detect environment changes.
 
     # Reset the environment_altered flag to detect if a test altered
     # the environment
@@ -135,7 +131,10 @@ def _runtest_env_changed_exc(result: TestResult, runtests: RunTests,
         clear_caches()
         support.gc_collect()
 
-        with save_env(test_name, runtests):
+        with saved_test_environment(test_name,
+                                    runtests.verbose,
+                                    runtests.quiet,
+                                    pgo=runtests.pgo):
             _load_run_test(result, runtests)
     except support.ResourceDenied as msg:
         if not quiet and not pgo:


### PR DESCRIPTION
There is no need to check for environment changes twice.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-109276 -->
* Issue: gh-109276
<!-- /gh-issue-number -->
