### PR TITLE
gh-110266: Fix "`get_module_from_owned_type` is unused" warning

### DIFF
--- a/Modules/_testinternalcapi.c
+++ b/Modules/_testinternalcapi.c
@@ -42,6 +42,9 @@
 static PyObject *
 _get_current_module(void)
 {
+    // XXX Use the more efficient API now that we use heap types:
+    // return PyType_GetModule(cls);
+
     // We ensured it was imported in _run_script().
     PyObject *name = PyUnicode_FromString(MODULE_NAME);
     if (name == NULL) {

--- a/Modules/_xxinterpchannelsmodule.c
+++ b/Modules/_xxinterpchannelsmodule.c
@@ -100,15 +100,6 @@ _get_current_module(void)
     return mod;
 }
 
-static PyObject *
-get_module_from_owned_type(PyTypeObject *cls)
-{
-    assert(cls != NULL);
-    return _get_current_module();
-    // XXX Use the more efficient API now that we use heap types:
-    //return PyType_GetModule(cls);
-}
-
 static struct PyModuleDef moduledef;
 
 static PyObject *
@@ -2464,7 +2455,8 @@ channel__channel_id(PyObject *self, PyObject *args, PyObject *kwds)
         return NULL;
     }
     PyTypeObject *cls = state->ChannelIDType;
-    assert(get_module_from_owned_type(cls) == self);
+    assert(cls != NULL);
+    assert(_get_current_module() == self);
 
     return _channelid_new(self, cls, args, kwds);
 }


### PR DESCRIPTION
Fixes this warning that happens on all PRs:
<img width="563" alt="Снимок экрана 2023-10-03 в 12 52 15" src="https://github.com/python/cpython/assets/4660275/451f7ffd-66d5-4c2f-aa54-8603b303a5c0">


<!-- gh-issue-number: gh-110266 -->
* Issue: gh-110266
<!-- /gh-issue-number -->
