### PR TITLE
gh-109276: libregrtest: WASM use filename for JSON

### DIFF
--- a/Lib/test/libregrtest/main.py
+++ b/Lib/test/libregrtest/main.py
@@ -406,7 +406,7 @@ class Regrtest:
             python_cmd=self.python_cmd,
             randomize=self.randomize,
             random_seed=self.random_seed,
-            json_fd=None,
+            json_file=None,
         )
 
     def _run_tests(self, selected: TestTuple, tests: TestList | None) -> int:

--- a/Lib/test/libregrtest/main.py
+++ b/Lib/test/libregrtest/main.py
@@ -507,5 +507,10 @@ class Regrtest:
 
 def main(tests=None, **kwargs):
     """Run the Python suite."""
+
+    print("main process start sys.platform:", sys.platform)
+    print("main process start is_emscripten:", support.is_emscripten)
+    print("main process start is_wasi:", support.is_wasi)
+
     ns = _parse_args(sys.argv[1:], **kwargs)
     Regrtest(ns).main(tests=tests)

--- a/Lib/test/libregrtest/main.py
+++ b/Lib/test/libregrtest/main.py
@@ -117,6 +117,7 @@ class Regrtest:
             self.python_cmd: tuple[str] = tuple(ns.python)
         else:
             self.python_cmd = None
+        print("main process python_cmd:", self.python_cmd)
         self.coverage: bool = ns.trace
         self.coverage_dir: StrPath | None = ns.coverdir
         self.tmp_dir: StrPath | None = ns.tempdir

--- a/Lib/test/libregrtest/run_workers.py
+++ b/Lib/test/libregrtest/run_workers.py
@@ -227,10 +227,6 @@ class WorkerThread(threading.Thread):
             match_tests = None
         err_msg = None
 
-        print("main process is_emscripten:", support.is_emscripten)
-        print("main process is_wasi:", support.is_wasi)
-        print("main process JSON_FILE_USE_FILENAME:", JSON_FILE_USE_FILENAME)
-
         stdout_file = tempfile.TemporaryFile('w+', encoding=encoding)
         if JSON_FILE_USE_FILENAME:
             json_tmpfile = tempfile.NamedTemporaryFile('w+', encoding='utf8')

--- a/Lib/test/libregrtest/run_workers.py
+++ b/Lib/test/libregrtest/run_workers.py
@@ -227,11 +227,17 @@ class WorkerThread(threading.Thread):
             match_tests = None
         err_msg = None
 
+        print("main process is_emscripten:", support.is_emscripten)
+        print("main process is_wasi:", support.is_wasi)
+        print("main process JSON_FILE_USE_FILENAME:", JSON_FILE_USE_FILENAME)
+
         stdout_file = tempfile.TemporaryFile('w+', encoding=encoding)
         if JSON_FILE_USE_FILENAME:
             json_tmpfile = tempfile.NamedTemporaryFile('w+', encoding='utf8')
+            print("main process: create NamedTemporaryFile")
         else:
             json_tmpfile = tempfile.TemporaryFile('w+', encoding='utf8')
+            print("main process: create TemporaryFile")
 
         # gh-94026: Write stdout+stderr to a tempfile as workaround for
         # non-blocking pipes on Emscripten with NodeJS.
@@ -243,6 +249,8 @@ class WorkerThread(threading.Thread):
                 json_file = json_tmpfile.fileno()
                 if MS_WINDOWS:
                     json_file = msvcrt.get_osfhandle(json_file)
+            print("main process json_type file:", type(json_file))
+            print("main process json_type:", json_file)
 
             kwargs = {}
             if match_tests:

--- a/Lib/test/libregrtest/runtests.py
+++ b/Lib/test/libregrtest/runtests.py
@@ -20,6 +20,11 @@ else:
     JsonFileType = int
     JSON_FILE_USE_FILENAME = False
 
+import os
+print(os.getpid(), "JSON_FILE_USE_FILENAME:", JSON_FILE_USE_FILENAME)
+print(os.getpid(), "JsonFileType:", JsonFileType)
+
+
 
 @dataclasses.dataclass(slots=True, frozen=True)
 class HuntRefleak:

--- a/Lib/test/libregrtest/utils.py
+++ b/Lib/test/libregrtest/utils.py
@@ -17,8 +17,12 @@ from test.support import threading_helper
 
 
 MS_WINDOWS = (sys.platform == 'win32')
-WORK_DIR_PREFIX = 'test_python_'
-WORKER_WORK_DIR_PREFIX = f'{WORK_DIR_PREFIX}worker_'
+
+# All temporary files and temporary directories created by libregrtest should
+# use TMP_PREFIX so cleanup_temp_dir() can remove them all.
+TMP_PREFIX = 'test_python_'
+WORK_DIR_PREFIX = TMP_PREFIX
+WORKER_WORK_DIR_PREFIX = WORK_DIR_PREFIX + 'worker_'
 
 # bpo-38203: Maximum delay in seconds to exit Python (call Py_Finalize()).
 # Used to protect against threading._shutdown() hang.
@@ -580,7 +584,7 @@ def display_header():
 def cleanup_temp_dir(tmp_dir: StrPath):
     import glob
 
-    path = os.path.join(glob.escape(tmp_dir), WORK_DIR_PREFIX + '*')
+    path = os.path.join(glob.escape(tmp_dir), TMP_PREFIX + '*')
     print("Cleanup %s directory" % tmp_dir)
     for name in glob.glob(path):
         if os.path.isdir(name):

--- a/Lib/test/libregrtest/utils.py
+++ b/Lib/test/libregrtest/utils.py
@@ -387,7 +387,7 @@ def get_work_dir(parent_dir: StrPath, worker: bool = False) -> StrPath:
     # testing (see the -j option).
     # Emscripten and WASI have stubbed getpid(), Emscripten has only
     # milisecond clock resolution. Use randint() instead.
-    if sys.platform in {"emscripten", "wasi"}:
+    if support.is_emscripten or support.is_wasi:
         nounce = random.randint(0, 1_000_000)
     else:
         nounce = os.getpid()

--- a/Lib/test/libregrtest/worker.py
+++ b/Lib/test/libregrtest/worker.py
@@ -86,6 +86,8 @@ def worker_process(worker_json: StrJSON) -> NoReturn:
     # On Windows, it's a handle.
     # On Emscripten/WASI, it's a filename.
     json_file: JsonFileType = runtests.json_file
+    print("worker: json_file type:", type(json_file))
+    print("worker: json_file:", json_file)
 
     if MS_WINDOWS:
         import msvcrt

--- a/Lib/test/libregrtest/worker.py
+++ b/Lib/test/libregrtest/worker.py
@@ -27,10 +27,12 @@ def create_worker_process(runtests: RunTests,
         executable = python_cmd
     else:
         executable = [sys.executable]
+    print("main process executable:", executable)
     cmd = [*executable, *support.args_from_interpreter_flags(),
            '-u',    # Unbuffered stdout and stderr
            '-m', 'test.libregrtest.worker',
            worker_json]
+    print("main process worker cmd:", cmd)
 
     env = dict(os.environ)
     if tmp_dir is not None:

--- a/Lib/test/libregrtest/worker.py
+++ b/Lib/test/libregrtest/worker.py
@@ -7,7 +7,7 @@ from test import support
 from test.support import os_helper
 
 from .setup import setup_process, setup_test_dir
-from .runtests import RunTests, JsonFileType, JSON_FILE_USE_FILENAME
+from .runtests import RunTests, JsonFileType
 from .single import run_single_test
 from .utils import (
     StrPath, StrJSON, FilterTuple, MS_WINDOWS,
@@ -57,17 +57,23 @@ def create_worker_process(runtests: RunTests,
         close_fds=True,
         cwd=work_dir,
     )
-    if JSON_FILE_USE_FILENAME:
-        # Nothing to do to pass the JSON filename to the worker process
+
+    # Pass json_file to the worker process
+    if isinstance(json_file, str):
+        # Filename: nothing to do to
+        print("create_worker_process() json_file: filename")
         pass
     elif MS_WINDOWS:
-        # Pass the JSON handle to the worker process
+        # Windows handle
+        print("create_worker_process() json_file: Windows handle")
         startupinfo = subprocess.STARTUPINFO()
         startupinfo.lpAttributeList = {"handle_list": [json_file]}
         kwargs['startupinfo'] = startupinfo
     else:
-        # Pass the JSON file descriptor to the worker process
+        # Unix file descriptor
+        print("create_worker_process() json_file: Unix fd")
         kwargs['pass_fds'] = [json_file]
+
     if USE_PROCESS_GROUP:
         kwargs['start_new_session'] = True
 

--- a/Lib/test/libregrtest/worker.py
+++ b/Lib/test/libregrtest/worker.py
@@ -122,6 +122,10 @@ def main():
     tmp_dir = get_temp_dir()
     work_dir = get_work_dir(tmp_dir, worker=True)
 
+    print("worker process sys.platform:", sys.platform)
+    print("worker process is_emscripten:", support.is_emscripten)
+    print("worker process is_wasi:", support.is_wasi)
+
     with exit_timeout():
         with os_helper.temp_cwd(work_dir, quiet=True):
             worker_process(worker_json)


### PR DESCRIPTION
On Emscripten and WASI platforms, libregrtest now uses a filename for the JSON file. Passing a file descriptor to a child process doesn't work on these platforms.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-109276 -->
* Issue: gh-109276
<!-- /gh-issue-number -->
