### PR TITLE
gh-109402: Fix regrtest findtests()

### DIFF
--- a/Lib/test/libregrtest/findtests.py
+++ b/Lib/test/libregrtest/findtests.py
@@ -38,14 +38,19 @@ def findtests(*, testdir: StrPath | None = None, exclude=(),
         mod, ext = os.path.splitext(name)
         if (not mod.startswith("test_")) or (mod in exclude):
             continue
-        if mod in split_test_dirs:
+        if base_mod:
+            fullname = f"{base_mod}.{mod}"
+        else:
+            fullname = mod
+        if fullname in split_test_dirs:
             subdir = os.path.join(testdir, mod)
-            mod = f"{base_mod or 'test'}.{mod}"
+            if not base_mod:
+                fullname = f"test.{mod}"
             tests.extend(findtests(testdir=subdir, exclude=exclude,
                                    split_test_dirs=split_test_dirs,
-                                   base_mod=mod))
+                                   base_mod=fullname))
         elif ext in (".py", ""):
-            tests.append(f"{base_mod}.{mod}" if base_mod else mod)
+            tests.append(fullname)
     return sorted(tests)
 
 


### PR DESCRIPTION
Check for the full module name in SPLITTESTDIRS, not the relative module name.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-109402 -->
* Issue: gh-109402
<!-- /gh-issue-number -->
