### PR TITLE
[3.12] gh-101100: Fix Sphinx warnings from removed `~!` references (GH-113629)

### DIFF
--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -1860,7 +1860,7 @@ Standard Library
 
   (Contributed by Erlend E. Aasland in :issue:`5846`.)
 
-* :meth:`~!unittest.TestProgram.usageExit` is marked deprecated, to be removed
+* :meth:`!unittest.TestProgram.usageExit` is marked deprecated, to be removed
   in 3.13.
   (Contributed by Carlos Damázio in :gh:`67048`.)
 

--- a/Doc/whatsnew/3.7.rst
+++ b/Doc/whatsnew/3.7.rst
@@ -2004,15 +2004,15 @@ importlib
 ---------
 
 Methods
-:meth:`MetaPathFinder.find_module() <!importlib.abc.MetaPathFinder.find_module>`
+:meth:`!MetaPathFinder.find_module()`
 (replaced by
 :meth:`MetaPathFinder.find_spec() <importlib.abc.MetaPathFinder.find_spec>`)
 and
-:meth:`PathEntryFinder.find_loader() <!importlib.abc.PathEntryFinder.find_loader>`
+:meth:`!PathEntryFinder.find_loader()`
 (replaced by
 :meth:`PathEntryFinder.find_spec() <importlib.abc.PathEntryFinder.find_spec>`)
 both deprecated in Python 3.4 now emit :exc:`DeprecationWarning`.
-(Contributed by Matthias Bussonnier in :issue:`29576`)
+(Contributed by Matthias Bussonnier in :issue:`29576`.)
 
 The :class:`importlib.abc.ResourceLoader` ABC has been deprecated in
 favour of :class:`importlib.abc.ResourceReader`.


### PR DESCRIPTION
(cherry picked from commit 7595380347610598a3f5529214a449660892537b)

Less needed for this backport, most of them were 3.13 removals.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-101100 -->
* Issue: gh-101100
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--113641.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->