### PR TITLE
gh-110378: Move to `IsolatedAsyncTestCase` in `test_contextlib_async.py`

### DIFF
--- a/Lib/test/test_contextlib_async.py
+++ b/Lib/test/test_contextlib_async.py
@@ -2,7 +2,6 @@ import asyncio
 from contextlib import (
     asynccontextmanager, AbstractAsyncContextManager,
     AsyncExitStack, nullcontext, aclosing, contextmanager)
-import functools
 from test import support
 import unittest
 import traceback
@@ -11,21 +10,12 @@ from test.test_contextlib import TestBaseExitStack
 
 support.requires_working_socket(module=True)
 
-def _async_test(func):
-    """Decorator to turn an async function into a test case."""
-    @functools.wraps(func)
-    def wrapper(*args, **kwargs):
-        coro = func(*args, **kwargs)
-        asyncio.run(coro)
-    return wrapper
-
 def tearDownModule():
     asyncio.set_event_loop_policy(None)
 
 
-class TestAbstractAsyncContextManager(unittest.TestCase):
+class TestAbstractAsyncContextManager(unittest.IsolatedAsyncioTestCase):
 
-    @_async_test
     async def test_enter(self):
         class DefaultEnter(AbstractAsyncContextManager):
             async def __aexit__(self, *args):
@@ -37,7 +27,6 @@ class TestAbstractAsyncContextManager(unittest.TestCase):
         async with manager as context:
             self.assertIs(manager, context)
 
-    @_async_test
     async def test_slots(self):
         class DefaultAsyncContextManager(AbstractAsyncContextManager):
             __slots__ = ()
@@ -49,7 +38,6 @@ class TestAbstractAsyncContextManager(unittest.TestCase):
             manager = DefaultAsyncContextManager()
             manager.var = 42
 
-    @_async_test
     async def test_async_gen_propagates_generator_exit(self):
         # A regression test for https://bugs.python.org/issue33786.
 
@@ -104,9 +92,8 @@ class TestAbstractAsyncContextManager(unittest.TestCase):
         self.assertFalse(issubclass(NoneAexit, AbstractAsyncContextManager))
 
 
-class AsyncContextManagerTestCase(unittest.TestCase):
+class AsyncContextManagerTestCase(unittest.IsolatedAsyncioTestCase):
 
-    @_async_test
     async def test_contextmanager_plain(self):
         state = []
         @asynccontextmanager
@@ -120,7 +107,6 @@ class AsyncContextManagerTestCase(unittest.TestCase):
             state.append(x)
         self.assertEqual(state, [1, 42, 999])
 
-    @_async_test
     async def test_contextmanager_finally(self):
         state = []
         @asynccontextmanager
@@ -138,7 +124,6 @@ class AsyncContextManagerTestCase(unittest.TestCase):
                 raise ZeroDivisionError()
         self.assertEqual(state, [1, 42, 999])
 
-    @_async_test
     async def test_contextmanager_traceback(self):
         @asynccontextmanager
         async def f():
@@ -194,7 +179,6 @@ class AsyncContextManagerTestCase(unittest.TestCase):
                 self.assertEqual(frames[0].name, 'test_contextmanager_traceback')
                 self.assertEqual(frames[0].line, 'raise stop_exc')
 
-    @_async_test
     async def test_contextmanager_no_reraise(self):
         @asynccontextmanager
         async def whee():
@@ -204,7 +188,6 @@ class AsyncContextManagerTestCase(unittest.TestCase):
         # Calling __aexit__ should not result in an exception
         self.assertFalse(await ctx.__aexit__(TypeError, TypeError("foo"), None))
 
-    @_async_test
     async def test_contextmanager_trap_yield_after_throw(self):
         @asynccontextmanager
         async def whoo():
@@ -217,7 +200,6 @@ class AsyncContextManagerTestCase(unittest.TestCase):
         with self.assertRaises(RuntimeError):
             await ctx.__aexit__(TypeError, TypeError('foo'), None)
 
-    @_async_test
     async def test_contextmanager_trap_no_yield(self):
         @asynccontextmanager
         async def whoo():
@@ -227,7 +209,6 @@ class AsyncContextManagerTestCase(unittest.TestCase):
         with self.assertRaises(RuntimeError):
             await ctx.__aenter__()
 
-    @_async_test
     async def test_contextmanager_trap_second_yield(self):
         @asynccontextmanager
         async def whoo():
@@ -238,7 +219,6 @@ class AsyncContextManagerTestCase(unittest.TestCase):
         with self.assertRaises(RuntimeError):
             await ctx.__aexit__(None, None, None)
 
-    @_async_test
     async def test_contextmanager_non_normalised(self):
         @asynccontextmanager
         async def whoo():
@@ -252,7 +232,6 @@ class AsyncContextManagerTestCase(unittest.TestCase):
         with self.assertRaises(SyntaxError):
             await ctx.__aexit__(RuntimeError, None, None)
 
-    @_async_test
     async def test_contextmanager_except(self):
         state = []
         @asynccontextmanager
@@ -270,7 +249,6 @@ class AsyncContextManagerTestCase(unittest.TestCase):
             raise ZeroDivisionError(999)
         self.assertEqual(state, [1, 42, 999])
 
-    @_async_test
     async def test_contextmanager_except_stopiter(self):
         @asynccontextmanager
         async def woohoo():
@@ -297,7 +275,6 @@ class AsyncContextManagerTestCase(unittest.TestCase):
                 else:
                     self.fail(f'{stop_exc} was suppressed')
 
-    @_async_test
     async def test_contextmanager_wrap_runtimeerror(self):
         @asynccontextmanager
         async def woohoo():
@@ -342,14 +319,12 @@ class AsyncContextManagerTestCase(unittest.TestCase):
         self.assertEqual(baz.__doc__, "Whee!")
 
     @support.requires_docstrings
-    @_async_test
     async def test_instance_docstring_given_cm_docstring(self):
         baz = self._create_contextmanager_attribs()(None)
         self.assertEqual(baz.__doc__, "Whee!")
         async with baz:
             pass  # suppress warning
 
-    @_async_test
     async def test_keywords(self):
         # Ensure no keyword arguments are inhibited
         @asynccontextmanager
@@ -358,7 +333,6 @@ class AsyncContextManagerTestCase(unittest.TestCase):
         async with woohoo(self=11, func=22, args=33, kwds=44) as target:
             self.assertEqual(target, (11, 22, 33, 44))
 
-    @_async_test
     async def test_recursive(self):
         depth = 0
         ncols = 0
@@ -385,7 +359,6 @@ class AsyncContextManagerTestCase(unittest.TestCase):
         self.assertEqual(ncols, 10)
         self.assertEqual(depth, 0)
 
-    @_async_test
     async def test_decorator(self):
         entered = False
 
@@ -404,7 +377,6 @@ class AsyncContextManagerTestCase(unittest.TestCase):
         await test()
         self.assertFalse(entered)
 
-    @_async_test
     async def test_decorator_with_exception(self):
         entered = False
 
@@ -427,7 +399,6 @@ class AsyncContextManagerTestCase(unittest.TestCase):
             await test()
         self.assertFalse(entered)
 
-    @_async_test
     async def test_decorating_method(self):
 
         @asynccontextmanager
@@ -462,7 +433,7 @@ class AsyncContextManagerTestCase(unittest.TestCase):
         self.assertEqual(test.b, 2)
 
 
-class AclosingTestCase(unittest.TestCase):
+class AclosingTestCase(unittest.IsolatedAsyncioTestCase):
 
     @support.requires_docstrings
     def test_instance_docs(self):
@@ -470,7 +441,6 @@ class AclosingTestCase(unittest.TestCase):
         obj = aclosing(None)
         self.assertEqual(obj.__doc__, cm_docstring)
 
-    @_async_test
     async def test_aclosing(self):
         state = []
         class C:
@@ -482,7 +452,6 @@ class AclosingTestCase(unittest.TestCase):
             self.assertEqual(x, y)
         self.assertEqual(state, [1])
 
-    @_async_test
     async def test_aclosing_error(self):
         state = []
         class C:
@@ -496,7 +465,6 @@ class AclosingTestCase(unittest.TestCase):
                 1 / 0
         self.assertEqual(state, [1])
 
-    @_async_test
     async def test_aclosing_bpo41229(self):
         state = []
 
@@ -522,7 +490,7 @@ class AclosingTestCase(unittest.TestCase):
         self.assertEqual(state, [1])
 
 
-class TestAsyncExitStack(TestBaseExitStack, unittest.TestCase):
+class TestAsyncExitStack(TestBaseExitStack, unittest.IsolatedAsyncioTestCase):
     class SyncAsyncExitStack(AsyncExitStack):
         @staticmethod
         def run_coroutine(coro):
@@ -561,13 +529,6 @@ class TestAsyncExitStack(TestBaseExitStack, unittest.TestCase):
         ('__aexit__', 'cb_suppress = cb(*exc_details)'),
     ]
 
-    def setUp(self):
-        self.loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(self.loop)
-        self.addCleanup(self.loop.close)
-        self.addCleanup(asyncio.set_event_loop_policy, None)
-
-    @_async_test
     async def test_async_callback(self):
         expected = [
             ((), {}),
@@ -610,7 +571,6 @@ class TestAsyncExitStack(TestBaseExitStack, unittest.TestCase):
                 stack.push_async_callback(callback=_exit, arg=3)
         self.assertEqual(result, [])
 
-    @_async_test
     async def test_async_push(self):
         exc_raised = ZeroDivisionError
         async def _expect_exc(exc_type, exc, exc_tb):
@@ -646,7 +606,6 @@ class TestAsyncExitStack(TestBaseExitStack, unittest.TestCase):
             self.assertIs(stack._exit_callbacks[-1][1], _expect_exc)
             1/0
 
-    @_async_test
     async def test_enter_async_context(self):
         class TestCM(object):
             async def __aenter__(self):
@@ -668,7 +627,6 @@ class TestAsyncExitStack(TestBaseExitStack, unittest.TestCase):
 
         self.assertEqual(result, [1, 2, 3, 4])
 
-    @_async_test
     async def test_enter_async_context_errors(self):
         class LacksEnterAndExit:
             pass
@@ -688,7 +646,6 @@ class TestAsyncExitStack(TestBaseExitStack, unittest.TestCase):
                 await stack.enter_async_context(LacksExit())
             self.assertFalse(stack._exit_callbacks)
 
-    @_async_test
     async def test_async_exit_exception_chaining(self):
         # Ensure exception chaining matches the reference behaviour
         async def raise_exc(exc):
@@ -720,7 +677,6 @@ class TestAsyncExitStack(TestBaseExitStack, unittest.TestCase):
         self.assertIsInstance(inner_exc, ValueError)
         self.assertIsInstance(inner_exc.__context__, ZeroDivisionError)
 
-    @_async_test
     async def test_async_exit_exception_explicit_none_context(self):
         # Ensure AsyncExitStack chaining matches actual nested `with` statements
         # regarding explicit __context__ = None.
@@ -755,7 +711,6 @@ class TestAsyncExitStack(TestBaseExitStack, unittest.TestCase):
                 else:
                     self.fail("Expected IndexError, but no exception was raised")
 
-    @_async_test
     async def test_instance_bypass_async(self):
         class Example(object): pass
         cm = Example()
@@ -768,8 +723,7 @@ class TestAsyncExitStack(TestBaseExitStack, unittest.TestCase):
         self.assertIs(stack._exit_callbacks[-1][1], cm)
 
 
-class TestAsyncNullcontext(unittest.TestCase):
-    @_async_test
+class TestAsyncNullcontext(unittest.IsolatedAsyncioTestCase):
     async def test_async_nullcontext(self):
         class C:
             pass


### PR DESCRIPTION
After the change:

```
~/Desktop/cpython  main ✗                                                                 
» ./python.exe -m test test_contextlib_async
Using random seed 451969388
0:00:00 load avg: 1.34 Run 1 test sequentially
0:00:00 load avg: 1.34 [1/1] test_contextlib_async

== Tests result: SUCCESS ==

1 test OK.

Total duration: 99 ms
Total tests: run=58
Total test files: run=1/1
Result: SUCCESS
```

```                                                                                        
~/Desktop/cpython  main ✗                                                                 
» ./python.exe Lib/test/test_contextlib_async.py
..........................................................
----------------------------------------------------------------------
Ran 58 tests in 0.063s

OK
                      
```

<!-- gh-issue-number: gh-110378 -->
* Issue: gh-110378
<!-- /gh-issue-number -->
