### PR TITLE
gh-110033: Fix signal test_interprocess_signal()

### DIFF
--- a/Misc/NEWS.d/next/Tests/2023-09-28-18-14-52.gh-issue-110033.2yHMx0.rst
+++ b/Misc/NEWS.d/next/Tests/2023-09-28-18-14-52.gh-issue-110033.2yHMx0.rst
@@ -1,0 +1,5 @@
+Fix ``test_interprocess_signal()`` of ``test_signal``. Make sure that the
+``subprocess.Popen`` object is deleted before the test raising an exception
+in a signal handler. Otherwise, ``Popen.__del__()`` can get the exception
+which is logged as ``Exception ignored in: ...`` and the test fails. Patch by
+Victor Stinner.


### PR DESCRIPTION
Fix test_interprocess_signal() of test_signal. Make sure that the subprocess.Popen object is deleted before the test raising an exception in a signal handler. Otherwise, Popen.__del__() can get the exception which is logged as "Exception ignored in: ...." and the test fails.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-110033 -->
* Issue: gh-110033
<!-- /gh-issue-number -->
