### PR TITLE
gh-109593: ResourceTracker.ensure_running() calls finalizers

### DIFF
--- a/Misc/NEWS.d/next/Library/2023-09-20-18-28-12.gh-issue-109593.VVWJDC.rst
+++ b/Misc/NEWS.d/next/Library/2023-09-20-18-28-12.gh-issue-109593.VVWJDC.rst
@@ -1,0 +1,4 @@
+:mod:`multiprocessing`: Reduce the risk of reentrant calls to
+``ResourceTracker.ensure_running()`` by running explicitly a garbage
+collection, to call pending finalizers, before acquiring the
+``ResourceTracker`` lock.  Patch by Victor Stinner.


### PR DESCRIPTION
multiprocessing: Reduce the risk of reentrant calls to ResourceTracker.ensure_running() by running explicitly all finalizers before acquiring the ResourceTracker lock.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-109593 -->
* Issue: gh-109593
<!-- /gh-issue-number -->
