### PR TITLE
GH-101100: Fix reference warnings for ``__getitem__``

### DIFF
--- a/Doc/glossary.rst
+++ b/Doc/glossary.rst
@@ -636,7 +636,7 @@ Glossary
       iterables include all sequence types (such as :class:`list`, :class:`str`,
       and :class:`tuple`) and some non-sequence types like :class:`dict`,
       :term:`file objects <file object>`, and objects of any classes you define
-      with an :meth:`__iter__` method or with a :meth:`__getitem__` method
+      with an :meth:`__iter__` method or with a :meth:`~object.__getitem__` method
       that implements :term:`sequence` semantics.
 
       Iterables can be
@@ -1078,17 +1078,17 @@ Glossary
 
    sequence
       An :term:`iterable` which supports efficient element access using integer
-      indices via the :meth:`__getitem__` special method and defines a
+      indices via the :meth:`~object.__getitem__` special method and defines a
       :meth:`__len__` method that returns the length of the sequence.
       Some built-in sequence types are :class:`list`, :class:`str`,
       :class:`tuple`, and :class:`bytes`. Note that :class:`dict` also
-      supports :meth:`__getitem__` and :meth:`__len__`, but is considered a
+      supports :meth:`~object.__getitem__` and :meth:`__len__`, but is considered a
       mapping rather than a sequence because the lookups use arbitrary
       :term:`immutable` keys rather than integers.
 
       The :class:`collections.abc.Sequence` abstract base class
       defines a much richer interface that goes beyond just
-      :meth:`__getitem__` and :meth:`__len__`, adding :meth:`count`,
+      :meth:`~object.__getitem__` and :meth:`__len__`, adding :meth:`count`,
       :meth:`index`, :meth:`__contains__`, and
       :meth:`__reversed__`. Types that implement this expanded
       interface can be registered explicitly using

--- a/Doc/library/abc.rst
+++ b/Doc/library/abc.rst
@@ -154,7 +154,7 @@ a helper class :class:`ABC` to alternatively define ABCs through inheritance:
    Finally, the last line makes ``Foo`` a virtual subclass of ``MyIterable``,
    even though it does not define an :meth:`~iterator.__iter__` method (it uses
    the old-style iterable protocol, defined in terms of :meth:`__len__` and
-   :meth:`__getitem__`).  Note that this will not make ``get_iterator``
+   :meth:`~object.__getitem__`).  Note that this will not make ``get_iterator``
    available as a method of ``Foo``, so it is provided separately.
 
 

--- a/Doc/library/collections.abc.rst
+++ b/Doc/library/collections.abc.rst
@@ -192,7 +192,7 @@ ABC                            Inherits from          Abstract Methods        Mi
 .. [2] Checking ``isinstance(obj, Iterable)`` detects classes that are
    registered as :class:`Iterable` or that have an :meth:`__iter__`
    method, but it does not detect classes that iterate with the
-   :meth:`__getitem__` method.  The only reliable way to determine
+   :meth:`~object.__getitem__` method.  The only reliable way to determine
    whether an object is :term:`iterable` is to call ``iter(obj)``.
 
 
@@ -222,7 +222,7 @@ Collections Abstract Base Classes -- Detailed Descriptions
 
    Checking ``isinstance(obj, Iterable)`` detects classes that are registered
    as :class:`Iterable` or that have an :meth:`__iter__` method, but it does
-   not detect classes that iterate with the :meth:`__getitem__` method.
+   not detect classes that iterate with the :meth:`~object.__getitem__` method.
    The only reliable way to determine whether an object is :term:`iterable`
    is to call ``iter(obj)``.
 
@@ -262,8 +262,8 @@ Collections Abstract Base Classes -- Detailed Descriptions
 
    Implementation note: Some of the mixin methods, such as
    :meth:`__iter__`, :meth:`__reversed__` and :meth:`index`, make
-   repeated calls to the underlying :meth:`__getitem__` method.
-   Consequently, if :meth:`__getitem__` is implemented with constant
+   repeated calls to the underlying :meth:`~object.__getitem__` method.
+   Consequently, if :meth:`~object.__getitem__` is implemented with constant
    access speed, the mixin methods will have linear performance;
    however, if the underlying method is linear (as it would be with a
    linked list), the mixins will have quadratic performance and will

--- a/Doc/library/collections.rst
+++ b/Doc/library/collections.rst
@@ -743,12 +743,12 @@ stack manipulations such as ``dup``, ``drop``, ``swap``, ``over``, ``pick``,
         If calling :attr:`default_factory` raises an exception this exception is
         propagated unchanged.
 
-        This method is called by the :meth:`__getitem__` method of the
+        This method is called by the :meth:`~object.__getitem__` method of the
         :class:`dict` class when the requested key is not found; whatever it
-        returns or raises is then returned or raised by :meth:`__getitem__`.
+        returns or raises is then returned or raised by :meth:`~object.__getitem__`.
 
         Note that :meth:`__missing__` is *not* called for any operations besides
-        :meth:`__getitem__`. This means that :meth:`get` will, like normal
+        :meth:`~object.__getitem__`. This means that :meth:`get` will, like normal
         dictionaries, return ``None`` as a default rather than using
         :attr:`default_factory`.
 

--- a/Doc/library/email.compat32-message.rst
+++ b/Doc/library/email.compat32-message.rst
@@ -367,7 +367,7 @@ Here are the methods of the :class:`Message` class:
    .. method:: get(name, failobj=None)
 
       Return the value of the named header field.  This is identical to
-      :meth:`__getitem__` except that optional *failobj* is returned if the
+      :meth:`~object.__getitem__` except that optional *failobj* is returned if the
       named header is missing (defaults to ``None``).
 
    Here are some additional useful methods:

--- a/Doc/library/email.message.rst
+++ b/Doc/library/email.message.rst
@@ -247,7 +247,7 @@ message objects.
    .. method:: get(name, failobj=None)
 
       Return the value of the named header field.  This is identical to
-      :meth:`__getitem__` except that optional *failobj* is returned if the
+      :meth:`~object.__getitem__` except that optional *failobj* is returned if the
       named header is missing (*failobj* defaults to ``None``).
 
 

--- a/Doc/library/functions.rst
+++ b/Doc/library/functions.rst
@@ -983,7 +983,7 @@ are always available.  They are listed here in alphabetical order.
    differently depending on the presence of the second argument. Without a
    second argument, *object* must be a collection object which supports the
    :term:`iterable` protocol (the :meth:`__iter__` method), or it must support
-   the sequence protocol (the :meth:`__getitem__` method with integer arguments
+   the sequence protocol (the :meth:`~object.__getitem__` method with integer arguments
    starting at ``0``).  If it does not support either of those protocols,
    :exc:`TypeError` is raised. If the second argument, *sentinel*, is given,
    then *object* must be a callable object.  The iterator created in this case
@@ -1563,7 +1563,7 @@ are always available.  They are listed here in alphabetical order.
 
    Return a reverse :term:`iterator`.  *seq* must be an object which has
    a :meth:`__reversed__` method or supports the sequence protocol (the
-   :meth:`__len__` method and the :meth:`__getitem__` method with integer
+   :meth:`__len__` method and the :meth:`~object.__getitem__` method with integer
    arguments starting at ``0``).
 
 

--- a/Doc/library/mailbox.rst
+++ b/Doc/library/mailbox.rst
@@ -167,7 +167,7 @@ Supported mailbox formats are Maildir, mbox, MH, Babyl, and MMDF.
       Return a representation of the message corresponding to *key*. If no such
       message exists, *default* is returned if the method was called as
       :meth:`get` and a :exc:`KeyError` exception is raised if the method was
-      called as :meth:`__getitem__`. The message is represented as an instance
+      called as :meth:`~object.__getitem__`. The message is represented as an instance
       of the appropriate format-specific :class:`Message` subclass unless a
       custom message factory was specified when the :class:`Mailbox` instance
       was initialized.

--- a/Doc/library/operator.rst
+++ b/Doc/library/operator.rst
@@ -306,7 +306,7 @@ expect a function argument.
               itemgetter(*items)
 
    Return a callable object that fetches *item* from its operand using the
-   operand's :meth:`__getitem__` method.  If multiple items are specified,
+   operand's :meth:`~object.__getitem__` method.  If multiple items are specified,
    returns a tuple of lookup values.  For example:
 
    * After ``f = itemgetter(2)``, the call ``f(r)`` returns ``r[2]``.
@@ -326,7 +326,7 @@ expect a function argument.
                   return tuple(obj[item] for item in items)
           return g
 
-   The items can be any type accepted by the operand's :meth:`__getitem__`
+   The items can be any type accepted by the operand's :meth:`~object.__getitem__`
    method.  Dictionaries accept any :term:`hashable` value.  Lists, tuples, and
    strings accept an index or a slice:
 

--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -2266,7 +2266,7 @@ expression support in the :mod:`re` module).
 
    Return a copy of the string in which each character has been mapped through
    the given translation table.  The table must be an object that implements
-   indexing via :meth:`__getitem__`, typically a :term:`mapping` or
+   indexing via :meth:`~object.__getitem__`, typically a :term:`mapping` or
    :term:`sequence`.  When indexed by a Unicode ordinal (an integer), the
    table object can do any of the following: return a Unicode ordinal or a
    string, to map the character to one or more other characters; return

--- a/Doc/library/unittest.mock.rst
+++ b/Doc/library/unittest.mock.rst
@@ -1707,7 +1707,7 @@ Keywords can be used in the :func:`patch.dict` call to set values in the diction
 :func:`patch.dict` can be used with dictionary like objects that aren't actually
 dictionaries. At the very minimum they must support item getting, setting,
 deleting and either iteration or membership test. This corresponds to the
-magic methods :meth:`__getitem__`, :meth:`__setitem__`, :meth:`__delitem__` and either
+magic methods :meth:`~object.__getitem__`, :meth:`__setitem__`, :meth:`__delitem__` and either
 :meth:`__iter__` or :meth:`__contains__`.
 
     >>> class Container:

--- a/Doc/library/wsgiref.rst
+++ b/Doc/library/wsgiref.rst
@@ -180,7 +180,7 @@ also provides these miscellaneous utilities:
           print(chunk)
 
    .. versionchanged:: 3.11
-      Support for :meth:`__getitem__` method has been removed.
+      Support for :meth:`~object.__getitem__` method has been removed.
 
 
 :mod:`wsgiref.headers` -- WSGI response header tools
@@ -201,7 +201,7 @@ manipulation of WSGI response headers using a mapping-like interface.
    an empty list.
 
    :class:`Headers` objects support typical mapping operations including
-   :meth:`__getitem__`, :meth:`get`, :meth:`__setitem__`, :meth:`setdefault`,
+   :meth:`~object.__getitem__`, :meth:`get`, :meth:`__setitem__`, :meth:`setdefault`,
    :meth:`__delitem__` and :meth:`__contains__`.  For each of
    these methods, the key is the header name (treated case-insensitively), and the
    value is the first value associated with that header name.  Setting a header

--- a/Doc/library/xml.dom.pulldom.rst
+++ b/Doc/library/xml.dom.pulldom.rst
@@ -115,7 +115,7 @@ DOMEventStream Objects
 .. class:: DOMEventStream(stream, parser, bufsize)
 
    .. versionchanged:: 3.11
-      Support for :meth:`__getitem__` method has been removed.
+      Support for :meth:`~object.__getitem__` method has been removed.
 
    .. method:: getEvent()
 

--- a/Doc/reference/compound_stmts.rst
+++ b/Doc/reference/compound_stmts.rst
@@ -1058,7 +1058,7 @@ subject value:
 .. note:: Key-value pairs are matched using the two-argument form of the mapping
    subject's ``get()`` method.  Matched key-value pairs must already be present
    in the mapping, and not created on-the-fly via :meth:`__missing__` or
-   :meth:`__getitem__`.
+   :meth:`~object.__getitem__`.
 
 In simple terms ``{KEY1: P1, KEY2: P2, ... }`` matches only if all the following
 happens:

--- a/Doc/reference/expressions.rst
+++ b/Doc/reference/expressions.rst
@@ -889,7 +889,7 @@ to the index so that, for example, ``x[-1]`` selects the last item of ``x``. The
 resulting value must be a nonnegative integer less than the number of items in
 the sequence, and the subscription selects the item whose index is that value
 (counting from zero). Since the support for negative indices and slicing
-occurs in the object's :meth:`__getitem__` method, subclasses overriding
+occurs in the object's :meth:`~object.__getitem__` method, subclasses overriding
 this method will need to explicitly add that support.
 
 .. index::
@@ -944,7 +944,7 @@ slice list contains no proper slice).
    single: step (slice object attribute)
 
 The semantics for a slicing are as follows.  The primary is indexed (using the
-same :meth:`__getitem__` method as
+same :meth:`~object.__getitem__` method as
 normal subscription) with a key that is constructed from the slice list, as
 follows.  If the slice list contains at least one comma, the key is a tuple
 containing the conversion of the slice items; otherwise, the conversion of the
@@ -1670,7 +1670,7 @@ If an exception is raised during the iteration, it is as if :keyword:`in` raised
 that exception.
 
 Lastly, the old-style iteration protocol is tried: if a class defines
-:meth:`__getitem__`, ``x in y`` is ``True`` if and only if there is a non-negative
+:meth:`~object.__getitem__`, ``x in y`` is ``True`` if and only if there is a non-negative
 integer index *i* such that ``x is y[i] or x == y[i]``, and no lower integer index
 raises the :exc:`IndexError` exception.  (If any other exception is raised, it is as
 if :keyword:`in` raised that exception).

--- a/Doc/whatsnew/2.2.rst
+++ b/Doc/whatsnew/2.2.rst
@@ -424,22 +424,22 @@ Another significant addition to 2.2 is an iteration interface at both the C and
 Python levels.  Objects can define how they can be looped over by callers.
 
 In Python versions up to 2.1, the usual way to make ``for item in obj`` work is
-to define a :meth:`__getitem__` method that looks something like this::
+to define a :meth:`~object.__getitem__` method that looks something like this::
 
    def __getitem__(self, index):
        return <next item>
 
-:meth:`__getitem__` is more properly used to define an indexing operation on an
+:meth:`~object.__getitem__` is more properly used to define an indexing operation on an
 object so that you can write ``obj[5]`` to retrieve the sixth element.  It's a
 bit misleading when you're using this only to support :keyword:`for` loops.
 Consider some file-like object that wants to be looped over; the *index*
 parameter is essentially meaningless, as the class probably assumes that a
-series of :meth:`__getitem__` calls will be made with *index* incrementing by
-one each time.  In other words, the presence of the :meth:`__getitem__` method
+series of :meth:`~object.__getitem__` calls will be made with *index* incrementing by
+one each time.  In other words, the presence of the :meth:`~object.__getitem__` method
 doesn't mean that using ``file[5]``  to randomly access the sixth element will
 work, though it really should.
 
-In Python 2.2, iteration can be implemented separately, and :meth:`__getitem__`
+In Python 2.2, iteration can be implemented separately, and :meth:`~object.__getitem__`
 methods can be limited to classes that really do support random access.  The
 basic idea of iterators is  simple.  A new built-in function, ``iter(obj)``
 or ``iter(C, sentinel)``, is used to get an iterator. ``iter(obj)`` returns

--- a/Doc/whatsnew/2.3.rst
+++ b/Doc/whatsnew/2.3.rst
@@ -925,7 +925,7 @@ Deletion is more straightforward::
    >>> a
    [1, 3]
 
-One can also now pass slice objects to the :meth:`__getitem__` methods of the
+One can also now pass slice objects to the :meth:`~object.__getitem__` methods of the
 built-in sequences::
 
    >>> range(10).__getitem__(slice(0, 5, 2))
@@ -1596,7 +1596,7 @@ complete list of changes, or look through the CVS logs for all the details.
   module.
 
   Adding the mix-in as a superclass provides the full dictionary interface
-  whenever the class defines :meth:`__getitem__`, :meth:`__setitem__`,
+  whenever the class defines :meth:`~object.__getitem__`, :meth:`__setitem__`,
   :meth:`__delitem__`, and :meth:`keys`. For example::
 
      >>> import UserDict

--- a/Doc/whatsnew/3.8.rst
+++ b/Doc/whatsnew/3.8.rst
@@ -1653,7 +1653,7 @@ Deprecated
   deprecated and will be prohibited in Python 3.9.
   (Contributed by Elvis Pranskevichus in :issue:`34075`.)
 
-* The :meth:`__getitem__` methods of :class:`xml.dom.pulldom.DOMEventStream`,
+* The :meth:`~object.__getitem__` methods of :class:`xml.dom.pulldom.DOMEventStream`,
   :class:`wsgiref.util.FileWrapper` and :class:`fileinput.FileInput` have been
   deprecated.
 

--- a/Misc/NEWS.d/3.11.0a1.rst
+++ b/Misc/NEWS.d/3.11.0a1.rst
@@ -1720,7 +1720,7 @@ Improve the speed and accuracy of statistics.pvariance().
 .. nonce: WI9zQY
 .. section: Library
 
-Remove :meth:`__getitem__` methods of
+Remove :meth:`~object.__getitem__` methods of
 :class:`xml.dom.pulldom.DOMEventStream`, :class:`wsgiref.util.FileWrapper`
 and :class:`fileinput.FileInput`, deprecated since Python 3.9.
 

--- a/Misc/NEWS.d/3.8.0a1.rst
+++ b/Misc/NEWS.d/3.8.0a1.rst
@@ -3592,7 +3592,7 @@ Python 3.5.
 .. nonce: V8Ou3K
 .. section: Library
 
-Deprecate :meth:`__getitem__` methods of
+Deprecate :meth:`~object.__getitem__` methods of
 :class:`xml.dom.pulldom.DOMEventStream`, :class:`wsgiref.util.FileWrapper`
 and :class:`fileinput.FileInput`.
 


### PR DESCRIPTION


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--110118.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->

<!-- gh-issue-number: gh-101100 -->
* Issue: gh-101100
<!-- /gh-issue-number -->
