### PR TITLE
sysconfig docs: fix broken link to the source code

### DIFF
--- a/Doc/library/sysconfig.rst
+++ b/Doc/library/sysconfig.rst
@@ -9,7 +9,7 @@
 
 .. versionadded:: 3.2
 
-**Source code:** :source:`Lib/sysconfig.py`
+**Source code:** :source:`Lib/sysconfig`
 
 .. index::
    single: configuration information


### PR DESCRIPTION
It's now a package. See: https://github.com/python/cpython/commit/4a53a397c311567f05553bc25a28aebaba4f6f65

Clicking on the current reference leads to the error 404: https://docs.python.org/dev/library/sysconfig.html#module-sysconfig




<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--110920.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->