### PR TITLE
bpo-42519: Remove outdated sentence in comment

### DIFF
--- a/Include/objimpl.h
+++ b/Include/objimpl.h
@@ -35,7 +35,7 @@ Functions and macros for modules that implement new object types.
    fields, this also fills in the ob_size field.
 
  - PyObject_Free(op) releases the memory allocated for an object.  It does not
-   run a destructor -- it only frees the memory.  PyObject_Free is identical.
+   run a destructor -- it only frees the memory.
 
  - PyObject_Init(op, typeobj) and PyObject_InitVar(op, typeobj, n) don't
    allocate memory.  Instead of a 'type' parameter, they take a pointer to a


### PR DESCRIPTION
This sentence about `PyObject_Free()` was needed because the prior sentences were originally about `PyObject_Del()`, which has since been replaced by `PyObject_Free()` in #23587.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
