### PR TITLE
gh-109981: Fix support.fd_count() on macOS 14

### DIFF
--- a/Lib/test/support/os_helper.py
+++ b/Lib/test/support/os_helper.py
@@ -591,11 +591,12 @@ class FakePath:
 def fd_count():
     """Count the number of open file descriptors.
     """
-    fd_path = None
     if sys.platform.startswith(('linux', 'freebsd', 'emscripten')):
         fd_path = "/proc/self/fd"
     elif sys.platform == "darwin":
         fd_path = "/dev/fd"
+    else:
+        fd_path = None
 
     if fd_path is not None:
         try:

--- a/Lib/test/support/os_helper.py
+++ b/Lib/test/support/os_helper.py
@@ -600,6 +600,15 @@ def fd_count():
         except FileNotFoundError:
             pass
 
+    if sys.platform == 'darwin':
+        try:
+            names = os.listdir("/dev/fd")
+            # Subtract one because listdir() internally opens a file
+            # descriptor to list the content of the /dev/fd directory.
+            return len(names) - 1
+        except FileNotFoundError:
+            pass
+
     MAXFD = 256
     if hasattr(os, 'sysconf'):
         try:

--- a/Lib/test/support/os_helper.py
+++ b/Lib/test/support/os_helper.py
@@ -591,20 +591,17 @@ class FakePath:
 def fd_count():
     """Count the number of open file descriptors.
     """
+    fd_path = None
     if sys.platform.startswith(('linux', 'freebsd', 'emscripten')):
-        try:
-            names = os.listdir("/proc/self/fd")
-            # Subtract one because listdir() internally opens a file
-            # descriptor to list the content of the /proc/self/fd/ directory.
-            return len(names) - 1
-        except FileNotFoundError:
-            pass
+        fd_path = "/proc/self/fd"
+    elif sys.platform == "darwin":
+        fd_path = "/dev/fd"
 
-    if sys.platform == 'darwin':
+    if fd_path is not None:
         try:
-            names = os.listdir("/dev/fd")
+            names = os.listdir(fd_path)
             # Subtract one because listdir() internally opens a file
-            # descriptor to list the content of the /dev/fd directory.
+            # descriptor to list the content of the directory.
             return len(names) - 1
         except FileNotFoundError:
             pass

--- a/Misc/NEWS.d/next/macOS/2023-12-06-12-11-13.gh-issue-109981.mOHg10.rst
+++ b/Misc/NEWS.d/next/macOS/2023-12-06-12-11-13.gh-issue-109981.mOHg10.rst
@@ -1,0 +1,3 @@
+Use ``/dev/fd`` on macOS to determine the number of open files in
+``test.support.os_helper.fd_count`` to avoid a crash with "guarded" file
+descriptors when probing for open files.


### PR DESCRIPTION
This fixes a crash on macOS 14 when
running ``./python.exe -m test test_sax test_socket test_support``.

The root cause of this is a macOS feature where file descriptors used by system libraries are guarded an will cause a hard crash when used in "user" code.

<!-- gh-issue-number: gh-109981 -->
* Issue: gh-109981
<!-- /gh-issue-number -->
