### PR TITLE
gh-111856: fix os.fstat on windows with fat32 and exfat filesystem

### DIFF
--- a/Misc/NEWS.d/next/Windows/2023-11-13-22-35-27.gh-issue-111856.vEtA5z.rst
+++ b/Misc/NEWS.d/next/Windows/2023-11-13-22-35-27.gh-issue-111856.vEtA5z.rst
@@ -1,0 +1,2 @@
+Fixes :func:`~os.fstat` on file systems that do not support file ID
+requests. This includes FAT32 and exFAT.

--- a/Python/fileutils.c
+++ b/Python/fileutils.c
@@ -1239,6 +1239,7 @@ _Py_fstat_noraise(int fd, struct _Py_stat_struct *status)
     BY_HANDLE_FILE_INFORMATION info;
     FILE_BASIC_INFO basicInfo;
     FILE_ID_INFO idInfo;
+    FILE_ID_INFO *pIdInfo = &idInfo;
     HANDLE h;
     int type;
 
@@ -1271,15 +1272,19 @@ _Py_fstat_noraise(int fd, struct _Py_stat_struct *status)
     }
 
     if (!GetFileInformationByHandle(h, &info) ||
-        !GetFileInformationByHandleEx(h, FileBasicInfo, &basicInfo, sizeof(basicInfo)) ||
-        !GetFileInformationByHandleEx(h, FileIdInfo, &idInfo, sizeof(idInfo))) {
+        !GetFileInformationByHandleEx(h, FileBasicInfo, &basicInfo, sizeof(basicInfo))) {
         /* The Win32 error is already set, but we also set errno for
            callers who expect it */
         errno = winerror_to_errno(GetLastError());
         return -1;
     }
 
-    _Py_attribute_data_to_stat(&info, 0, &basicInfo, &idInfo, status);
+    if (!GetFileInformationByHandleEx(h, FileIdInfo, &idInfo, sizeof(idInfo))) {
+        /* Failed to get FileIdInfo, so do not pass it along */
+        pIdInfo = NULL;
+    }
+
+    _Py_attribute_data_to_stat(&info, 0, &basicInfo, pIdInfo, status);
     return 0;
 #else
     return fstat(fd, status);


### PR DESCRIPTION
The change is just like #104892.

I think this is hard to test this on GHA, since it needs a disk with fat32 or exfat filesystem. I made a test on my local machine, the drive "E://" is a fat32 filesystem.

Test codes:

```py
import os

f = open("e://a.jpg")
print(os.stat(f.fileno()))
f.close()
```

Before the comit:

```
C:\Users\xxxxx\Source\cpython>python a.py
Running Debug|x64 interpreter...
Traceback (most recent call last):
  File "C:\Users\xxxxx\Source\cpython\a.py", line 4, in <module>
    print(os.stat(f.fileno()))
          ^^^^^^^^^^^^^^^^^^^
OSError: [WinError 87] 参数错误。: 3
sys:1: ResourceWarning: unclosed file <_io.TextIOWrapper name='e://a.jpg' mode='r' encoding='cp936'>
```

After the commit:

```
C:\Users\xxxxx\Source\cpython>python a.py
Running Debug|x64 interpreter...
os.stat_result(st_mode=33206, st_ino=4194592, st_dev=1548577950, st_nlink=1, st_uid=0, st_gid=0, st_size=2812450, st_atime=1699718400, st_mtime=1673715360, st_ctime=-11644473600)
```

<!-- gh-issue-number: gh-111856 -->
* Issue: gh-111856
<!-- /gh-issue-number -->
