### PR TITLE
gh-94692: Only catch OSError in shutil.rmtree()

### DIFF
--- a/Lib/shutil.py
+++ b/Lib/shutil.py
@@ -768,13 +768,13 @@ def rmtree(path, ignore_errors=False, onerror=None, *, onexc=None, dir_fd=None):
         # lstat()/open()/fstat() trick.
         try:
             orig_st = os.lstat(path, dir_fd=dir_fd)
-        except Exception as err:
+        except OSError as err:
             onexc(os.lstat, path, err)
             return
         try:
             fd = os.open(path, os.O_RDONLY, dir_fd=dir_fd)
             fd_closed = False
-        except Exception as err:
+        except OSError as err:
             onexc(os.open, path, err)
             return
         try:

--- a/Misc/NEWS.d/next/Library/2023-12-05-16-20-40.gh-issue-94692.-e5C3c.rst
+++ b/Misc/NEWS.d/next/Library/2023-12-05-16-20-40.gh-issue-94692.-e5C3c.rst
@@ -1,0 +1,4 @@
+:func:`shutil.rmtree` now only catches OSError exceptions. Previously a
+symlink attack resistant version of ``shutil.rmtree()`` could ignore or pass
+to the error handler arbitrary exception when invalid arguments were
+provided.


### PR DESCRIPTION
Previously a symlink attack resistant version of shutil.rmtree() could ignore or pass to the error handler arbitrary exception when invalid arguments were provided.


<!-- gh-issue-number: gh-94692 -->
* Issue: gh-94692
<!-- /gh-issue-number -->
