### PR TITLE
typo: missing line of output in pull parser example

### DIFF
--- a/Doc/library/xml.etree.elementtree.rst
+++ b/Doc/library/xml.etree.elementtree.rst
@@ -154,6 +154,7 @@ elements, call :meth:`XMLPullParser.read_events`.  Here is an example::
    ...     print(elem.tag, 'text=', elem.text)
    ...
    end
+   mytag text= sometext more text
 
 The obvious use case is applications that operate in a non-blocking fashion
 where the XML data is being received from a socket or read incrementally from


### PR DESCRIPTION
I was reading over this example and thought there should have been one more line printed.

Running the example code produced the extra line of output as expected!

code:
```python
import xml.etree.ElementTree as ET
parser = ET.XMLPullParser(['start', 'end'])
parser.feed('<mytag>sometext')
list(parser.read_events())
# output: [('start', <Element 'mytag' at 0x1055559a0>)]
parser.feed(' more text</mytag>')
for event, elem in parser.read_events():
    print(event)
    print(elem.tag, 'text=', elem.text)

# output: end
# output: mytag text= sometext more text
```

<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--111068.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->
Link to updated line in docs preview: https://cpython-previews--111068.org.readthedocs.build/en/111068/library/xml.etree.elementtree.html#pull-api-for-non-blocking-parsing