### PR TITLE
GH-112727: Speed up `pathlib.Path.absolute()`

### DIFF
--- a/Lib/pathlib.py
+++ b/Lib/pathlib.py
@@ -1415,10 +1415,10 @@ class Path(_PathBase):
         """
         if self.is_absolute():
             return self
-        elif self.root:
+        if self.root:
             drive = os.path.splitroot(os.getcwd())[0]
             return self._from_parsed_parts(drive, self.root, self._tail)
-        elif self.drive:
+        if self.drive:
             # There is a CWD on each drive-letter drive.
             cwd = os.path.abspath(self.drive)
         else:

--- a/Lib/pathlib.py
+++ b/Lib/pathlib.py
@@ -1416,10 +1416,8 @@ class Path(_PathBase):
         if self.is_absolute():
             return self
         elif self.root:
-            cwd = os.getcwd()
-            if self._tail:
-                cwd_drv = os.path.splitroot(cwd)[0]
-                return self._from_parsed_parts(cwd_drv, self.root, self._tail)
+            cwd_drv = os.path.splitroot(os.getcwd())[0]
+            return self._from_parsed_parts(cwd_drv, self.root, self._tail)
         else:
             cwd = os.path.abspath(self.drive) if self.drive else os.getcwd()
             if self._tail:
@@ -1432,11 +1430,12 @@ class Path(_PathBase):
                 else:
                     cwd_tail = self._tail
                 return self._from_parsed_parts(cwd_drv, cwd_root, cwd_tail)
-        # Optimization: store the result of os.getcwd() as the normalized
-        # string representation of the path.
-        result = self.with_segments(cwd)
-        result._str = cwd
-        return result
+            else:
+                # Optimization: store the result of os.getcwd() as the normalized
+                # string representation of the path.
+                result = self.with_segments(cwd)
+                result._str = cwd
+                return result
 
     def resolve(self, strict=False):
         """

--- a/Misc/NEWS.d/next/Library/2023-12-04-21-30-34.gh-issue-112727.jpgNRB.rst
+++ b/Misc/NEWS.d/next/Library/2023-12-04-21-30-34.gh-issue-112727.jpgNRB.rst
@@ -1,0 +1,1 @@
+Speed up :meth:`pathlib.Path.absolute`. Patch by Barney Gale.


### PR DESCRIPTION
Use `_from_parsed_parts()` to create a pre-joined/pre-parsed path, rather than passing multiple arguments to `with_segments()`

<!-- gh-issue-number: gh-112727 -->
* Issue: gh-112727
<!-- /gh-issue-number -->
