### PR TITLE
gh-109955 : Update state transition comments for asyncio.Task

### DIFF
--- a/Lib/asyncio/tasks.py
+++ b/Lib/asyncio/tasks.py
@@ -78,15 +78,19 @@ class Task(futures._PyFuture):  # Inherit Python Task implementation
     #
     # - 1 (_fut_waiter is not None and not _fut_waiter.done());
     #   __step() is *not* scheduled and the Task is waiting for _fut_waiter.
-    # - 2 (_fut_waiter is None or _fut_waiter.done()), and __step() is scheduled;
+    # - 2a (_fut_waiter is None or _fut_waiter.done()), and __wakeup() is scheduled;
+    #   the Task is waiting for __wakeup() to be executed.
+    # - 2b (_fut_waiter is None or _fut_waiter.done()), and __step() is scheduled;
     #   the Task is waiting for __step() to be executed.
     # - 3 _fut_waiter is None and __step() is *not* scheduled;
     #   the Task is currently executing (in __step()).
     #
-    # The only transition from 1 to 2 is through __wakeup().  __wakeup()
-    # leaves _fut_waiter in place.
+    # The transition from 1 to 2a happens when _fut_waiter becomes done(),
+    # as it schedules __wakeup() to be called.
+    # The transition from 2a to 2b happens when __wakeup() is executed,
+    # scheduling __step() to be called, leaving _fut_waiter in place.
     # In state 1, one of the callbacks of __fut_waiter must be __wakeup().
-    # It transitions from 2 to 3 when __step() is executed, and it clears
+    # It transitions from 2b to 3 when __step() is executed, and it clears
     # _fut_waiter to None.
 
     # If False, don't log a message if the task is destroyed while its

--- a/Lib/asyncio/tasks.py
+++ b/Lib/asyncio/tasks.py
@@ -73,25 +73,23 @@ class Task(futures._PyFuture):  # Inherit Python Task implementation
     """A coroutine wrapped in a Future."""
 
     # An important invariant maintained while a Task not done:
-    # _fut_waiter is either None or a Future.  The task can be
-    # in any of 3 states:
+    # _fut_waiter is either None or a Future.  The Future
+    # can be either done() or not done().
+    # The task can be in any of 3 states:
     #
-    # - 1:  _fut_waiter is not None and not _fut_waiter.done()):
-    #       __step() is *not* scheduled and the Task is waiting for _fut_waiter.
-    # - 2a: _fut_waiter is None or _fut_waiter.done()) and __wakeup() is scheduled:
-    #       the Task is waiting for __wakeup() to be executed.
-    # - 2b: _fut_waiter is None or _fut_waiter.done()) and __step() is scheduled
+    # - 1: _fut_waiter is not None and not _fut_waiter.done():
+    #      __step() is *not* scheduled and the Task is waiting for _fut_waiter.
+    # - 2: (_fut_waiter is None or _fut_waiter.done()) and __step() is scheduled:
     #       the Task is waiting for __step() to be executed.
     # - 3:  _fut_waiter is None and __step() is *not* scheduled:
     #       the Task is currently executing (in __step()).
     #
-    # The transition from 1 to 2a happens when _fut_waiter becomes done(),
-    # as it schedules __wakeup() to be called.
-    # The transition from 2a to 2b happens when __wakeup() is executed,
-    # scheduling __step() to be called, leaving _fut_waiter in place.
-    # In state 1, one of the callbacks of __fut_waiter must be __wakeup().
-    # It transitions from 2b to 3 when __step() is executed, and it clears
-    # _fut_waiter to None.
+    # * In state 1, one of the callbacks of __fut_waiter must be __wakeup().
+    # * The transition from 1 to 2 happens when _fut_waiter becomes done(),
+    #   as it schedules __wakeup() to be called (which calls __step() so
+    #   we way that __step() is scheduled).
+    # * It transitions from 2 to 3 when __step() is executed, and it clears
+    #   _fut_waiter to None.
 
     # If False, don't log a message if the task is destroyed while its
     # status is still pending

--- a/Lib/asyncio/tasks.py
+++ b/Lib/asyncio/tasks.py
@@ -73,15 +73,23 @@ class Task(futures._PyFuture):  # Inherit Python Task implementation
     """A coroutine wrapped in a Future."""
 
     # An important invariant maintained while a Task not done:
+    # _fut_waiter is either None or a Future.  The task can be
+    # in any of 3 states:
     #
-    # - Either _fut_waiter is None, and _step() is scheduled;
-    # - or _fut_waiter is some Future, and _step() is *not* scheduled.
+    # - 1 (_fut_waiter is not None and not _fut_waiter.done());
+    #   __step() is *not* scheduled and the Task is waiting for _fut_waiter.
+    # - 2 (_fut_waiter is None or _fut_waiter.done()), and __step() is scheduled;
+    #   the Task is waiting for __step() to be executed.
+    # - 3 _fut_waiter is None and __step() is *not* scheduled;
+    #   the Task is currently executing (in __step()).
     #
-    # The only transition from the latter to the former is through
-    # _wakeup().  When _fut_waiter is not None, one of its callbacks
-    # must be _wakeup().
+    # The only transition from 1 to 2 is through __wakeup().  __wakeup()
+    # leaves _fut_waiter in place.
+    # In state 1, one of the callbacks of __fut_waiter must be __wakeup().
+    # It transitions from 2 to 3 when __step() is executed, and it clears
+    # _fut_waiter to None.
 
-    # If False, don't log a message if the task is destroyed whereas its
+    # If False, don't log a message if the task is destroyed while its
     # status is still pending
     _log_destroy_pending = True
 

--- a/Lib/asyncio/tasks.py
+++ b/Lib/asyncio/tasks.py
@@ -76,14 +76,14 @@ class Task(futures._PyFuture):  # Inherit Python Task implementation
     # _fut_waiter is either None or a Future.  The task can be
     # in any of 3 states:
     #
-    # - 1 (_fut_waiter is not None and not _fut_waiter.done());
-    #   __step() is *not* scheduled and the Task is waiting for _fut_waiter.
-    # - 2a (_fut_waiter is None or _fut_waiter.done()), and __wakeup() is scheduled;
-    #   the Task is waiting for __wakeup() to be executed.
-    # - 2b (_fut_waiter is None or _fut_waiter.done()), and __step() is scheduled;
-    #   the Task is waiting for __step() to be executed.
-    # - 3 _fut_waiter is None and __step() is *not* scheduled;
-    #   the Task is currently executing (in __step()).
+    # - 1:  _fut_waiter is not None and not _fut_waiter.done()):
+    #       __step() is *not* scheduled and the Task is waiting for _fut_waiter.
+    # - 2a: _fut_waiter is None or _fut_waiter.done()) and __wakeup() is scheduled:
+    #       the Task is waiting for __wakeup() to be executed.
+    # - 2b: _fut_waiter is None or _fut_waiter.done()) and __step() is scheduled
+    #       the Task is waiting for __step() to be executed.
+    # - 3:  _fut_waiter is None and __step() is *not* scheduled:
+    #       the Task is currently executing (in __step()).
     #
     # The transition from 1 to 2a happens when _fut_waiter becomes done(),
     # as it schedules __wakeup() to be called.


### PR DESCRIPTION
The in-line comments for the state transition of asyncio.Task objects has been out of date
for quite some time.
- `_fut_waiter` persist in a _done_ state on the Task between becoming _done_ and until `__step()` is executed.
- There is an intermediate state **2a** where `__wakeup()` is _scheduled_, followed by **2b** when `__step()` is scheduled.
- An unmentioned state exists for the Task, namely the _running_ state.
- `_step()` and `_wakeup()` have been `__step()` and `__wakeup()` for quite some time.

This PR attempts to rectify the situation.

<!-- gh-issue-number: gh-109955 -->
* Issue: gh-109955
<!-- /gh-issue-number -->
