### PR TITLE
gh-99606: Make code generated for an empty f-string identical to that of a normal empty string

### DIFF
--- a/Lib/importlib/_bootstrap_external.py
+++ b/Lib/importlib/_bootstrap_external.py
@@ -478,7 +478,7 @@ _code_type = type(_write_atomic.__code__)
 # Whenever MAGIC_NUMBER is changed, the ranges in the magic_values array
 # in PC/launcher.c must also be updated.
 
-MAGIC_NUMBER = (3578).to_bytes(2, 'little') + b'\r\n'
+MAGIC_NUMBER = (3566).to_bytes(2, 'little') + b'\r\n'
 
 _RAW_MAGIC_NUMBER = int.from_bytes(MAGIC_NUMBER, 'little')  # For import.c
 

--- a/Lib/importlib/_bootstrap_external.py
+++ b/Lib/importlib/_bootstrap_external.py
@@ -461,7 +461,6 @@ _code_type = type(_write_atomic.__code__)
 #     Python 3.13a1 3563 (Add CALL_KW and remove KW_NAMES)
 #     Python 3.13a1 3564 (Removed oparg from YIELD_VALUE, changed oparg values of RESUME)
 #     Python 3.13a1 3565 (Oparg of YIELD_VALUE indicates whether it is in a yield-from)
-#     Python 3.13a1 3566 (Code for empty f-string matches empty normal string)
 
 #     Python 3.14 will start with 3600
 

--- a/Lib/importlib/_bootstrap_external.py
+++ b/Lib/importlib/_bootstrap_external.py
@@ -461,6 +461,7 @@ _code_type = type(_write_atomic.__code__)
 #     Python 3.13a1 3563 (Add CALL_KW and remove KW_NAMES)
 #     Python 3.13a1 3564 (Removed oparg from YIELD_VALUE, changed oparg values of RESUME)
 #     Python 3.13a1 3565 (Oparg of YIELD_VALUE indicates whether it is in a yield-from)
+#     Python 3.13a1 3566 (Code for empty f-string matches empty normal string)
 
 #     Python 3.14 will start with 3600
 
@@ -477,7 +478,7 @@ _code_type = type(_write_atomic.__code__)
 # Whenever MAGIC_NUMBER is changed, the ranges in the magic_values array
 # in PC/launcher.c must also be updated.
 
-MAGIC_NUMBER = (3565).to_bytes(2, 'little') + b'\r\n'
+MAGIC_NUMBER = (3578).to_bytes(2, 'little') + b'\r\n'
 
 _RAW_MAGIC_NUMBER = int.from_bytes(MAGIC_NUMBER, 'little')  # For import.c
 

--- a/Lib/importlib/_bootstrap_external.py
+++ b/Lib/importlib/_bootstrap_external.py
@@ -477,7 +477,7 @@ _code_type = type(_write_atomic.__code__)
 # Whenever MAGIC_NUMBER is changed, the ranges in the magic_values array
 # in PC/launcher.c must also be updated.
 
-MAGIC_NUMBER = (3566).to_bytes(2, 'little') + b'\r\n'
+MAGIC_NUMBER = (3565).to_bytes(2, 'little') + b'\r\n'
 
 _RAW_MAGIC_NUMBER = int.from_bytes(MAGIC_NUMBER, 'little')  # For import.c
 

--- a/Lib/test/test_fstring.py
+++ b/Lib/test/test_fstring.py
@@ -8,6 +8,7 @@
 # Unicode identifiers in tests is allowed by PEP 3131.
 
 import ast
+import dis
 import os
 import re
 import types
@@ -1737,6 +1738,15 @@ print(f'''{{
             _, stdout, stderr = assert_python_ok(script)
             self.assertIn(rb'\1', stdout)
             self.assertEqual(len(stderr.strip().splitlines()), 2)
+
+    def test_fstring_without_formatting_bytecode(self):
+        # f-string without any formatting should emit the same bytecode
+        # as a normal string. See gh-99606.
+        def get_code(s):
+            return [(i.opname, i.oparg) for i in dis.get_instructions(s)]
+
+        for s in ["", "some string"]:
+            self.assertEqual(get_code(f"'{s}'"), get_code(f"f'{s}'"))
 
 if __name__ == '__main__':
     unittest.main()

--- a/Misc/NEWS.d/next/Core and Builtins/2023-11-25-20-36-38.gh-issue-99606.fDY5hK.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2023-11-25-20-36-38.gh-issue-99606.fDY5hK.rst
@@ -1,0 +1,2 @@
+Make code generated for an empty f-string identical to the code of an empty
+normal string.

--- a/Python/compile.c
+++ b/Python/compile.c
@@ -5042,8 +5042,12 @@ compiler_joined_str(struct compiler *c, expr_ty e)
     }
     else {
         VISIT_SEQ(c, expr, e->v.JoinedStr.values);
-        if (asdl_seq_LEN(e->v.JoinedStr.values) != 1) {
-            ADDOP_I(c, loc, BUILD_STRING, asdl_seq_LEN(e->v.JoinedStr.values));
+        if (value_count > 1) {
+            ADDOP_I(c, loc, BUILD_STRING, value_count);
+        }
+        else if (value_count == 0) {
+            _Py_DECLARE_STR(empty, "");
+            ADDOP_LOAD_CONST_NEW(c, loc, Py_NewRef(&_Py_STR(empty)));
         }
     }
     return SUCCESS;


### PR DESCRIPTION
Fixes #99606.

<!-- gh-issue-number: gh-99606 -->
* Issue: gh-99606
<!-- /gh-issue-number -->
