### PR TITLE
Glossary: Add "static type checker"

### DIFF
--- a/Doc/glossary.rst
+++ b/Doc/glossary.rst
@@ -1219,8 +1219,8 @@ Glossary
       attribute, or a function parameter or return value.
 
       Type hints are optional and are not enforced by Python but
-      they are useful to :term:`static type checkers <static type checker>`,
-      and aid IDEs with code completion and refactoring.
+      they are useful to :term:`static type checkers <static type checker>`.
+      They can also aid IDEs with code completion and refactoring.
 
       Type hints of global variables, class attributes, and functions,
       but not local variables, can be accessed using

--- a/Doc/glossary.rst
+++ b/Doc/glossary.rst
@@ -1138,6 +1138,11 @@ Glossary
       an :term:`expression` or one of several constructs with a keyword, such
       as :keyword:`if`, :keyword:`while` or :keyword:`for`.
 
+   static type checker
+      An external tool that reads Python code and analyzes it, looking for
+      issues such as incorrect types. See also :term:`type hints <type hint>`
+      and the :mod:`typing` module.
+
    strong reference
       In Python's C API, a strong reference is a reference to an object
       which is owned by the code holding the reference.  The strong
@@ -1214,8 +1219,8 @@ Glossary
       attribute, or a function parameter or return value.
 
       Type hints are optional and are not enforced by Python but
-      they are useful to static type analysis tools, and aid IDEs with code
-      completion and refactoring.
+      they are useful to :term:`static type checkers <static type checker>`,
+      and aid IDEs with code completion and refactoring.
 
       Type hints of global variables, class attributes, and functions,
       but not local variables, can be accessed using

--- a/Doc/howto/pyporting.rst
+++ b/Doc/howto/pyporting.rst
@@ -39,7 +39,8 @@ are:
 #. Once your dependencies are no longer blocking you, use continuous integration
    to make sure you stay compatible with Python 2 and 3 (tox_ can help test
    against multiple versions of Python; ``python -m pip install tox``)
-#. Consider using optional static type checking to make sure your type usage
+#. Consider using optional :term:`static type checking <static type checker>`
+   to make sure your type usage
    works in both Python 2 and 3 (e.g. use mypy_ to check your typing under both
    Python 2 and Python 3; ``python -m pip install mypy``).
 
@@ -395,7 +396,7 @@ comparisons occur, making the mistake much easier to track down.
 Consider using optional static type checking
 --------------------------------------------
 
-Another way to help port your code is to use a static type checker like
+Another way to help port your code is to use a :term:`static type checker` like
 mypy_ or pytype_ on your code. These tools can be used to analyze your code as
 if it's being run under Python 2, then you can run the tool a second time as if
 your code is running under Python 3. By running a static type checker twice like

--- a/Doc/library/datetime.rst
+++ b/Doc/library/datetime.rst
@@ -38,7 +38,8 @@ on efficient attribute extraction for output formatting and manipulation.
       Third-party library with expanded time zone and parsing support.
 
    Package `DateType <https://pypi.org/project/datetype/>`_
-      Third-party library that introduces distinct static types to e.g. allow static type checkers
+      Third-party library that introduces distinct static types to e.g. allow
+      :term:`static type checkers <static type checker>`
       to differentiate between naive and aware datetimes.
 
 .. _datetime-naive-aware:

--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -18,8 +18,8 @@
 .. note::
 
    The Python runtime does not enforce function and variable type annotations.
-   They can be used by third party tools such as type checkers, IDEs, linters,
-   etc.
+   They can be used by third party tools such as :term:`type checkers <static type checker>`,
+   IDEs, linters, etc.
 
 --------------
 


### PR DESCRIPTION
While working on #104004 I found it jarring to use the term "static type checker" without context in the docs for the warnings module. This PR splits out that part of the change so we can also apply it to 3.11 and 3.12.

I grepped for "static type checker" in the Doc folder and added links in a few places where it seemed helpful. I mostly left the docs for typing alone, since in that file the link would mostly be distracting.

<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--111837.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->