### PR TITLE
gh-109534: fix reference leak when SSL handshake fails

### DIFF
--- a/Lib/asyncio/selector_events.py
+++ b/Lib/asyncio/selector_events.py
@@ -235,6 +235,10 @@ class BaseSelectorEventLoop(base_events.BaseEventLoop):
                 await waiter
             except BaseException:
                 transport.close()
+                # gh-109534: When an exception is raised by the SSLProtocol object the
+                # exception set in this future can keep the protocol object alive and
+                # cause a reference cycle.
+                waiter = None
                 raise
                 # It's now up to the protocol to handle the connection.
 

--- a/Lib/asyncio/sslproto.py
+++ b/Lib/asyncio/sslproto.py
@@ -461,7 +461,7 @@ class SSLProtocol(protocols.BufferedProtocol):
                 logger.debug("%r received EOF", self)
 
             if self._state == SSLProtocolState.DO_HANDSHAKE:
-                self._on_handshake_complete(ConnectionResetError())
+                self._on_handshake_complete(ConnectionResetError)
 
             elif self._state == SSLProtocolState.WRAPPED:
                 self._set_state(SSLProtocolState.FLUSHING)
@@ -571,17 +571,22 @@ class SSLProtocol(protocols.BufferedProtocol):
             self._handshake_timeout_handle = None
 
         sslobj = self._sslobj
-        if handshake_exc is None:
-            self._set_state(SSLProtocolState.WRAPPED)
+        try:
+            if handshake_exc is None:
+                self._set_state(SSLProtocolState.WRAPPED)
+            else:
+                raise handshake_exc
+
             peercert = sslobj.getpeercert()
-        else:
+        except Exception as exc:
+            handshake_exc = None
             self._set_state(SSLProtocolState.UNWRAPPED)
-            if isinstance(handshake_exc, ssl.CertificateError):
+            if isinstance(exc, ssl.CertificateError):
                 msg = 'SSL handshake failed on verifying the certificate'
             else:
                 msg = 'SSL handshake failed'
-            self._fatal_error(handshake_exc, msg)
-            self._wakeup_waiter(handshake_exc)
+            self._fatal_error(exc, msg)
+            self._wakeup_waiter(exc)
             return
 
         if self._loop.get_debug():

--- a/Misc/NEWS.d/next/Library/2024-01-15-18-42-44.gh-issue-109534.wYaLMZ.rst
+++ b/Misc/NEWS.d/next/Library/2024-01-15-18-42-44.gh-issue-109534.wYaLMZ.rst
@@ -1,0 +1,3 @@
+Fix a reference leak in
+:class:`asyncio.selector_events.BaseSelectorEventLoop` when SSL handshakes
+fail. Patch contributed by Jamie Phan.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
Fixes a reference cycle issue between the `Future` object used in `selector_events.BaseSelectorEventLoop._accept_connection2` and `SSLProtocol` which prevented the `SSLProtocol` from deallocating and causing spikes in memory usage.

The root cause of the issue is that, on SSL handshake failure, the `SSLProtocol` sets the `Future` (waiter) exception, and the traceback frames in that exception will hold references to the protocol object and its buffers.

~Refactored `SSLProtocol._on_handshake_complete` to not use `try/except` as this created a frame that kept the waiter object alive.~ Edit: see comments below


<!-- gh-issue-number: gh-109534 -->
* Issue: gh-109534
<!-- /gh-issue-number -->
