### PR TITLE
Remove `imp_dummy_def` from `Tools/c-analyzer/cpython/ignored.tsv`

### DIFF
--- a/Tools/c-analyzer/cpython/ignored.tsv
+++ b/Tools/c-analyzer/cpython/ignored.tsv
@@ -565,7 +565,6 @@ Modules/_testmultiphase.c	-	def_nonascii_latin	-
 Modules/_testmultiphase.c	-	def_nonmodule	-
 Modules/_testmultiphase.c	-	def_nonmodule_with_exec_slots	-
 Modules/_testmultiphase.c	-	def_nonmodule_with_methods	-
-Modules/_testmultiphase.c	-	imp_dummy_def	-
 Modules/_testmultiphase.c	-	main_def	-
 Modules/_testmultiphase.c	-	main_slots	-
 Modules/_testmultiphase.c	-	meth_state_access_slots	-


### PR DESCRIPTION
It was removed in 3.12, no need to keep the ignore.