### PR TITLE
gh-112414: Fix `AttributeError` when calling `repr()` on a namespace package imported with a custom loader

### DIFF
--- a/Lib/importlib/_bootstrap.py
+++ b/Lib/importlib/_bootstrap.py
@@ -824,10 +824,16 @@ def _module_repr_from_spec(spec):
     """Return the repr to use for the module."""
     name = '?' if spec.name is None else spec.name
     if spec.origin is None:
-        if spec.loader is None:
+        loader = spec.loader
+        if loader is None:
             return f'<module {name!r}>'
+        elif (
+            _bootstrap_external is not None
+            and isinstance(loader, _bootstrap_external.NamespaceLoader)
+        ):
+            return f'<module {name!r} (namespace) from {list(loader._path)}>'
         else:
-            return f'<module {name!r} (namespace) from {list(spec.loader._path)}>'
+            return f'<module {name!r} ({loader!r})>'
     else:
         if spec.has_location:
             return f'<module {name!r} from {spec.origin!r}>'

--- a/Lib/test/test_importlib/import_/test___loader__.py
+++ b/Lib/test/test_importlib/import_/test___loader__.py
@@ -23,6 +23,10 @@ class SpecLoaderAttributeTests:
         with util.uncache('blah'), util.import_state(meta_path=[loader]):
             module = self.__import__('blah')
         self.assertEqual(loader, module.__loader__)
+        expected_repr_pattern = (
+            r"<module 'blah' \(<test\.test_importlib\..*SpecLoaderMock object at .+>\)>"
+        )
+        self.assertRegex(repr(module), expected_repr_pattern)
 
 
 (Frozen_SpecTests,

--- a/Lib/test/test_importlib/test_namespace_pkgs.py
+++ b/Lib/test/test_importlib/test_namespace_pkgs.py
@@ -80,7 +80,7 @@ class SingleNamespacePackage(NamespacePackageTest):
 
     def test_simple_repr(self):
         import foo.one
-        assert repr(foo).startswith("<module 'foo' (namespace) from [")
+        self.assertTrue(repr(foo).startswith("<module 'foo' (namespace) from ["))
 
 
 class DynamicPathNamespacePackage(NamespacePackageTest):

--- a/Misc/NEWS.d/next/Library/2023-11-26-13-44-19.gh-issue-112414.kx2E7S.rst
+++ b/Misc/NEWS.d/next/Library/2023-11-26-13-44-19.gh-issue-112414.kx2E7S.rst
@@ -1,0 +1,3 @@
+Fix regression in Python 3.12 where calling :func:`repr` on a module that
+had been imported using a custom :term:`loader` could fail with
+:exc:`AttributeError`. Patch by Alex Waygood.


### PR DESCRIPTION
Fixes a regression introduced by https://github.com/python/cpython/pull/98870

<!-- gh-issue-number: gh-112414 -->
* Issue: gh-112414
<!-- /gh-issue-number -->
