### PR TITLE
gh-101100: Fix sphinx warnings in `library/socketserver.rst`

### DIFF
--- a/Doc/library/socketserver.rst
+++ b/Doc/library/socketserver.rst
@@ -116,23 +116,28 @@ server is the address family.
    :class:`ForkingMixIn` and the Forking classes mentioned below are
    only available on POSIX platforms that support :func:`~os.fork`.
 
-   :meth:`!ForkingMixIn.server_close` waits until all child
-   processes complete, except if
-   :attr:`!ForkingMixIn.block_on_close` attribute is false.
+   .. attribute:: block_on_close
 
-   :meth:`!ThreadingMixIn.server_close` waits until all non-daemon
-   threads complete, except if
-   :attr:`!ThreadingMixIn.block_on_close` attribute is false. Use
-   daemonic threads by setting
-   :data:`!ThreadingMixIn.daemon_threads` to ``True`` to not wait until threads
-   complete.
+      :meth:`ForkingMixIn.server_close <BaseServer.server_close>`
+      waits until all child processes complete, except if
+      :attr:`block_on_close` attribute is ``False``.
+
+      :meth:`ThreadingMixIn.server_close <BaseServer.server_close>`
+      waits until all non-daemon threads complete, except if
+      :attr:`block_on_close` attribute is ``False``.
+
+   .. attribute:: daemon_threads
+
+      For :class:`ThreadingMixIn` use daemonic threads by setting
+      :data:`ThreadingMixIn.daemon_threads <daemon_threads>`
+      to ``True`` to not wait until threads complete.
 
    .. versionchanged:: 3.7
 
-      :meth:`!ForkingMixIn.server_close` and
-      :meth:`!ThreadingMixIn.server_close` now waits until all
+      :meth:`ForkingMixIn.server_close <BaseServer.server_close>` and
+      :meth:`ThreadingMixIn.server_close <BaseServer.server_close>` now waits until all
       child processes and non-daemonic threads complete.
-      Add a new :attr:`!ForkingMixIn.block_on_close` class
+      Add a new :attr:`ForkingMixIn.block_on_close <block_on_close>` class
       attribute to opt-in for the pre-3.7 behaviour.
 
 

--- a/Doc/library/socketserver.rst
+++ b/Doc/library/socketserver.rst
@@ -116,23 +116,23 @@ server is the address family.
    :class:`ForkingMixIn` and the Forking classes mentioned below are
    only available on POSIX platforms that support :func:`~os.fork`.
 
-   :meth:`socketserver.ForkingMixIn.server_close` waits until all child
+   :meth:`!ForkingMixIn.server_close` waits until all child
    processes complete, except if
-   :attr:`socketserver.ForkingMixIn.block_on_close` attribute is false.
+   :attr:`!ForkingMixIn.block_on_close` attribute is false.
 
-   :meth:`socketserver.ThreadingMixIn.server_close` waits until all non-daemon
+   :meth:`!ThreadingMixIn.server_close` waits until all non-daemon
    threads complete, except if
-   :attr:`socketserver.ThreadingMixIn.block_on_close` attribute is false. Use
+   :attr:`!ThreadingMixIn.block_on_close` attribute is false. Use
    daemonic threads by setting
-   :data:`ThreadingMixIn.daemon_threads` to ``True`` to not wait until threads
+   :data:`!ThreadingMixIn.daemon_threads` to ``True`` to not wait until threads
    complete.
 
    .. versionchanged:: 3.7
 
-      :meth:`socketserver.ForkingMixIn.server_close` and
-      :meth:`socketserver.ThreadingMixIn.server_close` now waits until all
+      :meth:`!ForkingMixIn.server_close` and
+      :meth:`!ThreadingMixIn.server_close` now waits until all
       child processes and non-daemonic threads complete.
-      Add a new :attr:`socketserver.ForkingMixIn.block_on_close` class
+      Add a new :attr:`!ForkingMixIn.block_on_close` class
       attribute to opt-in for the pre-3.7 behaviour.
 
 
@@ -412,13 +412,13 @@ Request Handler Objects
 
       This function must do all the work required to service a request.  The
       default implementation does nothing.  Several instance attributes are
-      available to it; the request is available as :attr:`self.request`; the client
-      address as :attr:`self.client_address`; and the server instance as
-      :attr:`self.server`, in case it needs access to per-server information.
+      available to it; the request is available as :attr:`request`; the client
+      address as :attr:`client_address`; and the server instance as
+      :attr:`server`, in case it needs access to per-server information.
 
-      The type of :attr:`self.request` is different for datagram or stream
-      services.  For stream services, :attr:`self.request` is a socket object; for
-      datagram services, :attr:`self.request` is a pair of string and socket.
+      The type of :attr:`request` is different for datagram or stream
+      services.  For stream services, :attr:`request` is a socket object; for
+      datagram services, :attr:`request` is a pair of string and socket.
 
 
    .. method:: finish()
@@ -428,20 +428,42 @@ Request Handler Objects
       raises an exception, this function will not be called.
 
 
+   .. attribute:: request
+
+      The *new* :class:`socket.socket` object
+      to be used to communicate with the client.
+
+
+   .. attribute:: client_address
+
+      Client address returned by :meth:`BaseServer.get_request`.
+
+
+   .. attribute:: server
+
+      :class:`BaseServer` object used for handling the request.
+
+
 .. class:: StreamRequestHandler
            DatagramRequestHandler
 
    These :class:`BaseRequestHandler` subclasses override the
    :meth:`~BaseRequestHandler.setup` and :meth:`~BaseRequestHandler.finish`
-   methods, and provide :attr:`self.rfile` and :attr:`self.wfile` attributes.
-   The :attr:`self.rfile` and :attr:`self.wfile` attributes can be
-   read or written, respectively, to get the request data or return data
-   to the client.
-   The :attr:`!rfile` attributes support the :class:`io.BufferedIOBase` readable interface,
-   and :attr:`!wfile` attributes support the :class:`!io.BufferedIOBase` writable interface.
+   methods, and provide :attr:`rfile` and :attr:`wfile` attributes.
+
+   .. attribute:: rfile
+
+      A file object from which receives the request is read.
+      Support the :class:`io.BufferedIOBase` readable interface.
+
+   .. attribute:: wfile
+
+      A file object to which the reply is written.
+      Support the :class:`io.BufferedIOBase` writable interface
+
 
    .. versionchanged:: 3.6
-      :attr:`StreamRequestHandler.wfile` also supports the
+      :attr:`wfile` also supports the
       :class:`io.BufferedIOBase` writable interface.
 
 

--- a/Doc/tools/.nitignore
+++ b/Doc/tools/.nitignore
@@ -108,7 +108,6 @@ Doc/library/shelve.rst
 Doc/library/signal.rst
 Doc/library/smtplib.rst
 Doc/library/socket.rst
-Doc/library/socketserver.rst
 Doc/library/ssl.rst
 Doc/library/stdtypes.rst
 Doc/library/string.rst


### PR DESCRIPTION
Before:

```
/Users/sobolev/Desktop/cpython/Doc/library/socketserver.rst:119: WARNING: py:meth reference target not found: socketserver.ForkingMixIn.server_close
/Users/sobolev/Desktop/cpython/Doc/library/socketserver.rst:119: WARNING: py:attr reference target not found: socketserver.ForkingMixIn.block_on_close
/Users/sobolev/Desktop/cpython/Doc/library/socketserver.rst:123: WARNING: py:meth reference target not found: socketserver.ThreadingMixIn.server_close
/Users/sobolev/Desktop/cpython/Doc/library/socketserver.rst:123: WARNING: py:attr reference target not found: socketserver.ThreadingMixIn.block_on_close
/Users/sobolev/Desktop/cpython/Doc/library/socketserver.rst:123: WARNING: py:data reference target not found: ThreadingMixIn.daemon_threads
/Users/sobolev/Desktop/cpython/Doc/library/socketserver.rst:132: WARNING: py:meth reference target not found: socketserver.ForkingMixIn.server_close
/Users/sobolev/Desktop/cpython/Doc/library/socketserver.rst:132: WARNING: py:meth reference target not found: socketserver.ThreadingMixIn.server_close
/Users/sobolev/Desktop/cpython/Doc/library/socketserver.rst:132: WARNING: py:attr reference target not found: socketserver.ForkingMixIn.block_on_close
/Users/sobolev/Desktop/cpython/Doc/library/socketserver.rst:413: WARNING: py:attr reference target not found: self.request
/Users/sobolev/Desktop/cpython/Doc/library/socketserver.rst:413: WARNING: py:attr reference target not found: self.client_address
/Users/sobolev/Desktop/cpython/Doc/library/socketserver.rst:413: WARNING: py:attr reference target not found: self.server
/Users/sobolev/Desktop/cpython/Doc/library/socketserver.rst:419: WARNING: py:attr reference target not found: self.request
/Users/sobolev/Desktop/cpython/Doc/library/socketserver.rst:419: WARNING: py:attr reference target not found: self.request
/Users/sobolev/Desktop/cpython/Doc/library/socketserver.rst:419: WARNING: py:attr reference target not found: self.request
/Users/sobolev/Desktop/cpython/Doc/library/socketserver.rst:434: WARNING: py:attr reference target not found: self.rfile
/Users/sobolev/Desktop/cpython/Doc/library/socketserver.rst:434: WARNING: py:attr reference target not found: self.wfile
/Users/sobolev/Desktop/cpython/Doc/library/socketserver.rst:434: WARNING: py:attr reference target not found: self.rfile
/Users/sobolev/Desktop/cpython/Doc/library/socketserver.rst:434: WARNING: py:attr reference target not found: self.wfile
/Users/sobolev/Desktop/cpython/Doc/library/socketserver.rst:444: WARNING: py:attr reference target not found: StreamRequestHandler.wfile
```

<!-- gh-issue-number: gh-101100 -->
* Issue: gh-101100
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--110207.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->