### PR TITLE
gh-101100: Fix sphinx warnings in `library/enum.rst`

### DIFF
--- a/Doc/library/enum.rst
+++ b/Doc/library/enum.rst
@@ -296,7 +296,7 @@ Data Types
 
    .. attribute:: Enum._order_
 
-      Used to ensure member order is consistent
+      No longer used, kept for backward compatibility.
       (class attribute, removed during class creation).
 
    .. attribute:: Enum._ignore_
@@ -815,8 +815,8 @@ Supported ``_sunder_`` names
 - :attr:`~Enum._ignore_` -- a list of names, either as a :class:`list` or a
   :class:`str`, that will not be transformed into members, and will be removed
   from the final class
-- :attr:`~Enum._order_` -- used to ensure member order is
-  consistent (class attribute, removed during class creation)
+- :attr:`~Enum._order_` -- no longer used, kept for backward
+  compatibility (class attribute, removed during class creation)
 - :meth:`~Enum._generate_next_value_` -- used to get an appropriate value for
   an enum member; may be overridden
 

--- a/Doc/library/enum.rst
+++ b/Doc/library/enum.rst
@@ -286,6 +286,19 @@ Data Types
          appropriate value will be chosen for you.  See :class:`auto` for the
          details.
 
+   .. attribute:: Enum._name_
+
+      Name of the member.
+
+   .. attribute:: Enum._value_
+
+      Value of the member, can be set in :meth:`~object.__new__`.
+
+   .. attribute:: Enum._order_
+
+      Used to ensure member order is consistent
+      (class attribute, removed during class creation).
+
    .. attribute:: Enum._ignore_
 
       ``_ignore_`` is only used during creation and is removed from the
@@ -802,7 +815,7 @@ Supported ``_sunder_`` names
 - :attr:`~Enum._ignore_` -- a list of names, either as a :class:`list` or a
   :class:`str`, that will not be transformed into members, and will be removed
   from the final class
-- :attr:`~Enum._order_` -- used in Python 2/3 code to ensure member order is
+- :attr:`~Enum._order_` -- used to ensure member order is
   consistent (class attribute, removed during class creation)
 - :meth:`~Enum._generate_next_value_` -- used to get an appropriate value for
   an enum member; may be overridden

--- a/Doc/tools/.nitignore
+++ b/Doc/tools/.nitignore
@@ -35,7 +35,6 @@ Doc/library/email.compat32-message.rst
 Doc/library/email.errors.rst
 Doc/library/email.parser.rst
 Doc/library/email.policy.rst
-Doc/library/enum.rst
 Doc/library/exceptions.rst
 Doc/library/faulthandler.rst
 Doc/library/fcntl.rst


### PR DESCRIPTION
Before:

```
/Users/sobolev/Desktop/cpython2/Doc/library/enum.rst:798: WARNING: py:attr reference target not found: Enum._name_
/Users/sobolev/Desktop/cpython2/Doc/library/enum.rst:799: WARNING: py:attr reference target not found: Enum._value_
/Users/sobolev/Desktop/cpython2/Doc/library/enum.rst:805: WARNING: py:attr reference target not found: Enum._order_
```

It renders just fine:
<img width="820" alt="Снимок экрана 2024-01-29 в 09 34 09" src="https://github.com/python/cpython/assets/4660275/718e0b85-47ce-45fc-9c20-cf63c70ded6c">

I though that I can possibly define these attributes in-place, but their rendering would be very strange this way. So, I went with a little duplication.

<!-- gh-issue-number: gh-101100 -->
* Issue: gh-101100
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--114696.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->