### PR TITLE
Fix a slight typo error: bad indentation in ifndef

### DIFF
--- a/Include/unicodeobject.h
+++ b/Include/unicodeobject.h
@@ -61,7 +61,7 @@ Copyright (c) Corporation for National Research Initiatives.
 #define Py_USING_UNICODE
 
 #ifndef SIZEOF_WCHAR_T
-#error Must define SIZEOF_WCHAR_T
+#  error Must define SIZEOF_WCHAR_T
 #endif
 
 #define Py_UNICODE_SIZE SIZEOF_WCHAR_T


### PR DESCRIPTION
Simple fix of a lack of indentation in one of the includes, in an ifndef (facilitated reading of the code)


