### PR TITLE
gh-111531: Tkinter: fix reference leaks in bind_class() and bind_all()

### DIFF
--- a/Lib/tkinter/__init__.py
+++ b/Lib/tkinter/__init__.py
@@ -1538,7 +1538,7 @@ class Misc:
         An additional boolean parameter ADD specifies whether FUNC will
         be called additionally to the other bound function or whether
         it will replace the previous function. See bind for the return value."""
-        return self._bind(('bind', 'all'), sequence, func, add, 0)
+        return self._root()._bind(('bind', 'all'), sequence, func, add, True)
 
     def unbind_all(self, sequence):
         """Unbind for all widgets for event SEQUENCE all functions."""
@@ -1552,7 +1552,7 @@ class Misc:
         whether it will replace the previous function. See bind for
         the return value."""
 
-        return self._bind(('bind', className), sequence, func, add, 0)
+        return self._root()._bind(('bind', className), sequence, func, add, True)
 
     def unbind_class(self, className, sequence):
         """Unbind for all widgets with bindtag CLASSNAME for event SEQUENCE

--- a/Misc/NEWS.d/next/Library/2023-10-31-07-46-56.gh-issue-111531.6zUV_G.rst
+++ b/Misc/NEWS.d/next/Library/2023-10-31-07-46-56.gh-issue-111531.6zUV_G.rst
@@ -1,0 +1,2 @@
+Fix reference leaks in ``bind_class()`` and ``bind_all()`` methods of
+:mod:`tkinted` widgets.

--- a/Misc/NEWS.d/next/Library/2023-10-31-07-46-56.gh-issue-111531.6zUV_G.rst
+++ b/Misc/NEWS.d/next/Library/2023-10-31-07-46-56.gh-issue-111531.6zUV_G.rst
@@ -1,2 +1,2 @@
 Fix reference leaks in ``bind_class()`` and ``bind_all()`` methods of
-:mod:`tkinted` widgets.
+:mod:`tkinter` widgets.


### PR DESCRIPTION


<!-- gh-issue-number: gh-111531 -->
* Issue: gh-111531
<!-- /gh-issue-number -->
