### PR TITLE
GH-110109: pathlib ABCs: drop use of `io.text_encoding()`

### DIFF
--- a/Lib/pathlib/__init__.py
+++ b/Lib/pathlib/__init__.py
@@ -270,6 +270,24 @@ class Path(_abc.PathBase, PurePath):
             encoding = io.text_encoding(encoding)
         return io.open(self, mode, buffering, encoding, errors, newline)
 
+    def read_text(self, encoding=None, errors=None, newline=None):
+        """
+        Open the file in text mode, read it, and close the file.
+        """
+        # Call io.text_encoding() here to ensure any warning is raised at an
+        # appropriate stack level.
+        encoding = io.text_encoding(encoding)
+        return _abc.PathBase.read_text(self, encoding, errors, newline)
+
+    def write_text(self, data, encoding=None, errors=None, newline=None):
+        """
+        Open the file in text mode, write to it, and close the file.
+        """
+        # Call io.text_encoding() here to ensure any warning is raised at an
+        # appropriate stack level.
+        encoding = io.text_encoding(encoding)
+        return _abc.PathBase.write_text(self, data, encoding, errors, newline)
+
     def iterdir(self):
         """Yield path objects of the directory contents.
 

--- a/Lib/pathlib/_abc.py
+++ b/Lib/pathlib/_abc.py
@@ -1,5 +1,4 @@
 import functools
-import io
 import ntpath
 import posixpath
 import sys
@@ -755,7 +754,6 @@ class PathBase(PurePathBase):
         """
         Open the file in text mode, read it, and close the file.
         """
-        encoding = io.text_encoding(encoding)
         with self.open(mode='r', encoding=encoding, errors=errors, newline=newline) as f:
             return f.read()
 
@@ -775,7 +773,6 @@ class PathBase(PurePathBase):
         if not isinstance(data, str):
             raise TypeError('data must be str, not %s' %
                             data.__class__.__name__)
-        encoding = io.text_encoding(encoding)
         with self.open(mode='w', encoding=encoding, errors=errors, newline=newline) as f:
             return f.write(data)
 


### PR DESCRIPTION
Do not use the locale-specific default encoding in `PathBase.read_text()` and `write_text()`. Locale settings shouldn't influence the operation of these base classes, which are intended mostly for implementing rich paths on *nonlocal* filesystems.

Also add a comment explaining the necessity of the `io.text_encoding()` call in `Path.read_text()` and `write_text()` despite its presence in `open()`.

<!-- gh-issue-number: gh-110109 -->
* Issue: gh-110109
<!-- /gh-issue-number -->
