### PR TITLE
gh-110820: Make sure processor specific defines are correct for Universal 2 build on macOS

### DIFF
--- a/Include/pymacconfig.h
+++ b/Include/pymacconfig.h
@@ -7,7 +7,9 @@
 #define PY_MACCONFIG_H
 #ifdef __APPLE__
 
+#undef ALIGNOF_MAX_ALIGN_T
 #undef SIZEOF_LONG
+#undef SIZEOF_LONG_DOUBLE
 #undef SIZEOF_PTHREAD_T
 #undef SIZEOF_SIZE_T
 #undef SIZEOF_TIME_T
@@ -20,6 +22,7 @@
 #undef DOUBLE_IS_BIG_ENDIAN_IEEE754
 #undef DOUBLE_IS_LITTLE_ENDIAN_IEEE754
 #undef HAVE_GCC_ASM_FOR_X87
+#undef HAVE_GCC_ASM_FOR_X64
 
 #undef VA_LIST_IS_ARRAY
 #if defined(__LP64__) && defined(__x86_64__)
@@ -74,8 +77,14 @@
 #  define DOUBLE_IS_LITTLE_ENDIAN_IEEE754
 #endif
 
-#ifdef __i386__
+#if defined(__i386__) || defined(__x86_64__)
 #  define HAVE_GCC_ASM_FOR_X87
+#  define ALIGNOF_MAX_ALIGN_T 16
+#  define HAVE_GCC_ASM_FOR_X64 1
+#  define SIZEOF_LONG_DOUBLE 16
+#else
+#  define ALIGNOF_MAX_ALIGN_T 8
+#  define SIZEOF_LONG_DOUBLE 8
 #endif
 
 #endif   // __APPLE__

--- a/Include/pyport.h
+++ b/Include/pyport.h
@@ -584,6 +584,7 @@ extern "C" {
 #if !defined(ALIGNOF_MAX_ALIGN_T) || ALIGNOF_MAX_ALIGN_T == 0
 #   undef ALIGNOF_MAX_ALIGN_T
 #   define ALIGNOF_MAX_ALIGN_T _Alignof(long double)
+#  error "Why?"
 #endif
 
 #ifndef PY_CXX_CONST

--- a/Include/pyport.h
+++ b/Include/pyport.h
@@ -584,7 +584,6 @@ extern "C" {
 #if !defined(ALIGNOF_MAX_ALIGN_T) || ALIGNOF_MAX_ALIGN_T == 0
 #   undef ALIGNOF_MAX_ALIGN_T
 #   define ALIGNOF_MAX_ALIGN_T _Alignof(long double)
-#  error "Why?"
 #endif
 
 #ifndef PY_CXX_CONST

--- a/Misc/NEWS.d/next/macOS/2023-12-07-14-19-46.gh-issue-110820.DIxb_F.rst
+++ b/Misc/NEWS.d/next/macOS/2023-12-07-14-19-46.gh-issue-110820.DIxb_F.rst
@@ -1,0 +1,3 @@
+Make sure the preprocessor definitions for ``ALIGNOF_MAX_ALIGN_T``,
+``SIZEOF_LONG_DOUBLE`` and ``HAVE_GCC_ASM_FOR_X64`` are correct for
+Universal 2 builds on macOS.


### PR DESCRIPTION

A number of processor specific defines are different for x86-64 and arm64, and need to be adjusted in pymacconfig.h.


<!-- gh-issue-number: gh-110820 -->
* Issue: gh-110820
<!-- /gh-issue-number -->
