### PR TITLE
gh-108113: docs : mention PyCF_OPTIMIZED_AST in ast Compiler Flags

### DIFF
--- a/Doc/library/ast.rst
+++ b/Doc/library/ast.rst
@@ -2457,6 +2457,13 @@ effects on the compilation of a program:
    Generates and returns an abstract syntax tree instead of returning a
    compiled code object.
 
+.. data:: PyCF_OPTIMIZED_AST
+
+   The returned AST is optimized according to the *optimize* argument
+   in :func:`compile` or :func:`ast.parse`.
+
+   .. versionadded:: 3.13
+
 .. data:: PyCF_TYPE_COMMENTS
 
    Enables support for :pep:`484` and :pep:`526` style type comments


### PR DESCRIPTION
[iritkatriel](https://github.com/iritkatriel) implemented in https://github.com/python/cpython/pull/108154 the new
compile() flag `ast.PyCF_OPTIMIZED_AST` .

this pull request adds to the [compiler-flags](https://docs.python.org/3.13/library/ast.html#compiler-flags) doc
a short description for this new flag .


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--113241.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->

<!-- gh-issue-number: gh-108113 -->
* Issue: gh-108113
<!-- /gh-issue-number -->
