### PR TITLE
gh-113157 gh-89519:  Fix method descriptors

### DIFF
--- a/Lib/test/test_descr.py
+++ b/Lib/test/test_descr.py
@@ -5004,6 +5004,21 @@ class ClassPropertiesAndMethods(unittest.TestCase):
         gc.collect()
         self.assertEqual(Parent.__subclasses__(), [])
 
+    def test_instance_method_get_behavior(self):
+        # test case for gh-113157
+
+        class A:
+            def meth(self):
+                return self
+
+        class B:
+            pass
+
+        a = A()
+        b = B()
+        b.meth = a.meth.__get__(b, B)
+        self.assertEqual(b.meth(), a)
+
     def test_attr_raise_through_property(self):
         # test case for gh-103272
         class A:

--- a/Objects/classobject.c
+++ b/Objects/classobject.c
@@ -319,6 +319,13 @@ method_traverse(PyMethodObject *im, visitproc visit, void *arg)
     return 0;
 }
 
+static PyObject *
+method_descr_get(PyObject *meth, PyObject *obj, PyObject *cls)
+{
+    Py_INCREF(meth);
+    return meth;
+}
+
 PyTypeObject PyMethod_Type = {
     PyVarObject_HEAD_INIT(&PyType_Type, 0)
     .tp_name = "method",
@@ -339,6 +346,7 @@ PyTypeObject PyMethod_Type = {
     .tp_methods = method_methods,
     .tp_members = method_memberlist,
     .tp_getset = method_getset,
+    .tp_descr_get = method_descr_get,
     .tp_new = method_new,
 };
 


### PR DESCRIPTION
Fix yet another problem created by classmethod descriptor chaining.   This completes the work in gh-89519, fixes the bug reported in gh-113157, and get us back to the stable and correct semantics in Python 3.9. 

There is still an open question about what if anything to do for Python 3.11 and Python 3.12.  We can' t backport this without breaking something else.

<!-- gh-issue-number: gh-113157 -->
* Issue: gh-113157
<!-- /gh-issue-number -->
