### PR TITLE
gh-109534: switch from sock_call to sock_call_ex in sock_send

### DIFF
--- a/Modules/socketmodule.c
+++ b/Modules/socketmodule.c
@@ -4341,6 +4341,7 @@ static PyObject *
 sock_send(PySocketSockObject *s, PyObject *args)
 {
     int flags = 0;
+    int err;
     Py_buffer pbuf;
     struct sock_send ctx;
 
@@ -4354,7 +4355,7 @@ sock_send(PySocketSockObject *s, PyObject *args)
     ctx.buf = pbuf.buf;
     ctx.len = pbuf.len;
     ctx.flags = flags;
-    if (sock_call(s, 1, sock_send_impl, &ctx) < 0) {
+    if (sock_call_ex(s, 1, sock_send_impl, &ctx, 0, &err, s->sock_timeout) < 0) {
         PyBuffer_Release(&pbuf);
         return NULL;
     }


### PR DESCRIPTION
While writing webcrawlers with https://github.com/sonic182/aiosonic I came across the issues best described in #109534

I had the great idea of explicitly deleting the event loop my crawler was running on, and hey - I got a traceback of the leaks, repeated ad nauseam:

```
OSError: [Errno 9] Bad file descriptor

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/lib/python3.10/asyncio/sslproto.py", line 692, in _process_write_backlog
    self._transport.write(chunk)
  File "/usr/lib/python3.10/asyncio/selector_events.py", line 935, in write
    self._fatal_error(exc, 'Fatal write error on socket transport')
  File "/usr/lib/python3.10/asyncio/selector_events.py", line 729, in _fatal_error
    self._force_close(exc)
  File "/usr/lib/python3.10/asyncio/selector_events.py", line 741, in _force_close
    self._loop.call_soon(self._call_connection_lost, exc)
  File "/usr/lib/python3.10/asyncio/base_events.py", line 753, in call_soon
    self._check_closed()
  File "/usr/lib/python3.10/asyncio/base_events.py", line 515, in _check_closed
    raise RuntimeError('Event loop is closed')
RuntimeError: Event loop is closed
Fatal error on SSL transport
protocol: <asyncio.sslproto.SSLProtocol object at 0x7fb576dadab0>
transport: <_SelectorSocketTransport closing fd=329>
Traceback (most recent call last):
  File "/usr/lib/python3.10/asyncio/selector_events.py", line 929, in write
    n = self._sock.send(data)
```

Notice this traceback happens with Python <= 3.10 only. Python >= 3.11 leaks forever regardless of whether the loop is deleted or not.

That got me thinking, there must be something special about the socket.send() function that isn't raising the exception... so I went looking in socketmodules.c, and lo and behold, there are multiple instances in that file where we use the sock_call()  thin wrapper around sock_call_ex().

The problem is that wrapper does not set an err pointer to pass to sock_call_ex(). As a result, the exception may never be raised.

As I said, multiple instances here, this one-liner won't solve #109534 by itself but I believe it's a step forward. I have a crawler running much more stabler now with this fix, particularly when I have to abort() the underlying SSL transport.

<!-- gh-issue-number: gh-109534 -->
* Issue: gh-109534
<!-- /gh-issue-number -->
