### PR TITLE
Set `hosted_on` for Read the Docs builds

### DIFF
--- a/Doc/conf.py
+++ b/Doc/conf.py
@@ -55,7 +55,7 @@ manpages_url = 'https://manpages.debian.org/{path}'
 
 # General substitutions.
 project = 'Python'
-copyright = '2001-%s, Python Software Foundation' % time.strftime('%Y')
+copyright = f"2001-{time.strftime('%Y')}, Python Software Foundation"
 
 # We look for the Include/patchlevel.h file in the current Python source tree
 # and replace the values accordingly.
@@ -303,7 +303,7 @@ if any('htmlhelp' in arg for arg in sys.argv):
     print("It may be removed in the future\n")
 
 # Short title used e.g. for <title> HTML tags.
-html_short_title = '%s Documentation' % release
+html_short_title = f'{release} Documentation'
 
 # Deployment preview information
 # (See .readthedocs.yml and https://docs.readthedocs.io/en/stable/reference/environment-variables.html)

--- a/Doc/conf.py
+++ b/Doc/conf.py
@@ -352,12 +352,9 @@ html_split_index = True
 
 latex_engine = 'xelatex'
 
-# Get LaTeX to handle Unicode correctly
 latex_elements = {
-}
-
-# Additional stuff for the LaTeX preamble.
-latex_elements['preamble'] = r'''
+    # For the LaTeX preamble.
+    'preamble': r'''
 \authoraddress{
   \sphinxstrong{Python Software Foundation}\\
   Email: \sphinxemail{docs@python.org}
@@ -365,13 +362,12 @@ latex_elements['preamble'] = r'''
 \let\Verbatim=\OriginalVerbatim
 \let\endVerbatim=\endOriginalVerbatim
 \setcounter{tocdepth}{2}
-'''
-
-# The paper size ('letter' or 'a4').
-latex_elements['papersize'] = 'a4'
-
-# The font size ('10pt', '11pt' or '12pt').
-latex_elements['pointsize'] = '10pt'
+''',
+    # The paper size ('letter' or 'a4').
+    'papersize': 'a4',
+    # The font size ('10pt', '11pt' or '12pt').
+    'pointsize': '10pt',
+}
 
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title, author, document class [howto/manual]).

--- a/Doc/conf.py
+++ b/Doc/conf.py
@@ -6,7 +6,9 @@
 # The contents of this file are pickled, so don't put values in the namespace
 # that aren't pickleable (module imports are okay, they're removed automatically).
 
-import sys, os, time
+import os
+import sys
+import time
 sys.path.append(os.path.abspath('tools/extensions'))
 sys.path.append(os.path.abspath('includes'))
 

--- a/Doc/conf.py
+++ b/Doc/conf.py
@@ -292,6 +292,9 @@ html_theme_options = {
     'root_include_title': False   # We use the version switcher instead.
 }
 
+if os.getenv("READTHEDOCS"):
+    html_theme_options["hosted_on"] = '<a href="https://about.readthedocs.com/">Read the Docs</a>'
+
 # Override stylesheet fingerprinting for Windows CHM htmlhelp to fix GH-91207
 # https://github.com/python/cpython/issues/91207
 if any('htmlhelp' in arg for arg in sys.argv):

--- a/Doc/conf.py
+++ b/Doc/conf.py
@@ -430,9 +430,9 @@ coverage_c_path = [
 
 # Regexes to find C items in the source files.
 coverage_c_regexes = {
-    'cfunction': (r'^PyAPI_FUNC\(.*\)\s+([^_][\w_]+)'),
-    'data': (r'^PyAPI_DATA\(.*\)\s+([^_][\w_]+)'),
-    'macro': (r'^#define ([^_][\w_]+)\(.*\)[\s|\\]'),
+    'cfunction': r'^PyAPI_FUNC\(.*\)\s+([^_][\w_]+)',
+    'data': r'^PyAPI_DATA\(.*\)\s+([^_][\w_]+)',
+    'macro': r'^#define ([^_][\w_]+)\(.*\)[\s|\\]',
 }
 
 # The coverage checker will ignore all C items whose names match these regexes


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
Helps https://github.com/python/docs-community/issues/5.

Added to the theme in https://github.com/python/python-docs-theme/pull/165, released in https://github.com/python/python-docs-theme/releases/tag/2024.1.

Right now we're only using Read the Docs for PR previews.

Also some cleanup, these can go in another PR but they seem trivial enough to include here.


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--114697.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->