### PR TITLE
importlib.import_module: use "package is None" instead of "if not package"

### DIFF
--- a/Lib/importlib/__init__.py
+++ b/Lib/importlib/__init__.py
@@ -78,7 +78,7 @@ def import_module(name, package=None):
     """
     level = 0
     if name.startswith('.'):
-        if not package:
+        if package is None:
             raise TypeError("the 'package' argument is required to perform a "
                             f"relative import for {name!r}")
         for character in name:


### PR DESCRIPTION
The `package` variable should be compared using the newer `package is None` way of comparing to `None` rather than `not package`
