### PR TITLE
[3.11] gh-101100: Fix sphinx warnings in `reference/import.rst` (GH-114646)

### DIFF
--- a/Doc/reference/import.rst
+++ b/Doc/reference/import.rst
@@ -327,7 +327,7 @@ modules, and one that knows how to import modules from an :term:`import path`
    finders replaced :meth:`~importlib.abc.MetaPathFinder.find_module`, which
    is now deprecated.  While it will continue to work without change, the
    import machinery will try it only if the finder does not implement
-   ``find_spec()``.
+   :meth:`~importlib.abc.MetaPathFinder.find_spec`.
 
 .. versionchanged:: 3.10
    Use of :meth:`~importlib.abc.MetaPathFinder.find_module` by the import system
@@ -795,7 +795,7 @@ attributes on package objects are also used.  These provide additional ways
 that the import machinery can be customized.
 
 :data:`sys.path` contains a list of strings providing search locations for
-modules and packages.  It is initialized from the :data:`PYTHONPATH`
+modules and packages.  It is initialized from the :envvar:`PYTHONPATH`
 environment variable and various other installation- and
 implementation-specific defaults.  Entries in :data:`sys.path` can name
 directories on the file system, zip files, and potentially other "locations"

--- a/Doc/tools/.nitignore
+++ b/Doc/tools/.nitignore
@@ -92,7 +92,6 @@ Doc/library/xmlrpc.server.rst
 Doc/library/zlib.rst
 Doc/reference/compound_stmts.rst
 Doc/reference/datamodel.rst
-Doc/reference/import.rst
 Doc/tutorial/datastructures.rst
 Doc/using/windows.rst
 Doc/whatsnew/2.0.rst


### PR DESCRIPTION
(cherry picked from commit a384b20c0ce5aa520fa91ae0233d53642925525b)

Co-authored-by: Nikita Sobolev <mail@sobolevn.me>

<!-- gh-issue-number: gh-101100 -->
* Issue: gh-101100
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--114654.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->