### PR TITLE
Fix env var typo in perf profiling docs

### DIFF
--- a/Doc/howto/perf_profiling.rst
+++ b/Doc/howto/perf_profiling.rst
@@ -162,8 +162,7 @@ the :option:`!-X` option takes precedence over the environment variable.
 
 Example, using the environment variable::
 
-   $ PYTHONPERFSUPPORT=1
-   $ python script.py
+   $ PYTHONPERFSUPPORT=1 python script.py
    $ perf report -g -i perf.data
 
 Example, using the :option:`!-X` option::


### PR DESCRIPTION


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--110404.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->