### PR TITLE
[3.12] gh-112155: Run `typing.py` doctests during tests (GH-112156)

### DIFF
--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -9282,5 +9282,11 @@ class TypeIterationTests(BaseTestCase):
             self.assertNotIsInstance(type_to_test, collections.abc.Iterable)
 
 
+def load_tests(loader, tests, pattern):
+    import doctest
+    tests.addTests(doctest.DocTestSuite(typing))
+    return tests
+
+
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
(cherry picked from commit 7680da458398c5a08b9c32785b1eeb7b7c0887e4)

Co-authored-by: Nikita Sobolev <mail@sobolevn.me>
Co-authored-by: Alex Waygood <Alex.Waygood@Gmail.com>

<!-- gh-issue-number: gh-112155 -->
* Issue: gh-112155
<!-- /gh-issue-number -->
