### PR TITLE
gh-110437: Allow overriding VCRuntimeDLL with a semicolon separated list of DLLs to bundle

### DIFF
--- a/Misc/NEWS.d/next/Windows/2023-10-06-14-20-14.gh-issue-110437.xpYy9q.rst
+++ b/Misc/NEWS.d/next/Windows/2023-10-06-14-20-14.gh-issue-110437.xpYy9q.rst
@@ -1,0 +1,2 @@
+Allows overriding the source of VC redistributables so that releases can be
+guaranteed to never downgrade between updates.

--- a/PCbuild/pyproject.props
+++ b/PCbuild/pyproject.props
@@ -233,7 +233,10 @@ public override bool Execute() {
   </Target>
 
   <Target Name="FindVCRuntime" Returns="VCRuntimeDLL" DependsOnTargets="FindVCRedistDir">
-    <ItemGroup Condition="$(VCInstallDir) != ''">
+    <ItemGroup Condition="$(VCRuntimeDLL) != ''">
+      <VCRuntimeDLL Include="$(VCRuntimeDLL)" />
+    </ItemGroup>
+    <ItemGroup Condition="$(VCInstallDir) != '' and $(VCRuntimeDLL) == ''">
       <VCRuntimeDLL Include="$(VCRedistDir)\Microsoft.VC*.CRT\vcruntime*.dll" />
     </ItemGroup>
 


### PR DESCRIPTION
Related change to our release build is at https://github.com/python/release-tools/pull/63

There's no need for us to always override the DLLs, but it's useful to do it when building installers.

<!-- gh-issue-number: gh-110437 -->
* Issue: gh-110437
<!-- /gh-issue-number -->
