### PR TITLE
gh-109739: regrtest disables load tracker if refleak

### DIFF
--- a/Misc/NEWS.d/next/Tests/2023-09-25-23-59-37.gh-issue-109739.MUn7K5.rst
+++ b/Misc/NEWS.d/next/Tests/2023-09-25-23-59-37.gh-issue-109739.MUn7K5.rst
@@ -1,0 +1,3 @@
+regrtest: Fix reference leak check on Windows. Disable the load tracker on
+Windows in the reference leak check mode (-R option). Patch by Victor
+Stinner.


### PR DESCRIPTION
Disable the Windwos load tracker when hunting reference leak.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-109739 -->
* Issue: gh-109739
<!-- /gh-issue-number -->
