### PR TITLE
gh-113877: Fix Tkinter method winfo_pathname() on 64-bit Windows

### DIFF
--- a/Lib/test/test_tkinter/test_misc.py
+++ b/Lib/test/test_tkinter/test_misc.py
@@ -281,6 +281,18 @@ class MiscTest(AbstractTkTest, unittest.TestCase):
         with self.assertRaises(tkinter.TclError):
             rgb((111, 78, 55))
 
+    def test_winfo_pathname(self):
+        t = tkinter.Toplevel(self.root)
+        w = tkinter.Button(t)
+        wid = w.winfo_id()
+        self.assertIsInstance(wid, int)
+        self.assertEqual(self.root.winfo_pathname(hex(wid)), str(w))
+        self.assertEqual(self.root.winfo_pathname(hex(wid), displayof=None), str(w))
+        self.assertEqual(self.root.winfo_pathname(hex(wid), displayof=t), str(w))
+        self.assertEqual(self.root.winfo_pathname(wid), str(w))
+        self.assertEqual(self.root.winfo_pathname(wid, displayof=None), str(w))
+        self.assertEqual(self.root.winfo_pathname(wid, displayof=t), str(w))
+
     def test_event_repr_defaults(self):
         e = tkinter.Event()
         e.serial = 12345

--- a/Lib/tkinter/__init__.py
+++ b/Lib/tkinter/__init__.py
@@ -1260,6 +1260,8 @@ class Misc:
 
     def winfo_pathname(self, id, displayof=0):
         """Return the pathname of the widget given by ID."""
+        if isinstance(id, int):
+            id = hex(id)
         args = ('winfo', 'pathname') \
                + self._displayof(displayof) + (id,)
         return self.tk.call(args)

--- a/Misc/NEWS.d/next/Library/2024-01-10-12-03-38.gh-issue-113877.RxKlrQ.rst
+++ b/Misc/NEWS.d/next/Library/2024-01-10-12-03-38.gh-issue-113877.RxKlrQ.rst
@@ -1,0 +1,1 @@
+Fix :mod:`tkinter` method ``winfo_pathname()`` on 64-bit Windows.


### PR DESCRIPTION
winfo_id() converts the result of "winfo id" command to integer, but "winfo pathname" command requires an argument to be a hexadecimal number on Win64.


<!-- gh-issue-number: gh-113877 -->
* Issue: gh-113877
<!-- /gh-issue-number -->
