### PR TITLE
[Enum] update class creation for RuntimeError changes

### DIFF
--- a/Doc/howto/enum.rst
+++ b/Doc/howto/enum.rst
@@ -1439,7 +1439,6 @@ alias::
     Traceback (most recent call last):
       ...
     ValueError: aliases not allowed in DuplicateFreeEnum:  'GRENE' --> 'GREEN'
-    Error calling __set_name__ on '_proto_member' instance 'GRENE' in 'Color'
 
 .. note::
 

--- a/Lib/enum.py
+++ b/Lib/enum.py
@@ -568,10 +568,11 @@ class EnumType(type):
         try:
             exc = None
             enum_class = super().__new__(metacls, cls, bases, classdict, **kwds)
-        except RuntimeError as e:
-            # any exceptions raised by member.__new__ will get converted to a
-            # RuntimeError, so get that original exception back and raise it instead
-            exc = e.__cause__ or e
+        except Exception as e:
+            # since 3.12 the line "Error calling __set_name__ on '_proto_member' instance ..."
+            # is tacked on to the error instead of raising a RuntimeError
+            # recreate the exception to discard
+            exc = type(e)(str(e))
         if exc is not None:
             raise exc
         #

--- a/Lib/enum.py
+++ b/Lib/enum.py
@@ -573,8 +573,11 @@ class EnumType(type):
             # is tacked on to the error instead of raising a RuntimeError
             # recreate the exception to discard
             exc = type(e)(str(e))
+            exc.__cause__ = e.__cause__
+            exc.__context__ = e.__context__
+            tb = e.__traceback__
         if exc is not None:
-            raise exc
+            raise exc.with_traceback(tb)
         #
         # update classdict with any changes made by __init_subclass__
         classdict.update(enum_class.__dict__)


### PR DESCRIPTION
prior to 3.12, an error that occurred during class creation, i.e.

    enum_class = super().__new__(metacls, cls, bases, classdict, **kwds)

resulted in a RuntimeError being raised with the original exception as the __cause__.

In 3.12, the original error is propagated with an extra line

    Error calling __set_name__ on '_proto_member' instance ...

To discard that noise, the raised exception is recreated before being raised.

<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--111815.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->