### PR TITLE
gh-111803: Use more reasonable nesting in test_plistlib's test_deep_nesting

### DIFF
--- a/Lib/test/test_plistlib.py
+++ b/Lib/test/test_plistlib.py
@@ -971,18 +971,15 @@ class TestBinaryPlistlib(unittest.TestCase):
         self.assertIs(b['x'], b)
 
     def test_deep_nesting(self):
-        for N in [300, 100000]:
+        for N in [50, 100]:
+          with self.subTest(N=N):
             chunks = [b'\xa1' + (i + 1).to_bytes(4, 'big') for i in range(N)]
-            try:
-                result = self.decode(*chunks, b'\x54seed', offset_size=4, ref_size=4)
-            except RecursionError:
-                pass
-            else:
-                for i in range(N):
-                    self.assertIsInstance(result, list)
-                    self.assertEqual(len(result), 1)
-                    result = result[0]
-                self.assertEqual(result, 'seed')
+            result = self.decode(*chunks, b'\x54seed', offset_size=4, ref_size=4)
+            for i in range(N):
+                self.assertIsInstance(result, list)
+                self.assertEqual(len(result), 1)
+                result = result[0]
+            self.assertEqual(result, 'seed')
 
     def test_large_timestamp(self):
         # Issue #26709: 32-bit timestamp out of range


### PR DESCRIPTION
This adjust the nesting levels used by the test_deep_nesting because the previous levels consistently hit the recursion limit and ended up not testing anything.

Adjusting the level is reasonable because the tested nesting levels should still be significantly larger than those seen in real world plist files.

The test also no longer ignores recursion errors.


<!-- gh-issue-number: gh-111803 -->
* Issue: gh-111803
<!-- /gh-issue-number -->
