### PR TITLE
gh-113090: Fix test.support.os_support.can_chmod() on Windows

### DIFF
--- a/Lib/test/support/os_helper.py
+++ b/Lib/test/support/os_helper.py
@@ -247,15 +247,15 @@ def can_chmod():
     global _can_chmod
     if _can_chmod is not None:
         return _can_chmod
-    if not hasattr(os, "chown"):
+    if not hasattr(os, "chmod"):
         _can_chmod = False
         return _can_chmod
     try:
         with open(TESTFN, "wb") as f:
             try:
-                os.chmod(TESTFN, 0o777)
+                os.chmod(TESTFN, 0o555)
                 mode1 = os.stat(TESTFN).st_mode
-                os.chmod(TESTFN, 0o666)
+                os.chmod(TESTFN, 0o777)
                 mode2 = os.stat(TESTFN).st_mode
             except OSError as e:
                 can = False
@@ -302,6 +302,10 @@ def can_dac_override():
             else:
                 _can_dac_override = True
     finally:
+        try:
+            os.chmod(TESTFN, 0o700)
+        except OSError:
+            pass
         unlink(TESTFN)
 
     return _can_dac_override

--- a/Lib/test/test_os.py
+++ b/Lib/test/test_os.py
@@ -1743,7 +1743,7 @@ class MakedirTests(unittest.TestCase):
         os.removedirs(path)
 
 
-@os_helper.skip_unless_working_chmod
+@unittest.skipUnless(hasattr(os, "chown"), "requires os.chown()")
 class ChownFileTests(unittest.TestCase):
 
     @classmethod

--- a/Lib/test/test_posix.py
+++ b/Lib/test/test_posix.py
@@ -791,7 +791,7 @@ class PosixTester(unittest.TestCase):
             self.assertRaises(TypeError, chown_func, first_param, uid, t(gid))
             check_stat(uid, gid)
 
-    @os_helper.skip_unless_working_chmod
+    @unittest.skipUnless(hasattr(os, "chown"), "requires os.chown()")
     @unittest.skipIf(support.is_emscripten, "getgid() is a stub")
     def test_chown(self):
         # raise an OSError if the file does not exist
@@ -956,6 +956,7 @@ class PosixTester(unittest.TestCase):
         finally:
             posix.chmod(target, mode)
 
+    @os_helper.skip_unless_working_chmod
     def test_chmod_file(self):
         self.check_chmod(posix.chmod, os_helper.TESTFN)
 
@@ -965,6 +966,7 @@ class PosixTester(unittest.TestCase):
         self.addCleanup(posix.rmdir, target)
         return target
 
+    @os_helper.skip_unless_working_chmod
     def test_chmod_dir(self):
         target = self.tempdir()
         self.check_chmod(posix.chmod, target)

--- a/Lib/test/test_tarfile.py
+++ b/Lib/test/test_tarfile.py
@@ -3452,7 +3452,7 @@ class TestExtractionFilters(unittest.TestCase):
         path = pathlib.Path(os.path.normpath(self.destdir / name))
         self.assertIn(path, self.expected_paths)
         self.expected_paths.remove(path)
-        if mode is not None and os_helper.can_chmod():
+        if mode is not None and os_helper.can_chmod() and os.name != 'nt':
             got = stat.filemode(stat.S_IMODE(path.stat().st_mode))
             self.assertEqual(got, mode)
         if type is None and isinstance(name, str) and name.endswith('/'):


### PR DESCRIPTION


<!-- gh-issue-number: gh-113090 -->
* Issue: gh-113090
<!-- /gh-issue-number -->
