### PR TITLE
gh-112507 Detect Cygwin and MSYS with `uname` instead of `$OSTYPE`

### DIFF
--- a/Lib/venv/scripts/common/activate
+++ b/Lib/venv/scripts/common/activate
@@ -39,14 +39,18 @@ deactivate () {
 deactivate nondestructive
 
 # on Windows, a path can contain colons and backslashes and has to be converted:
-if [ "${OSTYPE:-}" = "cygwin" ] || [ "${OSTYPE:-}" = "msys" ] ; then
-    # transform D:\path\to\venv to /d/path/to/venv on MSYS
-    # and to /cygdrive/d/path/to/venv on Cygwin
-    export VIRTUAL_ENV=$(cygpath "__VENV_DIR__")
-else
-    # use the path as-is
-    export VIRTUAL_ENV="__VENV_DIR__"
-fi
+case "$(uname)" in
+    CYGWIN*|MSYS*)
+        # transform D:\path\to\venv to /d/path/to/venv on MSYS
+        # and to /cygdrive/d/path/to/venv on Cygwin
+        VIRTUAL_ENV=$(cygpath "__VENV_DIR__")
+        export VIRTUAL_ENV
+        ;;
+    *)
+        # use the path as-is
+        export VIRTUAL_ENV="__VENV_DIR__"
+        ;;
+esac
 
 _OLD_VIRTUAL_PATH="$PATH"
 PATH="$VIRTUAL_ENV/__VENV_BIN_NAME__:$PATH"


### PR DESCRIPTION
`$OSTYPE` is not defined by POSIX and may not be present in other shells. `uname` is always available in any shell.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-112507 -->
* Issue: gh-112507
<!-- /gh-issue-number -->
