### PR TITLE
gh-112345: Let failed protocol subclasscheck show non-method members

### DIFF
--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -4099,14 +4099,14 @@ class ProtocolTests(BaseTestCase):
             def square_norm(self) -> float:
                 return self.x ** 2 + self.y ** 2
 
+        self.assertEqual(Vec2D.__protocol_attrs__, {'x', 'y', 'square_norm'})
         expected_error_message = (
             "Protocols with non-method members don't support issubclass()."
-            " Non-method members: {'x', 'y'}."
+            " Non-method members: ['x', 'y']."
         )
         with self.assertRaisesRegex(TypeError, re.escape(expected_error_message)):
             issubclass(int, Vec2D)
 
-        self.assertEqual(Vec2D.__protocol_attrs__, {'x', 'y', 'square_norm'})
 
 class GenericTests(BaseTestCase):
 

--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -4099,7 +4099,7 @@ class ProtocolTests(BaseTestCase):
             def square_norm(self) -> float:
                 return self.x ** 2 + self.y ** 2
 
-        assert Vec2D.__protocol_attrs__ == {'x', 'y', 'square_norm'}
+        self.assertEqual(Vec2D.__protocol_attrs__, {'x', 'y', 'square_norm'})
         expected_error_message = (
             "Protocols with non-method members don't support issubclass()."
             " Non-method members: {'x', 'y'}."

--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -4091,6 +4091,25 @@ class ProtocolTests(BaseTestCase):
         self.assertIsInstance(Foo(), ProtocolWithMixedMembers)
         self.assertNotIsInstance(42, ProtocolWithMixedMembers)
 
+    def test_protocol_issubclass_error_message(self):
+        class Vec2D(Protocol):
+            x: float
+            y: float
+
+            def square_norm(self) -> float:
+                return self.x ** 2 + self.y ** 2
+
+        assert Vec2D.__protocol_attrs__ == {'x', 'y', 'square_norm'}
+        expected_error_message = (
+            "Protocols with non-method members don't support issubclass()."
+            " Non-method members: {'x', 'y'}."
+        )
+
+        try:
+            issubclass(int, Vec2D)
+        except TypeError as exc:
+            self.assertEqual(str(exc), expected_error_message)
+
 
 class GenericTests(BaseTestCase):
 

--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -4102,7 +4102,7 @@ class ProtocolTests(BaseTestCase):
         self.assertEqual(Vec2D.__protocol_attrs__, {'x', 'y', 'square_norm'})
         expected_error_message = (
             "Protocols with non-method members don't support issubclass()."
-            " Non-method members: ['x', 'y']."
+            " Non-method members: 'x', 'y'."
         )
         with self.assertRaisesRegex(TypeError, re.escape(expected_error_message)):
             issubclass(int, Vec2D)

--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -4103,7 +4103,9 @@ class ProtocolTests(BaseTestCase):
             "Protocols with non-method members don't support issubclass()."
             " Non-method members: {'x', 'y'}."
         )
-        self.assertRaisesRegex(TypeError, f'^{re.escape(expected_error_message)}$')
+        with self.assertRaisesRegex(TypeError, re.escape(expected_error_message)):
+            issubclass(int, Vec2D)
+
         self.assertEqual(Vec2D.__protocol_attrs__, {'x', 'y', 'square_norm'})
 
 class GenericTests(BaseTestCase):

--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -4099,17 +4099,12 @@ class ProtocolTests(BaseTestCase):
             def square_norm(self) -> float:
                 return self.x ** 2 + self.y ** 2
 
-        self.assertEqual(Vec2D.__protocol_attrs__, {'x', 'y', 'square_norm'})
         expected_error_message = (
             "Protocols with non-method members don't support issubclass()."
             " Non-method members: {'x', 'y'}."
         )
-
-        try:
-            issubclass(int, Vec2D)
-        except TypeError as exc:
-            self.assertEqual(str(exc), expected_error_message)
-
+        self.assertRaisesRegex(TypeError, f'^{re.escape(expected_error_message)}$')
+        self.assertEqual(Vec2D.__protocol_attrs__, {'x', 'y', 'square_norm'})
 
 class GenericTests(BaseTestCase):
 

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -1828,8 +1828,13 @@ class _ProtocolMeta(ABCMeta):
                 not cls.__callable_proto_members_only__
                 and cls.__dict__.get("__subclasshook__") is _proto_hook
             ):
+                non_method_attrs = {
+                    attr for attr in cls.__protocol_attrs__
+                    if not callable(getattr(cls, attr, None))
+                }
                 raise TypeError(
-                    "Protocols with non-method members don't support issubclass()"
+                    "Protocols with non-method members don't support issubclass()."
+                    f" Non-method members: {non_method_attrs}."
                 )
             if not getattr(cls, '_is_runtime_protocol', False):
                 raise TypeError(

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -1834,7 +1834,7 @@ class _ProtocolMeta(ABCMeta):
                 )
                 raise TypeError(
                     "Protocols with non-method members don't support issubclass()."
-                    f" Non-method members: {non_method_attrs}."
+                    f" Non-method members: {str(non_method_attrs)[1:-1]}."
                 )
             if not getattr(cls, '_is_runtime_protocol', False):
                 raise TypeError(

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -1828,10 +1828,10 @@ class _ProtocolMeta(ABCMeta):
                 not cls.__callable_proto_members_only__
                 and cls.__dict__.get("__subclasshook__") is _proto_hook
             ):
-                non_method_attrs = {
+                non_method_attrs = sorted(
                     attr for attr in cls.__protocol_attrs__
                     if not callable(getattr(cls, attr, None))
-                }
+                )
                 raise TypeError(
                     "Protocols with non-method members don't support issubclass()."
                     f" Non-method members: {non_method_attrs}."

--- a/Misc/NEWS.d/next/Library/2023-11-23-17-25-27.gh-issue-112345.FFApHx.rst
+++ b/Misc/NEWS.d/next/Library/2023-11-23-17-25-27.gh-issue-112345.FFApHx.rst
@@ -1,0 +1,2 @@
+Improve error message when trying to call :func:`issubclass` against a :class:`typing.Protocol` that has non-method members.
+Patch by Randolf Scholz.

--- a/Misc/NEWS.d/next/Library/2023-11-23-17-25-27.gh-issue-112345.FFApHx.rst
+++ b/Misc/NEWS.d/next/Library/2023-11-23-17-25-27.gh-issue-112345.FFApHx.rst
@@ -1,2 +1,3 @@
-Improve error message when trying to call :func:`issubclass` against a :class:`typing.Protocol` that has non-method members.
+Improve error message when trying to call :func:`issubclass` against a
+:class:`typing.Protocol` that has non-method members.
 Patch by Randolf Scholz.

--- a/Misc/NEWS.d/next/Library/2023-11-23-18-37-04.gh-issue-112345.YJUAaE.rst
+++ b/Misc/NEWS.d/next/Library/2023-11-23-18-37-04.gh-issue-112345.YJUAaE.rst
@@ -1,0 +1,3 @@
+Improve error message when trying to call :func:`issubclass` against a
+:class:`typing.Protocol` that has non-method members.
+Patch by Randolf Scholz.

--- a/Misc/NEWS.d/next/Library/2023-11-23-18-37-04.gh-issue-112345.YJUAaE.rst
+++ b/Misc/NEWS.d/next/Library/2023-11-23-18-37-04.gh-issue-112345.YJUAaE.rst
@@ -1,3 +1,0 @@
-Improve error message when trying to call :func:`issubclass` against a
-:class:`typing.Protocol` that has non-method members.
-Patch by Randolf Scholz.


### PR DESCRIPTION
See https://github.com/python/cpython/pull/112340#discussion_r1403566211

Closes #112345

<!-- gh-issue-number: gh-112345 -->
* Issue: gh-112345
<!-- /gh-issue-number -->
