### PR TITLE
gh-111062 CI: Update skip lists for resuable workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -500,11 +500,13 @@ jobs:
     - check_source  # Transitive dependency, needed to access `run_tests` value
     - check-docs
     - check_generated_files
-    - build_windows
     - build_macos
+    - build_macos_free_threaded
     - build_ubuntu
     - build_ubuntu_free_threaded
     - build_ubuntu_ssltests
+    - build_windows
+    - build_windows_free_threaded
     - test_hypothesis
     - build_asan
     - cifuzz
@@ -517,10 +519,10 @@ jobs:
       with:
         allowed-failures: >-
           build_macos,
+          build_macos_free_threaded,
           build_ubuntu_free_threaded,
           build_ubuntu_ssltests,
-          build_win32,
-          build_win_arm64,
+          build_windows_free_threaded,
           cifuzz,
           test_hypothesis,
         allowed-skips: >-
@@ -535,13 +537,13 @@ jobs:
             needs.check_source.outputs.run_tests != 'true'
             && '
             check_generated_files,
-            build_win32,
-            build_win_amd64,
-            build_win_arm64,
             build_macos,
+            build_macos_free_threaded,
             build_ubuntu,
             build_ubuntu_free_threaded,
             build_ubuntu_ssltests,
+            build_windows,
+            build_windows_free_threaded,
             build_asan,
             '
             || ''


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

Add all the top-level jobs on the `needs` and `allowed-skips` lists, and add the `build_*_free_threaded` jobs on the `allowed_failures` list.

Rename `build_win32`, `build_win_amd64` and `build_win_arm64` to `build_windows` and `build_windows_free_threaded` in the skip/allow lists now they're in reusable workflows.

Here's a test build on my fork showing a docs-only build completing: https://github.com/hugovk/cpython/pull/58

Compare https://github.com/python/cpython/pull/111509 which "failed" the "All required checks pass" check.


<!-- gh-issue-number: gh-111062 -->
* Issue: gh-111062
<!-- /gh-issue-number -->
