### PR TITLE
Check argument in itertools's recipe for "grouper"

### DIFF
--- a/Doc/library/itertools.rst
+++ b/Doc/library/itertools.rst
@@ -916,9 +916,9 @@ which incur interpreter overhead.
        args = [iter(iterable)] * n
        if incomplete == 'fill':
            return zip_longest(*args, fillvalue=fillvalue)
-       if incomplete == 'strict':
+       elif incomplete == 'strict':
            return zip(*args, strict=True)
-       if incomplete == 'ignore':
+       elif incomplete == 'ignore':
            return zip(*args)
        else:
            raise ValueError('Expected fill, strict, or ignore')


### PR DESCRIPTION
The recipe for "grouper" has a minor bug where the "incomplete" argument wasn't checked properly
This can be trivially fixed by changing just two lines, replacing "if" by "elif".


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--112759.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->