### PR TITLE
gh-110864: Partially revert 110784, `constraints` cannot be `NULL`

### DIFF
--- a/Objects/typevarobject.c
+++ b/Objects/typevarobject.c
@@ -364,26 +364,24 @@ typevar_new_impl(PyTypeObject *type, PyObject *name, PyObject *constraints,
         }
     }
 
-    if (constraints != NULL) {
-        if (!PyTuple_CheckExact(constraints)) {
-            PyErr_SetString(PyExc_TypeError,
-                            "constraints must be a tuple");
-            return NULL;
-        }
-        Py_ssize_t n_constraints = PyTuple_GET_SIZE(constraints);
-        if (n_constraints == 1) {
-            PyErr_SetString(PyExc_TypeError,
-                            "A single constraint is not allowed");
-            Py_XDECREF(bound);
-            return NULL;
-        } else if (n_constraints == 0) {
-            constraints = NULL;
-        } else if (bound != NULL) {
-            PyErr_SetString(PyExc_TypeError,
-                            "Constraints cannot be combined with bound=...");
-            Py_XDECREF(bound);
-            return NULL;
-        }
+    if (!PyTuple_CheckExact(constraints)) {
+        PyErr_SetString(PyExc_TypeError,
+                        "Constraints must be a tuple");
+        return NULL;
+    }
+    Py_ssize_t n_constraints = PyTuple_GET_SIZE(constraints);
+    if (n_constraints == 1) {
+        PyErr_SetString(PyExc_TypeError,
+                        "A single constraint is not allowed");
+        Py_XDECREF(bound);
+        return NULL;
+    } else if (n_constraints == 0) {
+        constraints = NULL;
+    } else if (bound != NULL) {
+        PyErr_SetString(PyExc_TypeError,
+                        "Constraints cannot be combined with bound=...");
+        Py_XDECREF(bound);
+        return NULL;
     }
     PyObject *module = caller();
     if (module == NULL) {

--- a/Objects/typevarobject.c
+++ b/Objects/typevarobject.c
@@ -364,11 +364,7 @@ typevar_new_impl(PyTypeObject *type, PyObject *name, PyObject *constraints,
         }
     }
 
-    if (!PyTuple_CheckExact(constraints)) {
-        PyErr_SetString(PyExc_TypeError,
-                        "Constraints must be a tuple");
-        return NULL;
-    }
+    assert(PyTuple_CheckExact(constraints));
     Py_ssize_t n_constraints = PyTuple_GET_SIZE(constraints);
     if (n_constraints == 1) {
         PyErr_SetString(PyExc_TypeError,


### PR DESCRIPTION
I've also changed the exception message to be uppercase, like all others are.
Refs https://github.com/python/cpython/pull/110784
Refs https://github.com/python/cpython/pull/110868

<!-- gh-issue-number: gh-110864 -->
* Issue: gh-110864
<!-- /gh-issue-number -->
