### PR TITLE
gh-113010: Don't decrement deferred in pystats

### DIFF
--- a/Python/ceval_macros.h
+++ b/Python/ceval_macros.h
@@ -258,10 +258,6 @@ GETITEM(PyObject *v, Py_ssize_t i) {
         if (ADAPTIVE_COUNTER_IS_ZERO(next_instr->cache)) {       \
             STAT_INC((INSTNAME), deopt);                         \
         }                                                        \
-        else {                                                   \
-            /* This is about to be (incorrectly) incremented: */ \
-            STAT_DEC((INSTNAME), deferred);                      \
-        }                                                        \
     } while (0)
 #else
 #define UPDATE_MISS_STATS(INSTNAME) ((void)0)


### PR DESCRIPTION
This fixes a recently introduced bug where the deferred count is being unnecessarily decremented to counteract an increment elsewhere that is no longer happening.  This caused the values to flip around to "very large" 64-bit numbers.

Example output after this change: https://gist.github.com/mdboom/14a97e65c2164c92cb2c61b6121cd940

Output **before** this change: https://github.com/faster-cpython/benchmarking-public/blob/main/results/bm-20231210-3.13.0a2%2B-23df46a-PYTHON_UOPS/bm-20231210-azure-x86_64-python-23df46a1dde82bc5a515-3.13.0a2%2B-23df46a-pystats.md

<!-- gh-issue-number: gh-113010 -->
* Issue: gh-113010
<!-- /gh-issue-number -->
