### PR TITLE
gh-105323: Remove `WITH_APPLE_EDITLINE` to use the same declaration for all editline

### DIFF
--- a/Misc/NEWS.d/next/Library/2023-11-29-04-43-32.gh-issue-105323.zelrW9.rst
+++ b/Misc/NEWS.d/next/Library/2023-11-29-04-43-32.gh-issue-105323.zelrW9.rst
@@ -1,0 +1,1 @@
+Remove ``WITH_APPLE_EDITLINE`` to use the same declaration for all ``editline``

--- a/Misc/NEWS.d/next/Library/2023-11-29-04-43-32.gh-issue-105323.zelrW9.rst
+++ b/Misc/NEWS.d/next/Library/2023-11-29-04-43-32.gh-issue-105323.zelrW9.rst
@@ -1,1 +1,0 @@
-Remove ``WITH_APPLE_EDITLINE`` to use the same declaration for all ``editline``

--- a/Modules/readline.c
+++ b/Modules/readline.c
@@ -1043,10 +1043,8 @@ on_hook(PyObject *func)
 static int
 #if defined(_RL_FUNCTION_TYPEDEF)
 on_startup_hook(void)
-#elif defined(WITH_APPLE_EDITLINE)
-on_startup_hook(const char *Py_UNUSED(text), int Py_UNUSED(state))
 #else
-on_startup_hook(void)
+on_startup_hook(const char *Py_UNUSED(text), int Py_UNUSED(state))
 #endif
 {
     int r;
@@ -1065,10 +1063,8 @@ on_startup_hook(void)
 static int
 #if defined(_RL_FUNCTION_TYPEDEF)
 on_pre_input_hook(void)
-#elif defined(WITH_APPLE_EDITLINE)
-on_pre_input_hook(const char *Py_UNUSED(text), int Py_UNUSED(state))
 #else
-on_pre_input_hook(void)
+on_pre_input_hook(const char *Py_UNUSED(text), int Py_UNUSED(state))
 #endif
 {
     int r;

--- a/configure
+++ b/configure
@@ -23971,7 +23971,6 @@ fi
 
 
 
-
 # Check whether --with-readline was given.
 if test ${with_readline+y}
 then :
@@ -23993,22 +23992,6 @@ else $as_nop
 
 fi
 
-
-# gh-105323: Need to handle the macOS editline as an alias of readline.
-case $ac_sys_system/$ac_sys_release in #(
-  Darwin/*) :
-    ac_fn_c_check_type "$LINENO" "Function" "ac_cv_type_Function" "#include <readline/readline.h>
-"
-if test "x$ac_cv_type_Function" = xyes
-then :
-  printf "%s\n" "#define WITH_APPLE_EDITLINE 1" >>confdefs.h
-
-fi
- ;; #(
-  *) :
-
- ;;
-esac
 
 if test "x$with_readline" = xreadline
 then :

--- a/configure.ac
+++ b/configure.ac
@@ -5914,7 +5914,6 @@ dnl library (tinfo ncursesw ncurses termcap). We now assume that libreadline
 dnl or readline.pc provide correct linker information.
 
 AH_TEMPLATE([WITH_EDITLINE], [Define to build the readline module against libedit.])
-AH_TEMPLATE([WITH_APPLE_EDITLINE], [Define to build the readline module against Apple BSD editline.])
 
 AC_ARG_WITH(
   [readline],
@@ -5929,15 +5928,6 @@ AC_ARG_WITH(
     )
   ],
   [with_readline=readline]
-)
-
-# gh-105323: Need to handle the macOS editline as an alias of readline.
-AS_CASE([$ac_sys_system/$ac_sys_release],
-  [Darwin/*], [AC_CHECK_TYPE([Function],
-                             [AC_DEFINE([WITH_APPLE_EDITLINE])],
-                             [],
-                             [@%:@include <readline/readline.h>])],
-  []
 )
 
 AS_VAR_IF([with_readline], [readline], [

--- a/pyconfig.h.in
+++ b/pyconfig.h.in
@@ -1800,9 +1800,6 @@
 /* Define if WINDOW in curses.h offers a field _flags. */
 #undef WINDOW_HAS_FLAGS
 
-/* Define to build the readline module against Apple BSD editline. */
-#undef WITH_APPLE_EDITLINE
-
 /* Define if you want build the _decimal module using a coroutine-local rather
    than a thread-local context */
 #undef WITH_DECIMAL_CONTEXTVAR


### PR DESCRIPTION
See the discussion in https://github.com/python/cpython/issues/105323#issuecomment-1831052024

<!-- gh-issue-number: gh-105323 -->
* Issue: gh-105323
<!-- /gh-issue-number -->
