### PR TITLE
[3.12] GH-78988: Document `pathlib.Path.glob()` exception propagation. (GH-114036)

### DIFF
--- a/Doc/library/pathlib.rst
+++ b/Doc/library/pathlib.rst
@@ -916,6 +916,10 @@ call fails (for example because the path doesn't exist).
        PosixPath('setup.py'),
        PosixPath('test_pathlib.py')]
 
+   This method calls :meth:`Path.is_dir` on the top-level directory and
+   propagates any :exc:`OSError` exception that is raised. Subsequent
+   :exc:`OSError` exceptions from scanning directories are suppressed.
+
    By default, or when the *case_sensitive* keyword-only argument is set to
    ``None``, this method matches paths using platform-specific casing rules:
    typically, case-sensitive on POSIX, and case-insensitive on Windows.


### PR DESCRIPTION
We propagate the `OSError` from the `is_dir()` call on the top-level
directory, and suppress all others.
(cherry picked from commit 7092b3f1319269accf4c02f08256d51f111b9ca3)

<!-- gh-issue-number: gh-78988 -->
* Issue: gh-78988
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--114154.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->