### PR TITLE
[3.12] gh-111681: minor fixes to typing doctests; remove unused imports in `test_typing` (#111682)

### DIFF
--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -1941,7 +1941,7 @@ without the dedicated syntax, as documented below.
 
    .. doctest::
 
-      >>> from typing import ParamSpec
+      >>> from typing import ParamSpec, get_origin
       >>> P = ParamSpec("P")
       >>> get_origin(P.args) is P
       True

--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -9,8 +9,7 @@ import itertools
 import pickle
 import re
 import sys
-import warnings
-from unittest import TestCase, main, skipUnless, skip
+from unittest import TestCase, main, skip
 from unittest.mock import patch
 from copy import copy, deepcopy
 
@@ -45,7 +44,7 @@ import typing
 import weakref
 import types
 
-from test.support import import_helper, captured_stderr, cpython_only
+from test.support import captured_stderr, cpython_only
 from test.typinganndata import mod_generics_cache, _typed_dict_helper
 
 

--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -9,6 +9,7 @@ import itertools
 import pickle
 import re
 import sys
+import warnings
 from unittest import TestCase, main, skip
 from unittest.mock import patch
 from copy import copy, deepcopy


### PR DESCRIPTION
(cherry-picked from commit ccc8caa8587103c4ccf617ba106cef63344504dd)

Just doing this to reduce the risk of future merge conflicts when backporting changes to docs or tests.

<!-- gh-issue-number: gh-111681 -->
* Issue: gh-111681
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--112035.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->