### PR TITLE
gh-113743: Make the MRO cache thread-safe in free-threaded builds

### DIFF
--- a/Include/cpython/pyatomic.h
+++ b/Include/cpython/pyatomic.h
@@ -469,6 +469,9 @@ _Py_atomic_store_int_release(int *obj, int value);
 static inline int
 _Py_atomic_load_int_acquire(const int *obj);
 
+static inline uint32_t
+_Py_atomic_load_uint32_acquire(const uint32_t *obj);
+
 
 // --- _Py_atomic_fence ------------------------------------------------------
 

--- a/Include/cpython/pyatomic_gcc.h
+++ b/Include/cpython/pyatomic_gcc.h
@@ -495,6 +495,9 @@ static inline int
 _Py_atomic_load_int_acquire(const int *obj)
 { return __atomic_load_n(obj, __ATOMIC_ACQUIRE); }
 
+static inline uint32_t
+_Py_atomic_load_uint32_acquire(const uint32_t *obj)
+{ return __atomic_load_n(obj, __ATOMIC_ACQUIRE); }
 
 // --- _Py_atomic_fence ------------------------------------------------------
 

--- a/Include/cpython/pyatomic_msc.h
+++ b/Include/cpython/pyatomic_msc.h
@@ -938,6 +938,17 @@ _Py_atomic_load_int_acquire(const int *obj)
 #endif
 }
 
+static inline uint32_t
+_Py_atomic_load_uint32_acquire(const uint32_t *obj)
+{
+#if defined(_M_X64) || defined(_M_IX86)
+    return *(uint32_t volatile *)obj;
+#elif defined(_M_ARM64)
+    return (int)__ldar32((uint32_t volatile *)obj);
+#else
+#  error "no implementation of _Py_atomic_load_uint32_acquire"
+#endif
+}
 
 // --- _Py_atomic_fence ------------------------------------------------------
 

--- a/Include/cpython/pyatomic_std.h
+++ b/Include/cpython/pyatomic_std.h
@@ -870,6 +870,13 @@ _Py_atomic_load_int_acquire(const int *obj)
                                 memory_order_acquire);
 }
 
+static inline uint32_t
+_Py_atomic_load_uint32_acquire(const uint32_t *obj)
+{
+    _Py_USING_STD;
+    return atomic_load_explicit((const _Atomic(uint32_t)*)obj,
+                                memory_order_acquire);
+}
 
 
 // --- _Py_atomic_fence ------------------------------------------------------

--- a/Include/internal/pycore_critical_section.h
+++ b/Include/internal/pycore_critical_section.h
@@ -293,7 +293,8 @@ _PyCriticalSection_SuspendAll(PyThreadState *tstate);
 #ifdef Py_GIL_DISABLED
 
 static inline void
-_PyCriticalSection_AssertHeld(PyMutex *mutex) {
+_PyCriticalSection_AssertHeld(PyMutex *mutex)
+{
 #ifdef Py_DEBUG
     PyThreadState *tstate = _PyThreadState_GET();
     uintptr_t prev = tstate->critical_section;

--- a/Include/internal/pycore_lock.h
+++ b/Include/internal/pycore_lock.h
@@ -251,7 +251,39 @@ PyAPI_FUNC(void) _PyRWMutex_RUnlock(_PyRWMutex *rwmutex);
 PyAPI_FUNC(void) _PyRWMutex_Lock(_PyRWMutex *rwmutex);
 PyAPI_FUNC(void) _PyRWMutex_Unlock(_PyRWMutex *rwmutex);
 
-void _Py_yield(void);
+// Similar to linux seqlock: https://en.wikipedia.org/wiki/Seqlock
+// We use a sequence number to lock the writer, an even sequence means we're unlocked, an odd
+// sequence means we're locked.  Readers will read the sequence before attempting to read the
+// underlying data and then read the sequence number again after reading the data.  If the
+// sequence has not changed the data is valid.
+//
+// Differs a little bit in that we use CAS on sequence as the lock, instead of a seperate spin lock.
+// The writer can also detect that the undelering data has not changed and abandon the write
+// and restore the previous sequence.
+typedef struct {
+    int sequence;
+} _PySeqLock;
+
+// Lock the sequence lock for the writer
+PyAPI_FUNC(void) _PySeqLock_LockWrite(_PySeqLock *seqlock);
+
+// Unlock the sequence lock and move to the next sequence number.
+PyAPI_FUNC(void) _PySeqLock_UnlockWrite(_PySeqLock *seqlock);
+
+// Abandon the current update indicating that no mutations have occured
+// and restore the previous sequence value.
+PyAPI_FUNC(void) _PySeqLock_AbandonWrite(_PySeqLock *seqlock);
+
+// Begin a read operation and return the current sequence number.
+PyAPI_FUNC(int) _PySeqLock_BeginRead(_PySeqLock *seqlock);
+
+// End the read operation and confirm that the sequence number has not changed.
+// Returns 1 if the read was successful or 0 if the read should be re-tried.
+PyAPI_FUNC(int) _PySeqLock_EndRead(_PySeqLock *seqlock, int previous);
+
+// Check if the lock was held during a fork and clear the lock.  Returns 1
+// if the lock was held and any associated datat should be cleared.
+PyAPI_FUNC(int) _PySeqLock_AfterFork(_PySeqLock *seqlock);
 
 #ifdef __cplusplus
 }

--- a/Include/internal/pycore_lock.h
+++ b/Include/internal/pycore_lock.h
@@ -251,6 +251,7 @@ PyAPI_FUNC(void) _PyRWMutex_RUnlock(_PyRWMutex *rwmutex);
 PyAPI_FUNC(void) _PyRWMutex_Lock(_PyRWMutex *rwmutex);
 PyAPI_FUNC(void) _PyRWMutex_Unlock(_PyRWMutex *rwmutex);
 
+void _Py_yield(void);
 
 #ifdef __cplusplus
 }

--- a/Include/internal/pycore_lock.h
+++ b/Include/internal/pycore_lock.h
@@ -261,7 +261,7 @@ PyAPI_FUNC(void) _PyRWMutex_Unlock(_PyRWMutex *rwmutex);
 // The writer can also detect that the undelering data has not changed and abandon the write
 // and restore the previous sequence.
 typedef struct {
-    int sequence;
+    uint32_t sequence;
 } _PySeqLock;
 
 // Lock the sequence lock for the writer
@@ -275,15 +275,15 @@ PyAPI_FUNC(void) _PySeqLock_UnlockWrite(_PySeqLock *seqlock);
 PyAPI_FUNC(void) _PySeqLock_AbandonWrite(_PySeqLock *seqlock);
 
 // Begin a read operation and return the current sequence number.
-PyAPI_FUNC(int) _PySeqLock_BeginRead(_PySeqLock *seqlock);
+PyAPI_FUNC(uint32_t) _PySeqLock_BeginRead(_PySeqLock *seqlock);
 
 // End the read operation and confirm that the sequence number has not changed.
 // Returns 1 if the read was successful or 0 if the read should be re-tried.
-PyAPI_FUNC(int) _PySeqLock_EndRead(_PySeqLock *seqlock, int previous);
+PyAPI_FUNC(uint32_t) _PySeqLock_EndRead(_PySeqLock *seqlock, uint32_t previous);
 
 // Check if the lock was held during a fork and clear the lock.  Returns 1
 // if the lock was held and any associated datat should be cleared.
-PyAPI_FUNC(int) _PySeqLock_AfterFork(_PySeqLock *seqlock);
+PyAPI_FUNC(uint32_t) _PySeqLock_AfterFork(_PySeqLock *seqlock);
 
 #ifdef __cplusplus
 }

--- a/Include/internal/pycore_typeobject.h
+++ b/Include/internal/pycore_typeobject.h
@@ -79,7 +79,7 @@ struct types_state {
 extern PyStatus _PyTypes_InitTypes(PyInterpreterState *);
 extern void _PyTypes_FiniTypes(PyInterpreterState *);
 extern void _PyTypes_Fini(PyInterpreterState *);
-void _PyTypes_AfterFork(void);
+extern void _PyTypes_AfterFork(void);
 
 /* other API */
 

--- a/Include/internal/pycore_typeobject.h
+++ b/Include/internal/pycore_typeobject.h
@@ -28,6 +28,9 @@ struct _types_runtime_state {
 // see _PyType_Lookup().
 struct type_cache_entry {
     unsigned int version;  // initialized from type->tp_version_tag
+#ifdef Py_GIL_DISABLED
+    int sequence;
+#endif
     PyObject *name;        // reference to exactly a str or None
     PyObject *value;       // borrowed reference or NULL
 };
@@ -74,7 +77,7 @@ struct types_state {
 extern PyStatus _PyTypes_InitTypes(PyInterpreterState *);
 extern void _PyTypes_FiniTypes(PyInterpreterState *);
 extern void _PyTypes_Fini(PyInterpreterState *);
-
+void _PyTypes_AfterFork(void);
 
 /* other API */
 

--- a/Include/internal/pycore_typeobject.h
+++ b/Include/internal/pycore_typeobject.h
@@ -31,7 +31,7 @@ struct _types_runtime_state {
 struct type_cache_entry {
     unsigned int version;  // initialized from type->tp_version_tag
 #ifdef Py_GIL_DISABLED
-    int sequence;
+   _PySeqLock sequence;
 #endif
     PyObject *name;        // reference to exactly a str or None
     PyObject *value;       // borrowed reference or NULL

--- a/Include/internal/pycore_typeobject.h
+++ b/Include/internal/pycore_typeobject.h
@@ -9,6 +9,7 @@ extern "C" {
 #endif
 
 #include "pycore_moduleobject.h"  // PyModuleObject
+#include "pycore_lock.h"          // PyMutex
 
 
 /* state */
@@ -21,6 +22,7 @@ struct _types_runtime_state {
     // bpo-42745: next_version_tag remains shared by all interpreters
     // because of static types.
     unsigned int next_version_tag;
+    PyMutex type_mutex;
 };
 
 

--- a/Modules/_abc.c
+++ b/Modules/_abc.c
@@ -8,7 +8,6 @@
 #include "pycore_object.h"        // _PyType_GetSubclasses()
 #include "pycore_runtime.h"       // _Py_ID()
 #include "pycore_setobject.h"     // _PySet_NextEntry()
-#include "pycore_typeobject.h"    // _PyType_GetMRO()
 #include "pycore_weakref.h"       // _PyWeakref_GET_REF()
 #include "clinic/_abc.c.h"
 
@@ -744,18 +743,12 @@ _abc__abc_subclasscheck_impl(PyObject *module, PyObject *self,
     Py_DECREF(ok);
 
     /* 4. Check if it's a direct subclass. */
-    PyObject *mro = _PyType_GetMRO((PyTypeObject *)subclass);
-    assert(PyTuple_Check(mro));
-    for (pos = 0; pos < PyTuple_GET_SIZE(mro); pos++) {
-        PyObject *mro_item = PyTuple_GET_ITEM(mro, pos);
-        assert(mro_item != NULL);
-        if ((PyObject *)self == mro_item) {
-            if (_add_to_weak_set(&impl->_abc_cache, subclass) < 0) {
-                goto end;
-            }
-            result = Py_True;
+    if (PyType_IsSubtype((PyTypeObject *)subclass, (PyTypeObject *)self)) {
+        if (_add_to_weak_set(&impl->_abc_cache, subclass) < 0) {
             goto end;
         }
+        result = Py_True;
+        goto end;
     }
 
     /* 5. Check if it's a subclass of a registered class (recursive). */

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -60,13 +60,13 @@ class object "PyObject *" "&PyBaseObject_Type"
 // in odd behaviors w.r.t. running with the GIL as the outer type lock could
 // be released and reacquired during a subclass update if there's contention
 // on the subclass lock.
-#define BEGIN_TYPE_LOCK()                                           \
-    {                                                               \
-    _PyCriticalSection _cs;                                         \
-    _PyCriticalSection_Begin(&_cs, &_PyRuntime.types.type_mutex);   \
+#define BEGIN_TYPE_LOCK()                                               \
+    {                                                                   \
+        _PyCriticalSection _cs;                                         \
+        _PyCriticalSection_Begin(&_cs, &_PyRuntime.types.type_mutex);   \
 
-#define END_TYPE_LOCK()                                             \
-        _PyCriticalSection_End(&_cs);                               \
+#define END_TYPE_LOCK()                                                 \
+        _PyCriticalSection_End(&_cs);                                   \
     }
 
 #define ASSERT_TYPE_LOCK_HELD() \

--- a/Python/lock.c
+++ b/Python/lock.c
@@ -36,7 +36,7 @@ struct mutex_entry {
     int handed_off;
 };
 
-static void
+void
 _Py_yield(void)
 {
 #ifdef MS_WINDOWS

--- a/Python/lock.c
+++ b/Python/lock.c
@@ -465,16 +465,18 @@ _PyRWMutex_Unlock(_PyRWMutex *rwmutex)
 void _PySeqLock_LockWrite(_PySeqLock *seqlock)
 {
     // lock the entry by setting by moving to an odd sequence number
-    int prev = seqlock->sequence;
+    uint32_t prev = _Py_atomic_load_uint32_relaxed(&seqlock->sequence);
     while (1) {
         if (SEQLOCK_IS_UPDATING(prev)) {
             // Someone else is currently updating the cache
             _Py_yield();
-            prev = _Py_atomic_load_int32_relaxed(&seqlock->sequence);
-        } else if (_Py_atomic_compare_exchange_int32(&seqlock->sequence, &prev, prev + 1)) {
+            prev = _Py_atomic_load_uint32_relaxed(&seqlock->sequence);
+        }
+        else if (_Py_atomic_compare_exchange_uint32(&seqlock->sequence, &prev, prev + 1)) {
             // We've locked the cache
             break;
-        } else {
+        }
+        else {
             _Py_yield();
         }
     }
@@ -482,34 +484,34 @@ void _PySeqLock_LockWrite(_PySeqLock *seqlock)
 
 void _PySeqLock_AbandonWrite(_PySeqLock *seqlock)
 {
-    int new_seq = seqlock->sequence - 1;
+    uint32_t new_seq = seqlock->sequence - 1;
     assert(!SEQLOCK_IS_UPDATING(new_seq));
-    _Py_atomic_exchange_int32(&seqlock->sequence, new_seq);
+    _Py_atomic_store_uint32(&seqlock->sequence, new_seq);
 }
 
 void _PySeqLock_UnlockWrite(_PySeqLock *seqlock)
 {
-    int new_seq = seqlock->sequence + 1;
+    uint32_t new_seq = seqlock->sequence + 1;
     assert(!SEQLOCK_IS_UPDATING(new_seq));
-    _Py_atomic_exchange_int32(&seqlock->sequence, new_seq);
+    _Py_atomic_store_uint32(&seqlock->sequence, new_seq);
 }
 
-int _PySeqLock_BeginRead(_PySeqLock *seqlock)
+uint32_t _PySeqLock_BeginRead(_PySeqLock *seqlock)
 {
-    int sequence = _Py_atomic_load_int_acquire(&seqlock->sequence);
+    uint32_t sequence = _Py_atomic_load_uint32_acquire(&seqlock->sequence);
     while (SEQLOCK_IS_UPDATING(sequence)) {
         _Py_yield();
-        sequence = _Py_atomic_load_int_acquire(&seqlock->sequence);
+        sequence = _Py_atomic_load_uint32_acquire(&seqlock->sequence);
     }
 
     return sequence;
 }
 
-int _PySeqLock_EndRead(_PySeqLock *seqlock, int previous)
+uint32_t _PySeqLock_EndRead(_PySeqLock *seqlock, uint32_t previous)
 {
     // Synchronize again and validate that the entry hasn't been updated
     // while we were readying the values.
-     if (_Py_atomic_load_int_acquire(&seqlock->sequence) == previous) {
+     if (_Py_atomic_load_uint32_acquire(&seqlock->sequence) == previous) {
         return 1;
      }
 
@@ -517,7 +519,7 @@ int _PySeqLock_EndRead(_PySeqLock *seqlock, int previous)
      return 0;
 }
 
-int _PySeqLock_AfterFork(_PySeqLock *seqlock)
+uint32_t _PySeqLock_AfterFork(_PySeqLock *seqlock)
 {
     // Synchronize again and validate that the entry hasn't been updated
     // while we were readying the values.

--- a/Python/lock.c
+++ b/Python/lock.c
@@ -36,7 +36,7 @@ struct mutex_entry {
     int handed_off;
 };
 
-void
+static void
 _Py_yield(void)
 {
 #ifdef MS_WINDOWS
@@ -458,4 +458,73 @@ _PyRWMutex_Unlock(_PyRWMutex *rwmutex)
     if ((old_bits & _Py_HAS_PARKED) != 0) {
         _PyParkingLot_UnparkAll(&rwmutex->bits);
     }
+}
+
+#define SEQLOCK_IS_UPDATING(sequence) (sequence & 0x01)
+
+void _PySeqLock_LockWrite(_PySeqLock *seqlock)
+{
+    // lock the entry by setting by moving to an odd sequence number
+    int prev = seqlock->sequence;
+    while (1) {
+        if (SEQLOCK_IS_UPDATING(prev)) {
+            // Someone else is currently updating the cache
+            _Py_yield();
+            prev = _Py_atomic_load_int32_relaxed(&seqlock->sequence);
+        } else if (_Py_atomic_compare_exchange_int32(&seqlock->sequence, &prev, prev + 1)) {
+            // We've locked the cache
+            break;
+        } else {
+            _Py_yield();
+        }
+    }
+}
+
+void _PySeqLock_AbandonWrite(_PySeqLock *seqlock)
+{
+    int new_seq = seqlock->sequence - 1;
+    assert(!SEQLOCK_IS_UPDATING(new_seq));
+    _Py_atomic_exchange_int32(&seqlock->sequence, new_seq);
+}
+
+void _PySeqLock_UnlockWrite(_PySeqLock *seqlock)
+{
+    int new_seq = seqlock->sequence + 1;
+    assert(!SEQLOCK_IS_UPDATING(new_seq));
+    _Py_atomic_exchange_int32(&seqlock->sequence, new_seq);
+}
+
+int _PySeqLock_BeginRead(_PySeqLock *seqlock)
+{
+    int sequence = _Py_atomic_load_int_acquire(&seqlock->sequence);
+    while (SEQLOCK_IS_UPDATING(sequence)) {
+        _Py_yield();
+        sequence = _Py_atomic_load_int_acquire(&seqlock->sequence);
+    }
+
+    return sequence;
+}
+
+int _PySeqLock_EndRead(_PySeqLock *seqlock, int previous)
+{
+    // Synchronize again and validate that the entry hasn't been updated
+    // while we were readying the values.
+     if (_Py_atomic_load_int_acquire(&seqlock->sequence) == previous) {
+        return 1;
+     }
+
+     _Py_yield();
+     return 0;
+}
+
+int _PySeqLock_AfterFork(_PySeqLock *seqlock)
+{
+    // Synchronize again and validate that the entry hasn't been updated
+    // while we were readying the values.
+     if (SEQLOCK_IS_UPDATING(seqlock->sequence)) {
+        seqlock->sequence = 0;
+        return 1;
+     }
+
+     return 0;
 }

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -395,6 +395,7 @@ _Py_COMP_DIAG_POP
         &(runtime)->atexit.mutex, \
         &(runtime)->audit_hooks.mutex, \
         &(runtime)->allocators.mutex, \
+        &(runtime)->types.type_mutex, \
     }
 
 static void

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -499,6 +499,8 @@ _PyRuntimeState_ReInitThreads(_PyRuntimeState *runtime)
         _PyMutex_at_fork_reinit(locks[i]);
     }
 
+    _PyTypes_AfterFork();
+
     /* bpo-42540: id_mutex is freed by _PyInterpreterState_Delete, which does
      * not force the default allocator. */
     if (_PyThread_at_fork_reinit(&runtime->interpreters.main->id_mutex) < 0) {


### PR DESCRIPTION
This makes _PyType_Lookup thread safe.

There's a couple of aspects to this:
1) Thread safety of the underlying cache.

For this a lock that is similar to Linux's seqlock is used.  This allows the reader to read the sequence using acquire semantics which ensures it sees the values that were written by the last time the lock was released.  It reads the sequence a 2nd time again with acquire semantics after having read the values and confirms the sequence has not changed, in which case the values read were valid.  

On an update if we have multiple readers who missed but looked up the same value only the first one in will perform the update.  It also appears the linux implementation (at least initially?) used a separate spin lock, we just use CAS on the sequence.

There's currently a sequence/lock per-cache entry, on 64-bit builds this is free due to the alignment of the existing cache entries.

2) Make mutation of `mro` and type members thread safe
Because the cache is racing against mutations to the types those mutations also need to be thread safe.  This involves adding critical sections around mutation of the type's dictionary (type_setattro), mutation of the mro, and mutation of the bases (which of course ultimately mutates the mro).  

This bubbles up to a surprising number of functions as `lookup_tp_mro` and both are returning borrowed references which need to be protected in case the type is modified.  In general I've used assertions to make sure the locks are already held by the time we reach the functions using them to push the locking into the chunkier functions.

There is a single mutex which is used to protect all type objects.  This is because sometimes we need to actually update the type hierarchy, and if were to recurse through sub-types and lock them individually we could end up releasing the outer type's lock and open it up to mutation in a way which is not currently possible. 

`Py_BEGIN_CRITICAL_SECTION` and `Py_END_CRITICAL_SECTION` are a little inflexible in that you can't return inside of a critical section, so for more complicated functions I've added `_unlocked` variants and wrapped those in the original name which acquires the lock.

These unlocked versions are also used elsewhere when we know that we have the lock held.  If we've already acquired the lock currently re-acquiring the lock immediately, even from the same thread, comes with some additional cost as we first spin and then need to go to the parking lot.  

Also `_PyType_GetMRO` and `_PyType_GetBases` are currently returning borrowed references which aren't safe.  Luckily these functions aren't currently exported, so I've switched them to returning owned references.  `_PyType_GetBases` actually had no consumers before this diff but now is used internally to typeobject.c.  `_PyType_GetMRO` was only used in the abc module, and even then it's usage is actually just re-implementation of `PyType_IsSubtype` so I've replaced it with a call to that function.

In the future we may be able to improve this.  Currently much of this locking is done just to make sure we don't end up with a dangling reference to mro/bases.  In some cases it may be okay to race against mutations and just have the program behave as if whatever check is applied to those happened before the mutation (e.g. consider the case of `PyType_IsSubtype`, whether the mutation happens right after we fetch MRO or right after we release doesn't really matter, as the type can change as soon as we've released the lock).  Therefore we may be able to eliminate some of this locking by having a mutation of mro/bases scheduling the final dec ref to happen via qsbr when when hit the next quiescent state.

<!-- gh-issue-number: gh-113743 -->
* Issue: gh-113743
<!-- /gh-issue-number -->
