### PR TITLE
gh-110497: Add note about `OSError` being an alias to `IOError` in docs

### DIFF
--- a/Doc/library/ctypes.rst
+++ b/Doc/library/ctypes.rst
@@ -1403,7 +1403,8 @@ way is to instantiate one of the following classes:
    failure, an :class:`OSError` is automatically raised.
 
    .. versionchanged:: 3.3
-      :exc:`WindowsError` used to be raised.
+      :exc:`WindowsError` used to be raised,
+      which is now an alias of :exc:`OSError`.
 
    .. versionchanged:: 3.12
 
@@ -2088,13 +2089,14 @@ Utility functions
 .. function:: WinError(code=None, descr=None)
 
    Windows only: this function is probably the worst-named thing in ctypes. It
-   creates an instance of OSError.  If *code* is not specified,
+   creates an instance of :exc:`OSError`.  If *code* is not specified,
    ``GetLastError`` is called to determine the error code. If *descr* is not
    specified, :func:`FormatError` is called to get a textual description of the
    error.
 
    .. versionchanged:: 3.3
-      An instance of :exc:`WindowsError` used to be created.
+      An instance of :exc:`WindowsError` used to be created, which is now an
+      alias of :exc:`OSError`.
 
 
 .. function:: wstring_at(address, size=-1)

--- a/Doc/library/gettext.rst
+++ b/Doc/library/gettext.rst
@@ -167,7 +167,7 @@ install themselves in the built-in namespace as the function :func:`!_`.
    :class:`NullTranslations` instance if *fallback* is true.
 
    .. versionchanged:: 3.3
-      :exc:`IOError` used to be raised instead of :exc:`OSError`.
+      :exc:`IOError` used to be raised, it is now an alias of :exc:`OSError`.
 
    .. versionchanged:: 3.11
       *codeset* parameter is removed.

--- a/Doc/library/http.cookiejar.rst
+++ b/Doc/library/http.cookiejar.rst
@@ -44,8 +44,8 @@ The module defines the following exception:
    cookies from a file.  :exc:`LoadError` is a subclass of :exc:`OSError`.
 
    .. versionchanged:: 3.3
-      LoadError was made a subclass of :exc:`OSError` instead of
-      :exc:`IOError`.
+      :exc:`LoadError` used to be a subtype of :exc:`IOError`, which is now an
+      alias of :exc:`OSError`.
 
 
 The following classes are provided:

--- a/Doc/library/urllib.error.rst
+++ b/Doc/library/urllib.error.rst
@@ -27,8 +27,8 @@ The following exceptions are raised by :mod:`urllib.error` as appropriate:
       exception instance.
 
    .. versionchanged:: 3.3
-      :exc:`URLError` has been made a subclass of :exc:`OSError` instead
-      of :exc:`IOError`.
+      :exc:`URLError` used to be a subtype of :exc:`IOError`, which is now an
+      alias of :exc:`OSError`.
 
 
 .. exception:: HTTPError(url, code, msg, hdrs, fp)

--- a/Doc/library/zipimport.rst
+++ b/Doc/library/zipimport.rst
@@ -113,7 +113,7 @@ zipimporter Objects
       file wasn't found.
 
       .. versionchanged:: 3.3
-         :exc:`IOError` used to be raised instead of :exc:`OSError`.
+         :exc:`IOError` used to be raised, it is now an alias of :exc:`OSError`.
 
 
    .. method:: get_filename(fullname)


### PR DESCRIPTION


<!-- gh-issue-number: gh-110497 -->
* Issue: gh-110497
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--110498.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->