### PR TITLE
gh-113360: Fix `doctest` failure when `__test__` is set to falsy value

### DIFF
--- a/Lib/doctest.py
+++ b/Lib/doctest.py
@@ -1040,7 +1040,7 @@ class DocTestFinder:
 
         # Look for tests in a module's __test__ dictionary.
         if inspect.ismodule(obj) and self._recurse:
-            for valname, val in getattr(obj, '__test__', {}).items():
+            for valname, val in (getattr(obj, '__test__', None) or {}).items():
                 if not isinstance(valname, str):
                     raise ValueError("DocTestFinder.find: __test__ keys "
                                      "must be strings: %r" %

--- a/Lib/test/test_doctest.py
+++ b/Lib/test/test_doctest.py
@@ -597,6 +597,24 @@ functions, classes, and the `__test__` dictionary, if it exists:
      2  some_module.__test__.d
      1  some_module.sample_func
 
+When ``__test__`` is falsy, this value should be ignored:
+
+    >>> import types
+    >>> m = types.ModuleType('falsy_magic_test')
+    >>> m.__dict__.update({'__test__': None})
+
+    >>> finder = doctest.DocTestFinder()
+    >>> # Use module=test.test_doctest, to prevent doctest from
+    >>> # ignoring the objects since they weren't defined in m.
+    >>> import test.test_doctest
+    >>> finder.find(m, module=test.test_doctest)
+    []
+
+    >>> m.__dict__.update({'__test__': False})
+    >>> finder.find(m, module=test.test_doctest)
+    []
+
+
 Duplicate Removal
 ~~~~~~~~~~~~~~~~~
 If a single object is listed twice (under different names), then tests

--- a/Misc/NEWS.d/next/Library/2023-12-22-10-56-02.gh-issue-113360.vFD6x5.rst
+++ b/Misc/NEWS.d/next/Library/2023-12-22-10-56-02.gh-issue-113360.vFD6x5.rst
@@ -1,0 +1,1 @@
+Fix doctest failure when ``__test__`` magic var is set to a falsy value.


### PR DESCRIPTION
Refs https://github.com/python/cpython/pull/112109

Thanks a lot for the detailed analysis!

<!-- gh-issue-number: gh-113360 -->
* Issue: gh-113360
<!-- /gh-issue-number -->
