### PR TITLE
gh-111741: Recognise `image/webp` as a standard format in the `mimetypes` module.

### DIFF
--- a/Lib/mimetypes.py
+++ b/Lib/mimetypes.py
@@ -528,6 +528,7 @@ def _default_mime_types():
         '.tiff'   : 'image/tiff',
         '.tif'    : 'image/tiff',
         '.ico'    : 'image/vnd.microsoft.icon',
+        '.webp'   : 'image/webp',
         '.ras'    : 'image/x-cmu-raster',
         '.pnm'    : 'image/x-portable-anymap',
         '.pbm'    : 'image/x-portable-bitmap',
@@ -587,7 +588,6 @@ def _default_mime_types():
         '.pict': 'image/pict',
         '.pct' : 'image/pict',
         '.pic' : 'image/pict',
-        '.webp': 'image/webp',
         '.xul' : 'text/xul',
         }
 

--- a/Lib/test/test_mimetypes.py
+++ b/Lib/test/test_mimetypes.py
@@ -96,14 +96,12 @@ class MimeTypesTestCase(unittest.TestCase):
         # First try strict
         eq(self.db.guess_type('foo.xul', strict=True), (None, None))
         eq(self.db.guess_extension('image/jpg', strict=True), None)
-        eq(self.db.guess_extension('image/webp', strict=True), None)
         # And then non-strict
         eq(self.db.guess_type('foo.xul', strict=False), ('text/xul', None))
         eq(self.db.guess_type('foo.XUL', strict=False), ('text/xul', None))
         eq(self.db.guess_type('foo.invalid', strict=False), (None, None))
         eq(self.db.guess_extension('image/jpg', strict=False), '.jpg')
         eq(self.db.guess_extension('image/JPG', strict=False), '.jpg')
-        eq(self.db.guess_extension('image/webp', strict=False), '.webp')
 
     def test_filename_with_url_delimiters(self):
         # bpo-38449: URL delimiters cases should be handled also.
@@ -183,6 +181,7 @@ class MimeTypesTestCase(unittest.TestCase):
             self.assertEqual(mimetypes.guess_extension('application/xml'), '.xsl')
             self.assertEqual(mimetypes.guess_extension('audio/mpeg'), '.mp3')
             self.assertEqual(mimetypes.guess_extension('image/avif'), '.avif')
+            self.assertEqual(mimetypes.guess_extension('image/webp'), '.webp')
             self.assertEqual(mimetypes.guess_extension('image/jpeg'), '.jpg')
             self.assertEqual(mimetypes.guess_extension('image/tiff'), '.tiff')
             self.assertEqual(mimetypes.guess_extension('message/rfc822'), '.eml')

--- a/Misc/NEWS.d/next/Library/2023-11-04-22-32-27.gh-issue-111741.f1ufr8.rst
+++ b/Misc/NEWS.d/next/Library/2023-11-04-22-32-27.gh-issue-111741.f1ufr8.rst
@@ -1,0 +1,1 @@
+Recognise ``image/webp`` as a standard format in the :mod:`mimetypes` module.


### PR DESCRIPTION
WEBP is not recognised as a standard type and demands the user to use `strict=False` as in `mimetypes.guess_type("foobar.webp", strict=False)` to recognise it. This is because it was previously not recognised by IANA as an official type. 

Since the introduction of `webp` support in the `mimetypes` module in #89802 it has officially been accepted to IANA and thus is not a "non-standard format" anymore. 

Refs:
- https://bugs.chromium.org/p/webp/issues/detail?id=448#c46
- https://www.iana.org/assignments/media-types/media-types.xhtml#image
- https://datatracker.ietf.org/doc/draft-zern-webp/12/


<!-- gh-issue-number: gh-111741 -->
* Issue: gh-111741
<!-- /gh-issue-number -->
