### PR TITLE
gh-76785: Make interpreters.*Channel Objects Shareable

### DIFF
--- a/Lib/test/support/interpreters.py
+++ b/Lib/test/support/interpreters.py
@@ -241,4 +241,4 @@ class SendChannel(_ChannelEnd):
 
 
 # XXX This is causing leaks (gh-110318):
-#_channels._register_end_types(SendChannel, RecvChannel)
+_channels._register_end_types(SendChannel, RecvChannel)

--- a/Lib/test/test_interpreters.py
+++ b/Lib/test/test_interpreters.py
@@ -833,7 +833,6 @@ class TestChannels(TestBase):
         after = set(interpreters.list_all_channels())
         self.assertEqual(after, created)
 
-    @unittest.expectedFailure  # See gh-110318:
     def test_shareable(self):
         rch, sch = interpreters.create_channel()
 

--- a/Modules/_xxinterpchannelsmodule.c
+++ b/Modules/_xxinterpchannelsmodule.c
@@ -441,6 +441,10 @@ _get_current_module_state(void)
 static int
 traverse_module_state(module_state *state, visitproc visit, void *arg)
 {
+    /* external types */
+    Py_VISIT(state->send_channel_type);
+    Py_VISIT(state->recv_channel_type);
+
     /* heap types */
     Py_VISIT(state->ChannelIDType);
     Py_VISIT(state->XIBufferViewType);


### PR DESCRIPTION
This restores their shareability, which was disabled by gh-110318 due to ref leaks.

<!-- gh-issue-number: gh-76785 -->
* Issue: gh-76785
<!-- /gh-issue-number -->
