### PR TITLE
gh-112454: Disable TLS-PSK if OpenSSL was built without PSK support

### DIFF
--- a/Doc/library/ssl.rst
+++ b/Doc/library/ssl.rst
@@ -908,6 +908,12 @@ Constants
 
    .. versionadded:: 3.7
 
+.. data:: HAS_PSK
+
+   Whether the OpenSSL library has built-in support for TLS-PSK.
+
+   .. versionadded:: 3.13
+
 .. data:: CHANNEL_BINDING_TYPES
 
    List of supported TLS channel binding types.  Strings in this list
@@ -2050,6 +2056,9 @@ to speed up repeated connections from the same clients.
           return 'ClientId_1', psk_table.get(hint, b'')
       context.set_psk_client_callback(callback)
 
+   This method will raise :exc:`NotImplementedError` if :data:`HAS_PSK` is
+   ``False``.
+
    .. versionadded:: 3.13
 
 .. method:: SSLContext.set_psk_server_callback(callback, identity_hint=None)
@@ -2091,6 +2100,9 @@ to speed up repeated connections from the same clients.
       def callback(identity):
           return psk_table.get(identity, b'')
       context.set_psk_server_callback(callback, 'ServerId_1')
+
+   This method will raise :exc:`NotImplementedError` if :data:`HAS_PSK` is
+   ``False``.
 
    .. versionadded:: 3.13
 

--- a/Lib/ssl.py
+++ b/Lib/ssl.py
@@ -116,7 +116,7 @@ except ImportError:
 
 from _ssl import (
     HAS_SNI, HAS_ECDH, HAS_NPN, HAS_ALPN, HAS_SSLv2, HAS_SSLv3, HAS_TLSv1,
-    HAS_TLSv1_1, HAS_TLSv1_2, HAS_TLSv1_3
+    HAS_TLSv1_1, HAS_TLSv1_2, HAS_TLSv1_3, HAS_PSK
 )
 from _ssl import _DEFAULT_CIPHERS, _OPENSSL_API_VERSION
 

--- a/Lib/test/test_ssl.py
+++ b/Lib/test/test_ssl.py
@@ -4259,6 +4259,7 @@ class ThreadedTests(unittest.TestCase):
                                  'Session refers to a different SSLContext.')
 
     @requires_tls_version('TLSv1_2')
+    @unittest.skipUnless(ssl.HAS_PSK, 'TLS-PSK disabled on this OpenSSL build')
     def test_psk(self):
         psk = bytes.fromhex('deadbeef')
 
@@ -4326,6 +4327,7 @@ class ThreadedTests(unittest.TestCase):
                 s.connect((HOST, server.port))
 
     @requires_tls_version('TLSv1_3')
+    @unittest.skipUnless(ssl.HAS_PSK, 'TLS-PSK disabled on this OpenSSL build')
     def test_psk_tls1_3(self):
         psk = bytes.fromhex('deadbeef')
         identity_hint = 'identity-hint'


### PR DESCRIPTION
- If OpenSSL was built without PSK support, the python TLS-PSK methods will raise `NotImplementedError` if called
- Add a constant `ssl.HAS_PSK` to check if TLS-PSK is supported

As a side note (a mistake I made when trying to test this), make sure to build OpenSSL with:
```
./Configure no-psk
```
and **_not_**:
```
./Configure -DOPENSSL_NO_PSK
```
otherwise `OPENSSL_NO_PSK` is not available in the OpenSSL public headers.

CC: @gpshead 

<!-- gh-issue-number: gh-112454 -->
* Issue: gh-112454
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--112491.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->