### PR TITLE
gh-113317: Clean up Argument Clinic global namespace

### DIFF
--- a/Lib/test/test_clinic.py
+++ b/Lib/test/test_clinic.py
@@ -16,6 +16,7 @@ import unittest
 
 test_tools.skip_if_missing('clinic')
 with test_tools.imports_under_tool('clinic'):
+    import libclinic
     import clinic
     from clinic import DSLParser
 
@@ -3761,19 +3762,19 @@ class FormatHelperTests(unittest.TestCase):
                 actual = clinic.normalize_snippet(snippet, indent=indent)
                 self.assertEqual(actual, expected)
 
-    def test_quoted_for_c_string(self):
+    def test_escaped_docstring(self):
         dataset = (
             # input,    expected
-            (r"abc",    r"abc"),
-            (r"\abc",   r"\\abc"),
-            (r"\a\bc",  r"\\a\\bc"),
-            (r"\a\\bc", r"\\a\\\\bc"),
-            (r'"abc"',  r'\"abc\"'),
-            (r"'a'",    r"\'a\'"),
+            (r"abc",    r'"abc"'),
+            (r"\abc",   r'"\\abc"'),
+            (r"\a\bc",  r'"\\a\\bc"'),
+            (r"\a\\bc", r'"\\a\\\\bc"'),
+            (r'"abc"',  r'"\"abc\""'),
+            (r"'a'",    r'"\'a\'"'),
         )
         for line, expected in dataset:
             with self.subTest(line=line, expected=expected):
-                out = clinic.quoted_for_c_string(line)
+                out = libclinic.docstring_for_c_string(line)
                 self.assertEqual(out, expected)
 
     def test_format_escape(self):
@@ -3784,7 +3785,7 @@ class FormatHelperTests(unittest.TestCase):
 
     def test_indent_all_lines(self):
         # Blank lines are expected to be unchanged.
-        self.assertEqual(clinic.indent_all_lines("", prefix="bar"), "")
+        self.assertEqual(libclinic.indent_all_lines("", prefix="bar"), "")
 
         lines = (
             "one\n"
@@ -3794,7 +3795,7 @@ class FormatHelperTests(unittest.TestCase):
             "barone\n"
             "bartwo"
         )
-        out = clinic.indent_all_lines(lines, prefix="bar")
+        out = libclinic.indent_all_lines(lines, prefix="bar")
         self.assertEqual(out, expected)
 
         # If last line is empty, expect it to be unchanged.
@@ -3810,12 +3811,12 @@ class FormatHelperTests(unittest.TestCase):
             "bartwo\n"
             ""
         )
-        out = clinic.indent_all_lines(lines, prefix="bar")
+        out = libclinic.indent_all_lines(lines, prefix="bar")
         self.assertEqual(out, expected)
 
     def test_suffix_all_lines(self):
         # Blank lines are expected to be unchanged.
-        self.assertEqual(clinic.suffix_all_lines("", suffix="foo"), "")
+        self.assertEqual(libclinic.suffix_all_lines("", suffix="foo"), "")
 
         lines = (
             "one\n"
@@ -3825,7 +3826,7 @@ class FormatHelperTests(unittest.TestCase):
             "onefoo\n"
             "twofoo"
         )
-        out = clinic.suffix_all_lines(lines, suffix="foo")
+        out = libclinic.suffix_all_lines(lines, suffix="foo")
         self.assertEqual(out, expected)
 
         # If last line is empty, expect it to be unchanged.
@@ -3841,7 +3842,7 @@ class FormatHelperTests(unittest.TestCase):
             "twofoo\n"
             ""
         )
-        out = clinic.suffix_all_lines(lines, suffix="foo")
+        out = libclinic.suffix_all_lines(lines, suffix="foo")
         self.assertEqual(out, expected)
 
 

--- a/Tools/clinic/clinic.py
+++ b/Tools/clinic/clinic.py
@@ -1307,8 +1307,7 @@ class CLanguage(Language):
 
             has_optional_kw = (
                 max(pos_only, min_pos) + min_kw_only
-                <
-                len(converters) - int(vararg != self.NO_VARARG)
+                < len(converters) - int(vararg != self.NO_VARARG)
             )
 
             if limited_capi:

--- a/Tools/clinic/libclinic/__init__.py
+++ b/Tools/clinic/libclinic/__init__.py
@@ -1,0 +1,38 @@
+from typing import Final
+
+from .formatting import (
+    c_repr,
+    docstring_for_c_string,
+    indent_all_lines,
+    pprint_words,
+    suffix_all_lines,
+    wrapped_c_string_literal,
+    SIG_END_MARKER,
+)
+
+
+CLINIC_PREFIX: Final[str] = "__clinic_"
+CLINIC_PREFIXED_ARGS: Final[frozenset[str]] = frozenset({
+    "_keywords",
+    "_parser",
+    "args",
+    "argsbuf",
+    "fastargs",
+    "kwargs",
+    "kwnames",
+    "nargs",
+    "noptargs",
+    "return_value",
+})
+
+
+__all__ = [
+    # Formatting helpers
+    "c_repr",
+    "docstring_for_c_string",
+    "indent_all_lines",
+    "pprint_words",
+    "suffix_all_lines",
+    "wrapped_c_string_literal",
+    "SIG_END_MARKER",
+]

--- a/Tools/clinic/libclinic/__init__.py
+++ b/Tools/clinic/libclinic/__init__.py
@@ -11,6 +11,18 @@ from .formatting import (
 )
 
 
+__all__ = [
+    # Formatting helpers
+    "c_repr",
+    "docstring_for_c_string",
+    "indent_all_lines",
+    "pprint_words",
+    "suffix_all_lines",
+    "wrapped_c_string_literal",
+    "SIG_END_MARKER",
+]
+
+
 CLINIC_PREFIX: Final = "__clinic_"
 CLINIC_PREFIXED_ARGS: Final = frozenset(
     {
@@ -26,15 +38,3 @@ CLINIC_PREFIXED_ARGS: Final = frozenset(
         "return_value",
     }
 )
-
-
-__all__ = [
-    # Formatting helpers
-    "c_repr",
-    "docstring_for_c_string",
-    "indent_all_lines",
-    "pprint_words",
-    "suffix_all_lines",
-    "wrapped_c_string_literal",
-    "SIG_END_MARKER",
-]

--- a/Tools/clinic/libclinic/__init__.py
+++ b/Tools/clinic/libclinic/__init__.py
@@ -11,8 +11,8 @@ from .formatting import (
 )
 
 
-CLINIC_PREFIX: Final[str] = "__clinic_"
-CLINIC_PREFIXED_ARGS: Final[frozenset[str]] = frozenset({
+CLINIC_PREFIX: Final = "__clinic_"
+CLINIC_PREFIXED_ARGS: Final = frozenset({
     "_keywords",
     "_parser",
     "args",

--- a/Tools/clinic/libclinic/__init__.py
+++ b/Tools/clinic/libclinic/__init__.py
@@ -12,18 +12,20 @@ from .formatting import (
 
 
 CLINIC_PREFIX: Final = "__clinic_"
-CLINIC_PREFIXED_ARGS: Final = frozenset({
-    "_keywords",
-    "_parser",
-    "args",
-    "argsbuf",
-    "fastargs",
-    "kwargs",
-    "kwnames",
-    "nargs",
-    "noptargs",
-    "return_value",
-})
+CLINIC_PREFIXED_ARGS: Final = frozenset(
+    {
+        "_keywords",
+        "_parser",
+        "args",
+        "argsbuf",
+        "fastargs",
+        "kwargs",
+        "kwnames",
+        "nargs",
+        "noptargs",
+        "return_value",
+    }
+)
 
 
 __all__ = [

--- a/Tools/clinic/libclinic/formatting.py
+++ b/Tools/clinic/libclinic/formatting.py
@@ -4,13 +4,13 @@ import textwrap
 from typing import Final
 
 
-SIG_END_MARKER: Final = '--'
+SIG_END_MARKER: Final = "--"
 
 
 def docstring_for_c_string(docstring: str) -> str:
     lines = []
     # turn docstring into a properly quoted C string
-    for line in docstring.split('\n'):
+    for line in docstring.split("\n"):
         lines.append('"')
         lines.append(_quoted_for_c_string(line))
         lines.append('\\n"\n')
@@ -22,13 +22,13 @@ def docstring_for_c_string(docstring: str) -> str:
     else:
         lines.pop()
         lines.append('"')
-    return ''.join(lines)
+    return "".join(lines)
 
 
 def _quoted_for_c_string(s: str) -> str:
     """Helper for docstring_for_c_string()."""
     for old, new in (
-        ('\\', '\\\\'), # must be first!
+        ("\\", "\\\\"),  # must be first!
         ('"', '\\"'),
         ("'", "\\'"),
     ):
@@ -44,14 +44,19 @@ def wrapped_c_string_literal(
     text: str,
     *,
     width: int = 72,
-    suffix: str = '',
+    suffix: str = "",
     initial_indent: int = 0,
     subsequent_indent: int = 4
 ) -> str:
-    wrapped = textwrap.wrap(text, width=width, replace_whitespace=False,
-                            drop_whitespace=False, break_on_hyphens=False)
-    separator = c_repr(suffix + '\n' + subsequent_indent * ' ')
-    return initial_indent * ' ' + c_repr(separator.join(wrapped))
+    wrapped = textwrap.wrap(
+        text,
+        width=width,
+        replace_whitespace=False,
+        drop_whitespace=False,
+        break_on_hyphens=False,
+    )
+    separator = c_repr(suffix + "\n" + subsequent_indent * " ")
+    return initial_indent * " " + c_repr(separator.join(wrapped))
 
 
 def _add_prefix_and_suffix(s: str, prefix: str = "", suffix: str = "") -> str:

--- a/Tools/clinic/libclinic/formatting.py
+++ b/Tools/clinic/libclinic/formatting.py
@@ -41,12 +41,12 @@ def c_repr(s: str) -> str:
 
 
 def wrapped_c_string_literal(
-        text: str,
-        *,
-        width: int = 72,
-        suffix: str = '',
-        initial_indent: int = 0,
-        subsequent_indent: int = 4
+    text: str,
+    *,
+    width: int = 72,
+    suffix: str = '',
+    initial_indent: int = 0,
+    subsequent_indent: int = 4
 ) -> str:
     wrapped = textwrap.wrap(text, width=width, replace_whitespace=False,
                             drop_whitespace=False, break_on_hyphens=False)

--- a/Tools/clinic/libclinic/formatting.py
+++ b/Tools/clinic/libclinic/formatting.py
@@ -4,7 +4,7 @@ import textwrap
 from typing import Final
 
 
-SIG_END_MARKER: Final[str] = '--'
+SIG_END_MARKER: Final = '--'
 
 
 def docstring_for_c_string(docstring: str) -> str:

--- a/Tools/clinic/libclinic/formatting.py
+++ b/Tools/clinic/libclinic/formatting.py
@@ -25,19 +25,19 @@ def docstring_for_c_string(docstring: str) -> str:
     return "".join(lines)
 
 
-def _quoted_for_c_string(s: str) -> str:
+def _quoted_for_c_string(text: str) -> str:
     """Helper for docstring_for_c_string()."""
     for old, new in (
         ("\\", "\\\\"),  # must be first!
         ('"', '\\"'),
         ("'", "\\'"),
     ):
-        s = s.replace(old, new)
-    return s
+        text = text.replace(old, new)
+    return text
 
 
-def c_repr(s: str) -> str:
-    return '"' + s + '"'
+def c_repr(text: str) -> str:
+    return '"' + text + '"'
 
 
 def wrapped_c_string_literal(

--- a/Tools/clinic/libclinic/formatting.py
+++ b/Tools/clinic/libclinic/formatting.py
@@ -1,4 +1,4 @@
-"""A collection of various string formatting helpers."""
+"""A collection of string formatting helpers."""
 import textwrap
 
 from typing import Final
@@ -9,7 +9,7 @@ SIG_END_MARKER: Final = "--"
 
 def docstring_for_c_string(docstring: str) -> str:
     lines = []
-    # turn docstring into a properly quoted C string
+    # Turn docstring into a properly quoted C string.
     for line in docstring.split("\n"):
         lines.append('"')
         lines.append(_quoted_for_c_string(line))

--- a/Tools/clinic/libclinic/formatting.py
+++ b/Tools/clinic/libclinic/formatting.py
@@ -1,0 +1,83 @@
+"""A collection of various string formatting helpers."""
+import textwrap
+
+from typing import Final
+
+
+SIG_END_MARKER: Final[str] = '--'
+
+
+def docstring_for_c_string(docstring: str) -> str:
+        lines = []
+        # turn docstring into a properly quoted C string
+        for line in docstring.split('\n'):
+            lines.append('"')
+            lines.append(_quoted_for_c_string(line))
+            lines.append('\\n"\n')
+
+        if lines[-2] == SIG_END_MARKER:
+            # If we only have a signature, add the blank line that the
+            # __text_signature__ getter expects to be there.
+            lines.append('"\\n"')
+        else:
+            lines.pop()
+            lines.append('"')
+        return ''.join(lines)
+
+
+def _quoted_for_c_string(s: str) -> str:
+    """Helper for docstring_for_c_string()."""
+    for old, new in (
+        ('\\', '\\\\'), # must be first!
+        ('"', '\\"'),
+        ("'", "\\'"),
+    ):
+        s = s.replace(old, new)
+    return s
+
+
+def c_repr(s: str) -> str:
+    return '"' + s + '"'
+
+
+def wrapped_c_string_literal(
+        text: str,
+        *,
+        width: int = 72,
+        suffix: str = '',
+        initial_indent: int = 0,
+        subsequent_indent: int = 4
+) -> str:
+    wrapped = textwrap.wrap(text, width=width, replace_whitespace=False,
+                            drop_whitespace=False, break_on_hyphens=False)
+    separator = c_repr(suffix + '\n' + subsequent_indent * ' ')
+    return initial_indent * ' ' + c_repr(separator.join(wrapped))
+
+
+def _add_prefix_and_suffix(s: str, prefix: str = "", suffix: str = "") -> str:
+    """Return 's', with 'prefix' prepended and 'suffix' appended to all lines.
+
+    If the last line is empty, it remains unchanged.
+    If s is blank, returns s unchanged.
+
+    (textwrap.indent only adds to non-blank lines.)
+    """
+    *split, last = s.split("\n")
+    lines = [prefix + line + suffix + "\n" for line in split]
+    if last:
+        lines.append(prefix + last + suffix)
+    return "".join(lines)
+
+
+def indent_all_lines(s: str, prefix: str) -> str:
+    return _add_prefix_and_suffix(s, prefix=prefix)
+
+
+def suffix_all_lines(s: str, suffix: str) -> str:
+    return _add_prefix_and_suffix(s, suffix=suffix)
+
+
+def pprint_words(items: list[str]) -> str:
+    if len(items) <= 2:
+        return " and ".join(items)
+    return ", ".join(items[:-1]) + " and " + items[-1]

--- a/Tools/clinic/libclinic/formatting.py
+++ b/Tools/clinic/libclinic/formatting.py
@@ -1,6 +1,6 @@
 """A collection of string formatting helpers."""
-import textwrap
 
+import textwrap
 from typing import Final
 
 

--- a/Tools/clinic/libclinic/formatting.py
+++ b/Tools/clinic/libclinic/formatting.py
@@ -8,21 +8,21 @@ SIG_END_MARKER: Final = '--'
 
 
 def docstring_for_c_string(docstring: str) -> str:
-        lines = []
-        # turn docstring into a properly quoted C string
-        for line in docstring.split('\n'):
-            lines.append('"')
-            lines.append(_quoted_for_c_string(line))
-            lines.append('\\n"\n')
+    lines = []
+    # turn docstring into a properly quoted C string
+    for line in docstring.split('\n'):
+        lines.append('"')
+        lines.append(_quoted_for_c_string(line))
+        lines.append('\\n"\n')
 
-        if lines[-2] == SIG_END_MARKER:
-            # If we only have a signature, add the blank line that the
-            # __text_signature__ getter expects to be there.
-            lines.append('"\\n"')
-        else:
-            lines.pop()
-            lines.append('"')
-        return ''.join(lines)
+    if lines[-2] == SIG_END_MARKER:
+        # If we only have a signature, add the blank line that the
+        # __text_signature__ getter expects to be there.
+        lines.append('"\\n"')
+    else:
+        lines.pop()
+        lines.append('"')
+    return ''.join(lines)
 
 
 def _quoted_for_c_string(s: str) -> str:

--- a/Tools/clinic/libclinic/formatting.py
+++ b/Tools/clinic/libclinic/formatting.py
@@ -59,27 +59,31 @@ def wrapped_c_string_literal(
     return initial_indent * " " + c_repr(separator.join(wrapped))
 
 
-def _add_prefix_and_suffix(s: str, prefix: str = "", suffix: str = "") -> str:
-    """Return 's', with 'prefix' prepended and 'suffix' appended to all lines.
+def _add_prefix_and_suffix(
+    text: str,
+    prefix: str = "",
+    suffix: str = ""
+) -> str:
+    """Return 'text' with 'prefix' prepended and 'suffix' appended to all lines.
 
     If the last line is empty, it remains unchanged.
-    If s is blank, returns s unchanged.
+    If text is blank, return text unchanged.
 
     (textwrap.indent only adds to non-blank lines.)
     """
-    *split, last = s.split("\n")
+    *split, last = text.split("\n")
     lines = [prefix + line + suffix + "\n" for line in split]
     if last:
         lines.append(prefix + last + suffix)
     return "".join(lines)
 
 
-def indent_all_lines(s: str, prefix: str) -> str:
-    return _add_prefix_and_suffix(s, prefix=prefix)
+def indent_all_lines(text: str, prefix: str) -> str:
+    return _add_prefix_and_suffix(text, prefix=prefix)
 
 
-def suffix_all_lines(s: str, suffix: str) -> str:
-    return _add_prefix_and_suffix(s, suffix=suffix)
+def suffix_all_lines(text: str, suffix: str) -> str:
+    return _add_prefix_and_suffix(text, suffix=suffix)
 
 
 def pprint_words(items: list[str]) -> str:


### PR DESCRIPTION
Split up clinic.py by establishing libclinic as a support package for
Argument Clinic. Get rid of clinic.py globals by either making them
class members, or by putting them into libclinic.

- Move INCLUDE_COMMENT_COLUMN to BlockPrinter
- Move NO_VARARG to CLanguage
- Move formatting helpers to libclinic
- Move some constants to libclinic (and annotate them as Final)


<!-- gh-issue-number: gh-113317 -->
* Issue: gh-113317
<!-- /gh-issue-number -->
