### PR TITLE
gh-112202: Ensure that condition.notify() succeeds even when racing with Task.cancel()

### DIFF
--- a/Doc/library/asyncio-sync.rst
+++ b/Doc/library/asyncio-sync.rst
@@ -217,7 +217,7 @@ Condition
    .. method:: notify(n=1)
 
       Wake up *n* tasks (1 by default) waiting on this
-      condition.  The method is no-op if no tasks are waiting.
+      condition.  If fewer than *n* tasks are waiting they are all awoken.
 
       The lock must be acquired before this method is called and
       released shortly after.  If called with an *unlocked* lock
@@ -257,8 +257,8 @@ Condition
       Once awakened, the Condition re-acquires its lock and this method
       returns ``True``.
 
-      Note that a task *may* return from this call without having been
-      explicity awoken, which is why the caller should always re-check the state
+      Note that a task *may* return from this call spuriously,
+      which is why the caller should always re-check the state
       and be prepared to :meth:`wait` again. For this reason, you may
       prefer to use :meth:`wait_for` instead.
 

--- a/Doc/library/asyncio-sync.rst
+++ b/Doc/library/asyncio-sync.rst
@@ -268,7 +268,7 @@ Condition
 
       The predicate must be a callable which result will be
       interpreted as a boolean value.  The method will repeatedly
-      :meth:`wait` unil it evaluates to *true*. The final value is the
+      :meth:`wait` until the predicate evaluates to *true*. The final value is the
       return value.
 
 

--- a/Doc/library/asyncio-sync.rst
+++ b/Doc/library/asyncio-sync.rst
@@ -216,7 +216,7 @@ Condition
 
    .. method:: notify(n=1)
 
-      Wake up at most *n* tasks (1 by default) waiting on this
+      Wake up *n* tasks (1 by default) waiting on this
       condition.  The method is no-op if no tasks are waiting.
 
       The lock must be acquired before this method is called and
@@ -257,12 +257,18 @@ Condition
       Once awakened, the Condition re-acquires its lock and this method
       returns ``True``.
 
+      Note that a task *may* return from this call without having been
+      explicity awoken, which is why the caller should always re-check the state
+      and be prepared to :meth:`wait` again. For this reason, you may
+      prefer to use :meth:`wait_for` instead.
+
    .. coroutinemethod:: wait_for(predicate)
 
       Wait until a predicate becomes *true*.
 
       The predicate must be a callable which result will be
-      interpreted as a boolean value.  The final value is the
+      interpreted as a boolean value.  The method will repeatedly
+      :meth:`wait` unil it evaluates to *true*. The final value is the
       return value.
 
 

--- a/Doc/library/asyncio-sync.rst
+++ b/Doc/library/asyncio-sync.rst
@@ -217,7 +217,7 @@ Condition
    .. method:: notify(n=1)
 
       Wake up *n* tasks (1 by default) waiting on this
-      condition.  If fewer than *n* tasks are waiting they are all awoken.
+      condition.  If fewer than *n* tasks are waiting they are all awakened.
 
       The lock must be acquired before this method is called and
       released shortly after.  If called with an *unlocked* lock

--- a/Lib/asyncio/locks.py
+++ b/Lib/asyncio/locks.py
@@ -258,8 +258,8 @@ class Condition(_ContextManagerMixin, mixins._LoopBoundMixin):
         the same condition variable in another coroutine.  Once
         awakened, it re-acquires the lock and returns True.
 
-        This method may return without having been explicitly awoken by
-        a notify() or notify_all(), which is why the caller should always
+        This method may return spuriously,
+        which is why the caller should always
         re-check the state and be prepared to wait() again.
         """
         if not self.locked():
@@ -288,7 +288,7 @@ class Condition(_ContextManagerMixin, mixins._LoopBoundMixin):
                     except exceptions.CancelledError as e:
                         err = e
 
-                if err:
+                if err is not None:
                     try:
                         raise err  # Re-raise most recent exception instance.
                     finally:
@@ -305,7 +305,7 @@ class Condition(_ContextManagerMixin, mixins._LoopBoundMixin):
     async def wait_for(self, predicate):
         """Wait until a predicate becomes true.
 
-        The predicate should be a callable which result will be
+        The predicate should be a callable whose result will be
         interpreted as a boolean value.  The method will repeatedly
         wait() until it evaluates to true.  The final predicate value is
         the return value.
@@ -321,8 +321,8 @@ class Condition(_ContextManagerMixin, mixins._LoopBoundMixin):
         If the calling coroutine has not acquired the lock when this method
         is called, a RuntimeError is raised.
 
-        This method wakes up n of the coroutines waiting for the
-        condition variable; it is a no-op if no coroutines are waiting.
+        This method wakes up n of the coroutines waiting for the condition
+         variable; if fewer than n are waiting, they are all awoken.
 
         Note: an awakened coroutine does not actually return from its
         wait() call until it can reacquire the lock. Since notify() does

--- a/Lib/asyncio/locks.py
+++ b/Lib/asyncio/locks.py
@@ -24,22 +24,22 @@ class Lock(_ContextManagerMixin, mixins._LoopBoundMixin):
     """Primitive lock objects.
 
     A primitive lock is a synchronization primitive that is not owned
-    by a particular coroutine when locked.  A primitive lock is in one
+    by a particular task when locked.  A primitive lock is in one
     of two states, 'locked' or 'unlocked'.
 
     It is created in the unlocked state.  It has two basic methods,
     acquire() and release().  When the state is unlocked, acquire()
     changes the state to locked and returns immediately.  When the
     state is locked, acquire() blocks until a call to release() in
-    another coroutine changes it to unlocked, then the acquire() call
+    another task changes it to unlocked, then the acquire() call
     resets it to locked and returns.  The release() method should only
     be called in the locked state; it changes the state to unlocked
     and returns immediately.  If an attempt is made to release an
     unlocked lock, a RuntimeError will be raised.
 
-    When more than one coroutine is blocked in acquire() waiting for
-    the state to turn to unlocked, only one coroutine proceeds when a
-    release() call resets the state to unlocked; first coroutine which
+    When more than one task is blocked in acquire() waiting for
+    the state to turn to unlocked, only one task proceeds when a
+    release() call resets the state to unlocked; first task which
     is blocked in acquire() is being processed.
 
     acquire() is a coroutine and should be called with 'await'.
@@ -130,7 +130,7 @@ class Lock(_ContextManagerMixin, mixins._LoopBoundMixin):
         """Release a lock.
 
         When the lock is locked, reset it to unlocked, and return.
-        If any other coroutines are blocked waiting for the lock to become
+        If any other tasks are blocked waiting for the lock to become
         unlocked, allow exactly one of them to proceed.
 
         When invoked on an unlocked lock, a RuntimeError is raised.
@@ -182,8 +182,8 @@ class Event(mixins._LoopBoundMixin):
         return self._value
 
     def set(self):
-        """Set the internal flag to true. All coroutines waiting for it to
-        become true are awakened. Coroutine that call wait() once the flag is
+        """Set the internal flag to true. All tasks waiting for it to
+        become true are awakened. Tasks that call wait() once the flag is
         true will not block at all.
         """
         if not self._value:
@@ -194,7 +194,7 @@ class Event(mixins._LoopBoundMixin):
                     fut.set_result(True)
 
     def clear(self):
-        """Reset the internal flag to false. Subsequently, coroutines calling
+        """Reset the internal flag to false. Subsequently, tasks calling
         wait() will block until set() is called to set the internal flag
         to true again."""
         self._value = False
@@ -203,7 +203,7 @@ class Event(mixins._LoopBoundMixin):
         """Block until the internal flag is true.
 
         If the internal flag is true on entry, return True
-        immediately.  Otherwise, block until another coroutine calls
+        immediately.  Otherwise, block until another task calls
         set() to set the flag to true, then return True.
         """
         if self._value:
@@ -222,8 +222,8 @@ class Condition(_ContextManagerMixin, mixins._LoopBoundMixin):
     """Asynchronous equivalent to threading.Condition.
 
     This class implements condition variable objects. A condition variable
-    allows one or more coroutines to wait until they are notified by another
-    coroutine.
+    allows one or more tasks to wait until they are notified by another
+    task.
 
     A new Lock object is created and used as the underlying lock.
     """
@@ -250,12 +250,12 @@ class Condition(_ContextManagerMixin, mixins._LoopBoundMixin):
     async def wait(self):
         """Wait until notified.
 
-        If the calling coroutine has not acquired the lock when this
+        If the calling task has not acquired the lock when this
         method is called, a RuntimeError is raised.
 
         This method releases the underlying lock, and then blocks
         until it is awakened by a notify() or notify_all() call for
-        the same condition variable in another coroutine.  Once
+        the same condition variable in another task.  Once
         awakened, it re-acquires the lock and returns True.
 
         This method may return spuriously,
@@ -317,14 +317,14 @@ class Condition(_ContextManagerMixin, mixins._LoopBoundMixin):
         return result
 
     def notify(self, n=1):
-        """By default, wake up one coroutine waiting on this condition, if any.
-        If the calling coroutine has not acquired the lock when this method
+        """By default, wake up one task waiting on this condition, if any.
+        If the calling task has not acquired the lock when this method
         is called, a RuntimeError is raised.
 
-        This method wakes up n of the coroutines waiting for the condition
+        This method wakes up n of the tasks waiting for the condition
          variable; if fewer than n are waiting, they are all awoken.
 
-        Note: an awakened coroutine does not actually return from its
+        Note: an awakened task does not actually return from its
         wait() call until it can reacquire the lock. Since notify() does
         not release the lock, its caller should.
         """
@@ -390,7 +390,7 @@ class Semaphore(_ContextManagerMixin, mixins._LoopBoundMixin):
 
         If the internal counter is larger than zero on entry,
         decrement it by one and return True immediately.  If it is
-        zero on entry, block, waiting until some other coroutine has
+        zero on entry, block, waiting until some other task has
         called release() to make it larger than 0, and then return
         True.
         """
@@ -430,8 +430,8 @@ class Semaphore(_ContextManagerMixin, mixins._LoopBoundMixin):
     def release(self):
         """Release a semaphore, incrementing the internal counter by one.
 
-        When it was zero on entry and another coroutine is waiting for it to
-        become larger than zero again, wake up that coroutine.
+        When it was zero on entry and another task is waiting for it to
+        become larger than zero again, wake up that task.
         """
         self._value += 1
         self._wake_up_next()

--- a/Lib/asyncio/locks.py
+++ b/Lib/asyncio/locks.py
@@ -39,10 +39,8 @@ class Lock(_ContextManagerMixin, mixins._LoopBoundMixin):
 
     When more than one task is blocked in acquire() waiting for
     the state to turn to unlocked, only one task proceeds when a
-    release() call resets the state to unlocked; first task which
-    is blocked in acquire() is being processed.
-
-    acquire() is a coroutine and should be called with 'await'.
+    release() call resets the state to unlocked; successive release()
+    calls will unblock tasks in FIFO order.
 
     Locks also support the asynchronous context management protocol.
     'async with lock' statement should be used.

--- a/Lib/test/test_asyncio/test_locks.py
+++ b/Lib/test/test_asyncio/test_locks.py
@@ -817,14 +817,18 @@ class ConditionTests(unittest.IsolatedAsyncioTestCase):
         self.assertIs(err.exception, raised)
 
     async def test_cancelled_wakeup(self):
+        # Test that a task cancelled at the "same" time as it is woken
+        # up as part of a Condition.notify() does not result in a lost wakeup.
+        # This test simulates a cancel while the target task is awaiting initial
+        # wakeup on the wakeup queue.
         condition = asyncio.Condition()
         state = 0
         async def consumer():
             nonlocal state
             async with condition:
                 while True:
-                    await condition.wait_for(lambda: state > 0)
-                    if state > 10:
+                    await condition.wait_for(lambda: state != 0)
+                    if state < 0:
                         return
                     state -= 1
 
@@ -837,7 +841,8 @@ class ConditionTests(unittest.IsolatedAsyncioTestCase):
             state += 1
             condition.notify(1)
 
-            # but also cancel it at this point.  This cancellation could come from the outside
+            # Cancel it while it is awaiting to be run.
+            # This cancellation could come from the outside
             c[0].cancel()
 
             # now wait for the item to be consumed
@@ -849,6 +854,59 @@ class ConditionTests(unittest.IsolatedAsyncioTestCase):
             except TimeoutError:
                 pass
             self.assertEqual(state, 0)
+
+            # clean up
+            state = -1
+            condition.notify_all()
+        await c[1]
+
+    async def test_cancelled_wakeup_relock(self):
+        # Test that a task cancelled at the "same" time as it is woken
+        # up as part of a Condition.notify() does not result in a lost wakeup.
+        # This test simulates a cancel while the target task is acquiring the lock
+        # again.
+        condition = asyncio.Condition()
+        state = 0
+        async def consumer():
+            nonlocal state
+            async with condition:
+                while True:
+                    await condition.wait_for(lambda: state != 0)
+                    if state < 0:
+                        return
+                    state -= 1
+
+        # create two consumers
+        c = [asyncio.create_task(consumer()) for _ in range(2)]
+        # wait for them to settle
+        await asyncio.sleep(0)
+        async with condition:
+            # produce one item and wake up one
+            state += 1
+            condition.notify(1)
+
+            # now we sleep for a bit.  This allows the target task to wake up and
+            # settle on re-aquiring the lock
+            await asyncio.sleep(0)
+
+            # Cancel it while awaiting the lock
+            # This cancel could come the outside.
+            c[0].cancel()
+
+            # now wait for the item to be consumed
+            # if it doesn't means that our "notify" didn"t take hold.
+            # because it raced with a cancel()
+            try:
+                async with asyncio.timeout(0.01):
+                    await condition.wait_for(lambda: state == 0)
+            except TimeoutError:
+                pass
+            self.assertEqual(state, 0)
+
+            # clean up
+            state = -1
+            condition.notify_all()
+        await c[1]
 
 class SemaphoreTests(unittest.IsolatedAsyncioTestCase):
 

--- a/Misc/NEWS.d/next/Library/2024-01-12-09-35-07.gh-issue-112202.t_0V1m.rst
+++ b/Misc/NEWS.d/next/Library/2024-01-12-09-35-07.gh-issue-112202.t_0V1m.rst
@@ -1,0 +1,1 @@
+Ensure that a :func:`asyncio.Condition.notify` call does not get lost if the notified ``Task`` is simultaneously cancelled or encounters any other error.

--- a/Misc/NEWS.d/next/Library/2024-01-12-09-35-07.gh-issue-112202.t_0V1m.rst
+++ b/Misc/NEWS.d/next/Library/2024-01-12-09-35-07.gh-issue-112202.t_0V1m.rst
@@ -1,1 +1,1 @@
-Ensure that a :func:`asyncio.Condition.notify` call does not get lost if the notified ``Task`` is simultaneously cancelled or encounters any other error.
+Ensure that a :func:`asyncio.Condition.notify` call does not get lost if the awoken ``Task`` is simultaneously cancelled or encounters any other error.

--- a/Misc/NEWS.d/next/Library/2024-01-12-09-35-07.gh-issue-112202.t_0V1m.rst
+++ b/Misc/NEWS.d/next/Library/2024-01-12-09-35-07.gh-issue-112202.t_0V1m.rst
@@ -1,1 +1,1 @@
-Ensure that a :func:`asyncio.Condition.notify` call does not get lost if the awoken ``Task`` is simultaneously cancelled or encounters any other error.
+Ensure that a :func:`asyncio.Condition.notify` call does not get lost if the awakened ``Task`` is simultaneously cancelled or encounters any other error.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

If `Condition.notify()` raises an exception that *could* have occurred *after* the task was selected to be woken up, wake up another task instead, if available.

This ensures that  the typical case, of waking up *one* task to handle something, will succeed even if the candidate task
is cancelled at the same time or otherwise wakes up with an error.

This *may* result in a spurious wakeup of a waiting task, which is what the Condition Variable protocol specifies, precisely because waking up tasks *conservatively* (rather wake up too many than too few) is the safest and simplest to implement, and missing wakeups are serious (and cause deadlocks), while extra wakeups are easily handled by application code.

IMHO trying to guarantee that we never perform any extra wakeups would complicate the code too much and be too hard to verify, particularly since that is not a guarantee that Condition Variables are supposed to provide.

The PR includes

- Tests
- Fix to asyncio.Condition where raising an exception out of `condition.wait` after having released the lock will result in a second task being awoken, if available
- Documentation changes explaining the Condition Variable protocol and how if favors too many wakeups over to few wakeups (i.e. how "spurious wakeups" *may* occur)


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--112201.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->

<!-- gh-issue-number: gh-112202 -->
* Issue: gh-112202
<!-- /gh-issue-number -->
