### PR TITLE
gh-111931: feature: implement slicing for _BaseNetwork

### DIFF
--- a/Lib/ipaddress.py
+++ b/Lib/ipaddress.py
@@ -682,16 +682,38 @@ class _BaseNetwork(_IPAddressBase):
     def __str__(self):
         return '%s/%d' % (self.network_address, self.prefixlen)
 
-    def hosts(self):
-        """Generate Iterator over usable hosts in a network.
+    def hosts(self, count=None, *, offset=0, step=None):
+        """Generate Iterator over a subset of usable hosts in a network.
 
-        This is like __iter__ except it doesn't return the network
+        This is similar to __iter__ except it doesn't return the network
         or broadcast addresses.
 
+        Similar to slices, we can start the hosts at a given offset from the
+        first host. An offset of zero represents the first usable host, not the
+        first address of the network. If the step value is None, a step of 1 is
+        used.
+
+        The count represents the limit for how many hosts we want. The number
+        of yielded hosts may be less than this count, if it exceeds the range
+        of usable hosts.
         """
         network = int(self.network_address)
         broadcast = int(self.broadcast_address)
-        for x in range(network + 1, broadcast):
+        start_host = network + offset + 1
+        if isinstance(count, int):
+            if count < 0:
+                raise ValueError("count must be a non-negative integer, not %s" % count)
+            end_host = min(start_host + count*step, broadcast - 1)
+        elif count is None:
+            end_host = broadcast - 1
+        else:
+            raise TypeError("count must be an integer or None, not %s" % type(count))
+
+        # TODO: support negative stepsize
+        if isinstance(step, int) and step < 1:
+            raise ValueError("step must be a non-zero positive integer, not %s" % step)
+
+        for x in range(start_host, end_host, step):
             yield self._address_class(x)
 
     def __iter__(self):
@@ -700,18 +722,33 @@ class _BaseNetwork(_IPAddressBase):
         for x in range(network, broadcast + 1):
             yield self._address_class(x)
 
-    def __getitem__(self, n):
+    def __getitem__(self, index):
+        """Gets an IP address from the network range, including the network
+        address and broadcast address.
+
+        The index may be an integer, returning a single address within the
+        network range, or a slice of addresses from the network.
+        If a slice is requested, the returned generator may be empty, since
+        slices do not respect boundaries.
+        """
         network = int(self.network_address)
         broadcast = int(self.broadcast_address)
-        if n >= 0:
-            if network + n > broadcast:
-                raise IndexError('address out of range')
-            return self._address_class(network + n)
+        if isinstance(index, slice):
+            start, stop, step = index.indices(broadcast - network + 1)
+            for i in range(start, stop, step):
+                yield self._address_class(network+i)
+        elif isinstance(index, int):
+            if index >= 0:
+                if network + index > broadcast:
+                    raise IndexError('address out of range: %s' % (index))
+                return self._address_class(network + index)
+            else:
+                index += 1
+                if broadcast + index < network:
+                    raise IndexError('address out of range')
+                return self._address_class(broadcast + index)
         else:
-            n += 1
-            if broadcast + n < network:
-                raise IndexError('address out of range')
-            return self._address_class(broadcast + n)
+            raise TypeError('index must be an int or a slice: %s, not %s' % (index, type(index)))
 
     def __lt__(self, other):
         if not isinstance(other, _BaseNetwork):

--- a/Misc/NEWS.d/next/Library/2023-11-10-05-46-21.gh-issue-111931.XfOs1X.rst
+++ b/Misc/NEWS.d/next/Library/2023-11-10-05-46-21.gh-issue-111931.XfOs1X.rst
@@ -1,0 +1,5 @@
+The ``ipaddress`` module now supports slicing for ``_BaseNetwork`` objects.
+
+This enhancement allows for more intuitive indexing. The ``__getitem__`` method of ``_BaseNetwork`` has been extended to additionally support slicing, and the ``hosts`` method has been extended to optionally request a specific count of hosts, with an ``offset`` and ``step`` size.
+
+Currently negative indexes aren't supported for reversed slices.


### PR DESCRIPTION
gh-111931: feature: implement slicing for `_BaseNetwork`

I have extended `_BaseNetwork.__getitem__` to directly support slicing,
and `_BaseNetwork.hosts` to offer a similar set of features. The
intention behind this is to facilitate accessing specific networking
requirements, without having to manually convert the generators to lists
as library users.

The standard approach for supporting slicing with `__getitem__` is to
add the sequence interface, but —because the length of a network could
either refer to the bitsize of the address, or the number of addresses
available in the network—, I have opted to avoid it as to avoid any
potential confusion.

While normally I would expect `__getitem__` to return a list of the same
type, and not a generator, I followed the approach of
`_BaseNetwork.hosts` of returning a generator instead. I imagine this is
a reasonable choice anyway: large networks, especially for IPv6 and
beyond, would return an unreasonably large list.

Negative indices and stepsizes are not supported in this implementation,
but adding support for this would be consistent with slices for other
data structures.

Potential breaking change: I have renamed the argument of
_BaseNetwork.__getitem__ from `n` to `index`, which I imagine should not
be a problem, unless people are explicitly calling the instance method
to access items for some reason.

Key changes include:
- extended `_BaseNetwork.__getitem__` to directly support slicing
- modified `_BaseNetwork.hosts` to support features similar to slicing
- Opted to return generators for both changed functions, as opposed to
  lists. the rationale here is for memory concerns in large networks.
- avoided implementing `__len__` to avoid any potential confusion
  between `_BaseNetwork.num_addresses` and `IPVxLENGTH`
- TODO: implement negative indices and step sizes for both
  `_BaseNetwork.__getitem__` and `_BaseNetwork.hosts`

Signed-Off-By: Mazunki Hoksaas <rolferen@gmail.com>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
