### PR TITLE
gh-109496: Skip test_capi.test_decref_freed_object() on ASAN

### DIFF
--- a/Lib/test/test_capi/test_misc.py
+++ b/Lib/test/test_capi/test_misc.py
@@ -325,6 +325,8 @@ class CAPITest(unittest.TestCase):
 
     @unittest.skipUnless(hasattr(_testcapi, 'decref_freed_object'),
                          'need _testcapi.decref_freed_object()')
+    @support.skip_if_sanitizer("use after free on purpose",
+                               address=True, memory=True, ub=True)
     def test_decref_freed_object(self):
         code = """
             import _testcapi


### PR DESCRIPTION
Skip test_decref_freed_object() of test_capi.test_misc if Python is built with ASAN, MSAN or UBSAN sanitizers.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-109496 -->
* Issue: gh-109496
<!-- /gh-issue-number -->
