### PR TITLE
gh-110383: Swap 'the all' -> 'all the' in socket docs

### DIFF
--- a/Doc/library/socket.rst
+++ b/Doc/library/socket.rst
@@ -2100,7 +2100,7 @@ The next two examples are identical to the above two, but support both IPv4 and
 IPv6. The server side will listen to the first address family available (it
 should listen to both instead). On most of IPv6-ready systems, IPv6 will take
 precedence and the server may not accept IPv4 traffic. The client side will try
-to connect to the all addresses returned as a result of the name resolution, and
+to connect to all the addresses returned as a result of the name resolution, and
 sends traffic to the first one connected successfully. ::
 
    # Echo server program


### PR DESCRIPTION
Continues #110383, swaps 'the all' -> 'all the' in socket docs 
Reported in https://mail.python.org/archives/list/docs@python.org/thread/T7BAG3ROH3YT3YTAWCUE7CMZ2FI6VO72/


<!-- gh-issue-number: gh-110383 -->
* Issue: gh-110383
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--110434.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->