### PR TITLE
gh-111963: Update `sys.monitoring.free_tool_id` docs for clarification

### DIFF
--- a/Doc/library/sys.monitoring.rst
+++ b/Doc/library/sys.monitoring.rst
@@ -54,6 +54,13 @@ Registering and using tools
 
    Should be called once a tool no longer requires *tool_id*.
 
+.. note::
+
+   :func:`free_tool_id` will not disable global or local events associated
+   with *tool_id*, nor will it unregister any callback functions. This
+   function is only intended to be used to notify the VM that the
+   particular *tool_id* is no longer in use.
+
 .. function:: get_tool(tool_id: int, /) -> str | None
 
    Returns the name of the tool if *tool_id* is in use,


### PR DESCRIPTION
Add a note that `sys.monitoring.free_tool_id` will not disable events or unregister callbacks for clarification.

<!-- gh-issue-number: gh-111963 -->
* Issue: gh-111963
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--112291.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->