### PR TITLE
gh-113696: Docs: Annotate PyObject_CallOneArg and PyObject_CallNoArgs as returning a strong reference

### DIFF
--- a/Doc/data/refcounts.dat
+++ b/Doc/data/refcounts.dat
@@ -1590,11 +1590,11 @@ PyObject_Call:PyObject*:args:0:
 PyObject_Call:PyObject*:kw:0:
 
 PyObject_CallNoArgs:PyObject*::+1:
-PyObject_Call:PyObject*:callable_object:0:
+PyObject_CallNoArgs:PyObject*:callable_object:0:
 
 PyObject_CallOneArg:PyObject*::+1:
-PyObject_Call:PyObject*:callable_object:0:
-PyObject_Call:PyObject*:arg:0:
+PyObject_CallOneArg:PyObject*:callable_object:0:
+PyObject_CallOneArg:PyObject*:arg:0:
 
 PyObject_CallFunction:PyObject*::+1:
 PyObject_CallFunction:PyObject*:callable_object:0:

--- a/Doc/data/refcounts.dat
+++ b/Doc/data/refcounts.dat
@@ -1589,6 +1589,13 @@ PyObject_Call:PyObject*:callable_object:0:
 PyObject_Call:PyObject*:args:0:
 PyObject_Call:PyObject*:kw:0:
 
+PyObject_CallNoArgs:PyObject*::+1:
+PyObject_Call:PyObject*:callable_object:0:
+
+PyObject_CallOneArg:PyObject*::+1:
+PyObject_Call:PyObject*:callable_object:0:
+PyObject_Call:PyObject*:arg:0:
+
 PyObject_CallFunction:PyObject*::+1:
 PyObject_CallFunction:PyObject*:callable_object:0:
 PyObject_CallFunction:const char*:format::


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

[`PyObject_CallOneArg` and `PyObject_CallNoArgs` should be updated in the docs](https://docs.python.org/3/c-api/call.html#c.PyObject_CallOneArg) with the reference count annotation `"Return value: New reference."` (as is the case with [`PyObject_CallFunction`](https://docs.python.org/3/c-api/call.html#c.PyObject_CallFunction) et al.)


<!-- gh-issue-number: gh-113696 -->
* Issue: gh-113696
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--113697.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->