### PR TITLE
More helpful error message in JSON decoder

### DIFF
--- a/Lib/json/decoder.py
+++ b/Lib/json/decoder.py
@@ -161,7 +161,7 @@ def JSONObject(s_and_end, strict, scan_once, object_hook, object_pairs_hook,
             return pairs, end + 1
         elif nextchar != '"':
             raise JSONDecodeError(
-                "Expecting property name enclosed in double quotes", s, end)
+                "Expecting a property name enclosed in double quotes (no trailing comma allowed)", s, end)
     end += 1
     while True:
         key, end = scanstring(s, end, strict)

--- a/Lib/json/decoder.py
+++ b/Lib/json/decoder.py
@@ -161,7 +161,7 @@ def JSONObject(s_and_end, strict, scan_once, object_hook, object_pairs_hook,
             return pairs, end + 1
         elif nextchar != '"':
             raise JSONDecodeError(
-                "Expecting a property name enclosed in double quotes (no trailing comma allowed)", s, end)
+                "Expecting property name enclosed in double quotes", s, end)
     end += 1
     while True:
         key, end = scanstring(s, end, strict)
@@ -203,6 +203,8 @@ def JSONObject(s_and_end, strict, scan_once, object_hook, object_pairs_hook,
         end = _w(s, end).end()
         nextchar = s[end:end + 1]
         end += 1
+        if nextchar == '}':
+            raise JSONDecodeError("Trailing commas are not allowed in JSON objects.")
         if nextchar != '"':
             raise JSONDecodeError(
                 "Expecting property name enclosed in double quotes", s, end - 1)


### PR DESCRIPTION
While JavaScript typically parses the following example, it is not strictly valid JSON. But while the current Python error message `Expecting property name enclosed in double quotes` hints at a missing quote, the problem in fact is a trailing comma:
```js
{
  "key": "value",
}
```
The new error message becomes:
`Expecting a property name enclosed in double quotes (no trailing comma allowed)`

I believe this trivial change does neither require a NEWS entry nor a separate issue, but I do not have experience if there are any tools that depend on the exact error message of the exception...