### PR TITLE
GH-114013: fix setting `HOSTRUNNER` for `Tools/wasm/wasi.py`

### DIFF
--- a/Lib/test/test_isinstance.py
+++ b/Lib/test/test_isinstance.py
@@ -310,7 +310,7 @@ class TestIsInstanceIsSubclass(unittest.TestCase):
             @property
             def __bases__(self):
                 return self.__bases__
-        with support.infinite_recursion():
+        with support.infinite_recursion(25):
             self.assertRaises(RecursionError, issubclass, X(), int)
             self.assertRaises(RecursionError, issubclass, int, X())
             self.assertRaises(RecursionError, isinstance, 1, X())

--- a/Lib/test/test_richcmp.py
+++ b/Lib/test/test_richcmp.py
@@ -221,7 +221,7 @@ class MiscTest(unittest.TestCase):
             self.assertRaises(Exc, func, Bad())
 
     @support.no_tracing
-    @support.infinite_recursion()
+    @support.infinite_recursion(25)
     def test_recursion(self):
         # Check that comparison for recursive objects fails gracefully
         from collections import UserList

--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -5684,7 +5684,7 @@ class ForwardRefTests(BaseTestCase):
         def cmp(o1, o2):
             return o1 == o2
 
-        with infinite_recursion():
+        with infinite_recursion(25):
             r1 = namespace1()
             r2 = namespace2()
             self.assertIsNot(r1, r2)

--- a/Lib/test/test_userdict.py
+++ b/Lib/test/test_userdict.py
@@ -215,7 +215,7 @@ class UserDictTest(mapping_tests.TestHashMappingProtocol):
 
     # Decorate existing test with recursion limit, because
     # the test is for C structure, but `UserDict` is a Python structure.
-    test_repr_deep = support.infinite_recursion()(
+    test_repr_deep = support.infinite_recursion(25)(
         mapping_tests.TestHashMappingProtocol.test_repr_deep,
     )
 

--- a/Lib/test/test_userlist.py
+++ b/Lib/test/test_userlist.py
@@ -69,7 +69,7 @@ class UserListTest(list_tests.CommonTest):
 
     # Decorate existing test with recursion limit, because
     # the test is for C structure, but `UserList` is a Python structure.
-    test_repr_deep = support.infinite_recursion()(
+    test_repr_deep = support.infinite_recursion(25)(
         list_tests.CommonTest.test_repr_deep,
     )
 

--- a/Lib/test/test_xml_etree.py
+++ b/Lib/test/test_xml_etree.py
@@ -2535,7 +2535,7 @@ class BadElementTest(ElementTestCase, unittest.TestCase):
         e.extend([ET.Element('bar')])
         self.assertRaises(ValueError, e.remove, X('baz'))
 
-    @support.infinite_recursion()
+    @support.infinite_recursion(25)
     def test_recursive_repr(self):
         # Issue #25455
         e = ET.Element('foo')

--- a/Misc/NEWS.d/next/Build/2024-01-15-16-58-43.gh-issue-114013.FoSeQf.rst
+++ b/Misc/NEWS.d/next/Build/2024-01-15-16-58-43.gh-issue-114013.FoSeQf.rst
@@ -1,0 +1,4 @@
+Fix ``Tools/wasm/wasi.py`` to not include the path to ``python.wasm`` as
+part of ``HOSTRUNNER``. The environment variable is meant to specify how to
+run the WASI host only, having ``python.wasm`` and relevant flags appended
+to the ``HOSTRUNNER``.

--- a/Misc/NEWS.d/next/Build/2024-01-15-16-58-43.gh-issue-114013.FoSeQf.rst
+++ b/Misc/NEWS.d/next/Build/2024-01-15-16-58-43.gh-issue-114013.FoSeQf.rst
@@ -1,4 +1,4 @@
 Fix ``Tools/wasm/wasi.py`` to not include the path to ``python.wasm`` as
 part of ``HOSTRUNNER``. The environment variable is meant to specify how to
 run the WASI host only, having ``python.wasm`` and relevant flags appended
-to the ``HOSTRUNNER``.
+to the ``HOSTRUNNER``. This fixes ``make test`` work.

--- a/Tools/wasm/wasi.py
+++ b/Tools/wasm/wasi.py
@@ -233,9 +233,10 @@ def configure_wasi_python(context, working_dir):
          env=updated_env(env_additions | wasi_sdk_env(context)),
          quiet=context.quiet)
 
+    python_wasm = working_dir / "python.wasm"
     exec_script = working_dir / "python.sh"
     with exec_script.open("w", encoding="utf-8") as file:
-        file.write(f'#!/bin/sh\nexec {host_runner} "$@"\n')
+        file.write(f'#!/bin/sh\nexec {host_runner} {python_wasm} "$@"\n')
     exec_script.chmod(0o755)
     print(f"🏃‍♀️ Created {exec_script} ... ")
     sys.stdout.flush()
@@ -272,9 +273,7 @@ def main():
                         # Map the checkout to / to load the stdlib from /Lib.
                         "--dir {HOST_DIR}::{GUEST_DIR} "
                         # Set PYTHONPATH to the sysconfig data.
-                        "--env {ENV_VAR_NAME}={ENV_VAR_VALUE} "
-                        # Path to the WASM binary.
-                        "{PYTHON_WASM}")
+                        "--env {ENV_VAR_NAME}={ENV_VAR_VALUE}")
 
     parser = argparse.ArgumentParser()
     subcommands = parser.add_subparsers(dest="subcommand")
@@ -310,8 +309,8 @@ def main():
                                      "$WASI_SDK_PATH or /opt/wasi-sdk")
         subcommand.add_argument("--host-runner", action="store",
                         default=default_host_runner, dest="host_runner",
-                        help="Command template for running the WebAssembly "
-                             "code (default meant for wasmtime 14 or newer: "
+                        help="Command template for running the WASI host "
+                             "(default designed for wasmtime 14 or newer: "
                                 f"`{default_host_runner}`)")
 
     context = parser.parse_args()


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
This also fixes failing tests under a pydebug build of WASI thanks to `make test` now working.

<!-- gh-issue-number: gh-114013 -->
* Issue: gh-114013
<!-- /gh-issue-number -->
