### PR TITLE
gh-113456:Adapt to the file name change of LICENSE of openssl

### DIFF
--- a/Misc/NEWS.d/next/Build/2023-12-24-13-33-27.gh-issue-113456.LCUy-W.rst
+++ b/Misc/NEWS.d/next/Build/2023-12-24-13-33-27.gh-issue-113456.LCUy-W.rst
@@ -1,0 +1,1 @@
+Determine whether to copy LICENSE or LICENSE.txt by checking if it exists

--- a/PCbuild/openssl.vcxproj
+++ b/PCbuild/openssl.vcxproj
@@ -98,7 +98,8 @@ nmake
 
   <Target Name="_CopyToOutput" AfterTargets="Build">
     <ItemGroup>
-      <_Built Include="$(opensslDir)\LICENSE" />
+      <_Built Include="$(opensslDir)\LICENSE" Condition="Exists('$(opensslDir)\LICENSE')"/>
+      <_Built Include="$(opensslDir)\LICENSE.txt" Condition="Exists('$(opensslDir)\LICENSE.txt')"/>
       <_Built Include="$(IntDir)\libcrypto.lib;$(IntDir)\libcrypto-*.dll;$(IntDir)\libcrypto-*.pdb" />
       <_Built Include="$(IntDir)\libssl.lib;$(IntDir)\libssl-*.dll;$(IntDir)\libssl-*.pdb" />
       <_AppLink Include="$(opensslDir)\ms\applink.c" />


### PR DESCRIPTION
* Issue: [Prepare ssl failed because the file name of LICENSE of openssl changed #113456
](https://github.com/python/cpython/issues/113456)


<!-- gh-issue-number: gh-113456 -->
* Issue: gh-113456
<!-- /gh-issue-number -->
