### PR TITLE
gh-109702: Increase concurrent_futures deadlock timeout

### DIFF
--- a/Lib/test/test_concurrent_futures/test_deadlock.py
+++ b/Lib/test/test_concurrent_futures/test_deadlock.py
@@ -88,7 +88,7 @@ class ErrorAtUnpickle(object):
 
 
 class ExecutorDeadlockTest:
-    TIMEOUT = support.SHORT_TIMEOUT
+    TIMEOUT = support.LONG_TIMEOUT
 
     def _fail_on_deadlock(self, executor):
         # If we did not recover before TIMEOUT seconds, consider that the


### PR DESCRIPTION
Replace SHORT_TIMEOUT with LONG_TIMEOUT in test_deadlock of test_concurrent_futures.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-109702 -->
* Issue: gh-109702
<!-- /gh-issue-number -->
