### PR TITLE
gh-111178: Avoid calling functions from incompatible pointer types in dictobject.c

### DIFF
--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -4505,8 +4505,9 @@ PyTypeObject PyDictIterItem_Type = {
 /* dictreviter */
 
 static PyObject *
-dictreviter_iternext(dictiterobject *di)
+dictreviter_iternext(PyObject *self)
 {
+    dictiterobject *di = (dictiterobject *)self;
     PyDictObject *d = di->di_dict;
 
     if (d == NULL) {
@@ -4611,7 +4612,7 @@ PyTypeObject PyDictRevIterKey_Type = {
     .tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC,
     .tp_traverse = dictiter_traverse,
     .tp_iter = PyObject_SelfIter,
-    .tp_iternext = (iternextfunc)dictreviter_iternext,
+    .tp_iternext = dictreviter_iternext,
     .tp_methods = dictiter_methods
 };
 
@@ -4652,7 +4653,7 @@ PyTypeObject PyDictRevIterItem_Type = {
     .tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC,
     .tp_traverse = dictiter_traverse,
     .tp_iter = PyObject_SelfIter,
-    .tp_iternext = (iternextfunc)dictreviter_iternext,
+    .tp_iternext = dictreviter_iternext,
     .tp_methods = dictiter_methods
 };
 
@@ -4664,7 +4665,7 @@ PyTypeObject PyDictRevIterValue_Type = {
     .tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC,
     .tp_traverse = dictiter_traverse,
     .tp_iter = PyObject_SelfIter,
-    .tp_iternext = (iternextfunc)dictreviter_iternext,
+    .tp_iternext = dictreviter_iternext,
     .tp_methods = dictiter_methods
 };
 

--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -4378,8 +4378,9 @@ PyTypeObject PyDictIterValue_Type = {
 };
 
 static PyObject *
-dictiter_iternextitem(dictiterobject *di)
+dictiter_iternextitem(PyObject *self)
 {
+    dictiterobject *di = (dictiterobject *)self;
     PyObject *key, *value, *result;
     Py_ssize_t i;
     PyDictObject *d = di->di_dict;
@@ -4496,7 +4497,7 @@ PyTypeObject PyDictIterItem_Type = {
     0,                                          /* tp_richcompare */
     0,                                          /* tp_weaklistoffset */
     PyObject_SelfIter,                          /* tp_iter */
-    (iternextfunc)dictiter_iternextitem,        /* tp_iternext */
+    dictiter_iternextitem,                      /* tp_iternext */
     dictiter_methods,                           /* tp_methods */
     0,
 };

--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -4174,8 +4174,9 @@ static PyMethodDef dictiter_methods[] = {
 };
 
 static PyObject*
-dictiter_iternextkey(dictiterobject *di)
+dictiter_iternextkey(PyObject *self)
 {
+    dictiterobject *di = (dictiterobject *)self;
     PyObject *key;
     Py_ssize_t i;
     PyDictKeysObject *k;
@@ -4269,7 +4270,7 @@ PyTypeObject PyDictIterKey_Type = {
     0,                                          /* tp_richcompare */
     0,                                          /* tp_weaklistoffset */
     PyObject_SelfIter,                          /* tp_iter */
-    (iternextfunc)dictiter_iternextkey,         /* tp_iternext */
+    dictiter_iternextkey,                       /* tp_iternext */
     dictiter_methods,                           /* tp_methods */
     0,
 };

--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -4861,8 +4861,9 @@ Done:
 /*** dict_keys ***/
 
 static PyObject *
-dictkeys_iter(_PyDictViewObject *dv)
+dictkeys_iter(PyObject *self)
 {
+    _PyDictViewObject *dv = (_PyDictViewObject *)self;
     if (dv->dv_dict == NULL) {
         Py_RETURN_NONE;
     }
@@ -5249,7 +5250,7 @@ PyTypeObject PyDictKeys_Type = {
     0,                                          /* tp_clear */
     dictview_richcompare,                       /* tp_richcompare */
     0,                                          /* tp_weaklistoffset */
-    (getiterfunc)dictkeys_iter,                 /* tp_iter */
+    dictkeys_iter,                              /* tp_iter */
     0,                                          /* tp_iternext */
     dictkeys_methods,                           /* tp_methods */
     .tp_getset = dictview_getset,

--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -4829,8 +4829,9 @@ dictview_richcompare(PyObject *self, PyObject *other, int op)
 }
 
 static PyObject *
-dictview_repr(_PyDictViewObject *dv)
+dictview_repr(PyObject *self)
 {
+    _PyDictViewObject *dv = (_PyDictViewObject *)self;
     PyObject *seq;
     PyObject *result = NULL;
     Py_ssize_t rc;
@@ -5225,7 +5226,7 @@ PyTypeObject PyDictKeys_Type = {
     0,                                          /* tp_getattr */
     0,                                          /* tp_setattr */
     0,                                          /* tp_as_async */
-    (reprfunc)dictview_repr,                    /* tp_repr */
+    dictview_repr,                              /* tp_repr */
     &dictviews_as_number,                       /* tp_as_number */
     &dictkeys_as_sequence,                      /* tp_as_sequence */
     0,                                          /* tp_as_mapping */
@@ -5327,7 +5328,7 @@ PyTypeObject PyDictItems_Type = {
     0,                                          /* tp_getattr */
     0,                                          /* tp_setattr */
     0,                                          /* tp_as_async */
-    (reprfunc)dictview_repr,                    /* tp_repr */
+    dictview_repr,                              /* tp_repr */
     &dictviews_as_number,                       /* tp_as_number */
     &dictitems_as_sequence,                     /* tp_as_sequence */
     0,                                          /* tp_as_mapping */
@@ -5409,7 +5410,7 @@ PyTypeObject PyDictValues_Type = {
     0,                                          /* tp_getattr */
     0,                                          /* tp_setattr */
     0,                                          /* tp_as_async */
-    (reprfunc)dictview_repr,                    /* tp_repr */
+    dictview_repr,                              /* tp_repr */
     0,                                          /* tp_as_number */
     &dictvalues_as_sequence,                    /* tp_as_sequence */
     0,                                          /* tp_as_mapping */

--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -237,7 +237,7 @@ equally good collision statistics, needed less code & used less memory.
 static int dictresize(PyInterpreterState *interp, PyDictObject *mp,
                       uint8_t log_newsize, int unicode);
 
-static PyObject* dict_iter(PyDictObject *dict);
+static PyObject* dict_iter(PyObject *dict);
 
 #include "clinic/dictobject.c.h"
 
@@ -792,7 +792,7 @@ static PyDictKeysObject *
 clone_combined_dict_keys(PyDictObject *orig)
 {
     assert(PyDict_Check(orig));
-    assert(Py_TYPE(orig)->tp_iter == (getiterfunc)dict_iter);
+    assert(Py_TYPE(orig)->tp_iter == dict_iter);
     assert(orig->ma_values == NULL);
     assert(orig->ma_keys != Py_EMPTY_KEYS);
     assert(orig->ma_keys->dk_refcnt == 1);
@@ -2927,7 +2927,7 @@ dict_merge(PyInterpreterState *interp, PyObject *a, PyObject *b, int override)
         return -1;
     }
     mp = (PyDictObject*)a;
-    if (PyDict_Check(b) && (Py_TYPE(b)->tp_iter == (getiterfunc)dict_iter)) {
+    if (PyDict_Check(b) && (Py_TYPE(b)->tp_iter == dict_iter)) {
         other = (PyDictObject*)b;
         if (other == mp || other->ma_used == 0)
             /* a.update(a) or a.update({}); nothing to do */
@@ -3157,7 +3157,7 @@ PyDict_Copy(PyObject *o)
         return (PyObject *)split_copy;
     }
 
-    if (Py_TYPE(mp)->tp_iter == (getiterfunc)dict_iter &&
+    if (Py_TYPE(mp)->tp_iter == dict_iter &&
             mp->ma_values == NULL &&
             (mp->ma_used >= (mp->ma_keys->dk_nentries * 2) / 3))
     {
@@ -3939,8 +3939,9 @@ dict_vectorcall(PyObject *type, PyObject * const*args,
 }
 
 static PyObject *
-dict_iter(PyDictObject *dict)
+dict_iter(PyObject *self)
 {
+    PyDictObject *dict = (PyDictObject *)self;
     return dictiter_new(dict, &PyDictIterKey_Type);
 }
 
@@ -3983,7 +3984,7 @@ PyTypeObject PyDict_Type = {
     dict_tp_clear,                              /* tp_clear */
     dict_richcompare,                           /* tp_richcompare */
     0,                                          /* tp_weaklistoffset */
-    (getiterfunc)dict_iter,                     /* tp_iter */
+    dict_iter,                                  /* tp_iter */
     0,                                          /* tp_iternext */
     mapp_methods,                               /* tp_methods */
     0,                                          /* tp_members */

--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -4870,8 +4870,9 @@ dictkeys_iter(_PyDictViewObject *dv)
 }
 
 static int
-dictkeys_contains(_PyDictViewObject *dv, PyObject *obj)
+dictkeys_contains(PyObject *self, PyObject *obj)
 {
+    _PyDictViewObject *dv = (_PyDictViewObject *)self;
     if (dv->dv_dict == NULL)
         return 0;
     return PyDict_Contains((PyObject *)dv->dv_dict, obj);
@@ -4885,7 +4886,7 @@ static PySequenceMethods dictkeys_as_sequence = {
     0,                                  /* sq_slice */
     0,                                  /* sq_ass_item */
     0,                                  /* sq_ass_slice */
-    (objobjproc)dictkeys_contains,      /* sq_contains */
+    dictkeys_contains,                  /* sq_contains */
 };
 
 // Create a set object from dictviews object.
@@ -4925,7 +4926,7 @@ dictviews_sub(PyObject *self, PyObject *other)
 }
 
 static int
-dictitems_contains(_PyDictViewObject *dv, PyObject *obj);
+dictitems_contains(PyObject *dv, PyObject *obj);
 
 PyObject *
 _PyDictView_Intersect(PyObject* self, PyObject *other)
@@ -4935,7 +4936,7 @@ _PyDictView_Intersect(PyObject* self, PyObject *other)
     PyObject *key;
     Py_ssize_t len_self;
     int rv;
-    int (*dict_contains)(_PyDictViewObject *, PyObject *);
+    objobjproc dict_contains;
 
     /* Python interpreter swaps parameters when dict view
        is on right side of & */
@@ -4987,7 +4988,7 @@ _PyDictView_Intersect(PyObject* self, PyObject *other)
     }
 
     while ((key = PyIter_Next(it)) != NULL) {
-        rv = dict_contains((_PyDictViewObject *)self, key);
+        rv = dict_contains(self, key);
         if (rv < 0) {
             goto error;
         }
@@ -5282,8 +5283,9 @@ dictitems_iter(PyObject *self)
 }
 
 static int
-dictitems_contains(_PyDictViewObject *dv, PyObject *obj)
+dictitems_contains(PyObject *self, PyObject *obj)
 {
+    _PyDictViewObject *dv = (_PyDictViewObject *)self;
     int result;
     PyObject *key, *value, *found;
     if (dv->dv_dict == NULL)
@@ -5308,7 +5310,7 @@ static PySequenceMethods dictitems_as_sequence = {
     0,                                  /* sq_slice */
     0,                                  /* sq_ass_item */
     0,                                  /* sq_ass_slice */
-    (objobjproc)dictitems_contains,     /* sq_contains */
+    dictitems_contains,                 /* sq_contains */
 };
 
 static PyObject* dictitems_reversed(_PyDictViewObject *dv, PyObject *Py_UNUSED(ignored));

--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -5267,8 +5267,9 @@ dictkeys_reversed(_PyDictViewObject *dv, PyObject *Py_UNUSED(ignored))
 /*** dict_items ***/
 
 static PyObject *
-dictitems_iter(_PyDictViewObject *dv)
+dictitems_iter(PyObject *self)
 {
+    _PyDictViewObject *dv = (_PyDictViewObject *)self;
     if (dv->dv_dict == NULL) {
         Py_RETURN_NONE;
     }
@@ -5345,7 +5346,7 @@ PyTypeObject PyDictItems_Type = {
     0,                                          /* tp_clear */
     dictview_richcompare,                       /* tp_richcompare */
     0,                                          /* tp_weaklistoffset */
-    (getiterfunc)dictitems_iter,                /* tp_iter */
+    dictitems_iter,                             /* tp_iter */
     0,                                          /* tp_iternext */
     dictitems_methods,                          /* tp_methods */
     .tp_getset = dictview_getset,

--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -5365,8 +5365,9 @@ dictitems_reversed(_PyDictViewObject *dv, PyObject *Py_UNUSED(ignored))
 /*** dict_values ***/
 
 static PyObject *
-dictvalues_iter(_PyDictViewObject *dv)
+dictvalues_iter(PyObject *self)
 {
+    _PyDictViewObject *dv = (_PyDictViewObject *)self;
     if (dv->dv_dict == NULL) {
         Py_RETURN_NONE;
     }
@@ -5422,7 +5423,7 @@ PyTypeObject PyDictValues_Type = {
     0,                                          /* tp_clear */
     0,                                          /* tp_richcompare */
     0,                                          /* tp_weaklistoffset */
-    (getiterfunc)dictvalues_iter,               /* tp_iter */
+    dictvalues_iter,                            /* tp_iter */
     0,                                          /* tp_iternext */
     dictvalues_methods,                         /* tp_methods */
     .tp_getset = dictview_getset,

--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -4670,8 +4670,9 @@ PyTypeObject PyDictRevIterValue_Type = {
 /* The instance lay-out is the same for all three; but the type differs. */
 
 static void
-dictview_dealloc(_PyDictViewObject *dv)
+dictview_dealloc(PyObject *self)
 {
+    _PyDictViewObject *dv = (_PyDictViewObject *)self;
     /* bpo-31095: UnTrack is needed before calling any callbacks */
     _PyObject_GC_UNTRACK(dv);
     Py_XDECREF(dv->dv_dict);
@@ -5221,7 +5222,7 @@ PyTypeObject PyDictKeys_Type = {
     sizeof(_PyDictViewObject),                  /* tp_basicsize */
     0,                                          /* tp_itemsize */
     /* methods */
-    (destructor)dictview_dealloc,               /* tp_dealloc */
+    dictview_dealloc,                           /* tp_dealloc */
     0,                                          /* tp_vectorcall_offset */
     0,                                          /* tp_getattr */
     0,                                          /* tp_setattr */
@@ -5323,7 +5324,7 @@ PyTypeObject PyDictItems_Type = {
     sizeof(_PyDictViewObject),                  /* tp_basicsize */
     0,                                          /* tp_itemsize */
     /* methods */
-    (destructor)dictview_dealloc,               /* tp_dealloc */
+    dictview_dealloc,                           /* tp_dealloc */
     0,                                          /* tp_vectorcall_offset */
     0,                                          /* tp_getattr */
     0,                                          /* tp_setattr */
@@ -5405,7 +5406,7 @@ PyTypeObject PyDictValues_Type = {
     sizeof(_PyDictViewObject),                  /* tp_basicsize */
     0,                                          /* tp_itemsize */
     /* methods */
-    (destructor)dictview_dealloc,               /* tp_dealloc */
+    dictview_dealloc,                           /* tp_dealloc */
     0,                                          /* tp_vectorcall_offset */
     0,                                          /* tp_getattr */
     0,                                          /* tp_setattr */

--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -2450,8 +2450,9 @@ Fail:
 /* Methods */
 
 static void
-dict_dealloc(PyDictObject *mp)
+dict_dealloc(PyObject *self)
 {
+    PyDictObject *mp = (PyDictObject *)self;
     PyInterpreterState *interp = _PyInterpreterState_GET();
     assert(Py_REFCNT(mp) == 0);
     Py_SET_REFCNT(mp, 1);
@@ -3958,7 +3959,7 @@ PyTypeObject PyDict_Type = {
     "dict",
     sizeof(PyDictObject),
     0,
-    (destructor)dict_dealloc,                   /* tp_dealloc */
+    dict_dealloc,                               /* tp_dealloc */
     0,                                          /* tp_vectorcall_offset */
     0,                                          /* tp_getattr */
     0,                                          /* tp_setattr */

--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -4687,8 +4687,9 @@ dictview_traverse(PyObject *self, visitproc visit, void *arg)
 }
 
 static Py_ssize_t
-dictview_len(_PyDictViewObject *dv)
+dictview_len(PyObject *self)
 {
+    _PyDictViewObject *dv = (_PyDictViewObject *)self;
     Py_ssize_t len = 0;
     if (dv->dv_dict != NULL)
         len = dv->dv_dict->ma_used;
@@ -4870,7 +4871,7 @@ dictkeys_contains(_PyDictViewObject *dv, PyObject *obj)
 }
 
 static PySequenceMethods dictkeys_as_sequence = {
-    (lenfunc)dictview_len,              /* sq_length */
+    dictview_len,                       /* sq_length */
     0,                                  /* sq_concat */
     0,                                  /* sq_repeat */
     0,                                  /* sq_item */
@@ -4937,7 +4938,7 @@ _PyDictView_Intersect(PyObject* self, PyObject *other)
         self = tmp;
     }
 
-    len_self = dictview_len((_PyDictViewObject *)self);
+    len_self = dictview_len(self);
 
     /* if other is a set and self is smaller than other,
        reuse set intersection logic */
@@ -4949,7 +4950,7 @@ _PyDictView_Intersect(PyObject* self, PyObject *other)
     /* if other is another dict view, and it is bigger than self,
        swap them */
     if (PyDictViewSet_Check(other)) {
-        Py_ssize_t len_other = dictview_len((_PyDictViewObject *)other);
+        Py_ssize_t len_other = dictview_len(other);
         if (len_other > len_self) {
             PyObject *tmp = other;
             other = self;
@@ -5153,7 +5154,7 @@ dictviews_isdisjoint(PyObject *self, PyObject *other)
     PyObject *item = NULL;
 
     if (self == other) {
-        if (dictview_len((_PyDictViewObject *)self) == 0)
+        if (dictview_len(self) == 0)
             Py_RETURN_TRUE;
         else
             Py_RETURN_FALSE;
@@ -5162,7 +5163,7 @@ dictviews_isdisjoint(PyObject *self, PyObject *other)
     /* Iterate over the shorter object (only if other is a set,
      * because PySequence_Contains may be expensive otherwise): */
     if (PyAnySet_Check(other) || PyDictViewSet_Check(other)) {
-        Py_ssize_t len_self = dictview_len((_PyDictViewObject *)self);
+        Py_ssize_t len_self = dictview_len(self);
         Py_ssize_t len_other = PyObject_Size(other);
         if (len_other == -1)
             return NULL;
@@ -5292,7 +5293,7 @@ dictitems_contains(_PyDictViewObject *dv, PyObject *obj)
 }
 
 static PySequenceMethods dictitems_as_sequence = {
-    (lenfunc)dictview_len,              /* sq_length */
+    dictview_len,                       /* sq_length */
     0,                                  /* sq_concat */
     0,                                  /* sq_repeat */
     0,                                  /* sq_item */
@@ -5376,7 +5377,7 @@ dictvalues_iter(PyObject *self)
 }
 
 static PySequenceMethods dictvalues_as_sequence = {
-    (lenfunc)dictview_len,              /* sq_length */
+    dictview_len,                       /* sq_length */
     0,                                  /* sq_concat */
     0,                                  /* sq_repeat */
     0,                                  /* sq_item */

--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -2627,18 +2627,18 @@ dict_subscript(PyObject *self, PyObject *key)
 }
 
 static int
-dict_ass_sub(PyDictObject *mp, PyObject *v, PyObject *w)
+dict_ass_sub(PyObject *mp, PyObject *v, PyObject *w)
 {
     if (w == NULL)
-        return PyDict_DelItem((PyObject *)mp, v);
+        return PyDict_DelItem(mp, v);
     else
-        return PyDict_SetItem((PyObject *)mp, v, w);
+        return PyDict_SetItem(mp, v, w);
 }
 
 static PyMappingMethods dict_as_mapping = {
     dict_length, /*mp_length*/
     dict_subscript, /*mp_subscript*/
-    (objobjargproc)dict_ass_sub, /*mp_ass_subscript*/
+    dict_ass_sub, /*mp_ass_subscript*/
 };
 
 static PyObject *

--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -4278,8 +4278,9 @@ PyTypeObject PyDictIterKey_Type = {
 };
 
 static PyObject *
-dictiter_iternextvalue(dictiterobject *di)
+dictiter_iternextvalue(PyObject *self)
 {
+    dictiterobject *di = (dictiterobject *)self;
     PyObject *value;
     Py_ssize_t i;
     PyDictObject *d = di->di_dict;
@@ -4371,7 +4372,7 @@ PyTypeObject PyDictIterValue_Type = {
     0,                                          /* tp_richcompare */
     0,                                          /* tp_weaklistoffset */
     PyObject_SelfIter,                          /* tp_iter */
-    (iternextfunc)dictiter_iternextvalue,       /* tp_iternext */
+    dictiter_iternextvalue,                     /* tp_iternext */
     dictiter_methods,                           /* tp_methods */
     0,
 };

--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -4679,8 +4679,9 @@ dictview_dealloc(_PyDictViewObject *dv)
 }
 
 static int
-dictview_traverse(_PyDictViewObject *dv, visitproc visit, void *arg)
+dictview_traverse(PyObject *self, visitproc visit, void *arg)
 {
+    _PyDictViewObject *dv = (_PyDictViewObject *)self;
     Py_VISIT(dv->dv_dict);
     return 0;
 }
@@ -5235,7 +5236,7 @@ PyTypeObject PyDictKeys_Type = {
     0,                                          /* tp_as_buffer */
     Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC,/* tp_flags */
     0,                                          /* tp_doc */
-    (traverseproc)dictview_traverse,            /* tp_traverse */
+    dictview_traverse,                          /* tp_traverse */
     0,                                          /* tp_clear */
     dictview_richcompare,                       /* tp_richcompare */
     0,                                          /* tp_weaklistoffset */
@@ -5337,7 +5338,7 @@ PyTypeObject PyDictItems_Type = {
     0,                                          /* tp_as_buffer */
     Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC,/* tp_flags */
     0,                                          /* tp_doc */
-    (traverseproc)dictview_traverse,            /* tp_traverse */
+    dictview_traverse,                          /* tp_traverse */
     0,                                          /* tp_clear */
     dictview_richcompare,                       /* tp_richcompare */
     0,                                          /* tp_weaklistoffset */
@@ -5419,7 +5420,7 @@ PyTypeObject PyDictValues_Type = {
     0,                                          /* tp_as_buffer */
     Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC,/* tp_flags */
     0,                                          /* tp_doc */
-    (traverseproc)dictview_traverse,            /* tp_traverse */
+    dictview_traverse,                          /* tp_traverse */
     0,                                          /* tp_clear */
     0,                                          /* tp_richcompare */
     0,                                          /* tp_weaklistoffset */

--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -2584,8 +2584,9 @@ error:
 }
 
 static Py_ssize_t
-dict_length(PyDictObject *mp)
+dict_length(PyObject *self)
 {
+    PyDictObject *mp = (PyDictObject *)self;
     return mp->ma_used;
 }
 
@@ -2634,7 +2635,7 @@ dict_ass_sub(PyDictObject *mp, PyObject *v, PyObject *w)
 }
 
 static PyMappingMethods dict_as_mapping = {
-    (lenfunc)dict_length, /*mp_length*/
+    dict_length, /*mp_length*/
     (binaryfunc)dict_subscript, /*mp_subscript*/
     (objobjargproc)dict_ass_sub, /*mp_ass_subscript*/
 };

--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -4141,8 +4141,9 @@ dictiter_dealloc(dictiterobject *di)
 }
 
 static int
-dictiter_traverse(dictiterobject *di, visitproc visit, void *arg)
+dictiter_traverse(PyObject *self, visitproc visit, void *arg)
 {
+    dictiterobject *di = (dictiterobject *)self;
     Py_VISIT(di->di_dict);
     Py_VISIT(di->di_result);
     return 0;
@@ -4265,7 +4266,7 @@ PyTypeObject PyDictIterKey_Type = {
     0,                                          /* tp_as_buffer */
     Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC,/* tp_flags */
     0,                                          /* tp_doc */
-    (traverseproc)dictiter_traverse,            /* tp_traverse */
+    dictiter_traverse,                          /* tp_traverse */
     0,                                          /* tp_clear */
     0,                                          /* tp_richcompare */
     0,                                          /* tp_weaklistoffset */
@@ -4364,7 +4365,7 @@ PyTypeObject PyDictIterValue_Type = {
     0,                                          /* tp_as_buffer */
     Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC,    /* tp_flags */
     0,                                          /* tp_doc */
-    (traverseproc)dictiter_traverse,            /* tp_traverse */
+    dictiter_traverse,                          /* tp_traverse */
     0,                                          /* tp_clear */
     0,                                          /* tp_richcompare */
     0,                                          /* tp_weaklistoffset */
@@ -4488,7 +4489,7 @@ PyTypeObject PyDictIterItem_Type = {
     0,                                          /* tp_as_buffer */
     Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC,/* tp_flags */
     0,                                          /* tp_doc */
-    (traverseproc)dictiter_traverse,            /* tp_traverse */
+    dictiter_traverse,                          /* tp_traverse */
     0,                                          /* tp_clear */
     0,                                          /* tp_richcompare */
     0,                                          /* tp_weaklistoffset */
@@ -4606,7 +4607,7 @@ PyTypeObject PyDictRevIterKey_Type = {
     sizeof(dictiterobject),
     .tp_dealloc = (destructor)dictiter_dealloc,
     .tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC,
-    .tp_traverse = (traverseproc)dictiter_traverse,
+    .tp_traverse = dictiter_traverse,
     .tp_iter = PyObject_SelfIter,
     .tp_iternext = (iternextfunc)dictreviter_iternext,
     .tp_methods = dictiter_methods
@@ -4647,7 +4648,7 @@ PyTypeObject PyDictRevIterItem_Type = {
     sizeof(dictiterobject),
     .tp_dealloc = (destructor)dictiter_dealloc,
     .tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC,
-    .tp_traverse = (traverseproc)dictiter_traverse,
+    .tp_traverse = dictiter_traverse,
     .tp_iter = PyObject_SelfIter,
     .tp_iternext = (iternextfunc)dictreviter_iternext,
     .tp_methods = dictiter_methods
@@ -4659,7 +4660,7 @@ PyTypeObject PyDictRevIterValue_Type = {
     sizeof(dictiterobject),
     .tp_dealloc = (destructor)dictiter_dealloc,
     .tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC,
-    .tp_traverse = (traverseproc)dictiter_traverse,
+    .tp_traverse = dictiter_traverse,
     .tp_iter = PyObject_SelfIter,
     .tp_iternext = (iternextfunc)dictreviter_iternext,
     .tp_methods = dictiter_methods

--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -4131,8 +4131,9 @@ dictiter_new(PyDictObject *dict, PyTypeObject *itertype)
 }
 
 static void
-dictiter_dealloc(dictiterobject *di)
+dictiter_dealloc(PyObject *self)
 {
+    dictiterobject *di = (dictiterobject *)self;
     /* bpo-31095: UnTrack is needed before calling any callbacks */
     _PyObject_GC_UNTRACK(di);
     Py_XDECREF(di->di_dict);
@@ -4249,7 +4250,7 @@ PyTypeObject PyDictIterKey_Type = {
     sizeof(dictiterobject),                     /* tp_basicsize */
     0,                                          /* tp_itemsize */
     /* methods */
-    (destructor)dictiter_dealloc,               /* tp_dealloc */
+    dictiter_dealloc,                           /* tp_dealloc */
     0,                                          /* tp_vectorcall_offset */
     0,                                          /* tp_getattr */
     0,                                          /* tp_setattr */
@@ -4348,7 +4349,7 @@ PyTypeObject PyDictIterValue_Type = {
     sizeof(dictiterobject),                     /* tp_basicsize */
     0,                                          /* tp_itemsize */
     /* methods */
-    (destructor)dictiter_dealloc,               /* tp_dealloc */
+    dictiter_dealloc,                           /* tp_dealloc */
     0,                                          /* tp_vectorcall_offset */
     0,                                          /* tp_getattr */
     0,                                          /* tp_setattr */
@@ -4472,7 +4473,7 @@ PyTypeObject PyDictIterItem_Type = {
     sizeof(dictiterobject),                     /* tp_basicsize */
     0,                                          /* tp_itemsize */
     /* methods */
-    (destructor)dictiter_dealloc,               /* tp_dealloc */
+    dictiter_dealloc,                           /* tp_dealloc */
     0,                                          /* tp_vectorcall_offset */
     0,                                          /* tp_getattr */
     0,                                          /* tp_setattr */
@@ -4605,7 +4606,7 @@ PyTypeObject PyDictRevIterKey_Type = {
     PyVarObject_HEAD_INIT(&PyType_Type, 0)
     "dict_reversekeyiterator",
     sizeof(dictiterobject),
-    .tp_dealloc = (destructor)dictiter_dealloc,
+    .tp_dealloc = dictiter_dealloc,
     .tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC,
     .tp_traverse = dictiter_traverse,
     .tp_iter = PyObject_SelfIter,
@@ -4646,7 +4647,7 @@ PyTypeObject PyDictRevIterItem_Type = {
     PyVarObject_HEAD_INIT(&PyType_Type, 0)
     "dict_reverseitemiterator",
     sizeof(dictiterobject),
-    .tp_dealloc = (destructor)dictiter_dealloc,
+    .tp_dealloc = dictiter_dealloc,
     .tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC,
     .tp_traverse = dictiter_traverse,
     .tp_iter = PyObject_SelfIter,
@@ -4658,7 +4659,7 @@ PyTypeObject PyDictRevIterValue_Type = {
     PyVarObject_HEAD_INIT(&PyType_Type, 0)
     "dict_reversevalueiterator",
     sizeof(dictiterobject),
-    .tp_dealloc = (destructor)dictiter_dealloc,
+    .tp_dealloc = dictiter_dealloc,
     .tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC,
     .tp_traverse = dictiter_traverse,
     .tp_iter = PyObject_SelfIter,

--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -2591,8 +2591,9 @@ dict_length(PyObject *self)
 }
 
 static PyObject *
-dict_subscript(PyDictObject *mp, PyObject *key)
+dict_subscript(PyObject *self, PyObject *key)
 {
+    PyDictObject *mp = (PyDictObject *)self;
     Py_ssize_t ix;
     Py_hash_t hash;
     PyObject *value;
@@ -2636,7 +2637,7 @@ dict_ass_sub(PyDictObject *mp, PyObject *v, PyObject *w)
 
 static PyMappingMethods dict_as_mapping = {
     dict_length, /*mp_length*/
-    (binaryfunc)dict_subscript, /*mp_subscript*/
+    dict_subscript, /*mp_subscript*/
     (objobjargproc)dict_ass_sub, /*mp_ass_subscript*/
 };
 
@@ -3766,7 +3767,7 @@ PyDoc_STRVAR(values__doc__,
 
 static PyMethodDef mapp_methods[] = {
     DICT___CONTAINS___METHODDEF
-    {"__getitem__", _PyCFunction_CAST(dict_subscript),        METH_O | METH_COEXIST,
+    {"__getitem__",     dict_subscript,                 METH_O | METH_COEXIST,
      getitem__doc__},
     {"__sizeof__",      _PyCFunction_CAST(dict_sizeof),       METH_NOARGS,
      sizeof__doc__},

--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -2500,8 +2500,9 @@ dict_dealloc(PyObject *self)
 
 
 static PyObject *
-dict_repr(PyDictObject *mp)
+dict_repr(PyObject *self)
 {
+    PyDictObject *mp = (PyDictObject *)self;
     Py_ssize_t i;
     PyObject *key = NULL, *value = NULL;
     _PyUnicodeWriter writer;
@@ -3964,7 +3965,7 @@ PyTypeObject PyDict_Type = {
     0,                                          /* tp_getattr */
     0,                                          /* tp_setattr */
     0,                                          /* tp_as_async */
-    (reprfunc)dict_repr,                        /* tp_repr */
+    dict_repr,                                  /* tp_repr */
     &dict_as_number,                            /* tp_as_number */
     &dict_as_sequence,                          /* tp_as_sequence */
     &dict_as_mapping,                           /* tp_as_mapping */

--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -3109,9 +3109,9 @@ _PyDict_MergeEx(PyObject *a, PyObject *b, int override)
 }
 
 static PyObject *
-dict_copy(PyDictObject *mp, PyObject *Py_UNUSED(ignored))
+dict_copy(PyObject *mp, PyObject *Py_UNUSED(ignored))
 {
-    return PyDict_Copy((PyObject*)mp);
+    return PyDict_Copy(mp);
 }
 
 PyObject *
@@ -3513,9 +3513,9 @@ dict_setdefault_impl(PyDictObject *self, PyObject *key,
 }
 
 static PyObject *
-dict_clear(PyDictObject *mp, PyObject *Py_UNUSED(ignored))
+dict_clear(PyObject *mp, PyObject *Py_UNUSED(ignored))
 {
-    PyDict_Clear((PyObject *)mp);
+    PyDict_Clear(mp);
     Py_RETURN_NONE;
 }
 
@@ -3704,8 +3704,9 @@ _PyDict_KeysSize(PyDictKeysObject *keys)
 }
 
 static PyObject *
-dict_sizeof(PyDictObject *mp, PyObject *Py_UNUSED(ignored))
+dict_sizeof(PyObject *self, PyObject *Py_UNUSED(ignored))
 {
+    PyDictObject *mp = (PyDictObject *)self;
     return PyLong_FromSsize_t(_PyDict_SizeOf(mp));
 }
 
@@ -3769,7 +3770,7 @@ static PyMethodDef mapp_methods[] = {
     DICT___CONTAINS___METHODDEF
     {"__getitem__",     dict_subscript,                 METH_O | METH_COEXIST,
      getitem__doc__},
-    {"__sizeof__",      _PyCFunction_CAST(dict_sizeof),       METH_NOARGS,
+    {"__sizeof__",      dict_sizeof,                    METH_NOARGS,
      sizeof__doc__},
     DICT_GET_METHODDEF
     DICT_SETDEFAULT_METHODDEF
@@ -3784,9 +3785,9 @@ static PyMethodDef mapp_methods[] = {
     {"update",          _PyCFunction_CAST(dict_update), METH_VARARGS | METH_KEYWORDS,
      update__doc__},
     DICT_FROMKEYS_METHODDEF
-    {"clear",           (PyCFunction)dict_clear,        METH_NOARGS,
+    {"clear",           dict_clear,                     METH_NOARGS,
      clear__doc__},
-    {"copy",            (PyCFunction)dict_copy,         METH_NOARGS,
+    {"copy",            dict_copy,                      METH_NOARGS,
      copy__doc__},
     DICT___REVERSED___METHODDEF
     {"__class_getitem__", Py_GenericAlias, METH_O|METH_CLASS, PyDoc_STR("See PEP 585")},
@@ -4153,8 +4154,9 @@ dictiter_traverse(PyObject *self, visitproc visit, void *arg)
 }
 
 static PyObject *
-dictiter_len(dictiterobject *di, PyObject *Py_UNUSED(ignored))
+dictiter_len(PyObject *self, PyObject *Py_UNUSED(ignored))
 {
+    dictiterobject *di = (dictiterobject *)self;
     Py_ssize_t len = 0;
     if (di->di_dict != NULL && di->di_used == di->di_dict->ma_used)
         len = di->len;
@@ -4165,14 +4167,14 @@ PyDoc_STRVAR(length_hint_doc,
              "Private method returning an estimate of len(list(it)).");
 
 static PyObject *
-dictiter_reduce(dictiterobject *di, PyObject *Py_UNUSED(ignored));
+dictiter_reduce(PyObject *di, PyObject *Py_UNUSED(ignored));
 
 PyDoc_STRVAR(reduce_doc, "Return state information for pickling.");
 
 static PyMethodDef dictiter_methods[] = {
-    {"__length_hint__", _PyCFunction_CAST(dictiter_len), METH_NOARGS,
+    {"__length_hint__", dictiter_len,                   METH_NOARGS,
      length_hint_doc},
-     {"__reduce__", _PyCFunction_CAST(dictiter_reduce), METH_NOARGS,
+     {"__reduce__",     dictiter_reduce,                METH_NOARGS,
      reduce_doc},
     {NULL,              NULL}           /* sentinel */
 };
@@ -4635,8 +4637,9 @@ dict___reversed___impl(PyDictObject *self)
 }
 
 static PyObject *
-dictiter_reduce(dictiterobject *di, PyObject *Py_UNUSED(ignored))
+dictiter_reduce(PyObject *self, PyObject *Py_UNUSED(ignored))
 {
+    dictiterobject *di = (dictiterobject *)self;
     /* copy the iterator state */
     dictiterobject tmp = *di;
     Py_XINCREF(tmp.di_dict);
@@ -5214,15 +5217,15 @@ dictviews_isdisjoint(PyObject *self, PyObject *other)
 PyDoc_STRVAR(isdisjoint_doc,
 "Return True if the view and the given iterable have a null intersection.");
 
-static PyObject* dictkeys_reversed(_PyDictViewObject *dv, PyObject *Py_UNUSED(ignored));
+static PyObject* dictkeys_reversed(PyObject *dv, PyObject *Py_UNUSED(ignored));
 
 PyDoc_STRVAR(reversed_keys_doc,
 "Return a reverse iterator over the dict keys.");
 
 static PyMethodDef dictkeys_methods[] = {
-    {"isdisjoint",      (PyCFunction)dictviews_isdisjoint,  METH_O,
+    {"isdisjoint",      dictviews_isdisjoint,           METH_O,
      isdisjoint_doc},
-    {"__reversed__",    _PyCFunction_CAST(dictkeys_reversed),    METH_NOARGS,
+    {"__reversed__",    dictkeys_reversed,              METH_NOARGS,
      reversed_keys_doc},
     {NULL,              NULL}           /* sentinel */
 };
@@ -5267,8 +5270,9 @@ dictkeys_new(PyObject *dict, PyObject *Py_UNUSED(ignored))
 }
 
 static PyObject *
-dictkeys_reversed(_PyDictViewObject *dv, PyObject *Py_UNUSED(ignored))
+dictkeys_reversed(PyObject *self, PyObject *Py_UNUSED(ignored))
 {
+    _PyDictViewObject *dv = (_PyDictViewObject *)self;
     if (dv->dv_dict == NULL) {
         Py_RETURN_NONE;
     }
@@ -5318,15 +5322,15 @@ static PySequenceMethods dictitems_as_sequence = {
     dictitems_contains,                 /* sq_contains */
 };
 
-static PyObject* dictitems_reversed(_PyDictViewObject *dv, PyObject *Py_UNUSED(ignored));
+static PyObject* dictitems_reversed(PyObject *dv, PyObject *Py_UNUSED(ignored));
 
 PyDoc_STRVAR(reversed_items_doc,
 "Return a reverse iterator over the dict items.");
 
 static PyMethodDef dictitems_methods[] = {
-    {"isdisjoint",      (PyCFunction)dictviews_isdisjoint,  METH_O,
+    {"isdisjoint",      dictviews_isdisjoint,           METH_O,
      isdisjoint_doc},
-    {"__reversed__",    (PyCFunction)dictitems_reversed,    METH_NOARGS,
+    {"__reversed__",    dictitems_reversed,             METH_NOARGS,
      reversed_items_doc},
     {NULL,              NULL}           /* sentinel */
 };
@@ -5371,8 +5375,9 @@ dictitems_new(PyObject *dict, PyObject *Py_UNUSED(ignored))
 }
 
 static PyObject *
-dictitems_reversed(_PyDictViewObject *dv, PyObject *Py_UNUSED(ignored))
+dictitems_reversed(PyObject *self, PyObject *Py_UNUSED(ignored))
 {
+    _PyDictViewObject *dv = (_PyDictViewObject *)self;
     if (dv->dv_dict == NULL) {
         Py_RETURN_NONE;
     }
@@ -5402,13 +5407,13 @@ static PySequenceMethods dictvalues_as_sequence = {
     (objobjproc)0,                      /* sq_contains */
 };
 
-static PyObject* dictvalues_reversed(_PyDictViewObject *dv, PyObject *Py_UNUSED(ignored));
+static PyObject* dictvalues_reversed(PyObject *dv, PyObject *Py_UNUSED(ignored));
 
 PyDoc_STRVAR(reversed_values_doc,
 "Return a reverse iterator over the dict values.");
 
 static PyMethodDef dictvalues_methods[] = {
-    {"__reversed__",    (PyCFunction)dictvalues_reversed,    METH_NOARGS,
+    {"__reversed__",    dictvalues_reversed,            METH_NOARGS,
      reversed_values_doc},
     {NULL,              NULL}           /* sentinel */
 };
@@ -5453,8 +5458,9 @@ dictvalues_new(PyObject *dict, PyObject *Py_UNUSED(ignored))
 }
 
 static PyObject *
-dictvalues_reversed(_PyDictViewObject *dv, PyObject *Py_UNUSED(ignored))
+dictvalues_reversed(PyObject *self, PyObject *Py_UNUSED(ignored))
 {
+    _PyDictViewObject *dv = (_PyDictViewObject *)self;
     if (dv->dv_dict == NULL) {
         Py_RETURN_NONE;
     }


### PR DESCRIPTION
Proposed separately for review by respective codeowners.

<details>
<summary>Potential compiler warnings eliminated:</summary>

```
Objects/dictobject.c:2470:5: warning: cast from 'void (*)(PyDictObject *)' to 'destructor' (aka 'void (*)(struct _object *)') converts to incompatible function type [-Wcast-function-type-strict]
 2470 |     Py_TRASHCAN_BEGIN(mp, dict_dealloc)
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
./Include/cpython/object.h:482:43: note: expanded from macro 'Py_TRASHCAN_BEGIN'
  481 |     Py_TRASHCAN_BEGIN_CONDITION((op), \
      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  482 |         _PyTrash_cond(_PyObject_CAST(op), (destructor)(dealloc)))
      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~
./Include/cpython/object.h:467:13: note: expanded from macro 'Py_TRASHCAN_BEGIN_CONDITION'
  467 |         if (cond) { \
      |             ^~~~
Objects/dictobject.c:2635:5: warning: cast from 'Py_ssize_t (*)(PyDictObject *)' (aka 'long (*)(PyDictObject *)') to 'lenfunc' (aka 'long (*)(struct _object *)') converts to incompatible function type [-Wcast-function-type-strict]
 2635 |     (lenfunc)dict_length, /*mp_length*/
      |     ^~~~~~~~~~~~~~~~~~~~
Objects/dictobject.c:2636:5: warning: cast from 'PyObject *(*)(PyDictObject *, PyObject *)' (aka 'struct _object *(*)(PyDictObject *, struct _object *)') to 'binaryfunc' (aka 'struct _object *(*)(struct _object *, struct _object *)') converts to incompatible function type [-Wcast-function-type-strict]
 2636 |     (binaryfunc)dict_subscript, /*mp_subscript*/
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~
Objects/dictobject.c:2637:5: warning: cast from 'int (*)(PyDictObject *, PyObject *, PyObject *)' (aka 'int (*)(PyDictObject *, struct _object *, struct _object *)') to 'objobjargproc' (aka 'int (*)(struct _object *, struct _object *, struct _object *)') converts to incompatible function type [-Wcast-function-type-strict]
 2637 |     (objobjargproc)dict_ass_sub, /*mp_ass_subscript*/
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~
Objects/dictobject.c:2928:52: warning: cast from 'PyObject *(*)(PyDictObject *)' (aka 'struct _object *(*)(PyDictObject *)') to 'getiterfunc' (aka 'struct _object *(*)(struct _object *)') converts to incompatible function type [-Wcast-function-type-strict]
 2928 |     if (PyDict_Check(b) && (Py_TYPE(b)->tp_iter == (getiterfunc)dict_iter)) {
      |                                                    ^~~~~~~~~~~~~~~~~~~~~~
Objects/dictobject.c:3158:33: warning: cast from 'PyObject *(*)(PyDictObject *)' (aka 'struct _object *(*)(PyDictObject *)') to 'getiterfunc' (aka 'struct _object *(*)(struct _object *)') converts to incompatible function type [-Wcast-function-type-strict]
 3158 |     if (Py_TYPE(mp)->tp_iter == (getiterfunc)dict_iter &&
      |                                 ^~~~~~~~~~~~~~~~~~~~~~
Objects/dictobject.c:3766:21: warning: cast from 'PyObject *(*)(PyDictObject *, PyObject *)' (aka 'struct _object *(*)(PyDictObject *, struct _object *)') to 'void (*)(void)' converts to incompatible function type [-Wcast-function-type-strict]
 3766 |     {"__getitem__", _PyCFunction_CAST(dict_subscript),        METH_O | METH_COEXIST,
      |                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
./Include/methodobject.h:46:27: note: expanded from macro '_PyCFunction_CAST'
   46 |     _Py_CAST(PyCFunction, _Py_CAST(void(*)(void), (func)))
      |     ~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
./Include/pyport.h:19:31: note: expanded from macro '_Py_CAST'
   19 | #define _Py_CAST(type, expr) ((type)(expr))
      |                               ^
./Include/pyport.h:19:38: note: expanded from macro '_Py_CAST'
   19 | #define _Py_CAST(type, expr) ((type)(expr))
      |                                      ^~~~
Objects/dictobject.c:3766:21: warning: cast from 'void (*)(void)' to 'PyCFunction' (aka 'struct _object *(*)(struct _object *, struct _object *)') converts to incompatible function type [-Wcast-function-type-strict]
 3766 |     {"__getitem__", _PyCFunction_CAST(dict_subscript),        METH_O | METH_COEXIST,
      |                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
./Include/methodobject.h:46:5: note: expanded from macro '_PyCFunction_CAST'
   46 |     _Py_CAST(PyCFunction, _Py_CAST(void(*)(void), (func)))
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
./Include/pyport.h:19:31: note: expanded from macro '_Py_CAST'
   19 | #define _Py_CAST(type, expr) ((type)(expr))
      |                               ^~~~~~~~~~~~
Objects/dictobject.c:3768:25: warning: cast from 'PyObject *(*)(PyDictObject *, PyObject *)' (aka 'struct _object *(*)(PyDictObject *, struct _object *)') to 'void (*)(void)' converts to incompatible function type [-Wcast-function-type-strict]
 3768 |     {"__sizeof__",      _PyCFunction_CAST(dict_sizeof),       METH_NOARGS,
      |                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
./Include/methodobject.h:46:27: note: expanded from macro '_PyCFunction_CAST'
   46 |     _Py_CAST(PyCFunction, _Py_CAST(void(*)(void), (func)))
      |     ~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
./Include/pyport.h:19:31: note: expanded from macro '_Py_CAST'
   19 | #define _Py_CAST(type, expr) ((type)(expr))
      |                               ^
./Include/pyport.h:19:38: note: expanded from macro '_Py_CAST'
   19 | #define _Py_CAST(type, expr) ((type)(expr))
      |                                      ^~~~
Objects/dictobject.c:3768:25: warning: cast from 'void (*)(void)' to 'PyCFunction' (aka 'struct _object *(*)(struct _object *, struct _object *)') converts to incompatible function type [-Wcast-function-type-strict]
 3768 |     {"__sizeof__",      _PyCFunction_CAST(dict_sizeof),       METH_NOARGS,
      |                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
./Include/methodobject.h:46:5: note: expanded from macro '_PyCFunction_CAST'
   46 |     _Py_CAST(PyCFunction, _Py_CAST(void(*)(void), (func)))
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
./Include/pyport.h:19:31: note: expanded from macro '_Py_CAST'
   19 | #define _Py_CAST(type, expr) ((type)(expr))
      |                               ^~~~~~~~~~~~
Objects/dictobject.c:3783:25: warning: cast from 'PyObject *(*)(PyDictObject *, PyObject *)' (aka 'struct _object *(*)(PyDictObject *, struct _object *)') to 'PyCFunction' (aka 'struct _object *(*)(struct _object *, struct _object *)') converts to incompatible function type [-Wcast-function-type-strict]
 3783 |     {"clear",           (PyCFunction)dict_clear,        METH_NOARGS,
      |                         ^~~~~~~~~~~~~~~~~~~~~~~
Objects/dictobject.c:3785:25: warning: cast from 'PyObject *(*)(PyDictObject *, PyObject *)' (aka 'struct _object *(*)(PyDictObject *, struct _object *)') to 'PyCFunction' (aka 'struct _object *(*)(struct _object *, struct _object *)') converts to incompatible function type [-Wcast-function-type-strict]
 3785 |     {"copy",            (PyCFunction)dict_copy,         METH_NOARGS,
      |                         ^~~~~~~~~~~~~~~~~~~~~~
Objects/dictobject.c:3961:5: warning: cast from 'void (*)(PyDictObject *)' to 'destructor' (aka 'void (*)(struct _object *)') converts to incompatible function type [-Wcast-function-type-strict]
 3961 |     (destructor)dict_dealloc,                   /* tp_dealloc */
      |     ^~~~~~~~~~~~~~~~~~~~~~~~
Objects/dictobject.c:3966:5: warning: cast from 'PyObject *(*)(PyDictObject *)' (aka 'struct _object *(*)(PyDictObject *)') to 'reprfunc' (aka 'struct _object *(*)(struct _object *)') converts to incompatible function type [-Wcast-function-type-strict]
 3966 |     (reprfunc)dict_repr,                        /* tp_repr */
      |     ^~~~~~~~~~~~~~~~~~~
Objects/dictobject.c:3984:5: warning: cast from 'PyObject *(*)(PyDictObject *)' (aka 'struct _object *(*)(PyDictObject *)') to 'getiterfunc' (aka 'struct _object *(*)(struct _object *)') converts to incompatible function type [-Wcast-function-type-strict]
 3984 |     (getiterfunc)dict_iter,                     /* tp_iter */
      |     ^~~~~~~~~~~~~~~~~~~~~~
Objects/dictobject.c:4166:25: warning: cast from 'PyObject *(*)(dictiterobject *, PyObject *)' (aka 'struct _object *(*)(dictiterobject *, struct _object *)') to 'void (*)(void)' converts to incompatible function type [-Wcast-function-type-strict]
 4166 |     {"__length_hint__", _PyCFunction_CAST(dictiter_len), METH_NOARGS,
      |                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
./Include/methodobject.h:46:27: note: expanded from macro '_PyCFunction_CAST'
   46 |     _Py_CAST(PyCFunction, _Py_CAST(void(*)(void), (func)))
      |     ~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
./Include/pyport.h:19:31: note: expanded from macro '_Py_CAST'
   19 | #define _Py_CAST(type, expr) ((type)(expr))
      |                               ^
./Include/pyport.h:19:38: note: expanded from macro '_Py_CAST'
   19 | #define _Py_CAST(type, expr) ((type)(expr))
      |                                      ^~~~
Objects/dictobject.c:4166:25: warning: cast from 'void (*)(void)' to 'PyCFunction' (aka 'struct _object *(*)(struct _object *, struct _object *)') converts to incompatible function type [-Wcast-function-type-strict]
 4166 |     {"__length_hint__", _PyCFunction_CAST(dictiter_len), METH_NOARGS,
      |                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
./Include/methodobject.h:46:5: note: expanded from macro '_PyCFunction_CAST'
   46 |     _Py_CAST(PyCFunction, _Py_CAST(void(*)(void), (func)))
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
./Include/pyport.h:19:31: note: expanded from macro '_Py_CAST'
   19 | #define _Py_CAST(type, expr) ((type)(expr))
      |                               ^~~~~~~~~~~~
Objects/dictobject.c:4168:21: warning: cast from 'PyObject *(*)(dictiterobject *, PyObject *)' (aka 'struct _object *(*)(dictiterobject *, struct _object *)') to 'void (*)(void)' converts to incompatible function type [-Wcast-function-type-strict]
 4168 |      {"__reduce__", _PyCFunction_CAST(dictiter_reduce), METH_NOARGS,
      |                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
./Include/methodobject.h:46:27: note: expanded from macro '_PyCFunction_CAST'
   46 |     _Py_CAST(PyCFunction, _Py_CAST(void(*)(void), (func)))
      |     ~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
./Include/pyport.h:19:31: note: expanded from macro '_Py_CAST'
   19 | #define _Py_CAST(type, expr) ((type)(expr))
      |                               ^
./Include/pyport.h:19:38: note: expanded from macro '_Py_CAST'
   19 | #define _Py_CAST(type, expr) ((type)(expr))
      |                                      ^~~~
Objects/dictobject.c:4168:21: warning: cast from 'void (*)(void)' to 'PyCFunction' (aka 'struct _object *(*)(struct _object *, struct _object *)') converts to incompatible function type [-Wcast-function-type-strict]
 4168 |      {"__reduce__", _PyCFunction_CAST(dictiter_reduce), METH_NOARGS,
      |                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
./Include/methodobject.h:46:5: note: expanded from macro '_PyCFunction_CAST'
   46 |     _Py_CAST(PyCFunction, _Py_CAST(void(*)(void), (func)))
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
./Include/pyport.h:19:31: note: expanded from macro '_Py_CAST'
   19 | #define _Py_CAST(type, expr) ((type)(expr))
      |                               ^~~~~~~~~~~~
Objects/dictobject.c:4247:5: warning: cast from 'void (*)(dictiterobject *)' to 'destructor' (aka 'void (*)(struct _object *)') converts to incompatible function type [-Wcast-function-type-strict]
 4247 |     (destructor)dictiter_dealloc,               /* tp_dealloc */
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
Objects/dictobject.c:4264:5: warning: cast from 'int (*)(dictiterobject *, visitproc, void *)' (aka 'int (*)(dictiterobject *, int (*)(struct _object *, void *), void *)') to 'traverseproc' (aka 'int (*)(struct _object *, int (*)(struct _object *, void *), void *)') converts to incompatible function type [-Wcast-function-type-strict]
 4264 |     (traverseproc)dictiter_traverse,            /* tp_traverse */
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
Objects/dictobject.c:4269:5: warning: cast from 'PyObject *(*)(dictiterobject *)' (aka 'struct _object *(*)(dictiterobject *)') to 'iternextfunc' (aka 'struct _object *(*)(struct _object *)') converts to incompatible function type [-Wcast-function-type-strict]
 4269 |     (iternextfunc)dictiter_iternextkey,         /* tp_iternext */
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
Objects/dictobject.c:4346:5: warning: cast from 'void (*)(dictiterobject *)' to 'destructor' (aka 'void (*)(struct _object *)') converts to incompatible function type [-Wcast-function-type-strict]
 4346 |     (destructor)dictiter_dealloc,               /* tp_dealloc */
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
Objects/dictobject.c:4363:5: warning: cast from 'int (*)(dictiterobject *, visitproc, void *)' (aka 'int (*)(dictiterobject *, int (*)(struct _object *, void *), void *)') to 'traverseproc' (aka 'int (*)(struct _object *, int (*)(struct _object *, void *), void *)') converts to incompatible function type [-Wcast-function-type-strict]
 4363 |     (traverseproc)dictiter_traverse,            /* tp_traverse */
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
Objects/dictobject.c:4368:5: warning: cast from 'PyObject *(*)(dictiterobject *)' (aka 'struct _object *(*)(dictiterobject *)') to 'iternextfunc' (aka 'struct _object *(*)(struct _object *)') converts to incompatible function type [-Wcast-function-type-strict]
 4368 |     (iternextfunc)dictiter_iternextvalue,       /* tp_iternext */
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
Objects/dictobject.c:4470:5: warning: cast from 'void (*)(dictiterobject *)' to 'destructor' (aka 'void (*)(struct _object *)') converts to incompatible function type [-Wcast-function-type-strict]
 4470 |     (destructor)dictiter_dealloc,               /* tp_dealloc */
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
Objects/dictobject.c:4487:5: warning: cast from 'int (*)(dictiterobject *, visitproc, void *)' (aka 'int (*)(dictiterobject *, int (*)(struct _object *, void *), void *)') to 'traverseproc' (aka 'int (*)(struct _object *, int (*)(struct _object *, void *), void *)') converts to incompatible function type [-Wcast-function-type-strict]
 4487 |     (traverseproc)dictiter_traverse,            /* tp_traverse */
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
Objects/dictobject.c:4492:5: warning: cast from 'PyObject *(*)(dictiterobject *)' (aka 'struct _object *(*)(dictiterobject *)') to 'iternextfunc' (aka 'struct _object *(*)(struct _object *)') converts to incompatible function type [-Wcast-function-type-strict]
 4492 |     (iternextfunc)dictiter_iternextitem,        /* tp_iternext */
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
Objects/dictobject.c:4603:19: warning: cast from 'void (*)(dictiterobject *)' to 'destructor' (aka 'void (*)(struct _object *)') converts to incompatible function type [-Wcast-function-type-strict]
 4603 |     .tp_dealloc = (destructor)dictiter_dealloc,
      |                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
Objects/dictobject.c:4605:20: warning: cast from 'int (*)(dictiterobject *, visitproc, void *)' (aka 'int (*)(dictiterobject *, int (*)(struct _object *, void *), void *)') to 'traverseproc' (aka 'int (*)(struct _object *, int (*)(struct _object *, void *), void *)') converts to incompatible function type [-Wcast-function-type-strict]
 4605 |     .tp_traverse = (traverseproc)dictiter_traverse,
      |                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
Objects/dictobject.c:4607:20: warning: cast from 'PyObject *(*)(dictiterobject *)' (aka 'struct _object *(*)(dictiterobject *)') to 'iternextfunc' (aka 'struct _object *(*)(struct _object *)') converts to incompatible function type [-Wcast-function-type-strict]
 4607 |     .tp_iternext = (iternextfunc)dictreviter_iternext,
      |                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
Objects/dictobject.c:4644:19: warning: cast from 'void (*)(dictiterobject *)' to 'destructor' (aka 'void (*)(struct _object *)') converts to incompatible function type [-Wcast-function-type-strict]
 4644 |     .tp_dealloc = (destructor)dictiter_dealloc,
      |                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
Objects/dictobject.c:4646:20: warning: cast from 'int (*)(dictiterobject *, visitproc, void *)' (aka 'int (*)(dictiterobject *, int (*)(struct _object *, void *), void *)') to 'traverseproc' (aka 'int (*)(struct _object *, int (*)(struct _object *, void *), void *)') converts to incompatible function type [-Wcast-function-type-strict]
 4646 |     .tp_traverse = (traverseproc)dictiter_traverse,
      |                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
Objects/dictobject.c:4648:20: warning: cast from 'PyObject *(*)(dictiterobject *)' (aka 'struct _object *(*)(dictiterobject *)') to 'iternextfunc' (aka 'struct _object *(*)(struct _object *)') converts to incompatible function type [-Wcast-function-type-strict]
 4648 |     .tp_iternext = (iternextfunc)dictreviter_iternext,
      |                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
Objects/dictobject.c:4656:19: warning: cast from 'void (*)(dictiterobject *)' to 'destructor' (aka 'void (*)(struct _object *)') converts to incompatible function type [-Wcast-function-type-strict]
 4656 |     .tp_dealloc = (destructor)dictiter_dealloc,
      |                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
Objects/dictobject.c:4658:20: warning: cast from 'int (*)(dictiterobject *, visitproc, void *)' (aka 'int (*)(dictiterobject *, int (*)(struct _object *, void *), void *)') to 'traverseproc' (aka 'int (*)(struct _object *, int (*)(struct _object *, void *), void *)') converts to incompatible function type [-Wcast-function-type-strict]
 4658 |     .tp_traverse = (traverseproc)dictiter_traverse,
      |                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
Objects/dictobject.c:4660:20: warning: cast from 'PyObject *(*)(dictiterobject *)' (aka 'struct _object *(*)(dictiterobject *)') to 'iternextfunc' (aka 'struct _object *(*)(struct _object *)') converts to incompatible function type [-Wcast-function-type-strict]
 4660 |     .tp_iternext = (iternextfunc)dictreviter_iternext,
      |                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
Objects/dictobject.c:4870:5: warning: cast from 'Py_ssize_t (*)(_PyDictViewObject *)' (aka 'long (*)(_PyDictViewObject *)') to 'lenfunc' (aka 'long (*)(struct _object *)') converts to incompatible function type [-Wcast-function-type-strict]
 4870 |     (lenfunc)dictview_len,              /* sq_length */
      |     ^~~~~~~~~~~~~~~~~~~~~
Objects/dictobject.c:4877:5: warning: cast from 'int (*)(_PyDictViewObject *, PyObject *)' (aka 'int (*)(_PyDictViewObject *, struct _object *)') to 'objobjproc' (aka 'int (*)(struct _object *, struct _object *)') converts to incompatible function type [-Wcast-function-type-strict]
 4877 |     (objobjproc)dictkeys_contains,      /* sq_contains */
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
Objects/dictobject.c:5208:25: warning: cast from 'PyObject *(*)(_PyDictViewObject *, PyObject *)' (aka 'struct _object *(*)(_PyDictViewObject *, struct _object *)') to 'void (*)(void)' converts to incompatible function type [-Wcast-function-type-strict]
 5208 |     {"__reversed__",    _PyCFunction_CAST(dictkeys_reversed),    METH_NOARGS,
      |                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
./Include/methodobject.h:46:27: note: expanded from macro '_PyCFunction_CAST'
   46 |     _Py_CAST(PyCFunction, _Py_CAST(void(*)(void), (func)))
      |     ~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
./Include/pyport.h:19:31: note: expanded from macro '_Py_CAST'
   19 | #define _Py_CAST(type, expr) ((type)(expr))
      |                               ^
./Include/pyport.h:19:38: note: expanded from macro '_Py_CAST'
   19 | #define _Py_CAST(type, expr) ((type)(expr))
      |                                      ^~~~
Objects/dictobject.c:5208:25: warning: cast from 'void (*)(void)' to 'PyCFunction' (aka 'struct _object *(*)(struct _object *, struct _object *)') converts to incompatible function type [-Wcast-function-type-strict]
 5208 |     {"__reversed__",    _PyCFunction_CAST(dictkeys_reversed),    METH_NOARGS,
      |                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
./Include/methodobject.h:46:5: note: expanded from macro '_PyCFunction_CAST'
   46 |     _Py_CAST(PyCFunction, _Py_CAST(void(*)(void), (func)))
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
./Include/pyport.h:19:31: note: expanded from macro '_Py_CAST'
   19 | #define _Py_CAST(type, expr) ((type)(expr))
      |                               ^~~~~~~~~~~~
Objects/dictobject.c:5219:5: warning: cast from 'void (*)(_PyDictViewObject *)' to 'destructor' (aka 'void (*)(struct _object *)') converts to incompatible function type [-Wcast-function-type-strict]
 5219 |     (destructor)dictview_dealloc,               /* tp_dealloc */
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
Objects/dictobject.c:5224:5: warning: cast from 'PyObject *(*)(_PyDictViewObject *)' (aka 'struct _object *(*)(_PyDictViewObject *)') to 'reprfunc' (aka 'struct _object *(*)(struct _object *)') converts to incompatible function type [-Wcast-function-type-strict]
 5224 |     (reprfunc)dictview_repr,                    /* tp_repr */
      |     ^~~~~~~~~~~~~~~~~~~~~~~
Objects/dictobject.c:5236:5: warning: cast from 'int (*)(_PyDictViewObject *, visitproc, void *)' (aka 'int (*)(_PyDictViewObject *, int (*)(struct _object *, void *), void *)') to 'traverseproc' (aka 'int (*)(struct _object *, int (*)(struct _object *, void *), void *)') converts to incompatible function type [-Wcast-function-type-strict]
 5236 |     (traverseproc)dictview_traverse,            /* tp_traverse */
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
Objects/dictobject.c:5240:5: warning: cast from 'PyObject *(*)(_PyDictViewObject *)' (aka 'struct _object *(*)(_PyDictViewObject *)') to 'getiterfunc' (aka 'struct _object *(*)(struct _object *)') converts to incompatible function type [-Wcast-function-type-strict]
 5240 |     (getiterfunc)dictkeys_iter,                 /* tp_iter */
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~
Objects/dictobject.c:5292:5: warning: cast from 'Py_ssize_t (*)(_PyDictViewObject *)' (aka 'long (*)(_PyDictViewObject *)') to 'lenfunc' (aka 'long (*)(struct _object *)') converts to incompatible function type [-Wcast-function-type-strict]
 5292 |     (lenfunc)dictview_len,              /* sq_length */
      |     ^~~~~~~~~~~~~~~~~~~~~
Objects/dictobject.c:5299:5: warning: cast from 'int (*)(_PyDictViewObject *, PyObject *)' (aka 'int (*)(_PyDictViewObject *, struct _object *)') to 'objobjproc' (aka 'int (*)(struct _object *, struct _object *)') converts to incompatible function type [-Wcast-function-type-strict]
 5299 |     (objobjproc)dictitems_contains,     /* sq_contains */
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
Objects/dictobject.c:5310:25: warning: cast from 'PyObject *(*)(_PyDictViewObject *, PyObject *)' (aka 'struct _object *(*)(_PyDictViewObject *, struct _object *)') to 'PyCFunction' (aka 'struct _object *(*)(struct _object *, struct _object *)') converts to incompatible function type [-Wcast-function-type-strict]
 5310 |     {"__reversed__",    (PyCFunction)dictitems_reversed,    METH_NOARGS,
      |                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
Objects/dictobject.c:5321:5: warning: cast from 'void (*)(_PyDictViewObject *)' to 'destructor' (aka 'void (*)(struct _object *)') converts to incompatible function type [-Wcast-function-type-strict]
 5321 |     (destructor)dictview_dealloc,               /* tp_dealloc */
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
Objects/dictobject.c:5326:5: warning: cast from 'PyObject *(*)(_PyDictViewObject *)' (aka 'struct _object *(*)(_PyDictViewObject *)') to 'reprfunc' (aka 'struct _object *(*)(struct _object *)') converts to incompatible function type [-Wcast-function-type-strict]
 5326 |     (reprfunc)dictview_repr,                    /* tp_repr */
      |     ^~~~~~~~~~~~~~~~~~~~~~~
Objects/dictobject.c:5338:5: warning: cast from 'int (*)(_PyDictViewObject *, visitproc, void *)' (aka 'int (*)(_PyDictViewObject *, int (*)(struct _object *, void *), void *)') to 'traverseproc' (aka 'int (*)(struct _object *, int (*)(struct _object *, void *), void *)') converts to incompatible function type [-Wcast-function-type-strict]
 5338 |     (traverseproc)dictview_traverse,            /* tp_traverse */
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
Objects/dictobject.c:5342:5: warning: cast from 'PyObject *(*)(_PyDictViewObject *)' (aka 'struct _object *(*)(_PyDictViewObject *)') to 'getiterfunc' (aka 'struct _object *(*)(struct _object *)') converts to incompatible function type [-Wcast-function-type-strict]
 5342 |     (getiterfunc)dictitems_iter,                /* tp_iter */
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~
Objects/dictobject.c:5375:5: warning: cast from 'Py_ssize_t (*)(_PyDictViewObject *)' (aka 'long (*)(_PyDictViewObject *)') to 'lenfunc' (aka 'long (*)(struct _object *)') converts to incompatible function type [-Wcast-function-type-strict]
 5375 |     (lenfunc)dictview_len,              /* sq_length */
      |     ^~~~~~~~~~~~~~~~~~~~~
Objects/dictobject.c:5391:25: warning: cast from 'PyObject *(*)(_PyDictViewObject *, PyObject *)' (aka 'struct _object *(*)(_PyDictViewObject *, struct _object *)') to 'PyCFunction' (aka 'struct _object *(*)(struct _object *, struct _object *)') converts to incompatible function type [-Wcast-function-type-strict]
 5391 |     {"__reversed__",    (PyCFunction)dictvalues_reversed,    METH_NOARGS,
      |                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
Objects/dictobject.c:5402:5: warning: cast from 'void (*)(_PyDictViewObject *)' to 'destructor' (aka 'void (*)(struct _object *)') converts to incompatible function type [-Wcast-function-type-strict]
 5402 |     (destructor)dictview_dealloc,               /* tp_dealloc */
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
Objects/dictobject.c:5407:5: warning: cast from 'PyObject *(*)(_PyDictViewObject *)' (aka 'struct _object *(*)(_PyDictViewObject *)') to 'reprfunc' (aka 'struct _object *(*)(struct _object *)') converts to incompatible function type [-Wcast-function-type-strict]
 5407 |     (reprfunc)dictview_repr,                    /* tp_repr */
      |     ^~~~~~~~~~~~~~~~~~~~~~~
Objects/dictobject.c:5419:5: warning: cast from 'int (*)(_PyDictViewObject *, visitproc, void *)' (aka 'int (*)(_PyDictViewObject *, int (*)(struct _object *, void *), void *)') to 'traverseproc' (aka 'int (*)(struct _object *, int (*)(struct _object *, void *), void *)') converts to incompatible function type [-Wcast-function-type-strict]
 5419 |     (traverseproc)dictview_traverse,            /* tp_traverse */
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
Objects/dictobject.c:5423:5: warning: cast from 'PyObject *(*)(_PyDictViewObject *)' (aka 'struct _object *(*)(_PyDictViewObject *)') to 'getiterfunc' (aka 'struct _object *(*)(struct _object *)') converts to incompatible function type [-Wcast-function-type-strict]
 5423 |     (getiterfunc)dictvalues_iter,               /* tp_iter */
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
</details>

Example UBSan `-fsanitize=function` errors eliminated:

```
Objects/typeobject.c:5581:12: runtime error: call to function dict_repr through pointer to incorrect function type 'struct _object *(*)(struct _object *)'
dictobject.c:2503: note: dict_repr defined here
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior Objects/typeobject.c:5581:12 in 
Python/generated_cases.c.h:4872:30: runtime error: call to function dictiter_iternextkey through pointer to incorrect function type 'struct _object *(*)(struct _object *)'
dictobject.c:4175: note: dictiter_iternextkey defined here
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior Python/generated_cases.c.h:4872:30 in 
Objects/abstract.c:158:26: runtime error: call to function dict_subscript through pointer to incorrect function type 'struct _object *(*)(struct _object *, struct _object *)'
dictobject.c:2592: note: dict_subscript defined here
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior Objects/abstract.c:158:26 in 
Objects/abstract.c:232:19: runtime error: call to function dict_ass_sub through pointer to incorrect function type 'int (*)(struct _object *, struct _object *, struct _object *)'
dictobject.c:2627: note: dict_ass_sub defined here
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior Objects/abstract.c:232:19 in 
Python/generated_cases.c.h:2452:21: runtime error: call to function dictiter_dealloc through pointer to incorrect function type 'void (*)(struct _object *)'
dictobject.c:4132: note: dictiter_dealloc defined here
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior Python/generated_cases.c.h:2452:21 in 
Python/generated_cases.c.h:1225:13: runtime error: call to function dict_dealloc through pointer to incorrect function type 'void (*)(struct _object *)'
dictobject.c:2454: note: dict_dealloc defined here
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior Python/generated_cases.c.h:1225:13 in 
Objects/abstract.c:2371:26: runtime error: call to function dict_length through pointer to incorrect function type 'long (*)(struct _object *)'
dictobject.c:2586: note: dict_length defined here
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior Objects/abstract.c:2371:26 in 
Objects/abstract.c:2913:25: runtime error: call to function dictitems_iter through pointer to incorrect function type 'struct _object *(*)(struct _object *)'
dictobject.c:5265: note: dictitems_iter defined here
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior Objects/abstract.c:2913:25 in 
Python/generated_cases.c.h:2753:13: runtime error: call to function dictview_dealloc through pointer to incorrect function type 'void (*)(struct _object *)'
dictobject.c:4672: note: dictview_dealloc defined here
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior Python/generated_cases.c.h:2753:13 in 
Python/generated_cases.c.h:2440:24: runtime error: call to function dictiter_iternextitem through pointer to incorrect function type 'struct _object *(*)(struct _object *)'
dictobject.c:4375: note: dictiter_iternextitem defined here
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior Python/generated_cases.c.h:2440:24 in 
Objects/abstract.c:158:26: runtime error: call to function dict_subscript through pointer to incorrect function type 'struct _object *(*)(struct _object *, struct _object *)'
dictobject.c:2592: note: dict_subscript defined here
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior Objects/abstract.c:158:26 in 
```

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-111178 -->
* Issue: gh-111178
<!-- /gh-issue-number -->
