### PR TITLE
gh-111942: Fix test_io test_constructor()

### DIFF
--- a/Lib/test/test_io.py
+++ b/Lib/test/test_io.py
@@ -2722,7 +2722,7 @@ class TextIOWrapperTest(unittest.TestCase):
             t.__init__(b, encoding='utf-8\0')
         with self.assertRaises(invalid_type):
             t.__init__(b, encoding="utf-8", errors=42)
-        if support.Py_DEBUG or sys.flags.dev_mode or self.is_C:
+        if support.Py_DEBUG or sys.flags.dev_mode:
             with self.assertRaises(UnicodeEncodeError):
                 t.__init__(b, encoding="utf-8", errors='\udcfe')
         if support.Py_DEBUG or sys.flags.dev_mode:


### PR DESCRIPTION
The error handler is not tested in the _io extension. It's only tested if Python is built in debug mode (Py_DEBUG) or if the Python Development Mode (-X dev) is enabled.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-111942 -->
* Issue: gh-111942
<!-- /gh-issue-number -->
