### PR TITLE
GH-72904: Simplify implementation of `fnmatch.translate()`

### DIFF
--- a/Lib/test/test_fnmatch.py
+++ b/Lib/test/test_fnmatch.py
@@ -225,7 +225,7 @@ class TranslateTestCase(unittest.TestCase):
         self.assertEqual(translate('?'), r'(?s:.)\Z')
         self.assertEqual(translate('a?b*'), r'(?s:a.b.*)\Z')
         self.assertEqual(translate('[abc]'), r'(?s:[abc])\Z')
-        self.assertEqual(translate('[]]'), r'(?s:[]])\Z')
+        self.assertEqual(translate('[]]'), r'(?s:[\]])\Z')
         self.assertEqual(translate('[!x]'), r'(?s:[^x])\Z')
         self.assertEqual(translate('[^x]'), r'(?s:[\^x])\Z')
         self.assertEqual(translate('[x'), r'(?s:\[x)\Z')
@@ -235,7 +235,7 @@ class TranslateTestCase(unittest.TestCase):
         self.assertEqual(translate('*********'), r'(?s:.*)\Z')
         self.assertEqual(translate('A*********'), r'(?s:A.*)\Z')
         self.assertEqual(translate('*********A'), r'(?s:.*A)\Z')
-        self.assertEqual(translate('A*********?[?]?'), r'(?s:A.*.[?].)\Z')
+        self.assertEqual(translate('A*********?[?]?'), r'(?s:A.*.[\?].)\Z')
         # fancy translation to prevent exponential-time match failure
         t = translate('**a*a****a')
         self.assertEqual(t, r'(?s:(?>.*?a)(?>.*?a).*a)\Z')


### PR DESCRIPTION
Use `re` to scan shell-style patterns, rather than parsing them by hand in a fat loop. This makes the code twice as slow (!) but arguably more obvious


<!-- gh-issue-number: gh-72904 -->
* Issue: gh-72904
<!-- /gh-issue-number -->
