### PR TITLE
gh-109653: Improve import time of importlib.metadata / email.utils

### DIFF
--- a/Lib/email/_parseaddr.py
+++ b/Lib/email/_parseaddr.py
@@ -13,7 +13,7 @@ __all__ = [
     'quote',
     ]
 
-import time, calendar
+import time
 
 SPACE = ' '
 EMPTYSTRING = ''
@@ -194,6 +194,8 @@ def mktime_tz(data):
         # No zone info, so localtime is better assumption than GMT
         return time.mktime(data[:8] + (-1,))
     else:
+        import calendar
+
         t = calendar.timegm(data)
         return t - data[9]
 

--- a/Lib/email/_parseaddr.py
+++ b/Lib/email/_parseaddr.py
@@ -194,6 +194,7 @@ def mktime_tz(data):
         # No zone info, so localtime is better assumption than GMT
         return time.mktime(data[:8] + (-1,))
     else:
+        # Delay the import, since mktime_tz is rarely used
         import calendar
 
         t = calendar.timegm(data)

--- a/Lib/importlib/metadata/__init__.py
+++ b/Lib/importlib/metadata/__init__.py
@@ -1,7 +1,6 @@
 import os
 import re
 import abc
-import csv
 import sys
 import json
 import email
@@ -478,6 +477,8 @@ class Distribution(DeprecatedNonAbstract):
 
         @pass_none
         def make_files(lines):
+            import csv
+
             return starmap(make_file, csv.reader(lines))
 
         @pass_none

--- a/Lib/importlib/metadata/__init__.py
+++ b/Lib/importlib/metadata/__init__.py
@@ -477,6 +477,8 @@ class Distribution(DeprecatedNonAbstract):
 
         @pass_none
         def make_files(lines):
+            # Delay csv import, since Distribution.files is not as widely used
+            # as other parts of importlib.metadata
             import csv
 
             return starmap(make_file, csv.reader(lines))

--- a/Misc/NEWS.d/next/Library/2024-01-28-00-48-12.gh-issue-109653.vF4exe.rst
+++ b/Misc/NEWS.d/next/Library/2024-01-28-00-48-12.gh-issue-109653.vF4exe.rst
@@ -1,0 +1,1 @@
+Improve import time of :mod:`importlib.metadata` and :mod:`email.utils`.


### PR DESCRIPTION
My criterion for delayed imports is that they're only worth it if the majority of users of the module would benefit from it, otherwise you're just moving latency around unpredictably.

mktime_tz is not used anywhere in the standard library and grep.app indicates it's not got much use in the ecosystem either.

Distribution.files is not nearly as widely used as other importlib.metadata APIs, so we defer the csv import.

And it's pretty easy for Python programs to not ever need calendar and csv.

Before:
```
λ hyperfine -w 8 './python -c "import importlib.metadata"'
Benchmark 1: ./python -c "import importlib.metadata"
  Time (mean ± σ):      65.1 ms ±   0.5 ms    [User: 55.3 ms, System: 9.8 ms]
  Range (min … max):    64.4 ms …  66.4 ms    44 runs
```

After:
```
λ hyperfine -w 8 './python -c "import importlib.metadata"'
Benchmark 1: ./python -c "import importlib.metadata"
  Time (mean ± σ):      62.0 ms ±   0.3 ms    [User: 52.5 ms, System: 9.6 ms]
  Range (min … max):    61.3 ms …  62.8 ms    46 runs
```

for about a 3ms saving with warm disk cache, maybe 7-11ms with cold disk cache.

<!-- gh-issue-number: gh-109653 -->
* Issue: gh-109653
<!-- /gh-issue-number -->
