### PR TITLE
[3.12] gh-112645: remove deprecation warning for use of onerror in shutil.rmtree (#112659)

### DIFF
--- a/Doc/whatsnew/3.12.rst
+++ b/Doc/whatsnew/3.12.rst
@@ -838,8 +838,7 @@ shutil
 
 * :func:`shutil.rmtree` now accepts a new argument *onexc* which is an
   error handler like *onerror* but which expects an exception instance
-  rather than a *(typ, val, tb)* triplet. *onerror* is deprecated and
-  will be removed in Python 3.14.
+  rather than a *(typ, val, tb)* triplet. *onerror* is deprecated.
   (Contributed by Irit Katriel in :gh:`102828`.)
 
 * :func:`shutil.which` now consults the *PATHEXT* environment variable to
@@ -1261,8 +1260,8 @@ Deprecated
   :mod:`concurrent.futures` the fix is to use a different
   :mod:`multiprocessing` start method such as ``"spawn"`` or ``"forkserver"``.
 
-* :mod:`shutil`: The *onerror* argument of :func:`shutil.rmtree` is deprecated and will be removed
-  in Python 3.14. Use *onexc* instead. (Contributed by Irit Katriel in :gh:`102828`.)
+* :mod:`shutil`: The *onerror* argument of :func:`shutil.rmtree` is deprecated;
+  use *onexc* instead. (Contributed by Irit Katriel in :gh:`102828`.)
 
 * :mod:`sqlite3`:
 

--- a/Lib/shutil.py
+++ b/Lib/shutil.py
@@ -722,10 +722,6 @@ def rmtree(path, ignore_errors=False, onerror=None, *, onexc=None, dir_fd=None):
     If both onerror and onexc are set, onerror is ignored and onexc is used.
     """
 
-    if onerror is not None:
-        warnings.warn("onerror argument is deprecated, use onexc instead",
-                      DeprecationWarning, stacklevel=2)
-
     sys.audit("shutil.rmtree", path, dir_fd)
     if ignore_errors:
         def onexc(*args):

--- a/Lib/test/test_shutil.py
+++ b/Lib/test/test_shutil.py
@@ -209,8 +209,7 @@ class TestRmTree(BaseTest, unittest.TestCase):
         errors = []
         def onerror(*args):
             errors.append(args)
-        with self.assertWarns(DeprecationWarning):
-            shutil.rmtree(link, onerror=onerror)
+        shutil.rmtree(link, onerror=onerror)
         self.assertEqual(len(errors), 1)
         self.assertIs(errors[0][0], os.path.islink)
         self.assertEqual(errors[0][1], link)
@@ -271,8 +270,7 @@ class TestRmTree(BaseTest, unittest.TestCase):
         errors = []
         def onerror(*args):
             errors.append(args)
-        with self.assertWarns(DeprecationWarning):
-            shutil.rmtree(link, onerror=onerror)
+        shutil.rmtree(link, onerror=onerror)
         self.assertEqual(len(errors), 1)
         self.assertIs(errors[0][0], os.path.islink)
         self.assertEqual(errors[0][1], link)
@@ -341,8 +339,7 @@ class TestRmTree(BaseTest, unittest.TestCase):
         errors = []
         def onerror(*args):
             errors.append(args)
-        with self.assertWarns(DeprecationWarning):
-            shutil.rmtree(filename, onerror=onerror)
+        shutil.rmtree(filename, onerror=onerror)
         self.assertEqual(len(errors), 2)
         self.assertIs(errors[0][0], os.scandir)
         self.assertEqual(errors[0][1], filename)
@@ -411,8 +408,7 @@ class TestRmTree(BaseTest, unittest.TestCase):
         self.addCleanup(os.chmod, self.child_file_path, old_child_file_mode)
         self.addCleanup(os.chmod, self.child_dir_path, old_child_dir_mode)
 
-        with self.assertWarns(DeprecationWarning):
-            shutil.rmtree(TESTFN, onerror=self.check_args_to_onerror)
+        shutil.rmtree(TESTFN, onerror=self.check_args_to_onerror)
         # Test whether onerror has actually been called.
         self.assertEqual(self.errorState, 3,
                          "Expected call to onerror function did not happen.")
@@ -538,8 +534,7 @@ class TestRmTree(BaseTest, unittest.TestCase):
         self.addCleanup(os.chmod, self.child_file_path, old_child_file_mode)
         self.addCleanup(os.chmod, self.child_dir_path, old_child_dir_mode)
 
-        with self.assertWarns(DeprecationWarning):
-            shutil.rmtree(TESTFN, onerror=onerror, onexc=onexc)
+        shutil.rmtree(TESTFN, onerror=onerror, onexc=onexc)
         self.assertTrue(onexc_called)
         self.assertFalse(onerror_called)
 

--- a/Misc/NEWS.d/next/Library/2023-12-03-12-41-48.gh-issue-112645.blMsKf.rst
+++ b/Misc/NEWS.d/next/Library/2023-12-03-12-41-48.gh-issue-112645.blMsKf.rst
@@ -1,0 +1,1 @@
+Remove deprecation error on passing ``onerror`` to :func:`shutil.rmtree`.


### PR DESCRIPTION
[manual backport]

(cherry picked from commit 97857ac0580057c3a4f75d34209841c81ee11a96)



<!-- gh-issue-number: gh-112645 -->
* Issue: gh-112645
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--112665.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->