### PR TITLE
 GH-109190: Copyedit 3.12 What's New: Consistently show module names

### DIFF
--- a/Doc/whatsnew/3.12.rst
+++ b/Doc/whatsnew/3.12.rst
@@ -568,18 +568,18 @@ asyncio
   making some use-cases 2x to 5x faster.
   (Contributed by Jacob Bower & Itamar O in :gh:`102853`, :gh:`104140`, and :gh:`104138`)
 
-* On Linux, :mod:`asyncio` uses :class:`~asyncio.PidfdChildWatcher` by default
+* On Linux, :mod:`asyncio` uses :class:`asyncio.PidfdChildWatcher` by default
   if :func:`os.pidfd_open` is available and functional instead of
-  :class:`~asyncio.ThreadedChildWatcher`.
+  :class:`asyncio.ThreadedChildWatcher`.
   (Contributed by Kumar Aditya in :gh:`98024`.)
 
-* The child watcher classes :class:`~asyncio.MultiLoopChildWatcher`,
-  :class:`~asyncio.FastChildWatcher`, :class:`~asyncio.AbstractChildWatcher`
-  and :class:`~asyncio.SafeChildWatcher` are deprecated and
+* The child watcher classes :class:`asyncio.MultiLoopChildWatcher`,
+  :class:`asyncio.FastChildWatcher`, :class:`asyncio.AbstractChildWatcher`
+  and :class:`asyncio.SafeChildWatcher` are deprecated and
   will be removed in Python 3.14. It is recommended to not manually
   configure a child watcher as the event loop now uses the best available
-  child watcher for each platform (:class:`~asyncio.PidfdChildWatcher`
-  if supported and :class:`~asyncio.ThreadedChildWatcher` otherwise).
+  child watcher for each platform (:class:`asyncio.PidfdChildWatcher`
+  if supported and :class:`asyncio.ThreadedChildWatcher` otherwise).
   (Contributed by Kumar Aditya in :gh:`94597`.)
 
 * :func:`asyncio.set_child_watcher`, :func:`asyncio.get_child_watcher`,
@@ -606,15 +606,15 @@ asyncio
 calendar
 --------
 
-* Add enums :data:`~calendar.Month` and :data:`~calendar.Day`.
+* Add enums :data:`calendar.Month` and :data:`calendar.Day`.
   (Contributed by Prince Roshan in :gh:`103636`.)
 
 csv
 ---
 
-* Add :const:`~csv.QUOTE_NOTNULL` and :const:`~csv.QUOTE_STRINGS` flags to
+* Add :const:`csv.QUOTE_NOTNULL` and :const:`csv.QUOTE_STRINGS` flags to
   provide finer grained control of ``None`` and empty strings by
-  :class:`~csv.writer` objects.
+  :class:`csv.writer` objects.
 
 dis
 ---
@@ -624,7 +624,7 @@ dis
   :mod:`dis` module.
   :opcode:`HAVE_ARGUMENT` is still relevant to real opcodes,
   but it is not useful for pseudo instructions. Use the new
-  :data:`~dis.hasarg` collection instead.
+  :data:`dis.hasarg` collection instead.
   (Contributed by Irit Katriel in :gh:`94216`.)
 
 fractions
@@ -710,11 +710,11 @@ pathlib
 -------
 
 * Add support for subclassing :class:`pathlib.PurePath` and
-  :class:`~pathlib.Path`, plus their Posix- and Windows-specific variants.
-  Subclasses may override the :meth:`~pathlib.PurePath.with_segments` method
+  :class:`pathlib.Path`, plus their Posix- and Windows-specific variants.
+  Subclasses may override the :meth:`pathlib.PurePath.with_segments` method
   to pass information between path instances.
 
-* Add :meth:`~pathlib.Path.walk` for walking the directory trees and generating
+* Add :meth:`pathlib.Path.walk` for walking the directory trees and generating
   all file or directory names within them, similar to :func:`os.walk`.
   (Contributed by Stanislav Zmiev in :gh:`90385`.)
 
@@ -783,20 +783,20 @@ sqlite3
 * Add a :ref:`command-line interface <sqlite3-cli>`.
   (Contributed by Erlend E. Aasland in :gh:`77617`.)
 
-* Add the :attr:`~sqlite3.Connection.autocommit` attribute
-  to :class:`~sqlite3.Connection`
-  and the *autocommit* parameter to :func:`~sqlite3.connect`
+* Add the :attr:`sqlite3.Connection.autocommit` attribute
+  to :class:`sqlite3.Connection`
+  and the *autocommit* parameter to :func:`sqlite3.connect`
   to control :pep:`249`-compliant
   :ref:`transaction handling <sqlite3-transaction-control-autocommit>`.
   (Contributed by Erlend E. Aasland in :gh:`83638`.)
 
 * Add *entrypoint* keyword-only parameter to
-  :meth:`~sqlite3.Connection.load_extension`,
+  :meth:`sqlite3.Connection.load_extension`,
   for overriding the SQLite extension entry point.
   (Contributed by Erlend E. Aasland in :gh:`103015`.)
 
-* Add :meth:`~sqlite3.Connection.getconfig` and
-  :meth:`~sqlite3.Connection.setconfig` to :class:`~sqlite3.Connection`
+* Add :meth:`sqlite3.Connection.getconfig` and
+  :meth:`sqlite3.Connection.setconfig` to :class:`sqlite3.Connection`
   to make configuration changes to a database connection.
   (Contributed by Erlend E. Aasland in :gh:`103489`.)
 


### PR DESCRIPTION
In most of the "Improved Modules" list, we show the full module name (i.e. no ``~`` in the cross-reference role). This standardises so that we always show the module name for cross-referenced objects.

<!-- gh-issue-number: gh-109190 -->
* Issue: gh-109190
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--109664.org.readthedocs.build/en/109664/whatsnew/3.12.html#improved-modules

<!-- readthedocs-preview cpython-previews end -->