### PR TITLE
GH-111339: Change `valid` property of executors to `is_valid()` method

### DIFF
--- a/Lib/test/test_capi/test_misc.py
+++ b/Lib/test/test_capi/test_misc.py
@@ -2479,19 +2479,19 @@ class TestExecutorInvalidation(unittest.TestCase):
         # Set things up so each executor depends on the objects
         # with an equal or lower index.
         for i, exe in enumerate(executors):
-            self.assertTrue(exe.valid)
+            self.assertTrue(exe.is_valid())
             for obj in objects[:i+1]:
                 _testinternalcapi.add_executor_dependency(exe, obj)
-            self.assertTrue(exe.valid)
+            self.assertTrue(exe.is_valid())
         # Assert that the correct executors are invalidated
         # and check that nothing crashes when we invalidate
         # an executor mutliple times.
         for i in (4,3,2,1,0):
             _testinternalcapi.invalidate_executors(objects[i])
             for exe in executors[i:]:
-                self.assertFalse(exe.valid)
+                self.assertFalse(exe.is_valid())
             for exe in executors[:i]:
-                self.assertTrue(exe.valid)
+                self.assertTrue(exe.is_valid())
 
     def test_uop_optimizer_invalidation(self):
         # Generate a new function at each call
@@ -2506,9 +2506,9 @@ class TestExecutorInvalidation(unittest.TestCase):
         with temporary_optimizer(opt):
             f()
         exe = get_first_executor(f)
-        self.assertTrue(exe.valid)
+        self.assertTrue(exe.is_valid())
         _testinternalcapi.invalidate_executors(f.__code__)
-        self.assertFalse(exe.valid)
+        self.assertFalse(exe.is_valid())
 
 class TestUops(unittest.TestCase):
 

--- a/Python/optimizer.c
+++ b/Python/optimizer.c
@@ -225,9 +225,15 @@ counter_dealloc(_PyCounterExecutorObject *self) {
     PyObject_Free(self);
 }
 
-static PyMemberDef counter_members[] = {
-    { "valid", Py_T_UBYTE, offsetof(_PyCounterExecutorObject, executor.vm_data.valid), Py_READONLY, "is valid?" },
-    { NULL }
+static PyObject *
+is_valid(PyObject *self, PyObject *Py_UNUSED(ignored))
+{
+    return PyBool_FromLong(((_PyExecutorObject *)self)->vm_data.valid);
+}
+
+static PyMethodDef executor_methods[] = {
+    { "is_valid", is_valid, METH_NOARGS, NULL },
+    { NULL, NULL },
 };
 
 static PyTypeObject CounterExecutor_Type = {
@@ -237,7 +243,7 @@ static PyTypeObject CounterExecutor_Type = {
     .tp_itemsize = 0,
     .tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_DISALLOW_INSTANTIATION,
     .tp_dealloc = (destructor)counter_dealloc,
-    .tp_members = counter_members,
+    .tp_methods = executor_methods,
 };
 
 static _PyInterpreterFrame *
@@ -280,7 +286,7 @@ counter_get_counter(PyObject *self, PyObject *args)
     return PyLong_FromLongLong(((_PyCounterOptimizerObject *)self)->count);
 }
 
-static PyMethodDef counter_methods[] = {
+static PyMethodDef counter_optimizer_methods[] = {
     { "get_count", counter_get_counter, METH_NOARGS, NULL },
     { NULL, NULL },
 };
@@ -291,7 +297,7 @@ static PyTypeObject CounterOptimizer_Type = {
     .tp_basicsize = sizeof(_PyCounterOptimizerObject),
     .tp_itemsize = 0,
     .tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_DISALLOW_INSTANTIATION,
-    .tp_methods = counter_methods,
+    .tp_methods = counter_optimizer_methods,
     .tp_dealloc = (destructor)PyObject_Del,
 };
 
@@ -369,12 +375,6 @@ PySequenceMethods uop_as_sequence = {
     .sq_item = (ssizeargfunc)uop_item,
 };
 
-
-static PyMemberDef uop_members[] = {
-    { "valid", Py_T_UBYTE, offsetof(_PyUOpExecutorObject, base.vm_data.valid), Py_READONLY, "is valid?" },
-    { NULL }
-};
-
 static PyTypeObject UOpExecutor_Type = {
     PyVarObject_HEAD_INIT(&PyType_Type, 0)
     .tp_name = "uop_executor",
@@ -383,7 +383,7 @@ static PyTypeObject UOpExecutor_Type = {
     .tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_DISALLOW_INSTANTIATION,
     .tp_dealloc = (destructor)uop_dealloc,
     .tp_as_sequence = &uop_as_sequence,
-    .tp_members = uop_members,
+    .tp_methods = executor_methods,
 };
 
 static int


### PR DESCRIPTION
Partial fix for crashes with export PYTHONUOPS=1

Builtin methods seem more robust than builtin properties.
This is clearly a workaround, rather than a proper fix, but a proper fix will be a lot of work.


<!-- gh-issue-number: gh-111339 -->
* Issue: gh-111339
<!-- /gh-issue-number -->
