### PR TITLE
GH-77621: Delay some imports from pathlib

### DIFF
--- a/Lib/pathlib.py
+++ b/Lib/pathlib.py
@@ -5,14 +5,11 @@ paths with operations that have semantics appropriate for different
 operating systems.
 """
 
-import contextlib
 import functools
-import glob
 import io
 import ntpath
 import os
 import posixpath
-import re
 import sys
 import warnings
 from _collections_abc import Sequence
@@ -80,12 +77,13 @@ def _is_case_sensitive(pathmod):
 def _compile_pattern(pat, sep, case_sensitive):
     """Compile given glob pattern to a re.Pattern object (observing case
     sensitivity)."""
-    flags = re.NOFLAG if case_sensitive else re.IGNORECASE
-    regex = glob.translate(pat, recursive=True, include_hidden=True, seps=sep)
+    from glob import translate
+    regex = translate(pat, recursive=True, include_hidden=True, seps=sep)
     # The string representation of an empty path is a single dot ('.'). Empty
     # paths shouldn't match wildcards, so we consume it with an atomic group.
     regex = r'(\.\Z)?+' + regex
-    return re.compile(regex, flags).match
+    from re import compile, NOFLAG, IGNORECASE
+    return compile(regex, flags=NOFLAG if case_sensitive else IGNORECASE).match
 
 
 def _select_children(parent_paths, dir_only, follow_symlinks, match):
@@ -989,7 +987,8 @@ class _PathBase(PurePath):
     def _scandir(self):
         # Emulate os.scandir(), which returns an object that can be used as a
         # context manager. This method is called by walk() and glob().
-        return contextlib.nullcontext(self.iterdir())
+        from contextlib import nullcontext
+        return nullcontext(self.iterdir())
 
     def _make_child_relpath(self, name):
         path_str = str(self)

--- a/Lib/pathlib.py
+++ b/Lib/pathlib.py
@@ -72,18 +72,23 @@ def _is_case_sensitive(pathmod):
 # Globbing helpers
 #
 
+re = glob = None
+
 
 @functools.lru_cache(maxsize=256)
 def _compile_pattern(pat, sep, case_sensitive):
     """Compile given glob pattern to a re.Pattern object (observing case
     sensitivity)."""
-    from glob import translate
-    regex = translate(pat, recursive=True, include_hidden=True, seps=sep)
+    global re, glob
+    if re is None:
+        import re, glob
+
+    flags = re.NOFLAG if case_sensitive else re.IGNORECASE
+    regex = glob.translate(pat, recursive=True, include_hidden=True, seps=sep)
     # The string representation of an empty path is a single dot ('.'). Empty
     # paths shouldn't match wildcards, so we consume it with an atomic group.
     regex = r'(\.\Z)?+' + regex
-    from re import compile, NOFLAG, IGNORECASE
-    return compile(regex, flags=NOFLAG if case_sensitive else IGNORECASE).match
+    return re.compile(regex, flags=flags).match
 
 
 def _select_children(parent_paths, dir_only, follow_symlinks, match):

--- a/Misc/NEWS.d/next/Library/2023-11-21-02-58-14.gh-issue-77621.MYv5XS.rst
+++ b/Misc/NEWS.d/next/Library/2023-11-21-02-58-14.gh-issue-77621.MYv5XS.rst
@@ -1,0 +1,2 @@
+Slightly improve the import time of the :mod:`pathlib` module by deferring
+some imports. Patch by Barney Gale.


### PR DESCRIPTION
Import `contextlib`, `glob` and `re` only as required.


<!-- gh-issue-number: gh-77621 -->
* Issue: gh-77621
<!-- /gh-issue-number -->
