### PR TITLE
GH-109190: Copyedit 3.12 What's New: Synchronise C API deprecations with the 3.12 branch

### DIFF
--- a/Doc/whatsnew/3.12.rst
+++ b/Doc/whatsnew/3.12.rst
@@ -2172,8 +2172,6 @@ Pending Removal in Python 3.15
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 * :c:func:`PyImport_ImportModuleNoBlock`: use :c:func:`PyImport_ImportModule`
-* :c:func:`PyWeakref_GET_OBJECT`: use :c:func:`PyWeakref_GetRef`
-* :c:func:`PyWeakref_GetObject`: use :c:func:`PyWeakref_GetRef`
 * :c:type:`!Py_UNICODE_WIDE` type: use :c:type:`wchar_t`
 * :c:type:`Py_UNICODE` type: use :c:type:`wchar_t`
 * Python initialization functions:


### PR DESCRIPTION
* Not for backporting
* xref #109830

<!-- gh-issue-number: gh-109190 -->
* Issue: gh-109190
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--109844.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->