### PR TITLE
gh-114050: Fix crash when more than two arguments are passed to int()

### DIFF
--- a/Lib/test/test_int.py
+++ b/Lib/test/test_int.py
@@ -90,6 +90,7 @@ class IntTestCases(unittest.TestCase):
 
 
         self.assertRaises(TypeError, int, 1, 12)
+        self.assertRaises(TypeError, int, "10", 2, 1)
 
         self.assertEqual(int('0o123', 0), 83)
         self.assertEqual(int('0x123', 16), 291)

--- a/Misc/NEWS.d/next/Core and Builtins/2024-01-17-23-39-20.gh-issue-114050.Lnv1oq.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2024-01-17-23-39-20.gh-issue-114050.Lnv1oq.rst
@@ -1,0 +1,2 @@
+Fix segmentation fault caused by an incorrect format string
+in ``TypeError`` exception when more than two arguments are passed to ``int``.

--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -6171,7 +6171,7 @@ long_vectorcall(PyObject *type, PyObject * const*args,
             return long_new_impl(_PyType_CAST(type), args[0], args[1]);
         default:
             return PyErr_Format(PyExc_TypeError,
-                                "int expected at most 2 argument%s, got %zd",
+                                "int expected at most 2 arguments, got %zd",
                                 nargs);
     }
 }


### PR DESCRIPTION
Remove the typo in the format string, as it is unnecessary

issue : https://github.com/python/cpython/issues/114050

<!-- gh-issue-number: gh-114050 -->
* Issue: gh-114050
<!-- /gh-issue-number -->
