### PR TITLE
gh-112535: Update _Py_ThreadId() to support RISC-V

### DIFF
--- a/Include/object.h
+++ b/Include/object.h
@@ -283,6 +283,13 @@ _Py_ThreadId(void)
     // Both GCC and Clang have supported __builtin_thread_pointer
     // for s390 from long time ago.
     tid = (uintptr_t)__builtin_thread_pointer();
+#elif defined(__riscv)
+    #if defined(__clang__) && _Py__has_builtin(__builtin_thread_pointer)
+    tid = (uintptr_t)__builtin_thread_pointer();
+    #else
+    // tp is Thread Pointer provided by the RISC-V ABI.
+    __asm__ ("mv %0, tp" : "=r" (tid));
+    #endif
 #else
   # error "define _Py_ThreadId for this platform"
 #endif


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-112535 -->
* Issue: gh-112535
<!-- /gh-issue-number -->


* Clang supports __builtin_thread_pointer for RISC-V from [clang 11.0.0](https://github.com/llvm/llvm-project/commit/aabc24acf0d5f8677bd22fe9c108581e07c3e180)
* GCC supports  __builtin_thread_pointer for RISC-V from[ GCC 10.2.0](https://github.com/gcc-mirror/gcc/commit/1073b500e5d33af8b75567108a8c04fe2598df2b)  (The Clang team [said](https://reviews.llvm.org/D155828) that checking the __builtin_thread_pointer with __has_builtin but not safe for GCC)