### PR TITLE
gh-101100: Fix Sphinx warnings in `library/ast.rst`

### DIFF
--- a/Doc/library/ast.rst
+++ b/Doc/library/ast.rst
@@ -1935,7 +1935,7 @@ Function and class definitions
 .. class:: arg(arg, annotation, type_comment)
 
    A single argument in a list. ``arg`` is a raw string of the argument
-   name, ``annotation`` is its annotation, such as a :class:`Name` node.
+   name; ``annotation`` is its annotation, such as a :class:`Name` node.
 
    .. attribute:: type_comment
 

--- a/Doc/library/ast.rst
+++ b/Doc/library/ast.rst
@@ -45,7 +45,7 @@ Node classes
 
    This is the base of all AST node classes.  The actual node classes are
    derived from the :file:`Parser/Python.asdl` file, which is reproduced
-   :ref:`above <abstract-grammar>`.  They are defined in the :mod:`_ast` C
+   :ref:`above <abstract-grammar>`.  They are defined in the :mod:`!_ast` C
    module and re-exported in :mod:`ast`.
 
    There is one class defined for each left-hand side symbol in the abstract
@@ -128,14 +128,14 @@ Node classes
 
 .. deprecated:: 3.8
 
-   Old classes :class:`ast.Num`, :class:`ast.Str`, :class:`ast.Bytes`,
-   :class:`ast.NameConstant` and :class:`ast.Ellipsis` are still available,
+   Old classes :class:`!ast.Num`, :class:`!ast.Str`, :class:`!ast.Bytes`,
+   :class:`!ast.NameConstant` and :class:`!ast.Ellipsis` are still available,
    but they will be removed in future Python releases.  In the meantime,
    instantiating them will return an instance of a different class.
 
 .. deprecated:: 3.9
 
-   Old classes :class:`ast.Index` and :class:`ast.ExtSlice` are still
+   Old classes :class:`!ast.Index` and :class:`!ast.ExtSlice` are still
    available, but they will be removed in future Python releases.
    In the meantime, instantiating them will return an instance of
    a different class.
@@ -1935,8 +1935,7 @@ Function and class definitions
 .. class:: arg(arg, annotation, type_comment)
 
    A single argument in a list. ``arg`` is a raw string of the argument
-   name, ``annotation`` is its annotation, such as a :class:`Str` or
-   :class:`Name` node.
+   name, ``annotation`` is its annotation, such as a :class:`Name` node.
 
    .. attribute:: type_comment
 
@@ -2210,7 +2209,7 @@ and classes for traversing abstract syntax trees:
       Added ``type_comments``, ``mode='func_type'`` and ``feature_version``.
 
    .. versionchanged:: 3.13
-      The minimum supported version for feature_version is now (3,7)
+      The minimum supported version for ``feature_version`` is now ``(3, 7)``.
       The ``optimize`` argument was added.
 
 
@@ -2286,8 +2285,8 @@ and classes for traversing abstract syntax trees:
 .. function:: get_source_segment(source, node, *, padded=False)
 
    Get source code segment of the *source* that generated *node*.
-   If some location information (:attr:`lineno`, :attr:`end_lineno`,
-   :attr:`col_offset`, or :attr:`end_col_offset`) is missing, return ``None``.
+   If some location information (:attr:`~ast.AST.lineno`, :attr:`~ast.AST.end_lineno`,
+   :attr:`~ast.AST.col_offset`, or :attr:`~ast.AST.end_col_offset`) is missing, return ``None``.
 
    If *padded* is ``True``, the first line of a multi-line statement will
    be padded with spaces to match its original position.
@@ -2298,7 +2297,7 @@ and classes for traversing abstract syntax trees:
 .. function:: fix_missing_locations(node)
 
    When you compile a node tree with :func:`compile`, the compiler expects
-   :attr:`lineno` and :attr:`col_offset` attributes for every node that supports
+   :attr:`~ast.AST.lineno` and :attr:`~ast.AST.col_offset` attributes for every node that supports
    them.  This is rather tedious to fill in for generated nodes, so this helper
    adds these attributes recursively where not already set, by setting them to
    the values of the parent node.  It works recursively starting at *node*.
@@ -2313,8 +2312,8 @@ and classes for traversing abstract syntax trees:
 
 .. function:: copy_location(new_node, old_node)
 
-   Copy source location (:attr:`lineno`, :attr:`col_offset`, :attr:`end_lineno`,
-   and :attr:`end_col_offset`) from *old_node* to *new_node* if possible,
+   Copy source location (:attr:`~ast.AST.lineno`, :attr:`~ast.AST.col_offset`, :attr:`~ast.AST.end_lineno`,
+   and :attr:`~ast.AST.end_col_offset`) from *old_node* to *new_node* if possible,
    and return *new_node*.
 
 
@@ -2360,14 +2359,18 @@ and classes for traversing abstract syntax trees:
       visited unless the visitor calls :meth:`generic_visit` or visits them
       itself.
 
+   .. method:: visit_Constant(node)
+
+      Handles all constant nodes.
+
    Don't use the :class:`NodeVisitor` if you want to apply changes to nodes
    during traversal.  For this a special visitor exists
    (:class:`NodeTransformer`) that allows modifications.
 
    .. deprecated:: 3.8
 
-      Methods :meth:`visit_Num`, :meth:`visit_Str`, :meth:`visit_Bytes`,
-      :meth:`visit_NameConstant` and :meth:`visit_Ellipsis` are deprecated
+      Methods :meth:`!visit_Num`, :meth:`!visit_Str`, :meth:`!visit_Bytes`,
+      :meth:`!visit_NameConstant` and :meth:`!visit_Ellipsis` are deprecated
       now and will not be called in future Python versions.  Add the
       :meth:`visit_Constant` method to handle all constant nodes.
 
@@ -2396,7 +2399,7 @@ and classes for traversing abstract syntax trees:
               )
 
    Keep in mind that if the node you're operating on has child nodes you must
-   either transform the child nodes yourself or call the :meth:`generic_visit`
+   either transform the child nodes yourself or call the :meth:`~ast.NodeVisitor.generic_visit`
    method for the node first.
 
    For nodes that were part of a collection of statements (that applies to all
@@ -2405,7 +2408,7 @@ and classes for traversing abstract syntax trees:
 
    If :class:`NodeTransformer` introduces new nodes (that weren't part of
    original tree) without giving them location information (such as
-   :attr:`lineno`), :func:`fix_missing_locations` should be called with
+   :attr:`~ast.AST.lineno`), :func:`fix_missing_locations` should be called with
    the new sub-tree to recalculate the location information::
 
       tree = ast.parse('foo', mode='eval')

--- a/Misc/NEWS.d/3.9.0a1.rst
+++ b/Misc/NEWS.d/3.9.0a1.rst
@@ -2069,7 +2069,7 @@ Restores instantiation of Windows IOCP event loops from the non-main thread.
 .. section: Library
 
 Add default implementation of the :meth:`ast.NodeVisitor.visit_Constant`
-method which emits a deprecation warning and calls corresponding methody
+method which emits a deprecation warning and calls corresponding methods
 ``visit_Num()``, ``visit_Str()``, etc.
 
 ..


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


Fix 29 Sphinx warnings:

```
Doc/library/ast.rst:46: WARNING: py:mod reference target not found: _ast
Doc/library/ast.rst:131: WARNING: py:class reference target not found: ast.Num
Doc/library/ast.rst:131: WARNING: py:class reference target not found: ast.Str
Doc/library/ast.rst:131: WARNING: py:class reference target not found: ast.Bytes
Doc/library/ast.rst:131: WARNING: py:class reference target not found: ast.NameConstant
Doc/library/ast.rst:131: WARNING: py:class reference target not found: ast.Ellipsis
Doc/library/ast.rst:138: WARNING: py:class reference target not found: ast.Index
Doc/library/ast.rst:138: WARNING: py:class reference target not found: ast.ExtSlice
Doc/library/ast.rst:1937: WARNING: py:class reference target not found: Str
Doc/library/ast.rst:2288: WARNING: py:attr reference target not found: lineno
Doc/library/ast.rst:2288: WARNING: py:attr reference target not found: end_lineno
Doc/library/ast.rst:2288: WARNING: py:attr reference target not found: col_offset
Doc/library/ast.rst:2288: WARNING: py:attr reference target not found: end_col_offset
Doc/library/ast.rst:2300: WARNING: py:attr reference target not found: lineno
Doc/library/ast.rst:2300: WARNING: py:attr reference target not found: col_offset
Doc/library/ast.rst:2316: WARNING: py:attr reference target not found: lineno
Doc/library/ast.rst:2316: WARNING: py:attr reference target not found: col_offset
Doc/library/ast.rst:2316: WARNING: py:attr reference target not found: end_lineno
Doc/library/ast.rst:2316: WARNING: py:attr reference target not found: end_col_offset
Doc/library/ast.rst:2369: WARNING: py:meth reference target not found: visit_Num
Doc/library/ast.rst:2369: WARNING: py:meth reference target not found: visit_Str
Doc/library/ast.rst:2369: WARNING: py:meth reference target not found: visit_Bytes
Doc/library/ast.rst:2369: WARNING: py:meth reference target not found: visit_NameConstant
Doc/library/ast.rst:2369: WARNING: py:meth reference target not found: visit_Ellipsis
Doc/library/ast.rst:2369: WARNING: py:meth reference target not found: visit_Constant
Doc/library/ast.rst:2398: WARNING: py:meth reference target not found: generic_visit
Doc/library/ast.rst:2406: WARNING: py:attr reference target not found: lineno
Doc/whatsnew/3.8.rst:1673: WARNING: py:meth reference target not found: ast.NodeVisitor.visit_Constant
build/NEWS:21687: WARNING: py:meth reference target not found: ast.NodeVisitor.visit_Constant
```

These 14 remain:

```
Doc/library/ast.rst:51: WARNING: py:class reference target not found: ast.stmt
Doc/library/ast.rst:51: WARNING: py:class reference target not found: ast.expr
Doc/library/ast.rst:51: WARNING: py:class reference target not found: ast.expr
Doc/library/ast.rst:67: WARNING: py:attr reference target not found: left
Doc/library/ast.rst:67: WARNING: py:class reference target not found: ast.expr
Doc/library/ast.rst:82: WARNING: py:class reference target not found: ast.expr
Doc/library/ast.rst:82: WARNING: py:class reference target not found: ast.stmt
Doc/library/ast.rst:96: WARNING: py:class reference target not found: ast.T
Doc/library/ast.rst:98: WARNING: py:attr reference target not found: T._fields
Doc/library/ast.rst:2149: WARNING: py:class reference target not found: ast.operator
Doc/library/ast.rst:2149: WARNING: py:class reference target not found: ast.unaryop
Doc/library/ast.rst:2149: WARNING: py:class reference target not found: ast.cmpop
Doc/library/ast.rst:2149: WARNING: py:class reference target not found: ast.boolop
Doc/library/ast.rst:2149: WARNING: py:class reference target not found: ast.expr_context
```


<!-- gh-issue-number: gh-101100 -->
* Issue: gh-101100
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--113289.org.readthedocs.build/library/ast.html

<!-- readthedocs-preview cpython-previews end -->