### PR TITLE
[3.11] gh-80532: Do not set ipv6type when cross-compiling (GH-17956)

### DIFF
--- a/Misc/NEWS.d/next/Build/2020-01-11-23-49-17.bpo-36351.ce8BBh.rst
+++ b/Misc/NEWS.d/next/Build/2020-01-11-23-49-17.bpo-36351.ce8BBh.rst
@@ -1,0 +1,1 @@
+Do not set ipv6type when cross-compiling.

--- a/configure
+++ b/configure
@@ -14673,7 +14673,7 @@ ipv6type=unknown
 ipv6lib=none
 ipv6trylibc=no
 
-if test "$ipv6" = "yes"; then
+if test "$ipv6" = yes -a "$cross_compiling" = no; then
 	{ $as_echo "$as_me:${as_lineno-$LINENO}: checking ipv6 stack type" >&5
 $as_echo_n "checking ipv6 stack type... " >&6; }
 	for i in inria kame linux-glibc linux-inet6 solaris toshiba v6d zeta;

--- a/configure.ac
+++ b/configure.ac
@@ -4273,7 +4273,7 @@ ipv6type=unknown
 ipv6lib=none
 ipv6trylibc=no
 
-if test "$ipv6" = "yes"; then
+if test "$ipv6" = yes -a "$cross_compiling" = no; then
 	AC_MSG_CHECKING([ipv6 stack type])
 	for i in inria kame linux-glibc linux-inet6 solaris toshiba v6d zeta;
 	do


### PR DESCRIPTION
(cherry picked from commit 5e1916ba1bf521d6ff9d2c553c057f3ef7008977)

Co-authored-by: Zackery Spytz <zspytz@gmail.com>
Co-authored-by: Xavier de Gaye <xdegaye@gmail.com>


<!-- gh-issue-number: gh-80532 -->
* Issue: gh-80532
<!-- /gh-issue-number -->
