### PR TITLE
gh-113078: Use uint64 for dev_t and uint32 for makedev params

### DIFF
--- a/Misc/NEWS.d/next/Library/2023-12-14-01-46-24.gh-issue-113078.FQ5--F.rst
+++ b/Misc/NEWS.d/next/Library/2023-12-14-01-46-24.gh-issue-113078.FQ5--F.rst
@@ -1,0 +1,1 @@
+Fix POSIX's stat and makedev issue on FreeBSD when using a ZFS filesystem

--- a/Modules/clinic/posixmodule.c.h
+++ b/Modules/clinic/posixmodule.c.h
@@ -8411,25 +8411,23 @@ PyDoc_STRVAR(os_makedev__doc__,
     {"makedev", _PyCFunction_CAST(os_makedev), METH_FASTCALL, os_makedev__doc__},
 
 static dev_t
-os_makedev_impl(PyObject *module, int major, int minor);
+os_makedev_impl(PyObject *module, unsigned int major, unsigned int minor);
 
 static PyObject *
 os_makedev(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
-    int major;
-    int minor;
+    unsigned int major;
+    unsigned int minor;
     dev_t _return_value;
 
     if (!_PyArg_CheckPositional("makedev", nargs, 2, 2)) {
         goto exit;
     }
-    major = PyLong_AsInt(args[0]);
-    if (major == -1 && PyErr_Occurred()) {
+    if (!_PyLong_UnsignedInt_Converter(args[0], &major)) {
         goto exit;
     }
-    minor = PyLong_AsInt(args[1]);
-    if (minor == -1 && PyErr_Occurred()) {
+    if (!_PyLong_UnsignedInt_Converter(args[1], &minor)) {
         goto exit;
     }
     _return_value = os_makedev_impl(module, major, minor);
@@ -12421,4 +12419,4 @@ os__supports_virtual_terminal(PyObject *module, PyObject *Py_UNUSED(ignored))
 #ifndef OS__SUPPORTS_VIRTUAL_TERMINAL_METHODDEF
     #define OS__SUPPORTS_VIRTUAL_TERMINAL_METHODDEF
 #endif /* !defined(OS__SUPPORTS_VIRTUAL_TERMINAL_METHODDEF) */
-/*[clinic end generated code: output=ff0ec3371de19904 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=df786a0e56cd68a0 input=a9049054013a1b77]*/

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -934,7 +934,7 @@ fail:
 #endif /* MS_WINDOWS */
 
 
-#define _PyLong_FromDev PyLong_FromLongLong
+#define _PyLong_FromDev PyLong_FromUnsignedLongLong
 
 
 #if (defined(HAVE_MKNOD) && defined(HAVE_MAKEDEV)) || defined(HAVE_DEVICE_MACROS)
@@ -12040,16 +12040,16 @@ os_minor_impl(PyObject *module, dev_t device)
 /*[clinic input]
 os.makedev -> dev_t
 
-    major: int
-    minor: int
+    major: unsigned_int
+    minor: unsigned_int
     /
 
 Composes a raw device number from the major and minor device numbers.
 [clinic start generated code]*/
 
 static dev_t
-os_makedev_impl(PyObject *module, int major, int minor)
-/*[clinic end generated code: output=881aaa4aba6f6a52 input=4b9fd8fc73cbe48f]*/
+os_makedev_impl(PyObject *module, unsigned int major, unsigned int minor)
+/*[clinic end generated code: output=19d6d22807bf0d20 input=27d2f0106009da11]*/
 {
     return makedev(major, minor);
 }


### PR DESCRIPTION
Following the implementions from both FreeBSD and GNU glibc, `PyLong_FromDev should actually be unsigned. This can break on FreeBSD systems using ZFS, since they wouldn't generate device IDs with 56 upper bits randomly, therefore the MSB too.

Also, following the documentation from FreeBSD and Linux, `makedev` should accept unsigned 32 bit integers. The reason to that is because on FreeBSD `major` and `minor` can return anything on the 32 bit int range and on Linux it really specifies that it returns a unsigned integer.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-113078 -->
* Issue: gh-113078
<!-- /gh-issue-number -->
