### PR TITLE
gh-109051: asyncio: remove outgoing buffer from sslproto

### DIFF
--- a/Lib/asyncio/base_events.py
+++ b/Lib/asyncio/base_events.py
@@ -205,12 +205,14 @@ def _check_ssl_socket(sock):
 
 class _SendfileFallbackProtocol(protocols.Protocol):
     def __init__(self, transp):
-        if not isinstance(transp, transports._FlowControlMixin):
-            raise TypeError("transport should be _FlowControlMixin instance")
         self._transport = transp
         self._proto = transp.get_protocol()
         self._should_resume_reading = transp.is_reading()
-        self._should_resume_writing = transp._protocol_paused
+
+        # should we expect a call to resume_writing?
+        _, high_water = transp.get_write_buffer_limits()
+        self._should_resume_writing = transp.get_write_buffer_size() > high_water
+
         transp.pause_reading()
         transp.set_protocol(self)
         if self._should_resume_writing:

--- a/Lib/asyncio/sslproto.py
+++ b/Lib/asyncio/sslproto.py
@@ -75,8 +75,7 @@ def add_flowcontrol_defaults(high, low, kb):
     return hi, lo
 
 
-class _SSLProtocolTransport(transports._FlowControlMixin,
-                            transports.Transport):
+class _SSLProtocolTransport(transports.Transport):
 
     _start_tls_compatible = True
     _sendfile_compatible = constants._SendfileMode.FALLBACK

--- a/Lib/asyncio/sslproto.py
+++ b/Lib/asyncio/sslproto.py
@@ -158,16 +158,14 @@ class _SSLProtocolTransport(transports._FlowControlMixin,
         reduces opportunities for doing I/O and computation
         concurrently.
         """
-        self._ssl_protocol._set_write_buffer_limits(high, low)
-        self._ssl_protocol._control_app_writing()
+        self._ssl_protocol._transport.set_write_buffer_limits(high, low)
 
     def get_write_buffer_limits(self):
-        return (self._ssl_protocol._outgoing_low_water,
-                self._ssl_protocol._outgoing_high_water)
+        return self._ssl_protocol._transport.get_write_buffer_limits()
 
     def get_write_buffer_size(self):
         """Return the current size of the write buffers."""
-        return self._ssl_protocol._get_write_buffer_size()
+        return self._ssl_protocol._transport.get_write_buffer_size()
 
     def set_read_buffer_limits(self, high=None, low=None):
         """Set the high- and low-water limits for read flow control.
@@ -198,11 +196,6 @@ class _SSLProtocolTransport(transports._FlowControlMixin,
     def get_read_buffer_size(self):
         """Return the current size of the read buffer."""
         return self._ssl_protocol._get_read_buffer_size()
-
-    @property
-    def _protocol_paused(self):
-        # Required for sendfile fallback pause_writing/resume_writing logic
-        return self._ssl_protocol._app_writing_paused
 
     def write(self, data):
         """Write some data bytes to the transport.
@@ -251,11 +244,6 @@ class _SSLProtocolTransport(transports._FlowControlMixin,
         self._closed = True
         self._ssl_protocol._abort(exc)
 
-    def _test__append_write_backlog(self, data):
-        # for test only
-        self._ssl_protocol._write_backlog.append(data)
-        self._ssl_protocol._write_buffer_size += len(data)
-
 
 class SSLProtocol(protocols.BufferedProtocol):
     max_size = 256 * 1024   # Buffer size passed to read()
@@ -302,10 +290,6 @@ class SSLProtocol(protocols.BufferedProtocol):
         # completes.
         self._extra = dict(sslcontext=sslcontext)
 
-        # App data write buffering
-        self._write_backlog = collections.deque()
-        self._write_buffer_size = 0
-
         self._waiter = waiter
         self._loop = loop
         self._set_app_protocol(app_protocol)
@@ -331,8 +315,6 @@ class SSLProtocol(protocols.BufferedProtocol):
 
         # Flow Control
 
-        self._ssl_writing_paused = False
-
         self._app_reading_paused = False
 
         self._ssl_reading_paused = False
@@ -341,10 +323,6 @@ class SSLProtocol(protocols.BufferedProtocol):
         self._set_read_buffer_limits()
         self._eof_received = False
 
-        self._app_writing_paused = False
-        self._outgoing_high_water = 0
-        self._outgoing_low_water = 0
-        self._set_write_buffer_limits()
         self._get_app_transport()
 
     def _set_app_protocol(self, app_protocol):
@@ -391,7 +369,6 @@ class SSLProtocol(protocols.BufferedProtocol):
         meaning a regular EOF is received or the connection was
         aborted or closed).
         """
-        self._write_backlog.clear()
         self._outgoing.read()
         self._conn_lost += 1
 
@@ -468,7 +445,6 @@ class SSLProtocol(protocols.BufferedProtocol):
                     self._do_flush()
 
             elif self._state == SSLProtocolState.FLUSHING:
-                self._do_write()
                 self._set_state(SSLProtocolState.SHUTDOWN)
                 self._do_shutdown()
 
@@ -682,38 +658,19 @@ class SSLProtocol(protocols.BufferedProtocol):
             return
 
         for data in list_of_data:
-            self._write_backlog.append(data)
-            self._write_buffer_size += len(data)
+            self._sslobj.write(data)
 
         try:
             if self._state == SSLProtocolState.WRAPPED:
-                self._do_write()
+                self._process_outgoing()
 
         except Exception as ex:
             self._fatal_error(ex, 'Fatal error on SSL protocol')
 
-    def _do_write(self):
-        try:
-            while self._write_backlog:
-                data = self._write_backlog[0]
-                count = self._sslobj.write(data)
-                data_len = len(data)
-                if count < data_len:
-                    self._write_backlog[0] = data[count:]
-                    self._write_buffer_size -= count
-                else:
-                    del self._write_backlog[0]
-                    self._write_buffer_size -= data_len
-        except SSLAgainErrors:
-            pass
-        self._process_outgoing()
-
     def _process_outgoing(self):
-        if not self._ssl_writing_paused:
-            data = self._outgoing.read()
-            if len(data):
-                self._transport.write(data)
-        self._control_app_writing()
+        data = self._outgoing.read()
+        if len(data):
+            self._transport.write(data)
 
     # Incoming flow
 
@@ -731,10 +688,7 @@ class SSLProtocol(protocols.BufferedProtocol):
                     self._do_read__buffered()
                 else:
                     self._do_read__copied()
-                if self._write_backlog:
-                    self._do_write()
-                else:
-                    self._process_outgoing()
+                self._process_outgoing()
             self._control_ssl_reading()
         except Exception as ex:
             self._fatal_error(ex, 'Fatal error on SSL protocol')
@@ -811,46 +765,6 @@ class SSLProtocol(protocols.BufferedProtocol):
         except BaseException as ex:
             self._fatal_error(ex, 'Error calling eof_received()')
 
-    # Flow control for writes from APP socket
-
-    def _control_app_writing(self):
-        size = self._get_write_buffer_size()
-        if size >= self._outgoing_high_water and not self._app_writing_paused:
-            self._app_writing_paused = True
-            try:
-                self._app_protocol.pause_writing()
-            except (KeyboardInterrupt, SystemExit):
-                raise
-            except BaseException as exc:
-                self._loop.call_exception_handler({
-                    'message': 'protocol.pause_writing() failed',
-                    'exception': exc,
-                    'transport': self._app_transport,
-                    'protocol': self,
-                })
-        elif size <= self._outgoing_low_water and self._app_writing_paused:
-            self._app_writing_paused = False
-            try:
-                self._app_protocol.resume_writing()
-            except (KeyboardInterrupt, SystemExit):
-                raise
-            except BaseException as exc:
-                self._loop.call_exception_handler({
-                    'message': 'protocol.resume_writing() failed',
-                    'exception': exc,
-                    'transport': self._app_transport,
-                    'protocol': self,
-                })
-
-    def _get_write_buffer_size(self):
-        return self._outgoing.pending + self._write_buffer_size
-
-    def _set_write_buffer_limits(self, high=None, low=None):
-        high, low = add_flowcontrol_defaults(
-            high, low, constants.FLOW_CONTROL_HIGH_WATER_SSL_WRITE)
-        self._outgoing_high_water = high
-        self._outgoing_low_water = low
-
     # Flow control for reads to APP socket
 
     def _pause_reading(self):
@@ -895,16 +809,13 @@ class SSLProtocol(protocols.BufferedProtocol):
         """Called when the low-level transport's buffer goes over
         the high-water mark.
         """
-        assert not self._ssl_writing_paused
-        self._ssl_writing_paused = True
+        self._app_protocol.pause_writing()
 
     def resume_writing(self):
         """Called when the low-level transport's buffer drains below
         the low-water mark.
         """
-        assert self._ssl_writing_paused
-        self._ssl_writing_paused = False
-        self._process_outgoing()
+        self._app_protocol.resume_writing()
 
     def _fatal_error(self, exc, message='Fatal error on transport'):
         if self._transport:

--- a/Lib/test/test_asyncio/test_ssl.py
+++ b/Lib/test/test_asyncio/test_ssl.py
@@ -1305,7 +1305,6 @@ class TestSSL(test_utils.TestCase):
 
     def test_remote_shutdown_receives_trailing_data(self):
         CHUNK = 1024 * 128
-        SIZE = 32
 
         sslctx = self._create_server_ssl_context(
             test_utils.ONLYCERT,
@@ -1343,25 +1342,38 @@ class TestSSL(test_utils.TestCase):
             sslobj.write(b'pong')
             sock.send(outgoing.read())
 
-            time.sleep(0.2)  # wait for the peer to fill its backlog
+            data_len = 0
+            filled.wait()
+            # trigger peer's resume_writing()
+            incoming.write(sock.recv(65536 * 4))
+            while True:
+                try:
+                    chunk = len(sslobj.read(16384))
+                    data_len += chunk
+                except ssl.SSLWantReadError:
+                    break
 
             # send close_notify but don't wait for response
             with self.assertRaises(ssl.SSLWantReadError):
                 sslobj.unwrap()
             sock.send(outgoing.read())
 
+            eof_received.wait()
             # should receive all data
-            data_len = 0
             while True:
                 try:
                     chunk = len(sslobj.read(16384))
                     data_len += chunk
                 except ssl.SSLWantReadError:
                     incoming.write(sock.recv(16384))
+                    if not incoming.pending:
+                        # EOF received
+                        break
                 except ssl.SSLZeroReturnError:
                     break
 
-            self.assertEqual(data_len, CHUNK * SIZE)
+            assert count > 0
+            self.assertEqual(data_len, CHUNK * count)
 
             # verify that close_notify is received
             sslobj.unwrap()
@@ -1373,19 +1385,20 @@ class TestSSL(test_utils.TestCase):
             self.assertEqual(sock.recv_all(4), b'ping')
             sock.send(b'pong')
 
-            time.sleep(0.2)  # wait for the peer to fill its backlog
+            filled.wait()
 
             # send EOF
             sock.shutdown(socket.SHUT_WR)
 
             # should receive all data
-            data = sock.recv_all(CHUNK * SIZE)
-            self.assertEqual(len(data), CHUNK * SIZE)
+            assert count > 0
+            data = sock.recv_all(CHUNK * count)
+            self.assertEqual(len(data), CHUNK * count)
 
             sock.close()
 
         async def client(addr):
-            nonlocal future
+            nonlocal future, count
             future = self.loop.create_future()
 
             reader, writer = await asyncio.open_connection(
@@ -1396,15 +1409,18 @@ class TestSSL(test_utils.TestCase):
             data = await reader.readexactly(4)
             self.assertEqual(data, b'pong')
 
-            # fill write backlog in a hacky way - renegotiation won't help
-            for _ in range(SIZE):
-                writer.transport._test__append_write_backlog(b'x' * CHUNK)
+            count = 0
+            # Fill the buffer - with a hack to ensure the protocol is
+            # paused without actually waiting on drain
+            while not writer._protocol._paused:
+                writer.write(b'x' * CHUNK)
+                count += 1
+                await asyncio.sleep(0)
+            filled.set()
 
-            try:
-                data = await reader.read()
-                self.assertEqual(data, b'')
-            except (BrokenPipeError, ConnectionResetError):
-                pass
+            data = await reader.read()
+            self.assertEqual(data, b'')
+            eof_received.set()
 
             await future
 
@@ -1421,9 +1437,15 @@ class TestSSL(test_utils.TestCase):
                     self.loop.call_soon_threadsafe(future.set_result, None)
             return wrapper
 
+        filled = threading.Event()
+        eof_received = threading.Event()
+        count = 0
         with self.tcp_server(run(server)) as srv:
             self.loop.run_until_complete(client(srv.addr))
 
+        filled = threading.Event()
+        eof_received = threading.Event()
+        count = 0
         with self.tcp_server(run(eof_server)) as srv:
             self.loop.run_until_complete(client(srv.addr))
 


### PR DESCRIPTION
asyncio/sslproto.py TLS wrapper has a redundant outgoing buffer (the MemoryBIO object already serves as a buffer), and a flow control layer for outgoing data which serves an unclear purpose

If this extra logic can be removed, it would solve the AssertionError issue described in the issue as a secondary effect, because the asserted condition cannot be guaranteed in general (details in issue comments).

For reference, the current sslproto.py code was ported from uvloop, which manifests the same issue. The uvloop implementation uses the MemoryBIO directly as a write buffer, but still has the extra flow control logic which causes the mismatch.

<!-- gh-issue-number: gh-109051 -->
* Issue: gh-109051
<!-- /gh-issue-number -->
