### PR TITLE
gh-76785: Fix test_threading on Non-Subinterpreter Builds

### DIFF
--- a/Lib/test/test_threading.py
+++ b/Lib/test/test_threading.py
@@ -28,7 +28,7 @@ from test import support
 
 try:
     from test.support import interpreters
-except ModuleNotFoundError:
+except ImportError:
     interpreters = None
 
 threading_helper.requires_working_threading(module=True)


### PR DESCRIPTION
gh-112982 broke test_threading on one of the s390 buildbots (Fedora Clang Installed).  Apparently `ImportError` is raised (rather than `ModuleNotFoundError`) for the name part of "from" imports.  This fixes that by catching `ImportError` in test_threading.py.

<!-- gh-issue-number: gh-76785 -->
* Issue: gh-76785
<!-- /gh-issue-number -->
