### PR TITLE
[3.11] gh-101100: Silence Sphinx warnings when `ntpath` or `posixpath` are referenced (#112833)

### DIFF
--- a/Doc/conf.py
+++ b/Doc/conf.py
@@ -152,6 +152,10 @@ nitpick_ignore = [
     # Deprecated function that was never documented:
     ('py:func', 'getargspec'),
     ('py:func', 'inspect.getargspec'),
+    # Undocumented modules that users shouldn't have to worry about
+    # (implementation details of `os.path`):
+    ('py:mod', 'ntpath'),
+    ('py:mod', 'posixpath'),
 ]
 
 # Temporary undocumented names.

--- a/Doc/tools/.nitignore
+++ b/Doc/tools/.nitignore
@@ -75,7 +75,6 @@ Doc/library/multiprocessing.rst
 Doc/library/multiprocessing.shared_memory.rst
 Doc/library/numbers.rst
 Doc/library/optparse.rst
-Doc/library/os.path.rst
 Doc/library/os.rst
 Doc/library/pickle.rst
 Doc/library/pickletools.rst

--- a/Doc/whatsnew/3.7.rst
+++ b/Doc/whatsnew/3.7.rst
@@ -2144,9 +2144,9 @@ The following features and APIs have been removed from Python 3.7:
 * Removed support of the *exclude* argument in :meth:`tarfile.TarFile.add`.
   It was deprecated in Python 2.7 and 3.2.  Use the *filter* argument instead.
 
-* The ``splitunc()`` function in the :mod:`ntpath` module was deprecated in
-  Python 3.1, and has now been removed.  Use the :func:`~os.path.splitdrive`
-  function instead.
+* The :func:`!ntpath.splitunc` function was deprecated in
+  Python 3.1, and has now been removed.  Use :func:`~os.path.splitdrive`
+  instead.
 
 * :func:`collections.namedtuple` no longer supports the *verbose* parameter
   or ``_source`` attribute which showed the generated source code for the


### PR DESCRIPTION
(cherry-picked from commit 2c3906bc4b)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-101100 -->
* Issue: gh-101100
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--112858.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->