### PR TITLE
gh-109818: `reprlib.recursive_repr` copies `__type_params__`

### DIFF
--- a/Lib/reprlib.py
+++ b/Lib/reprlib.py
@@ -29,6 +29,7 @@ def recursive_repr(fillvalue='...'):
         wrapper.__name__ = getattr(user_function, '__name__')
         wrapper.__qualname__ = getattr(user_function, '__qualname__')
         wrapper.__annotations__ = getattr(user_function, '__annotations__', {})
+        wrapper.__type_params__ = getattr(user_function, '__type_params__', ())
         wrapper.__wrapped__ = user_function
         return wrapper
 

--- a/Lib/test/test_reprlib.py
+++ b/Lib/test/test_reprlib.py
@@ -774,5 +774,16 @@ class TestRecursiveRepr(unittest.TestCase):
 
         self.assertIs(X.f, X.__repr__.__wrapped__)
 
+    def test__type_params__(self):
+        class My:
+            @recursive_repr()
+            def __repr__[T: str](self, default: T = '') -> str:
+                return default
+
+        type_params = My().__repr__.__type_params__
+        self.assertEqual(len(type_params), 1)
+        self.assertEqual(type_params[0].__name__, 'T')
+        self.assertEqual(type_params[0].__bound__, str)
+
 if __name__ == "__main__":
     unittest.main()

--- a/Misc/NEWS.d/next/Library/2023-09-25-09-59-59.gh-issue-109818.dLRtT-.rst
+++ b/Misc/NEWS.d/next/Library/2023-09-25-09-59-59.gh-issue-109818.dLRtT-.rst
@@ -1,2 +1,2 @@
-Fix :func:`repllib.recursive_repl` not copying ``__type_params__`` from
+Fix :func:`reprlib.recursive_repr` not copying ``__type_params__`` from
 decorated function.

--- a/Misc/NEWS.d/next/Library/2023-09-25-09-59-59.gh-issue-109818.dLRtT-.rst
+++ b/Misc/NEWS.d/next/Library/2023-09-25-09-59-59.gh-issue-109818.dLRtT-.rst
@@ -1,0 +1,2 @@
+Fix :func:`repllib.recursive_repl` not copying ``__type_params__`` from
+decorated function.


### PR DESCRIPTION


<!-- gh-issue-number: gh-109818 -->
* Issue: gh-109818
<!-- /gh-issue-number -->
