### PR TITLE
Update DIFF_OMITTED advice to be usable code

### DIFF
--- a/Lib/unittest/case.py
+++ b/Lib/unittest/case.py
@@ -21,7 +21,7 @@ __unittest = True
 _subtest_msg_sentinel = object()
 
 DIFF_OMITTED = ('\nDiff is %s characters long. '
-                 'Set self.maxDiff to None to see it.')
+                 'Set self.maxDiff = None to see it.')
 
 class SkipTest(Exception):
     """


### PR DESCRIPTION
As a lazy developer, when I see the error message, "Diff is 711 characters long. Set self.maxDiff to None to see it," I copy "self.maxDiff to None", paste it into my code, then edit "to" to "=". This saves me a step.