### PR TITLE
gh-109980: Fix test_tarfile_vs_tar on macOS

### DIFF
--- a/Lib/test/test_shutil.py
+++ b/Lib/test/test_shutil.py
@@ -1660,7 +1660,6 @@ class TestArchives(BaseTest, unittest.TestCase):
     def test_tarfile_vs_tar(self):
         root_dir, base_dir = self._create_files()
         base_name = os.path.join(self.mkdtemp(), 'archive')
-
         with no_chdir:
             tarball = make_archive(base_name, 'gztar', root_dir, base_dir)
 
@@ -1684,8 +1683,6 @@ class TestArchives(BaseTest, unittest.TestCase):
                 tar_cmd.insert(1, '--no-mac-metadata')
         subprocess.check_call(tar_cmd, cwd=root_dir,
                               stdout=subprocess.DEVNULL)
-
-
 
         self.assertTrue(os.path.isfile(tarball2))
         # let's compare both tarballs

--- a/Misc/NEWS.d/next/Tests/2023-12-09-21-27-46.gh-issue-109980.y--500.rst
+++ b/Misc/NEWS.d/next/Tests/2023-12-09-21-27-46.gh-issue-109980.y--500.rst
@@ -1,0 +1,2 @@
+Fix ``test_tarfile_vs_tar`` in ``test_shutil`` for macOS, where system tar
+can include more information in the archive than :mod:`shutil.make_archive`.


### PR DESCRIPTION
On recentish macOS versions the system tar
command includes system metadata (ACLs, extended attributes and resource forks) in the tar archive, which
shutil.make_archive will not do. This can cause
spurious test failures.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-109980 -->
* Issue: gh-109980
<!-- /gh-issue-number -->
