### PR TITLE
gh-101100: Fix sphinx warnings in `c-api/file.rst`

### DIFF
--- a/Doc/c-api/file.rst
+++ b/Doc/c-api/file.rst
@@ -65,8 +65,12 @@ the :mod:`io` APIs instead.
    Overrides the normal behavior of :func:`io.open_code` to pass its parameter
    through the provided handler.
 
-   The handler is a function of type :c:expr:`PyObject *(\*)(PyObject *path,
-   void *userData)`, where *path* is guaranteed to be :c:type:`PyUnicodeObject`.
+   The handler is a function of type:
+
+   .. c:type:: Py_OpenCodeHookFunction
+
+      Equivalent of :c:expr:`PyObject *(\*)(PyObject *path,
+      void *userData)`, where *path* is guaranteed to be :c:type:`PyUnicodeObject`.
 
    The *userData* pointer is passed into the hook function. Since hook
    functions may be called from different runtimes, this pointer should not

--- a/Doc/c-api/file.rst
+++ b/Doc/c-api/file.rst
@@ -70,7 +70,8 @@ the :mod:`io` APIs instead.
    .. c:type:: Py_OpenCodeHookFunction
 
       Equivalent of :c:expr:`PyObject *(\*)(PyObject *path,
-      void *userData)`, where *path* is guaranteed to be :c:type:`PyUnicodeObject`.
+      void *userData)`, where *path* is guaranteed to be
+      :c:type:`PyUnicodeObject`.
 
    The *userData* pointer is passed into the hook function. Since hook
    functions may be called from different runtimes, this pointer should not

--- a/Doc/c-api/object.rst
+++ b/Doc/c-api/object.rst
@@ -21,7 +21,8 @@ Object Protocol
 
 .. c:macro:: Py_PRINT_RAW
 
-   Flag to be used with multiple functions that print the object (like :c:func:`PyObject_Print` and :c:func:`PyFile_WriteObject`).
+   Flag to be used with multiple functions that print the object (like
+   :c:func:`PyObject_Print` and :c:func:`PyFile_WriteObject`).
    If passed, these function would use the :func:`str` of the object
    instead of the :func:`repr`.
 

--- a/Doc/c-api/object.rst
+++ b/Doc/c-api/object.rst
@@ -19,6 +19,13 @@ Object Protocol
    to NotImplemented and return it).
 
 
+.. c:macro:: Py_PRINT_RAW
+
+   Flag to be used with multiple functions that print the object (like :c:func:`PyObject_Print` and :c:func:`PyFile_WriteObject`).
+   If passed, these function would use the :func:`str` of the object
+   instead of the :func:`repr`.
+
+
 .. c:function:: int PyObject_Print(PyObject *o, FILE *fp, int flags)
 
    Print an object *o*, on file *fp*.  Returns ``-1`` on error.  The flags argument

--- a/Doc/tools/.nitignore
+++ b/Doc/tools/.nitignore
@@ -4,7 +4,6 @@
 
 Doc/c-api/descriptor.rst
 Doc/c-api/exceptions.rst
-Doc/c-api/file.rst
 Doc/c-api/float.rst
 Doc/c-api/gcsupport.rst
 Doc/c-api/init.rst

--- a/Doc/tools/.nitignore
+++ b/Doc/tools/.nitignore
@@ -11,7 +11,6 @@ Doc/c-api/init_config.rst
 Doc/c-api/intro.rst
 Doc/c-api/memoryview.rst
 Doc/c-api/module.rst
-Doc/c-api/object.rst
 Doc/c-api/stable.rst
 Doc/c-api/sys.rst
 Doc/c-api/type.rst


### PR DESCRIPTION
It used to be:

```
/Users/sobolev/Desktop/cpython2/Doc/c-api/file.rst:63: WARNING: c:identifier reference target not found: Py_OpenCodeHookFunction
/Users/sobolev/Desktop/cpython2/Doc/c-api/file.rst:95: WARNING: c:macro reference target not found: Py_PRINT_RAW
```

I've added docs about two public things:
- `Py_PRINT_RAW` macro
- `Py_OpenCodeHookFunction` typedef

<!-- gh-issue-number: gh-101100 -->
* Issue: gh-101100
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--114546.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->