### PR TITLE
gh-86918: Fix file descriptor leaking in multiprocessing.Queue 

### DIFF
--- a/Lib/multiprocessing/queues.py
+++ b/Lib/multiprocessing/queues.py
@@ -143,6 +143,11 @@ class Queue(object):
         if close:
             self._close = None
             close()
+        else:
+            if not self._reader.closed:
+                self._reader.close()
+            if not self._writer.closed:
+                self._writer.close()
 
     def join_thread(self):
         debug('Queue.join_thread()')

--- a/Misc/NEWS.d/next/Library/2023-12-09-15-31-41.gh-issue-86918.-egweI.rst
+++ b/Misc/NEWS.d/next/Library/2023-12-09-15-31-41.gh-issue-86918.-egweI.rst
@@ -1,0 +1,1 @@
+Fix file descriptor leaking in multiprocessing.Queue


### PR DESCRIPTION
If don't put data in multiprocessing.Queue and directly close the queue, queue._reader and queue._writer wouldn't be closd.
```
Python 3.13.0a2+ (heads/fix-issue-86918:14203efdc5, Dec  9 2023, 22:01:44) [Clang 15.0.0 (clang-1500.0.40.1)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import multiprocessing
>>> q = multiprocessing.Queue()
>>> q.close()
>>> q.join_thread()
>>> q._reader.closed
True
>>> q._writer.closed
True
>>>
``` 

<!-- gh-issue-number: gh-86918 -->
* Issue: gh-86918
<!-- /gh-issue-number -->
