### PR TITLE
gh-110995: Fix test_gdb check_usable_gdb()

### DIFF
--- a/Misc/NEWS.d/next/Tests/2023-10-17-17-54-36.gh-issue-110995.Fx8KRD.rst
+++ b/Misc/NEWS.d/next/Tests/2023-10-17-17-54-36.gh-issue-110995.Fx8KRD.rst
@@ -1,0 +1,2 @@
+test_gdb: Fix detection of gdb built without Python scripting support. Patch
+by Victor Stinner.


### PR DESCRIPTION
Fix detection of gdb built without Python scripting support.

* check_usable_gdb() doesn't check gdb exit code when calling run_gdb().
* Use shutil.which() to get the path to the gdb program.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-110995 -->
* Issue: gh-110995
<!-- /gh-issue-number -->
