### PR TITLE
gh-109991: Remove obsolete NEWS entries for OpenSSL 3.0.10

### DIFF
--- a/Misc/NEWS.d/next/Tools-Demos/2023-08-12-13-18-15.gh-issue-107565.Tv22Ne.rst
+++ b/Misc/NEWS.d/next/Tools-Demos/2023-08-12-13-18-15.gh-issue-107565.Tv22Ne.rst
@@ -1,2 +1,0 @@
-Update multissltests and GitHub CI workflows to use OpenSSL 1.1.1v, 3.0.10,
-and 3.1.2.

--- a/Misc/NEWS.d/next/Windows/2023-09-05-10-08-47.gh-issue-107565.CIMftz.rst
+++ b/Misc/NEWS.d/next/Windows/2023-09-05-10-08-47.gh-issue-107565.CIMftz.rst
@@ -1,1 +1,0 @@
-Update Windows build to use OpenSSL 3.0.10.

--- a/Misc/NEWS.d/next/macOS/2023-08-12-13-33-57.gh-issue-107565.SJwqf4.rst
+++ b/Misc/NEWS.d/next/macOS/2023-08-12-13-33-57.gh-issue-107565.SJwqf4.rst
@@ -1,1 +1,0 @@
-Update macOS installer to use OpenSSL 3.0.10.


### PR DESCRIPTION


<!-- gh-issue-number: gh-109991 -->
* Issue: gh-109991
<!-- /gh-issue-number -->
