### PR TITLE
Fix typo in 3.13's whatsnew

### DIFF
--- a/Doc/whatsnew/3.13.rst
+++ b/Doc/whatsnew/3.13.rst
@@ -116,7 +116,7 @@ Other Language Changes
   the file is not accessible.
   (Contributed by Moonsik Park in :gh:`82367`.)
 
-* Fixed a bug where a :keyword:`global` decleration in an :keyword:`except` block
+* Fixed a bug where a :keyword:`global` declaration in an :keyword:`except` block
   is rejected when the global is used in the :keyword:`else` block.
   (Contributed by Irit Katriel in :gh:`111123`.)
 


### PR DESCRIPTION
Replace `decleration` with `declaration`.


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--111215.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->