### PR TITLE
gh-108838: Improve docs - remove redundant newline statement for csv reader docs

### DIFF
--- a/Doc/library/csv.rst
+++ b/Doc/library/csv.rst
@@ -58,8 +58,7 @@ The :mod:`csv` module defines the following functions:
    Return a reader object which will iterate over lines in the given *csvfile*.
    *csvfile* can be any object which supports the :term:`iterator` protocol and returns a
    string each time its :meth:`!__next__` method is called --- :term:`file objects
-   <file object>` and list objects are both suitable.   If *csvfile* is a file object,
-   it should be opened with ``newline=''``. [1]_  An optional
+   <file object>` and list objects are both suitable. [1]_  An optional
    *dialect* parameter can be given which is used to define a set of parameters
    specific to a particular CSV dialect.  It may be an instance of a subclass of
    the :class:`Dialect` class or one of the strings returned by the
@@ -75,7 +74,7 @@ The :mod:`csv` module defines the following functions:
    A short usage example::
 
       >>> import csv
-      >>> with open('eggs.csv', newline='') as csvfile:
+      >>> with open('eggs.csv') as csvfile:
       ...     spamreader = csv.reader(csvfile, delimiter=' ', quotechar='|')
       ...     for row in spamreader:
       ...         print(', '.join(row))


### PR DESCRIPTION
gh-https://github.com/python/cpython/issues/108838: Fix CSV Reader documentation in csv-Module

<!-- gh-issue-number: gh-108838 -->
* Issue: gh-108838
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--110256.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->