### PR TITLE
Docs: Superseded modules: list only module names

### DIFF
--- a/Doc/library/superseded.rst
+++ b/Doc/library/superseded.rst
@@ -9,5 +9,6 @@ backwards compatibility. They have been superseded by other modules.
 
 
 .. toctree::
+   :maxdepth: 1
 
    optparse.rst


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

The [Superseded Modules](https://docs.python.org/3.12/library/superseded.html) page:

> The modules described in this chapter are deprecated and only kept for backwards compatibility. They have been superseded by other modules.

It shows a full table of modules with all sections and subsections:

<details>
<summary>Screenshot before</summary>

![image](https://github.com/python/cpython/assets/1324225/8e64b766-93c5-4b99-885d-8640bbb43d3b)

</details>

It's much cleaner to show only the modules:

<details>
<summary>Screenshot after</summary>

![image](https://github.com/python/cpython/assets/1324225/1032ab2a-eaea-45ad-b8ab-0c2876e59d50)


</details>


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--109439.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->