### PR TITLE
[3.11] gh-113358: Fix rendering tracebacks with exceptions with a broken __getattr__ (GH-113359)

### DIFF
--- a/Lib/test/test_traceback.py
+++ b/Lib/test/test_traceback.py
@@ -1601,6 +1601,21 @@ class BaseExceptionReportingTests:
         err_msg = '<note str() failed>'
         self.assertEqual(self.get_report(e), vanilla + err_msg + '\nFinal Note\n')
 
+        # an exception with a broken __getattr__ raising a non expected error
+        class BrokenException(Exception):
+            broken = False
+            def __getattr__(self, name):
+                if self.broken:
+                    raise ValueError(f'no {name}')
+                raise AttributeError(name)
+
+        e = BrokenException(123)
+        vanilla = self.get_report(e)
+        e.broken = True
+        self.assertEqual(
+            self.get_report(e),
+            vanilla + "Ignored error getting __notes__: ValueError('no __notes__')\n")
+
     def test_exception_with_multiple_notes(self):
         for e in [ValueError(42), SyntaxError('bad syntax')]:
             with self.subTest(e=e):

--- a/Lib/traceback.py
+++ b/Lib/traceback.py
@@ -733,7 +733,11 @@ class TracebackException:
         # Capture now to permit freeing resources: only complication is in the
         # unofficial API _format_final_exc_line
         self._str = _safe_string(exc_value, 'exception')
-        self.__notes__ = getattr(exc_value, '__notes__', None)
+        try:
+            self.__notes__ = getattr(exc_value, '__notes__', None)
+        except Exception as e:
+            self.__notes__ = [
+                f'Ignored error getting __notes__: {_safe_string(e, "__notes__", repr)}']
 
         if exc_type and issubclass(exc_type, SyntaxError):
             # Handle SyntaxError's specially

--- a/Misc/NEWS.d/next/Library/2023-12-21-14-55-06.gh-issue-113358.nRkiSL.rst
+++ b/Misc/NEWS.d/next/Library/2023-12-21-14-55-06.gh-issue-113358.nRkiSL.rst
@@ -1,0 +1,1 @@
+Fix rendering tracebacks with exceptions with a broken __getattr__

--- a/Misc/NEWS.d/next/Library/2023-12-21-14-55-06.gh-issue-113358.nRkiSL.rst
+++ b/Misc/NEWS.d/next/Library/2023-12-21-14-55-06.gh-issue-113358.nRkiSL.rst
@@ -1,1 +1,1 @@
-Fix rendering tracebacks with exceptions with a broken __getattr__
+Fix rendering tracebacks for exceptions with a broken ``__getattr__``.

--- a/Python/pythonrun.c
+++ b/Python/pythonrun.c
@@ -1208,16 +1208,17 @@ get_exception_notes(struct exception_print_context *ctx, PyObject *value, PyObje
 
     if (_PyObject_LookupAttr(value, &_Py_ID(__notes__), notes) < 0) {
         PyErr_Fetch(&type, &errvalue, &tback);
-        PyErr_Clear();
         *notes = PyList_New(1);
         if (!*notes) {
             goto error;
         }
         note = PyUnicode_FromFormat("Ignored error getting __notes__: %R", errvalue);
         if (!note) {
+            Py_XDECREF(*notes);
             goto error;
         }
         if (PyList_SetItem(*notes, 0, note) < 0) {
+            Py_XDECREF(*notes);
             goto error;
         }
     }

--- a/Python/pythonrun.c
+++ b/Python/pythonrun.c
@@ -1201,14 +1201,15 @@ error:
 
 static int
 get_exception_notes(struct exception_print_context *ctx, PyObject *value, PyObject **notes) {
-    PyObject *type = NULL;
-    PyObject *errvalue = NULL;
-    PyObject *tback = NULL;
     PyObject *note = NULL;
 
     if (_PyObject_LookupAttr(value, &_Py_ID(__notes__), notes) < 0) {
+        PyObject *type, *errvalue, *tback;
         PyErr_Fetch(&type, &errvalue, &tback);
         note = PyUnicode_FromFormat("Ignored error getting __notes__: %R", errvalue);
+        Py_XDECREF(type);
+        Py_XDECREF(errvalue);
+        Py_XDECREF(tback);
         if (!note) {
             goto error;
         }
@@ -1220,9 +1221,6 @@ get_exception_notes(struct exception_print_context *ctx, PyObject *value, PyObje
             Py_DECREF(*notes);
             goto error;
         }
-        Py_XDECREF(type);
-        Py_XDECREF(errvalue);
-        Py_XDECREF(tback);
     }
 
     return 0;

--- a/Python/pythonrun.c
+++ b/Python/pythonrun.c
@@ -1201,9 +1201,9 @@ error:
 
 static int
 get_exception_notes(struct exception_print_context *ctx, PyObject *value, PyObject **notes) {
-    PyObject *type;
-    PyObject *errvalue;
-    PyObject *tback;
+    PyObject *type = NULL;
+    PyObject *errvalue = NULL;
+    PyObject *tback = NULL;
     PyObject *note = NULL;
 
     if (_PyObject_LookupAttr(value, &_Py_ID(__notes__), notes) < 0) {
@@ -1223,9 +1223,15 @@ get_exception_notes(struct exception_print_context *ctx, PyObject *value, PyObje
         }
     }
 
+    Py_XDECREF(type);
+    Py_XDECREF(errvalue);
+    Py_XDECREF(tback);
     return 0;
 error:
     Py_XDECREF(note);
+    Py_XDECREF(type);
+    Py_XDECREF(errvalue);
+    Py_XDECREF(tback);
     return -1;
 }
 

--- a/Python/pythonrun.c
+++ b/Python/pythonrun.c
@@ -1208,24 +1208,23 @@ get_exception_notes(struct exception_print_context *ctx, PyObject *value, PyObje
 
     if (_PyObject_LookupAttr(value, &_Py_ID(__notes__), notes) < 0) {
         PyErr_Fetch(&type, &errvalue, &tback);
-        *notes = PyList_New(1);
-        if (!*notes) {
-            goto error;
-        }
         note = PyUnicode_FromFormat("Ignored error getting __notes__: %R", errvalue);
         if (!note) {
-            Py_DECREF(*notes);
+            goto error;
+        }
+        *notes = PyList_New(1);
+        if (!*notes) {
             goto error;
         }
         if (PyList_SetItem(*notes, 0, note) < 0) {
             Py_DECREF(*notes);
             goto error;
         }
+        Py_XDECREF(type);
+        Py_XDECREF(errvalue);
+        Py_XDECREF(tback);
     }
 
-    Py_XDECREF(type);
-    Py_XDECREF(errvalue);
-    Py_XDECREF(tback);
     return 0;
 error:
     Py_XDECREF(note);

--- a/Python/pythonrun.c
+++ b/Python/pythonrun.c
@@ -1228,9 +1228,6 @@ get_exception_notes(struct exception_print_context *ctx, PyObject *value, PyObje
     return 0;
 error:
     Py_XDECREF(note);
-    Py_XDECREF(type);
-    Py_XDECREF(errvalue);
-    Py_XDECREF(tback);
     return -1;
 }
 

--- a/Python/pythonrun.c
+++ b/Python/pythonrun.c
@@ -1214,11 +1214,11 @@ get_exception_notes(struct exception_print_context *ctx, PyObject *value, PyObje
         }
         note = PyUnicode_FromFormat("Ignored error getting __notes__: %R", errvalue);
         if (!note) {
-            Py_XDECREF(*notes);
+            Py_DECREF(*notes);
             goto error;
         }
         if (PyList_SetItem(*notes, 0, note) < 0) {
-            Py_XDECREF(*notes);
+            Py_DECREF(*notes);
             goto error;
         }
     }


### PR DESCRIPTION
(cherry picked from commit 04fabe22dd98b4d87f672254b743fbadd5206352)

Adjusted for 3.11, because exception printing also happens in C code.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-113358 -->
* Issue: gh-113358
<!-- /gh-issue-number -->
