### PR TITLE
[3.12] gh-105699: Re-enable the Multiple-Interpreters Stress Tests (gh-107572)

### DIFF
--- a/Lib/test/test_interpreters.py
+++ b/Lib/test/test_interpreters.py
@@ -468,7 +468,6 @@ class TestInterpreterRun(TestBase):
     # test_xxsubinterpreters covers the remaining Interpreter.run() behavior.
 
 
-@unittest.skip('these are crashing, likely just due just to _xxsubinterpreters (see gh-105699)')
 class StressTests(TestBase):
 
     # In these tests we generally want a lot of interpreters,


### PR DESCRIPTION
We had disabled them due to crashes they exposed, which have since been fixed.
(cherry picked from commit f9e3ff1)

(This is a repeat of gh-107783, which we had to revert.)


<!-- gh-issue-number: gh-105699 -->
* Issue: gh-105699
<!-- /gh-issue-number -->
