### PR TITLE
Edit stdlib2.rst: Tools for Working with Lists: edit implementation of breadth_first_search() 

### DIFF
--- a/Doc/tutorial/stdlib2.rst
+++ b/Doc/tutorial/stdlib2.rst
@@ -321,11 +321,12 @@ and breadth first tree searches::
 
    unsearched = deque([starting_node])
    def breadth_first_search(unsearched):
-       node = unsearched.popleft()
-       for m in gen_moves(node):
-           if is_goal(m):
-               return m
-           unsearched.append(m)
+       while unsearched:
+           node = unsearched.popleft()
+           if is_goal(node):
+               return node
+           for m in gen_moves(node):
+               unsearched.append(m)
 
 In addition to alternative list implementations, the library also offers other
 tools such as the :mod:`bisect` module with functions for manipulating sorted


### PR DESCRIPTION
I claim: the implementation of `breadth_first_search` is incorrect.

Argument 1:
The search does not check whether `is_goal(starting_node)`.
So, the implementation will fail to return `starting_node` when `is_goal(starting_node)`.

Argument 2:
The search stops after it checks and enqueues each child of `starting_node`. Put differently: the search enqueues each child of `starting_node` but does not proceed to apply `gen_moves` to each child.
So, the implementation will fail to return a goal if that goal has depth > 1.

This commit proposes two changes:
 - check whether `is_goal(starting_node)`
 - use `while` so search continues after it enqueues each child of `starting_node`
   - this permits search beyond depth = 1 

This commit does not propose adding a set for visited nodes, because the example specifies tree searches rather than graph searches: "These objects are well suited for implementing queues and breadth first tree searches...".


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--111925.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->