### PR TITLE
gh-112887: Fix tarfile FilterError handling to skip member extraction

### DIFF
--- a/Lib/tarfile.py
+++ b/Lib/tarfile.py
@@ -2309,21 +2309,21 @@ class TarFile(object):
         else:
             tarinfo = member
 
-        unfiltered = tarinfo
+        filtered = None
         try:
-            tarinfo = filter_function(tarinfo, path)
+            filtered = filter_function(tarinfo, path)
         except (OSError, FilterError) as e:
             self._handle_fatal_error(e)
         except ExtractError as e:
             self._handle_nonfatal_error(e)
-        if tarinfo is None:
-            self._dbg(2, "tarfile: Excluded %r" % unfiltered.name)
+        if filtered is None:
+            self._dbg(2, "tarfile: Excluded %r" % tarinfo.name)
             return None
         # Prepare the link target for makelink().
-        if tarinfo.islnk():
-            tarinfo = copy.copy(tarinfo)
-            tarinfo._link_target = os.path.join(path, tarinfo.linkname)
-        return tarinfo
+        if filtered.islnk():
+            filtered = copy.copy(filtered)
+            filtered._link_target = os.path.join(path, filtered.linkname)
+        return filtered
 
     def _extract_one(self, tarinfo, path, set_attrs, numeric_owner):
         """Extract from filtered tarinfo to disk"""

--- a/Lib/test/test_tarfile.py
+++ b/Lib/test/test_tarfile.py
@@ -3141,14 +3141,29 @@ class NoneInfoExtractTests(ReadTest):
     @contextmanager
     def extract_with_none(self, *attr_names):
         DIR = pathlib.Path(TEMPDIR) / "extractall_none"
+
         self.tar.errorlevel = 0
-        for member in self.tar.getmembers():
-            for attr_name in attr_names:
-                setattr(member, attr_name, None)
+
+        filter_function = self.tar._get_filter_function(self.extraction_filter)
+
         with os_helper.temp_dir(DIR):
-            self.tar.extractall(DIR, filter='fully_trusted')
+
+            # this makes sure we only test files which would have been extracted
+            # prior to changing metadata
+            # for example, special files are not extracted with the data filter,
+            # but 'mode' is required to identify them
+            filtered_members = []
+
+            for member in self.tar.getmembers():
+                member = self.tar._get_extract_tarinfo(member, filter_function, DIR)
+                if member is not None:
+                    for attr_name in attr_names:
+                        setattr(member, attr_name, None)
+                    filtered_members.append(member)
+            self.tar.extractall(DIR, members = filtered_members, filter=self.extraction_filter)
             self.check_files_present(DIR)
             yield DIR
+
 
     def test_extractall_none_mtime(self):
         # mtimes of extracted files should be later than 'now' -- the mtime
@@ -3477,6 +3492,14 @@ class TestExtractionFilters(unittest.TestCase):
             self.assertEqual(path.stat().st_size, size)
         for parent in path.parents:
             self.expected_paths.discard(parent)
+
+    def expect_file_skipped(self, name):
+        """ Check a single file extraction is skipped. E.g. due to a filter. """
+        if self.raised_exception:
+            raise self.raised_exception
+        # use normpath() rather than resolve() so we don't follow symlinks
+        path = pathlib.Path(os.path.normpath(self.destdir / name))
+        self.assertNotIn(path, self.expected_paths)
 
     def expect_exception(self, exc_type, message_re='.'):
         with self.assertRaisesRegex(exc_type, message_re):
@@ -4071,9 +4094,6 @@ class TestExtractionFilters(unittest.TestCase):
         with self.check_context(arc.open(errorlevel=0), extracterror_filter):
             self.expect_file('file')
 
-        with self.check_context(arc.open(errorlevel=0), filtererror_filter):
-            self.expect_file('file')
-
         with self.check_context(arc.open(errorlevel=0), oserror_filter):
             self.expect_file('file')
 
@@ -4082,6 +4102,11 @@ class TestExtractionFilters(unittest.TestCase):
 
         with self.check_context(arc.open(errorlevel=0), valueerror_filter):
             self.expect_exception(ValueError)
+
+        # If errorlevel is 0, FilterErrors are logged and member is skipped
+
+        with self.check_context(arc.open(errorlevel=0), filtererror_filter):
+            self.expect_file_skipped('file')
 
         # If 1, all fatal errors are raised
 

--- a/Misc/NEWS.d/next/Library/2023-12-12-20-26-43.gh-issue-112887.2DbuVm.rst
+++ b/Misc/NEWS.d/next/Library/2023-12-12-20-26-43.gh-issue-112887.2DbuVm.rst
@@ -1,0 +1,1 @@
+Fix bug in :mod:`tarfile` where calling :func:`TarFile.extract()` or :func:`TarFile.extractall()` would continue to extract filtered unsafe files when :attr:`errorlevel` was set to 0. Rather, this fix implements a 'skip-but-log' behavior that ensures unsafe members are not extracted, as was expected from the docs.


### PR DESCRIPTION
In `tarfile` library, if a FilterError is raised for a member during `TarFile.extract()` or `TarFile.extractall()` with `errorlevel` set to 0, a debugging message is correctly logged but the unsafe member is still extracted. Based on the documentation and a look at the code, it seems that the desired expectation with `errorlevel=0` is to not raise an exception, but skip member extraction and log the error.
Updates `tarfile` to properly handle `FilterError` and skip extraction on unsafe members even when an exception is not raised.

This issue was reported on Python 3.11 and should likely be backported as it is a security issue.

From the docs: 

> When a filter refuses to extract a file, it will raise an appropriate exception, a subclass of [FilterError](https://docs.python.org/3.11/library/tarfile.html#tarfile.FilterError). This will abort the extraction if [TarFile.errorlevel](https://docs.python.org/3.11/library/tarfile.html#tarfile.TarFile.errorlevel) is 1 or more. With errorlevel=0 the error will be logged and the member will be skipped, but extraction will continue.


<!-- gh-issue-number: gh-112887 -->
* Issue: gh-112887
<!-- /gh-issue-number -->
