### PR TITLE
[3.11] Fix typos in docs and comments (#109619)

### DIFF
--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -1233,7 +1233,7 @@ These can be used as types in annotations. They all support subscription using
    completely disables typechecking for a function or class.
 
    The responsibility of how to interpret the metadata
-   lies with the the tool or library encountering an
+   lies with the tool or library encountering an
    ``Annotated`` annotation. A tool or library encountering an ``Annotated`` type
    can scan through the metadata elements to determine if they are of interest
    (e.g., using :func:`isinstance`).

--- a/Doc/whatsnew/3.5.rst
+++ b/Doc/whatsnew/3.5.rst
@@ -921,7 +921,7 @@ and improves their substitutability for lists.
 Docstrings produced by :func:`~collections.namedtuple` can now be updated::
 
     Point = namedtuple('Point', ['x', 'y'])
-    Point.__doc__ += ': Cartesian coodinate'
+    Point.__doc__ += ': Cartesian coordinate'
     Point.x.__doc__ = 'abscissa'
     Point.y.__doc__ = 'ordinate'
 

--- a/Lib/test/test_descr.py
+++ b/Lib/test/test_descr.py
@@ -1980,7 +1980,7 @@ order (MRO) for bases """
         ns = {}
         exec(code, ns)
         number_attrs = ns["number_attrs"]
-        # Warm up the the function for quickening (PEP 659)
+        # Warm up the function for quickening (PEP 659)
         for _ in range(30):
             self.assertEqual(number_attrs(Numbers()), list(range(280)))
 

--- a/Lib/test/test_frame.py
+++ b/Lib/test/test_frame.py
@@ -317,7 +317,7 @@ class TestIncompleteFrameAreInvisible(unittest.TestCase):
             sneaky_frame_object = None
             gc.enable()
             next(g)
-            # g.gi_frame should be the the frame object from the callback (the
+            # g.gi_frame should be the frame object from the callback (the
             # one that was *requested* second, but *created* first):
             self.assertIs(g.gi_frame, sneaky_frame_object)
         finally:

--- a/Lib/test/test_unpack.py
+++ b/Lib/test/test_unpack.py
@@ -162,7 +162,7 @@ class TestCornerCases(unittest.TestCase):
         ns = {}
         exec(code, ns)
         unpack_400 = ns["unpack_400"]
-        # Warm up the the function for quickening (PEP 659)
+        # Warm up the function for quickening (PEP 659)
         for _ in range(30):
             y = unpack_400(range(400))
             self.assertEqual(y, 399)


### PR DESCRIPTION
(cherry-picked from commit ef6d475db3af4d30a3104fa6301dcd36c71eacab)

<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--109622.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->