### PR TITLE
GH-112906: Fix performance regression in pathlib path initialisation

### DIFF
--- a/Lib/pathlib/__init__.py
+++ b/Lib/pathlib/__init__.py
@@ -90,6 +90,7 @@ class PurePath(_abc.PurePathBase):
                         "object where __fspath__ returns a str, "
                         f"not {type(path).__name__!r}")
                 paths.append(path)
+        # Avoid calling super().__init__, as an optimisation
         self._raw_paths = paths
         self._resolving = False
 

--- a/Lib/pathlib/__init__.py
+++ b/Lib/pathlib/__init__.py
@@ -70,7 +70,7 @@ class PurePath(_abc.PurePathBase):
             cls = PureWindowsPath if os.name == 'nt' else PurePosixPath
         return object.__new__(cls)
 
-    def __init__(self, *args):
+    def _load_args(self, args):
         paths = []
         for arg in args:
             if isinstance(arg, PurePath):
@@ -90,7 +90,7 @@ class PurePath(_abc.PurePathBase):
                         "object where __fspath__ returns a str, "
                         f"not {type(path).__name__!r}")
                 paths.append(path)
-        super().__init__(*paths)
+        return paths
 
     def __reduce__(self):
         # Using the parts tuple helps share interned path parts

--- a/Lib/pathlib/__init__.py
+++ b/Lib/pathlib/__init__.py
@@ -71,6 +71,11 @@ class PurePath(_abc.PurePathBase):
         return object.__new__(cls)
 
     def _load_args(self, args):
+        """Type-checks and returns the given *args*. TypeError is raised if
+        any argument does not implement the os.PathLike interface, or
+        implements it but doesn't return a string. This method is called from
+        PurePathBase.__init__().
+        """
         paths = []
         for arg in args:
             if isinstance(arg, PurePath):

--- a/Lib/pathlib/__init__.py
+++ b/Lib/pathlib/__init__.py
@@ -70,12 +70,7 @@ class PurePath(_abc.PurePathBase):
             cls = PureWindowsPath if os.name == 'nt' else PurePosixPath
         return object.__new__(cls)
 
-    def _load_args(self, args):
-        """Type-checks and returns the given *args*. TypeError is raised if
-        any argument does not implement the os.PathLike interface, or
-        implements it but doesn't return a string. This method is called from
-        PurePathBase.__init__().
-        """
+    def __init__(self, *args):
         paths = []
         for arg in args:
             if isinstance(arg, PurePath):
@@ -95,7 +90,8 @@ class PurePath(_abc.PurePathBase):
                         "object where __fspath__ returns a str, "
                         f"not {type(path).__name__!r}")
                 paths.append(path)
-        return paths
+        self._raw_paths = paths
+        self._resolving = False
 
     def __reduce__(self):
         # Using the parts tuple helps share interned path parts

--- a/Lib/pathlib/_abc.py
+++ b/Lib/pathlib/_abc.py
@@ -206,9 +206,13 @@ class PurePathBase:
     )
     pathmod = os.path
 
-    def __init__(self, *paths):
-        self._raw_paths = paths
+    def __init__(self, *args):
+        self._raw_paths = self._load_args(args)
         self._resolving = False
+
+    def _load_args(self, args):
+        # overridden in pathlib.PurePath
+        return args
 
     def with_segments(self, *pathsegments):
         """Construct a new path object from any number of path-like objects.

--- a/Lib/pathlib/_abc.py
+++ b/Lib/pathlib/_abc.py
@@ -211,7 +211,11 @@ class PurePathBase:
         self._resolving = False
 
     def _load_args(self, args):
-        # overridden in pathlib.PurePath
+        """Returns the given *args* unchanged. Subclasses may override this
+        method to avoid adding an __init__() method that calls super() and
+        packs/unpacks arguments, which would introduce a noticeable slowdown.
+        This method is overridden in PurePath.
+        """
         return args
 
     def with_segments(self, *pathsegments):

--- a/Lib/pathlib/_abc.py
+++ b/Lib/pathlib/_abc.py
@@ -206,17 +206,9 @@ class PurePathBase:
     )
     pathmod = os.path
 
-    def __init__(self, *args):
-        self._raw_paths = self._load_args(args)
+    def __init__(self, *paths):
+        self._raw_paths = paths
         self._resolving = False
-
-    def _load_args(self, args):
-        """Returns the given *args* unchanged. Subclasses may override this
-        method to avoid adding an __init__() method that calls super() and
-        packs/unpacks arguments, which would introduce a noticeable slowdown.
-        This method is overridden in PurePath.
-        """
-        return args
 
     def with_segments(self, *pathsegments):
         """Construct a new path object from any number of path-like objects.


### PR DESCRIPTION
This was caused by 76929fdeeb, specifically its use of `super()` and its packing/unpacking of `*args`.

<!-- gh-issue-number: gh-112906 -->
* Issue: gh-112906
<!-- /gh-issue-number -->
