### PR TITLE
gh-109627: duplicated smalll exit blocks need to be assigned jump target labels

### DIFF
--- a/Lib/test/test_compile.py
+++ b/Lib/test/test_compile.py
@@ -1252,6 +1252,15 @@ class TestSpecifics(unittest.TestCase):
             return a, b
         self.assertEqual(f(), (54, 96))
 
+    def test_duplicated_small_exit_block(self):
+        # See gh-109627
+        def f():
+            while element and something:
+                try:
+                    return something
+                except:
+                    pass
+
 
 @requires_debug_ranges()
 class TestSourcePositions(unittest.TestCase):

--- a/Misc/NEWS.d/next/Core and Builtins/2023-09-20-23-04-15.gh-issue-109627.xxe7De.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2023-09-20-23-04-15.gh-issue-109627.xxe7De.rst
@@ -1,0 +1,2 @@
+Fix bug where the compiler does not assign a new jump target label to a
+duplicated small exit block.

--- a/Python/flowgraph.c
+++ b/Python/flowgraph.c
@@ -575,16 +575,23 @@ check_cfg(cfg_builder *g) {
     return SUCCESS;
 }
 
+static int
+get_max_label(basicblock *entryblock)
+{
+    int lbl = -1;
+    for (basicblock *b = entryblock; b != NULL; b = b->b_next) {
+        if (b->b_label.id > lbl) {
+            lbl = b->b_label.id;
+        }
+    }
+    return lbl;
+}
+
 /* Calculate the actual jump target from the target_label */
 static int
 translate_jump_labels_to_targets(basicblock *entryblock)
 {
-    int max_label = -1;
-    for (basicblock *b = entryblock; b != NULL; b = b->b_next) {
-        if (b->b_label.id > max_label) {
-            max_label = b->b_label.id;
-        }
-    }
+    int max_label = get_max_label(entryblock);
     size_t mapsize = sizeof(basicblock *) * (max_label + 1);
     basicblock **label2block = (basicblock **)PyMem_Malloc(mapsize);
     if (!label2block) {
@@ -2230,18 +2237,6 @@ is_exit_without_lineno(basicblock *b) {
 }
 
 
-static int
-max_label(cfg_builder *g)
-{
-    int lbl = -1;
-    for (basicblock *b = g->g_entryblock; b != NULL; b = b->b_next) {
-        if (b->b_label.id > lbl) {
-            lbl = b->b_label.id;
-        }
-    }
-    return lbl;
-}
-
 /* PEP 626 mandates that the f_lineno of a frame is correct
  * after a frame terminates. It would be prohibitively expensive
  * to continuously update the f_lineno field at runtime,
@@ -2256,7 +2251,7 @@ duplicate_exits_without_lineno(cfg_builder *g)
 {
     assert(no_empty_basic_blocks(g));
 
-    int next_lbl = max_label(g) + 1;
+    int next_lbl = get_max_label(g->g_entryblock) + 1;
 
     /* Copy all exit blocks without line number that are targets of a jump.
      */

--- a/Python/flowgraph.c
+++ b/Python/flowgraph.c
@@ -2229,6 +2229,19 @@ is_exit_without_lineno(basicblock *b) {
     return true;
 }
 
+
+static int
+max_label(cfg_builder *g)
+{
+    int lbl = -1;
+    for (basicblock *b = g->g_entryblock; b != NULL; b = b->b_next) {
+        if (b->b_label.id > lbl) {
+            lbl = b->b_label.id;
+        }
+    }
+    return lbl;
+}
+
 /* PEP 626 mandates that the f_lineno of a frame is correct
  * after a frame terminates. It would be prohibitively expensive
  * to continuously update the f_lineno field at runtime,
@@ -2242,6 +2255,9 @@ static int
 duplicate_exits_without_lineno(cfg_builder *g)
 {
     assert(no_empty_basic_blocks(g));
+
+    int next_lbl = max_label(g) + 1;
+
     /* Copy all exit blocks without line number that are targets of a jump.
      */
     basicblock *entryblock = g->g_entryblock;
@@ -2260,6 +2276,7 @@ duplicate_exits_without_lineno(cfg_builder *g)
                 target->b_predecessors--;
                 new_target->b_predecessors = 1;
                 new_target->b_next = target->b_next;
+                new_target->b_label.id = next_lbl++;
                 target->b_next = new_target;
             }
         }


### PR DESCRIPTION

Fixes #109627.

In order to ensure that function exits have a line number, the compiler duplicates small exit blocks which (1) do not have a line number in any instruction and (2) have more than one predecessor. Since these blocks are jump targets (at least one predecessor reaches this block via a jump or exception), they need to have labels assigned to them. This was missing, and is added in this PR.



<!-- gh-issue-number: gh-109627 -->
* Issue: gh-109627
<!-- /gh-issue-number -->
