### PR TITLE
gh-105967: Work around a macOS bug, limit zlib C library crc32 API calls to 1gig

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2023-12-01-19-02-21.gh-issue-105967.Puq5Cn.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2023-12-01-19-02-21.gh-issue-105967.Puq5Cn.rst
@@ -1,3 +1,4 @@
 Workaround a bug in Apple's macOS platform zlib library where
-:mod:`zlib.crc32` and :mod:`binascii.crc32` could produce incorrect results
-on multi-gigabyte inputs.
+:func:`zlib.crc32` and :func:`binascii.crc32` could produce incorrect results
+on multi-gigabyte inputs. Including when using :mod:`zipfile` on zips
+containing large data.

--- a/Misc/NEWS.d/next/Core and Builtins/2023-12-01-19-02-21.gh-issue-105967.Puq5Cn.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2023-12-01-19-02-21.gh-issue-105967.Puq5Cn.rst
@@ -1,0 +1,3 @@
+Workaround a bug in Apple's macOS platform zlib library where
+:mod:`zlib.crc32` and :mod:`binascii.crc32` could produce incorrect results
+on multi-gigabyte inputs.


### PR DESCRIPTION
Without this, `zlib.crc32` and `binascii.crc32` could produce incorrect results on multi-gigabyte inputs depending on the macOS version's Apple supplied zlib implementation.

Fixes #105967.

<!-- gh-issue-number: gh-105967 -->
* Issue: gh-105967
<!-- /gh-issue-number -->
