### PR TITLE
GH-113661: unittest runner: Don't exit 5 if tests were skipped

### DIFF
--- a/Doc/library/unittest.rst
+++ b/Doc/library/unittest.rst
@@ -2290,7 +2290,7 @@ Loading and running tests
    The *testRunner* argument can either be a test runner class or an already
    created instance of it. By default ``main`` calls :func:`sys.exit` with
    an exit code indicating success (0) or failure (1) of the tests run.
-   An exit code of 5 indicates that no tests were run.
+   An exit code of 5 indicates that no tests were run or skipped.
 
    The *testLoader* argument has to be a :class:`TestLoader` instance,
    and defaults to :data:`defaultTestLoader`.

--- a/Lib/test/test_unittest/test_program.py
+++ b/Lib/test/test_unittest/test_program.py
@@ -167,6 +167,18 @@ class Test_TestProgram(unittest.TestCase):
                     'expected failures=1, unexpected successes=1)\n')
         self.assertTrue(out.endswith(expected))
 
+    def test_ExitSkippedSuite(self):
+        stream = BufferedWriter()
+        with self.assertRaises(SystemExit) as cm:
+            unittest.main(
+                argv=["foobar", "-k", "testSkipped"],
+                testRunner=unittest.TextTestRunner(stream=stream),
+                testLoader=self.TestLoader(self.FooBar))
+        self.assertEqual(cm.exception.code, 0)
+        out = stream.getvalue()
+        expected = '\n\nOK (skipped=1)\n'
+        self.assertTrue(out.endswith(expected))
+
     def test_ExitEmptySuite(self):
         stream = BufferedWriter()
         with self.assertRaises(SystemExit) as cm:

--- a/Lib/unittest/main.py
+++ b/Lib/unittest/main.py
@@ -269,7 +269,7 @@ class TestProgram(object):
             testRunner = self.testRunner
         self.result = testRunner.run(self.test)
         if self.exit:
-            if self.result.testsRun == 0:
+            if self.result.testsRun == 0 and len(self.result.skipped) == 0:
                 sys.exit(_NO_TESTS_EXITCODE)
             elif self.result.wasSuccessful():
                 sys.exit(0)

--- a/Lib/unittest/runner.py
+++ b/Lib/unittest/runner.py
@@ -274,7 +274,7 @@ class TextTestRunner(object):
                 infos.append("failures=%d" % failed)
             if errored:
                 infos.append("errors=%d" % errored)
-        elif run == 0:
+        elif run == 0 and not skipped:
             self.stream.write("NO TESTS RAN")
         else:
             self.stream.write("OK")

--- a/Misc/NEWS.d/next/Library/2024-01-09-08-59-43.gh-issue-113661.asvXSx.rst
+++ b/Misc/NEWS.d/next/Library/2024-01-09-08-59-43.gh-issue-113661.asvXSx.rst
@@ -1,0 +1,3 @@
+unittest runner: Don't exit 5 if tests were skipped. The intention of
+exiting 5 was to detect issues where the test suite wasn't discovered at
+all. If we skipped tests, it was correctly discovered.


### PR DESCRIPTION
The intention of exiting 5 was to detect issues where the test suite wasn't discovered at all. If we skipped tests, it was correctly discovered.

Follow on to (and resolving a bug in) GH-62432.

<!-- gh-issue-number: gh-113661 -->
* Issue: gh-113661
<!-- /gh-issue-number -->
