### PR TITLE
gh-109276: libregrtest: add RunTests.work_dir

### DIFF
--- a/Lib/test/libregrtest/cmdline.py
+++ b/Lib/test/libregrtest/cmdline.py
@@ -331,7 +331,9 @@ def _create_parser():
                        help='writes JUnit-style XML results to the specified '
                             'file')
     group.add_argument('--tempdir', metavar='PATH',
-                       help='override the working directory for the test run')
+                       help='Override the working directory for the test run. '
+                            'It should not be too long and should only '
+                            'use ASCII characters.')
     group.add_argument('--cleanup', action='store_true',
                        help='remove old test_python_* directories')
     return parser

--- a/Lib/test/libregrtest/main.py
+++ b/Lib/test/libregrtest/main.py
@@ -421,6 +421,13 @@ class Regrtest:
         self.first_runtests = runtests
         self.logger.set_tests(runtests)
 
+        print()
+        print("tempfile.gettempdir:", tempfile.gettempdir())
+        print("self.tmp_dir:", self.tmp_dir)
+        print("runtests.work_dir:", runtests.work_dir)
+        print("cwd:", os.getcwd())
+        print()
+
         setup_process()
 
         self.logger.start_load_tracker()

--- a/Lib/test/libregrtest/runtests.py
+++ b/Lib/test/libregrtest/runtests.py
@@ -39,6 +39,7 @@ class RunTests:
     # On Unix, it's a file descriptor.
     # On Windows, it's a handle.
     json_fd: int | None = None
+    work_dir: StrPath = None
 
     def copy(self, **override):
         state = dataclasses.asdict(self)

--- a/Lib/test/libregrtest/worker.py
+++ b/Lib/test/libregrtest/worker.py
@@ -102,7 +102,13 @@ def main():
 
     with exit_timeout():
         runtests = RunTests.from_json(worker_json)
+        cwd = os.getcwd()
         with os_helper.change_cwd(runtests.work_dir):
+            msg = f"worker {runtests.tests[0]} (pid {os.getpid()}): {cwd}"
+            cwd2 = os.getcwd()
+            if cwd2 != cwd:
+                msg = f"{cwd} => {cwd2}"
+            print(msg)
             worker_process(runtests)
 
 

--- a/Lib/test/pythoninfo.py
+++ b/Lib/test/pythoninfo.py
@@ -1,16 +1,11 @@
 """
 Collect various information about Python to help debugging test failures.
 """
-from __future__ import print_function
 import errno
 import re
 import sys
 import traceback
-import unittest
 import warnings
-
-
-MS_WINDOWS = (sys.platform == 'win32')
 
 
 def normalize_text(text):
@@ -493,12 +488,9 @@ def collect_datetime(info_add):
 
 
 def collect_sysconfig(info_add):
-    # On Windows, sysconfig is not reliable to get macros used
-    # to build Python
-    if MS_WINDOWS:
-        return
-
     import sysconfig
+
+    info_add('sysconfig.is_python_build', sysconfig.is_python_build())
 
     for name in (
         'ABIFLAGS',
@@ -523,7 +515,9 @@ def collect_sysconfig(info_add):
         'Py_NOGIL',
         'SHELL',
         'SOABI',
+        'abs_builddir',
         'prefix',
+        'srcdir',
     ):
         value = sysconfig.get_config_var(name)
         if name == 'ANDROID_API_LEVEL' and not value:
@@ -711,6 +705,7 @@ def collect_resource(info_add):
 
 
 def collect_test_socket(info_add):
+    import unittest
     try:
         from test import test_socket
     except (ImportError, unittest.SkipTest):
@@ -896,6 +891,11 @@ def collect_fips(info_add):
         pass
 
 
+def collect_tempfile(info_add):
+    import tempfile
+
+    info_add('tempfile.gettempdir', tempfile.gettempdir())
+
 def collect_info(info):
     error = False
     info_add = info.add
@@ -930,6 +930,7 @@ def collect_info(info):
         collect_sysconfig,
         collect_testcapi,
         collect_testinternalcapi,
+        collect_tempfile,
         collect_time,
         collect_tkinter,
         collect_windows,


### PR DESCRIPTION
* WorkerThread now always creates a temporary directory, even on Emscripten and WASI: it's used as the working directory of the test worker process.
* Fix Emscripten and WASI: start the test worker process in the Python source code directory, where 'python.js' and 'python.wasm' can be found. Then worker_process() goes to the temporary directory created to run tests.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-109276 -->
* Issue: gh-109276
<!-- /gh-issue-number -->
