### PR TITLE
gh-111881: Import _sha2 lazily in random

### DIFF
--- a/Lib/random.py
+++ b/Lib/random.py
@@ -97,6 +97,7 @@ SG_MAGICCONST = 1.0 + _log(4.5)
 BPF = 53        # Number of bits in a float
 RECIP_BPF = 2 ** -BPF
 _ONE = 1
+_sha512 = None
 
 
 class Random(_random.Random):
@@ -151,13 +152,15 @@ class Random(_random.Random):
             a = -2 if x == -1 else x
 
         elif version == 2 and isinstance(a, (str, bytes, bytearray)):
-            try:
-                # hashlib is pretty heavy to load, try lean internal
-                # module first
-                from _sha2 import sha512 as _sha512
-            except ImportError:
-                # fallback to official implementation
-                from hashlib import sha512 as _sha512
+            global _sha512
+            if _sha512 is None:
+                try:
+                    # hashlib is pretty heavy to load, try lean internal
+                    # module first
+                    from _sha2 import sha512 as _sha512
+                except ImportError:
+                    # fallback to official implementation
+                    from hashlib import sha512 as _sha512
 
             if isinstance(a, str):
                 a = a.encode()


### PR DESCRIPTION
The random module now imports the _sha2 module laziliy in Random.seed() method for str, bytes and bytearray seeds. Lazy import makes Python startup faster and reduce the number of imported modules at startup.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-111881 -->
* Issue: gh-111881
<!-- /gh-issue-number -->
