### PR TITLE
gh-101438: Avoid reference cycle in ElementTree.iterparse.

### DIFF
--- a/Lib/xml/etree/ElementTree.py
+++ b/Lib/xml/etree/ElementTree.py
@@ -1241,9 +1241,8 @@ def iterparse(source, events=None, parser=None):
                 pullparser.feed(data)
             root = pullparser._close_and_return_root()
             yield from pullparser.read_events()
-            iterator = wr()
-            if iterator:
-                iterator.root = root
+            if it := wr():
+                it.root = root
         finally:
             if close_source:
                 source.close()

--- a/Lib/xml/etree/ElementTree.py
+++ b/Lib/xml/etree/ElementTree.py
@@ -1241,7 +1241,8 @@ def iterparse(source, events=None, parser=None):
                 pullparser.feed(data)
             root = pullparser._close_and_return_root()
             yield from pullparser.read_events()
-            if it := wr():
+            it = wr()
+            if it is not None:
                 it.root = root
         finally:
             if close_source:

--- a/Misc/NEWS.d/next/Library/2024-01-18-22-29-28.gh-issue-101438.1-uUi_.rst
+++ b/Misc/NEWS.d/next/Library/2024-01-18-22-29-28.gh-issue-101438.1-uUi_.rst
@@ -1,0 +1,4 @@
+Avoid reference cycle in ElementTree.iterparse. The iterator returned by
+``ElementTree.iterparse`` may hold on to a file descriptor. The reference
+cycle prevented prompt clean-up of the file decsriptor if the returned
+iterator was not exhausted.

--- a/Misc/NEWS.d/next/Library/2024-01-18-22-29-28.gh-issue-101438.1-uUi_.rst
+++ b/Misc/NEWS.d/next/Library/2024-01-18-22-29-28.gh-issue-101438.1-uUi_.rst
@@ -1,4 +1,4 @@
 Avoid reference cycle in ElementTree.iterparse. The iterator returned by
 ``ElementTree.iterparse`` may hold on to a file descriptor. The reference
-cycle prevented prompt clean-up of the file decsriptor if the returned
+cycle prevented prompt clean-up of the file descriptor if the returned
 iterator was not exhausted.


### PR DESCRIPTION
Refactor `IterParseIterator` to avoid a reference cycle between the iterator() function and the IterParseIterator() instance. This leads to more prompt clean-up of the "source" file if the returned iterator is not exhausted and not otherwise part of a reference cycle.

This also avoids a test failure in the GC implementation for the free-threaded build (#114262): if the "source" file is finalized before the `iterator()` generator, a `ResourceWarning` is issued leading to a failure in test_iterparse() in test_xml_etree.py. In theory, this warning can occur in the default build as well, but that is much less likely to occur because it would require an unlucky scheduling of the GC between creation of the generator and the file object in order to change the order of finalization.


<!-- gh-issue-number: gh-101438 -->
* Issue: gh-101438
<!-- /gh-issue-number -->
