### PR TITLE
gh-107652: Fix CIFuzz build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,12 +82,14 @@ jobs:
           # CPython, so CIFuzz should be run only for code that is likely to be
           # merged into the main branch; compatibility with older branches may
           # be broken.
-          if [ "$GITHUB_BASE_REF" = "main" ]; then
+          FUZZ_RELEVANT_FILES='(\.c$|\.h$|\.cpp$|^configure$|^\.github/workflows/build\.yml$|^Modules/_xxtestfuzz)'
+          if [ "$GITHUB_BASE_REF" = "main" ] && [ "$(git diff --name-only origin/$GITHUB_BASE_REF.. | grep -qvE $FUZZ_RELEVANT_FILES; echo $?)" -eq 1 ]; then
             # The tests are pretty slow so they are executed only for PRs
             # changing relevant files.
-            FUZZ_RELEVANT_FILES='(\.c$|\.h$|\.cpp$|^configure$|^\.github/workflows/build\.yml$|^Modules/_xxtestfuzz)'
-            git diff --name-only origin/$GITHUB_BASE_REF.. | grep -qvE $FUZZ_RELEVANT_FILES && echo "run_cifuzz=true" >> $GITHUB_OUTPUT
+            echo "Run CIFuzz tests"
+            echo "run_cifuzz=true" >> $GITHUB_OUTPUT
           else
+            echo "Branch too old for CIFuzz tests; or no C files were changed"
             echo "run_cifuzz=false" >> $GITHUB_OUTPUT
           fi
       - name: Compute hash for config cache key

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -86,7 +86,9 @@ jobs:
             # The tests are pretty slow so they are executed only for PRs
             # changing relevant files.
             FUZZ_RELEVANT_FILES='(\.c$|\.h$|\.cpp$|^configure$|^\.github/workflows/build\.yml$|^Modules/_xxtestfuzz)'
-            git diff --name-only origin/$GITHUB_BASE_REF.. | grep -qvE $FUZZ_RELEVANT_FILES && echo "run_cifuzz=true" >> $GITHUB_OUTPUT || true
+            git diff --name-only origin/$GITHUB_BASE_REF.. | grep -qvE $FUZZ_RELEVANT_FILES && echo "run_cifuzz=true" >> $GITHUB_OUTPUT
+          else
+            echo "run_cifuzz=false" >> $GITHUB_OUTPUT
           fi
       - name: Compute hash for config cache key
         id: config_hash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -83,7 +83,7 @@ jobs:
           # merged into the main branch; compatibility with older branches may
           # be broken.
           FUZZ_RELEVANT_FILES='(\.c$|\.h$|\.cpp$|^configure$|^\.github/workflows/build\.yml$|^Modules/_xxtestfuzz)'
-          if [ "$GITHUB_BASE_REF" = "main" ] && [ "$(git diff --name-only origin/$GITHUB_BASE_REF.. | grep -qvE $FUZZ_RELEVANT_FILES; echo $?)" -eq 1 ]; then
+          if [ "$GITHUB_BASE_REF" = "main" ] && [ "$(git diff --name-only origin/$GITHUB_BASE_REF.. | grep -qE $FUZZ_RELEVANT_FILES; echo $?)" ]; then
             # The tests are pretty slow so they are executed only for PRs
             # changing relevant files.
             echo "Run CIFuzz tests"


### PR DESCRIPTION
When CI job was skipped the job was failing: https://github.com/python/cpython/actions/runs/6459321247/job/17536559744?pr=110573

```
Error: The template is not valid. .github/workflows/build.yml (Line: 620, Col: 24): Error reading JToken from JsonReader. Path '', line 0, position 0.
```

This happened because `run_cifuzz` was not set. Now we use the same logic as for other tools by setting it to `false`

Refs https://github.com/python/cpython/pull/107653
Refs https://github.com/python/cpython/issues/107652