### PR TITLE
gh-114648: Add IndexError exception to tutorial datastructures list.pop entry

### DIFF
--- a/Doc/tutorial/datastructures.rst
+++ b/Doc/tutorial/datastructures.rst
@@ -50,10 +50,7 @@ objects:
    Remove the item at the given position in the list, and return it.  If no index
    is specified, ``a.pop()`` removes and returns the last item in the list.
    It raises an :exc:`IndexError` if the list is empty or the index is
-   outside the list range.  (The square brackets around the *i* in the method
-   signature denote that the parameter is optional, not that you should type
-   square brackets at that position.  You will see this notation frequently in
-   the Python Library Reference.)
+   outside the list range.
 
 
 .. method:: list.clear()

--- a/Doc/tutorial/datastructures.rst
+++ b/Doc/tutorial/datastructures.rst
@@ -48,10 +48,12 @@ objects:
    :noindex:
 
    Remove the item at the given position in the list, and return it.  If no index
-   is specified, ``a.pop()`` removes and returns the last item in the list.  (The
-   square brackets around the *i* in the method signature denote that the parameter
-   is optional, not that you should type square brackets at that position.  You
-   will see this notation frequently in the Python Library Reference.)
+   is specified, ``a.pop()`` removes and returns the last item in the list.
+   It raises an :exc:`IndexError` if the list is empty or the index is
+   outside the list range.  (The square brackets around the *i* in the method
+   signature denote that the parameter is optional, not that you should type
+   square brackets at that position.  You will see this notation frequently in
+   the Python Library Reference.)
 
 
 .. method:: list.clear()

--- a/Misc/NEWS.d/next/Documentation/2024-01-28-14-31-53.gh-issue-114648.LkD8IM.rst
+++ b/Misc/NEWS.d/next/Documentation/2024-01-28-14-31-53.gh-issue-114648.LkD8IM.rst
@@ -1,1 +1,0 @@
-Added :exc:`IndexError` to :meth:`pop` of :class:`list`.

--- a/Misc/NEWS.d/next/Documentation/2024-01-28-14-31-53.gh-issue-114648.LkD8IM.rst
+++ b/Misc/NEWS.d/next/Documentation/2024-01-28-14-31-53.gh-issue-114648.LkD8IM.rst
@@ -1,0 +1,1 @@
+Added :exc:`IndexError` to :meth:`pop` of :class:`list`.


### PR DESCRIPTION
To be consistent with the other two methods which have documented exceptions.

<!-- gh-issue-number: gh-114648 -->
* Issue: gh-114648
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--114681.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->