### PR TITLE
gh-112026: Add again _PyThreadState_UncheckedGet() function

### DIFF
--- a/Include/cpython/pystate.h
+++ b/Include/cpython/pystate.h
@@ -231,6 +231,9 @@ struct _ts {
  * if it is NULL. */
 PyAPI_FUNC(PyThreadState *) PyThreadState_GetUnchecked(void);
 
+// Alias kept for backward compatibility
+#define _PyThreadState_UncheckedGet PyThreadState_GetUnchecked
+
 
 // Disable tracing and profiling.
 PyAPI_FUNC(void) PyThreadState_EnterTracing(PyThreadState *tstate);

--- a/Misc/NEWS.d/next/C API/2023-11-15-18-36-21.gh-issue-112026._Yybr5.rst
+++ b/Misc/NEWS.d/next/C API/2023-11-15-18-36-21.gh-issue-112026._Yybr5.rst
@@ -1,0 +1,3 @@
+Add again the private ``_PyThreadState_UncheckedGet()`` function as an alias
+to the new public :c:func:`PyThreadState_GetUnchecked` function. Patch by
+Victor Stinner.


### PR DESCRIPTION
Add again the private _PyThreadState_UncheckedGet() function as an alias to the new public PyThreadState_GetUnchecked() function.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-112026 -->
* Issue: gh-112026
<!-- /gh-issue-number -->
