### PR TITLE
gh-112970: Detect and use closefrom() on platforms where it is available

### DIFF
--- a/Misc/NEWS.d/next/Library/2023-12-11-16-13-15.gh-issue-112970.87jmKP.rst
+++ b/Misc/NEWS.d/next/Library/2023-12-11-16-13-15.gh-issue-112970.87jmKP.rst
@@ -1,0 +1,1 @@
+Use closefrom on Linux where available (e.g. glibc-2.34), rather than only FreeBSD.

--- a/Misc/NEWS.d/next/Library/2023-12-11-16-13-15.gh-issue-112970.87jmKP.rst
+++ b/Misc/NEWS.d/next/Library/2023-12-11-16-13-15.gh-issue-112970.87jmKP.rst
@@ -1,1 +1,1 @@
-Use closefrom on Linux where available (e.g. glibc-2.34), rather than only FreeBSD.
+Use :c:func:`!closefrom` on Linux where available (e.g. glibc-2.34), rather than only FreeBSD.

--- a/Python/fileutils.c
+++ b/Python/fileutils.c
@@ -2922,7 +2922,7 @@ _Py_closerange(int first, int last)
 #ifdef USE_CLOSEFROM
     if (last >= sysconf(_SC_OPEN_MAX)) {
         /* Any errors encountered while closing file descriptors are ignored */
-        closefrom(first);
+        (void)closefrom(first);
     }
     else
 #endif /* USE_CLOSEFROM */

--- a/Python/fileutils.c
+++ b/Python/fileutils.c
@@ -2878,9 +2878,9 @@ done:
  *    non-opened fd in the middle.
  * 2b. If fdwalk(3) isn't available, just do a plain close(2) loop.
  */
-#ifdef __FreeBSD__
+#ifdef HAVE_CLOSEFROM
 #  define USE_CLOSEFROM
-#endif /* __FreeBSD__ */
+#endif /* HAVE_CLOSEFROM */
 
 #ifdef HAVE_FDWALK
 #  define USE_FDWALK

--- a/configure
+++ b/configure
@@ -17224,6 +17224,12 @@ then :
   printf "%s\n" "#define HAVE_CLOCK 1" >>confdefs.h
 
 fi
+ac_fn_c_check_func "$LINENO" "closefrom" "ac_cv_func_closefrom"
+if test "x$ac_cv_func_closefrom" = xyes
+then :
+  printf "%s\n" "#define HAVE_CLOSEFROM 1" >>confdefs.h
+
+fi
 ac_fn_c_check_func "$LINENO" "close_range" "ac_cv_func_close_range"
 if test "x$ac_cv_func_close_range" = xyes
 then :

--- a/configure.ac
+++ b/configure.ac
@@ -4743,7 +4743,7 @@ fi
 
 # checks for library functions
 AC_CHECK_FUNCS([ \
-  accept4 alarm bind_textdomain_codeset chmod chown clock close_range confstr \
+  accept4 alarm bind_textdomain_codeset chmod chown clock closefrom close_range confstr \
   copy_file_range ctermid dup dup3 execv explicit_bzero explicit_memset \
   faccessat fchmod fchmodat fchown fchownat fdopendir fdwalk fexecve \
   fork fork1 fpathconf fstatat ftime ftruncate futimens futimes futimesat \

--- a/pyconfig.h.in
+++ b/pyconfig.h.in
@@ -157,6 +157,9 @@
 /* Define to 1 if you have the `clock_settime' function. */
 #undef HAVE_CLOCK_SETTIME
 
+/* Define to 1 if you have the `closefrom' function. */
+#undef HAVE_CLOSEFROM
+
 /* Define to 1 if you have the `close_range' function. */
 #undef HAVE_CLOSE_RANGE
 


### PR DESCRIPTION
glibc-2.34 implements closefrom(3) using the same semantics as on BSD. Check for closefrom in configure and use the check result in fileutils.c rather than hardcoding a FreeBSD check (which was wrong for other BSDs anyway).


<!-- gh-issue-number: gh-112970 -->
* Issue: gh-112970
<!-- /gh-issue-number -->
