### PR TITLE
gh-111474: Add color and a fancy output mode to regrtest

### DIFF
--- a/Lib/test/libregrtest/cmdline.py
+++ b/Lib/test/libregrtest/cmdline.py
@@ -174,6 +174,7 @@ class Namespace(argparse.Namespace):
         self.tempdir = None
         self.progress_reporter = None
         self.color = None
+        self.fancy_report_skip_reason = False
         self._add_python_opts = True
         self.xmlpath = None
         self.single_process = False
@@ -261,6 +262,8 @@ def _create_parser():
                        choices=['plain', 'fancy', 'detect'], default='detect')
     group.add_argument('--color', action=argparse.BooleanOptionalAction,
                        help='use color in the progress reports')
+    group.add_argument('--fancy_report_skip_reason', action='store_true',
+                       help='in the fancy reporter, report the skip reason')
 
     group = parser.add_argument_group('Selecting tests')
     group.add_argument('-r', '--randomize', action='store_true',

--- a/Lib/test/libregrtest/cmdline.py
+++ b/Lib/test/libregrtest/cmdline.py
@@ -172,6 +172,8 @@ class Namespace(argparse.Namespace):
         self.threshold = None
         self.fail_rerun = False
         self.tempdir = None
+        self.progress_reporter = None
+        self.color = None
         self._add_python_opts = True
         self.xmlpath = None
         self.single_process = False
@@ -255,6 +257,10 @@ def _create_parser():
                        help='print the slowest 10 tests')
     group.add_argument('--header', action='store_true',
                        help='print header with interpreter info')
+    group.add_argument('--progress_reporter',
+                       choices=['plain', 'fancy', 'detect'], default='detect')
+    group.add_argument('--color', action=argparse.BooleanOptionalAction,
+                       help='use color in the progress reports')
 
     group = parser.add_argument_group('Selecting tests')
     group.add_argument('-r', '--randomize', action='store_true',
@@ -484,6 +490,8 @@ def _parse_args(args, **kwargs):
         parser.error("--pgo/-v don't go together!")
     if ns.pgo_extended:
         ns.pgo = True  # pgo_extended implies pgo
+    if ns.progress_reporter == 'fancy' and ns.use_mp is None:
+        ns.use_mp = 0
 
     if ns.nowindows:
         print("Warning: the --nowindows (-n) option is deprecated. "

--- a/Lib/test/libregrtest/cmdline.py
+++ b/Lib/test/libregrtest/cmdline.py
@@ -172,8 +172,8 @@ class Namespace(argparse.Namespace):
         self.threshold = None
         self.fail_rerun = False
         self.tempdir = None
-        self.color = None
-        self.progress_reporter = None
+        self.color: bool | None = None
+        self.progress_reporter: str | None = None
         self.fancy_report_skip_reason = False
         self._add_python_opts = True
         self.xmlpath = None

--- a/Lib/test/libregrtest/cmdline.py
+++ b/Lib/test/libregrtest/cmdline.py
@@ -172,8 +172,8 @@ class Namespace(argparse.Namespace):
         self.threshold = None
         self.fail_rerun = False
         self.tempdir = None
-        self.progress_reporter = None
         self.color = None
+        self.progress_reporter = None
         self.fancy_report_skip_reason = False
         self._add_python_opts = True
         self.xmlpath = None
@@ -258,10 +258,10 @@ def _create_parser():
                        help='print the slowest 10 tests')
     group.add_argument('--header', action='store_true',
                        help='print header with interpreter info')
-    group.add_argument('--progress_reporter',
-                       choices=['plain', 'fancy', 'detect'], default='detect')
     group.add_argument('--color', action=argparse.BooleanOptionalAction,
                        help='use color in the progress reports')
+    group.add_argument('--progress_reporter',
+                       choices=['plain', 'fancy', 'detect'], default='detect')
     group.add_argument('--fancy_report_skip_reason', action='store_true',
                        help='in the fancy reporter, report the skip reason')
 

--- a/Lib/test/libregrtest/logger.py
+++ b/Lib/test/libregrtest/logger.py
@@ -17,7 +17,6 @@ if MS_WINDOWS:
 
 STATE_OK = (State.PASSED,)
 STATE_SKIP = (State.SKIPPED, State.RESOURCE_DENIED)
-STATE_WARNING = (State.SKIPPED, State.ENV_CHANGED, State.RESOURCE_DENIED)
 
 class Logger:
     ERROR_COLOR = '\033[1m\033[31m'
@@ -70,7 +69,7 @@ class Logger:
             return text
         if state in STATE_OK:
             return self.good(text)
-        elif state in STATE_WARNING:
+        elif state in STATE_SKIP:
             return self.warning(text)
         else:
             return self.error(text)

--- a/Lib/test/libregrtest/logger.py
+++ b/Lib/test/libregrtest/logger.py
@@ -15,6 +15,7 @@ if MS_WINDOWS:
     from .win_utils import WindowsLoadTracker
 
 STATE_OK = (State.PASSED,)
+STATE_SKIP = (State.SKIPPED, State.RESOURCE_DENIED)
 STATE_WARNING = (State.SKIPPED, State.ENV_CHANGED, State.RESOURCE_DENIED)
 
 class Logger:
@@ -222,7 +223,7 @@ class FancyLogger(Logger):
         # If the test is skipped, extra info might be in the test output. We
         # want to display just the skip reason, though, so that needs to be
         # extracted.
-        if (state == State.SKIPPED and not info_text and
+        if (state in STATE_SKIP and not info_text and
             stdout and ' skipped -- ' in stdout):
             _, _, new_info_text = stdout.partition(' skipped -- ')
             stdout = None

--- a/Lib/test/libregrtest/logger.py
+++ b/Lib/test/libregrtest/logger.py
@@ -137,7 +137,7 @@ class Logger:
         if (result is not None and not self._pgo and
             result.duration is not None and
             result.duration >= PROGRESS_MIN_TIME):
-            text = f"{text} ({format_duration(result.duration)})"
+            text = f"{text} ({self.warning(format_duration(result.duration))})"
         if error_text:
             text = f"{text} ({self.error(error_text)})"
 

--- a/Lib/test/libregrtest/logger.py
+++ b/Lib/test/libregrtest/logger.py
@@ -190,7 +190,9 @@ class StatusRemovingWrapper(io.TextIOWrapper):
             # of the status report and clearing the screen below it. This
             # will mess up if something wrote new lines to the screen since
             # the last status report without going through here (e.g.
-            # writing directly to the underlying buffer, or the fd).
+            # writing directly to the underlying buffer, or the fd). That
+            # shouldn't happen when using multiprocessing to run the tests
+            # in isolation.
             super().write(f'\033[{self.status_size}A' + '\033[0J')
         self.status_size = 0
         super().write(msg)
@@ -310,7 +312,7 @@ class FancyLogger(Logger):
 
 
 def detect_vt100_capability():
-    # Rough, "good enough" vt100 detection.
+    """Rough, "good enough" vt100 detection."""
     if not sys.stdout.isatty():
         return False
     try:

--- a/Lib/test/libregrtest/main.py
+++ b/Lib/test/libregrtest/main.py
@@ -12,7 +12,7 @@ from test.support import (os_helper, MS_WINDOWS, flush_std_streams,
 
 from .cmdline import _parse_args, Namespace
 from .findtests import findtests, split_test_packages, list_cases
-from .logger import Logger
+from .logger import create_logger
 from .pgo import setup_pgo_tests
 from .result import State, TestResult
 from .results import TestResults, EXITCODE_INTERRUPTED
@@ -65,7 +65,7 @@ class Regrtest:
         self.first_state: str | None = None
 
         # Logger
-        self.logger = Logger(self.results, self.quiet, self.pgo)
+        self.logger = create_logger(self.results, ns)
 
         # Actions
         self.want_header: bool = ns.header

--- a/Lib/test/libregrtest/run_workers.py
+++ b/Lib/test/libregrtest/run_workers.py
@@ -446,8 +446,8 @@ class WorkerThread(threading.Thread):
                 break
 
 
-def get_running(workers: list[WorkerThread]) -> str | None:
-    running: list[str] = []
+def get_running(workers: list[WorkerThread]) -> list[tuple[float, str]] | None:
+    running: list[tuple[float, str]] = []
     for worker in workers:
         test_name = worker.test_name
         if not test_name:

--- a/Lib/test/libregrtest/run_workers.py
+++ b/Lib/test/libregrtest/run_workers.py
@@ -466,7 +466,7 @@ class RunWorkers:
         self.num_workers = num_workers
         self.runtests = runtests
         self.log = logger.log
-        self.display_progress = logger.display_progress
+        self.update_progress = logger.update_progress
         self.results: TestResults = results
         self.live_worker_count = 0
 
@@ -542,27 +542,24 @@ class RunWorkers:
                 # display progress
                 running = get_running(self.workers)
                 if running:
-                    self.display_progress(
-                        self.test_index, '', running=running)
+                    self.update_progress(
+                        self.test_index, None, running=running)
 
     def display_result(self, mp_result: MultiprocessResult, stdout: str|None) -> None:
         result = mp_result.result
         pgo = self.runtests.pgo
 
-        text = str(result)
-        info_text = error_text = None
+        error_text = None
         if mp_result.err_msg:
             # WORKER_BUG
             error_text = mp_result.err_msg
-        elif (result.duration >= PROGRESS_MIN_TIME and not pgo):
-            info_text = format_duration(result.duration)
         if pgo:
             running = None
         else:
             running = get_running(self.workers)
-        self.display_progress(self.test_index, text, state=result.state,
-                              info_text=info_text, error_text=error_text,
-                              running=running, stdout=stdout)
+        self.update_progress(self.test_index, result,
+                             error_text=error_text,
+                             running=running, stdout=stdout)
 
     def _process_result(self, item: QueueOutput) -> TestResult:
         """Returns True if test runner must stop."""

--- a/Lib/test/test_keyword.py
+++ b/Lib/test/test_keyword.py
@@ -40,13 +40,13 @@ class Test_iskeyword(unittest.TestCase):
         self.assertIn("await", keyword.kwlist)
 
     def test_soft_keywords(self):
-        self.assertNotIn("type", keyword.softkwlist)
+        self.assertIn("type", keyword.softkwlist)
         self.assertIn("match", keyword.softkwlist)
         self.assertIn("case", keyword.softkwlist)
         self.assertIn("_", keyword.softkwlist)
 
     def test_keywords_are_sorted(self):
-        self.assertListNotEqual(sorted(keyword.kwlist), keyword.kwlist)
+        self.assertListEqual(sorted(keyword.kwlist), keyword.kwlist)
 
     def test_softkeywords_are_sorted(self):
         self.assertListEqual(sorted(keyword.softkwlist), keyword.softkwlist)

--- a/Lib/test/test_keyword.py
+++ b/Lib/test/test_keyword.py
@@ -40,13 +40,13 @@ class Test_iskeyword(unittest.TestCase):
         self.assertIn("await", keyword.kwlist)
 
     def test_soft_keywords(self):
-        self.assertIn("type", keyword.softkwlist)
+        self.assertNotIn("type", keyword.softkwlist)
         self.assertIn("match", keyword.softkwlist)
         self.assertIn("case", keyword.softkwlist)
         self.assertIn("_", keyword.softkwlist)
 
     def test_keywords_are_sorted(self):
-        self.assertListEqual(sorted(keyword.kwlist), keyword.kwlist)
+        self.assertListNotEqual(sorted(keyword.kwlist), keyword.kwlist)
 
     def test_softkeywords_are_sorted(self):
         self.assertListEqual(sorted(keyword.softkwlist), keyword.softkwlist)

--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -2089,6 +2089,11 @@ cleantest: all
 test: all
 	$(TESTRUNNER) --fast-ci --timeout=$(TESTTIMEOUT) $(TESTOPTS)
 
+# like 'test' but use the fancy runner if possible.
+.PHONY: fancytest
+fancytest: all
+	$(TESTRUNNER) --progress_reporter=detect --fast-ci --timeout=$(TESTTIMEOUT) $(TESTOPTS)
+
 # Run the test suite for both architectures in a Universal build on OSX.
 # Must be run on an Intel box.
 .PHONY: testuniversal


### PR DESCRIPTION
Refactor regrtest to push more decisions about formatting to the `Logger` class. Add color support to `Logger`, and add a `FancyLogger` subclass that uses vt100 terminal control to make the test output much more condensed and easier to visually scan.

The color support for logger uses just bold green, bold red and normal yellow to print "good", "bad" and "notable" things. This makes anomalous things and interleaved test output stand out a lot more:

![Screenshot of test output in a light on black terminal screen, with test passes and low load numbers colored in bold green, the time spent in (long running) tests in yellow, and other text uncolored](https://github.com/python/cpython/assets/3949752/79e61e3c-1463-4ddf-9754-fc0c2650e2b0)

Color support is enabled by passing `--color` to regrtest (for example by setting the EXTRATESTOPTS environment variable in the `make test` call.) It doesn't try to detect color support. It obeys the `NO_COLOR` environment variable to disable color.

The fancy logger is enabled by passing `--progress_reporter=fancy` (or by passing `--progress_reporter=detect` and having a functioning terminal with a known terminal type). It enables color by default, but it still obeys `NO_COLOR`. The fancy logger will keep redrawing the same lines on the screen rather than printing new lines, reporting all running tests. Test output, test failures, and output that is longer than can be printed on a single line will still appear on their own lines, without being overwritten. (The exception is still-running tests; if those are too long they will get truncated as long as they are running, but are printed in full when they finish.) An additional option, `--fancy_report_skip_reason`, can be passed to make the fancy reporter print test skips with full test reason on a line of their own.

Here is a short demo of the fancy reporter running:

https://github.com/python/cpython/assets/3949752/4004088b-c45a-4b0f-8013-991b9b00cdb3

Here's what it looks like when test output needs to be printed:

![An image of the fancy reporter reporting the passing of a test with extra output, which appears on a line of its own, with the continually updating test progress below it](https://github.com/python/cpython/assets/3949752/18370e80-27bd-4551-a45e-3162611efb1a)

And here's what it looks like when using the `--fancy_report_skip_reason` option is added:

![An image of the fancy reporter reporting test skips, which appear on a line of their own, with the continually updating test progress below it](https://github.com/python/cpython/assets/3949752/6b9a51cf-37b7-443e-ac8d-86a78d4a9b4c)

The refactoring to support the fancy output logger are probably enough to also enable a Tkinter-based logger, although that's more work than I'm willing to put into it (since I would not use it myself).

*With a very small exception, existing behaviour is not changed.* The new options (`--color` and `--progress_reporter`) have to explicitly be passed, via the `EXTRATESTOPTS` environment variable or the `TESTOPTS` make variable, to enable them. The exception is the regrtest output when it's been waiting on running tests and doesn't have any test results to report for more than 30 seconds. Before the refactoring this looked like:

```
0:00:00 load avg: 0.09 Run 4 tests in parallel using 4 worker processes
0:00:00 load avg: 0.09 [1/4] test_keyword passed
0:00:00 load avg: 0.09 [2/4] test_list passed
0:00:00 load avg: 0.09 [3/4] test_dict passed
0:00:30 load avg: 0.06 running (1): test_multiprocessing_forkserver.test_threads (30.3 sec)
0:00:42 load avg: 0.05 [4/4] test_multiprocessing_forkserver.test_threads passed (42.4 sec)
```

but now it looks like:

```
0:00:00 load avg: 0.03 Run 4 tests in parallel using 4 worker processes
0:00:00 load avg: 0.03 [1/4] test_keyword passed
0:00:00 load avg: 0.03 [2/4] test_list passed
0:00:00 load avg: 0.03 [3/4] test_dict passed
0:00:30 load avg: 0.07 [3/4] running (1): test_multiprocessing_forkserver.test_threads 30.3 sec
0:00:42 load avg: 0.19 [4/4] test_multiprocessing_forkserver.test_threads passed (42.5 sec)
```

Changing the output back is not impossible, but to my eyes the new output makes more sense anyway.

<!-- gh-issue-number: gh-111474 -->
* Issue: gh-111474
<!-- /gh-issue-number -->
