### PR TITLE
gh-109276, gh-109508: Fix libregrtest stdout

### DIFF
--- a/Doc/using/configure.rst
+++ b/Doc/using/configure.rst
@@ -965,7 +965,7 @@ Main Makefile targets
   this the default target of the ``make`` command (``make all`` or just
   ``make``).
 
-* ``make test``: Build Python and run the Python test suite with ``--slow-ci``
+* ``make test``: Build Python and run the Python test suite with ``--fast-ci``
   option. Variables:
 
   * ``TESTOPTS``: additional regrtest command line options.

--- a/Lib/test/libregrtest/main.py
+++ b/Lib/test/libregrtest/main.py
@@ -513,9 +513,11 @@ class Regrtest:
             print_warning(f"Failed to reexecute Python: {exc!r}\n"
                           f"Command: {cmd_text}")
 
-    def main(self, tests: TestList | None = None):
-        if self.want_reexec and self.ci_mode:
-            self._reexecute_python()
+    def _init(self):
+        # Set sys.stdout encoder error handler to backslashreplace,
+        # similar to sys.stderr error handler, to avoid UnicodeEncodeError
+        # when printing a traceback or any other non-encodable character.
+        sys.stdout.reconfigure(errors="backslashreplace")
 
         if self.junit_filename and not os.path.isabs(self.junit_filename):
             self.junit_filename = os.path.abspath(self.junit_filename)
@@ -523,6 +525,12 @@ class Regrtest:
         strip_py_suffix(self.cmdline_args)
 
         self.tmp_dir = get_temp_dir(self.tmp_dir)
+
+    def main(self, tests: TestList | None = None):
+        if self.want_reexec and self.ci_mode:
+            self._reexecute_python()
+
+        self._init()
 
         if self.want_cleanup:
             cleanup_temp_dir(self.tmp_dir)

--- a/Lib/test/libregrtest/setup.py
+++ b/Lib/test/libregrtest/setup.py
@@ -11,7 +11,7 @@ from test.support.os_helper import TESTFN_UNDECODABLE, FS_NONASCII
 from .runtests import RunTests
 from .utils import (
     setup_unraisable_hook, setup_threading_excepthook, fix_umask,
-    replace_stdout, adjust_rlimit_nofile)
+    adjust_rlimit_nofile)
 
 
 UNICODE_GUARD_ENV = "PYTHONREGRTEST_UNICODE_GUARD"
@@ -49,7 +49,7 @@ def setup_process():
             faulthandler.register(signum, chain=True, file=stderr_fd)
 
     adjust_rlimit_nofile()
-    replace_stdout()
+
     support.record_original_stdout(sys.stdout)
 
     # Some times __path__ and __file__ are not absolute (e.g. while running from


### PR DESCRIPTION
Remove replace_stdout(): call sys.stdout.reconfigure() instead of set the error handler to backslashreplace.

display_header() logs an empty line and flush stdout.

Remove encoding workaround in display_header() since stdout error handler is now set to backslashreplace earlier.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-109276 -->
* Issue: gh-109276
<!-- /gh-issue-number -->
