### PR TITLE
gh-113255: Clarify docs for `typing.reveal_type`

### DIFF
--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -2615,24 +2615,20 @@ Functions and decorators
    This can be useful when you want to debug how your type checker
    handles a particular piece of code.
 
-   The function returns its argument unchanged, which allows using
-   it within an expression::
-
-      x = reveal_type(1)  # Revealed type is "builtins.int"
-
-   Most type checkers support ``reveal_type()`` anywhere, even if the
-   name is not imported from ``typing``. Importing the name from
-   ``typing`` allows your code to run without runtime errors and
-   communicates intent more clearly.
-
-   At runtime, this function prints the runtime type of its argument to stderr
-   and returns it unchanged::
+   At runtime, this function prints the runtime type of its argument to
+   :data:`sys.stderr` and returns the argument unchanged (allowing the call to
+   be used within an expression)::
 
       x = reveal_type(1)  # prints "Runtime type is int"
       print(x)  # prints "1"
 
    Note that the runtime type may be different from (more or less specific
    than) the type statically inferred by a type checker.
+
+   Most type checkers support ``reveal_type()`` anywhere, even if the
+   name is not imported from ``typing``. Importing the name from
+   ``typing``, however, allows your code to run without runtime errors and
+   communicates intent more clearly.
 
    .. versionadded:: 3.11
 

--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -2604,12 +2604,10 @@ Functions and decorators
 
 .. function:: reveal_type(obj, /)
 
-   Ask a static type checker to reveal the statically inferred type of an
-   expression.
+   Ask a static type checker to reveal the inferred type of an expression.
 
    When a static type checker encounters a call to this function,
-   it emits a diagnostic with the inferred static type of the argument.
-   For example::
+   it emits a diagnostic with the inferred type of the argument. For example::
 
       x: int = 1
       reveal_type(x)  # Revealed type is "builtins.int"

--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -2631,12 +2631,13 @@ Functions and decorators
       x = reveal_type(1)  # prints "Runtime type is int"
       print(x)  # prints "1"
 
-   Note that the runtime type inferred by ``reveal_type()`` can be different
-   from other static type checkers. Static type checkers in some cases will
-   know more (e.g. generic types, like the element types of a list) and in some
-   cases will know less (e.g. a runtime value will never be a union, it will
-   always be one concrete type or the other, but static type systems use union
-   types to represent that at runtime the value may be any of several types.)
+   Note that ``reveal_type()`` at runtime doesn't infer a type in the same way
+   that static type checkers do; it returns the actual type at runtime. Static
+   type checkers in some cases will know more (e.g. generic types, like the
+   element types of a list) and in some cases will know less (e.g. a runtime
+   value will never be a union, it will always be one concrete type or the
+   other, but static type systems use union types to represent that at runtime
+   the value may be any of several types.)
 
    .. versionadded:: 3.11
 

--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -2607,8 +2607,9 @@ Functions and decorators
    Ask a static type checker to reveal the statically inferred type of an
    expression.
 
-   When a static type checker encounters a call to this function, it emits a
-   diagnostic with the inferred static type of the argument. For example::
+   When a static type checker encounters a call to this function,
+   it emits a diagnostic with the inferred static type of the argument.
+   For example::
 
       x: int = 1
       reveal_type(x)  # Revealed type is "builtins.int"

--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -2604,10 +2604,11 @@ Functions and decorators
 
 .. function:: reveal_type(obj, /)
 
-   Reveal the inferred static type of an expression.
+   Ask a static type checker to reveal the statically inferred type of an
+   expression.
 
-   When a static type checker encounters a call to this function,
-   it emits a diagnostic with the type of the argument. For example::
+   When a static type checker encounters a call to this function, it emits a
+   diagnostic with the inferred static type of the argument. For example::
 
       x: int = 1
       reveal_type(x)  # Revealed type is "builtins.int"
@@ -2631,13 +2632,8 @@ Functions and decorators
       x = reveal_type(1)  # prints "Runtime type is int"
       print(x)  # prints "1"
 
-   Note that ``reveal_type()`` at runtime doesn't infer a type in the same way
-   that static type checkers do; it returns the actual type at runtime. Static
-   type checkers in some cases will know more (e.g. generic types, like the
-   element types of a list) and in some cases will know less (e.g. a runtime
-   value will never be a union, it will always be one concrete type or the
-   other, but static type systems use union types to represent that at runtime
-   the value may be any of several types.)
+   Note that the runtime type may be different from (more or less specific
+   than) the type statically inferred by a type checker.
 
    .. versionadded:: 3.11
 

--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -2631,6 +2631,13 @@ Functions and decorators
       x = reveal_type(1)  # prints "Runtime type is int"
       print(x)  # prints "1"
 
+   Note that the runtime type inferred by ``reveal_type()`` can be different
+   from other static type checkers. Static type checkers in some cases will
+   know more (e.g. generic types, like the element types of a list) and in some
+   cases will know less (e.g. a runtime value will never be a union, it will
+   always be one concrete type or the other, but static type systems use union
+   types to represent that at runtime the value may be any of several types.)
+
    .. versionadded:: 3.11
 
 .. decorator:: dataclass_transform(*, eq_default=True, order_default=False, \

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -3301,10 +3301,11 @@ class TextIO(IO[str]):
 
 
 def reveal_type[T](obj: T, /) -> T:
-    """Reveal the inferred type of a variable.
+    """Ask a static type checker to reveal the statically inferred type of an
+    expression.
 
-    When a static type checker encounters a call to ``reveal_type()``,
-    it will emit the inferred type of the argument::
+    When a static type checker encounters a call to this function,
+    it emits a diagnostic with the inferred static type of the argument.
 
         x: int = 1
         reveal_type(x)

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -3303,8 +3303,8 @@ class TextIO(IO[str]):
 def reveal_type[T](obj: T, /) -> T:
     """Ask a static type checker to reveal the inferred type of an expression.
 
-    When a static type checker encounters a call to this function,
-    it emits a diagnostic with the inferred type of the argument.
+    When a static type checker encounters a call to ``reveal_type()``,
+    it will emit the inferred type of the argument::
 
         x: int = 1
         reveal_type(x)
@@ -3313,7 +3313,7 @@ def reveal_type[T](obj: T, /) -> T:
     will produce output similar to 'Revealed type is "builtins.int"'.
 
     At runtime, the function prints the runtime type of the
-    argument and returns it unchanged.
+    argument and returns the argument unchanged.
     """
     print(f"Runtime type is {type(obj).__name__!r}", file=sys.stderr)
     return obj

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -3301,11 +3301,10 @@ class TextIO(IO[str]):
 
 
 def reveal_type[T](obj: T, /) -> T:
-    """Ask a static type checker to reveal the statically inferred type of an
-    expression.
+    """Ask a static type checker to reveal the inferred type of an expression.
 
     When a static type checker encounters a call to this function,
-    it emits a diagnostic with the inferred static type of the argument.
+    it emits a diagnostic with the inferred type of the argument.
 
         x: int = 1
         reveal_type(x)


### PR DESCRIPTION
Why?

The current comment mentioned `reveal_type()` is supported by other type checkers, and with this **we can run without runtime errors**. This may mislead readers the fact that CPython's `reveal_type()` does not necessary to infer the same type as other type checkers (even though runtime is mentioned many times, but it's not obvious). 

Initial proposal

The [comment](https://github.com/python/cpython/issues/113255#issuecomment-1861408323 ) by Carl Meyer resolves this confusion. So I suggest adding the comment (with a bit modification to make it concise) to the doc.

<!-- gh-issue-number: gh-113255 -->
* Issue: gh-113255
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--113286.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->