### PR TITLE
gh-109653: Speedup import of threading module

### DIFF
--- a/Lib/threading.py
+++ b/Lib/threading.py
@@ -1629,9 +1629,7 @@ def _register_atexit(func, *arg, **kwargs):
     if _SHUTTING_DOWN:
         raise RuntimeError("can't register atexit after shutdown")
 
-    import functools
-    call = functools.partial(func, *arg, **kwargs)
-    _threading_atexits.append(call)
+    _threading_atexits.append(lambda: func(*arg, **kwargs))
 
 
 from _thread import stack_size

--- a/Lib/threading.py
+++ b/Lib/threading.py
@@ -3,7 +3,6 @@
 import os as _os
 import sys as _sys
 import _thread
-import functools
 import warnings
 import _weakref
 
@@ -1630,6 +1629,7 @@ def _register_atexit(func, *arg, **kwargs):
     if _SHUTTING_DOWN:
         raise RuntimeError("can't register atexit after shutdown")
 
+    import functools
     call = functools.partial(func, *arg, **kwargs)
     _threading_atexits.append(call)
 

--- a/Misc/NEWS.d/next/Library/2024-01-23-23-13-47.gh-issue-109653.KLBHmT.rst
+++ b/Misc/NEWS.d/next/Library/2024-01-23-23-13-47.gh-issue-109653.KLBHmT.rst
@@ -1,0 +1,1 @@
+Reduce the import time of :mod:`threading` module by ~50%. Patch by Daniel Hollas.


### PR DESCRIPTION
Delayed import of `functools` speeds up the `import threading` by ~50% (2ms -> 1ms) in my testing.

Since the `functools` module is only used in the internal `_register_atexit` function that is called by `concurrent.futures`, this seems like a worthwhile win for users of `threading` module who do not use `asyncio`. 

Part of #109653 

CC @AlexWaygood 

<!-- gh-issue-number: gh-109653 -->
* Issue: gh-109653
<!-- /gh-issue-number -->
