### PR TITLE
gh-38807: fix race condition in Lib/trace.py

### DIFF
--- a/Lib/trace.py
+++ b/Lib/trace.py
@@ -258,8 +258,7 @@ class CoverageResults:
                 modulename = _modname(filename)
             else:
                 dir = coverdir
-                if not os.path.exists(dir):
-                    os.makedirs(dir)
+                os.makedirs(dir, exist_ok=True)
                 modulename = _fullmodname(filename)
 
             # If desired, get a list of the line numbers which represent

--- a/Misc/NEWS.d/next/Library/2023-09-22-22-17-45.gh-issue-38807.m9McRN.rst
+++ b/Misc/NEWS.d/next/Library/2023-09-22-22-17-45.gh-issue-38807.m9McRN.rst
@@ -1,0 +1,3 @@
+Fix race condition in :mod:`trace`. Instead of checking if a directory
+exists and creating it, directly call :func:`os.makedirs` with the kwarg
+``exist_ok=True``.


### PR DESCRIPTION
Instead of checking if a directory does not exist and thereafter creating it, directly call `os.makedirs` with the `exist_ok` kwarg.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-38807 -->
* Issue: gh-38807
<!-- /gh-issue-number -->
