### PR TITLE
GH-111429: Speed up `pathlib.PurePath.[is_]relative_to()`

### DIFF
--- a/Lib/pathlib.py
+++ b/Lib/pathlib.py
@@ -647,9 +647,11 @@ class PurePath:
                    "scheduled for removal in Python {remove}")
             warnings._deprecated("pathlib.PurePath.relative_to(*args)", msg,
                                  remove=(3, 14))
-        other = self.with_segments(other, *_deprecated)
+            other = self.with_segments(other, *_deprecated)
+        elif not isinstance(other, PurePath):
+            other = self.with_segments(other)
         for step, path in enumerate([other] + list(other.parents)):
-            if self.is_relative_to(path):
+            if path == self or path in self.parents:
                 break
             elif not walk_up:
                 raise ValueError(f"{str(self)!r} is not in the subpath of {str(other)!r}")
@@ -669,7 +671,9 @@ class PurePath:
                    "scheduled for removal in Python {remove}")
             warnings._deprecated("pathlib.PurePath.is_relative_to(*args)",
                                  msg, remove=(3, 14))
-        other = self.with_segments(other, *_deprecated)
+            other = self.with_segments(other, *_deprecated)
+        elif not isinstance(other, PurePath):
+            other = self.with_segments(other)
         return other == self or other in self.parents
 
     @property

--- a/Lib/pathlib.py
+++ b/Lib/pathlib.py
@@ -652,15 +652,12 @@ class PurePath:
             other = self.with_segments(other)
         for step, path in enumerate([other] + list(other.parents)):
             if path == self or path in self.parents:
-                break
+                return self.with_segments(*['..'] * step, *self._tail[len(path._tail):])
             elif not walk_up:
                 raise ValueError(f"{str(self)!r} is not in the subpath of {str(other)!r}")
             elif path.name == '..':
                 raise ValueError(f"'..' segment in {str(other)!r} cannot be walked")
-        else:
-            raise ValueError(f"{str(self)!r} and {str(other)!r} have different anchors")
-        parts = ['..'] * step + self._tail[len(path._tail):]
-        return self.with_segments(*parts)
+        raise ValueError(f"{str(self)!r} and {str(other)!r} have different anchors")
 
     def is_relative_to(self, other, /, *_deprecated):
         """Return True if the path is relative to another path or False.

--- a/Lib/pathlib.py
+++ b/Lib/pathlib.py
@@ -652,7 +652,8 @@ class PurePath:
             other = self.with_segments(other)
         for step, path in enumerate([other] + list(other.parents)):
             if path == self or path in self.parents:
-                return self.with_segments(*['..'] * step, *self._tail[len(path._tail):])
+                tail = ['..'] * step + self._tail[len(path._tail):]
+                return self._from_parsed_parts('', '', tail)
             elif not walk_up:
                 raise ValueError(f"{str(self)!r} is not in the subpath of {str(other)!r}")
             elif path.name == '..':

--- a/Lib/pathlib.py
+++ b/Lib/pathlib.py
@@ -652,13 +652,15 @@ class PurePath:
             other = self.with_segments(other)
         for step, path in enumerate([other] + list(other.parents)):
             if path == self or path in self.parents:
-                tail = ['..'] * step + self._tail[len(path._tail):]
-                return self._from_parsed_parts('', '', tail)
+                break
             elif not walk_up:
                 raise ValueError(f"{str(self)!r} is not in the subpath of {str(other)!r}")
             elif path.name == '..':
                 raise ValueError(f"'..' segment in {str(other)!r} cannot be walked")
-        raise ValueError(f"{str(self)!r} and {str(other)!r} have different anchors")
+        else:
+            raise ValueError(f"{str(self)!r} and {str(other)!r} have different anchors")
+        parts = ['..'] * step + self._tail[len(path._tail):]
+        return self._from_parsed_parts('', '', parts)
 
     def is_relative_to(self, other, /, *_deprecated):
         """Return True if the path is relative to another path or False.

--- a/Misc/NEWS.d/next/Library/2023-10-28-22-11-11.gh-issue-111429.mJGxuQ.rst
+++ b/Misc/NEWS.d/next/Library/2023-10-28-22-11-11.gh-issue-111429.mJGxuQ.rst
@@ -1,0 +1,2 @@
+Speed up :meth:`pathlib.PurePath.relative_to` and
+:meth:`~pathlib.PurePath.is_relative_to`.


### PR DESCRIPTION
Avoid unnecessary calls to `with_segments()`. This makes both `is_relative_to()` and `relative_to()` faster when passed a `PurePath` object, and makes `relative_to()` faster when passed another kind of path-like object (like a `str`).

Also, use `_from_parsed_parts()` in `relative_to()` to return a *pre-parsed* path. Operations like `str(p.relative_to(q))` are faster as a result.

<!-- gh-issue-number: gh-111429 -->
* Issue: gh-111429
<!-- /gh-issue-number -->
