### PR TITLE
gh-110695: test_asyncio uses 50 ms for clock resolution

### DIFF
--- a/Lib/test/test_asyncio/utils.py
+++ b/Lib/test/test_asyncio/utils.py
@@ -37,9 +37,9 @@ from test.support import threading_helper
 
 
 # Use the maximum known clock resolution (gh-75191, gh-110088): Windows
-# GetTickCount64() has a resolution of 15.6 ms.  Use 20 ms to tolerate rounding
+# GetTickCount64() has a resolution of 15.6 ms. Use 50 ms to tolerate rounding
 # issues.
-CLOCK_RES = 0.020
+CLOCK_RES = 0.050
 
 
 def data_file(*filename):


### PR DESCRIPTION
Before utils.CLOCK_RES constant was added (20 ms), test_asyncio already used 50 ms.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-110695 -->
* Issue: gh-110695
<!-- /gh-issue-number -->
