### PR TITLE
gh-110869: handle delim chars in user/pw (urllib)

### DIFF
--- a/Lib/urllib/parse.py
+++ b/Lib/urllib/parse.py
@@ -411,9 +411,12 @@ def _splitparams(url):
     return url[:i], url[i+1:]
 
 def _splitnetloc(url, start=0):
+    at = url.find("@", start)
+    # update start if '@' is found and it is not preceded by any delimiters
+    _start = start if at < 0 or url[at - 1] in '/?#' else at + 1
     delim = len(url)   # position of end of domain part of url, default is end
     for c in '/?#':    # look for delimiters; the order is NOT important
-        wdelim = url.find(c, start)        # find first of this delim
+        wdelim = url.find(c, _start)       # find first of this delim
         if wdelim >= 0:                    # if found
             delim = min(delim, wdelim)     # use earliest delim position
     return url[start:delim], url[delim:]   # return (domain, rest)

--- a/Misc/NEWS.d/next/Library/2023-10-14-13-50-44.gh-issue-110869.Smq6YT.rst
+++ b/Misc/NEWS.d/next/Library/2023-10-14-13-50-44.gh-issue-110869.Smq6YT.rst
@@ -1,0 +1,1 @@
+Parse correctly URL with user or password containing delimiters characters


### PR DESCRIPTION
Check for path/query/fragment after "@" symbol if present, but only if it is not preceded by path ("/"), query ("?") or fragment ("#") symbols, otherwise keep the original starting point


<!-- gh-issue-number: gh-110869 -->
* Issue: gh-110869
<!-- /gh-issue-number -->
