### PR TITLE
gh-103092: Make ``pyexpat`` module importable in sub-interpreters

### DIFF
--- a/Modules/pyexpat.c
+++ b/Modules/pyexpat.c
@@ -2062,9 +2062,7 @@ pyexpat_free(void *module)
 
 static PyModuleDef_Slot pyexpat_slots[] = {
     {Py_mod_exec, pyexpat_exec},
-    // XXX gh-103092: fix isolation.
-    {Py_mod_multiple_interpreters, Py_MOD_MULTIPLE_INTERPRETERS_NOT_SUPPORTED},
-    //{Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
+    {Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
     {0, NULL}
 };
 


### PR DESCRIPTION
`pyexpat` is already isolated: #104506

<!-- gh-issue-number: gh-103092 -->
* Issue: gh-103092
<!-- /gh-issue-number -->
