### PR TITLE
gh-72284: Revise lists in IDLE doc 

### DIFF
--- a/Doc/library/idle.rst
+++ b/Doc/library/idle.rst
@@ -442,8 +442,8 @@ assume that the keys have not been re-bound to something else.)
 
 * :kbd:`C-Home` and :kbd:`C-End` go to beginning or end of the file.
 
-* :kbd:`Backspace` and :kbd:`Del` (or `C-d`) delete the previous or
-  next character.
+* :kbd:`Backspace` and :kbd:`Del` (or :kbd:`C-d`) delete the previous
+  or next character.
 
 * :kbd:`C-Backspace` and :kbd:`C-Del` delete one word left or right.
 

--- a/Doc/library/idle.rst
+++ b/Doc/library/idle.rst
@@ -18,8 +18,6 @@ IDLE is Python's Integrated Development and Learning Environment.
 
 IDLE has the following features:
 
-* coded in 100% pure Python, using the :mod:`tkinter` GUI toolkit
-
 * cross-platform: works mostly the same on Windows, Unix, and macOS
 
 * Python shell window (interactive interpreter) with colorizing
@@ -422,41 +420,34 @@ and that other files do not.  Run Python code with the Run menu.
 Key bindings
 ^^^^^^^^^^^^
 
-In this section, 'C' refers to the :kbd:`Control` key on Windows and Unix and
-the :kbd:`Command` key on macOS.
+The IDLE insertion cursor is a thin vertical bar between character
+positions.  When characters are entered, the insertion cursor and
+everything to its right moves right one character and
+the new character is entered in the new space.
 
-* :kbd:`Backspace` deletes to the left; :kbd:`Del` deletes to the right
+Several non-character keys move the cursor and possibly
+delete characters.  Deletion does not puts text on the clipboard,
+but IDLE has an undo list.  Wherever this doc discusses keys,
+'C' refers to the :kbd:`Control` key on Windows and
+Unix and the :kbd:`Command` key on macOS.  (And all such dicussions
+assume that the keys have not been re-bound to something else.)
 
-* :kbd:`C-Backspace` delete word left; :kbd:`C-Del` delete word to the right
+* Arrow keys move the cursor one character or line.
 
-* Arrow keys and :kbd:`Page Up`/:kbd:`Page Down` to move around
+* :kbd:`C-LeftArrow` and :kbd:`C-RightArrow` moves left or right one word.
 
-* :kbd:`C-LeftArrow` and :kbd:`C-RightArrow` moves by words
+* :kbd:`Home` and :kbd:`End` go to the beginning or end of the line.
 
-* :kbd:`Home`/:kbd:`End` go to begin/end of line
+* :kbd:`Page Up` and :kbd:`Page Down` go up or down one screen.
 
-* :kbd:`C-Home`/:kbd:`C-End` go to begin/end of file
+* :kbd:`C-Home` and :kbd:`C-End` go to beginning or end of the file.
 
-* Some useful Emacs bindings are inherited from Tcl/Tk:
+* :kbd:`Backspace` and :kbd:`Del` (or `C-d`) delete the previous or
+  next character.
 
-  * :kbd:`C-a` beginning of line
+* :kbd:`C-Backspace` and :kbd:`C-Del` delete one word left or right.
 
-  * :kbd:`C-e` end of line
-
-  * :kbd:`C-k` kill line (but doesn't put it in clipboard)
-
-  * :kbd:`C-l` center window around the insertion point
-
-  * :kbd:`C-b` go backward one character without deleting (usually you can
-    also use the cursor key for this)
-
-  * :kbd:`C-f` go forward one character without deleting (usually you can
-    also use the cursor key for this)
-
-  * :kbd:`C-p` go up one line (usually you can also use the cursor key for
-    this)
-
-  * :kbd:`C-d` delete next character
+* :kbd:`C-k` deletes ('kills') everything to the right.
 
 Standard keybindings (like :kbd:`C-c` to copy and :kbd:`C-v` to paste)
 may work.  Keybindings are selected in the Configure IDLE dialog.
@@ -611,23 +602,18 @@ when one requests a restart on the Shell menu, or when one runs code
 in an editor window.
 
 The editing features described in previous subsections work when entering
-code interactively.  IDLE's Shell window also responds to the following keys.
+code interactively.  IDLE's Shell window also responds to the following:
 
-* :kbd:`C-c` interrupts executing command
+* :kbd:`C-c` attemps to interrupt statement execution (but may fail).
 
-* :kbd:`C-d` sends end-of-file; closes window if typed at a ``>>>`` prompt
+* :kbd:`C-d` closes Shell if typed at a ``>>>`` prompt.
 
-* :kbd:`Alt-/` (Expand word) is also useful to reduce typing
+* :kbd:`Alt-p` and :kbd:`Alt-n` (:kbd:`C-p` and :kbd:`C-n` on macOS)
+  retrieve to the current prompt the previous or next previously
+  entered statement that matches anything already typed.
 
-  Command history
-
-  * :kbd:`Alt-p` retrieves previous command matching what you have typed. On
-    macOS use :kbd:`C-p`.
-
-  * :kbd:`Alt-n` retrieves next. On macOS use :kbd:`C-n`.
-
-  * :kbd:`Return` while the cursor is on any previous command
-    retrieves that command
+* :kbd:`Return` while the cursor is on any previous statement
+  appends the latter to anything already typed at the prompt.
 
 Text colors
 ^^^^^^^^^^^

--- a/Lib/idlelib/News3.txt
+++ b/Lib/idlelib/News3.txt
@@ -4,6 +4,9 @@ Released on 2024-10-xx
 =========================
 
 
+gh-72284: Improve the lists of features, editor key bindings,
+and shell key bingings in the IDLE doc.
+
 gh-113903: Fix rare failure of test.test_idle, in test_configdialog.
 
 gh-113729: Fix the "Help -> IDLE Doc" menu bug in 3.11.7 and 3.12.1.

--- a/Lib/idlelib/help.html
+++ b/Lib/idlelib/help.html
@@ -226,7 +226,6 @@
 <p>IDLE is Python’s Integrated Development and Learning Environment.</p>
 <p>IDLE has the following features:</p>
 <ul class="simple">
-<li><p>coded in 100% pure Python, using the <a class="reference internal" href="tkinter.html#module-tkinter" title="tkinter: Interface to Tcl/Tk for graphical user interfaces"><code class="xref py py-mod docutils literal notranslate"><span class="pre">tkinter</span></code></a> GUI toolkit</p></li>
 <li><p>cross-platform: works mostly the same on Windows, Unix, and macOS</p></li>
 <li><p>Python shell window (interactive interpreter) with colorizing
 of code input, output, and error messages</p></li>
@@ -547,30 +546,26 @@ and that other files do not.  Run Python code with the Run menu.</p>
 </section>
 <section id="key-bindings">
 <h3>Key bindings<a class="headerlink" href="#key-bindings" title="Permalink to this heading">¶</a></h3>
-<p>In this section, ‘C’ refers to the <kbd class="kbd docutils literal notranslate">Control</kbd> key on Windows and Unix and
-the <kbd class="kbd docutils literal notranslate">Command</kbd> key on macOS.</p>
+<p>The IDLE insertion cursor is a thin vertical bar between character
+positions.  When characters are entered, the insertion cursor and
+everything to its right moves right one character and
+the new character is entered in the new space.</p>
+<p>Several non-character keys move the cursor and possibly
+delete characters.  Deletion does not puts text on the clipboard,
+but IDLE has an undo list.  Wherever this doc discusses keys,
+‘C’ refers to the <kbd class="kbd docutils literal notranslate">Control</kbd> key on Windows and
+Unix and the <kbd class="kbd docutils literal notranslate">Command</kbd> key on macOS.  (And all such dicussions
+assume that the keys have not been re-bound to something else.)</p>
 <ul class="simple">
-<li><p><kbd class="kbd docutils literal notranslate">Backspace</kbd> deletes to the left; <kbd class="kbd docutils literal notranslate">Del</kbd> deletes to the right</p></li>
-<li><p><kbd class="kbd compound docutils literal notranslate"><kbd class="kbd docutils literal notranslate">C</kbd>-<kbd class="kbd docutils literal notranslate">Backspace</kbd></kbd> delete word left; <kbd class="kbd compound docutils literal notranslate"><kbd class="kbd docutils literal notranslate">C</kbd>-<kbd class="kbd docutils literal notranslate">Del</kbd></kbd> delete word to the right</p></li>
-<li><p>Arrow keys and <kbd class="kbd docutils literal notranslate">Page Up</kbd>/<kbd class="kbd docutils literal notranslate">Page Down</kbd> to move around</p></li>
-<li><p><kbd class="kbd compound docutils literal notranslate"><kbd class="kbd docutils literal notranslate">C</kbd>-<kbd class="kbd docutils literal notranslate">LeftArrow</kbd></kbd> and <kbd class="kbd compound docutils literal notranslate"><kbd class="kbd docutils literal notranslate">C</kbd>-<kbd class="kbd docutils literal notranslate">RightArrow</kbd></kbd> moves by words</p></li>
-<li><p><kbd class="kbd docutils literal notranslate">Home</kbd>/<kbd class="kbd docutils literal notranslate">End</kbd> go to begin/end of line</p></li>
-<li><p><kbd class="kbd compound docutils literal notranslate"><kbd class="kbd docutils literal notranslate">C</kbd>-<kbd class="kbd docutils literal notranslate">Home</kbd></kbd>/<kbd class="kbd compound docutils literal notranslate"><kbd class="kbd docutils literal notranslate">C</kbd>-<kbd class="kbd docutils literal notranslate">End</kbd></kbd> go to begin/end of file</p></li>
-<li><p>Some useful Emacs bindings are inherited from Tcl/Tk:</p>
-<ul>
-<li><p><kbd class="kbd compound docutils literal notranslate"><kbd class="kbd docutils literal notranslate">C</kbd>-<kbd class="kbd docutils literal notranslate">a</kbd></kbd> beginning of line</p></li>
-<li><p><kbd class="kbd compound docutils literal notranslate"><kbd class="kbd docutils literal notranslate">C</kbd>-<kbd class="kbd docutils literal notranslate">e</kbd></kbd> end of line</p></li>
-<li><p><kbd class="kbd compound docutils literal notranslate"><kbd class="kbd docutils literal notranslate">C</kbd>-<kbd class="kbd docutils literal notranslate">k</kbd></kbd> kill line (but doesn’t put it in clipboard)</p></li>
-<li><p><kbd class="kbd compound docutils literal notranslate"><kbd class="kbd docutils literal notranslate">C</kbd>-<kbd class="kbd docutils literal notranslate">l</kbd></kbd> center window around the insertion point</p></li>
-<li><p><kbd class="kbd compound docutils literal notranslate"><kbd class="kbd docutils literal notranslate">C</kbd>-<kbd class="kbd docutils literal notranslate">b</kbd></kbd> go backward one character without deleting (usually you can
-also use the cursor key for this)</p></li>
-<li><p><kbd class="kbd compound docutils literal notranslate"><kbd class="kbd docutils literal notranslate">C</kbd>-<kbd class="kbd docutils literal notranslate">f</kbd></kbd> go forward one character without deleting (usually you can
-also use the cursor key for this)</p></li>
-<li><p><kbd class="kbd compound docutils literal notranslate"><kbd class="kbd docutils literal notranslate">C</kbd>-<kbd class="kbd docutils literal notranslate">p</kbd></kbd> go up one line (usually you can also use the cursor key for
-this)</p></li>
-<li><p><kbd class="kbd compound docutils literal notranslate"><kbd class="kbd docutils literal notranslate">C</kbd>-<kbd class="kbd docutils literal notranslate">d</kbd></kbd> delete next character</p></li>
-</ul>
-</li>
+<li><p>Arrow keys move the cursor one character or line.</p></li>
+<li><p><kbd class="kbd compound docutils literal notranslate"><kbd class="kbd docutils literal notranslate">C</kbd>-<kbd class="kbd docutils literal notranslate">LeftArrow</kbd></kbd> and <kbd class="kbd compound docutils literal notranslate"><kbd class="kbd docutils literal notranslate">C</kbd>-<kbd class="kbd docutils literal notranslate">RightArrow</kbd></kbd> moves left or right one word.</p></li>
+<li><p><kbd class="kbd docutils literal notranslate">Home</kbd> and <kbd class="kbd docutils literal notranslate">End</kbd> go to the beginning or end of the line.</p></li>
+<li><p><kbd class="kbd docutils literal notranslate">Page Up</kbd> and <kbd class="kbd docutils literal notranslate">Page Down</kbd> go up or down one screen.</p></li>
+<li><p><kbd class="kbd compound docutils literal notranslate"><kbd class="kbd docutils literal notranslate">C</kbd>-<kbd class="kbd docutils literal notranslate">Home</kbd></kbd> and <kbd class="kbd compound docutils literal notranslate"><kbd class="kbd docutils literal notranslate">C</kbd>-<kbd class="kbd docutils literal notranslate">End</kbd></kbd> go to beginning or end of the file.</p></li>
+<li><p><kbd class="kbd docutils literal notranslate">Backspace</kbd> and <kbd class="kbd docutils literal notranslate">Del</kbd> (or <cite>C-d</cite>) delete the previous or
+next character.</p></li>
+<li><p><kbd class="kbd compound docutils literal notranslate"><kbd class="kbd docutils literal notranslate">C</kbd>-<kbd class="kbd docutils literal notranslate">Backspace</kbd></kbd> and <kbd class="kbd compound docutils literal notranslate"><kbd class="kbd docutils literal notranslate">C</kbd>-<kbd class="kbd docutils literal notranslate">Del</kbd></kbd> delete one word left or right.</p></li>
+<li><p><kbd class="kbd compound docutils literal notranslate"><kbd class="kbd docutils literal notranslate">C</kbd>-<kbd class="kbd docutils literal notranslate">k</kbd></kbd> deletes (‘kills’) everything to the right.</p></li>
 </ul>
 <p>Standard keybindings (like <kbd class="kbd compound docutils literal notranslate"><kbd class="kbd docutils literal notranslate">C</kbd>-<kbd class="kbd docutils literal notranslate">c</kbd></kbd> to copy and <kbd class="kbd compound docutils literal notranslate"><kbd class="kbd docutils literal notranslate">C</kbd>-<kbd class="kbd docutils literal notranslate">v</kbd></kbd> to paste)
 may work.  Keybindings are selected in the Configure IDLE dialog.</p>
@@ -697,20 +692,15 @@ re-started.  This occurs when the user execution process has crashed,
 when one requests a restart on the Shell menu, or when one runs code
 in an editor window.</p>
 <p>The editing features described in previous subsections work when entering
-code interactively.  IDLE’s Shell window also responds to the following keys.</p>
-<ul>
-<li><p><kbd class="kbd compound docutils literal notranslate"><kbd class="kbd docutils literal notranslate">C</kbd>-<kbd class="kbd docutils literal notranslate">c</kbd></kbd> interrupts executing command</p></li>
-<li><p><kbd class="kbd compound docutils literal notranslate"><kbd class="kbd docutils literal notranslate">C</kbd>-<kbd class="kbd docutils literal notranslate">d</kbd></kbd> sends end-of-file; closes window if typed at a <code class="docutils literal notranslate"><span class="pre">&gt;&gt;&gt;</span></code> prompt</p></li>
-<li><p><kbd class="kbd compound docutils literal notranslate"><kbd class="kbd docutils literal notranslate">Alt</kbd>-<kbd class="kbd docutils literal notranslate">/</kbd></kbd> (Expand word) is also useful to reduce typing</p>
-<p>Command history</p>
+code interactively.  IDLE’s Shell window also responds to the following:</p>
 <ul class="simple">
-<li><p><kbd class="kbd compound docutils literal notranslate"><kbd class="kbd docutils literal notranslate">Alt</kbd>-<kbd class="kbd docutils literal notranslate">p</kbd></kbd> retrieves previous command matching what you have typed. On
-macOS use <kbd class="kbd compound docutils literal notranslate"><kbd class="kbd docutils literal notranslate">C</kbd>-<kbd class="kbd docutils literal notranslate">p</kbd></kbd>.</p></li>
-<li><p><kbd class="kbd compound docutils literal notranslate"><kbd class="kbd docutils literal notranslate">Alt</kbd>-<kbd class="kbd docutils literal notranslate">n</kbd></kbd> retrieves next. On macOS use <kbd class="kbd compound docutils literal notranslate"><kbd class="kbd docutils literal notranslate">C</kbd>-<kbd class="kbd docutils literal notranslate">n</kbd></kbd>.</p></li>
-<li><p><kbd class="kbd docutils literal notranslate">Return</kbd> while the cursor is on any previous command
-retrieves that command</p></li>
-</ul>
-</li>
+<li><p><kbd class="kbd compound docutils literal notranslate"><kbd class="kbd docutils literal notranslate">C</kbd>-<kbd class="kbd docutils literal notranslate">c</kbd></kbd> attemps to interrupt statement execution (but may fail).</p></li>
+<li><p><kbd class="kbd compound docutils literal notranslate"><kbd class="kbd docutils literal notranslate">C</kbd>-<kbd class="kbd docutils literal notranslate">d</kbd></kbd> closes Shell if typed at a <code class="docutils literal notranslate"><span class="pre">&gt;&gt;&gt;</span></code> prompt.</p></li>
+<li><p><kbd class="kbd compound docutils literal notranslate"><kbd class="kbd docutils literal notranslate">Alt</kbd>-<kbd class="kbd docutils literal notranslate">p</kbd></kbd> and <kbd class="kbd compound docutils literal notranslate"><kbd class="kbd docutils literal notranslate">Alt</kbd>-<kbd class="kbd docutils literal notranslate">n</kbd></kbd> (<kbd class="kbd compound docutils literal notranslate"><kbd class="kbd docutils literal notranslate">C</kbd>-<kbd class="kbd docutils literal notranslate">p</kbd></kbd> and <kbd class="kbd compound docutils literal notranslate"><kbd class="kbd docutils literal notranslate">C</kbd>-<kbd class="kbd docutils literal notranslate">n</kbd></kbd> on macOS)
+retrieve to the current prompt the previous or next previously
+entered statement that matches anything already typed.</p></li>
+<li><p><kbd class="kbd docutils literal notranslate">Return</kbd> while the cursor is on any previous statement
+appends the latter to anything already typed at the prompt.</p></li>
 </ul>
 </section>
 <section id="text-colors">
@@ -1190,7 +1180,7 @@ sense that feature changes can be backported (see <span class="target" id="index
 <br />
     <br />
 
-    Last updated on Jan 16, 2024 (16:17 UTC).
+    Last updated on Jan 17, 2024 (06:57 UTC).
     <a href="/bugs.html">Found a bug</a>?
     <br />
 

--- a/Lib/idlelib/help.py
+++ b/Lib/idlelib/help.py
@@ -102,7 +102,7 @@ class HelpParser(HTMLParser):
             if self.level > 0:
                 self.nested_dl = True
         elif tag == 'li':
-            s = '\n* ' if self.simplelist else '\n\n* '
+            s = '\n* ' #if self.simplelist else '\n\n* '
         elif tag == 'dt':
             s = '\n\n' if not self.nested_dl else '\n'  # Avoid extra line.
             self.nested_dl = False

--- a/Lib/idlelib/help.py
+++ b/Lib/idlelib/help.py
@@ -102,7 +102,7 @@ class HelpParser(HTMLParser):
             if self.level > 0:
                 self.nested_dl = True
         elif tag == 'li':
-            s = '\n* ' #if self.simplelist else '\n\n* '
+            s = '\n* '
         elif tag == 'dt':
             s = '\n\n' if not self.nested_dl else '\n'  # Avoid extra line.
             self.nested_dl = False

--- a/Misc/NEWS.d/next/IDLE/2024-01-17-02-15-33.gh-issue-72284.cAQiYO.rst
+++ b/Misc/NEWS.d/next/IDLE/2024-01-17-02-15-33.gh-issue-72284.cAQiYO.rst
@@ -1,0 +1,2 @@
+Improve the lists of features, editor key bindings, and shell key bingings
+in the IDLE doc.


### PR DESCRIPTION
 Tkinter is a fact, not necessarily a feature.

 Reorganize editor key bindings in a logical order
  and remove those that do not work, at least on Windows.

 Improve shell bindings list.


<!-- gh-issue-number: gh-72284 -->
* Issue: gh-72284
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--114174.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->