### PR TITLE
GH-111485: Fix DEFAULT_OUTPUT in opcode_metadata_generator.py

### DIFF
--- a/Tools/cases_generator/opcode_metadata_generator.py
+++ b/Tools/cases_generator/opcode_metadata_generator.py
@@ -366,7 +366,7 @@ arg_parser = argparse.ArgumentParser(
 )
 
 
-DEFAULT_OUTPUT = ROOT / "Include/internal/pycore_uop_metadata.h"
+DEFAULT_OUTPUT = ROOT / "Include/internal/pycore_opcode_metadata.h"
 
 
 arg_parser.add_argument(


### PR DESCRIPTION
The default was accidentally copied from another file.

<!-- gh-issue-number: gh-111485 -->
* Issue: gh-111485
<!-- /gh-issue-number -->
