### PR TITLE
gh-112302: Annotate SBOM file as generated in .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -84,6 +84,7 @@ Lib/keyword.py                                      generated
 Lib/test/levenshtein_examples.json                  generated
 Lib/test/test_stable_abi_ctypes.py                  generated
 Lib/token.py                                        generated
+Misc/sbom.spdx.json                                 generated
 Objects/typeslots.inc                               generated
 PC/python3dll.c                                     generated
 Parser/parser.c                                     generated


### PR DESCRIPTION
Recommended by @pitrou: https://github.com/python/cpython/pull/112303#issuecomment-1845802150

<!-- gh-issue-number: gh-112302 -->
* Issue: gh-112302
<!-- /gh-issue-number -->
