### PR TITLE
gh-53502: Fix plistlib.dump() for naive datetime with aware_datetime option

### DIFF
--- a/Lib/plistlib.py
+++ b/Lib/plistlib.py
@@ -155,7 +155,7 @@ def _date_from_string(s, aware_datetime):
 
 
 def _date_to_string(d, aware_datetime):
-    if aware_datetime and d.tzinfo is not None:
+    if aware_datetime:
         d = d.astimezone(datetime.UTC)
     return '%04d-%02d-%02dT%02d:%02d:%02dZ' % (
         d.year, d.month, d.day,
@@ -791,7 +791,7 @@ class _BinaryPlistWriter (object):
             self._fp.write(struct.pack('>Bd', 0x23, value))
 
         elif isinstance(value, datetime.datetime):
-            if self._aware_datetime and value.tzinfo is not None:
+            if self._aware_datetime:
                 dt = value.astimezone(datetime.UTC)
                 offset = dt - datetime.datetime(2001, 1, 1, tzinfo=datetime.UTC)
                 f = offset.total_seconds()

--- a/Lib/test/test_plistlib.py
+++ b/Lib/test/test_plistlib.py
@@ -885,7 +885,8 @@ class TestPlistlib(unittest.TestCase):
         for fmt in ALL_FORMATS:
             s = plistlib.dumps(dt, fmt=fmt, aware_datetime=True)
             parsed = plistlib.loads(s, aware_datetime=False)
-            self.assertEqual(parsed, dt)
+            expected = dt.astimezone(datetime.UTC).replace(tzinfo=None)
+            self.assertEqual(parsed, expected)
 
 
 class TestBinaryPlistlib(unittest.TestCase):


### PR DESCRIPTION


<!-- gh-issue-number: gh-53502 -->
* Issue: gh-53502
<!-- /gh-issue-number -->
