### PR TITLE
[3.12] gh-101100: Fix sphinx warnings in `Doc/library/__future__.rst` (#109814)

### DIFF
--- a/Doc/library/__future__.rst
+++ b/Doc/library/__future__.rst
@@ -22,42 +22,48 @@
   can be inspected programmatically via importing :mod:`__future__` and examining
   its contents.
 
-Each statement in :file:`__future__.py` is of the form::
+.. _future-classes:
 
-   FeatureName = _Feature(OptionalRelease, MandatoryRelease,
-                          CompilerFlag)
+.. class:: _Feature
 
+   Each statement in :file:`__future__.py` is of the form::
 
-where, normally, *OptionalRelease* is less than *MandatoryRelease*, and both are
-5-tuples of the same form as :data:`sys.version_info`::
+      FeatureName = _Feature(OptionalRelease, MandatoryRelease,
+                             CompilerFlag)
 
-   (PY_MAJOR_VERSION, # the 2 in 2.1.0a3; an int
-    PY_MINOR_VERSION, # the 1; an int
-    PY_MICRO_VERSION, # the 0; an int
-    PY_RELEASE_LEVEL, # "alpha", "beta", "candidate" or "final"; string
-    PY_RELEASE_SERIAL # the 3; an int
-   )
+   where, normally, *OptionalRelease* is less than *MandatoryRelease*, and both are
+   5-tuples of the same form as :data:`sys.version_info`::
 
-*OptionalRelease* records the first release in which the feature was accepted.
+      (PY_MAJOR_VERSION, # the 2 in 2.1.0a3; an int
+       PY_MINOR_VERSION, # the 1; an int
+       PY_MICRO_VERSION, # the 0; an int
+       PY_RELEASE_LEVEL, # "alpha", "beta", "candidate" or "final"; string
+       PY_RELEASE_SERIAL # the 3; an int
+      )
 
-In the case of a *MandatoryRelease* that has not yet occurred,
-*MandatoryRelease* predicts the release in which the feature will become part of
-the language.
+.. method:: _Feature.getOptionalRelease()
 
-Else *MandatoryRelease* records when the feature became part of the language; in
-releases at or after that, modules no longer need a future statement to use the
-feature in question, but may continue to use such imports.
+   *OptionalRelease* records the first release in which the feature was accepted.
 
-*MandatoryRelease* may also be ``None``, meaning that a planned feature got
-dropped.
+.. method:: _Feature.getMandatoryRelease()
 
-Instances of class :class:`_Feature` have two corresponding methods,
-:meth:`getOptionalRelease` and :meth:`getMandatoryRelease`.
+   In the case of a *MandatoryRelease* that has not yet occurred,
+   *MandatoryRelease* predicts the release in which the feature will become part of
+   the language.
 
-*CompilerFlag* is the (bitfield) flag that should be passed in the fourth
-argument to the built-in function :func:`compile` to enable the feature in
-dynamically compiled code.  This flag is stored in the :attr:`compiler_flag`
-attribute on :class:`_Feature` instances.
+   Else *MandatoryRelease* records when the feature became part of the language; in
+   releases at or after that, modules no longer need a future statement to use the
+   feature in question, but may continue to use such imports.
+
+   *MandatoryRelease* may also be ``None``, meaning that a planned feature got
+   dropped or that it is not yet decided.
+
+.. attribute:: _Feature.compiler_flag
+
+   *CompilerFlag* is the (bitfield) flag that should be passed in the fourth
+   argument to the built-in function :func:`compile` to enable the feature in
+   dynamically compiled code.  This flag is stored in the :attr:`_Feature.compiler_flag`
+   attribute on :class:`_Feature` instances.
 
 No feature description will ever be deleted from :mod:`__future__`. Since its
 introduction in Python 2.1 the following features have found their way into the

--- a/Doc/tools/.nitignore
+++ b/Doc/tools/.nitignore
@@ -28,7 +28,6 @@ Doc/howto/isolating-extensions.rst
 Doc/howto/logging.rst
 Doc/howto/urllib2.rst
 Doc/library/2to3.rst
-Doc/library/__future__.rst
 Doc/library/abc.rst
 Doc/library/aifc.rst
 Doc/library/ast.rst


### PR DESCRIPTION
(cherry-picked from commit f2eaa92b0cc5a37a9e6010c7c6f5ad1a230ea49b)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-101100 -->
* Issue: gh-101100
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--112702.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->