### PR TITLE
gh-111569: Fix critical sections test on WebAssembly

### DIFF
--- a/Include/pyport.h
+++ b/Include/pyport.h
@@ -470,6 +470,14 @@ extern "C" {
 #  define WITH_THREAD
 #endif
 
+/* Some WebAssembly platforms do not provide a working pthread implementation.
+ * Thread support is stubbed and any attempt to create a new thread fails.
+ */
+#if (!defined(HAVE_PTHREAD_STUBS) && \
+      (!defined(__EMSCRIPTEN__) || defined(__EMSCRIPTEN_PTHREADS__)))
+#  define Py_CAN_START_THREADS 1
+#endif
+
 #ifdef WITH_THREAD
 #  ifdef Py_BUILD_CORE
 #    ifdef HAVE_THREAD_LOCAL

--- a/Include/pyport.h
+++ b/Include/pyport.h
@@ -470,6 +470,13 @@ extern "C" {
 #  define WITH_THREAD
 #endif
 
+/* Some WebAssembly platforms do not provide a working pthread implementation.
+ * Thread support is stubbed and any attempt to create a new thread fails.
+ */
+#if !defined(__wasi__) && (!defined(__EMSCRIPTEN__) || defined(__EMSCRIPTEN_PTHREADS__))
+#  define Py_CAN_START_THREADS 1
+#endif
+
 #ifdef WITH_THREAD
 #  ifdef Py_BUILD_CORE
 #    ifdef HAVE_THREAD_LOCAL

--- a/Include/pyport.h
+++ b/Include/pyport.h
@@ -470,13 +470,6 @@ extern "C" {
 #  define WITH_THREAD
 #endif
 
-/* Some WebAssembly platforms do not provide a working pthread implementation.
- * Thread support is stubbed and any attempt to create a new thread fails.
- */
-#if !defined(__wasi__) && (!defined(__EMSCRIPTEN__) || defined(__EMSCRIPTEN_PTHREADS__))
-#  define Py_CAN_START_THREADS 1
-#endif
-
 #ifdef WITH_THREAD
 #  ifdef Py_BUILD_CORE
 #    ifdef HAVE_THREAD_LOCAL

--- a/Modules/_testinternalcapi/test_critical_sections.c
+++ b/Modules/_testinternalcapi/test_critical_sections.c
@@ -170,6 +170,7 @@ thread_critical_sections(void *arg)
     }
 }
 
+#ifdef Py_CAN_START_THREADS
 static PyObject *
 test_critical_sections_threads(PyObject *self, PyObject *Py_UNUSED(args))
 {
@@ -194,12 +195,15 @@ test_critical_sections_threads(PyObject *self, PyObject *Py_UNUSED(args))
     Py_DECREF(test_data.obj1);
     Py_RETURN_NONE;
 }
+#endif
 
 static PyMethodDef test_methods[] = {
     {"test_critical_sections", test_critical_sections, METH_NOARGS},
     {"test_critical_sections_nest", test_critical_sections_nest, METH_NOARGS},
     {"test_critical_sections_suspend", test_critical_sections_suspend, METH_NOARGS},
+#ifdef Py_CAN_START_THREADS
     {"test_critical_sections_threads", test_critical_sections_threads, METH_NOARGS},
+#endif
     {NULL, NULL} /* sentinel */
 };
 

--- a/Modules/_testinternalcapi/test_critical_sections.c
+++ b/Modules/_testinternalcapi/test_critical_sections.c
@@ -170,7 +170,7 @@ thread_critical_sections(void *arg)
     }
 }
 
-#ifdef Py_CAN_START_THREADS
+#ifndef HAVE_PTHREAD_STUBS
 static PyObject *
 test_critical_sections_threads(PyObject *self, PyObject *Py_UNUSED(args))
 {
@@ -201,7 +201,7 @@ static PyMethodDef test_methods[] = {
     {"test_critical_sections", test_critical_sections, METH_NOARGS},
     {"test_critical_sections_nest", test_critical_sections_nest, METH_NOARGS},
     {"test_critical_sections_suspend", test_critical_sections_suspend, METH_NOARGS},
-#ifdef Py_CAN_START_THREADS
+#ifndef HAVE_PTHREAD_STUBS
     {"test_critical_sections_threads", test_critical_sections_threads, METH_NOARGS},
 #endif
     {NULL, NULL} /* sentinel */

--- a/Modules/_testinternalcapi/test_critical_sections.c
+++ b/Modules/_testinternalcapi/test_critical_sections.c
@@ -170,7 +170,7 @@ thread_critical_sections(void *arg)
     }
 }
 
-#ifndef HAVE_PTHREAD_STUBS
+#ifdef Py_CAN_START_THREADS
 static PyObject *
 test_critical_sections_threads(PyObject *self, PyObject *Py_UNUSED(args))
 {
@@ -201,7 +201,7 @@ static PyMethodDef test_methods[] = {
     {"test_critical_sections", test_critical_sections, METH_NOARGS},
     {"test_critical_sections_nest", test_critical_sections_nest, METH_NOARGS},
     {"test_critical_sections_suspend", test_critical_sections_suspend, METH_NOARGS},
-#ifndef HAVE_PTHREAD_STUBS
+#ifdef Py_CAN_START_THREADS
     {"test_critical_sections_threads", test_critical_sections_threads, METH_NOARGS},
 #endif
     {NULL, NULL} /* sentinel */


### PR DESCRIPTION
This adds a macro `Py_CAN_START_THREADS` that corresponds to the Python function test.support.threading_helper.can_start_thread(). Some WebAssembly platforms do not have a working pthread implementation.

This macro is used to guard the critical sections C API tests that require a working threads implementation.

<!-- gh-issue-number: gh-111569 -->
* Issue: gh-111569
<!-- /gh-issue-number -->
