### PR TITLE
gh-109721: Guard `_testinternalcapi` imports in tests

### DIFF
--- a/Lib/test/test_cmd_line.py
+++ b/Lib/test/test_cmd_line.py
@@ -799,6 +799,7 @@ class CmdLineTest(unittest.TestCase):
         self.assertEqual(proc.stdout.rstrip(), name)
         self.assertEqual(proc.returncode, 0)
 
+    @support.cpython_only
     def test_pythonmalloc(self):
         # Test the PYTHONMALLOC environment variable
         pymalloc = support.with_pymalloc()

--- a/Lib/test/test_import/__init__.py
+++ b/Lib/test/test_import/__init__.py
@@ -22,7 +22,6 @@ import time
 import types
 import unittest
 from unittest import mock
-import _testinternalcapi
 import _imp
 
 from test.support import os_helper
@@ -50,6 +49,10 @@ try:
     import _xxsubinterpreters as _interpreters
 except ModuleNotFoundError:
     _interpreters = None
+try:
+    import _testinternalcapi
+except ImportError:
+    _testinternalcapi = None
 
 
 skip_if_dont_write_bytecode = unittest.skipIf(

--- a/Lib/test/test_opcache.py
+++ b/Lib/test/test_opcache.py
@@ -4,10 +4,13 @@ import dis
 import threading
 import types
 import unittest
-from test.support import threading_helper, import_helper
+from test.support import threading_helper, check_impl_detail
 
 # Skip this module on other interpreters, it is cpython specific:
-_testinternalcapi = import_helper.import_module('_testinternalcapi')
+if check_impl_detail(cpython=False):
+    raise unittest.SkipTest('implementation detail specific to cpython')
+
+import _testinternalcapi
 
 
 def disabling_optimizer(func):

--- a/Lib/test/test_opcache.py
+++ b/Lib/test/test_opcache.py
@@ -4,13 +4,14 @@ import dis
 import threading
 import types
 import unittest
-from test.support import threading_helper
-import _testinternalcapi
+from test.support import threading_helper, import_helper
+
+# Skip this module on other interpreters, it is cpython specific:
+_testinternalcapi = import_helper.import_module('_testinternalcapi')
 
 
 def disabling_optimizer(func):
     def wrapper(*args, **kwargs):
-        import _testinternalcapi
         old_opt = _testinternalcapi.get_optimizer()
         _testinternalcapi.set_optimizer(None)
         try:


### PR DESCRIPTION
Why?
1. `test_cmd_line.py` only imports it without a guard in `check_pythonmalloc`, which is only used in `test_pythonmalloc`, so marking it as `@cpython_only` is good enoug
2. `test_import/__init__.py` already has several guards like `requires_singlephase_init` which implies `@cpython_only`, so only a `except ImportError` is needed
3. `test_opcache` can be skipped without `_testinternalcapi`, because most (all?) tests are cpython-only and require it

<!-- gh-issue-number: gh-109721 -->
* Issue: gh-109721
<!-- /gh-issue-number -->
