### PR TITLE
gh-109860: Use a New Thread State When Switching Interpreters, When Necessary

### DIFF
--- a/Include/cpython/pystate.h
+++ b/Include/cpython/pystate.h
@@ -98,6 +98,7 @@ struct _ts {
 #  define _PyThreadState_WHENCE_INTERP 1
 #  define _PyThreadState_WHENCE_THREADING 2
 #  define _PyThreadState_WHENCE_GILSTATE 3
+#  define _PyThreadState_WHENCE_EXEC 4
 #endif
     int _whence;
 
@@ -211,6 +212,13 @@ struct _ts {
    // This value is duplicated in Lib/test/support/__init__.py
 #  define Py_C_RECURSION_LIMIT 1500
 #endif
+
+PyAPI_FUNC(void) PyThreadState_Init(
+    PyThreadState *tstate,
+    PyInterpreterState *interp,
+    int whence);
+PyAPI_FUNC(void) PyThreadState_Fini(PyThreadState *tstate);
+PyAPI_FUNC(void) PyThreadState_Bind(PyThreadState *tstate);
 
 
 /* other API */

--- a/Include/cpython/pystate.h
+++ b/Include/cpython/pystate.h
@@ -92,6 +92,14 @@ struct _ts {
         /* padding to align to 4 bytes */
         unsigned int :24;
     } _status;
+#ifdef Py_BUILD_CORE
+#  define _PyThreadState_WHENCE_NOTSET -1
+#  define _PyThreadState_WHENCE_UNKNOWN 0
+#  define _PyThreadState_WHENCE_INTERP 1
+#  define _PyThreadState_WHENCE_THREADING 2
+#  define _PyThreadState_WHENCE_GILSTATE 3
+#endif
+    int _whence;
 
     int py_recursion_remaining;
     int py_recursion_limit;

--- a/Include/cpython/pystate.h
+++ b/Include/cpython/pystate.h
@@ -213,13 +213,6 @@ struct _ts {
 #  define Py_C_RECURSION_LIMIT 1500
 #endif
 
-PyAPI_FUNC(void) PyThreadState_Init(
-    PyThreadState *tstate,
-    PyInterpreterState *interp,
-    int whence);
-PyAPI_FUNC(void) PyThreadState_Fini(PyThreadState *tstate);
-PyAPI_FUNC(void) PyThreadState_Bind(PyThreadState *tstate);
-
 
 /* other API */
 

--- a/Include/internal/pycore_pystate.h
+++ b/Include/internal/pycore_pystate.h
@@ -142,7 +142,7 @@ static inline PyInterpreterState* _PyInterpreterState_GET(void) {
 extern PyThreadState * _PyThreadState_New(
     PyInterpreterState *interp,
     int whence);
-extern void _PyThreadState_Bind(PyThreadState *tstate);
+#define _PyThreadState_Bind(tstate) PyThreadState_Bind(tstate)
 extern void _PyThreadState_DeleteExcept(PyThreadState *tstate);
 
 // Export for '_testinternalcapi' shared extension

--- a/Include/internal/pycore_pystate.h
+++ b/Include/internal/pycore_pystate.h
@@ -139,7 +139,9 @@ static inline PyInterpreterState* _PyInterpreterState_GET(void) {
 
 // PyThreadState functions
 
-extern PyThreadState * _PyThreadState_New(PyInterpreterState *interp);
+extern PyThreadState * _PyThreadState_New(
+    PyInterpreterState *interp,
+    int whence);
 extern void _PyThreadState_Bind(PyThreadState *tstate);
 extern void _PyThreadState_DeleteExcept(PyThreadState *tstate);
 

--- a/Include/internal/pycore_pystate.h
+++ b/Include/internal/pycore_pystate.h
@@ -48,6 +48,7 @@ _Py_IsMainInterpreterFinalizing(PyInterpreterState *interp)
 PyAPI_FUNC(int) _PyInterpreterState_SetRunningMain(PyInterpreterState *);
 PyAPI_FUNC(void) _PyInterpreterState_SetNotRunningMain(PyInterpreterState *);
 PyAPI_FUNC(int) _PyInterpreterState_IsRunningMain(PyInterpreterState *);
+PyAPI_FUNC(int) _PyInterpreterState_FailIfRunningMain(PyInterpreterState *);
 
 
 static inline const PyConfig *

--- a/Include/internal/pycore_pystate.h
+++ b/Include/internal/pycore_pystate.h
@@ -142,7 +142,7 @@ static inline PyInterpreterState* _PyInterpreterState_GET(void) {
 extern PyThreadState * _PyThreadState_New(
     PyInterpreterState *interp,
     int whence);
-#define _PyThreadState_Bind(tstate) PyThreadState_Bind(tstate)
+extern void _PyThreadState_Bind(PyThreadState *tstate);
 extern void _PyThreadState_DeleteExcept(PyThreadState *tstate);
 
 // Export for '_testinternalcapi' shared extension

--- a/Include/internal/pycore_runtime_init.h
+++ b/Include/internal/pycore_runtime_init.h
@@ -185,6 +185,7 @@ extern PyTypeObject _PyExc_MemoryError;
 
 #define _PyThreadState_INIT \
     { \
+        ._whence = _PyThreadState_WHENCE_NOTSET, \
         .py_recursion_limit = Py_DEFAULT_RECURSION_LIMIT, \
         .context_ver = 1, \
     }

--- a/Lib/threading.py
+++ b/Lib/threading.py
@@ -1595,7 +1595,7 @@ def _shutdown():
         assert tlock is not None
         if tlock.locked():
             # It should have been released already by
-            # PyInterpreterState_SetNotRunningMain(), but there may be
+            # _PyInterpreterState_SetNotRunningMain(), but there may be
             # embedders that aren't calling that yet.
             tlock.release()
         _main_thread._stop()

--- a/Lib/threading.py
+++ b/Lib/threading.py
@@ -1593,8 +1593,11 @@ def _shutdown():
         # The main thread isn't finished yet, so its thread state lock can't
         # have been released.
         assert tlock is not None
-        assert tlock.locked()
-        tlock.release()
+        if tlock.locked():
+            # It should have been released already by
+            # PyInterpreterState_SetNotRunningMain(), but there may be
+            # embedders that aren't calling that yet.
+            tlock.release()
         _main_thread._stop()
     else:
         # bpo-1596321: _shutdown() must be called in the main thread.

--- a/Modules/_threadmodule.c
+++ b/Modules/_threadmodule.c
@@ -1205,7 +1205,7 @@ thread_PyThread_start_new_thread(PyObject *self, PyObject *fargs)
     if (boot == NULL) {
         return PyErr_NoMemory();
     }
-    boot->tstate = _PyThreadState_New(interp);
+    boot->tstate = _PyThreadState_New(interp, _PyThreadState_WHENCE_THREADING);
     if (boot->tstate == NULL) {
         PyMem_RawFree(boot);
         if (!PyErr_Occurred()) {

--- a/Modules/_xxsubinterpretersmodule.c
+++ b/Modules/_xxsubinterpretersmodule.c
@@ -514,6 +514,10 @@ interp_create(PyObject *self, PyObject *args, PyObject *kwds)
         PyThreadState_Swap(save_tstate);
         return NULL;
     }
+
+    PyThreadState_Clear(tstate);
+    PyThreadState_Delete(tstate);
+
     _PyInterpreterState_RequireIDRef(interp, 1);
     return idobj;
 }

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -655,7 +655,8 @@ pycore_create_interpreter(_PyRuntimeState *runtime,
         return status;
     }
 
-    PyThreadState *tstate = _PyThreadState_New(interp);
+    PyThreadState *tstate = _PyThreadState_New(interp,
+                                               _PyThreadState_WHENCE_INTERP);
     if (tstate == NULL) {
         return _PyStatus_ERR("can't make first thread");
     }
@@ -2050,7 +2051,8 @@ new_interpreter(PyThreadState **tstate_p, const PyInterpreterConfig *config)
         return _PyStatus_OK();
     }
 
-    PyThreadState *tstate = _PyThreadState_New(interp);
+    PyThreadState *tstate = _PyThreadState_New(interp,
+                                               _PyThreadState_WHENCE_INTERP);
     if (tstate == NULL) {
         PyInterpreterState_Delete(interp);
         *tstate_p = NULL;

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -1615,11 +1615,11 @@ PyThreadState_Clear(PyThreadState *tstate)
 
     if (tstate->on_delete != NULL) {
         // For the "main" thread of each interpreter, this is meant
-        // to be done in PyInterpreterState_SetNotRunningMain().
-        // Tha leaves threads created by the threading module,
+        // to be done in _PyInterpreterState_SetNotRunningMain().
+        // That leaves threads created by the threading module,
         // and any threads killed by forking.
         // However, we also accommodate "main" threads that still
-        // don't call PyInterpreterState_SetNotRunningMain() yet.
+        // don't call _PyInterpreterState_SetNotRunningMain() yet.
         tstate->on_delete(tstate->on_delete_data);
     }
 

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -1094,9 +1094,7 @@ _PyInterpreterState_DeleteExceptMain(_PyRuntimeState *runtime)
 int
 _PyInterpreterState_SetRunningMain(PyInterpreterState *interp)
 {
-    if (interp->threads.main != NULL) {
-        PyErr_SetString(PyExc_RuntimeError,
-                        "interpreter already running");
+    if (_PyInterpreterState_FailIfRunningMain(interp) < 0) {
         return -1;
     }
     PyThreadState *tstate = current_fast_get(&_PyRuntime);
@@ -1134,6 +1132,17 @@ int
 _PyInterpreterState_IsRunningMain(PyInterpreterState *interp)
 {
     return (interp->threads.main != NULL);
+}
+
+int
+_PyInterpreterState_FailIfRunningMain(PyInterpreterState *interp)
+{
+    if (interp->threads.main != NULL) {
+        PyErr_SetString(PyExc_RuntimeError,
+                        "interpreter already running");
+        return -1;
+    }
+    return 0;
 }
 
 

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -1585,6 +1585,9 @@ PyThreadState_Clear(PyThreadState *tstate)
     Py_CLEAR(tstate->context);
 
     if (tstate->on_delete != NULL) {
+        assert(tstate->_whence == _PyThreadState_WHENCE_THREADING
+               || (tstate->interp->finalizing
+                   && tstate == _PyInterpreterState_GetFinalizing(tstate->interp)));
         tstate->on_delete(tstate->on_delete_data);
     }
 

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -1408,8 +1408,6 @@ add_threadstate(PyInterpreterState *interp, PyThreadState *tstate,
                 PyThreadState *next)
 {
     assert(interp->threads.head != tstate);
-    assert((next != NULL && tstate->id != 1) ||
-           (next == NULL && tstate->id == 1));
     if (next != NULL) {
         assert(next->prev == NULL || next->prev == tstate);
         next->prev = tstate;

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -1607,12 +1607,10 @@ PyThreadState_Clear(PyThreadState *tstate)
     if (tstate->on_delete != NULL) {
         // For the "main" thread of each interpreter, this is meant
         // to be done in PyInterpreterState_SetNotRunningMain().
-        // Tha leaves threads created by the threading module.
+        // Tha leaves threads created by the threading module,
+        // and any threads killed by forking.
         // However, we also accommodate "main" threads that still
         // don't call PyInterpreterState_SetNotRunningMain() yet.
-        assert(tstate->_whence == _PyThreadState_WHENCE_THREADING
-               || (tstate->interp->finalizing
-                   && tstate == _PyInterpreterState_GetFinalizing(tstate->interp)));
         tstate->on_delete(tstate->on_delete_data);
     }
 

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -1338,7 +1338,14 @@ free_threadstate(PyThreadState *tstate)
 {
     // The initial thread state of the interpreter is allocated
     // as part of the interpreter state so should not be freed.
-    if (tstate != &tstate->interp->_initial_thread) {
+    if (tstate == &tstate->interp->_initial_thread) {
+        // Restore to _PyThreadState_INIT.
+        tstate = &tstate->interp->_initial_thread;
+        memcpy(tstate,
+               &initial._main_interpreter._initial_thread,
+               sizeof(*tstate));
+    }
+    else {
         PyMem_RawFree(tstate);
     }
 }
@@ -1438,6 +1445,7 @@ new_threadstate(PyInterpreterState *interp, int whence)
         used_newtstate = 0;
         tstate = &interp->_initial_thread;
     }
+    // XXX Re-use interp->_initial_thread if not in use?
     else {
         // Every valid interpreter must have at least one thread.
         assert(id > 1);


### PR DESCRIPTION
In a few places we switch to another interpreter without knowing if it has a thread state associated with the current thread.  For the main interpreter there wasn't much of a problem, but for subinterpreters we were mostly okay re-using the tstate created with the interpreter (located via `PyInterpreterState_ThreadHead()`).  There was a good chance that tstate wasn't actually in use by another thread.

However, there are no guarantees of that.  Furthermore, re-using an already used tstate is currently fragile.  To address this, now we create a new thread state in each of those places and use it.

One consequence of this change is that `PyInterpreterState_ThreadHead()` may not return `NULL` (though that won't happen for the main interpreter).

<!-- gh-issue-number: gh-109860 -->
* Issue: gh-109860
<!-- /gh-issue-number -->
