### PR TITLE
gh-112671: Fixing typo in the Macro Docs

### DIFF
--- a/Doc/c-api/structures.rst
+++ b/Doc/c-api/structures.rst
@@ -592,7 +592,7 @@ Macro name                       C type                        Python type
 
    (*): Zero-terminated, UTF8-encoded C string.
    With :c:macro:`!Py_T_STRING` the C representation is a pointer;
-   with :c:macro:`!Py_T_STRING_INLINE` the string is stored directly
+   with :c:macro:`!Py_T_STRING_INPLACE` the string is stored directly
    in the structure.
 
    (**): String of length 1. Only ASCII is accepted.


### PR DESCRIPTION
Fixes #112671 

I just replaced Py_T_STRING_INLINE with Py_T_STRING_INPLACE

<!-- gh-issue-number: gh-112671 -->
* Issue: gh-112671
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--112715.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->