### PR TITLE
gh-113257: Fix SBOM metadata for pip 23.3.2

### DIFF
--- a/Misc/sbom.spdx.json
+++ b/Misc/sbom.spdx.json
@@ -1703,16 +1703,16 @@
           "checksumValue": "7ccf472345f20d35bdc9d1841ff5f313260c2c33fe417f48c30ac46cccabf5be"
         }
       ],
-      "downloadLocation": "https://files.pythonhosted.org/packages/50/c2/e06851e8cc28dcad7c155f4753da8833ac06a5c704c109313b8d5a62968a/pip-23.2.1-py3-none-any.whl",
+      "downloadLocation": "https://files.pythonhosted.org/packages/15/aa/3f4c7bcee2057a76562a5b33ecbd199be08cdb4443a02e26bd2c3cf6fc39/pip-23.3.2-py3-none-any.whl",
       "externalRefs": [
         {
           "referenceCategory": "SECURITY",
-          "referenceLocator": "cpe:2.3:a:pypa:pip:23.2.1:*:*:*:*:*:*:*",
+          "referenceLocator": "cpe:2.3:a:pypa:pip:23.3.2:*:*:*:*:*:*:*",
           "referenceType": "cpe23Type"
         },
         {
           "referenceCategory": "PACKAGE_MANAGER",
-          "referenceLocator": "pkg:pypi/pip@23.2.1",
+          "referenceLocator": "pkg:pypi/pip@23.3.2",
           "referenceType": "purl"
         }
       ],
@@ -1720,7 +1720,7 @@
       "name": "pip",
       "originator": "Organization: Python Packaging Authority",
       "primaryPackagePurpose": "SOURCE",
-      "versionInfo": "23.2.1"
+      "versionInfo": "23.3.2"
     }
   ],
   "relationships": [

--- a/Tools/build/generate_sbom.py
+++ b/Tools/build/generate_sbom.py
@@ -50,7 +50,7 @@ PACKAGE_TO_FILES = {
         include=["Modules/expat/**"]
     ),
     "pip": PackageFiles(
-        include=["Lib/ensurepip/_bundled/pip-*-py3-none-any.whl"]
+        include=["Lib/ensurepip/_bundled/pip-23.3.2-py3-none-any.whl"]
     ),
     "macholib": PackageFiles(
         include=["Lib/ctypes/macholib/**"],


### PR DESCRIPTION
Fixes the SBOM metadata that wasn't updated in https://github.com/python/cpython/pull/113249, this is part 1 of #113257 which will automatically update pip SBOM metadata when the wheel is updated.

cc @hugovk 

<!-- gh-issue-number: gh-113257 -->
* Issue: gh-113257
<!-- /gh-issue-number -->
