### PR TITLE
gh-111681: Fix doctests in `typing.rst` and remove unused imports

### DIFF
--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -643,15 +643,10 @@ with type variables' described above as parameter specification variables are
 treated by the typing module as a specialized type variable.  The one exception
 to this is that a list of types can be used to substitute a :class:`ParamSpec`:
 
-.. doctest::
-
    >>> class Z[T, **P]: ...  # T is a TypeVar; P is a ParamSpec
    ...
    >>> Z[int, [dict, float]]
    __main__.Z[int, [dict, float]]
-
-   >>> 1 + 2
-   4
 
 Classes generic over a :class:`ParamSpec` can also be created using explicit
 inheritance from :class:`Generic`. In this case, ``**`` is not used::
@@ -3070,7 +3065,8 @@ Introspection helpers
       >>> class P(Protocol):
       ...     def a(self) -> str: ...
       ...     b: int
-      >>> assert get_protocol_members(P) == frozenset({'a', 'b'})
+      >>> get_protocol_members(P) == frozenset({'a', 'b'})
+      True
 
    Raise :exc:`TypeError` for arguments that are not Protocols.
 

--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -3059,7 +3059,7 @@ Introspection helpers
 
    Return the set of members defined in a :class:`Protocol`.
 
-   ::
+   .. doctest::
 
       >>> from typing import Protocol, get_protocol_members
       >>> class P(Protocol):

--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -641,7 +641,7 @@ User-defined generics for parameter expressions are also supported via parameter
 specification variables in the form ``[**P]``.  The behavior is consistent
 with type variables' described above as parameter specification variables are
 treated by the typing module as a specialized type variable.  The one exception
-to this is that a list of types can be used to substitute a :class:`ParamSpec`:
+to this is that a list of types can be used to substitute a :class:`ParamSpec`::
 
    >>> class Z[T, **P]: ...  # T is a TypeVar; P is a ParamSpec
    ...

--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -1954,7 +1954,7 @@ without the dedicated syntax, as documented below.
 
    .. doctest::
 
-      >>> from typing import ParamSpec
+      >>> from typing import ParamSpec, get_origin
       >>> P = ParamSpec("P")
       >>> get_origin(P.args) is P
       True
@@ -3065,8 +3065,7 @@ Introspection helpers
       >>> class P(Protocol):
       ...     def a(self) -> str: ...
       ...     b: int
-      >>> get_protocol_members(P)
-      frozenset({'a', 'b'})
+      >>> assert get_protocol_members(P) == frozenset({'a', 'b'})
 
    Raise :exc:`TypeError` for arguments that are not Protocols.
 

--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -648,6 +648,9 @@ to this is that a list of types can be used to substitute a :class:`ParamSpec`::
    >>> Z[int, [dict, float]]
    __main__.Z[int, [dict, float]]
 
+   >>> 1 + 2
+   4
+
 Classes generic over a :class:`ParamSpec` can also be created using explicit
 inheritance from :class:`Generic`. In this case, ``**`` is not used::
 

--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -641,7 +641,9 @@ User-defined generics for parameter expressions are also supported via parameter
 specification variables in the form ``[**P]``.  The behavior is consistent
 with type variables' described above as parameter specification variables are
 treated by the typing module as a specialized type variable.  The one exception
-to this is that a list of types can be used to substitute a :class:`ParamSpec`::
+to this is that a list of types can be used to substitute a :class:`ParamSpec`:
+
+.. doctest::
 
    >>> class Z[T, **P]: ...  # T is a TypeVar; P is a ParamSpec
    ...

--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -9,8 +9,9 @@ import itertools
 import pickle
 import re
 import sys
-import warnings
-from unittest import TestCase, main, skipUnless, skip
+import os
+import doctest
+from unittest import TestCase, main, skip
 from unittest.mock import patch
 from copy import copy, deepcopy
 
@@ -45,7 +46,7 @@ import typing
 import weakref
 import types
 
-from test.support import import_helper, captured_stderr, cpython_only
+from test.support import captured_stderr, cpython_only, REPO_ROOT
 from test import mod_generics_cache
 from test import _typed_dict_helper
 
@@ -9463,6 +9464,16 @@ class TypeIterationTests(BaseTestCase):
     def test_is_not_instance_of_iterable(self):
         for type_to_test in self._UNITERABLE_TYPES:
             self.assertNotIsInstance(type_to_test, collections.abc.Iterable)
+
+
+def load_tests(loader, tests, pattern):
+    tests.addTests(doctest.DocFileSuite(
+        os.path.join(REPO_ROOT, 'Doc/library/typing.rst'),
+        module_relative=False,
+        # Some tests in `typing.rst` pretend to be executed in `__main__`:
+        globs={'__name__': '__main__'},
+    ))
+    return tests
 
 
 if __name__ == '__main__':

--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -9,8 +9,6 @@ import itertools
 import pickle
 import re
 import sys
-import os
-import doctest
 from unittest import TestCase, main, skip
 from unittest.mock import patch
 from copy import copy, deepcopy
@@ -46,7 +44,7 @@ import typing
 import weakref
 import types
 
-from test.support import captured_stderr, cpython_only, REPO_ROOT
+from test.support import captured_stderr, cpython_only
 from test import mod_generics_cache
 from test import _typed_dict_helper
 
@@ -9464,16 +9462,6 @@ class TypeIterationTests(BaseTestCase):
     def test_is_not_instance_of_iterable(self):
         for type_to_test in self._UNITERABLE_TYPES:
             self.assertNotIsInstance(type_to_test, collections.abc.Iterable)
-
-
-def load_tests(loader, tests, pattern):
-    tests.addTests(doctest.DocFileSuite(
-        os.path.join(REPO_ROOT, 'Doc/library/typing.rst'),
-        module_relative=False,
-        # Some tests in `typing.rst` pretend to be executed in `__main__`:
-        globs={'__name__': '__main__'},
-    ))
-    return tests
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Without `globs` it would fail:

```pytb
» ./python.exe -m test test_typing
Using random seed: 1924694082
0:00:00 load avg: 1.95 Run 1 test sequentially
0:00:00 load avg: 1.95 [1/1] test_typing
test test_typing failed -- Traceback (most recent call last):
  File "/Users/sobolev/Desktop/cpython2/Lib/doctest.py", line 2263, in runTest
    raise self.failureException(self.format_failure(new.getvalue()))
AssertionError: Failed doctest test for typing.rst
  File "/Users/sobolev/Desktop/cpython2/Doc/library/typing.rst", line 0

----------------------------------------------------------------------
File "/Users/sobolev/Desktop/cpython2/Doc/library/typing.rst", line 648, in typing.rst
Failed example:
    Z[int, [dict, float]]
Expected:
    __main__.Z[int, [dict, float]]
Got:
    Z[int, [dict, float]]
----------------------------------------------------------------------
File "/Users/sobolev/Desktop/cpython2/Doc/library/typing.rst", line 669, in typing.rst
Failed example:
    X[int, str]
Expected:
    __main__.X[[int, str]]
Got:
    X[[int, str]]
----------------------------------------------------------------------
File "/Users/sobolev/Desktop/cpython2/Doc/library/typing.rst", line 671, in typing.rst
Failed example:
    X[[int, str]]
Expected:
    __main__.X[[int, str]]
Got:
    X[[int, str]]
----------------------------------------------------------------------
File "/Users/sobolev/Desktop/cpython2/Doc/library/typing.rst", line 1996, in typing.rst
Failed example:
    Alias.__module__
Expected:
    '__main__'
Got nothing
```

<!-- gh-issue-number: gh-111681 -->
* Issue: gh-111681
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--111682.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->