### PR TITLE
[3.11] gh-111309: Use unittest to collect and run distutils tests

### DIFF
--- a/Lib/distutils/tests/__init__.py
+++ b/Lib/distutils/tests/__init__.py
@@ -1,9 +1,7 @@
 """Test suite for distutils.
 
 This test suite consists of a collection of test modules in the
-distutils.tests package.  Each test module has a name starting with
-'test' and contains a function test_suite().  The function is expected
-to return an initialized unittest.TestSuite instance.
+distutils.tests package.
 
 Tests for the command classes in the distutils.command package are
 included in distutils.tests as well, instead of using a separate
@@ -13,29 +11,21 @@ by import rather than matching pre-defined names.
 """
 
 import os
-import sys
 import unittest
-from test.support import run_unittest
 from test.support.warnings_helper import save_restore_warnings_filters
+from test.support import warnings_helper
+from test.support import load_package_tests
 
 
-here = os.path.dirname(__file__) or os.curdir
-
-
-def test_suite():
-    suite = unittest.TestSuite()
-    for fn in os.listdir(here):
-        if fn.startswith("test") and fn.endswith(".py"):
-            modname = "distutils.tests." + fn[:-3]
-            # bpo-40055: Save/restore warnings filters to leave them unchanged.
-            # Importing tests imports docutils which imports pkg_resources
-            # which adds a warnings filter.
-            with save_restore_warnings_filters():
-                __import__(modname)
-            module = sys.modules[modname]
-            suite.addTest(module.test_suite())
-    return suite
-
+def load_tests(*args):
+    # bpo-40055: Save/restore warnings filters to leave them unchanged.
+    # Importing tests imports docutils which imports pkg_resources
+    # which adds a warnings filter.
+    with (save_restore_warnings_filters(),
+          warnings_helper.check_warnings(
+            ("The distutils.sysconfig module is deprecated", DeprecationWarning),
+            quiet=True)):
+        return load_package_tests(os.path.dirname(__file__), *args)
 
 if __name__ == "__main__":
-    run_unittest(test_suite())
+    unittest.main()

--- a/Lib/distutils/tests/test_archive_util.py
+++ b/Lib/distutils/tests/test_archive_util.py
@@ -13,7 +13,7 @@ from distutils.archive_util import (check_archive_formats, make_tarball,
                                     ARCHIVE_FORMATS)
 from distutils.spawn import find_executable, spawn
 from distutils.tests import support
-from test.support import run_unittest, patch
+from test.support import patch
 from test.support.os_helper import change_cwd
 from test.support.warnings_helper import check_warnings
 
@@ -389,8 +389,5 @@ class ArchiveUtilTestCase(support.TempdirManager,
         finally:
             archive.close()
 
-def test_suite():
-    return unittest.TestLoader().loadTestsFromTestCase(ArchiveUtilTestCase)
-
 if __name__ == "__main__":
-    run_unittest(test_suite())
+    unittest.main()

--- a/Lib/distutils/tests/test_bdist.py
+++ b/Lib/distutils/tests/test_bdist.py
@@ -1,7 +1,6 @@
 """Tests for distutils.command.bdist."""
 import os
 import unittest
-from test.support import run_unittest
 
 import warnings
 with warnings.catch_warnings():
@@ -44,9 +43,5 @@ class BuildTestCase(support.TempdirManager,
                             '%s should take --skip-build from bdist' % name)
 
 
-def test_suite():
-    return unittest.TestLoader().loadTestsFromTestCase(BuildTestCase)
-
-
 if __name__ == '__main__':
-    run_unittest(test_suite())
+    unittest.main()

--- a/Lib/distutils/tests/test_bdist_dumb.py
+++ b/Lib/distutils/tests/test_bdist_dumb.py
@@ -4,7 +4,6 @@ import os
 import sys
 import zipfile
 import unittest
-from test.support import run_unittest
 
 from distutils.core import Distribution
 from distutils.command.bdist_dumb import bdist_dumb
@@ -90,8 +89,5 @@ class BuildDumbTestCase(support.TempdirManager,
             wanted.append('foo.%s.pyc' % sys.implementation.cache_tag)
         self.assertEqual(contents, sorted(wanted))
 
-def test_suite():
-    return unittest.TestLoader().loadTestsFromTestCase(BuildDumbTestCase)
-
 if __name__ == '__main__':
-    run_unittest(test_suite())
+    unittest.main()

--- a/Lib/distutils/tests/test_bdist_rpm.py
+++ b/Lib/distutils/tests/test_bdist_rpm.py
@@ -3,7 +3,7 @@
 import unittest
 import sys
 import os
-from test.support import run_unittest, requires_zlib
+from test.support import requires_zlib
 
 from distutils.core import Distribution
 from distutils.command.bdist_rpm import bdist_rpm
@@ -134,8 +134,5 @@ class BuildRpmTestCase(support.TempdirManager,
 
         os.remove(os.path.join(pkg_dir, 'dist', 'foo-0.1-1.noarch.rpm'))
 
-def test_suite():
-    return unittest.TestLoader().loadTestsFromTestCase(BuildRpmTestCase)
-
 if __name__ == '__main__':
-    run_unittest(test_suite())
+    unittest.main()

--- a/Lib/distutils/tests/test_build.py
+++ b/Lib/distutils/tests/test_build.py
@@ -2,7 +2,6 @@
 import unittest
 import os
 import sys
-from test.support import run_unittest
 
 from distutils.command.build import build
 from distutils.tests import support
@@ -50,8 +49,5 @@ class BuildTestCase(support.TempdirManager,
         # executable is os.path.normpath(sys.executable)
         self.assertEqual(cmd.executable, os.path.normpath(sys.executable))
 
-def test_suite():
-    return unittest.TestLoader().loadTestsFromTestCase(BuildTestCase)
-
 if __name__ == "__main__":
-    run_unittest(test_suite())
+    unittest.main()

--- a/Lib/distutils/tests/test_build_clib.py
+++ b/Lib/distutils/tests/test_build_clib.py
@@ -5,7 +5,7 @@ import sys
 import sysconfig
 
 from test.support import (
-    run_unittest, missing_compiler_executable, requires_subprocess
+    missing_compiler_executable, requires_subprocess
 )
 
 from distutils.command.build_clib import build_clib
@@ -140,8 +140,5 @@ class BuildCLibTestCase(support.TempdirManager,
         # let's check the result
         self.assertIn('libfoo.a', os.listdir(build_temp))
 
-def test_suite():
-    return unittest.TestLoader().loadTestsFromTestCase(BuildCLibTestCase)
-
 if __name__ == "__main__":
-    run_unittest(test_suite())
+    unittest.main()

--- a/Lib/distutils/tests/test_build_ext.py
+++ b/Lib/distutils/tests/test_build_ext.py
@@ -545,11 +545,5 @@ class ParallelBuildExtTestCase(BuildExtTestCase):
         return build_ext
 
 
-def test_suite():
-    suite = unittest.TestSuite()
-    suite.addTest(unittest.TestLoader().loadTestsFromTestCase(BuildExtTestCase))
-    suite.addTest(unittest.TestLoader().loadTestsFromTestCase(ParallelBuildExtTestCase))
-    return suite
-
 if __name__ == '__main__':
-    support.run_unittest(__name__)
+    unittest.main()

--- a/Lib/distutils/tests/test_build_py.py
+++ b/Lib/distutils/tests/test_build_py.py
@@ -9,7 +9,7 @@ from distutils.core import Distribution
 from distutils.errors import DistutilsFileError
 
 from distutils.tests import support
-from test.support import run_unittest, requires_subprocess
+from test.support import requires_subprocess
 
 
 class BuildPyTestCase(support.TempdirManager,
@@ -174,8 +174,5 @@ class BuildPyTestCase(support.TempdirManager,
                       self.logs[0][1] % self.logs[0][2])
 
 
-def test_suite():
-    return unittest.TestLoader().loadTestsFromTestCase(BuildPyTestCase)
-
 if __name__ == "__main__":
-    run_unittest(test_suite())
+    unittest.main()

--- a/Lib/distutils/tests/test_build_scripts.py
+++ b/Lib/distutils/tests/test_build_scripts.py
@@ -8,7 +8,6 @@ from distutils.core import Distribution
 from distutils import sysconfig
 
 from distutils.tests import support
-from test.support import run_unittest
 
 
 class BuildScriptsTestCase(support.TempdirManager,
@@ -105,8 +104,5 @@ class BuildScriptsTestCase(support.TempdirManager,
         for name in expected:
             self.assertIn(name, built)
 
-def test_suite():
-    return unittest.TestLoader().loadTestsFromTestCase(BuildScriptsTestCase)
-
 if __name__ == "__main__":
-    run_unittest(test_suite())
+    unittest.main()

--- a/Lib/distutils/tests/test_check.py
+++ b/Lib/distutils/tests/test_check.py
@@ -2,7 +2,6 @@
 import os
 import textwrap
 import unittest
-from test.support import run_unittest
 
 from distutils.command.check import check, HAS_DOCUTILS
 from distutils.tests import support
@@ -156,8 +155,5 @@ class CheckTestCase(support.LoggingSilencer,
                           {}, **{'strict': 1,
                                  'restructuredtext': 1})
 
-def test_suite():
-    return unittest.TestLoader().loadTestsFromTestCase(CheckTestCase)
-
 if __name__ == "__main__":
-    run_unittest(test_suite())
+    unittest.main()

--- a/Lib/distutils/tests/test_clean.py
+++ b/Lib/distutils/tests/test_clean.py
@@ -4,7 +4,6 @@ import unittest
 
 from distutils.command.clean import clean
 from distutils.tests import support
-from test.support import run_unittest
 
 class cleanTestCase(support.TempdirManager,
                     support.LoggingSilencer,
@@ -42,8 +41,5 @@ class cleanTestCase(support.TempdirManager,
         cmd.ensure_finalized()
         cmd.run()
 
-def test_suite():
-    return unittest.TestLoader().loadTestsFromTestCase(cleanTestCase)
-
 if __name__ == "__main__":
-    run_unittest(test_suite())
+    unittest.main()

--- a/Lib/distutils/tests/test_cmd.py
+++ b/Lib/distutils/tests/test_cmd.py
@@ -1,7 +1,7 @@
 """Tests for distutils.cmd."""
 import unittest
 import os
-from test.support import captured_stdout, run_unittest
+from test.support import captured_stdout
 
 from distutils.cmd import Command
 from distutils.dist import Distribution
@@ -119,8 +119,5 @@ class CommandTestCase(unittest.TestCase):
         finally:
             debug.DEBUG = False
 
-def test_suite():
-    return unittest.TestLoader().loadTestsFromTestCase(CommandTestCase)
-
 if __name__ == '__main__':
-    run_unittest(test_suite())
+    unittest.main()

--- a/Lib/distutils/tests/test_config.py
+++ b/Lib/distutils/tests/test_config.py
@@ -8,7 +8,6 @@ from distutils.log import set_threshold
 from distutils.log import WARN
 
 from distutils.tests import support
-from test.support import run_unittest
 
 PYPIRC = """\
 [distutils]
@@ -134,8 +133,5 @@ class PyPIRCCommandTestCase(BasePyPIRCCommandTestCase):
         self.assertEqual(config, waited)
 
 
-def test_suite():
-    return unittest.TestLoader().loadTestsFromTestCase(PyPIRCCommandTestCase)
-
 if __name__ == "__main__":
-    run_unittest(test_suite())
+    unittest.main()

--- a/Lib/distutils/tests/test_config_cmd.py
+++ b/Lib/distutils/tests/test_config_cmd.py
@@ -4,7 +4,7 @@ import os
 import sys
 import sysconfig
 from test.support import (
-    run_unittest, missing_compiler_executable, requires_subprocess
+    missing_compiler_executable, requires_subprocess
 )
 
 from distutils.command.config import dump_file, config
@@ -96,8 +96,5 @@ class ConfigTestCase(support.LoggingSilencer,
         for f in (f1, f2):
             self.assertFalse(os.path.exists(f))
 
-def test_suite():
-    return unittest.TestLoader().loadTestsFromTestCase(ConfigTestCase)
-
 if __name__ == "__main__":
-    run_unittest(test_suite())
+    unittest.main()

--- a/Lib/distutils/tests/test_core.py
+++ b/Lib/distutils/tests/test_core.py
@@ -5,7 +5,7 @@ import distutils.core
 import os
 import shutil
 import sys
-from test.support import captured_stdout, run_unittest
+from test.support import captured_stdout
 from test.support import os_helper
 import unittest
 from distutils.tests import support
@@ -133,8 +133,5 @@ class CoreTestCase(support.EnvironGuard, unittest.TestCase):
         wanted = "options (after parsing config files):\n"
         self.assertEqual(stdout.readlines()[0], wanted)
 
-def test_suite():
-    return unittest.TestLoader().loadTestsFromTestCase(CoreTestCase)
-
 if __name__ == "__main__":
-    run_unittest(test_suite())
+    unittest.main()

--- a/Lib/distutils/tests/test_cygwinccompiler.py
+++ b/Lib/distutils/tests/test_cygwinccompiler.py
@@ -3,7 +3,6 @@ import unittest
 import sys
 import os
 from io import BytesIO
-from test.support import run_unittest
 
 from distutils import cygwinccompiler
 from distutils.cygwinccompiler import (check_config_h,
@@ -147,8 +146,5 @@ class CygwinCCompilerTestCase(support.TempdirManager,
                        '[MSC v.1999 32 bits (Intel)]')
         self.assertRaises(ValueError, get_msvcr)
 
-def test_suite():
-    return unittest.TestLoader().loadTestsFromTestCase(CygwinCCompilerTestCase)
-
 if __name__ == '__main__':
-    run_unittest(test_suite())
+    unittest.main()

--- a/Lib/distutils/tests/test_dep_util.py
+++ b/Lib/distutils/tests/test_dep_util.py
@@ -5,7 +5,6 @@ import os
 from distutils.dep_util import newer, newer_pairwise, newer_group
 from distutils.errors import DistutilsFileError
 from distutils.tests import support
-from test.support import run_unittest
 
 class DepUtilTestCase(support.TempdirManager, unittest.TestCase):
 
@@ -73,8 +72,5 @@ class DepUtilTestCase(support.TempdirManager, unittest.TestCase):
                                     missing='newer'))
 
 
-def test_suite():
-    return unittest.TestLoader().loadTestsFromTestCase(DepUtilTestCase)
-
 if __name__ == "__main__":
-    run_unittest(test_suite())
+    unittest.main()

--- a/Lib/distutils/tests/test_dir_util.py
+++ b/Lib/distutils/tests/test_dir_util.py
@@ -11,7 +11,7 @@ from distutils.dir_util import (mkpath, remove_tree, create_tree, copy_tree,
 
 from distutils import log
 from distutils.tests import support
-from test.support import run_unittest, is_emscripten, is_wasi
+from test.support import is_emscripten, is_wasi
 
 
 class DirUtilTestCase(support.TempdirManager, unittest.TestCase):
@@ -136,8 +136,5 @@ class DirUtilTestCase(support.TempdirManager, unittest.TestCase):
             dir_util.copy_tree(src, None)
 
 
-def test_suite():
-    return unittest.TestLoader().loadTestsFromTestCase(DirUtilTestCase)
-
 if __name__ == "__main__":
-    run_unittest(test_suite())
+    unittest.main()

--- a/Lib/distutils/tests/test_dist.py
+++ b/Lib/distutils/tests/test_dist.py
@@ -12,7 +12,7 @@ from distutils.dist import Distribution, fix_help_options
 from distutils.cmd import Command
 
 from test.support import (
-     captured_stdout, captured_stderr, run_unittest
+     captured_stdout, captured_stderr
 )
 from test.support.os_helper import TESTFN
 from distutils.tests import support
@@ -519,11 +519,5 @@ class MetadataTestCase(support.TempdirManager, support.EnvironGuard,
         self.assertEqual(metadata.obsoletes, None)
         self.assertEqual(metadata.requires, ['foo'])
 
-def test_suite():
-    suite = unittest.TestSuite()
-    suite.addTest(unittest.TestLoader().loadTestsFromTestCase(DistributionTestCase))
-    suite.addTest(unittest.TestLoader().loadTestsFromTestCase(MetadataTestCase))
-    return suite
-
 if __name__ == "__main__":
-    run_unittest(test_suite())
+    unittest.main()

--- a/Lib/distutils/tests/test_extension.py
+++ b/Lib/distutils/tests/test_extension.py
@@ -3,7 +3,6 @@ import unittest
 import os
 import warnings
 
-from test.support import run_unittest
 from test.support.warnings_helper import check_warnings
 from distutils.extension import read_setup_file, Extension
 
@@ -63,8 +62,5 @@ class ExtensionTestCase(unittest.TestCase):
         self.assertEqual(str(w.warnings[0].message),
                           "Unknown Extension options: 'chic'")
 
-def test_suite():
-    return unittest.TestLoader().loadTestsFromTestCase(ExtensionTestCase)
-
 if __name__ == "__main__":
-    run_unittest(test_suite())
+    unittest.main()

--- a/Lib/distutils/tests/test_file_util.py
+++ b/Lib/distutils/tests/test_file_util.py
@@ -8,7 +8,6 @@ from distutils.file_util import move_file, copy_file
 from distutils import log
 from distutils.tests import support
 from distutils.errors import DistutilsFileError
-from test.support import run_unittest
 from test.support.os_helper import unlink
 
 
@@ -119,8 +118,5 @@ class FileUtilTestCase(support.TempdirManager, unittest.TestCase):
                 self.assertEqual(f.read(), 'some content')
 
 
-def test_suite():
-    return unittest.TestLoader().loadTestsFromTestCase(FileUtilTestCase)
-
 if __name__ == "__main__":
-    run_unittest(test_suite())
+    unittest.main()

--- a/Lib/distutils/tests/test_filelist.py
+++ b/Lib/distutils/tests/test_filelist.py
@@ -9,7 +9,7 @@ from distutils.filelist import glob_to_re, translate_pattern, FileList
 from distutils import filelist
 
 from test.support import os_helper
-from test.support import captured_stdout, run_unittest
+from test.support import captured_stdout
 from distutils.tests import support
 
 MANIFEST_IN = """\
@@ -329,12 +329,5 @@ class FindAllTestCase(unittest.TestCase):
             self.assertEqual(filelist.findall(temp_dir), expected)
 
 
-def test_suite():
-    return unittest.TestSuite([
-        unittest.TestLoader().loadTestsFromTestCase(FileListTestCase),
-        unittest.TestLoader().loadTestsFromTestCase(FindAllTestCase),
-    ])
-
-
 if __name__ == "__main__":
-    run_unittest(test_suite())
+    unittest.main()

--- a/Lib/distutils/tests/test_install.py
+++ b/Lib/distutils/tests/test_install.py
@@ -5,7 +5,7 @@ import sys
 import unittest
 import site
 
-from test.support import captured_stdout, run_unittest, requires_subprocess
+from test.support import captured_stdout, requires_subprocess
 
 from distutils import sysconfig
 from distutils.command.install import install, HAS_USER_SITE
@@ -254,8 +254,5 @@ class InstallTestCase(support.TempdirManager,
         self.assertGreater(len(self.logs), old_logs_len)
 
 
-def test_suite():
-    return unittest.TestLoader().loadTestsFromTestCase(InstallTestCase)
-
 if __name__ == "__main__":
-    run_unittest(test_suite())
+    unittest.main()

--- a/Lib/distutils/tests/test_install_data.py
+++ b/Lib/distutils/tests/test_install_data.py
@@ -4,7 +4,6 @@ import unittest
 
 from distutils.command.install_data import install_data
 from distutils.tests import support
-from test.support import run_unittest
 
 class InstallDataTestCase(support.TempdirManager,
                           support.LoggingSilencer,
@@ -68,8 +67,5 @@ class InstallDataTestCase(support.TempdirManager,
         self.assertTrue(os.path.exists(os.path.join(inst2, rtwo)))
         self.assertTrue(os.path.exists(os.path.join(inst, rone)))
 
-def test_suite():
-    return unittest.TestLoader().loadTestsFromTestCase(InstallDataTestCase)
-
 if __name__ == "__main__":
-    run_unittest(test_suite())
+    unittest.main()

--- a/Lib/distutils/tests/test_install_headers.py
+++ b/Lib/distutils/tests/test_install_headers.py
@@ -4,7 +4,6 @@ import unittest
 
 from distutils.command.install_headers import install_headers
 from distutils.tests import support
-from test.support import run_unittest
 
 class InstallHeadersTestCase(support.TempdirManager,
                              support.LoggingSilencer,
@@ -32,8 +31,5 @@ class InstallHeadersTestCase(support.TempdirManager,
         # let's check the results
         self.assertEqual(len(cmd.get_outputs()), 2)
 
-def test_suite():
-    return unittest.TestLoader().loadTestsFromTestCase(InstallHeadersTestCase)
-
 if __name__ == "__main__":
-    run_unittest(test_suite())
+    unittest.main()

--- a/Lib/distutils/tests/test_install_lib.py
+++ b/Lib/distutils/tests/test_install_lib.py
@@ -8,7 +8,7 @@ from distutils.command.install_lib import install_lib
 from distutils.extension import Extension
 from distutils.tests import support
 from distutils.errors import DistutilsOptionError
-from test.support import run_unittest, requires_subprocess
+from test.support import requires_subprocess
 
 
 class InstallLibTestCase(support.TempdirManager,
@@ -110,8 +110,5 @@ class InstallLibTestCase(support.TempdirManager,
                       self.logs[0][1] % self.logs[0][2])
 
 
-def test_suite():
-    return unittest.TestLoader().loadTestsFromTestCase(InstallLibTestCase)
-
 if __name__ == "__main__":
-    run_unittest(test_suite())
+    unittest.main()

--- a/Lib/distutils/tests/test_install_scripts.py
+++ b/Lib/distutils/tests/test_install_scripts.py
@@ -7,7 +7,6 @@ from distutils.command.install_scripts import install_scripts
 from distutils.core import Distribution
 
 from distutils.tests import support
-from test.support import run_unittest
 
 
 class InstallScriptsTestCase(support.TempdirManager,
@@ -75,8 +74,5 @@ class InstallScriptsTestCase(support.TempdirManager,
             self.assertIn(name, installed)
 
 
-def test_suite():
-    return unittest.TestLoader().loadTestsFromTestCase(InstallScriptsTestCase)
-
 if __name__ == "__main__":
-    run_unittest(test_suite())
+    unittest.main()

--- a/Lib/distutils/tests/test_log.py
+++ b/Lib/distutils/tests/test_log.py
@@ -3,7 +3,7 @@
 import io
 import sys
 import unittest
-from test.support import swap_attr, run_unittest
+from test.support import swap_attr
 
 from distutils import log
 
@@ -39,8 +39,5 @@ class TestLog(unittest.TestCase):
                         'Fαtal\trrr' if errors == 'ignore' else
                         'Fαtal\t\\xc8rr\\u014dr')
 
-def test_suite():
-    return unittest.TestLoader().loadTestsFromTestCase(TestLog)
-
 if __name__ == "__main__":
-    run_unittest(test_suite())
+    unittest.main()

--- a/Lib/distutils/tests/test_msvc9compiler.py
+++ b/Lib/distutils/tests/test_msvc9compiler.py
@@ -5,7 +5,6 @@ import os
 
 from distutils.errors import DistutilsPlatformError
 from distutils.tests import support
-from test.support import run_unittest
 
 # A manifest with the only assembly reference being the msvcrt assembly, so
 # should have the assembly completely stripped.  Note that although the
@@ -177,8 +176,5 @@ class msvc9compilerTestCase(support.TempdirManager,
         self.assertIsNone(got)
 
 
-def test_suite():
-    return unittest.TestLoader().loadTestsFromTestCase(msvc9compilerTestCase)
-
 if __name__ == "__main__":
-    run_unittest(test_suite())
+    unittest.main()

--- a/Lib/distutils/tests/test_msvccompiler.py
+++ b/Lib/distutils/tests/test_msvccompiler.py
@@ -5,7 +5,6 @@ import os
 
 from distutils.errors import DistutilsPlatformError
 from distutils.tests import support
-from test.support import run_unittest
 
 
 SKIP_MESSAGE = (None if sys.platform == "win32" else
@@ -74,8 +73,5 @@ class msvccompilerTestCase(support.TempdirManager,
         else:
             raise unittest.SkipTest("VS 2015 is not installed")
 
-def test_suite():
-    return unittest.TestLoader().loadTestsFromTestCase(msvccompilerTestCase)
-
 if __name__ == "__main__":
-    run_unittest(test_suite())
+    unittest.main()

--- a/Lib/distutils/tests/test_register.py
+++ b/Lib/distutils/tests/test_register.py
@@ -5,7 +5,6 @@ import getpass
 import urllib
 import warnings
 
-from test.support import run_unittest
 from test.support.warnings_helper import check_warnings
 
 from distutils.command import register as register_module
@@ -317,8 +316,5 @@ class RegisterTestCase(BasePyPIRCCommandTestCase):
         self.assertEqual(results[3], 75 * '-' + '\nxxx\n' + 75 * '-')
 
 
-def test_suite():
-    return unittest.TestLoader().loadTestsFromTestCase(RegisterTestCase)
-
 if __name__ == "__main__":
-    run_unittest(test_suite())
+    unittest.main()

--- a/Lib/distutils/tests/test_sdist.py
+++ b/Lib/distutils/tests/test_sdist.py
@@ -6,7 +6,7 @@ import warnings
 import zipfile
 from os.path import join
 from textwrap import dedent
-from test.support import captured_stdout, run_unittest
+from test.support import captured_stdout
 from test.support.warnings_helper import check_warnings
 
 try:
@@ -486,8 +486,5 @@ class SDistTestCase(BasePyPIRCCommandTestCase):
         finally:
             archive.close()
 
-def test_suite():
-    return unittest.TestLoader().loadTestsFromTestCase(SDistTestCase)
-
 if __name__ == "__main__":
-    run_unittest(test_suite())
+    unittest.main()

--- a/Lib/distutils/tests/test_spawn.py
+++ b/Lib/distutils/tests/test_spawn.py
@@ -3,7 +3,7 @@ import os
 import stat
 import sys
 import unittest.mock
-from test.support import run_unittest, unix_shell, requires_subprocess
+from test.support import unix_shell, requires_subprocess
 from test.support import os_helper
 
 from distutils.spawn import find_executable
@@ -132,8 +132,5 @@ class SpawnTestCase(support.TempdirManager,
         self.assertIn("command 'does-not-exist' failed", str(ctx.exception))
 
 
-def test_suite():
-    return unittest.TestLoader().loadTestsFromTestCase(SpawnTestCase)
-
 if __name__ == "__main__":
-    run_unittest(test_suite())
+    unittest.main()

--- a/Lib/distutils/tests/test_sysconfig.py
+++ b/Lib/distutils/tests/test_sysconfig.py
@@ -10,7 +10,7 @@ import unittest
 from distutils import sysconfig
 from distutils.ccompiler import get_default_compiler
 from distutils.tests import support
-from test.support import run_unittest, swap_item, requires_subprocess, is_wasi
+from test.support import swap_item, requires_subprocess, is_wasi
 from test.support.os_helper import TESTFN
 from test.support.warnings_helper import check_warnings
 
@@ -254,11 +254,5 @@ class SysconfigTestCase(support.EnvironGuard, unittest.TestCase):
         self.assertEqual(0, p.returncode, "Subprocess failed: " + outs)
 
 
-def test_suite():
-    suite = unittest.TestSuite()
-    suite.addTest(unittest.TestLoader().loadTestsFromTestCase(SysconfigTestCase))
-    return suite
-
-
 if __name__ == '__main__':
-    run_unittest(test_suite())
+    unittest.main()

--- a/Lib/distutils/tests/test_text_file.py
+++ b/Lib/distutils/tests/test_text_file.py
@@ -3,7 +3,6 @@ import os
 import unittest
 from distutils.text_file import TextFile
 from distutils.tests import support
-from test.support import run_unittest
 
 TEST_DATA = """# test file
 
@@ -100,8 +99,5 @@ class TextFileTestCase(support.TempdirManager, unittest.TestCase):
         finally:
             in_file.close()
 
-def test_suite():
-    return unittest.TestLoader().loadTestsFromTestCase(TextFileTestCase)
-
 if __name__ == "__main__":
-    run_unittest(test_suite())
+    unittest.main()

--- a/Lib/distutils/tests/test_unixccompiler.py
+++ b/Lib/distutils/tests/test_unixccompiler.py
@@ -1,7 +1,6 @@
 """Tests for distutils.unixccompiler."""
 import sys
 import unittest
-from test.support import run_unittest
 from test.support.os_helper import EnvironmentVarGuard
 
 from distutils import sysconfig
@@ -138,8 +137,5 @@ class UnixCCompilerTestCase(unittest.TestCase):
         self.assertEqual(self.cc.linker_so[0], 'my_ld')
 
 
-def test_suite():
-    return unittest.TestLoader().loadTestsFromTestCase(UnixCCompilerTestCase)
-
 if __name__ == "__main__":
-    run_unittest(test_suite())
+    unittest.main()

--- a/Lib/distutils/tests/test_upload.py
+++ b/Lib/distutils/tests/test_upload.py
@@ -4,7 +4,6 @@ import unittest
 import unittest.mock as mock
 from urllib.error import HTTPError
 
-from test.support import run_unittest
 
 from distutils.command import upload as upload_mod
 from distutils.command.upload import upload
@@ -216,8 +215,5 @@ class uploadTestCase(BasePyPIRCCommandTestCase):
                     self.clear_logs()
 
 
-def test_suite():
-    return unittest.TestLoader().loadTestsFromTestCase(uploadTestCase)
-
 if __name__ == "__main__":
-    run_unittest(test_suite())
+    unittest.main()

--- a/Lib/distutils/tests/test_util.py
+++ b/Lib/distutils/tests/test_util.py
@@ -3,7 +3,6 @@ import os
 import sys
 import unittest
 from copy import copy
-from test.support import run_unittest
 from unittest import mock
 
 from distutils.errors import DistutilsPlatformError, DistutilsByteCompileError
@@ -306,8 +305,5 @@ class UtilTestCase(support.EnvironGuard, unittest.TestCase):
         self.assertEqual(msg, "error: Unable to find batch file")
 
 
-def test_suite():
-    return unittest.TestLoader().loadTestsFromTestCase(UtilTestCase)
-
 if __name__ == "__main__":
-    run_unittest(test_suite())
+    unittest.main()

--- a/Lib/distutils/tests/test_version.py
+++ b/Lib/distutils/tests/test_version.py
@@ -2,7 +2,6 @@
 import unittest
 from distutils.version import LooseVersion
 from distutils.version import StrictVersion
-from test.support import run_unittest
 
 class VersionTestCase(unittest.TestCase):
 
@@ -80,8 +79,5 @@ class VersionTestCase(unittest.TestCase):
                           'cmp(%s, %s) should be NotImplemented, got %s' %
                           (v1, v2, res))
 
-def test_suite():
-    return unittest.TestLoader().loadTestsFromTestCase(VersionTestCase)
-
 if __name__ == "__main__":
-    run_unittest(test_suite())
+    unittest.main()

--- a/Lib/distutils/tests/test_versionpredicate.py
+++ b/Lib/distutils/tests/test_versionpredicate.py
@@ -4,10 +4,10 @@
 
 import distutils.versionpredicate
 import doctest
-from test.support import run_unittest
 
-def test_suite():
-    return doctest.DocTestSuite(distutils.versionpredicate)
+def load_tests(loader, tests, pattern):
+    tests.addTest(doctest.DocTestSuite(distutils.versionpredicate))
+    return tests
 
 if __name__ == '__main__':
-    run_unittest(test_suite())
+    unittest.main()

--- a/Lib/test/test_distutils.py
+++ b/Lib/test/test_distutils.py
@@ -1,8 +1,6 @@
 """Tests for distutils.
 
-The tests for distutils are defined in the distutils.tests package;
-the test_suite() function there returns a test suite that's ready to
-be run.
+The tests for distutils are defined in the distutils.tests package.
 """
 
 import unittest
@@ -12,13 +10,7 @@ from test.support import warnings_helper
 with warnings_helper.check_warnings(
     ("The distutils package is deprecated", DeprecationWarning), quiet=True):
 
-    import distutils.tests
-
-
-def load_tests(*_):
-    # used by unittest
-    return distutils.tests.test_suite()
-
+    from distutils.tests import load_tests
 
 def tearDownModule():
     support.reap_children()

--- a/Misc/NEWS.d/next/Tests/2023-10-25-13-13-30.gh-issue-111309.Re7orL.rst
+++ b/Misc/NEWS.d/next/Tests/2023-10-25-13-13-30.gh-issue-111309.Re7orL.rst
@@ -1,0 +1,1 @@
+:mod:`distutils` tests can now be run via :mod:`unittest`.


### PR DESCRIPTION
* use unittest.main() instead of run_unittest(test_suite()) to run tests from modules via the CLI
* add explicit load_tests() to load doctests
* use test.support.load_package_tests() to load tests in submodules of distutils.tests
* removes no longer needed test_suite() functions


<!-- gh-issue-number: gh-111309 -->
* Issue: gh-111309
<!-- /gh-issue-number -->
