### PR TITLE
gh-110383 TimeIt Docs Spelling Fix

### DIFF
--- a/Doc/library/timeit.rst
+++ b/Doc/library/timeit.rst
@@ -151,7 +151,7 @@ The module defines three convenience functions and a public class:
       so that the total time >= 0.2 second, returning the eventual
       (number of loops, time taken for that number of loops). It calls
       :meth:`.timeit` with increasing numbers from the sequence 1, 2, 5,
-      10, 20, 50, ... until the time taken is at least 0.2 second.
+      10, 20, 50, ... until the time taken is at least 0.2 seconds.
 
       If *callback* is given and is not ``None``, it will be called after
       each trial with two arguments: ``callback(number, time_taken)``.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
https://mail.python.org/archives/list/docs@python.org/thread/CQON3MGDEN6CY5KFXXBY4FTCG2FIIDTM/
In the docs, https://docs.python.org/3/library/timeit.html#timeit.Timer.autorange, the last line of the first paragraph read:

> until the time taken is at least 0.2 second.

This pull request changes that to read:

> until the time taken is at least 0.2 seconds.

Mentioned as the second-to-last issue in #110383 

<!-- gh-issue-number: gh-110383 -->
* Issue: gh-110383
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--110407.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->