### PR TITLE
[3.11] gh-95649: Document that asyncio contains uvloop code (GH-107536)

### DIFF
--- a/Doc/license.rst
+++ b/Doc/license.rst
@@ -1064,3 +1064,32 @@ The audioop module uses the code base in g771.c file of the SoX project::
     distributed freely.  This document may not be included in published
     material or commercial packages without the written consent of its
     author.
+
+
+asyncio
+----------
+
+Parts of the :mod:`asyncio` module are incorporated from
+`uvloop 0.16 <https://github.com/MagicStack/uvloop/tree/v0.16.0>`_,
+which is distributed under the MIT license::
+
+  Copyright (c) 2015-2021 MagicStack Inc.  http://magic.io
+
+  Permission is hereby granted, free of charge, to any person obtaining
+  a copy of this software and associated documentation files (the
+  "Software"), to deal in the Software without restriction, including
+  without limitation the rights to use, copy, modify, merge, publish,
+  distribute, sublicense, and/or sell copies of the Software, and to
+  permit persons to whom the Software is furnished to do so, subject to
+  the following conditions:
+
+  The above copyright notice and this permission notice shall be
+  included in all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+  MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+  LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+  OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+  WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/Lib/asyncio/constants.py
+++ b/Lib/asyncio/constants.py
@@ -1,3 +1,7 @@
+# Contains code from https://github.com/MagicStack/uvloop/tree/v0.16.0
+# SPDX-License-Identifier: PSF-2.0 AND (MIT OR Apache-2.0)
+# SPDX-FileCopyrightText: Copyright (c) 2015-2021 MagicStack Inc.  http://magic.io
+
 import enum
 
 # After the connection is lost, log warnings after this many write()s.

--- a/Lib/asyncio/events.py
+++ b/Lib/asyncio/events.py
@@ -1,5 +1,9 @@
 """Event loop and event loop policy."""
 
+# Contains code from https://github.com/MagicStack/uvloop/tree/v0.16.0
+# SPDX-License-Identifier: PSF-2.0 AND (MIT OR Apache-2.0)
+# SPDX-FileCopyrightText: Copyright (c) 2015-2021 MagicStack Inc.  http://magic.io
+
 __all__ = (
     'AbstractEventLoopPolicy',
     'AbstractEventLoop', 'AbstractServer',

--- a/Lib/asyncio/sslproto.py
+++ b/Lib/asyncio/sslproto.py
@@ -1,3 +1,7 @@
+# Contains code from https://github.com/MagicStack/uvloop/tree/v0.16.0
+# SPDX-License-Identifier: PSF-2.0 AND (MIT OR Apache-2.0)
+# SPDX-FileCopyrightText: Copyright (c) 2015-2021 MagicStack Inc.  http://magic.io
+
 import collections
 import enum
 import warnings

--- a/Lib/test/test_asyncio/test_ssl.py
+++ b/Lib/test/test_asyncio/test_ssl.py
@@ -1,3 +1,7 @@
+# Contains code from https://github.com/MagicStack/uvloop/tree/v0.16.0
+# SPDX-License-Identifier: PSF-2.0 AND (MIT OR Apache-2.0)
+# SPDX-FileCopyrightText: Copyright (c) 2015-2021 MagicStack Inc.  http://magic.io
+
 import asyncio
 import asyncio.sslproto
 import contextlib

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -944,6 +944,7 @@ Carsten Klein
 Bastian Kleineidam
 Joel Klimont
 Bob Kline
+Alois Klink
 Matthias Klose
 Jeremy Kloth
 Thomas Kluyver

--- a/Misc/NEWS.d/next/Documentation/2023-08-01-13-11-39.gh-issue-95649.F4KhPS.rst
+++ b/Misc/NEWS.d/next/Documentation/2023-08-01-13-11-39.gh-issue-95649.F4KhPS.rst
@@ -1,0 +1,3 @@
+Document that the :mod:`asyncio` module contains code taken from `v0.16.0 of
+the uvloop project <https://github.com/MagicStack/uvloop/tree/v0.16.0>`_, as
+well as the required MIT licensing information.


### PR DESCRIPTION
Some of the asyncio SSL changes in GH-31275 (see [1]) were taken from v0.16.0 of the uvloop project (see [2]). In order to comply with the MIT license, we need to just need to document the copyright information.

(cherry picked from commit https://github.com/python/cpython/commit/dce30c9cbc212e5455e100f35ac6afeb30dfd23e)

[1]: https://github.com/python/cpython/pull/31275
[2]: https://github.com/MagicStack/uvloop/tree/v0.16.0


---

Backport was due to a merge conflict in `Doc/license.rst` due to:
- https://github.com/python/cpython/commit/f66be6b11a0329e90cb0630c24fd8b07ce6b5c7c removing a license in `Doc/license.rst`
- https://github.com/python/cpython/commit/05f2f0ac92afa560315eb66fd6576683c7f69e2d adding a license in `Doc/license.rst`

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--114045.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->