### PR TITLE
gh-112278: reduce time cost for platform module when no permission to WMI on Windows

### DIFF
--- a/Lib/platform.py
+++ b/Lib/platform.py
@@ -315,7 +315,7 @@ def _syscmd_ver(system='', release='', version='',
 try:
     import _wmi
 except ImportError:
-    def _wmi_query(*keys):
+    def _wmi_query(table, *keys):
         raise OSError("not supported")
 else:
     def _wmi_query(table, *keys):
@@ -323,10 +323,16 @@ else:
             "OS": "Win32_OperatingSystem",
             "CPU": "Win32_Processor",
         }[table]
-        data = _wmi.exec_query("SELECT {} FROM {}".format(
-            ",".join(keys),
-            table,
-        )).split("\0")
+        try:
+            data = _wmi.exec_query("SELECT {} FROM {}".format(
+                ",".join(keys),
+                table,
+            )).split("\0")
+        except OSError:
+            global _wmi_query
+            def _wmi_query(table, *keys):
+                raise OSError("not supported")
+            raise OSError("not supported")
         split_data = (i.partition("=") for i in data)
         dict_data = {i[0]: i[2] for i in split_data}
         return (dict_data[k] for k in keys)

--- a/Lib/platform.py
+++ b/Lib/platform.py
@@ -318,9 +318,9 @@ def _syscmd_ver(system='', release='', version='',
 
 
 def _wmi_query(table, *keys):
+    global _wmi
     if not _wmi:
         raise OSError("not supported")
-
     table = {
         "OS": "Win32_OperatingSystem",
         "CPU": "Win32_Processor",
@@ -331,7 +331,6 @@ def _wmi_query(table, *keys):
             table,
         )).split("\0")
     except OSError:
-        global _wmi
         _wmi = None
         raise OSError("not supported")
     split_data = (i.partition("=") for i in data)

--- a/Lib/platform.py
+++ b/Lib/platform.py
@@ -118,6 +118,10 @@ import re
 import sys
 import functools
 import itertools
+try:
+    import _wmi
+except ImportError:
+    _wmi = None
 
 ### Globals & Constants
 
@@ -312,30 +316,27 @@ def _syscmd_ver(system='', release='', version='',
         version = _norm_version(version)
     return system, release, version
 
-try:
-    import _wmi
-except ImportError:
-    def _wmi_query(table, *keys):
+
+def _wmi_query(table, *keys):
+    if not _wmi:
         raise OSError("not supported")
-else:
-    def _wmi_query(table, *keys):
-        table = {
-            "OS": "Win32_OperatingSystem",
-            "CPU": "Win32_Processor",
-        }[table]
-        try:
-            data = _wmi.exec_query("SELECT {} FROM {}".format(
-                ",".join(keys),
-                table,
-            )).split("\0")
-        except OSError:
-            global _wmi_query
-            def _wmi_query(table, *keys):
-                raise OSError("not supported")
-            raise OSError("not supported")
-        split_data = (i.partition("=") for i in data)
-        dict_data = {i[0]: i[2] for i in split_data}
-        return (dict_data[k] for k in keys)
+
+    table = {
+        "OS": "Win32_OperatingSystem",
+        "CPU": "Win32_Processor",
+    }[table]
+    try:
+        data = _wmi.exec_query("SELECT {} FROM {}".format(
+            ",".join(keys),
+            table,
+        )).split("\0")
+    except OSError:
+        global _wmi
+        _wmi = None
+        raise OSError("not supported")
+    split_data = (i.partition("=") for i in data)
+    dict_data = {i[0]: i[2] for i in split_data}
+    return (dict_data[k] for k in keys)
 
 
 _WIN32_CLIENT_RELEASES = [

--- a/Misc/NEWS.d/next/Windows/2023-12-03-19-22-37.gh-issue-112278.FiloCE.rst
+++ b/Misc/NEWS.d/next/Windows/2023-12-03-19-22-37.gh-issue-112278.FiloCE.rst
@@ -1,0 +1,2 @@
+Reduce the time cost for some functions in :mod:`platform` on Windows if
+current user has no permission to the WMI.

--- a/PC/_wmimodule.cpp
+++ b/PC/_wmimodule.cpp
@@ -44,6 +44,7 @@ struct _query_data {
     LPCWSTR query;
     HANDLE writePipe;
     HANDLE readPipe;
+    HANDLE connectEvent;
 };
 
 
@@ -86,6 +87,7 @@ _query_thread(LPVOID param)
             NULL, NULL, 0, NULL, 0, 0, &services
         );
     }
+    SetEvent(data->connectEvent);
     if (SUCCEEDED(hr)) {
         hr = CoSetProxyBlanket(
             services, RPC_C_AUTHN_WINNT, RPC_C_AUTHZ_NONE, NULL,
@@ -231,7 +233,8 @@ _wmi_exec_query_impl(PyObject *module, PyObject *query)
 
     Py_BEGIN_ALLOW_THREADS
 
-    if (!CreatePipe(&data.readPipe, &data.writePipe, NULL, 0)) {
+    data.connectEvent = CreateEvent(NULL, TRUE, FALSE, NULL);
+    if (!data.connectEvent || !CreatePipe(&data.readPipe, &data.writePipe, NULL, 0)) {
         err = GetLastError();
     } else {
         hThread = CreateThread(NULL, 0, _query_thread, (LPVOID*)&data, 0, NULL);
@@ -241,6 +244,21 @@ _wmi_exec_query_impl(PyObject *module, PyObject *query)
             // we need to close it here.
             CloseHandle(data.writePipe);
         }
+    }
+
+    // If current user doesn't have permission to query the WMI, the function
+    // IWbemLocator::ConnectServer will hang for 5 seconds, and there is no way
+    // to specify the timeout. So we use an Event object to simulate a timeout.
+    // More detail: gh-112278.
+    switch (WaitForSingleObject(data.connectEvent, 100)) {
+    case WAIT_OBJECT_0:
+        break;
+    case WAIT_TIMEOUT:
+        err = WAIT_TIMEOUT;
+        break;
+    default:
+        err = GetLastError();
+        break;
     }
 
     while (!err) {
@@ -265,7 +283,7 @@ _wmi_exec_query_impl(PyObject *module, PyObject *query)
     }
 
     // Allow the thread some time to clean up
-    switch (WaitForSingleObject(hThread, 1000)) {
+    switch (WaitForSingleObject(hThread, 100)) {
     case WAIT_OBJECT_0:
         // Thread ended cleanly
         if (!GetExitCodeThread(hThread, (LPDWORD)&err)) {
@@ -286,6 +304,7 @@ _wmi_exec_query_impl(PyObject *module, PyObject *query)
     }
 
     CloseHandle(hThread);
+    CloseHandle(data.connectEvent);
     hThread = NULL;
 
     Py_END_ALLOW_THREADS

--- a/PC/_wmimodule.cpp
+++ b/PC/_wmimodule.cpp
@@ -246,10 +246,10 @@ _wmi_exec_query_impl(PyObject *module, PyObject *query)
         }
     }
 
-    // If current user doesn't have permission to query the WMI, the function
-    // IWbemLocator::ConnectServer will hang for 5 seconds, and there is no way
-    // to specify the timeout. So we use an Event object to simulate a timeout.
-    // More detail: gh-112278.
+    // gh-112278: If current user doesn't have permission to query the WMI, the
+    // function IWbemLocator::ConnectServer will hang for 5 seconds, and there
+    // is no way to specify the timeout. So we use an Event object to simulate
+    // a timeout.
     switch (WaitForSingleObject(data.connectEvent, 100)) {
     case WAIT_OBJECT_0:
         break;

--- a/PC/_wmimodule.cpp
+++ b/PC/_wmimodule.cpp
@@ -87,7 +87,9 @@ _query_thread(LPVOID param)
             NULL, NULL, 0, NULL, 0, 0, &services
         );
     }
-    SetEvent(data->connectEvent);
+    if (!SetEvent(data->connectEvent)) {
+        hr = HRESULT_FROM_WIN32(GetLastError());
+    }
     if (SUCCEEDED(hr)) {
         hr = CoSetProxyBlanket(
             services, RPC_C_AUTHN_WINNT, RPC_C_AUTHZ_NONE, NULL,


### PR DESCRIPTION
Using an `Event` object to simulate timeout for `IWbemLocator::ConnectServer`. I set it to 100ms, and it's enough for the normal path on my machine. And there have another 100ms plus for waiting the query thread. The final time usage on my local machine:

```
PS C:\Users\xxxxx\Source\cpython> .\python.bat -m timeit -s "import platform" -n 1 -r 1 "platform.system()"
Running Debug|x64 interpreter...
1 loop, best of 1: 301 msec per loop
```

<!-- gh-issue-number: gh-112278 -->
* Issue: gh-112278
<!-- /gh-issue-number -->
