### PR TITLE
GH-113657: Add back missing `_SET_IP` uops in tier two

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2024-01-02-11-14-29.gh-issue-113657.CQo9vF.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2024-01-02-11-14-29.gh-issue-113657.CQo9vF.rst
@@ -1,0 +1,2 @@
+Fix an issue that caused important instruction pointer updates to be
+optimized out of tier two traces.

--- a/Python/optimizer_analysis.c
+++ b/Python/optimizer_analysis.c
@@ -42,7 +42,7 @@ remove_unneeded_uops(_PyUOpInstruction *buffer, int buffer_size)
                     buffer[last_set_ip].opcode = _SET_IP;
                 }
             }
-            if (_PyUop_Flags[opcode] & HAS_ERROR_FLAG || opcode == _PUSH_FRAME) {
+            if ((_PyUop_Flags[opcode] & HAS_ERROR_FLAG) || opcode == _PUSH_FRAME) {
                 if (last_set_ip >= 0) {
                     buffer[last_set_ip].opcode = _SET_IP;
                 }

--- a/Python/optimizer_analysis.c
+++ b/Python/optimizer_analysis.c
@@ -4,6 +4,7 @@
 #include "pycore_opcode_metadata.h"
 #include "pycore_opcode_utils.h"
 #include "pycore_pystate.h"       // _PyInterpreterState_GET()
+#include "pycore_uop_metadata.h"
 #include "pycore_uops.h"
 #include "pycore_long.h"
 #include "cpython/optimizer.h"
@@ -35,13 +36,13 @@ remove_unneeded_uops(_PyUOpInstruction *buffer, int buffer_size)
             break;
         }
         else {
-            if (OPCODE_HAS_ESCAPES(opcode)) {
+            if (_PyUop_Flags[opcode] & HAS_ESCAPES_FLAG) {
                 maybe_invalid = true;
                 if (last_set_ip >= 0) {
                     buffer[last_set_ip].opcode = _SET_IP;
                 }
             }
-            if (OPCODE_HAS_ERROR(opcode) || opcode == _PUSH_FRAME) {
+            if (_PyUop_Flags[opcode] & HAS_ERROR_FLAG || opcode == _PUSH_FRAME) {
                 if (last_set_ip >= 0) {
                     buffer[last_set_ip].opcode = _SET_IP;
                 }


### PR DESCRIPTION
Looks like these macro uses weren't updated when the metadata for tier one and tier two instructions was split in GH-113287.


<!-- gh-issue-number: gh-113657 -->
* Issue: gh-113657
<!-- /gh-issue-number -->
