### PR TITLE
gh-109295: Skip test_generated_cases if different mount drives

### DIFF
--- a/Lib/test/test_generated_cases.py
+++ b/Lib/test/test_generated_cases.py
@@ -1,10 +1,30 @@
 import contextlib
+import os
+import sys
 import tempfile
 import unittest
-import os
 
 from test import support
 from test import test_tools
+
+
+def skip_if_different_mount_drives():
+    if sys.platform != 'win32':
+        return
+    ROOT = os.path.dirname(os.path.dirname(__file__))
+    root_drive = os.path.splitroot(ROOT)[0]
+    cwd_drive = os.path.splitroot(os.getcwd())[0]
+    if root_drive != cwd_drive:
+        # generate_cases.py uses relpath() which raises ValueError if ROOT
+        # and the current working different have different mount drives
+        # (on Windows).
+        raise unittest.SkipTest(
+            f"the current working directory and the Python source code "
+            f"directory have different mount drives "
+            f"({cwd_drive} and {root_drive})"
+        )
+skip_if_different_mount_drives()
+
 
 test_tools.skip_if_missing('cases_generator')
 with test_tools.imports_under_tool('cases_generator'):


### PR DESCRIPTION
On Windows, skip the test if the current working directory and the Python source code directory have different mount drives. It happens if the temporary directory is on a different mount drive than the Python source code.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-109295 -->
* Issue: gh-109295
<!-- /gh-issue-number -->
