### PR TITLE
gh-113650: Add workaround option for MSVC ARM64 bug affecting string encoding

### DIFF
--- a/PCbuild/pyproject.props
+++ b/PCbuild/pyproject.props
@@ -29,6 +29,7 @@
 
     <!-- See https://developercommunity.visualstudio.com/t/Regression-in-MSVC-1433-1434-ARM64-co/10224361 -->
     <MSVCHasBrokenARM64Clamping Condition="$(_VCToolsVersion) == '14.34' or $(_VCToolsVersion) == '14.35'">true</MSVCHasBrokenARM64Clamping>
+    <MSVCHasBrokenARM64SignExtension Condition="$(_VCToolsVersion) == '14.37'">true</MSVCHasBrokenARM64SignExtension>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -62,6 +63,7 @@
       <AdditionalOptions Condition="$(PlatformToolset) == 'ClangCL'">-Wno-deprecated-non-prototype -Wno-unused-label -Wno-pointer-sign -Wno-incompatible-pointer-types-discards-qualifiers -Wno-unused-function %(AdditionalOptions)</AdditionalOptions>
       <AdditionalOptions Condition="$(Configuration) != 'Debug' and $(PlatformToolset) == 'ClangCL'">-flto %(AdditionalOptions)</AdditionalOptions>
       <AdditionalOptions Condition="$(MSVCHasBrokenARM64Clamping) == 'true' and $(Platform) == 'ARM64'">-d2pattern-opt-disable:-932189325 %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions Condition="$(MSVCHasBrokenARM64SignExtension) == 'true' and $(Platform) == 'ARM64'">-d2ssa-patterns-all- %(AdditionalOptions)</AdditionalOptions>
       <AdditionalOptions Condition="$(GenerateSourceDependencies) == 'true'">/sourceDependencies "$(IntDir.Trim(`\`))" %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <ClCompile Condition="$(Configuration) == 'Debug'">


### PR DESCRIPTION
This will hurt performance, but only for ARM64 binaries built with the affected compiler version.
The alternative is that string encoding fails, which makes the whole interpreter useless. Slow is preferable.
We won't do a non-experimental release until we can be sure we have a good compiler.

<!-- gh-issue-number: gh-113650 -->
* Issue: gh-113650
<!-- /gh-issue-number -->
