### PR TITLE
gh-109395: Remove skipped coverage job from Azure Pipelines

### DIFF
--- a/.azure-pipelines/ci.yml
+++ b/.azure-pipelines/ci.yml
@@ -1,6 +1,3 @@
-variables:
-  coverage: false
-
 trigger: ['main', '3.11', '3.10', '3.9', '3.8', '3.7']
 
 jobs:
@@ -49,33 +46,6 @@ jobs:
   - template: ./posix-steps.yml
     parameters:
       dependencies: apt
-
-
-- job: Ubuntu_Coverage_CI_Tests
-  displayName: Ubuntu CI Tests (coverage)
-  dependsOn: Prebuild
-  condition: |
-    and(
-        and(
-            succeeded(),
-            eq(variables['coverage'], 'true')
-        ),
-        eq(dependencies.Prebuild.outputs['tests.run'], 'true')
-    )
-
-  pool:
-    vmImage: ubuntu-22.04
-
-  variables:
-    testRunTitle: '$(Build.SourceBranchName)-linux-coverage'
-    testRunPlatform: linux-coverage
-    openssl_version: 1.1.1u
-
-  steps:
-  - template: ./posix-steps.yml
-    parameters:
-      dependencies: apt
-      coverage: true
 
 
 - job: Windows_CI_Tests

--- a/.azure-pipelines/posix-steps.yml
+++ b/.azure-pipelines/posix-steps.yml
@@ -1,5 +1,4 @@
 parameters:
-  coverage: false
   sudo_dependencies: sudo
   dependencies: apt
   patchcheck: true
@@ -23,47 +22,16 @@ steps:
 - script: make -j4
   displayName: 'Build CPython'
 
-- ${{ if eq(parameters.coverage, 'true') }}:
-  - script: ./python -m venv venv && ./venv/bin/python -m pip install -U coverage
-    displayName: 'Set up virtual environment'
+- script: make pythoninfo
+  displayName: 'Display build info'
 
-  - script: ./venv/bin/python -m test.pythoninfo
-    displayName: 'Display build info'
-
-  - script: |
-      $COMMAND -m coverage run --pylib -m test \
-                --fail-env-changed \
-                -uall,-cpu \
-                --junit-xml=$(build.binariesDirectory)/test-results.xml \
-                -x test_multiprocessing_fork \
-                -x test_multiprocessing_forkserver \
-                -x test_multiprocessing_spawn \
-                -x test_concurrent_futures
-    displayName: 'Tests with coverage'
-    env:
-      ${{ if eq(parameters.xvfb, 'true') }}:
-        COMMAND: xvfb-run ./venv/bin/python
-      ${{ if ne(parameters.xvfb, 'true') }}:
-        COMMAND: ./venv/bin/python
-
-  - script: ./venv/bin/python -m coverage xml
-    displayName: 'Generate coverage.xml'
-
-  - script: source ./venv/bin/activate && bash <(curl -s https://codecov.io/bash) -y .github/codecov.yml
-    displayName: 'Publish code coverage results'
-
-
-- ${{ if ne(parameters.coverage, 'true') }}:
-  - script: make pythoninfo
-    displayName: 'Display build info'
-
-  - script: $COMMAND buildbottest TESTOPTS="-j4 -uall,-cpu --junit-xml=$(build.binariesDirectory)/test-results.xml"
-    displayName: 'Tests'
-    env:
-      ${{ if eq(parameters.xvfb, 'true') }}:
-        COMMAND: xvfb-run make
-      ${{ if ne(parameters.xvfb, 'true') }}:
-        COMMAND: make
+- script: $COMMAND buildbottest TESTOPTS="-j4 -uall,-cpu --junit-xml=$(build.binariesDirectory)/test-results.xml"
+  displayName: 'Tests'
+  env:
+    ${{ if eq(parameters.xvfb, 'true') }}:
+      COMMAND: xvfb-run make
+    ${{ if ne(parameters.xvfb, 'true') }}:
+      COMMAND: make
 
 - ${{ if eq(parameters.patchcheck, 'true') }}:
   - script: |

--- a/.azure-pipelines/pr.yml
+++ b/.azure-pipelines/pr.yml
@@ -1,6 +1,3 @@
-variables:
-  coverage: false
-
 pr: ['main', '3.11', '3.10', '3.9', '3.8', '3.7']
 
 jobs:
@@ -51,33 +48,6 @@ jobs:
   - template: ./posix-steps.yml
     parameters:
       dependencies: apt
-
-
-- job: Ubuntu_Coverage_PR_Tests
-  displayName: Ubuntu PR Tests (coverage)
-  dependsOn: Prebuild
-  condition: |
-    and(
-        and(
-            succeeded(),
-            eq(variables['coverage'], 'true')
-        ),
-        eq(dependencies.Prebuild.outputs['tests.run'], 'true')
-    )
-
-  pool:
-    vmImage: ubuntu-22.04
-
-  variables:
-    testRunTitle: '$(Build.SourceBranchName)-linux-coverage'
-    testRunPlatform: linux-coverage
-    openssl_version: 1.1.1u
-
-  steps:
-  - template: ./posix-steps.yml
-    parameters:
-      dependencies: apt
-      coverage: true
 
 
 - job: Windows_PR_Tests


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

Remove the skipped `Ubuntu CI Tests (coverage)` job.

It looks like the last time it ran was in April 2021: https://app.codecov.io/gh/python/cpython

Even if we enable it, it crashes with a core dump [after 59 minutes](https://dev.azure.com/hugovk/CPython/_build/results?buildId=4009&view=logs&j=dab3c75d-0b55-5e4b-43c6-bb67925e6034&t=c144e935-82e9-5e97-ddc9-7022ba754539), compared to 15 minutes for the regular `Ubuntu CI Tests` build, which passes.


<!-- gh-issue-number: gh-109395 -->
* Issue: gh-109395
<!-- /gh-issue-number -->
