### PR TITLE
GH-113528: Deoptimise `pathlib._abc.PurePathBase.parts`

### DIFF
--- a/Lib/pathlib/__init__.py
+++ b/Lib/pathlib/__init__.py
@@ -196,6 +196,15 @@ class PurePath(_abc.PurePathBase):
         return self._parts_normcase >= other._parts_normcase
 
     @property
+    def parts(self):
+        """An object providing sequence-like access to the
+        components in the filesystem path."""
+        if self.drive or self.root:
+            return (self.drive + self.root,) + tuple(self._tail)
+        else:
+            return tuple(self._tail)
+
+    @property
     def parent(self):
         """The logical parent of the path."""
         drv = self.drive

--- a/Lib/pathlib/_abc.py
+++ b/Lib/pathlib/_abc.py
@@ -381,10 +381,10 @@ class PurePathBase:
     def parts(self):
         """An object providing sequence-like access to the
         components in the filesystem path."""
-        if self.drive or self.root:
-            return (self.drive + self.root,) + tuple(self._tail)
-        else:
-            return tuple(self._tail)
+        anchor, parts = self._stack
+        if anchor:
+            parts.append(anchor)
+        return tuple(reversed(parts))
 
     def joinpath(self, *pathsegments):
         """Combine this path with one or several arguments, and return a


### PR DESCRIPTION
Implement `parts` using `_stack`, which itself calls `pathmod.split()` repeatedly. This avoids use of `_tail`, which will be moved to `PurePath` shortly.

Move existing implementation to `PurePath`. No change of behaviour in public classes.

<!-- gh-issue-number: gh-113528 -->
* Issue: gh-113528
<!-- /gh-issue-number -->
