### PR TITLE
gh-75666: Tkinter: "unbind(sequence, funcid)" now only unbinds "funcid"

### DIFF
--- a/Lib/test/test_tkinter/test_misc.py
+++ b/Lib/test/test_tkinter/test_misc.py
@@ -433,6 +433,8 @@ class BindTest(AbstractTkTest, unittest.TestCase):
         self.frame = tkinter.Frame(self.root, class_='Test',
                                    width=150, height=100)
         self.frame.pack()
+        self.frame.focus_set()
+        self.frame.wait_visibility()
 
     def assertCommandExist(self, funcid):
         self.assertEqual(_info_commands(self.root, funcid), (funcid,))
@@ -482,25 +484,40 @@ class BindTest(AbstractTkTest, unittest.TestCase):
         event = '<Control-Alt-Key-c>'
         self.assertEqual(f.bind(), ())
         self.assertEqual(f.bind(event), '')
-        def test1(e): pass
-        def test2(e): pass
+        def test1(e): events.append('a')
+        def test2(e): events.append('b')
+        def test3(e): events.append('c')
 
         funcid = f.bind(event, test1)
         funcid2 = f.bind(event, test2, add=True)
-
-        f.unbind(event, funcid)
-        script = f.bind(event)
-        self.assertNotIn(funcid, script)
-        self.assertIn(funcid2, script)
-        self.assertEqual(f.bind(), (event,))
-        self.assertCommandNotExist(funcid)
-        self.assertCommandExist(funcid2)
+        funcid3 = f.bind(event, test3, add=True)
+        events = []
+        f.event_generate(event)
+        self.assertEqual(events, ['a', 'b', 'c'])
 
         f.unbind(event, funcid2)
+        script = f.bind(event)
+        self.assertNotIn(funcid2, script)
+        self.assertIn(funcid, script)
+        self.assertIn(funcid3, script)
+        self.assertEqual(f.bind(), (event,))
+        self.assertCommandNotExist(funcid2)
+        self.assertCommandExist(funcid)
+        self.assertCommandExist(funcid3)
+        events = []
+        f.event_generate(event)
+        self.assertEqual(events, ['a', 'c'])
+
+        f.unbind(event, funcid)
+        f.unbind(event, funcid3)
         self.assertEqual(f.bind(event), '')
         self.assertEqual(f.bind(), ())
         self.assertCommandNotExist(funcid)
         self.assertCommandNotExist(funcid2)
+        self.assertCommandNotExist(funcid3)
+        events = []
+        f.event_generate(event)
+        self.assertEqual(events, [])
 
         # non-idempotent
         self.assertRaises(tkinter.TclError, f.unbind, event, funcid2)

--- a/Lib/test/test_tkinter/test_misc.py
+++ b/Lib/test/test_tkinter/test_misc.py
@@ -481,6 +481,7 @@ class BindTest(AbstractTkTest, unittest.TestCase):
         f = self.frame
         f.focus_set()
         f.wait_visibility()
+        f.update_idletasks()
         event = '<Control-Alt-Key-c>'
         self.assertEqual(f.bind(), ())
         self.assertEqual(f.bind(event), '')

--- a/Lib/test/test_tkinter/test_misc.py
+++ b/Lib/test/test_tkinter/test_misc.py
@@ -491,6 +491,8 @@ class BindTest(AbstractTkTest, unittest.TestCase):
         f.unbind(event, funcid)
         script = f.bind(event)
         self.assertNotIn(funcid, script)
+        self.assertIn(funcid2, script)
+        self.assertEqual(f.bind(), (event,))
         self.assertCommandNotExist(funcid)
         self.assertCommandExist(funcid2)
 

--- a/Lib/test/test_tkinter/test_misc.py
+++ b/Lib/test/test_tkinter/test_misc.py
@@ -433,8 +433,6 @@ class BindTest(AbstractTkTest, unittest.TestCase):
         self.frame = tkinter.Frame(self.root, class_='Test',
                                    width=150, height=100)
         self.frame.pack()
-        self.frame.focus_set()
-        self.frame.wait_visibility()
 
     def assertCommandExist(self, funcid):
         self.assertEqual(_info_commands(self.root, funcid), (funcid,))
@@ -481,6 +479,8 @@ class BindTest(AbstractTkTest, unittest.TestCase):
 
     def test_unbind2(self):
         f = self.frame
+        f.focus_set()
+        f.wait_visibility()
         event = '<Control-Alt-Key-c>'
         self.assertEqual(f.bind(), ())
         self.assertEqual(f.bind(event), '')

--- a/Lib/test/test_tkinter/test_misc.py
+++ b/Lib/test/test_tkinter/test_misc.py
@@ -479,8 +479,8 @@ class BindTest(AbstractTkTest, unittest.TestCase):
 
     def test_unbind2(self):
         f = self.frame
-        f.focus_set()
         f.wait_visibility()
+        f.focus_force()
         f.update_idletasks()
         event = '<Control-Alt-Key-c>'
         self.assertEqual(f.bind(), ())

--- a/Lib/tkinter/__init__.py
+++ b/Lib/tkinter/__init__.py
@@ -1530,7 +1530,10 @@ class Misc:
         """Unbind for this widget the event SEQUENCE.
 
         If FUNCID is given, only unbind the function identified with FUNCID
-        and also delete that command.
+        and also delete the corresponding Tcl command.
+
+        Otherwise destroy the current binding for SEQUENCE, leaving SEQUENCE
+        unbound.
         """
         if funcid is None:
             self.tk.call('bind', self._w, sequence, '')

--- a/Lib/tkinter/__init__.py
+++ b/Lib/tkinter/__init__.py
@@ -1527,10 +1527,21 @@ class Misc:
         return self._bind(('bind', self._w), sequence, func, add)
 
     def unbind(self, sequence, funcid=None):
-        """Unbind for this widget for event SEQUENCE  the
-        function identified with FUNCID."""
-        self.tk.call('bind', self._w, sequence, '')
-        if funcid:
+        """Unbind for this widget the event SEQUENCE.
+
+        If FUNCID is given, only unbind the function identified with FUNCID
+        and also delete that command.
+        """
+        if funcid is None:
+            self.tk.call('bind', self._w, sequence, '')
+        else:
+            lines = self.tk.call('bind', self._w, sequence).split('\n')
+            prefix = f'if {{"[{funcid} '
+            keep = '\n'.join(line for line in lines
+                             if not line.startswith(prefix))
+            if not keep.strip():
+                keep = ''
+            self.tk.call('bind', self._w, sequence, keep)
             self.deletecommand(funcid)
 
     def bind_all(self, sequence=None, func=None, add=None):

--- a/Misc/NEWS.d/next/Library/2023-10-25-16-37-13.gh-issue-75666.BpsWut.rst
+++ b/Misc/NEWS.d/next/Library/2023-10-25-16-37-13.gh-issue-75666.BpsWut.rst
@@ -1,4 +1,4 @@
-Change the behavior of :mod:`tkinter` widget's ``unbind()`` method with two
+Fix the behavior of :mod:`tkinter` widget's ``unbind()`` method with two
 arguments. Previously, ``widget.unbind(sequence, funcid)`` destroyed the
 current binding for *sequence*, leaving *sequence* unbound, and deleted the
 *funcid* command. Now it removes only *funcid* from the binding for

--- a/Misc/NEWS.d/next/Library/2023-10-25-16-37-13.gh-issue-75666.BpsWut.rst
+++ b/Misc/NEWS.d/next/Library/2023-10-25-16-37-13.gh-issue-75666.BpsWut.rst
@@ -1,0 +1,6 @@
+Change the behavior of :mod:`tkinter` widget's ``unbind()`` method with two
+arguments. Previously, ``widget.unbind(sequence, funcid)`` destroyed the
+current binding for *sequence*, leaving *sequence* unbound, and deleted the
+*funcid* command. Now it removes only *funcid* from the binding for
+*sequence*, keeping other commands, and deletes the *funcid* command. It
+leaves *sequence* unbound only if *funcid* was the last bound command.


### PR DESCRIPTION
Previously, "widget.unbind(sequence, funcid)" destroyed the current binding for "sequence", leaving "sequence" unbound, and deleted the "funcid" command.

Now it removes only "funcid" from the binding for "sequence", keeping other commands, and deletes the "funcid" command.
It leaves "sequence" unbound only if "funcid" was the last bound command.


<!-- gh-issue-number: gh-75666 -->
* Issue: gh-75666
<!-- /gh-issue-number -->
