### PR TITLE
gh-112529: Track if debug allocator is used as underlying allocator

### DIFF
--- a/Include/internal/pycore_pymem.h
+++ b/Include/internal/pycore_pymem.h
@@ -44,6 +44,7 @@ struct _pymem_allocators {
         debug_alloc_api_t mem;
         debug_alloc_api_t obj;
     } debug;
+    int is_debug_enabled;
     PyObjectArenaAllocator obj_arena;
 };
 
@@ -106,6 +107,8 @@ extern int _PyMem_GetAllocatorName(
    PYMEM_ALLOCATOR_NOT_SET does nothing. */
 extern int _PyMem_SetupAllocators(PyMemAllocatorName allocator);
 
+/* Is the debug allocator enabled? */
+extern int _PyMem_DebugEnabled(void);
 
 #ifdef __cplusplus
 }

--- a/Include/internal/pycore_pymem_init.h
+++ b/Include/internal/pycore_pymem_init.h
@@ -70,6 +70,7 @@ extern void _PyMem_ArenaFree(void *, void *, size_t);
         PYDBGMEM_ALLOC(runtime), \
         PYDBGOBJ_ALLOC(runtime), \
     }
+# define _pymem_is_debug_enabled_INIT 1
 #else
 # define _pymem_allocators_standard_INIT(runtime) \
     { \
@@ -77,6 +78,7 @@ extern void _PyMem_ArenaFree(void *, void *, size_t);
         PYMEM_ALLOC, \
         PYOBJ_ALLOC, \
     }
+# define _pymem_is_debug_enabled_INIT 0
 #endif
 
 #define _pymem_allocators_debug_INIT \

--- a/Include/internal/pycore_runtime_init.h
+++ b/Include/internal/pycore_runtime_init.h
@@ -86,6 +86,7 @@ extern PyTypeObject _PyExc_MemoryError;
             .standard = _pymem_allocators_standard_INIT(runtime), \
             .debug = _pymem_allocators_debug_INIT, \
             .obj_arena = _pymem_allocators_obj_arena_INIT, \
+            .is_debug_enabled = _pymem_is_debug_enabled_INIT, \
         }, \
         .obmalloc = _obmalloc_global_state_INIT, \
         .pyhash_state = pyhash_state_INIT, \

--- a/Objects/obmalloc.c
+++ b/Objects/obmalloc.c
@@ -615,11 +615,7 @@ _PyMem_GetCurrentAllocatorName(void)
 int
 _PyMem_DebugEnabled(void)
 {
-#ifdef WITH_PYMALLOC
     return _PyRuntime.allocators.is_debug_enabled;
-#else
-    return 0;
-#endif
 }
 
 #ifdef WITH_PYMALLOC

--- a/Objects/obmalloc.c
+++ b/Objects/obmalloc.c
@@ -439,12 +439,14 @@ set_up_allocators_unlocked(PyMemAllocatorName allocator)
         (void)set_default_allocator_unlocked(PYMEM_DOMAIN_RAW, pydebug, NULL);
         (void)set_default_allocator_unlocked(PYMEM_DOMAIN_MEM, pydebug, NULL);
         (void)set_default_allocator_unlocked(PYMEM_DOMAIN_OBJ, pydebug, NULL);
+        _PyRuntime.allocators.is_debug_enabled = pydebug;
         break;
 
     case PYMEM_ALLOCATOR_DEBUG:
         (void)set_default_allocator_unlocked(PYMEM_DOMAIN_RAW, 1, NULL);
         (void)set_default_allocator_unlocked(PYMEM_DOMAIN_MEM, 1, NULL);
         (void)set_default_allocator_unlocked(PYMEM_DOMAIN_OBJ, 1, NULL);
+        _PyRuntime.allocators.is_debug_enabled = 1;
         break;
 
 #ifdef WITH_PYMALLOC
@@ -458,7 +460,9 @@ set_up_allocators_unlocked(PyMemAllocatorName allocator)
         set_allocator_unlocked(PYMEM_DOMAIN_MEM, &pymalloc);
         set_allocator_unlocked(PYMEM_DOMAIN_OBJ, &pymalloc);
 
-        if (allocator == PYMEM_ALLOCATOR_PYMALLOC_DEBUG) {
+        int is_debug = (allocator == PYMEM_ALLOCATOR_PYMALLOC_DEBUG);
+        _PyRuntime.allocators.is_debug_enabled = is_debug;
+        if (is_debug) {
             set_up_debug_hooks_unlocked();
         }
         break;
@@ -477,7 +481,9 @@ set_up_allocators_unlocked(PyMemAllocatorName allocator)
         PyMemAllocatorEx objmalloc = MIMALLOC_OBJALLOC;
         set_allocator_unlocked(PYMEM_DOMAIN_OBJ, &objmalloc);
 
-        if (allocator == PYMEM_ALLOCATOR_MIMALLOC_DEBUG) {
+        int is_debug = (allocator == PYMEM_ALLOCATOR_MIMALLOC_DEBUG);
+        _PyRuntime.allocators.is_debug_enabled = is_debug;
+        if (is_debug) {
             set_up_debug_hooks_unlocked();
         }
 
@@ -493,7 +499,9 @@ set_up_allocators_unlocked(PyMemAllocatorName allocator)
         set_allocator_unlocked(PYMEM_DOMAIN_MEM, &malloc_alloc);
         set_allocator_unlocked(PYMEM_DOMAIN_OBJ, &malloc_alloc);
 
-        if (allocator == PYMEM_ALLOCATOR_MALLOC_DEBUG) {
+        int is_debug = (allocator == PYMEM_ALLOCATOR_MALLOC_DEBUG);
+        _PyRuntime.allocators.is_debug_enabled = is_debug;
+        if (is_debug) {
             set_up_debug_hooks_unlocked();
         }
         break;
@@ -604,13 +612,17 @@ _PyMem_GetCurrentAllocatorName(void)
 }
 
 
-#ifdef WITH_PYMALLOC
-static int
+int
 _PyMem_DebugEnabled(void)
 {
-    return (_PyObject.malloc == _PyMem_DebugMalloc);
+#ifdef WITH_PYMALLOC
+    return _PyRuntime.allocators.is_debug_enabled;
+#else
+    return 0;
+#endif
 }
 
+#ifdef WITH_PYMALLOC
 static int
 _PyMem_PymallocEnabled(void)
 {
@@ -691,6 +703,7 @@ set_up_debug_hooks_unlocked(void)
     set_up_debug_hooks_domain_unlocked(PYMEM_DOMAIN_RAW);
     set_up_debug_hooks_domain_unlocked(PYMEM_DOMAIN_MEM);
     set_up_debug_hooks_domain_unlocked(PYMEM_DOMAIN_OBJ);
+    _PyRuntime.allocators.is_debug_enabled = 1;
 }
 
 void


### PR DESCRIPTION
The GC implementation for free-threaded builds will need to accurately detect if the debug allocator is used because it affects the offset of the Python object from the beginning of the memory allocation. The current implementation of `_PyMem_DebugEnabled` only considers if the debug allocator is the outer-most allocator; it doesn't handle the case of "hooks" like tracemalloc being used on top of the debug allocator.

This change enables more accurate detection of the debug allocator by tracking when debug hooks are enabled.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-112529 -->
* Issue: gh-112529
<!-- /gh-issue-number -->
