### PR TITLE
[3.11] gh-111165: Remove documentation for moved functions (GH-111467).

### DIFF
--- a/Doc/library/test.rst
+++ b/Doc/library/test.rst
@@ -489,16 +489,6 @@ The :mod:`test.support` module defines the following functions:
    rather than looking directly in the path directories.
 
 
-.. function:: match_test(test)
-
-   Determine whether *test* matches the patterns set in :func:`set_match_tests`.
-
-
-.. function:: set_match_tests(accept_patterns=None, ignore_patterns=None)
-
-   Define match patterns on test filenames and test method names for filtering tests.
-
-
 .. function:: setswitchinterval(interval)
 
    Set the :func:`sys.setswitchinterval` to the given *interval*.  Defines


### PR DESCRIPTION
(cherry picked from commit 4d6bdf8aabcc92303041420a96750fbc52c9f213)


<!-- gh-issue-number: gh-111165 -->
* Issue: gh-111165
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--111472.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->