### PR TITLE
gh-103092: Make `_elementtree` module importable in sub-interpreters

### DIFF
--- a/Modules/_elementtree.c
+++ b/Modules/_elementtree.c
@@ -4418,9 +4418,7 @@ error:
 
 static struct PyModuleDef_Slot elementtree_slots[] = {
     {Py_mod_exec, module_exec},
-    // XXX gh-103092: fix isolation.
-    {Py_mod_multiple_interpreters, Py_MOD_MULTIPLE_INTERPRETERS_NOT_SUPPORTED},
-    //{Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
+    {Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
     {0, NULL},
 };
 


### PR DESCRIPTION
It's looks like `_elementtree` is already isolated: #104561 but field `Py_mod_multiple_interpreters` is still set to `Py_MOD_MULTIPLE_INTERPRETERS_NOT_SUPPORTED`, Kumar just forgot to change it :)

<!-- gh-issue-number: gh-103092 -->
* Issue: gh-103092
<!-- /gh-issue-number -->
