### PR TITLE
no-issue: Remove redundant check in dbm.open()

### DIFF
--- a/Modules/_dbmmodule.c
+++ b/Modules/_dbmmodule.c
@@ -557,11 +557,6 @@ dbmopen_impl(PyObject *module, PyObject *filename, const char *flags,
     }
 
     const char *name = PyBytes_AS_STRING(filenamebytes);
-    if (strlen(name) != (size_t)PyBytes_GET_SIZE(filenamebytes)) {
-        Py_DECREF(filenamebytes);
-        PyErr_SetString(PyExc_ValueError, "embedded null character");
-        return NULL;
-    }
     PyObject *self = newdbmobject(state, name, iflags, mode);
     Py_DECREF(filenamebytes);
     return self;


### PR DESCRIPTION
PyUnicode_FSConverter() already checks for embedded null characters.
