### PR TITLE
Docs: fix typo in doc for sqlite3.Cursor.execute

### DIFF
--- a/Doc/library/sqlite3.rst
+++ b/Doc/library/sqlite3.rst
@@ -1502,7 +1502,7 @@ Cursor objects
 
    .. method:: execute(sql, parameters=(), /)
 
-      Execute SQL a single SQL statement,
+      Execute a single SQL statement,
       optionally binding Python values using
       :ref:`placeholders <sqlite3-placeholders>`.
 


### PR DESCRIPTION
Can be backported all the way to 3.10 (same as #101782, which introduced the typo).

<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--112442.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->