### PR TITLE
gh-112414: Add additional unit tests for calling `repr()` on a namespace package

### DIFF
--- a/Lib/test/test_importlib/import_/test___loader__.py
+++ b/Lib/test/test_importlib/import_/test___loader__.py
@@ -23,10 +23,6 @@ class SpecLoaderAttributeTests:
         with util.uncache('blah'), util.import_state(meta_path=[loader]):
             module = self.__import__('blah')
         self.assertEqual(loader, module.__loader__)
-        expected_repr_pattern = (
-            r"<module 'blah' \(<test\.test_importlib\..*SpecLoaderMock object at .+>\)>"
-        )
-        self.assertRegex(repr(module), expected_repr_pattern)
 
 
 (Frozen_SpecTests,

--- a/Lib/test/test_module/__init__.py
+++ b/Lib/test/test_module/__init__.py
@@ -1,4 +1,5 @@
 # Test the module type
+import importlib.machinery
 import unittest
 import weakref
 from test.support import gc_collect
@@ -263,6 +264,23 @@ a = A(destroyed)"""
                          '{!r} does not start with {!r}'.format(r, starts_with))
         self.assertEqual(r[-len(ends_with):], ends_with,
                          '{!r} does not end with {!r}'.format(r, ends_with))
+
+    def test_module_repr_with_namespace_package(self):
+        m = ModuleType('foo')
+        loader = importlib.machinery.NamespaceLoader("foo", ["bar"], "baz")
+        spec = importlib.machinery.ModuleSpec("foo", loader)
+        m.__loader__ = loader
+        m.__spec__ = spec
+        self.assertEqual(repr(m), "<module 'foo' (namespace) from ['bar']>")
+
+    def test_module_repr_with_namespace_package_and_custom_loader(self):
+        m = ModuleType('foo')
+        loader = BareLoader()
+        spec = importlib.machinery.ModuleSpec("foo", loader)
+        m.__loader__ = loader
+        m.__spec__ = spec
+        expected_repr_pattern = r"<module 'foo' \(<.*\.BareLoader object at .+>\)>"
+        self.assertRegex(repr(m), expected_repr_pattern)
 
     def test_module_finalization_at_shutdown(self):
         # Module globals and builtins should still be available during shutdown

--- a/Lib/test/test_module/__init__.py
+++ b/Lib/test/test_module/__init__.py
@@ -283,6 +283,16 @@ a = A(destroyed)"""
         self.assertRegex(repr(m), expected_repr_pattern)
         self.assertNotIn('from', repr(m))
 
+    def test_module_repr_with_fake_namespace_package(self):
+        m = ModuleType('foo')
+        loader = BareLoader()
+        loader._path = ['spam']
+        spec = importlib.machinery.ModuleSpec("foo", loader)
+        m.__loader__ = loader
+        m.__spec__ = spec
+        expected_repr_pattern = r"<module 'foo' \(<.*\.BareLoader object at .+>\)>"
+        self.assertRegex(repr(m), expected_repr_pattern)
+        self.assertNotIn('from', repr(m))
     def test_module_finalization_at_shutdown(self):
         # Module globals and builtins should still be available during shutdown
         rc, out, err = assert_python_ok("-c", "from test.test_module import final_a")

--- a/Lib/test/test_module/__init__.py
+++ b/Lib/test/test_module/__init__.py
@@ -267,8 +267,8 @@ a = A(destroyed)"""
 
     def test_module_repr_with_namespace_package(self):
         m = ModuleType('foo')
-        loader = importlib.machinery.NamespaceLoader("foo", ["bar"], "baz")
-        spec = importlib.machinery.ModuleSpec("foo", loader)
+        loader = importlib.machinery.NamespaceLoader('foo', ['bar'], 'baz')
+        spec = importlib.machinery.ModuleSpec('foo', loader)
         m.__loader__ = loader
         m.__spec__ = spec
         self.assertEqual(repr(m), "<module 'foo' (namespace) from ['bar']>")
@@ -276,7 +276,7 @@ a = A(destroyed)"""
     def test_module_repr_with_namespace_package_and_custom_loader(self):
         m = ModuleType('foo')
         loader = BareLoader()
-        spec = importlib.machinery.ModuleSpec("foo", loader)
+        spec = importlib.machinery.ModuleSpec('foo', loader)
         m.__loader__ = loader
         m.__spec__ = spec
         expected_repr_pattern = r"<module 'foo' \(<.*\.BareLoader object at .+>\)>"
@@ -287,12 +287,13 @@ a = A(destroyed)"""
         m = ModuleType('foo')
         loader = BareLoader()
         loader._path = ['spam']
-        spec = importlib.machinery.ModuleSpec("foo", loader)
+        spec = importlib.machinery.ModuleSpec('foo', loader)
         m.__loader__ = loader
         m.__spec__ = spec
         expected_repr_pattern = r"<module 'foo' \(<.*\.BareLoader object at .+>\)>"
         self.assertRegex(repr(m), expected_repr_pattern)
         self.assertNotIn('from', repr(m))
+
     def test_module_finalization_at_shutdown(self):
         # Module globals and builtins should still be available during shutdown
         rc, out, err = assert_python_ok("-c", "from test.test_module import final_a")

--- a/Lib/test/test_module/__init__.py
+++ b/Lib/test/test_module/__init__.py
@@ -281,6 +281,7 @@ a = A(destroyed)"""
         m.__spec__ = spec
         expected_repr_pattern = r"<module 'foo' \(<.*\.BareLoader object at .+>\)>"
         self.assertRegex(repr(m), expected_repr_pattern)
+        self.assertNotIn('from', repr(m))
 
     def test_module_finalization_at_shutdown(self):
         # Module globals and builtins should still be available during shutdown


### PR DESCRIPTION
Addressing @ericsnowcurrently's post-merge review at https://github.com/python/cpython/pull/112425#discussion_r1406535569. I've verified locally that the second test here fails if you build CPython with https://github.com/python/cpython/commit/e954ac7205d7a6e356c1736eb372d2b50dbd9f69 (the commit prior to https://github.com/python/cpython/commit/0622839cfedacbb48eba27180fd0f0586fe97771).

@ericsnowcurrently, would you also like me to remove the test I added in https://github.com/python/cpython/commit/0622839cfedacbb48eba27180fd0f0586fe97771, or is that okay to stay? :)

<!-- gh-issue-number: gh-112414 -->
* Issue: gh-112414
<!-- /gh-issue-number -->
