### PR TITLE
gh-85984: Document change in return type of tty functions

### DIFF
--- a/Doc/library/tty.rst
+++ b/Doc/library/tty.rst
@@ -43,6 +43,9 @@ The :mod:`tty` module defines the following functions:
    :func:`termios.tcsetattr`. The return value of :func:`termios.tcgetattr`
    is saved before setting *fd* to raw mode; this value is returned.
 
+   .. versionchanged:: 3.12
+      The return value is now the original tty attributes, instead of None.
+
 
 .. function:: setcbreak(fd, when=termios.TCSAFLUSH)
 
@@ -50,6 +53,9 @@ The :mod:`tty` module defines the following functions:
    defaults to :const:`termios.TCSAFLUSH`, and is passed to
    :func:`termios.tcsetattr`. The return value of :func:`termios.tcgetattr`
    is saved before setting *fd* to cbreak mode; this value is returned.
+
+   .. versionchanged:: 3.12
+      The return value is now the original tty attributes, instead of None.
 
 
 .. seealso::


### PR DESCRIPTION
Followup from #101832

<!-- gh-issue-number: gh-85984 -->
* Issue: gh-85984
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--110028.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->