### PR TITLE
[3.11] Docs: align sqlite3 docs with versionadded/versionchanged recommendations (#114400)

### DIFF
--- a/Doc/library/sqlite3.rst
+++ b/Doc/library/sqlite3.rst
@@ -331,14 +331,14 @@ Module functions
    .. audit-event:: sqlite3.connect database sqlite3.connect
    .. audit-event:: sqlite3.connect/handle connection_handle sqlite3.connect
 
-   .. versionadded:: 3.4
-      The *uri* parameter.
+   .. versionchanged:: 3.4
+      Added the *uri* parameter.
 
    .. versionchanged:: 3.7
       *database* can now also be a :term:`path-like object`, not only a string.
 
-   .. versionadded:: 3.10
-      The ``sqlite3.connect/handle`` auditing event.
+   .. versionchanged:: 3.10
+      Added the ``sqlite3.connect/handle`` auditing event.
 
 .. function:: complete_statement(statement)
 
@@ -662,8 +662,8 @@ Connection objects
       :raises NotSupportedError:
           If *deterministic* is used with SQLite versions older than 3.8.3.
 
-      .. versionadded:: 3.8
-         The *deterministic* parameter.
+      .. versionchanged:: 3.8
+         Added the *deterministic* parameter.
 
       Example:
 
@@ -1553,9 +1553,9 @@ Row objects
 Blob objects
 ^^^^^^^^^^^^
 
-.. versionadded:: 3.11
-
 .. class:: Blob
+
+   .. versionadded:: 3.11
 
    A :class:`Blob` instance is a :term:`file-like object`
    that can read and write data in an SQLite :abbr:`BLOB (Binary Large OBject)`.


### PR DESCRIPTION
(cherry picked from commit 336030161a6cb8aa5b4f42a08510f4383984703f)

When a parameter is added to a function or method, use the 'versionchanged'
directive, not 'versionadded'.


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--114403.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->