### PR TITLE
gh-106168: Revert the "size before item" setting

### DIFF
--- a/Doc/whatsnew/3.13.rst
+++ b/Doc/whatsnew/3.13.rst
@@ -1048,8 +1048,6 @@ New Features
 * If Python is built in :ref:`debug mode <debug-build>` or :option:`with
   assertions <--with-assertions>`, :c:func:`PyTuple_SET_ITEM` and
   :c:func:`PyList_SET_ITEM` now check the index argument with an assertion.
-  If the assertion fails in :c:func:`PyTuple_SET_ITEM`, make sure that the
-  tuple size is set before.
   (Contributed by Victor Stinner in :gh:`106168`.)
 
 * Add :c:func:`PyModule_Add` function: similar to

--- a/Include/internal/pycore_list.h
+++ b/Include/internal/pycore_list.h
@@ -51,8 +51,8 @@ _PyList_AppendTakeRef(PyListObject *self, PyObject *newitem)
     Py_ssize_t allocated = self->allocated;
     assert((size_t)len + 1 < PY_SSIZE_T_MAX);
     if (allocated > len) {
-        Py_SET_SIZE(self, len + 1);
         PyList_SET_ITEM(self, len, newitem);
+        Py_SET_SIZE(self, len + 1);
         return 0;
     }
     return _PyList_AppendTakeRefListResize(self, newitem);

--- a/Objects/listobject.c
+++ b/Objects/listobject.c
@@ -956,8 +956,8 @@ list_extend(PyListObject *self, PyObject *iterable)
         if (Py_SIZE(self) < self->allocated) {
             /* steals ref */
             Py_ssize_t len = Py_SIZE(self);
-            Py_SET_SIZE(self, len + 1);
             PyList_SET_ITEM(self, len, item);
+            Py_SET_SIZE(self, len + 1);
         }
         else {
             if (_PyList_AppendTakeRef(self, item) < 0)


### PR DESCRIPTION
Update the size only after setting the item, to avoid temporary inconsistencies.

Also remove the "what's new" sentence regarding the size setting since tuples cannot grow after allocation.

<!-- gh-issue-number: gh-106168 -->
* Issue: gh-106168
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--111683.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->