### PR TITLE
gh-110367: Fix regrtest test_worker_output_on_failure() on ASAN build

### DIFF
--- a/Lib/test/support/__init__.py
+++ b/Lib/test/support/__init__.py
@@ -436,6 +436,14 @@ def skip_if_sanitizer(reason=None, *, address=False, memory=False, ub=False):
     return unittest.skipIf(skip, reason)
 
 
+def set_sanitizer_env_var(env, option):
+    for name in ('ASAN_OPTIONS', 'MSAN_OPTIONS', 'UBSAN_OPTIONS'):
+        if name in env:
+            env[name] += f':{option}'
+        else:
+            env[name] = option
+
+
 def system_must_validate_cert(f):
     """Skip the test on TLS certificate validation failures."""
     @functools.wraps(f)

--- a/Lib/test/test_faulthandler.py
+++ b/Lib/test/test_faulthandler.py
@@ -67,11 +67,7 @@ class FaultHandlerTests(unittest.TestCase):
 
         # Sanitizers must not handle SIGSEGV (ex: for test_enable_fd())
         option = 'handle_segv=0'
-        for name in ('ASAN_OPTIONS', 'MSAN_OPTIONS', 'UBSAN_OPTIONS'):
-            if name in env:
-                env[name] += f':{option}'
-            else:
-                env[name] = option
+        support.set_sanitizer_env_var(env, option)
 
         with support.SuppressCrashReport():
             process = script_helper.spawn_python('-c', code,

--- a/Lib/test/test_regrtest.py
+++ b/Lib/test/test_regrtest.py
@@ -674,7 +674,7 @@ class BaseTestCase(unittest.TestCase):
         if 'stderr' not in kw:
             kw['stderr'] = subprocess.STDOUT
         proc = subprocess.run(args,
-                              universal_newlines=True,
+                              text=True,
                               input=input,
                               stdout=subprocess.PIPE,
                               **kw)
@@ -756,8 +756,8 @@ class ProgramsTestCase(BaseTestCase):
         self.check_executed_tests(output, self.tests,
                                   randomize=True, stats=len(self.tests))
 
-    def run_tests(self, args):
-        output = self.run_python(args)
+    def run_tests(self, args, env=None):
+        output = self.run_python(args, env=env)
         self.check_output(output)
 
     def test_script_regrtest(self):
@@ -2061,7 +2061,14 @@ class ArgsTestCase(BaseTestCase):
         """)
         testname = self.create_test(code=code)
 
-        output = self.run_tests("-j1", testname, exitcode=EXITCODE_BAD_TEST)
+        # Sanitizers must not handle SIGSEGV (ex: for test_enable_fd())
+        env = dict(os.environ)
+        option = 'handle_segv=0'
+        support.set_sanitizer_env_var(env, option)
+
+        output = self.run_tests("-j1", testname,
+                                exitcode=EXITCODE_BAD_TEST,
+                                env=env)
         self.check_executed_tests(output, testname,
                                   failed=[testname],
                                   stats=0, parallel=True)


### PR DESCRIPTION
Set ASAN_OPTIONS="handle_segv=0" env var to run the test.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-110367 -->
* Issue: gh-110367
<!-- /gh-issue-number -->
