### PR TITLE
GH-109653: Defer import of ``importlib.metadata._adapters``

### DIFF
--- a/Lib/importlib/metadata/__init__.py
+++ b/Lib/importlib/metadata/__init__.py
@@ -439,6 +439,7 @@ class Distribution(DeprecatedNonAbstract):
         The returned object will have keys that name the various bits of
         metadata.  See PEP 566 for details.
         """
+        # deferred for performance (python/cpython#109829)
         from . import _adapters
 
         opt_text = (

--- a/Lib/importlib/metadata/__init__.py
+++ b/Lib/importlib/metadata/__init__.py
@@ -15,7 +15,7 @@ import posixpath
 import collections
 import inspect
 
-from . import _adapters, _meta
+from . import _meta
 from ._collections import FreezableDefaultDict, Pair
 from ._functools import method_cache, pass_none
 from ._itertools import always_iterable, unique_everseen
@@ -439,6 +439,8 @@ class Distribution(DeprecatedNonAbstract):
         The returned object will have keys that name the various bits of
         metadata.  See PEP 566 for details.
         """
+        from . import _adapters
+
         opt_text = (
             self.read_text('METADATA')
             or self.read_text('PKG-INFO')

--- a/Lib/importlib/resources/_common.py
+++ b/Lib/importlib/resources/_common.py
@@ -107,7 +107,9 @@ def from_package(package: types.ModuleType):
     Return a Traversable object for the given package.
 
     """
+    # deferred for performance (python/cpython#109829)
     from ._adapters import wrap_spec
+
     spec = wrap_spec(package)
     reader = spec.loader.get_resource_reader(spec.name)
     return reader.files()

--- a/Lib/importlib/resources/_common.py
+++ b/Lib/importlib/resources/_common.py
@@ -12,8 +12,6 @@ import itertools
 from typing import Union, Optional, cast
 from .abc import ResourceReader, Traversable
 
-from ._adapters import wrap_spec
-
 Package = Union[types.ModuleType, str]
 Anchor = Package
 
@@ -109,6 +107,7 @@ def from_package(package: types.ModuleType):
     Return a Traversable object for the given package.
 
     """
+    from ._adapters import wrap_spec
     spec = wrap_spec(package)
     reader = spec.loader.get_resource_reader(spec.name)
     return reader.files()

--- a/Misc/NEWS.d/next/Library/2024-03-20-23-07-58.gh-issue-109653.uu3lrX.rst
+++ b/Misc/NEWS.d/next/Library/2024-03-20-23-07-58.gh-issue-109653.uu3lrX.rst
@@ -1,0 +1,2 @@
+Deferred select imports in importlib.metadata and importlib.resources for a
+14% speedup.


### PR DESCRIPTION
For a ~14% speed up. However, this introduces inline imports into ``.metadata``, which might be undesirable.

A

<!-- gh-issue-number: gh-109653 -->
* Issue: gh-109653
<!-- /gh-issue-number -->
