### PR TITLE
gh-111995: Add getnameinfo extension flag

### DIFF
--- a/Misc/NEWS.d/next/Library/2023-11-14-16-31-59.gh-issue-111995.OoX8JJ.rst
+++ b/Misc/NEWS.d/next/Library/2023-11-14-16-31-59.gh-issue-111995.OoX8JJ.rst
@@ -1,0 +1,2 @@
+Added the ``NI_IDN`` constant to the :mod:`socket` module when present in C
+at build time for use with :func:`socket.getnameinfo`.

--- a/Modules/socketmodule.c
+++ b/Modules/socketmodule.c
@@ -8809,6 +8809,9 @@ socket_exec(PyObject *m)
 #ifdef NI_DGRAM
     ADD_INT_MACRO(m, NI_DGRAM);
 #endif
+#ifdef NI_IDN
+    ADD_INT_MACRO(m, NI_IDN);
+#endif
 
     /* shutdown() parameters */
 #ifdef SHUT_RD


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

This PR adds the `NI_IDN` `getnameinfo` extension flag.

See: https://man7.org/linux/man-pages/man3/getnameinfo.3.html

The other two flags (`NI_IDN_ALLOW_UNASSIGNED`, `NI_IDN_USE_STD3_ASCII_RULES`) are deprecated and I deliberately did not include them in the patch.

<!-- gh-issue-number: gh-111995 -->
* Issue: gh-111995
<!-- /gh-issue-number -->

Fixes #111995.