### PR TITLE
gh-111810: Fix `test_repr_deep` from `test_userlist` on WASI

### DIFF
--- a/Lib/test/test_userlist.py
+++ b/Lib/test/test_userlist.py
@@ -3,6 +3,8 @@
 from collections import UserList
 from test import list_tests
 import unittest
+from test import support
+
 
 class UserListTest(list_tests.CommonTest):
     type2test = UserList
@@ -64,6 +66,12 @@ class UserListTest(list_tests.CommonTest):
         v = u.copy()
         self.assertEqual(u, v)
         self.assertEqual(type(u), type(v))
+
+    # Decorate existing test with recursion limit, because
+    # the test is for C structure, but `UserList` is a Python structure.
+    test_repr_deep = support.infinite_recursion()(
+        list_tests.CommonTest.test_repr_deep,
+    )
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Let's try this approach. I didn't change `list_tests` at all, because `test_list` relies on it and we need to test C stack limit unchanged. But, for Python structure, we need the lower recursion limit.

<!-- gh-issue-number: gh-111810 -->
* Issue: gh-111810
<!-- /gh-issue-number -->
