### PR TITLE
pythongh-109534: close transport if waiter is done

### DIFF
--- a/Lib/asyncio/selector_events.py
+++ b/Lib/asyncio/selector_events.py
@@ -233,6 +233,7 @@ class BaseSelectorEventLoop(base_events.BaseEventLoop):
 
             try:
                 await waiter
+                transport.close()
             except BaseException:
                 transport.close()
                 raise


### PR DESCRIPTION
I'm not able to reproduce #109534 anymore with this fix. Checking asyncio/sslproto.py it seems the waiter is only done on error or connection lost so this seems safe.


<!-- gh-issue-number: gh-109534 -->
* Issue: gh-109534
<!-- /gh-issue-number -->
