### PR TITLE
gh-109566: Fix regrtest Python options for WASM/WASI

### DIFF
--- a/Lib/test/libregrtest/main.py
+++ b/Lib/test/libregrtest/main.py
@@ -504,9 +504,12 @@ class Regrtest:
         if sys.flags.bytes_warning < 2:
             python_opts.append('-bb')
 
-        # Ignore PYTHON* environment variables
-        if not sys.flags.ignore_environment:
-            python_opts.append('-E')
+        # WASM/WASI buildbot builders pass multiple PYTHON environment
+        # variables such as PYTHONPATH and _PYTHON_HOSTRUNNER.
+        if not self.python_cmd:
+            # Ignore PYTHON* environment variables
+            if not sys.flags.ignore_environment:
+                python_opts.append('-E')
 
         if not python_opts:
             return

--- a/Lib/test/libregrtest/worker.py
+++ b/Lib/test/libregrtest/worker.py
@@ -22,11 +22,15 @@ def create_worker_process(runtests: RunTests, output_fd: int,
     python_cmd = runtests.python_cmd
     worker_json = runtests.as_json()
 
+    python_opts = support.args_from_interpreter_flags()
     if python_cmd is not None:
         executable = python_cmd
+        # Remove -E option, since --python=COMMAND can set PYTHON environment
+        # variables, such as PYTHONPATH, in the worker process.
+        python_opts = [opt for opt in python_opts if opt != "-E"]
     else:
         executable = (sys.executable,)
-    cmd = [*executable, *support.args_from_interpreter_flags(),
+    cmd = [*executable, *python_opts,
            '-u',    # Unbuffered stdout and stderr
            '-m', 'test.libregrtest.worker',
            worker_json]


### PR DESCRIPTION
WASM and WASI buildbots use multiple PYTHON environment variables such as PYTHONPATH and _PYTHON_HOSTRUNNER. Don't use -E if the --python=COMMAND option is used.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-109566 -->
* Issue: gh-109566
<!-- /gh-issue-number -->
