### PR TITLE
[3.12] gh-103053: Skip test_freeze_simple_script() on PGO build (#109591)

### DIFF
--- a/Lib/test/libregrtest/utils.py
+++ b/Lib/test/libregrtest/utils.py
@@ -259,16 +259,8 @@ def get_build_info():
     elif '-flto' in ldflags_nodist:
         optimizations.append('LTO')
 
-    # --enable-optimizations
-    pgo_options = (
-        # GCC
-        '-fprofile-use',
-        # clang: -fprofile-instr-use=code.profclangd
-        '-fprofile-instr-use',
-        # ICC
-        "-prof-use",
-    )
-    if any(option in cflags_nodist for option in pgo_options):
+    if support.check_cflags_pgo():
+        # PGO (--enable-optimizations)
         optimizations.append('PGO')
     if optimizations:
         build.append('+'.join(optimizations))

--- a/Lib/test/pythoninfo.py
+++ b/Lib/test/pythoninfo.py
@@ -867,6 +867,15 @@ def collect_fips(info_add):
         pass
 
 
+def collect_libregrtest_utils(info_add):
+    try:
+        from test.libregrtest import utils
+    except ImportError:
+        return
+
+    info_add('libregrtests.build_info', ' '.join(utils.get_build_info()))
+
+
 def collect_info(info):
     error = False
     info_add = info.add
@@ -904,6 +913,7 @@ def collect_info(info):
         collect_tkinter,
         collect_windows,
         collect_zlib,
+        collect_libregrtest_utils,
 
         # Collecting from tests should be last as they have side effects.
         collect_test_socket,

--- a/Lib/test/support/__init__.py
+++ b/Lib/test/support/__init__.py
@@ -781,6 +781,21 @@ def python_is_optimized():
     return final_opt not in ('', '-O0', '-Og')
 
 
+def check_cflags_pgo():
+    # Check if Python was built with ./configure --enable-optimizations:
+    # with Profile Guided Optimization (PGO).
+    cflags_nodist = sysconfig.get_config_var('PY_CFLAGS_NODIST') or ''
+    pgo_options = (
+        # GCC
+        '-fprofile-use',
+        # clang: -fprofile-instr-use=code.profclangd
+        '-fprofile-instr-use',
+        # ICC
+        "-prof-use",
+    )
+    return any(option in cflags_nodist for option in pgo_options)
+
+
 _header = 'nP'
 _align = '0n'
 if hasattr(sys, "getobjects"):

--- a/Lib/test/test_tools/test_freeze.py
+++ b/Lib/test/test_tools/test_freeze.py
@@ -15,6 +15,10 @@ with imports_under_tool('freeze', 'test'):
 @support.requires_zlib()
 @unittest.skipIf(sys.platform.startswith('win'), 'not supported on Windows')
 @support.skip_if_buildbot('not all buildbots have enough space')
+# gh-103053: Skip test if Python is built with Profile Guided Optimization
+# (PGO), since the test is just too slow in this case.
+@unittest.skipIf(support.check_cflags_pgo(),
+                 'test is too slow with PGO')
 class TestFreeze(unittest.TestCase):
 
     @support.requires_resource('cpu') # Building Python is slow

--- a/Misc/NEWS.d/next/Tests/2023-09-20-02-32-17.gh-issue-103053.AoUJuK.rst
+++ b/Misc/NEWS.d/next/Tests/2023-09-20-02-32-17.gh-issue-103053.AoUJuK.rst
@@ -1,0 +1,4 @@
+Skip test_freeze_simple_script() of test_tools.test_freeze if Python is built
+with ``./configure --enable-optimizations``, which means with Profile Guided
+Optimization (PGO): it just makes the test too slow. The freeze tool is tested
+by many other CIs with other (faster) compiler flags. Patch by Victor Stinner.


### PR DESCRIPTION
Skip test_freeze_simple_script() of test_tools.test_freeze if Python is built with "./configure --enable-optimizations", which means with Profile Guided Optimization (PGO): it just makes the test too slow. The freeze tool is tested by many other CIs with other (faster) compiler flags.

test.pythoninfo now gets also get_build_info() of
test.libregrtests.utils.

(cherry picked from commit 81cd1bd713624c3d26b647f3d28f2fd905887a0d)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-103053 -->
* Issue: gh-103053
<!-- /gh-issue-number -->
