### PR TITLE
gh-113102: Fix typo in INSTRUMENTED_RESUME

### DIFF
--- a/Python/bytecodes.c
+++ b/Python/bytecodes.c
@@ -192,7 +192,7 @@ dummy_func(
                 ERROR_IF(err, error);
                 if (frame->instr_ptr != this_instr) {
                     /* Instrumentation has jumped */
-                    next_instr = this_instr;
+                    next_instr = frame->instr_ptr;
                     DISPATCH();
                 }
             }

--- a/Python/generated_cases.c.h
+++ b/Python/generated_cases.c.h
@@ -3156,7 +3156,7 @@
                 if (err) goto error;
                 if (frame->instr_ptr != this_instr) {
                     /* Instrumentation has jumped */
-                    next_instr = this_instr;
+                    next_instr = frame->instr_ptr;
                     DISPATCH();
                 }
             }


### PR DESCRIPTION
This was noted by @neonene in https://github.com/python/cpython/issues/111485#issuecomment-1820941392. @markshannon replied positively (?) but nobody followed up. @markshannon do you still agree with @neonene's analysis that this was a typo?

<!-- gh-issue-number: gh-113102 -->
* Issue: gh-113102
<!-- /gh-issue-number -->
