### PR TITLE
gh-101100: Fix Sphinx warnings in `howto/isolating-extensions.rst`

### DIFF
--- a/Doc/howto/isolating-extensions.rst
+++ b/Doc/howto/isolating-extensions.rst
@@ -337,7 +337,7 @@ That is, heap types should:
 
 - Have the :c:macro:`Py_TPFLAGS_HAVE_GC` flag.
 - Define a traverse function using ``Py_tp_traverse``, which
-  visits the type (e.g. using :c:expr:`Py_VISIT(Py_TYPE(self))`).
+  visits the type (e.g. using ``Py_VISIT(Py_TYPE(self))``).
 
 Please refer to the the documentation of
 :c:macro:`Py_TPFLAGS_HAVE_GC` and :c:member:`~PyTypeObject.tp_traverse`
@@ -482,7 +482,7 @@ The largest roadblock is getting *the class a method was defined in*, or
 that method's "defining class" for short. The defining class can have a
 reference to the module it is part of.
 
-Do not confuse the defining class with :c:expr:`Py_TYPE(self)`. If the method
+Do not confuse the defining class with ``Py_TYPE(self)``. If the method
 is called on a *subclass* of your type, ``Py_TYPE(self)`` will refer to
 that subclass, which may be defined in different module than yours.
 

--- a/Doc/tools/.nitignore
+++ b/Doc/tools/.nitignore
@@ -23,7 +23,6 @@ Doc/extending/extending.rst
 Doc/glossary.rst
 Doc/howto/descriptor.rst
 Doc/howto/enum.rst
-Doc/howto/isolating-extensions.rst
 Doc/howto/logging.rst
 Doc/howto/urllib2.rst
 Doc/library/ast.rst


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

Fix these two warnings:

```
Doc/howto/isolating-extensions.rst:339: WARNING: c:identifier reference target not found: self
Doc/howto/isolating-extensions.rst:485: WARNING: c:identifier reference target not found: self
```


<!-- gh-issue-number: gh-101100 -->
* Issue: gh-101100
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--113493.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->