### PR TITLE
gh-109961: Use proper `module` for `copy` method docs

### DIFF
--- a/Doc/library/copy.rst
+++ b/Doc/library/copy.rst
@@ -87,7 +87,7 @@ pickle functions from the :mod:`copyreg` module.
    single: __copy__() (copy protocol)
    single: __deepcopy__() (copy protocol)
 
-.. currentmodule:: builtins
+.. currentmodule:: None
 
 In order for a class to define its own copy implementation, it can define
 special methods :meth:`~object.__copy__` and :meth:`~object.__deepcopy__`.

--- a/Doc/library/copy.rst
+++ b/Doc/library/copy.rst
@@ -88,20 +88,22 @@ pickle functions from the :mod:`copyreg` module.
    single: __deepcopy__() (copy protocol)
 
 In order for a class to define its own copy implementation, it can define
-special methods :meth:`~object.__copy__` and :meth:`~object.__deepcopy__`.
+special methods :meth:`~builtins.object.__copy__` and :meth:`~builtins.object.__deepcopy__`.
 
 .. method:: object.__copy__(self)
+   :module: builtins
    :noindexentry:
 
    Called to implement the shallow copy operation;
    no additional arguments are passed.
 
 .. method:: object.__deepcopy__(self, memo)
+   :module: builtins
    :noindexentry:
 
    Called to implement the deep copy operation; it is passed one
    argument, the *memo* dictionary.  If the ``__deepcopy__`` implementation needs
-   to make a deep copy of a component, it should call the :func:`deepcopy` function
+   to make a deep copy of a component, it should call the :func:`~copy.deepcopy` function
    with the component as first argument and the *memo* dictionary as second argument.
    The *memo* dictionary should be treated as an opaque object.
 
@@ -111,9 +113,10 @@ special methods :meth:`~object.__copy__` and :meth:`~object.__deepcopy__`.
 
 Function :func:`replace` is more limited than :func:`copy` and :func:`deepcopy`,
 and only supports named tuples created by :func:`~collections.namedtuple`,
-:mod:`dataclasses`, and other classes which define method :meth:`~object.__replace__`.
+:mod:`dataclasses`, and other classes which define method :meth:`~builtins.object.__replace__`.
 
 .. method:: object.__replace__(self, /, **changes)
+   :module: builtins
    :noindexentry:
 
    This method should create a new object of the same type,

--- a/Doc/library/copy.rst
+++ b/Doc/library/copy.rst
@@ -87,18 +87,18 @@ pickle functions from the :mod:`copyreg` module.
    single: __copy__() (copy protocol)
    single: __deepcopy__() (copy protocol)
 
+.. currentmodule:: builtins
+
 In order for a class to define its own copy implementation, it can define
-special methods :meth:`~builtins.object.__copy__` and :meth:`~builtins.object.__deepcopy__`.
+special methods :meth:`~object.__copy__` and :meth:`~object.__deepcopy__`.
 
 .. method:: object.__copy__(self)
-   :module: builtins
    :noindexentry:
 
    Called to implement the shallow copy operation;
    no additional arguments are passed.
 
 .. method:: object.__deepcopy__(self, memo)
-   :module: builtins
    :noindexentry:
 
    Called to implement the deep copy operation; it is passed one
@@ -111,12 +111,12 @@ special methods :meth:`~builtins.object.__copy__` and :meth:`~builtins.object.__
 .. index::
    single: __replace__() (replace protocol)
 
-Function :func:`replace` is more limited than :func:`copy` and :func:`deepcopy`,
+Function :func:`!copy.replace` is more limited
+than :func:`~copy.copy` and :func:`~copy.deepcopy`,
 and only supports named tuples created by :func:`~collections.namedtuple`,
-:mod:`dataclasses`, and other classes which define method :meth:`~builtins.object.__replace__`.
+:mod:`dataclasses`, and other classes which define method :meth:`~object.__replace__`.
 
 .. method:: object.__replace__(self, /, **changes)
-   :module: builtins
    :noindexentry:
 
    This method should create a new object of the same type,


### PR DESCRIPTION
This sets correct `:module:` context for `builtins.object.{__copy__,__deepcopy__,__replace__}`

Now their urls are:
- [`library/copy.html#object.__copy__`](https://cpython-previews--110027.org.readthedocs.build/en/110027/library/copy.html#object.__copy__)
- [`library/copy.html#object.__deepcopy__`](https://cpython-previews--110027.org.readthedocs.build/en/110027/library/copy.html#object.__deepcopy__)
- [`library/copy.html#object.__replace__`](https://cpython-previews--110027.org.readthedocs.build/en/110027/library/copy.html#object.__replace__)

All links seem to work. 
CC @AA-Turner @hugovk @serhiy-storchaka 

Refs https://github.com/python/cpython/pull/109968

<!-- gh-issue-number: gh-109961 -->
* Issue: gh-109961
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--110027.org.readthedocs.build/en/110027/library/copy.html

<!-- readthedocs-preview cpython-previews end -->