### PR TITLE
gh-112984: Fix test_ctypes.test_loading.test_load_dll_with_flags when directory name includes a dot

### DIFF
--- a/Lib/test/test_ctypes/test_loading.py
+++ b/Lib/test/test_ctypes/test_loading.py
@@ -141,7 +141,7 @@ class LoaderTest(unittest.TestCase):
     def test_load_dll_with_flags(self):
         _sqlite3 = import_helper.import_module("_sqlite3")
         src = _sqlite3.__file__
-        if src.partition(".")[0].lower().endswith("_d"):
+        if os.path.basename(src).partition(".")[0].lower().endswith("_d"):
             ext = "_d.dll"
         else:
             ext = ".dll"


### PR DESCRIPTION


<!-- gh-issue-number: gh-112984 -->
* Issue: gh-112984
<!-- /gh-issue-number -->
