### PR TITLE
gh-109295: Clean up multiprocessing in test_asyncio and test_compileall

### DIFF
--- a/Lib/test/test_asyncio/test_events.py
+++ b/Lib/test/test_asyncio/test_events.py
@@ -31,6 +31,7 @@ import asyncio
 from asyncio import coroutines
 from asyncio import events
 from asyncio import selector_events
+from multiprocessing.util import _cleanup_tests as multiprocessing_cleanup_tests
 from test.test_asyncio import utils as test_utils
 from test import support
 from test.support import socket_helper
@@ -2781,6 +2782,8 @@ class GetEventLoopTestsMixin:
             self.assertEqual(
                 self.loop.run_until_complete(main()),
                 'hello')
+
+            multiprocessing_cleanup_tests()
 
     def test_get_event_loop_returns_running_loop(self):
         class TestError(Exception):

--- a/Lib/test/test_asyncio/test_events.py
+++ b/Lib/test/test_asyncio/test_events.py
@@ -2766,6 +2766,8 @@ class GetEventLoopTestsMixin:
             # multiprocessing.synchronize module cannot be imported.
             support.skip_if_broken_multiprocessing_synchronize()
 
+            self.addCleanup(multiprocessing_cleanup_tests)
+
             async def main():
                 if multiprocessing.get_start_method() == 'fork':
                     # Avoid 'fork' DeprecationWarning.
@@ -2782,8 +2784,6 @@ class GetEventLoopTestsMixin:
             self.assertEqual(
                 self.loop.run_until_complete(main()),
                 'hello')
-
-            multiprocessing_cleanup_tests()
 
     def test_get_event_loop_returns_running_loop(self):
         class TestError(Exception):

--- a/Lib/test/test_compileall.py
+++ b/Lib/test/test_compileall.py
@@ -18,6 +18,7 @@ from unittest import mock, skipUnless
 try:
     # compileall relies on ProcessPoolExecutor if ProcessPoolExecutor exists
     # and it can function.
+    from multiprocessing.util import _cleanup_tests as multiprocessing_cleanup_tests
     from concurrent.futures import ProcessPoolExecutor
     from concurrent.futures.process import _check_system_limits
     _check_system_limits()
@@ -68,6 +69,7 @@ class CompileallTestsBase:
 
     def tearDown(self):
         shutil.rmtree(self.directory)
+        multiprocessing_cleanup_tests()
 
     def add_bad_source_file(self):
         self.bad_source_path = os.path.join(self.directory, '_test_bad.py')


### PR DESCRIPTION
test_asyncio and test_compileall now clean up multiprocessing by calling _cleanup_tests() method: explicitly clean up resources and stop background processes like the resource tracker.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-109295 -->
* Issue: gh-109295
<!-- /gh-issue-number -->
