### PR TITLE
gh-112925: Fix error in example of `datetime.time.fromisoformat` and add doctest marker

### DIFF
--- a/Doc/library/datetime.rst
+++ b/Doc/library/datetime.rst
@@ -1798,6 +1798,8 @@ Other constructor:
    4. Fractional hours and minutes are not supported.
 
    Examples::
+   
+   .. doctest::
 
        >>> from datetime import time
        >>> time.fromisoformat('04:23:01')
@@ -1808,7 +1810,7 @@ Other constructor:
        datetime.time(4, 23, 1)
        >>> time.fromisoformat('04:23:01.000384')
        datetime.time(4, 23, 1, 384)
-       >>> time.fromisoformat('04:23:01,000')
+       >>> time.fromisoformat('04:23:01,000384')
        datetime.time(4, 23, 1, 384)
        >>> time.fromisoformat('04:23:01+04:00')
        datetime.time(4, 23, 1, tzinfo=datetime.timezone(datetime.timedelta(seconds=14400)))

--- a/Doc/library/datetime.rst
+++ b/Doc/library/datetime.rst
@@ -1798,7 +1798,7 @@ Other constructor:
    4. Fractional hours and minutes are not supported.
 
    Examples::
-   
+
    .. doctest::
 
        >>> from datetime import time


### PR DESCRIPTION


<!-- gh-issue-number: gh-112925 -->
* Issue: gh-112925
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--112931.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->