### PR TITLE
gh-94438: Add additional cases to mark_stacks with tests

### DIFF
--- a/Lib/test/test_sys_settrace.py
+++ b/Lib/test/test_sys_settrace.py
@@ -2089,7 +2089,7 @@ class JumpTestCase(unittest.TestCase):
         else:
             output.append(5)
 
-    @jump_test(6, 2, [5, 5, 6])
+    @jump_test(6, 5, [5, 5, 6])
     def test_jump_is_not_none_backwards(output):
         x = None
         if x is not None:

--- a/Lib/test/test_sys_settrace.py
+++ b/Lib/test/test_sys_settrace.py
@@ -2088,7 +2088,7 @@ class JumpTestCase(unittest.TestCase):
             output.append(1)
         else:
             output.append(2)
-    
+
     @jump_test(2, 1, [2, 3])
     def test_jump_is_not_none_backwards(output):
         x = None
@@ -2097,7 +2097,7 @@ class JumpTestCase(unittest.TestCase):
         else:
             output.append(2)
         output.append(3)
-        
+
     @jump_test(3, 5, [2, 5], warning=(RuntimeWarning, unbound_locals))
     def test_jump_out_of_block_forwards(output):
         for i in 1, 2:

--- a/Lib/test/test_sys_settrace.py
+++ b/Lib/test/test_sys_settrace.py
@@ -2072,7 +2072,7 @@ class JumpTestCase(unittest.TestCase):
         else:
             output.append(5)
 
-    @jump_test(6, 5 [3, 5, 6])
+    @jump_test(6, 5, [3, 5, 6])
     def test_jump_is_none_backwards(output):
         x = None
         if x is None:
@@ -2081,15 +2081,15 @@ class JumpTestCase(unittest.TestCase):
             output.append(5)
         output.append(6)
 
-    @jump_test(1, 4, [2])
+    @jump_test(1, 4, [5])
     def test_jump_is_not_none_forwards(output):
         x = None
         if x is not None:
-            output.append(1)
+            output.append(3)
         else:
-            output.append(2)
+            output.append(5)
 
-    @jump_test(6, 5, [3, 5, 6])
+    @jump_test(6, 2, [5, 5, 6])
     def test_jump_is_not_none_backwards(output):
         x = None
         if x is not None:

--- a/Lib/test/test_sys_settrace.py
+++ b/Lib/test/test_sys_settrace.py
@@ -2064,13 +2064,39 @@ class JumpTestCase(unittest.TestCase):
         output.append(1)
         output.append(2)
 
-    @jump_test(1, 4, [])
-    def test_jump_is_none_forward(output):
+    @jump_test(1, 4, [2])
+    def test_jump_is_none_forwards(output):
         x = None
         if x is None:
             output.append(1)
         else:
             output.append(2)
+
+    @jump_test(2, 1, [1, 3])
+    def test_jump_is_none_backwards(output):
+        x = None
+        if x is None:
+            output.append(1)
+        else:
+            output.append(2)
+        output.append(3)
+
+    @jump_test(1, 4, [2])
+    def test_jump_is_not_none_forwards(output):
+        x = None
+        if x is not None:
+            output.append(1)
+        else:
+            output.append(2)
+    
+    @jump_test(2, 1, [2, 3])
+    def test_jump_is_not_none_backwards(output):
+        x = None
+        if x is not None:
+            output.append(1)
+        else:
+            output.append(2)
+        output.append(3)
         
     @jump_test(3, 5, [2, 5], warning=(RuntimeWarning, unbound_locals))
     def test_jump_out_of_block_forwards(output):

--- a/Lib/test/test_sys_settrace.py
+++ b/Lib/test/test_sys_settrace.py
@@ -2064,22 +2064,22 @@ class JumpTestCase(unittest.TestCase):
         output.append(1)
         output.append(2)
 
-    @jump_test(1, 4, [2])
+    @jump_test(1, 4, [5])
     def test_jump_is_none_forwards(output):
         x = None
         if x is None:
-            output.append(1)
+            output.append(3)
         else:
-            output.append(2)
+            output.append(5)
 
-    @jump_test(2, 1, [1, 3])
+    @jump_test(6, 5 [3, 5, 6])
     def test_jump_is_none_backwards(output):
         x = None
         if x is None:
-            output.append(1)
+            output.append(3)
         else:
-            output.append(2)
-        output.append(3)
+            output.append(5)
+        output.append(6)
 
     @jump_test(1, 4, [2])
     def test_jump_is_not_none_forwards(output):
@@ -2089,14 +2089,14 @@ class JumpTestCase(unittest.TestCase):
         else:
             output.append(2)
 
-    @jump_test(2, 1, [2, 3])
+    @jump_test(6, 5, [3, 5, 6])
     def test_jump_is_not_none_backwards(output):
         x = None
         if x is not None:
-            output.append(1)
+            output.append(3)
         else:
-            output.append(2)
-        output.append(3)
+            output.append(5)
+        output.append(6)
 
     @jump_test(3, 5, [2, 5], warning=(RuntimeWarning, unbound_locals))
     def test_jump_out_of_block_forwards(output):

--- a/Lib/test/test_sys_settrace.py
+++ b/Lib/test/test_sys_settrace.py
@@ -2064,6 +2064,14 @@ class JumpTestCase(unittest.TestCase):
         output.append(1)
         output.append(2)
 
+    @jump_test(1, 4, [])
+    def test_jump_is_none_forward(output):
+        x = None
+        if x is None:
+            output.append(1)
+        else:
+            output.append(2)
+        
     @jump_test(3, 5, [2, 5], warning=(RuntimeWarning, unbound_locals))
     def test_jump_out_of_block_forwards(output):
         for i in 1, 2:

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -1345,6 +1345,7 @@ Michele Orrù
 Tomáš Orsava
 Oleg Oshmyan
 Denis Osipov
+Savannah Ostrowski
 Denis S. Otkidach
 Peter Otten
 Michael Otteneder

--- a/Misc/NEWS.d/next/Core and Builtins/2023-10-23-22-11-09.gh-issue-94438.y2pITu.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2023-10-23-22-11-09.gh-issue-94438.y2pITu.rst
@@ -1,0 +1,1 @@
+Fix a regression that prevented jumping across `is None` and `is not None` when debugging. Patch by Savannah Ostrowski.

--- a/Misc/NEWS.d/next/Core and Builtins/2023-10-23-22-11-09.gh-issue-94438.y2pITu.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2023-10-23-22-11-09.gh-issue-94438.y2pITu.rst
@@ -1,1 +1,1 @@
-Fix a regression that prevented jumping across `is None` and `is not None` when debugging. Patch by Savannah Ostrowski.
+Fix a regression that prevented jumping across ``is None`` and ``is not None`` when debugging. Patch by Savannah Ostrowski.

--- a/Objects/frameobject.c
+++ b/Objects/frameobject.c
@@ -329,6 +329,8 @@ mark_stacks(PyCodeObject *code_obj, int len)
             switch (opcode) {
                 case POP_JUMP_IF_FALSE:
                 case POP_JUMP_IF_TRUE:
+                case POP_JUMP_IF_NONE:
+                case POP_JUMP_IF_NOT_NONE:
                 {
                     int64_t target_stack;
                     int j = next_i + oparg;


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

After reading through https://github.com/python/cpython/issues/94438, it appeared that there were still outstanding issues with mark_stacks as there was no case that checking for POP_JUMP_IF_NONE and POP_JUMP_IF_NOT_NONE, which could break pdb's jump in 3.11 or higher. This adds these case to the switch statement plus a couple of tests.

<!-- gh-issue-number: gh-94438 -->
* Issue: gh-94438
<!-- /gh-issue-number -->
