### PR TITLE
gh-109319: deprecate dis.HAVE_ARGUMENT

### DIFF
--- a/Doc/library/dis.rst
+++ b/Doc/library/dis.rst
@@ -1623,6 +1623,8 @@ iterations of the loop.
       it is not true that comparison with ``HAVE_ARGUMENT`` indicates whether
       they use their arg.
 
+   .. deprecated:: 3.13
+      Use :data:`hasarg` instead.
 
 .. opcode:: CALL_INTRINSIC_1
 

--- a/Doc/whatsnew/3.13.rst
+++ b/Doc/whatsnew/3.13.rst
@@ -301,8 +301,8 @@ Deprecated
 
   (Contributed by Erlend E. Aasland in :gh:`107948` and :gh:`108278`.)
 
-* The `dis.HAVE_ARGUMENT` separator is deprecated. Check membership in
-  `dis.hasarg` instead.
+* The :data:`~dis.HAVE_ARGUMENT` separator is deprecated. Check membership
+  in :data:`~dis.hasarg` instead.
   (Contributed by Irit Katriel in :gh:`109319`.)
 
 

--- a/Doc/whatsnew/3.13.rst
+++ b/Doc/whatsnew/3.13.rst
@@ -301,6 +301,11 @@ Deprecated
 
   (Contributed by Erlend E. Aasland in :gh:`107948` and :gh:`108278`.)
 
+* The `dis.HAVE_ARGUMENT` separator is deprecated. Check membership in
+  `dis.hasarg` instead.
+  (Contributed by Irit Katriel in :gh:`109319`.)
+
+
 Pending Removal in Python 3.14
 ------------------------------
 

--- a/Doc/whatsnew/3.13.rst
+++ b/Doc/whatsnew/3.13.rst
@@ -301,7 +301,7 @@ Deprecated
 
   (Contributed by Erlend E. Aasland in :gh:`107948` and :gh:`108278`.)
 
-* The :data:`~dis.HAVE_ARGUMENT` separator is deprecated. Check membership
+* The ``dis.HAVE_ARGUMENT`` separator is deprecated. Check membership
   in :data:`~dis.hasarg` instead.
   (Contributed by Irit Katriel in :gh:`109319`.)
 

--- a/Misc/NEWS.d/next/Library/2023-09-12-13-01-55.gh-issue-109319.YaCMtW.rst
+++ b/Misc/NEWS.d/next/Library/2023-09-12-13-01-55.gh-issue-109319.YaCMtW.rst
@@ -1,1 +1,1 @@
-Deprecate the `dis.HAVE_ARGUMENT` field in favour of `dis.hasarg`.
+Deprecate the ``dis.HAVE_ARGUMENT`` field in favour of ``dis.hasarg``.

--- a/Misc/NEWS.d/next/Library/2023-09-12-13-01-55.gh-issue-109319.YaCMtW.rst
+++ b/Misc/NEWS.d/next/Library/2023-09-12-13-01-55.gh-issue-109319.YaCMtW.rst
@@ -1,0 +1,1 @@
+Deprecate the `dis.HAVE_ARGUMENT` field in favour of `dis.hasarg`.


### PR DESCRIPTION
Fixes #109319 .

<!-- gh-issue-number: gh-109319 -->
* Issue: gh-109319
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--109320.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->