### PR TITLE
[3.11] gh-110756: Fix libregrtest clear_caches() for distutils

### DIFF
--- a/Lib/test/libregrtest/utils.py
+++ b/Lib/test/libregrtest/utils.py
@@ -184,6 +184,15 @@ def clear_caches():
         if stream is not None:
             stream.flush()
 
+    # Clear assorted module caches.
+    # Don't worry about resetting the cache if the module is not loaded
+    try:
+        distutils_dir_util = sys.modules['distutils.dir_util']
+    except KeyError:
+        pass
+    else:
+        distutils_dir_util._path_created.clear()
+
     try:
         re = sys.modules['re']
     except KeyError:


### PR DESCRIPTION
Restore code removed by recent sync with the main branch which no longer has distutils:
commit 26748ed4f61520c59af15547792d1e73144a4314.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-110756 -->
* Issue: gh-110756
<!-- /gh-issue-number -->
