### PR TITLE
Remove redundant `_PyFrame_GetCode`

### DIFF
--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -10450,7 +10450,7 @@ super_init_without_args(_PyInterpreterFrame *cframe, PyCodeObject *co,
         return -1;
     }
 
-    assert(_PyFrame_GetCode(cframe)->co_nlocalsplus > 0);
+    assert(co->co_nlocalsplus > 0);
     PyObject *firstarg = _PyFrame_GetLocalsArray(cframe)[0];
     // The first argument might be a cell.
     if (firstarg != NULL && (_PyLocals_GetKind(co->co_localspluskinds, 0) & CO_FAST_CELL)) {


### PR DESCRIPTION
No need to call `_PyFrame_GetCode(cframe)`, it is already passed as `co`:
https://github.com/python/cpython/blob/d91e43ed7839b601cbeadd137d89e69e2cc3efda/Objects/typeobject.c#L10546