### PR TITLE
WIP: gh-114467: Support posix_spawn in subprocess.Popen with cwd != None

### DIFF
--- a/Doc/library/os.rst
+++ b/Doc/library/os.rst
@@ -5161,11 +5161,18 @@ written in Python, such as a mail server's external command delivery program.
 
       Performs ``os.closerange(fd, INF)``.
 
+   .. data:: POSIX_SPAWN_CHDIR
+
+      (``os.POSIX_SPAWN_CHDIR``, *path*)
+
+      Performs ``os.chdir(path)``.
+
    These tuples correspond to the C library
    :c:func:`!posix_spawn_file_actions_addopen`,
    :c:func:`!posix_spawn_file_actions_addclose`,
-   :c:func:`!posix_spawn_file_actions_adddup2`, and
-   :c:func:`!posix_spawn_file_actions_addclosefrom_np` API calls used to prepare
+   :c:func:`!posix_spawn_file_actions_adddup2`,
+   :c:func:`!posix_spawn_file_actions_addclosefrom_np`, and
+   :c:func:`!posix_spawn_file_actions_addchdir_np` API calls used to prepare
    for the :c:func:`!posix_spawn` call itself.
 
    The *setpgroup* argument will set the process group of the child to the value
@@ -5209,8 +5216,11 @@ written in Python, such as a mail server's external command delivery program.
 
    .. versionchanged:: 3.13
       *env* parameter accepts ``None``.
-      ``os.POSIX_SPAWN_CLOSEFROM`` is available on platforms where
-      :c:func:`!posix_spawn_file_actions_addclosefrom_np` exists.
+
+   .. versionchanged:: 3.14
+      ``os.POSIX_SPAWN_CLOSEFROM`` and ``os.POSIX_SPAWN_CHDIR`` are available
+      on platforms where :c:func:`!posix_spawn_file_actions_addclosefrom_np`
+      and :c:func:`!posix_spawn_file_actions_addchdir_np` exist.
 
    .. availability:: Unix, not WASI, not Android, not iOS.
 

--- a/Doc/library/os.rst
+++ b/Doc/library/os.rst
@@ -5216,11 +5216,12 @@ written in Python, such as a mail server's external command delivery program.
 
    .. versionchanged:: 3.13
       *env* parameter accepts ``None``.
+      ``os.POSIX_SPAWN_CLOSEFROM`` is available on platforms where
+      :c:func:`!posix_spawn_file_actions_addclosefrom_np` exists.
 
-   .. versionchanged:: 3.14
-      ``os.POSIX_SPAWN_CLOSEFROM`` and ``os.POSIX_SPAWN_CHDIR`` are available
-      on platforms where :c:func:`!posix_spawn_file_actions_addclosefrom_np`
-      and :c:func:`!posix_spawn_file_actions_addchdir_np` exist.
+   .. versionchanged:: 3.15
+      ``os.POSIX_SPAWN_CHDIR`` is available on platforms where
+      :c:func:`!posix_spawn_file_actions_addchdir_np` exist.
 
    .. availability:: Unix, not WASI, not Android, not iOS.
 

--- a/Lib/subprocess.py
+++ b/Lib/subprocess.py
@@ -806,6 +806,7 @@ _CAN_USE_KQUEUE = not _mswindows and _can_use_kqueue()
 # These are primarily fail-safe knobs for negatives. A True value does not
 # guarantee the given libc/syscall API will be used.
 _USE_POSIX_SPAWN = _use_posix_spawn()
+_HAVE_POSIX_SPAWN_CHDIR = hasattr(os, 'POSIX_SPAWN_CHDIR')
 _HAVE_POSIX_SPAWN_CLOSEFROM = hasattr(os, 'POSIX_SPAWN_CLOSEFROM')
 
 
@@ -1836,7 +1837,7 @@ class Popen:
                     errread, errwrite)
 
 
-        def _posix_spawn(self, args, executable, env, restore_signals, close_fds,
+        def _posix_spawn(self, args, executable, env, restore_signals, close_fds, cwd,
                          p2cread, p2cwrite,
                          c2pread, c2pwrite,
                          errread, errwrite):
@@ -1862,6 +1863,9 @@ class Popen:
             ):
                 if fd != -1:
                     file_actions.append((os.POSIX_SPAWN_DUP2, fd, fd2))
+
+            if cwd:
+                file_actions.append((os.POSIX_SPAWN_CHDIR, cwd))
 
             if close_fds:
                 file_actions.append((os.POSIX_SPAWN_CLOSEFROM, 3))
@@ -1915,7 +1919,7 @@ class Popen:
                     and preexec_fn is None
                     and (not close_fds or _HAVE_POSIX_SPAWN_CLOSEFROM)
                     and not pass_fds
-                    and cwd is None
+                    and (cwd is None or _HAVE_POSIX_SPAWN_CHDIR)
                     and (p2cread == -1 or p2cread > 2)
                     and (c2pwrite == -1 or c2pwrite > 2)
                     and (errwrite == -1 or errwrite > 2)
@@ -1925,7 +1929,8 @@ class Popen:
                     and gids is None
                     and uid is None
                     and umask < 0):
-                self._posix_spawn(args, executable, env, restore_signals, close_fds,
+                self._posix_spawn(args, executable, env, restore_signals,
+                                  close_fds, cwd,
                                   p2cread, p2cwrite,
                                   c2pread, c2pwrite,
                                   errread, errwrite)

--- a/Lib/subprocess.py
+++ b/Lib/subprocess.py
@@ -1864,7 +1864,7 @@ class Popen:
                 if fd != -1:
                     file_actions.append((os.POSIX_SPAWN_DUP2, fd, fd2))
 
-            if cwd:
+            if cwd is not None:
                 file_actions.append((os.POSIX_SPAWN_CHDIR, cwd))
 
             if close_fds:

--- a/Lib/test/test_subprocess.py
+++ b/Lib/test/test_subprocess.py
@@ -2018,6 +2018,7 @@ class POSIXProcessTestCase(BaseTestCase):
                       self._nonexistent_dir)
         return desired_exception
 
+    @mock.patch("subprocess._HAVE_POSIX_SPAWN_CHDIR", new=False)
     def test_exception_cwd(self):
         """Test error in the child raised in the parent for a bad cwd."""
         desired_exception = self._get_chdir_exception()

--- a/Misc/NEWS.d/next/Library/2026-04-01-15-16-28.gh-issue-114467.g-8r4E.rst
+++ b/Misc/NEWS.d/next/Library/2026-04-01-15-16-28.gh-issue-114467.g-8r4E.rst
@@ -1,0 +1,3 @@
+The :mod:`subprocess` module can now use the :func:`os.posix_spawn` function
+with ``cwd`` set on platforms where ``posix_spawn_file_actions_addchdir_np``
+is available. Patch by Jakub Kulik.

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -7884,7 +7884,7 @@ parse_file_actions(PyObject *file_actions,
                     Py_DECREF(path);
                     goto fail;
                 }
-                Py_XDECREF(cwd);
+                Py_XDECREF(*cwd);
                 *cwd = path;
                 break;
             }

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -7606,6 +7606,9 @@ enum posix_spawn_file_actions_identifier {
 #ifdef HAVE_POSIX_SPAWN_FILE_ACTIONS_ADDCLOSEFROM_NP
     ,POSIX_SPAWN_CLOSEFROM
 #endif
+#ifdef HAVE_POSIX_SPAWN_FILE_ACTIONS_ADDCHDIR_NP
+    ,POSIX_SPAWN_CHDIR
+#endif
 };
 
 #if defined(HAVE_SCHED_SETPARAM) || defined(HAVE_SCHED_SETSCHEDULER) || defined(POSIX_SPAWN_SETSCHEDULER) || defined(POSIX_SPAWN_SETSCHEDPARAM)
@@ -7864,6 +7867,25 @@ parse_file_actions(PyObject *file_actions,
                 }
                 break;
             }
+#endif
+#ifdef HAVE_POSIX_SPAWN_FILE_ACTIONS_ADDCHDIR_NP
+            case POSIX_SPAWN_CHDIR: {
+                PyObject *path;
+                if (!PyArg_ParseTuple(file_action, "OO&"
+                        ";A chdir file_action tuple must have 2 elements",
+                        &tag_obj, PyUnicode_FSConverter, &path))
+                {
+                    goto fail;
+                }
+                errno = posix_spawn_file_actions_addchdir_np(file_actionsp,
+                        PyBytes_AS_STRING(path));
+                if (errno) {
+                    posix_error();
+                    Py_DECREF(path);
+                    goto fail;
+                }
+                Py_DECREF(path);
+                break;
 #endif
             default: {
                 PyErr_SetString(PyExc_TypeError,
@@ -18149,6 +18171,9 @@ all_ins(PyObject *m)
     if (PyModule_AddIntConstant(m, "POSIX_SPAWN_DUP2", POSIX_SPAWN_DUP2)) return -1;
 #ifdef HAVE_POSIX_SPAWN_FILE_ACTIONS_ADDCLOSEFROM_NP
     if (PyModule_AddIntMacro(m, POSIX_SPAWN_CLOSEFROM)) return -1;
+#endif
+#ifdef HAVE_POSIX_SPAWN_FILE_ACTIONS_ADDCHDIR_NP
+    if (PyModule_AddIntMacro(m, POSIX_SPAWN_CHDIR)) return -1;
 #endif
 #endif
 

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -7760,7 +7760,7 @@ fail:
 static int
 parse_file_actions(PyObject *file_actions,
                    posix_spawn_file_actions_t *file_actionsp,
-                   PyObject *temp_buffer, PyObject** cwd)
+                   PyObject *temp_buffer, PyObject* cwd_buffer)
 {
     PyObject *seq;
     PyObject *file_action = NULL;
@@ -7884,8 +7884,10 @@ parse_file_actions(PyObject *file_actions,
                     Py_DECREF(path);
                     goto fail;
                 }
-                Py_XDECREF(*cwd);
-                *cwd = path;
+                if (PyList_Append(cwd_buffer, path)) {
+                    Py_DECREF(path);
+                    goto fail;
+                }
                 break;
             }
 #endif
@@ -7925,7 +7927,7 @@ py_posix_spawn(int use_posix_spawnp, PyObject *module, path_t *path, PyObject *a
     Py_ssize_t argc, envc;
     PyObject *result = NULL;
     PyObject *temp_buffer = NULL;
-    PyObject *cwd = NULL;
+    PyObject *cwd_buffer = NULL;
     pid_t pid;
     int err_code;
 
@@ -7997,7 +7999,12 @@ py_posix_spawn(int use_posix_spawnp, PyObject *module, path_t *path, PyObject *a
         if (!temp_buffer) {
             goto exit;
         }
-        if (parse_file_actions(file_actions, &file_actions_buf, temp_buffer, &cwd)) {
+        /* TODO there can be multiple cwd actions .... */
+        cwd_buffer = PyList_New(0);
+        if (!cwd_buffer) {
+            goto exit;
+        }
+        if (parse_file_actions(file_actions, &file_actions_buf, temp_buffer, cwd_buffer)) {
             goto exit;
         }
         file_actionsp = &file_actions_buf;
@@ -8030,13 +8037,36 @@ py_posix_spawn(int use_posix_spawnp, PyObject *module, path_t *path, PyObject *a
     if (err_code) {
         errno = err_code;
 #ifdef HAVE_POSIX_SPAWN_FILE_ACTIONS_ADDCHDIR_NP
-        if (errno == ENOENT && cwd != NULL) {
-            /* ENOENT can occur when either the path of the executable or the
-             * cwd given via file_actions doesn't exist. Since it's not feasible
-             * to determine which of those paths caused the problem, we return
-             * an exception with both. */
-            PyErr_Format(PyExc_FileNotFoundError, "Either '%S' or '%s' doesn't exist.",
+        Py_ssize_t cwd_size = PyList_GET_SIZE(cwd_buffer);
+        if (errno == ENOENT && cwd_size > 0) {
+            /* ENOENT can occur when either the path of the executable or any of
+             * the cwds given via file_actions doesn't exist. Since it's not
+             * possible to determine which of those paths caused the problem,
+             * we return an exception with all of those. */
+
+            if (cwd_size == 1) {
+                /* the common case */
+                PyObject *cwd = PyList_GET_ITEM(cwd_buffer, 0);
+                PyErr_Format(PyExc_FileNotFoundError, "Either '%S' or '%s' doesn't exist.",
                          path->object, PyBytes_AS_STRING(cwd));
+            } else {
+                /* TODO ..... */
+                PyObject *separator = PyBytes_FromString(", ");
+                if (!separator) {
+                    goto exit;
+                }
+
+                PyObject *joined = PyObject_CallMethod(separator, "join", "O", cwd_buffer);
+                Py_DECREF(separator);
+                if (!joined) {
+                    goto exit;
+                }
+                PyErr_Format(PyExc_FileNotFoundError,
+                             "Either '%S' or one of (%s) doesn't exist.",
+                             path->object, PyBytes_AS_STRING(joined));
+
+                Py_DECREF(joined);
+            }
             goto exit;
         }
 #endif
@@ -8061,7 +8091,7 @@ exit:
     if (argvlist) {
         free_string_array(argvlist, argc);
     }
-    Py_XDECREF(cwd);
+    Py_XDECREF(cwd_buffer);
     Py_XDECREF(temp_buffer);
     return result;
 }

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -7999,7 +7999,8 @@ py_posix_spawn(int use_posix_spawnp, PyObject *module, path_t *path, PyObject *a
         if (!temp_buffer) {
             goto exit;
         }
-        /* TODO there can be multiple cwd actions .... */
+        /* Use a list to capture all directories passed via POSIX_SPAWN_CHDIR
+         * action for potential exception creation below. */
         cwd_buffer = PyList_New(0);
         if (!cwd_buffer) {
             goto exit;
@@ -8045,12 +8046,13 @@ py_posix_spawn(int use_posix_spawnp, PyObject *module, path_t *path, PyObject *a
              * we return an exception with all of those. */
 
             if (cwd_size == 1) {
-                /* the common case */
                 PyObject *cwd = PyList_GET_ITEM(cwd_buffer, 0);
                 PyErr_Format(PyExc_FileNotFoundError, "Either '%S' or '%s' doesn't exist.",
                          path->object, PyBytes_AS_STRING(cwd));
             } else {
-                /* TODO ..... */
+                /* Multiple POSIX_SPAWN_CHDIR actions were used in a single
+                 * spawn. In this case, we have to build the expection message
+                 * from all possibly missing paths. */
                 PyObject *separator = PyBytes_FromString(", ");
                 if (!separator) {
                     goto exit;

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -7886,6 +7886,7 @@ parse_file_actions(PyObject *file_actions,
                 }
                 Py_DECREF(path);
                 break;
+            }
 #endif
             default: {
                 PyErr_SetString(PyExc_TypeError,

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -8038,8 +8038,8 @@ py_posix_spawn(int use_posix_spawnp, PyObject *module, path_t *path, PyObject *a
     if (err_code) {
         errno = err_code;
 #ifdef HAVE_POSIX_SPAWN_FILE_ACTIONS_ADDCHDIR_NP
-        Py_ssize_t cwd_size = PyList_GET_SIZE(cwd_buffer);
-        if (errno == ENOENT && cwd_size > 0) {
+        Py_ssize_t cwd_size;
+        if (errno == ENOENT && cwd_buffer && (cwd_size = PyList_GET_SIZE(cwd_buffer))) {
             /* ENOENT can occur when either the path of the executable or any of
              * the cwds given via file_actions doesn't exist. Since it's not
              * possible to determine which of those paths caused the problem,

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -7760,7 +7760,7 @@ fail:
 static int
 parse_file_actions(PyObject *file_actions,
                    posix_spawn_file_actions_t *file_actionsp,
-                   PyObject *temp_buffer)
+                   PyObject *temp_buffer, PyObject** cwd)
 {
     PyObject *seq;
     PyObject *file_action = NULL;
@@ -7884,7 +7884,8 @@ parse_file_actions(PyObject *file_actions,
                     Py_DECREF(path);
                     goto fail;
                 }
-                Py_DECREF(path);
+                Py_XDECREF(cwd);
+                *cwd = path;
                 break;
             }
 #endif
@@ -7924,6 +7925,7 @@ py_posix_spawn(int use_posix_spawnp, PyObject *module, path_t *path, PyObject *a
     Py_ssize_t argc, envc;
     PyObject *result = NULL;
     PyObject *temp_buffer = NULL;
+    PyObject *cwd = NULL;
     pid_t pid;
     int err_code;
 
@@ -7995,7 +7997,7 @@ py_posix_spawn(int use_posix_spawnp, PyObject *module, path_t *path, PyObject *a
         if (!temp_buffer) {
             goto exit;
         }
-        if (parse_file_actions(file_actions, &file_actions_buf, temp_buffer)) {
+        if (parse_file_actions(file_actions, &file_actions_buf, temp_buffer, &cwd)) {
             goto exit;
         }
         file_actionsp = &file_actions_buf;
@@ -8027,6 +8029,17 @@ py_posix_spawn(int use_posix_spawnp, PyObject *module, path_t *path, PyObject *a
 
     if (err_code) {
         errno = err_code;
+#ifdef HAVE_POSIX_SPAWN_FILE_ACTIONS_ADDCHDIR_NP
+        if (errno == ENOENT && cwd != NULL) {
+            /* ENOENT can occur when either the path of the executable or the
+             * cwd given via file_actions doesn't exist. Since it's not feasible
+             * to determine which of those paths caused the problem, we return
+             * an exception with both. */
+            PyErr_Format(PyExc_FileNotFoundError, "Either '%S' or '%s' doesn't exist.",
+                         path->object, PyBytes_AS_STRING(cwd));
+            goto exit;
+        }
+#endif
         PyErr_SetFromErrnoWithFilenameObject(PyExc_OSError, path->object);
         goto exit;
     }
@@ -8048,6 +8061,7 @@ exit:
     if (argvlist) {
         free_string_array(argvlist, argc);
     }
+    Py_XDECREF(cwd);
     Py_XDECREF(temp_buffer);
     return result;
 }

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -8056,7 +8056,7 @@ py_posix_spawn(int use_posix_spawnp, PyObject *module, path_t *path, PyObject *a
                     goto exit;
                 }
 
-                PyObject *joined = PyObject_CallMethod(separator, "join", "O", cwd_buffer);
+                PyObject *joined = PyBytes_Join(separator, cwd_buffer);
                 Py_DECREF(separator);
                 if (!joined) {
                     goto exit;

--- a/configure
+++ b/configure
@@ -20110,12 +20110,6 @@ then :
   printf "%s\n" "#define HAVE_POSIX_SPAWNP 1" >>confdefs.h
 
 fi
-ac_fn_c_check_func "$LINENO" "posix_spawn_file_actions_addchdir_np" "ac_cv_func_posix_spawn_file_actions_addchdir_np"
-if test "x$ac_cv_func_posix_spawn_file_actions_addchdir_np" = xyes
-then :
-  printf "%s\n" "#define HAVE_POSIX_SPAWN_FILE_ACTIONS_ADDCHDIR_NP 1" >>confdefs.h
-
-fi
 ac_fn_c_check_func "$LINENO" "posix_spawn_file_actions_addclosefrom_np" "ac_cv_func_posix_spawn_file_actions_addclosefrom_np"
 if test "x$ac_cv_func_posix_spawn_file_actions_addclosefrom_np" = xyes
 then :
@@ -20744,6 +20738,12 @@ ac_fn_c_check_func "$LINENO" "getgroups" "ac_cv_func_getgroups"
 if test "x$ac_cv_func_getgroups" = xyes
 then :
   printf "%s\n" "#define HAVE_GETGROUPS 1" >>confdefs.h
+
+fi
+ac_fn_c_check_func "$LINENO" "posix_spawn_file_actions_addchdir_np" "ac_cv_func_posix_spawn_file_actions_addchdir_np"
+if test "x$ac_cv_func_posix_spawn_file_actions_addchdir_np" = xyes
+then :
+  printf "%s\n" "#define HAVE_POSIX_SPAWN_FILE_ACTIONS_ADDCHDIR_NP 1" >>confdefs.h
 
 fi
 ac_fn_c_check_func "$LINENO" "system" "ac_cv_func_system"

--- a/configure
+++ b/configure
@@ -20110,6 +20110,12 @@ then :
   printf "%s\n" "#define HAVE_POSIX_SPAWNP 1" >>confdefs.h
 
 fi
+ac_fn_c_check_func "$LINENO" "posix_spawn_file_actions_addchdir_np" "ac_cv_func_posix_spawn_file_actions_addchdir_np"
+if test "x$ac_cv_func_posix_spawn_file_actions_addchdir_np" = xyes
+then :
+  printf "%s\n" "#define HAVE_POSIX_SPAWN_FILE_ACTIONS_ADDCHDIR_NP 1" >>confdefs.h
+
+fi
 ac_fn_c_check_func "$LINENO" "posix_spawn_file_actions_addclosefrom_np" "ac_cv_func_posix_spawn_file_actions_addclosefrom_np"
 if test "x$ac_cv_func_posix_spawn_file_actions_addclosefrom_np" = xyes
 then :

--- a/configure.ac
+++ b/configure.ac
@@ -5335,7 +5335,7 @@ AC_CHECK_FUNCS([ \
   lockf lstat lutimes madvise mbrtowc memrchr mkdirat mkfifo mkfifoat \
   mknod mknodat mktime mmap mremap nice openat opendir pathconf pause pipe \
   pipe2 plock poll ppoll posix_fadvise posix_fallocate posix_openpt posix_spawn posix_spawnp \
-  posix_spawn_file_actions_addclosefrom_np \
+  posix_spawn_file_actions_addchdir_np posix_spawn_file_actions_addclosefrom_np \
   pread preadv preadv2 process_vm_readv \
   pthread_cond_timedwait_relative_np pthread_condattr_setclock pthread_init \
   pthread_kill pthread_get_name_np pthread_getname_np pthread_set_name_np \

--- a/configure.ac
+++ b/configure.ac
@@ -5335,7 +5335,7 @@ AC_CHECK_FUNCS([ \
   lockf lstat lutimes madvise mbrtowc memrchr mkdirat mkfifo mkfifoat \
   mknod mknodat mktime mmap mremap nice openat opendir pathconf pause pipe \
   pipe2 plock poll ppoll posix_fadvise posix_fallocate posix_openpt posix_spawn posix_spawnp \
-  posix_spawn_file_actions_addchdir_np posix_spawn_file_actions_addclosefrom_np \
+  posix_spawn_file_actions_addclosefrom_np \
   pread preadv preadv2 process_vm_readv \
   pthread_cond_timedwait_relative_np pthread_condattr_setclock pthread_init \
   pthread_kill pthread_get_name_np pthread_getname_np pthread_set_name_np \
@@ -5371,7 +5371,7 @@ fi
 # header definition prevents usage - autoconf doesn't use the headers), or
 # raise an error if used at runtime. Force these symbols off.
 if test "$ac_sys_system" != "iOS" ; then
-  AC_CHECK_FUNCS([getentropy getgroups system])
+  AC_CHECK_FUNCS([getentropy getgroups posix_spawn_file_actions_addchdir_np system])
 fi
 
 AC_CHECK_DECL([dirfd],

--- a/pyconfig.h.in
+++ b/pyconfig.h.in
@@ -975,6 +975,10 @@
 /* Define to 1 if you have the 'posix_spawnp' function. */
 #undef HAVE_POSIX_SPAWNP
 
+/* Define to 1 if you have the 'posix_spawn_file_actions_addchdir_np'
+   function. */
+#undef HAVE_POSIX_SPAWN_FILE_ACTIONS_ADDCHDIR_NP
+
 /* Define to 1 if you have the 'posix_spawn_file_actions_addclosefrom_np'
    function. */
 #undef HAVE_POSIX_SPAWN_FILE_ACTIONS_ADDCLOSEFROM_NP


### PR DESCRIPTION
This is a work in progress as there is still one issue to solve:

Running `subprocess.run(["/usr/bin/ls"], cwd="/nonexistent")` should fail with:
`FileNotFoundError: [Errno 2] No such file or directory: '/nonexistent'`

but with this PR, it fails with:
`FileNotFoundError: [Errno 2] No such file or directory: '/usr/bin/ls'`

which is incorrect, because it's not '/usr/bin/ls' that is missing, it's the directory. I have yet to determine how to fix this.

(this also causes `test.test_subprocess.POSIXProcessTestCase.test_exception_cwd` to fail).

<!-- gh-issue-number: gh-114467 -->
* Issue: gh-114467
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--114468.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->