### PR TITLE
Fix incorrect parameter docstring for str.rsplit

### DIFF
--- a/Objects/clinic/unicodeobject.c.h
+++ b/Objects/clinic/unicodeobject.c.h
@@ -953,7 +953,7 @@ PyDoc_STRVAR(unicode_split__doc__,
 "    character (including \\n \\r \\t \\f and spaces) and will discard\n"
 "    empty strings from the result.\n"
 "  maxsplit\n"
-"    Maximum number of splits (starting from the left).\n"
+"    Maximum number of splits.\n"
 "    -1 (the default value) means no limit.\n"
 "\n"
 "Note, str.split() is mainly useful for data that has been intentionally\n"
@@ -1077,7 +1077,7 @@ PyDoc_STRVAR(unicode_rsplit__doc__,
 "    character (including \\n \\r \\t \\f and spaces) and will discard\n"
 "    empty strings from the result.\n"
 "  maxsplit\n"
-"    Maximum number of splits (starting from the left).\n"
+"    Maximum number of splits.\n"
 "    -1 (the default value) means no limit.\n"
 "\n"
 "Splitting starts at the end of the string and works to the front.");
@@ -1504,4 +1504,4 @@ skip_optional_pos:
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=4acdcfdc93f2a0f6 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=0c0db28b6a01d281 input=a9049054013a1b77]*/

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -12405,7 +12405,7 @@ str.split as unicode_split
         character (including \n \r \t \f and spaces) and will discard
         empty strings from the result.
     maxsplit: Py_ssize_t = -1
-        Maximum number of splits (starting from the left).
+        Maximum number of splits.
         -1 (the default value) means no limit.
 
 Return a list of the substrings in the string, using sep as the separator string.
@@ -12418,7 +12418,7 @@ the regular expression module.
 
 static PyObject *
 unicode_split_impl(PyObject *self, PyObject *sep, Py_ssize_t maxsplit)
-/*[clinic end generated code: output=3a65b1db356948dc input=07b9040d98c5fe8d]*/
+/*[clinic end generated code: output=3a65b1db356948dc input=30914f5690f8954f]*/
 {
     if (sep == Py_None)
         return split(self, NULL, maxsplit);


### PR DESCRIPTION
The parameter docstring for maxsplit was specific to str.split, but was automatically cloned to str.rsplit.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
