### PR TITLE
gh-106765: Building python 3.11.x installer FAILS, launcher.wixproj c…

### DIFF
--- a/Misc/NEWS.d/next/Documentation/2023-10-09-14-02-06.gh-issue-gh-106765.zrjpdz.rst
+++ b/Misc/NEWS.d/next/Documentation/2023-10-09-14-02-06.gh-issue-gh-106765.zrjpdz.rst
@@ -1,6 +1,0 @@
-For Python 3.11.x and above, enable "Microsoft .NET Framework 4.8 Advanced Services"
-instead of "Microsoft .NET Framework Version 3.5" available for Windows 10 and above.
-Also make sure "MSVC v143 - VS 2022 C++ ARM64 build tools" are selected under
-"Desktop Development with C++" in "Visual Studio installer" even if you are not
-building on ARM64 along with other x64 related v143 build tools. This is because for
-3.11.x and above we have upgraded to Wix-3.14.

--- a/Misc/NEWS.d/next/Documentation/2023-10-09-14-02-06.gh-issue-gh-106765.zrjpdz.rst
+++ b/Misc/NEWS.d/next/Documentation/2023-10-09-14-02-06.gh-issue-gh-106765.zrjpdz.rst
@@ -1,0 +1,6 @@
+For Python 3.11.x and above, enable "Microsoft .NET Framework 4.8 Advanced Services"
+instead of "Microsoft .NET Framework Version 3.5" available for Windows 10 and above.
+Also make sure "MSVC v143 - VS 2022 C++ ARM64 build tools" are selected under
+"Desktop Development with C++" in "Visual Studio installer" even if you are not
+building on ARM64 along with other x64 related v143 build tools. This is because for
+3.11.x and above we have upgraded to Wix-3.14.

--- a/README.rst
+++ b/README.rst
@@ -76,6 +76,9 @@ to macOS framework and universal builds.  Refer to `Mac/README.rst
 On Windows, see `PCbuild/readme.txt
 <https://github.com/python/cpython/blob/main/PCbuild/readme.txt>`_.
 
+To build Windows installer, see `Tools/msi/README.txt
+<https://github.com/python/cpython/blob/main/Tools/msi/README.txt>`_.
+
 If you wish, you can create a subdirectory and invoke configure from there.
 For example::
 

--- a/Tools/msi/README.txt
+++ b/Tools/msi/README.txt
@@ -73,6 +73,13 @@ building on a recent Windows version, use the Control Panel (Programs | Programs
 and Features | Turn Windows Features on or off) and ensure that the entry
 ".NET Framework 3.5 (includes .NET 2.0 and 3.0)" is enabled.
 
+For Python 3.11.x and above, enable "Microsoft .NET Framework 4.8 Advanced Services"
+instead of "Microsoft .NET Framework Version 3.5" available for Windows 10 and above.
+Also make sure "MSVC v143 - VS 2022 C++ ARM64 build tools" are selected under
+"Desktop Development with C++" in "Visual Studio installer" even if you are not
+building on ARM64 along with other x64 related v143 build tools. This is because for
+3.11.x and above we have upgraded to Wix-3.14.
+
 For testing, the installer should be built with the Tools/msi/build.bat
 script:
 


### PR DESCRIPTION
gh-106765: Building python 3.11.x installer FAILS, launcher.wixproj cannot detect v143 buildtools - Build documentation updated