### PR TITLE
gh-113775: Fix HttpOnly Prefix Issue in MozillaCookieJar.save method

### DIFF
--- a/Doc/library/http.cookiejar.rst
+++ b/Doc/library/http.cookiejar.rst
@@ -716,9 +716,10 @@ Cookies may have additional non-standard cookie-attributes.  These may be
 accessed using the following methods:
 
 
-.. method:: Cookie.has_nonstandard_attr(name)
+.. method:: Cookie.has_nonstandard_attr(name, case_insensitive=False)
 
-   Return ``True`` if cookie has the named cookie-attribute.
+   Return ``True`` if cookie has the named cookie-attribute. If *case_insensitive*
+   is true, the name is compared without regard to case.
 
 
 .. method:: Cookie.get_nonstandard_attr(name, default=None)

--- a/Lib/http/cookiejar.py
+++ b/Lib/http/cookiejar.py
@@ -800,7 +800,10 @@ class Cookie:
 
         self._rest = copy.copy(rest)
 
-    def has_nonstandard_attr(self, name):
+    def has_nonstandard_attr(self, name, case_insensitive=False):
+        if case_insensitive:
+            name = name.lower()
+            return any(k.lower() == name for k in self._rest)
         return name in self._rest
     def get_nonstandard_attr(self, name, default=None):
         return self._rest.get(name, default)

--- a/Lib/http/cookiejar.py
+++ b/Lib/http/cookiejar.py
@@ -2116,7 +2116,7 @@ class MozillaCookieJar(FileCookieJar):
                 else:
                     name = cookie.name
                     value = cookie.value
-                if cookie.has_nonstandard_attr(HTTPONLY_ATTR):
+                if cookie.has_nonstandard_attr(HTTPONLY_ATTR, case_insensitive=True):
                     domain = HTTPONLY_PREFIX + domain
                 f.write(
                     "\t".join([domain, initial_dot, cookie.path,

--- a/Lib/http/cookiejar.py
+++ b/Lib/http/cookiejar.py
@@ -50,7 +50,7 @@ def _debug(*args):
         logger = logging.getLogger("http.cookiejar")
     return logger.debug(*args)
 
-HTTPONLY_ATTR = "HTTPOnly"
+HTTPONLY_ATTR = "HttpOnly"
 HTTPONLY_PREFIX = "#HttpOnly_"
 DEFAULT_HTTP_PORT = str(http.client.HTTP_PORT)
 NETSCAPE_MAGIC_RGX = re.compile("#( Netscape)? HTTP Cookie File")

--- a/Lib/test/test_http_cookiejar.py
+++ b/Lib/test/test_http_cookiejar.py
@@ -1958,19 +1958,17 @@ class LWPCookieTests(unittest.TestCase):
 
         # Check that the HttpOnly prefix is added to the correct cookies
         for key in ["foo1", "foo2", "foo3"]:
-            matches = [x for x in lines if key in x]
-            self.assertEqual(len(matches), 1,
-                             "Incorrect number of matches for cookie with value %r" % key)
-            self.assertTrue(matches[0].startswith("#HttpOnly_"),
-                            "Cookie with value %r is missing the HttpOnly prefix" % key)
+            with self.subTest(key=key):
+                matches = [x for x in lines if key in x]
+                self.assertEqual(len(matches), 1)
+                self.assertTrue(matches[0].startswith("#HttpOnly_"))
 
         # Check that the HttpOnly prefix is not added to the correct cookies
         for key in ["foo4"]:
-            matches = [x for x in lines if key in x]
-            self.assertEqual(len(matches), 1,
-                             "Incorrect number of matches for cookie with value %r" % key)
-            self.assertFalse(matches[0].startswith("#HttpOnly_"),
-                             "Cookie with value %r has the HttpOnly prefix" % key)
+            with self.subTest(key=key):
+                matches = [x for x in lines if key in x]
+                self.assertEqual(len(matches), 1)
+                self.assertFalse(matches[0].startswith("#HttpOnly_"))
 
     def test_netscape_misc(self):
         # Some additional Netscape cookies tests.

--- a/Lib/test/test_http_cookiejar.py
+++ b/Lib/test/test_http_cookiejar.py
@@ -1882,7 +1882,7 @@ class LWPCookieTests(unittest.TestCase):
 
         for cookie in c:
             if cookie.name == "foo1":
-                cookie.set_nonstandard_attr("HTTPOnly", "")
+                cookie.set_nonstandard_attr("HttpOnly", "")
 
         def save_and_restore(cj, ignore_discard):
             try:
@@ -1897,7 +1897,7 @@ class LWPCookieTests(unittest.TestCase):
         new_c = save_and_restore(c, True)
         self.assertEqual(len(new_c), 6)  # none discarded
         self.assertIn("name='foo1', value='bar'", repr(new_c))
-        self.assertIn("rest={'HTTPOnly': ''}", repr(new_c))
+        self.assertIn("rest={'HttpOnly': ''}", repr(new_c))
 
         new_c = save_and_restore(c, False)
         self.assertEqual(len(new_c), 4)  # 2 of them discarded on save

--- a/Lib/test/test_http_cookiejar.py
+++ b/Lib/test/test_http_cookiejar.py
@@ -623,6 +623,7 @@ class CookieTests(unittest.TestCase):
         # case is preserved
         self.assertTrue(cookie.has_nonstandard_attr("blArgh"))
         self.assertFalse(cookie.has_nonstandard_attr("blargh"))
+        self.assertTrue(cookie.has_nonstandard_attr("blargh", case_insensitive=True))
 
         cookie = c._cookies["www.acme.com"]["/"]["ni"]
         self.assertEqual(cookie.domain, "www.acme.com")

--- a/Lib/test/test_http_cookiejar.py
+++ b/Lib/test/test_http_cookiejar.py
@@ -1957,20 +1957,20 @@ class LWPCookieTests(unittest.TestCase):
             os_helper.unlink(filename)
 
         # Check that the HttpOnly prefix is added to the correct cookies
-        for value in ["foo1", "foo2", "foo3"]:
-            matches = [x for x in lines if value in x]
+        for key in ["foo1", "foo2", "foo3"]:
+            matches = [x for x in lines if key in x]
             self.assertEqual(len(matches), 1,
-                             "Incorrect number of matches for cookie with value %r" % value)
+                             "Incorrect number of matches for cookie with value %r" % key)
             self.assertTrue(matches[0].startswith("#HttpOnly_"),
-                            "Cookie with value %r is missing the HttpOnly prefix" % value)
+                            "Cookie with value %r is missing the HttpOnly prefix" % key)
 
         # Check that the HttpOnly prefix is not added to the correct cookies
-        for value in ["foo4"]:
-            matches = [x for x in lines if value in x]
+        for key in ["foo4"]:
+            matches = [x for x in lines if key in x]
             self.assertEqual(len(matches), 1,
-                             "Incorrect number of matches for cookie with value %r" % value)
+                             "Incorrect number of matches for cookie with value %r" % key)
             self.assertFalse(matches[0].startswith("#HttpOnly_"),
-                             "Cookie with value %r has the HttpOnly prefix" % value)
+                             "Cookie with value %r has the HttpOnly prefix" % key)
 
     def test_netscape_misc(self):
         # Some additional Netscape cookies tests.

--- a/Misc/NEWS.d/next/Library/2025-03-23-08-26-53.gh-issue-113775.7-2Dqp.rst
+++ b/Misc/NEWS.d/next/Library/2025-03-23-08-26-53.gh-issue-113775.7-2Dqp.rst
@@ -1,0 +1,1 @@
+Fix handling of the ``#HttpOnly_`` prefix in :class:`http.cookiejar.MozillaCookieJar`.


### PR DESCRIPTION
MozillaCookieJar recognizes and writes the `#HttpOnly_` prefix, based on curl's specifications. However, it is uncommon for cookies obtained via HTTP to be written with the HttpOnly prefix.

This issue stems from the case-sensitive nature of the HttpOnly attribute check and the fact that the value of the constant `HTTPONLY_ATTR` is `"HTTPOnly"` instead of the more commonly used `"HttpOnly"`.

In accordance with [RFC6265](https://datatracker.ietf.org/doc/html/rfc6265), this PR proposes the addition of a `case_insensitive` option to `Cookie.has_nonstandard_attr`. Additionally, it modifies the value of `HTTPONLY_ATTR` to the more widely recognized `"HttpOnly"`.

This PR includes code changes, docs fixes, and additional tests.

<!-- gh-issue-number: gh-113775 -->
* Issue: gh-113775
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--113795.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->