### PR TITLE
gh-110383: Fix docstring for str.rsplit maxsplit param to 'starting from the right'

### DIFF
--- a/Objects/clinic/unicodeobject.c.h
+++ b/Objects/clinic/unicodeobject.c.h
@@ -1078,7 +1078,7 @@ PyDoc_STRVAR(unicode_rsplit__doc__,
 "    character (including \\n \\r \\t \\f and spaces) and will discard\n"
 "    empty strings from the result.\n"
 "  maxsplit\n"
-"    Maximum number of splits (starting from the left).\n"
+"    Maximum number of splits (starting from the right).\n"
 "    -1 (the default value) means no limit.\n"
 "\n"
 "Splitting starts at the end of the string and works to the front.");
@@ -1505,4 +1505,4 @@ skip_optional_pos:
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=873d8b3d09af3095 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=392a9ebd2077f89d input=a9049054013a1b77]*/

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -12686,7 +12686,17 @@ PyUnicode_RSplit(PyObject *s, PyObject *sep, Py_ssize_t maxsplit)
 }
 
 /*[clinic input]
-str.rsplit as unicode_rsplit = str.split
+str.rsplit as unicode_rsplit
+
+    sep: object = None
+        The separator used to split the string.
+
+        When set to None (the default value), will split on any whitespace
+        character (including \n \r \t \f and spaces) and will discard
+        empty strings from the result.
+    maxsplit: Py_ssize_t = -1
+        Maximum number of splits (starting from the right).
+        -1 (the default value) means no limit.
 
 Return a list of the substrings in the string, using sep as the separator string.
 

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -12705,7 +12705,7 @@ Splitting starts at the end of the string and works to the front.
 
 static PyObject *
 unicode_rsplit_impl(PyObject *self, PyObject *sep, Py_ssize_t maxsplit)
-/*[clinic end generated code: output=c2b815c63bcabffc input=ea78406060fce33c]*/
+/*[clinic end generated code: output=c2b815c63bcabffc input=e58ee898aeab2b5e]*/
 {
     if (sep == Py_None)
         return rsplit(self, NULL, maxsplit);


### PR DESCRIPTION
Previously the parameters including their docstrings were cloned from `str.split` but that says 'starting from the left' which is not correct for `str.rsplit`.

It is not possible to partially clone or modify according to: https://devguide.python.org/development-tools/clinic/#how-to-clone-existing-functions so copy from `split` and modify as necessary.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

This follows on from https://github.com/python/cpython/pull/111247 hopefully addressing the feedback there.

<!-- gh-issue-number: gh-110383 -->
* Issue: gh-110383
<!-- /gh-issue-number -->
