### PR TITLE
[3.11] gh-101778: Fix build error when there's a dangling symlink in the directory containing "ffi.h"

### DIFF
--- a/Misc/NEWS.d/next/Build/2023-12-25-10-06-59.gh-issue-101778.JfhRkx.rst
+++ b/Misc/NEWS.d/next/Build/2023-12-25-10-06-59.gh-issue-101778.JfhRkx.rst
@@ -1,0 +1,2 @@
+Fix build error when there's a dangling symlink in the directory containing
+``ffi.h``.

--- a/setup.py
+++ b/setup.py
@@ -224,6 +224,7 @@ def is_macosx_sdk_path(path):
 
 def grep_headers_for(function, headers):
     for header in headers:
+        if not os.path.exists(header): continue
         with open(header, 'r', errors='surrogateescape') as f:
             if function in f.read():
                 return True


### PR DESCRIPTION
`grep_headers_for` in `setup.py` was not robust when encountering dangling symlinks.

This PR directly targets 3.11 because the build machinery for extensions was changed in 3.12 and therefore main and 3.12 don't need updating.

<!-- gh-issue-number: gh-101778 -->
* Issue: gh-101778
<!-- /gh-issue-number -->
