### PR TITLE
gh-99180: Remove traceback anchors in return and assign statements that cover all the displayed range

### DIFF
--- a/Lib/traceback.py
+++ b/Lib/traceback.py
@@ -607,13 +607,10 @@ class StackSummary(list):
 
                 # attempt to parse for anchors
                 anchors = None
+                show_carets = False
                 with suppress(Exception):
                     anchors = _extract_caret_anchors_from_line_segment(segment)
-
-                # only use carets if there are anchors or the carets do not span all lines
-                show_carets = False
-                if anchors or all_lines[0][:start_offset].lstrip() or all_lines[-1][end_offset:].rstrip():
-                    show_carets = True
+                show_carets = self.should_show_carets(start_offset, end_offset, all_lines, anchors)
 
                 result = []
 
@@ -726,6 +723,37 @@ class StackSummary(list):
                 row.append('    {name} = {value}\n'.format(name=name, value=value))
 
         return ''.join(row)
+
+    def should_show_carets(self, start_offset, end_offset, all_lines, anchors):
+        with suppress(SyntaxError, ImportError):
+            import ast
+            tree = ast.parse('\n'.join(all_lines))
+            statement = tree.body[0]
+            value = None
+            def _spawns_full_line(value):
+                return (
+                    value.lineno == 1
+                    and value.end_lineno == len(all_lines)
+                    and value.col_offset == start_offset
+                    and value.end_col_offset == end_offset
+                )
+            match statement:
+                case ast.Return(value=ast.Call()):
+                    if isinstance(statement.value.func, ast.Name):
+                        value = statement.value
+                case ast.Assign(value=ast.Call()):
+                    if (
+                        len(statement.targets) == 1 and
+                        isinstance(statement.targets[0], ast.Name)
+                    ):
+                        value = statement.value
+            if value is not None and _spawns_full_line(value):
+                return False
+        if anchors:
+            return True
+        if all_lines[0][:start_offset].lstrip() or all_lines[-1][end_offset:].rstrip():
+            return True
+        return False
 
     def format(self, **kwargs):
         """Format the stack ready for printing.

--- a/Misc/NEWS.d/next/Core and Builtins/2023-12-03-18-21-59.gh-issue-99180.5m0V0q.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2023-12-03-18-21-59.gh-issue-99180.5m0V0q.rst
@@ -1,0 +1,2 @@
+Elide uninformative traceback indicators in ``return`` and simple
+``assignment`` statements. Patch by Pablo Galindo.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-99180 -->
* Issue: gh-99180
<!-- /gh-issue-number -->
