### PR TITLE
gh-111262: Make PyDict_Pop() public

### DIFF
--- a/Doc/c-api/dict.rst
+++ b/Doc/c-api/dict.rst
@@ -173,6 +173,16 @@ Dictionary Objects
 
    .. versionadded:: 3.4
 
+
+.. c:function:: PyObject* PyDict_Pop(PyObject *p, PyObject *key, PyObject *defaultobj)
+
+   This is the same as the Python-level :meth:`dict.pop`.  It removes the *key*
+   from the dictionary *p* and returns its value.  If the key is not in the dict,
+   the value *defaultobj* is returned instead if it is not ``NULL``, or otherwise a
+   :exc:`KeyError` is raised and ``NULL`` is returned.
+
+   .. versionadded:: 3.13
+
 .. c:function:: PyObject* PyDict_Items(PyObject *p)
 
    Return a :c:type:`PyListObject` containing all the items from the dictionary.

--- a/Include/cpython/dictobject.h
+++ b/Include/cpython/dictobject.h
@@ -45,7 +45,7 @@ static inline Py_ssize_t PyDict_GET_SIZE(PyObject *op) {
 #define PyDict_GET_SIZE(op) PyDict_GET_SIZE(_PyObject_CAST(op))
 
 PyAPI_FUNC(int) PyDict_ContainsString(PyObject *mp, const char *key);
-
+PyAPI_FUNC(PyObject *) PyDict_Pop(PyObject *dict, PyObject *key, PyObject *default_value);
 
 /* Dictionary watchers */
 

--- a/Misc/NEWS.d/next/C API/2023-10-24-12-12-44.gh-issue-111262.UkK3x-.rst
+++ b/Misc/NEWS.d/next/C API/2023-10-24-12-12-44.gh-issue-111262.UkK3x-.rst
@@ -1,0 +1,1 @@
+Add a new C-API function PyDict_Pop to replace a previously removed underscore function.

--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -2272,6 +2272,16 @@ _PyDict_Pop(PyObject *dict, PyObject *key, PyObject *deflt)
     return _PyDict_Pop_KnownHash(dict, key, hash, deflt);
 }
 
+PyObject *
+PyDict_Pop(PyObject *dict, PyObject *key, PyObject *deflt)
+{
+    if (!PyDict_Check(dict)) {
+        PyErr_BadInternalCall();
+        return -1;
+    }
+    return _PyDict_Pop(dict, key, deflt);
+}
+
 /* Internal version of dict.from_keys().  It is subclass-friendly. */
 PyObject *
 _PyDict_FromKeys(PyObject *cls, PyObject *iterable, PyObject *value)


### PR DESCRIPTION
See https://github.com/python/cpython/pull/108449

I kept the internal function since it saves the type check on the fast path and can thus still be used internally.

<!-- gh-issue-number: gh-111262 -->
* Issue: gh-111262
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--111263.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->