### PR TITLE
GH-113595: Don't enter invalid executor

### DIFF
--- a/Python/bytecodes.c
+++ b/Python/bytecodes.c
@@ -2364,17 +2364,27 @@ dummy_func(
 
             PyCodeObject *code = _PyFrame_GetCode(frame);
             _PyExecutorObject *executor = (_PyExecutorObject *)code->co_executors->executors[oparg&255];
-            Py_INCREF(executor);
-            if (executor->execute == _PyUOpExecute) {
-                current_executor = (_PyUOpExecutorObject *)executor;
-                GOTO_TIER_TWO();
+            if (executor->vm_data.valid) {
+                Py_INCREF(executor);
+                if (executor->execute == _PyUOpExecute) {
+                    current_executor = (_PyUOpExecutorObject *)executor;
+                    GOTO_TIER_TWO();
+                }
+                next_instr = executor->execute(executor, frame, stack_pointer);
+                frame = tstate->current_frame;
+                if (next_instr == NULL) {
+                    goto resume_with_error;
+                }
+                stack_pointer = _PyFrame_GetStackPointer(frame);
             }
-            next_instr = executor->execute(executor, frame, stack_pointer);
-            frame = tstate->current_frame;
-            if (next_instr == NULL) {
-                goto resume_with_error;
+            else {
+                opcode = this_instr->op.code = executor->vm_data.opcode;
+                this_instr->op.arg = executor->vm_data.oparg;
+                oparg = (oparg & (~255)) | executor->vm_data.oparg;
+                code->co_executors->executors[oparg&255] = NULL;
+                Py_DECREF(executor);
+                DISPATCH_GOTO();
             }
-            stack_pointer = _PyFrame_GetStackPointer(frame);
         }
 
         replaced op(_POP_JUMP_IF_FALSE, (cond -- )) {


### PR DESCRIPTION
This PR checks if an executor is invalid before entering it.
If the executor is invalid, it cleans up the `ENTER_EXECUTOR` and executor.

<!-- gh-issue-number: gh-113595 -->
* Issue: gh-113595
<!-- /gh-issue-number -->
