### PR TITLE
gh-102362: Fix macOS version number in result of sysconfig.get_platform()

### DIFF
--- a/Lib/_osx_support.py
+++ b/Lib/_osx_support.py
@@ -507,6 +507,11 @@ def get_platform_osx(_config_vars, osname, release, machine):
     # MACOSX_DEPLOYMENT_TARGET.
 
     macver = _config_vars.get('MACOSX_DEPLOYMENT_TARGET', '')
+    if macver and '.' not in macver:
+        # Ensure that the version includes at least a major
+        # and minor version, even if MACOSX_DEPLOYMENT_TARGET
+        # is set to a single-label version like "14".
+        macver += '.0'
     macrelease = _get_system_version() or macver
     macver = macver or macrelease
 

--- a/Misc/NEWS.d/next/macOS/2023-12-10-20-30-06.gh-issue-102362.y8svbF.rst
+++ b/Misc/NEWS.d/next/macOS/2023-12-10-20-30-06.gh-issue-102362.y8svbF.rst
@@ -1,0 +1,3 @@
+Make sure the result of :func:`sysconfig.get_plaform` includes at least a
+major and minor versions, even if ``MACOSX_DEPLOYMENT_TARGET`` is set to
+only a major version during build to match the format expected by pip.


### PR DESCRIPTION

Change _osx_support.get_platform_osx() to make sure that the version number in the result includes at least a major and minor version (e.g. 14.2) even if MACOSX_DEPLOYMENT_TARGET is set to just a major version (e.g. 14).

This matches the versions expected by pip when selecting appropriate wheels for installation.


<!-- gh-issue-number: gh-102362 -->
* Issue: gh-102362
<!-- /gh-issue-number -->
