### PR TITLE
[3.12] gh-108826: Document `dis` module CLI and rename `_test` function to `main` (#108827)

### DIFF
--- a/Doc/library/asyncio.rst
+++ b/Doc/library/asyncio.rst
@@ -56,6 +56,8 @@ Additionally, there are **low-level** APIs for
 * :ref:`bridge <asyncio-futures>` callback-based libraries and code
   with async/await syntax.
 
+.. _asyncio-cli:
+
 You can experiment with an ``asyncio`` concurrent context in the REPL:
 
 .. code-block:: pycon

--- a/Doc/library/cmdline.rst
+++ b/Doc/library/cmdline.rst
@@ -1,0 +1,57 @@
+++++++++++++++++++++++++++++++++++++
+Modules command-line interface (CLI)
+++++++++++++++++++++++++++++++++++++
+
+The following modules have a command-line interface.
+
+* :ref:`ast <ast-cli>`
+* :ref:`asyncio <asyncio-cli>`
+* :mod:`base64`
+* :ref:`calendar <calendar-cli>`
+* :mod:`code`
+* :ref:`compileall <compileall-cli>`
+* :mod:`cProfile`: see :ref:`profile <profile-cli>`
+* :ref:`difflib <difflib-interface>`
+* :ref:`dis <dis-cli>`
+* :mod:`doctest`
+* :mod:`!encodings.rot_13`
+* :mod:`ensurepip`
+* :mod:`filecmp`
+* :mod:`fileinput`
+* :mod:`ftplib`
+* :ref:`gzip <gzip-cli>`
+* :ref:`http.server <http-server-cli>`
+* :mod:`!idlelib`
+* :ref:`inspect <inspect-module-cli>`
+* :ref:`json.tool <json-commandline>`
+* :mod:`mimetypes`
+* :mod:`pdb`
+* :mod:`pickle`
+* :ref:`pickletools <pickletools-cli>`
+* :mod:`platform`
+* :mod:`poplib`
+* :ref:`profile <profile-cli>`
+* :mod:`pstats`
+* :ref:`py_compile <py_compile-cli>`
+* :mod:`pyclbr`
+* :mod:`pydoc`
+* :mod:`quopri`
+* :mod:`runpy`
+* :ref:`site <site-commandline>`
+* :ref:`sqlite3 <sqlite3-cli>`
+* :ref:`sysconfig <sysconfig-cli>`
+* :mod:`tabnanny`
+* :ref:`tarfile <tarfile-commandline>`
+* :mod:`!this`
+* :ref:`timeit <timeit-command-line-interface>`
+* :ref:`tokenize <tokenize-cli>`
+* :ref:`trace <trace-cli>`
+* :mod:`turtledemo`
+* :ref:`unittest <unittest-command-line-interface>`
+* :ref:`uuid <uuid-cli>`
+* :mod:`venv`
+* :mod:`webbrowser`
+* :ref:`zipapp <zipapp-command-line-interface>`
+* :ref:`zipfile <zipfile-commandline>`
+
+See also the :ref:`Python command-line interface <using-on-general>`.

--- a/Doc/library/compileall.rst
+++ b/Doc/library/compileall.rst
@@ -16,6 +16,8 @@ have write permission to the library directories.
 
 .. include:: ../includes/wasm-notavail.rst
 
+.. _compileall-cli:
+
 Command-line use
 ----------------
 

--- a/Doc/library/dis.rst
+++ b/Doc/library/dis.rst
@@ -63,6 +63,28 @@ the following command can be used to display the disassembly of
 
 (The "2" is a line number).
 
+.. _dis-cli:
+
+Command-line interface
+----------------------
+
+The :mod:`dis` module can be invoked as a script from the command line:
+
+.. code-block:: sh
+
+   python -m dis [-h] [infile]
+
+The following options are accepted:
+
+.. program:: dis
+
+.. cmdoption:: -h, --help
+
+   Display usage and exit.
+
+If :file:`infile` is specified, its disassembled code will be written to stdout.
+Otherwise, disassembly is performed on compiled source code recieved from stdin.
+
 Bytecode analysis
 -----------------
 

--- a/Doc/library/gzip.rst
+++ b/Doc/library/gzip.rst
@@ -250,6 +250,8 @@ Example of how to GZIP compress a binary string::
 
 .. program:: gzip
 
+.. _gzip-cli:
+
 Command Line Interface
 ----------------------
 

--- a/Doc/library/index.rst
+++ b/Doc/library/index.rst
@@ -73,5 +73,6 @@ the `Python Package Index <https://pypi.org>`_.
    language.rst
    windows.rst
    unix.rst
+   cmdline.rst
    superseded.rst
    security_warnings.rst

--- a/Doc/library/pickletools.rst
+++ b/Doc/library/pickletools.rst
@@ -17,6 +17,8 @@ are useful for Python core developers who are working on the :mod:`pickle`;
 ordinary users of the :mod:`pickle` module probably won't find the
 :mod:`pickletools` module relevant.
 
+.. _pickletools-cli:
+
 Command line usage
 ------------------
 

--- a/Doc/library/profile.rst
+++ b/Doc/library/profile.rst
@@ -121,6 +121,8 @@ results to a file by specifying a filename to the :func:`run` function::
 The :class:`pstats.Stats` class reads profile results from a file and formats
 them in various ways.
 
+.. _profile-cli:
+
 The files :mod:`cProfile` and :mod:`profile` can also be invoked as a script to
 profile another script.  For example::
 

--- a/Doc/library/py_compile.rst
+++ b/Doc/library/py_compile.rst
@@ -125,6 +125,7 @@ byte-code cache files in the directory containing the source code.
       This option is useful when the ``.pycs`` are kept up to date by some
       system external to Python like a build system.
 
+.. _py_compile-cli:
 
 Command-Line Interface
 ----------------------

--- a/Doc/library/sysconfig.rst
+++ b/Doc/library/sysconfig.rst
@@ -427,6 +427,7 @@ Other functions
 
    Return the path of :file:`Makefile`.
 
+.. _sysconfig-cli:
 
 Using :mod:`sysconfig` as a script
 ----------------------------------

--- a/Lib/dis.py
+++ b/Lib/dis.py
@@ -790,8 +790,7 @@ class Bytecode:
             return output.getvalue()
 
 
-def _test():
-    """Simple test program to disassemble a file."""
+def main():
     import argparse
 
     parser = argparse.ArgumentParser()
@@ -803,4 +802,4 @@ def _test():
     dis(code)
 
 if __name__ == "__main__":
-    _test()
+    main()

--- a/Misc/NEWS.d/next/Documentation/2023-09-03-13-43-49.gh-issue-108826.KG7abS.rst
+++ b/Misc/NEWS.d/next/Documentation/2023-09-03-13-43-49.gh-issue-108826.KG7abS.rst
@@ -1,0 +1,1 @@
+:mod:`dis` module command-line interface is now mentioned in documentation.


### PR DESCRIPTION
Co-authored-by: Hugo van Kemenade <hugovk@users.noreply.github.com>
Co-authored-by: blurb-it[bot] <43283697+blurb-it[bot]@users.noreply.github.com>
(cherry picked from commit 0d805b998ded854840f029b7f0c9a02eb3efa251)

I removed the `-C` option for dis, as it's new in 3.13.

Also include `cmdline.rst` and the extra reST anchors. 

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-108826 -->
* Issue: gh-108826
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--110681.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->