### PR TITLE
gh-107265: Add deopt for opcode from executor for future proof

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2023-09-14-20-15-57.gh-issue-107265.qHZL_6.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2023-09-14-20-15-57.gh-issue-107265.qHZL_6.rst
@@ -1,0 +1,1 @@
+Deopt opcodes hidden by the executor when base opcode is needed

--- a/Objects/codeobject.c
+++ b/Objects/codeobject.c
@@ -1505,7 +1505,7 @@ deopt_code(PyCodeObject *code, _Py_CODEUNIT *instructions)
         int opcode = _Py_GetBaseOpcode(code, i);
         if (opcode == ENTER_EXECUTOR) {
             _PyExecutorObject *exec = code->co_executors->executors[instructions[i].op.arg];
-            opcode = exec->vm_data.opcode;
+            opcode = _PyOpcode_Deopt[exec->vm_data.opcode];
             instructions[i].op.arg = exec->vm_data.oparg;
         }
         assert(opcode != ENTER_EXECUTOR);

--- a/Python/instrumentation.c
+++ b/Python/instrumentation.c
@@ -306,7 +306,7 @@ _PyInstruction_GetLength(PyCodeObject *code, int offset)
     if (opcode == ENTER_EXECUTOR) {
         int exec_index = _PyCode_CODE(code)[offset].op.arg;
         _PyExecutorObject *exec = code->co_executors->executors[exec_index];
-        opcode = exec->vm_data.opcode;
+        opcode = _PyOpcode_Deopt[exec->vm_data.opcode];
 
     }
     assert(opcode != ENTER_EXECUTOR);


### PR DESCRIPTION
For now only `JUMP_BACKWARD` is converted to `ENTER_EXECUTOR`, and it does not have specialization. However, in the future there might be other instructions involved, and in the scenarios where we want the base opcode, we should deopt the opcode from the VM.

<!-- gh-issue-number: gh-107265 -->
* Issue: gh-107265
<!-- /gh-issue-number -->
