### PR TITLE
gh-112620: Fix dis error on show_cache with labels

### DIFF
--- a/Lib/test/test_dis.py
+++ b/Lib/test/test_dis.py
@@ -1896,6 +1896,18 @@ class InstructionTests(InstructionTestCase):
                                   positions=None)
         self.assertEqual(instruction.arg, instruction.oparg)
 
+    def test_show_caches_with_label(self):
+        def f(x, y, z):
+            if x:
+                res = y
+            else:
+                res = z
+            return res
+
+        output = io.StringIO()
+        dis.dis(f.__code__, file=output, show_caches=True)
+        self.assertIn("L1:", output.getvalue())
+
     def test_baseopname_and_baseopcode(self):
         # Standard instructions
         for name, code in dis.opmap.items():


### PR DESCRIPTION
Cache entries take the label_width from the instruction that precedes them.

The dis module needs to be refactored to separate Instruction generation from formatting, then this will be simpler. 

Fixes #112620.



<!-- gh-issue-number: gh-112620 -->
* Issue: gh-112620
<!-- /gh-issue-number -->
