### PR TITLE
gh-110119: Temporarily skip test_cppext on --disable-gil builds.

### DIFF
--- a/Lib/test/test_cppext/__init__.py
+++ b/Lib/test/test_cppext/__init__.py
@@ -14,6 +14,10 @@ SOURCE = os.path.join(os.path.dirname(__file__), 'extension.cpp')
 SETUP = os.path.join(os.path.dirname(__file__), 'setup.py')
 
 
+# gh-110119: pip does not currently support 't' in the ABI flag use by
+# --disable-gil builds. Once it does, we can remove this skip.
+@unittest.skipIf(sysconfig.get_config_var('Py_NOGIL') == 1,
+                 'test does not work with --disable-gil')
 @support.requires_subprocess()
 class TestCPPExt(unittest.TestCase):
     @support.requires_resource('cpu')


### PR DESCRIPTION
The current version of pip does not support "t" in the ABI flags. Skip the test in `--disable-gil` builds until we can update pip.

<!-- gh-issue-number: gh-110119 -->
* Issue: gh-110119
<!-- /gh-issue-number -->
