### PR TITLE
gh-76785: Print the Traceback from Interpreter.run()

### DIFF
--- a/Modules/_xxsubinterpretersmodule.c
+++ b/Modules/_xxsubinterpretersmodule.c
@@ -410,6 +410,10 @@ error:
                 failure);
         PyErr_Clear();
     }
+    // XXX Instead, store the rendered traceback on sharedexc,
+    // attach it to the exception when applied,
+    // and teach PyErr_Display() to print it.
+    PyErr_Display(NULL, excval, NULL);
     Py_XDECREF(excval);
     assert(!PyErr_Occurred());
     _PyInterpreterState_SetNotRunningMain(interp);


### PR DESCRIPTION
This is a temporary fix.  The full fix may involve serializing the traceback in some form.

<!-- gh-issue-number: gh-76785 -->
* Issue: gh-76785
<!-- /gh-issue-number -->
