### PR TITLE
GH-111485: Use micro-ops to split specialization code from base action

### DIFF
--- a/Include/internal/pycore_opcode_metadata.h
+++ b/Include/internal/pycore_opcode_metadata.h
@@ -27,68 +27,94 @@
 
 #define _EXIT_TRACE 300
 #define _SET_IP 301
-#define _GUARD_BOTH_INT 302
-#define _BINARY_OP_MULTIPLY_INT 303
-#define _BINARY_OP_ADD_INT 304
-#define _BINARY_OP_SUBTRACT_INT 305
-#define _GUARD_BOTH_FLOAT 306
-#define _BINARY_OP_MULTIPLY_FLOAT 307
-#define _BINARY_OP_ADD_FLOAT 308
-#define _BINARY_OP_SUBTRACT_FLOAT 309
-#define _GUARD_BOTH_UNICODE 310
-#define _BINARY_OP_ADD_UNICODE 311
-#define _BINARY_OP_INPLACE_ADD_UNICODE 312
-#define _POP_FRAME 313
-#define _GUARD_GLOBALS_VERSION 314
-#define _GUARD_BUILTINS_VERSION 315
-#define _LOAD_GLOBAL_MODULE 316
-#define _LOAD_GLOBAL_BUILTINS 317
-#define _GUARD_TYPE_VERSION 318
-#define _CHECK_MANAGED_OBJECT_HAS_VALUES 319
-#define _LOAD_ATTR_INSTANCE_VALUE 320
-#define _CHECK_ATTR_MODULE 321
-#define _LOAD_ATTR_MODULE 322
-#define _CHECK_ATTR_WITH_HINT 323
-#define _LOAD_ATTR_WITH_HINT 324
-#define _LOAD_ATTR_SLOT 325
-#define _CHECK_ATTR_CLASS 326
-#define _LOAD_ATTR_CLASS 327
-#define _GUARD_DORV_VALUES 328
-#define _STORE_ATTR_INSTANCE_VALUE 329
-#define _STORE_ATTR_SLOT 330
-#define _IS_NONE 331
-#define _ITER_CHECK_LIST 332
-#define _ITER_JUMP_LIST 333
-#define _IS_ITER_EXHAUSTED_LIST 334
-#define _ITER_NEXT_LIST 335
-#define _ITER_CHECK_TUPLE 336
-#define _ITER_JUMP_TUPLE 337
-#define _IS_ITER_EXHAUSTED_TUPLE 338
-#define _ITER_NEXT_TUPLE 339
-#define _ITER_CHECK_RANGE 340
-#define _ITER_JUMP_RANGE 341
-#define _IS_ITER_EXHAUSTED_RANGE 342
-#define _ITER_NEXT_RANGE 343
-#define _GUARD_DORV_VALUES_INST_ATTR_FROM_DICT 344
-#define _GUARD_KEYS_VERSION 345
-#define _LOAD_ATTR_METHOD_WITH_VALUES 346
-#define _LOAD_ATTR_METHOD_NO_DICT 347
-#define _LOAD_ATTR_NONDESCRIPTOR_WITH_VALUES 348
-#define _LOAD_ATTR_NONDESCRIPTOR_NO_DICT 349
-#define _CHECK_ATTR_METHOD_LAZY_DICT 350
-#define _LOAD_ATTR_METHOD_LAZY_DICT 351
-#define _CHECK_CALL_BOUND_METHOD_EXACT_ARGS 352
-#define _INIT_CALL_BOUND_METHOD_EXACT_ARGS 353
-#define _CHECK_PEP_523 354
-#define _CHECK_FUNCTION_EXACT_ARGS 355
-#define _CHECK_STACK_SPACE 356
-#define _INIT_CALL_PY_EXACT_ARGS 357
-#define _PUSH_FRAME 358
-#define _POP_JUMP_IF_FALSE 359
-#define _POP_JUMP_IF_TRUE 360
-#define _JUMP_TO_TOP 361
-#define _SAVE_RETURN_OFFSET 362
-#define _INSERT 363
+#define _SPECIALIZE_TO_BOOL 302
+#define _TO_BOOL 303
+#define _GUARD_BOTH_INT 304
+#define _BINARY_OP_MULTIPLY_INT 305
+#define _BINARY_OP_ADD_INT 306
+#define _BINARY_OP_SUBTRACT_INT 307
+#define _GUARD_BOTH_FLOAT 308
+#define _BINARY_OP_MULTIPLY_FLOAT 309
+#define _BINARY_OP_ADD_FLOAT 310
+#define _BINARY_OP_SUBTRACT_FLOAT 311
+#define _GUARD_BOTH_UNICODE 312
+#define _BINARY_OP_ADD_UNICODE 313
+#define _BINARY_OP_INPLACE_ADD_UNICODE 314
+#define _SPECIALIZE_BINARY_SUBSCR 315
+#define _BINARY_SUBSCR 316
+#define _SPECIALIZE_STORE_SUBSCR 317
+#define _STORE_SUBSCR 318
+#define _POP_FRAME 319
+#define _SPECIALIZE_SEND 320
+#define _SEND 321
+#define _SPECIALIZE_UNPACK_SEQUENCE 322
+#define _UNPACK_SEQUENCE 323
+#define _SPECIALIZE_STORE_ATTR 324
+#define _STORE_ATTR 325
+#define _SPECIALIZE_LOAD_GLOBAL 326
+#define _LOAD_GLOBAL 327
+#define _GUARD_GLOBALS_VERSION 328
+#define _GUARD_BUILTINS_VERSION 329
+#define _LOAD_GLOBAL_MODULE 330
+#define _LOAD_GLOBAL_BUILTINS 331
+#define _SPECIALIZE_LOAD_SUPER_ATTR 332
+#define _LOAD_SUPER_ATTR 333
+#define _SPECIALIZE_LOAD_ATTR 334
+#define _LOAD_ATTR 335
+#define _GUARD_TYPE_VERSION 336
+#define _CHECK_MANAGED_OBJECT_HAS_VALUES 337
+#define _LOAD_ATTR_INSTANCE_VALUE 338
+#define _CHECK_ATTR_MODULE 339
+#define _LOAD_ATTR_MODULE 340
+#define _CHECK_ATTR_WITH_HINT 341
+#define _LOAD_ATTR_WITH_HINT 342
+#define _LOAD_ATTR_SLOT 343
+#define _CHECK_ATTR_CLASS 344
+#define _LOAD_ATTR_CLASS 345
+#define _GUARD_DORV_VALUES 346
+#define _STORE_ATTR_INSTANCE_VALUE 347
+#define _STORE_ATTR_SLOT 348
+#define _SPECIALIZE_COMPARE_OP 349
+#define _COMPARE_OP 350
+#define _IS_NONE 351
+#define _SPECIALIZE_FOR_ITER 352
+#define _FOR_ITER 353
+#define _ITER_CHECK_LIST 354
+#define _ITER_JUMP_LIST 355
+#define _IS_ITER_EXHAUSTED_LIST 356
+#define _ITER_NEXT_LIST 357
+#define _ITER_CHECK_TUPLE 358
+#define _ITER_JUMP_TUPLE 359
+#define _IS_ITER_EXHAUSTED_TUPLE 360
+#define _ITER_NEXT_TUPLE 361
+#define _ITER_CHECK_RANGE 362
+#define _ITER_JUMP_RANGE 363
+#define _IS_ITER_EXHAUSTED_RANGE 364
+#define _ITER_NEXT_RANGE 365
+#define _GUARD_DORV_VALUES_INST_ATTR_FROM_DICT 366
+#define _GUARD_KEYS_VERSION 367
+#define _LOAD_ATTR_METHOD_WITH_VALUES 368
+#define _LOAD_ATTR_METHOD_NO_DICT 369
+#define _LOAD_ATTR_NONDESCRIPTOR_WITH_VALUES 370
+#define _LOAD_ATTR_NONDESCRIPTOR_NO_DICT 371
+#define _CHECK_ATTR_METHOD_LAZY_DICT 372
+#define _LOAD_ATTR_METHOD_LAZY_DICT 373
+#define _SPECIALIZE_CALL 374
+#define _CALL 375
+#define _CHECK_CALL_BOUND_METHOD_EXACT_ARGS 376
+#define _INIT_CALL_BOUND_METHOD_EXACT_ARGS 377
+#define _CHECK_PEP_523 378
+#define _CHECK_FUNCTION_EXACT_ARGS 379
+#define _CHECK_STACK_SPACE 380
+#define _INIT_CALL_PY_EXACT_ARGS 381
+#define _PUSH_FRAME 382
+#define _SPECIALIZE_BINARY_OP 383
+#define _BINARY_OP 384
+#define _POP_JUMP_IF_FALSE 385
+#define _POP_JUMP_IF_TRUE 386
+#define _JUMP_TO_TOP 387
+#define _SAVE_RETURN_OFFSET 388
+#define _INSERT 389
 
 extern int _PyOpcode_num_popped(int opcode, int oparg, bool jump);
 #ifdef NEED_OPCODE_METADATA
@@ -137,6 +163,10 @@ int _PyOpcode_num_popped(int opcode, int oparg, bool jump)  {
         case UNARY_NEGATIVE:
             return 1;
         case UNARY_NOT:
+            return 1;
+        case _SPECIALIZE_TO_BOOL:
+            return 1;
+        case _TO_BOOL:
             return 1;
         case TO_BOOL:
             return 1;
@@ -192,6 +222,10 @@ int _PyOpcode_num_popped(int opcode, int oparg, bool jump)  {
             return 2;
         case BINARY_OP_INPLACE_ADD_UNICODE:
             return 2;
+        case _SPECIALIZE_BINARY_SUBSCR:
+            return 2;
+        case _BINARY_SUBSCR:
+            return 2;
         case BINARY_SUBSCR:
             return 2;
         case BINARY_SLICE:
@@ -212,6 +246,10 @@ int _PyOpcode_num_popped(int opcode, int oparg, bool jump)  {
             return (oparg-1) + 2;
         case SET_ADD:
             return (oparg-1) + 2;
+        case _SPECIALIZE_STORE_SUBSCR:
+            return 2;
+        case _STORE_SUBSCR:
+            return 3;
         case STORE_SUBSCR:
             return 3;
         case STORE_SUBSCR_LIST_INT:
@@ -244,6 +282,10 @@ int _PyOpcode_num_popped(int opcode, int oparg, bool jump)  {
             return 1;
         case GET_AWAITABLE:
             return 1;
+        case _SPECIALIZE_SEND:
+            return 2;
+        case _SEND:
+            return 2;
         case SEND:
             return 2;
         case SEND_GEN:
@@ -268,6 +310,10 @@ int _PyOpcode_num_popped(int opcode, int oparg, bool jump)  {
             return 1;
         case DELETE_NAME:
             return 0;
+        case _SPECIALIZE_UNPACK_SEQUENCE:
+            return 1;
+        case _UNPACK_SEQUENCE:
+            return 1;
         case UNPACK_SEQUENCE:
             return 1;
         case UNPACK_SEQUENCE_TWO_TUPLE:
@@ -278,6 +324,10 @@ int _PyOpcode_num_popped(int opcode, int oparg, bool jump)  {
             return 1;
         case UNPACK_EX:
             return 1;
+        case _SPECIALIZE_STORE_ATTR:
+            return 1;
+        case _STORE_ATTR:
+            return 2;
         case STORE_ATTR:
             return 2;
         case DELETE_ATTR:
@@ -291,6 +341,10 @@ int _PyOpcode_num_popped(int opcode, int oparg, bool jump)  {
         case LOAD_FROM_DICT_OR_GLOBALS:
             return 1;
         case LOAD_NAME:
+            return 0;
+        case _SPECIALIZE_LOAD_GLOBAL:
+            return 0;
+        case _LOAD_GLOBAL:
             return 0;
         case LOAD_GLOBAL:
             return 0;
@@ -346,6 +400,10 @@ int _PyOpcode_num_popped(int opcode, int oparg, bool jump)  {
             return (oparg - 1) + 3;
         case INSTRUMENTED_LOAD_SUPER_ATTR:
             return 3;
+        case _SPECIALIZE_LOAD_SUPER_ATTR:
+            return 3;
+        case _LOAD_SUPER_ATTR:
+            return 3;
         case LOAD_SUPER_ATTR:
             return 3;
         case LOAD_SUPER_METHOD:
@@ -358,6 +416,10 @@ int _PyOpcode_num_popped(int opcode, int oparg, bool jump)  {
             return 3;
         case LOAD_SUPER_ATTR_METHOD:
             return 3;
+        case _SPECIALIZE_LOAD_ATTR:
+            return 1;
+        case _LOAD_ATTR:
+            return 1;
         case LOAD_ATTR:
             return 1;
         case LOAD_METHOD:
@@ -407,6 +469,10 @@ int _PyOpcode_num_popped(int opcode, int oparg, bool jump)  {
         case _STORE_ATTR_SLOT:
             return 2;
         case STORE_ATTR_SLOT:
+            return 2;
+        case _SPECIALIZE_COMPARE_OP:
+            return 2;
+        case _COMPARE_OP:
             return 2;
         case COMPARE_OP:
             return 2;
@@ -463,6 +529,10 @@ int _PyOpcode_num_popped(int opcode, int oparg, bool jump)  {
         case GET_ITER:
             return 1;
         case GET_YIELD_FROM_ITER:
+            return 1;
+        case _SPECIALIZE_FOR_ITER:
+            return 1;
+        case _FOR_ITER:
             return 1;
         case FOR_ITER:
             return 1;
@@ -544,6 +614,10 @@ int _PyOpcode_num_popped(int opcode, int oparg, bool jump)  {
             return 1;
         case INSTRUMENTED_CALL:
             return 0;
+        case _SPECIALIZE_CALL:
+            return oparg + 2;
+        case _CALL:
+            return oparg + 2;
         case CALL:
             return oparg + 2;
         case _CHECK_CALL_BOUND_METHOD_EXACT_ARGS:
@@ -622,6 +696,10 @@ int _PyOpcode_num_popped(int opcode, int oparg, bool jump)  {
             return 2;
         case COPY:
             return (oparg-1) + 1;
+        case _SPECIALIZE_BINARY_OP:
+            return 2;
+        case _BINARY_OP:
+            return 2;
         case BINARY_OP:
             return 2;
         case SWAP:
@@ -714,6 +792,10 @@ int _PyOpcode_num_pushed(int opcode, int oparg, bool jump)  {
             return 1;
         case UNARY_NOT:
             return 1;
+        case _SPECIALIZE_TO_BOOL:
+            return 1;
+        case _TO_BOOL:
+            return 1;
         case TO_BOOL:
             return 1;
         case TO_BOOL_BOOL:
@@ -768,6 +850,10 @@ int _PyOpcode_num_pushed(int opcode, int oparg, bool jump)  {
             return 0;
         case BINARY_OP_INPLACE_ADD_UNICODE:
             return 0;
+        case _SPECIALIZE_BINARY_SUBSCR:
+            return 2;
+        case _BINARY_SUBSCR:
+            return 1;
         case BINARY_SUBSCR:
             return 1;
         case BINARY_SLICE:
@@ -788,6 +874,10 @@ int _PyOpcode_num_pushed(int opcode, int oparg, bool jump)  {
             return (oparg-1) + 1;
         case SET_ADD:
             return (oparg-1) + 1;
+        case _SPECIALIZE_STORE_SUBSCR:
+            return 2;
+        case _STORE_SUBSCR:
+            return 0;
         case STORE_SUBSCR:
             return 0;
         case STORE_SUBSCR_LIST_INT:
@@ -820,6 +910,10 @@ int _PyOpcode_num_pushed(int opcode, int oparg, bool jump)  {
             return 2;
         case GET_AWAITABLE:
             return 1;
+        case _SPECIALIZE_SEND:
+            return 2;
+        case _SEND:
+            return 2;
         case SEND:
             return 2;
         case SEND_GEN:
@@ -844,6 +938,10 @@ int _PyOpcode_num_pushed(int opcode, int oparg, bool jump)  {
             return 0;
         case DELETE_NAME:
             return 0;
+        case _SPECIALIZE_UNPACK_SEQUENCE:
+            return 1;
+        case _UNPACK_SEQUENCE:
+            return oparg;
         case UNPACK_SEQUENCE:
             return oparg;
         case UNPACK_SEQUENCE_TWO_TUPLE:
@@ -854,6 +952,10 @@ int _PyOpcode_num_pushed(int opcode, int oparg, bool jump)  {
             return oparg;
         case UNPACK_EX:
             return (oparg & 0xFF) + (oparg >> 8) + 1;
+        case _SPECIALIZE_STORE_ATTR:
+            return 1;
+        case _STORE_ATTR:
+            return 0;
         case STORE_ATTR:
             return 0;
         case DELETE_ATTR:
@@ -868,8 +970,12 @@ int _PyOpcode_num_pushed(int opcode, int oparg, bool jump)  {
             return 1;
         case LOAD_NAME:
             return 1;
-        case LOAD_GLOBAL:
+        case _SPECIALIZE_LOAD_GLOBAL:
+            return 0;
+        case _LOAD_GLOBAL:
             return ((oparg & 1) ? 1 : 0) + 1;
+        case LOAD_GLOBAL:
+            return (oparg & 1 ? 1 : 0) + 1;
         case _GUARD_GLOBALS_VERSION:
             return 0;
         case _GUARD_BUILTINS_VERSION:
@@ -922,22 +1028,30 @@ int _PyOpcode_num_pushed(int opcode, int oparg, bool jump)  {
             return (oparg - 1) + 1;
         case INSTRUMENTED_LOAD_SUPER_ATTR:
             return ((oparg & 1) ? 1 : 0) + 1;
+        case _SPECIALIZE_LOAD_SUPER_ATTR:
+            return 3;
+        case _LOAD_SUPER_ATTR:
+            return ((oparg & 1) ? 1 : 0) + 1;
         case LOAD_SUPER_ATTR:
-            return ((oparg & 1) ? 1 : 0) + 1;
+            return (oparg & 1 ? 1 : 0) + 1;
         case LOAD_SUPER_METHOD:
-            return ((oparg & 1) ? 1 : 0) + 1;
+            return (oparg & 1 ? 1 : 0) + 1;
         case LOAD_ZERO_SUPER_METHOD:
-            return ((oparg & 1) ? 1 : 0) + 1;
+            return (oparg & 1 ? 1 : 0) + 1;
         case LOAD_ZERO_SUPER_ATTR:
-            return ((oparg & 1) ? 1 : 0) + 1;
+            return (oparg & 1 ? 1 : 0) + 1;
         case LOAD_SUPER_ATTR_ATTR:
             return 1;
         case LOAD_SUPER_ATTR_METHOD:
             return 2;
+        case _SPECIALIZE_LOAD_ATTR:
+            return 1;
+        case _LOAD_ATTR:
+            return ((oparg & 1) ? 1 : 0) + 1;
         case LOAD_ATTR:
-            return ((oparg & 1) ? 1 : 0) + 1;
+            return (oparg & 1 ? 1 : 0) + 1;
         case LOAD_METHOD:
-            return ((oparg & 1) ? 1 : 0) + 1;
+            return (oparg & 1 ? 1 : 0) + 1;
         case _GUARD_TYPE_VERSION:
             return 1;
         case _CHECK_MANAGED_OBJECT_HAS_VALUES:
@@ -984,6 +1098,10 @@ int _PyOpcode_num_pushed(int opcode, int oparg, bool jump)  {
             return 0;
         case STORE_ATTR_SLOT:
             return 0;
+        case _SPECIALIZE_COMPARE_OP:
+            return 2;
+        case _COMPARE_OP:
+            return 1;
         case COMPARE_OP:
             return 1;
         case COMPARE_OP_FLOAT:
@@ -1040,6 +1158,10 @@ int _PyOpcode_num_pushed(int opcode, int oparg, bool jump)  {
             return 1;
         case GET_YIELD_FROM_ITER:
             return 1;
+        case _SPECIALIZE_FOR_ITER:
+            return 1;
+        case _FOR_ITER:
+            return 2;
         case FOR_ITER:
             return 2;
         case INSTRUMENTED_FOR_ITER:
@@ -1120,6 +1242,10 @@ int _PyOpcode_num_pushed(int opcode, int oparg, bool jump)  {
             return 2;
         case INSTRUMENTED_CALL:
             return 0;
+        case _SPECIALIZE_CALL:
+            return oparg + 2;
+        case _CALL:
+            return 1;
         case CALL:
             return 1;
         case _CHECK_CALL_BOUND_METHOD_EXACT_ARGS:
@@ -1198,6 +1324,10 @@ int _PyOpcode_num_pushed(int opcode, int oparg, bool jump)  {
             return 1;
         case COPY:
             return (oparg-1) + 2;
+        case _SPECIALIZE_BINARY_OP:
+            return 2;
+        case _BINARY_OP:
+            return 1;
         case BINARY_OP:
             return 1;
         case SWAP:
@@ -1248,6 +1378,7 @@ enum InstructionFormat {
     INSTR_FMT_IBC0,
     INSTR_FMT_IBC00,
     INSTR_FMT_IBC000,
+    INSTR_FMT_IBC0000000,
     INSTR_FMT_IBC00000000,
     INSTR_FMT_IX,
     INSTR_FMT_IXC,
@@ -1331,6 +1462,8 @@ const struct opcode_metadata _PyOpcode_opcode_metadata[OPCODE_METADATA_SIZE] = {
     [INSTRUMENTED_END_SEND] = { true, INSTR_FMT_IX, HAS_ERROR_FLAG },
     [UNARY_NEGATIVE] = { true, INSTR_FMT_IX, HAS_ERROR_FLAG },
     [UNARY_NOT] = { true, INSTR_FMT_IX, 0 },
+    [_SPECIALIZE_TO_BOOL] = { true, INSTR_FMT_IXC, 0 },
+    [_TO_BOOL] = { true, INSTR_FMT_IXC0, HAS_ERROR_FLAG },
     [TO_BOOL] = { true, INSTR_FMT_IXC00, HAS_ERROR_FLAG },
     [TO_BOOL_BOOL] = { true, INSTR_FMT_IXC00, HAS_DEOPT_FLAG },
     [TO_BOOL_INT] = { true, INSTR_FMT_IXC00, HAS_DEOPT_FLAG },
@@ -1358,6 +1491,8 @@ const struct opcode_metadata _PyOpcode_opcode_metadata[OPCODE_METADATA_SIZE] = {
     [BINARY_OP_ADD_UNICODE] = { true, INSTR_FMT_IXC, HAS_DEOPT_FLAG | HAS_ERROR_FLAG },
     [_BINARY_OP_INPLACE_ADD_UNICODE] = { true, INSTR_FMT_IXC, HAS_LOCAL_FLAG | HAS_DEOPT_FLAG | HAS_ERROR_FLAG },
     [BINARY_OP_INPLACE_ADD_UNICODE] = { true, INSTR_FMT_IXC, HAS_LOCAL_FLAG | HAS_DEOPT_FLAG | HAS_ERROR_FLAG },
+    [_SPECIALIZE_BINARY_SUBSCR] = { true, INSTR_FMT_IXC, 0 },
+    [_BINARY_SUBSCR] = { true, INSTR_FMT_IX, HAS_ERROR_FLAG },
     [BINARY_SUBSCR] = { true, INSTR_FMT_IXC, HAS_ERROR_FLAG },
     [BINARY_SLICE] = { true, INSTR_FMT_IX, HAS_ERROR_FLAG },
     [STORE_SLICE] = { true, INSTR_FMT_IX, HAS_ERROR_FLAG },
@@ -1368,6 +1503,8 @@ const struct opcode_metadata _PyOpcode_opcode_metadata[OPCODE_METADATA_SIZE] = {
     [BINARY_SUBSCR_GETITEM] = { true, INSTR_FMT_IXC, HAS_DEOPT_FLAG },
     [LIST_APPEND] = { true, INSTR_FMT_IB, HAS_ARG_FLAG | HAS_ERROR_FLAG },
     [SET_ADD] = { true, INSTR_FMT_IB, HAS_ARG_FLAG | HAS_ERROR_FLAG },
+    [_SPECIALIZE_STORE_SUBSCR] = { true, INSTR_FMT_IXC, 0 },
+    [_STORE_SUBSCR] = { true, INSTR_FMT_IX, HAS_ERROR_FLAG },
     [STORE_SUBSCR] = { true, INSTR_FMT_IXC, HAS_ERROR_FLAG },
     [STORE_SUBSCR_LIST_INT] = { true, INSTR_FMT_IXC, HAS_DEOPT_FLAG },
     [STORE_SUBSCR_DICT] = { true, INSTR_FMT_IXC, HAS_DEOPT_FLAG | HAS_ERROR_FLAG },
@@ -1384,6 +1521,8 @@ const struct opcode_metadata _PyOpcode_opcode_metadata[OPCODE_METADATA_SIZE] = {
     [GET_AITER] = { true, INSTR_FMT_IX, HAS_ERROR_FLAG },
     [GET_ANEXT] = { true, INSTR_FMT_IX, HAS_ERROR_FLAG },
     [GET_AWAITABLE] = { true, INSTR_FMT_IB, HAS_ARG_FLAG | HAS_ERROR_FLAG },
+    [_SPECIALIZE_SEND] = { true, INSTR_FMT_IXC, 0 },
+    [_SEND] = { true, INSTR_FMT_IB, HAS_ARG_FLAG | HAS_JUMP_FLAG | HAS_ERROR_FLAG },
     [SEND] = { true, INSTR_FMT_IBC, HAS_ARG_FLAG | HAS_JUMP_FLAG | HAS_ERROR_FLAG },
     [SEND_GEN] = { true, INSTR_FMT_IBC, HAS_ARG_FLAG | HAS_DEOPT_FLAG },
     [INSTRUMENTED_YIELD_VALUE] = { true, INSTR_FMT_IB, HAS_ARG_FLAG | HAS_ERROR_FLAG },
@@ -1396,11 +1535,15 @@ const struct opcode_metadata _PyOpcode_opcode_metadata[OPCODE_METADATA_SIZE] = {
     [LOAD_BUILD_CLASS] = { true, INSTR_FMT_IX, HAS_ERROR_FLAG },
     [STORE_NAME] = { true, INSTR_FMT_IB, HAS_ARG_FLAG | HAS_NAME_FLAG | HAS_ERROR_FLAG },
     [DELETE_NAME] = { true, INSTR_FMT_IB, HAS_ARG_FLAG | HAS_NAME_FLAG | HAS_ERROR_FLAG },
+    [_SPECIALIZE_UNPACK_SEQUENCE] = { true, INSTR_FMT_IBC, HAS_ARG_FLAG },
+    [_UNPACK_SEQUENCE] = { true, INSTR_FMT_IB, HAS_ARG_FLAG | HAS_ERROR_FLAG },
     [UNPACK_SEQUENCE] = { true, INSTR_FMT_IBC, HAS_ARG_FLAG | HAS_ERROR_FLAG },
     [UNPACK_SEQUENCE_TWO_TUPLE] = { true, INSTR_FMT_IBC, HAS_ARG_FLAG | HAS_DEOPT_FLAG },
     [UNPACK_SEQUENCE_TUPLE] = { true, INSTR_FMT_IBC, HAS_ARG_FLAG | HAS_DEOPT_FLAG },
     [UNPACK_SEQUENCE_LIST] = { true, INSTR_FMT_IBC, HAS_ARG_FLAG | HAS_DEOPT_FLAG },
     [UNPACK_EX] = { true, INSTR_FMT_IB, HAS_ARG_FLAG | HAS_ERROR_FLAG },
+    [_SPECIALIZE_STORE_ATTR] = { true, INSTR_FMT_IBC, HAS_ARG_FLAG | HAS_NAME_FLAG },
+    [_STORE_ATTR] = { true, INSTR_FMT_IBC00, HAS_ARG_FLAG | HAS_NAME_FLAG | HAS_ERROR_FLAG },
     [STORE_ATTR] = { true, INSTR_FMT_IBC000, HAS_ARG_FLAG | HAS_NAME_FLAG | HAS_ERROR_FLAG },
     [DELETE_ATTR] = { true, INSTR_FMT_IB, HAS_ARG_FLAG | HAS_NAME_FLAG | HAS_ERROR_FLAG },
     [STORE_GLOBAL] = { true, INSTR_FMT_IB, HAS_ARG_FLAG | HAS_NAME_FLAG | HAS_ERROR_FLAG },
@@ -1408,6 +1551,8 @@ const struct opcode_metadata _PyOpcode_opcode_metadata[OPCODE_METADATA_SIZE] = {
     [LOAD_LOCALS] = { true, INSTR_FMT_IX, HAS_ERROR_FLAG },
     [LOAD_FROM_DICT_OR_GLOBALS] = { true, INSTR_FMT_IB, HAS_ARG_FLAG | HAS_NAME_FLAG | HAS_ERROR_FLAG },
     [LOAD_NAME] = { true, INSTR_FMT_IB, HAS_ARG_FLAG | HAS_NAME_FLAG | HAS_ERROR_FLAG },
+    [_SPECIALIZE_LOAD_GLOBAL] = { true, INSTR_FMT_IBC, HAS_ARG_FLAG | HAS_NAME_FLAG },
+    [_LOAD_GLOBAL] = { true, INSTR_FMT_IBC00, HAS_ARG_FLAG | HAS_NAME_FLAG | HAS_ERROR_FLAG },
     [LOAD_GLOBAL] = { true, INSTR_FMT_IBC000, HAS_ARG_FLAG | HAS_NAME_FLAG | HAS_ERROR_FLAG },
     [_GUARD_GLOBALS_VERSION] = { true, INSTR_FMT_IXC, HAS_DEOPT_FLAG },
     [_GUARD_BUILTINS_VERSION] = { true, INSTR_FMT_IXC, HAS_DEOPT_FLAG },
@@ -1435,12 +1580,16 @@ const struct opcode_metadata _PyOpcode_opcode_metadata[OPCODE_METADATA_SIZE] = {
     [DICT_MERGE] = { true, INSTR_FMT_IB, HAS_ARG_FLAG | HAS_ERROR_FLAG },
     [MAP_ADD] = { true, INSTR_FMT_IB, HAS_ARG_FLAG | HAS_ERROR_FLAG },
     [INSTRUMENTED_LOAD_SUPER_ATTR] = { true, INSTR_FMT_IBC, HAS_ARG_FLAG },
+    [_SPECIALIZE_LOAD_SUPER_ATTR] = { true, INSTR_FMT_IBC, HAS_ARG_FLAG },
+    [_LOAD_SUPER_ATTR] = { true, INSTR_FMT_IB, HAS_ARG_FLAG | HAS_NAME_FLAG | HAS_ERROR_FLAG },
     [LOAD_SUPER_ATTR] = { true, INSTR_FMT_IBC, HAS_ARG_FLAG | HAS_NAME_FLAG | HAS_ERROR_FLAG },
     [LOAD_SUPER_METHOD] = { true, 0, HAS_ARG_FLAG | HAS_NAME_FLAG | HAS_ERROR_FLAG },
     [LOAD_ZERO_SUPER_METHOD] = { true, 0, HAS_ARG_FLAG | HAS_NAME_FLAG | HAS_ERROR_FLAG },
     [LOAD_ZERO_SUPER_ATTR] = { true, 0, HAS_ARG_FLAG | HAS_NAME_FLAG | HAS_ERROR_FLAG },
     [LOAD_SUPER_ATTR_ATTR] = { true, INSTR_FMT_IBC, HAS_ARG_FLAG | HAS_NAME_FLAG | HAS_DEOPT_FLAG | HAS_ERROR_FLAG },
     [LOAD_SUPER_ATTR_METHOD] = { true, INSTR_FMT_IBC, HAS_ARG_FLAG | HAS_NAME_FLAG | HAS_DEOPT_FLAG | HAS_ERROR_FLAG },
+    [_SPECIALIZE_LOAD_ATTR] = { true, INSTR_FMT_IBC, HAS_ARG_FLAG | HAS_NAME_FLAG },
+    [_LOAD_ATTR] = { true, INSTR_FMT_IBC0000000, HAS_ARG_FLAG | HAS_NAME_FLAG | HAS_ERROR_FLAG },
     [LOAD_ATTR] = { true, INSTR_FMT_IBC00000000, HAS_ARG_FLAG | HAS_NAME_FLAG | HAS_ERROR_FLAG },
     [LOAD_METHOD] = { true, 0, HAS_ARG_FLAG | HAS_NAME_FLAG | HAS_ERROR_FLAG },
     [_GUARD_TYPE_VERSION] = { true, INSTR_FMT_IXC0, HAS_DEOPT_FLAG },
@@ -1466,6 +1615,8 @@ const struct opcode_metadata _PyOpcode_opcode_metadata[OPCODE_METADATA_SIZE] = {
     [STORE_ATTR_WITH_HINT] = { true, INSTR_FMT_IBC000, HAS_ARG_FLAG | HAS_NAME_FLAG | HAS_DEOPT_FLAG },
     [_STORE_ATTR_SLOT] = { true, INSTR_FMT_IXC, 0 },
     [STORE_ATTR_SLOT] = { true, INSTR_FMT_IXC000, HAS_DEOPT_FLAG },
+    [_SPECIALIZE_COMPARE_OP] = { true, INSTR_FMT_IBC, HAS_ARG_FLAG },
+    [_COMPARE_OP] = { true, INSTR_FMT_IB, HAS_ARG_FLAG | HAS_ERROR_FLAG },
     [COMPARE_OP] = { true, INSTR_FMT_IBC, HAS_ARG_FLAG | HAS_ERROR_FLAG },
     [COMPARE_OP_FLOAT] = { true, INSTR_FMT_IBC, HAS_ARG_FLAG | HAS_DEOPT_FLAG },
     [COMPARE_OP_INT] = { true, INSTR_FMT_IBC, HAS_ARG_FLAG | HAS_DEOPT_FLAG },
@@ -1494,6 +1645,8 @@ const struct opcode_metadata _PyOpcode_opcode_metadata[OPCODE_METADATA_SIZE] = {
     [MATCH_KEYS] = { true, INSTR_FMT_IX, HAS_ERROR_FLAG },
     [GET_ITER] = { true, INSTR_FMT_IX, HAS_ERROR_FLAG },
     [GET_YIELD_FROM_ITER] = { true, INSTR_FMT_IX, HAS_ERROR_FLAG },
+    [_SPECIALIZE_FOR_ITER] = { true, INSTR_FMT_IBC, HAS_ARG_FLAG },
+    [_FOR_ITER] = { true, INSTR_FMT_IB, HAS_ARG_FLAG | HAS_JUMP_FLAG | HAS_ERROR_FLAG },
     [FOR_ITER] = { true, INSTR_FMT_IBC, HAS_ARG_FLAG | HAS_JUMP_FLAG | HAS_ERROR_FLAG },
     [INSTRUMENTED_FOR_ITER] = { true, INSTR_FMT_IBC, HAS_ARG_FLAG | HAS_ERROR_FLAG },
     [_ITER_CHECK_LIST] = { true, INSTR_FMT_IX, HAS_DEOPT_FLAG },
@@ -1534,6 +1687,8 @@ const struct opcode_metadata _PyOpcode_opcode_metadata[OPCODE_METADATA_SIZE] = {
     [_LOAD_ATTR_METHOD_LAZY_DICT] = { true, INSTR_FMT_IBC000, HAS_ARG_FLAG },
     [LOAD_ATTR_METHOD_LAZY_DICT] = { true, INSTR_FMT_IBC00000000, HAS_ARG_FLAG | HAS_DEOPT_FLAG },
     [INSTRUMENTED_CALL] = { true, INSTR_FMT_IBC00, HAS_ARG_FLAG | HAS_ERROR_FLAG },
+    [_SPECIALIZE_CALL] = { true, INSTR_FMT_IBC, HAS_ARG_FLAG },
+    [_CALL] = { true, INSTR_FMT_IBC0, HAS_ARG_FLAG | HAS_EVAL_BREAK_FLAG | HAS_ERROR_FLAG },
     [CALL] = { true, INSTR_FMT_IBC00, HAS_ARG_FLAG | HAS_EVAL_BREAK_FLAG | HAS_ERROR_FLAG },
     [_CHECK_CALL_BOUND_METHOD_EXACT_ARGS] = { true, INSTR_FMT_IB, HAS_ARG_FLAG | HAS_DEOPT_FLAG },
     [_INIT_CALL_BOUND_METHOD_EXACT_ARGS] = { true, INSTR_FMT_IB, HAS_ARG_FLAG },
@@ -1573,6 +1728,8 @@ const struct opcode_metadata _PyOpcode_opcode_metadata[OPCODE_METADATA_SIZE] = {
     [FORMAT_SIMPLE] = { true, INSTR_FMT_IX, HAS_ERROR_FLAG },
     [FORMAT_WITH_SPEC] = { true, INSTR_FMT_IX, HAS_ERROR_FLAG },
     [COPY] = { true, INSTR_FMT_IB, HAS_ARG_FLAG },
+    [_SPECIALIZE_BINARY_OP] = { true, INSTR_FMT_IBC, HAS_ARG_FLAG },
+    [_BINARY_OP] = { true, INSTR_FMT_IB, HAS_ARG_FLAG | HAS_ERROR_FLAG },
     [BINARY_OP] = { true, INSTR_FMT_IBC, HAS_ARG_FLAG | HAS_ERROR_FLAG },
     [SWAP] = { true, INSTR_FMT_IB, HAS_ARG_FLAG },
     [INSTRUMENTED_INSTRUCTION] = { true, INSTR_FMT_IX, HAS_ERROR_FLAG },
@@ -1614,7 +1771,6 @@ const struct opcode_macro_expansion _PyOpcode_macro_expansion[OPCODE_MACRO_EXPAN
     [END_SEND] = { .nuops = 1, .uops = { { END_SEND, 0, 0 } } },
     [UNARY_NEGATIVE] = { .nuops = 1, .uops = { { UNARY_NEGATIVE, 0, 0 } } },
     [UNARY_NOT] = { .nuops = 1, .uops = { { UNARY_NOT, 0, 0 } } },
-    [TO_BOOL] = { .nuops = 1, .uops = { { TO_BOOL, 0, 0 } } },
     [TO_BOOL_BOOL] = { .nuops = 1, .uops = { { TO_BOOL_BOOL, 0, 0 } } },
     [TO_BOOL_INT] = { .nuops = 1, .uops = { { TO_BOOL_INT, 0, 0 } } },
     [TO_BOOL_LIST] = { .nuops = 1, .uops = { { TO_BOOL_LIST, 0, 0 } } },
@@ -1629,7 +1785,6 @@ const struct opcode_macro_expansion _PyOpcode_macro_expansion[OPCODE_MACRO_EXPAN
     [BINARY_OP_ADD_FLOAT] = { .nuops = 2, .uops = { { _GUARD_BOTH_FLOAT, 0, 0 }, { _BINARY_OP_ADD_FLOAT, 0, 0 } } },
     [BINARY_OP_SUBTRACT_FLOAT] = { .nuops = 2, .uops = { { _GUARD_BOTH_FLOAT, 0, 0 }, { _BINARY_OP_SUBTRACT_FLOAT, 0, 0 } } },
     [BINARY_OP_ADD_UNICODE] = { .nuops = 2, .uops = { { _GUARD_BOTH_UNICODE, 0, 0 }, { _BINARY_OP_ADD_UNICODE, 0, 0 } } },
-    [BINARY_SUBSCR] = { .nuops = 1, .uops = { { BINARY_SUBSCR, 0, 0 } } },
     [BINARY_SLICE] = { .nuops = 1, .uops = { { BINARY_SLICE, 0, 0 } } },
     [STORE_SLICE] = { .nuops = 1, .uops = { { STORE_SLICE, 0, 0 } } },
     [BINARY_SUBSCR_LIST_INT] = { .nuops = 1, .uops = { { BINARY_SUBSCR_LIST_INT, 0, 0 } } },
@@ -1638,7 +1793,6 @@ const struct opcode_macro_expansion _PyOpcode_macro_expansion[OPCODE_MACRO_EXPAN
     [BINARY_SUBSCR_DICT] = { .nuops = 1, .uops = { { BINARY_SUBSCR_DICT, 0, 0 } } },
     [LIST_APPEND] = { .nuops = 1, .uops = { { LIST_APPEND, 0, 0 } } },
     [SET_ADD] = { .nuops = 1, .uops = { { SET_ADD, 0, 0 } } },
-    [STORE_SUBSCR] = { .nuops = 1, .uops = { { STORE_SUBSCR, 0, 0 } } },
     [STORE_SUBSCR_LIST_INT] = { .nuops = 1, .uops = { { STORE_SUBSCR_LIST_INT, 0, 0 } } },
     [STORE_SUBSCR_DICT] = { .nuops = 1, .uops = { { STORE_SUBSCR_DICT, 0, 0 } } },
     [DELETE_SUBSCR] = { .nuops = 1, .uops = { { DELETE_SUBSCR, 0, 0 } } },
@@ -1654,19 +1808,17 @@ const struct opcode_macro_expansion _PyOpcode_macro_expansion[OPCODE_MACRO_EXPAN
     [LOAD_BUILD_CLASS] = { .nuops = 1, .uops = { { LOAD_BUILD_CLASS, 0, 0 } } },
     [STORE_NAME] = { .nuops = 1, .uops = { { STORE_NAME, 0, 0 } } },
     [DELETE_NAME] = { .nuops = 1, .uops = { { DELETE_NAME, 0, 0 } } },
-    [UNPACK_SEQUENCE] = { .nuops = 1, .uops = { { UNPACK_SEQUENCE, 0, 0 } } },
+    [UNPACK_SEQUENCE] = { .nuops = 2, .uops = { { _SPECIALIZE_UNPACK_SEQUENCE, 1, 0 }, { _UNPACK_SEQUENCE, 0, 0 } } },
     [UNPACK_SEQUENCE_TWO_TUPLE] = { .nuops = 1, .uops = { { UNPACK_SEQUENCE_TWO_TUPLE, 0, 0 } } },
     [UNPACK_SEQUENCE_TUPLE] = { .nuops = 1, .uops = { { UNPACK_SEQUENCE_TUPLE, 0, 0 } } },
     [UNPACK_SEQUENCE_LIST] = { .nuops = 1, .uops = { { UNPACK_SEQUENCE_LIST, 0, 0 } } },
     [UNPACK_EX] = { .nuops = 1, .uops = { { UNPACK_EX, 0, 0 } } },
-    [STORE_ATTR] = { .nuops = 1, .uops = { { STORE_ATTR, 0, 0 } } },
     [DELETE_ATTR] = { .nuops = 1, .uops = { { DELETE_ATTR, 0, 0 } } },
     [STORE_GLOBAL] = { .nuops = 1, .uops = { { STORE_GLOBAL, 0, 0 } } },
     [DELETE_GLOBAL] = { .nuops = 1, .uops = { { DELETE_GLOBAL, 0, 0 } } },
     [LOAD_LOCALS] = { .nuops = 1, .uops = { { LOAD_LOCALS, 0, 0 } } },
     [LOAD_FROM_DICT_OR_GLOBALS] = { .nuops = 1, .uops = { { LOAD_FROM_DICT_OR_GLOBALS, 0, 0 } } },
     [LOAD_NAME] = { .nuops = 1, .uops = { { LOAD_NAME, 0, 0 } } },
-    [LOAD_GLOBAL] = { .nuops = 1, .uops = { { LOAD_GLOBAL, 0, 0 } } },
     [LOAD_GLOBAL_MODULE] = { .nuops = 2, .uops = { { _GUARD_GLOBALS_VERSION, 1, 1 }, { _LOAD_GLOBAL_MODULE, 1, 3 } } },
     [LOAD_GLOBAL_BUILTIN] = { .nuops = 3, .uops = { { _GUARD_GLOBALS_VERSION, 1, 1 }, { _GUARD_BUILTINS_VERSION, 1, 2 }, { _LOAD_GLOBAL_BUILTINS, 1, 3 } } },
     [DELETE_FAST] = { .nuops = 1, .uops = { { DELETE_FAST, 0, 0 } } },
@@ -1690,7 +1842,6 @@ const struct opcode_macro_expansion _PyOpcode_macro_expansion[OPCODE_MACRO_EXPAN
     [MAP_ADD] = { .nuops = 1, .uops = { { MAP_ADD, 0, 0 } } },
     [LOAD_SUPER_ATTR_ATTR] = { .nuops = 1, .uops = { { LOAD_SUPER_ATTR_ATTR, 0, 0 } } },
     [LOAD_SUPER_ATTR_METHOD] = { .nuops = 1, .uops = { { LOAD_SUPER_ATTR_METHOD, 0, 0 } } },
-    [LOAD_ATTR] = { .nuops = 1, .uops = { { LOAD_ATTR, 0, 0 } } },
     [LOAD_ATTR_INSTANCE_VALUE] = { .nuops = 3, .uops = { { _GUARD_TYPE_VERSION, 2, 1 }, { _CHECK_MANAGED_OBJECT_HAS_VALUES, 0, 0 }, { _LOAD_ATTR_INSTANCE_VALUE, 1, 3 } } },
     [LOAD_ATTR_MODULE] = { .nuops = 2, .uops = { { _CHECK_ATTR_MODULE, 2, 1 }, { _LOAD_ATTR_MODULE, 1, 3 } } },
     [LOAD_ATTR_WITH_HINT] = { .nuops = 3, .uops = { { _GUARD_TYPE_VERSION, 2, 1 }, { _CHECK_ATTR_WITH_HINT, 0, 0 }, { _LOAD_ATTR_WITH_HINT, 1, 3 } } },
@@ -1698,7 +1849,6 @@ const struct opcode_macro_expansion _PyOpcode_macro_expansion[OPCODE_MACRO_EXPAN
     [LOAD_ATTR_CLASS] = { .nuops = 2, .uops = { { _CHECK_ATTR_CLASS, 2, 1 }, { _LOAD_ATTR_CLASS, 4, 5 } } },
     [STORE_ATTR_INSTANCE_VALUE] = { .nuops = 3, .uops = { { _GUARD_TYPE_VERSION, 2, 1 }, { _GUARD_DORV_VALUES, 0, 0 }, { _STORE_ATTR_INSTANCE_VALUE, 1, 3 } } },
     [STORE_ATTR_SLOT] = { .nuops = 2, .uops = { { _GUARD_TYPE_VERSION, 2, 1 }, { _STORE_ATTR_SLOT, 1, 3 } } },
-    [COMPARE_OP] = { .nuops = 1, .uops = { { COMPARE_OP, 0, 0 } } },
     [COMPARE_OP_FLOAT] = { .nuops = 1, .uops = { { COMPARE_OP_FLOAT, 0, 0 } } },
     [COMPARE_OP_INT] = { .nuops = 1, .uops = { { COMPARE_OP_INT, 0, 0 } } },
     [COMPARE_OP_STR] = { .nuops = 1, .uops = { { COMPARE_OP_STR, 0, 0 } } },
@@ -1744,7 +1894,6 @@ const struct opcode_macro_expansion _PyOpcode_macro_expansion[OPCODE_MACRO_EXPAN
     [FORMAT_SIMPLE] = { .nuops = 1, .uops = { { FORMAT_SIMPLE, 0, 0 } } },
     [FORMAT_WITH_SPEC] = { .nuops = 1, .uops = { { FORMAT_WITH_SPEC, 0, 0 } } },
     [COPY] = { .nuops = 1, .uops = { { COPY, 0, 0 } } },
-    [BINARY_OP] = { .nuops = 1, .uops = { { BINARY_OP, 0, 0 } } },
     [SWAP] = { .nuops = 1, .uops = { { SWAP, 0, 0 } } },
 };
 #endif // NEED_OPCODE_METADATA
@@ -1754,6 +1903,8 @@ extern const char * const _PyOpcode_uop_name[OPCODE_UOP_NAME_SIZE];
 const char * const _PyOpcode_uop_name[OPCODE_UOP_NAME_SIZE] = {
     [_EXIT_TRACE] = "_EXIT_TRACE",
     [_SET_IP] = "_SET_IP",
+    [_SPECIALIZE_TO_BOOL] = "_SPECIALIZE_TO_BOOL",
+    [_TO_BOOL] = "_TO_BOOL",
     [_GUARD_BOTH_INT] = "_GUARD_BOTH_INT",
     [_BINARY_OP_MULTIPLY_INT] = "_BINARY_OP_MULTIPLY_INT",
     [_BINARY_OP_ADD_INT] = "_BINARY_OP_ADD_INT",
@@ -1765,11 +1916,27 @@ const char * const _PyOpcode_uop_name[OPCODE_UOP_NAME_SIZE] = {
     [_GUARD_BOTH_UNICODE] = "_GUARD_BOTH_UNICODE",
     [_BINARY_OP_ADD_UNICODE] = "_BINARY_OP_ADD_UNICODE",
     [_BINARY_OP_INPLACE_ADD_UNICODE] = "_BINARY_OP_INPLACE_ADD_UNICODE",
+    [_SPECIALIZE_BINARY_SUBSCR] = "_SPECIALIZE_BINARY_SUBSCR",
+    [_BINARY_SUBSCR] = "_BINARY_SUBSCR",
+    [_SPECIALIZE_STORE_SUBSCR] = "_SPECIALIZE_STORE_SUBSCR",
+    [_STORE_SUBSCR] = "_STORE_SUBSCR",
     [_POP_FRAME] = "_POP_FRAME",
+    [_SPECIALIZE_SEND] = "_SPECIALIZE_SEND",
+    [_SEND] = "_SEND",
+    [_SPECIALIZE_UNPACK_SEQUENCE] = "_SPECIALIZE_UNPACK_SEQUENCE",
+    [_UNPACK_SEQUENCE] = "_UNPACK_SEQUENCE",
+    [_SPECIALIZE_STORE_ATTR] = "_SPECIALIZE_STORE_ATTR",
+    [_STORE_ATTR] = "_STORE_ATTR",
+    [_SPECIALIZE_LOAD_GLOBAL] = "_SPECIALIZE_LOAD_GLOBAL",
+    [_LOAD_GLOBAL] = "_LOAD_GLOBAL",
     [_GUARD_GLOBALS_VERSION] = "_GUARD_GLOBALS_VERSION",
     [_GUARD_BUILTINS_VERSION] = "_GUARD_BUILTINS_VERSION",
     [_LOAD_GLOBAL_MODULE] = "_LOAD_GLOBAL_MODULE",
     [_LOAD_GLOBAL_BUILTINS] = "_LOAD_GLOBAL_BUILTINS",
+    [_SPECIALIZE_LOAD_SUPER_ATTR] = "_SPECIALIZE_LOAD_SUPER_ATTR",
+    [_LOAD_SUPER_ATTR] = "_LOAD_SUPER_ATTR",
+    [_SPECIALIZE_LOAD_ATTR] = "_SPECIALIZE_LOAD_ATTR",
+    [_LOAD_ATTR] = "_LOAD_ATTR",
     [_GUARD_TYPE_VERSION] = "_GUARD_TYPE_VERSION",
     [_CHECK_MANAGED_OBJECT_HAS_VALUES] = "_CHECK_MANAGED_OBJECT_HAS_VALUES",
     [_LOAD_ATTR_INSTANCE_VALUE] = "_LOAD_ATTR_INSTANCE_VALUE",
@@ -1783,7 +1950,11 @@ const char * const _PyOpcode_uop_name[OPCODE_UOP_NAME_SIZE] = {
     [_GUARD_DORV_VALUES] = "_GUARD_DORV_VALUES",
     [_STORE_ATTR_INSTANCE_VALUE] = "_STORE_ATTR_INSTANCE_VALUE",
     [_STORE_ATTR_SLOT] = "_STORE_ATTR_SLOT",
+    [_SPECIALIZE_COMPARE_OP] = "_SPECIALIZE_COMPARE_OP",
+    [_COMPARE_OP] = "_COMPARE_OP",
     [_IS_NONE] = "_IS_NONE",
+    [_SPECIALIZE_FOR_ITER] = "_SPECIALIZE_FOR_ITER",
+    [_FOR_ITER] = "_FOR_ITER",
     [_ITER_CHECK_LIST] = "_ITER_CHECK_LIST",
     [_ITER_JUMP_LIST] = "_ITER_JUMP_LIST",
     [_IS_ITER_EXHAUSTED_LIST] = "_IS_ITER_EXHAUSTED_LIST",
@@ -1804,6 +1975,8 @@ const char * const _PyOpcode_uop_name[OPCODE_UOP_NAME_SIZE] = {
     [_LOAD_ATTR_NONDESCRIPTOR_NO_DICT] = "_LOAD_ATTR_NONDESCRIPTOR_NO_DICT",
     [_CHECK_ATTR_METHOD_LAZY_DICT] = "_CHECK_ATTR_METHOD_LAZY_DICT",
     [_LOAD_ATTR_METHOD_LAZY_DICT] = "_LOAD_ATTR_METHOD_LAZY_DICT",
+    [_SPECIALIZE_CALL] = "_SPECIALIZE_CALL",
+    [_CALL] = "_CALL",
     [_CHECK_CALL_BOUND_METHOD_EXACT_ARGS] = "_CHECK_CALL_BOUND_METHOD_EXACT_ARGS",
     [_INIT_CALL_BOUND_METHOD_EXACT_ARGS] = "_INIT_CALL_BOUND_METHOD_EXACT_ARGS",
     [_CHECK_PEP_523] = "_CHECK_PEP_523",
@@ -1811,6 +1984,8 @@ const char * const _PyOpcode_uop_name[OPCODE_UOP_NAME_SIZE] = {
     [_CHECK_STACK_SPACE] = "_CHECK_STACK_SPACE",
     [_INIT_CALL_PY_EXACT_ARGS] = "_INIT_CALL_PY_EXACT_ARGS",
     [_PUSH_FRAME] = "_PUSH_FRAME",
+    [_SPECIALIZE_BINARY_OP] = "_SPECIALIZE_BINARY_OP",
+    [_BINARY_OP] = "_BINARY_OP",
     [_POP_JUMP_IF_FALSE] = "_POP_JUMP_IF_FALSE",
     [_POP_JUMP_IF_TRUE] = "_POP_JUMP_IF_TRUE",
     [_JUMP_TO_TOP] = "_JUMP_TO_TOP",

--- a/Lib/test/test_capi/test_misc.py
+++ b/Lib/test/test_capi/test_misc.py
@@ -2595,7 +2595,7 @@ class TestUops(unittest.TestCase):
         ex = get_first_executor(testfunc)
         self.assertIsNotNone(ex)
         uops = {opname for opname, _, _ in ex}
-        self.assertIn("UNPACK_SEQUENCE", uops)
+        self.assertIn("_UNPACK_SEQUENCE", uops)
 
     def test_pop_jump_if_false(self):
         def testfunc(n):

--- a/Python/abstract_interp_cases.c.h
+++ b/Python/abstract_interp_cases.c.h
@@ -38,7 +38,7 @@
             break;
         }
 
-        case TO_BOOL: {
+        case _TO_BOOL: {
             PARTITIONNODE_OVERWRITE((_Py_PARTITIONNODE_t *)PARTITIONNODE_NULLROOT, PEEK(-(-1)), true);
             break;
         }
@@ -113,7 +113,7 @@
             break;
         }
 
-        case BINARY_SUBSCR: {
+        case _BINARY_SUBSCR: {
             STACK_SHRINK(1);
             PARTITIONNODE_OVERWRITE((_Py_PARTITIONNODE_t *)PARTITIONNODE_NULLROOT, PEEK(-(-1)), true);
             break;
@@ -164,7 +164,7 @@
             break;
         }
 
-        case STORE_SUBSCR: {
+        case _STORE_SUBSCR: {
             STACK_SHRINK(3);
             break;
         }
@@ -242,7 +242,11 @@
             break;
         }
 
-        case UNPACK_SEQUENCE: {
+        case _SPECIALIZE_UNPACK_SEQUENCE: {
+            break;
+        }
+
+        case _UNPACK_SEQUENCE: {
             STACK_SHRINK(1);
             STACK_GROW(oparg);
             break;
@@ -272,7 +276,7 @@
             break;
         }
 
-        case STORE_ATTR: {
+        case _STORE_ATTR: {
             STACK_SHRINK(2);
             break;
         }
@@ -308,7 +312,7 @@
             break;
         }
 
-        case LOAD_GLOBAL: {
+        case _LOAD_GLOBAL: {
             STACK_GROW(1);
             STACK_GROW(((oparg & 1) ? 1 : 0));
             PARTITIONNODE_OVERWRITE((_Py_PARTITIONNODE_t *)PARTITIONNODE_NULLROOT, PEEK(-(-1 - (oparg & 1 ? 1 : 0))), true);
@@ -456,7 +460,7 @@
             break;
         }
 
-        case LOAD_ATTR: {
+        case _LOAD_ATTR: {
             STACK_GROW(((oparg & 1) ? 1 : 0));
             PARTITIONNODE_OVERWRITE((_Py_PARTITIONNODE_t *)PARTITIONNODE_NULLROOT, PEEK(-(-1 - (oparg & 1 ? 1 : 0))), true);
             PARTITIONNODE_OVERWRITE((_Py_PARTITIONNODE_t *)PARTITIONNODE_NULLROOT, PEEK(-(-(oparg & 1 ? 1 : 0))), true);
@@ -532,7 +536,7 @@
             break;
         }
 
-        case COMPARE_OP: {
+        case _COMPARE_OP: {
             STACK_SHRINK(1);
             PARTITIONNODE_OVERWRITE((_Py_PARTITIONNODE_t *)PARTITIONNODE_NULLROOT, PEEK(-(-1)), true);
             break;
@@ -901,7 +905,7 @@
             break;
         }
 
-        case BINARY_OP: {
+        case _BINARY_OP: {
             STACK_SHRINK(1);
             PARTITIONNODE_OVERWRITE((_Py_PARTITIONNODE_t *)PARTITIONNODE_NULLROOT, PEEK(-(-1)), true);
             break;

--- a/Python/bytecodes.c
+++ b/Python/bytecodes.c
@@ -1879,7 +1879,6 @@ dummy_func(
                 if (_PyObject_GetMethod(owner, name, &attr)) {
                     /* We can bypass temporary bound method object.
                        meth is unbound method and obj is self.
-
                        meth | self | arg1 | ... | argN
                      */
                     assert(attr != NULL);  // No errors on this branch
@@ -1890,7 +1889,6 @@ dummy_func(
                        something was returned by a descriptor protocol).  Set
                        the second element of the stack to NULL, to signal
                        CALL that it's not a method call.
-
                        NULL | meth | arg1 | ... | argN
                     */
                     DECREF_INPUTS();

--- a/Python/executor_cases.c.h
+++ b/Python/executor_cases.c.h
@@ -1117,7 +1117,6 @@
             }
             else {
                 /* Slow-path if globals or builtins is not a dict */
-
                 /* namespace 1: globals */
                 if (PyMapping_GetOptionalItem(GLOBALS(), name, &res) < 0) goto error;
                 if (res == NULL) {
@@ -1596,7 +1595,6 @@
                 if (_PyObject_GetMethod(owner, name, &attr)) {
                     /* We can bypass temporary bound method object.
                        meth is unbound method and obj is self.
-
                        meth | self | arg1 | ... | argN
                      */
                     assert(attr != NULL);  // No errors on this branch
@@ -1607,7 +1605,6 @@
                        something was returned by a descriptor protocol).  Set
                        the second element of the stack to NULL, to signal
                        CALL that it's not a method call.
-
                        NULL | meth | arg1 | ... | argN
                     */
                     Py_DECREF(owner);

--- a/Python/generated_cases.c.h
+++ b/Python/generated_cases.c.h
@@ -2052,7 +2052,6 @@
                 }
                 else {
                     /* Slow-path if globals or builtins is not a dict */
-    
                     /* namespace 1: globals */
                     if (PyMapping_GetOptionalItem(GLOBALS(), name, &res) < 0) goto error;
                     if (res == NULL) {
@@ -2586,7 +2585,6 @@
                             frame, this_instr, global_super, arg);
                     if (err) goto pop_3_error;
                 }
-    
                 // we make no attempt to optimize here; specializations should
                 // handle any case whose performance we care about
                 PyObject *stack[] = {class, self};
@@ -2724,7 +2722,6 @@
                     if (_PyObject_GetMethod(owner, name, &attr)) {
                         /* We can bypass temporary bound method object.
                            meth is unbound method and obj is self.
-    
                            meth | self | arg1 | ... | argN
                          */
                         assert(attr != NULL);  // No errors on this branch
@@ -2735,7 +2732,6 @@
                            something was returned by a descriptor protocol).  Set
                            the second element of the stack to NULL, to signal
                            CALL that it's not a method call.
-    
                            NULL | meth | arg1 | ... | argN
                         */
                         Py_DECREF(owner);

--- a/Tools/cases_generator/analysis.py
+++ b/Tools/cases_generator/analysis.py
@@ -383,7 +383,12 @@ class Analyzer:
         return MacroInstruction(macro.name, format, flags, macro, parts, offset)
 
     def analyze_pseudo(self, pseudo: parsing.Pseudo) -> PseudoInstruction:
-        targets = [self.instrs[target] for target in pseudo.targets]
+        targets: list[Instruction | MacroInstruction] = []
+        for target_name in pseudo.targets:
+            if target_name in self.instrs:
+                targets.append(self.instrs[target_name])
+            else:
+                targets.append(self.macro_instrs[target_name])
         assert targets
         ignored_flags = {"HAS_EVAL_BREAK_FLAG", "HAS_DEOPT_FLAG", "HAS_ERROR_FLAG"}
         assert len({t.instr_flags.bitmap(ignore=ignored_flags) for t in targets}) == 1

--- a/Tools/cases_generator/generate_cases.py
+++ b/Tools/cases_generator/generate_cases.py
@@ -178,17 +178,17 @@ class Generator(Analyzer):
                 # for all targets.
                 for target in self.pseudos[thing.name].targets:
                     target_instr = self.instrs.get(target)
-                    # Currently target is always an instr. This could change
-                    # in the future, e.g., if we have a pseudo targetting a
-                    # macro instruction.
-                    assert target_instr
-                    target_popped = effect_str(target_instr.input_effects)
-                    target_pushed = effect_str(target_instr.output_effects)
-                    if popped is None:
-                        popped, pushed = target_popped, target_pushed
+                    if target_instr is None:
+                        target_instr = self.macro_instrs[target]
+                        popped, pushed = stacking.get_stack_effect_info_for_macro(target_instr)
                     else:
-                        assert popped == target_popped
-                        assert pushed == target_pushed
+                        target_popped = effect_str(target_instr.input_effects)
+                        target_pushed = effect_str(target_instr.output_effects)
+                        if popped is None:
+                            popped, pushed = target_popped, target_pushed
+                        else:
+                            assert popped == target_popped
+                            assert pushed == target_pushed
             case _:
                 assert_never(thing)
         assert popped is not None and pushed is not None

--- a/Tools/cases_generator/generate_cases.py
+++ b/Tools/cases_generator/generate_cases.py
@@ -179,8 +179,8 @@ class Generator(Analyzer):
                 for target in self.pseudos[thing.name].targets:
                     target_instr = self.instrs.get(target)
                     if target_instr is None:
-                        target_instr = self.macro_instrs[target]
-                        popped, pushed = stacking.get_stack_effect_info_for_macro(target_instr)
+                        macro_instr = self.macro_instrs[target]
+                        popped, pushed = stacking.get_stack_effect_info_for_macro(macro_instr)
                     else:
                         target_popped = effect_str(target_instr.input_effects)
                         target_pushed = effect_str(target_instr.output_effects)

--- a/Tools/cases_generator/instructions.py
+++ b/Tools/cases_generator/instructions.py
@@ -285,7 +285,7 @@ class PseudoInstruction:
     """A pseudo instruction."""
 
     name: str
-    targets: list[Instruction]
+    targets: list[Instruction | MacroInstruction]
     instr_flags: InstructionFlags
 
 


### PR DESCRIPTION
Makes the split into specialization and default action for "normal" instructions explicit.

<!-- gh-issue-number: gh-111485 -->
* Issue: gh-111485
<!-- /gh-issue-number -->
