### PR TITLE
gh-110514: Add PY_THROW to `sys.setprofile` events

### DIFF
--- a/Lib/test/test_sys_setprofile.py
+++ b/Lib/test/test_sys_setprofile.py
@@ -255,6 +255,25 @@ class ProfileHookTestCase(TestCaseBase):
                               (1, 'return', g_ident),
                               ])
 
+    def test_unfinished_generator(self):
+        def f():
+            for i in range(2):
+                yield i
+        def g(p):
+            next(f())
+
+        f_ident = ident(f)
+        g_ident = ident(g)
+        self.check_events(g, [(1, 'call', g_ident),
+                              (2, 'call', f_ident),
+                              (2, 'return', f_ident),
+                              # once more; the generator is being garbage collected
+                              # and it will do a PY_THROW
+                              (2, 'call', f_ident),
+                              (2, 'return', f_ident),
+                              (1, 'return', g_ident),
+                              ])
+
     def test_stop_iteration(self):
         def f():
             for i in range(2):

--- a/Misc/NEWS.d/next/Core and Builtins/2023-10-08-20-08-54.gh-issue-110514.Q9bdRU.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2023-10-08-20-08-54.gh-issue-110514.Q9bdRU.rst
@@ -1,0 +1,1 @@
+Add ``PY_THROW`` to :func:`sys.setprofile` events

--- a/Python/legacy_tracing.c
+++ b/Python/legacy_tracing.c
@@ -378,6 +378,11 @@ _PyEval_SetProfile(PyThreadState *tstate, Py_tracefunc func, PyObject *arg)
             return -1;
         }
         if (set_callbacks(PY_MONITORING_SYS_PROFILE_ID,
+            (vectorcallfunc)sys_profile_func3, PyTrace_CALL,
+                        PY_MONITORING_EVENT_PY_THROW, -1)) {
+            return -1;
+        }
+        if (set_callbacks(PY_MONITORING_SYS_PROFILE_ID,
             (vectorcallfunc)sys_profile_func3, PyTrace_RETURN,
                         PY_MONITORING_EVENT_PY_RETURN, PY_MONITORING_EVENT_PY_YIELD)) {
             return -1;
@@ -417,7 +422,8 @@ _PyEval_SetProfile(PyThreadState *tstate, Py_tracefunc func, PyObject *arg)
         events =
             (1 << PY_MONITORING_EVENT_PY_START) | (1 << PY_MONITORING_EVENT_PY_RESUME) |
             (1 << PY_MONITORING_EVENT_PY_RETURN) | (1 << PY_MONITORING_EVENT_PY_YIELD) |
-            (1 << PY_MONITORING_EVENT_CALL) | (1 << PY_MONITORING_EVENT_PY_UNWIND);
+            (1 << PY_MONITORING_EVENT_CALL) | (1 << PY_MONITORING_EVENT_PY_UNWIND) |
+            (1 << PY_MONITORING_EVENT_PY_THROW);
     }
     return _PyMonitoring_SetEvents(PY_MONITORING_SYS_PROFILE_ID, events);
 }


### PR DESCRIPTION
`sys.setprofile` suffers the same issue as #106161 - it does not record `PY_THROW` events. So when the generator is garbage collected, the count is wrong.

For `profile` module, that means an assertion is raised.

This needs backporting.

<!-- gh-issue-number: gh-110514 -->
* Issue: gh-110514
<!-- /gh-issue-number -->
