### PR TITLE
gh-114328: tty cbreak mode should not alter ICRNL

### DIFF
--- a/Doc/library/tty.rst
+++ b/Doc/library/tty.rst
@@ -37,6 +37,9 @@ The :mod:`tty` module defines the following functions:
 
    .. versionadded:: 3.12
 
+   .. versionchanged:: 3.12.2
+      The ``ICRNL`` flag is no longer cleared.
+
 
 .. function:: setraw(fd, when=termios.TCSAFLUSH)
 
@@ -58,6 +61,11 @@ The :mod:`tty` module defines the following functions:
 
    .. versionchanged:: 3.12
       The return value is now the original tty attributes, instead of None.
+
+   .. versionchanged:: 3.12.2
+      The ``ICRNL`` flag is no longer cleared. This matches both the behavior
+      of 3.11 and earlier as well as what Linux, macOS, and BSDs describe in
+      their ``stty(1)`` man pages regarding cbreak mode.
 
 
 .. seealso::

--- a/Doc/library/tty.rst
+++ b/Doc/library/tty.rst
@@ -35,10 +35,14 @@ The :mod:`tty` module defines the following functions:
    Convert the tty attribute list *mode*, which is a list like the one returned
    by :func:`termios.tcgetattr`, to that of a tty in cbreak mode.
 
+   This clears the ``ECHO`` and ``ICANON`` local mode flags in *mode* as well
+   as setting the minimum input to 1 byte with no delay.
+
    .. versionadded:: 3.12
 
    .. versionchanged:: 3.12.2
-      The ``ICRNL`` flag is no longer cleared.
+      The ``ICRNL`` flag is no longer cleared. This matches Linux and macOS
+      ``stty cbreak`` behavior and what :func:`setcbreak` historically did.
 
 
 .. function:: setraw(fd, when=termios.TCSAFLUSH)
@@ -59,13 +63,16 @@ The :mod:`tty` module defines the following functions:
    :func:`termios.tcsetattr`. The return value of :func:`termios.tcgetattr`
    is saved before setting *fd* to cbreak mode; this value is returned.
 
+   This clears the ``ECHO`` and ``ICANON`` local mode flags as well as setting
+   the minimum input to 1 byte with no delay.
+
    .. versionchanged:: 3.12
       The return value is now the original tty attributes, instead of None.
 
    .. versionchanged:: 3.12.2
-      The ``ICRNL`` flag is no longer cleared. This matches both the behavior
-      of 3.11 and earlier as well as what Linux, macOS, and BSDs describe in
-      their ``stty(1)`` man pages regarding cbreak mode.
+      The ``ICRNL`` flag is no longer cleared. This restores the behavior
+      of Python 3.11 and earlier as well as matching what Linux, macOS, & BSDs
+      describe in their ``stty(1)`` man pages regarding cbreak mode.
 
 
 .. seealso::

--- a/Lib/tty.py
+++ b/Lib/tty.py
@@ -45,9 +45,6 @@ def cfmakeraw(mode):
 
 def cfmakecbreak(mode):
     """Make termios mode cbreak."""
-    # Do not map CR to NL on input.
-    mode[IFLAG] &= ~(ICRNL)
-
     # Do not echo characters; disable canonical input.
     mode[LFLAG] &= ~(ECHO | ICANON)
 

--- a/Misc/NEWS.d/next/Library/2024-01-19-15-48-06.gh-issue-114328.hixxW3.rst
+++ b/Misc/NEWS.d/next/Library/2024-01-19-15-48-06.gh-issue-114328.hixxW3.rst
@@ -1,0 +1,4 @@
+The :func:`tty.setcbreak` and new :func:`tty.cfmakecbreak` no longer clears
+the terminal input ICRLF flag. This fixes a regression introduced in 3.12
+that no longer matched how OSes define cbreak mode in their ``stty(1)``
+manual pages.


### PR DESCRIPTION
The terminal CR -> NL mapping setting should be inherited in cbreak mode as OSes do not specify altering it as part of their `stty` cbreak mode definition.


<!-- gh-issue-number: gh-114328 -->
* Issue: gh-114328
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--114335.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->