### PR TITLE
gh-110367: Make regrtest --verbose3 compatible with --huntrleaks -jN

### DIFF
--- a/Lib/test/libregrtest/cmdline.py
+++ b/Lib/test/libregrtest/cmdline.py
@@ -493,10 +493,16 @@ def _parse_args(args, **kwargs):
         ns.randomize = True
     if ns.verbose:
         ns.header = True
-    if ns.huntrleaks and ns.verbose3:
+    # When -jN option is used, a worker process does not use --verbose3
+    # and so -R 3:3 -jN --verbose3 just works as expected: there is no false
+    # alarm about memory leak.
+    if ns.huntrleaks and ns.verbose3 and ns.use_mp is None:
         ns.verbose3 = False
+        # run_single_test() replaces sys.stdout with io.StringIO if verbose3
+        # is true. In this case, huntrleaks sees an write into StringIO as
+        # a memory leak, whereas it is not (gh-71290).
         print("WARNING: Disable --verbose3 because it's incompatible with "
-              "--huntrleaks: see http://bugs.python.org/issue27103",
+              "--huntrleaks without -jN option",
               file=sys.stderr)
     if ns.forever:
         # --forever implies --failfast

--- a/Lib/test/test_regrtest.py
+++ b/Lib/test/test_regrtest.py
@@ -2120,6 +2120,27 @@ class ArgsTestCase(BaseTestCase):
             self.assertIn(f"Exit code {exitcode} (SIGSEGV)", output)
         self.check_line(output, "just before crash!", full=True, regex=False)
 
+    def test_verbose3(self):
+        code = textwrap.dedent(r"""
+            import unittest
+            from test import support
+
+            class VerboseTests(unittest.TestCase):
+                def test_pass(self):
+                    print("SPAM SPAM SPAM")
+        """)
+        testname = self.create_test(code=code)
+
+        # Run sequentially
+        output = self.run_tests("--verbose3", testname)
+        self.check_executed_tests(output, testname, stats=1)
+        self.assertNotIn('SPAM SPAM SPAM', output)
+
+        # Check for reference leaks, run in parallel
+        output = self.run_tests("-R", "3:3", "-j1", "--verbose3", testname)
+        self.check_executed_tests(output, testname, stats=1, parallel=True)
+        self.assertNotIn('SPAM SPAM SPAM', output)
+
 
 class TestUtils(unittest.TestCase):
     def test_format_duration(self):

--- a/Lib/test/test_regrtest.py
+++ b/Lib/test/test_regrtest.py
@@ -2136,10 +2136,12 @@ class ArgsTestCase(BaseTestCase):
         self.check_executed_tests(output, testname, stats=1)
         self.assertNotIn('SPAM SPAM SPAM', output)
 
-        # Check for reference leaks, run in parallel
-        output = self.run_tests("-R", "3:3", "-j1", "--verbose3", testname)
-        self.check_executed_tests(output, testname, stats=1, parallel=True)
-        self.assertNotIn('SPAM SPAM SPAM', output)
+        # -R option needs a debug build
+        if support.Py_DEBUG:
+            # Check for reference leaks, run in parallel
+            output = self.run_tests("-R", "3:3", "-j1", "--verbose3", testname)
+            self.check_executed_tests(output, testname, stats=1, parallel=True)
+            self.assertNotIn('SPAM SPAM SPAM', output)
 
 
 class TestUtils(unittest.TestCase):

--- a/Misc/NEWS.d/next/Tests/2023-10-31-22-09-25.gh-issue-110367.UhQi44.rst
+++ b/Misc/NEWS.d/next/Tests/2023-10-31-22-09-25.gh-issue-110367.UhQi44.rst
@@ -1,0 +1,3 @@
+Make regrtest ``--verbose3`` option compatible with ``--huntrleaks -jN``
+options. The ``./python -m test -j1 -R 3:3 --verbose3`` command now works as
+expected. Patch by Victor Stinner.


### PR DESCRIPTION
"./python -m test -j1 -R 3:3 --verbose3" now works as expected, since run_single_test() does not replace sys.stdout with StringIO in this case.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-110367 -->
* Issue: gh-110367
<!-- /gh-issue-number -->
