### PR TITLE
GH-109190: Copyedit 3.12 What's New: Update the ``imp`` porting guidance

### DIFF
--- a/Doc/whatsnew/3.12.rst
+++ b/Doc/whatsnew/3.12.rst
@@ -1390,7 +1390,7 @@ imp
 * The :mod:`!imp` module has been removed.  (Contributed by Barry Warsaw in
   :gh:`98040`.)
 
-* Replace removed :mod:`!imp` functions with :mod:`importlib` functions:
+  To migrate, consult the following correspondence table:
 
     =================================  =======================================
        imp                                importlib
@@ -1405,9 +1405,10 @@ imp
     ``imp.new_module(name)``           ``types.ModuleType(name)``
     ``imp.reload()``                   :func:`importlib.reload`
     ``imp.source_from_cache()``        :func:`importlib.util.source_from_cache`
+    ``imp.load_source()``              *See below*
     =================================  =======================================
 
-* Replace ``imp.load_source()`` with::
+  Replace ``imp.load_source()`` with::
 
         import importlib.util
         import importlib.machinery


### PR DESCRIPTION
* This merges three bullets into one, and rewords the lead to make it clear that this is a guide to porting rather than an internal change to Python.

<!-- gh-issue-number: gh-109190 -->
* Issue: gh-109190
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--109755.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->