### PR TITLE
gh-90815: Fix _PyMem_MimallocEnabled() compiler warning

### DIFF
--- a/Objects/obmalloc.c
+++ b/Objects/obmalloc.c
@@ -561,14 +561,13 @@ _PyMem_GetCurrentAllocatorName(void)
 }
 
 
-#if defined(WITH_PYMALLOC) || defined(WITH_MIMALLOC)
+#ifdef WITH_PYMALLOC
 static int
 _PyMem_DebugEnabled(void)
 {
     return (_PyObject.malloc == _PyMem_DebugMalloc);
 }
 
-#ifdef WITH_PYMALLOC
 static int
 _PyMem_PymallocEnabled(void)
 {
@@ -579,7 +578,7 @@ _PyMem_PymallocEnabled(void)
         return (_PyObject.malloc == _PyObject_Malloc);
     }
 }
-#endif
+
 #ifdef WITH_MIMALLOC
 static int
 _PyMem_MimallocEnabled(void)
@@ -591,8 +590,9 @@ _PyMem_MimallocEnabled(void)
         return (_PyObject.malloc == _PyObject_MiMalloc);
     }
 }
-#endif
-#endif // defined(WITH_PYMALLOC) || defined(WITH_MIMALLOC)
+#endif  // WITH_MIMALLOC
+
+#endif  // WITH_PYMALLOC
 
 
 static void
@@ -1073,7 +1073,7 @@ _PyInterpreterState_GetAllocatedBlocks(PyInterpreterState *interp)
 void
 _PyInterpreterState_FinalizeAllocatedBlocks(PyInterpreterState *interp)
 {
-#ifdef WITH_MIAMLLOC
+#ifdef WITH_MIMALLOC
     if (_PyMem_MimallocEnabled()) {
         return;
     }


### PR DESCRIPTION
Don't declare _PyMem_MimallocEnabled() if WITH_PYMALLOC macro is not defined (./configure --without-pymalloc).

Fix also a typo in _PyInterpreterState_FinalizeAllocatedBlocks().

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-90815 -->
* Issue: gh-90815
<!-- /gh-issue-number -->
