### PR TITLE
gh-106168: Check allocated instead of size index bounds in PyList_SET_ITEM()

### DIFF
--- a/Include/cpython/listobject.h
+++ b/Include/cpython/listobject.h
@@ -39,7 +39,7 @@ static inline void
 PyList_SET_ITEM(PyObject *op, Py_ssize_t index, PyObject *value) {
     PyListObject *list = _PyList_CAST(op);
     assert(0 <= index);
-    assert(index < Py_SIZE(list));
+    assert(index < list->allocated);
     list->ob_item[index] = value;
 }
 #define PyList_SET_ITEM(op, index, value) \


### PR DESCRIPTION
Check the index bound assertions in PyList_SET_ITEM() against [0:allocated] instead of [0:size] to re-allow valid use cases that assign within the allocated area.

First increasing the size before setting a new value seems less safe and clean than allowing access to the allocated area and adjusting the size on successful updates.

<!-- gh-issue-number: gh-106168 -->
* Issue: gh-106168
<!-- /gh-issue-number -->
