### PR TITLE
gh-110383: Explained which error message is generated when there is an unhandled exception

### DIFF
--- a/Doc/tutorial/errors.rst
+++ b/Doc/tutorial/errors.rst
@@ -108,8 +108,9 @@ The :keyword:`try` statement works as follows.
 
 * If an exception occurs which does not match the exception named in the *except
   clause*, it is passed on to outer :keyword:`try` statements; if no handler is
-  found, it is an *unhandled exception* and execution stops with a message as
-  shown above.
+  found, it is an *unhandled exception* and execution stops with error message. 
+  The error message will provide information about the *unhandled exception*,
+  as described in the :ref:`tut-exceptions` section.
 
 A :keyword:`try` statement may have more than one *except clause*, to specify
 handlers for different exceptions.  At most one handler will be executed.

--- a/Doc/tutorial/errors.rst
+++ b/Doc/tutorial/errors.rst
@@ -108,7 +108,7 @@ The :keyword:`try` statement works as follows.
 
 * If an exception occurs which does not match the exception named in the *except
   clause*, it is passed on to outer :keyword:`try` statements; if no handler is
-  found, it is an *unhandled exception* and execution stops with error message. 
+  found, it is an *unhandled exception* and execution stops with error message.
   The error message will provide information about the *unhandled exception*,
   as described in the :ref:`tut-exceptions` section.
 

--- a/Doc/tutorial/errors.rst
+++ b/Doc/tutorial/errors.rst
@@ -108,9 +108,7 @@ The :keyword:`try` statement works as follows.
 
 * If an exception occurs which does not match the exception named in the *except
   clause*, it is passed on to outer :keyword:`try` statements; if no handler is
-  found, it is an *unhandled exception* and execution stops with error message.
-  The error message will provide information about the *unhandled exception*,
-  as described in the :ref:`tut-exceptions` section.
+  found, it is an *unhandled exception* and execution stops with an error message.
 
 A :keyword:`try` statement may have more than one *except clause*, to specify
 handlers for different exceptions.  At most one handler will be executed.


### PR DESCRIPTION
The line "with a message as shown above" is ambiguous as an error message has also came after the intended error message. So, I clealy explain which error message is generated and linked the message to where it is being described. 

<!-- gh-issue-number: gh-110383 -->
* Issue: gh-110383
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--111574.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->