### PR TITLE
gh-110392: Fix tty functions

### DIFF
--- a/Lib/test/test_tty.py
+++ b/Lib/test/test_tty.py
@@ -58,7 +58,9 @@ class TestTty(unittest.TestCase):
         self.assertEqual(mode[5], self.mode[5])
 
     def test_setraw(self):
-        mode = tty.setraw(self.fd)
+        mode0 = termios.tcgetattr(self.fd)
+        mode1 = tty.setraw(self.fd)
+        self.assertEqual(mode1, mode0)
         mode2 = termios.tcgetattr(self.fd)
         self.check_raw(mode2)
         mode3 = tty.setraw(self.fd, termios.TCSANOW)
@@ -67,7 +69,9 @@ class TestTty(unittest.TestCase):
         tty.setraw(fd=self.fd, when=termios.TCSANOW)
 
     def test_setcbreak(self):
-        mode = tty.setcbreak(self.fd)
+        mode0 = termios.tcgetattr(self.fd)
+        mode1 = tty.setcbreak(self.fd)
+        self.assertEqual(mode1, mode0)
         mode2 = termios.tcgetattr(self.fd)
         self.check_cbreak(mode2)
         mode3 = tty.setcbreak(self.fd, termios.TCSANOW)

--- a/Lib/tty.py
+++ b/Lib/tty.py
@@ -39,6 +39,7 @@ def cfmakeraw(mode):
     # Case B: MIN>0, TIME=0
     # A pending read shall block until MIN (here 1) bytes are received,
     # or a signal is received.
+    mode[CC] = list(mode[CC])
     mode[CC][VMIN] = 1
     mode[CC][VTIME] = 0
 
@@ -54,6 +55,7 @@ def cfmakecbreak(mode):
     # Case B: MIN>0, TIME=0
     # A pending read shall block until MIN (here 1) bytes are received,
     # or a signal is received.
+    mode[CC] = list(mode[CC])
     mode[CC][VMIN] = 1
     mode[CC][VTIME] = 0
 

--- a/Misc/NEWS.d/next/Library/2023-10-10-17-56-41.gh-issue-110392.6g6CnP.rst
+++ b/Misc/NEWS.d/next/Library/2023-10-10-17-56-41.gh-issue-110392.6g6CnP.rst
@@ -1,0 +1,4 @@
+Fix :func:`tty.setraw` and :func:`tty.setcbreak`: previously they returned
+partially modified list of the original tty attributes.
+:func:`tty.cfmakeraw` and :func:`tty.cfmakecbreak` now make a copy of the
+list of special characters before modifying it.


### PR DESCRIPTION
* tty.setraw() and tty.setcbreak() previously returned partially modified list of the original tty attributes. Now they return the correct list of the original tty attributes
* tty.cfmakeraw() and tty.cfmakecbreak() now make a copy of the list of special characters before modifying it.


<!-- gh-issue-number: gh-110392 -->
* Issue: gh-110392
<!-- /gh-issue-number -->
