### PR TITLE
gh-109653: Improve import time of  `logging` by lazy loading `traceback`

### DIFF
--- a/Lib/logging/__init__.py
+++ b/Lib/logging/__init__.py
@@ -23,7 +23,10 @@ Copyright (C) 2001-2022 Vinay Sajip. All Rights Reserved.
 To use, simply 'import logging' and log away!
 """
 
-import sys, os, time, io, re, traceback, warnings, weakref, collections.abc
+import sys, os, time, io, re, warnings, weakref, collections.abc
+
+# Speed up import time by delaying traceback import until needed
+traceback = None
 
 from types import GenericAlias
 from string import Template
@@ -653,6 +656,9 @@ class Formatter(object):
         This default implementation just uses
         traceback.print_exception()
         """
+        global traceback
+        if traceback is None:
+            import traceback
         sio = io.StringIO()
         tb = ei[2]
         # See issues #9427, #1553375. Commented out for now.
@@ -1061,6 +1067,9 @@ class Handler(Filterer):
         The record which was being processed is passed in to this method.
         """
         if raiseExceptions and sys.stderr:  # see issue 13807
+            global traceback
+            if traceback is None:
+                import traceback
             exc = sys.exception()
             try:
                 sys.stderr.write('--- Logging error ---\n')
@@ -1601,6 +1610,9 @@ class Logger(Filterer):
         co = f.f_code
         sinfo = None
         if stack_info:
+            global traceback
+            if traceback is None:
+                import traceback
             with io.StringIO() as sio:
                 sio.write("Stack (most recent call last):\n")
                 traceback.print_stack(f, file=sio)

--- a/Misc/NEWS.d/next/Library/2023-12-12-08-44-30.gh-issue-109653.ZCUa8H.rst
+++ b/Misc/NEWS.d/next/Library/2023-12-12-08-44-30.gh-issue-109653.ZCUa8H.rst
@@ -1,0 +1,1 @@
+Reduce the import time of :mod:`logging` module by ~15%. Patch by Daniel Hollas.


### PR DESCRIPTION
Lazy importing `traceback` module in `logging` improves the import time by ~15% on my machine (PGO-optimized build on Linux). Since `traceback` is used here to handle exceptions, these code paths should by definition better be exceptional so lazy loading makes sense.

In order to avoid performance impacts, I have used [a trick proposed in a similar PR](https://github.com/python/cpython/pull/112244#discussion_r1405165765). Perhaps this trick is not necessary here though since as mentioned above these code paths should not be hot.

TODO: Fix the failing test.

<!-- gh-issue-number: gh-109653 -->
* Issue: gh-109653
<!-- /gh-issue-number -->
