### PR TITLE
gh-110590: Fix `_sre.compile` error overwrite

### DIFF
--- a/Lib/test/test_re.py
+++ b/Lib/test/test_re.py
@@ -2735,6 +2735,9 @@ class ImplementationTest(unittest.TestCase):
             _sre.compile("abc", 0, [long_overflow], 0, {}, ())
         with self.assertRaises(TypeError):
             _sre.compile({}, 0, [], 0, [], [])
+        # gh-110590: `TypeError` was overwritten with `OverflowError`:
+        with self.assertRaises(TypeError):
+            _sre.compile('', 0, ['abc'], 0, {}, ())
 
     @cpython_only
     def test_repeat_minmax_overflow_maxrepeat(self):

--- a/Misc/NEWS.d/next/Library/2023-10-10-10-46-55.gh-issue-110590.fatz-h.rst
+++ b/Misc/NEWS.d/next/Library/2023-10-10-10-46-55.gh-issue-110590.fatz-h.rst
@@ -1,0 +1,2 @@
+Fix ``_sre.compile`` error overwriting `TypeError` with `OverflowError` when
+`code` arguments was a list of non-ints.

--- a/Misc/NEWS.d/next/Library/2023-10-10-10-46-55.gh-issue-110590.fatz-h.rst
+++ b/Misc/NEWS.d/next/Library/2023-10-10-10-46-55.gh-issue-110590.fatz-h.rst
@@ -1,3 +1,3 @@
 Fix ``_sre.compile`` error overwriting ``TypeError``
-with ``OverflowError`` when ``code`` arguments
+with ``OverflowError`` when ``code`` argument
 was a list of non-ints.

--- a/Misc/NEWS.d/next/Library/2023-10-10-10-46-55.gh-issue-110590.fatz-h.rst
+++ b/Misc/NEWS.d/next/Library/2023-10-10-10-46-55.gh-issue-110590.fatz-h.rst
@@ -1,3 +1,3 @@
-Fix ``_sre.compile`` error overwriting ``TypeError``
-with ``OverflowError`` when ``code`` argument
-was a list of non-ints.
+Fix a bug in :meth:`!_sre.compile` where :exc:`TypeError`
+would be overwritten by :exc:`OverflowError` when
+the *code* argument was a list of non-ints.

--- a/Misc/NEWS.d/next/Library/2023-10-10-10-46-55.gh-issue-110590.fatz-h.rst
+++ b/Misc/NEWS.d/next/Library/2023-10-10-10-46-55.gh-issue-110590.fatz-h.rst
@@ -1,2 +1,3 @@
-Fix ``_sre.compile`` error overwriting `TypeError` with `OverflowError` when
-``code`` arguments was a list of non-ints.
+Fix ``_sre.compile`` error overwriting ``TypeError``
+with ``OverflowError`` when ``code`` arguments
+was a list of non-ints.

--- a/Misc/NEWS.d/next/Library/2023-10-10-10-46-55.gh-issue-110590.fatz-h.rst
+++ b/Misc/NEWS.d/next/Library/2023-10-10-10-46-55.gh-issue-110590.fatz-h.rst
@@ -1,2 +1,2 @@
 Fix ``_sre.compile`` error overwriting `TypeError` with `OverflowError` when
-`code` arguments was a list of non-ints.
+``code`` arguments was a list of non-ints.

--- a/Modules/_sre/sre.c
+++ b/Modules/_sre/sre.c
@@ -1508,6 +1508,9 @@ _sre_compile_impl(PyObject *module, PyObject *pattern, int flags,
     for (i = 0; i < n; i++) {
         PyObject *o = PyList_GET_ITEM(code, i);
         unsigned long value = PyLong_AsUnsignedLong(o);
+        if (value == (unsigned long)-1 && PyErr_Occurred()) {
+            break;
+        }
         self->code[i] = (SRE_CODE) value;
         if ((unsigned long) self->code[i] != value) {
             PyErr_SetString(PyExc_OverflowError,


### PR DESCRIPTION
`PyLong_AsUnsignedLong` strikes back 😉 

<!-- gh-issue-number: gh-110590 -->
* Issue: gh-110590
<!-- /gh-issue-number -->
