### PR TITLE
gh-109833: Fix asyncio test_wait_for()

### DIFF
--- a/Lib/test/test_asyncio/test_waitfor.py
+++ b/Lib/test/test_asyncio/test_waitfor.py
@@ -1,6 +1,7 @@
 import asyncio
 import unittest
 import time
+from test import support
 
 
 def tearDownModule():
@@ -130,7 +131,7 @@ class AsyncioWaitForTest(unittest.IsolatedAsyncioTestCase):
             nonlocal foo_running
             foo_running = True
             try:
-                await asyncio.sleep(10)
+                await asyncio.sleep(support.LONG_TIMEOUT)
             finally:
                 foo_running = False
             return 'done'
@@ -144,7 +145,7 @@ class AsyncioWaitForTest(unittest.IsolatedAsyncioTestCase):
         self.assertTrue(fut.done())
         # it should have been cancelled due to the timeout
         self.assertTrue(fut.cancelled())
-        self.assertLess(t1 - t0, 0.5)
+        self.assertLess(t1 - t0, support.SHORT_TIMEOUT)
         self.assertEqual(foo_running, False)
 
     async def test_wait_for_blocking(self):


### PR DESCRIPTION
Expect the test to be "short" but don't measure the exact performance of the CI. SHORT_TIMEOUT is about 30 seconds whereas the cancelled coroutine takes around 1 hour.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-109833 -->
* Issue: gh-109833
<!-- /gh-issue-number -->
