### PR TITLE
gh-112898: Remove the false "Cancel" button in the "Save On Close" msgbox

### DIFF
--- a/Lib/idlelib/editor.py
+++ b/Lib/idlelib/editor.py
@@ -1110,18 +1110,18 @@ class EditorWindow:
         self.close()
         return "break"
 
-    def maybesave(self):
+    def maybesave(self, force=False):
         if self.io:
             if not self.get_saved():
                 if self.top.state()!='normal':
                     self.top.deiconify()
                 self.top.lower()
                 self.top.lift()
-            return self.io.maybesave()
+            return self.io.maybesave(force=force)
 
-    def close(self):
+    def close(self, force=False):
         try:
-            reply = self.maybesave()
+            reply = self.maybesave(force=force)
             if str(reply) != "cancel":
                 self._close()
             return reply

--- a/Lib/idlelib/filelist.py
+++ b/Lib/idlelib/filelist.py
@@ -49,12 +49,15 @@ class FileList:
     def new(self, filename=None):
         return self.EditorWindow(self, filename)
 
-    def close_all_callback(self, *args, **kwds):
+    def close_all_callback(self, *args, force=False, **kwds):
         for edit in list(self.inversedict):
-            reply = edit.close()
+            reply = edit.close(force=force)
             if reply == "cancel":
                 break
         return "break"
+
+    def close_all_force_callback(self, *args, **kwds):
+        return self.close_all_callback(*args, force=True, **kwds)
 
     def unregister_maybe_terminate(self, edit):
         try:

--- a/Lib/idlelib/iomenu.py
+++ b/Lib/idlelib/iomenu.py
@@ -179,7 +179,7 @@ class IOBinding:
         self.updaterecentfileslist(filename)
         return True
 
-    def maybesave(self):
+    def maybesave(self, force=False):
         """Return 'yes', 'no', 'cancel' as appropriate.
 
         Tkinter messagebox.askyesnocancel converts these tk responses
@@ -190,15 +190,19 @@ class IOBinding:
         message = ("Do you want to save "
                    f"{self.filename or 'this untitled document'}"
                    " before closing?")
-        confirm = messagebox.askyesnocancel(
+        makemsgbox = messagebox.askyesno if force else messagebox.askyesnocancel
+        confirm = makemsgbox(
                   title="Save On Close",
                   message=message,
                   default=messagebox.YES,
                   parent=self.text)
+        reply = "no" if force else "cancel"
         if confirm:
             self.save(None)
-            reply = "yes" if self.get_saved() else "cancel"
-        else:  reply = "cancel" if confirm is None else "no"
+            if self.get_saved():
+                reply = "yes"
+        elif confirm is not None:
+            reply = "no"
         self.text.focus_set()
         return reply
 

--- a/Lib/idlelib/macosx.py
+++ b/Lib/idlelib/macosx.py
@@ -221,7 +221,7 @@ def overrideRootMenu(root, flist):
         # The binding above doesn't reliably work on all versions of Tk
         # on macOS. Adding command definition below does seem to do the
         # right thing for now.
-        root.createcommand('::tk::mac::Quit', flist.close_all_callback)
+        root.createcommand('::tk::mac::Quit', flist.close_all_force_callback)
 
     if isCarbonTk():
         # for Carbon AquaTk, replace the default Tk apple menu

--- a/Misc/NEWS.d/next/IDLE/2023-12-12-10-34-07.gh-issue-112898.ta3N4t.rst
+++ b/Misc/NEWS.d/next/IDLE/2023-12-12-10-34-07.gh-issue-112898.ta3N4t.rst
@@ -1,0 +1,2 @@
+Remove the "Cancel" button in the "Save On Close" message box on macOS when
+the user has no option to cancel quiting.


### PR DESCRIPTION
On macOS, when it is asked just before quiting the application, the user has no option to cancel quiting.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-112898 -->
* Issue: gh-112898
<!-- /gh-issue-number -->
