### PR TITLE
gh-111803: Make test_deep_nesting from test_plistlib more strict

### DIFF
--- a/Lib/test/test_plistlib.py
+++ b/Lib/test/test_plistlib.py
@@ -971,7 +971,7 @@ class TestBinaryPlistlib(unittest.TestCase):
         self.assertIs(b['x'], b)
 
     def test_deep_nesting(self):
-        for N in [50, 300, 100000]:
+        for N in [50, 300, 100_000]:
             chunks = [b'\xa1' + (i + 1).to_bytes(4, 'big') for i in range(N)]
             try:
                 result = self.decode(*chunks, b'\x54seed', offset_size=4, ref_size=4)

--- a/Lib/test/test_plistlib.py
+++ b/Lib/test/test_plistlib.py
@@ -971,12 +971,12 @@ class TestBinaryPlistlib(unittest.TestCase):
         self.assertIs(b['x'], b)
 
     def test_deep_nesting(self):
-        for N in [300, 100000]:
+        for N in [50, 300, 100000]:
             chunks = [b'\xa1' + (i + 1).to_bytes(4, 'big') for i in range(N)]
             try:
                 result = self.decode(*chunks, b'\x54seed', offset_size=4, ref_size=4)
             except RecursionError:
-                pass
+                self.assertGreater(N, sys.getrecursionlimit())
             else:
                 for i in range(N):
                     self.assertIsInstance(result, list)


### PR DESCRIPTION
It is no longer silently passed if RecursionError was raised for low recursion depth.


<!-- gh-issue-number: gh-111803 -->
* Issue: gh-111803
<!-- /gh-issue-number -->
