### PR TITLE
gh-111165: Remove documentation for moved functions

### DIFF
--- a/Doc/library/test.rst
+++ b/Doc/library/test.rst
@@ -498,16 +498,6 @@ The :mod:`test.support` module defines the following functions:
    rather than looking directly in the path directories.
 
 
-.. function:: match_test(test)
-
-   Determine whether *test* matches the patterns set in :func:`set_match_tests`.
-
-
-.. function:: set_match_tests(accept_patterns=None, ignore_patterns=None)
-
-   Define match patterns on test filenames and test method names for filtering tests.
-
-
 .. function:: get_pagesize()
 
    Get size of a page in bytes.


### PR DESCRIPTION


<!-- gh-issue-number: gh-111165 -->
* Issue: gh-111165
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--111467.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->