### PR TITLE
[CVE-2023-27043] gh-102988: Reject malformed addresses in email.parseaddr()

### DIFF
--- a/Doc/library/email.utils.rst
+++ b/Doc/library/email.utils.rst
@@ -58,7 +58,7 @@ of the new API.
    begins with angle brackets, they are stripped off.
 
 
-.. function:: parseaddr(address)
+.. function:: parseaddr(address, *, strict=True)
 
    Parse address -- which should be the value of some address-containing field such
    as :mailheader:`To` or :mailheader:`Cc` -- into its constituent *realname* and

--- a/Doc/library/email.utils.rst
+++ b/Doc/library/email.utils.rst
@@ -65,6 +65,11 @@ of the new API.
    *email address* parts.  Returns a tuple of that information, unless the parse
    fails, in which case a 2-tuple of ``('', '')`` is returned.
 
+   If *strict* is true, use a strict parser which rejects malformed inputs.
+
+   .. versionchanged:: 3.13
+      Add *strict* optional parameter and reject malformed inputs by default.
+
 
 .. function:: formataddr(pair, charset='utf-8')
 
@@ -82,12 +87,15 @@ of the new API.
       Added the *charset* option.
 
 
-.. function:: getaddresses(fieldvalues)
+.. function:: getaddresses(fieldvalues, *, strict=True)
 
    This method returns a list of 2-tuples of the form returned by ``parseaddr()``.
    *fieldvalues* is a sequence of header field values as might be returned by
-   :meth:`Message.get_all <email.message.Message.get_all>`.  Here's a simple
-   example that gets all the recipients of a message::
+   :meth:`Message.get_all <email.message.Message.get_all>`.
+
+   If *strict* is true, use a strict parser which rejects malformed inputs.
+
+   Here's a simple example that gets all the recipients of a message::
 
       from email.utils import getaddresses
 
@@ -96,6 +104,9 @@ of the new API.
       resent_tos = msg.get_all('resent-to', [])
       resent_ccs = msg.get_all('resent-cc', [])
       all_recipients = getaddresses(tos + ccs + resent_tos + resent_ccs)
+
+   .. versionchanged:: 3.13
+      Add *strict* optional parameter and reject malformed inputs by default.
 
 
 .. function:: parsedate(date)

--- a/Doc/whatsnew/3.13.rst
+++ b/Doc/whatsnew/3.13.rst
@@ -200,6 +200,8 @@ email
   encountered instead of potentially inaccurate values. Add optional *strict*
   parameter to these two functions: use ``strict=False`` to get the old
   behavior, accept malformed inputs.
+  ``getattr(email.utils, 'supports_strict_parsing', False)`` can be use to
+  check if the *strict* paramater is available.
   (Contributed by Thomas Dwyer and Victor Stinner for :gh:`102988` to improve
   the CVE-2023-27043 fix.)
 

--- a/Doc/whatsnew/3.13.rst
+++ b/Doc/whatsnew/3.13.rst
@@ -200,8 +200,8 @@ email
   encountered instead of potentially inaccurate values. Add optional *strict*
   parameter to these two functions: use ``strict=False`` to get the old
   behavior, accept malformed inputs.
-  (Contributed by Thomas Dwyer for :gh:`102988` to improve the CVE-2023-27043
-  fix.)
+  (Contributed by Thomas Dwyer and Victor Stinner for :gh:`102988` to improve
+  the CVE-2023-27043 fix.)
 
 glob
 ----

--- a/Doc/whatsnew/3.13.rst
+++ b/Doc/whatsnew/3.13.rst
@@ -192,6 +192,17 @@ doctest
   :attr:`doctest.TestResults.skipped` attributes.
   (Contributed by Victor Stinner in :gh:`108794`.)
 
+email
+-----
+
+* :func:`email.utils.getaddresses` and :func:`email.utils.parseaddr` now return
+  ``('', '')`` 2-tuples in more situations where invalid email addresses are
+  encountered instead of potentially inaccurate values. Add optional *strict*
+  parameter to these two functions: use ``strict=False`` to get the old
+  behavior, accept malformed inputs.
+  (Contributed by Thomas Dwyer for :gh:`102988` to improve the CVE-2023-27043
+  fix.)
+
 glob
 ----
 

--- a/Lib/email/utils.py
+++ b/Lib/email/utils.py
@@ -138,7 +138,7 @@ def _strip_quoted_realnames(addr):
                 start = pos + 1
                 open_pos = None
 
-    if start < (len(addr) - 1):
+    if start < len(addr):
         result.append(addr[start:])
 
     return ''.join(result)

--- a/Lib/email/utils.py
+++ b/Lib/email/utils.py
@@ -153,17 +153,18 @@ def getaddresses(fieldvalues, *, strict=True):
     When parsing fails for a fieldvalue, a 2-tuple of ('', '') is returned in
     its place.
 
-    If strict is True, use a strict parser which rejects malformed inputs.
-    In this case, if the resulting list of parsed addresses is greater than
-    the number of fieldvalues in the input list, a parsing error has occurred
-    and consequently a list containing a single empty 2-tuple [('', '')] is
-    returned in its place. This is done to avoid invalid output.
-
-    Malformed input: getaddresses(['alice@example.com <bob@example.com>'])
-    Invalid output: [('', 'alice@example.com'), ('', 'bob@example.com')]
-    Safe output: [('', '')]
-
+    If strict is true, use a strict parser which rejects malformed inputs.
     """
+
+    # If strict is true, if the resulting list of parsed addresses is greater
+    # than the number of fieldvalues in the input list, a parsing error has
+    # occurred and consequently a list containing a single empty 2-tuple [('',
+    # '')] is returned in its place. This is done to avoid invalid output.
+    #
+    # Malformed input: getaddresses(['alice@example.com <bob@example.com>'])
+    # Invalid output: [('', 'alice@example.com'), ('', 'bob@example.com')]
+    # Safe output: [('', '')]
+
     if not strict:
         all = COMMASPACE.join(str(v) for v in fieldvalues)
         a = _AddressList(all)

--- a/Lib/email/utils.py
+++ b/Lib/email/utils.py
@@ -125,22 +125,21 @@ def _strip_quoted_realnames(addr):
         # Fast path
         return addr
 
-    start = None
-    remove = []
+    start = 0
+    open_pos = None
+    result = []
     for pos, ch in _iter_escaped_chars(addr):
         if ch == '"':
-            if start is None:
-                start = pos
+            if open_pos is None:
+                open_pos = pos
             else:
-                remove.append((start, pos))
-                start = None
+                if start != open_pos:
+                    result.append(addr[start:open_pos])
+                start = pos + 1
+                open_pos = None
 
-    result = []
-    pos = 0
-    for start, stop in remove:
-        result.append(addr[pos:start])
-        pos = stop + 1
-    result.append(addr[pos:])
+    if start < (len(addr) - 1):
+        result.append(addr[start:])
 
     return ''.join(result)
 

--- a/Lib/email/utils.py
+++ b/Lib/email/utils.py
@@ -146,6 +146,8 @@ def _strip_quoted_realnames(addr):
     return ''.join(result)
 
 
+supports_strict_parsing = True
+
 def getaddresses(fieldvalues, *, strict=True):
     """Return a list of (REALNAME, EMAIL) or ('','') for each fieldvalue.
 

--- a/Lib/email/utils.py
+++ b/Lib/email/utils.py
@@ -106,6 +106,10 @@ def formataddr(pair, charset='utf-8'):
 
 def _strip_quoted_realname(addr):
     """Remove real name between quotes."""
+    if '"' not in addr:
+        # Fast path
+        return addr
+
     pos = 0
     start = None
     remove = []
@@ -117,9 +121,6 @@ def _strip_quoted_realname(addr):
                 remove.append((start, pos))
                 start = None
         pos += 1
-
-    if not remove:
-        return addr
 
     result = []
     pos = 0

--- a/Lib/email/utils.py
+++ b/Lib/email/utils.py
@@ -172,7 +172,7 @@ def getaddresses(fieldvalues, *, strict=True):
 
     fieldvalues = [str(v) for v in fieldvalues]
     fieldvalues = _pre_parse_validation(fieldvalues)
-    addr = COMMASPACE.join(v for v in fieldvalues)
+    addr = COMMASPACE.join(fieldvalues)
     a = _AddressList(addr)
     result = _post_parse_validation(a.addresslist)
 

--- a/Lib/email/utils.py
+++ b/Lib/email/utils.py
@@ -108,14 +108,13 @@ def _iter_escaped_chars(addr):
     pos = 0
     escape = False
     for pos, ch in enumerate(addr):
-        if ch == '\\' and not escape:
+        if escape:
+            yield (pos, '\\' + ch)
+            escape = False
+        elif ch == '\\':
             escape = True
         else:
-            if escape:
-                yield (pos, '\\' + ch)
-            else:
-                yield (pos, ch)
-            escape = False
+            yield (pos, ch)
     if escape:
         yield (pos, '\\')
 

--- a/Lib/email/utils.py
+++ b/Lib/email/utils.py
@@ -104,8 +104,8 @@ def formataddr(pair, charset='utf-8'):
     return address
 
 
-def _strip_quoted_realname(addr):
-    """Remove real name between quotes."""
+def _strip_quoted_realnames(addr):
+    """Strip real names between quotes."""
     if '"' not in addr:
         # Fast path
         return addr
@@ -113,13 +113,18 @@ def _strip_quoted_realname(addr):
     pos = 0
     start = None
     remove = []
+    previous = None
     while pos < len(addr):
-        if addr[pos] == '"':
+        ch = addr[pos]
+        if ch == '"' and previous != '\\':
             if start is None:
                 start = pos
             else:
                 remove.append((start, pos))
                 start = None
+        elif ch == '\\' and previous == '\\':
+            previous = None
+        previous = ch
         pos += 1
 
     result = []
@@ -165,8 +170,8 @@ def getaddresses(fieldvalues, *, strict=True):
     n = 0
     for v in fieldvalues:
         # When a comma is used in the Real Name part it is not a deliminator.
-        # So strip those out before counting the commas
-        v = _strip_quoted_realname(v)
+        # So strip those out before counting the commas.
+        v = _strip_quoted_realnames(v)
         # Expected number of addresses: 1 + number of commas
         n += 1 + v.count(',')
     if len(result) != n:

--- a/Lib/test/test_email/test_email.py
+++ b/Lib/test/test_email/test_email.py
@@ -3329,7 +3329,7 @@ Foo
 
         # Test utils.getaddresses() and utils.parseaddr() on malformed email
         # addresses: default behavior (strict=True) rejects malformed address,
-        # and strict=True which tolerates malformed address.
+        # and strict=False which tolerates malformed address.
         for invalid_separator, expected_non_strict in (
             ('(', [(f'<{bob}>', alice)]),
             (')', [('', alice), empty, ('', bob)]),

--- a/Lib/test/test_email/test_email.py
+++ b/Lib/test/test_email/test_email.py
@@ -3321,6 +3321,23 @@ Foo
            [('Al Person', 'aperson@dom.ain'),
             ('Bud Person', 'bperson@dom.ain')])
 
+    def test_getaddresses_comma_in_name(self):
+        """GH-106669 regression test."""
+        self.assertEqual(
+            utils.getaddresses(
+                [
+                    '"Bud, Person" <bperson@dom.ain>',
+                    'aperson@dom.ain (Al Person)',
+                    '"Mariusz Felisiak" <to@example.com>',
+                ]
+            ),
+            [
+                ('Bud, Person', 'bperson@dom.ain'),
+                ('Al Person', 'aperson@dom.ain'),
+                ('Mariusz Felisiak', 'to@example.com'),
+            ],
+        )
+
     def test_parsing_errors(self):
         """Test for parsing errors from CVE-2023-27043 and CVE-2019-16056"""
         alice = 'alice@example.org'

--- a/Lib/test/test_email/test_email.py
+++ b/Lib/test/test_email/test_email.py
@@ -3676,12 +3676,23 @@ multipart/report
         def check(addr, expected):
             self.assertEqual(utils._strip_quoted_realnames(addr), expected)
 
-        check('Jane Doe <jane@example.net>, John Doe <john@example.net>',
-              'Jane Doe <jane@example.net>, John Doe <john@example.net>')
         check('"Jane Doe" <jane@example.net>, "John Doe" <john@example.net>',
               ' <jane@example.net>,  <john@example.net>')
         check(r'"Jane \"Doe\"." <jane@example.net>',
               ' <jane@example.net>')
+
+        # special cases
+        check(r'before"name"after', 'beforeafter')
+        check(r'before"name"', 'before')
+        check(r'"name"after', 'after')
+
+        # no change
+        for addr in (
+            'Jane Doe <jane@example.net>, John Doe <john@example.net>',
+            'lone " quote',
+        ):
+            self.assertEqual(utils._strip_quoted_realnames(addr), addr)
+
 
     def test_check_parenthesis(self):
         addr = 'alice@example.net'

--- a/Lib/test/test_email/test_email.py
+++ b/Lib/test/test_email/test_email.py
@@ -3684,7 +3684,10 @@ multipart/report
         # special cases
         check(r'before"name"after', 'beforeafter')
         check(r'before"name"', 'before')
+        check(r'b"name"', 'b')  # single char
         check(r'"name"after', 'after')
+        check(r'"name"a', 'a')  # single char
+        check(r'"name"', '')
 
         # no change
         for addr in (

--- a/Lib/test/test_email/test_email.py
+++ b/Lib/test/test_email/test_email.py
@@ -16,6 +16,7 @@ from unittest.mock import patch
 
 import email
 import email.policy
+import email.utils
 
 from email.charset import Charset
 from email.generator import Generator, DecodedGenerator, BytesGenerator
@@ -3404,6 +3405,9 @@ Foo
         self.assertEqual(utils.parseaddr([address]), empty)
         self.assertEqual(utils.parseaddr([address], strict=False),
                          ('', address))
+
+        # Test email.utils.supports_strict_parsing attribute
+        self.assertEqual(email.utils.supports_strict_parsing, True)
 
     def test_getaddresses_nasty(self):
         for addresses, expected in (

--- a/Misc/NEWS.d/next/Library/2023-10-20-15-28-08.gh-issue-102988.dStNO7.rst
+++ b/Misc/NEWS.d/next/Library/2023-10-20-15-28-08.gh-issue-102988.dStNO7.rst
@@ -2,5 +2,5 @@
 return ``('', '')`` 2-tuples in more situations where invalid email
 addresses are encountered instead of potentially inaccurate values. Add
 optional *strict* parameter to these two functions: use ``strict=False`` to
-get the old behavior, accept malformed inputs. Patch by Thomas Dwyer to
-improve the CVE-2023-27043 fix.
+get the old behavior, accept malformed inputs. Patch by Thomas Dwyer and Victor
+Stinner to improve the CVE-2023-27043 fix.

--- a/Misc/NEWS.d/next/Library/2023-10-20-15-28-08.gh-issue-102988.dStNO7.rst
+++ b/Misc/NEWS.d/next/Library/2023-10-20-15-28-08.gh-issue-102988.dStNO7.rst
@@ -1,0 +1,6 @@
+:func:`email.utils.getaddresses` and :func:`email.utils.parseaddr` now
+return ``('', '')`` 2-tuples in more situations where invalid email
+addresses are encountered instead of potentially inaccurate values. Add
+optional *strict* parameter to these two functions: use ``strict=False`` to
+get the old behavior, accept malformed inputs. Patch by Thomas Dwyer to
+improve the CVE-2023-27043 fix.

--- a/Misc/NEWS.d/next/Library/2023-10-20-15-28-08.gh-issue-102988.dStNO7.rst
+++ b/Misc/NEWS.d/next/Library/2023-10-20-15-28-08.gh-issue-102988.dStNO7.rst
@@ -2,5 +2,7 @@
 return ``('', '')`` 2-tuples in more situations where invalid email
 addresses are encountered instead of potentially inaccurate values. Add
 optional *strict* parameter to these two functions: use ``strict=False`` to
-get the old behavior, accept malformed inputs. Patch by Thomas Dwyer and Victor
+get the old behavior, accept malformed inputs.
+``getattr(email.utils, 'supports_strict_parsing', False)`` can be use to check
+if the *strict* paramater is available. Patch by Thomas Dwyer and Victor
 Stinner to improve the CVE-2023-27043 fix.


### PR DESCRIPTION
Detect email address parsing errors and return empty tuple to indicate the parsing error (old API). Add an optional 'strict' parameter to getaddresses() and parseaddr() functions. Patch by Thomas Dwyer.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-102988 -->
* Issue: gh-102988
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--111116.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->