### PR TITLE
[3.12] gh-111942: Fix SystemError in the TextIOWrapper constructor (#112061)

### DIFF
--- a/Lib/test/test_io.py
+++ b/Lib/test/test_io.py
@@ -2732,9 +2732,7 @@ class TextIOWrapperTest(unittest.TestCase):
         if support.Py_DEBUG or sys.flags.dev_mode or self.is_C:
             with self.assertRaises(UnicodeEncodeError):
                 t.__init__(b, encoding="utf-8", errors='\udcfe')
-        if support.Py_DEBUG or sys.flags.dev_mode:
-            # TODO: If encoded to UTF-8, should also be checked for
-            # embedded null characters.
+        if support.Py_DEBUG or sys.flags.dev_mode or self.is_C:
             with self.assertRaises(ValueError):
                 t.__init__(b, encoding="utf-8", errors='replace\0')
         with self.assertRaises(TypeError):

--- a/Misc/NEWS.d/next/Library/2023-11-14-18-43-55.gh-issue-111942.x1pnrj.rst
+++ b/Misc/NEWS.d/next/Library/2023-11-14-18-43-55.gh-issue-111942.x1pnrj.rst
@@ -1,0 +1,2 @@
+Fix SystemError in the TextIOWrapper constructor with non-encodable "errors"
+argument in non-debug mode.

--- a/Modules/_io/textio.c
+++ b/Modules/_io/textio.c
@@ -1119,6 +1119,15 @@ _io_TextIOWrapper___init___impl(textio *self, PyObject *buffer,
     else if (io_check_errors(errors)) {
         return -1;
     }
+    Py_ssize_t errors_len;
+    const char *errors_str = PyUnicode_AsUTF8AndSize(errors, &errors_len);
+    if (errors_str == NULL) {
+        return -1;
+    }
+    if (strlen(errors_str) != (size_t)errors_len) {
+        PyErr_SetString(PyExc_ValueError, "embedded null character");
+        return -1;
+    }
 
     if (validate_newline(newline) < 0) {
         return -1;
@@ -1191,11 +1200,11 @@ _io_TextIOWrapper___init___impl(textio *self, PyObject *buffer,
     /* Build the decoder object */
     _PyIO_State *state = find_io_state_by_def(Py_TYPE(self));
     self->state = state;
-    if (_textiowrapper_set_decoder(self, codec_info, PyUnicode_AsUTF8(errors)) != 0)
+    if (_textiowrapper_set_decoder(self, codec_info, errors_str) != 0)
         goto error;
 
     /* Build the encoder object */
-    if (_textiowrapper_set_encoder(self, codec_info, PyUnicode_AsUTF8(errors)) != 0)
+    if (_textiowrapper_set_encoder(self, codec_info, errors_str) != 0)
         goto error;
 
     /* Finished sorting out the codec details */


### PR DESCRIPTION
In non-debug more the check for the "errors" argument is skipped, and then PyUnicode_AsUTF8() can fail, but its result was not checked.

Co-authored-by: Victor Stinner <vstinner@python.org>
(cherry picked from commit 9302f05f9af07332c414b3c19003efd1b1763cf3)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-111942 -->
* Issue: gh-111942
<!-- /gh-issue-number -->
