### PR TITLE
gh-110196: Fix ipaddress.IPv6Address.__reduce__

### DIFF
--- a/Lib/ipaddress.py
+++ b/Lib/ipaddress.py
@@ -1970,6 +1970,9 @@ class IPv6Address(_BaseV6, _BaseAddress):
             return False
         return self._scope_id == getattr(other, '_scope_id', None)
 
+    def __reduce__(self):
+        return (self.__class__, (str(self),))
+
     @property
     def scope_id(self):
         """Identifier of a particular zone of the address's scope.

--- a/Lib/test/test_ipaddress.py
+++ b/Lib/test/test_ipaddress.py
@@ -551,7 +551,7 @@ class AddressTestCase_v6(BaseTestCase, CommonTestMixin_v6):
     def test_copy(self):
         addr = self.factory('2001:db8::%scope')
         self.assertEqual(addr, copy.copy(addr))
-        self.assertEqual(addr, copy.deepcopy(addr))        
+        self.assertEqual(addr, copy.deepcopy(addr))
 
 
 class NetmaskTestMixin_v4(CommonTestMixin_v4):

--- a/Lib/test/test_ipaddress.py
+++ b/Lib/test/test_ipaddress.py
@@ -543,6 +543,7 @@ class AddressTestCase_v6(BaseTestCase, CommonTestMixin_v6):
 
     def test_pickle(self):
         self.pickle_test('2001:db8::')
+        self.pickle_test('2001:db8::%scope')
 
     def test_weakref(self):
         weakref.ref(self.factory('2001:db8::'))

--- a/Lib/test/test_ipaddress.py
+++ b/Lib/test/test_ipaddress.py
@@ -4,6 +4,7 @@
 """Unittest for ipaddress module."""
 
 
+import copy
 import unittest
 import re
 import contextlib
@@ -546,6 +547,11 @@ class AddressTestCase_v6(BaseTestCase, CommonTestMixin_v6):
     def test_weakref(self):
         weakref.ref(self.factory('2001:db8::'))
         weakref.ref(self.factory('2001:db8::%scope'))
+
+    def test_copy(self):
+        addr = self.factory('2001:db8::%scope')
+        self.assertEqual(addr, copy.copy(addr))
+        self.assertEqual(addr, copy.deepcopy(addr))        
 
 
 class NetmaskTestMixin_v4(CommonTestMixin_v4):

--- a/Misc/NEWS.d/next/Library/2023-10-02-05-23-27.gh-issue-110196.djwt0z.rst
+++ b/Misc/NEWS.d/next/Library/2023-10-02-05-23-27.gh-issue-110196.djwt0z.rst
@@ -1,0 +1,1 @@
+Add ``__reduce__`` method to :class:`IPv6Address` in order to keep ``scope_id``


### PR DESCRIPTION
`IPv6Address` should keep `scope_id`. Inheriting `__reduce__` from `_BaseAddress` will only keep the ip address.

<!-- gh-issue-number: gh-110196 -->
* Issue: gh-110196
<!-- /gh-issue-number -->
