### PR TITLE
gh-109276: regrtest re-runs "env changed" tests

### DIFF
--- a/Lib/test/test_regrtest.py
+++ b/Lib/test/test_regrtest.py
@@ -463,7 +463,7 @@ class BaseTestCase(unittest.TestCase):
             randomize = True
 
         rerun_failed = []
-        if rerun is not None:
+        if rerun is not None and not env_changed:
             failed = [rerun.name]
             if not rerun.success:
                 rerun_failed.append(rerun.name)
@@ -590,7 +590,7 @@ class BaseTestCase(unittest.TestCase):
         state = ', '.join(state)
         if rerun is not None:
             new_state = 'SUCCESS' if rerun.success else 'FAILURE'
-            state = 'FAILURE then ' + new_state
+            state = f'{state} then {new_state}'
         self.check_line(output, f'Result: {state}', full=True)
 
     def parse_random_seed(self, output):
@@ -1227,6 +1227,15 @@ class ArgsTestCase(BaseTestCase):
                                 exitcode=EXITCODE_ENV_CHANGED)
         self.check_executed_tests(output, [testname], env_changed=testname,
                                   fail_env_changed=True, stats=1)
+
+        # rerun
+        output = self.run_tests("--rerun", testname)
+        self.check_executed_tests(output, [testname],
+                                  env_changed=testname,
+                                  rerun=Rerun(testname,
+                                              match=None,
+                                              success=True),
+                                  stats=2)
 
     def test_rerun_fail(self):
         # FAILURE then FAILURE

--- a/Misc/NEWS.d/next/Tests/2023-09-25-14-41-18.gh-issue-109276.uC_cWo.rst
+++ b/Misc/NEWS.d/next/Tests/2023-09-25-14-41-18.gh-issue-109276.uC_cWo.rst
@@ -1,0 +1,3 @@
+regrtest: When a test fails with "env changed" and the --rerun option is
+used, the test is now re-run in verbose mode in a fresh process. Patch by
+Victor Stinner.


### PR DESCRIPTION
When a test fails with "env changed" and --rerun option is used, the test is now re-run in verbose mode in a fresh process.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-109276 -->
* Issue: gh-109276
<!-- /gh-issue-number -->
