### PR TITLE
gh-101100: Fix sphinx warnings in `Doc/library/locale.rst`

### DIFF
--- a/Doc/library/locale.rst
+++ b/Doc/library/locale.rst
@@ -18,7 +18,7 @@ know all the specifics of each country where the software is executed.
 
 .. index:: pair: module; _locale
 
-The :mod:`locale` module is implemented on top of the :mod:`_locale` module,
+The :mod:`locale` module is implemented on top of the :mod:`!_locale` module,
 which in turn uses an ANSI C locale implementation if available.
 
 The :mod:`locale` module defines the following exception and functions:
@@ -192,7 +192,13 @@ The :mod:`locale` module defines the following exception and functions:
       Get a format string for :func:`time.strftime` to represent time in the am/pm
       format.
 
-   .. data:: DAY_1 ... DAY_7
+   .. data:: DAY_1
+             DAY_2
+             DAY_3
+             DAY_4
+             DAY_5
+             DAY_6
+             DAY_7
 
       Get the name of the n-th day of the week.
 
@@ -202,15 +208,43 @@ The :mod:`locale` module defines the following exception and functions:
          international convention (ISO 8601) that Monday is the first day of the
          week.
 
-   .. data:: ABDAY_1 ... ABDAY_7
+   .. data:: ABDAY_1
+             ABDAY_2
+             ABDAY_3
+             ABDAY_4
+             ABDAY_5
+             ABDAY_6
+             ABDAY_7
 
       Get the abbreviated name of the n-th day of the week.
 
-   .. data:: MON_1 ... MON_12
+   .. data:: MON_1
+             MON_2
+             MON_3
+             MON_4
+             MON_5
+             MON_6
+             MON_7
+             MON_8
+             MON_9
+             MON_10
+             MON_11
+             MON_12
 
       Get the name of the n-th month.
 
-   .. data:: ABMON_1 ... ABMON_12
+   .. data:: ABMON_1
+             ABMON_2
+             ABMON_3
+             ABMON_4
+             ABMON_5
+             ABMON_6
+             ABMON_7
+             ABMON_8
+             ABMON_9
+             ABMON_10
+             ABMON_11
+             ABMON_12
 
       Get the abbreviated name of the n-th month.
 
@@ -229,14 +263,14 @@ The :mod:`locale` module defines the following exception and functions:
 
    .. data:: NOEXPR
 
-      Get a regular expression that can be used with the regex(3) function to
+      Get a regular expression that can be used with the ``regex(3)`` function to
       recognize a negative response to a yes/no question.
 
       .. note::
 
          The regular expressions for :const:`YESEXPR` and
          :const:`NOEXPR` use syntax suitable for the
-         :c:func:`regex` function from the C library, which might
+         ``regex`` function from the C library, which might
          differ from the syntax used in :mod:`re`.
 
    .. data:: CRNCYSTR
@@ -581,9 +615,9 @@ the locale is ``C``).
 
 When Python code uses the :mod:`locale` module to change the locale, this also
 affects the embedding application.  If the embedding application doesn't want
-this to happen, it should remove the :mod:`_locale` extension module (which does
+this to happen, it should remove the :mod:`!_locale` extension module (which does
 all the work) from the table of built-in modules in the :file:`config.c` file,
-and make sure that the :mod:`_locale` module is not accessible as a shared
+and make sure that the :mod:`!_locale` module is not accessible as a shared
 library.
 
 
@@ -592,22 +626,23 @@ library.
 Access to message catalogs
 --------------------------
 
-.. function:: gettext(msg)
-.. function:: dgettext(domain, msg)
-.. function:: dcgettext(domain, msg, category)
-.. function:: textdomain(domain)
-.. function:: bindtextdomain(domain, dir)
+.. function:: gettext(msg, /)
+.. function:: dgettext(domain, msg, /)
+.. function:: dcgettext(domain, msg, category, /)
+.. function:: textdomain(domain, /)
+.. function:: bindtextdomain(domain, dir, /)
+.. function:: bind_textdomain_codeset(domain, codeset, /)
 
 The locale module exposes the C library's gettext interface on systems that
-provide this interface.  It consists of the functions :func:`!gettext`,
-:func:`!dgettext`, :func:`!dcgettext`, :func:`!textdomain`, :func:`!bindtextdomain`,
-and :func:`!bind_textdomain_codeset`.  These are similar to the same functions in
+provide this interface.  It consists of the functions :func:`gettext`,
+:func:`dgettext`, :func:`dcgettext`, :func:`textdomain`, :func:`bindtextdomain`,
+and :func:`bind_textdomain_codeset`.  These are similar to the same functions in
 the :mod:`gettext` module, but use the C library's binary format for message
 catalogs, and the C library's search algorithms for locating message catalogs.
 
 Python applications should normally find no need to invoke these functions, and
 should use :mod:`gettext` instead.  A known exception to this rule are
 applications that link with additional C libraries which internally invoke
-:c:func:`gettext` or :c:func:`dcgettext`.  For these applications, it may be
+C functions ``gettext`` or ``dcgettext``.  For these applications, it may be
 necessary to bind the text domain, so that the libraries can properly locate
 their message catalogs.

--- a/Doc/library/locale.rst
+++ b/Doc/library/locale.rst
@@ -626,12 +626,12 @@ library.
 Access to message catalogs
 --------------------------
 
-.. function:: gettext(msg, /)
-.. function:: dgettext(domain, msg, /)
-.. function:: dcgettext(domain, msg, category, /)
-.. function:: textdomain(domain, /)
-.. function:: bindtextdomain(domain, dir, /)
-.. function:: bind_textdomain_codeset(domain, codeset, /)
+.. function:: gettext(msg)
+.. function:: dgettext(domain, msg)
+.. function:: dcgettext(domain, msg, category)
+.. function:: textdomain(domain)
+.. function:: bindtextdomain(domain, dir)
+.. function:: bind_textdomain_codeset(domain, codeset)
 
 The locale module exposes the C library's gettext interface on systems that
 provide this interface.  It consists of the functions :func:`gettext`,

--- a/Doc/tools/.nitignore
+++ b/Doc/tools/.nitignore
@@ -50,7 +50,6 @@ Doc/library/functools.rst
 Doc/library/http.cookiejar.rst
 Doc/library/http.server.rst
 Doc/library/importlib.rst
-Doc/library/locale.rst
 Doc/library/logging.config.rst
 Doc/library/logging.handlers.rst
 Doc/library/lzma.rst


### PR DESCRIPTION
Before:

```
/Users/sobolev/Desktop/cpython2/Doc/library/locale.rst:21: WARNING: py:mod reference target not found: _locale
/Users/sobolev/Desktop/cpython2/Doc/library/locale.rst:201: WARNING: py:const reference target not found: DAY_1
/Users/sobolev/Desktop/cpython2/Doc/library/locale.rst:237: WARNING: c:func reference target not found: regex
/Users/sobolev/Desktop/cpython2/Doc/library/locale.rst:582: WARNING: py:mod reference target not found: _locale
/Users/sobolev/Desktop/cpython2/Doc/library/locale.rst:582: WARNING: py:mod reference target not found: _locale
/Users/sobolev/Desktop/cpython2/Doc/library/locale.rst:608: WARNING: c:func reference target not found: gettext
/Users/sobolev/Desktop/cpython2/Doc/library/locale.rst:608: WARNING: c:func reference target not found: dcgettext
```

<!-- gh-issue-number: gh-101100 -->
* Issue: gh-101100
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--114425.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->