### PR TITLE
Add some 'meta hooks' to our pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,3 +26,8 @@ repos:
         args: [--enable=default-role]
         files: ^Doc/|^Misc/NEWS.d/next/
         types: [rst]
+
+  - repo: meta
+    hooks:
+      - id: check-hooks-apply
+      - id: check-useless-excludes


### PR DESCRIPTION
This adds some 'meta hooks' to our pre-commit config. These hooks check the validity of our pre-commit config file itself. See https://pre-commit.com/#meta-hooks for more details.