### PR TITLE
Docs: Polish profile documentation

### DIFF
--- a/Doc/library/profile.rst
+++ b/Doc/library/profile.rst
@@ -121,7 +121,7 @@ results to a file by specifying a filename to the :func:`run` function::
 The :class:`pstats.Stats` class reads profile results from a file and formats
 them in various ways.
 
-You can also do inline profiling with :class:`Profile`::
+You can also do inline profiling with :class:`cProfile.Profile`::
 
    import cProfile
    import re

--- a/Doc/library/profile.rst
+++ b/Doc/library/profile.rst
@@ -54,7 +54,7 @@ This section is provided for users that "don't want to read the manual." It
 provides a very brief overview, and allows a user to rapidly perform profiling
 on an existing application.
 
-To profile a function that takes a single argument, you can do::
+To profile a statement with the namespace of ``__main__``, you can do::
 
    import cProfile
    import re
@@ -121,6 +121,14 @@ results to a file by specifying a filename to the :func:`run` function::
 The :class:`pstats.Stats` class reads profile results from a file and formats
 them in various ways.
 
+You can also do inline profiling with :class:`Profile`::
+
+   import cProfile
+   import re
+   with cProfile.Profile() as pr:
+       re.compile("foo|bar")
+   pr.print_stats()
+
 .. _profile-cli:
 
 The files :mod:`cProfile` and :mod:`profile` can also be invoked as a script to
@@ -140,6 +148,9 @@ the output by. This only applies when ``-o`` is not supplied.
 
    .. versionadded:: 3.8
       Added the ``-m`` option to :mod:`profile`.
+
+Note that if the process is terminated by ``SIGTERM`` during profiling, no
+results will be generated/printed.
 
 The :mod:`pstats` module's :class:`~pstats.Stats` class has a variety of methods
 for manipulating and printing the data saved into a profile results file::
@@ -315,11 +326,6 @@ functions:
    .. method:: runcall(func, /, *args, **kwargs)
 
       Profile ``func(*args, **kwargs)``
-
-Note that profiling will only work if the called command/function actually
-returns.  If the interpreter is terminated (e.g. via a :func:`sys.exit` call
-during the called command/function execution) no profiling results will be
-printed.
 
 .. _profile-stats:
 
@@ -577,23 +583,20 @@ implementations.
 Limitations
 ===========
 
-One limitation has to do with accuracy of timing information. There is a
-fundamental problem with deterministic profilers involving accuracy.  The most
-obvious restriction is that the underlying "clock" is only ticking at a rate
-(typically) of about .001 seconds.  Hence no measurements will be more accurate
-than the underlying clock.  If enough measurements are taken, then the "error"
-will tend to average out. Unfortunately, removing this first error induces a
-second source of error.
+To avoid infinite recursion, :mod:`profile` and :mod:`cProfile` do not work
+inside the trace function set by :func:`sys.settrace` or :func:`sys.setprofile`.
 
-The second problem is that it "takes a while" from when an event is dispatched
+It "takes a while" from when an event is dispatched
 until the profiler's call to get the time actually *gets* the state of the
 clock.  Similarly, there is a certain lag when exiting the profiler event
 handler from the time that the clock's value was obtained (and then squirreled
 away), until the user's code is once again executing.  As a result, functions
 that are called many times, or call many functions, will typically accumulate
-this error. The error that accumulates in this fashion is typically less than
-the accuracy of the clock (less than one clock tick), but it *can* accumulate
-and become very significant.
+this error.
+
+Also, the logic in the profiler event handler takes time to execute, which
+will introduce skew into the results, making the functions slower than they
+would be if the profiler was not running.
 
 The problem is more important with :mod:`profile` than with the lower-overhead
 :mod:`cProfile`.  For this reason, :mod:`profile` provides a means of

--- a/Doc/library/profile.rst
+++ b/Doc/library/profile.rst
@@ -54,7 +54,7 @@ This section is provided for users that "don't want to read the manual." It
 provides a very brief overview, and allows a user to rapidly perform profiling
 on an existing application.
 
-To profile a statement with the namespace of ``__main__``, you can do::
+To profile a statement with the namespace of :mod:`__main__`, you can do::
 
    import cProfile
    import re

--- a/Doc/library/profile.rst
+++ b/Doc/library/profile.rst
@@ -149,8 +149,9 @@ the output by. This only applies when ``-o`` is not supplied.
    .. versionadded:: 3.8
       Added the ``-m`` option to :mod:`profile`.
 
-Note that if the process is terminated by ``SIGTERM`` during profiling, no
-results will be generated/printed.
+Note that if the process is terminated abruptly (for example, by
+:data:`~signal.SIGTERM` or :data:`~signal.SIGKILL`) during profiling,
+no results will be generated/printed.
 
 The :mod:`pstats` module's :class:`~pstats.Stats` class has a variety of methods
 for manipulating and printing the data saved into a profile results file::

--- a/Doc/library/profile.rst
+++ b/Doc/library/profile.rst
@@ -54,7 +54,7 @@ This section is provided for users that "don't want to read the manual." It
 provides a very brief overview, and allows a user to rapidly perform profiling
 on an existing application.
 
-To profile a statement with the namespace of :mod:`__main__`, you can do::
+To profile a single statement, you can do::
 
    import cProfile
    import re
@@ -585,7 +585,7 @@ Limitations
 ===========
 
 To avoid infinite recursion, :mod:`profile` and :mod:`cProfile` do not work
-inside the trace function set by :func:`sys.settrace` or :func:`sys.setprofile`.
+inside trace functions set using :func:`sys.settrace` or :func:`sys.setprofile`.
 
 It "takes a while" from when an event is dispatched
 until the profiler's call to get the time actually *gets* the state of the

--- a/Doc/library/profile.rst
+++ b/Doc/library/profile.rst
@@ -584,9 +584,6 @@ implementations.
 Limitations
 ===========
 
-To avoid infinite recursion, :mod:`profile` and :mod:`cProfile` do not work
-inside trace functions set using :func:`sys.settrace` or :func:`sys.setprofile`.
-
 It "takes a while" from when an event is dispatched
 until the profiler's call to get the time actually *gets* the state of the
 clock.  Similarly, there is a certain lag when exiting the profiler event
@@ -608,6 +605,9 @@ negative numbers (when call counts are exceptionally low, and the gods of
 probability work against you :-). )  Do *not* be alarmed by negative numbers in
 the profile.  They should *only* appear if you have calibrated your profiler,
 and the results are actually better than without calibration.
+
+To avoid infinite recursion, :mod:`profile` and :mod:`cProfile` do not work
+inside trace functions set using :func:`sys.settrace` or :func:`sys.setprofile`.
 
 
 .. _profile-calibration:

--- a/Doc/library/profile.rst
+++ b/Doc/library/profile.rst
@@ -121,7 +121,7 @@ results to a file by specifying a filename to the :func:`run` function::
 The :class:`pstats.Stats` class reads profile results from a file and formats
 them in various ways.
 
-You can also do inline profiling with :class:`cProfile.Profile`::
+You can also do inline profiling with :class:`cProfile.Profile <profile.Profile>`::
 
    import cProfile
    import re


### PR DESCRIPTION
There are a couple of issues with the current (outdated) documentation

* `To profile a function that takes a single argument` is simply misleading. It does not have to be a function, and `a single argument` is .. just wrong.
* Users do not like "code as string" and we should at least provide the way to do it with actual code in the "instant manual".
* The original statement of cprofile not being able to handle `sys.exit()` is wrong - it can. However, #104676 mentioned that it can't handle `SIGTERM`. I moved this statement up - closer to where it should be seen.
* In the limitation section, the claim about clock precision is super old - we know it was there at least 16 years ago, when it was copied from somewhere else. The resolution of the system clock *now* is at ns level. I removed the section directly, we can redo the statement to talk about this - it's still possible that the system clock resolution is an issue, but it's probably much better and definitely not at 0.001s level.

<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--110494.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->