### PR TITLE
gh-111089: Add cache to PyUnicode_AsUTF8() for embedded NUL

### DIFF
--- a/Doc/whatsnew/3.13.rst
+++ b/Doc/whatsnew/3.13.rst
@@ -1120,6 +1120,13 @@ New Features
 * Add :c:func:`PyUnicode_AsUTF8` function to the limited C API.
   (Contributed by Victor Stinner in :gh:`111089`.)
 
+* Add ``PyASCIIObject.state.embed_null`` member to Python :class:`str` objects.
+  It is used as a cache by :c:func:`PyUnicode_AsUTF8` to only check once if a
+  string contains a null character. Strings created by
+  :c:func:`PyUnicode_FromString` initializes *embed_null* to 0 since the string
+  cannot contain a null character.
+  (Contributed by Victor Stinner in :gh:`111089`.)
+
 
 Porting to Python 3.13
 ----------------------
@@ -1192,7 +1199,7 @@ Porting to Python 3.13
 
 * The :c:func:`PyUnicode_AsUTF8` function now raises an exception if the string
   contains embedded null characters. To accept embedded null characters and
-  truncate on purpose at the first null byte,
+  truncate on purpose at the first null character,
   ``PyUnicode_AsUTF8AndSize(unicode, NULL)`` can be used instead.
   (Contributed by Victor Stinner in :gh:`111089`.)
 

--- a/Include/cpython/unicodeobject.h
+++ b/Include/cpython/unicodeobject.h
@@ -142,9 +142,16 @@ typedef struct {
         unsigned int ascii:1;
         /* The object is statically allocated. */
         unsigned int statically_allocated:1;
+        // Does the string embed null characters? Possible values:
+        //   0: No
+        //   1: Yes
+        //   2: Unknown, the string must be scanned
+        //   3: Invalid state (must not be used)
+        // Cache used by PyUnicode_AsUTF8() to avoid calling strlen().
+        unsigned int embed_null:2;
         /* Padding to ensure that PyUnicode_DATA() is always aligned to
            4 bytes (see issue #19537 on m68k). */
-        unsigned int :24;
+        unsigned int :22;
     } state;
 } PyASCIIObject;
 

--- a/Include/internal/pycore_runtime_init.h
+++ b/Include/internal/pycore_runtime_init.h
@@ -215,7 +215,7 @@ extern PyTypeObject _PyExc_MemoryError;
         _PyBytes_SIMPLE_INIT((CH), 1) \
     }
 
-#define _PyUnicode_ASCII_BASE_INIT(LITERAL, ASCII) \
+#define _PyUnicode_ASCII_BASE_INIT(LITERAL, ASCII, EMBED_NUL) \
     { \
         .ob_base = _PyObject_HEAD_INIT(&PyUnicode_Type), \
         .length = sizeof(LITERAL) - 1, \
@@ -225,11 +225,17 @@ extern PyTypeObject _PyExc_MemoryError;
             .compact = 1, \
             .ascii = (ASCII), \
             .statically_allocated = 1, \
+            .embed_null = (EMBED_NUL), \
         }, \
     }
 #define _PyASCIIObject_INIT(LITERAL) \
     { \
-        ._ascii = _PyUnicode_ASCII_BASE_INIT((LITERAL), 1), \
+        ._ascii = _PyUnicode_ASCII_BASE_INIT((LITERAL), 1, 0), \
+        ._data = (LITERAL) \
+    }
+#define _PyASCIIObject_INIT_embed_null(LITERAL) \
+    { \
+        ._ascii = _PyUnicode_ASCII_BASE_INIT((LITERAL), 1, 1), \
         ._data = (LITERAL) \
     }
 #define INIT_STR(NAME, LITERAL) \
@@ -239,7 +245,7 @@ extern PyTypeObject _PyExc_MemoryError;
 #define _PyUnicode_LATIN1_INIT(LITERAL, UTF8) \
     { \
         ._latin1 = { \
-            ._base = _PyUnicode_ASCII_BASE_INIT((LITERAL), 0), \
+            ._base = _PyUnicode_ASCII_BASE_INIT((LITERAL), 0, 0), \
             .utf8 = (UTF8), \
             .utf8_length = sizeof(UTF8) - 1, \
         }, \

--- a/Include/internal/pycore_runtime_init_generated.h
+++ b/Include/internal/pycore_runtime_init_generated.h
@@ -1259,7 +1259,7 @@ extern "C" {
 }
 
 #define _Py_str_ascii_INIT { \
-    _PyASCIIObject_INIT("\x00"), \
+    _PyASCIIObject_INIT_embed_null("\x00"), \
     _PyASCIIObject_INIT("\x01"), \
     _PyASCIIObject_INIT("\x02"), \
     _PyASCIIObject_INIT("\x03"), \

--- a/Misc/NEWS.d/next/C API/2023-11-01-03-18-21.gh-issue-111089.GxXlz0.rst
+++ b/Misc/NEWS.d/next/C API/2023-11-01-03-18-21.gh-issue-111089.GxXlz0.rst
@@ -1,5 +1,5 @@
 Add ``PyASCIIObject.state.embed_null`` member to Python str objects. It is
 used as a cache by :c:func:`PyUnicode_AsUTF8` to only check once if a string
 contains a null character. Strings created by :c:func:`PyUnicode_FromString`
-initializes *embed_null* since the string cannot contain a null character.
+initializes *embed_null* to 0 since the string cannot contain a null character.
 Patch by Victor Stinner.

--- a/Misc/NEWS.d/next/C API/2023-11-01-03-18-21.gh-issue-111089.GxXlz0.rst
+++ b/Misc/NEWS.d/next/C API/2023-11-01-03-18-21.gh-issue-111089.GxXlz0.rst
@@ -1,0 +1,5 @@
+Add ``PyASCIIObject.state.embed_null`` member to Python str objects. It is
+used as a cache by :c:func:`PyUnicode_AsUTF8` to only check once if a string
+contains a null character. Strings created by :c:func:`PyUnicode_FromString`
+initializes *embed_null* since the string cannot contain a null character.
+Patch by Victor Stinner.

--- a/Modules/_testcapi/unicode.c
+++ b/Modules/_testcapi/unicode.c
@@ -301,7 +301,12 @@ unicode_fromstring(PyObject *self, PyObject *arg)
     if (!PyArg_Parse(arg, "z#", &s, &size)) {
         return NULL;
     }
-    return PyUnicode_FromString(s);
+    PyObject *unicode = PyUnicode_FromString(s);
+    if (unicode == NULL) {
+        return NULL;
+    }
+    assert(((PyASCIIObject*)unicode)->state.embed_null == 0);
+    return unicode;
 }
 
 /* Test PyUnicode_FromKindAndData() */

--- a/Modules/_testcapi/unicode.c
+++ b/Modules/_testcapi/unicode.c
@@ -301,12 +301,7 @@ unicode_fromstring(PyObject *self, PyObject *arg)
     if (!PyArg_Parse(arg, "z#", &s, &size)) {
         return NULL;
     }
-    PyObject *unicode = PyUnicode_FromString(s);
-    if (unicode == NULL) {
-        return NULL;
-    }
-    assert(((PyASCIIObject*)unicode)->state.embed_null == 0);
-    return unicode;
+    return PyUnicode_FromString(s);
 }
 
 /* Test PyUnicode_FromKindAndData() */

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -189,6 +189,8 @@ NOTE: In the interpreter's initialization phase, some globals are currently
 #  define OVERALLOCATE_FACTOR 4
 #endif
 
+#define EMBED_NULL_UNKNOWN 2
+
 /* Forward declaration */
 static inline int
 _PyUnicodeWriter_WriteCharInline(_PyUnicodeWriter *writer, Py_UCS4 ch);
@@ -628,7 +630,7 @@ _PyUnicode_CheckConsistency(PyObject *op, int check_content)
         CHECK(PyUnicode_READ(kind, data, ascii->length) == 0);
     }
 
-    if (_PyUnicode_STATE(ascii).embed_null != 2) {
+    if (_PyUnicode_STATE(ascii).embed_null != EMBED_NULL_UNKNOWN) {
         Py_ssize_t pos = findchar(PyUnicode_DATA(ascii),
                                   PyUnicode_KIND(ascii),
                                   PyUnicode_GET_LENGTH(ascii),
@@ -1266,7 +1268,7 @@ PyUnicode_New(Py_ssize_t size, Py_UCS4 maxchar)
     _PyUnicode_STATE(unicode).compact = 1;
     _PyUnicode_STATE(unicode).ascii = is_ascii;
     _PyUnicode_STATE(unicode).statically_allocated = 0;
-    _PyUnicode_STATE(unicode).embed_null = 2;
+    _PyUnicode_STATE(unicode).embed_null = EMBED_NULL_UNKNOWN;
     if (is_ascii) {
         ((char*)data)[size] = 0;
     }
@@ -3876,7 +3878,7 @@ PyUnicode_AsUTF8(PyObject *unicode)
 
     // Cache to avoid calling O(n) strlen() operation at every
     // PyUnicode_AsUTF8() call on the same object.
-    if (_PyUnicode_STATE(unicode).embed_null == 2) {
+    if (_PyUnicode_STATE(unicode).embed_null == EMBED_NULL_UNKNOWN) {
         if (strlen(utf8) != (size_t)size) {
             _PyUnicode_STATE(unicode).embed_null = 1;
         }
@@ -14668,7 +14670,7 @@ unicode_subtype_new(PyTypeObject *type, PyObject *unicode)
     _PyUnicode_STATE(self).compact = 0;
     _PyUnicode_STATE(self).ascii = _PyUnicode_STATE(unicode).ascii;
     _PyUnicode_STATE(self).statically_allocated = 0;
-    _PyUnicode_STATE(self).embed_null = 2;
+    _PyUnicode_STATE(self).embed_null = EMBED_NULL_UNKNOWN;
     _PyUnicode_UTF8_LENGTH(self) = 0;
     _PyUnicode_UTF8(self) = NULL;
     _PyUnicode_DATA_ANY(self) = NULL;

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -1015,6 +1015,7 @@ resize_compact(PyObject *unicode, Py_ssize_t length)
         _PyUnicode_UTF8(unicode) = NULL;
         _PyUnicode_UTF8_LENGTH(unicode) = 0;
     }
+    _PyUnicode_STATE(unicode).embed_null = EMBED_NULL_UNKNOWN;
 #ifdef Py_TRACE_REFS
     _Py_ForgetReference(unicode);
 #endif
@@ -1068,6 +1069,7 @@ resize_inplace(PyObject *unicode, Py_ssize_t length)
         _PyUnicode_UTF8(unicode) = NULL;
         _PyUnicode_UTF8_LENGTH(unicode) = 0;
     }
+    _PyUnicode_STATE(unicode).embed_null = EMBED_NULL_UNKNOWN;
 
     data = (PyObject *)PyObject_Realloc(data, new_size);
     if (data == NULL) {
@@ -11082,6 +11084,7 @@ PyUnicode_Append(PyObject **p_left, PyObject *right)
         Py_DECREF(left);
         *p_left = res;
     }
+    assert(_PyUnicode_STATE(*p_left).embed_null == EMBED_NULL_UNKNOWN);
     assert(_PyUnicode_CheckConsistency(*p_left, 1));
     return;
 

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -14668,6 +14668,7 @@ unicode_subtype_new(PyTypeObject *type, PyObject *unicode)
     _PyUnicode_STATE(self).compact = 0;
     _PyUnicode_STATE(self).ascii = _PyUnicode_STATE(unicode).ascii;
     _PyUnicode_STATE(self).statically_allocated = 0;
+    _PyUnicode_STATE(self).embed_null = 2;
     _PyUnicode_UTF8_LENGTH(self) = 0;
     _PyUnicode_UTF8(self) = NULL;
     _PyUnicode_DATA_ANY(self) = NULL;

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -3880,19 +3880,21 @@ PyUnicode_AsUTF8(PyObject *unicode)
 
     // Cache to avoid calling O(n) strlen() operation at every
     // PyUnicode_AsUTF8() call on the same object.
-    if (_PyUnicode_STATE(unicode).embed_null == EMBED_NULL_UNKNOWN) {
-        if (strlen(utf8) != (size_t)size) {
-            _PyUnicode_STATE(unicode).embed_null = 1;
+    if (_PyUnicode_STATE(unicode).embed_null != 0) {
+        if (_PyUnicode_STATE(unicode).embed_null == EMBED_NULL_UNKNOWN) {
+            if (strlen(utf8) != (size_t)size) {
+                _PyUnicode_STATE(unicode).embed_null = 1;
+            }
+            else {
+                _PyUnicode_STATE(unicode).embed_null = 0;
+            }
         }
-        else {
-            _PyUnicode_STATE(unicode).embed_null = 0;
-        }
-    }
 
-    if (_PyUnicode_STATE(unicode).embed_null == 1) {
-        PyErr_SetString(PyExc_ValueError,
-                        "embedded null character");
-        return NULL;
+        if (_PyUnicode_STATE(unicode).embed_null == 1) {
+            PyErr_SetString(PyExc_ValueError,
+                            "embedded null character");
+            return NULL;
+        }
     }
 
     return utf8;

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -633,7 +633,7 @@ _PyUnicode_CheckConsistency(PyObject *op, int check_content)
                                   PyUnicode_KIND(ascii),
                                   PyUnicode_GET_LENGTH(ascii),
                                   0, 1);
-        assert(_PyUnicode_STATE(ascii).embed_null == (pos >= 0));
+        CHECK(_PyUnicode_STATE(ascii).embed_null == (pos >= 0));
     }
 
     return 1;


### PR DESCRIPTION
Add PyASCIIObject.state.embed_null member to Python str objects. It is used as a cache by PyUnicode_AsUTF8() to only check once if a string contains a null character. Strings created by PyUnicode_FromString() initializes *embed_null* since the string cannot contain a null character.

Global static strings now also initialize the *embed_null* member. The chr(0) singleton ("\0" string) is the only static string which contains a null character.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-111089 -->
* Issue: gh-111089
<!-- /gh-issue-number -->
