### PR TITLE
gh-111062: Separate macOS build into a reusable workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -231,39 +231,11 @@ jobs:
 
   build_macos:
     name: 'macOS'
-    runs-on: macos-latest
-    timeout-minutes: 60
     needs: check_source
     if: needs.check_source.outputs.run_tests == 'true'
-    env:
-      HOMEBREW_NO_ANALYTICS: 1
-      HOMEBREW_NO_AUTO_UPDATE: 1
-      HOMEBREW_NO_INSTALL_CLEANUP: 1
-      PYTHONSTRICTEXTENSIONBUILD: 1
-    steps:
-    - uses: actions/checkout@v4
-    - name: Restore config.cache
-      uses: actions/cache@v3
-      with:
-        path: config.cache
-        key: ${{ github.job }}-${{ runner.os }}-${{ needs.check_source.outputs.config_hash }}
-    - name: Install Homebrew dependencies
-      run: brew install pkg-config openssl@3.0 xz gdbm tcl-tk
-    - name: Configure CPython
-      run: |
-        GDBM_CFLAGS="-I$(brew --prefix gdbm)/include" \
-        GDBM_LIBS="-L$(brew --prefix gdbm)/lib -lgdbm" \
-        ./configure \
-          --config-cache \
-          --with-pydebug \
-          --prefix=/opt/python-dev \
-          --with-openssl="$(brew --prefix openssl@3.0)"
-    - name: Build CPython
-      run: make -j4
-    - name: Display build info
-      run: make pythoninfo
-    - name: Tests
-      run: make test
+    uses: ./.github/workflows/reusable-build-macos.yml
+    with:
+      config_hash: ${{ needs.check_source.outputs.config_hash }}
 
   build_ubuntu:
     name: 'Ubuntu'

--- a/.github/workflows/reusable-build-macos.yml
+++ b/.github/workflows/reusable-build-macos.yml
@@ -7,7 +7,6 @@ on:
 
 jobs:
   build_macos:
-    name: Test on macOS
     runs-on: macos-latest
     timeout-minutes: 60
     env:

--- a/.github/workflows/reusable-build-macos.yml
+++ b/.github/workflows/reusable-build-macos.yml
@@ -1,0 +1,41 @@
+on:
+  workflow_call:
+    inputs:
+      config_hash:
+        required: true
+        type: string
+
+jobs:
+  build_macos:
+    name: Test on macOS
+    runs-on: macos-latest
+    timeout-minutes: 60
+    env:
+      HOMEBREW_NO_ANALYTICS: 1
+      HOMEBREW_NO_AUTO_UPDATE: 1
+      HOMEBREW_NO_INSTALL_CLEANUP: 1
+      PYTHONSTRICTEXTENSIONBUILD: 1
+    steps:
+    - uses: actions/checkout@v4
+    - name: Restore config.cache
+      uses: actions/cache@v3
+      with:
+        path: config.cache
+        key: ${{ github.job }}-${{ runner.os }}-${{ inputs.config_hash }}
+    - name: Install Homebrew dependencies
+      run: brew install pkg-config openssl@3.0 xz gdbm tcl-tk
+    - name: Configure CPython
+      run: |
+        GDBM_CFLAGS="-I$(brew --prefix gdbm)/include" \
+        GDBM_LIBS="-L$(brew --prefix gdbm)/lib -lgdbm" \
+        ./configure \
+          --config-cache \
+          --with-pydebug \
+          --prefix=/opt/python-dev \
+          --with-openssl="$(brew --prefix openssl@3.0)"
+    - name: Build CPython
+      run: make -j4
+    - name: Display build info
+      run: make pythoninfo
+    - name: Tests
+      run: make test


### PR DESCRIPTION
# gh-111062: Separate macOS build into a reusable workflow

For #111062, in order to run nogil build/tests, separate the build into a reusable workflow first.
