### PR TITLE
[3.11] GH-112160: Pin to manifest of quay.io/tiran/cpython_autoconf

### DIFF
--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -2405,7 +2405,9 @@ regen-configure:
 	@if command -v podman >/dev/null; then RUNTIME="podman"; else RUNTIME="docker"; fi; \
 	if ! command -v $$RUNTIME; then echo "$@ needs either Podman or Docker container runtime." >&2; exit 1; fi; \
 	if command -v selinuxenabled >/dev/null && selinuxenabled; then OPT=":Z"; fi; \
-	CMD="$$RUNTIME run --rm --pull=always -v $(abs_srcdir):/src$$OPT quay.io/tiran/cpython_autoconf:269"; \
+	# Manifest corresponds with tag '269' \
+	CPYTHON_AUTOCONF_MANIFEST="sha256:f370fee95eefa3d57b00488bce4911635411fa83e2d293ced8cf8a3674ead939" \
+	CMD="$$RUNTIME run --rm --pull=missing -v $(abs_srcdir):/src$$OPT quay.io/tiran/cpython_autoconf@$$CPYTHON_AUTOCONF_MANIFEST"; \
 	echo $$CMD; \
 	$$CMD || exit $?
 


### PR DESCRIPTION
Part of #112160, this only pins to the manifest. Branches 3.10 and earlier will require adding the entire target.


<!-- gh-issue-number: gh-112160 -->
* Issue: gh-112160
<!-- /gh-issue-number -->
