### PR TITLE
gh-111490: Change what exception type we expect in `test_pyexpat`

### DIFF
--- a/Lib/test/test_pyexpat.py
+++ b/Lib/test/test_pyexpat.py
@@ -544,7 +544,7 @@ class sf1296433Test(unittest.TestCase):
         parser = expat.ParserCreate()
         parser.CharacterDataHandler = handler
 
-        self.assertRaises(Exception, parser.Parse, xml.encode('iso8859'))
+        self.assertRaises(SpecificException, parser.Parse, xml.encode('iso8859'))
 
 class ChardataBufferTest(unittest.TestCase):
     """


### PR DESCRIPTION
@serhiy-storchaka your diff is the last one, would you please take a look?
Diff: https://github.com/python/cpython/blame/940ee962a8a1e87543fd36338228e526e7f35067/Lib/test/test_pyexpat.py#L547

<!-- gh-issue-number: gh-111490 -->
* Issue: gh-111490
<!-- /gh-issue-number -->
