### PR TITLE
[3.11] Bump test deps: `ruff` and `pre-commit-hooks` (GH-110972)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.0.292
+    rev: v0.1.0
     hooks:
       - id: ruff
         name: Run Ruff on Lib/test/
@@ -8,7 +8,7 @@ repos:
         files: ^Lib/test/
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v4.5.0
     hooks:
       - id: check-toml
         exclude: ^Lib/test/test_tomllib/


### PR DESCRIPTION
(cherry picked from commit b75b1f389f083db8568bff573c33ab4ecf29655a)

3.11 does not have mypy at all.