### PR TITLE
gh-112305: Fix check-clean-src to detect frozen_modules .h files.

### DIFF
--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -657,11 +657,12 @@ check-clean-src:
 	@if test -n "$(VPATH)" -a \( \
 	    -f "$(srcdir)/$(BUILDPYTHON)" \
 	    -o -f "$(srcdir)/Programs/python.o" \
-	    -o -f "$(srcdir)\Python/frozen_modules/importlib._bootstrap.h" \
+	    -o -f "$(srcdir)/Python/frozen_modules/importlib._bootstrap.h" \
 	\); then \
 		echo "Error: The source directory ($(srcdir)) is not clean" ; \
 		echo "Building Python out of the source tree (in $(abs_builddir)) requires a clean source tree ($(abs_srcdir))" ; \
-		echo "Try to run: make -C \"$(srcdir)\" clean" ; \
+		echo "Build artifacts such as .o files, executables, and Python/frozen_modules/*.h must not exist within $(srcdir)." ; \
+		echo "Try to run:  make -C \"$(srcdir)\" clean || (cd \"$(srcdir)\" && git clean -fdx)" ; \
 		exit 1; \
 	fi
 

--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -662,7 +662,8 @@ check-clean-src:
 		echo "Error: The source directory ($(srcdir)) is not clean" ; \
 		echo "Building Python out of the source tree (in $(abs_builddir)) requires a clean source tree ($(abs_srcdir))" ; \
 		echo "Build artifacts such as .o files, executables, and Python/frozen_modules/*.h must not exist within $(srcdir)." ; \
-		echo "Try to run:  make -C \"$(srcdir)\" clean || (cd \"$(srcdir)\" && git clean -fdx)" ; \
+		echo "Try to run:" ; \
+		echo "  (cd \"$(srcdir)\" && make clean || git clean -fdx -e Doc/venv)" ; \
 		exit 1; \
 	fi
 

--- a/Misc/NEWS.d/next/Build/2023-12-21-05-35-06.gh-issue-112305.VfqQPx.rst
+++ b/Misc/NEWS.d/next/Build/2023-12-21-05-35-06.gh-issue-112305.VfqQPx.rst
@@ -1,0 +1,3 @@
+Fixed the ``check-clean-src`` step performed on out of tree builds to detect
+errant ``$(srcdir)/Python/frozen_modules/*.h`` files and recommend
+appropriate source tree cleanup steps to get a working build again.


### PR DESCRIPTION
A typo left this check broken so many of us who do out-of-tree builds were seeing strange failures due to bad `Python/frozen_modules/*.h` files being picked up from the source tree and used at build time from different Python versions leading to errors like:

`Fatal Python error: _PyImport_InitCore: failed to initialize importlib`

Or similar once our build got to an "invoke the interpreter" bootstrapping step due to incorrect bytecode being embedded.

<!-- gh-issue-number: gh-112305 -->
* Issue: gh-112305
<!-- /gh-issue-number -->
