### PR TITLE
gh-51944: fix type and missing addition in gh-112823

### DIFF
--- a/Modules/termios.c
+++ b/Modules/termios.c
@@ -840,6 +840,9 @@ static struct constant {
 #ifdef CDSR_OFLOW
     {"CDSR_OFLOW", CDSR_OFLOW},
 #endif
+#ifdef CCTS_OFLOW
+    {"CCTS_OFLOW", CCTS_OFLOW},
+#endif
 #ifdef CCAR_OFLOW
     {"CCAR_OFLOW", CCAR_OFLOW},
 #endif
@@ -912,7 +915,7 @@ static struct constant {
     {"VSTOP", VSTOP},
     {"VSUSP", VSUSP},
 #ifdef VDSUSP
-    {"VDSUSP", VREPRINT},
+    {"VDSUSP", VDSUSP},
 #endif
     {"VEOL", VEOL},
 #ifdef VREPRINT


### PR DESCRIPTION
Fix the defition of VDSUSP and CCTS_OFLOW (which
was mentioned in NEWS, but not actually addded)


<!-- gh-issue-number: gh-51944 -->
* Issue: gh-51944
<!-- /gh-issue-number -->
