### PR TITLE
Clarifying nonlocal doc: SyntaxError is raised if nearest enclosing scope is global

### DIFF
--- a/Doc/reference/executionmodel.rst
+++ b/Doc/reference/executionmodel.rst
@@ -139,8 +139,9 @@ namespace.  Names are resolved in the top-level namespace by searching the
 global namespace, i.e. the namespace of the module containing the code block,
 and the builtins namespace, the namespace of the module :mod:`builtins`.  The
 global namespace is searched first.  If the names are not found there, the
-builtins namespace is searched.  The :keyword:`!global` statement must precede
-all uses of the listed names.
+builtins namespace is searched.  A new variable is created in the global 
+namespace if the name is also not found in builtins namespace.  The 
+:keyword:`!global` statement must precede all uses of the listed names.
 
 The :keyword:`global` statement has the same scope as a name binding operation
 in the same block.  If the nearest enclosing scope for a free variable contains
@@ -151,7 +152,8 @@ a global statement, the free variable is treated as a global.
 The :keyword:`nonlocal` statement causes corresponding names to refer
 to previously bound variables in the nearest enclosing function scope.
 :exc:`SyntaxError` is raised at compile time if the given name does not
-exist in any enclosing function scope. :ref:`Type parameters <type-params>`
+exist in any enclosing function scope, or if the nearest enclosing scope 
+is the global (module) scope. :ref:`Type parameters <type-params>`
 cannot be rebound with the :keyword:`!nonlocal` statement.
 
 .. index:: pair: module; __main__

--- a/Doc/reference/executionmodel.rst
+++ b/Doc/reference/executionmodel.rst
@@ -133,8 +133,7 @@ determined by scanning the entire text of the block for name binding operations.
 See :ref:`the FAQ entry on UnboundLocalError <faq-unboundlocalerror>`
 for examples.
 
-The :keyword:`global` statement must precede all uses of the listed names.
-If the global statement occurs within a block, all uses of the names
+If the :keyword:`global` statement occurs within a block, all uses of the names
 specified in the statement refer to the bindings of those names in the top-level
 namespace.  Names are resolved in the top-level namespace by searching the
 global namespace, the namespace of the module containing the code block,
@@ -142,6 +141,7 @@ and the builtins namespace, the namespace of the module :mod:`builtins`.  The
 global namespace is searched first.  If the names are not found there, the
 builtins namespace is searched next.  If the names are also not found in the
 builtins namespace, new variables are created in the global namespace.
+The :keyword:`global` statement must precede all uses of the listed names.
 
 The :keyword:`global` statement has the same scope as a name binding operation
 in the same block.  If the nearest enclosing scope for a free variable contains

--- a/Doc/reference/executionmodel.rst
+++ b/Doc/reference/executionmodel.rst
@@ -141,7 +141,7 @@ and the builtins namespace, the namespace of the module :mod:`builtins`.  The
 global namespace is searched first.  If the names are not found there, the
 builtins namespace is searched next.  If the names are also not found in the
 builtins namespace, new variables are created in the global namespace.
-The :keyword:`global` statement must precede all uses of the listed names.
+The global statement must precede all uses of the listed names.
 
 The :keyword:`global` statement has the same scope as a name binding operation
 in the same block.  If the nearest enclosing scope for a free variable contains

--- a/Doc/reference/executionmodel.rst
+++ b/Doc/reference/executionmodel.rst
@@ -133,15 +133,15 @@ determined by scanning the entire text of the block for name binding operations.
 See :ref:`the FAQ entry on UnboundLocalError <faq-unboundlocalerror>`
 for examples.
 
-If the :keyword:`global` statement occurs within a block, all uses of the names
+The :keyword:`!global` statement must precede all uses of the listed names.
+If the global statement occurs within a block, all uses of the names
 specified in the statement refer to the bindings of those names in the top-level
 namespace.  Names are resolved in the top-level namespace by searching the
-global namespace, i.e. the namespace of the module containing the code block,
+global namespace, the namespace of the module containing the code block,
 and the builtins namespace, the namespace of the module :mod:`builtins`.  The
 global namespace is searched first.  If the names are not found there, the
-builtins namespace is searched.  A new variable is created in the global
-namespace if the name is also not found in the builtins namespace.  The
-:keyword:`!global` statement must precede all uses of the listed names.
+builtins namespace is searched next.  If the names are also not found in the
+builtins namespace, new variables are created in the global namespace.
 
 The :keyword:`global` statement has the same scope as a name binding operation
 in the same block.  If the nearest enclosing scope for a free variable contains

--- a/Doc/reference/executionmodel.rst
+++ b/Doc/reference/executionmodel.rst
@@ -139,9 +139,9 @@ namespace.  Names are resolved in the top-level namespace by searching the
 global namespace, i.e. the namespace of the module containing the code block,
 and the builtins namespace, the namespace of the module :mod:`builtins`.  The
 global namespace is searched first.  If the names are not found there, the
-builtins namespace is searched next.  If the names are also not found in the
+builtins namespace is searched next. If the names are also not found in the
 builtins namespace, new variables are created in the global namespace.
-The global statement must precede all uses of the listed names.
+The :keyword:`global` statement must precede all uses of the listed names.
 
 The :keyword:`global` statement has the same scope as a name binding operation
 in the same block.  If the nearest enclosing scope for a free variable contains

--- a/Doc/reference/executionmodel.rst
+++ b/Doc/reference/executionmodel.rst
@@ -133,7 +133,7 @@ determined by scanning the entire text of the block for name binding operations.
 See :ref:`the FAQ entry on UnboundLocalError <faq-unboundlocalerror>`
 for examples.
 
-The :keyword:`!global` statement must precede all uses of the listed names.
+The :keyword:`global` statement must precede all uses of the listed names.
 If the global statement occurs within a block, all uses of the names
 specified in the statement refer to the bindings of those names in the top-level
 namespace.  Names are resolved in the top-level namespace by searching the

--- a/Doc/reference/executionmodel.rst
+++ b/Doc/reference/executionmodel.rst
@@ -152,8 +152,7 @@ a global statement, the free variable is treated as a global.
 The :keyword:`nonlocal` statement causes corresponding names to refer
 to previously bound variables in the nearest enclosing function scope.
 :exc:`SyntaxError` is raised at compile time if the given name does not
-exist in any enclosing function scope, or if the nearest enclosing scope
-is the global (module) scope. :ref:`Type parameters <type-params>`
+exist in any enclosing function scope. :ref:`Type parameters <type-params>`
 cannot be rebound with the :keyword:`!nonlocal` statement.
 
 .. index:: pair: module; __main__

--- a/Doc/reference/executionmodel.rst
+++ b/Doc/reference/executionmodel.rst
@@ -136,7 +136,7 @@ for examples.
 If the :keyword:`global` statement occurs within a block, all uses of the names
 specified in the statement refer to the bindings of those names in the top-level
 namespace.  Names are resolved in the top-level namespace by searching the
-global namespace, the namespace of the module containing the code block,
+global namespace, i.e. the namespace of the module containing the code block,
 and the builtins namespace, the namespace of the module :mod:`builtins`.  The
 global namespace is searched first.  If the names are not found there, the
 builtins namespace is searched next.  If the names are also not found in the

--- a/Doc/reference/executionmodel.rst
+++ b/Doc/reference/executionmodel.rst
@@ -141,7 +141,7 @@ and the builtins namespace, the namespace of the module :mod:`builtins`.  The
 global namespace is searched first.  If the names are not found there, the
 builtins namespace is searched next. If the names are also not found in the
 builtins namespace, new variables are created in the global namespace.
-The :keyword:`global` statement must precede all uses of the listed names.
+The global statement must precede all uses of the listed names.
 
 The :keyword:`global` statement has the same scope as a name binding operation
 in the same block.  If the nearest enclosing scope for a free variable contains

--- a/Doc/reference/executionmodel.rst
+++ b/Doc/reference/executionmodel.rst
@@ -139,8 +139,8 @@ namespace.  Names are resolved in the top-level namespace by searching the
 global namespace, i.e. the namespace of the module containing the code block,
 and the builtins namespace, the namespace of the module :mod:`builtins`.  The
 global namespace is searched first.  If the names are not found there, the
-builtins namespace is searched.  A new variable is created in the global 
-namespace if the name is also not found in builtins namespace.  The 
+builtins namespace is searched.  A new variable is created in the global
+namespace if the name is also not found in builtins namespace.  The
 :keyword:`!global` statement must precede all uses of the listed names.
 
 The :keyword:`global` statement has the same scope as a name binding operation
@@ -152,7 +152,7 @@ a global statement, the free variable is treated as a global.
 The :keyword:`nonlocal` statement causes corresponding names to refer
 to previously bound variables in the nearest enclosing function scope.
 :exc:`SyntaxError` is raised at compile time if the given name does not
-exist in any enclosing function scope, or if the nearest enclosing scope 
+exist in any enclosing function scope, or if the nearest enclosing scope
 is the global (module) scope. :ref:`Type parameters <type-params>`
 cannot be rebound with the :keyword:`!nonlocal` statement.
 

--- a/Doc/reference/executionmodel.rst
+++ b/Doc/reference/executionmodel.rst
@@ -140,7 +140,7 @@ global namespace, i.e. the namespace of the module containing the code block,
 and the builtins namespace, the namespace of the module :mod:`builtins`.  The
 global namespace is searched first.  If the names are not found there, the
 builtins namespace is searched.  A new variable is created in the global
-namespace if the name is also not found in builtins namespace.  The
+namespace if the name is also not found in the builtins namespace.  The
 :keyword:`!global` statement must precede all uses of the listed names.
 
 The :keyword:`global` statement has the same scope as a name binding operation


### PR DESCRIPTION
(Made a new PR because force push messed up the original PR https://github.com/python/cpython/pull/113572)

N̶o̶n̶l̶o̶c̶a̶l̶ ̶t̶h̶r̶o̶w̶s̶ ̶S̶y̶n̶t̶a̶x̶E̶r̶r̶o̶r̶ ̶i̶f̶ ̶t̶h̶e̶ ̶n̶e̶a̶r̶e̶s̶t̶ ̶e̶n̶c̶l̶o̶s̶i̶n̶g̶ ̶s̶c̶o̶p̶e̶ ̶i̶s̶ ̶g̶l̶o̶b̶a̶l̶.̶ ̶C̶u̶r̶r̶e̶n̶t̶l̶y̶,̶ ̶P̶y̶t̶h̶o̶n̶ ̶L̶a̶n̶g̶u̶a̶g̶e̶ R̶e̶f̶e̶r̶e̶n̶c̶e̶ ̶s̶e̶c̶t̶i̶o̶n̶ ̶E̶x̶e̶c̶u̶t̶i̶o̶n̶ ̶M̶o̶d̶e̶l̶ ̶4̶.̶2̶.̶2̶ ̶d̶o̶e̶s̶ ̶n̶o̶t̶ ̶s̶a̶y̶ ̶s̶o̶.̶ This pull request fixes that. This PR also adds another statement, in the same section, saying `global` statement creates a variable if existing variable binding is not found.

[Here](https://discord.com/channels/935215565872693329/1188244701468434563) is the link to Python Docs discord discussion thread with @ezio-melotti on this topic.

https://docs.python.org/3/reference/executionmodel.html#resolution-of-names

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--114009.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->