### PR TITLE
gh-111933: fix broken link to A.Neumaier article

### DIFF
--- a/Python/bltinmodule.c
+++ b/Python/bltinmodule.c
@@ -2611,9 +2611,10 @@ builtin_sum_impl(PyObject *module, PyObject *iterable, PyObject *start)
             }
             if (PyFloat_CheckExact(item)) {
                 // Improved Kahan–Babuška algorithm by Arnold Neumaier
-                // Neumaier, A. (1974), Rundungsfehleranalyse einiger Verfahren zur Summation endlicher Summen.
-                // Z. angew. Math. Mech., 54: 39-51. https://doi.org/10.1002/zamm.19740540106
-                // https://web.archive.org/web/20220804051351/https://www.mat.univie.ac.at/~neum/scan/01.pdf
+                // Neumaier, A. (1974), Rundungsfehleranalyse einiger Verfahren
+                // zur Summation endlicher Summen.  Z. angew. Math. Mech.,
+                // 54: 39-51. https://doi.org/10.1002/zamm.19740540106
+                // Scanned text: https://arnold-neumaier.at/scan/01.pdf
                 double x = PyFloat_AS_DOUBLE(item);
                 double t = f_result + x;
                 if (fabs(f_result) >= fabs(x)) {

--- a/Python/bltinmodule.c
+++ b/Python/bltinmodule.c
@@ -2611,7 +2611,7 @@ builtin_sum_impl(PyObject *module, PyObject *iterable, PyObject *start)
             }
             if (PyFloat_CheckExact(item)) {
                 // Improved Kahan–Babuška algorithm by Arnold Neumaier
-                // https://www.mat.univie.ac.at/~neum/scan/01.pdf
+                // https://web.archive.org/web/20220804051351/https://www.mat.univie.ac.at/~neum/scan/01.pdf
                 double x = PyFloat_AS_DOUBLE(item);
                 double t = f_result + x;
                 if (fabs(f_result) >= fabs(x)) {

--- a/Python/bltinmodule.c
+++ b/Python/bltinmodule.c
@@ -2611,6 +2611,8 @@ builtin_sum_impl(PyObject *module, PyObject *iterable, PyObject *start)
             }
             if (PyFloat_CheckExact(item)) {
                 // Improved Kahan–Babuška algorithm by Arnold Neumaier
+                // Neumaier, A. (1974), Rundungsfehleranalyse einiger Verfahren zur Summation endlicher Summen.
+                // Z. angew. Math. Mech., 54: 39-51. https://doi.org/10.1002/zamm.19740540106
                 // https://web.archive.org/web/20220804051351/https://www.mat.univie.ac.at/~neum/scan/01.pdf
                 double x = PyFloat_AS_DOUBLE(item);
                 double t = f_result + x;

--- a/Python/bltinmodule.c
+++ b/Python/bltinmodule.c
@@ -2614,7 +2614,7 @@ builtin_sum_impl(PyObject *module, PyObject *iterable, PyObject *start)
                 // Neumaier, A. (1974), Rundungsfehleranalyse einiger Verfahren
                 // zur Summation endlicher Summen.  Z. angew. Math. Mech.,
                 // 54: 39-51. https://doi.org/10.1002/zamm.19740540106
-                // Scanned text: https://arnold-neumaier.at/scan/01.pdf
+                // https://en.wikipedia.org/wiki/Kahan_summation_algorithm#Further_enhancements
                 double x = PyFloat_AS_DOUBLE(item);
                 double t = f_result + x;
                 if (fabs(f_result) >= fabs(x)) {


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
It seems there are links to the archive.org in comments across the codebase.  So, I hope it's fine.

Alternatively, we could point to the journal page: https://doi.org/10.1002/zamm.19740540106 (not open access, however).  Or just add a citation (Neumaier, A. (1974), Rundungsfehleranalyse einiger Verfahren zur Summation endlicher Summen. Z. angew. Math. Mech., 54: 39-51.).

<!-- gh-issue-number: gh-111933 -->
* Issue: gh-111933
<!-- /gh-issue-number -->
