### PR TITLE
GH-94438: Fix `RuntimeWarning` for jump tests in `test_sys_settrace`

### DIFF
--- a/Lib/test/test_sys_settrace.py
+++ b/Lib/test/test_sys_settrace.py
@@ -2064,7 +2064,7 @@ class JumpTestCase(unittest.TestCase):
         output.append(1)
         output.append(2)
 
-    @jump_test(1, 4, [5])
+    @jump_test(1, 4, [5], warning=(RuntimeWarning, unbound_locals))
     def test_jump_is_none_forwards(output):
         x = None
         if x is None:
@@ -2081,7 +2081,7 @@ class JumpTestCase(unittest.TestCase):
             output.append(5)
         output.append(6)
 
-    @jump_test(1, 4, [5])
+    @jump_test(2, 4, [5])
     def test_jump_is_not_none_forwards(output):
         x = None
         if x is not None:

--- a/Lib/test/test_sys_settrace.py
+++ b/Lib/test/test_sys_settrace.py
@@ -9,6 +9,7 @@ from functools import wraps
 import asyncio
 from test.support import import_helper
 import contextlib
+import warnings
 
 support.requires_working_socket(module=True)
 
@@ -2001,6 +2002,9 @@ class JumpTestCase(unittest.TestCase):
                 stack.enter_context(self.assertRaisesRegex(*error))
             if warning is not None:
                 stack.enter_context(self.assertWarnsRegex(*warning))
+            else:
+                stack.enter_context(warnings.catch_warnings())
+                warnings.filterwarnings('error') 
             func(output)
 
         sys.settrace(None)

--- a/Lib/test/test_sys_settrace.py
+++ b/Lib/test/test_sys_settrace.py
@@ -2004,7 +2004,7 @@ class JumpTestCase(unittest.TestCase):
                 stack.enter_context(self.assertWarnsRegex(*warning))
             else:
                 stack.enter_context(warnings.catch_warnings())
-                warnings.simplefilter('error') 
+                warnings.simplefilter('error')
             func(output)
 
         sys.settrace(None)

--- a/Lib/test/test_sys_settrace.py
+++ b/Lib/test/test_sys_settrace.py
@@ -2004,7 +2004,7 @@ class JumpTestCase(unittest.TestCase):
                 stack.enter_context(self.assertWarnsRegex(*warning))
             else:
                 stack.enter_context(warnings.catch_warnings())
-                warnings.filterwarnings('error') 
+                warnings.simplefilter('error') 
             func(output)
 
         sys.settrace(None)


### PR DESCRIPTION
A couple of new tests were introduced to test_sys_settrace in #111237, however, two of them triggered a RuntimeWarning:

```
./python -m test test_sys_settrace -m test_jump_is_not_none_forwards
Using random seed: 53646886
0:00:00 load avg: 0.44 Run 1 test sequentially
0:00:00 load avg: 0.44 [1/1] test_sys_settrace
/home/gaogaotiantian/programs/mycpython/Lib/test/test_sys_settrace.py:1947: RuntimeWarning: assigning None to 1 unbound local
  frame.f_lineno = self.firstLine + self.jumpTo

== Tests result: SUCCESS ==
```

This is because the jump happens before all the local variables are assigned:

```python
    @jump_test(1, 4, [5])
    def test_jump_is_not_none_forwards(output):
        x = None
        if x is not None:
            output.append(3)
        else:
            output.append(5)
```

The test jumps on line 1 - before `x` is assigned to `None`. So when `frame.f_lineno` is being set, a warning is generated to alert the users that the unbound local variables are being set to `None`.

This does not affect the validity or the result of the test, but I don't think it's intended, and it is not the best practice. Especially considering that the decorator can already take care of such warnings.

In this PR, two different fixes were applied to the problematic tests to maximize the diversity:
* Add the warning to expected result
* Start from line 2 so `x` is assigned.

A warning checker is also introduced so this won't happen in the future - if a test is not expecting a warning, then a warning is treated as an error. This might not be the best practice for all tests globally, but in this specific case, we do have "expected warnings" and it should count.

<!-- gh-issue-number: gh-94438 -->
* Issue: gh-94438
<!-- /gh-issue-number -->
