### PR TITLE
gh-110803: Reorganize docs for what PyType_Slot doesn't cover

### DIFF
--- a/Doc/c-api/structures.rst
+++ b/Doc/c-api/structures.rst
@@ -406,7 +406,11 @@ Accessing attributes of extension types
 .. c:type:: PyMemberDef
 
    Structure which describes an attribute of a type which corresponds to a C
-   struct member.  Its fields are, in order:
+   struct member.
+   When defining a class, put a NULL-terminated array of these
+   structures in the :c:member:`~PyTypeObject.tp_members` slot.
+
+   Its fields are, in order:
 
    .. c:member:: const char* name
 

--- a/Doc/c-api/type.rst
+++ b/Doc/c-api/type.rst
@@ -504,15 +504,6 @@ The following functions and structs are used to create
         :c:member:`~PyBufferProcs.bf_releasebuffer` are now available
         under the :ref:`limited API <limited-c-api>`.
 
-     .. versionchanged:: 3.12
-        Uses of :c:member:`~PyTypeObject.tp_weaklistoffset` and
-        :c:member:`~PyTypeObject.tp_dictoffset` should now be avoided in favor
-        of the :c:macro:`Py_TPFLAGS_MANAGED_WEAKREF` and
-        :c:macro:`Py_TPFLAGS_MANAGED_DICT` flags, if at all possible.
-        For cases where it's not possible (e.g. to support older versions
-        of Python), use the previous approach documented in
-        :ref:`PyMemberDef <pymemberdef-offsets>`.
-
    .. c:member:: void *pfunc
 
       The desired value of the slot. In most cases, this is a pointer

--- a/Doc/c-api/type.rst
+++ b/Doc/c-api/type.rst
@@ -461,21 +461,34 @@ The following functions and structs are used to create
       * ``Py_nb_add`` to set :c:member:`PyNumberMethods.nb_add`
       * ``Py_sq_length`` to set :c:member:`PySequenceMethods.sq_length`
 
-      The following fields cannot be set at all using :c:type:`PyType_Spec` and
-      :c:type:`PyType_Slot`:
+      The following “offset” fields cannot be set using :c:type:`PyType_Slot`:
 
-      * :c:member:`~PyTypeObject.tp_dict`
-      * :c:member:`~PyTypeObject.tp_mro`
-      * :c:member:`~PyTypeObject.tp_cache`
-      * :c:member:`~PyTypeObject.tp_subclasses`
-      * :c:member:`~PyTypeObject.tp_weaklist`
+         * :c:member:`~PyTypeObject.tp_weaklistoffset`
+           (use :c:macro:`Py_TPFLAGS_MANAGED_WEAKREF` instead if possible)
+         * :c:member:`~PyTypeObject.tp_dictoffset`
+           (use :c:macro:`Py_TPFLAGS_MANAGED_DICT` instead if possible)
+         * :c:member:`~PyTypeObject.tp_vectorcall_offset`
+           (use ``"__vectorcalloffset__"`` in
+           :ref:`PyMemberDef <pymemberdef-offsets>`)
+
+         If it is not possible to switch to a ``MANAGED`` flag (for example,
+         for vectorcall or to support Python older than 3.12), specify the
+         offset in :c:member:`Py_tp_members <PyTypeObject.tp_members>`.
+         See :ref:`PyMemberDef documentation <pymemberdef-offsets>`
+         for details.
+
+      The following fields cannot be set at all when creating a heap type:
+
       * :c:member:`~PyTypeObject.tp_vectorcall`
-      * :c:member:`~PyTypeObject.tp_weaklistoffset`
-        (use :c:macro:`Py_TPFLAGS_MANAGED_WEAKREF` instead)
-      * :c:member:`~PyTypeObject.tp_dictoffset`
-        (use :c:macro:`Py_TPFLAGS_MANAGED_DICT` instead)
-      * :c:member:`~PyTypeObject.tp_vectorcall_offset`
-        (see :ref:`PyMemberDef <pymemberdef-offsets>`)
+        (use :c:member:`~PyTypeObject.tp_new` and/or
+        :c:member:`~PyTypeObject.tp_init`)
+
+      * Internal fields:
+        :c:member:`~PyTypeObject.tp_dict`,
+        :c:member:`~PyTypeObject.tp_mro`,
+        :c:member:`~PyTypeObject.tp_cache`,
+        :c:member:`~PyTypeObject.tp_subclasses`, and
+        :c:member:`~PyTypeObject.tp_weaklist`.
 
       Setting :c:data:`Py_tp_bases` or :c:data:`Py_tp_base` may be
       problematic on some platforms.
@@ -490,6 +503,15 @@ The following functions and structs are used to create
         :c:member:`~PyBufferProcs.bf_getbuffer` and
         :c:member:`~PyBufferProcs.bf_releasebuffer` are now available
         under the :ref:`limited API <limited-c-api>`.
+
+     .. versionchanged:: 3.12
+        Uses of :c:member:`~PyTypeObject.tp_weaklistoffset` and
+        :c:member:`~PyTypeObject.tp_dictoffset` should now be avoided in favor
+        of the :c:macro:`Py_TPFLAGS_MANAGED_WEAKREF` and
+        :c:macro:`Py_TPFLAGS_MANAGED_DICT` flags, if at all possible.
+        For cases where it's not possible (e.g. to support older versions
+        of Python), use the previous approach documented in
+        :ref:`PyMemberDef <pymemberdef-offsets>`.
 
    .. c:member:: void *pfunc
 


### PR DESCRIPTION
- Cover the offset fields first
- Mention the old alternative for MANAGED flags, which is needed to support older Pythons
- De-emphasize the internal flags: use an inline list.
- Add a note to PyMemberDef saying what to do with it

(Not to be backported to 3.11, which doesn't have public `Py_TPFLAGS_MANAGED_*` flags.)


<!-- gh-issue-number: gh-110803 -->
* Issue: gh-110803
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--110813.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->