### PR TITLE
gh-111187: Postpone removal version for locale.getdefaultlocale() to 3.15

### DIFF
--- a/Doc/library/locale.rst
+++ b/Doc/library/locale.rst
@@ -303,7 +303,7 @@ The :mod:`locale` module defines the following exception and functions:
    *language code* and *encoding* may be ``None`` if their values cannot be
    determined.
 
-   .. deprecated-removed:: 3.11 3.13
+   .. deprecated-removed:: 3.11 3.15
 
 
 .. function:: getlocale(category=LC_CTYPE)

--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -1798,7 +1798,7 @@ Standard Library
   * :func:`importlib.resources.path`
 
 * The :func:`locale.getdefaultlocale` function is deprecated and will be
-  removed in Python 3.13. Use :func:`locale.setlocale`,
+  removed in Python 3.15. Use :func:`locale.setlocale`,
   :func:`locale.getpreferredencoding(False) <locale.getpreferredencoding>` and
   :func:`locale.getlocale` functions instead.
   (Contributed by Victor Stinner in :gh:`90817`.)

--- a/Doc/whatsnew/3.12.rst
+++ b/Doc/whatsnew/3.12.rst
@@ -1360,7 +1360,6 @@ Other modules:
 APIs:
 
 * :class:`!configparser.LegacyInterpolation` (:gh:`90765`)
-* :func:`locale.getdefaultlocale` (:gh:`90817`)
 * ``locale.resetlocale()`` (:gh:`90817`)
 * :meth:`!turtle.RawTurtle.settiltangle` (:gh:`50096`)
 * :func:`!unittest.findTestCases` (:gh:`50096`)
@@ -1429,6 +1428,17 @@ and will be removed in Python 3.14.
 * The ``__package__`` and ``__cached__`` attributes on module objects.
 
 * The ``co_lnotab`` attribute of code objects.
+
+Pending Removal in Python 3.15
+------------------------------
+
+The following APIs have been deprecated
+and will be removed in Python 3.15.
+
+APIs:
+
+* :func:`locale.getdefaultlocale` (:gh:`90817`)
+
 
 Pending Removal in Future Versions
 ----------------------------------

--- a/Doc/whatsnew/3.13.rst
+++ b/Doc/whatsnew/3.13.rst
@@ -500,6 +500,13 @@ Pending Removal in Python 3.15
   rarely used.  No direct replacement exists.  *Anything* is better than CGI
   to interface a web server with a request handler.
 
+* :class:`locale`: :func:`locale.getdefaultlocale` was deprecated in Python 3.11
+  and originally planned for removal in Python 3.13 (:gh:`90817`),
+  but removal has been postponed to Python 3.15.
+  Use :func:`locale.setlocale()`, :func:`locale.getencoding()` and
+  :func:`locale.getlocale()` instead.
+  (Contributed by Hugo van Kemenade in :gh:`111187`.)
+
 * :class:`typing.NamedTuple`:
 
   * The undocumented keyword argument syntax for creating NamedTuple classes
@@ -611,10 +618,6 @@ although there is currently no date scheduled for their removal.
   Use ``files()`` instead.  Refer to `importlib-resources: Migrating from Legacy
   <https://importlib-resources.readthedocs.io/en/latest/using.html#migrating-from-legacy>`_
   for migration advice.
-
-* :func:`locale.getdefaultlocale`: use :func:`locale.setlocale()`,
-  :func:`locale.getencoding()` and :func:`locale.getlocale()` instead
-  (:gh:`90817`)
 
 * :mod:`mailbox`: Use of StringIO input and text mode is deprecated, use
   BytesIO and binary mode instead.

--- a/Lib/locale.py
+++ b/Lib/locale.py
@@ -541,11 +541,13 @@ def getdefaultlocale(envvars=('LC_ALL', 'LC_CTYPE', 'LANG', 'LANGUAGE')):
     """
 
     import warnings
-    warnings.warn(
-        "Use setlocale(), getencoding() and getlocale() instead",
-        DeprecationWarning, stacklevel=2
-    )
+    warnings._deprecated(
+        "locale.getdefaultlocale",
+        "{name!r} is deprecated and slated for removal in Python {remove}. "
+        "Use setlocale(), getencoding() and getlocale() instead.",
+        remove=(3, 15))
     return _getdefaultlocale(envvars)
+
 
 def _getdefaultlocale(envvars=('LC_ALL', 'LC_CTYPE', 'LANG', 'LANGUAGE')):
     try:

--- a/Misc/NEWS.d/next/Library/2023-10-22-21-28-05.gh-issue-111187._W11Ab.rst
+++ b/Misc/NEWS.d/next/Library/2023-10-22-21-28-05.gh-issue-111187._W11Ab.rst
@@ -1,0 +1,1 @@
+Postpone removal version for locale.getdefaultlocale() to Python 3.15.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

Should we update What's New in 3.11 and 3.12?

Should we backport these changes to 3.11 and 3.12?


<!-- gh-issue-number: gh-111187 -->
* Issue: gh-111187
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--111188.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->