### PR TITLE
Fix typo in Doc/library/textwrap.rst

### DIFF
--- a/Doc/library/textwrap.rst
+++ b/Doc/library/textwrap.rst
@@ -238,7 +238,7 @@ hyphenated words; only then will long words be broken if necessary, unless
       However, the sentence detection algorithm is imperfect: it assumes that a
       sentence ending consists of a lowercase letter followed by one of ``'.'``,
       ``'!'``, or ``'?'``, possibly followed by one of ``'"'`` or ``"'"``,
-      followed by a space.  One problem with this is algorithm is that it is
+      followed by a space.  One problem with this algorithm is that it is
       unable to detect the difference between "Dr." in ::
 
          [...] Dr. Frankenstein's monster [...]


### PR DESCRIPTION
From [`textwrap` &sect; `TextWrapper.fix_sentence_endings`](https://docs.python.org/3/library/textwrap.html#textwrap.TextWrapper.fix_sentence_endings):

> One problem with this is algorithm is that it is unable to [...]

The line should have read as follows:

> One problem with this algorithm is that it is unable to [...]


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--110328.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->