### PR TITLE
gh-112252: Fix error on unset $OSNAME in venv/activate

### DIFF
--- a/Lib/venv/scripts/common/activate
+++ b/Lib/venv/scripts/common/activate
@@ -39,7 +39,7 @@ deactivate () {
 deactivate nondestructive
 
 # on Windows, a path can contain colons and backslashes and has to be converted:
-if [ "$OSTYPE" = "cygwin" ] || [ "$OSTYPE" = "msys" ] ; then
+if [ "${OSTYPE:-}" = "cygwin" ] || [ "${OSTYPE:-}" = "msys" ] ; then
     # transform D:\path\to\venv to /d/path/to/venv on MSYS
     # and to /cygdrive/d/path/to/venv on Cygwin
     export VIRTUAL_ENV=$(cygpath "__VENV_DIR__")


### PR DESCRIPTION
Fixes usage of potentially unset $OSNAME environment variable in `venv/activate` script.

<!-- gh-issue-number: gh-112252 -->
* Issue: gh-112252
<!-- /gh-issue-number -->
