### PR TITLE
gh-100762: Fix optimization in gen_close 

### DIFF
--- a/Lib/test/test_cprofile.py
+++ b/Lib/test/test_cprofile.py
@@ -83,8 +83,8 @@ class CProfileTest(ProfileTest):
 
         for func, (cc, nc, _, _, _) in pr.stats.items():
             if func[2] == "<genexpr>":
-                self.assertEqual(cc, 2)
-                self.assertEqual(nc, 2)
+                self.assertEqual(cc, 1)
+                self.assertEqual(nc, 1)
 
 
 class TestCommandLine(unittest.TestCase):

--- a/Lib/test/test_sys_setprofile.py
+++ b/Lib/test/test_sys_setprofile.py
@@ -267,10 +267,6 @@ class ProfileHookTestCase(TestCaseBase):
         self.check_events(g, [(1, 'call', g_ident),
                               (2, 'call', f_ident),
                               (2, 'return', f_ident),
-                              # once more; the generator is being garbage collected
-                              # and it will do a PY_THROW
-                              (2, 'call', f_ident),
-                              (2, 'return', f_ident),
                               (1, 'return', g_ident),
                               ])
 

--- a/Objects/genobject.c
+++ b/Objects/genobject.c
@@ -390,7 +390,6 @@ gen_close(PyGenObject *gen, PyObject *args)
         assert(yf == NULL);
         Py_RETURN_NONE;
     }
-
     if (yf) {
         PyFrameState state = gen->gi_frame_state;
         gen->gi_frame_state = FRAME_EXECUTING;

--- a/Objects/genobject.c
+++ b/Objects/genobject.c
@@ -378,18 +378,16 @@ static PyObject *
 gen_close(PyGenObject *gen, PyObject *args)
 {
     PyObject *retval;
-    PyObject *yf = _PyGen_yf(gen);
     int err = 0;
 
     if (gen->gi_frame_state == FRAME_CREATED) {
-        assert(yf == NULL);
         gen->gi_frame_state = FRAME_COMPLETED;
         Py_RETURN_NONE;
     }
     if (gen->gi_frame_state >= FRAME_COMPLETED) {
-        assert(yf == NULL);
         Py_RETURN_NONE;
     }
+    PyObject *yf = _PyGen_yf(gen);
     if (yf) {
         PyFrameState state = gen->gi_frame_state;
         gen->gi_frame_state = FRAME_EXECUTING;

--- a/Objects/genobject.c
+++ b/Objects/genobject.c
@@ -403,7 +403,7 @@ gen_close(PyGenObject *gen, PyObject *args)
      * YIELD_VALUE if the debugger has changed the lineno. */
     if (err == 0 && is_yield(frame->prev_instr)) {
         assert(is_resume(frame->prev_instr + 1));
-        int exception_handler_depth = frame->prev_instr[0].op.code;
+        int exception_handler_depth = frame->prev_instr[0].op.arg;
         assert(exception_handler_depth > 0);
         /* We can safely ignore the outermost try block
          * as it automatically generated to handle

--- a/Objects/genobject.c
+++ b/Objects/genobject.c
@@ -378,17 +378,19 @@ static PyObject *
 gen_close(PyGenObject *gen, PyObject *args)
 {
     PyObject *retval;
+    PyObject *yf = _PyGen_yf(gen);
     int err = 0;
 
     if (gen->gi_frame_state == FRAME_CREATED) {
+        assert(yf == NULL);
         gen->gi_frame_state = FRAME_COMPLETED;
         Py_RETURN_NONE;
     }
     if (gen->gi_frame_state >= FRAME_COMPLETED) {
+        assert(yf == NULL);
         Py_RETURN_NONE;
     }
 
-    PyObject *yf = _PyGen_yf(gen);
     if (yf) {
         PyFrameState state = gen->gi_frame_state;
         gen->gi_frame_state = FRAME_EXECUTING;

--- a/Objects/genobject.c
+++ b/Objects/genobject.c
@@ -408,6 +408,7 @@ gen_close(PyGenObject *gen, PyObject *args)
          * as it automatically generated to handle
          * StopIteration. */
         if (exception_handler_depth == 1) {
+            gen->gi_frame_state = FRAME_COMPLETED;
             Py_RETURN_NONE;
         }
     }

--- a/Objects/genobject.c
+++ b/Objects/genobject.c
@@ -378,7 +378,6 @@ static PyObject *
 gen_close(PyGenObject *gen, PyObject *args)
 {
     PyObject *retval;
-    PyObject *yf = _PyGen_yf(gen);
     int err = 0;
 
     if (gen->gi_frame_state == FRAME_CREATED) {
@@ -388,6 +387,8 @@ gen_close(PyGenObject *gen, PyObject *args)
     if (gen->gi_frame_state >= FRAME_COMPLETED) {
         Py_RETURN_NONE;
     }
+
+    PyObject *yf = _PyGen_yf(gen);
     if (yf) {
         PyFrameState state = gen->gi_frame_state;
         gen->gi_frame_state = FRAME_EXECUTING;


### PR DESCRIPTION
In https://github.com/python/cpython/commit/f02fa64bf2d03ef7a28650c164e17a5fb5d8543d  lines 383-389 were added, with returns that do not decref ``yf``.  I think this is ok because ``yf`` is always NULL in these cases. Adding the assertions.

Also, the optimization for the case of exception_handler_depth== 1 is not working because ``op.code`` is checked instead of ``op.arg``.

<!-- gh-issue-number: gh-100762 -->
* Issue: gh-100762
<!-- /gh-issue-number -->
