### PR TITLE
gh-112155: Run `typing.py` doctests during tests

### DIFF
--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -9464,5 +9464,11 @@ class TypeIterationTests(BaseTestCase):
             self.assertNotIsInstance(type_to_test, collections.abc.Iterable)
 
 
+def load_tests(loader, tests, ignore):
+    import doctest
+    tests.addTests(doctest.DocTestSuite(typing))
+    return tests
+
+
 if __name__ == '__main__':
     main()

--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -9464,7 +9464,7 @@ class TypeIterationTests(BaseTestCase):
             self.assertNotIsInstance(type_to_test, collections.abc.Iterable)
 
 
-def load_tests(loader, tests, ignore):
+def load_tests(loader, tests, pattern):
     import doctest
     tests.addTests(doctest.DocTestSuite(typing))
     return tests

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -3404,8 +3404,8 @@ def get_protocol_members(tp: type, /) -> frozenset[str]:
         >>> class P(Protocol):
         ...     def a(self) -> str: ...
         ...     b: int
-        >>> get_protocol_members(P)
-        frozenset({'a', 'b'})
+        >>> get_protocol_members(P) == frozenset({'a', 'b', 'c'})
+        True
 
     Raise a TypeError for arguments that are not Protocols.
     """

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -3404,7 +3404,7 @@ def get_protocol_members(tp: type, /) -> frozenset[str]:
         >>> class P(Protocol):
         ...     def a(self) -> str: ...
         ...     b: int
-        >>> get_protocol_members(P) == frozenset({'a', 'b', 'c'})
+        >>> get_protocol_members(P) == frozenset({'a', 'b'})
         True
 
     Raise a TypeError for arguments that are not Protocols.


### PR DESCRIPTION
After this change we can detect some hypothetical problems with `doctests` in `typing.py`.
After my change to some incorrect value doctest fails:

```
» ./python.exe -m test test_typing   
Using random seed: 3171999375
0:00:00 load avg: 1.44 Run 1 test sequentially
0:00:00 load avg: 1.44 [1/1] test_typing
test test_typing failed -- Traceback (most recent call last):
  File "/Users/sobolev/Desktop/cpython2/Lib/doctest.py", line 2267, in runTest
    raise self.failureException(self.format_failure(new.getvalue()))
AssertionError: Failed doctest test for typing.get_protocol_members
  File "/Users/sobolev/Desktop/cpython2/Lib/typing.py", line 3398, in get_protocol_members

----------------------------------------------------------------------
File "/Users/sobolev/Desktop/cpython2/Lib/typing.py", line 3407, in typing.get_protocol_members
Failed example:
    get_protocol_members(P)
Expected:
    frozenset({'a', 'b', 'c'})
Got:
    frozenset({'a', 'b'})


test_typing failed (1 failure)

== Tests result: FAILURE ==

1 test failed:
    test_typing

Total duration: 253 ms
Total tests: run=601 failures=1 skipped=1
Total test files: run=1/1 failed=1
Result: FAILURE
```

<!-- gh-issue-number: gh-112155 -->
* Issue: gh-112155
<!-- /gh-issue-number -->
