### PR TITLE
gh-112758: Updated pathlib documentation for PurePath.match

### DIFF
--- a/Doc/library/pathlib.rst
+++ b/Doc/library/pathlib.rst
@@ -596,7 +596,7 @@ Pure paths provide the following methods and properties:
       True
 
    .. versionchanged:: 3.12
-      Accepts path object.
+      Accepts another path object.
 
    As with other methods, case-sensitivity follows platform defaults::
 

--- a/Doc/library/pathlib.rst
+++ b/Doc/library/pathlib.rst
@@ -596,7 +596,7 @@ Pure paths provide the following methods and properties:
       True
 
    .. versionchanged:: 3.12
-      Accepts another path object.
+      Accepts an object implementing the :class:`os.PathLike` interface.
 
    As with other methods, case-sensitivity follows platform defaults::
 

--- a/Doc/library/pathlib.rst
+++ b/Doc/library/pathlib.rst
@@ -595,6 +595,9 @@ Pure paths provide the following methods and properties:
       >>> PurePath('a/b.py').match(pattern)
       True
 
+   .. versionchanged:: 3.12
+      Accepts path object.
+
    As with other methods, case-sensitivity follows platform defaults::
 
       >>> PurePosixPath('b.py').match('*.PY')


### PR DESCRIPTION
Updated the PurePath.match based on issue [#112758](https://github.com/python/cpython/issues/112758)

Added the following to the pathlib documentation:
Changed in Version 3.12: Accepts another path object.

I am not sure if this wording is correct and/or if this change to the documentation needs backport to 3.12 documentation. If either one or both of these changes need to be made I will make the necessary adjustments.

<!-- gh-issue-number: gh-112758 -->
* Issue: gh-112758
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--112814.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->