### PR TITLE
gh-103092: Port some `_ctypes` data types to heap types (alt)

### DIFF
--- a/Modules/_ctypes/callbacks.c
+++ b/Modules/_ctypes/callbacks.c
@@ -175,7 +175,8 @@ static void _CallPythonObject(void *mem,
                 PrintError("create argument %zd:\n", i);
                 goto Done;
             }
-            if (!CDataObject_Check(obj)) {
+            ctypes_state *st = GLOBAL_STATE();
+            if (!CDataObject_Check(st, obj)) {
                 Py_DECREF(obj);
                 PrintError("unexpected result of create argument %zd:\n", i);
                 goto Done;
@@ -344,13 +345,10 @@ CThunkObject *_ctypes_alloc_callback(PyObject *callable,
     assert(PyTuple_Check(converters));
     nargs = PyTuple_GET_SIZE(converters);
     p = CThunkObject_new(nargs);
-    if (p == NULL)
+    if (p == NULL) {
         return NULL;
-
-#ifdef Py_DEBUG
-    ctypes_state *st = GLOBAL_STATE();
-    assert(CThunk_CheckExact(st, (PyObject *)p));
-#endif
+    }
+    assert(CThunk_CheckExact(GLOBAL_STATE(), (PyObject *)p));
 
     p->pcl_write = Py_ffi_closure_alloc(sizeof(ffi_closure), &p->pcl_exec);
     if (p->pcl_write == NULL) {

--- a/Modules/_ctypes/cfield.c
+++ b/Modules/_ctypes/cfield.c
@@ -204,7 +204,8 @@ PyCField_set(CFieldObject *self, PyObject *inst, PyObject *value)
 {
     CDataObject *dst;
     char *ptr;
-    if (!CDataObject_Check(inst)) {
+    ctypes_state *st = GLOBAL_STATE();
+    if (!CDataObject_Check(st, inst)) {
         PyErr_SetString(PyExc_TypeError,
                         "not a ctype instance");
         return -1;
@@ -227,7 +228,8 @@ PyCField_get(CFieldObject *self, PyObject *inst, PyTypeObject *type)
     if (inst == NULL) {
         return Py_NewRef(self);
     }
-    if (!CDataObject_Check(inst)) {
+    ctypes_state *st = GLOBAL_STATE();
+    if (!CDataObject_Check(st, inst)) {
         PyErr_SetString(PyExc_TypeError,
                         "not a ctype instance");
         return NULL;

--- a/Modules/_ctypes/ctypes.h
+++ b/Modules/_ctypes/ctypes.h
@@ -41,6 +41,13 @@ typedef struct {
     PyTypeObject *PyComError_Type;
 #endif
     PyTypeObject *StructParam_Type;
+    PyTypeObject *PyCData_Type;
+    PyTypeObject *Struct_Type;
+    PyTypeObject *Union_Type;
+    PyTypeObject *PyCArray_Type;
+    PyTypeObject *Simple_Type;
+    PyTypeObject *PyCPointer_Type;
+    PyTypeObject *PyCFuncPtr_Type;
 } ctypes_state;
 
 extern ctypes_state global_state;
@@ -150,9 +157,8 @@ extern int PyObject_stginfo(PyObject *self, Py_ssize_t *psize, Py_ssize_t *palig
 
 
 
-extern PyTypeObject PyCData_Type;
-#define CDataObject_CheckExact(v)       Py_IS_TYPE(v, &PyCData_Type)
-#define CDataObject_Check(v)            PyObject_TypeCheck(v, &PyCData_Type)
+#define CDataObject_CheckExact(st, v)       Py_IS_TYPE((v), (st)->PyCData_Type)
+#define CDataObject_Check(st, v)            PyObject_TypeCheck((v), (st)->PyCData_Type)
 #define _CDataObject_HasExternalBuffer(v)  ((v)->b_ptr != (char *)&(v)->b_value)
 
 extern PyTypeObject PyCSimpleType_Type;
@@ -172,18 +178,15 @@ extern PyObject *PyCData_AtAddress(PyObject *type, void *buf);
 extern PyObject *PyCData_FromBytes(PyObject *type, char *data, Py_ssize_t length);
 
 extern PyTypeObject PyCArrayType_Type;
-extern PyTypeObject PyCArray_Type;
 extern PyTypeObject PyCPointerType_Type;
-extern PyTypeObject PyCPointer_Type;
-extern PyTypeObject PyCFuncPtr_Type;
 extern PyTypeObject PyCFuncPtrType_Type;
 extern PyTypeObject PyCStructType_Type;
 
 #define PyCArrayTypeObject_Check(v)     PyObject_TypeCheck(v, &PyCArrayType_Type)
-#define ArrayObject_Check(v)            PyObject_TypeCheck(v, &PyCArray_Type)
-#define PointerObject_Check(v)          PyObject_TypeCheck(v, &PyCPointer_Type)
+#define ArrayObject_Check(st, v)        PyObject_TypeCheck((v), (st)->PyCArray_Type)
+#define PointerObject_Check(st, v)      PyObject_TypeCheck((v), (st)->PyCPointer_Type)
 #define PyCPointerTypeObject_Check(v)   PyObject_TypeCheck(v, &PyCPointerType_Type)
-#define PyCFuncPtrObject_Check(v)               PyObject_TypeCheck(v, &PyCFuncPtr_Type)
+#define PyCFuncPtrObject_Check(st, v)   PyObject_TypeCheck((v), (st)->PyCFuncPtr_Type)
 #define PyCFuncPtrTypeObject_Check(v)   PyObject_TypeCheck(v, &PyCFuncPtrType_Type)
 #define PyCStructTypeObject_Check(v)    PyObject_TypeCheck(v, &PyCStructType_Type)
 

--- a/Tools/c-analyzer/cpython/globals-to-fix.tsv
+++ b/Tools/c-analyzer/cpython/globals-to-fix.tsv
@@ -347,27 +347,16 @@ Modules/_testclinic.c	-	DeprKwdNew	-
 ## static types
 
 Modules/_ctypes/_ctypes.c	-	PyCArrayType_Type	-
-Modules/_ctypes/_ctypes.c	-	PyCArray_Type	-
-Modules/_ctypes/_ctypes.c	-	PyCData_Type	-
 Modules/_ctypes/_ctypes.c	-	PyCFuncPtrType_Type	-
-Modules/_ctypes/_ctypes.c	-	PyCFuncPtr_Type	-
 Modules/_ctypes/_ctypes.c	-	PyCPointerType_Type	-
-Modules/_ctypes/_ctypes.c	-	PyCPointer_Type	-
 Modules/_ctypes/_ctypes.c	-	PyCSimpleType_Type	-
 Modules/_ctypes/_ctypes.c	-	PyCStructType_Type	-
-Modules/_ctypes/_ctypes.c	-	Simple_Type	-
-Modules/_ctypes/_ctypes.c	-	Struct_Type	-
 Modules/_ctypes/_ctypes.c	-	UnionType_Type	-
-Modules/_ctypes/_ctypes.c	-	Union_Type	-
 Modules/_ctypes/callproc.c	-	PyCArg_Type	-
 Modules/_ctypes/ctypes.h	-	PyCArg_Type	-
 Modules/_ctypes/ctypes.h	-	PyCArrayType_Type	-
-Modules/_ctypes/ctypes.h	-	PyCArray_Type	-
-Modules/_ctypes/ctypes.h	-	PyCData_Type	-
 Modules/_ctypes/ctypes.h	-	PyCFuncPtrType_Type	-
-Modules/_ctypes/ctypes.h	-	PyCFuncPtr_Type	-
 Modules/_ctypes/ctypes.h	-	PyCPointerType_Type	-
-Modules/_ctypes/ctypes.h	-	PyCPointer_Type	-
 Modules/_ctypes/ctypes.h	-	PyCSimpleType_Type	-
 Modules/_ctypes/ctypes.h	-	PyCStgDict_Type	-
 Modules/_ctypes/ctypes.h	-	PyCStructType_Type	-


### PR DESCRIPTION
An alternative PR to #113630. This version will keep the behavior unchanged by making the `MOD_ADD_TYPE()` macro hack the  metatype's `tp_new` slot.

<!-- gh-issue-number: gh-103092 -->
* Issue: gh-103092
<!-- /gh-issue-number -->
