### PR TITLE
gh-113750: Fix object resurrection in free-threaded builds

### DIFF
--- a/Include/cpython/object.h
+++ b/Include/cpython/object.h
@@ -4,6 +4,7 @@
 
 PyAPI_FUNC(void) _Py_NewReference(PyObject *op);
 PyAPI_FUNC(void) _Py_NewReferenceNoTotal(PyObject *op);
+PyAPI_FUNC(void) _Py_ResurrectReference(PyObject *op);
 
 #ifdef Py_REF_DEBUG
 /* These are useful as debugging aids when chasing down refleaks. */

--- a/Modules/_testcapi/gc.c
+++ b/Modules/_testcapi/gc.c
@@ -126,9 +126,7 @@ slot_tp_del(PyObject *self)
      * never happened.
      */
     {
-        Py_ssize_t refcnt = Py_REFCNT(self);
-        _Py_NewReferenceNoTotal(self);
-        Py_SET_REFCNT(self, refcnt);
+        _Py_ResurrectReference(self);
     }
     assert(!PyType_IS_GC(Py_TYPE(self)) || PyObject_GC_IsTracked(self));
 }

--- a/Objects/object.c
+++ b/Objects/object.c
@@ -509,9 +509,7 @@ PyObject_CallFinalizerFromDealloc(PyObject *self)
 
     /* tp_finalize resurrected it!  Make it look like the original Py_DECREF
      * never happened. */
-    Py_ssize_t refcnt = Py_REFCNT(self);
-    _Py_NewReferenceNoTotal(self);
-    Py_SET_REFCNT(self, refcnt);
+    _Py_ResurrectReference(self);
 
     _PyObject_ASSERT(self,
                      (!_PyType_IS_GC(Py_TYPE(self))
@@ -2387,6 +2385,17 @@ void
 _Py_NewReferenceNoTotal(PyObject *op)
 {
     new_reference(op);
+}
+
+void
+_Py_ResurrectReference(PyObject *op)
+{
+    if (_PyRuntime.tracemalloc.config.tracing) {
+        _PyTraceMalloc_NewReference(op);
+    }
+#ifdef Py_TRACE_REFS
+    _Py_AddToAllObjects(op);
+#endif
 }
 
 


### PR DESCRIPTION
This avoids the undesired re-initializing of fields like `ob_gc_bits`, `ob_mutex`, and `ob_tid` when an object is resurrected due to its finalizer being called.

This change has no effect on the default (with GIL) build.

<!-- gh-issue-number: gh-113750 -->
* Issue: gh-113750
<!-- /gh-issue-number -->
