### PR TITLE
gh-109566: PCbuild/rt.bat now uses --fast-ci

### DIFF
--- a/PCbuild/rt.bat
+++ b/PCbuild/rt.bat
@@ -32,7 +32,7 @@ set pcbuild=%~dp0
 set suffix=
 set qmode=
 set dashO=
-set regrtestargs=--fail-env-changed --fail-rerun
+set regrtestargs=--fast-ci
 set exe=
 
 :CheckOpts


### PR DESCRIPTION
Replace "--fail-env-changed --fail-rerun" with "--fast-ci".

Tools/buildbot/test.bat pass --slow-ci which has the priority over --fast-ci.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-109566 -->
* Issue: gh-109566
<!-- /gh-issue-number -->
