### PR TITLE
gh-112567: Add _PyTimeFraction C API

### DIFF
--- a/Include/internal/pycore_time.h
+++ b/Include/internal/pycore_time.h
@@ -253,13 +253,6 @@ PyAPI_FUNC(void) _PyTime_AsTimespec_clamp(_PyTime_t t, struct timespec *ts);
 // Compute t1 + t2. Clamp to [_PyTime_MIN; _PyTime_MAX] on overflow.
 extern _PyTime_t _PyTime_Add(_PyTime_t t1, _PyTime_t t2);
 
-// Compute ticks * mul / div.
-// Clamp to [_PyTime_MIN; _PyTime_MAX] on overflow.
-// The caller must ensure that ((div - 1) * mul) cannot overflow.
-extern _PyTime_t _PyTime_MulDiv(_PyTime_t ticks,
-    _PyTime_t mul,
-    _PyTime_t div);
-
 // Structure used by time.get_clock_info()
 typedef struct {
     const char *implementation;
@@ -353,6 +346,32 @@ PyAPI_FUNC(_PyTime_t) _PyDeadline_Init(_PyTime_t timeout);
 // Pseudo code: deadline - _PyTime_GetMonotonicClock().
 // Export for '_ssl' shared extension.
 PyAPI_FUNC(_PyTime_t) _PyDeadline_Get(_PyTime_t deadline);
+
+
+// --- _PyTimeFraction -------------------------------------------------------
+
+typedef struct {
+    _PyTime_t numer;
+    _PyTime_t denom;
+} _PyTimeFraction;
+
+// Set a fraction.
+// Return 0 on success.
+// Return -1 if the fraction is invalid.
+extern int _PyTimeFraction_Set(
+    _PyTimeFraction *frac,
+    _PyTime_t numer,
+    _PyTime_t denom);
+
+// Compute ticks * frac.numer / frac.denom.
+// Clamp to [_PyTime_MIN; _PyTime_MAX] on overflow.
+extern _PyTime_t _PyTimeFraction_Mul(
+    _PyTime_t ticks,
+    const _PyTimeFraction *frac);
+
+// Compute a clock resolution: frac.numer / frac.denom / 1e9.
+extern double _PyTimeFraction_Resolution(
+    const _PyTimeFraction *frac);
 
 
 #ifdef __cplusplus


### PR DESCRIPTION
Use a fraction internally in the _PyTime API to reduce the risk of integer overflow: simplify the fraction using Greatest Common Denominator (GCD). The fraction API is used by time functions: perf_counter(), monotonic() and process_time().

For example, QueryPerformanceFrequency() usually returns 10 MHz on Windows 10 and newer. The fraction SEC_TO_NS / frequency = 1_000_000_000 / 10_000_000 can be simplified to 100 / 1.

* Add _PyTimeFraction type.
* Add functions:

  * _Py_GetTicksPerSecond()
  * _PyTimeFraction_Set()
  * _PyTimeFraction_Mul()
  * _PyTimeFraction_Resolution()

* Remove _PyTime_Init().
* Remove _PyRuntimeState.time member.
* os.times() now calls _Py_GetTicksPerSecond().
* Rename _PyTime_GetClockWithInfo() to py_clock().

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-112567 -->
* Issue: gh-112567
<!-- /gh-issue-number -->
