### PR TITLE
gh-101100: Fix sphinx warnings in `library/email.mime.rst`

### DIFF
--- a/Doc/library/email.mime.rst
+++ b/Doc/library/email.mime.rst
@@ -28,7 +28,7 @@ make things easier.
 
 Here are the classes:
 
-.. currentmodule:: email.mime.base
+.. module:: email.mime.base
 
 .. class:: MIMEBase(_maintype, _subtype, *, policy=compat32, **_params)
 
@@ -58,7 +58,7 @@ Here are the classes:
       Added *policy* keyword-only parameter.
 
 
-.. currentmodule:: email.mime.nonmultipart
+.. module:: email.mime.nonmultipart
 
 .. class:: MIMENonMultipart()
 
@@ -72,7 +72,7 @@ Here are the classes:
    is called, a :exc:`~email.errors.MultipartConversionError` exception is raised.
 
 
-.. currentmodule:: email.mime.multipart
+.. module:: email.mime.multipart
 
 .. class:: MIMEMultipart(_subtype='mixed', boundary=None, _subparts=None, \
                          *, policy=compat32, **_params)
@@ -104,7 +104,7 @@ Here are the classes:
    .. versionchanged:: 3.6
       Added *policy* keyword-only parameter.
 
-.. currentmodule:: email.mime.application
+.. module:: email.mime.application
 
 .. class:: MIMEApplication(_data, _subtype='octet-stream', \
                            _encoder=email.encoders.encode_base64, \
@@ -135,7 +135,7 @@ Here are the classes:
    .. versionchanged:: 3.6
       Added *policy* keyword-only parameter.
 
-.. currentmodule:: email.mime.audio
+.. module:: email.mime.audio
 
 .. class:: MIMEAudio(_audiodata, _subtype=None, \
                      _encoder=email.encoders.encode_base64, \
@@ -169,7 +169,7 @@ Here are the classes:
    .. versionchanged:: 3.6
       Added *policy* keyword-only parameter.
 
-.. currentmodule:: email.mime.image
+.. module:: email.mime.image
 
 .. class:: MIMEImage(_imagedata, _subtype=None, \
                      _encoder=email.encoders.encode_base64, \
@@ -205,7 +205,7 @@ Here are the classes:
    .. versionchanged:: 3.6
       Added *policy* keyword-only parameter.
 
-.. currentmodule:: email.mime.message
+.. module:: email.mime.message
 
 .. class:: MIMEMessage(_msg, _subtype='rfc822', *, policy=compat32)
 
@@ -225,7 +225,7 @@ Here are the classes:
    .. versionchanged:: 3.6
       Added *policy* keyword-only parameter.
 
-.. currentmodule:: email.mime.text
+.. module:: email.mime.text
 
 .. class:: MIMEText(_text, _subtype='plain', _charset=None, *, policy=compat32)
 

--- a/Doc/tools/.nitignore
+++ b/Doc/tools/.nitignore
@@ -33,7 +33,6 @@ Doc/library/decimal.rst
 Doc/library/email.charset.rst
 Doc/library/email.compat32-message.rst
 Doc/library/email.errors.rst
-Doc/library/email.mime.rst
 Doc/library/email.parser.rst
 Doc/library/email.policy.rst
 Doc/library/enum.rst


### PR DESCRIPTION
Before:

```
/Users/sobolev/Desktop/cpython2/Doc/library/email.mime.rst:35: WARNING: py:mod reference target not found: email.mime.base
/Users/sobolev/Desktop/cpython2/Doc/library/email.mime.rst:65: WARNING: py:mod reference target not found: email.mime.nonmultipart
/Users/sobolev/Desktop/cpython2/Doc/library/email.mime.rst:80: WARNING: py:mod reference target not found: email.mime.multipart
/Users/sobolev/Desktop/cpython2/Doc/library/email.mime.rst:113: WARNING: py:mod reference target not found: email.mime.application
/Users/sobolev/Desktop/cpython2/Doc/library/email.mime.rst:144: WARNING: py:mod reference target not found: email.mime.audio
/Users/sobolev/Desktop/cpython2/Doc/library/email.mime.rst:178: WARNING: py:mod reference target not found: email.mime.image
/Users/sobolev/Desktop/cpython2/Doc/library/email.mime.rst:212: WARNING: py:mod reference target not found: email.mime.message
/Users/sobolev/Desktop/cpython2/Doc/library/email.mime.rst:232: WARNING: py:mod reference target not found: email.mime.text
```

It renders the same way and has the same references.

<!-- gh-issue-number: gh-101100 -->
* Issue: gh-101100
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--114635.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->