### PR TITLE
gh-111788: Don't treat path in robots.txt as URL in `urllib.robotparser`

### DIFF
--- a/Lib/test/test_robotparser.py
+++ b/Lib/test/test_robotparser.py
@@ -299,6 +299,17 @@ Disallow: /cyberworld/map/\
         self.assertEqual(str(self.parser), self.expected_output)
 
 
+class WeirdUnquotePathTest(BaseRobotTest, unittest.TestCase):
+    robots_txt = """\
+User-agent: *
+
+# This can be interpreted as weird unquoted path, or an URL with invalid IPv6
+# host as well.
+Disallow: //[foo]/bar
+    """
+    pass
+
+
 class RobotHandler(BaseHTTPRequestHandler):
 
     def do_GET(self):
@@ -387,6 +398,7 @@ class NetworkTestCase(unittest.TestCase):
         self.assertEqual(parser.mtime(), 0)
         self.assertIsNone(parser.crawl_delay('*'))
         self.assertIsNone(parser.request_rate('*'))
+
 
 if __name__=='__main__':
     unittest.main()

--- a/Lib/urllib/robotparser.py
+++ b/Lib/urllib/robotparser.py
@@ -19,6 +19,15 @@ __all__ = ["RobotFileParser"]
 RequestRate = collections.namedtuple("RequestRate", "requests seconds")
 
 
+def normalize_path(path):
+    query, fragment = '', ''
+    if '#' in path:
+        path, fragment = path.split('#', 1)
+    if '?' in path:
+        path, query = path.split('?', 1)
+    return urllib.parse.urlunsplit(('', '', path, query, fragment))
+
+
 class RobotFileParser:
     """ This class provides a set of methods to read, parse and answer
     questions about a single robots.txt file.
@@ -219,7 +228,7 @@ class RuleLine:
         if path == '' and not allowance:
             # an empty value means allow all
             allowance = True
-        path = urllib.parse.urlunparse(urllib.parse.urlparse(path))
+        path = normalize_path(path)
         self.path = urllib.parse.quote(path)
         self.allowance = allowance
 

--- a/Misc/NEWS.d/next/Library/2023-12-17-22-38-10.gh-issue-111788.twWfD-.rst
+++ b/Misc/NEWS.d/next/Library/2023-12-17-22-38-10.gh-issue-111788.twWfD-.rst
@@ -1,0 +1,2 @@
+Fix a bug that :func:`urllib.robotparser` will raise exception when parse
+weird robot.txt.

--- a/Misc/NEWS.d/next/Library/2023-12-17-22-38-10.gh-issue-111788.twWfD-.rst
+++ b/Misc/NEWS.d/next/Library/2023-12-17-22-38-10.gh-issue-111788.twWfD-.rst
@@ -1,2 +1,1 @@
-Fix a bug that :func:`urllib.robotparser` will raise exception when parse
-weird robot.txt.
+Don't treat path in robots.txt as URL in :func:`urllib.robotparser`.


### PR DESCRIPTION


<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-111788 -->
* Issue: gh-111788
<!-- /gh-issue-number -->
