### PR TITLE
TaskGroup: Explicitly None check for propagated cancellation error

### DIFF
--- a/Lib/asyncio/taskgroups.py
+++ b/Lib/asyncio/taskgroups.py
@@ -132,7 +132,7 @@ class TaskGroup:
 
         # Propagate CancelledError if there is one, except if there
         # are other errors -- those have priority.
-        if propagate_cancellation_error and not self._errors:
+        if propagate_cancellation_error is not None and not self._errors:
             raise propagate_cancellation_error
 
         if et is not None and not issubclass(et, exceptions.CancelledError):


### PR DESCRIPTION
The issue is trivial IMHO, if you think otherwise I will submit an issue.