### PR TITLE
gh-111015: Install IDLE.app and Python Launcher.app on macOS with correct permissions

### DIFF
--- a/Mac/Makefile.in
+++ b/Mac/Makefile.in
@@ -257,6 +257,8 @@ install_IDLE:
 		rm "$(DESTDIR)$(LIBDEST)/idlelib/config-extensions.def~" ; \
 	fi
 	touch "$(DESTDIR)$(PYTHONAPPSDIR)/IDLE.app"
+	chmod -R ugo+rX,go-w "$(DESTDIR)$(PYTHONAPPSDIR)/IDLE.app"
+	chmod ugo+x "$(DESTDIR)$(PYTHONAPPSDIR)/IDLE.app/Contents/MacOS/IDLE"
 
 $(INSTALLED_PYTHONAPP): install_Python
 

--- a/Mac/PythonLauncher/Makefile.in
+++ b/Mac/PythonLauncher/Makefile.in
@@ -27,6 +27,8 @@ install: Python\ Launcher.app
 	-test -d "$(DESTDIR)$(PYTHONAPPSDIR)/Python Launcher.app" && rm -r "$(DESTDIR)$(PYTHONAPPSDIR)/Python Launcher.app"
 	/bin/cp -r "Python Launcher.app" "$(DESTDIR)$(PYTHONAPPSDIR)"
 	touch "$(DESTDIR)$(PYTHONAPPSDIR)/Python Launcher.app"
+	chmod -R ugo+rX,go-w "$(DESTDIR)$(PYTHONAPPSDIR)/Python Launcher.app"
+	chmod ugo+x "$(DESTDIR)$(PYTHONAPPSDIR)/Python Launcher.app/Contents/MacOS/Python Launcher"
 
 clean:
 	rm -f *.o "Python Launcher"

--- a/Misc/NEWS.d/next/IDLE/2023-10-18-01-40-36.gh-issue-111015.NaLI2L.rst
+++ b/Misc/NEWS.d/next/IDLE/2023-10-18-01-40-36.gh-issue-111015.NaLI2L.rst
@@ -1,1 +1,0 @@
-Ensure that IDLE.app is installed with appropriate permissions.

--- a/Misc/NEWS.d/next/IDLE/2023-10-18-01-40-36.gh-issue-111015.NaLI2L.rst
+++ b/Misc/NEWS.d/next/IDLE/2023-10-18-01-40-36.gh-issue-111015.NaLI2L.rst
@@ -1,0 +1,1 @@
+Ensure that IDLE.app is installed with appropriate permissions.

--- a/Misc/NEWS.d/next/macOS/2023-10-18-01-40-36.gh-issue-111015.NaLI2L.rst
+++ b/Misc/NEWS.d/next/macOS/2023-10-18-01-40-36.gh-issue-111015.NaLI2L.rst
@@ -1,0 +1,1 @@
+Ensure that IDLE.app and Python Launcher.app are installed with appropriate permissions on macOS builds.


### PR DESCRIPTION
Closes: #111015


<!-- gh-issue-number: gh-111015 -->
* Issue: gh-111015
<!-- /gh-issue-number -->
