### PR TITLE
gh-81479: For Help => IDLE Doc, stop double-spacing some lists.

### DIFF
--- a/Lib/idlelib/help.py
+++ b/Lib/idlelib/help.py
@@ -102,7 +102,7 @@ class HelpParser(HTMLParser):
             if self.level > 0:
                 self.nested_dl = True
         elif tag == 'li':
-            s = '\n* ' if self.simplelist else '\n\n* '
+            s = '\n* ' #if self.simplelist else '\n\n* '
         elif tag == 'dt':
             s = '\n\n' if not self.nested_dl else '\n'  # Avoid extra line.
             self.nested_dl = False

--- a/Lib/idlelib/help.py
+++ b/Lib/idlelib/help.py
@@ -102,7 +102,7 @@ class HelpParser(HTMLParser):
             if self.level > 0:
                 self.nested_dl = True
         elif tag == 'li':
-            s = '\n* ' #if self.simplelist else '\n\n* '
+            s = '\n* '
         elif tag == 'dt':
             s = '\n\n' if not self.nested_dl else '\n'  # Avoid extra line.
             self.nested_dl = False


### PR DESCRIPTION
This matches Firefox format.  Edge double-spaces non-simple lists as the viewer did, but I think it looks worse.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-81479 -->
* Issue: gh-81479
<!-- /gh-issue-number -->
