### PR TITLE
[3.9] Fix documentation build by pinning Alabaster version to 0.7.13

### DIFF
--- a/Doc/requirements.txt
+++ b/Doc/requirements.txt
@@ -10,6 +10,8 @@ sphinx==2.4.4
 docutils==0.17.1
 # Jinja version is pinned to a version compatible with Sphinx version 2.4.4.
 jinja2==3.0.3
+# Alabaster version is pinned to a version compatible with Sphinx version 2.4.4.
+alabaster==0.7.13
 
 blurb
 


### PR DESCRIPTION
Alabaster is Sphinx's dependency. Alabaster 0.7.14 released on 2024-01-08 dropped support for Sphinx 3.3 and earlier.

https://alabaster.readthedocs.io/en/latest/changelog.html#id2 (anchor to the section works correctly as of 2024-01-08)

* Last successful build (Alabaster 0.7.13): https://github.com/python/python-docs-pl/actions/runs/7442401328/job/20245885176
* Example failing build (Alabaster 0.7.14): https://github.com/python/python-docs-pl/actions/runs/7442543845/job/20246206969
Error message:
```
% make … latex # [or html]
…
Sphinx version error:
The alabaster extension used by this project needs at least Sphinx v3.4; it therefore cannot be built with this version.
make: *** [Makefile:51: build] Error 2
Error: Process completed with exit code 2.
```

The same affects also 3.8 branch. Would it be possible for someone with the permissions to mark it for a backport?

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
