### PR TITLE
gh-111178: Avoid calling functions from incompatible pointer types in _tkinter.c

### DIFF
--- a/Modules/_tkinter.c
+++ b/Modules/_tkinter.c
@@ -749,8 +749,9 @@ PyDoc_STRVAR(PyTclObject_string__doc__,
 "the string representation of this object, either as str or bytes");
 
 static PyObject *
-PyTclObject_string(PyTclObject *self, void *ignored)
+PyTclObject_string(PyObject *_self, void *ignored)
 {
+    PyTclObject *self = (PyTclObject *)_self;
     if (!self->string) {
         self->string = unicodeFromTclObj(self->value);
         if (!self->string)
@@ -817,7 +818,7 @@ get_typename(PyTclObject* obj, void* ignored)
 
 static PyGetSetDef PyTclObject_getsetlist[] = {
     {"typename", (getter)get_typename, NULL, get_typename__doc__},
-    {"string", (getter)PyTclObject_string, NULL,
+    {"string", PyTclObject_string, NULL,
      PyTclObject_string__doc__},
     {0},
 };

--- a/Modules/_tkinter.c
+++ b/Modules/_tkinter.c
@@ -735,8 +735,9 @@ newPyTclObject(Tcl_Obj *arg)
 }
 
 static void
-PyTclObject_dealloc(PyTclObject *self)
+PyTclObject_dealloc(PyObject *_self)
 {
+    PyTclObject *self = (PyTclObject *)_self;
     PyObject *tp = (PyObject *) Py_TYPE(self);
     Tcl_DecrRefCount(self->value);
     Py_XDECREF(self->string);
@@ -827,7 +828,7 @@ static PyGetSetDef PyTclObject_getsetlist[] = {
 };
 
 static PyType_Slot PyTclObject_Type_slots[] = {
-    {Py_tp_dealloc, (destructor)PyTclObject_dealloc},
+    {Py_tp_dealloc, PyTclObject_dealloc},
     {Py_tp_repr, PyTclObject_repr},
     {Py_tp_str, PyTclObject_str},
     {Py_tp_getattro, PyObject_GenericGetAttr},

--- a/Modules/_tkinter.c
+++ b/Modules/_tkinter.c
@@ -771,8 +771,9 @@ PyTclObject_str(PyTclObject *self)
 }
 
 static PyObject *
-PyTclObject_repr(PyTclObject *self)
+PyTclObject_repr(PyObject *_self)
 {
+    PyTclObject *self = (PyTclObject *)_self;
     PyObject *repr, *str = PyTclObject_str(self);
     if (str == NULL)
         return NULL;
@@ -826,7 +827,7 @@ static PyGetSetDef PyTclObject_getsetlist[] = {
 
 static PyType_Slot PyTclObject_Type_slots[] = {
     {Py_tp_dealloc, (destructor)PyTclObject_dealloc},
-    {Py_tp_repr, (reprfunc)PyTclObject_repr},
+    {Py_tp_repr, PyTclObject_repr},
     {Py_tp_str, (reprfunc)PyTclObject_str},
     {Py_tp_getattro, PyObject_GenericGetAttr},
     {Py_tp_richcompare, PyTclObject_richcompare},

--- a/Modules/_tkinter.c
+++ b/Modules/_tkinter.c
@@ -810,14 +810,15 @@ PyTclObject_richcompare(PyObject *self, PyObject *other, int op)
 PyDoc_STRVAR(get_typename__doc__, "name of the Tcl type");
 
 static PyObject*
-get_typename(PyTclObject* obj, void* ignored)
+get_typename(PyObject *self, void* ignored)
 {
+    PyTclObject *obj = (PyTclObject *)self;
     return unicodeFromTclString(obj->value->typePtr->name);
 }
 
 
 static PyGetSetDef PyTclObject_getsetlist[] = {
-    {"typename", (getter)get_typename, NULL, get_typename__doc__},
+    {"typename", get_typename, NULL, get_typename__doc__},
     {"string", PyTclObject_string, NULL,
      PyTclObject_string__doc__},
     {0},

--- a/Modules/_tkinter.c
+++ b/Modules/_tkinter.c
@@ -761,8 +761,9 @@ PyTclObject_string(PyObject *_self, void *ignored)
 }
 
 static PyObject *
-PyTclObject_str(PyTclObject *self)
+PyTclObject_str(PyObject *_self)
 {
+    PyTclObject *self = (PyTclObject *)_self;
     if (self->string) {
         return Py_NewRef(self->string);
     }
@@ -774,7 +775,7 @@ static PyObject *
 PyTclObject_repr(PyObject *_self)
 {
     PyTclObject *self = (PyTclObject *)_self;
-    PyObject *repr, *str = PyTclObject_str(self);
+    PyObject *repr, *str = PyTclObject_str(_self);
     if (str == NULL)
         return NULL;
     repr = PyUnicode_FromFormat("<%s object: %R>",
@@ -828,7 +829,7 @@ static PyGetSetDef PyTclObject_getsetlist[] = {
 static PyType_Slot PyTclObject_Type_slots[] = {
     {Py_tp_dealloc, (destructor)PyTclObject_dealloc},
     {Py_tp_repr, PyTclObject_repr},
-    {Py_tp_str, (reprfunc)PyTclObject_str},
+    {Py_tp_str, PyTclObject_str},
     {Py_tp_getattro, PyObject_GenericGetAttr},
     {Py_tp_richcompare, PyTclObject_richcompare},
     {Py_tp_getset, PyTclObject_getsetlist},


### PR DESCRIPTION
Potential compiler warnings eliminated:

```
./Modules/_tkinter.c:819:18: warning: cast from 'PyObject *(*)(PyTclObject *, void *)' (aka 'struct _object *(*)(PyTclObject *, void *)') to 'getter' (aka 'struct _object *(*)(struct _object *, void *)') converts to incompatible function type [-Wcast-function-type-strict]
  819 |     {"typename", (getter)get_typename, NULL, get_typename__doc__},
      |                  ^~~~~~~~~~~~~~~~~~~~
./Modules/_tkinter.c:820:16: warning: cast from 'PyObject *(*)(PyTclObject *, void *)' (aka 'struct _object *(*)(PyTclObject *, void *)') to 'getter' (aka 'struct _object *(*)(struct _object *, void *)') converts to incompatible function type [-Wcast-function-type-strict]
  820 |     {"string", (getter)PyTclObject_string, NULL,
      |                ^~~~~~~~~~~~~~~~~~~~~~~~~~
./Modules/_tkinter.c:826:21: warning: cast from 'void (*)(PyTclObject *)' to 'destructor' (aka 'void (*)(struct _object *)') converts to incompatible function type [-Wcast-function-type-strict]
  826 |     {Py_tp_dealloc, (destructor)PyTclObject_dealloc},
      |                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
./Modules/_tkinter.c:827:18: warning: cast from 'PyObject *(*)(PyTclObject *)' (aka 'struct _object *(*)(PyTclObject *)') to 'reprfunc' (aka 'struct _object *(*)(struct _object *)') converts to incompatible function type [-Wcast-function-type-strict]
  827 |     {Py_tp_repr, (reprfunc)PyTclObject_repr},
      |                  ^~~~~~~~~~~~~~~~~~~~~~~~~~
./Modules/_tkinter.c:828:17: warning: cast from 'PyObject *(*)(PyTclObject *)' (aka 'struct _object *(*)(PyTclObject *)') to 'reprfunc' (aka 'struct _object *(*)(struct _object *)') converts to incompatible function type [-Wcast-function-type-strict]
  828 |     {Py_tp_str, (reprfunc)PyTclObject_str},
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~
./Modules/_tkinter.c:1388:23: warning: cast from 'int (*)(Tkapp_CallEvent *, int)' (aka 'int (*)(struct Tkapp_CallEvent *, int)') to 'Tcl_EventProc *' (aka 'int (*)(struct Tcl_Event *, int)') converts to incompatible function type [-Wcast-function-type-strict]
 1388 |         ev->ev.proc = (Tcl_EventProc*)Tkapp_CallProc;
      |                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
./Modules/_tkinter.c:1666:23: warning: cast from 'int (*)(VarEvent *, int)' (aka 'int (*)(struct VarEvent *, int)') to 'Tcl_EventProc *' (aka 'int (*)(struct Tcl_Event *, int)') converts to incompatible function type [-Wcast-function-type-strict]
 1666 |         ev->ev.proc = (Tcl_EventProc*)var_proc;
      |                       ^~~~~~~~~~~~~~~~~~~~~~~~
./Modules/_tkinter.c:2293:23: warning: cast from 'int (*)(CommandEvent *, int)' (aka 'int (*)(struct CommandEvent *, int)') to 'Tcl_EventProc *' (aka 'int (*)(struct Tcl_Event *, int)') converts to incompatible function type [-Wcast-function-type-strict]
 2293 |         ev->ev.proc = (Tcl_EventProc*)Tkapp_CommandProc;
      |                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
./Modules/_tkinter.c:2346:23: warning: cast from 'int (*)(CommandEvent *, int)' (aka 'int (*)(struct CommandEvent *, int)') to 'Tcl_EventProc *' (aka 'int (*)(struct Tcl_Event *, int)') converts to incompatible function type [-Wcast-function-type-strict]
 2346 |         ev->ev.proc = (Tcl_EventProc*)Tkapp_CommandProc;
      |                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-111178 -->
* Issue: gh-111178
<!-- /gh-issue-number -->
