### PR TITLE
gh-109357: Fix test_monitoring.test_gh108976()

### DIFF
--- a/Lib/test/test_monitoring.py
+++ b/Lib/test/test_monitoring.py
@@ -1721,6 +1721,7 @@ class TestRegressions(MonitoringTestBase, unittest.TestCase):
 
     def test_gh108976(self):
         sys.monitoring.use_tool_id(0, "test")
+        self.addCleanup(sys.monitoring.free_tool_id, 0)
         sys.monitoring.set_events(0, 0)
         sys.monitoring.register_callback(0, E.LINE, lambda *args: sys.monitoring.set_events(0, 0))
         sys.monitoring.register_callback(0, E.INSTRUCTION, lambda *args: 0)


### PR DESCRIPTION
The test now calls free_tool_id() so it can be run multiple times in the same process. For example, the following command no longer fails:

    python -m test test_monitoring -R 3:3

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-109357 -->
* Issue: gh-109357
<!-- /gh-issue-number -->
