### PR TITLE
gh-114312: Fix rare event counter tests on aarch64

### DIFF
--- a/Modules/_testinternalcapi.c
+++ b/Modules/_testinternalcapi.c
@@ -1642,11 +1642,11 @@ get_rare_event_counters(PyObject *self, PyObject *type)
 
     return Py_BuildValue(
         "{sksksksksk}",
-        "set_class", interp->rare_events.set_class,
-        "set_bases", interp->rare_events.set_bases,
-        "set_eval_frame_func", interp->rare_events.set_eval_frame_func,
-        "builtin_dict", interp->rare_events.builtin_dict,
-        "func_modification", interp->rare_events.func_modification
+        "set_class", (unsigned long)interp->rare_events.set_class,
+        "set_bases", (unsigned long)interp->rare_events.set_bases,
+        "set_eval_frame_func", (unsigned long)interp->rare_events.set_eval_frame_func,
+        "builtin_dict", (unsigned long)interp->rare_events.builtin_dict,
+        "func_modification", (unsigned long)interp->rare_events.func_modification
     );
 }
 


### PR DESCRIPTION
These new tests from #114493 were failing on aarch64 buildbots, presumably because of the mismatch between uint8_t and the 'k' code to Py_BuildValue.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-114312 -->
* Issue: gh-114312
<!-- /gh-issue-number -->
