### PR TITLE
Fix link to 'The Perils of Floating Point', on the tutorial

### DIFF
--- a/Doc/tutorial/floatingpoint.rst
+++ b/Doc/tutorial/floatingpoint.rst
@@ -150,7 +150,7 @@ section.  See `Examples of Floating Point Problems
 <https://jvns.ca/blog/2023/01/13/examples-of-floating-point-problems/>`_ for
 a pleasant summary of how binary floating-point works and the kinds of
 problems commonly encountered in practice.  Also see
-`The Perils of Floating Point <https://www.lahey.com/float.htm>`_
+`The Perils of Floating Point <https://www.stat.cmu.edu/~brian/711/week03/perils-of-floating-point.pdf>`_
 for a more complete account of other common surprises.
 
 As that says near the end, "there are no easy answers."  Still, don't be unduly

--- a/Doc/tutorial/floatingpoint.rst
+++ b/Doc/tutorial/floatingpoint.rst
@@ -150,7 +150,7 @@ section.  See `Examples of Floating Point Problems
 <https://jvns.ca/blog/2023/01/13/examples-of-floating-point-problems/>`_ for
 a pleasant summary of how binary floating-point works and the kinds of
 problems commonly encountered in practice.  Also see
-`The Perils of Floating Point <https://www.stat.cmu.edu/~brian/711/week03/perils-of-floating-point.pdf>`_
+`The Perils of Floating Point <http://www.indowsway.com/floatingpoint.htm>`_
 for a more complete account of other common surprises.
 
 As that says near the end, "there are no easy answers."  Still, don't be unduly


### PR DESCRIPTION
CPython Tutorial "15. Floating Point Arithmetic: Issues and Limitations" links to the document "The Perils of Floating Point", which was written by Bruce M. Bush in 1996, while working for Lahey Software Solutions. The document was hosted by this company, which ceased its activity last year. Fortunately, a copy of the document was kept by by Emeritus professor Brian Junker, from Carnegie Mellon University, which is the document I am linking to right now.

The document provide details on how floating point numbers are represented on computer systems and it should be interesting to keep this reference.



<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--112499.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->