### PR TITLE
gh-109538: Catch closed loop runtime error and issue warning

### DIFF
--- a/Lib/asyncio/streams.py
+++ b/Lib/asyncio/streams.py
@@ -406,11 +406,10 @@ class StreamWriter:
 
     def __del__(self, warnings=warnings):
         if not self._transport.is_closing():
-            try:
-                self.close()
-            except RuntimeError:
+            if self._loop.is_closed():
                 warnings.warn("loop is closed", ResourceWarning)
             else:
+                self.close()
                 warnings.warn(f"unclosed {self!r}", ResourceWarning)
 
 class StreamReader:

--- a/Lib/asyncio/streams.py
+++ b/Lib/asyncio/streams.py
@@ -406,9 +406,12 @@ class StreamWriter:
 
     def __del__(self, warnings=warnings):
         if not self._transport.is_closing():
-            self.close()
-            warnings.warn(f"unclosed {self!r}", ResourceWarning)
-
+            try:
+                self.close()
+            except RuntimeError:
+                warnings.warn("loop is closed", ResourceWarning)
+            else:
+                warnings.warn(f"unclosed {self!r}", ResourceWarning)
 
 class StreamReader:
 

--- a/Lib/test/test_asyncio/test_streams.py
+++ b/Lib/test/test_asyncio/test_streams.py
@@ -1082,16 +1082,50 @@ os.close(fd)
             self.assertEqual(data, b'HTTP/1.0 200 OK\r\n')
             data = await rd.read()
             self.assertTrue(data.endswith(b'\r\n\r\nTest message'))
-            with self.assertWarns(ResourceWarning):
+            with self.assertWarns(ResourceWarning) as cm:
                 del wr
                 gc.collect()
-
+                self.assertEqual(len(cm.warnings), 1)
+                self.assertTrue(str(cm.warnings[0].message).startswith("unclosed <StreamWriter"))
 
         messages = []
         self.loop.set_exception_handler(lambda loop, ctx: messages.append(ctx))
 
         with test_utils.run_test_server() as httpd:
             self.loop.run_until_complete(inner(httpd))
+
+        self.assertEqual(messages, [])
+
+    def test_loop_is_closed_resource_warnings(self):
+        async def inner(httpd):
+            rd, wr = await asyncio.open_connection(*httpd.address)
+
+            wr.write(b'GET / HTTP/1.0\r\n\r\n')
+            data = await rd.readline()
+            self.assertEqual(data, b'HTTP/1.0 200 OK\r\n')
+            data = await rd.read()
+            self.assertTrue(data.endswith(b'\r\n\r\nTest message'))
+            self.loop.stop()
+            wr.close()
+            while not wr._loop.is_closed():
+                await asyncio.sleep(0.0)
+
+            with self.assertWarns(ResourceWarning) as cm:
+                del wr
+                gc.collect()
+                self.assertEqual(len(cm.warnings), 1)
+                self.assertEqual("loop is closed", str(cm.warnings[0].message))
+
+        messages = []
+        self.loop.set_exception_handler(lambda loop, ctx: messages.append(ctx))
+
+        with test_utils.run_test_server() as httpd:
+            try:
+                self.loop.run_until_complete(inner(httpd))
+            except RuntimeError:
+                pass
+            finally:
+                gc.collect()
 
         self.assertEqual(messages, [])
 

--- a/Misc/NEWS.d/next/Library/2023-11-11-16-42-48.gh-issue-109538.cMG5ux.rst
+++ b/Misc/NEWS.d/next/Library/2023-11-11-16-42-48.gh-issue-109538.cMG5ux.rst
@@ -1,1 +1,1 @@
-Issue warning message instead of having :class:`RuntimeError` be displayed when event loop has already been closed at :method:`StreamWriter.__del__`
+Issue warning message instead of having :class:`RuntimeError` be displayed when event loop has already been closed at :meth:`StreamWriter.__del__`.

--- a/Misc/NEWS.d/next/Library/2023-11-11-16-42-48.gh-issue-109538.cMG5ux.rst
+++ b/Misc/NEWS.d/next/Library/2023-11-11-16-42-48.gh-issue-109538.cMG5ux.rst
@@ -1,0 +1,1 @@
+Issue warning message instead of having :class:`RuntimeError` be displayed when event loop has already been closed at :method:`StreamWriter.__del__`


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
Catch RuntimeError("Event loop is closed") from base_events.py line 514 then issue a warning to user

<!-- gh-issue-number: gh-109538 -->
* Issue: gh-109538
<!-- /gh-issue-number -->
