### PR TITLE
gh-76785: Module-level Fixes for test.support.interpreters

### DIFF
--- a/Lib/test/support/interpreters.py
+++ b/Lib/test/support/interpreters.py
@@ -122,9 +122,9 @@ class _ChannelEnd:
 
     def __init__(self, cid):
         if self._end == 'send':
-            cid = _channels._channel_id(cid, send=True)
+            cid = _channels._channel_id(cid, send=True, force=True)
         elif self._end == 'recv':
-            cid = _channels._channel_id(cid, recv=True)
+            cid = _channels._channel_id(cid, recv=True, force=True)
         else:
             raise NotImplementedError(self._end)
         self._id = cid

--- a/Lib/test/support/interpreters.py
+++ b/Lib/test/support/interpreters.py
@@ -171,6 +171,9 @@ class RecvChannel(_ChannelEnd):
         else:
             return _channels.recv(self._id, default)
 
+    def close(self):
+        _channels.close(self._id, recv=True)
+
 
 class SendChannel(_ChannelEnd):
     """The sending end of a cross-interpreter channel."""
@@ -196,3 +199,6 @@ class SendChannel(_ChannelEnd):
         # None.  This should be fixed when channel_send_wait() is added.
         # See bpo-32604 and gh-19829.
         return _channels.send(self._id, obj)
+
+    def close(self):
+        _channels.close(self._id, send=True)

--- a/Lib/test/support/interpreters.py
+++ b/Lib/test/support/interpreters.py
@@ -7,7 +7,8 @@ import _xxinterpchannels as _channels
 # aliases:
 from _xxsubinterpreters import is_shareable
 from _xxinterpchannels import (
-    ChannelError, ChannelNotFoundError, ChannelEmptyError,
+    ChannelError, ChannelNotFoundError, ChannelClosedError,
+    ChannelEmptyError, ChannelNotEmptyError,
 )
 
 

--- a/Lib/test/test_interpreters.py
+++ b/Lib/test/test_interpreters.py
@@ -574,6 +574,22 @@ class TestChannels(TestBase):
         after = set(interpreters.list_all_channels())
         self.assertEqual(after, created)
 
+    def test_shareable(self):
+        rch, sch = interpreters.create_channel()
+
+        self.assertTrue(
+            interpreters.is_shareable(rch))
+        self.assertTrue(
+            interpreters.is_shareable(sch))
+
+        sch.send_nowait(rch)
+        sch.send_nowait(sch)
+        rch2 = rch.recv()
+        sch2 = rch.recv()
+
+        self.assertEqual(rch2, rch)
+        self.assertEqual(sch2, sch)
+
 
 class TestRecvChannelAttrs(TestBase):
 

--- a/Modules/_xxinterpchannelsmodule.c
+++ b/Modules/_xxinterpchannelsmodule.c
@@ -1803,21 +1803,12 @@ done:
     return res;
 }
 
+static PyTypeObject * _get_current_channel_end_type(int end);
+
 static PyObject *
 _channel_from_cid(PyObject *cid, int end)
 {
-    PyObject *highlevel = PyImport_ImportModule("interpreters");
-    if (highlevel == NULL) {
-        PyErr_Clear();
-        highlevel = PyImport_ImportModule("test.support.interpreters");
-        if (highlevel == NULL) {
-            return NULL;
-        }
-    }
-    const char *clsname = (end == CHANNEL_RECV) ? "RecvChannel" :
-                                                  "SendChannel";
-    PyObject *cls = PyObject_GetAttrString(highlevel, clsname);
-    Py_DECREF(highlevel);
+    PyObject *cls = (PyObject *)_get_current_channel_end_type(end);
     if (cls == NULL) {
         return NULL;
     }

--- a/Modules/_xxinterpchannelsmodule.c
+++ b/Modules/_xxinterpchannelsmodule.c
@@ -218,6 +218,21 @@ get_module_state(PyObject *mod)
     return state;
 }
 
+static module_state *
+_get_current_module_state(void)
+{
+    PyObject *mod = _get_current_module();
+    if (mod == NULL) {
+        // XXX import it?
+        PyErr_SetString(PyExc_RuntimeError,
+                        MODULE_NAME " module not imported yet");
+        return NULL;
+    }
+    module_state *state = get_module_state(mod);
+    Py_DECREF(mod);
+    return state;
+}
+
 static int
 traverse_module_state(module_state *state, visitproc visit, void *arg)
 {

--- a/Modules/_xxinterpchannelsmodule.c
+++ b/Modules/_xxinterpchannelsmodule.c
@@ -1993,9 +1993,21 @@ _get_current_channel_end_type(int end)
         cls = state->recv_channel_type;
     }
     if (cls == NULL) {
-        // XXX Use some other exception type?
-        PyErr_SetString(PyExc_RuntimeError, "interpreters module not imported yet");
-        return NULL;
+        PyObject *highlevel = PyImport_ImportModule("interpreters");
+        if (highlevel == NULL) {
+            PyErr_Clear();
+            highlevel = PyImport_ImportModule("test.support.interpreters");
+            if (highlevel == NULL) {
+                return NULL;
+            }
+        }
+        if (end == CHANNEL_SEND) {
+            cls = state->send_channel_type;
+        }
+        else {
+            cls = state->recv_channel_type;
+        }
+        assert(cls != NULL);
     }
     return cls;
 }


### PR DESCRIPTION
* add `RecvChannel.close()` and `SendChannel.close()`
* make `RecvChannel` and `SendChannel` shareable
* expose `ChannelEmptyError` and `ChannelNotEmptyError`

<!-- gh-issue-number: gh-76785 -->
* Issue: gh-76785
<!-- /gh-issue-number -->
