### PR TITLE
gh-85283: If Py_LIMITED_API is defined, undefine Py_BUILD_CORE

### DIFF
--- a/Doc/whatsnew/3.13.rst
+++ b/Doc/whatsnew/3.13.rst
@@ -1075,6 +1075,11 @@ Porting to Python 3.13
   :c:func:`!Py_TOLOWER`.
   (Contributed by Victor Stinner in :gh:`108765`.)
 
+* If the :c:macro:`Py_LIMITED_API` macro is defined, :c:macro:`Py_BUILD_CORE`,
+  :c:macro:`Py_BUILD_CORE_BUILTIN` and :c:macro:`Py_BUILD_CORE_MODULE` macros
+  are now undefined by ``<Python.h>``.
+  (Contributed by Victor Stinner in :gh:`85283`.)
+
 Deprecated
 ----------
 

--- a/Doc/whatsnew/3.13.rst
+++ b/Doc/whatsnew/3.13.rst
@@ -1075,8 +1075,8 @@ Porting to Python 3.13
   :c:func:`!Py_TOLOWER`.
   (Contributed by Victor Stinner in :gh:`108765`.)
 
-* If the :c:macro:`Py_LIMITED_API` macro is defined, :c:macro:`Py_BUILD_CORE`,
-  :c:macro:`Py_BUILD_CORE_BUILTIN` and :c:macro:`Py_BUILD_CORE_MODULE` macros
+* If the :c:macro:`Py_LIMITED_API` macro is defined, :c:macro:`!Py_BUILD_CORE`,
+  :c:macro:`!Py_BUILD_CORE_BUILTIN` and :c:macro:`!Py_BUILD_CORE_MODULE` macros
   are now undefined by ``<Python.h>``.
   (Contributed by Victor Stinner in :gh:`85283`.)
 

--- a/Include/pyport.h
+++ b/Include/pyport.h
@@ -48,10 +48,6 @@
 #  define Py_BUILD_CORE
 #endif
 
-#if defined(Py_LIMITED_API) && defined(Py_BUILD_CORE)
-#  error "Py_LIMITED_API is not compatible with Py_BUILD_CORE"
-#endif
-
 
 /**************************************************************************
 Symbols and macros to supply platform-independent interfaces to basic
@@ -360,6 +356,15 @@ extern "C" {
 #endif
 
 #include "exports.h"
+
+#ifdef Py_LIMITED_API
+   // The internal C API must not be used with the limited C API: make sure
+   // that Py_BUILD_CORE macro is not defined in this case. These 3 macros are
+   // used by exports.h, so only undefine them afterwards.
+#  undef Py_BUILD_CORE
+#  undef Py_BUILD_CORE_BUILTIN
+#  undef Py_BUILD_CORE_MODULE
+#endif
 
 /* limits.h constants that may be missing */
 

--- a/Misc/NEWS.d/next/C API/2023-10-11-17-29-52.gh-issue-85283.OsqIBF.rst
+++ b/Misc/NEWS.d/next/C API/2023-10-11-17-29-52.gh-issue-85283.OsqIBF.rst
@@ -1,3 +1,3 @@
-If the :c:macro:`Py_LIMITED_API` macro is defined, :c:macro:`Py_BUILD_CORE`,
-:c:macro:`Py_BUILD_CORE_BUILTIN` and :c:macro:`Py_BUILD_CORE_MODULE` macros
+If the :c:macro:`Py_LIMITED_API` macro is defined, :c:macro:`!Py_BUILD_CORE`,
+:c:macro:`!Py_BUILD_CORE_BUILTIN` and :c:macro:`!Py_BUILD_CORE_MODULE` macros
 are now undefined by ``<Python.h>``. Patch by Victor Stinner.

--- a/Misc/NEWS.d/next/C API/2023-10-11-17-29-52.gh-issue-85283.OsqIBF.rst
+++ b/Misc/NEWS.d/next/C API/2023-10-11-17-29-52.gh-issue-85283.OsqIBF.rst
@@ -1,0 +1,3 @@
+If the :c:macro:`Py_LIMITED_API` macro is defined, :c:macro:`Py_BUILD_CORE`,
+:c:macro:`Py_BUILD_CORE_BUILTIN` and :c:macro:`Py_BUILD_CORE_MODULE` macros
+are now undefined by ``<Python.h>``. Patch by Victor Stinner.


### PR DESCRIPTION
If the Py_LIMITED_API macro is defined, Py_BUILD_CORE, Py_BUILD_CORE_BUILTIN and Py_BUILD_CORE_MODULE macros are now undefined by Python.h.

Only undefine these 3 macros after including "exports.h" which uses them to define PyAPI_FUNC(), PyAPI_DATA() and PyMODINIT_FUNC macros.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-85283 -->
* Issue: gh-85283
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--110725.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->