### PR TITLE
[3.12] gh-109096: Silence test_httpservers fork + threads DeprecationWarning on CGI support

### DIFF
--- a/Lib/test/test_httpservers.py
+++ b/Lib/test/test_httpservers.py
@@ -26,6 +26,7 @@ import time
 import datetime
 import threading
 from unittest import mock
+import warnings
 from io import BytesIO, StringIO
 
 import unittest
@@ -699,7 +700,11 @@ print("</pre>")
         "This test can't be run reliably as root (issue #13308).")
 class CGIHTTPServerTestCase(BaseTestCase):
     class request_handler(NoLogRequestHandler, CGIHTTPRequestHandler):
-        pass
+        def run_cgi(self):
+            # Silence the threading + fork DeprecationWarning this causes.
+            # gh-109096: This is deprecated in 3.13 to go away in 3.15.
+            with warnings.catch_warnings(action='ignore', category=DeprecationWarning):
+                return super().run_cgi()
 
     linesep = os.linesep.encode('ascii')
 


### PR DESCRIPTION
We're not fixing CGIHTTPRequestHandler as it is deprecated in 3.13 to go away in 3.15.  This just removes noise from our test suite when warnings are rightfully enabled.

If the long pre-existing fork+threading mix here ever causes anyone deadlocks as is possible, disabling the test entirely on that platform makes sense rather than attempting to fix http.server.CGIHTTPRequestHandler or refactor the test to not use a threaded server in the test.

<!-- gh-issue-number: gh-109096 -->
* Issue: gh-109096
<!-- /gh-issue-number -->
