### PR TITLE
gh-111784: Add `PyCapsule_ImportCapsule` and fix segfault in `_elementtree.c`

### DIFF
--- a/Include/pycapsule.h
+++ b/Include/pycapsule.h
@@ -52,6 +52,11 @@ PyAPI_FUNC(void *) PyCapsule_Import(
     const char *name,           /* UTF-8 encoded string */
     int no_block);
 
+PyAPI_FUNC(PyObject *) PyCapsule_ImportCapsule(
+        const char *name,
+        int no_block
+);
+
 #ifdef __cplusplus
 }
 #endif

--- a/Modules/_elementtree.c
+++ b/Modules/_elementtree.c
@@ -98,6 +98,7 @@ typedef struct {
     PyTypeObject *TreeBuilder_Type;
     PyTypeObject *XMLParser_Type;
 
+    PyObject *expat_capsule;
     struct PyExpat_CAPI *expat_capi;
 } elementtreestate;
 
@@ -137,6 +138,7 @@ elementtree_clear(PyObject *m)
     Py_CLEAR(st->parseerror_obj);
     Py_CLEAR(st->deepcopy_obj);
     Py_CLEAR(st->elementpath_obj);
+    Py_CLEAR(st->expat_capsule);
     Py_CLEAR(st->comment_factory);
     Py_CLEAR(st->pi_factory);
 
@@ -167,6 +169,7 @@ elementtree_traverse(PyObject *m, visitproc visit, void *arg)
     Py_VISIT(st->parseerror_obj);
     Py_VISIT(st->deepcopy_obj);
     Py_VISIT(st->elementpath_obj);
+    Py_VISIT(st->expat_capsule);
     Py_VISIT(st->comment_factory);
     Py_VISIT(st->pi_factory);
 
@@ -4343,7 +4346,10 @@ module_exec(PyObject *m)
         goto error;
 
     /* link against pyexpat */
-    st->expat_capi = PyCapsule_Import(PyExpat_CAPSULE_NAME, 0);
+    if (!(st->expat_capsule = PyCapsule_ImportCapsule(PyExpat_CAPSULE_NAME, 0)))
+        goto error;
+    if (!(st->expat_capi = PyCapsule_GetPointer(st->expat_capsule, PyExpat_CAPSULE_NAME)))
+        goto error;
     if (st->expat_capi) {
         /* check that it's usable */
         if (strcmp(st->expat_capi->magic, PyExpat_CAPI_MAGIC) != 0 ||


### PR DESCRIPTION
That's a PoC.

We can add a `NEWS` entry and doc about new public API later, if we consider this as the right solution.

Also, I was incorrect in issue. We need to keep reference to the capsule, not `pyexpat` module.

<!-- gh-issue-number: gh-111784 -->
* Issue: gh-111784
<!-- /gh-issue-number -->
