### PR TITLE
gh-112903: Fix MRO resolution for `GenericAlias` types

### DIFF
--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -4886,6 +4886,20 @@ class GenericTests(BaseTestCase):
         class C(List[int], B): ...
         self.assertEqual(C.__mro__, (C, list, B, Generic, object))
 
+    def test_multiple_inheritance_gh112903(self):
+        # https://github.com/python/cpython/issues/112903
+        K = TypeVar("K")
+        V = TypeVar("V")
+
+        class BaseMap(typing.Mapping[K, V]): ...
+        class MutableMap(BaseMap[K, V], typing.MutableMapping[K, V]): ...
+        # This should not raise:
+        class MyMap1(Dict[K, V], MutableMap[K, V]): ...
+        class MyMap2(MutableMap[K, V], Dict[K, V]): ...
+
+        self.assertIn(Generic, MyMap1.__mro__)
+        self.assertIn(Generic, MyMap2.__mro__)
+
     def test_init_subclass_super_called(self):
         class FinalException(Exception):
             pass

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -1137,7 +1137,10 @@ class _BaseGenericAlias(_Final, _root=True):
             res.append(self.__origin__)
         i = bases.index(self)
         for b in bases[i+1:]:
-            if isinstance(b, _BaseGenericAlias) or issubclass(b, Generic):
+            if (
+                isinstance(b, (_BaseGenericAlias, GenericAlias))
+                or issubclass(b, Generic)
+            ):
                 break
         else:
             res.append(Generic)

--- a/Misc/NEWS.d/next/Library/2023-12-09-23-19-14.gh-issue-112903.qusnMI.rst
+++ b/Misc/NEWS.d/next/Library/2023-12-09-23-19-14.gh-issue-112903.qusnMI.rst
@@ -1,0 +1,1 @@
+Fix MRO resolution issue for generic aliases in 3.13


### PR DESCRIPTION
There are multiple related issues, including https://github.com/python/cpython/pull/108403
So, let's be very simple here: we had a specific problem, which is now fixed.


<!-- gh-issue-number: gh-112903 -->
* Issue: gh-112903
<!-- /gh-issue-number -->
