### PR TITLE
GH-79634: Speed up pathlib globbing by removing `joinpath()` call.

### DIFF
--- a/Lib/pathlib/_abc.py
+++ b/Lib/pathlib/_abc.py
@@ -771,7 +771,7 @@ class PathBase(PurePathBase):
         filter_paths = False
         deduplicate_paths = False
         sep = self.pathmod.sep
-        paths = iter([self.joinpath('')] if self.is_dir() else [])
+        paths = iter([self] if self.is_dir() else [])
         while stack:
             part = stack.pop()
             if part in specials:

--- a/Lib/test/test_pathlib/test_pathlib.py
+++ b/Lib/test/test_pathlib/test_pathlib.py
@@ -1824,6 +1824,8 @@ class PathTest(test_pathlib_abc.DummyPathTest, PurePathTest):
             list(p.glob(''))
         with self.assertRaisesRegex(ValueError, 'Unacceptable pattern'):
             list(p.glob('.'))
+        with self.assertRaisesRegex(ValueError, 'Unacceptable pattern'):
+            list(p.glob('./'))
 
     def test_glob_many_open_files(self):
         depth = 30

--- a/Lib/test/test_pathlib/test_pathlib_abc.py
+++ b/Lib/test/test_pathlib/test_pathlib_abc.py
@@ -1097,12 +1097,11 @@ class DummyPathTest(DummyPurePathTest):
             _check(p.glob("*/"), ["dirA/", "dirB/", "dirC/", "dirE/", "linkB/"])
 
     def test_glob_empty_pattern(self):
-        def _check(glob, expected):
-            self.assertEqual(set(glob), { P(self.base, q) for q in expected })
         P = self.cls
         p = P(self.base)
-        _check(p.glob(""), [""])
-        _check(p.glob("."), ["."])
+        self.assertEqual(list(p.glob("")), [p])
+        self.assertEqual(list(p.glob(".")), [p / "."])
+        self.assertEqual(list(p.glob("./")), [p / "./"])
 
     def test_glob_case_sensitive(self):
         P = self.cls


### PR DESCRIPTION
Remove `self.joinpath('')` call that should have been removed in 6313cdde.

This makes `PathBase.glob('')` yield itself *without* adding a trailing slash. It's hard to say whether this is more or less correct, but at least everything else is faster, and there's no behaviour change in the public classes where empty glob patterns are disallowed.


<!-- gh-issue-number: gh-79634 -->
* Issue: gh-79634
<!-- /gh-issue-number -->
