### PR TITLE
gh-101100: Fix sphinx warnings in `library/asyncio-eventloop.rst`

### DIFF
--- a/Doc/library/asyncio-eventloop.rst
+++ b/Doc/library/asyncio-eventloop.rst
@@ -509,7 +509,7 @@ Opening network connections
 
    .. versionchanged:: 3.6
 
-      The socket option :py:const:`~socket.TCP_NODELAY` is set by default
+      The socket option :ref:`socket.TCP_NODELAY <unix-constants>` is set by default
       for all TCP connections.
 
    .. versionchanged:: 3.7
@@ -581,7 +581,7 @@ Opening network connections
    * *reuse_port* tells the kernel to allow this endpoint to be bound to the
      same port as other existing endpoints are bound to, so long as they all
      set this flag when being created. This option is not supported on Windows
-     and some Unixes. If the :py:const:`~socket.SO_REUSEPORT` constant is not
+     and some Unixes. If the :ref:`socket.SO_REUSEPORT <unix-constants>` constant is not
      defined then this capability is unsupported.
 
    * *allow_broadcast* tells the kernel to allow this endpoint to send
@@ -607,7 +607,8 @@ Opening network connections
 
    .. versionchanged:: 3.8.1
       The *reuse_address* parameter is no longer supported, as using
-      :py:const:`~sockets.SO_REUSEADDR` poses a significant security concern for
+      :ref:`socket.SO_REUSEADDR <unix-constants>`
+      poses a significant security concern for
       UDP. Explicitly passing ``reuse_address=True`` will raise an exception.
 
       When multiple processes with differing UIDs assign sockets to an
@@ -616,7 +617,8 @@ Opening network connections
 
       For supported platforms, *reuse_port* can be used as a replacement for
       similar functionality. With *reuse_port*,
-      :py:const:`~sockets.SO_REUSEPORT` is used instead, which specifically
+      :ref:`socket.SO_REUSEPORT <unix-constants>`
+      is used instead, which specifically
       prevents processes with differing UIDs from assigning sockets to the same
       socket address.
 
@@ -756,7 +758,7 @@ Creating network servers
    .. versionchanged:: 3.6
 
       Added *ssl_handshake_timeout* and *start_serving* parameters.
-      The socket option :py:const:`~socket.TCP_NODELAY` is set by default
+      The socket option :ref:`socket.TCP_NODELAY <unix-constants>` is set by default
       for all TCP connections.
 
    .. versionchanged:: 3.11
@@ -1888,7 +1890,7 @@ Set signal handlers for SIGINT and SIGTERM
 
 (This ``signals`` example only works on Unix.)
 
-Register handlers for signals :py:data:`SIGINT` and :py:data:`SIGTERM`
+Register handlers for signals :const:`~signal.SIGINT` and :const:`~signal.SIGTERM`
 using the :meth:`loop.add_signal_handler` method::
 
     import asyncio

--- a/Doc/library/asyncio-eventloop.rst
+++ b/Doc/library/asyncio-eventloop.rst
@@ -509,7 +509,7 @@ Opening network connections
 
    .. versionchanged:: 3.6
 
-      The socket option :ref:`socket.TCP_NODELAY <unix-constants>` is set by default
+      The socket option :ref:`socket.TCP_NODELAY <socket-unix-constants>` is set by default
       for all TCP connections.
 
    .. versionchanged:: 3.7
@@ -581,7 +581,7 @@ Opening network connections
    * *reuse_port* tells the kernel to allow this endpoint to be bound to the
      same port as other existing endpoints are bound to, so long as they all
      set this flag when being created. This option is not supported on Windows
-     and some Unixes. If the :ref:`socket.SO_REUSEPORT <unix-constants>` constant is not
+     and some Unixes. If the :ref:`socket.SO_REUSEPORT <socket-unix-constants>` constant is not
      defined then this capability is unsupported.
 
    * *allow_broadcast* tells the kernel to allow this endpoint to send
@@ -607,7 +607,7 @@ Opening network connections
 
    .. versionchanged:: 3.8.1
       The *reuse_address* parameter is no longer supported, as using
-      :ref:`socket.SO_REUSEADDR <unix-constants>`
+      :ref:`socket.SO_REUSEADDR <socket-unix-constants>`
       poses a significant security concern for
       UDP. Explicitly passing ``reuse_address=True`` will raise an exception.
 
@@ -617,7 +617,7 @@ Opening network connections
 
       For supported platforms, *reuse_port* can be used as a replacement for
       similar functionality. With *reuse_port*,
-      :ref:`socket.SO_REUSEPORT <unix-constants>`
+      :ref:`socket.SO_REUSEPORT <socket-unix-constants>`
       is used instead, which specifically
       prevents processes with differing UIDs from assigning sockets to the same
       socket address.
@@ -758,7 +758,7 @@ Creating network servers
    .. versionchanged:: 3.6
 
       Added *ssl_handshake_timeout* and *start_serving* parameters.
-      The socket option :ref:`socket.TCP_NODELAY <unix-constants>` is set by default
+      The socket option :ref:`socket.TCP_NODELAY <socket-unix-constants>` is set by default
       for all TCP connections.
 
    .. versionchanged:: 3.11

--- a/Doc/library/socket.rst
+++ b/Doc/library/socket.rst
@@ -352,6 +352,12 @@ Constants
    defined then this protocol is unsupported.  More constants may be available
    depending on the system.
 
+.. data:: AF_UNSPEC
+
+   The value :const:`AF_UNSPEC` indicates that
+   :func:`getaddrinfo` should return socket addresses for any
+   address family (either IPv4 or IPv6, for example) that can
+   be used with node and service.
 
 .. data:: SOCK_STREAM
           SOCK_DGRAM
@@ -379,6 +385,8 @@ Constants
    .. availability:: Linux >= 2.6.27.
 
    .. versionadded:: 3.2
+
+.. _unix-constants:
 
 .. data:: SO_*
           SOMAXCONN

--- a/Doc/library/socket.rst
+++ b/Doc/library/socket.rst
@@ -354,10 +354,9 @@ Constants
 
 .. data:: AF_UNSPEC
 
-   The value :const:`AF_UNSPEC` indicates that
+   :const:`AF_UNSPEC` means that
    :func:`getaddrinfo` should return socket addresses for any
-   address family (either IPv4 or IPv6, for example) that can
-   be used with node and service.
+   address family (either IPv4, IPv6, or any other) that can be used.
 
 .. data:: SOCK_STREAM
           SOCK_DGRAM

--- a/Doc/library/socket.rst
+++ b/Doc/library/socket.rst
@@ -386,7 +386,7 @@ Constants
 
    .. versionadded:: 3.2
 
-.. _unix-constants:
+.. _socket-unix-constants:
 
 .. data:: SO_*
           SOMAXCONN

--- a/Doc/tools/.nitignore
+++ b/Doc/tools/.nitignore
@@ -30,7 +30,6 @@ Doc/howto/logging.rst
 Doc/howto/urllib2.rst
 Doc/library/abc.rst
 Doc/library/ast.rst
-Doc/library/asyncio-eventloop.rst
 Doc/library/asyncio-extending.rst
 Doc/library/asyncio-policy.rst
 Doc/library/asyncio-stream.rst


### PR DESCRIPTION
Before:

```
/Users/sobolev/Desktop/cpython/Doc/library/asyncio-eventloop.rst:512: WARNING: py:const reference target not found: socket.TCP_NODELAY
/Users/sobolev/Desktop/cpython/Doc/library/asyncio-eventloop.rst:581: WARNING: py:const reference target not found: socket.SO_REUSEPORT
/Users/sobolev/Desktop/cpython/Doc/library/asyncio-eventloop.rst:609: WARNING: py:const reference target not found: sockets.SO_REUSEADDR
/Users/sobolev/Desktop/cpython/Doc/library/asyncio-eventloop.rst:617: WARNING: py:const reference target not found: sockets.SO_REUSEPORT
/Users/sobolev/Desktop/cpython/Doc/library/asyncio-eventloop.rst:702: WARNING: py:const reference target not found: socket.AF_UNSPEC
/Users/sobolev/Desktop/cpython/Doc/library/asyncio-eventloop.rst:758: WARNING: py:const reference target not found: socket.TCP_NODELAY
/Users/sobolev/Desktop/cpython/Doc/library/asyncio-eventloop.rst:1891: WARNING: py:data reference target not found: SIGINT
/Users/sobolev/Desktop/cpython/Doc/library/asyncio-eventloop.rst:1891: WARNING: py:data reference target not found: SIGTERM
```

So, what I did?
1. I've added `unix-constants` reference, better name is appreciated, because not all constants under `TCP_*` are explicitly documented. I don't think that there's clean a way to do that
2. I've also documented `AF_UNSPEC`, because it is rather special. I took the wording from https://man7.org/linux/man-pages/man3/getaddrinfo.3.html

<!-- gh-issue-number: gh-101100 -->
* Issue: gh-101100
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--111222.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->