### PR TITLE
gh-111356: Add missing documented objects to io.__all__

### DIFF
--- a/Lib/io.py
+++ b/Lib/io.py
@@ -45,7 +45,8 @@ __all__ = ["BlockingIOError", "open", "open_code", "IOBase", "RawIOBase",
            "FileIO", "BytesIO", "StringIO", "BufferedIOBase",
            "BufferedReader", "BufferedWriter", "BufferedRWPair",
            "BufferedRandom", "TextIOBase", "TextIOWrapper",
-           "UnsupportedOperation", "SEEK_SET", "SEEK_CUR", "SEEK_END"]
+           "UnsupportedOperation", "SEEK_SET", "SEEK_CUR", "SEEK_END",
+           "DEFAULT_BUFFER_SIZE", "text_encoding", "IncrementalNewlineDecoder"]
 
 
 import _io

--- a/Lib/test/test_io.py
+++ b/Lib/test/test_io.py
@@ -4042,19 +4042,18 @@ class PyIncrementalNewlineDecoderTest(IncrementalNewlineDecoderTest):
 
 class MiscIOTest(unittest.TestCase):
 
+    # for test__all__, actual values are set in subclasses
+    name_of_module = None
+    extra_exported = ()
+    not_exported = ()
+
     def tearDown(self):
         os_helper.unlink(os_helper.TESTFN)
 
     def test___all__(self):
-        for name in self.io.__all__:
-            obj = getattr(self.io, name, None)
-            self.assertIsNotNone(obj, name)
-            if name in ("open", "open_code"):
-                continue
-            elif "error" in name.lower() or name == "UnsupportedOperation":
-                self.assertTrue(issubclass(obj, Exception), name)
-            elif not name.startswith("SEEK_"):
-                self.assertTrue(issubclass(obj, self.IOBase))
+        support.check__all__(self, self.io, self.name_of_module,
+                             extra=self.extra_exported,
+                             not_exported=self.not_exported)
 
     def test_attributes(self):
         f = self.open(os_helper.TESTFN, "wb", buffering=0)
@@ -4416,6 +4415,8 @@ class MiscIOTest(unittest.TestCase):
 
 class CMiscIOTest(MiscIOTest):
     io = io
+    name_of_module = "io", "_io"
+    extra_exported = "BlockingIOError",
 
     def test_readinto_buffer_overflow(self):
         # Issue #18025
@@ -4480,6 +4481,9 @@ class CMiscIOTest(MiscIOTest):
 
 class PyMiscIOTest(MiscIOTest):
     io = pyio
+    name_of_module = "_pyio", "io"
+    extra_exported = "BlockingIOError", "open_code",
+    not_exported = "valid_seek_flags",
 
 
 @unittest.skipIf(os.name == 'nt', 'POSIX signals required for this test.')
@@ -4767,7 +4771,7 @@ def load_tests(loader, tests, pattern):
     mocks = (MockRawIO, MisbehavedRawIO, MockFileIO, CloseFailureIO,
              MockNonBlockWriterIO, MockUnseekableIO, MockRawIOWithoutRead,
              SlowFlushRawIO)
-    all_members = io.__all__ + ["IncrementalNewlineDecoder"]
+    all_members = io.__all__
     c_io_ns = {name : getattr(io, name) for name in all_members}
     py_io_ns = {name : getattr(pyio, name) for name in all_members}
     globs = globals()

--- a/Misc/NEWS.d/next/Library/2023-10-30-08-50-46.gh-issue-111356.Bc8LvA.rst
+++ b/Misc/NEWS.d/next/Library/2023-10-30-08-50-46.gh-issue-111356.Bc8LvA.rst
@@ -1,0 +1,1 @@
+Added :func:`io.text_encoding()`, :data:`io.DEFAULT_BUFFER_SIZE`, and :class:`io.IncrementalNewlineDecoder` to ``io.__all__``.


### PR DESCRIPTION
This change updates `io.__all__` with three missing public and documented entries: [`text_encoding()`](https://docs.python.org/3/library/io.html?highlight=text_encoding#io.text_encoding), [`DEFAULT_BUFFER_SIZE`](https://docs.python.org/3/library/io.html?highlight=text_encoding#io.DEFAULT_BUFFER_SIZE), and [`IncrementalNewlineDecoder`](https://docs.python.org/3/library/io.html?highlight=text_encoding#io.IncrementalNewlineDecoder).

As suggested by @AlexWaygood, I have also updated the tests to check `__all__` using `test.support.check__all__()`. As a matter of fact, there already was `test__all__()` in `MiscIOTest`, which ostensibly checked that all exported symbols existed. It seems like the test was also designed to check some properties of the exported objects; however, these existing checks failed for me.

I have removed the existing checks and replaced them with the suggest `check__all__()`. I am using a few new attributes to tailor the test to `CMiscIOTest` and `PyMiscIOTest`, respectively.

Since I don't understand why existing tests would fail, some extra attention might be warranted here. There is also another detail of possible interest: `IncrementalNewlineDecoder` was not added to `io.__all__`, but was added to `all_members` in the test setup. This could indicate an intentional omission (albeit 15 years ago).

<!-- gh-issue-number: gh-111356 -->
* Issue: gh-111356
<!-- /gh-issue-number -->
