### PR TITLE
gh-110481: fix 'unused function' warning for `is_shared_refcnt_dead`.

### DIFF
--- a/Objects/object.c
+++ b/Objects/object.c
@@ -297,15 +297,17 @@ _Py_DecRef(PyObject *o)
 }
 
 #ifdef Py_NOGIL
+# ifdef Py_REF_DEBUG
 static inline int
 is_shared_refcnt_dead(Py_ssize_t shared)
 {
-#if SIZEOF_SIZE_T == 8
+#  if SIZEOF_SIZE_T == 8
     return shared == (Py_ssize_t)0xDDDDDDDDDDDDDDDD;
-#else
+#  else
     return shared == (Py_ssize_t)0xDDDDDDDD;
-#endif
+#  endif
 }
+# endif
 
 void
 _Py_DecRefSharedDebug(PyObject *o, const char *filename, int lineno)
@@ -412,7 +414,7 @@ _Py_ExplicitMergeRefcount(PyObject *op, Py_ssize_t extra)
     _Py_atomic_store_uintptr_relaxed(&op->ob_tid, 0);
     return refcnt;
 }
-#endif
+#endif  /* Py_NOGIL */
 
 
 /**************************************/


### PR DESCRIPTION
The `is_shared_refcnt_dead` function is only used if `Py_REF_DEBUG` is set.

<!-- gh-issue-number: gh-110481 -->
* Issue: gh-110481
<!-- /gh-issue-number -->
