### PR TITLE
Revert "Fix a code snippet typo in asyncio docs (#108427)"

### DIFF
--- a/Doc/library/asyncio-task.rst
+++ b/Doc/library/asyncio-task.rst
@@ -592,7 +592,7 @@ Shielding From Cancellation
 
    is equivalent to::
 
-       res = await shield(something())
+       res = await something()
 
    *except* that if the coroutine containing it is cancelled, the
    Task running in ``something()`` is not cancelled.  From the point


### PR DESCRIPTION
This reverts commit 7f316763402a7d5556deecc3acd06cb719e189b3.

The change resulted in a tautology and should not have been made.  There
may be an opportunity for additional clarity in this section, but this
change wasn't it :)

Ref: https://github.com/python/cpython/pull/108427#issuecomment-1777525740


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--111271.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->