### PR TITLE
[3.12] gh-106967: remove Release and Date fields from whatsnew for 3.12

### DIFF
--- a/Doc/whatsnew/3.12.rst
+++ b/Doc/whatsnew/3.12.rst
@@ -3,8 +3,7 @@
   What's New In Python 3.12
 ****************************
 
-:Release: |release|
-:Date: |today|
+:Editor: TBD
 
 .. Rules for maintenance:
 


### PR DESCRIPTION

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
Backport of e8884529de9874783624615ac1ed34541e8a1373 from PR https://github.com/python/cpython/pull/107000.

> python/release-tools template for "What's New" page automatically adds a "Release" field and a "Date" field with the date set to "today", which becomes the day the docs are built, which is forever increasing. This is the topic of https://github.com/python/release-tools/issues/34 which is yet to be fixed. In the meantime, this commit fixes it manually.

<!-- gh-issue-number: gh-106967 -->
* Issue: gh-106967
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--109648.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->