### PR TITLE
[3.12] gh-111881: Use lazy import in test.support (#111885)

### DIFF
--- a/Lib/test/support/__init__.py
+++ b/Lib/test/support/__init__.py
@@ -6,7 +6,6 @@ if __name__ != 'test.support':
 import contextlib
 import dataclasses
 import functools
-import getpass
 import opcode
 import os
 import re
@@ -382,6 +381,7 @@ def requires_mac_ver(*min_version):
 
 def skip_if_buildbot(reason=None):
     """Decorator raising SkipTest if running on a buildbot."""
+    import getpass
     if not reason:
         reason = 'not suitable for buildbots'
     try:

--- a/Lib/test/support/os_helper.py
+++ b/Lib/test/support/os_helper.py
@@ -10,6 +10,8 @@ import time
 import unittest
 import warnings
 
+from test import support
+
 
 # Filename used for testing
 TESTFN_ASCII = '@test'
@@ -720,13 +722,16 @@ class EnvironmentVarGuard(collections.abc.MutableMapping):
 
 
 try:
-    import ctypes
-    kernel32 = ctypes.WinDLL('kernel32', use_last_error=True)
+    if support.MS_WINDOWS:
+        import ctypes
+        kernel32 = ctypes.WinDLL('kernel32', use_last_error=True)
 
-    ERROR_FILE_NOT_FOUND = 2
-    DDD_REMOVE_DEFINITION = 2
-    DDD_EXACT_MATCH_ON_REMOVE = 4
-    DDD_NO_BROADCAST_SYSTEM = 8
+        ERROR_FILE_NOT_FOUND = 2
+        DDD_REMOVE_DEFINITION = 2
+        DDD_EXACT_MATCH_ON_REMOVE = 4
+        DDD_NO_BROADCAST_SYSTEM = 8
+    else:
+        raise AttributeError
 except (ImportError, AttributeError):
     def subst_drive(path):
         raise unittest.SkipTest('ctypes or kernel32 is not available')


### PR DESCRIPTION
* Import lazily getpass in test.support
* Only import ctypes on Windows in test.support.os_helper.

(cherry picked from commit 0372e3b02a7e3dc1c564dba94dcd817c5472b04f)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-111881 -->
* Issue: gh-111881
<!-- /gh-issue-number -->
