### PR TITLE
gh-113858: GH Actions: Limit max ccache size for the asan build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -454,6 +454,7 @@ jobs:
       uses: hendrikmuhs/ccache-action@v1.2
       with:
         save: ${{ github.event_name == 'push' }}
+        max-size: "200M"
     - name: Configure CPython
       run: ./configure --config-cache --with-address-sanitizer --without-pymalloc
     - name: Build CPython


### PR DESCRIPTION
I forgot this in #113945 (fcb4c8d31a4b1c60ed9990db3eacd1db9cac4df2) :(


<!-- gh-issue-number: gh-113858 -->
* Issue: gh-113858
<!-- /gh-issue-number -->
