### PR TITLE
gh-112867: fix for WITH_PYMALLOC_RADIX_TREE=0

### DIFF
--- a/Include/internal/pycore_obmalloc.h
+++ b/Include/internal/pycore_obmalloc.h
@@ -665,7 +665,9 @@ struct _obmalloc_global_state {
 struct _obmalloc_state {
     struct _obmalloc_pools pools;
     struct _obmalloc_mgmt mgmt;
+#if WITH_PYMALLOC_RADIX_TREE
     struct _obmalloc_usage usage;
+#endif
 };
 
 

--- a/Misc/NEWS.d/next/Build/2023-12-08-11-33-37.gh-issue-112867.ZzDfXQ.rst
+++ b/Misc/NEWS.d/next/Build/2023-12-08-11-33-37.gh-issue-112867.ZzDfXQ.rst
@@ -1,0 +1,1 @@
+Fix the build for the case that WITH_PYMALLOC_RADIX_TREE=0 set.


### PR DESCRIPTION
The _obmalloc_usage structure is only defined if the obmalloc radix tree is enabled.

<!-- gh-issue-number: gh-112867 -->
* Issue: gh-112867
<!-- /gh-issue-number -->
