### PR TITLE
 GH-109190: Copyedit 3.12 What's New: Typing PEPs

### DIFF
--- a/Doc/whatsnew/3.12.rst
+++ b/Doc/whatsnew/3.12.rst
@@ -345,7 +345,7 @@ Typing ``**kwargs`` in a function signature as introduced by :pep:`484` allowed
 for valid annotations only in cases where all of the ``**kwargs`` were of the
 same type.
 
-This PEP specifies a more precise way of typing ``**kwargs`` by relying on
+:pep:`692` specifies a more precise way of typing ``**kwargs`` by relying on
 typed dictionaries::
 
    from typing import TypedDict, Unpack

--- a/Doc/whatsnew/3.12.rst
+++ b/Doc/whatsnew/3.12.rst
@@ -333,7 +333,7 @@ See  :mod:`sys.monitoring` for details.
 New Features Related to Type Hints
 ==================================
 
-This section covers major changes affecting :pep:`484` type hints and
+This section covers major changes affecting :pep:`type hints <484>` and
 the :mod:`typing` module.
 
 .. _whatsnew312-pep692:

--- a/Doc/whatsnew/3.12.rst
+++ b/Doc/whatsnew/3.12.rst
@@ -436,8 +436,8 @@ parameters with bounds or constraints::
 
 The value of type aliases and the bound and constraints of type variables
 created through this syntax are evaluated only on demand (see
-:ref:`lazy-evaluation`). This means type aliases are able to refer to other
-types defined later in the file.
+:ref:`lazy evaluation <lazy-evaluation>`). This means type aliases are able to
+refer to other types defined later in the file.
 
 Type parameters declared through a type parameter list are visible within the
 scope of the declaration and any nested scopes, but not in the outer scope. For

--- a/Doc/whatsnew/3.12.rst
+++ b/Doc/whatsnew/3.12.rst
@@ -389,6 +389,8 @@ Example::
      def get_colour(self) -> str:
        return "red"
 
+See :pep:`698` for more details.
+
 (Contributed by Steven Troxler in :gh:`101561`.)
 
 .. _whatsnew312-pep695:


### PR DESCRIPTION
- Inline the reference to PEP-484
- Add a link to PEP-692
- Add a link to PEP-698
- Override the case of the rendered link for lazy evaluation in PEP 695's overview

<!-- gh-issue-number: gh-109190 -->
* Issue: gh-109190
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--109659.org.readthedocs.build/en/109659/whatsnew/3.12.html#new-features-related-to-type-hints
<!-- readthedocs-preview cpython-previews end -->