### PR TITLE
gh-113317: Pass clinic to AC parse_arg() methods

### DIFF
--- a/Modules/_multiprocessing/multiprocessing.c
+++ b/Modules/_multiprocessing/multiprocessing.c
@@ -14,7 +14,7 @@ class HANDLE_converter(CConverter):
     type = "HANDLE"
     format_unit = '"F_HANDLE"'
 
-    def parse_arg(self, argname, displayname, *, limited_capi):
+    def parse_arg(self, argname, displayname, *, limited_capi, clinic):
         return self.format_code("""
             {paramname} = PyLong_AsVoidPtr({argname});
             if (!{paramname} && PyErr_Occurred()) {{{{
@@ -24,7 +24,7 @@ class HANDLE_converter(CConverter):
             argname=argname)
 
 [python start generated code]*/
-/*[python end generated code: output=da39a3ee5e6b4b0d input=3cf0318efc6a8772]*/
+/*[python end generated code: output=da39a3ee5e6b4b0d input=47f380fb213296a1]*/
 
 /*[clinic input]
 module _multiprocessing

--- a/Modules/_posixsubprocess.c
+++ b/Modules/_posixsubprocess.c
@@ -87,7 +87,7 @@ class pid_t_converter(CConverter):
     type = 'pid_t'
     format_unit = '" _Py_PARSE_PID "'
 
-    def parse_arg(self, argname, displayname, *, limited_capi):
+    def parse_arg(self, argname, displayname, *, limited_capi, clinic):
         return self.format_code("""
             {paramname} = PyLong_AsPid({argname});
             if ({paramname} == -1 && PyErr_Occurred()) {{{{
@@ -96,7 +96,7 @@ class pid_t_converter(CConverter):
             """,
             argname=argname)
 [python start generated code]*/
-/*[python end generated code: output=da39a3ee5e6b4b0d input=c94349aa1aad151d]*/
+/*[python end generated code: output=da39a3ee5e6b4b0d input=aa9c0e6301db8ef6]*/
 
 #include "clinic/_posixsubprocess.c.h"
 

--- a/Modules/_struct.c
+++ b/Modules/_struct.c
@@ -109,7 +109,7 @@ class cache_struct_converter(CConverter):
     c_default = "NULL"
     broken_limited_capi = True
 
-    def parse_arg(self, argname, displayname, *, limited_capi):
+    def parse_arg(self, argname, displayname, *, limited_capi, clinic):
         assert not limited_capi
         return self.format_code("""
             if (!{converter}(module, {argname}, &{paramname})) {{{{
@@ -122,7 +122,7 @@ class cache_struct_converter(CConverter):
     def cleanup(self):
         return "Py_XDECREF(%s);\n" % self.name
 [python start generated code]*/
-/*[python end generated code: output=da39a3ee5e6b4b0d input=c33b27d6b06006c6]*/
+/*[python end generated code: output=da39a3ee5e6b4b0d input=80f70ca6a3b875f7]*/
 
 static int cache_struct_converter(PyObject *, PyObject *, PyStructObject **);
 

--- a/Modules/overlapped.c
+++ b/Modules/overlapped.c
@@ -38,7 +38,7 @@
 class pointer_converter(CConverter):
     format_unit = '"F_POINTER"'
 
-    def parse_arg(self, argname, displayname, *, limited_capi):
+    def parse_arg(self, argname, displayname, *, limited_capi, clinic):
         return self.format_code("""
             {paramname} = PyLong_AsVoidPtr({argname});
             if (!{paramname} && PyErr_Occurred()) {{{{
@@ -56,7 +56,7 @@ class HANDLE_converter(pointer_converter):
 class ULONG_PTR_converter(pointer_converter):
     type = 'ULONG_PTR'
 
-    def parse_arg(self, argname, displayname, *, limited_capi):
+    def parse_arg(self, argname, displayname, *, limited_capi, clinic):
         return self.format_code("""
             {paramname} = (uintptr_t)PyLong_AsVoidPtr({argname});
             if (!{paramname} && PyErr_Occurred()) {{{{
@@ -71,7 +71,7 @@ class DWORD_converter(unsigned_long_converter):
 class BOOL_converter(int_converter):
     type = 'BOOL'
 [python start generated code]*/
-/*[python end generated code: output=da39a3ee5e6b4b0d input=436f4440630a304c]*/
+/*[python end generated code: output=da39a3ee5e6b4b0d input=8a9cdb4812199916]*/
 
 /*[clinic input]
 module _overlapped

--- a/Modules/resource.c
+++ b/Modules/resource.c
@@ -30,7 +30,7 @@ class pid_t_converter(CConverter):
     type = 'pid_t'
     format_unit = '" _Py_PARSE_PID "'
 
-    def parse_arg(self, argname, displayname, *, limited_capi):
+    def parse_arg(self, argname, displayname, *, limited_capi, clinic):
         return self.format_code("""
             {paramname} = PyLong_AsPid({argname});
             if ({paramname} == -1 && PyErr_Occurred()) {{{{
@@ -39,7 +39,7 @@ class pid_t_converter(CConverter):
             """,
             argname=argname)
 [python start generated code]*/
-/*[python end generated code: output=da39a3ee5e6b4b0d input=c94349aa1aad151d]*/
+/*[python end generated code: output=da39a3ee5e6b4b0d input=aa9c0e6301db8ef6]*/
 
 #include "clinic/resource.c.h"
 

--- a/PC/_testconsole.c
+++ b/PC/_testconsole.c
@@ -40,7 +40,7 @@ class HANDLE_converter(CConverter):
     type = 'void *'
     format_unit = '"_Py_PARSE_UINTPTR"'
 
-    def parse_arg(self, argname, displayname, *, limited_capi):
+    def parse_arg(self, argname, displayname, *, limited_capi, clinic):
         return self.format_code("""
             {paramname} = PyLong_AsVoidPtr({argname});
             if (!{paramname} && PyErr_Occurred()) {{{{
@@ -49,7 +49,7 @@ class HANDLE_converter(CConverter):
             """,
             argname=argname)
 [python start generated code]*/
-/*[python end generated code: output=da39a3ee5e6b4b0d input=380aa5c91076742b]*/
+/*[python end generated code: output=da39a3ee5e6b4b0d input=b12b8e675b3d0739]*/
 /*[python end generated code:]*/
 
 /*[clinic input]

--- a/PC/msvcrtmodule.c
+++ b/PC/msvcrtmodule.c
@@ -38,7 +38,7 @@ class HANDLE_converter(CConverter):
     type = 'void *'
     format_unit = '"_Py_PARSE_UINTPTR"'
 
-    def parse_arg(self, argname, displayname, *, limited_capi):
+    def parse_arg(self, argname, displayname, *, limited_capi, clinic):
         return self.format_code("""
             {paramname} = PyLong_AsVoidPtr({argname});
             if (!{paramname} && PyErr_Occurred()) {{{{
@@ -75,7 +75,7 @@ class wchar_t_return_converter(CReturnConverter):
         data.return_conversion.append(
             'return_value = PyUnicode_FromOrdinal(_return_value);\n')
 [python start generated code]*/
-/*[python end generated code: output=da39a3ee5e6b4b0d input=ff031be44ab3250d]*/
+/*[python end generated code: output=da39a3ee5e6b4b0d input=01864ad0c19dd001]*/
 
 /*[clinic input]
 module msvcrt

--- a/PC/winreg.c
+++ b/PC/winreg.c
@@ -222,7 +222,7 @@ class HKEY_converter(CConverter):
     converter = 'clinic_HKEY_converter'
     broken_limited_capi = True
 
-    def parse_arg(self, argname, displayname, *, limited_capi):
+    def parse_arg(self, argname, displayname, *, limited_capi, clinic):
         assert not limited_capi
         return self.format_code("""
             if (!{converter}(_PyModule_GetState(module), {argname}, &{paramname})) {{{{
@@ -252,7 +252,7 @@ class self_return_converter(CReturnConverter):
         data.return_conversion.append(
             'return_value = (PyObject *)_return_value;\n')
 [python start generated code]*/
-/*[python end generated code: output=da39a3ee5e6b4b0d input=4979f33998ffb6f8]*/
+/*[python end generated code: output=da39a3ee5e6b4b0d input=b315ae970b9dbabd]*/
 
 #include "clinic/winreg.c.h"
 


### PR DESCRIPTION
Add 'clinic' parameter to Argument Clinic parse_arg() and bad_argument() methods. Remove usage of the 'clinic' global variable in these methods.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-113317 -->
* Issue: gh-113317
<!-- /gh-issue-number -->
