### PR TITLE
gh-85283: _stat extension now uses the limited C API

### DIFF
--- a/Doc/whatsnew/3.13.rst
+++ b/Doc/whatsnew/3.13.rst
@@ -928,6 +928,10 @@ Build Changes
 * Building CPython now requires a compiler with support for the C11 atomic
   library, GCC built-in atomic functions, or MSVC interlocked intrinsics.
 
+* The ``_stat`` C extension is now built with the :ref:`limited C API
+  <limited-c-api>`.
+  (Contributed by Victor Stinner in :gh:`85283`.)
+
 
 C API Changes
 =============

--- a/Misc/NEWS.d/next/Build/2023-08-29-15-05-09.gh-issue-85283.tlK7G7.rst
+++ b/Misc/NEWS.d/next/Build/2023-08-29-15-05-09.gh-issue-85283.tlK7G7.rst
@@ -1,0 +1,2 @@
+The ``_stat`` C extension is now built with the :ref:`limited C API
+<limited-c-api>`. Patch by Victor Stinner.

--- a/Modules/_stat.c
+++ b/Modules/_stat.c
@@ -11,6 +11,9 @@
  *
  */
 
+// Need limited C API version 3.13 for PyModule_Add() on Windows
+#define Py_LIMITED_API 0x030d0000
+
 #include "Python.h"
 
 #ifdef HAVE_SYS_TYPES_H


### PR DESCRIPTION
The _stat C extension is now built with the limited C API.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-85283 -->
* Issue: gh-85283
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--110711.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->