### PR TITLE
gh-113655: Revert extra stack reserve in PGO builds unless UseExtraStackReserve=true

### DIFF
--- a/PCbuild/python.vcxproj
+++ b/PCbuild/python.vcxproj
@@ -99,7 +99,7 @@
       <StackReserveSize Condition="$(Configuration) == 'Debug'">12000000</StackReserveSize>
       <StackReserveSize Condition="$(Configuration) == 'PGInstrument'">12000000</StackReserveSize>
       <!-- HACK: Need additional memory to avoid crashing until gh-113655 is fixed -->
-      <StackReserveSize Condition="$(Configuration) == 'PGUpdate'">3000000</StackReserveSize>
+      <StackReserveSize Condition="$(Configuration) == 'PGUpdate' and $(UseExtraStackReserve) == 'true'">3000000</StackReserveSize>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/PCbuild/pythonw.vcxproj
+++ b/PCbuild/pythonw.vcxproj
@@ -94,7 +94,7 @@
       <StackReserveSize Condition="$(Configuration) == 'Debug'">12000000</StackReserveSize>
       <StackReserveSize Condition="$(Configuration) == 'PGInstrument'">12000000</StackReserveSize>
       <!-- HACK: Need additional memory to avoid crashing until gh-113655 is fixed -->
-      <StackReserveSize Condition="$(Configuration) == 'PGUpdate'">3000000</StackReserveSize>
+      <StackReserveSize Condition="$(Configuration) == 'PGUpdate' and $(UseExtraStackReserve) == 'true'">3000000</StackReserveSize>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>


### PR DESCRIPTION
We want to avoid expanding the default memory allocation for every Python stack, so changing the default back to the original value to encourage a real fix.

The option is there to avoid this becoming a release blocking issue next release.

<!-- gh-issue-number: gh-113655 -->
* Issue: gh-113655
<!-- /gh-issue-number -->
