### PR TITLE
Bump various dependencies in `Doc/requirements-oldest-sphinx.txt`

### DIFF
--- a/Doc/requirements-oldest-sphinx.txt
+++ b/Doc/requirements-oldest-sphinx.txt
@@ -13,16 +13,16 @@ python-docs-theme>=2022.1
 # Sphinx 4.2 comes from ``needs_sphinx = '4.2'`` in ``Doc/conf.py``.
 
 alabaster==0.7.13
-Babel==2.12.1
+Babel==2.13.0
 certifi==2023.7.22
-charset-normalizer==3.2.0
+charset-normalizer==3.3.0
 colorama==0.4.6
-docutils==0.16
+docutils==0.17.1
 idna==3.4
 imagesize==1.4.1
-Jinja2==2.11.3
-MarkupSafe==1.1.1
-packaging==23.1
+Jinja2==3.1.2
+MarkupSafe==2.1.3
+packaging==23.2
 Pygments==2.16.1
 requests==2.31.0
 snowballstemmer==2.2.0
@@ -33,4 +33,4 @@ sphinxcontrib-htmlhelp==2.0.1
 sphinxcontrib-jsmath==1.0.1
 sphinxcontrib-qthelp==1.0.3
 sphinxcontrib-serializinghtml==1.1.5
-urllib3==2.0.4
+urllib3==2.0.6


### PR DESCRIPTION
This resolves a [Dependabot security alert](https://github.com/python/cpython/security/dependabot/3) on the repository for `urllib3==2.0.4`.

I followed the instructions here for regenerating the dependencies, which resulted in several other bumps as well:

https://github.com/python/cpython/blob/bb2e96f6f4d6c397c4eb5775a09262a207675577/Doc/requirements-oldest-sphinx.txt#L9-L13

The only one that's required to resolve the security alert is the `urllib3` bump, though; we could stick to just that if it's preferred.

<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--110278.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->