### PR TITLE
gh-107901: jump leaving an exception handler doesn't need an eval break check

### DIFF
--- a/Lib/test/test_dis.py
+++ b/Lib/test/test_dis.py
@@ -578,11 +578,11 @@ dis_asyncwith = """\
 
 %4d   L12:     CLEANUP_THROW
 
-  --   L13:     JUMP_BACKWARD           26 (to L5)
+  --   L13:     JUMP_BACKWARD_NO_INTERRUPT 25 (to L5)
 
 %4d   L14:     CLEANUP_THROW
 
-  --   L15:     JUMP_BACKWARD           11 (to L11)
+  --   L15:     JUMP_BACKWARD_NO_INTERRUPT 9 (to L11)
 
 %4d   L16:     PUSH_EXC_INFO
                 WITH_EXCEPT_START

--- a/Misc/NEWS.d/next/Core and Builtins/2024-01-11-14-03-31.gh-issue-107901.U65IyC.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2024-01-11-14-03-31.gh-issue-107901.U65IyC.rst
@@ -1,0 +1,1 @@
+A jump leaving an exception handler back to normal code no longer checks the eval breaker.

--- a/Python/flowgraph.c
+++ b/Python/flowgraph.c
@@ -2164,7 +2164,7 @@ push_cold_blocks_to_end(cfg_builder *g) {
             if (!IS_LABEL(b->b_next->b_label)) {
                 b->b_next->b_label.id = next_lbl++;
             }
-            basicblock_addop(explicit_jump, JUMP, b->b_next->b_label.id, NO_LOCATION);
+            basicblock_addop(explicit_jump, JUMP_NO_INTERRUPT, b->b_next->b_label.id, NO_LOCATION);
             explicit_jump->b_cold = 1;
             explicit_jump->b_next = b->b_next;
             b->b_next = explicit_jump;


### PR DESCRIPTION


<!-- gh-issue-number: gh-107901 -->
* Issue: gh-107901
<!-- /gh-issue-number -->
