### PR TITLE
gh-111848: Clean up RESERVE() macro

### DIFF
--- a/Python/optimizer.c
+++ b/Python/optimizer.c
@@ -425,7 +425,6 @@ translate_bytecode_to_trace(
     _Py_CODEUNIT *initial_instr = instr;
     int trace_length = 0;
     int max_length = buffer_size;
-    int reserved = 0;
     struct {
         PyCodeObject *code;
         _Py_CODEUNIT *instr;
@@ -455,8 +454,6 @@ translate_bytecode_to_trace(
             (OPARG), \
             (uint64_t)(OPERAND)); \
     assert(trace_length < max_length); \
-    assert(reserved > 0); \
-    reserved--; \
     trace[trace_length].opcode = (OPCODE); \
     trace[trace_length].oparg = (OPARG); \
     trace[trace_length].operand = (OPERAND); \
@@ -473,11 +470,10 @@ translate_bytecode_to_trace(
                 (opname), (n), max_length - trace_length); \
         OPT_STAT_INC(trace_too_long); \
         goto done; \
-    } \
-    reserved = (n);  // Keep ADD_TO_TRACE honest
+    }
 
-// Reserve space for main+stub uops, plus 3 for _SET_IP, _CHECK_VALIDITY and _EXIT_TRACE
-#define RESERVE(main, stub) RESERVE_RAW((main) + (stub) + 3, _PyUopName(opcode))
+// Reserve space for N uops, plus 3 for _SET_IP, _CHECK_VALIDITY and _EXIT_TRACE
+#define RESERVE(needed) RESERVE_RAW((needed) + 3, _PyUopName(opcode))
 
 // Trace stack operations (used by _PUSH_FRAME, _POP_FRAME)
 #define TRACE_STACK_PUSH() \
@@ -542,7 +538,7 @@ top:  // Jump here after _PUSH_FRAME or likely branches
             case POP_JUMP_IF_FALSE:
             case POP_JUMP_IF_TRUE:
             {
-                RESERVE(1, 0);
+                RESERVE(1);
                 int counter = instr[1].cache;
                 int bitcount = _Py_popcount32(counter);
                 int jump_likely = bitcount > 8;
@@ -565,7 +561,7 @@ top:  // Jump here after _PUSH_FRAME or likely branches
             case JUMP_BACKWARD:
             {
                 if (instr + 2 - oparg == initial_instr && code == initial_code) {
-                    RESERVE(1, 0);
+                    RESERVE(1);
                     ADD_TO_TRACE(_JUMP_TO_TOP, 0, 0, 0);
                 }
                 else {
@@ -577,7 +573,7 @@ top:  // Jump here after _PUSH_FRAME or likely branches
 
             case JUMP_FORWARD:
             {
-                RESERVE(0, 0);
+                RESERVE(0);
                 // This will emit two _SET_IP instructions; leave it to the optimizer
                 instr += oparg;
                 break;
@@ -589,7 +585,7 @@ top:  // Jump here after _PUSH_FRAME or likely branches
                 if (expansion->nuops > 0) {
                     // Reserve space for nuops (+ _SET_IP + _EXIT_TRACE)
                     int nuops = expansion->nuops;
-                    RESERVE(nuops, 0);
+                    RESERVE(nuops);
                     if (expansion->uops[nuops-1].uop == _POP_FRAME) {
                         // Check for trace stack underflow now:
                         // We can't bail e.g. in the middle of
@@ -731,13 +727,12 @@ done:
     if (trace_length > 4) {
         ADD_TO_TRACE(_EXIT_TRACE, 0, 0, target);
         DPRINTF(1,
-                "Created a trace for %s (%s:%d) at byte offset %d -- length %d+%d\n",
+                "Created a trace for %s (%s:%d) at byte offset %d -- length %d\n",
                 PyUnicode_AsUTF8(code->co_qualname),
                 PyUnicode_AsUTF8(code->co_filename),
                 code->co_firstlineno,
                 2 * INSTR_IP(initial_instr, code),
-                trace_length,
-                buffer_size - max_length);
+                trace_length);
         OPT_HIST(trace_length + buffer_size - max_length, trace_length_hist);
         return 1;
     }


### PR DESCRIPTION
And avoid compiler warnings about unused 'reserved' variable in non-debug mode.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-111848 -->
* Issue: gh-111848
<!-- /gh-issue-number -->
