### PR TITLE
gh-112606: Use sem_clockwait with monotonic time when supported in parking_lot.c

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2023-12-04-23-51-40.gh-issue-112606.pHvfIs.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2023-12-04-23-51-40.gh-issue-112606.pHvfIs.rst
@@ -1,1 +1,0 @@
-If ``sem_clockwait`` and ``CLOCK_MONOTONIC`` are supported, ``parking_lot.c`` will use ``sem_clockwait`` with monotonic time rather than system time in ``_PySemaphore_PlatformWait``.

--- a/Misc/NEWS.d/next/Core and Builtins/2023-12-04-23-51-40.gh-issue-112606.pHvfIs.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2023-12-04-23-51-40.gh-issue-112606.pHvfIs.rst
@@ -1,0 +1,1 @@
+If ``sem_clockwait`` and ``CLOCK_MONOTONIC`` are supported, ``parking_lot.c`` will use ``sem_clockwait`` with monotonic time rather than system time in ``_PySemaphore_PlatformWait``.

--- a/Python/parking_lot.c
+++ b/Python/parking_lot.c
@@ -125,7 +125,6 @@ _PySemaphore_PlatformWait(_PySemaphore *sema, _PyTime_t timeout)
 
         err = sem_clockwait(&sema->platform_sem, CLOCK_MONOTONIC, &ts);
 #else
-        // does not support CLOCK_MONOTONIC, use system clock
         _PyTime_t deadline = _PyTime_Add(_PyTime_GetSystemClock(), timeout);
 
         _PyTime_AsTimespec_clamp(deadline, &ts);

--- a/Python/parking_lot.c
+++ b/Python/parking_lot.c
@@ -118,10 +118,20 @@ _PySemaphore_PlatformWait(_PySemaphore *sema, _PyTime_t timeout)
     if (timeout >= 0) {
         struct timespec ts;
 
+#if defined(CLOCK_MONOTONIC) && defined(HAVE_SEM_CLOCKWAIT)
+        _PyTime_t deadline = _PyTime_Add(_PyTime_GetMonotonicClock(), timeout);
+
+        _PyTime_AsTimespec_clamp(deadline, &ts);
+
+        err = sem_clockwait(&sema->platform_sem, CLOCK_MONOTONIC, &ts);
+#else
+        // does not support CLOCK_MONOTONIC, use system clock
         _PyTime_t deadline = _PyTime_Add(_PyTime_GetSystemClock(), timeout);
-        _PyTime_AsTimespec(deadline, &ts);
+
+        _PyTime_AsTimespec_clamp(deadline, &ts);
 
         err = sem_timedwait(&sema->platform_sem, &ts);
+#endif
     }
     else {
         err = sem_wait(&sema->platform_sem);
@@ -151,7 +161,7 @@ _PySemaphore_PlatformWait(_PySemaphore *sema, _PyTime_t timeout)
             struct timespec ts;
 
             _PyTime_t deadline = _PyTime_Add(_PyTime_GetSystemClock(), timeout);
-            _PyTime_AsTimespec(deadline, &ts);
+            _PyTime_AsTimespec_clamp(deadline, &ts);
 
             err = pthread_cond_timedwait(&sema->cond, &sema->mutex, &ts);
         }


### PR DESCRIPTION
Completes one part of moving `parking_lot.c`'s semaphore waiting to prefer functions that support `CLOCK_MONOTONIC` Uses `sem_clockwait` in the semaphore-based implementation. Split with previous PR to move support for `CLOCK_MONOTONIC` in `pthread_condvar_t` implementation to a separate PR.



<!-- gh-issue-number: gh-112606 -->
* Issue: gh-112606
<!-- /gh-issue-number -->
