### PR TITLE
gh-113269: IDLE - Fix test_editor hang (macOS)

### DIFF
--- a/Lib/idlelib/News3.txt
+++ b/Lib/idlelib/News3.txt
@@ -4,6 +4,8 @@ Released on 2024-10-xx
 =========================
 
 
+gh-113269: Fix test_editor hang on macOS Catalina.
+
 gh-112939: Fix processing unsaved files when quitting IDLE on macOS.
 Patch by Ronald Oussoren and Christopher Chavez.
 

--- a/Lib/idlelib/idle_test/test_editor.py
+++ b/Lib/idlelib/idle_test/test_editor.py
@@ -95,7 +95,7 @@ class GetLineIndentTest(unittest.TestCase):
 def insert(text, string):
     text.delete('1.0', 'end')
     text.insert('end', string)
-    text.update()  # Force update for colorizer to finish.
+    text.update_idletasks()  # Force update for colorizer to finish.
 
 
 class IndentAndNewlineTest(unittest.TestCase):

--- a/Misc/NEWS.d/next/IDLE/2023-12-19-00-03-12.gh-issue-113269.lrU-IC.rst
+++ b/Misc/NEWS.d/next/IDLE/2023-12-19-00-03-12.gh-issue-113269.lrU-IC.rst
@@ -1,0 +1,1 @@
+Fix test_editor hang on macOS Catalina.


### PR DESCRIPTION
Hangs on installed 3.13.0a2 on macOS Catalina.
Behavior on installed 3.12.1 and 3.11.7 is unknown.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-113269 -->
* Issue: gh-113269
<!-- /gh-issue-number -->
