### PR TITLE
gh-101178: refactor base64.b85encode to be memory friendly

### DIFF
--- a/Lib/base64.py
+++ b/Lib/base64.py
@@ -302,8 +302,8 @@ def _85encode(b, chars, chars2, pad=False, foldnuls=False, foldspaces=False):
     if not isinstance(b, bytes_types):
         b = memoryview(b).tobytes()
 
-    return binascii.b2a_base85(b, chars=chars, pad=pad,
-                               foldnuls=foldnuls, foldspaces=foldspaces)
+    return binascii._b2a_base85(b, chars=chars, pad=pad,
+                                foldnuls=foldnuls, foldspaces=foldspaces)
 
 def a85encode(b, *, foldspaces=False, wrapcol=0, pad=False, adobe=False):
     """Encode bytes-like object b using Ascii85 and return a bytes object.

--- a/Lib/test/test_base64.py
+++ b/Lib/test/test_base64.py
@@ -528,6 +528,7 @@ class BaseXYTestCase(unittest.TestCase):
                 b"""0123456789!@#0^&*();:<>,. []{}""":
                 b"""VPa!sWoBn+X=-b1ZEkOHadLBXb#`}nd3r%YLqtVJM@UIZOH55pPf$@("""
                 b"""Q&d$}S6EqEFflSSG&MFiI5{CeBQRbjDkv#CIy^osE+AW7dwl""",
+            b"paddu\xc7": b'aA9O*b;k',
             b'no padding..': b'Zf_uPVPs@!Zf7no',
             b'zero compression\x00\x00\x00\x00': b'dS!BNAY*TBaB^jHb7^mG00000',
             b'zero compression\x00\x00\x00': b'dS!BNAY*TBaB^jHb7^mG0000',

--- a/Modules/binascii.c
+++ b/Modules/binascii.c
@@ -1299,9 +1299,11 @@ binascii_b2a_base85_impl(PyObject *module, Py_buffer *data, Py_buffer *chars,
 
         if (foldnuls && value == 0) {
             *ascii_data++ = 'z';
-        } else if (foldspaces && value == 0x20202020) {
+        }
+        else if (foldspaces && value == 0x20202020) {
             *ascii_data++ = 'y';
-        } else {
+        }
+        else {
             for (j = 0; j < 5 ; j++) {
                 ascii_data[4 - j] = table[value % 85];
                 value /= 85;

--- a/Modules/binascii.c
+++ b/Modules/binascii.c
@@ -1290,8 +1290,9 @@ binascii__b2a_base85_impl(PyObject *module, Py_buffer *data,
     size_t i = 0 ;
     int padding = 0;
 
+    // Conversion largely inspired from git base85 implementation
     while (i < bin_len) {
-        // translate each 4 byte chunk to 32bit integer
+        // Translate each 4 byte chunk to 32bit integer
         uint32_t value = 0;
         for (int cnt = 24; cnt >= 0; cnt -= 8) {
             value |= bin_data[i] << cnt;
@@ -1302,6 +1303,7 @@ binascii__b2a_base85_impl(PyObject *module, Py_buffer *data,
             }
         }
 
+        // Handle NULL only and space-only cases (specific to ASCII85)
         if (foldnuls && value == 0) {
             *ascii_data++ = 'z';
         }
@@ -1317,6 +1319,7 @@ binascii__b2a_base85_impl(PyObject *module, Py_buffer *data,
         }
     }
 
+    // Expand the last folded null in case it did not fill a full chunk
     if (padding && !pad && foldnuls && ascii_data[-1] == 'z') {
         ascii_data--;
         memset(ascii_data, table[0], 5);

--- a/Modules/binascii.c
+++ b/Modules/binascii.c
@@ -1308,8 +1308,8 @@ binascii_b2a_base85_impl(PyObject *module, Py_buffer *data, Py_buffer *chars,
             *ascii_data++ = 'y';
         }
         else {
-            for (int j = 0; j < 5 ; j++) {
-                ascii_data[4 - j] = table[value % 85];
+            for (int j = 4; j >= 0; j--) {
+                ascii_data[j] = table[value % 85];
                 value /= 85;
             }
             ascii_data += 5;

--- a/Modules/binascii.c
+++ b/Modules/binascii.c
@@ -1240,7 +1240,7 @@ binascii_b2a_qp_impl(PyObject *module, Py_buffer *data, int quotetabs,
 }
 
 /*[clinic input]
-binascii.b2a_base85
+binascii._b2a_base85
 
     data: Py_buffer
     chars: Py_buffer
@@ -1259,9 +1259,10 @@ Utility method used by the base64 module to encode a85/b85 data
 [clinic start generated code]*/
 
 static PyObject *
-binascii_b2a_base85_impl(PyObject *module, Py_buffer *data, Py_buffer *chars,
-                         int pad, int foldnuls, int foldspaces)
-/*[clinic end generated code: output=0a92b3c535580aa0 input=a2d8ae712ed5adba]*/
+binascii__b2a_base85_impl(PyObject *module, Py_buffer *data,
+                          Py_buffer *chars, int pad, int foldnuls,
+                          int foldspaces)
+/*[clinic end generated code: output=cefe84c300ad7314 input=3c8faf77b992dcc2]*/
 {
     if (chars->len != 85) {
         PyErr_SetString(PyExc_ValueError,
@@ -1336,7 +1337,7 @@ static struct PyMethodDef binascii_module_methods[] = {
     BINASCII_B2A_UU_METHODDEF
     BINASCII_A2B_BASE64_METHODDEF
     BINASCII_B2A_BASE64_METHODDEF
-    BINASCII_B2A_BASE85_METHODDEF
+    BINASCII__B2A_BASE85_METHODDEF
     BINASCII_A2B_HEX_METHODDEF
     BINASCII_B2A_HEX_METHODDEF
     BINASCII_HEXLIFY_METHODDEF

--- a/Modules/clinic/binascii.c.h
+++ b/Modules/clinic/binascii.c.h
@@ -775,9 +775,9 @@ exit:
     return return_value;
 }
 
-PyDoc_STRVAR(binascii_b2a_base85__doc__,
-"b2a_base85($module, /, data, chars, pad=False, foldnuls=False,\n"
-"           foldspaces=False)\n"
+PyDoc_STRVAR(binascii__b2a_base85__doc__,
+"_b2a_base85($module, /, data, chars, pad=False, foldnuls=False,\n"
+"            foldspaces=False)\n"
 "--\n"
 "\n"
 "Utility method used by the base64 module to encode a85/b85 data\n"
@@ -788,15 +788,16 @@ PyDoc_STRVAR(binascii_b2a_base85__doc__,
 "    foldnuls: replace NULL chunks by \'z\'\n"
 "    foldspaces: replace space-only chucks by \'y\'");
 
-#define BINASCII_B2A_BASE85_METHODDEF    \
-    {"b2a_base85", _PyCFunction_CAST(binascii_b2a_base85), METH_FASTCALL|METH_KEYWORDS, binascii_b2a_base85__doc__},
+#define BINASCII__B2A_BASE85_METHODDEF    \
+    {"_b2a_base85", _PyCFunction_CAST(binascii__b2a_base85), METH_FASTCALL|METH_KEYWORDS, binascii__b2a_base85__doc__},
 
 static PyObject *
-binascii_b2a_base85_impl(PyObject *module, Py_buffer *data, Py_buffer *chars,
-                         int pad, int foldnuls, int foldspaces);
+binascii__b2a_base85_impl(PyObject *module, Py_buffer *data,
+                          Py_buffer *chars, int pad, int foldnuls,
+                          int foldspaces);
 
 static PyObject *
-binascii_b2a_base85(PyObject *module, PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames)
+binascii__b2a_base85(PyObject *module, PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     #if defined(Py_BUILD_CORE) && !defined(Py_BUILD_CORE_MODULE)
@@ -820,7 +821,7 @@ binascii_b2a_base85(PyObject *module, PyObject *const *args, Py_ssize_t nargs, P
     static const char * const _keywords[] = {"data", "chars", "pad", "foldnuls", "foldspaces", NULL};
     static _PyArg_Parser _parser = {
         .keywords = _keywords,
-        .fname = "b2a_base85",
+        .fname = "_b2a_base85",
         .kwtuple = KWTUPLE,
     };
     #undef KWTUPLE
@@ -869,7 +870,7 @@ binascii_b2a_base85(PyObject *module, PyObject *const *args, Py_ssize_t nargs, P
         goto exit;
     }
 skip_optional_pos:
-    return_value = binascii_b2a_base85_impl(module, &data, &chars, pad, foldnuls, foldspaces);
+    return_value = binascii__b2a_base85_impl(module, &data, &chars, pad, foldnuls, foldspaces);
 
 exit:
     /* Cleanup for data */
@@ -883,4 +884,4 @@ exit:
 
     return return_value;
 }
-/*[clinic end generated code: output=ae4488d2f300a0ff input=a9049054013a1b77]*/
+/*[clinic end generated code: output=a1f5ae9968e8e52d input=a9049054013a1b77]*/

--- a/Modules/clinic/binascii.c.h
+++ b/Modules/clinic/binascii.c.h
@@ -774,4 +774,113 @@ exit:
 
     return return_value;
 }
-/*[clinic end generated code: output=9ed7fbeec13c6606 input=a9049054013a1b77]*/
+
+PyDoc_STRVAR(binascii_b2a_base85__doc__,
+"b2a_base85($module, /, data, chars, pad=False, foldnuls=False,\n"
+"           foldspaces=False)\n"
+"--\n"
+"\n"
+"Utility method used by the base64 module to encode a85/b85 data\n"
+"\n"
+"    data: bytes\n"
+"    chars: 85 bytes conversion table\n"
+"    pad: use NULL-paded input if necessary\n"
+"    foldnuls: replace NULL chunks by \'z\'\n"
+"    foldspaces: replace space-only chucks by \'y\'");
+
+#define BINASCII_B2A_BASE85_METHODDEF    \
+    {"b2a_base85", _PyCFunction_CAST(binascii_b2a_base85), METH_FASTCALL|METH_KEYWORDS, binascii_b2a_base85__doc__},
+
+static PyObject *
+binascii_b2a_base85_impl(PyObject *module, Py_buffer *data, Py_buffer *chars,
+                         int pad, int foldnuls, int foldspaces);
+
+static PyObject *
+binascii_b2a_base85(PyObject *module, PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames)
+{
+    PyObject *return_value = NULL;
+    #if defined(Py_BUILD_CORE) && !defined(Py_BUILD_CORE_MODULE)
+
+    #define NUM_KEYWORDS 5
+    static struct {
+        PyGC_Head _this_is_not_used;
+        PyObject_VAR_HEAD
+        PyObject *ob_item[NUM_KEYWORDS];
+    } _kwtuple = {
+        .ob_base = PyVarObject_HEAD_INIT(&PyTuple_Type, NUM_KEYWORDS)
+        .ob_item = { &_Py_ID(data), &_Py_ID(chars), &_Py_ID(pad), &_Py_ID(foldnuls), &_Py_ID(foldspaces), },
+    };
+    #undef NUM_KEYWORDS
+    #define KWTUPLE (&_kwtuple.ob_base.ob_base)
+
+    #else  // !Py_BUILD_CORE
+    #  define KWTUPLE NULL
+    #endif  // !Py_BUILD_CORE
+
+    static const char * const _keywords[] = {"data", "chars", "pad", "foldnuls", "foldspaces", NULL};
+    static _PyArg_Parser _parser = {
+        .keywords = _keywords,
+        .fname = "b2a_base85",
+        .kwtuple = KWTUPLE,
+    };
+    #undef KWTUPLE
+    PyObject *argsbuf[5];
+    Py_ssize_t noptargs = nargs + (kwnames ? PyTuple_GET_SIZE(kwnames) : 0) - 2;
+    Py_buffer data = {NULL, NULL};
+    Py_buffer chars = {NULL, NULL};
+    int pad = 0;
+    int foldnuls = 0;
+    int foldspaces = 0;
+
+    args = _PyArg_UnpackKeywords(args, nargs, NULL, kwnames, &_parser,
+            /*minpos*/ 2, /*maxpos*/ 5, /*minkw*/ 0, /*varpos*/ 0, argsbuf);
+    if (!args) {
+        goto exit;
+    }
+    if (PyObject_GetBuffer(args[0], &data, PyBUF_SIMPLE) != 0) {
+        goto exit;
+    }
+    if (PyObject_GetBuffer(args[1], &chars, PyBUF_SIMPLE) != 0) {
+        goto exit;
+    }
+    if (!noptargs) {
+        goto skip_optional_pos;
+    }
+    if (args[2]) {
+        pad = PyObject_IsTrue(args[2]);
+        if (pad < 0) {
+            goto exit;
+        }
+        if (!--noptargs) {
+            goto skip_optional_pos;
+        }
+    }
+    if (args[3]) {
+        foldnuls = PyObject_IsTrue(args[3]);
+        if (foldnuls < 0) {
+            goto exit;
+        }
+        if (!--noptargs) {
+            goto skip_optional_pos;
+        }
+    }
+    foldspaces = PyObject_IsTrue(args[4]);
+    if (foldspaces < 0) {
+        goto exit;
+    }
+skip_optional_pos:
+    return_value = binascii_b2a_base85_impl(module, &data, &chars, pad, foldnuls, foldspaces);
+
+exit:
+    /* Cleanup for data */
+    if (data.obj) {
+       PyBuffer_Release(&data);
+    }
+    /* Cleanup for chars */
+    if (chars.obj) {
+       PyBuffer_Release(&chars);
+    }
+
+    return return_value;
+}
+/*[clinic end generated code: output=ae4488d2f300a0ff input=a9049054013a1b77]*/


### PR DESCRIPTION
## Current description

Rewrote the `base64._85encode` method logic in C, by plugging in the `binascii` module (already taking care of the bae64 methods)

By using C and a single buffer, the memory use is reduced to a minimum, addressing the initial issue.

It also greatly improves performance as a bonus:

main
```
SMALL (11 bytes): 1575427 iterations (1.27 µs per call, 115.41 ns per byte)
MEDIUM (200 bytes): 204909 iterations (9.76 µs per call, 48.80 ns per byte)
BIG (5000 bytes): 8623 iterations (231.94 µs per call, 46.39 ns per byte)
VERYBIG (500000 bytes): 81 iterations (24.69 ms per call, 49.38 ns per byte)
```

branch
```
SMALL (11 bytes): 11230718 iterations (178.08 ns per call, 16.19 ns per byte)
MEDIUM (200 bytes): 6004721 iterations (333.07 ns per call, 1.67 ns per byte)
BIG (5000 bytes): 458005 iterations (4.37 µs per call, 873.35 ps per byte)
VERYBIG (500000 bytes): 4772 iterations (419.11 µs per call, 838.22 ps per byte)
```

Script used to test: https://gist.github.com/romuald/7aeba5f40693bb351da4abe62ad7321d


## Previous description (python refactor)

**not up to date with current PR**

Refactor code to make use of generators instead of allocating 2 potentially huge lists for large datasets

Memory gain only measured using macOS and a 5Mb input.

Using `main`:

```
Before encoding
Physical footprint:         16.3M
Physical footprint (peak):  21.3M

After encoding
Physical footprint:         45.0M
Physical footprint (peak):  244.1M
```

With refactor:
```
Before encoding
Physical footprint:         14.6M
Physical footprint (peak):  19.6M

After encoding
Physical footprint:         28.5M
Physical footprint (peak):  34.4M
```

~~The execution time is more than doubled, which may not be acceptable. However the memory used is reduced by more than 90%~~
edit: changed the algorithm to be more efficient, the performance decrease now seems to be negligible

I also have no idea how (and if) I should test this

Here is the script I've used to measure the execution time, ~~the `memdebug` can probably be adapted to read `/proc/{pid}` on Linux~~
edit: updated to work on Linux too

```python
import os
import sys
import random
import hashlib
import platform
import subprocess
from time import time

from base64 import b85encode

def memdebug():
    if platform.system == "Darwin":
        if not os.environ.get("MallocStackLogging"):
            return

        res = subprocess.check_output(["malloc_history", str(os.getpid()), "-highWaterMark", "-allBySize"])

        for line in res.splitlines():
            if line.startswith(b"Physical"):
                print(line.decode())
    elif platform.system() == "Linux":
        with open(f"/proc/{os.getpid()}/status") as reader:
            for line in reader:
                if line.startswith("VmPeak:"):
                    print(line, end="")


def main():
    # use a stable input
    rnd = random.Random()
    rnd.seed(42)
    data = rnd.randbytes(5_000_000)

    memdebug()

    start = time()
    import pdb
    try:
        res = b85encode(data)
    except Exception:
        # pdb.post_mortem()
        raise
    end = time()

    memdebug()

    print("Data length:", len(data))
    print("Output length:", len(res))
    print(f"Decode time:  {end-start:.3f}s")

    h = hashlib.md5(res).hexdigest()
    print("Hashed result", h)
    assert h == "ad97e45ba085865e70f7aa05c9a31388"

    

if __name__ == '__main__':
    main()
```

<!-- gh-issue-number: gh-101178 -->
* Issue: gh-101178
<!-- /gh-issue-number -->
