### PR TITLE
[WIP] GH-102783: Speed up `pathlib.PurePath.__fspath__()` by returning raw path

### DIFF
--- a/Lib/pathlib.py
+++ b/Lib/pathlib.py
@@ -609,7 +609,9 @@ class PurePath:
         if len(paths) == 1:
             self._raw_path_cached = paths[0]
         elif len(paths) == 0:
-            self._raw_path_cached = '.'
+            self._str = self._raw_path_cached = '.'
+            self._drv = self._root = ''
+            self._tail_cached = []
         self._resolving = False
 
     def __reduce__(self):

--- a/Lib/pathlib.py
+++ b/Lib/pathlib.py
@@ -261,8 +261,6 @@ class PurePath:
 
     @classmethod
     def _parse_path(cls, path):
-        if not path:
-            return '', '', []
         sep = cls.pathmod.sep
         altsep = cls.pathmod.altsep
         if altsep:
@@ -605,12 +603,13 @@ class PurePath:
                         "argument should be a str or an os.PathLike "
                         "object where __fspath__ returns a str, "
                         f"not {type(path).__name__!r}")
-                paths.append(path)
+                if path:
+                    paths.append(path)
         self._raw_paths = paths
         if len(paths) == 1:
             self._raw_path_cached = paths[0]
         elif len(paths) == 0:
-            self._raw_path_cached = ''
+            self._raw_path_cached = '.'
         self._resolving = False
 
     def __reduce__(self):

--- a/Lib/test/test_pathlib.py
+++ b/Lib/test/test_pathlib.py
@@ -708,6 +708,13 @@ class PurePathTest(unittest.TestCase):
         p = P('a/b')
         self._check_str(p.__fspath__(), ('a/b',))
         self._check_str(os.fspath(p), ('a/b',))
+        self.assertEqual('.', P().__fspath__())
+        self.assertEqual('.', P('').__fspath__())
+        self.assertEqual('.', P('.').__fspath__())
+        self.assertEqual('.', P('', '').__fspath__())
+        self.assertEqual('.', P('.', '').__fspath__())
+        self.assertEqual('.', P('', '.').__fspath__())
+        self.assertEqual(f'.{self.sep}.', P('.', '.').__fspath__())
 
     def test_bytes(self):
         P = self.cls

--- a/Misc/NEWS.d/next/Library/2023-11-25-12-46-21.gh-issue-102783.O-toHf.rst
+++ b/Misc/NEWS.d/next/Library/2023-11-25-12-46-21.gh-issue-102783.O-toHf.rst
@@ -1,0 +1,2 @@
+Speed up ``pathlib.PurePath.__fspath__()`` by returning an unnormalized
+path.


### PR DESCRIPTION
Return an unnormalized path from `pathlib.PurePath.__fspath__()`. This is equivalent to a normalized path (because pathlib's normalization doesn't change the meaning of paths), but considerably cheaper to generate.

Draft PR because it depends on a fix for #65238.

<!-- gh-issue-number: gh-102783 -->
* Issue: gh-102783
<!-- /gh-issue-number -->
