### PR TITLE
[3.12] gh-109370: Fix unexpected traceback output in test_concurrent_futures (GH-109780)

### DIFF
--- a/Lib/concurrent/futures/process.py
+++ b/Lib/concurrent/futures/process.py
@@ -526,7 +526,8 @@ class _ExecutorManagerThread(threading.Thread):
 
         # gh-107219: Close the connection writer which can unblock
         # Queue._feed() if it was stuck in send_bytes().
-        self.call_queue._writer.close()
+        if sys.platform == 'win32':
+            self.call_queue._writer.close()
 
         # clean up resources
         self._join_executor_internals(broken=True)

--- a/Lib/multiprocessing/connection.py
+++ b/Lib/multiprocessing/connection.py
@@ -42,7 +42,6 @@ except ImportError:
 BUFSIZE = 8192
 # A very generous timeout when it comes to local connections...
 CONNECTION_TIMEOUT = 20.
-WSA_OPERATION_ABORTED = 995
 
 _mmap_counter = itertools.count()
 
@@ -300,7 +299,7 @@ if _winapi:
             finally:
                 self._send_ov = None
                 nwritten, err = ov.GetOverlappedResult(True)
-            if err == WSA_OPERATION_ABORTED:
+            if err == _winapi.ERROR_OPERATION_ABORTED:
                 # close() was called by another thread while
                 # WaitForMultipleObjects() was waiting for the overlapped
                 # operation.


### PR DESCRIPTION
Follow-up of gh-107219.

* Only close the connection writer on Windows.
* Also use existing constant _winapi.ERROR_OPERATION_ABORTED instead of WSA_OPERATION_ABORTED.

(cherry picked from commit 0b4e090422db5f959184353d53552d1675f74212)


<!-- gh-issue-number: gh-109370 -->
* Issue: gh-109370
<!-- /gh-issue-number -->
