### PR TITLE
Correct documentation for AF_PACKET

### DIFF
--- a/Doc/library/socket.rst
+++ b/Doc/library/socket.rst
@@ -185,7 +185,7 @@ created.  Socket addresses are represented as follows:
   .. versionadded:: 3.7
 
 - :const:`AF_PACKET` is a low-level interface directly to network devices.
-  The packets are represented by the tuple
+  The addresses are represented by the tuple
   ``(ifname, proto[, pkttype[, hatype[, addr]]])`` where:
 
   - *ifname* - String specifying the device name.
@@ -193,7 +193,6 @@ created.  Socket addresses are represented as follows:
     May be :data:`ETH_P_ALL` to capture all protocols,
     one of the :ref:`ETHERTYPE_* constants <socket-ethernet-types>`
     or any other Ethernet protocol number.
-    Value must be in network-byte-order.
   - *pkttype* - Optional integer specifying the packet type:
 
     - ``PACKET_HOST`` (the default) - Packet addressed to the local host.


### PR DESCRIPTION
Protocol in the address tuple should *not* be in the network-byte-order, because it is converted internally[1].

[1] https://github.com/python/cpython/blob/89ddea4886942b0c27a778a0ad3f0d5ac5f518f0/Modules/socketmodule.c#L2144


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--112339.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->