### PR TITLE
gh-109590 - Update shutil.which on win32 to only give back PATHEXT matches by default

### DIFF
--- a/Doc/library/shutil.rst
+++ b/Doc/library/shutil.rst
@@ -476,6 +476,12 @@ Directory and files operations
       or ends with an extension that is in ``PATHEXT``; and filenames that
       have no extension can now be found.
 
+   .. versionchanged:: 3.12.1
+      On Windows, if *mode* includes ``os.X_OK``, only executables with an
+      extension in ``PATHEXT`` will be returned. Therefore extension-less
+      files cannot be returned by :func:`shutil.which` by default on Windows.
+      This brings behavior closer to that of Python 3.11.
+
 .. exception:: Error
 
    This exception collects exceptions that are raised during a multi-file

--- a/Doc/library/shutil.rst
+++ b/Doc/library/shutil.rst
@@ -477,9 +477,9 @@ Directory and files operations
       have no extension can now be found.
 
    .. versionchanged:: 3.12.1
-      On Windows, if *mode* includes ``os.X_OK``, only executables with an
-      extension in ``PATHEXT`` will be returned. Therefore extension-less
-      files cannot be returned by :func:`shutil.which` by default on Windows.
+      On Windows, if *mode* includes ``os.X_OK``, executables with an
+      extension in ``PATHEXT`` will be preferred over executables without a
+      matching extension.
       This brings behavior closer to that of Python 3.11.
 
 .. exception:: Error

--- a/Lib/shutil.py
+++ b/Lib/shutil.py
@@ -1560,10 +1560,9 @@ def which(cmd, mode=os.F_OK | os.X_OK, path=None):
         # for a PATHEXT match. The first cmd is the direct match
         # (e.g. python.exe instead of python)
         # Check that direct match first if and only if the extension is in PATHEXT
-        if mode & os.X_OK and not any(
-            [os.path.splitext(files[0])[1].upper() == ext.upper() for ext in pathext]
-            ):
-            files = files[1:]
+        suffix = os.path.splitext(files[0])[1].casefold()
+        if mode & os.X_OK and not any(suffix == ext.casefold() for ext in pathext):
+            del files[0]
     else:
         # On other platforms you don't have things like PATHEXT to tell you
         # what file suffixes are executable, so just pass on cmd as-is.

--- a/Lib/shutil.py
+++ b/Lib/shutil.py
@@ -1554,8 +1554,16 @@ def which(cmd, mode=os.F_OK | os.X_OK, path=None):
         if use_bytes:
             pathext = [os.fsencode(ext) for ext in pathext]
 
-        # Always try checking the originally given cmd, if it doesn't match, try pathext
-        files = [cmd] + [cmd + ext for ext in pathext]
+        files = ([cmd] + [cmd + ext for ext in pathext])
+
+        # gh-109590. If we are looking for an executable, we need to look
+        # for a PATHEXT match. The first cmd is the direct match
+        # (e.g. python.exe instead of python)
+        # Check that direct match first if and only if the extension is in PATHEXT
+        if mode & os.X_OK and not any(
+            [os.path.splitext(files[0])[1].upper() == ext.upper() for ext in pathext]
+            ):
+            files = files[1:]
     else:
         # On other platforms you don't have things like PATHEXT to tell you
         # what file suffixes are executable, so just pass on cmd as-is.

--- a/Lib/shutil.py
+++ b/Lib/shutil.py
@@ -1560,9 +1560,10 @@ def which(cmd, mode=os.F_OK | os.X_OK, path=None):
         # for a PATHEXT match. The first cmd is the direct match
         # (e.g. python.exe instead of python)
         # Check that direct match first if and only if the extension is in PATHEXT
+        # Otherwise check it last
         suffix = os.path.splitext(files[0])[1].upper()
         if mode & os.X_OK and not any(suffix == ext.upper() for ext in pathext):
-            del files[0]
+            files.append(files.pop(0))
     else:
         # On other platforms you don't have things like PATHEXT to tell you
         # what file suffixes are executable, so just pass on cmd as-is.

--- a/Lib/shutil.py
+++ b/Lib/shutil.py
@@ -1560,8 +1560,8 @@ def which(cmd, mode=os.F_OK | os.X_OK, path=None):
         # for a PATHEXT match. The first cmd is the direct match
         # (e.g. python.exe instead of python)
         # Check that direct match first if and only if the extension is in PATHEXT
-        suffix = os.path.splitext(files[0])[1].casefold()
-        if mode & os.X_OK and not any(suffix == ext.casefold() for ext in pathext):
+        suffix = os.path.splitext(files[0])[1].upper()
+        if mode & os.X_OK and not any(suffix == ext.upper() for ext in pathext):
             del files[0]
     else:
         # On other platforms you don't have things like PATHEXT to tell you

--- a/Lib/test/test_shutil.py
+++ b/Lib/test/test_shutil.py
@@ -2067,6 +2067,14 @@ class TestWhich(BaseTest, unittest.TestCase):
         self.curdir = os.curdir
         self.ext = ".EXE"
 
+    def to_text_type(self, s):
+        '''
+        In this class we're testing with str, so convert s to a str
+        '''
+        if isinstance(s, bytes):
+            return s.decode()
+        return s
+
     def test_basic(self):
         # Given an EXE in a directory, it should be returned.
         rv = shutil.which(self.file, path=self.dir)
@@ -2254,9 +2262,9 @@ class TestWhich(BaseTest, unittest.TestCase):
 
     @unittest.skipUnless(sys.platform == "win32", 'test specific to Windows')
     def test_pathext(self):
-        ext = ".xyz"
+        ext = self.to_text_type(".xyz")
         temp_filexyz = tempfile.NamedTemporaryFile(dir=self.temp_dir,
-                                                   prefix="Tmp2", suffix=ext)
+                                                   prefix=self.to_text_type("Tmp2"), suffix=ext)
         os.chmod(temp_filexyz.name, stat.S_IXUSR)
         self.addCleanup(temp_filexyz.close)
 
@@ -2265,16 +2273,16 @@ class TestWhich(BaseTest, unittest.TestCase):
         program = os.path.splitext(program)[0]
 
         with os_helper.EnvironmentVarGuard() as env:
-            env['PATHEXT'] = ext
+            env['PATHEXT'] = ext if isinstance(ext, str) else ext.decode()
             rv = shutil.which(program, path=self.temp_dir)
             self.assertEqual(rv, temp_filexyz.name)
 
     # Issue 40592: See https://bugs.python.org/issue40592
     @unittest.skipUnless(sys.platform == "win32", 'test specific to Windows')
     def test_pathext_with_empty_str(self):
-        ext = ".xyz"
+        ext = self.to_text_type(".xyz")
         temp_filexyz = tempfile.NamedTemporaryFile(dir=self.temp_dir,
-                                                   prefix="Tmp2", suffix=ext)
+                                                   prefix=self.to_text_type("Tmp2"), suffix=ext)
         self.addCleanup(temp_filexyz.close)
 
         # strip path and extension
@@ -2282,7 +2290,7 @@ class TestWhich(BaseTest, unittest.TestCase):
         program = os.path.splitext(program)[0]
 
         with os_helper.EnvironmentVarGuard() as env:
-            env['PATHEXT'] = f"{ext};"  # note the ;
+            env['PATHEXT'] = f"{ext if isinstance(ext, str) else ext.decode()};"  # note the ;
             rv = shutil.which(program, path=self.temp_dir)
             self.assertEqual(rv, temp_filexyz.name)
 
@@ -2290,13 +2298,14 @@ class TestWhich(BaseTest, unittest.TestCase):
     @unittest.skipUnless(sys.platform == "win32", 'test specific to Windows')
     def test_pathext_applied_on_files_in_path(self):
         with os_helper.EnvironmentVarGuard() as env:
-            env["PATH"] = self.temp_dir
+            env["PATH"] = self.temp_dir if isinstance(self.temp_dir, str) else self.temp_dir.decode()
             env["PATHEXT"] = ".test"
 
-            test_path = pathlib.Path(self.temp_dir) / "test_program.test"
-            test_path.touch(mode=0o755)
+            test_path = os.path.join(self.temp_dir, self.to_text_type("test_program.test"))
+            open(test_path, 'w').close()
+            os.chmod(test_path, 0o755)
 
-            self.assertEqual(shutil.which("test_program"), str(test_path))
+            self.assertEqual(shutil.which(self.to_text_type("test_program")), test_path)
 
     # See GH-75586
     @unittest.skipUnless(sys.platform == "win32", 'test specific to Windows')
@@ -2312,6 +2321,43 @@ class TestWhich(BaseTest, unittest.TestCase):
             self.assertFalse(shutil._win_path_needs_curdir('dontcare', os.X_OK))
             need_curdir_mock.assert_called_once_with('dontcare')
 
+    # See GH-109590
+    @unittest.skipUnless(sys.platform == "win32", 'test specific to Windows')
+    def test_pathext_enforced_for_execute(self):
+        with os_helper.EnvironmentVarGuard() as env:
+            env["PATH"] = self.temp_dir if isinstance(self.temp_dir, str) else self.temp_dir.decode()
+            env["PATHEXT"] = ".test"
+
+            exe = os.path.join(self.temp_dir, self.to_text_type("test.exe"))
+            open(exe, 'w').close()
+            os.chmod(exe, 0o755)
+
+            # default does not match since .exe is not in PATHEXT
+            self.assertIsNone(shutil.which(self.to_text_type("test.exe")))
+
+            # but if we don't use os.X_OK we're ok not matching PATHEXT
+            self.assertEqual(shutil.which(self.to_text_type("test.exe"), mode=os.F_OK), exe)
+
+    # See GH-109590
+    @unittest.skipUnless(sys.platform == "win32", 'test specific to Windows')
+    def test_pathext_given_extension_preferred(self):
+        with os_helper.EnvironmentVarGuard() as env:
+            env["PATH"] = self.temp_dir if isinstance(self.temp_dir, str) else self.temp_dir.decode()
+            env["PATHEXT"] = ".exe2;.exe"
+
+            exe = os.path.join(self.temp_dir, self.to_text_type("test.exe"))
+            open(exe, 'w').close()
+            os.chmod(exe, 0o755)
+
+            exe2 = os.path.join(self.temp_dir, self.to_text_type("test.exe2"))
+            open(exe2, 'w').close()
+            os.chmod(exe2, 0o755)
+
+            # even though .exe2 is preferred in PATHEXT, we matched directly to test.exe
+            self.assertEqual(shutil.which(self.to_text_type("test.exe")), exe)
+
+            self.assertEqual(shutil.which(self.to_text_type("test")), exe2)
+
 
 class TestWhichBytes(TestWhich):
     def setUp(self):
@@ -2319,8 +2365,17 @@ class TestWhichBytes(TestWhich):
         self.dir = os.fsencode(self.dir)
         self.file = os.fsencode(self.file)
         self.temp_file.name = os.fsencode(self.temp_file.name)
+        self.temp_dir = os.fsencode(self.temp_dir)
         self.curdir = os.fsencode(self.curdir)
         self.ext = os.fsencode(self.ext)
+
+    def to_text_type(self, s):
+        '''
+        In this class we're testing with bytes, so convert s to a bytes
+        '''
+        if isinstance(s, str):
+            return s.encode()
+        return s
 
 
 class TestMove(BaseTest, unittest.TestCase):

--- a/Misc/NEWS.d/next/Library/2023-09-24-06-04-14.gh-issue-109590.9EMofC.rst
+++ b/Misc/NEWS.d/next/Library/2023-09-24-06-04-14.gh-issue-109590.9EMofC.rst
@@ -1,2 +1,3 @@
-:func:`shutil.which` will only match files with an extension in ``PATHEXT`` if the given mode includes ``os.X_OK`` on win32.
+:func:`shutil.which` will prefer files with an extension in ``PATHEXT`` if the given mode includes ``os.X_OK`` on win32.
+If no ``PATHEXT`` match is found, a file without an extension in ``PATHEXT`` can be returned.
 This change will have :func:`shutil.which` act more similarly to previous behavior in Python 3.11.

--- a/Misc/NEWS.d/next/Library/2023-09-24-06-04-14.gh-issue-109590.9EMofC.rst
+++ b/Misc/NEWS.d/next/Library/2023-09-24-06-04-14.gh-issue-109590.9EMofC.rst
@@ -1,0 +1,2 @@
+:func:`shutil.which` will only match files with an extension in ``PATHEXT`` if the given mode includes ``os.X_OK`` on win32.
+This change will have :func:`shutil.which` act more similarly to previous behavior in Python 3.11.


### PR DESCRIPTION
Based off the conversation in [gh-109590](https://github.com/python/cpython/issues/109590), if os.X_OK, only give back things that match PATHEXT. Add some corresponding tests. 

@zooba said this should probably be in a 3.12.1, so I've marked it that way, though I'm not sure what else I need to change to aim for that. Please advise. Thanks.

Also updated the `which` tests to work a bit cleaner in terms of `str` vs `bytes`. Previously a decent amount of testing wasn't actually running as `bytes`.

<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--109995.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->