### PR TITLE
gh-111085 Fix logic order causing nicer error to never be raised in asyncio.Timeout

### DIFF
--- a/Lib/asyncio/timeouts.py
+++ b/Lib/asyncio/timeouts.py
@@ -84,9 +84,9 @@ class Timeout:
     async def __aenter__(self) -> "Timeout":
         self._state = _State.ENTERED
         self._task = tasks.current_task()
-        self._cancelling = self._task.cancelling()
         if self._task is None:
             raise RuntimeError("Timeout should be used inside a task")
+        self._cancelling = self._task.cancelling()
         self.reschedule(self._when)
         return self
 

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -760,6 +760,7 @@ Aaron Hill
 Joel Hillacre
 Richie Hindle
 Konrad Hinsen
+James Hilton-Balfe
 Richard Hoberecht
 David Hobley
 Tim Hochberg

--- a/Misc/NEWS.d/next/Library/2023-10-19-11-40-38.gh-issue-0.hBPpQr.rst
+++ b/Misc/NEWS.d/next/Library/2023-10-19-11-40-38.gh-issue-0.hBPpQr.rst
@@ -1,0 +1,1 @@
+Fix asyncio.Timeout raising an AttributeError over a RuntimeError due to logic bug. Patch by James Hilton-Balfe

--- a/Misc/NEWS.d/next/Library/2023-10-19-11-40-38.gh-issue-0.hBPpQr.rst
+++ b/Misc/NEWS.d/next/Library/2023-10-19-11-40-38.gh-issue-0.hBPpQr.rst
@@ -1,1 +1,0 @@
-Fix asyncio.Timeout raising an AttributeError over a RuntimeError due to logic bug. Patch by James Hilton-Balfe

--- a/Misc/NEWS.d/next/Library/2023-10-19-11-40-38.gh-issue-111085.hBPpQr.rst
+++ b/Misc/NEWS.d/next/Library/2023-10-19-11-40-38.gh-issue-111085.hBPpQr.rst
@@ -1,0 +1,1 @@
+Fix :class:`asyncio.Timeout` raising an :exc:`AttributeError` over a :exc:`RuntimeError` due to logic bug. Patch by James Hilton-Balfe


### PR DESCRIPTION
~~I don't think this needs a news entry or an issue~~

<!-- gh-issue-number: gh-111085 -->
* Issue: gh-111085
<!-- /gh-issue-number -->
