### PR TITLE
gh-113889: thread_pthread.h: provide fallback if `pthread_threadid_np` unavailable

### DIFF
--- a/Misc/NEWS.d/next/macOS/2024-01-10-01-49-45.gh-issue-113889.hMOPWT.rst
+++ b/Misc/NEWS.d/next/macOS/2024-01-10-01-49-45.gh-issue-113889.hMOPWT.rst
@@ -1,0 +1,1 @@
+Provide a fallback for systems where pthread_threadid_np is unsupported. Fixes Python on older macOS.

--- a/Python/thread_pthread.h
+++ b/Python/thread_pthread.h
@@ -32,6 +32,10 @@
 #   include <sys/lwp.h>         /* lwp_gettid() */
 #endif
 
+#if defined(__APPLE__)
+#include <AvailabilityMacros.h>
+#endif
+
 /* The POSIX spec requires that use of pthread_attr_setstacksize
    be conditional on _POSIX_THREAD_ATTR_STACKSIZE being defined. */
 #ifdef _POSIX_THREAD_ATTR_STACKSIZE
@@ -379,7 +383,17 @@ PyThread_get_thread_native_id(void)
         PyThread_init_thread();
 #ifdef __APPLE__
     uint64_t native_id;
+#if MAC_OS_X_VERSION_MAX_ALLOWED < 1060 || defined(__POWERPC__)
+    native_id = pthread_mach_thread_np(pthread_self());
+#elif MAC_OS_X_VERSION_MIN_REQUIRED < 1060
+    if (&pthread_threadid_np != NULL) {
+        (void) pthread_threadid_np(NULL, &native_id);
+    } else {
+        native_id = pthread_mach_thread_np(pthread_self());
+    }
+#else
     (void) pthread_threadid_np(NULL, &native_id);
+#endif
 #elif defined(__linux__)
     pid_t native_id;
     native_id = syscall(SYS_gettid);


### PR DESCRIPTION
This PR adds a simple fallback for systems where there is no `pthread_threadid_np` (10.5.8 and earlier for x86, 10.6.8 and earlier for ppc).
This fallback is used, for example, in the current Ruby:
https://github.com/ruby/ruby/blob/1817d644ee827f10516947c4d999a8120017025b/thread_pthread.c#L2761-L2790

P. S. I understand that older macOS versions are not actively supported, but this is a trivial fix to make Python work, it will benefit those who use such systems.

<!-- gh-issue-number: gh-113889 -->
* Issue: gh-113889
<!-- /gh-issue-number -->
