### PR TITLE
gh-109653: Improve `enum` import time by avoiding import of `functools`

### DIFF
--- a/Lib/enum.py
+++ b/Lib/enum.py
@@ -1,8 +1,6 @@
 import sys
 import builtins as bltns
 from types import MappingProxyType, DynamicClassAttribute
-from operator import or_ as _or_
-from functools import reduce
 
 
 __all__ = [
@@ -1884,7 +1882,8 @@ class verify:
                     missed = [v for v in values if v not in member_values]
                     if missed:
                         missing_names.append(name)
-                        missing_value |= reduce(_or_, missed)
+                        for val in missed:
+                            missing_value |= val
                 if missing_names:
                     if len(missing_names) == 1:
                         alias = 'alias %s is missing' % missing_names[0]

--- a/Misc/NEWS.d/next/Library/2023-09-23-12-47-45.gh-issue-109653.9wZBfs.rst
+++ b/Misc/NEWS.d/next/Library/2023-09-23-12-47-45.gh-issue-109653.9wZBfs.rst
@@ -1,0 +1,1 @@
+Reduce the import time of :mod:`enum` by over 50%. Patch by Alex Waygood.


### PR DESCRIPTION
This reduces the import time of `enum` by over 50% on my machine (PGO-optimised, non-debug build on Windows), from around 0.007s to around 0.003s

<!-- gh-issue-number: gh-109653 -->
* Issue: gh-109653
<!-- /gh-issue-number -->
