### PR TITLE
gh-109553: Add link to precise specification of lambda parameters list

### DIFF
--- a/Doc/reference/expressions.rst
+++ b/Doc/reference/expressions.rst
@@ -1843,7 +1843,8 @@ object.  The unnamed object behaves like a function object defined with:
 
 See section :ref:`function` for the syntax of parameter lists.  Note that
 functions created with lambda expressions cannot contain statements or
-annotations.
+annotations. See :doc:`standard Python grammar <./grammar>`
+for precise grammar specification of lambda parameters.
 
 
 .. _exprlists:


### PR DESCRIPTION
Based on the grammar seems like it's possible to have type annotations there:
https://docs.python.org/3/reference/expressions.html#lambda

lambda has a parameter_list, parameter_list can have a defparameter and defparameter is a parameter. This is the valid grammar for parameter:

```
parameter  ::=  identifier [":" expression]
```

Although there's a note on the page that
> Note that functions created with lambda expressions cannot contain statements or annotations.

I think it makes sense to hint the reader that they should read the other link for parameter grammar instead of the grammar on this page. Let me know if you think we should just update the grammar on this page. I thought that is not a good idea because it is good enough.

<!-- gh-issue-number: gh-109553 -->
* Issue: gh-109553
<!-- /gh-issue-number -->

* https://cpython-previews--109552.org.readthedocs.build/en/109552/reference/expressions.html#lambda
