### PR TITLE
gh-112532: Require mimalloc in `--disable-gil` builds

### DIFF
--- a/Include/internal/pycore_pymem_init.h
+++ b/Include/internal/pycore_pymem_init.h
@@ -18,7 +18,18 @@ extern void * _PyMem_RawRealloc(void *, void *, size_t);
 extern void _PyMem_RawFree(void *, void *);
 #define PYRAW_ALLOC {NULL, _PyMem_RawMalloc, _PyMem_RawCalloc, _PyMem_RawRealloc, _PyMem_RawFree}
 
-#if defined(WITH_PYMALLOC)
+#if defined(Py_GIL_DISABLED) && defined(WITH_MIMALLOC)
+extern void* _PyObject_MiMalloc(void *, size_t);
+extern void* _PyObject_MiCalloc(void *, size_t, size_t);
+extern void _PyObject_MiFree(void *, void *);
+extern void* _PyObject_MiRealloc(void *, void *, size_t);
+#  define PYOBJ_ALLOC {NULL, _PyObject_MiMalloc, _PyObject_MiCalloc, _PyObject_MiRealloc, _PyObject_MiFree}
+extern void* _PyMem_MiMalloc(void *, size_t);
+extern void* _PyMem_MiCalloc(void *, size_t, size_t);
+extern void _PyMem_MiFree(void *, void *);
+extern void* _PyMem_MiRealloc(void *, void *, size_t);
+#  define PYMEM_ALLOC {NULL, _PyMem_MiMalloc, _PyMem_MiCalloc, _PyMem_MiRealloc, _PyMem_MiFree}
+#elif defined(WITH_PYMALLOC)
 extern void* _PyObject_Malloc(void *, size_t);
 extern void* _PyObject_Calloc(void *, size_t, size_t);
 extern void _PyObject_Free(void *, void *);

--- a/Include/internal/pycore_pymem_init.h
+++ b/Include/internal/pycore_pymem_init.h
@@ -18,7 +18,8 @@ extern void * _PyMem_RawRealloc(void *, void *, size_t);
 extern void _PyMem_RawFree(void *, void *);
 #define PYRAW_ALLOC {NULL, _PyMem_RawMalloc, _PyMem_RawCalloc, _PyMem_RawRealloc, _PyMem_RawFree}
 
-#if defined(Py_GIL_DISABLED) && defined(WITH_MIMALLOC)
+#ifdef Py_GIL_DISABLED
+// Py_GIL_DISABLED requires mimalloc
 extern void* _PyObject_MiMalloc(void *, size_t);
 extern void* _PyObject_MiCalloc(void *, size_t, size_t);
 extern void _PyObject_MiFree(void *, void *);

--- a/Lib/test/support/__init__.py
+++ b/Lib/test/support/__init__.py
@@ -1844,7 +1844,7 @@ class SaveSignals:
 
 def with_pymalloc():
     import _testcapi
-    return _testcapi.WITH_PYMALLOC
+    return _testcapi.WITH_PYMALLOC and not Py_GIL_DISABLED
 
 
 def with_mimalloc():

--- a/Lib/test/test_capi/test_mem.py
+++ b/Lib/test/test_capi/test_mem.py
@@ -164,7 +164,7 @@ class PyMemPymallocDebugTests(PyMemDebugTests):
 
 
 @unittest.skipUnless(support.with_mimalloc(), 'need mimaloc')
-class PyMemMallocDebugTests(PyMemDebugTests):
+class PyMemMimallocDebugTests(PyMemDebugTests):
     PYTHONMALLOC = 'mimalloc_debug'
 
 

--- a/Lib/test/test_capi/test_mem.py
+++ b/Lib/test/test_capi/test_mem.py
@@ -152,6 +152,8 @@ class PyMemDebugTests(unittest.TestCase):
             self.assertGreaterEqual(count, i*5-2)
 
 
+# Py_GIL_DISABLED requires mimalloc (not malloc)
+@unittest.skipIf(support.Py_GIL_DISABLED, 'need malloc')
 class PyMemMallocDebugTests(PyMemDebugTests):
     PYTHONMALLOC = 'malloc_debug'
 
@@ -159,6 +161,11 @@ class PyMemMallocDebugTests(PyMemDebugTests):
 @unittest.skipUnless(support.with_pymalloc(), 'need pymalloc')
 class PyMemPymallocDebugTests(PyMemDebugTests):
     PYTHONMALLOC = 'pymalloc_debug'
+
+
+@unittest.skipUnless(support.with_mimalloc(), 'need mimaloc')
+class PyMemMallocDebugTests(PyMemDebugTests):
+    PYTHONMALLOC = 'mimalloc_debug'
 
 
 @unittest.skipUnless(support.Py_DEBUG, 'need Py_DEBUG')

--- a/Lib/test/test_cmd_line.py
+++ b/Lib/test/test_cmd_line.py
@@ -738,6 +738,8 @@ class CmdLineTest(unittest.TestCase):
                 out = self.run_xdev("-c", code, check_exitcode=False)
             if support.with_pymalloc():
                 alloc_name = "pymalloc_debug"
+            elif support.Py_GIL_DISABLED:
+                alloc_name = "mimalloc_debug"
             else:
                 alloc_name = "malloc_debug"
             self.assertEqual(out, alloc_name)
@@ -814,9 +816,13 @@ class CmdLineTest(unittest.TestCase):
     @support.cpython_only
     def test_pythonmalloc(self):
         # Test the PYTHONMALLOC environment variable
+        malloc = not support.Py_GIL_DISABLED
         pymalloc = support.with_pymalloc()
         mimalloc = support.with_mimalloc()
-        if pymalloc:
+        if support.Py_GIL_DISABLED:
+            default_name = 'mimalloc_debug' if support.Py_DEBUG else 'mimalloc'
+            default_name_debug = 'mimalloc_debug'
+        elif pymalloc:
             default_name = 'pymalloc_debug' if support.Py_DEBUG else 'pymalloc'
             default_name_debug = 'pymalloc_debug'
         else:
@@ -826,9 +832,12 @@ class CmdLineTest(unittest.TestCase):
         tests = [
             (None, default_name),
             ('debug', default_name_debug),
-            ('malloc', 'malloc'),
-            ('malloc_debug', 'malloc_debug'),
         ]
+        if malloc:
+            tests.extend([
+                ('malloc', 'malloc'),
+                ('malloc_debug', 'malloc_debug'),
+            ])
         if pymalloc:
             tests.extend((
                 ('pymalloc', 'pymalloc'),

--- a/Lib/test/test_embed.py
+++ b/Lib/test/test_embed.py
@@ -23,6 +23,12 @@ MACOS = (sys.platform == 'darwin')
 PYMEM_ALLOCATOR_NOT_SET = 0
 PYMEM_ALLOCATOR_DEBUG = 2
 PYMEM_ALLOCATOR_MALLOC = 3
+PYMEM_ALLOCATOR_MIMALLOC = 7
+if support.Py_GIL_DISABLED:
+    ALLOCATOR_FOR_CONFIG = PYMEM_ALLOCATOR_MIMALLOC
+else:
+    ALLOCATOR_FOR_CONFIG = PYMEM_ALLOCATOR_MALLOC
+
 Py_STATS = hasattr(sys, '_stats_on')
 
 # _PyCoreConfig_InitCompatConfig()
@@ -841,7 +847,7 @@ class InitConfigTests(EmbeddingTestsMixin, unittest.TestCase):
 
     def test_init_from_config(self):
         preconfig = {
-            'allocator': PYMEM_ALLOCATOR_MALLOC,
+            'allocator': ALLOCATOR_FOR_CONFIG,
             'utf8_mode': 1,
         }
         config = {
@@ -908,7 +914,7 @@ class InitConfigTests(EmbeddingTestsMixin, unittest.TestCase):
 
     def test_init_compat_env(self):
         preconfig = {
-            'allocator': PYMEM_ALLOCATOR_MALLOC,
+            'allocator': ALLOCATOR_FOR_CONFIG,
         }
         config = {
             'use_hash_seed': 1,
@@ -942,7 +948,7 @@ class InitConfigTests(EmbeddingTestsMixin, unittest.TestCase):
 
     def test_init_python_env(self):
         preconfig = {
-            'allocator': PYMEM_ALLOCATOR_MALLOC,
+            'allocator': ALLOCATOR_FOR_CONFIG,
             'utf8_mode': 1,
         }
         config = {
@@ -984,7 +990,7 @@ class InitConfigTests(EmbeddingTestsMixin, unittest.TestCase):
                                api=API_COMPAT)
 
     def test_init_env_dev_mode_alloc(self):
-        preconfig = dict(allocator=PYMEM_ALLOCATOR_MALLOC)
+        preconfig = dict(allocator=ALLOCATOR_FOR_CONFIG)
         config = dict(dev_mode=1,
                       faulthandler=1,
                       warnoptions=['default'])

--- a/Lib/test/test_os.py
+++ b/Lib/test/test_os.py
@@ -5080,7 +5080,10 @@ class ForkTests(unittest.TestCase):
                 support.wait_process(pid, exitcode=0)
         """
         assert_python_ok("-c", code)
-        assert_python_ok("-c", code, PYTHONMALLOC="malloc_debug")
+        if support.Py_GIL_DISABLED:
+            assert_python_ok("-c", code, PYTHONMALLOC="mimalloc_debug")
+        else:
+            assert_python_ok("-c", code, PYTHONMALLOC="malloc_debug")
 
     @unittest.skipUnless(sys.platform in ("linux", "darwin"),
                          "Only Linux and macOS detect this today.")

--- a/Programs/_testembed.c
+++ b/Programs/_testembed.c
@@ -576,7 +576,11 @@ static int test_init_from_config(void)
     _PyPreConfig_InitCompatConfig(&preconfig);
 
     putenv("PYTHONMALLOC=malloc_debug");
+#ifndef Py_GIL_DISABLED
     preconfig.allocator = PYMEM_ALLOCATOR_MALLOC;
+#else
+    preconfig.allocator = PYMEM_ALLOCATOR_MIMALLOC;
+#endif
 
     putenv("PYTHONUTF8=0");
     Py_UTF8Mode = 0;
@@ -765,7 +769,11 @@ static int test_init_dont_parse_argv(void)
 static void set_most_env_vars(void)
 {
     putenv("PYTHONHASHSEED=42");
+#ifndef Py_GIL_DISABLED
     putenv("PYTHONMALLOC=malloc");
+#else
+    putenv("PYTHONMALLOC=mimalloc");
+#endif
     putenv("PYTHONTRACEMALLOC=2");
     putenv("PYTHONPROFILEIMPORTTIME=1");
     putenv("PYTHONNODEBUGRANGES=1");
@@ -851,7 +859,11 @@ static int test_init_env_dev_mode_alloc(void)
     /* Test initialization from environment variables */
     Py_IgnoreEnvironmentFlag = 0;
     set_all_env_vars_dev_mode();
+#ifndef Py_GIL_DISABLED
     putenv("PYTHONMALLOC=malloc");
+#else
+    putenv("PYTHONMALLOC=mimalloc");
+#endif
     _testembed_Py_InitializeFromConfig();
     dump_config();
     Py_Finalize();

--- a/configure
+++ b/configure
@@ -16891,6 +16891,8 @@ printf "%s\n" "#define WITH_MIMALLOC 1" >>confdefs.h
 
   MIMALLOC_HEADERS='$(MIMALLOC_HEADERS)'
 
+elif test "$disable_gil" = "yes"; then
+  as_fn_error $? "--disable-gil requires mimalloc memory allocator (--with-mimalloc)." "$LINENO" 5
 fi
 
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $with_mimalloc" >&5

--- a/configure.ac
+++ b/configure.ac
@@ -4558,6 +4558,8 @@ if test "$with_mimalloc" != no; then
   with_mimalloc=yes
   AC_DEFINE([WITH_MIMALLOC], [1], [Define if you want to compile in mimalloc memory allocator.])
   AC_SUBST([MIMALLOC_HEADERS], ['$(MIMALLOC_HEADERS)'])
+elif test "$disable_gil" = "yes"; then
+  AC_MSG_ERROR([--disable-gil requires mimalloc memory allocator (--with-mimalloc).])
 fi
 
 AC_MSG_RESULT([$with_mimalloc])


### PR DESCRIPTION
In `--disable-gil` builds, the default allocator is now "mimalloc" and the "malloc" and "pymalloc" allocators are disabled.

The `--disable-gil` builds will rely on `mimalloc` for finding GC objects as well as for some thread-safety guarantees. That will require building with mimalloc and using it at runtime.


<!-- gh-issue-number: gh-112532 -->
* Issue: gh-112532
<!-- /gh-issue-number -->
