### PR TITLE
gh-74690: Optimise `isinstance()` and `issubclass()` calls against runtime-checkable protocols by avoiding costly `super()` calls

### DIFF
--- a/Misc/NEWS.d/next/Library/2023-12-04-14-05-24.gh-issue-74690.eODKRm.rst
+++ b/Misc/NEWS.d/next/Library/2023-12-04-14-05-24.gh-issue-74690.eODKRm.rst
@@ -1,4 +1,5 @@
-Speedup `isinstance()` checks by roughly 20% for :func:`runtime-checkable
-protocols <typing.runtime_checkable>` that only have one callable member.
-Speedup `issubclass()` checks for these protocols by roughly 10%. Patch by
-Alex Waygood.
+Speedup :func:`isinstance` checks by roughly 20% for
+:func:`runtime-checkable protocols <typing.runtime_checkable>`
+that only have one callable member.
+Speedup `issubclass()` checks for these protocols by roughly 10%.
+Patch by Alex Waygood.

--- a/Misc/NEWS.d/next/Library/2023-12-04-14-05-24.gh-issue-74690.eODKRm.rst
+++ b/Misc/NEWS.d/next/Library/2023-12-04-14-05-24.gh-issue-74690.eODKRm.rst
@@ -1,0 +1,4 @@
+Speedup `isinstance()` checks by roughly 20% for :func:`runtime-checkable
+protocols <typing.runtime_checkable>` that only have one callable member.
+Speedup `issubclass()` checks for these protocols by roughly 10%. Patch by
+Alex Waygood.

--- a/Misc/NEWS.d/next/Library/2023-12-04-14-05-24.gh-issue-74690.eODKRm.rst
+++ b/Misc/NEWS.d/next/Library/2023-12-04-14-05-24.gh-issue-74690.eODKRm.rst
@@ -1,5 +1,5 @@
 Speedup :func:`isinstance` checks by roughly 20% for
 :func:`runtime-checkable protocols <typing.runtime_checkable>`
 that only have one callable member.
-Speedup `issubclass()` checks for these protocols by roughly 10%.
+Speedup :func:`issubclass` checks for these protocols by roughly 10%.
 Patch by Alex Waygood.


### PR DESCRIPTION
Before:

```
>python -m timeit -s "from typing import SupportsIndex" "isinstance(0, SupportsIndex)"
Running PGUpdate|x64 interpreter...
1000000 loops, best of 5: 379 nsec per loop

>python -m timeit -s "from typing import SupportsIndex" "issubclass(int, SupportsIndex)"
Running PGUpdate|x64 interpreter...
500000 loops, best of 5: 592 nsec per loop
```

After:

```
>python -m timeit -s "from typing import SupportsIndex" "isinstance(0, SupportsIndex)"
Running PGUpdate|x64 interpreter...
1000000 loops, best of 5: 298 nsec per loop

>python -m timeit -s "from typing import SupportsIndex" "issubclass(int, SupportsIndex)"
Running PGUpdate|x64 interpreter...
500000 loops, best of 5: 523 nsec per loop
```

Timings done using a fresh PGO-optimised build on Windows with the `main` branch.

<!-- gh-issue-number: gh-74690 -->
* Issue: gh-74690
<!-- /gh-issue-number -->
