### PR TITLE
[3.12] gh-111929: Fix regrtest --pgo: test_str => test_unicode

### DIFF
--- a/Lib/test/libregrtest/pgo.py
+++ b/Lib/test/libregrtest/pgo.py
@@ -42,10 +42,10 @@ PGO_TESTS = [
     'test_set',
     'test_sqlite3',
     'test_statistics',
-    'test_str',
     'test_struct',
     'test_tabnanny',
     'test_time',
+    'test_unicode',
     'test_xml_etree',
     'test_xml_etree_c',
 ]


### PR DESCRIPTION
test_unicode was renamed to test_str in Python 3.13, but Python 3.12 still uses test_unicode name.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-111929 -->
* Issue: gh-111929
<!-- /gh-issue-number -->
