### PR TITLE
gh-110558: Enable ruff's pyupgrade rules when running on Argument Clinic

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
         args: [--exit-non-zero-on-fix]
         files: ^Lib/test/
       - id: ruff
-        name: Run Ruff on Tools/clinic/
+        name: Run Ruff on Argument Clinic
         args: [--exit-non-zero-on-fix, --config=Tools/clinic/.ruff.toml]
         files: ^Tools/clinic/|Lib/test/test_clinic.py
 

--- a/Lib/test/test_clinic.py
+++ b/Lib/test/test_clinic.py
@@ -2398,7 +2398,7 @@ class ClinicExternalTest(TestCase):
     def test_external(self):
         CLINIC_TEST = 'clinic.test.c'
         source = support.findfile(CLINIC_TEST)
-        with open(source, 'r', encoding='utf-8') as f:
+        with open(source, encoding='utf-8') as f:
             orig_contents = f.read()
 
         # Run clinic CLI and verify that it does not complain.
@@ -2406,7 +2406,7 @@ class ClinicExternalTest(TestCase):
         out = self.expect_success("-f", "-o", TESTFN, source)
         self.assertEqual(out, "")
 
-        with open(TESTFN, 'r', encoding='utf-8') as f:
+        with open(TESTFN, encoding='utf-8') as f:
             new_contents = f.read()
 
         self.assertEqual(new_contents, orig_contents)
@@ -2466,7 +2466,7 @@ class ClinicExternalTest(TestCase):
                 "/*[clinic end generated code: "
                 "output=c16447c01510dfb3 input=9543a8d2da235301]*/\n"
             )
-            with open(fn, 'r', encoding='utf-8') as f:
+            with open(fn, encoding='utf-8') as f:
                 generated = f.read()
             self.assertTrue(generated.endswith(checksum),
                             (generated, checksum))

--- a/Tools/clinic/.ruff.toml
+++ b/Tools/clinic/.ruff.toml
@@ -2,8 +2,23 @@ target-version = "py310"
 fix = true
 select = [
     "F",  # Enable all pyflakes rules
+    "UP",  # Enable all pyupgrade rules by default
     "RUF100",  # Ban unused `# noqa` comments
     "PGH004",  # Ban blanket `# noqa` comments (only ignore specific error codes)
+]
+ignore = [
+    # Unnecessary parentheses to functools.lru_cache: just leads to unnecessary churn.
+    # https://github.com/python/cpython/pull/104684#discussion_r1199653347.
+    "UP011",
+    # Use format specifiers instead of %-style formatting.
+    # Doesn't always make code more readable.
+    "UP031",
+    # Use f-strings instead of format specifiers.
+    # Doesn't always make code more readable.
+    "UP032",
+    # Use PEP-604 unions rather than tuples for isinstance() checks.
+    # Makes code slower and more verbose. https://github.com/astral-sh/ruff/issues/7871.
+    "UP038",
 ]
 unfixable = [
     # The autofixes sometimes do the wrong things for these;

--- a/Tools/clinic/clinic.py
+++ b/Tools/clinic/clinic.py
@@ -2423,7 +2423,7 @@ extensions['py'] = PythonLanguage
 
 def write_file(filename: str, new_contents: str) -> None:
     try:
-        with open(filename, 'r', encoding="utf-8") as fp:
+        with open(filename, encoding="utf-8") as fp:
             old_contents = fp.read()
 
         if old_contents == new_contents:


### PR DESCRIPTION
These are more opinionated, lint-style checks than the existing `pyflakes` rules that we currently have enabled on Argument Clinic, following #110559. The full list of pyupgrade rules is at https://docs.astral.sh/ruff/rules/#pyupgrade-up.

Thoughts? Is this a useful addition?

<!-- gh-issue-number: gh-110558 -->
* Issue: gh-110558
<!-- /gh-issue-number -->
