### PR TITLE
Docs: double colon at end of paragraph causes doctest directive to display on website

### DIFF
--- a/Doc/tutorial/floatingpoint.rst
+++ b/Doc/tutorial/floatingpoint.rst
@@ -137,7 +137,7 @@ the :func:`math.isclose` function can be useful for comparing inexact values:
    True
 
 Alternatively, the :func:`round` function can be used to compare rough
-approximations::
+approximations:
 
 .. doctest::
 


### PR DESCRIPTION
The presence of a double colon is causing `.. doctest::` to display in Tutorial 15, **Floating Point Arithmetic: Issues and Limitations** doc: https://docs.python.org/3/tutorial/floatingpoint.html

![image](https://github.com/python/cpython/assets/9964605/9581df9f-ad66-4642-8bcf-9b79f767db4f)

Removing the colon should allow it to parse the directive properly.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--110485.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->