### PR TITLE
gh-110647: Fix signal test_stress_modifying_handlers()

### DIFF
--- a/Lib/test/test_signal.py
+++ b/Lib/test/test_signal.py
@@ -1339,7 +1339,7 @@ class StressTest(unittest.TestCase):
                 num_sent_signals += 1
 
         def cycle_handlers():
-            while num_sent_signals < 100:
+            while num_sent_signals < 100 or num_received_signals < 1:
                 for i in range(20000):
                     # Cycle between a Python-defined and a non-Python handler
                     for handler in [custom_handler, signal.SIG_IGN]:
@@ -1372,7 +1372,7 @@ class StressTest(unittest.TestCase):
             if not ignored:
                 # Sanity check that some signals were received, but not all
                 self.assertGreater(num_received_signals, 0)
-            self.assertLess(num_received_signals, num_sent_signals)
+            self.assertLessEqual(num_received_signals, num_sent_signals)
         finally:
             do_stop = True
             t.join()

--- a/Misc/NEWS.d/next/Tests/2023-10-10-23-20-13.gh-issue-110647.jKG3sY.rst
+++ b/Misc/NEWS.d/next/Tests/2023-10-10-23-20-13.gh-issue-110647.jKG3sY.rst
@@ -1,0 +1,2 @@
+Fix test_stress_modifying_handlers() of test_signal. Patch by Victor
+Stinner.


### PR DESCRIPTION
* cycle_handlers() now waits until at least one signal is received.
* num_received_signals can be equal to num_sent_signals.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-110647 -->
* Issue: gh-110647
<!-- /gh-issue-number -->
