### PR TITLE
GH-105900: Fix `pathlib.Path.symlink_to(target_is_directory=...)` docs

### DIFF
--- a/Doc/library/pathlib.rst
+++ b/Doc/library/pathlib.rst
@@ -1510,9 +1510,11 @@ call fails (for example because the path doesn't exist).
 
 .. method:: Path.symlink_to(target, target_is_directory=False)
 
-   Make this path a symbolic link to *target*.  Under Windows,
-   *target_is_directory* must be true (default ``False``) if the link's target
-   is a directory.  Under POSIX, *target_is_directory*'s value is ignored.
+   Make this path a symbolic link to *target*.  Under Windows, if the target
+   is present, the type of the symlink will be created to match.  Otherwise,
+   the symlink will be created as a directory if *target_is_directory* is
+   ``True`` or a file symlink (the default) otherwise.  Under POSIX,
+   *target_is_directory*'s value is ignored.
 
    ::
 

--- a/Doc/library/pathlib.rst
+++ b/Doc/library/pathlib.rst
@@ -1510,11 +1510,13 @@ call fails (for example because the path doesn't exist).
 
 .. method:: Path.symlink_to(target, target_is_directory=False)
 
-   Make this path a symbolic link to *target*.  Under Windows, if the target
-   is present, the type of the symlink will be created to match.  Otherwise,
-   the symlink will be created as a directory if *target_is_directory* is
-   ``True`` or a file symlink (the default) otherwise.  Under POSIX,
-   *target_is_directory*'s value is ignored.
+   Make this path a symbolic link pointing to *target*.
+
+   On Windows, a symlink represents either a file or a directory, and does not
+   morph to the target dynamically.  If the target is present, the type of the
+   symlink will be created to match. Otherwise, the symlink will be created
+   as a directory if *target_is_directory* is ``True`` or a file symlink (the
+   default) otherwise.  On non-Windows platforms, *target_is_directory* is ignored.
 
    ::
 

--- a/Misc/NEWS.d/next/Documentation/2024-01-13-18-58-04.gh-issue-105900.go-Qkk.rst
+++ b/Misc/NEWS.d/next/Documentation/2024-01-13-18-58-04.gh-issue-105900.go-Qkk.rst
@@ -1,0 +1,2 @@
+Fix misleading documentation for *target_is_directory* parameter of
+:meth:`pathlib.Path.symlink_to`.

--- a/Misc/NEWS.d/next/Documentation/2024-01-13-18-58-04.gh-issue-105900.go-Qkk.rst
+++ b/Misc/NEWS.d/next/Documentation/2024-01-13-18-58-04.gh-issue-105900.go-Qkk.rst
@@ -1,2 +1,0 @@
-Fix misleading documentation for *target_is_directory* parameter of
-:meth:`pathlib.Path.symlink_to`.


### PR DESCRIPTION
Clarify that *target_is_directory* only matters if the target doesn't exist.


<!-- gh-issue-number: gh-105900 -->
* Issue: gh-105900
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--114035.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->