### PR TITLE
gh-101100: Fix Sphinx warnings in `library/cmd.rst`

### DIFF
--- a/Doc/library/cmd.rst
+++ b/Doc/library/cmd.rst
@@ -76,27 +76,30 @@ A :class:`Cmd` instance has the following methods:
       single: ! (exclamation); in a command interpreter
 
    An interpreter instance will recognize a command name ``foo`` if and only if it
-   has a method :meth:`do_foo`.  As a special case, a line beginning with the
+   has a method :meth:`!do_foo`.  As a special case, a line beginning with the
    character ``'?'`` is dispatched to the method :meth:`do_help`.  As another
    special case, a line beginning with the character ``'!'`` is dispatched to the
-   method :meth:`do_shell` (if such a method is defined).
+   method :meth:`!do_shell` (if such a method is defined).
 
    This method will return when the :meth:`postcmd` method returns a true value.
    The *stop* argument to :meth:`postcmd` is the return value from the command's
    corresponding :meth:`!do_\*` method.
 
    If completion is enabled, completing commands will be done automatically, and
-   completing of commands args is done by calling :meth:`complete_foo` with
+   completing of commands args is done by calling :meth:`!complete_foo` with
    arguments *text*, *line*, *begidx*, and *endidx*.  *text* is the string prefix
    we are attempting to match: all returned matches must begin with it. *line* is
    the current input line with leading whitespace removed, *begidx* and *endidx*
    are the beginning and ending indexes of the prefix text, which could be used to
    provide different completion depending upon which position the argument is in.
 
+
+.. method:: Cmd.do_help(arg)
+
    All subclasses of :class:`Cmd` inherit a predefined :meth:`do_help`.  This
    method, called with an argument ``'bar'``, invokes the corresponding method
-   :meth:`help_bar`, and if that is not present, prints the docstring of
-   :meth:`do_bar`, if available.  With no argument, :meth:`do_help` lists all
+   :meth:`!help_bar`, and if that is not present, prints the docstring of
+   :meth:`!do_bar`, if available.  With no argument, :meth:`do_help` lists all
    available help topics (that is, all commands with corresponding
    :meth:`!help_\*` methods or commands that have docstrings), and also lists any
    undocumented commands.
@@ -229,8 +232,8 @@ Instances of :class:`Cmd` subclasses have some public instance variables:
 .. attribute:: Cmd.use_rawinput
 
    A flag, defaulting to true.  If true, :meth:`cmdloop` uses :func:`input` to
-   display a prompt and read the next command; if false, :meth:`sys.stdout.write`
-   and :meth:`sys.stdin.readline` are used. (This means that by importing
+   display a prompt and read the next command; if false, :meth:`!sys.stdout.write`
+   and :meth:`!sys.stdin.readline` are used. (This means that by importing
    :mod:`readline`, on systems that support it, the interpreter will automatically
    support :program:`Emacs`\ -like line editing  and command-history keystrokes.)
 
@@ -249,14 +252,14 @@ This section presents a simple example of how to build a shell around a few of
 the commands in the :mod:`turtle` module.
 
 Basic turtle commands such as :meth:`~turtle.forward` are added to a
-:class:`Cmd` subclass with method named :meth:`do_forward`.  The argument is
+:class:`Cmd` subclass with method named :meth:`!do_forward`.  The argument is
 converted to a number and dispatched to the turtle module.  The docstring is
 used in the help utility provided by the shell.
 
 The example also includes a basic record and playback facility implemented with
 the :meth:`~Cmd.precmd` method which is responsible for converting the input to
-lowercase and writing the commands to a file.  The :meth:`do_playback` method
-reads the file and adds the recorded commands to the :attr:`cmdqueue` for
+lowercase and writing the commands to a file.  The :meth:`!do_playback` method
+reads the file and adds the recorded commands to the :attr:`~Cmd.cmdqueue` for
 immediate playback::
 
     import cmd, sys

--- a/Doc/library/cmd.rst
+++ b/Doc/library/cmd.rst
@@ -232,8 +232,8 @@ Instances of :class:`Cmd` subclasses have some public instance variables:
 .. attribute:: Cmd.use_rawinput
 
    A flag, defaulting to true.  If true, :meth:`cmdloop` uses :func:`input` to
-   display a prompt and read the next command; if false, :data:`sys.stdout.write <sys.stdout>`
-   and :data:`sys.stdin.readline <sys.stdin>` are used. (This means that by importing
+   display a prompt and read the next command; if false, :data:`sys.stdout.write() <sys.stdout>`
+   and :data:`sys.stdin.readline() <sys.stdin>` are used. (This means that by importing
    :mod:`readline`, on systems that support it, the interpreter will automatically
    support :program:`Emacs`\ -like line editing  and command-history keystrokes.)
 

--- a/Doc/library/cmd.rst
+++ b/Doc/library/cmd.rst
@@ -232,8 +232,8 @@ Instances of :class:`Cmd` subclasses have some public instance variables:
 .. attribute:: Cmd.use_rawinput
 
    A flag, defaulting to true.  If true, :meth:`cmdloop` uses :func:`input` to
-   display a prompt and read the next command; if false, :meth:`!sys.stdout.write`
-   and :meth:`!sys.stdin.readline` are used. (This means that by importing
+   display a prompt and read the next command; if false, :data:`sys.stdout.write <sys.stdout>`
+   and :data:`sys.stdin.readline <sys.stdin>` are used. (This means that by importing
    :mod:`readline`, on systems that support it, the interpreter will automatically
    support :program:`Emacs`\ -like line editing  and command-history keystrokes.)
 

--- a/Doc/library/cmd.rst
+++ b/Doc/library/cmd.rst
@@ -96,10 +96,10 @@ A :class:`Cmd` instance has the following methods:
 
 .. method:: Cmd.do_help(arg)
 
-   All subclasses of :class:`Cmd` inherit a predefined :meth:`do_help`.  This
+   All subclasses of :class:`Cmd` inherit a predefined :meth:`!do_help`.  This
    method, called with an argument ``'bar'``, invokes the corresponding method
    :meth:`!help_bar`, and if that is not present, prints the docstring of
-   :meth:`!do_bar`, if available.  With no argument, :meth:`do_help` lists all
+   :meth:`!do_bar`, if available.  With no argument, :meth:`!do_help` lists all
    available help topics (that is, all commands with corresponding
    :meth:`!help_\*` methods or commands that have docstrings), and also lists any
    undocumented commands.

--- a/Doc/tools/.nitignore
+++ b/Doc/tools/.nitignore
@@ -33,7 +33,6 @@ Doc/library/asyncio-task.rst
 Doc/library/bdb.rst
 Doc/library/bisect.rst
 Doc/library/calendar.rst
-Doc/library/cmd.rst
 Doc/library/collections.rst
 Doc/library/concurrent.futures.rst
 Doc/library/configparser.rst


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
Fix 13 Sphinx warnings:

* `do_foo`, `complete_foo`, `help_bar` and `do_bar`, `do_forward` and `do_playback` are examples, silence with `!`
* There's already a paragraph about `do_help`, let's add `.. method:: Cmd.do_help(arg)` so it can be linked to
* Silence `sys.stdout.write` and `sys.stdin.readline` with `!`. Or is there somewhere good to link to? 
* `cmdqueue` was missing the class ref, change to `~Cmd.cmdqueue`

```
Doc/library/cmd.rst:78: WARNING: py:meth reference target not found: do_foo
Doc/library/cmd.rst:78: WARNING: py:meth reference target not found: do_help
Doc/library/cmd.rst:78: WARNING: py:meth reference target not found: do_shell
Doc/library/cmd.rst:88: WARNING: py:meth reference target not found: complete_foo
Doc/library/cmd.rst:96: WARNING: py:meth reference target not found: do_help
Doc/library/cmd.rst:96: WARNING: py:meth reference target not found: help_bar
Doc/library/cmd.rst:96: WARNING: py:meth reference target not found: do_bar
Doc/library/cmd.rst:96: WARNING: py:meth reference target not found: do_help
Doc/library/cmd.rst:231: WARNING: py:meth reference target not found: sys.stdout.write
Doc/library/cmd.rst:231: WARNING: py:meth reference target not found: sys.stdin.readline
Doc/library/cmd.rst:251: WARNING: py:meth reference target not found: do_forward
Doc/library/cmd.rst:256: WARNING: py:meth reference target not found: do_playback
Doc/library/cmd.rst:256: WARNING: py:attr reference target not found: cmdqueue
```


<!-- gh-issue-number: gh-101100 -->
* Issue: gh-101100
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--113502.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->