### PR TITLE
Sync whatsnew with the edit I made in the 3.12 backport PR.

### DIFF
--- a/Doc/whatsnew/3.12.rst
+++ b/Doc/whatsnew/3.12.rst
@@ -1071,7 +1071,9 @@ Deprecated
   with the POSIX platform when doing so. Even if such code *appeared* to work.
   We added the warning to to raise awareness as issues encounted by code doing
   this are becoming more frequent. See the :func:`os.fork` documentation for
-  more details.
+  more details along with `this discussion on fork being incompatible with threads
+  <https://discuss.python.org/t/33555>`_ for *why* we're now surfacing this
+  longstanding platform compatibility problem to developers.
 
   When this warning appears due to usage of :mod:`multiprocessing` or
   :mod:`concurrent.futures` the fix is to use a different


### PR DESCRIPTION
A post main merge edit to the text was added in the 3.12 backport PR.
  https://github.com/python/cpython/pull/109773/commits/e38d7104b8f245e5db6d487932c44edf0d2c4762

This includes that in main.  It's a minor edit over #109767 to resolve the comment there.

<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--109807.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->