### PR TITLE
gh-65052: Prevent pdb from crashing when trying to display objects

### DIFF
--- a/Lib/pdb.py
+++ b/Lib/pdb.py
@@ -432,8 +432,8 @@ class Pdb(bdb.Bdb, cmd.Cmd):
                 if newvalue is not oldvalue and newvalue != oldvalue:
                     displaying[expr] = newvalue
                     self.message('display %s: %s  [old: %s]' %
-                                 (expr, self._safe_repr(newvalue),
-                                  self._safe_repr(oldvalue)))
+                                 (expr, self._safe_repr(newvalue, expr),
+                                  self._safe_repr(oldvalue, expr)))
 
     def _get_tb_and_exceptions(self, tb_or_exc):
         """
@@ -1461,7 +1461,7 @@ class Pdb(bdb.Bdb, cmd.Cmd):
         for i in range(n):
             name = co.co_varnames[i]
             if name in dict:
-                self.message('%s = %s' % (name, self._safe_repr(dict[name])))
+                self.message('%s = %s' % (name, self._safe_repr(dict[name], name)))
             else:
                 self.message('%s = *** undefined ***' % (name,))
     do_a = do_args
@@ -1475,7 +1475,7 @@ class Pdb(bdb.Bdb, cmd.Cmd):
             self._print_invalid_arg(arg)
             return
         if '__return__' in self.curframe_locals:
-            self.message(self._safe_repr(self.curframe_locals['__return__']))
+            self.message(self._safe_repr(self.curframe_locals['__return__'], "retval"))
         else:
             self.error('Not yet returned!')
     do_rv = do_retval
@@ -1510,11 +1510,11 @@ class Pdb(bdb.Bdb, cmd.Cmd):
         except:
             self._error_exc()
 
-    def _safe_repr(self, obj):
+    def _safe_repr(self, obj, expr):
         try:
             return repr(obj)
         except Exception as e:
-            return _rstr(f"*** {self._format_exc(e)} ***")
+            return _rstr(f"*** repr({expr}) failed: {self._format_exc(e)} ***")
 
     def do_p(self, arg):
         """p expression
@@ -1696,7 +1696,7 @@ class Pdb(bdb.Bdb, cmd.Cmd):
             if self.displaying:
                 self.message('Currently displaying:')
                 for key, val in self.displaying.get(self.curframe, {}).items():
-                    self.message('%s: %s' % (key, self._safe_repr(val)))
+                    self.message('%s: %s' % (key, self._safe_repr(val, key)))
             else:
                 self.message('No expression is being displayed')
         else:
@@ -1705,7 +1705,7 @@ class Pdb(bdb.Bdb, cmd.Cmd):
             else:
                 val = self._getval_except(arg)
                 self.displaying.setdefault(self.curframe, {})[arg] = val
-                self.message('display %s: %s' % (arg, self._safe_repr(val)))
+                self.message('display %s: %s' % (arg, self._safe_repr(val, arg)))
 
     complete_display = _complete_expression
 

--- a/Lib/test/test_pdb.py
+++ b/Lib/test/test_pdb.py
@@ -2383,17 +2383,17 @@ def test_pdb_issue_gh_65052():
     > <doctest test.test_pdb.test_pdb_issue_gh_65052[0]>(4)__new__()-><A instance at ...>
     -> return object.__new__(cls)
     (Pdb) retval
-    *** AttributeError: 'A' object has no attribute 'a' ***
+    *** repr(retval) failed: AttributeError: 'A' object has no attribute 'a' ***
     (Pdb) continue
     > <doctest test.test_pdb.test_pdb_issue_gh_65052[0]>(7)__init__()
     -> self.a = 1
     (Pdb) args
-    self = *** AttributeError: 'A' object has no attribute 'a' ***
+    self = *** repr(self) failed: AttributeError: 'A' object has no attribute 'a' ***
     (Pdb) display self
-    display self: *** AttributeError: 'A' object has no attribute 'a' ***
+    display self: *** repr(self) failed: AttributeError: 'A' object has no attribute 'a' ***
     (Pdb) display
     Currently displaying:
-    self: *** AttributeError: 'A' object has no attribute 'a' ***
+    self: *** repr(self) failed: AttributeError: 'A' object has no attribute 'a' ***
     (Pdb) continue
     """
 

--- a/Lib/test/test_pdb.py
+++ b/Lib/test/test_pdb.py
@@ -2350,6 +2350,53 @@ def test_pdb_ambiguous_statements():
     (Pdb) continue
     """
 
+def test_pdb_issue_gh_65052():
+    """See GH-65052
+
+    args, retval and display should not crash if the object is not displayable
+    >>> class A:
+    ...     def __new__(cls):
+    ...         import pdb; pdb.Pdb(nosigint=True, readrc=False).set_trace()
+    ...         return object.__new__(cls)
+    ...     def __init__(self):
+    ...         import pdb; pdb.Pdb(nosigint=True, readrc=False).set_trace()
+    ...         self.a = 1
+    ...     def __repr__(self):
+    ...         return self.a
+
+    >>> def test_function():
+    ...     A()
+    >>> with PdbTestInput([  # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
+    ...     's',
+    ...     'retval',
+    ...     'continue',
+    ...     'args',
+    ...     'display self',
+    ...     'display',
+    ...     'continue',
+    ... ]):
+    ...    test_function()
+    > <doctest test.test_pdb.test_pdb_issue_gh_65052[0]>(4)__new__()
+    -> return object.__new__(cls)
+    (Pdb) s
+    --Return--
+    > <doctest test.test_pdb.test_pdb_issue_gh_65052[0]>(4)__new__()-><A instance at ...>
+    -> return object.__new__(cls)
+    (Pdb) retval
+    *** AttributeError: 'A' object has no attribute 'a' ***
+    (Pdb) continue
+    > <doctest test.test_pdb.test_pdb_issue_gh_65052[0]>(7)__init__()
+    -> self.a = 1
+    (Pdb) args
+    self = *** AttributeError: 'A' object has no attribute 'a' ***
+    (Pdb) display self
+    display self: *** AttributeError: 'A' object has no attribute 'a' ***
+    (Pdb) display
+    Currently displaying:
+    self: *** AttributeError: 'A' object has no attribute 'a' ***
+    (Pdb) continue
+    """
+
 
 @support.requires_subprocess()
 class PdbTestCase(unittest.TestCase):

--- a/Misc/NEWS.d/next/Library/2023-10-09-19-09-32.gh-issue-65052.C2mRlo.rst
+++ b/Misc/NEWS.d/next/Library/2023-10-09-19-09-32.gh-issue-65052.C2mRlo.rst
@@ -1,0 +1,1 @@
+Prevent :mod:`pdb` from crashing when trying to display undisplayable objects


### PR DESCRIPTION
Currently in `pdb` we have a couple of explicit/implicit usage of `repr` when the object is arbitrary - which could potentially cause a `pdb` crash when the object is not displayable. Even though it's not super common, we should try out best making `pdb` not crash. Hence `_safe_repr` is introduced to print objects for:
* args
* display
* retval

<!-- gh-issue-number: gh-65052 -->
* Issue: gh-65052
<!-- /gh-issue-number -->
