### PR TITLE
[3.11] GH-99334: Explain that `PurePath.is_relative_to()` is purely lexical. (GH-114031).

### DIFF
--- a/Doc/library/pathlib.rst
+++ b/Doc/library/pathlib.rst
@@ -510,6 +510,13 @@ Pure paths provide the following methods and properties:
 
    If multiple arguments are supplied, they are joined together.
 
+   This method is string-based; it neither accesses the filesystem nor treats
+   "``..``" segments specially. The following code is equivalent:
+
+      >>> u = PurePath('/usr')
+      >>> u == p or u in p.parents
+      False
+
    .. versionadded:: 3.9
 
 


### PR DESCRIPTION
(cherry picked from commit 3a61d24062aaa1e13ba794360b6c765d9a1f2b06)

<!-- gh-issue-number: gh-99334 -->
* Issue: gh-99334
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--114461.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->