### PR TITLE
gh-107901: duplicate blocks with no lineno that have an eval break and multiple predecessors

### DIFF
--- a/Lib/test/test_compile.py
+++ b/Lib/test/test_compile.py
@@ -1098,6 +1098,21 @@ class TestSpecifics(unittest.TestCase):
         code_lines = self.get_code_lines(test.__code__)
         self.assertEqual(expected_lines, code_lines)
 
+    def test_line_number_synthetic_jump_multiple_predecessors(self):
+        def f():
+            for x in it:
+                try:
+                    if C1:
+                        yield 2
+                except OSError:
+                    pass
+
+        # Ensure that all JUMP_BACKWARDs have line number
+        code = f.__code__
+        for inst in dis.Bytecode(code):
+            if inst.opname == 'JUMP_BACKWARD':
+                self.assertIsNotNone(inst.positions.lineno)
+
     def test_lineno_of_backward_jump(self):
         # Issue gh-107901
         def f():

--- a/Misc/NEWS.d/next/Core and Builtins/2024-01-11-16-54-53.gh-issue-107901.Td3JPI.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2024-01-11-16-54-53.gh-issue-107901.Td3JPI.rst
@@ -1,0 +1,1 @@
+Compiler duplicates basic blocks that have an eval breaker check, no line number, and multiple predecessors on different lines.

--- a/Misc/NEWS.d/next/Core and Builtins/2024-01-11-16-54-53.gh-issue-107901.Td3JPI.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2024-01-11-16-54-53.gh-issue-107901.Td3JPI.rst
@@ -1,1 +1,0 @@
-Compiler duplicates basic blocks that have an eval breaker check, no line number, and multiple predecessors on different lines.

--- a/Misc/NEWS.d/next/Core and Builtins/2024-01-11-16-54-55.gh-issue-107901.Td3JPI.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2024-01-11-16-54-55.gh-issue-107901.Td3JPI.rst
@@ -1,1 +1,1 @@
-Compiler duplicates basic blocks that have an eval breaker check, no line number, and multiple predecessors on different lines.
+Compiler duplicates basic blocks that have an eval breaker check, no line number, and multiple predecessors.

--- a/Misc/NEWS.d/next/Core and Builtins/2024-01-11-16-54-55.gh-issue-107901.Td3JPI.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2024-01-11-16-54-55.gh-issue-107901.Td3JPI.rst
@@ -1,0 +1,1 @@
+Compiler duplicates basic blocks that have an eval breaker check, no line number, and multiple predecessors on different lines.

--- a/Python/flowgraph.c
+++ b/Python/flowgraph.c
@@ -2257,15 +2257,17 @@ convert_pseudo_ops(basicblock *entryblock)
 
 static inline bool
 is_exit_or_eval_check_without_lineno(basicblock *b) {
-    if (! (basicblock_exits_scope(b) || basicblock_has_eval_break(b))) {
+    if (basicblock_exits_scope(b) || basicblock_has_eval_break(b)) {
+        for (int i = 0; i < b->b_iused; i++) {
+            if (b->b_instr[i].i_loc.lineno >= 0) {
+                return false;
+            }
+        }
+        return true;
+    }
+    else {
         return false;
     }
-    for (int i = 0; i < b->b_iused; i++) {
-        if (b->b_instr[i].i_loc.lineno >= 0) {
-            return false;
-        }
-    }
-    return true;
 }
 
 

--- a/Python/flowgraph.c
+++ b/Python/flowgraph.c
@@ -316,6 +316,16 @@ basicblock_exits_scope(const basicblock *b) {
     return last && IS_SCOPE_EXIT_OPCODE(last->i_opcode);
 }
 
+static inline int
+basicblock_has_eval_break(const basicblock *b) {
+    for (int i = 0; i < b->b_iused; i++) {
+        if (OPCODE_HAS_EVAL_BREAK(b->b_instr[i].i_opcode)) {
+            return true;
+        }
+    }
+    return false;
+}
+
 static bool
 cfg_builder_current_block_is_terminated(cfg_builder *g)
 {
@@ -2246,8 +2256,8 @@ convert_pseudo_ops(basicblock *entryblock)
 }
 
 static inline bool
-is_exit_without_lineno(basicblock *b) {
-    if (!basicblock_exits_scope(b)) {
+is_exit_or_eval_check_without_lineno(basicblock *b) {
+    if (! (basicblock_exits_scope(b) || basicblock_has_eval_break(b))) {
         return false;
     }
     for (int i = 0; i < b->b_iused; i++) {
@@ -2283,7 +2293,7 @@ duplicate_exits_without_lineno(cfg_builder *g)
         }
         if (is_jump(last)) {
             basicblock *target = next_nonempty_block(last->i_target);
-            if (is_exit_without_lineno(target) && target->b_predecessors > 1) {
+            if (is_exit_or_eval_check_without_lineno(target) && target->b_predecessors > 1) {
                 basicblock *new_target = copy_basicblock(g, target);
                 if (new_target == NULL) {
                     return ERROR;
@@ -2303,7 +2313,7 @@ duplicate_exits_without_lineno(cfg_builder *g)
      * fall through, and thus can only have a single predecessor */
     for (basicblock *b = entryblock; b != NULL; b = b->b_next) {
         if (BB_HAS_FALLTHROUGH(b) && b->b_next && b->b_iused > 0) {
-            if (is_exit_without_lineno(b->b_next)) {
+            if (is_exit_or_eval_check_without_lineno(b->b_next)) {
                 cfg_instr *last = basicblock_last_instr(b);
                 assert(last != NULL);
                 b->b_next->b_instr[0].i_loc = last->i_loc;


### PR DESCRIPTION

This ensures that these blocks get a line number propagated to them.

<!-- gh-issue-number: gh-107901 -->
* Issue: gh-107901
<!-- /gh-issue-number -->
