### PR TITLE
Docs: Add `os.splice` flags argument

### DIFF
--- a/Doc/library/os.rst
+++ b/Doc/library/os.rst
@@ -1716,8 +1716,25 @@ or `the MSDN <https://msdn.microsoft.com/en-us/library/z0kc8e3z.aspx>`_ on Windo
 .. function:: splice(src, dst, count, offset_src=None, offset_dst=None, flags=0)
 
    Transfer *count* bytes from file descriptor *src*, starting from offset
-   *offset_src*, to file descriptor *dst*, starting from offset *offset_dst*,
-   which can use *flags* to modify the semantics of the call.
+   *offset_src*, to file descriptor *dst*, starting from offset *offset_dst*.
+
+   *flags* argument is a bit mask that is composed by ORing
+   together zero or more of the following: :const:`SPLICE_F_MOVE`,
+   :const:`SPLICE_F_NONBLOCK`, and :const:`SPLICE_F_MORE`.
+
+   If :const:`SPLICE_F_MOVE` is specified it hints the kernel
+   to move pages instead of copying, but pages may still be copied if the
+   kernel cannot move the pages from the pipe.
+
+   If :const:`SPLICE_F_NONBLOCK` is specified it hints the kernel
+   to not block on I/O.  This makes the splice pipe
+   operations nonblocking, but splice may nevertheless
+   block because the file descriptors that are spliced
+   to/from may block.
+
+   If :const:`SPLICE_F_MORE` is specified it hints the kernel
+   that more data will be coming in a subsequent splice.
+
    At least one of the file descriptors must refer to a pipe. If *offset_src*
    is ``None``, then *src* is read from the current position; respectively for
    *offset_dst*. The offset associated to the file descriptor that refers to a
@@ -1735,6 +1752,8 @@ or `the MSDN <https://msdn.microsoft.com/en-us/library/z0kc8e3z.aspx>`_ on Windo
    pipe, then this means that there was no data to transfer, and it would not
    make sense to block because there are no writers connected to the write end
    of the pipe.
+
+   See man page :manpage:`splice(2)` for more information.
 
    .. availability:: Linux >= 2.6.17 with glibc >= 2.5
 

--- a/Doc/library/os.rst
+++ b/Doc/library/os.rst
@@ -1713,10 +1713,11 @@ or `the MSDN <https://msdn.microsoft.com/en-us/library/z0kc8e3z.aspx>`_ on Windo
       Added support for pipes on Windows.
 
 
-.. function:: splice(src, dst, count, offset_src=None, offset_dst=None)
+.. function:: splice(src, dst, count, offset_src=None, offset_dst=None, flags=0)
 
    Transfer *count* bytes from file descriptor *src*, starting from offset
-   *offset_src*, to file descriptor *dst*, starting from offset *offset_dst*.
+   *offset_src*, to file descriptor *dst*, starting from offset *offset_dst*,
+   which can use *flags* to modify the semantics of the call.
    At least one of the file descriptors must refer to a pipe. If *offset_src*
    is ``None``, then *src* is read from the current position; respectively for
    *offset_dst*. The offset associated to the file descriptor that refers to a

--- a/Doc/library/os.rst
+++ b/Doc/library/os.rst
@@ -1752,7 +1752,7 @@ or `the MSDN <https://msdn.microsoft.com/en-us/library/z0kc8e3z.aspx>`_ on Windo
    make sense to block because there are no writers connected to the write end
    of the pipe.
 
-   ..seealso:: The :manpage:`splice(2)` man page.
+   .. seealso:: The :manpage:`splice(2)` man page.
 
    .. availability:: Linux >= 2.6.17 with glibc >= 2.5
 

--- a/Doc/library/os.rst
+++ b/Doc/library/os.rst
@@ -1718,9 +1718,9 @@ or `the MSDN <https://msdn.microsoft.com/en-us/library/z0kc8e3z.aspx>`_ on Windo
    Transfer *count* bytes from file descriptor *src*, starting from offset
    *offset_src*, to file descriptor *dst*, starting from offset *offset_dst*.
 
-   *flags* argument is a bit mask that is composed by ORing
-   together zero or more of the following: :const:`SPLICE_F_MOVE`,
-   :const:`SPLICE_F_NONBLOCK`, and :const:`SPLICE_F_MORE`.
+   The splicing behaviour can be modified by specifying a *flags* value.
+   Any of the following variables may used, combined using bitwise OR
+   (the ``|`` operator):
 
    * If :const:`SPLICE_F_MOVE` is specified,
      the kernel is asked to move pages instead of copying,

--- a/Doc/library/os.rst
+++ b/Doc/library/os.rst
@@ -1722,18 +1722,17 @@ or `the MSDN <https://msdn.microsoft.com/en-us/library/z0kc8e3z.aspx>`_ on Windo
    together zero or more of the following: :const:`SPLICE_F_MOVE`,
    :const:`SPLICE_F_NONBLOCK`, and :const:`SPLICE_F_MORE`.
 
-   If :const:`SPLICE_F_MOVE` is specified it hints the kernel
-   to move pages instead of copying, but pages may still be copied if the
-   kernel cannot move the pages from the pipe.
+   * If :const:`SPLICE_F_MOVE` is specified,
+     the kernel is asked to move pages instead of copying,
+     but pages may still be copied if the kernel cannot move the pages from the pipe.
 
-   If :const:`SPLICE_F_NONBLOCK` is specified it hints the kernel
-   to not block on I/O.  This makes the splice pipe
-   operations nonblocking, but splice may nevertheless
-   block because the file descriptors that are spliced
-   to/from may block.
+   * If :const:`SPLICE_F_NONBLOCK` is specified,
+     the kernel is asked to not block on I/O.
+     This makes the splice pipe operations nonblocking,
+     but splice may nevertheless block because the spliced file descriptors may block.
 
-   If :const:`SPLICE_F_MORE` is specified it hints the kernel
-   that more data will be coming in a subsequent splice.
+   * If :const:`SPLICE_F_MORE` is specified,
+     it hints to the kernel that more data will be coming in a subsequent splice.
 
    At least one of the file descriptors must refer to a pipe. If *offset_src*
    is ``None``, then *src* is read from the current position; respectively for

--- a/Doc/library/os.rst
+++ b/Doc/library/os.rst
@@ -1753,7 +1753,7 @@ or `the MSDN <https://msdn.microsoft.com/en-us/library/z0kc8e3z.aspx>`_ on Windo
    make sense to block because there are no writers connected to the write end
    of the pipe.
 
-   See man page :manpage:`splice(2)` for more information.
+   ..seealso:: The :manpage:`splice(2)` man page.
 
    .. availability:: Linux >= 2.6.17 with glibc >= 2.5
 


### PR DESCRIPTION
The docs for `os.splice` misses the `flags` argument but it is documented in `posixmodule.c`:

https://github.com/python/cpython/blob/64ab9f7d5c7cbe5ef997c7d841151e0e71e7f582/Modules/posixmodule.c#L11565-L11566

Ref: https://github.com/python/typeshed/pull/10771

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--109847.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->