### PR TITLE
gh-108724: Fix _PySemaphore compile error on WASM

### DIFF
--- a/Include/internal/pycore_semaphore.h
+++ b/Include/internal/pycore_semaphore.h
@@ -20,7 +20,8 @@
 #   error "Require native threads. See https://bugs.python.org/issue31370"
 #endif
 
-#if defined(_POSIX_SEMAPHORES) && (_POSIX_SEMAPHORES+0) != -1
+#if (defined(_POSIX_SEMAPHORES) && (_POSIX_SEMAPHORES+0) != -1 && \
+        defined(HAVE_SEM_TIMEDWAIT))
 #   define _Py_USE_SEMAPHORES
 #   include <semaphore.h>
 #endif


### PR DESCRIPTION
Some WASM platforms have POSIX semaphores, but not `sem_timedwait`.

<!-- gh-issue-number: gh-108724 -->
* Issue: gh-108724
<!-- /gh-issue-number -->
