### PR TITLE
gh-113172: Fix compiler warnings in Modules/_xxinterpqueuesmodule.c

### DIFF
--- a/Modules/_xxinterpqueuesmodule.c
+++ b/Modules/_xxinterpqueuesmodule.c
@@ -234,11 +234,13 @@ static int
 add_exctype(PyObject *mod, PyObject **p_state_field,
             const char *qualname, const char *doc, PyObject *base)
 {
+#ifndef NDEBUG
     const char *dot = strrchr(qualname, '.');
     assert(dot != NULL);
     const char *name = dot+1;
     assert(*p_state_field == NULL);
     assert(!PyObject_HasAttrStringWithError(mod, name));
+#endif
     PyObject *exctype = PyErr_NewExceptionWithDoc(qualname, doc, base, NULL);
     if (exctype == NULL) {
         return -1;
@@ -1505,7 +1507,7 @@ queuesmod_is_full(PyObject *self, PyObject *args, PyObject *kwds)
     }
     int64_t qid = qidarg.id;
 
-    int is_full;
+    int is_full = 0;
     int err = queue_is_full(&_globals.queues, qid, &is_full);
     if (handle_queue_error(err, self, qid)) {
         return NULL;


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-113172 -->
* Issue: gh-113172
<!-- /gh-issue-number -->
