### PR TITLE
gh-109191: Fix build with newer editline

### DIFF
--- a/Misc/NEWS.d/next/Build/2023-10-05-11-46-20.gh-issue-109191.imUkVN.rst
+++ b/Misc/NEWS.d/next/Build/2023-10-05-11-46-20.gh-issue-109191.imUkVN.rst
@@ -1,1 +1,1 @@
-Fix compile error when building with recent versions of libedit
+Fix compile error when building with recent versions of libedit.

--- a/Misc/NEWS.d/next/Build/2023-10-05-11-46-20.gh-issue-109191.imUkVN.rst
+++ b/Misc/NEWS.d/next/Build/2023-10-05-11-46-20.gh-issue-109191.imUkVN.rst
@@ -1,0 +1,1 @@
+Fix compile error when building with recent versions of libedit

--- a/Modules/readline.c
+++ b/Modules/readline.c
@@ -446,7 +446,7 @@ readline_set_completion_display_matches_hook_impl(PyObject *module,
        default completion display. */
     rl_completion_display_matches_hook =
         readlinestate_global->completion_display_matches_hook ?
-#if defined(_RL_FUNCTION_TYPEDEF)
+#if defined(HAVE_RL_COMPDISP_FUNC_T)
         (rl_compdisp_func_t *)on_completion_display_matches_hook : 0;
 #else
         (VFunction *)on_completion_display_matches_hook : 0;

--- a/configure
+++ b/configure
@@ -24632,9 +24632,7 @@ fi
 if test "x$ac_cv_type_rl_compdisp_func_t" = xyes
 then :
 
-
 printf "%s\n" "#define HAVE_RL_COMPDISP_FUNC_T 1" >>confdefs.h
-
 
 fi
 

--- a/configure
+++ b/configure
@@ -24618,6 +24618,27 @@ printf "%s\n" "#define HAVE_RL_APPEND_HISTORY 1" >>confdefs.h
 
 fi
 
+    # in readline as well as newer editline (April 2023)
+    ac_fn_c_check_type "$LINENO" "rl_compdisp_func_t" "ac_cv_type_rl_compdisp_func_t" "
+      #include <stdio.h> /* Must be first for Gnu Readline */
+      #ifdef WITH_EDITLINE
+      # include <editline/readline.h>
+      #else
+      # include <readline/readline.h>
+      # include <readline/history.h>
+      #endif
+
+"
+if test "x$ac_cv_type_rl_compdisp_func_t" = xyes
+then :
+
+
+printf "%s\n" "#define HAVE_RL_COMPDISP_FUNC_T 1" >>confdefs.h
+
+
+fi
+
+
 
 
 CFLAGS=$save_CFLAGS

--- a/configure.ac
+++ b/configure.ac
@@ -5992,6 +5992,11 @@ AS_VAR_IF([with_readline], [no], [
       AC_DEFINE([HAVE_RL_APPEND_HISTORY], [1], [Define if readline supports append_history])
     ])
 
+    # in readline as well as newer editline (April 2023)
+    AC_CHECK_TYPE([rl_compdisp_func_t], [
+      AC_DEFINE([HAVE_RL_COMPDISP_FUNC_T], [1], [Define if readline supports rl_compdisp_func_t])
+    ], [], [readline_includes])
+
     m4_undefine([readline_includes])
   ])dnl WITH_SAVE_ENV()
 ])

--- a/configure.ac
+++ b/configure.ac
@@ -5993,9 +5993,11 @@ AS_VAR_IF([with_readline], [no], [
     ])
 
     # in readline as well as newer editline (April 2023)
-    AC_CHECK_TYPE([rl_compdisp_func_t], [
-      AC_DEFINE([HAVE_RL_COMPDISP_FUNC_T], [1], [Define if readline supports rl_compdisp_func_t])
-    ], [], [readline_includes])
+    AC_CHECK_TYPE([rl_compdisp_func_t],
+                  [AC_DEFINE([HAVE_RL_COMPDISP_FUNC_T], [1],
+                             [Define if readline supports rl_compdisp_func_t])],
+                  [],
+                  [readline_includes])
 
     m4_undefine([readline_includes])
   ])dnl WITH_SAVE_ENV()

--- a/pyconfig.h.in
+++ b/pyconfig.h.in
@@ -983,6 +983,9 @@
 /* Define if you can turn off readline's signal handling. */
 #undef HAVE_RL_CATCH_SIGNAL
 
+/* Define if readline supports rl_compdisp_func_t */
+#undef HAVE_RL_COMPDISP_FUNC_T
+
 /* Define if you have readline 2.2 */
 #undef HAVE_RL_COMPLETION_APPEND_CHARACTER
 


### PR DESCRIPTION
Fixes compile with BSD libedit versions since April 2023.

Requires backport to 3.12 (should cleanly apply).
Requires backport to 3.11 and 3.10 using this manual cherry-pick: https://github.com/Bo98/cpython/commit/b0c571f6ad0f233ba9d0f24e32fc8db1081be247
I believe 3.9 and older don't technically support libedit except Apple's 2012 version, but a similar cherry-pick could be made if desired.

<!-- gh-issue-number: gh-109191 -->
* Issue: gh-109191
<!-- /gh-issue-number -->
