### PR TITLE
gh-108716: make regen-global-objects no longer builds deepfreeze.c

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -140,9 +140,6 @@ jobs:
         run: make regen-configure
       - name: Build CPython
         run: |
-          # Deepfreeze will usually cause global objects to be added or removed,
-          # so we run it before regen-global-objects gets rum (in regen-all).
-          make regen-deepfreeze
           make -j4 regen-all
           make regen-stdlib-module-names
       - name: Check for changes

--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -492,9 +492,6 @@ OBJECT_OBJS=	\
 		Objects/weakrefobject.o \
 		@PERF_TRAMPOLINE_OBJ@
 
-DEEPFREEZE_C = Python/deepfreeze/deepfreeze.c
-DEEPFREEZE_OBJS = Python/deepfreeze/deepfreeze.o
-
 ##########################################################################
 # objects that get linked into the Python library
 LIBRARY_OBJS_OMIT_FROZEN=	\
@@ -1252,9 +1249,7 @@ regen-frozen: Tools/build/freeze_modules.py $(FROZEN_FILES_IN)
 ############################################################################
 # Deepfreeze targets
 
-.PHONY: regen-deepfreeze
-regen-deepfreeze: $(DEEPFREEZE_C)
-
+DEEPFREEZE_C = Python/deepfreeze/deepfreeze.c
 DEEPFREEZE_DEPS=$(srcdir)/Tools/build/deepfreeze.py Include/internal/pycore_global_strings.h $(FREEZE_MODULE_DEPS) $(FROZEN_FILES_OUT)
 
 # BEGIN: deepfreeze modules
@@ -1294,10 +1289,9 @@ regen-importlib: regen-frozen
 # Global objects
 
 # Dependencies which can add and/or remove _Py_ID() identifiers:
-# - deepfreeze.c
 # - "make clinic"
 .PHONY: regen-global-objects
-regen-global-objects: $(srcdir)/Tools/build/generate_global_objects.py $(DEEPFREEZE_C) clinic
+regen-global-objects: $(srcdir)/Tools/build/generate_global_objects.py clinic
 	$(PYTHON_FOR_REGEN) $(srcdir)/Tools/build/generate_global_objects.py
 
 ############################################################################


### PR DESCRIPTION
Remove more references to now unused Python/deepfreeze/deepfreeze.c.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-108716 -->
* Issue: gh-108716
<!-- /gh-issue-number -->
