### PR TITLE
gh-104711: Ignore the driver letters in `is_cgi` method in http/server.py

### DIFF
--- a/Lib/http/server.py
+++ b/Lib/http/server.py
@@ -1035,12 +1035,20 @@ class CGIHTTPRequestHandler(SimpleHTTPRequestHandler):
         (and the next character is a '/' or the end of the string).
 
         """
-        collapsed_path = _url_collapse_path(self.path)
-        dir_sep = collapsed_path.find('/', 1)
-        while dir_sep > 0 and not collapsed_path[:dir_sep] in self.cgi_directories:
-            dir_sep = collapsed_path.find('/', dir_sep+1)
+        path = _url_collapse_path(self.path)
+
+        words = []
+        for word in path.split('/'):
+            if os.path.dirname(word) or word in (os.curdir, os.pardir):
+                continue
+            words.append(word)
+        path = '/'.join(words)
+
+        dir_sep = path.find('/', 1)
+        while dir_sep > 0 and not path[:dir_sep] in self.cgi_directories:
+            dir_sep = path.find('/', dir_sep+1)
         if dir_sep > 0:
-            head, tail = collapsed_path[:dir_sep], collapsed_path[dir_sep+1:]
+            head, tail = path[:dir_sep], path[dir_sep+1:]
             self.cgi_info = head, tail
             return True
         return False

--- a/Lib/test/test_httpservers.py
+++ b/Lib/test/test_httpservers.py
@@ -865,6 +865,16 @@ class CGIHTTPServerTestCase(BaseTestCase):
             (res.read(), res.getheader('Content-type'), res.status),
             (b'Hello World' + self.linesep, 'text/html', HTTPStatus.OK))
 
+    def test_is_cgi(self):
+        res = self.request('/x:/cgi-bin/file1.py')
+        if sys.platform == 'win32':
+            # On Windows, drive letters will be ignored.
+            self.assertEqual(
+                (res.read(), res.getheader('Content-type'), res.status),
+                (b'Hello World' + self.linesep, 'text/html', HTTPStatus.OK))
+        else:
+            self.assertEqual(res.status, HTTPStatus.NOT_FOUND)
+
     def test_issue19435(self):
         res = self.request('///////////nocgi.py/../cgi-bin/nothere.sh')
         self.assertEqual(res.status, HTTPStatus.NOT_FOUND)

--- a/Misc/NEWS.d/next/Security/2024-01-20-21-40-34.gh-issue-104711.ufnQJs.rst
+++ b/Misc/NEWS.d/next/Security/2024-01-20-21-40-34.gh-issue-104711.ufnQJs.rst
@@ -1,0 +1,3 @@
+On the Windows platform, when determining whether a request is CGI or not in
+the :class:`http.server.CGIHTTPRequestHandler`, ignore the driver letters in
+the URL path to prevent CGI source code disclosure and directory listing.


### PR DESCRIPTION
The main change is to added some codes in `translate_path` https://github.com/python/cpython/blob/8e33193f41aca5d84cdbac0b6e7abd4bbce4cf31/Lib/http/server.py#L855-L859

to `is_cgi` to make them have more consistent behavior. But the renaming from `collapsed_path` to more suitable `path` after the change made the diff more complex to review.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-104711 -->
* Issue: gh-104711
<!-- /gh-issue-number -->
