### PR TITLE
[3.11] Docs: structure the ftplib reference (#114317)

### DIFF
--- a/Doc/library/ftplib.rst
+++ b/Doc/library/ftplib.rst
@@ -45,9 +45,18 @@ Here's a sample session using the :mod:`ftplib` module::
    '221 Goodbye.'
 
 
-The module defines the following items:
+.. _ftplib-reference:
 
-.. class:: FTP(host='', user='', passwd='', acct='', timeout=None, source_address=None, *, encoding='utf-8')
+Reference
+---------
+
+.. _ftp-objects:
+
+FTP objects
+^^^^^^^^^^^
+
+.. class:: FTP(host='', user='', passwd='', acct='', timeout=None, \
+               source_address=None, *, encoding='utf-8')
 
    Return a new instance of the :class:`FTP` class.  When *host* is given, the
    method call ``connect(host)`` is made.  When *user* is given, additionally
@@ -85,7 +94,264 @@ The module defines the following items:
       The *encoding* parameter was added, and the default was changed from
       Latin-1 to UTF-8 to follow :rfc:`2640`.
 
-.. class:: FTP_TLS(host='', user='', passwd='', acct='', keyfile=None, certfile=None, context=None, timeout=None, source_address=None, *, encoding='utf-8')
+   Several :class:`!FTP` methods are available in two flavors:
+   one for handling text files and another for binary files.
+   The methods are named for the command which is used followed by
+   ``lines`` for the text version or ``binary`` for the binary version.
+
+   :class:`FTP` instances have the following methods:
+
+   .. method:: FTP.set_debuglevel(level)
+
+      Set the instance's debugging level.  This controls the amount of debugging
+      output printed.  The default, ``0``, produces no debugging output.  A value of
+      ``1`` produces a moderate amount of debugging output, generally a single line
+      per request.  A value of ``2`` or higher produces the maximum amount of
+      debugging output, logging each line sent and received on the control connection.
+
+
+   .. method:: FTP.connect(host='', port=0, timeout=None, source_address=None)
+
+      Connect to the given host and port.  The default port number is ``21``, as
+      specified by the FTP protocol specification.  It is rarely needed to specify a
+      different port number.  This function should be called only once for each
+      instance; it should not be called at all if a host was given when the instance
+      was created.  All other methods can only be used after a connection has been
+      made.
+      The optional *timeout* parameter specifies a timeout in seconds for the
+      connection attempt. If no *timeout* is passed, the global default timeout
+      setting will be used.
+      *source_address* is a 2-tuple ``(host, port)`` for the socket to bind to as
+      its source address before connecting.
+
+      .. audit-event:: ftplib.connect self,host,port ftplib.FTP.connect
+
+      .. versionchanged:: 3.3
+         *source_address* parameter was added.
+
+
+   .. method:: FTP.getwelcome()
+
+      Return the welcome message sent by the server in reply to the initial
+      connection.  (This message sometimes contains disclaimers or help information
+      that may be relevant to the user.)
+
+
+   .. method:: FTP.login(user='anonymous', passwd='', acct='')
+
+      Log in as the given *user*.  The *passwd* and *acct* parameters are optional and
+      default to the empty string.  If no *user* is specified, it defaults to
+      ``'anonymous'``.  If *user* is ``'anonymous'``, the default *passwd* is
+      ``'anonymous@'``.  This function should be called only once for each instance,
+      after a connection has been established; it should not be called at all if a
+      host and user were given when the instance was created.  Most FTP commands are
+      only allowed after the client has logged in.  The *acct* parameter supplies
+      "accounting information"; few systems implement this.
+
+
+   .. method:: FTP.abort()
+
+      Abort a file transfer that is in progress.  Using this does not always work, but
+      it's worth a try.
+
+
+   .. method:: FTP.sendcmd(cmd)
+
+      Send a simple command string to the server and return the response string.
+
+      .. audit-event:: ftplib.sendcmd self,cmd ftplib.FTP.sendcmd
+
+
+   .. method:: FTP.voidcmd(cmd)
+
+      Send a simple command string to the server and handle the response.  Return
+      nothing if a response code corresponding to success (codes in the range
+      200--299) is received.  Raise :exc:`error_reply` otherwise.
+
+      .. audit-event:: ftplib.sendcmd self,cmd ftplib.FTP.voidcmd
+
+
+   .. method:: FTP.retrbinary(cmd, callback, blocksize=8192, rest=None)
+
+      Retrieve a file in binary transfer mode.  *cmd* should be an appropriate
+      ``RETR`` command: ``'RETR filename'``. The *callback* function is called for
+      each block of data received, with a single bytes argument giving the data
+      block. The optional *blocksize* argument specifies the maximum chunk size to
+      read on the low-level socket object created to do the actual transfer (which
+      will also be the largest size of the data blocks passed to *callback*).  A
+      reasonable default is chosen. *rest* means the same thing as in the
+      :meth:`transfercmd` method.
+
+
+   .. method:: FTP.retrlines(cmd, callback=None)
+
+      Retrieve a file or directory listing in the encoding specified by the
+      *encoding* parameter at initialization.
+      *cmd* should be an appropriate ``RETR`` command (see :meth:`retrbinary`) or
+      a command such as ``LIST`` or ``NLST`` (usually just the string ``'LIST'``).
+      ``LIST`` retrieves a list of files and information about those files.
+      ``NLST`` retrieves a list of file names.
+      The *callback* function is called for each line with a string argument
+      containing the line with the trailing CRLF stripped.  The default *callback*
+      prints the line to ``sys.stdout``.
+
+
+   .. method:: FTP.set_pasv(val)
+
+      Enable "passive" mode if *val* is true, otherwise disable passive mode.
+      Passive mode is on by default.
+
+
+   .. method:: FTP.storbinary(cmd, fp, blocksize=8192, callback=None, rest=None)
+
+      Store a file in binary transfer mode.  *cmd* should be an appropriate
+      ``STOR`` command: ``"STOR filename"``. *fp* is a :term:`file object`
+      (opened in binary mode) which is read until EOF using its :meth:`~io.IOBase.read`
+      method in blocks of size *blocksize* to provide the data to be stored.
+      The *blocksize* argument defaults to 8192.  *callback* is an optional single
+      parameter callable that is called on each block of data after it is sent.
+      *rest* means the same thing as in the :meth:`transfercmd` method.
+
+      .. versionchanged:: 3.2
+         *rest* parameter added.
+
+
+   .. method:: FTP.storlines(cmd, fp, callback=None)
+
+      Store a file in line mode.  *cmd* should be an appropriate
+      ``STOR`` command (see :meth:`storbinary`).  Lines are read until EOF from the
+      :term:`file object` *fp* (opened in binary mode) using its :meth:`~io.IOBase.readline`
+      method to provide the data to be stored.  *callback* is an optional single
+      parameter callable that is called on each line after it is sent.
+
+
+   .. method:: FTP.transfercmd(cmd, rest=None)
+
+      Initiate a transfer over the data connection.  If the transfer is active, send an
+      ``EPRT`` or  ``PORT`` command and the transfer command specified by *cmd*, and
+      accept the connection.  If the server is passive, send an ``EPSV`` or ``PASV``
+      command, connect to it, and start the transfer command.  Either way, return the
+      socket for the connection.
+
+      If optional *rest* is given, a ``REST`` command is sent to the server, passing
+      *rest* as an argument.  *rest* is usually a byte offset into the requested file,
+      telling the server to restart sending the file's bytes at the requested offset,
+      skipping over the initial bytes.  Note however that the :meth:`transfercmd`
+      method converts *rest* to a string with the *encoding* parameter specified
+      at initialization, but no check is performed on the string's contents.  If the
+      server does not recognize the ``REST`` command, an :exc:`error_reply` exception
+      will be raised.  If this happens, simply call :meth:`transfercmd` without a
+      *rest* argument.
+
+
+   .. method:: FTP.ntransfercmd(cmd, rest=None)
+
+      Like :meth:`transfercmd`, but returns a tuple of the data connection and the
+      expected size of the data.  If the expected size could not be computed, ``None``
+      will be returned as the expected size.  *cmd* and *rest* means the same thing as
+      in :meth:`transfercmd`.
+
+
+   .. method:: FTP.mlsd(path="", facts=[])
+
+      List a directory in a standardized format by using ``MLSD`` command
+      (:rfc:`3659`).  If *path* is omitted the current directory is assumed.
+      *facts* is a list of strings representing the type of information desired
+      (e.g. ``["type", "size", "perm"]``).  Return a generator object yielding a
+      tuple of two elements for every file found in path.  First element is the
+      file name, the second one is a dictionary containing facts about the file
+      name.  Content of this dictionary might be limited by the *facts* argument
+      but server is not guaranteed to return all requested facts.
+
+      .. versionadded:: 3.3
+
+
+   .. method:: FTP.nlst(argument[, ...])
+
+      Return a list of file names as returned by the ``NLST`` command.  The
+      optional *argument* is a directory to list (default is the current server
+      directory).  Multiple arguments can be used to pass non-standard options to
+      the ``NLST`` command.
+
+      .. note:: If your server supports the command, :meth:`mlsd` offers a better API.
+
+
+   .. method:: FTP.dir(argument[, ...])
+
+      Produce a directory listing as returned by the ``LIST`` command, printing it to
+      standard output.  The optional *argument* is a directory to list (default is the
+      current server directory).  Multiple arguments can be used to pass non-standard
+      options to the ``LIST`` command.  If the last argument is a function, it is used
+      as a *callback* function as for :meth:`retrlines`; the default prints to
+      ``sys.stdout``.  This method returns ``None``.
+
+      .. note:: If your server supports the command, :meth:`mlsd` offers a better API.
+
+
+   .. method:: FTP.rename(fromname, toname)
+
+      Rename file *fromname* on the server to *toname*.
+
+
+   .. method:: FTP.delete(filename)
+
+      Remove the file named *filename* from the server.  If successful, returns the
+      text of the response, otherwise raises :exc:`error_perm` on permission errors or
+      :exc:`error_reply` on other errors.
+
+
+   .. method:: FTP.cwd(pathname)
+
+      Set the current directory on the server.
+
+
+   .. method:: FTP.mkd(pathname)
+
+      Create a new directory on the server.
+
+
+   .. method:: FTP.pwd()
+
+      Return the pathname of the current directory on the server.
+
+
+   .. method:: FTP.rmd(dirname)
+
+      Remove the directory named *dirname* on the server.
+
+
+   .. method:: FTP.size(filename)
+
+      Request the size of the file named *filename* on the server.  On success, the
+      size of the file is returned as an integer, otherwise ``None`` is returned.
+      Note that the ``SIZE`` command is not  standardized, but is supported by many
+      common server implementations.
+
+
+   .. method:: FTP.quit()
+
+      Send a ``QUIT`` command to the server and close the connection. This is the
+      "polite" way to close a connection, but it may raise an exception if the server
+      responds with an error to the ``QUIT`` command.  This implies a call to the
+      :meth:`close` method which renders the :class:`FTP` instance useless for
+      subsequent calls (see below).
+
+
+   .. method:: FTP.close()
+
+      Close the connection unilaterally.  This should not be applied to an already
+      closed connection such as after a successful call to :meth:`~FTP.quit`.
+      After this call the :class:`FTP` instance should not be used any more (after
+      a call to :meth:`close` or :meth:`~FTP.quit` you cannot reopen the
+      connection by issuing another :meth:`login` method).
+
+
+FTP_TLS objects
+^^^^^^^^^^^^^^^
+
+.. class:: FTP_TLS(host='', user='', passwd='', acct='', keyfile=None, \
+                   certfile=None, context=None, timeout=None, \
+                   source_address=None, *, encoding='utf-8')
 
    A :class:`FTP` subclass which adds TLS support to FTP as described in
    :rfc:`4217`.
@@ -133,6 +399,42 @@ The module defines the following items:
       >>> ftps.nlst()
       ['6jack', 'OpenBSD', 'antilink', 'blogbench', 'bsdcam', 'clockspeed', 'djbdns-jedi', 'docs', 'eaccelerator-jedi', 'favicon.ico', 'francotone', 'fugu', 'ignore', 'libpuzzle', 'metalog', 'minidentd', 'misc', 'mysql-udf-global-user-variables', 'php-jenkins-hash', 'php-skein-hash', 'php-webdav', 'phpaudit', 'phpbench', 'pincaster', 'ping', 'posto', 'pub', 'public', 'public_keys', 'pure-ftpd', 'qscan', 'qtc', 'sharedance', 'skycache', 'sound', 'tmp', 'ucarp']
 
+   :class:`!FTP_TLS` class inherits from :class:`FTP`,
+   defining these additional methods and attributes:
+
+   .. attribute:: FTP_TLS.ssl_version
+
+      The SSL version to use (defaults to :data:`ssl.PROTOCOL_SSLv23`).
+
+   .. method:: FTP_TLS.auth()
+
+      Set up a secure control connection by using TLS or SSL, depending on what
+      is specified in the :attr:`ssl_version` attribute.
+
+      .. versionchanged:: 3.4
+         The method now supports hostname check with
+         :attr:`ssl.SSLContext.check_hostname` and *Server Name Indication* (see
+         :const:`ssl.HAS_SNI`).
+
+   .. method:: FTP_TLS.ccc()
+
+      Revert control channel back to plaintext.  This can be useful to take
+      advantage of firewalls that know how to handle NAT with non-secure FTP
+      without opening fixed ports.
+
+      .. versionadded:: 3.3
+
+   .. method:: FTP_TLS.prot_p()
+
+      Set up secure data connection.
+
+   .. method:: FTP_TLS.prot_c()
+
+      Set up clear text data connection.
+
+
+Module variables
+^^^^^^^^^^^^^^^^
 
 .. exception:: error_reply
 
@@ -172,296 +474,3 @@ The module defines the following items:
       Parser for the :file:`.netrc` file format.  The file :file:`.netrc` is
       typically used by FTP clients to load user authentication information
       before prompting the user.
-
-
-.. _ftp-objects:
-
-FTP Objects
------------
-
-Several methods are available in two flavors: one for handling text files and
-another for binary files.  These are named for the command which is used
-followed by ``lines`` for the text version or ``binary`` for the binary version.
-
-:class:`FTP` instances have the following methods:
-
-
-.. method:: FTP.set_debuglevel(level)
-
-   Set the instance's debugging level.  This controls the amount of debugging
-   output printed.  The default, ``0``, produces no debugging output.  A value of
-   ``1`` produces a moderate amount of debugging output, generally a single line
-   per request.  A value of ``2`` or higher produces the maximum amount of
-   debugging output, logging each line sent and received on the control connection.
-
-
-.. method:: FTP.connect(host='', port=0, timeout=None, source_address=None)
-
-   Connect to the given host and port.  The default port number is ``21``, as
-   specified by the FTP protocol specification.  It is rarely needed to specify a
-   different port number.  This function should be called only once for each
-   instance; it should not be called at all if a host was given when the instance
-   was created.  All other methods can only be used after a connection has been
-   made.
-   The optional *timeout* parameter specifies a timeout in seconds for the
-   connection attempt. If no *timeout* is passed, the global default timeout
-   setting will be used.
-   *source_address* is a 2-tuple ``(host, port)`` for the socket to bind to as
-   its source address before connecting.
-
-   .. audit-event:: ftplib.connect self,host,port ftplib.FTP.connect
-
-   .. versionchanged:: 3.3
-      *source_address* parameter was added.
-
-
-.. method:: FTP.getwelcome()
-
-   Return the welcome message sent by the server in reply to the initial
-   connection.  (This message sometimes contains disclaimers or help information
-   that may be relevant to the user.)
-
-
-.. method:: FTP.login(user='anonymous', passwd='', acct='')
-
-   Log in as the given *user*.  The *passwd* and *acct* parameters are optional and
-   default to the empty string.  If no *user* is specified, it defaults to
-   ``'anonymous'``.  If *user* is ``'anonymous'``, the default *passwd* is
-   ``'anonymous@'``.  This function should be called only once for each instance,
-   after a connection has been established; it should not be called at all if a
-   host and user were given when the instance was created.  Most FTP commands are
-   only allowed after the client has logged in.  The *acct* parameter supplies
-   "accounting information"; few systems implement this.
-
-
-.. method:: FTP.abort()
-
-   Abort a file transfer that is in progress.  Using this does not always work, but
-   it's worth a try.
-
-
-.. method:: FTP.sendcmd(cmd)
-
-   Send a simple command string to the server and return the response string.
-
-   .. audit-event:: ftplib.sendcmd self,cmd ftplib.FTP.sendcmd
-
-
-.. method:: FTP.voidcmd(cmd)
-
-   Send a simple command string to the server and handle the response.  Return
-   nothing if a response code corresponding to success (codes in the range
-   200--299) is received.  Raise :exc:`error_reply` otherwise.
-
-   .. audit-event:: ftplib.sendcmd self,cmd ftplib.FTP.voidcmd
-
-
-.. method:: FTP.retrbinary(cmd, callback, blocksize=8192, rest=None)
-
-   Retrieve a file in binary transfer mode.  *cmd* should be an appropriate
-   ``RETR`` command: ``'RETR filename'``. The *callback* function is called for
-   each block of data received, with a single bytes argument giving the data
-   block. The optional *blocksize* argument specifies the maximum chunk size to
-   read on the low-level socket object created to do the actual transfer (which
-   will also be the largest size of the data blocks passed to *callback*).  A
-   reasonable default is chosen. *rest* means the same thing as in the
-   :meth:`transfercmd` method.
-
-
-.. method:: FTP.retrlines(cmd, callback=None)
-
-   Retrieve a file or directory listing in the encoding specified by the
-   *encoding* parameter at initialization.
-   *cmd* should be an appropriate ``RETR`` command (see :meth:`retrbinary`) or
-   a command such as ``LIST`` or ``NLST`` (usually just the string ``'LIST'``).
-   ``LIST`` retrieves a list of files and information about those files.
-   ``NLST`` retrieves a list of file names.
-   The *callback* function is called for each line with a string argument
-   containing the line with the trailing CRLF stripped.  The default *callback*
-   prints the line to ``sys.stdout``.
-
-
-.. method:: FTP.set_pasv(val)
-
-   Enable "passive" mode if *val* is true, otherwise disable passive mode.
-   Passive mode is on by default.
-
-
-.. method:: FTP.storbinary(cmd, fp, blocksize=8192, callback=None, rest=None)
-
-   Store a file in binary transfer mode.  *cmd* should be an appropriate
-   ``STOR`` command: ``"STOR filename"``. *fp* is a :term:`file object`
-   (opened in binary mode) which is read until EOF using its :meth:`~io.IOBase.read`
-   method in blocks of size *blocksize* to provide the data to be stored.
-   The *blocksize* argument defaults to 8192.  *callback* is an optional single
-   parameter callable that is called on each block of data after it is sent.
-   *rest* means the same thing as in the :meth:`transfercmd` method.
-
-   .. versionchanged:: 3.2
-      *rest* parameter added.
-
-
-.. method:: FTP.storlines(cmd, fp, callback=None)
-
-   Store a file in line mode.  *cmd* should be an appropriate
-   ``STOR`` command (see :meth:`storbinary`).  Lines are read until EOF from the
-   :term:`file object` *fp* (opened in binary mode) using its :meth:`~io.IOBase.readline`
-   method to provide the data to be stored.  *callback* is an optional single
-   parameter callable that is called on each line after it is sent.
-
-
-.. method:: FTP.transfercmd(cmd, rest=None)
-
-   Initiate a transfer over the data connection.  If the transfer is active, send an
-   ``EPRT`` or  ``PORT`` command and the transfer command specified by *cmd*, and
-   accept the connection.  If the server is passive, send an ``EPSV`` or ``PASV``
-   command, connect to it, and start the transfer command.  Either way, return the
-   socket for the connection.
-
-   If optional *rest* is given, a ``REST`` command is sent to the server, passing
-   *rest* as an argument.  *rest* is usually a byte offset into the requested file,
-   telling the server to restart sending the file's bytes at the requested offset,
-   skipping over the initial bytes.  Note however that the :meth:`transfercmd`
-   method converts *rest* to a string with the *encoding* parameter specified
-   at initialization, but no check is performed on the string's contents.  If the
-   server does not recognize the ``REST`` command, an :exc:`error_reply` exception
-   will be raised.  If this happens, simply call :meth:`transfercmd` without a
-   *rest* argument.
-
-
-.. method:: FTP.ntransfercmd(cmd, rest=None)
-
-   Like :meth:`transfercmd`, but returns a tuple of the data connection and the
-   expected size of the data.  If the expected size could not be computed, ``None``
-   will be returned as the expected size.  *cmd* and *rest* means the same thing as
-   in :meth:`transfercmd`.
-
-
-.. method:: FTP.mlsd(path="", facts=[])
-
-   List a directory in a standardized format by using ``MLSD`` command
-   (:rfc:`3659`).  If *path* is omitted the current directory is assumed.
-   *facts* is a list of strings representing the type of information desired
-   (e.g. ``["type", "size", "perm"]``).  Return a generator object yielding a
-   tuple of two elements for every file found in path.  First element is the
-   file name, the second one is a dictionary containing facts about the file
-   name.  Content of this dictionary might be limited by the *facts* argument
-   but server is not guaranteed to return all requested facts.
-
-   .. versionadded:: 3.3
-
-
-.. method:: FTP.nlst(argument[, ...])
-
-   Return a list of file names as returned by the ``NLST`` command.  The
-   optional *argument* is a directory to list (default is the current server
-   directory).  Multiple arguments can be used to pass non-standard options to
-   the ``NLST`` command.
-
-   .. note:: If your server supports the command, :meth:`mlsd` offers a better API.
-
-
-.. method:: FTP.dir(argument[, ...])
-
-   Produce a directory listing as returned by the ``LIST`` command, printing it to
-   standard output.  The optional *argument* is a directory to list (default is the
-   current server directory).  Multiple arguments can be used to pass non-standard
-   options to the ``LIST`` command.  If the last argument is a function, it is used
-   as a *callback* function as for :meth:`retrlines`; the default prints to
-   ``sys.stdout``.  This method returns ``None``.
-
-   .. note:: If your server supports the command, :meth:`mlsd` offers a better API.
-
-
-.. method:: FTP.rename(fromname, toname)
-
-   Rename file *fromname* on the server to *toname*.
-
-
-.. method:: FTP.delete(filename)
-
-   Remove the file named *filename* from the server.  If successful, returns the
-   text of the response, otherwise raises :exc:`error_perm` on permission errors or
-   :exc:`error_reply` on other errors.
-
-
-.. method:: FTP.cwd(pathname)
-
-   Set the current directory on the server.
-
-
-.. method:: FTP.mkd(pathname)
-
-   Create a new directory on the server.
-
-
-.. method:: FTP.pwd()
-
-   Return the pathname of the current directory on the server.
-
-
-.. method:: FTP.rmd(dirname)
-
-   Remove the directory named *dirname* on the server.
-
-
-.. method:: FTP.size(filename)
-
-   Request the size of the file named *filename* on the server.  On success, the
-   size of the file is returned as an integer, otherwise ``None`` is returned.
-   Note that the ``SIZE`` command is not  standardized, but is supported by many
-   common server implementations.
-
-
-.. method:: FTP.quit()
-
-   Send a ``QUIT`` command to the server and close the connection. This is the
-   "polite" way to close a connection, but it may raise an exception if the server
-   responds with an error to the ``QUIT`` command.  This implies a call to the
-   :meth:`close` method which renders the :class:`FTP` instance useless for
-   subsequent calls (see below).
-
-
-.. method:: FTP.close()
-
-   Close the connection unilaterally.  This should not be applied to an already
-   closed connection such as after a successful call to :meth:`~FTP.quit`.
-   After this call the :class:`FTP` instance should not be used any more (after
-   a call to :meth:`close` or :meth:`~FTP.quit` you cannot reopen the
-   connection by issuing another :meth:`login` method).
-
-
-FTP_TLS Objects
----------------
-
-:class:`FTP_TLS` class inherits from :class:`FTP`, defining these additional objects:
-
-.. attribute:: FTP_TLS.ssl_version
-
-   The SSL version to use (defaults to :data:`ssl.PROTOCOL_SSLv23`).
-
-.. method:: FTP_TLS.auth()
-
-   Set up a secure control connection by using TLS or SSL, depending on what
-   is specified in the :attr:`ssl_version` attribute.
-
-   .. versionchanged:: 3.4
-      The method now supports hostname check with
-      :attr:`ssl.SSLContext.check_hostname` and *Server Name Indication* (see
-      :const:`ssl.HAS_SNI`).
-
-.. method:: FTP_TLS.ccc()
-
-   Revert control channel back to plaintext.  This can be useful to take
-   advantage of firewalls that know how to handle NAT with non-secure FTP
-   without opening fixed ports.
-
-   .. versionadded:: 3.3
-
-.. method:: FTP_TLS.prot_p()
-
-   Set up secure data connection.
-
-.. method:: FTP_TLS.prot_c()
-
-   Set up clear text data connection.


### PR DESCRIPTION
(cherry picked from commit b1ad5a5d446f944a45c43a3e865d1d8f47611071)

Introduce the following headings and subheadings:

- Reference
  * FTP objects
  * FTP_TLS objects
  * Module variables


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--114351.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->