### PR TITLE
gh-101100: Fix Sphinx warnings for 2.6 port-specific deprecations

### DIFF
--- a/Doc/whatsnew/2.0.rst
+++ b/Doc/whatsnew/2.0.rst
@@ -130,7 +130,7 @@ Guidelines":
 Read the rest of :pep:`1` for the details of the PEP editorial process, style, and
 format.  PEPs are kept in the Python CVS tree on SourceForge, though they're not
 part of the Python 2.0 distribution, and are also available in HTML form from
-https://peps.python.org/.  As of September 2000, there are 25 PEPS, ranging
+https://peps.python.org/.  As of September 2000, there are 25 PEPs, ranging
 from :pep:`201`, "Lockstep Iteration", to PEP 225, "Elementwise/Objectwise
 Operators".
 

--- a/Doc/whatsnew/2.6.rst
+++ b/Doc/whatsnew/2.6.rst
@@ -4,8 +4,6 @@
   What's New in Python 2.6
 ****************************
 
-.. XXX add trademark info for Apple, Microsoft, SourceForge.
-
 :Author: A.M. Kuchling (amk at amk.ca)
 
 .. $Id$
@@ -1051,8 +1049,6 @@ the :mod:`io` module:
   sockets, but Python 2.6 hasn't restructured its file and socket objects
   in this way.
 
-  .. XXX should 2.6 register them in io.py?
-
 * :class:`BufferedIOBase` is an abstract base class that
   buffers data in memory to reduce the number of
   system calls used, making I/O processing more efficient.
@@ -1132,8 +1128,6 @@ can use this operation to lock memory in place
 while an external caller could be modifying the contents,
 so there's a corresponding ``PyBuffer_Release(Py_buffer *view)`` to
 indicate that the external caller is done.
-
-.. XXX PyObject_GetBuffer not documented in c-api
 
 The *flags* argument to :c:func:`PyObject_GetBuffer` specifies
 constraints upon the memory returned.  Some examples are:

--- a/Doc/whatsnew/2.6.rst
+++ b/Doc/whatsnew/2.6.rst
@@ -3110,8 +3110,8 @@ Port-Specific Changes: Windows
 
 * The :mod:`msvcrt` module now supports
   both the normal and wide char variants of the console I/O
-  API.  The :func:`getwch` function reads a keypress and returns a Unicode
-  value, as does the :func:`getwche` function.  The :func:`putwch` function
+  API.  The :func:`~msvcrt.getwch` function reads a keypress and returns a Unicode
+  value, as does the :func:`~msvcrt.getwche` function.  The :func:`~msvcrt.putwch` function
   takes a Unicode character and writes it to the console.
   (Contributed by Christian Heimes.)
 
@@ -3120,24 +3120,24 @@ Port-Specific Changes: Windows
   directory path.  (Contributed by Josiah Carlson; :issue:`957650`.)
 
 * The :mod:`socket` module's socket objects now have an
-  :meth:`ioctl` method that provides a limited interface to the
+  :meth:`~socket.socket.ioctl` method that provides a limited interface to the
   :c:func:`WSAIoctl` system interface.
 
-* The :mod:`_winreg` module now has a function,
-  :func:`ExpandEnvironmentStrings`,
+* The :mod:`_winreg <winreg>` module now has a function,
+  :func:`~winreg.ExpandEnvironmentStrings`,
   that expands environment variable references such as ``%NAME%``
   in an input string.  The handle objects provided by this
   module now support the context protocol, so they can be used
   in :keyword:`with` statements. (Contributed by Christian Heimes.)
 
-  :mod:`_winreg` also has better support for x64 systems,
-  exposing the :func:`DisableReflectionKey`, :func:`EnableReflectionKey`,
-  and :func:`QueryReflectionKey` functions, which enable and disable
+  :mod:`_winreg <winreg>` also has better support for x64 systems,
+  exposing the :func:`~winreg.DisableReflectionKey`, :func:`~winreg.EnableReflectionKey`,
+  and :func:`~winreg.QueryReflectionKey` functions, which enable and disable
   registry reflection for 32-bit processes running on 64-bit systems.
   (:issue:`1753245`)
 
-* The :mod:`!msilib` module's :class:`Record` object
-  gained :meth:`GetInteger` and :meth:`GetString` methods that
+* The :mod:`!msilib` module's :class:`!Record` object
+  gained :meth:`!GetInteger` and :meth:`!GetString` methods that
   return field values as an integer or a string.
   (Contributed by Floris Bruynooghe; :issue:`2125`.)
 
@@ -3151,49 +3151,49 @@ Port-Specific Changes: Mac OS X
   :option:`!--with-framework-name=` option to the
   :program:`configure` script.
 
-* The :mod:`macfs` module has been removed.  This in turn required the
-  :func:`macostools.touched` function to be removed because it depended on the
-  :mod:`macfs` module.  (:issue:`1490190`)
+* The :mod:`!macfs` module has been removed.  This in turn required the
+  :func:`!macostools.touched` function to be removed because it depended on the
+  :mod:`!macfs` module.  (:issue:`1490190`)
 
 * Many other Mac OS modules have been deprecated and will be removed in
   Python 3.0:
-  :mod:`_builtinSuites`,
-  :mod:`aepack`,
-  :mod:`aetools`,
-  :mod:`aetypes`,
-  :mod:`applesingle`,
-  :mod:`appletrawmain`,
-  :mod:`appletrunner`,
-  :mod:`argvemulator`,
-  :mod:`Audio_mac`,
-  :mod:`autoGIL`,
-  :mod:`Carbon`,
-  :mod:`cfmfile`,
-  :mod:`CodeWarrior`,
-  :mod:`ColorPicker`,
-  :mod:`EasyDialogs`,
-  :mod:`Explorer`,
-  :mod:`Finder`,
-  :mod:`FrameWork`,
-  :mod:`findertools`,
-  :mod:`ic`,
-  :mod:`icglue`,
-  :mod:`icopen`,
-  :mod:`macerrors`,
-  :mod:`MacOS`,
-  :mod:`macfs`,
-  :mod:`macostools`,
-  :mod:`macresource`,
-  :mod:`MiniAEFrame`,
-  :mod:`Nav`,
-  :mod:`Netscape`,
-  :mod:`OSATerminology`,
-  :mod:`pimp`,
-  :mod:`PixMapWrapper`,
-  :mod:`StdSuites`,
-  :mod:`SystemEvents`,
-  :mod:`Terminal`, and
-  :mod:`terminalcommand`.
+  :mod:`!_builtinSuites`,
+  :mod:`!aepack`,
+  :mod:`!aetools`,
+  :mod:`!aetypes`,
+  :mod:`!applesingle`,
+  :mod:`!appletrawmain`,
+  :mod:`!appletrunner`,
+  :mod:`!argvemulator`,
+  :mod:`!Audio_mac`,
+  :mod:`!autoGIL`,
+  :mod:`!Carbon`,
+  :mod:`!cfmfile`,
+  :mod:`!CodeWarrior`,
+  :mod:`!ColorPicker`,
+  :mod:`!EasyDialogs`,
+  :mod:`!Explorer`,
+  :mod:`!Finder`,
+  :mod:`!FrameWork`,
+  :mod:`!findertools`,
+  :mod:`!ic`,
+  :mod:`!icglue`,
+  :mod:`!icopen`,
+  :mod:`!macerrors`,
+  :mod:`!MacOS`,
+  :mod:`!macfs`,
+  :mod:`!macostools`,
+  :mod:`!macresource`,
+  :mod:`!MiniAEFrame`,
+  :mod:`!Nav`,
+  :mod:`!Netscape`,
+  :mod:`!OSATerminology`,
+  :mod:`!pimp`,
+  :mod:`!PixMapWrapper`,
+  :mod:`!StdSuites`,
+  :mod:`!SystemEvents`,
+  :mod:`!Terminal`, and
+  :mod:`!terminalcommand`.
 
 .. ======================================================================
 
@@ -3202,29 +3202,29 @@ Port-Specific Changes: IRIX
 
 A number of old IRIX-specific modules were deprecated and will
 be removed in Python 3.0:
-:mod:`al` and :mod:`AL`,
-:mod:`cd`,
-:mod:`cddb`,
-:mod:`cdplayer`,
-:mod:`CL` and :mod:`cl`,
-:mod:`DEVICE`,
-:mod:`ERRNO`,
-:mod:`FILE`,
-:mod:`FL` and :mod:`fl`,
-:mod:`flp`,
-:mod:`fm`,
-:mod:`GET`,
-:mod:`GLWS`,
-:mod:`GL` and :mod:`gl`,
-:mod:`IN`,
-:mod:`IOCTL`,
-:mod:`jpeg`,
-:mod:`panelparser`,
-:mod:`readcd`,
-:mod:`SV` and :mod:`sv`,
-:mod:`torgb`,
-:mod:`videoreader`, and
-:mod:`WAIT`.
+:mod:`!al` and :mod:`!AL`,
+:mod:`!cd`,
+:mod:`!cddb`,
+:mod:`!cdplayer`,
+:mod:`!CL` and :mod:`!cl`,
+:mod:`!DEVICE`,
+:mod:`!ERRNO`,
+:mod:`!FILE`,
+:mod:`!FL` and :mod:`!fl`,
+:mod:`!flp`,
+:mod:`!fm`,
+:mod:`!GET`,
+:mod:`!GLWS`,
+:mod:`!GL` and :mod:`!gl`,
+:mod:`!IN`,
+:mod:`!IOCTL`,
+:mod:`!jpeg`,
+:mod:`!panelparser`,
+:mod:`!readcd`,
+:mod:`!SV` and :mod:`!sv`,
+:mod:`!torgb`,
+:mod:`!videoreader`, and
+:mod:`!WAIT`.
 
 .. ======================================================================
 

--- a/Doc/whatsnew/2.6.rst
+++ b/Doc/whatsnew/2.6.rst
@@ -126,7 +126,7 @@ and to C extension code as :c:data:`!Py_Py3kWarningFlag`.
    The 3\ *xxx* series of PEPs, which contains proposals for Python 3.0.
    :pep:`3000` describes the development process for Python 3.0.
    Start with :pep:`3100` that describes the general goals for Python
-   3.0, and then explore the higher-numbered PEPS that propose
+   3.0, and then explore the higher-numbered PEPs that propose
    specific features.
 
 


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

Follow on from https://github.com/python/cpython/pull/113725, fix 81 warnings from these sections, mostly removed deprecations:

- Port-Specific Changes: Windows
- Port-Specific Changes: Mac OS X
- Port-Specific Changes: IRIX

```
Doc/whatsnew/2.6.rst:3111: WARNING: py:func reference target not found: getwch
Doc/whatsnew/2.6.rst:3111: WARNING: py:func reference target not found: getwche
Doc/whatsnew/2.6.rst:3111: WARNING: py:func reference target not found: putwch
Doc/whatsnew/2.6.rst:3122: WARNING: py:meth reference target not found: ioctl
Doc/whatsnew/2.6.rst:3126: WARNING: py:mod reference target not found: _winreg
Doc/whatsnew/2.6.rst:3126: WARNING: py:func reference target not found: ExpandEnvironmentStrings
Doc/whatsnew/2.6.rst:3133: WARNING: py:mod reference target not found: _winreg
Doc/whatsnew/2.6.rst:3133: WARNING: py:func reference target not found: DisableReflectionKey
Doc/whatsnew/2.6.rst:3133: WARNING: py:func reference target not found: EnableReflectionKey
Doc/whatsnew/2.6.rst:3133: WARNING: py:func reference target not found: QueryReflectionKey
Doc/whatsnew/2.6.rst:3139: WARNING: py:class reference target not found: Record
Doc/whatsnew/2.6.rst:3139: WARNING: py:meth reference target not found: GetInteger
Doc/whatsnew/2.6.rst:3139: WARNING: py:meth reference target not found: GetString
Doc/whatsnew/2.6.rst:3154: WARNING: py:mod reference target not found: macfs
Doc/whatsnew/2.6.rst:3154: WARNING: py:func reference target not found: macostools.touched
Doc/whatsnew/2.6.rst:3154: WARNING: py:mod reference target not found: macfs
Doc/whatsnew/2.6.rst:3158: WARNING: py:mod reference target not found: _builtinSuites
Doc/whatsnew/2.6.rst:3158: WARNING: py:mod reference target not found: aepack
Doc/whatsnew/2.6.rst:3158: WARNING: py:mod reference target not found: aetools
Doc/whatsnew/2.6.rst:3158: WARNING: py:mod reference target not found: aetypes
Doc/whatsnew/2.6.rst:3158: WARNING: py:mod reference target not found: applesingle
Doc/whatsnew/2.6.rst:3158: WARNING: py:mod reference target not found: appletrawmain
Doc/whatsnew/2.6.rst:3158: WARNING: py:mod reference target not found: appletrunner
Doc/whatsnew/2.6.rst:3158: WARNING: py:mod reference target not found: argvemulator
Doc/whatsnew/2.6.rst:3158: WARNING: py:mod reference target not found: Audio_mac
Doc/whatsnew/2.6.rst:3158: WARNING: py:mod reference target not found: autoGIL
Doc/whatsnew/2.6.rst:3158: WARNING: py:mod reference target not found: Carbon
Doc/whatsnew/2.6.rst:3158: WARNING: py:mod reference target not found: cfmfile
Doc/whatsnew/2.6.rst:3158: WARNING: py:mod reference target not found: CodeWarrior
Doc/whatsnew/2.6.rst:3158: WARNING: py:mod reference target not found: ColorPicker
Doc/whatsnew/2.6.rst:3158: WARNING: py:mod reference target not found: EasyDialogs
Doc/whatsnew/2.6.rst:3158: WARNING: py:mod reference target not found: Explorer
Doc/whatsnew/2.6.rst:3158: WARNING: py:mod reference target not found: Finder
Doc/whatsnew/2.6.rst:3158: WARNING: py:mod reference target not found: FrameWork
Doc/whatsnew/2.6.rst:3158: WARNING: py:mod reference target not found: findertools
Doc/whatsnew/2.6.rst:3158: WARNING: py:mod reference target not found: ic
Doc/whatsnew/2.6.rst:3158: WARNING: py:mod reference target not found: icglue
Doc/whatsnew/2.6.rst:3158: WARNING: py:mod reference target not found: icopen
Doc/whatsnew/2.6.rst:3158: WARNING: py:mod reference target not found: macerrors
Doc/whatsnew/2.6.rst:3158: WARNING: py:mod reference target not found: MacOS
Doc/whatsnew/2.6.rst:3158: WARNING: py:mod reference target not found: macfs
Doc/whatsnew/2.6.rst:3158: WARNING: py:mod reference target not found: macostools
Doc/whatsnew/2.6.rst:3158: WARNING: py:mod reference target not found: macresource
Doc/whatsnew/2.6.rst:3158: WARNING: py:mod reference target not found: MiniAEFrame
Doc/whatsnew/2.6.rst:3158: WARNING: py:mod reference target not found: Nav
Doc/whatsnew/2.6.rst:3158: WARNING: py:mod reference target not found: Netscape
Doc/whatsnew/2.6.rst:3158: WARNING: py:mod reference target not found: OSATerminology
Doc/whatsnew/2.6.rst:3158: WARNING: py:mod reference target not found: pimp
Doc/whatsnew/2.6.rst:3158: WARNING: py:mod reference target not found: PixMapWrapper
Doc/whatsnew/2.6.rst:3158: WARNING: py:mod reference target not found: StdSuites
Doc/whatsnew/2.6.rst:3158: WARNING: py:mod reference target not found: SystemEvents
Doc/whatsnew/2.6.rst:3158: WARNING: py:mod reference target not found: Terminal
Doc/whatsnew/2.6.rst:3158: WARNING: py:mod reference target not found: terminalcommand
Doc/whatsnew/2.6.rst:3203: WARNING: py:mod reference target not found: al
Doc/whatsnew/2.6.rst:3203: WARNING: py:mod reference target not found: AL
Doc/whatsnew/2.6.rst:3203: WARNING: py:mod reference target not found: cd
Doc/whatsnew/2.6.rst:3203: WARNING: py:mod reference target not found: cddb
Doc/whatsnew/2.6.rst:3203: WARNING: py:mod reference target not found: cdplayer
Doc/whatsnew/2.6.rst:3203: WARNING: py:mod reference target not found: CL
Doc/whatsnew/2.6.rst:3203: WARNING: py:mod reference target not found: cl
Doc/whatsnew/2.6.rst:3203: WARNING: py:mod reference target not found: DEVICE
Doc/whatsnew/2.6.rst:3203: WARNING: py:mod reference target not found: ERRNO
Doc/whatsnew/2.6.rst:3203: WARNING: py:mod reference target not found: FILE
Doc/whatsnew/2.6.rst:3203: WARNING: py:mod reference target not found: FL
Doc/whatsnew/2.6.rst:3203: WARNING: py:mod reference target not found: fl
Doc/whatsnew/2.6.rst:3203: WARNING: py:mod reference target not found: flp
Doc/whatsnew/2.6.rst:3203: WARNING: py:mod reference target not found: fm
Doc/whatsnew/2.6.rst:3203: WARNING: py:mod reference target not found: GET
Doc/whatsnew/2.6.rst:3203: WARNING: py:mod reference target not found: GLWS
Doc/whatsnew/2.6.rst:3203: WARNING: py:mod reference target not found: GL
Doc/whatsnew/2.6.rst:3203: WARNING: py:mod reference target not found: gl
Doc/whatsnew/2.6.rst:3203: WARNING: py:mod reference target not found: IN
Doc/whatsnew/2.6.rst:3203: WARNING: py:mod reference target not found: IOCTL
Doc/whatsnew/2.6.rst:3203: WARNING: py:mod reference target not found: jpeg
Doc/whatsnew/2.6.rst:3203: WARNING: py:mod reference target not found: panelparser
Doc/whatsnew/2.6.rst:3203: WARNING: py:mod reference target not found: readcd
Doc/whatsnew/2.6.rst:3203: WARNING: py:mod reference target not found: SV
Doc/whatsnew/2.6.rst:3203: WARNING: py:mod reference target not found: sv
Doc/whatsnew/2.6.rst:3203: WARNING: py:mod reference target not found: torgb
Doc/whatsnew/2.6.rst:3203: WARNING: py:mod reference target not found: videoreader
Doc/whatsnew/2.6.rst:3203: WARNING: py:mod reference target not found: WAIT
```

Also:

* Remove XXX comments, these TODOs are no longer relevant 15 years later
* Fix typo "PEPS" -> "PEPs"


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--113752.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->

<!-- gh-issue-number: gh-101100 -->
* Issue: gh-101100
<!-- /gh-issue-number -->
