### PR TITLE
gh-81682: Fix test failures when CPython is built without docstrings

### DIFF
--- a/Lib/idlelib/idle_test/test_calltip.py
+++ b/Lib/idlelib/idle_test/test_calltip.py
@@ -7,6 +7,7 @@ import textwrap
 import types
 import re
 from idlelib.idle_test.mock_tk import Text
+from test.support import MISSING_C_DOCSTRINGS
 
 
 # Test Class TC is used in multiple get_argspec test methods
@@ -50,6 +51,8 @@ class Get_argspecTest(unittest.TestCase):
     # but a red buildbot is better than a user crash (as has happened).
     # For a simple mismatch, change the expected output to the actual.
 
+    @unittest.skipIf(MISSING_C_DOCSTRINGS,
+                     "Signature information for builtins requires docstrings")
     def test_builtins(self):
 
         def tiptest(obj, out):
@@ -143,6 +146,8 @@ you\'ll probably have to override _wrap_chunks().''')
         f.__doc__ = 'a'*300
         self.assertEqual(get_spec(f), f"()\n{'a'*(calltip._MAX_COLS-3) + '...'}")
 
+    @unittest.skipIf(MISSING_C_DOCSTRINGS,
+                     "Signature information for builtins requires docstrings")
     def test_multiline_docstring(self):
         # Test fewer lines than max.
         self.assertEqual(get_spec(range),
@@ -157,6 +162,7 @@ bytes(bytes_or_buffer) -> immutable copy of bytes_or_buffer
 bytes(int) -> bytes object of size given by the parameter initialized with null bytes
 bytes() -> empty bytes object''')
 
+    def test_multiline_docstring_2(self):
         # Test more than max lines
         def f(): pass
         f.__doc__ = 'a\n' * 15

--- a/Lib/test/test_capi/test_misc.py
+++ b/Lib/test/test_capi/test_misc.py
@@ -469,6 +469,8 @@ class CAPITest(unittest.TestCase):
             del L
             self.assertEqual(PyList.num, 0)
 
+    @unittest.skipIf(MISSING_C_DOCSTRINGS,
+                     "Signature information for builtins requires docstrings")
     def test_heap_ctype_doc_and_text_signature(self):
         self.assertEqual(_testcapi.HeapDocCType.__doc__, "somedoc")
         self.assertEqual(_testcapi.HeapDocCType.__text_signature__, "(arg1, arg2)")

--- a/Lib/test/test_coroutines.py
+++ b/Lib/test/test_coroutines.py
@@ -953,11 +953,12 @@ class CoroutineTest(unittest.TestCase):
 
     def test_corotype_1(self):
         ct = types.CoroutineType
-        self.assertIn('into coroutine', ct.send.__doc__)
-        self.assertIn('inside coroutine', ct.close.__doc__)
-        self.assertIn('in coroutine', ct.throw.__doc__)
-        self.assertIn('of the coroutine', ct.__dict__['__name__'].__doc__)
-        self.assertIn('of the coroutine', ct.__dict__['__qualname__'].__doc__)
+        if not support.MISSING_C_DOCSTRINGS:
+            self.assertIn('into coroutine', ct.send.__doc__)
+            self.assertIn('inside coroutine', ct.close.__doc__)
+            self.assertIn('in coroutine', ct.throw.__doc__)
+            self.assertIn('of the coroutine', ct.__dict__['__name__'].__doc__)
+            self.assertIn('of the coroutine', ct.__dict__['__qualname__'].__doc__)
         self.assertEqual(ct.__name__, 'coroutine')
 
         async def f(): pass

--- a/Lib/test/test_curses.py
+++ b/Lib/test/test_curses.py
@@ -8,7 +8,7 @@ import unittest
 from unittest.mock import MagicMock
 
 from test.support import (requires, verbose, SaveSignals, cpython_only,
-                          check_disallow_instantiation)
+                          check_disallow_instantiation, MISSING_C_DOCSTRINGS)
 from test.support.import_helper import import_module
 
 # Optionally test curses module.  This currently requires that the
@@ -1142,6 +1142,8 @@ class TestCurses(unittest.TestCase):
         with self.assertRaises(TypeError):
             del stdscr.encoding
 
+    @unittest.skipIf(MISSING_C_DOCSTRINGS,
+                     "Signature information for builtins requires docstrings")
     def test_issue21088(self):
         stdscr = self.stdscr
         #

--- a/Lib/test/test_functools.py
+++ b/Lib/test/test_functools.py
@@ -939,6 +939,8 @@ class TestCmpToKey:
         self.assertRaises(TypeError, hash, k)
         self.assertNotIsInstance(k, collections.abc.Hashable)
 
+    @unittest.skipIf(support.MISSING_C_DOCSTRINGS,
+                     "Signature information for builtins requires docstrings")
     def test_cmp_to_signature(self):
         self.assertEqual(str(Signature.from_callable(self.cmp_to_key)),
                          '(mycmp)')

--- a/Lib/test/test_importlib/extension/test_loader.py
+++ b/Lib/test/test_importlib/extension/test_loader.py
@@ -9,6 +9,7 @@ import unittest
 import warnings
 import importlib.util
 import importlib
+from test.support import MISSING_C_DOCSTRINGS
 
 
 class LoaderTests:
@@ -373,7 +374,8 @@ class MultiPhaseExtensionModuleTests(abc.LoaderTests):
             with self.subTest(name):
                 module = self.load_module_by_name(name)
                 self.assertEqual(module.__name__, name)
-                self.assertEqual(module.__doc__, "Module named in %s" % lang)
+                if not MISSING_C_DOCSTRINGS:
+                    self.assertEqual(module.__doc__, "Module named in %s" % lang)
 
 
 (Frozen_MultiPhaseExtensionModuleTests,

--- a/Lib/test/test_inspect/test_inspect.py
+++ b/Lib/test/test_inspect/test_inspect.py
@@ -3990,6 +3990,8 @@ class TestSignatureObject(unittest.TestCase):
         foo_sig = MySignature.from_callable(foo)
         self.assertIsInstance(foo_sig, MySignature)
 
+    @unittest.skipIf(MISSING_C_DOCSTRINGS,
+                     "Signature information for builtins requires docstrings")
     def test_signature_from_callable_class(self):
         # A regression test for a class inheriting its signature from `object`.
         class MySignature(inspect.Signature): pass
@@ -4080,7 +4082,8 @@ class TestSignatureObject(unittest.TestCase):
                             par('c', PORK, annotation="'MyClass'"),
                         )))
 
-                self.assertEqual(signature_func(isa.UnannotatedClass), sig())
+                if not MISSING_C_DOCSTRINGS:
+                    self.assertEqual(signature_func(isa.UnannotatedClass), sig())
                 self.assertEqual(signature_func(isa.unannotated_function),
                     sig(
                         parameters=(

--- a/Lib/test/test_module/__init__.py
+++ b/Lib/test/test_module/__init__.py
@@ -30,7 +30,7 @@ class ModuleTests(unittest.TestCase):
             self.fail("__name__ = %s" % repr(s))
         except AttributeError:
             pass
-        self.assertEqual(foo.__doc__, ModuleType.__doc__)
+        self.assertEqual(foo.__doc__, ModuleType.__doc__ or '')
 
     def test_uninitialized_missing_getattr(self):
         # Issue 8297

--- a/Lib/test/test_pydoc.py
+++ b/Lib/test/test_pydoc.py
@@ -32,7 +32,7 @@ from test.support.script_helper import (assert_python_ok,
 from test.support import threading_helper
 from test.support import (reap_children, captured_output, captured_stdout,
                           captured_stderr, is_emscripten, is_wasi,
-                          requires_docstrings)
+                          requires_docstrings, MISSING_C_DOCSTRINGS)
 from test.support.os_helper import (TESTFN, rmtree, unlink)
 from test import pydoc_mod
 
@@ -906,12 +906,15 @@ class A(builtins.object)
  |  ----------------------------------------------------------------------
  |  Data descriptors defined here:
  |
- |  __dict__
- |      dictionary for instance variables
+ |  __dict__%s
  |
- |  __weakref__
- |      list of weak references to the object
-''' % __name__)
+ |  __weakref__%s
+''' % (__name__,
+       '' if MISSING_C_DOCSTRINGS else
+       '\n |      dictionary for instance variables',
+       '' if MISSING_C_DOCSTRINGS else
+       '\n |      list of weak references to the object',
+      ))
 
         def func(
             arg1: Callable[[Annotated[int, 'Some doc']], str],
@@ -1154,13 +1157,15 @@ class TestDescriptions(unittest.TestCase):
         doc = pydoc.render_doc(typing.List[int], renderer=pydoc.plaintext)
         self.assertIn('_GenericAlias in module typing', doc)
         self.assertIn('List = class list(object)', doc)
-        self.assertIn(list.__doc__.strip().splitlines()[0], doc)
+        if not MISSING_C_DOCSTRINGS:
+            self.assertIn(list.__doc__.strip().splitlines()[0], doc)
 
         self.assertEqual(pydoc.describe(list[int]), 'GenericAlias')
         doc = pydoc.render_doc(list[int], renderer=pydoc.plaintext)
         self.assertIn('GenericAlias in module builtins', doc)
         self.assertIn('\nclass list(object)', doc)
-        self.assertIn(list.__doc__.strip().splitlines()[0], doc)
+        if not MISSING_C_DOCSTRINGS:
+            self.assertIn(list.__doc__.strip().splitlines()[0], doc)
 
     def test_union_type(self):
         self.assertEqual(pydoc.describe(typing.Union[int, str]), '_UnionGenericAlias')
@@ -1174,7 +1179,8 @@ class TestDescriptions(unittest.TestCase):
         doc = pydoc.render_doc(int | str, renderer=pydoc.plaintext)
         self.assertIn('UnionType in module types object', doc)
         self.assertIn('\nclass UnionType(builtins.object)', doc)
-        self.assertIn(types.UnionType.__doc__.strip().splitlines()[0], doc)
+        if not MISSING_C_DOCSTRINGS:
+            self.assertIn(types.UnionType.__doc__.strip().splitlines()[0], doc)
 
     def test_special_form(self):
         self.assertEqual(pydoc.describe(typing.NoReturn), '_SpecialForm')
@@ -1327,6 +1333,7 @@ class TestDescriptions(unittest.TestCase):
             "__class_getitem__(object, /) method of builtins.type instance")
 
     @support.cpython_only
+    @requires_docstrings
     def test_module_level_callable_unrepresentable_default(self):
         import _testcapi
         builtin = _testcapi.func_with_unrepresentable_signature
@@ -1334,6 +1341,7 @@ class TestDescriptions(unittest.TestCase):
             "func_with_unrepresentable_signature(a, b=<x>)")
 
     @support.cpython_only
+    @requires_docstrings
     def test_builtin_staticmethod_unrepresentable_default(self):
         self.assertEqual(self._get_summary_line(str.maketrans),
             "maketrans(x, y=<unrepresentable>, z=<unrepresentable>, /)")
@@ -1343,6 +1351,7 @@ class TestDescriptions(unittest.TestCase):
             "staticmeth(a, b=<x>)")
 
     @support.cpython_only
+    @requires_docstrings
     def test_unbound_builtin_method_unrepresentable_default(self):
         self.assertEqual(self._get_summary_line(dict.pop),
             "pop(self, key, default=<unrepresentable>, /)")
@@ -1352,6 +1361,7 @@ class TestDescriptions(unittest.TestCase):
             "meth(self, /, a, b=<x>)")
 
     @support.cpython_only
+    @requires_docstrings
     def test_bound_builtin_method_unrepresentable_default(self):
         self.assertEqual(self._get_summary_line({}.pop),
             "pop(key, default=<unrepresentable>, /) "
@@ -1363,6 +1373,7 @@ class TestDescriptions(unittest.TestCase):
             "method of _testcapi.DocStringUnrepresentableSignatureTest instance")
 
     @support.cpython_only
+    @requires_docstrings
     def test_unbound_builtin_classmethod_unrepresentable_default(self):
         import _testcapi
         cls = _testcapi.DocStringUnrepresentableSignatureTest
@@ -1371,6 +1382,7 @@ class TestDescriptions(unittest.TestCase):
             "classmeth(type, /, a, b=<x>)")
 
     @support.cpython_only
+    @requires_docstrings
     def test_bound_builtin_classmethod_unrepresentable_default(self):
         import _testcapi
         cls = _testcapi.DocStringUnrepresentableSignatureTest

--- a/Lib/test/test_pydoc.py
+++ b/Lib/test/test_pydoc.py
@@ -910,10 +910,8 @@ class A(builtins.object)
  |
  |  __weakref__%s
 ''' % (__name__,
-       '' if MISSING_C_DOCSTRINGS else
-       '\n |      dictionary for instance variables',
-       '' if MISSING_C_DOCSTRINGS else
-       '\n |      list of weak references to the object',
+       '' if MISSING_C_DOCSTRINGS else '\n |      dictionary for instance variables',
+       '' if MISSING_C_DOCSTRINGS else '\n |      list of weak references to the object',
       ))
 
         def func(

--- a/Lib/test/test_rlcompleter.py
+++ b/Lib/test/test_rlcompleter.py
@@ -2,6 +2,7 @@ import unittest
 from unittest.mock import patch
 import builtins
 import rlcompleter
+from test.support import MISSING_C_DOCSTRINGS
 
 class CompleteMe:
     """ Trivial class used in testing rlcompleter.Completer. """
@@ -40,12 +41,12 @@ class TestRlcompleter(unittest.TestCase):
 
         # test with a customized namespace
         self.assertEqual(self.completer.global_matches('CompleteM'),
-                         ['CompleteMe()'])
+                ['CompleteMe(' if MISSING_C_DOCSTRINGS else 'CompleteMe()'])
         self.assertEqual(self.completer.global_matches('eg'),
                          ['egg('])
         # XXX: see issue5256
         self.assertEqual(self.completer.global_matches('CompleteM'),
-                         ['CompleteMe()'])
+                ['CompleteMe(' if MISSING_C_DOCSTRINGS else 'CompleteMe()'])
 
     def test_attr_matches(self):
         # test with builtins namespace

--- a/Lib/test/test_types.py
+++ b/Lib/test/test_types.py
@@ -1,6 +1,6 @@
 # Python test set -- part 6, built-in types
 
-from test.support import run_with_locale, cpython_only
+from test.support import run_with_locale, cpython_only, MISSING_C_DOCSTRINGS
 import collections.abc
 from collections import namedtuple
 import copy
@@ -598,6 +598,8 @@ class TypesTests(unittest.TestCase):
         self.assertIsInstance(object.__lt__, types.WrapperDescriptorType)
         self.assertIsInstance(int.__lt__, types.WrapperDescriptorType)
 
+    @unittest.skipIf(MISSING_C_DOCSTRINGS,
+                     "Signature information for builtins requires docstrings")
     def test_dunder_get_signature(self):
         sig = inspect.signature(object.__init__.__get__)
         self.assertEqual(list(sig.parameters), ["instance", "owner"])

--- a/Lib/test/test_zoneinfo/test_zoneinfo.py
+++ b/Lib/test/test_zoneinfo/test_zoneinfo.py
@@ -17,6 +17,7 @@ import unittest
 from datetime import date, datetime, time, timedelta, timezone
 from functools import cached_property
 
+from test.support import MISSING_C_DOCSTRINGS
 from test.test_zoneinfo import _support as test_support
 from test.test_zoneinfo._support import OS_ENV_LOCK, TZPATH_TEST_LOCK, ZoneInfoTestBase
 from test.support.import_helper import import_module
@@ -404,6 +405,8 @@ class ZoneInfoTest(TzPathUserMixin, ZoneInfoTestBase):
 class CZoneInfoTest(ZoneInfoTest):
     module = c_zoneinfo
 
+    @unittest.skipIf(MISSING_C_DOCSTRINGS,
+                     "Signature information for builtins requires docstrings")
     def test_signatures(self):
         """Ensure that C module has valid method signatures."""
         import inspect


### PR DESCRIPTION


<!-- gh-issue-number: gh-81682 -->
* Issue: gh-81682
<!-- /gh-issue-number -->
