### PR TITLE
gh-109329: Add stat for "trace too short"

### DIFF
--- a/Include/cpython/pystats.h
+++ b/Include/cpython/pystats.h
@@ -110,6 +110,7 @@ typedef struct _optimization_stats {
     uint64_t trace_stack_overflow;
     uint64_t trace_stack_underflow;
     uint64_t trace_too_long;
+    uint64_t trace_too_short;
     uint64_t inner_loop;
     uint64_t recursive_call;
     UOpStats opcode[512];

--- a/Python/optimizer.c
+++ b/Python/optimizer.c
@@ -798,6 +798,7 @@ done:
         return trace_length;
     }
     else {
+        OPT_STAT_INC(trace_too_short);
         DPRINTF(4,
                 "No trace for %s (%s:%d) at byte offset %d\n",
                 PyUnicode_AsUTF8(code->co_qualname),

--- a/Python/specialize.c
+++ b/Python/specialize.c
@@ -229,6 +229,7 @@ print_optimization_stats(FILE *out, OptimizationStats *stats)
     fprintf(out, "Optimization trace stack overflow: %" PRIu64 "\n", stats->trace_stack_overflow);
     fprintf(out, "Optimization trace stack underflow: %" PRIu64 "\n", stats->trace_stack_underflow);
     fprintf(out, "Optimization trace too long: %" PRIu64 "\n", stats->trace_too_long);
+    fprintf(out, "Optimization trace too short: %" PRIu64 "\n", stats->trace_too_short);
     fprintf(out, "Optimization inner loop: %" PRIu64 "\n", stats->inner_loop);
     fprintf(out, "Optimization recursive call: %" PRIu64 "\n", stats->recursive_call);
 

--- a/Tools/scripts/summarize_stats.py
+++ b/Tools/scripts/summarize_stats.py
@@ -760,6 +760,7 @@ def calculate_optimization_stats(stats):
     trace_stack_overflow = stats["Optimization trace stack overflow"]
     trace_stack_underflow = stats["Optimization trace stack underflow"]
     trace_too_long = stats["Optimization trace too long"]
+    trace_too_short = stats["Optimiztion trace too short"]
     inner_loop = stats["Optimization inner loop"]
     recursive_call = stats["Optimization recursive call"]
 
@@ -771,6 +772,7 @@ def calculate_optimization_stats(stats):
         ("Trace stack overflow", trace_stack_overflow, ""),
         ("Trace stack underflow", trace_stack_underflow, ""),
         ("Trace too long", trace_too_long, ""),
+        ("Trace too short", trace_too_short, ""),
         ("Inner loop found", inner_loop, ""),
         ("Recursive call", recursive_call, ""),
     ]


### PR DESCRIPTION
Adds a simple counter for when the trace is too short.


<!-- gh-issue-number: gh-109329 -->
* Issue: gh-109329
<!-- /gh-issue-number -->
