### PR TITLE
gh-108198: Add `Logger._log` and `Logger.manager` documentation

### DIFF
--- a/Doc/library/logging.rst
+++ b/Doc/library/logging.rst
@@ -390,7 +390,7 @@ is the module's name in the Python package namespace.
 
    .. attribute:: manager
 
-      The logger :class:`~Manager`.
+      The logger ``logging.Manager``.
 
    .. versionchanged:: 3.7
       Loggers can now be pickled and unpickled.

--- a/Doc/library/logging.rst
+++ b/Doc/library/logging.rst
@@ -1021,11 +1021,11 @@ information into logging calls. For a usage example, see the section on
 
    .. attribute:: manager
 
-      Delegates to the underlying :attr:`!manager`` on *logger*.
+      Delegates to the underlying :attr:`!manager` on *logger*.
 
    .. attribute:: _log
 
-      Delegates to the underlying :meth:`!_log`` method on *logger*.
+      Delegates to the underlying :meth:`!_log` method on *logger*.
 
    In addition to the above, :class:`LoggerAdapter` supports the following
    methods of :class:`Logger`: :meth:`~Logger.debug`, :meth:`~Logger.info`,

--- a/Doc/library/logging.rst
+++ b/Doc/library/logging.rst
@@ -383,6 +383,15 @@ is the module's name in the Python package namespace.
 
       .. versionadded:: 3.2
 
+   .. method:: Logger._log(level, msg, args, exc_info=None, extra=None, stack_info=False, stacklevel=1)
+
+      Low-level logging routine which creates a :class:`~LogRecord` and then calls
+      all the handlers of this logger to handle the record.
+
+   .. attribute:: manager
+
+      The logger :class:`~Manager`.
+
    .. versionchanged:: 3.7
       Loggers can now be pickled and unpickled.
 


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

I just added some brief documentation for the `Logger._log` method and `Logger.manager` attribute.
I am unsure if we want the `Logger.manager` attribute documented since the whole `logging.Manager` class isn't documented.

This is my very first PR against `cpython` so please give any advice or feel free to just close the PR if it is useless. 

I also fixed two double-back quotes on the same documentation page. Should I move that to another PR?

<!-- gh-issue-number: gh-108198 -->
* Issue: gh-108198
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--114248.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->