### PR TITLE
gh-112100 Verify that zoneinfo can be imported

### DIFF
--- a/Lib/test/test__xxsubinterpreters.py
+++ b/Lib/test/test__xxsubinterpreters.py
@@ -796,6 +796,11 @@ class RunStringTests(TestBase):
                 sys.exit(42)
                 """))
 
+    def test_import_capsule(self):
+        interpreters.run_string(self.id, dedent("""
+            import zoneinfo
+            """))
+
     def test_with_shared(self):
         r, w = os.pipe()
 


### PR DESCRIPTION
Adds a test that you can import `zoneinfo` from a sub interpreter. 


<!-- gh-issue-number: gh-112100 -->
* Issue: gh-112100
<!-- /gh-issue-number -->
