### PR TITLE
gh-110752: Reset `ceval.eval_breaker` to 0 in `interpreter_clear`

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2023-10-12-06-32-25.gh-issue-110752.FYfI0h.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2023-10-12-06-32-25.gh-issue-110752.FYfI0h.rst
@@ -1,0 +1,1 @@
+Reset ``ceval.eval_breaker`` in :func:`interpreter_clear`

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -890,6 +890,10 @@ interpreter_clear(PyInterpreterState *interp, PyThreadState *tstate)
 
     Py_CLEAR(interp->audit_hooks);
 
+    // At this time, all the threads should be cleared so we don't need
+    // atomic operations for eval_breaker
+    interp->ceval.eval_breaker = 0;
+
     for (int i = 0; i < _PY_MONITORING_UNGROUPED_EVENTS; i++) {
         interp->monitors.tools[i] = 0;
     }


### PR DESCRIPTION
I tried to read the code and I believe at this point all the threads should be done so we don't need atomic operations.

Also no test was added for now. The test requires interpreter finalization so it needs to be in its own process.

<!-- gh-issue-number: gh-110752 -->
* Issue: gh-110752
<!-- /gh-issue-number -->
