### PR TITLE
gh-112331: Fix reference manual description of attribute lookup mechanics

### DIFF
--- a/Doc/reference/expressions.rst
+++ b/Doc/reference/expressions.rst
@@ -827,13 +827,13 @@ attribute whose name is the identifier. The type and value produced is
 determined by the object.  Multiple evaluations of the same attribute
 reference may yield different objects.
 
-This production can be customized by overriding the :meth:`__getattribute__`
-method or the :meth:`__getattr__` method.  The :meth:`__getattribute__`
-is called first and either returns a value or raises :exc:`AttributeError`
-if the attribute is not available.
+This production can be customized by overriding the
+:meth:`~object.__getattribute__` method or the :meth:`__getattr__` method.
+The :meth:`__getattribute__` method is called first and either returns a value
+or raises :exc:`AttributeError` if the attribute is not available.
 
-If an :exc:`AttributeError` raised and the object has a :meth:`__getattr__`
-method, that method is called as a fallback.
+If an :exc:`AttributeError` raised and the object has a
+:meth:`~object.__getattr__` method, that method is called as a fallback.
 
 .. _subscriptions:
 

--- a/Doc/reference/expressions.rst
+++ b/Doc/reference/expressions.rst
@@ -823,12 +823,17 @@ An attribute reference is a primary followed by a period and a name:
 
 The primary must evaluate to an object of a type that supports attribute
 references, which most objects do.  This object is then asked to produce the
-attribute whose name is the identifier.  This production can be customized by
-overriding the :meth:`__getattr__` method.  If this attribute is not available,
-the exception :exc:`AttributeError` is raised.  Otherwise, the type and value of
-the object produced is determined by the object.  Multiple evaluations of the
-same attribute reference may yield different objects.
+attribute whose name is the identifier. The type and value produced is
+determined by the object.  Multiple evaluations of the same attribute
+reference may yield different objects.
 
+This production can be customized by overriding the :meth:`__getattribute__`
+method or the :meth:`__getattr__` method.  The :meth:`__getattribute__`
+is called first and either returns a value or raises :exc:`AttributeError`
+if the attribute is not available.
+
+If an :exc:`AttributeError` raised and the object has a :meth:`__getattr__`
+method, that method is called as a fallback.
 
 .. _subscriptions:
 

--- a/Doc/reference/expressions.rst
+++ b/Doc/reference/expressions.rst
@@ -829,7 +829,7 @@ reference may yield different objects.
 
 This production can be customized by overriding the
 :meth:`~object.__getattribute__` method or the :meth:`~object.__getattr__`
-method.  The :meth:`__getattribute__` method is called first and either
+method.  The :meth:`!__getattribute__` method is called first and either
 returns a value or raises :exc:`AttributeError` if the attribute is not
 available.
 

--- a/Doc/reference/expressions.rst
+++ b/Doc/reference/expressions.rst
@@ -833,7 +833,7 @@ method.  The :meth:`__getattribute__` method is called first and either
 returns a value or raises :exc:`AttributeError` if the attribute is not
 available.
 
-If an :exc:`AttributeError` raised and the object has a :meth:`__getattr__`
+If an :exc:`AttributeError` is raised and the object has a :meth:`__getattr__`
 method, that method is called as a fallback.
 
 .. _subscriptions:

--- a/Doc/reference/expressions.rst
+++ b/Doc/reference/expressions.rst
@@ -833,7 +833,7 @@ method.  The :meth:`__getattribute__` method is called first and either
 returns a value or raises :exc:`AttributeError` if the attribute is not
 available.
 
-If an :exc:`AttributeError` is raised and the object has a :meth:`__getattr__`
+If an :exc:`AttributeError` is raised and the object has a :meth:`!__getattr__`
 method, that method is called as a fallback.
 
 .. _subscriptions:

--- a/Doc/reference/expressions.rst
+++ b/Doc/reference/expressions.rst
@@ -828,12 +828,13 @@ determined by the object.  Multiple evaluations of the same attribute
 reference may yield different objects.
 
 This production can be customized by overriding the
-:meth:`~object.__getattribute__` method or the :meth:`__getattr__` method.
-The :meth:`__getattribute__` method is called first and either returns a value
-or raises :exc:`AttributeError` if the attribute is not available.
+:meth:`~object.__getattribute__` method or the :meth:`~object.__getattr__`
+method.  The :meth:`__getattribute__` method is called first and either
+returns a value or raises :exc:`AttributeError` if the attribute is not
+available.
 
-If an :exc:`AttributeError` raised and the object has a
-:meth:`~object.__getattr__` method, that method is called as a fallback.
+If an :exc:`AttributeError` raised and the object has a :meth:`__getattr__`
+method, that method is called as a fallback.
 
 .. _subscriptions:
 


### PR DESCRIPTION
Make the lookup mechanics description match the logic found in `slot_tp_getattr_hook` in `Objects/typeobject.c'.

Notably, mention of `__getattribute__` was missing.


<!-- gh-issue-number: gh-112331 -->
* Issue: gh-112331
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--112375.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->