### PR TITLE
gh-113548: Allow CLI arguments to `pdb -m`

### DIFF
--- a/Lib/pdb.py
+++ b/Lib/pdb.py
@@ -2186,14 +2186,16 @@ def main():
     import argparse
 
     parser = argparse.ArgumentParser(prog="pdb",
+                                     usage="%(prog)s [-h] [-c command] (-m module | pyfile) [args ...]",
                                      description=_usage,
                                      formatter_class=argparse.RawDescriptionHelpFormatter,
                                      allow_abbrev=False)
 
+    # We need to maunally get the script from args, because the first positional
+    # arguments could be either the script we need to debug, or the argument
+    # to the -m module
     parser.add_argument('-c', '--command', action='append', default=[], metavar='command')
-    group = parser.add_mutually_exclusive_group(required=True)
-    group.add_argument('-m', metavar='module')
-    group.add_argument('pyfile', nargs='?')
+    parser.add_argument('-m', metavar='module')
     parser.add_argument('args', nargs="*")
 
     if len(sys.argv) == 1:
@@ -2208,7 +2210,11 @@ def main():
         file = opts.m
         target = _ModuleTarget(file)
     else:
-        file = opts.pyfile
+        # No module is given, use the first positional argument as the script to debug
+        if not opts.args:
+            parser.error("one of the arguments -m pyfile is required")
+        file = opts.args[0]
+        opts.args = opts.args[1:]
         target = _ScriptTarget(file)
 
     target.check()

--- a/Lib/pdb.py
+++ b/Lib/pdb.py
@@ -2198,7 +2198,7 @@ def main():
                         help='pdb commands to execute as if given in a .pdbrc file')
     parser.add_argument('-m', metavar='module', dest='module')
     parser.add_argument('args', nargs='*',
-                        help="the first arg is the script to debug if -m is not specified")
+                        help="when -m is not specified, the first arg is the script to debug")
 
     if len(sys.argv) == 1:
         # If no arguments were given (python -m pdb), print the whole help message.

--- a/Lib/pdb.py
+++ b/Lib/pdb.py
@@ -2197,8 +2197,8 @@ def main():
     parser.add_argument('-c', '--command', action='append', default=[], metavar='command', dest='commands',
                         help='pdb commands to execute as if given in a .pdbrc file')
     parser.add_argument('-m', metavar='module', dest='module')
-    parser.add_argument('pyfile', nargs='?')
-    parser.add_argument('args', nargs='*')
+    parser.add_argument('args', nargs='*',
+                        help="the first arg is the script to debug if -m is not specified")
 
     if len(sys.argv) == 1:
         # If no arguments were given (python -m pdb), print the whole help message.
@@ -2211,13 +2211,10 @@ def main():
     if opts.module:
         file = opts.module
         target = _ModuleTarget(file)
-        # If the module is given, the first positional argument is not the script
-        if opts.pyfile:
-            opts.args = [opts.pyfile] + opts.args
     else:
-        if not opts.pyfile:
+        if not opts.args:
             parser.error("no module or script to run")
-        file = opts.pyfile
+        file = opts.args.pop(0)
         target = _ScriptTarget(file)
 
     target.check()

--- a/Lib/pdb.py
+++ b/Lib/pdb.py
@@ -2216,7 +2216,7 @@ def main():
             opts.args = [opts.pyfile] + opts.args
     else:
         if not opts.pyfile:
-            parser.error("one of the arguments -m pyfile is required")
+            parser.error("no module or script to run")
         file = opts.pyfile
         target = _ScriptTarget(file)
 

--- a/Lib/test/test_pdb.py
+++ b/Lib/test/test_pdb.py
@@ -2959,6 +2959,15 @@ def bœr():
         stdout, stderr = self.run_pdb_module(script, commands)
         self.assertTrue(any("SUCCESS" in l for l in stdout.splitlines()), stdout)
 
+    def test_run_module_with_args(self):
+        commands = """
+            continue
+        """
+        self._run_pdb(["calendar", "-m"], commands, expected_returncode=2)
+
+        stdout, _ = self._run_pdb(["-m", "calendar", "1"], commands)
+        self.assertIn("December", stdout)
+
     def test_breakpoint(self):
         script = """
             if __name__ == '__main__':

--- a/Misc/NEWS.d/next/Library/2023-12-28-22-52-45.gh-issue-113548.j6TJ7O.rst
+++ b/Misc/NEWS.d/next/Library/2023-12-28-22-52-45.gh-issue-113548.j6TJ7O.rst
@@ -1,0 +1,1 @@
+Allow CLI arguments to pdb -m

--- a/Misc/NEWS.d/next/Library/2023-12-28-22-52-45.gh-issue-113548.j6TJ7O.rst
+++ b/Misc/NEWS.d/next/Library/2023-12-28-22-52-45.gh-issue-113548.j6TJ7O.rst
@@ -1,1 +1,1 @@
-Allow CLI arguments to pdb -m
+:mod:`pdb` now allows CLI arguments to ``pdb -m``.


### PR DESCRIPTION
Currently we can't pass arguments when we debug a module with `pdb`, because the first argument will be considered as pyfile(the script to debug) which makes `argparse` mad (mutually exclusive group!).

The usage string is great though, very informative, but we(I) can't make this work properly with our `argparse`.

In order to deal with it, we put the first argument (pyfile) back into `opts.args` if `-m` exists. We like the usage string so we just give the old one to `ArgumentParser` to fake it - it's much easier to understand than the would-be default.

The internal code is not the cleanest (but not difficult to follow), but on the user side it works pretty well.

Some requests from @vstinner in #109165 is also addressed.

<!-- gh-issue-number: gh-113548 -->
* Issue: gh-113548
<!-- /gh-issue-number -->
