### PR TITLE
gh-111159: Fix `SyntaxError` doctests for non-builtin exception classes

### DIFF
--- a/Lib/doctest.py
+++ b/Lib/doctest.py
@@ -1399,15 +1399,12 @@ class DocTestRunner:
                     # we don't care about the carets / suggestions / etc
                     # We only care about the error message and notes.
                     # They start with `SyntaxError:` (or any other class name)
+                    exc_name = f"{exception[0].__qualname__}:"
+                    exc_fullname = f"{exception[0].__module__}.{exception[0].__qualname__}:"
                     exc_msg_index = next(
                         index
                         for index, line in enumerate(formatted_ex)
-                        if (
-                            line.startswith(f"{exception[0].__qualname__}:")
-                            or line.startswith(
-                                f"{exception[0].__module__}.{exception[0].__qualname__}:",
-                            )
-                        )
+                        if line.startswith(exc_name) or line.startswith(exc_fullname)
                     )
                     formatted_ex = formatted_ex[exc_msg_index:]
 

--- a/Lib/doctest.py
+++ b/Lib/doctest.py
@@ -1399,12 +1399,14 @@ class DocTestRunner:
                     # we don't care about the carets / suggestions / etc
                     # We only care about the error message and notes.
                     # They start with `SyntaxError:` (or any other class name)
-                    exc_name = f"{exception[0].__qualname__}:"
-                    exc_fullname = f"{exception[0].__module__}.{exception[0].__qualname__}:"
+                    exception_line_prefixes = (
+                        f"{exception[0].__qualname__}:",
+                        f"{exception[0].__module__}.{exception[0].__qualname__}:",
+                    )
                     exc_msg_index = next(
                         index
                         for index, line in enumerate(formatted_ex)
-                        if line.startswith(exc_name) or line.startswith(exc_fullname)
+                        if line.startswith(exception_line_prefixes)
                     )
                     formatted_ex = formatted_ex[exc_msg_index:]
 

--- a/Lib/doctest.py
+++ b/Lib/doctest.py
@@ -1402,7 +1402,12 @@ class DocTestRunner:
                     exc_msg_index = next(
                         index
                         for index, line in enumerate(formatted_ex)
-                        if line.startswith(f"{exception[0].__name__}:")
+                        if (
+                            line.startswith(f"{exception[0].__qualname__}:")
+                            or line.startswith(
+                                f"{exception[0].__module__}.{exception[0].__qualname__}:",
+                            )
+                        )
                     )
                     formatted_ex = formatted_ex[exc_msg_index:]
 

--- a/Lib/test/test_doctest.py
+++ b/Lib/test/test_doctest.py
@@ -3310,6 +3310,25 @@ def test_syntax_error_with_note(cls, multiline=False):
     raise exc
 
 
+def test_syntax_error_subclass_from_stdlib():
+    """
+    `ParseError` is a subclass of `SyntaxError`, but it is not a builtin:
+
+    >>> from xml.etree.ElementTree import ParseError
+    >>> test_syntax_error_subclass_from_stdlib()
+    Traceback (most recent call last):
+      ...
+    xml.etree.ElementTree.ParseError: error
+    error
+    Note
+    Line
+    """
+    from xml.etree.ElementTree import ParseError
+    exc = ParseError("error\nerror")
+    exc.add_note('Note\nLine')
+    raise exc
+
+
 def test_syntax_error_with_incorrect_expected_note():
     """
     >>> def f(x):

--- a/Lib/test/test_doctest.py
+++ b/Lib/test/test_doctest.py
@@ -3314,7 +3314,6 @@ def test_syntax_error_subclass_from_stdlib():
     """
     `ParseError` is a subclass of `SyntaxError`, but it is not a builtin:
 
-    >>> from xml.etree.ElementTree import ParseError
     >>> test_syntax_error_subclass_from_stdlib()
     Traceback (most recent call last):
       ...

--- a/Misc/NEWS.d/next/Library/2023-11-04-10-24-25.gh-issue-111541.x0RBI1.rst
+++ b/Misc/NEWS.d/next/Library/2023-11-04-10-24-25.gh-issue-111541.x0RBI1.rst
@@ -1,1 +1,1 @@
-Fix :mod:`doctest` for `SyntaxError` not-builtin subclasses.
+Fix :mod:`doctest` for :exc:`SyntaxError` not-builtin subclasses.

--- a/Misc/NEWS.d/next/Library/2023-11-04-10-24-25.gh-issue-111541.x0RBI1.rst
+++ b/Misc/NEWS.d/next/Library/2023-11-04-10-24-25.gh-issue-111541.x0RBI1.rst
@@ -1,0 +1,1 @@
+Fix :mod:`doctest` for `SyntaxError` not-builtin subclasses.


### PR DESCRIPTION


<!-- gh-issue-number: gh-111159 -->
* Issue: gh-111159
<!-- /gh-issue-number -->
