### PR TITLE
GH-111784: Fix segfault by keeping pyexpat module alive for capsule lifetime

### DIFF
--- a/Misc/NEWS.d/next/Library/2023-11-15-04-44-28.gh-issue-111784._ZyckQ.rst
+++ b/Misc/NEWS.d/next/Library/2023-11-15-04-44-28.gh-issue-111784._ZyckQ.rst
@@ -1,0 +1,1 @@
+Fix segfault during deallocation of ``_elementtree.XMLParser`` by keeping pyexpat module alive for capsule lifetime. Patch by Kumar Aditya.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

This fixes the segfault reported on the issue, it also avoids adding any new API as it has to be backported and is minimal.

<!-- gh-issue-number: gh-111784 -->
* Issue: gh-111784
<!-- /gh-issue-number -->
