### PR TITLE
gh-113384: Skip test_freeze for framework builds on macOS

### DIFF
--- a/Lib/test/test_tools/test_freeze.py
+++ b/Lib/test/test_tools/test_freeze.py
@@ -14,6 +14,8 @@ with imports_under_tool('freeze', 'test'):
 
 @support.requires_zlib()
 @unittest.skipIf(sys.platform.startswith('win'), 'not supported on Windows')
+@unittest.skipIf(sys.platform == 'darwin' and sys._framework,
+        'not supported for frameworks builds on macOS')
 @support.skip_if_buildbot('not all buildbots have enough space')
 # gh-103053: Skip test if Python is built with Profile Guided Optimization
 # (PGO), since the test is just too slow in this case.


### PR DESCRIPTION
As described in #65701 freeze.py doesn't work for framework builds on macOS. Therefore disable the test.

<!-- gh-issue-number: gh-113384 -->
* Issue: gh-113384
<!-- /gh-issue-number -->
