### PR TITLE
docs: fix typo in contextlib

### DIFF
--- a/Doc/library/contextlib.rst
+++ b/Doc/library/contextlib.rst
@@ -185,7 +185,7 @@ Functions and classes provided:
    .. note::
 
       Most types managing resources support the :term:`context manager` protocol,
-      which closes *thing* on leaving the :keyword:`with` statment.
+      which closes *thing* on leaving the :keyword:`with` statement.
       As such, :func:`!closing` is most useful for third party types that don't
       support context managers.
       This example is purely for illustration purposes,


### PR DESCRIPTION
Fix a typo in `contextlib` docs in a paragraph that has just been added in #112198 
Should be backported to 3.11 and 3.12, since the corresponding backport PRs have already been merged there as well (#114459, #114458)

I verified that the same typo does not appear anywhere else in the repo with `git grep statment`, and I also ran the `contextlib` through a spellchecker and did not find further issues.

CC @AA-Turner 

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--114507.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->