### PR TITLE
gh-113039: Don't use relative include path in getpath.c

### DIFF
--- a/Modules/getpath.c
+++ b/Modules/getpath.c
@@ -22,7 +22,7 @@
 #endif
 
 /* Reference the precompiled getpath.py */
-#include "../Python/frozen_modules/getpath.h"
+#include "Python/frozen_modules/getpath.h"
 
 #if (!defined(PREFIX) || !defined(EXEC_PREFIX) \
         || !defined(VERSION) || !defined(VPATH) \

--- a/Modules/getpath.c
+++ b/Modules/getpath.c
@@ -22,11 +22,7 @@
 #endif
 
 /* Reference the precompiled getpath.py */
-#ifdef MS_WINDOWS
-#include "../Python/frozen_modules/getpath.h"
-#else
 #include "Python/frozen_modules/getpath.h"
-#endif
 
 #if (!defined(PREFIX) || !defined(EXEC_PREFIX) \
         || !defined(VERSION) || !defined(VPATH) \

--- a/Modules/getpath.c
+++ b/Modules/getpath.c
@@ -22,7 +22,11 @@
 #endif
 
 /* Reference the precompiled getpath.py */
+#ifdef MS_WINDOWS
+#include "../Python/frozen_modules/getpath.h"
+#else
 #include "Python/frozen_modules/getpath.h"
+#endif
 
 #if (!defined(PREFIX) || !defined(EXEC_PREFIX) \
         || !defined(VERSION) || !defined(VPATH) \

--- a/PCbuild/pythoncore.vcxproj
+++ b/PCbuild/pythoncore.vcxproj
@@ -120,6 +120,7 @@
         PLATLIBDIR="DLLs";
         %(PreprocessorDefinitions)
       </PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>$(PySourcePath);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Using an abs include path for the `getpath.h` frozen module header, beyond making things cleaner, also makes it easier to use different build systems where the generated frozen modules headers are only intermediate build artifacts. my motivating use-case is using [buck2](https://buck2.build/) to build cpython, where I needed to apply a patch like this.

<!-- gh-issue-number: gh-113039 -->
* Issue: gh-113039
<!-- /gh-issue-number -->
