### PR TITLE
Update pre-commit to fix Sphinx Lint

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.1.2
+    rev: v0.1.7
     hooks:
       - id: ruff
         name: Run Ruff on Lib/test/
@@ -24,7 +24,7 @@ repos:
         types_or: [c, inc, python, rst]
 
   - repo: https://github.com/sphinx-contrib/sphinx-lint
-    rev: v0.8.1
+    rev: v0.9.1
     hooks:
       - id: sphinx-lint
         args: [--enable=default-role]


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

This fixes this error on pre-commit/linting:

```pytb
[INFO] Initializing environment for https://github.com/astral-sh/ruff-pre-commit.
[INFO] Installing environment for https://github.com/astral-sh/ruff-pre-commit.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/sphinx-contrib/sphinx-lint.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
An unexpected error has occurred: CalledProcessError: command: ('/Users/hugo/.cache/pre-commit/repouv8h8bwe/py_env-python3/bin/python', '-mpip', 'install', '.')
return code: 1
stdout:
    Processing /Users/hugo/.cache/pre-commit/repouv8h8bwe
      Installing build dependencies: started
      Installing build dependencies: finished with status 'done'
      Getting requirements to build wheel: started
      Getting requirements to build wheel: finished with status 'done'
      Preparing metadata (pyproject.toml): started
      Preparing metadata (pyproject.toml): finished with status 'error'
stderr:
      error: subprocess-exited-with-error

      × Preparing metadata (pyproject.toml) did not run successfully.
      │ exit code: 1
      ╰─> [43 lines of output]
          /private/var/folders/c8/hl_96fcs0hjgr29njx33x20c0000gn/T/pip-build-env-77idmup0/overlay/lib/python3.12/site-packages/setuptools_scm/git.py:163: UserWarning: "/Users/hugo/.cache/pre-commit/repouv8h8bwe" is shallow and may cause errors
            warnings.warn(f'"{wd.path}" is shallow and may cause errors')
          Traceback (most recent call last):
            File "/Users/hugo/.cache/pre-commit/repouv8h8bwe/py_env-python3/lib/python3.12/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 353, in <module>
              main()
            File "/Users/hugo/.cache/pre-commit/repouv8h8bwe/py_env-python3/lib/python3.12/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 335, in main
              json_out['return_val'] = hook(**hook_input['kwargs'])
                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
            File "/Users/hugo/.cache/pre-commit/repouv8h8bwe/py_env-python3/lib/python3.12/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 152, in prepare_metadata_for_build_wheel
              whl_basename = backend.build_wheel(metadata_directory, config_settings)
                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
            File "/private/var/folders/c8/hl_96fcs0hjgr29njx33x20c0000gn/T/pip-build-env-77idmup0/overlay/lib/python3.12/site-packages/hatchling/build.py", line 58, in build_wheel
              return os.path.basename(next(builder.build(directory=wheel_directory, versions=['standard'])))
                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
            File "/private/var/folders/c8/hl_96fcs0hjgr29njx33x20c0000gn/T/pip-build-env-77idmup0/overlay/lib/python3.12/site-packages/hatchling/builders/plugin/interface.py", line 155, in build
              artifact = version_api[version](directory, **build_data)
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
            File "/private/var/folders/c8/hl_96fcs0hjgr29njx33x20c0000gn/T/pip-build-env-77idmup0/overlay/lib/python3.12/site-packages/hatchling/builders/wheel.py", line 407, in build_standard
              for included_file in self.recurse_included_files():
            File "/private/var/folders/c8/hl_96fcs0hjgr29njx33x20c0000gn/T/pip-build-env-77idmup0/overlay/lib/python3.12/site-packages/hatchling/builders/plugin/interface.py", line 176, in recurse_included_files
              yield from self.recurse_selected_project_files()
            File "/private/var/folders/c8/hl_96fcs0hjgr29njx33x20c0000gn/T/pip-build-env-77idmup0/overlay/lib/python3.12/site-packages/hatchling/builders/plugin/interface.py", line 180, in recurse_selected_project_files
              if self.config.only_include:
                 ^^^^^^^^^^^^^^^^^^^^^^^^
            File "/private/var/folders/c8/hl_96fcs0hjgr29njx33x20c0000gn/T/pip-build-env-77idmup0/overlay/lib/python3.12/site-packages/hatchling/builders/config.py", line 781, in only_include
              only_include = only_include_config.get('only-include', self.default_only_include()) or self.packages
                                                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
            File "/private/var/folders/c8/hl_96fcs0hjgr29njx33x20c0000gn/T/pip-build-env-77idmup0/overlay/lib/python3.12/site-packages/hatchling/builders/wheel.py", line 235, in default_only_include
              return self.default_file_selection_options.only_include
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
            File "/Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/functools.py", line 995, in __get__
              val = self.func(instance)
                    ^^^^^^^^^^^^^^^^^^^
            File "/private/var/folders/c8/hl_96fcs0hjgr29njx33x20c0000gn/T/pip-build-env-77idmup0/overlay/lib/python3.12/site-packages/hatchling/builders/wheel.py", line 223, in default_file_selection_options
              raise ValueError(message)
          ValueError: Unable to determine which files to ship inside the wheel using the following heuristics: https://hatch.pypa.io/latest/plugins/builder/wheel/#default-file-selection

          At least one file selection option must be defined in the `tool.hatch.build.targets.wheel` table, see: https://hatch.pypa.io/latest/config/build/

          As an example, if you intend to ship a directory named `foo` that resides within a `src` directory located at the root of your project, you can define the following:

          [tool.hatch.build.targets.wheel]
          packages = ["src/foo"]
          [end of output]

      note: This error originates from a subprocess, and is likely not a problem with pip.
    error: metadata-generation-failed

    × Encountered error while generating package metadata.
    ╰─> See above for output.

    note: This is an issue with the package mentioned above, not pip.
    hint: See above for details.
Check the log at /Users/hugo/.cache/pre-commit/pre-commit.log
```

https://github.com/sphinx-contrib/sphinx-lint/pull/106