### PR TITLE
Do not build the macOS installer with mimalloc enabled 

### DIFF
--- a/Mac/BuildScript/build-installer.py
+++ b/Mac/BuildScript/build-installer.py
@@ -1147,7 +1147,9 @@ def buildPython():
     # will find them during its extension import sanity checks.
 
     print("Running configure...")
+    print(" NOTE: --with-mimalloc=no pending resolution of weak linking issues")
     runCommand("%s -C --enable-framework --enable-universalsdk=/ "
+               "--with-mimalloc=no "
                "--with-universal-archs=%s "
                "%s "
                "%s "


### PR DESCRIPTION
Do not build the macOS installer with mimalloc enabled pending resolution of weak linking crashes during interpreter startup on macOS 10.9, 10.10, and 10.11 when built on macOS 11 and later.
