### PR TITLE
gh-114673: Docs: Fix os.startfile argument filepath

### DIFF
--- a/Doc/library/os.rst
+++ b/Doc/library/os.rst
@@ -4788,7 +4788,7 @@ written in Python, such as a mail server's external command delivery program.
    .. availability:: Windows.
 
 
-.. function:: startfile(path, [operation], [arguments], [cwd], [show_cmd])
+.. function:: startfile(filepath, [operation], [arguments], [cwd], [show_cmd])
 
    Start a file with its associated application.
 
@@ -4807,7 +4807,7 @@ written in Python, such as a mail server's external command delivery program.
    document.
 
    The default working directory is inherited, but may be overridden by the *cwd*
-   argument. This should be an absolute path. A relative *path* will be resolved
+   argument. This should be an absolute path. A relative *filepath* will be resolved
    against this argument.
 
    Use *show_cmd* to override the default window style. Whether this has any
@@ -4816,7 +4816,7 @@ written in Python, such as a mail server's external command delivery program.
 
    :func:`startfile` returns as soon as the associated application is launched.
    There is no option to wait for the application to close, and no way to retrieve
-   the application's exit status.  The *path* parameter is relative to the current
+   the application's exit status.  The *filepath* parameter is relative to the current
    directory or *cwd*.  If you want to use an absolute path, make sure the first
    character is not a slash (``'/'``)  Use :mod:`pathlib` or the
    :func:`os.path.normpath` function to ensure that paths are properly encoded for
@@ -4826,9 +4826,9 @@ written in Python, such as a mail server's external command delivery program.
    function is not resolved until this function is first called.  If the function
    cannot be resolved, :exc:`NotImplementedError` will be raised.
 
-   .. audit-event:: os.startfile path,operation os.startfile
+   .. audit-event:: os.startfile filepath,operation os.startfile
 
-   .. audit-event:: os.startfile/2 path,operation,arguments,cwd,show_cmd os.startfile
+   .. audit-event:: os.startfile/2 filepath,operation,arguments,cwd,show_cmd os.startfile
 
    .. availability:: Windows.
 


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

Since this is a simple documentation fix, I directly filed it as PR instead of creating an issue first.

During my investigation on issues with `os.startfile`'s annotations in typeshed, I discovered that the first argument name differs between documentation and implementation. ( See https://github.com/python/typeshed/issues/10991 )

While the official docs list the argument name as `path` ([docs](https://docs.python.org/3/library/os.html#os.startfile)), the CPython source code has the first argument as `filepath` ([CPython/main](https://github.com/python/cpython/blob/f55cb44359821e71c29903f2152b4658509dac0d/Modules/clinic/posixmodule.c.h#L9784)), and firing up a REPL to check actual behavior mirrors the same:

```
>>> from os import startfile
>>> startfile(path='explorer')
Traceback (most recent call last):
  File "<pyshell#1>", line 1, in <module>
    startfile(path='explorer')
TypeError: startfile() missing required argument 'filepath' (pos 1)
```

This PR aims to align the docs with the implementation by renaming the `path` argument to `filepath`.

<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--112359.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->

<!-- gh-issue-number: gh-114673 -->
* Issue: gh-114673
<!-- /gh-issue-number -->
