### PR TITLE
dump readable opcode names in flowgraph debug utility

### DIFF
--- a/Python/flowgraph.c
+++ b/Python/flowgraph.c
@@ -261,8 +261,8 @@ dump_instr(cfg_instr *i)
     if (HAS_TARGET(i->i_opcode)) {
         sprintf(arg, "target: %p [%d] ", i->i_target, i->i_oparg);
     }
-    fprintf(stderr, "line: %d, opcode: %d %s%s\n",
-                    i->i_loc.lineno, i->i_opcode, arg, jump);
+    fprintf(stderr, "line: %d, opcode: %d (%s) %s%s\n",
+                    i->i_loc.lineno, i->i_opcode, _PyOpcode_OpName[i->i_opcode], arg, jump);
 }
 
 static inline int
@@ -2661,4 +2661,3 @@ _PyCfg_OptimizedCfgToInstructionSequence(cfg_builder *g,
 
     return SUCCESS;
 }
-

--- a/Python/flowgraph.c
+++ b/Python/flowgraph.c
@@ -261,8 +261,8 @@ dump_instr(cfg_instr *i)
     if (HAS_TARGET(i->i_opcode)) {
         sprintf(arg, "target: %p [%d] ", i->i_target, i->i_oparg);
     }
-    fprintf(stderr, "line: %d, opcode: %d (%s) %s%s\n",
-                    i->i_loc.lineno, i->i_opcode, _PyOpcode_OpName[i->i_opcode], arg, jump);
+    fprintf(stderr, "line: %d, %s (%d)  %s%s\n",
+                    i->i_loc.lineno, _PyOpcode_OpName[i->i_opcode], i->i_opcode, arg, jump);
 }
 
 static inline int


### PR DESCRIPTION
The main issue I have with these debug dump utilities in `flowgraph.c` is that they only dump numeric codes for opcodes, not names, which makes it much more painstaking to understand the dumps.

But this is easily fixable! With this PR, the human-readable name for each opcode is also given.

Sample output:

```
-1: [EH=0 CLD=0 WRM=1 NO_FT=0 0x7ffff7c38a60] used: 4, depth: 0,
  [00] line: 42, opcode: 149 (RESUME) arg: 0
  [01] line: 57, opcode: 85 (LOAD_FAST) arg: 1
  [02] line: 57, opcode: 40 (TO_BOOL)
  [03] line: 57, opcode: 97 (POP_JUMP_IF_FALSE) target: 0x7ffff7c38b80 [1] jump
-1: [EH=0 CLD=0 WRM=1 NO_FT=0 0x7ffff7c38ac0] used: 6, depth: 0,
  [00] line: 57, opcode: 91 (LOAD_GLOBAL) arg: 1
  [01] line: 57, opcode: 85 (LOAD_FAST) arg: 1
  [02] line: 57, opcode: 91 (LOAD_GLOBAL) arg: 2
  [03] line: 57, opcode: 53 (CALL) arg: 2
  [04] line: 57, opcode: 40 (TO_BOOL)
  [05] line: 57, opcode: 100 (POP_JUMP_IF_TRUE) target: 0x7ffff7c38b80 [1] jump
-1: [EH=0 CLD=0 WRM=1 NO_FT=1 0x7ffff7c38b20] used: 4, depth: 0,
  [00] line: 58, opcode: 91 (LOAD_GLOBAL) arg: 5
  [01] line: 58, opcode: 83 (LOAD_CONST) arg: 1
  [02] line: 58, opcode: 53 (CALL) arg: 1
  [03] line: 58, opcode: 101 (RAISE_VARARGS) arg: 1
1: [EH=0 CLD=0 WRM=1 NO_FT=0 0x7ffff7c38b80] used: 2, depth: 0,
  [00] line: 63, opcode: 85 (LOAD_FAST) arg: 1
  [01] line: 63, opcode: 99 (POP_JUMP_IF_NOT_NONE) target: 0x7ffff7c38c40 [3] jump
-1: [EH=0 CLD=0 WRM=1 NO_FT=1 0x7ffff7c38be0] used: 4, depth: 0, return
  [00] line: 64, opcode: 83 (LOAD_CONST) arg: 3
  [01] line: 64, opcode: 85 (LOAD_FAST) arg: 0
  [02] line: 64, opcode: 108 (STORE_ATTR) arg: 3
  [03] line: 64, opcode: 103 (RETURN_CONST) arg: 2
3: [EH=0 CLD=0 WRM=1 NO_FT=0 0x7ffff7c38c40] used: 5, depth: 0,
  [00] line: 66, opcode: 83 (LOAD_CONST) arg: 4
  [01] line: 66, opcode: 85 (LOAD_FAST) arg: 0
  [02] line: 66, opcode: 108 (STORE_ATTR) arg: 3
  [03] line: 67, opcode: 88 (LOAD_FAST_LOAD_FAST) arg: 16
  [04] line: 67, opcode: 108 (STORE_ATTR) arg: 4
2: [EH=0 CLD=0 WRM=1 NO_FT=1 0x7ffff7c38ca0] used: 1, depth: 0, return
  [00] line: 67, opcode: 103 (RETURN_CONST) arg: 2
```