### PR TITLE
# gh-111700: Fix syntax highlighting for c code in the "What's New In Python 3.12" documentation

### DIFF
--- a/Doc/whatsnew/3.12.rst
+++ b/Doc/whatsnew/3.12.rst
@@ -343,7 +343,9 @@ cores. This is currently only available through the C-API,
 though a Python API is :pep:`anticipated for 3.13 <554>`.
 
 Use the new :c:func:`Py_NewInterpreterFromConfig` function to
-create an interpreter with its own GIL::
+create an interpreter with its own GIL:
+
+.. code-block:: c
 
    PyInterpreterConfig config = {
        .check_multi_interp_extensions = 1,


### PR DESCRIPTION
Fixes gh-111700

I skimmed through the rest of the doc for c-code blocks with bad syntax highlighting but didn't find any that were obvious to me.


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--113609.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->