### PR TITLE
gh-52161: Enhance Cmd support for docstrings

### DIFF
--- a/Lib/cmd.py
+++ b/Lib/cmd.py
@@ -42,12 +42,15 @@ listings of documented functions, miscellaneous topics, and undocumented
 functions respectively.
 """
 
-import string, sys
+import inspect
+import string
+import sys
 
 __all__ = ["Cmd"]
 
 PROMPT = '(Cmd) '
 IDENTCHARS = string.ascii_letters + string.digits + '_'
+
 
 class Cmd:
     """A simple framework for writing line-oriented command interpreters.
@@ -297,7 +300,8 @@ class Cmd:
                 func = getattr(self, 'help_' + arg)
             except AttributeError:
                 try:
-                    doc=getattr(self, 'do_' + arg).__doc__
+                    doc = getattr(self, 'do_' + arg).__doc__
+                    doc = inspect.cleandoc(doc)
                     if doc:
                         self.stdout.write("%s\n"%str(doc))
                         return

--- a/Lib/cmd.py
+++ b/Lib/cmd.py
@@ -111,14 +111,14 @@ class Cmd:
                 import readline
                 self.old_completer = readline.get_completer()
                 readline.set_completer(self.complete)
-                readline.parse_and_bind(self.completekey+": complete")
+                readline.parse_and_bind(self.completekey + ": complete")
             except ImportError:
                 pass
         try:
             if intro is not None:
                 self.intro = intro
             if self.intro:
-                self.stdout.write(str(self.intro)+"\n")
+                self.stdout.write(str(self.intro) + "\n")
             stop = None
             while not stop:
                 if self.cmdqueue:
@@ -148,7 +148,6 @@ class Cmd:
                     readline.set_completer(self.old_completer)
                 except ImportError:
                     pass
-
 
     def precmd(self, line):
         """Hook method executed just before the command line is
@@ -188,7 +187,8 @@ class Cmd:
             else:
                 return None, None, line
         i, n = 0, len(line)
-        while i < n and line[i] in self.identchars: i = i+1
+        while i < n and line[i] in self.identchars:
+            i = i + 1
         cmd, arg = line[:i], line[i:].strip()
         return cmd, arg, line
 
@@ -208,7 +208,7 @@ class Cmd:
         if cmd is None:
             return self.default(line)
         self.lastcmd = line
-        if line == 'EOF' :
+        if line == 'EOF':
             self.lastcmd = ''
         if cmd == '':
             return self.default(line)
@@ -236,7 +236,7 @@ class Cmd:
         returns.
 
         """
-        self.stdout.write('*** Unknown syntax: %s\n'%line)
+        self.stdout.write('*** Unknown syntax: %s\n' % line)
 
     def completedefault(self, *ignored):
         """Method called to complete an input line when no command-specific
@@ -248,7 +248,7 @@ class Cmd:
         return []
 
     def completenames(self, text, *ignored):
-        dotext = 'do_'+text
+        dotext = 'do_' + text
         return [a[3:] for a in self.get_names() if a.startswith(dotext)]
 
     def complete(self, text, state):
@@ -264,7 +264,7 @@ class Cmd:
             stripped = len(origline) - len(line)
             begidx = readline.get_begidx() - stripped
             endidx = readline.get_endidx() - stripped
-            if begidx>0:
+            if begidx > 0:
                 cmd, args, foo = self.parseline(line)
                 if cmd == '':
                     compfunc = self.completedefault
@@ -303,11 +303,11 @@ class Cmd:
                     doc = getattr(self, 'do_' + arg).__doc__
                     doc = inspect.cleandoc(doc)
                     if doc:
-                        self.stdout.write("%s\n"%str(doc))
+                        self.stdout.write("%s\n" % str(doc))
                         return
                 except AttributeError:
                     pass
-                self.stdout.write("%s\n"%str(self.nohelp % (arg,)))
+                self.stdout.write("%s\n" % str(self.nohelp % (arg,)))
                 return
             func()
         else:
@@ -326,7 +326,7 @@ class Cmd:
                     if name == prevname:
                         continue
                     prevname = name
-                    cmd=name[3:]
+                    cmd = name[3:]
                     if cmd in topics:
                         cmds_doc.append(cmd)
                         topics.remove(cmd)
@@ -334,17 +334,17 @@ class Cmd:
                         cmds_doc.append(cmd)
                     else:
                         cmds_undoc.append(cmd)
-            self.stdout.write("%s\n"%str(self.doc_leader))
-            self.print_topics(self.doc_header,   cmds_doc,   15,80)
-            self.print_topics(self.misc_header,  sorted(topics),15,80)
-            self.print_topics(self.undoc_header, cmds_undoc, 15,80)
+            self.stdout.write("%s\n" % str(self.doc_leader))
+            self.print_topics(self.doc_header,   cmds_doc,       15, 80)
+            self.print_topics(self.misc_header,  sorted(topics), 15, 80)
+            self.print_topics(self.undoc_header, cmds_undoc,     15, 80)
 
     def print_topics(self, header, cmds, cmdlen, maxcol):
         if cmds:
-            self.stdout.write("%s\n"%str(header))
+            self.stdout.write("%s\n" % str(header))
             if self.ruler:
-                self.stdout.write("%s\n"%str(self.ruler * len(header)))
-            self.columnize(cmds, maxcol-1)
+                self.stdout.write("%s\n" % str(self.ruler * len(header)))
+            self.columnize(cmds, maxcol - 1)
             self.stdout.write("\n")
 
     def columnize(self, list, displaywidth=80):
@@ -358,23 +358,23 @@ class Cmd:
             return
 
         nonstrings = [i for i in range(len(list))
-                        if not isinstance(list[i], str)]
+                      if not isinstance(list[i], str)]
         if nonstrings:
             raise TypeError("list[i] not a string for i in %s"
                             % ", ".join(map(str, nonstrings)))
         size = len(list)
         if size == 1:
-            self.stdout.write('%s\n'%str(list[0]))
+            self.stdout.write('%s\n' % str(list[0]))
             return
         # Try every row count from 1 upwards
         for nrows in range(1, len(list)):
-            ncols = (size+nrows-1) // nrows
+            ncols = (size + nrows - 1) // nrows
             colwidths = []
             totwidth = -2
             for col in range(ncols):
                 colwidth = 0
                 for row in range(nrows):
-                    i = row + nrows*col
+                    i = row + nrows * col
                     if i >= size:
                         break
                     x = list[i]
@@ -392,7 +392,7 @@ class Cmd:
         for row in range(nrows):
             texts = []
             for col in range(ncols):
-                i = row + nrows*col
+                i = row + nrows * col
                 if i >= size:
                     x = ""
                 else:
@@ -402,4 +402,4 @@ class Cmd:
                 del texts[-1]
             for col in range(len(texts)):
                 texts[col] = texts[col].ljust(colwidths[col])
-            self.stdout.write("%s\n"%str("  ".join(texts)))
+            self.stdout.write("%s\n" % str("  ".join(texts)))

--- a/Lib/cmd.py
+++ b/Lib/cmd.py
@@ -42,15 +42,12 @@ listings of documented functions, miscellaneous topics, and undocumented
 functions respectively.
 """
 
-import inspect
-import string
-import sys
+import inspect, string, sys
 
 __all__ = ["Cmd"]
 
 PROMPT = '(Cmd) '
 IDENTCHARS = string.ascii_letters + string.digits + '_'
-
 
 class Cmd:
     """A simple framework for writing line-oriented command interpreters.
@@ -111,14 +108,14 @@ class Cmd:
                 import readline
                 self.old_completer = readline.get_completer()
                 readline.set_completer(self.complete)
-                readline.parse_and_bind(self.completekey + ": complete")
+                readline.parse_and_bind(self.completekey+": complete")
             except ImportError:
                 pass
         try:
             if intro is not None:
                 self.intro = intro
             if self.intro:
-                self.stdout.write(str(self.intro) + "\n")
+                self.stdout.write(str(self.intro)+"\n")
             stop = None
             while not stop:
                 if self.cmdqueue:
@@ -148,6 +145,7 @@ class Cmd:
                     readline.set_completer(self.old_completer)
                 except ImportError:
                     pass
+
 
     def precmd(self, line):
         """Hook method executed just before the command line is
@@ -187,8 +185,7 @@ class Cmd:
             else:
                 return None, None, line
         i, n = 0, len(line)
-        while i < n and line[i] in self.identchars:
-            i = i + 1
+        while i < n and line[i] in self.identchars: i = i+1
         cmd, arg = line[:i], line[i:].strip()
         return cmd, arg, line
 
@@ -208,7 +205,7 @@ class Cmd:
         if cmd is None:
             return self.default(line)
         self.lastcmd = line
-        if line == 'EOF':
+        if line == 'EOF' :
             self.lastcmd = ''
         if cmd == '':
             return self.default(line)
@@ -236,7 +233,7 @@ class Cmd:
         returns.
 
         """
-        self.stdout.write('*** Unknown syntax: %s\n' % line)
+        self.stdout.write('*** Unknown syntax: %s\n'%line)
 
     def completedefault(self, *ignored):
         """Method called to complete an input line when no command-specific
@@ -248,7 +245,7 @@ class Cmd:
         return []
 
     def completenames(self, text, *ignored):
-        dotext = 'do_' + text
+        dotext = 'do_'+text
         return [a[3:] for a in self.get_names() if a.startswith(dotext)]
 
     def complete(self, text, state):
@@ -264,7 +261,7 @@ class Cmd:
             stripped = len(origline) - len(line)
             begidx = readline.get_begidx() - stripped
             endidx = readline.get_endidx() - stripped
-            if begidx > 0:
+            if begidx>0:
                 cmd, args, foo = self.parseline(line)
                 if cmd == '':
                     compfunc = self.completedefault
@@ -300,14 +297,14 @@ class Cmd:
                 func = getattr(self, 'help_' + arg)
             except AttributeError:
                 try:
-                    doc = getattr(self, 'do_' + arg).__doc__
+                    doc=getattr(self, 'do_' + arg).__doc__
                     doc = inspect.cleandoc(doc)
                     if doc:
-                        self.stdout.write("%s\n" % str(doc))
+                        self.stdout.write("%s\n"%str(doc))
                         return
                 except AttributeError:
                     pass
-                self.stdout.write("%s\n" % str(self.nohelp % (arg,)))
+                self.stdout.write("%s\n"%str(self.nohelp % (arg,)))
                 return
             func()
         else:
@@ -326,7 +323,7 @@ class Cmd:
                     if name == prevname:
                         continue
                     prevname = name
-                    cmd = name[3:]
+                    cmd=name[3:]
                     if cmd in topics:
                         cmds_doc.append(cmd)
                         topics.remove(cmd)
@@ -334,17 +331,17 @@ class Cmd:
                         cmds_doc.append(cmd)
                     else:
                         cmds_undoc.append(cmd)
-            self.stdout.write("%s\n" % str(self.doc_leader))
-            self.print_topics(self.doc_header,   cmds_doc,       15, 80)
-            self.print_topics(self.misc_header,  sorted(topics), 15, 80)
-            self.print_topics(self.undoc_header, cmds_undoc,     15, 80)
+            self.stdout.write("%s\n"%str(self.doc_leader))
+            self.print_topics(self.doc_header,   cmds_doc,   15,80)
+            self.print_topics(self.misc_header,  sorted(topics),15,80)
+            self.print_topics(self.undoc_header, cmds_undoc, 15,80)
 
     def print_topics(self, header, cmds, cmdlen, maxcol):
         if cmds:
-            self.stdout.write("%s\n" % str(header))
+            self.stdout.write("%s\n"%str(header))
             if self.ruler:
-                self.stdout.write("%s\n" % str(self.ruler * len(header)))
-            self.columnize(cmds, maxcol - 1)
+                self.stdout.write("%s\n"%str(self.ruler * len(header)))
+            self.columnize(cmds, maxcol-1)
             self.stdout.write("\n")
 
     def columnize(self, list, displaywidth=80):
@@ -358,23 +355,23 @@ class Cmd:
             return
 
         nonstrings = [i for i in range(len(list))
-                      if not isinstance(list[i], str)]
+                        if not isinstance(list[i], str)]
         if nonstrings:
             raise TypeError("list[i] not a string for i in %s"
                             % ", ".join(map(str, nonstrings)))
         size = len(list)
         if size == 1:
-            self.stdout.write('%s\n' % str(list[0]))
+            self.stdout.write('%s\n'%str(list[0]))
             return
         # Try every row count from 1 upwards
         for nrows in range(1, len(list)):
-            ncols = (size + nrows - 1) // nrows
+            ncols = (size+nrows-1) // nrows
             colwidths = []
             totwidth = -2
             for col in range(ncols):
                 colwidth = 0
                 for row in range(nrows):
-                    i = row + nrows * col
+                    i = row + nrows*col
                     if i >= size:
                         break
                     x = list[i]
@@ -392,7 +389,7 @@ class Cmd:
         for row in range(nrows):
             texts = []
             for col in range(ncols):
-                i = row + nrows * col
+                i = row + nrows*col
                 if i >= size:
                     x = ""
                 else:
@@ -402,4 +399,4 @@ class Cmd:
                 del texts[-1]
             for col in range(len(texts)):
                 texts[col] = texts[col].ljust(colwidths[col])
-            self.stdout.write("%s\n" % str("  ".join(texts)))
+            self.stdout.write("%s\n"%str("  ".join(texts)))

--- a/Misc/NEWS.d/next/Library/2023-10-17-16-11-03.gh-issue-52161.WBYyCJ.rst
+++ b/Misc/NEWS.d/next/Library/2023-10-17-16-11-03.gh-issue-52161.WBYyCJ.rst
@@ -1,0 +1,2 @@
+:meth:`cmd.Cmd.do_help` now cleans docstrings with :func:`inspect.cleandoc`
+before writing them. Patch by Filip Łapkiewicz.


### PR DESCRIPTION
do_help will now clean indentation and remove leading/trailing empty lines from a dosctring before printing using inspect.cleandoc()

~~Also minor PEP 8 compliance fixes in lines close to my additions.~~

The issue also calls for documenting suport for docstrings, but that's already done as far as I can see.

Fixes: #52161
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-52161 -->
* Issue: gh-52161
<!-- /gh-issue-number -->
