### PR TITLE
gh-111881: Import doctest lazily in libregrtest

### DIFF
--- a/Lib/test/libregrtest/single.py
+++ b/Lib/test/libregrtest/single.py
@@ -93,22 +93,23 @@ def regrtest_runner(result: TestResult, test_func, runtests: RunTests) -> None:
 
     stats: TestStats | None
 
-    if isinstance(test_result, TestStats):
-        stats = test_result
-    elif isinstance(test_result, unittest.TestResult):
-        stats = TestStats.from_unittest(test_result)
-    elif test_result is None:
-        print_warning(f"{result.test_name} test runner returned None: {test_func}")
-        stats = None
-    else:
-        # Don't import doctest at top level since only few tests return
-        # a doctest.TestResult instance.
-        import doctest
-        if isinstance(test_result, doctest.TestResults):
-            stats = TestStats.from_doctest(test_result)
-        else:
-            print_warning(f"Unknown test result type: {type(test_result)}")
+    match test_result:
+        case TestStats():
+            stats = test_result
+        case unittest.TestResult():
+            stats = TestStats.from_unittest(test_result)
+        case None:
+            print_warning(f"{result.test_name} test runner returned None: {test_func}")
             stats = None
+        case _:
+            # Don't import doctest at top level since only few tests return
+            # a doctest.TestResult instance.
+            import doctest
+            if isinstance(test_result, doctest.TestResults):
+                stats = TestStats.from_doctest(test_result)
+            else:
+                print_warning(f"Unknown test result type: {type(test_result)}")
+                stats = None
 
     result.stats = stats
 

--- a/Lib/test/libregrtest/single.py
+++ b/Lib/test/libregrtest/single.py
@@ -1,4 +1,3 @@
-import doctest
 import faulthandler
 import gc
 import importlib
@@ -94,17 +93,20 @@ def regrtest_runner(result: TestResult, test_func, runtests: RunTests) -> None:
 
     stats: TestStats | None
 
-    match test_result:
-        case TestStats():
-            stats = test_result
-        case unittest.TestResult():
-            stats = TestStats.from_unittest(test_result)
-        case doctest.TestResults():
+    if isinstance(test_result, TestStats):
+        stats = test_result
+    elif isinstance(test_result, unittest.TestResult):
+        stats = TestStats.from_unittest(test_result)
+    elif test_result is None:
+        print_warning(f"{result.test_name} test runner returned None: {test_func}")
+        stats = None
+    else:
+        # Don't import doctest at top level since only few tests return
+        # a doctest.TestResult instance.
+        import doctest
+        if isinstance(test_result, doctest.TestResults):
             stats = TestStats.from_doctest(test_result)
-        case None:
-            print_warning(f"{result.test_name} test runner returned None: {test_func}")
-            stats = None
-        case _:
+        else:
             print_warning(f"Unknown test result type: {type(test_result)}")
             stats = None
 


### PR DESCRIPTION
In most cases, doctest is not needed. So don't always import it at startup.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-111881 -->
* Issue: gh-111881
<!-- /gh-issue-number -->
