### PR TITLE
[3.12] Docs: align sqlite3 docs with versionadded/versionchanged recommendations (#114400)

### DIFF
--- a/Doc/library/sqlite3.rst
+++ b/Doc/library/sqlite3.rst
@@ -343,17 +343,17 @@ Module functions
    .. audit-event:: sqlite3.connect database sqlite3.connect
    .. audit-event:: sqlite3.connect/handle connection_handle sqlite3.connect
 
-   .. versionadded:: 3.4
-      The *uri* parameter.
+   .. versionchanged:: 3.4
+      Added the *uri* parameter.
 
    .. versionchanged:: 3.7
       *database* can now also be a :term:`path-like object`, not only a string.
 
-   .. versionadded:: 3.10
-      The ``sqlite3.connect/handle`` auditing event.
+   .. versionchanged:: 3.10
+      Added the ``sqlite3.connect/handle`` auditing event.
 
-   .. versionadded:: 3.12
-      The *autocommit* parameter.
+   .. versionchanged:: 3.12
+      Added the *autocommit* parameter.
 
 .. function:: complete_statement(statement)
 
@@ -738,8 +738,8 @@ Connection objects
       :raises NotSupportedError:
           If *deterministic* is used with SQLite versions older than 3.8.3.
 
-      .. versionadded:: 3.8
-         The *deterministic* parameter.
+      .. versionchanged:: 3.8
+         Added the *deterministic* parameter.
 
       Example:
 
@@ -1101,8 +1101,8 @@ Connection objects
       .. versionchanged:: 3.10
          Added the ``sqlite3.load_extension`` auditing event.
 
-      .. versionadded:: 3.12
-         The *entrypoint* parameter.
+      .. versionchanged:: 3.12
+         Added the *entrypoint* parameter.
 
    .. _Loading an Extension: https://www.sqlite.org/loadext.html#loading_an_extension_
 
@@ -1731,9 +1731,9 @@ Row objects
 Blob objects
 ^^^^^^^^^^^^
 
-.. versionadded:: 3.11
-
 .. class:: Blob
+
+   .. versionadded:: 3.11
 
    A :class:`Blob` instance is a :term:`file-like object`
    that can read and write data in an SQLite :abbr:`BLOB (Binary Large OBject)`.


### PR DESCRIPTION
(cherry picked from commit 336030161a6cb8aa5b4f42a08510f4383984703f)

When a parameter is added to a function or method, use the 'versionchanged'
directive, not 'versionadded'.


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--114402.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->