### PR TITLE
Remove unused imports in multiprocessing docs example

### DIFF
--- a/Doc/library/multiprocessing.rst
+++ b/Doc/library/multiprocessing.rst
@@ -2619,7 +2619,6 @@ server::
 The following code uses :func:`~multiprocessing.connection.wait` to
 wait for messages from multiple processes at once::
 
-   import time, random
    from multiprocessing import Process, Pipe, current_process
    from multiprocessing.connection import wait
 


### PR DESCRIPTION
Remove unused imports in multiprocessing docs example.

<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--109984.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->