### PR TITLE
gh-109868: Skip deepcopy memo check for empty memo

### DIFF
--- a/Lib/copy.py
+++ b/Lib/copy.py
@@ -121,13 +121,13 @@ def deepcopy(x, memo=None, _nil=[]):
     See the module's __doc__ string for more info.
     """
 
+    d = id(x)
     if memo is None:
         memo = {}
-
-    d = id(x)
-    y = memo.get(d, _nil)
-    if y is not _nil:
-        return y
+    else:
+        y = memo.get(d, _nil)
+        if y is not _nil:
+            return y
 
     cls = type(x)
 


### PR DESCRIPTION
In the `copy.deepcopy` method we can skip the initial memo check if the memo was just created.

Benchmark:
```
from copy import deepcopy
obj={'simple': 'dict'}
%timeit deepcopy(obj)
```
```
main: 1.91 µs ± 1.38 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)
pr: 1.82 µs ± 8.18 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)
```

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-109868 -->
* Issue: gh-109868
<!-- /gh-issue-number -->
