### PR TITLE
Doc: c-api: fix order of PyMemberDef fields

### DIFF
--- a/Doc/c-api/structures.rst
+++ b/Doc/c-api/structures.rst
@@ -419,14 +419,14 @@ Accessing attributes of extension types
 
          The string should be static, no copy is made of it.
 
-   .. c:member:: Py_ssize_t offset
-
-      The offset in bytes that the member is located on the type’s object struct.
-
    .. c:member:: int type
 
       The type of the member in the C struct.
       See :ref:`PyMemberDef-types` for the possible values.
+
+   .. c:member:: Py_ssize_t offset
+
+      The offset in bytes that the member is located on the type’s object struct.
 
    .. c:member:: int flags
 


### PR DESCRIPTION
The field order is different from its definition.
https://github.com/python/cpython/blob/4d1eea59bd26d329417cc2252f1c91b52d0f4a28/Include/descrobject.h#L36-L47

This issue was introduced in https://github.com/python/cpython/pull/99014/files#diff-7cc88f3345d03aaf0505c8c85cf6912c43b87a16e124332e84059f1550061286

<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--112879.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->