### PR TITLE
gh-109862: Fix test_create_subprocess_with_pidfd when it was run separately

### DIFF
--- a/Lib/test/test_asyncio/test_subprocess.py
+++ b/Lib/test/test_asyncio/test_subprocess.py
@@ -975,8 +975,13 @@ if sys.platform != 'win32':
 
             async def main():
                 # asyncio.Runner did not call asyncio.set_event_loop()
-                with self.assertRaises(RuntimeError):
-                    asyncio.get_event_loop_policy().get_event_loop()
+                with warnings.catch_warnings():
+                    warnings.simplefilter('error', DeprecationWarning)
+                    # get_event_loop() raises DeprecationWarning if
+                    # set_event_loop() was never called and RuntimeError if
+                    # it was called at least once.
+                    with self.assertRaises((RuntimeError, DeprecationWarning)):
+                        asyncio.get_event_loop_policy().get_event_loop()
                 return await asyncio.to_thread(asyncio.run, in_thread())
             with self.assertWarns(DeprecationWarning):
                 asyncio.set_child_watcher(asyncio.PidfdChildWatcher())


### PR DESCRIPTION


<!-- gh-issue-number: gh-109862 -->
* Issue: gh-109862
<!-- /gh-issue-number -->
