### PR TITLE
gh-109956: Also test `typing.NamedTuple` with `copy.replace`

### DIFF
--- a/Lib/test/test_copy.py
+++ b/Lib/test/test_copy.py
@@ -948,6 +948,7 @@ class TestReplace(unittest.TestCase):
                 p = Point(11, 22)
                 self.assertIsInstance(p, Point)
                 self.assertEqual(copy.replace(p), (11, 22))
+                self.assertIsInstance(copy.replace(p), Point)
                 self.assertEqual(copy.replace(p, x=1), (1, 22))
                 self.assertEqual(copy.replace(p, y=2), (11, 2))
                 self.assertEqual(copy.replace(p, x=1, y=2), (1, 2))

--- a/Lib/test/test_copy.py
+++ b/Lib/test/test_copy.py
@@ -946,6 +946,7 @@ class TestReplace(unittest.TestCase):
         for Point in (PointFromCall, PointFromInheritance, PointFromClass):
             with self.subTest(Point=Point):
                 p = Point(11, 22)
+                self.assertIsInstance(p, Point)
                 self.assertEqual(copy.replace(p), (11, 22))
                 self.assertEqual(copy.replace(p, x=1), (1, 22))
                 self.assertEqual(copy.replace(p, y=2), (11, 2))

--- a/Lib/test/test_copy.py
+++ b/Lib/test/test_copy.py
@@ -936,14 +936,22 @@ class TestReplace(unittest.TestCase):
 
     def test_namedtuple(self):
         from collections import namedtuple
-        Point = namedtuple('Point', 'x y', defaults=(0,))
-        p = Point(11, 22)
-        self.assertEqual(copy.replace(p), (11, 22))
-        self.assertEqual(copy.replace(p, x=1), (1, 22))
-        self.assertEqual(copy.replace(p, y=2), (11, 2))
-        self.assertEqual(copy.replace(p, x=1, y=2), (1, 2))
-        with self.assertRaisesRegex(ValueError, 'unexpected field name'):
-            copy.replace(p, x=1, error=2)
+        from typing import NamedTuple
+        PointFromCall = namedtuple('Point', 'x y', defaults=(0,))
+        class PointFromInheritance(PointFromCall):
+            pass
+        class PointFromClass(NamedTuple):
+            x: int
+            y: int = 0
+        for Point in (PointFromCall, PointFromInheritance, PointFromClass):
+            with self.subTest(Point=Point):
+                p = Point(11, 22)
+                self.assertEqual(copy.replace(p), (11, 22))
+                self.assertEqual(copy.replace(p, x=1), (1, 22))
+                self.assertEqual(copy.replace(p, y=2), (11, 2))
+                self.assertEqual(copy.replace(p, x=1, y=2), (1, 2))
+                with self.assertRaisesRegex(ValueError, 'unexpected field name'):
+                    copy.replace(p, x=1, error=2)
 
     def test_dataclass(self):
         from dataclasses import dataclass


### PR DESCRIPTION
I've also added `PointFromInheritance`, since it is a very common pattern.

<!-- gh-issue-number: gh-109956 -->
* Issue: gh-109956
<!-- /gh-issue-number -->
