### PR TITLE
gh-110697: Use CLOCK_RES in test_os.TimerfdTests

### DIFF
--- a/Lib/test/test_os.py
+++ b/Lib/test/test_os.py
@@ -4029,7 +4029,7 @@ class TimerfdTests(unittest.TestCase):
         t = time.perf_counter() - t
 
         total_time = initial_expiration + interval * (count - 1)
-        self.assertGreater(t, total_time)
+        self.assertGreater(t, total_time - self.CLOCK_RES)
 
         # wait 3.5 time of interval
         time.sleep( (count+0.5) * interval)
@@ -4083,7 +4083,7 @@ class TimerfdTests(unittest.TestCase):
         t = time.perf_counter() - t
 
         total_time = initial_expiration + interval * (count - 1)
-        self.assertGreater(t, total_time)
+        self.assertGreater(t, total_time - self.CLOCK_RES)
 
     def check_timerfd_poll(self, nanoseconds):
         fd = self.timerfd_create(time.CLOCK_REALTIME, flags=os.TFD_NONBLOCK)
@@ -4129,10 +4129,10 @@ class TimerfdTests(unittest.TestCase):
         total_time = initial_expiration_ns + interval_ns * (count - 1)
         if nanoseconds:
             dt = time.perf_counter_ns() - t
-            self.assertGreater(dt, total_time)
+            self.assertGreater(dt, total_time - self.CLOCK_RES_NS)
         else:
             dt = time.perf_counter() - t
-            self.assertGreater(dt, total_time / sec_to_nsec)
+            self.assertGreater(dt, total_time / sec_to_nsec - self.CLOCK_RES)
         selector.unregister(fd)
 
     def test_timerfd_poll(self):
@@ -4189,7 +4189,7 @@ class TimerfdTests(unittest.TestCase):
         t = time.perf_counter_ns() - t
 
         total_time_ns = initial_expiration_ns + interval_ns * (count - 1)
-        self.assertGreater(t, total_time_ns)
+        self.assertGreater(t, total_time_ns - self.CLOCK_RES_NS)
 
         # wait 3.5 time of interval
         time.sleep( (count+0.5) * interval_ns / one_sec_in_nsec)
@@ -4248,7 +4248,7 @@ class TimerfdTests(unittest.TestCase):
         t = time.perf_counter_ns() - t
 
         total_time_ns = initial_expiration_ns + interval_ns * (count - 1)
-        self.assertGreater(t, total_time_ns)
+        self.assertGreater(t, total_time_ns - self.CLOCK_RES_NS)
 
 class OSErrorTests(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
More TimerfdTests tests tolerate a difference of 1 ms in measured elapsed time.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-110697 -->
* Issue: gh-110697
<!-- /gh-issue-number -->
