### PR TITLE
gh-84978: expose __float__ dunder method as as_float

### DIFF
--- a/Doc/library/operator.rst
+++ b/Doc/library/operator.rst
@@ -116,6 +116,10 @@ The mathematical and bitwise operations are the most numerous:
       The result always has exact type :class:`int`.  Previously, the result
       could have been an instance of a subclass of ``int``.
 
+.. function:: as_float(a)
+              __float__(a)
+
+   Return *a* converted to a float.  Equivalent to ``a.__float__()``.
 
 .. function:: inv(obj)
               invert(obj)

--- a/Lib/operator.py
+++ b/Lib/operator.py
@@ -10,7 +10,7 @@ for convenience.
 This is the pure Python implementation of the module.
 """
 
-__all__ = ['abs', 'add', 'and_', 'attrgetter', 'call', 'concat', 'contains', 'countOf',
+__all__ = ['abs', 'add', 'and_', 'attrgetter', 'as_float', 'call', 'concat', 'contains', 'countOf',
            'delitem', 'eq', 'floordiv', 'ge', 'getitem', 'gt', 'iadd', 'iand',
            'iconcat', 'ifloordiv', 'ilshift', 'imatmul', 'imod', 'imul',
            'index', 'indexOf', 'inv', 'invert', 'ior', 'ipow', 'irshift',
@@ -87,6 +87,10 @@ def floordiv(a, b):
 def index(a):
     "Same as a.__index__()."
     return a.__index__()
+
+def as_float(a):
+    "Same as a.__float__()."
+    return a.__float__()
 
 def inv(a):
     "Same as ~a."
@@ -432,6 +436,7 @@ __and__ = and_
 __call__ = call
 __floordiv__ = floordiv
 __index__ = index
+__float__ = as_float
 __inv__ = inv
 __invert__ = invert
 __lshift__ = lshift

--- a/Lib/test/test_operator.py
+++ b/Lib/test/test_operator.py
@@ -142,6 +142,14 @@ class OperatorTestCase:
         self.assertRaises(TypeError, operator.add, None, None)
         self.assertEqual(operator.add(3, 4), 7)
 
+    def test_as_float(self):
+        from fractions import Fraction as F
+
+        operator = self.module
+        self.assertRaises(TypeError, operator.as_float)
+        self.assertRaises(AttributeError, operator.as_float, None)
+        self.assertEqual(operator.as_float(F(1, 2)), 0.5)
+
     def test_bitwise_and(self):
         operator = self.module
         self.assertRaises(TypeError, operator.and_)

--- a/Misc/NEWS.d/next/Library/2023-10-06-09-36-06.gh-issue-84978.WVF04J.rst
+++ b/Misc/NEWS.d/next/Library/2023-10-06-09-36-06.gh-issue-84978.WVF04J.rst
@@ -1,0 +1,2 @@
+Expose :meth:`~object.__float__` as :func:`operator.as_float`.  Patch by
+Sergey B Kirpichev.


### PR DESCRIPTION
This is a lightweight alternative for #26827 (an alternate constructor could be more discoverable option).  Similar functions could be added for ``__complex__()`` and ``__int__()`` methods.  But, probably, support of float subclasses in ``__float__()`` should be removed first (see #109311).

Of course, this is not an equivalent to ``PyFloat_AsDouble()``, which tries to use ``__index__()`` dunder if there is no ``__float__()`` one.  But maybe it could serve at least as a partial solution for the issue?

---------------------------
to decide:
- name: as_float vs float (c.f. index)?

-----
<!-- gh-issue-number: gh-84978 -->
* Issue: gh-84978
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--110460.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->