### PR TITLE
gh-112369: Improve list_resize() function

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2023-11-24-13-53-21.gh-issue-112369.2fYGcK.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2023-11-24-13-53-21.gh-issue-112369.2fYGcK.rst
@@ -1,0 +1,1 @@
+- Removed unnecessary conditional branching from list_resize() function

--- a/Objects/listobject.c
+++ b/Objects/listobject.c
@@ -85,9 +85,6 @@ list_resize(PyListObject *self, Py_ssize_t newsize)
     }
     else {
         // integer overflow
-        items = NULL;
-    }
-    if (items == NULL) {
         PyErr_NoMemory();
         return -1;
     }


### PR DESCRIPTION
* removed the unnecessary NULL allocation for variable "items"
* immediately called PyErr_NoMemory() and then return -1.

There will be improvements as much as the NULL allocation in row 88 and the comparative operation in row 90 disappeared, but the effect is unlikely to be significant.

As a person aiming for a more concise code, I think it is right to improve it like this.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-112369 -->
* Issue: gh-112369
<!-- /gh-issue-number -->
