### PR TITLE
gh-108364: In sqlite3, disable foreign keys before dumping SQL schema

### DIFF
--- a/Lib/sqlite3/dump.py
+++ b/Lib/sqlite3/dump.py
@@ -26,6 +26,10 @@ def _iterdump(connection):
 
     writeable_schema = False
     cu = connection.cursor()
+    # Disable foreign key constraints, if there is any foreign key violation.
+    violations = cu.execute("PRAGMA foreign_key_check").fetchall()
+    if violations:
+        yield('PRAGMA foreign_keys=OFF;')
     yield('BEGIN TRANSACTION;')
 
     # sqlite_master table contains the SQL CREATE statements for the database.

--- a/Misc/NEWS.d/next/Library/2024-01-11-22-22-51.gh-issue-108364.QH7C-1.rst
+++ b/Misc/NEWS.d/next/Library/2024-01-11-22-22-51.gh-issue-108364.QH7C-1.rst
@@ -1,0 +1,3 @@
+:meth:`sqlite3.Connection.iterdump` now ensures that foreign key support is
+disabled before dumping the database schema, if there is any foreign key
+violation. Patch by Erlend E. Aasland and Mariusz Felisiak.


### PR DESCRIPTION
Superseded #108471.

<!-- gh-issue-number: gh-108364 -->
* Issue: gh-108364
<!-- /gh-issue-number -->
