### PR TITLE
[3.11] gh-113566: Fix asyncio segfault

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2023-12-29-16-55-12.gh-issue-113566.grGQEg.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2023-12-29-16-55-12.gh-issue-113566.grGQEg.rst
@@ -1,0 +1,2 @@
+Fix a 3.11-specific crash when the ``repr`` of a :class:`~asyncio.Future` is
+requested after the module has already been garbage-collected.

--- a/Modules/_asynciomodule.c
+++ b/Modules/_asynciomodule.c
@@ -1377,6 +1377,9 @@ static PyObject *
 FutureObj_repr(FutureObj *fut)
 {
     ENSURE_FUTURE_ALIVE(fut)
+    if (asyncio_future_repr_func == NULL) {
+        return PyUnicode_FromFormat("<Future at %p>", fut);
+    }
     return PyObject_CallOneArg(asyncio_future_repr_func, (PyObject *)fut);
 }
 


### PR DESCRIPTION
This fixes a 3.11-specific segfault when the `repr()` of a `Future` is requested during process finalization, after the `_asyncio` module has already cleared its globals. We couldn't repro it on 3.12 or later.

<!-- gh-issue-number: gh-113566 -->
* Issue: gh-113566
<!-- /gh-issue-number -->
