### PR TITLE
Docs: Use 'f-strings' as header

### DIFF
--- a/Doc/reference/lexical_analysis.rst
+++ b/Doc/reference/lexical_analysis.rst
@@ -708,10 +708,12 @@ and formatted string literals may be concatenated with plain string literals.
    single: ! (exclamation); in formatted string literal
    single: : (colon); in formatted string literal
    single: = (equals); for help in debugging using string literals
-.. _f-strings:
 
-Formatted string literals
--------------------------
+.. _f-strings:
+.. _formatted-string-literals:
+
+f-strings
+---------
 
 .. versionadded:: 3.6
 


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

Most people know them as f-strings, use this as the title. The introductory paragraph uses both terms: 

> A formatted string literal or f-string is a string literal that is prefixed with ``'f'`` or ``'F'``.

Keep both terms as a Sphinx reference for linking:

* https://cpython-previews--112888.org.readthedocs.build/en/112888/reference/lexical_analysis.html#f-strings

* https://cpython-previews--112888.org.readthedocs.build/en/112888/reference/lexical_analysis.html#formatted-string-literals

<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--112888.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->