### PR TITLE
gh-114101: Correct `PyErr_Format` arguments in `_testcapi` module

### DIFF
--- a/Modules/_testcapi/getargs.c
+++ b/Modules/_testcapi/getargs.c
@@ -56,9 +56,9 @@ parse_tuple_and_keywords(PyObject *self, PyObject *args)
             keywords[i] = PyBytes_AS_STRING(o);
         }
         else {
-            PyErr_Format(PyExc_ValueError,
+            PyErr_SetString(PyExc_ValueError,
                 "parse_tuple_and_keywords: "
-                "keywords must be str or bytes", i);
+                "keywords must be str or bytes");
             goto exit;
         }
     }

--- a/Modules/_testcapimodule.c
+++ b/Modules/_testcapimodule.c
@@ -112,12 +112,12 @@ test_sizeof_c_types(PyObject *self, PyObject *Py_UNUSED(ignored))
         return (PyObject*)NULL;              \
     }
 #define IS_SIGNED(TYPE) (((TYPE)-1) < (TYPE)0)
-#define CHECK_SIGNNESS(TYPE, SIGNED)         \
-    if (IS_SIGNED(TYPE) != SIGNED) {         \
-        PyErr_Format(get_testerror(self),    \
-            "%s signness is, instead of %i",  \
-            #TYPE, IS_SIGNED(TYPE), SIGNED); \
-        return (PyObject*)NULL;              \
+#define CHECK_SIGNNESS(TYPE, SIGNED)            \
+    if (IS_SIGNED(TYPE) != SIGNED) {            \
+        PyErr_Format(get_testerror(self),       \
+            "%s signness is %i, instead of %i", \
+            #TYPE, IS_SIGNED(TYPE), SIGNED);    \
+        return (PyObject*)NULL;                 \
     }
 
     /* integer types */


### PR DESCRIPTION
I think this is mirror change and fix to the tests, so news entry is not needed.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-114101 -->
* Issue: gh-114101
<!-- /gh-issue-number -->
