### PR TITLE
gh-111132: Fix crash on interactive_filename in `run_mod`

### DIFF
--- a/Lib/test/test_cmd_line_script.py
+++ b/Lib/test/test_cmd_line_script.py
@@ -684,6 +684,17 @@ class CmdLineTest(unittest.TestCase):
                     ]
                 )
 
+    def test_syntaxerror_does_not_crash(self):
+        script = "nonlocal x\n"
+        with os_helper.temp_dir() as script_dir:
+            script_name = _make_test_script(script_dir, 'script', script)
+            exitcode, stdout, stderr = assert_python_failure(script_name)
+            text = io.TextIOWrapper(io.BytesIO(stderr), 'ascii').read()
+            # It used to crash in https://github.com/python/cpython/issues/111132
+            self.assertTrue(text.endswith(
+                'SyntaxError: nonlocal declaration not allowed at module level\n',
+            ), text)
+
     def test_consistent_sys_path_for_direct_execution(self):
         # This test case ensures that the following all give the same
         # sys.path configuration:

--- a/Python/pythonrun.c
+++ b/Python/pythonrun.c
@@ -1277,7 +1277,9 @@ run_mod(mod_ty mod, PyObject *filename, PyObject *globals, PyObject *locals,
 
     PyCodeObject *co = _PyAST_Compile(mod, interactive_filename, flags, -1, arena);
     if (co == NULL) {
-        Py_DECREF(interactive_filename);
+        if (interactive_src) {
+            Py_DECREF(interactive_filename);
+        }
         return NULL;
     }
 


### PR DESCRIPTION
Here's what happens (at least in my understanding): we only change `interactive_filename` to a new object if `interactive_src` is set. https://github.com/python/cpython/commit/e1d8c65e1df990ef8d61b8912742e1a021395e78

But, otherwise, it still remains an old https://github.com/python/cpython/commit/e1d8c65e1df990ef8d61b8912742e1a021395e78#diff-2ecd9b536bc387479d824dc4b53f89679d6978d25c6b8a28ab21ed03e745e46eR1270 `filename` object.

So, I guess that we only need to decref this object when `interactive_src` is set.

<!-- gh-issue-number: gh-111132 -->
* Issue: gh-111132
<!-- /gh-issue-number -->
