### PR TITLE
gh-103791: handle `BaseExceptionGroup` in `contextlib.suppress()`

### DIFF
--- a/Doc/library/contextlib.rst
+++ b/Doc/library/contextlib.rst
@@ -312,10 +312,6 @@ Functions and classes provided:
 
    .. versionchanged:: 3.12
       ``suppress`` now supports suppressing exceptions raised as
-      part of an :exc:`ExceptionGroup`.
-
-   .. versionchanged:: 3.12.1
-      ``suppress`` now supports suppressing exceptions raised as
       part of an :exc:`BaseExceptionGroup`.
 
 .. function:: redirect_stdout(new_target)

--- a/Doc/library/contextlib.rst
+++ b/Doc/library/contextlib.rst
@@ -304,8 +304,8 @@ Functions and classes provided:
 
    This context manager is :ref:`reentrant <reentrant-cms>`.
 
-   If the code within the :keyword:`!with` block raises an
-   :exc:`ExceptionGroup`, suppressed exceptions are removed from the
+   If the code within the :keyword:`!with` block raises a
+   :exc:`BaseExceptionGroup`, suppressed exceptions are removed from the
    group.  If any exceptions in the group are not suppressed, a group containing them is re-raised.
 
    .. versionadded:: 3.4
@@ -313,6 +313,10 @@ Functions and classes provided:
    .. versionchanged:: 3.12
       ``suppress`` now supports suppressing exceptions raised as
       part of an :exc:`ExceptionGroup`.
+
+   .. versionchanged:: 3.12.1
+      ``suppress`` now supports suppressing exceptions raised as
+      part of an :exc:`BaseExceptionGroup`.
 
 .. function:: redirect_stdout(new_target)
 

--- a/Lib/contextlib.py
+++ b/Lib/contextlib.py
@@ -461,7 +461,7 @@ class suppress(AbstractContextManager):
             return
         if issubclass(exctype, self._exceptions):
             return True
-        if issubclass(exctype, ExceptionGroup):
+        if issubclass(exctype, BaseExceptionGroup):
             match, rest = excinst.split(self._exceptions)
             if rest is None:
                 return True

--- a/Lib/test/test_contextlib.py
+++ b/Lib/test/test_contextlib.py
@@ -1301,6 +1301,20 @@ class TestSuppress(ExceptionIsLikeMixin, unittest.TestCase):
         # we don't accidentally discard a ctrl-c with KeyboardInterrupt.
         with suppress(GeneratorExit):
             raise BaseExceptionGroup("message", [GeneratorExit()])
+        # If we raise a BaseException group, we can still suppress parts
+        with self.assertRaises(BaseExceptionGroup) as eg1:
+            with suppress(KeyError):
+                raise BaseExceptionGroup("message", [GeneratorExit("g"), KeyError("k")])
+        self.assertExceptionIsLike(
+            eg1.exception, BaseExceptionGroup("message", [GeneratorExit("g")]),
+        )
+        # If we suppress all the leaf BaseExceptions, we get a non-base ExceptionGroup
+        with self.assertRaises(ExceptionGroup) as eg1:
+            with suppress(GeneratorExit):
+                raise BaseExceptionGroup("message", [GeneratorExit("g"), KeyError("k")])
+        self.assertExceptionIsLike(
+            eg1.exception, ExceptionGroup("message", [KeyError("k")]),
+        )
 
 
 class TestChdir(unittest.TestCase):

--- a/Lib/test/test_contextlib.py
+++ b/Lib/test/test_contextlib.py
@@ -1297,6 +1297,10 @@ class TestSuppress(ExceptionIsLikeMixin, unittest.TestCase):
                 [KeyError("ke1"), KeyError("ke2")],
             ),
         )
+        # Check handling of BaseExceptionGroup, using GeneratorExit so that
+        # we don't accidentally discard a ctrl-c with KeyboardInterrupt.
+        with suppress(GeneratorExit):
+            raise BaseExceptionGroup("message", [GeneratorExit()])
 
 
 class TestChdir(unittest.TestCase):

--- a/Misc/NEWS.d/next/Library/2023-11-09-10-45-56.gh-issue-103791.sdfkja.rst
+++ b/Misc/NEWS.d/next/Library/2023-11-09-10-45-56.gh-issue-103791.sdfkja.rst
@@ -1,0 +1,3 @@
+:class:`contextlib.suppress` now supports suppressing exceptions raised as
+part of a :exc:`BaseExceptionGroup`, in addition to the recent support for
+:exc:`ExceptionGroup`.


### PR DESCRIPTION
As suggested by @iritkatriel in https://github.com/python/cpython/pull/103792#discussion_r1387343565.

<!-- gh-issue-number: gh-103791 -->
* Issue: gh-103791
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--111910.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->