### PR TITLE
gh-113787: Fix refleaks in test_capi

### DIFF
--- a/Modules/_testcapi/vectorcall_limited.c
+++ b/Modules/_testcapi/vectorcall_limited.c
@@ -195,6 +195,6 @@ _PyTestCapi_Init_VectorcallLimited(PyObject *m) {
     if (PyModule_AddType(m, (PyTypeObject *)LimitedVectorCallClass) < 0) {
         return -1;
     }
-
+    Py_DECREF(LimitedVectorCallClass);
     return 0;
 }

--- a/Modules/_testcapimodule.c
+++ b/Modules/_testcapimodule.c
@@ -49,7 +49,7 @@ get_testcapi_state(PyObject *module)
 
 static PyObject *
 get_testerror(PyObject *self) {
-    testcapistate_t *state = get_testcapi_state((PyObject *)Py_TYPE(self));
+    testcapistate_t *state = get_testcapi_state(self);
     return state->error;
 }
 
@@ -3947,7 +3947,6 @@ PyInit__testcapi(void)
 
     testcapistate_t *state = get_testcapi_state(m);
     state->error = PyErr_NewException("_testcapi.error", NULL, NULL);
-    Py_INCREF(state->error);
     PyModule_AddObject(m, "error", state->error);
 
     if (PyType_Ready(&ContainerNoGC_type) < 0) {


### PR DESCRIPTION
Since b2566d89ce50e9924bb2fccb87dcfa3ceb6cc0d6, the `_testcapi`  module has specified a non-negative value to `PyModuleDef.m_size`, which seems to require a bit different refcount management. Every (sub-) interpreter now calls the single phase `PyInit__testcapi()` with each module state. Previously, the call was only once when running [the subinterpreter test case](https://github.com/python/cpython/blob/802d4954f12541ba28dd7f18bf4a65054941a80d/Lib/test/test_capi/test_misc.py#L1963-L1969), and repeating `Py_INCREF(TestError)` n-times in `PyInit__testcapi` did not affect passing the refleak test for me.

The patch for `vectorcall_limited.c` follows the way in [`structmember.c`](https://github.com/python/cpython/blob/802d4954f12541ba28dd7f18bf4a65054941a80d/Modules/_testcapi/structmember.c#L204-L210)

cc @nascheme @ericsnowcurrently @Eclips4

<!-- gh-issue-number: gh-113787 -->
* Issue: gh-113787
<!-- /gh-issue-number -->
