### PR TITLE
GH-104584: Fix refleak when tracing through calls

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2023-10-10-00-49-35.gh-issue-104584.z94TuJ.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2023-10-10-00-49-35.gh-issue-104584.z94TuJ.rst
@@ -1,0 +1,1 @@
+Fix a reference leak when running with :envvar:`PYTHONUOPS` or :option:`-X uops <-X>` enabled.

--- a/Misc/NEWS.d/next/Core and Builtins/2023-10-10-00-49-35.gh-issue-106908.z94TuJ.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2023-10-10-00-49-35.gh-issue-106908.z94TuJ.rst
@@ -1,2 +1,0 @@
-Fix a reference leak when running with :envvar:`PYTHONUOPS` or :option:`-X
-uops <-X>` enabled.

--- a/Misc/NEWS.d/next/Core and Builtins/2023-10-10-00-49-35.gh-issue-106908.z94TuJ.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2023-10-10-00-49-35.gh-issue-106908.z94TuJ.rst
@@ -1,0 +1,2 @@
+Fix a reference leak when running with :envvar:`PYTHONUOPS` or :option:`-X
+uops <-X>` enabled.

--- a/Objects/funcobject.c
+++ b/Objects/funcobject.c
@@ -288,7 +288,7 @@ _PyFunction_LookupByVersion(uint32_t version)
     PyFunctionObject *func = interp->func_state.func_version_cache[
         version % FUNC_VERSION_CACHE_SIZE];
     if (func != NULL && func->func_version == version) {
-        return (PyFunctionObject *)Py_NewRef(func);
+        return func;
     }
     return NULL;
 }


### PR DESCRIPTION
This modifies `_PyFunction_LookupByVersion` to return a borrowed reference, which is what the caller assumes (and most internal "lookup" functions do, in general).

<!-- gh-issue-number: gh-104584 -->
* Issue: gh-104584
<!-- /gh-issue-number -->
