### PR TITLE
gh-111301: Advertise importlib methods removal in What's new in Python 3.12

### DIFF
--- a/Doc/whatsnew/3.12.rst
+++ b/Doc/whatsnew/3.12.rst
@@ -1371,6 +1371,18 @@ APIs:
 * :meth:`!unittest.TestProgram.usageExit` (:gh:`67048`)
 * :class:`!webbrowser.MacOSX` (:gh:`86421`)
 * :class:`classmethod` descriptor chaining (:gh:`89519`)
+* :mod:`importlib.resources` deprecated methods:
+
+  * ``contents()``
+  * ``is_resource()``
+  * ``open_binary()``
+  * ``open_text()``
+  * ``path()``
+  * ``read_binary()``
+  * ``read_text()``
+
+  Use :func:`importlib.resources.files()` instead.  Refer to `importlib-resources: Migrating from Legacy
+  <https://importlib-resources.readthedocs.io/en/latest/using.html#migrating-from-legacy>`_ (:gh:`106531`)
 
 Pending Removal in Python 3.14
 ------------------------------


### PR DESCRIPTION
Addendum to the previously reported changes.
I came across the remark from the community member and realized this is true:

>  Nor does the Python 3.12.0 documentation state that this is going to be removed in Python 3.13 (or 3.14).
See: https://github.com/linkchecker/linkchecker/issues/768#issuecomment-1789540050

I want to bridge the information gap with this PR.

<!-- gh-issue-number: gh-111301 -->
* Issue: gh-111301
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--111630.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->