### PR TITLE
gh-112984: Fix link error on free-threaded Windows build

### DIFF
--- a/Tools/peg_generator/pegen/build.py
+++ b/Tools/peg_generator/pegen/build.py
@@ -220,6 +220,9 @@ def compile_c_extension(
         )
     else:
         objects = compiler.object_filenames(extension.sources, output_dir=cmd.build_temp)
+    # The cmd.get_libraries() call needs a valid compiler attribute or we will
+    # get an incorrect library name on the free-threaded Windows build.
+    cmd.compiler = compiler
     # Now link the object files together into a "shared object"
     compiler.link_shared_object(
         objects,


### PR DESCRIPTION
The test_peg_generator test tried to link the python313_d.lib library, which failed because the library is now named python313t_d.lib. The underlying problem is that the cmd.compiler attribute was not set when we call get_libraries() from distutils.


<!-- gh-issue-number: gh-112984 -->
* Issue: gh-112984
<!-- /gh-issue-number -->
