### PR TITLE
[3.11] gh-112160: Backport 'Tools/build/regen-configure.sh' script

### DIFF
--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -2404,17 +2404,9 @@ recheck:
 autoconf:
 	(cd $(srcdir); autoreconf -ivf -Werror)
 
-# See https://github.com/tiran/cpython_autoconf container
 .PHONY: regen-configure
 regen-configure:
-	@if command -v podman >/dev/null; then RUNTIME="podman"; else RUNTIME="docker"; fi; \
-	if ! command -v $$RUNTIME; then echo "$@ needs either Podman or Docker container runtime." >&2; exit 1; fi; \
-	if command -v selinuxenabled >/dev/null && selinuxenabled; then OPT=":Z"; fi; \
-	# Manifest corresponds with tag '269' \
-	CPYTHON_AUTOCONF_MANIFEST="sha256:f370fee95eefa3d57b00488bce4911635411fa83e2d293ced8cf8a3674ead939" \
-	CMD="$$RUNTIME run --rm --pull=missing -v $(abs_srcdir):/src$$OPT quay.io/tiran/cpython_autoconf@$$CPYTHON_AUTOCONF_MANIFEST"; \
-	echo $$CMD; \
-	$$CMD || exit $?
+	$(srcdir)/Tools/build/regen-configure.sh
 
 # Create a tags file for vi
 tags::

--- a/Tools/build/regen-configure.sh
+++ b/Tools/build/regen-configure.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+set -e -x
+
+# Manifest corresponds with tag '269'
+# See https://github.com/tiran/cpython_autoconf container
+CPYTHON_AUTOCONF_MANIFEST="sha256:f370fee95eefa3d57b00488bce4911635411fa83e2d293ced8cf8a3674ead939"
+
+abs_srcdir=$(cd "$(dirname "$0")/../.."; pwd)
+
+if podman --version &>/dev/null; then
+    RUNTIME="podman"
+elif docker --version &>/dev/null; then
+    RUNTIME="docker"
+else
+    echo "$@ needs either Podman or Docker container runtime." >&2
+    exit 1
+fi
+
+PATH_OPT=""
+if command -v selinuxenabled >/dev/null && selinuxenabled; then
+    PATH_OPT=":Z"
+fi
+
+"$RUNTIME" run --rm --pull=missing -v "$abs_srcdir:/src$PATH_OPT" "quay.io/tiran/cpython_autoconf@$CPYTHON_AUTOCONF_MANIFEST"


### PR DESCRIPTION
Follow-up to https://github.com/python/cpython/issues/112160, it turns out to be advantageous to have the actual script outside of the Makefile so it can be called without calling `./configure` first, [as is the case in release-tools](https://github.com/python/release-tools/pull/87#issuecomment-1900282055).

This would need to be backported from 3.11 to 3.8 so release-tools can work for all versions.

<!-- gh-issue-number: gh-112160 -->
* Issue: gh-112160
<!-- /gh-issue-number -->
