### PR TITLE
gh-111295: Fix timemodule.c not checking for errors when initializing

### DIFF
--- a/Misc/NEWS.d/next/Library/2023-10-25-08-42-05.gh-issue-111295.H2K4lf.rst
+++ b/Misc/NEWS.d/next/Library/2023-10-25-08-42-05.gh-issue-111295.H2K4lf.rst
@@ -1,0 +1,1 @@
+Fix :mod:`time` not checking for errors when initializing.

--- a/Modules/timemodule.c
+++ b/Modules/timemodule.c
@@ -1740,12 +1740,11 @@ get_gmtoff(time_t t, struct tm *p)
 static int
 init_timezone(PyObject *m)
 {
-#define ADD_INT(NAME, VALUE) \
-    do { \
-        if (PyModule_AddIntConstant(m, NAME, VALUE) < 0) { \
-            return -1; \
-        } \
-    } while (0)
+#define ADD_INT(NAME, VALUE) do {                       \
+    if (PyModule_AddIntConstant(m, NAME, VALUE) < 0) {  \
+        return -1;                                      \
+    }                                                   \
+while (0)
 
     assert(!PyErr_Occurred());
 

--- a/Modules/timemodule.c
+++ b/Modules/timemodule.c
@@ -1744,7 +1744,7 @@ init_timezone(PyObject *m)
     if (PyModule_AddIntConstant(m, NAME, VALUE) < 0) {  \
         return -1;                                      \
     }                                                   \
-while (0)
+} while (0)
 
     assert(!PyErr_Occurred());
 

--- a/Modules/timemodule.c
+++ b/Modules/timemodule.c
@@ -1740,6 +1740,13 @@ get_gmtoff(time_t t, struct tm *p)
 static int
 init_timezone(PyObject *m)
 {
+#define ADD_INT(NAME, VALUE) \
+    do { \
+        if (PyModule_AddIntConstant(m, NAME, VALUE) < 0) { \
+            return -1; \
+        } \
+    } while (0)
+
     assert(!PyErr_Occurred());
 
     /* This code moved from PyInit_time wholesale to allow calling it from
@@ -1763,13 +1770,13 @@ init_timezone(PyObject *m)
 #if !defined(MS_WINDOWS) || defined(MS_WINDOWS_DESKTOP) || defined(MS_WINDOWS_SYSTEM)
     tzset();
 #endif
-    PyModule_AddIntConstant(m, "timezone", _Py_timezone);
+    ADD_INT("timezone", _Py_timezone);
 #ifdef HAVE_ALTZONE
-    PyModule_AddIntConstant(m, "altzone", altzone);
+    ADD_INT("altzone", altzone);
 #else
-    PyModule_AddIntConstant(m, "altzone", _Py_timezone-3600);
+    ADD_INT("altzone", _Py_timezone-3600);
 #endif
-    PyModule_AddIntConstant(m, "daylight", _Py_daylight);
+    ADD_INT("daylight", _Py_daylight);
 #ifdef MS_WINDOWS
     TIME_ZONE_INFORMATION tzinfo = {0};
     GetTimeZoneInformation(&tzinfo);
@@ -1828,20 +1835,21 @@ init_timezone(PyObject *m)
     PyObject *tzname_obj;
     if (janzone < julyzone) {
         /* DST is reversed in the southern hemisphere */
-        PyModule_AddIntConstant(m, "timezone", julyzone);
-        PyModule_AddIntConstant(m, "altzone", janzone);
-        PyModule_AddIntConstant(m, "daylight", janzone != julyzone);
+        ADD_INT("timezone", julyzone);
+        ADD_INT("altzone", janzone);
+        ADD_INT("daylight", janzone != julyzone);
         tzname_obj = Py_BuildValue("(zz)", julyname, janname);
     } else {
-        PyModule_AddIntConstant(m, "timezone", janzone);
-        PyModule_AddIntConstant(m, "altzone", julyzone);
-        PyModule_AddIntConstant(m, "daylight", janzone != julyzone);
+        ADD_INT("timezone", janzone);
+        ADD_INT("altzone", julyzone);
+        ADD_INT("daylight", janzone != julyzone);
         tzname_obj = Py_BuildValue("(zz)", janname, julyname);
     }
     if (PyModule_Add(m, "tzname", tzname_obj) < 0) {
         return -1;
     }
 #endif // !HAVE_DECL_TZNAME
+#undef ADD_INT
 
     if (PyErr_Occurred()) {
         return -1;


### PR DESCRIPTION


<!-- gh-issue-number: gh-111295 -->
* Issue: gh-111295
<!-- /gh-issue-number -->
