### PR TITLE
gh-109832: concurrent.futures test_deadlock restores sys.stderr

### DIFF
--- a/Lib/test/test_concurrent_futures/test_deadlock.py
+++ b/Lib/test/test_concurrent_futures/test_deadlock.py
@@ -145,6 +145,9 @@ class ExecutorDeadlockTest:
         self._check_crash(BrokenProcessPool, id, ExitAtUnpickle())
 
     def test_error_at_task_unpickle(self):
+        # gh-109832: Restore stderr overriden by _raise_error_ignore_stderr()
+        self.addCleanup(setattr, sys, 'stderr', sys.stderr)
+
         # Check problem occurring while unpickling a task on workers
         self._check_crash(BrokenProcessPool, id, ErrorAtUnpickle())
 
@@ -180,6 +183,9 @@ class ExecutorDeadlockTest:
         self._check_crash(PicklingError, _return_instance, ErrorAtPickle)
 
     def test_error_during_result_unpickle_in_result_handler(self):
+        # gh-109832: Restore stderr overriden by _raise_error_ignore_stderr()
+        self.addCleanup(setattr, sys, 'stderr', sys.stderr)
+
         # Check problem occurring while unpickling a task in
         # the result_handler thread
         self._check_crash(BrokenProcessPool,


### PR DESCRIPTION
test_error_at_task_unpickle() and
test_error_during_result_unpickle_in_result_handler() now restore sys.stderr which is overriden by _raise_error_ignore_stderr().

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-109832 -->
* Issue: gh-109832
<!-- /gh-issue-number -->
