### PR TITLE
gh-109719: Fix missing jump target labels when compiler reorders cold/warm blocks

### DIFF
--- a/Lib/test/test_compile.py
+++ b/Lib/test/test_compile.py
@@ -1261,6 +1261,17 @@ class TestSpecifics(unittest.TestCase):
                 except:
                     pass
 
+    def test_cold_block_moved_to_end(self):
+        # See gh-109719
+        def f():
+            while name:
+                try:
+                    break
+                except:
+                    pass
+            else:
+                1 if 1 else 1
+
 
 @requires_debug_ranges()
 class TestSourcePositions(unittest.TestCase):

--- a/Misc/NEWS.d/next/Core and Builtins/2023-09-22-13-38-17.gh-issue-109719.fx5OTz.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2023-09-22-13-38-17.gh-issue-109719.fx5OTz.rst
@@ -1,0 +1,1 @@
+Fix missing jump target labels when compiler reorders cold/warm blocks.

--- a/Misc/NEWS.d/next/Core and Builtins/2023-09-22-13-38-19.gh-issue-109719.fx5OTz.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2023-09-22-13-38-19.gh-issue-109719.fx5OTz.rst
@@ -1,1 +1,0 @@
-Fix missing jump target labels when compiler reorders cold/warm blocks.

--- a/Misc/NEWS.d/next/Core and Builtins/2023-09-22-13-38-19.gh-issue-109719.fx5OTz.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2023-09-22-13-38-19.gh-issue-109719.fx5OTz.rst
@@ -1,0 +1,1 @@
+Fix missing jump target labels when compiler reorders cold/warm blocks.

--- a/Python/flowgraph.c
+++ b/Python/flowgraph.c
@@ -2149,7 +2149,6 @@ push_cold_blocks_to_end(cfg_builder *g) {
             basicblock_addop(explicit_jump, JUMP, b->b_next->b_label.id, NO_LOCATION);
             explicit_jump->b_cold = 1;
             explicit_jump->b_next = b->b_next;
-            explicit_jump->b_label.id = next_lbl++;
             b->b_next = explicit_jump;
 
             /* set target */

--- a/Python/flowgraph.c
+++ b/Python/flowgraph.c
@@ -2133,6 +2133,8 @@ push_cold_blocks_to_end(cfg_builder *g) {
     }
     RETURN_IF_ERROR(mark_cold(entryblock));
 
+    int next_lbl = get_max_label(g->g_entryblock) + 1;
+
     /* If we have a cold block with fallthrough to a warm block, add */
     /* an explicit jump instead of fallthrough */
     for (basicblock *b = entryblock; b != NULL; b = b->b_next) {
@@ -2141,9 +2143,13 @@ push_cold_blocks_to_end(cfg_builder *g) {
             if (explicit_jump == NULL) {
                 return ERROR;
             }
+            if (!IS_LABEL(b->b_next->b_label)) {
+                b->b_next->b_label.id = next_lbl++;
+            }
             basicblock_addop(explicit_jump, JUMP, b->b_next->b_label.id, NO_LOCATION);
             explicit_jump->b_cold = 1;
             explicit_jump->b_next = b->b_next;
+            explicit_jump->b_label.id = next_lbl++;
             b->b_next = explicit_jump;
 
             /* set target */


### PR DESCRIPTION
Fixes #109719.



<!-- gh-issue-number: gh-109719 -->
* Issue: gh-109719
<!-- /gh-issue-number -->
