### PR TITLE
gh-109649: Fix test_os.test_process_cpu_count_affinity()

### DIFF
--- a/Lib/test/test_os.py
+++ b/Lib/test/test_os.py
@@ -4342,8 +4342,8 @@ class CPUCountTests(unittest.TestCase):
     @unittest.skipUnless(hasattr(os, 'sched_setaffinity'),
                          "don't have sched affinity support")
     def test_process_cpu_count_affinity(self):
-        ncpu = os.cpu_count()
-        if ncpu is None:
+        affinity1 = os.process_cpu_count()
+        if affinity1 is None:
             self.skipTest("Could not determine the number of CPUs")
 
         # Disable one CPU
@@ -4356,8 +4356,8 @@ class CPUCountTests(unittest.TestCase):
         os.sched_setaffinity(0, mask)
 
         # test process_cpu_count()
-        affinity = os.process_cpu_count()
-        self.assertEqual(affinity, ncpu - 1)
+        affinity2 = os.process_cpu_count()
+        self.assertEqual(affinity2, affinity1 - 1)
 
 
 # FD inheritance check is only useful for systems with process support.


### PR DESCRIPTION
When CPUs are isolated on Linux, os.process_cpu_count() is smaller than os.cpu_count(). Fix the test for this case.

Example with "isolcpus=5,11 rcu_nocbs=5,11" options passed to a Linux command line to isolated two logical CPUs:

```
$ ./python -c 'import os; print(os.process_cpu_count(), "/", os.cpu_count())'
10 / 12
```

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
