### PR TITLE
gh-111625: Fix link to Info-ZIP homepage

### DIFF
--- a/Doc/tools/templates/download.html
+++ b/Doc/tools/templates/download.html
@@ -49,12 +49,12 @@ Python in one of various formats, follow one of links in this table.</p>
 
 <p>Unix users should download the .tar.bz2 archives; these are bzipped tar
 archives and can be handled in the usual way using tar and the bzip2
-program. The <a href="http://www.info-zip.org">InfoZIP</a> unzip program can be
+program. The <a href="https://infozip.sourceforge.net">Info-ZIP</a> unzip program can be
 used to handle the ZIP archives if desired. The .tar.bz2 archives provide the
 best compression and fastest download times.</p>
 
 <p>Windows users can use the ZIP archives since those are customary on that
-platform. These are created on Unix using the InfoZIP zip program.</p>
+platform. These are created on Unix using the Info-ZIP zip program.</p>
 
 
 <h2>Problems</h2>

--- a/Lib/test/ziptestdata/README.md
+++ b/Lib/test/ziptestdata/README.md
@@ -1,7 +1,7 @@
 # Test data for `test_zipfile`
 
 The test executables in this directory are created manually from header.sh and
-the `testdata_module_inside_zip.py` file.  You must have infozip's zip utility
+the `testdata_module_inside_zip.py` file.  You must have Info-ZIP's zip utility
 installed (`apt install zip` on Debian).
 
 ## Purpose
@@ -25,7 +25,7 @@ rm zip2.zip
 
 ### Modern format (4.5) zip64 file
 
-Redirecting from stdin forces infozip's zip tool to create a zip64.
+Redirecting from stdin forces Info-ZIP's zip tool to create a zip64.
 
 ```
 zip -0 <testdata_module_inside_zip.py >zip64.zip


### PR DESCRIPTION
fix gh-111625 fix link redirect and correct spelling of Info-ZIP

<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--111626.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->