### PR TITLE
gh-109793: Allow Switching Interpreters During Finalization

### DIFF
--- a/Include/cpython/pyatomic.h
+++ b/Include/cpython/pyatomic.h
@@ -501,3 +501,20 @@ static inline void _Py_atomic_fence_release(void);
 #else
 #  error "no available pyatomic implementation for this platform/compiler"
 #endif
+
+
+// --- aliases ---------------------------------------------------------------
+
+#if SIZEOF_LONG == 8
+# define _Py_atomic_load_ulong _Py_atomic_load_uint64
+# define _Py_atomic_load_ulong_relaxed _Py_atomic_load_uint64_relaxed
+# define _Py_atomic_store_ulong _Py_atomic_store_uint64
+# define _Py_atomic_store_ulong_relaxed _Py_atomic_store_uint64_relaxed
+#elif SIZEOF_LONG == 4
+# define _Py_atomic_load_ulong _Py_atomic_load_uint32
+# define _Py_atomic_load_ulong_relaxed _Py_atomic_load_uint32_relaxed
+# define _Py_atomic_store_ulong _Py_atomic_store_uint32
+# define _Py_atomic_store_ulong_relaxed _Py_atomic_store_uint32_relaxed
+#else
+# error "long must be 4 or 8 bytes in size"
+#endif  // SIZEOF_LONG

--- a/Include/internal/pycore_atomic.h
+++ b/Include/internal/pycore_atomic.h
@@ -46,10 +46,6 @@ typedef struct _Py_atomic_address {
     atomic_uintptr_t _value;
 } _Py_atomic_address;
 
-typedef struct _Py_atomic_ulong {
-    atomic_ulong _value;
-} _Py_atomic_ulong;
-
 typedef struct _Py_atomic_int {
     atomic_int _value;
 } _Py_atomic_int;
@@ -80,10 +76,6 @@ typedef enum _Py_memory_order {
 typedef struct _Py_atomic_address {
     uintptr_t _value;
 } _Py_atomic_address;
-
-typedef struct _Py_atomic_ulong {
-    unsigned long _value;
-} _Py_atomic_ulong;
 
 typedef struct _Py_atomic_int {
     int _value;
@@ -122,10 +114,6 @@ typedef enum _Py_memory_order {
 typedef struct _Py_atomic_address {
     uintptr_t _value;
 } _Py_atomic_address;
-
-typedef struct _Py_atomic_ulong {
-    unsigned long _value;
-} _Py_atomic_ulong;
 
 typedef struct _Py_atomic_int {
     int _value;
@@ -263,10 +251,6 @@ typedef struct _Py_atomic_address {
     volatile uintptr_t _value;
 } _Py_atomic_address;
 
-typedef struct _Py_atomic_ulong {
-    volatile unsigned long _value;
-} _Py_atomic_ulong;
-
 typedef struct _Py_atomic_int {
     volatile int _value;
 } _Py_atomic_int;
@@ -402,10 +386,6 @@ typedef enum _Py_memory_order {
 typedef struct _Py_atomic_address {
     volatile uintptr_t _value;
 } _Py_atomic_address;
-
-typedef struct _Py_atomic_ulong {
-    volatile unsigned long _value;
-} _Py_atomic_ulong;
 
 typedef struct _Py_atomic_int {
     volatile int _value;
@@ -543,10 +523,6 @@ typedef enum _Py_memory_order {
 typedef struct _Py_atomic_address {
     uintptr_t _value;
 } _Py_atomic_address;
-
-typedef struct _Py_atomic_ulong {
-    unsigned long _value;
-} _Py_atomic_ulong;
 
 typedef struct _Py_atomic_int {
     int _value;

--- a/Include/internal/pycore_atomic.h
+++ b/Include/internal/pycore_atomic.h
@@ -46,6 +46,10 @@ typedef struct _Py_atomic_address {
     atomic_uintptr_t _value;
 } _Py_atomic_address;
 
+typedef struct _Py_atomic_ulong {
+    atomic_ulong _value;
+} _Py_atomic_ulong;
+
 typedef struct _Py_atomic_int {
     atomic_int _value;
 } _Py_atomic_int;
@@ -76,6 +80,10 @@ typedef enum _Py_memory_order {
 typedef struct _Py_atomic_address {
     uintptr_t _value;
 } _Py_atomic_address;
+
+typedef struct _Py_atomic_ulong {
+    unsigned long _value;
+} _Py_atomic_ulong;
 
 typedef struct _Py_atomic_int {
     int _value;
@@ -114,6 +122,10 @@ typedef enum _Py_memory_order {
 typedef struct _Py_atomic_address {
     uintptr_t _value;
 } _Py_atomic_address;
+
+typedef struct _Py_atomic_ulong {
+    unsigned long _value;
+} _Py_atomic_ulong;
 
 typedef struct _Py_atomic_int {
     int _value;
@@ -251,6 +263,10 @@ typedef struct _Py_atomic_address {
     volatile uintptr_t _value;
 } _Py_atomic_address;
 
+typedef struct _Py_atomic_ulong {
+    volatile unsigned long _value;
+} _Py_atomic_ulong;
+
 typedef struct _Py_atomic_int {
     volatile int _value;
 } _Py_atomic_int;
@@ -386,6 +402,10 @@ typedef enum _Py_memory_order {
 typedef struct _Py_atomic_address {
     volatile uintptr_t _value;
 } _Py_atomic_address;
+
+typedef struct _Py_atomic_ulong {
+    volatile unsigned long _value;
+} _Py_atomic_ulong;
 
 typedef struct _Py_atomic_int {
     volatile int _value;
@@ -523,6 +543,10 @@ typedef enum _Py_memory_order {
 typedef struct _Py_atomic_address {
     uintptr_t _value;
 } _Py_atomic_address;
+
+typedef struct _Py_atomic_ulong {
+    unsigned long _value;
+} _Py_atomic_ulong;
 
 typedef struct _Py_atomic_int {
     int _value;

--- a/Include/internal/pycore_interp.h
+++ b/Include/internal/pycore_interp.h
@@ -94,7 +94,7 @@ struct _is {
        to access it, don't access it directly. */
     _Py_atomic_address _finalizing;
     /* The ID of the OS thread in which we are finalizing. */
-    _Py_atomic_ulong _finalizing_id;
+    unsigned long _finalizing_id;
 
     struct _gc_runtime_state gc;
 
@@ -219,19 +219,20 @@ _PyInterpreterState_GetFinalizing(PyInterpreterState *interp) {
 
 static inline unsigned long
 _PyInterpreterState_GetFinalizingID(PyInterpreterState *interp) {
-    return _Py_atomic_load_relaxed(&interp->_finalizing_id);
+    return _Py_atomic_load_ulong_relaxed(&interp->_finalizing_id);
 }
 
 static inline void
 _PyInterpreterState_SetFinalizing(PyInterpreterState *interp, PyThreadState *tstate) {
     _Py_atomic_store_relaxed(&interp->_finalizing, (uintptr_t)tstate);
     if (tstate == NULL) {
-        _Py_atomic_store_relaxed(&interp->_finalizing_id, 0);
+        _Py_atomic_store_ulong_relaxed(&interp->_finalizing_id, 0);
     }
     else {
         // XXX Re-enable this assert once gh-109860 is fixed.
         //assert(tstate->thread_id == PyThread_get_thread_ident());
-        _Py_atomic_store_relaxed(&interp->_finalizing_id, tstate->thread_id);
+        _Py_atomic_store_ulong_relaxed(&interp->_finalizing_id,
+                                       tstate->thread_id);
     }
 }
 

--- a/Include/internal/pycore_interp.h
+++ b/Include/internal/pycore_interp.h
@@ -93,6 +93,8 @@ struct _is {
        and _PyInterpreterState_SetFinalizing()
        to access it, don't access it directly. */
     _Py_atomic_address _finalizing;
+    /* The ID of the OS thread in which we are finalizing. */
+    _Py_atomic_ulong _finalizing_id;
 
     struct _gc_runtime_state gc;
 
@@ -215,9 +217,21 @@ _PyInterpreterState_GetFinalizing(PyInterpreterState *interp) {
     return (PyThreadState*)_Py_atomic_load_relaxed(&interp->_finalizing);
 }
 
+static inline unsigned long
+_PyInterpreterState_GetFinalizingID(PyInterpreterState *interp) {
+    return _Py_atomic_load_relaxed(&interp->_finalizing_id);
+}
+
 static inline void
 _PyInterpreterState_SetFinalizing(PyInterpreterState *interp, PyThreadState *tstate) {
     _Py_atomic_store_relaxed(&interp->_finalizing, (uintptr_t)tstate);
+    if (tstate == NULL) {
+        _Py_atomic_store_relaxed(&interp->_finalizing_id, 0);
+    }
+    else {
+        assert(tstate->thread_id == PyThread_get_thread_ident());
+        _Py_atomic_store_relaxed(&interp->_finalizing_id, tstate->thread_id);
+    }
 }
 
 

--- a/Include/internal/pycore_interp.h
+++ b/Include/internal/pycore_interp.h
@@ -229,7 +229,8 @@ _PyInterpreterState_SetFinalizing(PyInterpreterState *interp, PyThreadState *tst
         _Py_atomic_store_relaxed(&interp->_finalizing_id, 0);
     }
     else {
-        assert(tstate->thread_id == PyThread_get_thread_ident());
+        // XXX Re-enable this assert once gh-109860 is fixed.
+        //assert(tstate->thread_id == PyThread_get_thread_ident());
         _Py_atomic_store_relaxed(&interp->_finalizing_id, tstate->thread_id);
     }
 }

--- a/Include/internal/pycore_pystate.h
+++ b/Include/internal/pycore_pystate.h
@@ -36,8 +36,12 @@ _Py_IsMainInterpreter(PyInterpreterState *interp)
 static inline int
 _Py_IsMainInterpreterFinalizing(PyInterpreterState *interp)
 {
-    return (_PyRuntimeState_GetFinalizing(interp->runtime) != NULL &&
-            interp == &interp->runtime->_main_interpreter);
+    /* bpo-39877: Access _PyRuntime directly rather than using
+       tstate->interp->runtime to support calls from Python daemon threads.
+       After Py_Finalize() has been called, tstate can be a dangling pointer:
+       point to PyThreadState freed memory. */
+    return (_PyRuntimeState_GetFinalizing(&_PyRuntime) != NULL &&
+            interp == &_PyRuntime._main_interpreter);
 }
 
 

--- a/Include/internal/pycore_runtime.h
+++ b/Include/internal/pycore_runtime.h
@@ -317,7 +317,8 @@ _PyRuntimeState_SetFinalizing(_PyRuntimeState *runtime, PyThreadState *tstate) {
         _Py_atomic_store_relaxed(&runtime->_finalizing_id, 0);
     }
     else {
-        assert(tstate->thread_id == PyThread_get_thread_ident());
+        // XXX Re-enable this assert once gh-109860 is fixed.
+        //assert(tstate->thread_id == PyThread_get_thread_ident());
         _Py_atomic_store_relaxed(&runtime->_finalizing_id, tstate->thread_id);
     }
 }

--- a/Include/internal/pycore_runtime.h
+++ b/Include/internal/pycore_runtime.h
@@ -171,6 +171,8 @@ typedef struct pyruntimestate {
        Use _PyRuntimeState_GetFinalizing() and _PyRuntimeState_SetFinalizing()
        to access it, don't access it directly. */
     _Py_atomic_address _finalizing;
+    /* The ID of the OS thread in which we are finalizing. */
+    _Py_atomic_ulong _finalizing_id;
 
     struct pyinterpreters {
         PyThread_type_lock mutex;
@@ -303,9 +305,21 @@ _PyRuntimeState_GetFinalizing(_PyRuntimeState *runtime) {
     return (PyThreadState*)_Py_atomic_load_relaxed(&runtime->_finalizing);
 }
 
+static inline unsigned long
+_PyRuntimeState_GetFinalizingID(_PyRuntimeState *runtime) {
+    return _Py_atomic_load_relaxed(&runtime->_finalizing_id);
+}
+
 static inline void
 _PyRuntimeState_SetFinalizing(_PyRuntimeState *runtime, PyThreadState *tstate) {
     _Py_atomic_store_relaxed(&runtime->_finalizing, (uintptr_t)tstate);
+    if (tstate == NULL) {
+        _Py_atomic_store_relaxed(&runtime->_finalizing_id, 0);
+    }
+    else {
+        assert(tstate->thread_id == PyThread_get_thread_ident());
+        _Py_atomic_store_relaxed(&runtime->_finalizing_id, tstate->thread_id);
+    }
 }
 
 #ifdef __cplusplus

--- a/Include/internal/pycore_runtime.h
+++ b/Include/internal/pycore_runtime.h
@@ -172,7 +172,7 @@ typedef struct pyruntimestate {
        to access it, don't access it directly. */
     _Py_atomic_address _finalizing;
     /* The ID of the OS thread in which we are finalizing. */
-    _Py_atomic_ulong _finalizing_id;
+    unsigned long _finalizing_id;
 
     struct pyinterpreters {
         PyThread_type_lock mutex;
@@ -307,19 +307,20 @@ _PyRuntimeState_GetFinalizing(_PyRuntimeState *runtime) {
 
 static inline unsigned long
 _PyRuntimeState_GetFinalizingID(_PyRuntimeState *runtime) {
-    return _Py_atomic_load_relaxed(&runtime->_finalizing_id);
+    return _Py_atomic_load_ulong_relaxed(&runtime->_finalizing_id);
 }
 
 static inline void
 _PyRuntimeState_SetFinalizing(_PyRuntimeState *runtime, PyThreadState *tstate) {
     _Py_atomic_store_relaxed(&runtime->_finalizing, (uintptr_t)tstate);
     if (tstate == NULL) {
-        _Py_atomic_store_relaxed(&runtime->_finalizing_id, 0);
+        _Py_atomic_store_ulong_relaxed(&runtime->_finalizing_id, 0);
     }
     else {
         // XXX Re-enable this assert once gh-109860 is fixed.
         //assert(tstate->thread_id == PyThread_get_thread_ident());
-        _Py_atomic_store_relaxed(&runtime->_finalizing_id, tstate->thread_id);
+        _Py_atomic_store_ulong_relaxed(&runtime->_finalizing_id,
+                                       tstate->thread_id);
     }
 }
 

--- a/Lib/test/test_interpreters.py
+++ b/Lib/test/test_interpreters.py
@@ -499,6 +499,12 @@ class FinalizationTests(TestBase):
             ''']
         proc = subprocess.run(argv, capture_output=True, text=True)
         self.assertIn('Traceback', proc.stderr)
+        if proc.returncode == 0 and support.verbose:
+            print()
+            print("--- cmd unexpected succeeded ---")
+            print(f"stdout:\n{proc.stdout}")
+            print(f"stderr:\n{proc.stderr}")
+            print("------")
         self.assertEqual(proc.returncode, 1)
 
 

--- a/Lib/test/test_interpreters.py
+++ b/Lib/test/test_interpreters.py
@@ -1,5 +1,6 @@
 import contextlib
 import os
+import sys
 import threading
 from textwrap import dedent
 import unittest
@@ -485,6 +486,20 @@ class StressTests(TestBase):
         threads = (threading.Thread(target=task) for _ in range(200))
         with threading_helper.start_threads(threads):
             pass
+
+
+class FinalizationTests(TestBase):
+
+    def test_gh_109793(self):
+        import subprocess
+        argv = [sys.executable, '-c', '''if True:
+            import _xxsubinterpreters as _interpreters
+            interpid = _interpreters.create()
+            raise Exception
+            ''']
+        proc = subprocess.run(argv, capture_output=True, text=True)
+        self.assertIn('Traceback', proc.stderr)
+        self.assertEqual(proc.returncode, 1)
 
 
 class TestIsShareable(TestBase):

--- a/Misc/NEWS.d/next/Core and Builtins/2023-09-25-09-24-10.gh-issue-109793.zFQBkv.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2023-09-25-09-24-10.gh-issue-109793.zFQBkv.rst
@@ -1,1 +1,4 @@
-``sys.path[0]`` is now set properly for subinterpreters.
+The main thread no longer exits prematurely when a subinterpreter
+is cleaned up during runtime finalization.  The bug was a problem
+particularly because, when triggered, the Python process would
+always return with a 0 exitcode, even if it failed.

--- a/Misc/NEWS.d/next/Core and Builtins/2023-09-25-09-24-10.gh-issue-109793.zFQBkv.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2023-09-25-09-24-10.gh-issue-109793.zFQBkv.rst
@@ -1,0 +1,1 @@
+``sys.path[0]`` is now set properly for subinterpreters.

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -2964,17 +2964,22 @@ _PyThreadState_MustExit(PyThreadState *tstate)
        tstate->interp->runtime to support calls from Python daemon threads.
        After Py_Finalize() has been called, tstate can be a dangling pointer:
        point to PyThreadState freed memory. */
+    unsigned long finalizing_id = _PyRuntimeState_GetFinalizingID(&_PyRuntime);
     PyThreadState *finalizing = _PyRuntimeState_GetFinalizing(&_PyRuntime);
     if (finalizing == NULL) {
+        // XXX This isn't completely safe from daemon thraeds,
+        // since tstate might be a dangling pointer.
         finalizing = _PyInterpreterState_GetFinalizing(tstate->interp);
+        finalizing_id = _PyInterpreterState_GetFinalizingID(tstate->interp);
     }
+    // XXX else check &_PyRuntime._main_interpreter._initial_thread
     if (finalizing == NULL) {
         return 0;
     }
     else if (finalizing == tstate) {
         return 0;
     }
-    else if (finalizing->thread_id == tstate->thread_id) {
+    else if (finalizing_id == PyThread_get_thread_ident()) {
         /* gh-109793: we must have switched interpreters. */
         return 0;
     }

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -2968,7 +2968,17 @@ _PyThreadState_MustExit(PyThreadState *tstate)
     if (finalizing == NULL) {
         finalizing = _PyInterpreterState_GetFinalizing(tstate->interp);
     }
-    return (finalizing != NULL && finalizing != tstate);
+    if (finalizing == NULL) {
+        return 0;
+    }
+    else if (finalizing == tstate) {
+        return 0;
+    }
+    else if (finalizing->thread_id == tstate->thread_id) {
+        /* gh-109793: we must have switched interpreters. */
+        return 0;
+    }
+    return 1;
 }
 
 


### PR DESCRIPTION
Essentially, we should check the thread ID rather than the thread state pointer.

<!-- gh-issue-number: gh-109793 -->
* Issue: gh-109793
<!-- /gh-issue-number -->
