### PR TITLE
gh-113637: Let c_annotations.py to handle the spacing of Limited/Unstable API & Stable ABI translation strings

### DIFF
--- a/Doc/tools/extensions/c_annotations.py
+++ b/Doc/tools/extensions/c_annotations.py
@@ -126,7 +126,8 @@ class Annotations:
                         f"Object type mismatch in limited API annotation "
                         f"for {name}: {record['role']!r} != {objtype!r}")
                 stable_added = record['added']
-                message = sphinx_gettext(' Part of the ')
+                message = sphinx_gettext('Part of the')
+                message = message.center(len(message) + 2)
                 emph_node = nodes.emphasis(message, message,
                                            classes=['stableabi'])
                 ref_node = addnodes.pending_xref(
@@ -139,27 +140,27 @@ class Annotations:
                     ref_node += nodes.Text(sphinx_gettext('Stable ABI'))
                 emph_node += ref_node
                 if struct_abi_kind == 'opaque':
-                    emph_node += nodes.Text(sphinx_gettext(' (as an opaque struct)'))
+                    emph_node += nodes.Text(' ' + sphinx_gettext('(as an opaque struct)'))
                 elif struct_abi_kind == 'full-abi':
-                    emph_node += nodes.Text(sphinx_gettext(' (including all members)'))
+                    emph_node += nodes.Text(' ' + sphinx_gettext('(including all members)'))
                 if record['ifdef_note']:
                     emph_node += nodes.Text(' ' + record['ifdef_note'])
                 if stable_added == '3.2':
                     # Stable ABI was introduced in 3.2.
                     pass
                 else:
-                    emph_node += nodes.Text(sphinx_gettext(' since version %s') % stable_added)
+                    emph_node += nodes.Text(' ' + sphinx_gettext('since version %s') % stable_added)
                 emph_node += nodes.Text('.')
                 if struct_abi_kind == 'members':
                     emph_node += nodes.Text(
-                        sphinx_gettext(' (Only some members are part of the stable ABI.)'))
+                        ' ' + sphinx_gettext('(Only some members are part of the stable ABI.)'))
                 node.insert(0, emph_node)
 
             # Unstable API annotation.
             if name.startswith('PyUnstable'):
                 warn_node = nodes.admonition(
                     classes=['unstable-c-api', 'warning'])
-                message = sphinx_gettext('This is ')
+                message = sphinx_gettext('This is') + ' '
                 emph_node = nodes.emphasis(message, message)
                 ref_node = addnodes.pending_xref(
                     'Unstable API', refdomain="std",

--- a/Doc/tools/templates/dummy.html
+++ b/Doc/tools/templates/dummy.html
@@ -9,14 +9,14 @@ In extensions/pyspecific.py:
 
 In extensions/c_annotations.py:
 
-{% trans %} Part of the {% endtrans %}
+{% trans %}Part of the{% endtrans %}
 {% trans %}Limited API{% endtrans %}
 {% trans %}Stable ABI{% endtrans %}
-{% trans %} (as an opaque struct){% endtrans %}
-{% trans %} (including all members){% endtrans %}
-{% trans %} since version %s{% endtrans %}
-{% trans %} (Only some members are part of the stable ABI.){% endtrans %}
-{% trans %}This is {% endtrans %}
+{% trans %}(as an opaque struct){% endtrans %}
+{% trans %}(including all members){% endtrans %}
+{% trans %}since version %s{% endtrans %}
+{% trans %}(Only some members are part of the stable ABI.){% endtrans %}
+{% trans %}This is{% endtrans %}
 {% trans %}Unstable API{% endtrans %}
 {% trans %}. It may change without warning in minor releases.{% endtrans %}
 {% trans %}Return value: Always NULL.{% endtrans %}

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -31,6 +31,7 @@ Farhan Ahmad
 Matthew Ahrens
 Nir Aides
 Akira
+Ege Akman
 Yaniv Aknin
 Jyrki Alakuijala
 Tatiana Al-Chueyr


### PR DESCRIPTION
I've removed the hardcoded leading and trailing whitespaces in the template file, now ``c_annotations.py`` handles them.

- For ``Part of the``: We add one leading and one trailing space to the translated string
- For ``This is``: We add a trailing space
- For the rest of the translated strings: We add a leading space

This makes the translations easier and less error-prone to unwanted concatenations.

See also: https://github.com/python/cpython/pull/107680#discussion_r1439087745

CC: @AA-Turner and @hugovk

Here is how it looks in the preview:
  - English (RTD preview):
    ![image](https://github.com/python/cpython/assets/75242929/548cf62b-d743-40d5-8723-bf33e526f6ce)
    ![image](https://github.com/python/cpython/assets/75242929/3ed02888-c7b8-4fe1-9552-f000c29fb5f1)
    ![image](https://github.com/python/cpython/assets/75242929/746d2b04-c5d1-42c5-8bb1-d9ed309930da)
  - Turkish (local build):
    ![image](https://github.com/python/cpython/assets/75242929/bd3f46b3-0cea-45c0-9ddb-be4dc4f0a20a)
    ![image](https://github.com/python/cpython/assets/75242929/c20c91d8-1f60-47b1-ae1b-c6d77ed75194)
    ![image](https://github.com/python/cpython/assets/75242929/51d64f77-633c-48c1-84af-7647e99c0956)

<!-- gh-issue-number: gh-113637 -->
* Issue: gh-113637
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--113638.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->