### PR TITLE
Add SynchronizedBase to __all__ in ``multiprocessing.sharedctypes``

### DIFF
--- a/Lib/multiprocessing/sharedctypes.py
+++ b/Lib/multiprocessing/sharedctypes.py
@@ -16,7 +16,7 @@ from . import get_context
 from .context import reduction, assert_spawning
 _ForkingPickler = reduction.ForkingPickler
 
-__all__ = ['RawValue', 'RawArray', 'Value', 'Array', 'copy', 'synchronized']
+__all__ = ['RawValue', 'RawArray', 'Value', 'Array', 'copy', 'synchronized', 'SynchronizedBase']
 
 #
 #

--- a/Lib/multiprocessing/sharedctypes.py
+++ b/Lib/multiprocessing/sharedctypes.py
@@ -25,7 +25,7 @@ __all__ = [
     'Synchronized', 'SynchronizedArray', 'SynchronizedString',
     # Misc functions
     'copy', 'synchronized'
-]
+    ]
 
 #
 #

--- a/Lib/multiprocessing/sharedctypes.py
+++ b/Lib/multiprocessing/sharedctypes.py
@@ -16,7 +16,16 @@ from . import get_context
 from .context import reduction, assert_spawning
 _ForkingPickler = reduction.ForkingPickler
 
-__all__ = ['RawValue', 'RawArray', 'Value', 'Array', 'copy', 'synchronized', 'SynchronizedBase']
+__all__ = [
+    # Methods for getting ctypes in shared memory
+    'RawValue', 'RawArray',
+    # Methods for getting synchronization wrappers
+    'Value', 'Array',
+    # The synchronization types
+    'Synchronized', 'SynchronizedArray', 'SynchronizedString',
+    # Misc functions
+    'copy', 'synchronized'
+]
 
 #
 #

--- a/Misc/NEWS.d/next/Documentation/2023-10-03-17-59-00.gh-issue-0.m1D01N.rst
+++ b/Misc/NEWS.d/next/Documentation/2023-10-03-17-59-00.gh-issue-0.m1D01N.rst
@@ -1,0 +1,1 @@
+Export the base synchronization class so multiprocessing users can typecheck their code.

--- a/Misc/NEWS.d/next/Documentation/2023-10-03-17-59-00.gh-issue-0.m1D01N.rst
+++ b/Misc/NEWS.d/next/Documentation/2023-10-03-17-59-00.gh-issue-0.m1D01N.rst
@@ -1,1 +1,2 @@
-Export the base synchronization class so multiprocessing users can typecheck their code.
+Export :class:`multiprocessing.SynchronizedBase` so multiprocessing users can
+typecheck their code.

--- a/Misc/NEWS.d/next/Documentation/2023-10-03-17-59-00.gh-issue-0.m1D01N.rst
+++ b/Misc/NEWS.d/next/Documentation/2023-10-03-17-59-00.gh-issue-0.m1D01N.rst
@@ -1,2 +1,4 @@
-Export :class:`multiprocessing.SynchronizedBase` so multiprocessing users can
-typecheck their code.
+Export :class:`multiprocessing.Synchronized`,
+:class:`multiprocessing.SynchronizedArray`, and
+:class:`multiprocessing.SynchronizedString` so multiprocessing users can
+annotate their code well.


### PR DESCRIPTION
Recently I was writing some heavily-parallel code,
and I tried to type-check with `mypy`. I (naively)
thought that `multiprocessing.Value` was a class
and was very confused when `mypy` threw an error
on that line. I dropped into the interpreter and
tried to use the `help` function to find the
return type of `Value` - and failed. I dropped
into the code and found that the type returned
from the `Value` function was not exported from
the module.

I want types in Python to be _awesome_. I think
`mypy` is a step in the right direction for that.
This change is me doing my part to expose more
types so `mypy` can become as good as it can be.