### PR TITLE
gh-74573: document that ndbm can silently corrupt databases on macOS

### DIFF
--- a/Doc/library/dbm.rst
+++ b/Doc/library/dbm.rst
@@ -272,9 +272,9 @@ This module can be used with the "classic" ndbm interface or the GNU GDBM
 compatibility interface. On Unix, the :program:`configure` script will attempt
 to locate the appropriate header file to simplify building this module.
 
-.. warning:: 
+.. warning::
 
-   The ndbm library shipped as part of macOS has an undocumented limitation on the 
+   The ndbm library shipped as part of macOS has an undocumented limitation on the
    size of values, which can result in corrupted database files
    when storing values larger than this limit. Reading such corrupted files can
    result in a hard crash (segmentation fault).

--- a/Doc/library/dbm.rst
+++ b/Doc/library/dbm.rst
@@ -272,6 +272,13 @@ This module can be used with the "classic" ndbm interface or the GNU GDBM
 compatibility interface. On Unix, the :program:`configure` script will attempt
 to locate the appropriate header file to simplify building this module.
 
+.. warning:: 
+
+   The ndbm library shipped as part of macOS has an undocumented limitation on the 
+   size of values, which can result in corrupted database files
+   when storing values larger than this limit. Reading such corrupted files can
+   result in a hard crash (segmentation fault).
+
 .. exception:: error
 
    Raised on :mod:`dbm.ndbm`-specific errors, such as I/O errors. :exc:`KeyError` is raised

--- a/Doc/library/shelve.rst
+++ b/Doc/library/shelve.rst
@@ -113,6 +113,9 @@ Restrictions
   differs across Unix versions and requires knowledge about the database
   implementation used.
 
+* On macOS :mod:`dbm.ndbm` can silently corrupt the database file on updates,
+  which can cause hard crashes when trying to read from the database.
+
 
 .. class:: Shelf(dict, protocol=None, writeback=False, keyencoding='utf-8')
 

--- a/Misc/NEWS.d/next/macOS/2023-12-21-11-53-47.gh-issue-74573.MA6Vys.rst
+++ b/Misc/NEWS.d/next/macOS/2023-12-21-11-53-47.gh-issue-74573.MA6Vys.rst
@@ -1,0 +1,3 @@
+Document that :mod:`dbm.ndbm` can silently corrupt DBM files on updates when
+exceeding undocumented platform limits, and can crash (segmentation fault)
+when reading such a corrupted file. (FB8919203)


### PR DESCRIPTION
The system ndbm implementation on macOS has an undocumented limitation on the size of values and can silently corrupt database files when those are exceeded.

<!-- gh-issue-number: gh-74573 -->
* Issue: gh-74573
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--113354.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->