### PR TITLE
gh-112026: Restore removed _PyDict_GetItemStringWithError()

### DIFF
--- a/Include/cpython/dictobject.h
+++ b/Include/cpython/dictobject.h
@@ -34,7 +34,7 @@ typedef struct {
 
 PyAPI_FUNC(PyObject *) _PyDict_GetItem_KnownHash(PyObject *mp, PyObject *key,
                                                  Py_hash_t hash);
-
+PyAPI_FUNC(PyObject *) _PyDict_GetItemStringWithError(PyObject *, const char *);
 PyAPI_FUNC(PyObject *) PyDict_SetDefault(
     PyObject *mp, PyObject *key, PyObject *defaultobj);
 

--- a/Misc/NEWS.d/next/C API/2023-11-15-17-10-09.gh-issue-112026.ts9yyn.rst
+++ b/Misc/NEWS.d/next/C API/2023-11-15-17-10-09.gh-issue-112026.ts9yyn.rst
@@ -1,0 +1,2 @@
+Restore the removed ``_PyDict_GetItemStringWithError()`` function. It is
+used by numpy. Patch by Victor Stinner.

--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -1842,6 +1842,20 @@ _PyDict_GetItemIdWithError(PyObject *dp, _Py_Identifier *key)
     return _PyDict_GetItem_KnownHash(dp, kv, hash);  // borrowed reference
 }
 
+PyObject *
+_PyDict_GetItemStringWithError(PyObject *v, const char *key)
+{
+    PyObject *kv, *rv;
+    kv = PyUnicode_FromString(key);
+    if (kv == NULL) {
+        return NULL;
+    }
+    rv = PyDict_GetItemWithError(v, kv);
+    Py_DECREF(kv);
+    return rv;
+}
+
+
 /* Fast version of global value lookup (LOAD_GLOBAL).
  * Lookup in globals, then builtins.
  *


### PR DESCRIPTION
Restore the removed _PyDict_GetItemStringWithError() function. It is used by numpy.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-112026 -->
* Issue: gh-112026
<!-- /gh-issue-number -->
