### PR TITLE
Add note to `sys.orig_argv` clarifying the difference from `sys.argv`

### DIFF
--- a/Doc/library/sys.rst
+++ b/Doc/library/sys.rst
@@ -1298,8 +1298,6 @@ always available.
    Arguments consumed by the interpreter itself will be present in *sys.orig_argv*
    and missing from :data:`sys.argv`.
 
-   See also :data:`sys.argv`.
-
    .. versionadded:: 3.10
 
 

--- a/Doc/library/sys.rst
+++ b/Doc/library/sys.rst
@@ -1294,7 +1294,7 @@ always available.
    executable.
 
    The elements of *sys.orig_argv* are the arguments to the Python interpreter,
-   while the elements of :data:`sys.argv` are the arguments to the user's script.
+   while the elements of :data:`sys.argv` are the arguments to the user's program.
    Arguments consumed by the interpreter itself will be present in *sys.orig_argv*
    and missing from :data:`sys.argv`.
 

--- a/Doc/library/sys.rst
+++ b/Doc/library/sys.rst
@@ -1293,9 +1293,9 @@ always available.
    The list of the original command line arguments passed to the Python
    executable.
 
-   The elements of *sys.orig_argv* are the arguments to the Python interpreter,
+   The elements of :data:`sys.orig_argv` are the arguments to the Python interpreter,
    while the elements of :data:`sys.argv` are the arguments to the user's program.
-   Arguments consumed by the interpreter itself will be present in *sys.orig_argv*
+   Arguments consumed by the interpreter itself will be present in :data:`sys.orig_argv`
    and missing from :data:`sys.argv`.
 
    .. versionadded:: 3.10

--- a/Doc/library/sys.rst
+++ b/Doc/library/sys.rst
@@ -1293,6 +1293,11 @@ always available.
    The list of the original command line arguments passed to the Python
    executable.
 
+   Note that the elements of *sys.orig_argv* are the arguments to the Python interpreter,
+   while the elements of :data:`sys.argv` are the arguments to the user's script.
+   Arguments consumed by the interpreter itself will be present in *sys.orig_argv*
+   and missing from :data:`sys.argv`.
+
    See also :data:`sys.argv`.
 
    .. versionadded:: 3.10

--- a/Doc/library/sys.rst
+++ b/Doc/library/sys.rst
@@ -1293,7 +1293,7 @@ always available.
    The list of the original command line arguments passed to the Python
    executable.
 
-   Note that the elements of *sys.orig_argv* are the arguments to the Python interpreter,
+   The elements of *sys.orig_argv* are the arguments to the Python interpreter,
    while the elements of :data:`sys.argv` are the arguments to the user's script.
    Arguments consumed by the interpreter itself will be present in *sys.orig_argv*
    and missing from :data:`sys.argv`.


### PR DESCRIPTION
Add a note to `sys.orig_argv` to help clarify how it differs from `sys.argv`.

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--114630.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->