### PR TITLE
gh-109936: return on EOF in shutil.copyfileobj

### DIFF
--- a/Lib/shutil.py
+++ b/Lib/shutil.py
@@ -200,7 +200,9 @@ def copyfileobj(fsrc, fdst, length=0):
     # Localize variable access to minimize overhead.
     fsrc_read = fsrc.read
     fdst_write = fdst.write
-    while buf := fsrc_read(length):
+    while len(buf := fsrc_read(length)) == length:
+        fdst_write(buf)
+    if buf:
         fdst_write(buf)
 
 def _samefile(src, dst):

--- a/Misc/NEWS.d/next/Library/2023-09-26-16-57-47.gh-issue-109936.tOr6cE.rst
+++ b/Misc/NEWS.d/next/Library/2023-09-26-16-57-47.gh-issue-109936.tOr6cE.rst
@@ -1,0 +1,1 @@
+shutil.copyfileobj now correctly returns on EOF


### PR DESCRIPTION
Alters the loop condition to break on short read.

<!-- gh-issue-number: gh-109936 -->
* Issue: gh-109936
<!-- /gh-issue-number -->
