### PR TITLE
gh-111704: Add `doctest_test_doctest_blocks` option to Sphinx

### DIFF
--- a/Doc/conf.py
+++ b/Doc/conf.py
@@ -485,3 +485,6 @@ ogp_custom_meta_tags = [
     '<meta property="og:image:height" content="200" />',
     '<meta name="theme-color" content="#3776ab" />',
 ]
+
+# sphinx-doctest config
+doctest_test_doctest_blocks = 'test'

--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -648,6 +648,9 @@ to this is that a list of types can be used to substitute a :class:`ParamSpec`::
    >>> Z[int, [dict, float]]
    __main__.Z[int, [dict, float]]
 
+   >>> 1 + 2
+   4
+
 Classes generic over a :class:`ParamSpec` can also be created using explicit
 inheritance from :class:`Generic`. In this case, ``**`` is not used::
 

--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -647,7 +647,6 @@ to this is that a list of types can be used to substitute a :class:`ParamSpec`::
    ...
    >>> Z[int, [dict, float]]
    __main__.Z[int, [dict, float]]
-
    >>> 1 + 2
    4
 


### PR DESCRIPTION
Let's see if anything changes.

<!-- gh-issue-number: gh-111704 -->
* Issue: gh-111704
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--111723.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->