### PR TITLE
gh-111386: Fix `uint32_t` cast in `generated_cases.c.h`

### DIFF
--- a/Python/bytecodes.c
+++ b/Python/bytecodes.c
@@ -2686,7 +2686,7 @@ dummy_func(
             assert(next_instr[oparg].op.code == END_FOR ||
                    next_instr[oparg].op.code == INSTRUMENTED_END_FOR);
             assert(1 + INLINE_CACHE_ENTRIES_FOR_ITER == next_instr - frame->instr_ptr);
-            frame->return_offset = (uint16_t)1 + INLINE_CACHE_ENTRIES_FOR_ITER + oparg;
+            frame->return_offset = (uint16_t)(1 + INLINE_CACHE_ENTRIES_FOR_ITER + oparg);
             DISPATCH_INLINED(gen_frame);
         }
 

--- a/Python/bytecodes.c
+++ b/Python/bytecodes.c
@@ -2686,7 +2686,7 @@ dummy_func(
             assert(next_instr[oparg].op.code == END_FOR ||
                    next_instr[oparg].op.code == INSTRUMENTED_END_FOR);
             assert(1 + INLINE_CACHE_ENTRIES_FOR_ITER == next_instr - frame->instr_ptr);
-            frame->return_offset = 1 + INLINE_CACHE_ENTRIES_FOR_ITER + oparg;
+            frame->return_offset = (uint16_t)1 + INLINE_CACHE_ENTRIES_FOR_ITER + oparg;
             DISPATCH_INLINED(gen_frame);
         }
 

--- a/Python/generated_cases.c.h
+++ b/Python/generated_cases.c.h
@@ -3440,7 +3440,7 @@
             assert(next_instr[oparg].op.code == END_FOR ||
                    next_instr[oparg].op.code == INSTRUMENTED_END_FOR);
             assert(1 + INLINE_CACHE_ENTRIES_FOR_ITER == next_instr - frame->instr_ptr);
-            frame->return_offset = (uint16_t)1 + INLINE_CACHE_ENTRIES_FOR_ITER + oparg;
+            frame->return_offset = (uint16_t)(1 + INLINE_CACHE_ENTRIES_FOR_ITER + oparg);
             DISPATCH_INLINED(gen_frame);
         }
 

--- a/Python/generated_cases.c.h
+++ b/Python/generated_cases.c.h
@@ -3440,7 +3440,7 @@
             assert(next_instr[oparg].op.code == END_FOR ||
                    next_instr[oparg].op.code == INSTRUMENTED_END_FOR);
             assert(1 + INLINE_CACHE_ENTRIES_FOR_ITER == next_instr - frame->instr_ptr);
-            frame->return_offset = 1 + INLINE_CACHE_ENTRIES_FOR_ITER + oparg;
+            frame->return_offset = (uint16_t)1 + INLINE_CACHE_ENTRIES_FOR_ITER + oparg;
             DISPATCH_INLINED(gen_frame);
         }
 


### PR DESCRIPTION
Other places in this file just cast it:

```
» ag -Q 'frame->return_offset = (uint16_t)' Python/bytecodes.c
984:                frame->return_offset = (uint16_t)(1 + INLINE_CACHE_ENTRIES_SEND + oparg);
1023:            frame->return_offset = (uint16_t)(1 + INLINE_CACHE_ENTRIES_SEND + oparg);
2689:            frame->return_offset = (uint16_t)1 + INLINE_CACHE_ENTRIES_FOR_ITER + oparg;
3972:            frame->return_offset = (uint16_t)(next_instr - frame->instr_ptr);
```

Now, warning should be gone!

<!-- gh-issue-number: gh-111386 -->
* Issue: gh-111386
<!-- /gh-issue-number -->
