### PR TITLE
gh-112890: `unittest` Test Discovery page updated "`unittest` dropped the namspace packages support"

### DIFF
--- a/Doc/library/unittest.rst
+++ b/Doc/library/unittest.rst
@@ -346,8 +346,8 @@ the `load_tests protocol`_.
    ``python -m unittest discover -s root/namespace -t root``).
 
 .. versionchanged:: 3.11
-   Python 3.11 dropped the :term:`namespace packages <namespace package>`
-   support. It has been broken since Python 3.7. Start directory and
+   unittest dropped the :term:`namespace packages <namespace package>`
+   support in Python 3.11. It has been broken since Python 3.7. Start directory and
    subdirectories containing tests must be regular package that have
    ``__init__.py`` file.
 

--- a/Doc/library/unittest.rst
+++ b/Doc/library/unittest.rst
@@ -346,7 +346,7 @@ the `load_tests protocol`_.
    ``python -m unittest discover -s root/namespace -t root``).
 
 .. versionchanged:: 3.11
-   unittest dropped the :term:`namespace packages <namespace package>`
+   :mod:`unittest` dropped the :term:`namespace packages <namespace package>`
    support in Python 3.11. It has been broken since Python 3.7. Start directory and
    subdirectories containing tests must be regular package that have
    ``__init__.py`` file.


### PR DESCRIPTION
Updated the language in [documenttation for `unittest` Test Discovery](https://docs.python.org/3/library/unittest.html#test-discovery) to say the following: "Changed in version 3.11: unittest dropped the [namespace packages](https://docs.python.org/3/glossary.html#term-namespace-package) support in Python 3.11. It has been broken since Python 3.7. Start directory and subdirectories containing tests must be regular package that have init.py file." 

This update was based on [gh-112890](https://github.com/python/cpython/issues/112890)

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--113195.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->