### PR TITLE
gh-112730: Update docs for colour env vars

### DIFF
--- a/Doc/using/cmdline.rst
+++ b/Doc/using/cmdline.rst
@@ -612,7 +612,9 @@ Miscellaneous options
    .. versionadded:: 3.13
       The ``-X presite`` option.
 
-Controlling Color
+.. _using-on-controlling-color:
+
+Controlling color
 ~~~~~~~~~~~~~~~~~
 
 The Python interpreter is configured by default to use colors to highlight
@@ -1135,6 +1137,7 @@ conflict.
 
    If this variable is set to ``1``, the interpreter will colorize various kinds
    of output. Setting it to ``0`` deactivates this behavior.
+   See also :ref:`using-on-controlling-color`.
 
    .. versionadded:: 3.13
 

--- a/Doc/whatsnew/3.13.rst
+++ b/Doc/whatsnew/3.13.rst
@@ -91,7 +91,8 @@ Improved Error Messages
 * The interpreter now colorizes error messages when displaying tracebacks by default.
   This feature can be controlled via the new :envvar:`PYTHON_COLORS` environment
   variable as well as the canonical ``NO_COLOR`` and ``FORCE_COLOR`` environment
-  variables. (Contributed by Pablo Galindo Salgado in :gh:`112730`.)
+  variables. See also :ref:`using-on-controlling-color`.
+  (Contributed by Pablo Galindo Salgado in :gh:`112730`.)
 
 Other Language Changes
 ======================

--- a/Misc/python.man
+++ b/Misc/python.man
@@ -601,6 +601,9 @@ show how long each import takes. This is exactly equivalent to setting
 .IP PYTHONBREAKPOINT
 If this environment variable is set to 0, it disables the default debugger. It
 can be set to the callable of your debugger of choice.
+.IP PYTHON_COLORS
+If this variable is set to 1, the interpreter will colorize various kinds of
+output. Setting it to 0 deactivates this behavior.
 .SS Debug-mode variables
 Setting these variables only has an effect in a debug build of Python, that is,
 if Python was configured with the


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

* Make "Controlling color" header in sentence case to match others:

![image](https://github.com/python/cpython/assets/1324225/773a9949-bace-45f7-945c-933811cb0716)

* Link from the env var and what's new sections to the most descriptive "Controlling color" section.

* Also add the env var description to `python.man` so it shows in the man pages. 

(I spotted the note at the top of `cmdline.rst` saying "You probably should update Misc/python.man, too, if you modify this file". There's a few other missing env vars to fill in.)


<!-- gh-issue-number: gh-112730 -->
* Issue: gh-112730
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--112837.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->