### PR TITLE
gh-101100: Fix Sphinx warning in `library/gettext.rst`

### DIFF
--- a/Doc/library/gettext.rst
+++ b/Doc/library/gettext.rst
@@ -257,7 +257,7 @@ are the methods of :class:`!NullTranslations`:
 
    .. method:: info()
 
-      Return the "protected" :attr:`!_info` variable, a dictionary containing
+      Return a dictionary containing
       the metadata found in the message catalog file.
 
 

--- a/Doc/library/gettext.rst
+++ b/Doc/library/gettext.rst
@@ -257,7 +257,7 @@ are the methods of :class:`!NullTranslations`:
 
    .. method:: info()
 
-      Return the "protected" :attr:`_info` variable, a dictionary containing
+      Return the "protected" :attr:`!_info` variable, a dictionary containing
       the metadata found in the message catalog file.
 
 
@@ -298,7 +298,7 @@ The :class:`GNUTranslations` class
 
 The :mod:`gettext` module provides one additional class derived from
 :class:`NullTranslations`: :class:`GNUTranslations`.  This class overrides
-:meth:`_parse` to enable reading GNU :program:`gettext` format :file:`.mo` files
+:meth:`!_parse` to enable reading GNU :program:`gettext` format :file:`.mo` files
 in both big-endian and little-endian format.
 
 :class:`GNUTranslations` parses optional metadata out of the translation
@@ -306,7 +306,7 @@ catalog. It is convention with GNU :program:`gettext` to include metadata as
 the translation for the empty string. This metadata is in :rfc:`822`\ -style
 ``key: value`` pairs, and should contain the ``Project-Id-Version`` key.  If the
 key ``Content-Type`` is found, then the ``charset`` property is used to
-initialize the "protected" :attr:`_charset` instance variable, defaulting to
+initialize the "protected" :attr:`!_charset` instance variable, defaulting to
 ``None`` if not found.  If the charset encoding is specified, then all message
 ids and message strings read from the catalog are converted to Unicode using
 this encoding, else ASCII is assumed.
@@ -315,7 +315,7 @@ Since message ids are read as Unicode strings too, all ``*gettext()`` methods
 will assume message ids as Unicode strings, not byte strings.
 
 The entire set of key/value pairs are placed into a dictionary and set as the
-"protected" :attr:`_info` instance variable.
+"protected" :attr:`!_info` instance variable.
 
 If the :file:`.mo` file's magic number is invalid, the major version number is
 unexpected, or if other problems occur while reading the file, instantiating a
@@ -636,7 +636,7 @@ implementations, and valuable experience to the creation of this module:
 
 .. rubric:: Footnotes
 
-.. [#] The default locale directory is system dependent; for example, on RedHat Linux
+.. [#] The default locale directory is system dependent; for example, on Red Hat Linux
    it is :file:`/usr/share/locale`, but on Solaris it is :file:`/usr/lib/locale`.
    The :mod:`gettext` module does not try to support these system dependent
    defaults; instead its default is :file:`{sys.base_prefix}/share/locale` (see

--- a/Doc/library/gettext.rst
+++ b/Doc/library/gettext.rst
@@ -296,7 +296,7 @@ are the methods of :class:`!NullTranslations`:
 The :class:`GNUTranslations` class
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The :mod:`gettext` module provides one additional class derived from
+The :mod:`!gettext` module provides one additional class derived from
 :class:`NullTranslations`: :class:`GNUTranslations`.  This class overrides
 :meth:`!_parse` to enable reading GNU :program:`gettext` format :file:`.mo` files
 in both big-endian and little-endian format.
@@ -638,7 +638,7 @@ implementations, and valuable experience to the creation of this module:
 
 .. [#] The default locale directory is system dependent; for example, on Red Hat Linux
    it is :file:`/usr/share/locale`, but on Solaris it is :file:`/usr/lib/locale`.
-   The :mod:`gettext` module does not try to support these system dependent
+   The :mod:`!gettext` module does not try to support these system dependent
    defaults; instead its default is :file:`{sys.base_prefix}/share/locale` (see
    :data:`sys.base_prefix`). For this reason, it is always best to call
    :func:`bindtextdomain` with an explicit absolute path at the start of your

--- a/Doc/tools/.nitignore
+++ b/Doc/tools/.nitignore
@@ -58,7 +58,6 @@ Doc/library/fcntl.rst
 Doc/library/ftplib.rst
 Doc/library/functions.rst
 Doc/library/functools.rst
-Doc/library/gettext.rst
 Doc/library/http.client.rst
 Doc/library/http.cookiejar.rst
 Doc/library/http.cookies.rst


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

Most of these underscore-prefixed are described as "protected", I don't think they need documenting individually, so added `!`.

Also fix RedHat -> Red Hat typo. 

```console
❯ SPHINXERRORHANDLING=-n PATH=./venv/bin:$PATH sphinx-build -b html -d build/doctrees -j auto -n . build/html library/gettext.rst  2>&1 | grep WARNING | tee >(wc -l)
Doc/library/gettext.rst:260: WARNING: py:attr reference target not found: _info
Doc/library/gettext.rst:299: WARNING: py:meth reference target not found: _parse
Doc/library/gettext.rst:304: WARNING: py:attr reference target not found: _charset
Doc/library/gettext.rst:317: WARNING: py:attr reference target not found: _info
       4
```


<!-- gh-issue-number: gh-101100 -->
* Issue: gh-101100
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--112668.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->