### PR TITLE
gh-101100: Fix Sphinx warnings in `c-api/float.rst`

### DIFF
--- a/Doc/c-api/float.rst
+++ b/Doc/c-api/float.rst
@@ -162,3 +162,12 @@ represents a NaN or infinity.
 .. c:function:: double PyFloat_Unpack8(const unsigned char *p, int le)
 
    Unpack the IEEE 754 binary64 double precision format as a C double.
+
+Constants
+^^^^^^^^^
+
+.. c:macro:: PY_BIG_ENDIAN
+
+   A constant which can be used by pack and unpack functions to use the native
+   endian: it is equal to ``1`` on big endian processor, or ``0`` on little
+   endian processor.

--- a/Doc/tools/.nitignore
+++ b/Doc/tools/.nitignore
@@ -5,7 +5,6 @@
 Doc/c-api/descriptor.rst
 Doc/c-api/exceptions.rst
 Doc/c-api/file.rst
-Doc/c-api/float.rst
 Doc/c-api/gcsupport.rst
 Doc/c-api/init.rst
 Doc/c-api/init_config.rst


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


Fix these warnings by documenting the constant:

```
Doc/c-api/float.rst:109: WARNING: c:macro reference target not found: PY_BIG_ENDIAN
Doc/c-api/float.rst:140: WARNING: c:macro reference target not found: PY_BIG_ENDIAN
```


<!-- gh-issue-number: gh-101100 -->
* Issue: gh-101100
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--113494.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->