### PR TITLE
GH-112245: Promote free threaded CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -190,7 +190,7 @@ jobs:
   build_windows_free_threaded:
     name: 'Windows (free-threaded)'
     needs: check_source
-    if: needs.check_source.outputs.run_tests == 'true' && contains(github.event.pull_request.labels.*.name, 'topic-free-threaded')
+    if: needs.check_source.outputs.run_tests == 'true'
     uses: ./.github/workflows/reusable-windows.yml
     with:
       free-threaded: true
@@ -206,7 +206,7 @@ jobs:
   build_macos_free_threaded:
     name: 'macOS (free-threaded)'
     needs: check_source
-    if: needs.check_source.outputs.run_tests == 'true' && contains(github.event.pull_request.labels.*.name, 'topic-free-threaded')
+    if: needs.check_source.outputs.run_tests == 'true'
     uses: ./.github/workflows/reusable-macos.yml
     with:
       config_hash: ${{ needs.check_source.outputs.config_hash }}
@@ -228,7 +228,7 @@ jobs:
   build_ubuntu_free_threaded:
     name: 'Ubuntu (free-threaded)'
     needs: check_source
-    if: needs.check_source.outputs.run_tests == 'true' && contains(github.event.pull_request.labels.*.name, 'topic-free-threaded')
+    if: needs.check_source.outputs.run_tests == 'true'
     uses: ./.github/workflows/reusable-ubuntu.yml
     with:
       config_hash: ${{ needs.check_source.outputs.config_hash }}
@@ -521,10 +521,7 @@ jobs:
       uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe
       with:
         allowed-failures: >-
-          build_macos_free_threaded,
-          build_ubuntu_free_threaded,
           build_ubuntu_ssltests,
-          build_windows_free_threaded,
           cifuzz,
           test_hypothesis,
         allowed-skips: >-


### PR DESCRIPTION
this implements the changes proposed in GH-112245 and [discussed on discourse](https://discuss.python.org/t/is-it-time-to-promote-free-threaded-ci-and-buildbots/39064), namely:

1. Change the triggering of the free-threaded jobs to always trigger, instead of conditionally on the presence of the topic-free-threaded label.
2. Remove the free-threaded jobs from the list of allowed failures (aka require that these jobs pass to get green signal).