### PR TITLE
gh-110167: Fix test_socket deadlock in doCleanups()

### DIFF
--- a/Lib/test/test_socket.py
+++ b/Lib/test/test_socket.py
@@ -218,8 +218,13 @@ class SocketUDPLITETest(SocketUDPTest):
 class ThreadSafeCleanupTestCase:
     """Subclass of unittest.TestCase with thread-safe cleanup methods.
 
-    This subclass protects the addCleanup() and doCleanups() methods
-    with a recursive lock.
+    This subclass protects the addCleanup() method with a recursive lock.
+
+    doCleanups() is called when the server completed, but the client can still
+    be running in its thread especially if the server failed with a timeout.
+    Don't put a lock on doCleanups() to prevent deadlock between addCleanup()
+    called in the client and doCleanups() waiting for self.done.wait of
+    ThreadableTest._setUp() (gh-110167)
     """
 
     def __init__(self, *args, **kwargs):
@@ -230,9 +235,6 @@ class ThreadSafeCleanupTestCase:
         with self._cleanup_lock:
             return super().addCleanup(*args, **kwargs)
 
-    def doCleanups(self, *args, **kwargs):
-        with self._cleanup_lock:
-            return super().doCleanups(*args, **kwargs)
 
 class SocketCANTest(unittest.TestCase):
 

--- a/Misc/NEWS.d/next/Tests/2023-10-05-19-33-49.gh-issue-110167.mIdj3v.rst
+++ b/Misc/NEWS.d/next/Tests/2023-10-05-19-33-49.gh-issue-110167.mIdj3v.rst
@@ -1,0 +1,5 @@
+Fix a deadlock in test_socket when server fails with a timeout but the
+client is still running in its thread. Don't hold a lock to call cleanup
+functions in doCleanups(). One of the cleanup function waits until the
+client completes, whereas the client could deadlock if it called
+addCleanup() in such situation. Patch by Victor Stinner.


### PR DESCRIPTION
Fix a deadlock in test_socket when server fails with a timeout but the client is still running in its timeout. Don't hold a lock to call cleanup functions in doCleanups(). One of the cleanup function waits until the client completes, whereas the client could deadlock if it called addCleanup() in such situation.

doCleanups() is called when the server completed, but the client can still be running in its thread especially if the server failed with a timeout. Don't put a lock on doCleanups() to prevent deadlock between addCleanup() called in the client and doCleanups() waiting for self.done.wait of ThreadableTest._setUp().

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-110167 -->
* Issue: gh-110167
<!-- /gh-issue-number -->
