### PR TITLE
[3.11] gh-110918: regrtest: allow to intermix --match and --ignore options (GH-110919)

### DIFF
--- a/Lib/test/libregrtest/findtests.py
+++ b/Lib/test/libregrtest/findtests.py
@@ -5,7 +5,7 @@ import unittest
 from test import support
 
 from .utils import (
-    StrPath, TestName, TestTuple, TestList, FilterTuple,
+    StrPath, TestName, TestTuple, TestList, TestFilter,
     abs_module_name, count, printlist)
 
 
@@ -82,11 +82,10 @@ def _list_cases(suite):
                 print(test.id())
 
 def list_cases(tests: TestTuple, *,
-               match_tests: FilterTuple | None = None,
-               ignore_tests: FilterTuple | None = None,
+               match_tests: TestFilter | None = None,
                test_dir: StrPath | None = None):
     support.verbose = False
-    support.set_match_tests(match_tests, ignore_tests)
+    support.set_match_tests(match_tests)
 
     skipped = []
     for test_name in tests:

--- a/Lib/test/libregrtest/main.py
+++ b/Lib/test/libregrtest/main.py
@@ -19,7 +19,7 @@ from .runtests import RunTests, HuntRefleak
 from .setup import setup_process, setup_test_dir
 from .single import run_single_test, PROGRESS_MIN_TIME
 from .utils import (
-    StrPath, StrJSON, TestName, TestList, TestTuple, FilterTuple,
+    StrPath, StrJSON, TestName, TestList, TestTuple, TestFilter,
     strip_py_suffix, count, format_duration,
     printlist, get_temp_dir, get_work_dir, exit_timeout,
     display_header, cleanup_temp_dir, print_warning,
@@ -78,14 +78,7 @@ class Regrtest:
                                            and ns._add_python_opts)
 
         # Select tests
-        if ns.match_tests:
-            self.match_tests: FilterTuple | None = tuple(ns.match_tests)
-        else:
-            self.match_tests = None
-        if ns.ignore_tests:
-            self.ignore_tests: FilterTuple | None = tuple(ns.ignore_tests)
-        else:
-            self.ignore_tests = None
+        self.match_tests: TestFilter = ns.match_tests
         self.exclude: bool = ns.exclude
         self.fromfile: StrPath | None = ns.fromfile
         self.starting_test: TestName | None = ns.start
@@ -389,7 +382,7 @@ class Regrtest:
 
     def display_summary(self):
         duration = time.perf_counter() - self.logger.start_time
-        filtered = bool(self.match_tests) or bool(self.ignore_tests)
+        filtered = bool(self.match_tests)
 
         # Total duration
         print()
@@ -407,7 +400,6 @@ class Regrtest:
             fail_fast=self.fail_fast,
             fail_env_changed=self.fail_env_changed,
             match_tests=self.match_tests,
-            ignore_tests=self.ignore_tests,
             match_tests_dict=None,
             rerun=False,
             forever=self.forever,
@@ -660,7 +652,6 @@ class Regrtest:
         elif self.want_list_cases:
             list_cases(selected,
                        match_tests=self.match_tests,
-                       ignore_tests=self.ignore_tests,
                        test_dir=self.test_dir)
         else:
             exitcode = self.run_tests(selected, tests)

--- a/Lib/test/libregrtest/run_workers.py
+++ b/Lib/test/libregrtest/run_workers.py
@@ -261,7 +261,7 @@ class WorkerThread(threading.Thread):
 
         kwargs = {}
         if match_tests:
-            kwargs['match_tests'] = match_tests
+            kwargs['match_tests'] = [(test, True) for test in match_tests]
         if self.runtests.output_on_failure:
             kwargs['verbose'] = True
             kwargs['output_on_failure'] = False

--- a/Lib/test/libregrtest/runtests.py
+++ b/Lib/test/libregrtest/runtests.py
@@ -8,7 +8,7 @@ from typing import Any
 from test import support
 
 from .utils import (
-    StrPath, StrJSON, TestTuple, FilterTuple, FilterDict)
+    StrPath, StrJSON, TestTuple, TestFilter, FilterTuple, FilterDict)
 
 
 class JsonFileType:
@@ -72,8 +72,7 @@ class RunTests:
     tests: TestTuple
     fail_fast: bool
     fail_env_changed: bool
-    match_tests: FilterTuple | None
-    ignore_tests: FilterTuple | None
+    match_tests: TestFilter
     match_tests_dict: FilterDict | None
     rerun: bool
     forever: bool

--- a/Lib/test/libregrtest/setup.py
+++ b/Lib/test/libregrtest/setup.py
@@ -92,7 +92,7 @@ def setup_tests(runtests: RunTests):
     support.PGO = runtests.pgo
     support.PGO_EXTENDED = runtests.pgo_extended
 
-    support.set_match_tests(runtests.match_tests, runtests.ignore_tests)
+    support.set_match_tests(runtests.match_tests)
 
     if runtests.use_junit:
         support.junit_xml_list = []

--- a/Lib/test/libregrtest/utils.py
+++ b/Lib/test/libregrtest/utils.py
@@ -52,6 +52,7 @@ TestTuple = tuple[TestName, ...]
 TestList = list[TestName]
 # --match and --ignore options: list of patterns
 # ('*' joker character can be used)
+TestFilter = list[tuple[TestName, bool]]
 FilterTuple = tuple[TestName, ...]
 FilterDict = dict[TestName, FilterTuple]
 

--- a/Lib/test/libregrtest/worker.py
+++ b/Lib/test/libregrtest/worker.py
@@ -10,7 +10,7 @@ from .setup import setup_process, setup_test_dir
 from .runtests import RunTests, JsonFile, JsonFileType
 from .single import run_single_test
 from .utils import (
-    StrPath, StrJSON, FilterTuple,
+    StrPath, StrJSON, TestFilter,
     get_temp_dir, get_work_dir, exit_timeout)
 
 
@@ -73,7 +73,7 @@ def create_worker_process(runtests: RunTests, output_fd: int,
 def worker_process(worker_json: StrJSON) -> NoReturn:
     runtests = RunTests.from_json(worker_json)
     test_name = runtests.tests[0]
-    match_tests: FilterTuple | None = runtests.match_tests
+    match_tests: TestFilter = runtests.match_tests
     json_file: JsonFile = runtests.json_file
 
     setup_test_dir(runtests.test_dir)
@@ -81,7 +81,7 @@ def worker_process(worker_json: StrJSON) -> NoReturn:
 
     if runtests.rerun:
         if match_tests:
-            matching = "matching: " + ", ".join(match_tests)
+            matching = "matching: " + ", ".join(pattern for pattern, result in match_tests if result)
             print(f"Re-running {test_name} in verbose mode ({matching})", flush=True)
         else:
             print(f"Re-running {test_name} in verbose mode", flush=True)

--- a/Lib/test/support/__init__.py
+++ b/Lib/test/support/__init__.py
@@ -6,7 +6,9 @@ if __name__ != 'test.support':
 import contextlib
 import dataclasses
 import functools
+import itertools
 import getpass
+import operator
 import os
 import re
 import stat
@@ -1172,18 +1174,17 @@ def _run_suite(suite):
 
 
 # By default, don't filter tests
-_match_test_func = None
-
-_accept_test_patterns = None
-_ignore_test_patterns = None
+_test_matchers = ()
+_test_patterns = ()
 
 
 def match_test(test):
     # Function used by support.run_unittest() and regrtest --list-cases
-    if _match_test_func is None:
-        return True
-    else:
-        return _match_test_func(test.id())
+    result = False
+    for matcher, result in reversed(_test_matchers):
+        if matcher(test.id()):
+            return result
+    return not result
 
 
 def _is_full_match_test(pattern):
@@ -1196,47 +1197,30 @@ def _is_full_match_test(pattern):
     return ('.' in pattern) and (not re.search(r'[?*\[\]]', pattern))
 
 
-def set_match_tests(accept_patterns=None, ignore_patterns=None):
-    global _match_test_func, _accept_test_patterns, _ignore_test_patterns
+def set_match_tests(patterns):
+    global _test_matchers, _test_patterns
 
-    if accept_patterns is None:
-        accept_patterns = ()
-    if ignore_patterns is None:
-        ignore_patterns = ()
-
-    accept_func = ignore_func = None
-
-    if accept_patterns != _accept_test_patterns:
-        accept_patterns, accept_func = _compile_match_function(accept_patterns)
-    if ignore_patterns != _ignore_test_patterns:
-        ignore_patterns, ignore_func = _compile_match_function(ignore_patterns)
-
-    # Create a copy since patterns can be mutable and so modified later
-    _accept_test_patterns = tuple(accept_patterns)
-    _ignore_test_patterns = tuple(ignore_patterns)
-
-    if accept_func is not None or ignore_func is not None:
-        def match_function(test_id):
-            accept = True
-            ignore = False
-            if accept_func:
-                accept = accept_func(test_id)
-            if ignore_func:
-                ignore = ignore_func(test_id)
-            return accept and not ignore
-
-        _match_test_func = match_function
+    if not patterns:
+        _test_matchers = ()
+        _test_patterns = ()
+    else:
+        itemgetter = operator.itemgetter
+        patterns = tuple(patterns)
+        if patterns != _test_patterns:
+            _test_matchers = [
+                (_compile_match_function(map(itemgetter(0), it)), result)
+                for result, it in itertools.groupby(patterns, itemgetter(1))
+            ]
+            _test_patterns = patterns
 
 
 def _compile_match_function(patterns):
-    if not patterns:
-        func = None
-        # set_match_tests(None) behaves as set_match_tests(())
-        patterns = ()
-    elif all(map(_is_full_match_test, patterns)):
+    patterns = list(patterns)
+
+    if all(map(_is_full_match_test, patterns)):
         # Simple case: all patterns are full test identifier.
         # The test.bisect_cmd utility only uses such full test identifiers.
-        func = set(patterns).__contains__
+        return set(patterns).__contains__
     else:
         import fnmatch
         regex = '|'.join(map(fnmatch.translate, patterns))
@@ -1244,7 +1228,7 @@ def _compile_match_function(patterns):
         # don't use flags=re.IGNORECASE
         regex_match = re.compile(regex).match
 
-        def match_test_regex(test_id):
+        def match_test_regex(test_id, regex_match=regex_match):
             if regex_match(test_id):
                 # The regex matches the whole identifier, for example
                 # 'test.test_os.FileTests.test_access'.
@@ -1255,9 +1239,7 @@ def _compile_match_function(patterns):
                 # into: 'test', 'test_os', 'FileTests' and 'test_access'.
                 return any(map(regex_match, test_id.split(".")))
 
-        func = match_test_regex
-
-    return patterns, func
+        return match_test_regex
 
 
 def run_unittest(*classes):

--- a/Misc/NEWS.d/next/Tests/2023-10-16-13-47-24.gh-issue-110918.aFgZK3.rst
+++ b/Misc/NEWS.d/next/Tests/2023-10-16-13-47-24.gh-issue-110918.aFgZK3.rst
@@ -1,0 +1,4 @@
+Test case matching patterns specified by options ``--match``, ``--ignore``,
+``--matchfile`` and ``--ignorefile`` are now tested in the order of
+specification, and the last match determines whether the test case be run or
+ignored.


### PR DESCRIPTION
Test case matching patterns specified by options --match, --ignore, --matchfile and --ignorefile are now tested in the order of specification, and the last match determines whether the test case be run or ignored.
(cherry picked from commit 9a1fe09622cd0f1e24c2ba5335c94c5d70306fd0)


<!-- gh-issue-number: gh-110918 -->
* Issue: gh-110918
<!-- /gh-issue-number -->
