### PR TITLE
gh-114286: Fix `maybe-uninitialized` warning in `Modules/_io/fileio.c`

### DIFF
--- a/Modules/_io/fileio.c
+++ b/Modules/_io/fileio.c
@@ -157,7 +157,7 @@ _io_FileIO_close_impl(fileio *self, PyTypeObject *cls)
         return res;
     }
 
-    PyObject *exc;
+    PyObject *exc = NULL;
     if (res == NULL) {
         exc = PyErr_GetRaisedException();
     }


### PR DESCRIPTION


<!-- gh-issue-number: gh-114286 -->
* Issue: gh-114286
<!-- /gh-issue-number -->
