### PR TITLE
gh-112075: Make some `dict` operations thread-safe without GIL

### DIFF
--- a/Objects/clinic/dictobject.c.h
+++ b/Objects/clinic/dictobject.c.h
@@ -32,7 +32,9 @@ dict_fromkeys(PyTypeObject *type, PyObject *const *args, Py_ssize_t nargs)
     }
     value = args[1];
 skip_optional:
+    Py_BEGIN_CRITICAL_SECTION(type);
     return_value = dict_fromkeys_impl(type, iterable, value);
+    Py_END_CRITICAL_SECTION();
 
 exit:
     return return_value;
@@ -191,6 +193,12 @@ dict___reversed___impl(PyDictObject *self);
 static PyObject *
 dict___reversed__(PyDictObject *self, PyObject *Py_UNUSED(ignored))
 {
-    return dict___reversed___impl(self);
+    PyObject *return_value = NULL;
+
+    Py_BEGIN_CRITICAL_SECTION(self);
+    return_value = dict___reversed___impl(self);
+    Py_END_CRITICAL_SECTION();
+
+    return return_value;
 }
-/*[clinic end generated code: output=17c3c4cf9a9b95a7 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=60390b467722d482 input=a9049054013a1b77]*/


### PR DESCRIPTION
#112075

For `dict.__len__`, `_Py_atomic_load_ssize_relaxed` is used to access `PyDictObject` `ma_used` field.

For the following methods
* `dict.fromkeys`
* `dict.copy`
* `dict_richcompare`
* `dict.clear`
* `dict.__sizeof__`
* `dict.__or__`
* `dict.__ior__`
* `dict.__reversed__`
* `dict.keys`
* `dict.items`
* `dict.values`
* `dict.update` (in `dict_update_common`)
* `dict.__init__` (in `dict_update_common`)
* `dict.__repr__`

the critical section API is used, either in form of AC directive or macro.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
