### PR TITLE
gh-90815: Fix mimalloc atomic.h on Windows arm64

### DIFF
--- a/Include/internal/mimalloc/mimalloc/atomic.h
+++ b/Include/internal/mimalloc/mimalloc/atomic.h
@@ -195,7 +195,7 @@ static inline uintptr_t mi_atomic_load_explicit(_Atomic(uintptr_t) const* p, mi_
 #else
   uintptr_t x = *p;
   if (mo > mi_memory_order_relaxed) {
-    while (!mi_atomic_compare_exchange_weak_explicit(p, &x, x, mo, mi_memory_order_relaxed)) { /* nothing */ };
+    while (!mi_atomic_compare_exchange_weak_explicit((_Atomic(uintptr_t)*)p, &x, x, mo, mi_memory_order_relaxed)) { /* nothing */ };
   }
   return x;
 #endif


### PR DESCRIPTION
mi_atomic_load_explicit() casts 'p' argument to drop the 'const' qualifier on Windows arm64 platform. Fix the compiler warning:

    'function': different 'const' qualifiers
    (compiling source file ..\Objects\mimalloc\options.c)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-90815 -->
* Issue: gh-90815
<!-- /gh-issue-number -->
