### PR TITLE
show example with trailing slash

### DIFF
--- a/Doc/library/pathlib.rst
+++ b/Doc/library/pathlib.rst
@@ -151,6 +151,8 @@ we also call *flavours*:
 
       >>> PurePath('foo//bar')
       PurePosixPath('foo/bar')
+      >>> PurePath('foo/bar/')
+      PurePosixPath('foo/bar')
       >>> PurePath('//foo/bar')
       PurePosixPath('//foo/bar')
       >>> PurePath('foo/./bar')


### PR DESCRIPTION

# show example with trailing slash


```
added an example with a trailing slash
````



<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--113256.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->