### PR TITLE
Add extra tests for `random.binomialvariate`

### DIFF
--- a/Lib/random.py
+++ b/Lib/random.py
@@ -801,8 +801,6 @@ class Random(_random.Random):
 
         """
         # Error check inputs and handle edge cases
-        if not isinstance(n, int):
-            raise TypeError("n must be an integer")
         if n < 0:
             raise ValueError("n must be non-negative")
         if p <= 0.0 or p >= 1.0:
@@ -815,8 +813,6 @@ class Random(_random.Random):
         random = self.random
 
         # Fast path for a common case
-        if n == 0:
-            return 0
         if n == 1:
             return _index(random() < p)
 
@@ -829,7 +825,7 @@ class Random(_random.Random):
             # https://dl.acm.org/doi/pdf/10.1145/42372.42381
             x = y = 0
             c = _log2(1.0 - p)
-            if c == 0:
+            if not c:
                 return x
             while True:
                 y += _floor(_log2(random()) / c) + 1

--- a/Lib/random.py
+++ b/Lib/random.py
@@ -801,6 +801,8 @@ class Random(_random.Random):
 
         """
         # Error check inputs and handle edge cases
+        if not isinstance(n, int):
+            raise TypeError("n must be an integer")
         if n < 0:
             raise ValueError("n must be non-negative")
         if p <= 0.0 or p >= 1.0:
@@ -813,6 +815,8 @@ class Random(_random.Random):
         random = self.random
 
         # Fast path for a common case
+        if n == 0:
+            return 0
         if n == 1:
             return _index(random() < p)
 
@@ -825,7 +829,7 @@ class Random(_random.Random):
             # https://dl.acm.org/doi/pdf/10.1145/42372.42381
             x = y = 0
             c = _log2(1.0 - p)
-            if not c:
+            if c == 0:
                 return x
             while True:
                 y += _floor(_log2(random()) / c) + 1

--- a/Lib/test/test_random.py
+++ b/Lib/test/test_random.py
@@ -1077,16 +1077,22 @@ class TestDistributions(unittest.TestCase):
         # Cover all the code paths
         with self.assertRaises(ValueError):
             B(n=-1)                            # Negative n
+        with self.assertRaises(TypeError):
+            B(n=0.5)                           # float n
         with self.assertRaises(ValueError):
             B(n=1, p=-0.5)                     # Negative p
         with self.assertRaises(ValueError):
             B(n=1, p=1.5)                      # p > 1.0
+        self.assertEqual(B(0, 0.5), 0)         # n == 0
         self.assertEqual(B(10, 0.0), 0)        # p == 0.0
         self.assertEqual(B(10, 1.0), 10)       # p == 1.0
         self.assertTrue(B(1, 0.3) in {0, 1})   # n == 1 fast path
         self.assertTrue(B(1, 0.9) in {0, 1})   # n == 1 fast path
         self.assertTrue(B(1, 0.0) in {0})      # n == 1 fast path
         self.assertTrue(B(1, 1.0) in {1})      # n == 1 fast path
+
+        # BG method very small p
+        self.assertEqual(B(5, 1e-8), 0)
 
         # BG method p <= 0.5 and n*p=1.25
         self.assertTrue(B(5, 0.25) in set(range(6)))

--- a/Lib/test/test_random.py
+++ b/Lib/test/test_random.py
@@ -1090,7 +1090,7 @@ class TestDistributions(unittest.TestCase):
         self.assertTrue(B(1, 1.0) in {1})      # n == 1 fast path
 
         # BG method very small p
-        self.assertEqual(B(5, 1e-8), 0)
+        self.assertEqual(B(5, 1e-18), 0)
 
         # BG method p <= 0.5 and n*p=1.25
         self.assertTrue(B(5, 0.25) in set(range(6)))

--- a/Lib/test/test_random.py
+++ b/Lib/test/test_random.py
@@ -1077,8 +1077,6 @@ class TestDistributions(unittest.TestCase):
         # Cover all the code paths
         with self.assertRaises(ValueError):
             B(n=-1)                            # Negative n
-        with self.assertRaises(TypeError):
-            B(n=0.5)                           # float n
         with self.assertRaises(ValueError):
             B(n=1, p=-0.5)                     # Negative p
         with self.assertRaises(ValueError):

--- a/Misc/NEWS.d/next/Library/2023-11-22-23-08-47.gh-issue-81620.mfZ2Wf.rst
+++ b/Misc/NEWS.d/next/Library/2023-11-22-23-08-47.gh-issue-81620.mfZ2Wf.rst
@@ -1,0 +1,1 @@
+Ensure *n* is integer in :func:`random.binomialvariate`

--- a/Misc/NEWS.d/next/Library/2023-11-22-23-08-47.gh-issue-81620.mfZ2Wf.rst
+++ b/Misc/NEWS.d/next/Library/2023-11-22-23-08-47.gh-issue-81620.mfZ2Wf.rst
@@ -1,1 +1,1 @@
-Ensure *n* is integer in :func:`random.binomialvariate`
+Add extra tests for :func:`random.binomialvariate`


### PR DESCRIPTION
Currently `random.binomialvariate` does not check the type of `n` while the docs clearly states it should be an integer (and mathmatically it should be an integer). This could cause things like `random.binomialvariate(3.5, 1) == 3.5`. In this PR, a check for the type of `n` is added.

I also added the check for `n == 0`. This introduces an extra if check on the common path. `n == 0` works without this check, it just requires some extra calculation. I can take it out if we want to make the common path slightly faster.

`if not c` is changed to `if c == 0`, which I believe is much better when checking a number against `0`.

A couple of test cases are added as well, notably `self.assertEqual(B(5, 1e-8), 0)`, which will trigger the uncovered path in BG method under `if c == 0`.

<!-- gh-issue-number: gh-81620 -->
* Issue: gh-81620
<!-- /gh-issue-number -->
