### PR TITLE
gh-109991: Update macOS installer to use OpenSSL 3.0.10.

### DIFF
--- a/Mac/BuildScript/build-installer.py
+++ b/Mac/BuildScript/build-installer.py
@@ -246,9 +246,9 @@ def library_recipes():
 
     result.extend([
           dict(
-              name="OpenSSL 3.0.10",
-              url="https://www.openssl.org/source/openssl-3.0.10.tar.gz",
-              checksum='1761d4f5b13a1028b9b6f3d4b8e17feb0cedc9370f6afe61d7193d2cdce83323',
+              name="OpenSSL 3.0.11",
+              url="https://www.openssl.org/source/openssl-3.0.11.tar.gz",
+              checksum='b3425d3bb4a2218d0697eb41f7fc0cdede016ed19ca49d168b78e8d947887f55',
               buildrecipe=build_universal_openssl,
               configure=None,
               install=None,

--- a/Misc/NEWS.d/next/macOS/2023-09-27-22-35-22.gh-issue-109991.-xJzaF.rst
+++ b/Misc/NEWS.d/next/macOS/2023-09-27-22-35-22.gh-issue-109991.-xJzaF.rst
@@ -1,0 +1,1 @@
+Update macOS installer to use OpenSSL 3.0.11.


### PR DESCRIPTION


<!-- gh-issue-number: gh-109991 -->
* Issue: gh-109991
<!-- /gh-issue-number -->
