### PR TITLE
gh-112529: Use GC heaps for GC allocations in free-threaded builds

### DIFF
--- a/Include/internal/pycore_object_alloc.h
+++ b/Include/internal/pycore_object_alloc.h
@@ -13,6 +13,23 @@ extern "C" {
 #  error "this header requires Py_BUILD_CORE define"
 #endif
 
+#ifdef Py_GIL_DISABLED
+static inline mi_heap_t *
+_PyObject_GetAllocationHeap(_PyThreadStateImpl *tstate, PyTypeObject *tp)
+{
+    struct _mimalloc_thread_state *m = &tstate->mimalloc;
+    if (_PyType_HasFeature(tp, Py_TPFLAGS_PREHEADER)) {
+        return &m->heaps[_Py_MIMALLOC_HEAP_GC_PRE];
+    }
+    else if (_PyType_IS_GC(tp)) {
+        return &m->heaps[_Py_MIMALLOC_HEAP_GC];
+    }
+    else {
+        return &m->heaps[_Py_MIMALLOC_HEAP_OBJECT];
+    }
+}
+#endif
+
 // Sets the heap used for PyObject_Malloc(), PyObject_Realloc(), etc. calls in
 // Py_GIL_DISABLED builds. We use different heaps depending on if the object
 // supports GC and if it has a pre-header. We smuggle the choice of heap
@@ -24,12 +41,7 @@ _PyObject_MallocWithType(PyTypeObject *tp, size_t size)
 #ifdef Py_GIL_DISABLED
     _PyThreadStateImpl *tstate = (_PyThreadStateImpl *)_PyThreadState_GET();
     struct _mimalloc_thread_state *m = &tstate->mimalloc;
-    if (_PyType_HasFeature(tp, Py_TPFLAGS_PREHEADER)) {
-        m->current_object_heap = &m->heaps[_Py_MIMALLOC_HEAP_GC_PRE];
-    }
-    else if (_PyType_IS_GC(tp)) {
-        m->current_object_heap = &m->heaps[_Py_MIMALLOC_HEAP_GC];
-    }
+    m->current_object_heap = _PyObject_GetAllocationHeap(tstate, tp);
 #endif
     void *mem = PyObject_Malloc(size);
 #ifdef Py_GIL_DISABLED
@@ -44,12 +56,7 @@ _PyObject_ReallocWithType(PyTypeObject *tp, void *ptr, size_t size)
 #ifdef Py_GIL_DISABLED
     _PyThreadStateImpl *tstate = (_PyThreadStateImpl *)_PyThreadState_GET();
     struct _mimalloc_thread_state *m = &tstate->mimalloc;
-    if (_PyType_HasFeature(tp, Py_TPFLAGS_PREHEADER)) {
-        m->current_object_heap = &m->heaps[_Py_MIMALLOC_HEAP_GC_PRE];
-    }
-    else if (_PyType_IS_GC(tp)) {
-        m->current_object_heap = &m->heaps[_Py_MIMALLOC_HEAP_GC];
-    }
+    m->current_object_heap = _PyObject_GetAllocationHeap(tstate, tp);
 #endif
     void *mem = PyObject_Realloc(ptr, size);
 #ifdef Py_GIL_DISABLED

--- a/Include/internal/pycore_object_alloc.h
+++ b/Include/internal/pycore_object_alloc.h
@@ -1,0 +1,64 @@
+#ifndef Py_INTERNAL_OBJECT_ALLOC_H
+#define Py_INTERNAL_OBJECT_ALLOC_H
+
+#include "pycore_object.h"      // _PyType_HasFeature()
+#include "pycore_pystate.h"     // _PyThreadState_GET()
+#include "pycore_tstate.h"      // _PyThreadStateImpl
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifndef Py_BUILD_CORE
+#  error "this header requires Py_BUILD_CORE define"
+#endif
+
+// Sets the heap used for PyObject_Malloc(), PyObject_Realloc(), etc. calls in
+// Py_GIL_DISABLED builds. We use different heaps depending on if the object
+// supports GC and if it has a pre-header. We smuggle the choice of heap
+// through the _mimalloc_thread_state. In the default build, this simply
+// calls PyObject_Malloc().
+static inline void *
+_PyObject_MallocWithType(PyTypeObject *tp, size_t size)
+{
+#ifdef Py_GIL_DISABLED
+    _PyThreadStateImpl *tstate = (_PyThreadStateImpl *)_PyThreadState_GET();
+    struct _mimalloc_thread_state *m = &tstate->mimalloc;
+    if (_PyType_HasFeature(tp, Py_TPFLAGS_PREHEADER)) {
+        m->current_object_heap = &m->heaps[_Py_MIMALLOC_HEAP_GC_PRE];
+    }
+    else if (_PyType_IS_GC(tp)) {
+        m->current_object_heap = &m->heaps[_Py_MIMALLOC_HEAP_GC];
+    }
+#endif
+    void *mem = PyObject_Malloc(size);
+#ifdef Py_GIL_DISABLED
+    m->current_object_heap = &m->heaps[_Py_MIMALLOC_HEAP_OBJECT];
+#endif
+    return mem;
+}
+
+static inline void *
+_PyObject_ReallocWithType(PyTypeObject *tp, void *ptr, size_t size)
+{
+#ifdef Py_GIL_DISABLED
+    _PyThreadStateImpl *tstate = (_PyThreadStateImpl *)_PyThreadState_GET();
+    struct _mimalloc_thread_state *m = &tstate->mimalloc;
+    if (_PyType_HasFeature(tp, Py_TPFLAGS_PREHEADER)) {
+        m->current_object_heap = &m->heaps[_Py_MIMALLOC_HEAP_GC_PRE];
+    }
+    else if (_PyType_IS_GC(tp)) {
+        m->current_object_heap = &m->heaps[_Py_MIMALLOC_HEAP_GC];
+    }
+#endif
+    void *mem = PyObject_Realloc(ptr, size);
+#ifdef Py_GIL_DISABLED
+    m->current_object_heap = &m->heaps[_Py_MIMALLOC_HEAP_OBJECT];
+#endif
+    return mem;
+}
+
+#ifdef __cplusplus
+}
+#endif
+#endif  // !Py_INTERNAL_OBJECT_ALLOC_H

--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -1852,6 +1852,7 @@ PYTHON_HEADERS= \
 		$(srcdir)/Include/internal/pycore_moduleobject.h \
 		$(srcdir)/Include/internal/pycore_namespace.h \
 		$(srcdir)/Include/internal/pycore_object.h \
+		$(srcdir)/Include/internal/pycore_object_alloc.h \
 		$(srcdir)/Include/internal/pycore_object_state.h \
 		$(srcdir)/Include/internal/pycore_obmalloc.h \
 		$(srcdir)/Include/internal/pycore_obmalloc_init.h \

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -11,6 +11,7 @@
 #include "pycore_modsupport.h"    // _PyArg_NoKwnames()
 #include "pycore_moduleobject.h"  // _PyModule_GetDef()
 #include "pycore_object.h"        // _PyType_HasFeature()
+#include "pycore_object_alloc.h"  // _PyObject_MallocWithType()
 #include "pycore_pyerrors.h"      // _PyErr_Occurred()
 #include "pycore_pystate.h"       // _PyThreadState_GET()
 #include "pycore_symtable.h"      // _Py_Mangle()
@@ -1729,7 +1730,7 @@ _PyType_AllocNoTrack(PyTypeObject *type, Py_ssize_t nitems)
     const size_t size = _PyObject_VAR_SIZE(type, nitems+1);
 
     const size_t presize = _PyType_PreHeaderSize(type);
-    char *alloc = PyObject_Malloc(size + presize);
+    char *alloc = _PyObject_MallocWithType(type, size + presize);
     if (alloc  == NULL) {
         return PyErr_NoMemory();
     }

--- a/PCbuild/pythoncore.vcxproj
+++ b/PCbuild/pythoncore.vcxproj
@@ -255,6 +255,7 @@
     <ClInclude Include="..\Include\internal\pycore_moduleobject.h" />
     <ClInclude Include="..\Include\internal\pycore_namespace.h" />
     <ClInclude Include="..\Include\internal\pycore_object.h" />
+    <ClInclude Include="..\Include\internal\pycore_object_alloc.h" />
     <ClInclude Include="..\Include\internal\pycore_object_state.h" />
     <ClInclude Include="..\Include\internal\pycore_obmalloc.h" />
     <ClInclude Include="..\Include\internal\pycore_obmalloc_init.h" />

--- a/PCbuild/pythoncore.vcxproj.filters
+++ b/PCbuild/pythoncore.vcxproj.filters
@@ -693,6 +693,9 @@
     <ClInclude Include="..\Include\internal\pycore_object.h">
       <Filter>Include\internal</Filter>
     </ClInclude>
+    <ClInclude Include="..\Include\internal\pycore_object_alloc.h">
+      <Filter>Include\internal</Filter>
+    </ClInclude>
     <ClInclude Include="..\Include\internal\pycore_object_state.h">
       <Filter>Include\internal</Filter>
     </ClInclude>


### PR DESCRIPTION
The free-threaded build's garbage collector implementation will need to find GC objects by traversing mimalloc heaps. This hooks up the allocation calls with the correct heaps by using a thread-local "current_obj_heap" variable. There is no effect on the default (with GIL) build.


<!-- gh-issue-number: gh-112529 -->
* Issue: gh-112529
<!-- /gh-issue-number -->
