### PR TITLE
gh-112332: Deprecate TracebackException.exc_type, add exc_type_str.

### DIFF
--- a/Doc/library/traceback.rst
+++ b/Doc/library/traceback.rst
@@ -287,6 +287,14 @@ capture data for later printing in a lightweight fashion.
 
       The class of the original traceback.
 
+      .. deprecated:: 3.13
+
+   .. attribute:: exc_type_str
+
+      String display of the class of the original exception.
+
+      .. versionadded:: 3.13
+
    .. attribute:: filename
 
       For syntax errors - the file name where the error occurred.

--- a/Doc/whatsnew/3.13.rst
+++ b/Doc/whatsnew/3.13.rst
@@ -308,6 +308,12 @@ traceback
   to format the nested exceptions of a :exc:`BaseExceptionGroup` instance, recursively.
   (Contributed by Irit Katriel in :gh:`105292`.)
 
+* Add the field *exc_type_str* to :class:`~traceback.TracebackException`, which
+  holds a string display of the *exc_type*. Deprecate the field *exc_type*
+  which holds the type object itself. Add parameter *save_exc_type* (default
+  ``True``) to indicate whether ``exc_type`` should be saved.
+  (Contributed by Irit Katriel in :gh:`112332`.)
+
 typing
 ------
 
@@ -366,6 +372,11 @@ Deprecated
   outdated, unmaintained, and rarely used.  It has a high potential for both
   security and functionality bugs.  This includes removal of the ``--cgi``
   flag to the ``python -m http.server`` command line in 3.15.
+
+* :mod:`traceback`:
+
+  * The field *exc_type* of :class:`traceback.TracebackException` is
+    deprecated. Use *exc_type_str* instead.
 
 * :mod:`typing`:
 

--- a/Lib/test/test_traceback.py
+++ b/Lib/test/test_traceback.py
@@ -2715,9 +2715,9 @@ class Unrepresentable:
 
 class TestTracebackException(unittest.TestCase):
 
-    def test_smoke(self):
+    def do_test_smoke(self, exc, expected_type_str):
         try:
-            1/0
+            raise exc
         except Exception as e:
             exc_obj = e
             exc = traceback.TracebackException.from_exception(e)
@@ -2727,8 +2727,22 @@ class TestTracebackException(unittest.TestCase):
         self.assertEqual(None, exc.__context__)
         self.assertEqual(False, exc.__suppress_context__)
         self.assertEqual(expected_stack, exc.stack)
-        self.assertEqual(type(exc_obj), exc.exc_type)
+        with self.assertWarns(DeprecationWarning):
+            self.assertEqual(type(exc_obj), exc.exc_type)
+        self.assertEqual(expected_type_str, exc.exc_type_str)
         self.assertEqual(str(exc_obj), str(exc))
+
+    def test_smoke_builtin(self):
+        self.do_test_smoke(ValueError(42), 'ValueError')
+
+    def test_smoke_user_exception(self):
+        class MyException(Exception):
+            pass
+
+        self.do_test_smoke(
+            MyException('bad things happened'),
+            ('test.test_traceback.TestTracebackException.'
+             'test_smoke_user_exception.<locals>.MyException'))
 
     def test_from_exception(self):
         # Check all the parameters are accepted.
@@ -2750,7 +2764,9 @@ class TestTracebackException(unittest.TestCase):
         self.assertEqual(None, exc.__context__)
         self.assertEqual(False, exc.__suppress_context__)
         self.assertEqual(expected_stack, exc.stack)
-        self.assertEqual(type(exc_obj), exc.exc_type)
+        with self.assertWarns(DeprecationWarning):
+            self.assertEqual(type(exc_obj), exc.exc_type)
+        self.assertEqual(type(exc_obj).__name__, exc.exc_type_str)
         self.assertEqual(str(exc_obj), str(exc))
 
     def test_cause(self):
@@ -2772,7 +2788,9 @@ class TestTracebackException(unittest.TestCase):
         self.assertEqual(exc_context, exc.__context__)
         self.assertEqual(True, exc.__suppress_context__)
         self.assertEqual(expected_stack, exc.stack)
-        self.assertEqual(type(exc_obj), exc.exc_type)
+        with self.assertWarns(DeprecationWarning):
+            self.assertEqual(type(exc_obj), exc.exc_type)
+        self.assertEqual(type(exc_obj).__name__, exc.exc_type_str)
         self.assertEqual(str(exc_obj), str(exc))
 
     def test_context(self):
@@ -2792,7 +2810,9 @@ class TestTracebackException(unittest.TestCase):
         self.assertEqual(exc_context, exc.__context__)
         self.assertEqual(False, exc.__suppress_context__)
         self.assertEqual(expected_stack, exc.stack)
-        self.assertEqual(type(exc_obj), exc.exc_type)
+        with self.assertWarns(DeprecationWarning):
+            self.assertEqual(type(exc_obj), exc.exc_type)
+        self.assertEqual(type(exc_obj).__name__, exc.exc_type_str)
         self.assertEqual(str(exc_obj), str(exc))
 
     def test_long_context_chain(self):
@@ -2837,7 +2857,9 @@ class TestTracebackException(unittest.TestCase):
         self.assertEqual(None, exc.__context__)
         self.assertEqual(True, exc.__suppress_context__)
         self.assertEqual(expected_stack, exc.stack)
-        self.assertEqual(type(exc_obj), exc.exc_type)
+        with self.assertWarns(DeprecationWarning):
+            self.assertEqual(type(exc_obj), exc.exc_type)
+        self.assertEqual(type(exc_obj).__name__, exc.exc_type_str)
         self.assertEqual(str(exc_obj), str(exc))
 
     def test_compact_no_cause(self):
@@ -2857,7 +2879,9 @@ class TestTracebackException(unittest.TestCase):
         self.assertEqual(exc_context, exc.__context__)
         self.assertEqual(False, exc.__suppress_context__)
         self.assertEqual(expected_stack, exc.stack)
-        self.assertEqual(type(exc_obj), exc.exc_type)
+        with self.assertWarns(DeprecationWarning):
+            self.assertEqual(type(exc_obj), exc.exc_type)
+        self.assertEqual(type(exc_obj).__name__, exc.exc_type_str)
         self.assertEqual(str(exc_obj), str(exc))
 
     def test_no_refs_to_exception_and_traceback_objects(self):

--- a/Lib/test/test_traceback.py
+++ b/Lib/test/test_traceback.py
@@ -2884,6 +2884,17 @@ class TestTracebackException(unittest.TestCase):
         self.assertEqual(type(exc_obj).__name__, exc.exc_type_str)
         self.assertEqual(str(exc_obj), str(exc))
 
+    def test_no_save_exc_type(self):
+        try:
+            1/0
+        except Exception as e:
+            exc = e
+
+        te = traceback.TracebackException.from_exception(
+                 exc, save_exc_type=False)
+        with self.assertWarns(DeprecationWarning):
+            self.assertIsNone(te.exc_type)
+
     def test_no_refs_to_exception_and_traceback_objects(self):
         try:
             1/0

--- a/Misc/NEWS.d/next/Library/2023-11-23-10-41-21.gh-issue-112332.rhTBaa.rst
+++ b/Misc/NEWS.d/next/Library/2023-11-23-10-41-21.gh-issue-112332.rhTBaa.rst
@@ -1,0 +1,2 @@
+Deprecate the ``exc_type`` field of :class:`traceback.TracebackException`.
+Add ``exc_type_str`` to replace it.


### PR DESCRIPTION
Fixes #112332.

<!-- gh-issue-number: gh-112332 -->
* Issue: gh-112332
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--112333.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->