### PR TITLE
[3.12] gh-110820: Make sure processor specific defines are correct for Universal 2 build on macOS (gh-112828)

### DIFF
--- a/Include/pymacconfig.h
+++ b/Include/pymacconfig.h
@@ -8,7 +8,7 @@
       * only compile-time constant in these scenarios.
       */
 
-#ifdef __APPLE__
+#if defined(__APPLE__)
 
 # undef ALIGNOF_MAX_ALIGN_T
 # undef SIZEOF_LONG

--- a/Include/pymacconfig.h
+++ b/Include/pymacconfig.h
@@ -8,9 +8,10 @@
       * only compile-time constant in these scenarios.
       */
 
-#if defined(__APPLE__)
+#ifdef __APPLE__
 
 # undef SIZEOF_LONG
+# undef SIZEOF_LONG_DOUBLE
 # undef SIZEOF_PTHREAD_T
 # undef SIZEOF_SIZE_T
 # undef SIZEOF_TIME_T
@@ -23,6 +24,7 @@
 # undef DOUBLE_IS_BIG_ENDIAN_IEEE754
 # undef DOUBLE_IS_LITTLE_ENDIAN_IEEE754
 # undef HAVE_GCC_ASM_FOR_X87
+# undef HAVE_GCC_ASM_FOR_X64
 
 #    undef VA_LIST_IS_ARRAY
 #    if defined(__LP64__) && defined(__x86_64__)
@@ -80,8 +82,14 @@
 #define DOUBLE_IS_LITTLE_ENDIAN_IEEE754
 #endif /* __BIG_ENDIAN */
 
-#ifdef __i386__
+#if defined(__i386__) || defined(__x86_64__)
 # define HAVE_GCC_ASM_FOR_X87
+# define ALIGNOF_MAX_ALIGN_T 16
+# define HAVE_GCC_ASM_FOR_X64 1
+# define SIZEOF_LONG_DOUBLE 16
+#else
+# define ALIGNOF_MAX_ALIGN_T 8
+# define SIZEOF_LONG_DOUBLE 8
 #endif
 
 

--- a/Include/pymacconfig.h
+++ b/Include/pymacconfig.h
@@ -10,6 +10,7 @@
 
 #ifdef __APPLE__
 
+# undef ALIGNOF_MAX_ALIGN_T
 # undef SIZEOF_LONG
 # undef SIZEOF_LONG_DOUBLE
 # undef SIZEOF_PTHREAD_T

--- a/Misc/NEWS.d/next/macOS/2023-12-07-14-19-46.gh-issue-110820.DIxb_F.rst
+++ b/Misc/NEWS.d/next/macOS/2023-12-07-14-19-46.gh-issue-110820.DIxb_F.rst
@@ -1,0 +1,3 @@
+Make sure the preprocessor definitions for ``ALIGNOF_MAX_ALIGN_T``,
+``SIZEOF_LONG_DOUBLE`` and ``HAVE_GCC_ASM_FOR_X64`` are correct for
+Universal 2 builds on macOS.


### PR DESCRIPTION
A number of processor specific defines are different for x86-64 and arm64, and need to be adjusted in pymacconfig.h.

cherrypick of 15a80b15af9a0b0ebe6bd538a1919712ce7d4ef9
