### PR TITLE
gh-111962: Make dtoa thread-safe in `--disable-gil` builds.

### DIFF
--- a/Include/internal/pycore_dtoa.h
+++ b/Include/internal/pycore_dtoa.h
@@ -36,7 +36,7 @@ struct _dtoa_state {
 #define Bigint_Kmax 7
 
 /* The size of the cached powers of 5 array */
-#define Bigint_Pow5max 8
+#define Bigint_Pow5size 8
 
 #ifndef PRIVATE_MEM
 #define PRIVATE_MEM 2304
@@ -45,8 +45,9 @@ struct _dtoa_state {
     ((PRIVATE_MEM+sizeof(double)-1)/sizeof(double))
 
 struct _dtoa_state {
-    /* p5s is an array of powers of 5 of the form 5**(2**i), i >= 2 */
-    struct Bigint *p5s[Bigint_Pow5max];
+    // p5s is an array of powers of 5 of the form:
+    // 5**(2**(i+2)) for 0 <= i < Bigint_Pow5size
+    struct Bigint *p5s[Bigint_Pow5size];
     // XXX This should be freed during runtime fini.
     struct Bigint *freelist[Bigint_Kmax+1];
     double preallocated[Bigint_PREALLOC_SIZE];

--- a/Include/internal/pycore_dtoa.h
+++ b/Include/internal/pycore_dtoa.h
@@ -36,7 +36,7 @@ struct _dtoa_state {
 #define Bigint_Kmax 7
 
 /* The size of the cached powers of 5 array */
-#define Bigint_Pow5max 7
+#define Bigint_Pow5max 8
 
 #ifndef PRIVATE_MEM
 #define PRIVATE_MEM 2304

--- a/Include/internal/pycore_dtoa.h
+++ b/Include/internal/pycore_dtoa.h
@@ -35,6 +35,9 @@ struct _dtoa_state {
 /* The size of the Bigint freelist */
 #define Bigint_Kmax 7
 
+/* The size of the cached powers of 5 array */
+#define Bigint_Pow5max 7
+
 #ifndef PRIVATE_MEM
 #define PRIVATE_MEM 2304
 #endif
@@ -42,9 +45,9 @@ struct _dtoa_state {
     ((PRIVATE_MEM+sizeof(double)-1)/sizeof(double))
 
 struct _dtoa_state {
-    /* p5s is a linked list of powers of 5 of the form 5**(2**i), i >= 2 */
+    /* p5s is an array of powers of 5 of the form 5**(2**i), i >= 2 */
+    struct Bigint *p5s[Bigint_Pow5max];
     // XXX This should be freed during runtime fini.
-    struct Bigint *p5s;
     struct Bigint *freelist[Bigint_Kmax+1];
     double preallocated[Bigint_PREALLOC_SIZE];
     double *preallocated_next;
@@ -57,15 +60,17 @@ struct _dtoa_state {
 #endif  // !Py_USING_MEMORY_DEBUGGER
 
 
-/* These functions are used by modules compiled as C extension like math:
-   they must be exported. */
-
 extern double _Py_dg_strtod(const char *str, char **ptr);
 extern char* _Py_dg_dtoa(double d, int mode, int ndigits,
                          int *decpt, int *sign, char **rve);
 extern void _Py_dg_freedtoa(char *s);
 
 #endif // _PY_SHORT_FLOAT_REPR == 1
+
+
+extern PyStatus _PyDtoa_Init(PyInterpreterState *interp);
+extern void _PyDtoa_Fini(PyInterpreterState *interp);
+
 
 #ifdef __cplusplus
 }

--- a/Python/dtoa.c
+++ b/Python/dtoa.c
@@ -695,9 +695,9 @@ pow5mult(Bigint *b, int k)
     PyInterpreterState *interp = _PyInterpreterState_GET();
     p5s = interp->dtoa.p5s;
     for(;;) {
+        assert(p5s != interp->dtoa.p5s + Bigint_Pow5size);
         p5 = *p5s;
         p5s++;
-        assert(p5s != interp->dtoa.p5s + Bigint_Pow5size);
         if (k & 1) {
             b1 = mult(b, p5);
             Bfree(b);

--- a/Python/dtoa.c
+++ b/Python/dtoa.c
@@ -2807,7 +2807,7 @@ _PyDtoa_Init(PyInterpreterState *interp)
     }
     p5s[0] = p5;
 
-    // compute 5**8, 5**16, 5**32, ..., 5**256
+    // compute 5**8, 5**16, 5**32, ..., 5**512
     for (Py_ssize_t i = 1; i < Bigint_Pow5max; i++) {
         p5 = mult(p5, p5);
         if (p5 == NULL) {

--- a/Python/dtoa.c
+++ b/Python/dtoa.c
@@ -309,7 +309,7 @@ BCinfo {
 // struct Bigint is defined in pycore_dtoa.h.
 typedef struct Bigint Bigint;
 
-#if !defined(Py_NOGIL) && !defined(Py_USING_MEMORY_DEBUGGER)
+#if !defined(Py_GIL_DISABLED) && !defined(Py_USING_MEMORY_DEBUGGER)
 
 /* Memory management: memory is allocated from, and returned to, Kmax+1 pools
    of memory, where pool k (0 <= k <= Kmax) is for Bigints b with b->maxwds ==
@@ -428,7 +428,7 @@ Bfree(Bigint *v)
     }
 }
 
-#endif /* !defined(Py_NOGIL) && !defined(Py_USING_MEMORY_DEBUGGER) */
+#endif /* !defined(Py_GIL_DISABLED) && !defined(Py_USING_MEMORY_DEBUGGER) */
 
 #define Bcopy(x,y) memcpy((char *)&x->sign, (char *)&y->sign,   \
                           y->wds*sizeof(Long) + 2*sizeof(int))

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -825,6 +825,11 @@ pycore_interp_init(PyThreadState *tstate)
         return status;
     }
 
+    status = _PyDtoa_Init(interp);
+    if (_PyStatus_EXCEPTION(status)) {
+        return status;
+    }
+
     // The GC must be initialized before the first GC collection.
     status = _PyGC_Init(interp);
     if (_PyStatus_EXCEPTION(status)) {
@@ -1781,6 +1786,7 @@ finalize_interp_clear(PyThreadState *tstate)
     _PyXI_Fini(tstate->interp);
     _PyExc_ClearExceptionGroupType(tstate->interp);
     _Py_clear_generic_types(tstate->interp);
+    _PyDtoa_Fini(tstate->interp);
 
     /* Clear interpreter state and all thread states */
     _PyInterpreterState_Clear(tstate);


### PR DESCRIPTION
This avoids using the Bigint free-list in `--disable-gil` builds and pre-computes the needed powers of 5 during interpreter initialization.


<!-- gh-issue-number: gh-111962 -->
* Issue: gh-111962
<!-- /gh-issue-number -->
