### PR TITLE
Fix indentation in `__post_init__` documentation.

### DIFF
--- a/Doc/library/dataclasses.rst
+++ b/Doc/library/dataclasses.rst
@@ -538,8 +538,8 @@ that has to be called, it is common to call this method in a
 
     class Rectangle:
         def __init__(self, height, width):
-          self.height = height
-          self.width = width
+            self.height = height
+            self.width = width
 
     @dataclass
     class Square(Rectangle):


### PR DESCRIPTION
A small fix in the `Rectangle` example in the documentation for `__post_init__` in `dataclasses`.

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--114666.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->