### PR TITLE
Add `.ruff_cache/` to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@ gmon.out
 .coverage
 .mypy_cache/
 .pytest_cache/
+.ruff_cache/
 .DS_Store
 
 *.exe


### PR DESCRIPTION
`ruff` uses this folder for some cache-related stuff, we ignore similar folders in this project.

See https://docs.astral.sh/ruff/settings/#cache-dir