### PR TITLE
Docs: Add label to grammar spec for linking from PEPs

### DIFF
--- a/Doc/reference/grammar.rst
+++ b/Doc/reference/grammar.rst
@@ -1,3 +1,5 @@
+.. _full-grammar-specification:
+
 Full Grammar specification
 ==========================
 


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

This will allow us to reliably link to the page from PEPs with ``` :ref:`python:full-grammar-specification` ``` via intersphinx.


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--113235.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->