### PR TITLE
gh-101100: Fix Sphinx warnings in `library/bisect.rst`

### DIFF
--- a/Doc/library/bisect.rst
+++ b/Doc/library/bisect.rst
@@ -19,9 +19,9 @@ linear searches or frequent resorting.
 The module is called :mod:`bisect` because it uses a basic bisection
 algorithm to do its work.  Unlike other bisection tools that search for a
 specific value, the functions in this module are designed to locate an
-insertion point. Accordingly, the functions never call an :meth:`__eq__`
+insertion point. Accordingly, the functions never call an :meth:`~object.__eq__`
 method to determine whether a value has been found.  Instead, the
-functions only call the :meth:`__lt__` method and will return an insertion
+functions only call the :meth:`~object.__lt__` method and will return an insertion
 point between values in an array.
 
 .. _bisect functions:
@@ -73,7 +73,7 @@ The following functions are provided:
    Insert *x* in *a* in sorted order.
 
    This function first runs :py:func:`~bisect.bisect_left` to locate an insertion point.
-   Next, it runs the :meth:`insert` method on *a* to insert *x* at the
+   Next, it runs the :meth:`!insert` method on *a* to insert *x* at the
    appropriate position to maintain sort order.
 
    To support inserting records in a table, the *key* function (if any) is
@@ -93,7 +93,7 @@ The following functions are provided:
    entries of *x*.
 
    This function first runs :py:func:`~bisect.bisect_right` to locate an insertion point.
-   Next, it runs the :meth:`insert` method on *a* to insert *x* at the
+   Next, it runs the :meth:`!insert` method on *a* to insert *x* at the
    appropriate position to maintain sort order.
 
    To support inserting records in a table, the *key* function (if any) is

--- a/Doc/tools/.nitignore
+++ b/Doc/tools/.nitignore
@@ -32,7 +32,6 @@ Doc/library/asyncio-policy.rst
 Doc/library/asyncio-subprocess.rst
 Doc/library/asyncio-task.rst
 Doc/library/bdb.rst
-Doc/library/bisect.rst
 Doc/library/calendar.rst
 Doc/library/cmd.rst
 Doc/library/collections.rst


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

Fix these four warnings, by linking to the `object` methods for the first two, and silencing the last two with `!`:

```
Doc/library/bisect.rst:19: WARNING: py:meth reference target not found: __eq__
Doc/library/bisect.rst:19: WARNING: py:meth reference target not found: __lt__
Doc/library/bisect.rst:75: WARNING: py:meth reference target not found: insert
Doc/library/bisect.rst:95: WARNING: py:meth reference target not found: insert
```


<!-- gh-issue-number: gh-101100 -->
* Issue: gh-101100
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--113496.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->