### PR TITLE
gh-101100: Fix sphinx warnings in `library/difflib.rst`

### DIFF
--- a/Doc/library/difflib.rst
+++ b/Doc/library/difflib.rst
@@ -570,8 +570,8 @@ The :class:`SequenceMatcher` class has this constructor:
 
 The three methods that return the ratio of matching to total characters can give
 different results due to differing levels of approximation, although
-:meth:`quick_ratio` and :meth:`real_quick_ratio` are always at least as large as
-:meth:`ratio`:
+:meth:`~SequenceMatcher.quick_ratio` and :meth:`~SequenceMatcher.real_quick_ratio`
+are always at least as large as :meth:`~SequenceMatcher.ratio`:
 
    >>> s = SequenceMatcher(None, "abcd", "bcde")
    >>> s.ratio()
@@ -593,15 +593,15 @@ This example compares two strings, considering blanks to be "junk":
    ...                     "private Thread currentThread;",
    ...                     "private volatile Thread currentThread;")
 
-:meth:`ratio` returns a float in [0, 1], measuring the similarity of the
-sequences.  As a rule of thumb, a :meth:`ratio` value over 0.6 means the
+:meth:`~SequenceMatcher.ratio` returns a float in [0, 1], measuring the similarity of the
+sequences.  As a rule of thumb, a :meth:`~SequenceMatcher.ratio` value over 0.6 means the
 sequences are close matches:
 
    >>> print(round(s.ratio(), 3))
    0.866
 
 If you're only interested in where the sequences match,
-:meth:`get_matching_blocks` is handy:
+:meth:`~SequenceMatcher.get_matching_blocks` is handy:
 
    >>> for block in s.get_matching_blocks():
    ...     print("a[%d] and b[%d] match for %d elements" % block)
@@ -609,12 +609,12 @@ If you're only interested in where the sequences match,
    a[8] and b[17] match for 21 elements
    a[29] and b[38] match for 0 elements
 
-Note that the last tuple returned by :meth:`get_matching_blocks` is always a
-dummy, ``(len(a), len(b), 0)``, and this is the only case in which the last
+Note that the last tuple returned by :meth:`~SequenceMatcher.get_matching_blocks`
+is always a dummy, ``(len(a), len(b), 0)``, and this is the only case in which the last
 tuple element (number of elements matched) is ``0``.
 
 If you want to know how to change the first sequence into the second, use
-:meth:`get_opcodes`:
+:meth:`~SequenceMatcher.get_opcodes`:
 
    >>> for opcode in s.get_opcodes():
    ...     print("%6s a[%d:%d] b[%d:%d]" % opcode)
@@ -689,7 +689,7 @@ Differ Example
 
 This example compares two texts. First we set up the texts, sequences of
 individual single-line strings ending with newlines (such sequences can also be
-obtained from the :meth:`~io.BaseIO.readlines` method of file-like objects):
+obtained from the :meth:`~io.IOBase.readlines` method of file-like objects):
 
    >>> text1 = '''  1. Beautiful is better than ugly.
    ...   2. Explicit is better than implicit.

--- a/Doc/tools/.nitignore
+++ b/Doc/tools/.nitignore
@@ -53,7 +53,6 @@ Doc/library/csv.rst
 Doc/library/datetime.rst
 Doc/library/dbm.rst
 Doc/library/decimal.rst
-Doc/library/difflib.rst
 Doc/library/doctest.rst
 Doc/library/email.charset.rst
 Doc/library/email.compat32-message.rst


### PR DESCRIPTION
Before:

```
/Users/sobolev/Desktop/cpython/Doc/library/difflib.rst:571: WARNING: py:meth reference target not found: quick_ratio
/Users/sobolev/Desktop/cpython/Doc/library/difflib.rst:571: WARNING: py:meth reference target not found: real_quick_ratio
/Users/sobolev/Desktop/cpython/Doc/library/difflib.rst:571: WARNING: py:meth reference target not found: ratio
/Users/sobolev/Desktop/cpython/Doc/library/difflib.rst:596: WARNING: py:meth reference target not found: ratio
/Users/sobolev/Desktop/cpython/Doc/library/difflib.rst:596: WARNING: py:meth reference target not found: ratio
/Users/sobolev/Desktop/cpython/Doc/library/difflib.rst:603: WARNING: py:meth reference target not found: get_matching_blocks
/Users/sobolev/Desktop/cpython/Doc/library/difflib.rst:612: WARNING: py:meth reference target not found: get_matching_blocks
/Users/sobolev/Desktop/cpython/Doc/library/difflib.rst:616: WARNING: py:meth reference target not found: get_opcodes
/Users/sobolev/Desktop/cpython/Doc/library/difflib.rst:690: WARNING: py:meth reference target not found: io.BaseIO.readlines
```

<!-- gh-issue-number: gh-101100 -->
* Issue: gh-101100
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--110074.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->