### PR TITLE
gh-104232: Fix `sys.settrace` docs to reflect the reality

### DIFF
--- a/Doc/library/sys.rst
+++ b/Doc/library/sys.rst
@@ -1554,9 +1554,8 @@ always available.
    function to be used for the new scope, or ``None`` if the scope shouldn't be
    traced.
 
-   The local trace function should return a reference to itself (or to another
-   function for further tracing in that scope), or ``None`` to turn off tracing
-   in that scope.
+   The local trace function should return a reference to itself, or to another
+   function which would then be used as the local trace function for the scope.
 
    If there is any error occurred in the trace function, it will be unset, just
    like ``settrace(None)`` is called.


### PR DESCRIPTION
In our current docs, we claim that:

> The local trace function should return a reference to itself (or to another function for further tracing in that scope), or None to turn off tracing in that scope.

That is not the case, and for as far as we know.

Returning `None` in the local trace function has no effect and it's already the de facto. There are at least 3 issues about this (#104232, #78980 and #56201) and it should not be that difficult to fix this. Rather than changing the behavior which could potentially break someone's code, we can simply change our docs because we never achieved what we claimed anyway, and people are fine with it.

<!-- gh-issue-number: gh-104232 -->
* Issue: gh-104232
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--110516.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->