### PR TITLE
gh-101100: Fix Sphinx warnings in `library/calendar.rst`

### DIFF
--- a/Doc/library/calendar.rst
+++ b/Doc/library/calendar.rst
@@ -196,6 +196,13 @@ interpreted as prescribed by the ISO 8601 standard.  Year 0 is 1 BC, year -1 is
       output (defaulting to the system default encoding).
 
 
+   .. method:: formatmonthname(theyear, themonth, withyear=True)
+
+      Return a month name as an HTML table row. If *withyear* is true the year
+      will be included in the row, otherwise just the month name will be
+      used.
+
+
    :class:`!HTMLCalendar` has the following attributes you can override to
    customize the CSS classes used by the calendar:
 
@@ -289,7 +296,7 @@ interpreted as prescribed by the ISO 8601 standard.  Year 0 is 1 BC, year -1 is
 
 .. note::
 
-   The constructor, :meth:`formatweekday` and :meth:`formatmonthname` methods
+   The constructor, :meth:`!formatweekday` and :meth:`!formatmonthname` methods
    of these two classes temporarily change the ``LC_TIME`` locale to the given
    *locale*. Because the current locale is a process-wide setting, they are
    not thread-safe.
@@ -358,7 +365,7 @@ For simple text calendars this module provides the following functions.
 
 .. function:: month(theyear, themonth, w=0, l=0)
 
-   Returns a month's calendar in a multi-line string using the :meth:`formatmonth`
+   Returns a month's calendar in a multi-line string using the :meth:`~TextCalendar.formatmonth`
    of the :class:`TextCalendar` class.
 
 
@@ -370,7 +377,7 @@ For simple text calendars this module provides the following functions.
 .. function:: calendar(year, w=2, l=1, c=6, m=3)
 
    Returns a 3-column calendar for an entire year as a multi-line string using
-   the :meth:`formatyear` of the :class:`TextCalendar` class.
+   the :meth:`~TextCalendar.formatyear` of the :class:`TextCalendar` class.
 
 
 .. function:: timegm(tuple)

--- a/Doc/tools/.nitignore
+++ b/Doc/tools/.nitignore
@@ -32,7 +32,6 @@ Doc/library/asyncio-subprocess.rst
 Doc/library/asyncio-task.rst
 Doc/library/bdb.rst
 Doc/library/bisect.rst
-Doc/library/calendar.rst
 Doc/library/cmd.rst
 Doc/library/collections.rst
 Doc/library/concurrent.futures.rst


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

Fix these five warnings:

* the first by documenting it
* the next two each refer to methods of _two_ subclasses, so it's not obvious which subclass (or superclass)'s methods to link to, so just silence with `!`
* the last two by including the relevant class in the link

```
Doc/library/calendar.rst:232: WARNING: py:meth reference target not found: formatmonthname
Doc/library/calendar.rst:292: WARNING: py:meth reference target not found: formatweekday
Doc/library/calendar.rst:292: WARNING: py:meth reference target not found: formatmonthname
Doc/library/calendar.rst:361: WARNING: py:meth reference target not found: formatmonth
Doc/library/calendar.rst:372: WARNING: py:meth reference target not found: formatyear
```



<!-- gh-issue-number: gh-101100 -->
* Issue: gh-101100
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--113500.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->