### PR TITLE
Remove unused `SPHINXLINT` var from `Doc/Makefile`.

### DIFF
--- a/Doc/Makefile
+++ b/Doc/Makefile
@@ -7,7 +7,6 @@
 PYTHON       = python3
 VENVDIR      = ./venv
 SPHINXBUILD  = PATH=$(VENVDIR)/bin:$$PATH sphinx-build
-SPHINXLINT   = PATH=$(VENVDIR)/bin:$$PATH sphinx-lint
 BLURB        = PATH=$(VENVDIR)/bin:$$PATH blurb
 JOBS         = auto
 PAPER        =


### PR DESCRIPTION
This PR removes the `SPHINXLINT` var from `Doc/Makefile`, since it's no longer used.

<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--110570.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->