### PR TITLE
gh-113625: Align object addresses in the Descriptor HowTo Guide

### DIFF
--- a/Doc/howto/descriptor.rst
+++ b/Doc/howto/descriptor.rst
@@ -1250,7 +1250,7 @@ instance::
     <function D.f at 0x00C45070>
 
     >>> d.f.__self__
-    <__main__.D object at 0x1012e1f98>
+    <__main__.D object at 0x00B18C90>
 
 If you have ever wondered where *self* comes from in regular methods or where
 *cls* comes from in class methods, this is it!


### PR DESCRIPTION


<!-- gh-issue-number: gh-113625 -->
* Issue: gh-113625
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--113894.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->