### PR TITLE
gh-101100: Fix Sphinx reference warnings in the glossary

### DIFF
--- a/Doc/glossary.rst
+++ b/Doc/glossary.rst
@@ -1103,11 +1103,13 @@ Glossary
 
       The :class:`collections.abc.Sequence` abstract base class
       defines a much richer interface that goes beyond just
-      :meth:`~object.__getitem__` and :meth:`~object.__len__`.
-      :ref:`Common Sequence Operations <typesseq-common>`
-      provides a list common to most sequence types.
-      Types which implement this expanded interface can be registered explicitly using
-      :func:`~abc.ABCMeta.register`.
+      :meth:`~object.__getitem__` and :meth:`~object.__len__`, adding
+      :meth:`!count`, :meth:`!index`, :meth:`~object.__contains__`, and
+      :meth:`~object.__reversed__`. Types that implement this expanded
+      interface can be registered explicitly using
+      :func:`~abc.ABCMeta.register`. For more documentation on sequence
+      methods generally, see
+      :ref:`Common Sequence Operations <typesseq-common>`.
 
    set comprehension
       A compact way to process all or part of the elements in an iterable and

--- a/Doc/glossary.rst
+++ b/Doc/glossary.rst
@@ -1103,10 +1103,10 @@ Glossary
 
       The :class:`collections.abc.Sequence` abstract base class
       defines a much richer interface that goes beyond just
-      :meth:`~object.__getitem__` and :meth:`~object.__len__`, adding
-      :meth:`!count`, :meth:`!index`, :meth:`~object.__contains__`, and
-      :meth:`~object.__reversed__`. Types that implement this expanded
-      interface can be registered explicitly using
+      :meth:`~object.__getitem__` and :meth:`~object.__len__`.
+      :ref:`Common Sequence Operations <typesseq-common>`
+      provides a list common to most sequence types.
+      Types which implement this expanded interface can be registered explicitly using
       :func:`~abc.ABCMeta.register`.
 
    set comprehension

--- a/Doc/glossary.rst
+++ b/Doc/glossary.rst
@@ -341,7 +341,7 @@ Glossary
    docstring
       A string literal which appears as the first expression in a class,
       function or module.  While ignored when the suite is executed, it is
-      recognized by the compiler and put into the :attr:`__doc__` attribute
+      recognized by the compiler and put into the :attr:`!__doc__` attribute
       of the enclosing class, function or module.  Since it is available via
       introspection, it is the canonical place for documentation of the
       object.
@@ -754,7 +754,7 @@ Glossary
 
    loader
       An object that loads a module. It must define a method named
-      :meth:`load_module`. A loader is typically returned by a
+      :meth:`!load_module`. A loader is typically returned by a
       :term:`finder`. See :pep:`302` for details and
       :class:`importlib.abc.Loader` for an :term:`abstract base class`.
 
@@ -1104,7 +1104,7 @@ Glossary
       The :class:`collections.abc.Sequence` abstract base class
       defines a much richer interface that goes beyond just
       :meth:`~object.__getitem__` and :meth:`~object.__len__`, adding
-      :meth:`count`, :meth:`index`, :meth:`~object.__contains__`, and
+      :meth:`!count`, :meth:`!index`, :meth:`~object.__contains__`, and
       :meth:`~object.__reversed__`. Types that implement this expanded
       interface can be registered explicitly using
       :func:`~abc.ABCMeta.register`.

--- a/Doc/glossary.rst
+++ b/Doc/glossary.rst
@@ -754,7 +754,7 @@ Glossary
 
    loader
       An object that loads a module. It must define a method named
-      :meth:`!load_module`. A loader is typically returned by a
+      :meth:`load_module`. A loader is typically returned by a
       :term:`finder`. See :pep:`302` for details and
       :class:`importlib.abc.Loader` for an :term:`abstract base class`.
 


### PR DESCRIPTION
Given context, I don't think any of these reference problems need to actually be references.


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--114729.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->

<!-- gh-issue-number: gh-101100 -->
* Issue: gh-101100
<!-- /gh-issue-number -->
