### PR TITLE
gh-101225: Fix hang when passing Pipe instances to child in multiprocessing

### DIFF
--- a/Lib/multiprocessing/managers.py
+++ b/Lib/multiprocessing/managers.py
@@ -156,7 +156,7 @@ class Server(object):
         Listener, Client = listener_client[serializer]
 
         # do authentication later
-        self.listener = Listener(address=address, backlog=16)
+        self.listener = Listener(address=address, backlog=128)
         self.address = self.listener.address
 
         self.id_to_obj = {'0': (None, ())}

--- a/Lib/multiprocessing/resource_sharer.py
+++ b/Lib/multiprocessing/resource_sharer.py
@@ -123,7 +123,7 @@ class _ResourceSharer(object):
         from .connection import Listener
         assert self._listener is None, "Already have Listener"
         util.debug('starting listener and thread for sending handles')
-        self._listener = Listener(authkey=process.current_process().authkey, backlog=16)
+        self._listener = Listener(authkey=process.current_process().authkey, backlog=128)
         self._address = self._listener.address
         t = threading.Thread(target=self._serve)
         t.daemon = True

--- a/Lib/multiprocessing/resource_sharer.py
+++ b/Lib/multiprocessing/resource_sharer.py
@@ -123,7 +123,7 @@ class _ResourceSharer(object):
         from .connection import Listener
         assert self._listener is None, "Already have Listener"
         util.debug('starting listener and thread for sending handles')
-        self._listener = Listener(authkey=process.current_process().authkey)
+        self._listener = Listener(authkey=process.current_process().authkey, backlog=16)
         self._address = self._listener.address
         t = threading.Thread(target=self._serve)
         t.daemon = True

--- a/Misc/NEWS.d/next/Library/2023-12-29-17-46-06.gh-issue-101225.QaEyxF.rst
+++ b/Misc/NEWS.d/next/Library/2023-12-29-17-46-06.gh-issue-101225.QaEyxF.rst
@@ -1,0 +1,2 @@
+Fix a hang in :mod:`multiprocessing` when passing ``Pipe`` instances to
+workers on macOS.

--- a/Misc/NEWS.d/next/Library/2023-12-29-17-46-06.gh-issue-101225.QaEyxF.rst
+++ b/Misc/NEWS.d/next/Library/2023-12-29-17-46-06.gh-issue-101225.QaEyxF.rst
@@ -1,4 +1,4 @@
 Increase the backlog for :class:`multiprocessing.connection.Listener` objects created
-by :mod:`multiprocessing.manaager` and :mod:`multiprocessing.resource_sharer` to 
+by :mod:`multiprocessing.manaager` and :mod:`multiprocessing.resource_sharer` to
 significantly reduce the risk of getting a connection refused error when creating
 a :class:`multiprocessing.connection.Connection` to them.

--- a/Misc/NEWS.d/next/Library/2023-12-29-17-46-06.gh-issue-101225.QaEyxF.rst
+++ b/Misc/NEWS.d/next/Library/2023-12-29-17-46-06.gh-issue-101225.QaEyxF.rst
@@ -1,2 +1,4 @@
-Fix a hang in :mod:`multiprocessing` when passing ``Pipe`` instances to
-workers on macOS.
+Increase the backlog for :class:`multiprocessing.connection.Listener` objects created
+by :mod:`multiprocessing.manaager` and :mod:`multiprocessing.resource_sharer` to 
+significantly reduce the risk of getting a connection refused error when creating
+a :class:`multiprocessing.connection.Connection` to them.

--- a/Misc/NEWS.d/next/Library/2023-12-29-17-46-06.gh-issue-101225.QaEyxF.rst
+++ b/Misc/NEWS.d/next/Library/2023-12-29-17-46-06.gh-issue-101225.QaEyxF.rst
@@ -1,4 +1,4 @@
 Increase the backlog for :class:`multiprocessing.connection.Listener` objects created
-by :mod:`multiprocessing.manaager` and :mod:`multiprocessing.resource_sharer` to
+by :mod:`multiprocessing.manager` and :mod:`multiprocessing.resource_sharer` to
 significantly reduce the risk of getting a connection refused error when creating
 a :class:`multiprocessing.connection.Connection` to them.


### PR DESCRIPTION
This PR uses the same backlog value when creating
a `.connection.Client` in `.resource_sharer` as is used in `.manager`.

On macOS the default backlog (1) is small enough to cause the socket accept queue to fill up when starting a number of children.


<!-- gh-issue-number: gh-101225 -->
* Issue: gh-101225
<!-- /gh-issue-number -->
