### PR TITLE
gh-114014: Update `fractions.Fraction()`'s rational parsing regex

### DIFF
--- a/Lib/fractions.py
+++ b/Lib/fractions.py
@@ -62,7 +62,7 @@ _RATIONAL_FORMAT = re.compile(r"""
     (?:                                   # followed by
        (?:\s*/\s*(?P<denom>\d+(_\d+)*))?  # an optional denominator
     |                                     # or
-       (?:\.(?P<decimal>d*|\d+(_\d+)*))?  # an optional fractional part
+       (?:\.(?P<decimal>\d*|\d+(_\d+)*))? # an optional fractional part
        (?:E(?P<exp>[-+]?\d+(_\d+)*))?     # and optional exponent
     )
     \s*\Z                                 # and optional whitespace to finish

--- a/Lib/fractions.py
+++ b/Lib/fractions.py
@@ -55,17 +55,17 @@ def _hash_algorithm(numerator, denominator):
     return -2 if result == -1 else result
 
 _RATIONAL_FORMAT = re.compile(r"""
-    \A\s*                                 # optional whitespace at the start,
-    (?P<sign>[-+]?)                       # an optional sign, then
-    (?=\d|\.\d)                           # lookahead for digit or .digit
-    (?P<num>\d*|\d+(_\d+)*)               # numerator (possibly empty)
-    (?:                                   # followed by
-       (?:\s*/\s*(?P<denom>\d+(_\d+)*))?  # an optional denominator
-    |                                     # or
-       (?:\.(?P<decimal>\d*|\d+(_\d+)*))? # an optional fractional part
-       (?:E(?P<exp>[-+]?\d+(_\d+)*))?     # and optional exponent
+    \A\s*                                  # optional whitespace at the start,
+    (?P<sign>[-+]?)                        # an optional sign, then
+    (?=\d|\.\d)                            # lookahead for digit or .digit
+    (?P<num>\d*|\d+(_\d+)*)                # numerator (possibly empty)
+    (?:                                    # followed by
+       (?:\s*/\s*(?P<denom>\d+(_\d+)*))?   # an optional denominator
+    |                                      # or
+       (?:\.(?P<decimal>\d*|\d+(_\d+)*))?  # an optional fractional part
+       (?:E(?P<exp>[-+]?\d+(_\d+)*))?      # and optional exponent
     )
-    \s*\Z                                 # and optional whitespace to finish
+    \s*\Z                                  # and optional whitespace to finish
 """, re.VERBOSE | re.IGNORECASE)
 
 

--- a/Lib/test/test_fractions.py
+++ b/Lib/test/test_fractions.py
@@ -261,6 +261,30 @@ class FractionTest(unittest.TestCase):
         self.assertRaisesMessage(
             ValueError, "Invalid literal for Fraction: '1.1e+1__1'",
             F, "1.1e+1__1")
+        self.assertRaisesMessage(
+            ValueError, "Invalid literal for Fraction: '123.dd'",
+            F, "123.dd")
+        self.assertRaisesMessage(
+            ValueError, "Invalid literal for Fraction: '123.5_dd'",
+            F, "123.5_dd")
+        self.assertRaisesMessage(
+            ValueError, "Invalid literal for Fraction: 'dd.5'",
+            F, "dd.5")
+        self.assertRaisesMessage(
+            ValueError, "Invalid literal for Fraction: '7_dd'",
+            F, "7_dd")
+        self.assertRaisesMessage(
+            ValueError, "Invalid literal for Fraction: '1/dd'",
+            F, "1/dd")
+        self.assertRaisesMessage(
+            ValueError, "Invalid literal for Fraction: '1/123_dd'",
+            F, "1/123_dd")
+        self.assertRaisesMessage(
+            ValueError, "Invalid literal for Fraction: '789edd'",
+            F, "789edd")
+        self.assertRaisesMessage(
+            ValueError, "Invalid literal for Fraction: '789e2_dd'",
+            F, "789e2_dd")
         # Test catastrophic backtracking.
         val = "9"*50 + "_"
         self.assertRaisesMessage(

--- a/Misc/NEWS.d/next/Library/2024-01-13-11-34-29.gh-issue-114014.WRHifN.rst
+++ b/Misc/NEWS.d/next/Library/2024-01-13-11-34-29.gh-issue-114014.WRHifN.rst
@@ -1,1 +1,1 @@
-Fixed a bug in `fractions.Fraction()` where an invalid string using `d` in the decimals part creates a different error compared to other invalid letters/characters. Patch by Jeremiah Gabriel Pascual.
+Fixed a bug in :class:`fractions.Fraction` where an invalid string using ``d`` in the decimals part creates a different error compared to other invalid letters/characters. Patch by Jeremiah Gabriel Pascual.

--- a/Misc/NEWS.d/next/Library/2024-01-13-11-34-29.gh-issue-114014.WRHifN.rst
+++ b/Misc/NEWS.d/next/Library/2024-01-13-11-34-29.gh-issue-114014.WRHifN.rst
@@ -1,0 +1,1 @@
+Fixed a bug in `fractions.Fraction()` where an invalid string using `d` in the decimals part creates a different error compared to other invalid letters/characters. Patch by Jeremiah Gabriel Pascual.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
Fixes #114014.

The previous regex caused unintentional inconsistency in error messages due to the below:
```
(?P<decimal>d*|\d+(_\d+)*)
            ^
```
Which matches the character `d` instead of the intended digit set `\d`. Fix it by adding a backslash behind `d`.
```
(?P<decimal>\d*|\d+(_\d+)*)
            ^^
```

<!-- gh-issue-number: gh-114014 -->
* Issue: gh-114014
<!-- /gh-issue-number -->
