### PR TITLE
GH-113528: Remove a couple of expensive pathlib ABC tests

### DIFF
--- a/Lib/test/test_pathlib/test_pathlib_abc.py
+++ b/Lib/test/test_pathlib/test_pathlib_abc.py
@@ -8,7 +8,6 @@ import unittest
 from pathlib._abc import UnsupportedOperation, PurePathBase, PathBase
 import posixpath
 
-from test.support import set_recursion_limit
 from test.support.os_helper import TESTFN
 
 
@@ -1224,25 +1223,6 @@ class DummyPathTest(DummyPurePathTest):
                   }
         self.assertEqual(given, {p / x for x in expect})
 
-    def test_glob_many_open_files(self):
-        depth = 30
-        P = self.cls
-        p = base = P(self.base) / 'deep'
-        p.mkdir()
-        for _ in range(depth):
-            p /= 'd'
-            p.mkdir()
-        pattern = '/'.join(['*'] * depth)
-        iters = [base.glob(pattern) for j in range(100)]
-        for it in iters:
-            self.assertEqual(next(it), p)
-        iters = [base.rglob('d') for j in range(100)]
-        p = base
-        for i in range(depth):
-            p = p / 'd'
-            for it in iters:
-                self.assertEqual(next(it), p)
-
     def test_glob_dotdot(self):
         # ".." is not special in globs.
         P = self.cls
@@ -1285,17 +1265,6 @@ class DummyPathTest(DummyPurePathTest):
         bad_link = base / 'bad_link'
         bad_link.symlink_to("bad" * 200)
         self.assertEqual(sorted(base.glob('**/*')), [bad_link])
-
-    def test_glob_above_recursion_limit(self):
-        recursion_limit = 50
-        # directory_depth > recursion_limit
-        directory_depth = recursion_limit + 10
-        base = self.cls(self.base, 'deep')
-        path = base.joinpath(*(['d'] * directory_depth))
-        path.mkdir(parents=True)
-
-        with set_recursion_limit(recursion_limit):
-            list(base.glob('**/'))
 
     def test_glob_recursive_no_trailing_slash(self):
         P = self.cls
@@ -1825,17 +1794,6 @@ class DummyPathTest(DummyPurePathTest):
         else:
             self.fail("symlink not found")
 
-    def test_walk_above_recursion_limit(self):
-        recursion_limit = 40
-        # directory_depth > recursion_limit
-        directory_depth = recursion_limit + 10
-        base = self.cls(self.base, 'deep')
-        path = base.joinpath(*(['d'] * directory_depth))
-        path.mkdir(parents=True)
-
-        with set_recursion_limit(recursion_limit):
-            list(base.walk())
-            list(base.walk(top_down=False))
 
 class DummyPathWithSymlinks(DummyPath):
     def readlink(self):


### PR DESCRIPTION
Run expensive tests for walking and globbing from `test_pathlib` but not `test_pathlib_abc`. The ABCs are not as tightly optimised as the classes in top-level `pathlib`, and so these tests are taking rather a long time on some buildbots. Coverage of the main `pathlib` classes should suffice.


<!-- gh-issue-number: gh-113528 -->
* Issue: gh-113528
<!-- /gh-issue-number -->
