### PR TITLE
gh-109653: Fix py312 regression in the import time of `random`

### DIFF
--- a/Lib/random.py
+++ b/Lib/random.py
@@ -65,7 +65,7 @@ import _random
 
 try:
     # hashlib is pretty heavy to load, try lean internal module first
-    from _sha512 import sha512 as _sha512
+    from _sha2 import sha512 as _sha512
 except ImportError:
     # fallback to official implementation
     from hashlib import sha512 as _sha512

--- a/Misc/NEWS.d/next/Library/2023-10-02-15-40-10.gh-issue-109653.iB0peK.rst
+++ b/Misc/NEWS.d/next/Library/2023-10-02-15-40-10.gh-issue-109653.iB0peK.rst
@@ -1,2 +1,2 @@
-Reduce the import time of :mod:`random` by around 60%. Patch by Alex
+Fix a Python 3.12 regression in the import time of :mod:`random`. Patch by Alex
 Waygood.

--- a/Misc/NEWS.d/next/Library/2023-10-02-15-40-10.gh-issue-109653.iB0peK.rst
+++ b/Misc/NEWS.d/next/Library/2023-10-02-15-40-10.gh-issue-109653.iB0peK.rst
@@ -1,0 +1,2 @@
+Reduce the import time of :mod:`random` by around 60%. Patch by Alex
+Waygood.


### PR DESCRIPTION
As an optimisation to reduce the import time of the module, `random` first tries to import `sha512` from the internal `_sha512` module before falling back to `hashlib`. The problem, however, is that Python no longer has a `_sha512` module! It was removed in https://github.com/python/cpython/commit/0b13575e74ff3321364a3389eda6b4e92792afe1, by @gpshead. That means we're currently always falling back to the slow path in `random.py`, leading to the import time of `random` being far slower than it should be.

Importing `sha512` from the correct module in the fast path cuts 60% off the import time of `random`.

<!-- gh-issue-number: gh-109653 -->
* Issue: gh-109653
<!-- /gh-issue-number -->
