### PR TITLE
gh-109329: Count tier2 miss opcodes

### DIFF
--- a/Include/cpython/pystats.h
+++ b/Include/cpython/pystats.h
@@ -98,6 +98,7 @@ typedef struct _gc_stats {
 
 typedef struct _uop_stats {
     uint64_t execution_count;
+    uint64_t miss;
 } UOpStats;
 
 #define _Py_UOP_HIST_SIZE 32

--- a/Include/internal/pycore_code.h
+++ b/Include/internal/pycore_code.h
@@ -283,7 +283,7 @@ extern int _PyStaticCode_Init(PyCodeObject *co);
     do { if (_Py_stats && PyFunction_Check(callable)) _Py_stats->call_stats.eval_calls[name]++; } while (0)
 #define GC_STAT_ADD(gen, name, n) do { if (_Py_stats) _Py_stats->gc_stats[(gen)].name += (n); } while (0)
 #define OPT_STAT_INC(name) do { if (_Py_stats) _Py_stats->optimization_stats.name++; } while (0)
-#define UOP_EXE_INC(opname) do { if (_Py_stats) _Py_stats->optimization_stats.opcode[opname].execution_count++; } while (0)
+#define UOP_STAT_INC(opname, name) do { if (_Py_stats) { assert(opname < 512); _Py_stats->optimization_stats.opcode[opname].name++; } } while (0)
 #define OPT_UNSUPPORTED_OPCODE(opname) do { if (_Py_stats) _Py_stats->optimization_stats.unsupported_opcode[opname]++; } while (0)
 #define OPT_HIST(length, name) \
     do { \

--- a/Include/internal/pycore_code.h
+++ b/Include/internal/pycore_code.h
@@ -308,7 +308,7 @@ PyAPI_FUNC(PyObject*) _Py_GetSpecializationStats(void);
 #define EVAL_CALL_STAT_INC_IF_FUNCTION(name, callable) ((void)0)
 #define GC_STAT_ADD(gen, name, n) ((void)0)
 #define OPT_STAT_INC(name) ((void)0)
-#define UOP_EXE_INC(opname) ((void)0)
+#define UOP_STAT_INC(opname, name) ((void)0)
 #define OPT_UNSUPPORTED_OPCODE(opname) ((void)0)
 #define OPT_HIST(length, name) ((void)0)
 #endif  // !Py_STATS

--- a/Python/executor.c
+++ b/Python/executor.c
@@ -25,6 +25,7 @@
 #undef DEOPT_IF
 #define DEOPT_IF(COND, INSTNAME) \
     if ((COND)) {                \
+        UOP_STAT_INC(INSTNAME, miss); \
         goto deoptimize;         \
     }
 
@@ -93,7 +94,7 @@ _PyUopExecute(_PyExecutorObject *executor, _PyInterpreterFrame *frame, PyObject 
                 (int)(stack_pointer - _PyFrame_Stackbase(frame)));
         pc++;
         OPT_STAT_INC(uops_executed);
-        UOP_EXE_INC(opcode);
+        UOP_STAT_INC(opcode, execution_count);
 #ifdef Py_STATS
         trace_uop_execution_counter++;
 #endif

--- a/Python/specialize.c
+++ b/Python/specialize.c
@@ -247,6 +247,9 @@ print_optimization_stats(FILE *out, OptimizationStats *stats)
         if (stats->opcode[i].execution_count) {
             fprintf(out, "uops[%s].execution_count : %" PRIu64 "\n", names[i], stats->opcode[i].execution_count);
         }
+        if (stats->opcode[i].miss) {
+            fprintf(out, "uops[%s].specialization.miss : %" PRIu64 "\n", names[i], stats->opcode[i].miss);
+        }
     }
 
     for (int i = 0; i < 256; i++) {

--- a/Tools/scripts/summarize_stats.py
+++ b/Tools/scripts/summarize_stats.py
@@ -1016,7 +1016,7 @@ def optimization_section() -> Section:
                 ],
             )
         yield Section(
-            "Uop stats",
+            "Uop execution stats",
             "",
             [
                 Table(

--- a/Tools/scripts/summarize_stats.py
+++ b/Tools/scripts/summarize_stats.py
@@ -419,6 +419,8 @@ class Ratio:
         self.num = num
         self.den = den
         self.percentage = percentage
+        if den == 0 and num != 0:
+            raise ValueError("Invalid denominator")
 
     def __float__(self):
         if self.den == 0:

--- a/Tools/scripts/summarize_stats.py
+++ b/Tools/scripts/summarize_stats.py
@@ -419,8 +419,6 @@ class Ratio:
         self.num = num
         self.den = den
         self.percentage = percentage
-        if den == 0 and num != 0:
-            raise ValueError("Invalid denominator")
 
     def __float__(self):
         if self.den == 0:


### PR DESCRIPTION
This records the number of times a specific uop causes a DEOPT (in the same way this is already done for Tier 1).  The `summarize_stats.py` script already supports the display, by virtue of reusing the code from Tier 1.

Marked as draft because it is necessarily built on #110398 which should be merged first.

<!-- gh-issue-number: gh-109329 -->
* Issue: gh-109329
<!-- /gh-issue-number -->
