### PR TITLE
gh-112301: fix compiler warning about a possible use of an uninitialized variable

### DIFF
--- a/Modules/_io/fileio.c
+++ b/Modules/_io/fileio.c
@@ -157,7 +157,7 @@ _io_FileIO_close_impl(fileio *self, PyTypeObject *cls)
         return res;
     }
 
-    PyObject *exc;
+    PyObject *exc = NULL;
     if (res == NULL) {
         exc = PyErr_GetRaisedException();
     }
@@ -171,7 +171,7 @@ _io_FileIO_close_impl(fileio *self, PyTypeObject *cls)
         }
     }
     rc = internal_close(self);
-    if (res == NULL) {
+    if (exc != NULL) {
         _PyErr_ChainExceptions1(exc);
     }
     if (rc < 0) {


### PR DESCRIPTION
In https://github.com/python/cpython/issues/112301, @mdboom posted a proposal for adding some recommended compiler flags. 

This PR addresses a single class of warnings (-Wmaybe-uninitialized) that may crop up if we were to switch to the "hardened" build command.

Specific build error:
```
./Modules/_io/fileio.c:175:9: warning: ‘exc’ may be used uninitialized [-Wmaybe-uninitialized]
  175 |         _PyErr_ChainExceptions1(exc);
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
./Modules/_io/fileio.c: In function ‘_io_FileIO_close’:
./Modules/_io/fileio.c:160:15: note: ‘exc’ was declared here
  160 |     PyObject *exc;
```

<!-- gh-issue-number: gh-112301 -->
* Issue: gh-112301
<!-- /gh-issue-number -->
