### PR TITLE
Add missing sections to blurbs

### DIFF
--- a/Misc/NEWS.d/3.5.3.rst
+++ b/Misc/NEWS.d/3.5.3.rst
@@ -3,5 +3,6 @@
 .. no changes: True
 .. nonce: zYPqUK
 .. release date: 2017-01-17
+.. section: Library
 
 There were no code changes between 3.5.3rc1 and 3.5.3 final.

--- a/Misc/NEWS.d/3.6.0.rst
+++ b/Misc/NEWS.d/3.6.0.rst
@@ -3,5 +3,6 @@
 .. no changes: True
 .. nonce: F9ENBV
 .. release date: 2016-12-23
+.. section: Library
 
 No changes since release candidate 2

--- a/Misc/NEWS.d/3.6.2.rst
+++ b/Misc/NEWS.d/3.6.2.rst
@@ -3,5 +3,6 @@
 .. no changes: True
 .. nonce: F9ENBV
 .. release date: 2017-07-17
+.. section: Library
 
 No changes since release candidate 2


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

Fixes https://github.com/python/core-workflow/issues/525.

After adding more validation to blurb in https://github.com/python/core-workflow/pull/507 (unreleased), `blurb merge` fails for these three files because they're missing a section entry.

Other "no new changes" blurbs do contain a `section: Library` entry:

* https://github.com/python/cpython/blob/main/Misc/NEWS.d/3.5.4.rst?plain=1
* https://github.com/python/cpython/blob/main/Misc/NEWS.d/3.5.5.rst?plain=1
* https://github.com/python/cpython/blob/main/Misc/NEWS.d/3.6.4.rst?plain=1
* https://github.com/python/cpython/blob/main/Misc/NEWS.d/3.6.6.rst?plain=1

We could modify blurb to allow files in `Misc/NEWS.d/next` to skip this validation, but it's easier to add the missing sections.
