### PR TITLE
gh-103053: Fix BUILDPYTHON target of Makefile

### DIFF
--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -783,7 +783,10 @@ clinic-tests: check-clean-src $(srcdir)/Lib/test/clinic.test.c
 
 # Build the interpreter
 $(BUILDPYTHON):	Programs/python.o $(LINK_PYTHON_DEPS)
-	$(LINKCC) $(PY_CORE_LDFLAGS) $(LINKFORSHARED) -o $@ Programs/python.o $(LINK_PYTHON_OBJS) $(LIBS) $(MODLIBS) $(SYSLIBS)
+	@ # gh-103053: Use "-o $(BUILDPYTHON)" instead of "-o $@".
+	@ # On FreeBSD when Python is built out of tree, $@ contains the source
+	@ # directory, whereas the build directory is expected.
+	$(LINKCC) $(PY_CORE_LDFLAGS) $(LINKFORSHARED) -o $(BUILDPYTHON) Programs/python.o $(LINK_PYTHON_OBJS) $(LIBS) $(MODLIBS) $(SYSLIBS)
 
 platform: $(PYTHON_FOR_BUILD_DEPS) pybuilddir.txt
 	$(RUNSHARED) $(PYTHON_FOR_BUILD) -c 'import sys ; from sysconfig import get_platform ; print("%s-%d.%d" % (get_platform(), *sys.version_info[:2]))' >platform

--- a/Misc/NEWS.d/next/Build/2023-10-06-01-35-22.gh-issue-103053.qyJ0ru.rst
+++ b/Misc/NEWS.d/next/Build/2023-10-06-01-35-22.gh-issue-103053.qyJ0ru.rst
@@ -1,0 +1,4 @@
+On FreeBSD when Python is built out of tree, the "python" program was
+created in the source directory instead of build directory. Fix the Makefile
+to write the "python" program in the build directory. Patch by Victor
+Stinner.


### PR DESCRIPTION
On FreeBSD when Python is built out of tree, the "python" program was
created in the source directory instead of build directory. Fix the
Makefile to write the "python" program in the build directory.


<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-103053 -->
* Issue: gh-103053
<!-- /gh-issue-number -->
