### PR TITLE
gh-101100: Fix sphinx warnings in `asyncio-task.rst`

### DIFF
--- a/Doc/library/asyncio-task.rst
+++ b/Doc/library/asyncio-task.rst
@@ -829,6 +829,7 @@ Waiting Primitives
    be one of the following constants:
 
    .. list-table::
+      :header-rows: 1
 
       * - Constant
         - Description

--- a/Doc/library/asyncio-task.rst
+++ b/Doc/library/asyncio-task.rst
@@ -828,23 +828,21 @@ Waiting Primitives
    *return_when* indicates when this function should return.  It must
    be one of the following constants:
 
-   .. tabularcolumns:: |l|L|
+   .. list-table::
 
-   +-----------------------------+----------------------------------------+
-   | Constant                    | Description                            |
-   +=============================+========================================+
-   | :const:`FIRST_COMPLETED`    | The function will return when any      |
-   |                             | future finishes or is cancelled.       |
-   +-----------------------------+----------------------------------------+
-   | :const:`FIRST_EXCEPTION`    | The function will return when any      |
-   |                             | future finishes by raising an          |
-   |                             | exception.  If no future raises an     |
-   |                             | exception then it is equivalent to     |
-   |                             | :const:`ALL_COMPLETED`.                |
-   +-----------------------------+----------------------------------------+
-   | :const:`ALL_COMPLETED`      | The function will return when all      |
-   |                             | futures finish or are cancelled.       |
-   +-----------------------------+----------------------------------------+
+      * - Constant
+        - Description
+
+      * - .. data:: FIRST_COMPLETED
+        - The function will return when any future finishes or is cancelled.
+
+      * - .. data:: FIRST_EXCEPTION
+        - The function will return when any future finishes by raising an
+          exception. If no future raises an exception
+          then it is equivalent to :const:`ALL_COMPLETED`.
+
+      * - .. data:: ALL_COMPLETED
+        - The function will return when all futures finish or are cancelled.
 
    Unlike :func:`~asyncio.wait_for`, ``wait()`` does not cancel the
    futures when a timeout occurs.

--- a/Doc/tools/.nitignore
+++ b/Doc/tools/.nitignore
@@ -27,7 +27,6 @@ Doc/library/ast.rst
 Doc/library/asyncio-extending.rst
 Doc/library/asyncio-policy.rst
 Doc/library/asyncio-subprocess.rst
-Doc/library/asyncio-task.rst
 Doc/library/bdb.rst
 Doc/library/collections.rst
 Doc/library/concurrent.futures.rst


### PR DESCRIPTION
It used to be:

```
/Users/sobolev/Desktop/cpython2/Doc/library/asyncio-task.rst:837: WARNING: py:const reference target not found: FIRST_COMPLETED
/Users/sobolev/Desktop/cpython2/Doc/library/asyncio-task.rst:840: WARNING: py:const reference target not found: FIRST_EXCEPTION
/Users/sobolev/Desktop/cpython2/Doc/library/asyncio-task.rst:840: WARNING: py:const reference target not found: ALL_COMPLETED
/Users/sobolev/Desktop/cpython2/Doc/library/asyncio-task.rst:846: WARNING: py:const reference target not found: ALL_COMPLETED
```

<!-- gh-issue-number: gh-101100 -->
* Issue: gh-101100
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--114469.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->