### PR TITLE
gh-112502: Docs: Improve docs for gc.collect method

### DIFF
--- a/Doc/library/gc.rst
+++ b/Doc/library/gc.rst
@@ -42,8 +42,8 @@ The :mod:`gc` module provides the following functions:
 
    With no arguments, run a full collection.  The optional argument *generation*
    may be an integer specifying which generation to collect (from 0 to 2).  A
-   :exc:`ValueError` is raised if the generation number  is invalid. The number of
-   objects collected plus the number of uncollectable objects returned.
+   :exc:`ValueError` is raised if the generation number  is invalid. The sum of
+   collected objects and uncollectable objects is returned.
 
    The free lists maintained for a number of built-in types are cleared
    whenever a full collection or collection of the highest generation (2)

--- a/Doc/library/gc.rst
+++ b/Doc/library/gc.rst
@@ -43,7 +43,7 @@ The :mod:`gc` module provides the following functions:
    With no arguments, run a full collection.  The optional argument *generation*
    may be an integer specifying which generation to collect (from 0 to 2).  A
    :exc:`ValueError` is raised if the generation number  is invalid. The number of
-   unreachable objects found is returned.
+   objects collected plus the number of uncollectable objects returned.
 
    The free lists maintained for a number of built-in types are cleared
    whenever a full collection or collection of the highest generation (2)


### PR DESCRIPTION
Refined the documentation for the `gc.collect()` function to provide a more accurate description of its behavior. Specifically, updated the documentation to reflect that the function now returns the sum of the number of objects collected and the number of uncollectable objects. This adjustment aligns the documentation with the existing implementation in gcmodule.c, where the stats returned by `gc.collect()` include both collected and uncollectable objects.

No changes were made to the gcmodule.c code; this modification focuses solely on improving the clarity of the documentation.

- issue: gh-112502