### PR TITLE
GH-110109: Drop use of new regex features in `pathlib._abc`.

### DIFF
--- a/Lib/pathlib/_abc.py
+++ b/Lib/pathlib/_abc.py
@@ -61,7 +61,7 @@ def _compile_pattern(pat, sep, case_sensitive):
     if re is None:
         import re, glob
 
-    flags = re.NOFLAG if case_sensitive else re.IGNORECASE
+    flags = 0 if case_sensitive else re.IGNORECASE
     regex = glob.translate(pat, recursive=True, include_hidden=True, seps=sep)
     return re.compile(regex, flags=flags).match
 


### PR DESCRIPTION
A regex group with a `?+` possessive quantifier was used to match empty paths, which were represented as a single dot, preventing the dot from being matched by other wildcards. This quantifier is only available from Python 3.11+, but pathlib's `_abc.py` file will be made available as a PyPI package for Python 3.8+.

This commit adds a new private `_pattern_str` property that works like `__str__()` but represents empty paths as `''` rather than `'.'`. This string is used for pattern matching, which removes the need for the possessive group. We also replace `re.NOFLAG` with `0`, again for backwards-compatibility with older Python.

Improves compatibility with older Python; no other change of behaviour.

See external `pathlib_abc` issue: https://github.com/barneygale/pathlib_abc/issues/8


<!-- gh-issue-number: gh-110109 -->
* Issue: gh-110109
<!-- /gh-issue-number -->
