### PR TITLE
gh-113703: Correctly identify incomplete f-strings in the codeop module

### DIFF
--- a/Lib/test/test_codeop.py
+++ b/Lib/test/test_codeop.py
@@ -223,6 +223,9 @@ class CodeopTests(unittest.TestCase):
         ai("(x for x in")
         ai("(x for x in (")
 
+        ai('a = f"""')
+        ai('a = \\')
+
     def test_invalid(self):
         ai = self.assertInvalid
         ai("a b")

--- a/Misc/NEWS.d/next/Core and Builtins/2024-01-04-17-15-30.gh-issue-113703.Zsk0pY.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2024-01-04-17-15-30.gh-issue-113703.Zsk0pY.rst
@@ -1,0 +1,2 @@
+Fix a regression in the :mod:`codeop` module that was causing to correctly
+identify incomplete f-strings. Patch by Pablo Galindo

--- a/Misc/NEWS.d/next/Core and Builtins/2024-01-04-17-15-30.gh-issue-113703.Zsk0pY.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2024-01-04-17-15-30.gh-issue-113703.Zsk0pY.rst
@@ -1,2 +1,2 @@
-Fix a regression in the :mod:`codeop` module that was causing to correctly
+Fix a regression in the :mod:`codeop` module that was causing it to incorrectly
 identify incomplete f-strings. Patch by Pablo Galindo

--- a/Parser/lexer/lexer.c
+++ b/Parser/lexer/lexer.c
@@ -1355,9 +1355,13 @@ f_string_middle:
             tok->lineno = the_current_tok->f_string_line_start;
 
             if (current_tok->f_string_quote_size == 3) {
-                return MAKE_TOKEN(_PyTokenizer_syntaxerror(tok,
+                _PyTokenizer_syntaxerror(tok,
                                     "unterminated triple-quoted f-string literal"
-                                    " (detected at line %d)", start));
+                                    " (detected at line %d)", start);
+                if (c != '\n') {
+                    tok->done = E_EOFS;
+                }
+                return MAKE_TOKEN(ERRORTOKEN);
             }
             else {
                 return MAKE_TOKEN(_PyTokenizer_syntaxerror(tok,


### PR DESCRIPTION


<!-- gh-issue-number: gh-113703 -->
* Issue: gh-113703
<!-- /gh-issue-number -->
