### PR TITLE
gh-61199: Remove superfluous global statements from `base64._b32{en,de}code()*`

### DIFF
--- a/Lib/base64.py
+++ b/Lib/base64.py
@@ -164,7 +164,6 @@ _b32tab2 = {}
 _b32rev = {}
 
 def _b32encode(alphabet, s):
-    global _b32tab2
     # Delay the initialization of the table to not waste memory
     # if the function is never called
     if alphabet not in _b32tab2:
@@ -200,7 +199,6 @@ def _b32encode(alphabet, s):
     return bytes(encoded)
 
 def _b32decode(alphabet, s, casefold=False, map01=None):
-    global _b32rev
     # Delay the initialization of the table to not waste memory
     # if the function is never called
     if alphabet not in _b32rev:


### PR DESCRIPTION
Remove now useless "global" statements from the base32 encode / decode methods

None values where changed to a global dict by
4ce6faa6c9591de6079347eccc9e61ae4e8d9e31

<!-- gh-issue-number: gh-61199 -->
* Issue: gh-61199
<!-- /gh-issue-number -->
