### PR TITLE
Simplify concurrent.futures.process code by using itertools.batched()

### DIFF
--- a/Lib/concurrent/futures/process.py
+++ b/Lib/concurrent/futures/process.py
@@ -193,11 +193,7 @@ class _SafeQueue(Queue):
 def _get_chunks(*iterables, chunksize):
     """ Iterates over zip()ed iterables in chunks. """
     it = zip(*iterables)
-    while True:
-        chunk = tuple(itertools.islice(it, chunksize))
-        if not chunk:
-            return
-        yield chunk
+    return itertools.batched(it, chunksize)
 
 
 def _process_chunk(fn, chunk):

--- a/Lib/concurrent/futures/process.py
+++ b/Lib/concurrent/futures/process.py
@@ -190,12 +190,6 @@ class _SafeQueue(Queue):
             super()._on_queue_feeder_error(e, obj)
 
 
-def _get_chunks(*iterables, chunksize):
-    """ Iterates over zip()ed iterables in chunks. """
-    it = zip(*iterables)
-    return itertools.batched(it, chunksize)
-
-
 def _process_chunk(fn, chunk):
     """ Processes a chunk of an iterable passed to map.
 
@@ -843,7 +837,7 @@ class ProcessPoolExecutor(_base.Executor):
             raise ValueError("chunksize must be >= 1.")
 
         results = super().map(partial(_process_chunk, fn),
-                              _get_chunks(*iterables, chunksize=chunksize),
+                              itertools.batched(zip(*iterables), chunksize),
                               timeout=timeout)
         return _chain_from_iterable_of_lists(results)
 


### PR DESCRIPTION
Advantages:
* use new standard library, to encourage users to also use stdlibs.
```py
d=list(range(50000))

list(concurrent.futures.process._get_chunks(d, chunksize=1))
# 105 ms ± 4.43 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)

list(_get_chunks(d, chunksize=1))
# 5.87 ms ± 378 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
```
* performance. the difference is significant when chunksize is small,  and the chunksize is usually `=1`.