### PR TITLE
Fix typo in py312 whatsnew: add missing closing paren

### DIFF
--- a/Doc/whatsnew/3.12.rst
+++ b/Doc/whatsnew/3.12.rst
@@ -303,7 +303,7 @@ Let's cover these in detail:
 See :pep:`701` for more details.
 
 As a positive side-effect of how this feature has been implemented (by parsing f-strings
-with :pep:`the PEG parser <617>`, now error messages for f-strings are more precise
+with :pep:`the PEG parser <617>`), now error messages for f-strings are more precise
 and include the exact location of the error. For example, in Python 3.11, the following
 f-string raises a :exc:`SyntaxError`:
 


### PR DESCRIPTION


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--110255.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->