### PR TITLE
gh-112125: Fix None.__ne__(None) returning NotImplemented instead of False

### DIFF
--- a/Include/internal/pycore_typeobject.h
+++ b/Include/internal/pycore_typeobject.h
@@ -135,6 +135,8 @@ extern PyObject* _Py_type_getattro_impl(PyTypeObject *type, PyObject *name,
                                         int *suppress_missing_attribute);
 extern PyObject* _Py_type_getattro(PyTypeObject *type, PyObject *name);
 
+extern PyObject* _Py_BaseObject_RichCompare(PyObject* self, PyObject* other, int op);
+
 extern PyObject* _Py_slot_tp_getattro(PyObject *self, PyObject *name);
 extern PyObject* _Py_slot_tp_getattr_hook(PyObject *self, PyObject *name);
 

--- a/Lib/test/test_builtin.py
+++ b/Lib/test/test_builtin.py
@@ -627,6 +627,11 @@ class BuiltinTest(unittest.TestCase):
         # test that object has a __dir__()
         self.assertEqual(sorted([].__dir__()), dir([]))
 
+    def test___ne__(self):
+        self.assertFalse(None.__ne__(None))
+        self.assertTrue(None.__ne__(0))
+        self.assertTrue(None.__ne__("abc"))
+
     def test_divmod(self):
         self.assertEqual(divmod(12, 7), (1, 5))
         self.assertEqual(divmod(-12, 7), (-2, 2))

--- a/Misc/NEWS.d/next/Core and Builtins/2023-12-07-13-19-55.gh-issue-112125.4ADN7i.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2023-12-07-13-19-55.gh-issue-112125.4ADN7i.rst
@@ -1,0 +1,1 @@
+Fix None.__ne__(None) returning NotImplemented instead of False

--- a/Objects/object.c
+++ b/Objects/object.c
@@ -2026,7 +2026,7 @@ PyTypeObject _PyNone_Type = {
     0,                  /*tp_doc */
     0,                  /*tp_traverse */
     0,                  /*tp_clear */
-    0,                  /*tp_richcompare */
+    _Py_BaseObject_RichCompare, /*tp_richcompare */
     0,                  /*tp_weaklistoffset */
     0,                  /*tp_iter */
     0,                  /*tp_iternext */

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -5625,6 +5625,12 @@ object_richcompare(PyObject *self, PyObject *other, int op)
     return res;
 }
 
+PyObject*
+_Py_BaseObject_RichCompare(PyObject* self, PyObject* other, int op)
+{
+    return object_richcompare(self, other, op);
+}
+
 static PyObject *
 object_get_class(PyObject *self, void *closure)
 {


### PR DESCRIPTION
<!-- gh-issue-number: gh-112125 -->
* Issue: gh-112125
<!-- /gh-issue-number -->

I tested this fix on Windows 11 with VS2022.  Compiled and ran `None.__ne__(None)` before and after my changes.  Result before: `NotImplemented`, after: `False`

Note: this is my first pull request/contributing and this code wasn't my original idea - thanks to @rhettinger for suggesting the route to fix this.  I only implemented the code.
