### PR TITLE
GH-109190: Copyedit 3.12 What's New: bytecode (LOAD_METHOD)

### DIFF
--- a/Doc/whatsnew/3.12.rst
+++ b/Doc/whatsnew/3.12.rst
@@ -998,9 +998,9 @@ Optimizations
 CPython bytecode changes
 ========================
 
-* Remove the :opcode:`LOAD_METHOD` instruction. It has been merged into
+* Remove the :opcode:`!LOAD_METHOD` instruction. It has been merged into
   :opcode:`LOAD_ATTR`. :opcode:`LOAD_ATTR` will now behave like the old
-  :opcode:`LOAD_METHOD` instruction if the low bit of its oparg is set.
+  :opcode:`!LOAD_METHOD` instruction if the low bit of its oparg is set.
   (Contributed by Ken Jin in :gh:`93429`.)
 
 * Remove the :opcode:`!JUMP_IF_FALSE_OR_POP` and :opcode:`!JUMP_IF_TRUE_OR_POP`


### PR DESCRIPTION
- Suppress an incorrect cross reference to ``LOAD_METHOD``. This opcode was removed in #93429, but #94216 introduced new pseudo instructions reusing the name. I believe that this cross reference is consequently currently wrong.

<!-- gh-issue-number: gh-109190 -->
* Issue: gh-109190
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--109665.org.readthedocs.build/en/109665/whatsnew/3.12.html#cpython-bytecode-changes

<!-- readthedocs-preview cpython-previews end -->