### PR TITLE
Remove outdated docstring from the `quantify` itertools recipe

### DIFF
--- a/Doc/library/itertools.rst
+++ b/Doc/library/itertools.rst
@@ -845,7 +845,6 @@ which incur interpreter overhead.
 
    def quantify(iterable, pred=bool):
        "Given a predicate that returns True or False, count the True results."
-       "Count how many times the predicate is True"
        return sum(map(pred, iterable))
 
    def all_equal(iterable):


### PR DESCRIPTION
This was left in gh-109555.

<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--109726.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->