### PR TITLE
DOC: Reuse old bltin-boolean-values ref tag

### DIFF
--- a/Doc/library/functions.rst
+++ b/Doc/library/functions.rst
@@ -147,7 +147,7 @@ are always available.  They are listed here in alphabetical order.
    or omitted, this returns ``False``; otherwise, it returns ``True``.  The
    :class:`bool` class is a subclass of :class:`int` (see :ref:`typesnumeric`).
    It cannot be subclassed further.  Its only instances are ``False`` and
-   ``True`` (see :ref:`bltin-boolean-values`).
+   ``True`` (see :ref:`typebool`).
 
    .. index:: pair: Boolean; type
 

--- a/Doc/library/functions.rst
+++ b/Doc/library/functions.rst
@@ -147,7 +147,7 @@ are always available.  They are listed here in alphabetical order.
    or omitted, this returns ``False``; otherwise, it returns ``True``.  The
    :class:`bool` class is a subclass of :class:`int` (see :ref:`typesnumeric`).
    It cannot be subclassed further.  Its only instances are ``False`` and
-   ``True`` (see :ref:`typebool`).
+   ``True`` (see :ref:`bltin-boolean-values`).
 
    .. index:: pair: Boolean; type
 

--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -804,7 +804,7 @@ number, :class:`float`, or :class:`complex`::
            hash_value = -2
        return hash_value
 
-.. _typebool:
+.. _bltin-boolean-values:
 
 Boolean Type - :class:`bool`
 ============================

--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -805,6 +805,7 @@ number, :class:`float`, or :class:`complex`::
        return hash_value
 
 .. _bltin-boolean-values:
+.. _typebool:
 
 Boolean Type - :class:`bool`
 ============================


### PR DESCRIPTION
gh-103487: Reuse old `bltin-boolean-values` ref tag to avoid breaking downstream intersphinx via numpydoc

The PR is opened as suggested in https://github.com/python/cpython/pull/103487/files#r1346336728 by @hauntsaninja 

close https://github.com/astropy/astropy/issues/15428

close https://github.com/numpy/numpydoc/issues/509

<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--110371.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->