### PR TITLE
gh-109401: Fix threading barrier test_default_timeout()

### DIFF
--- a/Lib/test/lock_tests.py
+++ b/Lib/test/lock_tests.py
@@ -1014,13 +1014,15 @@ class BarrierTests(BaseTestCase):
         """
         Test the barrier's default timeout
         """
-        # create a barrier with a low default timeout
-        barrier = self.barriertype(self.N, timeout=0.3)
+        # gh-109401: Barrier timeout should be long enough
+        # to create 4 threads on a slow CI.
+        timeout = 1.0
+        barrier = self.barriertype(self.N, timeout=timeout)
         def f():
             i = barrier.wait()
             if i == self.N // 2:
-                # One thread is later than the default timeout of 0.3s.
-                time.sleep(1.0)
+                # One thread is later than the default timeout.
+                time.sleep(timeout * 2)
             self.assertRaises(threading.BrokenBarrierError, barrier.wait)
         self.run_threads(f)
 


### PR DESCRIPTION
Increase timeouts. Barrier default timeout should be long enough to spawn 4 threads on a slow CI.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-109401 -->
* Issue: gh-109401
<!-- /gh-issue-number -->
