### PR TITLE
gh-110527: Improve `PySet_Clear` docs

### DIFF
--- a/Doc/c-api/set.rst
+++ b/Doc/c-api/set.rst
@@ -164,5 +164,5 @@ subtypes but not for instances of :class:`frozenset` or its subtypes.
 .. c:function:: int PySet_Clear(PyObject *set)
 
    Empty an existing set of all elements. Return ``0`` on
-   success or ``-1`` on failure. Raise :exc:`SystemError` if *set* is not an
-   instance of :class:`set` or its subtype.
+   success. If *set* is not an instance of :class:`set` or its subtype
+   return ``-1`` and raise :exc:`SystemError`.

--- a/Doc/c-api/set.rst
+++ b/Doc/c-api/set.rst
@@ -163,4 +163,6 @@ subtypes but not for instances of :class:`frozenset` or its subtypes.
 
 .. c:function:: int PySet_Clear(PyObject *set)
 
-   Empty an existing set of all elements.
+   Empty an existing set of all elements. Return ``0`` on
+   success or ``-1`` on failure. Raise :exc:`SystemError` if *set* is not an
+   instance of :class:`set` or its subtype.

--- a/Doc/c-api/set.rst
+++ b/Doc/c-api/set.rst
@@ -164,5 +164,5 @@ subtypes but not for instances of :class:`frozenset` or its subtypes.
 .. c:function:: int PySet_Clear(PyObject *set)
 
    Empty an existing set of all elements. Return ``0`` on
-   success. If *set* is not an instance of :class:`set` or its subtype
-   return ``-1`` and raise :exc:`SystemError`.
+   success. Return ``-1`` and raise :exc:`SystemError` if *set* is not an instance of
+   :class:`set` or its subtype.


### PR DESCRIPTION
Mention that it can return `-1` and raise `SystemError`: https://github.com/python/cpython/blob/7e30821b17b56bb5ed9799f62eb45e448cb52c8e/Objects/setobject.c#L2291-L2298



<!-- gh-issue-number: gh-110527 -->
* Issue: gh-110527
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--110528.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->