### PR TITLE
Fix typo in perf profiling docs

### DIFF
--- a/Doc/howto/perf_profiling.rst
+++ b/Doc/howto/perf_profiling.rst
@@ -97,7 +97,7 @@ Then we can use ``perf report`` to analyze the data:
                             |          |          |                     |          |          |--2.97%--_PyObject_Malloc
     ...
 
-As you can see, the Python functions are not shown in the output, only ``_Py_Eval_EvalFrameDefault``
+As you can see, the Python functions are not shown in the output, only ``_PyEval_EvalFrameDefault``
 (the function that evaluates the Python bytecode) shows up. Unfortunately that's not very useful because all Python
 functions use the same C function to evaluate bytecode so we cannot know which Python function corresponds to which
 bytecode-evaluating function.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
`_Py_Eval_EvalFrameDefault` seems to be a typo of `_PyEval_EvalFrameDefault`.

<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--112112.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->