### PR TITLE
Remove unused variable from `functools._lru_cache_wrapper`

### DIFF
--- a/Lib/functools.py
+++ b/Lib/functools.py
@@ -603,7 +603,6 @@ def _lru_cache_wrapper(user_function, maxsize, typed, _CacheInfo):
                     # still adjusting the links.
                     root = oldroot[NEXT]
                     oldkey = root[KEY]
-                    oldresult = root[RESULT]
                     root[KEY] = root[RESULT] = None
                     # Now update the cache dictionary.
                     del cache[oldkey]


### PR DESCRIPTION
It was not used, so we can skip doing one extra `__getitem__` call.