### PR TITLE
gh-101100: Fix sphinx warnings in `Doc/c-api/memory.rst`

### DIFF
--- a/Doc/c-api/memory.rst
+++ b/Doc/c-api/memory.rst
@@ -267,14 +267,14 @@ The following type-oriented macros are provided for convenience.  Note  that
 .. c:macro:: PyMem_New(TYPE, n)
 
    Same as :c:func:`PyMem_Malloc`, but allocates ``(n * sizeof(TYPE))`` bytes of
-   memory.  Returns a pointer cast to :c:expr:`TYPE*`.  The memory will not have
+   memory.  Returns a pointer cast to ``TYPE*``.  The memory will not have
    been initialized in any way.
 
 
 .. c:macro:: PyMem_Resize(p, TYPE, n)
 
    Same as :c:func:`PyMem_Realloc`, but the memory block is resized to ``(n *
-   sizeof(TYPE))`` bytes.  Returns a pointer cast to :c:expr:`TYPE*`. On return,
+   sizeof(TYPE))`` bytes.  Returns a pointer cast to ``TYPE*``. On return,
    *p* will be a pointer to the new memory area, or ``NULL`` in the event of
    failure.
 

--- a/Doc/tools/.nitignore
+++ b/Doc/tools/.nitignore
@@ -10,7 +10,6 @@ Doc/c-api/gcsupport.rst
 Doc/c-api/init.rst
 Doc/c-api/init_config.rst
 Doc/c-api/intro.rst
-Doc/c-api/memory.rst
 Doc/c-api/memoryview.rst
 Doc/c-api/module.rst
 Doc/c-api/object.rst


### PR DESCRIPTION
Before:

```
/Users/sobolev/Desktop/cpython2/Doc/c-api/memory.rst:269: WARNING: c:identifier reference target not found: TYPE
/Users/sobolev/Desktop/cpython2/Doc/c-api/memory.rst:276: WARNING: c:identifier reference target not found: TYPE
```

`TYPE` is a macro argument, it should not be `:c:expr:`, see docs https://www.sphinx-doc.org/en/master/usage/domains/c.html#role-c-expr

It should be just a code inline expr `TYPE*`.

<!-- gh-issue-number: gh-101100 -->
* Issue: gh-101100
<!-- /gh-issue-number -->
