### PR TITLE
gh-109495: Remove unused slots from the Python implementation of datetime

### DIFF
--- a/Lib/_pydatetime.py
+++ b/Lib/_pydatetime.py
@@ -1684,7 +1684,7 @@ class datetime(date):
     The year, month and day arguments are required. tzinfo may be None, or an
     instance of a tzinfo subclass. The remaining arguments may be ints.
     """
-    __slots__ = date.__slots__ + time.__slots__
+    __slots__ = time.__slots__
 
     def __new__(cls, year, month=None, day=None, hour=0, minute=0, second=0,
                 microsecond=0, tzinfo=None, *, fold=0):

--- a/Misc/NEWS.d/next/Library/2023-09-16-15-44-16.gh-issue-109495.m2H5Bk.rst
+++ b/Misc/NEWS.d/next/Library/2023-09-16-15-44-16.gh-issue-109495.m2H5Bk.rst
@@ -1,0 +1,1 @@
+Remove unnecessary extra ``__slots__`` in :py:class:`datetime`\'s pure python implementation to reduce memory size, as they are defined in the superclass. Patch by James Hilton-Balfe


### PR DESCRIPTION
These slots aren't required because they are defined in the super class

<!-- gh-issue-number: gh-109495 -->
* Issue: gh-109495
<!-- /gh-issue-number -->
