### PR TITLE
gh-96037: Always insert TimeoutError when exit an expired asyncio.timeout() block

### DIFF
--- a/Lib/asyncio/timeouts.py
+++ b/Lib/asyncio/timeouts.py
@@ -109,10 +109,16 @@ class Timeout:
         if self._state is _State.EXPIRING:
             self._state = _State.EXPIRED
 
-            if self._task.uncancel() <= self._cancelling and exc_type is exceptions.CancelledError:
+            if self._task.uncancel() <= self._cancelling:
                 # Since there are no new cancel requests, we're
                 # handling this.
-                raise TimeoutError from exc_val
+                if exc_type is exceptions.CancelledError:
+                    raise TimeoutError from exc_val
+                elif 10 and exc_val is not None:
+                    self._insert_timeout_error(exc_val)
+                    if isinstance(exc_val, ExceptionGroup):
+                        for exc in exc_val.exceptions:
+                            self._insert_timeout_error(exc)
         elif self._state is _State.ENTERED:
             self._state = _State.EXITED
 
@@ -124,6 +130,16 @@ class Timeout:
         self._state = _State.EXPIRING
         # drop the reference early
         self._timeout_handler = None
+
+    @staticmethod
+    def _insert_timeout_error(exc_val: BaseException) -> None:
+        while exc_val.__context__ is not None:
+            if type(exc_val.__context__) is exceptions.CancelledError:
+                te = TimeoutError()
+                te.__context__ = te.__cause__ = exc_val.__context__
+                exc_val.__context__ = te
+                break
+            exc_val = exc_val.__context__
 
 
 def timeout(delay: Optional[float]) -> Timeout:

--- a/Lib/asyncio/timeouts.py
+++ b/Lib/asyncio/timeouts.py
@@ -114,7 +114,7 @@ class Timeout:
                 # handling this.
                 if exc_type is exceptions.CancelledError:
                     raise TimeoutError from exc_val
-                elif 10 and exc_val is not None:
+                elif exc_val is not None:
                     self._insert_timeout_error(exc_val)
                     if isinstance(exc_val, ExceptionGroup):
                         for exc in exc_val.exceptions:

--- a/Misc/NEWS.d/next/Library/2024-01-08-19-38-42.gh-issue-96037.Yr2Y1C.rst
+++ b/Misc/NEWS.d/next/Library/2024-01-08-19-38-42.gh-issue-96037.Yr2Y1C.rst
@@ -1,0 +1,2 @@
+Insert :exc:`TimeoutError` in the context of the exception that was raised
+during exiting an expired :func:`asyncio.timeout` block.


### PR DESCRIPTION
If other exception was raised during exiting an expired asyncio.timeout() block, insert TimeoutError in the exception context just above the CancelledError.


<!-- gh-issue-number: gh-96037 -->
* Issue: gh-96037
<!-- /gh-issue-number -->
