### PR TITLE
gh-109413: libregrtest: enable mypy's `--strict-optional` check on most files

### DIFF
--- a/Lib/test/libregrtest/mypy.ini
+++ b/Lib/test/libregrtest/mypy.ini
@@ -25,7 +25,7 @@ warn_return_any = False
 disable_error_code = return
 
 # Enable --strict-optional for these ASAP:
-[mypy-Lib.test.libregrtest.main.*,Lib.test.libregrtest.run_workers.*,Lib.test.libregrtest.worker.*,Lib.test.libregrtest.single.*,Lib.test.libregrtest.results.*,Lib.test.libregrtest.utils.*]
+[mypy-Lib.test.libregrtest.main.*,Lib.test.libregrtest.run_workers.*]
 strict_optional = False
 
 # Various internal modules that typeshed deliberately doesn't have stubs for:

--- a/Lib/test/libregrtest/results.py
+++ b/Lib/test/libregrtest/results.py
@@ -31,7 +31,7 @@ class TestResults:
 
         self.interrupted: bool = False
         self.worker_bug: bool = False
-        self.test_times: list[tuple[float | None, TestName]] = []
+        self.test_times: list[tuple[float, TestName]] = []
         self.stats = TestStats()
         # used by --junit-xml
         self.testsuite_xml: list = []
@@ -117,6 +117,8 @@ class TestResults:
             self.worker_bug = True
 
         if result.has_meaningful_duration() and not rerun:
+            if result.duration is None:
+                raise RuntimeError("result.duration was unexpectedly None!")
             self.test_times.append((result.duration, test_name))
         if result.stats is not None:
             self.stats.accumulate(result.stats)

--- a/Lib/test/libregrtest/results.py
+++ b/Lib/test/libregrtest/results.py
@@ -31,7 +31,7 @@ class TestResults:
 
         self.interrupted: bool = False
         self.worker_bug: bool = False
-        self.test_times: list[tuple[float, TestName]] = []
+        self.test_times: list[tuple[float | None, TestName]] = []
         self.stats = TestStats()
         # used by --junit-xml
         self.testsuite_xml: list = []

--- a/Lib/test/libregrtest/results.py
+++ b/Lib/test/libregrtest/results.py
@@ -118,7 +118,7 @@ class TestResults:
 
         if result.has_meaningful_duration() and not rerun:
             if result.duration is None:
-                raise RuntimeError("result.duration was unexpectedly None!")
+                raise ValueError("result.duration is None")
             self.test_times.append((result.duration, test_name))
         if result.stats is not None:
             self.stats.accumulate(result.stats)

--- a/Lib/test/libregrtest/runtests.py
+++ b/Lib/test/libregrtest/runtests.py
@@ -93,7 +93,7 @@ class RunTests:
     python_cmd: tuple[str, ...] | None
     randomize: bool
     random_seed: int | str
-    json_file: JsonFile | None
+    json_file: JsonFile
 
     def copy(self, **override):
         state = dataclasses.asdict(self)

--- a/Lib/test/libregrtest/runtests.py
+++ b/Lib/test/libregrtest/runtests.py
@@ -93,7 +93,7 @@ class RunTests:
     python_cmd: tuple[str, ...] | None
     randomize: bool
     random_seed: int | str
-    json_file: JsonFile
+    json_file: JsonFile | None
 
     def copy(self, **override):
         state = dataclasses.asdict(self)

--- a/Lib/test/libregrtest/single.py
+++ b/Lib/test/libregrtest/single.py
@@ -237,11 +237,11 @@ def _runtest(result: TestResult, runtests: RunTests) -> None:
     output_on_failure = runtests.output_on_failure
     timeout = runtests.timeout
 
-    use_timeout = (
-        timeout is not None and threading_helper.can_start_thread
-    )
-    if use_timeout:
+    if timeout is not None and threading_helper.can_start_thread:
+        use_timeout = True
         faulthandler.dump_traceback_later(timeout, exit=True)
+    else:
+        use_timeout = False
 
     try:
         setup_tests(runtests)

--- a/Lib/test/libregrtest/utils.py
+++ b/Lib/test/libregrtest/utils.py
@@ -377,10 +377,19 @@ def get_temp_dir(tmp_dir: StrPath | None = None) -> StrPath:
                         # Python out of the source tree, especially when the
                         # source tree is read only.
                         tmp_dir = sysconfig.get_config_var('srcdir')
+                        if not tmp_dir:
+                            raise RuntimeError(
+                                "Could not determine the correct value for tmp_dir"
+                            )
                 tmp_dir = os.path.join(tmp_dir, 'build')
             else:
                 # WASI platform
                 tmp_dir = sysconfig.get_config_var('projectbase')
+                if tmp_dir is None:
+                    raise RuntimeError(
+                        "sysconfig.get_config_var('projectbase') "
+                        "unexpectedly returned `None` on WASI"
+                    )
                 tmp_dir = os.path.join(tmp_dir, 'build')
 
                 # When get_temp_dir() is called in a worker process,

--- a/Lib/test/libregrtest/utils.py
+++ b/Lib/test/libregrtest/utils.py
@@ -385,10 +385,10 @@ def get_temp_dir(tmp_dir: StrPath | None = None) -> StrPath:
             else:
                 # WASI platform
                 tmp_dir = sysconfig.get_config_var('projectbase')
-                if tmp_dir is None:
+                if not tmp_dir:
                     raise RuntimeError(
                         "sysconfig.get_config_var('projectbase') "
-                        "unexpectedly returned `None` on WASI"
+                        f"unexpectedly returned {tmp_dir!r} on WASI"
                     )
                 tmp_dir = os.path.join(tmp_dir, 'build')
 


### PR DESCRIPTION
Mypy's `--strict-optional` check is one of its most important checks, and it's enabled by default when you run mypy. It warns you if it infers that an object might be of type `Foo | None` at runtime, even though the code is only guaranteed to work if the object is an instance of `Foo`.

We currently have `--strict-optional` disabled on several files, as there were too many errors to deal with initially, and the priority was to have mypy enabled in CI so that we could work on improving the type annotations incrementally. This PR re-enables `--strict-optional` on four files where it's easy to do so.

<!-- gh-issue-number: gh-109413 -->
* Issue: gh-109413
<!-- /gh-issue-number -->
