### PR TITLE
Docs: make htmllive: open browser when ready

### DIFF
--- a/Doc/Makefile
+++ b/Doc/Makefile
@@ -19,8 +19,12 @@ SPHINXERRORHANDLING = -W
 PAPEROPT_a4     = -D latex_elements.papersize=a4paper
 PAPEROPT_letter = -D latex_elements.papersize=letterpaper
 
-ALLSPHINXOPTS = -b $(BUILDER) -d build/doctrees $(PAPEROPT_$(PAPER)) -j $(JOBS) \
-                $(SPHINXOPTS) $(SPHINXERRORHANDLING) . build/$(BUILDER) $(SOURCES)
+ALLSPHINXOPTS = -b $(BUILDER) \
+                -d build/doctrees \
+                -j $(JOBS) \
+                $(PAPEROPT_$(PAPER)) \
+                $(SPHINXOPTS) $(SPHINXERRORHANDLING) \
+                . build/$(BUILDER) $(SOURCES)
 
 .PHONY: help
 help:
@@ -142,7 +146,7 @@ htmlview: html
 
 .PHONY: htmllive
 htmllive: SPHINXBUILD = $(VENVDIR)/bin/sphinx-autobuild
-htmllive: SPHINXOPTS = --re-ignore="/venv/"
+htmllive: SPHINXOPTS = --re-ignore="/venv/" --open-browser --delay 0
 htmllive: html
 
 .PHONY: clean


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

Like https://github.com/python/peps/pull/3558 and https://github.com/python/devguide/pull/1233.

When running `make -C Docs htmllive`, this will open the browser when the docs have been built the first time. 

It means you don't need to hunt around for the link in:

```console
❯ make -C Doc htmllive
mkdir -p build
Building NEWS from Misc/NEWS.d with blurb
./venv/bin/sphinx-autobuild -b html -d build/doctrees -j auto  --re-ignore="/venv/" --open-browser --delay 0 -W . build/html
[sphinx-autobuild] > sphinx-build -b html -d build/doctrees -j auto -W /Users/hugo/github/python/cpython/main/Doc /Users/hugo/github/python/cpython/main/Doc/build/html
Running Sphinx v6.2.1
loading pickled environment... done
building [mo]: targets for 0 po files that are out of date
writing output...
building [html]: targets for 463 source files that are out of date
updating environment: 0 added, 4 changed, 0 removed
reading sources... [100%] whatsnew/changelog
looking for now-outdated files... none found
pickling environment... done
checking consistency... done
preparing documents... done
writing output... [100%] whatsnew/2.2 .. whatsnew/index
generating indices... genindex py-modindex done
writing additional pages... download index search opensearch done
copying images... [100%] using/win_installer.png
copying downloadable files... [100%] includes/tzinfo_examples.py
copying static files... done
copying extra files... done
dumping search index in English (code: en)... done
dumping object inventory... done
Writing glossary.json
build succeeded.

The HTML pages are in build/html.
[I 231219 15:20:27 server:335] Serving on http://127.0.0.1:8000
[I 231219 15:20:27 handlers:62] Start watching changes
[I 231219 15:20:27 handlers:64] Start detecting changes
[I 231219 15:20:28 handlers:135] Browser Connected: http://127.0.0.1:8000/
```

Also make `ALLSPHINXOPTS` multiline to match https://github.com/python/devguide/blob/78fc0d7aa9fd0d6733d10c23b178b2a0e2799afc/Makefile#L18-L23 and https://github.com/python/peps/blob/9779c7efe63ab8dbb8bb673c5346c35505d97065/Makefile#L14-L17 to make it much easier to compare and maintain them.

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--113288.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->