### PR TITLE
gh-111259: Optimize recursive wildcards in pathlib

### DIFF
--- a/Lib/pathlib.py
+++ b/Lib/pathlib.py
@@ -124,13 +124,13 @@ def _compile_pattern_lines(pattern_lines, case_sensitive):
         elif part == '*':
             part = r'.+'
         elif part == '**\n':
-            # '**/' component: we use '[\s\S]' rather than '.' so that path
+            # '**/' component: we use '(?s:.)' rather than '.' so that path
             # separators (i.e. newlines) are matched. The trailing '^' ensures
             # we terminate after a path separator (i.e. on a new line).
-            part = r'[\s\S]*^'
+            part = r'(?s:.)*^'
         elif part == '**':
             # '**' component.
-            part = r'[\s\S]*'
+            part = r'(?s:.)*'
         elif '**' in part:
             raise ValueError("Invalid pattern: '**' can only be an entire path component")
         else:

--- a/Misc/NEWS.d/next/Library/2023-10-25-11-13-35.gh-issue-111259.z7ndeA.rst
+++ b/Misc/NEWS.d/next/Library/2023-10-25-11-13-35.gh-issue-111259.z7ndeA.rst
@@ -1,0 +1,1 @@
+Optimize recursive wildcards in :mod:`pathlib`.


### PR DESCRIPTION
Regular expression pattern `(?s:.)` is much faster than `[\s\S]`.


<!-- gh-issue-number: gh-111259 -->
* Issue: gh-111259
<!-- /gh-issue-number -->
