### PR TITLE
gh-113903: Fix an IDLE configdialog test

### DIFF
--- a/Lib/idlelib/News3.txt
+++ b/Lib/idlelib/News3.txt
@@ -4,6 +4,8 @@ Released on 2024-10-xx
 =========================
 
 
+gh-113903: Fix rare failure of test.test_idle, in test_configdialog.
+
 gh-113729: Fix the "Help -> IDLE Doc" menu bug in 3.11.7 and 3.12.1.
 
 gh-57795: Enter selected text into the Find box when opening

--- a/Lib/idlelib/idle_test/test_configdialog.py
+++ b/Lib/idlelib/idle_test/test_configdialog.py
@@ -420,15 +420,8 @@ class HighPageTest(unittest.TestCase):
         # Set highlight_target through clicking highlight_sample.
         eq = self.assertEqual
         d = self.page
-
-        elem = {}
-        count = 0
         hs = d.highlight_sample
         hs.focus_force()
-
-        def tag_to_element(elem):
-            for element, tag in d.theme_elements.items():
-                elem[tag] = element
 
         def click_char(index):
             "Simulate click on character at *index*."
@@ -442,11 +435,12 @@ class HighPageTest(unittest.TestCase):
             hs.event_generate('<ButtonPress-1>', x=x, y=y)
             hs.event_generate('<ButtonRelease-1>', x=x, y=y)
 
-        # Flip theme_elements to make the tag the key.
-        tag_to_element(elem)
+        # Reverse theme_elements to make the tag the key.
+        elem = {tag: element for element, tag in d.theme_elements.items()}
 
         # If highlight_sample has a tag that isn't in theme_elements, there
         # will be a KeyError in the test run.
+        count = 0
         for tag in hs.tag_names():
             try:
                 click_char(hs.tag_nextrange(tag, "1.0")[0])
@@ -454,7 +448,7 @@ class HighPageTest(unittest.TestCase):
                 count += 1
                 eq(d.set_highlight_target.called, count)
             except IndexError:
-                pass  # Skip unused tag.
+                pass  # Skip unused theme_elements tag, like 'sel'.
 
     def test_highlight_sample_double_click(self):
         # Test double click on highlight_sample.

--- a/Lib/idlelib/idle_test/test_configdialog.py
+++ b/Lib/idlelib/idle_test/test_configdialog.py
@@ -430,11 +430,11 @@ class HighPageTest(unittest.TestCase):
             for element, tag in d.theme_elements.items():
                 elem[tag] = element
 
-        def click_char(start_index):
-            "Simulate click on character."
-            hs.see(start_index)
+        def click_char(index):
+            "Simulate click on character at *index*."
+            hs.see(index)
             hs.update_idletasks()
-            x, y, dx, dy = hs.bbox(start_index)
+            x, y, dx, dy = hs.bbox(index)
             x += dx // 2
             y += dy // 2
             hs.event_generate('<Enter>', x=0, y=0)
@@ -448,11 +448,13 @@ class HighPageTest(unittest.TestCase):
         # If highlight_sample has a tag that isn't in theme_elements, there
         # will be a KeyError in the test run.
         for tag in hs.tag_names():
-            for start_index in hs.tag_ranges(tag)[0::2]:
-                count += 1
-                click_char(start_index)
+            try:
+                click_char(hs.tag_nextrange(tag, "1.0")[0])
                 eq(d.highlight_target.get(), elem[tag])
+                count += 1
                 eq(d.set_highlight_target.called, count)
+            except IndexError:
+                pass  # Skip unused tag.
 
     def test_highlight_sample_double_click(self):
         # Test double click on highlight_sample.

--- a/Lib/idlelib/idle_test/test_configdialog.py
+++ b/Lib/idlelib/idle_test/test_configdialog.py
@@ -425,15 +425,16 @@ class HighPageTest(unittest.TestCase):
         count = 0
         hs = d.highlight_sample
         hs.focus_force()
-        hs.see(1.0)
-        hs.update_idletasks()
 
         def tag_to_element(elem):
             for element, tag in d.theme_elements.items():
                 elem[tag] = element
 
-        def click_it(start):
-            x, y, dx, dy = hs.bbox(start)
+        def click_char(start_index):
+            "Simulate click on character."
+            hs.see(start_index)
+            hs.update_idletasks()
+            x, y, dx, dy = hs.bbox(start_index)
             x += dx // 2
             y += dy // 2
             hs.event_generate('<Enter>', x=0, y=0)
@@ -449,7 +450,7 @@ class HighPageTest(unittest.TestCase):
         for tag in hs.tag_names():
             for start_index in hs.tag_ranges(tag)[0::2]:
                 count += 1
-                click_it(start_index)
+                click_char(start_index)
                 eq(d.highlight_target.get(), elem[tag])
                 eq(d.set_highlight_target.called, count)
 

--- a/Misc/NEWS.d/next/IDLE/2024-01-11-21-26-58.gh-issue-113903.__GLlQ.rst
+++ b/Misc/NEWS.d/next/IDLE/2024-01-11-21-26-58.gh-issue-113903.__GLlQ.rst
@@ -1,0 +1,1 @@
+Fix rare failure of test.test_idle, in test_configdialog.


### PR DESCRIPTION
test_configdialog.HighPageTest.test_highlight_target_text_mouse fails
if a line of the Highlight tab text sample is not visible.  If so, bbox()
in click_char() returns None and the unpacking iteration fails.

This occurred on a Devuan Linux system.  Fix by moving the
'see character' inside click_char, just before the bbox call.

Also, reduce the click_char calls to just one per tag name and
replace the other nested function with a dict comprehension.

<!-- gh-issue-number: gh-113903 -->
* Issue: gh-113903
<!-- /gh-issue-number -->
