### PR TITLE
gh-104638: make `TarFile.extraction_filter` future release references more clear

### DIFF
--- a/Doc/library/tarfile.rst
+++ b/Doc/library/tarfile.rst
@@ -557,7 +557,7 @@ be finalized; only the internally used file object will be closed. See the
    and fall back to the :func:`fully_trusted <fully_trusted_filter>` filter,
    whose dangerous behavior matches previous versions of Python.
 
-   In Python 3.14+, leaving ``extraction_filter=None`` will cause
+   In Python 3.14, leaving ``extraction_filter=None`` will cause
    extraction methods to use the :func:`data <data_filter>` filter by default.
 
    The attribute may be set on instances or overridden in subclasses.


### PR DESCRIPTION
Documentation for `TarFile.extraction_filter` future releases are referenced as "In python 3.14+ ..." which may be confusing thus plus symbol is removed.


<!-- gh-issue-number: gh-104638 -->
* Issue: gh-104638
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--109908.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->