### PR TITLE
GH-99334: Explain that `PurePath.is_relative_to()` is purely lexical.

### DIFF
--- a/Doc/library/pathlib.rst
+++ b/Doc/library/pathlib.rst
@@ -528,6 +528,13 @@ Pure paths provide the following methods and properties:
       >>> p.is_relative_to('/usr')
       False
 
+   This method is string-based; it neither accesses the filesystem nor treats
+   "``..``" segments specially. The following code is equivalent:
+
+      >>> u = PurePath('/usr')
+      >>> u == p or u in p.parents
+      True
+
    .. versionadded:: 3.9
 
    .. deprecated-removed:: 3.12 3.14

--- a/Doc/library/pathlib.rst
+++ b/Doc/library/pathlib.rst
@@ -533,7 +533,7 @@ Pure paths provide the following methods and properties:
 
       >>> u = PurePath('/usr')
       >>> u == p or u in p.parents
-      True
+      False
 
    .. versionadded:: 3.9
 

--- a/Misc/NEWS.d/next/Documentation/2024-01-13-18-23-56.gh-issue-99334.qv6b34.rst
+++ b/Misc/NEWS.d/next/Documentation/2024-01-13-18-23-56.gh-issue-99334.qv6b34.rst
@@ -1,0 +1,1 @@
+Explain that :meth:`PurePath.is_relative_to` is a purely lexical operation.

--- a/Misc/NEWS.d/next/Documentation/2024-01-13-18-23-56.gh-issue-99334.qv6b34.rst
+++ b/Misc/NEWS.d/next/Documentation/2024-01-13-18-23-56.gh-issue-99334.qv6b34.rst
@@ -1,1 +1,0 @@
-Explain that :meth:`PurePath.is_relative_to` is a purely lexical operation.


### PR DESCRIPTION


<!-- gh-issue-number: gh-99334 -->
* Issue: gh-99334
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--114031.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->