### PR TITLE
Docs: Add `make htmllive` to rebuild and reload HTML files in your browser

### DIFF
--- a/Doc/Makefile
+++ b/Doc/Makefile
@@ -29,6 +29,7 @@ help:
 	@echo "  venv       to create a venv with necessary tools"
 	@echo "  html       to make standalone HTML files"
 	@echo "  htmlview   to open the index page built by the html target in your browser"
+	@echo "  htmllive   to rebuild and reload HTML files in your browser"
 	@echo "  htmlhelp   to make HTML files and a HTML help project"
 	@echo "  latex      to make LaTeX files, you can set PAPER=a4 or PAPER=letter"
 	@echo "  text       to make plain text files"
@@ -138,6 +139,11 @@ pydoc-topics: build
 .PHONY: htmlview
 htmlview: html
 	$(PYTHON) -c "import os, webbrowser; webbrowser.open('file://' + os.path.realpath('build/html/index.html'))"
+
+.PHONY: htmllive
+htmllive: SPHINXBUILD = $(VENVDIR)/bin/sphinx-autobuild
+htmllive: SPHINXOPTS = --re-ignore="/venv/"
+htmllive: html
 
 .PHONY: clean
 clean: clean-venv

--- a/Doc/requirements.txt
+++ b/Doc/requirements.txt
@@ -11,6 +11,7 @@ sphinx==6.2.1
 
 blurb
 
+sphinx-autobuild
 sphinxext-opengraph==0.7.5
 
 # The theme used by the documentation is stored separately, so we need


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

Add a `make htmllive` target to use https://github.com/executablebooks/sphinx-autobuild.

When you run it, it builds the docs and serves them at something like http://127.0.0.1:8000/

You can visit any page, for example http://127.0.0.1:8000/pep-0101.html, and when you edit/save your source `.rst` file, it will automatically rebuild and update the page in the browser.

This drastically improves the edit/inspect loop. A very nice touch is it will also keep you at the same position in the page.

Compare before:

1. switch to IDE: edit, save
2. switch to prompt: `make html`
3. switch to browser: reload, inspect
4. repeat

To this PR:

1. switch to IDE: edit, save
2. ~switch to prompt: `make html`~
3. switch to browser: ~reload,~ inspect
4. repeat

We've already added this to the devguide (https://github.com/python/devguide/pull/1208, https://github.com/python/devguide/pull/1212) and have an open PR for the PEPs: https://github.com/python/peps/pull/3521.

cc @pradyunsg


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--111900.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->