### PR TITLE
gh-106670: Set convenience variable for post mortem debugging

### DIFF
--- a/Lib/pdb.py
+++ b/Lib/pdb.py
@@ -304,6 +304,14 @@ class Pdb(bdb.Bdb, cmd.Cmd):
         # cache it here to ensure that modifications are not overwritten.
         self.curframe_locals = self.curframe.f_locals
         self.set_convenience_variable(self.curframe, '_frame', self.curframe)
+
+        if self._chained_exceptions:
+            self.set_convenience_variable(
+                self.curframe,
+                '_exception',
+                self._chained_exceptions[self._chained_exception_index],
+            )
+
         return self.execRcLines()
 
     # Can be executed earlier than 'setup' if desired

--- a/Lib/test/test_pdb.py
+++ b/Lib/test/test_pdb.py
@@ -859,9 +859,11 @@ def test_post_mortem_chained():
     >>> with PdbTestInput([  # doctest: +ELLIPSIS, +NORMALIZE_WHITESPACE
     ...     'exceptions',
     ...     'exceptions 0',
+    ...     '$_exception',
     ...     'up',
     ...     'down',
     ...     'exceptions 1',
+    ...     '$_exception',
     ...     'up',
     ...     'down',
     ...     'exceptions -1',
@@ -882,6 +884,8 @@ def test_post_mortem_chained():
     (Pdb) exceptions 0
     > <doctest test.test_pdb.test_post_mortem_chained[0]>(3)test_function_2()
     -> 1/0
+    (Pdb) $_exception
+    ZeroDivisionError('division by zero')
     (Pdb) up
     > <doctest test.test_pdb.test_post_mortem_chained[1]>(3)test_function_reraise()
     -> test_function_2()
@@ -891,6 +895,8 @@ def test_post_mortem_chained():
     (Pdb) exceptions 1
     > <doctest test.test_pdb.test_post_mortem_chained[1]>(5)test_function_reraise()
     -> raise ZeroDivisionError('reraised') from e
+    (Pdb) $_exception
+    ZeroDivisionError('reraised')
     (Pdb) up
     > <doctest test.test_pdb.test_post_mortem_chained[2]>(5)test_function()
     -> test_function_reraise()

--- a/Misc/NEWS.d/next/Library/2023-10-07-00-18-40.gh-issue-106670.kCGyRc.rst
+++ b/Misc/NEWS.d/next/Library/2023-10-07-00-18-40.gh-issue-106670.kCGyRc.rst
@@ -1,1 +1,1 @@
-Set convenience variable ``$_exception`` for post mortem debugging
+In :mod:`pdb`, set convenience variable ``$_exception`` for post mortem debugging.

--- a/Misc/NEWS.d/next/Library/2023-10-07-00-18-40.gh-issue-106670.kCGyRc.rst
+++ b/Misc/NEWS.d/next/Library/2023-10-07-00-18-40.gh-issue-106670.kCGyRc.rst
@@ -1,0 +1,1 @@
+Set convenience variable ``$_exception`` for post mortem debugging


### PR DESCRIPTION
This is a minor improvement to the newly supported chained exception feature.

We have convenience variable `$_exception` which stores the exception object when an exception is being raised. We can reuse that when we are in post mortem mode analyzing exceptions.

<!-- gh-issue-number: gh-106670 -->
* Issue: gh-106670
<!-- /gh-issue-number -->
