### PR TITLE
gh-110367: Enhance regrtest -jN --verbose3

### DIFF
--- a/Lib/test/libregrtest/run_workers.py
+++ b/Lib/test/libregrtest/run_workers.py
@@ -262,6 +262,9 @@ class WorkerThread(threading.Thread):
         kwargs = {}
         if match_tests:
             kwargs['match_tests'] = match_tests
+        if self.runtests.output_on_failure:
+            kwargs['verbose'] = True
+            kwargs['output_on_failure'] = False
         return self.runtests.copy(
             tests=tests,
             json_file=json_file,
@@ -562,8 +565,16 @@ class RunWorkers:
         self.results.accumulate_result(result, self.runtests)
         self.display_result(mp_result)
 
-        if mp_result.worker_stdout:
-            print(mp_result.worker_stdout, flush=True)
+        # Display worker stdout
+        if not self.runtests.output_on_failure:
+            show_stdout = True
+        else:
+            # --verbose3 ignores stdout on success
+            show_stdout = (result.state != State.PASSED)
+        if show_stdout:
+            stdout = mp_result.worker_stdout
+            if stdout:
+                print(stdout, flush=True)
 
         return result
 

--- a/Lib/test/test_faulthandler.py
+++ b/Lib/test/test_faulthandler.py
@@ -35,7 +35,7 @@ def expected_traceback(lineno1, lineno2, header, min_count=1):
         return '^' + regex + '$'
 
 def skip_segfault_on_android(test):
-    # Issue #32138: Raising SIGSEGV on Android may not cause a crash.
+    # gh-76319: Raising SIGSEGV on Android may not cause a crash.
     return unittest.skipIf(is_android,
                            'raising SIGSEGV on Android is unreliable')(test)
 

--- a/Misc/NEWS.d/next/Tests/2023-10-04-18-27-47.gh-issue-110367.Nnq1I7.rst
+++ b/Misc/NEWS.d/next/Tests/2023-10-04-18-27-47.gh-issue-110367.Nnq1I7.rst
@@ -1,0 +1,4 @@
+regrtest: When using worker processes (-jN) with --verbose3 option, regrtest
+can now display the worker output even if a worker process does crash.
+Previously, sys.stdout and sys.stderr were replaced and so the worker output
+was lost on a crash. Patch by Victor Stinner.


### PR DESCRIPTION
When using worker processes (-jN) with --verbose3 option, regrtest can now display the worker output even if a worker process does crash.  Previously, sys.stdout and sys.stderr were replaced and so the worker output was lost on a crash.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-110367 -->
* Issue: gh-110367
<!-- /gh-issue-number -->
