### PR TITLE
GH-112152: Fix typo in `typing.override` docstring

### DIFF
--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -3345,7 +3345,7 @@ def override[F: _Func](method: F, /) -> F:
     Usage::
 
         class Base:
-            def method(self) -> None: ...
+            def method(self) -> None:
                 pass
 
         class Child(Base):


### PR DESCRIPTION
Correcting a typo in `typing` module (closes #112152).

<!-- gh-issue-number: gh-112152 -->
* Issue: gh-112152
<!-- /gh-issue-number -->
