### PR TITLE
gh-111460: restore ncurses widechar support on macOS

### DIFF
--- a/Misc/NEWS.d/next/Library/2023-11-09-12-57-43.gh-issue-111460.TQaz9I.rst
+++ b/Misc/NEWS.d/next/Library/2023-11-09-12-57-43.gh-issue-111460.TQaz9I.rst
@@ -1,0 +1,3 @@
+:mod:`curses`: restore wide character support (including
+:func:`curses.unget_wch` and :meth:`~curses.window.get_wch`) on macOS, which
+was unavailable due to a regression in Python 3.12.

--- a/configure
+++ b/configure
@@ -25528,7 +25528,7 @@ fi
 fi
 CURSES_CFLAGS=$(echo $CURSES_CFLAGS | sed 's/-D_XOPEN_SOURCE=600//g')
 
-if test "$have_curses" = no -a "$ac_sys_system" = "Darwin"; then
+if test "$have_curses" != no -a "$ac_sys_system" = "Darwin"; then
 
   as_fn_append CURSES_CFLAGS " -D_XOPEN_SOURCE_EXTENDED=1"
   printf "%s\n" "#define HAVE_NCURSESW 1" >>confdefs.h

--- a/configure.ac
+++ b/configure.ac
@@ -6290,9 +6290,11 @@ dnl remove _XOPEN_SOURCE macro from curses cflags. pyconfig.h sets
 dnl the macro to 700.
 CURSES_CFLAGS=$(echo $CURSES_CFLAGS | sed 's/-D_XOPEN_SOURCE=600//g')
 
-if test "$have_curses" = no -a "$ac_sys_system" = "Darwin"; then
+if test "$have_curses" != no -a "$ac_sys_system" = "Darwin"; then
   dnl On macOS, there is no separate /usr/lib/libncursesw nor libpanelw.
-  dnl If we are here, we found a locally-supplied version of libncursesw.
+  dnl System-supplied ncurses combines libncurses/libpanel and supports wide
+  dnl characters, so we can use it like ncursesw.
+  dnl If a locally-supplied version of libncursesw is found, we will use that.
   dnl There should also be a libpanelw.
   dnl _XOPEN_SOURCE defines are usually excluded for macOS, but we need
   dnl _XOPEN_SOURCE_EXTENDED here for ncurses wide char support.


### PR DESCRIPTION
Ncurses wide character support on macOS was broken as an unintended consequence of https://github.com/python/cpython/pull/94452. It is now built as intended.

<!-- gh-issue-number: gh-111460 -->
* Issue: gh-111460
<!-- /gh-issue-number -->
