### PR TITLE
gh-112075: Adapt more dict methods to Argument Clinic

### DIFF
--- a/Objects/clinic/dictobject.c.h
+++ b/Objects/clinic/dictobject.c.h
@@ -42,7 +42,7 @@ PyDoc_STRVAR(dict_copy__doc__,
 "copy($self, /)\n"
 "--\n"
 "\n"
-"Returns a shallow copy of the dict.");
+"Return a shallow copy of the dict.");
 
 #define DICT_COPY_METHODDEF    \
     {"copy", (PyCFunction)dict_copy, METH_NOARGS, dict_copy__doc__},
@@ -140,7 +140,7 @@ PyDoc_STRVAR(dict_clear__doc__,
 "clear($self, /)\n"
 "--\n"
 "\n"
-"Removes all items.");
+"Remove all items from the dict.");
 
 #define DICT_CLEAR_METHODDEF    \
     {"clear", (PyCFunction)dict_clear, METH_NOARGS, dict_clear__doc__},
@@ -216,7 +216,7 @@ PyDoc_STRVAR(dict___sizeof____doc__,
 "__sizeof__($self, /)\n"
 "--\n"
 "\n"
-"Returns size of the dict in memory, in bytes.");
+"Return the size of the dict in memory, in bytes.");
 
 #define DICT___SIZEOF___METHODDEF    \
     {"__sizeof__", (PyCFunction)dict___sizeof__, METH_NOARGS, dict___sizeof____doc__},
@@ -252,7 +252,7 @@ PyDoc_STRVAR(dict_keys__doc__,
 "keys($self, /)\n"
 "--\n"
 "\n"
-"Returns a set-like object providing a view on the dict\'s keys.");
+"Return a set-like object providing a view on the dict\'s keys.");
 
 #define DICT_KEYS_METHODDEF    \
     {"keys", (PyCFunction)dict_keys, METH_NOARGS, dict_keys__doc__},
@@ -270,7 +270,7 @@ PyDoc_STRVAR(dict_items__doc__,
 "items($self, /)\n"
 "--\n"
 "\n"
-"Returns a set-like object providing a view on D\'s items.");
+"Return a set-like object providing a view on the dict\'s items.");
 
 #define DICT_ITEMS_METHODDEF    \
     {"items", (PyCFunction)dict_items, METH_NOARGS, dict_items__doc__},
@@ -288,7 +288,7 @@ PyDoc_STRVAR(dict_values__doc__,
 "values($self, /)\n"
 "--\n"
 "\n"
-"Returns an object providing a view on the dict\'s values.");
+"Return an object providing a view on the dict\'s values.");
 
 #define DICT_VALUES_METHODDEF    \
     {"values", (PyCFunction)dict_values, METH_NOARGS, dict_values__doc__},
@@ -301,4 +301,4 @@ dict_values(PyDictObject *self, PyObject *Py_UNUSED(ignored))
 {
     return dict_values_impl(self);
 }
-/*[clinic end generated code: output=6cc89cc533fd201b input=a9049054013a1b77]*/
+/*[clinic end generated code: output=f3ac47dfbf341b23 input=a9049054013a1b77]*/

--- a/Objects/clinic/dictobject.c.h
+++ b/Objects/clinic/dictobject.c.h
@@ -38,6 +38,24 @@ exit:
     return return_value;
 }
 
+PyDoc_STRVAR(dict_copy__doc__,
+"copy($self, /)\n"
+"--\n"
+"\n"
+"D.copy() -> a shallow copy of D");
+
+#define DICT_COPY_METHODDEF    \
+    {"copy", (PyCFunction)dict_copy, METH_NOARGS, dict_copy__doc__},
+
+static PyObject *
+dict_copy_impl(PyDictObject *self);
+
+static PyObject *
+dict_copy(PyDictObject *self, PyObject *Py_UNUSED(ignored))
+{
+    return dict_copy_impl(self);
+}
+
 PyDoc_STRVAR(dict___contains____doc__,
 "__contains__($self, key, /)\n"
 "--\n"
@@ -118,6 +136,24 @@ exit:
     return return_value;
 }
 
+PyDoc_STRVAR(dict_clear__doc__,
+"clear($self, /)\n"
+"--\n"
+"\n"
+"D.clear() -> None.  Remove all items from D.");
+
+#define DICT_CLEAR_METHODDEF    \
+    {"clear", (PyCFunction)dict_clear, METH_NOARGS, dict_clear__doc__},
+
+static PyObject *
+dict_clear_impl(PyDictObject *self);
+
+static PyObject *
+dict_clear(PyDictObject *self, PyObject *Py_UNUSED(ignored))
+{
+    return dict_clear_impl(self);
+}
+
 PyDoc_STRVAR(dict_pop__doc__,
 "pop($self, key, default=<unrepresentable>, /)\n"
 "--\n"
@@ -176,6 +212,24 @@ dict_popitem(PyDictObject *self, PyObject *Py_UNUSED(ignored))
     return dict_popitem_impl(self);
 }
 
+PyDoc_STRVAR(dict___sizeof____doc__,
+"__sizeof__($self, /)\n"
+"--\n"
+"\n"
+"D.__sizeof__() -> size of D in memory, in bytes");
+
+#define DICT___SIZEOF___METHODDEF    \
+    {"__sizeof__", (PyCFunction)dict___sizeof__, METH_NOARGS, dict___sizeof____doc__},
+
+static PyObject *
+dict___sizeof___impl(PyDictObject *self);
+
+static PyObject *
+dict___sizeof__(PyDictObject *self, PyObject *Py_UNUSED(ignored))
+{
+    return dict___sizeof___impl(self);
+}
+
 PyDoc_STRVAR(dict___reversed____doc__,
 "__reversed__($self, /)\n"
 "--\n"
@@ -193,4 +247,58 @@ dict___reversed__(PyDictObject *self, PyObject *Py_UNUSED(ignored))
 {
     return dict___reversed___impl(self);
 }
-/*[clinic end generated code: output=17c3c4cf9a9b95a7 input=a9049054013a1b77]*/
+
+PyDoc_STRVAR(dict_keys__doc__,
+"keys($self, /)\n"
+"--\n"
+"\n"
+"D.keys() -> a set-like object providing a view on D\'s keys");
+
+#define DICT_KEYS_METHODDEF    \
+    {"keys", (PyCFunction)dict_keys, METH_NOARGS, dict_keys__doc__},
+
+static PyObject *
+dict_keys_impl(PyDictObject *self);
+
+static PyObject *
+dict_keys(PyDictObject *self, PyObject *Py_UNUSED(ignored))
+{
+    return dict_keys_impl(self);
+}
+
+PyDoc_STRVAR(dict_items__doc__,
+"items($self, /)\n"
+"--\n"
+"\n"
+"D.items() -> a set-like object providing a view on D\'s items");
+
+#define DICT_ITEMS_METHODDEF    \
+    {"items", (PyCFunction)dict_items, METH_NOARGS, dict_items__doc__},
+
+static PyObject *
+dict_items_impl(PyDictObject *self);
+
+static PyObject *
+dict_items(PyDictObject *self, PyObject *Py_UNUSED(ignored))
+{
+    return dict_items_impl(self);
+}
+
+PyDoc_STRVAR(dict_values__doc__,
+"values($self, /)\n"
+"--\n"
+"\n"
+"D.values() -> an object providing a view on D\'s values");
+
+#define DICT_VALUES_METHODDEF    \
+    {"values", (PyCFunction)dict_values, METH_NOARGS, dict_values__doc__},
+
+static PyObject *
+dict_values_impl(PyDictObject *self);
+
+static PyObject *
+dict_values(PyDictObject *self, PyObject *Py_UNUSED(ignored))
+{
+    return dict_values_impl(self);
+}
+/*[clinic end generated code: output=852c83b680d0a4a0 input=a9049054013a1b77]*/

--- a/Objects/clinic/dictobject.c.h
+++ b/Objects/clinic/dictobject.c.h
@@ -42,7 +42,7 @@ PyDoc_STRVAR(dict_copy__doc__,
 "copy($self, /)\n"
 "--\n"
 "\n"
-"D.copy() -> a shallow copy of D");
+"Returns a shallow copy of D.");
 
 #define DICT_COPY_METHODDEF    \
     {"copy", (PyCFunction)dict_copy, METH_NOARGS, dict_copy__doc__},
@@ -140,7 +140,7 @@ PyDoc_STRVAR(dict_clear__doc__,
 "clear($self, /)\n"
 "--\n"
 "\n"
-"D.clear() -> None.  Remove all items from D.");
+"Removes all items.");
 
 #define DICT_CLEAR_METHODDEF    \
     {"clear", (PyCFunction)dict_clear, METH_NOARGS, dict_clear__doc__},
@@ -216,7 +216,7 @@ PyDoc_STRVAR(dict___sizeof____doc__,
 "__sizeof__($self, /)\n"
 "--\n"
 "\n"
-"D.__sizeof__() -> size of D in memory, in bytes");
+"Returns size of D in memory, in bytes.");
 
 #define DICT___SIZEOF___METHODDEF    \
     {"__sizeof__", (PyCFunction)dict___sizeof__, METH_NOARGS, dict___sizeof____doc__},
@@ -252,7 +252,7 @@ PyDoc_STRVAR(dict_keys__doc__,
 "keys($self, /)\n"
 "--\n"
 "\n"
-"D.keys() -> a set-like object providing a view on D\'s keys");
+"Returns a set-like object providing a view on D\'s keys.");
 
 #define DICT_KEYS_METHODDEF    \
     {"keys", (PyCFunction)dict_keys, METH_NOARGS, dict_keys__doc__},
@@ -270,7 +270,7 @@ PyDoc_STRVAR(dict_items__doc__,
 "items($self, /)\n"
 "--\n"
 "\n"
-"D.items() -> a set-like object providing a view on D\'s items");
+"Returns a set-like object providing a view on D\'s items.");
 
 #define DICT_ITEMS_METHODDEF    \
     {"items", (PyCFunction)dict_items, METH_NOARGS, dict_items__doc__},
@@ -288,7 +288,7 @@ PyDoc_STRVAR(dict_values__doc__,
 "values($self, /)\n"
 "--\n"
 "\n"
-"D.values() -> an object providing a view on D\'s values");
+"Returns an object providing a view on D\'s values.");
 
 #define DICT_VALUES_METHODDEF    \
     {"values", (PyCFunction)dict_values, METH_NOARGS, dict_values__doc__},
@@ -301,4 +301,4 @@ dict_values(PyDictObject *self, PyObject *Py_UNUSED(ignored))
 {
     return dict_values_impl(self);
 }
-/*[clinic end generated code: output=852c83b680d0a4a0 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=7b0c1b786b53efcf input=a9049054013a1b77]*/

--- a/Objects/clinic/dictobject.c.h
+++ b/Objects/clinic/dictobject.c.h
@@ -42,7 +42,7 @@ PyDoc_STRVAR(dict_copy__doc__,
 "copy($self, /)\n"
 "--\n"
 "\n"
-"Returns a shallow copy of D.");
+"Returns a shallow copy of the dict.");
 
 #define DICT_COPY_METHODDEF    \
     {"copy", (PyCFunction)dict_copy, METH_NOARGS, dict_copy__doc__},
@@ -216,7 +216,7 @@ PyDoc_STRVAR(dict___sizeof____doc__,
 "__sizeof__($self, /)\n"
 "--\n"
 "\n"
-"Returns size of D in memory, in bytes.");
+"Returns size of the dict in memory, in bytes.");
 
 #define DICT___SIZEOF___METHODDEF    \
     {"__sizeof__", (PyCFunction)dict___sizeof__, METH_NOARGS, dict___sizeof____doc__},
@@ -252,7 +252,7 @@ PyDoc_STRVAR(dict_keys__doc__,
 "keys($self, /)\n"
 "--\n"
 "\n"
-"Returns a set-like object providing a view on D\'s keys.");
+"Returns a set-like object providing a view on the dict\'s keys.");
 
 #define DICT_KEYS_METHODDEF    \
     {"keys", (PyCFunction)dict_keys, METH_NOARGS, dict_keys__doc__},
@@ -288,7 +288,7 @@ PyDoc_STRVAR(dict_values__doc__,
 "values($self, /)\n"
 "--\n"
 "\n"
-"Returns an object providing a view on D\'s values.");
+"Returns an object providing a view on the dict\'s values.");
 
 #define DICT_VALUES_METHODDEF    \
     {"values", (PyCFunction)dict_values, METH_NOARGS, dict_values__doc__},
@@ -301,4 +301,4 @@ dict_values(PyDictObject *self, PyObject *Py_UNUSED(ignored))
 {
     return dict_values_impl(self);
 }
-/*[clinic end generated code: output=7b0c1b786b53efcf input=a9049054013a1b77]*/
+/*[clinic end generated code: output=6cc89cc533fd201b input=a9049054013a1b77]*/

--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -5359,7 +5359,7 @@ PyTypeObject PyDictItems_Type = {
 /*[clinic input]
 dict.items
 
-Returns a set-like object providing a view on D's items.
+Return a set-like object providing a view on the dict's items.
 [clinic start generated code]*/
 
 static PyObject *

--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -5449,7 +5449,7 @@ PyTypeObject PyDictValues_Type = {
 /*[clinic input]
 dict.values
 
-Returns an object providing a view on the dict's values.
+Return an object providing a view on the dict's values.
 [clinic start generated code]*/
 
 static PyObject *

--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -5247,7 +5247,7 @@ PyTypeObject PyDictKeys_Type = {
 /*[clinic input]
 dict.keys
 
-Returns a set-like object providing a view on the dict's keys.
+Return a set-like object providing a view on the dict's keys.
 [clinic start generated code]*/
 
 static PyObject *

--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -3757,7 +3757,7 @@ static PyMethodDef mapp_methods[] = {
     DICT___CONTAINS___METHODDEF
     {"__getitem__",     dict_subscript,                 METH_O | METH_COEXIST,
      getitem__doc__},
-     DICT___SIZEOF___METHODDEF
+    DICT___SIZEOF___METHODDEF
     DICT_GET_METHODDEF
     DICT_SETDEFAULT_METHODDEF
     DICT_POP_METHODDEF

--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -3126,12 +3126,12 @@ _PyDict_MergeEx(PyObject *a, PyObject *b, int override)
 /*[clinic input]
 dict.copy
 
-Returns a shallow copy of D.
+Returns a shallow copy of the dict.
 [clinic start generated code]*/
 
 static PyObject *
 dict_copy_impl(PyDictObject *self)
-/*[clinic end generated code: output=ffb782cf970a5c39 input=6d9903c1b6362e32]*/
+/*[clinic end generated code: output=ffb782cf970a5c39 input=c3478619cd5ae21d]*/
 {
     return PyDict_Copy((PyObject *)self);
 }
@@ -3706,12 +3706,12 @@ _PyDict_KeysSize(PyDictKeysObject *keys)
 /*[clinic input]
 dict.__sizeof__
 
-Returns size of D in memory, in bytes.
+Returns size of the dict in memory, in bytes.
 [clinic start generated code]*/
 
 static PyObject *
 dict___sizeof___impl(PyDictObject *self)
-/*[clinic end generated code: output=44279379b3824bda input=33b3550475672efd]*/
+/*[clinic end generated code: output=44279379b3824bda input=4390a7fef5801970]*/
 {
     return PyLong_FromSsize_t(_PyDict_SizeOf(self));
 }
@@ -5247,12 +5247,12 @@ PyTypeObject PyDictKeys_Type = {
 /*[clinic input]
 dict.keys
 
-Returns a set-like object providing a view on D's keys.
+Returns a set-like object providing a view on the dict's keys.
 [clinic start generated code]*/
 
 static PyObject *
 dict_keys_impl(PyDictObject *self)
-/*[clinic end generated code: output=aac2830c62990358 input=26448b0710052252]*/
+/*[clinic end generated code: output=aac2830c62990358 input=7f7942e4dbbc4cdf]*/
 {
     return _PyDictView_New((PyObject *)self, &PyDictKeys_Type);
 }
@@ -5449,12 +5449,12 @@ PyTypeObject PyDictValues_Type = {
 /*[clinic input]
 dict.values
 
-Returns an object providing a view on D's values.
+Returns an object providing a view on the dict's values.
 [clinic start generated code]*/
 
 static PyObject *
 dict_values_impl(PyDictObject *self)
-/*[clinic end generated code: output=ce9f2e9e8a959dd4 input=53354b69fc077e0d]*/
+/*[clinic end generated code: output=ce9f2e9e8a959dd4 input=ccd5c09c261cd554]*/
 {
     return _PyDictView_New((PyObject *)self, &PyDictValues_Type);
 }

--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -3126,7 +3126,7 @@ _PyDict_MergeEx(PyObject *a, PyObject *b, int override)
 /*[clinic input]
 dict.copy
 
-Returns a shallow copy of the dict.
+Return a shallow copy of the dict.
 [clinic start generated code]*/
 
 static PyObject *

--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -3126,12 +3126,12 @@ _PyDict_MergeEx(PyObject *a, PyObject *b, int override)
 /*[clinic input]
 dict.copy
 
-D.copy() -> a shallow copy of D
+Returns a shallow copy of D.
 [clinic start generated code]*/
 
 static PyObject *
 dict_copy_impl(PyDictObject *self)
-/*[clinic end generated code: output=ffb782cf970a5c39 input=b96949d603dc505c]*/
+/*[clinic end generated code: output=ffb782cf970a5c39 input=6d9903c1b6362e32]*/
 {
     return PyDict_Copy((PyObject *)self);
 }
@@ -3508,12 +3508,12 @@ dict_setdefault_impl(PyDictObject *self, PyObject *key,
 /*[clinic input]
 dict.clear
 
-D.clear() -> None.  Remove all items from D.
+Removes all items.
 [clinic start generated code]*/
 
 static PyObject *
 dict_clear_impl(PyDictObject *self)
-/*[clinic end generated code: output=5139a830df00830a input=31e16ad16e56f4dc]*/
+/*[clinic end generated code: output=5139a830df00830a input=1824e4e555dfaf79]*/
 {
     PyDict_Clear((PyObject *)self);
     Py_RETURN_NONE;
@@ -3706,12 +3706,12 @@ _PyDict_KeysSize(PyDictKeysObject *keys)
 /*[clinic input]
 dict.__sizeof__
 
-D.__sizeof__() -> size of D in memory, in bytes
+Returns size of D in memory, in bytes.
 [clinic start generated code]*/
 
 static PyObject *
 dict___sizeof___impl(PyDictObject *self)
-/*[clinic end generated code: output=44279379b3824bda input=bcde0197a346f7ce]*/
+/*[clinic end generated code: output=44279379b3824bda input=33b3550475672efd]*/
 {
     return PyLong_FromSsize_t(_PyDict_SizeOf(self));
 }
@@ -5247,12 +5247,12 @@ PyTypeObject PyDictKeys_Type = {
 /*[clinic input]
 dict.keys
 
-D.keys() -> a set-like object providing a view on D's keys
+Returns a set-like object providing a view on D's keys.
 [clinic start generated code]*/
 
 static PyObject *
 dict_keys_impl(PyDictObject *self)
-/*[clinic end generated code: output=aac2830c62990358 input=4a20806094eaaed1]*/
+/*[clinic end generated code: output=aac2830c62990358 input=26448b0710052252]*/
 {
     return _PyDictView_New((PyObject *)self, &PyDictKeys_Type);
 }
@@ -5359,12 +5359,12 @@ PyTypeObject PyDictItems_Type = {
 /*[clinic input]
 dict.items
 
-D.items() -> a set-like object providing a view on D's items
+Returns a set-like object providing a view on D's items.
 [clinic start generated code]*/
 
 static PyObject *
 dict_items_impl(PyDictObject *self)
-/*[clinic end generated code: output=88c7db7150c7909a input=7c47bcbd09b31e59]*/
+/*[clinic end generated code: output=88c7db7150c7909a input=21ee5e4c8ead76c4]*/
 {
     return _PyDictView_New((PyObject *)self, &PyDictItems_Type);
 }
@@ -5449,12 +5449,12 @@ PyTypeObject PyDictValues_Type = {
 /*[clinic input]
 dict.values
 
-D.values() -> an object providing a view on D's values
+Returns an object providing a view on D's values.
 [clinic start generated code]*/
 
 static PyObject *
 dict_values_impl(PyDictObject *self)
-/*[clinic end generated code: output=ce9f2e9e8a959dd4 input=004353e8ab5d1aa9]*/
+/*[clinic end generated code: output=ce9f2e9e8a959dd4 input=53354b69fc077e0d]*/
 {
     return _PyDictView_New((PyObject *)self, &PyDictValues_Type);
 }

--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -3706,7 +3706,7 @@ _PyDict_KeysSize(PyDictKeysObject *keys)
 /*[clinic input]
 dict.__sizeof__
 
-Returns size of the dict in memory, in bytes.
+Return the size of the dict in memory, in bytes.
 [clinic start generated code]*/
 
 static PyObject *

--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -3131,7 +3131,7 @@ Return a shallow copy of the dict.
 
 static PyObject *
 dict_copy_impl(PyDictObject *self)
-/*[clinic end generated code: output=ffb782cf970a5c39 input=c3478619cd5ae21d]*/
+/*[clinic end generated code: output=ffb782cf970a5c39 input=73935f042b639de4]*/
 {
     return PyDict_Copy((PyObject *)self);
 }
@@ -3513,7 +3513,7 @@ Remove all items from the dict.
 
 static PyObject *
 dict_clear_impl(PyDictObject *self)
-/*[clinic end generated code: output=5139a830df00830a input=1824e4e555dfaf79]*/
+/*[clinic end generated code: output=5139a830df00830a input=0bf729baba97a4c2]*/
 {
     PyDict_Clear((PyObject *)self);
     Py_RETURN_NONE;
@@ -3711,7 +3711,7 @@ Return the size of the dict in memory, in bytes.
 
 static PyObject *
 dict___sizeof___impl(PyDictObject *self)
-/*[clinic end generated code: output=44279379b3824bda input=4390a7fef5801970]*/
+/*[clinic end generated code: output=44279379b3824bda input=4fec4ddfc44a4d1a]*/
 {
     return PyLong_FromSsize_t(_PyDict_SizeOf(self));
 }
@@ -5252,7 +5252,7 @@ Return a set-like object providing a view on the dict's keys.
 
 static PyObject *
 dict_keys_impl(PyDictObject *self)
-/*[clinic end generated code: output=aac2830c62990358 input=7f7942e4dbbc4cdf]*/
+/*[clinic end generated code: output=aac2830c62990358 input=42f48a7a771212a7]*/
 {
     return _PyDictView_New((PyObject *)self, &PyDictKeys_Type);
 }
@@ -5364,7 +5364,7 @@ Return a set-like object providing a view on the dict's items.
 
 static PyObject *
 dict_items_impl(PyDictObject *self)
-/*[clinic end generated code: output=88c7db7150c7909a input=21ee5e4c8ead76c4]*/
+/*[clinic end generated code: output=88c7db7150c7909a input=87c822872eb71f5a]*/
 {
     return _PyDictView_New((PyObject *)self, &PyDictItems_Type);
 }
@@ -5454,7 +5454,7 @@ Return an object providing a view on the dict's values.
 
 static PyObject *
 dict_values_impl(PyDictObject *self)
-/*[clinic end generated code: output=ce9f2e9e8a959dd4 input=ccd5c09c261cd554]*/
+/*[clinic end generated code: output=ce9f2e9e8a959dd4 input=b46944f85493b230]*/
 {
     return _PyDictView_New((PyObject *)self, &PyDictValues_Type);
 }

--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -2641,9 +2641,14 @@ static PyMappingMethods dict_as_mapping = {
     dict_ass_sub, /*mp_ass_subscript*/
 };
 
-static PyObject *
-dict_keys(PyDictObject *mp)
+PyObject *
+PyDict_Keys(PyObject *dict)
 {
+    if (dict == NULL || !PyDict_Check(dict)) {
+        PyErr_BadInternalCall();
+        return NULL;
+    }
+    PyDictObject *mp = (PyDictObject *)dict;
     PyObject *v;
     Py_ssize_t n;
 
@@ -2672,9 +2677,14 @@ dict_keys(PyDictObject *mp)
     return v;
 }
 
-static PyObject *
-dict_values(PyDictObject *mp)
+PyObject *
+PyDict_Values(PyObject *dict)
 {
+    if (dict == NULL || !PyDict_Check(dict)) {
+        PyErr_BadInternalCall();
+        return NULL;
+    }
+    PyDictObject *mp = (PyDictObject *)dict;
     PyObject *v;
     Py_ssize_t n;
 
@@ -2703,9 +2713,14 @@ dict_values(PyDictObject *mp)
     return v;
 }
 
-static PyObject *
-dict_items(PyDictObject *mp)
+PyObject *
+PyDict_Items(PyObject *dict)
 {
+    if (dict == NULL || !PyDict_Check(dict)) {
+        PyErr_BadInternalCall();
+        return NULL;
+    }
+    PyDictObject *mp = (PyDictObject *)dict;
     PyObject *v;
     Py_ssize_t i, n;
     PyObject *item;
@@ -3108,10 +3123,17 @@ _PyDict_MergeEx(PyObject *a, PyObject *b, int override)
     return dict_merge(interp, a, b, override);
 }
 
+/*[clinic input]
+dict.copy
+
+D.copy() -> a shallow copy of D
+[clinic start generated code]*/
+
 static PyObject *
-dict_copy(PyObject *mp, PyObject *Py_UNUSED(ignored))
+dict_copy_impl(PyDictObject *self)
+/*[clinic end generated code: output=ffb782cf970a5c39 input=b96949d603dc505c]*/
 {
-    return PyDict_Copy(mp);
+    return PyDict_Copy((PyObject *)self);
 }
 
 PyObject *
@@ -3215,36 +3237,6 @@ PyDict_Size(PyObject *mp)
         return -1;
     }
     return ((PyDictObject *)mp)->ma_used;
-}
-
-PyObject *
-PyDict_Keys(PyObject *mp)
-{
-    if (mp == NULL || !PyDict_Check(mp)) {
-        PyErr_BadInternalCall();
-        return NULL;
-    }
-    return dict_keys((PyDictObject *)mp);
-}
-
-PyObject *
-PyDict_Values(PyObject *mp)
-{
-    if (mp == NULL || !PyDict_Check(mp)) {
-        PyErr_BadInternalCall();
-        return NULL;
-    }
-    return dict_values((PyDictObject *)mp);
-}
-
-PyObject *
-PyDict_Items(PyObject *mp)
-{
-    if (mp == NULL || !PyDict_Check(mp)) {
-        PyErr_BadInternalCall();
-        return NULL;
-    }
-    return dict_items((PyDictObject *)mp);
 }
 
 /* Return 1 if dicts equal, 0 if not, -1 if error.
@@ -3512,10 +3504,18 @@ dict_setdefault_impl(PyDictObject *self, PyObject *key,
     return Py_XNewRef(val);
 }
 
+
+/*[clinic input]
+dict.clear
+
+D.clear() -> None.  Remove all items from D.
+[clinic start generated code]*/
+
 static PyObject *
-dict_clear(PyObject *mp, PyObject *Py_UNUSED(ignored))
+dict_clear_impl(PyDictObject *self)
+/*[clinic end generated code: output=5139a830df00830a input=31e16ad16e56f4dc]*/
 {
-    PyDict_Clear(mp);
+    PyDict_Clear((PyObject *)self);
     Py_RETURN_NONE;
 }
 
@@ -3703,11 +3703,17 @@ _PyDict_KeysSize(PyDictKeysObject *keys)
     return size;
 }
 
+/*[clinic input]
+dict.__sizeof__
+
+D.__sizeof__() -> size of D in memory, in bytes
+[clinic start generated code]*/
+
 static PyObject *
-dict_sizeof(PyObject *self, PyObject *Py_UNUSED(ignored))
+dict___sizeof___impl(PyDictObject *self)
+/*[clinic end generated code: output=44279379b3824bda input=bcde0197a346f7ce]*/
 {
-    PyDictObject *mp = (PyDictObject *)self;
-    return PyLong_FromSsize_t(_PyDict_SizeOf(mp));
+    return PyLong_FromSsize_t(_PyDict_SizeOf(self));
 }
 
 static PyObject *
@@ -3739,56 +3745,31 @@ dict_ior(PyObject *self, PyObject *other)
 PyDoc_STRVAR(getitem__doc__,
 "__getitem__($self, key, /)\n--\n\nReturn self[key].");
 
-PyDoc_STRVAR(sizeof__doc__,
-"D.__sizeof__() -> size of D in memory, in bytes");
-
 PyDoc_STRVAR(update__doc__,
 "D.update([E, ]**F) -> None.  Update D from dict/iterable E and F.\n\
 If E is present and has a .keys() method, then does:  for k in E: D[k] = E[k]\n\
 If E is present and lacks a .keys() method, then does:  for k, v in E: D[k] = v\n\
 In either case, this is followed by: for k in F:  D[k] = F[k]");
 
-PyDoc_STRVAR(clear__doc__,
-"D.clear() -> None.  Remove all items from D.");
-
-PyDoc_STRVAR(copy__doc__,
-"D.copy() -> a shallow copy of D");
-
 /* Forward */
-static PyObject *dictkeys_new(PyObject *, PyObject *);
-static PyObject *dictitems_new(PyObject *, PyObject *);
-static PyObject *dictvalues_new(PyObject *, PyObject *);
-
-PyDoc_STRVAR(keys__doc__,
-             "D.keys() -> a set-like object providing a view on D's keys");
-PyDoc_STRVAR(items__doc__,
-             "D.items() -> a set-like object providing a view on D's items");
-PyDoc_STRVAR(values__doc__,
-             "D.values() -> an object providing a view on D's values");
 
 static PyMethodDef mapp_methods[] = {
     DICT___CONTAINS___METHODDEF
     {"__getitem__",     dict_subscript,                 METH_O | METH_COEXIST,
      getitem__doc__},
-    {"__sizeof__",      dict_sizeof,                    METH_NOARGS,
-     sizeof__doc__},
+     DICT___SIZEOF___METHODDEF
     DICT_GET_METHODDEF
     DICT_SETDEFAULT_METHODDEF
     DICT_POP_METHODDEF
     DICT_POPITEM_METHODDEF
-    {"keys",            dictkeys_new,                   METH_NOARGS,
-    keys__doc__},
-    {"items",           dictitems_new,                  METH_NOARGS,
-    items__doc__},
-    {"values",          dictvalues_new,                 METH_NOARGS,
-    values__doc__},
+    DICT_KEYS_METHODDEF
+    DICT_ITEMS_METHODDEF
+    DICT_VALUES_METHODDEF
     {"update",          _PyCFunction_CAST(dict_update), METH_VARARGS | METH_KEYWORDS,
      update__doc__},
     DICT_FROMKEYS_METHODDEF
-    {"clear",           dict_clear,                     METH_NOARGS,
-     clear__doc__},
-    {"copy",            dict_copy,                      METH_NOARGS,
-     copy__doc__},
+    DICT_CLEAR_METHODDEF
+    DICT_COPY_METHODDEF
     DICT___REVERSED___METHODDEF
     {"__class_getitem__", Py_GenericAlias, METH_O|METH_CLASS, PyDoc_STR("See PEP 585")},
     {NULL,              NULL}   /* sentinel */
@@ -5263,10 +5244,17 @@ PyTypeObject PyDictKeys_Type = {
     .tp_getset = dictview_getset,
 };
 
+/*[clinic input]
+dict.keys
+
+D.keys() -> a set-like object providing a view on D's keys
+[clinic start generated code]*/
+
 static PyObject *
-dictkeys_new(PyObject *dict, PyObject *Py_UNUSED(ignored))
+dict_keys_impl(PyDictObject *self)
+/*[clinic end generated code: output=aac2830c62990358 input=4a20806094eaaed1]*/
 {
-    return _PyDictView_New(dict, &PyDictKeys_Type);
+    return _PyDictView_New((PyObject *)self, &PyDictKeys_Type);
 }
 
 static PyObject *
@@ -5368,10 +5356,17 @@ PyTypeObject PyDictItems_Type = {
     .tp_getset = dictview_getset,
 };
 
+/*[clinic input]
+dict.items
+
+D.items() -> a set-like object providing a view on D's items
+[clinic start generated code]*/
+
 static PyObject *
-dictitems_new(PyObject *dict, PyObject *Py_UNUSED(ignored))
+dict_items_impl(PyDictObject *self)
+/*[clinic end generated code: output=88c7db7150c7909a input=7c47bcbd09b31e59]*/
 {
-    return _PyDictView_New(dict, &PyDictItems_Type);
+    return _PyDictView_New((PyObject *)self, &PyDictItems_Type);
 }
 
 static PyObject *
@@ -5451,10 +5446,17 @@ PyTypeObject PyDictValues_Type = {
     .tp_getset = dictview_getset,
 };
 
+/*[clinic input]
+dict.values
+
+D.values() -> an object providing a view on D's values
+[clinic start generated code]*/
+
 static PyObject *
-dictvalues_new(PyObject *dict, PyObject *Py_UNUSED(ignored))
+dict_values_impl(PyDictObject *self)
+/*[clinic end generated code: output=ce9f2e9e8a959dd4 input=004353e8ab5d1aa9]*/
 {
-    return _PyDictView_New(dict, &PyDictValues_Type);
+    return _PyDictView_New((PyObject *)self, &PyDictValues_Type);
 }
 
 static PyObject *

--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -3508,7 +3508,7 @@ dict_setdefault_impl(PyDictObject *self, PyObject *key,
 /*[clinic input]
 dict.clear
 
-Removes all items.
+Remove all items from the dict.
 [clinic start generated code]*/
 
 static PyObject *


### PR DESCRIPTION
Uses argument clinic for the remaining `dict` methods which aren't using it yet.  This will allow to use argument clinic's `@critical_section` consistently where it's appropriate.

Mostly straight forward, the most dramatic thing is that some of the argument clinic names overlap with existing names.  Those existing names are just wrapped in public dict API so the functionality just moves into the public API.

<!-- gh-issue-number: gh-112075 -->
* Issue: gh-112075
<!-- /gh-issue-number -->
