### PR TITLE
gh-111806: Fix `test_recursion` in `test_richcmp` on WASI builds

### DIFF
--- a/Lib/test/test_richcmp.py
+++ b/Lib/test/test_richcmp.py
@@ -221,6 +221,7 @@ class MiscTest(unittest.TestCase):
             self.assertRaises(Exc, func, Bad())
 
     @support.no_tracing
+    @support.infinite_recursion(25)
     def test_recursion(self):
         # Check that comparison for recursive objects fails gracefully
         from collections import UserList


### PR DESCRIPTION
Next, I plan to do multiple issues at once, because it would be much easier to review.
They can be unified in logical bulks.

repr-based (next in my list):
- https://github.com/python/cpython/issues/111809
- https://github.com/python/cpython/issues/111810
- https://github.com/python/cpython/issues/111811
- https://github.com/python/cpython/issues/111800
- https://github.com/python/cpython/issues/111799

<!-- gh-issue-number: gh-111806 -->
* Issue: gh-111806
<!-- /gh-issue-number -->
