### PR TITLE
Docs: Add missing line continuation to FTP_TLS class docs

### DIFF
--- a/Doc/library/ftplib.rst
+++ b/Doc/library/ftplib.rst
@@ -348,7 +348,7 @@ FTP objects
 FTP_TLS objects
 ^^^^^^^^^^^^^^^
 
-.. class:: FTP_TLS(host='', user='', passwd='', acct='', *, context=None,
+.. class:: FTP_TLS(host='', user='', passwd='', acct='', *, context=None, \
                    timeout=None, source_address=None, encoding='utf-8')
 
    A :class:`FTP` subclass which adds TLS support to FTP as described in


### PR DESCRIPTION
Regression introduced by b1ad5a5d4.


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--114352.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->