### PR TITLE
gh-113781: Silence AttributeError in warning module during Python finalization

### DIFF
--- a/Lib/warnings.py
+++ b/Lib/warnings.py
@@ -67,7 +67,7 @@ def _formatwarnmsg_impl(msg):
             except Exception:
                 # When a warning is logged during Python shutdown, tracemalloc
                 # and the import machinery don't work anymore
-                tracing = False
+                tracing = True
                 tb = None
 
         if tb is not None:

--- a/Lib/warnings.py
+++ b/Lib/warnings.py
@@ -61,12 +61,13 @@ def _formatwarnmsg_impl(msg):
             tracing = True
             tb = None
         else:
-            tracing = tracemalloc.is_tracing()
             try:
+                tracing = tracemalloc.is_tracing()
                 tb = tracemalloc.get_object_traceback(msg.source)
             except Exception:
                 # When a warning is logged during Python shutdown, tracemalloc
                 # and the import machinery don't work anymore
+                tracing = False
                 tb = None
 
         if tb is not None:

--- a/Lib/warnings.py
+++ b/Lib/warnings.py
@@ -58,16 +58,16 @@ def _formatwarnmsg_impl(msg):
         # catch Exception, not only ImportError and RecursionError.
         except Exception:
             # don't suggest to enable tracemalloc if it's not available
-            tracing = True
+            suggest_tracemalloc = False
             tb = None
         else:
             try:
-                tracing = tracemalloc.is_tracing()
+                suggest_tracemalloc = not tracemalloc.is_tracing()
                 tb = tracemalloc.get_object_traceback(msg.source)
             except Exception:
                 # When a warning is logged during Python shutdown, tracemalloc
                 # and the import machinery don't work anymore
-                tracing = True
+                suggest_tracemalloc = False
                 tb = None
 
         if tb is not None:
@@ -86,7 +86,7 @@ def _formatwarnmsg_impl(msg):
                 if line:
                     line = line.strip()
                     s += '    %s\n' % line
-        elif not tracing:
+        elif suggest_tracemalloc:
             s += (f'{category}: Enable tracemalloc to get the object '
                   f'allocation traceback\n')
     return s

--- a/Misc/NEWS.d/next/Library/2024-01-08-14-57-09.gh-issue-113781.IoTnwi.rst
+++ b/Misc/NEWS.d/next/Library/2024-01-08-14-57-09.gh-issue-113781.IoTnwi.rst
@@ -1,0 +1,2 @@
+Silence unraisable AttributeError when warnings are emitted during Python
+finalization.


### PR DESCRIPTION
The tracemalloc module can already be cleared.



<!-- gh-issue-number: gh-113781 -->
* Issue: gh-113781
<!-- /gh-issue-number -->
