### PR TITLE
Docs: bump Pygments to fix contrast ratios to meet WCAG AA guidelines

### DIFF
--- a/Doc/constraints.txt
+++ b/Doc/constraints.txt
@@ -10,8 +10,7 @@ colorama<0.5
 imagesize<1.5
 Jinja2<3.2
 packaging<24
-# Pygments==2.15.0 breaks CI
-Pygments<2.16,!=2.15.0
+Pygments>=2.16.1,<3
 requests<3
 snowballstemmer<3
 sphinxcontrib-applehelp<1.1


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

Already updated in [`Doc/requirements-oldest-sphinx.txt`](https://github.com/python/cpython/blob/29b875bb93099171aeb7a60cd18d4e1f4ea3c1db/Doc/requirements-oldest-sphinx.txt#L26), used for testing on the CI.

Let's also allow it for the real docs, so we can include the dark mode contrast fixed by https://github.com/pygments/pygments/pull/2448 in Pygments 2.16.

For example:

# Before

<img width="815" alt="image" src="https://github.com/pygments/pygments/assets/1324225/0bbd0790-9994-469b-8713-a5ff09313bd0">

# After

<img width="812" alt="image" src="https://github.com/pygments/pygments/assets/1324225/1b528649-8a96-47c3-bc98-5fbbc9ed55e2">




<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--110208.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->