### PR TITLE
simplify code to pop exception in frame_setlineno

### DIFF
--- a/Objects/frameobject.c
+++ b/Objects/frameobject.c
@@ -805,13 +805,10 @@ frame_setlineno(PyFrameObject *f, PyObject* p_new_lineno, void *Py_UNUSED(ignore
     while (start_stack > best_stack) {
         if (top_of_stack(start_stack) == Except) {
             /* Pop exception stack as well as the evaluation stack */
-            PyThreadState *tstate = _PyThreadState_GET();
-            _PyErr_StackItem *exc_info = tstate->exc_info;
-            PyObject *value = exc_info->exc_value;
             PyObject *exc = _PyFrame_StackPop(f->f_frame);
             assert(PyExceptionInstance_Check(exc) || exc == Py_None);
-            exc_info->exc_value = exc;
-            Py_XDECREF(value);
+            PyThreadState *tstate = _PyThreadState_GET();
+            Py_XSETREF(tstate->exc_info->exc_value, exc);
         }
         else {
             PyObject *v = _PyFrame_StackPop(f->f_frame);


### PR DESCRIPTION
The code to pop an exception from the stack in ``frame_setlineno`` is a bit convoluted - a relic of the exc_info past. This PR tides it up.

