### PR TITLE
gh-76186: Fix misleading error message in multiprocesing module (draft)

### DIFF
--- a/Lib/test/test_ctypes/test_parameters.py
+++ b/Lib/test/test_ctypes/test_parameters.py
@@ -86,13 +86,13 @@ class SimpleTypesTestCase(unittest.TestCase):
         with self.assertRaises(TypeError) as cm:
             c_char.from_param(b"abc")
         self.assertEqual(str(cm.exception),
-                         "one character bytes, bytearray or integer expected")
+                         "character bytes, bytearray or integer expected")
 
     def test_c_wchar(self):
         with self.assertRaises(TypeError) as cm:
             c_wchar.from_param("abc")
         self.assertEqual(str(cm.exception),
-                         "one character unicode string expected")
+                         "character unicode string expected")
 
 
         with self.assertRaises(TypeError) as cm:

--- a/Misc/NEWS.d/next/Core and Builtins/2023-10-11-14-04-00.gh-issue-76186.p3zwCQ.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2023-10-11-14-04-00.gh-issue-76186.p3zwCQ.rst
@@ -1,0 +1,1 @@
+Fix misleading error message in multiprocesing module. Patch by Joannah Nanjekye

--- a/Modules/_ctypes/cfield.c
+++ b/Modules/_ctypes/cfield.c
@@ -1104,7 +1104,7 @@ c_set(void *ptr, PyObject *value, Py_ssize_t size)
     }
   error:
     PyErr_Format(PyExc_TypeError,
-                 "one character bytes, bytearray or integer expected");
+                 "character bytes, bytearray or integer expected");
     return NULL;
 }
 
@@ -1133,7 +1133,7 @@ u_set(void *ptr, PyObject *value, Py_ssize_t size)
     if (len != 1) {
         Py_DECREF(value);
         PyErr_SetString(PyExc_TypeError,
-                        "one character unicode string expected");
+                        "character unicode string expected");
         return NULL;
     }
 


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-76186 -->
* Issue: gh-76186
<!-- /gh-issue-number -->
