### PR TITLE
gh-110383: Fix documentation profile cumtime fix

### DIFF
--- a/Doc/library/profile.rst
+++ b/Doc/library/profile.rst
@@ -82,8 +82,8 @@ the following::
 
 The first line indicates that 214 calls were monitored.  Of those calls, 207
 were :dfn:`primitive`, meaning that the call was not induced via recursion. The
-next line: ``Ordered by: cumulative time`` indicates rows sorting order
-for the table below. The column headings include:
+next line: ``Ordered by: cumulative time`` indicates the output is sorted
+by the ``cumtime`` values. The column headings include:
 
 ncalls
    for the number of calls.

--- a/Doc/library/profile.rst
+++ b/Doc/library/profile.rst
@@ -80,10 +80,10 @@ the following::
         1    0.000    0.000    0.000    0.000 _compiler.py:598(_code)
         1    0.000    0.000    0.000    0.000 _parser.py:435(_parse_sub)
 
-The first line indicates that 214 calls were monitored.  Of those calls, 207
+The first line indicates that 214 calls were monitored. Of those calls, 207
 were :dfn:`primitive`, meaning that the call was not induced via recursion. The
-next line: ``Ordered by: cumulative time``, indicates that the text string in the
-far right column was used to sort the output. The column headings include:
+next line: ``Ordered by: cumulative time`` indicates rows sorting order
+for the table below. The column headings include:
 
 ncalls
    for the number of calls.

--- a/Doc/library/profile.rst
+++ b/Doc/library/profile.rst
@@ -80,7 +80,7 @@ the following::
         1    0.000    0.000    0.000    0.000 _compiler.py:598(_code)
         1    0.000    0.000    0.000    0.000 _parser.py:435(_parse_sub)
 
-The first line indicates that 214 calls were monitored. Of those calls, 207
+The first line indicates that 214 calls were monitored.  Of those calls, 207
 were :dfn:`primitive`, meaning that the call was not induced via recursion. The
 next line: ``Ordered by: cumulative time`` indicates rows sorting order
 for the table below. The column headings include:


### PR DESCRIPTION
Rephrased for a clearer explanation: profiler docs inaccuracy by 2dfkit

https://mail.python.org/archives/list/docs@python.org/thread/DJNXVVP2UW4R6OAPRA6TE5WMHDC4NKZ6/#DJNXVVP2UW4R6OAPRA6TE5WMHDC4NKZ6

<!-- gh-issue-number: gh-110383 -->
* Issue: gh-110383
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--112221.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->