### PR TITLE
gh-83856: Honor atexit for all multiprocessing start methods

### DIFF
--- a/Lib/multiprocessing/forkserver.py
+++ b/Lib/multiprocessing/forkserver.py
@@ -1,3 +1,4 @@
+import atexit
 import errno
 import os
 import selectors
@@ -271,6 +272,8 @@ def main(listener_fd, alive_r, preload, main_path=None, sys_path=None):
                                 selector.close()
                                 unused_fds = [alive_r, child_w, sig_r, sig_w]
                                 unused_fds.extend(pid_to_fd.values())
+                                atexit._clear()
+                                atexit.register(util._exit_function)
                                 code = _serve_one(child_r, fds,
                                                   unused_fds,
                                                   old_handlers)
@@ -278,6 +281,7 @@ def main(listener_fd, alive_r, preload, main_path=None, sys_path=None):
                                 sys.excepthook(*sys.exc_info())
                                 sys.stderr.flush()
                             finally:
+                                atexit._run_exitfuncs()
                                 os._exit(code)
                         else:
                             # Send pid to client process

--- a/Lib/multiprocessing/popen_fork.py
+++ b/Lib/multiprocessing/popen_fork.py
@@ -1,3 +1,4 @@
+import atexit
 import os
 import signal
 
@@ -66,10 +67,13 @@ class Popen(object):
         self.pid = os.fork()
         if self.pid == 0:
             try:
+                atexit._clear()
+                atexit.register(util._exit_function)
                 os.close(parent_r)
                 os.close(parent_w)
                 code = process_obj._bootstrap(parent_sentinel=child_r)
             finally:
+                atexit._run_exitfuncs()
                 os._exit(code)
         else:
             os.close(child_w)

--- a/Lib/multiprocessing/process.py
+++ b/Lib/multiprocessing/process.py
@@ -310,11 +310,8 @@ class BaseProcess(object):
                 # _run_after_forkers() is executed
                 del old_process
             util.info('child process calling self.run()')
-            try:
-                self.run()
-                exitcode = 0
-            finally:
-                util._exit_function()
+            self.run()
+            exitcode = 0
         except SystemExit as e:
             if e.code is None:
                 exitcode = 0

--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -6083,6 +6083,29 @@ class TestNamedResource(unittest.TestCase):
         self.assertFalse(err, msg=err.decode('utf-8'))
 
 
+class _TestAtExit(BaseTestCase):
+
+    ALLOWED_TYPES = ('processes',)
+
+    @classmethod
+    def _write_file_at_exit(self, output_path):
+        import atexit
+        def exit_handler():
+            with open(output_path, 'w') as f:
+                f.write("deadbeef")
+        atexit.register(exit_handler)
+
+    def test_atexit(self):
+        # gh-83856
+        with os_helper.temp_dir() as temp_dir:
+            output_path = os.path.join(temp_dir, 'output.txt')
+            p = self.Process(target=self._write_file_at_exit, args=(output_path,))
+            p.start()
+            p.join()
+            with open(output_path) as f:
+                self.assertEqual(f.read(), 'deadbeef')
+
+
 class MiscTestCase(unittest.TestCase):
     def test__all__(self):
         # Just make sure names in not_exported are excluded

--- a/Lib/test/test_atexit.py
+++ b/Lib/test/test_atexit.py
@@ -58,7 +58,7 @@ class FunctionalTest(unittest.TestCase):
 
         with os_helper.temp_dir() as temp_dir:
             output_path = os.path.join(temp_dir, 'output.txt')
-            code = textwrap.dedent(f"""
+            code = textwrap.dedent(rf"""
                 import multiprocessing
                 import os
                 import tempfile
@@ -67,7 +67,7 @@ class FunctionalTest(unittest.TestCase):
                     import atexit
                     def exit_handler():
                         with open('{output_path}', 'a') as f:
-                            f.write(f'|{{arg}}|\\n')
+                            f.write(f'|{{arg}}|\n')
                     atexit.register(exit_handler)
 
                 if __name__ == '__main__':

--- a/Lib/test/test_atexit.py
+++ b/Lib/test/test_atexit.py
@@ -66,7 +66,7 @@ class FunctionalTest(unittest.TestCase):
                 def test(arg):
                     import atexit
                     def exit_handler():
-                        with open('{output_path}', 'a') as f:
+                        with open({repr(output_path)}, 'a') as f:
                             f.write(f'|{{arg}}|\n')
                     atexit.register(exit_handler)
 

--- a/Lib/test/test_atexit.py
+++ b/Lib/test/test_atexit.py
@@ -1,9 +1,11 @@
 import atexit
 import os
+import sys
+import tempfile
 import textwrap
 import unittest
 from test import support
-from test.support import script_helper
+from test.support import script_helper, os_helper
 
 
 class GeneralTest(unittest.TestCase):
@@ -45,6 +47,43 @@ class FunctionalTest(unittest.TestCase):
         res = script_helper.assert_python_ok("-c", code)
         self.assertEqual(res.out.decode().splitlines(), ["atexit2", "atexit1"])
         self.assertFalse(res.err)
+
+    def test_multiprocessing(self):
+        if sys.platform == "win32":
+            contexts = ["spawn"]
+        elif sys.platform == "darwin":
+            contexts = ["forkserver", "spawn"]
+        else:
+            contexts = ["fork", "forkserver", "spawn"]
+
+        with os_helper.temp_dir() as temp_dir:
+            output_path = os.path.join(temp_dir, 'output.txt')
+            code = textwrap.dedent(f"""
+                import multiprocessing
+                import os
+                import tempfile
+
+                def test(arg):
+                    import atexit
+                    def exit_handler():
+                        with open('{output_path}', 'a') as f:
+                            f.write(f'|{{arg}}|\\n')
+                    atexit.register(exit_handler)
+
+                if __name__ == '__main__':
+                    for context in {contexts}:
+                        p = multiprocessing.get_context(context).Process(target=test, args=(context,))
+                        p.start()
+                        p.join()
+            """)
+            file_name = script_helper.make_script(temp_dir, 'foo', code)
+            script_helper.run_test_script(file_name)
+
+            with open(output_path, "r") as f:
+                out = f.read()
+
+        for context in contexts:
+            self.assertIn(f"|{context}|", out)
 
 
 @support.cpython_only

--- a/Lib/test/test_atexit.py
+++ b/Lib/test/test_atexit.py
@@ -1,11 +1,9 @@
 import atexit
 import os
-import sys
-import tempfile
 import textwrap
 import unittest
 from test import support
-from test.support import script_helper, os_helper
+from test.support import script_helper
 
 
 class GeneralTest(unittest.TestCase):

--- a/Misc/NEWS.d/next/Library/2024-01-19-05-40-46.gh-issue-83856.jN5M80.rst
+++ b/Misc/NEWS.d/next/Library/2024-01-19-05-40-46.gh-issue-83856.jN5M80.rst
@@ -1,0 +1,1 @@
+Honor :mod:`atexit` for all :mod:`multiprocessing` start methods


### PR DESCRIPTION
Currently, `atexit` does not work for `fork` and `forkserver` methods for `multiprocessing`, because multiprocessing kills the forked process with `os._exit()`. This causes a couple of issues:

1. Obviously, `atexit` does not work, which is unexpected and undocumented.
2. `fork` and `forkserver` has a different behavior than `spawn`, which is pretty bad
3. Even for `spawn`, the cleanup order will be messed up, because `util._exit_function` is explicitly called in `Process.bootstrap`, and `atexit` callbacks will all be called after it. (See #114220)

I'll have to admit that this is not the safest patch, it slightly changes the cleanup routine for all multiprocessing code. However, I still believe the benefit is worth the risk because this results in a consistent behavior.

<!-- gh-issue-number: gh-83856 -->
* Issue: gh-83856
<!-- /gh-issue-number -->
