### PR TITLE
gh-109402: Fix `libregrtest` when module matches folder name

### DIFF
--- a/Lib/test/libregrtest/findtests.py
+++ b/Lib/test/libregrtest/findtests.py
@@ -38,7 +38,7 @@ def findtests(*, testdir: StrPath | None = None, exclude=(),
         mod, ext = os.path.splitext(name)
         if (not mod.startswith("test_")) or (mod in exclude):
             continue
-        if mod in split_test_dirs:
+        if mod in split_test_dirs and os.path.isdir(mod):
             subdir = os.path.join(testdir, mod)
             mod = f"{base_mod or 'test'}.{mod}"
             tests.extend(findtests(testdir=subdir, exclude=exclude,


### PR DESCRIPTION
It is fine now :)

```
0:00:00 load avg: 2.42 Run 5 tests sequentially
...
0:00:00 load avg: 2.42 [5/5] test_future_stmt.test_future_stmt

== Tests result: SUCCESS ==

All 5 tests OK.

Total duration: 177 ms
Total tests: run=32
Total test files: run=5/5
Result: SUCCESS
```

I am not sure if I should test it somehow in CI.

<!-- gh-issue-number: gh-109402 -->
* Issue: gh-109402
<!-- /gh-issue-number -->
