### PR TITLE
GH-112215: Increase C recursion limit for non debug builds

### DIFF
--- a/Include/cpython/pystate.h
+++ b/Include/cpython/pystate.h
@@ -225,7 +225,7 @@ struct _ts {
 #  define Py_C_RECURSION_LIMIT 500
 #else
    // This value is duplicated in Lib/test/support/__init__.py
-#  define Py_C_RECURSION_LIMIT 7000
+#  define Py_C_RECURSION_LIMIT 10000
 #endif
 
 

--- a/Include/cpython/pystate.h
+++ b/Include/cpython/pystate.h
@@ -223,9 +223,11 @@ struct _ts {
    // layout, optimization, and WASI runtime. Wasmtime can handle about 700
    // recursions, sometimes less. 500 is a more conservative limit.
 #  define Py_C_RECURSION_LIMIT 500
+#elif defined(__s390x__)
+#  define Py_C_RECURSION_LIMIT 1500
 #else
    // This value is duplicated in Lib/test/support/__init__.py
-#  define Py_C_RECURSION_LIMIT 9000
+#  define Py_C_RECURSION_LIMIT 8000
 #endif
 
 

--- a/Include/cpython/pystate.h
+++ b/Include/cpython/pystate.h
@@ -225,7 +225,7 @@ struct _ts {
 #  define Py_C_RECURSION_LIMIT 500
 #else
    // This value is duplicated in Lib/test/support/__init__.py
-#  define Py_C_RECURSION_LIMIT 10000
+#  define Py_C_RECURSION_LIMIT 9000
 #endif
 
 

--- a/Include/cpython/pystate.h
+++ b/Include/cpython/pystate.h
@@ -225,7 +225,7 @@ struct _ts {
 #  define Py_C_RECURSION_LIMIT 500
 #else
    // This value is duplicated in Lib/test/support/__init__.py
-#  define Py_C_RECURSION_LIMIT 4500
+#  define Py_C_RECURSION_LIMIT 7000
 #endif
 
 

--- a/Include/cpython/pystate.h
+++ b/Include/cpython/pystate.h
@@ -224,7 +224,7 @@ struct _ts {
    // recursions, sometimes less. 500 is a more conservative limit.
 #  define Py_C_RECURSION_LIMIT 500
 #elif defined(__s390x__)
-#  define Py_C_RECURSION_LIMIT 1500
+#  define Py_C_RECURSION_LIMIT 1200
 #else
    // This value is duplicated in Lib/test/support/__init__.py
 #  define Py_C_RECURSION_LIMIT 8000

--- a/Include/cpython/pystate.h
+++ b/Include/cpython/pystate.h
@@ -225,7 +225,7 @@ struct _ts {
 #  define Py_C_RECURSION_LIMIT 500
 #else
    // This value is duplicated in Lib/test/support/__init__.py
-#  define Py_C_RECURSION_LIMIT 1500
+#  define Py_C_RECURSION_LIMIT 4500
 #endif
 
 

--- a/Lib/test/support/__init__.py
+++ b/Lib/test/support/__init__.py
@@ -2123,6 +2123,9 @@ def set_recursion_limit(limit):
 
 def infinite_recursion(max_depth=None):
     if max_depth is None:
+        # Pick a number large enough to cause problems
+        # but not take too long for code that can handle
+        # very deep recursion.
         max_depth = 20_000
     elif max_depth < 3:
         raise ValueError("max_depth must be at least 3, got {max_depth}")
@@ -2362,8 +2365,6 @@ def adjust_int_max_str_digits(max_digits):
     finally:
         sys.set_int_max_str_digits(current)
 
-#For recursion tests, easily exceeds default recursion limit
-EXCEEDS_RECURSION_LIMIT = 10_000
 
 def _get_c_recursion_limit():
     try:
@@ -2371,10 +2372,13 @@ def _get_c_recursion_limit():
         return _testcapi.Py_C_RECURSION_LIMIT
     except (ImportError, AttributeError):
         # Originally taken from Include/cpython/pystate.h .
-        return 4500
+        return 7000
 
 # The default C recursion limit.
 Py_C_RECURSION_LIMIT = _get_c_recursion_limit()
+
+#For recursion tests, easily exceeds default recursion limit
+EXCEEDS_RECURSION_LIMIT = Py_C_RECURSION_LIMIT * 3
 
 #Windows doesn't have os.uname() but it doesn't support s390x.
 skip_on_s390x = unittest.skipIf(hasattr(os, 'uname') and os.uname().machine == 's390x',

--- a/Lib/test/support/__init__.py
+++ b/Lib/test/support/__init__.py
@@ -2122,19 +2122,8 @@ def set_recursion_limit(limit):
         sys.setrecursionlimit(original_limit)
 
 def infinite_recursion(max_depth=None):
-    """Set a lower limit for tests that interact with infinite recursions
-    (e.g test_ast.ASTHelpers_Test.test_recursion_direct) since on some
-    debug windows builds, due to not enough functions being inlined the
-    stack size might not handle the default recursion limit (1000). See
-    bpo-11105 for details."""
     if max_depth is None:
-        if not python_is_optimized() or Py_DEBUG:
-            # Python built without compiler optimizations or in debug mode
-            # usually consumes more stack memory per function call.
-            # Unoptimized number based on what works under a WASI debug build.
-            max_depth = 50
-        else:
-            max_depth = 100
+        max_depth = 20_000
     elif max_depth < 3:
         raise ValueError("max_depth must be at least 3, got {max_depth}")
     depth = get_recursion_depth()
@@ -2374,7 +2363,7 @@ def adjust_int_max_str_digits(max_digits):
         sys.set_int_max_str_digits(current)
 
 #For recursion tests, easily exceeds default recursion limit
-EXCEEDS_RECURSION_LIMIT = 5000
+EXCEEDS_RECURSION_LIMIT = 10_000
 
 def _get_c_recursion_limit():
     try:
@@ -2382,7 +2371,7 @@ def _get_c_recursion_limit():
         return _testcapi.Py_C_RECURSION_LIMIT
     except (ImportError, AttributeError):
         # Originally taken from Include/cpython/pystate.h .
-        return 1500
+        return 4500
 
 # The default C recursion limit.
 Py_C_RECURSION_LIMIT = _get_c_recursion_limit()

--- a/Lib/test/support/__init__.py
+++ b/Lib/test/support/__init__.py
@@ -2372,7 +2372,7 @@ def _get_c_recursion_limit():
         return _testcapi.Py_C_RECURSION_LIMIT
     except (ImportError, AttributeError):
         # Originally taken from Include/cpython/pystate.h .
-        return 7000
+        return 8000
 
 # The default C recursion limit.
 Py_C_RECURSION_LIMIT = _get_c_recursion_limit()

--- a/Lib/test/test_ast.py
+++ b/Lib/test/test_ast.py
@@ -19,7 +19,7 @@ except ImportError:
 
 from test import support
 from test.support.import_helper import import_fresh_module
-from test.support import os_helper, script_helper
+from test.support import os_helper, script_helper, Py_DEBUG
 from test.support.ast_helper import ASTTestMixin
 
 def to_tuple(t):

--- a/Lib/test/test_ast.py
+++ b/Lib/test/test_ast.py
@@ -19,7 +19,7 @@ except ImportError:
 
 from test import support
 from test.support.import_helper import import_fresh_module
-from test.support import os_helper, script_helper, Py_DEBUG
+from test.support import os_helper, script_helper
 from test.support.ast_helper import ASTTestMixin
 
 def to_tuple(t):

--- a/Lib/test/test_functools.py
+++ b/Lib/test/test_functools.py
@@ -1862,6 +1862,19 @@ class TestLRU:
         self.assertEqual(str(Signature.from_callable(lru.cache_info)), '()')
         self.assertEqual(str(Signature.from_callable(lru.cache_clear)), '()')
 
+    @support.skip_on_s390x
+    def test_lru_recursion(self):
+
+        @self.module.lru_cache
+        def fib(n):
+            if n <= 1:
+                return n
+            return fib(n-1) + fib(n-2)
+
+        if not support.Py_DEBUG:
+            with support.infinite_recursion():
+                fib(2500)
+
 
 @py_functools.lru_cache()
 def py_cached_func(x, y):

--- a/Lib/test/test_functools.py
+++ b/Lib/test/test_functools.py
@@ -1863,6 +1863,7 @@ class TestLRU:
         self.assertEqual(str(Signature.from_callable(lru.cache_clear)), '()')
 
     @support.skip_on_s390x
+    @unittest.skipIf(support.is_wasi, "WASI has limited C stack")
     def test_lru_recursion(self):
 
         @self.module.lru_cache

--- a/Lib/test/test_json/test_recursion.py
+++ b/Lib/test/test_json/test_recursion.py
@@ -85,10 +85,10 @@ class TestRecursion:
         for x in range(100000):
             l, d = [l], {'k':d}
         with self.assertRaises(RecursionError):
-            with support.infinite_recursion():
+            with support.infinite_recursion(5000):
                 self.dumps(l)
         with self.assertRaises(RecursionError):
-            with support.infinite_recursion():
+            with support.infinite_recursion(5000):
                 self.dumps(d)
 
     def test_endless_recursion(self):
@@ -99,7 +99,7 @@ class TestRecursion:
                 return [o]
 
         with self.assertRaises(RecursionError):
-            with support.infinite_recursion():
+            with support.infinite_recursion(1000):
                 EndlessJSONEncoder(check_circular=False).encode(5j)
 
 

--- a/Lib/test/test_support.py
+++ b/Lib/test/test_support.py
@@ -630,7 +630,7 @@ class TestSupport(unittest.TestCase):
             if depth:
                 recursive_function(depth - 1)
 
-        for max_depth in (5, 25, 250):
+        for max_depth in (5, 25, 250, 2500):
             with support.infinite_recursion(max_depth):
                 available = support.get_recursion_available()
 

--- a/Lib/test/test_xml_etree.py
+++ b/Lib/test/test_xml_etree.py
@@ -2535,7 +2535,7 @@ class BadElementTest(ElementTestCase, unittest.TestCase):
         e.extend([ET.Element('bar')])
         self.assertRaises(ValueError, e.remove, X('baz'))
 
-    @support.infinite_recursion(25)
+    @support.infinite_recursion()
     def test_recursive_repr(self):
         # Issue #25455
         e = ET.Element('foo')

--- a/Misc/NEWS.d/next/Core and Builtins/2023-12-15-16-26-01.gh-issue-112215.xJS6_6.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2023-12-15-16-26-01.gh-issue-112215.xJS6_6.rst
@@ -1,0 +1,3 @@
+Increase the C recursion limit by a factor of 3 for non-debug builds, except
+for webassembly and s390 platforms which are unchanged. This mitigates some
+regressions in 3.12 with deep recursion mixing builtin (C) and Python code.


### PR DESCRIPTION
[Experimentation](https://github.com/python/cpython/pull/113328) shows that we can safely increase the C recursion limit for non-debug builds considerably.

In hindsight, we should have done this when we introduced the C recursion limit. There is little value in having the same limit for debug and non-debug builds and the low limit needed for debug builds is too restrictive for release builds.



<!-- gh-issue-number: gh-112215 -->
* Issue: gh-112215
<!-- /gh-issue-number -->
