### PR TITLE
Make clearest information about sequences negative  indexes

### DIFF
--- a/Doc/reference/datamodel.rst
+++ b/Doc/reference/datamodel.rst
@@ -299,14 +299,17 @@ Sequences
 These represent finite ordered sets indexed by non-negative numbers. The
 built-in function :func:`len` returns the number of items of a sequence. When
 the length of a sequence is *n*, the index set contains the numbers 0, 1,
-..., *n*-1.  Item *i* of sequence *a* is selected by ``a[i]``.
+..., *n*-1.  Item *i* of sequence *a* is selected by ``a[i]``. Some sequences,
+including built-in sequences, interpret negative subscripts by adding the
+sequence length. For example, ``a[-2]`` equals ``a[n-2]``, the second to last
+item of sequence a with length ``n``.
 
 .. index:: single: slicing
 
 Sequences also support slicing: ``a[i:j]`` selects all items with index *k* such
 that *i* ``<=`` *k* ``<`` *j*.  When used as an expression, a slice is a
-sequence of the same type.  This implies that the index set is renumbered so
-that it starts at 0.
+sequence of the same type. The comment above about negative indexes also applies
+to negative slice positions.
 
 Some sequences also support "extended slicing" with a third "step" parameter:
 ``a[i:j:k]`` selects all items of *a* with index *x* where ``x = i + n*k``, *n*

--- a/Doc/reference/datamodel.rst
+++ b/Doc/reference/datamodel.rst
@@ -296,7 +296,7 @@ Sequences
    single: item selection
    single: subscription
 
-These represent finite ordered sets indexed by non-negative numbers. The
+These represent finite ordered sets indexed by integer numbers. The
 built-in function :func:`len` returns the number of items of a sequence. When
 the length of a sequence is *n*, the index set contains the numbers 0, 1,
 ..., *n*-1.  Item *i* of sequence *a* is selected by ``a[i]``.

--- a/Doc/reference/datamodel.rst
+++ b/Doc/reference/datamodel.rst
@@ -296,14 +296,26 @@ Sequences
    single: item selection
    single: subscription
 
-These represent finite ordered sets indexed by non-negative numbers. The
+These represent finite ordered sets indexed by integer numbers. The
 built-in function :func:`len` returns the number of items of a sequence. When
-the length of a sequence is *n*, the index set contains the numbers 0,
-1, 2, ..., *n*-1.
+the length of a sequence is *n*, the index set contains the numbers -*n*,
+-*n*+1, -*n*+2, ..., 0, 1, ..., *n*-1.
 
-Sequences are instances of a :ref:`container class <sequence-types>`, so they
-support the :ref:`subscription <subscriptions>` and :ref:`slicing <slicings>`
-operations.
+For non-negative numbers, the item *i* of sequence *a* is selected by ``a[i]``.
+
+For negative numbers, -1 is the last item and -2 is the penultimate (next to
+last) item and so forth. Think of ``seq[-n]`` as the same as ``seq[len(seq)-n]``.
+
+.. index:: single: slicing
+
+Sequences also support slicing: ``a[i:j]`` selects all items with index *k* such
+that *i* ``<=`` *k* ``<`` *j*.  When used as an expression, a slice is a
+sequence of the same type.  This implies that the index set is renumbered so
+that it starts at 0.
+
+Some sequences also support "extended slicing" with a third "step" parameter:
+``a[i:j:k]`` selects all items of *a* with index *x* where ``x = i + n*k``, *n*
+``>=`` ``0`` and *i* ``<=`` *x* ``<`` *j*.
 
 Sequences are distinguished according to their mutability:
 

--- a/Doc/reference/datamodel.rst
+++ b/Doc/reference/datamodel.rst
@@ -296,26 +296,14 @@ Sequences
    single: item selection
    single: subscription
 
-These represent finite ordered sets indexed by integer numbers. The
+These represent finite ordered sets indexed by non-negative numbers. The
 built-in function :func:`len` returns the number of items of a sequence. When
-the length of a sequence is *n*, the index set contains the numbers -*n*,
--*n*+1, -*n*+2, ..., 0, 1, ..., *n*-1.
+the length of a sequence is *n*, the index set contains the numbers 0,
+1, 2, ..., *n*-1.
 
-For non-negative numbers, the item *i* of sequence *a* is selected by ``a[i]``.
-
-For negative numbers, -1 is the last item and -2 is the penultimate (next to
-last) item and so forth. Think of ``seq[-n]`` as the same as ``seq[len(seq)-n]``.
-
-.. index:: single: slicing
-
-Sequences also support slicing: ``a[i:j]`` selects all items with index *k* such
-that *i* ``<=`` *k* ``<`` *j*.  When used as an expression, a slice is a
-sequence of the same type.  This implies that the index set is renumbered so
-that it starts at 0.
-
-Some sequences also support "extended slicing" with a third "step" parameter:
-``a[i:j:k]`` selects all items of *a* with index *x* where ``x = i + n*k``, *n*
-``>=`` ``0`` and *i* ``<=`` *x* ``<`` *j*.
+Sequences are instances of a :ref:`container class <sequence-types>`, so they
+support the :ref:`subscription <subscriptions>` and :ref:`slicing <slicings>`
+operations.
 
 Sequences are distinguished according to their mutability:
 

--- a/Doc/reference/datamodel.rst
+++ b/Doc/reference/datamodel.rst
@@ -298,8 +298,13 @@ Sequences
 
 These represent finite ordered sets indexed by integer numbers. The
 built-in function :func:`len` returns the number of items of a sequence. When
-the length of a sequence is *n*, the index set contains the numbers 0, 1,
-..., *n*-1.  Item *i* of sequence *a* is selected by ``a[i]``.
+the length of a sequence is *n*, the index set contains the numbers -*n*,
+-*n*+1, -*n*+2, ..., 0, 1, ..., *n*-1.
+
+For non-negative numbers, the item *i* of sequence *a* is selected by ``a[i]``.
+
+For negative numbers, -1 is the last item and -2 is the penultimate (next to
+last) item and so forth. Think of ``seq[-n]`` as the same as ``seq[len(seq)-n]``.
 
 .. index:: single: slicing
 

--- a/Doc/reference/datamodel.rst
+++ b/Doc/reference/datamodel.rst
@@ -296,7 +296,7 @@ Sequences
    single: item selection
    single: subscription
 
-These represent finite ordered sets indexed by integer numbers. The
+These represent finite ordered sets indexed by non-negative numbers. The
 built-in function :func:`len` returns the number of items of a sequence. When
 the length of a sequence is *n*, the index set contains the numbers 0, 1,
 ..., *n*-1.  Item *i* of sequence *a* is selected by ``a[i]``.

--- a/Doc/reference/datamodel.rst
+++ b/Doc/reference/datamodel.rst
@@ -298,13 +298,8 @@ Sequences
 
 These represent finite ordered sets indexed by integer numbers. The
 built-in function :func:`len` returns the number of items of a sequence. When
-the length of a sequence is *n*, the index set contains the numbers -*n*,
--*n*+1, -*n*+2, ..., 0, 1, ..., *n*-1.
-
-For non-negative numbers, the item *i* of sequence *a* is selected by ``a[i]``.
-
-For negative numbers, -1 is the last item and -2 is the penultimate (next to
-last) item and so forth. Think of ``seq[-n]`` as the same as ``seq[len(seq)-n]``.
+the length of a sequence is *n*, the index set contains the numbers 0, 1,
+..., *n*-1.  Item *i* of sequence *a* is selected by ``a[i]``.
 
 .. index:: single: slicing
 


### PR DESCRIPTION
The documentation says:
```These represent finite ordered sets indexed by non-negative numbers```
but indexes can be negative too. This PR fixed it and added some information about indexes.

The text used was inspired by a FAQ:
https://docs.python.org/pt-br/3/faq/programming.html#what-s-a-negative-index

Co-authored-by: Terry Jan Reedy <tjreedy@udel.edu>

<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--110903.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->