### PR TITLE
gh-113664: Update big O notation in bisect.rst to be consistently mono-spaced

### DIFF
--- a/Doc/library/bisect.rst
+++ b/Doc/library/bisect.rst
@@ -79,7 +79,7 @@ The following functions are provided:
    To support inserting records in a table, the *key* function (if any) is
    applied to *x* for the search step but not for the insertion step.
 
-   Keep in mind that the ``O(log n)`` search is dominated by the slow O(n)
+   Keep in mind that the ``O(log n)`` search is dominated by the slow ``O(n)``
    insertion step.
 
    .. versionchanged:: 3.10
@@ -99,7 +99,7 @@ The following functions are provided:
    To support inserting records in a table, the *key* function (if any) is
    applied to *x* for the search step but not for the insertion step.
 
-   Keep in mind that the ``O(log n)`` search is dominated by the slow O(n)
+   Keep in mind that the ``O(log n)`` search is dominated by the slow ``O(n)``
    insertion step.
 
    .. versionchanged:: 3.10


### PR DESCRIPTION
Update bisect.rst with consistent mono-spacing of big O e.g. ``O(n)``

<!-- gh-issue-number: gh-113664 -->
* Issue: gh-113664
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--113673.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->