### PR TITLE
gh-108765: Python.h no longer includes <stddef.h> on Windows

### DIFF
--- a/Doc/whatsnew/3.13.rst
+++ b/Doc/whatsnew/3.13.rst
@@ -1186,6 +1186,14 @@ Porting to Python 3.13
   ``PyUnicode_AsUTF8AndSize(unicode, NULL)`` can be used instead.
   (Contributed by Victor Stinner in :gh:`111089`.)
 
+* On Windows, ``Python.h`` no longer includes the ``<stddef.h>`` standard
+  header file. If needed, it should now be included explicitly. For example, it
+  provides ``offsetof()`` function, and ``size_t`` and ``ptrdiff_t`` types.
+  Including ``<stddef.h>`` explicitly was already needed by all other
+  platforms, the ``HAVE_STDDEF_H`` macro is only defined on Windows.
+  (Contributed by Victor Stinner in :gh:`108765`.)
+
+
 Deprecated
 ----------
 

--- a/Include/Python.h
+++ b/Include/Python.h
@@ -22,9 +22,6 @@
 #include <math.h>                 // HUGE_VAL
 #include <stdarg.h>               // va_list
 #include <wchar.h>                // wchar_t
-#ifdef HAVE_STDDEF_H
-#  include <stddef.h>             // size_t
-#endif
 #ifdef HAVE_SYS_TYPES_H
 #  include <sys/types.h>          // ssize_t
 #endif

--- a/Misc/NEWS.d/next/C API/2023-10-31-18-22-03.gh-issue-108765._beYv8.rst
+++ b/Misc/NEWS.d/next/C API/2023-10-31-18-22-03.gh-issue-108765._beYv8.rst
@@ -1,0 +1,3 @@
+On Windows, ``Python.h`` no longer includes the ``<stddef.h>`` standard
+header file. If needed, it should now be included explicitly. Patch by
+Victor Stinner.


### PR DESCRIPTION
In practice, only Windows is impacted, because the HAVE_STDDEF_H macro was only defined on Windows.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-108765 -->
* Issue: gh-108765
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--111563.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->