### PR TITLE
gh-109276: libregrtest: fix work dir on WASI

### DIFF
--- a/Lib/test/libregrtest/run_workers.py
+++ b/Lib/test/libregrtest/run_workers.py
@@ -338,11 +338,10 @@ class WorkerThread(threading.Thread):
 
             if retcode is None:
                 raise WorkerError(self.test_name, None, stdout, state=State.TIMEOUT)
+            if retcode != 0:
+                raise WorkerError(self.test_name, f"Exit code {retcode}", stdout)
 
             result, stdout = self.read_json(json_file, json_tmpfile, stdout)
-
-        if retcode != 0:
-            raise WorkerError(self.test_name, f"Exit code {retcode}", stdout)
 
         if tmp_files:
             msg = (f'\n\n'

--- a/Lib/test/libregrtest/utils.py
+++ b/Lib/test/libregrtest/utils.py
@@ -360,14 +360,25 @@ def get_temp_dir(tmp_dir: StrPath | None = None) -> StrPath:
         # to keep the test files in a subfolder.  This eases the cleanup of leftover
         # files using the "make distclean" command.
         if sysconfig.is_python_build():
-            tmp_dir = sysconfig.get_config_var('abs_builddir')
-            if tmp_dir is None:
-                # bpo-30284: On Windows, only srcdir is available. Using
-                # abs_builddir mostly matters on UNIX when building Python
-                # out of the source tree, especially when the source tree
-                # is read only.
-                tmp_dir = sysconfig.get_config_var('srcdir')
-            tmp_dir = os.path.join(tmp_dir, 'build')
+            if not support.is_wasi:
+                tmp_dir = sysconfig.get_config_var('abs_builddir')
+                if tmp_dir is None:
+                    # bpo-30284: On Windows, only srcdir is available. Using
+                    # abs_builddir mostly matters on UNIX when building Python
+                    # out of the source tree, especially when the source tree
+                    # is read only.
+                    tmp_dir = sysconfig.get_config_var('srcdir')
+                tmp_dir = os.path.join(tmp_dir, 'build')
+            else:
+                # WASI platform
+                tmp_dir = sysconfig.get_config_var('projectbase')
+                tmp_dir = os.path.join(tmp_dir, 'build')
+
+                # When get_temp_dir() is called in a worker process,
+                # get_temp_dir() path is different than in the parent process
+                # which is not a WASI process. So the parent does not create
+                # the same "tmp_dir" than the test worker process.
+                os.makedirs(self.tmp_dir, exist_ok=True)
         else:
             tmp_dir = tempfile.gettempdir()
 

--- a/Lib/test/libregrtest/utils.py
+++ b/Lib/test/libregrtest/utils.py
@@ -378,7 +378,7 @@ def get_temp_dir(tmp_dir: StrPath | None = None) -> StrPath:
                 # get_temp_dir() path is different than in the parent process
                 # which is not a WASI process. So the parent does not create
                 # the same "tmp_dir" than the test worker process.
-                os.makedirs(self.tmp_dir, exist_ok=True)
+                os.makedirs(tmp_dir, exist_ok=True)
         else:
             tmp_dir = tempfile.gettempdir()
 


### PR DESCRIPTION
On WASI platform, get_temp_dir() should behave differently since the parent process is a WASI process and uses a different get_temp_dir() path.

Fix also WorkerThread._runtest(): don't read JSON file if the worker process exit code is non-zero.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-109276 -->
* Issue: gh-109276
<!-- /gh-issue-number -->
