### PR TITLE
gh-101100: Fix sphinx warnings in `Doc/library/xml.etree.elementtree.rst`

### DIFF
--- a/Doc/library/xml.etree.elementtree.rst
+++ b/Doc/library/xml.etree.elementtree.rst
@@ -17,7 +17,7 @@ for parsing and creating XML data.
    This module will use a fast implementation whenever available.
 
 .. deprecated:: 3.3
-   The :mod:`xml.etree.cElementTree` module is deprecated.
+   The :mod:`!xml.etree.cElementTree` module is deprecated.
 
 
 .. warning::
@@ -825,6 +825,8 @@ Reference
 Functions
 ^^^^^^^^^
 
+.. module:: xml.etree.ElementInclude
+
 .. function:: xml.etree.ElementInclude.default_loader( href, parse, encoding=None)
    :module:
 
@@ -861,6 +863,9 @@ Functions
 
 Element Objects
 ^^^^^^^^^^^^^^^
+
+.. module:: xml.etree.ElementTree
+   :noindex:
 
 .. class:: Element(tag, attrib={}, **extra)
 

--- a/Doc/tools/.nitignore
+++ b/Doc/tools/.nitignore
@@ -139,7 +139,6 @@ Doc/library/wsgiref.rst
 Doc/library/xml.dom.minidom.rst
 Doc/library/xml.dom.pulldom.rst
 Doc/library/xml.dom.rst
-Doc/library/xml.etree.elementtree.rst
 Doc/library/xml.rst
 Doc/library/xml.sax.handler.rst
 Doc/library/xml.sax.reader.rst


### PR DESCRIPTION
It used to be like this:

```
/Users/sobolev/Desktop/cpython/Doc/library/xml.etree.elementtree.rst:20: WARNING: py:mod reference target not found: xml.etree.cElementTree
/Users/sobolev/Desktop/cpython/Doc/library/xml.etree.elementtree.rst:765: WARNING: py:mod reference target not found: xml.etree.ElementInclude
```

Now I define correct module where we define functions in this module, later I switch the module back to the default one. Preview:

<img width="826" alt="Снимок экрана 2023-09-24 в 11 09 41" src="https://github.com/python/cpython/assets/4660275/f541bf3b-a197-48d3-b1fb-00b5953cb874">


<!-- gh-issue-number: gh-101100 -->
* Issue: gh-101100
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--109799.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->