### PR TITLE
gh-113628: Fix test_site test with long stdlib paths

### DIFF
--- a/Lib/test/test_site.py
+++ b/Lib/test/test_site.py
@@ -648,6 +648,9 @@ class _pthFileTests(unittest.TestCase):
         # see https://github.com/python/cpython/issues/113628)
         encoded_libpath_length = len(libpath.encode("utf-8"))
         repetitions = min(200, 30000 // encoded_libpath_length)
+        if repetitions <= 2:
+            self.skipTest(
+                f"Python stdlib path is too long ({encoded_libpath_length:,} bytes)")
         pth_lines.extend(libpath for _ in range(repetitions))
         pth_lines.extend(['', '# comment'])
         if import_site:

--- a/Lib/test/test_site.py
+++ b/Lib/test/test_site.py
@@ -643,8 +643,6 @@ class _pthFileTests(unittest.TestCase):
 
     @support.requires_subprocess()
     def test_underpth_basic(self):
-        libpath = test.support.STDLIB_DIR
-        exe_prefix = os.path.dirname(sys.executable)
         pth_lines = ['#.', '# ..', *sys.path, '.', '..']
         exe_file = self._create_underpth_exe(pth_lines)
         sys_path = self._calc_sys_path_for_underpth_nosite(

--- a/Lib/test/test_site.py
+++ b/Lib/test/test_site.py
@@ -643,7 +643,12 @@ class _pthFileTests(unittest.TestCase):
 
     def _get_pth_lines(self, libpath: str, *, import_site: bool):
         pth_lines = ['fake-path-name']
-        pth_lines.extend(libpath for _ in range(200))
+        # include 200 lines of `libpath` in _pth lines (or fewer
+        # if the `libpath` is long enough to get close to 32KB
+        # see https://github.com/python/cpython/issues/113628)
+        encoded_libpath_length = len(libpath.encode("utf-8"))
+        repetitions = min(200, 30000 // encoded_libpath_length)
+        pth_lines.extend(libpath for _ in range(repetitions))
         pth_lines.extend(['', '# comment'])
         if import_site:
             pth_lines.append('import site')

--- a/Lib/test/test_site.py
+++ b/Lib/test/test_site.py
@@ -641,6 +641,14 @@ class _pthFileTests(unittest.TestCase):
             sys_path.append(abs_path)
         return sys_path
 
+    def _get_pth_lines(self, libpath: str, *, import_site: bool):
+        pth_lines = ['fake-path-name']
+        pth_lines.extend(libpath for _ in range(200))
+        pth_lines.extend(['', '# comment'])
+        if import_site:
+            pth_lines.append('import site')
+        return pth_lines
+
     @support.requires_subprocess()
     def test_underpth_basic(self):
         pth_lines = ['#.', '# ..', *sys.path, '.', '..']
@@ -664,12 +672,7 @@ class _pthFileTests(unittest.TestCase):
     def test_underpth_nosite_file(self):
         libpath = test.support.STDLIB_DIR
         exe_prefix = os.path.dirname(sys.executable)
-        pth_lines = [
-            'fake-path-name',
-            *[libpath for _ in range(200)],
-            '',
-            '# comment',
-        ]
+        pth_lines = self._get_pth_lines(libpath, import_site=False)
         exe_file = self._create_underpth_exe(pth_lines)
         sys_path = self._calc_sys_path_for_underpth_nosite(
             os.path.dirname(exe_file),
@@ -693,13 +696,8 @@ class _pthFileTests(unittest.TestCase):
     def test_underpth_file(self):
         libpath = test.support.STDLIB_DIR
         exe_prefix = os.path.dirname(sys.executable)
-        exe_file = self._create_underpth_exe([
-            'fake-path-name',
-            *[libpath for _ in range(200)],
-            '',
-            '# comment',
-            'import site'
-        ])
+        exe_file = self._create_underpth_exe(
+            self._get_pth_lines(libpath, import_site=True))
         sys_prefix = os.path.dirname(exe_file)
         env = os.environ.copy()
         env['PYTHONPATH'] = 'from-env'
@@ -718,13 +716,8 @@ class _pthFileTests(unittest.TestCase):
     def test_underpth_dll_file(self):
         libpath = test.support.STDLIB_DIR
         exe_prefix = os.path.dirname(sys.executable)
-        exe_file = self._create_underpth_exe([
-            'fake-path-name',
-            *[libpath for _ in range(200)],
-            '',
-            '# comment',
-            'import site'
-        ], exe_pth=False)
+        exe_file = self._create_underpth_exe(
+            self._get_pth_lines(libpath, import_site=True), exe_pth=False)
         sys_prefix = os.path.dirname(exe_file)
         env = os.environ.copy()
         env['PYTHONPATH'] = 'from-env'


### PR DESCRIPTION
As suggested by @terryjreedy [on the issue](https://github.com/python/cpython/issues/113628#issuecomment-1873485317), adapt the number of `libpath` lines in pth lines based on the length of `libpath` to avoid exceeding a pth file that exceeds the 32KB limit.

I (arbitrarily) added a skip test if we end up with 2 or fewer repetitions (which is highly unlikely, considering this would mean a stdlib path of over 10k bytes)

<!-- gh-issue-number: gh-113628 -->
* Issue: gh-113628
<!-- /gh-issue-number -->
