### PR TITLE
gh-109748: Fix venv test_zippath_from_non_installed_posix()

### DIFF
--- a/Lib/test/test_venv.py
+++ b/Lib/test/test_venv.py
@@ -559,6 +559,13 @@ class BasicTest(BaseTest):
                                     platlibdir,
                                     stdlib_zip)
         additional_pythonpath_for_non_installed = []
+
+        # gh-109748: Don't copy __pycache__/ sub-directories, because they can
+        # be modified by other Python tests running in parallel.
+        ignored_names = {'__pycache__'}
+        def ignore_pycache(src, names):
+            return ignored_names
+
         # Copy stdlib files to the non-installed python so venv can
         # correctly calculate the prefix.
         for eachpath in sys.path:
@@ -575,7 +582,8 @@ class BasicTest(BaseTest):
                     if os.path.isfile(fn):
                         shutil.copy(fn, libdir)
                     elif os.path.isdir(fn):
-                        shutil.copytree(fn, os.path.join(libdir, name))
+                        shutil.copytree(fn, os.path.join(libdir, name),
+                                        ignore=ignore_pycache)
             else:
                 additional_pythonpath_for_non_installed.append(
                     eachpath)

--- a/Misc/NEWS.d/next/Tests/2023-09-26-00-49-18.gh-issue-109748.nxlT1i.rst
+++ b/Misc/NEWS.d/next/Tests/2023-09-26-00-49-18.gh-issue-109748.nxlT1i.rst
@@ -1,0 +1,3 @@
+Fix ``test_zippath_from_non_installed_posix()`` of test_venv: don't copy
+``__pycache__/`` sub-directories, because they can be modified by other Python
+tests running in parallel. Patch by Victor Stinner.


### PR DESCRIPTION
Fix test_zippath_from_non_installed_posix() of test_venv: don't copy __pycache__/ directories because they can be modified by other Python tests running in parallel.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-109748 -->
* Issue: gh-109748
<!-- /gh-issue-number -->
