### PR TITLE
gh-111881: Use lazy import in unittest

### DIFF
--- a/Lib/unittest/case.py
+++ b/Lib/unittest/case.py
@@ -2,7 +2,6 @@
 
 import sys
 import functools
-import difflib
 import pprint
 import re
 import warnings
@@ -1065,6 +1064,8 @@ class TestCase(object):
                 except (TypeError, IndexError, NotImplementedError):
                     differing += ('Unable to index element %d '
                                   'of second %s\n' % (len1, seq_type_name))
+
+        import difflib
         standardMsg = differing
         diffMsg = '\n' + '\n'.join(
             difflib.ndiff(pprint.pformat(seq1).splitlines(),
@@ -1178,6 +1179,7 @@ class TestCase(object):
         self.assertIsInstance(d2, dict, 'Second argument is not a dictionary')
 
         if d1 != d2:
+            import difflib
             standardMsg = '%s != %s' % _common_shorten_repr(d1, d2)
             diff = ('\n' + '\n'.join(difflib.ndiff(
                            pprint.pformat(d1).splitlines(),
@@ -1247,6 +1249,7 @@ class TestCase(object):
             secondlines = second_presplit.splitlines(keepends=True)
 
             # Generate the message and diff, then raise the exception
+            import difflib
             standardMsg = '%s != %s' % _common_shorten_repr(first, second)
             diff = '\n' + ''.join(difflib.ndiff(firstlines, secondlines))
             standardMsg = self._truncateMessage(standardMsg, diff)

--- a/Lib/unittest/loader.py
+++ b/Lib/unittest/loader.py
@@ -7,8 +7,6 @@ import traceback
 import types
 import functools
 
-from fnmatch import fnmatch, fnmatchcase
-
 from . import case, suite, util
 
 __unittest = True
@@ -219,8 +217,12 @@ class TestLoader(object):
             fullName = f'%s.%s.%s' % (
                 testCaseClass.__module__, testCaseClass.__qualname__, attrname
             )
-            return self.testNamePatterns is None or \
-                any(fnmatchcase(fullName, pattern) for pattern in self.testNamePatterns)
+            if self.testNamePatterns is None:
+                return True
+            else:
+                from fnmatch import fnmatchcase
+                return any(fnmatchcase(fullName, pattern) for pattern in self.testNamePatterns)
+
         testFnNames = list(filter(shouldIncludeMethod, dir(testCaseClass)))
         if self.sortTestMethodsUsing:
             testFnNames.sort(key=functools.cmp_to_key(self.sortTestMethodsUsing))
@@ -339,6 +341,7 @@ class TestLoader(object):
 
     def _match_path(self, path, full_path, pattern):
         # override this method to use alternative matching strategy
+        from fnmatch import fnmatch
         return fnmatch(path, pattern)
 
     def _find_tests(self, start_dir, pattern):

--- a/Lib/unittest/main.py
+++ b/Lib/unittest/main.py
@@ -1,8 +1,7 @@
 """Unittest main program"""
 
-import sys
-import argparse
 import os
+import sys
 
 from . import loader, runner
 from .signals import installHandler
@@ -159,6 +158,7 @@ class TestProgram(object):
         self._discovery_parser = self._getDiscoveryArgParser(parent_parser)
 
     def _getParentArgParser(self):
+        import argparse
         parser = argparse.ArgumentParser(add_help=False)
 
         parser.add_argument('-v', '--verbose', dest='verbosity',
@@ -197,6 +197,7 @@ class TestProgram(object):
         return parser
 
     def _getMainArgParser(self, parent):
+        import argparse
         parser = argparse.ArgumentParser(parents=[parent])
         parser.prog = self.progName
         parser.print_help = self._print_help
@@ -208,6 +209,7 @@ class TestProgram(object):
         return parser
 
     def _getDiscoveryArgParser(self, parent):
+        import argparse
         parser = argparse.ArgumentParser(parents=[parent])
         parser.prog = '%s discover' % self.progName
         parser.epilog = ('For test discovery all test modules must be '


### PR DESCRIPTION
Use lazy imports for argparse, difflib and fnmatch imports in unittest to speedup Python startup time when running tests, and the number of imported modules when running tests.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-111881 -->
* Issue: gh-111881
<!-- /gh-issue-number -->
