### PR TITLE
gh-101100: Fix Sphinx warnings in `c-api/structures.rst`

### DIFF
--- a/Doc/c-api/structures.rst
+++ b/Doc/c-api/structures.rst
@@ -517,11 +517,11 @@ The following flags can be used with :c:member:`PyMemberDef.flags`:
    from ``PyObject``.
 
    Can only be used as part of :c:member:`Py_tp_members <PyTypeObject.tp_members>`
-   :c:type:`slot <PyTypeSlot>` when creating a class using negative
+   :c:type:`slot <PyType_Slot>` when creating a class using negative
    :c:member:`~PyType_Spec.basicsize`.
    It is mandatory in that case.
 
-   This flag is only used in :c:type:`PyTypeSlot`.
+   This flag is only used in :c:type:`PyType_Slot`.
    When setting :c:member:`~PyTypeObject.tp_members` during
    class creation, Python clears it and sets
    :c:member:`PyMemberDef.offset` to the offset from the ``PyObject`` struct.

--- a/Doc/c-api/structures.rst
+++ b/Doc/c-api/structures.rst
@@ -660,7 +660,7 @@ Defining Getters and Setters
    .. c:member:: setter set
 
       Optional C function to set or delete the attribute.
-      If ``NULL``, the attribute is readonly.
+      If ``NULL``, the attribute is read-only.
 
    .. c:member:: const char* doc
 

--- a/Doc/c-api/structures.rst
+++ b/Doc/c-api/structures.rst
@@ -669,18 +669,18 @@ Defining Getters and Setters
 
       Optional function pointer, providing additional data for getter and setter.
 
-   The ``get`` function takes one :c:expr:`PyObject*` parameter (the
-   instance) and a function pointer (the associated ``closure``)::
+.. c:type:: PyObject *(*getter)(PyObject *, void *)
 
-      typedef PyObject *(*getter)(PyObject *, void *);
+   The ``get`` function takes one :c:expr:`PyObject*` parameter (the
+   instance) and a function pointer (the associated ``closure``):
 
    It should return a new reference on success or ``NULL`` with a set exception
    on failure.
 
-   ``set`` functions take two :c:expr:`PyObject*` parameters (the instance and
-   the value to be set) and a function pointer (the associated ``closure``)::
+.. c:type:: int (*setter)(PyObject *, PyObject *, void *)
 
-      typedef int (*setter)(PyObject *, PyObject *, void *);
+   ``set`` functions take two :c:expr:`PyObject*` parameters (the instance and
+   the value to be set) and a function pointer (the associated ``closure``):
 
    In case the attribute should be deleted the second parameter is ``NULL``.
    Should return ``0`` on success or ``-1`` with a set exception on failure.

--- a/Doc/c-api/structures.rst
+++ b/Doc/c-api/structures.rst
@@ -659,7 +659,8 @@ Defining Getters and Setters
 
    .. c:member:: setter set
 
-      Optional C function to set or delete the attribute, if omitted the attribute is readonly.
+      Optional C function to set or delete the attribute.
+      If ``NULL``, the attribute is readonly.
 
    .. c:member:: const char* doc
 

--- a/Doc/tools/.nitignore
+++ b/Doc/tools/.nitignore
@@ -15,7 +15,6 @@ Doc/c-api/memoryview.rst
 Doc/c-api/module.rst
 Doc/c-api/object.rst
 Doc/c-api/stable.rst
-Doc/c-api/structures.rst
 Doc/c-api/sys.rst
 Doc/c-api/type.rst
 Doc/c-api/typeobj.rst


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

Fix these two warnings:
```
Doc/c-api/structures.rst:519: WARNING: c:type reference target not found: PyTypeSlot
Doc/c-api/structures.rst:524: WARNING: c:type reference target not found: PyTypeSlot
```

They're typos, should be `PyType_Slot`. See PR https://github.com/python/cpython/pull/103511 where they were added (to 3.12, no backport needed for 3.11).

That leaves these two warnings in this file:

```
Doc/c-api/structures.rst:656: WARNING: c:identifier reference target not found: getter
Doc/c-api/structures.rst:660: WARNING: c:identifier reference target not found: setter
```

I'm not sure what to do with these, any ideas? (Added in PR https://github.com/python/cpython/pull/100054, also in 3.12.)


<!-- gh-issue-number: gh-101100 -->
* Issue: gh-101100
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--113564.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->