### PR TITLE
gh-111724: Fix doctest `ResourceWarning` in `howto/descriptor.rst`

### DIFF
--- a/Doc/howto/descriptor.rst
+++ b/Doc/howto/descriptor.rst
@@ -943,6 +943,10 @@ it can be updated:
     >>> Movie('Star Wars').director
     'J.J. Abrams'
 
+.. testcleanup::
+
+   conn.close()
+
 
 Pure Python Equivalents
 ^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION


<!-- gh-issue-number: gh-111724 -->
* Issue: gh-111724
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--111725.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->