### PR TITLE
 GH-109190: Copyedit 3.12 What's New: PEP 669

### DIFF
--- a/Doc/whatsnew/3.12.rst
+++ b/Doc/whatsnew/3.12.rst
@@ -322,13 +322,15 @@ A Python API is anticipated for 3.13.  (See :pep:`554`.)
 PEP 669: Low impact monitoring for CPython
 ------------------------------------------
 
-CPython 3.12 now supports the ability to monitor calls,
-returns, lines, exceptions and other events using instrumentation.
+:pep:`669` defines a new :mod:`API <sys.monitoring>` for profilers,
+debuggers, and other tools to monitor events in CPython.
+This instrumentation covers a wide range of events, including calls,
+returns, lines, exceptions, jumps, and more.
 This means that you only pay for what you use, providing support
 for near-zero overhead debuggers and coverage tools.
-
 See  :mod:`sys.monitoring` for details.
 
+(Contributed by Mark Shannon in :gh:`103083`)
 
 New Features Related to Type Hints
 ==================================

--- a/Doc/whatsnew/3.12.rst
+++ b/Doc/whatsnew/3.12.rst
@@ -324,7 +324,7 @@ PEP 669: Low impact monitoring for CPython
 
 :pep:`669` defines a new :mod:`API <sys.monitoring>` for profilers,
 debuggers, and other tools to monitor events in CPython.
-This instrumentation covers a wide range of events, including calls,
+It covers a wide range of events, including calls,
 returns, lines, exceptions, jumps, and more.
 This means that you only pay for what you use, providing support
 for near-zero overhead debuggers and coverage tools.

--- a/Doc/whatsnew/3.12.rst
+++ b/Doc/whatsnew/3.12.rst
@@ -330,7 +330,7 @@ This means that you only pay for what you use, providing support
 for near-zero overhead debuggers and coverage tools.
 See  :mod:`sys.monitoring` for details.
 
-(Contributed by Mark Shannon in :gh:`103083`)
+(Contributed by Mark Shannon in :gh:`103083`.)
 
 New Features Related to Type Hints
 ==================================


### PR DESCRIPTION
- Add a link to the PEP
- Copyedit and expand the introductory paragraph
- Add contribution credits

<!-- gh-issue-number: gh-109190 -->
* Issue: gh-109190
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--109658.org.readthedocs.build/en/109658/whatsnew/3.12.html#pep-669-low-impact-monitoring-for-cpython

<!-- readthedocs-preview cpython-previews end -->