### PR TITLE
gh-112092: Fixed contradicting statement

### DIFF
--- a/Doc/c-api/stable.rst
+++ b/Doc/c-api/stable.rst
@@ -16,7 +16,7 @@ CPython's Application Binary Interface (ABI) is forward- and
 backwards-compatible across a minor release (if these are compiled the same
 way; see :ref:`stable-abi-platform` below).
 So, code compiled for Python 3.10.0 will work on 3.10.8 and vice versa,
-but will need to be compiled separately for any other minor version.
+but will need to be compiled separately for 3.9.x and 3.11.x.
 
 There are two tiers of C API with different stability expectations:
 

--- a/Doc/c-api/stable.rst
+++ b/Doc/c-api/stable.rst
@@ -16,8 +16,7 @@ CPython's Application Binary Interface (ABI) is forward- and
 backwards-compatible across a minor release (if these are compiled the same
 way; see :ref:`stable-abi-platform` below).
 So, code compiled for Python 3.10.0 will work on 3.10.8 and vice versa,
-but will need to be compiled separately for any other minor version; 
-Unless documented otherwise.
+but will need to be compiled separately for any other minor version.
 
 There are two tiers of C API with different stability expectations:
 

--- a/Doc/c-api/stable.rst
+++ b/Doc/c-api/stable.rst
@@ -16,7 +16,8 @@ CPython's Application Binary Interface (ABI) is forward- and
 backwards-compatible across a minor release (if these are compiled the same
 way; see :ref:`stable-abi-platform` below).
 So, code compiled for Python 3.10.0 will work on 3.10.8 and vice versa,
-but will need to be compiled separately for 3.9.x and 3.10.x.
+but will need to be compiled separately for any other minor version; 
+Unless documented otherwise.
 
 There are two tiers of C API with different stability expectations:
 


### PR DESCRIPTION
This fixes #112092

```
gh-112092: Fixed contradicting statement
```


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--112093.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->