### PR TITLE
[3.9] gh-112160: Add 'regen-configure' make target

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -93,8 +93,12 @@ jobs:
           grep "aclocal 1.16.3" aclocal.m4
           grep -q "runstatedir" configure
           grep -q "PKG_PROG_PKG_CONFIG" aclocal.m4
+      - name: Configure CPython
+        run: |
+          # Build Python with the libpython dynamic library
+          ./configure --config-cache --with-pydebug --enable-shared
       - name: Regenerate autoconf files
-        run: docker run --rm -v $(pwd):/src quay.io/tiran/cpython_autoconf:269
+        run: make regen-configure
       - name: Build CPython
         run: |
           ./configure --with-pydebug

--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -1815,6 +1815,18 @@ autoconf:
 	# Regenerate pyconfig.h.in from configure.ac using autoheader
 	(cd $(srcdir); autoheader -Wall)
 
+# See https://github.com/tiran/cpython_autoconf container
+.PHONY: regen-configure
+regen-configure:
+	@if command -v podman >/dev/null; then RUNTIME="podman"; else RUNTIME="docker"; fi; \
+	if ! command -v $$RUNTIME; then echo "$@ needs either Podman or Docker container runtime." >&2; exit 1; fi; \
+	if command -v selinuxenabled >/dev/null && selinuxenabled; then OPT=":Z"; fi; \
+	# Manifest corresponds with tag '269' \
+	CPYTHON_AUTOCONF_MANIFEST="sha256:f370fee95eefa3d57b00488bce4911635411fa83e2d293ced8cf8a3674ead939" \
+	CMD="$$RUNTIME run --rm --pull=missing -v $(abs_srcdir):/src$$OPT quay.io/tiran/cpython_autoconf@$$CPYTHON_AUTOCONF_MANIFEST"; \
+	echo $$CMD; \
+	$$CMD || exit $?
+
 # Create a tags file for vi
 tags::
 	ctags -w $(srcdir)/Include/*.h $(srcdir)/Include/cpython/*.h $(srcdir)/Include/internal/*.h


### PR DESCRIPTION
Part of #112160, this adds the `regen-configure` make target to the 3.9 branch.

<!-- gh-issue-number: gh-112160 -->
* Issue: gh-112160
<!-- /gh-issue-number -->