### PR TITLE
[3.11] gh-107298: Document PyMODINIT_FUNC macro (#109236)

### DIFF
--- a/Doc/c-api/intro.rst
+++ b/Doc/c-api/intro.rst
@@ -105,6 +105,30 @@ defined closer to where they are useful (e.g. :c:macro:`Py_RETURN_NONE`).
 Others of a more general utility are defined here.  This is not necessarily a
 complete listing.
 
+.. c:macro:: PyMODINIT_FUNC
+
+   Declare an extension module ``PyInit`` initialization function. The function
+   return type is :c:expr:`PyObject*`. The macro declares any special linkage
+   declarations required by the platform, and for C++ declares the function as
+   ``extern "C"``.
+
+   The initialization function must be named :samp:`PyInit_{name}`, where
+   *name* is the name of the module, and should be the only non-\ ``static``
+   item defined in the module file. Example::
+
+       static struct PyModuleDef spam_module = {
+           PyModuleDef_HEAD_INIT,
+           .m_name = "spam",
+           ...
+       };
+
+       PyMODINIT_FUNC
+       PyInit_spam(void)
+       {
+           return PyModule_Create(&spam_module);
+       }
+
+
 .. c:macro:: Py_ABS(x)
 
    Return the absolute value of ``x``.

--- a/Doc/using/configure.rst
+++ b/Doc/using/configure.rst
@@ -679,7 +679,7 @@ Extensions defined after the ``*shared*`` marker are built as dynamic libraries.
 The :file:`setup.py` script only builds C extensions as shared libraries using
 the :mod:`distutils` module.
 
-The :c:macro:`PyAPI_FUNC()`, :c:macro:`PyAPI_DATA()` and
+The :c:macro:`!PyAPI_FUNC()`, :c:macro:`!PyAPI_DATA()` and
 :c:macro:`PyMODINIT_FUNC` macros of :file:`Include/pyport.h` are defined
 differently depending if the ``Py_BUILD_CORE_MODULE`` macro is defined:
 

--- a/Doc/whatsnew/2.3.rst
+++ b/Doc/whatsnew/2.3.rst
@@ -1889,7 +1889,7 @@ Changes to Python's build process and to the C API include:
 * The :c:macro:`!DL_EXPORT` and :c:macro:`!DL_IMPORT` macros are now deprecated.
   Initialization functions for Python extension modules should now be declared
   using the new macro :c:macro:`PyMODINIT_FUNC`, while the Python core will
-  generally use the :c:macro:`PyAPI_FUNC` and :c:macro:`PyAPI_DATA` macros.
+  generally use the :c:macro:`!PyAPI_FUNC` and :c:macro:`!PyAPI_DATA` macros.
 
 * The interpreter can be compiled without any docstrings for the built-in
   functions and modules by supplying :option:`!--without-doc-strings` to the


### PR DESCRIPTION
Document PyMODINIT_FUNC macro.

Remove links to PyAPI_FUNC() and PyAPI_DATA() macros since they are not documented. These macros should only be used to define the Python C API. They should not be used outside Python code base.

(cherry picked from commit d7a27e527d7e669d2e45cff80ad725978226477c)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-107298 -->
* Issue: gh-107298
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--109948.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->