### PR TITLE
[3.11] GH-94438: Restore ability to jump over None tests (GH-111237)

### DIFF
--- a/Lib/test/test_sys_settrace.py
+++ b/Lib/test/test_sys_settrace.py
@@ -1952,6 +1952,40 @@ class JumpTestCase(unittest.TestCase):
         output.append(1)
         output.append(2)
 
+    @jump_test(1, 4, [5])
+    def test_jump_is_none_forwards(output):
+        x = None
+        if x is None:
+            output.append(3)
+        else:
+            output.append(5)
+
+    @jump_test(6, 5, [3, 5, 6])
+    def test_jump_is_none_backwards(output):
+        x = None
+        if x is None:
+            output.append(3)
+        else:
+            output.append(5)
+        output.append(6)
+
+    @jump_test(1, 4, [5])
+    def test_jump_is_not_none_forwards(output):
+        x = None
+        if x is not None:
+            output.append(3)
+        else:
+            output.append(5)
+
+    @jump_test(6, 5, [5, 5, 6])
+    def test_jump_is_not_none_backwards(output):
+        x = None
+        if x is not None:
+            output.append(3)
+        else:
+            output.append(5)
+        output.append(6)
+
     @jump_test(3, 5, [2, 5])
     def test_jump_out_of_block_forwards(output):
         for i in 1, 2:

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -1324,6 +1324,7 @@ Michele Orrù
 Tomáš Orsava
 Oleg Oshmyan
 Denis Osipov
+Savannah Ostrowski
 Denis S. Otkidach
 Peter Otten
 Michael Otteneder

--- a/Misc/NEWS.d/next/Core and Builtins/2023-10-23-22-11-09.gh-issue-94438.y2pITu.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2023-10-23-22-11-09.gh-issue-94438.y2pITu.rst
@@ -1,0 +1,1 @@
+Fix a regression that prevented jumping across ``is None`` and ``is not None`` when debugging. Patch by Savannah Ostrowski.

--- a/Objects/frameobject.c
+++ b/Objects/frameobject.c
@@ -315,19 +315,27 @@ mark_stacks(PyCodeObject *code_obj, int len)
                 case POP_JUMP_BACKWARD_IF_FALSE:
                 case POP_JUMP_FORWARD_IF_TRUE:
                 case POP_JUMP_BACKWARD_IF_TRUE:
+                case POP_JUMP_FORWARD_IF_NONE:
+                case POP_JUMP_BACKWARD_IF_NONE:
+                case POP_JUMP_FORWARD_IF_NOT_NONE:
+                case POP_JUMP_BACKWARD_IF_NOT_NONE:
                 {
                     int64_t target_stack;
                     int j = get_arg(code, i);
                     if (opcode == POP_JUMP_FORWARD_IF_FALSE ||
                         opcode == POP_JUMP_FORWARD_IF_TRUE ||
                         opcode == JUMP_IF_FALSE_OR_POP ||
-                        opcode == JUMP_IF_TRUE_OR_POP)
+                        opcode == JUMP_IF_TRUE_OR_POP ||
+                        opcode == POP_JUMP_FORWARD_IF_NONE ||
+                        opcode == POP_JUMP_FORWARD_IF_NOT_NONE)
                     {
                         j += i + 1;
                     }
                     else {
                         assert(opcode == POP_JUMP_BACKWARD_IF_FALSE ||
-                               opcode == POP_JUMP_BACKWARD_IF_TRUE);
+                               opcode == POP_JUMP_BACKWARD_IF_TRUE  ||
+                               opcode == POP_JUMP_BACKWARD_IF_NONE ||
+                               opcode == POP_JUMP_BACKWARD_IF_NOT_NONE);
                         j = i + 1 - j;
                     }
                     assert(j < len);


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

Was unable to automatically backport 3.11 for https://github.com/python/cpython/pull/111237 as some of the bytecode instructions changed in 3.12

cc: @brandtbucher 


<!-- gh-issue-number: gh-94438 -->
* Issue: gh-94438
<!-- /gh-issue-number -->
