### PR TITLE
gh-89414: Document that SIGCLD is not available on macOS

### DIFF
--- a/Doc/library/signal.rst
+++ b/Doc/library/signal.rst
@@ -157,6 +157,8 @@ The variables defined in the :mod:`signal` module are:
 
    Alias to :data:`SIGCHLD`.
 
+   .. availability:: not macOS
+
 .. data:: SIGCONT
 
    Continue the process if it is currently stopped

--- a/Doc/library/signal.rst
+++ b/Doc/library/signal.rst
@@ -157,7 +157,7 @@ The variables defined in the :mod:`signal` module are:
 
    Alias to :data:`SIGCHLD`.
 
-   .. availability:: not macOS
+   .. availability:: not macOS.
 
 .. data:: SIGCONT
 


### PR DESCRIPTION


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--113580.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->

<!-- gh-issue-number: gh-89414 -->
* Issue: gh-89414
<!-- /gh-issue-number -->
