### PR TITLE
Fix typo in documentation of `importlib.metadata`

### DIFF
--- a/Doc/library/importlib.metadata.rst
+++ b/Doc/library/importlib.metadata.rst
@@ -41,7 +41,7 @@ and metadata defined by the `Core metadata specifications <https://packaging.pyt
    and one top-level *import package*
    may map to multiple *distribution packages*
    if it is a namespace package.
-   You can use :ref:`package_distributions() <package-distributions>`
+   You can use :ref:`packages_distributions() <package-distributions>`
    to get a mapping between them.
 
 By default, distribution metadata can live on the file system


### PR DESCRIPTION
`package_distributions()` should be `packages_distributions()`(Be consistent with the code).

This is a minor documentation change, so issue and NEWs can be skipped.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--112099.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->