### PR TITLE
gh-113317: Argument Clinic: tear out internal text accumulator APIs

### DIFF
--- a/Lib/test/test_clinic.py
+++ b/Lib/test/test_clinic.py
@@ -3761,20 +3761,6 @@ class FormatHelperTests(unittest.TestCase):
                 actual = clinic.normalize_snippet(snippet, indent=indent)
                 self.assertEqual(actual, expected)
 
-    def test_accumulator(self):
-        acc = clinic.text_accumulator()
-        self.assertEqual(acc.output(), "")
-        acc.append("a")
-        self.assertEqual(acc.output(), "a")
-        self.assertEqual(acc.output(), "")
-        acc.append("b")
-        self.assertEqual(acc.output(), "b")
-        self.assertEqual(acc.output(), "")
-        acc.append("c")
-        acc.append("d")
-        self.assertEqual(acc.output(), "cd")
-        self.assertEqual(acc.output(), "")
-
     def test_quoted_for_c_string(self):
         dataset = (
             # input,    expected
@@ -3789,22 +3775,6 @@ class FormatHelperTests(unittest.TestCase):
             with self.subTest(line=line, expected=expected):
                 out = clinic.quoted_for_c_string(line)
                 self.assertEqual(out, expected)
-
-    def test_rstrip_lines(self):
-        lines = (
-            "a \n"
-            "b\n"
-            " c\n"
-            " d \n"
-        )
-        expected = (
-            "a\n"
-            "b\n"
-            " c\n"
-            " d\n"
-        )
-        out = clinic.rstrip_lines(lines)
-        self.assertEqual(out, expected)
 
     def test_format_escape(self):
         line = "{}, {a}"

--- a/Tools/clinic/clinic.py
+++ b/Tools/clinic/clinic.py
@@ -1800,8 +1800,7 @@ class CLanguage(Language):
         out.append('        goto exit;\n')
         out.append("}")
 
-        output = "".join(out)
-        template_dict['option_group_parsing'] = format_escape(output)
+        template_dict['option_group_parsing'] = format_escape("".join(out))
 
     def render_function(
             self,

--- a/Tools/clinic/clinic.py
+++ b/Tools/clinic/clinic.py
@@ -257,14 +257,12 @@ def linear_format(s: str, **kwargs: str) -> str:
     for line in s.split('\n'):
         indent, curly, trailing = line.partition('{')
         if not curly:
-            lines.append(line)
-            lines.append('\n')
+            lines.extend([line, "\n"])
             continue
 
         name, curly, trailing = trailing.partition('}')
         if not curly or name not in kwargs:
-            lines.append(line)
-            lines.append('\n')
+            lines.extend([line, "\n"])
             continue
 
         if trailing:
@@ -280,8 +278,7 @@ def linear_format(s: str, **kwargs: str) -> str:
 
         stripped = [line.rstrip() for line in value.split("\n")]
         value = textwrap.indent("\n".join(stripped), indent)
-        lines.append(value)
-        lines.append('\n')
+        lines.extend([value, "\n"])
 
     return "".join(lines[:-1])
 
@@ -6232,8 +6229,7 @@ class DSLParser:
                 else:
                     s = ' ' + text
                     if line_length + len(s) >= 72:
-                        lines.append('\n')
-                        lines.append(indent)
+                        lines.extend(["\n", indent])
                         line_length = len(indent)
                         s = text
                 line_length += len(s)
@@ -6260,8 +6256,7 @@ class DSLParser:
                     added_star = True
                     add_parameter('*,')
 
-                p_lines = []
-                p_lines.append(fix_right_bracket_count(p.right_bracket_count))
+                p_lines = [fix_right_bracket_count(p.right_bracket_count)]
 
                 if isinstance(p.converter, self_converter):
                     # annotate first parameter as being a "self".

--- a/Tools/clinic/clinic.py
+++ b/Tools/clinic/clinic.py
@@ -106,7 +106,6 @@ NULL = Null()
 sig_end_marker = '--'
 
 TemplateDict = dict[str, str]
-TextAccumulator = list[str]
 
 
 @dc.dataclass
@@ -2342,6 +2341,9 @@ class BlockPrinter:
 
     def write(self, text: str) -> None:
         self.f.write(text)
+
+
+TextAccumulator = list[str]
 
 
 class BufferSeries:

--- a/Tools/clinic/clinic.py
+++ b/Tools/clinic/clinic.py
@@ -6310,8 +6310,8 @@ class DSLParser:
         # therefore this is commented out:
         #
         # if f.return_converter.py_default:
-        #     acc.add(' -> ')
-        #     acc.add(f.return_converter.py_default)
+        #     lines.append(' -> ')
+        #     lines.append(f.return_converter.py_default)
 
         if not f.docstring_only:
             lines.append("\n" + sig_end_marker + "\n")


### PR DESCRIPTION
Replace the internal accumulator APIs by using lists of strings and join().

Yak-shaving for separating out formatting code into a separate file.


<!-- gh-issue-number: gh-113317 -->
* Issue: gh-113317
<!-- /gh-issue-number -->
