### PR TITLE
gh-84583: Make pdb enter post-mortem mode even for SyntaxError

### DIFF
--- a/Lib/pdb.py
+++ b/Lib/pdb.py
@@ -2151,9 +2151,6 @@ def main():
     while True:
         try:
             pdb._run(target)
-            if pdb._user_requested_quit:
-                break
-            print("The program finished and will be restarted")
         except Restart:
             print("Restarting", target, "with arguments:")
             print("\t" + " ".join(sys.argv[1:]))
@@ -2161,9 +2158,6 @@ def main():
             # In most cases SystemExit does not warrant a post-mortem session.
             print("The program exited via sys.exit(). Exit status:", end=' ')
             print(e)
-        except SyntaxError:
-            traceback.print_exc()
-            sys.exit(1)
         except BaseException as e:
             traceback.print_exc()
             print("Uncaught exception. Entering post mortem debugging")
@@ -2171,6 +2165,9 @@ def main():
             pdb.interaction(None, e)
             print("Post mortem debugger finished. The " + target +
                   " will be restarted")
+        if pdb._user_requested_quit:
+            break
+        print("The program finished and will be restarted")
 
 
 # When invoked as main program, invoke the debugger on a script

--- a/Lib/test/test_pdb.py
+++ b/Lib/test/test_pdb.py
@@ -2638,12 +2638,27 @@ def bœr():
         commands = ''
         expected = "SyntaxError:"
         stdout, stderr = self.run_pdb_script(
-            script, commands, expected_returncode=1
+            script, commands
         )
         self.assertIn(expected, stdout,
             '\n\nExpected:\n{}\nGot:\n{}\n'
             'Fail to handle a syntax error in the debuggee.'
             .format(expected, stdout))
+
+    def test_issue84583(self):
+        # A syntax error from ast.literal_eval should not make pdb exit.
+        script = "import ast; ast.literal_eval('')\n"
+        commands = """
+            continue
+            where
+            quit
+        """
+        stdout, stderr = self.run_pdb_script(script, commands)
+        # The code should appear 3 times in the stdout:
+        # 1. when pdb starts
+        # 2. when the exception is raised, in trackback
+        # 3. in where command
+        self.assertEqual(stdout.count("ast.literal_eval('')"), 3)
 
     def test_issue26053(self):
         # run command of pdb prompt echoes the correct args

--- a/Misc/NEWS.d/next/Library/2023-10-14-21-33-57.gh-issue-84583.-Cmn4_.rst
+++ b/Misc/NEWS.d/next/Library/2023-10-14-21-33-57.gh-issue-84583.-Cmn4_.rst
@@ -1,0 +1,1 @@
+Make :mod:`pdb` enter post-mortem mode even for :exc:`SyntaxError`


### PR DESCRIPTION
In #60384, a special check for `SyntaxError` is introduced in `pdb`'s `main()` function to avoid infinite loop in `pdb` if the source file has a `SyntaxError`. The solution is not elegant enough as we could have a real `SyntaxError` which we want to debug at run-time. #84583 gave an example with `ast.literal_eval('')`. This could happen in other scenarios as well, when we compile dynamically generated code.

The original check for `SyntaxError` was just to prevent `pdb` from stuck, we can easily do that by moving the `pdb._user_requested_quit` outside of the try statement, so the `quit` request from post-mortem mode can be respected too.

This has one minor behavior change - when the user tries to "exit" from the post mortem debugging, for example, using Ctrl+D or `quit` command, `pdb` used to restart the program, now it will exit.

I think this is a more reasonable behavior - we told the users explicitly to use `cont` and `step` to restart the program, and `exit` should just mean "exit".

<!-- gh-issue-number: gh-84583 -->
* Issue: gh-84583
<!-- /gh-issue-number -->
