### PR TITLE
gh-103417: Fix: infinite run (timefunc in scheduler example)

### DIFF
--- a/Doc/library/sched.rst
+++ b/Doc/library/sched.rst
@@ -36,7 +36,7 @@ scheduler:
 Example::
 
    >>> import sched, time
-   >>> s = sched.scheduler(time.monotonic, time.sleep)
+   >>> s = sched.scheduler(time.time, time.sleep)
    >>> def print_time(a='default'):
    ...     print("From print_time", time.time(), a)
    ...


### PR DESCRIPTION
# Infinite run - sched documentation

I modify the `timefunc` function in the scheduler example because example was write for `time.time` and not for `time.monotonic`. This mistake cause an infinite run.


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--111497.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->

<!-- gh-issue-number: gh-103417 -->
* Issue: gh-103417
<!-- /gh-issue-number -->
