### PR TITLE
gh-113602: Bail out when the parser tries to override existing errors

### DIFF
--- a/Lib/test/test_syntax.py
+++ b/Lib/test/test_syntax.py
@@ -2360,6 +2360,8 @@ func(
 """
         self._check_error(code, "parenthesis '\\)' does not match opening parenthesis '\\['")
 
+        self._check_error("match y:\n case e(e=v,v,", " was never closed")
+
         # Examples with dencodings
         s = b'# coding=latin\n(aaaaaaaaaaaaaaaaa\naaaaaaaaaaa\xb5'
         self._check_error(s, r"'\(' was never closed")

--- a/Misc/NEWS.d/next/Core and Builtins/2024-01-01-00-07-02.gh-issue-113602.cWuTzk.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2024-01-01-00-07-02.gh-issue-113602.cWuTzk.rst
@@ -1,0 +1,2 @@
+Fix an error that was causing the parser to try to overwrite existing errors
+and crashing in the process. Patch by Pablo Galindo

--- a/Parser/pegen_errors.c
+++ b/Parser/pegen_errors.c
@@ -311,6 +311,10 @@ _PyPegen_raise_error_known_location(Parser *p, PyObject *errtype,
                                     Py_ssize_t end_lineno, Py_ssize_t end_col_offset,
                                     const char *errmsg, va_list va)
 {
+    // Bail out if we already have an error set.
+    if (p->error_indicator && PyErr_Occurred()) {
+        return NULL;
+    }
     PyObject *value = NULL;
     PyObject *errstr = NULL;
     PyObject *error_line = NULL;


### PR DESCRIPTION


<!-- gh-issue-number: gh-113602 -->
* Issue: gh-113602
<!-- /gh-issue-number -->
