### PR TITLE
gh-111253: Fix socketmodule.c not checking for errors when initializing

### DIFF
--- a/Misc/NEWS.d/next/Library/2023-10-24-12-20-46.gh-issue-111253.HFywSK.rst
+++ b/Misc/NEWS.d/next/Library/2023-10-24-12-20-46.gh-issue-111253.HFywSK.rst
@@ -1,0 +1,1 @@
+Fix ``_socket`` module not checking for errors when initializing.

--- a/Misc/NEWS.d/next/Library/2023-10-24-12-20-46.gh-issue-111253.HFywSK.rst
+++ b/Misc/NEWS.d/next/Library/2023-10-24-12-20-46.gh-issue-111253.HFywSK.rst
@@ -1,1 +1,1 @@
-Fix ``_socket`` module not checking for errors when initializing.
+Add error checking during :mod:`!_socket` module init.

--- a/Modules/socketmodule.c
+++ b/Modules/socketmodule.c
@@ -7723,10 +7723,10 @@ socket_exec(PyObject *m)
 
 /* FreeBSD divert(4) */
 #ifdef PF_DIVERT
-    PyModule_AddIntMacro(m, PF_DIVERT);
+    ADD_INT_MACRO(m, PF_DIVERT);
 #endif
 #ifdef AF_DIVERT
-    PyModule_AddIntMacro(m, AF_DIVERT);
+    ADD_INT_MACRO(m, AF_DIVERT);
 #endif
 
 #ifdef AF_PACKET


### PR DESCRIPTION


<!-- gh-issue-number: gh-111253 -->
* Issue: gh-111253
<!-- /gh-issue-number -->
