### PR TITLE
gh-104522: Fix test_subprocess failure when build Python in the root home directory

### DIFF
--- a/Lib/test/test_subprocess.py
+++ b/Lib/test/test_subprocess.py
@@ -2018,11 +2018,10 @@ class POSIXProcessTestCase(BaseTestCase):
                                 user=user,
                                 close_fds=close_fds)
                     except PermissionError as e:  # (EACCES, EPERM)
-                        self.assertIsNone(e.filename)
-                    except OSError as e:
-                        if e.errno not in (errno.EACCES, errno.EPERM):
-                            raise
-                        self.assertIsNone(e.filename)
+                        if e.errno == errno.EACCES:
+                            self.assertEqual(e.filename, sys.executable)
+                        else:
+                            self.assertIsNone(e.filename)
                     else:
                         if isinstance(user, str):
                             user_uid = pwd.getpwnam(user).pw_uid

--- a/Lib/test/test_subprocess.py
+++ b/Lib/test/test_subprocess.py
@@ -1991,9 +1991,9 @@ class POSIXProcessTestCase(BaseTestCase):
 
     @unittest.skipUnless(hasattr(os, 'setreuid'), 'no setreuid on platform')
     def test_user(self):
-        # For code coverage of the user parameter.  We don't care if we get an
-        # EPERM error from it depending on the test execution environment, that
-        # still indicates that it was called.
+        # For code coverage of the user parameter.  We don't care if we get a
+        # permission error from it depending on the test execution environment,
+        # that still indicates that it was called.
 
         uid = os.geteuid()
         test_users = [65534 if uid != 65534 else 65533, uid]


### PR DESCRIPTION
EPERM is raised when setreuid() fails.
EACCES is set in execve() when the test user has not access to sys.executable.


<!-- gh-issue-number: gh-104522 -->
* Issue: gh-104522
<!-- /gh-issue-number -->
