### PR TITLE
gh-113440: Ignore the "ver" command failure with exit code 0xc0000142

### DIFF
--- a/Lib/test/pythoninfo.py
+++ b/Lib/test/pythoninfo.py
@@ -925,6 +925,8 @@ def collect_windows(info_add):
                                 stderr=subprocess.PIPE,
                                 text=True)
         output = proc.communicate()[0]
+        if proc.returncode == 0xc0000142:
+            return
         if proc.returncode:
             output = ""
     except OSError:


### PR DESCRIPTION


<!-- gh-issue-number: gh-113440 -->
* Issue: gh-113440
<!-- /gh-issue-number -->
