### PR TITLE
gh-111650: Generate pyconfig.h on Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,6 +92,7 @@ Programs/_testembed
 PC/python_nt*.h
 PC/pythonnt_rc*.h
 Modules/python.exp
+PC/pyconfig.h
 PC/*/*.exp
 PC/*/*.lib
 PC/*/*.bsc

--- a/Lib/test/test_sysconfig.py
+++ b/Lib/test/test_sysconfig.py
@@ -472,9 +472,10 @@ class TestSysConfig(unittest.TestCase):
             # should be a full source checkout.
             Python_h = os.path.join(srcdir, 'Include', 'Python.h')
             self.assertTrue(os.path.exists(Python_h), Python_h)
-            # <srcdir>/PC/pyconfig.h always exists even if unused on POSIX.
-            pyconfig_h = os.path.join(srcdir, 'PC', 'pyconfig.h')
-            self.assertTrue(os.path.exists(pyconfig_h), pyconfig_h)
+            if os.name == 'nt':
+                # <srcdir>/PC/pyconfig.h only exists on Windows.
+                pyconfig_h = os.path.join(srcdir, 'PC', 'pyconfig.h')
+                self.assertTrue(os.path.exists(pyconfig_h), pyconfig_h)
             pyconfig_h_in = os.path.join(srcdir, 'pyconfig.h.in')
             self.assertTrue(os.path.exists(pyconfig_h_in), pyconfig_h_in)
         elif os.name == 'posix':

--- a/Misc/NEWS.d/next/Windows/2023-11-16-16-19-51.gh-issue-111650.zdWe-n.rst
+++ b/Misc/NEWS.d/next/Windows/2023-11-16-16-19-51.gh-issue-111650.zdWe-n.rst
@@ -1,0 +1,2 @@
+On Windows, ``PC\pyconfig.h`` is now generated from ``PC\pyconfig.h.in``
+during the build process.

--- a/PC/pyconfig.h.in
+++ b/PC/pyconfig.h.in
@@ -1,7 +1,7 @@
 #ifndef Py_CONFIG_H
 #define Py_CONFIG_H
 
-/* pyconfig.h.  NOT Generated automatically by configure.
+/* pyconfig.h.in.
 
 This is a manually maintained version used for the Watcom,
 Borland and Microsoft Visual C++ compilers.  It is a
@@ -709,6 +709,9 @@ Py_NO_ENABLE_SHARED to find out.  Also support MS_NO_COREDLL for b/w compat */
 
 /* Define to 1 if you have the `erfc' function. */
 #define HAVE_ERFC 1
+
+/* Define if you want to disable the GIL */
+#undef Py_NOGIL
 
 // netdb.h functions (provided by winsock.h)
 #define HAVE_GETHOSTNAME 1

--- a/PC/pyconfig.h.in
+++ b/PC/pyconfig.h.in
@@ -711,7 +711,7 @@ Py_NO_ENABLE_SHARED to find out.  Also support MS_NO_COREDLL for b/w compat */
 #define HAVE_ERFC 1
 
 /* Define if you want to disable the GIL */
-#undef Py_NOGIL
+#undef Py_GIL_DISABLED
 
 // netdb.h functions (provided by winsock.h)
 #define HAVE_GETHOSTNAME 1

--- a/PCbuild/generate_pyconfig.ps1
+++ b/PCbuild/generate_pyconfig.ps1
@@ -1,0 +1,50 @@
+#
+# Generates pyconfig.h from PC\pyconfig.h.in
+#
+
+param (
+    [string[]]$define,
+    [string]$File
+)
+
+$definedValues = @{}
+
+foreach ($arg in $define) {
+    $parts = $arg -split '='
+
+    if ($parts.Count -eq 1) {
+        $key = $parts[0]
+        $definedValues[$key] = ""
+    } elseif ($parts.Count -eq 2) {
+        $key = $parts[0]
+        $value = $parts[1]
+        $definedValues[$key] = $value
+    } else {
+        Write-Host "Invalid argument: $arg"
+        exit 1
+    }
+}
+
+$cpythonRoot = Split-Path $PSScriptRoot -Parent
+$pyconfigPath = Join-Path $cpythonRoot "PC\pyconfig.h.in"
+
+$header = "/* pyconfig.h.  Generated from PC\pyconfig.h.in by generate_pyconfig.ps1.  */"
+
+$lines = Get-Content -Path $pyconfigPath
+$lines = @($header) + $lines
+
+foreach ($i in 0..($lines.Length - 1)) {
+    if ($lines[$i] -match "^#undef (\w+)$") {
+        $key = $Matches[1]
+        if ($definedValues.ContainsKey($key)) {
+            $value = $definedValues[$key]
+            $lines[$i] = "#define $key $value".TrimEnd()
+        } else {
+            $lines[$i] = "/* #undef $key */"
+        }
+    }
+}
+
+$ParentDir = Split-Path -Path $File -Parent
+New-Item -ItemType Directory -Force -Path $ParentDir | Out-Null
+Set-Content -Path $File -Value $lines

--- a/PCbuild/pcbuild.proj
+++ b/PCbuild/pcbuild.proj
@@ -15,7 +15,7 @@
     <IncludeSSL Condition="'$(IncludeSSL)' == ''">true</IncludeSSL>
     <IncludeTkinter Condition="'$(IncludeTkinter)' == ''">true</IncludeTkinter>
     <IncludeUwp Condition="'$(IncludeUwp)' == ''">false</IncludeUwp>
-    <PyConfigArgs Condition="'$(DisableGil)' == 'true'">Py_NOGIL=1,$(PyConfigArgs)</PyConfigArgs>
+    <PyConfigArgs Condition="'$(DisableGil)' == 'true'">Py_GIL_DISABLED=1,$(PyConfigArgs)</PyConfigArgs>
   </PropertyGroup>
 
   <ItemDefinitionGroup>

--- a/PCbuild/pcbuild.proj
+++ b/PCbuild/pcbuild.proj
@@ -3,6 +3,7 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props"/>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props"/>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets"/>
+  <Import Project="python.props" />
   <PropertyGroup Label="Globals">
     <ProjectGuid>{CC9B93A2-439D-4058-9D29-6DCF43774405}</ProjectGuid>
     <Platform Condition="'$(Platform)' == ''">Win32</Platform>
@@ -14,6 +15,7 @@
     <IncludeSSL Condition="'$(IncludeSSL)' == ''">true</IncludeSSL>
     <IncludeTkinter Condition="'$(IncludeTkinter)' == ''">true</IncludeTkinter>
     <IncludeUwp Condition="'$(IncludeUwp)' == ''">false</IncludeUwp>
+    <PyConfigArgs Condition="'$(DisableGil)' == 'true'">Py_NOGIL=1,$(PyConfigArgs)</PyConfigArgs>
   </PropertyGroup>
 
   <ItemDefinitionGroup>
@@ -93,6 +95,11 @@
     <!-- venv[w]launcher.exe -->
     <Projects2 Include="venvlauncher.vcxproj;venvwlauncher.vcxproj" />
   </ItemGroup>
+
+  <Target Name="PreBuild" BeforeTargets="Build">
+    <!-- Stick a _PLACEHOLDER=1 after $(PyConfigArgs) to handle both trailing commas and empty $(PyConfigArgs) -->
+    <Exec Command="powershell.exe $(PySourcePath)PCbuild\generate_pyconfig.ps1 -File $(PySourcePath)PC\pyconfig.h -define $(PyConfigArgs)_PLACEHOLDER=1" />
+  </Target>
 
   <Target Name="Build">
     <MSBuild Projects="@(FreezeProjects)"


### PR DESCRIPTION
Prior to this change, the `Py_NOGIL` macro was not defined when building C API extensions with the `--disable-gil` build on Windows. `Py_NOGIL` was only defined as a pre-processor definition in pyproject.props, but that is not used by C-API extensions.

This instead generates the `pyconfig.h` header on Windows as part of the build process. For now, `Py_NOGIL` is the only macro that may be conditionally defined in the generated file.

<!-- gh-issue-number: gh-111650 -->
* Issue: gh-111650
<!-- /gh-issue-number -->
