### PR TITLE
gh-109960: Remove test_pty timeout of 10 seconds

### DIFF
--- a/Lib/test/test_pty.py
+++ b/Lib/test/test_pty.py
@@ -80,16 +80,8 @@ def expectedFailureIfStdinIsTTY(fun):
 # because pty code is not too portable.
 class PtyTest(unittest.TestCase):
     def setUp(self):
-        old_alarm = signal.signal(signal.SIGALRM, self.handle_sig)
-        self.addCleanup(signal.signal, signal.SIGALRM, old_alarm)
-
         old_sighup = signal.signal(signal.SIGHUP, self.handle_sighup)
         self.addCleanup(signal.signal, signal.SIGHUP, old_sighup)
-
-        # isatty() and close() can hang on some platforms. Set an alarm
-        # before running the test to make sure we don't hang forever.
-        self.addCleanup(signal.alarm, 0)
-        signal.alarm(10)
 
         # Save original stdin window size.
         self.stdin_dim = None
@@ -100,9 +92,6 @@ class PtyTest(unittest.TestCase):
                                 self.stdin_dim)
             except tty.error:
                 pass
-
-    def handle_sig(self, sig, frame):
-        self.fail("isatty hung")
 
     @staticmethod
     def handle_sighup(signum, frame):


### PR DESCRIPTION
In 2003, test_pty got a hardcoded timeout of 10 seconds to prevent hanging on AIX & HPUX "if run after test_openpty": commit 7d8145268ee282f14d6adce9305dc3c1c7ffec14. Since 2003, test_pty was no longer reported to hang on AIX. But today, the test can fail simply because a CI is very busy running other tests in parallel. The timeout of 10 seconds is no longer needed, just remove it. Moreover, regrtest now has multiple built-in generic timeout mecanisms.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-109960 -->
* Issue: gh-109960
<!-- /gh-issue-number -->
