### PR TITLE
gh-113773: add list.index() "key" named argument

### DIFF
--- a/Lib/test/list_tests.py
+++ b/Lib/test/list_tests.py
@@ -380,6 +380,26 @@ class CommonTest(seq_tests.CommonTest):
         # This used to seg fault before patch #1005778
         self.assertRaises(ValueError, a.index, None)
 
+    def test_index_key(self):
+        data = [(i, chr(i)) for i in range(100)]
+        idx = data.index("a", key=lambda i:i[1])
+        self.assertEqual(data[idx][1], "a")
+
+        with self.assertRaises(ValueError):
+            data.index("foo", key=lambda i:i[1])
+
+        # verify that errors propagate
+        with self.assertRaises(ZeroDivisionError):
+            data.index("a", key=lambda i: 1/0)
+
+        # verify that key method can modify the list without crashing
+        def evil_key(i):
+            del data[:]
+            return i[1]
+        with self.assertRaises(ValueError):
+            idx = data.index("a", key=evil_key)
+        self.assertEqual(data, [])        
+
     def test_reverse(self):
         u = self.type2test([-2, -1, 0, 1, 2])
         u2 = u[:]

--- a/Lib/test/list_tests.py
+++ b/Lib/test/list_tests.py
@@ -396,9 +396,10 @@ class CommonTest(seq_tests.CommonTest):
         def evil_key(i):
             del data[:]
             return i[1]
+
         with self.assertRaises(ValueError):
             idx = data.index("a", key=evil_key)
-        self.assertEqual(data, [])        
+        self.assertEqual(data, [])
 
     def test_reverse(self):
         u = self.type2test([-2, -1, 0, 1, 2])

--- a/Lib/test/test_call.py
+++ b/Lib/test/test_call.py
@@ -98,10 +98,6 @@ class CFunctionCallsErrorMessages(unittest.TestCase):
         msg = r"bool\(\) takes no keyword arguments"
         self.assertRaisesRegex(TypeError, msg, bool, x=2)
 
-    def test_varargs4_kw(self):
-        msg = r"^(list[.])?index\(\) takes no keyword arguments$"
-        self.assertRaisesRegex(TypeError, msg, [].index, x=2)
-
     def test_varargs5_kw(self):
         msg = r"^hasattr\(\) takes no keyword arguments$"
         self.assertRaisesRegex(TypeError, msg, hasattr, x=2)

--- a/Misc/NEWS.d/next/Core and Builtins/2024-01-07-12-53-28.gh-issue-113773.uUjnBu.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2024-01-07-12-53-28.gh-issue-113773.uUjnBu.rst
@@ -1,0 +1,1 @@
+:func:`list.index` now supports the *key* keyword-only argument. When provided, each list item is first transformed by it before comparint it with *value*.

--- a/Objects/clinic/listobject.c.h
+++ b/Objects/clinic/listobject.c.h
@@ -246,46 +246,84 @@ list_reverse(PyListObject *self, PyObject *Py_UNUSED(ignored))
 }
 
 PyDoc_STRVAR(list_index__doc__,
-"index($self, value, start=0, stop=sys.maxsize, /)\n"
+"index($self, value, start=0, stop=sys.maxsize, /, *,\n"
+"      key=<unrepresentable>)\n"
 "--\n"
 "\n"
 "Return first index of value.\n"
 "\n"
-"Raises ValueError if the value is not present.");
+"Raises ValueError if the value is not present.\n"
+"A callable \'key\' can be provided to transform each item before comparison with \'value\'.");
 
 #define LIST_INDEX_METHODDEF    \
-    {"index", _PyCFunction_CAST(list_index), METH_FASTCALL, list_index__doc__},
+    {"index", _PyCFunction_CAST(list_index), METH_FASTCALL|METH_KEYWORDS, list_index__doc__},
 
 static PyObject *
 list_index_impl(PyListObject *self, PyObject *value, Py_ssize_t start,
-                Py_ssize_t stop);
+                Py_ssize_t stop, PyObject *key);
 
 static PyObject *
-list_index(PyListObject *self, PyObject *const *args, Py_ssize_t nargs)
+list_index(PyListObject *self, PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
+    #if defined(Py_BUILD_CORE) && !defined(Py_BUILD_CORE_MODULE)
+
+    #define NUM_KEYWORDS 1
+    static struct {
+        PyGC_Head _this_is_not_used;
+        PyObject_VAR_HEAD
+        PyObject *ob_item[NUM_KEYWORDS];
+    } _kwtuple = {
+        .ob_base = PyVarObject_HEAD_INIT(&PyTuple_Type, NUM_KEYWORDS)
+        .ob_item = { &_Py_ID(key), },
+    };
+    #undef NUM_KEYWORDS
+    #define KWTUPLE (&_kwtuple.ob_base.ob_base)
+
+    #else  // !Py_BUILD_CORE
+    #  define KWTUPLE NULL
+    #endif  // !Py_BUILD_CORE
+
+    static const char * const _keywords[] = {"", "", "", "key", NULL};
+    static _PyArg_Parser _parser = {
+        .keywords = _keywords,
+        .fname = "index",
+        .kwtuple = KWTUPLE,
+    };
+    #undef KWTUPLE
+    PyObject *argsbuf[4];
+    Py_ssize_t noptargs = nargs + (kwnames ? PyTuple_GET_SIZE(kwnames) : 0) - 1;
     PyObject *value;
     Py_ssize_t start = 0;
     Py_ssize_t stop = PY_SSIZE_T_MAX;
+    PyObject *key = NULL;
 
-    if (!_PyArg_CheckPositional("index", nargs, 1, 3)) {
+    args = _PyArg_UnpackKeywords(args, nargs, NULL, kwnames, &_parser, 1, 3, 0, argsbuf);
+    if (!args) {
         goto exit;
     }
     value = args[0];
     if (nargs < 2) {
-        goto skip_optional;
+        goto skip_optional_posonly;
     }
+    noptargs--;
     if (!_PyEval_SliceIndexNotNone(args[1], &start)) {
         goto exit;
     }
     if (nargs < 3) {
-        goto skip_optional;
+        goto skip_optional_posonly;
     }
+    noptargs--;
     if (!_PyEval_SliceIndexNotNone(args[2], &stop)) {
         goto exit;
     }
-skip_optional:
-    return_value = list_index_impl(self, value, start, stop);
+skip_optional_posonly:
+    if (!noptargs) {
+        goto skip_optional_kwonly;
+    }
+    key = args[3];
+skip_optional_kwonly:
+    return_value = list_index_impl(self, value, start, stop, key);
 
 exit:
     return return_value;
@@ -384,4 +422,4 @@ list___reversed__(PyListObject *self, PyObject *Py_UNUSED(ignored))
 {
     return list___reversed___impl(self);
 }
-/*[clinic end generated code: output=f2d7b63119464ff4 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=33d604e8788095b7 input=a9049054013a1b77]*/

--- a/Objects/listobject.c
+++ b/Objects/listobject.c
@@ -2677,13 +2677,15 @@ list_index_impl(PyListObject *self, PyObject *value, Py_ssize_t start,
 
     if (start < 0) {
         start += Py_SIZE(self);
-        if (start < 0)
+        if (start < 0) {
             start = 0;
+        }
     }
     if (stop < 0) {
         stop += Py_SIZE(self);
-        if (stop < 0)
+        if (stop < 0) {
             stop = 0;
+        }
     }
     for (i = start; i < stop && i < Py_SIZE(self); i++) {
         PyObject *obj, *item = self->ob_item[i];
@@ -2701,10 +2703,12 @@ list_index_impl(PyListObject *self, PyObject *value, Py_ssize_t start,
         }
         int cmp = PyObject_RichCompareBool(obj, value, Py_EQ);
         Py_DECREF(obj);
-        if (cmp > 0)
+        if (cmp > 0) {
             return PyLong_FromSsize_t(i);
-        else if (cmp < 0)
+        }
+        else if (cmp < 0) {
             return NULL;
+        }
     }
     PyErr_Format(PyExc_ValueError, "%R is not in list", value);
     return NULL;

--- a/Objects/listobject.c
+++ b/Objects/listobject.c
@@ -2689,7 +2689,7 @@ list_index_impl(PyListObject *self, PyObject *value, Py_ssize_t start,
         for (i = start; i < stop && i < Py_SIZE(self); i++) {
             PyObject *obj = self->ob_item[i];
             /* take reference to item, in case comparison methods modify list */
-            Py_INCREF(obj);  
+            Py_INCREF(obj);
             int cmp = PyObject_RichCompareBool(obj, value, Py_EQ);
             Py_DECREF(obj);
             if (cmp > 0)
@@ -2701,7 +2701,7 @@ list_index_impl(PyListObject *self, PyObject *value, Py_ssize_t start,
         for (i = start; i < stop && i < Py_SIZE(self); i++) {
             PyObject *item = self->ob_item[i];
             /* take reference to item, in case key modifies list */
-            Py_INCREF(item);  
+            Py_INCREF(item);
             PyObject *obj = PyObject_CallFunctionObjArgs(key, item, NULL);
             Py_DECREF(item);
             if (!obj)

--- a/Objects/listobject.c
+++ b/Objects/listobject.c
@@ -2689,13 +2689,15 @@ list_index_impl(PyListObject *self, PyObject *value, Py_ssize_t start,
         PyObject *obj, *item = self->ob_item[i];
         /* take reference to item, in case list modified by key or comparison */
         Py_INCREF(item);
-        if (!key) {
+        if (key == NULL) {
             obj = item;
-        } else {
+        }
+        else {
             obj = PyObject_CallFunctionObjArgs(key, item, NULL);
             Py_DECREF(item);
-            if (!obj)
+            if (obj == NULL) {
                 return NULL;
+            }
         }
         int cmp = PyObject_RichCompareBool(obj, value, Py_EQ);
         Py_DECREF(obj);


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

This PR adds a keyword-only `key` argument to `list.index()`.
When provided, each list item is transformed by the `key` callable before being compared to `value`, thus allowing
a functional-style search of an item in a list:

```python
data = [(i, chr(i)) for i in range(100)]
index_of_a  = data.index("a", key=lambda i: i[1])
```

This is based on an idea by @rhettinger from the discussion in PR #112498, where a case for finding an object in a list via
keyed lookup is made.  This PR applies that idea directly to the list object underlying the heap in question.

`list.index()` is not explicitly documented anywhere, so there is no doc update.

<!-- gh-issue-number: gh-113773 -->
* Issue: gh-113773
<!-- /gh-issue-number -->
