### PR TITLE
gh-111654: remove redundant decref on the eval stack value

### DIFF
--- a/Lib/test/test_exceptions.py
+++ b/Lib/test/test_exceptions.py
@@ -1844,6 +1844,13 @@ class NameErrorTests(unittest.TestCase):
         self.assertIn("nonsense", err.getvalue())
         self.assertIn("ZeroDivisionError", err.getvalue())
 
+    def test_gh_111654(self):
+        def f():
+            class TestClass:
+                TestClass
+
+        self.assertRaises(NameError, f)
+
     # Note: name suggestion tests live in `test_traceback`.
 
 

--- a/Misc/NEWS.d/next/Core and Builtins/2023-11-03-01-04-55.gh-issue-111654.scUhDO.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2023-11-03-01-04-55.gh-issue-111654.scUhDO.rst
@@ -1,0 +1,2 @@
+Fix runtime crash when some error happens in opcode
+``LOAD_FROM_DICT_OR_DEREF``.

--- a/Python/bytecodes.c
+++ b/Python/bytecodes.c
@@ -1537,10 +1537,8 @@ dummy_func(
             assert(oparg >= 0 && oparg < _PyFrame_GetCode(frame)->co_nlocalsplus);
             name = PyTuple_GET_ITEM(_PyFrame_GetCode(frame)->co_localsplusnames, oparg);
             if (PyMapping_GetOptionalItem(class_dict, name, &value) < 0) {
-                Py_DECREF(class_dict);
                 GOTO_ERROR(error);
             }
-            Py_DECREF(class_dict);
             if (!value) {
                 PyObject *cell = GETLOCAL(oparg);
                 value = PyCell_GET(cell);
@@ -1550,6 +1548,7 @@ dummy_func(
                 }
                 Py_INCREF(value);
             }
+            Py_DECREF(class_dict);
         }
 
         inst(LOAD_DEREF, ( -- value)) {

--- a/Python/executor_cases.c.h
+++ b/Python/executor_cases.c.h
@@ -1241,10 +1241,8 @@
             assert(oparg >= 0 && oparg < _PyFrame_GetCode(frame)->co_nlocalsplus);
             name = PyTuple_GET_ITEM(_PyFrame_GetCode(frame)->co_localsplusnames, oparg);
             if (PyMapping_GetOptionalItem(class_dict, name, &value) < 0) {
-                Py_DECREF(class_dict);
                 GOTO_ERROR(error);
             }
-            Py_DECREF(class_dict);
             if (!value) {
                 PyObject *cell = GETLOCAL(oparg);
                 value = PyCell_GET(cell);
@@ -1254,6 +1252,7 @@
                 }
                 Py_INCREF(value);
             }
+            Py_DECREF(class_dict);
             stack_pointer[-1] = value;
             break;
         }

--- a/Python/generated_cases.c.h
+++ b/Python/generated_cases.c.h
@@ -2206,10 +2206,8 @@
             assert(oparg >= 0 && oparg < _PyFrame_GetCode(frame)->co_nlocalsplus);
             name = PyTuple_GET_ITEM(_PyFrame_GetCode(frame)->co_localsplusnames, oparg);
             if (PyMapping_GetOptionalItem(class_dict, name, &value) < 0) {
-                Py_DECREF(class_dict);
                 GOTO_ERROR(error);
             }
-            Py_DECREF(class_dict);
             if (!value) {
                 PyObject *cell = GETLOCAL(oparg);
                 value = PyCell_GET(cell);
@@ -2219,6 +2217,7 @@
                 }
                 Py_INCREF(value);
             }
+            Py_DECREF(class_dict);
             stack_pointer[-1] = value;
             DISPATCH();
         }


### PR DESCRIPTION
This is just like https://github.com/python/cpython/pull/109123, but for another OP code. In the error path, the `class_dict` is still on the value stack, and the error unwinding process will call decref on it. So we should remove the decref in error path, or there will be a double decref, and cause the ref count to negative in the GC process, and leads to the runtime crash.

<!-- gh-issue-number: gh-111654 -->
* Issue: gh-111654
<!-- /gh-issue-number -->
