### PR TITLE
gh-111774: Update Tracing C API documentation: suggest to use `PyObject_SetAttrString` to set frame object fields

### DIFF
--- a/Doc/c-api/init.rst
+++ b/Doc/c-api/init.rst
@@ -1662,8 +1662,7 @@ Python-level trace functions in previous versions.
 
    The value passed as the *what* parameter to a :c:type:`Py_tracefunc` function
    (but not a profiling function) when a line-number event is being reported.
-   It may be disabled for a frame by setting :attr:`f_trace_lines` to *0* on that frame
-   with ``PyObject_SetAttrString(frame, "f_trace_lines", Py_False)`` call.
+   It may be disabled for a frame by ``PyObject_SetAttrString(frame, "f_trace_lines", Py_False)`` call.
 
 
 .. c:var:: int PyTrace_RETURN
@@ -1694,8 +1693,7 @@ Python-level trace functions in previous versions.
 
    The value for the *what* parameter to :c:type:`Py_tracefunc` functions (but not
    profiling functions) when a new opcode is about to be executed.  This event is
-   not emitted by default: it must be explicitly requested by setting
-   :attr:`f_trace_opcodes` to *1* on the frame with
+   not emitted by default: it must be explicitly requested by 
    ``PyObject_SetAttrString(frame, "f_trace_opcodes", Py_True)`` call.
 
 

--- a/Doc/c-api/init.rst
+++ b/Doc/c-api/init.rst
@@ -1693,7 +1693,7 @@ Python-level trace functions in previous versions.
 
    The value for the *what* parameter to :c:type:`Py_tracefunc` functions (but not
    profiling functions) when a new opcode is about to be executed.  This event is
-   not emitted by default: it must be explicitly requested by 
+   not emitted by default: it must be explicitly requested by
    ``PyObject_SetAttrString(frame, "f_trace_opcodes", Py_True)`` call.
 
 

--- a/Doc/c-api/init.rst
+++ b/Doc/c-api/init.rst
@@ -1662,7 +1662,8 @@ Python-level trace functions in previous versions.
 
    The value passed as the *what* parameter to a :c:type:`Py_tracefunc` function
    (but not a profiling function) when a line-number event is being reported.
-   It may be disabled for a frame by setting :attr:`f_trace_lines` to *0* on that frame.
+   It may be disabled for a frame by setting :attr:`f_trace_lines` to *0* on that frame
+   with ``PyObject_GetAttrString(frame, "f_trace_lines", Py_False)`` call.
 
 
 .. c:var:: int PyTrace_RETURN
@@ -1694,7 +1695,8 @@ Python-level trace functions in previous versions.
    The value for the *what* parameter to :c:type:`Py_tracefunc` functions (but not
    profiling functions) when a new opcode is about to be executed.  This event is
    not emitted by default: it must be explicitly requested by setting
-   :attr:`f_trace_opcodes` to *1* on the frame.
+   :attr:`f_trace_opcodes` to *1* on the frame with
+   ``PyObject_GetAttrString(frame, "f_trace_opcodes", Py_True)`` call.
 
 
 .. c:function:: void PyEval_SetProfile(Py_tracefunc func, PyObject *obj)

--- a/Doc/c-api/init.rst
+++ b/Doc/c-api/init.rst
@@ -1663,7 +1663,7 @@ Python-level trace functions in previous versions.
    The value passed as the *what* parameter to a :c:type:`Py_tracefunc` function
    (but not a profiling function) when a line-number event is being reported.
    It may be disabled for a frame by setting :attr:`f_trace_lines` to *0* on that frame
-   with ``PyObject_GetAttrString(frame, "f_trace_lines", Py_False)`` call.
+   with ``PyObject_SetAttrString(frame, "f_trace_lines", Py_False)`` call.
 
 
 .. c:var:: int PyTrace_RETURN
@@ -1696,7 +1696,7 @@ Python-level trace functions in previous versions.
    profiling functions) when a new opcode is about to be executed.  This event is
    not emitted by default: it must be explicitly requested by setting
    :attr:`f_trace_opcodes` to *1* on the frame with
-   ``PyObject_GetAttrString(frame, "f_trace_opcodes", Py_True)`` call.
+   ``PyObject_SetAttrString(frame, "f_trace_opcodes", Py_True)`` call.
 
 
 .. c:function:: void PyEval_SetProfile(Py_tracefunc func, PyObject *obj)


### PR DESCRIPTION
Fixes #111774

<!-- gh-issue-number: gh-111774 -->
* Issue: gh-111774
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--111776.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->