### PR TITLE
GH-113415: Remove unnecessary `io.text_encoding()` calls in pathlib

### DIFF
--- a/Lib/pathlib/_abc.py
+++ b/Lib/pathlib/_abc.py
@@ -1,5 +1,4 @@
 import functools
-import io
 import ntpath
 import posixpath
 import sys
@@ -755,7 +754,6 @@ class PathBase(PurePathBase):
         """
         Open the file in text mode, read it, and close the file.
         """
-        encoding = io.text_encoding(encoding)
         with self.open(mode='r', encoding=encoding, errors=errors, newline=newline) as f:
             return f.read()
 
@@ -775,7 +773,6 @@ class PathBase(PurePathBase):
         if not isinstance(data, str):
             raise TypeError('data must be str, not %s' %
                             data.__class__.__name__)
-        encoding = io.text_encoding(encoding)
         with self.open(mode='w', encoding=encoding, errors=errors, newline=newline) as f:
             return f.write(data)
 


### PR DESCRIPTION
`Path.open()` already calls `io.text_encoding()`, so we can safely remove these calls and remove the import of `io` from `pathlib._abc`.

<!-- gh-issue-number: gh-113415 -->
* Issue: gh-113415
<!-- /gh-issue-number -->
