### PR TITLE
GH-113350: Enhancing Error Level Representation in Logging HOWTO page of python docs 3.12.1 by changing the word "above" to required changes.

### DIFF
--- a/Doc/howto/logging-cookbook.rst
+++ b/Doc/howto/logging-cookbook.rst
@@ -334,7 +334,7 @@ Suppose you configure logging with the following JSON:
 
 This configuration does *almost* what we want, except that ``sys.stdout`` would show messages
 of severity ``ERROR`` and only events of this severity and higher will be tracked
-as well as ``INFO`` and ``WARNING`` messages. To prevent this, we can set up a filter which 
+as well as ``INFO`` and ``WARNING`` messages. To prevent this, we can set up a filter which
 excludes those messages and add it to the relevant handler. This can be configured by
 adding a ``filters`` section parallel to ``formatters`` and ``handlers``:
 

--- a/Doc/howto/logging-cookbook.rst
+++ b/Doc/howto/logging-cookbook.rst
@@ -332,10 +332,10 @@ Suppose you configure logging with the following JSON:
         }
     }
 
-This configuration does *almost* what we want, except that ``sys.stdout`` would
-show messages of severity ``ERROR`` and only events of this level and higher severity will be tracked as well as ``INFO`` and
-``WARNING`` messages. To prevent this, we can set up a filter which excludes
-those messages and add it to the relevant handler. This can be configured by
+This configuration does *almost* what we want, except that ``sys.stdout`` would show messages
+of severity ``ERROR`` and only events of this severity and higher will be tracked
+as well as ``INFO`` and ``WARNING`` messages. To prevent this, we can set up a filter which 
+excludes those messages and add it to the relevant handler. This can be configured by
 adding a ``filters`` section parallel to ``formatters`` and ``handlers``:
 
 .. code-block:: json

--- a/Doc/howto/logging-cookbook.rst
+++ b/Doc/howto/logging-cookbook.rst
@@ -333,7 +333,7 @@ Suppose you configure logging with the following JSON:
     }
 
 This configuration does *almost* what we want, except that ``sys.stdout`` would
-show messages of severity ``ERROR`` and above as well as ``INFO`` and
+show messages of severity ``ERROR`` and only events of this level and higher severity will be tracked as well as ``INFO`` and
 ``WARNING`` messages. To prevent this, we can set up a filter which excludes
 those messages and add it to the relevant handler. This can be configured by
 adding a ``filters`` section parallel to ``formatters`` and ``handlers``:

--- a/Doc/howto/logging.rst
+++ b/Doc/howto/logging.rst
@@ -89,8 +89,8 @@ described below (in increasing order of severity):
 |              | itself may be unable to continue running.   |
 +--------------+---------------------------------------------+
 
-The default level is ``WARNING``, which means that only events of this level and higher severity and above will be tracked, 
-unless the logging package is configured to do otherwise.
+The default level is ``WARNING``, which means that only events of this severity and higher
+will be tracked, unless the logging package is configured to do otherwise.
 
 Events that are tracked can be handled in different ways. The simplest way of
 handling tracked events is to print them to the console. Another common way

--- a/Doc/howto/logging.rst
+++ b/Doc/howto/logging.rst
@@ -89,9 +89,8 @@ described below (in increasing order of severity):
 |              | itself may be unable to continue running.   |
 +--------------+---------------------------------------------+
 
-The default level is ``WARNING``, which means that only events of this level
-and above will be tracked, unless the logging package is configured to do
-otherwise.
+The default level is ``WARNING``, which means that only events of this level and higher severity and above will be tracked, 
+unless the logging package is configured to do otherwise.
 
 Events that are tracked can be handled in different ways. The simplest way of
 handling tracked events is to print them to the console. Another common way


### PR DESCRIPTION

Fix #113350 Basic logging tutorial: Confusing matrix and use of word "above" 

This Pull Request changes the documentation of logging-cookbook.rst and logging.rst from "above" word to required changes. 
Review the current sorting logic for error levels and also split the lines as told before with the intended arrangement.
This approach will enhance user understanding and optimize the functionality of the logging HOWTO for improved user experience.




<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--113491.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->

<!-- gh-issue-number: gh-113350 -->
* Issue: gh-113350
<!-- /gh-issue-number -->
