### PR TITLE
gh-109219: propagate free vars through type param scopes

### DIFF
--- a/Lib/test/test_type_params.py
+++ b/Lib/test/test_type_params.py
@@ -499,20 +499,6 @@ class TypeParamsAccessTest(unittest.TestCase):
                                             r"Cannot use [a-z]+ in annotation scope within class scope"):
                     run_code(code.format(case))
 
-    def test_complex_nested_classes(self):
-        code = """
-            def f():
-                T = str
-                class C:
-                    T = int
-                    class D[U](T):
-                        x = T
-                return C
-        """
-        C = run_code(code)["f"]()
-        self.assertIn(int, C.D.__bases__)
-        self.assertIs(C.D.x, str)
-
 
 def make_base(arg):
     class Base:
@@ -708,6 +694,19 @@ class TypeParamsClassScopeTest(unittest.TestCase):
         cls = ns["outer"]()
         self.assertEqual(cls.Alias.__value__, "class")
 
+    def test_nested_free(self):
+        ns = run_code("""
+            def f():
+                T = str
+                class C:
+                    T = int
+                    class D[U](T):
+                        x = T
+                return C
+        """)
+        C = ns["f"]()
+        self.assertIn(int, C.D.__bases__)
+        self.assertIs(C.D.x, str)
 
 class TypeParamsManglingTest(unittest.TestCase):
     def test_mangling(self):

--- a/Lib/test/test_type_params.py
+++ b/Lib/test/test_type_params.py
@@ -499,6 +499,20 @@ class TypeParamsAccessTest(unittest.TestCase):
                                             r"Cannot use [a-z]+ in annotation scope within class scope"):
                     run_code(code.format(case))
 
+    def test_complex_nested_classes(self):
+        code = """
+            def f():
+                T = str
+                class C:
+                    T = int
+                    class D[U](T):
+                        x = T
+                return C
+        """
+        C = run_code(code)["f"]()
+        self.assertIn(int, C.D.__bases__)
+        self.assertIs(C.D.x, str)
+
 
 def make_base(arg):
     class Base:

--- a/Misc/NEWS.d/next/Core and Builtins/2023-09-13-08-42-45.gh-issue-109219.UiN8sc.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2023-09-13-08-42-45.gh-issue-109219.UiN8sc.rst
@@ -1,0 +1,2 @@
+Fix compiling type param scopes that use a name which is also free in an
+inner scope.

--- a/Python/symtable.c
+++ b/Python/symtable.c
@@ -1077,7 +1077,7 @@ analyze_block(PySTEntryObject *ste, PyObject *bound, PyObject *free,
         goto error;
     /* Records the results of the analysis in the symbol table entry */
     if (!update_symbols(ste->ste_symbols, scopes, bound, newfree, inlined_cells,
-                        (ste->ste_type == ClassBlock) || class_entry))
+                        (ste->ste_type == ClassBlock) || ste->ste_can_see_class_scope))
         goto error;
 
     temp = PyNumber_InPlaceOr(free, newfree);

--- a/Python/symtable.c
+++ b/Python/symtable.c
@@ -836,8 +836,7 @@ update_symbols(PyObject *symbols, PyObject *scopes,
                the class that has the same name as a local
                or global in the class scope.
             */
-            if  (classflag &&
-                 PyLong_AS_LONG(v) & (DEF_BOUND | DEF_GLOBAL)) {
+            if  (classflag) {
                 long flags = PyLong_AS_LONG(v) | DEF_FREE_CLASS;
                 v_new = PyLong_FromLong(flags);
                 if (!v_new) {
@@ -1078,7 +1077,7 @@ analyze_block(PySTEntryObject *ste, PyObject *bound, PyObject *free,
         goto error;
     /* Records the results of the analysis in the symbol table entry */
     if (!update_symbols(ste->ste_symbols, scopes, bound, newfree, inlined_cells,
-                        ste->ste_type == ClassBlock))
+                        (ste->ste_type == ClassBlock) || class_entry))
         goto error;
 
     temp = PyNumber_InPlaceOr(free, newfree);


### PR DESCRIPTION
When an annotation scope is inside a class scope, unbound name references in the annotation scope that are bound in the enclosing class scope and would otherwise be free variables are overridden (in `analyze_name`) to use `GLOBAL_EXPLICIT` or `GLOBAL_IMPLICIT` scope instead, since they should behave like name references in the class scope, which see only the class-scope and globals, not other enclosing scopes. E.g. in this example, the reference to `T` in D's bases (which is in a nested annotation scope, since `D` is generic) should have `GLOBAL_IMPLICIT` scope, which results in it using `LOAD_FROM_DICT_OR_GLOBALS` (where the dict is the class namespace); just as if it were a reference directly in C's scope:

```
def f():
    T = str
    class C:
        T = int
        class D[U](T):
            pass
```

But in the case where the same name is also free in a child scope of the annotation scope (replace `pass` with `T` in the above example), it must be included in the free vars of the annotation scope, so that the child scope has access to the cell when its closure is constructed.

The symbol flag `DEF_CLASS_FREE` is intended for these class-scope cases, where a name must have a scope other than `FREE` in order for references to it to behave correctly, but must still be included in freevars because it is free in a child scope.

So we must add `DEF_CLASS_FREE` to such names not only in class scopes, but also in annotation scopes enclosed by class scopes.

Previously, we only added `DEF_CLASS_FREE` if the name was bound in the class scope; otherwise, it would be `FREE` anyway and `DEF_CLASS_FREE` would be redundant. To preserve this check in annotation scope cases, we'd have to check if the name is bound in the enclosing class scope, not the annotation scope. But this check is unnecessary, since a redundant `DEF_CLASS_FREE` on a `FREE` name is harmless; either way the name will be added to freevars, and this is the only impact of `DEF_CLASS_FREE`. So it's simpler to just remove the check.

<!-- gh-issue-number: gh-109219 -->
* Issue: gh-109219
<!-- /gh-issue-number -->
