### PR TITLE
gh-109413: Fix some trivial mypy nitpicks in libregrtest

### DIFF
--- a/Lib/test/libregrtest/logger.py
+++ b/Lib/test/libregrtest/logger.py
@@ -32,9 +32,9 @@ class Logger:
 
         mins, secs = divmod(int(test_time), 60)
         hours, mins = divmod(mins, 60)
-        test_time = "%d:%02d:%02d" % (hours, mins, secs)
+        formatted_test_time = "%d:%02d:%02d" % (hours, mins, secs)
 
-        line = f"{test_time} {line}"
+        line = f"{formatted_test_time} {line}"
         if empty:
             line = line[:-1]
 

--- a/Lib/test/libregrtest/logger.py
+++ b/Lib/test/libregrtest/logger.py
@@ -28,13 +28,13 @@ class Logger:
             line = f"load avg: {load_avg:.2f} {line}"
 
         # add the timestamp prefix:  "0:01:05 "
-        test_time = time.perf_counter() - self.start_time
+        log_time = time.perf_counter() - self.start_time
 
-        mins, secs = divmod(int(test_time), 60)
+        mins, secs = divmod(int(log_time), 60)
         hours, mins = divmod(mins, 60)
-        formatted_test_time = "%d:%02d:%02d" % (hours, mins, secs)
+        formatted_log_time = "%d:%02d:%02d" % (hours, mins, secs)
 
-        line = f"{formatted_test_time} {line}"
+        line = f"{formatted_log_time} {line}"
         if empty:
             line = line[:-1]
 

--- a/Lib/test/libregrtest/results.py
+++ b/Lib/test/libregrtest/results.py
@@ -231,8 +231,7 @@ class TestResults:
             report.append(f'failures={stats.failures:,}')
         if stats.skipped:
             report.append(f'skipped={stats.skipped:,}')
-        report = ' '.join(report)
-        print(f"Total tests: {report}")
+        print(f"Total tests: {' '.join(report)}")
 
         # Total test files
         all_tests = [self.good, self.bad, self.rerun,
@@ -256,5 +255,4 @@ class TestResults:
         ):
             if tests:
                 report.append(f'{name}={len(tests)}')
-        report = ' '.join(report)
-        print(f"Total test files: {report}")
+        print(f"Total test files: {' '.join(report)}")

--- a/Lib/test/libregrtest/single.py
+++ b/Lib/test/libregrtest/single.py
@@ -136,14 +136,14 @@ def _runtest_env_changed_exc(result: TestResult, runtests: RunTests,
         with saved_test_environment(test_name,
                                     runtests.verbose, quiet, pgo=pgo):
             _load_run_test(result, runtests)
-    except support.ResourceDenied as msg:
+    except support.ResourceDenied as exc:
         if not quiet and not pgo:
-            print(f"{test_name} skipped -- {msg}", flush=True)
+            print(f"{test_name} skipped -- {exc}", flush=True)
         result.state = State.RESOURCE_DENIED
         return
-    except unittest.SkipTest as msg:
+    except unittest.SkipTest as exc:
         if not quiet and not pgo:
-            print(f"{test_name} skipped -- {msg}", flush=True)
+            print(f"{test_name} skipped -- {exc}", flush=True)
         result.state = State.SKIPPED
         return
     except support.TestFailedWithDetails as exc:

--- a/Lib/test/libregrtest/worker.py
+++ b/Lib/test/libregrtest/worker.py
@@ -25,7 +25,7 @@ def create_worker_process(runtests: RunTests, output_fd: int,
     if python_cmd is not None:
         executable = python_cmd
     else:
-        executable = [sys.executable]
+        executable = (sys.executable,)
     cmd = [*executable, *support.args_from_interpreter_flags(),
            '-u',    # Unbuffered stdout and stderr
            '-m', 'test.libregrtest.worker',


### PR DESCRIPTION
This PR fixes various mypy nitpicks with `Lib/test/libregrtest` that require small changes to the existing code, but can all be resolved fairly trivially.

Currently, if you `cd` into `Lib/test` and then run `mypy --config-file regrtest/mypy.ini`, mypy reports 23 errors. This PR brings the number of errors reported down to 9.

<!-- gh-issue-number: gh-109413 -->
* Issue: gh-109413
<!-- /gh-issue-number -->
