### PR TITLE
gh-109917, gh-105829: Fix concurrent.futures _ThreadWakeup.wakeup()

### DIFF
--- a/Lib/test/test_concurrent_futures/test_deadlock.py
+++ b/Lib/test/test_concurrent_futures/test_deadlock.py
@@ -1,6 +1,4 @@
 import contextlib
-import queue
-import signal
 import sys
 import time
 import unittest
@@ -203,7 +201,7 @@ class ExecutorDeadlockTest:
         self.executor.shutdown(wait=True)
         with self.executor_type(max_workers=2,
                                 mp_context=self.get_context()) as executor:
-            self.executor = executor  # Allow clean up in fail_on_deadlock
+            self.executor = executor  # Allow clean up in _fail_on_deadlock
             f = executor.submit(_crash, delay=.1)
             executor.shutdown(wait=True)
             with self.assertRaises(BrokenProcessPool):
@@ -216,7 +214,7 @@ class ExecutorDeadlockTest:
         self.executor.shutdown(wait=True)
         with self.executor_type(max_workers=2,
                                 mp_context=self.get_context()) as executor:
-            self.executor = executor  # Allow clean up in fail_on_deadlock
+            self.executor = executor  # Allow clean up in _fail_on_deadlock
 
             # Start the executor and get the executor_manager_thread to collect
             # the threads and avoid dangling thread that should be cleaned up
@@ -244,78 +242,11 @@ class ExecutorDeadlockTest:
         data = "a" * support.PIPE_MAX_SIZE
         with self.executor_type(max_workers=2,
                                 mp_context=self.get_context()) as executor:
-            self.executor = executor  # Allow clean up in fail_on_deadlock
+            self.executor = executor  # Allow clean up in _fail_on_deadlock
             with self.assertRaises(BrokenProcessPool):
                 list(executor.map(_crash_with_data, [data] * 10))
 
         executor.shutdown(wait=True)
-
-    def test_gh105829_should_not_deadlock_if_wakeup_pipe_full(self):
-        # Issue #105829: The _ExecutorManagerThread wakeup pipe could
-        # fill up and block. See: https://github.com/python/cpython/issues/105829
-
-        # Lots of cargo culting while writing this test, apologies if
-        # something is really stupid...
-
-        self.executor.shutdown(wait=True)
-
-        if not hasattr(signal, 'alarm'):
-            raise unittest.SkipTest(
-                "Tested platform does not support the alarm signal")
-
-        def timeout(_signum, _frame):
-            import faulthandler
-            faulthandler.dump_traceback()
-
-            raise RuntimeError("timed out while submitting jobs?")
-
-        thread_run = futures.process._ExecutorManagerThread.run
-        def mock_run(self):
-            # Delay thread startup so the wakeup pipe can fill up and block
-            time.sleep(3)
-            thread_run(self)
-
-        class MockWakeup(_ThreadWakeup):
-            """Mock wakeup object to force the wakeup to block"""
-            def __init__(self):
-                super().__init__()
-                self._dummy_queue = queue.Queue(maxsize=1)
-
-            def wakeup(self):
-                self._dummy_queue.put(None, block=True)
-                super().wakeup()
-
-            def clear(self):
-                try:
-                    while True:
-                        self._dummy_queue.get_nowait()
-                except queue.Empty:
-                    super().clear()
-
-        with (unittest.mock.patch.object(futures.process._ExecutorManagerThread,
-                                         'run', mock_run),
-              unittest.mock.patch('concurrent.futures.process._ThreadWakeup',
-                                  MockWakeup)):
-            with self.executor_type(max_workers=2,
-                                    mp_context=self.get_context()) as executor:
-                self.executor = executor  # Allow clean up in fail_on_deadlock
-
-                job_num = 100
-                job_data = range(job_num)
-
-                # Need to use sigalarm for timeout detection because
-                # Executor.submit is not guarded by any timeout (both
-                # self._work_ids.put(self._queue_count) and
-                # self._executor_manager_thread_wakeup.wakeup() might
-                # timeout, maybe more?). In this specific case it was
-                # the wakeup call that deadlocked on a blocking pipe.
-                old_handler = signal.signal(signal.SIGALRM, timeout)
-                try:
-                    signal.alarm(int(self.TIMEOUT))
-                    self.assertEqual(job_num, len(list(executor.map(int, job_data))))
-                finally:
-                    signal.alarm(0)
-                    signal.signal(signal.SIGALRM, old_handler)
 
 
 create_executor_tests(globals(), ExecutorDeadlockTest,

--- a/Lib/test/test_concurrent_futures/test_process_pool.py
+++ b/Lib/test/test_concurrent_futures/test_process_pool.py
@@ -254,7 +254,7 @@ class ProcessPoolExecutorTest(ExecutorTest):
             thread_wakeup._wakeup_msg = b'x' * msg_len
             msg_size = 4 + len(thread_wakeup._wakeup_msg)
 
-            njob = pipe_size // msg_size
+            njob = pipe_size // msg_size + 10  # Add some margin
             job_data = range(njob)
             if support.verbose:
                 print(f"run {njob:,} jobs")


### PR DESCRIPTION
Remove test_gh105829_should_not_deadlock_if_wakeup_pipe_full() of test_concurrent_futures.test_deadlock. The test is no longer relevant.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-105829 -->
* Issue: gh-105829
<!-- /gh-issue-number -->


<!-- gh-issue-number: gh-109917 -->
* Issue: gh-109917
<!-- /gh-issue-number -->
