### PR TITLE
gh-101100: Fix sphinx warnings in `Doc/c-api/memoryview.rst`

### DIFF
--- a/Doc/c-api/memoryview.rst
+++ b/Doc/c-api/memoryview.rst
@@ -20,6 +20,17 @@ any other object.
    read/write, otherwise it may be either read-only or read/write at the
    discretion of the exporter.
 
+
+.. c:macro:: PyBUF_READ
+
+   Flag to request a readonly buffer.
+
+
+.. c:macro:: PyBUF_WRITE
+
+   Flag to request a writable buffer.
+
+
 .. c:function:: PyObject *PyMemoryView_FromMemory(char *mem, Py_ssize_t size, int flags)
 
    Create a memoryview object using *mem* as the underlying buffer.
@@ -40,6 +51,8 @@ any other object.
    interface. If memory is contiguous, the memoryview object points to the
    original memory. Otherwise, a copy is made and the memoryview points to a
    new bytes object.
+
+   *buffertype* can be one of :c:macro:`PyBUF_READ` or :c:macro:`PyBUF_WRITE`.
 
 
 .. c:function:: int PyMemoryView_Check(PyObject *obj)

--- a/Doc/tools/.nitignore
+++ b/Doc/tools/.nitignore
@@ -9,7 +9,6 @@ Doc/c-api/gcsupport.rst
 Doc/c-api/init.rst
 Doc/c-api/init_config.rst
 Doc/c-api/intro.rst
-Doc/c-api/memoryview.rst
 Doc/c-api/module.rst
 Doc/c-api/stable.rst
 Doc/c-api/sys.rst


### PR DESCRIPTION
It used to be:

```
/Users/sobolev/Desktop/cpython2/Doc/c-api/memoryview.rst:25: WARNING: c:macro reference target not found: PyBUF_READ
/Users/sobolev/Desktop/cpython2/Doc/c-api/memoryview.rst:25: WARNING: c:macro reference target not found: PyBUF_WRITE
```

I documented these values there, because they are primarily used in `memoryview`. Grep:

```
Misc/stable_abi.toml
2336:[const.PyBUF_READ]
2338:[const.PyBUF_WRITE]

Python/import.c
3506:        data = PyMemoryView_FromMemory((char *)info.data, info.size, PyBUF_READ);
3547:        if (PyObject_GetBuffer(dataobj, &buf, PyBUF_READ) != 0) {

Include/pybuffer.h
113:#define PyBUF_WRITEABLE PyBUF_WRITABLE
137:#define PyBUF_READ  0x100
138:#define PyBUF_WRITE 0x200

Objects/memoryobject.c
740:   PyBUF_READ or PyBUF_WRITE. view->format is set to "B" (unsigned bytes).
750:    assert(flags == PyBUF_READ || flags == PyBUF_WRITE);
756:    readonly = (flags == PyBUF_WRITE) ? 0 : 1;
952:   buffertype={PyBUF_READ, PyBUF_WRITE} and order={'C', 'F'ortran, or 'A'ny}.
957:   As usual, if buffertype=PyBUF_WRITE, the exporter's buffer must be writable,
963:   Otherwise, if the buffertype is PyBUF_READ, the memoryview will be
974:    assert(buffertype == PyBUF_READ || buffertype == PyBUF_WRITE);
982:    if (buffertype == PyBUF_WRITE && view->readonly) {
992:    if (buffertype == PyBUF_WRITE) {
2095:    x->mview = PyMemoryView_FromMemory(x->item, itemsize, PyBUF_WRITE);

Lib/test/test_buffer.py
888:                    contig = get_contiguous(result, PyBUF_READ, order)
1278:        self.assertRaises(TypeError, get_contiguous, nd, PyBUF_READ, 961)
1279:        self.assertRaises(UnicodeEncodeError, get_contiguous, nd, PyBUF_READ,
1281:        self.assertRaises(ValueError, get_contiguous, nd, PyBUF_READ, 'Z')
2487:        self.assertRaises(ValueError, get_contiguous, nd, PyBUF_READ, 'C')
2488:        self.assertRaises(ValueError, get_contiguous, nd, PyBUF_READ, 'F')
2489:        self.assertRaises(ValueError, get_contiguous, nd[::-1], PyBUF_READ, 'C')
3981:        self.assertRaises(TypeError, get_contiguous, {}, PyBUF_READ, 'F')
3984:        self.assertRaises(BufferError, get_contiguous, b'x', PyBUF_WRITE, 'C')
3988:        self.assertRaises(BufferError, get_contiguous, nd, PyBUF_WRITE, 'A')
3993:            m = get_contiguous(nd, PyBUF_READ, order)
4000:            m = get_contiguous(nd, PyBUF_READ, order)
4007:            m = get_contiguous(nd, PyBUF_WRITE, order)
4018:            m = get_contiguous(nd, PyBUF_READ, order)
4026:            m = get_contiguous(nd, PyBUF_READ, order)
4032:            m = get_contiguous(nd, PyBUF_WRITE, order)
4038:            m = get_contiguous(nd, PyBUF_WRITE, order)
4045:            m = get_contiguous(nd, PyBUF_READ, order)
4054:            m = get_contiguous(nd, PyBUF_READ, order)
4064:            m = get_contiguous(nd, PyBUF_WRITE, order)
4067:        self.assertRaises(BufferError, get_contiguous, nd, PyBUF_WRITE, 'F')
4068:        m = get_contiguous(nd, PyBUF_READ, order)
4074:            m = get_contiguous(nd, PyBUF_WRITE, order)
4077:        self.assertRaises(BufferError, get_contiguous, nd, PyBUF_WRITE, 'C')
4078:        m = get_contiguous(nd, PyBUF_READ, order)
4084:            self.assertRaises(BufferError, get_contiguous, nd, PyBUF_WRITE,
4086:            m = get_contiguous(nd, PyBUF_READ, order)
4091:        m = get_contiguous(nd, PyBUF_READ, 'C')

Modules/_pickle.c
1403:    PyObject *buf_obj = PyMemoryView_FromMemory(buf, n, PyBUF_WRITE);

Modules/_testbuffer.c
413:    mview = PyMemoryView_FromMemory(ptr, itemsize, PyBUF_WRITE);
582:    mview = PyMemoryView_FromMemory(ptr, itemsize, PyBUF_READ);
711:    mview = PyMemoryView_FromMemory(item, base->itemsize, PyBUF_WRITE);
2399:            "buffertype must be PyBUF_READ or PyBUF_WRITE");
2407:    if (type != PyBUF_READ && type != PyBUF_WRITE) {
2878:    PyModule_AddIntMacro(m, PyBUF_READ);
2879:    PyModule_AddIntMacro(m, PyBUF_WRITE);
```

<!-- gh-issue-number: gh-101100 -->
* Issue: gh-101100
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--114669.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->