### PR TITLE
gh-92936: allow double quote in cookie values

### DIFF
--- a/Lib/http/cookies.py
+++ b/Lib/http/cookies.py
@@ -426,7 +426,7 @@ _CookiePattern = re.compile(r"""
     (                              # Optional group: there may not be a value.
     \s*=\s*                          # Equal Sign
     (?P<val>                         # Start of group 'val'
-    "(?:[^\\"]|\\.)*"                  # Any double-quoted string
+    "(?:\\"|.)*?"                    # Any double-quoted string
     |                                  # or
     # Special case for "expires" attr
     (\w{3,6}day|\w{3}),\s              # Day of the week or abbreviated day

--- a/Lib/test/test_http_cookies.py
+++ b/Lib/test/test_http_cookies.py
@@ -48,6 +48,18 @@ class CookieTests(unittest.TestCase):
                     'Set-Cookie: d=r',
                     'Set-Cookie: f=h'
                 ))
+            },
+
+            {'data': 'cookie="{"key": "value"}"',
+             'dict': {'cookie': '{"key": "value"}'},
+             'repr': "<SimpleCookie: cookie='{\"key\": \"value\"}'>",
+             'output': 'Set-Cookie: cookie="{"key": "value"}"',
+            },
+
+            {'data': 'key="some value; surrounded by quotes"',
+             'dict': {'key': 'some value; surrounded by quotes'},
+             'repr': "<SimpleCookie: key='some value; surrounded by quotes'>",
+             'output': 'Set-Cookie: key="some value; surrounded by quotes"',
             }
         ]
 

--- a/Lib/test/test_http_cookies.py
+++ b/Lib/test/test_http_cookies.py
@@ -50,16 +50,27 @@ class CookieTests(unittest.TestCase):
                 ))
             },
 
-            {'data': 'cookie="{"key": "value"}"',
-             'dict': {'cookie': '{"key": "value"}'},
-             'repr': "<SimpleCookie: cookie='{\"key\": \"value\"}'>",
-             'output': 'Set-Cookie: cookie="{"key": "value"}"',
+            # gh-92936: allow double quote in cookie values
+            {
+                'data': 'cookie="{"key": "value"}"',
+                'dict': {'cookie': '{"key": "value"}'},
+                'repr': "<SimpleCookie: cookie='{\"key\": \"value\"}'>",
+                'output': 'Set-Cookie: cookie="{"key": "value"}"',
             },
-
-            {'data': 'key="some value; surrounded by quotes"',
-             'dict': {'key': 'some value; surrounded by quotes'},
-             'repr': "<SimpleCookie: key='some value; surrounded by quotes'>",
-             'output': 'Set-Cookie: key="some value; surrounded by quotes"',
+            {
+                'data': 'key="some value; surrounded by quotes"',
+                'dict': {'key': 'some value; surrounded by quotes'},
+                'repr': "<SimpleCookie: key='some value; surrounded by quotes'>",
+                'output': 'Set-Cookie: key="some value; surrounded by quotes"',
+            },
+            {
+                'data': 'session="user123"; preferences="{"theme": "dark"}"',
+                'dict': {'session': 'user123', 'preferences': '{"theme": "dark"}'},
+                'repr': "<SimpleCookie: preferences='{\"theme\": \"dark\"}' session='user123'>",
+                'output': '\n'.join((
+                    'Set-Cookie: preferences="{"theme": "dark"}"',
+                    'Set-Cookie: session="user123"',
+                ))
             }
         ]
 

--- a/Misc/NEWS.d/next/Library/2025-08-08-21-20-14.gh-issue-92936.rOgG1S.rst
+++ b/Misc/NEWS.d/next/Library/2025-08-08-21-20-14.gh-issue-92936.rOgG1S.rst
@@ -1,0 +1,2 @@
+Update regex used by ``http.cookies.SimpleCookie`` to handle values containing
+double quotes.


### PR DESCRIPTION
As detailed more extensively in: https://github.com/python/cpython/issues/92936 it's not uncommon to see cookies with json and therefore double quotes in them. While IMO a well behaved application would base64 or otherwise encode those values, there are numerous services putting double quotes in the cookies, and it would be nice to have support for this directly in python so various http server/client/util libraries don't need to implement their own cookie parsing. Additionally browsers are tolerant of and handle double quotes in cookie values so `SimpleCookie` should also.

Before this change `SimpleCookie` will without error drop cookie values that appear after a value with a double quote in them, which can lead to some very confusing and hard to debug issues when implementing http clients and servers.
After this change `SimpleCookie` allows a double quote character in the values section of the cookie while making no attempt to determine if the value is valid json or anything else (since that's a application/usecase specific concern)

Downstream issues:
https://github.com/aio-libs/aiohttp/issues/7993
https://github.com/yt-dlp/yt-dlp/pull/4780

<!-- gh-issue-number: gh-92936 -->
* Issue: gh-92936
<!-- /gh-issue-number -->
