### PR TITLE
gh-109594: Fix concurrent.futures test_timeout()

### DIFF
--- a/Lib/test/test_concurrent_futures/test_wait.py
+++ b/Lib/test/test_concurrent_futures/test_wait.py
@@ -112,24 +112,25 @@ class WaitTests:
                               future2]), finished)
         self.assertEqual(set(), pending)
 
-    @support.requires_resource('walltime')
     def test_timeout(self):
-        future1 = self.executor.submit(mul, 6, 7)
-        future2 = self.executor.submit(time.sleep, 6)
+        short_timeout = 0.050
+        long_timeout = short_timeout * 10
+
+        future = self.executor.submit(time.sleep, long_timeout)
 
         finished, pending = futures.wait(
                 [CANCELLED_AND_NOTIFIED_FUTURE,
                  EXCEPTION_FUTURE,
                  SUCCESSFUL_FUTURE,
-                 future1, future2],
-                timeout=5,
+                 future],
+                timeout=short_timeout,
                 return_when=futures.ALL_COMPLETED)
 
         self.assertEqual(set([CANCELLED_AND_NOTIFIED_FUTURE,
                               EXCEPTION_FUTURE,
-                              SUCCESSFUL_FUTURE,
-                              future1]), finished)
-        self.assertEqual(set([future2]), pending)
+                              SUCCESSFUL_FUTURE]),
+                         finished)
+        self.assertEqual(set([future]), pending)
 
 
 class ThreadPoolWaitTests(ThreadPoolMixin, WaitTests, BaseTestCase):

--- a/Misc/NEWS.d/next/Tests/2023-09-28-14-47-14.gh-issue-109594.DB5KPP.rst
+++ b/Misc/NEWS.d/next/Tests/2023-09-28-14-47-14.gh-issue-109594.DB5KPP.rst
@@ -1,0 +1,4 @@
+Fix test_timeout() of test_concurrent_futures.test_wait. Remove the future
+which may or may not complete depending if it takes longer than the timeout
+ot not. Keep the second future which does not complete before wait()
+timeout. Patch by Victor Stinner.


### PR DESCRIPTION
Fix test_timeout() of test_concurrent_futures.test_wait. Remove the future which may or may not complete depending if it takes longer than the timeout ot not. Keep the second future which does not complete before wait(). Make also the test faster: 0.5 second instead of 6 seconds, so remove @support.requires_resource('walltime') decorator.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-109594 -->
* Issue: gh-109594
<!-- /gh-issue-number -->
