### PR TITLE
gh-101100: Fix Sphinx warnings for 2.6 deprecations and removals

### DIFF
--- a/Doc/library/subprocess.rst
+++ b/Doc/library/subprocess.rst
@@ -1461,8 +1461,8 @@ Return code handling translates as follows::
        print("There were some errors")
 
 
-Replacing functions from the :mod:`popen2` module
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Replacing functions from the :mod:`!popen2` module
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. note::
 

--- a/Doc/whatsnew/2.0.rst
+++ b/Doc/whatsnew/2.0.rst
@@ -1095,8 +1095,8 @@ module.
   GNU gettext message catalog library. (Integrated by Barry Warsaw, from separate
   contributions by Martin  von Löwis, Peter Funk, and James Henstridge.)
 
-* :mod:`linuxaudiodev`: Support for the :file:`/dev/audio` device on Linux, a
-  twin to the existing :mod:`sunaudiodev` module. (Contributed by Peter Bosch,
+* :mod:`!linuxaudiodev`: Support for the :file:`/dev/audio` device on Linux, a
+  twin to the existing :mod:`!sunaudiodev` module. (Contributed by Peter Bosch,
   with fixes by Jeremy Hylton.)
 
 * :mod:`mmap`: An interface to memory-mapped files on both Windows and Unix.  A
@@ -1140,7 +1140,7 @@ module.
   supported by the :mod:`gzip` module) (Contributed by James C. Ahlstrom.)
 
 * :mod:`imputil`: A module that provides a simpler way for writing customized
-  import hooks, in comparison to the existing :mod:`ihooks` module.  (Implemented
+  import hooks, in comparison to the existing :mod:`!ihooks` module.  (Implemented
   by Greg Stein, with much discussion on python-dev along the way.)
 
 .. ======================================================================

--- a/Doc/whatsnew/2.0.rst
+++ b/Doc/whatsnew/2.0.rst
@@ -1139,7 +1139,7 @@ module.
   Unix, not to be confused with :program:`gzip`\ -format files (which are
   supported by the :mod:`gzip` module) (Contributed by James C. Ahlstrom.)
 
-* :mod:`imputil`: A module that provides a simpler way for writing customized
+* :mod:`!imputil`: A module that provides a simpler way for writing customized
   import hooks, in comparison to the existing :mod:`!ihooks` module.  (Implemented
   by Greg Stein, with much discussion on python-dev along the way.)
 

--- a/Doc/whatsnew/2.2.rst
+++ b/Doc/whatsnew/2.2.rst
@@ -144,7 +144,7 @@ To make the set of types complete, new type objects such as :func:`dict` and
                               length, start, whence)
 
 The now-obsolete :mod:`!posixfile` module contained a class that emulated all of
-a file object's methods and also added a :meth:`lock` method, but this class
+a file object's methods and also added a :meth:`!lock` method, but this class
 couldn't be passed to internal functions that expected a built-in file,
 something which is possible with our new :class:`LockableFile`.
 

--- a/Doc/whatsnew/2.2.rst
+++ b/Doc/whatsnew/2.2.rst
@@ -143,7 +143,7 @@ To make the set of types complete, new type objects such as :func:`dict` and
            return fcntl.lockf(self.fileno(), operation,
                               length, start, whence)
 
-The now-obsolete :mod:`posixfile` module contained a class that emulated all of
+The now-obsolete :mod:`!posixfile` module contained a class that emulated all of
 a file object's methods and also added a :meth:`lock` method, but this class
 couldn't be passed to internal functions that expected a built-in file,
 something which is possible with our new :class:`LockableFile`.

--- a/Doc/whatsnew/2.4.rst
+++ b/Doc/whatsnew/2.4.rst
@@ -387,13 +387,13 @@ The standard library provides a number of ways to execute a subprocess, offering
 different features and different levels of complexity.
 ``os.system(command)`` is easy to use, but slow (it runs a shell process
 which executes the command) and dangerous (you have to be careful about escaping
-the shell's metacharacters).  The :mod:`popen2` module offers classes that can
+the shell's metacharacters).  The :mod:`!popen2` module offers classes that can
 capture standard output and standard error from the subprocess, but the naming
 is confusing.  The :mod:`subprocess` module cleans  this up, providing a unified
 interface that offers all the features you might need.
 
-Instead of :mod:`popen2`'s collection of classes, :mod:`subprocess` contains a
-single class called :class:`Popen`  whose constructor supports a number of
+Instead of :mod:`!popen2`'s collection of classes, :mod:`subprocess` contains a
+single class called :class:`subprocess.Popen`  whose constructor supports a number of
 different keyword arguments. ::
 
    class Popen(args, bufsize=0, executable=None,
@@ -1529,7 +1529,7 @@ code:
   will now always be unequal, and  relative comparisons (``<``, ``>``) will raise
   a :exc:`TypeError`.
 
-* :func:`dircache.listdir` now passes exceptions to the caller instead of
+* :func:`!dircache.listdir` now passes exceptions to the caller instead of
   returning empty lists.
 
 * :func:`LexicalHandler.startDTD` used to receive the public and system IDs in

--- a/Doc/whatsnew/2.5.rst
+++ b/Doc/whatsnew/2.5.rst
@@ -1680,7 +1680,7 @@ The ctypes package
 
 The :mod:`ctypes` package, written by Thomas Heller, has been added  to the
 standard library.  :mod:`ctypes` lets you call arbitrary functions  in shared
-libraries or DLLs.  Long-time users may remember the :mod:`dl` module, which
+libraries or DLLs.  Long-time users may remember the :mod:`!dl` module, which
 provides functions for loading shared libraries and calling functions in them.
 The :mod:`ctypes` package is much fancier.
 
@@ -1877,12 +1877,12 @@ The hashlib package
 -------------------
 
 A new :mod:`hashlib` module, written by Gregory P. Smith,  has been added to
-replace the :mod:`md5` and :mod:`sha` modules.  :mod:`hashlib` adds support for
+replace the :mod:`!md5` and :mod:`!sha` modules.  :mod:`hashlib` adds support for
 additional secure hashes (SHA-224, SHA-256, SHA-384, and SHA-512). When
 available, the module uses OpenSSL for fast platform optimized implementations
 of algorithms.
 
-The old :mod:`md5` and :mod:`sha` modules still exist as wrappers around hashlib
+The old :mod:`!md5` and :mod:`!sha` modules still exist as wrappers around hashlib
 to preserve backwards compatibility.  The new module's interface is very close
 to that of the old modules, but not identical. The most significant difference
 is that the constructor functions for creating new hashing objects are named

--- a/Doc/whatsnew/2.6.rst
+++ b/Doc/whatsnew/2.6.rst
@@ -2916,8 +2916,8 @@ Deprecations and Removals
 
 * Changes to the :class:`Exception` interface
   as dictated by :pep:`352` continue to be made.  For 2.6,
-  the :attr:`message` attribute is being deprecated in favor of the
-  :attr:`args` attribute.
+  the :attr:`!message` attribute is being deprecated in favor of the
+  :attr:`!args` attribute.
 
 * (3.0-warning mode) Python 3.0 will feature a reorganized standard
   library that will drop many outdated modules and rename others.
@@ -2925,51 +2925,51 @@ Deprecations and Removals
   when they are imported.
 
   The list of deprecated modules is:
-  :mod:`audiodev`,
-  :mod:`bgenlocations`,
-  :mod:`buildtools`,
-  :mod:`bundlebuilder`,
-  :mod:`Canvas`,
-  :mod:`compiler`,
-  :mod:`dircache`,
-  :mod:`dl`,
-  :mod:`fpformat`,
-  :mod:`gensuitemodule`,
-  :mod:`ihooks`,
-  :mod:`imageop`,
-  :mod:`imgfile`,
-  :mod:`linuxaudiodev`,
-  :mod:`mhlib`,
-  :mod:`mimetools`,
-  :mod:`multifile`,
-  :mod:`new`,
-  :mod:`pure`,
-  :mod:`statvfs`,
-  :mod:`sunaudiodev`,
-  :mod:`test.testall`, and
-  :mod:`toaiff`.
+  :mod:`!audiodev`,
+  :mod:`!bgenlocations`,
+  :mod:`!buildtools`,
+  :mod:`!bundlebuilder`,
+  :mod:`!Canvas`,
+  :mod:`!compiler`,
+  :mod:`!dircache`,
+  :mod:`!dl`,
+  :mod:`!fpformat`,
+  :mod:`!gensuitemodule`,
+  :mod:`!ihooks`,
+  :mod:`!imageop`,
+  :mod:`!imgfile`,
+  :mod:`!linuxaudiodev`,
+  :mod:`!mhlib`,
+  :mod:`!mimetools`,
+  :mod:`!multifile`,
+  :mod:`!new`,
+  :mod:`!pure`,
+  :mod:`!statvfs`,
+  :mod:`!sunaudiodev`,
+  :mod:`!test.testall`, and
+  :mod:`!toaiff`.
 
-* The :mod:`gopherlib` module has been removed.
+* The :mod:`!gopherlib` module has been removed.
 
-* The :mod:`MimeWriter` module and :mod:`mimify` module
+* The :mod:`!MimeWriter` module and :mod:`!mimify` module
   have been deprecated; use the :mod:`email`
   package instead.
 
-* The :mod:`md5` module has been deprecated; use the :mod:`hashlib` module
+* The :mod:`!md5` module has been deprecated; use the :mod:`hashlib` module
   instead.
 
-* The :mod:`posixfile` module has been deprecated; :func:`fcntl.lockf`
+* The :mod:`!posixfile` module has been deprecated; :func:`fcntl.lockf`
   provides better locking.
 
-* The :mod:`popen2` module has been deprecated; use the :mod:`subprocess`
+* The :mod:`!popen2` module has been deprecated; use the :mod:`subprocess`
   module.
 
-* The :mod:`rgbimg` module has been removed.
+* The :mod:`!rgbimg` module has been removed.
 
-* The :mod:`sets` module has been deprecated; it's better to
+* The :mod:`!sets` module has been deprecated; it's better to
   use the built-in :class:`set` and :class:`frozenset` types.
 
-* The :mod:`sha` module has been deprecated; use the :mod:`hashlib` module
+* The :mod:`!sha` module has been deprecated; use the :mod:`hashlib` module
   instead.
 
 

--- a/Doc/whatsnew/2.6.rst
+++ b/Doc/whatsnew/2.6.rst
@@ -2917,7 +2917,7 @@ Deprecations and Removals
 * Changes to the :class:`Exception` interface
   as dictated by :pep:`352` continue to be made.  For 2.6,
   the :attr:`!message` attribute is being deprecated in favor of the
-  :attr:`!args` attribute.
+  :attr:`~BaseException.args` attribute.
 
 * (3.0-warning mode) Python 3.0 will feature a reorganized standard
   library that will drop many outdated modules and rename others.

--- a/Doc/whatsnew/2.7.rst
+++ b/Doc/whatsnew/2.7.rst
@@ -1315,8 +1315,8 @@ changes, or look through the Subversion logs for all the details.
   giving the source address that will be used for the connection.
   (Contributed by Eldon Ziegler; :issue:`3972`.)
 
-* The :mod:`ihooks` module now supports relative imports.  Note that
-  :mod:`ihooks` is an older module for customizing imports,
+* The :mod:`!ihooks` module now supports relative imports.  Note that
+  :mod:`!ihooks` is an older module for customizing imports,
   superseded by the :mod:`imputil` module added in Python 2.0.
   (Relative import support added by Neil Schemenauer.)
 

--- a/Doc/whatsnew/2.7.rst
+++ b/Doc/whatsnew/2.7.rst
@@ -1317,7 +1317,7 @@ changes, or look through the Subversion logs for all the details.
 
 * The :mod:`!ihooks` module now supports relative imports.  Note that
   :mod:`!ihooks` is an older module for customizing imports,
-  superseded by the :mod:`imputil` module added in Python 2.0.
+  superseded by the :mod:`!imputil` module added in Python 2.0.
   (Relative import support added by Neil Schemenauer.)
 
   .. revision 75423

--- a/Doc/whatsnew/3.0.rst
+++ b/Doc/whatsnew/3.0.rst
@@ -555,8 +555,8 @@ very extensive changes to the standard library.  :pep:`3108` is the
 reference for the major changes to the library.  Here's a capsule
 review:
 
-* Many old modules were removed.  Some, like :mod:`gopherlib` (no
-  longer used) and :mod:`md5` (replaced by :mod:`hashlib`), were
+* Many old modules were removed.  Some, like :mod:`!gopherlib` (no
+  longer used) and :mod:`!md5` (replaced by :mod:`hashlib`), were
   already deprecated by :pep:`4`.  Others were removed as a result
   of the removal of support for various platforms such as Irix, BeOS
   and Mac OS 9 (see :pep:`11`).  Some modules were also selected for
@@ -626,7 +626,7 @@ review:
 Some other changes to standard library modules, not covered by
 :pep:`3108`:
 
-* Killed :mod:`sets`.  Use the built-in :func:`set` class.
+* Killed :mod:`!sets`.  Use the built-in :func:`set` class.
 
 * Cleanup of the :mod:`sys` module: removed :func:`sys.exitfunc`,
   :func:`sys.exc_clear`, :data:`sys.exc_type`, :data:`sys.exc_value`,
@@ -648,7 +648,7 @@ Some other changes to standard library modules, not covered by
 
 * Cleanup of the :mod:`random` module: removed the :func:`jumpahead` API.
 
-* The :mod:`new` module is gone.
+* The :mod:`!new` module is gone.
 
 * The functions :func:`os.tmpnam`, :func:`os.tempnam` and
   :func:`os.tmpfile` have been removed in favor of the :mod:`tempfile`


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

Fix 54 warnings:
```
Doc/library/subprocess.rst:1464: WARNING: py:mod reference target not found: popen2
Doc/whatsnew/2.0.rst:1098: WARNING: py:mod reference target not found: linuxaudiodev
Doc/whatsnew/2.0.rst:1098: WARNING: py:mod reference target not found: sunaudiodev
Doc/whatsnew/2.0.rst:1142: WARNING: py:mod reference target not found: ihooks
Doc/whatsnew/2.2.rst:146: WARNING: py:mod reference target not found: posixfile
Doc/whatsnew/2.4.rst:386: WARNING: py:mod reference target not found: popen2
Doc/whatsnew/2.4.rst:395: WARNING: py:mod reference target not found: popen2
Doc/whatsnew/2.4.rst:395: WARNING: py:class reference target not found: Popen
Doc/whatsnew/2.4.rst:1532: WARNING: py:func reference target not found: dircache.listdir
Doc/whatsnew/2.5.rst:1681: WARNING: py:mod reference target not found: dl
Doc/whatsnew/2.5.rst:1879: WARNING: py:mod reference target not found: md5
Doc/whatsnew/2.5.rst:1879: WARNING: py:mod reference target not found: sha
Doc/whatsnew/2.5.rst:1885: WARNING: py:mod reference target not found: md5
Doc/whatsnew/2.5.rst:1885: WARNING: py:mod reference target not found: sha
Doc/whatsnew/2.6.rst:2917: WARNING: py:attr reference target not found: message
Doc/whatsnew/2.6.rst:2917: WARNING: py:attr reference target not found: args
Doc/whatsnew/2.6.rst:2927: WARNING: py:mod reference target not found: audiodev
Doc/whatsnew/2.6.rst:2927: WARNING: py:mod reference target not found: bgenlocations
Doc/whatsnew/2.6.rst:2927: WARNING: py:mod reference target not found: buildtools
Doc/whatsnew/2.6.rst:2927: WARNING: py:mod reference target not found: bundlebuilder
Doc/whatsnew/2.6.rst:2927: WARNING: py:mod reference target not found: Canvas
Doc/whatsnew/2.6.rst:2927: WARNING: py:mod reference target not found: compiler
Doc/whatsnew/2.6.rst:2927: WARNING: py:mod reference target not found: dircache
Doc/whatsnew/2.6.rst:2927: WARNING: py:mod reference target not found: dl
Doc/whatsnew/2.6.rst:2927: WARNING: py:mod reference target not found: fpformat
Doc/whatsnew/2.6.rst:2927: WARNING: py:mod reference target not found: gensuitemodule
Doc/whatsnew/2.6.rst:2927: WARNING: py:mod reference target not found: ihooks
Doc/whatsnew/2.6.rst:2927: WARNING: py:mod reference target not found: imageop
Doc/whatsnew/2.6.rst:2927: WARNING: py:mod reference target not found: imgfile
Doc/whatsnew/2.6.rst:2927: WARNING: py:mod reference target not found: linuxaudiodev
Doc/whatsnew/2.6.rst:2927: WARNING: py:mod reference target not found: mhlib
Doc/whatsnew/2.6.rst:2927: WARNING: py:mod reference target not found: mimetools
Doc/whatsnew/2.6.rst:2927: WARNING: py:mod reference target not found: multifile
Doc/whatsnew/2.6.rst:2927: WARNING: py:mod reference target not found: new
Doc/whatsnew/2.6.rst:2927: WARNING: py:mod reference target not found: pure
Doc/whatsnew/2.6.rst:2927: WARNING: py:mod reference target not found: statvfs
Doc/whatsnew/2.6.rst:2927: WARNING: py:mod reference target not found: sunaudiodev
Doc/whatsnew/2.6.rst:2927: WARNING: py:mod reference target not found: test.testall
Doc/whatsnew/2.6.rst:2927: WARNING: py:mod reference target not found: toaiff
Doc/whatsnew/2.6.rst:2952: WARNING: py:mod reference target not found: gopherlib
Doc/whatsnew/2.6.rst:2954: WARNING: py:mod reference target not found: MimeWriter
Doc/whatsnew/2.6.rst:2954: WARNING: py:mod reference target not found: mimify
Doc/whatsnew/2.6.rst:2958: WARNING: py:mod reference target not found: md5
Doc/whatsnew/2.6.rst:2961: WARNING: py:mod reference target not found: posixfile
Doc/whatsnew/2.6.rst:2964: WARNING: py:mod reference target not found: popen2
Doc/whatsnew/2.6.rst:2967: WARNING: py:mod reference target not found: rgbimg
Doc/whatsnew/2.6.rst:2969: WARNING: py:mod reference target not found: sets
Doc/whatsnew/2.6.rst:2972: WARNING: py:mod reference target not found: sha
Doc/whatsnew/2.7.rst:1318: WARNING: py:mod reference target not found: ihooks
Doc/whatsnew/2.7.rst:1318: WARNING: py:mod reference target not found: ihooks
Doc/whatsnew/3.0.rst:558: WARNING: py:mod reference target not found: gopherlib
Doc/whatsnew/3.0.rst:558: WARNING: py:mod reference target not found: md5
Doc/whatsnew/3.0.rst:629: WARNING: py:mod reference target not found: sets
Doc/whatsnew/3.0.rst:651: WARNING: py:mod reference target not found: new
```


<!-- gh-issue-number: gh-101100 -->
* Issue: gh-101100
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--113725.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->