### PR TITLE
gh-101100: Fix sphinx warnings in `library/codecs.rst`

### DIFF
--- a/Doc/library/codecs.rst
+++ b/Doc/library/codecs.rst
@@ -520,44 +520,46 @@ The base :class:`Codec` class defines these methods which also define the
 function interfaces of the stateless encoder and decoder:
 
 
-.. method:: Codec.encode(input, errors='strict')
+.. class:: Codec
 
-   Encodes the object *input* and returns a tuple (output object, length consumed).
-   For instance, :term:`text encoding` converts
-   a string object to a bytes object using a particular
-   character set encoding (e.g., ``cp1252`` or ``iso-8859-1``).
+   .. method:: encode(input, errors='strict')
 
-   The *errors* argument defines the error handling to apply.
-   It defaults to ``'strict'`` handling.
+      Encodes the object *input* and returns a tuple (output object, length consumed).
+      For instance, :term:`text encoding` converts
+      a string object to a bytes object using a particular
+      character set encoding (e.g., ``cp1252`` or ``iso-8859-1``).
 
-   The method may not store state in the :class:`Codec` instance. Use
-   :class:`StreamWriter` for codecs which have to keep state in order to make
-   encoding efficient.
+      The *errors* argument defines the error handling to apply.
+      It defaults to ``'strict'`` handling.
 
-   The encoder must be able to handle zero length input and return an empty object
-   of the output object type in this situation.
+      The method may not store state in the :class:`Codec` instance. Use
+      :class:`StreamWriter` for codecs which have to keep state in order to make
+      encoding efficient.
+
+      The encoder must be able to handle zero length input and return an empty object
+      of the output object type in this situation.
 
 
-.. method:: Codec.decode(input, errors='strict')
+   .. method:: decode(input, errors='strict')
 
-   Decodes the object *input* and returns a tuple (output object, length
-   consumed). For instance, for a :term:`text encoding`, decoding converts
-   a bytes object encoded using a particular
-   character set encoding to a string object.
+      Decodes the object *input* and returns a tuple (output object, length
+      consumed). For instance, for a :term:`text encoding`, decoding converts
+      a bytes object encoded using a particular
+      character set encoding to a string object.
 
-   For text encodings and bytes-to-bytes codecs,
-   *input* must be a bytes object or one which provides the read-only
-   buffer interface -- for example, buffer objects and memory mapped files.
+      For text encodings and bytes-to-bytes codecs,
+      *input* must be a bytes object or one which provides the read-only
+      buffer interface -- for example, buffer objects and memory mapped files.
 
-   The *errors* argument defines the error handling to apply.
-   It defaults to ``'strict'`` handling.
+      The *errors* argument defines the error handling to apply.
+      It defaults to ``'strict'`` handling.
 
-   The method may not store state in the :class:`Codec` instance. Use
-   :class:`StreamReader` for codecs which have to keep state in order to make
-   decoding efficient.
+      The method may not store state in the :class:`Codec` instance. Use
+      :class:`StreamReader` for codecs which have to keep state in order to make
+      decoding efficient.
 
-   The decoder must be able to handle zero length input and return an empty object
-   of the output object type in this situation.
+      The decoder must be able to handle zero length input and return an empty object
+      of the output object type in this situation.
 
 
 Incremental Encoding and Decoding
@@ -705,7 +707,7 @@ Stream Encoding and Decoding
 
 The :class:`StreamWriter` and :class:`StreamReader` classes provide generic
 working interfaces which can be used to implement new encoding submodules very
-easily. See :mod:`encodings.utf_8` for an example of how this is done.
+easily. See :mod:`!encodings.utf_8` for an example of how this is done.
 
 
 .. _stream-writer-objects:
@@ -895,9 +897,10 @@ The design is such that one can use the factory functions returned by the
 .. class:: StreamRecoder(stream, encode, decode, Reader, Writer, errors='strict')
 
    Creates a :class:`StreamRecoder` instance which implements a two-way conversion:
-   *encode* and *decode* work on the frontend — the data visible to
-   code calling :meth:`read` and :meth:`write`, while *Reader* and *Writer*
-   work on the backend — the data in *stream*.
+   *encode* and *decode* work on the frontend — the data visible to
+   code calling :meth:`~StreamReader.read` and :meth:`~StreamWriter.write`,
+   while *Reader* and *Writer*
+   work on the backend — the data in *stream*.
 
    You can use these objects to do transparent transcodings, e.g., from Latin-1
    to UTF-8 and back.
@@ -1417,8 +1420,8 @@ to :class:`bytes` mappings. They are not supported by :meth:`bytes.decode`
 |                      | quotedprintable, | quoted printable.            | ``quotetabs=True`` /         |
 |                      | quoted_printable |                              | :meth:`quopri.decode`        |
 +----------------------+------------------+------------------------------+------------------------------+
-| uu_codec             | uu               | Convert the operand using    | :meth:`uu.encode` /          |
-|                      |                  | uuencode.                    | :meth:`uu.decode`            |
+| uu_codec             | uu               | Convert the operand using    |                              |
+|                      |                  | uuencode.                    |                              |
 +----------------------+------------------+------------------------------+------------------------------+
 | zlib_codec           | zip, zlib        | Compress the operand using   | :meth:`zlib.compress` /      |
 |                      |                  | gzip.                        | :meth:`zlib.decompress`      |

--- a/Doc/tools/.nitignore
+++ b/Doc/tools/.nitignore
@@ -42,7 +42,6 @@ Doc/library/bisect.rst
 Doc/library/bz2.rst
 Doc/library/calendar.rst
 Doc/library/cmd.rst
-Doc/library/codecs.rst
 Doc/library/collections.abc.rst
 Doc/library/collections.rst
 Doc/library/concurrent.futures.rst


### PR DESCRIPTION
Notes:
- `uu` module was removed in 3.13, so I dropped `uu.encode` and `uu.decode` parts, since they no longer exist
- There's a PR by @CAM-Gerlach with the deprecation notices to `codecs.uu_codec` https://github.com/python/cpython/pull/92758/
- I am not sure that `uu.encode` and `uu.decode` part should be backported. In the backport we can use `!` instead

<!-- gh-issue-number: gh-101100 -->
* Issue: gh-101100
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--110979.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->