### PR TITLE
gh-101100: Fix Sphinx warnings in `library/configparser.rst`

### DIFF
--- a/Doc/library/configparser.rst
+++ b/Doc/library/configparser.rst
@@ -208,7 +208,7 @@ converters and customize the provided ones. [1]_
 Fallback Values
 ---------------
 
-As with a dictionary, you can use a section's :meth:`get` method to
+As with a dictionary, you can use a section's :meth:`~ConfigParser.get` method to
 provide fallback values:
 
 .. doctest::
@@ -232,7 +232,7 @@ even if we specify a fallback:
    >>> topsecret.get('CompressionLevel', '3')
    '9'
 
-One more thing to be aware of is that the parser-level :meth:`get` method
+One more thing to be aware of is that the parser-level :meth:`~ConfigParser.get` method
 provides a custom, more complex interface, maintained for backwards
 compatibility.  When using this method, a fallback value can be provided via
 the ``fallback`` keyword-only argument:
@@ -481,7 +481,7 @@ historical background and it's very likely that you will want to customize some
 of the features.
 
 The most common way to change the way a specific config parser works is to use
-the :meth:`__init__` options:
+the :meth:`!__init__` options:
 
 * *defaults*, default value: ``None``
 
@@ -491,7 +491,7 @@ the :meth:`__init__` options:
   the documented default.
 
   Hint: if you want to specify default values for a specific section, use
-  :meth:`read_dict` before you read the actual file.
+  :meth:`~ConfigParser.read_dict` before you read the actual file.
 
 * *dict_type*, default value: :class:`dict`
 
@@ -635,8 +635,8 @@ the :meth:`__init__` options:
 * *strict*, default value: ``True``
 
   When set to ``True``, the parser will not allow for any section or option
-  duplicates while reading from a single source (using :meth:`read_file`,
-  :meth:`read_string` or :meth:`read_dict`).  It is recommended to use strict
+  duplicates while reading from a single source (using :meth:`~ConfigParser.read_file`,
+  :meth:`~ConfigParser.read_string` or :meth:`~ConfigParser.read_dict`).  It is recommended to use strict
   parsers in new applications.
 
   .. versionchanged:: 3.2
@@ -697,7 +697,7 @@ the :meth:`__init__` options:
   desirable, users may define them in a subclass or pass a dictionary where each
   key is a name of the converter and each value is a callable implementing said
   conversion.  For instance, passing ``{'decimal': decimal.Decimal}`` would add
-  :meth:`getdecimal` on both the parser object and all section proxies.  In
+  :meth:`!getdecimal` on both the parser object and all section proxies.  In
   other words, it will be possible to write both
   ``parser_instance.getdecimal('section', 'key', fallback=0)`` and
   ``parser_instance['section'].getdecimal('key', 0)``.
@@ -1062,11 +1062,11 @@ ConfigParser Objects
       yielding Unicode strings (for example files opened in text mode).
 
       Optional argument *source* specifies the name of the file being read.  If
-      not given and *f* has a :attr:`name` attribute, that is used for
+      not given and *f* has a :attr:`!name` attribute, that is used for
       *source*; the default is ``'<???>'``.
 
       .. versionadded:: 3.2
-         Replaces :meth:`readfp`.
+         Replaces :meth:`!readfp`.
 
    .. method:: read_string(string, source='<string>')
 
@@ -1214,7 +1214,7 @@ ConfigParser Objects
 
 .. data:: MAX_INTERPOLATION_DEPTH
 
-   The maximum depth for recursive interpolation for :meth:`get` when the *raw*
+   The maximum depth for recursive interpolation for :meth:`~configparser.ConfigParser.get` when the *raw*
    parameter is false.  This is relevant only when the default *interpolation*
    is used.
 
@@ -1287,13 +1287,13 @@ Exceptions
 
 .. exception:: DuplicateSectionError
 
-   Exception raised if :meth:`add_section` is called with the name of a section
+   Exception raised if :meth:`~ConfigParser.add_section` is called with the name of a section
    that is already present or in strict parsers when a section if found more
    than once in a single input file, string or dictionary.
 
    .. versionadded:: 3.2
       Optional ``source`` and ``lineno`` attributes and arguments to
-      :meth:`__init__` were added.
+      :meth:`!__init__` were added.
 
 
 .. exception:: DuplicateOptionError
@@ -1345,9 +1345,9 @@ Exceptions
 
    Exception raised when errors occur attempting to parse a file.
 
-.. versionchanged:: 3.12
-   The ``filename`` attribute and :meth:`__init__` constructor argument were
-   removed.  They have been available using the name ``source`` since 3.2.
+   .. versionchanged:: 3.12
+      The ``filename`` attribute and :meth:`!__init__` constructor argument were
+      removed.  They have been available using the name ``source`` since 3.2.
 
 .. rubric:: Footnotes
 

--- a/Doc/library/logging.config.rst
+++ b/Doc/library/logging.config.rst
@@ -93,8 +93,8 @@ in :mod:`logging` itself) and defining handlers which are declared either in
 
    :param fname: A filename, or a file-like object, or an instance derived
                  from :class:`~configparser.RawConfigParser`. If a
-                 ``RawConfigParser``-derived instance is passed, it is used as
-                 is. Otherwise, a :class:`~configparser.Configparser` is
+                 :class:`!RawConfigParser`-derived instance is passed, it is used as
+                 is. Otherwise, a :class:`~configparser.ConfigParser` is
                  instantiated, and the configuration read by it from the
                  object passed in ``fname``. If that has a :meth:`readline`
                  method, it is assumed to be a file-like object and read using
@@ -103,7 +103,7 @@ in :mod:`logging` itself) and defining handlers which are declared either in
                  :meth:`~configparser.ConfigParser.read`.
 
 
-   :param defaults: Defaults to be passed to the ConfigParser can be specified
+   :param defaults: Defaults to be passed to the :class:`!ConfigParser` can be specified
                     in this argument.
 
    :param disable_existing_loggers: If specified as ``False``, loggers which

--- a/Doc/tools/.nitignore
+++ b/Doc/tools/.nitignore
@@ -33,7 +33,6 @@ Doc/library/asyncio-task.rst
 Doc/library/bdb.rst
 Doc/library/collections.rst
 Doc/library/concurrent.futures.rst
-Doc/library/configparser.rst
 Doc/library/csv.rst
 Doc/library/datetime.rst
 Doc/library/dbm.rst

--- a/Doc/whatsnew/2.0.rst
+++ b/Doc/whatsnew/2.0.rst
@@ -1030,7 +1030,7 @@ Module changes
 
 Lots of improvements and bugfixes were made to Python's extensive standard
 library; some of the affected modules include :mod:`readline`,
-:mod:`ConfigParser`, :mod:`!cgi`, :mod:`calendar`, :mod:`posix`, :mod:`readline`,
+:mod:`ConfigParser <configparser>`, :mod:`!cgi`, :mod:`calendar`, :mod:`posix`, :mod:`readline`,
 :mod:`xmllib`, :mod:`!aifc`, :mod:`!chunk`, :mod:`wave`, :mod:`random`, :mod:`shelve`,
 and :mod:`!nntplib`.  Consult the CVS logs for the exact patch-by-patch details.
 

--- a/Doc/whatsnew/2.4.rst
+++ b/Doc/whatsnew/2.4.rst
@@ -1052,9 +1052,9 @@ complete list of changes, or look through the CVS logs for all the details.
   advantage of :class:`collections.deque` for improved performance.  (Contributed
   by Raymond Hettinger.)
 
-* The :mod:`ConfigParser` classes have been enhanced slightly. The :meth:`read`
+* The :mod:`ConfigParser <configparser>` classes have been enhanced slightly. The :meth:`~configparser.ConfigParser.read`
   method now returns a list of the files that were successfully parsed, and the
-  :meth:`set` method raises :exc:`TypeError` if passed a *value* argument that
+  :meth:`~configparser.ConfigParser.set` method raises :exc:`TypeError` if passed a *value* argument that
   isn't a string.   (Contributed by John Belmonte and David Goodger.)
 
 * The :mod:`curses` module now supports the ncurses extension

--- a/Doc/whatsnew/2.7.rst
+++ b/Doc/whatsnew/2.7.rst
@@ -287,7 +287,7 @@ remains O(1).
 The standard library now supports use of ordered dictionaries in several
 modules.
 
-* The :mod:`ConfigParser` module uses them by default, meaning that
+* The :mod:`ConfigParser <configparser>` module uses them by default, meaning that
   configuration files can now be read, modified, and then written back
   in their original order.
 
@@ -1134,7 +1134,7 @@ changes, or look through the Subversion logs for all the details.
   another type that isn't a :class:`Mapping`.
   (Fixed by Daniel Stutzbach; :issue:`8729`.)
 
-* Constructors for the parsing classes in the :mod:`ConfigParser` module now
+* Constructors for the parsing classes in the :mod:`ConfigParser <configparser>` module now
   take an *allow_no_value* parameter, defaulting to false; if true,
   options without values will be allowed.  For example::
 

--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -1773,7 +1773,7 @@ Standard Library
 
   * the :class:`!configparser.SafeConfigParser` class
   * the :attr:`!configparser.ParsingError.filename` property
-  * the :meth:`configparser.RawConfigParser.readfp` method
+  * the :meth:`!configparser.RawConfigParser.readfp` method
 
   (Contributed by Hugo van Kemenade in :issue:`45173`.)
 

--- a/Doc/whatsnew/3.2.rst
+++ b/Doc/whatsnew/3.2.rst
@@ -183,7 +183,7 @@ PEP 391:  Dictionary Based Configuration for Logging
 
 The :mod:`logging` module provided two kinds of configuration, one style with
 function calls for each option or another style driven by an external file saved
-in a :mod:`ConfigParser` format.  Those options did not provide the flexibility
+in a :mod:`configparser` format.  Those options did not provide the flexibility
 to create configurations from JSON or YAML files, nor did they support
 incremental configuration, which is needed for specifying logger options from a
 command line.
@@ -2134,7 +2134,7 @@ configparser
 
 The :mod:`configparser` module was modified to improve usability and
 predictability of the default parser and its supported INI syntax.  The old
-:class:`ConfigParser` class was removed in favor of :class:`SafeConfigParser`
+:class:`!ConfigParser` class was removed in favor of :class:`!SafeConfigParser`
 which has in turn been renamed to :class:`~configparser.ConfigParser`. Support
 for inline comments is now turned off by default and section or option
 duplicates are not allowed in a single configuration source.
@@ -2414,7 +2414,7 @@ when one operand is much larger than the other (patch by Andress Bennetts in
 (:issue:`1569291` by Alexander Belopolsky). The :class:`BaseHTTPRequestHandler`
 has more efficient buffering (:issue:`3709` by Andrew Schaaf).  The
 :func:`operator.attrgetter` function has been sped-up (:issue:`10160` by
-Christos Georgiou).  And :class:`ConfigParser` loads multi-line arguments a bit
+Christos Georgiou).  And :class:`~configparser.ConfigParser` loads multi-line arguments a bit
 faster (:issue:`7113` by Łukasz Langa).
 
 
@@ -2614,8 +2614,8 @@ This section lists previously described changes and other bugfixes that may
 require changes to your code:
 
 * The :mod:`configparser` module has a number of clean-ups.  The major change is
-  to replace the old :class:`ConfigParser` class with long-standing preferred
-  alternative :class:`SafeConfigParser`.  In addition there are a number of
+  to replace the old :class:`!ConfigParser` class with long-standing preferred
+  alternative :class:`!SafeConfigParser`.  In addition there are a number of
   smaller incompatibilities:
 
   * The interpolation syntax is now validated on

--- a/Misc/NEWS.d/3.11.0a1.rst
+++ b/Misc/NEWS.d/3.11.0a1.rst
@@ -1642,9 +1642,9 @@ interval specified with nanosecond precision.
 .. nonce: UptGAn
 .. section: Library
 
-Remove from the :mod:`configparser` module: the :class:`SafeConfigParser`
-class, the :attr:`filename` property of the :class:`ParsingError` class, the
-:meth:`readfp` method of the :class:`ConfigParser` class, deprecated since
+Remove from the :mod:`configparser` module: the :class:`!SafeConfigParser`
+class, the :attr:`!filename` property of the :class:`~configparser.ParsingError` class, the
+:meth:`!readfp` method of the :class:`~configparser.ConfigParser` class, deprecated since
 Python 3.2.
 
 Patch by Hugo van Kemenade.

--- a/Misc/NEWS.d/3.11.0a6.rst
+++ b/Misc/NEWS.d/3.11.0a6.rst
@@ -941,7 +941,7 @@ uvloop library.
 
 Make the :class:`configparser.ConfigParser` constructor raise
 :exc:`TypeError` if the ``interpolation`` parameter is not of type
-:class:`configparser.Interpolation`
+:class:`!configparser.Interpolation`
 
 ..
 

--- a/Misc/NEWS.d/3.8.0a1.rst
+++ b/Misc/NEWS.d/3.8.0a1.rst
@@ -5045,7 +5045,7 @@ functionality.
 .. section: Library
 
 ``ConfigParser.items()`` was fixed so that key-value pairs passed in via
-``vars`` are not included in the resulting output.
+:func:`vars` are not included in the resulting output.
 
 ..
 

--- a/Misc/NEWS.d/3.8.0a1.rst
+++ b/Misc/NEWS.d/3.8.0a1.rst
@@ -5044,8 +5044,8 @@ functionality.
 .. nonce: C_K-J9
 .. section: Library
 
-`ConfigParser.items()` was fixed so that key-value pairs passed in via
-`vars` are not included in the resulting output.
+``ConfigParser.items()`` was fixed so that key-value pairs passed in via
+``vars`` are not included in the resulting output.
 
 ..
 


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

Fix 14 warnings in `library/configparser.rst` and 20 `configparser`-related warnings elsewhere:

```
build/NEWS:10797: WARNING: py:class reference target not found: configparser.Interpolation
build/NEWS:13368: WARNING: py:attr reference target not found: filename
build/NEWS:13368: WARNING: py:class reference target not found: ConfigParser
build/NEWS:13368: WARNING: py:class reference target not found: ParsingError
build/NEWS:13368: WARNING: py:class reference target not found: SafeConfigParser
build/NEWS:13368: WARNING: py:meth reference target not found: readfp
build/NEWS:26630: WARNING: py:obj reference target not found: ConfigParser.items()
Doc/library/configparser.rst:211: WARNING: py:meth reference target not found: get
Doc/library/configparser.rst:235: WARNING: py:meth reference target not found: get
Doc/library/configparser.rst:483: WARNING: py:meth reference target not found: __init__
Doc/library/configparser.rst:493: WARNING: py:meth reference target not found: read_dict
Doc/library/configparser.rst:637: WARNING: py:meth reference target not found: read_dict
Doc/library/configparser.rst:637: WARNING: py:meth reference target not found: read_file
Doc/library/configparser.rst:637: WARNING: py:meth reference target not found: read_string
Doc/library/configparser.rst:694: WARNING: py:meth reference target not found: getdecimal
Doc/library/configparser.rst:1064: WARNING: py:attr reference target not found: name
Doc/library/configparser.rst:1069: WARNING: py:meth reference target not found: readfp
Doc/library/configparser.rst:1217: WARNING: py:meth reference target not found: get
Doc/library/configparser.rst:1290: WARNING: py:meth reference target not found: add_section
Doc/library/configparser.rst:1295: WARNING: py:meth reference target not found: __init__
Doc/library/configparser.rst:1349: WARNING: py:meth reference target not found: __init__
Doc/library/logging.config.rst:94: WARNING: py:class reference target not found: configparser.Configparser
Doc/whatsnew/2.0.rst:1031: WARNING: py:mod reference target not found: ConfigParser
Doc/whatsnew/2.4.rst:1055: WARNING: py:meth reference target not found: read
Doc/whatsnew/2.4.rst:1055: WARNING: py:mod reference target not found: ConfigParser
Doc/whatsnew/2.7.rst:290: WARNING: py:mod reference target not found: ConfigParser
Doc/whatsnew/2.7.rst:1137: WARNING: py:mod reference target not found: ConfigParser
Doc/whatsnew/3.2.rst:184: WARNING: py:mod reference target not found: ConfigParser
Doc/whatsnew/3.2.rst:2135: WARNING: py:class reference target not found: ConfigParser
Doc/whatsnew/3.2.rst:2135: WARNING: py:class reference target not found: SafeConfigParser
Doc/whatsnew/3.2.rst:2411: WARNING: py:class reference target not found: ConfigParser
Doc/whatsnew/3.2.rst:2616: WARNING: py:class reference target not found: ConfigParser
Doc/whatsnew/3.2.rst:2616: WARNING: py:class reference target not found: SafeConfigParser
Doc/whatsnew/3.11.rst:1776: WARNING: py:meth reference target not found: configparser.RawConfigParser.readfp
```


<!-- gh-issue-number: gh-101100 -->
* Issue: gh-101100
<!-- /gh-issue-number -->
