### PR TITLE
gh-109474: Update two Unix packaging URLs 

### DIFF
--- a/Doc/using/unix.rst
+++ b/Doc/using/unix.rst
@@ -30,9 +30,9 @@ following links:
       for Debian users
    https://en.opensuse.org/Portal:Packaging
       for OpenSuse users
-   https://docs-old.fedoraproject.org/en-US/Fedora_Draft_Documentation/0.1/html/RPM_Guide/ch-creating-rpms.html
+   https://docs.fedoraproject.org/en-US/package-maintainers/Packaging_Tutorial_GNU_Hello/
       for Fedora users
-   http://www.slackbook.org/html/package-management-making-packages.html
+   https://slackbook.org/html/package-management-making-packages.html
       for Slackware users
 
 


### PR DESCRIPTION
fix a broken URL for fedora RPM packaging guide and fix a URL redirect for Slackware packaging guide.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--109307.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->

<!-- gh-issue-number: gh-109474 -->
* Issue: gh-109474
<!-- /gh-issue-number -->
