### PR TITLE
gh-113827: Move Windows frozen modules directory to allow PGO builds

### DIFF
--- a/PCbuild/pyproject.props
+++ b/PCbuild/pyproject.props
@@ -12,7 +12,7 @@
     <IntDir>$(IntDir.Replace(`\\`, `\`))</IntDir>
     <!-- pyconfig.h is updated by pythoncore.vcxproj, so it's always in pythoncore's IntDir -->
     <GeneratedPyConfigDir>$(Py_IntDir)\$(MajorVersionNumber)$(MinorVersionNumber)$(ArchName)_$(Configuration)\pythoncore\</GeneratedPyConfigDir>
-    <GeneratedFrozenModulesDir>$(Py_IntDir)\$(MajorVersionNumber)$(MinorVersionNumber)_frozen_$(Configuration)\</GeneratedFrozenModulesDir>
+    <GeneratedFrozenModulesDir>$(Py_IntDir)\$(MajorVersionNumber)$(MinorVersionNumber)_frozen\</GeneratedFrozenModulesDir>
     <TargetName Condition="'$(TargetName)' == ''">$(ProjectName)</TargetName>
     <TargetName>$(TargetName)$(PyDebugExt)</TargetName>
     <GenerateManifest>false</GenerateManifest>


### PR DESCRIPTION


<!-- gh-issue-number: gh-113827 -->
* Issue: gh-113827
<!-- /gh-issue-number -->
