### PR TITLE
IDLE: fix config_key htest

### DIFF
--- a/Lib/idlelib/config_key.py
+++ b/Lib/idlelib/config_key.py
@@ -351,4 +351,4 @@ if __name__ == '__main__':
     main('idlelib.idle_test.test_config_key', verbosity=2, exit=False)
 
     from idlelib.idle_test.htest import run
-    run(GetKeysDialog)
+    run(GetKeysWindow)

--- a/Lib/idlelib/idle_test/htest.py
+++ b/Lib/idlelib/idle_test/htest.py
@@ -152,7 +152,7 @@ _editor_window_spec = {
            "Best to close editor first."
     }
 
-GetKeysDialog_spec = {
+GetKeysWindow_spec = {
     'file': 'config_key',
     'kwds': {'title': 'Test keybindings',
              'action': 'find-again',


### PR DESCRIPTION
Change 'Dialog' to 'Window' in two places to match the name of the config_key class being tested.
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
