### PR TITLE
[3.11] gh-109615: Fix support test_copy_python_src_ignore() (#109958)

### DIFF
--- a/Lib/test/libregrtest/main.py
+++ b/Lib/test/libregrtest/main.py
@@ -731,11 +731,13 @@ class Regrtest:
             if sysconfig.is_python_build():
                 self.tmp_dir = sysconfig.get_config_var('abs_builddir')
                 if self.tmp_dir is None:
-                    # gh-74470: On Windows, only srcdir is available. Using
-                    # abs_builddir mostly matters on UNIX when building Python
-                    # out of the source tree, especially when the source tree
-                    # is read only.
-                    self.tmp_dir = sysconfig.get_config_var('srcdir')
+                    self.tmp_dir = sysconfig.get_config_var('abs_srcdir')
+                    if not self.tmp_dir:
+                        # gh-74470: On Windows, only srcdir is available. Using
+                        # abs_builddir mostly matters on UNIX when building
+                        # Python out of the source tree, especially when the
+                        # source tree is read only.
+                        self.tmp_dir = sysconfig.get_config_var('srcdir')
                 self.tmp_dir = os.path.join(self.tmp_dir, 'build')
             else:
                 self.tmp_dir = tempfile.gettempdir()

--- a/Lib/test/pythoninfo.py
+++ b/Lib/test/pythoninfo.py
@@ -524,7 +524,10 @@ def collect_sysconfig(info_add):
         'Py_NOGIL',
         'SHELL',
         'SOABI',
+        'abs_builddir',
+        'abs_srcdir',
         'prefix',
+        'srcdir',
     ):
         value = sysconfig.get_config_var(name)
         if name == 'ANDROID_API_LEVEL' and not value:

--- a/Lib/test/test_support.py
+++ b/Lib/test/test_support.py
@@ -779,8 +779,13 @@ class TestSupport(unittest.TestCase):
         #self.assertEqual(available, 2)
 
     def test_copy_python_src_ignore(self):
-        src_dir = sysconfig.get_config_var('srcdir')
+        src_dir = sysconfig.get_config_var('abs_srcdir')
+        if not src_dir:
+            src_dir = sysconfig.get_config_var('srcdir')
         src_dir = os.path.abspath(src_dir)
+        if not os.path.exists(src_dir):
+            self.skipTest(f"cannot access Python source code directory:"
+                          f" {src_dir!r}")
 
         ignored = {'.git', '__pycache__'}
 

--- a/Tools/freeze/test/freeze.py
+++ b/Tools/freeze/test/freeze.py
@@ -7,9 +7,16 @@ import sysconfig
 from test import support
 
 
+def get_python_source_dir():
+    src_dir = sysconfig.get_config_var('abs_srcdir')
+    if not src_dir:
+        src_dir = sysconfig.get_config_var('srcdir')
+    return os.path.abspath(src_dir)
+
+
 TESTS_DIR = os.path.dirname(__file__)
 TOOL_ROOT = os.path.dirname(TESTS_DIR)
-SRCDIR = os.path.abspath(sysconfig.get_config_var('srcdir'))
+SRCDIR = get_python_source_dir()
 
 MAKE = shutil.which('make')
 FREEZE = os.path.join(TOOL_ROOT, 'freeze.py')

--- a/Tools/scripts/patchcheck.py
+++ b/Tools/scripts/patchcheck.py
@@ -11,6 +11,13 @@ import reindent
 import untabify
 
 
+def get_python_source_dir():
+    src_dir = sysconfig.get_config_var('abs_srcdir')
+    if not src_dir:
+        src_dir = sysconfig.get_config_var('srcdir')
+    return os.path.abspath(src_dir)
+
+
 # Excluded directories which are copies of external libraries:
 # don't check their coding style
 EXCLUDE_DIRS = [os.path.join('Modules', '_ctypes', 'libffi_osx'),
@@ -18,7 +25,7 @@ EXCLUDE_DIRS = [os.path.join('Modules', '_ctypes', 'libffi_osx'),
                 os.path.join('Modules', '_decimal', 'libmpdec'),
                 os.path.join('Modules', 'expat'),
                 os.path.join('Modules', 'zlib')]
-SRCDIR = sysconfig.get_config_var('srcdir')
+SRCDIR = get_python_source_dir()
 
 
 def n_files_str(count):


### PR DESCRIPTION
Fix the test when run on an installed Python: use "abs_srcdir" of sysconfig, and skip the test if the Python source code cannot be found.

* Tools/patchcheck/patchcheck.py, Tools/freeze/test/freeze.py and Lib/test/libregrtest/utils.py now first try to get "abs_srcdir" from sysconfig, before getting "srcdir" from sysconfig.
* test.pythoninfo logs sysconfig "abs_srcdir".

(cherry picked from commit b89ed9df39851348fbb1552294644f99f6b17d2c)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-109615 -->
* Issue: gh-109615
<!-- /gh-issue-number -->
