### PR TITLE
gh-111652: Fix --enable-pystats build

### DIFF
--- a/Include/internal/pycore_code.h
+++ b/Include/internal/pycore_code.h
@@ -271,6 +271,8 @@ extern int _PyStaticCode_Init(PyCodeObject *co);
 
 #ifdef Py_STATS
 
+#include "pycore_bitutils.h"  // _Py_bit_length
+
 #define STAT_INC(opname, name) do { if (_Py_stats) _Py_stats->opcode_stats[opname].specialization.name++; } while (0)
 #define STAT_DEC(opname, name) do { if (_Py_stats) _Py_stats->opcode_stats[opname].specialization.name--; } while (0)
 #define OPCODE_EXE_INC(opname) do { if (_Py_stats) _Py_stats->opcode_stats[opname].execution_count++; } while (0)


### PR DESCRIPTION
7e135a moved code around such that _Py_bit_length was no longer visible to OPT_HIST. This includes "pycore_bitutils.h" to address that.


<!-- gh-issue-number: gh-111652 -->
* Issue: gh-111652
<!-- /gh-issue-number -->
