### PR TITLE
gh-110525: Cover `PySet_Add` corner case with `frozenset` objects

### DIFF
--- a/Modules/_testcapi/set.c
+++ b/Modules/_testcapi/set.c
@@ -152,6 +152,8 @@ test_frozenset_add_in_capi(PyObject *self, PyObject *Py_UNUSED(obj))
     else if (contains == 0) {
         goto unexpected;
     }
+    Py_DECREF(fs);
+    Py_DECREF(num);
     Py_RETURN_NONE;
 
 unexpected:

--- a/Modules/_testcapi/set.c
+++ b/Modules/_testcapi/set.c
@@ -129,6 +129,33 @@ set_clear(PyObject *self, PyObject *obj)
     RETURN_INT(PySet_Clear(obj));
 }
 
+static PyObject *
+test_frozenset_add_in_capi(PyObject *self, PyObject *Py_UNUSED(obj))
+{
+    // Test that `frozenset` can be used with `PySet_Add`,
+    // when frozenset is just created in CAPI.
+    PyObject *fs = PyFrozenSet_New(NULL);
+    if (fs == NULL) {
+        return NULL;
+    }
+    PyObject *num = PyLong_FromLong(1);
+    if (num == NULL) {
+        return NULL;
+    }
+    if (PySet_Add(fs, num) < 0) {
+        return NULL;
+    }
+    int contains = PySet_Contains(fs, num);
+    if (contains < 0) {
+        return NULL;
+    }
+    else if (contains == 0) {
+        PyErr_SetString(PyExc_ValueError, "set does not contain expected value");
+        return NULL;
+    }
+    Py_RETURN_NONE;
+}
+
 static PyMethodDef test_methods[] = {
     {"set_check", set_check, METH_O},
     {"set_checkexact", set_checkexact, METH_O},
@@ -147,6 +174,8 @@ static PyMethodDef test_methods[] = {
     {"set_discard", set_discard, METH_VARARGS},
     {"set_pop", set_pop, METH_O},
     {"set_clear", set_clear, METH_O},
+
+    {"test_frozenset_add_in_capi", test_frozenset_add_in_capi, METH_NOARGS},
 
     {NULL},
 };

--- a/Modules/_testcapi/set.c
+++ b/Modules/_testcapi/set.c
@@ -146,6 +146,7 @@ test_frozenset_add_in_capi(PyObject *self, PyObject *Py_UNUSED(obj))
         return NULL;
     }
     int contains = PySet_Contains(fs, num);
+    Py_DECREF(num);
     if (contains < 0) {
         return NULL;
     }

--- a/Modules/_testcapi/set.c
+++ b/Modules/_testcapi/set.c
@@ -140,21 +140,26 @@ test_frozenset_add_in_capi(PyObject *self, PyObject *Py_UNUSED(obj))
     }
     PyObject *num = PyLong_FromLong(1);
     if (num == NULL) {
-        return NULL;
+        goto error;
     }
     if (PySet_Add(fs, num) < 0) {
-        return NULL;
+        goto error;
     }
     int contains = PySet_Contains(fs, num);
-    Py_DECREF(num);
     if (contains < 0) {
-        return NULL;
+        goto error;
     }
     else if (contains == 0) {
-        PyErr_SetString(PyExc_ValueError, "set does not contain expected value");
-        return NULL;
+        goto unexpected;
     }
     Py_RETURN_NONE;
+
+unexpected:
+    PyErr_SetString(PyExc_ValueError, "set does not contain expected value");
+error:
+    Py_DECREF(fs);
+    Py_XDECREF(num);
+    return NULL;
 }
 
 static PyMethodDef test_methods[] = {


### PR DESCRIPTION
This corner case cannot be covered from Python code, as far as I can tell. But, it is documented:

```rst
   Also works with :class:`frozenset`
   instances (like :c:func:`PyTuple_SetItem` it can be used to fill in the values
   of brand new frozensets before they are exposed to other code).
```

So, I think we need to test it as well in C code. Sorry for missing this in the original PR!

<!-- gh-issue-number: gh-110525 -->
* Issue: gh-110525
<!-- /gh-issue-number -->
