### PR TITLE
[3.12] gh-105699: Revert gh-107783 "Re-enable the Multiple-Interpreters Stress Tests"

### DIFF
--- a/Lib/test/test_interpreters.py
+++ b/Lib/test/test_interpreters.py
@@ -464,6 +464,7 @@ class TestInterpreterRun(TestBase):
     # test_xxsubinterpreters covers the remaining Interpreter.run() behavior.
 
 
+@unittest.skip('these are crashing, likely just due just to _xxsubinterpreters (see gh-105699)')
 class StressTests(TestBase):
 
     # In these tests we generally want a lot of interpreters,


### PR DESCRIPTION
This reverts commit a4aac7d3eafc413ae75f26ca1a1246bdba23c7fb.

The stress tests are still failing on FreeBSD.