### PR TITLE
gh-112660: Do not clear arbitrary errors on import

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2023-12-03-15-29-53.gh-issue-112660.gldBvh.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2023-12-03-15-29-53.gh-issue-112660.gldBvh.rst
@@ -1,0 +1,2 @@
+Do not clear unexpected errors during formatting error messages for
+ImportError and AttributeError for modules.

--- a/Objects/moduleobject.c
+++ b/Objects/moduleobject.c
@@ -749,27 +749,20 @@ module_repr(PyModuleObject *m)
 }
 
 /* Check if the "_initializing" attribute of the module spec is set to true.
-   Clear the exception and return 0 if spec is NULL.
  */
 int
 _PyModuleSpec_IsInitializing(PyObject *spec)
 {
-    if (spec != NULL) {
-        PyObject *value;
-        int ok = PyObject_GetOptionalAttr(spec, &_Py_ID(_initializing), &value);
-        if (ok == 0) {
-            return 0;
-        }
-        if (value != NULL) {
-            int initializing = PyObject_IsTrue(value);
-            Py_DECREF(value);
-            if (initializing >= 0) {
-                return initializing;
-            }
-        }
+    if (spec == NULL) {
+        return 0;
     }
-    PyErr_Clear();
-    return 0;
+    PyObject *value;
+    int rc = PyObject_GetOptionalAttr(spec, &_Py_ID(_initializing), &value);
+    if (rc > 0) {
+        rc = PyObject_IsTrue(value);
+        Py_DECREF(value);
+    }
+    return rc;
 }
 
 /* Check if the submodule name is in the "_uninitialized_submodules" attribute
@@ -782,17 +775,13 @@ _PyModuleSpec_IsUninitializedSubmodule(PyObject *spec, PyObject *name)
          return 0;
     }
 
-    PyObject *value = PyObject_GetAttr(spec, &_Py_ID(_uninitialized_submodules));
-    if (value == NULL) {
-        return 0;
+    PyObject *value;
+    int rc = PyObject_GetOptionalAttr(spec, &_Py_ID(_uninitialized_submodules), &value);
+    if (rc > 0) {
+        rc = PySequence_Contains(value, name);
+        Py_DECREF(value);
     }
-
-    int is_uninitialized = PySequence_Contains(value, name);
-    Py_DECREF(value);
-    if (is_uninitialized == -1) {
-        return 0;
-    }
-    return is_uninitialized;
+    return rc;
 }
 
 PyObject*
@@ -840,23 +829,27 @@ _Py_module_getattro_impl(PyModuleObject *m, PyObject *name, int suppress)
             return NULL;
         }
         if (suppress != 1) {
-            if (_PyModuleSpec_IsInitializing(spec)) {
+            int rc = _PyModuleSpec_IsInitializing(spec);
+            if (rc > 0) {
                 PyErr_Format(PyExc_AttributeError,
                                 "partially initialized "
                                 "module '%U' has no attribute '%U' "
                                 "(most likely due to a circular import)",
                                 mod_name, name);
             }
-            else if (_PyModuleSpec_IsUninitializedSubmodule(spec, name)) {
-                PyErr_Format(PyExc_AttributeError,
+            else if (rc == 0) {
+                rc = _PyModuleSpec_IsUninitializedSubmodule(spec, name);
+                if (rc > 0) {
+                    PyErr_Format(PyExc_AttributeError,
                                 "cannot access submodule '%U' of module '%U' "
                                 "(most likely due to a circular import)",
                                 name, mod_name);
-            }
-            else {
-                PyErr_Format(PyExc_AttributeError,
+                }
+                else if (rc == 0) {
+                    PyErr_Format(PyExc_AttributeError,
                                 "module '%U' has no attribute '%U'",
                                 mod_name, name);
+                }
             }
         }
         Py_XDECREF(spec);


### PR DESCRIPTION
Previously arbitrary errors could be cleared during formatting error messages for ImportError or AttributeError for modules. Now all unexpected errors are reported.


<!-- gh-issue-number: gh-112660 -->
* Issue: gh-112660
<!-- /gh-issue-number -->
