### PR TITLE
gh-114315: Make `threading.Lock` a real class, not a factory function

### DIFF
--- a/Doc/library/threading.rst
+++ b/Doc/library/threading.rst
@@ -535,8 +535,8 @@ All methods are executed atomically.
    thread may release it.
 
    .. versionchanged:: 3.13
-      Prior to 3.13 ``Lock`` actually used to be a factory
-      function which returned an instance
+      ``Lock`` is now a class. In earlier Python versions,
+      ``Lock`` used to be a factory function which returned an instance
       of the most efficient version of the concrete Lock class that is supported
       by the platform.
 

--- a/Doc/library/threading.rst
+++ b/Doc/library/threading.rst
@@ -535,10 +535,9 @@ All methods are executed atomically.
    thread may release it.
 
    .. versionchanged:: 3.13
-      ``Lock`` is now a class. In earlier Python versions,
-      ``Lock`` used to be a factory function which returned an instance
-      of the most efficient version of the concrete Lock class that is supported
-      by the platform.
+      ``Lock`` is now a class. In earlier Pythons, ``Lock`` was a factory
+      function which returned an instance of the underlying private lock
+      type.
 
 
    .. method:: acquire(blocking=True, timeout=-1)

--- a/Doc/library/threading.rst
+++ b/Doc/library/threading.rst
@@ -534,9 +534,11 @@ All methods are executed atomically.
    lock, subsequent attempts to acquire it block, until it is released; any
    thread may release it.
 
-   Note that ``Lock`` is actually a factory function which returns an instance
-   of the most efficient version of the concrete Lock class that is supported
-   by the platform.
+   .. versionchanged:: 3.13
+      Prior to 3.13 ``Lock`` actually used to be a factory
+      function which returned an instance
+      of the most efficient version of the concrete Lock class that is supported
+      by the platform.
 
 
    .. method:: acquire(blocking=True, timeout=-1)

--- a/Lib/test/test_threading.py
+++ b/Lib/test/test_threading.py
@@ -170,11 +170,15 @@ class ThreadTests(BaseTestCase):
                 t.start()
                 t.join()
 
-    @cpython_only
-    def test_disallow_instantiation(self):
-        # Ensure that the type disallows instantiation (bpo-43916)
-        lock = threading.Lock()
-        test.support.check_disallow_instantiation(self, type(lock))
+    def test_lock_no_args(self):
+        threading.Lock()  # works
+        self.assertRaises(TypeError, threading.Lock, 1)
+        self.assertRaises(TypeError, threading.Lock, a=1)
+        self.assertRaises(TypeError, threading.Lock, 1, 2, a=1, b=2)
+
+    def test_lock_or_none(self):
+        import types
+        self.assertIsInstance(threading.Lock | None, types.UnionType)
 
     # Create a bunch of threads, let each do some work, wait until all are
     # done.

--- a/Lib/test/test_threading.py
+++ b/Lib/test/test_threading.py
@@ -176,6 +176,12 @@ class ThreadTests(BaseTestCase):
         self.assertRaises(TypeError, threading.Lock, a=1)
         self.assertRaises(TypeError, threading.Lock, 1, 2, a=1, b=2)
 
+    def test_lock_no_subclass(self):
+        # Intentionally disallow subclasses of threading.Lock because they have
+        # never been allowed, so why start now just because the type is public?
+        with self.assertRaises(TypeError):
+            class MyLock(threading.Lock): pass
+
     def test_lock_or_none(self):
         import types
         self.assertIsInstance(threading.Lock | None, types.UnionType)

--- a/Lib/threading.py
+++ b/Lib/threading.py
@@ -5,7 +5,6 @@ import sys as _sys
 import _thread
 import functools
 import warnings
-import _weakref
 
 from time import monotonic as _time
 from _weakrefset import WeakSet
@@ -108,7 +107,7 @@ def gettrace():
 
 # Synchronization classes
 
-Lock = _allocate_lock
+Lock = type(_allocate_lock())
 
 def RLock(*args, **kwargs):
     """Factory function that returns a new reentrant lock.

--- a/Lib/threading.py
+++ b/Lib/threading.py
@@ -36,6 +36,7 @@ __all__ = ['get_ident', 'active_count', 'Condition', 'current_thread',
 _start_joinable_thread = _thread.start_joinable_thread
 _daemon_threads_allowed = _thread.daemon_threads_allowed
 _allocate_lock = _thread.allocate_lock
+_LockType = _thread.LockType
 _set_sentinel = _thread._set_sentinel
 get_ident = _thread.get_ident
 _is_main_interpreter = _thread._is_main_interpreter
@@ -107,7 +108,7 @@ def gettrace():
 
 # Synchronization classes
 
-Lock = type(_allocate_lock())
+Lock = _LockType
 
 def RLock(*args, **kwargs):
     """Factory function that returns a new reentrant lock.

--- a/Misc/NEWS.d/next/Library/2024-01-23-14-11-49.gh-issue-114315.KeVdzl.rst
+++ b/Misc/NEWS.d/next/Library/2024-01-23-14-11-49.gh-issue-114315.KeVdzl.rst
@@ -1,0 +1,2 @@
+Make :class:`threading.Lock` a real class, not a factory function. Add
+``__new__`` to ``_thread.lock`` type.

--- a/Modules/_threadmodule.c
+++ b/Modules/_threadmodule.c
@@ -1863,10 +1863,6 @@ thread_module_exec(PyObject *module)
     if (state->lock_type == NULL) {
         return -1;
     }
-    if (PyModule_AddType(module, state->lock_type) < 0) {
-        return -1;
-    }
-    // Old alias: lock -> LockType
     if (PyDict_SetItemString(d, "LockType", (PyObject *)state->lock_type) < 0) {
         return -1;
     }

--- a/Modules/_threadmodule.c
+++ b/Modules/_threadmodule.c
@@ -364,9 +364,7 @@ lock_new(PyTypeObject *type, PyObject *args, PyObject *kwargs)
     }
 
     PyObject *module = PyType_GetModuleByDef(type, &thread_module);
-    if (module == NULL) {
-        return NULL;
-    }
+    assert(module != NULL);
     return (PyObject *)newlockobject(module);
 
 error:

--- a/Modules/_threadmodule.c
+++ b/Modules/_threadmodule.c
@@ -5,6 +5,7 @@
 #include "Python.h"
 #include "pycore_interp.h"        // _PyInterpreterState.threads.count
 #include "pycore_moduleobject.h"  // _PyModule_GetState()
+#include "pycore_modsupport.h"    // _PyArg_NoKeywords()
 #include "pycore_pylifecycle.h"
 #include "pycore_pystate.h"       // _PyThreadState_SetCurrent()
 #include "pycore_sysmodule.h"     // _PySys_GetAttr()
@@ -354,11 +355,22 @@ static lockobject *newlockobject(PyObject *module);
 static PyObject *
 lock_new(PyTypeObject *type, PyObject *args, PyObject *kwargs)
 {
+    // convert to AC?
+    if (!_PyArg_NoKeywords("lock", kwargs)) {
+        goto error;
+    }
+    if (!_PyArg_CheckPositional("lock", PyTuple_GET_SIZE(args), 0, 0)) {
+        goto error;
+    }
+
     PyObject *module = PyType_GetModuleByDef(type, &thread_module);
     if (module == NULL) {
         return NULL;
     }
     return (PyObject *)newlockobject(module);
+
+error:
+    return NULL;
 }
 
 

--- a/Modules/_threadmodule.c
+++ b/Modules/_threadmodule.c
@@ -1863,6 +1863,10 @@ thread_module_exec(PyObject *module)
     if (state->lock_type == NULL) {
         return -1;
     }
+    if (PyModule_AddType(module, state->lock_type) < 0) {
+        return -1;
+    }
+    // Old alias: lock -> LockType
     if (PyDict_SetItemString(d, "LockType", (PyObject *)state->lock_type) < 0) {
         return -1;
     }


### PR DESCRIPTION


<!-- gh-issue-number: gh-114315 -->
* Issue: gh-114315
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--114479.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->