### PR TITLE
gh-114198: Rename dataclass __replace__ argument to 'self'

### DIFF
--- a/Lib/dataclasses.py
+++ b/Lib/dataclasses.py
@@ -1558,14 +1558,14 @@ def replace(obj, /, **changes):
     return _replace(obj, **changes)
 
 
-def _replace(obj, /, **changes):
+def _replace(self, /, **changes):
     # We're going to mutate 'changes', but that's okay because it's a
-    # new dict, even if called with 'replace(obj, **my_changes)'.
+    # new dict, even if called with 'replace(self, **my_changes)'.
 
     # It's an error to have init=False fields in 'changes'.
-    # If a field is not in 'changes', read its value from the provided obj.
+    # If a field is not in 'changes', read its value from the provided 'self'.
 
-    for f in getattr(obj, _FIELDS).values():
+    for f in getattr(self, _FIELDS).values():
         # Only consider normal fields or InitVars.
         if f._field_type is _FIELD_CLASSVAR:
             continue
@@ -1582,11 +1582,11 @@ def _replace(obj, /, **changes):
             if f._field_type is _FIELD_INITVAR and f.default is MISSING:
                 raise TypeError(f"InitVar {f.name!r} "
                                 f'must be specified with replace()')
-            changes[f.name] = getattr(obj, f.name)
+            changes[f.name] = getattr(self, f.name)
 
     # Create the new object, which calls __init__() and
     # __post_init__() (if defined), using all of the init fields we've
     # added and/or left in 'changes'.  If there are values supplied in
     # changes that aren't fields, this will correctly raise a
     # TypeError.
-    return obj.__class__(**changes)
+    return self.__class__(**changes)

--- a/Misc/NEWS.d/next/Library/2024-01-18-10-07-52.gh-issue-114198.lK4Iif.rst
+++ b/Misc/NEWS.d/next/Library/2024-01-18-10-07-52.gh-issue-114198.lK4Iif.rst
@@ -1,0 +1,2 @@
+The signature for the ``__replace__`` method on :mod:`dataclasses` now has
+the first argument named ``self``, rather than ``obj``.


### PR DESCRIPTION
This change renames the dataclass `__replace__` method's first argument name from `obj` to `self`.

This results in a more tidy set of signatures for dataclasses; i.e.:
```
>>> import dataclasses, inspect, pprint
>>> @dataclasses.dataclass
... class Foo:
...   x: int
... 
>>> pprint.pprint({n:inspect.signature(f) for n, f in inspect.getmembers(Foo, inspect.isfunction)})
{'__eq__': <Signature (self, other)>,
 '__init__': <Signature (self, x: int) -> None>,
 '__replace__': <Signature (self, /, **changes)>,
 '__repr__': <Signature (self)>}
```


<!-- gh-issue-number: gh-114198 -->
* Issue: gh-114198
<!-- /gh-issue-number -->
