### PR TITLE
gh-59254: mention in open() doc that line buffering is for writing

### DIFF
--- a/Doc/library/functions.rst
+++ b/Doc/library/functions.rst
@@ -1221,7 +1221,7 @@ are always available.  They are listed here in alphabetical order.
 
    *buffering* is an optional integer used to set the buffering policy.  Pass 0
    to switch buffering off (only allowed in binary mode), 1 to select line
-   buffering (only usable in text mode), and an integer > 1 to indicate the size
+   buffering (only usable when writing in text mode), and an integer > 1 to indicate the size
    in bytes of a fixed-size chunk buffer. Note that specifying a buffer size this
    way applies for binary buffered I/O, but ``TextIOWrapper`` (i.e., files opened
    with ``mode='r+'``) would have another buffering. To disable buffering in


### PR DESCRIPTION
Fixes #59254.

<!-- gh-issue-number: gh-59254 -->
* Issue: gh-59254
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--112318.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->