### PR TITLE
GH-78988: Document `pathlib.Path.glob()` exception propagation.

### DIFF
--- a/Doc/library/pathlib.rst
+++ b/Doc/library/pathlib.rst
@@ -993,6 +993,10 @@ call fails (for example because the path doesn't exist).
       Set *follow_symlinks* to ``True`` or ``False`` to improve performance
       of recursive globbing.
 
+   This method calls :meth:`Path.is_dir` on the top-level directory and
+   propagates any :exc:`OSError` exception that is raised. Subsequent
+   :exc:`OSError` exceptions from scanning directories are suppressed.
+
    By default, or when the *case_sensitive* keyword-only argument is set to
    ``None``, this method matches paths using platform-specific casing rules:
    typically, case-sensitive on POSIX, and case-insensitive on Windows.

--- a/Misc/NEWS.d/next/Documentation/2024-01-13-19-36-51.gh-issue-78988.QC-EQP.rst
+++ b/Misc/NEWS.d/next/Documentation/2024-01-13-19-36-51.gh-issue-78988.QC-EQP.rst
@@ -1,0 +1,1 @@
+Document :meth:`pathlib.Path.glob` exception propagation.

--- a/Misc/NEWS.d/next/Documentation/2024-01-13-19-36-51.gh-issue-78988.QC-EQP.rst
+++ b/Misc/NEWS.d/next/Documentation/2024-01-13-19-36-51.gh-issue-78988.QC-EQP.rst
@@ -1,1 +1,0 @@
-Document :meth:`pathlib.Path.glob` exception propagation.


### PR DESCRIPTION
We propagate any `OSError` from the `is_dir()` call on the top-level directory, and suppress all others.

<!-- gh-issue-number: gh-78988 -->
* Issue: gh-78988
<!-- /gh-issue-number -->
