### PR TITLE
gh-109276: libregrtest: fix worker working dir

### DIFF
--- a/Lib/test/libregrtest/main.py
+++ b/Lib/test/libregrtest/main.py
@@ -297,7 +297,7 @@ class Regrtest:
 
         jobs = runtests.get_jobs()
         if jobs is not None:
-            tests = f'{jobs} tests'
+            tests = count(jobs, 'test')
         else:
             tests = 'tests'
         msg = f"Run {tests} sequentially"
@@ -458,7 +458,7 @@ class Regrtest:
 
     def run_tests(self, selected: TestTuple, tests: TestList | None) -> int:
         os.makedirs(self.tmp_dir, exist_ok=True)
-        work_dir = get_work_dir(parent_dir=self.tmp_dir)
+        work_dir = get_work_dir(self.tmp_dir)
 
         # Put a timeout on Python exit
         with exit_timeout():

--- a/Lib/test/libregrtest/run_workers.py
+++ b/Lib/test/libregrtest/run_workers.py
@@ -9,7 +9,7 @@ import tempfile
 import threading
 import time
 import traceback
-from typing import Literal, TextIO
+from typing import Literal
 
 from test import support
 from test.support import os_helper
@@ -21,7 +21,7 @@ from .runtests import RunTests
 from .single import PROGRESS_MIN_TIME
 from .utils import (
     StrPath, StrJSON, TestName, MS_WINDOWS,
-    format_duration, print_warning, plural)
+    format_duration, print_warning, count, plural)
 from .worker import create_worker_process, USE_PROCESS_GROUP
 
 if MS_WINDOWS:
@@ -280,7 +280,7 @@ class WorkerThread(threading.Thread):
                 if worker_json:
                     result = TestResult.from_json(worker_json)
                 else:
-                    err_msg = f"empty JSON"
+                    err_msg = "empty JSON"
             except Exception as exc:
                 # gh-101634: Catch UnicodeDecodeError if stdout cannot be
                 # decoded from encoding
@@ -412,7 +412,7 @@ class RunWorkers:
                         for index in range(1, self.num_workers + 1)]
         jobs = self.runtests.get_jobs()
         if jobs is not None:
-            tests = f'{jobs} tests'
+            tests = count(jobs, 'test')
         else:
             tests = 'tests'
         nworkers = len(self.workers)

--- a/Lib/test/libregrtest/utils.py
+++ b/Lib/test/libregrtest/utils.py
@@ -17,6 +17,8 @@ from test.support import threading_helper
 
 
 MS_WINDOWS = (sys.platform == 'win32')
+WORK_DIR_PREFIX = 'test_python_'
+WORKER_WORK_DIR_PREFIX = f'{WORK_DIR_PREFIX}worker_'
 
 # bpo-38203: Maximum delay in seconds to exit Python (call Py_Finalize()).
 # Used to protect against threading._shutdown() hang.
@@ -346,7 +348,7 @@ def get_build_info():
     return build
 
 
-def get_temp_dir(tmp_dir):
+def get_temp_dir(tmp_dir: StrPath | None = None) -> StrPath:
     if tmp_dir:
         tmp_dir = os.path.expanduser(tmp_dir)
     else:
@@ -379,7 +381,7 @@ def fix_umask():
             os.umask(old_mask)
 
 
-def get_work_dir(*, parent_dir: StrPath = '', worker: bool = False):
+def get_work_dir(parent_dir: StrPath, worker: bool = False) -> StrPath:
     # Define a writable temp dir that will be used as cwd while running
     # the tests. The name of the dir includes the pid to allow parallel
     # testing (see the -j option).
@@ -391,12 +393,11 @@ def get_work_dir(*, parent_dir: StrPath = '', worker: bool = False):
         nounce = os.getpid()
 
     if worker:
-        work_dir = 'test_python_worker_{}'.format(nounce)
+        work_dir = WORK_DIR_PREFIX + str(nounce)
     else:
-        work_dir = 'test_python_{}'.format(nounce)
+        work_dir = WORKER_WORK_DIR_PREFIX + str(nounce)
     work_dir += os_helper.FS_NONASCII
-    if parent_dir:
-        work_dir = os.path.join(parent_dir, work_dir)
+    work_dir = os.path.join(parent_dir, work_dir)
     return work_dir
 
 
@@ -579,7 +580,7 @@ def display_header():
 def cleanup_temp_dir(tmp_dir: StrPath):
     import glob
 
-    path = os.path.join(glob.escape(tmp_dir), 'test_python_*')
+    path = os.path.join(glob.escape(tmp_dir), WORK_DIR_PREFIX + '*')
     print("Cleanup %s directory" % tmp_dir)
     for name in glob.glob(path):
         if os.path.isdir(name):


### PR DESCRIPTION
Fix Emscripten and WASI: start the test worker process in the Python source code directory, where 'python.js' and 'python.wasm' can be found. Then worker_process() changes to a temporary directory created to run tests.

* create_worker_process() uses os_helper.SAVEDCWD as cwd.
* worker_process() uses get_temp_dir() as the parent directory for get_work_dir().
* Don't use plural but singual for "test" in "Run 1 test ..." message.
* Remove unused imports.
* Add WORK_DIR_PREFIX and WORKER_WORK_DIR_PREFIX constants.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-109276 -->
* Issue: gh-109276
<!-- /gh-issue-number -->
