### PR TITLE
Docs: Add note to ¨Configure Python" section about sysconfig module

### DIFF
--- a/Doc/using/configure.rst
+++ b/Doc/using/configure.rst
@@ -12,6 +12,8 @@ List all ``./configure`` script options using::
     ./configure --help
 
 See also the :file:`Misc/SpecialBuilds.txt` in the Python source distribution.
+After compilation, the :mod:`sysconfig` module can be used to programmatically check
+the configure options used to compile the Python interpreter.
 
 General Options
 ---------------


### PR DESCRIPTION
There is no information about how to retrieve compile-time configuration options of the interpreter on the "Configure Python" documentation page, so this MR adds a sentence about the sysconfig module.

(I assume this is a trivial change, so no Github issue is required first)


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--112360.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->