### PR TITLE
gh-107220: docs: Improve importlib.metadata docs for entry point filtering

### DIFF
--- a/Doc/library/importlib.metadata.rst
+++ b/Doc/library/importlib.metadata.rst
@@ -113,7 +113,7 @@ Entry points
 
 The ``entry_points()`` function returns a collection of entry points.
 Entry points are represented by ``EntryPoint`` instances;
-each ``EntryPoint`` has a ``.name``, ``.group``, and ``.value`` attributes and
+each ``EntryPoint`` has ``.name``, ``.dist``, ``.group``, and ``.value`` attributes and
 a ``.load()`` method to resolve the value.  There are also ``.module``,
 ``.attr``, and ``.extras`` attributes for getting the components of the
 ``.value`` attribute.
@@ -139,6 +139,14 @@ Equivalently, since ``entry_points`` passes keyword arguments
 through to select::
 
     >>> scripts = entry_points(group='console_scripts')  # doctest: +SKIP
+
+Since comparing ``Distribution`` objects for equality is not trivial,
+``dist`` should currently not be used in ``EntryPoints.select()`` or
+``entry_points()`` since the comparison for equality will always result in
+``False`` and result in empty result sets. Filter by distribution manually
+instead, for example like this::
+
+    >>> eps = EntryPoints(ep for ep in entry_points() if ep.dist.name == 'pip')
 
 Pick out a specific script named "wheel" (found in the wheel project)::
 


### PR DESCRIPTION
`dist` kwarg in `entry_points()` is currently unusable as comparison will *always* return `False`. This needs to be pointed out in docs or users transitioning to this new API will likely fall into this trap. See #107220

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--109646.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->

<!-- gh-issue-number: gh-107220 -->
* Issue: gh-107220
<!-- /gh-issue-number -->
