### PR TITLE
gh-113791: Expose CLOCK_MONOTONIC_RAW_APPROX and CLOCK_UPTIME_RAW_APROX on macOS in the time module

### DIFF
--- a/Doc/library/time.rst
+++ b/Doc/library/time.rst
@@ -840,6 +840,15 @@ These constants are used as parameters for :func:`clock_getres` and
 
    .. versionadded:: 3.3
 
+.. data:: CLOCK_MONOTONIC_RAW_APPROX
+
+   Similar to :data:`CLOCK_MONOTONIC_RAW`, but reads a value cached by
+   the system at context switch and hence has less accuracy.
+
+   .. availability:: macOS >= 10.12.
+
+   .. versionadded:: 3.13
+
 
 .. data:: CLOCK_PROCESS_CPUTIME_ID
 
@@ -898,6 +907,15 @@ These constants are used as parameters for :func:`clock_getres` and
    .. availability:: macOS >= 10.12.
 
    .. versionadded:: 3.8
+
+.. data:: CLOCK_UPTIME_RAW_APPROX
+
+   Like :data:`CLOCK_UPTIME_RAW`, but the value is cached by the system
+   at context switches and therefore has less accuracy.
+
+   .. availability:: macOS >= 10.12.
+
+   .. versionadded:: 3.13
 
 The following constant is the only parameter that can be sent to
 :func:`clock_settime`.

--- a/Misc/NEWS.d/next/Library/2024-01-07-11-45-56.gh-issue-113791.XF5xSW.rst
+++ b/Misc/NEWS.d/next/Library/2024-01-07-11-45-56.gh-issue-113791.XF5xSW.rst
@@ -1,0 +1,2 @@
+Add ``CLOCK_MONOTONIC_RAW_APPROX`` and ``CLOCK_UPTIME_RAW_APPROX`` to
+:mod:`time` on macOS. These are clocks available on macOS 10.12 or later.

--- a/Modules/timemodule.c
+++ b/Modules/timemodule.c
@@ -2049,6 +2049,18 @@ time_exec(PyObject *module)
             return -1;
         }
 #endif
+#ifdef CLOCK_MONOTONIC_RAW_APPROX
+
+        if (PyModule_AddIntMacro(module, CLOCK_MONOTONIC_RAW_APPROX) < 0) {
+            return -1;
+        }
+#endif
+#ifdef CLOCK_UPTIME_RAW_APPROX
+
+        if (PyModule_AddIntMacro(module, CLOCK_UPTIME_RAW_APPROX) < 0) {
+            return -1;
+        }
+#endif
     }
 
 #endif  /* defined(HAVE_CLOCK_GETTIME) || defined(HAVE_CLOCK_SETTIME) || defined(HAVE_CLOCK_GETRES) */

--- a/Modules/timemodule.c
+++ b/Modules/timemodule.c
@@ -1993,20 +1993,16 @@ time_exec(PyObject *module)
             return -1;
         }
 #endif
-
 #ifdef CLOCK_MONOTONIC
-
         if (PyModule_AddIntMacro(module, CLOCK_MONOTONIC) < 0) {
             return -1;
         }
-
 #endif
 #ifdef CLOCK_MONOTONIC_RAW
         if (PyModule_AddIntMacro(module, CLOCK_MONOTONIC_RAW) < 0) {
             return -1;
         }
 #endif
-
 #ifdef CLOCK_HIGHRES
         if (PyModule_AddIntMacro(module, CLOCK_HIGHRES) < 0) {
             return -1;
@@ -2017,7 +2013,6 @@ time_exec(PyObject *module)
             return -1;
         }
 #endif
-
 #ifdef CLOCK_THREAD_CPUTIME_ID
         if (PyModule_AddIntMacro(module, CLOCK_THREAD_CPUTIME_ID) < 0) {
             return -1;
@@ -2044,19 +2039,16 @@ time_exec(PyObject *module)
         }
 #endif
 #ifdef CLOCK_UPTIME_RAW
-
         if (PyModule_AddIntMacro(module, CLOCK_UPTIME_RAW) < 0) {
             return -1;
         }
 #endif
 #ifdef CLOCK_MONOTONIC_RAW_APPROX
-
         if (PyModule_AddIntMacro(module, CLOCK_MONOTONIC_RAW_APPROX) < 0) {
             return -1;
         }
 #endif
 #ifdef CLOCK_UPTIME_RAW_APPROX
-
         if (PyModule_AddIntMacro(module, CLOCK_UPTIME_RAW_APPROX) < 0) {
             return -1;
         }


### PR DESCRIPTION


<!-- gh-issue-number: gh-113791 -->
* Issue: gh-113791
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--113792.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->