### PR TITLE
gh-111881: Use lazy import in doctest

### DIFF
--- a/Lib/doctest.py
+++ b/Lib/doctest.py
@@ -93,9 +93,7 @@ __all__ = [
 ]
 
 import __future__
-import difflib
 import inspect
-import linecache
 import os
 import pdb
 import re
@@ -932,6 +930,8 @@ class DocTestFinder:
             if file is None:
                 source_lines = None
             else:
+                import linecache
+
                 if module is not None:
                     # Supply the module globals in case the module was
                     # originally loaded via a PEP 302 loader and
@@ -1528,6 +1528,8 @@ class DocTestRunner:
         self.debugger.reset()
         pdb.set_trace = self.debugger.set_trace
 
+        import linecache
+
         # Patch linecache.getlines, so we can see the example's source
         # when we're inside the debugger.
         self.save_linecache_getlines = linecache.getlines
@@ -1738,6 +1740,8 @@ class OutputChecker:
 
         # Check if we should use diff.
         if self._do_a_fancy_diff(want, got, optionflags):
+            import difflib
+
             # Split want & got into lines.
             want_lines = want.splitlines(keepends=True)
             got_lines = got.splitlines(keepends=True)


### PR DESCRIPTION
Use lazy import for difflib and linecache imports in doctest to speedup Python startup and reduce the number of imports when running tests.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-111881 -->
* Issue: gh-111881
<!-- /gh-issue-number -->
