### PR TITLE
gh-113297: Fix segfault in compiler for with statement with 19 context managers

### DIFF
--- a/Lib/test/test_syntax.py
+++ b/Lib/test/test_syntax.py
@@ -2017,6 +2017,7 @@ Invalid expressions in type scopes:
 
 import re
 import doctest
+import textwrap
 import unittest
 
 from test import support
@@ -2278,6 +2279,28 @@ if x:
             code += f"{'    '*i}except Exception as e:\n"
         code += f"{' '*4*12}pass"
         self._check_error(code, "too many statically nested blocks")
+
+    @support.cpython_only
+    def test_with_statement_many_context_managers(self):
+        # See gh-113297
+        def get_code(n):
+            code = textwrap.dedent("""
+                def bug():
+                    with (
+                    a
+                """)
+            for i in range(n):
+                code += f"    as a{i}, a\n"
+            code += "): yield a"
+            return code
+
+        for n in range(19):
+            with self.subTest(f"within range: {n=}"):
+                compile(get_code(n), "<string>", "exec")
+
+        for n in range(20, 25):
+            with self.subTest(f"out of range: {n=}"):
+                self._check_error(get_code(n), "too many statically nested blocks")
 
     def test_barry_as_flufl_with_syntax_errors(self):
         # The "barry_as_flufl" rule can produce some "bugs-at-a-distance" if

--- a/Lib/test/test_syntax.py
+++ b/Lib/test/test_syntax.py
@@ -2283,6 +2283,7 @@ if x:
     @support.cpython_only
     def test_with_statement_many_context_managers(self):
         # See gh-113297
+
         def get_code(n):
             code = textwrap.dedent("""
                 def bug():
@@ -2294,11 +2295,13 @@ if x:
             code += "): yield a"
             return code
 
-        for n in range(19):
+        CO_MAXBLOCKS = 20  # static nesting limit of the compiler
+
+        for n in range(CO_MAXBLOCKS):
             with self.subTest(f"within range: {n=}"):
                 compile(get_code(n), "<string>", "exec")
 
-        for n in range(20, 25):
+        for n in range(CO_MAXBLOCKS, CO_MAXBLOCKS + 5):
             with self.subTest(f"out of range: {n=}"):
                 self._check_error(get_code(n), "too many statically nested blocks")
 

--- a/Misc/NEWS.d/next/Core and Builtins/2023-12-20-18-27-11.gh-issue-113297.BZyAI_.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2023-12-20-18-27-11.gh-issue-113297.BZyAI_.rst
@@ -1,0 +1,1 @@
+Fix segfault in the compiler on with statement with 19 context managers.

--- a/Python/flowgraph.c
+++ b/Python/flowgraph.c
@@ -648,7 +648,7 @@ mark_except_handlers(basicblock *entryblock) {
 
 
 struct _PyCfgExceptStack {
-    basicblock *handlers[CO_MAXBLOCKS+1];
+    basicblock *handlers[CO_MAXBLOCKS+2];
     int depth;
 };
 
@@ -661,6 +661,7 @@ push_except_block(struct _PyCfgExceptStack *stack, cfg_instr *setup) {
     if (opcode == SETUP_WITH || opcode == SETUP_CLEANUP) {
         target->b_preserve_lasti = 1;
     }
+    assert(stack->depth <= CO_MAXBLOCKS);
     stack->handlers[++stack->depth] = target;
     return target;
 }


### PR DESCRIPTION
Fixes #113297.

<!-- gh-issue-number: gh-113297 -->
* Issue: gh-113297
<!-- /gh-issue-number -->
