### PR TITLE
gh-112606: Use `pthread_cond_timedwait_relative_np` in parking_lot.c when available

### DIFF
--- a/Python/parking_lot.c
+++ b/Python/parking_lot.c
@@ -155,7 +155,6 @@ _PySemaphore_PlatformWait(_PySemaphore *sema, _PyTime_t timeout)
 #else
     pthread_mutex_lock(&sema->mutex);
     int err = 0;
-
     if (sema->counter == 0) {
         if (timeout >= 0) {
             struct timespec ts;

--- a/Python/parking_lot.c
+++ b/Python/parking_lot.c
@@ -155,14 +155,19 @@ _PySemaphore_PlatformWait(_PySemaphore *sema, _PyTime_t timeout)
 #else
     pthread_mutex_lock(&sema->mutex);
     int err = 0;
+
     if (sema->counter == 0) {
         if (timeout >= 0) {
             struct timespec ts;
-
+#if defined(HAVE_PTHREAD_COND_TIMEDWAIT_RELATIVE_NP)
+            _PyTime_AsTimespec_clamp(timeout, &ts);
+            err = pthread_cond_timedwait_relative_np(&sema->cond, &sema->mutex, &ts);
+#else
             _PyTime_t deadline = _PyTime_Add(_PyTime_GetSystemClock(), timeout);
             _PyTime_AsTimespec_clamp(deadline, &ts);
 
             err = pthread_cond_timedwait(&sema->cond, &sema->mutex, &ts);
+#endif // HAVE_PTHREAD_COND_TIMEDWAIT_RELATIVE_NP
         }
         else {
             err = pthread_cond_wait(&sema->cond, &sema->mutex);

--- a/configure
+++ b/configure
@@ -17872,6 +17872,12 @@ then :
   printf "%s\n" "#define HAVE_PREADV2 1" >>confdefs.h
 
 fi
+ac_fn_c_check_func "$LINENO" "pthread_cond_timedwait_relative_np" "ac_cv_func_pthread_cond_timedwait_relative_np"
+if test "x$ac_cv_func_pthread_cond_timedwait_relative_np" = xyes
+then :
+  printf "%s\n" "#define HAVE_PTHREAD_COND_TIMEDWAIT_RELATIVE_NP 1" >>confdefs.h
+
+fi
 ac_fn_c_check_func "$LINENO" "pthread_condattr_setclock" "ac_cv_func_pthread_condattr_setclock"
 if test "x$ac_cv_func_pthread_condattr_setclock" = xyes
 then :

--- a/configure.ac
+++ b/configure.ac
@@ -4796,8 +4796,8 @@ AC_CHECK_FUNCS([ \
   mknod mknodat mktime mmap mremap nice openat opendir pathconf pause pipe \
   pipe2 plock poll posix_fadvise posix_fallocate posix_openpt posix_spawn posix_spawnp \
   posix_spawn_file_actions_addclosefrom_np \
-  pread preadv preadv2 pthread_condattr_setclock pthread_init pthread_kill ptsname ptsname_r \
-  pwrite pwritev pwritev2 readlink readlinkat readv realpath renameat \
+  pread preadv preadv2 pthread_cond_timedwait_relative_np pthread_condattr_setclock pthread_init \
+  pthread_kill ptsname ptsname_r pwrite pwritev pwritev2 readlink readlinkat readv realpath renameat \
   rtpSpawn sched_get_priority_max sched_rr_get_interval sched_setaffinity \
   sched_setparam sched_setscheduler sem_clockwait sem_getvalue sem_open \
   sem_timedwait sem_unlink sendfile setegid seteuid setgid sethostname \

--- a/pyconfig.h.in
+++ b/pyconfig.h.in
@@ -936,6 +936,10 @@
 /* Define to 1 if you have the `pthread_condattr_setclock' function. */
 #undef HAVE_PTHREAD_CONDATTR_SETCLOCK
 
+/* Define to 1 if you have the `pthread_cond_timedwait_relative_np' function.
+   */
+#undef HAVE_PTHREAD_COND_TIMEDWAIT_RELATIVE_NP
+
 /* Defined for Solaris 2.6 bug in pthread header. */
 #undef HAVE_PTHREAD_DESTRUCTOR
 


### PR DESCRIPTION

Updates parking_lot.c to prefer functions that support CLOCK_MONOTONIC for semaphore and pthread_cond_t based implementations of _PySemaphore_PlatformWait. 


_Updated_: to instead use  [`pthread_cond_timedwait_relative_np`](https://github.com/apple-oss-distributions/libpthread/blob/d8c4e3c212553d3e0f5d76bb7d45a8acd61302dc/include/pthread/pthread.h#L556-L559) with a relative timeout which is supported on MacOS, unlike `pthread_condattr_setclock(..., CLOCK_MONOTONIC)`. Part of work to make `parking_lot.c` timing more accurate.

Linked to [PR](https://github.com/python/cpython/pull/112733) for POSIX semaphores.
<!-- gh-issue-number: gh-112606 -->
* Issue: gh-112606
<!-- /gh-issue-number -->
