### PR TITLE
gh-110241: Add missing error check to `record_eval` in `_testinternalcapi`

### DIFF
--- a/Modules/_testinternalcapi.c
+++ b/Modules/_testinternalcapi.c
@@ -675,7 +675,11 @@ record_eval(PyThreadState *tstate, struct _PyInterpreterFrame *f, int exc)
         assert(module != NULL);
         module_state *state = get_module_state(module);
         Py_DECREF(module);
-        PyList_Append(state->record_list, ((PyFunctionObject *)f->f_funcobj)->func_name);
+        int res = PyList_Append(state->record_list,
+                                ((PyFunctionObject *)f->f_funcobj)->func_name);
+        if (res < 0) {
+            return NULL;
+        }
     }
     return _PyEval_EvalFrameDefault(tstate, f, exc);
 }


### PR DESCRIPTION


<!-- gh-issue-number: gh-110241 -->
* Issue: gh-110241
<!-- /gh-issue-number -->
