### PR TITLE
gh-109566: regrtest doesn't enable --rerun if --python is used

### DIFF
--- a/Lib/test/libregrtest/cmdline.py
+++ b/Lib/test/libregrtest/cmdline.py
@@ -420,7 +420,8 @@ def _parse_args(args, **kwargs):
         ns.randomize = True
         ns.fail_env_changed = True
         ns.fail_rerun = True
-        ns.rerun = True
+        if ns.python is None:
+            ns.rerun = True
         ns.print_slow = True
         ns.verbose3 = True
         if MS_WINDOWS:

--- a/Lib/test/test_regrtest.py
+++ b/Lib/test/test_regrtest.py
@@ -374,7 +374,7 @@ class ParseArgsTestCase(unittest.TestCase):
         self.checkError(['--unknown-option'],
                         'unrecognized arguments: --unknown-option')
 
-    def check_ci_mode(self, args, use_resources):
+    def check_ci_mode(self, args, use_resources, rerun=True):
         ns = cmdline._parse_args(args)
         if utils.MS_WINDOWS:
             self.assertTrue(ns.nowindows)
@@ -383,7 +383,7 @@ class ParseArgsTestCase(unittest.TestCase):
         # which has an unclear API
         regrtest = main.Regrtest(ns)
         self.assertEqual(regrtest.num_workers, -1)
-        self.assertTrue(regrtest.want_rerun)
+        self.assertEqual(regrtest.want_rerun, rerun)
         self.assertTrue(regrtest.randomize)
         self.assertIsNone(regrtest.random_seed)
         self.assertTrue(regrtest.fail_env_changed)
@@ -399,6 +399,14 @@ class ParseArgsTestCase(unittest.TestCase):
         use_resources.remove('cpu')
         regrtest = self.check_ci_mode(args, use_resources)
         self.assertEqual(regrtest.timeout, 10 * 60)
+
+    def test_fast_ci_python_cmd(self):
+        args = ['--fast-ci', '--python', 'python -X dev']
+        use_resources = sorted(cmdline.ALL_RESOURCES)
+        use_resources.remove('cpu')
+        regrtest = self.check_ci_mode(args, use_resources, rerun=False)
+        self.assertEqual(regrtest.timeout, 10 * 60)
+        self.assertEqual(regrtest.python_cmd, ('python', '-X', 'dev'))
 
     def test_fast_ci_resource(self):
         # it should be possible to override resources


### PR DESCRIPTION
regrtest: --fast-ci and --slow-ci options no longer enable --rerun if the --python option is used.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-109566 -->
* Issue: gh-109566
<!-- /gh-issue-number -->
