### PR TITLE
gh-114150: Updated documentation for ctypes.PYFUNCTYPE

### DIFF
--- a/Doc/library/ctypes.rst
+++ b/Doc/library/ctypes.rst
@@ -1733,7 +1733,8 @@ See :ref:`ctypes-callback-functions` for examples.
 .. function:: PYFUNCTYPE(restype, *argtypes)
 
    The returned function prototype creates functions that use the Python calling
-   convention.  The function will *not* release the GIL during the call.
+   convention.  The function will acquire the GIL and use it like normal python
+   code during the call.
 
 Function prototypes created by these factory functions can be instantiated in
 different ways, depending on the type and number of the parameters in the call:


### PR DESCRIPTION
Resolves https://github.com/python/cpython/issues/114150 by making it clear that ctypes.PYFUNCTYPE does not change the way the GIL is handled in the called python code.

<!-- gh-issue-number: gh-114150 -->
* Issue: gh-114150
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--114151.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->