### PR TITLE
GH-111339: Move optimizer types to `object.c`

### DIFF
--- a/Include/internal/pycore_optimizer.h
+++ b/Include/internal/pycore_optimizer.h
@@ -14,15 +14,10 @@ int _Py_uop_analyze_and_optimize(PyCodeObject *code,
     _PyUOpInstruction *trace, int trace_len, int curr_stackentries);
 
 extern PyTypeObject _PyCounterExecutor_Type;
-#define _PyCounterExecutor_Check(op) Py_IS_TYPE((op), &_PyCounterExecutor_Type)
 extern PyTypeObject _PyCounterOptimizer_Type;
-#define _PyCounterOptimizer_Check(op) Py_IS_TYPE((op), &_PyCounterOptimizer_Type)
 extern PyTypeObject _PyDefaultOptimizer_Type;
-#define _PyDefaultOptimizer_Check(op) Py_IS_TYPE((op), &_PyDefaultOptimizer_Type)
 extern PyTypeObject _PyUOpExecutor_Type;
-#define _PyUOpExecutor_Check(op) Py_IS_TYPE((op), &_PyUOpExecutor_Type)
 extern PyTypeObject _PyUOpOptimizer_Type;
-#define _PyUOpOptimizer_Check(op) Py_IS_TYPE((op), &_PyUOpOptimizer_Type)
 
 #ifdef __cplusplus
 }

--- a/Include/internal/pycore_optimizer.h
+++ b/Include/internal/pycore_optimizer.h
@@ -13,6 +13,16 @@ extern "C" {
 int _Py_uop_analyze_and_optimize(PyCodeObject *code,
     _PyUOpInstruction *trace, int trace_len, int curr_stackentries);
 
+extern PyTypeObject _PyCounterExecutor_Type;
+#define _PyCounterExecutor_Check(op) Py_IS_TYPE((op), &_PyCounterExecutor_Type)
+extern PyTypeObject _PyCounterOptimizer_Type;
+#define _PyCounterOptimizer_Check(op) Py_IS_TYPE((op), &_PyCounterOptimizer_Type)
+extern PyTypeObject _PyDefaultOptimizer_Type;
+#define _PyDefaultOptimizer_Check(op) Py_IS_TYPE((op), &_PyDefaultOptimizer_Type)
+extern PyTypeObject _PyUOpExecutor_Type;
+#define _PyUOpExecutor_Check(op) Py_IS_TYPE((op), &_PyUOpExecutor_Type)
+extern PyTypeObject _PyUOpOptimizer_Type;
+#define _PyUOpOptimizer_Check(op) Py_IS_TYPE((op), &_PyUOpOptimizer_Type)
 
 #ifdef __cplusplus
 }

--- a/Objects/object.c
+++ b/Objects/object.c
@@ -13,7 +13,7 @@
 #include "pycore_memoryobject.h"  // _PyManagedBuffer_Type
 #include "pycore_namespace.h"     // _PyNamespace_Type
 #include "pycore_object.h"        // PyAPI_DATA() _Py_SwappedOp definition
-#include "pycore_optimizer.h"     // _Py_uop_analyze_and_optimize()
+#include "pycore_optimizer.h"     // _PyCounterExecutor_Type, _PyCounterOptimizer_Type, _PyDefaultOptimizer_Type, _PyUOpExecutor_Type, _PyUOpOptimizer_Type
 #include "pycore_pyerrors.h"      // _PyErr_Occurred()
 #include "pycore_pymem.h"         // _PyMem_IsPtrFreed()
 #include "pycore_pystate.h"       // _PyThreadState_GET()

--- a/Objects/object.c
+++ b/Objects/object.c
@@ -13,7 +13,7 @@
 #include "pycore_memoryobject.h"  // _PyManagedBuffer_Type
 #include "pycore_namespace.h"     // _PyNamespace_Type
 #include "pycore_object.h"        // PyAPI_DATA() _Py_SwappedOp definition
-#include "pycore_optimizer.h"     // _PyCounterExecutor_Type, _PyCounterOptimizer_Type, _PyDefaultOptimizer_Type, _PyUOpExecutor_Type, _PyUOpOptimizer_Type
+#include "pycore_optimizer.h"     // _PyUOpExecutor_Type, _PyUOpOptimizer_Type, ...
 #include "pycore_pyerrors.h"      // _PyErr_Occurred()
 #include "pycore_pymem.h"         // _PyMem_IsPtrFreed()
 #include "pycore_pystate.h"       // _PyThreadState_GET()

--- a/Objects/object.c
+++ b/Objects/object.c
@@ -13,6 +13,7 @@
 #include "pycore_memoryobject.h"  // _PyManagedBuffer_Type
 #include "pycore_namespace.h"     // _PyNamespace_Type
 #include "pycore_object.h"        // PyAPI_DATA() _Py_SwappedOp definition
+#include "pycore_optimizer.h"     // _Py_uop_analyze_and_optimize()
 #include "pycore_pyerrors.h"      // _PyErr_Occurred()
 #include "pycore_pymem.h"         // _PyMem_IsPtrFreed()
 #include "pycore_pystate.h"       // _PyThreadState_GET()
@@ -2157,6 +2158,9 @@ static PyTypeObject* static_types[] = {
     &_PyBufferWrapper_Type,
     &_PyContextTokenMissing_Type,
     &_PyCoroWrapper_Type,
+    &_PyCounterExecutor_Type,
+    &_PyCounterOptimizer_Type,
+    &_PyDefaultOptimizer_Type,
     &_Py_GenericAliasIterType,
     &_PyHamtItems_Type,
     &_PyHamtKeys_Type,
@@ -2176,6 +2180,8 @@ static PyTypeObject* static_types[] = {
     &_PyPositionsIterator,
     &_PyUnicodeASCIIIter_Type,
     &_PyUnion_Type,
+    &_PyUOpExecutor_Type,
+    &_PyUOpOptimizer_Type,
     &_PyWeakref_CallableProxyType,
     &_PyWeakref_ProxyType,
     &_PyWeakref_RefType,

--- a/Python/optimizer.c
+++ b/Python/optimizer.c
@@ -111,7 +111,7 @@ error_optimize(
     return -1;
 }
 
-static PyTypeObject DefaultOptimizer_Type = {
+PyTypeObject _PyDefaultOptimizer_Type = {
     PyVarObject_HEAD_INIT(&PyType_Type, 0)
     .tp_name = "noop_optimizer",
     .tp_basicsize = sizeof(_PyOptimizerObject),
@@ -120,7 +120,7 @@ static PyTypeObject DefaultOptimizer_Type = {
 };
 
 _PyOptimizerObject _PyOptimizer_Default = {
-    PyObject_HEAD_INIT(&DefaultOptimizer_Type)
+    PyObject_HEAD_INIT(&_PyDefaultOptimizer_Type)
     .optimize = error_optimize,
     .resume_threshold = UINT16_MAX,
     .backedge_threshold = UINT16_MAX,
@@ -236,7 +236,7 @@ static PyMethodDef executor_methods[] = {
     { NULL, NULL },
 };
 
-static PyTypeObject CounterExecutor_Type = {
+PyTypeObject _PyCounterExecutor_Type = {
     PyVarObject_HEAD_INIT(&PyType_Type, 0)
     .tp_name = "counting_executor",
     .tp_basicsize = sizeof(_PyCounterExecutorObject),
@@ -265,7 +265,7 @@ counter_optimize(
     int Py_UNUSED(curr_stackentries)
 )
 {
-    _PyCounterExecutorObject *executor = (_PyCounterExecutorObject *)_PyObject_New(&CounterExecutor_Type);
+    _PyCounterExecutorObject *executor = (_PyCounterExecutorObject *)_PyObject_New(&_PyCounterExecutor_Type);
     if (executor == NULL) {
         return -1;
     }
@@ -291,7 +291,7 @@ static PyMethodDef counter_optimizer_methods[] = {
     { NULL, NULL },
 };
 
-static PyTypeObject CounterOptimizer_Type = {
+PyTypeObject _PyCounterOptimizer_Type = {
     PyVarObject_HEAD_INIT(&PyType_Type, 0)
     .tp_name = "Counter optimizer",
     .tp_basicsize = sizeof(_PyCounterOptimizerObject),
@@ -304,9 +304,7 @@ static PyTypeObject CounterOptimizer_Type = {
 PyObject *
 PyUnstable_Optimizer_NewCounter(void)
 {
-    PyType_Ready(&CounterExecutor_Type);
-    PyType_Ready(&CounterOptimizer_Type);
-    _PyCounterOptimizerObject *opt = (_PyCounterOptimizerObject *)_PyObject_New(&CounterOptimizer_Type);
+    _PyCounterOptimizerObject *opt = (_PyCounterOptimizerObject *)_PyObject_New(&_PyCounterOptimizer_Type);
     if (opt == NULL) {
         return NULL;
     }
@@ -375,7 +373,7 @@ PySequenceMethods uop_as_sequence = {
     .sq_item = (ssizeargfunc)uop_item,
 };
 
-static PyTypeObject UOpExecutor_Type = {
+PyTypeObject _PyUOpExecutor_Type = {
     PyVarObject_HEAD_INIT(&PyType_Type, 0)
     .tp_name = "uop_executor",
     .tp_basicsize = sizeof(_PyUOpExecutorObject) - sizeof(_PyUOpInstruction),
@@ -929,7 +927,7 @@ uop_optimize(
         trace_length = _Py_uop_analyze_and_optimize(code, trace, trace_length, curr_stackentries);
     }
     trace_length = remove_unneeded_uops(trace, trace_length);
-    _PyUOpExecutorObject *executor = PyObject_NewVar(_PyUOpExecutorObject, &UOpExecutor_Type, trace_length);
+    _PyUOpExecutorObject *executor = PyObject_NewVar(_PyUOpExecutorObject, &_PyUOpExecutor_Type, trace_length);
     if (executor == NULL) {
         return -1;
     }
@@ -946,7 +944,7 @@ uop_opt_dealloc(PyObject *self) {
     PyObject_Free(self);
 }
 
-static PyTypeObject UOpOptimizer_Type = {
+PyTypeObject _PyUOpOptimizer_Type = {
     PyVarObject_HEAD_INIT(&PyType_Type, 0)
     .tp_name = "uop_optimizer",
     .tp_basicsize = sizeof(_PyOptimizerObject),
@@ -958,9 +956,7 @@ static PyTypeObject UOpOptimizer_Type = {
 PyObject *
 PyUnstable_Optimizer_NewUOpOptimizer(void)
 {
-    PyType_Ready(&UOpExecutor_Type);
-    PyType_Ready(&UOpOptimizer_Type);
-    _PyOptimizerObject *opt = PyObject_New(_PyOptimizerObject, &UOpOptimizer_Type);
+    _PyOptimizerObject *opt = PyObject_New(_PyOptimizerObject, &_PyUOpOptimizer_Type);
     if (opt == NULL) {
         return NULL;
     }

--- a/Tools/c-analyzer/cpython/ignored.tsv
+++ b/Tools/c-analyzer/cpython/ignored.tsv
@@ -374,11 +374,11 @@ Python/sysmodule.c	-	perf_map_state	-
 Python/sysmodule.c	-	_PySys_ImplCacheTag	-
 Python/sysmodule.c	-	_PySys_ImplName	-
 Python/sysmodule.c	-	whatstrings	-
-Python/optimizer.c	-	DefaultOptimizer_Type	-
-Python/optimizer.c	-	CounterExecutor_Type	-
-Python/optimizer.c	-	CounterOptimizer_Type	-
-Python/optimizer.c	-	UOpExecutor_Type	-
-Python/optimizer.c	-	UOpOptimizer_Type	-
+Python/optimizer.c	-	_PyDefaultOptimizer_Type	-
+Python/optimizer.c	-	_PyCounterExecutor_Type	-
+Python/optimizer.c	-	_PyCounterOptimizer_Type	-
+Python/optimizer.c	-	_PyUOpExecutor_Type	-
+Python/optimizer.c	-	_PyUOpOptimizer_Type	-
 Python/optimizer.c	-	_PyOptimizer_Default	-
 
 ##-----------------------


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
This PR moves types defined in `optimizer.c` to `static_types` in `object.c` per @brandtbucher's [hunch](https://github.com/python/cpython/issues/111339#issuecomment-1781508285). I tried to abide by the naming conventions of the other types in `static_types` by updating names to be prefixed by `_Py`. Please let me know if this is incorrect. 

I've tested this and I can no longer reproduce the assertion error.



<!-- gh-issue-number: gh-111339 -->
* Issue: gh-111339
<!-- /gh-issue-number -->
