### PR TITLE
gh-110017: Disable test_signal.test_stress_modifying_handlers on macOS

### DIFF
--- a/Lib/test/test_signal.py
+++ b/Lib/test/test_signal.py
@@ -1318,6 +1318,7 @@ class StressTest(unittest.TestCase):
         # Python handler
         self.assertEqual(len(sigs), N, "Some signals were lost")
 
+    @unittest.skipIf(sys.platform == "darwin", "crashes due to system bug (FB13453490)")
     @unittest.skipUnless(hasattr(signal, "SIGUSR1"),
                          "test needs SIGUSR1")
     @threading_helper.requires_working_threading()

--- a/Misc/NEWS.d/next/macOS/2023-12-07-15-53-16.gh-issue-110017.UMYzMR.rst
+++ b/Misc/NEWS.d/next/macOS/2023-12-07-15-53-16.gh-issue-110017.UMYzMR.rst
@@ -1,0 +1,2 @@
+Disable a signal handling stress test on macOS due to a bug in macOS
+(FB13453490).


### PR DESCRIPTION
Test test_stress_modifying_handlers in test_signal can crash the interpreter due to a bug in macOS. Filed as FB13453490 with Apple.

<!-- gh-issue-number: gh-110017 -->
* Issue: gh-110017
<!-- /gh-issue-number -->
