### PR TITLE
gh-103053: Fix test_tools.test_freeze on FreeBSD

### DIFF
--- a/Misc/NEWS.d/next/Tests/2023-10-06-02-32-18.gh-issue-103053.VfxBLI.rst
+++ b/Misc/NEWS.d/next/Tests/2023-10-06-02-32-18.gh-issue-103053.VfxBLI.rst
@@ -1,0 +1,3 @@
+Fix test_tools.test_freeze on FreeBSD: run "make distclean" instead of "make
+clean" in the copied source directory to remove also the "python" program.
+Patch by Victor Stinner.


### PR DESCRIPTION
Fix test_tools.test_freeze on FreeBSD: run "make distclean" instead of "make clean" in the copied source directory to remove also the "python" program.

Other test_freeze changes:

* Log executed commands and directories, and the current directory.
* No longer uses make -C option to change the directory, instead use subprocess cwd parameter.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-103053 -->
* Issue: gh-103053
<!-- /gh-issue-number -->
