### PR TITLE
gh-101100: Fix sphinx warnings in `library/devmode.rst`

### DIFF
--- a/Doc/library/devmode.rst
+++ b/Doc/library/devmode.rst
@@ -59,9 +59,9 @@ Effects of the Python Development Mode:
   ``default``.
 
 * Call :func:`faulthandler.enable` at Python startup to install handlers for
-  the :const:`signal.SIGSEGV`, :const:`signal.SIGFPE`,
-  :const:`signal.SIGABRT`, :const:`signal.SIGBUS` and
-  :const:`signal.SIGILL` signals to dump the Python traceback on a crash.
+  the :const:`~signal.SIGSEGV`, :const:`~signal.SIGFPE`,
+  :const:`~signal.SIGABRT`, :const:`~signal.SIGBUS` and
+  :const:`~signal.SIGILL` signals to dump the Python traceback on a crash.
 
   It behaves as if the :option:`-X faulthandler <-X>` command line option is
   used or if the :envvar:`PYTHONFAULTHANDLER` environment variable is set to

--- a/Doc/library/devmode.rst
+++ b/Doc/library/devmode.rst
@@ -59,8 +59,9 @@ Effects of the Python Development Mode:
   ``default``.
 
 * Call :func:`faulthandler.enable` at Python startup to install handlers for
-  the :const:`SIGSEGV`, :const:`SIGFPE`, :const:`SIGABRT`, :const:`SIGBUS` and
-  :const:`SIGILL` signals to dump the Python traceback on a crash.
+  the :const:`signal.SIGSEGV`, :const:`signal.SIGFPE`,
+  :const:`signal.SIGABRT`, :const:`signal.SIGBUS` and
+  :const:`signal.SIGILL` signals to dump the Python traceback on a crash.
 
   It behaves as if the :option:`-X faulthandler <-X>` command line option is
   used or if the :envvar:`PYTHONFAULTHANDLER` environment variable is set to

--- a/Doc/tools/.nitignore
+++ b/Doc/tools/.nitignore
@@ -53,7 +53,6 @@ Doc/library/csv.rst
 Doc/library/datetime.rst
 Doc/library/dbm.rst
 Doc/library/decimal.rst
-Doc/library/devmode.rst
 Doc/library/difflib.rst
 Doc/library/doctest.rst
 Doc/library/email.charset.rst


### PR DESCRIPTION
It used to be:

```
/Users/sobolev/Desktop/cpython/Doc/library/devmode.rst:61: WARNING: py:const reference target not found: SIGSEGV
/Users/sobolev/Desktop/cpython/Doc/library/devmode.rst:61: WARNING: py:const reference target not found: SIGFPE
/Users/sobolev/Desktop/cpython/Doc/library/devmode.rst:61: WARNING: py:const reference target not found: SIGABRT
/Users/sobolev/Desktop/cpython/Doc/library/devmode.rst:61: WARNING: py:const reference target not found: SIGBUS
/Users/sobolev/Desktop/cpython/Doc/library/devmode.rst:61: WARNING: py:const reference target not found: SIGILL
```

<!-- gh-issue-number: gh-101100 -->
* Issue: gh-101100
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--109963.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->