### PR TITLE
gh-108724: Use _PyTime_GetMonotonicClock() in parking_lot.c

### DIFF
--- a/Python/parking_lot.c
+++ b/Python/parking_lot.c
@@ -118,7 +118,7 @@ _PySemaphore_PlatformWait(_PySemaphore *sema, _PyTime_t timeout)
     if (timeout >= 0) {
         struct timespec ts;
 
-        _PyTime_t deadline = _PyTime_Add(_PyTime_GetSystemClock(), timeout);
+        _PyTime_t deadline = _PyTime_Add(_PyTime_GetMonotonicClock(), timeout);
         _PyTime_AsTimespec(deadline, &ts);
 
         err = sem_timedwait(&sema->platform_sem, &ts);
@@ -150,7 +150,7 @@ _PySemaphore_PlatformWait(_PySemaphore *sema, _PyTime_t timeout)
         if (timeout >= 0) {
             struct timespec ts;
 
-            _PyTime_t deadline = _PyTime_Add(_PyTime_GetSystemClock(), timeout);
+            _PyTime_t deadline = _PyTime_Add(_PyTime_GetMonotonicClock(), timeout);
             _PyTime_AsTimespec(deadline, &ts);
 
             err = pthread_cond_timedwait(&sema->cond, &sema->mutex, &ts);


### PR DESCRIPTION
Using a system clock causes issues when it's being updated by the system administrator, NTP, Daylight Saving Time, or anything else. Sadly, on Windows, the monotonic clock resolution is around 15.6 ms.

Example: https://github.com/python/cpython/issues/85876

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-108724 -->
* Issue: gh-108724
<!-- /gh-issue-number -->
