### PR TITLE
gh-114107: Fix importlib.metadata symlink test if symlinks aren't supported

### DIFF
--- a/Lib/test/test_importlib/test_main.py
+++ b/Lib/test/test_importlib/test_main.py
@@ -4,6 +4,7 @@ import unittest
 import warnings
 import importlib.metadata
 import contextlib
+from test.support import os_helper
 
 try:
     import pyfakefs.fake_filesystem_unittest as ffs
@@ -403,6 +404,7 @@ class PackagesDistributionsTest(
 
         assert not any(name.endswith('.dist-info') for name in distributions)
 
+    @os_helper.skip_unless_symlink
     def test_packages_distributions_symlinked_top_level(self) -> None:
         """
         Distribution is resolvable from a simple top-level symlink in RECORD.


### PR DESCRIPTION


<!-- gh-issue-number: gh-114107 -->
* Issue: gh-114107
<!-- /gh-issue-number -->
