### PR TITLE
GH-113350: Changed the python docs 3.12.1 in logging HOWTO

### DIFF
--- a/Doc/howto/logging-cookbook.rst
+++ b/Doc/howto/logging-cookbook.rst
@@ -333,7 +333,7 @@ Suppose you configure logging with the following JSON:
     }
 
 This configuration does *almost* what we want, except that ``sys.stdout`` would
-show messages of severity ``ERROR`` and above as well as ``INFO`` and
+show messages of severity ``ERROR`` and only events of this level and higher severity will be tracked as well as ``INFO`` and
 ``WARNING`` messages. To prevent this, we can set up a filter which excludes
 those messages and add it to the relevant handler. This can be configured by
 adding a ``filters`` section parallel to ``formatters`` and ``handlers``:

--- a/Doc/howto/logging.rst
+++ b/Doc/howto/logging.rst
@@ -89,9 +89,8 @@ described below (in increasing order of severity):
 |              | itself may be unable to continue running.   |
 +--------------+---------------------------------------------+
 
-The default level is ``WARNING``, which means that only events of this level
-and above will be tracked, unless the logging package is configured to do
-otherwise.
+The default level is ``WARNING``, which means that only events of this level and higher severity and above will be tracked, 
+unless the logging package is configured to do otherwise.
 
 Events that are tracked can be handled in different ways. The simplest way of
 handling tracked events is to print them to the console. Another common way


### PR DESCRIPTION
Fix #113350 - Basic logging tutorial: Confusing matrix and use of word "above"

This Pull Request changes the documentation of  `logging-cookbook.rst` and `logging.rst` from "above" word to required changes.

<!-- gh-issue-number: gh-113350 -->
* Issue: gh-113350
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--113424.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->