### PR TITLE
gh-109961: Docs: Fix incorrect rendering of `__replace__` in `copy.rst`

### DIFF
--- a/Doc/library/copy.rst
+++ b/Doc/library/copy.rst
@@ -91,13 +91,13 @@ In order for a class to define its own copy implementation, it can define
 special methods :meth:`~object.__copy__` and :meth:`~object.__deepcopy__`.
 
 .. method:: object.__copy__(self)
-   :noindex:
+   :noindexentry:
 
    Called to implement the shallow copy operation;
    no additional arguments are passed.
 
 .. method:: object.__deepcopy__(self, memo)
-   :noindex:
+   :noindexentry:
 
    Called to implement the deep copy operation; it is passed one
    argument, the *memo* dictionary.  If the ``__deepcopy__`` implementation needs
@@ -114,7 +114,7 @@ and only supports named tuples created by :func:`~collections.namedtuple`,
 :mod:`dataclasses`, and other classes which define method :meth:`~object.__replace__`.
 
 .. method:: object.__replace__(self, /, **changes)
-   :noindex:
+   :noindexentry:
 
    This method should create a new object of the same type,
    replacing fields with values from *changes*.

--- a/Doc/library/copy.rst
+++ b/Doc/library/copy.rst
@@ -91,11 +91,13 @@ In order for a class to define its own copy implementation, it can define
 special methods :meth:`~object.__copy__` and :meth:`~object.__deepcopy__`.
 
 .. method:: object.__copy__(self)
+   :noindex:
 
    Called to implement the shallow copy operation;
    no additional arguments are passed.
 
 .. method:: object.__deepcopy__(self, memo)
+   :noindex:
 
    Called to implement the deep copy operation; it is passed one
    argument, the *memo* dictionary.  If the ``__deepcopy__`` implementation needs
@@ -112,6 +114,7 @@ and only supports named tuples created by :func:`~collections.namedtuple`,
 :mod:`dataclasses`, and other classes which define method :meth:`~object.__replace__`.
 
 .. method:: object.__replace__(self, /, **changes)
+   :noindex:
 
    This method should create a new object of the same type,
    replacing fields with values from *changes*.

--- a/Doc/library/copy.rst
+++ b/Doc/library/copy.rst
@@ -88,13 +88,20 @@ pickle functions from the :mod:`copyreg` module.
    single: __deepcopy__() (copy protocol)
 
 In order for a class to define its own copy implementation, it can define
-special methods :meth:`__copy__` and :meth:`__deepcopy__`.  The former is called
-to implement the shallow copy operation; no additional arguments are passed.
-The latter is called to implement the deep copy operation; it is passed one
-argument, the ``memo`` dictionary.  If the :meth:`__deepcopy__` implementation needs
-to make a deep copy of a component, it should call the :func:`deepcopy` function
-with the component as first argument and the memo dictionary as second argument.
-The memo dictionary should be treated as an opaque object.
+special methods :meth:`~object.__copy__` and :meth:`~object.__deepcopy__`.
+
+.. method:: object.__copy__(self)
+
+   Called to implement the shallow copy operation;
+   no additional arguments are passed.
+
+.. method:: object.__deepcopy__(self, memo)
+
+   Called to implement the deep copy operation; it is passed one
+   argument, the *memo* dictionary.  If the ``__deepcopy__`` implementation needs
+   to make a deep copy of a component, it should call the :func:`deepcopy` function
+   with the component as first argument and the *memo* dictionary as second argument.
+   The *memo* dictionary should be treated as an opaque object.
 
 
 .. index::
@@ -102,13 +109,12 @@ The memo dictionary should be treated as an opaque object.
 
 Function :func:`replace` is more limited than :func:`copy` and :func:`deepcopy`,
 and only supports named tuples created by :func:`~collections.namedtuple`,
-:mod:`dataclasses`, and other classes which define method :meth:`!__replace__`.
+:mod:`dataclasses`, and other classes which define method :meth:`~object.__replace__`.
 
-   .. method:: __replace__(self, /, **changes)
-      :noindex:
+.. method:: object.__replace__(self, /, **changes)
 
-:meth:`!__replace__` should create a new object of the same type,
-replacing fields with values from *changes*.
+   This method should create a new object of the same type,
+   replacing fields with values from *changes*.
 
 
 .. seealso::

--- a/Doc/tools/.nitignore
+++ b/Doc/tools/.nitignore
@@ -48,7 +48,6 @@ Doc/library/collections.rst
 Doc/library/concurrent.futures.rst
 Doc/library/configparser.rst
 Doc/library/contextlib.rst
-Doc/library/copy.rst
 Doc/library/csv.rst
 Doc/library/datetime.rst
 Doc/library/dbm.rst


### PR DESCRIPTION
This is how it looks now:
<img width="796" alt="Снимок экрана 2023-09-27 в 16 22 12" src="https://github.com/python/cpython/assets/4660275/77e53cbb-c327-49db-a9a3-10a40b0dc807">

I've also added `__copy__` and `__deepcopy__` definitions, so they can be referenced.

Refs https://github.com/python/cpython/issues/101100

<!-- gh-issue-number: gh-109961 -->
* Issue: gh-109961
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--109968.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->