### PR TITLE
gh-111969: refactor to make it easier to construct a dis.Instruction object

### DIFF
--- a/Lib/test/test_dis.py
+++ b/Lib/test/test_dis.py
@@ -2001,6 +2001,24 @@ class InstructionTests(InstructionTestCase):
                                   positions=None)
         self.assertEqual(10 + 2 + 1*2 + 100*2, instruction.jump_target)
 
+    def test_argval_argrepr(self):
+        f = dis.Instruction._get_argval_argrepr
+
+        offset = 42
+        co_consts = (0, 1, 2, 3)
+        names = {1: 'a', 2: 'b'}
+        varname_from_oparg = lambda i : names[i]
+        args = (offset, co_consts, names, varname_from_oparg)
+        self.assertEqual(f(opcode.opmap["POP_TOP"], None, *args), (None, ''))
+        self.assertEqual(f(opcode.opmap["LOAD_CONST"], 1, *args), (1, '1'))
+        self.assertEqual(f(opcode.opmap["LOAD_GLOBAL"], 2, *args), ('a', 'a'))
+        self.assertEqual(f(opcode.opmap["JUMP_BACKWARD"], 11, *args), (24, 'to 24'))
+        self.assertEqual(f(opcode.opmap["COMPARE_OP"], 3, *args), ('<', '<'))
+        self.assertEqual(f(opcode.opmap["SET_FUNCTION_ATTRIBUTE"], 2, *args), (2, 'kwdefaults'))
+        self.assertEqual(f(opcode.opmap["BINARY_OP"], 3, *args), (3, '<<'))
+        self.assertEqual(f(opcode.opmap["CALL_INTRINSIC_1"], 2, *args), (2, 'INTRINSIC_IMPORT_STAR'))
+
+
     def test_start_offset(self):
         # When no extended args are present,
         # start_offset should be equal to offset

--- a/Lib/test/test_dis.py
+++ b/Lib/test/test_dis.py
@@ -2018,7 +2018,6 @@ class InstructionTests(InstructionTestCase):
         self.assertEqual(f(opcode.opmap["BINARY_OP"], 3, *args), (3, '<<'))
         self.assertEqual(f(opcode.opmap["CALL_INTRINSIC_1"], 2, *args), (2, 'INTRINSIC_IMPORT_STAR'))
 
-
     def test_start_offset(self):
         # When no extended args are present,
         # start_offset should be equal to offset


### PR DESCRIPTION
This extracts the argval, argrepr calculation into a separate method (of Instruction) so that it can be reused from a (new) factory method. I don't want to document the factory method for now, so that its signature can still change.


<!-- gh-issue-number: gh-111969 -->
* Issue: gh-111969
<!-- /gh-issue-number -->
