### PR TITLE
gh-114100: Replace ``print`` in ``test_pty`` with a simple expression

### DIFF
--- a/Lib/test/test_pty.py
+++ b/Lib/test/test_pty.py
@@ -292,7 +292,7 @@ class PtyTest(unittest.TestCase):
         self.assertEqual(data, b"")
 
     def test_spawn_doesnt_hang(self):
-        pty.spawn([sys.executable, '-c', 'print("1 + 1")'])
+        pty.spawn([sys.executable, '-c', '1 + 1'])
 
 class SmallPtyTests(unittest.TestCase):
     """These tests don't spawn children or hang."""

--- a/Lib/test/test_pty.py
+++ b/Lib/test/test_pty.py
@@ -292,7 +292,7 @@ class PtyTest(unittest.TestCase):
         self.assertEqual(data, b"")
 
     def test_spawn_doesnt_hang(self):
-        pty.spawn([sys.executable, '-c', 'print("hi there")'])
+        pty.spawn([sys.executable, '-c', 'print("1 + 1")'])
 
 class SmallPtyTests(unittest.TestCase):
     """These tests don't spawn children or hang."""


### PR DESCRIPTION
From name of test (``test_spawn_doesnt_hang``) I can assume that purpose of this test - check that spawn doesn't hang, so I had chosen this approach.
Another approach may be the same as  in #114565.

<!-- gh-issue-number: gh-114100 -->
* Issue: gh-114100
<!-- /gh-issue-number -->
