### PR TITLE
gh-110138: Improve grammar in idiomatic usage of ``__main__.py``

### DIFF
--- a/Doc/library/__main__.rst
+++ b/Doc/library/__main__.rst
@@ -239,8 +239,8 @@ Idiomatic Usage
 ^^^^^^^^^^^^^^^
 
 The contents of ``__main__.py`` typically isn't fenced with
-``if __name__ == '__main__'`` blocks.  Instead, those files are kept short,
-functions to execute from other modules.  Those other modules can then be
+``if __name__ == '__main__'`` blocks.  Instead, those files are kept
+short and import functions to execute from other modules.  Those other modules can then be
 easily unit-tested and are properly reusable.
 
 If used, an ``if __name__ == '__main__'`` block will still work as expected

--- a/Doc/library/__main__.rst
+++ b/Doc/library/__main__.rst
@@ -238,8 +238,8 @@ package.  For more details, see :ref:`intra-package-references` in the
 Idiomatic Usage
 ^^^^^^^^^^^^^^^
 
-The contents of ``__main__.py`` typically isn't fenced with
-``if __name__ == '__main__'`` blocks.  Instead, those files are kept
+The content of ``__main__.py`` typically isn't fenced with an
+``if __name__ == '__main__'`` block.  Instead, those files are kept
 short and import functions to execute from other modules.  Those other modules can then be
 easily unit-tested and are properly reusable.
 


### PR DESCRIPTION


<!-- gh-issue-number: gh-110138 -->
* Issue: gh-110138
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--110142.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->