### PR TITLE
gh-111089: Use PyUnicode_AsUTF8() in getargs.c

### DIFF
--- a/Python/getargs.c
+++ b/Python/getargs.c
@@ -932,19 +932,15 @@ convertsimple(PyObject *arg, const char **p_format, va_list *p_va, int flags,
         } else {
             /* "s" or "z" */
             const char **p = va_arg(*p_va, const char **);
-            Py_ssize_t len;
             sarg = NULL;
 
             if (c == 'z' && arg == Py_None)
                 *p = NULL;
             else if (PyUnicode_Check(arg)) {
-                sarg = PyUnicode_AsUTF8AndSize(arg, &len);
-                if (sarg == NULL)
+                sarg = PyUnicode_AsUTF8(arg);
+                if (sarg == NULL) {
                     return converterr(CONV_UNICODE,
                                       arg, msgbuf, bufsize);
-                if (strlen(sarg) != (size_t)len) {
-                    PyErr_SetString(PyExc_ValueError, "embedded null character");
-                    RETURN_ERR_OCCURRED;
                 }
                 *p = sarg;
             }


### PR DESCRIPTION
Replace PyUnicode_AsUTF8AndSize() with PyUnicode_AsUTF8() to remove the explicit check for embedded null characters.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-111089 -->
* Issue: gh-111089
<!-- /gh-issue-number -->
