### PR TITLE
[docs] fix typo in regex 'c' -> 'a'

### DIFF
--- a/Doc/howto/regex.rst
+++ b/Doc/howto/regex.rst
@@ -911,7 +911,7 @@ explicit by using a non-capturing group: ``(?:...)``, where you can replace the
 
    >>> m = re.match("([abc])+", "abc")
    >>> m.groups()
-   ('c',)
+   ('a',)
    >>> m = re.match("(?:[abc])+", "abc")
    >>> m.groups()
    ()


### PR DESCRIPTION
noticing this minor issue while reviewing regex module during advent of code :)

```
>>> import re
>>> m = re.match("([abc])", "abc")
>>> m.groups()
('a',)
```

> Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

I think this is a trivial change, not requiring an issue, let me know if you prefer a different process.

have a good day and thanks for your attention and your maintenance work.

Pietro
