### PR TITLE
gh-112405: Optimise `pathlib.Path.relative_to`

### DIFF
--- a/Lib/pathlib.py
+++ b/Lib/pathlib.py
@@ -14,6 +14,7 @@ import sys
 import warnings
 from _collections_abc import Sequence
 from errno import ENOENT, ENOTDIR, EBADF, ELOOP, EINVAL
+from itertools import chain
 from stat import S_ISDIR, S_ISLNK, S_ISREG, S_ISSOCK, S_ISBLK, S_ISCHR, S_ISFIFO
 
 try:
@@ -445,7 +446,7 @@ class PurePath:
             other = self.with_segments(other, *_deprecated)
         elif not isinstance(other, PurePath):
             other = self.with_segments(other)
-        for step, path in enumerate([other] + list(other.parents)):
+        for step, path in enumerate(chain([other], other.parents)):
             if path == self or path in self.parents:
                 break
             elif not walk_up:

--- a/Misc/NEWS.d/next/Library/2023-11-25-20-29-28.gh-issue-112405.cOtzxC.rst
+++ b/Misc/NEWS.d/next/Library/2023-11-25-20-29-28.gh-issue-112405.cOtzxC.rst
@@ -1,1 +1,1 @@
-Optimize :meth:`pathlib.Path.relative_to`. Patch by Alex Waygood.
+Optimize :meth:`pathlib.PurePath.relative_to`. Patch by Alex Waygood.

--- a/Misc/NEWS.d/next/Library/2023-11-25-20-29-28.gh-issue-112405.cOtzxC.rst
+++ b/Misc/NEWS.d/next/Library/2023-11-25-20-29-28.gh-issue-112405.cOtzxC.rst
@@ -1,1 +1,1 @@
-Optimise :meth:`pathlib.Path.relative_to`. Patch by Alex Waygood.
+Optimize :meth:`pathlib.Path.relative_to`. Patch by Alex Waygood.

--- a/Misc/NEWS.d/next/Library/2023-11-25-20-29-28.gh-issue-112405.cOtzxC.rst
+++ b/Misc/NEWS.d/next/Library/2023-11-25-20-29-28.gh-issue-112405.cOtzxC.rst
@@ -1,0 +1,1 @@
+Optimise :meth:`pathlib.Path.relative_to`. Patch by Alex Waygood.


### PR DESCRIPTION
On `main` (Windows machine, PGO-optimised build):

```
>python -m timeit -s "from pathlib import Path; p = Path('a/b/c/d/e/f/g')" "p.relative_to('a/b/c/d')"
Running PGUpdate|x64 interpreter...
10000 loops, best of 5: 28.7 usec per loop
```

With this PR:

```
>python -m timeit -s "from pathlib import Path; p = Path('a/b/c/d/e/f/g')" "p.relative_to('a/b/c/d')"
Running PGUpdate|x64 interpreter...
20000 loops, best of 5: 19.5 usec per loop
```

Fixes #112405

<!-- gh-issue-number: gh-112405 -->
* Issue: gh-112405
<!-- /gh-issue-number -->
