### PR TITLE
gh-110319: Assert type_version != 0 before using it

### DIFF
--- a/Python/bytecodes.c
+++ b/Python/bytecodes.c
@@ -2026,8 +2026,8 @@ dummy_func(
             DEOPT_IF(tstate->interp->eval_frame);
 
             PyTypeObject *cls = Py_TYPE(owner);
-            DEOPT_IF(cls->tp_version_tag != type_version);
             assert(type_version != 0);
+            DEOPT_IF(cls->tp_version_tag != type_version);
             assert(Py_IS_TYPE(fget, &PyFunction_Type));
             PyFunctionObject *f = (PyFunctionObject *)fget;
             assert(func_version != 0);
@@ -2049,8 +2049,8 @@ dummy_func(
             assert((oparg & 1) == 0);
             DEOPT_IF(tstate->interp->eval_frame);
             PyTypeObject *cls = Py_TYPE(owner);
-            DEOPT_IF(cls->tp_version_tag != type_version);
             assert(type_version != 0);
+            DEOPT_IF(cls->tp_version_tag != type_version);
             assert(Py_IS_TYPE(getattribute, &PyFunction_Type));
             PyFunctionObject *f = (PyFunctionObject *)getattribute;
             assert(func_version != 0);

--- a/Python/generated_cases.c.h
+++ b/Python/generated_cases.c.h
@@ -2933,8 +2933,8 @@
             DEOPT_IF(tstate->interp->eval_frame, LOAD_ATTR);
 
             PyTypeObject *cls = Py_TYPE(owner);
-            DEOPT_IF(cls->tp_version_tag != type_version, LOAD_ATTR);
             assert(type_version != 0);
+            DEOPT_IF(cls->tp_version_tag != type_version, LOAD_ATTR);
             assert(Py_IS_TYPE(fget, &PyFunction_Type));
             PyFunctionObject *f = (PyFunctionObject *)fget;
             assert(func_version != 0);
@@ -2964,8 +2964,8 @@
             assert((oparg & 1) == 0);
             DEOPT_IF(tstate->interp->eval_frame, LOAD_ATTR);
             PyTypeObject *cls = Py_TYPE(owner);
-            DEOPT_IF(cls->tp_version_tag != type_version, LOAD_ATTR);
             assert(type_version != 0);
+            DEOPT_IF(cls->tp_version_tag != type_version, LOAD_ATTR);
             assert(Py_IS_TYPE(getattribute, &PyFunction_Type));
             PyFunctionObject *f = (PyFunctionObject *)getattribute;
             assert(func_version != 0);

--- a/Tools/cases_generator/generate_cases.py
+++ b/Tools/cases_generator/generate_cases.py
@@ -94,7 +94,7 @@ arg_parser = argparse.ArgumentParser(
 
 arg_parser.add_argument(
     "-v",
-    "--verbose",
+    "--viable",
     help="Print list of non-viable uops and exit",
     action="store_true",
 )
@@ -871,7 +871,7 @@ def main() -> None:
     a.analyze()  # Prints messages and sets a.errors on failure
     if a.errors:
         sys.exit(f"Found {a.errors} errors")
-    if args.verbose:
+    if args.viable:
         # Load execution counts from bmraw.json, if it exists
         a.report_non_viable_uops("bmraw.json")
         return


### PR DESCRIPTION
- Ensure that `assert(type_version != 0);` always comes *before* using `type_version`

Also:
- In cases_generator, rename `-v` to from `--verbose` to `--viable`

<!-- gh-issue-number: gh-110319 -->
* Issue: gh-110319
<!-- /gh-issue-number -->
