### PR TITLE
gh-101100: Fix sphinx warnings in `concurrent.futures.rst`

### DIFF
--- a/Doc/library/concurrent.futures.rst
+++ b/Doc/library/concurrent.futures.rst
@@ -275,7 +275,8 @@ to a :class:`ProcessPoolExecutor` will result in deadlock.
 
    .. versionchanged:: 3.3
       When one of the worker processes terminates abruptly, a
-      :exc:`BrokenProcessPool` error is now raised.  Previously, behaviour
+      :exc:`~concurrent.futures.process.BrokenProcessPool` error is now raised.
+      Previously, behaviour
       was undefined but operations on the executor or its futures would often
       freeze or deadlock.
 
@@ -493,23 +494,22 @@ Module Functions
    *return_when* indicates when this function should return.  It must be one of
    the following constants:
 
-   .. tabularcolumns:: |l|L|
+   .. list-table::
+      :header-rows: 1
 
-   +-----------------------------+----------------------------------------+
-   | Constant                    | Description                            |
-   +=============================+========================================+
-   | :const:`FIRST_COMPLETED`    | The function will return when any      |
-   |                             | future finishes or is cancelled.       |
-   +-----------------------------+----------------------------------------+
-   | :const:`FIRST_EXCEPTION`    | The function will return when any      |
-   |                             | future finishes by raising an          |
-   |                             | exception.  If no future raises an     |
-   |                             | exception then it is equivalent to     |
-   |                             | :const:`ALL_COMPLETED`.                |
-   +-----------------------------+----------------------------------------+
-   | :const:`ALL_COMPLETED`      | The function will return when all      |
-   |                             | futures finish or are cancelled.       |
-   +-----------------------------+----------------------------------------+
+      * - Constant
+        - Description
+
+      * - .. data:: FIRST_COMPLETED
+        - The function will return when any future finishes or is cancelled.
+
+      * - .. data:: FIRST_EXCEPTION
+        - The function will return when any future finishes by raising an
+          exception. If no future raises an exception
+          then it is equivalent to :const:`ALL_COMPLETED`.
+
+      * - .. data:: ALL_COMPLETED
+        - The function will return when all futures finish or are cancelled.
 
 .. function:: as_completed(fs, timeout=None)
 
@@ -570,7 +570,8 @@ Exception classes
 .. exception:: BrokenThreadPool
 
    Derived from :exc:`~concurrent.futures.BrokenExecutor`, this exception
-   class is raised when one of the workers of a :class:`ThreadPoolExecutor`
+   class is raised when one of the workers
+   of a :class:`~concurrent.futures.ThreadPoolExecutor`
    has failed initializing.
 
    .. versionadded:: 3.7
@@ -581,7 +582,8 @@ Exception classes
 
    Derived from :exc:`~concurrent.futures.BrokenExecutor` (formerly
    :exc:`RuntimeError`), this exception class is raised when one of the
-   workers of a :class:`ProcessPoolExecutor` has terminated in a non-clean
+   workers of a :class:`~concurrent.futures.ProcessPoolExecutor`
+   has terminated in a non-clean
    fashion (for example, if it was killed from the outside).
 
    .. versionadded:: 3.3

--- a/Doc/tools/.nitignore
+++ b/Doc/tools/.nitignore
@@ -29,7 +29,6 @@ Doc/library/asyncio-policy.rst
 Doc/library/asyncio-subprocess.rst
 Doc/library/bdb.rst
 Doc/library/collections.rst
-Doc/library/concurrent.futures.rst
 Doc/library/csv.rst
 Doc/library/datetime.rst
 Doc/library/dbm.rst


### PR DESCRIPTION
Errors fixed:

```
/Users/sobolev/Desktop/cpython2/Doc/library/concurrent.futures.rst:277: WARNING: py:exc reference target not found: BrokenProcessPool
/Users/sobolev/Desktop/cpython2/Doc/library/concurrent.futures.rst:502: WARNING: py:const reference target not found: FIRST_COMPLETED
/Users/sobolev/Desktop/cpython2/Doc/library/concurrent.futures.rst:505: WARNING: py:const reference target not found: FIRST_EXCEPTION
/Users/sobolev/Desktop/cpython2/Doc/library/concurrent.futures.rst:505: WARNING: py:const reference target not found: ALL_COMPLETED
/Users/sobolev/Desktop/cpython2/Doc/library/concurrent.futures.rst:511: WARNING: py:const reference target not found: ALL_COMPLETED
/Users/sobolev/Desktop/cpython2/Doc/library/concurrent.futures.rst:572: WARNING: py:class reference target not found: ThreadPoolExecutor
/Users/sobolev/Desktop/cpython2/Doc/library/concurrent.futures.rst:582: WARNING: py:class reference target not found: ProcessPoolExecutor
```

Refs https://github.com/python/cpython/pull/114469

<!-- gh-issue-number: gh-101100 -->
* Issue: gh-101100
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--114521.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->