### PR TITLE
Fix trivial typo in test_interpreters

### DIFF
--- a/Lib/test/test_interpreters/__main__.py
+++ b/Lib/test/test_interpreters/__main__.py
@@ -1,4 +1,4 @@
 from . import load_tests
 import unittest
 
-nittest.main()
+unittest.main()


### PR DESCRIPTION
Just one letter, but it was making test_interpreters fail to compile.
