### PR TITLE
[3.12] gh-110968: Py_MOD_PER_INTERPRETER_GIL_SUPPORTED was added to 3.12

### DIFF
--- a/Include/moduleobject.h
+++ b/Include/moduleobject.h
@@ -84,12 +84,14 @@ struct PyModuleDef_Slot {
 #define _Py_mod_LAST_SLOT 3
 #endif
 
-/* for Py_mod_multiple_interpreters: */
-#define Py_MOD_MULTIPLE_INTERPRETERS_NOT_SUPPORTED ((void *)0)
-#define Py_MOD_MULTIPLE_INTERPRETERS_SUPPORTED ((void *)1)
-#define Py_MOD_PER_INTERPRETER_GIL_SUPPORTED ((void *)2)
-
 #endif /* New in 3.5 */
+
+/* for Py_mod_multiple_interpreters: */
+#if !defined(Py_LIMITED_API) || Py_LIMITED_API+0 >= 0x030c0000
+#  define Py_MOD_MULTIPLE_INTERPRETERS_NOT_SUPPORTED ((void *)0)
+#  define Py_MOD_MULTIPLE_INTERPRETERS_SUPPORTED ((void *)1)
+#  define Py_MOD_PER_INTERPRETER_GIL_SUPPORTED ((void *)2)
+#endif
 
 struct PyModuleDef {
   PyModuleDef_Base m_base;

--- a/Modules/xxlimited.c
+++ b/Modules/xxlimited.c
@@ -62,7 +62,8 @@
           pass
    */
 
-#define Py_LIMITED_API 0x030b0000
+// Need limited C API version 3.12 for Py_MOD_PER_INTERPRETER_GIL_SUPPORTED
+#define Py_LIMITED_API 0x030c0000
 
 #include "Python.h"
 #include <string.h>

--- a/Modules/xxlimited_35.c
+++ b/Modules/xxlimited_35.c
@@ -293,7 +293,6 @@ xx_modexec(PyObject *m)
 
 static PyModuleDef_Slot xx_slots[] = {
     {Py_mod_exec, xx_modexec},
-    {Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
     {0, NULL}
 };
 


### PR DESCRIPTION
Constants like Py_MOD_PER_INTERPRETER_GIL_SUPPORTED were only added to the limited C API version 3.12 and newer.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-110968 -->
* Issue: gh-110968
<!-- /gh-issue-number -->
