### PR TITLE
gh-101100: Fix sphinx warnings in `Doc/library/__future__.rst`

### DIFF
--- a/Doc/library/__future__.rst
+++ b/Doc/library/__future__.rst
@@ -110,6 +110,7 @@ language using this mechanism:
    `announcement for Python 3.11 <https://mail.python.org/archives/list/python-dev@python.org/message/VIZEBX5EYMSYIJNDBF6DMUMZOCWHARSO/>`__).
    No final decision has been made yet. See also :pep:`563` and :pep:`649`.
 
+
 .. seealso::
 
    :ref:`future`

--- a/Doc/library/__future__.rst
+++ b/Doc/library/__future__.rst
@@ -22,42 +22,48 @@
   can be inspected programmatically via importing :mod:`__future__` and examining
   its contents.
 
-Each statement in :file:`__future__.py` is of the form::
+.. _future-classes:
 
-   FeatureName = _Feature(OptionalRelease, MandatoryRelease,
-                          CompilerFlag)
+.. class:: _Feature
 
+   Each statement in :file:`__future__.py` is of the form::
 
-where, normally, *OptionalRelease* is less than *MandatoryRelease*, and both are
-5-tuples of the same form as :data:`sys.version_info`::
+      FeatureName = _Feature(OptionalRelease, MandatoryRelease,
+                             CompilerFlag)
 
-   (PY_MAJOR_VERSION, # the 2 in 2.1.0a3; an int
-    PY_MINOR_VERSION, # the 1; an int
-    PY_MICRO_VERSION, # the 0; an int
-    PY_RELEASE_LEVEL, # "alpha", "beta", "candidate" or "final"; string
-    PY_RELEASE_SERIAL # the 3; an int
-   )
+   where, normally, *OptionalRelease* is less than *MandatoryRelease*, and both are
+   5-tuples of the same form as :data:`sys.version_info`::
 
-*OptionalRelease* records the first release in which the feature was accepted.
+      (PY_MAJOR_VERSION, # the 2 in 2.1.0a3; an int
+       PY_MINOR_VERSION, # the 1; an int
+       PY_MICRO_VERSION, # the 0; an int
+       PY_RELEASE_LEVEL, # "alpha", "beta", "candidate" or "final"; string
+       PY_RELEASE_SERIAL # the 3; an int
+      )
 
-In the case of a *MandatoryRelease* that has not yet occurred,
-*MandatoryRelease* predicts the release in which the feature will become part of
-the language.
+.. method:: _Feature.getOptionalRelease()
 
-Else *MandatoryRelease* records when the feature became part of the language; in
-releases at or after that, modules no longer need a future statement to use the
-feature in question, but may continue to use such imports.
+   *OptionalRelease* records the first release in which the feature was accepted.
 
-*MandatoryRelease* may also be ``None``, meaning that a planned feature got
-dropped.
+.. method:: _Feature.getMandatoryRelease()
 
-Instances of class :class:`_Feature` have two corresponding methods,
-:meth:`getOptionalRelease` and :meth:`getMandatoryRelease`.
+   In the case of a *MandatoryRelease* that has not yet occurred,
+   *MandatoryRelease* predicts the release in which the feature will become part of
+   the language.
 
-*CompilerFlag* is the (bitfield) flag that should be passed in the fourth
-argument to the built-in function :func:`compile` to enable the feature in
-dynamically compiled code.  This flag is stored in the :attr:`compiler_flag`
-attribute on :class:`_Feature` instances.
+   Else *MandatoryRelease* records when the feature became part of the language; in
+   releases at or after that, modules no longer need a future statement to use the
+   feature in question, but may continue to use such imports.
+
+   *MandatoryRelease* may also be ``None``, meaning that a planned feature got
+   dropped or that it is not yet decided.
+
+.. attribute:: _Feature.compiler_flag
+
+   *CompilerFlag* is the (bitfield) flag that should be passed in the fourth
+   argument to the built-in function :func:`compile` to enable the feature in
+   dynamically compiled code.  This flag is stored in the :attr:`_Feature.compiler_flag`
+   attribute on :class:`_Feature` instances.
 
 No feature description will ever be deleted from :mod:`__future__`. Since its
 introduction in Python 2.1 the following features have found their way into the
@@ -103,7 +109,6 @@ language using this mechanism:
    (`announcement for Python 3.10 <https://mail.python.org/archives/list/python-dev@python.org/message/CLVXXPQ2T2LQ5MP2Y53VVQFCXYWQJHKZ/>`__;
    `announcement for Python 3.11 <https://mail.python.org/archives/list/python-dev@python.org/message/VIZEBX5EYMSYIJNDBF6DMUMZOCWHARSO/>`__).
    No final decision has been made yet. See also :pep:`563` and :pep:`649`.
-
 
 .. seealso::
 

--- a/Doc/tools/.nitignore
+++ b/Doc/tools/.nitignore
@@ -28,7 +28,6 @@ Doc/howto/enum.rst
 Doc/howto/isolating-extensions.rst
 Doc/howto/logging.rst
 Doc/howto/urllib2.rst
-Doc/library/__future__.rst
 Doc/library/abc.rst
 Doc/library/ast.rst
 Doc/library/asyncio-dev.rst


### PR DESCRIPTION
Before:

```
/Users/sobolev/Desktop/cpython/Doc/library/__future__.rst:54: WARNING: py:class reference target not found: _Feature
/Users/sobolev/Desktop/cpython/Doc/library/__future__.rst:54: WARNING: py:meth reference target not found: getOptionalRelease
/Users/sobolev/Desktop/cpython/Doc/library/__future__.rst:54: WARNING: py:meth reference target not found: getMandatoryRelease
/Users/sobolev/Desktop/cpython/Doc/library/__future__.rst:57: WARNING: py:attr reference target not found: compiler_flag
/Users/sobolev/Desktop/cpython/Doc/library/__future__.rst:57: WARNING: py:class reference target not found: _Feature
```

Changes:
1. I documented `_Feature` class and its members and added sphinx markup, because they were already documented but without the proper markup

<img width="883" alt="Снимок экрана 2023-09-25 в 09 12 59" src="https://github.com/python/cpython/assets/4660275/d558848a-a716-45c0-bed4-53b4ff9d2747">

This is now much more readable, has more metadata, and links to every part of the explanation.

2. I've also changed

> *MandatoryRelease* may also be ``None``, meaning that a planned feature got
> dropped.

to be 

> *MandatoryRelease* may also be ``None``, meaning that a planned feature got
> dropped or that it is not yet decided.

Because of the note below:
> No final decision has been made yet. See also :pep:`563` and :pep:`649`.


<!-- gh-issue-number: gh-101100 -->
* Issue: gh-101100
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--109814.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->