### PR TITLE
gh-110968: Py_MOD_PER_INTERPRETER_GIL_SUPPORTED new in 3.13.

### DIFF
--- a/Include/moduleobject.h
+++ b/Include/moduleobject.h
@@ -79,12 +79,14 @@ struct PyModuleDef_Slot {
 #define _Py_mod_LAST_SLOT 3
 #endif
 
+#endif /* New in 3.5 */
+
 /* for Py_mod_multiple_interpreters: */
+#if !defined(Py_LIMITED_API) || Py_LIMITED_API+0 >= 0x030d0000
 #define Py_MOD_MULTIPLE_INTERPRETERS_NOT_SUPPORTED ((void *)0)
 #define Py_MOD_MULTIPLE_INTERPRETERS_SUPPORTED ((void *)1)
 #define Py_MOD_PER_INTERPRETER_GIL_SUPPORTED ((void *)2)
-
-#endif /* New in 3.5 */
+#endif
 
 struct PyModuleDef {
   PyModuleDef_Base m_base;

--- a/Modules/_ctypes/_ctypes_test.c
+++ b/Modules/_ctypes/_ctypes_test.c
@@ -1,8 +1,11 @@
-#define Py_LIMITED_API 0x03060000
+// Need limited C API version 3.13 for Py_MOD_PER_INTERPRETER_GIL_SUPPORTED
+#define Py_LIMITED_API 0x030d0000
 
 #include <Python.h>
 
+#include <stdio.h>                // printf()
 #include <stdlib.h>               // qsort()
+#include <string.h>               // memset()
 #ifdef MS_WIN32
 #  include <windows.h>
 #endif

--- a/Modules/errnomodule.c
+++ b/Modules/errnomodule.c
@@ -1,9 +1,10 @@
 /* Errno module */
 
-// Need PyModuleDef_Slot added to limited C API version 3.5
-#define Py_LIMITED_API 0x03050000
+// Need limited C API version 3.13 for Py_MOD_PER_INTERPRETER_GIL_SUPPORTED
+#define Py_LIMITED_API 0x030d0000
 
 #include "Python.h"
+#include <errno.h>                // EPIPE
 
 /* Windows socket errors (WSA*)  */
 #ifdef MS_WINDOWS

--- a/Modules/xxlimited.c
+++ b/Modules/xxlimited.c
@@ -62,7 +62,7 @@
           pass
    */
 
-#define Py_LIMITED_API 0x030b0000
+#define Py_LIMITED_API 0x030d0000
 
 #include "Python.h"
 #include <string.h>

--- a/Modules/xxlimited.c
+++ b/Modules/xxlimited.c
@@ -62,6 +62,7 @@
           pass
    */
 
+// Need limited C API version 3.13 for Py_MOD_PER_INTERPRETER_GIL_SUPPORTED
 #define Py_LIMITED_API 0x030d0000
 
 #include "Python.h"

--- a/Modules/xxlimited_35.c
+++ b/Modules/xxlimited_35.c
@@ -293,7 +293,6 @@ xx_modexec(PyObject *m)
 
 static PyModuleDef_Slot xx_slots[] = {
     {Py_mod_exec, xx_modexec},
-    {Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
     {0, NULL}
 };
 


### PR DESCRIPTION
* Only add Py_MOD_PER_INTERPRETER_GIL_SUPPORTED to limited C API version 3.13.
* errno, xxlimited and _ctypes_test extensions now need the limited C API version 3.13 to get Py_MOD_PER_INTERPRETER_GIL_SUPPORTED.  They
  now include standard header files explicitly: <errno.h>, <string.h>
  and <stdio.h>.
* xxlimited_35: Remove Py_mod_multiple_interpreters slot, incompatible with limited C API version 3.5.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-110968 -->
* Issue: gh-110968
<!-- /gh-issue-number -->
