### PR TITLE
gh-90102: Optimize io.FileIO.isatty()

### DIFF
--- a/Misc/NEWS.d/next/Library/2023-11-28-17-22-03.gh-issue-90102.JrgowE.rst
+++ b/Misc/NEWS.d/next/Library/2023-11-28-17-22-03.gh-issue-90102.JrgowE.rst
@@ -1,0 +1,2 @@
+Optimize :meth:`io.FileIO.isatty`. Only invoke the ``isatty()`` system call
+for character devices and cache the result. It also makes :func:`open` a bit faster.

--- a/Modules/_io/fileio.c
+++ b/Modules/_io/fileio.c
@@ -1151,11 +1151,13 @@ _io_FileIO_isatty_impl(fileio *self)
     if (self->fd < 0)
         return err_closed();
     if (self->isatty < 0) {
+        int res;
         Py_BEGIN_ALLOW_THREADS
         _Py_BEGIN_SUPPRESS_IPH
-        self->isatty = isatty(self->fd);
+        res = isatty(self->fd);
         _Py_END_SUPPRESS_IPH
         Py_END_ALLOW_THREADS
+        self->isatty = res;
     }
     return PyBool_FromLong(self->isatty);
 }


### PR DESCRIPTION
Only invoke the isatty() system call for character devices and cache the result.


<!-- gh-issue-number: gh-90102 -->
* Issue: gh-90102
<!-- /gh-issue-number -->
