### PR TITLE
gh-109413 Improve the mypy config file for libregrtest

### DIFF
--- a/Lib/test/libregrtest/mypy.ini
+++ b/Lib/test/libregrtest/mypy.ini
@@ -1,12 +1,10 @@
 # Config file for running mypy on libregrtest.
-#
-# Note: mypy can't be run on libregrtest from the CPython repo root.
-# If you try to do so, mypy will complain
-# about the entire `Lib/` directory "shadowing the stdlib".
-# Instead, `cd` into `Lib/test`, then run `mypy --config-file libregrtest/mypy.ini`.
+# Run mypy by invoking `mypy --config-file Lib/test/libregrtest/mypy.ini`
+# on the command-line from the repo root
 
 [mypy]
-packages = libregrtest
+files = Lib/test/libregrtest
+explicit_package_bases = True
 python_version = 3.11
 platform = linux
 pretty = True
@@ -17,7 +15,6 @@ strict = True
 
 # Various stricter settings that we can't yet enable
 # Try to enable these in the following order:
-strict_optional = False
 disallow_any_generics = False
 disallow_incomplete_defs = False
 disallow_untyped_calls = False
@@ -27,21 +24,10 @@ warn_return_any = False
 
 disable_error_code = return
 
+# Enable --strict-optional for these ASAP:
+[mypy-Lib.test.libregrtest.main.*,Lib.test.libregrtest.run_workers.*,Lib.test.libregrtest.worker.*,Lib.test.libregrtest.single.*,Lib.test.libregrtest.results.*,Lib.test.libregrtest.utils.*]
+strict_optional = False
+
 # Various internal modules that typeshed deliberately doesn't have stubs for:
-[mypy-_abc.*]
-ignore_missing_imports = True
-
-[mypy-_opcode.*]
-ignore_missing_imports = True
-
-[mypy-_overlapped.*]
-ignore_missing_imports = True
-
-[mypy-_testcapi.*]
-ignore_missing_imports = True
-
-[mypy-_testinternalcapi.*]
-ignore_missing_imports = True
-
-[mypy-test.*]
+[mypy-_abc.*,_opcode.*,_overlapped.*,_testcapi.*,_testinternalcapi.*,test.*]
 ignore_missing_imports = True


### PR DESCRIPTION
- Set `explicit_package_bases = True` in the config file. This means that mypy can now be run on libregrtest from the repo root, rather than having to `cd` into the `Lib/test` directory. You can now invoke mypy by running `mypy --config-file Lib/test/libregrtest/mypy.ini`.
- Consolidate all of the packages we're ignoring missing import from into one section, rather than having a separate section for each one.
- Only disable `--strict-optional` for the specific submodules that currently have strict-optional errors in them.

Cc. @vstinner 

<!-- gh-issue-number: gh-109413 -->
* Issue: gh-109413
<!-- /gh-issue-number -->
