### PR TITLE
GH-110109: Test pure functionality of `pathlib.Path` user subclasses

### DIFF
--- a/Lib/test/test_pathlib.py
+++ b/Lib/test/test_pathlib.py
@@ -1569,15 +1569,6 @@ class PurePathSubclassTest(PurePathTest):
     test_repr_roundtrips = None
 
 
-@only_posix
-class PosixPathAsPureTest(PurePosixPathTest):
-    cls = pathlib.PosixPath
-
-@only_nt
-class WindowsPathAsPureTest(PureWindowsPathTest):
-    cls = pathlib.WindowsPath
-
-
 #
 # Tests for the virtual classes.
 #
@@ -1771,6 +1762,7 @@ class DummyPathTest(unittest.TestCase):
     #
 
     def setUp(self):
+        super().setUp()
         pathmod = self.cls.pathmod
         p = self.cls(BASE)
         p.mkdir(parents=True)
@@ -2793,7 +2785,7 @@ class DummyPathWithSymlinksTest(DummyPathTest):
 # Tests for the concrete classes.
 #
 
-class PathTest(DummyPathTest):
+class PathTest(DummyPathTest, PurePathTest):
     """Tests for the FS-accessing functionalities of the Path classes."""
     cls = pathlib.Path
     can_symlink = os_helper.can_symlink()
@@ -3409,7 +3401,7 @@ class PathTest(DummyPathTest):
 
 
 @only_posix
-class PosixPathTest(PathTest):
+class PosixPathTest(PathTest, PurePosixPathTest):
     cls = pathlib.PosixPath
 
     def test_absolute(self):
@@ -3585,7 +3577,7 @@ class PosixPathTest(PathTest):
 
 
 @only_nt
-class WindowsPathTest(PathTest):
+class WindowsPathTest(PathTest, PureWindowsPathTest):
     cls = pathlib.WindowsPath
 
     def test_absolute(self):


### PR DESCRIPTION
Add `PurePathTest` as a superclass of `PathTest`, and therefore also `PathSubclassTest`. This adds coverage of pure functionality in user subclasses of `pathlib.Path`.

Remove `PosixPathAsPureTest` and `WindowsPathAsPureTest`, as they now duplicate `PosixPathTest` and `WindowsPathTest`.

This makes the MROs of test unit classes match the MROs of pathlib classes.


<!-- gh-issue-number: gh-110109 -->
* Issue: gh-110109
<!-- /gh-issue-number -->
