### PR TITLE
gh-59013: Set breakpoint on the first executable line in pdb when using `break func`

### DIFF
--- a/Lib/pdb.py
+++ b/Lib/pdb.py
@@ -96,17 +96,47 @@ class Restart(Exception):
 __all__ = ["run", "pm", "Pdb", "runeval", "runctx", "runcall", "set_trace",
            "post_mortem", "help"]
 
+
+def find_first_executable_line(code):
+    """ Try to find the first executable line of the code object.
+
+    Equivalently, find the line number of the instruction that's
+    after RESUME
+
+    Return code.co_firstlineno if no executable line is found.
+    """
+    prev = None
+    for instr in dis.get_instructions(code):
+        if prev is not None and prev.opname == 'RESUME':
+            if instr.positions.lineno is not None:
+                return instr.positions.lineno
+            return code.co_firstlineno
+        prev = instr
+    return code.co_firstlineno
+
 def find_function(funcname, filename):
     cre = re.compile(r'def\s+%s\s*[(]' % re.escape(funcname))
     try:
         fp = tokenize.open(filename)
     except OSError:
         return None
+    funcdef = ""
+    funcstart = None
     # consumer of this info expects the first line to be 1
     with fp:
         for lineno, line in enumerate(fp, start=1):
             if cre.match(line):
-                return funcname, filename, lineno
+                funcstart, funcdef = lineno, line
+            elif funcdef:
+                funcdef += line
+
+            if funcdef:
+                try:
+                    funccode = compile(funcdef, filename, 'exec').co_consts[0]
+                except SyntaxError:
+                    continue
+                lineno_offset = find_first_executable_line(funccode)
+                return funcname, filename, funcstart + lineno_offset - 1
     return None
 
 def lasti2lineno(code, lasti):
@@ -913,7 +943,7 @@ class Pdb(bdb.Bdb, cmd.Cmd):
                     #use co_name to identify the bkpt (function names
                     #could be aliased, but co_name is invariant)
                     funcname = code.co_name
-                    lineno = self._find_first_executable_line(code)
+                    lineno = find_first_executable_line(code)
                     filename = code.co_filename
                 except:
                     # last thing to try
@@ -1015,23 +1045,6 @@ class Pdb(bdb.Bdb, cmd.Cmd):
             self.error('Blank or comment')
             return 0
         return lineno
-
-    def _find_first_executable_line(self, code):
-        """ Try to find the first executable line of the code object.
-
-        Equivalently, find the line number of the instruction that's
-        after RESUME
-
-        Return code.co_firstlineno if no executable line is found.
-        """
-        prev = None
-        for instr in dis.get_instructions(code):
-            if prev is not None and prev.opname == 'RESUME':
-                if instr.positions.lineno is not None:
-                    return instr.positions.lineno
-                return code.co_firstlineno
-            prev = instr
-        return code.co_firstlineno
 
     def do_enable(self, arg):
         """enable bpnumber [bpnumber ...]

--- a/Lib/test/test_pdb.py
+++ b/Lib/test/test_pdb.py
@@ -2622,15 +2622,15 @@ def bœr():
             def foo(): pass
 
             def bar():
-                pass
+                pass  # line 4
 
             def baz():
                 # comment
-                pass
+                pass  # line 8
 
             def mul():
                 # code on multiple lines
-                code = compile(
+                code = compile(   # line 12
                     'def f()',
                     '<string>',
                     'exec',

--- a/Lib/test/test_pdb.py
+++ b/Lib/test/test_pdb.py
@@ -2587,7 +2587,7 @@ def quux():
     pass
 """.encode(),
             'bœr',
-            ('bœr', 4),
+            ('bœr', 5),
         )
 
     def test_find_function_found_with_encoding_cookie(self):
@@ -2604,7 +2604,7 @@ def quux():
     pass
 """.encode('iso-8859-15'),
             'bœr',
-            ('bœr', 5),
+            ('bœr', 6),
         )
 
     def test_find_function_found_with_bom(self):
@@ -2614,8 +2614,23 @@ def bœr():
     pass
 """.encode(),
             'bœr',
-            ('bœr', 1),
+            ('bœr', 2),
         )
+
+    def test_find_function_empty_file(self):
+        code = textwrap.dedent("""\
+            def foo(): pass
+
+            def bar():
+                pass
+
+            def baz():
+                # comment
+                pass
+        """).encode()
+        self._assert_find_function(code, 'foo', ('foo', 1))
+        self._assert_find_function(code, 'bar', ('bar', 4))
+        self._assert_find_function(code, 'baz', ('baz', 8))
 
     def test_issue7964(self):
         # open the file as binary so we can force \r\n newline

--- a/Lib/test/test_pdb.py
+++ b/Lib/test/test_pdb.py
@@ -2617,7 +2617,7 @@ def bœr():
             ('bœr', 2),
         )
 
-    def test_find_function_empty_file(self):
+    def test_find_function_first_executable_line(self):
         code = textwrap.dedent("""\
             def foo(): pass
 
@@ -2627,10 +2627,20 @@ def bœr():
             def baz():
                 # comment
                 pass
+
+            def mul():
+                # code on multiple lines
+                code = compile(
+                    'def f()',
+                    '<string>',
+                    'exec',
+                )
         """).encode()
+
         self._assert_find_function(code, 'foo', ('foo', 1))
         self._assert_find_function(code, 'bar', ('bar', 4))
         self._assert_find_function(code, 'baz', ('baz', 8))
+        self._assert_find_function(code, 'mul', ('mul', 12))
 
     def test_issue7964(self):
         # open the file as binary so we can force \r\n newline

--- a/Misc/NEWS.d/next/Library/2023-11-27-19-54-43.gh-issue-59013.chpQ0e.rst
+++ b/Misc/NEWS.d/next/Library/2023-11-27-19-54-43.gh-issue-59013.chpQ0e.rst
@@ -1,1 +1,1 @@
-Set breakpoint on the first executable line in :mod:`pdb` instead of function definition when using ``break func``
+Set breakpoint on the first executable line of the function, instead of the line of function definition when the user do ``break func`` using :mod:`pdb`

--- a/Misc/NEWS.d/next/Library/2023-11-27-19-54-43.gh-issue-59013.chpQ0e.rst
+++ b/Misc/NEWS.d/next/Library/2023-11-27-19-54-43.gh-issue-59013.chpQ0e.rst
@@ -1,1 +1,1 @@
-Set breakpoint on the first executable line in :mod:`pdb` instead of function definition when using `break func`
+Set breakpoint on the first executable line in :mod:`pdb` instead of function definition when using ``break func``

--- a/Misc/NEWS.d/next/Library/2023-11-27-19-54-43.gh-issue-59013.chpQ0e.rst
+++ b/Misc/NEWS.d/next/Library/2023-11-27-19-54-43.gh-issue-59013.chpQ0e.rst
@@ -1,0 +1,1 @@
+Set breakpoint on the first executable line in :mod:`pdb` instead of function definition when using `break func`


### PR DESCRIPTION
In #110582, we made `break foo` work if `foo` is already a known function (that has an associated code object). However, if `foo` is in another module or it's not defined yet, we still use regular expression to find the definition, which will still set the breakpoint on the `def` line. This is an inconsistent behavior and will confuse users because the actual break will be on the first executable line.

This PR solves the issue by trying to compile the head of function to find the first executable line. As long as the first couple of lines are compilable, we should be able to find the first executable line of the function and set the break point on it. This skips comments, empty lines well (and not using pure strings to figure it out).

Notably, this is a breaking change - because the previous behavior is confusing.

<!-- gh-issue-number: gh-59013 -->
* Issue: gh-59013
<!-- /gh-issue-number -->
