### PR TITLE
gh-85283: Build errno and _ctypes_test with limited C API

### DIFF
--- a/Doc/whatsnew/3.13.rst
+++ b/Doc/whatsnew/3.13.rst
@@ -932,8 +932,8 @@ Build Changes
 * Building CPython now requires a compiler with support for the C11 atomic
   library, GCC built-in atomic functions, or MSVC interlocked intrinsics.
 
-* The ``_stat`` and ``_testimportmultiple`` C extensions are now built with the
-  :ref:`limited C API <limited-c-api>`.
+* The ``errno``, ``_ctypes_test``, ``_stat`` and ``_testimportmultiple`` C
+  extensions are now built with the :ref:`limited C API <limited-c-api>`.
   (Contributed by Victor Stinner in :gh:`85283`.)
 
 

--- a/Misc/NEWS.d/next/Build/2023-10-17-01-56-11.gh-issue-85283.V156T2.rst
+++ b/Misc/NEWS.d/next/Build/2023-10-17-01-56-11.gh-issue-85283.V156T2.rst
@@ -1,2 +1,3 @@
-The ``_testimportmultiple`` C extension is now built with the :ref:`limited
-C API <limited-c-api>`. Patch by Victor Stinner.
+The ``errno``, ``_ctypes_test`` and ``_testimportmultiple`` C extensions are
+now built with the :ref:`limited C API <limited-c-api>`. Patch by Victor
+Stinner.

--- a/Modules/_ctypes/_ctypes_test.c
+++ b/Modules/_ctypes/_ctypes_test.c
@@ -1,10 +1,11 @@
+#define Py_LIMITED_API 0x03060000
+
 #include <Python.h>
 
-#ifdef MS_WIN32
-#include <windows.h>
-#endif
-
 #include <stdlib.h>               // qsort()
+#ifdef MS_WIN32
+#  include <windows.h>
+#endif
 
 #define EXPORT(x) Py_EXPORTED_SYMBOL x
 

--- a/Modules/_testimportmultiple.c
+++ b/Modules/_testimportmultiple.c
@@ -4,7 +4,7 @@
  * foo, bar), only the first one is called the same as the compiled file.
  */
 
-#define Py_LIMITED_API 0x030d0000
+#define Py_LIMITED_API 0x03020000
 
 #include <Python.h>
 

--- a/Modules/errnomodule.c
+++ b/Modules/errnomodule.c
@@ -1,41 +1,44 @@
-
 /* Errno module */
+
+// Need PyModuleDef_Slot added to limited C API version 3.5
+#define Py_LIMITED_API 0x03050000
 
 #include "Python.h"
 
 /* Windows socket errors (WSA*)  */
 #ifdef MS_WINDOWS
-#ifndef WIN32_LEAN_AND_MEAN
-#define WIN32_LEAN_AND_MEAN
-#endif
-#include <windows.h>
-/* The following constants were added to errno.h in VS2010 but have
-   preferred WSA equivalents. */
-#undef EADDRINUSE
-#undef EADDRNOTAVAIL
-#undef EAFNOSUPPORT
-#undef EALREADY
-#undef ECONNABORTED
-#undef ECONNREFUSED
-#undef ECONNRESET
-#undef EDESTADDRREQ
-#undef EHOSTUNREACH
-#undef EINPROGRESS
-#undef EISCONN
-#undef ELOOP
-#undef EMSGSIZE
-#undef ENETDOWN
-#undef ENETRESET
-#undef ENETUNREACH
-#undef ENOBUFS
-#undef ENOPROTOOPT
-#undef ENOTCONN
-#undef ENOTSOCK
-#undef EOPNOTSUPP
-#undef EPROTONOSUPPORT
-#undef EPROTOTYPE
-#undef ETIMEDOUT
-#undef EWOULDBLOCK
+#  ifndef WIN32_LEAN_AND_MEAN
+#    define WIN32_LEAN_AND_MEAN
+#  endif
+#  include <windows.h>
+
+   // The following constants were added to errno.h in VS2010 but have
+   // preferred WSA equivalents.
+#  undef EADDRINUSE
+#  undef EADDRNOTAVAIL
+#  undef EAFNOSUPPORT
+#  undef EALREADY
+#  undef ECONNABORTED
+#  undef ECONNREFUSED
+#  undef ECONNRESET
+#  undef EDESTADDRREQ
+#  undef EHOSTUNREACH
+#  undef EINPROGRESS
+#  undef EISCONN
+#  undef ELOOP
+#  undef EMSGSIZE
+#  undef ENETDOWN
+#  undef ENETRESET
+#  undef ENETUNREACH
+#  undef ENOBUFS
+#  undef ENOPROTOOPT
+#  undef ENOTCONN
+#  undef ENOTSOCK
+#  undef EOPNOTSUPP
+#  undef EPROTONOSUPPORT
+#  undef EPROTOTYPE
+#  undef ETIMEDOUT
+#  undef EWOULDBLOCK
 #endif
 
 /*


### PR DESCRIPTION
_testimportmultiple is now built with limited C API version 3.2.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-85283 -->
* Issue: gh-85283
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--110955.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->