### PR TITLE
Fix `c-api/file.rst` indexes

### DIFF
--- a/Doc/c-api/file.rst
+++ b/Doc/c-api/file.rst
@@ -60,21 +60,19 @@ the :mod:`io` APIs instead.
    raised if the end of the file is reached immediately.
 
 
-.. c:type:: PyObject * (*Py_OpenCodeHookFunction)(PyObject *, void *)
-
-   Equivalent of :c:expr:`PyObject *(\*)(PyObject *path,
-   void *userData)`, where *path* is guaranteed to be
-   :c:type:`PyUnicodeObject`.
-
-   .. versionadded:: 3.8
-
-
 .. c:function:: int PyFile_SetOpenCodeHook(Py_OpenCodeHookFunction handler)
 
    Overrides the normal behavior of :func:`io.open_code` to pass its parameter
    through the provided handler.
 
-   The *handler* is a function of type :c:type:`Py_OpenCodeHookFunction`.
+   The *handler* is a function of type:
+
+   .. c:namespace:: NULL
+   .. c:type:: PyObject * (*Py_OpenCodeHookFunction)(PyObject *, void *)
+
+      Equivalent of :c:expr:`PyObject *(\*)(PyObject *path,
+      void *userData)`, where *path* is guaranteed to be
+      :c:type:`PyUnicodeObject`.
 
    The *userData* pointer is passed into the hook function. Since hook
    functions may be called from different runtimes, this pointer should not

--- a/Doc/c-api/file.rst
+++ b/Doc/c-api/file.rst
@@ -60,18 +60,21 @@ the :mod:`io` APIs instead.
    raised if the end of the file is reached immediately.
 
 
+.. c:type:: PyObject * (*Py_OpenCodeHookFunction)(PyObject *, void *)
+
+   Equivalent of :c:expr:`PyObject *(\*)(PyObject *path,
+   void *userData)`, where *path* is guaranteed to be
+   :c:type:`PyUnicodeObject`.
+
+   .. versionadded:: 3.8
+
+
 .. c:function:: int PyFile_SetOpenCodeHook(Py_OpenCodeHookFunction handler)
 
    Overrides the normal behavior of :func:`io.open_code` to pass its parameter
    through the provided handler.
 
-   The handler is a function of type:
-
-   .. c:type:: Py_OpenCodeHookFunction
-
-      Equivalent of :c:expr:`PyObject *(\*)(PyObject *path,
-      void *userData)`, where *path* is guaranteed to be
-      :c:type:`PyUnicodeObject`.
+   The *handler* is a function of type :c:type:`Py_OpenCodeHookFunction`.
 
    The *userData* pointer is passed into the hook function. Since hook
    functions may be called from different runtimes, this pointer should not


### PR DESCRIPTION
It is now:
<img width="973" alt="Снимок экрана 2024-01-26 в 18 48 18" src="https://github.com/python/cpython/assets/4660275/3fe858aa-43f5-4994-95bf-0dc84ec1e747">

Fixes https://github.com/python/cpython/pull/114546

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--114608.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->