### PR TITLE
[3.12] Bump test deps: `ruff` and `mypy` (GH-111288)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.1.0
+    rev: v0.1.2
     hooks:
       - id: ruff
         name: Run Ruff on Lib/test/

--- a/Tools/clinic/requirements-dev.txt
+++ b/Tools/clinic/requirements-dev.txt
@@ -1,2 +1,2 @@
 # Requirements file for external linters and checks we run on Tools/clinic/ in CI
-mypy==1.6.0
+mypy==1.6.1


### PR DESCRIPTION
(cherry picked from commit https://github.com/python/cpython/commit/0d1cbff833f761f80383f4ce5fe31f686f3f04eb)

3.12 does not have `Tools/requirements-dev.txt` but have `Tools/clinic/requirements-dev.txt`

(backport to #111288)