### PR TITLE
fix extraneous backslashes in hashlib docs

### DIFF
--- a/Doc/library/hashlib.rst
+++ b/Doc/library/hashlib.rst
@@ -136,16 +136,16 @@ Using :func:`new` with an algorithm name:
    '031edd7d41651593c5fe5c006fa5752b37fddff7bc4e843aa6af0c950f4b9406'
 
 
-.. function:: md5([, data], \*, usedforsecurity=True)
-.. function:: sha1([, data], \*, usedforsecurity=True)
-.. function:: sha224([, data], \*, usedforsecurity=True)
-.. function:: sha256([, data], \*, usedforsecurity=True)
-.. function:: sha384([, data], \*, usedforsecurity=True)
-.. function:: sha512([, data], \*, usedforsecurity=True)
-.. function:: sha3_224([, data], \*, usedforsecurity=True)
-.. function:: sha3_256([, data], \*, usedforsecurity=True)
-.. function:: sha3_384([, data], \*, usedforsecurity=True)
-.. function:: sha3_512([, data], \*, usedforsecurity=True)
+.. function:: md5([, data], *, usedforsecurity=True)
+.. function:: sha1([, data], *, usedforsecurity=True)
+.. function:: sha224([, data], *, usedforsecurity=True)
+.. function:: sha256([, data], *, usedforsecurity=True)
+.. function:: sha384([, data], *, usedforsecurity=True)
+.. function:: sha512([, data], *, usedforsecurity=True)
+.. function:: sha3_224([, data], *, usedforsecurity=True)
+.. function:: sha3_256([, data], *, usedforsecurity=True)
+.. function:: sha3_384([, data], *, usedforsecurity=True)
+.. function:: sha3_512([, data], *, usedforsecurity=True)
 
 Named constructors such as these are faster than passing an algorithm name to
 :func:`new`.
@@ -234,8 +234,8 @@ A hash object has the following methods:
 SHAKE variable length digests
 -----------------------------
 
-.. function:: shake_128([, data], \*, usedforsecurity=True)
-.. function:: shake_256([, data], \*, usedforsecurity=True)
+.. function:: shake_128([, data], *, usedforsecurity=True)
+.. function:: shake_256([, data], *, usedforsecurity=True)
 
 The :func:`shake_128` and :func:`shake_256` algorithms provide variable
 length digests with length_in_bits//2 up to 128 or 256 bits of security.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--109468.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->