### PR TITLE
gh-61648: Detect line numbers of properties in doctests

### DIFF
--- a/Lib/doctest.py
+++ b/Lib/doctest.py
@@ -1136,6 +1136,8 @@ class DocTestFinder:
 
         # Find the line number for functions & methods.
         if inspect.ismethod(obj): obj = obj.__func__
+        if isinstance(obj, property):
+            obj = obj.fget
         if inspect.isfunction(obj) and getattr(obj, '__doc__', None):
             # We don't use `docstring` var here, because `obj` can be changed.
             obj = obj.__code__

--- a/Lib/test/doctest_lineno.py
+++ b/Lib/test/doctest_lineno.py
@@ -49,5 +49,21 @@ class MethodWrapper:
         'method_with_doctest'
         """
 
+    @classmethod
+    def classmethod_with_doctest(cls):
+        """
+        This has a doctest!
+        >>> MethodWrapper.classmethod_with_doctest.__name__
+        'classmethod_with_doctest'
+        """
+
+    @property
+    def property_with_doctest(self):
+        """
+        This has a doctest!
+        >>> MethodWrapper.property_with_doctest.__name__
+        'property_with_doctest'
+        """
+
 # https://github.com/python/cpython/issues/99433
 str_wrapper = object().__str__

--- a/Lib/test/test_doctest.py
+++ b/Lib/test/test_doctest.py
@@ -670,9 +670,11 @@ It used to be broken for quite some time until `bpo-28249`.
        30  test.doctest_lineno.ClassWithDoctest
      None  test.doctest_lineno.ClassWithoutDocstring
      None  test.doctest_lineno.MethodWrapper
+       53  test.doctest_lineno.MethodWrapper.classmethod_with_doctest
        39  test.doctest_lineno.MethodWrapper.method_with_docstring
        45  test.doctest_lineno.MethodWrapper.method_with_doctest
      None  test.doctest_lineno.MethodWrapper.method_without_docstring
+       61  test.doctest_lineno.MethodWrapper.property_with_doctest
         4  test.doctest_lineno.func_with_docstring
        12  test.doctest_lineno.func_with_doctest
      None  test.doctest_lineno.func_without_docstring

--- a/Misc/NEWS.d/next/Library/2023-12-15-12-35-28.gh-issue-61648.G-4pz0.rst
+++ b/Misc/NEWS.d/next/Library/2023-12-15-12-35-28.gh-issue-61648.G-4pz0.rst
@@ -1,0 +1,1 @@
+Detect line numbers of properties in doctests.


### PR DESCRIPTION


<!-- gh-issue-number: gh-61648 -->
* Issue: gh-61648
<!-- /gh-issue-number -->
