### PR TITLE
gh-105912: document gotcha with using os.fork on macOS

### DIFF
--- a/Doc/library/os.rst
+++ b/Doc/library/os.rst
@@ -4373,6 +4373,11 @@ written in Python, such as a mail server's external command delivery program.
       If you use TLS sockets in an application calling ``fork()``, see
       the warning in the :mod:`ssl` documentation.
 
+   .. warning::
+
+      On macOS the use of this function is unsafe when mixed with using
+      higher-level system APIs, and that includes using :mod:`urllib.request`.
+
    .. versionchanged:: 3.8
       Calling ``fork()`` in a subinterpreter is no longer supported
       (:exc:`RuntimeError` is raised).
@@ -4411,6 +4416,11 @@ written in Python, such as a mail server's external command delivery program.
    :mod:`pty` module.  If an error occurs :exc:`OSError` is raised.
 
    .. audit-event:: os.forkpty "" os.forkpty
+
+   .. warning::
+
+      On macOS the use of this function is unsafe when mixed with using
+      higher-level system APIs, and that includes using :mod:`urllib.request`.
 
    .. versionchanged:: 3.12
       If Python is able to detect that your process has multiple

--- a/Doc/library/pty.rst
+++ b/Doc/library/pty.rst
@@ -33,6 +33,9 @@ The :mod:`pty` module defines the following functions:
    file descriptor connected to the child's controlling terminal (and also to the
    child's standard input and output).
 
+   .. warning:: On macOS the use of this function is unsafe when mixed with using
+      higher-level system APIs, and that includes using :mod:`urllib.request`.
+
 
 .. function:: openpty()
 

--- a/Doc/library/urllib.request.rst
+++ b/Doc/library/urllib.request.rst
@@ -25,7 +25,7 @@ authentication, redirections, cookies and more.
 
    On macOS it is unsafe to use this module in programs using
    :func:`os.fork` because the :func:`getproxies` implementation for
-   macOS uses a higher-level system API. Set the environement variable
+   macOS uses a higher-level system API. Set the environment variable
    ``no_proxy`` to ``*`` to avoid this problem
    (e.g. ``os.environ["no_proxy"] = "*"``).
 

--- a/Doc/library/urllib.request.rst
+++ b/Doc/library/urllib.request.rst
@@ -21,6 +21,14 @@ authentication, redirections, cookies and more.
     The `Requests package <https://requests.readthedocs.io/en/master/>`_
     is recommended for a higher-level HTTP client interface.
 
+.. warning::
+
+   On macOS it is unsafe to use this module in programs using
+   :func:`os.fork` because the :func:`getproxies` implementation for
+   macOS uses a higher-level system API. Set the environement variable
+   ``no_proxy`` to ``*`` to avoid this problem 
+   (e.g. ``os.environ["no_proxy"] = "*"``).
+
 .. include:: ../includes/wasm-notavail.rst
 
 The :mod:`urllib.request` module defines the following functions:

--- a/Doc/library/urllib.request.rst
+++ b/Doc/library/urllib.request.rst
@@ -26,7 +26,7 @@ authentication, redirections, cookies and more.
    On macOS it is unsafe to use this module in programs using
    :func:`os.fork` because the :func:`getproxies` implementation for
    macOS uses a higher-level system API. Set the environement variable
-   ``no_proxy`` to ``*`` to avoid this problem 
+   ``no_proxy`` to ``*`` to avoid this problem
    (e.g. ``os.environ["no_proxy"] = "*"``).
 
 .. include:: ../includes/wasm-notavail.rst


### PR DESCRIPTION
Using ``fork(2)`` on macOS when also using higher-level system APIs in the parent proces can crash on macOS because those system APIs are not written to handle this usage pattern.

There's nothing we can do about this other than documenting the problem.


<!-- gh-issue-number: gh-105912 -->
* Issue: gh-105912
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--112871.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->