### PR TITLE
[3.11] Bump test deps: `ruff` and `mypy` (GH-111288)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.1.0
+    rev: v0.1.2
     hooks:
       - id: ruff
         name: Run Ruff on Lib/test/


### PR DESCRIPTION
(cherry picked from commit https://github.com/python/cpython/commit/0d1cbff833f761f80383f4ce5fe31f686f3f04eb)

3.11 does not have mypy

(backport to #111288)