### PR TITLE
gh-109795: `_thread.start_new_thread`: allocate thread bootstate using raw memory allocator

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2023-09-24-22-26-56.gh-issue-109795.gI7KW6.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2023-09-24-22-26-56.gh-issue-109795.gI7KW6.rst
@@ -1,0 +1,1 @@
+:func:`_thread.start_new_thread` now uses raw memory allocator to allocate new thread bootstate. This helps to avoid crashes in case when new thread gets started at interpreter finalization.

--- a/Misc/NEWS.d/next/Core and Builtins/2023-09-24-22-26-56.gh-issue-109795.gI7KW6.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2023-09-24-22-26-56.gh-issue-109795.gI7KW6.rst
@@ -1,1 +1,1 @@
-:func:`_thread.start_new_thread` now uses raw memory allocator to allocate new thread bootstate. This helps to avoid crashes in case when new thread gets started at interpreter finalization.
+:func:`!_thread.start_new_thread` now uses raw memory allocator to allocate new thread bootstate. This helps to avoid crashes in case when new thread gets started at interpreter finalization.

--- a/Misc/NEWS.d/next/Core and Builtins/2023-09-24-22-26-56.gh-issue-109795.gI7KW6.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2023-09-24-22-26-56.gh-issue-109795.gI7KW6.rst
@@ -1,1 +1,0 @@
-:func:`!_thread.start_new_thread` now uses raw memory allocator to allocate new thread bootstate. This helps to avoid crashes in case when new thread gets started at interpreter finalization.

--- a/Modules/_threadmodule.c
+++ b/Modules/_threadmodule.c
@@ -1184,10 +1184,9 @@ thread_PyThread_start_new_thread(PyObject *self, PyObject *fargs)
         return NULL;
     }
 
-    // gh-109795: Use PyMem_RawMalloc() to allocate new thread bootstate.
-    // If new thread is started at Python finalization,
-    // i.e. thread_run() routine is invoked in newly created OS thread,
-    // it should be able to free bootstate without holding the GIL.
+    // gh-109795: Use PyMem_RawMalloc() instead of PyMem_Malloc(),
+    // because it should be possible to call thread_bootstate_free()
+    // without holding the GIL.
     struct bootstate *boot = PyMem_RawMalloc(sizeof(struct bootstate));
     if (boot == NULL) {
         return PyErr_NoMemory();

--- a/Modules/_threadmodule.c
+++ b/Modules/_threadmodule.c
@@ -1184,6 +1184,10 @@ thread_PyThread_start_new_thread(PyObject *self, PyObject *fargs)
         return NULL;
     }
 
+    // gh-109795: Use PyMem_RawMalloc() to allocate new thread bootstate.
+    // If new thread is started at Python finalization,
+    // i.e. thread_run() routine is invoked in newly created OS thread,
+    // it should be able to free bootstate without holding the GIL.
     struct bootstate *boot = PyMem_RawMalloc(sizeof(struct bootstate));
     if (boot == NULL) {
         return PyErr_NoMemory();

--- a/Modules/_threadmodule.c
+++ b/Modules/_threadmodule.c
@@ -1066,7 +1066,7 @@ thread_bootstate_free(struct bootstate *boot, int decref)
         Py_DECREF(boot->args);
         Py_XDECREF(boot->kwargs);
     }
-    PyMem_Free(boot);
+    PyMem_RawFree(boot);
 }
 
 
@@ -1184,13 +1184,13 @@ thread_PyThread_start_new_thread(PyObject *self, PyObject *fargs)
         return NULL;
     }
 
-    struct bootstate *boot = PyMem_NEW(struct bootstate, 1);
+    struct bootstate *boot = PyMem_RawMalloc(sizeof(struct bootstate));
     if (boot == NULL) {
         return PyErr_NoMemory();
     }
     boot->tstate = _PyThreadState_New(interp);
     if (boot->tstate == NULL) {
-        PyMem_Free(boot);
+        PyMem_RawFree(boot);
         if (!PyErr_Occurred()) {
             return PyErr_NoMemory();
         }


### PR DESCRIPTION
Fixes #109795

When new thread is starting, but Python is finalizing, `PyMem_Free` can't be called on new thread `bootstate`, because this thread doesn't own the GIL. We should use raw memory allocator to allocate/free `bootstate` to avoid crashes/other unexpected behaviour.

<!-- gh-issue-number: gh-109795 -->
* Issue: gh-109795
<!-- /gh-issue-number -->
