### PR TITLE
gh-109653: Avoid a top-level import of `types` in `functools`

### DIFF
--- a/Lib/functools.py
+++ b/Lib/functools.py
@@ -19,8 +19,9 @@ from collections import namedtuple
 # import types, weakref  # Deferred to single_dispatch()
 from reprlib import recursive_repr
 from _thread import RLock
-from types import GenericAlias
 
+# Avoid importing types, so we can speedup import time
+GenericAlias = type(list[int])
 
 ################################################################################
 ### update_wrapper() and wraps() decorator

--- a/Misc/NEWS.d/next/Library/2023-09-24-13-28-35.gh-issue-109653.9IFU0B.rst
+++ b/Misc/NEWS.d/next/Library/2023-09-24-13-28-35.gh-issue-109653.9IFU0B.rst
@@ -1,0 +1,2 @@
+Improve import time of :mod:`functools` by around 13%. Patch by Alex
+Waygood.


### PR DESCRIPTION
This reduces the import time of `functools` by around 13%, according to my measurements (using a PGO-optimised non-debug build, on Windows)

<!-- gh-issue-number: gh-109653 -->
* Issue: gh-109653
<!-- /gh-issue-number -->
