### PR TITLE
gh-113937 Fix failures in type cache tests due to re-running

### DIFF
--- a/Lib/test/test_type_cache.py
+++ b/Lib/test/test_type_cache.py
@@ -67,7 +67,8 @@ class TypeCacheTests(unittest.TestCase):
 
         type_assign_version(C)
         orig_version = type_get_version(C)
-        self.assertNotEqual(orig_version, 0)
+        if orig_version == 0:
+            self.skipTest("Could not assign a valid type version")
 
         type_modified(C)
         type_assign_specific_version_unsafe(C, orig_version + 5)

--- a/Lib/test/test_type_cache.py
+++ b/Lib/test/test_type_cache.py
@@ -84,10 +84,11 @@ class TypeCacheWithSpecializationTests(unittest.TestCase):
     def tearDown(self):
         _clear_type_cache()
 
-    def _assign_and_check_valid_version(self, user_type):
-        type_modified(user_type)
-        type_assign_version(user_type)
-        self.assertNotEqual(type_get_version(user_type), 0)
+    def _assign_valid_version_or_skip(self, type_):
+        type_modified(type_)
+        type_assign_version(type_)
+        if type_get_version(type_) == 0:
+            self.skipTest("Could not assign valid type version")
 
     def _assign_and_check_version_0(self, user_type):
         type_modified(user_type)
@@ -98,8 +99,6 @@ class TypeCacheWithSpecializationTests(unittest.TestCase):
         return set(instr.opname for instr in dis.Bytecode(func, adaptive=True))
 
     def _check_specialization(self, func, arg, opname, *, should_specialize):
-        self.assertIn(opname, self._all_opnames(func))
-
         for _ in range(100):
             func(arg)
 
@@ -113,7 +112,7 @@ class TypeCacheWithSpecializationTests(unittest.TestCase):
             def foo(self):
                 pass
 
-        self._assign_and_check_valid_version(A)
+        self._assign_valid_version_or_skip(A)
 
         def load_foo_1(type_):
             type_.foo
@@ -129,8 +128,8 @@ class TypeCacheWithSpecializationTests(unittest.TestCase):
         self._check_specialization(load_foo_2, A, "LOAD_ATTR", should_specialize=False)
 
     def test_class_load_attr_specialization_static_type(self):
-        self._assign_and_check_valid_version(str)
-        self._assign_and_check_valid_version(bytes)
+        self._assign_valid_version_or_skip(str)
+        self._assign_valid_version_or_skip(bytes)
 
         def get_capitalize_1(type_):
             return type_.capitalize
@@ -164,7 +163,7 @@ class TypeCacheWithSpecializationTests(unittest.TestCase):
             def x(self):
                 return 9
 
-        self._assign_and_check_valid_version(G)
+        self._assign_valid_version_or_skip(G)
 
         def load_x_1(instance):
             instance.x
@@ -183,7 +182,7 @@ class TypeCacheWithSpecializationTests(unittest.TestCase):
         class B:
             __slots__ = ("bar",)
 
-        self._assign_and_check_valid_version(B)
+        self._assign_valid_version_or_skip(B)
 
         def store_bar_1(type_):
             type_.bar = 10
@@ -203,7 +202,7 @@ class TypeCacheWithSpecializationTests(unittest.TestCase):
             def __init__(self):
                 pass
 
-        self._assign_and_check_valid_version(F)
+        self._assign_valid_version_or_skip(F)
 
         def call_class_1(type_):
             type_()
@@ -222,7 +221,7 @@ class TypeCacheWithSpecializationTests(unittest.TestCase):
         class H:
             pass
 
-        self._assign_and_check_valid_version(H)
+        self._assign_valid_version_or_skip(H)
 
         def to_bool_1(instance):
             not instance


### PR DESCRIPTION
This addresses test failures in `test_type_cache` arising from re-running the same tests multiple times. There are no source code changes. New behavior in test_type_cache:
- skip tests if a valid version tag cannot be initially assigned
- only check whether a function has / has not been specialized after calling it several times

To test these changes, I ran the following tests:
- `./python.exe -m test test_type_cache`
- `./python.exe -m test test_type_cache --forever` (killed manually after 5 minutes)
- `./python.exe -m test test_type_cache -R 3:3`

I specifically did not add a news entry, but will happily do so if anyone thinks it's appropriate.

<!-- gh-issue-number: gh-113937 -->
* Issue: gh-113937
<!-- /gh-issue-number -->
