### PR TITLE
gh-111178: Make slot functions in typeobject.c have compatible types

### DIFF
--- a/Include/internal/pycore_typeobject.h
+++ b/Include/internal/pycore_typeobject.h
@@ -133,7 +133,7 @@ _PyType_IsReady(PyTypeObject *type)
 
 extern PyObject* _Py_type_getattro_impl(PyTypeObject *type, PyObject *name,
                                         int *suppress_missing_attribute);
-extern PyObject* _Py_type_getattro(PyTypeObject *type, PyObject *name);
+extern PyObject* _Py_type_getattro(PyObject *type, PyObject *name);
 
 extern PyObject* _Py_slot_tp_getattro(PyObject *self, PyObject *name);
 extern PyObject* _Py_slot_tp_getattr_hook(PyObject *self, PyObject *name);

--- a/Objects/object.c
+++ b/Objects/object.c
@@ -1196,7 +1196,7 @@ PyObject_GetOptionalAttr(PyObject *v, PyObject *name, PyObject **result)
         }
         return 0;
     }
-    if (tp->tp_getattro == (getattrofunc)_Py_type_getattro) {
+    if (tp->tp_getattro == _Py_type_getattro) {
         int supress_missing_attribute_exception = 0;
         *result = _Py_type_getattro_impl((PyTypeObject*)v, name, &supress_missing_attribute_exception);
         if (supress_missing_attribute_exception) {

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -6555,6 +6555,12 @@ PyDoc_STRVAR(object_doc,
 "When called, it accepts no arguments and returns a new featureless\n"
 "instance that has no instance attributes and cannot be given any.\n");
 
+static Py_hash_t
+object_hash(PyObject *obj)
+{
+    return _Py_HashPointer(obj);
+}
+
 PyTypeObject PyBaseObject_Type = {
     PyVarObject_HEAD_INIT(&PyType_Type, 0)
     "object",                                   /* tp_name */
@@ -6569,7 +6575,7 @@ PyTypeObject PyBaseObject_Type = {
     0,                                          /* tp_as_number */
     0,                                          /* tp_as_sequence */
     0,                                          /* tp_as_mapping */
-    (hashfunc)_Py_HashPointer,                  /* tp_hash */
+    object_hash,                                /* tp_hash */
     0,                                          /* tp_call */
     object_str,                                 /* tp_str */
     PyObject_GenericGetAttr,                    /* tp_getattro */

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -5342,9 +5342,9 @@ type_clear(PyObject *self)
 }
 
 static int
-type_is_gc(PyTypeObject *type)
+type_is_gc(PyObject *type)
 {
-    return type->tp_flags & Py_TPFLAGS_HEAPTYPE;
+    return ((PyTypeObject *)type)->tp_flags & Py_TPFLAGS_HEAPTYPE;
 }
 
 
@@ -5395,7 +5395,7 @@ PyTypeObject PyType_Type = {
     0,                                          /* tp_alloc */
     type_new,                                   /* tp_new */
     PyObject_GC_Del,                            /* tp_free */
-    (inquiry)type_is_gc,                        /* tp_is_gc */
+    type_is_gc,                                 /* tp_is_gc */
     .tp_vectorcall = type_vectorcall,
 };
 

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -1631,8 +1631,9 @@ type_repr(PyObject *self)
 }
 
 static PyObject *
-type_call(PyTypeObject *type, PyObject *args, PyObject *kwds)
+type_call(PyObject *self, PyObject *args, PyObject *kwds)
 {
+    PyTypeObject *type = (PyTypeObject *)self;
     PyObject *obj;
     PyThreadState *tstate = _PyThreadState_GET();
 
@@ -5362,7 +5363,7 @@ PyTypeObject PyType_Type = {
     0,                                          /* tp_as_sequence */
     0,                                          /* tp_as_mapping */
     0,                                          /* tp_hash */
-    (ternaryfunc)type_call,                     /* tp_call */
+    type_call,                                  /* tp_call */
     0,                                          /* tp_str */
     (getattrofunc)_Py_type_getattro,            /* tp_getattro */
     (setattrofunc)type_setattro,                /* tp_setattro */

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -5070,8 +5070,10 @@ _PyStaticType_Dealloc(PyInterpreterState *interp, PyTypeObject *type)
 
 
 static void
-type_dealloc(PyTypeObject *type)
+type_dealloc(PyObject *self)
 {
+    PyTypeObject *type = (PyTypeObject *)self;
+
     // Assert this is a heap-allocated type object
     _PyObject_ASSERT((PyObject *)type, type->tp_flags & Py_TPFLAGS_HEAPTYPE);
 
@@ -5350,7 +5352,7 @@ PyTypeObject PyType_Type = {
     "type",                                     /* tp_name */
     sizeof(PyHeapTypeObject),                   /* tp_basicsize */
     sizeof(PyMemberDef),                        /* tp_itemsize */
-    (destructor)type_dealloc,                   /* tp_dealloc */
+    type_dealloc,                               /* tp_dealloc */
     offsetof(PyTypeObject, tp_vectorcall),      /* tp_vectorcall_offset */
     0,                                          /* tp_getattr */
     0,                                          /* tp_setattr */

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -4925,8 +4925,9 @@ _Py_type_getattro(PyTypeObject *type, PyObject *name)
 }
 
 static int
-type_setattro(PyTypeObject *type, PyObject *name, PyObject *value)
+type_setattro(PyObject *self, PyObject *name, PyObject *value)
 {
+    PyTypeObject *type = (PyTypeObject *)self;
     int res;
     if (type->tp_flags & Py_TPFLAGS_IMMUTABLETYPE) {
         PyErr_Format(
@@ -5370,7 +5371,7 @@ PyTypeObject PyType_Type = {
     type_call,                                  /* tp_call */
     0,                                          /* tp_str */
     (getattrofunc)_Py_type_getattro,            /* tp_getattro */
-    (setattrofunc)type_setattro,                /* tp_setattro */
+    type_setattro,                              /* tp_setattro */
     0,                                          /* tp_as_buffer */
     Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC |
     Py_TPFLAGS_BASETYPE | Py_TPFLAGS_TYPE_SUBCLASS |

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -5261,8 +5261,10 @@ PyDoc_STRVAR(type_doc,
 "type(name, bases, dict, **kwds) -> a new type");
 
 static int
-type_traverse(PyTypeObject *type, visitproc visit, void *arg)
+type_traverse(PyObject *self, visitproc visit, void *arg)
 {
+    PyTypeObject *type = (PyTypeObject *)self;
+
     /* Because of type_is_gc(), the collector only calls this
        for heaptypes. */
     if (!(type->tp_flags & Py_TPFLAGS_HEAPTYPE)) {
@@ -5373,7 +5375,7 @@ PyTypeObject PyType_Type = {
     Py_TPFLAGS_HAVE_VECTORCALL |
     Py_TPFLAGS_ITEMS_AT_END,                    /* tp_flags */
     type_doc,                                   /* tp_doc */
-    (traverseproc)type_traverse,                /* tp_traverse */
+    type_traverse,                              /* tp_traverse */
     (inquiry)type_clear,                        /* tp_clear */
     0,                                          /* tp_richcompare */
     offsetof(PyTypeObject, tp_weaklist),        /* tp_weaklistoffset */

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -1597,8 +1597,9 @@ static PyGetSetDef type_getsets[] = {
 };
 
 static PyObject *
-type_repr(PyTypeObject *type)
+type_repr(PyObject *self)
 {
+    PyTypeObject *type = (PyTypeObject *)self;
     if (type->tp_name == NULL) {
         // type_repr() called before the type is fully initialized
         // by PyType_Ready().
@@ -5354,7 +5355,7 @@ PyTypeObject PyType_Type = {
     0,                                          /* tp_getattr */
     0,                                          /* tp_setattr */
     0,                                          /* tp_as_async */
-    (reprfunc)type_repr,                        /* tp_repr */
+    type_repr,                                  /* tp_repr */
     &type_as_number,                            /* tp_as_number */
     0,                                          /* tp_as_sequence */
     0,                                          /* tp_as_mapping */

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -4919,9 +4919,9 @@ _Py_type_getattro_impl(PyTypeObject *type, PyObject *name, int * suppress_missin
 /* This is similar to PyObject_GenericGetAttr(),
    but uses _PyType_Lookup() instead of just looking in type->tp_dict. */
 PyObject *
-_Py_type_getattro(PyTypeObject *type, PyObject *name)
+_Py_type_getattro(PyObject *type, PyObject *name)
 {
-    return _Py_type_getattro_impl(type, name, NULL);
+    return _Py_type_getattro_impl((PyTypeObject *)type, name, NULL);
 }
 
 static int
@@ -5370,7 +5370,7 @@ PyTypeObject PyType_Type = {
     0,                                          /* tp_hash */
     type_call,                                  /* tp_call */
     0,                                          /* tp_str */
-    (getattrofunc)_Py_type_getattro,            /* tp_getattro */
+    _Py_type_getattro,                          /* tp_getattro */
     type_setattro,                              /* tp_setattro */
     0,                                          /* tp_as_buffer */
     Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC |

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -5292,8 +5292,10 @@ type_traverse(PyObject *self, visitproc visit, void *arg)
 }
 
 static int
-type_clear(PyTypeObject *type)
+type_clear(PyObject *self)
 {
+    PyTypeObject *type = (PyTypeObject *)self;
+
     /* Because of type_is_gc(), the collector only calls this
        for heaptypes. */
     _PyObject_ASSERT((PyObject *)type, type->tp_flags & Py_TPFLAGS_HEAPTYPE);
@@ -5376,7 +5378,7 @@ PyTypeObject PyType_Type = {
     Py_TPFLAGS_ITEMS_AT_END,                    /* tp_flags */
     type_doc,                                   /* tp_doc */
     type_traverse,                              /* tp_traverse */
-    (inquiry)type_clear,                        /* tp_clear */
+    type_clear,                                 /* tp_clear */
     0,                                          /* tp_richcompare */
     offsetof(PyTypeObject, tp_weaklist),        /* tp_weaklistoffset */
     0,                                          /* tp_iter */


### PR DESCRIPTION
There are likely many more changes to be made for gh-111178; this is just one small batch proposed separately for review by the respective codeowner.

Potential compiler warnings addressed:

```
Objects/typeobject.c:5352:5: warning: cast from 'void (*)(PyTypeObject *)' (aka 'void (*)(struct _typeobject *)') to 'destructor' (aka 'void (*)(struct _object *)') converts to incompatible function type [-Wcast-function-type-strict]
 5352 |     (destructor)type_dealloc,                   /* tp_dealloc */
      |     ^~~~~~~~~~~~~~~~~~~~~~~~
Objects/typeobject.c:5357:5: warning: cast from 'PyObject *(*)(PyTypeObject *)' (aka 'struct _object *(*)(struct _typeobject *)') to 'reprfunc' (aka 'struct _object *(*)(struct _object *)') converts to incompatible function type [-Wcast-function-type-strict]
 5357 |     (reprfunc)type_repr,                        /* tp_repr */
      |     ^~~~~~~~~~~~~~~~~~~
Objects/typeobject.c:5362:5: warning: cast from 'PyObject *(*)(PyTypeObject *, PyObject *, PyObject *)' (aka 'struct _object *(*)(struct _typeobject *, struct _object *, struct _object *)') to 'ternaryfunc' (aka 'struct _object *(*)(struct _object *, struct _object *, struct _object *)') converts to incompatible function type [-Wcast-function-type-strict]
 5362 |     (ternaryfunc)type_call,                     /* tp_call */
      |     ^~~~~~~~~~~~~~~~~~~~~~
Objects/typeobject.c:5364:5: warning: cast from 'PyObject *(*)(PyTypeObject *, PyObject *)' (aka 'struct _object *(*)(struct _typeobject *, struct _object *)') to 'getattrofunc' (aka 'struct _object *(*)(struct _object *, struct _object *)') converts to incompatible function type [-Wcast-function-type-strict]
 5364 |     (getattrofunc)_Py_type_getattro,            /* tp_getattro */
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
Objects/typeobject.c:5365:5: warning: cast from 'int (*)(PyTypeObject *, PyObject *, PyObject *)' (aka 'int (*)(struct _typeobject *, struct _object *, struct _object *)') to 'setattrofunc' (aka 'int (*)(struct _object *, struct _object *, struct _object *)') converts to incompatible function type [-Wcast-function-type-strict]
 5365 |     (setattrofunc)type_setattro,                /* tp_setattro */
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~
Objects/typeobject.c:5372:5: warning: cast from 'int (*)(PyTypeObject *, visitproc, void *)' (aka 'int (*)(struct _typeobject *, int (*)(struct _object *, void *), void *)') to 'traverseproc' (aka 'int (*)(struct _object *, int (*)(struct _object *, void *), void *)') converts to incompatible function type [-Wcast-function-type-strict]
 5372 |     (traverseproc)type_traverse,                /* tp_traverse */
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~
Objects/typeobject.c:5373:5: warning: cast from 'int (*)(PyTypeObject *)' (aka 'int (*)(struct _typeobject *)') to 'inquiry' (aka 'int (*)(struct _object *)') converts to incompatible function type [-Wcast-function-type-strict]
 5373 |     (inquiry)type_clear,                        /* tp_clear */
      |     ^~~~~~~~~~~~~~~~~~~
Objects/typeobject.c:5390:5: warning: cast from 'int (*)(PyTypeObject *)' (aka 'int (*)(struct _typeobject *)') to 'inquiry' (aka 'int (*)(struct _object *)') converts to incompatible function type [-Wcast-function-type-strict]
 5390 |     (inquiry)type_is_gc,                        /* tp_is_gc */
      |     ^~~~~~~~~~~~~~~~~~~
Objects/typeobject.c:6572:5: warning: cast from 'Py_hash_t (*)(const void *)' (aka 'long (*)(const void *)') to 'hashfunc' (aka 'long (*)(struct _object *)') converts to incompatible function type [-Wcast-function-type-strict]
 6572 |     (hashfunc)_Py_HashPointer,                  /* tp_hash */
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~
```

Example UBSan `-fsanitize=function` errors addressed:

```
Objects/typeobject.c:7788:12: runtime error: call to function _Py_type_getattro through pointer to incorrect function type 'struct _object *(*)(struct _object *, struct _object *)'
typeobject.c:4921: note: _Py_type_getattro defined here
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior Objects/typeobject.c:7788:12 in 
Objects/call.c:242:18: runtime error: call to function type_call through pointer to incorrect function type 'struct _object *(*)(struct _object *, struct _object *, struct _object *)'
typeobject.c:1634: note: type_call defined here
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior Objects/call.c:242:18 in 
Objects/typeobject.c:1905:16: runtime error: call to function type_clear through pointer to incorrect function type 'int (*)(struct _object *)'
typeobject.c:5290: note: type_clear defined here
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior Objects/typeobject.c:1905:16 in 
Include/internal/pycore_object.h:444:43: runtime error: call to function type_is_gc through pointer to incorrect function type 'int (*)(struct _object *)'
typeobject.c:5338: note: type_is_gc defined here
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior Include/internal/pycore_object.h:444:43 in 
Objects/typeobject.c:5581:12: runtime error: call to function type_repr through pointer to incorrect function type 'struct _object *(*)(struct _object *)'
typeobject.c:1601: note: type_repr defined here
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior Objects/typeobject.c:5581:12 in 
Objects/object.c:1308:15: runtime error: call to function type_setattro through pointer to incorrect function type 'int (*)(struct _object *, struct _object *, struct _object *)'
typeobject.c:4927: note: type_setattro defined here
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior Objects/object.c:1308:15 in 
Modules/_ctypes/_ctypes.c:908:12: runtime error: call to function type_traverse through pointer to incorrect function type 'int (*)(struct _object *, int (*)(struct _object *, void *), void *)'
typeobject.c:5261: note: type_traverse defined here
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior Modules/_ctypes/_ctypes.c:908:12 in
```