### PR TITLE
GH-95913: Add the release date for Python 3.11

### DIFF
--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -45,7 +45,7 @@
    when researching a change.
 
 This article explains the new features in Python 3.11, compared to 3.10.
-
+Python 3.11 was released on October 24, 2022.
 For full details, see the :ref:`changelog <changelog>`.
 
 

--- a/Doc/whatsnew/3.9.rst
+++ b/Doc/whatsnew/3.9.rst
@@ -44,7 +44,6 @@
 
 This article explains the new features in Python 3.9, compared to 3.8.
 Python 3.9 was released on October 5, 2020.
-
 For full details, see the :ref:`changelog <changelog>`.
 
 .. seealso::


### PR DESCRIPTION
Also remove a newline between the date and the changelog note in 3.9 whatsnew.

A

<!-- gh-issue-number: gh-95913 -->
* Issue: gh-95913
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--109750.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->