### PR TITLE
GH-82695: Clarify `pathlib.Path.mkdir()` documentation

### DIFF
--- a/Doc/library/pathlib.rst
+++ b/Doc/library/pathlib.rst
@@ -1280,9 +1280,9 @@ call fails (for example because the path doesn't exist).
    If *exist_ok* is false (the default), :exc:`FileExistsError` is
    raised if the target directory already exists.
 
-   If *exist_ok* is true, :exc:`FileExistsError` exceptions will be
-   ignored (same behavior as the POSIX ``mkdir -p`` command), but only if the
-   last path component is not an existing non-directory file.
+   If *exist_ok* is true, :exc:`FileExistsError` is raised only if the given
+   path already exists in the file system and is not a directory (same
+   behavior as the POSIX ``mkdir -p`` command).
 
    .. versionchanged:: 3.5
       The *exist_ok* parameter was added.

--- a/Doc/library/pathlib.rst
+++ b/Doc/library/pathlib.rst
@@ -1280,7 +1280,7 @@ call fails (for example because the path doesn't exist).
    If *exist_ok* is false (the default), :exc:`FileExistsError` is
    raised if the target directory already exists.
 
-   If *exist_ok* is true, :exc:`FileExistsError` is raised only if the given
+   If *exist_ok* is true, :exc:`FileExistsError` will not be raised unless the given
    path already exists in the file system and is not a directory (same
    behavior as the POSIX ``mkdir -p`` command).
 

--- a/Misc/NEWS.d/next/Documentation/2024-01-13-18-34-39.gh-issue-82695.xNkDqE.rst
+++ b/Misc/NEWS.d/next/Documentation/2024-01-13-18-34-39.gh-issue-82695.xNkDqE.rst
@@ -1,0 +1,2 @@
+Clarify :meth:`pathlib.Path.mkdir` documentation by removing a double
+negative.

--- a/Misc/NEWS.d/next/Documentation/2024-01-13-18-34-39.gh-issue-82695.xNkDqE.rst
+++ b/Misc/NEWS.d/next/Documentation/2024-01-13-18-34-39.gh-issue-82695.xNkDqE.rst
@@ -1,2 +1,0 @@
-Clarify :meth:`pathlib.Path.mkdir` documentation by removing a double
-negative.


### PR DESCRIPTION
Remove a double negative in the documentation of `mkdir()`'s *exist_ok* parameter.


<!-- gh-issue-number: gh-82695 -->
* Issue: gh-82695
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--114032.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->