### PR TITLE
Remove myself from typing CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -151,7 +151,7 @@ Doc/c-api/stable.rst          @encukou
 
 **/*idlelib*                  @terryjreedy
 
-**/*typing*                   @gvanrossum @Fidget-Spinner @JelleZijlstra @AlexWaygood
+**/*typing*                   @gvanrossum @JelleZijlstra @AlexWaygood
 
 **/*ftplib                    @giampaolo
 **/*shutil                    @giampaolo


### PR DESCRIPTION
I'm too out of date now, and the current team taking care of it are way more than qualified.