### PR TITLE
Whitespace fix in asyncio-stream.rst

### DIFF
--- a/Doc/library/asyncio-stream.rst
+++ b/Doc/library/asyncio-stream.rst
@@ -157,8 +157,8 @@ and work with streams:
    .. versionchanged:: 3.10
       Removed the *loop* parameter.
 
-  .. versionchanged:: 3.11
-     Added the *ssl_shutdown_timeout* parameter.
+   .. versionchanged:: 3.11
+      Added the *ssl_shutdown_timeout* parameter.
 
 
 .. coroutinefunction:: start_unix_server(client_connected_cb, path=None, \


### PR DESCRIPTION
Indentation fix

<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--110015.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->