### PR TITLE
gh-110383: Add documentation entry for `sorted(d)`

### DIFF
--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -4605,7 +4605,7 @@ can be used interchangeably to index the same dictionary entry.
 
    .. describe:: sorted(d)
 
-      Return a sorted iterator over the keys of the dictionary. This is a 
+      Return a sorted iterator over the keys of the dictionary. This is a
       shortcut for ``sorted(d.keys())``.
 
    .. describe:: reversed(d)

--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -4603,6 +4603,11 @@ can be used interchangeably to index the same dictionary entry.
          LIFO order is now guaranteed. In prior versions, :meth:`popitem` would
          return an arbitrary key/value pair.
 
+   .. describe:: sorted(d)
+
+      Return a sorted iterator over the keys of the dictionary. This is a 
+      shortcut for ``sorted(d.keys())``.
+
    .. describe:: reversed(d)
 
       Return a reverse iterator over the keys of the dictionary. This is a


### PR DESCRIPTION
Continues #110383
Originally reported in https://mail.python.org/archives/list/docs@python.org/thread/ZEDPZHRVGLYR4ZFZ5I3NBWVMHMX4WPGW/ (3rd list item)

Add a documentation entry for `sorted(d)` to clarify that it returns the sorted _keys_ and not the `dict` itself.

<!-- gh-issue-number: gh-110383 -->
* Issue: gh-110383
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--112777.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->