### PR TITLE
Add private _PyUnicode_AsUTF8() function

### DIFF
--- a/Include/internal/pycore_unicodeobject.h
+++ b/Include/internal/pycore_unicodeobject.h
@@ -434,6 +434,10 @@ struct _Py_unicode_state {
 extern void _PyUnicode_InternInPlace(PyInterpreterState *interp, PyObject **p);
 extern void _PyUnicode_ClearInterned(PyInterpreterState *interp);
 
+// Like PyUnicode_AsUTF8(), but check for embedded null characters.
+// Export for '_sqlite3' shared extension.
+PyAPI_FUNC(const char *) _PyUnicode_AsUTF8(PyObject *);
+
 
 #ifdef __cplusplus
 }

--- a/Include/internal/pycore_unicodeobject.h
+++ b/Include/internal/pycore_unicodeobject.h
@@ -436,7 +436,7 @@ extern void _PyUnicode_ClearInterned(PyInterpreterState *interp);
 
 // Like PyUnicode_AsUTF8(), but check for embedded null characters.
 // Export for '_sqlite3' shared extension.
-PyAPI_FUNC(const char *) _PyUnicode_AsUTF8(PyObject *);
+PyAPI_FUNC(const char *) _PyUnicode_AsUTF8NoNUL(PyObject *);
 
 
 #ifdef __cplusplus

--- a/Modules/_io/textio.c
+++ b/Modules/_io/textio.c
@@ -1020,13 +1020,8 @@ io_check_errors(PyObject *errors)
         return 0;
     }
 
-    Py_ssize_t name_length;
-    const char *name = PyUnicode_AsUTF8AndSize(errors, &name_length);
+    const char *name = _PyUnicode_AsUTF8(errors);
     if (name == NULL) {
-        return -1;
-    }
-    if (strlen(name) != (size_t)name_length) {
-        PyErr_SetString(PyExc_ValueError, "embedded null character in errors");
         return -1;
     }
     PyObject *handler = PyCodec_LookupError(name);

--- a/Modules/_io/textio.c
+++ b/Modules/_io/textio.c
@@ -1020,7 +1020,7 @@ io_check_errors(PyObject *errors)
         return 0;
     }
 
-    const char *name = _PyUnicode_AsUTF8(errors);
+    const char *name = _PyUnicode_AsUTF8NoNUL(errors);
     if (name == NULL) {
         return -1;
     }

--- a/Modules/_sqlite/connection.c
+++ b/Modules/_sqlite/connection.c
@@ -76,16 +76,10 @@ isolation_level_converter(PyObject *str_or_none, const char **result)
         *result = NULL;
     }
     else if (PyUnicode_Check(str_or_none)) {
-        Py_ssize_t sz;
-        const char *str = PyUnicode_AsUTF8AndSize(str_or_none, &sz);
+        const char *str = _PyUnicode_AsUTF8(str_or_none);
         if (str == NULL) {
             return 0;
         }
-        if (strlen(str) != (size_t)sz) {
-            PyErr_SetString(PyExc_ValueError, "embedded null character");
-            return 0;
-        }
-
         const char *level = get_isolation_level(str);
         if (level == NULL) {
             return 0;

--- a/Modules/_sqlite/connection.c
+++ b/Modules/_sqlite/connection.c
@@ -76,7 +76,7 @@ isolation_level_converter(PyObject *str_or_none, const char **result)
         *result = NULL;
     }
     else if (PyUnicode_Check(str_or_none)) {
-        const char *str = _PyUnicode_AsUTF8(str_or_none);
+        const char *str = _PyUnicode_AsUTF8NoNUL(str_or_none);
         if (str == NULL) {
             return 0;
         }

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -3847,6 +3847,18 @@ PyUnicode_AsUTF8(PyObject *unicode)
     return PyUnicode_AsUTF8AndSize(unicode, NULL);
 }
 
+const char *
+_PyUnicode_AsUTF8(PyObject *unicode)
+{
+    Py_ssize_t size;
+    const char *s = PyUnicode_AsUTF8AndSize(unicode, &size);
+    if (s && strlen(s) != (size_t)size) {
+        PyErr_SetString(PyExc_ValueError, "embedded null character");
+        return NULL;
+    }
+    return s;
+}
+
 /*
 PyUnicode_GetSize() has been deprecated since Python 3.3
 because it returned length of Py_UNICODE.

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -3848,7 +3848,7 @@ PyUnicode_AsUTF8(PyObject *unicode)
 }
 
 const char *
-_PyUnicode_AsUTF8(PyObject *unicode)
+_PyUnicode_AsUTF8NoNUL(PyObject *unicode)
 {
     Py_ssize_t size;
     const char *s = PyUnicode_AsUTF8AndSize(unicode, &size);


### PR DESCRIPTION
Like PyUnicode_AsUTF8(), but check for embedded null characters.

It is only used in two places, but I am planning to use it more.

Since it is a private function, I do not expect a hot discussion about it. I added similar variants of `PyUnicode_AsUnicode()` in the past.