### PR TITLE
Unnecessary escape in Doc/library/enum.rst

### DIFF
--- a/Doc/library/enum.rst
+++ b/Doc/library/enum.rst
@@ -322,7 +322,7 @@ Data Types
          >>> PowersOfThree.SECOND.value
          9
 
-   .. method:: Enum.__init_subclass__(cls, \**kwds)
+   .. method:: Enum.__init_subclass__(cls, **kwds)
 
       A *classmethod* that is used to further configure subsequent subclasses.
       By default, does nothing.


### PR DESCRIPTION
There's a stray leading backslash; possibly used with the intention of escaping `**`, it is actually rendered as a literal character:

![__init_subclass__(cls, \**kwds)](https://github.com/python/cpython/assets/122007197/6283b325-df17-4597-b96e-3714b83e1bf3)


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--110780.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->