### PR TITLE
Retain shorter tables of contents for Sphinx 5.2.3+

### DIFF
--- a/Doc/conf.py
+++ b/Doc/conf.py
@@ -74,6 +74,10 @@ highlight_language = 'python3'
 # Minimum version of sphinx required
 needs_sphinx = '4.2'
 
+# Create table of contents entries for domain objects (e.g. functions, classes,
+# attributes, etc.). Default is True.
+toc_object_entries = False
+
 # Ignore any .rst files in the includes/ directory;
 # they're embedded in pages but not rendered individually.
 # Ignore any .rst files in the venv/ directory.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

Sphinx 5.2.3 added a new opt-out feature to add domain objects (e.g. functions, classes, attributes, etc.) to tables of contents (https://github.com/sphinx-doc/sphinx/pull/10886).

This make some of the menus much longer and less readable.

For example, Sphinx 4.5.0 (https://docs.python.org/3/library/sqlite3.html) vs 6.2.1 (https://docs.python.org/dev/library/sqlite3.html): 

![image](https://github.com/python/cpython/assets/1324225/a3e5e6e3-d93c-4f48-8588-7a923f64f009)

Especially:

![image](https://github.com/python/cpython/assets/1324225/c77f822e-f5bd-4d91-a739-f0e46681b441)

We currently only have Sphinx 6.2.1 on `main`, `3.11` and `3.12` are on Sphinx 4.5.0.


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--114318.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->