### PR TITLE
gh-111246: Remove listening Unix socket on close

### DIFF
--- a/Doc/library/asyncio-eventloop.rst
+++ b/Doc/library/asyncio-eventloop.rst
@@ -803,7 +803,8 @@ Creating network servers
    .. versionchanged:: 3.13
 
       The Unix socket will automatically be removed from the filesystem
-      when the server is closed.
+      when the server is closed, unless the socket has been replaced
+      after the server has been created.
 
 
 .. coroutinemethod:: loop.connect_accepted_socket(protocol_factory, \

--- a/Doc/library/asyncio-eventloop.rst
+++ b/Doc/library/asyncio-eventloop.rst
@@ -800,6 +800,11 @@ Creating network servers
 
       Added the *ssl_shutdown_timeout* parameter.
 
+   .. versionchanged:: 3.13
+
+      The Unix socket will automatically be removed from the filesystem
+      when the server is closed.
+
 
 .. coroutinemethod:: loop.connect_accepted_socket(protocol_factory, \
                         sock, *, ssl=None, ssl_handshake_timeout=None, \

--- a/Doc/library/asyncio-eventloop.rst
+++ b/Doc/library/asyncio-eventloop.rst
@@ -776,7 +776,7 @@ Creating network servers
                           *, sock=None, backlog=100, ssl=None, \
                           ssl_handshake_timeout=None, \
                           ssl_shutdown_timeout=None, \
-                          start_serving=True)
+                          start_serving=True, cleanup_socket=True)
 
    Similar to :meth:`loop.create_server` but works with the
    :py:const:`~socket.AF_UNIX` socket family.
@@ -785,6 +785,10 @@ Creating network servers
    unless a *sock* argument is provided.  Abstract Unix sockets,
    :class:`str`, :class:`bytes`, and :class:`~pathlib.Path` paths
    are supported.
+
+   If *cleanup_socket* is True then the Unix socket will automatically
+   be removed from the filesystem when the server is closed, unless the
+   socket has been replaced after the server has been created.
 
    See the documentation of the :meth:`loop.create_server` method
    for information about arguments to this method.
@@ -802,9 +806,7 @@ Creating network servers
 
    .. versionchanged:: 3.13
 
-      The Unix socket will automatically be removed from the filesystem
-      when the server is closed, unless the socket has been replaced
-      after the server has been created.
+      Added the *cleanup_socket* parameter.
 
 
 .. coroutinemethod:: loop.connect_accepted_socket(protocol_factory, \

--- a/Doc/whatsnew/3.13.rst
+++ b/Doc/whatsnew/3.13.rst
@@ -144,6 +144,12 @@ array
   It can be used instead of ``'u'`` type code, which is deprecated.
   (Contributed by Inada Naoki in :gh:`80480`.)
 
+asyncio
+-------
+
+* :meth:`asyncio.loop.create_unix_server` will now automatically remove
+  the Unix socket when the server is closed.
+
 copy
 ----
 

--- a/Doc/whatsnew/3.13.rst
+++ b/Doc/whatsnew/3.13.rst
@@ -149,6 +149,7 @@ asyncio
 
 * :meth:`asyncio.loop.create_unix_server` will now automatically remove
   the Unix socket when the server is closed.
+  (Contributed by Pierre Ossman in :gh:`111246`.)
 
 copy
 ----

--- a/Lib/asyncio/unix_events.py
+++ b/Lib/asyncio/unix_events.py
@@ -477,6 +477,8 @@ class _UnixSelectorEventLoop(selector_events.BaseSelectorEventLoop):
         if path is not None:
             try:
                 os.unlink(path)
+            except FileNotFoundError:
+                pass
             except OSError as err:
                 logger.error('Unable to clean up listening UNIX socket '
                              '%r: %r', path, err)

--- a/Lib/test/test_asyncio/test_server.py
+++ b/Lib/test/test_asyncio/test_server.py
@@ -205,6 +205,17 @@ class UnixServerCleanupTests(unittest.IsolatedAsyncioTestCase):
             srv.close()
             self.assertTrue(os.path.exists(addr))
 
+    @socket_helper.skip_unless_bind_unix_socket
+    async def test_unix_server_cleanup_prevented(self):
+        with test_utils.unix_socket_path() as addr:
+            async def serve(*args):
+                pass
+
+            srv = await asyncio.start_unix_server(serve, addr, cleanup_socket=False)
+
+            srv.close()
+            self.assertTrue(os.path.exists(addr))
+
 
 @unittest.skipUnless(hasattr(asyncio, 'ProactorEventLoop'), 'Windows only')
 class ProactorStartServerTests(BaseStartServer, unittest.TestCase):

--- a/Lib/test/test_asyncio/test_server.py
+++ b/Lib/test/test_asyncio/test_server.py
@@ -190,6 +190,21 @@ class UnixServerCleanupTests(unittest.IsolatedAsyncioTestCase):
 
             srv.close()
 
+    @socket_helper.skip_unless_bind_unix_socket
+    async def test_unix_server_cleanup_replaced(self):
+        with test_utils.unix_socket_path() as addr:
+            async def serve(*args):
+                pass
+
+            srv = await asyncio.start_unix_server(serve, addr)
+
+            os.unlink(addr)
+            sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+            sock.bind(addr)
+
+            srv.close()
+            self.assertTrue(os.path.exists(addr))
+
 
 @unittest.skipUnless(hasattr(asyncio, 'ProactorEventLoop'), 'Windows only')
 class ProactorStartServerTests(BaseStartServer, unittest.TestCase):

--- a/Lib/test/test_asyncio/test_server.py
+++ b/Lib/test/test_asyncio/test_server.py
@@ -175,6 +175,21 @@ class UnixServerCleanupTests(unittest.IsolatedAsyncioTestCase):
             srv.close()
             self.assertFalse(os.path.exists(addr))
 
+    @socket_helper.skip_unless_bind_unix_socket
+    async def test_unix_server_cleanup_gone(self):
+        with test_utils.unix_socket_path() as addr:
+            async def serve(*args):
+                pass
+
+            sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+            sock.bind(addr)
+
+            srv = await asyncio.start_unix_server(serve, sock=sock)
+
+            os.unlink(addr)
+
+            srv.close()
+
 
 @unittest.skipUnless(hasattr(asyncio, 'ProactorEventLoop'), 'Windows only')
 class ProactorStartServerTests(BaseStartServer, unittest.TestCase):

--- a/Lib/test/test_asyncio/test_server.py
+++ b/Lib/test/test_asyncio/test_server.py
@@ -1,4 +1,6 @@
 import asyncio
+import os
+import socket
 import time
 import threading
 import unittest
@@ -145,6 +147,33 @@ class TestServer2(unittest.IsolatedAsyncioTestCase):
 
         srv._detach()
         await task2
+
+
+class UnixServerCleanupTests(unittest.IsolatedAsyncioTestCase):
+    @socket_helper.skip_unless_bind_unix_socket
+    async def test_unix_server_addr_cleanup(self):
+        with test_utils.unix_socket_path() as addr:
+            async def serve(*args):
+                pass
+
+            srv = await asyncio.start_unix_server(serve, addr)
+
+            srv.close()
+            self.assertFalse(os.path.exists(addr))
+
+    @socket_helper.skip_unless_bind_unix_socket
+    async def test_unix_server_sock_cleanup(self):
+        with test_utils.unix_socket_path() as addr:
+            async def serve(*args):
+                pass
+
+            sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+            sock.bind(addr)
+
+            srv = await asyncio.start_unix_server(serve, sock=sock)
+
+            srv.close()
+            self.assertFalse(os.path.exists(addr))
 
 
 @unittest.skipUnless(hasattr(asyncio, 'ProactorEventLoop'), 'Windows only')

--- a/Lib/test/test_asyncio/test_server.py
+++ b/Lib/test/test_asyncio/test_server.py
@@ -149,9 +149,11 @@ class TestServer2(unittest.IsolatedAsyncioTestCase):
         await task2
 
 
+# Test the various corner cases of Unix server socket removal
 class UnixServerCleanupTests(unittest.IsolatedAsyncioTestCase):
     @socket_helper.skip_unless_bind_unix_socket
     async def test_unix_server_addr_cleanup(self):
+        # Default scenario
         with test_utils.unix_socket_path() as addr:
             async def serve(*args):
                 pass
@@ -163,6 +165,7 @@ class UnixServerCleanupTests(unittest.IsolatedAsyncioTestCase):
 
     @socket_helper.skip_unless_bind_unix_socket
     async def test_unix_server_sock_cleanup(self):
+        # Using already bound socket
         with test_utils.unix_socket_path() as addr:
             async def serve(*args):
                 pass
@@ -177,6 +180,7 @@ class UnixServerCleanupTests(unittest.IsolatedAsyncioTestCase):
 
     @socket_helper.skip_unless_bind_unix_socket
     async def test_unix_server_cleanup_gone(self):
+        # Someone else has already cleaned up the socket
         with test_utils.unix_socket_path() as addr:
             async def serve(*args):
                 pass
@@ -192,6 +196,7 @@ class UnixServerCleanupTests(unittest.IsolatedAsyncioTestCase):
 
     @socket_helper.skip_unless_bind_unix_socket
     async def test_unix_server_cleanup_replaced(self):
+        # Someone else has replaced the socket with their own
         with test_utils.unix_socket_path() as addr:
             async def serve(*args):
                 pass
@@ -207,6 +212,7 @@ class UnixServerCleanupTests(unittest.IsolatedAsyncioTestCase):
 
     @socket_helper.skip_unless_bind_unix_socket
     async def test_unix_server_cleanup_prevented(self):
+        # Automatic cleanup explicitly disabled
         with test_utils.unix_socket_path() as addr:
             async def serve(*args):
                 pass

--- a/Misc/NEWS.d/next/Library/2023-10-30-14-47-23.gh-issue-111246.QJ_ehs.rst
+++ b/Misc/NEWS.d/next/Library/2023-10-30-14-47-23.gh-issue-111246.QJ_ehs.rst
@@ -1,0 +1,2 @@
+:meth:`asyncio.loop.create_unix_server` will now automatically remove the
+Unix socket when the server is closed.


### PR DESCRIPTION
Relieve developers from the burden of manually cleaning up their Unix sockets by having asyncio take care of that internally.

Fixes #111246.

<!-- gh-issue-number: gh-111246 -->
* Issue: gh-111246
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--111483.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->