### PR TITLE
GH-109190: Copyedit 3.12 What's New: PEP 684

### DIFF
--- a/Doc/whatsnew/3.12.rst
+++ b/Doc/whatsnew/3.12.rst
@@ -292,7 +292,8 @@ can be used to customize buffer creation.
 PEP 684: A Per-Interpreter GIL
 ------------------------------
 
-Sub-interpreters may now be created with a unique GIL per interpreter.
+:pep:`684` introduces a per-interpreter :term:`GIL <global interpreter lock>`,
+so that sub-interpreters may now be created with a unique GIL per interpreter.
 This allows Python programs to take full advantage of multiple CPU
 cores. This is currently only available through the C-API,
 though a Python API is :pep:`anticipated for 3.13 <554>`.

--- a/Doc/whatsnew/3.12.rst
+++ b/Doc/whatsnew/3.12.rst
@@ -294,7 +294,8 @@ PEP 684: A Per-Interpreter GIL
 
 Sub-interpreters may now be created with a unique GIL per interpreter.
 This allows Python programs to take full advantage of multiple CPU
-cores.
+cores. This is currently only available through the C-API,
+though a Python API is :pep:`anticipated for 3.13 <554>`.
 
 Use the new :c:func:`Py_NewInterpreterFromConfig` function to
 create an interpreter with its own GIL::
@@ -312,8 +313,6 @@ create an interpreter with its own GIL::
 
 For further examples how to use the C-API for sub-interpreters with a
 per-interpreter GIL, see :source:`Modules/_xxsubinterpretersmodule.c`.
-
-A Python API is anticipated for 3.13.  (See :pep:`554`.)
 
 (Contributed by Eric Snow in :gh:`104210`, etc.)
 


### PR DESCRIPTION
- Add an introduction to the section
- Add a bridging note about the expected Python API and the C-API

<!-- gh-issue-number: gh-109190 -->
* Issue: gh-109190
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--109657.org.readthedocs.build/en/109657/whatsnew/3.12.html#pep-684-a-per-interpreter-gil

<!-- readthedocs-preview cpython-previews end -->