### PR TITLE
gh-101100: Define `test.regrtest` module to fix references

### DIFF
--- a/Doc/library/test.rst
+++ b/Doc/library/test.rst
@@ -159,6 +159,9 @@ guidelines to be followed:
 Running tests using the command-line interface
 ----------------------------------------------
 
+.. module:: test.regrtest
+   :synopsis: Drives the regression test suite.
+
 The :mod:`test` package can be run as a script to drive Python's regression
 test suite, thanks to the :option:`-m` option: :program:`python -m test`. Under
 the hood, it uses :mod:`test.regrtest`; the call :program:`python -m


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

Fixes 7 Sphinx warnings:

```
Doc/library/test.rst:18: WARNING: py:mod reference target not found: test.regrtest
Doc/library/test.rst:18: WARNING: py:mod reference target not found: test.regrtest
Doc/library/test.rst:88: WARNING: py:mod reference target not found: test.regrtest
Doc/library/test.rst:162: WARNING: py:mod reference target not found: test.regrtest
Doc/library/test.rst:230: WARNING: py:mod reference target not found: test.regrtest
Doc/library/test.rst:463: WARNING: py:mod reference target not found: test.regrtest
Doc/library/test.rst:480: WARNING: py:mod reference target not found: test.regrtest
```


<!-- gh-issue-number: gh-101100 -->
* Issue: gh-101100
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--112381.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->