### PR TITLE
gh-94309: py312 "what's new": improve deprecation notice for typing.Hashable and typing.Sized

### DIFF
--- a/Doc/whatsnew/3.12.rst
+++ b/Doc/whatsnew/3.12.rst
@@ -1289,8 +1289,9 @@ Deprecated
 
 * :mod:`typing`:
 
-  * :class:`typing.Hashable` and :class:`typing.Sized` aliases for :class:`collections.abc.Hashable`
-    and :class:`collections.abc.Sized`. (:gh:`94309`.)
+  * :class:`typing.Hashable` and :class:`typing.Sized`, aliases for
+    :class:`collections.abc.Hashable` and :class:`collections.abc.Sized` respectively, are
+    deprecated. (:gh:`94309`.)
 
   * :class:`typing.ByteString`, deprecated since Python 3.9, now causes a
     :exc:`DeprecationWarning` to be emitted when it is used.


### PR DESCRIPTION
The documentation of the deprecation of typing aliases in 3.12 (#94309) was just the names of the aliases, without a description of what happens to them. This can cause confusion, even if it's in the "Deprecated" section of documentation, since all other items include this description.

This should be backported to 3.12.

<!-- gh-issue-number: gh-94309 -->
* Issue: gh-94309
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--112196.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->