### PR TITLE
[3.12] gh-109627: duplicated small exit blocks need to be assigned jump target labels (#109630)

### DIFF
--- a/Lib/test/test_compile.py
+++ b/Lib/test/test_compile.py
@@ -1216,6 +1216,15 @@ class TestSpecifics(unittest.TestCase):
             return a
         self.assertEqual(f("x", "y", "z"), "y")
 
+    def test_duplicated_small_exit_block(self):
+        # See gh-109627
+        def f():
+            while element and something:
+                try:
+                    return something
+                except:
+                    pass
+
 
 @requires_debug_ranges()
 class TestSourcePositions(unittest.TestCase):

--- a/Misc/NEWS.d/next/Core and Builtins/2023-09-20-23-04-15.gh-issue-109627.xxe7De.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2023-09-20-23-04-15.gh-issue-109627.xxe7De.rst
@@ -1,0 +1,2 @@
+Fix bug where the compiler does not assign a new jump target label to a
+duplicated small exit block.


### PR DESCRIPTION

(cherry picked from commit 9ccf0545efd5bc5af5aa51774030c471d49a972b)


<!-- gh-issue-number: gh-109627 -->
* Issue: gh-109627
<!-- /gh-issue-number -->
