### PR TITLE
gh-111348: Fix direct invocation of `test_doctest`; remove `test_doctest.test_coverage`

### DIFF
--- a/Lib/test/test_doctest.py
+++ b/Lib/test/test_doctest.py
@@ -3218,19 +3218,8 @@ def load_tests(loader, tests, pattern):
     return tests
 
 
-def test_coverage(coverdir):
-    trace = import_helper.import_module('trace')
-    tracer = trace.Trace(ignoredirs=[sys.base_prefix, sys.base_exec_prefix,],
-                         trace=0, count=1)
-    tracer.run('test_main()')
-    r = tracer.results()
-    print('Writing coverage results...')
-    r.write_results(show_missing=True, summary=True,
-                    coverdir=coverdir)
-
-
 if __name__ == '__main__':
-    if '-c' in sys.argv:
-        test_coverage('/tmp/doctest.cover')
-    else:
-        unittest.main()
+    raise RuntimeError(
+        "Running `test_doctest` via cmdline is not supported, "
+        "use `-m test test_doctest` instead"
+    )

--- a/Lib/test/test_doctest.py
+++ b/Lib/test/test_doctest.py
@@ -3219,7 +3219,4 @@ def load_tests(loader, tests, pattern):
 
 
 if __name__ == '__main__':
-    raise RuntimeError(
-        "Running `test_doctest` via cmdline is not supported, "
-        "use `-m test test_doctest` instead"
-    )
+    unittest.main(module='test.test_doctest')


### PR DESCRIPTION
Instead of this coverage (which is almost 20 years old https://github.com/python/cpython/blame/78e6d72e38ef4b490f0098b644454031f20ae361/Lib/test/test_doctest.py#L3365-L3373) we should work on proper `coverage.py` integration in our test suite.

<!-- gh-issue-number: gh-111348 -->
* Issue: gh-111348
<!-- /gh-issue-number -->
