### PR TITLE
[3.11] Fix more references to datetime and time classes (GH-114717)

### DIFF
--- a/Doc/library/datetime.rst
+++ b/Doc/library/datetime.rst
@@ -1664,7 +1664,7 @@ Usage of ``KabulTz`` from above::
 :class:`.time` Objects
 ----------------------
 
-A :class:`time` object represents a (local) time of day, independent of any particular
+A :class:`.time` object represents a (local) time of day, independent of any particular
 day, and subject to adjustment via a :class:`tzinfo` object.
 
 .. class:: time(hour=0, minute=0, second=0, microsecond=0, tzinfo=None, *, fold=0)
@@ -2497,7 +2497,7 @@ information, which are supported in ``datetime.strptime`` but are discarded by
 ``time.strptime``.
 
 For :class:`.time` objects, the format codes for year, month, and day should not
-be used, as :class:`time` objects have no such values. If they're used anyway,
+be used, as :class:`!time` objects have no such values. If they're used anyway,
 ``1900`` is substituted for the year, and ``1`` for the month and day.
 
 For :class:`date` objects, the format codes for hours, minutes, seconds, and

--- a/Doc/library/mailbox.rst
+++ b/Doc/library/mailbox.rst
@@ -1027,8 +1027,8 @@ When a :class:`!MaildirMessage` instance is created based upon a
       leading "From " or trailing newline. For convenience, *time_* may be
       specified and will be formatted appropriately and appended to *from_*. If
       *time_* is specified, it should be a :class:`time.struct_time` instance, a
-      tuple suitable for passing to :meth:`time.strftime`, or ``True`` (to use
-      :meth:`time.gmtime`).
+      tuple suitable for passing to :func:`time.strftime`, or ``True`` (to use
+      :func:`time.gmtime`).
 
 
    .. method:: get_flags()
@@ -1399,8 +1399,8 @@ When a :class:`!BabylMessage` instance is created based upon an
       leading "From " or trailing newline. For convenience, *time_* may be
       specified and will be formatted appropriately and appended to *from_*. If
       *time_* is specified, it should be a :class:`time.struct_time` instance, a
-      tuple suitable for passing to :meth:`time.strftime`, or ``True`` (to use
-      :meth:`time.gmtime`).
+      tuple suitable for passing to :func:`time.strftime`, or ``True`` (to use
+      :func:`time.gmtime`).
 
 
    .. method:: get_flags()

--- a/Doc/whatsnew/3.8.rst
+++ b/Doc/whatsnew/3.8.rst
@@ -754,8 +754,8 @@ datetime
 --------
 
 Added new alternate constructors :meth:`datetime.date.fromisocalendar` and
-:meth:`datetime.datetime.fromisocalendar`, which construct :class:`date` and
-:class:`datetime` objects respectively from ISO year, week number, and weekday;
+:meth:`datetime.datetime.fromisocalendar`, which construct :class:`~datetime.date` and
+:class:`~datetime.datetime` objects respectively from ISO year, week number, and weekday;
 these are the inverse of each class's ``isocalendar`` method.
 (Contributed by Paul Ganssle in :issue:`36004`.)
 


### PR DESCRIPTION
They could be confused with references to datetime and time modules.
(cherry picked from commit 39c766b579cabc71a4a50773d299d4350221a70b)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--114726.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->