### PR TITLE
 GH-109190: Copyedit 3.12 What's New: Other Language Changes

### DIFF
--- a/Doc/whatsnew/3.12.rst
+++ b/Doc/whatsnew/3.12.rst
@@ -500,8 +500,8 @@ Other Language Changes
 * A backslash-character pair that is not a valid escape sequence now generates
   a :exc:`SyntaxWarning`, instead of :exc:`DeprecationWarning`.
   For example, ``re.compile("\d+\.\d+")`` now emits a :exc:`SyntaxWarning`
-  (``"\d"`` is an invalid escape sequence), use raw strings for regular
-  expression: ``re.compile(r"\d+\.\d+")``.
+  (``"\d"`` is an invalid escape sequence, use raw strings for regular
+  expression: ``re.compile(r"\d+\.\d+")``).
   In a future Python version, :exc:`SyntaxError` will eventually be raised,
   instead of :exc:`SyntaxWarning`.
   (Contributed by Victor Stinner in :gh:`98401`.)

--- a/Doc/whatsnew/3.12.rst
+++ b/Doc/whatsnew/3.12.rst
@@ -472,7 +472,7 @@ Other Language Changes
   have a new a *filter* argument that allows limiting tar features than may be
   surprising or dangerous, such as creating files outside the destination
   directory.
-  See :ref:`tarfile-extraction-filter` for details.
+  See :ref:`tarfile extraction filters <tarfile-extraction-filter>` for details.
   In Python 3.14, the default will switch to ``'data'``.
   (Contributed by Petr Viktorin in :pep:`706`.)
 

--- a/Doc/whatsnew/3.12.rst
+++ b/Doc/whatsnew/3.12.rst
@@ -458,12 +458,12 @@ and others in :gh:`103764`.)
 Other Language Changes
 ======================
 
-* Add :ref:`perf_profiling` through the new
-  environment variable :envvar:`PYTHONPERFSUPPORT`,
-  the new command-line option :option:`-X perf <-X>`,
+* Add :ref:`support for the perf profiler <perf_profiling>` through the new
+  environment variable :envvar:`PYTHONPERFSUPPORT`
+  and command-line option :option:`-X perf <-X>`,
   as well as the new :func:`sys.activate_stack_trampoline`,
   :func:`sys.deactivate_stack_trampoline`,
-  and :func:`sys.is_stack_trampoline_active` APIs.
+  and :func:`sys.is_stack_trampoline_active` functions.
   (Design by Pablo Galindo. Contributed by Pablo Galindo and Christian Heimes
   with contributions from Gregory P. Smith [Google] and Mark Shannon
   in :gh:`96123`.)

--- a/Doc/whatsnew/3.12.rst
+++ b/Doc/whatsnew/3.12.rst
@@ -530,7 +530,7 @@ Other Language Changes
   when summing floats or mixed ints and floats.
   (Contributed by Raymond Hettinger in :gh:`100425`.)
 
-* Exceptions raised in a typeobject's ``__set_name__`` method are no longer
+* Exceptions raised in a class or type's ``__set_name__`` method are no longer
   wrapped by a :exc:`RuntimeError`. Context information is added to the
   exception as a :pep:`678` note. (Contributed by Irit Katriel in :gh:`77757`.)
 


### PR DESCRIPTION
- Copyedit ``perf`` support
- Use an explicit title for the link to ``perf-profiling``
- Use an explicit title for the link to ``tarfile-extraction-filter``
- Fix the bracket position for the invalid escapes note
- Avoid the unfamiliar "typeobject" in favour of "class or type"

<!-- gh-issue-number: gh-109190 -->
* Issue: gh-109190
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--109660.org.readthedocs.build/en/109660/whatsnew/3.12.html#other-language-changes

<!-- readthedocs-preview cpython-previews end -->