### PR TITLE
gh-110828: AIX 32bit build needs -latomic for _testcapi module

### DIFF
--- a/Misc/NEWS.d/next/Build/2023-10-17-03-10-40.gh-issue-110828.31vQ9B.rst
+++ b/Misc/NEWS.d/next/Build/2023-10-17-03-10-40.gh-issue-110828.31vQ9B.rst
@@ -1,1 +1,1 @@
-AIX 32bit build needs -latomic for _testcapi module build
+AIX 32bit needs ``-latomic`` to build the :mod:`!_testcapi` extension module.

--- a/Misc/NEWS.d/next/Build/2023-10-17-03-10-40.gh-issue-110828.31vQ9B.rst
+++ b/Misc/NEWS.d/next/Build/2023-10-17-03-10-40.gh-issue-110828.31vQ9B.rst
@@ -1,0 +1,1 @@
+AIX 32bit build needs -latomic for _testcapi module build

--- a/configure
+++ b/configure
@@ -27926,6 +27926,7 @@ printf "%s\n" "$ac_cv_libatomic_needed" >&6; }
 if test "x$ac_cv_libatomic_needed" = xyes
 then :
   LIBS="${LIBS} -latomic"
+  LIBATOMIC=${LIBATOMIC-"-latomic"}
 fi
 CPPFLAGS=$save_CPPFLAGS
 
@@ -30080,6 +30081,7 @@ then :
 
 
 
+as_fn_append MODULE_BLOCK "MODULE__TESTCAPI_LDFLAGS=$LIBATOMIC$as_nl"
 
 fi
    if test "$py_cv_module__testcapi" = yes; then

--- a/configure
+++ b/configure
@@ -27926,7 +27926,7 @@ printf "%s\n" "$ac_cv_libatomic_needed" >&6; }
 if test "x$ac_cv_libatomic_needed" = xyes
 then :
   LIBS="${LIBS} -latomic"
-  LIBATOMIC=${LIBATOMIC-"-latomic"}
+           LIBATOMIC=${LIBATOMIC-"-latomic"}
 fi
 CPPFLAGS=$save_CPPFLAGS
 
@@ -30080,8 +30080,7 @@ fi
 then :
 
 
-
-as_fn_append MODULE_BLOCK "MODULE__TESTCAPI_LDFLAGS=$LIBATOMIC$as_nl"
+    as_fn_append MODULE_BLOCK "MODULE__TESTCAPI_LDFLAGS=$LIBATOMIC$as_nl"
 
 fi
    if test "$py_cv_module__testcapi" = yes; then

--- a/configure.ac
+++ b/configure.ac
@@ -7051,7 +7051,8 @@ int main()
 ])
 
 AS_VAR_IF([ac_cv_libatomic_needed], [yes],
-          [LIBS="${LIBS} -latomic"])
+          [LIBS="${LIBS} -latomic"
+           LIBATOMIC=${LIBATOMIC-"-latomic"}])
 _RESTORE_VAR([CPPFLAGS])
 
 
@@ -7323,7 +7324,10 @@ PY_STDLIB_MOD([_hashlib], [], [test "$ac_cv_working_openssl_hashlib" = yes],
   [$OPENSSL_INCLUDES], [$OPENSSL_LDFLAGS $OPENSSL_LDFLAGS_RPATH $LIBCRYPTO_LIBS])
 
 dnl test modules
-PY_STDLIB_MOD([_testcapi], [test "$TEST_MODULES" = yes])
+PY_STDLIB_MOD([_testcapi],
+    [test "$TEST_MODULES" = yes],  []
+    dnl Modules/_testcapi needs -latomic for 32bit AIX build
+    [], [], [$LIBATOMIC])
 PY_STDLIB_MOD([_testclinic], [test "$TEST_MODULES" = yes])
 PY_STDLIB_MOD([_testclinic_limited], [test "$TEST_MODULES" = yes])
 PY_STDLIB_MOD([_testinternalcapi], [test "$TEST_MODULES" = yes])

--- a/configure.ac
+++ b/configure.ac
@@ -7325,7 +7325,7 @@ PY_STDLIB_MOD([_hashlib], [], [test "$ac_cv_working_openssl_hashlib" = yes],
 
 dnl test modules
 PY_STDLIB_MOD([_testcapi],
-    [test "$TEST_MODULES" = yes],  []
+    [test "$TEST_MODULES" = yes],
     dnl Modules/_testcapi needs -latomic for 32bit AIX build
     [], [], [$LIBATOMIC])
 PY_STDLIB_MOD([_testclinic], [test "$TEST_MODULES" = yes])


### PR DESCRIPTION
This PR is to fix the problem mentioned in the issue #110828 


<!-- gh-issue-number: gh-110828 -->
* Issue: gh-110828
<!-- /gh-issue-number -->
