### PR TITLE
gh-110178: Use fewer weakrefs in test_typing.py

### DIFF
--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -550,7 +550,7 @@ class TypeVarTests(BaseTestCase):
             with self.subTest(cls=cls):
                 vals = weakref.WeakValueDictionary()
 
-                for x in range(100000):
+                for x in range(10):
                     vals[x] = cls(str(x))
                 del vals
 


### PR DESCRIPTION
Confirmed that without the C changes from #108517, this test still segfaults with only 10 weakrefs.

<!-- gh-issue-number: gh-110178 -->
* Issue: gh-110178
<!-- /gh-issue-number -->
