### PR TITLE
GH-79634: Accept path-like objects as pathlib glob patterns.

### DIFF
--- a/Doc/library/pathlib.rst
+++ b/Doc/library/pathlib.rst
@@ -1020,6 +1020,9 @@ call fails (for example because the path doesn't exist).
       future Python release, patterns with this ending will match both files
       and directories. Add a trailing slash to match only directories.
 
+   .. versionchanged:: 3.13
+      The *pattern* parameter accepts a :term:`path-like object`.
+
 .. method:: Path.group(*, follow_symlinks=True)
 
    Return the name of the group owning the file. :exc:`KeyError` is raised
@@ -1481,6 +1484,9 @@ call fails (for example because the path doesn't exist).
 
    .. versionchanged:: 3.13
       The *follow_symlinks* parameter was added.
+
+   .. versionchanged:: 3.13
+      The *pattern* parameter accepts a :term:`path-like object`.
 
 .. method:: Path.rmdir()
 

--- a/Lib/pathlib/__init__.py
+++ b/Lib/pathlib/__init__.py
@@ -603,7 +603,7 @@ class Path(_abc.PathBase, PurePath):
     def _scandir(self):
         return os.scandir(self)
 
-    def _make_child_entry(self, entry, is_dir=False):
+    def _make_child_entry(self, entry):
         # Transform an entry yielded from _scandir() into a path object.
         path_str = entry.name if str(self) == '.' else entry.path
         path = self.with_segments(path_str)
@@ -614,6 +614,8 @@ class Path(_abc.PathBase, PurePath):
         return path
 
     def _make_child_relpath(self, name):
+        if not name:
+            return self
         path_str = str(self)
         tail = self._tail
         if tail:

--- a/Lib/pathlib/__init__.py
+++ b/Lib/pathlib/__init__.py
@@ -471,7 +471,8 @@ class PurePath(_abc.PurePathBase):
     def _pattern_parts(self):
         """List of path components, to be used with patterns in glob()."""
         parts = self._tail.copy()
-        if self._raw_path.endswith('**'):
+        pattern = self._raw_path
+        if pattern.endswith('**'):
             # GH-70303: '**' only matches directories. Add trailing slash.
             warnings.warn(
                 "Pattern ending '**' will match files and directories in a "
@@ -479,7 +480,7 @@ class PurePath(_abc.PurePathBase):
                 "directories and remove this warning.",
                 FutureWarning, 4)
             parts.append('')
-        elif self._raw_path[-1] in (self.pathmod.sep, self.pathmod.altsep):
+        elif pattern[-1] in (self.pathmod.sep, self.pathmod.altsep):
             # GH-65238: pathlib doesn't preserve trailing slash. Add it back.
             parts.append('')
         return parts

--- a/Lib/pathlib/__init__.py
+++ b/Lib/pathlib/__init__.py
@@ -472,16 +472,20 @@ class PurePath(_abc.PurePathBase):
         """Stack of path components, to be used with patterns in glob()."""
         parts = self._tail.copy()
         pattern = self._raw_path
-        if pattern.endswith('**'):
+        if self.anchor:
+            raise NotImplementedError("Non-relative patterns are unsupported")
+        elif not parts:
+            raise ValueError("Unacceptable pattern: {!r}".format(pattern))
+        elif pattern[-1] in (self.pathmod.sep, self.pathmod.altsep):
+            # GH-65238: pathlib doesn't preserve trailing slash. Add it back.
+            parts.append('')
+        elif parts[-1] == '**':
             # GH-70303: '**' only matches directories. Add trailing slash.
             warnings.warn(
                 "Pattern ending '**' will match files and directories in a "
                 "future Python release. Add a trailing slash to match only "
                 "directories and remove this warning.",
                 FutureWarning, 4)
-            parts.append('')
-        elif pattern[-1] in (self.pathmod.sep, self.pathmod.altsep):
-            # GH-65238: pathlib doesn't preserve trailing slash. Add it back.
             parts.append('')
         parts.reverse()
         return parts

--- a/Lib/pathlib/__init__.py
+++ b/Lib/pathlib/__init__.py
@@ -468,8 +468,8 @@ class PurePath(_abc.PurePathBase):
         return prefix + quote_from_bytes(os.fsencode(path))
 
     @property
-    def _pattern_parts(self):
-        """List of path components, to be used with patterns in glob()."""
+    def _pattern_stack(self):
+        """Stack of path components, to be used with patterns in glob()."""
         parts = self._tail.copy()
         pattern = self._raw_path
         if pattern.endswith('**'):
@@ -483,6 +483,7 @@ class PurePath(_abc.PurePathBase):
         elif pattern[-1] in (self.pathmod.sep, self.pathmod.altsep):
             # GH-65238: pathlib doesn't preserve trailing slash. Add it back.
             parts.append('')
+        parts.reverse()
         return parts
 
 

--- a/Lib/pathlib/_abc.py
+++ b/Lib/pathlib/_abc.py
@@ -430,7 +430,10 @@ class PurePathBase:
     @property
     def _pattern_stack(self):
         """Stack of path components, to be used with patterns in glob()."""
-        return self._stack[1]
+        anchor, parts = self._stack
+        if anchor:
+            raise NotImplementedError("Non-relative patterns are unsupported")
+        return parts
 
     def match(self, path_pattern, *, case_sensitive=None):
         """
@@ -733,11 +736,6 @@ class PathBase(PurePathBase):
         """
         if not isinstance(pattern, PurePathBase):
             pattern = self.with_segments(pattern)
-        if pattern.anchor:
-            raise NotImplementedError("Non-relative patterns are unsupported")
-        elif not pattern.parts:
-            raise ValueError("Unacceptable pattern: {!r}".format(pattern))
-
         if case_sensitive is None:
             # TODO: evaluate case-sensitivity of each directory in _select_children().
             case_sensitive = _is_case_sensitive(self.pathmod)

--- a/Lib/test/test_pathlib/test_pathlib.py
+++ b/Lib/test/test_pathlib/test_pathlib.py
@@ -1859,6 +1859,22 @@ class PathTest(test_pathlib_abc.DummyPathTest, PurePathTest):
         with self.assertWarns(FutureWarning):
             p.rglob('*/**')
 
+    def test_glob_pathlike(self):
+        P = self.cls
+        p = P(self.base)
+        pattern = "dir*/file*"
+        expect = {p / "dirB/fileB", p / "dirC/fileC"}
+        self.assertEqual(expect, set(p.glob(P(pattern))))
+        self.assertEqual(expect, set(p.glob(FakePath(pattern))))
+
+    def test_rglob_pathlike(self):
+        P = self.cls
+        p = P(self.base, "dirC")
+        pattern = "**/file*"
+        expect = {p / "fileC", p / "dirD/fileD"}
+        self.assertEqual(expect, set(p.rglob(P(pattern))))
+        self.assertEqual(expect, set(p.rglob(FakePath(pattern))))
+
 
 @only_posix
 class PosixPathTest(PathTest, PurePosixPathTest):

--- a/Lib/test/test_pathlib/test_pathlib.py
+++ b/Lib/test/test_pathlib/test_pathlib.py
@@ -1818,6 +1818,13 @@ class PathTest(test_pathlib_abc.DummyPathTest, PurePathTest):
             list(base.walk())
             list(base.walk(top_down=False))
 
+    def test_glob_empty_pattern(self):
+        p = self.cls('')
+        with self.assertRaisesRegex(ValueError, 'Unacceptable pattern'):
+            list(p.glob(''))
+        with self.assertRaisesRegex(ValueError, 'Unacceptable pattern'):
+            list(p.glob('.'))
+
     def test_glob_many_open_files(self):
         depth = 30
         P = self.cls

--- a/Lib/test/test_pathlib/test_pathlib_abc.py
+++ b/Lib/test/test_pathlib/test_pathlib_abc.py
@@ -1045,9 +1045,12 @@ class DummyPathTest(DummyPurePathTest):
             _check(p.glob("*/"), ["dirA/", "dirB/", "dirC/", "dirE/", "linkB/"])
 
     def test_glob_empty_pattern(self):
-        p = self.cls('')
-        with self.assertRaisesRegex(ValueError, 'Unacceptable pattern'):
-            list(p.glob(''))
+        def _check(glob, expected):
+            self.assertEqual(set(glob), { P(self.base, q) for q in expected })
+        P = self.cls
+        p = P(self.base)
+        _check(p.glob(""), [""])
+        _check(p.glob("."), ["."])
 
     def test_glob_case_sensitive(self):
         P = self.cls

--- a/Misc/NEWS.d/next/Library/2024-01-12-17-32-36.gh-issue-79634.uTSTRI.rst
+++ b/Misc/NEWS.d/next/Library/2024-01-12-17-32-36.gh-issue-79634.uTSTRI.rst
@@ -1,0 +1,2 @@
+Accept :term:`path-like objects <path-like object>` as patterns in
+:meth:`pathlib.Path.glob` and :meth:`~pathlib.Path.rglob`.


### PR DESCRIPTION
Allow `os.PathLike` objects to be passed as patterns to `pathlib.Path.glob()` and `rglob()`.

(It's already possible to use them in `PurePath.match()`)

While we're in the area:

- Allow empty glob patterns in `PathBase` (but not `Path`)
- Speed up globbing in `PathBase` by generating paths with trailing slashes only as a final step, rather than for every intermediate directory.
- Simplify and speed up handling of rare patterns involving both `**` and `..` segments.

----

<!-- gh-issue-number: gh-79634 -->
* Issue: gh-79634
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--114017.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->