### PR TITLE
Fix more references to datetime and time classes

### DIFF
--- a/Doc/library/datetime.rst
+++ b/Doc/library/datetime.rst
@@ -1255,7 +1255,7 @@ Instance methods:
    ``tzinfo=None`` can be specified to create a naive datetime from an aware
    datetime with no conversion of date and time data.
 
-   :class:`datetime` objects are also supported by generic function
+   :class:`.datetime` objects are also supported by generic function
    :func:`copy.replace`.
 
    .. versionchanged:: 3.6
@@ -1678,7 +1678,7 @@ Usage of ``KabulTz`` from above::
 :class:`.time` Objects
 ----------------------
 
-A :class:`time` object represents a (local) time of day, independent of any particular
+A :class:`.time` object represents a (local) time of day, independent of any particular
 day, and subject to adjustment via a :class:`tzinfo` object.
 
 .. class:: time(hour=0, minute=0, second=0, microsecond=0, tzinfo=None, *, fold=0)
@@ -1836,7 +1836,7 @@ Instance methods:
    ``tzinfo=None`` can be specified to create a naive :class:`.time` from an
    aware :class:`.time`, without conversion of the time data.
 
-   :class:`time` objects are also supported by generic function
+   :class:`.time` objects are also supported by generic function
    :func:`copy.replace`.
 
    .. versionchanged:: 3.6
@@ -2522,7 +2522,7 @@ information, which are supported in ``datetime.strptime`` but are discarded by
 ``time.strptime``.
 
 For :class:`.time` objects, the format codes for year, month, and day should not
-be used, as :class:`time` objects have no such values. If they're used anyway,
+be used, as :class:`!time` objects have no such values. If they're used anyway,
 ``1900`` is substituted for the year, and ``1`` for the month and day.
 
 For :class:`date` objects, the format codes for hours, minutes, seconds, and

--- a/Doc/library/mailbox.rst
+++ b/Doc/library/mailbox.rst
@@ -1136,8 +1136,8 @@ When a :class:`!MaildirMessage` instance is created based upon a
       leading "From " or trailing newline. For convenience, *time_* may be
       specified and will be formatted appropriately and appended to *from_*. If
       *time_* is specified, it should be a :class:`time.struct_time` instance, a
-      tuple suitable for passing to :meth:`time.strftime`, or ``True`` (to use
-      :meth:`time.gmtime`).
+      tuple suitable for passing to :func:`time.strftime`, or ``True`` (to use
+      :func:`time.gmtime`).
 
 
    .. method:: get_flags()
@@ -1508,8 +1508,8 @@ When a :class:`!BabylMessage` instance is created based upon an
       leading "From " or trailing newline. For convenience, *time_* may be
       specified and will be formatted appropriately and appended to *from_*. If
       *time_* is specified, it should be a :class:`time.struct_time` instance, a
-      tuple suitable for passing to :meth:`time.strftime`, or ``True`` (to use
-      :meth:`time.gmtime`).
+      tuple suitable for passing to :func:`time.strftime`, or ``True`` (to use
+      :func:`time.gmtime`).
 
 
    .. method:: get_flags()

--- a/Doc/whatsnew/3.8.rst
+++ b/Doc/whatsnew/3.8.rst
@@ -754,8 +754,8 @@ datetime
 --------
 
 Added new alternate constructors :meth:`datetime.date.fromisocalendar` and
-:meth:`datetime.datetime.fromisocalendar`, which construct :class:`date` and
-:class:`datetime` objects respectively from ISO year, week number, and weekday;
+:meth:`datetime.datetime.fromisocalendar`, which construct :class:`~datetime.date` and
+:class:`~datetime.datetime` objects respectively from ISO year, week number, and weekday;
 these are the inverse of each class's ``isocalendar`` method.
 (Contributed by Paul Ganssle in :issue:`36004`.)
 

--- a/Misc/NEWS.d/3.13.0a1.rst
+++ b/Misc/NEWS.d/3.13.0a1.rst
@@ -2276,7 +2276,7 @@ creation.
 .. nonce: m2H5Bk
 .. section: Library
 
-Remove unnecessary extra ``__slots__`` in :py:class:`datetime`\'s pure
+Remove unnecessary extra ``__slots__`` in :class:`~datetime.datetime`\'s pure
 python implementation to reduce memory size, as they are defined in the
 superclass. Patch by James Hilton-Balfe
 


### PR DESCRIPTION
They could be confused with references to datetime and time modules.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--114717.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->