### PR TITLE
Docs: fix markup for `importlib.machinery.NamespaceLoader`

### DIFF
--- a/Doc/library/importlib.rst
+++ b/Doc/library/importlib.rst
@@ -1145,7 +1145,7 @@ find and load modules.
       .. versionadded:: 3.4
 
 
-.. class:: NamespaceLoader(name, path, path_finder):
+.. class:: NamespaceLoader(name, path, path_finder)
 
    A concrete implementation of :class:`importlib.abc.InspectLoader` for
    namespace packages.  This is an alias for a private class and is only made


### PR DESCRIPTION
The markup for this class is incorrect, leading it to be rendered incorrectly by Sphinx, and meaning that there's no anchor on the HTML webpage that you can link to.

<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--112479.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->