### PR TITLE
GH-111798: skip `test_super_deep()` from `test_call` under pydebug builds on WASI

### DIFF
--- a/Misc/NEWS.d/next/Tests/2024-01-12-14-34-24.gh-issue-111798.hd9B_-.rst
+++ b/Misc/NEWS.d/next/Tests/2024-01-12-14-34-24.gh-issue-111798.hd9B_-.rst
@@ -1,0 +1,2 @@
+Disable ``test_super_deep()`` from ``test_call`` under pydebug builds on
+WASI; the stack depth is too small to make the test useful.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-111798 -->
* Issue: gh-111798
<!-- /gh-issue-number -->
