### PR TITLE
gh-91960: Disable Cirrus CI for now

### DIFF
--- a/.cirrus-DISABLED.yml
+++ b/.cirrus-DISABLED.yml
@@ -1,3 +1,6 @@
+# gh-91960: Job disabled since Python is out of free credit (September 2023):
+# https://discuss.python.org/t/freebsd-gets-a-new-cirrus-ci-github-action-job-and-a-new-buildbot/33122/26
+
 freebsd_task:
   freebsd_instance:
     matrix:


### PR DESCRIPTION
Python is out of free credit and so all jobs are reported as failure.

Rename .cirrus.yml to .cirrus-DISABLED.yml to disable the job.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-91960 -->
* Issue: gh-91960
<!-- /gh-issue-number -->
