### PR TITLE
Add some common VSCode tasks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,7 +37,6 @@ __pycache__
 tags
 TAGS
 .vs/
-.vscode/
 gmon.out
 .coverage
 .mypy_cache/
@@ -46,6 +45,10 @@ gmon.out
 .DS_Store
 
 *.exe
+
+# Visual Studio Code
+.vscode/*
+!.vscode/tasks.json
 
 # Ignore core dumps... but not Tools/msi/core/ or the like.
 core

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,87 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+      {
+        "label": "Build Python",
+        "type": "shell",
+        "command": "./configure --with-pydebug && make -j",
+        "group": {
+          "kind": "build",
+          "isDefault": true
+        },
+        "presentation": {
+          "reveal": "always",
+          "panel": "new"
+        },
+        "problemMatcher": []
+      },
+      {
+        "label": "Run all tests",
+        "type": "shell",
+        "command": "./python -m test -W -o -j4 -x test_asyncio -x test_multiprocessing_fork -x test_multiprocessing_forkserver -x test_multiprocessing_spawn -x test_concurrent_futures -x test_socket -x test_subprocess -x test_signal -x test_sysconfig",
+        "group": {
+          "kind": "test",
+          "isDefault": true
+        },
+        "presentation": {
+          "reveal": "always",
+          "panel": "new"
+        },
+        "problemMatcher": []
+      },
+      {
+        "label": "Run specific test file",
+        "type": "shell",
+        "command": "./python -m test -W -o -v ${input:test_file}",
+        "group": {
+          "kind": "test",
+          "isDefault": true
+        },
+        "presentation": {
+          "reveal": "always",
+          "panel": "new"
+        },
+        "problemMatcher": []
+      },
+      {
+        "label": "Run specific unit test",
+        "type": "shell",
+        "command": "./python -m unittest -v ${input:unit_test}",
+        "group": {
+          "kind": "test",
+          "isDefault": true
+        },
+        "presentation": {
+          "reveal": "always",
+          "panel": "new"
+        },
+        "problemMatcher": []
+      },
+      {
+        "label": "Run patch check",
+        "type": "shell",
+        "command": "make patchcheck",
+        "group": {
+          "kind": "test",
+          "isDefault": true
+        },
+        "presentation": {
+          "reveal": "always",
+          "panel": "new"
+        },
+        "problemMatcher": []
+      }
+    ],
+    "inputs": [
+        {
+          "id": "test_file",
+          "type": "promptString",
+          "description": "Which test file should run (without the extension)?"
+        },
+        {
+            "id": "unit_test",
+            "type": "promptString",
+            "description": "Which unit test should run?"
+          },
+      ]
+  }


### PR DESCRIPTION
This will add some common tasks as [VS-Code custom tasks](https://code.visualstudio.com/docs/editor/tasks#_custom-tasks), so they are fast accessible via VS-Code task command.

![image](https://github.com/python/cpython/assets/35783820/b2cdbfae-4eb1-46e5-8d71-d6b4387d2943)


Some tasks (_eq. "Run specific test file" or "Run specific unit test"_) has additional prompts

![image](https://github.com/python/cpython/assets/35783820/c83eed39-f0bb-42ba-8d8e-6472ba548dfb)

![image](https://github.com/python/cpython/assets/35783820/cc90e044-faa9-4f06-b289-c5519d299167)
