### PR TITLE
GH-113373: Speed up pathlib parsing using `__init_subclass__()`

### DIFF
--- a/Lib/pathlib/__init__.py
+++ b/Lib/pathlib/__init__.py
@@ -32,7 +32,7 @@ __all__ = [
 UnsupportedOperation = _abc.UnsupportedOperation
 
 
-class PurePath(_abc.PurePathBase):
+class PurePath(_abc.PurePathBase, pathmod=os.path):
     """Base class for manipulating paths without I/O.
 
     PurePath represents a filesystem path and offers operations which
@@ -59,7 +59,6 @@ class PurePath(_abc.PurePathBase):
         # path. It's set when `__hash__()` is called for the first time.
         '_hash',
     )
-    pathmod = os.path
 
     def __new__(cls, *args, **kwargs):
         """Construct a PurePath from one or several strings and or existing
@@ -191,23 +190,21 @@ class PurePath(_abc.PurePathBase):
 os.PathLike.register(PurePath)
 
 
-class PurePosixPath(PurePath):
+class PurePosixPath(PurePath, pathmod=posixpath):
     """PurePath subclass for non-Windows systems.
 
     On a POSIX system, instantiating a PurePath should return this object.
     However, you can also instantiate it directly on any system.
     """
-    pathmod = posixpath
     __slots__ = ()
 
 
-class PureWindowsPath(PurePath):
+class PureWindowsPath(PurePath, pathmod=ntpath):
     """PurePath subclass for Windows systems.
 
     On a Windows system, instantiating a PurePath should return this object.
     However, you can also instantiate it directly on any system.
     """
-    pathmod = ntpath
     __slots__ = ()
 
 

--- a/Lib/pathlib/__init__.py
+++ b/Lib/pathlib/__init__.py
@@ -117,7 +117,7 @@ class PurePath(_abc.PurePathBase):
         try:
             return self._str_normcase_cached
         except AttributeError:
-            if _abc._is_case_sensitive(self.pathmod):
+            if self._case_sensitive:
                 self._str_normcase_cached = str(self)
             else:
                 self._str_normcase_cached = str(self).lower()
@@ -141,7 +141,7 @@ class PurePath(_abc.PurePathBase):
         try:
             return self._parts_normcase_cached
         except AttributeError:
-            self._parts_normcase_cached = self._str_normcase.split(self.pathmod.sep)
+            self._parts_normcase_cached = self._str_normcase.split(self._sep)
             return self._parts_normcase_cached
 
     def __lt__(self, other):
@@ -309,7 +309,7 @@ class Path(_abc.PathBase, PurePath):
         drive, root, rel = os.path.splitroot(cwd)
         if not rel:
             return self._from_parsed_parts(drive, root, self._tail)
-        tail = rel.split(self.pathmod.sep)
+        tail = rel.split(self._sep)
         tail.extend(self._tail)
         return self._from_parsed_parts(drive, root, tail)
 

--- a/Lib/pathlib/_abc.py
+++ b/Lib/pathlib/_abc.py
@@ -200,12 +200,17 @@ class PurePathBase:
         '_resolving',
     )
     pathmod = posixpath
+    _sep = '/'
+    _altsep = None
+    _case_sensitive = True
 
-    def __init_subclass__(cls, **kwargs):
+    def __init_subclass__(cls, pathmod=None, **kwargs):
         super().__init_subclass__(**kwargs)
-        cls._sep = cls.pathmod.sep
-        cls._altsep = cls.pathmod.altsep
-        cls._case_sensitive = cls.pathmod.normcase('Aa') == 'Aa'
+        if pathmod is not None:
+            cls.pathmod = pathmod
+            cls._sep = pathmod.sep
+            cls._altsep = pathmod.altsep
+            cls._case_sensitive = pathmod.normcase('Aa') == 'Aa'
 
     def __init__(self, *paths):
         self._raw_paths = paths

--- a/Misc/NEWS.d/next/Library/2023-12-22-19-29-22.gh-issue-113373.bt7Ewv.rst
+++ b/Misc/NEWS.d/next/Library/2023-12-22-19-29-22.gh-issue-113373.bt7Ewv.rst
@@ -1,0 +1,2 @@
+Speed up path parsing in :mod:`pathlib` by storing path separators and case
+sensitivity as private class attributes. Patch by Barney Gale.


### PR DESCRIPTION
Set `_sep`, `_altsep` and `_case_sensitive` class attributes from `_abc.PurePathBase.__init_subclass__()`, which reduces the number of attribute accesses needed for several pathlib operations.


<!-- gh-issue-number: gh-113373 -->
* Issue: gh-113373
<!-- /gh-issue-number -->
