### PR TITLE
gh-109653: Remove unused imports in the `Lib/` directory

### DIFF
--- a/Lib/asyncio/tasks.py
+++ b/Lib/asyncio/tasks.py
@@ -17,7 +17,6 @@ import inspect
 import itertools
 import math
 import types
-import warnings
 import weakref
 from types import GenericAlias
 

--- a/Lib/test/mapping_tests.py
+++ b/Lib/test/mapping_tests.py
@@ -1,7 +1,6 @@
 # tests common to dict and UserDict
 import unittest
 import collections
-import sys
 from test.support import Py_C_RECURSION_LIMIT
 
 

--- a/Lib/test/support/interpreters.py
+++ b/Lib/test/support/interpreters.py
@@ -5,7 +5,7 @@ import _xxsubinterpreters as _interpreters
 import _xxinterpchannels as _channels
 
 # aliases:
-from _xxsubinterpreters import is_shareable, RunFailedError
+from _xxsubinterpreters import is_shareable
 from _xxinterpchannels import (
     ChannelError, ChannelNotFoundError, ChannelEmptyError,
 )

--- a/Lib/test/test_asyncio/test_eager_task_factory.py
+++ b/Lib/test/test_asyncio/test_eager_task_factory.py
@@ -7,7 +7,6 @@ import unittest
 from unittest import mock
 from asyncio import tasks
 from test.test_asyncio import utils as test_utils
-import test.support
 from test.support.script_helper import assert_python_ok
 
 MOCK_ANY = mock.ANY

--- a/Lib/test/test_capi/test_abstract.py
+++ b/Lib/test/test_capi/test_abstract.py
@@ -1,8 +1,5 @@
 import unittest
-import sys
 from collections import OrderedDict
-from test import support
-from test.support import import_helper
 import _testcapi
 
 

--- a/Lib/test/test_capi/test_dict.py
+++ b/Lib/test/test_capi/test_dict.py
@@ -1,9 +1,6 @@
 import unittest
-import sys
 from collections import OrderedDict, UserDict
 from types import MappingProxyType
-from test import support
-from test.support import import_helper
 import _testcapi
 
 

--- a/Lib/test/test_capi/test_misc.py
+++ b/Lib/test/test_capi/test_misc.py
@@ -2,7 +2,7 @@
 # these are all functions _testcapi exports whose name begins with 'test_'.
 
 import _thread
-from collections import OrderedDict, deque
+from collections import deque
 import contextlib
 import importlib.machinery
 import importlib.util

--- a/Lib/test/test_csv.py
+++ b/Lib/test/test_csv.py
@@ -10,7 +10,7 @@ import csv
 import gc
 import pickle
 from test import support
-from test.support import warnings_helper, import_helper, check_disallow_instantiation
+from test.support import import_helper, check_disallow_instantiation
 from itertools import permutations
 from textwrap import dedent
 from collections import OrderedDict

--- a/Lib/test/test_decimal.py
+++ b/Lib/test/test_decimal.py
@@ -41,7 +41,6 @@ from test.support import (TestFailed,
                           darwin_malloc_err_warning, is_emscripten)
 from test.support.import_helper import import_fresh_module
 from test.support import threading_helper
-from test.support import warnings_helper
 import random
 import inspect
 import threading

--- a/Lib/test/test_dictviews.py
+++ b/Lib/test/test_dictviews.py
@@ -1,7 +1,6 @@
 import collections.abc
 import copy
 import pickle
-import sys
 import unittest
 from test.support import Py_C_RECURSION_LIMIT
 

--- a/Lib/test/test_gdb.py
+++ b/Lib/test/test_gdb.py
@@ -4,7 +4,6 @@
 # Lib/test/test_jit_gdb.py
 
 import os
-import platform
 import re
 import subprocess
 import sys

--- a/Lib/test/test_importlib/import_/test_packages.py
+++ b/Lib/test/test_importlib/import_/test_packages.py
@@ -1,7 +1,6 @@
 from test.test_importlib import util
 import sys
 import unittest
-from test import support
 from test.support import import_helper
 
 

--- a/Lib/test/test_monitoring.py
+++ b/Lib/test/test_monitoring.py
@@ -8,6 +8,7 @@ import sys
 import textwrap
 import types
 import unittest
+import asyncio
 
 PAIR = (0,1)
 

--- a/Lib/test/test_monitoring.py
+++ b/Lib/test/test_monitoring.py
@@ -8,7 +8,6 @@ import sys
 import textwrap
 import types
 import unittest
-import asyncio
 
 PAIR = (0,1)
 

--- a/Lib/test/test_peg_generator/__init__.py
+++ b/Lib/test/test_peg_generator/__init__.py
@@ -1,5 +1,4 @@
 import os.path
-import unittest
 from test import support
 from test.support import load_package_tests
 

--- a/Lib/test/test_pyexpat.py
+++ b/Lib/test/test_pyexpat.py
@@ -2,7 +2,6 @@
 # handler, are obscure and unhelpful.
 
 import os
-import platform
 import sys
 import sysconfig
 import unittest
@@ -14,7 +13,7 @@ from test.support import os_helper
 from xml.parsers import expat
 from xml.parsers.expat import errors
 
-from test.support import sortdict, is_emscripten, is_wasi
+from test.support import sortdict
 
 
 class SetAttributeTest(unittest.TestCase):

--- a/Lib/test/test_sqlite3/test_dump.py
+++ b/Lib/test/test_sqlite3/test_dump.py
@@ -1,7 +1,6 @@
 # Author: Paul Kippes <kippesp@gmail.com>
 
 import unittest
-import sqlite3 as sqlite
 
 from .util import memory_database
 from .util import MemoryDatabaseMixin

--- a/Lib/test/test_sqlite3/test_userfunctions.py
+++ b/Lib/test/test_sqlite3/test_userfunctions.py
@@ -29,7 +29,7 @@ from unittest.mock import Mock, patch
 from test.support import bigmemtest, gc_collect
 
 from .util import cx_limit, memory_database
-from .util import with_tracebacks, check_tracebacks
+from .util import with_tracebacks
 
 
 def func_returntext():

--- a/Lib/test/test_sqlite3/util.py
+++ b/Lib/test/test_sqlite3/util.py
@@ -4,7 +4,6 @@ import io
 import re
 import sqlite3
 import test.support
-import unittest
 
 
 # Helper for temporary memory databases

--- a/Lib/test/test_tkinter/support.py
+++ b/Lib/test/test_tkinter/support.py
@@ -1,6 +1,5 @@
 import functools
 import tkinter
-import unittest
 
 class AbstractTkTest:
 

--- a/Lib/test/test_unittest/testmock/testthreadingmock.py
+++ b/Lib/test/test_unittest/testmock/testthreadingmock.py
@@ -3,7 +3,7 @@ import unittest
 import concurrent.futures
 
 from test.support import threading_helper
-from unittest.mock import patch, ThreadingMock, call
+from unittest.mock import patch, ThreadingMock
 
 
 threading_helper.requires_working_threading(module=True)

--- a/Lib/test/test_zlib.py
+++ b/Lib/test/test_zlib.py
@@ -3,7 +3,6 @@ from test import support
 from test.support import import_helper
 import binascii
 import copy
-import os
 import pickle
 import random
 import sys


### PR DESCRIPTION
As suggested in https://github.com/python/cpython/issues/109653#issuecomment-1732329802 by @hugovk.

Nearly all of these are in `Lib/test/`, but there is also one in `Lib/asyncio/tasks.py`.

<!-- gh-issue-number: gh-109653 -->
* Issue: gh-109653
<!-- /gh-issue-number -->
