### PR TITLE
GH-113703: Fix regression of incomplete code.InteractiveInterpreter.runsource

### DIFF
--- a/Lib/codeop.py
+++ b/Lib/codeop.py
@@ -66,7 +66,7 @@ def _maybe_compile(compiler, source, filename, symbol):
                 compiler(source + "\n", filename, symbol)
                 return None
             except SyntaxError as e:
-                if "incomplete input" in str(e):
+                if "incomplete input" in str(e) or "unterminated triple" in str(e):
                     return None
                 # fallthrough
 

--- a/Lib/test/test_code_module.py
+++ b/Lib/test/test_code_module.py
@@ -153,6 +153,10 @@ class TestInteractiveConsole(unittest.TestCase, MockSys):
         """)
         self.assertIn(expected, output)
 
+    def test_incomplete(self):
+        self.assertEqual(self.console.runsource('a = f"""'), True)
+        self.assertEqual(self.console.runsource('a = \\'), True)
+
 
 class TestInteractiveConsoleLocalExit(unittest.TestCase, MockSys):
 

--- a/Misc/NEWS.d/next/Core and Builtins/2024-01-04-17-56-18.gh-issue-113703.UEbV-e.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2024-01-04-17-56-18.gh-issue-113703.UEbV-e.rst
@@ -1,0 +1,2 @@
+Fix regression of ``codeop.compile_command`` raising an error when
+encountering incomplete f-strings.


### PR DESCRIPTION
This is a very dumb fix. Feedback is welcomed. It works because to my understanding, unterminated something is basically incomplete, but I could be wrong.

fixes https://github.com/python/cpython/issues/113703

<!-- gh-issue-number: gh-113703 -->
* Issue: gh-113703
<!-- /gh-issue-number -->
