### PR TITLE
gh-108765: Include explicitly <unistd.h> in signalmodule.c

### DIFF
--- a/Doc/whatsnew/3.13.rst
+++ b/Doc/whatsnew/3.13.rst
@@ -1120,7 +1120,8 @@ Porting to Python 3.13
 * ``Python.h`` no longer includes the ``<unistd.h>`` standard header file. If
   needed, it should now be included explicitly. For example, it provides the
   functions: ``read()``, ``write()``, ``close()``, ``isatty()``, ``lseek()``,
-  ``getpid()``, ``getcwd()``, ``sysconf()`` and ``getpagesize()``.
+  ``getpid()``, ``getcwd()``, ``sysconf()``, ``getpagesize()``, ``alarm()`` and
+  ``pause()``.
   As a consequence, ``_POSIX_SEMAPHORES`` and ``_POSIX_THREADS`` macros are no
   longer defined by ``Python.h``. The ``HAVE_UNISTD_H`` and ``HAVE_PTHREAD_H``
   macros defined by ``Python.h`` can be used to decide if ``<unistd.h>`` and

--- a/Modules/signalmodule.c
+++ b/Modules/signalmodule.c
@@ -21,6 +21,7 @@
 #  include "socketmodule.h"       // SOCKET_T
 #endif
 
+#include <unistd.h>               // alarm()
 #ifdef MS_WINDOWS
 #  ifdef HAVE_PROCESS_H
 #    include <process.h>

--- a/Modules/signalmodule.c
+++ b/Modules/signalmodule.c
@@ -21,7 +21,9 @@
 #  include "socketmodule.h"       // SOCKET_T
 #endif
 
-#include <unistd.h>               // alarm()
+#ifdef HAVE_UNISTD_H
+#  include <unistd.h>             // alarm()
+#endif
 #ifdef MS_WINDOWS
 #  ifdef HAVE_PROCESS_H
 #    include <process.h>


### PR DESCRIPTION
unistd.h is needed by alarm() and pause().

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-108765 -->
* Issue: gh-108765
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--111402.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->