### PR TITLE
gh-111942: Fix SystemError in the TextIOWrapper constructor

### DIFF
--- a/Lib/test/test_io.py
+++ b/Lib/test/test_io.py
@@ -2725,9 +2725,7 @@ class TextIOWrapperTest(unittest.TestCase):
         if support.Py_DEBUG or sys.flags.dev_mode or self.is_C:
             with self.assertRaises(UnicodeEncodeError):
                 t.__init__(b, encoding="utf-8", errors='\udcfe')
-        if support.Py_DEBUG or sys.flags.dev_mode:
-            # TODO: If encoded to UTF-8, should also be checked for
-            # embedded null characters.
+        if support.Py_DEBUG or sys.flags.dev_mode or self.is_C:
             with self.assertRaises(ValueError):
                 t.__init__(b, encoding="utf-8", errors='replace\0')
         with self.assertRaises(TypeError):

--- a/Misc/NEWS.d/next/Library/2023-11-14-18-43-55.gh-issue-111942.x1pnrj.rst
+++ b/Misc/NEWS.d/next/Library/2023-11-14-18-43-55.gh-issue-111942.x1pnrj.rst
@@ -1,0 +1,2 @@
+Fix SystemError in the TextIOWrapper constructor with non-encodable "errors"
+argument in non-debug mode.

--- a/Modules/_io/textio.c
+++ b/Modules/_io/textio.c
@@ -1112,6 +1112,10 @@ _io_TextIOWrapper___init___impl(textio *self, PyObject *buffer,
     else if (io_check_errors(errors)) {
         return -1;
     }
+    const char *errors_str = PyUnicode_AsUTF8(errors);
+    if (errors_str == NULL) {
+        return -1;
+    }
 
     if (validate_newline(newline) < 0) {
         return -1;
@@ -1184,11 +1188,11 @@ _io_TextIOWrapper___init___impl(textio *self, PyObject *buffer,
     /* Build the decoder object */
     _PyIO_State *state = find_io_state_by_def(Py_TYPE(self));
     self->state = state;
-    if (_textiowrapper_set_decoder(self, codec_info, PyUnicode_AsUTF8(errors)) != 0)
+    if (_textiowrapper_set_decoder(self, codec_info, errors_str) != 0)
         goto error;
 
     /* Build the encoder object */
-    if (_textiowrapper_set_encoder(self, codec_info, PyUnicode_AsUTF8(errors)) != 0)
+    if (_textiowrapper_set_encoder(self, codec_info, errors_str) != 0)
         goto error;
 
     /* Finished sorting out the codec details */

--- a/Modules/_io/textio.c
+++ b/Modules/_io/textio.c
@@ -1112,7 +1112,7 @@ _io_TextIOWrapper___init___impl(textio *self, PyObject *buffer,
     else if (io_check_errors(errors)) {
         return -1;
     }
-    const char *errors_str = PyUnicode_AsUTF8(errors);
+    const char *errors_str = _PyUnicode_AsUTF8NoNUL(errors);
     if (errors_str == NULL) {
         return -1;
     }


### PR DESCRIPTION
In non-debug more the check for the "errors" argument is skipped, and then PyUnicode_AsUTF8() can fail, but its result was not checked.


<!-- gh-issue-number: gh-111942 -->
* Issue: gh-111942
<!-- /gh-issue-number -->
