### PR TITLE
gh-110938: Add several missing syntax tests for PEP695 funcs and classes

### DIFF
--- a/Lib/test/test_syntax.py
+++ b/Lib/test/test_syntax.py
@@ -1004,7 +1004,22 @@ Missing ':' before suites:
    Traceback (most recent call last):
    SyntaxError: expected ':'
 
+   >>> def f[T]()
+   ...     pass
+   Traceback (most recent call last):
+   SyntaxError: expected ':'
+
    >>> class A
+   ...     pass
+   Traceback (most recent call last):
+   SyntaxError: expected ':'
+
+   >>> class A[T]
+   ...     pass
+   Traceback (most recent call last):
+   SyntaxError: expected ':'
+
+   >>> class A[T]()
    ...     pass
    Traceback (most recent call last):
    SyntaxError: expected ':'


### PR DESCRIPTION
This PR tests:
- Line: https://github.com/python/cpython/pull/110973/files#diff-2973ca53337859793077e9bdc1a1623063379f0fdfcb788836fd82ebb66b763bR1375
- And `def` for the same thing (this test was missing as well)
<!-- gh-issue-number: gh-110938 -->
* Issue: gh-110938
<!-- /gh-issue-number -->
