### PR TITLE
gh-101100: Fix Sphinx warning in library/http.cookies.rst

### DIFF
--- a/Doc/library/http.cookies.rst
+++ b/Doc/library/http.cookies.rst
@@ -18,16 +18,16 @@ cookie value.
 
 The module formerly strictly applied the parsing rules described in the
 :rfc:`2109` and :rfc:`2068` specifications.  It has since been discovered that
-MSIE 3.0x doesn't follow the character rules outlined in those specs and also
-many current day browsers and servers have relaxed parsing rules when comes to
-Cookie handling.  As a result, the parsing rules used are a bit less strict.
+MSIE 3.0x didn't follow the character rules outlined in those specs and also
+many current day browsers and servers have relaxed parsing rules when it comes to
+cookie handling.  As a result, the parsing rules used are a bit less strict.
 
 The character set, :data:`string.ascii_letters`, :data:`string.digits` and
 ``!#$%&'*+-.^_`|~:`` denote the set of valid characters allowed by this module
-in Cookie name (as :attr:`~Morsel.key`).
+in a cookie name (as :attr:`~Morsel.key`).
 
 .. versionchanged:: 3.3
-   Allowed ':' as a valid Cookie name character.
+   Allowed ':' as a valid cookie name character.
 
 
 .. note::
@@ -56,7 +56,7 @@ in Cookie name (as :attr:`~Morsel.key`).
 
    This class derives from :class:`BaseCookie` and overrides :meth:`~BaseCookie.value_decode`
    and :meth:`~BaseCookie.value_encode`. SimpleCookie supports strings as cookie values.
-   When setting the value, SimpleCookie calls the builtin :func:`str()` to convert
+   When setting the value, :class:`!SimpleCookie` calls the builtin :func:`str()` to convert
    the value to a string. Values received from HTTP are kept as strings.
 
 .. seealso::

--- a/Doc/library/http.cookies.rst
+++ b/Doc/library/http.cookies.rst
@@ -54,8 +54,8 @@ in Cookie name (as :attr:`~Morsel.key`).
 
 .. class:: SimpleCookie([input])
 
-   This class derives from :class:`BaseCookie` and overrides :meth:`value_decode`
-   and :meth:`value_encode`. SimpleCookie supports strings as cookie values.
+   This class derives from :class:`BaseCookie` and overrides :meth:`~BaseCookie.value_decode`
+   and :meth:`~BaseCookie.value_encode`. SimpleCookie supports strings as cookie values.
    When setting the value, SimpleCookie calls the builtin :func:`str()` to convert
    the value to a string. Values received from HTTP are kept as strings.
 
@@ -129,17 +129,17 @@ Morsel Objects
    Abstract a key/value pair, which has some :rfc:`2109` attributes.
 
    Morsels are dictionary-like objects, whose set of keys is constant --- the valid
-   :rfc:`2109` attributes, which are
+   :rfc:`2109` attributes, which are:
 
-   * ``expires``
-   * ``path``
-   * ``comment``
-   * ``domain``
-   * ``max-age``
-   * ``secure``
-   * ``version``
-   * ``httponly``
-   * ``samesite``
+   * .. attribute:: expires
+   * .. attribute:: path
+   * .. attribute:: comment
+   * .. attribute:: domain
+   * .. attribute:: max-age
+   * .. attribute:: secure
+   * .. attribute:: version
+   * .. attribute:: httponly
+   * .. attribute:: samesite
 
    The attribute :attr:`httponly` specifies that the cookie is only transferred
    in HTTP requests, and is not accessible through JavaScript. This is intended
@@ -152,7 +152,7 @@ Morsel Objects
    The keys are case-insensitive and their default value is ``''``.
 
    .. versionchanged:: 3.5
-      :meth:`~Morsel.__eq__` now takes :attr:`~Morsel.key` and :attr:`~Morsel.value`
+      :meth:`!__eq__` now takes :attr:`~Morsel.key` and :attr:`~Morsel.value`
       into account.
 
    .. versionchanged:: 3.7

--- a/Doc/library/http.cookies.rst
+++ b/Doc/library/http.cookies.rst
@@ -18,9 +18,10 @@ cookie value.
 
 The module formerly strictly applied the parsing rules described in the
 :rfc:`2109` and :rfc:`2068` specifications.  It has since been discovered that
-MSIE 3.0x didn't follow the character rules outlined in those specs and also
-many current day browsers and servers have relaxed parsing rules when it comes to
-cookie handling.  As a result, the parsing rules used are a bit less strict.
+MSIE 3.0x didn't follow the character rules outlined in those specs; many
+current-day browsers and servers have also relaxed parsing rules when it comes
+to cookie handling.  As a result, this module now uses parsing rules that are a
+bit less strict than they once were.
 
 The character set, :data:`string.ascii_letters`, :data:`string.digits` and
 ``!#$%&'*+-.^_`|~:`` denote the set of valid characters allowed by this module
@@ -55,8 +56,9 @@ in a cookie name (as :attr:`~Morsel.key`).
 .. class:: SimpleCookie([input])
 
    This class derives from :class:`BaseCookie` and overrides :meth:`~BaseCookie.value_decode`
-   and :meth:`~BaseCookie.value_encode`. SimpleCookie supports strings as cookie values.
-   When setting the value, :class:`!SimpleCookie` calls the builtin :func:`str()` to convert
+   and :meth:`~BaseCookie.value_encode`. :class:`!SimpleCookie` supports
+   strings as cookie values. When setting the value, :class:`!SimpleCookie`
+   calls the builtin :func:`str` to convert
    the value to a string. Values received from HTTP are kept as strings.
 
 .. seealso::
@@ -131,15 +133,15 @@ Morsel Objects
    Morsels are dictionary-like objects, whose set of keys is constant --- the valid
    :rfc:`2109` attributes, which are:
 
-   * .. attribute:: expires
-   * .. attribute:: path
-   * .. attribute:: comment
-   * .. attribute:: domain
-   * .. attribute:: max-age
-   * .. attribute:: secure
-   * .. attribute:: version
-   * .. attribute:: httponly
-   * .. attribute:: samesite
+     .. attribute:: expires
+                    path
+                    comment
+                    domain
+                    max-age
+                    secure
+                    version
+                    httponly
+                    samesite
 
    The attribute :attr:`httponly` specifies that the cookie is only transferred
    in HTTP requests, and is not accessible through JavaScript. This is intended

--- a/Doc/tools/.nitignore
+++ b/Doc/tools/.nitignore
@@ -57,7 +57,6 @@ Doc/library/ftplib.rst
 Doc/library/functools.rst
 Doc/library/http.client.rst
 Doc/library/http.cookiejar.rst
-Doc/library/http.cookies.rst
 Doc/library/http.server.rst
 Doc/library/importlib.rst
 Doc/library/inspect.rst


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

Fix these warnings:

```console
❯ SPHINXERRORHANDLING=-n PATH=./venv/bin:$PATH sphinx-build -b html -d build/doctrees -j auto -n . build/html library/http.cookies.rst 2>&1 | grep WARNING | tee >(wc -l)
Doc/library/http.cookies.rst:57: WARNING: py:meth reference target not found: value_decode
Doc/library/http.cookies.rst:57: WARNING: py:meth reference target not found: value_encode
Doc/library/http.cookies.rst:144: WARNING: py:attr reference target not found: httponly
Doc/library/http.cookies.rst:148: WARNING: py:attr reference target not found: samesite
Doc/library/http.cookies.rst:155: WARNING: py:meth reference target not found: Morsel.__eq__
Doc/library/http.cookies.rst:164: WARNING: py:attr reference target not found: samesite
       6
```

Plus refer to MSIE 3.0x in the past tense (EOL since something like 2003! Should we even remove that bit?), make cookie lowercase, adjust some formatting.


<!-- gh-issue-number: gh-101100 -->
* Issue: gh-101100
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--112908.org.readthedocs.build/en/112908/library/http.cookies.html

<!-- readthedocs-preview cpython-previews end -->