### PR TITLE
Add a version added note for PY_VECTORCALL_ARGUMENTS_OFFSET

### DIFF
--- a/Doc/c-api/call.rst
+++ b/Doc/c-api/call.rst
@@ -108,6 +108,8 @@ This is a pointer to a function with the following signature:
    Doing so will allow callables such as bound methods to make their onward
    calls (which include a prepended *self* argument) very efficiently.
 
+   .. versionadded:: 3.8
+
 To call an object that implements vectorcall, use a :ref:`call API <capi-call>`
 function as with any other callable.
 :c:func:`PyObject_Vectorcall` will usually be most efficient.


### PR DESCRIPTION
Trivial change.

METH_FASTCALL was added in 3.7, vector call came in 3.8. 

The macro `PY_VECTORCALL_ARGUMENTS_OFFSET` doesn't have the version added (it was 3.8)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--110963.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->