### PR TITLE
Lint: Remove files that no longer fail to parse or with F811

### DIFF
--- a/Lib/test/.ruff.toml
+++ b/Lib/test/.ruff.toml
@@ -8,9 +8,6 @@ extend-exclude = [
     # Failed to lint
     "encoded_modules/module_iso_8859_1.py",
     "encoded_modules/module_koi8_r.py",
-    # Failed to parse
-    "support/socket_helper.py",
-    "test_fstring.py",
     # TODO Fix: F811 Redefinition of unused name
     "test__opcode.py",
     "test_buffer.py",
@@ -26,7 +23,6 @@ extend-exclude = [
     "test_keywordonlyarg.py",
     "test_pkg.py",
     "test_subclassinit.py",
-    "test_unittest/testmock/testpatch.py",
     "test_yield_from.py",
     "time_hashlib.py",
     # Pending https://github.com/python/cpython/pull/109139


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
Following the release of Ruff 0.0.292 with support for Python 3.12's PEP 701 f-strings, these files no longer fail to parse, and we can include them in the check.

* https://github.com/astral-sh/ruff/releases/tag/v0.0.292
* https://github.com/astral-sh/ruff/pull/7376
* https://github.com/python/cpython/pull/110179

Also remove `test_unittest/testmock/testpatch.py`, it didn't need to be in the list in the first place.

I'll do manual backports to 3.12 and 3.11 as they're slightly different.