### PR TITLE
gh-109566: regrtest --fast-ci no longer enables --nowindow

### DIFF
--- a/Lib/test/libregrtest/cmdline.py
+++ b/Lib/test/libregrtest/cmdline.py
@@ -4,8 +4,6 @@ import shlex
 import sys
 from test.support import os_helper
 
-from .utils import MS_WINDOWS
-
 
 USAGE = """\
 python -m test [options] [test_name1 [test_name2 ...]]
@@ -414,7 +412,7 @@ def _parse_args(args, **kwargs):
         # Similar to options:
         #
         #     -j0 --randomize --fail-env-changed --fail-rerun --rerun
-        #     --slowest --verbose3 --nowindows
+        #     --slowest --verbose3
         if ns.use_mp is None:
             ns.use_mp = 0
         ns.randomize = True
@@ -424,8 +422,6 @@ def _parse_args(args, **kwargs):
             ns.rerun = True
         ns.print_slow = True
         ns.verbose3 = True
-        if MS_WINDOWS:
-            ns.nowindows = True  # Silence alerts under Windows
     else:
         ns._add_python_opts = False
 

--- a/Lib/test/test_regrtest.py
+++ b/Lib/test/test_regrtest.py
@@ -376,8 +376,6 @@ class ParseArgsTestCase(unittest.TestCase):
 
     def check_ci_mode(self, args, use_resources, rerun=True):
         ns = cmdline._parse_args(args)
-        if utils.MS_WINDOWS:
-            self.assertTrue(ns.nowindows)
 
         # Check Regrtest attributes which are more reliable than Namespace
         # which has an unclear API


### PR DESCRIPTION
The --nowindow option is deprecated and does nothing but logs a warning.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-109566 -->
* Issue: gh-109566
<!-- /gh-issue-number -->
