### PR TITLE
gh-113343: Fix error check on mmap(2)

### DIFF
--- a/Python/perf_trampoline.c
+++ b/Python/perf_trampoline.c
@@ -247,7 +247,7 @@ new_code_arena(void)
              mem_size, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS,
              -1,  // fd (not used here)
              0);  // offset (not used here)
-    if (!memory) {
+    if (memory == MAP_FAILED) {
         PyErr_SetFromErrno(PyExc_OSError);
         PyErr_FormatUnraisable("Failed to create new mmap for perf trampoline");
         perf_status = PERF_STATUS_FAILED;


### PR DESCRIPTION
According to the [man page](https://man7.org/linux/man-pages/man2/mmap.2.html#RETURN_VALUE), mmap(2) returns MAP_FAILED (-1) on error instead of NULL.

<!-- gh-issue-number: gh-113343 -->
* Issue: gh-113343
<!-- /gh-issue-number -->
