### PR TITLE
[3.12] gh-108948: Skip test_tarfile.test_modes() on EFTYPE error (#109697)

### DIFF
--- a/Lib/test/test_tarfile.py
+++ b/Lib/test/test_tarfile.py
@@ -1,3 +1,4 @@
+import errno
 import sys
 import os
 import io
@@ -3791,9 +3792,21 @@ class TestExtractionFilters(unittest.TestCase):
         tmp_filename = os.path.join(TEMPDIR, "tmp.file")
         with open(tmp_filename, 'w'):
             pass
-        os.chmod(tmp_filename, os.stat(tmp_filename).st_mode | stat.S_ISVTX)
-        have_sticky_files = (os.stat(tmp_filename).st_mode & stat.S_ISVTX)
-        os.unlink(tmp_filename)
+        try:
+            try:
+                os.chmod(tmp_filename,
+                         os.stat(tmp_filename).st_mode | stat.S_ISVTX)
+            except OSError as exc:
+                if exc.errno == getattr(errno, "EFTYPE", 0):
+                    # gh-108948: On FreeBSD, regular users cannot set
+                    # the sticky bit.
+                    self.skipTest("chmod() failed with EFTYPE: "
+                                  "regular users cannot set sticky bit")
+                else:
+                    raise
+            have_sticky_files = (os.stat(tmp_filename).st_mode & stat.S_ISVTX)
+        finally:
+            os.unlink(tmp_filename)
 
         os.mkdir(tmp_filename)
         os.chmod(tmp_filename, os.stat(tmp_filename).st_mode | stat.S_ISVTX)


### PR DESCRIPTION
On FreeBSD, regular users cannot set the sticky bit. Skip the test if chmod() fails with EFTYPE error.

(cherry picked from commit 26e06ad617bb416201c769fea91cd33d544c6a1c)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-108948 -->
* Issue: gh-108948
<!-- /gh-issue-number -->
