### PR TITLE
[3.12] gh-112826: Fix the threading Module When _thread is Missing _is_main_interpreter()

### DIFF
--- a/Doc/whatsnew/3.12.rst
+++ b/Doc/whatsnew/3.12.rst
@@ -1895,6 +1895,15 @@ Changes in the Python API
   * Mixing tabs and spaces as indentation in the same file is not supported anymore and will
     raise a :exc:`TabError`.
 
+  * The :mod:`threading` module now expects the `_thread` module to have
+    a ``_is_main_interpreter`` attribute.  Is is a function with no
+    arguments that returns ``True`` if the current interpreter is the
+    main interpreter.
+
+    Any library or application that provides a custom ``_thread`` module
+    must make sure it provides ``_is_main_interpreter()``.
+    (See :gh:`112826`.)
+
 Build Changes
 =============
 

--- a/Doc/whatsnew/3.12.rst
+++ b/Doc/whatsnew/3.12.rst
@@ -1895,7 +1895,7 @@ Changes in the Python API
   * Mixing tabs and spaces as indentation in the same file is not supported anymore and will
     raise a :exc:`TabError`.
 
-  * The :mod:`threading` module now expects the `_thread` module to have
+  * The :mod:`threading` module now expects the :mod:`!_thread` module to have
     a ``_is_main_interpreter`` attribute.  Is is a function with no
     arguments that returns ``True`` if the current interpreter is the
     main interpreter.

--- a/Doc/whatsnew/3.12.rst
+++ b/Doc/whatsnew/3.12.rst
@@ -1896,7 +1896,7 @@ Changes in the Python API
     raise a :exc:`TabError`.
 
   * The :mod:`threading` module now expects the :mod:`!_thread` module to have
-    a ``_is_main_interpreter`` attribute.  Is is a function with no
+    an ``_is_main_interpreter`` attribute.  It is a function with no
     arguments that returns ``True`` if the current interpreter is the
     main interpreter.
 

--- a/Doc/whatsnew/3.12.rst
+++ b/Doc/whatsnew/3.12.rst
@@ -1901,7 +1901,7 @@ Changes in the Python API
     main interpreter.
 
     Any library or application that provides a custom ``_thread`` module
-    must make sure it provides ``_is_main_interpreter()``.
+    should provide ``_is_main_interpreter()``.
     (See :gh:`112826`.)
 
 Build Changes

--- a/Doc/whatsnew/3.12.rst
+++ b/Doc/whatsnew/3.12.rst
@@ -1895,14 +1895,14 @@ Changes in the Python API
   * Mixing tabs and spaces as indentation in the same file is not supported anymore and will
     raise a :exc:`TabError`.
 
-  * The :mod:`threading` module now expects the :mod:`!_thread` module to have
-    an ``_is_main_interpreter`` attribute.  It is a function with no
-    arguments that returns ``True`` if the current interpreter is the
-    main interpreter.
+* The :mod:`threading` module now expects the :mod:`!_thread` module to have
+  an ``_is_main_interpreter`` attribute.  It is a function with no
+  arguments that returns ``True`` if the current interpreter is the
+  main interpreter.
 
-    Any library or application that provides a custom ``_thread`` module
-    should provide ``_is_main_interpreter()``.
-    (See :gh:`112826`.)
+  Any library or application that provides a custom ``_thread`` module
+  should provide ``_is_main_interpreter()``.
+  (See :gh:`112826`.)
 
 Build Changes
 =============

--- a/Lib/test/test_threading.py
+++ b/Lib/test/test_threading.py
@@ -1827,6 +1827,39 @@ class MiscTestCase(unittest.TestCase):
         support.check__all__(self, threading, ('threading', '_thread'),
                              extra=extra, not_exported=not_exported)
 
+    @requires_subprocess()
+    def test_gh112826_missing__thread__is_main_interpreter(self):
+        with os_helper.temp_dir() as tempdir:
+            modname = '_thread_fake'
+            import os.path
+            filename = os.path.join(tempdir, modname + '.py')
+            with open(filename, 'w') as outfile:
+                outfile.write("""if True:
+                    import _thread
+                    ns = globals().update(vars(_thread))
+                    #from _thread import *
+                    del _is_main_interpreter
+                    """)
+            expected_output = 'success!'
+            script = f"""if True:
+                import sys
+                sys.path.insert(0, {tempdir!r})
+                import {modname}
+                sys.modules['_thread'] = _thread_fake
+                del sys.modules[{modname!r}]
+
+                import threading
+                print({expected_output!r}, end='')
+                """
+            proc = subprocess.run(
+                [sys.executable, "-c", script],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                text=True,
+            )
+            self.assertEqual(proc.stdout, expected_output)
+            self.assertEqual(proc.returncode, 0)
+
 
 class InterruptMainTests(unittest.TestCase):
     def check_interrupt_main_with_signal_handler(self, signum):

--- a/Lib/threading.py
+++ b/Lib/threading.py
@@ -37,7 +37,20 @@ _daemon_threads_allowed = _thread.daemon_threads_allowed
 _allocate_lock = _thread.allocate_lock
 _set_sentinel = _thread._set_sentinel
 get_ident = _thread.get_ident
-_is_main_interpreter = _thread._is_main_interpreter
+try:
+    _is_main_interpreter = _thread._is_main_interpreter
+except AttributeError:
+    # See https://github.com/python/cpython/issues/112826.
+    # We can pretend a subinterpreter is the main interpreter for the
+    # sake of _shutdown(), since that only means we do not wait for the
+    # subinterpreter's threads to finish.  Instead, they will be stopped
+    # later by the mechanism we use for daemon threads.  The likelihood
+    # of this case is small because rarely will the _thread module be
+    # replaced by a module without _is_main_interpreter().
+    # Furthermore, this is all irrelevant in applications
+    # that do not use subinterpreters.
+    def _is_main_interpreter():
+        return True
 try:
     get_native_id = _thread.get_native_id
     _HAVE_THREAD_NATIVE_ID = True


### PR DESCRIPTION
`_thread._is_main_interpreter()` was added (and aliased as `threading._is_main_interpreter()`) after the 3.12.0 release, in gh-110707 (a backport of gh-112661).  However, that change did not accommodate cases where users replace the `_thread` module with a custom version that doesn't have `_is_main_interpreter()` defined (e.g. gevent).

This change fixes that by falling back to a dummy `_is_main_interpreter()` that always says "yes".  That case is unlikely and the consequences of saying a subinterpreter is the main interpreter, relative to `threading._shutdown(), are almost zero.

(We are fixing this in 3.12 only because it is a regression from the already released 3.12.0.  In 3.13 (main) we will only have the note in "What's New".)

<!-- gh-issue-number: gh-112826 -->
* Issue: gh-112826
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--112850.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->