### PR TITLE
Docs: Add `restart_events()` and positional arg semantics for `sys.monitoring`

### DIFF
--- a/Doc/library/sys.monitoring.rst
+++ b/Doc/library/sys.monitoring.rst
@@ -44,17 +44,17 @@ Identifiers are integers in the range 0 to 5 inclusive.
 Registering and using tools
 '''''''''''''''''''''''''''
 
-.. function:: use_tool_id(tool_id: int, name: str) -> None
+.. function:: use_tool_id(tool_id: int, name: str, /) -> None
 
    Must be called before *tool_id* can be used.
    *tool_id* must be in the range 0 to 5 inclusive.
    Raises a :exc:`ValueError` if *tool_id* is in use.
 
-.. function:: free_tool_id(tool_id: int) -> None
+.. function:: free_tool_id(tool_id: int, /) -> None
 
    Should be called once a tool no longer requires *tool_id*.
 
-.. function:: get_tool(tool_id: int) -> str | None
+.. function:: get_tool(tool_id: int, /) -> str | None
 
    Returns the name of the tool if *tool_id* is in use,
    otherwise it returns ``None``.
@@ -237,11 +237,11 @@ Setting events globally
 
 Events can be controlled globally by modifying the set of events being monitored.
 
-.. function:: get_events(tool_id: int) -> int
+.. function:: get_events(tool_id: int, /) -> int
 
    Returns the ``int`` representing all the active events.
 
-.. function:: set_events(tool_id: int, event_set: int)
+.. function:: set_events(tool_id: int, event_set: int, /)
 
    Activates all events which are set in *event_set*.
    Raises a :exc:`ValueError` if *tool_id* is not in use.
@@ -253,11 +253,11 @@ Per code object events
 
 Events can also be controlled on a per code object basis.
 
-.. function:: get_local_events(tool_id: int, code: CodeType) -> int
+.. function:: get_local_events(tool_id: int, code: CodeType, /) -> int
 
    Returns all the local events for *code*
 
-.. function:: set_local_events(tool_id: int, code: CodeType, event_set: int)
+.. function:: set_local_events(tool_id: int, code: CodeType, event_set: int, /)
 
    Activates all the local events for *code* which are set in *event_set*.
    Raises a :exc:`ValueError` if *tool_id* is not in use.
@@ -284,6 +284,11 @@ performance monitoring. For example, a program can be run under a
 debugger with no overhead if the debugger disables all monitoring
 except for a few breakpoints.
 
+.. function:: restart_events()
+
+   Enable all the events that were disabled by :data:`sys.monitoring.DISABLE`
+   for all tools.
+
 
 .. _callbacks:
 
@@ -292,7 +297,7 @@ Registering callback functions
 
 To register a callable for events call
 
-.. function:: register_callback(tool_id: int, event: int, func: Callable | None) -> Callable | None
+.. function:: register_callback(tool_id: int, event: int, func: Callable | None, /) -> Callable | None
 
    Registers the callable *func* for the *event* with the given *tool_id*
 

--- a/Doc/library/sys.monitoring.rst
+++ b/Doc/library/sys.monitoring.rst
@@ -241,7 +241,7 @@ Events can be controlled globally by modifying the set of events being monitored
 
    Returns the ``int`` representing all the active events.
 
-.. function:: set_events(tool_id: int, event_set: int, /)
+.. function:: set_events(tool_id: int, event_set: int, /) -> None
 
    Activates all events which are set in *event_set*.
    Raises a :exc:`ValueError` if *tool_id* is not in use.
@@ -257,7 +257,7 @@ Events can also be controlled on a per code object basis.
 
    Returns all the local events for *code*
 
-.. function:: set_local_events(tool_id: int, code: CodeType, event_set: int, /)
+.. function:: set_local_events(tool_id: int, code: CodeType, event_set: int, /) -> None
 
    Activates all the local events for *code* which are set in *event_set*.
    Raises a :exc:`ValueError` if *tool_id* is not in use.
@@ -284,7 +284,7 @@ performance monitoring. For example, a program can be run under a
 debugger with no overhead if the debugger disables all monitoring
 except for a few breakpoints.
 
-.. function:: restart_events()
+.. function:: restart_events() -> None
 
    Enable all the events that were disabled by :data:`sys.monitoring.DISABLE`
    for all tools.


### PR DESCRIPTION
All the functions in `sys.monitoring` are postional argument only, so use positional arg semantics to clarify it. Many functions like [exec](https://docs.python.org/3.12/library/functions.html?#exec) are already using it for the docs.

Also `restart_events()` is not mentioned in the docs, added it.

<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--111291.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->