### PR TITLE
gh-66425: Remove the unreachable code to set `REMOTE_HOST` header

### DIFF
--- a/Lib/wsgiref/simple_server.py
+++ b/Lib/wsgiref/simple_server.py
@@ -84,10 +84,6 @@ class WSGIRequestHandler(BaseHTTPRequestHandler):
 
         env['PATH_INFO'] = urllib.parse.unquote(path, 'iso-8859-1')
         env['QUERY_STRING'] = query
-
-        host = self.address_string()
-        if host != self.client_address[0]:
-            env['REMOTE_HOST'] = host
         env['REMOTE_ADDR'] = self.client_address[0]
 
         if self.headers.get('content-type') is None:

--- a/Misc/NEWS.d/next/Library/2023-10-29-03-46-27.gh-issue-66425.FWTdDo.rst
+++ b/Misc/NEWS.d/next/Library/2023-10-29-03-46-27.gh-issue-66425.FWTdDo.rst
@@ -1,0 +1,3 @@
+Remove the code to set the REMOTE_HOST header from wsgiref module,
+as it is unreachable. This header is used for performance reasons,
+which is not necessary in the wsgiref module.


### PR DESCRIPTION
@corona10 Hi Donghee. Thank you for leading the CPython dev. sprint at PyCon APAC 2023. This patch does not contain additional test code because it only removes the unreachable lines; there are no changes in behavior.

Please refer to https://www.rfc-editor.org/rfc/rfc3875#page-16 about `REMOTE_HOST` header.

<!-- gh-issue-number: gh-66425 -->
* Issue: gh-66425
<!-- /gh-issue-number -->
