### PR TITLE
GH-109190: Copyedit 3.12 What's New: Use the ``:file:`` role

### DIFF
--- a/Doc/whatsnew/3.12.rst
+++ b/Doc/whatsnew/3.12.rst
@@ -1713,10 +1713,10 @@ Build Changes
   if the Clang compiler accepts the flag.
   (Contributed by Dong-hee Na in :gh:`89536`.)
 
-* Add ``COMPILEALL_OPTS`` variable in the :file:`Makefile` to override
-  :mod:`compileall` options (default: ``-j0``) in ``make install``.
-  Also merged the 3 ``compileall`` commands into a single command to
-  build .pyc files for all optimization levels (0, 1, 2) at once.
+* Add ``COMPILEALL_OPTS`` variable in :file:`Makefile` to override :mod:`compileall`
+  options (default: ``-j0``) in ``make install``. Also merged the 3
+  ``compileall`` commands into a single command to build .pyc files for all
+  optimization levels (0, 1, 2) at once.
   (Contributed by Victor Stinner in :gh:`99289`.)
 
 * Add platform triplets for 64-bit LoongArch:

--- a/Doc/whatsnew/3.12.rst
+++ b/Doc/whatsnew/3.12.rst
@@ -1880,8 +1880,8 @@ New Features
   - ``SSTATE_INTERNED_IMMORTAL_STATIC`` An identifier for interned unicode
        objects that are immortal and static
   - ``sys.getunicodeinternedsize`` This returns the total number of unicode
-      objects that have been interned. This is now needed for :file:`refleak.py`
-      to correctly track reference counts and allocated blocks
+      objects that have been interned. This is now needed for :file:`refleak.py` to
+      correctly track reference counts and allocated blocks
 
   (Contributed by Eddie Elizondo in :gh:`84436`.)
 

--- a/Doc/whatsnew/3.12.rst
+++ b/Doc/whatsnew/3.12.rst
@@ -1571,8 +1571,8 @@ zipimport
 Others
 ------
 
-* Removed the ``suspicious`` rule from the documentation :file:`Makefile`,
-  and removed ``Doc/tools/rstlint.py``, both in favor of `sphinx-lint
+* Removed the ``suspicious`` rule from the documentation :file:`Makefile`, and
+  removed ``Doc/tools/rstlint.py``, both in favor of `sphinx-lint
   <https://github.com/sphinx-contrib/sphinx-lint>`_.
   (Contributed by Julien Palard in :gh:`98179`.)
 

--- a/Doc/whatsnew/3.12.rst
+++ b/Doc/whatsnew/3.12.rst
@@ -1571,8 +1571,8 @@ zipimport
 Others
 ------
 
-* Removed the ``suspicious`` rule from the documentation Makefile, and
-  removed ``Doc/tools/rstlint.py``, both in favor of `sphinx-lint
+* Removed the ``suspicious`` rule from the documentation :file:`Makefile`,
+  and removed ``Doc/tools/rstlint.py``, both in favor of `sphinx-lint
   <https://github.com/sphinx-contrib/sphinx-lint>`_.
   (Contributed by Julien Palard in :gh:`98179`.)
 
@@ -1698,9 +1698,9 @@ Changes in the Python API
 Build Changes
 =============
 
-* Python no longer uses ``setup.py`` to build shared C extension modules.
+* Python no longer uses :file:`setup.py` to build shared C extension modules.
   Build parameters like headers and libraries are detected in ``configure``
-  script. Extensions are built by ``Makefile``. Most extensions use
+  script. Extensions are built by :file:`Makefile`. Most extensions use
   ``pkg-config`` and fall back to manual detection.
   (Contributed by Christian Heimes in :gh:`93939`.)
 
@@ -1713,10 +1713,10 @@ Build Changes
   if the Clang compiler accepts the flag.
   (Contributed by Dong-hee Na in :gh:`89536`.)
 
-* Add ``COMPILEALL_OPTS`` variable in Makefile to override :mod:`compileall`
-  options (default: ``-j0``) in ``make install``. Also merged the 3
-  ``compileall`` commands into a single command to build .pyc files for all
-  optimization levels (0, 1, 2) at once.
+* Add ``COMPILEALL_OPTS`` variable in the :file:`Makefile` to override
+  :mod:`compileall` options (default: ``-j0``) in ``make install``.
+  Also merged the 3 ``compileall`` commands into a single command to
+  build .pyc files for all optimization levels (0, 1, 2) at once.
   (Contributed by Victor Stinner in :gh:`99289`.)
 
 * Add platform triplets for 64-bit LoongArch:
@@ -1880,8 +1880,8 @@ New Features
   - ``SSTATE_INTERNED_IMMORTAL_STATIC`` An identifier for interned unicode
        objects that are immortal and static
   - ``sys.getunicodeinternedsize`` This returns the total number of unicode
-      objects that have been interned. This is now needed for refleak.py to
-      correctly track reference counts and allocated blocks
+      objects that have been interned. This is now needed for :file:`refleak.py`
+      to correctly track reference counts and allocated blocks
 
   (Contributed by Eddie Elizondo in :gh:`84436`.)
 
@@ -2071,10 +2071,10 @@ Deprecated
 * Creating immutable types (:c:macro:`Py_TPFLAGS_IMMUTABLETYPE`) with mutable
   bases is deprecated and will be disabled in Python 3.14.
 
-* The ``structmember.h`` header is deprecated, though it continues to be
+* The :file:`structmember.h` header is deprecated, though it continues to be
   available and there are no plans to remove it.
 
-  Its contents are now available just by including ``Python.h``,
+  Its contents are now available just by including :file:`Python.h`,
   with a ``Py`` prefix added if it was missing:
 
   - :c:struct:`PyMemberDef`, :c:func:`PyMember_GetOne` and
@@ -2084,14 +2084,14 @@ Deprecated
   - The flags :c:macro:`Py_READONLY` (previously ``READONLY``) and
     :c:macro:`Py_AUDIT_READ` (previously all uppercase)
 
-  Several items are not exposed from ``Python.h``:
+  Several items are not exposed from :file:`Python.h`:
 
   - :c:macro:`T_OBJECT` (use :c:macro:`Py_T_OBJECT_EX`)
   - :c:macro:`T_NONE` (previously undocumented, and pretty quirky)
   - The macro ``WRITE_RESTRICTED`` which does nothing.
   - The macros ``RESTRICTED`` and ``READ_RESTRICTED``, equivalents of
     :c:macro:`Py_AUDIT_READ`.
-  - In some configurations, ``<stddef.h>`` is not included from ``Python.h``.
+  - In some configurations, ``<stddef.h>`` is not included from :file:`Python.h`.
     It should be included manually when using ``offsetof()``.
 
   The deprecated header continues to provide its original
@@ -2121,8 +2121,8 @@ Deprecated
 Removed
 -------
 
-* Remove the ``token.h`` header file. There was never any public tokenizer C
-  API. The ``token.h`` header file was only designed to be used by Python
+* Remove the :file:`token.h` header file. There was never any public tokenizer C
+  API. The :file:`token.h` header file was only designed to be used by Python
   internals.
   (Contributed by Victor Stinner in :gh:`92651`.)
 


### PR DESCRIPTION
* Use semantic markup for files where appropriate

<!-- gh-issue-number: gh-109190 -->
* Issue: gh-109190
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--109756.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->