### PR TITLE
[3.11] gh-106905: Avoid incorrect SystemError about recursion depth mismatch (#106906)

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2023-07-20-11-41-16.gh-issue-106905.AyZpuB.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2023-07-20-11-41-16.gh-issue-106905.AyZpuB.rst
@@ -1,0 +1,1 @@
+Fix incorrect SystemError about AST constructor recursion depth mismatch.

--- a/Parser/asdl_c.py
+++ b/Parser/asdl_c.py
@@ -1273,6 +1273,7 @@ class ObjVisitor(PickleVisitor):
         self.emit("state->recursion_depth--;", 1)
         self.emit("return result;", 1)
         self.emit("failed:", 0)
+        self.emit("state->recursion_depth--;", 1)
         self.emit("Py_XDECREF(value);", 1)
         self.emit("Py_XDECREF(result);", 1)
         self.emit("return NULL;", 1)

--- a/Python/Python-ast.c
+++ b/Python/Python-ast.c
@@ -3675,6 +3675,7 @@ ast2obj_mod(struct ast_state *state, void* _o)
     state->recursion_depth--;
     return result;
 failed:
+    state->recursion_depth--;
     Py_XDECREF(value);
     Py_XDECREF(result);
     return NULL;
@@ -4240,6 +4241,7 @@ ast2obj_stmt(struct ast_state *state, void* _o)
     state->recursion_depth--;
     return result;
 failed:
+    state->recursion_depth--;
     Py_XDECREF(value);
     Py_XDECREF(result);
     return NULL;
@@ -4723,6 +4725,7 @@ ast2obj_expr(struct ast_state *state, void* _o)
     state->recursion_depth--;
     return result;
 failed:
+    state->recursion_depth--;
     Py_XDECREF(value);
     Py_XDECREF(result);
     return NULL;
@@ -4894,6 +4897,7 @@ ast2obj_comprehension(struct ast_state *state, void* _o)
     state->recursion_depth--;
     return result;
 failed:
+    state->recursion_depth--;
     Py_XDECREF(value);
     Py_XDECREF(result);
     return NULL;
@@ -4959,6 +4963,7 @@ ast2obj_excepthandler(struct ast_state *state, void* _o)
     state->recursion_depth--;
     return result;
 failed:
+    state->recursion_depth--;
     Py_XDECREF(value);
     Py_XDECREF(result);
     return NULL;
@@ -5019,6 +5024,7 @@ ast2obj_arguments(struct ast_state *state, void* _o)
     state->recursion_depth--;
     return result;
 failed:
+    state->recursion_depth--;
     Py_XDECREF(value);
     Py_XDECREF(result);
     return NULL;
@@ -5079,6 +5085,7 @@ ast2obj_arg(struct ast_state *state, void* _o)
     state->recursion_depth--;
     return result;
 failed:
+    state->recursion_depth--;
     Py_XDECREF(value);
     Py_XDECREF(result);
     return NULL;
@@ -5134,6 +5141,7 @@ ast2obj_keyword(struct ast_state *state, void* _o)
     state->recursion_depth--;
     return result;
 failed:
+    state->recursion_depth--;
     Py_XDECREF(value);
     Py_XDECREF(result);
     return NULL;
@@ -5189,6 +5197,7 @@ ast2obj_alias(struct ast_state *state, void* _o)
     state->recursion_depth--;
     return result;
 failed:
+    state->recursion_depth--;
     Py_XDECREF(value);
     Py_XDECREF(result);
     return NULL;
@@ -5224,6 +5233,7 @@ ast2obj_withitem(struct ast_state *state, void* _o)
     state->recursion_depth--;
     return result;
 failed:
+    state->recursion_depth--;
     Py_XDECREF(value);
     Py_XDECREF(result);
     return NULL;
@@ -5264,6 +5274,7 @@ ast2obj_match_case(struct ast_state *state, void* _o)
     state->recursion_depth--;
     return result;
 failed:
+    state->recursion_depth--;
     Py_XDECREF(value);
     Py_XDECREF(result);
     return NULL;
@@ -5425,6 +5436,7 @@ ast2obj_pattern(struct ast_state *state, void* _o)
     state->recursion_depth--;
     return result;
 failed:
+    state->recursion_depth--;
     Py_XDECREF(value);
     Py_XDECREF(result);
     return NULL;
@@ -5464,6 +5476,7 @@ ast2obj_type_ignore(struct ast_state *state, void* _o)
     state->recursion_depth--;
     return result;
 failed:
+    state->recursion_depth--;
     Py_XDECREF(value);
     Py_XDECREF(result);
     return NULL;


### PR DESCRIPTION
Backport of 1447af797048e62049d00bbd96d8daee3929f527 from https://github.com/python/cpython/pull/106906.

* gh-106905: avoid incorrect SystemError about recursion depth mismatch
* Update Misc/NEWS.d/next/Core and Builtins/2023-07-20-11-41-16.gh-issue-106905.AyZpuB.rst