### PR TITLE
gh-111112: Avoid potential confusion in TCP server example.

### DIFF
--- a/Doc/library/socketserver.rst
+++ b/Doc/library/socketserver.rst
@@ -494,7 +494,7 @@ This is the server side::
        def handle(self):
            # self.request is the TCP socket connected to the client
            self.data = self.request.recv(1024).strip()
-           print("{} wrote:".format(self.client_address[0]))
+           print("Received from {}:".format(self.client_address[0]))
            print(self.data)
            # just send back the same data, but upper-cased
            self.request.sendall(self.data.upper())
@@ -525,8 +525,9 @@ objects that simplify communication by providing the standard file interface)::
 
 The difference is that the ``readline()`` call in the second handler will call
 ``recv()`` multiple times until it encounters a newline character, while the
-single ``recv()`` call in the first handler will just return what has been sent
-from the client in one ``sendall()`` call.
+single ``recv()`` call in the first handler will just return what has been
+received so far from the client's ``sendall()`` call (typically all of it, but
+this is not guaranteed by the TCP protocol).
 
 
 This is the client side::


### PR DESCRIPTION
socket.recv(), as documented by the Python reference documentation, returns at most `bufsize` bytes, and the underlying TCP protocol means there is no guaranteed correspondence between what is sent by the client and what is received by the server.

This conflation could mislead readers into thinking that TCP is datagram-based or has similar semantics, which will likely appear to work for simple cases, but introduce difficult to reproduce bugs.

<!-- gh-issue-number: gh-111112 -->
* Issue: gh-111112
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--111113.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->