### PR TITLE
[3.12] gh-113358: Fix rendering tracebacks with exceptions with a broken __getattr__ (GH-113359)

### DIFF
--- a/Lib/test/test_traceback.py
+++ b/Lib/test/test_traceback.py
@@ -1654,6 +1654,21 @@ class BaseExceptionReportingTests:
         err_msg = "b'please do not show me as numbers'"
         self.assertEqual(self.get_report(e), vanilla + err_msg + '\n')
 
+        # an exception with a broken __getattr__ raising a non expected error
+        class BrokenException(Exception):
+            broken = False
+            def __getattr__(self, name):
+                if self.broken:
+                    raise ValueError(f'no {name}')
+                raise AttributeError(name)
+
+        e = BrokenException(123)
+        vanilla = self.get_report(e)
+        e.broken = True
+        self.assertEqual(
+            self.get_report(e),
+            vanilla + "Ignored error getting __notes__: ValueError('no __notes__')\n")
+
     def test_exception_with_multiple_notes(self):
         for e in [ValueError(42), SyntaxError('bad syntax')]:
             with self.subTest(e=e):

--- a/Lib/traceback.py
+++ b/Lib/traceback.py
@@ -738,7 +738,11 @@ class TracebackException:
         # Capture now to permit freeing resources: only complication is in the
         # unofficial API _format_final_exc_line
         self._str = _safe_string(exc_value, 'exception')
-        self.__notes__ = getattr(exc_value, '__notes__', None)
+        try:
+            self.__notes__ = getattr(exc_value, '__notes__', None)
+        except Exception as e:
+            self.__notes__ = [
+                f'Ignored error getting __notes__: {_safe_string(e, '__notes__', repr)}']
 
         if exc_type and issubclass(exc_type, SyntaxError):
             # Handle SyntaxError's specially

--- a/Misc/NEWS.d/next/Library/2023-12-21-14-55-06.gh-issue-113358.nRkiSL.rst
+++ b/Misc/NEWS.d/next/Library/2023-12-21-14-55-06.gh-issue-113358.nRkiSL.rst
@@ -1,0 +1,1 @@
+Fix rendering tracebacks for exceptions with a broken ``__getattr__``.

--- a/Python/pythonrun.c
+++ b/Python/pythonrun.c
@@ -1171,6 +1171,7 @@ get_exception_notes(struct exception_print_context *ctx, PyObject *value, PyObje
     if (_PyObject_LookupAttr(value, &_Py_ID(__notes__), notes) < 0) {
         PyObject *type, *errvalue, *tback;
         PyErr_Fetch(&type, &errvalue, &tback);
+        PyErr_NormalizeException(&type, &errvalue, &tback);
         note = PyUnicode_FromFormat("Ignored error getting __notes__: %R", errvalue);
         Py_XDECREF(type);
         Py_XDECREF(errvalue);

--- a/Python/pythonrun.c
+++ b/Python/pythonrun.c
@@ -1165,6 +1165,36 @@ error:
 }
 
 static int
+get_exception_notes(struct exception_print_context *ctx, PyObject *value, PyObject **notes) {
+    PyObject *note = NULL;
+
+    if (_PyObject_LookupAttr(value, &_Py_ID(__notes__), notes) < 0) {
+        PyObject *type, *errvalue, *tback;
+        PyErr_Fetch(&type, &errvalue, &tback);
+        note = PyUnicode_FromFormat("Ignored error getting __notes__: %R", errvalue);
+        Py_XDECREF(type);
+        Py_XDECREF(errvalue);
+        Py_XDECREF(tback);
+        if (!note) {
+            goto error;
+        }
+        *notes = PyList_New(1);
+        if (!*notes) {
+            goto error;
+        }
+        if (PyList_SetItem(*notes, 0, note) < 0) {
+            Py_DECREF(*notes);
+            goto error;
+        }
+    }
+
+    return 0;
+error:
+    Py_XDECREF(note);
+    return -1;
+}
+
+static int
 print_exception(struct exception_print_context *ctx, PyObject *value)
 {
     PyObject *notes = NULL;
@@ -1183,7 +1213,7 @@ print_exception(struct exception_print_context *ctx, PyObject *value)
 
     /* grab the type and notes now because value can change below */
     PyObject *type = (PyObject *) Py_TYPE(value);
-    if (_PyObject_LookupAttr(value, &_Py_ID(__notes__), &notes) < 0) {
+    if (get_exception_notes(ctx, value, &notes) < 0) {
         goto error;
     }
 


### PR DESCRIPTION
(cherry picked from commit 04fabe22dd98b4d87f672254b743fbadd5206352)

Adjusted for 3.12, because exception printing also happens in C code.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-113358 -->
* Issue: gh-113358
<!-- /gh-issue-number -->
