### PR TITLE
gh-59703: restore include of mach-o/dyld.h 

### DIFF
--- a/Modules/getpath.c
+++ b/Modules/getpath.c
@@ -18,6 +18,7 @@
 
 #ifdef __APPLE__
 #  include <dlfcn.h>
+#  include <mach-o/dyld.h>
 #endif
 
 /* Reference the precompiled getpath.py */


### PR DESCRIPTION
On older versions of macOS, `_NSGetExecutablePath` appears to only be available via `macho-o/dyld` so `macho-o/dyld.h` is still needed by `Modules/getpath.c` to allow building for older releases of macOS on newer ones (for example, by using `MACOSX_DEPLOYMENT_TARGET=10.9`).


<!-- gh-issue-number: gh-59703 -->
* Issue: gh-59703
<!-- /gh-issue-number -->
