### PR TITLE
gh-101100: Fix sphinx warnings in `library/asyncio-dev.rst`

### DIFF
--- a/Doc/library/asyncio-eventloop.rst
+++ b/Doc/library/asyncio-eventloop.rst
@@ -1395,7 +1395,7 @@ Enabling debug mode
 
    This attribute can be used to set the
    minimum execution duration in seconds that is considered "slow".
-   "Slow" callbacks are logged.
+   When debug mode is enabled, "slow" callbacks are logged.
 
    Default value is 100 milliseconds.
 

--- a/Doc/library/asyncio-eventloop.rst
+++ b/Doc/library/asyncio-eventloop.rst
@@ -1393,7 +1393,7 @@ Enabling debug mode
 
 .. attribute:: loop.slow_callback_duration
 
-   When debug mode is enabled, this attribute can be used to set the
+   This attribute can be used to set the
    minimum execution duration in seconds that is considered "slow".
    "Slow" callbacks are logged.
 

--- a/Doc/library/asyncio-eventloop.rst
+++ b/Doc/library/asyncio-eventloop.rst
@@ -243,9 +243,9 @@ Scheduling callbacks
    See the :ref:`concurrency and multithreading <asyncio-multithreading>`
    section of the documentation.
 
-.. versionchanged:: 3.7
-   The *context* keyword-only parameter was added. See :pep:`567`
-   for more details.
+   .. versionchanged:: 3.7
+      The *context* keyword-only parameter was added. See :pep:`567`
+      for more details.
 
 .. _asyncio-pass-keywords:
 
@@ -1390,6 +1390,14 @@ Enabling debug mode
 
       The new :ref:`Python Development Mode <devmode>` can now also be used
       to enable the debug mode.
+
+.. attribute:: loop.slow_callback_duration
+
+   When debug mode is enabled, this attribute can be used to set the
+   minimum execution duration in seconds that is considered "slow".
+   "Slow" callbacks are logged.
+
+   Default value is 100 milliseconds.
 
 .. seealso::
 

--- a/Doc/tools/.nitignore
+++ b/Doc/tools/.nitignore
@@ -30,7 +30,6 @@ Doc/howto/logging.rst
 Doc/howto/urllib2.rst
 Doc/library/abc.rst
 Doc/library/ast.rst
-Doc/library/asyncio-dev.rst
 Doc/library/asyncio-eventloop.rst
 Doc/library/asyncio-extending.rst
 Doc/library/asyncio-policy.rst


### PR DESCRIPTION
Please, note that this change is not about `asyncio-eventloop.rst`, but is about `asyncio-dev.rst` which just happens to reference `asyncio-eventloop.rst`:

```
/Users/sobolev/Desktop/cpython/Doc/library/asyncio-dev.rst:60: WARNING: py:attr reference target not found: loop.slow_callback_duration
```

I've also fixed one `asyncio-eventloop.rst` problem, which cannot be detected by Sphinx (just because I saw it):
<img width="786" alt="Снимок экрана 2023-10-22 в 17 09 31" src="https://github.com/python/cpython/assets/4660275/d908b165-8b5b-49e6-b251-4863fdfc6dfd">

I've moved the `.. versionchanged` inside the function body.

In the next PR I will fix warnings specific to `asyncio-eventloop.rst`.

<!-- gh-issue-number: gh-101100 -->
* Issue: gh-101100
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--111179.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->