### PR TITLE
gh-101100: Fix sphinx warnings in `turtle.rst`

### DIFF
--- a/Doc/library/turtle.rst
+++ b/Doc/library/turtle.rst
@@ -2315,7 +2315,7 @@ Public classes
 .. class:: RawTurtle(canvas)
            RawPen(canvas)
 
-   :param canvas: a :class:`tkinter.Canvas`, a :class:`ScrolledCanvas` or a
+   :param canvas: a :class:`!tkinter.Canvas`, a :class:`ScrolledCanvas` or a
                   :class:`TurtleScreen`
 
    Create a turtle.  The turtle has all methods described above as "methods of
@@ -2330,7 +2330,7 @@ Public classes
 
 .. class:: TurtleScreen(cv)
 
-   :param cv: a :class:`tkinter.Canvas`
+   :param cv: a :class:`!tkinter.Canvas`
 
    Provides screen oriented methods like :func:`bgcolor` etc. that are described
    above.
@@ -2414,7 +2414,7 @@ instance if one is not already present.
 
 ``Turtle`` is a subclass of :class:`RawTurtle`, which *doesn't* automatically
 create a drawing surface - a *canvas* will need to be provided or created for
-it. The *canvas* can be a :class:`tkinter.Canvas`, :class:`ScrolledCanvas`
+it. The *canvas* can be a :class:`!tkinter.Canvas`, :class:`ScrolledCanvas`
 or :class:`TurtleScreen`.
 
 
@@ -2422,7 +2422,7 @@ or :class:`TurtleScreen`.
 turtle. :class:`Screen` is a subclass of ``TurtleScreen``, and
 includes :ref:`some additional methods <screenspecific>` for managing its
 appearance (including size and title) and behaviour. ``TurtleScreen``'s
-constructor needs a :class:`tkinter.Canvas` or a
+constructor needs a :class:`!tkinter.Canvas` or a
 :class:`ScrolledCanvas` as an argument.
 
 The functional interface for turtle graphics uses the various methods of

--- a/Doc/tools/.nitignore
+++ b/Doc/tools/.nitignore
@@ -130,7 +130,6 @@ Doc/library/tkinter.scrolledtext.rst
 Doc/library/tkinter.ttk.rst
 Doc/library/traceback.rst
 Doc/library/tty.rst
-Doc/library/turtle.rst
 Doc/library/unittest.mock.rst
 Doc/library/unittest.rst
 Doc/library/urllib.parse.rst


### PR DESCRIPTION
It was:

```
/Users/sobolev/Desktop/cpython/Doc/library/turtle.rst:2318: WARNING: py:class reference target not found: tkinter.Canvas
/Users/sobolev/Desktop/cpython/Doc/library/turtle.rst:2333: WARNING: py:class reference target not found: tkinter.Canvas
/Users/sobolev/Desktop/cpython/Doc/library/turtle.rst:2415: WARNING: py:class reference target not found: tkinter.Canvas
/Users/sobolev/Desktop/cpython/Doc/library/turtle.rst:2421: WARNING: py:class reference target not found: tkinter.Canvas
```

But, since `tkinter.Canvas` is not documented in `tkinter`, we cannot reference it.

<!-- gh-issue-number: gh-101100 -->
* Issue: gh-101100
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--109394.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->