### PR TITLE
gh-109566: regrtest _add_python_opts() handles KeyboardInterrupt

### DIFF
--- a/Lib/test/libregrtest/utils.py
+++ b/Lib/test/libregrtest/utils.py
@@ -541,7 +541,7 @@ def display_header(use_resources: tuple[str, ...]):
         print(f"== resources ({len(use_resources)}): "
               f"{', '.join(sorted(use_resources))}")
     else:
-        print(f"== resources: (all disabled, use -u option)")
+        print("== resources: (all disabled, use -u option)")
 
     # This makes it easier to remember what to set in your local
     # environment when trying to reproduce a sanitizer failure.


### PR DESCRIPTION
In the subprocess code path, wait until the child process completes with a timeout of EXIT_TIMEOUT seconds.

Fix create_worker_process() regression: use start_new_session=True if USE_PROCESS_GROUP is true.

WorkerThread.wait_stopped() uses a timeout of 60 seconds, instead of 30 seconds.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-109566 -->
* Issue: gh-109566
<!-- /gh-issue-number -->
