### PR TITLE
gh-109565: Fix concurrent.futures test_future_times_out()

### DIFF
--- a/Lib/test/test_concurrent_futures/test_as_completed.py
+++ b/Lib/test/test_concurrent_futures/test_as_completed.py
@@ -42,11 +42,14 @@ class AsCompletedTests:
                              EXCEPTION_FUTURE,
                              SUCCESSFUL_FUTURE}
 
-        for timeout in (0, 0.01):
+        # Windows clock resolution is around 15.6 ms
+        short_timeout = 0.100
+        for timeout in (0, short_timeout):
             with self.subTest(timeout):
 
-                future = self.executor.submit(time.sleep, 0.1)
                 completed_futures = set()
+                future = self.executor.submit(time.sleep, short_timeout * 10)
+
                 try:
                     for f in futures.as_completed(
                         already_completed | {future},


### PR DESCRIPTION
as_completed() uses a timeout of 100 ms instead of 10 ms. Windows monotonic clock resolution is around 15.6 ms.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-109565 -->
* Issue: gh-109565
<!-- /gh-issue-number -->
