### PR TITLE
gh-110923: Don't silently skip tests in `test__opcode.py`

### DIFF
--- a/Lib/test/.ruff.toml
+++ b/Lib/test/.ruff.toml
@@ -11,7 +11,6 @@ extend-exclude = [
     "encoded_modules/module_iso_8859_1.py",
     "encoded_modules/module_koi8_r.py",
     # TODO Fix: F811 Redefinition of unused name
-    "test__opcode.py",
     "test_buffer.py",
     "test_ctypes/test_arrays.py",
     "test_ctypes/test_functions.py",

--- a/Lib/test/test__opcode.py
+++ b/Lib/test/test__opcode.py
@@ -8,6 +8,14 @@ from _opcode import stack_effect
 
 
 class OpListTests(unittest.TestCase):
+    def check_bool_function_result(self, func, ops, expected):
+        for op in ops:
+            if isinstance(op, str):
+                op = dis.opmap[op]
+            with self.subTest(opcode=op, func=func):
+                self.assertIsInstance(func(op), bool)
+                self.assertEqual(func(op), expected)
+
     def test_invalid_opcodes(self):
         invalid = [-100, -1, 255, 512, 513, 1000]
         self.check_bool_function_result(_opcode.is_valid, invalid, False)
@@ -47,7 +55,7 @@ class OpListTests(unittest.TestCase):
         check_function(self, _opcode.has_exc, dis.hasexc)
 
 
-class OpListTests(unittest.TestCase):
+class StackEffectTests(unittest.TestCase):
     def test_stack_effect(self):
         self.assertEqual(stack_effect(dis.opmap['POP_TOP']), -1)
         self.assertEqual(stack_effect(dis.opmap['BUILD_SLICE'], 0), -1)


### PR DESCRIPTION
- Rename the second `unittest.TestCase` subclass so that it doesn't silently override the tests in the first test class
- Add back a helper method deleted in https://github.com/python/cpython/commit/40f3f11a773b854c6d94746aa3b1881c8ac71b0f so that the tests in the `OpListTests` class pass
- Enable ruff on `Lib/test/test__opcode.py`, to prevent this regressing again in the future.

Fixes #110923

<!-- gh-issue-number: gh-110923 -->
* Issue: gh-110923
<!-- /gh-issue-number -->
