### PR TITLE
gh-74690: Avoid a costly type check where possible in `_ProtocolMeta.__subclasscheck__`

### DIFF
--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -1790,6 +1790,12 @@ _abc_instancecheck = ABCMeta.__instancecheck__
 _abc_subclasscheck = ABCMeta.__subclasscheck__
 
 
+def _type_check_subclasscheck_second_arg(arg):
+    if not isinstance(arg, type):
+        # Same error message as for issubclass(1, int).
+        raise TypeError('issubclass() arg 1 must be a class')
+
+
 class _ProtocolMeta(ABCMeta):
     # This metaclass is somewhat unfortunate,
     # but is necessary for several reasons...
@@ -1829,13 +1835,11 @@ class _ProtocolMeta(ABCMeta):
             getattr(cls, '_is_protocol', False)
             and not _allow_reckless_class_checks()
         ):
-            if not isinstance(other, type):
-                # Same error message as for issubclass(1, int).
-                raise TypeError('issubclass() arg 1 must be a class')
             if (
                 not cls.__callable_proto_members_only__
                 and cls.__dict__.get("__subclasshook__") is _proto_hook
             ):
+                _type_check_subclasscheck_second_arg(other)
                 non_method_attrs = sorted(
                     attr for attr in cls.__protocol_attrs__
                     if not callable(getattr(cls, attr, None))
@@ -1845,6 +1849,7 @@ class _ProtocolMeta(ABCMeta):
                     f" Non-method members: {str(non_method_attrs)[1:-1]}."
                 )
             if not getattr(cls, '_is_runtime_protocol', False):
+                _type_check_subclasscheck_second_arg(other)
                 raise TypeError(
                     "Instance and class checks can only be used with "
                     "@runtime_checkable protocols"

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -1795,7 +1795,8 @@ def _type_check_issubclass_arg_1(arg):
     in `issubclass(arg, <protocol>)`.
 
     In most cases, this is verified by type.__subclasscheck__.
-    As such, we don't perform this check unless we absolutely have to.
+    Checking it again unnecessarily would slow down issubclass() checks,
+    so, we don't perform this check unless we absolutely have to.
 
     For various error paths, however,
     we want to ensure that *this* error message is shown to the user

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -1790,7 +1790,17 @@ _abc_instancecheck = ABCMeta.__instancecheck__
 _abc_subclasscheck = ABCMeta.__subclasscheck__
 
 
-def _type_check_subclasscheck_second_arg(arg):
+def _type_check_issubclass_arg_1(arg):
+    """Raise TypeError if `arg` is not an instance of `type`
+    in `issubclass(arg, <protocol>)`.
+
+    In most cases, this is verified by type.__subclasscheck__.
+    As such, we don't perform this check unless we absolutely have to.
+
+    For various error paths, however,
+    we want to ensure that *this* error message is shown to the user
+    where relevant, rather than a typing.py-specific error message.
+    """
     if not isinstance(arg, type):
         # Same error message as for issubclass(1, int).
         raise TypeError('issubclass() arg 1 must be a class')
@@ -1839,7 +1849,7 @@ class _ProtocolMeta(ABCMeta):
                 not cls.__callable_proto_members_only__
                 and cls.__dict__.get("__subclasshook__") is _proto_hook
             ):
-                _type_check_subclasscheck_second_arg(other)
+                _type_check_issubclass_arg_1(other)
                 non_method_attrs = sorted(
                     attr for attr in cls.__protocol_attrs__
                     if not callable(getattr(cls, attr, None))
@@ -1849,7 +1859,7 @@ class _ProtocolMeta(ABCMeta):
                     f" Non-method members: {str(non_method_attrs)[1:-1]}."
                 )
             if not getattr(cls, '_is_runtime_protocol', False):
-                _type_check_subclasscheck_second_arg(other)
+                _type_check_issubclass_arg_1(other)
                 raise TypeError(
                     "Instance and class checks can only be used with "
                     "@runtime_checkable protocols"

--- a/Misc/NEWS.d/next/Library/2023-12-04-16-45-11.gh-issue-74690.pQYP5U.rst
+++ b/Misc/NEWS.d/next/Library/2023-12-04-16-45-11.gh-issue-74690.pQYP5U.rst
@@ -1,0 +1,2 @@
+Speedup :func:`issubclass` checks against simple :func:`runtime-checkable
+protocols <typing.runtime_checkable>` by around 6%. Patch by Alex Waygood.


### PR DESCRIPTION
This speeds up `issubclass(int, typing.SupportsIndex)` by around 6%.

The approach is to move the code around a bit so that we delegate the type-checking to `type.__subclasscheck__` wherever possible; `type.__subclasscheck__` can do it faster. We now only check from `_ProtocolMeta.__subclasscheck__` whether `other` is an instance of `type` if we _know_ we're about to raise an exception anyway, and we want the `issubclass() arg 2 must be a type` message to take priority over the other error message we could potentially give the user.

<!-- gh-issue-number: gh-74690 -->
* Issue: gh-74690
<!-- /gh-issue-number -->
