### PR TITLE
gh-110961: Fixed asyncio.wait docstring to remove deprecated coroutine reference

### DIFF
--- a/Lib/asyncio/tasks.py
+++ b/Lib/asyncio/tasks.py
@@ -424,8 +424,6 @@ async def wait(fs, *, timeout=None, return_when=ALL_COMPLETED):
 
     The fs iterable must not be empty.
 
-    Coroutines will be wrapped in Tasks.
-
     Returns two sets of Future: (done, pending).
 
     Usage:

--- a/Misc/NEWS.d/next/Library/2023-10-18-02-45-26.gh-issue-110961.y6IXGk.rst
+++ b/Misc/NEWS.d/next/Library/2023-10-18-02-45-26.gh-issue-110961.y6IXGk.rst
@@ -1,0 +1,2 @@
+Fixed :func:`asyncio.wait` docstring, removing the deprecated coroutine
+reference. Patch by Bar Harel.

--- a/Misc/NEWS.d/next/Library/2023-10-18-02-45-26.gh-issue-110961.y6IXGk.rst
+++ b/Misc/NEWS.d/next/Library/2023-10-18-02-45-26.gh-issue-110961.y6IXGk.rst
@@ -1,2 +1,0 @@
-Fixed :func:`asyncio.wait` docstring, removing the deprecated coroutine
-reference. Patch by Bar Harel.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

Simply removed that line. No need to add deprecation or other heavy information that already exist in the docs.

<!-- gh-issue-number: gh-110961 -->
* Issue: gh-110961
<!-- /gh-issue-number -->
