### PR TITLE
gh-101100: Define `_tkinter` module to fix references

### DIFF
--- a/Doc/library/tkinter.rst
+++ b/Doc/library/tkinter.rst
@@ -232,6 +232,9 @@ The modules that provide Tk support include:
 
 Additional modules:
 
+.. module:: _tkinter
+   :synopsis: A binary module that contains the low-level interface to Tcl/Tk.
+
 :mod:`_tkinter`
    A binary module that contains the low-level interface to Tcl/Tk.
    It is automatically imported by the main :mod:`tkinter` module,


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

Fixes 7 Sphinx warnings:

```console
❯ SPHINXERRORHANDLING=-n PATH=./venv/bin:$PATH sphinx-build -b html -d build/doctrees -j auto -n . build/html 2>&1  | grep "py:mod reference target not found: _tkinter" | tee >(wc -l)
Doc/library/tkinter.rst:22: WARNING: py:mod reference target not found: _tkinter
Doc/library/tkinter.rst:108: WARNING: py:mod reference target not found: _tkinter
Doc/library/tkinter.rst:240: WARNING: py:mod reference target not found: _tkinter
Doc/whatsnew/3.5.rst:1938: WARNING: py:mod reference target not found: _tkinter
Doc/whatsnew/2.3.rst:1572: WARNING: py:mod reference target not found: _tkinter
Doc/whatsnew/2.3.rst:1578: WARNING: py:mod reference target not found: _tkinter
Doc/whatsnew/2.3.rst:2034: WARNING: py:mod reference target not found: _tkinter
       7
```

<!-- gh-issue-number: gh-101100 -->
* Issue: gh-101100
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--112382.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->