### PR TITLE
gh-114332: fix flags reference for re.compile() docs

### DIFF
--- a/Doc/library/re.rst
+++ b/Doc/library/re.rst
@@ -712,6 +712,8 @@ regular expressions.  Most non-trivial applications always use the compiled
 form.
 
 
+.. _flags:
+
 Flags
 ^^^^^
 
@@ -880,8 +882,8 @@ Functions
    below.
 
    The expression's behaviour can be modified by specifying a *flags* value.
-   Values can be any of the following variables, combined using bitwise OR (the
-   ``|`` operator).
+   Values can be any of the :ref:`flags` variables, combined using bitwise OR
+   (the ``|`` operator).
 
    The sequence ::
 

--- a/Doc/library/re.rst
+++ b/Doc/library/re.rst
@@ -712,8 +712,6 @@ regular expressions.  Most non-trivial applications always use the compiled
 form.
 
 
-.. _flags:
-
 Flags
 ^^^^^
 
@@ -882,7 +880,7 @@ Functions
    below.
 
    The expression's behaviour can be modified by specifying a *flags* value.
-   Values can be any of the :ref:`flags` variables, combined using bitwise OR
+   Values can be any of the `flags`_ variables, combined using bitwise OR
    (the ``|`` operator).
 
    The sequence ::


### PR DESCRIPTION
The #93000 change set inadvertently caused a sentence in re.compile()
documentation to refer to details that no longer followed. Correct this
with a link to the Flags sub-subsection.

<!-- gh-issue-number: gh-114332 -->
* Issue: gh-114332
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--114334.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->