### PR TITLE
gh-109287: fix overrides in cases generator

### DIFF
--- a/Lib/test/test_generated_cases.py
+++ b/Lib/test/test_generated_cases.py
@@ -598,6 +598,41 @@ class TestGeneratedCases(unittest.TestCase):
         """
         self.run_cases_test(input, output)
 
+    def test_override_inst(self):
+        input = """
+        inst(OP, (--)) {
+            spam();
+        }
+        override inst(OP, (--)) {
+            ham();
+        }
+        """
+        output = """
+        TARGET(OP) {
+            ham();
+            DISPATCH();
+        }
+        """
+        self.run_cases_test(input, output)
+
+    def test_override_op(self):
+        input = """
+        op(OP, (--)) {
+            spam();
+        }
+        macro(M) = OP;
+        override op(OP, (--)) {
+            ham();
+        }
+        """
+        output = """
+        TARGET(M) {
+            ham();
+            DISPATCH();
+        }
+        """
+        self.run_cases_test(input, output)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/Tools/cases_generator/analysis.py
+++ b/Tools/cases_generator/analysis.py
@@ -12,7 +12,6 @@ from instructions import (
     InstructionOrCacheEffect,
     MacroInstruction,
     MacroParts,
-    OverriddenInstructionPlaceHolder,
     PseudoInstruction,
 )
 import parsing
@@ -66,7 +65,6 @@ class Analyzer:
         parsing.InstDef
         | parsing.Macro
         | parsing.Pseudo
-        | OverriddenInstructionPlaceHolder
     ]
     instrs: dict[str, Instruction]  # Includes ops
     macros: dict[str, parsing.Macro]
@@ -141,7 +139,7 @@ class Analyzer:
             match thing:
                 case parsing.InstDef(name=name):
                     macro: parsing.Macro | None = None
-                    if thing.kind == "inst":
+                    if thing.kind == "inst" and not thing.override:
                         macro = parsing.Macro(name, [parsing.OpName(name)])
                     if name in self.instrs:
                         if not thing.override:
@@ -150,12 +148,7 @@ class Analyzer:
                                 f"previous definition @ {self.instrs[name].inst.context}",
                                 thing_first_token,
                             )
-                        placeholder = OverriddenInstructionPlaceHolder(name=name)
-                        self.everything[instrs_idx[name]] = placeholder
-                        if macro is not None:
-                            self.warning(
-                                f"Overriding desugared {macro.name} may not work", thing
-                            )
+                        self.everything[instrs_idx[name]] = thing
                     if name not in self.instrs and thing.override:
                         raise psr.make_syntax_error(
                             f"Definition of '{name}' @ {thing.context} is supposed to be "

--- a/Tools/cases_generator/generate_cases.py
+++ b/Tools/cases_generator/generate_cases.py
@@ -26,7 +26,6 @@ from instructions import (
     MacroInstruction,
     MacroParts,
     PseudoInstruction,
-    OverriddenInstructionPlaceHolder,
     TIER_ONE,
     TIER_TWO,
 )
@@ -208,8 +207,6 @@ class Generator(Analyzer):
         popped_data: list[tuple[AnyInstruction, str]] = []
         pushed_data: list[tuple[AnyInstruction, str]] = []
         for thing in self.everything:
-            if isinstance(thing, OverriddenInstructionPlaceHolder):
-                continue
             if isinstance(thing, parsing.Macro) and thing.name in self.instrs:
                 continue
             instr, popped, pushed = self.get_stack_effect_info(thing)
@@ -393,8 +390,6 @@ class Generator(Analyzer):
         for thing in self.everything:
             format: str | None = None
             match thing:
-                case OverriddenInstructionPlaceHolder():
-                    continue
                 case parsing.InstDef():
                     format = self.instrs[thing.name].instr_fmt
                 case parsing.Macro():
@@ -492,8 +487,6 @@ class Generator(Analyzer):
                 # Write metadata for each instruction
                 for thing in self.everything:
                     match thing:
-                        case OverriddenInstructionPlaceHolder():
-                            continue
                         case parsing.InstDef():
                             self.write_metadata_for_inst(self.instrs[thing.name])
                         case parsing.Macro():
@@ -774,8 +767,6 @@ class Generator(Analyzer):
             n_macros = 0
             for thing in self.everything:
                 match thing:
-                    case OverriddenInstructionPlaceHolder():
-                        self.write_overridden_instr_place_holder(thing)
                     case parsing.InstDef():
                         pass
                     case parsing.Macro():
@@ -834,14 +825,6 @@ class Generator(Analyzer):
         print(
             f"Wrote some stuff to {abstract_interpreter_filename}",
             file=sys.stderr,
-        )
-
-    def write_overridden_instr_place_holder(
-        self, place_holder: OverriddenInstructionPlaceHolder
-    ) -> None:
-        self.out.emit("")
-        self.out.emit(
-            f"{self.out.comment} TARGET({place_holder.name}) overridden by later definition"
         )
 
 

--- a/Tools/cases_generator/instructions.py
+++ b/Tools/cases_generator/instructions.py
@@ -295,11 +295,6 @@ class PseudoInstruction:
     instr_flags: InstructionFlags
 
 
-@dataclasses.dataclass
-class OverriddenInstructionPlaceHolder:
-    name: str
-
-
 AnyInstruction = Instruction | MacroInstruction | PseudoInstruction
 
 


### PR DESCRIPTION
The fix here is based on fully buying into the idea that `inst` is just syntactic sugar for an `op` and `macro`, and the principle that one does not ever override a macro, one overrides only the definition of an op; `override inst` is equivalent to `override op`. One can freely override an op (whether originally defined via `op` or implicitly via `inst`) that may be part of one or several macros (explicit or implicit), and the override will be reflected in the generated contents of each macro.

I think this approach makes sense; since explicitly-defined macros have never supported overrides, it's not clear why we should try to special-case some concept of overriding implicitly-defined macros.

I also _think_ this approach should meet all our actual override needs; if we discover that I'm wrong, we can propose a later PR to generally add support for macro overrides.

This also implies some behavioral changes. The idea of a "placeholder comment" for overrides, or trying to emit the override contents later in the output, no longer makes much sense, since ops do not directly appear in the output, only macros do, and the macro itself is not overridden.

We could add an "// override" comment in some form; I didn't do that here and don't think it's needed. If you are trying to debug why your generated cases look the way they do, you should be enabling `#line` directives, which will give you much clearer provenance details.

<!-- gh-issue-number: gh-109287 -->
* Issue: gh-109287
<!-- /gh-issue-number -->
