### PR TITLE
gh-101100: Fix Sphinx warnings in `library/tty.rst`

### DIFF
--- a/Doc/library/termios.rst
+++ b/Doc/library/termios.rst
@@ -43,10 +43,20 @@ The module defines the following functions:
 
    Set the tty attributes for file descriptor *fd* from the *attributes*, which is
    a list like the one returned by :func:`tcgetattr`.  The *when* argument
-   determines when the attributes are changed: :const:`TCSANOW` to change
-   immediately, :const:`TCSADRAIN` to change after transmitting all queued output,
-   or :const:`TCSAFLUSH` to change after transmitting all queued output and
-   discarding all queued input.
+   determines when the attributes are changed:
+
+   .. data:: TCSANOW
+
+      Change attributes immediately.
+
+   .. data:: TCSADRAIN
+
+      Change attributes after transmitting all queued output.
+
+   .. data:: TCSAFLUSH
+
+      Change attributes after transmitting all queued output and
+      discarding all queued input.
 
 
 .. function:: tcsendbreak(fd, duration)

--- a/Doc/tools/.nitignore
+++ b/Doc/tools/.nitignore
@@ -121,7 +121,6 @@ Doc/library/tkinter.rst
 Doc/library/tkinter.scrolledtext.rst
 Doc/library/tkinter.ttk.rst
 Doc/library/traceback.rst
-Doc/library/tty.rst
 Doc/library/unittest.mock.rst
 Doc/library/unittest.rst
 Doc/library/urllib.parse.rst


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

Fixes these warnings:

```
Doc/library/termios.rst:44: WARNING: py:const reference target not found: TCSANOW
Doc/library/termios.rst:44: WARNING: py:const reference target not found: TCSADRAIN
Doc/library/termios.rst:44: WARNING: py:const reference target not found: TCSAFLUSH
Doc/library/tty.rst:41: WARNING: py:const reference target not found: termios.TCSAFLUSH
Doc/library/tty.rst:52: WARNING: py:const reference target not found: termios.TCSAFLUSH
```

(Some remain in `termios.rst` that can be handled later.)

`termios.rst` renders like this:

![image](https://github.com/python/cpython/assets/1324225/8b39313b-5cf1-4bec-91e1-9b58cbeed390)


<!-- gh-issue-number: gh-101100 -->
* Issue: gh-101100
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews.readthedocs.io/en/latest/library/termios.html

<!-- readthedocs-preview cpython-previews end -->