### PR TITLE
gh-110038: KqueueSelector must count all read/write events

### DIFF
--- a/Lib/selectors.py
+++ b/Lib/selectors.py
@@ -500,15 +500,15 @@ if hasattr(select, 'kqueue'):
             key = super().register(fileobj, events, data)
             try:
                 if events & EVENT_READ:
-                    self._max_events += 1
                     kev = select.kevent(key.fd, select.KQ_FILTER_READ,
                                         select.KQ_EV_ADD)
                     self._selector.control([kev], 0, 0)
-                if events & EVENT_WRITE:
                     self._max_events += 1
+                if events & EVENT_WRITE:
                     kev = select.kevent(key.fd, select.KQ_FILTER_WRITE,
                                         select.KQ_EV_ADD)
                     self._selector.control([kev], 0, 0)
+                    self._max_events += 1
             except:
                 super().unregister(fileobj)
                 raise
@@ -517,9 +517,9 @@ if hasattr(select, 'kqueue'):
         def unregister(self, fileobj):
             key = super().unregister(fileobj)
             if key.events & EVENT_READ:
-                self._max_events -= 1
                 kev = select.kevent(key.fd, select.KQ_FILTER_READ,
                                     select.KQ_EV_DELETE)
+                self._max_events -= 1
                 try:
                     self._selector.control([kev], 0, 0)
                 except OSError:
@@ -527,9 +527,9 @@ if hasattr(select, 'kqueue'):
                     # was registered.
                     pass
             if key.events & EVENT_WRITE:
-                self._max_events -= 1
                 kev = select.kevent(key.fd, select.KQ_FILTER_WRITE,
                                     select.KQ_EV_DELETE)
+                self._max_events -= 1
                 try:
                     self._selector.control([kev], 0, 0)
                 except OSError:

--- a/Lib/test/test_selectors.py
+++ b/Lib/test/test_selectors.py
@@ -285,6 +285,35 @@ class BaseSelectorTestCase:
 
         self.assertEqual([(wr_key, selectors.EVENT_WRITE)], result)
 
+    def test_select_read_write(self):
+        # gh-110038: when a file descriptor is registered for both read and
+        # write, the two events must be seen on a single call to select().
+        s = self.SELECTOR()
+        self.addCleanup(s.close)
+
+        sock1, sock2 = self.make_socketpair()
+        sock2.send(b"foo")
+        my_key = s.register(sock1, selectors.EVENT_READ | selectors.EVENT_WRITE)
+
+        seen_read, seen_write = False, False
+        result = s.select()
+        # We get the read and write either in the same result entry or in two
+        # distinct entries with the same key.
+        self.assertLessEqual(len(result), 2)
+        for key, events in result:
+            self.assertTrue(isinstance(key, selectors.SelectorKey))
+            self.assertEqual(key, my_key)
+            self.assertFalse(events & ~(selectors.EVENT_READ |
+                                        selectors.EVENT_WRITE))
+            if events & selectors.EVENT_READ:
+                self.assertFalse(seen_read)
+                seen_read = True
+            if events & selectors.EVENT_WRITE:
+                self.assertFalse(seen_write)
+                seen_write = True
+        self.assertTrue(seen_read)
+        self.assertTrue(seen_write)
+
     def test_context_manager(self):
         s = self.SELECTOR()
         self.addCleanup(s.close)

--- a/Misc/NEWS.d/next/Library/2023-09-28-18-50-33.gh-issue-110038.nx_gCu.rst
+++ b/Misc/NEWS.d/next/Library/2023-09-28-18-50-33.gh-issue-110038.nx_gCu.rst
@@ -1,0 +1,3 @@
+Fixed an issue that caused :meth:`KqueueSelector.select` to not return all
+the ready events in some cases when a file descriptor is registered for both
+read and write.


### PR DESCRIPTION
With this change, each registered read or write filter is counted separately, even if it shares a fd.

As a side effect, a call to `KqueueSelector.select()` might return a separate entry with the same key, one with EVENT_READ and the other with EVENT_WRITE (and never both). This was already the case before, but it might become more evident now.

<!-- gh-issue-number: gh-110038 -->
* Issue: gh-110038
<!-- /gh-issue-number -->
