### PR TITLE
gh-113356: Ignore errors in "._ABC.pth"

### DIFF
--- a/Lib/site.py
+++ b/Lib/site.py
@@ -176,7 +176,7 @@ def addpackage(sitedir, name, known_paths):
     except OSError:
         return
     with f:
-        if name.startswith*("._"):
+        if name.startswith("._"):
             try:
                 f.readline()
                 f.seek(0)

--- a/Lib/site.py
+++ b/Lib/site.py
@@ -176,19 +176,20 @@ def addpackage(sitedir, name, known_paths):
     except OSError:
         return
     with f:
-        try:
-            f.readline()
-            f.seek(0)
-        except UnicodeDecodeError:
-            # MacOS can create files with a "._" prefix in the name
-            # next to the regular file when the system needs to store
-            # metadata (such as extended attributes) that the filesystem
-            # cannot store natively.
-            #
-            # Ignore errors when trying to parse these files.
-            if name.startswith("._") and os.path.exists(os.path.join(sitedir, name[2:])):
-                return
-            raise
+        if name.startswith*("._"):
+            try:
+                f.readline()
+                f.seek(0)
+            except UnicodeDecodeError:
+                # MacOS can create files with a "._" prefix in the name
+                # next to the regular file when the system needs to store
+                # metadata (such as extended attributes) that the filesystem
+                # cannot store natively.
+                #
+                # Ignore errors when trying to parse these files.
+                if os.path.exists(os.path.join(sitedir, name[2:])):
+                    return
+                raise
 
         for n, line in enumerate(f):
             if line.startswith("#"):

--- a/Lib/site.py
+++ b/Lib/site.py
@@ -177,19 +177,16 @@ def addpackage(sitedir, name, known_paths):
         return
     with f:
         if name.startswith("._"):
-            try:
-                f.readline()
-                f.seek(0)
-            except UnicodeDecodeError:
-                # MacOS can create files with a "._" prefix in the name
-                # next to the regular file when the system needs to store
-                # metadata (such as extended attributes) that the filesystem
-                # cannot store natively.
-                #
-                # Ignore errors when trying to parse these files.
-                if os.path.exists(os.path.join(sitedir, name[2:])):
+            # MacOS will create "._" files next to a regular file
+            # when a filesystem driver needs to store metadata that
+            # cannot be stored natively. Such files are encoded
+            # in AppleDouble format.
+            # The test looks for the magic marker at the start of such
+            # files.
+            if f.buffer.read(4) == b"\x00\x05\x16\x07" \
+               and os.path.exists(os.path.join(sitedir, name[2:])):
                     return
-                raise
+            f.seek(0)
 
         for n, line in enumerate(f):
             if line.startswith("#"):

--- a/Lib/site.py
+++ b/Lib/site.py
@@ -177,29 +177,8 @@ def addpackage(sitedir, name, known_paths):
         return
     with f:
         try:
-            for n, line in enumerate(f):
-                if line.startswith("#"):
-                    continue
-                if line.strip() == "":
-                    continue
-                try:
-                    if line.startswith(("import ", "import\t")):
-                        exec(line)
-                        continue
-                    line = line.rstrip()
-                    dir, dircase = makepath(sitedir, line)
-                    if not dircase in known_paths and os.path.exists(dir):
-                        sys.path.append(dir)
-                        known_paths.add(dircase)
-                except Exception as exc:
-                    print("Error processing line {:d} of {}:\n".format(n+1, fullname),
-                          file=sys.stderr)
-                    import traceback
-                    for record in traceback.format_exception(exc):
-                        for line in record.splitlines():
-                            print('  '+line, file=sys.stderr)
-                    print("\nRemainder of file ignored", file=sys.stderr)
-                    break
+            f.readline()
+            f.seek(0)
         except UnicodeDecodeError:
             # MacOS can create files with a "._" prefix in the name
             # next to the regular file when the system needs to store
@@ -210,6 +189,30 @@ def addpackage(sitedir, name, known_paths):
             if name.startswith("._") and os.path.exists(os.path.join(sitedir, name[2:])):
                 return
             raise
+
+        for n, line in enumerate(f):
+            if line.startswith("#"):
+                continue
+            if line.strip() == "":
+                continue
+            try:
+                if line.startswith(("import ", "import\t")):
+                    exec(line)
+                    continue
+                line = line.rstrip()
+                dir, dircase = makepath(sitedir, line)
+                if not dircase in known_paths and os.path.exists(dir):
+                    sys.path.append(dir)
+                    known_paths.add(dircase)
+            except Exception as exc:
+                print("Error processing line {:d} of {}:\n".format(n+1, fullname),
+                      file=sys.stderr)
+                import traceback
+                for record in traceback.format_exception(exc):
+                    for line in record.splitlines():
+                        print('  '+line, file=sys.stderr)
+                print("\nRemainder of file ignored", file=sys.stderr)
+                break
     if reset:
         known_paths = None
     return known_paths

--- a/Lib/test/test_site.py
+++ b/Lib/test/test_site.py
@@ -187,13 +187,20 @@ class HelperFunctionsTests(unittest.TestCase):
         resource_fork = os.path.join(pth_dir, "._" + pth_fn)
         with open(resource_fork, "wb") as fp:
             self.addCleanup(lambda: os.remove(resource_fork))
-            # Some random that that isn't valid UTF-8
-            fp.write(b"\xff\xff\xff")
+
+            # The bytes below were generated on macOS 14 using an
+            # exFAT filesystem. Command to write an xattr:
+            # `xattr -w key value test.txt`. These bytes are not
+            # the complete AppleDouble file, but just a significant
+            # prefix.
+            fp.write(b'\x00\x05\x16\x07\x00\x02\x00\x00Mac OS X        ')
+            fp.write(b'\x00\x02\x00\x00\x00\t\x00\x00\x002\x00\x00\x0e')
+            fp.write(b'\xb0\x00\x00\x00\x02\x00\x00\x0e\xe2\x00\x00')
+            fp.write(b'\x01\x1e')
 
         with captured_stderr() as err_out:
             self.assertFalse(site.addpackage(pth_dir, "._" + pth_fn, set()))
         self.assertEqual(err_out.getvalue(), "")
-
 
     def test_addsitedir(self):
         # Same tests for test_addpackage since addsitedir() essentially just

--- a/Lib/test/test_site.py
+++ b/Lib/test/test_site.py
@@ -181,6 +181,20 @@ class HelperFunctionsTests(unittest.TestCase):
             if isinstance(path, str):
                 self.assertNotIn("abc\x00def", path)
 
+    def test_addpackage_macOS_resources(self):
+        # GH-113356
+        pth_dir, pth_fn = self.make_pth("dummy\n")
+        resource_fork = os.path.join(pth_dir, "._" + pth_fn)
+        with open(resource_fork, "wb") as fp:
+            self.addCleanup(lambda: os.remove(resource_fork))
+            # Some random that that isn't valid UTF-8
+            fp.write(b"\xff\xff\xff")
+
+        with captured_stderr() as err_out:
+            self.assertFalse(site.addpackage(pth_dir, "._" + pth_fn, set()))
+        self.assertEqual(err_out.getvalue(), "")
+
+
     def test_addsitedir(self):
         # Same tests for test_addpackage since addsitedir() essentially just
         # calls addpackage() for every .pth file in the directory

--- a/Misc/NEWS.d/next/macOS/2023-12-21-14-18-24.gh-issue-113356.Vz2osH.rst
+++ b/Misc/NEWS.d/next/macOS/2023-12-21-14-18-24.gh-issue-113356.Vz2osH.rst
@@ -1,0 +1,3 @@
+Ignore "._" prefixed pth files when those cannot be parsed. These files are
+created on macOS when the system tries store metadata that is not supported
+by the filesystem (such as extended attributes on exFAT)


### PR DESCRIPTION
On macOS the system can create a "._" file next to a regular file when the system needs to store metadata that is not supported by the filesystem (such as storing extended attributes on an exFAT filesystem).

Those files are binary data and cause startup failures when the base file is a ".pth" file.


<!-- gh-issue-number: gh-113356 -->
* Issue: gh-113356
<!-- /gh-issue-number -->
