### PR TITLE
Fix typo in documentation of `SysLogHandler.createSocket`

### DIFF
--- a/Doc/library/logging.handlers.rst
+++ b/Doc/library/logging.handlers.rst
@@ -656,9 +656,7 @@ supports sending logging messages to a remote or local Unix syslog.
       to the other end. This method is called during handler initialization,
       but it's not regarded as an error if the other end isn't listening at
       this point - the method will be called again when emitting an event, if
-      but it's not regarded as an error if the other end isn't listening yet
-      --- the method will be called again when emitting an event,
-      if there is no socket at that point.
+      there is no socket at that point.
 
       .. versionadded:: 3.11
 


### PR DESCRIPTION
Part of the text was duplicated, so I deleted it.

(I consider this a "typo", so I didn't file an issue and made a PR directly)


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--111665.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->