### PR TITLE
gh-114685: Fix incorrect use of `PyBUF_READ` in `import.c`

### DIFF
--- a/Python/import.c
+++ b/Python/import.c
@@ -3544,7 +3544,7 @@ _imp_get_frozen_object_impl(PyObject *module, PyObject *name,
     struct frozen_info info = {0};
     Py_buffer buf = {0};
     if (PyObject_CheckBuffer(dataobj)) {
-        if (PyObject_GetBuffer(dataobj, &buf, PyBUF_READ) != 0) {
+        if (PyObject_GetBuffer(dataobj, &buf, PyBUF_SIMPLE) != 0) {
             return NULL;
         }
         info.data = (const char *)buf.buf;


### PR DESCRIPTION
It looks like a typo to me, so no NEWS entry.

<!-- gh-issue-number: gh-114685 -->
* Issue: gh-114685
<!-- /gh-issue-number -->
