### PR TITLE
[3.12] gh-109889: comment out assertion indicating a failed optimization of a redundant NOP

### DIFF
--- a/Python/flowgraph.c
+++ b/Python/flowgraph.c
@@ -1595,7 +1595,11 @@ optimize_cfg(cfg_builder *g, PyObject *consts, PyObject *const_cache)
         remove_redundant_nops(b);
     }
     eliminate_empty_basic_blocks(g);
-    assert(no_redundant_nops(g));
+    /* This assertion fails in an edge case (See gh-109889).
+     * Remove it for the release (it's just one more NOP in the
+     * bytecode for unlikely code).
+     */
+    // assert(no_redundant_nops(g));
     RETURN_IF_ERROR(remove_redundant_jumps(g));
     return SUCCESS;
 }

--- a/Python/flowgraph.c
+++ b/Python/flowgraph.c
@@ -366,6 +366,7 @@ _PyCfgBuilder_Addop(cfg_builder *g, int opcode, int oparg, location loc)
 #ifndef NDEBUG
 static int remove_redundant_nops(basicblock *bb);
 
+/*
 static bool
 no_redundant_nops(cfg_builder *g) {
     for (basicblock *b = g->g_entryblock; b != NULL; b = b->b_next) {
@@ -375,6 +376,7 @@ no_redundant_nops(cfg_builder *g) {
     }
     return true;
 }
+*/
 
 static bool
 no_empty_basic_blocks(cfg_builder *g) {


### PR DESCRIPTION

There is an optimization in the compiler where it removes redundant NOPs, and this assertion checks that it doesn't miss any. 

Through fuzzing, it was found that in the case where there is a basic block with just a single instruction which is a redundant NOP, the NOP is not being removed (see #109889). 

This close to the 3.12.0 release, I am proposing to comment out the assertion. There is no correctness issue here (just an extra NOP in some unlikely code).

I will work on a proper fix for the optimization for 3.13 and 3.12.1.



<!-- gh-issue-number: gh-109889 -->
* Issue: gh-109889
<!-- /gh-issue-number -->
