### PR TITLE
[3.8] gh-108310: Fix TestPreHandshakeClose tests in test_ssl

### DIFF
--- a/Lib/test/test_ssl.py
+++ b/Lib/test/test_ssl.py
@@ -150,6 +150,9 @@ OP_CIPHER_SERVER_PREFERENCE = getattr(ssl, "OP_CIPHER_SERVER_PREFERENCE", 0)
 OP_ENABLE_MIDDLEBOX_COMPAT = getattr(ssl, "OP_ENABLE_MIDDLEBOX_COMPAT", 0)
 OP_IGNORE_UNEXPECTED_EOF = getattr(ssl, "OP_IGNORE_UNEXPECTED_EOF", 0)
 
+# *_TIMEOUT constants are available in test.support in 3.9+
+SHORT_TIMEOUT = 30.0
+
 # Ubuntu has patched OpenSSL and changed behavior of security level 2
 # see https://bugs.python.org/issue41561#msg389003
 def is_ubuntu():
@@ -4835,7 +4838,7 @@ class TestPreHandshakeClose(unittest.TestCase):
             self.listener = None  # set by .start()
             self.port = None  # set by .start()
             if timeout is None:
-                self.timeout = support.SHORT_TIMEOUT
+                self.timeout = SHORT_TIMEOUT
             else:
                 self.timeout = timeout
             super().__init__(name=name)
@@ -4917,7 +4920,7 @@ class TestPreHandshakeClose(unittest.TestCase):
 
         def call_after_accept(unused):
             server_accept_called.set()
-            if not ready_for_server_wrap_socket.wait(support.SHORT_TIMEOUT):
+            if not ready_for_server_wrap_socket.wait(SHORT_TIMEOUT):
                 raise RuntimeError("wrap_socket event never set, test may fail.")
             return False  # Tell the server thread to continue.
 
@@ -4961,7 +4964,7 @@ class TestPreHandshakeClose(unittest.TestCase):
         client_can_continue_with_wrap_socket = threading.Event()
 
         def call_after_accept(conn_to_client):
-            if not server_can_continue_with_wrap_socket.wait(support.SHORT_TIMEOUT):
+            if not server_can_continue_with_wrap_socket.wait(SHORT_TIMEOUT):
                 print("ERROR: test client took too long")
 
             # This forces an immediate connection close via RST on .close().
@@ -4987,7 +4990,7 @@ class TestPreHandshakeClose(unittest.TestCase):
             client.connect(server.listener.getsockname())
             server_can_continue_with_wrap_socket.set()
 
-            if not client_can_continue_with_wrap_socket.wait(support.SHORT_TIMEOUT):
+            if not client_can_continue_with_wrap_socket.wait(SHORT_TIMEOUT):
                 self.fail("test server took too long")
             ssl_ctx = ssl.create_default_context()
             try:
@@ -5026,7 +5029,7 @@ class TestPreHandshakeClose(unittest.TestCase):
                 http.client.HTTPConnection.connect(self)
 
                 # Wait for our fault injection server to have done its thing.
-                if not server_responding.wait(support.SHORT_TIMEOUT) and support.verbose:
+                if not server_responding.wait(SHORT_TIMEOUT) and support.verbose:
                     sys.stdout.write("server_responding event never set.")
                 self.sock = self._context.wrap_socket(
                         self.sock, server_hostname=self.host)
@@ -5104,7 +5107,7 @@ def test_main(verbose=False):
     tests = [
         ContextTests, BasicSocketTests, SSLErrorTests, MemoryBIOTests,
         SSLObjectTests, SimpleBackgroundTests, ThreadedTests,
-        TestPostHandshakeAuth, TestSSLDebug
+        TestPostHandshakeAuth, TestSSLDebug, TestPreHandshakeClose
     ]
 
     if support.is_resource_enabled('network'):

--- a/Misc/NEWS.d/next/Tests/2023-10-11-16-02-55.gh-issue-108310.URRe8Y.rst
+++ b/Misc/NEWS.d/next/Tests/2023-10-11-16-02-55.gh-issue-108310.URRe8Y.rst
@@ -1,0 +1,2 @@
+SSL tests for pre-handshake close were previously not enabled on Python 3.8
+due to an incorrect backport. This is now fixed. Patch by Lumír Balhar.


### PR DESCRIPTION
The new class is part of the fix for CVE-2023-40217: https://github.com/python/cpython/commit/b4bcc06a9cfe13d96d5270809d963f8ba278f89b but it's not in the lists of tests so they're not
executed. The new tests also need `SHORT_TIMEOUT`
constant not available in test.support in 3.8.

I'm using the original issue here as this change fixes the original testsuite for the CVE in TLS.

An alternative for having the constant in test_ssl is to backport this commit from 3.9: https://github.com/python/cpython/commit/24c6258269acd842914450f55491690ba87dded9 But it touches a lot of files and I think that might be too much for 3.8.

Cc the authors of the original fix: @ambv and @gpshead 

<!-- gh-issue-number: gh-108310 -->
* Issue: gh-108310
<!-- /gh-issue-number -->
