### PR TITLE
gh-110166: Fix gdb CFunctionFullTests on ppc64le clang build

### DIFF
--- a/Lib/test/test_gdb/test_cfunction_full.py
+++ b/Lib/test/test_gdb/test_cfunction_full.py
@@ -18,7 +18,7 @@ class CFunctionFullTests(CFunctionTests):
         gdb_output = self.get_stack_trace(
             cmd,
             breakpoint=func_name,
-            cmds_after_breakpoint=['py-bt-full'],
+            cmds_after_breakpoint=['bt', 'py-bt-full'],
             # bpo-45207: Ignore 'Function "meth_varargs" not
             # defined.' message in stderr.
             ignore_stderr=True,


### PR DESCRIPTION
CFunctionFullTests now also runs "bt" command before "py-bt-full", similar than CFunctionTests which also runs "bt" command before "py-bt". So test_gdb can skip the test if patterns like "?? ()" are found in the output.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-110166 -->
* Issue: gh-110166
<!-- /gh-issue-number -->
