### PR TITLE
gh-81137: deprecate assignment of code object to a function of a mismatched type

### DIFF
--- a/Doc/whatsnew/3.13.rst
+++ b/Doc/whatsnew/3.13.rst
@@ -401,7 +401,7 @@ Deprecated
   (as has always been the case for an executing frame).
   (Contributed by Irit Katriel in :gh:`79932`.)
 
-* Assignment to a function's :attr:`__code__` attribute where the new code
+* Assignment to a function's ``__code__`` attribute where the new code
   object's type does not match the function's type, is deprecated. The
   different types are: plain function, generator, async generator and
   coroutine.

--- a/Doc/whatsnew/3.13.rst
+++ b/Doc/whatsnew/3.13.rst
@@ -401,6 +401,12 @@ Deprecated
   (as has always been the case for an executing frame).
   (Contributed by Irit Katriel in :gh:`79932`.)
 
+* Assignment to a function's :attr:`__code__` attribute where the new code
+  object's type does not match the function's type, is deprecated. The
+  different types are: plain function, generator, async generator and
+  coroutine.
+  (Contributed by Irit Katriel in :gh:`81137`.)
+
 
 Pending Removal in Python 3.14
 ------------------------------

--- a/Lib/test/test_funcattrs.py
+++ b/Lib/test/test_funcattrs.py
@@ -2,6 +2,7 @@ import textwrap
 import types
 import typing
 import unittest
+import warnings
 
 
 def global_function():
@@ -69,6 +70,27 @@ class FunctionPropertiesTest(FuncAttrsTest):
         self.assertEqual(test(), None)
         test.__code__ = self.b.__code__
         self.assertEqual(test(), 3) # self.b always returns 3, arbitrarily
+
+    def test_invalid___code___assignment(self):
+        def A(): pass
+        def B(): yield
+        async def C(): yield
+        async def D(x): await x
+
+        for src in [A, B, C, D]:
+            for dst in [A, B, C, D]:
+                if src == dst:
+                    continue
+
+                assert src.__code__.co_flags != dst.__code__.co_flags
+                prev = dst.__code__
+                try:
+                    with self.assertWarnsRegex(DeprecationWarning, 'code object of non-matching type'):
+                        dst.__code__ = src.__code__
+                finally:
+                    with warnings.catch_warnings():
+                        warnings.filterwarnings('ignore', '', DeprecationWarning)
+                        dst.__code__ = prev
 
     def test___globals__(self):
         self.assertIs(self.b.__globals__, globals())

--- a/Misc/NEWS.d/next/Core and Builtins/2023-11-07-12-59-02.gh-issue-81137.qFpJCY.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2023-11-07-12-59-02.gh-issue-81137.qFpJCY.rst
@@ -1,0 +1,2 @@
+Deprecate assignment to a function's ``__code__`` field when the new code
+object is of a mismatched type (e.g., from a generator to a plain function).


### PR DESCRIPTION
Fixes #81137.

<!-- gh-issue-number: gh-81137 -->
* Issue: gh-81137
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--111823.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->