### PR TITLE
gh-111922: Allow Using a Minimal Proxy for TracebackException.exc_type

### DIFF
--- a/Lib/test/test_traceback.py
+++ b/Lib/test/test_traceback.py
@@ -3272,10 +3272,6 @@ class TestTracebackExceptionExcType(unittest.TestCase, ModuleTestBase):
         self._check(tbexc, expected)
         return tbexc
 
-    def check_str(self, exc, qualname, /, **expected):
-        with self.assertRaises(ValueError):
-            self._new(exc, qualname)
-
     def check_none(self, exc):
         expected = {n: None for n in self.ATTRS}
         tbexc = self._new(exc, None)
@@ -3308,10 +3304,6 @@ class TestTracebackExceptionExcType(unittest.TestCase, ModuleTestBase):
             )
             self.check_proxy(exc, proxy, **vars(proxy))
 
-        with self.subTest('str'):
-            exc_type = expected['__qualname__']
-            self.check_str(exc, exc_type, **expected)
-
         with self.subTest('missing'):
             self.check_none(exc)
 
@@ -3343,10 +3335,6 @@ class TestTracebackExceptionExcType(unittest.TestCase, ModuleTestBase):
                 __qualname__='mymod.AnotherError',
             )
             self.check_proxy(exc, proxy, **vars(proxy))
-
-        with self.subTest('str'):
-            exc_type = expected['__qualname__']
-            self.check_str(exc, exc_type, **expected)
 
         with self.subTest('missing'):
             self.check_none(exc)
@@ -3415,10 +3403,6 @@ class TestTracebackExceptionExcType(unittest.TestCase, ModuleTestBase):
             tbexc = self.check_proxy(exc, proxy, **vars(proxy))
             # This cannot match:
             self.assertFalse(hasattr(tbexc, 'msg'))
-
-        with self.subTest('str'):
-            exc_type = expected['__qualname__']
-            self.check_str(exc, exc_type, **expected)
 
         with self.subTest('missing'):
             self.check_none(exc)
@@ -3490,10 +3474,6 @@ class TestTracebackExceptionExcType(unittest.TestCase, ModuleTestBase):
             tbexc = self.check_proxy(exc, proxy, **vars(proxy))
             # This cannot match:
             self.assertNotIn('Did you mean', str(tbexc))
-
-        with self.subTest('str'):
-            exc_type = expected['__qualname__']
-            self.check_str(exc, exc_type, **expected)
 
         with self.subTest('missing'):
             self.check_none(exc)
@@ -3568,10 +3548,6 @@ class TestTracebackExceptionExcType(unittest.TestCase, ModuleTestBase):
             # This cannot match:
             self.assertNotIn('Did you mean', str(tbexc))
 
-        with self.subTest('str'):
-            exc_type = expected['__qualname__']
-            self.check_str(exc, exc_type, **expected)
-
         with self.subTest('missing'):
             self.check_none(exc)
 
@@ -3638,10 +3614,6 @@ class TestTracebackExceptionExcType(unittest.TestCase, ModuleTestBase):
             tbexc = self.check_proxy(exc, proxy, **vars(proxy))
             # This cannot match:
             self.assertNotIn('Did you mean', str(tbexc))
-
-        with self.subTest('str'):
-            exc_type = expected['__qualname__']
-            self.check_str(exc, exc_type, **expected)
 
         with self.subTest('missing'):
             self.check_none(exc)

--- a/Lib/test/test_traceback.py
+++ b/Lib/test/test_traceback.py
@@ -49,6 +49,7 @@ class ModuleTestBase:
 
         if not mod_name:
             mod_name = ''.join(random.choices(string.ascii_letters, k=16))
+            assert mod_name not in sys.modules, repr(mod_name)
         self.addCleanup(lambda: sys.modules.pop(mod_name, None))
 
         module = tmpdir / (mod_name + ".py")
@@ -2731,7 +2732,6 @@ class TestStack(unittest.TestCase):
 class Unrepresentable:
     def __repr__(self) -> str:
         raise Exception("Unrepresentable")
-
 
 class TestTracebackException(unittest.TestCase):
 

--- a/Lib/test/test_traceback.py
+++ b/Lib/test/test_traceback.py
@@ -3403,8 +3403,8 @@ class TestTracebackExceptionExcType(unittest.TestCase, ModuleTestBase):
         with self.subTest('matching proxy'):
             proxy = type(sys.implementation)(**expected)
             tbexc = self.check_proxy(exc, proxy, **expected)
-            # This cannot match:
-            self.assertFalse(hasattr(tbexc, 'msg'))
+            # Verify the special-casing in __init__().
+            self.assertEqual(tbexc.msg, exc.msg)
 
         with self.subTest('mismatching proxy'):
             proxy = type(sys.implementation)(
@@ -3455,8 +3455,8 @@ class TestTracebackExceptionExcType(unittest.TestCase, ModuleTestBase):
             proxy = type(sys.implementation)(**expected)
             self.check_proxy(exc, proxy, **expected)
             tbexc = self.check_proxy(exc, proxy, **expected)
-            # This cannot match:
-            self.assertFalse(hasattr(tbexc, 'msg'))
+            # Verify the special-casing in __init__().
+            self.assertEqual(tbexc.msg, exc_sub.msg)
 
     def test_ImportError(self):
         expected = dict(
@@ -3478,8 +3478,8 @@ class TestTracebackExceptionExcType(unittest.TestCase, ModuleTestBase):
             proxy = type(sys.implementation)(**expected)
             self.check_proxy(exc, proxy, **expected)
             tbexc = self.check_proxy(exc, proxy, **expected)
-            # This cannot match:
-            self.assertNotIn('Did you mean', str(tbexc))
+            # Verify the special-casing in __init__().
+            self.assertIn('Did you mean', str(tbexc))
 
         with self.subTest('mismatching proxy'):
             proxy = type(sys.implementation)(
@@ -3530,8 +3530,8 @@ class TestTracebackExceptionExcType(unittest.TestCase, ModuleTestBase):
             proxy = type(sys.implementation)(**expected)
             self.check_proxy(exc, proxy, **expected)
             tbexc = self.check_proxy(exc, proxy, **expected)
-            # This cannot match:
-            self.assertNotIn('Did you mean', str(tbexc))
+            # Verify the special-casing in __init__().
+            self.assertIn('Did you mean', str(tbexc))
 
     def test_AttributeError(self):
         expected = dict(
@@ -3555,8 +3555,8 @@ class TestTracebackExceptionExcType(unittest.TestCase, ModuleTestBase):
             proxy = type(sys.implementation)(**expected)
             self.check_proxy(exc, proxy, **expected)
             tbexc = self.check_proxy(exc, proxy, **expected)
-            # This cannot match:
-            self.assertNotIn('Did you mean', str(tbexc))
+            # Verify the special-casing in __init__().
+            self.assertIn('Did you mean', str(tbexc))
 
         with self.subTest('mismatching proxy'):
             proxy = type(sys.implementation)(
@@ -3602,8 +3602,8 @@ class TestTracebackExceptionExcType(unittest.TestCase, ModuleTestBase):
             proxy = type(sys.implementation)(**expected)
             self.check_proxy(exc, proxy, **expected)
             tbexc = self.check_proxy(exc, proxy, **expected)
-            # This cannot match:
-            self.assertNotIn('Did you mean', str(tbexc))
+            # Verify the special-casing in __init__().
+            self.assertIn('Did you mean', str(tbexc))
 
     def test_NameError(self):
         expected = dict(
@@ -3626,8 +3626,8 @@ class TestTracebackExceptionExcType(unittest.TestCase, ModuleTestBase):
             proxy = type(sys.implementation)(**expected)
             self.check_proxy(exc, proxy, **expected)
             tbexc = self.check_proxy(exc, proxy, **expected)
-            # This cannot match:
-            self.assertNotIn('Did you mean', str(tbexc))
+            # Verify the special-casing in __init__().
+            self.assertIn('Did you mean', str(tbexc))
 
         with self.subTest('mismatching proxy'):
             proxy = type(sys.implementation)(
@@ -3678,8 +3678,8 @@ class TestTracebackExceptionExcType(unittest.TestCase, ModuleTestBase):
             proxy = type(sys.implementation)(**expected)
             self.check_proxy(exc, proxy, **expected)
             tbexc = self.check_proxy(exc, proxy, **expected)
-            # This cannot match:
-            self.assertNotIn('Did you mean', str(tbexc))
+            # Verify the special-casing in __init__().
+            self.assertIn('Did you mean', str(tbexc))
 
 
 global_for_suggestions = None

--- a/Lib/traceback.py
+++ b/Lib/traceback.py
@@ -713,10 +713,19 @@ def _match_class(exc_type, *expected):
     assert expected
     if exc_type is None:
         return False
-    if not isinstance(exc_type, type):
+    assert all(et.__module__ == 'builtins' for et in expected)
+    if isinstance(exc_type, type):
+        if not issubclass(exc_type, expected):
+            return False
+    elif exc_type.__module__ != 'builtins':
         return False
-    if not issubclass(exc_type, expected):
-        return False
+    else:
+        assert exc_type.__qualname__ == exc_type.__name__
+        for _expected in expected:
+            if exc_type.__name__ == _expected.__name__:
+                break
+        else:
+            return False
     return True
 
 

--- a/Lib/traceback.py
+++ b/Lib/traceback.py
@@ -709,10 +709,12 @@ def _resolve_exc_type(exc_type):
         raise ValueError(f'unsupported exc_type {exc_type!r}')
 
 
-def _match_class(exc_type, *expected):
+def _match_class(exc_type, expected):
     assert expected
     if exc_type is None:
         return False
+    if isinstance(expected, type):
+        expected = (expected,)
     assert all(et.__module__ == 'builtins' for et in expected)
     if isinstance(exc_type, type):
         if not issubclass(exc_type, expected):
@@ -811,7 +813,7 @@ class TracebackException:
             suggestion = _compute_suggestion_error(exc_value, exc_traceback, wrong_name)
             if suggestion:
                 self._str += f". Did you mean: '{suggestion}'?"
-        elif _match_class(exc_type, NameError, AttributeError) and \
+        elif _match_class(exc_type, (NameError, AttributeError)) and \
                 getattr(exc_value, "name", None) is not None:
             wrong_name = getattr(exc_value, "name", None)
             suggestion = _compute_suggestion_error(exc_value, exc_traceback, wrong_name)

--- a/Misc/NEWS.d/next/Library/2023-11-22-14-47-28.gh-issue-111922.qc94fY.rst
+++ b/Misc/NEWS.d/next/Library/2023-11-22-14-47-28.gh-issue-111922.qc94fY.rst
@@ -1,0 +1,2 @@
+Allow ``TracebackException.exc_type`` to be a minimal proxy instead of only
+an actual exception type.


### PR DESCRIPTION
Passing a proxy for exc_type is helpful when the `TracebackException` is going to be serialized (e.g. pickle) and you don't want to serialize user-defined types.

(That's the concrete motivation for me.  For the `_xxsubinterpreters` module I'm propagating exceptions via a pickled `TracebackException` and don't want to deal with unpickling a user-defined exception class in a different interpreter.)

Note that most of this PR is tests, including a bunch of coverage of existing behavior.

<!-- gh-issue-number: gh-111922 -->
* Issue: gh-111922
<!-- /gh-issue-number -->
