### PR TITLE
[3.12] gh-112716: Fix SystemError when __builtins__ is not a dict (GH-112770)

### DIFF
--- a/Lib/test/test_builtin.py
+++ b/Lib/test/test_builtin.py
@@ -812,6 +812,32 @@ class BuiltinTest(unittest.TestCase):
         self.assertRaisesRegex(NameError, "name 'superglobal' is not defined",
                                exec, code, {'__builtins__': customdict()})
 
+    def test_eval_builtins_mapping(self):
+        code = compile("superglobal", "test", "eval")
+        # works correctly
+        ns = {'__builtins__': types.MappingProxyType({'superglobal': 1})}
+        self.assertEqual(eval(code, ns), 1)
+        # custom builtins mapping is missing key
+        ns = {'__builtins__': types.MappingProxyType({})}
+        self.assertRaisesRegex(NameError, "name 'superglobal' is not defined",
+                               eval, code, ns)
+
+    def test_exec_builtins_mapping_import(self):
+        code = compile("import foo.bar", "test", "exec")
+        ns = {'__builtins__': types.MappingProxyType({})}
+        self.assertRaisesRegex(ImportError, "__import__ not found", exec, code, ns)
+        ns = {'__builtins__': types.MappingProxyType({'__import__': lambda *args: args})}
+        exec(code, ns)
+        self.assertEqual(ns['foo'], ('foo.bar', ns, ns, None, 0))
+
+    def test_eval_builtins_mapping_reduce(self):
+        # list_iterator.__reduce__() calls _PyEval_GetBuiltin("iter")
+        code = compile("x.__reduce__()", "test", "eval")
+        ns = {'__builtins__': types.MappingProxyType({}), 'x': iter([1, 2])}
+        self.assertRaisesRegex(AttributeError, "iter", eval, code, ns)
+        ns = {'__builtins__': types.MappingProxyType({'iter': iter}), 'x': iter([1, 2])}
+        self.assertEqual(eval(code, ns), (iter, ([1, 2],), 0))
+
     def test_exec_redirected(self):
         savestdout = sys.stdout
         sys.stdout = None # Whatever that cannot flush()

--- a/Misc/NEWS.d/next/Core and Builtins/2023-12-05-20-41-58.gh-issue-112716.hOcx0Y.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2023-12-05-20-41-58.gh-issue-112716.hOcx0Y.rst
@@ -1,0 +1,2 @@
+Fix SystemError in the ``import`` statement and in ``__reduce__()`` methods
+of builtin types when ``__builtins__`` is not a dict.

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -2308,11 +2308,8 @@ PyObject *
 _PyEval_GetBuiltin(PyObject *name)
 {
     PyThreadState *tstate = _PyThreadState_GET();
-    PyObject *attr = PyDict_GetItemWithError(PyEval_GetBuiltins(), name);
-    if (attr) {
-        Py_INCREF(attr);
-    }
-    else if (!_PyErr_Occurred(tstate)) {
+    PyObject *attr = PyObject_GetItem(PyEval_GetBuiltins(), name);
+    if (attr == NULL && _PyErr_ExceptionMatches(tstate, PyExc_KeyError)) {
         _PyErr_SetObject(tstate, PyExc_AttributeError, name);
     }
     return attr;
@@ -2467,9 +2464,9 @@ import_name(PyThreadState *tstate, _PyInterpreterFrame *frame,
     PyObject *import_func, *res;
     PyObject* stack[5];
 
-    import_func = _PyDict_GetItemWithError(frame->f_builtins, &_Py_ID(__import__));
+    import_func = PyObject_GetItem(frame->f_builtins, &_Py_ID(__import__));
     if (import_func == NULL) {
-        if (!_PyErr_Occurred(tstate)) {
+        if (_PyErr_ExceptionMatches(tstate, PyExc_KeyError)) {
             _PyErr_SetString(tstate, PyExc_ImportError, "__import__ not found");
         }
         return NULL;
@@ -2477,6 +2474,7 @@ import_name(PyThreadState *tstate, _PyInterpreterFrame *frame,
     PyObject *locals = frame->f_locals;
     /* Fast path for not overloaded __import__. */
     if (_PyImport_IsDefaultImportFunc(tstate->interp, import_func)) {
+        Py_DECREF(import_func);
         int ilevel = _PyLong_AsInt(level);
         if (ilevel == -1 && _PyErr_Occurred(tstate)) {
             return NULL;
@@ -2489,8 +2487,6 @@ import_name(PyThreadState *tstate, _PyInterpreterFrame *frame,
                         ilevel);
         return res;
     }
-
-    Py_INCREF(import_func);
 
     stack[0] = name;
     stack[1] = frame->f_globals;


### PR DESCRIPTION
It was raised in two cases:
* in the import statement when looking up __import__
* in pickling some builtin type when looking up built-ins iter, getattr, etc.

(cherry picked from commit 1161c14e8c68296fc465cd48970b32be9bee012e)


<!-- gh-issue-number: gh-112716 -->
* Issue: gh-112716
<!-- /gh-issue-number -->
