### PR TITLE
gh-111482: Fix time_clockid_converter() on AIX

### DIFF
--- a/Modules/timemodule.c
+++ b/Modules/timemodule.c
@@ -236,8 +236,8 @@ _PyTime_GetClockWithInfo(_PyTime_t *tp, _Py_clock_info_t *info)
 static int
 time_clockid_converter(PyObject *obj, clockid_t *p)
 {
-#if defined(_AIX) && (SIZEOF_LONG == 8)
-    long clk_id = PyLong_AsLong(obj);
+#ifdef _AIX
+    long long clk_id = PyLong_AsLongLong(obj);
 #else
     int clk_id = PyLong_AsInt(obj);
 #endif


### PR DESCRIPTION
clockid_t is defined as long long on AIX.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-111482 -->
* Issue: gh-111482
<!-- /gh-issue-number -->
