### PR TITLE
gh-111157: Mention `__notes__` in `traceback.format_exception_only` docstring

### DIFF
--- a/Lib/traceback.py
+++ b/Lib/traceback.py
@@ -156,7 +156,8 @@ def format_exception_only(exc, /, value=_sentinel):
     Normally, the list contains a single string; however, for
     SyntaxError exceptions, it contains several lines that (when
     printed) display detailed information about where the syntax
-    error occurred.
+    error occurred. Following the message, the list
+    contains the exception's ``__notes__``.
 
     The message indicating which exception occurred is always the last
     string in the list.
@@ -860,7 +861,8 @@ class TracebackException:
         Normally, the generator emits a single string; however, for
         SyntaxError exceptions, it emits several lines that (when
         printed) display detailed information about where the syntax
-        error occurred.
+        error occurred. Following the message, the list
+        contains the exception's ``__notes__``.
 
         The message indicating which exception occurred is always the last
         string in the output.

--- a/Lib/traceback.py
+++ b/Lib/traceback.py
@@ -860,7 +860,7 @@ class TracebackException:
         several lines that (when printed)
         display detailed information about where the syntax error occurred.
         Following the message, generator also yields
-        all exception's ``__notes__``.
+        all the exception's ``__notes__``.
         """
 
         indent = 3 * _depth * ' '

--- a/Lib/traceback.py
+++ b/Lib/traceback.py
@@ -153,15 +153,11 @@ def format_exception_only(exc, /, value=_sentinel):
 
     The return value is a list of strings, each ending in a newline.
 
-    Normally, the list contains a single string; however, for
-    SyntaxError exceptions, it contains several lines that (when
-    printed) display detailed information about where the syntax
-    error occurred. Following the message, the list
+    The list contains the exception's message, which is
+    normally a single string; however, for :exc:`SyntaxError` exceptions, it
+    contains several lines that (when printed) display detailed information
+    about where the syntax error occurred. Following the message, the list
     contains the exception's ``__notes__``.
-
-    The message indicating which exception occurred is always the last
-    string in the list.
-
     """
     if value is _sentinel:
         value = exc
@@ -858,14 +854,12 @@ class TracebackException:
 
         The return value is a generator of strings, each ending in a newline.
 
-        Normally, the generator emits a single string; however, for
-        SyntaxError exceptions, it emits several lines that (when
-        printed) display detailed information about where the syntax
-        error occurred. Following the message, the list
-        contains the exception's ``__notes__``.
-
-        The message indicating which exception occurred is always the last
-        string in the output.
+        Generator normally yields a single string;
+        however, for :exc:`SyntaxError` exceptions, it
+        contains several lines that (when printed) display detailed information
+        about where the syntax error occurred.
+        Following the message, generator also emits
+        all exception's ``__notes__``.
         """
 
         indent = 3 * _depth * ' '

--- a/Lib/traceback.py
+++ b/Lib/traceback.py
@@ -854,11 +854,12 @@ class TracebackException:
 
         The return value is a generator of strings, each ending in a newline.
 
-        Generator normally yields a single string;
-        however, for :exc:`SyntaxError` exceptions, it
-        contains several lines that (when printed) display detailed information
-        about where the syntax error occurred.
-        Following the message, generator also emits
+        Generator yields the exception message.
+        For :exc:`SyntaxError` exceptions, it
+        also yields (before the exception message)
+        several lines that (when printed)
+        display detailed information about where the syntax error occurred.
+        Following the message, generator also yields
         all exception's ``__notes__``.
         """
 


### PR DESCRIPTION


<!-- gh-issue-number: gh-111157 -->
* Issue: gh-111157
<!-- /gh-issue-number -->
