### PR TITLE
gh-114077: Fix OverflowError in socket.sendfile() when pass count >2GiB

### DIFF
--- a/Lib/socket.py
+++ b/Lib/socket.py
@@ -382,7 +382,7 @@ class socket(_socket.socket):
                     if timeout and not selector_select(timeout):
                         raise TimeoutError('timed out')
                     if count:
-                        blocksize = count - total_sent
+                        blocksize = min(count - total_sent, blocksize)
                         if blocksize <= 0:
                             break
                     try:

--- a/Misc/NEWS.d/next/Library/2024-01-15-12-12-54.gh-issue-114077.KcVnfj.rst
+++ b/Misc/NEWS.d/next/Library/2024-01-15-12-12-54.gh-issue-114077.KcVnfj.rst
@@ -1,2 +1,2 @@
-Fix possible OverflowError in :meth:`socket.socket.sendfile` when pass
+Fix possible :exc:`OverflowError` in :meth:`socket.socket.sendfile` when pass
 *count* larger than 2 GiB on 32-bit platform.

--- a/Misc/NEWS.d/next/Library/2024-01-15-12-12-54.gh-issue-114077.KcVnfj.rst
+++ b/Misc/NEWS.d/next/Library/2024-01-15-12-12-54.gh-issue-114077.KcVnfj.rst
@@ -1,0 +1,2 @@
+Fix possible OverflowError in :meth:`socket.socket.sendfile` when pass
+*count* larger than 2 GiB on 32-bit platform.


### PR DESCRIPTION
There are no tests for sending such large files. And I think that they would be non-practical.

<!-- gh-issue-number: gh-114077 -->
* Issue: gh-114077
<!-- /gh-issue-number -->
