### PR TITLE
gh-109408: Remove Ubuntu unit tests from Azure Pipelines

### DIFF
--- a/.azure-pipelines/ci.yml
+++ b/.azure-pipelines/ci.yml
@@ -11,25 +11,6 @@ jobs:
   - template: ./prebuild-checks.yml
 
 
-- job: Ubuntu_CI_Tests
-  displayName: Ubuntu CI Tests
-  dependsOn: Prebuild
-  condition: and(succeeded(), eq(dependencies.Prebuild.outputs['tests.run'], 'true'))
-
-  pool:
-    vmImage: ubuntu-22.04
-
-  variables:
-    testRunTitle: '$(build.sourceBranchName)-linux'
-    testRunPlatform: linux
-    openssl_version: 1.1.1u
-
-  steps:
-  - template: ./posix-steps.yml
-    parameters:
-      dependencies: apt
-
-
 - job: Windows_CI_Tests
   displayName: Windows CI Tests
   dependsOn: Prebuild

--- a/.azure-pipelines/posix-steps.yml
+++ b/.azure-pipelines/posix-steps.yml
@@ -1,6 +1,3 @@
-parameters:
-  patchcheck: true
-
 steps:
 - checkout: self
   clean: true
@@ -22,9 +19,8 @@ steps:
 - script: make pythoninfo
   displayName: 'Display build info'
 
-- ${{ if eq(parameters.patchcheck, 'true') }}:
-  - script: |
-      git fetch origin
-      ./python Tools/patchcheck/patchcheck.py --ci true
-    displayName: 'Run patchcheck.py'
-    condition: and(succeeded(), eq(variables['Build.Reason'], 'PullRequest'))
+- script: |
+    git fetch origin
+    ./python Tools/patchcheck/patchcheck.py --ci true
+  displayName: 'Run patchcheck.py'
+  condition: and(succeeded(), eq(variables['Build.Reason'], 'PullRequest'))

--- a/.azure-pipelines/posix-steps.yml
+++ b/.azure-pipelines/posix-steps.yml
@@ -1,6 +1,4 @@
 parameters:
-  sudo_dependencies: sudo
-  dependencies: apt
   patchcheck: true
 
 steps:
@@ -12,7 +10,7 @@ steps:
 - script: sudo setfacl -Rb /home/vsts
   displayName: 'Workaround ACL issue'
 
-- script: ${{ parameters.sudo_dependencies }} ./.azure-pipelines/posix-deps-${{ parameters.dependencies }}.sh $(openssl_version)
+- script: sudo ./.azure-pipelines/posix-deps-apt.sh $(openssl_version)
   displayName: 'Install dependencies'
 
 - script: ./configure --with-pydebug

--- a/.azure-pipelines/posix-steps.yml
+++ b/.azure-pipelines/posix-steps.yml
@@ -2,7 +2,6 @@ parameters:
   sudo_dependencies: sudo
   dependencies: apt
   patchcheck: true
-  xvfb: true
 
 steps:
 - checkout: self
@@ -25,27 +24,9 @@ steps:
 - script: make pythoninfo
   displayName: 'Display build info'
 
-- script: $COMMAND buildbottest TESTOPTS="-j4 -uall,-cpu --junit-xml=$(build.binariesDirectory)/test-results.xml"
-  displayName: 'Tests'
-  env:
-    ${{ if eq(parameters.xvfb, 'true') }}:
-      COMMAND: xvfb-run make
-    ${{ if ne(parameters.xvfb, 'true') }}:
-      COMMAND: make
-
 - ${{ if eq(parameters.patchcheck, 'true') }}:
   - script: |
       git fetch origin
       ./python Tools/patchcheck/patchcheck.py --ci true
     displayName: 'Run patchcheck.py'
     condition: and(succeeded(), eq(variables['Build.Reason'], 'PullRequest'))
-
-
-- task: PublishTestResults@2
-  displayName: 'Publish Test Results'
-  inputs:
-    testResultsFiles: '$(build.binariesDirectory)/test-results.xml'
-    mergeTestResults: true
-    testRunTitle: $(testRunTitle)
-    platform: $(testRunPlatform)
-  condition: succeededOrFailed()

--- a/.azure-pipelines/pr.yml
+++ b/.azure-pipelines/pr.yml
@@ -11,8 +11,8 @@ jobs:
   - template: ./prebuild-checks.yml
 
 
-- job: Ubuntu_PR_Tests
-  displayName: Ubuntu PR Tests
+- job: Ubuntu_Patchcheck
+  displayName: Ubuntu patchcheck
   dependsOn: Prebuild
   condition: and(succeeded(), eq(dependencies.Prebuild.outputs['tests.run'], 'true'))
 

--- a/.azure-pipelines/pr.yml
+++ b/.azure-pipelines/pr.yml
@@ -26,8 +26,6 @@ jobs:
 
   steps:
   - template: ./posix-steps.yml
-    parameters:
-      dependencies: apt
 
 
 - job: Windows_PR_Tests


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


Both `ci.yml` and `pr.yml` run `Ubuntu_CI_Tests` which runs `.azure-pipelines/posix-steps.yml`

`.azure-pipelines/posix-steps.yml` does:

1. checkout/setup
2. build Python 
3. display build info
4. run unit tests
5. run `patchcheck` (PR only)
6. report unit test results

This PR removes the Ubuntu unit test run (4)/report (6), as we're running it on GitHub Actions.

Because `patchcheck` is only run for PRs (`pr.yml`), there's no point building Python and then doing nothing for `ci.yml`, so we can remove the whole `Ubuntu_CI_Tests` from `ci.yml`.

Finally, rename `Ubuntu_CI_Tests` to something more accurate: `Ubuntu_Patchcheck`.

This speeds up Ubunutu part of `pr.yml` from ~14 to ~4 mins, and `ci.yml` from ~14 to 0 mins.


<!-- gh-issue-number: gh-109408 -->
* Issue: gh-109408
<!-- /gh-issue-number -->
