### PR TITLE
gh-101100: Fix Sphinx warnings in `reference/expressions.rst`

### DIFF
--- a/Doc/reference/expressions.rst
+++ b/Doc/reference/expressions.rst
@@ -1001,7 +1001,7 @@ but does not affect the semantics.
 
 The primary must evaluate to a callable object (user-defined functions, built-in
 functions, methods of built-in objects, class objects, methods of class
-instances, and all objects having a :meth:`__call__` method are callable).  All
+instances, and all objects having a :meth:`~object.__call__` method are callable).  All
 argument expressions are evaluated before the call is attempted.  Please refer
 to section :ref:`function` for the syntax of formal :term:`parameter` lists.
 
@@ -1159,7 +1159,7 @@ a class instance:
       pair: instance; call
       single: __call__() (object method)
 
-   The class must define a :meth:`__call__` method; the effect is then the same as
+   The class must define a :meth:`~object.__call__` method; the effect is then the same as
    if that method was called.
 
 
@@ -1211,7 +1211,7 @@ Raising ``0.0`` to a negative power results in a :exc:`ZeroDivisionError`.
 Raising a negative number to a fractional power results in a :class:`complex`
 number. (In earlier versions it raised a :exc:`ValueError`.)
 
-This operation can be customized using the special :meth:`__pow__` method.
+This operation can be customized using the special :meth:`~object.__pow__` method.
 
 .. _unary:
 
@@ -1234,7 +1234,7 @@ All unary arithmetic and bitwise operations have the same priority:
    single: - (minus); unary operator
 
 The unary ``-`` (minus) operator yields the negation of its numeric argument; the
-operation can be overridden with the :meth:`__neg__` special method.
+operation can be overridden with the :meth:`~object.__neg__` special method.
 
 .. index::
    single: plus
@@ -1242,7 +1242,7 @@ operation can be overridden with the :meth:`__neg__` special method.
    single: + (plus); unary operator
 
 The unary ``+`` (plus) operator yields its numeric argument unchanged; the
-operation can be overridden with the :meth:`__pos__` special method.
+operation can be overridden with the :meth:`~object.__pos__` special method.
 
 .. index::
    single: inversion
@@ -1251,7 +1251,7 @@ operation can be overridden with the :meth:`__pos__` special method.
 The unary ``~`` (invert) operator yields the bitwise inversion of its integer
 argument.  The bitwise inversion of ``x`` is defined as ``-(x+1)``.  It only
 applies to integral numbers or to custom objects that override the
-:meth:`__invert__` special method.
+:meth:`~object.__invert__` special method.
 
 
 
@@ -1289,8 +1289,8 @@ the other must be a sequence. In the former case, the numbers are converted to a
 common type and then multiplied together.  In the latter case, sequence
 repetition is performed; a negative repetition factor yields an empty sequence.
 
-This operation can be customized using the special :meth:`__mul__` and
-:meth:`__rmul__` methods.
+This operation can be customized using the special :meth:`~object.__mul__` and
+:meth:`~object.__rmul__` methods.
 
 .. index::
    single: matrix multiplication
@@ -1314,8 +1314,8 @@ integer; the result is that of mathematical division with the 'floor' function
 applied to the result.  Division by zero raises the :exc:`ZeroDivisionError`
 exception.
 
-This operation can be customized using the special :meth:`__truediv__` and
-:meth:`__floordiv__` methods.
+This operation can be customized using the special :meth:`~object.__truediv__` and
+:meth:`~object.__floordiv__` methods.
 
 .. index::
    single: modulo
@@ -1340,7 +1340,7 @@ also overloaded by string objects to perform old-style string formatting (also
 known as interpolation).  The syntax for string formatting is described in the
 Python Library Reference, section :ref:`old-string-formatting`.
 
-The *modulo* operation can be customized using the special :meth:`__mod__` method.
+The *modulo* operation can be customized using the special :meth:`~object.__mod__` method.
 
 The floor division operator, the modulo operator, and the :func:`divmod`
 function are not defined for complex numbers.  Instead, convert to a floating
@@ -1356,8 +1356,8 @@ must either both be numbers or both be sequences of the same type.  In the
 former case, the numbers are converted to a common type and then added together.
 In the latter case, the sequences are concatenated.
 
-This operation can be customized using the special :meth:`__add__` and
-:meth:`__radd__` methods.
+This operation can be customized using the special :meth:`~object.__add__` and
+:meth:`~object.__radd__` methods.
 
 .. index::
    single: subtraction
@@ -1367,7 +1367,7 @@ This operation can be customized using the special :meth:`__add__` and
 The ``-`` (subtraction) operator yields the difference of its arguments.  The
 numeric arguments are first converted to a common type.
 
-This operation can be customized using the special :meth:`__sub__` method.
+This operation can be customized using the special :meth:`~object.__sub__` method.
 
 
 .. _shifting:
@@ -1388,8 +1388,8 @@ The shifting operations have lower priority than the arithmetic operations:
 These operators accept integers as arguments.  They shift the first argument to
 the left or right by the number of bits given by the second argument.
 
-This operation can be customized using the special :meth:`__lshift__` and
-:meth:`__rshift__` methods.
+This operation can be customized using the special :meth:`~object.__lshift__` and
+:meth:`~object.__rshift__` methods.
 
 .. index:: pair: exception; ValueError
 
@@ -1416,8 +1416,8 @@ Each of the three bitwise operations has a different priority level:
    pair: operator; & (ampersand)
 
 The ``&`` operator yields the bitwise AND of its arguments, which must be
-integers or one of them must be a custom object overriding :meth:`__and__` or
-:meth:`__rand__` special methods.
+integers or one of them must be a custom object overriding :meth:`~object.__and__` or
+:meth:`~object.__rand__` special methods.
 
 .. index::
    pair: bitwise; xor
@@ -1425,8 +1425,8 @@ integers or one of them must be a custom object overriding :meth:`__and__` or
    pair: operator; ^ (caret)
 
 The ``^`` operator yields the bitwise XOR (exclusive OR) of its arguments, which
-must be integers or one of them must be a custom object overriding :meth:`__xor__` or
-:meth:`__rxor__` special methods.
+must be integers or one of them must be a custom object overriding :meth:`~object.__xor__` or
+:meth:`~object.__rxor__` special methods.
 
 .. index::
    pair: bitwise; or
@@ -1434,8 +1434,8 @@ must be integers or one of them must be a custom object overriding :meth:`__xor_
    pair: operator; | (vertical bar)
 
 The ``|`` operator yields the bitwise (inclusive) OR of its arguments, which
-must be integers or one of them must be a custom object overriding :meth:`__or__` or
-:meth:`__ror__` special methods.
+must be integers or one of them must be a custom object overriding :meth:`~object.__or__` or
+:meth:`~object.__ror__` special methods.
 
 
 .. _comparisons:
@@ -1502,7 +1502,7 @@ comparison implementation.
 Because all types are (direct or indirect) subtypes of :class:`object`, they
 inherit the default comparison behavior from :class:`object`.  Types can
 customize their comparison behavior by implementing
-:dfn:`rich comparison methods` like :meth:`__lt__`, described in
+:dfn:`rich comparison methods` like :meth:`~object.__lt__`, described in
 :ref:`customization`.
 
 The default behavior for equality comparison (``==`` and ``!=``) is based on
@@ -1666,12 +1666,12 @@ substring of *y*.  An equivalent test is ``y.find(x) != -1``.  Empty strings are
 always considered to be a substring of any other string, so ``"" in "abc"`` will
 return ``True``.
 
-For user-defined classes which define the :meth:`__contains__` method, ``x in
+For user-defined classes which define the :meth:`~object.__contains__` method, ``x in
 y`` returns ``True`` if ``y.__contains__(x)`` returns a true value, and
 ``False`` otherwise.
 
-For user-defined classes which do not define :meth:`__contains__` but do define
-:meth:`__iter__`, ``x in y`` is ``True`` if some value ``z``, for which the
+For user-defined classes which do not define :meth:`~object.__contains__` but do define
+:meth:`~object.__iter__`, ``x in y`` is ``True`` if some value ``z``, for which the
 expression ``x is z or x == z`` is true, is produced while iterating over ``y``.
 If an exception is raised during the iteration, it is as if :keyword:`in` raised
 that exception.

--- a/Doc/tools/.nitignore
+++ b/Doc/tools/.nitignore
@@ -96,7 +96,6 @@ Doc/library/xmlrpc.server.rst
 Doc/library/zlib.rst
 Doc/reference/compound_stmts.rst
 Doc/reference/datamodel.rst
-Doc/reference/expressions.rst
 Doc/reference/import.rst
 Doc/tutorial/datastructures.rst
 Doc/using/windows.rst


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

Fix remaining 26 reference warnings in this file, all squiggle object dunders:

```
Doc/reference/expressions.rst:1002: WARNING: py:meth reference target not found: __call__
Doc/reference/expressions.rst:1162: WARNING: py:meth reference target not found: __call__
Doc/reference/expressions.rst:1214: WARNING: py:meth reference target not found: __pow__
Doc/reference/expressions.rst:1236: WARNING: py:meth reference target not found: __neg__
Doc/reference/expressions.rst:1244: WARNING: py:meth reference target not found: __pos__
Doc/reference/expressions.rst:1251: WARNING: py:meth reference target not found: __invert__
Doc/reference/expressions.rst:1292: WARNING: py:meth reference target not found: __mul__
Doc/reference/expressions.rst:1292: WARNING: py:meth reference target not found: __rmul__
Doc/reference/expressions.rst:1317: WARNING: py:meth reference target not found: __truediv__
Doc/reference/expressions.rst:1317: WARNING: py:meth reference target not found: __floordiv__
Doc/reference/expressions.rst:1343: WARNING: py:meth reference target not found: __mod__
Doc/reference/expressions.rst:1359: WARNING: py:meth reference target not found: __add__
Doc/reference/expressions.rst:1359: WARNING: py:meth reference target not found: __radd__
Doc/reference/expressions.rst:1370: WARNING: py:meth reference target not found: __sub__
Doc/reference/expressions.rst:1391: WARNING: py:meth reference target not found: __lshift__
Doc/reference/expressions.rst:1391: WARNING: py:meth reference target not found: __rshift__
Doc/reference/expressions.rst:1418: WARNING: py:meth reference target not found: __and__
Doc/reference/expressions.rst:1418: WARNING: py:meth reference target not found: __rand__
Doc/reference/expressions.rst:1427: WARNING: py:meth reference target not found: __xor__
Doc/reference/expressions.rst:1427: WARNING: py:meth reference target not found: __rxor__
Doc/reference/expressions.rst:1436: WARNING: py:meth reference target not found: __or__
Doc/reference/expressions.rst:1436: WARNING: py:meth reference target not found: __ror__
Doc/reference/expressions.rst:1502: WARNING: py:meth reference target not found: __lt__
Doc/reference/expressions.rst:1669: WARNING: py:meth reference target not found: __contains__
Doc/reference/expressions.rst:1673: WARNING: py:meth reference target not found: __contains__
Doc/reference/expressions.rst:1673: WARNING: py:meth reference target not found: __iter__
```

<!-- gh-issue-number: gh-101100 -->
* Issue: gh-101100
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--114194.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->