### PR TITLE
gh-109917: Fix test instability in test_concurrent_futures

### DIFF
--- a/Lib/test/test_concurrent_futures/test_deadlock.py
+++ b/Lib/test/test_concurrent_futures/test_deadlock.py
@@ -286,11 +286,12 @@ class ExecutorDeadlockTest:
                 super().wakeup()
 
             def clear(self):
+                super().clear()
                 try:
                     while True:
                         self._dummy_queue.get_nowait()
                 except queue.Empty:
-                    super().clear()
+                    pass
 
         with (unittest.mock.patch.object(futures.process._ExecutorManagerThread,
                                          'run', mock_run),


### PR DESCRIPTION
The test had an instability issue due to the ordering of the dummy queue operation and the real wakeup pipe operations. Both primitives are thread safe but not done atomically as a single update and may interleave arbitrarily. With the old order of operations this can lead to an incorrect state where the dummy queue is full but the wakeup pipe is empty. By swapping the order in clear() I think this can no longer happen in any possible operation interleaving (famous last words).

This is a minimal update to fix the issue. Long term it might be better to rewrite the test along the lines of https://github.com/python/cpython/pull/110129 where we make it possible to override the wakeup message and cause the blocking behaviour that way instead of the small dummy queue used now. Less mocking is usually better and the test can be faster as well. It does require a minor modification to the implementation and there were other issues in https://github.com/python/cpython/pull/110129 but the general test idea seems better than the current solution.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-109917 -->
* Issue: gh-109917
<!-- /gh-issue-number -->
