### PR TITLE
gh-108303: Remove `Lib/test/shadowed_super.py`

### DIFF
--- a/Lib/test/shadowed_super.py
+++ b/Lib/test/shadowed_super.py
@@ -1,7 +1,0 @@
-class super:
-    msg = "truly super"
-
-
-class C:
-    def method(self):
-        return super().msg

--- a/Lib/test/test_super.py
+++ b/Lib/test/test_super.py
@@ -1,8 +1,9 @@
 """Unit tests for zero-argument super() & related machinery."""
 
+import textwrap
 import unittest
 from unittest.mock import patch
-from test import shadowed_super
+from test.support import import_helper
 
 
 ADAPTIVE_WARMUP_DELAY = 2
@@ -342,6 +343,18 @@ class TestSuper(unittest.TestCase):
             super(1, int)
 
     def test_shadowed_global(self):
+        source = textwrap.dedent(
+            """
+            class super:
+                msg = "truly super"
+
+            class C:
+                def method(self):
+                    return super().msg
+            """,
+        )
+        with import_helper.ready_to_import(name="shadowed_super", source=source):
+            import shadowed_super
         self.assertEqual(shadowed_super.C().method(), "truly super")
 
     def test_shadowed_local(self):

--- a/Lib/test/test_super.py
+++ b/Lib/test/test_super.py
@@ -356,6 +356,7 @@ class TestSuper(unittest.TestCase):
         with import_helper.ready_to_import(name="shadowed_super", source=source):
             import shadowed_super
         self.assertEqual(shadowed_super.C().method(), "truly super")
+        import_helper.unload("shadowed_super")
 
     def test_shadowed_local(self):
         class super:


### PR DESCRIPTION
This support file was only used in a single test, there's no point in using it, really.
It can be replaced with a simple script.

<!-- gh-issue-number: gh-108303 -->
* Issue: gh-108303
<!-- /gh-issue-number -->
