### PR TITLE
gh-109870: Combine exec calls in dataclass

### DIFF
--- a/Lib/dataclasses.py
+++ b/Lib/dataclasses.py
@@ -878,9 +878,9 @@ def _set_new_attribute(cls, name, value):
 def _hash_set_none(cls, fields, globals):
     return None
 
-def _hash_add(cls, fields, globals):
-    flds = [f for f in fields if (f.compare if f.hash is None else f.hash)]
-    return _set_qualname(cls, _hash_fn(flds, globals))
+class _HASH_ADD:
+    pass
+_hash_add = _HASH_ADD
 
 def _hash_exception(cls, fields, globals):
     # Raise an exception.


### PR DESCRIPTION
As mentioned in the gh issue, this is my attempt to combine the various exec calls (init, repr, eq, etc) into one, resulting in a increasing speedup with each additional exec call avoided. Around 1.1-1.22 speedup.

I don't expect this to be taken as-is. Mainly wanted to get something up so @ericvsmith has something cleaned up to look at.

<!-- gh-issue-number: gh-109870 -->
* Issue: gh-109870
<!-- /gh-issue-number -->
