### PR TITLE
gh-111092: Make turtledemo run without default root enabled

### DIFF
--- a/Lib/turtledemo/__main__.py
+++ b/Lib/turtledemo/__main__.py
@@ -161,7 +161,7 @@ class DemoWindow(object):
                               label='Help', underline=0)
         root['menu'] = self.mBar
 
-        pane = PanedWindow(orient=HORIZONTAL, sashwidth=5,
+        pane = PanedWindow(root, orient=HORIZONTAL, sashwidth=5,
                            sashrelief=SOLID, bg='#ddd')
         pane.add(self.makeTextFrame(pane))
         pane.add(self.makeGraphFrame(pane))

--- a/Misc/NEWS.d/next/Library/2023-10-19-22-46-34.gh-issue-111092.hgut12.rst
+++ b/Misc/NEWS.d/next/Library/2023-10-19-22-46-34.gh-issue-111092.hgut12.rst
@@ -1,0 +1,1 @@
+Make turtledemo run without default root enabled.


### PR DESCRIPTION
Add missing 'root' argument to PanedWindow call.  Other root children already have it.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-111092 -->
* Issue: gh-111092
<!-- /gh-issue-number -->
