### PR TITLE
Remove bogus annotations from the descriptor howto guide

### DIFF
--- a/Doc/howto/descriptor.rst
+++ b/Doc/howto/descriptor.rst
@@ -521,11 +521,11 @@ everyday Python programs.
 Descriptor protocol
 -------------------
 
-``descr.__get__(self, obj, type=None) -> value``
+``descr.__get__(self, obj, type=None)``
 
-``descr.__set__(self, obj, value) -> None``
+``descr.__set__(self, obj, value)``
 
-``descr.__delete__(self, obj) -> None``
+``descr.__delete__(self, obj)``
 
 That is all there is to it.  Define any of these methods and an object is
 considered a descriptor and can override default behavior upon being looked up


### PR DESCRIPTION
These are distracting and add no value. We don't even use them in the main docs.  Knowing type annotations is not a prerequisite for reading this guide.   These lines aren't `def` statements so the the `->` notation makes no sense and is out of context. Also `-> value` isn't even a valid type.  It is just noise.

<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--112349.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->