### PR TITLE
Bump mypy to 1.8.0

### DIFF
--- a/Tools/clinic/clinic.py
+++ b/Tools/clinic/clinic.py
@@ -5815,11 +5815,11 @@ class DSLParser:
         parameter_name = parameter.arg
         name, legacy, kwargs = self.parse_converter(parameter.annotation)
 
+        value: object
         if not default:
             if self.parameter_state is ParamState.OPTIONAL:
                 fail(f"Can't have a parameter without a default ({parameter_name!r}) "
                       "after a parameter with a default!")
-            value: Sentinels | Null
             if is_vararg:
                 value = NULL
                 kwargs.setdefault('c_default', "NULL")

--- a/Tools/requirements-dev.txt
+++ b/Tools/requirements-dev.txt
@@ -1,6 +1,6 @@
 # Requirements file for external linters and checks we run on
 # Tools/clinic, Tools/cases_generator/, and Tools/peg_generator/ in CI
-mypy==1.7.1
+mypy==1.8.0
 
 # needed for peg_generator:
 types-psutil==5.9.5.17


### PR DESCRIPTION
The new mypy version flags a minor typing error in `clinic.py`:

```
Tools\clinic\clinic.py:5933: error: Subclass of "Sentinels" and "bool" cannot exist: "bool" is final  [unreachable]
                        if isinstance(value, (bool, NoneType)):
                                      ^~~~~
Tools\clinic\clinic.py:5933: error: Subclass of "Sentinels" and "NoneType" cannot exist: "NoneType" is final  [unreachable]
                        if isinstance(value, (bool, NoneType)):
                                      ^~~~~
Tools\clinic\clinic.py:5933: error: Subclass of "Null" and "bool" cannot exist: "bool" is final  [unreachable]
                        if isinstance(value, (bool, NoneType)):
                                      ^~~~~
Tools\clinic\clinic.py:5933: error: Subclass of "Null" and "NoneType" cannot exist: "NoneType" is final  [unreachable]
                        if isinstance(value, (bool, NoneType)):
                                      ^~~~~
Tools\clinic\clinic.py:5934: error: Statement is unreachable  [unreachable]
                            c_default = "Py_" + py_default
                            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

The issue is that our current annotation for `value` is incorrect; it should have a much broader type, since it could potentially be anything returned from a call to `eval()` on line 5927