### PR TITLE
gh-113655: Skip test_lru_recursion during PGO runs to avoid C stack exhaustion

### DIFF
--- a/Lib/test/test_functools.py
+++ b/Lib/test/test_functools.py
@@ -1866,6 +1866,7 @@ class TestLRU:
 
     @support.skip_on_s390x
     @unittest.skipIf(support.is_wasi, "WASI has limited C stack")
+    @unittest.skipIf(support.PGO, "PGO builds may have reduced C stack")
     def test_lru_recursion(self):
 
         @self.module.lru_cache

--- a/Lib/test/test_functools.py
+++ b/Lib/test/test_functools.py
@@ -1866,7 +1866,6 @@ class TestLRU:
 
     @support.skip_on_s390x
     @unittest.skipIf(support.is_wasi, "WASI has limited C stack")
-    @unittest.skipIf(support.PGO, "PGO builds may have reduced C stack")
     def test_lru_recursion(self):
 
         @self.module.lru_cache

--- a/PCbuild/python.vcxproj
+++ b/PCbuild/python.vcxproj
@@ -94,8 +94,9 @@
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
-      <StackReserveSize Condition="$(Configuration) != 'Debug'">2000000</StackReserveSize>
+      <StackReserveSize>2000000</StackReserveSize>
       <StackReserveSize Condition="$(Configuration) == 'Debug'">12000000</StackReserveSize>
+      <StackReserveSize Condition="$(Configuration) == 'PGInstrument'">12000000</StackReserveSize>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/PCbuild/python.vcxproj
+++ b/PCbuild/python.vcxproj
@@ -97,6 +97,8 @@
       <StackReserveSize>2000000</StackReserveSize>
       <StackReserveSize Condition="$(Configuration) == 'Debug'">12000000</StackReserveSize>
       <StackReserveSize Condition="$(Configuration) == 'PGInstrument'">12000000</StackReserveSize>
+      <!-- HACK: Need additional memory to avoid crashing until gh-113655 is fixed -->
+      <StackReserveSize Condition="$(Configuration) == 'PGUpdate'">3000000</StackReserveSize>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/PCbuild/pythonw.vcxproj
+++ b/PCbuild/pythonw.vcxproj
@@ -92,6 +92,8 @@
       <StackReserveSize>2000000</StackReserveSize>
       <StackReserveSize Condition="$(Configuration) == 'Debug'">12000000</StackReserveSize>
       <StackReserveSize Condition="$(Configuration) == 'PGInstrument'">12000000</StackReserveSize>
+      <!-- HACK: Need additional memory to avoid crashing until gh-113655 is fixed -->
+      <StackReserveSize Condition="$(Configuration) == 'PGUpdate'">3000000</StackReserveSize>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/PCbuild/pythonw.vcxproj
+++ b/PCbuild/pythonw.vcxproj
@@ -89,8 +89,9 @@
   </PropertyGroup>
   <ItemDefinitionGroup>
     <Link>
-      <StackReserveSize Condition="$(Configuration) != 'Debug'">2000000</StackReserveSize>
-      <StackReserveSize Condition="$(Configuration) == 'Debug'">8000000</StackReserveSize>
+      <StackReserveSize>2000000</StackReserveSize>
+      <StackReserveSize Condition="$(Configuration) == 'Debug'">12000000</StackReserveSize>
+      <StackReserveSize Condition="$(Configuration) == 'PGInstrument'">12000000</StackReserveSize>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>


### PR DESCRIPTION


<!-- gh-issue-number: gh-113655 -->
* Issue: gh-113655
<!-- /gh-issue-number -->
