### PR TITLE
gh-111881: Import lazily linecache in traceback

### DIFF
--- a/Lib/traceback.py
+++ b/Lib/traceback.py
@@ -2,7 +2,6 @@
 
 import collections.abc
 import itertools
-import linecache
 import sys
 import textwrap
 from contextlib import suppress
@@ -333,6 +332,7 @@ class FrameSummary:
         if self._line is None:
             if self.lineno is None:
                 return None
+            import linecache
             self._line = linecache.getline(self.filename, self.lineno)
         return self._line.strip()
 
@@ -429,6 +429,8 @@ class StackSummary(list):
                 frame_gen = itertools.islice(frame_gen, limit)
             else:
                 frame_gen = collections.deque(frame_gen, maxlen=-limit)
+
+        import linecache
 
         result = klass()
         fnames = set()


### PR DESCRIPTION
The linecache module is only used by StackSummary and FrameSummary.line property. Import the linecache module lazily to speedup Python imports and reduce the number of imports when the traceback module is imported.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-111881 -->
* Issue: gh-111881
<!-- /gh-issue-number -->
