### PR TITLE
[3.11] GH-101130: Document multiple arguments for `PurePath.[is_]relative_to()`

### DIFF
--- a/Doc/library/pathlib.rst
+++ b/Doc/library/pathlib.rst
@@ -508,6 +508,8 @@ Pure paths provide the following methods and properties:
       >>> p.is_relative_to('/usr')
       False
 
+   If multiple arguments are supplied, they are joined together.
+
    .. versionadded:: 3.9
 
 
@@ -588,6 +590,8 @@ Pure paths provide the following methods and properties:
         File "pathlib.py", line 694, in relative_to
           .format(str(self), str(formatted)))
       ValueError: '/etc/passwd' is not in the subpath of '/usr' OR one path is relative and the other absolute.
+
+   If multiple arguments are supplied, they are joined together.
 
    NOTE: This function is part of :class:`PurePath` and works with strings. It does not check or access the underlying file structure.
 

--- a/Misc/NEWS.d/next/Documentation/2024-01-13-18-48-13.gh-issue-101130.lK8nFn.rst
+++ b/Misc/NEWS.d/next/Documentation/2024-01-13-18-48-13.gh-issue-101130.lK8nFn.rst
@@ -1,0 +1,3 @@
+Document that multiple arguments are joined together when given to
+:meth:`pathlib.PurePath.relative_to` or
+:meth:`~pathlib.PurePath.is_relative_to`

--- a/Misc/NEWS.d/next/Documentation/2024-01-13-18-48-13.gh-issue-101130.lK8nFn.rst
+++ b/Misc/NEWS.d/next/Documentation/2024-01-13-18-48-13.gh-issue-101130.lK8nFn.rst
@@ -1,3 +1,0 @@
-Document that multiple arguments are joined together when given to
-:meth:`pathlib.PurePath.relative_to` or
-:meth:`~pathlib.PurePath.is_relative_to`


### PR DESCRIPTION
3.11-only change as this is already covered in the 3.12+ deprecation warning.


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--114034.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->

<!-- gh-issue-number: gh-101130 -->
* Issue: gh-101130
<!-- /gh-issue-number -->
