### PR TITLE
gh-109653: Defer importing `warnings` in several modules

### DIFF
--- a/Lib/argparse.py
+++ b/Lib/argparse.py
@@ -89,8 +89,6 @@ import os as _os
 import re as _re
 import sys as _sys
 
-import warnings
-
 from gettext import gettext as _, ngettext
 
 SUPPRESS = '==SUPPRESS=='
@@ -910,6 +908,7 @@ class BooleanOptionalAction(Action):
         #   parser.add_argument('-f', action=BooleanOptionalAction, type=int)
         for field_name in ('type', 'choices', 'metavar'):
             if locals()[field_name] is not _deprecated_default:
+                import warnings
                 warnings._deprecated(
                     field_name,
                     "{name!r} is deprecated as of Python 3.12 and will be "
@@ -1700,6 +1699,7 @@ class _ArgumentGroup(_ActionsContainer):
         self._group_actions.remove(action)
 
     def add_argument_group(self, *args, **kwargs):
+        import warnings
         warnings.warn(
             "Nesting argument groups is deprecated.",
             category=DeprecationWarning,
@@ -1728,6 +1728,7 @@ class _MutuallyExclusiveGroup(_ArgumentGroup):
         self._group_actions.remove(action)
 
     def add_mutually_exclusive_group(self, *args, **kwargs):
+        import warnings
         warnings.warn(
             "Nesting mutually exclusive groups is deprecated.",
             category=DeprecationWarning,

--- a/Lib/calendar.py
+++ b/Lib/calendar.py
@@ -10,7 +10,6 @@ import datetime
 from enum import IntEnum, global_enum
 import locale as _locale
 from itertools import repeat
-import warnings
 
 __all__ = ["IllegalMonthError", "IllegalWeekdayError", "setfirstweekday",
            "firstweekday", "isleap", "leapdays", "weekday", "monthrange",
@@ -44,6 +43,7 @@ class IllegalWeekdayError(ValueError):
 
 def __getattr__(name):
     if name in ('January', 'February'):
+        import warnings
         warnings.warn(f"The '{name}' attribute is deprecated, use '{name.upper()}' instead",
                       DeprecationWarning, stacklevel=2)
         if name == 'January':

--- a/Lib/getpass.py
+++ b/Lib/getpass.py
@@ -18,7 +18,6 @@ import contextlib
 import io
 import os
 import sys
-import warnings
 
 __all__ = ["getpass","getuser","GetPassWarning"]
 
@@ -118,6 +117,7 @@ def win_getpass(prompt='Password: ', stream=None):
 
 
 def fallback_getpass(prompt='Password: ', stream=None):
+    import warnings
     warnings.warn("Can not control echo on the terminal.", GetPassWarning,
                   stacklevel=2)
     if not stream:

--- a/Lib/shutil.py
+++ b/Lib/shutil.py
@@ -10,7 +10,6 @@ import stat
 import fnmatch
 import collections
 import errno
-import warnings
 
 try:
     import zlib
@@ -723,6 +722,7 @@ def rmtree(path, ignore_errors=False, onerror=None, *, onexc=None, dir_fd=None):
     """
 
     if onerror is not None:
+        import warnings
         warnings.warn("onerror argument is deprecated, use onexc instead",
                       DeprecationWarning, stacklevel=2)
 

--- a/Lib/tarfile.py
+++ b/Lib/tarfile.py
@@ -46,7 +46,6 @@ import time
 import struct
 import copy
 import re
-import warnings
 
 try:
     import pwd
@@ -2219,6 +2218,7 @@ class TarFile(object):
         if filter is None:
             filter = self.extraction_filter
             if filter is None:
+                import warnings
                 warnings.warn(
                     'Python 3.14 will, by default, filter extracted tar '
                     + 'archives and reject files or modify their metadata. '

--- a/Misc/NEWS.d/next/Library/2023-10-03-15-17-03.gh-issue-109653.9DYOMD.rst
+++ b/Misc/NEWS.d/next/Library/2023-10-03-15-17-03.gh-issue-109653.9DYOMD.rst
@@ -1,0 +1,3 @@
+Slightly improve the import time of several standard-library modules by
+deferring imports of :mod:`warnings` within those modules. Patch by Alex
+Waygood.


### PR DESCRIPTION
`warnings` is a pretty cheap import, so the import-time saving from deferring it is usually pretty minimal. However, it's also a textbook example of an import that should be deferred wherever reasonable. Most of the time, it's only imported so that a `DeprecationWarning` can be emitted, and we should try to make it so that users only have to pay the (small) performance penalty from it being imported if they actually hit the specific code path that's deprecated.

Nonetheless, since the performance impact of importing `warnings` is so small, I've tried to avoid modules that make multiple uses of `warnings` -- it's not particularly DRY to have import warnings repeated several times in the same module. The one exception I made here is `argparse`: `argparse` really should be importing the absolute minimum set of modules given that it's a CLI framework (see #74338 for previous discussion).

<!-- gh-issue-number: gh-109653 -->
* Issue: gh-109653
<!-- /gh-issue-number -->
