### PR TITLE
gh-79871: IDLE - Fix test_debugger bug and buildbot failures

### DIFF
--- a/Lib/idlelib/idle_test/test_debugger.py
+++ b/Lib/idlelib/idle_test/test_debugger.py
@@ -44,10 +44,8 @@ class IdbTest(unittest.TestCase):
         cls.msg = 'file.py:2: <module>()'
 
     def test_init(self):
-        # Test that Idb.__init_ calls Bdb.__init__.
-        idb = debugger.Idb(None)
-        self.assertIsNone(idb.gui)
-        self.assertTrue(hasattr(idb, 'breaks'))
+        self.assertIs(self.idb.gui, self.gui)
+
 
     def test_user_line(self):
         # Test that .user_line() creates a string message for a frame.
@@ -279,6 +277,7 @@ class NameSpaceTest(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
+        requires('gui')
         cls.root = Tk()
         cls.root.withdraw()
 

--- a/Lib/idlelib/idle_test/test_debugger.py
+++ b/Lib/idlelib/idle_test/test_debugger.py
@@ -1,4 +1,7 @@
-"Test debugger, coverage 19%"
+"""Test debugger, coverage 66%
+
+Try to make tests pass with draft bdbx, which may replace bdb in 3.13+.
+"""
 
 from idlelib import debugger
 from collections import namedtuple
@@ -45,7 +48,7 @@ class IdbTest(unittest.TestCase):
 
     def test_init(self):
         self.assertIs(self.idb.gui, self.gui)
-
+        # Won't test super call since two Bdbs are very different.
 
     def test_user_line(self):
         # Test that .user_line() creates a string message for a frame.


### PR DESCRIPTION
Missing "requires('gui')" causes Tk() to fail when no gui.  This caused CI Hypothesis test to fail,
but I did not understand message.  Then buildbots failed.

 IdbTest failed on draft Bdb replacement because so different.
Simplified version works on old and new.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
