### PR TITLE
[3.11] gh-113637: Let c_annotations.py to handle the spacing of Limited/Unstable API & Stable ABI translation strings (#113638)

### DIFF
--- a/Doc/tools/extensions/c_annotations.py
+++ b/Doc/tools/extensions/c_annotations.py
@@ -126,7 +126,8 @@ class Annotations:
                         f"Object type mismatch in limited API annotation "
                         f"for {name}: {record['role']!r} != {objtype!r}")
                 stable_added = record['added']
-                message = sphinx_gettext(' Part of the ')
+                message = sphinx_gettext('Part of the')
+                message = message.center(len(message) + 2)
                 emph_node = nodes.emphasis(message, message,
                                            classes=['stableabi'])
                 ref_node = addnodes.pending_xref(
@@ -139,20 +140,20 @@ class Annotations:
                     ref_node += nodes.Text(sphinx_gettext('Stable ABI'))
                 emph_node += ref_node
                 if struct_abi_kind == 'opaque':
-                    emph_node += nodes.Text(sphinx_gettext(' (as an opaque struct)'))
+                    emph_node += nodes.Text(' ' + sphinx_gettext('(as an opaque struct)'))
                 elif struct_abi_kind == 'full-abi':
-                    emph_node += nodes.Text(sphinx_gettext(' (including all members)'))
+                    emph_node += nodes.Text(' ' + sphinx_gettext('(including all members)'))
                 if record['ifdef_note']:
                     emph_node += nodes.Text(' ' + record['ifdef_note'])
                 if stable_added == '3.2':
                     # Stable ABI was introduced in 3.2.
                     pass
                 else:
-                    emph_node += nodes.Text(sphinx_gettext(' since version %s') % stable_added)
+                    emph_node += nodes.Text(' ' + sphinx_gettext('since version %s') % stable_added)
                 emph_node += nodes.Text('.')
                 if struct_abi_kind == 'members':
                     emph_node += nodes.Text(
-                        sphinx_gettext(' (Only some members are part of the stable ABI.)'))
+                        ' ' + sphinx_gettext('(Only some members are part of the stable ABI.)'))
                 node.insert(0, emph_node)
 
             # Return value annotation

--- a/Doc/tools/templates/dummy.html
+++ b/Doc/tools/templates/dummy.html
@@ -9,13 +9,13 @@ In extensions/pyspecific.py:
 
 In extensions/c_annotations.py:
 
-{% trans %} Part of the {% endtrans %}
+{% trans %}Part of the{% endtrans %}
 {% trans %}Limited API{% endtrans %}
 {% trans %}Stable ABI{% endtrans %}
-{% trans %} (as an opaque struct){% endtrans %}
-{% trans %} (including all members){% endtrans %}
-{% trans %} since version %s{% endtrans %}
-{% trans %} (Only some members are part of the stable ABI.){% endtrans %}
+{% trans %}(as an opaque struct){% endtrans %}
+{% trans %}(including all members){% endtrans %}
+{% trans %}since version %s{% endtrans %}
+{% trans %}(Only some members are part of the stable ABI.){% endtrans %}
 {% trans %}Return value: Always NULL.{% endtrans %}
 {% trans %}Return value: New reference.{% endtrans %}
 {% trans %}Return value: Borrowed reference.{% endtrans %}

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -31,6 +31,7 @@ Farhan Ahmad
 Matthew Ahrens
 Nir Aides
 Akira
+Ege Akman
 Yaniv Aknin
 Jyrki Alakuijala
 Tatiana Al-Chueyr


### PR DESCRIPTION
(cherry picked from commit ea978c645edd7bc29d811c61477dff766d7318b6)


<!-- gh-issue-number: gh-113637 -->
* Issue: gh-113637
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--113679.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->