### PR TITLE
gh-66515: Fix locking of an MH mailbox without ".mh_sequences" file

### DIFF
--- a/Lib/test/test_mailbox.py
+++ b/Lib/test/test_mailbox.py
@@ -1360,6 +1360,15 @@ class TestMH(TestMailbox, unittest.TestCase):
         box.set_sequences({})
         self.assertEqual(os.listdir(path), ['.mh_sequences'])
 
+    def test_lock_unlock_no_dot_mh_sequences_file(self):
+        path = os.path.join(self._path, 'foo.bar')
+        os.mkdir(path)
+        box = self._factory(path)
+        self.assertEqual(os.listdir(path), [])
+        box.lock()
+        box.unlock()
+        self.assertEqual(os.listdir(path), ['.mh_sequences'])
+
     def test_issue2625(self):
         msg0 = mailbox.MHMessage(self._template % 0)
         msg0.add_sequence('foo')


### PR DESCRIPTION
Guarantee that it eiser open an existing ".mh_sequences" file or create a new ".mh_sequences" file, but do not replace existing ".mh_sequences" file.



<!-- gh-issue-number: gh-66515 -->
* Issue: gh-66515
<!-- /gh-issue-number -->
