### PR TITLE
gh-101100: Fix Sphinx Lint warnings in `Misc/`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,7 +28,7 @@ repos:
     hooks:
       - id: sphinx-lint
         args: [--enable=default-role]
-        files: ^Doc/|^Misc/NEWS.d/next/
+        files: ^Doc/|^Misc/NEWS.d/
 
   - repo: meta
     hooks:

--- a/Misc/NEWS.d/3.10.0a1.rst
+++ b/Misc/NEWS.d/3.10.0a1.rst
@@ -4,7 +4,7 @@
 .. release date: 2020-10-05
 .. section: Security
 
-Fixes `python3x._pth` being ignored on Windows, caused by the fix for
+Fixes ``python3x._pth`` being ignored on Windows, caused by the fix for
 :issue:`29778` (CVE-2020-15801).
 
 ..
@@ -217,7 +217,7 @@ Port the :mod:`_opcode` extension module to multi-phase initialization
 .. nonce: 3-VJiH
 .. section: Core and Builtins
 
-Fixes the wrong error description in the error raised by using 2 `,` in
+Fixes the wrong error description in the error raised by using 2 ``,`` in
 format string in f-string and :meth:`str.format`.
 
 ..
@@ -747,7 +747,7 @@ Galindo.
 
 Fix a bug where a line with only a line continuation character is not
 considered a blank line at tokenizer level. In such cases, more than a
-single `NEWLINE` token was emitted. The old parser was working around the
+single ``NEWLINE`` token was emitted. The old parser was working around the
 issue, but the new parser threw a :exc:`SyntaxError` for valid input due to
 this. For example, an empty line following a line continuation character was
 interpreted as a :exc:`SyntaxError`.
@@ -1157,7 +1157,7 @@ The :class:`threading.Thread` constructor now uses the target name if the
 .. nonce: bnh-VG
 .. section: Library
 
-fix `tkinter.EventType` Enum so all members are strings, and none are tuples
+fix ``tkinter.EventType`` Enum so all members are strings, and none are tuples
 
 ..
 
@@ -1229,8 +1229,8 @@ Previously there was no way to check that without using private API. See the
 .. nonce: pI_uZQ
 .. section: Library
 
-Honor `object` overrides in `Enum` class creation (specifically, `__str__`,
-`__repr__`, `__format__`, and `__reduce_ex__`).
+Honor ``object`` overrides in ``Enum`` class creation (specifically, ``__str__``,
+``__repr__``, ``__format__``, and ``__reduce_ex__``).
 
 ..
 
@@ -1239,7 +1239,7 @@ Honor `object` overrides in `Enum` class creation (specifically, `__str__`,
 .. nonce: IpYkEe
 .. section: Library
 
-`enum.Flag` and `enum.IntFlag` members are now iterable
+``enum.Flag`` and ``enum.IntFlag`` members are now iterable.
 
 ..
 
@@ -1557,7 +1557,7 @@ activation.
 .. nonce: wqrj8C
 .. section: Library
 
-Recursive evaluation of `typing.ForwardRef` in `get_type_hints`.
+Recursive evaluation of ``typing.ForwardRef`` in ``get_type_hints``.
 
 ..
 
@@ -1851,8 +1851,8 @@ Merry.
 .. nonce: 1dk8Bu
 .. section: Library
 
-:mod:`ensurepip` now disables the use of `pip` cache when installing the
-bundled versions of `pip` and `setuptools`.  Patch by Krzysztof Konopko.
+:mod:`ensurepip` now disables the use of ``pip`` cache when installing the
+bundled versions of ``pip`` and ``setuptools``.  Patch by Krzysztof Konopko.
 
 ..
 
@@ -1933,7 +1933,7 @@ Smith and Tal Einat.
 .. nonce: n7fOwS
 .. section: Library
 
-Added a `defaults` parameter to :class:`logging.Formatter`, to allow
+Added a ``defaults`` parameter to :class:`logging.Formatter`, to allow
 specifying default values for custom fields. Patch by Asaf Alon and Bar
 Harel.
 
@@ -2225,7 +2225,7 @@ policy.
 .. nonce: ps7Yf1
 .. section: Library
 
-func:`hashlib.new` passed ``usedforsecurity`` to OpenSSL EVP constructor
+:func:`hashlib.new` passed ``usedforsecurity`` to OpenSSL EVP constructor
 ``_hashlib.new()``. test_hashlib and test_smtplib handle strict security
 policy better.
 
@@ -2393,8 +2393,8 @@ closes connection during TLS negotiation
 .. nonce: kOOaHn
 .. section: Library
 
-fix default `_missing_` so a duplicate `ValueError` is not set as the
-`__context__` of the original `ValueError`
+fix default ``_missing_`` so a duplicate ``ValueError`` is not set as the
+``__context__`` of the original ``ValueError``.
 
 ..
 

--- a/Misc/NEWS.d/3.10.0a2.rst
+++ b/Misc/NEWS.d/3.10.0a2.rst
@@ -88,10 +88,10 @@ Goldschmidt.
 .. nonce: d4a-8o
 .. section: Core and Builtins
 
-Fix a bug in the parser, where a curly brace following a `primary` didn't
-fail immediately. This led to invalid expressions like `a {b}` to throw a
+Fix a bug in the parser, where a curly brace following a ``primary`` didn't
+fail immediately. This led to invalid expressions like ``a {b}`` to throw a
 :exc:`SyntaxError` with a wrong offset, or invalid expressions ending with a
-curly brace like `a {` to not fail immediately in the REPL.
+curly brace like ``a {`` to not fail immediately in the REPL.
 
 ..
 
@@ -214,7 +214,7 @@ Micro optimization for range.index if step is 1. Patch by Donghee Na.
 .. nonce: qPWjJA
 .. section: Core and Builtins
 
-Add `sys._current_exceptions()` function to retrieve a dictionary mapping
+Add ``sys._current_exceptions()`` function to retrieve a dictionary mapping
 each thread's identifier to the topmost exception currently active in that
 thread at the time the function is called.
 
@@ -302,7 +302,7 @@ type to a heap type. Patch by Mohamed Koubaa and Victor Stinner.
 .. section: Library
 
 Fix memory leak in :func:`subprocess.Popen` in case an uid (gid) specified
-in `user` (`group`, `extra_groups`) overflows `uid_t` (`gid_t`).
+in ``user`` (``group``, ``extra_groups``) overflows ``uid_t`` (``gid_t``).
 
 ..
 
@@ -649,7 +649,7 @@ Document __format__ functionality for IP addresses.
 .. nonce: CzBMit
 .. section: Documentation
 
-Document the default implementation of `object.__eq__`.
+Document the default implementation of ``object.__eq__``.
 
 ..
 
@@ -878,7 +878,7 @@ targeting 3.10 or later.
 .. nonce: sh8IDY
 .. section: C API
 
-Add `_Py_closerange` function to provide performant closing of a range of
+Add ``_Py_closerange`` function to provide performant closing of a range of
 file descriptors.
 
 ..
@@ -898,7 +898,7 @@ available again in limited API.
 .. nonce: ZZ5wJG
 .. section: C API
 
-Add `PyIter_Send` function to allow sending value into
+Add ``PyIter_Send`` function to allow sending value into
 generator/coroutine/iterator without raising StopIteration exception to
 signal return.
 

--- a/Misc/NEWS.d/3.10.0a3.rst
+++ b/Misc/NEWS.d/3.10.0a3.rst
@@ -247,8 +247,8 @@ fixes union type expressions not de-duplicating ``GenericAlias`` objects.
 .. nonce: B-Veg7
 .. section: Core and Builtins
 
-The import system triggers a `ImportWarning` when it falls back to using
-`load_module()`.
+The import system triggers a ``ImportWarning`` when it falls back to using
+``load_module()``.
 
 ..
 
@@ -464,8 +464,8 @@ Support signal module on VxWorks.
 .. nonce: r9rNCj
 .. section: Library
 
-We fixed an issue in `pickle.whichmodule` in which importing
-`multiprocessing` could change the how pickle identifies which module an
+We fixed an issue in ``pickle.whichmodule`` in which importing
+``multiprocessing`` could change the how pickle identifies which module an
 object belongs to, potentially breaking the unpickling of those objects.
 
 ..
@@ -602,7 +602,7 @@ function when ``os.open`` fails.
 .. nonce: F363jO
 .. section: Library
 
-Fix `os.sendfile()` on illumos.
+Fix ``os.sendfile()`` on illumos.
 
 ..
 
@@ -718,8 +718,8 @@ Improve asyncio.wait function to create the futures set just one time.
 .. nonce: BzizYV
 .. section: Library
 
-Update various modules in the stdlib to fall back on `__spec__.loader` when
-`__loader__` isn't defined on a module.
+Update various modules in the stdlib to fall back on ``__spec__.loader`` when
+``__loader__`` isn't defined on a module.
 
 ..
 
@@ -728,8 +728,8 @@ Update various modules in the stdlib to fall back on `__spec__.loader` when
 .. nonce: CAsI3O
 .. section: Library
 
-The `load_module()` methods found in importlib now trigger a
-DeprecationWarning.
+The ``load_module()`` methods found in ``importlib`` now trigger a
+``DeprecationWarning``.
 
 ..
 
@@ -872,7 +872,7 @@ extension during TLS handshake when no custom context is supplied.
 .. nonce: 5mi7b0
 .. section: Library
 
-Add func:`os.eventfd` to provide a low level interface for Linux's event
+Add :func:`os.eventfd` to provide a low level interface for Linux's event
 notification file descriptor.
 
 ..

--- a/Misc/NEWS.d/3.10.0a4.rst
+++ b/Misc/NEWS.d/3.10.0a4.rst
@@ -516,7 +516,7 @@ Define THREAD_STACK_SIZE for VxWorks.
 .. nonce: x8TASR
 .. section: Library
 
-[Enum] `_EnumDict.update()` is now supported
+[Enum] ``_EnumDict.update()`` is now supported.
 
 ..
 

--- a/Misc/NEWS.d/3.10.0a7.rst
+++ b/Misc/NEWS.d/3.10.0a7.rst
@@ -261,7 +261,7 @@ the annotations _Py_NO_SANITIZE_ADDRESS, _Py_NO_SANITIZE_THREAD, and
 _Py_NO_SANITIZE_MEMORY. Those annotations are no longer needed.
 
 To disable the radix tree map, set a preprocessor flag as follows:
-`-DWITH_PYMALLOC_RADIX_TREE=0`.
+``-DWITH_PYMALLOC_RADIX_TREE=0``.
 
 Co-authored-by: Tim Peters <tim.peters@gmail.com>
 
@@ -664,11 +664,11 @@ on failure.
 .. nonce: f1dr_5
 .. section: Library
 
-Enum's `repr()` and `str()` have changed: `repr()` is now
-*EnumClass.MemberName* and `str()` is *MemberName*.  Additionally, stdlib
+Enum's ``repr()`` and ``str()`` have changed: ``repr()`` is now
+*EnumClass.MemberName* and ``str()`` is *MemberName*.  Additionally, stdlib
 Enum's whose contents are available as module attributes, such as
-`RegexFlag.IGNORECASE`, have their `repr()` as *module.name*, e.g.
-`re.IGNORECASE`.
+``RegexFlag.IGNORECASE``, have their ``repr()`` as *module.name*, e.g.
+``re.IGNORECASE``.
 
 ..
 

--- a/Misc/NEWS.d/3.10.0b1.rst
+++ b/Misc/NEWS.d/3.10.0b1.rst
@@ -1181,8 +1181,8 @@ Lewis Gaul.
 .. nonce: NzLVaR
 .. section: Library
 
-Add `pathlib.Path.hardlink_to()` method that supersedes `link_to()`. The new
-method has the same argument order as `symlink_to()`.
+Add ``pathlib.Path.hardlink_to()`` method that supersedes ``link_to()``. The new
+method has the same argument order as ``symlink_to()``.
 
 ..
 

--- a/Misc/NEWS.d/3.11.0a1.rst
+++ b/Misc/NEWS.d/3.11.0a1.rst
@@ -3204,7 +3204,7 @@ deprecated, for removal in 3.14.
 .. section: Library
 
 When :class:`http.server.SimpleHTTPRequestHandler` sends a ``301 (Moved
-Permanently)`` for a directory path not ending with `/`, add a
+Permanently)`` for a directory path not ending with ``/``, add a
 ``Content-Length: 0`` header. This improves the behavior for certain
 clients.
 
@@ -3240,7 +3240,7 @@ Patch by Erlend E. Aasland.
 .. nonce: m72tlH
 .. section: Library
 
-AIX: `Lib/_aix_support.get_platform()` may fail in an AIX WPAR. The fileset
+AIX: ``Lib/_aix_support.get_platform()`` may fail in an AIX WPAR. The fileset
 bos.rte appears to have a builddate in both LPAR and WPAR so this fileset is
 queried rather than bos.mp64. To prevent a similar situation (no builddate
 in ODM) a value (9988) sufficient for completing a build is provided. Patch
@@ -3685,9 +3685,9 @@ equivalents are valid.
 .. nonce: aJuvQF
 .. section: Documentation
 
-Removed the othergui.rst file, any references to it, and the list of GUI
+Removed the ``othergui.rst`` file, any references to it, and the list of GUI
 frameworks in the FAQ. In their place I've added links to the Python Wiki
-`page on GUI frameworks <https://wiki.python.org/moin/GuiProgramming>`.
+`page on GUI frameworks <https://wiki.python.org/moin/GuiProgramming>`_.
 
 ..
 

--- a/Misc/NEWS.d/3.11.0a2.rst
+++ b/Misc/NEWS.d/3.11.0a2.rst
@@ -507,7 +507,7 @@ Waygood.
 .. section: Library
 
 Make :func:`inspect.getmodule` catch ``FileNotFoundError`` raised by
-:'func:`inspect.getabsfile`, and return ``None`` to indicate that the module
+:func:`inspect.getabsfile`, and return ``None`` to indicate that the module
 could not be determined.
 
 ..
@@ -897,8 +897,8 @@ was often the case on macOS.
 .. nonce: F18qcE
 .. section: Tests
 
-Add more test cases for `@functools.singledispatchmethod` when combined with
-`@classmethod` or `@staticmethod`.
+Add more test cases for ``@functools.singledispatchmethod`` when combined with
+``@classmethod`` or ``@staticmethod``.
 
 ..
 

--- a/Misc/NEWS.d/3.11.0a3.rst
+++ b/Misc/NEWS.d/3.11.0a3.rst
@@ -350,7 +350,7 @@ Galindo.
 .. section: Library
 
 Fix possible crash when getting an attribute of
-class:`xml.etree.ElementTree.Element` simultaneously with replacing the
+:class:`xml.etree.ElementTree.Element` simultaneously with replacing the
 ``attrib`` dict.
 
 ..

--- a/Misc/NEWS.d/3.11.0a4.rst
+++ b/Misc/NEWS.d/3.11.0a4.rst
@@ -510,7 +510,7 @@ Remove special-casing of ``__new__`` in :meth:`enum.Enum.__dir__`.
 
 Improve day constants in :mod:`calendar`.
 
-Now all constants (`MONDAY` ... `SUNDAY`) are documented, tested, and added
+Now all constants (``MONDAY`` ... ``SUNDAY``) are documented, tested, and added
 to ``__all__``.
 
 ..

--- a/Misc/NEWS.d/3.11.0a5.rst
+++ b/Misc/NEWS.d/3.11.0a5.rst
@@ -275,7 +275,7 @@ Do not use POSIX semaphores on NetBSD
 .. nonce: M9m8Qd
 .. section: Core and Builtins
 
-Improve the exc:`TypeError` message for non-string second arguments passed
+Improve the :exc:`TypeError` message for non-string second arguments passed
 to the built-in functions :func:`getattr` and :func:`hasattr`. Patch by Géry
 Ogam.
 
@@ -673,7 +673,7 @@ file
 .. section: Tests
 
 Mocks can no longer be provided as the specs for other Mocks. As a result,
-an already-mocked object cannot be passed to `mock.Mock()`. This can uncover
+an already-mocked object cannot be passed to ``mock.Mock()``. This can uncover
 bugs in tests since these Mock-derived Mocks will always pass certain tests
 (e.g. isinstance) and builtin assert functions (e.g.
 assert_called_once_with) will unconditionally pass.

--- a/Misc/NEWS.d/3.11.0a6.rst
+++ b/Misc/NEWS.d/3.11.0a6.rst
@@ -1034,7 +1034,7 @@ if zlib uses the s390x hardware accelerator. Patch by Victor Stinner.
 .. nonce: jfciLG
 .. section: Build
 
-Respect `--with-suffix` when building on case-insensitive file systems.
+Respect ``--with-suffix`` when building on case-insensitive file systems.
 
 ..
 
@@ -1151,7 +1151,7 @@ Make query dialogs on Windows start with a cursor in the entry box.
 .. nonce: FhiH5P
 .. section: IDLE
 
-Apply IDLE syntax highlighting to `.pyi` files. Patch by Alex Waygood and
+Apply IDLE syntax highlighting to ``.pyi`` files. Patch by Alex Waygood and
 Terry Jan Reedy.
 
 ..

--- a/Misc/NEWS.d/3.11.0b1.rst
+++ b/Misc/NEWS.d/3.11.0b1.rst
@@ -437,7 +437,7 @@ cache when applicable.
 .. section: Core and Builtins
 
 Classes and functions that unconditionally declared their docstrings
-ignoring the `--without-doc-strings` compilation flag no longer do so.
+ignoring the ``--without-doc-strings`` compilation flag no longer do so.
 
 The classes affected are :class:`ctypes.UnionType`,
 :class:`pickle.PickleBuffer`, :class:`testcapi.RecursingInfinitelyError`,
@@ -576,7 +576,7 @@ planned). Patch by Alex Waygood.
 .. section: Library
 
 Deprecate nested classes in enum definitions becoming members -- in 3.13
-they will be normal classes; add `member` and `nonmember` functions to allow
+they will be normal classes; add ``member`` and ``nonmember`` functions to allow
 control over results now.
 
 ..
@@ -785,7 +785,7 @@ avoid :exc:`BrokenPipeError` at garbage collection and at
 .. nonce: V0YveU
 .. section: Library
 
-Add `datetime.UTC` alias for `datetime.timezone.utc`.
+Add ``datetime.UTC`` alias for ``datetime.timezone.utc``.
 
 Patch by Kabir Kwatra.
 
@@ -1657,9 +1657,9 @@ Convert :mod:`csv` to use Argument Clinic for :func:`csv.field_size_limit`,
 .. nonce: z2WhDQ
 .. section: Library
 
-Raise an ArgumentError when the same subparser name is added twice to an
-`argparse.ArgumentParser`.  This is consistent with the (default) behavior
-when the same option string is added twice to an ArgumentParser.
+Raise an ``ArgumentError`` when the same subparser name is added twice to an
+``argparse.ArgumentParser``.  This is consistent with the (default) behavior
+when the same option string is added twice to an ``ArgumentParser``.
 
 ..
 
@@ -1712,7 +1712,7 @@ Aviv Palivoda and Erlend E. Aasland.
 .. nonce: kTjJLx
 .. section: Documentation
 
-Add a new `gh` role to the documentation to link to GitHub issues.
+Add a new ``gh`` role to the documentation to link to GitHub issues.
 
 ..
 

--- a/Misc/NEWS.d/3.5.0a1.rst
+++ b/Misc/NEWS.d/3.5.0a1.rst
@@ -251,8 +251,8 @@ and "surrogatepass" error handlers.
 .. nonce: FM72m-
 .. section: Core and Builtins
 
-speed up `PyObject_IsInstance` and `PyObject_IsSubclass` in the common case
-that the second argument has metaclass `type`.
+speed up ``PyObject_IsInstance`` and ``PyObject_IsSubclass`` in the common case
+that the second argument has metaclass ``type``.
 
 ..
 
@@ -261,8 +261,8 @@ that the second argument has metaclass `type`.
 .. nonce: ds5wQa
 .. section: Core and Builtins
 
-Add a new `PyErr_FormatV` function, similar to `PyErr_Format` but accepting
-a `va_list` argument.
+Add a new ``PyErr_FormatV`` function, similar to ``PyErr_Format`` but accepting
+a ``va_list`` argument.
 
 ..
 
@@ -1522,7 +1522,7 @@ Fixed fcntl() with integer argument on 64-bit big-endian platforms.
 .. nonce: 62MLqr
 .. section: Library
 
-Add an `--sort-keys` option to json.tool CLI.
+Add an ``--sort-keys`` option to ``json.tool`` CLI.
 
 ..
 
@@ -1745,7 +1745,7 @@ already failed.
 .. section: Library
 
 Make it possible to examine the errors from unittest discovery without
-executing the test suite. The new `errors` attribute on TestLoader exposes
+executing the test suite. The new ``errors`` attribute on ``TestLoader`` exposes
 these non-fatal errors encountered during discovery.
 
 ..
@@ -2342,9 +2342,9 @@ as normal call attributes.
 .. nonce: Nghn-Y
 .. section: Library
 
-load_tests() is now unconditionally run when it is present in a package's
-__init__.py.  TestLoader.loadTestsFromModule() still accepts use_load_tests,
-but it is deprecated and ignored.  A new keyword-only attribute `pattern` is
+``load_tests()`` is now unconditionally run when it is present in a package's
+``__init__.py``.  ``TestLoader.loadTestsFromModule()`` still accepts use_load_tests,
+but it is deprecated and ignored.  A new keyword-only attribute ``pattern`` is
 added and documented.  Patch given by Robert Collins, tweaked by Barry
 Warsaw.
 
@@ -2736,8 +2736,8 @@ Convert posixmodule to use Argument Clinic.
 .. nonce: YccmZF
 .. section: Library
 
-Add an *exists_ok* argument to `Pathlib.mkdir()` to mimic `mkdir -p` and
-`os.makedirs()` functionality.  When true, ignore FileExistsErrors.  Patch
+Add an *exists_ok* argument to ``Pathlib.mkdir()`` to mimic ``mkdir -p`` and
+``os.makedirs()`` functionality.  When true, ignore ``FileExistsErrors``.  Patch
 by Berker Peksag.
 
 ..
@@ -3930,7 +3930,7 @@ has been called.
 .. nonce: 5CDoox
 .. section: Library
 
-New keyword argument `unsafe` to Mock. It raises `AttributeError` incase of
+New keyword argument ``unsafe`` to Mock. It raises ``AttributeError`` incase of
 an attribute startswith assert or assret.
 
 ..
@@ -4173,7 +4173,7 @@ provide better security by default.
 .. nonce: FP5FY0
 .. section: Library
 
-`assertRaisesRegex` and `assertWarnsRegex` now raise a TypeError if the
+``assertRaisesRegex`` and ``assertWarnsRegex`` now raise a ``TypeError`` if the
 second argument is not a string or compiled regex.
 
 ..

--- a/Misc/NEWS.d/3.5.0b4.rst
+++ b/Misc/NEWS.d/3.5.0b4.rst
@@ -129,7 +129,7 @@ Random.setstate() now validates the value of state last element.
 .. nonce: HvJf6T
 .. section: Library
 
-Fixed an issue that caused `inspect.getsource` to return incorrect results
+Fixed an issue that caused ``inspect.getsource`` to return incorrect results
 on nested functions.
 
 ..

--- a/Misc/NEWS.d/3.5.2rc1.rst
+++ b/Misc/NEWS.d/3.5.2rc1.rst
@@ -710,9 +710,9 @@ Fixed the comparison of plistlib.Data with other types.
 .. nonce: RMRMtM
 .. section: Library
 
-Fix an uninitialized variable in `ctypes.util`.
+Fix an uninitialized variable in ``ctypes.util``.
 The bug only occurs on SunOS when the ctypes implementation searches for the
-`crle` program.  Patch by Xiang Zhang.  Tested on SunOS by Kees Bos.
+``crle`` program.  Patch by Xiang Zhang.  Tested on SunOS by Kees Bos.
 
 ..
 

--- a/Misc/NEWS.d/3.6.0a1.rst
+++ b/Misc/NEWS.d/3.6.0a1.rst
@@ -1113,9 +1113,9 @@ Fixed the comparison of plistlib.Data with other types.
 .. nonce: RMRMtM
 .. section: Library
 
-Fix an uninitialized variable in `ctypes.util`.
+Fix an uninitialized variable in ``ctypes.util``.
 The bug only occurs on SunOS when the ctypes implementation searches for the
-`crle` program.  Patch by Xiang Zhang.  Tested on SunOS by Kees Bos.
+``crle`` program.  Patch by Xiang Zhang.  Tested on SunOS by Kees Bos.
 
 ..
 
@@ -3915,7 +3915,7 @@ Fix output of python-config --extension-suffix.
 .. nonce: yLO-r4
 .. section: Tools/Demos
 
-The pyvenv script has been deprecated in favour of `python3 -m venv`.
+The pyvenv script has been deprecated in favour of ``python3 -m venv``.
 
 ..
 

--- a/Misc/NEWS.d/3.6.0b1.rst
+++ b/Misc/NEWS.d/3.6.0b1.rst
@@ -166,7 +166,7 @@ a DeprecationWarning.  Patch by Emanuel Barry.
 .. nonce: aABzcL
 .. section: Core and Builtins
 
-`dict` implementation is changed like PyPy. It is more compact and preserves
+``dict`` implementation is changed like PyPy. It is more compact and preserves
 insertion order. (Concept developed by Raymond Hettinger and patch by Inada
 Naoki.)
 

--- a/Misc/NEWS.d/3.6.3.rst
+++ b/Misc/NEWS.d/3.6.3.rst
@@ -4,7 +4,7 @@
 .. release date: 2017-10-03
 .. section: Library
 
-Re-allow arbitrary iterables in `concurrent.futures.as_completed()`. Fixes
+Re-allow arbitrary iterables in ``concurrent.futures.as_completed()``. Fixes
 regression in 3.6.3rc1.
 
 ..

--- a/Misc/NEWS.d/3.6.3rc1.rst
+++ b/Misc/NEWS.d/3.6.3rc1.rst
@@ -24,8 +24,8 @@ fixes.
 .. nonce: 0yiA5Q
 .. section: Core and Builtins
 
-Fix an assertion failure in `subprocess.Popen()` on Windows, in case the env
-argument has a bad keys() method. Patch by Oren Milman.
+Fix an assertion failure in ``subprocess.Popen()`` on Windows, in case the env
+argument has a bad ``keys()`` method. Patch by Oren Milman.
 
 ..
 
@@ -34,7 +34,7 @@ argument has a bad keys() method. Patch by Oren Milman.
 .. nonce: rS-FlC
 .. section: Core and Builtins
 
-Fix an assertion failure in `PyErr_WriteUnraisable()` in case of an
+Fix an assertion failure in ``PyErr_WriteUnraisable()`` in case of an
 exception with a bad ``__module__`` attribute. Patch by Oren Milman.
 
 ..
@@ -95,7 +95,7 @@ plans to remove the functions from sys/types.h.
 .. nonce: t8QggK
 .. section: Core and Builtins
 
-Fix an assertion failure in `zipimport.zipimporter.get_data` on Windows,
+Fix an assertion failure in ``zipimport.zipimporter.get_data`` on Windows,
 when the return value of ``pathname.replace('/','\\')`` isn't a string.
 Patch by Oren Milman.
 
@@ -106,7 +106,7 @@ Patch by Oren Milman.
 .. nonce: YMduKF
 .. section: Core and Builtins
 
-Fix an assertion failure in the write() method of `io.TextIOWrapper`, when
+Fix an assertion failure in the ``write()`` method of ``io.TextIOWrapper``, when
 the encoder doesn't return a bytes object. Patch by Oren Milman.
 
 ..
@@ -116,7 +116,7 @@ the encoder doesn't return a bytes object. Patch by Oren Milman.
 .. nonce: dRJzqR
 .. section: Core and Builtins
 
-Fix a crash in some methods of `io.TextIOWrapper`, when the decoder's state
+Fix a crash in some methods of ``io.TextIOWrapper``, when the decoder's state
 is invalid. Patch by Oren Milman.
 
 ..
@@ -477,7 +477,7 @@ attributes to help the garbage collector to destroy all widgets.
 .. nonce: 1t2hn5
 .. section: Library
 
-Fix `copyreg._slotnames()` mangled attribute calculation for classes whose
+Fix ``copyreg._slotnames()`` mangled attribute calculation for classes whose
 name begins with an underscore. Patch by Shane Harvey.
 
 ..
@@ -585,7 +585,7 @@ socket.close() now ignores ECONNRESET error.
 .. nonce: CLvEvV
 .. section: Library
 
-Fix out of bounds write in `asyncio.CFuture.remove_done_callback()`.
+Fix out of bounds write in ``asyncio.CFuture.remove_done_callback()``.
 
 ..
 
@@ -933,7 +933,7 @@ Add tests for configdialog keys tab. Patch by Cheryl Sabella.
 .. nonce: sqE1FS
 .. section: IDLE
 
-IDLE: Calltips use `inspect.signature` instead of `inspect.getfullargspec`.
+IDLE: Calltips use ``inspect.signature`` instead of ``inspect.getfullargspec``.
 This improves calltips for builtins converted to use Argument Clinic. Patch
 by Louie Lu.
 

--- a/Misc/NEWS.d/3.6.4rc1.rst
+++ b/Misc/NEWS.d/3.6.4rc1.rst
@@ -138,7 +138,7 @@ integer with binary base.
 .. section: Core and Builtins
 
 Fixed an assertion failure in Python parser in case of a bad
-`unicodedata.normalize()`. Patch by Oren Milman.
+``unicodedata.normalize()``. Patch by Oren Milman.
 
 ..
 
@@ -147,7 +147,7 @@ Fixed an assertion failure in Python parser in case of a bad
 .. nonce: wT9Iy7
 .. section: Core and Builtins
 
-Raise a `TypeError` with a helpful error message when class creation fails
+Raise a ``TypeError`` with a helpful error message when class creation fails
 due to a metaclass with a bad ``__prepare__()`` method. Patch by Oren
 Milman.
 
@@ -158,7 +158,7 @@ Milman.
 .. nonce: OxwINs
 .. section: Core and Builtins
 
-Fix an assertion failure in `_warnings.warn()` in case of a bad ``__name__``
+Fix an assertion failure in ``_warnings.warn()`` in case of a bad ``__name__``
 global. Patch by Oren Milman.
 
 ..
@@ -168,8 +168,8 @@ global. Patch by Oren Milman.
 .. nonce: VomaFa
 .. section: Core and Builtins
 
-Fix an assertion failure in `json`, in case `_json.make_encoder()` received
-a bad `encoder()` argument. Patch by Oren Milman.
+Fix an assertion failure in ``json``, in case ``_json.make_encoder()`` received
+a bad ``encoder()`` argument. Patch by Oren Milman.
 
 ..
 
@@ -189,7 +189,7 @@ such a module. Patch by Oren Milman.
 .. nonce: r7m2sj
 .. section: Core and Builtins
 
-Fix an assertion failure in `ctypes` class definition, in case the class has
+Fix an assertion failure in ``ctypes`` class definition, in case the class has
 an attribute whose name is specified in ``_anonymous_`` but not in
 ``_fields_``. Patch by Oren Milman.
 
@@ -200,7 +200,7 @@ an attribute whose name is specified in ``_anonymous_`` but not in
 .. nonce: o06iKD
 .. section: Core and Builtins
 
-Fix an assertion failure in `_random.Random.seed()` in case the argument has
+Fix an assertion failure in ``_random.Random.seed()`` in case the argument has
 a bad ``__abs__()`` method. Patch by Oren Milman.
 
 ..
@@ -220,7 +220,7 @@ string. Patch by Oren Milman.
 .. nonce: bNE2l-
 .. section: Core and Builtins
 
-Fix a crash in the ``__setstate__()`` method of `ctypes._CData`, in case of
+Fix a crash in the ``__setstate__()`` method of ``ctypes._CData``, in case of
 a bad ``__dict__``. Patch by Oren Milman.
 
 ..
@@ -240,8 +240,8 @@ float with a bad as_integer_ratio() method. Patch by Oren Milman.
 .. nonce: 7lzaKV
 .. section: Core and Builtins
 
-Fix an assertion failure in `warnings.warn_explicit`, when the return value
-of the received loader's get_source() has a bad splitlines() method. Patch
+Fix an assertion failure in ``warnings.warn_explicit``, when the return value
+of the received loader's ``get_source()`` has a bad ``splitlines()`` method. Patch
 by Oren Milman.
 
 ..
@@ -251,8 +251,8 @@ by Oren Milman.
 .. nonce: j7ZvN_
 .. section: Core and Builtins
 
-`PyErr_PrintEx()` clears now the ignored exception that may be raised by
-`_PySys_SetObjectId()`, for example when no memory.
+``PyErr_PrintEx()`` clears now the ignored exception that may be raised by
+``_PySys_SetObjectId()``, for example when no memory.
 
 ..
 
@@ -599,8 +599,8 @@ On Windows, faulthandler.enable() now ignores MSC and COM exceptions.
 .. nonce: XrVMME
 .. section: Library
 
-Prevent crashes in `_elementtree` due to unsafe cleanup of `Element.text`
-and `Element.tail`. Patch by Oren Milman.
+Prevent crashes in ``_elementtree`` due to unsafe cleanup of ``Element.text``
+and ``Element.tail``. Patch by Oren Milman.
 
 ..
 
@@ -813,8 +813,8 @@ reference leaks.
 .. nonce: lo7FQX
 .. section: Tests
 
-Add the `set_nomemory(start, stop)` and `remove_mem_hooks()` functions to
-the _testcapi module.
+Add the ``set_nomemory(start, stop)`` and ``remove_mem_hooks()`` functions to
+the ``_testcapi`` module.
 
 ..
 
@@ -897,7 +897,7 @@ Prevent double substitution of prefix in python-config.sh.
 .. nonce: KUDjno
 .. section: Build
 
-Avoid wholesale rebuild after `make regen-all` if nothing changed.
+Avoid wholesale rebuild after ``make regen-all`` if nothing changed.
 
 ..
 
@@ -1123,7 +1123,7 @@ and Py_SetPath()
 .. nonce: Q3T_8n
 .. section: C API
 
-The `PyExc_RecursionErrorInst` singleton is removed and
-`PyErr_NormalizeException()` does not use it anymore. This singleton is
+The ``PyExc_RecursionErrorInst`` singleton is removed and
+``PyErr_NormalizeException()`` does not use it anymore. This singleton is
 persistent and its members being never cleared may cause a segfault during
 finalization of the interpreter. See also issue #22898.

--- a/Misc/NEWS.d/3.6.5rc1.rst
+++ b/Misc/NEWS.d/3.6.5rc1.rst
@@ -283,7 +283,7 @@ Make sure sys.argv remains as a list when running trace.
 .. nonce: bvHDOc
 .. section: Library
 
-Fixed `asyncio.Condition` issue which silently ignored cancellation after
+Fixed ``asyncio.Condition`` issue which silently ignored cancellation after
 notifying and cancelling a conditional lock. Patch by Bar Harel.
 
 ..
@@ -599,7 +599,7 @@ deprecation.
 .. nonce: w1m_8r
 .. section: Documentation
 
-Improve docstrings for `pathlib.PurePath` subclasses.
+Improve docstrings for ``pathlib.PurePath`` subclasses.
 
 ..
 

--- a/Misc/NEWS.d/3.6.6rc1.rst
+++ b/Misc/NEWS.d/3.6.6rc1.rst
@@ -110,7 +110,7 @@ on Windows.
 .. nonce: UoC319
 .. section: Core and Builtins
 
-Fix a crash in `ctypes.cast()` in case the type argument is a ctypes
+Fix a crash in ``ctypes.cast()`` in case the type argument is a ctypes
 structured data type. Patch by Eryk Sun and Oren Milman.
 
 ..
@@ -248,7 +248,7 @@ Patch by Zvi Effron
 .. nonce: taxbVT
 .. section: Library
 
-Fix race condition with `ReadTransport.resume_reading` in Windows proactor
+Fix race condition with ``ReadTransport.resume_reading`` in Windows proactor
 event loop.
 
 ..
@@ -346,7 +346,7 @@ tree of tuples or lists with ``line_info=False`` and ``col_info=True``.
 .. nonce: B56Hc1
 .. section: Library
 
-Fix FD leak in `_SelectorSocketTransport`  Patch by Vlad Starostin.
+Fix FD leak in ``_SelectorSocketTransport``  Patch by Vlad Starostin.
 
 ..
 

--- a/Misc/NEWS.d/3.7.0a1.rst
+++ b/Misc/NEWS.d/3.7.0a1.rst
@@ -86,7 +86,7 @@ information.
 .. nonce: r7m2sj
 .. section: Core and Builtins
 
-Fix an assertion failure in `ctypes` class definition, in case the class has
+Fix an assertion failure in ``ctypes`` class definition, in case the class has
 an attribute whose name is specified in ``_anonymous_`` but not in
 ``_fields_``. Patch by Oren Milman.
 
@@ -97,8 +97,8 @@ an attribute whose name is specified in ``_anonymous_`` but not in
 .. nonce: 0yiA5Q
 .. section: Core and Builtins
 
-Fix an assertion failure in `subprocess.Popen()` on Windows, in case the env
-argument has a bad keys() method. Patch by Oren Milman.
+Fix an assertion failure in ``subprocess.Popen()`` on Windows, in case the env
+argument has a bad ``keys()`` method. Patch by Oren Milman.
 
 ..
 
@@ -107,7 +107,7 @@ argument has a bad keys() method. Patch by Oren Milman.
 .. nonce: rS-FlC
 .. section: Core and Builtins
 
-Fix an assertion failure in `PyErr_WriteUnraisable()` in case of an
+Fix an assertion failure in ``PyErr_WriteUnraisable()`` in case of an
 exception with a bad ``__module__`` attribute. Patch by Oren Milman.
 
 ..
@@ -224,7 +224,7 @@ plans to remove the functions from sys/types.h.
 .. nonce: t8QggK
 .. section: Core and Builtins
 
-Fix an assertion failure in `zipimport.zipimporter.get_data` on Windows,
+Fix an assertion failure in ``zipimport.zipimporter.get_data`` on Windows,
 when the return value of ``pathname.replace('/','\\')`` isn't a string.
 Patch by Oren Milman.
 
@@ -235,7 +235,7 @@ Patch by Oren Milman.
 .. nonce: YMduKF
 .. section: Core and Builtins
 
-Fix an assertion failure in the write() method of `io.TextIOWrapper`, when
+Fix an assertion failure in the ``write()`` method of ``io.TextIOWrapper``, when
 the encoder doesn't return a bytes object. Patch by Oren Milman.
 
 ..
@@ -245,7 +245,7 @@ the encoder doesn't return a bytes object. Patch by Oren Milman.
 .. nonce: dRJzqR
 .. section: Core and Builtins
 
-Fix a crash in some methods of `io.TextIOWrapper`, when the decoder's state
+Fix a crash in some methods of ``io.TextIOWrapper``, when the decoder's state
 is invalid. Patch by Oren Milman.
 
 ..
@@ -1855,7 +1855,7 @@ docserver attribute to None to break a reference cycle.
 .. nonce: gwnthq
 .. section: Library
 
-Many asserts in `multiprocessing` are now more informative, and some error
+Many asserts in ``multiprocessing`` are now more informative, and some error
 types have been changed to more specific ones.
 
 ..
@@ -1896,7 +1896,7 @@ child exit.
 .. nonce: -2_YGj
 .. section: Library
 
-`dis` now works with asynchronous generator and coroutine objects. Patch by
+``dis`` now works with asynchronous generator and coroutine objects. Patch by
 George Collins based on diagnosis by Luciano Ramalho.
 
 ..
@@ -1906,10 +1906,10 @@ George Collins based on diagnosis by Luciano Ramalho.
 .. nonce: huQi2Y
 .. section: Library
 
-There are a number of uninformative asserts in the `multiprocessing` module,
+There are a number of uninformative asserts in the ``multiprocessing`` module,
 as noted in issue 5001. This change fixes two of the most potentially
 problematic ones, since they are in error-reporting code, in the
-`multiprocessing.managers.convert_to_error` function. (It also makes more
+``multiprocessing.managers.convert_to_error`` function. (It also makes more
 informative a ValueError message.) The only potentially problematic change
 is that the AssertionError is now a TypeError; however, this should also
 help distinguish it from an AssertionError being *reported* by the
@@ -1973,7 +1973,7 @@ attributes to help the garbage collector to destroy all widgets.
 .. nonce: 1t2hn5
 .. section: Library
 
-Fix `copyreg._slotnames()` mangled attribute calculation for classes whose
+Fix ``copyreg._slotnames()`` mangled attribute calculation for classes whose
 name begins with an underscore. Patch by Shane Harvey.
 
 ..
@@ -1983,7 +1983,7 @@ name begins with an underscore. Patch by Shane Harvey.
 .. nonce: 2CFVCO
 .. section: Library
 
-Allow `logging.config.fileConfig` to accept kwargs and/or args.
+Allow ``logging.config.fileConfig`` to accept kwargs and/or args.
 
 ..
 
@@ -2159,7 +2159,7 @@ socket.close() now ignores ECONNRESET error.
 .. nonce: CLvEvV
 .. section: Library
 
-Fix out of bounds write in `asyncio.CFuture.remove_done_callback()`.
+Fix out of bounds write in ``asyncio.CFuture.remove_done_callback()``.
 
 ..
 
@@ -2406,7 +2406,7 @@ Don't log exceptions if Task/Future "cancel()" method was called.
 .. nonce: xihJ4Y
 .. section: Library
 
-Fix path calculation in `imp.load_package()`, fixing it for cases when a
+Fix path calculation in ``imp.load_package()``, fixing it for cases when a
 package is only shipped with bytecodes. Patch by Alexandru Ardelean.
 
 ..
@@ -4947,8 +4947,8 @@ run test_zipfile64.
 .. nonce: lo7FQX
 .. section: Tests
 
-Add the `set_nomemory(start, stop)` and `remove_mem_hooks()` functions to
-the _testcapi module.
+Add the ``set_nomemory(start, stop)`` and ``remove_mem_hooks()`` functions to
+the ``_testcapi`` module.
 
 ..
 
@@ -5076,7 +5076,7 @@ on the Android armv7 qemu emulator.
 .. nonce: 4f-VJK
 .. section: Build
 
-Allow --with-lto to be used on all builds, not just `make profile-opt`.
+Allow ``--with-lto`` to be used on all builds, not just ``make profile-opt``.
 
 ..
 
@@ -5819,7 +5819,7 @@ Add tests for configdialog keys tab. Patch by Cheryl Sabella.
 .. nonce: sqE1FS
 .. section: IDLE
 
-IDLE: Calltips use `inspect.signature` instead of `inspect.getfullargspec`.
+IDLE: Calltips use ``inspect.signature`` instead of ``inspect.getfullargspec``.
 This improves calltips for builtins converted to use Argument Clinic. Patch
 by Louie Lu.
 
@@ -6224,9 +6224,9 @@ Added the slice index converter in Argument Clinic.
 .. nonce: KPFC7o
 .. section: Tools/Demos
 
-Argument Clinic now uses the converter `bool(accept={int})` rather than
-`int` for semantical booleans.  This avoids repeating the default value for
-Python and C and will help in converting to `bool` in future.
+Argument Clinic now uses the converter ``bool(accept={int})`` rather than
+``int`` for semantical booleans.  This avoids repeating the default value for
+Python and C and will help in converting to ``bool`` in future.
 
 ..
 

--- a/Misc/NEWS.d/3.7.0a2.rst
+++ b/Misc/NEWS.d/3.7.0a2.rst
@@ -65,8 +65,8 @@ integer with binary base.
 .. nonce: MtgLCn
 .. section: Core and Builtins
 
-Fix an assertion failure in `zipimporter.get_source()` in case of a bad
-`zlib.decompress()`. Patch by Oren Milman.
+Fix an assertion failure in ``zipimporter.get_source()`` in case of a bad
+``zlib.decompress()``. Patch by Oren Milman.
 
 ..
 
@@ -76,7 +76,7 @@ Fix an assertion failure in `zipimporter.get_source()` in case of a bad
 .. section: Core and Builtins
 
 Fixed an assertion failure in Python parser in case of a bad
-`unicodedata.normalize()`. Patch by Oren Milman.
+``unicodedata.normalize()``. Patch by Oren Milman.
 
 ..
 
@@ -85,7 +85,7 @@ Fixed an assertion failure in Python parser in case of a bad
 .. nonce: wT9Iy7
 .. section: Core and Builtins
 
-Raise a `TypeError` with a helpful error message when class creation fails
+Raise a ``TypeError`` with a helpful error message when class creation fails
 due to a metaclass with a bad ``__prepare__()`` method. Patch by Oren
 Milman.
 
@@ -105,7 +105,7 @@ Importlib was instrumented with two dtrace probes to profile import timing.
 .. nonce: OxwINs
 .. section: Core and Builtins
 
-Fix an assertion failure in `_warnings.warn()` in case of a bad ``__name__``
+Fix an assertion failure in ``_warnings.warn()`` in case of a bad ``__name__``
 global. Patch by Oren Milman.
 
 ..
@@ -115,7 +115,7 @@ global. Patch by Oren Milman.
 .. nonce: pRVTRB
 .. section: Core and Builtins
 
-Improved the error message logic for object.__new__ and object.__init__.
+Improved the error message logic for ``object.__new__`` and ``object.__init__``.
 
 ..
 
@@ -124,8 +124,8 @@ Improved the error message logic for object.__new__ and object.__init__.
 .. nonce: VomaFa
 .. section: Core and Builtins
 
-Fix an assertion failure in `json`, in case `_json.make_encoder()` received
-a bad `encoder()` argument. Patch by Oren Milman.
+Fix an assertion failure in ``json``, in case ``_json.make_encoder()`` received
+a bad ``encoder()`` argument. Patch by Oren Milman.
 
 ..
 
@@ -145,7 +145,7 @@ such a module. Patch by Oren Milman.
 .. nonce: o06iKD
 .. section: Core and Builtins
 
-Fix an assertion failure in `_random.Random.seed()` in case the argument has
+Fix an assertion failure in ``_random.Random.seed()`` in case the argument has
 a bad ``__abs__()`` method. Patch by Oren Milman.
 
 ..
@@ -218,7 +218,7 @@ string. Patch by Oren Milman.
 .. nonce: bNE2l-
 .. section: Core and Builtins
 
-Fix a crash in the ``__setstate__()`` method of `ctypes._CData`, in case of
+Fix a crash in the ``__setstate__()`` method of ``ctypes._CData``, in case of
 a bad ``__dict__``. Patch by Oren Milman.
 
 ..
@@ -238,8 +238,8 @@ float with a bad as_integer_ratio() method. Patch by Oren Milman.
 .. nonce: 7lzaKV
 .. section: Core and Builtins
 
-Fix an assertion failure in `warnings.warn_explicit`, when the return value
-of the received loader's get_source() has a bad splitlines() method. Patch
+Fix an assertion failure in ``warnings.warn_explicit``, when the return value
+of the received loader's ``get_source()`` has a bad ``splitlines()`` method. Patch
 by Oren Milman.
 
 ..
@@ -286,8 +286,8 @@ On Windows, faulthandler.enable() now ignores MSC and COM exceptions.
 .. nonce: XrVMME
 .. section: Library
 
-Prevent crashes in `_elementtree` due to unsafe cleanup of `Element.text`
-and `Element.tail`. Patch by Oren Milman.
+Prevent crashes in ``_elementtree`` due to unsafe cleanup of ``Element.text``
+and ``Element.tail``. Patch by Oren Milman.
 
 ..
 
@@ -307,8 +307,8 @@ compiling. bm_regex_compile benchmark shows 14% performance improvements.
 .. section: Library
 
 The types of compiled regular objects and match objects are now exposed as
-`re.Pattern` and `re.Match`.  This adds information in pydoc output for the
-re module.
+``re.Pattern`` and ``re.Match``.  This adds information in pydoc output for the
+``re`` module.
 
 ..
 
@@ -485,10 +485,10 @@ since Python 3.3.)
 .. nonce: cIMFJW
 .. section: Library
 
-Reprs of subclasses of some collection and iterator classes (`bytearray`,
-`array.array`, `collections.deque`, `collections.defaultdict`,
-`itertools.count`, `itertools.repeat`) now contain actual type name insteads
-of hardcoded name of the base class.
+Reprs of subclasses of some collection and iterator classes (``bytearray``,
+``array.array``, ``collections.deque``, ``collections.defaultdict``,
+``itertools.count``, ``itertools.repeat``) now contain actual type name instead
+of hardcoded names of the base class.
 
 ..
 
@@ -584,7 +584,7 @@ Correct PCBuild/ case to PCbuild/ in build scripts and documentation.
 .. nonce: KUDjno
 .. section: Build
 
-Avoid wholesale rebuild after `make regen-all` if nothing changed.
+Avoid wholesale rebuild after ``make regen-all`` if nothing changed.
 
 ..
 
@@ -657,8 +657,8 @@ for code and tests by Guilherme Polo and Cheryl Sabella, respectively.
 .. nonce: K_EjpO
 .. section: C API
 
-Make `PyMapping_Keys()`, `PyMapping_Values()` and `PyMapping_Items()` always
-return a `list` (rather than a `list` or a `tuple`). Patch by Oren Milman.
+Make ``PyMapping_Keys()``, ``PyMapping_Values()`` and ``PyMapping_Items()`` always
+return a ``list`` (rather than a ``list`` or a ``tuple``). Patch by Oren Milman.
 
 ..
 

--- a/Misc/NEWS.d/3.7.0a3.rst
+++ b/Misc/NEWS.d/3.7.0a3.rst
@@ -240,8 +240,8 @@ after shrinking a memory block.
 .. nonce: j7ZvN_
 .. section: Core and Builtins
 
-`PyErr_PrintEx()` clears now the ignored exception that may be raised by
-`_PySys_SetObjectId()`, for example when no memory.
+``PyErr_PrintEx()`` clears now the ignored exception that may be raised by
+``_PySys_SetObjectId()``, for example when no memory.
 
 ..
 
@@ -643,7 +643,7 @@ undocumented.
 .. nonce: RwietE
 .. section: Library
 
-cProfile command line now accepts `-m module_name` as an alternative to
+cProfile command line now accepts ``-m module_name`` as an alternative to
 script path. Patch by Sanyam Khurana.
 
 ..
@@ -926,7 +926,7 @@ Fix multiprocessing.Process when stdout and/or stderr is closed or None.
 .. nonce: -1MBEy
 .. section: Library
 
-Add `subnet_of` and `superset_of` containment tests to
+Add ``subnet_of`` and ``superset_of`` containment tests to
 :class:`ipaddress.IPv6Network` and :class:`ipaddress.IPv4Network`. Patch by
 Michel Albert and Cheryl Sabella.
 
@@ -948,7 +948,7 @@ for backward compatibility with Python 2.2, and was deprecated since Python
 .. nonce: IxCvGB
 .. section: Library
 
-Add a ``subprocess.Popen(text=False)`` keyword argument to `subprocess`
+Add a ``subprocess.Popen(text=False)`` keyword argument to ``subprocess``
 functions to be more explicit about when the library should attempt to
 decode outputs into text. Patch by Andrew Clegg.
 
@@ -1191,7 +1191,7 @@ interruptions. If it crashes, restart it when necessary.
 .. nonce: AniZuz
 .. section: Library
 
-Added support for AF_UNIX socket in asyncio `create_datagram_endpoint`.
+Added support for AF_UNIX socket in asyncio ``create_datagram_endpoint``.
 
 ..
 
@@ -1609,7 +1609,7 @@ comparison functions.
 .. nonce: Q3T_8n
 .. section: C API
 
-The `PyExc_RecursionErrorInst` singleton is removed and
-`PyErr_NormalizeException()` does not use it anymore. This singleton is
+The ``PyExc_RecursionErrorInst`` singleton is removed and
+``PyErr_NormalizeException()`` does not use it anymore. This singleton is
 persistent and its members being never cleared may cause a segfault during
 finalization of the interpreter. See also issue #22898.

--- a/Misc/NEWS.d/3.7.0a4.rst
+++ b/Misc/NEWS.d/3.7.0a4.rst
@@ -152,7 +152,7 @@ option or the ``PYTHONWARNINGS`` environment variable.
 .. nonce: PgGQaB
 .. section: Core and Builtins
 
-`-X dev` now injects a ``'default'`` entry into sys.warnoptions, ensuring
+``-X dev`` now injects a ``'default'`` entry into sys.warnoptions, ensuring
 that it behaves identically to actually passing ``-Wdefault`` at the command
 line.
 
@@ -192,7 +192,7 @@ by Ivan Levkivskyi.
 .. nonce: mDeCLK
 .. section: Core and Builtins
 
-The `atexit` module now has its callback stored per interpreter.
+The ``atexit`` module now has its callback stored per interpreter.
 
 ..
 
@@ -792,7 +792,7 @@ to more readily adjust to platform dependent behaviour.
 .. nonce: ODpc9y
 .. section: Windows
 
-Implement support for `subprocess.Popen(close_fds=True)` on Windows. Patch
+Implement support for ``subprocess.Popen(close_fds=True)`` on Windows. Patch
 by Segev Finer.
 
 ..

--- a/Misc/NEWS.d/3.7.0b2.rst
+++ b/Misc/NEWS.d/3.7.0b2.rst
@@ -214,7 +214,7 @@ helper methods that can be used instead ``_dump_registry``,
 .. nonce: bvHDOc
 .. section: Library
 
-Fixed `asyncio.Condition` issue which silently ignored cancellation after
+Fixed ``asyncio.Condition`` issue which silently ignored cancellation after
 notifying and cancelling a conditional lock. Patch by Bar Harel.
 
 ..
@@ -497,7 +497,7 @@ deprecation.
 .. nonce: w1m_8r
 .. section: Documentation
 
-Improve docstrings for `pathlib.PurePath` subclasses.
+Improve docstrings for ``pathlib.PurePath`` subclasses.
 
 ..
 

--- a/Misc/NEWS.d/3.7.0b4.rst
+++ b/Misc/NEWS.d/3.7.0b4.rst
@@ -371,8 +371,8 @@ suffixes).
 .. nonce: o7G_UO
 .. section: Build
 
-By default, modules configured in `Modules/Setup` are no longer built with
-`-DPy_BUILD_CORE`. Instead, modules that specifically need that preprocessor
+By default, modules configured in ``Modules/Setup`` are no longer built with
+``-DPy_BUILD_CORE``. Instead, modules that specifically need that preprocessor
 definition include it in their individual entries.
 
 ..

--- a/Misc/NEWS.d/3.7.0b5.rst
+++ b/Misc/NEWS.d/3.7.0b5.rst
@@ -26,7 +26,7 @@ module_globals is not a dict.
 .. nonce: kqBNzv
 .. section: Core and Builtins
 
-The new `os.posix_spawn` added in 3.7.0b1 was removed as we are still
+The new ``os.posix_spawn`` added in 3.7.0b1 was removed as we are still
 working on what the API should look like.  Expect this in 3.8 instead.
 
 ..
@@ -77,7 +77,7 @@ their body. Based on patch by Inada Naoki.
 .. nonce: UoC319
 .. section: Core and Builtins
 
-Fix a crash in `ctypes.cast()` in case the type argument is a ctypes
+Fix a crash in ``ctypes.cast()`` in case the type argument is a ctypes
 structured data type. Patch by Eryk Sun and Oren Milman.
 
 ..
@@ -254,8 +254,8 @@ default.
 .. nonce: C6Hnd1
 .. section: Library
 
-Do not simplify arguments to `typing.Union`. Now `Union[Manager, Employee]`
-is not simplified to `Employee` at runtime. Such simplification previously
+Do not simplify arguments to ``typing.Union``. Now ``Union[Manager, Employee]``
+is not simplified to ``Employee`` at runtime. Such simplification previously
 caused several bugs and limited possibilities for introspection.
 
 ..
@@ -314,7 +314,7 @@ Patch by Zvi Effron
 .. nonce: taxbVT
 .. section: Library
 
-Fix race condition with `ReadTransport.resume_reading` in Windows proactor
+Fix race condition with ``ReadTransport.resume_reading`` in Windows proactor
 event loop.
 
 ..
@@ -324,7 +324,7 @@ event loop.
 .. nonce: pj2Mbb
 .. section: Library
 
-Fix failure in `typing.get_type_hints()` when ClassVar was provided as a
+Fix failure in ``typing.get_type_hints()`` when ClassVar was provided as a
 string forward reference.
 
 ..
@@ -427,7 +427,7 @@ Donghee Na.
 .. nonce: B56Hc1
 .. section: Library
 
-Fix FD leak in `_SelectorSocketTransport`  Patch by Vlad Starostin.
+Fix FD leak in ``_SelectorSocketTransport``  Patch by Vlad Starostin.
 
 ..
 
@@ -466,7 +466,7 @@ Support arrays >=2GiB in :mod:`ctypes`.  Patch by Segev Finer.
 .. nonce: E5gba1
 .. section: Documentation
 
-Document that `asyncio.wait()` does not cancel its futures on timeout.
+Document that ``asyncio.wait()`` does not cancel its futures on timeout.
 
 ..
 

--- a/Misc/NEWS.d/3.8.0a1.rst
+++ b/Misc/NEWS.d/3.8.0a1.rst
@@ -882,7 +882,7 @@ Update valgrind suppression list to use
 .. nonce: GIOm_8
 .. section: Core and Builtins
 
-Added the "socket" option in the `stat.filemode()` Python implementation to
+Added the "socket" option in the ``stat.filemode()`` Python implementation to
 match the C implementation.
 
 ..
@@ -1271,8 +1271,8 @@ parentheses in the string representation.
 .. nonce: tDBciE
 .. section: Core and Builtins
 
-Added support for the `setpgroup`, `resetids`, `setsigmask`, `setsigdef` and
-`scheduler` parameters of `posix_spawn`. Patch by Pablo Galindo.
+Added support for the ``setpgroup``, ``resetids``, ``setsigmask``, ``setsigdef`` and
+``scheduler`` parameters of ``posix_spawn``. Patch by Pablo Galindo.
 
 ..
 
@@ -1735,7 +1735,7 @@ Patch by Zackery Spytz.
 .. nonce: UoC319
 .. section: Core and Builtins
 
-Fix a crash in `ctypes.cast()` in case the type argument is a ctypes
+Fix a crash in ``ctypes.cast()`` in case the type argument is a ctypes
 structured data type. Patch by Eryk Sun and Oren Milman.
 
 ..
@@ -1745,7 +1745,7 @@ structured data type. Patch by Eryk Sun and Oren Milman.
 .. nonce: jgYsSA
 .. section: Core and Builtins
 
-Fix a crash in `os.utime()` in case of a bad ns argument. Patch by Oren
+Fix a crash in ``os.utime()`` in case of a bad ns argument. Patch by Oren
 Milman.
 
 ..
@@ -2025,7 +2025,7 @@ Fixed help() on metaclasses. Patch by Sanyam Khurana.
 .. nonce: PutiOC
 .. section: Library
 
-Expose ``raise(signum)`` as `raise_signal`
+Expose ``raise(signum)`` as ``raise_signal``
 
 ..
 
@@ -2248,7 +2248,7 @@ the pool is still running.
 .. nonce: abB4BN
 .. section: Library
 
-When a :class:`Mock` instance was used to wrap an object, if `side_effect`
+When a :class:`Mock` instance was used to wrap an object, if ``side_effect``
 is used in one of the mocks of it methods, don't call the original
 implementation and return the result of using the side effect the same way
 that it is done with return_value.
@@ -2377,7 +2377,7 @@ compliant, and will not throw an exception on a trailing '%'.
 .. nonce: vepCSJ
 .. section: Library
 
-The function `platform.popen` has been removed, it was deprecated since
+The function ``platform.popen`` has been removed, it was deprecated since
 Python 3.3: use :func:`os.popen` instead.
 
 ..
@@ -2529,9 +2529,9 @@ Fix incorrect parsing of :class:`_io.IncrementalNewlineDecoder`'s
 .. nonce: CulMN8
 .. section: Library
 
-Remove `StreamReaderProtocol._untrack_reader`. The call to `_untrack_reader`
+Remove ``StreamReaderProtocol._untrack_reader``. The call to ``_untrack_reader``
 is currently performed too soon, causing the protocol to forget about the
-reader before `connection_lost` can run and feed the EOF to the reader.
+reader before ``connection_lost`` can run and feed the EOF to the reader.
 
 ..
 
@@ -2583,8 +2583,8 @@ polling for new events.
 .. nonce: ltSrtr
 .. section: Library
 
-`importlib` no longer logs `wrote <bytecode path>` redundantly after
-`(created|could not create) <bytecode path>` is already logged. Patch by
+``importlib`` no longer logs ``wrote <bytecode path>`` redundantly after
+``(created|could not create) <bytecode path>`` is already logged. Patch by
 Quentin Agren.
 
 ..
@@ -2717,7 +2717,7 @@ Use :func:`socket.CMSG_SPACE` to calculate ancillary data size instead of
 .. nonce: rWBb43
 .. section: Library
 
-The `mailbox.mbox.get_string` function *from_* parameter can now
+The ``mailbox.mbox.get_string`` function *from_* parameter can now
 successfully be set to a non-default value.
 
 ..
@@ -2799,7 +2799,7 @@ children which are instances of ``Element`` subclasses.
 .. nonce: z2FbOp
 .. section: Library
 
-:class:`smtplib.SMTP` objects now always have a `sock` attribute present
+:class:`smtplib.SMTP` objects now always have a ``sock`` attribute present
 
 ..
 
@@ -2914,7 +2914,7 @@ Fix inspect module polluted ``sys.modules`` when parsing
 .. nonce: Wo2PoJ
 .. section: Library
 
-Add `mtime` argument to `gzip.compress` for reproducible output. Patch by
+Add ``mtime`` argument to ``gzip.compress`` for reproducible output. Patch by
 Guo Ci Teo.
 
 ..
@@ -3019,7 +3019,7 @@ argument.  Patch by Andrés Delfino.
 .. nonce: rSPBW9
 .. section: Library
 
-In :class:`QueueHandler`, clear `exc_text` from :class:`LogRecord` to
+In :class:`QueueHandler`, clear ``exc_text`` from :class:`LogRecord` to
 prevent traceback from being written twice.
 
 ..
@@ -3060,8 +3060,8 @@ and will be removed in future Python versions.
 .. nonce: CUE8LU
 .. section: Library
 
-Add deprecation warning when `loop` is used in methods: `asyncio.sleep`,
-`asyncio.wait` and `asyncio.wait_for`.
+Add deprecation warning when ``loop`` is used in methods: ``asyncio.sleep``,
+``asyncio.wait`` and ``asyncio.wait_for``.
 
 ..
 
@@ -3191,7 +3191,7 @@ the stream is deleted (garbage collected) without ``close()`` call.
 .. nonce: 3IPIH5
 .. section: Library
 
-`Enum._missing_`:  raise `ValueError` if None returned and `TypeError` if
+``Enum._missing_``:  raise ``ValueError`` if None returned and ``TypeError`` if
 non-member is returned.
 
 ..
@@ -3302,8 +3302,8 @@ issues on Windows.
 .. nonce: xL7-kG
 .. section: Library
 
-Fix possible mojibake in the error message of `pwd.getpwnam` and
-`grp.getgrnam` using string representation because of invisible characters
+Fix possible mojibake in the error message of ``pwd.getpwnam`` and
+``grp.getgrnam`` using string representation because of invisible characters
 or trailing whitespaces. Patch by William Grzybowski.
 
 ..
@@ -4575,8 +4575,8 @@ OpenSSL 1.1.1
 .. nonce: nzQgD8
 .. section: Library
 
-Release GIL on `grp.getgrnam`, `grp.getgrgid`, `pwd.getpwnam` and
-`pwd.getpwuid` if reentrant variants of these functions are available. Patch
+Release GIL on ``grp.getgrnam``, ``grp.getgrgid``, ``pwd.getpwnam`` and
+``pwd.getpwuid`` if reentrant variants of these functions are available. Patch
 by William Grzybowski.
 
 ..
@@ -4656,8 +4656,8 @@ default.
 .. nonce: C6Hnd1
 .. section: Library
 
-Do not simplify arguments to `typing.Union`. Now `Union[Manager, Employee]`
-is not simplified to `Employee` at runtime. Such simplification previously
+Do not simplify arguments to ``typing.Union``. Now ``Union[Manager, Employee]``
+is not simplified to ``Employee`` at runtime. Such simplification previously
 caused several bugs and limited possibilities for introspection.
 
 ..
@@ -4736,7 +4736,7 @@ Patch by Zvi Effron
 .. nonce: taxbVT
 .. section: Library
 
-Fix race condition with `ReadTransport.resume_reading` in Windows proactor
+Fix race condition with ``ReadTransport.resume_reading`` in Windows proactor
 event loop.
 
 ..
@@ -4746,7 +4746,7 @@ event loop.
 .. nonce: pj2Mbb
 .. section: Library
 
-Fix failure in `typing.get_type_hints()` when ClassVar was provided as a
+Fix failure in ``typing.get_type_hints()`` when ClassVar was provided as a
 string forward reference.
 
 ..
@@ -5150,7 +5150,7 @@ instead of a wrapper function for exit callbacks.
 .. nonce: B56Hc1
 .. section: Library
 
-Fix FD leak in `_SelectorSocketTransport`  Patch by Vlad Starostin.
+Fix FD leak in ``_SelectorSocketTransport``  Patch by Vlad Starostin.
 
 ..
 
@@ -5777,7 +5777,7 @@ helper methods that can be used instead ``_dump_registry``,
 .. nonce: bvHDOc
 .. section: Library
 
-Fixed `asyncio.Condition` issue which silently ignored cancellation after
+Fixed ``asyncio.Condition`` issue which silently ignored cancellation after
 notifying and cancelling a conditional lock. Patch by Bar Harel.
 
 ..
@@ -5992,7 +5992,7 @@ Add Ttk spinbox widget to :mod:`tkinter.ttk`.  Patch by Alan D Moore.
 .. nonce: flC-dE
 .. section: Library
 
-:mod:`profile` CLI accepts `-m module_name` as an alternative to script
+:mod:`profile` CLI accepts ``-m module_name`` as an alternative to script
 path.
 
 ..
@@ -6147,8 +6147,8 @@ Support arrays >=2GiB in :mod:`ctypes`.  Patch by Segev Finer.
 .. nonce: pDsFJl
 .. section: Library
 
-Removed support of arguments in `tkinter.ttk.Treeview.selection`. It was
-deprecated in 3.6.  Use specialized methods like `selection_set` for
+Removed support of arguments in ``tkinter.ttk.Treeview.selection``. It was
+deprecated in 3.6.  Use specialized methods like ``selection_set`` for
 changing the selection.
 
 ..
@@ -6224,7 +6224,7 @@ imported from ``typing`` directly.
 .. nonce: 2eVOYS
 .. section: Documentation
 
-Fix the documentation about an unexisting `f_restricted` attribute in the
+Fix the documentation about an unexisting ``f_restricted`` attribute in the
 frame object. Patch by Stéphane Wirtel
 
 ..
@@ -6311,7 +6311,7 @@ Document how passing coroutines to asyncio.wait() can be confusing.
 .. nonce: p9PoYv
 .. section: Documentation
 
-Make clear that ``==`` operator sometimes is equivalent to `is`. The ``<``,
+Make clear that ``==`` operator sometimes is equivalent to ``is``. The ``<``,
 ``<=``, ``>`` and ``>=`` operators are only defined where they make sense.
 
 ..
@@ -6409,7 +6409,7 @@ Improve the documentation of :func:`asyncio.open_connection`,
 .. nonce: E5gba1
 .. section: Documentation
 
-Document that `asyncio.wait()` does not cancel its futures on timeout.
+Document that ``asyncio.wait()`` does not cancel its futures on timeout.
 
 ..
 
@@ -6660,7 +6660,7 @@ Stéphane Wirtel
 .. nonce: w1m_8r
 .. section: Documentation
 
-Improve docstrings for `pathlib.PurePath` subclasses.
+Improve docstrings for ``pathlib.PurePath`` subclasses.
 
 ..
 
@@ -6997,7 +6997,7 @@ Use 3072 RSA keys and SHA-256 signature for test certs and keys.
 .. nonce: H8fCGa
 .. section: Tests
 
-Remove special condition for AIX in `test_subprocess.test_undecodable_env`
+Remove special condition for AIX in ``test_subprocess.test_undecodable_env``
 
 ..
 
@@ -7006,7 +7006,7 @@ Remove special condition for AIX in `test_subprocess.test_undecodable_env`
 .. nonce: IsRDPB
 .. section: Tests
 
-Fix `test_utf8_mode.test_cmd_line` for AIX
+Fix ``test_utf8_mode.test_cmd_line`` for AIX
 
 ..
 
@@ -7034,9 +7034,9 @@ Fix ftplib test for TLS 1.3 by reading from data socket.
 .. nonce: g7TwYm
 .. section: Tests
 
-Fix `test_socket` on AIX 6.1 and later IPv6 zone id supports only
-supported by inet_pton6_zone() Switch to runtime-based platform.system() to
-establish current platform  rather than build-time based sys.platform()
+Fix ``test_socket`` on AIX 6.1 and later IPv6 zone id supports only
+supported by ``inet_pton6_zone()``. Switch to runtime-based ``platform.system()`` to
+establish current platform rather than build-time based ``sys.platform()``
 
 ..
 
@@ -7172,8 +7172,8 @@ Fix failing ``test_asyncio`` on macOS 10.12.2+ due to transport of
 .. nonce: IKDsqu
 .. section: Tests
 
-Making sure the `SMTPUTF8SimTests` class of tests gets run in
-test_smtplib.py.
+Making sure the ``SMTPUTF8SimTests`` class of tests gets run in
+``test_smtplib.py``.
 
 ..
 
@@ -7282,7 +7282,7 @@ CFLAGS to build third-party C extensions through distutils.
 .. nonce: XZTttb
 .. section: Build
 
-Fix a compiler error when statically linking `pyexpat` in `Modules/Setup`.
+Fix a compiler error when statically linking ``pyexpat`` in ``Modules/Setup``.
 
 ..
 
@@ -7520,8 +7520,8 @@ suffixes).
 .. nonce: o7G_UO
 .. section: Build
 
-By default, modules configured in `Modules/Setup` are no longer built with
-`-DPy_BUILD_CORE`. Instead, modules that specifically need that preprocessor
+By default, modules configured in ``Modules/Setup`` are no longer built with
+``-DPy_BUILD_CORE``. Instead, modules that specifically need that preprocessor
 definition include it in their individual entries.
 
 ..
@@ -8090,7 +8090,7 @@ Fix imports in idlelib.window.
 .. nonce: QEaANl
 .. section: IDLE
 
-Proper format `calltip` when the function has no docstring.
+Proper format ``calltip`` when the function has no docstring.
 
 ..
 

--- a/Misc/NEWS.d/3.8.0a2.rst
+++ b/Misc/NEWS.d/3.8.0a2.rst
@@ -4,7 +4,7 @@
 .. release date: 2019-02-25
 .. section: Core and Builtins
 
-Raise a :exc:`SyntaxError` when assigning a value to `__debug__` with the
+Raise a :exc:`SyntaxError` when assigning a value to ``__debug__`` with the
 Assignment Operator. Contributed by Stéphane Wirtel and Pablo Galindo.
 
 ..

--- a/Misc/NEWS.d/3.8.0a3.rst
+++ b/Misc/NEWS.d/3.8.0a3.rst
@@ -324,7 +324,7 @@ Raise ModuleNotFoundError in pyclbr when a module can't be found. Thanks to
 .. nonce: MDXLw6
 .. section: Library
 
-Switch the default format used for writing tars with mod:`tarfile` to the
+Switch the default format used for writing tars with :mod:`tarfile` to the
 modern POSIX.1-2001 pax standard, from the vendor-specific GNU. Contributed
 by C.A.M. Gerlach.
 
@@ -473,7 +473,7 @@ path string.
 .. nonce: NA_rXa
 .. section: Library
 
-Ensure custom :func:`warnings.formatwarning` function can receive `line` as
+Ensure custom :func:`warnings.formatwarning` function can receive ``line`` as
 positional argument. Based on patch by Tashrif Billah.
 
 ..
@@ -533,10 +533,10 @@ Kumar Akshay.
 .. nonce: yffB3F
 .. section: Library
 
-`pprint.pp` has been added to pretty-print objects with dictionary keys
+``pprint.pp`` has been added to pretty-print objects with dictionary keys
 being sorted with their insertion order by default. Parameter *sort_dicts*
-has been added to `pprint.pprint`, `pprint.pformat` and
-`pprint.PrettyPrinter`. Contributed by Rémi Lapeyre.
+has been added to ``pprint.pprint``, ``pprint.pformat`` and
+``pprint.PrettyPrinter``. Contributed by Rémi Lapeyre.
 
 ..
 

--- a/Misc/NEWS.d/3.8.0a4.rst
+++ b/Misc/NEWS.d/3.8.0a4.rst
@@ -168,7 +168,7 @@ decoder.
 Changing ``dict`` keys during iteration of the dict itself, ``keys()``,
 ``values()``, or ``items()`` will now be detected in certain corner cases
 where keys are deleted/added so that the number of keys isn't changed. A
-`RuntimeError` will be raised after ``len(dict)`` iterations. Contributed by
+``RuntimeError`` will be raised after ``len(dict)`` iterations. Contributed by
 Thomas Perl.
 
 ..
@@ -580,7 +580,7 @@ is a dictionary.
 .. section: Library
 
 Calling ``stop()`` on an unstarted or stopped :func:`unittest.mock.patch`
-object will now return `None` instead of raising :exc:`RuntimeError`, making
+object will now return ``None`` instead of raising :exc:`RuntimeError`, making
 the method idempotent. Patch by Karthikeyan Singaravelan.
 
 ..
@@ -609,9 +609,9 @@ Add time module support and fix test_time faiures for VxWorks.
 .. nonce: i2Z1XR
 .. section: Library
 
-Added support for keyword arguments `default_namespace` and
-`xml_declaration` in functions ElementTree.tostring() and
-ElementTree.tostringlist().
+Added support for keyword arguments ``default_namespace`` and
+``xml_declaration`` in functions ``ElementTree.tostring()`` and
+``ElementTree.tostringlist()``.
 
 ..
 
@@ -744,7 +744,7 @@ Remove stale unix datagram socket before binding
 .. nonce: _4Q_bi
 .. section: Library
 
-Implemented Happy Eyeballs in `asyncio.create_connection()`. Added two new
+Implemented Happy Eyeballs in ``asyncio.create_connection()``. Added two new
 arguments, *happy_eyeballs_delay* and *interleave*, to specify Happy
 Eyeballs behavior.
 
@@ -1405,7 +1405,7 @@ only present in alpha releases of Python 3.8. Patch by Paul Ganssle.
 .. nonce: wpbWeb
 .. section: C API
 
-Modify ``PyObject_Init`` to correctly increase the refcount of heap-
-allocated Type objects. Also fix the refcounts of the heap-allocated types
+Modify ``PyObject_Init`` to correctly increase the refcount of heap-allocated
+Type objects. Also fix the refcounts of the heap-allocated types
 that were either doing this manually or not decreasing the type's refcount
 in tp_dealloc

--- a/Misc/NEWS.d/3.8.0b1.rst
+++ b/Misc/NEWS.d/3.8.0b1.rst
@@ -146,8 +146,8 @@ constant expressions inside the f-string).
 .. nonce: VeVvhJ
 .. section: Core and Builtins
 
-The `bytes.hex`, `bytearray.hex`, and `memoryview.hex` methods as well as
-the `binascii.hexlify` and `b2a_hex` functions now have the ability to
+The ``bytes.hex``, ``bytearray.hex``, and ``memoryview.hex`` methods as well as
+the ``binascii.hexlify`` and ``b2a_hex`` functions now have the ability to
 include an optional separator between hex bytes.  This functionality was
 inspired by MicroPython's hexlify implementation.
 
@@ -198,8 +198,8 @@ any error.
 .. nonce: QwLa3P
 .. section: Core and Builtins
 
-Only accept text after `# type: ignore` if the first character is ASCII.
-This is to disallow things like `# type: ignoreé`.
+Only accept text after ``# type: ignore`` if the first character is ASCII.
+This is to disallow things like ``# type: ignoreé``.
 
 ..
 
@@ -208,9 +208,9 @@ This is to disallow things like `# type: ignoreé`.
 .. nonce: EFRHZ3
 .. section: Core and Builtins
 
-Store text appearing after a `# type: ignore` comment in the AST. For
-example a type ignore like `# type: ignore[E1000]` will have the string
-`"[E1000]"` stored in its AST node.
+Store text appearing after a ``# type: ignore`` comment in the AST. For
+example a type ignore like ``# type: ignore[E1000]`` will have the string
+``"[E1000]"`` stored in its AST node.
 
 ..
 
@@ -414,7 +414,7 @@ Fix incorrect use of ``%p`` in format strings. Patch by Zackery Spytz.
 .. nonce: RO20OV
 .. section: Core and Builtins
 
-builtins.help() now prefixes `async` for async functions
+``builtins.help()`` now prefixes ``async`` for async functions.
 
 ..
 
@@ -443,7 +443,7 @@ Added fix for broken symlinks in combination with pathlib
 .. section: Core and Builtins
 
 Added new trashcan macros to deal with a double deallocation that could
-occur when the `tp_dealloc` of a subclass calls the `tp_dealloc` of a base
+occur when the ``tp_dealloc`` of a subclass calls the ``tp_dealloc`` of a base
 class and that base class uses the trashcan mechanism. Patch by Jeroen
 Demeyer.
 
@@ -768,7 +768,7 @@ Taskaya
 .. nonce: u7cxu7
 .. section: Library
 
-PDB command `args` now  display positional only arguments. Patch contributed
+PDB command ``args`` now  display positional only arguments. Patch contributed
 by Rémi Lapeyre.
 
 ..
@@ -778,7 +778,7 @@ by Rémi Lapeyre.
 .. nonce: JkZORP
 .. section: Library
 
-PDB command `args` now  display keyword only arguments. Patch contributed by
+PDB command ``args`` now  display keyword only arguments. Patch contributed by
 Rémi Lapeyre.
 
 ..
@@ -799,7 +799,7 @@ Add missing names to ``typing.__all__``: ``ChainMap``, ``ForwardRef``,
 .. section: Library
 
 Add SupportsIndex protocol to the typing module to allow type checking to
-detect classes that can be passed to `hex()`, `oct()` and `bin()`.
+detect classes that can be passed to ``hex()``, ``oct()`` and ``bin()``.
 
 ..
 
@@ -1023,10 +1023,10 @@ reading metadata from third-party packages.
 .. nonce: iigeqk
 .. section: Library
 
-When using `type_comments=True` in `ast.parse`, treat `# type: ignore`
+When using ``type_comments=True`` in ``ast.parse``, treat ``# type: ignore``
 followed by a non-alphanumeric character and then arbitrary text as a type
 ignore, instead of requiring nothing but whitespace or another comment. This
-is to permit formations such as `# type: ignore[E1000]`.
+is to permit formations such as ``# type: ignore[E1000]``.
 
 ..
 
@@ -1066,7 +1066,7 @@ exposed to the user.  Patch by Aviv Palivoda.
 .. nonce: WK8Y-k
 .. section: Library
 
-In `shutil.copystat()`, first copy extended file attributes and then file
+In ``shutil.copystat()``, first copy extended file attributes and then file
 permissions, since extended attributes can only be set on the destination
 while it is still writeable.
 
@@ -1120,7 +1120,7 @@ add_done_callback correctly when the Future has already completed.
 .. nonce: 4payXb
 .. section: Library
 
-Limit `max_workers` in `ProcessPoolExecutor` to 61 to work around a
+Limit ``max_workers`` in ``ProcessPoolExecutor`` to 61 to work around a
 WaitForMultipleObjects limitation.
 
 ..
@@ -1676,7 +1676,7 @@ documentation covers it independently.
 .. nonce: 6hg6J8
 .. section: Documentation
 
-Add detail to the documentation on the `pty.spawn` function.
+Add detail to the documentation on the ``pty.spawn`` function.
 
 ..
 
@@ -1704,7 +1704,7 @@ Added the context variable in glossary.
 .. nonce: Q7s2FB
 .. section: Documentation
 
-Clarify that `copy()` is not part of the `MutableSequence` ABC.
+Clarify that ``copy()`` is not part of the ``MutableSequence`` ABC.
 
 ..
 
@@ -1713,7 +1713,7 @@ Clarify that `copy()` is not part of the `MutableSequence` ABC.
 .. nonce: jalAaQ
 .. section: Documentation
 
-Make `codecs.StreamRecoder.writelines` take a list of bytes.
+Make ``codecs.StreamRecoder.writelines`` take a list of bytes.
 
 ..
 

--- a/Misc/NEWS.d/3.9.0a1.rst
+++ b/Misc/NEWS.d/3.9.0a1.rst
@@ -1304,7 +1304,7 @@ parameter. Patch by Pablo Galindo.
 .. nonce: J12cWT
 .. section: Library
 
-Fixed `hmac.new` and `hmac.HMAC` to raise TypeError instead of ValueError
+Fixed ``hmac.new`` and ``hmac.HMAC`` to raise TypeError instead of ValueError
 when the digestmod parameter, now required in 3.8, is omitted.  Also
 clarified the hmac module documentation and docstrings.
 
@@ -1478,7 +1478,7 @@ Removes _AwaitEvent from AsyncMock.
 .. section: Library
 
 Allow the rare code that wants to send invalid http requests from the
-`http.client` library a way to do so.  The fixes for bpo-30458 led to
+``http.client`` library a way to do so.  The fixes for bpo-30458 led to
 breakage for some projects that were relying on this ability to test their
 own behavior in the face of bad requests.
 
@@ -1813,9 +1813,9 @@ Update importlib.metadata with changes from `importlib_metadata 0.21
 .. nonce: 8zn2o3
 .. section: Library
 
-Remove `__code__` check in AsyncMock that incorrectly evaluated function
-specs as async objects but failed to evaluate classes with `__await__` but
-no `__code__` attribute defined as async objects.
+Remove ``__code__`` check in AsyncMock that incorrectly evaluated function
+specs as async objects but failed to evaluate classes with ``__await__`` but
+no ``__code__`` attribute defined as async objects.
 
 ..
 
@@ -1976,11 +1976,11 @@ thread at a time.
 .. nonce: kP-n4L
 .. section: Library
 
-Subscripts to the `unittest.mock.call` objects now receive the same chaining
+Subscripts to the ``unittest.mock.call`` objects now receive the same chaining
 mechanism as any other custom attributes, so that the following usage no
-longer raises a `TypeError`:
+longer raises a ``TypeError``:
 
-call().foo().__getitem__('bar')
+``call().foo().__getitem__('bar')``
 
 Patch by blhsing
 
@@ -2210,7 +2210,7 @@ Add C fastpath for statistics.NormalDist.inv_cdf() Patch by Donghee Na
 .. nonce: Ene6L-
 .. section: Library
 
-Remove the deprecated method `threading.Thread.isAlive()`. Patch by Donghee
+Remove the deprecated method ``threading.Thread.isAlive()``. Patch by Donghee
 Na.
 
 ..
@@ -2260,8 +2260,8 @@ directories are added and that duplicates are excluded.
 .. nonce: xfvdb_
 .. section: Library
 
-Renamed and documented `test.bytecode_helper` as
-`test.support.bytecode_helper`. Patch by Joannah Nanjekye.
+Renamed and documented ``test.bytecode_helper`` as
+``test.support.bytecode_helper``. Patch by Joannah Nanjekye.
 
 ..
 
@@ -2289,8 +2289,8 @@ many small lines are passed. Patch by Sergey Fedoseev.
 .. nonce: ycbL2z
 .. section: Library
 
-`ensurepip` now uses `importlib.resources.read_binary()` to read data
-instead of `pkgutil.get_data()`. Patch by Joannah Nanjekye.
+``ensurepip`` now uses ``importlib.resources.read_binary()`` to read data
+instead of ``pkgutil.get_data()``. Patch by Joannah Nanjekye.
 
 ..
 
@@ -2524,8 +2524,8 @@ Make internal attributes for statistics.NormalDist() private.
 .. nonce: S5am28
 .. section: Library
 
-Fix `NonCallableMock._call_matcher` returning tuple instead of `_Call`
-object when `self._spec_signature` exists. Patch by Elizabeth Uselton
+Fix ``NonCallableMock._call_matcher`` returning tuple instead of ``_Call``
+object when ``self._spec_signature`` exists. Patch by Elizabeth Uselton
 
 ..
 
@@ -2673,7 +2673,7 @@ which had a too large value in some situations.
 .. nonce: 0i1MR-
 .. section: Library
 
-Fixes a possible hang when using a timeout on `subprocess.run()` while
+Fixes a possible hang when using a timeout on ``subprocess.run()`` while
 capturing output.  If the child process spawned its own children or
 otherwise connected its stdout or stderr handles with another process, we
 could hang after the timeout was reached and our child was killed when
@@ -2708,8 +2708,8 @@ The distutils ``bdist_wininst`` command is deprecated in Python 3.8, use
 .. nonce: O53a5S
 .. section: Library
 
-When `Enum.__str__` is overridden in a derived class, the override will be
-used by `Enum.__format__` regardless of whether mixin classes are present.
+When ``Enum.__str__`` is overridden in a derived class, the override will be
+used by ``Enum.__format__`` regardless of whether mixin classes are present.
 
 ..
 
@@ -3195,9 +3195,9 @@ Remove ``Enum._convert`` method, deprecated in 3.8.
 .. nonce: TTzHxj
 .. section: Library
 
-`argparse._ActionsContainer.add_argument` now throws error, if someone
+``argparse._ActionsContainer.add_argument`` now throws error, if someone
 accidentally pass FileType class object instead of instance of FileType as
-`type` argument
+``type`` argument.
 
 ..
 
@@ -3458,7 +3458,7 @@ Patch contributed by Rémi Lapeyre.
 .. section: Library
 
 Fixes a bug in :mod:`!cgi` module when a multipart/form-data request has no
-`Content-Length` header.
+``Content-Length`` header.
 
 ..
 
@@ -3566,8 +3566,8 @@ source argument. Patch by Emily Morehouse and Maxwell "5.13b" McKinnon.
 .. nonce: 0stF0u
 .. section: Library
 
-Added __format__ to IPv4 and IPv6 classes.  Always outputs a fully zero-
-padded string. Supports b/x/n modifiers (bin/hex/native format).  Native
+Added ``__format__`` to IPv4 and IPv6 classes.  Always outputs a fully
+zero-padded string. Supports b/x/n modifiers (bin/hex/native format).  Native
 format for IPv4 is bin, native format for IPv6 is hex. Also supports '#' and
 '_' modifiers.
 
@@ -3789,7 +3789,7 @@ verify the maildir folder layout correctness. Patch by Sviatoslav Sydorenko.
 .. nonce: 7tiFR-
 .. section: Documentation
 
-Fix `importlib` examples to insert any newly created modules via
+Fix ``importlib`` examples to insert any newly created modules via
 importlib.util.module_from_spec() immediately into sys.modules instead of
 after calling loader.exec_module().
 
@@ -3888,7 +3888,7 @@ Make C-API docs clear about what the "main" interpreter is.
 .. nonce: Iqiqtm
 .. section: Documentation
 
-The documentation for decimal string formatting using the `:g` specifier has
+The documentation for decimal string formatting using the ``:g`` specifier has
 been updated to reflect the correct exponential notation cutoff point.
 Original patch contributed by Tuomas Suutari.
 
@@ -4450,8 +4450,8 @@ Fix _hashlib build when Blake2 is disabled, but OpenSSL supports it.
 .. nonce: buCO84
 .. section: Build
 
-Misc/python-config.in now uses `getvar()` for all still existing
-`sysconfig.get_config_var()` calls. Patch by Joannah Nanjekye.
+Misc/python-config.in now uses ``getvar()`` for all still existing
+``sysconfig.get_config_var()`` calls. Patch by Joannah Nanjekye.
 
 ..
 

--- a/Misc/NEWS.d/3.9.0a2.rst
+++ b/Misc/NEWS.d/3.9.0a2.rst
@@ -403,7 +403,7 @@ locale encoding is not UTF-8.
 Prevent UnboundLocalError to pop up in parse_message_id.
 
 parse_message_id() was improperly using a token defined inside an exception
-handler, which was raising `UnboundLocalError` on parsing an invalid value.
+handler, which was raising ``UnboundLocalError`` on parsing an invalid value.
 Patch by Claudiu Popa.
 
 ..
@@ -444,12 +444,12 @@ random.choices() now raises a ValueError when all the weights are zero.
 Raise pickle.UnpicklingError when loading an item from memo for invalid
 input.
 
-The previous code was raising a `KeyError` for both the Python and C
+The previous code was raising a ``KeyError`` for both the Python and C
 implementation. This was caused by the specified index of an invalid input
 which did not exist in the memo structure, where the pickle stores what
-objects it has seen. The malformed input would have caused either a `BINGET`
-or `LONG_BINGET` load from the memo, leading to a `KeyError` as the
-determined index was bogus. Patch by Claudiu Popa
+objects it has seen. The malformed input would have caused either a ``BINGET``
+or ``LONG_BINGET`` load from the memo, leading to a ``KeyError`` as the
+determined index was bogus. Patch by Claudiu Popa.
 
 ..
 
@@ -458,7 +458,7 @@ determined index was bogus. Patch by Claudiu Popa
 .. nonce: iKx23z
 .. section: Library
 
-Calling func:`shutil.copytree` to copy a directory tree from one directory
+Calling func:``shutil.copytree`` to copy a directory tree from one directory
 to another subdirectory resulted in an endless loop and a RecursionError. A
 fix was added to consume an iterator and create the list of the entries to
 be copied, avoiding the recursion for newly created directories. Patch by
@@ -685,7 +685,7 @@ added.
 .. section: Documentation
 
 Update documentation to state that to activate virtual environments under
-fish one should use `source`, not `.` as documented at
+fish one should use ``source``, not ``.`` as documented at
 https://fishshell.com/docs/current/cmds/source.html.
 
 ..
@@ -884,7 +884,7 @@ Add support for building and releasing Windows ARM64 packages.
 
 Fixed a crash on OSX dynamic builds that occurred when re-initializing the
 posix module after a Py_Finalize if the environment had changed since the
-previous `import posix`. Patch by Benoît Hudson.
+previous ``import posix``. Patch by Benoît Hudson.
 
 ..
 

--- a/Misc/NEWS.d/3.9.0a3.rst
+++ b/Misc/NEWS.d/3.9.0a3.rst
@@ -266,8 +266,8 @@ The :func:`os.unsetenv` function is now also available on Windows.
 .. nonce: D2tSXk
 .. section: Library
 
-Fixed a regression with the `ignore` callback of :func:`shutil.copytree`.
-The argument types are now str and List[str] again.
+Fixed a regression with the ``ignore`` callback of :func:`shutil.copytree`.
+The argument types are now ``str`` and ``List[str]`` again.
 
 ..
 
@@ -507,8 +507,8 @@ for examples of :class:`!NNTP` news reader server and nntplib tests.
 .. nonce: ihRT1z
 .. section: Library
 
-Proxy the `SimpleHTTPRequestHandler.guess_type` to `mimetypes.guess_type` so
-the `mimetypes.init` is called lazily to avoid unnecessary costs when
+Proxy the ``SimpleHTTPRequestHandler.guess_type`` to ``mimetypes.guess_type`` so
+the ``mimetypes.init`` is called lazily to avoid unnecessary costs when
 :mod:`http.server` module is imported.
 
 ..
@@ -547,10 +547,10 @@ all options.  Giovanni Lombardo contributed part of the patch.
 .. nonce: nzwGyG
 .. section: Library
 
-If an exception were to be thrown in `Logger.isEnabledFor` (say, by asyncio
-timeouts or stopit) , the `logging` global lock may not be released
+If an exception were to be thrown in ``Logger.isEnabledFor`` (say, by asyncio
+timeouts or stopit) , the ``logging`` global lock may not be released
 appropriately, resulting in deadlock.  This change wraps that block of code
-with `try...finally` to ensure the lock is released.
+with ``try...finally`` to ensure the lock is released.
 
 ..
 
@@ -571,7 +571,7 @@ new task spawning before exception raising.
 .. section: Library
 
 Correctly parenthesize filter-based statements that contain lambda
-expressions in mod:`!lib2to3`. Patch by Donghee Na.
+expressions in :mod:`!lib2to3`. Patch by Donghee Na.
 
 ..
 
@@ -732,9 +732,9 @@ different process.
 .. nonce: beZ0Sk
 .. section: Library
 
-Removes trailing space in formatted currency with `international=True` and a
-locale with symbol following value. E.g. `locale.currency(12.34,
-international=True)` returned `'12,34 EUR '` instead of `'12,34 EUR'`.
+Removes trailing space in formatted currency with ``international=True`` and a
+locale with symbol following value. E.g. ``locale.currency(12.34,
+international=True)`` returned ``'12,34 EUR '`` instead of ``'12,34 EUR'``.
 
 ..
 
@@ -835,7 +835,7 @@ functions are now required to build Python.
 .. nonce: aBmj13
 .. section: Build
 
-Updated the documentation in `./configure --help` to show default values,
+Updated the documentation in ``./configure --help`` to show default values,
 reference documentation where required and add additional explanation where
 needed.
 

--- a/Misc/NEWS.d/3.9.0a4.rst
+++ b/Misc/NEWS.d/3.9.0a4.rst
@@ -4,8 +4,8 @@
 .. release date: 2020-02-25
 .. section: Security
 
-Add audit events to functions in `fcntl`, `msvcrt`, `os`, `resource`,
-`shutil`, `signal` and `syslog`.
+Add audit events to functions in ``fcntl``, ``msvcrt``, ``os``, ``resource``,
+``shutil``, ``signal`` and ``syslog``.
 
 ..
 
@@ -81,9 +81,9 @@ Fix regression caused by fix for bpo-39386, that prevented calling
 .. nonce: itNmC0
 .. section: Core and Builtins
 
-Change the ending column offset of `Attribute` nodes constructed in
-`ast_for_dotted_name` to point at the end of the current node and not at the
-end of the last `NAME` node.
+Change the ending column offset of ``Attribute`` nodes constructed in
+``ast_for_dotted_name`` to point at the end of the current node and not at the
+end of the last ``NAME`` node.
 
 ..
 
@@ -269,7 +269,7 @@ codec.
 .. nonce: qiubSp
 .. section: Library
 
-Remove obsolete check for `__args__` in bdb.Bdb.format_stack_entry.
+Remove obsolete check for ``__args__`` in ``bdb.Bdb.format_stack_entry``.
 
 ..
 
@@ -599,7 +599,7 @@ default return values. Patch by Karthikeyan Singaravelan.
 .. nonce: udRSWE
 .. section: Library
 
-`inspect.Signature.parameters` and `inspect.BoundArguments.arguments` are
+``inspect.Signature.parameters`` and ``inspect.BoundArguments.arguments`` are
 now dicts instead of OrderedDicts. Patch contributed by Rémi Lapeyre.
 
 ..
@@ -619,9 +619,9 @@ multiprocessing.Process.
 .. nonce: e0C5dF
 .. section: Library
 
-* Add `lazycache` function to `__all__`.
-* Use `dict.clear` to clear the cache.
-* Refactoring `getline` function and `checkcache` function.
+* Add ``lazycache`` function to ``__all__``.
+* Use ``dict.clear`` to clear the cache.
+* Refactoring ``getline`` function and ``checkcache`` function.
 
 ..
 

--- a/Misc/NEWS.d/3.9.0a5.rst
+++ b/Misc/NEWS.d/3.9.0a5.rst
@@ -691,7 +691,7 @@ Fix AttributeError when calling get_stack on a PyAsyncGenObject Task
 .. section: Library
 
 The :func:`compileall.compile_dir` function's *ddir* parameter and the
-compileall command line flag `-d` no longer write the wrong pathname to the
+compileall command line flag ``-d`` no longer write the wrong pathname to the
 generated pyc file for submodules beneath the root of the directory tree
 being compiled.  This fixes a regression introduced with Python 3.5.
 

--- a/Misc/NEWS.d/3.9.0a6.rst
+++ b/Misc/NEWS.d/3.9.0a6.rst
@@ -59,8 +59,8 @@ anything that depends on it.
 .. section: Core and Builtins
 
 Fix the tokenizer to display the correct error message, when there is a
-SyntaxError on the last input character and no newline follows. It used to
-be `unexpected EOF while parsing`, while it should be `invalid syntax`.
+``SyntaxError`` on the last input character and no newline follows. It used to
+be ``unexpected EOF while parsing``, while it should be ``invalid syntax``.
 
 ..
 
@@ -79,7 +79,7 @@ evaluation for annotations activated. Patch by Batuhan Taskaya.
 .. nonce: vXPze5
 .. section: Core and Builtins
 
-Report a specialized error message, `invalid string prefix`, when the
+Report a specialized error message, ``invalid string prefix``, when the
 tokenizer encounters a string with an invalid prefix.
 
 ..
@@ -434,7 +434,7 @@ for the correspondent concrete type (``list`` in this case).
 .. nonce: ux8FUr
 .. section: Library
 
-func:`inspect.getdoc` no longer returns docstring inherited from the type of
+:func:`inspect.getdoc` no longer returns docstring inherited from the type of
 the object or from parent class if it is a class if it is not defined in the
 object itself. In :mod:`pydoc` the documentation string is now shown not
 only for class, function, method etc, but for any object that has its own
@@ -504,7 +504,7 @@ extension. This allows the use of functions such as ``json_object``.
 .. nonce: 4EcyIN
 .. section: Library
 
-Wait in `KqueueSelector.select` when no fds are registered
+Wait in ``KqueueSelector.select`` when no fds are registered
 
 ..
 
@@ -701,7 +701,7 @@ per header: use the realm of the first Basic challenge.
 .. section: Library
 
 Removed daemon threads from :mod:`concurrent.futures` by adding an internal
-`threading._register_atexit()`, which calls registered functions prior to
+``threading._register_atexit()``, which calls registered functions prior to
 joining all non-daemon threads. This allows for compatibility with
 subinterpreters, which don't support daemon threads.
 
@@ -781,9 +781,9 @@ Added :pep:`584` operators to :class:`weakref.WeakKeyDictionary`.
 .. nonce: 56Yokh
 .. section: Library
 
-Fix linear runtime behaviour of the `__getitem__` and `__setitem__` methods
+Fix linear runtime behaviour of the ``__getitem__`` and ``__setitem__`` methods
 in :class:`multiprocessing.shared_memory.ShareableList`. This avoids
-quadratic performance when iterating a `ShareableList`. Patch by Thomas
+quadratic performance when iterating a ``ShareableList``. Patch by Thomas
 Krennwallner.
 
 ..
@@ -793,9 +793,9 @@ Krennwallner.
 .. nonce: AxXZNz
 .. section: Library
 
-Remove undocumented support for *closing* a `pathlib.Path` object via its
+Remove undocumented support for *closing* a ``pathlib.Path`` object via its
 context manager. The context manager magic methods remain, but they are now
-a no-op, making `Path` objects immutable.
+a no-op, making ``Path`` objects immutable.
 
 ..
 

--- a/Misc/NEWS.d/3.9.0b1.rst
+++ b/Misc/NEWS.d/3.9.0b1.rst
@@ -684,7 +684,7 @@ The ``isocalendar()`` methods of :class:`datetime.date` and
 .. nonce: t6kW_1
 .. section: Documentation
 
-Add version of removal for explicit passing of coros to `asyncio.wait()`'s
+Add version of removal for explicit passing of coros to ``asyncio.wait()``'s
 documentation
 
 ..


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

Expand Sphinx Lint in pre-commit to check all of `Misc/` and fix 315 warnings:

```
Misc/NEWS.d/3.10.0a2.rst:91: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.10.0a2.rst:92: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.10.0a2.rst:94: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.10.0a2.rst:217: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.10.0a2.rst:305: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.10.0a2.rst:652: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.10.0a2.rst:881: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.10.0a2.rst:901: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.10.0b1.rst:1184: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.10.0b1.rst:1185: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.10.0a7.rst:264: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.10.0a7.rst:667: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.10.0a7.rst:668: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.10.0a7.rst:670: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.10.0a7.rst:671: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.10.0a3.rst:250: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.10.0a3.rst:251: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.10.0a3.rst:467: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.10.0a3.rst:468: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.10.0a3.rst:605: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.10.0a3.rst:721: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.10.0a3.rst:722: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.10.0a3.rst:731: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.10.0a3.rst:875: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.10.0a3.rst:875: role missing opening tag colon ( func:`). (missing-space-before-role)
Misc/NEWS.d/3.11.0a2.rst:510: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.11.0a2.rst:900: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.11.0a2.rst:901: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.10.0a4.rst:519: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.11.0a3.rst:353: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.11.0a3.rst:352: role missing opening tag colon (
class:`). (missing-space-before-role)
Misc/NEWS.d/3.11.0a6.rst:1037: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.11.0a6.rst:1154: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.10.0a1.rst:7: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.10.0a1.rst:220: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.10.0a1.rst:750: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.10.0a1.rst:1160: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.10.0a1.rst:1232: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.10.0a1.rst:1233: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.10.0a1.rst:1242: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.10.0a1.rst:1560: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.10.0a1.rst:1854: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.10.0a1.rst:1855: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.10.0a1.rst:1936: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.10.0a1.rst:2228: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.10.0a1.rst:2396: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.10.0a1.rst:2397: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.10.0a1.rst:2228: role missing opening tag colon (func:`). (missing-space-before-role)
Misc/NEWS.d/3.11.0a4.rst:513: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.11.0a5.rst:278: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.11.0a5.rst:676: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.11.0a5.rst:278: role missing opening tag colon ( exc:`). (missing-space-before-role)
Misc/NEWS.d/3.11.0b1.rst:440: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.11.0b1.rst:579: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.11.0b1.rst:788: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.11.0b1.rst:1661: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.11.0b1.rst:1715: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.5.0b4.rst:132: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.5.2rc1.rst:713: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.5.2rc1.rst:715: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.6.0b1.rst:169: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.11.0a1.rst:3207: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.11.0a1.rst:3243: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.11.0a1.rst:3690: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.11.0a1.rst:3690: missing underscore after closing backtick in hyperlink (missing-underscore-after-hyperlink)
Misc/NEWS.d/3.6.3.rst:7: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.6.3rc1.rst:27: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.6.3rc1.rst:37: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.6.3rc1.rst:98: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.6.3rc1.rst:109: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.6.3rc1.rst:119: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.6.3rc1.rst:480: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.6.3rc1.rst:588: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.6.3rc1.rst:936: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.6.5rc1.rst:286: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.6.5rc1.rst:602: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.7.0a4.rst:155: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.7.0a4.rst:195: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.7.0a4.rst:795: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.6.6rc1.rst:113: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.6.6rc1.rst:251: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.6.6rc1.rst:349: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.5.0a1.rst:254: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.5.0a1.rst:255: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.5.0a1.rst:264: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.5.0a1.rst:265: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.5.0a1.rst:1525: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.5.0a1.rst:1748: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.5.0a1.rst:2347: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.5.0a1.rst:2739: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.5.0a1.rst:2740: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.5.0a1.rst:3933: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.5.0a1.rst:4176: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.6.4rc1.rst:141: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.6.4rc1.rst:150: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.6.4rc1.rst:161: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.6.4rc1.rst:171: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.6.4rc1.rst:172: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.6.4rc1.rst:192: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.6.4rc1.rst:203: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.6.4rc1.rst:223: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.6.4rc1.rst:243: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.6.4rc1.rst:254: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.6.4rc1.rst:255: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.6.4rc1.rst:602: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.6.4rc1.rst:603: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.6.4rc1.rst:816: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.6.4rc1.rst:900: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.6.4rc1.rst:1126: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.6.4rc1.rst:1127: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.7.0a2.rst:68: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.7.0a2.rst:69: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.7.0a2.rst:79: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.7.0a2.rst:88: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.7.0a2.rst:108: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.7.0a2.rst:127: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.7.0a2.rst:128: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.7.0a2.rst:148: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.7.0a2.rst:221: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.7.0a2.rst:241: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.7.0a2.rst:289: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.7.0a2.rst:290: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.7.0a2.rst:310: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.7.0a2.rst:488: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.7.0a2.rst:489: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.7.0a2.rst:490: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.7.0a2.rst:587: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.7.0a2.rst:660: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.7.0a2.rst:661: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.7.0b5.rst:29: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.7.0b5.rst:80: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.7.0b5.rst:257: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.7.0b5.rst:258: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.7.0b5.rst:317: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.7.0b5.rst:327: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.7.0b5.rst:430: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.7.0b5.rst:469: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.7.0b4.rst:374: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.7.0b4.rst:375: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.8.0a2.rst:7: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.6.0a1.rst:1116: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.6.0a1.rst:1118: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.6.0a1.rst:3918: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.7.0b2.rst:217: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.7.0b2.rst:500: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.7.0a3.rst:243: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.7.0a3.rst:244: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.7.0a3.rst:646: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.7.0a3.rst:929: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.7.0a3.rst:951: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.7.0a3.rst:1194: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.7.0a3.rst:1612: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.7.0a3.rst:1613: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.8.0a4.rst:171: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.8.0a4.rst:583: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.8.0a4.rst:612: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.8.0a4.rst:613: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.8.0a4.rst:747: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.8.0a4.rst:1408: Line ends with dangling hyphen (dangling-hyphen)
Misc/NEWS.d/3.9.0a2.rst:406: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.9.0a2.rst:447: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.9.0a2.rst:450: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.9.0a2.rst:451: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.9.0a2.rst:461: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.9.0a2.rst:688: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.9.0a2.rst:887: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.9.0a2.rst:461: role missing opening tag colon ( func:`). (missing-space-before-role)
Misc/NEWS.d/3.8.0a3.rst:327: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.8.0a3.rst:476: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.8.0a3.rst:536: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.8.0a3.rst:538: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.8.0a3.rst:539: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.8.0a3.rst:327: role missing opening tag colon ( mod:`). (missing-space-before-role)
Misc/NEWS.d/3.7.0a1.rst:89: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.7.0a1.rst:100: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.7.0a1.rst:110: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.7.0a1.rst:227: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.7.0a1.rst:238: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.7.0a1.rst:248: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.7.0a1.rst:1858: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.7.0a1.rst:1899: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.7.0a1.rst:1909: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.7.0a1.rst:1912: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.7.0a1.rst:1976: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.7.0a1.rst:1986: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.7.0a1.rst:2162: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.7.0a1.rst:2409: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.7.0a1.rst:4950: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.7.0a1.rst:5079: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.7.0a1.rst:5822: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.7.0a1.rst:6227: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.7.0a1.rst:6228: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.7.0a1.rst:6229: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.9.0a6.rst:63: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.9.0a6.rst:82: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.9.0a6.rst:437: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.9.0a6.rst:507: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.9.0a6.rst:704: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.9.0a6.rst:784: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.9.0a6.rst:786: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.9.0a6.rst:796: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.9.0a6.rst:798: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.9.0a6.rst:437: role missing opening tag colon (func:`). (missing-space-before-role)
Misc/NEWS.d/3.9.0a3.rst:269: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.9.0a3.rst:510: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.9.0a3.rst:511: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.9.0a3.rst:550: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.9.0a3.rst:551: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.9.0a3.rst:553: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.9.0a3.rst:574: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.9.0a3.rst:735: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.9.0a3.rst:737: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.9.0a3.rst:838: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.9.0a3.rst:574: role missing opening tag colon ( mod:`). (missing-space-before-role)
Misc/NEWS.d/3.9.0a4.rst:7: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.9.0a4.rst:8: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.9.0a4.rst:84: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.9.0a4.rst:85: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.9.0a4.rst:86: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.9.0a4.rst:272: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.9.0a4.rst:602: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.9.0a4.rst:622: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.9.0a4.rst:623: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.9.0a4.rst:624: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.9.0b1.rst:687: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.9.0a5.rst:694: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.8.0b1.rst:149: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.8.0b1.rst:150: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.8.0b1.rst:201: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.8.0b1.rst:202: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.8.0b1.rst:211: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.8.0b1.rst:212: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.8.0b1.rst:213: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.8.0b1.rst:417: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.8.0b1.rst:446: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.8.0b1.rst:771: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.8.0b1.rst:781: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.8.0b1.rst:802: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.8.0b1.rst:1026: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.8.0b1.rst:1029: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.8.0b1.rst:1069: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.8.0b1.rst:1123: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.8.0b1.rst:1679: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.8.0b1.rst:1707: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.8.0b1.rst:1716: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.9.0a1.rst:1307: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.9.0a1.rst:1481: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.9.0a1.rst:1816: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.9.0a1.rst:1817: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.9.0a1.rst:1818: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.9.0a1.rst:1979: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.9.0a1.rst:1981: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.9.0a1.rst:2213: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.9.0a1.rst:2263: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.9.0a1.rst:2264: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.9.0a1.rst:2292: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.9.0a1.rst:2293: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.9.0a1.rst:2527: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.9.0a1.rst:2528: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.9.0a1.rst:2676: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.9.0a1.rst:2711: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.9.0a1.rst:2712: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.9.0a1.rst:3198: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.9.0a1.rst:3200: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.9.0a1.rst:3461: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.9.0a1.rst:3792: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.9.0a1.rst:3891: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.9.0a1.rst:4453: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.9.0a1.rst:4454: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.9.0a1.rst:3569: Line ends with dangling hyphen (dangling-hyphen)
Misc/NEWS.d/3.8.0a1.rst:885: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.8.0a1.rst:1274: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.8.0a1.rst:1275: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.8.0a1.rst:1738: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.8.0a1.rst:1748: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.8.0a1.rst:2028: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.8.0a1.rst:2251: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.8.0a1.rst:2380: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.8.0a1.rst:2532: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.8.0a1.rst:2534: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.8.0a1.rst:2586: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.8.0a1.rst:2587: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.8.0a1.rst:2720: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.8.0a1.rst:2802: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.8.0a1.rst:2917: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.8.0a1.rst:3022: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.8.0a1.rst:3063: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.8.0a1.rst:3064: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.8.0a1.rst:3194: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.8.0a1.rst:3305: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.8.0a1.rst:3306: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.8.0a1.rst:4578: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.8.0a1.rst:4579: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.8.0a1.rst:4659: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.8.0a1.rst:4660: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.8.0a1.rst:4739: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.8.0a1.rst:4749: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.8.0a1.rst:5153: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.8.0a1.rst:5780: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.8.0a1.rst:5995: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.8.0a1.rst:6150: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.8.0a1.rst:6151: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.8.0a1.rst:6227: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.8.0a1.rst:6314: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.8.0a1.rst:6412: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.8.0a1.rst:6663: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.8.0a1.rst:7000: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.8.0a1.rst:7009: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.8.0a1.rst:7037: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.8.0a1.rst:7175: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.8.0a1.rst:7285: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.8.0a1.rst:7523: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.8.0a1.rst:7524: default role used (hint: for inline literals, use double backticks) (default-role)
Misc/NEWS.d/3.8.0a1.rst:8093: default role used (hint: for inline literals, use double backticks) (default-role)
```



Which also fixes these 231 Sphinx nit-picky warnings:

```
build/NEWS:9367: WARNING: py:obj reference target not found: --without-doc-strings
build/NEWS:9420: WARNING: py:obj reference target not found: member
build/NEWS:9420: WARNING: py:obj reference target not found: nonmember
build/NEWS:9797: WARNING: py:obj reference target not found: gh
build/NEWS:10935: WARNING: py:obj reference target not found: --with-suffix
build/NEWS:10983: WARNING: py:obj reference target not found: pyi
build/NEWS:11261: WARNING: py:obj reference target not found: mock.Mock()
build/NEWS:11575: WARNING: py:obj reference target not found: MONDAY
build/NEWS:11575: WARNING: py:obj reference target not found: SUNDAY
build/NEWS:12646: WARNING: py:obj reference target not found: @functools.singledispatchmethod
build/NEWS:12646: WARNING: py:obj reference target not found: @classmethod
build/NEWS:12646: WARNING: py:obj reference target not found: @staticmethod
build/NEWS:14031: WARNING: py:obj reference target not found: /
build/NEWS:14047: WARNING: py:obj reference target not found: Lib/_aix_support.get_platform()
build/NEWS:14217: WARNING: py:obj reference target not found: https://wiki.python.org/moin/GuiProgramming
build/NEWS:15197: WARNING: py:obj reference target not found: link_to()
build/NEWS:15197: WARNING: py:obj reference target not found: symlink_to()
build/NEWS:15549: WARNING: py:obj reference target not found: -DWITH_PYMALLOC_RADIX_TREE=0
build/NEWS:15698: WARNING: py:obj reference target not found: RegexFlag.IGNORECASE
build/NEWS:16551: WARNING: py:obj reference target not found: _EnumDict.update()
build/NEWS:16834: WARNING: py:obj reference target not found: load_module()
build/NEWS:16914: WARNING: py:obj reference target not found: pickle.whichmodule
build/NEWS:17007: WARNING: py:obj reference target not found: __spec__.loader
build/NEWS:17010: WARNING: py:obj reference target not found: load_module()
build/NEWS:17338: WARNING: py:obj reference target not found: primary
build/NEWS:17338: WARNING: py:obj reference target not found: a
{b}
build/NEWS:17338: WARNING: py:obj reference target not found: a {
build/NEWS:17421: WARNING: py:obj reference target not found: user
build/NEWS:17421: WARNING: py:obj reference target not found: group
build/NEWS:17421: WARNING: py:obj reference target not found: extra_groups
build/NEWS:17421: WARNING: py:obj reference target not found: uid_t
build/NEWS:17421: WARNING: py:obj reference target not found: gid_t
build/NEWS:17634: WARNING: py:obj reference target not found: _Py_closerange
build/NEWS:17640: WARNING: py:obj reference target not found: PyIter_Send
build/NEWS:17655: WARNING: py:obj reference target not found: python3x._pth
build/NEWS:17727: WARNING: py:obj reference target not found: ,
build/NEWS:17892: WARNING: py:obj reference target not found: NEWLINE
build/NEWS:18045: WARNING: py:obj reference target not found: tkinter.EventType
build/NEWS:18069: WARNING: py:obj reference target not found: Enum
build/NEWS:18069: WARNING: py:obj reference target not found: __str__
build/NEWS:18069: WARNING: py:obj reference target not found: __repr__
build/NEWS:18069: WARNING: py:obj reference target not found: __format__
build/NEWS:18069: WARNING: py:obj reference target not found: __reduce_ex__
build/NEWS:18261: WARNING: py:obj reference target not found: pip
build/NEWS:18261: WARNING: py:obj reference target not found: pip
build/NEWS:18261: WARNING: py:obj reference target not found: setuptools
build/NEWS:18289: WARNING: py:obj reference target not found: defaults
build/NEWS:18438: WARNING: py:obj reference target not found: _missing_
build/NEWS:18438: WARNING: py:obj reference target not found: __context__
build/NEWS:19199: WARNING: py:obj reference target not found: unexpected EOF while parsing
build/NEWS:19199: WARNING: py:obj reference target not found: invalid
syntax
build/NEWS:19207: WARNING: py:obj reference target not found: invalid string prefix
build/NEWS:19355: WARNING: py:obj reference target not found: KqueueSelector.select
build/NEWS:19422: WARNING: py:obj reference target not found: threading._register_atexit()
build/NEWS:19452: WARNING: py:obj reference target not found: __getitem__
build/NEWS:19452: WARNING: py:obj reference target not found: __setitem__
build/NEWS:19452: WARNING: py:obj reference target not found: ShareableList
build/NEWS:19458: WARNING: py:obj reference target not found: Path
build/NEWS:19882: WARNING: py:obj reference target not found: -d
build/NEWS:20161: WARNING: py:obj reference target not found: Attribute
build/NEWS:20161: WARNING: py:obj reference target not found: ast_for_dotted_name
build/NEWS:20161: WARNING: py:obj reference target not found: NAME
build/NEWS:20225: WARNING: py:obj reference target not found: __args__
build/NEWS:20347: WARNING: py:obj reference target not found: lazycache
build/NEWS:20347: WARNING: py:obj reference target not found: __all__
build/NEWS:20347: WARNING: py:obj reference target not found: getline
build/NEWS:20347: WARNING: py:obj reference target not found: checkcache
build/NEWS:20590: WARNING: py:obj reference target not found: ignore
build/NEWS:20675: WARNING: py:obj reference target not found: SimpleHTTPRequestHandler.guess_type
build/NEWS:20687: WARNING: py:obj reference target not found: Logger.isEnabledFor
build/NEWS:20687: WARNING: py:obj reference target not found: try...finally
build/NEWS:20753: WARNING: py:obj reference target not found: international=True
build/NEWS:20753: WARNING: py:obj reference target not found: locale.currency(12.34, international=True)
build/NEWS:20753: WARNING: py:obj reference target not found: '12,34 EUR '
build/NEWS:20753: WARNING: py:obj reference target not found: '12,34 EUR'
build/NEWS:20794: WARNING: py:obj reference target not found: /configure --help
build/NEWS:21001: WARNING: py:obj reference target not found: BINGET
build/NEWS:21001: WARNING: py:obj reference target not found: LONG_BINGET
build/NEWS:21096: WARNING: py:obj reference target not found: source
build/NEWS:21096: WARNING: py:obj reference target not found: 
build/NEWS:21179: WARNING: py:obj reference target not found: import posix
build/NEWS:21659: WARNING: py:obj reference target not found: hmac.HMAC
build/NEWS:21832: WARNING: py:obj reference target not found: __code__
build/NEWS:21832: WARNING: py:obj reference target not found: __await__
build/NEWS:21832: WARNING: py:obj reference target not found: __code__
build/NEWS:21964: WARNING: py:obj reference target not found: threading.Thread.isAlive()
build/NEWS:21979: WARNING: py:obj reference target not found: test.bytecode_helper
build/NEWS:21988: WARNING: py:obj reference target not found: importlib.resources.read_binary()
build/NEWS:22069: WARNING: py:obj reference target not found: NonCallableMock._call_matcher
build/NEWS:22069: WARNING: py:obj reference target not found: _Call
build/NEWS:22069: WARNING: py:obj reference target not found: self._spec_signature
build/NEWS:22132: WARNING: py:obj reference target not found: Enum.__str__
build/NEWS:22132: WARNING: py:obj reference target not found: Enum.__format__
build/NEWS:22305: WARNING: py:obj reference target not found: argparse._ActionsContainer.add_argument
build/NEWS:22389: WARNING: py:obj reference target not found: Content-Length
build/NEWS:22524: WARNING: py:obj reference target not found: :g
build/NEWS:22718: WARNING: py:obj reference target not found: getvar()
build/NEWS:23232: WARNING: py:obj reference target not found: b2a_hex
build/NEWS:23251: WARNING: py:obj reference target not found: # type: ignore
build/NEWS:23251: WARNING: py:obj reference target not found: # type: ignoreé
build/NEWS:23254: WARNING: py:obj reference target not found: # type: ignore
build/NEWS:23254: WARNING: py:obj reference target not found: # type: ignore[E1000]
build/NEWS:23254: WARNING: py:obj reference target not found: "[E1000]"
build/NEWS:23325: WARNING: py:obj reference target not found: async
build/NEWS:23332: WARNING: py:obj reference target not found: tp_dealloc
build/NEWS:23332: WARNING: py:obj reference target not found: tp_dealloc
build/NEWS:23447: WARNING: py:obj reference target not found: args
build/NEWS:23450: WARNING: py:obj reference target not found: args
build/NEWS:23540: WARNING: py:obj reference target not found: type_comments=True
build/NEWS:23540: WARNING: py:obj reference target not found: # type:
ignore
build/NEWS:23540: WARNING: py:obj reference target not found: # type: ignore[E1000]
build/NEWS:23575: WARNING: py:obj reference target not found: max_workers
build/NEWS:23575: WARNING: py:obj reference target not found: ProcessPoolExecutor
build/NEWS:23778: WARNING: py:obj reference target not found: codecs.StreamRecoder.writelines
build/NEWS:24144: WARNING: py:obj reference target not found: default_namespace
build/NEWS:24144: WARNING: py:obj reference target not found: xml_declaration
build/NEWS:24191: WARNING: py:obj reference target not found: asyncio.create_connection()
build/NEWS:24632: WARNING: py:obj reference target not found: line
build/NEWS:25434: WARNING: py:obj reference target not found: setpgroup
build/NEWS:25434: WARNING: py:obj reference target not found: resetids
build/NEWS:25434: WARNING: py:obj reference target not found: setsigmask
build/NEWS:25434: WARNING: py:obj reference target not found: setsigdef
build/NEWS:25434: WARNING: py:obj reference target not found: scheduler
build/NEWS:25434: WARNING: py:obj reference target not found: posix_spawn
build/NEWS:25693: WARNING: py:obj reference target not found: raise_signal
build/NEWS:25767: WARNING: py:obj reference target not found: side_effect
build/NEWS:25816: WARNING: py:obj reference target not found: platform.popen
build/NEWS:25866: WARNING: py:obj reference target not found: StreamReaderProtocol._untrack_reader
build/NEWS:25866: WARNING: py:obj reference target not found: _untrack_reader
build/NEWS:25866: WARNING: py:obj reference target not found: connection_lost
build/NEWS:25887: WARNING: py:obj reference target not found: bytecode path
build/NEWS:25887: WARNING: py:obj reference target not found: bytecode path
build/NEWS:25932: WARNING: py:obj reference target not found: mailbox.mbox.get_string
build/NEWS:25960: WARNING: py:obj reference target not found: sock
build/NEWS:26001: WARNING: py:obj reference target not found: mtime
build/NEWS:26038: WARNING: py:obj reference target not found: exc_text
build/NEWS:26053: WARNING: py:obj reference target not found: loop
build/NEWS:26096: WARNING: py:obj reference target not found: Enum._missing_
build/NEWS:26591: WARNING: py:obj reference target not found: Union[Manager, Employee]
build/NEWS:26591: WARNING: py:obj reference target not found: Employee
build/NEWS:26619: WARNING: py:obj reference target not found: ReadTransport.resume_reading
build/NEWS:26754: WARNING: py:obj reference target not found: _SelectorSocketTransport
build/NEWS:27045: WARNING: py:obj reference target not found: -m module_name
build/NEWS:27102: WARNING: py:obj reference target not found: selection_set
build/NEWS:27127: WARNING: py:obj reference target not found: f_restricted
build/NEWS:27154: WARNING: py:obj reference target not found: is
build/NEWS:27374: WARNING: py:obj reference target not found: test_subprocess.test_undecodable_env
build/NEWS:27377: WARNING: py:obj reference target not found: test_utf8_mode.test_cmd_line
build/NEWS:27384: WARNING: py:obj reference target not found: test_socket
build/NEWS:27427: WARNING: py:obj reference target not found: SMTPUTF8SimTests
build/NEWS:27465: WARNING: py:obj reference target not found: pyexpat
build/NEWS:27465: WARNING: py:obj reference target not found: Modules/Setup
build/NEWS:27540: WARNING: py:obj reference target not found: Modules/Setup
build/NEWS:27540: WARNING: py:obj reference target not found: -DPy_BUILD_CORE
build/NEWS:27716: WARNING: py:obj reference target not found: calltip
build/NEWS:28223: WARNING: py:obj reference target not found: Union[Manager, Employee]
build/NEWS:28223: WARNING: py:obj reference target not found: Employee
build/NEWS:28244: WARNING: py:obj reference target not found: ReadTransport.resume_reading
build/NEWS:28282: WARNING: py:obj reference target not found: _SelectorSocketTransport
build/NEWS:28480: WARNING: py:obj reference target not found: Modules/Setup
build/NEWS:28480: WARNING: py:obj reference target not found: -DPy_BUILD_CORE
build/NEWS:29372: WARNING: py:obj reference target not found: -X dev
build/NEWS:29589: WARNING: py:obj reference target not found: subprocess.Popen(close_fds=True)
build/NEWS:29716: WARNING: py:obj reference target not found: PyErr_PrintEx()
build/NEWS:29716: WARNING: py:obj reference target not found: _PySys_SetObjectId()
build/NEWS:29868: WARNING: py:obj reference target not found: -m module_name
build/NEWS:29959: WARNING: py:obj reference target not found: subnet_of
build/NEWS:29959: WARNING: py:obj reference target not found: superset_of
build/NEWS:30049: WARNING: py:obj reference target not found: create_datagram_endpoint
build/NEWS:30210: WARNING: py:obj reference target not found: PyExc_RecursionErrorInst
build/NEWS:30210: WARNING: py:obj reference target not found: PyErr_NormalizeException()
build/NEWS:30244: WARNING: py:obj reference target not found: zipimporter.get_source()
build/NEWS:30257: WARNING: py:obj reference target not found: _warnings.warn()
build/NEWS:30263: WARNING: py:obj reference target not found: _json.make_encoder()
build/NEWS:30263: WARNING: py:obj reference target not found: encoder()
build/NEWS:30271: WARNING: py:obj reference target not found: _random.Random.seed()
build/NEWS:30321: WARNING: py:obj reference target not found: _elementtree
build/NEWS:30321: WARNING: py:obj reference target not found: Element.text
build/NEWS:30321: WARNING: py:obj reference target not found: Element.tail
build/NEWS:30424: WARNING: py:obj reference target not found: make regen-all
build/NEWS:30457: WARNING: py:obj reference target not found: PyMapping_Keys()
build/NEWS:30457: WARNING: py:obj reference target not found: PyMapping_Values()
build/NEWS:30457: WARNING: py:obj reference target not found: PyMapping_Items()
build/NEWS:30520: WARNING: py:obj reference target not found: PyErr_WriteUnraisable()
build/NEWS:31102: WARNING: py:obj reference target not found: multiprocessing.managers.convert_to_error
build/NEWS:31129: WARNING: py:obj reference target not found: copyreg._slotnames()
build/NEWS:31184: WARNING: py:obj reference target not found: asyncio.CFuture.remove_done_callback()
build/NEWS:31264: WARNING: py:obj reference target not found: imp.load_package()
build/NEWS:32077: WARNING: py:obj reference target not found: set_nomemory(start, stop)
build/NEWS:32077: WARNING: py:obj reference target not found: remove_mem_hooks()
build/NEWS:32120: WARNING: py:obj reference target not found: make
profile-opt
build/NEWS:32506: WARNING: py:obj reference target not found: bool(accept={int})
build/NEWS:32681: WARNING: py:obj reference target not found: ReadTransport.resume_reading
build/NEWS:32710: WARNING: py:obj reference target not found: _SelectorSocketTransport
build/NEWS:33314: WARNING: py:obj reference target not found: _warnings.warn()
build/NEWS:33317: WARNING: py:obj reference target not found: _json.make_encoder()
build/NEWS:33317: WARNING: py:obj reference target not found: encoder()
build/NEWS:33329: WARNING: py:obj reference target not found: _random.Random.seed()
build/NEWS:33346: WARNING: py:obj reference target not found: PyErr_PrintEx()
build/NEWS:33346: WARNING: py:obj reference target not found: _PySys_SetObjectId()
build/NEWS:33466: WARNING: py:obj reference target not found: _elementtree
build/NEWS:33466: WARNING: py:obj reference target not found: Element.text
build/NEWS:33466: WARNING: py:obj reference target not found: Element.tail
build/NEWS:33540: WARNING: py:obj reference target not found: set_nomemory(start, stop)
build/NEWS:33540: WARNING: py:obj reference target not found: remove_mem_hooks()
build/NEWS:33565: WARNING: py:obj reference target not found: make regen-all
build/NEWS:33662: WARNING: py:obj reference target not found: PyExc_RecursionErrorInst
build/NEWS:33662: WARNING: py:obj reference target not found: PyErr_NormalizeException()
build/NEWS:33709: WARNING: py:obj reference target not found: PyErr_WriteUnraisable()
build/NEWS:33855: WARNING: py:obj reference target not found: copyreg._slotnames()
build/NEWS:33887: WARNING: py:obj reference target not found: asyncio.CFuture.remove_done_callback()
build/NEWS:37101: WARNING: py:obj reference target not found: ctypes.util
build/NEWS:37101: WARNING: py:obj reference target not found: crle
build/NEWS:37996: WARNING: py:obj reference target not found: python3 -m
venv
build/NEWS:39447: WARNING: py:obj reference target not found: ctypes.util
build/NEWS:39447: WARNING: py:obj reference target not found: crle
build/NEWS:41780: WARNING: py:obj reference target not found: PyObject_IsInstance
build/NEWS:41780: WARNING: py:obj reference target not found: PyObject_IsSubclass
build/NEWS:41783: WARNING: py:obj reference target not found: PyErr_FormatV
build/NEWS:41783: WARNING: py:obj reference target not found: PyErr_Format
build/NEWS:41783: WARNING: py:obj reference target not found: va_list
build/NEWS:42169: WARNING: py:obj reference target not found: --sort-keys
build/NEWS:42235: WARNING: py:obj reference target not found: errors
build/NEWS:42415: WARNING: py:obj reference target not found: pattern
build/NEWS:42543: WARNING: py:obj reference target not found: Pathlib.mkdir()
build/NEWS:42543: WARNING: py:obj reference target not found: mkdir -p
build/NEWS:42909: WARNING: py:obj reference target not found: unsafe
build/NEWS:42984: WARNING: py:obj reference target not found: assertRaisesRegex
build/NEWS:42984: WARNING: py:obj reference target not found: assertWarnsRegex
```

I considered replacing things like:

```rst
`multiprocessing` module
```
with:
```
:mod:`multiprocessing` module
```
(and for `:func:`, `:meth:`, etc. etc.) but these are historical release notes so I think this is most pragmatic:
```rst
``multiprocessing`` module
```


<!-- gh-issue-number: gh-101100 -->
* Issue: gh-101100
<!-- /gh-issue-number -->
