### PR TITLE
[3.11] gh-101100: Fix Sphinx warnings for 2.6 port-specific deprecations (GH-113752)

### DIFF
--- a/Doc/whatsnew/2.0.rst
+++ b/Doc/whatsnew/2.0.rst
@@ -130,7 +130,7 @@ Guidelines":
 Read the rest of :pep:`1` for the details of the PEP editorial process, style, and
 format.  PEPs are kept in the Python CVS tree on SourceForge, though they're not
 part of the Python 2.0 distribution, and are also available in HTML form from
-https://peps.python.org/.  As of September 2000, there are 25 PEPS, ranging
+https://peps.python.org/.  As of September 2000, there are 25 PEPs, ranging
 from :pep:`201`, "Lockstep Iteration", to PEP 225, "Elementwise/Objectwise
 Operators".
 

--- a/Doc/whatsnew/2.6.rst
+++ b/Doc/whatsnew/2.6.rst
@@ -4,8 +4,6 @@
   What's New in Python 2.6
 ****************************
 
-.. XXX add trademark info for Apple, Microsoft, SourceForge.
-
 :Author: A.M. Kuchling (amk at amk.ca)
 
 .. $Id$
@@ -128,7 +126,7 @@ and to C extension code as :c:data:`Py_Py3kWarningFlag`.
    The 3\ *xxx* series of PEPs, which contains proposals for Python 3.0.
    :pep:`3000` describes the development process for Python 3.0.
    Start with :pep:`3100` that describes the general goals for Python
-   3.0, and then explore the higher-numbered PEPS that propose
+   3.0, and then explore the higher-numbered PEPs that propose
    specific features.
 
 
@@ -1051,8 +1049,6 @@ the :mod:`io` module:
   sockets, but Python 2.6 hasn't restructured its file and socket objects
   in this way.
 
-  .. XXX should 2.6 register them in io.py?
-
 * :class:`BufferedIOBase` is an abstract base class that
   buffers data in memory to reduce the number of
   system calls used, making I/O processing more efficient.
@@ -1132,8 +1128,6 @@ can use this operation to lock memory in place
 while an external caller could be modifying the contents,
 so there's a corresponding ``PyBuffer_Release(Py_buffer *view)`` to
 indicate that the external caller is done.
-
-.. XXX PyObject_GetBuffer not documented in c-api
 
 The *flags* argument to :c:func:`PyObject_GetBuffer` specifies
 constraints upon the memory returned.  Some examples are:
@@ -3110,8 +3104,8 @@ Port-Specific Changes: Windows
 
 * The :mod:`msvcrt` module now supports
   both the normal and wide char variants of the console I/O
-  API.  The :func:`getwch` function reads a keypress and returns a Unicode
-  value, as does the :func:`getwche` function.  The :func:`putwch` function
+  API.  The :func:`~msvcrt.getwch` function reads a keypress and returns a Unicode
+  value, as does the :func:`~msvcrt.getwche` function.  The :func:`~msvcrt.putwch` function
   takes a Unicode character and writes it to the console.
   (Contributed by Christian Heimes.)
 
@@ -3120,24 +3114,24 @@ Port-Specific Changes: Windows
   directory path.  (Contributed by Josiah Carlson; :issue:`957650`.)
 
 * The :mod:`socket` module's socket objects now have an
-  :meth:`ioctl` method that provides a limited interface to the
+  :meth:`~socket.socket.ioctl` method that provides a limited interface to the
   :c:func:`WSAIoctl` system interface.
 
-* The :mod:`_winreg` module now has a function,
-  :func:`ExpandEnvironmentStrings`,
+* The :mod:`_winreg <winreg>` module now has a function,
+  :func:`~winreg.ExpandEnvironmentStrings`,
   that expands environment variable references such as ``%NAME%``
   in an input string.  The handle objects provided by this
   module now support the context protocol, so they can be used
   in :keyword:`with` statements. (Contributed by Christian Heimes.)
 
-  :mod:`_winreg` also has better support for x64 systems,
-  exposing the :func:`DisableReflectionKey`, :func:`EnableReflectionKey`,
-  and :func:`QueryReflectionKey` functions, which enable and disable
+  :mod:`_winreg <winreg>` also has better support for x64 systems,
+  exposing the :func:`~winreg.DisableReflectionKey`, :func:`~winreg.EnableReflectionKey`,
+  and :func:`~winreg.QueryReflectionKey` functions, which enable and disable
   registry reflection for 32-bit processes running on 64-bit systems.
   (:issue:`1753245`)
 
-* The :mod:`msilib` module's :class:`Record` object
-  gained :meth:`GetInteger` and :meth:`GetString` methods that
+* The :mod:`msilib` module's :class:`!Record` object
+  gained :meth:`~msilib.Record.GetInteger` and :meth:`~msilib.Record.GetString` methods that
   return field values as an integer or a string.
   (Contributed by Floris Bruynooghe; :issue:`2125`.)
 
@@ -3151,49 +3145,49 @@ Port-Specific Changes: Mac OS X
   :option:`!--with-framework-name=` option to the
   :program:`configure` script.
 
-* The :mod:`macfs` module has been removed.  This in turn required the
-  :func:`macostools.touched` function to be removed because it depended on the
-  :mod:`macfs` module.  (:issue:`1490190`)
+* The :mod:`!macfs` module has been removed.  This in turn required the
+  :func:`!macostools.touched` function to be removed because it depended on the
+  :mod:`!macfs` module.  (:issue:`1490190`)
 
 * Many other Mac OS modules have been deprecated and will be removed in
   Python 3.0:
-  :mod:`_builtinSuites`,
-  :mod:`aepack`,
-  :mod:`aetools`,
-  :mod:`aetypes`,
-  :mod:`applesingle`,
-  :mod:`appletrawmain`,
-  :mod:`appletrunner`,
-  :mod:`argvemulator`,
-  :mod:`Audio_mac`,
-  :mod:`autoGIL`,
-  :mod:`Carbon`,
-  :mod:`cfmfile`,
-  :mod:`CodeWarrior`,
-  :mod:`ColorPicker`,
-  :mod:`EasyDialogs`,
-  :mod:`Explorer`,
-  :mod:`Finder`,
-  :mod:`FrameWork`,
-  :mod:`findertools`,
-  :mod:`ic`,
-  :mod:`icglue`,
-  :mod:`icopen`,
-  :mod:`macerrors`,
-  :mod:`MacOS`,
-  :mod:`macfs`,
-  :mod:`macostools`,
-  :mod:`macresource`,
-  :mod:`MiniAEFrame`,
-  :mod:`Nav`,
-  :mod:`Netscape`,
-  :mod:`OSATerminology`,
-  :mod:`pimp`,
-  :mod:`PixMapWrapper`,
-  :mod:`StdSuites`,
-  :mod:`SystemEvents`,
-  :mod:`Terminal`, and
-  :mod:`terminalcommand`.
+  :mod:`!_builtinSuites`,
+  :mod:`!aepack`,
+  :mod:`!aetools`,
+  :mod:`!aetypes`,
+  :mod:`!applesingle`,
+  :mod:`!appletrawmain`,
+  :mod:`!appletrunner`,
+  :mod:`!argvemulator`,
+  :mod:`!Audio_mac`,
+  :mod:`!autoGIL`,
+  :mod:`!Carbon`,
+  :mod:`!cfmfile`,
+  :mod:`!CodeWarrior`,
+  :mod:`!ColorPicker`,
+  :mod:`!EasyDialogs`,
+  :mod:`!Explorer`,
+  :mod:`!Finder`,
+  :mod:`!FrameWork`,
+  :mod:`!findertools`,
+  :mod:`!ic`,
+  :mod:`!icglue`,
+  :mod:`!icopen`,
+  :mod:`!macerrors`,
+  :mod:`!MacOS`,
+  :mod:`!macfs`,
+  :mod:`!macostools`,
+  :mod:`!macresource`,
+  :mod:`!MiniAEFrame`,
+  :mod:`!Nav`,
+  :mod:`!Netscape`,
+  :mod:`!OSATerminology`,
+  :mod:`!pimp`,
+  :mod:`!PixMapWrapper`,
+  :mod:`!StdSuites`,
+  :mod:`!SystemEvents`,
+  :mod:`!Terminal`, and
+  :mod:`!terminalcommand`.
 
 .. ======================================================================
 
@@ -3202,29 +3196,29 @@ Port-Specific Changes: IRIX
 
 A number of old IRIX-specific modules were deprecated and will
 be removed in Python 3.0:
-:mod:`al` and :mod:`AL`,
-:mod:`cd`,
-:mod:`cddb`,
-:mod:`cdplayer`,
-:mod:`CL` and :mod:`cl`,
-:mod:`DEVICE`,
-:mod:`ERRNO`,
-:mod:`FILE`,
-:mod:`FL` and :mod:`fl`,
-:mod:`flp`,
-:mod:`fm`,
-:mod:`GET`,
-:mod:`GLWS`,
-:mod:`GL` and :mod:`gl`,
-:mod:`IN`,
-:mod:`IOCTL`,
-:mod:`jpeg`,
-:mod:`panelparser`,
-:mod:`readcd`,
-:mod:`SV` and :mod:`sv`,
-:mod:`torgb`,
-:mod:`videoreader`, and
-:mod:`WAIT`.
+:mod:`!al` and :mod:`!AL`,
+:mod:`!cd`,
+:mod:`!cddb`,
+:mod:`!cdplayer`,
+:mod:`!CL` and :mod:`!cl`,
+:mod:`!DEVICE`,
+:mod:`!ERRNO`,
+:mod:`!FILE`,
+:mod:`!FL` and :mod:`!fl`,
+:mod:`!flp`,
+:mod:`!fm`,
+:mod:`!GET`,
+:mod:`!GLWS`,
+:mod:`!GL` and :mod:`!gl`,
+:mod:`!IN`,
+:mod:`!IOCTL`,
+:mod:`!jpeg`,
+:mod:`!panelparser`,
+:mod:`!readcd`,
+:mod:`!SV` and :mod:`!sv`,
+:mod:`!torgb`,
+:mod:`!videoreader`, and
+:mod:`!WAIT`.
 
 .. ======================================================================
 


### PR DESCRIPTION
(cherry picked from commit 2e17cad2b8899126eb2024bf75db331b871bd5bc)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-101100 -->
* Issue: gh-101100
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--113847.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->