### PR TITLE
gh-111380: Show SyntaxWarnings only once when parsing if invalid syntax is encouintered

### DIFF
--- a/Lib/test/test_string_literals.py
+++ b/Lib/test/test_string_literals.py
@@ -131,6 +131,18 @@ class TestLiterals(unittest.TestCase):
         self.assertEqual(exc.lineno, 1)
         self.assertEqual(exc.offset, 1)
 
+        # Check that the warning is raised ony once if there are syntax errors
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter('always', category=SyntaxWarning)
+            with self.assertRaises(SyntaxError) as cm:
+                eval("'\\e' $")
+            exc = cm.exception
+        self.assertEqual(len(w), 1)
+        self.assertEqual(w[0].category, SyntaxWarning)
+        self.assertRegex(str(w[0].message), 'invalid escape sequence')
+        self.assertEqual(w[0].filename, '<string>')
+
     def test_eval_str_invalid_octal_escape(self):
         for i in range(0o400, 0o1000):
             with self.assertWarns(SyntaxWarning):

--- a/Misc/NEWS.d/next/Core and Builtins/2023-10-27-11-51-40.gh-issue-111380.vgSbir.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2023-10-27-11-51-40.gh-issue-111380.vgSbir.rst
@@ -1,0 +1,2 @@
+Fix a bug that was causing :exc:`SyntaxWarning` to appear twice when parsing
+if invalid syntax is encountered later. Patch by Pablo galindo

--- a/Parser/string_parser.c
+++ b/Parser/string_parser.c
@@ -13,6 +13,11 @@
 static int
 warn_invalid_escape_sequence(Parser *p, const char *first_invalid_escape, Token *t)
 {
+    if (p->call_invalid_rules) {
+        // Do not report warnings if we are in the second pass of the parser
+        // to avoid showing the warning twice.
+        return 0;
+    }
     unsigned char c = *first_invalid_escape;
     if ((t->type == FSTRING_MIDDLE || t->type == FSTRING_END) && (c == '{' || c == '}')) {
         // in this case the tokenizer has already emitted a warning,


### PR DESCRIPTION


<!-- gh-issue-number: gh-111380 -->
* Issue: gh-111380
<!-- /gh-issue-number -->
