### PR TITLE
gh-89902: Deprecate non-standard format specifier "N" for Decimal

### DIFF
--- a/Doc/whatsnew/3.13.rst
+++ b/Doc/whatsnew/3.13.rst
@@ -345,6 +345,10 @@ Deprecated
   in :data:`~dis.hasarg` instead.
   (Contributed by Irit Katriel in :gh:`109319`.)
 
+* Deprecate non-standard format specifier "N" for :class:`decimal.Decimal`.
+  It was not documented and only supported in the C implementation.
+  (Contributed by Serhiy Storchaka in :gh:`89902`.)
+
 
 Pending Removal in Python 3.14
 ------------------------------

--- a/Lib/test/test_decimal.py
+++ b/Lib/test/test_decimal.py
@@ -1222,6 +1222,23 @@ class FormatTest:
         self.assertEqual(get_fmt(Decimal('-1.5'), dotsep_wide, '020n'),
                          '-0\u00b4000\u00b4000\u00b4000\u00b4001\u00bf5')
 
+    def test_deprecated_N_format(self):
+        Decimal = self.decimal.Decimal
+        h = Decimal('6.62607015e-34')
+        if self.decimal == C:
+            with self.assertWarns(DeprecationWarning) as cm:
+                r = format(h, 'N')
+            self.assertEqual(cm.filename, __file__)
+            self.assertEqual(r, format(h, 'n').upper())
+            with self.assertWarns(DeprecationWarning) as cm:
+                r = format(h, '010.3N')
+            self.assertEqual(cm.filename, __file__)
+            self.assertEqual(r, format(h, '010.3n').upper())
+        else:
+            self.assertRaises(ValueError, format, h, 'N')
+            self.assertRaises(ValueError, format, h, '010.3N')
+
+
     @run_with_locale('LC_ALL', 'ps_AF')
     def test_wide_char_separator_decimal_point(self):
         # locale with wide char separator and decimal point

--- a/Misc/NEWS.d/next/Library/2023-10-07-21-12-28.gh-issue-89902.dCokZj.rst
+++ b/Misc/NEWS.d/next/Library/2023-10-07-21-12-28.gh-issue-89902.dCokZj.rst
@@ -1,0 +1,2 @@
+Deprecate non-standard format specifier "N" for :class:`decimal.Decimal`. It
+was not documented and only supported in the C implementation.

--- a/Modules/_decimal/_decimal.c
+++ b/Modules/_decimal/_decimal.c
@@ -3593,6 +3593,12 @@ dec_format(PyObject *dec, PyObject *args)
     if (replace_fillchar) {
         dec_replace_fillchar(decstring);
     }
+    if (strchr(fmt, 'N') != NULL) {
+        if (PyErr_WarnEx(PyExc_DeprecationWarning,
+                         "Format specifier 'N' is deprecated", 1) < 0) {
+            goto finish;
+        }
+    }
 
     result = PyUnicode_DecodeUTF8(decstring, size, NULL);
 


### PR DESCRIPTION
It was not documented and only supported in the C implementation.


<!-- gh-issue-number: gh-89902 -->
* Issue: gh-89902
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--110508.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->