### PR TITLE
gh-110733: Optimize _run_once for many iterations of the event loop

### DIFF
--- a/Lib/asyncio/base_events.py
+++ b/Lib/asyncio/base_events.py
@@ -1907,8 +1907,11 @@ class BaseEventLoop(events.AbstractEventLoop):
             timeout = 0
         elif self._scheduled:
             # Compute the desired timeout.
-            when = self._scheduled[0]._when
-            timeout = min(max(0, when - self.time()), MAXIMUM_SELECT_TIMEOUT)
+            timeout = self._scheduled[0]._when - self.time()
+            if timeout > MAXIMUM_SELECT_TIMEOUT:
+                timeout = MAXIMUM_SELECT_TIMEOUT
+            elif timeout < 0:
+                timeout = 0
 
         event_list = self._selector.select(timeout)
         self._process_events(event_list)

--- a/Misc/NEWS.d/next/Library/2023-10-11-18-43-43.gh-issue-110733.UlrgVm.rst
+++ b/Misc/NEWS.d/next/Library/2023-10-11-18-43-43.gh-issue-110733.UlrgVm.rst
@@ -1,0 +1,1 @@
+Optimize asyncio :meth:`BaseEventLoop._run_once` for many iteration case.

--- a/Misc/NEWS.d/next/Library/2023-10-11-18-43-43.gh-issue-110733.UlrgVm.rst
+++ b/Misc/NEWS.d/next/Library/2023-10-11-18-43-43.gh-issue-110733.UlrgVm.rst
@@ -1,1 +1,1 @@
-Optimize asyncio :meth:`BaseEventLoop._run_once` for many iteration case.
+Micro-optimization: Avoid calling ``min()``, ``max()`` in :meth:`BaseEventLoop._run_once`.


### PR DESCRIPTION
Replace `min` and `max` in `_run_once` with simple `<` and `>`

close #110733


<!-- gh-issue-number: gh-110733 -->
* Issue: gh-110733
<!-- /gh-issue-number -->

benchmarks in #110733
```
new: 0.36033158400096
original: 0.4667800000170246
```
