### PR TITLE
gh-114678: Fix incorrect deprecation warning for 'N' specifier in Decimal format

### DIFF
--- a/Lib/test/test_decimal.py
+++ b/Lib/test/test_decimal.py
@@ -41,6 +41,7 @@ from test.support import (TestFailed,
                           darwin_malloc_err_warning, is_emscripten)
 from test.support.import_helper import import_fresh_module
 from test.support import threading_helper
+from test.support import warnings_helper
 import random
 import inspect
 import threading
@@ -1237,10 +1238,14 @@ class FormatTest:
         else:
             self.assertRaises(ValueError, format, h, 'N')
             self.assertRaises(ValueError, format, h, '010.3N')
-        self.assertEqual(format(h, 'N>10.3'), 'NN6.63E-34')
-        self.assertEqual(format(h, 'N>10.3n'), 'NN6.63e-34')
-        self.assertEqual(format(h, 'N>10.3e'), 'N6.626e-34')
-        self.assertEqual(format(h, 'N>10.3f'), 'NNNNN0.000')
+        with warnings_helper.check_no_warnings(self):
+            self.assertEqual(format(h, 'N>10.3'), 'NN6.63E-34')
+            self.assertEqual(format(h, 'N>10.3n'), 'NN6.63e-34')
+            self.assertEqual(format(h, 'N>10.3e'), 'N6.626e-34')
+            self.assertEqual(format(h, 'N>10.3f'), 'NNNNN0.000')
+            self.assertRaises(ValueError, format, h, '>Nf')
+            self.assertRaises(ValueError, format, h, '10Nf')
+            self.assertRaises(ValueError, format, h, 'Nx')
 
     @run_with_locale('LC_ALL', 'ps_AF')
     def test_wide_char_separator_decimal_point(self):

--- a/Lib/test/test_decimal.py
+++ b/Lib/test/test_decimal.py
@@ -1237,7 +1237,10 @@ class FormatTest:
         else:
             self.assertRaises(ValueError, format, h, 'N')
             self.assertRaises(ValueError, format, h, '010.3N')
-
+        self.assertEqual(format(h, 'N>10.3'), 'NN6.63E-34')
+        self.assertEqual(format(h, 'N>10.3n'), 'NN6.63e-34')
+        self.assertEqual(format(h, 'N>10.3e'), 'N6.626e-34')
+        self.assertEqual(format(h, 'N>10.3f'), 'NNNNN0.000')
 
     @run_with_locale('LC_ALL', 'ps_AF')
     def test_wide_char_separator_decimal_point(self):

--- a/Misc/NEWS.d/next/Library/2024-01-28-19-40-40.gh-issue-114678.kYKcJw.rst
+++ b/Misc/NEWS.d/next/Library/2024-01-28-19-40-40.gh-issue-114678.kYKcJw.rst
@@ -1,2 +1,3 @@
-Fix incorrect deprecation warning for 'N' specifier in
-:class:`~decimal.Decimal` format. Based on patch by Stefan Krah.
+Ensure that deprecation warning for 'N' specifier in :class:`~decimal.Decimal`
+format is not raised for cases where 'N' appears in other places
+in the format specifier. Based on patch by Stefan Krah.

--- a/Misc/NEWS.d/next/Library/2024-01-28-19-40-40.gh-issue-114678.kYKcJw.rst
+++ b/Misc/NEWS.d/next/Library/2024-01-28-19-40-40.gh-issue-114678.kYKcJw.rst
@@ -1,0 +1,2 @@
+Fix incorrect deprecation warning for 'N' specifier in
+:class:`~decimal.Decimal` format. Based on patch by Stefan Krah.

--- a/Modules/_decimal/_decimal.c
+++ b/Modules/_decimal/_decimal.c
@@ -3446,6 +3446,14 @@ dec_format(PyObject *dec, PyObject *args)
         if (fmt == NULL) {
             return NULL;
         }
+
+        if (size > 0 && fmt[size-1] == 'N') {
+            if (PyErr_WarnEx(PyExc_DeprecationWarning,
+                             "Format specifier 'N' is deprecated", 1) < 0) {
+                return NULL;
+            }
+        }
+
         /* NOTE: If https://github.com/python/cpython/pull/29438 lands, the
          *   format string manipulation below can be eliminated by enhancing
          *   the forked mpd_parse_fmt_str(). */
@@ -3592,12 +3600,6 @@ dec_format(PyObject *dec, PyObject *args)
     size = strlen(decstring);
     if (replace_fillchar) {
         dec_replace_fillchar(decstring);
-    }
-    if (strchr(fmt, 'N') != NULL) {
-        if (PyErr_WarnEx(PyExc_DeprecationWarning,
-                         "Format specifier 'N' is deprecated", 1) < 0) {
-            goto finish;
-        }
     }
 
     result = PyUnicode_DecodeUTF8(decstring, size, NULL);


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-114678 -->
* Issue: gh-114678
<!-- /gh-issue-number -->
