### PR TITLE
Remove limit in Calendar CLI help message for year arg

### DIFF
--- a/Lib/calendar.py
+++ b/Lib/calendar.py
@@ -737,7 +737,7 @@ def main(args=None):
     parser.add_argument(
         "year",
         nargs='?', type=int,
-        help="year number (1-9999)"
+        help="year number"
     )
     parser.add_argument(
         "month",


### PR DESCRIPTION
The limit was removed in 66c88ce.

It was requested here https://github.com/python/cpython/pull/112241#discussion_r1469414491 that a trivial PR be made for this change.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
