### PR TITLE
GH-108852: Add support for Nushell on virtual environment creation

### DIFF
--- a/Doc/library/venv.rst
+++ b/Doc/library/venv.rst
@@ -96,10 +96,14 @@ containing the virtual environment):
 |             | csh/tcsh   | :samp:`$ source {<venv>}/bin/activate.csh`       |
 |             +------------+--------------------------------------------------+
 |             | PowerShell | :samp:`$ {<venv>}/bin/Activate.ps1`              |
+|             +------------+--------------------------------------------------+
+|             | Nushell    | :samp:`$ overlay use {<venv>}/bin/activate.nu`   |
 +-------------+------------+--------------------------------------------------+
 | Windows     | cmd.exe    | :samp:`C:\\> {<venv>}\\Scripts\\activate.bat`    |
 |             +------------+--------------------------------------------------+
 |             | PowerShell | :samp:`PS C:\\> {<venv>}\\Scripts\\Activate.ps1` |
+|             +------------+--------------------------------------------------+
+|             | Nushell    | :samp:`$ overlay use {<venv>}/bin/activate.nu`   |
 +-------------+------------+--------------------------------------------------+
 
 .. versionadded:: 3.4
@@ -108,6 +112,9 @@ containing the virtual environment):
 .. versionadded:: 3.8
    PowerShell activation scripts installed under POSIX for PowerShell Core
    support.
+
+.. versionadded:: 3.13
+   :program:`nushell` activation overlay script was added.
 
 You don't specifically *need* to activate a virtual environment,
 as you can just specify the full path to that environment's

--- a/Doc/using/venv-create.inc
+++ b/Doc/using/venv-create.inc
@@ -78,6 +78,8 @@ The command, if run with ``-h``, will show the available options::
    ``--without-scm-ignore-file`` was added along with creating an ignore file
    for ``git`` by default.
 
+   :program:`nushell` activation overlay script was added.
+
 .. versionchanged:: 3.12
 
    ``setuptools`` is no longer a core venv dependency.

--- a/Lib/venv/scripts/common/activate.nu
+++ b/Lib/venv/scripts/common/activate.nu
@@ -1,0 +1,96 @@
+# Virtual environment activation module
+# Activate with `overlay use activate.nu`
+# Deactivate with `deactivate`, as usual
+#
+# To customize the overlay name, you can call `overlay use activate.nu as foo`,
+# but then simply `deactivate` won't work because it is just an alias to hide
+# the "activate" overlay. You'd need to call `overlay hide foo` manually.
+
+export-env {
+    def is-string [x] {
+        ($x | describe) == 'string'
+    }
+
+    def has-env [...names] {
+        $names | each {|n|
+            $n in $env
+        } | all {|i| $i == true}
+    }
+
+    # Emulates a `test -z`, but btter as it handles e.g 'false'
+    def is-env-true [name: string] {
+      if (has-env $name) {
+        # Try to parse 'true', '0', '1', and fail if not convertible
+        let parsed = (do -i { $env | get $name | into bool })
+        if ($parsed | describe) == 'bool' {
+          $parsed
+        } else {
+          not ($env | get -i $name | is-empty)
+        }
+      } else {
+        false
+      }
+    }
+
+    let virtual_env = '__VIRTUAL_ENV__'
+    let bin = '__BIN_NAME__'
+
+    let is_windows = ($nu.os-info.family) == 'windows'
+    let path_name = (if (has-env 'Path') {
+            'Path'
+        } else {
+            'PATH'
+        }
+    )
+
+    let venv_path = ([$virtual_env $bin] | path join)
+    let new_path = ($env | get $path_name | prepend $venv_path)
+
+    # If there is no default prompt, then use the env name instead
+    let virtual_env_prompt = (if ('__VIRTUAL_PROMPT__' | is-empty) {
+        ($virtual_env | path basename)
+    } else {
+        '__VIRTUAL_PROMPT__'
+    })
+
+    let new_env = {
+        $path_name         : $new_path
+        VIRTUAL_ENV        : $virtual_env
+        VIRTUAL_ENV_PROMPT : $virtual_env_prompt
+    }
+
+    let new_env = (if (is-env-true 'VIRTUAL_ENV_DISABLE_PROMPT') {
+      $new_env
+    } else {
+      # Creating the new prompt for the session
+      let virtual_prefix = $'(char lparen)($virtual_env_prompt)(char rparen) '
+
+      # Back up the old prompt builder
+      let old_prompt_command = (if (has-env 'PROMPT_COMMAND') {
+              $env.PROMPT_COMMAND
+          } else {
+              ''
+        })
+
+      let new_prompt = (if (has-env 'PROMPT_COMMAND') {
+          if 'closure' in ($old_prompt_command | describe) {
+              {|| $'($virtual_prefix)(do $old_prompt_command)' }
+          } else {
+              {|| $'($virtual_prefix)($old_prompt_command)' }
+          }
+      } else {
+          {|| $'($virtual_prefix)' }
+      })
+
+      $new_env | merge {
+        PROMPT_COMMAND      : $new_prompt
+        VIRTUAL_PREFIX      : $virtual_prefix
+      }
+    })
+
+    # Environment variables that will be loaded as the virtual env
+    load-env $new_env
+}
+
+export alias pydoc = python -m pydoc
+export alias deactivate = overlay hide activate

--- a/Misc/NEWS.d/next/Documentation/2024-01-13-15-40-46.gh-issue-108852.fj849Y.rst
+++ b/Misc/NEWS.d/next/Documentation/2024-01-13-15-40-46.gh-issue-108852.fj849Y.rst
@@ -1,0 +1,2 @@
+Added support for :program:`nushell` in virtual environments. Patch by
+Hormet Yiltiz, Jakub Žádník, and Mel Massadian.


### PR DESCRIPTION
Add support for Nushell on virtual environment creation

Script originally contributed by @elferherrera and updated by the community (@melMass @fdncred @tusharsadhwani @kubouch @m-lima @WindSoilder @sophiajt @jimporter) to the Virtualenv project [4].

In light of some recent updates in Nushell development, we may be approaching a time to provide support for Nushell:
- Nushell users has been in increasing steadily and uses it in personal and work environments as it is quite stable [1].
- This script is fully tested as part of `virtualenv` and was stable since May 17, 2023 [2]. During this time, Nushell had 13 minor updates, none of which broke compatility and none required an update to this script [3].


[1] https://www.nushell.sh/blog/2023-11-16-nushell-2023-survey-results.html
[2] https://github.com/pypa/virtualenv/pull/2572
[3] https://github.com/nushell/nushell/pull/9212
[4] https://github.com/pypa/virtualenv/commits/main/src/virtualenv/activation/nushell/activate.nu

---- 

<!-- gh-issue-number: gh-108852 -->
* Issue: gh-108852
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--114043.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->