### PR TITLE
gh-110631: Set three-space indents for reST in EditorConfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,5 +8,8 @@ indent_style = space
 [*.{py,c,cpp,h}]
 indent_size = 4
 
+[*.rst]
+indent_size = 3
+
 [*.yml]
 indent_size = 2


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

https://devguide.python.org/documentation/style-guide/#use-of-whitespace says:

> All reST files use an indentation of 3 spaces

EditorConfig is read by many editors, and there are plugins for others, so helps avoid incorrect tabs in reST files. 

https://editorconfig.org/

<!-- gh-issue-number: gh-110631 -->
* Issue: gh-110631
<!-- /gh-issue-number -->
