### PR TITLE
gh-110109: Fix installed buildbots now `pathlib` is a package

### DIFF
--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -2164,6 +2164,7 @@ LIBSUBDIRS=	asyncio \
 		json \
 		logging \
 		multiprocessing multiprocessing/dummy \
+		pathlib \
 		pydoc_data \
 		re \
 		site-packages \


### PR DESCRIPTION
Followup to #112881

<!-- gh-issue-number: gh-110109 -->
* Issue: gh-110109
<!-- /gh-issue-number -->
