### PR TITLE
gh-113267: Revert "gh-106584: Fix exit code for unittest in Python 3.12 (#106588)"

### DIFF
--- a/Lib/test/test_unittest/test_discovery.py
+++ b/Lib/test/test_unittest/test_discovery.py
@@ -571,7 +571,7 @@ class TestDiscovery(unittest.TestCase):
         result = unittest.TestResult()
         suite.run(result)
         self.assertEqual(len(result.skipped), 1)
-        self.assertEqual(result.testsRun, 0)
+        self.assertEqual(result.testsRun, 1)
         self.assertEqual(import_calls, ['my_package'])
 
         # Check picklability

--- a/Lib/test/test_unittest/test_skipping.py
+++ b/Lib/test/test_unittest/test_skipping.py
@@ -103,16 +103,16 @@ class Test_TestSkipping(unittest.TestCase):
             result = LoggingResult(events)
             self.assertIs(suite.run(result), result)
             self.assertEqual(len(result.skipped), 1)
-            expected = ['addSkip', 'stopTest', 'startTest',
-                        'addSuccess', 'stopTest']
+            expected = ['startTest', 'addSkip', 'stopTest',
+                        'startTest', 'addSuccess', 'stopTest']
             self.assertEqual(events, expected)
-            self.assertEqual(result.testsRun, 1)
+            self.assertEqual(result.testsRun, 2)
             self.assertEqual(result.skipped, [(test_do_skip, "testing")])
             self.assertTrue(result.wasSuccessful())
 
             events = []
             result = test_do_skip.run()
-            self.assertEqual(events, ['startTestRun', 'addSkip',
+            self.assertEqual(events, ['startTestRun', 'startTest', 'addSkip',
                                       'stopTest', 'stopTestRun'])
             self.assertEqual(result.skipped, [(test_do_skip, "testing")])
 
@@ -135,13 +135,13 @@ class Test_TestSkipping(unittest.TestCase):
         test = Foo("test_1")
         suite = unittest.TestSuite([test])
         self.assertIs(suite.run(result), result)
-        self.assertEqual(events, ['addSkip', 'stopTest'])
+        self.assertEqual(events, ['startTest', 'addSkip', 'stopTest'])
         self.assertEqual(result.skipped, [(test, "testing")])
         self.assertEqual(record, [])
 
         events = []
         result = test.run()
-        self.assertEqual(events, ['startTestRun', 'addSkip',
+        self.assertEqual(events, ['startTestRun', 'startTest', 'addSkip',
                                   'stopTest', 'stopTestRun'])
         self.assertEqual(result.skipped, [(test, "testing")])
         self.assertEqual(record, [])

--- a/Lib/unittest/case.py
+++ b/Lib/unittest/case.py
@@ -606,6 +606,7 @@ class TestCase(object):
         else:
             stopTestRun = None
 
+        result.startTest(self)
         try:
             testMethod = getattr(self, self._testMethodName)
             if (getattr(self.__class__, "__unittest_skip__", False) or
@@ -615,9 +616,6 @@ class TestCase(object):
                             or getattr(testMethod, '__unittest_skip_why__', ''))
                 _addSkip(result, self, skip_why)
                 return result
-
-            # Increase the number of tests only if it hasn't been skipped
-            result.startTest(self)
 
             expecting_failure = (
                 getattr(self, "__unittest_expecting_failure__", False) or

--- a/Lib/unittest/result.py
+++ b/Lib/unittest/result.py
@@ -97,12 +97,10 @@ class TestResult(object):
 
             sys.stdout = self._original_stdout
             sys.stderr = self._original_stderr
-            if self._stdout_buffer is not None:
-                self._stdout_buffer.seek(0)
-                self._stdout_buffer.truncate()
-            if self._stderr_buffer is not None:
-                self._stderr_buffer.seek(0)
-                self._stderr_buffer.truncate()
+            self._stdout_buffer.seek(0)
+            self._stdout_buffer.truncate()
+            self._stderr_buffer.seek(0)
+            self._stderr_buffer.truncate()
 
     def stopTestRun(self):
         """Called once after all tests are executed.

--- a/Misc/NEWS.d/next/Library/2024-01-23-11-04-21.gh-issue-113267.xe_Pxe.rst
+++ b/Misc/NEWS.d/next/Library/2024-01-23-11-04-21.gh-issue-113267.xe_Pxe.rst
@@ -1,0 +1,2 @@
+Revert changes in :gh:`106584` which made calls of ``TestResult`` methods
+``startTest()`` and ``stopTest()`` unbalanced.


### PR DESCRIPTION
This reverts commit 8fc071345b50dd3de61ebeeaa287ccef21d061b2.


<!-- gh-issue-number: gh-106584 -->
* Issue: gh-106584
<!-- /gh-issue-number -->


<!-- gh-issue-number: gh-113267 -->
* Issue: gh-113267
<!-- /gh-issue-number -->
