### PR TITLE
[3.12] gh-111301: Move `importlib.resources.files` change to What's new in Python 3.12 (#111512)

### DIFF
--- a/Doc/whatsnew/3.12.rst
+++ b/Doc/whatsnew/3.12.rst
@@ -716,6 +716,9 @@ importlib.resources
 * :func:`importlib.resources.as_file` now supports resource directories.
   (Contributed by Jason R. Coombs in :gh:`97930`.)
 
+* Rename first parameter of :func:`importlib.resources.files` to *anchor*.
+  (Contributed by Jason R. Coombs in :gh:`100598`.)
+
 inspect
 -------
 


### PR DESCRIPTION
Closes https://github.com/python/cpython/issues/111301.
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-111301 -->
* Issue: gh-111301
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--111534.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->