### PR TITLE
[3.12] gh-110395: invalidate open kqueues after fork (GH-110517)

### DIFF
--- a/Lib/test/test_kqueue.py
+++ b/Lib/test/test_kqueue.py
@@ -5,6 +5,7 @@ import errno
 import os
 import select
 import socket
+from test import support
 import time
 import unittest
 
@@ -255,6 +256,23 @@ class TestKQueue(unittest.TestCase):
         kqueue = select.kqueue()
         self.addCleanup(kqueue.close)
         self.assertEqual(os.get_inheritable(kqueue.fileno()), False)
+
+    @support.requires_fork()
+    def test_fork(self):
+        # gh-110395: kqueue objects must be closed after fork
+        kqueue = select.kqueue()
+        if (pid := os.fork()) == 0:
+            try:
+                self.assertTrue(kqueue.closed)
+                with self.assertRaisesRegex(ValueError, "closed kqueue"):
+                    kqueue.fileno()
+            except:
+                os._exit(1)
+            finally:
+                os._exit(0)
+        else:
+            self.assertFalse(kqueue.closed)
+            support.wait_process(pid, exitcode=0)
 
 
 if __name__ == "__main__":

--- a/Lib/test/test_kqueue.py
+++ b/Lib/test/test_kqueue.py
@@ -271,8 +271,8 @@ class TestKQueue(unittest.TestCase):
             finally:
                 os._exit(0)
         else:
-            self.assertFalse(kqueue.closed)
             support.wait_process(pid, exitcode=0)
+            self.assertFalse(kqueue.closed)  # child done, we're still open.
 
 
 if __name__ == "__main__":

--- a/Misc/NEWS.d/next/Library/2023-10-08-14-17-06.gh-issue-110395._tdCsV.rst
+++ b/Misc/NEWS.d/next/Library/2023-10-08-14-17-06.gh-issue-110395._tdCsV.rst
@@ -1,0 +1,2 @@
+Ensure that :func:`select.kqueue` objects correctly appear as closed in
+forked children, to prevent operations on an invalid file descriptor.


### PR DESCRIPTION
Invalidate open select.kqueue instances after fork as the fd will be invalid in the child. (cherry picked from commit a6c1c04d4d2339f0094422974ae3f26f8c7c8565)

<!-- gh-issue-number: gh-110395 -->
* Issue: gh-110395
<!-- /gh-issue-number -->
