### PR TITLE
gh-107450: Fix testMemoryErrorBigSource in test_exceptions

### DIFF
--- a/Lib/test/test_exceptions.py
+++ b/Lib/test/test_exceptions.py
@@ -319,10 +319,12 @@ class ExceptionTests(unittest.TestCase):
         check('def f(*):\n  pass', 1, 7)
 
     @support.requires_resource('cpu')
-    @support.bigmemtest(support._2G, memuse=1.5)
-    def testMemoryErrorBigSource(self, _size):
+    @support.bigmemtest(support._2G, memuse=2, dry_run=False)
+    def testMemoryErrorBigSource(self, size):
+        templ = f"if True:\n %{size}sprint('hello world')"
+        src = templ.encode() % b''  # bytes formatting is faster
         with self.assertRaises(OverflowError):
-            exec(f"if True:\n {' ' * 2**31}print('hello world')")
+            compile(src, '<fragment>', 'exec')
 
     @cpython_only
     def testSettingException(self):


### PR DESCRIPTION
1. It uses 4GB of memory, not 3GB.
2. It should be skipped if not enough memory 
3. Scope is too wide: the error may occur not only at compile time, but may also occur when the source line is generated or when the compiled code is executed.


<!-- gh-issue-number: gh-107450 -->
* Issue: gh-107450
<!-- /gh-issue-number -->
