### PR TITLE
gh-112062: Make `_struct` module thread-safe in `--disable-gil` builds

### DIFF
--- a/Modules/_struct.c
+++ b/Modules/_struct.c
@@ -2250,19 +2250,11 @@ cache_struct_converter(PyObject *module, PyObject *fmt, PyStructObject **ptr)
         return 1;
     }
 
-    if (state->cache == NULL) {
-        state->cache = PyDict_New();
-        if (state->cache == NULL)
-            return 0;
-    }
-
-    s_object = PyDict_GetItemWithError(state->cache, fmt);
-    if (s_object != NULL) {
-        *ptr = (PyStructObject *)Py_NewRef(s_object);
-        return Py_CLEANUP_SUPPORTED;
-    }
-    else if (PyErr_Occurred()) {
+    if (PyDict_GetItemRef(state->cache, fmt, ptr) < 0) {
         return 0;
+    }
+    if (*ptr != NULL) {
+        return Py_CLEANUP_SUPPORTED;
     }
 
     s_object = PyObject_CallOneArg(state->PyStructType, fmt);
@@ -2288,7 +2280,7 @@ static PyObject *
 _clearcache_impl(PyObject *module)
 /*[clinic end generated code: output=ce4fb8a7bf7cb523 input=463eaae04bab3211]*/
 {
-    Py_CLEAR(get_struct_state(module)->cache);
+    PyDict_Clear(get_struct_state(module)->cache);
     Py_RETURN_NONE;
 }
 
@@ -2511,6 +2503,11 @@ static int
 _structmodule_exec(PyObject *m)
 {
     _structmodulestate *state = get_struct_state(m);
+
+    state->cache = PyDict_New();
+    if (state->cache == NULL) {
+        return -1;
+    }
 
     state->PyStructType = PyType_FromModuleAndSpec(
         m, &PyStructType_spec, NULL);

--- a/Modules/_struct.c
+++ b/Modules/_struct.c
@@ -2250,11 +2250,13 @@ cache_struct_converter(PyObject *module, PyObject *fmt, PyStructObject **ptr)
         return 1;
     }
 
-    if (PyDict_GetItemRef(state->cache, fmt, ptr) < 0) {
-        return 0;
-    }
-    if (*ptr != NULL) {
+    s_object = PyDict_GetItemWithError(state->cache, fmt);
+    if (s_object != NULL) {
+        *ptr = (PyStructObject *)Py_NewRef(s_object);
         return Py_CLEANUP_SUPPORTED;
+    }
+    else if (PyErr_Occurred()) {
+        return 0;
     }
 
     s_object = PyObject_CallOneArg(state->PyStructType, fmt);


### PR DESCRIPTION
Fixes #112062 

* clear cache dict but preserve the reference in `_clearcache_impl`
* create cache dict in `_structmodule_exec`

<!-- gh-issue-number: gh-112062 -->
* Issue: gh-112062
<!-- /gh-issue-number -->
