### PR TITLE
gh-110459: Make sure --with-openssl-rpath works on macOS

### DIFF
--- a/Misc/NEWS.d/next/macOS/2023-12-23-22-41-07.gh-issue-110459.NaMBJy.rst
+++ b/Misc/NEWS.d/next/macOS/2023-12-23-22-41-07.gh-issue-110459.NaMBJy.rst
@@ -1,2 +1,2 @@
-Running `configure ... --with-openssl-rpath=X/Y/Z` no longer fails to detect
+Running ``configure ... --with-openssl-rpath=X/Y/Z`` no longer fails to detect
 OpenSSL on macOS.

--- a/Misc/NEWS.d/next/macOS/2023-12-23-22-41-07.gh-issue-110459.NaMBJy.rst
+++ b/Misc/NEWS.d/next/macOS/2023-12-23-22-41-07.gh-issue-110459.NaMBJy.rst
@@ -1,0 +1,2 @@
+Running `configure ... --with-openssl-rpath=X/Y/Z` no longer fails to detect
+OpenSSL on macOS.

--- a/configure
+++ b/configure
@@ -27472,7 +27472,12 @@ then :
 
 else $as_nop
 
-  rpath_arg="-Wl,-rpath="
+  if test "$ac_sys_system" = "Darwin"
+  then
+     rpath_arg="-Wl,-rpath,"
+  else
+     rpath_arg="-Wl,-rpath="
+  fi
 
 fi
 

--- a/configure.ac
+++ b/configure.ac
@@ -6807,7 +6807,12 @@ AX_CHECK_OPENSSL([have_openssl=yes],[have_openssl=no])
 AS_VAR_IF([GNULD], [yes], [
   rpath_arg="-Wl,--enable-new-dtags,-rpath="
 ], [
-  rpath_arg="-Wl,-rpath="
+  if test "$ac_sys_system" = "Darwin"
+  then
+     rpath_arg="-Wl,-rpath,"
+  else
+     rpath_arg="-Wl,-rpath="
+  fi
 ])
 
 AC_MSG_CHECKING([for --with-openssl-rpath])


### PR DESCRIPTION
On macOS the `-rpath` linker flag is spelled differently than on on platforms.

<!-- gh-issue-number: gh-110459 -->
* Issue: gh-110459
<!-- /gh-issue-number -->
