### PR TITLE
gh-111406: Fix broken link to bpython's site

### DIFF
--- a/Doc/tutorial/interactive.rst
+++ b/Doc/tutorial/interactive.rst
@@ -51,4 +51,4 @@ bpython_.
 
 .. _GNU Readline: https://tiswww.case.edu/php/chet/readline/rltop.html
 .. _IPython: https://ipython.org/
-.. _bpython: https://www.bpython-interpreter.org/
+.. _bpython: https://bpython-interpreter.org/


### PR DESCRIPTION
This is a simple fix for #111406

<!-- gh-issue-number: gh-111406 -->
* Issue: gh-111406
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--111407.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->