### PR TITLE
[3.12] gh-109052: Use the base opcode when comparing code objects (gh…

### DIFF
--- a/Lib/test/test_code.py
+++ b/Lib/test/test_code.py
@@ -498,6 +498,25 @@ class CodeTest(unittest.TestCase):
         self.assertNotEqual(c, c1)
         self.assertNotEqual(hash(c), hash(c1))
 
+    @cpython_only
+    def test_code_equal_with_instrumentation(self):
+        """ GH-109052
+
+        Make sure the instrumentation doesn't affect the code equality
+        The validity of this test relies on the fact that "x is x" and
+        "x in x" have only one different instruction and the instructions
+        have the same argument.
+
+        """
+        code1 = compile("x is x", "example.py", "eval")
+        code2 = compile("x in x", "example.py", "eval")
+        sys._getframe().f_trace_opcodes = True
+        sys.settrace(lambda *args: None)
+        exec(code1, {'x': []})
+        exec(code2, {'x': []})
+        self.assertNotEqual(code1, code2)
+        sys.settrace(None)
+
 
 def isinterned(s):
     return s is sys.intern(('_' + s + '_')[1:-1])

--- a/Misc/NEWS.d/next/Core and Builtins/2023-09-07-18-49-01.gh-issue-109052.TBU4nC.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2023-09-07-18-49-01.gh-issue-109052.TBU4nC.rst
@@ -1,0 +1,1 @@
+Use the base opcode when comparing code objects to avoid interference from instrumentation

--- a/Objects/codeobject.c
+++ b/Objects/codeobject.c
@@ -1800,8 +1800,8 @@ code_richcompare(PyObject *self, PyObject *other, int op)
     for (int i = 0; i < Py_SIZE(co); i++) {
         _Py_CODEUNIT co_instr = _PyCode_CODE(co)[i];
         _Py_CODEUNIT cp_instr = _PyCode_CODE(cp)[i];
-        co_instr.op.code = _PyOpcode_Deopt[co_instr.op.code];
-        cp_instr.op.code = _PyOpcode_Deopt[cp_instr.op.code];
+        co_instr.op.code = _Py_GetBaseOpcode(co, i);
+        cp_instr.op.code = _Py_GetBaseOpcode(cp, i);
         eq = co_instr.cache == cp_instr.cache;
         if (!eq) {
             goto unequal;


### PR DESCRIPTION
…-109107)

(cherry picked from commit 057bc7249073066ed8087b548ee06f0eabfa9e7c)


<!-- gh-issue-number: gh-109052 -->
* Issue: gh-109052
<!-- /gh-issue-number -->
