### PR TITLE
gh-113407: Fix import of unittest.mock when CPython is built without docstrings

### DIFF
--- a/Lib/unittest/mock.py
+++ b/Lib/unittest/mock.py
@@ -2229,8 +2229,11 @@ class MagicProxy(Base):
         return self.create_mock()
 
 
-_CODE_ATTRS = dir(CodeType)
-_CODE_SIG = inspect.signature(partial(CodeType.__init__, None))
+try:
+    _CODE_SIG = inspect.signature(partial(CodeType.__init__, None))
+    _CODE_ATTRS = dir(CodeType)
+except ValueError:
+    _CODE_SIG = None
 
 
 class AsyncMockMixin(Base):
@@ -2250,9 +2253,12 @@ class AsyncMockMixin(Base):
         self.__dict__['_mock_await_count'] = 0
         self.__dict__['_mock_await_args'] = None
         self.__dict__['_mock_await_args_list'] = _CallList()
-        code_mock = NonCallableMock(spec_set=_CODE_ATTRS)
-        code_mock.__dict__["_spec_class"] = CodeType
-        code_mock.__dict__["_spec_signature"] = _CODE_SIG
+        if _CODE_SIG:
+            code_mock = NonCallableMock(spec_set=_CODE_ATTRS)
+            code_mock.__dict__["_spec_class"] = CodeType
+            code_mock.__dict__["_spec_signature"] = _CODE_SIG
+        else:
+            code_mock = NonCallableMock(spec_set=CodeType)
         code_mock.co_flags = (
             inspect.CO_COROUTINE
             + inspect.CO_VARARGS

--- a/Misc/NEWS.d/next/Library/2023-12-22-20-49-52.gh-issue-113407.C_O13_.rst
+++ b/Misc/NEWS.d/next/Library/2023-12-22-20-49-52.gh-issue-113407.C_O13_.rst
@@ -1,0 +1,1 @@
+Fix import of :mod:`unittest.mock` when CPython is built without docstrings.


### PR DESCRIPTION


<!-- gh-issue-number: gh-113407 -->
* Issue: gh-113407
<!-- /gh-issue-number -->
