### PR TITLE
GH-111293: Fix DirEntry.inode dropping higher bits

### DIFF
--- a/Misc/NEWS.d/next/Library/2023-10-25-05-01-28.gh-issue-111293.FSsLT6.rst
+++ b/Misc/NEWS.d/next/Library/2023-10-25-05-01-28.gh-issue-111293.FSsLT6.rst
@@ -1,1 +1,0 @@
-Fix os.DirEntry.inode() dropping higher 64 bits of a file id on Windows.

--- a/Misc/NEWS.d/next/Library/2023-10-25-05-01-28.gh-issue-111293.FSsLT6.rst
+++ b/Misc/NEWS.d/next/Library/2023-10-25-05-01-28.gh-issue-111293.FSsLT6.rst
@@ -1,0 +1,1 @@
+Fix os.DirEntry.inode() dropping higher 64 bits of a file id on Windows.

--- a/Misc/NEWS.d/next/Windows/2023-10-25-05-01-28.gh-issue-111293.FSsLT6.rst
+++ b/Misc/NEWS.d/next/Windows/2023-10-25-05-01-28.gh-issue-111293.FSsLT6.rst
@@ -1,0 +1,1 @@
+Fix :data:`os.DirEntry.inode` dropping higher 64 bits of a file id on some filesystems on Windows.

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -14805,6 +14805,7 @@ typedef struct {
 #ifdef MS_WINDOWS
     struct _Py_stat_struct win32_lstat;
     uint64_t win32_file_index;
+    uint64_t win32_file_index_high;
     int got_file_index;
 #else /* POSIX */
 #ifdef HAVE_DIRENT_D_TYPE
@@ -15134,11 +15135,12 @@ os_DirEntry_inode_impl(DirEntry *self)
         }
 
         self->win32_file_index = stat.st_ino;
+        self->win32_file_index_high = stat.st_ino_high;
         self->got_file_index = 1;
     }
     static_assert(sizeof(unsigned long long) >= sizeof(self->win32_file_index),
                   "DirEntry.win32_file_index is larger than unsigned long long");
-    return PyLong_FromUnsignedLongLong(self->win32_file_index);
+    return _pystat_l128_from_l64_l64(self->win32_file_index, self->win32_file_index_high);
 #else /* POSIX */
     static_assert(sizeof(unsigned long long) >= sizeof(self->d_ino),
                   "DirEntry.d_ino is larger than unsigned long long");

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -15138,8 +15138,6 @@ os_DirEntry_inode_impl(DirEntry *self)
         self->win32_file_index_high = stat.st_ino_high;
         self->got_file_index = 1;
     }
-    static_assert(sizeof(unsigned long long) >= sizeof(self->win32_file_index),
-                  "DirEntry.win32_file_index is larger than unsigned long long");
     return _pystat_l128_from_l64_l64(self->win32_file_index, self->win32_file_index_high);
 #else /* POSIX */
     static_assert(sizeof(unsigned long long) >= sizeof(self->d_ino),


### PR DESCRIPTION
# GH-111293: Fix DirEntry.inode dropping higher bits

See #111293 for more details.