### PR TITLE
Don't doubly-parallelise sphinx-lint

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,6 +39,7 @@ repos:
         args: [--enable=default-role]
         files: ^Doc/|^Misc/NEWS.d/next/
         types: [rst]
+        require_serial: true
 
   - repo: meta
     hooks:


### PR DESCRIPTION
Sphinx-Lint internally parallelises, and pre-commit also parallelises, leading to seeming resource contention. I observe a speed-up of ~5 seconds (from ~12 to ~7) when we let sphinx-lint control the parallelism.

```text
   5       12.582 pre-commit run sphinx-lint --all-files
   6       11.193 pre-commit run sphinx-lint --all-files
   7       13.530 pre-commit run sphinx-lint --all-files
   8        0.013 history
   9        7.422 pre-commit run sphinx-lint --all-files
  10        7.067 pre-commit run sphinx-lint --all-files
  11        7.344 pre-commit run sphinx-lint --all-files
```