### PR TITLE
gh-112510: Add `readline.backend` for the backend readline uses

### DIFF
--- a/Doc/library/readline.rst
+++ b/Doc/library/readline.rst
@@ -47,7 +47,7 @@ Readline library in general.
 
    The name of the underlying Readline library being used, either
    ``"readline"`` or ``"editline"``.
-   
+
    .. versionadded:: 3.13
 
 Init file

--- a/Doc/library/readline.rst
+++ b/Doc/library/readline.rst
@@ -27,16 +27,15 @@ Readline library in general.
 .. note::
 
   The underlying Readline library API may be implemented by
-  the ``libedit`` library instead of GNU readline.
+  the ``editline`` (``libedit``) library instead of GNU readline.
   On macOS the :mod:`readline` module detects which library is being used
   at run time.
 
-  The configuration file for ``libedit`` is different from that
+  The configuration file for ``editline`` is different from that
   of GNU readline. If you programmatically load configuration strings
-  you can check for the text "libedit" in :const:`readline.__doc__`
-  to differentiate between GNU readline and libedit.
+  you can use :data:`backend` to determine which library is being used.
 
-  If you use *editline*/``libedit`` readline emulation on macOS, the
+  If you use ``editline``/``libedit`` readline emulation on macOS, the
   initialization file located in your home directory is named
   ``.editrc``. For example, the following content in ``~/.editrc`` will
   turn ON *vi* keybindings and TAB completion::
@@ -44,6 +43,10 @@ Readline library in general.
     python:bind -v
     python:bind ^I rl_complete
 
+.. data:: backend
+
+   The name of the underlying Readline library being used, either
+   ``"readline"`` or ``"editline"``.
 
 Init file
 ---------

--- a/Doc/library/readline.rst
+++ b/Doc/library/readline.rst
@@ -47,6 +47,8 @@ Readline library in general.
 
    The name of the underlying Readline library being used, either
    ``"readline"`` or ``"editline"``.
+   
+   .. versionadded:: 3.13
 
 Init file
 ---------

--- a/Lib/site.py
+++ b/Lib/site.py
@@ -444,8 +444,7 @@ def enablerlcompleter():
 
         # Reading the initialization (config) file may not be enough to set a
         # completion key, so we set one first and then read the file.
-        readline_doc = getattr(readline, '__doc__', '')
-        if readline_doc is not None and 'libedit' in readline_doc:
+        if readline.backend == 'editline':
             readline.parse_and_bind('bind ^I rl_complete')
         else:
             readline.parse_and_bind('tab: complete')

--- a/Lib/test/test_pdb.py
+++ b/Lib/test/test_pdb.py
@@ -3293,7 +3293,7 @@ class PdbTestReadline(unittest.TestCase):
         # Ensure that the readline module is loaded
         # If this fails, the test is skipped because SkipTest will be raised
         readline = import_module('readline')
-        if readline.__doc__ and "libedit" in readline.__doc__:
+        if readline.backend == "editline":
             raise unittest.SkipTest("libedit readline is not supported for pdb")
 
     def test_basic_completion(self):

--- a/Lib/test/test_readline.py
+++ b/Lib/test/test_readline.py
@@ -145,6 +145,9 @@ class TestReadline(unittest.TestCase):
                                               TERM='xterm-256color')
         self.assertEqual(stdout, b'')
 
+    def test_backend(self):
+        self.assertIn(readline.backend, ("readline", "editline"))
+
     auto_history_script = """\
 import readline
 readline.set_auto_history({})

--- a/Lib/test/test_readline.py
+++ b/Lib/test/test_readline.py
@@ -19,7 +19,7 @@ readline = import_module('readline')
 if hasattr(readline, "_READLINE_LIBRARY_VERSION"):
     is_editline = ("EditLine wrapper" in readline._READLINE_LIBRARY_VERSION)
 else:
-    is_editline = (readline.__doc__ and "libedit" in readline.__doc__)
+    is_editline = readline.backend == "editline"
 
 
 def setUpModule():
@@ -198,7 +198,7 @@ print("History length:", readline.get_current_history_length())
 
         script = r"""import readline
 
-is_editline = readline.__doc__ and "libedit" in readline.__doc__
+is_editline = readline.backend == "editline"
 inserted = "[\xEFnserted]"
 macro = "|t\xEB[after]"
 set_pre_input_hook = getattr(readline, "set_pre_input_hook", None)

--- a/Lib/test/test_readline.py
+++ b/Lib/test/test_readline.py
@@ -171,7 +171,7 @@ print("History length:", readline.get_current_history_length())
                 if state == 0 and text == "$":
                     return "$complete"
                 return None
-            if "libedit" in getattr(readline, "__doc__", ""):
+            if readline.backend == "editline":
                 readline.parse_and_bind(r'bind "\\t" rl_complete')
             else:
                 readline.parse_and_bind(r'"\\t": complete')

--- a/Misc/NEWS.d/next/Library/2023-11-29-02-26-32.gh-issue-112510.j-zXGc.rst
+++ b/Misc/NEWS.d/next/Library/2023-11-29-02-26-32.gh-issue-112510.j-zXGc.rst
@@ -1,0 +1,1 @@
+Add :data:`readline.backend` for the backend readline uses (``editline`` or ``readline``)

--- a/Modules/readline.c
+++ b/Modules/readline.c
@@ -1571,8 +1571,7 @@ PyInit_readline(void)
         goto error;
     }
 
-    if (PyModule_AddStringConstant(m, "backend", backend) < 0)
-    {
+    if (PyModule_AddStringConstant(m, "backend", backend) < 0) {
         goto error;
     }
 

--- a/Modules/readline.c
+++ b/Modules/readline.c
@@ -1538,6 +1538,7 @@ static struct PyModuleDef readlinemodule = {
 PyMODINIT_FUNC
 PyInit_readline(void)
 {
+    const char *backend = "readline";
     PyObject *m;
     readlinestate *mod_state;
 
@@ -1545,8 +1546,10 @@ PyInit_readline(void)
         using_libedit_emulation = 1;
     }
 
-    if (using_libedit_emulation)
+    if (using_libedit_emulation) {
         readlinemodule.m_doc = doc_module_le;
+        backend = "editline";
+    }
 
 
     m = PyModule_Create(&readlinemodule);
@@ -1564,6 +1567,11 @@ PyInit_readline(void)
     }
     if (PyModule_AddStringConstant(m, "_READLINE_LIBRARY_VERSION",
                                    rl_library_version) < 0)
+    {
+        goto error;
+    }
+
+    if (PyModule_AddStringConstant(m, "backend", backend) < 0)
     {
         goto error;
     }


### PR DESCRIPTION


<!-- gh-issue-number: gh-112510 -->
* Issue: gh-112510
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--112511.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->