### PR TITLE
gh-76785: Avoid Pickled TracebackException for Propagated Subinterpreter Exceptions

### DIFF
--- a/Include/internal/pycore_crossinterp.h
+++ b/Include/internal/pycore_crossinterp.h
@@ -188,8 +188,7 @@ typedef struct _excinfo {
         const char *module;
     } type;
     const char *msg;
-    const char *pickled;
-    Py_ssize_t pickled_len;
+    const char *errdisplay;
 } _PyXI_excinfo;
 
 

--- a/Lib/test/support/interpreters/__init__.py
+++ b/Lib/test/support/interpreters/__init__.py
@@ -56,7 +56,7 @@ class ExecFailure(RuntimeError):
 
     def __str__(self):
         try:
-            formatted = ''.join(self.excinfo.tbexc.format()).rstrip()
+            formatted = self.excinfo.errdisplay
         except Exception:
             return super().__str__()
         else:


### PR DESCRIPTION
We need the `TracebackException` of uncaught exceptions for a single purpose: the error display.  Thus we only need to pass the formatted error display between interpreters.  Passing a pickled `TracebackException` is overkill.

<!-- gh-issue-number: gh-76785 -->
* Issue: gh-76785
<!-- /gh-issue-number -->
