### PR TITLE
Fix docstring and var name of itertools recipe

### DIFF
--- a/Doc/library/itertools.rst
+++ b/Doc/library/itertools.rst
@@ -798,10 +798,10 @@ which incur interpreter overhead.
        "Return first n items of the iterable as a list"
        return list(islice(iterable, n))
 
-   def prepend(value, iterator):
-       "Prepend a single value in front of an iterator"
+   def prepend(value, iterable):
+       "Prepend a single value in front of an iterable"
        # prepend(1, [2, 3, 4]) --> 1 2 3 4
-       return chain([value], iterator)
+       return chain([value], iterable)
 
    def tabulate(function, start=0):
        "Return function(0), function(1), ..."


### PR DESCRIPTION
`prepend()` works with arbitrary iterables, not only iterators. In fact, the example given uses a `list`, which is iterable, but not an iterator.

Spotted by @AlexWaygood in python/typeshed#10992.


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--112113.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->