### PR TITLE
Fix typos in docs and comments

### DIFF
--- a/Doc/c-api/exceptions.rst
+++ b/Doc/c-api/exceptions.rst
@@ -786,7 +786,7 @@ Exception Objects
 
    Implement part of the interpreter's implementation of :keyword:`!except*`.
    *orig* is the original exception that was caught, and *excs* is the list of
-   the exceptions that need to be raised. This list contains the the unhandled
+   the exceptions that need to be raised. This list contains the unhandled
    part of *orig*, if any, as well as the exceptions that were raised from the
    :keyword:`!except*` clauses (so they have a different traceback from *orig*) and
    those that were reraised (and have the same traceback as *orig*).

--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -1301,7 +1301,7 @@ These can be used as types in annotations. They all support subscription using
    completely disables typechecking for a function or class.
 
    The responsibility of how to interpret the metadata
-   lies with the the tool or library encountering an
+   lies with the tool or library encountering an
    ``Annotated`` annotation. A tool or library encountering an ``Annotated`` type
    can scan through the metadata elements to determine if they are of interest
    (e.g., using :func:`isinstance`).

--- a/Doc/library/unittest.mock.rst
+++ b/Doc/library/unittest.mock.rst
@@ -1130,7 +1130,7 @@ object::
 
   .. method:: wait_until_any_call_with(*args, **kwargs)
 
-      Waits until the the mock is called with the specified arguments.
+      Waits until the mock is called with the specified arguments.
 
       If a timeout was passed at the creation of the mock
       the function raises an :exc:`AssertionError` if the call is not performed in time.

--- a/Doc/whatsnew/3.12.rst
+++ b/Doc/whatsnew/3.12.rst
@@ -308,7 +308,7 @@ create an interpreter with its own GIL::
    if (PyStatus_Exception(status)) {
        return -1;
    }
-   /* The new interpeter is now active in the current thread. */
+   /* The new interpreter is now active in the current thread. */
 
 For further examples how to use the C-API for sub-interpreters with a
 per-interpreter GIL, see :source:`Modules/_xxsubinterpretersmodule.c`.

--- a/Doc/whatsnew/3.13.rst
+++ b/Doc/whatsnew/3.13.rst
@@ -119,7 +119,7 @@ copy
 ----
 
 * Add :func:`copy.replace` function which allows to create a modified copy of
-  an object, which is especially usefule for immutable objects.
+  an object, which is especially useful for immutable objects.
   It supports named tuples created with the factory function
   :func:`collections.namedtuple`, :class:`~dataclasses.dataclass` instances,
   various :mod:`datetime` objects, :class:`~inspect.Signature` objects,
@@ -208,7 +208,7 @@ tkinter
 traceback
 ---------
 
-* Add *show_group* paramter to :func:`traceback.TracebackException.format_exception_only`
+* Add *show_group* parameter to :func:`traceback.TracebackException.format_exception_only`
   to format the nested exceptions of a :exc:`BaseExceptionGroup` instance, recursively.
   (Contributed by Irit Katriel in :gh:`105292`.)
 

--- a/Doc/whatsnew/3.5.rst
+++ b/Doc/whatsnew/3.5.rst
@@ -921,7 +921,7 @@ and improves their substitutability for lists.
 Docstrings produced by :func:`~collections.namedtuple` can now be updated::
 
     Point = namedtuple('Point', ['x', 'y'])
-    Point.__doc__ += ': Cartesian coodinate'
+    Point.__doc__ += ': Cartesian coordinate'
     Point.x.__doc__ = 'abscissa'
     Point.y.__doc__ = 'ordinate'
 

--- a/Lib/concurrent/futures/process.py
+++ b/Lib/concurrent/futures/process.py
@@ -495,7 +495,7 @@ class _ExecutorManagerThread(threading.Thread):
                 # set_exception() fails if the future is cancelled: ignore it.
                 # Trying to check if the future is cancelled before calling
                 # set_exception() would leave a race condition if the future is
-                # cancelled betwen the check and set_exception().
+                # cancelled between the check and set_exception().
                 pass
             # Delete references to object. See issue16284
             del work_item

--- a/Lib/test/test_descr.py
+++ b/Lib/test/test_descr.py
@@ -1989,7 +1989,7 @@ class ClassPropertiesAndMethods(unittest.TestCase):
         ns = {}
         exec(code, ns)
         number_attrs = ns["number_attrs"]
-        # Warm up the the function for quickening (PEP 659)
+        # Warm up the function for quickening (PEP 659)
         for _ in range(30):
             self.assertEqual(number_attrs(Numbers()), list(range(280)))
 

--- a/Lib/test/test_dynamic.py
+++ b/Lib/test/test_dynamic.py
@@ -145,7 +145,7 @@ class RebindBuiltinsTests(unittest.TestCase):
         code = "lambda: " + "+".join(f"_number_{i}" for i in range(variables))
         sum_func = eval(code, MyGlobals())
         expected = sum(range(variables))
-        # Warm up the the function for quickening (PEP 659)
+        # Warm up the function for quickening (PEP 659)
         for _ in range(30):
             self.assertEqual(sum_func(), expected)
 

--- a/Lib/test/test_frame.py
+++ b/Lib/test/test_frame.py
@@ -322,7 +322,7 @@ class TestIncompleteFrameAreInvisible(unittest.TestCase):
             sneaky_frame_object = None
             gc.enable()
             next(g)
-            # g.gi_frame should be the the frame object from the callback (the
+            # g.gi_frame should be the frame object from the callback (the
             # one that was *requested* second, but *created* first):
             self.assertIs(g.gi_frame, sneaky_frame_object)
         finally:

--- a/Lib/test/test_unpack.py
+++ b/Lib/test/test_unpack.py
@@ -162,7 +162,7 @@ class TestCornerCases(unittest.TestCase):
         ns = {}
         exec(code, ns)
         unpack_400 = ns["unpack_400"]
-        # Warm up the the function for quickening (PEP 659)
+        # Warm up the function for quickening (PEP 659)
         for _ in range(30):
             y = unpack_400(range(400))
             self.assertEqual(y, 399)

--- a/Misc/NEWS.d/next/C API/2023-08-24-20-08-02.gh-issue-108014.20DOSS.rst
+++ b/Misc/NEWS.d/next/C API/2023-08-24-20-08-02.gh-issue-108014.20DOSS.rst
@@ -1,4 +1,4 @@
 Add :c:func:`PyLong_AsInt` function: similar to :c:func:`PyLong_AsLong`, but
 store the result in a C :c:expr:`int` instead of a C :c:expr:`long`.
-Previously, it was known as the the private function :c:func:`!_PyLong_AsInt`
+Previously, it was known as the private function :c:func:`!_PyLong_AsInt`
 (with an underscore prefix). Patch by Victor Stinner.

--- a/Objects/object_layout.md
+++ b/Objects/object_layout.md
@@ -36,7 +36,7 @@ and the ``dict`` field points to the dictionary.
 
 ## 3.12 pre-header
 
-In 3.12 the the pointer to the list of weak references is added to the
+In 3.12 the pointer to the list of weak references is added to the
 pre-header. In order to make space for it, the ``dict`` and ``values``
 pointers are combined into a single tagged pointer:
 

--- a/Tools/cases_generator/generate_cases.py
+++ b/Tools/cases_generator/generate_cases.py
@@ -168,7 +168,7 @@ class Generator(Analyzer):
                 popped, pushed = stacking.get_stack_effect_info_for_macro(instr)
             case parsing.Pseudo():
                 instr = self.pseudo_instrs[thing.name]
-                # Calculate stack effect, and check that it's the the same
+                # Calculate stack effect, and check that it's the same
                 # for all targets.
                 for target in self.pseudos[thing.name].targets:
                     target_instr = self.instrs.get(target)


### PR DESCRIPTION
# Proposed changes

Hi, this is my first PR to the project. Please feel free to close if unwanted. As per the pull request template I did not open an issue first, because this PR only fixes typos.

I found a few occurrences of "the the" and a few minor typos in the docs.

Are these alright?

Thank you. :)

<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--109619.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->