### PR TITLE
gh-109631: Allow interruption of short repeated regex matches

### DIFF
--- a/Misc/NEWS.d/next/Library/2023-09-25-23-00-37.gh-issue-109631.eWSqpO.rst
+++ b/Misc/NEWS.d/next/Library/2023-09-25-23-00-37.gh-issue-109631.eWSqpO.rst
@@ -1,0 +1,3 @@
+:mod:`re` functions such as :func:`re.findall`, :func:`re.split`,
+:func:`re.search` and :func:`re.sub` which perform short repeated matches
+can now be interrupted by user.

--- a/Modules/_sre/sre.h
+++ b/Modules/_sre/sre.h
@@ -95,6 +95,7 @@ typedef struct {
     size_t data_stack_base;
     /* current repeat context */
     SRE_REPEAT *repeat;
+    unsigned int sigcount;
 } SRE_STATE;
 
 typedef struct {

--- a/Modules/_sre/sre_lib.h
+++ b/Modules/_sre/sre_lib.h
@@ -564,7 +564,7 @@ SRE(match)(SRE_STATE* state, const SRE_CODE* pattern, int toplevel)
     Py_ssize_t alloc_pos, ctx_pos = -1;
     Py_ssize_t ret = 0;
     int jump;
-    unsigned int sigcount=0;
+    unsigned int sigcount = state->sigcount;
 
     SRE(match_context)* ctx;
     SRE(match_context)* nextctx;
@@ -1567,8 +1567,10 @@ exit:
     ctx_pos = ctx->last_ctx_pos;
     jump = ctx->jump;
     DATA_POP_DISCARD(ctx);
-    if (ctx_pos == -1)
+    if (ctx_pos == -1) {
+        state->sigcount = sigcount;
         return ret;
+    }
     DATA_LOOKUP_AT(SRE(match_context), ctx, ctx_pos);
 
     switch (jump) {


### PR DESCRIPTION
Counting for signal checking now continues in new match from the point where it ended in the previous match instead of starting from 0.


<!-- gh-issue-number: gh-109631 -->
* Issue: gh-109631
<!-- /gh-issue-number -->
