### PR TITLE
[3.12] gh-108447: Detect platform triplets for x86_64 GNU/Hurd (GH-108045)

### DIFF
--- a/Misc/NEWS.d/next/Build/2023-08-24-18-36-31.gh-issue-108447.Ofsygr.rst
+++ b/Misc/NEWS.d/next/Build/2023-08-24-18-36-31.gh-issue-108447.Ofsygr.rst
@@ -1,0 +1,1 @@
+Fix x86_64 GNU/Hurd build

--- a/configure
+++ b/configure
@@ -6899,7 +6899,13 @@ cat > conftest.c <<EOF
 #   error unknown platform triplet
 # endif
 #elif defined(__gnu_hurd__)
+# if defined(__x86_64__) && defined(__LP64__)
+        x86_64-gnu
+# elif defined(__i386__)
         i386-gnu
+# else
+#   error unknown platform triplet
+# endif
 #elif defined(__APPLE__)
         darwin
 #elif defined(__VXWORKS__)

--- a/configure.ac
+++ b/configure.ac
@@ -1078,7 +1078,13 @@ cat > conftest.c <<EOF
 #   error unknown platform triplet
 # endif
 #elif defined(__gnu_hurd__)
+# if defined(__x86_64__) && defined(__LP64__)
+        x86_64-gnu
+# elif defined(__i386__)
         i386-gnu
+# else
+#   error unknown platform triplet
+# endif
 #elif defined(__APPLE__)
         darwin
 #elif defined(__VXWORKS__)


### PR DESCRIPTION
(cherry picked from commit edb569e8e1f469ac5ce629cc647ab169d895de41)

<!-- gh-issue-number: gh-108447 -->
* Issue: gh-108447
<!-- /gh-issue-number -->
