### PR TITLE
[3.12] gh-101100: Fix sphinx warnings in `library/getpass.rst` (GH-110461)

### DIFF
--- a/Doc/library/getpass.rst
+++ b/Doc/library/getpass.rst
@@ -43,7 +43,7 @@ The :mod:`getpass` module provides two functions:
    Return the "login name" of the user.
 
    This function checks the environment variables :envvar:`LOGNAME`,
-   :envvar:`USER`, :envvar:`LNAME` and :envvar:`USERNAME`, in order, and
+   :envvar:`USER`, :envvar:`!LNAME` and :envvar:`USERNAME`, in order, and
    returns the value of the first one which is set to a non-empty string.  If
    none are set, the login name from the password database is returned on
    systems which support the :mod:`pwd` module, otherwise, an exception is

--- a/Doc/tools/.nitignore
+++ b/Doc/tools/.nitignore
@@ -76,7 +76,6 @@ Doc/library/ftplib.rst
 Doc/library/functions.rst
 Doc/library/functools.rst
 Doc/library/getopt.rst
-Doc/library/getpass.rst
 Doc/library/gettext.rst
 Doc/library/gzip.rst
 Doc/library/http.client.rst


### PR DESCRIPTION

(cherry picked from commit d144749914dbe295d71d037e8ca695783511123f)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-101100 -->
* Issue: gh-101100
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--111080.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->