### PR TITLE
gh-106560: Fix redundant declarations in Include/

### DIFF
--- a/Include/boolobject.h
+++ b/Include/boolobject.h
@@ -7,7 +7,7 @@ extern "C" {
 #endif
 
 
-PyAPI_DATA(PyTypeObject) PyBool_Type;
+// PyBool_Type is declared by object.h
 
 #define PyBool_Check(x) Py_IS_TYPE((x), &PyBool_Type)
 

--- a/Include/cpython/sysmodule.h
+++ b/Include/cpython/sysmodule.h
@@ -4,10 +4,6 @@
 
 typedef int(*Py_AuditHookFunction)(const char *, PyObject *, void *);
 
-PyAPI_FUNC(int) PySys_Audit(
-    const char *event,
-    const char *format,
-    ...);
 PyAPI_FUNC(int) PySys_AddAuditHook(Py_AuditHookFunction, void*);
 
 typedef struct {

--- a/Include/longobject.h
+++ b/Include/longobject.h
@@ -7,7 +7,7 @@ extern "C" {
 
 /* Long (arbitrary precision) integer object interface */
 
-PyAPI_DATA(PyTypeObject) PyLong_Type;
+// PyLong_Type is declared by object.h
 
 #define PyLong_Check(op) \
         PyType_FastSubclass(Py_TYPE(op), Py_TPFLAGS_LONG_SUBCLASS)

--- a/Misc/NEWS.d/next/C API/2023-12-02-02-08-11.gh-issue-106560.THvuji.rst
+++ b/Misc/NEWS.d/next/C API/2023-12-02-02-08-11.gh-issue-106560.THvuji.rst
@@ -1,0 +1,2 @@
+Fix redundant declarations in the public C API. Declare PyBool_Type,
+PyLong_Type and PySys_Audit() only once. Patch by Victor Stinner.


### PR DESCRIPTION
Don't declare PyBool_Type, PyLong_Type and PySys_Audit() twice, but only once.

Compiler warnings seen by building Python with gcc -Wredundant-decls.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-106560 -->
* Issue: gh-106560
<!-- /gh-issue-number -->
