### PR TITLE
Bump sphinx-lint to 0.7.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,13 +24,12 @@ repos:
         types_or: [c, inc, python, rst]
 
   - repo: https://github.com/sphinx-contrib/sphinx-lint
-    rev: v0.6.8
+    rev: v0.7.0
     hooks:
       - id: sphinx-lint
-        args: [--enable=default-role]
+        args: [--enable=default-role, -j1]
         files: ^Doc/|^Misc/NEWS.d/next/
         types: [rst]
-        require_serial: true
 
   - repo: meta
     hooks:


### PR DESCRIPTION
And use the new `-j1` flag for sphinx-lint, rather than the `require_serial` setting. This seems to be _marginally_ faster on my machine (~4s rather than ~5s).