### PR TITLE
C-API docs: Clarify the size of arenas

### DIFF
--- a/Doc/c-api/memory.rst
+++ b/Doc/c-api/memory.rst
@@ -626,7 +626,8 @@ The pymalloc allocator
 
 Python has a *pymalloc* allocator optimized for small objects (smaller or equal
 to 512 bytes) with a short lifetime. It uses memory mappings called "arenas"
-with a fixed size of 256 KiB. It falls back to :c:func:`PyMem_RawMalloc` and
+with a fixed size of either 256 KiB on 32-bit platforms or 1 MiB on 64-bit
+platforms. It falls back to :c:func:`PyMem_RawMalloc` and
 :c:func:`PyMem_RawRealloc` for allocations larger than 512 bytes.
 
 *pymalloc* is the :ref:`default allocator <default-memory-allocators>` of the


### PR DESCRIPTION
From 3.10.0 alpha 7, the pymalloc allocator uses arenas with a fixed size of 1
MiB on 64-bit platforms instead of 256 KiB on 32-bit platforms.

This is changed in https://github.com/python/cpython/pull/14474 (bpo-37448).
The following links are the relevant lines in the C code for your reference.
- https://github.com/python/cpython/pull/14474/files#diff-399a22135f328b4e42b0722ef216587945eedf2d8c103a584a3dca5b30650329R904-R906
- https://github.com/python/cpython/pull/14474/files#diff-399a22135f328b4e42b0722ef216587945eedf2d8c103a584a3dca5b30650329R927

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--110895.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->