### PR TITLE
gh-112678: Declare `Tkapp_CallDeallocArgs()` as `static`

### DIFF
--- a/Modules/_tkinter.c
+++ b/Modules/_tkinter.c
@@ -1202,7 +1202,7 @@ typedef struct Tkapp_CallEvent {
     Tcl_Condition *done;
 } Tkapp_CallEvent;
 
-void
+static void
 Tkapp_CallDeallocArgs(Tcl_Obj** objv, Tcl_Obj** objStore, int objc)
 {
     int i;


### PR DESCRIPTION
…as per PEP 7.

This should make no difference in functionality. According to `llvm-nm -gU Modules/_tkinter.o` there are no other similar issues in this file.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-112678 -->
* Issue: gh-112678
<!-- /gh-issue-number -->
