### PR TITLE
gh-108901: Deprecate `inspect.getargs`, slate it for removal in 3.15

### DIFF
--- a/Doc/whatsnew/3.13.rst
+++ b/Doc/whatsnew/3.13.rst
@@ -581,11 +581,11 @@ Pending Removal in Python 3.15
   All arguments will be removed from :func:`threading.RLock` in Python 3.15.
   (Contributed by Nikita Sobolev in :gh:`102029`.)
 
-* ``inspect.getargs`` is deprecated in 3.13 and slated for removal in 3.15.
-  :func:`inspect.signature` is the most accurate way to obtain the signature
-  of a callable. If you only have access to a code object, however,
-  ``inspect.signature(types.FunctionType(co, {}))`` can be used as a
-  direct replacement for ``inspect.getargs()``.
+* The undocumented function ``inspect.getargs`` is deprecated in Python 3.13
+  and slated for removal in Python 3.15. :func:`inspect.signature` is the most
+  accurate way to obtain the signature of a callable. If you only have access
+  to a code object, however, ``inspect.signature(types.FunctionType(co, {}))``
+  can be used as a direct replacement for ``inspect.getargs()``.
   (Contributed by Nikita Sobolev in :gh:`108901`.)
 
 Pending Removal in Python 3.16

--- a/Doc/whatsnew/3.13.rst
+++ b/Doc/whatsnew/3.13.rst
@@ -581,6 +581,10 @@ Pending Removal in Python 3.15
   All arguments will be removed from :func:`threading.RLock` in Python 3.15.
   (Contributed by Nikita Sobolev in :gh:`102029`.)
 
+* ``inspect.getargs`` is deprecated in 3.13 and slated for removal in 3.15,
+  instead use ``inspect.signature(types.FunctionType(co, {}))``.
+  (Contributed by Nikita Sobolev in :gh:`108901`.)
+
 Pending Removal in Python 3.16
 ------------------------------
 

--- a/Doc/whatsnew/3.13.rst
+++ b/Doc/whatsnew/3.13.rst
@@ -581,8 +581,11 @@ Pending Removal in Python 3.15
   All arguments will be removed from :func:`threading.RLock` in Python 3.15.
   (Contributed by Nikita Sobolev in :gh:`102029`.)
 
-* ``inspect.getargs`` is deprecated in 3.13 and slated for removal in 3.15,
-  instead use ``inspect.signature(types.FunctionType(co, {}))``.
+* ``inspect.getargs`` is deprecated in 3.13 and slated for removal in 3.15.
+  :func:`inspect.signature` is the most accurate way to obtain the signature
+  of a callable. If you only have access to a code object, however,
+  ``inspect.signature(types.FunctionType(co, {}))`` can be used as a
+  direct replacement for ``inspect.getargs()``.
   (Contributed by Nikita Sobolev in :gh:`108901`.)
 
 Pending Removal in Python 3.16

--- a/Lib/inspect.py
+++ b/Lib/inspect.py
@@ -1365,13 +1365,17 @@ def getargs(co):
     appended. 'varargs' and 'varkw' are the names of the * and **
     arguments or None.
 
-    Deprecated. Use ``inspect.signature(types.FunctionType(co, {}))`` instead.
+    Deprecated in 3.13 and slated for removal in 3.15.
+    ``inspect.signature`` is the most accurate way to obtain the signature
+    of a callable. If you only have access to a code object, however,
+    ``inspect.signature(types.FunctionType(co, {}))`` can be used as a
+    direct replacement for ``inspect.getargs()``.
     """
     import warnings
     warnings._deprecated(
         "getargs",
         "{name!r} is deprecated and slated for removal in Python {remove}, "
-        "use `inspect.signature(types.FunctionType(co, {{}}))` instead",
+        "use `inspect.signature` instead",
         remove=(3, 15),
     )
     if not iscode(co):

--- a/Lib/inspect.py
+++ b/Lib/inspect.py
@@ -1374,8 +1374,10 @@ def getargs(co):
     import warnings
     warnings._deprecated(
         "getargs",
-        "{name!r} is deprecated and slated for removal in Python {remove}, "
-        "use `inspect.signature` instead",
+        (
+            "{name!r} is deprecated and slated for removal in Python {remove}, "
+            "use `inspect.signature` instead."
+        ),
         remove=(3, 15),
     )
     if not iscode(co):

--- a/Lib/inspect.py
+++ b/Lib/inspect.py
@@ -1365,7 +1365,7 @@ def getargs(co):
     appended. 'varargs' and 'varkw' are the names of the * and **
     arguments or None.
 
-    Deprecated in 3.13 and slated for removal in 3.15.
+    Deprecated in Python 3.13; slated for removal in Python 3.15.
     ``inspect.signature`` is the most accurate way to obtain the signature
     of a callable. If you only have access to a code object, however,
     ``inspect.signature(types.FunctionType(co, {}))`` can be used as a

--- a/Lib/inspect.py
+++ b/Lib/inspect.py
@@ -1363,7 +1363,17 @@ def getargs(co):
     Three things are returned: (args, varargs, varkw), where
     'args' is the list of argument names. Keyword-only arguments are
     appended. 'varargs' and 'varkw' are the names of the * and **
-    arguments or None."""
+    arguments or None.
+
+    Deprecated. Use ``inspect.signature(types.FunctionType(co, {}))`` instead.
+    """
+    import warnings
+    warnings._deprecated(
+        "getargs",
+        "{name!r} is deprecated and slated for removal in Python {remove}, "
+        "use `inspect.signature(types.FunctionType(co, {{}}))` instead",
+        remove=(3, 15),
+    )
     if not iscode(co):
         raise TypeError('{!r} is not a code object'.format(co))
 
@@ -1489,7 +1499,10 @@ def getargvalues(frame):
     'args' is a list of the argument names.
     'varargs' and 'varkw' are the names of the * and ** arguments or None.
     'locals' is the locals dictionary of the given frame."""
-    args, varargs, varkw = getargs(frame.f_code)
+    import warnings
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore', category=DeprecationWarning)
+        args, varargs, varkw = getargs(frame.f_code)
     return ArgInfo(args, varargs, varkw, frame.f_locals)
 
 def formatannotation(annotation, base_module=None):

--- a/Lib/inspect.py
+++ b/Lib/inspect.py
@@ -1375,7 +1375,7 @@ def getargs(co):
     warnings._deprecated(
         "getargs",
         (
-            "{name!r} is deprecated and slated for removal in Python {remove}, "
+            "{name!r} is deprecated and slated for removal in Python {remove}; "
             "use `inspect.signature` instead."
         ),
         remove=(3, 15),

--- a/Lib/test/test_inspect/test_inspect.py
+++ b/Lib/test/test_inspect/test_inspect.py
@@ -5022,6 +5022,17 @@ class TestRepl(unittest.TestCase):
         self.assertIn(expected, output)
 
 
+class TestGetArgs(unittest.TestCase):
+    def test_getargs_deprecated(self):
+        import re
+
+        def func(a, b): ...
+
+        with self.assertWarnsRegex(
+            DeprecationWarning,
+            re.escape("'getargs' is deprecated and slated for removal in Python 3.15"),
+        ):
+            inspect.getargs(func.__code__)
 
 
 if __name__ == "__main__":

--- a/Misc/NEWS.d/next/Library/2023-11-20-12-31-14.gh-issue-108901.abVgVe.rst
+++ b/Misc/NEWS.d/next/Library/2023-11-20-12-31-14.gh-issue-108901.abVgVe.rst
@@ -1,0 +1,2 @@
+Deprecate undocumented ``inspect.getargs`` function. Instead use
+``inspect.signature(types.FunctionType(co, {}))``.

--- a/Misc/NEWS.d/next/Library/2023-11-20-12-31-14.gh-issue-108901.abVgVe.rst
+++ b/Misc/NEWS.d/next/Library/2023-11-20-12-31-14.gh-issue-108901.abVgVe.rst
@@ -1,5 +1,5 @@
-Undocumented ``inspect.getargs`` is deprecated in 3.13
-and slated for removal in 3.15.
+The undocumented function ``inspect.getargs`` is deprecated in
+Python 3.13 and slated for removal in Python 3.15.
 :func:`inspect.signature` is the most accurate way to obtain the signature
 of a callable. If you only have access to a code object, however,
 ``inspect.signature(types.FunctionType(co, {}))`` can be used as a

--- a/Misc/NEWS.d/next/Library/2023-11-20-12-31-14.gh-issue-108901.abVgVe.rst
+++ b/Misc/NEWS.d/next/Library/2023-11-20-12-31-14.gh-issue-108901.abVgVe.rst
@@ -1,2 +1,6 @@
-Deprecate undocumented ``inspect.getargs`` function. Instead use
-``inspect.signature(types.FunctionType(co, {}))``.
+Undocumented ``inspect.getargs`` is deprecated in 3.13
+and slated for removal in 3.15.
+:func:`inspect.signature` is the most accurate way to obtain the signature
+of a callable. If you only have access to a code object, however,
+``inspect.signature(types.FunctionType(co, {}))`` can be used as a
+direct replacement for ``inspect.getargs()``.


### PR DESCRIPTION
Following the discussion of https://github.com/python/cpython/pull/108902, I documented that `getargs` is deprecated (since it is not documented anywhere, I just modified its docstring) and that `inspect.signature(types.FunctionType(co, {}))` is the modern alternative. I think that it is safe to remove this function in two versions, because it does not work anyway (pos-only, kw-only params are incorrect).

I also don't think that modernizing `getargvalues` is valuable, because it will also be deprecated in 3.13 and hopefully removed in 3.15 as well.

CC @AlexWaygood @merwok @vstinner who reviewed the first PR.

<!-- gh-issue-number: gh-108901 -->
* Issue: gh-108901
<!-- /gh-issue-number -->
