### PR TITLE
Fix typo in datamodel docs

### DIFF
--- a/Doc/reference/datamodel.rst
+++ b/Doc/reference/datamodel.rst
@@ -2811,7 +2811,7 @@ through the object's keys; for sequences, it should iterate through the values.
    the accepted keys should be integers and slice objects.  Note that the
    special interpretation of negative indexes (if the class wishes to emulate a
    :term:`sequence` type) is up to the :meth:`__getitem__` method. If *key* is
-   of an inappropriate type, :exc:`TypeError` may be raised; if a value
+   of an inappropriate type, :exc:`TypeError` may be raised; if *key* is a value
    outside the set of indexes for the sequence (after any special
    interpretation of negative values), :exc:`IndexError` should be raised. For
    :term:`mapping` types, if *key* is missing (not in the container),

--- a/Doc/reference/datamodel.rst
+++ b/Doc/reference/datamodel.rst
@@ -2811,7 +2811,7 @@ through the object's keys; for sequences, it should iterate through the values.
    the accepted keys should be integers and slice objects.  Note that the
    special interpretation of negative indexes (if the class wishes to emulate a
    :term:`sequence` type) is up to the :meth:`__getitem__` method. If *key* is
-   of an inappropriate type, :exc:`TypeError` may be raised; if of a value
+   of an inappropriate type, :exc:`TypeError` may be raised; if a value
    outside the set of indexes for the sequence (after any special
    interpretation of negative values), :exc:`IndexError` should be raised. For
    :term:`mapping` types, if *key* is missing (not in the container),


### PR DESCRIPTION
This removes an extra word from a sentence in the [docs about `__getitem__`](https://docs.python.org/3/reference/datamodel.html#object.__getitem__).

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--113314.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->