### PR TITLE
gh-109566: Fix regrtest code adding Python options

### DIFF
--- a/Lib/test/__main__.py
+++ b/Lib/test/__main__.py
@@ -1,2 +1,2 @@
 from test.libregrtest.main import main
-main(reexec=True)
+main(_add_python_opts=True)

--- a/Lib/test/libregrtest/cmdline.py
+++ b/Lib/test/libregrtest/cmdline.py
@@ -184,7 +184,7 @@ class Namespace(argparse.Namespace):
         self.threshold = None
         self.fail_rerun = False
         self.tempdir = None
-        self.no_reexec = False
+        self._add_python_opts = True
 
         super().__init__(**kwargs)
 
@@ -344,7 +344,8 @@ def _create_parser():
                        help='override the working directory for the test run')
     group.add_argument('--cleanup', action='store_true',
                        help='remove old test_python_* directories')
-    group.add_argument('--no-reexec', action='store_true',
+    group.add_argument('--dont-add-python-opts', dest='_add_python_opts',
+                       action='store_false',
                        help="internal option, don't use it")
     return parser
 
@@ -425,7 +426,7 @@ def _parse_args(args, **kwargs):
         if MS_WINDOWS:
             ns.nowindows = True  # Silence alerts under Windows
     else:
-        ns.no_reexec = True
+        ns._add_python_opts = False
 
     # When both --slow-ci and --fast-ci options are present,
     # --slow-ci has the priority


### PR DESCRIPTION
* On Windows, use subprocess.run() instead of os.execv().
* Only add needed options
* Rename reexec parameter to _add_python_opts.
* Rename --no-reexec option to --dont-add-python-opts.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-109566 -->
* Issue: gh-109566
<!-- /gh-issue-number -->
