### PR TITLE
`functools.partial` docs: Use the more common spelling for "referenceable"

### DIFF
--- a/Doc/library/functools.rst
+++ b/Doc/library/functools.rst
@@ -742,7 +742,7 @@ have three read-only attributes:
    called.
 
 :class:`partial` objects are like :class:`function` objects in that they are
-callable, weak referencable, and can have attributes.  There are some important
+callable, weak referenceable, and can have attributes.  There are some important
 differences.  For instance, the :attr:`~definition.__name__` and :attr:`__doc__` attributes
 are not created automatically.  Also, :class:`partial` objects defined in
 classes behave like static methods and do not transform into bound methods


### PR DESCRIPTION
Fixes a typo in the last paragraph of the docs on `partial` objects, https://docs.python.org/3/library/functools.html#partial-objects

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--113675.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->