### PR TITLE
gh-76785: Print the Traceback from Interpreter.run()

### DIFF
--- a/Modules/_xxsubinterpretersmodule.c
+++ b/Modules/_xxsubinterpretersmodule.c
@@ -450,6 +450,10 @@ error:
                 "RunFailedError: script raised an uncaught exception (%s)",
                 failure);
     }
+    // XXX Instead, store the rendered traceback on sharedexc,
+    // attach it to the exception when applied,
+    // and teach PyErr_Display() to print it.
+    PyErr_Display(NULL, excval, NULL);
     Py_XDECREF(excval);
     if (errcode != ERR_ALREADY_RUNNING) {
         _PyInterpreterState_SetNotRunningMain(interp);

--- a/Modules/_xxsubinterpretersmodule.c
+++ b/Modules/_xxsubinterpretersmodule.c
@@ -450,11 +450,13 @@ error:
                 "RunFailedError: script raised an uncaught exception (%s)",
                 failure);
     }
-    // XXX Instead, store the rendered traceback on sharedexc,
-    // attach it to the exception when applied,
-    // and teach PyErr_Display() to print it.
-    PyErr_Display(NULL, excval, NULL);
-    Py_XDECREF(excval);
+    if (excval != NULL) {
+        // XXX Instead, store the rendered traceback on sharedexc,
+        // attach it to the exception when applied,
+        // and teach PyErr_Display() to print it.
+        PyErr_Display(NULL, excval, NULL);
+        Py_DECREF(excval);
+    }
     if (errcode != ERR_ALREADY_RUNNING) {
         _PyInterpreterState_SetNotRunningMain(interp);
     }


### PR DESCRIPTION
This is a temporary fix. The full fix may involve serializing the traceback in some form.

<!-- gh-issue-number: gh-76785 -->
* Issue: gh-76785
<!-- /gh-issue-number -->
