### PR TITLE
gh-101100: Fix sphinx warnings in `library/getpass.rst`

### DIFF
--- a/Doc/library/getpass.rst
+++ b/Doc/library/getpass.rst
@@ -43,7 +43,7 @@ The :mod:`getpass` module provides two functions:
    Return the "login name" of the user.
 
    This function checks the environment variables :envvar:`LOGNAME`,
-   :envvar:`USER`, :envvar:`LNAME` and :envvar:`USERNAME`, in order, and
+   :envvar:`USER`, :envvar:`!LNAME` and :envvar:`USERNAME`, in order, and
    returns the value of the first one which is set to a non-empty string.  If
    none are set, the login name from the password database is returned on
    systems which support the :mod:`pwd` module, otherwise, an exception is

--- a/Doc/tools/.nitignore
+++ b/Doc/tools/.nitignore
@@ -67,7 +67,6 @@ Doc/library/fcntl.rst
 Doc/library/ftplib.rst
 Doc/library/functions.rst
 Doc/library/functools.rst
-Doc/library/getpass.rst
 Doc/library/gettext.rst
 Doc/library/gzip.rst
 Doc/library/http.client.rst


### PR DESCRIPTION
Before:

```
/Users/sobolev/Desktop/cpython/Doc/library/getpass.rst:45: WARNING: 'envvar' reference target not found: LNAME
```

I don't think that we need to document this Linux-specific variable.
We don't document any other env vars from this function:

```
~/Desktop/cpython  main ✗                                                                 
» ag '.. envvar:: USER' Doc
                                                                                           
~/Desktop/cpython  main ✗                                                              1 ⚠️
» ag '.. envvar:: LOG' Doc 
```

But, they are pre-defined in Sphinx, I guess. But, not `LNAME`.
So, just ignore it.

<!-- gh-issue-number: gh-101100 -->
* Issue: gh-101100
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--110461.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->