### PR TITLE
gh-101100: Fix Sphinx reference warnings

### DIFF
--- a/Doc/c-api/set.rst
+++ b/Doc/c-api/set.rst
@@ -147,7 +147,7 @@ subtypes but not for instances of :class:`frozenset` or its subtypes.
 
    Return ``1`` if found and removed, ``0`` if not found (no action taken), and ``-1`` if an
    error is encountered.  Does not raise :exc:`KeyError` for missing keys.  Raise a
-   :exc:`TypeError` if the *key* is unhashable.  Unlike the Python :meth:`~set.discard`
+   :exc:`TypeError` if the *key* is unhashable.  Unlike the Python :meth:`~frozenset.discard`
    method, this function does not automatically convert unhashable sets into
    temporary frozensets. Raise :exc:`SystemError` if *set* is not an
    instance of :class:`set` or its subtype.

--- a/Doc/extending/newtypes.rst
+++ b/Doc/extending/newtypes.rst
@@ -296,7 +296,7 @@ An interesting advantage of using the :c:member:`~PyTypeObject.tp_members` table
 descriptors that are used at runtime is that any attribute defined this way can
 have an associated doc string simply by providing the text in the table.  An
 application can use the introspection API to retrieve the descriptor from the
-class object, and get the doc string using its :attr:`__doc__` attribute.
+class object, and get the doc string using its :attr:`!__doc__` attribute.
 
 As with the :c:member:`~PyTypeObject.tp_methods` table, a sentinel entry with a :c:member:`~PyMethodDef.ml_name` value
 of ``NULL`` is required.

--- a/Doc/library/asyncio-stream.rst
+++ b/Doc/library/asyncio-stream.rst
@@ -204,6 +204,10 @@ StreamReader
    directly; use :func:`open_connection` and :func:`start_server`
    instead.
 
+   .. method:: feed_eof()
+
+      Acknowledge the EOF.
+
    .. coroutinemethod:: read(n=-1)
 
       Read up to *n* bytes from the stream.

--- a/Doc/library/email.errors.rst
+++ b/Doc/library/email.errors.rst
@@ -58,6 +58,15 @@ The following exception classes are defined in the :mod:`email.errors` module:
    :class:`~email.mime.nonmultipart.MIMENonMultipart` (e.g.
    :class:`~email.mime.image.MIMEImage`).
 
+.. exception:: MessageDefect()
+
+   This is the base class for all defects found when parsing email messages.
+   It is derived from :exc:`ValueError`.
+
+.. exception:: HeaderDefect()
+
+   This is the base class for all defects found when parsing email headers.
+   It is derived from :exc:`MessageDefect`.
 
 Here is the list of the defects that the :class:`~email.parser.FeedParser`
 can find while parsing messages.  Note that the defects are added to the message

--- a/Doc/library/gzip.rst
+++ b/Doc/library/gzip.rst
@@ -105,7 +105,7 @@ The module defines the following items:
    should only be provided in compression mode.  If omitted or ``None``, the
    current time is used.  See the :attr:`mtime` attribute for more details.
 
-   Calling a :class:`GzipFile` object's :meth:`close` method does not close
+   Calling a :class:`GzipFile` object's :meth:`!close` method does not close
    *fileobj*, since you might wish to append more material after the compressed
    data.  This also allows you to pass an :class:`io.BytesIO` object opened for
    writing as *fileobj*, and retrieve the resulting memory buffer using the

--- a/Doc/library/importlib.resources.rst
+++ b/Doc/library/importlib.resources.rst
@@ -50,7 +50,7 @@ for example, a package and its resources can be imported from a zip file using
 ``get_resource_reader(fullname)`` method as specified by
 :class:`importlib.resources.abc.ResourceReader`.
 
-.. data:: Anchor
+.. class:: Anchor
 
     Represents an anchor for resources, either a :class:`module object
     <types.ModuleType>` or a module name as a string. Defined as
@@ -63,7 +63,7 @@ for example, a package and its resources can be imported from a zip file using
     (think files). A Traversable may contain other containers (think
     subdirectories).
 
-    *anchor* is an optional :data:`Anchor`. If the anchor is a
+    *anchor* is an optional :class:`Anchor`. If the anchor is a
     package, resources are resolved from that package. If a module,
     resources are resolved adjacent to that module (in the same package
     or the package root). If the anchor is omitted, the caller's module

--- a/Doc/library/importlib.resources.rst
+++ b/Doc/library/importlib.resources.rst
@@ -75,7 +75,7 @@ for example, a package and its resources can be imported from a zip file using
        *package* parameter was renamed to *anchor*. *anchor* can now
        be a non-package module and if omitted will default to the caller's
        module. *package* is still accepted for compatibility but will raise
-       a DeprecationWarning. Consider passing the anchor positionally or
+       a :exc:`DeprecationWarning`. Consider passing the anchor positionally or
        using ``importlib_resources >= 5.10`` for a compatible interface
        on older Pythons.
 

--- a/Doc/library/importlib.resources.rst
+++ b/Doc/library/importlib.resources.rst
@@ -72,9 +72,9 @@ for example, a package and its resources can be imported from a zip file using
     .. versionadded:: 3.9
 
     .. versionchanged:: 3.12
-       "package" parameter was renamed to "anchor". "anchor" can now
+       *package* parameter was renamed to *anchor*. *anchor* can now
        be a non-package module and if omitted will default to the caller's
-       module. "package" is still accepted for compatibility but will raise
+       module. *package* is still accepted for compatibility but will raise
        a DeprecationWarning. Consider passing the anchor positionally or
        using ``importlib_resources >= 5.10`` for a compatible interface
        on older Pythons.
@@ -96,4 +96,4 @@ for example, a package and its resources can be imported from a zip file using
     .. versionadded:: 3.9
 
     .. versionchanged:: 3.12
-       Added support for ``traversable`` representing a directory.
+       Added support for *traversable* representing a directory.

--- a/Doc/library/xml.rst
+++ b/Doc/library/xml.rst
@@ -73,7 +73,7 @@ decompression bomb         Safe                Safe                Safe         
 1. Expat 2.4.1 and newer is not vulnerable to the "billion laughs" and
    "quadratic blowup" vulnerabilities. Items still listed as vulnerable due to
    potential reliance on system-provided libraries. Check
-   :const:`pyexpat.EXPAT_VERSION`.
+   :const:`!pyexpat.EXPAT_VERSION`.
 2. :mod:`xml.etree.ElementTree` doesn't expand external entities and raises a
    :exc:`~xml.etree.ElementTree.ParseError` when an entity occurs.
 3. :mod:`xml.dom.minidom` doesn't expand external entities and simply returns

--- a/Doc/tools/.nitignore
+++ b/Doc/tools/.nitignore
@@ -68,7 +68,6 @@ Doc/library/http.client.rst
 Doc/library/http.cookiejar.rst
 Doc/library/http.cookies.rst
 Doc/library/http.server.rst
-Doc/library/importlib.resources.rst
 Doc/library/importlib.rst
 Doc/library/inspect.rst
 Doc/library/locale.rst

--- a/Doc/tools/.nitignore
+++ b/Doc/tools/.nitignore
@@ -122,7 +122,6 @@ Doc/library/wsgiref.rst
 Doc/library/xml.dom.minidom.rst
 Doc/library/xml.dom.pulldom.rst
 Doc/library/xml.dom.rst
-Doc/library/xml.rst
 Doc/library/xml.sax.handler.rst
 Doc/library/xml.sax.reader.rst
 Doc/library/xml.sax.rst

--- a/Doc/tools/.nitignore
+++ b/Doc/tools/.nitignore
@@ -32,7 +32,6 @@ Doc/library/abc.rst
 Doc/library/ast.rst
 Doc/library/asyncio-extending.rst
 Doc/library/asyncio-policy.rst
-Doc/library/asyncio-stream.rst
 Doc/library/asyncio-subprocess.rst
 Doc/library/asyncio-task.rst
 Doc/library/bdb.rst

--- a/Doc/tools/.nitignore
+++ b/Doc/tools/.nitignore
@@ -63,7 +63,6 @@ Doc/library/ftplib.rst
 Doc/library/functions.rst
 Doc/library/functools.rst
 Doc/library/gettext.rst
-Doc/library/gzip.rst
 Doc/library/http.client.rst
 Doc/library/http.cookiejar.rst
 Doc/library/http.cookies.rst

--- a/Doc/tools/.nitignore
+++ b/Doc/tools/.nitignore
@@ -14,7 +14,6 @@ Doc/c-api/memory.rst
 Doc/c-api/memoryview.rst
 Doc/c-api/module.rst
 Doc/c-api/object.rst
-Doc/c-api/set.rst
 Doc/c-api/stable.rst
 Doc/c-api/structures.rst
 Doc/c-api/sys.rst

--- a/Doc/tools/.nitignore
+++ b/Doc/tools/.nitignore
@@ -51,7 +51,6 @@ Doc/library/decimal.rst
 Doc/library/email.charset.rst
 Doc/library/email.compat32-message.rst
 Doc/library/email.errors.rst
-Doc/library/email.headerregistry.rst
 Doc/library/email.mime.rst
 Doc/library/email.parser.rst
 Doc/library/email.policy.rst

--- a/Doc/tools/.nitignore
+++ b/Doc/tools/.nitignore
@@ -21,7 +21,6 @@ Doc/c-api/sys.rst
 Doc/c-api/type.rst
 Doc/c-api/typeobj.rst
 Doc/extending/extending.rst
-Doc/extending/newtypes.rst
 Doc/glossary.rst
 Doc/howto/descriptor.rst
 Doc/howto/enum.rst


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

Fix 7 Sphinx warnings, in most files with a single warning:

```
Doc/c-api/set.rst:148: WARNING: py:meth reference target not found: set.discard
Doc/extending/newtypes.rst:295: WARNING: py:attr reference target not found: __doc__
Doc/library/asyncio-stream.rst:263: WARNING: py:meth reference target not found: feed_eof
Doc/library/email.headerregistry.rst:61: WARNING: py:exc reference target not found: email.errors.HeaderDefect
Doc/library/gzip.rst:108: WARNING: py:meth reference target not found: close
Doc/library/importlib.resources.rst:59: WARNING: py:class reference target not found: Anchor
Doc/library/xml.rst:73: WARNING: py:const reference target not found: pyexpat.EXPAT_VERSION
```

Plus a bit of extra cleanup, details in commits.

<!-- gh-issue-number: gh-101100 -->
* Issue: gh-101100
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--112416.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->