### PR TITLE
gh-74690: Improve performance when testing against protocols with many attributes.

### DIFF
--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -1850,6 +1850,11 @@ class _ProtocolMeta(ABCMeta):
         if super().__instancecheck__(instance):
             return True
 
+        # quick true negative check for protocols with many attributes.
+        if not hasattr(instance, '__getattr__'):
+            if not (cls.__protocol_attrs__ <= set(dir(instance))):
+                return False
+
         getattr_static = _lazy_load_getattr_static()
         for attr in cls.__protocol_attrs__:
             try:


### PR DESCRIPTION
This adds a very simple check for detecting true negatives:

```python
# quick true negative check for protocols with many attributes.
if not hasattr(instance, '__getattr__'):
    if not (cls.__protocol_attrs__ <= set(dir(instance))):
        return False
```

Running some benchmarks with `pyperf` against the example provided here: https://github.com/python/cpython/issues/74690#issuecomment-1275032959 give the following speedups:

| Benchmark      | baseline | baseline_repro       | test                  |
|----------------|----------|----------------------|-----------------------|
| one_int        | 34.9 us  | not significant      | 12.8 us: 2.73x faster |
| two_frac       | 505 ns   | 501 ns: 1.01x faster | 502 ns: 1.01x faster  |
| three_float    | 39.2 us  | not significant      | 10.7 us: 3.67x faster |
| Geometric mean | (ref)    | 1.05x slower         | 2.16x faster          |

`one_int` and `three_float` are negative examples, and we see a 2.7x-3.7x speedup, but no measurable slowdown for the true positive `two_frac`.

Are there any other benchmarks to test against?

<!-- gh-issue-number: gh-74690 -->
* Issue: gh-74690
<!-- /gh-issue-number -->
