### PR TITLE
gh-110332: Remove mentions of `random.WichmannHill` from `test_zlib`

### DIFF
--- a/Lib/test/test_zlib.py
+++ b/Lib/test/test_zlib.py
@@ -512,18 +512,7 @@ class CompressObjectTestCase(BaseCompressTestCase, unittest.TestCase):
 
         # Try 17K of data
         # generate random data stream
-        try:
-            # In 2.3 and later, WichmannHill is the RNG of the bug report
-            gen = random.WichmannHill()
-        except AttributeError:
-            try:
-                # 2.2 called it Random
-                gen = random.Random()
-            except AttributeError:
-                # others might simply have a single RNG
-                gen = random
-        gen.seed(1)
-        data = gen.randbytes(17 * 1024)
+        data = random.randbytes(17 * 1024)
 
         # compress, sync-flush, and decompress
         first = co.compress(data)


### PR DESCRIPTION
Related to https://github.com/python/cpython/issues/110171, I am looking through other usages of `Random.seed`

<!-- gh-issue-number: gh-110332 -->
* Issue: gh-110332
<!-- /gh-issue-number -->
