### PR TITLE
gh-65701: document that freeze doesn't work with framework builds on macOS

### DIFF
--- a/Misc/NEWS.d/next/macOS/2023-12-21-10-20-41.gh-issue-65701.Q2hNbN.rst
+++ b/Misc/NEWS.d/next/macOS/2023-12-21-10-20-41.gh-issue-65701.Q2hNbN.rst
@@ -1,2 +1,2 @@
-The freeze tool doesn't work with framework builds of Python. Document this
-and bail out early when running the tool with such a build.
+The :program:`freeze` tool doesn't work with framework builds of Python.
+Document this and bail out early when running the tool with such a build.

--- a/Misc/NEWS.d/next/macOS/2023-12-21-10-20-41.gh-issue-65701.Q2hNbN.rst
+++ b/Misc/NEWS.d/next/macOS/2023-12-21-10-20-41.gh-issue-65701.Q2hNbN.rst
@@ -1,0 +1,2 @@
+The freeze tool doesn't work with framework builds of Python. Document this
+and bail out early when running the tool with such a build.

--- a/Tools/freeze/README
+++ b/Tools/freeze/README
@@ -218,6 +218,11 @@ source tree).
 It is possible to create frozen programs that don't have a console
 window, by specifying the option '-s windows'. See the Usage below.
 
+Usage under macOS
+-----------------
+
+On macOS the freeze tool is not supported for framework builds.
+
 Usage
 -----
 

--- a/Tools/freeze/README
+++ b/Tools/freeze/README
@@ -221,7 +221,7 @@ window, by specifying the option '-s windows'. See the Usage below.
 Usage under macOS
 -----------------
 
-On macOS the freeze tool is not supported for framework builds.
+On macOS the :program:`freeze` tool is not supported for framework builds.
 
 Usage
 -----

--- a/Tools/freeze/README
+++ b/Tools/freeze/README
@@ -221,7 +221,7 @@ window, by specifying the option '-s windows'. See the Usage below.
 Usage under macOS
 -----------------
 
-On macOS the :program:`freeze` tool is not supported for framework builds.
+On macOS the freeze tool is not supported for framework builds.
 
 Usage
 -----

--- a/Tools/freeze/freeze.py
+++ b/Tools/freeze/freeze.py
@@ -136,6 +136,11 @@ def main():
     makefile = 'Makefile'
     subsystem = 'console'
 
+    if sys.platform == "darwin" and sysconfig.get_config_var("PYTHONFRAMEWORK"):
+        print(f"{sys.argv[0]} cannot be used with framework builds of Python", file=sys.stderr)
+        sys.exit(1)
+
+
     # parse command line by first replacing any "-i" options with the
     # file contents.
     pos = 1


### PR DESCRIPTION
The framework install is inherently incompatible with freeze. Document that that freeze doesn't work with framework builds and bail out early when trying to run freeze anyway.


<!-- gh-issue-number: gh-65701 -->
* Issue: gh-65701
<!-- /gh-issue-number -->
