### PR TITLE
gh-101100: Silence Sphinx warnings when `ntpath` or `posixpath` are referenced

### DIFF
--- a/Doc/conf.py
+++ b/Doc/conf.py
@@ -166,6 +166,10 @@ nitpick_ignore = [
     # Deprecated function that was never documented:
     ('py:func', 'getargspec'),
     ('py:func', 'inspect.getargspec'),
+    # Undocumented modules that users shouldn't have to worry about
+    # (implementation details of `os.path`):
+    ('py:mod', 'ntpath'),
+    ('py:mod', 'posixpath'),
 ]
 
 # Temporary undocumented names.

--- a/Doc/library/pathlib.rst
+++ b/Doc/library/pathlib.rst
@@ -306,7 +306,7 @@ Pure paths provide the following methods and properties:
 .. attribute:: PurePath.pathmod
 
    The implementation of the :mod:`os.path` module used for low-level path
-   operations: either ``posixpath`` or ``ntpath``.
+   operations: either :mod:`posixpath` or :mod:`ntpath`.
 
    .. versionadded:: 3.13
 

--- a/Doc/tools/.nitignore
+++ b/Doc/tools/.nitignore
@@ -72,7 +72,6 @@ Doc/library/multiprocessing.rst
 Doc/library/multiprocessing.shared_memory.rst
 Doc/library/numbers.rst
 Doc/library/optparse.rst
-Doc/library/os.path.rst
 Doc/library/os.rst
 Doc/library/pickle.rst
 Doc/library/pickletools.rst

--- a/Doc/whatsnew/3.7.rst
+++ b/Doc/whatsnew/3.7.rst
@@ -2144,9 +2144,9 @@ The following features and APIs have been removed from Python 3.7:
 * Removed support of the *exclude* argument in :meth:`tarfile.TarFile.add`.
   It was deprecated in Python 2.7 and 3.2.  Use the *filter* argument instead.
 
-* The ``splitunc()`` function in the :mod:`ntpath` module was deprecated in
-  Python 3.1, and has now been removed.  Use the :func:`~os.path.splitdrive`
-  function instead.
+* The :func:`!ntpath.splitunc` function was deprecated in
+  Python 3.1, and has now been removed.  Use :func:`~os.path.splitdrive`
+  instead.
 
 * :func:`collections.namedtuple` no longer supports the *verbose* parameter
   or ``_source`` attribute which showed the generated source code for the


### PR DESCRIPTION
`ntpath` and `posixpath` are undocumented modules, and I think they should stay undocumented. The vast majority of users won't need to worry about them; they're implementation details of `os.path`.

This PR silences Sphinx warnings when these modules are referenced (because Sphinx cannot resolve the references) by adding them to the `nitpick_ignore` list in `Doc/conf.py`. Doing this allows us to remove `library/os.path.rst` from the `.nitignore` list of files.

<!-- gh-issue-number: gh-101100 -->
* Issue: gh-101100
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--112833.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->