### PR TITLE
Remove unnecessary while in SocketIO.readinto

### DIFF
--- a/Lib/socket.py
+++ b/Lib/socket.py
@@ -702,16 +702,15 @@ class SocketIO(io.RawIOBase):
         self._checkReadable()
         if self._timeout_occurred:
             raise OSError("cannot read from timed out object")
-        while True:
-            try:
-                return self._sock.recv_into(b)
-            except timeout:
-                self._timeout_occurred = True
-                raise
-            except error as e:
-                if e.errno in _blocking_errnos:
-                    return None
-                raise
+        try:
+            return self._sock.recv_into(b)
+        except timeout:
+            self._timeout_occurred = True
+            raise
+        except error as e:
+            if e.errno in _blocking_errnos:
+                return None
+            raise
 
     def write(self, b):
         """Write the given bytes or bytearray object *b* to the socket


### PR DESCRIPTION
These changes remove unnecessary while left over from the commit 6e6c59b5085668f6047eb91bd671747b13fa36d1:
```python
while True:
    try:
        return self._sock.recv_into(b)
    except timeout:
        self._timeout_occurred = True
        raise
    except InterruptedError:  // <---------- removed
        continue              // <---------- removed
    except error as e:
        if e.args[0] in _blocking_errnos:
            return None
        raise
```
-->
```python
while True:
    try:
        return self._sock.recv_into(b)
    except timeout:
        self._timeout_occurred = True
        raise
    except error as e:
        if e.args[0] in _blocking_errnos:
            return None
        raise
```