### PR TITLE
gh-101100: Fix Sphinx nitpicks in `library/shelve.rst`

### DIFF
--- a/Doc/library/shelve.rst
+++ b/Doc/library/shelve.rst
@@ -149,13 +149,14 @@ Restrictions
 
 .. class:: BsdDbShelf(dict, protocol=None, writeback=False, keyencoding='utf-8')
 
-   A subclass of :class:`Shelf` which exposes :meth:`first`, :meth:`!next`,
-   :meth:`previous`, :meth:`last` and :meth:`set_location` which are available
-   in the third-party :mod:`bsddb` module from `pybsddb
+   A subclass of :class:`Shelf` which exposes :meth:`!first`, :meth:`!next`,
+   :meth:`!previous`, :meth:`!last` and :meth:`!set_location` methods.
+   These are available
+   in the third-party :mod:`!bsddb` module from `pybsddb
    <https://www.jcea.es/programacion/pybsddb.htm>`_ but not in other database
    modules.  The *dict* object passed to the constructor must support those
    methods.  This is generally accomplished by calling one of
-   :func:`bsddb.hashopen`, :func:`bsddb.btopen` or :func:`bsddb.rnopen`.  The
+   :func:`!bsddb.hashopen`, :func:`!bsddb.btopen` or :func:`!bsddb.rnopen`.  The
    optional *protocol*, *writeback*, and *keyencoding* parameters have the same
    interpretation as for the :class:`Shelf` class.
 

--- a/Doc/tools/.nitignore
+++ b/Doc/tools/.nitignore
@@ -87,7 +87,6 @@ Doc/library/readline.rst
 Doc/library/resource.rst
 Doc/library/rlcompleter.rst
 Doc/library/select.rst
-Doc/library/shelve.rst
 Doc/library/signal.rst
 Doc/library/smtplib.rst
 Doc/library/socket.rst


### PR DESCRIPTION


<!-- gh-issue-number: gh-101100 -->
* Issue: gh-101100
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--112836.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->