### PR TITLE
gh-85567: Fix resouce warnings in pickle and pickletools CLIs

### DIFF
--- a/Lib/pickle.py
+++ b/Lib/pickle.py
@@ -1793,7 +1793,7 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(
         description='display contents of the pickle files')
     parser.add_argument(
-        'pickle_file', type=argparse.FileType('br'),
+        'pickle_file',
         nargs='*', help='the pickle file')
     parser.add_argument(
         '-t', '--test', action='store_true',
@@ -1809,6 +1809,10 @@ if __name__ == "__main__":
             parser.print_help()
         else:
             import pprint
-            for f in args.pickle_file:
-                obj = load(f)
+            for fn in args.pickle_file:
+                if fn == '-':
+                    obj = load(sys.stdin.buffer)
+                else:
+                    with open(fn, 'rb') as f:
+                        obj = load(f)
                 pprint.pprint(obj)

--- a/Misc/NEWS.d/next/Library/2024-01-01-13-26-02.gh-issue-85567.K4U15m.rst
+++ b/Misc/NEWS.d/next/Library/2024-01-01-13-26-02.gh-issue-85567.K4U15m.rst
@@ -1,0 +1,2 @@
+Fix resource warnings for unclosed files in :mod:`pickle` and
+:mod:`pickletools` command line interfaces.


### PR DESCRIPTION
Explicitly open and close files instead of using FileType.


<!-- gh-issue-number: gh-85567 -->
* Issue: gh-85567
<!-- /gh-issue-number -->
