### PR TITLE
Docs: getopt is deprecated in Python 3.13

### DIFF
--- a/Doc/library/superseded.rst
+++ b/Doc/library/superseded.rst
@@ -10,4 +10,5 @@ backwards compatibility. They have been superseded by other modules.
 
 .. toctree::
 
+   getopt.rst
    optparse.rst

--- a/Doc/library/superseded.rst
+++ b/Doc/library/superseded.rst
@@ -4,7 +4,7 @@
 Superseded Modules
 ******************
 
-The modules described in this chapter are deprecated and only kept for
+The modules described in this chapter are deprecated or :term:`soft deprecated` and only kept for
 backwards compatibility. They have been superseded by other modules.
 
 


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

Let's list it alongside `optparse` on https://docs.python.org/3.13/library/superseded.html.

Re:

* https://docs.python.org/3.13/whatsnew/3.13.html#deprecated
* https://github.com/python/cpython/issues/106535


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--109438.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->