### PR TITLE
gh-100228: Document the os.fork threads DeprecationWarning.

### DIFF
--- a/Doc/library/concurrent.futures.rst
+++ b/Doc/library/concurrent.futures.rst
@@ -294,7 +294,7 @@ to a :class:`ProcessPoolExecutor` will result in deadlock.
       control the lifetime of workers in the pool.
 
    .. versionchanged:: 3.12
-      On POSIX systems if your application has multiple threads and the
+      On POSIX systems, if your application has multiple threads and the
       :mod:`multiprocessing` context uses the ``"fork"`` start method:
       The :func:`os.fork` called internally to spawn workers may raise a
       :exc:`DeprecationWarning`. Pass a *mp_context* configured to use a

--- a/Doc/library/concurrent.futures.rst
+++ b/Doc/library/concurrent.futures.rst
@@ -293,6 +293,14 @@ to a :class:`ProcessPoolExecutor` will result in deadlock.
       The *max_tasks_per_child* argument was added to allow users to
       control the lifetime of workers in the pool.
 
+   .. versionchanged:: 3.12
+      On POSIX systems if your application has multiple threads and the
+      :mod:`multiprocessing` context uses the ``"fork"`` start method:
+      The :func:`os.fork` called internally to spawn workers may raise a
+      :exc:`DeprecationWarning`. Pass a *mp_context* configured to use a
+      different start method. See the :func:`os.fork` documentation
+      further explanation.
+
 .. _processpoolexecutor-example:
 
 ProcessPoolExecutor Example

--- a/Doc/library/concurrent.futures.rst
+++ b/Doc/library/concurrent.futures.rst
@@ -298,7 +298,7 @@ to a :class:`ProcessPoolExecutor` will result in deadlock.
       :mod:`multiprocessing` context uses the ``"fork"`` start method:
       The :func:`os.fork` called internally to spawn workers may raise a
       :exc:`DeprecationWarning`. Pass a *mp_context* configured to use a
-      different start method. See the :func:`os.fork` documentation
+      different start method. See the :func:`os.fork` documentation for
       further explanation.
 
 .. _processpoolexecutor-example:

--- a/Doc/library/concurrent.futures.rst
+++ b/Doc/library/concurrent.futures.rst
@@ -296,7 +296,7 @@ to a :class:`ProcessPoolExecutor` will result in deadlock.
    .. versionchanged:: 3.12
       On POSIX systems, if your application has multiple threads and the
       :mod:`multiprocessing` context uses the ``"fork"`` start method:
-      The :func:`os.fork` called internally to spawn workers may raise a
+      The :func:`os.fork` function called internally to spawn workers may raise a
       :exc:`DeprecationWarning`. Pass a *mp_context* configured to use a
       different start method. See the :func:`os.fork` documentation for
       further explanation.

--- a/Doc/library/multiprocessing.rst
+++ b/Doc/library/multiprocessing.rst
@@ -135,7 +135,7 @@ to start a process.  These *start methods* are
        If Python is able to detect that your process has multiple threads, the
        :func:`os.fork` function that this start method calls internally will
        raise a :exc:`DeprecationWarning`. Use a different start method.
-       See the :func:`os.fork` documentation further explanation.
+       See the :func:`os.fork` documentation for further explanation.
 
   *forkserver*
     When the program starts and selects the *forkserver* start method,

--- a/Doc/library/multiprocessing.rst
+++ b/Doc/library/multiprocessing.rst
@@ -131,6 +131,12 @@ to start a process.  These *start methods* are
        Code that requires *fork* should explicitly specify that via
        :func:`get_context` or :func:`set_start_method`.
 
+    .. versionchanged:: 3.12
+       If Python is able to detect that your process has multiple threads, the
+       :func:`os.fork` function that this start method calls internally will
+       raise a :exc:`DeprecationWarning`. Use a different start method.
+       See the :func:`os.fork` documentation further explanation.
+
   *forkserver*
     When the program starts and selects the *forkserver* start method,
     a server process is spawned.  From then on, whenever a new process

--- a/Doc/library/os.rst
+++ b/Doc/library/os.rst
@@ -4159,7 +4159,7 @@ written in Python, such as a mail server's external command delivery program.
 
    .. warning::
 
-      If you use TLS sockets in an application calling ``fork()`` see
+      If you use TLS sockets in an application calling ``fork()``, see
       the warning in the :mod:`ssl` documentation.
 
    .. versionchanged:: 3.8

--- a/Doc/library/os.rst
+++ b/Doc/library/os.rst
@@ -4157,15 +4157,38 @@ written in Python, such as a mail server's external command delivery program.
 
    .. audit-event:: os.fork "" os.fork
 
+   .. warning::
+
+      If you use TLS sockets in an application calling ``fork()`` see
+      the warning in the :mod:`ssl` documentation.
+
    .. versionchanged:: 3.8
       Calling ``fork()`` in a subinterpreter is no longer supported
       (:exc:`RuntimeError` is raised).
 
-   .. warning::
+   .. versionchanged:: 3.12
+      If Python is able to detect that your process has multiple
+      threads, :func:`os.fork` now raises a :exc:`DeprecationWarning`.
 
-      See :mod:`ssl` for applications that use the SSL module with fork().
+      We chose to surface this as a warning, when detectable, to better
+      inform developers of a design problem that the POSIX platform
+      specificly calls this out as not supported. Even in code that
+      *appears* to work, it has never been safe to mix threading with
+      :func:`os.fork` on POSIX platforms. The CPython runtime itself has
+      always made API calls that are not safe for use in the child
+      process when threads existed in the parent (such as ``malloc`` and
+      ``free``).
 
-   .. availability:: Unix, not Emscripten, not WASI.
+      Users of macOS or users of libc or malloc implementations other
+      than those typically found in glibc to date are among those
+      already more likely to experience deadlocks running such code.
+
+      See `this discussion on fork being incompatible with threads
+      <https://discuss.python.org/t/concerns-regarding-deprecation-of-fork-with-alive-threads/33555>`_
+      for technical details of why we're surfacing this long standing
+      platform compatibility problem to developers.
+
+   .. availability:: POSIX, not Emscripten, not WASI.
 
 
 .. function:: forkpty()
@@ -4177,6 +4200,11 @@ written in Python, such as a mail server's external command delivery program.
    :mod:`pty` module.  If an error occurs :exc:`OSError` is raised.
 
    .. audit-event:: os.forkpty "" os.forkpty
+
+   .. versionchanged:: 3.12
+      If Python is able to detect that your process has multiple
+      threads, this now raises a :exc:`DeprecationWarning`. See the
+      longer explanation on :func:`os.fork`.
 
    .. versionchanged:: 3.8
       Calling ``forkpty()`` in a subinterpreter is no longer supported

--- a/Doc/library/os.rst
+++ b/Doc/library/os.rst
@@ -4185,7 +4185,7 @@ written in Python, such as a mail server's external command delivery program.
 
       See `this discussion on fork being incompatible with threads
       <https://discuss.python.org/t/33555>`_
-      for technical details of why we're surfacing this long standing
+      for technical details of why we're surfacing this longstanding
       platform compatibility problem to developers.
 
    .. availability:: POSIX, not Emscripten, not WASI.

--- a/Doc/library/os.rst
+++ b/Doc/library/os.rst
@@ -4172,7 +4172,7 @@ written in Python, such as a mail server's external command delivery program.
 
       We chose to surface this as a warning, when detectable, to better
       inform developers of a design problem that the POSIX platform
-      specificly calls this out as not supported. Even in code that
+      specifically notes as not supported. Even in code that
       *appears* to work, it has never been safe to mix threading with
       :func:`os.fork` on POSIX platforms. The CPython runtime itself has
       always made API calls that are not safe for use in the child
@@ -4184,7 +4184,7 @@ written in Python, such as a mail server's external command delivery program.
       already more likely to experience deadlocks running such code.
 
       See `this discussion on fork being incompatible with threads
-      <https://discuss.python.org/t/concerns-regarding-deprecation-of-fork-with-alive-threads/33555>`_
+      <https://discuss.python.org/t/33555>`_
       for technical details of why we're surfacing this long standing
       platform compatibility problem to developers.
 

--- a/Doc/whatsnew/3.12.rst
+++ b/Doc/whatsnew/3.12.rst
@@ -1225,6 +1225,19 @@ Pending Removal in Python 3.14
   :func:`~multiprocessing.set_start_method` APIs to explicitly specify when
   your code *requires* ``'fork'``.  See :ref:`multiprocessing-start-methods`.
 
+* :func:`os.fork` now raises a :exc:`DeprecationWarning` on POSIX when
+  it can detect that it is being called from a multithreaded process.
+  There has always been a fundamental incompatibility with the POSIX
+  platform when doing so.  Even if such code *appeared* to work. We
+  added the warning to to raise awareness as issues encounted by code
+  doing this are becoming more frequent. See the :func:`os.fork`
+  documentation for more details.
+
+  When this warning appears to come from within :mod:`multiprocessing`
+  while using that or :mod:`concurrent.futures` the safe fix is to use a
+  different start method such as ``spawn`` (anywhere) or ``forkserver``
+  (not on macOS).
+
 * :mod:`pkgutil`: :func:`pkgutil.find_loader` and :func:`pkgutil.get_loader`
   now raise :exc:`DeprecationWarning`;
   use :func:`importlib.util.find_spec` instead.

--- a/Doc/whatsnew/3.12.rst
+++ b/Doc/whatsnew/3.12.rst
@@ -1065,6 +1065,18 @@ Deprecated
   contain the creation time, which is also available in the new ``st_birthtime``
   field. (Contributed by Steve Dower in :gh:`99726`.)
 
+* :mod:`os`: On POSIX platforms, :func:`os.fork` can now raise a
+  :exc:`DeprecationWarning` when it can detect being called from a
+  multithreaded process. There has always been a fundamental incompatibility
+  with the POSIX platform when doing so. Even if such code *appeared* to work.
+  We added the warning to to raise awareness as issues encounted by code doing
+  this are becoming more frequent. See the :func:`os.fork` documentation for
+  more details.
+
+  When this warning appears due to usage of :mod:`multiprocessing` or
+  :mod:`concurrent.futures` the fix is to use a different
+  :mod:`multiprocessing` start method such as ``"spawn"`` or ``"forkserver"``.
+
 * :mod:`shutil`: The *onerror* argument of :func:`shutil.rmtree` is deprecated as will be removed
   in Python 3.14. Use *onexc* instead. (Contributed by Irit Katriel in :gh:`102828`.)
 
@@ -1224,19 +1236,6 @@ Pending Removal in Python 3.14
   :func:`~multiprocessing.get_context` or
   :func:`~multiprocessing.set_start_method` APIs to explicitly specify when
   your code *requires* ``'fork'``.  See :ref:`multiprocessing-start-methods`.
-
-* :func:`os.fork` now raises a :exc:`DeprecationWarning` on POSIX when
-  it can detect that it is being called from a multithreaded process.
-  There has always been a fundamental incompatibility with the POSIX
-  platform when doing so.  Even if such code *appeared* to work. We
-  added the warning to to raise awareness as issues encounted by code
-  doing this are becoming more frequent. See the :func:`os.fork`
-  documentation for more details.
-
-  When this warning appears to come from within :mod:`multiprocessing`
-  while using that or :mod:`concurrent.futures` the safe fix is to use a
-  different start method such as ``spawn`` (anywhere) or ``forkserver``
-  (not on macOS).
 
 * :mod:`pkgutil`: :func:`pkgutil.find_loader` and :func:`pkgutil.get_loader`
   now raise :exc:`DeprecationWarning`;


### PR DESCRIPTION
Better document the os.fork warning to explain questions such as those raised in https://discuss.python.org/t/concerns-regarding-deprecation-of-fork-with-alive-threads/33555.

<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--109767.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->

<!-- gh-issue-number: gh-100228 -->
* Issue: gh-100228
<!-- /gh-issue-number -->
