### PR TITLE
gh-113538: Don't crash in stream reader protocol callback when task is cancelled

### DIFF
--- a/Lib/asyncio/streams.py
+++ b/Lib/asyncio/streams.py
@@ -246,6 +246,9 @@ class StreamReaderProtocol(FlowControlMixin, protocols.Protocol):
                                             self._stream_writer)
             if coroutines.iscoroutine(res):
                 def callback(task):
+                    if task.cancelled():
+                        transport.close()
+                        return
                     exc = task.exception()
                     if exc is not None:
                         self._loop.call_exception_handler({

--- a/Lib/test/test_asyncio/test_streams.py
+++ b/Lib/test/test_asyncio/test_streams.py
@@ -1129,7 +1129,7 @@ os.close(fd)
 
         self.assertEqual(messages, [])
 
-    def test_unhandled_exceptions(self) -> None:
+    def _basetest_unhandled_exceptions(self, handle_echo):
         port = socket_helper.find_unused_port()
 
         messages = []
@@ -1143,9 +1143,6 @@ os.close(fd)
             await wr.wait_closed()
 
         async def main():
-            async def handle_echo(reader, writer):
-                raise Exception('test')
-
             server = await asyncio.start_server(
                 handle_echo, 'localhost', port)
             await server.start_serving()
@@ -1154,11 +1151,20 @@ os.close(fd)
             await server.wait_closed()
 
         self.loop.run_until_complete(main())
+        return messages
 
+    def test_unhandled_exception(self):
+        async def handle_echo(reader, writer):
+            raise Exception('test')
+        messages = self._basetest_unhandled_exceptions(handle_echo)
         self.assertEqual(messages[0]['message'],
-                         'Unhandled exception in client_connected_cb')
-        # Break explicitly reference cycle
-        messages = None
+                    'Unhandled exception in client_connected_cb')
+
+    def test_unhandled_cancel(self):
+        async def handle_echo(reader, writer):
+            asyncio.current_task().cancel()
+        messages = self._basetest_unhandled_exceptions(handle_echo)
+        self.assertEqual(messages, [])
 
 
 if __name__ == '__main__':

--- a/Misc/NEWS.d/next/Library/2024-01-03-14-19-26.gh-issue-113538.ahuBCo.rst
+++ b/Misc/NEWS.d/next/Library/2024-01-03-14-19-26.gh-issue-113538.ahuBCo.rst
@@ -1,0 +1,5 @@
+In :meth:`asyncio.StreamReaderProtocol.connection_made`, there is callback
+that logs an error if the task wrapping the "connected callback" fails. This
+callback would itself fail if the task was cancelled. Prevent this by
+checking whether the task was cancelled first. If so, close the transport
+but don't log an error.


### PR DESCRIPTION
That callback exists purely to log an error when the coroutine running in the task raises an exception. But if the task was cancelled instead, the callback itself crashes, which just logs noise. In that case we should just close the transport without logging anything.

CC @jsundahl

<!-- gh-issue-number: gh-113538 -->
* Issue: gh-113538
<!-- /gh-issue-number -->
