### PR TITLE
gh-113050: Pass `name` to BaseEventLoop task factory

### DIFF
--- a/Doc/library/asyncio-eventloop.rst
+++ b/Doc/library/asyncio-eventloop.rst
@@ -379,8 +379,8 @@ Creating Futures and Tasks
 
    If *factory* is ``None`` the default task factory will be set.
    Otherwise, *factory* must be a *callable* with the signature matching
-   ``(loop, coro, context=None)``, where *loop* is a reference to the active
-   event loop, and *coro* is a coroutine object.  The callable
+   ``(loop, coro, name=None, context=None)``, where *loop* is a reference
+   to the active event loop, and *coro* is a coroutine object. The callable
    must return a :class:`asyncio.Future`-compatible object.
 
 .. method:: loop.get_task_factory()

--- a/Lib/asyncio/base_events.py
+++ b/Lib/asyncio/base_events.py
@@ -461,11 +461,9 @@ class BaseEventLoop(events.AbstractEventLoop):
         else:
             if context is None:
                 # Use legacy API if context is not needed
-                task = self._task_factory(self, coro)
+                task = self._task_factory(self, coro, name=name)
             else:
-                task = self._task_factory(self, coro, context=context)
-
-            task.set_name(name)
+                task = self._task_factory(self, coro, name=name, context=context)
 
         return task
 

--- a/Lib/test/test_asyncio/test_base_events.py
+++ b/Lib/test/test_asyncio/test_base_events.py
@@ -722,7 +722,7 @@ class BaseEventLoopTests(test_utils.TestCase):
         async def coro():
             pass
 
-        factory = lambda loop, coro: MyTask(coro, loop=loop)
+        factory = lambda loop, coro, **kwargs: MyTask(coro, loop=loop, **kwargs)
 
         self.assertIsNone(self.loop.get_task_factory())
         self.loop.set_task_factory(factory)
@@ -816,8 +816,8 @@ class BaseEventLoopTests(test_utils.TestCase):
             loop.close()
 
     def test_create_named_task_with_custom_factory(self):
-        def task_factory(loop, coro):
-            return asyncio.Task(coro, loop=loop)
+        def task_factory(loop, coro, **kwargs):
+            return asyncio.Task(coro, loop=loop, **kwargs)
 
         async def test():
             pass

--- a/Lib/test/test_asyncio/test_tasks.py
+++ b/Lib/test/test_asyncio/test_tasks.py
@@ -3326,7 +3326,7 @@ class RunCoroutineThreadsafeTests(test_utils.TestCase):
         """Test coroutine submission from a thread to an event loop
         when the task factory raise an exception."""
 
-        def task_factory(loop, coro):
+        def task_factory(loop, coro, **kwargs):
             raise NameError
 
         run = self.loop.run_in_executor(

--- a/Misc/NEWS.d/next/Library/2023-12-13-23-05-44.gh-issue-113050.2SgcET.rst
+++ b/Misc/NEWS.d/next/Library/2023-12-13-23-05-44.gh-issue-113050.2SgcET.rst
@@ -1,0 +1,2 @@
+Ensure ``name`` parameter is passed to task factories set by
+:func:`asyncio.BaseEventLoop.set_task_factory`.


### PR DESCRIPTION
Issue: https://github.com/python/cpython/issues/113050

The task factory is used in the BaseEventLoop create_task method when set. This commit passes the `name` kwarg to this factory to set the name of the task, instead of setting the task in the loop method. This is more consistent with the eager_task_factory methods.

This is consistent with:

- How it is documented in the [`asyncio` Eager Task Factory docs](https://docs.python.org/3/library/asyncio-task.html#asyncio.eager_task_factory)
- [`asyncio.tasks.create_eager_task_factory`](https://github.com/python/cpython/blob/main/Lib/asyncio/tasks.py#L960-L964) which returns a factory with signature `def factory(loop, coro, *, name=None, context=None)`.
- [How `uvloop` is expecting it **in its unit tests**](https://github.com/MagicStack/uvloop/blob/master/tests/test_base.py#L543-L545)

This will be a breaking change if and only if:

- The `BaseEventLoop` is subclassed and the subclass does not override `create_task` (using the default implementation), *and*
- The subclass is used with a task factory that does not accept the `name` kwarg (or `**kwargs`).

`uvloop` will not be affected by this, but I have raised an issue to update their typing to reflect this expectation: https://github.com/MagicStack/uvloop/issues/584

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->



<!-- gh-issue-number: gh-113050 -->
* Issue: gh-113050
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--113051.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->