### PR TITLE
gh-110481: Implement _Py_DECREF_NO_DEALLOC for free-threaded build

### DIFF
--- a/Include/internal/pycore_object.h
+++ b/Include/internal/pycore_object.h
@@ -241,7 +241,6 @@ _Py_DECREF_NO_DEALLOC(PyObject *op)
     }
     else {
         Py_ssize_t refcount = _Py_atomic_load_ssize_relaxed(&op->ob_ref_shared);
-        assert(refcount != 0);
         Py_ssize_t new_shared;
         int should_queue = refcount == _Py_REF_MAYBE_WEAKREF;
         do {

--- a/Include/internal/pycore_object.h
+++ b/Include/internal/pycore_object.h
@@ -242,7 +242,7 @@ _Py_DECREF_NO_DEALLOC(PyObject *op)
     else {
         Py_ssize_t refcount = _Py_atomic_load_ssize_relaxed(&op->ob_ref_shared);
         Py_ssize_t new_shared;
-        int should_queue = refcount == _Py_REF_MAYBE_WEAKREF;
+        int should_queue = (refcount == 0 || refcount == _Py_REF_MAYBE_WEAKREF);
         do {
             if (should_queue) {
                 new_shared = _Py_REF_QUEUED;


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

I simply implement `_Py_DECREF_NO_DEALLOC` for the free-threaded build.
I assumed refcount will not be zero even after calling `_Py_DECREF_NO_DEALLOC`.

Please let me know if I missed something.

<!-- gh-issue-number: gh-110481 -->
* Issue: gh-110481
<!-- /gh-issue-number -->
