### PR TITLE
gh-113330: Fix mimalloc headers reference

### DIFF
--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -1791,7 +1791,7 @@ PYTHON_HEADERS= \
 		$(srcdir)/Include/cpython/warnings.h \
 		$(srcdir)/Include/cpython/weakrefobject.h \
 		\
-		@MIMALLOC_HEADERS@ \
+		$(MIMALLOC_HEADERS) \
 		\
 		$(srcdir)/Include/internal/pycore_abstract.h \
 		$(srcdir)/Include/internal/pycore_asdl.h \


### PR DESCRIPTION
The `MIMALLOC_HEADERS` variable is defined in the Makefile.pre.in, not the configure script, so we should use the `$(MIMALLOC_HEADERS)` syntax instead of the `@MIMALLOC_HEADERS@` syntax.


<!-- gh-issue-number: gh-113330 -->
* Issue: gh-113330
<!-- /gh-issue-number -->
