### PR TITLE
GH-113689: Fix broken handling of invalid executors

### DIFF
--- a/Python/bytecodes.c
+++ b/Python/bytecodes.c
@@ -2378,11 +2378,12 @@ dummy_func(
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
             else {
+                code->co_executors->executors[oparg & 255] = NULL;
                 opcode = this_instr->op.code = executor->vm_data.opcode;
                 this_instr->op.arg = executor->vm_data.oparg;
                 oparg = (oparg & (~255)) | executor->vm_data.oparg;
-                code->co_executors->executors[oparg&255] = NULL;
                 Py_DECREF(executor);
+                next_instr = this_instr;
                 DISPATCH_GOTO();
             }
         }

--- a/Python/generated_cases.c.h
+++ b/Python/generated_cases.c.h
@@ -2392,11 +2392,12 @@
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
             else {
+                code->co_executors->executors[oparg & 255] = NULL;
                 opcode = this_instr->op.code = executor->vm_data.opcode;
                 this_instr->op.arg = executor->vm_data.oparg;
                 oparg = (oparg & (~255)) | executor->vm_data.oparg;
-                code->co_executors->executors[oparg&255] = NULL;
                 Py_DECREF(executor);
+                next_instr = this_instr;
                 DISPATCH_GOTO();
             }
             DISPATCH();


### PR DESCRIPTION
This fixes two issues introduced in GH-113596:
- The wrong oparg was used to calculate the index of the current executor.
- `next_instr` wasn't reset before re-dispatching.

Skipping news since this was broken for less than a day.

<!-- gh-issue-number: gh-113689 -->
* Issue: gh-113689
<!-- /gh-issue-number -->
