### PR TITLE
gh-112026: Add again <unistd.h> include in Python.h

### DIFF
--- a/Doc/whatsnew/3.13.rst
+++ b/Doc/whatsnew/3.13.rst
@@ -1178,30 +1178,12 @@ Porting to Python 3.13
   also the ``HAVE_IEEEFP_H`` macro.
   (Contributed by Victor Stinner in :gh:`108765`.)
 
-* ``Python.h`` no longer includes the ``<unistd.h>`` standard header file. If
-  needed, it should now be included explicitly. For example, it provides the
-  functions: ``read()``, ``write()``, ``close()``, ``isatty()``, ``lseek()``,
-  ``getpid()``, ``getcwd()``, ``sysconf()``, ``getpagesize()``, ``alarm()`` and
-  ``pause()``.
-  As a consequence, ``_POSIX_SEMAPHORES`` and ``_POSIX_THREADS`` macros are no
-  longer defined by ``Python.h``. The ``HAVE_UNISTD_H`` and ``HAVE_PTHREAD_H``
-  macros defined by ``Python.h`` can be used to decide if ``<unistd.h>`` and
-  ``<pthread.h>`` header files can be included.
-  (Contributed by Victor Stinner in :gh:`108765`.)
-
 * ``Python.h`` no longer includes these standard header files: ``<time.h>``,
   ``<sys/select.h>`` and ``<sys/time.h>``. If needed, they should now be
   included explicitly. For example, ``<time.h>`` provides the ``clock()`` and
   ``gmtime()`` functions, ``<sys/select.h>`` provides the ``select()``
   function, and ``<sys/time.h>`` provides the ``futimes()``, ``gettimeofday()``
   and ``setitimer()`` functions.
-  (Contributed by Victor Stinner in :gh:`108765`.)
-
-* ``Python.h`` no longer includes the ``<ctype.h>`` standard header file. If
-  needed, it should now be included explicitly. For example, it provides
-  ``isalpha()`` and ``tolower()`` functions which are locale dependent. Python
-  provides locale independent functions, like :c:func:`!Py_ISALPHA` and
-  :c:func:`!Py_TOLOWER`.
   (Contributed by Victor Stinner in :gh:`108765`.)
 
 * If the :c:macro:`Py_LIMITED_API` macro is defined, :c:macro:`!Py_BUILD_CORE`,

--- a/Include/Python.h
+++ b/Include/Python.h
@@ -40,7 +40,9 @@
 #endif
 #if !defined(Py_LIMITED_API) || Py_LIMITED_API+0 < 0x030d0000
 #  include <ctype.h>              // tolower()
-#  include <unistd.h>             // close()
+#  ifndef MS_WINDOWS
+#    include <unistd.h>           // close()
+#  endif
 #endif
 
 

--- a/Include/Python.h
+++ b/Include/Python.h
@@ -26,14 +26,21 @@
 #  include <sys/types.h>          // ssize_t
 #endif
 
-// errno.h, stdio.h, stdlib.h and string.h headers are no longer used by
-// Python, but kept for backward compatibility (avoid compiler warnings).
-// They are no longer included by limited C API version 3.11 and newer.
+// <errno.h>, <stdio.h>, <stdlib.h> and <string.h> headers are no longer used
+// by Python, but kept for the backward compatibility of existing third party C
+// extensions. They are not included by limited C API version 3.11 and newer.
+//
+// The <ctype.h> and <unistd.h> headers are not included by limited C API
+// version 3.13 and newer.
 #if !defined(Py_LIMITED_API) || Py_LIMITED_API+0 < 0x030b0000
 #  include <errno.h>              // errno
 #  include <stdio.h>              // FILE*
 #  include <stdlib.h>             // getenv()
 #  include <string.h>             // memcpy()
+#endif
+#if !defined(Py_LIMITED_API) || Py_LIMITED_API+0 < 0x030d0000
+#  include <ctype.h>              // tolower()
+#  include <unistd.h>             // close()
 #endif
 
 

--- a/Misc/NEWS.d/next/C API/2023-11-13-17-57-11.gh-issue-112026.WJLJcI.rst
+++ b/Misc/NEWS.d/next/C API/2023-11-13-17-57-11.gh-issue-112026.WJLJcI.rst
@@ -1,0 +1,3 @@
+Add again ``<ctype.h>`` and ``<unistd.h>`` includes in ``Python.h``, but
+don't include them in the limited C API version 3.13 and newer. Patch by
+Victor Stinner.


### PR DESCRIPTION
Add again <ctype.h> and <unistd.h> includes in Python.h, but don't include them in the limited C API version 3.13 and newer.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-112026 -->
* Issue: gh-112026
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--112046.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->