### PR TITLE
fix bullet-list in `LOAD_SUPER_ATTR` documentation on `dis` page

### DIFF
--- a/Doc/library/dis.rst
+++ b/Doc/library/dis.rst
@@ -1214,9 +1214,10 @@ iterations of the loop.
    ``super(cls, self).method()``, ``super(cls, self).attr``).
 
    It pops three values from the stack (from top of stack down):
-   - ``self``: the first argument to the current method
-   -  ``cls``: the class within which the current method was defined
-   -  the global ``super``
+
+   * ``self``: the first argument to the current method
+   * ``cls``: the class within which the current method was defined
+   * the global ``super``
 
    With respect to its argument, it works similarly to :opcode:`LOAD_ATTR`,
    except that ``namei`` is shifted left by 2 bits instead of 1.


### PR DESCRIPTION
no issue number because change is trivial

before/after:
![image](https://github.com/python/cpython/assets/47365157/2bc29941-8e49-419c-8973-9752116dbd70)
![image](https://github.com/python/cpython/assets/47365157/94d08ff3-de7f-448d-8640-c66a33175ad6)


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--113461.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->