### PR TITLE
gh-111895: Convert definition list to bullet list for readability on mobile

### DIFF
--- a/Doc/howto/enum.rst
+++ b/Doc/howto/enum.rst
@@ -607,9 +607,9 @@ The complete signature is::
         start=1,
         )
 
-:value: What the new enum class will record as its name.
+* *value*: What the new enum class will record as its name.
 
-:names: The enum members.  This can be a whitespace- or comma-separated string
+* *names*: The enum members.  This can be a whitespace- or comma-separated string
   (values will start at 1 unless otherwise specified)::
 
     'RED GREEN BLUE' | 'RED,GREEN,BLUE' | 'RED, GREEN, BLUE'
@@ -626,13 +626,13 @@ The complete signature is::
 
     {'CHARTREUSE': 7, 'SEA_GREEN': 11, 'ROSEMARY': 42}
 
-:module: name of module where new enum class can be found.
+* *module*: name of module where new enum class can be found.
 
-:qualname: where in module new enum class can be found.
+* *qualname*: where in module new enum class can be found.
 
-:type: type to mix in to new enum class.
+* *type*: type to mix in to new enum class.
 
-:start: number to start counting at if only names are passed in.
+* *start*: number to start counting at if only names are passed in.
 
 .. versionchanged:: 3.5
    The *start* parameter was added.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

The definition list at https://docs.python.org/3/howto/enum.html#functional-api is very squashed on mobile and hard to read:

<details>
<summary>Mobile screenshot</summary>

![image](https://github.com/python/cpython/assets/1324225/b95bf499-de6a-4041-9e40-9cba58edd614)


</details>

It doesn't look great on desktop either:

<details>
<summary>Desktop screenshot</summary>

![image](https://github.com/python/cpython/assets/1324225/1cd030f6-baea-4cb3-aa1d-e0e585e66847)

</details>

Convert it to a bullet list instead:



<details>
<summary>Mobile screenshot</summary>

![image](https://github.com/python/cpython/assets/1324225/f180fb43-caef-4a5a-81fc-ae144a4fe0ef)


</details>


<details>
<summary>Desktop screenshot</summary>

![image](https://github.com/python/cpython/assets/1324225/f9da3944-b0e8-4778-8650-e85a359b648e)


</details>

Before: https://docs.python.org/3/howto/enum.html#functional-api
After: https://cpython-previews--111898.org.readthedocs.build/en/111898/howto/enum.html#functional-api



<!-- gh-issue-number: gh-111895 -->
* Issue: gh-111895
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--111898.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->