### PR TITLE
gh-113658 : Fixed the issue of 'SMTP.send_message() fails to extract 'RCPT TO' if Cc + Bcc are set'

### DIFF
--- a/Lib/email/utils.py
+++ b/Lib/email/utils.py
@@ -146,7 +146,15 @@ def _strip_quoted_realnames(addr):
 
 supports_strict_parsing = True
 
-def getaddresses(fieldvalues, *, strict=False):
+def filter_empty_fieldvalues(fieldvalues):
+    filteredfieldvalues = []
+    for fieldvalue in fieldvalues:
+        if fieldvalue != '':
+            filteredfieldvalues.append(fieldvalue)
+    return filteredfieldvalues
+
+
+def getaddresses(fieldvalues, *, strict=True):
     """Return a list of (REALNAME, EMAIL) or ('','') for each fieldvalue.
 
     When parsing fails for a fieldvalue, a 2-tuple of ('', '') is returned in
@@ -163,6 +171,9 @@ def getaddresses(fieldvalues, *, strict=False):
     # Malformed input: getaddresses(['alice@example.com <bob@example.com>'])
     # Invalid output: [('', 'alice@example.com'), ('', 'bob@example.com')]
     # Safe output: [('', '')]
+
+    #Filter field values to remove empty addresses (for eg, when bcc and cc are empty)
+    fieldvalues = filter_empty_fieldvalues(fieldvalues)
 
     if not strict:
         all = COMMASPACE.join(str(v) for v in fieldvalues)

--- a/Lib/email/utils.py
+++ b/Lib/email/utils.py
@@ -146,7 +146,7 @@ def _strip_quoted_realnames(addr):
 
 supports_strict_parsing = True
 
-def getaddresses(fieldvalues, *, strict=True):
+def getaddresses(fieldvalues, *, strict=False):
     """Return a list of (REALNAME, EMAIL) or ('','') for each fieldvalue.
 
     When parsing fails for a fieldvalue, a 2-tuple of ('', '') is returned in


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

# Fixed Issue #113658

```
gh-113658: Fixed the issue of 'SMTP.send_message() fails to extract 'RCPT TO' if Cc + Bcc are set'. This was caused due to "strict" evaluation of email.utils.getaddresses which returns list containing a single empty 2-tuple [('', '')] when the resulting list of parsed addresses is greater than the number of fieldvalues in the input list. This event occurs when bcc and cc are empty values (as given in the Issue input to reproduce the issue).

Hence, implemented a fix to check and remove if the fieldvalues have empty values. This fixed the issue #113658.


```


