### PR TITLE
GH-114610: Fix `pathlib._abc.PurePathBase.with_suffix('.ext')` handling of stems

### DIFF
--- a/Lib/pathlib/_abc.py
+++ b/Lib/pathlib/_abc.py
@@ -299,10 +299,13 @@ class PurePathBase:
         has no suffix, add given suffix.  If the given suffix is an empty
         string, remove the suffix from the path.
         """
+        stem = self.stem
         if not suffix:
-            return self.with_name(self.stem)
+            return self.with_name(stem)
+        elif not stem:
+            raise ValueError(f"{self!r} has an empty name")
         elif suffix.startswith('.') and len(suffix) > 1:
-            return self.with_name(self.stem + suffix)
+            return self.with_name(stem + suffix)
         else:
             raise ValueError(f"Invalid suffix {suffix!r}")
 

--- a/Lib/test/test_pathlib/test_pathlib.py
+++ b/Lib/test/test_pathlib/test_pathlib.py
@@ -329,13 +329,6 @@ class PurePathTest(test_pathlib_abc.DummyPurePathTest):
         self.assertRaises(ValueError, P('a/b').with_stem, '')
         self.assertRaises(ValueError, P('a/b').with_stem, '.')
 
-    def test_with_suffix_empty(self):
-        # Path doesn't have a "filename" component.
-        P = self.cls
-        self.assertRaises(ValueError, P('').with_suffix, '.gz')
-        self.assertRaises(ValueError, P('.').with_suffix, '.gz')
-        self.assertRaises(ValueError, P('/').with_suffix, '.gz')
-
     def test_relative_to_several_args(self):
         P = self.cls
         p = P('a/b')

--- a/Lib/test/test_pathlib/test_pathlib_abc.py
+++ b/Lib/test/test_pathlib/test_pathlib_abc.py
@@ -556,16 +556,9 @@ class DummyPurePathTest(unittest.TestCase):
         # Stripping suffix.
         self.assertEqual(P('a/b.py').with_suffix(''), P('a/b'))
         self.assertEqual(P('/a/b').with_suffix(''), P('/a/b'))
-
-    def test_with_suffix_empty(self):
-        P = self.cls
         # Path doesn't have a "filename" component.
-        self.assertEqual(P('').with_suffix('.gz'), P('.gz'))
-        self.assertEqual(P('.').with_suffix('.gz'), P('..gz'))
-        self.assertEqual(P('/').with_suffix('.gz'), P('/.gz'))
-
-    def test_with_suffix_seps(self):
-        P = self.cls
+        self.assertRaises(ValueError, P('').with_suffix, '.gz')
+        self.assertRaises(ValueError, P('/').with_suffix, '.gz')
         # Invalid suffix.
         self.assertRaises(ValueError, P('a/b').with_suffix, 'gz')
         self.assertRaises(ValueError, P('a/b').with_suffix, '/')


### PR DESCRIPTION
Raise `ValueError` if `with_suffix('.ext')` is called on a path without a stem. Paths may only have a non-empty suffix if they also have a non-empty stem.

ABC-only bugfix; no effect on public classes.


<!-- gh-issue-number: gh-114610 -->
* Issue: gh-114610
<!-- /gh-issue-number -->
