### PR TITLE
gh-111089: Use PyUnicode_AsUTF8() in Argument Clinic

### DIFF
--- a/Modules/_io/clinic/_iomodule.c.h
+++ b/Modules/_io/clinic/_iomodule.c.h
@@ -188,13 +188,8 @@ _io_open(PyObject *module, PyObject *const *args, Py_ssize_t nargs, PyObject *kw
             _PyArg_BadArgument("open", "argument 'mode'", "str", args[1]);
             goto exit;
         }
-        Py_ssize_t mode_length;
-        mode = PyUnicode_AsUTF8AndSize(args[1], &mode_length);
+        mode = PyUnicode_AsUTF8(args[1]);
         if (mode == NULL) {
-            goto exit;
-        }
-        if (strlen(mode) != (size_t)mode_length) {
-            PyErr_SetString(PyExc_ValueError, "embedded null character");
             goto exit;
         }
         if (!--noptargs) {
@@ -215,13 +210,8 @@ _io_open(PyObject *module, PyObject *const *args, Py_ssize_t nargs, PyObject *kw
             encoding = NULL;
         }
         else if (PyUnicode_Check(args[3])) {
-            Py_ssize_t encoding_length;
-            encoding = PyUnicode_AsUTF8AndSize(args[3], &encoding_length);
+            encoding = PyUnicode_AsUTF8(args[3]);
             if (encoding == NULL) {
-                goto exit;
-            }
-            if (strlen(encoding) != (size_t)encoding_length) {
-                PyErr_SetString(PyExc_ValueError, "embedded null character");
                 goto exit;
             }
         }
@@ -238,13 +228,8 @@ _io_open(PyObject *module, PyObject *const *args, Py_ssize_t nargs, PyObject *kw
             errors = NULL;
         }
         else if (PyUnicode_Check(args[4])) {
-            Py_ssize_t errors_length;
-            errors = PyUnicode_AsUTF8AndSize(args[4], &errors_length);
+            errors = PyUnicode_AsUTF8(args[4]);
             if (errors == NULL) {
-                goto exit;
-            }
-            if (strlen(errors) != (size_t)errors_length) {
-                PyErr_SetString(PyExc_ValueError, "embedded null character");
                 goto exit;
             }
         }
@@ -261,13 +246,8 @@ _io_open(PyObject *module, PyObject *const *args, Py_ssize_t nargs, PyObject *kw
             newline = NULL;
         }
         else if (PyUnicode_Check(args[5])) {
-            Py_ssize_t newline_length;
-            newline = PyUnicode_AsUTF8AndSize(args[5], &newline_length);
+            newline = PyUnicode_AsUTF8(args[5]);
             if (newline == NULL) {
-                goto exit;
-            }
-            if (strlen(newline) != (size_t)newline_length) {
-                PyErr_SetString(PyExc_ValueError, "embedded null character");
                 goto exit;
             }
         }
@@ -404,4 +384,4 @@ _io_open_code(PyObject *module, PyObject *const *args, Py_ssize_t nargs, PyObjec
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=5d60f4e778a600a4 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=feb173d5f2bfb98a input=a9049054013a1b77]*/

--- a/Modules/_io/clinic/fileio.c.h
+++ b/Modules/_io/clinic/fileio.c.h
@@ -107,13 +107,8 @@ _io_FileIO___init__(PyObject *self, PyObject *args, PyObject *kwargs)
             _PyArg_BadArgument("FileIO", "argument 'mode'", "str", fastargs[1]);
             goto exit;
         }
-        Py_ssize_t mode_length;
-        mode = PyUnicode_AsUTF8AndSize(fastargs[1], &mode_length);
+        mode = PyUnicode_AsUTF8(fastargs[1]);
         if (mode == NULL) {
-            goto exit;
-        }
-        if (strlen(mode) != (size_t)mode_length) {
-            PyErr_SetString(PyExc_ValueError, "embedded null character");
             goto exit;
         }
         if (!--noptargs) {
@@ -528,4 +523,4 @@ _io_FileIO_isatty(fileio *self, PyObject *Py_UNUSED(ignored))
 #ifndef _IO_FILEIO_TRUNCATE_METHODDEF
     #define _IO_FILEIO_TRUNCATE_METHODDEF
 #endif /* !defined(_IO_FILEIO_TRUNCATE_METHODDEF) */
-/*[clinic end generated code: output=1c0f4a36f76b0c6a input=a9049054013a1b77]*/
+/*[clinic end generated code: output=27cff9d0a618edb6 input=a9049054013a1b77]*/

--- a/Modules/_io/clinic/textio.c.h
+++ b/Modules/_io/clinic/textio.c.h
@@ -185,13 +185,8 @@ _io__TextIOBase_write(PyObject *self, PyTypeObject *cls, PyObject *const *args, 
         _PyArg_BadArgument("write", "argument 1", "str", args[0]);
         goto exit;
     }
-    Py_ssize_t s_length;
-    s = PyUnicode_AsUTF8AndSize(args[0], &s_length);
+    s = PyUnicode_AsUTF8(args[0]);
     if (s == NULL) {
-        goto exit;
-    }
-    if (strlen(s) != (size_t)s_length) {
-        PyErr_SetString(PyExc_ValueError, "embedded null character");
         goto exit;
     }
     return_value = _io__TextIOBase_write_impl(self, cls, s);
@@ -475,13 +470,8 @@ _io_TextIOWrapper___init__(PyObject *self, PyObject *args, PyObject *kwargs)
             encoding = NULL;
         }
         else if (PyUnicode_Check(fastargs[1])) {
-            Py_ssize_t encoding_length;
-            encoding = PyUnicode_AsUTF8AndSize(fastargs[1], &encoding_length);
+            encoding = PyUnicode_AsUTF8(fastargs[1]);
             if (encoding == NULL) {
-                goto exit;
-            }
-            if (strlen(encoding) != (size_t)encoding_length) {
-                PyErr_SetString(PyExc_ValueError, "embedded null character");
                 goto exit;
             }
         }
@@ -504,13 +494,8 @@ _io_TextIOWrapper___init__(PyObject *self, PyObject *args, PyObject *kwargs)
             newline = NULL;
         }
         else if (PyUnicode_Check(fastargs[3])) {
-            Py_ssize_t newline_length;
-            newline = PyUnicode_AsUTF8AndSize(fastargs[3], &newline_length);
+            newline = PyUnicode_AsUTF8(fastargs[3]);
             if (newline == NULL) {
-                goto exit;
-            }
-            if (strlen(newline) != (size_t)newline_length) {
-                PyErr_SetString(PyExc_ValueError, "embedded null character");
                 goto exit;
             }
         }
@@ -980,4 +965,4 @@ _io_TextIOWrapper_close(textio *self, PyObject *Py_UNUSED(ignored))
 {
     return _io_TextIOWrapper_close_impl(self);
 }
-/*[clinic end generated code: output=e58ce89b7354e77a input=a9049054013a1b77]*/
+/*[clinic end generated code: output=c9ffb48a5278cbd4 input=a9049054013a1b77]*/

--- a/Modules/_io/clinic/winconsoleio.c.h
+++ b/Modules/_io/clinic/winconsoleio.c.h
@@ -106,13 +106,8 @@ _io__WindowsConsoleIO___init__(PyObject *self, PyObject *args, PyObject *kwargs)
             _PyArg_BadArgument("_WindowsConsoleIO", "argument 'mode'", "str", fastargs[1]);
             goto exit;
         }
-        Py_ssize_t mode_length;
-        mode = PyUnicode_AsUTF8AndSize(fastargs[1], &mode_length);
+        mode = PyUnicode_AsUTF8(fastargs[1]);
         if (mode == NULL) {
-            goto exit;
-        }
-        if (strlen(mode) != (size_t)mode_length) {
-            PyErr_SetString(PyExc_ValueError, "embedded null character");
             goto exit;
         }
         if (!--noptargs) {
@@ -457,4 +452,4 @@ _io__WindowsConsoleIO_isatty(winconsoleio *self, PyObject *Py_UNUSED(ignored))
 #ifndef _IO__WINDOWSCONSOLEIO_ISATTY_METHODDEF
     #define _IO__WINDOWSCONSOLEIO_ISATTY_METHODDEF
 #endif /* !defined(_IO__WINDOWSCONSOLEIO_ISATTY_METHODDEF) */
-/*[clinic end generated code: output=04108fc26b187386 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=76408dd67894bc9c input=a9049054013a1b77]*/

--- a/Modules/_multiprocessing/clinic/multiprocessing.c.h
+++ b/Modules/_multiprocessing/clinic/multiprocessing.c.h
@@ -138,13 +138,8 @@ _multiprocessing_sem_unlink(PyObject *module, PyObject *arg)
         _PyArg_BadArgument("sem_unlink", "argument", "str", arg);
         goto exit;
     }
-    Py_ssize_t name_length;
-    name = PyUnicode_AsUTF8AndSize(arg, &name_length);
+    name = PyUnicode_AsUTF8(arg);
     if (name == NULL) {
-        goto exit;
-    }
-    if (strlen(name) != (size_t)name_length) {
-        PyErr_SetString(PyExc_ValueError, "embedded null character");
         goto exit;
     }
     return_value = _multiprocessing_sem_unlink_impl(module, name);
@@ -164,4 +159,4 @@ exit:
 #ifndef _MULTIPROCESSING_SEND_METHODDEF
     #define _MULTIPROCESSING_SEND_METHODDEF
 #endif /* !defined(_MULTIPROCESSING_SEND_METHODDEF) */
-/*[clinic end generated code: output=73b4cb8428d816da input=a9049054013a1b77]*/
+/*[clinic end generated code: output=c6735cbc59b6f324 input=a9049054013a1b77]*/

--- a/Modules/_multiprocessing/clinic/semaphore.c.h
+++ b/Modules/_multiprocessing/clinic/semaphore.c.h
@@ -266,13 +266,8 @@ _multiprocessing_SemLock(PyTypeObject *type, PyObject *args, PyObject *kwargs)
         _PyArg_BadArgument("SemLock", "argument 'name'", "str", fastargs[3]);
         goto exit;
     }
-    Py_ssize_t name_length;
-    name = PyUnicode_AsUTF8AndSize(fastargs[3], &name_length);
+    name = PyUnicode_AsUTF8(fastargs[3]);
     if (name == NULL) {
-        goto exit;
-    }
-    if (strlen(name) != (size_t)name_length) {
-        PyErr_SetString(PyExc_ValueError, "embedded null character");
         goto exit;
     }
     unlink = PyObject_IsTrue(fastargs[4]);
@@ -542,4 +537,4 @@ exit:
 #ifndef _MULTIPROCESSING_SEMLOCK___EXIT___METHODDEF
     #define _MULTIPROCESSING_SEMLOCK___EXIT___METHODDEF
 #endif /* !defined(_MULTIPROCESSING_SEMLOCK___EXIT___METHODDEF) */
-/*[clinic end generated code: output=d57992037e6770b6 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=fd94dc907e6ab57f input=a9049054013a1b77]*/

--- a/Modules/_sqlite/clinic/connection.c.h
+++ b/Modules/_sqlite/clinic/connection.c.h
@@ -297,26 +297,16 @@ blobopen(pysqlite_Connection *self, PyObject *const *args, Py_ssize_t nargs, PyO
         _PyArg_BadArgument("blobopen", "argument 1", "str", args[0]);
         goto exit;
     }
-    Py_ssize_t table_length;
-    table = PyUnicode_AsUTF8AndSize(args[0], &table_length);
+    table = PyUnicode_AsUTF8(args[0]);
     if (table == NULL) {
-        goto exit;
-    }
-    if (strlen(table) != (size_t)table_length) {
-        PyErr_SetString(PyExc_ValueError, "embedded null character");
         goto exit;
     }
     if (!PyUnicode_Check(args[1])) {
         _PyArg_BadArgument("blobopen", "argument 2", "str", args[1]);
         goto exit;
     }
-    Py_ssize_t col_length;
-    col = PyUnicode_AsUTF8AndSize(args[1], &col_length);
+    col = PyUnicode_AsUTF8(args[1]);
     if (col == NULL) {
-        goto exit;
-    }
-    if (strlen(col) != (size_t)col_length) {
-        PyErr_SetString(PyExc_ValueError, "embedded null character");
         goto exit;
     }
     if (!sqlite3_int64_converter(args[2], &row)) {
@@ -338,13 +328,8 @@ blobopen(pysqlite_Connection *self, PyObject *const *args, Py_ssize_t nargs, PyO
         _PyArg_BadArgument("blobopen", "argument 'name'", "str", args[4]);
         goto exit;
     }
-    Py_ssize_t name_length;
-    name = PyUnicode_AsUTF8AndSize(args[4], &name_length);
+    name = PyUnicode_AsUTF8(args[4]);
     if (name == NULL) {
-        goto exit;
-    }
-    if (strlen(name) != (size_t)name_length) {
-        PyErr_SetString(PyExc_ValueError, "embedded null character");
         goto exit;
     }
 skip_optional_kwonly:
@@ -499,13 +484,8 @@ pysqlite_connection_create_function(pysqlite_Connection *self, PyTypeObject *cls
         _PyArg_BadArgument("create_function", "argument 'name'", "str", args[0]);
         goto exit;
     }
-    Py_ssize_t name_length;
-    name = PyUnicode_AsUTF8AndSize(args[0], &name_length);
+    name = PyUnicode_AsUTF8(args[0]);
     if (name == NULL) {
-        goto exit;
-    }
-    if (strlen(name) != (size_t)name_length) {
-        PyErr_SetString(PyExc_ValueError, "embedded null character");
         goto exit;
     }
     narg = PyLong_AsInt(args[1]);
@@ -582,13 +562,8 @@ create_window_function(pysqlite_Connection *self, PyTypeObject *cls, PyObject *c
         _PyArg_BadArgument("create_window_function", "argument 1", "str", args[0]);
         goto exit;
     }
-    Py_ssize_t name_length;
-    name = PyUnicode_AsUTF8AndSize(args[0], &name_length);
+    name = PyUnicode_AsUTF8(args[0]);
     if (name == NULL) {
-        goto exit;
-    }
-    if (strlen(name) != (size_t)name_length) {
-        PyErr_SetString(PyExc_ValueError, "embedded null character");
         goto exit;
     }
     num_params = PyLong_AsInt(args[1]);
@@ -688,13 +663,8 @@ pysqlite_connection_create_aggregate(pysqlite_Connection *self, PyTypeObject *cl
         _PyArg_BadArgument("create_aggregate", "argument 'name'", "str", args[0]);
         goto exit;
     }
-    Py_ssize_t name_length;
-    name = PyUnicode_AsUTF8AndSize(args[0], &name_length);
+    name = PyUnicode_AsUTF8(args[0]);
     if (name == NULL) {
-        goto exit;
-    }
-    if (strlen(name) != (size_t)name_length) {
-        PyErr_SetString(PyExc_ValueError, "embedded null character");
         goto exit;
     }
     n_arg = PyLong_AsInt(args[1]);
@@ -1063,13 +1033,8 @@ pysqlite_connection_load_extension(pysqlite_Connection *self, PyObject *const *a
         _PyArg_BadArgument("load_extension", "argument 1", "str", args[0]);
         goto exit;
     }
-    Py_ssize_t extension_name_length;
-    extension_name = PyUnicode_AsUTF8AndSize(args[0], &extension_name_length);
+    extension_name = PyUnicode_AsUTF8(args[0]);
     if (extension_name == NULL) {
-        goto exit;
-    }
-    if (strlen(extension_name) != (size_t)extension_name_length) {
-        PyErr_SetString(PyExc_ValueError, "embedded null character");
         goto exit;
     }
     if (!noptargs) {
@@ -1079,13 +1044,8 @@ pysqlite_connection_load_extension(pysqlite_Connection *self, PyObject *const *a
         entrypoint = NULL;
     }
     else if (PyUnicode_Check(args[1])) {
-        Py_ssize_t entrypoint_length;
-        entrypoint = PyUnicode_AsUTF8AndSize(args[1], &entrypoint_length);
+        entrypoint = PyUnicode_AsUTF8(args[1]);
         if (entrypoint == NULL) {
-            goto exit;
-        }
-        if (strlen(entrypoint) != (size_t)entrypoint_length) {
-            PyErr_SetString(PyExc_ValueError, "embedded null character");
             goto exit;
         }
     }
@@ -1306,13 +1266,8 @@ pysqlite_connection_backup(pysqlite_Connection *self, PyObject *const *args, Py_
             _PyArg_BadArgument("backup", "argument 'name'", "str", args[3]);
             goto exit;
         }
-        Py_ssize_t name_length;
-        name = PyUnicode_AsUTF8AndSize(args[3], &name_length);
+        name = PyUnicode_AsUTF8(args[3]);
         if (name == NULL) {
-            goto exit;
-        }
-        if (strlen(name) != (size_t)name_length) {
-            PyErr_SetString(PyExc_ValueError, "embedded null character");
             goto exit;
         }
         if (!--noptargs) {
@@ -1380,13 +1335,8 @@ pysqlite_connection_create_collation(pysqlite_Connection *self, PyTypeObject *cl
         _PyArg_BadArgument("create_collation", "argument 1", "str", args[0]);
         goto exit;
     }
-    Py_ssize_t name_length;
-    name = PyUnicode_AsUTF8AndSize(args[0], &name_length);
+    name = PyUnicode_AsUTF8(args[0]);
     if (name == NULL) {
-        goto exit;
-    }
-    if (strlen(name) != (size_t)name_length) {
-        PyErr_SetString(PyExc_ValueError, "embedded null character");
         goto exit;
     }
     callable = args[1];
@@ -1462,13 +1412,8 @@ serialize(pysqlite_Connection *self, PyObject *const *args, Py_ssize_t nargs, Py
         _PyArg_BadArgument("serialize", "argument 'name'", "str", args[0]);
         goto exit;
     }
-    Py_ssize_t name_length;
-    name = PyUnicode_AsUTF8AndSize(args[0], &name_length);
+    name = PyUnicode_AsUTF8(args[0]);
     if (name == NULL) {
-        goto exit;
-    }
-    if (strlen(name) != (size_t)name_length) {
-        PyErr_SetString(PyExc_ValueError, "embedded null character");
         goto exit;
     }
 skip_optional_kwonly:
@@ -1565,13 +1510,8 @@ deserialize(pysqlite_Connection *self, PyObject *const *args, Py_ssize_t nargs, 
         _PyArg_BadArgument("deserialize", "argument 'name'", "str", args[1]);
         goto exit;
     }
-    Py_ssize_t name_length;
-    name = PyUnicode_AsUTF8AndSize(args[1], &name_length);
+    name = PyUnicode_AsUTF8(args[1]);
     if (name == NULL) {
-        goto exit;
-    }
-    if (strlen(name) != (size_t)name_length) {
-        PyErr_SetString(PyExc_ValueError, "embedded null character");
         goto exit;
     }
 skip_optional_kwonly:
@@ -1818,4 +1758,4 @@ exit:
 #ifndef DESERIALIZE_METHODDEF
     #define DESERIALIZE_METHODDEF
 #endif /* !defined(DESERIALIZE_METHODDEF) */
-/*[clinic end generated code: output=90b5b9c14261b8d7 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=7d2a4d9272f7cb9e input=a9049054013a1b77]*/

--- a/Modules/_sqlite/clinic/cursor.c.h
+++ b/Modules/_sqlite/clinic/cursor.c.h
@@ -135,13 +135,8 @@ pysqlite_cursor_executescript(pysqlite_Cursor *self, PyObject *arg)
         _PyArg_BadArgument("executescript", "argument", "str", arg);
         goto exit;
     }
-    Py_ssize_t sql_script_length;
-    sql_script = PyUnicode_AsUTF8AndSize(arg, &sql_script_length);
+    sql_script = PyUnicode_AsUTF8(arg);
     if (sql_script == NULL) {
-        goto exit;
-    }
-    if (strlen(sql_script) != (size_t)sql_script_length) {
-        PyErr_SetString(PyExc_ValueError, "embedded null character");
         goto exit;
     }
     return_value = pysqlite_cursor_executescript_impl(self, sql_script);
@@ -313,4 +308,4 @@ pysqlite_cursor_close(pysqlite_Cursor *self, PyObject *Py_UNUSED(ignored))
 {
     return pysqlite_cursor_close_impl(self);
 }
-/*[clinic end generated code: output=a8ce095c3c80cf65 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=c772882c7df587ea input=a9049054013a1b77]*/

--- a/Modules/_sqlite/clinic/module.c.h
+++ b/Modules/_sqlite/clinic/module.c.h
@@ -60,13 +60,8 @@ pysqlite_complete_statement(PyObject *module, PyObject *const *args, Py_ssize_t 
         _PyArg_BadArgument("complete_statement", "argument 'statement'", "str", args[0]);
         goto exit;
     }
-    Py_ssize_t statement_length;
-    statement = PyUnicode_AsUTF8AndSize(args[0], &statement_length);
+    statement = PyUnicode_AsUTF8(args[0]);
     if (statement == NULL) {
-        goto exit;
-    }
-    if (strlen(statement) != (size_t)statement_length) {
-        PyErr_SetString(PyExc_ValueError, "embedded null character");
         goto exit;
     }
     return_value = pysqlite_complete_statement_impl(module, statement);
@@ -208,4 +203,4 @@ skip_optional:
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=457ab0fdbb9e1880 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=19016e67830c19eb input=a9049054013a1b77]*/

--- a/Modules/_testcapi/clinic/exceptions.c.h
+++ b/Modules/_testcapi/clinic/exceptions.c.h
@@ -112,13 +112,8 @@ _testcapi_make_exception_with_doc(PyObject *module, PyObject *const *args, Py_ss
         _PyArg_BadArgument("make_exception_with_doc", "argument 'name'", "str", args[0]);
         goto exit;
     }
-    Py_ssize_t name_length;
-    name = PyUnicode_AsUTF8AndSize(args[0], &name_length);
+    name = PyUnicode_AsUTF8(args[0]);
     if (name == NULL) {
-        goto exit;
-    }
-    if (strlen(name) != (size_t)name_length) {
-        PyErr_SetString(PyExc_ValueError, "embedded null character");
         goto exit;
     }
     if (!noptargs) {
@@ -129,13 +124,8 @@ _testcapi_make_exception_with_doc(PyObject *module, PyObject *const *args, Py_ss
             _PyArg_BadArgument("make_exception_with_doc", "argument 'doc'", "str", args[1]);
             goto exit;
         }
-        Py_ssize_t doc_length;
-        doc = PyUnicode_AsUTF8AndSize(args[1], &doc_length);
+        doc = PyUnicode_AsUTF8(args[1]);
         if (doc == NULL) {
-            goto exit;
-        }
-        if (strlen(doc) != (size_t)doc_length) {
-            PyErr_SetString(PyExc_ValueError, "embedded null character");
             goto exit;
         }
         if (!--noptargs) {
@@ -456,4 +446,4 @@ _testcapi_unstable_exc_prep_reraise_star(PyObject *module, PyObject *const *args
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=0b11ef105030a48e input=a9049054013a1b77]*/
+/*[clinic end generated code: output=6f2b4f773e0ae755 input=a9049054013a1b77]*/

--- a/Modules/cjkcodecs/clinic/multibytecodec.c.h
+++ b/Modules/cjkcodecs/clinic/multibytecodec.c.h
@@ -73,13 +73,8 @@ _multibytecodec_MultibyteCodec_encode(MultibyteCodecObject *self, PyObject *cons
         errors = NULL;
     }
     else if (PyUnicode_Check(args[1])) {
-        Py_ssize_t errors_length;
-        errors = PyUnicode_AsUTF8AndSize(args[1], &errors_length);
+        errors = PyUnicode_AsUTF8(args[1]);
         if (errors == NULL) {
-            goto exit;
-        }
-        if (strlen(errors) != (size_t)errors_length) {
-            PyErr_SetString(PyExc_ValueError, "embedded null character");
             goto exit;
         }
     }
@@ -161,13 +156,8 @@ _multibytecodec_MultibyteCodec_decode(MultibyteCodecObject *self, PyObject *cons
         errors = NULL;
     }
     else if (PyUnicode_Check(args[1])) {
-        Py_ssize_t errors_length;
-        errors = PyUnicode_AsUTF8AndSize(args[1], &errors_length);
+        errors = PyUnicode_AsUTF8(args[1]);
         if (errors == NULL) {
-            goto exit;
-        }
-        if (strlen(errors) != (size_t)errors_length) {
-            PyErr_SetString(PyExc_ValueError, "embedded null character");
             goto exit;
         }
     }
@@ -682,4 +672,4 @@ PyDoc_STRVAR(_multibytecodec___create_codec__doc__,
 
 #define _MULTIBYTECODEC___CREATE_CODEC_METHODDEF    \
     {"__create_codec", (PyCFunction)_multibytecodec___create_codec, METH_O, _multibytecodec___create_codec__doc__},
-/*[clinic end generated code: output=219a363662d2fbff input=a9049054013a1b77]*/
+/*[clinic end generated code: output=b35a5c3797e0e54a input=a9049054013a1b77]*/

--- a/Modules/clinic/_codecsmodule.c.h
+++ b/Modules/clinic/_codecsmodule.c.h
@@ -54,13 +54,8 @@ _codecs_lookup(PyObject *module, PyObject *arg)
         _PyArg_BadArgument("lookup", "argument", "str", arg);
         goto exit;
     }
-    Py_ssize_t encoding_length;
-    encoding = PyUnicode_AsUTF8AndSize(arg, &encoding_length);
+    encoding = PyUnicode_AsUTF8(arg);
     if (encoding == NULL) {
-        goto exit;
-    }
-    if (strlen(encoding) != (size_t)encoding_length) {
-        PyErr_SetString(PyExc_ValueError, "embedded null character");
         goto exit;
     }
     return_value = _codecs_lookup_impl(module, encoding);
@@ -136,13 +131,8 @@ _codecs_encode(PyObject *module, PyObject *const *args, Py_ssize_t nargs, PyObje
             _PyArg_BadArgument("encode", "argument 'encoding'", "str", args[1]);
             goto exit;
         }
-        Py_ssize_t encoding_length;
-        encoding = PyUnicode_AsUTF8AndSize(args[1], &encoding_length);
+        encoding = PyUnicode_AsUTF8(args[1]);
         if (encoding == NULL) {
-            goto exit;
-        }
-        if (strlen(encoding) != (size_t)encoding_length) {
-            PyErr_SetString(PyExc_ValueError, "embedded null character");
             goto exit;
         }
         if (!--noptargs) {
@@ -153,13 +143,8 @@ _codecs_encode(PyObject *module, PyObject *const *args, Py_ssize_t nargs, PyObje
         _PyArg_BadArgument("encode", "argument 'errors'", "str", args[2]);
         goto exit;
     }
-    Py_ssize_t errors_length;
-    errors = PyUnicode_AsUTF8AndSize(args[2], &errors_length);
+    errors = PyUnicode_AsUTF8(args[2]);
     if (errors == NULL) {
-        goto exit;
-    }
-    if (strlen(errors) != (size_t)errors_length) {
-        PyErr_SetString(PyExc_ValueError, "embedded null character");
         goto exit;
     }
 skip_optional_pos:
@@ -236,13 +221,8 @@ _codecs_decode(PyObject *module, PyObject *const *args, Py_ssize_t nargs, PyObje
             _PyArg_BadArgument("decode", "argument 'encoding'", "str", args[1]);
             goto exit;
         }
-        Py_ssize_t encoding_length;
-        encoding = PyUnicode_AsUTF8AndSize(args[1], &encoding_length);
+        encoding = PyUnicode_AsUTF8(args[1]);
         if (encoding == NULL) {
-            goto exit;
-        }
-        if (strlen(encoding) != (size_t)encoding_length) {
-            PyErr_SetString(PyExc_ValueError, "embedded null character");
             goto exit;
         }
         if (!--noptargs) {
@@ -253,13 +233,8 @@ _codecs_decode(PyObject *module, PyObject *const *args, Py_ssize_t nargs, PyObje
         _PyArg_BadArgument("decode", "argument 'errors'", "str", args[2]);
         goto exit;
     }
-    Py_ssize_t errors_length;
-    errors = PyUnicode_AsUTF8AndSize(args[2], &errors_length);
+    errors = PyUnicode_AsUTF8(args[2]);
     if (errors == NULL) {
-        goto exit;
-    }
-    if (strlen(errors) != (size_t)errors_length) {
-        PyErr_SetString(PyExc_ValueError, "embedded null character");
         goto exit;
     }
 skip_optional_pos:
@@ -311,13 +286,8 @@ _codecs_escape_decode(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
         errors = NULL;
     }
     else if (PyUnicode_Check(args[1])) {
-        Py_ssize_t errors_length;
-        errors = PyUnicode_AsUTF8AndSize(args[1], &errors_length);
+        errors = PyUnicode_AsUTF8(args[1]);
         if (errors == NULL) {
-            goto exit;
-        }
-        if (strlen(errors) != (size_t)errors_length) {
-            PyErr_SetString(PyExc_ValueError, "embedded null character");
             goto exit;
         }
     }
@@ -371,13 +341,8 @@ _codecs_escape_encode(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
         errors = NULL;
     }
     else if (PyUnicode_Check(args[1])) {
-        Py_ssize_t errors_length;
-        errors = PyUnicode_AsUTF8AndSize(args[1], &errors_length);
+        errors = PyUnicode_AsUTF8(args[1]);
         if (errors == NULL) {
-            goto exit;
-        }
-        if (strlen(errors) != (size_t)errors_length) {
-            PyErr_SetString(PyExc_ValueError, "embedded null character");
             goto exit;
         }
     }
@@ -425,13 +390,8 @@ _codecs_utf_7_decode(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
         errors = NULL;
     }
     else if (PyUnicode_Check(args[1])) {
-        Py_ssize_t errors_length;
-        errors = PyUnicode_AsUTF8AndSize(args[1], &errors_length);
+        errors = PyUnicode_AsUTF8(args[1]);
         if (errors == NULL) {
-            goto exit;
-        }
-        if (strlen(errors) != (size_t)errors_length) {
-            PyErr_SetString(PyExc_ValueError, "embedded null character");
             goto exit;
         }
     }
@@ -491,13 +451,8 @@ _codecs_utf_8_decode(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
         errors = NULL;
     }
     else if (PyUnicode_Check(args[1])) {
-        Py_ssize_t errors_length;
-        errors = PyUnicode_AsUTF8AndSize(args[1], &errors_length);
+        errors = PyUnicode_AsUTF8(args[1]);
         if (errors == NULL) {
-            goto exit;
-        }
-        if (strlen(errors) != (size_t)errors_length) {
-            PyErr_SetString(PyExc_ValueError, "embedded null character");
             goto exit;
         }
     }
@@ -557,13 +512,8 @@ _codecs_utf_16_decode(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
         errors = NULL;
     }
     else if (PyUnicode_Check(args[1])) {
-        Py_ssize_t errors_length;
-        errors = PyUnicode_AsUTF8AndSize(args[1], &errors_length);
+        errors = PyUnicode_AsUTF8(args[1]);
         if (errors == NULL) {
-            goto exit;
-        }
-        if (strlen(errors) != (size_t)errors_length) {
-            PyErr_SetString(PyExc_ValueError, "embedded null character");
             goto exit;
         }
     }
@@ -623,13 +573,8 @@ _codecs_utf_16_le_decode(PyObject *module, PyObject *const *args, Py_ssize_t nar
         errors = NULL;
     }
     else if (PyUnicode_Check(args[1])) {
-        Py_ssize_t errors_length;
-        errors = PyUnicode_AsUTF8AndSize(args[1], &errors_length);
+        errors = PyUnicode_AsUTF8(args[1]);
         if (errors == NULL) {
-            goto exit;
-        }
-        if (strlen(errors) != (size_t)errors_length) {
-            PyErr_SetString(PyExc_ValueError, "embedded null character");
             goto exit;
         }
     }
@@ -689,13 +634,8 @@ _codecs_utf_16_be_decode(PyObject *module, PyObject *const *args, Py_ssize_t nar
         errors = NULL;
     }
     else if (PyUnicode_Check(args[1])) {
-        Py_ssize_t errors_length;
-        errors = PyUnicode_AsUTF8AndSize(args[1], &errors_length);
+        errors = PyUnicode_AsUTF8(args[1]);
         if (errors == NULL) {
-            goto exit;
-        }
-        if (strlen(errors) != (size_t)errors_length) {
-            PyErr_SetString(PyExc_ValueError, "embedded null character");
             goto exit;
         }
     }
@@ -757,13 +697,8 @@ _codecs_utf_16_ex_decode(PyObject *module, PyObject *const *args, Py_ssize_t nar
         errors = NULL;
     }
     else if (PyUnicode_Check(args[1])) {
-        Py_ssize_t errors_length;
-        errors = PyUnicode_AsUTF8AndSize(args[1], &errors_length);
+        errors = PyUnicode_AsUTF8(args[1]);
         if (errors == NULL) {
-            goto exit;
-        }
-        if (strlen(errors) != (size_t)errors_length) {
-            PyErr_SetString(PyExc_ValueError, "embedded null character");
             goto exit;
         }
     }
@@ -830,13 +765,8 @@ _codecs_utf_32_decode(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
         errors = NULL;
     }
     else if (PyUnicode_Check(args[1])) {
-        Py_ssize_t errors_length;
-        errors = PyUnicode_AsUTF8AndSize(args[1], &errors_length);
+        errors = PyUnicode_AsUTF8(args[1]);
         if (errors == NULL) {
-            goto exit;
-        }
-        if (strlen(errors) != (size_t)errors_length) {
-            PyErr_SetString(PyExc_ValueError, "embedded null character");
             goto exit;
         }
     }
@@ -896,13 +826,8 @@ _codecs_utf_32_le_decode(PyObject *module, PyObject *const *args, Py_ssize_t nar
         errors = NULL;
     }
     else if (PyUnicode_Check(args[1])) {
-        Py_ssize_t errors_length;
-        errors = PyUnicode_AsUTF8AndSize(args[1], &errors_length);
+        errors = PyUnicode_AsUTF8(args[1]);
         if (errors == NULL) {
-            goto exit;
-        }
-        if (strlen(errors) != (size_t)errors_length) {
-            PyErr_SetString(PyExc_ValueError, "embedded null character");
             goto exit;
         }
     }
@@ -962,13 +887,8 @@ _codecs_utf_32_be_decode(PyObject *module, PyObject *const *args, Py_ssize_t nar
         errors = NULL;
     }
     else if (PyUnicode_Check(args[1])) {
-        Py_ssize_t errors_length;
-        errors = PyUnicode_AsUTF8AndSize(args[1], &errors_length);
+        errors = PyUnicode_AsUTF8(args[1]);
         if (errors == NULL) {
-            goto exit;
-        }
-        if (strlen(errors) != (size_t)errors_length) {
-            PyErr_SetString(PyExc_ValueError, "embedded null character");
             goto exit;
         }
     }
@@ -1030,13 +950,8 @@ _codecs_utf_32_ex_decode(PyObject *module, PyObject *const *args, Py_ssize_t nar
         errors = NULL;
     }
     else if (PyUnicode_Check(args[1])) {
-        Py_ssize_t errors_length;
-        errors = PyUnicode_AsUTF8AndSize(args[1], &errors_length);
+        errors = PyUnicode_AsUTF8(args[1]);
         if (errors == NULL) {
-            goto exit;
-        }
-        if (strlen(errors) != (size_t)errors_length) {
-            PyErr_SetString(PyExc_ValueError, "embedded null character");
             goto exit;
         }
     }
@@ -1113,13 +1028,8 @@ _codecs_unicode_escape_decode(PyObject *module, PyObject *const *args, Py_ssize_
         errors = NULL;
     }
     else if (PyUnicode_Check(args[1])) {
-        Py_ssize_t errors_length;
-        errors = PyUnicode_AsUTF8AndSize(args[1], &errors_length);
+        errors = PyUnicode_AsUTF8(args[1]);
         if (errors == NULL) {
-            goto exit;
-        }
-        if (strlen(errors) != (size_t)errors_length) {
-            PyErr_SetString(PyExc_ValueError, "embedded null character");
             goto exit;
         }
     }
@@ -1189,13 +1099,8 @@ _codecs_raw_unicode_escape_decode(PyObject *module, PyObject *const *args, Py_ss
         errors = NULL;
     }
     else if (PyUnicode_Check(args[1])) {
-        Py_ssize_t errors_length;
-        errors = PyUnicode_AsUTF8AndSize(args[1], &errors_length);
+        errors = PyUnicode_AsUTF8(args[1]);
         if (errors == NULL) {
-            goto exit;
-        }
-        if (strlen(errors) != (size_t)errors_length) {
-            PyErr_SetString(PyExc_ValueError, "embedded null character");
             goto exit;
         }
     }
@@ -1254,13 +1159,8 @@ _codecs_latin_1_decode(PyObject *module, PyObject *const *args, Py_ssize_t nargs
         errors = NULL;
     }
     else if (PyUnicode_Check(args[1])) {
-        Py_ssize_t errors_length;
-        errors = PyUnicode_AsUTF8AndSize(args[1], &errors_length);
+        errors = PyUnicode_AsUTF8(args[1]);
         if (errors == NULL) {
-            goto exit;
-        }
-        if (strlen(errors) != (size_t)errors_length) {
-            PyErr_SetString(PyExc_ValueError, "embedded null character");
             goto exit;
         }
     }
@@ -1312,13 +1212,8 @@ _codecs_ascii_decode(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
         errors = NULL;
     }
     else if (PyUnicode_Check(args[1])) {
-        Py_ssize_t errors_length;
-        errors = PyUnicode_AsUTF8AndSize(args[1], &errors_length);
+        errors = PyUnicode_AsUTF8(args[1]);
         if (errors == NULL) {
-            goto exit;
-        }
-        if (strlen(errors) != (size_t)errors_length) {
-            PyErr_SetString(PyExc_ValueError, "embedded null character");
             goto exit;
         }
     }
@@ -1371,13 +1266,8 @@ _codecs_charmap_decode(PyObject *module, PyObject *const *args, Py_ssize_t nargs
         errors = NULL;
     }
     else if (PyUnicode_Check(args[1])) {
-        Py_ssize_t errors_length;
-        errors = PyUnicode_AsUTF8AndSize(args[1], &errors_length);
+        errors = PyUnicode_AsUTF8(args[1]);
         if (errors == NULL) {
-            goto exit;
-        }
-        if (strlen(errors) != (size_t)errors_length) {
-            PyErr_SetString(PyExc_ValueError, "embedded null character");
             goto exit;
         }
     }
@@ -1436,13 +1326,8 @@ _codecs_mbcs_decode(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
         errors = NULL;
     }
     else if (PyUnicode_Check(args[1])) {
-        Py_ssize_t errors_length;
-        errors = PyUnicode_AsUTF8AndSize(args[1], &errors_length);
+        errors = PyUnicode_AsUTF8(args[1]);
         if (errors == NULL) {
-            goto exit;
-        }
-        if (strlen(errors) != (size_t)errors_length) {
-            PyErr_SetString(PyExc_ValueError, "embedded null character");
             goto exit;
         }
     }
@@ -1506,13 +1391,8 @@ _codecs_oem_decode(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
         errors = NULL;
     }
     else if (PyUnicode_Check(args[1])) {
-        Py_ssize_t errors_length;
-        errors = PyUnicode_AsUTF8AndSize(args[1], &errors_length);
+        errors = PyUnicode_AsUTF8(args[1]);
         if (errors == NULL) {
-            goto exit;
-        }
-        if (strlen(errors) != (size_t)errors_length) {
-            PyErr_SetString(PyExc_ValueError, "embedded null character");
             goto exit;
         }
     }
@@ -1581,13 +1461,8 @@ _codecs_code_page_decode(PyObject *module, PyObject *const *args, Py_ssize_t nar
         errors = NULL;
     }
     else if (PyUnicode_Check(args[2])) {
-        Py_ssize_t errors_length;
-        errors = PyUnicode_AsUTF8AndSize(args[2], &errors_length);
+        errors = PyUnicode_AsUTF8(args[2]);
         if (errors == NULL) {
-            goto exit;
-        }
-        if (strlen(errors) != (size_t)errors_length) {
-            PyErr_SetString(PyExc_ValueError, "embedded null character");
             goto exit;
         }
     }
@@ -1658,13 +1533,8 @@ _codecs_readbuffer_encode(PyObject *module, PyObject *const *args, Py_ssize_t na
         errors = NULL;
     }
     else if (PyUnicode_Check(args[1])) {
-        Py_ssize_t errors_length;
-        errors = PyUnicode_AsUTF8AndSize(args[1], &errors_length);
+        errors = PyUnicode_AsUTF8(args[1]);
         if (errors == NULL) {
-            goto exit;
-        }
-        if (strlen(errors) != (size_t)errors_length) {
-            PyErr_SetString(PyExc_ValueError, "embedded null character");
             goto exit;
         }
     }
@@ -1718,13 +1588,8 @@ _codecs_utf_7_encode(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
         errors = NULL;
     }
     else if (PyUnicode_Check(args[1])) {
-        Py_ssize_t errors_length;
-        errors = PyUnicode_AsUTF8AndSize(args[1], &errors_length);
+        errors = PyUnicode_AsUTF8(args[1]);
         if (errors == NULL) {
-            goto exit;
-        }
-        if (strlen(errors) != (size_t)errors_length) {
-            PyErr_SetString(PyExc_ValueError, "embedded null character");
             goto exit;
         }
     }
@@ -1773,13 +1638,8 @@ _codecs_utf_8_encode(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
         errors = NULL;
     }
     else if (PyUnicode_Check(args[1])) {
-        Py_ssize_t errors_length;
-        errors = PyUnicode_AsUTF8AndSize(args[1], &errors_length);
+        errors = PyUnicode_AsUTF8(args[1]);
         if (errors == NULL) {
-            goto exit;
-        }
-        if (strlen(errors) != (size_t)errors_length) {
-            PyErr_SetString(PyExc_ValueError, "embedded null character");
             goto exit;
         }
     }
@@ -1829,13 +1689,8 @@ _codecs_utf_16_encode(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
         errors = NULL;
     }
     else if (PyUnicode_Check(args[1])) {
-        Py_ssize_t errors_length;
-        errors = PyUnicode_AsUTF8AndSize(args[1], &errors_length);
+        errors = PyUnicode_AsUTF8(args[1]);
         if (errors == NULL) {
-            goto exit;
-        }
-        if (strlen(errors) != (size_t)errors_length) {
-            PyErr_SetString(PyExc_ValueError, "embedded null character");
             goto exit;
         }
     }
@@ -1891,13 +1746,8 @@ _codecs_utf_16_le_encode(PyObject *module, PyObject *const *args, Py_ssize_t nar
         errors = NULL;
     }
     else if (PyUnicode_Check(args[1])) {
-        Py_ssize_t errors_length;
-        errors = PyUnicode_AsUTF8AndSize(args[1], &errors_length);
+        errors = PyUnicode_AsUTF8(args[1]);
         if (errors == NULL) {
-            goto exit;
-        }
-        if (strlen(errors) != (size_t)errors_length) {
-            PyErr_SetString(PyExc_ValueError, "embedded null character");
             goto exit;
         }
     }
@@ -1946,13 +1796,8 @@ _codecs_utf_16_be_encode(PyObject *module, PyObject *const *args, Py_ssize_t nar
         errors = NULL;
     }
     else if (PyUnicode_Check(args[1])) {
-        Py_ssize_t errors_length;
-        errors = PyUnicode_AsUTF8AndSize(args[1], &errors_length);
+        errors = PyUnicode_AsUTF8(args[1]);
         if (errors == NULL) {
-            goto exit;
-        }
-        if (strlen(errors) != (size_t)errors_length) {
-            PyErr_SetString(PyExc_ValueError, "embedded null character");
             goto exit;
         }
     }
@@ -2002,13 +1847,8 @@ _codecs_utf_32_encode(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
         errors = NULL;
     }
     else if (PyUnicode_Check(args[1])) {
-        Py_ssize_t errors_length;
-        errors = PyUnicode_AsUTF8AndSize(args[1], &errors_length);
+        errors = PyUnicode_AsUTF8(args[1]);
         if (errors == NULL) {
-            goto exit;
-        }
-        if (strlen(errors) != (size_t)errors_length) {
-            PyErr_SetString(PyExc_ValueError, "embedded null character");
             goto exit;
         }
     }
@@ -2064,13 +1904,8 @@ _codecs_utf_32_le_encode(PyObject *module, PyObject *const *args, Py_ssize_t nar
         errors = NULL;
     }
     else if (PyUnicode_Check(args[1])) {
-        Py_ssize_t errors_length;
-        errors = PyUnicode_AsUTF8AndSize(args[1], &errors_length);
+        errors = PyUnicode_AsUTF8(args[1]);
         if (errors == NULL) {
-            goto exit;
-        }
-        if (strlen(errors) != (size_t)errors_length) {
-            PyErr_SetString(PyExc_ValueError, "embedded null character");
             goto exit;
         }
     }
@@ -2119,13 +1954,8 @@ _codecs_utf_32_be_encode(PyObject *module, PyObject *const *args, Py_ssize_t nar
         errors = NULL;
     }
     else if (PyUnicode_Check(args[1])) {
-        Py_ssize_t errors_length;
-        errors = PyUnicode_AsUTF8AndSize(args[1], &errors_length);
+        errors = PyUnicode_AsUTF8(args[1]);
         if (errors == NULL) {
-            goto exit;
-        }
-        if (strlen(errors) != (size_t)errors_length) {
-            PyErr_SetString(PyExc_ValueError, "embedded null character");
             goto exit;
         }
     }
@@ -2174,13 +2004,8 @@ _codecs_unicode_escape_encode(PyObject *module, PyObject *const *args, Py_ssize_
         errors = NULL;
     }
     else if (PyUnicode_Check(args[1])) {
-        Py_ssize_t errors_length;
-        errors = PyUnicode_AsUTF8AndSize(args[1], &errors_length);
+        errors = PyUnicode_AsUTF8(args[1]);
         if (errors == NULL) {
-            goto exit;
-        }
-        if (strlen(errors) != (size_t)errors_length) {
-            PyErr_SetString(PyExc_ValueError, "embedded null character");
             goto exit;
         }
     }
@@ -2229,13 +2054,8 @@ _codecs_raw_unicode_escape_encode(PyObject *module, PyObject *const *args, Py_ss
         errors = NULL;
     }
     else if (PyUnicode_Check(args[1])) {
-        Py_ssize_t errors_length;
-        errors = PyUnicode_AsUTF8AndSize(args[1], &errors_length);
+        errors = PyUnicode_AsUTF8(args[1]);
         if (errors == NULL) {
-            goto exit;
-        }
-        if (strlen(errors) != (size_t)errors_length) {
-            PyErr_SetString(PyExc_ValueError, "embedded null character");
             goto exit;
         }
     }
@@ -2284,13 +2104,8 @@ _codecs_latin_1_encode(PyObject *module, PyObject *const *args, Py_ssize_t nargs
         errors = NULL;
     }
     else if (PyUnicode_Check(args[1])) {
-        Py_ssize_t errors_length;
-        errors = PyUnicode_AsUTF8AndSize(args[1], &errors_length);
+        errors = PyUnicode_AsUTF8(args[1]);
         if (errors == NULL) {
-            goto exit;
-        }
-        if (strlen(errors) != (size_t)errors_length) {
-            PyErr_SetString(PyExc_ValueError, "embedded null character");
             goto exit;
         }
     }
@@ -2339,13 +2154,8 @@ _codecs_ascii_encode(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
         errors = NULL;
     }
     else if (PyUnicode_Check(args[1])) {
-        Py_ssize_t errors_length;
-        errors = PyUnicode_AsUTF8AndSize(args[1], &errors_length);
+        errors = PyUnicode_AsUTF8(args[1]);
         if (errors == NULL) {
-            goto exit;
-        }
-        if (strlen(errors) != (size_t)errors_length) {
-            PyErr_SetString(PyExc_ValueError, "embedded null character");
             goto exit;
         }
     }
@@ -2395,13 +2205,8 @@ _codecs_charmap_encode(PyObject *module, PyObject *const *args, Py_ssize_t nargs
         errors = NULL;
     }
     else if (PyUnicode_Check(args[1])) {
-        Py_ssize_t errors_length;
-        errors = PyUnicode_AsUTF8AndSize(args[1], &errors_length);
+        errors = PyUnicode_AsUTF8(args[1]);
         if (errors == NULL) {
-            goto exit;
-        }
-        if (strlen(errors) != (size_t)errors_length) {
-            PyErr_SetString(PyExc_ValueError, "embedded null character");
             goto exit;
         }
     }
@@ -2483,13 +2288,8 @@ _codecs_mbcs_encode(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
         errors = NULL;
     }
     else if (PyUnicode_Check(args[1])) {
-        Py_ssize_t errors_length;
-        errors = PyUnicode_AsUTF8AndSize(args[1], &errors_length);
+        errors = PyUnicode_AsUTF8(args[1]);
         if (errors == NULL) {
-            goto exit;
-        }
-        if (strlen(errors) != (size_t)errors_length) {
-            PyErr_SetString(PyExc_ValueError, "embedded null character");
             goto exit;
         }
     }
@@ -2541,13 +2341,8 @@ _codecs_oem_encode(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
         errors = NULL;
     }
     else if (PyUnicode_Check(args[1])) {
-        Py_ssize_t errors_length;
-        errors = PyUnicode_AsUTF8AndSize(args[1], &errors_length);
+        errors = PyUnicode_AsUTF8(args[1]);
         if (errors == NULL) {
-            goto exit;
-        }
-        if (strlen(errors) != (size_t)errors_length) {
-            PyErr_SetString(PyExc_ValueError, "embedded null character");
             goto exit;
         }
     }
@@ -2605,13 +2400,8 @@ _codecs_code_page_encode(PyObject *module, PyObject *const *args, Py_ssize_t nar
         errors = NULL;
     }
     else if (PyUnicode_Check(args[2])) {
-        Py_ssize_t errors_length;
-        errors = PyUnicode_AsUTF8AndSize(args[2], &errors_length);
+        errors = PyUnicode_AsUTF8(args[2]);
         if (errors == NULL) {
-            goto exit;
-        }
-        if (strlen(errors) != (size_t)errors_length) {
-            PyErr_SetString(PyExc_ValueError, "embedded null character");
             goto exit;
         }
     }
@@ -2659,13 +2449,8 @@ _codecs_register_error(PyObject *module, PyObject *const *args, Py_ssize_t nargs
         _PyArg_BadArgument("register_error", "argument 1", "str", args[0]);
         goto exit;
     }
-    Py_ssize_t errors_length;
-    errors = PyUnicode_AsUTF8AndSize(args[0], &errors_length);
+    errors = PyUnicode_AsUTF8(args[0]);
     if (errors == NULL) {
-        goto exit;
-    }
-    if (strlen(errors) != (size_t)errors_length) {
-        PyErr_SetString(PyExc_ValueError, "embedded null character");
         goto exit;
     }
     handler = args[1];
@@ -2700,13 +2485,8 @@ _codecs_lookup_error(PyObject *module, PyObject *arg)
         _PyArg_BadArgument("lookup_error", "argument", "str", arg);
         goto exit;
     }
-    Py_ssize_t name_length;
-    name = PyUnicode_AsUTF8AndSize(arg, &name_length);
+    name = PyUnicode_AsUTF8(arg);
     if (name == NULL) {
-        goto exit;
-    }
-    if (strlen(name) != (size_t)name_length) {
-        PyErr_SetString(PyExc_ValueError, "embedded null character");
         goto exit;
     }
     return_value = _codecs_lookup_error_impl(module, name);
@@ -2738,4 +2518,4 @@ exit:
 #ifndef _CODECS_CODE_PAGE_ENCODE_METHODDEF
     #define _CODECS_CODE_PAGE_ENCODE_METHODDEF
 #endif /* !defined(_CODECS_CODE_PAGE_ENCODE_METHODDEF) */
-/*[clinic end generated code: output=d8d9e372f7ccba35 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=5c95a170d813a46f input=a9049054013a1b77]*/

--- a/Modules/clinic/_cursesmodule.c.h
+++ b/Modules/clinic/_cursesmodule.c.h
@@ -2726,13 +2726,8 @@ _curses_setupterm(PyObject *module, PyObject *const *args, Py_ssize_t nargs, PyO
             term = NULL;
         }
         else if (PyUnicode_Check(args[0])) {
-            Py_ssize_t term_length;
-            term = PyUnicode_AsUTF8AndSize(args[0], &term_length);
+            term = PyUnicode_AsUTF8(args[0]);
             if (term == NULL) {
-                goto exit;
-            }
-            if (strlen(term) != (size_t)term_length) {
-                PyErr_SetString(PyExc_ValueError, "embedded null character");
                 goto exit;
             }
         }
@@ -3926,13 +3921,8 @@ _curses_tigetflag(PyObject *module, PyObject *arg)
         _PyArg_BadArgument("tigetflag", "argument", "str", arg);
         goto exit;
     }
-    Py_ssize_t capname_length;
-    capname = PyUnicode_AsUTF8AndSize(arg, &capname_length);
+    capname = PyUnicode_AsUTF8(arg);
     if (capname == NULL) {
-        goto exit;
-    }
-    if (strlen(capname) != (size_t)capname_length) {
-        PyErr_SetString(PyExc_ValueError, "embedded null character");
         goto exit;
     }
     return_value = _curses_tigetflag_impl(module, capname);
@@ -3969,13 +3959,8 @@ _curses_tigetnum(PyObject *module, PyObject *arg)
         _PyArg_BadArgument("tigetnum", "argument", "str", arg);
         goto exit;
     }
-    Py_ssize_t capname_length;
-    capname = PyUnicode_AsUTF8AndSize(arg, &capname_length);
+    capname = PyUnicode_AsUTF8(arg);
     if (capname == NULL) {
-        goto exit;
-    }
-    if (strlen(capname) != (size_t)capname_length) {
-        PyErr_SetString(PyExc_ValueError, "embedded null character");
         goto exit;
     }
     return_value = _curses_tigetnum_impl(module, capname);
@@ -4012,13 +3997,8 @@ _curses_tigetstr(PyObject *module, PyObject *arg)
         _PyArg_BadArgument("tigetstr", "argument", "str", arg);
         goto exit;
     }
-    Py_ssize_t capname_length;
-    capname = PyUnicode_AsUTF8AndSize(arg, &capname_length);
+    capname = PyUnicode_AsUTF8(arg);
     if (capname == NULL) {
-        goto exit;
-    }
-    if (strlen(capname) != (size_t)capname_length) {
-        PyErr_SetString(PyExc_ValueError, "embedded null character");
         goto exit;
     }
     return_value = _curses_tigetstr_impl(module, capname);
@@ -4318,4 +4298,4 @@ _curses_has_extended_color_support(PyObject *module, PyObject *Py_UNUSED(ignored
 #ifndef _CURSES_USE_DEFAULT_COLORS_METHODDEF
     #define _CURSES_USE_DEFAULT_COLORS_METHODDEF
 #endif /* !defined(_CURSES_USE_DEFAULT_COLORS_METHODDEF) */
-/*[clinic end generated code: output=96887782374f070a input=a9049054013a1b77]*/
+/*[clinic end generated code: output=555e266fc4838612 input=a9049054013a1b77]*/

--- a/Modules/clinic/_dbmmodule.c.h
+++ b/Modules/clinic/_dbmmodule.c.h
@@ -196,13 +196,8 @@ dbmopen(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
         _PyArg_BadArgument("open", "argument 2", "str", args[1]);
         goto exit;
     }
-    Py_ssize_t flags_length;
-    flags = PyUnicode_AsUTF8AndSize(args[1], &flags_length);
+    flags = PyUnicode_AsUTF8(args[1]);
     if (flags == NULL) {
-        goto exit;
-    }
-    if (strlen(flags) != (size_t)flags_length) {
-        PyErr_SetString(PyExc_ValueError, "embedded null character");
         goto exit;
     }
     if (nargs < 3) {
@@ -218,4 +213,4 @@ skip_optional:
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=96fdd4bd7bd256c5 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=48183905532205c2 input=a9049054013a1b77]*/

--- a/Modules/clinic/_elementtree.c.h
+++ b/Modules/clinic/_elementtree.c.h
@@ -1131,13 +1131,8 @@ _elementtree_XMLParser___init__(PyObject *self, PyObject *args, PyObject *kwargs
         encoding = NULL;
     }
     else if (PyUnicode_Check(fastargs[1])) {
-        Py_ssize_t encoding_length;
-        encoding = PyUnicode_AsUTF8AndSize(fastargs[1], &encoding_length);
+        encoding = PyUnicode_AsUTF8(fastargs[1]);
         if (encoding == NULL) {
-            goto exit;
-        }
-        if (strlen(encoding) != (size_t)encoding_length) {
-            PyErr_SetString(PyExc_ValueError, "embedded null character");
             goto exit;
         }
     }
@@ -1219,4 +1214,4 @@ skip_optional:
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=8fdaa17d3262800a input=a9049054013a1b77]*/
+/*[clinic end generated code: output=399d9d5c9435070b input=a9049054013a1b77]*/

--- a/Modules/clinic/_gdbmmodule.c.h
+++ b/Modules/clinic/_gdbmmodule.c.h
@@ -318,13 +318,8 @@ dbmopen(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
         _PyArg_BadArgument("open", "argument 2", "str", args[1]);
         goto exit;
     }
-    Py_ssize_t flags_length;
-    flags = PyUnicode_AsUTF8AndSize(args[1], &flags_length);
+    flags = PyUnicode_AsUTF8(args[1]);
     if (flags == NULL) {
-        goto exit;
-    }
-    if (strlen(flags) != (size_t)flags_length) {
-        PyErr_SetString(PyExc_ValueError, "embedded null character");
         goto exit;
     }
     if (nargs < 3) {
@@ -340,4 +335,4 @@ skip_optional:
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=c5ee922363d5a81f input=a9049054013a1b77]*/
+/*[clinic end generated code: output=725cafd8b2d8cfdb input=a9049054013a1b77]*/

--- a/Modules/clinic/_hashopenssl.c.h
+++ b/Modules/clinic/_hashopenssl.c.h
@@ -1278,13 +1278,8 @@ pbkdf2_hmac(PyObject *module, PyObject *const *args, Py_ssize_t nargs, PyObject 
         _PyArg_BadArgument("pbkdf2_hmac", "argument 'hash_name'", "str", args[0]);
         goto exit;
     }
-    Py_ssize_t hash_name_length;
-    hash_name = PyUnicode_AsUTF8AndSize(args[0], &hash_name_length);
+    hash_name = PyUnicode_AsUTF8(args[0]);
     if (hash_name == NULL) {
-        goto exit;
-    }
-    if (strlen(hash_name) != (size_t)hash_name_length) {
-        PyErr_SetString(PyExc_ValueError, "embedded null character");
         goto exit;
     }
     if (PyObject_GetBuffer(args[1], &password, PyBUF_SIMPLE) != 0) {
@@ -1824,4 +1819,4 @@ exit:
 #ifndef _HASHLIB_SCRYPT_METHODDEF
     #define _HASHLIB_SCRYPT_METHODDEF
 #endif /* !defined(_HASHLIB_SCRYPT_METHODDEF) */
-/*[clinic end generated code: output=b7eddeb3d6ccdeec input=a9049054013a1b77]*/
+/*[clinic end generated code: output=bc372898eaa3e000 input=a9049054013a1b77]*/

--- a/Modules/clinic/_localemodule.c.h
+++ b/Modules/clinic/_localemodule.c.h
@@ -37,13 +37,8 @@ _locale_setlocale(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
         locale = NULL;
     }
     else if (PyUnicode_Check(args[1])) {
-        Py_ssize_t locale_length;
-        locale = PyUnicode_AsUTF8AndSize(args[1], &locale_length);
+        locale = PyUnicode_AsUTF8(args[1]);
         if (locale == NULL) {
-            goto exit;
-        }
-        if (strlen(locale) != (size_t)locale_length) {
-            PyErr_SetString(PyExc_ValueError, "embedded null character");
             goto exit;
         }
     }
@@ -230,13 +225,8 @@ _locale_gettext(PyObject *module, PyObject *arg)
         _PyArg_BadArgument("gettext", "argument", "str", arg);
         goto exit;
     }
-    Py_ssize_t in_length;
-    in = PyUnicode_AsUTF8AndSize(arg, &in_length);
+    in = PyUnicode_AsUTF8(arg);
     if (in == NULL) {
-        goto exit;
-    }
-    if (strlen(in) != (size_t)in_length) {
-        PyErr_SetString(PyExc_ValueError, "embedded null character");
         goto exit;
     }
     return_value = _locale_gettext_impl(module, in);
@@ -277,13 +267,8 @@ _locale_dgettext(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
         domain = NULL;
     }
     else if (PyUnicode_Check(args[0])) {
-        Py_ssize_t domain_length;
-        domain = PyUnicode_AsUTF8AndSize(args[0], &domain_length);
+        domain = PyUnicode_AsUTF8(args[0]);
         if (domain == NULL) {
-            goto exit;
-        }
-        if (strlen(domain) != (size_t)domain_length) {
-            PyErr_SetString(PyExc_ValueError, "embedded null character");
             goto exit;
         }
     }
@@ -295,13 +280,8 @@ _locale_dgettext(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
         _PyArg_BadArgument("dgettext", "argument 2", "str", args[1]);
         goto exit;
     }
-    Py_ssize_t in_length;
-    in = PyUnicode_AsUTF8AndSize(args[1], &in_length);
+    in = PyUnicode_AsUTF8(args[1]);
     if (in == NULL) {
-        goto exit;
-    }
-    if (strlen(in) != (size_t)in_length) {
-        PyErr_SetString(PyExc_ValueError, "embedded null character");
         goto exit;
     }
     return_value = _locale_dgettext_impl(module, domain, in);
@@ -342,13 +322,8 @@ _locale_dcgettext(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
         domain = NULL;
     }
     else if (PyUnicode_Check(args[0])) {
-        Py_ssize_t domain_length;
-        domain = PyUnicode_AsUTF8AndSize(args[0], &domain_length);
+        domain = PyUnicode_AsUTF8(args[0]);
         if (domain == NULL) {
-            goto exit;
-        }
-        if (strlen(domain) != (size_t)domain_length) {
-            PyErr_SetString(PyExc_ValueError, "embedded null character");
             goto exit;
         }
     }
@@ -360,13 +335,8 @@ _locale_dcgettext(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
         _PyArg_BadArgument("dcgettext", "argument 2", "str", args[1]);
         goto exit;
     }
-    Py_ssize_t msgid_length;
-    msgid = PyUnicode_AsUTF8AndSize(args[1], &msgid_length);
+    msgid = PyUnicode_AsUTF8(args[1]);
     if (msgid == NULL) {
-        goto exit;
-    }
-    if (strlen(msgid) != (size_t)msgid_length) {
-        PyErr_SetString(PyExc_ValueError, "embedded null character");
         goto exit;
     }
     category = PyLong_AsInt(args[2]);
@@ -405,13 +375,8 @@ _locale_textdomain(PyObject *module, PyObject *arg)
         domain = NULL;
     }
     else if (PyUnicode_Check(arg)) {
-        Py_ssize_t domain_length;
-        domain = PyUnicode_AsUTF8AndSize(arg, &domain_length);
+        domain = PyUnicode_AsUTF8(arg);
         if (domain == NULL) {
-            goto exit;
-        }
-        if (strlen(domain) != (size_t)domain_length) {
-            PyErr_SetString(PyExc_ValueError, "embedded null character");
             goto exit;
         }
     }
@@ -456,13 +421,8 @@ _locale_bindtextdomain(PyObject *module, PyObject *const *args, Py_ssize_t nargs
         _PyArg_BadArgument("bindtextdomain", "argument 1", "str", args[0]);
         goto exit;
     }
-    Py_ssize_t domain_length;
-    domain = PyUnicode_AsUTF8AndSize(args[0], &domain_length);
+    domain = PyUnicode_AsUTF8(args[0]);
     if (domain == NULL) {
-        goto exit;
-    }
-    if (strlen(domain) != (size_t)domain_length) {
-        PyErr_SetString(PyExc_ValueError, "embedded null character");
         goto exit;
     }
     dirname_obj = args[1];
@@ -503,26 +463,16 @@ _locale_bind_textdomain_codeset(PyObject *module, PyObject *const *args, Py_ssiz
         _PyArg_BadArgument("bind_textdomain_codeset", "argument 1", "str", args[0]);
         goto exit;
     }
-    Py_ssize_t domain_length;
-    domain = PyUnicode_AsUTF8AndSize(args[0], &domain_length);
+    domain = PyUnicode_AsUTF8(args[0]);
     if (domain == NULL) {
-        goto exit;
-    }
-    if (strlen(domain) != (size_t)domain_length) {
-        PyErr_SetString(PyExc_ValueError, "embedded null character");
         goto exit;
     }
     if (args[1] == Py_None) {
         codeset = NULL;
     }
     else if (PyUnicode_Check(args[1])) {
-        Py_ssize_t codeset_length;
-        codeset = PyUnicode_AsUTF8AndSize(args[1], &codeset_length);
+        codeset = PyUnicode_AsUTF8(args[1]);
         if (codeset == NULL) {
-            goto exit;
-        }
-        if (strlen(codeset) != (size_t)codeset_length) {
-            PyErr_SetString(PyExc_ValueError, "embedded null character");
             goto exit;
         }
     }
@@ -595,4 +545,4 @@ _locale_getencoding(PyObject *module, PyObject *Py_UNUSED(ignored))
 #ifndef _LOCALE_BIND_TEXTDOMAIN_CODESET_METHODDEF
     #define _LOCALE_BIND_TEXTDOMAIN_CODESET_METHODDEF
 #endif /* !defined(_LOCALE_BIND_TEXTDOMAIN_CODESET_METHODDEF) */
-/*[clinic end generated code: output=034a3c219466d207 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=14a4bffed066ebb3 input=a9049054013a1b77]*/

--- a/Modules/clinic/_pickle.c.h
+++ b/Modules/clinic/_pickle.c.h
@@ -466,13 +466,8 @@ _pickle_Unpickler___init__(PyObject *self, PyObject *args, PyObject *kwargs)
             _PyArg_BadArgument("Unpickler", "argument 'encoding'", "str", fastargs[2]);
             goto exit;
         }
-        Py_ssize_t encoding_length;
-        encoding = PyUnicode_AsUTF8AndSize(fastargs[2], &encoding_length);
+        encoding = PyUnicode_AsUTF8(fastargs[2]);
         if (encoding == NULL) {
-            goto exit;
-        }
-        if (strlen(encoding) != (size_t)encoding_length) {
-            PyErr_SetString(PyExc_ValueError, "embedded null character");
             goto exit;
         }
         if (!--noptargs) {
@@ -484,13 +479,8 @@ _pickle_Unpickler___init__(PyObject *self, PyObject *args, PyObject *kwargs)
             _PyArg_BadArgument("Unpickler", "argument 'errors'", "str", fastargs[3]);
             goto exit;
         }
-        Py_ssize_t errors_length;
-        errors = PyUnicode_AsUTF8AndSize(fastargs[3], &errors_length);
+        errors = PyUnicode_AsUTF8(fastargs[3]);
         if (errors == NULL) {
-            goto exit;
-        }
-        if (strlen(errors) != (size_t)errors_length) {
-            PyErr_SetString(PyExc_ValueError, "embedded null character");
             goto exit;
         }
         if (!--noptargs) {
@@ -870,13 +860,8 @@ _pickle_load(PyObject *module, PyObject *const *args, Py_ssize_t nargs, PyObject
             _PyArg_BadArgument("load", "argument 'encoding'", "str", args[2]);
             goto exit;
         }
-        Py_ssize_t encoding_length;
-        encoding = PyUnicode_AsUTF8AndSize(args[2], &encoding_length);
+        encoding = PyUnicode_AsUTF8(args[2]);
         if (encoding == NULL) {
-            goto exit;
-        }
-        if (strlen(encoding) != (size_t)encoding_length) {
-            PyErr_SetString(PyExc_ValueError, "embedded null character");
             goto exit;
         }
         if (!--noptargs) {
@@ -888,13 +873,8 @@ _pickle_load(PyObject *module, PyObject *const *args, Py_ssize_t nargs, PyObject
             _PyArg_BadArgument("load", "argument 'errors'", "str", args[3]);
             goto exit;
         }
-        Py_ssize_t errors_length;
-        errors = PyUnicode_AsUTF8AndSize(args[3], &errors_length);
+        errors = PyUnicode_AsUTF8(args[3]);
         if (errors == NULL) {
-            goto exit;
-        }
-        if (strlen(errors) != (size_t)errors_length) {
-            PyErr_SetString(PyExc_ValueError, "embedded null character");
             goto exit;
         }
         if (!--noptargs) {
@@ -996,13 +976,8 @@ _pickle_loads(PyObject *module, PyObject *const *args, Py_ssize_t nargs, PyObjec
             _PyArg_BadArgument("loads", "argument 'encoding'", "str", args[2]);
             goto exit;
         }
-        Py_ssize_t encoding_length;
-        encoding = PyUnicode_AsUTF8AndSize(args[2], &encoding_length);
+        encoding = PyUnicode_AsUTF8(args[2]);
         if (encoding == NULL) {
-            goto exit;
-        }
-        if (strlen(encoding) != (size_t)encoding_length) {
-            PyErr_SetString(PyExc_ValueError, "embedded null character");
             goto exit;
         }
         if (!--noptargs) {
@@ -1014,13 +989,8 @@ _pickle_loads(PyObject *module, PyObject *const *args, Py_ssize_t nargs, PyObjec
             _PyArg_BadArgument("loads", "argument 'errors'", "str", args[3]);
             goto exit;
         }
-        Py_ssize_t errors_length;
-        errors = PyUnicode_AsUTF8AndSize(args[3], &errors_length);
+        errors = PyUnicode_AsUTF8(args[3]);
         if (errors == NULL) {
-            goto exit;
-        }
-        if (strlen(errors) != (size_t)errors_length) {
-            PyErr_SetString(PyExc_ValueError, "embedded null character");
             goto exit;
         }
         if (!--noptargs) {
@@ -1034,4 +1004,4 @@ skip_optional_kwonly:
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=7f0564b5fb5410a8 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=1c675a6680a6b90c input=a9049054013a1b77]*/

--- a/Modules/clinic/_ssl.c.h
+++ b/Modules/clinic/_ssl.c.h
@@ -391,13 +391,8 @@ _ssl__SSLSocket_get_channel_binding(PySSLSocket *self, PyObject *const *args, Py
         _PyArg_BadArgument("get_channel_binding", "argument 'cb_type'", "str", args[0]);
         goto exit;
     }
-    Py_ssize_t cb_type_length;
-    cb_type = PyUnicode_AsUTF8AndSize(args[0], &cb_type_length);
+    cb_type = PyUnicode_AsUTF8(args[0]);
     if (cb_type == NULL) {
-        goto exit;
-    }
-    if (strlen(cb_type) != (size_t)cb_type_length) {
-        PyErr_SetString(PyExc_ValueError, "embedded null character");
         goto exit;
     }
 skip_optional_pos:
@@ -473,13 +468,8 @@ _ssl__SSLContext_set_ciphers(PySSLContext *self, PyObject *arg)
         _PyArg_BadArgument("set_ciphers", "argument", "str", arg);
         goto exit;
     }
-    Py_ssize_t cipherlist_length;
-    cipherlist = PyUnicode_AsUTF8AndSize(arg, &cipherlist_length);
+    cipherlist = PyUnicode_AsUTF8(arg);
     if (cipherlist == NULL) {
-        goto exit;
-    }
-    if (strlen(cipherlist) != (size_t)cipherlist_length) {
-        PyErr_SetString(PyExc_ValueError, "embedded null character");
         goto exit;
     }
     return_value = _ssl__SSLContext_set_ciphers_impl(self, cipherlist);
@@ -1316,13 +1306,8 @@ _ssl_txt2obj(PyObject *module, PyObject *const *args, Py_ssize_t nargs, PyObject
         _PyArg_BadArgument("txt2obj", "argument 'txt'", "str", args[0]);
         goto exit;
     }
-    Py_ssize_t txt_length;
-    txt = PyUnicode_AsUTF8AndSize(args[0], &txt_length);
+    txt = PyUnicode_AsUTF8(args[0]);
     if (txt == NULL) {
-        goto exit;
-    }
-    if (strlen(txt) != (size_t)txt_length) {
-        PyErr_SetString(PyExc_ValueError, "embedded null character");
         goto exit;
     }
     if (!noptargs) {
@@ -1427,13 +1412,8 @@ _ssl_enum_certificates(PyObject *module, PyObject *const *args, Py_ssize_t nargs
         _PyArg_BadArgument("enum_certificates", "argument 'store_name'", "str", args[0]);
         goto exit;
     }
-    Py_ssize_t store_name_length;
-    store_name = PyUnicode_AsUTF8AndSize(args[0], &store_name_length);
+    store_name = PyUnicode_AsUTF8(args[0]);
     if (store_name == NULL) {
-        goto exit;
-    }
-    if (strlen(store_name) != (size_t)store_name_length) {
-        PyErr_SetString(PyExc_ValueError, "embedded null character");
         goto exit;
     }
     return_value = _ssl_enum_certificates_impl(module, store_name);
@@ -1503,13 +1483,8 @@ _ssl_enum_crls(PyObject *module, PyObject *const *args, Py_ssize_t nargs, PyObje
         _PyArg_BadArgument("enum_crls", "argument 'store_name'", "str", args[0]);
         goto exit;
     }
-    Py_ssize_t store_name_length;
-    store_name = PyUnicode_AsUTF8AndSize(args[0], &store_name_length);
+    store_name = PyUnicode_AsUTF8(args[0]);
     if (store_name == NULL) {
-        goto exit;
-    }
-    if (strlen(store_name) != (size_t)store_name_length) {
-        PyErr_SetString(PyExc_ValueError, "embedded null character");
         goto exit;
     }
     return_value = _ssl_enum_crls_impl(module, store_name);
@@ -1527,4 +1502,4 @@ exit:
 #ifndef _SSL_ENUM_CRLS_METHODDEF
     #define _SSL_ENUM_CRLS_METHODDEF
 #endif /* !defined(_SSL_ENUM_CRLS_METHODDEF) */
-/*[clinic end generated code: output=aa6b0a898b6077fe input=a9049054013a1b77]*/
+/*[clinic end generated code: output=8350af68e0a56792 input=a9049054013a1b77]*/

--- a/Modules/clinic/_testclinic.c.h
+++ b/Modules/clinic/_testclinic.c.h
@@ -2935,13 +2935,8 @@ clone_f1(PyObject *module, PyObject *const *args, Py_ssize_t nargs, PyObject *kw
         _PyArg_BadArgument("clone_f1", "argument 'path'", "str", args[0]);
         goto exit;
     }
-    Py_ssize_t path_length;
-    path = PyUnicode_AsUTF8AndSize(args[0], &path_length);
+    path = PyUnicode_AsUTF8(args[0]);
     if (path == NULL) {
-        goto exit;
-    }
-    if (strlen(path) != (size_t)path_length) {
-        PyErr_SetString(PyExc_ValueError, "embedded null character");
         goto exit;
     }
     return_value = clone_f1_impl(module, path);
@@ -3001,13 +2996,8 @@ clone_f2(PyObject *module, PyObject *const *args, Py_ssize_t nargs, PyObject *kw
         _PyArg_BadArgument("clone_f2", "argument 'path'", "str", args[0]);
         goto exit;
     }
-    Py_ssize_t path_length;
-    path = PyUnicode_AsUTF8AndSize(args[0], &path_length);
+    path = PyUnicode_AsUTF8(args[0]);
     if (path == NULL) {
-        goto exit;
-    }
-    if (strlen(path) != (size_t)path_length) {
-        PyErr_SetString(PyExc_ValueError, "embedded null character");
         goto exit;
     }
     return_value = clone_f2_impl(module, path);
@@ -3141,4 +3131,4 @@ skip_optional_pos:
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=90743ac900d60f9f input=a9049054013a1b77]*/
+/*[clinic end generated code: output=32dc6ac90757da7a input=a9049054013a1b77]*/

--- a/Modules/clinic/_tkinter.c.h
+++ b/Modules/clinic/_tkinter.c.h
@@ -25,13 +25,8 @@ _tkinter_tkapp_eval(TkappObject *self, PyObject *arg)
         _PyArg_BadArgument("eval", "argument", "str", arg);
         goto exit;
     }
-    Py_ssize_t script_length;
-    script = PyUnicode_AsUTF8AndSize(arg, &script_length);
+    script = PyUnicode_AsUTF8(arg);
     if (script == NULL) {
-        goto exit;
-    }
-    if (strlen(script) != (size_t)script_length) {
-        PyErr_SetString(PyExc_ValueError, "embedded null character");
         goto exit;
     }
     return_value = _tkinter_tkapp_eval_impl(self, script);
@@ -61,13 +56,8 @@ _tkinter_tkapp_evalfile(TkappObject *self, PyObject *arg)
         _PyArg_BadArgument("evalfile", "argument", "str", arg);
         goto exit;
     }
-    Py_ssize_t fileName_length;
-    fileName = PyUnicode_AsUTF8AndSize(arg, &fileName_length);
+    fileName = PyUnicode_AsUTF8(arg);
     if (fileName == NULL) {
-        goto exit;
-    }
-    if (strlen(fileName) != (size_t)fileName_length) {
-        PyErr_SetString(PyExc_ValueError, "embedded null character");
         goto exit;
     }
     return_value = _tkinter_tkapp_evalfile_impl(self, fileName);
@@ -97,13 +87,8 @@ _tkinter_tkapp_record(TkappObject *self, PyObject *arg)
         _PyArg_BadArgument("record", "argument", "str", arg);
         goto exit;
     }
-    Py_ssize_t script_length;
-    script = PyUnicode_AsUTF8AndSize(arg, &script_length);
+    script = PyUnicode_AsUTF8(arg);
     if (script == NULL) {
-        goto exit;
-    }
-    if (strlen(script) != (size_t)script_length) {
-        PyErr_SetString(PyExc_ValueError, "embedded null character");
         goto exit;
     }
     return_value = _tkinter_tkapp_record_impl(self, script);
@@ -133,13 +118,8 @@ _tkinter_tkapp_adderrorinfo(TkappObject *self, PyObject *arg)
         _PyArg_BadArgument("adderrorinfo", "argument", "str", arg);
         goto exit;
     }
-    Py_ssize_t msg_length;
-    msg = PyUnicode_AsUTF8AndSize(arg, &msg_length);
+    msg = PyUnicode_AsUTF8(arg);
     if (msg == NULL) {
-        goto exit;
-    }
-    if (strlen(msg) != (size_t)msg_length) {
-        PyErr_SetString(PyExc_ValueError, "embedded null character");
         goto exit;
     }
     return_value = _tkinter_tkapp_adderrorinfo_impl(self, msg);
@@ -193,13 +173,8 @@ _tkinter_tkapp_exprstring(TkappObject *self, PyObject *arg)
         _PyArg_BadArgument("exprstring", "argument", "str", arg);
         goto exit;
     }
-    Py_ssize_t s_length;
-    s = PyUnicode_AsUTF8AndSize(arg, &s_length);
+    s = PyUnicode_AsUTF8(arg);
     if (s == NULL) {
-        goto exit;
-    }
-    if (strlen(s) != (size_t)s_length) {
-        PyErr_SetString(PyExc_ValueError, "embedded null character");
         goto exit;
     }
     return_value = _tkinter_tkapp_exprstring_impl(self, s);
@@ -229,13 +204,8 @@ _tkinter_tkapp_exprlong(TkappObject *self, PyObject *arg)
         _PyArg_BadArgument("exprlong", "argument", "str", arg);
         goto exit;
     }
-    Py_ssize_t s_length;
-    s = PyUnicode_AsUTF8AndSize(arg, &s_length);
+    s = PyUnicode_AsUTF8(arg);
     if (s == NULL) {
-        goto exit;
-    }
-    if (strlen(s) != (size_t)s_length) {
-        PyErr_SetString(PyExc_ValueError, "embedded null character");
         goto exit;
     }
     return_value = _tkinter_tkapp_exprlong_impl(self, s);
@@ -265,13 +235,8 @@ _tkinter_tkapp_exprdouble(TkappObject *self, PyObject *arg)
         _PyArg_BadArgument("exprdouble", "argument", "str", arg);
         goto exit;
     }
-    Py_ssize_t s_length;
-    s = PyUnicode_AsUTF8AndSize(arg, &s_length);
+    s = PyUnicode_AsUTF8(arg);
     if (s == NULL) {
-        goto exit;
-    }
-    if (strlen(s) != (size_t)s_length) {
-        PyErr_SetString(PyExc_ValueError, "embedded null character");
         goto exit;
     }
     return_value = _tkinter_tkapp_exprdouble_impl(self, s);
@@ -301,13 +266,8 @@ _tkinter_tkapp_exprboolean(TkappObject *self, PyObject *arg)
         _PyArg_BadArgument("exprboolean", "argument", "str", arg);
         goto exit;
     }
-    Py_ssize_t s_length;
-    s = PyUnicode_AsUTF8AndSize(arg, &s_length);
+    s = PyUnicode_AsUTF8(arg);
     if (s == NULL) {
-        goto exit;
-    }
-    if (strlen(s) != (size_t)s_length) {
-        PyErr_SetString(PyExc_ValueError, "embedded null character");
         goto exit;
     }
     return_value = _tkinter_tkapp_exprboolean_impl(self, s);
@@ -350,13 +310,8 @@ _tkinter_tkapp_createcommand(TkappObject *self, PyObject *const *args, Py_ssize_
         _PyArg_BadArgument("createcommand", "argument 1", "str", args[0]);
         goto exit;
     }
-    Py_ssize_t name_length;
-    name = PyUnicode_AsUTF8AndSize(args[0], &name_length);
+    name = PyUnicode_AsUTF8(args[0]);
     if (name == NULL) {
-        goto exit;
-    }
-    if (strlen(name) != (size_t)name_length) {
-        PyErr_SetString(PyExc_ValueError, "embedded null character");
         goto exit;
     }
     func = args[1];
@@ -387,13 +342,8 @@ _tkinter_tkapp_deletecommand(TkappObject *self, PyObject *arg)
         _PyArg_BadArgument("deletecommand", "argument", "str", arg);
         goto exit;
     }
-    Py_ssize_t name_length;
-    name = PyUnicode_AsUTF8AndSize(arg, &name_length);
+    name = PyUnicode_AsUTF8(arg);
     if (name == NULL) {
-        goto exit;
-    }
-    if (strlen(name) != (size_t)name_length) {
-        PyErr_SetString(PyExc_ValueError, "embedded null character");
         goto exit;
     }
     return_value = _tkinter_tkapp_deletecommand_impl(self, name);
@@ -694,13 +644,8 @@ _tkinter_create(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
         screenName = NULL;
     }
     else if (PyUnicode_Check(args[0])) {
-        Py_ssize_t screenName_length;
-        screenName = PyUnicode_AsUTF8AndSize(args[0], &screenName_length);
+        screenName = PyUnicode_AsUTF8(args[0]);
         if (screenName == NULL) {
-            goto exit;
-        }
-        if (strlen(screenName) != (size_t)screenName_length) {
-            PyErr_SetString(PyExc_ValueError, "embedded null character");
             goto exit;
         }
     }
@@ -715,13 +660,8 @@ _tkinter_create(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
         _PyArg_BadArgument("create", "argument 2", "str", args[1]);
         goto exit;
     }
-    Py_ssize_t baseName_length;
-    baseName = PyUnicode_AsUTF8AndSize(args[1], &baseName_length);
+    baseName = PyUnicode_AsUTF8(args[1]);
     if (baseName == NULL) {
-        goto exit;
-    }
-    if (strlen(baseName) != (size_t)baseName_length) {
-        PyErr_SetString(PyExc_ValueError, "embedded null character");
         goto exit;
     }
     if (nargs < 3) {
@@ -731,13 +671,8 @@ _tkinter_create(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
         _PyArg_BadArgument("create", "argument 3", "str", args[2]);
         goto exit;
     }
-    Py_ssize_t className_length;
-    className = PyUnicode_AsUTF8AndSize(args[2], &className_length);
+    className = PyUnicode_AsUTF8(args[2]);
     if (className == NULL) {
-        goto exit;
-    }
-    if (strlen(className) != (size_t)className_length) {
-        PyErr_SetString(PyExc_ValueError, "embedded null character");
         goto exit;
     }
     if (nargs < 4) {
@@ -775,13 +710,8 @@ _tkinter_create(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
         use = NULL;
     }
     else if (PyUnicode_Check(args[7])) {
-        Py_ssize_t use_length;
-        use = PyUnicode_AsUTF8AndSize(args[7], &use_length);
+        use = PyUnicode_AsUTF8(args[7]);
         if (use == NULL) {
-            goto exit;
-        }
-        if (strlen(use) != (size_t)use_length) {
-            PyErr_SetString(PyExc_ValueError, "embedded null character");
             goto exit;
         }
     }
@@ -861,4 +791,4 @@ exit:
 #ifndef _TKINTER_TKAPP_DELETEFILEHANDLER_METHODDEF
     #define _TKINTER_TKAPP_DELETEFILEHANDLER_METHODDEF
 #endif /* !defined(_TKINTER_TKAPP_DELETEFILEHANDLER_METHODDEF) */
-/*[clinic end generated code: output=d447501ec5aa9447 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=0c8b5f960d7738fd input=a9049054013a1b77]*/

--- a/Modules/clinic/posixmodule.c.h
+++ b/Modules/clinic/posixmodule.c.h
@@ -4672,13 +4672,8 @@ os_getgrouplist(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
         _PyArg_BadArgument("getgrouplist", "argument 1", "str", args[0]);
         goto exit;
     }
-    Py_ssize_t user_length;
-    user = PyUnicode_AsUTF8AndSize(args[0], &user_length);
+    user = PyUnicode_AsUTF8(args[0]);
     if (user == NULL) {
-        goto exit;
-    }
-    if (strlen(user) != (size_t)user_length) {
-        PyErr_SetString(PyExc_ValueError, "embedded null character");
         goto exit;
     }
     basegid = PyLong_AsInt(args[1]);
@@ -4726,13 +4721,8 @@ os_getgrouplist(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
         _PyArg_BadArgument("getgrouplist", "argument 1", "str", args[0]);
         goto exit;
     }
-    Py_ssize_t user_length;
-    user = PyUnicode_AsUTF8AndSize(args[0], &user_length);
+    user = PyUnicode_AsUTF8(args[0]);
     if (user == NULL) {
-        goto exit;
-    }
-    if (strlen(user) != (size_t)user_length) {
-        PyErr_SetString(PyExc_ValueError, "embedded null character");
         goto exit;
     }
     if (!_Py_Gid_Converter(args[1], &basegid)) {
@@ -12403,4 +12393,4 @@ exit:
 #ifndef OS_WAITSTATUS_TO_EXITCODE_METHODDEF
     #define OS_WAITSTATUS_TO_EXITCODE_METHODDEF
 #endif /* !defined(OS_WAITSTATUS_TO_EXITCODE_METHODDEF) */
-/*[clinic end generated code: output=a05abdc48e3def44 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=a377982a6d1e77b9 input=a9049054013a1b77]*/

--- a/Modules/clinic/pyexpat.c.h
+++ b/Modules/clinic/pyexpat.c.h
@@ -129,13 +129,8 @@ pyexpat_xmlparser_SetBase(xmlparseobject *self, PyObject *arg)
         _PyArg_BadArgument("SetBase", "argument", "str", arg);
         goto exit;
     }
-    Py_ssize_t base_length;
-    base = PyUnicode_AsUTF8AndSize(arg, &base_length);
+    base = PyUnicode_AsUTF8(arg);
     if (base == NULL) {
-        goto exit;
-    }
-    if (strlen(base) != (size_t)base_length) {
-        PyErr_SetString(PyExc_ValueError, "embedded null character");
         goto exit;
     }
     return_value = pyexpat_xmlparser_SetBase_impl(self, base);
@@ -228,13 +223,8 @@ pyexpat_xmlparser_ExternalEntityParserCreate(xmlparseobject *self, PyTypeObject 
         context = NULL;
     }
     else if (PyUnicode_Check(args[0])) {
-        Py_ssize_t context_length;
-        context = PyUnicode_AsUTF8AndSize(args[0], &context_length);
+        context = PyUnicode_AsUTF8(args[0]);
         if (context == NULL) {
-            goto exit;
-        }
-        if (strlen(context) != (size_t)context_length) {
-            PyErr_SetString(PyExc_ValueError, "embedded null character");
             goto exit;
         }
     }
@@ -249,13 +239,8 @@ pyexpat_xmlparser_ExternalEntityParserCreate(xmlparseobject *self, PyTypeObject 
         _PyArg_BadArgument("ExternalEntityParserCreate", "argument 2", "str", args[1]);
         goto exit;
     }
-    Py_ssize_t encoding_length;
-    encoding = PyUnicode_AsUTF8AndSize(args[1], &encoding_length);
+    encoding = PyUnicode_AsUTF8(args[1]);
     if (encoding == NULL) {
-        goto exit;
-    }
-    if (strlen(encoding) != (size_t)encoding_length) {
-        PyErr_SetString(PyExc_ValueError, "embedded null character");
         goto exit;
     }
 skip_optional_posonly:
@@ -418,13 +403,8 @@ pyexpat_ParserCreate(PyObject *module, PyObject *const *args, Py_ssize_t nargs, 
             encoding = NULL;
         }
         else if (PyUnicode_Check(args[0])) {
-            Py_ssize_t encoding_length;
-            encoding = PyUnicode_AsUTF8AndSize(args[0], &encoding_length);
+            encoding = PyUnicode_AsUTF8(args[0]);
             if (encoding == NULL) {
-                goto exit;
-            }
-            if (strlen(encoding) != (size_t)encoding_length) {
-                PyErr_SetString(PyExc_ValueError, "embedded null character");
                 goto exit;
             }
         }
@@ -441,13 +421,8 @@ pyexpat_ParserCreate(PyObject *module, PyObject *const *args, Py_ssize_t nargs, 
             namespace_separator = NULL;
         }
         else if (PyUnicode_Check(args[1])) {
-            Py_ssize_t namespace_separator_length;
-            namespace_separator = PyUnicode_AsUTF8AndSize(args[1], &namespace_separator_length);
+            namespace_separator = PyUnicode_AsUTF8(args[1]);
             if (namespace_separator == NULL) {
-                goto exit;
-            }
-            if (strlen(namespace_separator) != (size_t)namespace_separator_length) {
-                PyErr_SetString(PyExc_ValueError, "embedded null character");
                 goto exit;
             }
         }
@@ -498,4 +473,4 @@ exit:
 #ifndef PYEXPAT_XMLPARSER_USEFOREIGNDTD_METHODDEF
     #define PYEXPAT_XMLPARSER_USEFOREIGNDTD_METHODDEF
 #endif /* !defined(PYEXPAT_XMLPARSER_USEFOREIGNDTD_METHODDEF) */
-/*[clinic end generated code: output=48c4296e43777df4 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=bfc1f3d3e2cbc8dc input=a9049054013a1b77]*/

--- a/Modules/clinic/symtablemodule.c.h
+++ b/Modules/clinic/symtablemodule.c.h
@@ -36,13 +36,8 @@ _symtable_symtable(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
         _PyArg_BadArgument("symtable", "argument 3", "str", args[2]);
         goto exit;
     }
-    Py_ssize_t startstr_length;
-    startstr = PyUnicode_AsUTF8AndSize(args[2], &startstr_length);
+    startstr = PyUnicode_AsUTF8(args[2]);
     if (startstr == NULL) {
-        goto exit;
-    }
-    if (strlen(startstr) != (size_t)startstr_length) {
-        PyErr_SetString(PyExc_ValueError, "embedded null character");
         goto exit;
     }
     return_value = _symtable_symtable_impl(module, source, filename, startstr);
@@ -50,4 +45,4 @@ _symtable_symtable(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=931964a76a72f850 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=9af1ab5a114a1ec7 input=a9049054013a1b77]*/

--- a/Objects/clinic/bytearrayobject.c.h
+++ b/Objects/clinic/bytearrayobject.c.h
@@ -68,13 +68,8 @@ bytearray___init__(PyObject *self, PyObject *args, PyObject *kwargs)
             _PyArg_BadArgument("bytearray", "argument 'encoding'", "str", fastargs[1]);
             goto exit;
         }
-        Py_ssize_t encoding_length;
-        encoding = PyUnicode_AsUTF8AndSize(fastargs[1], &encoding_length);
+        encoding = PyUnicode_AsUTF8(fastargs[1]);
         if (encoding == NULL) {
-            goto exit;
-        }
-        if (strlen(encoding) != (size_t)encoding_length) {
-            PyErr_SetString(PyExc_ValueError, "embedded null character");
             goto exit;
         }
         if (!--noptargs) {
@@ -85,13 +80,8 @@ bytearray___init__(PyObject *self, PyObject *args, PyObject *kwargs)
         _PyArg_BadArgument("bytearray", "argument 'errors'", "str", fastargs[2]);
         goto exit;
     }
-    Py_ssize_t errors_length;
-    errors = PyUnicode_AsUTF8AndSize(fastargs[2], &errors_length);
+    errors = PyUnicode_AsUTF8(fastargs[2]);
     if (errors == NULL) {
-        goto exit;
-    }
-    if (strlen(errors) != (size_t)errors_length) {
-        PyErr_SetString(PyExc_ValueError, "embedded null character");
         goto exit;
     }
 skip_optional_pos:
@@ -960,13 +950,8 @@ bytearray_decode(PyByteArrayObject *self, PyObject *const *args, Py_ssize_t narg
             _PyArg_BadArgument("decode", "argument 'encoding'", "str", args[0]);
             goto exit;
         }
-        Py_ssize_t encoding_length;
-        encoding = PyUnicode_AsUTF8AndSize(args[0], &encoding_length);
+        encoding = PyUnicode_AsUTF8(args[0]);
         if (encoding == NULL) {
-            goto exit;
-        }
-        if (strlen(encoding) != (size_t)encoding_length) {
-            PyErr_SetString(PyExc_ValueError, "embedded null character");
             goto exit;
         }
         if (!--noptargs) {
@@ -977,13 +962,8 @@ bytearray_decode(PyByteArrayObject *self, PyObject *const *args, Py_ssize_t narg
         _PyArg_BadArgument("decode", "argument 'errors'", "str", args[1]);
         goto exit;
     }
-    Py_ssize_t errors_length;
-    errors = PyUnicode_AsUTF8AndSize(args[1], &errors_length);
+    errors = PyUnicode_AsUTF8(args[1]);
     if (errors == NULL) {
-        goto exit;
-    }
-    if (strlen(errors) != (size_t)errors_length) {
-        PyErr_SetString(PyExc_ValueError, "embedded null character");
         goto exit;
     }
 skip_optional_pos:
@@ -1261,4 +1241,4 @@ bytearray_sizeof(PyByteArrayObject *self, PyObject *Py_UNUSED(ignored))
 {
     return bytearray_sizeof_impl(self);
 }
-/*[clinic end generated code: output=0797a5e03cda2a16 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=5a7de6295a7ce6cc input=a9049054013a1b77]*/

--- a/Objects/clinic/bytesobject.c.h
+++ b/Objects/clinic/bytesobject.c.h
@@ -720,13 +720,8 @@ bytes_decode(PyBytesObject *self, PyObject *const *args, Py_ssize_t nargs, PyObj
             _PyArg_BadArgument("decode", "argument 'encoding'", "str", args[0]);
             goto exit;
         }
-        Py_ssize_t encoding_length;
-        encoding = PyUnicode_AsUTF8AndSize(args[0], &encoding_length);
+        encoding = PyUnicode_AsUTF8(args[0]);
         if (encoding == NULL) {
-            goto exit;
-        }
-        if (strlen(encoding) != (size_t)encoding_length) {
-            PyErr_SetString(PyExc_ValueError, "embedded null character");
             goto exit;
         }
         if (!--noptargs) {
@@ -737,13 +732,8 @@ bytes_decode(PyBytesObject *self, PyObject *const *args, Py_ssize_t nargs, PyObj
         _PyArg_BadArgument("decode", "argument 'errors'", "str", args[1]);
         goto exit;
     }
-    Py_ssize_t errors_length;
-    errors = PyUnicode_AsUTF8AndSize(args[1], &errors_length);
+    errors = PyUnicode_AsUTF8(args[1]);
     if (errors == NULL) {
-        goto exit;
-    }
-    if (strlen(errors) != (size_t)errors_length) {
-        PyErr_SetString(PyExc_ValueError, "embedded null character");
         goto exit;
     }
 skip_optional_pos:
@@ -997,13 +987,8 @@ bytes_new(PyTypeObject *type, PyObject *args, PyObject *kwargs)
             _PyArg_BadArgument("bytes", "argument 'encoding'", "str", fastargs[1]);
             goto exit;
         }
-        Py_ssize_t encoding_length;
-        encoding = PyUnicode_AsUTF8AndSize(fastargs[1], &encoding_length);
+        encoding = PyUnicode_AsUTF8(fastargs[1]);
         if (encoding == NULL) {
-            goto exit;
-        }
-        if (strlen(encoding) != (size_t)encoding_length) {
-            PyErr_SetString(PyExc_ValueError, "embedded null character");
             goto exit;
         }
         if (!--noptargs) {
@@ -1014,13 +999,8 @@ bytes_new(PyTypeObject *type, PyObject *args, PyObject *kwargs)
         _PyArg_BadArgument("bytes", "argument 'errors'", "str", fastargs[2]);
         goto exit;
     }
-    Py_ssize_t errors_length;
-    errors = PyUnicode_AsUTF8AndSize(fastargs[2], &errors_length);
+    errors = PyUnicode_AsUTF8(fastargs[2]);
     if (errors == NULL) {
-        goto exit;
-    }
-    if (strlen(errors) != (size_t)errors_length) {
-        PyErr_SetString(PyExc_ValueError, "embedded null character");
         goto exit;
     }
 skip_optional_pos:
@@ -1029,4 +1009,4 @@ skip_optional_pos:
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=8a49dbbd78914a6f input=a9049054013a1b77]*/
+/*[clinic end generated code: output=97aab3f6ae398664 input=a9049054013a1b77]*/

--- a/Objects/clinic/floatobject.c.h
+++ b/Objects/clinic/floatobject.c.h
@@ -275,13 +275,8 @@ float___getformat__(PyTypeObject *type, PyObject *arg)
         _PyArg_BadArgument("__getformat__", "argument", "str", arg);
         goto exit;
     }
-    Py_ssize_t typestr_length;
-    typestr = PyUnicode_AsUTF8AndSize(arg, &typestr_length);
+    typestr = PyUnicode_AsUTF8(arg);
     if (typestr == NULL) {
-        goto exit;
-    }
-    if (strlen(typestr) != (size_t)typestr_length) {
-        PyErr_SetString(PyExc_ValueError, "embedded null character");
         goto exit;
     }
     return_value = float___getformat___impl(type, typestr);
@@ -318,4 +313,4 @@ float___format__(PyObject *self, PyObject *arg)
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=c79743c8551c30d9 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=01f6fbd082eefead input=a9049054013a1b77]*/

--- a/Objects/clinic/memoryobject.c.h
+++ b/Objects/clinic/memoryobject.c.h
@@ -305,13 +305,8 @@ memoryview_tobytes(PyMemoryViewObject *self, PyObject *const *args, Py_ssize_t n
         order = NULL;
     }
     else if (PyUnicode_Check(args[0])) {
-        Py_ssize_t order_length;
-        order = PyUnicode_AsUTF8AndSize(args[0], &order_length);
+        order = PyUnicode_AsUTF8(args[0]);
         if (order == NULL) {
-            goto exit;
-        }
-        if (strlen(order) != (size_t)order_length) {
-            PyErr_SetString(PyExc_ValueError, "embedded null character");
             goto exit;
         }
     }
@@ -413,4 +408,4 @@ skip_optional_pos:
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=7e76a09106921ba2 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=abd8c0ce804d8992 input=a9049054013a1b77]*/

--- a/Objects/clinic/unicodeobject.c.h
+++ b/Objects/clinic/unicodeobject.c.h
@@ -203,13 +203,8 @@ unicode_encode(PyObject *self, PyObject *const *args, Py_ssize_t nargs, PyObject
             _PyArg_BadArgument("encode", "argument 'encoding'", "str", args[0]);
             goto exit;
         }
-        Py_ssize_t encoding_length;
-        encoding = PyUnicode_AsUTF8AndSize(args[0], &encoding_length);
+        encoding = PyUnicode_AsUTF8(args[0]);
         if (encoding == NULL) {
-            goto exit;
-        }
-        if (strlen(encoding) != (size_t)encoding_length) {
-            PyErr_SetString(PyExc_ValueError, "embedded null character");
             goto exit;
         }
         if (!--noptargs) {
@@ -220,13 +215,8 @@ unicode_encode(PyObject *self, PyObject *const *args, Py_ssize_t nargs, PyObject
         _PyArg_BadArgument("encode", "argument 'errors'", "str", args[1]);
         goto exit;
     }
-    Py_ssize_t errors_length;
-    errors = PyUnicode_AsUTF8AndSize(args[1], &errors_length);
+    errors = PyUnicode_AsUTF8(args[1]);
     if (errors == NULL) {
-        goto exit;
-    }
-    if (strlen(errors) != (size_t)errors_length) {
-        PyErr_SetString(PyExc_ValueError, "embedded null character");
         goto exit;
     }
 skip_optional_pos:
@@ -1473,13 +1463,8 @@ unicode_new(PyTypeObject *type, PyObject *args, PyObject *kwargs)
             _PyArg_BadArgument("str", "argument 'encoding'", "str", fastargs[1]);
             goto exit;
         }
-        Py_ssize_t encoding_length;
-        encoding = PyUnicode_AsUTF8AndSize(fastargs[1], &encoding_length);
+        encoding = PyUnicode_AsUTF8(fastargs[1]);
         if (encoding == NULL) {
-            goto exit;
-        }
-        if (strlen(encoding) != (size_t)encoding_length) {
-            PyErr_SetString(PyExc_ValueError, "embedded null character");
             goto exit;
         }
         if (!--noptargs) {
@@ -1490,13 +1475,8 @@ unicode_new(PyTypeObject *type, PyObject *args, PyObject *kwargs)
         _PyArg_BadArgument("str", "argument 'errors'", "str", fastargs[2]);
         goto exit;
     }
-    Py_ssize_t errors_length;
-    errors = PyUnicode_AsUTF8AndSize(fastargs[2], &errors_length);
+    errors = PyUnicode_AsUTF8(fastargs[2]);
     if (errors == NULL) {
-        goto exit;
-    }
-    if (strlen(errors) != (size_t)errors_length) {
-        PyErr_SetString(PyExc_ValueError, "embedded null character");
         goto exit;
     }
 skip_optional_pos:
@@ -1505,4 +1485,4 @@ skip_optional_pos:
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=873d8b3d09af3095 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=20313d6339272ddc input=a9049054013a1b77]*/

--- a/Python/clinic/Python-tokenize.c.h
+++ b/Python/clinic/Python-tokenize.c.h
@@ -65,13 +65,8 @@ tokenizeriter_new(PyTypeObject *type, PyObject *args, PyObject *kwargs)
         _PyArg_BadArgument("tokenizeriter", "argument 'encoding'", "str", fastargs[2]);
         goto exit;
     }
-    Py_ssize_t encoding_length;
-    encoding = PyUnicode_AsUTF8AndSize(fastargs[2], &encoding_length);
+    encoding = PyUnicode_AsUTF8(fastargs[2]);
     if (encoding == NULL) {
-        goto exit;
-    }
-    if (strlen(encoding) != (size_t)encoding_length) {
-        PyErr_SetString(PyExc_ValueError, "embedded null character");
         goto exit;
     }
 skip_optional_kwonly:
@@ -80,4 +75,4 @@ skip_optional_kwonly:
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=dcd6ec48f06a092e input=a9049054013a1b77]*/
+/*[clinic end generated code: output=92cb8176149f0924 input=a9049054013a1b77]*/

--- a/Python/clinic/bltinmodule.c.h
+++ b/Python/clinic/bltinmodule.c.h
@@ -329,13 +329,8 @@ builtin_compile(PyObject *module, PyObject *const *args, Py_ssize_t nargs, PyObj
         _PyArg_BadArgument("compile", "argument 'mode'", "str", args[2]);
         goto exit;
     }
-    Py_ssize_t mode_length;
-    mode = PyUnicode_AsUTF8AndSize(args[2], &mode_length);
+    mode = PyUnicode_AsUTF8(args[2]);
     if (mode == NULL) {
-        goto exit;
-    }
-    if (strlen(mode) != (size_t)mode_length) {
-        PyErr_SetString(PyExc_ValueError, "embedded null character");
         goto exit;
     }
     if (!noptargs) {
@@ -1212,4 +1207,4 @@ builtin_issubclass(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=31bded5d08647a57 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=95d3813b1798f018 input=a9049054013a1b77]*/

--- a/Python/clinic/sysmodule.c.h
+++ b/Python/clinic/sysmodule.c.h
@@ -1259,13 +1259,8 @@ sys_activate_stack_trampoline(PyObject *module, PyObject *arg)
         _PyArg_BadArgument("activate_stack_trampoline", "argument", "str", arg);
         goto exit;
     }
-    Py_ssize_t backend_length;
-    backend = PyUnicode_AsUTF8AndSize(arg, &backend_length);
+    backend = PyUnicode_AsUTF8(arg);
     if (backend == NULL) {
-        goto exit;
-    }
-    if (strlen(backend) != (size_t)backend_length) {
-        PyErr_SetString(PyExc_ValueError, "embedded null character");
         goto exit;
     }
     return_value = sys_activate_stack_trampoline_impl(module, backend);
@@ -1452,4 +1447,4 @@ exit:
 #ifndef SYS_GETANDROIDAPILEVEL_METHODDEF
     #define SYS_GETANDROIDAPILEVEL_METHODDEF
 #endif /* !defined(SYS_GETANDROIDAPILEVEL_METHODDEF) */
-/*[clinic end generated code: output=f36d45c829250775 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=cdfb714878deeaf1 input=a9049054013a1b77]*/

--- a/Tools/clinic/clinic.py
+++ b/Tools/clinic/clinic.py
@@ -4350,32 +4350,21 @@ class str_converter(CConverter):
                     {bad_argument}
                     goto exit;
                 }}}}
-                Py_ssize_t {length_name};
-                {paramname} = PyUnicode_AsUTF8AndSize({argname}, &{length_name});
+                {paramname} = PyUnicode_AsUTF8({argname});
                 if ({paramname} == NULL) {{{{
-                    goto exit;
-                }}}}
-                if (strlen({paramname}) != (size_t){length_name}) {{{{
-                    PyErr_SetString(PyExc_ValueError, "embedded null character");
                     goto exit;
                 }}}}
                 """,
                 argname=argname,
-                bad_argument=self.bad_argument(displayname, 'str', limited_capi=limited_capi),
-                length_name=self.length_name)
+                bad_argument=self.bad_argument(displayname, 'str', limited_capi=limited_capi))
         if self.format_unit == 'z':
             return self.format_code("""
                 if ({argname} == Py_None) {{{{
                     {paramname} = NULL;
                 }}}}
                 else if (PyUnicode_Check({argname})) {{{{
-                    Py_ssize_t {length_name};
-                    {paramname} = PyUnicode_AsUTF8AndSize({argname}, &{length_name});
+                    {paramname} = PyUnicode_AsUTF8({argname});
                     if ({paramname} == NULL) {{{{
-                        goto exit;
-                    }}}}
-                    if (strlen({paramname}) != (size_t){length_name}) {{{{
-                        PyErr_SetString(PyExc_ValueError, "embedded null character");
                         goto exit;
                     }}}}
                 }}}}
@@ -4385,8 +4374,7 @@ class str_converter(CConverter):
                 }}}}
                 """,
                 argname=argname,
-                bad_argument=self.bad_argument(displayname, 'str or None', limited_capi=limited_capi),
-                length_name=self.length_name)
+                bad_argument=self.bad_argument(displayname, 'str or None', limited_capi=limited_capi))
         return super().parse_arg(argname, displayname, limited_capi=limited_capi)
 
 #


### PR DESCRIPTION
Replace PyUnicode_AsUTF8AndSize() with PyUnicode_AsUTF8() to remove the explicit check for embedded null characters.

The change avoids to have to include explicitly <string.h> to get the strlen() function when using a recent version of the limited C API.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-111089 -->
* Issue: gh-111089
<!-- /gh-issue-number -->
