### PR TITLE
gh-110180: Remove unused `_PickleUsingNameMixin` class from `typing`

### DIFF
--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -937,13 +937,6 @@ def _is_typevar_like(x: Any) -> bool:
     return isinstance(x, (TypeVar, ParamSpec)) or _is_unpacked_typevartuple(x)
 
 
-class _PickleUsingNameMixin:
-    """Mixin enabling pickling based on self.__name__."""
-
-    def __reduce__(self):
-        return self.__name__
-
-
 def _typevar_subst(self, arg):
     msg = "Parameters to generic types must be types."
     arg = _type_check(arg, msg, is_argument=True)


### PR DESCRIPTION
Fixes #110180

<!-- gh-issue-number: gh-110180 -->
* Issue: gh-110180
<!-- /gh-issue-number -->
