### PR TITLE
gh-113358: Fix rendering tracebacks with exceptions with a broken __getattr__

### DIFF
--- a/Lib/test/test_traceback.py
+++ b/Lib/test/test_traceback.py
@@ -2219,7 +2219,9 @@ class BaseExceptionReportingTests:
         e = BrokenException(123)
         vanilla = self.get_report(e)
         e.broken = True
-        self.assertEqual(self.get_report(e), vanilla)
+        self.assertEqual(
+            self.get_report(e),
+            vanilla + "Ignored exception getting __notes__: ValueError('no __notes__')\n")
 
     def test_exception_with_multiple_notes(self):
         for e in [ValueError(42), SyntaxError('bad syntax')]:

--- a/Lib/test/test_traceback.py
+++ b/Lib/test/test_traceback.py
@@ -2221,7 +2221,7 @@ class BaseExceptionReportingTests:
         e.broken = True
         self.assertEqual(
             self.get_report(e),
-            vanilla + "Ignored exception getting __notes__: ValueError('no __notes__')\n")
+            vanilla + "Ignored error getting __notes__: ValueError('no __notes__')\n")
 
     def test_exception_with_multiple_notes(self):
         for e in [ValueError(42), SyntaxError('bad syntax')]:

--- a/Lib/test/test_traceback.py
+++ b/Lib/test/test_traceback.py
@@ -2209,6 +2209,18 @@ class BaseExceptionReportingTests:
         err_msg = "b'please do not show me as numbers'"
         self.assertEqual(self.get_report(e), vanilla + err_msg + '\n')
 
+        # an exception with a broken __getattr__ raising a non expected error
+        class BrokenException(Exception):
+            broken = False
+            def __getattr__(self, name):
+                if self.broken:
+                    raise ValueError(f'no {name}')
+
+        e = BrokenException(123)
+        vanilla = self.get_report(e)
+        e.broken = True
+        self.assertEqual(self.get_report(e), vanilla)
+
     def test_exception_with_multiple_notes(self):
         for e in [ValueError(42), SyntaxError('bad syntax')]:
             with self.subTest(e=e):

--- a/Lib/traceback.py
+++ b/Lib/traceback.py
@@ -1053,10 +1053,10 @@ class TracebackException:
         self._str = _safe_string(exc_value, 'exception')
         notes = None
         try:
-            notes = getattr(exc_value, '__notes__', None)
-        except Exception:
-            pass
-        self.__notes__ = notes
+            self.__notes__ = getattr(exc_value, '__notes__', None)
+        except Exception as e:
+            self.__notes__ = [
+                f'Ignored exception getting __notes__: {_safe_string(e, '__notes__', repr)}']
 
         self._is_syntax_error = False
         self._have_exc_type = exc_type is not None

--- a/Lib/traceback.py
+++ b/Lib/traceback.py
@@ -1051,7 +1051,6 @@ class TracebackException:
         # Capture now to permit freeing resources: only complication is in the
         # unofficial API _format_final_exc_line
         self._str = _safe_string(exc_value, 'exception')
-        notes = None
         try:
             self.__notes__ = getattr(exc_value, '__notes__', None)
         except Exception as e:

--- a/Lib/traceback.py
+++ b/Lib/traceback.py
@@ -1051,7 +1051,12 @@ class TracebackException:
         # Capture now to permit freeing resources: only complication is in the
         # unofficial API _format_final_exc_line
         self._str = _safe_string(exc_value, 'exception')
-        self.__notes__ = getattr(exc_value, '__notes__', None)
+        notes = None
+        try:
+            notes = getattr(exc_value, '__notes__', None)
+        except Exception:
+            pass
+        self.__notes__ = notes
 
         self._is_syntax_error = False
         self._have_exc_type = exc_type is not None

--- a/Lib/traceback.py
+++ b/Lib/traceback.py
@@ -1055,7 +1055,7 @@ class TracebackException:
             self.__notes__ = getattr(exc_value, '__notes__', None)
         except Exception as e:
             self.__notes__ = [
-                f'Ignored exception getting __notes__: {_safe_string(e, '__notes__', repr)}']
+                f'Ignored error getting __notes__: {_safe_string(e, '__notes__', repr)}']
 
         self._is_syntax_error = False
         self._have_exc_type = exc_type is not None

--- a/Misc/NEWS.d/next/Library/2023-12-21-14-55-06.gh-issue-113358.nRkiSL.rst
+++ b/Misc/NEWS.d/next/Library/2023-12-21-14-55-06.gh-issue-113358.nRkiSL.rst
@@ -1,0 +1,1 @@
+Fix rendering tracebacks with exceptions with a broken __getattr__


### PR DESCRIPTION


<!-- gh-issue-number: gh-113358 -->
* Issue: gh-113358
<!-- /gh-issue-number -->
