### PR TITLE
gh-111139: Optimize math.gcd(int, int)

### DIFF
--- a/Modules/mathmodule.c
+++ b/Modules/mathmodule.c
@@ -759,11 +759,8 @@ m_log10(double x)
 static PyObject *
 math_gcd(PyObject *module, PyObject * const *args, Py_ssize_t nargs)
 {
-    // Fast-path for the common case: avoid calling _PyNumber_Index()
-    // and the loop.
-    if (nargs == 2
-        && PyLong_CheckExact(args[0])
-        && PyLong_CheckExact(args[1]))
+    // Fast-path for the common case: gcd(int, int)
+    if (nargs == 2 && PyLong_CheckExact(args[0]) && PyLong_CheckExact(args[1]))
     {
         return _PyLong_GCD(args[0], args[1]);
     }

--- a/Modules/mathmodule.c
+++ b/Modules/mathmodule.c
@@ -759,13 +759,20 @@ m_log10(double x)
 static PyObject *
 math_gcd(PyObject *module, PyObject * const *args, Py_ssize_t nargs)
 {
-    PyObject *res, *x;
-    Py_ssize_t i;
+    // Fast-path for the common case: avoid calling _PyNumber_Index()
+    // and the loop.
+    if (nargs == 2
+        && PyLong_CheckExact(args[0])
+        && PyLong_CheckExact(args[1]))
+    {
+        return _PyLong_GCD(args[0], args[1]);
+    }
 
     if (nargs == 0) {
         return PyLong_FromLong(0);
     }
-    res = PyNumber_Index(args[0]);
+
+    PyObject *res = PyNumber_Index(args[0]);
     if (res == NULL) {
         return NULL;
     }
@@ -775,8 +782,8 @@ math_gcd(PyObject *module, PyObject * const *args, Py_ssize_t nargs)
     }
 
     PyObject *one = _PyLong_GetOne();  // borrowed ref
-    for (i = 1; i < nargs; i++) {
-        x = _PyNumber_Index(args[i]);
+    for (Py_ssize_t i = 1; i < nargs; i++) {
+        PyObject *x = _PyNumber_Index(args[i]);
         if (x == NULL) {
             Py_DECREF(res);
             return NULL;


### PR DESCRIPTION
Add a fast-path for the common case.

Benchmark:

    python -m pyperf timeit \
        -s 'import math; gcd=math.gcd; x=2*3; y=3*5' \
        'gcd(x,y)'

Result: 1.07x faster (-3.4 ns)

    Mean +- std dev: 52.6 ns +- 4.0 ns -> 49.2 ns +- 0.4 ns: 1.07x faster

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-111139 -->
* Issue: gh-111139
<!-- /gh-issue-number -->
