### PR TITLE
gh-101100: Fix Sphinx warnings in `whatsnew/3.11.rst` and related

### DIFF
--- a/Doc/tools/.nitignore
+++ b/Doc/tools/.nitignore
@@ -111,3 +111,4 @@ Doc/whatsnew/3.7.rst
 Doc/whatsnew/3.8.rst
 Doc/whatsnew/3.9.rst
 Doc/whatsnew/3.10.rst
+Doc/whatsnew/3.11.rst

--- a/Doc/tools/.nitignore
+++ b/Doc/tools/.nitignore
@@ -111,4 +111,3 @@ Doc/whatsnew/3.7.rst
 Doc/whatsnew/3.8.rst
 Doc/whatsnew/3.9.rst
 Doc/whatsnew/3.10.rst
-Doc/whatsnew/3.11.rst

--- a/Doc/whatsnew/2.7.rst
+++ b/Doc/whatsnew/2.7.rst
@@ -2130,7 +2130,7 @@ Changes to Python's build process and to the C API include:
   only the filename, function name, and first line number are required.
   This is useful for extension modules that are attempting to
   construct a more useful traceback stack.  Previously such
-  extensions needed to call :c:func:`PyCode_New`, which had many
+  extensions needed to call :c:func:`!PyCode_New`, which had many
   more arguments.  (Added by Jeffrey Yasskin.)
 
 * New function: :c:func:`PyErr_NewExceptionWithDoc` creates a new

--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -1278,7 +1278,7 @@ This section covers specific optimizations independent of the
   (Contributed by Stefan Behnel in :gh:`68264`.)
 
 * Resizing lists is streamlined for the common case,
-  speeding up :meth:`!list.append` by ≈15%
+  speeding up :meth:`list.append` by ≈15%
   and simple :term:`list comprehension`\s by up to 20-30%
   (Contributed by Dennis Sweeney in :gh:`91165`.)
 

--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -672,7 +672,7 @@ enum
 
 * Changed :meth:`Enum.__format__() <enum.Enum.__format__>` (the default for
   :func:`format`, :meth:`str.format` and :term:`f-string`\s) to always produce
-  the same result as :meth:`Enum.__str__()`:  for enums inheriting from
+  the same result as :meth:`Enum.__str__() <enum.Enum.__str__>`:  for enums inheriting from
   :class:`~enum.ReprEnum` it will be the member's value; for all other enums
   it will be the enum and member name (e.g. ``Color.RED``).
 
@@ -1278,7 +1278,7 @@ This section covers specific optimizations independent of the
   (Contributed by Stefan Behnel in :gh:`68264`.)
 
 * Resizing lists is streamlined for the common case,
-  speeding up :meth:`list.append` by ≈15%
+  speeding up :meth:`!list.append` by ≈15%
   and simple :term:`list comprehension`\s by up to 20-30%
   (Contributed by Dennis Sweeney in :gh:`91165`.)
 
@@ -1604,7 +1604,7 @@ raw, adaptive bytecode containing quickened data.
 New opcodes
 -----------
 
-* :opcode:`ASYNC_GEN_WRAP`, :opcode:`RETURN_GENERATOR` and :opcode:`SEND`,
+* :opcode:`!ASYNC_GEN_WRAP`, :opcode:`RETURN_GENERATOR` and :opcode:`SEND`,
   used in generators and co-routines.
 
 * :opcode:`COPY_FREE_VARS`,
@@ -1615,7 +1615,7 @@ New opcodes
 
 * :opcode:`MAKE_CELL`, to create :ref:`cell-objects`.
 
-* :opcode:`CHECK_EG_MATCH`  and  :opcode:`PREP_RERAISE_STAR`,
+* :opcode:`CHECK_EG_MATCH`  and  :opcode:`!PREP_RERAISE_STAR`,
   to handle the :ref:`new exception groups and except* <whatsnew311-pep654>`
   added in :pep:`654`.
 
@@ -1630,38 +1630,38 @@ New opcodes
 Replaced opcodes
 ----------------
 
-+------------------------------------+-----------------------------------+-----------------------------------------+
-| Replaced Opcode(s)                 | New Opcode(s)                     | Notes                                   |
-+====================================+===================================+=========================================+
-| | :opcode:`!BINARY_*`              | :opcode:`BINARY_OP`               | Replaced all numeric binary/in-place    |
-| | :opcode:`!INPLACE_*`             |                                   | opcodes with a single opcode            |
-+------------------------------------+-----------------------------------+-----------------------------------------+
-| | :opcode:`!CALL_FUNCTION`         | | :opcode:`CALL`                  | Decouples argument shifting for methods |
-| | :opcode:`!CALL_FUNCTION_KW`      | | :opcode:`KW_NAMES`              | from handling of keyword arguments;     |
-| | :opcode:`!CALL_METHOD`           | | :opcode:`PRECALL`               | allows better specialization of calls   |
-|                                    | | :opcode:`PUSH_NULL`             |                                         |
-+------------------------------------+-----------------------------------+-----------------------------------------+
-| | :opcode:`!DUP_TOP`               | | :opcode:`COPY`                  | Stack manipulation instructions         |
-| | :opcode:`!DUP_TOP_TWO`           | | :opcode:`SWAP`                  |                                         |
-| | :opcode:`!ROT_TWO`               |                                   |                                         |
-| | :opcode:`!ROT_THREE`             |                                   |                                         |
-| | :opcode:`!ROT_FOUR`              |                                   |                                         |
-| | :opcode:`!ROT_N`                 |                                   |                                         |
-+------------------------------------+-----------------------------------+-----------------------------------------+
-| | :opcode:`!JUMP_IF_NOT_EXC_MATCH` | | :opcode:`CHECK_EXC_MATCH`       | Now performs check but doesn't jump     |
-+------------------------------------+-----------------------------------+-----------------------------------------+
-| | :opcode:`!JUMP_ABSOLUTE`         | | :opcode:`JUMP_BACKWARD`         | See [#bytecode-jump]_;                  |
-| | :opcode:`!POP_JUMP_IF_FALSE`     | | :opcode:`POP_JUMP_BACKWARD_IF_* | ``TRUE``, ``FALSE``,                    |
-| | :opcode:`!POP_JUMP_IF_TRUE`      |   <POP_JUMP_BACKWARD_IF_TRUE>`    | ``NONE`` and ``NOT_NONE`` variants      |
-|                                    | | :opcode:`POP_JUMP_FORWARD_IF_*  | for each direction                      |
-|                                    |   <POP_JUMP_FORWARD_IF_TRUE>`     |                                         |
-+------------------------------------+-----------------------------------+-----------------------------------------+
-| | :opcode:`!SETUP_WITH`            | :opcode:`BEFORE_WITH`             | :keyword:`with` block setup             |
-| | :opcode:`!SETUP_ASYNC_WITH`      |                                   |                                         |
-+------------------------------------+-----------------------------------+-----------------------------------------+
++------------------------------------+------------------------------------+-----------------------------------------+
+| Replaced Opcode(s)                 | New Opcode(s)                      | Notes                                   |
++====================================+====================================+=========================================+
+| | :opcode:`!BINARY_*`              | :opcode:`BINARY_OP`                | Replaced all numeric binary/in-place    |
+| | :opcode:`!INPLACE_*`             |                                    | opcodes with a single opcode            |
++------------------------------------+------------------------------------+-----------------------------------------+
+| | :opcode:`!CALL_FUNCTION`         | | :opcode:`CALL`                   | Decouples argument shifting for methods |
+| | :opcode:`!CALL_FUNCTION_KW`      | | :opcode:`!KW_NAMES`              | from handling of keyword arguments;     |
+| | :opcode:`!CALL_METHOD`           | | :opcode:`!PRECALL`               | allows better specialization of calls   |
+|                                    | | :opcode:`PUSH_NULL`              |                                         |
++------------------------------------+------------------------------------+-----------------------------------------+
+| | :opcode:`!DUP_TOP`               | | :opcode:`COPY`                   | Stack manipulation instructions         |
+| | :opcode:`!DUP_TOP_TWO`           | | :opcode:`SWAP`                   |                                         |
+| | :opcode:`!ROT_TWO`               |                                    |                                         |
+| | :opcode:`!ROT_THREE`             |                                    |                                         |
+| | :opcode:`!ROT_FOUR`              |                                    |                                         |
+| | :opcode:`!ROT_N`                 |                                    |                                         |
++------------------------------------+------------------------------------+-----------------------------------------+
+| | :opcode:`!JUMP_IF_NOT_EXC_MATCH` | | :opcode:`CHECK_EXC_MATCH`        | Now performs check but doesn't jump     |
++------------------------------------+------------------------------------+-----------------------------------------+
+| | :opcode:`!JUMP_ABSOLUTE`         | | :opcode:`JUMP_BACKWARD`          | See [#bytecode-jump]_;                  |
+| | :opcode:`!POP_JUMP_IF_FALSE`     | | :opcode:`!POP_JUMP_BACKWARD_IF_*`| ``TRUE``, ``FALSE``,                    |
+| | :opcode:`!POP_JUMP_IF_TRUE`      | | :opcode:`!POP_JUMP_FORWARD_IF_*` | ``NONE`` and ``NOT_NONE`` variants      |
+|                                    |                                    | for each direction                      |
+|                                    |                                    |                                         |
++------------------------------------+------------------------------------+-----------------------------------------+
+| | :opcode:`!SETUP_WITH`            | :opcode:`BEFORE_WITH`              | :keyword:`with` block setup             |
+| | :opcode:`!SETUP_ASYNC_WITH`      |                                    |                                         |
++------------------------------------+------------------------------------+-----------------------------------------+
 
 .. [#bytecode-jump] All jump opcodes are now relative, including the
-   existing :opcode:`JUMP_IF_TRUE_OR_POP` and :opcode:`JUMP_IF_FALSE_OR_POP`.
+   existing :opcode:`!JUMP_IF_TRUE_OR_POP` and :opcode:`!JUMP_IF_FALSE_OR_POP`.
    The argument is now an offset from the current instruction
    rather than an absolute location.
 
@@ -1789,13 +1789,13 @@ Standard Library
   and will be removed in a future Python version,
   due to not supporting resources located within package subdirectories:
 
-  * :func:`importlib.resources.contents`
-  * :func:`importlib.resources.is_resource`
-  * :func:`importlib.resources.open_binary`
-  * :func:`importlib.resources.open_text`
-  * :func:`importlib.resources.read_binary`
-  * :func:`importlib.resources.read_text`
-  * :func:`importlib.resources.path`
+  * :func:`!importlib.resources.contents`
+  * :func:`!importlib.resources.is_resource`
+  * :func:`!importlib.resources.open_binary`
+  * :func:`!importlib.resources.open_text`
+  * :func:`!importlib.resources.read_binary`
+  * :func:`!importlib.resources.read_text`
+  * :func:`!importlib.resources.path`
 
 * The :func:`locale.getdefaultlocale` function is deprecated and will be
   removed in Python 3.15. Use :func:`locale.setlocale`,
@@ -1803,7 +1803,7 @@ Standard Library
   :func:`locale.getlocale` functions instead.
   (Contributed by Victor Stinner in :gh:`90817`.)
 
-* The :func:`locale.resetlocale` function is deprecated and will be
+* The :func:`!locale.resetlocale` function is deprecated and will be
   removed in Python 3.13. Use ``locale.setlocale(locale.LC_ALL, "")`` instead.
   (Contributed by Victor Stinner in :gh:`90817`.)
 
@@ -1967,7 +1967,7 @@ Removed C APIs are :ref:`listed separately <whatsnew311-c-api-removed>`.
 
   (Contributed by Victor Stinner in :issue:`45085`.)
 
-* Removed the :mod:`distutils` ``bdist_msi`` command deprecated in Python 3.9.
+* Removed the :mod:`!distutils` ``bdist_msi`` command deprecated in Python 3.9.
   Use ``bdist_wheel`` (wheel packages) instead.
   (Contributed by Hugo van Kemenade in :issue:`45124`.)
 
@@ -2295,7 +2295,7 @@ Porting to Python 3.11
   as its second parameter, instead of ``PyFrameObject*``.
   See :pep:`523` for more details of how to use this function pointer type.
 
-* :c:func:`PyCode_New` and :c:func:`PyCode_NewWithPosOnlyArgs` now take
+* :c:func:`!PyCode_New` and :c:func:`!PyCode_NewWithPosOnlyArgs` now take
   an additional ``exception_table`` argument.
   Using these functions should be avoided, if at all possible.
   To get a custom code object: create a code object using the compiler,
@@ -2402,7 +2402,7 @@ Porting to Python 3.11
   been included directly, consider including ``Python.h`` instead.
   (Contributed by Victor Stinner in :issue:`35134`.)
 
-* The :c:func:`PyUnicode_CHECK_INTERNED` macro has been excluded from the
+* The :c:func:`!PyUnicode_CHECK_INTERNED` macro has been excluded from the
   limited C API. It was never usable there, because it used internal structures
   which are not available in the limited C API.
   (Contributed by Victor Stinner in :issue:`46007`.)
@@ -2465,7 +2465,7 @@ Porting to Python 3.11
 
   Debuggers that accessed the :attr:`~frame.f_locals` directly *must* call
   :c:func:`PyFrame_GetLocals` instead. They no longer need to call
-  :c:func:`PyFrame_FastToLocalsWithError` or :c:func:`PyFrame_LocalsToFast`,
+  :c:func:`!PyFrame_FastToLocalsWithError` or :c:func:`!PyFrame_LocalsToFast`,
   in fact they should not call those functions. The necessary updating of the
   frame is now managed by the virtual machine.
 
@@ -2604,8 +2604,8 @@ and will be removed in Python 3.12.
 * :c:func:`!PyUnicode_GET_DATA_SIZE`
 * :c:func:`!PyUnicode_GET_SIZE`
 * :c:func:`!PyUnicode_GetSize`
-* :c:func:`PyUnicode_IS_COMPACT`
-* :c:func:`PyUnicode_IS_READY`
+* :c:func:`!PyUnicode_IS_COMPACT`
+* :c:func:`!PyUnicode_IS_READY`
 * :c:func:`PyUnicode_READY`
 * :c:func:`!PyUnicode_WSTR_LENGTH`
 * :c:func:`!_PyUnicode_AsUnicode`
@@ -2660,7 +2660,7 @@ Removed
   (Contributed by Victor Stinner in :issue:`45474`.)
 
 * Exclude :c:func:`PyWeakref_GET_OBJECT` from the limited C API. It never
-  worked since the :c:type:`PyWeakReference` structure is opaque in the
+  worked since the :c:type:`!PyWeakReference` structure is opaque in the
   limited C API.
   (Contributed by Victor Stinner in :issue:`35134`.)
 

--- a/Doc/whatsnew/3.8.rst
+++ b/Doc/whatsnew/3.8.rst
@@ -1623,8 +1623,8 @@ Build and C API Changes
   allocation or deallocation may need to be adjusted.
   (Contributed by Eddie Elizondo in :issue:`35810`.)
 
-* The new function :c:func:`PyCode_NewWithPosOnlyArgs` allows to create
-  code objects like :c:func:`PyCode_New`, but with an extra *posonlyargcount*
+* The new function :c:func:`!PyCode_NewWithPosOnlyArgs` allows to create
+  code objects like :c:func:`!PyCode_New`, but with an extra *posonlyargcount*
   parameter for indicating the number of positional-only arguments.
   (Contributed by Pablo Galindo in :issue:`37221`.)
 

--- a/Misc/NEWS.d/3.11.0a2.rst
+++ b/Misc/NEWS.d/3.11.0a2.rst
@@ -1189,7 +1189,7 @@ context objects can now be disabled.
 .. section: C API
 
 Exclude :c:func:`PyWeakref_GET_OBJECT` from the limited C API. It never
-worked since the :c:type:`PyWeakReference` structure is opaque in the
+worked since the :c:type:`!PyWeakReference` structure is opaque in the
 limited C API.
 
 ..

--- a/Misc/NEWS.d/3.11.0a4.rst
+++ b/Misc/NEWS.d/3.11.0a4.rst
@@ -161,7 +161,7 @@ faster due to reference-counting optimizations. Patch by Dennis Sweeney.
 .. nonce: 7oGp-I
 .. section: Core and Builtins
 
-:opcode:`PREP_RERAISE_STAR` no longer pushes ``lasti`` to the stack.
+:opcode:`!PREP_RERAISE_STAR` no longer pushes ``lasti`` to the stack.
 
 ..
 
@@ -170,7 +170,7 @@ faster due to reference-counting optimizations. Patch by Dennis Sweeney.
 .. nonce: IKx4v6
 .. section: Core and Builtins
 
-Remove :opcode:`POP_EXCEPT_AND_RERAISE` and replace it by an equivalent
+Remove :opcode:`!POP_EXCEPT_AND_RERAISE` and replace it by an equivalent
 sequence of other opcodes.
 
 ..
@@ -1171,7 +1171,7 @@ Replaced deprecated usage of :c:func:`PyImport_ImportModuleNoBlock` with
 .. nonce: sMgDLz
 .. section: C API
 
-The :c:func:`PyUnicode_CHECK_INTERNED` macro has been excluded from the
+The :c:func:`!PyUnicode_CHECK_INTERNED` macro has been excluded from the
 limited C API. It was never usable there, because it used internal
 structures which are not available in the limited C API. Patch by Victor
 Stinner.

--- a/Misc/NEWS.d/3.11.0a6.rst
+++ b/Misc/NEWS.d/3.11.0a6.rst
@@ -248,7 +248,7 @@ Don't un-adapt :opcode:`COMPARE_OP` when collecting specialization stats.
 .. nonce: RX_AzJ
 .. section: Core and Builtins
 
-Fix specialization stats gathering for :opcode:`PRECALL` instructions.
+Fix specialization stats gathering for :opcode:`!PRECALL` instructions.
 
 ..
 

--- a/Misc/NEWS.d/3.11.0a7.rst
+++ b/Misc/NEWS.d/3.11.0a7.rst
@@ -138,7 +138,7 @@ Replaced :opcode:`JUMP_ABSOLUTE` by the relative jump
 .. nonce: SwrrFO
 .. section: Core and Builtins
 
-:c:func:`PyFrame_FastToLocalsWithError` and :c:func:`PyFrame_LocalsToFast`
+:c:func:`!PyFrame_FastToLocalsWithError` and :c:func:`!PyFrame_LocalsToFast`
 are no longer called during profiling nor tracing. C code can access the
 ``f_locals`` attribute of :c:type:`PyFrameObject` by calling
 :c:func:`PyFrame_GetLocals`.
@@ -295,7 +295,7 @@ oparg) as an adaptive counter.
 .. nonce: O12Pba
 .. section: Core and Builtins
 
-Use inline caching for :opcode:`PRECALL` and :opcode:`CALL`, and remove the
+Use inline caching for :opcode:`!PRECALL` and :opcode:`CALL`, and remove the
 internal machinery for managing the (now unused) non-inline caches.
 
 ..

--- a/Misc/NEWS.d/3.11.0b1.rst
+++ b/Misc/NEWS.d/3.11.0b1.rst
@@ -403,8 +403,8 @@ so this led to crashes. The problem is now fixed.
 .. nonce: 6S_uoU
 .. section: Core and Builtins
 
-Make opcodes :opcode:`JUMP_IF_TRUE_OR_POP` and
-:opcode:`JUMP_IF_FALSE_OR_POP` relative rather than absolute.
+Make opcodes :opcode:`!JUMP_IF_TRUE_OR_POP` and
+:opcode:`!JUMP_IF_FALSE_OR_POP` relative rather than absolute.
 
 ..
 

--- a/Misc/NEWS.d/3.12.0a4.rst
+++ b/Misc/NEWS.d/3.12.0a4.rst
@@ -13,8 +13,8 @@ Fix misleading default value in :func:`input`'s ``__text_signature__``.
 .. nonce: cmGwxv
 .. section: Core and Builtins
 
-Remove :opcode:`UNARY_POSITIVE`, :opcode:`ASYNC_GEN_WRAP` and
-:opcode:`LIST_TO_TUPLE`, replacing them with intrinsics.
+Remove :opcode:`!UNARY_POSITIVE`, :opcode:`!ASYNC_GEN_WRAP` and
+:opcode:`!LIST_TO_TUPLE`, replacing them with intrinsics.
 
 ..
 

--- a/Misc/NEWS.d/3.12.0a6.rst
+++ b/Misc/NEWS.d/3.12.0a6.rst
@@ -170,7 +170,7 @@ all as not all platform C libraries generate an error.
 .. section: Core and Builtins
 
 Add :opcode:`CALL_INTRINSIC_2` and use it instead of
-:opcode:`PREP_RERAISE_STAR`.
+:opcode:`!PREP_RERAISE_STAR`.
 
 ..
 

--- a/Misc/NEWS.d/3.12.0a7.rst
+++ b/Misc/NEWS.d/3.12.0a7.rst
@@ -24,7 +24,7 @@ Reduce the number of inline :opcode:`CACHE` entries for
 .. nonce: PRkGca
 .. section: Core and Builtins
 
-Removed :opcode:`JUMP_IF_FALSE_OR_POP` and :opcode:`JUMP_IF_TRUE_OR_POP`
+Removed :opcode:`!JUMP_IF_FALSE_OR_POP` and :opcode:`!JUMP_IF_TRUE_OR_POP`
 instructions.
 
 ..

--- a/Misc/NEWS.d/3.12.0b1.rst
+++ b/Misc/NEWS.d/3.12.0b1.rst
@@ -1008,7 +1008,7 @@ Update the bundled copy of pip to version 23.1.2.
 .. nonce: pst8iT
 .. section: Library
 
-Make :mod:`dis` display the value of oparg of :opcode:`KW_NAMES`.
+Make :mod:`dis` display the value of oparg of :opcode:`!KW_NAMES`.
 
 ..
 

--- a/Misc/NEWS.d/3.8.0a1.rst
+++ b/Misc/NEWS.d/3.8.0a1.rst
@@ -3395,8 +3395,8 @@ Zackery Spytz.
 .. nonce: S0Irst
 .. section: Library
 
-Fix parsing non-ASCII identifiers in :mod:`lib2to3.pgen2.tokenize` (PEP
-3131).
+Fix parsing non-ASCII identifiers in :mod:`!lib2to3.pgen2.tokenize`
+(:pep:`3131`).
 
 ..
 

--- a/Misc/NEWS.d/3.9.0a1.rst
+++ b/Misc/NEWS.d/3.9.0a1.rst
@@ -5715,8 +5715,8 @@ The :c:macro:`METH_FASTCALL` calling convention has been documented.
 .. nonce: 4tClQT
 .. section: C API
 
-The new function :c:func:`PyCode_NewWithPosOnlyArgs` allows to create code
-objects like :c:func:`PyCode_New`, but with an extra *posonlyargcount*
+The new function :c:func:`!PyCode_NewWithPosOnlyArgs` allows to create code
+objects like :c:func:`!PyCode_New`, but with an extra *posonlyargcount*
 parameter for indicating the number of positonal-only arguments.
 
 ..

--- a/Misc/NEWS.d/3.9.0a5.rst
+++ b/Misc/NEWS.d/3.9.0a5.rst
@@ -1122,7 +1122,7 @@ a different condition than the GIL.
 .. nonce: Nbl7lF
 .. section: Tools/Demos
 
-Added support to fix ``getproxies`` in the :mod:`lib2to3.fixes.fix_urllib`
+Added support to fix ``getproxies`` in the :mod:`!lib2to3.fixes.fix_urllib`
 module. Patch by José Roberto Meza Cabrera.
 
 ..


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

Fix 51 warnings, mainly removals or renames.

```
Doc/whatsnew/2.7.rst:2129: WARNING: c:func reference target not found: PyCode_New
Doc/whatsnew/3.11.rst:673: WARNING: py:meth reference target not found: Enum.__str__
Doc/whatsnew/3.11.rst:1280: WARNING: py:meth reference target not found: list.append
Doc/whatsnew/3.11.rst:1607: WARNING: 'opcode' reference target not found: ASYNC_GEN_WRAP
Doc/whatsnew/3.11.rst:1618: WARNING: 'opcode' reference target not found: PREP_RERAISE_STAR
Doc/whatsnew/3.11.rst:1641: WARNING: 'opcode' reference target not found: KW_NAMES
Doc/whatsnew/3.11.rst:1642: WARNING: 'opcode' reference target not found: PRECALL
Doc/whatsnew/3.11.rst:1655: WARNING: 'opcode' reference target not found: POP_JUMP_BACKWARD_IF_TRUE
Doc/whatsnew/3.11.rst:1657: WARNING: 'opcode' reference target not found: POP_JUMP_FORWARD_IF_TRUE
Doc/whatsnew/3.11.rst:1663: WARNING: 'opcode' reference target not found: JUMP_IF_TRUE_OR_POP
Doc/whatsnew/3.11.rst:1663: WARNING: 'opcode' reference target not found: JUMP_IF_FALSE_OR_POP
Doc/whatsnew/3.11.rst:1792: WARNING: py:func reference target not found: importlib.resources.contents
Doc/whatsnew/3.11.rst:1793: WARNING: py:func reference target not found: importlib.resources.is_resource
Doc/whatsnew/3.11.rst:1794: WARNING: py:func reference target not found: importlib.resources.open_binary
Doc/whatsnew/3.11.rst:1795: WARNING: py:func reference target not found: importlib.resources.open_text
Doc/whatsnew/3.11.rst:1796: WARNING: py:func reference target not found: importlib.resources.read_binary
Doc/whatsnew/3.11.rst:1797: WARNING: py:func reference target not found: importlib.resources.read_text
Doc/whatsnew/3.11.rst:1798: WARNING: py:func reference target not found: importlib.resources.path
Doc/whatsnew/3.11.rst:1806: WARNING: py:func reference target not found: locale.resetlocale
Doc/whatsnew/3.11.rst:1970: WARNING: py:mod reference target not found: distutils
Doc/whatsnew/3.11.rst:2298: WARNING: c:func reference target not found: PyCode_New
Doc/whatsnew/3.11.rst:2298: WARNING: c:func reference target not found: PyCode_NewWithPosOnlyArgs
Doc/whatsnew/3.11.rst:2405: WARNING: c:func reference target not found: PyUnicode_CHECK_INTERNED
Doc/whatsnew/3.11.rst:2466: WARNING: c:func reference target not found: PyFrame_FastToLocalsWithError
Doc/whatsnew/3.11.rst:2466: WARNING: c:func reference target not found: PyFrame_LocalsToFast
Doc/whatsnew/3.11.rst:2607: WARNING: c:func reference target not found: PyUnicode_IS_COMPACT
Doc/whatsnew/3.11.rst:2608: WARNING: c:func reference target not found: PyUnicode_IS_READY
Doc/whatsnew/3.11.rst:2662: WARNING: c:type reference target not found: PyWeakReference
Doc/whatsnew/3.8.rst:1626: WARNING: c:func reference target not found: PyCode_NewWithPosOnlyArgs
Doc/whatsnew/3.8.rst:1626: WARNING: c:func reference target not found: PyCode_New
build/NEWS:4617: WARNING: 'opcode' reference target not found: KW_NAMES
build/NEWS:5158: WARNING: 'opcode' reference target not found: JUMP_IF_FALSE_OR_POP
build/NEWS:5158: WARNING: 'opcode' reference target not found: JUMP_IF_TRUE_OR_POP
build/NEWS:5508: WARNING: 'opcode' reference target not found: PREP_RERAISE_STAR
build/NEWS:6036: WARNING: 'opcode' reference target not found: UNARY_POSITIVE
build/NEWS:6036: WARNING: 'opcode' reference target not found: ASYNC_GEN_WRAP
build/NEWS:6036: WARNING: 'opcode' reference target not found: LIST_TO_TUPLE
build/NEWS:9676: WARNING: 'opcode' reference target not found: JUMP_IF_TRUE_OR_POP
build/NEWS:9676: WARNING: 'opcode' reference target not found: JUMP_IF_FALSE_OR_POP
build/NEWS:10343: WARNING: c:func reference target not found: PyFrame_FastToLocalsWithError
build/NEWS:10343: WARNING: c:func reference target not found: PyFrame_LocalsToFast
build/NEWS:10396: WARNING: 'opcode' reference target not found: PRECALL
build/NEWS:10968: WARNING: 'opcode' reference target not found: PRECALL
build/NEWS:11773: WARNING: 'opcode' reference target not found: PREP_RERAISE_STAR
build/NEWS:11776: WARNING: 'opcode' reference target not found: POP_EXCEPT_AND_RERAISE
build/NEWS:12139: WARNING: c:func reference target not found: PyUnicode_CHECK_INTERNED
build/NEWS:13083: WARNING: c:type reference target not found: PyWeakReference
build/NEWS:20372: WARNING: py:mod reference target not found: lib2to3.fixes.fix_urllib
build/NEWS:23463: WARNING: c:func reference target not found: PyCode_NewWithPosOnlyArgs
build/NEWS:23463: WARNING: c:func reference target not found: PyCode_New
build/NEWS:26488: WARNING: py:mod reference target not found: lib2to3.pgen2.tokenize
```


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--114531.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->

<!-- gh-issue-number: gh-101100 -->
* Issue: gh-101100
<!-- /gh-issue-number -->
