### PR TITLE
gh-110682: Ignore `__match_args__` from `__instancecheck__` in protocols

### DIFF
--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -3801,6 +3801,39 @@ class ProtocolTests(BaseTestCase):
 
             self.assertIsInstance(E(), D)
 
+    def test_runtime_checkable_with_match_args(self):
+        @runtime_checkable
+        class P_regular(Protocol):
+            x: int
+            y: int
+
+        @runtime_checkable
+        class P_match(Protocol):
+            __match_args__ = ('x', 'y')
+            x: int
+            y: int
+
+        class Regular:
+            def __init__(self, x: int, y: int):
+                self.x = x
+                self.y = y
+
+        class WithMatch:
+            __match_args__ = ('x', 'y', 'z')
+            def __init__(self, x: int, y: int, z: int):
+                self.x = x
+                self.y = y
+                self.z = z
+
+        class Nope: ...
+
+        self.assertIsInstance(Regular(1, 2), P_regular)
+        self.assertIsInstance(Regular(1, 2), P_match)
+        self.assertIsInstance(WithMatch(1, 2, 3), P_regular)
+        self.assertIsInstance(WithMatch(1, 2, 3), P_match)
+        self.assertNotIsInstance(Nope(), P_regular)
+        self.assertNotIsInstance(Nope(), P_match)
+
     def test_supports_int(self):
         self.assertIsSubclass(int, typing.SupportsInt)
         self.assertNotIsSubclass(str, typing.SupportsInt)

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -1669,7 +1669,8 @@ _TYPING_INTERNALS = frozenset({
 _SPECIAL_NAMES = frozenset({
     '__abstractmethods__', '__annotations__', '__dict__', '__doc__',
     '__init__', '__module__', '__new__', '__slots__',
-    '__subclasshook__', '__weakref__', '__class_getitem__'
+    '__subclasshook__', '__weakref__', '__class_getitem__',
+    '__match_args__',
 })
 
 # These special attributes will be not collected as protocol members.

--- a/Misc/NEWS.d/next/Library/2023-10-11-11-00-11.gh-issue-110682.bXRFaX.rst
+++ b/Misc/NEWS.d/next/Library/2023-10-11-11-00-11.gh-issue-110682.bXRFaX.rst
@@ -1,2 +1,4 @@
-Protocols used to check for ``__match_args__`` attribute in
-``__instancecheck__``. Now, this attribute is ignored.
+:func:`runtime-checkable protocols <typing.runtime_checkable>` used
+to consider ``__match_args__`` a protocol member in
+``__instancecheck__`` if it was present on the protocol. Now, this attribute is
+ignored if it is present.

--- a/Misc/NEWS.d/next/Library/2023-10-11-11-00-11.gh-issue-110682.bXRFaX.rst
+++ b/Misc/NEWS.d/next/Library/2023-10-11-11-00-11.gh-issue-110682.bXRFaX.rst
@@ -1,0 +1,2 @@
+Protocols used to check for ``__match_args__`` attribute in
+``__instancecheck__``. Now, this attribute is ignored.


### PR DESCRIPTION


<!-- gh-issue-number: gh-110682 -->
* Issue: gh-110682
<!-- /gh-issue-number -->
