### PR TITLE
gh-101100: Fix Sphinx warnings in `library/pyclbr.rst`

### DIFF
--- a/Doc/library/pyclbr.rst
+++ b/Doc/library/pyclbr.rst
@@ -61,7 +61,7 @@ Function Objects
 
 .. class:: Function
 
-   Class :class:`Function` instances describe functions defined by def
+   Class :class:`!Function` instances describe functions defined by def
    statements.  They have the following attributes:
 
 
@@ -114,7 +114,7 @@ Class Objects
 
 .. class:: Class
 
-   Class :class:`Class` instances describe classes defined by class
+   Class :class:`!Class` instances describe classes defined by class
    statements.  They have the same attributes as Functions and two more.
 
 
@@ -155,11 +155,11 @@ Class Objects
 
    .. attribute:: super
 
-      A list of :class:`Class` objects which describe the immediate base
+      A list of :class:`!Class` objects which describe the immediate base
       classes of the class being described.  Classes which are named as
       superclasses but which are not discoverable by :func:`readmodule_ex`
       are listed as a string with the class name instead of as
-      :class:`Class` objects.
+      :class:`!Class` objects.
 
 
    .. attribute:: methods

--- a/Doc/library/pyclbr.rst
+++ b/Doc/library/pyclbr.rst
@@ -61,50 +61,50 @@ Function Objects
 
 .. class:: Function
 
-Class :class:`Function` instances describe functions defined by def
-statements.  They have the following attributes:
+   Class :class:`Function` instances describe functions defined by def
+   statements.  They have the following attributes:
 
 
-.. attribute:: Function.file
+   .. attribute:: file
 
-   Name of the file in which the function is defined.
-
-
-.. attribute:: Function.module
-
-   The name of the module defining the function described.
+      Name of the file in which the function is defined.
 
 
-.. attribute:: Function.name
+   .. attribute:: module
 
-   The name of the function.
-
-
-.. attribute:: Function.lineno
-
-   The line number in the file where the definition starts.
+      The name of the module defining the function described.
 
 
-.. attribute:: Function.parent
+   .. attribute:: name
 
-   For top-level functions, None.  For nested functions, the parent.
-
-   .. versionadded:: 3.7
+      The name of the function.
 
 
-.. attribute:: Function.children
+   .. attribute:: lineno
 
-   A dictionary mapping names to descriptors for nested functions and
-   classes.
-
-   .. versionadded:: 3.7
+      The line number in the file where the definition starts.
 
 
-.. attribute:: Function.is_async
+   .. attribute:: parent
 
-   ``True`` for functions that are defined with the ``async`` prefix, ``False`` otherwise.
+      For top-level functions, None.  For nested functions, the parent.
 
-   .. versionadded:: 3.10
+      .. versionadded:: 3.7
+
+
+   .. attribute:: children
+
+      A dictionary mapping names to descriptors for nested functions and
+      classes.
+
+      .. versionadded:: 3.7
+
+
+   .. attribute:: is_async
+
+      ``True`` for functions that are defined with the ``async`` prefix, ``False`` otherwise.
+
+      .. versionadded:: 3.10
 
 
 .. _pyclbr-class-objects:
@@ -114,56 +114,56 @@ Class Objects
 
 .. class:: Class
 
-Class :class:`Class` instances describe classes defined by class
-statements.  They have the same attributes as Functions and two more.
+   Class :class:`Class` instances describe classes defined by class
+   statements.  They have the same attributes as Functions and two more.
 
 
-.. attribute:: Class.file
+   .. attribute:: file
 
-   Name of the file in which the class is defined.
-
-
-.. attribute:: Class.module
-
-   The name of the module defining the class described.
+      Name of the file in which the class is defined.
 
 
-.. attribute:: Class.name
+   .. attribute:: module
 
-   The name of the class.
-
-
-.. attribute:: Class.lineno
-
-   The line number in the file where the definition starts.
+      The name of the module defining the class described.
 
 
-.. attribute:: Class.parent
+   .. attribute:: name
 
-   For top-level classes, None.  For nested classes, the parent.
-
-   .. versionadded:: 3.7
+      The name of the class.
 
 
-.. attribute:: Class.children
+   .. attribute:: lineno
 
-   A dictionary mapping names to descriptors for nested functions and
-   classes.
-
-   .. versionadded:: 3.7
+      The line number in the file where the definition starts.
 
 
-.. attribute:: Class.super
+   .. attribute:: parent
 
-   A list of :class:`Class` objects which describe the immediate base
-   classes of the class being described.  Classes which are named as
-   superclasses but which are not discoverable by :func:`readmodule_ex`
-   are listed as a string with the class name instead of as
-   :class:`Class` objects.
+      For top-level classes, None.  For nested classes, the parent.
+
+      .. versionadded:: 3.7
 
 
-.. attribute:: Class.methods
+   .. attribute:: children
 
-   A dictionary mapping method names to line numbers.  This can be
-   derived from the newer children dictionary, but remains for
-   back-compatibility.
+      A dictionary mapping names to descriptors for nested functions and
+      classes.
+
+      .. versionadded:: 3.7
+
+
+   .. attribute:: super
+
+      A list of :class:`Class` objects which describe the immediate base
+      classes of the class being described.  Classes which are named as
+      superclasses but which are not discoverable by :func:`readmodule_ex`
+      are listed as a string with the class name instead of as
+      :class:`Class` objects.
+
+
+   .. attribute:: methods
+
+      A dictionary mapping method names to line numbers.  This can be
+      derived from the newer children dictionary, but remains for
+      back-compatibility.

--- a/Doc/library/pyclbr.rst
+++ b/Doc/library/pyclbr.rst
@@ -58,6 +58,9 @@ of these classes.
 
 Function Objects
 ----------------
+
+.. class:: Function
+
 Class :class:`Function` instances describe functions defined by def
 statements.  They have the following attributes:
 
@@ -108,6 +111,9 @@ statements.  They have the following attributes:
 
 Class Objects
 -------------
+
+.. class:: Class
+
 Class :class:`Class` instances describe classes defined by class
 statements.  They have the same attributes as Functions and two more.
 

--- a/Doc/library/pyclbr.rst
+++ b/Doc/library/pyclbr.rst
@@ -87,14 +87,14 @@ Function Objects
 
    .. attribute:: parent
 
-      For top-level functions, None.  For nested functions, the parent.
+      For top-level functions, ``None``.  For nested functions, the parent.
 
       .. versionadded:: 3.7
 
 
    .. attribute:: children
 
-      A dictionary mapping names to descriptors for nested functions and
+      A :class:`dictionary <dict>` mapping names to descriptors for nested functions and
       classes.
 
       .. versionadded:: 3.7
@@ -102,7 +102,8 @@ Function Objects
 
    .. attribute:: is_async
 
-      ``True`` for functions that are defined with the ``async`` prefix, ``False`` otherwise.
+      ``True`` for functions that are defined with the
+      :keyword:`async <async def>` prefix, ``False`` otherwise.
 
       .. versionadded:: 3.10
 
@@ -115,7 +116,8 @@ Class Objects
 .. class:: Class
 
    Class :class:`!Class` instances describe classes defined by class
-   statements.  They have the same attributes as Functions and two more.
+   statements.  They have the same attributes as :class:`Functions <Function>`
+   and two more.
 
 
    .. attribute:: file
@@ -164,6 +166,7 @@ Class Objects
 
    .. attribute:: methods
 
-      A dictionary mapping method names to line numbers.  This can be
-      derived from the newer children dictionary, but remains for
+      A :class:`dictionary <dict>` mapping method names to line numbers.
+      This can be derived from the newer :attr:`children` dictionary,
+      but remains for
       back-compatibility.

--- a/Doc/tools/.nitignore
+++ b/Doc/tools/.nitignore
@@ -67,7 +67,6 @@ Doc/library/pickletools.rst
 Doc/library/platform.rst
 Doc/library/plistlib.rst
 Doc/library/profile.rst
-Doc/library/pyclbr.rst
 Doc/library/pydoc.rst
 Doc/library/pyexpat.rst
 Doc/library/readline.rst

--- a/Doc/whatsnew/3.10.rst
+++ b/Doc/whatsnew/3.10.rst
@@ -1316,8 +1316,8 @@ pyclbr
 ------
 
 Add an ``end_lineno`` attribute to the ``Function`` and ``Class``
-objects in the tree returned by :func:`pyclbr.readline` and
-:func:`pyclbr.readline_ex`.  It matches the existing (start) ``lineno``.
+objects in the tree returned by :func:`pyclbr.readmodule` and
+:func:`pyclbr.readmodule_ex`.  It matches the existing (start) ``lineno``.
 (Contributed by Aviral Srivastava in :issue:`38307`.)
 
 shelve


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

Fix 6 warnings:

```
Doc/library/pyclbr.rst:61: WARNING: py:class reference target not found: Function
Doc/library/pyclbr.rst:111: WARNING: py:class reference target not found: Class
Doc/library/pyclbr.rst:152: WARNING: py:class reference target not found: Class
Doc/library/pyclbr.rst:152: WARNING: py:class reference target not found: Class
Doc/whatsnew/3.10.rst:1318: WARNING: py:func reference target not found: pyclbr.readline
Doc/whatsnew/3.10.rst:1318: WARNING: py:func reference target not found: pyclbr.readline_ex
```

First four fixed by adding the `..class:` targets.

@AlexWaygood I think you're going to ask me to also add `!` to these `Function` and `Class` refs because they appear inside the actual classes?

The last two look like typos (added in https://github.com/python/cpython/pull/24348) for `readmodule` and `readmodule_ex` that are documented and exist in https://github.com/python/cpython/blob/main/Lib/pyclbr.py


<!-- gh-issue-number: gh-101100 -->
* Issue: gh-101100
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--113739.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->