### PR TITLE
[3.11] gh-111881: Use lazy import in test.support (#111885) (#111890)

### DIFF
--- a/Lib/test/support/__init__.py
+++ b/Lib/test/support/__init__.py
@@ -6,7 +6,6 @@ if __name__ != 'test.support':
 import contextlib
 import dataclasses
 import functools
-import getpass
 import os
 import re
 import stat
@@ -380,6 +379,7 @@ def requires_mac_ver(*min_version):
 
 def skip_if_buildbot(reason=None):
     """Decorator raising SkipTest if running on a buildbot."""
+    import getpass
     if not reason:
         reason = 'not suitable for buildbots'
     try:


### PR DESCRIPTION
gh-111881: Use lazy import in test.support (#111885)

* Import lazily getpass in test.support

Backport to 3.11: test.support.os_helper is unchanged.

(cherry picked from commit 0372e3b02a7e3dc1c564dba94dcd817c5472b04f) (cherry picked from commit e983ca859de279682631dbb13b959f14a7d89a7b)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
