### PR TITLE
gh-109580: Skip test_perf_profiler on ASAN build

### DIFF
--- a/Lib/test/test_perf_profiler.py
+++ b/Lib/test/test_perf_profiler.py
@@ -17,6 +17,11 @@ from test.support.os_helper import temp_dir
 if not support.has_subprocess_support:
     raise unittest.SkipTest("test module requires subprocess")
 
+if support.check_sanitizer(address=True, memory=True, ub=True):
+    # gh-109580: Skip the test because it does crash randomly if Python is
+    # built with ASAN.
+    raise unittest.SkipTest("test crash randomly on ASAN/MSAN/UBSAN build")
+
 
 def supports_trampoline_profiling():
     perf_trampoline = sysconfig.get_config_var("PY_HAVE_PERF_TRAMPOLINE")
@@ -287,7 +292,6 @@ def run_perf(cwd, *args, **env_vars):
 
 @unittest.skipUnless(perf_command_works(), "perf command doesn't work")
 @unittest.skipUnless(is_unwinding_reliable(), "Unwinding is unreliable")
-@support.skip_if_sanitizer(address=True, memory=True, ub=True)
 class TestPerfProfiler(unittest.TestCase):
     def setUp(self):
         super().setUp()

--- a/Misc/NEWS.d/next/Tests/2023-09-19-19-08-22.gh-issue-109580.G02Zam.rst
+++ b/Misc/NEWS.d/next/Tests/2023-09-19-19-08-22.gh-issue-109580.G02Zam.rst
@@ -1,0 +1,3 @@
+Skip ``test_perf_profiler`` if Python is built with ASAN, MSAN or UBSAN
+sanitizer. Python does crash randomly in this test on such build. Patch by
+Victor Stinner.


### PR DESCRIPTION
Skip test_perf_profiler if Python is built with ASAN, MSAN or UBSAN sanitizer. Python does crash randomly in this test on such build.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-109580 -->
* Issue: gh-109580
<!-- /gh-issue-number -->
