### PR TITLE
Update appendix.rst -- 'nonzero exit' -> 'nonzero exit status'

### DIFF
--- a/Doc/tutorial/appendix.rst
+++ b/Doc/tutorial/appendix.rst
@@ -20,7 +20,7 @@ In interactive mode, it then returns to the primary prompt; when input came from
 a file, it exits with a nonzero exit status after printing the stack trace.
 (Exceptions handled by an :keyword:`except` clause in a :keyword:`try` statement
 are not errors in this context.)  Some errors are unconditionally fatal and
-cause an exit with a nonzero exit; this applies to internal inconsistencies and
+cause an exit with a nonzero exit status; this applies to internal inconsistencies and
 some cases of running out of memory.  All error messages are written to the
 standard error stream; normal output from executed commands is written to
 standard output.


### PR DESCRIPTION
Add single word 'status'.

The paragraph includes the phrase 'nonzero exit status'. Later in the paragraph 'nonzero exit' occurs. I propose to use the same phrase in both places. 

The sentence I edit 
```
Some errors are unconditionally fatal and cause an exit with a nonzero exit
```
uses 'exit' twice with two different meanings. The proposal to use the phrase 'exit status' will distinguish these two uses. 


Other places in the documentation use similar phrases, e.g. 
1. 'exits with status code' -- https://docs.python.org/3/library/__main__.html?#import-main
2. 'exiting with the specified status' --  https://docs.python.org/3/library/argparse.html?#argparse.ArgumentParser.exit

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--112039.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->