### PR TITLE
regrtest: Prepend 'use' options in --{fast,slow}-ci

### DIFF
--- a/Lib/test/libregrtest/cmdline.py
+++ b/Lib/test/libregrtest/cmdline.py
@@ -418,14 +418,16 @@ def _parse_args(args, **kwargs):
     # --slow-ci has the priority
     if ns.slow_ci:
         # Similar to: -u "all" --timeout=1200
-        if not ns.use:
-            ns.use = [['all']]
+        if ns.use is None:
+            ns.use = []
+        ns.use.insert(0, ['all'])
         if ns.timeout is None:
             ns.timeout = 1200  # 20 minutes
     elif ns.fast_ci:
         # Similar to: -u "all,-cpu" --timeout=600
-        if not ns.use:
-            ns.use = [['all', '-cpu']]
+        if ns.use is None:
+            ns.use = []
+        ns.use.insert(0, ['all', '-cpu'])
         if ns.timeout is None:
             ns.timeout = 600  # 10 minutes
 

--- a/Lib/test/test_regrtest.py
+++ b/Lib/test/test_regrtest.py
@@ -416,9 +416,11 @@ class ParseArgsTestCase(unittest.TestCase):
         self.assertEqual(regrtest.python_cmd, ('python', '-X', 'dev'))
 
     def test_fast_ci_resource(self):
-        # it should be possible to override resources
-        args = ['--fast-ci', '-u', 'network']
-        use_resources = ['network']
+        # it should be possible to override resources individually
+        args = ['--fast-ci', '-u-network']
+        use_resources = sorted(cmdline.ALL_RESOURCES)
+        use_resources.remove('cpu')
+        use_resources.remove('network')
         self.check_ci_mode(args, use_resources)
 
     def test_slow_ci(self):


### PR DESCRIPTION
This allows individual resources to be disabled without having to
explicitly re-enable all others.
