### PR TITLE
gh-110276: Run `test_str`, not `test_unicode`, as part of the PGO build

### DIFF
--- a/Lib/test/libregrtest/pgo.py
+++ b/Lib/test/libregrtest/pgo.py
@@ -42,10 +42,10 @@ PGO_TESTS = [
     'test_set',
     'test_sqlite3',
     'test_statistics',
+    'test_str',
     'test_struct',
     'test_tabnanny',
     'test_time',
-    'test_unicode',
     'test_xml_etree',
     'test_xml_etree_c',
 ]


### PR DESCRIPTION
`test_unicode` does not exist

<!-- gh-issue-number: gh-110276 -->
* Issue: gh-110276
<!-- /gh-issue-number -->
