### PR TITLE
gh-112796: Remove two disabled code blocks from expat/xmlparse.c

### DIFF
--- a/Modules/expat/xmlparse.c
+++ b/Modules/expat/xmlparse.c
@@ -3099,23 +3099,6 @@ doContent(XML_Parser parser, int startTagLevel, const ENCODING *enc,
       enum XML_Error result;
       if (parser->m_startCdataSectionHandler)
         parser->m_startCdataSectionHandler(parser->m_handlerArg);
-      /* BEGIN disabled code */
-      /* Suppose you doing a transformation on a document that involves
-         changing only the character data.  You set up a defaultHandler
-         and a characterDataHandler.  The defaultHandler simply copies
-         characters through.  The characterDataHandler does the
-         transformation and writes the characters out escaping them as
-         necessary.  This case will fail to work if we leave out the
-         following two lines (because & and < inside CDATA sections will
-         be incorrectly escaped).
-
-         However, now we have a start/endCdataSectionHandler, so it seems
-         easier to let the user deal with this.
-      */
-      else if (0 && parser->m_characterDataHandler)
-        parser->m_characterDataHandler(parser->m_handlerArg, parser->m_dataBuf,
-                                       0);
-      /* END disabled code */
       else if (parser->m_defaultHandler)
         reportDefault(parser, enc, s, next);
       result
@@ -4053,12 +4036,6 @@ doCdataSection(XML_Parser parser, const ENCODING *enc, const char **startPtr,
     case XML_TOK_CDATA_SECT_CLOSE:
       if (parser->m_endCdataSectionHandler)
         parser->m_endCdataSectionHandler(parser->m_handlerArg);
-      /* BEGIN disabled code */
-      /* see comment under XML_TOK_CDATA_SECT_OPEN */
-      else if (0 && parser->m_characterDataHandler)
-        parser->m_characterDataHandler(parser->m_handlerArg, parser->m_dataBuf,
-                                       0);
-      /* END disabled code */
       else if (parser->m_defaultHandler)
         reportDefault(parser, enc, s, next);
       *startPtr = next;


### PR DESCRIPTION
This removes two blocks of code from expat/xmlparse.c that were disabled by turning them into ``if(0 && ...)`` blocks.

This code has been inactive since 2019 and can be revived from the repository when it is needed again.

<!-- gh-issue-number: gh-112796 -->
* Issue: gh-112796
<!-- /gh-issue-number -->
