### PR TITLE
gh-111699: Fix smtpd locale in What's New in Python 3.12 docs

### DIFF
--- a/Doc/whatsnew/3.12.rst
+++ b/Doc/whatsnew/3.12.rst
@@ -1640,7 +1640,10 @@ locale
   use :func:`locale.format_string` instead.
   (Contributed by Victor Stinner in :gh:`94226`.)
 
-* ``smtpd``: The module has been removed according to the schedule in :pep:`594`,
+smtpd
+-----
+
+* The ``smtpd`` module has been removed according to the schedule in :pep:`594`,
   having been deprecated in Python 3.4.7 and 3.5.4.
   Use aiosmtpd_ PyPI module or any other
   :mod:`asyncio`-based server instead.

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -1459,6 +1459,7 @@ Paul Prescod
 Donovan Preston
 Eric Price
 Paul Price
+Matt Prodani
 Iuliia Proskurnia
 Dorian Pula
 Jyrki Pulliainen

--- a/Misc/NEWS.d/next/Documentation/2023-11-30-02-19-23.gh-issue-111699.PN0ZwF.rst
+++ b/Misc/NEWS.d/next/Documentation/2023-11-30-02-19-23.gh-issue-111699.PN0ZwF.rst
@@ -1,0 +1,1 @@
+In `What's new in Python 3.12` docs, relocate `smtpd` module deprecation notice to it's own section rather than under `locale`.


### PR DESCRIPTION
In `What's new in Python 3.12` docs, relocate `smtpd` module deprecation notice to it's own section rather than under `locale`.
<!-- gh-issue-number: gh-111699 -->
* Issue: gh-111699
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--112543.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->