### PR TITLE
gh-112451: Make C-extension datetime.timezone acceptable as a base class.

### DIFF
--- a/Lib/test/test_types.py
+++ b/Lib/test/test_types.py
@@ -642,6 +642,11 @@ class TypesTests(unittest.TestCase):
     def test_capsule_type(self):
         self.assertIsInstance(_datetime.datetime_CAPI, types.CapsuleType)
 
+    def test_timezone_base_type(self):
+        class MyTimezone(_datetime.timezone):
+            pass
+
+        self.assertIs(issubclass(MyTimezone, _datetime.timezone), True)
 
 class UnionTests(unittest.TestCase):
 

--- a/Misc/NEWS.d/next/Library/2024-01-15-13-45-26.gh-issue-112451.KFFlYs.rst
+++ b/Misc/NEWS.d/next/Library/2024-01-15-13-45-26.gh-issue-112451.KFFlYs.rst
@@ -1,0 +1,1 @@
+Make C-extension ``datetime.timezone`` acceptable as a base class.

--- a/Modules/_datetimemodule.c
+++ b/Modules/_datetimemodule.c
@@ -4107,7 +4107,7 @@ static PyTypeObject PyDateTime_TimeZoneType = {
     0,                                /* tp_getattro */
     0,                                /* tp_setattro */
     0,                                /* tp_as_buffer */
-    Py_TPFLAGS_DEFAULT,               /* tp_flags */
+    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE, /* tp_flags */
     timezone_doc,                     /* tp_doc */
     0,                                /* tp_traverse */
     0,                                /* tp_clear */


### PR DESCRIPTION
Should we implement `tp_alloc` for `datetime.timezone`? :thinking: Can do if it's required.

<!-- gh-issue-number: gh-112451 -->
* Issue: gh-112451
<!-- /gh-issue-number -->
