### PR TITLE
 [3.11] gh-113358 Fix rendering tracebacks with exceptions with a broken __getattr__ : Normalize exception 

### DIFF
--- a/Python/pythonrun.c
+++ b/Python/pythonrun.c
@@ -1206,6 +1206,7 @@ get_exception_notes(struct exception_print_context *ctx, PyObject *value, PyObje
     if (_PyObject_LookupAttr(value, &_Py_ID(__notes__), notes) < 0) {
         PyObject *type, *errvalue, *tback;
         PyErr_Fetch(&type, &errvalue, &tback);
+        PyErr_NormalizeException(&type, &errvalue, &tback);
         note = PyUnicode_FromFormat("Ignored error getting __notes__: %R", errvalue);
         Py_XDECREF(type);
         Py_XDECREF(errvalue);


### PR DESCRIPTION
During review of https://github.com/python/cpython/pull/114173 we found out
that a call to `PyErr_NormalizeException` was missing after `PyErr_Fetch`.

These are changes that were missing from https://github.com/python/cpython/pull/114118 


<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-113358 -->
* Issue: gh-113358
<!-- /gh-issue-number -->
