### PR TITLE
gh-110014: Fix inconsistent struct definition in pycore_semaphore.h

### DIFF
--- a/Include/internal/pycore_semaphore.h
+++ b/Include/internal/pycore_semaphore.h
@@ -20,6 +20,10 @@
 #   error "Require native threads. See https://bugs.python.org/issue31370"
 #endif
 
+#ifndef MS_WINDOWS
+#   include <unistd.h>              // _POSIX_SEMAPHORES
+#endif
+
 #if (defined(_POSIX_SEMAPHORES) && (_POSIX_SEMAPHORES+0) != -1 && \
         defined(HAVE_SEM_TIMEDWAIT))
 #   define _Py_USE_SEMAPHORES


### PR DESCRIPTION
The pycore_semaphore.h header is included by Python/lock.c and Python/parking_lot.c. The macro `_POSIX_SEMAPHORES` was not consistently defined across the two files (due to a missing include of `<unistd.h>`) leading to different struct definitions. The RHEL8 ppc64le LTO buildbot correctly warned due to this issue.


<!-- gh-issue-number: gh-110014 -->
* Issue: gh-110014
<!-- /gh-issue-number -->
