### PR TITLE
Update ConfigParser docs defining valid section name

### DIFF
--- a/Doc/library/configparser.rst
+++ b/Doc/library/configparser.rst
@@ -271,7 +271,7 @@ out.  Values can also span multiple lines, as long as they are indented deeper
 than the first line of the value.  Depending on the parser's mode, blank lines
 may be treated as parts of multiline values or ignored.
 
-By default,  a valid section name can be any string that does not contain '\\n' or ']'.
+By default, a valid section name can be any string that does not contain '\\n'.
 To change this, see :attr:`ConfigParser.SECTCRE`.
 
 Configuration files may include comments, prefixed by specific


### PR DESCRIPTION
Hi.

Just a trivial enhancement to the documentation. The `ConfigParser.SECTCRE` regex was updated in https://github.com/python/cpython/pull/17129 to allow `]` in section names, but the documentation does not reflect that.

<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--110506.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->