### PR TITLE
[3.12] gh-109413: libregrtest: enable mypy's `--strict-optional` check on most files (#112586)

### DIFF
--- a/Lib/test/libregrtest/mypy.ini
+++ b/Lib/test/libregrtest/mypy.ini
@@ -1,0 +1,33 @@
+# Config file for running mypy on libregrtest.
+# Run mypy by invoking `mypy --config-file Lib/test/libregrtest/mypy.ini`
+# on the command-line from the repo root
+
+[mypy]
+files = Lib/test/libregrtest
+explicit_package_bases = True
+python_version = 3.12
+platform = linux
+pretty = True
+
+# Enable most stricter settings
+enable_error_code = ignore-without-code
+strict = True
+
+# Various stricter settings that we can't yet enable
+# Try to enable these in the following order:
+disallow_any_generics = False
+disallow_incomplete_defs = False
+disallow_untyped_calls = False
+disallow_untyped_defs = False
+check_untyped_defs = False
+warn_return_any = False
+
+disable_error_code = return
+
+# Enable --strict-optional for these ASAP:
+[mypy-Lib.test.libregrtest.main.*,Lib.test.libregrtest.run_workers.*]
+strict_optional = False
+
+# Various internal modules that typeshed deliberately doesn't have stubs for:
+[mypy-_abc.*,_opcode.*,_overlapped.*,_testcapi.*,_testinternalcapi.*,test.*]
+ignore_missing_imports = True

--- a/Lib/test/libregrtest/results.py
+++ b/Lib/test/libregrtest/results.py
@@ -114,6 +114,8 @@ class TestResults:
             self.worker_bug = True
 
         if result.has_meaningful_duration() and not rerun:
+            if result.duration is None:
+                raise ValueError("result.duration is None")
             self.test_times.append((result.duration, test_name))
         if result.stats is not None:
             self.stats.accumulate(result.stats)

--- a/Lib/test/libregrtest/single.py
+++ b/Lib/test/libregrtest/single.py
@@ -237,11 +237,11 @@ def _runtest(result: TestResult, runtests: RunTests) -> None:
     output_on_failure = runtests.output_on_failure
     timeout = runtests.timeout
 
-    use_timeout = (
-        timeout is not None and threading_helper.can_start_thread
-    )
-    if use_timeout:
+    if timeout is not None and threading_helper.can_start_thread:
+        use_timeout = True
         faulthandler.dump_traceback_later(timeout, exit=True)
+    else:
+        use_timeout = False
 
     try:
         setup_tests(runtests)

--- a/Lib/test/libregrtest/utils.py
+++ b/Lib/test/libregrtest/utils.py
@@ -377,10 +377,19 @@ def get_temp_dir(tmp_dir: StrPath | None = None) -> StrPath:
                         # Python out of the source tree, especially when the
                         # source tree is read only.
                         tmp_dir = sysconfig.get_config_var('srcdir')
+                        if not tmp_dir:
+                            raise RuntimeError(
+                                "Could not determine the correct value for tmp_dir"
+                            )
                 tmp_dir = os.path.join(tmp_dir, 'build')
             else:
                 # WASI platform
                 tmp_dir = sysconfig.get_config_var('projectbase')
+                if not tmp_dir:
+                    raise RuntimeError(
+                        "sysconfig.get_config_var('projectbase') "
+                        f"unexpectedly returned {tmp_dir!r} on WASI"
+                    )
                 tmp_dir = os.path.join(tmp_dir, 'build')
 
                 # When get_temp_dir() is called in a worker process,


### PR DESCRIPTION
(cherry-picked from commit 70a38ffb3d712f973eb17bd1bda541f238ae70d2 )

Note: I'm deliberately backporting the entire mypy config file to the 3.12 branch, even though we don't run mypy on `libregrtest` on the 3.12 branch. Having the config file _exist_ on this branch will make future backports easier, even if the file is never actually _used_ on this branch.

<!-- gh-issue-number: gh-109413 -->
* Issue: gh-109413
<!-- /gh-issue-number -->
