### PR TITLE
GH-109190: Copyedit 3.12 What's New: PEP 709

### DIFF
--- a/Doc/whatsnew/3.12.rst
+++ b/Doc/whatsnew/3.12.rst
@@ -246,14 +246,11 @@ PEP 709: Comprehension inlining
 
 Dictionary, list, and set comprehensions are now inlined, rather than creating a
 new single-use function object for each execution of the comprehension. This
-speeds up execution of a comprehension by up to 2x.
+speeds up execution of a comprehension by up to two times.
 
-Comprehension iteration variables remain isolated; they don't overwrite a
+Comprehension iteration variables remain isolated and don't overwrite a
 variable of the same name in the outer scope, nor are they visible after the
-comprehension. This isolation is now maintained via stack/locals manipulation,
-not via separate function scope.
-
-Inlining does result in a few visible behavior changes:
+comprehension. Inlining does result in a few visible behavior changes:
 
 * There is no longer a separate frame for the comprehension in tracebacks,
   and tracing/profiling no longer shows the comprehension as a function call.

--- a/Doc/whatsnew/3.12.rst
+++ b/Doc/whatsnew/3.12.rst
@@ -247,6 +247,7 @@ PEP 709: Comprehension inlining
 Dictionary, list, and set comprehensions are now inlined, rather than creating a
 new single-use function object for each execution of the comprehension. This
 speeds up execution of a comprehension by up to two times.
+See :pep:`709` for further details.
 
 Comprehension iteration variables remain isolated and don't overwrite a
 variable of the same name in the outer scope, nor are they visible after the

--- a/Doc/whatsnew/3.12.rst
+++ b/Doc/whatsnew/3.12.rst
@@ -267,7 +267,7 @@ comprehension. Inlining does result in a few visible behavior changes:
   create a list of keys to iterate over: ``keys = list(locals()); [k for k in
   keys]``.
 
-Contributed by Carl Meyer and Vladimir Matveev in :pep:`709`.
+(Contributed by Carl Meyer and Vladimir Matveev in :pep:`709`.)
 
 .. _whatsnew312-pep688:
 


### PR DESCRIPTION
- Write out '2x' in words
- Add a link to PEP-709 in the summary paragraph
- Merge two sentences & remove implemenetation detail from What's New
- Standardise brackets for contribution credits


<!-- gh-issue-number: gh-109190 -->
* Issue: gh-109190
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--109656.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->