### PR TITLE
gh-112043: Align concurrent.futures.Executor.map docs with implementation

### DIFF
--- a/Doc/library/concurrent.futures.rst
+++ b/Doc/library/concurrent.futures.rst
@@ -39,14 +39,14 @@ Executor Objects
              future = executor.submit(pow, 323, 1235)
              print(future.result())
 
-   .. method:: map(func, *iterables, timeout=None, chunksize=1)
+   .. method:: map(fn, *iterables, timeout=None, chunksize=1)
 
-      Similar to :func:`map(func, *iterables) <map>` except:
+      Similar to :func:`map(fn, *iterables) <map>` except:
 
       * the *iterables* are collected immediately rather than lazily;
 
-      * *func* is executed asynchronously and several calls to
-        *func* may be made concurrently.
+      * *fn* is executed asynchronously and several calls to
+        *fn* may be made concurrently.
 
       The returned iterator raises a :exc:`TimeoutError`
       if :meth:`~iterator.__next__` is called and the result isn't available
@@ -54,7 +54,7 @@ Executor Objects
       *timeout* can be an int or a float.  If *timeout* is not specified or
       ``None``, there is no limit to the wait time.
 
-      If a *func* call raises an exception, then that exception will be
+      If a *fn* call raises an exception, then that exception will be
       raised when its value is retrieved from the iterator.
 
       When using :class:`ProcessPoolExecutor`, this method chops *iterables*


### PR DESCRIPTION
The first parameters is named 'fn', not 'func'.


<!-- gh-issue-number: gh-112043 -->
* Issue: gh-112043
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--114153.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->