### PR TITLE
gh-106529: Cleanups split off gh-112134

### DIFF
--- a/Include/internal/pycore_uops.h
+++ b/Include/internal/pycore_uops.h
@@ -10,7 +10,7 @@ extern "C" {
 
 #include "pycore_frame.h"         // _PyInterpreterFrame
 
-#define _Py_UOP_MAX_TRACE_LENGTH 128
+#define _Py_UOP_MAX_TRACE_LENGTH 256
 
 typedef struct {
     uint16_t opcode;

--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -1609,6 +1609,7 @@ Python/ceval.o: \
 		$(srcdir)/Python/ceval_macros.h \
 		$(srcdir)/Python/condvar.h \
 		$(srcdir)/Python/generated_cases.c.h \
+		$(srcdir)/Python/executor_cases.c.h \
 		$(srcdir)/Python/opcode_targets.h
 
 Python/flowgraph.o: \

--- a/Python/bytecodes.c
+++ b/Python/bytecodes.c
@@ -1210,6 +1210,7 @@ dummy_func(
         };
 
         specializing op(_SPECIALIZE_UNPACK_SEQUENCE, (counter/1, seq -- seq)) {
+            TIER_ONE_ONLY
             #if ENABLE_SPECIALIZATION
             if (ADAPTIVE_COUNTER_IS_ZERO(counter)) {
                 next_instr = this_instr;

--- a/Python/generated_cases.c.h
+++ b/Python/generated_cases.c.h
@@ -1731,6 +1731,7 @@
             seq = stack_pointer[-1];
             {
                 uint16_t counter = read_u16(&this_instr[1].cache);
+                TIER_ONE_ONLY
                 #if ENABLE_SPECIALIZATION
                 if (ADAPTIVE_COUNTER_IS_ZERO(counter)) {
                     next_instr = this_instr;

--- a/Python/optimizer.c
+++ b/Python/optimizer.c
@@ -325,7 +325,8 @@ uop_dealloc(_PyUOpExecutorObject *self) {
 }
 
 static const char *
-uop_name(int index) {
+uop_name(int index)
+{
     if (index <= MAX_REAL_OPCODE) {
         return _PyOpcode_OpName[index];
     }
@@ -832,6 +833,24 @@ make_executor_from_uops(_PyUOpInstruction *buffer, _PyBloomFilter *dependencies)
     assert(dest == -1);
     executor->base.execute = _PyUopExecute;
     _Py_ExecutorInit((_PyExecutorObject *)executor, dependencies);
+#ifdef Py_DEBUG
+    char *python_lltrace = Py_GETENV("PYTHON_LLTRACE");
+    int lltrace = 0;
+    if (python_lltrace != NULL && *python_lltrace >= '0') {
+        lltrace = *python_lltrace - '0';  // TODO: Parse an int and all that
+    }
+    if (lltrace >= 2) {
+        printf("Optimized executor (length %d):\n", length);
+        for (int i = 0; i < length; i++) {
+            printf("%4d %s(%d, %d, %" PRIu64 ")\n",
+                   i,
+                   uop_name(executor->trace[i].opcode),
+                   executor->trace[i].oparg,
+                   executor->trace[i].target,
+                   executor->trace[i].operand);
+        }
+    }
+#endif
     return (_PyExecutorObject *)executor;
 }
 

--- a/Tools/cases_generator/flags.py
+++ b/Tools/cases_generator/flags.py
@@ -53,7 +53,7 @@ ESCAPING_FUNCTIONS = (
 
 def makes_escaping_api_call(instr: parsing.InstDef) -> bool:
     if "CALL_INTRINSIC" in instr.name:
-        return True;
+        return True
     tkns = iter(instr.tokens)
     for tkn in tkns:
         if tkn.kind != lx.IDENTIFIER:
@@ -78,6 +78,7 @@ def makes_escaping_api_call(instr: parsing.InstDef) -> bool:
             continue
         return True
     return False
+
 
 @dataclasses.dataclass
 class InstructionFlags:
@@ -124,9 +125,7 @@ class InstructionFlags:
                 or variable_used(instr, "exception_unwind")
                 or variable_used(instr, "resume_with_error")
             ),
-            HAS_ESCAPES_FLAG=(
-                makes_escaping_api_call(instr)
-            ),
+            HAS_ESCAPES_FLAG=makes_escaping_api_call(instr),
         )
 
     @staticmethod

--- a/Tools/cases_generator/parsing.py
+++ b/Tools/cases_generator/parsing.py
@@ -105,7 +105,7 @@ UOp = OpName | CacheEffect
 
 @dataclass
 class InstHeader(Node):
-    annotations : list[str]
+    annotations: list[str]
     kind: Literal["inst", "op"]
     name: str
     inputs: list[InputEffect]
@@ -114,7 +114,7 @@ class InstHeader(Node):
 
 @dataclass
 class InstDef(Node):
-    annotations : list[str]
+    annotations: list[str]
     kind: Literal["inst", "op"]
     name: str
     inputs: list[InputEffect]


### PR DESCRIPTION
- Double max trace size to 256
- Add a dependency on executor_cases.c.h for ceval.o
- Mark `_SPECIALIZE_UNPACK_SEQUENCE` as `TIER_ONE_ONLY`
- Add debug output back showing the optimized trace
- Bunch of cleanups to Tools/cases_generator/

<!-- gh-issue-number: gh-106529 -->
* Issue: gh-106529
<!-- /gh-issue-number -->
