### PR TITLE
gh-112898: warn about unsaved files when quitting IDLE on macOS

### DIFF
--- a/Lib/idlelib/macosx.py
+++ b/Lib/idlelib/macosx.py
@@ -131,16 +131,6 @@ def addOpenEventSupport(root, flist):
     # one for every file that should be opened.
     root.createcommand("::tk::mac::OpenDocument", doOpenFile)
 
-def addQuitSupport(root, flist):
-    """
-    This ensures that the application will respond properly to quit events,
-    including the "IDLE -> Quit IDLE" menu.
-    """
-    def doQuit():
-        flist.close_all_callback()
-
-    root.createcommand("::tk::mac::Quit", doQuit)
-
 def hideTkConsole(root):
     try:
         root.tk.call('console', 'hide')
@@ -231,7 +221,7 @@ def overrideRootMenu(root, flist):
         # The binding above doesn't reliably work on all versions of Tk
         # on macOS. Adding command definition below does seem to do the
         # right thing for now.
-        root.createcommand('exit', flist.close_all_callback)
+        root.createcommand('::tk::mac::Quit', flist.close_all_callback)
 
     if isCarbonTk():
         # for Carbon AquaTk, replace the default Tk apple menu
@@ -280,7 +270,6 @@ def setupApp(root, flist):
         hideTkConsole(root)
         overrideRootMenu(root, flist)
         addOpenEventSupport(root, flist)
-        addQuitSupport(root, flist)
         fixb2context(root)
 
 

--- a/Lib/idlelib/macosx.py
+++ b/Lib/idlelib/macosx.py
@@ -131,6 +131,16 @@ def addOpenEventSupport(root, flist):
     # one for every file that should be opened.
     root.createcommand("::tk::mac::OpenDocument", doOpenFile)
 
+def addQuitSupport(root, flist):
+    """
+    This ensures that the application will respond properly to quit events,
+    including the "IDLE -> Quit IDLE" menu.
+    """
+    def doQuit():
+        flist.close_all_callback()
+
+    root.createcommand("::tk::mac::Quit", doQuit)
+
 def hideTkConsole(root):
     try:
         root.tk.call('console', 'hide')
@@ -270,6 +280,7 @@ def setupApp(root, flist):
         hideTkConsole(root)
         overrideRootMenu(root, flist)
         addOpenEventSupport(root, flist)
+        addQuitSupport(root, flist)
         fixb2context(root)
 
 

--- a/Misc/NEWS.d/next/IDLE/2023-12-10-20-01-11.gh-issue-112898.98aWv2.rst
+++ b/Misc/NEWS.d/next/IDLE/2023-12-10-20-01-11.gh-issue-112898.98aWv2.rst
@@ -1,0 +1,1 @@
+Fix processing unsaved files when quitting IDLE on macOS.


### PR DESCRIPTION
Implement the TK function ``::tk::mac::Quit`` on macOS to ensure that IDLE asks about saving unsaved files when quitting IDLE.

Co-authored-by: Christopher Chavez <chrischavez@gmx.us>

<!-- gh-issue-number: gh-112898 -->
* Issue: gh-112898
<!-- /gh-issue-number -->
