### PR TITLE
Fix iter_index() to work with lists which do not support stop=None.

### DIFF
--- a/Doc/library/itertools.rst
+++ b/Doc/library/itertools.rst
@@ -877,6 +877,7 @@ which incur interpreter overhead.
                    yield i
        else:
            # Fast path for sequences
+           stop = len(iterable) if stop is None else stop
            i = start - 1
            try:
                while True:
@@ -1345,6 +1346,16 @@ The following recipes have a more mathematical flavor:
     Traceback (most recent call last):
     ...
     ValueError
+    >>> # Verify that both paths can find identical NaN values
+    >>> x = float('NaN')
+    >>> y = float('NaN')
+    >>> list(iter_index([0, x, x, y, 0], x))
+    [1, 2]
+    >>> list(iter_index(iter([0, x, x, y, 0]), x))
+    [1, 2]
+    >>> # Test list input. Lists do not support None for the stop argument
+    >>> list(iter_index(list('AABCADEAF'), 'A'))
+    [0, 1, 4, 7]
 
     >>> list(sieve(30))
     [2, 3, 5, 7, 11, 13, 17, 19, 23, 29]


### PR DESCRIPTION
* Fix bug where `iter_index()` did not work for list inputs.
* Add test for list inputs.
* Also add tests to make sure NaN handling is consistent between the two code paths.

<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--109306.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->