### PR TITLE
gh-111374: Add a new PYTHON_FROZEN_MODULES env var, equivalent of `-X frozen_modules`.

### DIFF
--- a/Doc/using/cmdline.rst
+++ b/Doc/using/cmdline.rst
@@ -540,7 +540,8 @@ Miscellaneous options
      if this is an installed Python (the normal case).  If it's under
      development (running from the source tree) then the default is "off".
      Note that the "importlib_bootstrap" and "importlib_bootstrap_external"
-     frozen modules are always used, even if this flag is set to "off".
+     frozen modules are always used, even if this flag is set to "off". See
+     also :envvar:`PYTHONFROZENMODULES`.
    * ``-X perf`` enables support for the Linux ``perf`` profiler.
      When this option is provided, the ``perf`` profiler will be able to
      report Python calls. This option is only available on some platforms and
@@ -1088,6 +1089,19 @@ conflict.
    values of :func:`os.cpu_count` and :func:`os.process_cpu_count`.
 
    See also the :option:`-X cpu_count <-X>` command-line option.
+
+   .. versionadded:: 3.13
+
+.. envvar:: PYTHONFROZENMODULES
+
+   If this variable is set, it determines whether or not frozen modules are
+   ignored by the import machinery.  A value of "on" means they get
+   imported and "off" means they are ignored.  The default is "on"
+   for non-debug builds (the normal case) and "off" for debug builds.
+   Note that the "importlib_bootstrap" and "importlib_bootstrap_external"
+   frozen modules are always used, even if this flag is set to "off".
+
+   See also the :option:`-X frozen_modules` command-line option.
 
    .. versionadded:: 3.13
 

--- a/Doc/using/cmdline.rst
+++ b/Doc/using/cmdline.rst
@@ -535,13 +535,13 @@ Miscellaneous options
      location indicators when the interpreter displays tracebacks. See also
      :envvar:`PYTHONNODEBUGRANGES`.
    * ``-X frozen_modules`` determines whether or not frozen modules are
-     ignored by the import machinery.  A value of "on" means they get
-     imported and "off" means they are ignored.  The default is "on"
+     ignored by the import machinery.  A value of ``on`` means they get
+     imported and ``off`` means they are ignored.  The default is ``on``
      if this is an installed Python (the normal case).  If it's under
-     development (running from the source tree) then the default is "off".
-     Note that the "importlib_bootstrap" and "importlib_bootstrap_external"
-     frozen modules are always used, even if this flag is set to "off". See
-     also :envvar:`PYTHON_FROZEN_MODULES`.
+     development (running from the source tree) then the default is ``off``.
+     Note that the :mod:`!importlib_bootstrap` and
+     :mod:`!importlib_bootstrap_external` frozen modules are always used, even
+     if this flag is set to ``off``. See also :envvar:`PYTHON_FROZEN_MODULES`.
    * ``-X perf`` enables support for the Linux ``perf`` profiler.
      When this option is provided, the ``perf`` profiler will be able to
      report Python calls. This option is only available on some platforms and
@@ -1098,8 +1098,9 @@ conflict.
    frozen modules are ignored by the import machinery.  A value of ``on`` means
    they get imported and ``off`` means they are ignored.  The default is ``on``
    for non-debug builds (the normal case) and ``off`` for debug builds.
-   Note that the :mod:`!importlib_bootstrap` and :mod:`!importlib_bootstrap_external`
-   frozen modules are always used, even if this flag is set to ``off``.
+   Note that the :mod:`!importlib_bootstrap` and
+   :mod:`!importlib_bootstrap_external` frozen modules are always used, even
+   if this flag is set to ``off``.
 
    See also the :option:`-X frozen_modules <-X>` command-line option.
 

--- a/Doc/using/cmdline.rst
+++ b/Doc/using/cmdline.rst
@@ -1094,9 +1094,9 @@ conflict.
 
 .. envvar:: PYTHONFROZENMODULES
 
-   If this variable is set, it determines whether or not frozen modules are
-   ignored by the import machinery.  A value of "on" means they get
-   imported and "off" means they are ignored.  The default is "on"
+   If this variable is set to ``on`` or ``off``, it determines whether or not
+   frozen modules are ignored by the import machinery.  A value of "on" means
+   they get imported and "off" means they are ignored.  The default is "on"
    for non-debug builds (the normal case) and "off" for debug builds.
    Note that the "importlib_bootstrap" and "importlib_bootstrap_external"
    frozen modules are always used, even if this flag is set to "off".

--- a/Doc/using/cmdline.rst
+++ b/Doc/using/cmdline.rst
@@ -1101,7 +1101,7 @@ conflict.
    Note that the "importlib_bootstrap" and "importlib_bootstrap_external"
    frozen modules are always used, even if this flag is set to "off".
 
-   See also the :option:`-X frozen_modules` command-line option.
+   See also the :option:`-X frozen_modules <-X>` command-line option.
 
    .. versionadded:: 3.13
 

--- a/Doc/using/cmdline.rst
+++ b/Doc/using/cmdline.rst
@@ -541,7 +541,7 @@ Miscellaneous options
      development (running from the source tree) then the default is "off".
      Note that the "importlib_bootstrap" and "importlib_bootstrap_external"
      frozen modules are always used, even if this flag is set to "off". See
-     also :envvar:`PYTHONFROZENMODULES`.
+     also :envvar:`PYTHON_FROZEN_MODULES`.
    * ``-X perf`` enables support for the Linux ``perf`` profiler.
      When this option is provided, the ``perf`` profiler will be able to
      report Python calls. This option is only available on some platforms and
@@ -1092,7 +1092,7 @@ conflict.
 
    .. versionadded:: 3.13
 
-.. envvar:: PYTHONFROZENMODULES
+.. envvar:: PYTHON_FROZEN_MODULES
 
    If this variable is set to ``on`` or ``off``, it determines whether or not
    frozen modules are ignored by the import machinery.  A value of "on" means

--- a/Doc/using/cmdline.rst
+++ b/Doc/using/cmdline.rst
@@ -1095,11 +1095,11 @@ conflict.
 .. envvar:: PYTHON_FROZEN_MODULES
 
    If this variable is set to ``on`` or ``off``, it determines whether or not
-   frozen modules are ignored by the import machinery.  A value of "on" means
-   they get imported and "off" means they are ignored.  The default is "on"
-   for non-debug builds (the normal case) and "off" for debug builds.
-   Note that the "importlib_bootstrap" and "importlib_bootstrap_external"
-   frozen modules are always used, even if this flag is set to "off".
+   frozen modules are ignored by the import machinery.  A value of ``on`` means
+   they get imported and ``off`` means they are ignored.  The default is ``on``
+   for non-debug builds (the normal case) and ``off`` for debug builds.
+   Note that the :mod:`!importlib_bootstrap` and :mod:`!importlib_bootstrap_external`
+   frozen modules are always used, even if this flag is set to ``off``.
 
    See also the :option:`-X frozen_modules <-X>` command-line option.
 

--- a/Doc/whatsnew/3.13.rst
+++ b/Doc/whatsnew/3.13.rst
@@ -121,7 +121,8 @@ Other Language Changes
   (Contributed by Irit Katriel in :gh:`111123`.)
 
 * Added a new environment variable :envvar:`PYTHON_FROZEN_MODULES`. It
-  determines whether or not frozen modules are ignored by the import machinery.
+  determines whether or not frozen modules are ignored by the import machinery,
+  equivalent of the :option:`-X frozen_modules <-X>` command line option.
   (Contributed by Yilei Yang in :gh:`111374`.)
 
 New Modules

--- a/Doc/whatsnew/3.13.rst
+++ b/Doc/whatsnew/3.13.rst
@@ -120,6 +120,10 @@ Other Language Changes
   is rejected when the global is used in the :keyword:`else` block.
   (Contributed by Irit Katriel in :gh:`111123`.)
 
+* Added a new environment variable :envvar:`PYTHON_FROZEN_MODULES`. It
+  determines whether or not frozen modules are ignored by the import machinery.
+  (Contributed by Yilei Yang in :gh:`111374`.)
+
 New Modules
 ===========
 

--- a/Doc/whatsnew/3.13.rst
+++ b/Doc/whatsnew/3.13.rst
@@ -122,7 +122,7 @@ Other Language Changes
 
 * Added a new environment variable :envvar:`PYTHON_FROZEN_MODULES`. It
   determines whether or not frozen modules are ignored by the import machinery,
-  equivalent of the :option:`-X frozen_modules <-X>` command line option.
+  equivalent of the :option:`-X frozen_modules <-X>` command-line option.
   (Contributed by Yilei Yang in :gh:`111374`.)
 
 New Modules

--- a/Lib/test/test_cmd_line.py
+++ b/Lib/test/test_cmd_line.py
@@ -157,7 +157,7 @@ class CmdLineTest(unittest.TestCase):
         tests = {
             ('on', 'FrozenImporter'),
             ('off', 'SourceFileLoader'),
-            ('', 'FrozenImporter'),
+            ('', 'SourceFileLoader'),
         }
         for raw, expected in tests:
             cmd = ['-c', 'import os; print(os.__spec__.loader, end="")']

--- a/Lib/test/test_cmd_line.py
+++ b/Lib/test/test_cmd_line.py
@@ -157,7 +157,6 @@ class CmdLineTest(unittest.TestCase):
         tests = {
             ('on', 'FrozenImporter'),
             ('off', 'SourceFileLoader'),
-            ('', 'SourceFileLoader'),
         }
         for raw, expected in tests:
             cmd = ['-c', 'import os; print(os.__spec__.loader, end="")']

--- a/Lib/test/test_cmd_line.py
+++ b/Lib/test/test_cmd_line.py
@@ -153,6 +153,18 @@ class CmdLineTest(unittest.TestCase):
                 res = assert_python_ok(*cmd)
                 self.assertRegex(res.out.decode('utf-8'), expected)
 
+    def test_env_var_frozen_modules(self):
+        tests = {
+            ('on', 'FrozenImporter'),
+            ('off', 'SourceFileLoader'),
+            ('', 'FrozenImporter'),
+        }
+        for raw, expected in tests:
+            cmd = ['-c', 'import os; print(os.__spec__.loader, end="")']
+            with self.subTest(raw):
+                res = assert_python_ok(*cmd, PYTHONFROZENMODULES=raw)
+                self.assertRegex(res.out.decode('utf-8'), expected)
+
     def test_run_module(self):
         # Test expected operation of the '-m' switch
         # Switch needs an argument

--- a/Lib/test/test_cmd_line.py
+++ b/Lib/test/test_cmd_line.py
@@ -161,7 +161,7 @@ class CmdLineTest(unittest.TestCase):
         for raw, expected in tests:
             cmd = ['-c', 'import os; print(os.__spec__.loader, end="")']
             with self.subTest(raw):
-                res = assert_python_ok(*cmd, PYTHONFROZENMODULES=raw)
+                res = assert_python_ok(*cmd, PYTHON_FROZEN_MODULES=raw)
                 self.assertRegex(res.out.decode('utf-8'), expected)
 
     def test_run_module(self):

--- a/Misc/NEWS.d/next/Core and Builtins/2023-10-27-11-22-09.gh-issue-111374.e9lrPZ.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2023-10-27-11-22-09.gh-issue-111374.e9lrPZ.rst
@@ -1,3 +1,3 @@
 Added a new environment variable :envvar:`PYTHON_FROZEN_MODULES`. It
 determines whether or not frozen modules are ignored by the import machinery,
-equivalent of the :option:`-X frozen_modules <-X>` command line option.
+equivalent of the :option:`-X frozen_modules <-X>` command-line option.

--- a/Misc/NEWS.d/next/Core and Builtins/2023-10-27-11-22-09.gh-issue-111374.e9lrPZ.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2023-10-27-11-22-09.gh-issue-111374.e9lrPZ.rst
@@ -1,0 +1,3 @@
+Add a new environment variable, "PYTHONFROZENMODULES=[on|off]" to opt out of
+(or into) using optional frozen modules. Equivalent of the
+"-X frozen_modules=[on|off]" command line option.

--- a/Misc/NEWS.d/next/Core and Builtins/2023-10-27-11-22-09.gh-issue-111374.e9lrPZ.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2023-10-27-11-22-09.gh-issue-111374.e9lrPZ.rst
@@ -1,3 +1,3 @@
-Add a new environment variable, "PYTHONFROZENMODULES=[on|off]" to opt out of
+Add a new environment variable, "PYTHON_FROZEN_MODULES=[on|off]" to opt out of
 (or into) using optional frozen modules. Equivalent of the
 "-X frozen_modules=[on|off]" command line option.

--- a/Misc/NEWS.d/next/Core and Builtins/2023-10-27-11-22-09.gh-issue-111374.e9lrPZ.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2023-10-27-11-22-09.gh-issue-111374.e9lrPZ.rst
@@ -1,3 +1,3 @@
-Add a new environment variable, "PYTHON_FROZEN_MODULES=[on|off]" to opt out of
-(or into) using optional frozen modules. Equivalent of the
-"-X frozen_modules=[on|off]" command line option.
+Added a new environment variable :envvar:`PYTHON_FROZEN_MODULES`. It
+determines whether or not frozen modules are ignored by the import machinery,
+equivalent of the :option:`-X frozen_modules <-X>` command line option.

--- a/Python/initconfig.c
+++ b/Python/initconfig.c
@@ -285,11 +285,14 @@ static const char usage_envvars[] =
 "PYTHONDEVMODE: enable the development mode.\n"
 "PYTHONPYCACHEPREFIX: root directory for bytecode cache (pyc) files.\n"
 "PYTHONWARNDEFAULTENCODING: enable opt-in EncodingWarning for 'encoding=None'.\n"
-"PYTHONNODEBUGRANGES: If this variable is set, it disables the inclusion of the \n"
+"PYTHONNODEBUGRANGES: if this variable is set, it disables the inclusion of the \n"
 "   tables mapping extra location information (end line, start column offset \n"
 "   and end column offset) to every instruction in code objects. This is useful \n"
 "   when smaller code objects and pyc files are desired as well as suppressing the \n"
 "   extra visual location indicators when the interpreter displays tracebacks.\n"
+"PYTHONFROZENMODULES     : if this variable is set, it determines whether or not \n"
+"   frozen modules should be used. The default is \"on\" (or \"off\" if you are \n"
+"   running a local build).\n"
 "These variables have equivalent command-line parameters (see --help for details):\n"
 "PYTHONDEBUG             : enable parser debug mode (-d)\n"
 "PYTHONDONTWRITEBYTECODE : don't write .pyc files (-B)\n"
@@ -2130,6 +2133,23 @@ config_init_import(PyConfig *config, int compute_path_config)
     status = _PyConfig_InitPathConfig(config, compute_path_config);
     if (_PyStatus_EXCEPTION(status)) {
         return status;
+    }
+
+    const char *env = config_get_env(config, "PYTHONFROZENMODULES");
+    if (env == NULL) {
+    }
+    else if (strcmp(env, "on") == 0) {
+        config->use_frozen_modules = 1;
+    }
+    else if (strcmp(env, "off") == 0) {
+        config->use_frozen_modules = 0;
+    }
+    else if (strlen(env) == 0) {
+        // "PYTHONFROZENMODULES=" implies "on".
+        config->use_frozen_modules = 1;
+    } else {
+        return PyStatus_Error("bad value for PYTHONFROZENMODULES "
+                              "(expected \"on\" or \"off\")");
     }
 
     /* -X frozen_modules=[on|off] */

--- a/Python/initconfig.c
+++ b/Python/initconfig.c
@@ -2143,10 +2143,6 @@ config_init_import(PyConfig *config, int compute_path_config)
     }
     else if (strcmp(env, "off") == 0) {
         config->use_frozen_modules = 0;
-    }
-    else if (strlen(env) == 0) {
-        // "PYTHONFROZENMODULES=" implies "on".
-        config->use_frozen_modules = 1;
     } else {
         return PyStatus_Error("bad value for PYTHONFROZENMODULES "
                               "(expected \"on\" or \"off\")");

--- a/Python/initconfig.c
+++ b/Python/initconfig.c
@@ -290,7 +290,7 @@ static const char usage_envvars[] =
 "   and end column offset) to every instruction in code objects. This is useful \n"
 "   when smaller code objects and pyc files are desired as well as suppressing the \n"
 "   extra visual location indicators when the interpreter displays tracebacks.\n"
-"PYTHONFROZENMODULES     : if this variable is set, it determines whether or not \n"
+"PYTHON_FROZEN_MODULES     : if this variable is set, it determines whether or not \n"
 "   frozen modules should be used. The default is \"on\" (or \"off\" if you are \n"
 "   running a local build).\n"
 "These variables have equivalent command-line parameters (see --help for details):\n"
@@ -2135,7 +2135,7 @@ config_init_import(PyConfig *config, int compute_path_config)
         return status;
     }
 
-    const char *env = config_get_env(config, "PYTHONFROZENMODULES");
+    const char *env = config_get_env(config, "PYTHON_FROZEN_MODULES");
     if (env == NULL) {
     }
     else if (strcmp(env, "on") == 0) {
@@ -2144,7 +2144,7 @@ config_init_import(PyConfig *config, int compute_path_config)
     else if (strcmp(env, "off") == 0) {
         config->use_frozen_modules = 0;
     } else {
-        return PyStatus_Error("bad value for PYTHONFROZENMODULES "
+        return PyStatus_Error("bad value for PYTHON_FROZEN_MODULES "
                               "(expected \"on\" or \"off\")");
     }
 

--- a/Python/initconfig.c
+++ b/Python/initconfig.c
@@ -290,7 +290,7 @@ static const char usage_envvars[] =
 "   and end column offset) to every instruction in code objects. This is useful \n"
 "   when smaller code objects and pyc files are desired as well as suppressing the \n"
 "   extra visual location indicators when the interpreter displays tracebacks.\n"
-"PYTHON_FROZEN_MODULES     : if this variable is set, it determines whether or not \n"
+"PYTHON_FROZEN_MODULES   : if this variable is set, it determines whether or not \n"
 "   frozen modules should be used. The default is \"on\" (or \"off\" if you are \n"
 "   running a local build).\n"
 "These variables have equivalent command-line parameters (see --help for details):\n"


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

It seems that `config_get_env` can't distinguish between "not set" and "set to an empty string"? So `PYTHON_FROZEN_MODULES=` means differently than `-X frozen_modules` without values. I'm not sure if this could create confusion, but on the other hand the use of `-X frozen_modules` or `-X frozen_modules=` with empty values isn't explicitly documented.

<!-- gh-issue-number: gh-111374 -->
* Issue: gh-111374
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--111411.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->