### PR TITLE
gh-110378: Fix test_async_gen_propagates_generator_exit in test_contextlib_async

### DIFF
--- a/Lib/test/test_contextlib_async.py
+++ b/Lib/test/test_contextlib_async.py
@@ -61,15 +61,11 @@ class TestAbstractAsyncContextManager(unittest.TestCase):
             async with ctx():
                 yield 11
 
-        ret = []
-        exc = ValueError(22)
-        with self.assertRaises(ValueError):
-            async with ctx():
-                async for val in gen():
-                    ret.append(val)
-                    raise exc
-
-        self.assertEqual(ret, [11])
+        g = gen()
+        async for val in g:
+            self.assertEqual(val, 11)
+            break
+        await g.aclose()
 
     def test_exit_is_abstract(self):
         class MissingAexit(AbstractAsyncContextManager):


### PR DESCRIPTION
It now fails if the original bug is not fixed, and no longer produce ResourceWarning with fixed code.


<!-- gh-issue-number: gh-110378 -->
* Issue: gh-110378
<!-- /gh-issue-number -->
