### PR TITLE
[3.12] gh-101100: Fix sphinx warnings in `concurrent.futures.rst` (GH-114521)

### DIFF
--- a/Doc/library/concurrent.futures.rst
+++ b/Doc/library/concurrent.futures.rst
@@ -271,7 +271,8 @@ to a :class:`ProcessPoolExecutor` will result in deadlock.
 
    .. versionchanged:: 3.3
       When one of the worker processes terminates abruptly, a
-      :exc:`BrokenProcessPool` error is now raised.  Previously, behaviour
+      :exc:`~concurrent.futures.process.BrokenProcessPool` error is now raised.
+      Previously, behaviour
       was undefined but operations on the executor or its futures would often
       freeze or deadlock.
 
@@ -485,23 +486,22 @@ Module Functions
    *return_when* indicates when this function should return.  It must be one of
    the following constants:
 
-   .. tabularcolumns:: |l|L|
+   .. list-table::
+      :header-rows: 1
 
-   +-----------------------------+----------------------------------------+
-   | Constant                    | Description                            |
-   +=============================+========================================+
-   | :const:`FIRST_COMPLETED`    | The function will return when any      |
-   |                             | future finishes or is cancelled.       |
-   +-----------------------------+----------------------------------------+
-   | :const:`FIRST_EXCEPTION`    | The function will return when any      |
-   |                             | future finishes by raising an          |
-   |                             | exception.  If no future raises an     |
-   |                             | exception then it is equivalent to     |
-   |                             | :const:`ALL_COMPLETED`.                |
-   +-----------------------------+----------------------------------------+
-   | :const:`ALL_COMPLETED`      | The function will return when all      |
-   |                             | futures finish or are cancelled.       |
-   +-----------------------------+----------------------------------------+
+      * - Constant
+        - Description
+
+      * - .. data:: FIRST_COMPLETED
+        - The function will return when any future finishes or is cancelled.
+
+      * - .. data:: FIRST_EXCEPTION
+        - The function will return when any future finishes by raising an
+          exception. If no future raises an exception
+          then it is equivalent to :const:`ALL_COMPLETED`.
+
+      * - .. data:: ALL_COMPLETED
+        - The function will return when all futures finish or are cancelled.
 
 .. function:: as_completed(fs, timeout=None)
 
@@ -562,7 +562,8 @@ Exception classes
 .. exception:: BrokenThreadPool
 
    Derived from :exc:`~concurrent.futures.BrokenExecutor`, this exception
-   class is raised when one of the workers of a :class:`ThreadPoolExecutor`
+   class is raised when one of the workers
+   of a :class:`~concurrent.futures.ThreadPoolExecutor`
    has failed initializing.
 
    .. versionadded:: 3.7
@@ -573,7 +574,8 @@ Exception classes
 
    Derived from :exc:`~concurrent.futures.BrokenExecutor` (formerly
    :exc:`RuntimeError`), this exception class is raised when one of the
-   workers of a :class:`ProcessPoolExecutor` has terminated in a non-clean
+   workers of a :class:`~concurrent.futures.ProcessPoolExecutor`
+   has terminated in a non-clean
    fashion (for example, if it was killed from the outside).
 
    .. versionadded:: 3.3

--- a/Doc/tools/.nitignore
+++ b/Doc/tools/.nitignore
@@ -35,7 +35,6 @@ Doc/library/bdb.rst
 Doc/library/cgi.rst
 Doc/library/chunk.rst
 Doc/library/collections.rst
-Doc/library/concurrent.futures.rst
 Doc/library/copy.rst
 Doc/library/csv.rst
 Doc/library/datetime.rst


### PR DESCRIPTION


(cherry picked from commit 8744ecf5896ccf57875574a9aed46369b8d48dc1)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-101100 -->
* Issue: gh-101100
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--114525.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->