### PR TITLE
gh-110912: Correctly display tracebacks for MemoryError exceptions using the traceback module

### DIFF
--- a/Lib/test/test_traceback.py
+++ b/Lib/test/test_traceback.py
@@ -2815,6 +2815,7 @@ class TestTracebackException(unittest.TestCase):
              'ZeroDivisionError: division by zero',
              ''])
 
+
 class TestTracebackException_ExceptionGroups(unittest.TestCase):
     def setUp(self):
         super().setUp()

--- a/Lib/test/test_traceback.py
+++ b/Lib/test/test_traceback.py
@@ -933,11 +933,12 @@ class TracebackErrorLocationCaretTestBase:
 
         actual = self.get_exception(f)
         expected = ['Traceback (most recent call last):',
-            f'  File \"{__file__}\", line {self.callable_line}, in get_exception',
+            f'  File "{__file__}", line {self.callable_line}, in get_exception',
             '    callable()',
-            f'  File \"{__file__}\", line {f.__code__.co_firstlineno + 1}, in f',
+            f'  File "{__file__}", line {f.__code__.co_firstlineno + 1}, in f',
             '    raise MemoryError()']
         self.assertEqual(actual, expected)
+
 
 @requires_debug_ranges()
 class PurePythonTracebackErrorCaretTests(

--- a/Lib/test/test_traceback.py
+++ b/Lib/test/test_traceback.py
@@ -2813,7 +2813,6 @@ class TestTracebackException(unittest.TestCase):
              '    x = 12',
              'ZeroDivisionError: division by zero',
              ''])
-    
 
 class TestTracebackException_ExceptionGroups(unittest.TestCase):
     def setUp(self):

--- a/Lib/test/test_traceback.py
+++ b/Lib/test/test_traceback.py
@@ -926,8 +926,18 @@ class TracebackErrorLocationCaretTestBase:
             "             ^^^^",
         ]
         self.assertEqual(actual, expected)
-
-
+    
+    def test_memory_error(self):
+        def f():
+            raise MemoryError()
+        
+        actual = self.get_exception(f)
+        expected = ['Traceback (most recent call last):',
+            f'  File \"{__file__}\", line {self.callable_line}, in get_exception',
+            '    callable()',
+            f'  File \"{__file__}\", line {f.__code__.co_firstlineno + 1}, in f',
+            '    raise MemoryError()']
+        self.assertEqual(actual, expected)
 
 @requires_debug_ranges()
 class PurePythonTracebackErrorCaretTests(
@@ -2803,7 +2813,7 @@ class TestTracebackException(unittest.TestCase):
              '    x = 12',
              'ZeroDivisionError: division by zero',
              ''])
-
+    
 
 class TestTracebackException_ExceptionGroups(unittest.TestCase):
     def setUp(self):

--- a/Lib/test/test_traceback.py
+++ b/Lib/test/test_traceback.py
@@ -926,11 +926,11 @@ class TracebackErrorLocationCaretTestBase:
             "             ^^^^",
         ]
         self.assertEqual(actual, expected)
-    
+
     def test_memory_error(self):
         def f():
             raise MemoryError()
-        
+
         actual = self.get_exception(f)
         expected = ['Traceback (most recent call last):',
             f'  File \"{__file__}\", line {self.callable_line}, in get_exception',

--- a/Misc/NEWS.d/next/Core and Builtins/2023-10-16-12-12-48.gh-issue-110912.uEJGi_.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2023-10-16-12-12-48.gh-issue-110912.uEJGi_.rst
@@ -1,0 +1,2 @@
+Correctly display the traceback for :exc:`MemoryError` exceptions using the
+:mod:`traceeback` module. Patch by Pablo Galindo

--- a/Misc/NEWS.d/next/Core and Builtins/2023-10-16-12-12-48.gh-issue-110912.uEJGi_.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2023-10-16-12-12-48.gh-issue-110912.uEJGi_.rst
@@ -1,2 +1,2 @@
 Correctly display the traceback for :exc:`MemoryError` exceptions using the
-:mod:`traceeback` module. Patch by Pablo Galindo
+:mod:`traceback` module. Patch by Pablo Galindo

--- a/Python/pythonrun.c
+++ b/Python/pythonrun.c
@@ -1047,7 +1047,7 @@ _PyErr_Display(PyObject *file, PyObject *unused, PyObject *value, PyObject *tb)
 
     int unhandled_keyboard_interrupt = _PyRuntime.signals.unhandled_keyboard_interrupt;
 
-    if (!value || PyErr_GivenExceptionMatches(value, PyExc_MemoryError)) {
+    if (!value) {
         goto fallback;
     }
 

--- a/Python/pythonrun.c
+++ b/Python/pythonrun.c
@@ -1031,6 +1031,7 @@ error:
 void
 _PyErr_Display(PyObject *file, PyObject *unused, PyObject *value, PyObject *tb)
 {
+    assert(value != NULL);
     assert(file != NULL && file != Py_None);
     if (PyExceptionInstance_Check(value)
         && tb != NULL && PyTraceBack_Check(tb)) {
@@ -1046,10 +1047,6 @@ _PyErr_Display(PyObject *file, PyObject *unused, PyObject *value, PyObject *tb)
     }
 
     int unhandled_keyboard_interrupt = _PyRuntime.signals.unhandled_keyboard_interrupt;
-
-    if (!value) {
-        goto fallback;
-    }
 
     // Try first with the stdlib traceback module
     PyObject *traceback_module = PyImport_ImportModule("traceback");


### PR DESCRIPTION
Closes: #110912


<!-- gh-issue-number: gh-110912 -->
* Issue: gh-110912
<!-- /gh-issue-number -->
