### PR TITLE
gh-113208: Mention namespace packages don't require __init__.py

### DIFF
--- a/Doc/tutorial/modules.rst
+++ b/Doc/tutorial/modules.rst
@@ -437,7 +437,8 @@ When importing the package, Python searches through the directories on
 ``sys.path`` looking for the package subdirectory.
 
 The :file:`__init__.py` files are required to make Python treat directories
-containing the file as packages.  This prevents directories with a common name,
+containing the file as packages (unless using a :term:`namespace package`, a
+relatively advanced features). This prevents directories with a common name,
 such as ``string``, from unintentionally hiding valid modules that occur later
 on the module search path. In the simplest case, :file:`__init__.py` can just be
 an empty file, but it can also execute initialization code for the package or

--- a/Doc/tutorial/modules.rst
+++ b/Doc/tutorial/modules.rst
@@ -438,7 +438,7 @@ When importing the package, Python searches through the directories on
 
 The :file:`__init__.py` files are required to make Python treat directories
 containing the file as packages (unless using a :term:`namespace package`, a
-relatively advanced features). This prevents directories with a common name,
+relatively advanced feature). This prevents directories with a common name,
 such as ``string``, from unintentionally hiding valid modules that occur later
 on the module search path. In the simplest case, :file:`__init__.py` can just be
 an empty file, but it can also execute initialization code for the package or


### PR DESCRIPTION
<!-- readthedocs-preview cpython-previews start -->

<!-- gh-issue-number: gh-113208 -->
* Issue: gh-113208
<!-- /gh-issue-number -->
----
📚 Documentation preview 📚: https://cpython-previews--113209.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->