### PR TITLE
[3.12] gh-114021: Pin various sphinxcontrib extensions to older versions

### DIFF
--- a/Doc/constraints.txt
+++ b/Doc/constraints.txt
@@ -15,10 +15,10 @@ requests<3
 snowballstemmer<3
 sphinxcontrib-applehelp<1.0.5
 sphinxcontrib-devhelp<1.0.6
-sphinxcontrib-htmlhelp<2.1
+sphinxcontrib-htmlhelp<2.0.5
 sphinxcontrib-jsmath<1.1
-sphinxcontrib-qthelp<1.1
-sphinxcontrib-serializinghtml<1.2
+sphinxcontrib-qthelp<1.0.7
+sphinxcontrib-serializinghtml<1.1.10
 
 # Direct dependencies of Jinja2 (Jinja is a dependency of Sphinx, see above)
 MarkupSafe<2.2

--- a/Doc/constraints.txt
+++ b/Doc/constraints.txt
@@ -13,7 +13,7 @@ packaging<24
 Pygments>=2.16.1,<3
 requests<3
 snowballstemmer<3
-sphinxcontrib-applehelp<1.1
+sphinxcontrib-applehelp<1.0.5
 sphinxcontrib-devhelp<1.1
 sphinxcontrib-htmlhelp<2.1
 sphinxcontrib-jsmath<1.1

--- a/Doc/constraints.txt
+++ b/Doc/constraints.txt
@@ -14,7 +14,7 @@ Pygments>=2.16.1,<3
 requests<3
 snowballstemmer<3
 sphinxcontrib-applehelp<1.0.5
-sphinxcontrib-devhelp<1.1
+sphinxcontrib-devhelp<1.0.6
 sphinxcontrib-htmlhelp<2.1
 sphinxcontrib-jsmath<1.1
 sphinxcontrib-qthelp<1.1


### PR DESCRIPTION
This PR pins a number of sphinxcontrib extensions to ensure they can be used with the version of Sphinx used to build the documentation.

<!-- gh-issue-number: gh-114021 -->
* Issue: gh-114021
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--114022.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->