### PR TITLE
gh-109503: Fix document for `shutil.move` on usage of `os.rename` since it's inaccurate

### DIFF
--- a/Doc/library/shutil.rst
+++ b/Doc/library/shutil.rst
@@ -361,10 +361,14 @@ Directory and files operations
    directory. If the destination already exists but is not a directory, it may
    be overwritten depending on :func:`os.rename` semantics.
 
-   If the destination is on the current filesystem, then :func:`os.rename` is
-   used. Otherwise, *src* is copied to *dst* using *copy_function* and then
-   removed.  In case of symlinks, a new symlink pointing to the target of *src*
-   will be created in or as *dst* and *src* will be removed.
+   :func:`os.rename` is preferably used internally when *src* and *dst* are on
+   the same filesystem. In case :func:`os.rename` fails due to :exc:`OSError`
+   (e.g. the user has write permission to *dst* file but not to its parent
+   directory), this method falls back to using *copy_function*, in which case
+   *src* is copied to *dst* using *copy_function* and then removed.
+
+   In case of symlinks, a new symlink pointing to the target of *src* will be
+   created in or as *dst*, and *src* will be removed.
 
    If *copy_function* is given, it must be a callable that takes two arguments
    *src* and *dst*, and will be used to copy *src* to *dst* if

--- a/Lib/shutil.py
+++ b/Lib/shutil.py
@@ -829,10 +829,14 @@ def move(src, dst, copy_function=copy2):
     If the destination already exists but is not a directory, it may be
     overwritten depending on os.rename() semantics.
 
-    If the destination is on our current filesystem, then rename() is used.
-    Otherwise, src is copied to the destination and then removed. Symlinks are
-    recreated under the new name if os.rename() fails because of cross
-    filesystem renames.
+    os.rename() is preferably used if the source and destination are on the
+    same filesystem. In case os.rename() fails due to OSError (e.g. the user
+    has write permission to *dst* file but not to its parent directory),
+    this method falls back to using *copy_function* silently.
+    Symlinks are also recreated under the new name if os.rename() fails
+    because of cross filesystem renames.
+
+    It's recommended to use os.rename() if atomic move is strictly required.
 
     The optional `copy_function` argument is a callable that will be used
     to copy the source or it will be delegated to `copytree`.

--- a/Misc/NEWS.d/next/Documentation/2023-09-16-23-42-27.gh-issue-109503.mZ-kdU.rst
+++ b/Misc/NEWS.d/next/Documentation/2023-09-16-23-42-27.gh-issue-109503.mZ-kdU.rst
@@ -1,0 +1,3 @@
+Fix documentation for :func:`shutil.move` on usage of
+:func:`os.rename` since nonatomic move might be used even if the files are
+on the same filesystem. Patch by Fang Li


### PR DESCRIPTION
# gh-109503: Fix document for `shutil.move` on usage of `os.rename` since it's inaccurate

The [document/docstring](https://github.com/python/cpython/blob/e57ecf6bbc59f999d27b125ea51b042c24a07bd9/Doc/library/shutil.rst?plain=1#L364-L366) for `shutil.move` states:

> If the destination is on the current filesystem, then :func:`os.rename` is used.
> Otherwise, *src* is copied to *dst* using *copy_function* and then removed.

which seems to be incorrect. The actual behavior shows below:


* If `src` and `target` are on the same filesystem, `os.rename` is **preferred**, which is an *atomic* operation. 
* But, if `os.rename` fails due to some reason *(e.g. permission denied)*, then `shutil.move` will **silently** fallback to *nonatomic* `copy+remove`.

This `fallback` behavior is crucial in case atomic operation matters. It creates false statement that an operation must be atomic, while in fact it is non-atomic in some cases.

## For example

**Given all following dirs and files on the SAME filesystem**

```
// 600: rw_ ___ ___
// 700: rwx ___ ___

userA:groupA 700  /dirSrc
userA:groupA 600  /dirSrc/fileSrc

userB:groupB 700  /dirTarget
userA:groupA 600  /dirTarget/fileTarget
```

**When the userA calls:**

```python
# Run by userA
shutil.move('/dirSrc/fileSrc', '/dirTarget/fileTarget')
# Move succeeded
```

Based on current doc, user expects that the move must be **atomic** since both files are on the same filesystem. But in fact, this operation will fall back to `copy+del` silently, which is **not** atomic.

<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--109504.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->