### PR TITLE
gh-113205: test_multiprocessing.test_terminate: Test the API on threadpools

### DIFF
--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -2693,12 +2693,17 @@ class _TestPool(BaseTestCase):
                 p.join()
 
     def test_terminate(self):
-        if self.TYPE == 'threads':
-            self.skipTest("Threads cannot be terminated")
-
         # Simulate slow tasks which take "forever" to complete
+        sleep_time = support.LONG_TIMEOUT
+
+        if self.TYPE == 'threads':
+            # Thread pool workers can't be forced to quit, so if the first
+            # task starts early enough, we will end up waiting for it.
+            # Sleep for a shorter time, so the test doesn't block.
+            sleep_time = 1
+
         p = self.Pool(3)
-        args = [support.LONG_TIMEOUT for i in range(10_000)]
+        args = [sleep_time for i in range(10_000)]
         result = p.map_async(time.sleep, args, chunksize=1)
         p.terminate()
         p.join()


### PR DESCRIPTION
Threads can't be forced to terminate (without potentially corrupting too much state), so the  expected behaviour of `ThreadPool.terminate` is to wait for the currently executing tasks to finish.

The entire terminate test was skipped in GH-110848 (0e9c364f4ac18a2237bdbac702b96bcf8ef9cb09). Instead of skipping it entirely, we should ensure the API eventually succeeds.

For the record: on my machine, when the test is un-skipped on 3.12, the task manages to start in about 1.5% cases.

---

On older branches, the test is not skipped, so it occasionally takes 5 minutes. The backports will fix issue #113205.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-113205 -->
* Issue: gh-113205
<!-- /gh-issue-number -->
