### PR TITLE
Add m1 macos builds to the CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -216,8 +216,15 @@ jobs:
       run: .\PCbuild\build.bat -e -d -p arm64
 
   build_macos:
-    name: 'macOS'
-    runs-on: macos-latest
+    strategy:
+      matrix:
+        include:
+        - worker_name: "macos-latest"
+          arch_name: "intel"
+        - worker_name: "macos-latest-xlarge"
+          arch_name: "m1"
+    name: "macOS ${{ matrix.arch_name }}"
+    runs-on: ${{ matrix.worker_name }}
     timeout-minutes: 60
     needs: check_source
     if: needs.check_source.outputs.run_tests == 'true'


### PR DESCRIPTION
It was just released: https://github.blog/changelog/2023-10-02-github-actions-apple-silicon-m1-macos-runners-are-now-available-in-public-beta/

Since m1 macs are very different from Intel macs, I think it might make sense to test both of them.

