### PR TITLE
[3.11] gh-111681: minor fix to a typing doctest (#111682)

### DIFF
--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -1785,7 +1785,7 @@ for creating generic types.
 
    .. doctest::
 
-      >>> from typing import ParamSpec
+      >>> from typing import ParamSpec, get_origin
       >>> P = ParamSpec("P")
       >>> get_origin(P.args) is P
       True


### PR DESCRIPTION
(cherry-picked from commit https://github.com/python/cpython/commit/ccc8caa8587103c4ccf617ba106cef63344504dd)

As with the 3.12 backport, I'm just doing this to reduce the risk of future merge conflicts when backporting changes to docs or tests.

<!-- gh-issue-number: gh-111681 -->
* Issue: gh-111681
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--112037.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->