### PR TITLE
[3.11] GH-92584: Move installation schemes overview to sysconfig docs (GH-108018)

### DIFF
--- a/Doc/library/site.rst
+++ b/Doc/library/site.rst
@@ -199,7 +199,7 @@ Module contents
    :file:`~/Library/Python/{X.Y}` for macOS framework builds, and
    :file:`{%APPDATA%}\\Python` for Windows.  This value is used by Distutils to
    compute the installation directories for scripts, data files, Python modules,
-   etc. for the :ref:`user installation scheme <inst-alt-install-user>`.
+   etc. for the :ref:`user installation scheme <sysconfig-user-scheme>`.
    See also :envvar:`PYTHONUSERBASE`.
 
 

--- a/Doc/library/sysconfig.rst
+++ b/Doc/library/sysconfig.rst
@@ -20,6 +20,7 @@ The :mod:`sysconfig` module provides access to Python's configuration
 information like the list of installation paths and the configuration variables
 relevant for the current platform.
 
+
 Configuration variables
 -----------------------
 
@@ -60,6 +61,7 @@ Example of usage::
    >>> sysconfig.get_config_vars('AR', 'CXX')
    ['ar', 'g++']
 
+
 .. _installation_paths:
 
 Installation paths
@@ -68,27 +70,24 @@ Installation paths
 Python uses an installation scheme that differs depending on the platform and on
 the installation options.  These schemes are stored in :mod:`sysconfig` under
 unique identifiers based on the value returned by :const:`os.name`.
-
-Every new component that is installed using :mod:`!distutils` or a
-Distutils-based system will follow the same scheme to copy its file in the right
-places.
+The schemes are used by package installers to determine where to copy files to.
 
 Python currently supports nine schemes:
 
 - *posix_prefix*: scheme for POSIX platforms like Linux or macOS.  This is
   the default scheme used when Python or a component is installed.
-- *posix_home*: scheme for POSIX platforms used when a *home* option is used
-  upon installation.  This scheme is used when a component is installed through
-  Distutils with a specific home prefix.
-- *posix_user*: scheme for POSIX platforms used when a component is installed
-  through Distutils and the *user* option is used.  This scheme defines paths
-  located under the user home directory.
+- *posix_home*: scheme for POSIX platforms, when the *home* option is used.
+  This scheme defines paths located under a specific home prefix.
+- *posix_user*: scheme for POSIX platforms, when the *user* option is used.
+  This scheme defines paths located under the user's home directory
+  (:const:`site.USER_BASE`).
 - *posix_venv*: scheme for :mod:`Python virtual environments <venv>` on POSIX
   platforms; by default it is the same as *posix_prefix*.
-- *nt*: scheme for NT platforms like Windows.
-- *nt_user*: scheme for NT platforms, when the *user* option is used.
-- *nt_venv*: scheme for :mod:`Python virtual environments <venv>` on NT
-  platforms; by default it is the same as *nt*.
+- *nt*: scheme for Windows.
+  This is the default scheme used when Python or a component is installed.
+- *nt_user*: scheme for Windows, when the *user* option is used.
+- *nt_venv*: scheme for :mod:`Python virtual environments <venv>` on Windows;
+  by default it is the same as *nt*.
 - *venv*: a scheme with values from either *posix_venv* or *nt_venv* depending
   on the platform Python runs on.
 - *osx_framework_user*: scheme for macOS, when the *user* option is used.
@@ -101,7 +100,7 @@ identifier.  Python currently uses eight paths:
 - *platstdlib*: directory containing the standard Python library files that are
   platform-specific.
 - *platlib*: directory for site-specific, platform-specific files.
-- *purelib*: directory for site-specific, non-platform-specific files.
+- *purelib*: directory for site-specific, non-platform-specific files ('pure' Python).
 - *include*: directory for non-platform-specific header files for
   the Python C-API.
 - *platinclude*: directory for platform-specific header files for
@@ -109,7 +108,157 @@ identifier.  Python currently uses eight paths:
 - *scripts*: directory for script files.
 - *data*: directory for data files.
 
-:mod:`sysconfig` provides some functions to determine these paths.
+
+.. _sysconfig-user-scheme:
+
+User scheme
+---------------
+
+This scheme is designed to be the most convenient solution for users that don't
+have write permission to the global site-packages directory or don't want to
+install into it.
+
+Files will be installed into subdirectories of :const:`site.USER_BASE` (written
+as :file:`{userbase}` hereafter).  This scheme installs pure Python modules and
+extension modules in the same location (also known as :const:`site.USER_SITE`).
+
+``posix_user``
+^^^^^^^^^^^^^^
+
+============== ===========================================================
+Path           Installation directory
+============== ===========================================================
+*stdlib*       :file:`{userbase}/lib/python{X.Y}`
+*platstdlib*   :file:`{userbase}/lib/python{X.Y}`
+*platlib*      :file:`{userbase}/lib/python{X.Y}/site-packages`
+*purelib*      :file:`{userbase}/lib/python{X.Y}/site-packages`
+*include*      :file:`{userbase}/include/python{X.Y}`
+*scripts*      :file:`{userbase}/bin`
+*data*         :file:`{userbase}`
+============== ===========================================================
+
+``nt_user``
+^^^^^^^^^^^
+
+============== ===========================================================
+Path           Installation directory
+============== ===========================================================
+*stdlib*       :file:`{userbase}\\Python{XY}`
+*platstdlib*   :file:`{userbase}\\Python{XY}`
+*platlib*      :file:`{userbase}\\Python{XY}\\site-packages`
+*purelib*      :file:`{userbase}\\Python{XY}\\site-packages`
+*include*      :file:`{userbase}\\Python{XY}\\Include`
+*scripts*      :file:`{userbase}\\Python{XY}\\Scripts`
+*data*         :file:`{userbase}`
+============== ===========================================================
+
+``osx_framework_user``
+^^^^^^^^^^^^^^^^^^^^^^
+
+============== ===========================================================
+Path           Installation directory
+============== ===========================================================
+*stdlib*       :file:`{userbase}/lib/python`
+*platstdlib*   :file:`{userbase}/lib/python`
+*platlib*      :file:`{userbase}/lib/python/site-packages`
+*purelib*      :file:`{userbase}/lib/python/site-packages`
+*include*      :file:`{userbase}/include/python{X.Y}`
+*scripts*      :file:`{userbase}/bin`
+*data*         :file:`{userbase}`
+============== ===========================================================
+
+
+.. _sysconfig-home-scheme:
+
+Home scheme
+-----------
+
+The idea behind the "home scheme" is that you build and maintain a personal
+stash of Python modules.  This scheme's name is derived from the idea of a
+"home" directory on Unix, since it's not unusual for a Unix user to make their
+home directory have a layout similar to :file:`/usr/` or :file:`/usr/local/`.
+This scheme can be used by anyone, regardless of the operating system they
+are installing for.
+
+``posix_home``
+^^^^^^^^^^^^^^
+
+============== ===========================================================
+Path           Installation directory
+============== ===========================================================
+*stdlib*       :file:`{home}/lib/python`
+*platstdlib*   :file:`{home}/lib/python`
+*platlib*      :file:`{home}/lib/python`
+*purelib*      :file:`{home}/lib/python`
+*include*      :file:`{home}/include/python`
+*platinclude*  :file:`{home}/include/python`
+*scripts*      :file:`{home}/bin`
+*data*         :file:`{home}`
+============== ===========================================================
+
+
+.. _sysconfig-prefix-scheme:
+
+Prefix scheme
+-------------
+
+The "prefix scheme" is useful when you wish to use one Python installation to
+perform the build/install (i.e., to run the setup script), but install modules
+into the third-party module directory of a different Python installation (or
+something that looks like a different Python installation).  If this sounds a
+trifle unusual, it is---that's why the user and home schemes come before.  However,
+there are at least two known cases where the prefix scheme will be useful.
+
+First, consider that many Linux distributions put Python in :file:`/usr`, rather
+than the more traditional :file:`/usr/local`.  This is entirely appropriate,
+since in those cases Python is part of "the system" rather than a local add-on.
+However, if you are installing Python modules from source, you probably want
+them to go in :file:`/usr/local/lib/python2.{X}` rather than
+:file:`/usr/lib/python2.{X}`.
+
+Another possibility is a network filesystem where the name used to write to a
+remote directory is different from the name used to read it: for example, the
+Python interpreter accessed as :file:`/usr/local/bin/python` might search for
+modules in :file:`/usr/local/lib/python2.{X}`, but those modules would have to
+be installed to, say, :file:`/mnt/{@server}/export/lib/python2.{X}`.
+
+``posix_prefix``
+^^^^^^^^^^^^^^^^
+
+============== ==========================================================
+Path           Installation directory
+============== ==========================================================
+*stdlib*       :file:`{prefix}/lib/python{X.Y}`
+*platstdlib*   :file:`{prefix}/lib/python{X.Y}`
+*platlib*      :file:`{prefix}/lib/python{X.Y}/site-packages`
+*purelib*      :file:`{prefix}/lib/python{X.Y}/site-packages`
+*include*      :file:`{prefix}/include/python{X.Y}`
+*platinclude*  :file:`{prefix}/include/python{X.Y}`
+*scripts*      :file:`{prefix}/bin`
+*data*         :file:`{prefix}`
+============== ==========================================================
+
+``nt``
+^^^^^^
+
+============== ==========================================================
+Path           Installation directory
+============== ==========================================================
+*stdlib*       :file:`{prefix}\\Lib`
+*platstdlib*   :file:`{prefix}\\Lib`
+*platlib*      :file:`{prefix}\\Lib\\site-packages`
+*purelib*      :file:`{prefix}\\Lib\\site-packages`
+*include*      :file:`{prefix}\\Include`
+*platinclude*  :file:`{prefix}\\Include`
+*scripts*      :file:`{prefix}\\Scripts`
+*data*         :file:`{prefix}`
+============== ==========================================================
+
+
+Installation path functions
+---------------------------
+
+:mod:`sysconfig` provides some functions to determine these installation paths.
 
 .. function:: get_scheme_names()
 

--- a/Doc/using/cmdline.rst
+++ b/Doc/using/cmdline.rst
@@ -797,8 +797,8 @@ conflict.
 
    Defines the :data:`user base directory <site.USER_BASE>`, which is used to
    compute the path of the :data:`user site-packages directory <site.USER_SITE>`
-   and :ref:`Distutils installation paths <inst-alt-install-user>` for
-   ``python setup.py install --user``.
+   and :ref:`installation paths <sysconfig-user-scheme>` for
+   ``python -m pip install --user``.
 
    .. seealso::
 


### PR DESCRIPTION


<!-- gh-issue-number: gh-92584 -->
* Issue: gh-92584
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--110214.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->