### PR TITLE
fix variable name in `dis` documentation

### DIFF
--- a/Doc/library/dis.rst
+++ b/Doc/library/dis.rst
@@ -597,7 +597,7 @@ not have to be) the original ``STACK[-2]``.
 
       key = STACK.pop()
       container = STACK.pop()
-      STACK.append(container[index])
+      STACK.append(container[key])
 
 
 .. opcode:: STORE_SUBSCR


### PR DESCRIPTION
**BINARY_SUBSCR** opcode explanation erroneously uses two different names `key` and `index` to refer to the same variable. **STORE_SUBSCR** and **DELETE_SUBSCR** use only `key` in the same context. Changing `index` to `key` for consistency.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--109343.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->