### PR TITLE
gh-110843: strict_parsing allows empty values

### DIFF
--- a/Lib/test/test_urlparse.py
+++ b/Lib/test/test_urlparse.py
@@ -36,6 +36,7 @@ parse_qsl_test_cases = [
     ("a=a+b;b=b+c", [('a', 'a b;b=b c')]),
     (b";a=b", [(b';a', b'b')]),
     (b"a=a+b;b=b+c", [(b'a', b'a b;b=b c')]),
+    (b"a&b", [(b'a', b''), (b'b', b'')])
 ]
 
 # Each parse_qs testcase is a two-tuple that contains
@@ -66,6 +67,10 @@ parse_qs_test_cases = [
     ("a=a+b;b=b+c", {'a': ['a b;b=b c']}),
     (b";a=b", {b';a': [b'b']}),
     (b"a=a+b;b=b+c", {b'a':[ b'a b;b=b c']}),
+]
+
+parse_qsl_strict_test_cases = [
+    "&", "&&"
 ]
 
 class UrlParseTestCase(unittest.TestCase):
@@ -139,6 +144,11 @@ class UrlParseTestCase(unittest.TestCase):
             result = urllib.parse.parse_qs(orig, keep_blank_values=False)
             self.assertEqual(result, expect_without_blanks,
                             "Error parsing %r" % orig)
+
+    def test_qsl_strict_parsing(self):
+        for qs in parse_qsl_strict_test_cases:
+            with self.assertRaises(ValueError):
+                urllib.parse.parse_qsl(qs, strict_parsing=True)
 
     def test_roundtrips(self):
         str_cases = [

--- a/Lib/urllib/parse.py
+++ b/Lib/urllib/parse.py
@@ -780,12 +780,13 @@ def parse_qsl(qs, keep_blank_values=False, strict_parsing=False,
     r = []
     query_args = qs.split(separator) if qs else []
     for name_value in query_args:
-        if not name_value and not strict_parsing:
+        if not name_value:
+            if strict_parsing:
+                raise ValueError("Empty query field name")
             continue
+
         nv = name_value.split('=', 1)
         if len(nv) != 2:
-            if strict_parsing:
-                raise ValueError("bad query field: %r" % (name_value,))
             # Handle case of a control-name with no equal sign
             if keep_blank_values:
                 nv.append('')

--- a/Misc/NEWS.d/next/Library/2023-10-14-17-28-51.gh-issue-110843.FJSSKX.rst
+++ b/Misc/NEWS.d/next/Library/2023-10-14-17-28-51.gh-issue-110843.FJSSKX.rst
@@ -1,0 +1,2 @@
+urllib.parse_qsl in strict mode allows keys without values in query string:
+"a&b"


### PR DESCRIPTION
According to issue https://github.com/python/cpython/issues/110843, there is a proposal of patch that allows only keys in query string. I don't know the assumptions of the strict option (is it RFC strict?). 

There weren't any tests checking strict mode, so I've added one.  

It's my first commit to this project, so feel free to comment or discard ;)

<!-- gh-issue-number: gh-110843 -->
* Issue: gh-110843
<!-- /gh-issue-number -->
