### PR TITLE
gh-111085: Fix invalid state handling in TaskGroup and Timeout

### DIFF
--- a/Lib/asyncio/taskgroups.py
+++ b/Lib/asyncio/taskgroups.py
@@ -55,15 +55,13 @@ class TaskGroup:
         if self._entered:
             raise RuntimeError(
                 f"TaskGroup {self!r} has been already entered")
-        self._entered = True
-
         if self._loop is None:
             self._loop = events.get_running_loop()
-
         self._parent_task = tasks.current_task(self._loop)
         if self._parent_task is None:
             raise RuntimeError(
                 f'TaskGroup {self!r} cannot determine the parent task')
+        self._entered = True
 
         return self
 

--- a/Lib/asyncio/taskgroups.py
+++ b/Lib/asyncio/taskgroups.py
@@ -54,7 +54,7 @@ class TaskGroup:
     async def __aenter__(self):
         if self._entered:
             raise RuntimeError(
-                f"TaskGroup {self!r} has been already entered")
+                f"TaskGroup {self!r} has already been entered")
         if self._loop is None:
             self._loop = events.get_running_loop()
         self._parent_task = tasks.current_task(self._loop)

--- a/Lib/asyncio/timeouts.py
+++ b/Lib/asyncio/timeouts.py
@@ -82,7 +82,7 @@ class Timeout:
 
     async def __aenter__(self) -> "Timeout":
         if self._state is not _State.CREATED:
-            raise RuntimeError("Timeout has been already entered")
+            raise RuntimeError("Timeout has already been entered")
         task = tasks.current_task()
         if task is None:
             raise RuntimeError("Timeout should be used inside a task")

--- a/Lib/asyncio/timeouts.py
+++ b/Lib/asyncio/timeouts.py
@@ -49,7 +49,6 @@ class Timeout:
 
     def reschedule(self, when: Optional[float]) -> None:
         """Reschedule the timeout."""
-        assert self._state is not _State.CREATED
         if self._state is not _State.ENTERED:
             raise RuntimeError(
                 f"Cannot change state of {self._state.value} Timeout",
@@ -82,11 +81,14 @@ class Timeout:
         return f"<Timeout [{self._state.value}]{info_str}>"
 
     async def __aenter__(self) -> "Timeout":
-        self._state = _State.ENTERED
-        self._task = tasks.current_task()
-        self._cancelling = self._task.cancelling()
-        if self._task is None:
+        if self._state is not _State.CREATED:
+            raise RuntimeError(f"Timeout has been already {self._state.value}")
+        task = tasks.current_task()
+        if task is None:
             raise RuntimeError("Timeout should be used inside a task")
+        self._state = _State.ENTERED
+        self._task = task
+        self._cancelling = self._task.cancelling()
         self.reschedule(self._when)
         return self
 

--- a/Lib/asyncio/timeouts.py
+++ b/Lib/asyncio/timeouts.py
@@ -82,7 +82,7 @@ class Timeout:
 
     async def __aenter__(self) -> "Timeout":
         if self._state is not _State.CREATED:
-            raise RuntimeError(f"Timeout has been already {self._state.value}")
+            raise RuntimeError("Timeout has been already entered")
         task = tasks.current_task()
         if task is None:
             raise RuntimeError("Timeout should be used inside a task")

--- a/Lib/asyncio/timeouts.py
+++ b/Lib/asyncio/timeouts.py
@@ -50,6 +50,8 @@ class Timeout:
     def reschedule(self, when: Optional[float]) -> None:
         """Reschedule the timeout."""
         if self._state is not _State.ENTERED:
+            if self._state is _State.CREATED:
+                raise RuntimeError("Timeout has not been entered")
             raise RuntimeError(
                 f"Cannot change state of {self._state.value} Timeout",
             )

--- a/Lib/test/test_asyncio/test_taskgroups.py
+++ b/Lib/test/test_asyncio/test_taskgroups.py
@@ -784,7 +784,7 @@ class TestTaskGroup(unittest.IsolatedAsyncioTestCase):
     async def test_taskgroup_already_entered(self):
         tg = taskgroups.TaskGroup()
         async with tg:
-            with self.assertRaisesRegex(RuntimeError, "already entered"):
+            with self.assertRaisesRegex(RuntimeError, "has already been entered"):
                 async with tg:
                     pass
 
@@ -792,7 +792,7 @@ class TestTaskGroup(unittest.IsolatedAsyncioTestCase):
         tg = taskgroups.TaskGroup()
         async with tg:
             pass
-        with self.assertRaisesRegex(RuntimeError, "already entered"):
+        with self.assertRaisesRegex(RuntimeError, "has already been entered"):
             async with tg:
                 pass
 
@@ -801,7 +801,7 @@ class TestTaskGroup(unittest.IsolatedAsyncioTestCase):
         async with tg:
             pass
         coro = asyncio.sleep(0)
-        with self.assertRaisesRegex(RuntimeError, "finished"):
+        with self.assertRaisesRegex(RuntimeError, "is finished"):
             tg.create_task(coro)
         # We still have to await coro to avoid a warning
         await coro

--- a/Lib/test/test_asyncio/test_taskgroups.py
+++ b/Lib/test/test_asyncio/test_taskgroups.py
@@ -8,6 +8,8 @@ import contextlib
 from asyncio import taskgroups
 import unittest
 
+from test.test_asyncio.utils import await_without_task
+
 
 # To prevent a warning "test altered the execution environment"
 def tearDownModule():
@@ -778,6 +780,49 @@ class TestTaskGroup(unittest.IsolatedAsyncioTestCase):
                 self.fail('CustomException not raised')
 
         await asyncio.create_task(main())
+
+    async def test_taskgroup_already_entered(self):
+        tg = taskgroups.TaskGroup()
+        async with tg:
+            with self.assertRaisesRegex(RuntimeError, "already entered"):
+                async with tg:
+                    pass
+
+    async def test_taskgroup_double_enter(self):
+        tg = taskgroups.TaskGroup()
+        async with tg:
+            pass
+        with self.assertRaisesRegex(RuntimeError, "already entered"):
+            async with tg:
+                pass
+
+    async def test_taskgroup_finished(self):
+        tg = taskgroups.TaskGroup()
+        async with tg:
+            pass
+        coro = asyncio.sleep(0)
+        with self.assertRaisesRegex(RuntimeError, "finished"):
+            tg.create_task(coro)
+        # We still have to await coro to avoid a warning
+        await coro
+
+    async def test_taskgroup_not_entered(self):
+        tg = taskgroups.TaskGroup()
+        coro = asyncio.sleep(0)
+        with self.assertRaisesRegex(RuntimeError, "has not been entered"):
+            tg.create_task(coro)
+        # We still have to await coro to avoid a warning
+        await coro
+
+    async def test_taskgroup_without_parent_task(self):
+        tg = taskgroups.TaskGroup()
+        with self.assertRaisesRegex(RuntimeError, "parent task"):
+            await await_without_task(tg.__aenter__())
+        coro = asyncio.sleep(0)
+        with self.assertRaisesRegex(RuntimeError, "has not been entered"):
+            tg.create_task(coro)
+        # We still have to await coro to avoid a warning
+        await coro
 
 
 if __name__ == "__main__":

--- a/Lib/test/test_asyncio/test_timeouts.py
+++ b/Lib/test/test_asyncio/test_timeouts.py
@@ -277,6 +277,20 @@ class TimeoutTests(unittest.IsolatedAsyncioTestCase):
         with self.assertRaisesRegex(RuntimeError, "finished"):
             cm.reschedule(0.02)
 
+    async def test_timeout_expired(self):
+        with self.assertRaises(TimeoutError):
+            async with asyncio.timeout(0.01) as cm:
+                await asyncio.sleep(1)
+        with self.assertRaisesRegex(RuntimeError, "expired"):
+            cm.reschedule(0.02)
+
+    async def test_timeout_expiring(self):
+        async with asyncio.timeout(0.01) as cm:
+            with self.assertRaises(asyncio.CancelledError):
+                await asyncio.sleep(1)
+            with self.assertRaisesRegex(RuntimeError, "expiring"):
+                cm.reschedule(0.02)
+
     async def test_timeout_not_entered(self):
         cm = asyncio.timeout(0.01)
         with self.assertRaisesRegex(RuntimeError, "has not been entered"):

--- a/Lib/test/test_asyncio/test_timeouts.py
+++ b/Lib/test/test_asyncio/test_timeouts.py
@@ -279,14 +279,14 @@ class TimeoutTests(unittest.IsolatedAsyncioTestCase):
 
     async def test_timeout_not_entered(self):
         cm = asyncio.timeout(0.01)
-        with self.assertRaisesRegex(RuntimeError, "Cannot change state"):
+        with self.assertRaisesRegex(RuntimeError, "has not been entered"):
             cm.reschedule(0.02)
 
     async def test_timeout_without_task(self):
         cm = asyncio.timeout(0.01)
         with self.assertRaisesRegex(RuntimeError, "task"):
             await await_without_task(cm.__aenter__())
-        with self.assertRaisesRegex(RuntimeError, "Cannot change state"):
+        with self.assertRaisesRegex(RuntimeError, "has not been entered"):
             cm.reschedule(0.02)
 
 

--- a/Lib/test/test_asyncio/test_timeouts.py
+++ b/Lib/test/test_asyncio/test_timeouts.py
@@ -5,10 +5,11 @@ import time
 
 import asyncio
 
+from test.test_asyncio.utils import await_without_task
+
 
 def tearDownModule():
     asyncio.set_event_loop_policy(None)
-
 
 class TimeoutTests(unittest.IsolatedAsyncioTestCase):
 
@@ -256,6 +257,37 @@ class TimeoutTests(unittest.IsolatedAsyncioTestCase):
                 await asyncio.sleep(1)
         cause = exc.exception.__cause__
         assert isinstance(cause, asyncio.CancelledError)
+
+    async def test_timeout_already_entered(self):
+        async with asyncio.timeout(0.01) as cm:
+            with self.assertRaisesRegex(RuntimeError, "already active"):
+                async with cm:
+                    pass
+
+    async def test_timeout_double_enter(self):
+        async with asyncio.timeout(0.01) as cm:
+            pass
+        with self.assertRaisesRegex(RuntimeError, "already finished"):
+            async with cm:
+                pass
+
+    async def test_timeout_finished(self):
+        async with asyncio.timeout(0.01) as cm:
+            pass
+        with self.assertRaisesRegex(RuntimeError, "finished"):
+            cm.reschedule(0.02)
+
+    async def test_timeout_not_entered(self):
+        cm = asyncio.timeout(0.01)
+        with self.assertRaisesRegex(RuntimeError, "Cannot change state"):
+            cm.reschedule(0.02)
+
+    async def test_timeout_without_task(self):
+        cm = asyncio.timeout(0.01)
+        with self.assertRaisesRegex(RuntimeError, "task"):
+            await await_without_task(cm.__aenter__())
+        with self.assertRaisesRegex(RuntimeError, "Cannot change state"):
+            cm.reschedule(0.02)
 
 
 if __name__ == '__main__':

--- a/Lib/test/test_asyncio/test_timeouts.py
+++ b/Lib/test/test_asyncio/test_timeouts.py
@@ -260,14 +260,14 @@ class TimeoutTests(unittest.IsolatedAsyncioTestCase):
 
     async def test_timeout_already_entered(self):
         async with asyncio.timeout(0.01) as cm:
-            with self.assertRaisesRegex(RuntimeError, "already entered"):
+            with self.assertRaisesRegex(RuntimeError, "has already been entered"):
                 async with cm:
                     pass
 
     async def test_timeout_double_enter(self):
         async with asyncio.timeout(0.01) as cm:
             pass
-        with self.assertRaisesRegex(RuntimeError, "already entered"):
+        with self.assertRaisesRegex(RuntimeError, "has already been entered"):
             async with cm:
                 pass
 

--- a/Lib/test/test_asyncio/test_timeouts.py
+++ b/Lib/test/test_asyncio/test_timeouts.py
@@ -260,14 +260,14 @@ class TimeoutTests(unittest.IsolatedAsyncioTestCase):
 
     async def test_timeout_already_entered(self):
         async with asyncio.timeout(0.01) as cm:
-            with self.assertRaisesRegex(RuntimeError, "already active"):
+            with self.assertRaisesRegex(RuntimeError, "already entered"):
                 async with cm:
                     pass
 
     async def test_timeout_double_enter(self):
         async with asyncio.timeout(0.01) as cm:
             pass
-        with self.assertRaisesRegex(RuntimeError, "already finished"):
+        with self.assertRaisesRegex(RuntimeError, "already entered"):
             async with cm:
                 pass
 

--- a/Lib/test/test_asyncio/utils.py
+++ b/Lib/test/test_asyncio/utils.py
@@ -620,9 +620,9 @@ async def await_without_task(coro):
         try:
             for _ in coro.__await__():
                 pass
-        except:
+        except BaseException as err:
             nonlocal exc
-            exc = sys.exception()
+            exc = err
     asyncio.get_running_loop().call_soon(func)
     await asyncio.sleep(0)
     if exc is not None:

--- a/Lib/test/test_asyncio/utils.py
+++ b/Lib/test/test_asyncio/utils.py
@@ -612,3 +612,18 @@ def mock_nonblocking_socket(proto=socket.IPPROTO_TCP, type=socket.SOCK_STREAM,
     sock.family = family
     sock.gettimeout.return_value = 0.0
     return sock
+
+
+async def await_without_task(coro):
+    exc = None
+    def func():
+        try:
+            for _ in coro.__await__():
+                pass
+        except:
+            nonlocal exc
+            exc = sys.exception()
+    asyncio.get_running_loop().call_soon(func)
+    await asyncio.sleep(0)
+    if exc is not None:
+        raise exc

--- a/Misc/NEWS.d/next/Library/2023-10-20-15-29-10.gh-issue-110910.u2oPwX.rst
+++ b/Misc/NEWS.d/next/Library/2023-10-20-15-29-10.gh-issue-110910.u2oPwX.rst
@@ -1,0 +1,3 @@
+Fix invalid state handling in :class:`asyncio.TaskGroup` and
+:class:`asyncio.Timeout`. They now raise proper RuntimeError if they are
+improperly used and are left in consitent state after this.

--- a/Misc/NEWS.d/next/Library/2023-10-20-15-29-10.gh-issue-110910.u2oPwX.rst
+++ b/Misc/NEWS.d/next/Library/2023-10-20-15-29-10.gh-issue-110910.u2oPwX.rst
@@ -1,3 +1,3 @@
 Fix invalid state handling in :class:`asyncio.TaskGroup` and
 :class:`asyncio.Timeout`. They now raise proper RuntimeError if they are
-improperly used and are left in consitent state after this.
+improperly used and are left in consistent state after this.


### PR DESCRIPTION
asyncio.TaskGroup and asyncio.Timeout classes now raise proper RuntimeError if they are improperly used.

* When they are used without entering the context manager.
* When they are used after finishing.
* When the context manager is entered more than once (simultaneously or sequentially).
* If there is no current task when entering the context manager.

They are now left in consistent state after raising an exception, so following operations can be correctly performed (if they are allowed).

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-111085 -->
* Issue: gh-111085
<!-- /gh-issue-number -->
