### PR TITLE
gh-110164: regrtest disables random if SOURCE_DATE_EPOCH

### DIFF
--- a/Lib/test/libregrtest/main.py
+++ b/Lib/test/libregrtest/main.py
@@ -106,8 +106,6 @@ class Regrtest:
         self.fail_env_changed: bool = ns.fail_env_changed
         self.fail_rerun: bool = ns.fail_rerun
         self.forever: bool = ns.forever
-        self.randomize: bool = ns.randomize
-        self.random_seed: int | None = ns.random_seed
         self.output_on_failure: bool = ns.verbose3
         self.timeout: float | None = ns.timeout
         if ns.huntrleaks:
@@ -128,6 +126,13 @@ class Regrtest:
         self.coverage: bool = ns.trace
         self.coverage_dir: StrPath | None = ns.coverdir
         self.tmp_dir: StrPath | None = ns.tempdir
+
+        # Randomize
+        self.randomize: bool = ns.randomize
+        self.random_seed: int | None = ns.random_seed
+        if 'SOURCE_DATE_EPOCH' in os.environ:
+            self.randomize = False
+            self.random_seed = None
 
         # tests
         self.first_runtests: RunTests | None = None

--- a/Lib/test/test_regrtest.py
+++ b/Lib/test/test_regrtest.py
@@ -148,6 +148,14 @@ class ParseArgsTestCase(unittest.TestCase):
                 ns = self.parse_args([opt])
                 self.assertTrue(ns.randomize)
 
+        with os_helper.EnvironmentVarGuard() as env:
+            env['SOURCE_DATE_EPOCH'] = '1'
+
+            ns = self.parse_args(['--randomize'])
+            regrtest = main.Regrtest(ns)
+            self.assertFalse(regrtest.randomize)
+            self.assertIsNone(regrtest.random_seed)
+
     def test_randseed(self):
         ns = self.parse_args(['--randseed', '12345'])
         self.assertEqual(ns.random_seed, 12345)

--- a/Misc/NEWS.d/next/Core and Builtins/2023-10-01-02-58-00.gh-issue-110164.z7TMCq.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2023-10-01-02-58-00.gh-issue-110164.z7TMCq.rst
@@ -1,0 +1,2 @@
+regrtest: If the ``SOURCE_DATE_EPOCH`` environment variable is defined,
+regrtest now disables tests randomization. Patch by Victor Stinner.


### PR DESCRIPTION
If the SOURCE_DATE_EPOCH environment variable is defined, regrtest now disables randomization of tests.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-110164 -->
* Issue: gh-110164
<!-- /gh-issue-number -->
