### PR TITLE
gh-110205: Fix asyncio ThreadedChildWatcher._join_threads()

### DIFF
--- a/Lib/asyncio/unix_events.py
+++ b/Lib/asyncio/unix_events.py
@@ -1373,12 +1373,16 @@ class ThreadedChildWatcher(AbstractChildWatcher):
     def close(self):
         self._join_threads()
 
-    def _join_threads(self):
+    def _join_threads(self, timeout=None):
         """Internal: Join all non-daemon threads"""
         threads = [thread for thread in list(self._threads.values())
                    if thread.is_alive() and not thread.daemon]
         for thread in threads:
-            thread.join()
+            thread.join(timeout)
+
+        # Clear references to terminated threads
+        self.threads = [thread for thread in list(self._threads.values())
+                        if thread.is_alive() and not thread.daemon]
 
     def __enter__(self):
         return self
@@ -1397,7 +1401,7 @@ class ThreadedChildWatcher(AbstractChildWatcher):
     def add_child_handler(self, pid, callback, *args):
         loop = events.get_running_loop()
         thread = threading.Thread(target=self._do_waitpid,
-                                  name=f"waitpid-{next(self._pid_counter)}",
+                                  name=f"asyncio-waitpid-{next(self._pid_counter)}",
                                   args=(loop, pid, callback, args),
                                   daemon=True)
         self._threads[pid] = thread

--- a/Lib/asyncio/unix_events.py
+++ b/Lib/asyncio/unix_events.py
@@ -1381,8 +1381,8 @@ class ThreadedChildWatcher(AbstractChildWatcher):
             thread.join(timeout)
 
         # Clear references to terminated threads
-        self.threads[:] = [thread for thread in list(self._threads.values())
-                           if thread.is_alive() and not thread.daemon]
+        self._threads[:] = [thread for thread in list(self._threads.values())
+                            if thread.is_alive() and not thread.daemon]
 
     def __enter__(self):
         return self

--- a/Lib/asyncio/unix_events.py
+++ b/Lib/asyncio/unix_events.py
@@ -1381,8 +1381,8 @@ class ThreadedChildWatcher(AbstractChildWatcher):
             thread.join(timeout)
 
         # Clear references to terminated threads
-        self.threads = [thread for thread in list(self._threads.values())
-                        if thread.is_alive() and not thread.daemon]
+        self.threads[:] = [thread for thread in list(self._threads.values())
+                           if thread.is_alive() and not thread.daemon]
 
     def __enter__(self):
         return self

--- a/Lib/test/test_asyncio/utils.py
+++ b/Lib/test/test_asyncio/utils.py
@@ -546,6 +546,7 @@ class TestCase(unittest.TestCase):
             else:
                 loop._default_executor.shutdown(wait=True)
         loop.close()
+
         policy = support.maybe_get_event_loop_policy()
         if policy is not None:
             try:
@@ -557,9 +558,11 @@ class TestCase(unittest.TestCase):
                 pass
             else:
                 if isinstance(watcher, asyncio.ThreadedChildWatcher):
-                    threads = list(watcher._threads.values())
-                    for thread in threads:
-                        thread.join()
+                    watcher._join_threads(timeout=support.SHORT_TIMEOUT)
+                    threads = watcher._threads
+                    if threads:
+                        self.fail(f"watcher still has running threads: "
+                                  f"{threads}")
 
     def set_event_loop(self, loop, *, cleanup=True):
         if loop is None:


### PR DESCRIPTION
ThreadedChildWatcher._join_threads() now clears references to completed threads.

test_asyncio.utils.TestCase now calls _join_threads() of the watcher, uses SHORT_TIMEOUT to join a thread, and then raises an exception if there are still running threads.

Rename also ThreadedChildWatcher threads to add "asyncio-" prefix to the name.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-110205 -->
* Issue: gh-110205
<!-- /gh-issue-number -->
