### PR TITLE
Docs: OpenSSL wording ambiguity

### DIFF
--- a/Doc/library/ssl.rst
+++ b/Doc/library/ssl.rst
@@ -25,7 +25,7 @@ probably additional platforms, as long as OpenSSL is installed on that platform.
 
    Some behavior may be platform dependent, since calls are made to the
    operating system socket APIs.  The installed version of OpenSSL may also
-   cause variations in behavior. For example, TLSv1.3 with OpenSSL version
+   cause variations in behavior. For example, TLSv1.3 comes with OpenSSL version
    1.1.1.
 
 .. warning::


### PR DESCRIPTION
Trivial wording improvement. Before [`2875c60`](https://github.com/python/cpython/commit/2875c603b2a7691b55c2046aca54831c91efda8e#diff-df0c7115ade453321aadb2eb534941f2ec87c4b52563bae70421918dce5435dc) there was "… comes with…" that I'd suggest having back.

Currently the sentence reads as there are some issues with the combination of TLS v1.3 and OpenSSL 1.1.1 as an example, as noted with behavior variations the sentence before.

Maybe it's just puzzling for non-english-speaking reader(?) so feel free to disregard this if it feels right as-is. This is only an attempt to make the message crystal clear.

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--113296.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->