### PR TITLE
gh-85972: Use native timeout for inet socket operations 

### DIFF
--- a/Lib/test/test_socket.py
+++ b/Lib/test/test_socket.py
@@ -5993,7 +5993,7 @@ class NonblockConstantTest(unittest.TestCase):
                 self.assertTrue(s.getblocking())
         else:
             self.assertEqual(s.type, socket.SOCK_STREAM)
-            self.assertEqual(s.gettimeout(), None)
+            self.assertEqual(s.gettimeout(), timeout)
             self.assertFalse(
                 fcntl.fcntl(s, fcntl.F_GETFL, os.O_NONBLOCK) & os.O_NONBLOCK)
             self.assertTrue(s.getblocking())
@@ -6006,15 +6006,15 @@ class NonblockConstantTest(unittest.TestCase):
                            socket.SOCK_STREAM | socket.SOCK_NONBLOCK) as s:
             self.checkNonblock(s)
             s.setblocking(True)
-            self.checkNonblock(s, nonblock=False)
+            self.checkNonblock(s, nonblock=False, timeout=None)
             s.setblocking(False)
             self.checkNonblock(s)
             s.settimeout(None)
-            self.checkNonblock(s, nonblock=False)
+            self.checkNonblock(s, nonblock=False, timeout=None)
             s.settimeout(2.0)
-            self.checkNonblock(s, timeout=2.0)
+            self.checkNonblock(s, nonblock=False, timeout=2.0)
             s.setblocking(True)
-            self.checkNonblock(s, nonblock=False)
+            self.checkNonblock(s, nonblock=False, timeout=None)
         # defaulttimeout
         t = socket.getdefaulttimeout()
         socket.setdefaulttimeout(0.0)
@@ -6022,13 +6022,13 @@ class NonblockConstantTest(unittest.TestCase):
             self.checkNonblock(s)
         socket.setdefaulttimeout(None)
         with socket.socket() as s:
-            self.checkNonblock(s, False)
+            self.checkNonblock(s, nonblock=False, timeout=None)
         socket.setdefaulttimeout(2.0)
         with socket.socket() as s:
-            self.checkNonblock(s, timeout=2.0)
+            self.checkNonblock(s, nonblock=False, timeout=2.0)
         socket.setdefaulttimeout(None)
         with socket.socket() as s:
-            self.checkNonblock(s, False)
+            self.checkNonblock(s, nonblock=False, timeout=None)
         socket.setdefaulttimeout(t)
 
 

--- a/Lib/test/test_socket.py
+++ b/Lib/test/test_socket.py
@@ -4780,16 +4780,16 @@ class NonBlockingTCPTests(ThreadedTCPSocketTest):
         blocking = (timeout != 0.0)
         self.assertEqual(sock.getblocking(), blocking)
 
-        if fcntl is not None:
-            # When a Python socket has a non-zero timeout, it's switched
-            # internally to a non-blocking mode. Later, sock.sendall(),
-            # sock.recv(), and other socket operations use a select() call and
-            # handle EWOULDBLOCK/EGAIN on all socket operations. That's how
-            # timeouts are enforced.
-            fd_blocking = (timeout is None)
+        # if fcntl is not None:
+        #     # When a Python socket has a non-zero timeout, it's switched
+        #     # internally to a non-blocking mode. Later, sock.sendall(),
+        #     # sock.recv(), and other socket operations use a select() call and
+        #     # handle EWOULDBLOCK/EGAIN on all socket operations. That's how
+        #     # timeouts are enforced.
+        #     fd_blocking = (timeout is None)
 
-            flag = fcntl.fcntl(sock, fcntl.F_GETFL, os.O_NONBLOCK)
-            self.assertEqual(not bool(flag & os.O_NONBLOCK), fd_blocking)
+        #     flag = fcntl.fcntl(sock, fcntl.F_GETFL, os.O_NONBLOCK)
+        #     self.assertEqual(not bool(flag & os.O_NONBLOCK), fd_blocking)
 
     def testSetBlocking(self):
         # Test setblocking() and settimeout() methods

--- a/Lib/test/test_socket.py
+++ b/Lib/test/test_socket.py
@@ -4780,17 +4780,6 @@ class NonBlockingTCPTests(ThreadedTCPSocketTest):
         blocking = (timeout != 0.0)
         self.assertEqual(sock.getblocking(), blocking)
 
-        # if fcntl is not None:
-        #     # When a Python socket has a non-zero timeout, it's switched
-        #     # internally to a non-blocking mode. Later, sock.sendall(),
-        #     # sock.recv(), and other socket operations use a select() call and
-        #     # handle EWOULDBLOCK/EGAIN on all socket operations. That's how
-        #     # timeouts are enforced.
-        #     fd_blocking = (timeout is None)
-
-        #     flag = fcntl.fcntl(sock, fcntl.F_GETFL, os.O_NONBLOCK)
-        #     self.assertEqual(not bool(flag & os.O_NONBLOCK), fd_blocking)
-
     def testSetBlocking(self):
         # Test setblocking() and settimeout() methods
         self.serv.setblocking(True)

--- a/Lib/test/test_ssl.py
+++ b/Lib/test/test_ssl.py
@@ -3573,8 +3573,7 @@ class ThreadedTests(unittest.TestCase):
                 c.settimeout(0.2)
                 c.connect((host, port))
                 # Will attempt handshake and time out
-                self.assertRaisesRegex(TimeoutError, "timed out",
-                                       test_wrap_socket, c)
+                self.assertRaises(TimeoutError, test_wrap_socket, c)
             finally:
                 c.close()
             try:
@@ -3582,8 +3581,7 @@ class ThreadedTests(unittest.TestCase):
                 c = test_wrap_socket(c)
                 c.settimeout(0.2)
                 # Will attempt handshake and time out
-                self.assertRaisesRegex(TimeoutError, "timed out",
-                                       c.connect, (host, port))
+                self.assertRaises(TimeoutError, c.connect, (host, port))
             finally:
                 c.close()
         finally:

--- a/Misc/NEWS.d/next/Library/2023-10-17-21-38-56.gh-issue-85972.jnlGo0.rst
+++ b/Misc/NEWS.d/next/Library/2023-10-17-21-38-56.gh-issue-85972.jnlGo0.rst
@@ -1,0 +1,2 @@
+Use the ``SO_SNDTIMEO`` / ``SO_RCVTIMEO`` socket option to implement the
+timeout for ``INET`` / ``INET6`` sockets instead of ``select``.

--- a/Modules/socketmodule.c
+++ b/Modules/socketmodule.c
@@ -3499,11 +3499,6 @@ internal_connect(PySocketSockObject *s, struct sockaddr *addr, int addrlen,
     Py_BEGIN_ALLOW_THREADS
     res = connect(s->sock_fd, addr, addrlen);
     Py_END_ALLOW_THREADS
-    if (s->sock_timeout > 0) {
-        if (internal_setblocking(s, 1) < 0) {
-            return -1;
-        }
-    }
 
     if (!res) {
         /* connect() succeeded, the socket is connected */
@@ -3514,6 +3509,13 @@ internal_connect(PySocketSockObject *s, struct sockaddr *addr, int addrlen,
 
     /* save error, PyErr_CheckSignals() can replace it */
     err = GET_SOCK_ERROR;
+
+    if (s->sock_timeout > 0) {
+        if (internal_setblocking(s, 1) < 0) {
+            return -1;
+        }
+    }
+
     if (CHECK_ERRNO(EINTR)) {
         if (PyErr_CheckSignals())
             return -1;

--- a/Modules/socketmodule.c
+++ b/Modules/socketmodule.c
@@ -3155,8 +3155,9 @@ sock_settimeout(PySocketSockObject *s, PyObject *arg)
 {
     _PyTime_t timeout;
 
-    if (socket_parse_timeout(&timeout, arg) < 0)
+    if (socket_parse_timeout(&timeout, arg) < 0) {
         return NULL;
+    }
     
     if (internal_settimeout(s, timeout) < 0) {
         return NULL;

--- a/Modules/socketmodule.c
+++ b/Modules/socketmodule.c
@@ -3517,6 +3517,9 @@ internal_connect(PySocketSockObject *s, struct sockaddr *addr, int addrlen,
 {
     int res, err, wait_connect;
 
+    // SO_SNDTIMEO dose not affcet the connect call on some platforms, so set
+    // the sock to non-blocking mode to get the result immediate and use the
+    // select stuff latter.
     if (s->sock_timeout > 0 &&
         (s->sock_family == AF_INET || s->sock_family == AF_INET6))
     {

--- a/Modules/socketmodule.c
+++ b/Modules/socketmodule.c
@@ -3517,13 +3517,6 @@ internal_connect(PySocketSockObject *s, struct sockaddr *addr, int addrlen,
 {
     int res, err, wait_connect;
 
-    if (s->sock_timeout > 0 &&
-        (s->sock_family == AF_INET || s->sock_family == AF_INET6))
-    {
-        if (internal_setblocking(s, 0) < 0) {
-            return -1;
-        }
-    }
     Py_BEGIN_ALLOW_THREADS
     res = connect(s->sock_fd, addr, addrlen);
     Py_END_ALLOW_THREADS
@@ -3537,13 +3530,6 @@ internal_connect(PySocketSockObject *s, struct sockaddr *addr, int addrlen,
 
     /* save error, PyErr_CheckSignals() can replace it */
     err = GET_SOCK_ERROR;
-
-    if (s->sock_timeout > 0) {
-        if (internal_setblocking(s, 1) < 0) {
-            return -1;
-        }
-    }
-
     if (CHECK_ERRNO(EINTR)) {
         if (PyErr_CheckSignals())
             return -1;

--- a/Modules/socketmodule.c
+++ b/Modules/socketmodule.c
@@ -111,6 +111,8 @@ Local naming conventions:
 #include "pycore_fileutils.h"     // _Py_set_inheritable()
 #include "pycore_moduleobject.h"  // _PyModule_GetState
 
+#include <stdbool.h>
+
 #ifdef _Py_MEMORY_SANITIZER
 #  include <sanitizer/msan_interface.h>
 #endif

--- a/Modules/socketmodule.c
+++ b/Modules/socketmodule.c
@@ -3517,6 +3517,13 @@ internal_connect(PySocketSockObject *s, struct sockaddr *addr, int addrlen,
 {
     int res, err, wait_connect;
 
+    if (s->sock_timeout > 0 &&
+        (s->sock_family == AF_INET || s->sock_family == AF_INET6))
+    {
+        if (internal_setblocking(s, 0) < 0) {
+            return -1;
+        }
+    }
     Py_BEGIN_ALLOW_THREADS
     res = connect(s->sock_fd, addr, addrlen);
     Py_END_ALLOW_THREADS
@@ -3530,6 +3537,13 @@ internal_connect(PySocketSockObject *s, struct sockaddr *addr, int addrlen,
 
     /* save error, PyErr_CheckSignals() can replace it */
     err = GET_SOCK_ERROR;
+
+    if (s->sock_timeout > 0) {
+        if (internal_setblocking(s, 1) < 0) {
+            return -1;
+        }
+    }
+
     if (CHECK_ERRNO(EINTR)) {
         if (PyErr_CheckSignals())
             return -1;

--- a/Modules/socketmodule.c
+++ b/Modules/socketmodule.c
@@ -3111,7 +3111,7 @@ internal_settimeout(PySocketSockObject *s, _PyTime_t timeout) {
 
             struct timeval zero = {
                 .tv_sec = 0,
-                .tv_usec = 0
+                .tv_usec = 0,
             };
             if (setsockopt(s->sock_fd, SOL_SOCKET, SO_SNDTIMEO, &zero,
                            sizeof(struct timeval)) != 0) {
@@ -3473,7 +3473,9 @@ internal_connect(PySocketSockObject *s, struct sockaddr *addr, int addrlen,
 {
     int res, err, wait_connect;
 
-    if (s->sock_timeout > 0) {
+    if (s->sock_timeout > 0 &&
+        (s->sock_family == AF_INET || s->sock_family == AF_INET6))
+    {
         if (internal_setblocking(s, 0) < 0) {
             return -1;
         }

--- a/Modules/socketmodule.c
+++ b/Modules/socketmodule.c
@@ -3168,7 +3168,7 @@ internal_settimeout(PySocketSockObject *s, _PyTime_t timeout) {
                 }
             }
             #ifdef MS_WINDOWS
-            if (setsockopt(s->sock_fd, SOL_SOCKET, SO_SNDTIMEO,
+            if (setsockopt(s->sock_fd, SOL_SOCKET, SO_RCVTIMEO,
                            (char *)&timeout_ms, sizeof(int)) != 0)
             #else
             if (setsockopt(s->sock_fd, SOL_SOCKET, SO_RCVTIMEO,

--- a/Modules/socketmodule.c
+++ b/Modules/socketmodule.c
@@ -3115,8 +3115,9 @@ internal_settimeout(PySocketSockObject *s, _PyTime_t timeout) {
                 .tv_sec = 0,
                 .tv_usec = 0,
             };
-            if (setsockopt(s->sock_fd, SOL_SOCKET, SO_SNDTIMEO, &zero,
-                           sizeof(struct timeval)) != 0) {
+            if (setsockopt(s->sock_fd, SOL_SOCKET, SO_SNDTIMEO, (char *)&zero,
+                           sizeof(struct timeval)) != 0)
+            {
                 // EINVAL means emote closed the socket fd or shutdown has been
                 // called.
                 if (!CHECK_ERRNO(EINVAL)) {
@@ -3124,8 +3125,9 @@ internal_settimeout(PySocketSockObject *s, _PyTime_t timeout) {
                     return -1;
                 }
             }
-            if (setsockopt(s->sock_fd, SOL_SOCKET, SO_RCVTIMEO, &zero,
-                       sizeof(struct timeval)) != 0) {
+            if (setsockopt(s->sock_fd, SOL_SOCKET, SO_RCVTIMEO, (char *)&zero,
+                           sizeof(struct timeval)) != 0)
+            {
                 // EINVAL means emote closed the socket fd or shutdown has been
                 // called.
                 if (!CHECK_ERRNO(EINVAL)) {
@@ -3138,8 +3140,9 @@ internal_settimeout(PySocketSockObject *s, _PyTime_t timeout) {
 
             struct timeval timeout_tv;
             _PyTime_AsTimeval(timeout, &timeout_tv, _PyTime_ROUND_TIMEOUT);
-            if (setsockopt(s->sock_fd, SOL_SOCKET, SO_SNDTIMEO, &timeout_tv,
-                           sizeof(struct timeval)) != 0) {
+            if (setsockopt(s->sock_fd, SOL_SOCKET, SO_SNDTIMEO,
+                           (char *)&timeout_tv, sizeof(struct timeval)) != 0)
+            {
                 // EINVAL means emote closed the socket fd or shutdown has been
                 // called.
                 if (!CHECK_ERRNO(EINVAL)) {
@@ -3147,8 +3150,9 @@ internal_settimeout(PySocketSockObject *s, _PyTime_t timeout) {
                     return -1;
                 }
             }
-            if (setsockopt(s->sock_fd, SOL_SOCKET, SO_RCVTIMEO, &timeout_tv,
-                       sizeof(struct timeval)) != 0) {
+            if (setsockopt(s->sock_fd, SOL_SOCKET, SO_RCVTIMEO,
+                           (char *)&timeout_tv, sizeof(struct timeval)) != 0)
+            {
                 // EINVAL means emote closed the socket fd or shutdown has been
                 // called.
                 if (!CHECK_ERRNO(EINVAL)) {

--- a/Modules/socketmodule.c
+++ b/Modules/socketmodule.c
@@ -3115,13 +3115,21 @@ internal_settimeout(PySocketSockObject *s, _PyTime_t timeout) {
             };
             if (setsockopt(s->sock_fd, SOL_SOCKET, SO_SNDTIMEO, &zero,
                            sizeof(struct timeval)) != 0) {
-                set_error();
-                return -1;
+                // EINVAL means emote closed the socket fd or shutdown has been
+                // called.
+                if (!CHECK_ERRNO(EINVAL)) {
+                    set_error();
+                    return -1;
+                }
             }
             if (setsockopt(s->sock_fd, SOL_SOCKET, SO_RCVTIMEO, &zero,
                        sizeof(struct timeval)) != 0) {
-                set_error();
-                return -1;
+                // EINVAL means emote closed the socket fd or shutdown has been
+                // called.
+                if (!CHECK_ERRNO(EINVAL)) {
+                    set_error();
+                    return -1;
+                }
             }
         } else {
             block = 1;
@@ -3130,13 +3138,21 @@ internal_settimeout(PySocketSockObject *s, _PyTime_t timeout) {
             _PyTime_AsTimeval(timeout, &timeout_tv, _PyTime_ROUND_TIMEOUT);
             if (setsockopt(s->sock_fd, SOL_SOCKET, SO_SNDTIMEO, &timeout_tv,
                            sizeof(struct timeval)) != 0) {
-                set_error();
-                return -1;
+                // EINVAL means emote closed the socket fd or shutdown has been
+                // called.
+                if (!CHECK_ERRNO(EINVAL)) {
+                    set_error();
+                    return -1;
+                }
             }
             if (setsockopt(s->sock_fd, SOL_SOCKET, SO_RCVTIMEO, &timeout_tv,
                        sizeof(struct timeval)) != 0) {
-                set_error();
-                return -1;
+                // EINVAL means emote closed the socket fd or shutdown has been
+                // called.
+                if (!CHECK_ERRNO(EINVAL)) {
+                    set_error();
+                    return -1;
+                }
             }
         }
     } else {

--- a/Modules/socketmodule.c
+++ b/Modules/socketmodule.c
@@ -3158,7 +3158,7 @@ sock_settimeout(PySocketSockObject *s, PyObject *arg)
     if (socket_parse_timeout(&timeout, arg) < 0) {
         return NULL;
     }
-    
+
     if (internal_settimeout(s, timeout) < 0) {
         return NULL;
     }

--- a/Modules/socketmodule.c
+++ b/Modules/socketmodule.c
@@ -3473,9 +3473,19 @@ internal_connect(PySocketSockObject *s, struct sockaddr *addr, int addrlen,
 {
     int res, err, wait_connect;
 
+    if (s->sock_timeout > 0) {
+        if (internal_setblocking(s, 0) < 0) {
+            return -1;
+        }
+    }
     Py_BEGIN_ALLOW_THREADS
     res = connect(s->sock_fd, addr, addrlen);
     Py_END_ALLOW_THREADS
+    if (s->sock_timeout > 0) {
+        if (internal_setblocking(s, 1) < 0) {
+            return -1;
+        }
+    }
 
     if (!res) {
         /* connect() succeeded, the socket is connected */

--- a/Modules/socketmodule.c
+++ b/Modules/socketmodule.c
@@ -3528,7 +3528,7 @@ internal_connect(PySocketSockObject *s, struct sockaddr *addr, int addrlen,
 
     /* connect() failed */
 
-    /* save error, PyErr_CheckSignals() can replace it */
+    /* save error, PyErr_CheckSignals() / internal_setblocking() can replace it */
     err = GET_SOCK_ERROR;
 
     if (s->sock_timeout > 0) {
@@ -3537,7 +3537,7 @@ internal_connect(PySocketSockObject *s, struct sockaddr *addr, int addrlen,
         }
     }
 
-    if (CHECK_ERRNO(EINTR)) {
+    if (err == EINTR) {
         if (PyErr_CheckSignals())
             return -1;
 
@@ -3560,7 +3560,8 @@ internal_connect(PySocketSockObject *s, struct sockaddr *addr, int addrlen,
 
     if (!wait_connect) {
         if (raise) {
-            /* restore error, maybe replaced by PyErr_CheckSignals() */
+            /* restore error, maybe replaced by PyErr_CheckSignals() or
+               internal_setblocing() */
             SET_SOCK_ERROR(err);
             s->errorhandler();
             return -1;

--- a/Modules/socketmodule.c
+++ b/Modules/socketmodule.c
@@ -3124,7 +3124,7 @@ internal_settimeout(PySocketSockObject *s, _PyTime_t timeout) {
                            sizeof(struct timeval)) != 0)
             #endif
             {
-                // EINVAL means emote closed the socket fd or shutdown has been
+                // EINVAL means remote closed the socket fd or shutdown has been
                 // called.
                 if (!CHECK_ERRNO(EINVAL)) {
                     set_error();
@@ -3139,7 +3139,7 @@ internal_settimeout(PySocketSockObject *s, _PyTime_t timeout) {
                            sizeof(struct timeval)) != 0)
             #endif
             {
-                // EINVAL means emote closed the socket fd or shutdown has been
+                // EINVAL means remote closed the socket fd or shutdown has been
                 // called.
                 if (!CHECK_ERRNO(EINVAL)) {
                     set_error();
@@ -3160,7 +3160,7 @@ internal_settimeout(PySocketSockObject *s, _PyTime_t timeout) {
                            (char *)&timeout_tv, sizeof(struct timeval)) != 0)
             #endif
             {
-                // EINVAL means emote closed the socket fd or shutdown has been
+                // EINVAL means remote closed the socket fd or shutdown has been
                 // called.
                 if (!CHECK_ERRNO(EINVAL)) {
                     set_error();
@@ -3175,7 +3175,7 @@ internal_settimeout(PySocketSockObject *s, _PyTime_t timeout) {
                            (char *)&timeout_tv, sizeof(struct timeval)) != 0)
             #endif
             {
-                // EINVAL means emote closed the socket fd or shutdown has been
+                // EINVAL means remote closed the socket fd or shutdown has been
                 // called.
                 if (!CHECK_ERRNO(EINVAL)) {
                     set_error();

--- a/Modules/socketmodule.c
+++ b/Modules/socketmodule.c
@@ -3113,16 +3113,14 @@ internal_settimeout(PySocketSockObject *s, _PyTime_t timeout) {
 
             #ifdef MS_WINDOWS
             DWORD zero = 0;
-            if (setsockopt(s->sock_fd, SOL_SOCKET, SO_SNDTIMEO, (char *)&zero,
-                           sizeof(DWORD)) != 0)
             #else
             struct timeval zero = {
                 .tv_sec = 0,
                 .tv_usec = 0,
             };
-            if (setsockopt(s->sock_fd, SOL_SOCKET, SO_SNDTIMEO, (char *)&zero,
-                           sizeof(struct timeval)) != 0)
             #endif
+            if (setsockopt(s->sock_fd, SOL_SOCKET, SO_SNDTIMEO, (char *)&zero,
+                           sizeof(zero)) != 0)
             {
                 // EINVAL means remote closed the socket fd or shutdown has been
                 // called.
@@ -3131,13 +3129,8 @@ internal_settimeout(PySocketSockObject *s, _PyTime_t timeout) {
                     return -1;
                 }
             }
-            #ifdef MS_WINDOWS
             if (setsockopt(s->sock_fd, SOL_SOCKET, SO_RCVTIMEO, (char *)&zero,
-                           sizeof(int)) != 0)
-            #else
-            if (setsockopt(s->sock_fd, SOL_SOCKET, SO_RCVTIMEO, (char *)&zero,
-                           sizeof(struct timeval)) != 0)
-            #endif
+                           sizeof(zero)) != 0)
             {
                 // EINVAL means remote closed the socket fd or shutdown has been
                 // called.
@@ -3150,19 +3143,17 @@ internal_settimeout(PySocketSockObject *s, _PyTime_t timeout) {
             block = 1;
 
             #ifdef MS_WINDOWS
-            _PyTime_t timeout_as_ms = _PyTime_AsMilliseconds(timeout, _PyTime_ROUND_FLOOR);
-            DWORD timeout_ms = INFINITE;
+            _PyTime_t timeout_as_ms = _PyTime_AsMilliseconds(timeout, _PyTime_ROUND_TIMEOUT);
+            DWORD timeout_tv = INFINITE;
             if ((DWORD)timeout_as_ms == timeout_as_ms) {
-                timeout_ms = (DWORD)timeout_as_ms;
+                timeout_tv = (DWORD)timeout_as_ms;
             }
-            if (setsockopt(s->sock_fd, SOL_SOCKET, SO_SNDTIMEO,
-                           (char *)&timeout_ms, sizeof(DWORD)) != 0)
             #else
             struct timeval timeout_tv;
             _PyTime_AsTimeval(timeout, &timeout_tv, _PyTime_ROUND_TIMEOUT);
-            if (setsockopt(s->sock_fd, SOL_SOCKET, SO_SNDTIMEO,
-                           (char *)&timeout_tv, sizeof(struct timeval)) != 0)
             #endif
+            if (setsockopt(s->sock_fd, SOL_SOCKET, SO_SNDTIMEO,
+                           (char *)&timeout_tv, sizeof(timeout_tv)) != 0)
             {
                 // EINVAL means remote closed the socket fd or shutdown has been
                 // called.
@@ -3171,13 +3162,8 @@ internal_settimeout(PySocketSockObject *s, _PyTime_t timeout) {
                     return -1;
                 }
             }
-            #ifdef MS_WINDOWS
             if (setsockopt(s->sock_fd, SOL_SOCKET, SO_RCVTIMEO,
-                           (char *)&timeout_ms, sizeof(int)) != 0)
-            #else
-            if (setsockopt(s->sock_fd, SOL_SOCKET, SO_RCVTIMEO,
-                           (char *)&timeout_tv, sizeof(struct timeval)) != 0)
-            #endif
+                           (char *)&timeout_tv, sizeof(timeout_tv)) != 0)
             {
                 // EINVAL means remote closed the socket fd or shutdown has been
                 // called.

--- a/Modules/socketmodule.c
+++ b/Modules/socketmodule.c
@@ -3150,7 +3150,11 @@ internal_settimeout(PySocketSockObject *s, _PyTime_t timeout) {
             block = 1;
 
             #ifdef MS_WINDOWS
-            DWORD timeout_ms = timeout / 1000000;
+            _PyTime_t timeout_as_ms = _PyTime_AsMilliseconds(timeout, _PyTime_ROUND_FLOOR);
+            DWORD timeout_ms = INFINITE;
+            if ((DWORD)timeout_as_ms == timeout_as_ms) {
+                timeout_ms = (DWORD)timeout_as_ms;
+            }
             if (setsockopt(s->sock_fd, SOL_SOCKET, SO_SNDTIMEO,
                            (char *)&timeout_ms, sizeof(DWORD)) != 0)
             #else


### PR DESCRIPTION
I have a dig into using `SO_SENDTIMEO` and `SO_RECVTIMEO` to implement the timeout operation, and found that most platforms support using them to set the `write` / `send` / `read` / `recv` ... timeouts for INET sockets.  
  
For Unix domain sockets, only Linux supports using these options to set the timeout.  
  
For `connect` / `accept`, `SO_SENDTIMEO` and `SO_RECVTIMEO` also affect these two operations' timeout on Linux.  
  
So, in this PR, Unix domain sockets will keep the old behavior (use setblocking(0) and select to emulate timeout).  
  
For INET sockets, `socket.settimeout` will use `SO_SENDTIMEO` and `SO_RECVTIMEO` options to set the timeout to the socket directly and use this to enforce a timeout.  

For INET sockets, `connect` will use the old behavior (use setblocking(0) and select to emulate timeout) to enforce a timeout. To achieve this, we should set it to non-blocking mode and call the old `connect`, then set it to blocking mode again.

<!-- gh-issue-number: gh-85972 -->
* Issue: gh-85972
<!-- /gh-issue-number -->
