### PR TITLE
gh-113688: fix dtrace build on Solaris

### DIFF
--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -547,7 +547,7 @@ LINK_PYTHON_OBJS=@LINK_PYTHON_OBJS@
 # On some systems, object files that reference DTrace probes need to be modified
 # in-place by dtrace(1).
 DTRACE_DEPS = \
-	Python/ceval.o Python/import.o Python/sysmodule.o Modules/gcmodule.o
+	Python/ceval.o Python/gc.o Python/import.o Python/sysmodule.o
 
 ##########################################################################
 # decimal's libmpdec
@@ -1648,8 +1648,8 @@ Include/pydtrace_probes.h: $(srcdir)/Include/pydtrace.d
 	mv $@.tmp $@
 
 Python/ceval.o: $(srcdir)/Include/pydtrace.h
+Python/gc.o: $(srcdir)/Include/pydtrace.h
 Python/import.o: $(srcdir)/Include/pydtrace.h
-Modules/gcmodule.o: $(srcdir)/Include/pydtrace.h
 
 Python/pydtrace.o: $(srcdir)/Include/pydtrace.d $(DTRACE_DEPS)
 	$(DTRACE) $(DFLAGS) -o $@ -G -s $< $(DTRACE_DEPS)


### PR DESCRIPTION
On systems where object files with DTrace probes need to be modified in-place by dtrace (e.g. Solaris), the build currently fails because new `gc.c` is not included.


<!-- gh-issue-number: gh-113688 -->
* Issue: gh-113688
<!-- /gh-issue-number -->
