### PR TITLE
gh-101100: Fix Sphinx warnings from removed `~!` references

### DIFF
--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -1860,7 +1860,7 @@ Standard Library
 
   (Contributed by Erlend E. Aasland in :issue:`5846`.)
 
-* :meth:`!usageExit` is marked deprecated, to be removed
+* :meth:`!unittest.TestProgram.usageExit` is marked deprecated, to be removed
   in 3.13.
   (Contributed by Carlos Damázio in :gh:`67048`.)
 

--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -1860,7 +1860,7 @@ Standard Library
 
   (Contributed by Erlend E. Aasland in :issue:`5846`.)
 
-* :meth:`~!unittest.TestProgram.usageExit` is marked deprecated, to be removed
+* :meth:`!usageExit` is marked deprecated, to be removed
   in 3.13.
   (Contributed by Carlos Damázio in :gh:`67048`.)
 

--- a/Doc/whatsnew/3.3.rst
+++ b/Doc/whatsnew/3.3.rst
@@ -1052,7 +1052,7 @@ their ``__init__`` method (for example, file objects) or in their
 crypt
 -----
 
-Addition of salt and modular crypt format (hashing method) and the :func:`~!crypt.mksalt`
+Addition of salt and modular crypt format (hashing method) and the :func:`!mksalt`
 function to the :mod:`!crypt` module.
 
 (:issue:`10924`)

--- a/Doc/whatsnew/3.4.rst
+++ b/Doc/whatsnew/3.4.rst
@@ -605,15 +605,15 @@ Using ``ABC`` as a base class has essentially the same effect as specifying
 aifc
 ----
 
-The :meth:`~!aifc.aifc.getparams` method now returns a namedtuple rather than a
+The :meth:`!getparams` method now returns a namedtuple rather than a
 plain tuple.  (Contributed by Claudiu Popa in :issue:`17818`.)
 
 :func:`!aifc.open` now supports the context management protocol: when used in a
-:keyword:`with` block, the :meth:`~!aifc.aifc.close` method of the returned
+:keyword:`with` block, the :meth:`!close` method of the returned
 object will be called automatically at the end of the block.  (Contributed by
 Serhiy Storchacha in :issue:`16486`.)
 
-The :meth:`~!aifc.aifc.writeframesraw` and :meth:`~!aifc.aifc.writeframes`
+The :meth:`!writeframesraw` and :meth:`!writeframes`
 methods now accept any :term:`bytes-like object`.  (Contributed by Serhiy
 Storchaka in :issue:`8311`.)
 
@@ -632,7 +632,7 @@ audioop
 :mod:`!audioop` now supports 24-bit samples.  (Contributed by Serhiy Storchaka
 in :issue:`12866`.)
 
-New :func:`~!audioop.byteswap` function converts big-endian samples to
+New :func:`!byteswap` function converts big-endian samples to
 little-endian and vice versa.  (Contributed by Serhiy Storchaka in
 :issue:`19641`.)
 
@@ -1528,7 +1528,7 @@ work on Windows.  This change was actually inadvertently made in 3.3.4.
 sunau
 -----
 
-The :meth:`~!sunau.getparams` method now returns a namedtuple rather than a
+The :meth:`!getparams` method now returns a namedtuple rather than a
 plain tuple.  (Contributed by Claudiu Popa in :issue:`18901`.)
 
 :meth:`!sunau.open` now supports the context management protocol: when used in a
@@ -1540,8 +1540,8 @@ in :issue:`18878`.)
 support for writing 24 sample using the module.  (Contributed by
 Serhiy Storchaka in :issue:`19261`.)
 
-The :meth:`~!sunau.AU_write.writeframesraw` and
-:meth:`~!sunau.AU_write.writeframes` methods now accept any :term:`bytes-like
+The :meth:`!writeframesraw` and
+:meth:`!writeframes` methods now accept any :term:`bytes-like
 object`.  (Contributed by Serhiy Storchaka in :issue:`8311`.)
 
 

--- a/Doc/whatsnew/3.5.rst
+++ b/Doc/whatsnew/3.5.rst
@@ -1252,7 +1252,7 @@ Oberkirch in :issue:`21800`.)
 imghdr
 ------
 
-The :func:`~!imghdr.what` function now recognizes the
+The :func:`!what` function now recognizes the
 `OpenEXR <https://www.openexr.com>`_ format
 (contributed by Martin Vignali and Claudiu Popa in :issue:`20295`),
 and the `WebP <https://en.wikipedia.org/wiki/WebP>`_ format

--- a/Doc/whatsnew/3.7.rst
+++ b/Doc/whatsnew/3.7.rst
@@ -851,7 +851,7 @@ crypt
 The :mod:`!crypt` module now supports the Blowfish hashing method.
 (Contributed by Serhiy Storchaka in :issue:`31664`.)
 
-The :func:`~!crypt.mksalt` function now allows specifying the number of rounds
+The :func:`!mksalt` function now allows specifying the number of rounds
 for hashing.  (Contributed by Serhiy Storchaka in :issue:`31702`.)
 
 
@@ -2004,15 +2004,15 @@ importlib
 ---------
 
 Methods
-:meth:`MetaPathFinder.find_module() <!importlib.abc.MetaPathFinder.find_module>`
+:meth:`!MetaPathFinder.find_module()`
 (replaced by
 :meth:`MetaPathFinder.find_spec() <importlib.abc.MetaPathFinder.find_spec>`)
 and
-:meth:`PathEntryFinder.find_loader() <!importlib.abc.PathEntryFinder.find_loader>`
+:meth:`!PathEntryFinder.find_loader()`
 (replaced by
 :meth:`PathEntryFinder.find_spec() <importlib.abc.PathEntryFinder.find_spec>`)
 both deprecated in Python 3.4 now emit :exc:`DeprecationWarning`.
-(Contributed by Matthias Bussonnier in :issue:`29576`)
+(Contributed by Matthias Bussonnier in :issue:`29576`.)
 
 The :class:`importlib.abc.ResourceLoader` ABC has been deprecated in
 favour of :class:`importlib.abc.ResourceReader`.

--- a/Doc/whatsnew/3.9.rst
+++ b/Doc/whatsnew/3.9.rst
@@ -585,7 +585,7 @@ queue.
 nntplib
 -------
 
-:class:`~!nntplib.NNTP` and :class:`~!nntplib.NNTP_SSL` now raise a :class:`ValueError`
+:class:`!NNTP` and :class:`!NNTP_SSL` now raise a :class:`ValueError`
 if the given timeout for their constructor is zero to prevent the creation of
 a non-blocking socket. (Contributed by Donghee Na in :issue:`39259`.)
 

--- a/Misc/NEWS.d/3.11.0a1.rst
+++ b/Misc/NEWS.d/3.11.0a1.rst
@@ -3483,9 +3483,9 @@ Improved reprs of :mod:`threading` synchronization objects:
 Deprecated the following :mod:`unittest` functions, scheduled for removal in
 Python 3.13:
 
-* :func:`~!unittest.findTestCases`
-* :func:`~!unittest.makeSuite`
-* :func:`~!unittest.getTestCaseNames`
+* :func:`!findTestCases`
+* :func:`!makeSuite`
+* :func:`!getTestCaseNames`
 
 Use :class:`~unittest.TestLoader` methods instead:
 

--- a/Misc/NEWS.d/3.11.0a7.rst
+++ b/Misc/NEWS.d/3.11.0a7.rst
@@ -1038,8 +1038,7 @@ Add optional parameter *dir_fd* in :func:`shutil.rmtree`.
 .. nonce: AixHW7
 .. section: Library
 
-:meth:`~!unittest.TestProgram.usageExit` is marked deprecated, to be removed
-in 3.13.
+:meth:`!usageExit` is marked deprecated xx, to be removed in 3.13.
 
 ..
 

--- a/Misc/NEWS.d/3.11.0a7.rst
+++ b/Misc/NEWS.d/3.11.0a7.rst
@@ -1038,7 +1038,8 @@ Add optional parameter *dir_fd* in :func:`shutil.rmtree`.
 .. nonce: AixHW7
 .. section: Library
 
-:meth:`!usageExit` is marked deprecated xx, to be removed in 3.13.
+:meth:`!unittest.TestProgram.usageExit` is marked as deprecated,
+to be removed in Python 3.13.
 
 ..
 

--- a/Misc/NEWS.d/3.9.0a3.rst
+++ b/Misc/NEWS.d/3.9.0a3.rst
@@ -454,7 +454,7 @@ resilients to inaccessible sys.path entries (importlib_metadata v1.4.0).
 .. nonce: _S5VjC
 .. section: Library
 
-:class:`~!nntplib.NNTP` and :class:`~!nntplib.NNTP_SSL` now raise a
+:class:`!NNTP` and :class:`!NNTP_SSL` now raise a
 :class:`ValueError` if the given timeout for their constructor is zero to
 prevent the creation of a non-blocking socket. Patch by Donghee Na.
 
@@ -498,7 +498,7 @@ prevent the creation of a non-blocking socket. Patch by Donghee Na.
 .. section: Library
 
 Updated the Gmane domain from news.gmane.org to news.gmane.io which is used
-for examples of :class:`~!nntplib.NNTP` news reader server and nntplib tests.
+for examples of :class:`!NNTP` news reader server and nntplib tests.
 
 ..
 


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

Fix 23 warnings for things like ``` :meth:`~!unittest.TestProgram.usageExit` ``` - the tilde says to render it like `usageExit` and the exclamation mark says not to look up the reference.

But after deprecations have been removed, Sphinx nevertheless issues a warning. So instead let's switch to ``` :meth:`!usageExit` ``` to show the short version and not look it up. This silences the warning.

```
Doc/whatsnew/3.11.rst:1863: WARNING: py:meth reference target not found: !unittest.TestProgram.usageExit
Doc/whatsnew/3.3.rst:1055: WARNING: py:func reference target not found: !crypt.mksalt
Doc/whatsnew/3.4.rst:1531: WARNING: py:meth reference target not found: !sunau.getparams
Doc/whatsnew/3.4.rst:1543: WARNING: py:meth reference target not found: !sunau.AU_write.writeframes
Doc/whatsnew/3.4.rst:1543: WARNING: py:meth reference target not found: !sunau.AU_write.writeframesraw
Doc/whatsnew/3.4.rst:608: WARNING: py:meth reference target not found: !aifc.aifc.getparams
Doc/whatsnew/3.4.rst:611: WARNING: py:meth reference target not found: !aifc.aifc.close
Doc/whatsnew/3.4.rst:616: WARNING: py:meth reference target not found: !aifc.aifc.writeframes
Doc/whatsnew/3.4.rst:616: WARNING: py:meth reference target not found: !aifc.aifc.writeframesraw
Doc/whatsnew/3.4.rst:635: WARNING: py:func reference target not found: !audioop.byteswap
Doc/whatsnew/3.5.rst:1255: WARNING: py:func reference target not found: !imghdr.what
Doc/whatsnew/3.7.rst:2006: WARNING: py:meth reference target not found: !importlib.abc.MetaPathFinder.find_module
Doc/whatsnew/3.7.rst:2006: WARNING: py:meth reference target not found: !importlib.abc.PathEntryFinder.find_loader
Doc/whatsnew/3.7.rst:854: WARNING: py:func reference target not found: !crypt.mksalt
Doc/whatsnew/3.9.rst:588: WARNING: py:class reference target not found: !nntplib.NNTP
Doc/whatsnew/3.9.rst:588: WARNING: py:class reference target not found: !nntplib.NNTP_SSL
build/NEWS:10243: WARNING: py:meth reference target not found: !unittest.TestProgram.usageExit
build/NEWS:14046: WARNING: py:func reference target not found: !unittest.findTestCases
build/NEWS:14047: WARNING: py:func reference target not found: !unittest.makeSuite
build/NEWS:14048: WARNING: py:func reference target not found: !unittest.getTestCaseNames
build/NEWS:20562: WARNING: py:class reference target not found: !nntplib.NNTP
build/NEWS:20562: WARNING: py:class reference target not found: !nntplib.NNTP_SSL
build/NEWS:20578: WARNING: py:class reference target not found: !nntplib.NNTP
```

And for future removals, instead of doing:

```diff
-:meth:`~unittest.TestProgram.usageExit`
+:meth:`~!unittest.TestProgram.usageExit`
```

Let's prefer:

```diff
-:meth:`~unittest.TestProgram.usageExit`
+:meth:`!usageExit`
```


<!-- gh-issue-number: gh-101100 -->
* Issue: gh-101100
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--113629.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->