### PR TITLE
gh-108269: Add CFBundleAllowMixedLocalizations to Info.plist on macOS

### DIFF
--- a/Mac/IDLE/IDLE.app/Contents/Info.plist
+++ b/Mac/IDLE/IDLE.app/Contents/Info.plist
@@ -56,5 +56,7 @@
 	<string>%version%</string>
 	<key>NSHighResolutionCapable</key>
 	<true/>
+	<key>CFBundleAllowMixedLocalizations</key>
+	<true/>
 </dict>
 </plist>

--- a/Mac/Resources/app/Info.plist.in
+++ b/Mac/Resources/app/Info.plist.in
@@ -58,5 +58,7 @@
 	<string>(c) 2001-2023 Python Software Foundation.</string>
 	<key>NSHighResolutionCapable</key>
 	<true/>
+	<key>CFBundleAllowMixedLocalizations</key>
+	<true/>
 </dict>
 </plist>

--- a/Mac/Resources/framework/Info.plist.in
+++ b/Mac/Resources/framework/Info.plist.in
@@ -24,5 +24,7 @@
 	<string>????</string>
 	<key>CFBundleVersion</key>
 	<string>%VERSION%</string>
+	<key>CFBundleAllowMixedLocalizations</key>
+	<true/>
 </dict>
 </plist>

--- a/Misc/NEWS.d/next/macOS/2023-12-16-11-45-32.gh-issue-108269.wVgCHF.rst
+++ b/Misc/NEWS.d/next/macOS/2023-12-16-11-45-32.gh-issue-108269.wVgCHF.rst
@@ -1,0 +1,4 @@
+Set ``CFBundleAllowMixedLocalizations`` to true in the Info.plist for the
+framework, embedded Python.app and IDLE.app with framework installs on
+macOS.  This allows applications to pick up the user's preferred locale when
+that's different from english.


### PR DESCRIPTION
Adding this key with a value of true enables detecting the users prefered language in libraries accessing system APIs for this.

<!-- gh-issue-number: gh-108269 -->
* Issue: gh-108269
<!-- /gh-issue-number -->
