### PR TITLE
gh-112736: Refactor del-safe symbol handling in subprocess

### DIFF
--- a/Misc/NEWS.d/next/Library/2023-12-05-01-19-28.gh-issue-112736.rdHDrU.rst
+++ b/Misc/NEWS.d/next/Library/2023-12-05-01-19-28.gh-issue-112736.rdHDrU.rst
@@ -1,0 +1,1 @@
+The use of del-safe symbols in ``subprocess`` was refactored to allow for use in cross-platform build environments.


### PR DESCRIPTION
Refactors the use of del-safe symbols so that they can be overridden in a cross-platform build environment.

Includes the first references to iOS as a platform identifier (following the acceptance of [PEP 730](https://github.com/python/steering-council/issues/218#issuecomment-1839333665)). I was advised in an in-person chat with @ned-deily that as long as tvOS/watchOS patches didn't break anything for existing platforms, they were OK to leave in; but I'm happy to strip those out if you'd prefer.

There's no new tests... because I'm not sure what a test for this would look like. It doesn't change any runtime behavior - the change is really only observable if you're building a crossenv-style environment. I'm open to suggestions for what a test for this would entail.

<!-- gh-issue-number: gh-112736 -->
* Issue: gh-112736
<!-- /gh-issue-number -->
