### PR TITLE
gh-111699: Move smtpd note to dedicated section in What's New Python 3.12 doc

### DIFF
--- a/Doc/whatsnew/3.12.rst
+++ b/Doc/whatsnew/3.12.rst
@@ -1640,7 +1640,10 @@ locale
   use :func:`locale.format_string` instead.
   (Contributed by Victor Stinner in :gh:`94226`.)
 
-* ``smtpd``: The module has been removed according to the schedule in :pep:`594`,
+smtpd
+-----
+
+* The ``smtpd`` module has been removed according to the schedule in :pep:`594`,
   having been deprecated in Python 3.4.7 and 3.5.4.
   Use aiosmtpd_ PyPI module or any other
   :mod:`asyncio`-based server instead.

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -1459,6 +1459,7 @@ Paul Prescod
 Donovan Preston
 Eric Price
 Paul Price
+Matt Prodani
 Iuliia Proskurnia
 Dorian Pula
 Jyrki Pulliainen

--- a/Misc/NEWS.d/next/Documentation/2023-11-30-02-33-59.gh-issue-111699._O5G_y.rst
+++ b/Misc/NEWS.d/next/Documentation/2023-11-30-02-33-59.gh-issue-111699._O5G_y.rst
@@ -1,0 +1,1 @@
+Relocate ``smtpd`` deprecation notice to its own section rather than under ``locale`` in What's New in Python 3.12 document


### PR DESCRIPTION
Relocate smtpd deprecation notice to its own section rather than under 'locale' in docs for What's New in Python 3.12 doc


<!-- gh-issue-number: gh-111699 -->
* Issue: gh-111699
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--112544.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->