### PR TITLE
Document the args to create an addinfourl object

### DIFF
--- a/Doc/library/urllib.request.rst
+++ b/Doc/library/urllib.request.rst
@@ -1588,7 +1588,7 @@ minimal file-like interface, including ``read()`` and ``readline()``.
 Functions defined by this module are used internally by the :mod:`urllib.request` module.
 The typical response object is a :class:`urllib.response.addinfourl` instance:
 
-.. class:: addinfourl
+.. class:: addinfourl(fp, headers, url, code=None)
 
    .. attribute:: url
 


### PR DESCRIPTION
The docs for the `urllib.response.addinfourl` class weren't showing what parameters it took to create a new instance.

<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--111235.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->