### PR TITLE
gh-53502: Fixes for tests in gh-113363

### DIFF
--- a/Lib/plistlib.py
+++ b/Lib/plistlib.py
@@ -155,7 +155,7 @@ def _date_from_string(s, aware_datetime):
 
 
 def _date_to_string(d, aware_datetime):
-    if aware_datetime:
+    if aware_datetime and d.tzinfo is not None:
         d = d.astimezone(datetime.UTC)
     return '%04d-%02d-%02dT%02d:%02d:%02dZ' % (
         d.year, d.month, d.day,
@@ -791,7 +791,7 @@ class _BinaryPlistWriter (object):
             self._fp.write(struct.pack('>Bd', 0x23, value))
 
         elif isinstance(value, datetime.datetime):
-            if self._aware_datetime:
+            if self._aware_datetime and value.tzinfo is not None:
                 dt = value.astimezone(datetime.UTC)
                 offset = dt - datetime.datetime(2001, 1, 1, tzinfo=datetime.UTC)
                 f = offset.total_seconds()

--- a/Lib/test/test_plistlib.py
+++ b/Lib/test/test_plistlib.py
@@ -881,11 +881,11 @@ class TestPlistlib(unittest.TestCase):
         # Save a naive datetime with aware_datetime set to true.  This will lead
         # to having different time as compared to the current machine's
         # timezone, which is UTC.
-        dt = datetime.datetime(2345, 6, 7, 8, tzinfo=None)
+        dt = datetime.datetime(2003, 6, 7, 8, tzinfo=None)
         for fmt in ALL_FORMATS:
             s = plistlib.dumps(dt, fmt=fmt, aware_datetime=True)
             parsed = plistlib.loads(s, aware_datetime=False)
-            expected = dt + datetime.timedelta(seconds=time.timezone)
+            expected = dt + 2 * datetime.timedelta(seconds=time.timezone)
             self.assertEqual(parsed, expected)
 
 

--- a/Lib/test/test_plistlib.py
+++ b/Lib/test/test_plistlib.py
@@ -885,8 +885,7 @@ class TestPlistlib(unittest.TestCase):
         for fmt in ALL_FORMATS:
             s = plistlib.dumps(dt, fmt=fmt, aware_datetime=True)
             parsed = plistlib.loads(s, aware_datetime=False)
-            expected = dt + 2 * datetime.timedelta(seconds=time.timezone)
-            self.assertEqual(parsed, expected)
+            self.assertEqual(parsed, dt)
 
 
 class TestBinaryPlistlib(unittest.TestCase):


### PR DESCRIPTION
1. Use 32-bit compatible date in test_dump_naive_datetime_with_aware_datetime_option

2. test_dump_naive_datetime_with_aware_datetime_option: Writing non-aware datetimes with aware_datetime==True leads to the time being off by twice the timezone offset from UTC

<!-- gh-issue-number: gh-53502 -->
* Issue: gh-53502
<!-- /gh-issue-number -->
