### PR TITLE
gh-112826: Add a "What's New" Entry About _thread._is_main_interpreter

### DIFF
--- a/Doc/whatsnew/3.12.rst
+++ b/Doc/whatsnew/3.12.rst
@@ -2236,6 +2236,15 @@ Porting to Python 3.12
   guidance then please create a new GitHub issue
   and CC ``@ericsnowcurrently``.
 
+  * The :mod:`threading` module now expects the :mod:`!_thread` module to have
+    a ``_is_main_interpreter`` attribute.  Is is a function with no
+    arguments that returns ``True`` if the current interpreter is the
+    main interpreter.
+
+    Any library or application that provides a custom ``_thread`` module
+    must make sure it provides ``_is_main_interpreter()``.
+    (See :gh:`112826`.)
+
 Deprecated
 ----------
 

--- a/Doc/whatsnew/3.12.rst
+++ b/Doc/whatsnew/3.12.rst
@@ -1892,6 +1892,15 @@ Changes in the Python API
   * Mixing tabs and spaces as indentation in the same file is not supported anymore and will
     raise a :exc:`TabError`.
 
+* The :mod:`threading` module now expects the :mod:`!_thread` module to have
+  an ``_is_main_interpreter`` attribute.  It is a function with no
+  arguments that returns ``True`` if the current interpreter is the
+  main interpreter.
+
+  Any library or application that provides a custom ``_thread`` module
+  should provide ``_is_main_interpreter()``.
+  (See :gh:`112826`.)
+
 Build Changes
 =============
 
@@ -2235,15 +2244,6 @@ Porting to Python 3.12
   If your custom allocator is not already thread-safe and you need
   guidance then please create a new GitHub issue
   and CC ``@ericsnowcurrently``.
-
-  * The :mod:`threading` module now expects the :mod:`!_thread` module to have
-    a ``_is_main_interpreter`` attribute.  Is is a function with no
-    arguments that returns ``True`` if the current interpreter is the
-    main interpreter.
-
-    Any library or application that provides a custom ``_thread`` module
-    must make sure it provides ``_is_main_interpreter()``.
-    (See :gh:`112826`.)
 
 Deprecated
 ----------

--- a/Doc/whatsnew/3.13.rst
+++ b/Doc/whatsnew/3.13.rst
@@ -1046,6 +1046,15 @@ Changes in the Python API
   retrieve a username, instead of :exc:`ImportError` on non-Unix platforms or
   :exc:`KeyError` on Unix platforms where the password database is empty.
 
+  * The :mod:`threading` module now expects the :mod:`!_thread` module to have
+    a ``_is_main_interpreter`` attribute.  Is is a function with no
+    arguments that returns ``True`` if the current interpreter is the
+    main interpreter.
+
+    Any library or application that provides a custom ``_thread`` module
+    must make sure it provides ``_is_main_interpreter()``.
+    (See :gh:`112826`.)
+
 
 Build Changes
 =============

--- a/Doc/whatsnew/3.13.rst
+++ b/Doc/whatsnew/3.13.rst
@@ -1046,14 +1046,15 @@ Changes in the Python API
   retrieve a username, instead of :exc:`ImportError` on non-Unix platforms or
   :exc:`KeyError` on Unix platforms where the password database is empty.
 
-  * The :mod:`threading` module now expects the :mod:`!_thread` module to have
-    a ``_is_main_interpreter`` attribute.  Is is a function with no
-    arguments that returns ``True`` if the current interpreter is the
-    main interpreter.
+* The :mod:`threading` module now expects the :mod:`!_thread` module to have
+  an ``_is_main_interpreter`` attribute.  It is a function with no
+  arguments that returns ``True`` if the current interpreter is the
+  main interpreter.
 
-    Any library or application that provides a custom ``_thread`` module
-    must make sure it provides ``_is_main_interpreter()``.
-    (See :gh:`112826`.)
+  Any library or application that provides a custom ``_thread`` module
+  must provide ``_is_main_interpreter()``, just like the module's
+  other "private" attributes.
+  (See :gh:`112826`.)
 
 
 Build Changes


### PR DESCRIPTION
As of gh-112661, the `threading` module expects the `_thread` module to have a `_is_main_interpreter()`, which is used in the internal `threading._shutdown()`.  This change causes a problem for anyone that replaces the `_thread` module with a custom one (only if they don't provide `_is_main_interpreter()`).  They need to be sure to add it for 3.13+, thus this PR is adding a note in "What's New".

This also forward-ports the "What's New" entry from 3.12 (gh-112850).  Note that we do not also forward-port the fix in that PR.  The fix is there only due to a regression from 3.12.0.  There is no regression in 3.13+.

<!-- gh-issue-number: gh-112826 -->
* Issue: gh-112826
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--112853.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->