### PR TITLE
gh-110631: Fix reST indentation in `Doc/whatsnew`

### DIFF
--- a/Doc/whatsnew/2.6.rst
+++ b/Doc/whatsnew/2.6.rst
@@ -875,11 +875,11 @@ The signature of the new function is::
 
 The parameters are:
 
- * *args*: positional arguments whose values will be printed out.
- * *sep*: the separator, which will be printed between arguments.
- * *end*: the ending text, which will be printed after all of the
-   arguments have been output.
- * *file*: the file object to which the output will be sent.
+* *args*: positional arguments whose values will be printed out.
+* *sep*: the separator, which will be printed between arguments.
+* *end*: the ending text, which will be printed after all of the
+  arguments have been output.
+* *file*: the file object to which the output will be sent.
 
 .. seealso::
 
@@ -1138,13 +1138,13 @@ indicate that the external caller is done.
 The *flags* argument to :c:func:`PyObject_GetBuffer` specifies
 constraints upon the memory returned.  Some examples are:
 
- * :c:macro:`PyBUF_WRITABLE` indicates that the memory must be writable.
+* :c:macro:`PyBUF_WRITABLE` indicates that the memory must be writable.
 
- * :c:macro:`PyBUF_LOCK` requests a read-only or exclusive lock on the memory.
+* :c:macro:`PyBUF_LOCK` requests a read-only or exclusive lock on the memory.
 
- * :c:macro:`PyBUF_C_CONTIGUOUS` and :c:macro:`PyBUF_F_CONTIGUOUS`
-   requests a C-contiguous (last dimension varies the fastest) or
-   Fortran-contiguous (first dimension varies the fastest) array layout.
+* :c:macro:`PyBUF_C_CONTIGUOUS` and :c:macro:`PyBUF_F_CONTIGUOUS`
+  requests a C-contiguous (last dimension varies the fastest) or
+  Fortran-contiguous (first dimension varies the fastest) array layout.
 
 Two new argument codes for :c:func:`PyArg_ParseTuple`,
 ``s*`` and ``z*``, return locked buffer objects for a parameter.

--- a/Doc/whatsnew/2.7.rst
+++ b/Doc/whatsnew/2.7.rst
@@ -2368,7 +2368,7 @@ Port-Specific Changes: Mac OS X
   installation and a user-installed copy of the same version.
   (Changed by Ronald Oussoren; :issue:`4865`.)
 
-   .. versionchanged:: 2.7.13
+  .. versionchanged:: 2.7.13
 
      As of 2.7.13, this change was removed.
      ``/Library/Python/2.7/site-packages``, the site-packages directory

--- a/Doc/whatsnew/3.10.rst
+++ b/Doc/whatsnew/3.10.rst
@@ -221,116 +221,116 @@ have been incorporated. Some of the most notable ones are as follows:
 
 * Missing ``:`` before blocks:
 
-    .. code-block:: python
+  .. code-block:: python
 
-        >>> if rocket.position > event_horizon
-          File "<stdin>", line 1
-            if rocket.position > event_horizon
-                                              ^
-        SyntaxError: expected ':'
+      >>> if rocket.position > event_horizon
+        File "<stdin>", line 1
+          if rocket.position > event_horizon
+                                            ^
+      SyntaxError: expected ':'
 
-    (Contributed by Pablo Galindo in :issue:`42997`.)
+  (Contributed by Pablo Galindo in :issue:`42997`.)
 
 * Unparenthesised tuples in comprehensions targets:
 
-    .. code-block:: python
+  .. code-block:: python
 
-        >>> {x,y for x,y in zip('abcd', '1234')}
-          File "<stdin>", line 1
-            {x,y for x,y in zip('abcd', '1234')}
-             ^
-        SyntaxError: did you forget parentheses around the comprehension target?
+      >>> {x,y for x,y in zip('abcd', '1234')}
+        File "<stdin>", line 1
+          {x,y for x,y in zip('abcd', '1234')}
+           ^
+      SyntaxError: did you forget parentheses around the comprehension target?
 
-    (Contributed by Pablo Galindo in :issue:`43017`.)
+  (Contributed by Pablo Galindo in :issue:`43017`.)
 
 * Missing commas in collection literals and between expressions:
 
-    .. code-block:: python
+  .. code-block:: python
 
-        >>> items = {
-        ... x: 1,
-        ... y: 2
-        ... z: 3,
-          File "<stdin>", line 3
-            y: 2
-               ^
-        SyntaxError: invalid syntax. Perhaps you forgot a comma?
+      >>> items = {
+      ... x: 1,
+      ... y: 2
+      ... z: 3,
+        File "<stdin>", line 3
+          y: 2
+             ^
+      SyntaxError: invalid syntax. Perhaps you forgot a comma?
 
-    (Contributed by Pablo Galindo in :issue:`43822`.)
+  (Contributed by Pablo Galindo in :issue:`43822`.)
 
 * Multiple Exception types without parentheses:
 
-    .. code-block:: python
+  .. code-block:: python
 
-        >>> try:
-        ...     build_dyson_sphere()
-        ... except NotEnoughScienceError, NotEnoughResourcesError:
-          File "<stdin>", line 3
-            except NotEnoughScienceError, NotEnoughResourcesError:
-                   ^
-        SyntaxError: multiple exception types must be parenthesized
+      >>> try:
+      ...     build_dyson_sphere()
+      ... except NotEnoughScienceError, NotEnoughResourcesError:
+        File "<stdin>", line 3
+          except NotEnoughScienceError, NotEnoughResourcesError:
+                 ^
+      SyntaxError: multiple exception types must be parenthesized
 
-    (Contributed by Pablo Galindo in :issue:`43149`.)
+  (Contributed by Pablo Galindo in :issue:`43149`.)
 
 * Missing ``:`` and values in dictionary literals:
 
-    .. code-block:: python
+  .. code-block:: python
 
-        >>> values = {
-        ... x: 1,
-        ... y: 2,
-        ... z:
-        ... }
-          File "<stdin>", line 4
-            z:
-             ^
-        SyntaxError: expression expected after dictionary key and ':'
+      >>> values = {
+      ... x: 1,
+      ... y: 2,
+      ... z:
+      ... }
+        File "<stdin>", line 4
+          z:
+           ^
+      SyntaxError: expression expected after dictionary key and ':'
 
-        >>> values = {x:1, y:2, z w:3}
-          File "<stdin>", line 1
-            values = {x:1, y:2, z w:3}
-                                ^
-        SyntaxError: ':' expected after dictionary key
+      >>> values = {x:1, y:2, z w:3}
+        File "<stdin>", line 1
+          values = {x:1, y:2, z w:3}
+                              ^
+      SyntaxError: ':' expected after dictionary key
 
-    (Contributed by Pablo Galindo in :issue:`43823`.)
+  (Contributed by Pablo Galindo in :issue:`43823`.)
 
 * ``try`` blocks without ``except`` or ``finally`` blocks:
 
-    .. code-block:: python
+  .. code-block:: python
 
-        >>> try:
-        ...     x = 2
-        ... something = 3
-          File "<stdin>", line 3
-            something  = 3
-            ^^^^^^^^^
-        SyntaxError: expected 'except' or 'finally' block
+      >>> try:
+      ...     x = 2
+      ... something = 3
+        File "<stdin>", line 3
+          something  = 3
+          ^^^^^^^^^
+      SyntaxError: expected 'except' or 'finally' block
 
-    (Contributed by Pablo Galindo in :issue:`44305`.)
+  (Contributed by Pablo Galindo in :issue:`44305`.)
 
 * Usage of ``=`` instead of ``==`` in comparisons:
 
-    .. code-block:: python
+  .. code-block:: python
 
-        >>> if rocket.position = event_horizon:
-          File "<stdin>", line 1
-            if rocket.position = event_horizon:
-                               ^
-        SyntaxError: cannot assign to attribute here. Maybe you meant '==' instead of '='?
+      >>> if rocket.position = event_horizon:
+        File "<stdin>", line 1
+          if rocket.position = event_horizon:
+                             ^
+      SyntaxError: cannot assign to attribute here. Maybe you meant '==' instead of '='?
 
-    (Contributed by Pablo Galindo in :issue:`43797`.)
+  (Contributed by Pablo Galindo in :issue:`43797`.)
 
 * Usage of ``*`` in f-strings:
 
-    .. code-block:: python
+  .. code-block:: python
 
-        >>> f"Black holes {*all_black_holes} and revelations"
-          File "<stdin>", line 1
-            (*all_black_holes)
-             ^
-        SyntaxError: f-string: cannot use starred expression here
+      >>> f"Black holes {*all_black_holes} and revelations"
+        File "<stdin>", line 1
+          (*all_black_holes)
+           ^
+      SyntaxError: f-string: cannot use starred expression here
 
-    (Contributed by Pablo Galindo in :issue:`41064`.)
+  (Contributed by Pablo Galindo in :issue:`41064`.)
 
 IndentationErrors
 ~~~~~~~~~~~~~~~~~
@@ -365,10 +365,10 @@ raised from:
 
 (Contributed by Pablo Galindo in :issue:`38530`.)
 
-   .. warning::
-      Notice this won't work if :c:func:`PyErr_Display` is not called to display the error
-      which can happen if some other custom error display function is used. This is a common
-      scenario in some REPLs like IPython.
+.. warning::
+   Notice this won't work if :c:func:`PyErr_Display` is not called to display the error
+   which can happen if some other custom error display function is used. This is a common
+   scenario in some REPLs like IPython.
 
 NameErrors
 ~~~~~~~~~~
@@ -387,10 +387,10 @@ was raised from:
 
 (Contributed by Pablo Galindo in :issue:`38530`.)
 
-   .. warning::
-      Notice this won't work if :c:func:`PyErr_Display` is not called to display the error,
-      which can happen if some other custom error display function is used. This is a common
-      scenario in some REPLs like IPython.
+.. warning::
+   Notice this won't work if :c:func:`PyErr_Display` is not called to display the error,
+   which can happen if some other custom error display function is used. This is a common
+   scenario in some REPLs like IPython.
 
 
 PEP 626: Precise line numbers for debugging and other tools
@@ -433,16 +433,16 @@ A match statement takes an expression and compares its value to successive
 patterns given as one or more case blocks.  Specifically, pattern matching
 operates by:
 
-    1. using data with type and shape (the ``subject``)
-    2. evaluating the ``subject`` in the ``match`` statement
-    3. comparing the subject with each pattern in a ``case`` statement
-       from top to bottom until a match is confirmed.
-    4. executing the action associated with the pattern of the confirmed
-       match
-    5. If an exact match is not confirmed, the last case, a wildcard ``_``,
-       if provided, will be used as the matching case. If an exact match is
-       not confirmed and a wildcard case does not exist, the entire match
-       block is a no-op.
+1. using data with type and shape (the ``subject``)
+2. evaluating the ``subject`` in the ``match`` statement
+3. comparing the subject with each pattern in a ``case`` statement
+   from top to bottom until a match is confirmed.
+4. executing the action associated with the pattern of the confirmed
+   match
+5. If an exact match is not confirmed, the last case, a wildcard ``_``,
+   if provided, will be used as the matching case. If an exact match is
+   not confirmed and a wildcard case does not exist, the entire match
+   block is a no-op.
 
 Declarative approach
 ~~~~~~~~~~~~~~~~~~~~
@@ -2211,16 +2211,16 @@ Removed
 * Removed ``Py_UNICODE_str*`` functions manipulating ``Py_UNICODE*`` strings.
   (Contributed by Inada Naoki in :issue:`41123`.)
 
-   * ``Py_UNICODE_strlen``: use :c:func:`PyUnicode_GetLength` or
-     :c:macro:`PyUnicode_GET_LENGTH`
-   * ``Py_UNICODE_strcat``: use :c:func:`PyUnicode_CopyCharacters` or
-     :c:func:`PyUnicode_FromFormat`
-   * ``Py_UNICODE_strcpy``, ``Py_UNICODE_strncpy``: use
-     :c:func:`PyUnicode_CopyCharacters` or :c:func:`PyUnicode_Substring`
-   * ``Py_UNICODE_strcmp``: use :c:func:`PyUnicode_Compare`
-   * ``Py_UNICODE_strncmp``: use :c:func:`PyUnicode_Tailmatch`
-   * ``Py_UNICODE_strchr``, ``Py_UNICODE_strrchr``: use
-     :c:func:`PyUnicode_FindChar`
+  * ``Py_UNICODE_strlen``: use :c:func:`PyUnicode_GetLength` or
+    :c:macro:`PyUnicode_GET_LENGTH`
+  * ``Py_UNICODE_strcat``: use :c:func:`PyUnicode_CopyCharacters` or
+    :c:func:`PyUnicode_FromFormat`
+  * ``Py_UNICODE_strcpy``, ``Py_UNICODE_strncpy``: use
+    :c:func:`PyUnicode_CopyCharacters` or :c:func:`PyUnicode_Substring`
+  * ``Py_UNICODE_strcmp``: use :c:func:`PyUnicode_Compare`
+  * ``Py_UNICODE_strncmp``: use :c:func:`PyUnicode_Tailmatch`
+  * ``Py_UNICODE_strchr``, ``Py_UNICODE_strrchr``: use
+    :c:func:`PyUnicode_FindChar`
 
 * Removed ``PyUnicode_GetMax()``. Please migrate to new (:pep:`393`) APIs.
   (Contributed by Inada Naoki in :issue:`41103`.)

--- a/Doc/whatsnew/3.12.rst
+++ b/Doc/whatsnew/3.12.rst
@@ -2398,15 +2398,15 @@ Removed
 
 * Legacy Unicode APIs have been removed. See :pep:`623` for detail.
 
-   * :c:macro:`!PyUnicode_WCHAR_KIND`
-   * :c:func:`!PyUnicode_AS_UNICODE`
-   * :c:func:`!PyUnicode_AsUnicode`
-   * :c:func:`!PyUnicode_AsUnicodeAndSize`
-   * :c:func:`!PyUnicode_AS_DATA`
-   * :c:func:`!PyUnicode_FromUnicode`
-   * :c:func:`!PyUnicode_GET_SIZE`
-   * :c:func:`!PyUnicode_GetSize`
-   * :c:func:`!PyUnicode_GET_DATA_SIZE`
+  * :c:macro:`!PyUnicode_WCHAR_KIND`
+  * :c:func:`!PyUnicode_AS_UNICODE`
+  * :c:func:`!PyUnicode_AsUnicode`
+  * :c:func:`!PyUnicode_AsUnicodeAndSize`
+  * :c:func:`!PyUnicode_AS_DATA`
+  * :c:func:`!PyUnicode_FromUnicode`
+  * :c:func:`!PyUnicode_GET_SIZE`
+  * :c:func:`!PyUnicode_GetSize`
+  * :c:func:`!PyUnicode_GET_DATA_SIZE`
 
 * Remove the ``PyUnicode_InternImmortal()`` function macro.
   (Contributed by Victor Stinner in :gh:`85858`.)

--- a/Doc/whatsnew/3.13.rst
+++ b/Doc/whatsnew/3.13.rst
@@ -1135,37 +1135,37 @@ Removed
 
 * Remove old buffer protocols deprecated in Python 3.0. Use :ref:`bufferobjects` instead.
 
-   * :c:func:`!PyObject_CheckReadBuffer`: Use :c:func:`PyObject_CheckBuffer` to
-     test if the object supports the buffer protocol.
-     Note that :c:func:`PyObject_CheckBuffer` doesn't guarantee that
-     :c:func:`PyObject_GetBuffer` will succeed.
-     To test if the object is actually readable, see the next example
-     of :c:func:`PyObject_GetBuffer`.
+  * :c:func:`!PyObject_CheckReadBuffer`: Use :c:func:`PyObject_CheckBuffer` to
+    test if the object supports the buffer protocol.
+    Note that :c:func:`PyObject_CheckBuffer` doesn't guarantee that
+    :c:func:`PyObject_GetBuffer` will succeed.
+    To test if the object is actually readable, see the next example
+    of :c:func:`PyObject_GetBuffer`.
 
-   * :c:func:`!PyObject_AsCharBuffer`, :c:func:`!PyObject_AsReadBuffer`:
-     :c:func:`PyObject_GetBuffer` and :c:func:`PyBuffer_Release` instead:
+  * :c:func:`!PyObject_AsCharBuffer`, :c:func:`!PyObject_AsReadBuffer`:
+    :c:func:`PyObject_GetBuffer` and :c:func:`PyBuffer_Release` instead:
 
-     .. code-block:: c
+    .. code-block:: c
 
-        Py_buffer view;
-        if (PyObject_GetBuffer(obj, &view, PyBUF_SIMPLE) < 0) {
-            return NULL;
-        }
-        // Use `view.buf` and `view.len` to read from the buffer.
-        // You may need to cast buf as `(const char*)view.buf`.
-        PyBuffer_Release(&view);
+       Py_buffer view;
+       if (PyObject_GetBuffer(obj, &view, PyBUF_SIMPLE) < 0) {
+           return NULL;
+       }
+       // Use `view.buf` and `view.len` to read from the buffer.
+       // You may need to cast buf as `(const char*)view.buf`.
+       PyBuffer_Release(&view);
 
-   * :c:func:`!PyObject_AsWriteBuffer`: Use
-     :c:func:`PyObject_GetBuffer` and :c:func:`PyBuffer_Release` instead:
+  * :c:func:`!PyObject_AsWriteBuffer`: Use
+    :c:func:`PyObject_GetBuffer` and :c:func:`PyBuffer_Release` instead:
 
-     .. code-block:: c
+    .. code-block:: c
 
-        Py_buffer view;
-        if (PyObject_GetBuffer(obj, &view, PyBUF_WRITABLE) < 0) {
-            return NULL;
-        }
-        // Use `view.buf` and `view.len` to write to the buffer.
-        PyBuffer_Release(&view);
+       Py_buffer view;
+       if (PyObject_GetBuffer(obj, &view, PyBUF_WRITABLE) < 0) {
+           return NULL;
+       }
+       // Use `view.buf` and `view.len` to write to the buffer.
+       PyBuffer_Release(&view);
 
   (Contributed by Inada Naoki in :gh:`85275`.)
 

--- a/Doc/whatsnew/3.3.rst
+++ b/Doc/whatsnew/3.3.rst
@@ -917,12 +917,12 @@ abstract methods. The recommended approach to declaring abstract descriptors is
 now to provide :attr:`__isabstractmethod__` as a dynamically updated
 property. The built-in descriptors have been updated accordingly.
 
-  * :class:`abc.abstractproperty` has been deprecated, use :class:`property`
-    with :func:`abc.abstractmethod` instead.
-  * :class:`abc.abstractclassmethod` has been deprecated, use
-    :class:`classmethod` with :func:`abc.abstractmethod` instead.
-  * :class:`abc.abstractstaticmethod` has been deprecated, use
-    :class:`staticmethod` with :func:`abc.abstractmethod` instead.
+* :class:`abc.abstractproperty` has been deprecated, use :class:`property`
+  with :func:`abc.abstractmethod` instead.
+* :class:`abc.abstractclassmethod` has been deprecated, use
+  :class:`classmethod` with :func:`abc.abstractmethod` instead.
+* :class:`abc.abstractstaticmethod` has been deprecated, use
+  :class:`staticmethod` with :func:`abc.abstractmethod` instead.
 
 (Contributed by Darren Dale in :issue:`11610`.)
 
@@ -1060,32 +1060,32 @@ function to the :mod:`!crypt` module.
 curses
 ------
 
- * If the :mod:`curses` module is linked to the ncursesw library, use Unicode
-   functions when Unicode strings or characters are passed (e.g.
-   :c:func:`waddwstr`), and bytes functions otherwise (e.g. :c:func:`waddstr`).
- * Use the locale encoding instead of ``utf-8`` to encode Unicode strings.
- * :class:`curses.window` has a new :attr:`curses.window.encoding` attribute.
- * The :class:`curses.window` class has a new :meth:`~curses.window.get_wch`
-   method to get a wide character
- * The :mod:`curses` module has a new :meth:`~curses.unget_wch` function to
-   push a wide character so the next :meth:`~curses.window.get_wch` will return
-   it
+* If the :mod:`curses` module is linked to the ncursesw library, use Unicode
+  functions when Unicode strings or characters are passed (e.g.
+  :c:func:`waddwstr`), and bytes functions otherwise (e.g. :c:func:`waddstr`).
+* Use the locale encoding instead of ``utf-8`` to encode Unicode strings.
+* :class:`curses.window` has a new :attr:`curses.window.encoding` attribute.
+* The :class:`curses.window` class has a new :meth:`~curses.window.get_wch`
+  method to get a wide character
+* The :mod:`curses` module has a new :meth:`~curses.unget_wch` function to
+  push a wide character so the next :meth:`~curses.window.get_wch` will return
+  it
 
 (Contributed by Iñigo Serna in :issue:`6755`.)
 
 datetime
 --------
 
- * Equality comparisons between naive and aware :class:`~datetime.datetime`
-   instances now return :const:`False` instead of raising :exc:`TypeError`
-   (:issue:`15006`).
- * New :meth:`datetime.datetime.timestamp` method: Return POSIX timestamp
-   corresponding to the :class:`~datetime.datetime` instance.
- * The :meth:`datetime.datetime.strftime` method supports formatting years
-   older than 1000.
- * The :meth:`datetime.datetime.astimezone` method can now be
-   called without arguments to convert datetime instance to the system
-   timezone.
+* Equality comparisons between naive and aware :class:`~datetime.datetime`
+  instances now return :const:`False` instead of raising :exc:`TypeError`
+  (:issue:`15006`).
+* New :meth:`datetime.datetime.timestamp` method: Return POSIX timestamp
+  corresponding to the :class:`~datetime.datetime` instance.
+* The :meth:`datetime.datetime.strftime` method supports formatting years
+  older than 1000.
+* The :meth:`datetime.datetime.astimezone` method can now be
+  called without arguments to convert datetime instance to the system
+  timezone.
 
 
 .. _new-decimal:
@@ -1210,25 +1210,25 @@ the ``Message`` object it is serializing.  The default policy is
 
 The minimum set of controls implemented by all ``policy`` objects are:
 
-    .. tabularcolumns:: |l|L|
+.. tabularcolumns:: |l|L|
 
-    ===============     =======================================================
-    max_line_length     The maximum length, excluding the linesep character(s),
-                        individual lines may have when a ``Message`` is
-                        serialized.  Defaults to 78.
+===============     =======================================================
+max_line_length     The maximum length, excluding the linesep character(s),
+                    individual lines may have when a ``Message`` is
+                    serialized.  Defaults to 78.
 
-    linesep             The character used to separate individual lines when a
-                        ``Message`` is serialized.  Defaults to ``\n``.
+linesep             The character used to separate individual lines when a
+                    ``Message`` is serialized.  Defaults to ``\n``.
 
-    cte_type            ``7bit`` or ``8bit``.  ``8bit`` applies only to a
-                        ``Bytes`` ``generator``, and means that non-ASCII may
-                        be used where allowed by the protocol (or where it
-                        exists in the original input).
+cte_type            ``7bit`` or ``8bit``.  ``8bit`` applies only to a
+                    ``Bytes`` ``generator``, and means that non-ASCII may
+                    be used where allowed by the protocol (or where it
+                    exists in the original input).
 
-    raise_on_defect     Causes a ``parser`` to raise error when defects are
-                        encountered instead of adding them to the ``Message``
-                        object's ``defects`` list.
-    ===============     =======================================================
+raise_on_defect     Causes a ``parser`` to raise error when defects are
+                    encountered instead of adding them to the ``Message``
+                    object's ``defects`` list.
+===============     =======================================================
 
 A new policy instance, with new settings, is created using the
 :meth:`~email.policy.Policy.clone` method of policy objects.  ``clone`` takes
@@ -1263,21 +1263,21 @@ removal of the code) may occur if deemed necessary by the core developers.
 The new policies are instances of :class:`~email.policy.EmailPolicy`,
 and add the following additional controls:
 
-    .. tabularcolumns:: |l|L|
+.. tabularcolumns:: |l|L|
 
-    ===============     =======================================================
-    refold_source       Controls whether or not headers parsed by a
-                        :mod:`~email.parser` are refolded by the
-                        :mod:`~email.generator`.  It can be ``none``, ``long``,
-                        or ``all``.  The default is ``long``, which means that
-                        source headers with a line longer than
-                        ``max_line_length`` get refolded.  ``none`` means no
-                        line get refolded, and ``all`` means that all lines
-                        get refolded.
+===============     =======================================================
+refold_source       Controls whether or not headers parsed by a
+                    :mod:`~email.parser` are refolded by the
+                    :mod:`~email.generator`.  It can be ``none``, ``long``,
+                    or ``all``.  The default is ``long``, which means that
+                    source headers with a line longer than
+                    ``max_line_length`` get refolded.  ``none`` means no
+                    line get refolded, and ``all`` means that all lines
+                    get refolded.
 
-    header_factory      A callable that take a ``name`` and ``value`` and
-                        produces a custom header object.
-    ===============     =======================================================
+header_factory      A callable that take a ``name`` and ``value`` and
+                    produces a custom header object.
+===============     =======================================================
 
 The ``header_factory`` is the key to the new features provided by the new
 policies.  When one of the new policies is used, any header retrieved from
@@ -1352,18 +1352,18 @@ API.
 
 New utility functions:
 
-   * :func:`~email.utils.format_datetime`: given a :class:`~datetime.datetime`,
-     produce a string formatted for use in an email header.
+* :func:`~email.utils.format_datetime`: given a :class:`~datetime.datetime`,
+  produce a string formatted for use in an email header.
 
-   * :func:`~email.utils.parsedate_to_datetime`: given a date string from
-     an email header, convert it into an aware :class:`~datetime.datetime`,
-     or a naive :class:`~datetime.datetime` if the offset is ``-0000``.
+* :func:`~email.utils.parsedate_to_datetime`: given a date string from
+  an email header, convert it into an aware :class:`~datetime.datetime`,
+  or a naive :class:`~datetime.datetime` if the offset is ``-0000``.
 
-   * :func:`~email.utils.localtime`: With no argument, returns the
-     current local time as an aware :class:`~datetime.datetime` using the local
-     :class:`~datetime.timezone`.  Given an aware :class:`~datetime.datetime`,
-     converts it into an aware :class:`~datetime.datetime` using the
-     local :class:`~datetime.timezone`.
+* :func:`~email.utils.localtime`: With no argument, returns the
+  current local time as an aware :class:`~datetime.datetime` using the local
+  :class:`~datetime.timezone`.  Given an aware :class:`~datetime.datetime`,
+  converts it into an aware :class:`~datetime.datetime` using the
+  local :class:`~datetime.timezone`.
 
 
 ftplib

--- a/Doc/whatsnew/3.7.rst
+++ b/Doc/whatsnew/3.7.rst
@@ -1580,13 +1580,13 @@ The initialization of the default warnings filters has changed as follows:
 * warnings filters enabled via the command line or the environment now have the
   following order of precedence:
 
-     * the ``BytesWarning`` filter for :option:`-b` (or ``-bb``)
-     * any filters specified with the :option:`-W` option
-     * any filters specified with the :envvar:`PYTHONWARNINGS` environment
-       variable
-     * any other CPython specific filters (e.g. the ``default`` filter added
-       for the new ``-X dev`` mode)
-     * any implicit filters defined directly by the warnings machinery
+  * the ``BytesWarning`` filter for :option:`-b` (or ``-bb``)
+  * any filters specified with the :option:`-W` option
+  * any filters specified with the :envvar:`PYTHONWARNINGS` environment
+    variable
+  * any other CPython specific filters (e.g. the ``default`` filter added
+    for the new ``-X dev`` mode)
+  * any implicit filters defined directly by the warnings machinery
 
 * in :ref:`CPython debug builds <debug-build>`, all warnings are now displayed
   by default (the implicit filter list is empty)


### PR DESCRIPTION
This PR fixes indentation errors that resulted in spurious `blockquote`s and definition lists in the `Doc/whatsnew` dir.

<!-- gh-issue-number: gh-110631 -->
* Issue: gh-110631
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--110632.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->