### PR TITLE
[3.12] gh-109649: Enhance os.cpu_count() documentation

### DIFF
--- a/Doc/library/os.rst
+++ b/Doc/library/os.rst
@@ -5188,6 +5188,10 @@ Miscellaneous System Information
    Return the number of logical CPUs in the system. Returns ``None`` if
    undetermined.
 
+   This number is not equivalent to the number of logical CPUs the current
+   process can use. ``len(os.sched_getaffinity(0))`` gets the number of logical
+   CPUs the calling thread of the current process is restricted to
+
    .. versionadded:: 3.4
 
 

--- a/Doc/library/os.rst
+++ b/Doc/library/os.rst
@@ -5141,8 +5141,10 @@ operating system.
 
 .. function:: sched_getaffinity(pid, /)
 
-   Return the set of CPUs the process with PID *pid* (or the current process
-   if zero) is restricted to.
+   Return the set of CPUs the process with PID *pid* is restricted to.
+
+   If *pid* is zero, return the set of CPUs the calling thread of the current
+   process is restricted to.
 
 
 .. _os-path:
@@ -5183,12 +5185,8 @@ Miscellaneous System Information
 
 .. function:: cpu_count()
 
-   Return the number of CPUs in the system. Returns ``None`` if undetermined.
-
-   This number is not equivalent to the number of CPUs the current process can
-   use.  The number of usable CPUs can be obtained with
-   ``len(os.sched_getaffinity(0))``
-
+   Return the number of logical CPUs in the system. Returns ``None`` if
+   undetermined.
 
    .. versionadded:: 3.4
 

--- a/Lib/test/test_posix.py
+++ b/Lib/test/test_posix.py
@@ -1205,6 +1205,7 @@ class PosixTester(unittest.TestCase):
     @requires_sched_affinity
     def test_sched_setaffinity(self):
         mask = posix.sched_getaffinity(0)
+        self.addCleanup(posix.sched_setaffinity, 0, list(mask))
         if len(mask) > 1:
             # Empty masks are forbidden
             mask.pop()


### PR DESCRIPTION
* Doc: Specify that os.cpu_count() counts *logicial* CPUs.
* Doc: Specify that os.sched_getaffinity(0) is related to the calling thread.
* Fix test_posix.test_sched_getaffinity(): restore the old CPU mask when the test completes!

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-109649 -->
* Issue: gh-109649
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--110169.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->