### PR TITLE
[3.11] gh-111929: Fix regrtest clear_caches()

### DIFF
--- a/Lib/test/libregrtest/utils.py
+++ b/Lib/test/libregrtest/utils.py
@@ -272,13 +272,6 @@ def clear_caches():
         for f in typing._cleanups:
             f()
 
-    try:
-        fractions = sys.modules['fractions']
-    except KeyError:
-        pass
-    else:
-        fractions._hash_algorithm.cache_clear()
-
 
 def get_build_info():
     # Get most important configure and build options as a list of strings.


### PR DESCRIPTION
Python 3.11 doesn't have the fractions._hash_algorithm.cache_clear() function.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-111929 -->
* Issue: gh-111929
<!-- /gh-issue-number -->
