### PR TITLE
GH-79033: docs: Minor improvement to asyncio.Server.wait_closed()

### DIFF
--- a/Doc/library/asyncio-eventloop.rst
+++ b/Doc/library/asyncio-eventloop.rst
@@ -1672,7 +1672,7 @@ Do not instantiate the :class:`Server` class directly.
 
    .. coroutinemethod:: wait_closed()
 
-      Wait until the :meth:`close` method completes.
+      Wait until all connections are closed after calling the :meth:`close` method.
 
    .. attribute:: sockets
 


### PR DESCRIPTION
@gvanrossum Just a small followup from #98582.

In aiohttp, for some reason it was originally written as calling `wait_closed()` _before_ cancelling the open connections. So, from that wording in the Python documentation I always assumed that it was waiting for the sockets to stop listening, rather than waiting for the connections to be closed. Clearly this was wrong, and it actually did nothing, and aiohttp's shutdown should have been broken long ago.

In particular, the close() method says 'The sockets that represent existing incoming client connections are left open.'.
So, saying that it waits for close() to complete, which itself says connections are left open was a little confusing.

<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--111260.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->

<!-- gh-issue-number: gh-79033 -->
* Issue: gh-79033
<!-- /gh-issue-number -->
