### PR TITLE
gh-88516: show file proxy icon in IDLE editor windows on macOS

### DIFF
--- a/Lib/idlelib/editor.py
+++ b/Lib/idlelib/editor.py
@@ -1054,7 +1054,7 @@ class EditorWindow:
         else:
             title = "untitled"
         icon = short or long or title
-        if not self.get_saved() and not macosx.isCocoaTk():
+        if not self.get_saved():
             title = "*%s*" % title
             icon = "*%s" % icon
         self.top.wm_title(title)

--- a/Lib/idlelib/editor.py
+++ b/Lib/idlelib/editor.py
@@ -1058,6 +1058,10 @@ class EditorWindow:
         self.top.wm_title(title)
         self.top.wm_iconname(icon)
 
+        if macosx.isCocoaTk():
+            # Add a proxy icon to the window title
+            self.top.wm_attributes("-titlepath", long)
+
     def get_saved(self):
         return self.undo.get_saved()
 

--- a/Lib/idlelib/editor.py
+++ b/Lib/idlelib/editor.py
@@ -1043,7 +1043,9 @@ class EditorWindow:
     def saved_change_hook(self):
         short = self.short_title()
         long = self.long_title()
-        if short and long:
+        if short and long and not macosx.isCocoaTk():
+            # Don't use both values on macOS because
+            # that doesn't match platform conventions.
             title = short + " - " + long + _py_version
         elif short:
             title = short

--- a/Lib/idlelib/editor.py
+++ b/Lib/idlelib/editor.py
@@ -1054,7 +1054,7 @@ class EditorWindow:
         else:
             title = "untitled"
         icon = short or long or title
-        if not self.get_saved():
+        if not self.get_saved() and not macosx.isCocoaTk():
             title = "*%s*" % title
             icon = "*%s" % icon
         self.top.wm_title(title)
@@ -1063,6 +1063,9 @@ class EditorWindow:
         if macosx.isCocoaTk():
             # Add a proxy icon to the window title
             self.top.wm_attributes("-titlepath", long)
+
+            # Maintain the modification status for the window
+            self.top.wm_attributes("-modified", not self.get_saved())
 
     def get_saved(self):
         return self.undo.get_saved()

--- a/Misc/NEWS.d/next/IDLE/2023-12-09-11-04-26.gh-issue-88516.SIIvfs.rst
+++ b/Misc/NEWS.d/next/IDLE/2023-12-09-11-04-26.gh-issue-88516.SIIvfs.rst
@@ -1,0 +1,2 @@
+On macOS show a proxy icon in the title bar of editor windows to match
+platform behaviour.


### PR DESCRIPTION
The platform standard on macOS is to show a proxy icon for open files in the titlebar of Windows. Make sure IDLE matches this behaviour.

Also:
- Maintain the right window modification status for editor windows ("dot" in the close indicator for unsaved files)
- Don't show both the short and long (file) name to match platform behaviour with other editors.


<!-- gh-issue-number: gh-88516 -->
* Issue: gh-88516
<!-- /gh-issue-number -->
