### PR TITLE
gh-112622: Pass name to loop create_task method

### DIFF
--- a/Lib/asyncio/taskgroups.py
+++ b/Lib/asyncio/taskgroups.py
@@ -158,10 +158,10 @@ class TaskGroup:
         if self._aborting:
             raise RuntimeError(f"TaskGroup {self!r} is shutting down")
         if context is None:
-            task = self._loop.create_task(coro)
+            task = self._loop.create_task(coro, name=name)
         else:
-            task = self._loop.create_task(coro, context=context)
-        task.set_name(name)
+            task = self._loop.create_task(coro, name=name, context=context)
+
         # optimization: Immediately call the done callback if the task is
         # already done (e.g. if the coro was able to complete eagerly),
         # and skip scheduling a done callback

--- a/Lib/asyncio/tasks.py
+++ b/Lib/asyncio/tasks.py
@@ -404,11 +404,10 @@ def create_task(coro, *, name=None, context=None):
     loop = events.get_running_loop()
     if context is None:
         # Use legacy API if context is not needed
-        task = loop.create_task(coro)
+        task = loop.create_task(coro, name=name)
     else:
-        task = loop.create_task(coro, context=context)
+        task = loop.create_task(coro, name=name, context=context)
 
-    task.set_name(name)
     return task
 
 

--- a/Misc/NEWS.d/next/Library/2023-12-03-01-01-52.gh-issue-112622.1Z8cpx.rst
+++ b/Misc/NEWS.d/next/Library/2023-12-03-01-01-52.gh-issue-112622.1Z8cpx.rst
@@ -1,0 +1,2 @@
+Ensure ``name`` parameter is passed to event loop in
+:func:`asyncio.create_task`.


### PR DESCRIPTION

Issue: https://github.com/python/cpython/issues/112622

The name parameter is not being passed to the event loop and is instead being set by the asyncio.create_task function. This means that third party implementations of the event loop will never receive the name parameter. This commit fixes this.

Note [Python 3.7 (now end-of-life) is the last version which does not expect a name parameter for `asyncio.create_task`](https://docs.python.org/3.7/library/asyncio-task.html#asyncio.create_task).


<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-112622 -->
* Issue: gh-112622
<!-- /gh-issue-number -->
