### PR TITLE
[3.12] gh-114480: Add docs for f_trace_opcodes behavior on 3.12

### DIFF
--- a/Doc/library/sys.rst
+++ b/Doc/library/sys.rst
@@ -1644,7 +1644,7 @@ always available.
    .. versionchanged:: 3.12
       ``'opcode'`` event will only be emitted if :attr:`~frame.f_trace_opcodes`
       of at least one frame has been set to :const:`True` before :func:`settrace`
-      is called. This behavior is changed back in 3.13 to be consistent with
+      is called. This behavior will be changed back in 3.13 to be consistent with
       previous versions.
 
 .. function:: set_asyncgen_hooks([firstiter] [, finalizer])

--- a/Doc/library/sys.rst
+++ b/Doc/library/sys.rst
@@ -1644,7 +1644,8 @@ always available.
    .. versionchanged:: 3.12
       ``'opcode'`` event will only be emitted if :attr:`~frame.f_trace_opcodes`
       of at least one frame has been set to :const:`True` before :func:`settrace`
-      is called.
+      is called. This behavior is changed back in 3.13 to be consistent with
+      previous versions.
 
 .. function:: set_asyncgen_hooks([firstiter] [, finalizer])
 

--- a/Doc/library/sys.rst
+++ b/Doc/library/sys.rst
@@ -1641,6 +1641,11 @@ always available.
       ``'opcode'`` event type added; :attr:`~frame.f_trace_lines` and
       :attr:`~frame.f_trace_opcodes` attributes added to frames
 
+   .. versionchanged:: 3.12
+      ``'opcode'`` event will only be emitted if :attr:`~frame.f_trace_opcodes`
+      of at least one frame has been set to :const:`True` before :func:`settrace`
+      is called.
+
 .. function:: set_asyncgen_hooks([firstiter] [, finalizer])
 
    Accepts two optional keyword arguments which are callables that accept an


### PR DESCRIPTION
3.12 introduced a weird behavior for `f_trace_opcodes` due to PEP 669. We should document it. However, this behavior is fixed in main (3.13) so we only need to document it in 3.12 branch.

<!-- gh-issue-number: gh-114480 -->
* Issue: gh-114480
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--114540.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->