### PR TITLE
[3.11] Backport PR #112477: correct socket AF_PACKET docs

### DIFF
--- a/Doc/library/socket.rst
+++ b/Doc/library/socket.rst
@@ -185,12 +185,11 @@ created.  Socket addresses are represented as follows:
   .. versionadded:: 3.7
 
 - :const:`AF_PACKET` is a low-level interface directly to network devices.
-  The packets are represented by the tuple
+  The addresses are represented by the tuple
   ``(ifname, proto[, pkttype[, hatype[, addr]]])`` where:
 
   - *ifname* - String specifying the device name.
-  - *proto* - An in network-byte-order integer specifying the Ethernet
-    protocol number.
+  - *proto* - An integer specifying the Ethernet protocol number.
   - *pkttype* - Optional integer specifying the packet type:
 
     - ``PACKET_HOST`` (the default) - Packet addressed to the local host.


### PR DESCRIPTION
Network byte order is not involved in the `int` on the Python side. That happens under the hood.

Correctly use the term addresses instead of packets.

backport of #112339.


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--112478.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->