### PR TITLE
[3.10] gh-109991: Update Windows build to use OpenSSL 1.1.1w

### DIFF
--- a/Misc/NEWS.d/next/Windows/2023-09-29-10-35-29.gh-issue-109991.GmuzGZ.rst
+++ b/Misc/NEWS.d/next/Windows/2023-09-29-10-35-29.gh-issue-109991.GmuzGZ.rst
@@ -1,4 +1,4 @@
 Windows builds now use OpenSSL 1.1.1w. Note that OpenSSL 1.1 has reached its
-end of life and no future fixes will be mode, and this version of Python is
+end of life and no future fixes will be made, and this version of Python is
 no longer receiving maintenance fixes and will not be updated to OpenSSL
 3.0.

--- a/Misc/NEWS.d/next/Windows/2023-09-29-10-35-29.gh-issue-109991.GmuzGZ.rst
+++ b/Misc/NEWS.d/next/Windows/2023-09-29-10-35-29.gh-issue-109991.GmuzGZ.rst
@@ -1,0 +1,4 @@
+Windows builds now use OpenSSL 1.1.1w. Note that OpenSSL 1.1 has reached its
+end of life and no future fixes will be mode, and this version of Python is
+no longer receiving maintenance fixes and will not be updated to OpenSSL
+3.0.

--- a/PCbuild/get_externals.bat
+++ b/PCbuild/get_externals.bat
@@ -53,7 +53,7 @@ echo.Fetching external libraries...
 set libraries=
 set libraries=%libraries%                                       bzip2-1.0.8
 if NOT "%IncludeLibffiSrc%"=="false" set libraries=%libraries%  libffi-3.3.0
-if NOT "%IncludeSSLSrc%"=="false" set libraries=%libraries%     openssl-1.1.1u
+if NOT "%IncludeSSLSrc%"=="false" set libraries=%libraries%     openssl-1.1.1w
 set libraries=%libraries%                                       sqlite-3.40.1.0
 if NOT "%IncludeTkinterSrc%"=="false" set libraries=%libraries% tcl-core-8.6.12.0
 if NOT "%IncludeTkinterSrc%"=="false" set libraries=%libraries% tk-8.6.12.0
@@ -77,7 +77,7 @@ echo.Fetching external binaries...
 
 set binaries=
 if NOT "%IncludeLibffi%"=="false"  set binaries=%binaries% libffi-3.3.0
-if NOT "%IncludeSSL%"=="false"     set binaries=%binaries% openssl-bin-1.1.1u
+if NOT "%IncludeSSL%"=="false"     set binaries=%binaries% openssl-bin-1.1.1w
 if NOT "%IncludeTkinter%"=="false" set binaries=%binaries% tcltk-8.6.12.0
 if NOT "%IncludeSSLSrc%"=="false"  set binaries=%binaries% nasm-2.11.06
 

--- a/PCbuild/python.props
+++ b/PCbuild/python.props
@@ -70,8 +70,8 @@
     <libffiDir Condition="$(libffiDir) == ''">$(ExternalsDir)libffi-3.3.0\</libffiDir>
     <libffiOutDir Condition="$(libffiOutDir) == ''">$(libffiDir)$(ArchName)\</libffiOutDir>
     <libffiIncludeDir Condition="$(libffiIncludeDir) == ''">$(libffiOutDir)include</libffiIncludeDir>
-    <opensslDir Condition="$(opensslDir) == ''">$(ExternalsDir)openssl-1.1.1u\</opensslDir>
-    <opensslOutDir Condition="$(opensslOutDir) == ''">$(ExternalsDir)openssl-bin-1.1.1u\$(ArchName)\</opensslOutDir>
+    <opensslDir Condition="$(opensslDir) == ''">$(ExternalsDir)openssl-1.1.1w\</opensslDir>
+    <opensslOutDir Condition="$(opensslOutDir) == ''">$(ExternalsDir)openssl-bin-1.1.1w\$(ArchName)\</opensslOutDir>
     <opensslIncludeDir Condition="$(opensslIncludeDir) == ''">$(opensslOutDir)include</opensslIncludeDir>
     <nasmDir Condition="$(nasmDir) == ''">$(ExternalsDir)\nasm-2.11.06\</nasmDir>
     <zlibDir Condition="$(zlibDir) == ''">$(ExternalsDir)\zlib-1.2.13\</zlibDir>


### PR DESCRIPTION
Requesting RM signoff on the new policy I've invented in the NEWS entry @pablogsal @ambv 

Walking a thin line between "we don't ship binaries" and "we still apply security fixes", but I think this one fits our policy best.

<!-- gh-issue-number: gh-109991 -->
* Issue: gh-109991
<!-- /gh-issue-number -->
