### PR TITLE
gh-113655: Reduce recursion limit to a safe number for Windows

### DIFF
--- a/Include/cpython/pystate.h
+++ b/Include/cpython/pystate.h
@@ -227,7 +227,7 @@ struct _ts {
 #  define Py_C_RECURSION_LIMIT 1200
 #else
    // This value is duplicated in Lib/test/support/__init__.py
-#  define Py_C_RECURSION_LIMIT 8000
+#  define Py_C_RECURSION_LIMIT 4000
 #endif
 
 

--- a/Lib/test/support/__init__.py
+++ b/Lib/test/support/__init__.py
@@ -2377,7 +2377,7 @@ def _get_c_recursion_limit():
         return _testcapi.Py_C_RECURSION_LIMIT
     except (ImportError, AttributeError):
         # Originally taken from Include/cpython/pystate.h .
-        return 8000
+        return 4000
 
 # The default C recursion limit.
 Py_C_RECURSION_LIMIT = _get_c_recursion_limit()

--- a/Lib/test/test_functools.py
+++ b/Lib/test/test_functools.py
@@ -1876,8 +1876,7 @@ class TestLRU:
 
         if not support.Py_DEBUG:
             with support.infinite_recursion():
-                fib(1250)
-
+                self.assertRaises(RecursionError, fib, 2000)
 
 @py_functools.lru_cache()
 def py_cached_func(x, y):

--- a/Lib/test/test_functools.py
+++ b/Lib/test/test_functools.py
@@ -1876,7 +1876,7 @@ class TestLRU:
 
         if not support.Py_DEBUG:
             with support.infinite_recursion():
-                fib(2500)
+                fib(1250)
 
 
 @py_functools.lru_cache()


### PR DESCRIPTION
#113397 recently increased the C recursion limit from 1,500 to 8,000.  Unfortunately, this has caused the Windows release buildbots as well as PGO builds to fail with a stack overflow.

The reason, as far as I can tell, is that while there *was* a set of experiments to determine the largest number that would work for Windows (#113328) (which passed the buildbots), that didn't include the new test that was added in the merged PR #113397 (`test_functools:test_lru_recursion`) and that new test pushes the stack farther than any of the other tests.

Unfortunately, it doesn't seem to be enough to just limit the test, `Py_C_RECURSION_LIMIT` also has to be reduced to prevent a C stack overflow.

<!-- gh-issue-number: gh-113655 -->
* Issue: gh-113655
<!-- /gh-issue-number -->
