### PR TITLE
gh-114492: Initialize struct termios before calling tcgetattr()

### DIFF
--- a/Misc/NEWS.d/next/Library/2024-01-23-21-20-40.gh-issue-114492.vKxl5o.rst
+++ b/Misc/NEWS.d/next/Library/2024-01-23-21-20-40.gh-issue-114492.vKxl5o.rst
@@ -1,0 +1,2 @@
+Make the result of :func:`termios.tcgetattr` reproducible on Alpine Linux.
+Previously it could leave a random garbage in some fields.

--- a/Modules/termios.c
+++ b/Modules/termios.c
@@ -98,6 +98,8 @@ termios_tcgetattr_impl(PyObject *module, int fd)
     struct termios mode;
     int r;
 
+    /* Alpine Linux can leave some fields uninitialized. */
+    memset(&mode, 0, sizeof(mode));
     Py_BEGIN_ALLOW_THREADS
     r = tcgetattr(fd, &mode);
     Py_END_ALLOW_THREADS


### PR DESCRIPTION
On Alpine Linux it could leave some field non-initialized.


<!-- gh-issue-number: gh-114492 -->
* Issue: gh-114492
<!-- /gh-issue-number -->
