### PR TITLE
docs: specify that PyBytes_AsStringAndSize returns 0 on success

### DIFF
--- a/Doc/c-api/bytes.rst
+++ b/Doc/c-api/bytes.rst
@@ -155,6 +155,7 @@ called with a non-bytes parameter.
 
    Return the null-terminated contents of the object *obj*
    through the output variables *buffer* and *length*.
+   Returns ``0`` on success.
 
    If *length* is ``NULL``, the bytes object
    may not contain embedded null bytes;


### PR DESCRIPTION


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--110888.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->