### PR TITLE
gh-112800: Ignore PermissionError on SubprocessTransport.close()

### DIFF
--- a/Lib/asyncio/base_subprocess.py
+++ b/Lib/asyncio/base_subprocess.py
@@ -115,7 +115,8 @@ class BaseSubprocessTransport(transports.SubprocessTransport):
 
             try:
                 self._proc.kill()
-            except ProcessLookupError:
+            except (ProcessLookupError, PermissionError):
+                # the process may have already exited or may be running setuid
                 pass
 
             # Don't clear the _proc reference yet: _post_init() may still run

--- a/Misc/NEWS.d/next/Library/2023-12-06-16-01-33.gh-issue-112800.TNsGJ-.rst
+++ b/Misc/NEWS.d/next/Library/2023-12-06-16-01-33.gh-issue-112800.TNsGJ-.rst
@@ -1,0 +1,2 @@
+Fix :mod:`asyncio` ``SubprocessTransport.close()`` not to throw
+``PermissionError`` when used with setuid executables.


### PR DESCRIPTION
In case the spawned process is setuid, we may not be able to send signals to it, in which case our .kill() call will raise PermissionError.

Ignore that in order to avoid .close() raising an exception.  Hopefully the process will exit as a result of receiving EOF on its stdin.

Closes #112800

<!-- gh-issue-number: gh-112800 -->
* Issue: gh-112800
<!-- /gh-issue-number -->
