### PR TITLE
gh-113569: Display calls in Mock.assert_has_calls failure when empty

### DIFF
--- a/Lib/test/test_unittest/testmock/testmock.py
+++ b/Lib/test/test_unittest/testmock/testmock.py
@@ -1547,6 +1547,8 @@ class MockTest(unittest.TestCase):
         mock = Mock(spec=f)
         mock(1)
 
+        uncalled_mock = Mock()
+
         with self.assertRaisesRegex(
                 AssertionError,
                 '^{}$'.format(
@@ -1556,6 +1558,14 @@ class MockTest(unittest.TestCase):
             mock.assert_has_calls([call()])
         self.assertIsNone(cm.exception.__cause__)
 
+        with self.assertRaisesRegex(
+                AssertionError,
+                '^{}$'.format(
+                    re.escape('Calls not found.\n'
+                              'Expected: [call()]\n'
+                              '  Actual: []'))) as cm:
+            uncalled_mock.assert_has_calls([call()])
+        self.assertIsNone(cm.exception.__cause__)
 
         with self.assertRaisesRegex(
                 AssertionError,

--- a/Lib/test/test_unittest/testmock/testmock.py
+++ b/Lib/test/test_unittest/testmock/testmock.py
@@ -1547,34 +1547,33 @@ class MockTest(unittest.TestCase):
         mock = Mock(spec=f)
         mock(1)
 
-        with self.assertRaisesRegex(
-                AssertionError,
-                '^{}$'.format(
-                    re.escape('Calls not found.\n'
-                              'Expected: [call()]\n'
-                              '  Actual: [call(1)]'))) as cm:
+        with self.assertRaises(AssertionError) as cm:
             mock.assert_has_calls([call()])
+        self.assertEqual(str(cm.exception),
+            'Calls not found.\n'
+            'Expected: [call()]\n'
+            '  Actual: [call(1)]'
+        )
         self.assertIsNone(cm.exception.__cause__)
 
         uncalled_mock = Mock()
-        with self.assertRaisesRegex(
-                AssertionError,
-                '^{}$'.format(
-                    re.escape('Calls not found.\n'
-                              'Expected: [call()]\n'
-                              '  Actual: []'))) as cm:
+        with self.assertRaises(AssertionError) as cm:
             uncalled_mock.assert_has_calls([call()])
+        self.assertEqual(str(cm.exception),
+            'Calls not found.\n'
+            'Expected: [call()]\n'
+            '  Actual: []'
+        )
         self.assertIsNone(cm.exception.__cause__)
 
-        with self.assertRaisesRegex(
-                AssertionError,
-                '^{}$'.format(
-                    re.escape(
-                        'Error processing expected calls.\n'
-                        "Errors: [None, TypeError('too many positional arguments')]\n"
-                        "Expected: [call(), call(1, 2)]\n"
-                        '  Actual: [call(1)]'))) as cm:
+        with self.assertRaises(AssertionError) as cm:
             mock.assert_has_calls([call(), call(1, 2)])
+        self.assertEqual(str(cm.exception),
+            'Error processing expected calls.\n'
+            "Errors: [None, TypeError('too many positional arguments')]\n"
+            'Expected: [call(), call(1, 2)]\n'
+            '  Actual: [call(1)]'
+        )
         self.assertIsInstance(cm.exception.__cause__, TypeError)
 
     def test_assert_any_call(self):

--- a/Lib/test/test_unittest/testmock/testmock.py
+++ b/Lib/test/test_unittest/testmock/testmock.py
@@ -1547,8 +1547,6 @@ class MockTest(unittest.TestCase):
         mock = Mock(spec=f)
         mock(1)
 
-        uncalled_mock = Mock()
-
         with self.assertRaisesRegex(
                 AssertionError,
                 '^{}$'.format(
@@ -1558,6 +1556,7 @@ class MockTest(unittest.TestCase):
             mock.assert_has_calls([call()])
         self.assertIsNone(cm.exception.__cause__)
 
+        uncalled_mock = Mock()
         with self.assertRaisesRegex(
                 AssertionError,
                 '^{}$'.format(

--- a/Lib/unittest/mock.py
+++ b/Lib/unittest/mock.py
@@ -1085,7 +1085,7 @@ class NonCallableMock(Base):
         return klass(**kw)
 
 
-    def _calls_repr(self, prefix="Calls", display_empty=False):
+    def _calls_repr(self, prefix="Calls", *, display_empty=False):
         """Renders self.mock_calls as a string.
 
         Example: "\nCalls: [call(1), call(2)]."

--- a/Lib/unittest/mock.py
+++ b/Lib/unittest/mock.py
@@ -1011,7 +1011,7 @@ class NonCallableMock(Base):
                 raise AssertionError(
                     f'{problem}\n'
                     f'Expected: {_CallList(calls)}'
-                    f'{self._calls_repr(prefix="  Actual").rstrip(".")}'
+                    f'{self._calls_repr(prefix="  Actual", display_empty=True).rstrip(".")}'
                 ) from cause
             return
 
@@ -1085,7 +1085,7 @@ class NonCallableMock(Base):
         return klass(**kw)
 
 
-    def _calls_repr(self, prefix="Calls"):
+    def _calls_repr(self, prefix="Calls", display_empty=False):
         """Renders self.mock_calls as a string.
 
         Example: "\nCalls: [call(1), call(2)]."
@@ -1093,7 +1093,7 @@ class NonCallableMock(Base):
         If self.mock_calls is empty, an empty string is returned. The
         output will be truncated if very long.
         """
-        if not self.mock_calls:
+        if not self.mock_calls and not display_empty:
             return ""
         return f"\n{prefix}: {safe_repr(self.mock_calls)}."
 

--- a/Lib/unittest/mock.py
+++ b/Lib/unittest/mock.py
@@ -1010,8 +1010,8 @@ class NonCallableMock(Base):
                                     for e in expected])
                 raise AssertionError(
                     f'{problem}\n'
-                    f'Expected: {_CallList(calls)}'
-                    f'{self._calls_repr(prefix="  Actual", display_empty=True).rstrip(".")}'
+                    f'Expected: {_CallList(calls)}\n'
+                    f'  Actual: {safe_repr(self.mock_calls)}'
                 ) from cause
             return
 
@@ -1085,7 +1085,7 @@ class NonCallableMock(Base):
         return klass(**kw)
 
 
-    def _calls_repr(self, prefix="Calls", *, display_empty=False):
+    def _calls_repr(self):
         """Renders self.mock_calls as a string.
 
         Example: "\nCalls: [call(1), call(2)]."
@@ -1093,9 +1093,9 @@ class NonCallableMock(Base):
         If self.mock_calls is empty, an empty string is returned. The
         output will be truncated if very long.
         """
-        if not self.mock_calls and not display_empty:
+        if not self.mock_calls:
             return ""
-        return f"\n{prefix}: {safe_repr(self.mock_calls)}."
+        return f"\nCalls: {safe_repr(self.mock_calls)}."
 
 
 # Denylist for forbidden attribute names in safe mode

--- a/Misc/NEWS.d/next/Library/2023-12-29-17-57-45.gh-issue-113569.qcRCEI.rst
+++ b/Misc/NEWS.d/next/Library/2023-12-29-17-57-45.gh-issue-113569.qcRCEI.rst
@@ -1,0 +1,2 @@
+Display list of actual calls in unittest `Mock.assert_has_calls` failure
+message even if empty.

--- a/Misc/NEWS.d/next/Library/2023-12-29-17-57-45.gh-issue-113569.qcRCEI.rst
+++ b/Misc/NEWS.d/next/Library/2023-12-29-17-57-45.gh-issue-113569.qcRCEI.rst
@@ -1,2 +1,2 @@
-Display list of actual calls in unittest `Mock.assert_has_calls` failure
-message even if empty.
+Indicate if there were no actual calls in unittest
+:meth:`~unittest.mock.Mock.assert_has_calls` failure.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
Closes #113569

<!-- gh-issue-number: gh-113569 -->
* Issue: gh-113569
<!-- /gh-issue-number -->
