### PR TITLE
gh-110020: Fix unused variable warnings in `bytecodes.c`

### DIFF
--- a/Python/bytecodes.c
+++ b/Python/bytecodes.c
@@ -2023,8 +2023,7 @@ dummy_func(
         }
 
         op(_GUARD_DORV_VALUES, (owner -- owner)) {
-            PyTypeObject *tp = Py_TYPE(owner);
-            assert(tp->tp_flags & Py_TPFLAGS_MANAGED_DICT);
+            assert(Py_TYPE(owner)->tp_flags & Py_TPFLAGS_MANAGED_DICT);
             PyDictOrValues dorv = *_PyObject_DictOrValuesPointer(owner);
             DEOPT_IF(!_PyDictOrValues_IsValues(dorv), STORE_ATTR);
         }
@@ -2789,8 +2788,7 @@ dummy_func(
         }
 
         op(_GUARD_DORV_VALUES_INST_ATTR_FROM_DICT, (owner -- owner)) {
-            PyTypeObject *owner_cls = Py_TYPE(owner);
-            assert(owner_cls->tp_flags & Py_TPFLAGS_MANAGED_DICT);
+            assert(Py_TYPE(owner)->tp_flags & Py_TPFLAGS_MANAGED_DICT);
             PyDictOrValues *dorv = _PyObject_DictOrValuesPointer(owner);
             DEOPT_IF(!_PyDictOrValues_IsValues(*dorv) &&
                      !_PyObject_MakeInstanceAttributesFromDict(owner, dorv),
@@ -2823,8 +2821,7 @@ dummy_func(
 
         op(_LOAD_ATTR_METHOD_NO_DICT, (descr/4, owner -- attr, self if (1))) {
             assert(oparg & 1);
-            PyTypeObject *owner_cls = Py_TYPE(owner);
-            assert(owner_cls->tp_dictoffset == 0);
+            assert(Py_TYPE(owner)->tp_dictoffset == 0);
             STAT_INC(LOAD_ATTR, hit);
             assert(descr != NULL);
             assert(_PyType_HasFeature(Py_TYPE(descr), Py_TPFLAGS_METHOD_DESCRIPTOR));

--- a/Python/executor_cases.c.h
+++ b/Python/executor_cases.c.h
@@ -1736,8 +1736,7 @@
         case _GUARD_DORV_VALUES: {
             PyObject *owner;
             owner = stack_pointer[-1];
-            PyTypeObject *tp = Py_TYPE(owner);
-            assert(tp->tp_flags & Py_TPFLAGS_MANAGED_DICT);
+            assert(Py_TYPE(owner)->tp_flags & Py_TPFLAGS_MANAGED_DICT);
             PyDictOrValues dorv = *_PyObject_DictOrValuesPointer(owner);
             DEOPT_IF(!_PyDictOrValues_IsValues(dorv), STORE_ATTR);
             break;
@@ -2299,8 +2298,7 @@
         case _GUARD_DORV_VALUES_INST_ATTR_FROM_DICT: {
             PyObject *owner;
             owner = stack_pointer[-1];
-            PyTypeObject *owner_cls = Py_TYPE(owner);
-            assert(owner_cls->tp_flags & Py_TPFLAGS_MANAGED_DICT);
+            assert(Py_TYPE(owner)->tp_flags & Py_TPFLAGS_MANAGED_DICT);
             PyDictOrValues *dorv = _PyObject_DictOrValuesPointer(owner);
             DEOPT_IF(!_PyDictOrValues_IsValues(*dorv) &&
                      !_PyObject_MakeInstanceAttributesFromDict(owner, dorv),
@@ -2345,8 +2343,7 @@
             owner = stack_pointer[-1];
             PyObject *descr = (PyObject *)operand;
             assert(oparg & 1);
-            PyTypeObject *owner_cls = Py_TYPE(owner);
-            assert(owner_cls->tp_dictoffset == 0);
+            assert(Py_TYPE(owner)->tp_dictoffset == 0);
             STAT_INC(LOAD_ATTR, hit);
             assert(descr != NULL);
             assert(_PyType_HasFeature(Py_TYPE(descr), Py_TPFLAGS_METHOD_DESCRIPTOR));

--- a/Python/generated_cases.c.h
+++ b/Python/generated_cases.c.h
@@ -2631,8 +2631,7 @@
             }
             // _GUARD_DORV_VALUES
             {
-                PyTypeObject *tp = Py_TYPE(owner);
-                assert(tp->tp_flags & Py_TPFLAGS_MANAGED_DICT);
+                assert(Py_TYPE(owner)->tp_flags & Py_TPFLAGS_MANAGED_DICT);
                 PyDictOrValues dorv = *_PyObject_DictOrValuesPointer(owner);
                 DEOPT_IF(!_PyDictOrValues_IsValues(dorv), STORE_ATTR);
             }
@@ -3590,8 +3589,7 @@
             }
             // _GUARD_DORV_VALUES_INST_ATTR_FROM_DICT
             {
-                PyTypeObject *owner_cls = Py_TYPE(owner);
-                assert(owner_cls->tp_flags & Py_TPFLAGS_MANAGED_DICT);
+                assert(Py_TYPE(owner)->tp_flags & Py_TPFLAGS_MANAGED_DICT);
                 PyDictOrValues *dorv = _PyObject_DictOrValuesPointer(owner);
                 DEOPT_IF(!_PyDictOrValues_IsValues(*dorv) &&
                          !_PyObject_MakeInstanceAttributesFromDict(owner, dorv),
@@ -3639,8 +3637,7 @@
             {
                 PyObject *descr = read_obj(&next_instr[5].cache);
                 assert(oparg & 1);
-                PyTypeObject *owner_cls = Py_TYPE(owner);
-                assert(owner_cls->tp_dictoffset == 0);
+                assert(Py_TYPE(owner)->tp_dictoffset == 0);
                 STAT_INC(LOAD_ATTR, hit);
                 assert(descr != NULL);
                 assert(_PyType_HasFeature(Py_TYPE(descr), Py_TPFLAGS_METHOD_DESCRIPTOR));


### PR DESCRIPTION
Refs https://github.com/python/cpython/pull/109943

<!-- gh-issue-number: gh-110020 -->
* Issue: gh-110020
<!-- /gh-issue-number -->
