### PR TITLE
gh-94722: fix DocTest.__eq__ for case of no line number on one side

### DIFF
--- a/Lib/doctest.py
+++ b/Lib/doctest.py
@@ -591,9 +591,11 @@ class DocTest:
     def __lt__(self, other):
         if not isinstance(other, DocTest):
             return NotImplemented
-        return ((self.name, self.filename, self.lineno, id(self))
+        self_lno = self.lineno if self.lineno is not None else -1
+        other_lno = other.lineno if other.lineno is not None else -1
+        return ((self.name, self.filename, self_lno, id(self))
                 <
-                (other.name, other.filename, other.lineno, id(other)))
+                (other.name, other.filename, other_lno, id(other)))
 
 ######################################################################
 ## 3. DocTestParser

--- a/Lib/test/test_doctest.py
+++ b/Lib/test/test_doctest.py
@@ -413,6 +413,23 @@ Compare `DocTest`:
     False
     >>> test != other_test
     True
+    >>> test < other_test
+    False
+    >>> other_test < test
+    True
+
+Test comparison with lineno None on one side
+
+    >>> no_lineno = parser.get_doctest(docstring, globs, 'some_test',
+    ...                               'some_test', None)
+    >>> test.lineno is None
+    False
+    >>> no_lineno.lineno is None
+    True
+    >>> test < no_lineno
+    False
+    >>> no_lineno < test
+    True
 
 Compare `DocTestCase`:
 

--- a/Misc/NEWS.d/next/Library/2023-11-24-21-00-24.gh-issue-94722.GMIQIn.rst
+++ b/Misc/NEWS.d/next/Library/2023-11-24-21-00-24.gh-issue-94722.GMIQIn.rst
@@ -1,0 +1,2 @@
+Fix bug where comparison between instances of :class:`~doctest.DocTest` fails if
+one of them has ``None`` as its lineno.


### PR DESCRIPTION
Fixes #94722.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-94722 -->
* Issue: gh-94722
<!-- /gh-issue-number -->
