### PR TITLE
gh-111803: Support loading more deeply nested lists in binary plist format

### DIFF
--- a/Lib/plistlib.py
+++ b/Lib/plistlib.py
@@ -600,7 +600,8 @@ class _BinaryPlistParser:
             obj_refs = self._read_refs(s)
             result = []
             self._objects[ref] = result
-            result.extend(self._read_object(x) for x in obj_refs)
+            for x in obj_refs:
+                result.append(self._read_object(x))
 
         # tokenH == 0xB0 is documented as 'ordset', but is not actually
         # implemented in the Apple reference code.

--- a/Misc/NEWS.d/next/Library/2024-01-13-14-20-31.gh-issue-111803.llpLAw.rst
+++ b/Misc/NEWS.d/next/Library/2024-01-13-14-20-31.gh-issue-111803.llpLAw.rst
@@ -1,0 +1,2 @@
+:mod:`plistlib` now supports loading more deeply nested lists in binary
+format.


### PR DESCRIPTION
It no longer uses the C stack and the depth of nesting is only limited by Python recursion limit setting.


<!-- gh-issue-number: gh-111803 -->
* Issue: gh-111803
<!-- /gh-issue-number -->
