### PR TITLE
gh-111747: DOC: fix moved link to Documentation Translations

### DIFF
--- a/Doc/bugs.rst
+++ b/Doc/bugs.rst
@@ -38,7 +38,7 @@ though it may take a while to be processed.
    `Helping with Documentation <https://devguide.python.org/docquality/#helping-with-documentation>`_
       Comprehensive guide for individuals that are interested in contributing to Python documentation.
 
-   `Documentation Translations <https://devguide.python.org/documenting/#translating>`_
+   `Documentation Translations <https://devguide.python.org/documentation/translating/>`_
       A list of GitHub pages for documentation translation and their primary contacts.
 
 


### PR DESCRIPTION
fix link redirect

On the [Dealing with Bugs](https://docs.python.org/3.13/bugs.html) page there is a link to [Documentation Translations](https://devguide.python.org/documenting/#translating) which has been moved from https://devguide.python.org/documenting/#translating to https://devguide.python.org/documentation/translating/

<!-- gh-issue-number: gh-111747 -->
* Issue: gh-111747
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--111748.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->