### PR TITLE
GH-114610: Fix `pathlib.PurePath.with_stem('')` handling of file extensions

### DIFF
--- a/Lib/pathlib/_abc.py
+++ b/Lib/pathlib/_abc.py
@@ -295,7 +295,7 @@ class PurePathBase:
         suffix = self.suffix
         if not suffix:
             return self.with_name(stem)
-        if not stem:
+        elif not stem:
             raise ValueError(f"{self!r} has a non-empty suffix")
         else:
             return self.with_name(stem + suffix)

--- a/Lib/pathlib/_abc.py
+++ b/Lib/pathlib/_abc.py
@@ -296,6 +296,7 @@ class PurePathBase:
         if not suffix:
             return self.with_name(stem)
         elif not stem:
+            # If the suffix is non-empty, we can't make the stem empty.
             raise ValueError(f"{self!r} has a non-empty suffix")
         else:
             return self.with_name(stem + suffix)
@@ -309,6 +310,7 @@ class PurePathBase:
         if not suffix:
             return self.with_name(stem)
         elif not stem:
+            # If the stem is empty, we can't make the suffix non-empty.
             raise ValueError(f"{self!r} has an empty name")
         elif suffix.startswith('.') and len(suffix) > 1:
             return self.with_name(stem + suffix)

--- a/Lib/pathlib/_abc.py
+++ b/Lib/pathlib/_abc.py
@@ -292,7 +292,13 @@ class PurePathBase:
 
     def with_stem(self, stem):
         """Return a new path with the stem changed."""
-        return self.with_name(stem + self.suffix)
+        suffix = self.suffix
+        if not suffix:
+            return self.with_name(stem)
+        if not stem:
+            raise ValueError(f"{self!r} has a non-empty suffix")
+        else:
+            return self.with_name(stem + suffix)
 
     def with_suffix(self, suffix):
         """Return a new path with the file suffix changed.  If the path

--- a/Lib/test/test_pathlib/test_pathlib_abc.py
+++ b/Lib/test/test_pathlib/test_pathlib_abc.py
@@ -540,6 +540,8 @@ class DummyPurePathTest(unittest.TestCase):
         self.assertEqual(P('/').with_stem('d'), P('/d'))
         self.assertEqual(P('a/b').with_stem(''), P('a/'))
         self.assertEqual(P('a/b').with_stem('.'), P('a/.'))
+        self.assertRaises(ValueError, P('foo.gz').with_stem, '')
+        self.assertRaises(ValueError, P('/a/b/foo.gz').with_stem, '')
 
     def test_with_stem_seps(self):
         P = self.cls

--- a/Misc/NEWS.d/next/Library/2024-01-26-16-42-31.gh-issue-114610.S18Vuz.rst
+++ b/Misc/NEWS.d/next/Library/2024-01-26-16-42-31.gh-issue-114610.S18Vuz.rst
@@ -1,0 +1,2 @@
+Raise :exc:`ValueError` when an empty stem is supplied to
+:meth:`pathlib.PurePath.with_stem` but the path has a file extension.

--- a/Misc/NEWS.d/next/Library/2024-01-26-16-42-31.gh-issue-114610.S18Vuz.rst
+++ b/Misc/NEWS.d/next/Library/2024-01-26-16-42-31.gh-issue-114610.S18Vuz.rst
@@ -1,2 +1,4 @@
-Raise :exc:`ValueError` when an empty stem is supplied to
-:meth:`pathlib.PurePath.with_stem` but the path has a file extension.
+Fix bug where :meth:`pathlib.PurePath.with_stem` converted a non-empty path
+suffix to a stem when given an empty *stem* argument. It now raises
+:exc:`ValueError`, just like :meth:`pathlib.PurePath.with_suffix` does when
+called on a path with an empty stem, given a non-empty *suffix* argument.


### PR DESCRIPTION
Raise `ValueError` if `with_stem('')` is called on a path with a file extension. Paths may only have an empty stem if they also have an empty suffix.


<!-- gh-issue-number: gh-114610 -->
* Issue: gh-114610
<!-- /gh-issue-number -->
