### PR TITLE
gh-114709: Fix exceptions raised by posixpath.commonpath

### DIFF
--- a/Doc/library/os.path.rst
+++ b/Doc/library/os.path.rst
@@ -79,7 +79,7 @@ the :mod:`glob` module.)
 
 .. function:: commonpath(paths)
 
-   Return the longest common sub-path of each pathname in the sequence
+   Return the longest common sub-path of each pathname in the iterable
    *paths*.  Raise :exc:`ValueError` if *paths* contain both absolute
    and relative pathnames, the *paths* are on the different drives or
    if *paths* is empty.  Unlike :func:`commonprefix`, this returns a
@@ -90,7 +90,7 @@ the :mod:`glob` module.)
    .. versionadded:: 3.5
 
    .. versionchanged:: 3.6
-      Accepts a sequence of :term:`path-like objects <path-like object>`.
+      Accepts an iterable of :term:`path-like objects <path-like object>`.
 
 
 .. function:: commonprefix(list)

--- a/Lib/posixpath.py
+++ b/Lib/posixpath.py
@@ -546,10 +546,11 @@ def relpath(path, start=None):
 def commonpath(paths):
     """Given a sequence of path names, returns the longest common sub-path."""
 
+    paths = tuple(map(os.fspath, paths))
+
     if not paths:
         raise ValueError('commonpath() arg is an empty sequence')
 
-    paths = tuple(map(os.fspath, paths))
     if isinstance(paths[0], bytes):
         sep = b'/'
         curdir = b'.'

--- a/Lib/test/test_posixpath.py
+++ b/Lib/test/test_posixpath.py
@@ -703,7 +703,9 @@ class PosixPathTest(unittest.TestCase):
             self.assertRaises(exc, posixpath.commonpath,
                               [os.fsencode(p) for p in paths])
 
+        self.assertRaises(TypeError, posixpath.commonpath, None)
         self.assertRaises(ValueError, posixpath.commonpath, [])
+        self.assertRaises(ValueError, posixpath.commonpath, iter([]))
         check_error(ValueError, ['/usr', 'usr'])
         check_error(ValueError, ['usr', '/usr'])
 

--- a/Misc/NEWS.d/next/Library/2024-01-29-13-46-41.gh-issue-114709.SQ998l.rst
+++ b/Misc/NEWS.d/next/Library/2024-01-29-13-46-41.gh-issue-114709.SQ998l.rst
@@ -1,0 +1,5 @@
+:func:`posixpath.commonpath()` now raises a :exc:`ValueError` exception when
+passed an empty iterable. Previously, :exc:`IndexError` was raised.
+
+:func:`posixpath.commonpath()` now raises a :exc:`TypeError` exception when
+passed ``None``. Previously, :exc:`ValueError` was raised.


### PR DESCRIPTION
Raise ValueError, not IndexError when passed an empty iterable. Raise TypeError, not ValueError when passed None.


<!-- gh-issue-number: gh-114709 -->
* Issue: gh-114709
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--114710.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->