### PR TITLE
[3.12] gh-112302: Backport SBOM generation tooling

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -80,6 +80,7 @@ Lib/keyword.py                                      generated
 Lib/test/levenshtein_examples.json                  generated
 Lib/test/test_stable_abi_ctypes.py                  generated
 Lib/token.py                                        generated
+Misc/sbom.spdx.json                                 generated
 Objects/typeslots.inc                               generated
 PC/python3dll.c                                     generated
 Parser/parser.c                                     generated

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -166,3 +166,7 @@ Lib/ast.py                    @isidentical
 
 # zipfile.Path
 **/*zipfile/_path/*           @jaraco
+
+# SBOM
+/Misc/sbom.spdx.json          @sethmlarson
+/Tools/build/generate_sbom.py @sethmlarson

--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -1320,7 +1320,7 @@ regen-limited-abi: all
 regen-all: regen-cases regen-opcode regen-opcode-targets regen-typeslots \
 	regen-token regen-ast regen-keyword regen-sre regen-frozen \
 	regen-pegen-metaparser regen-pegen regen-test-frozenmain \
-	regen-test-levenshtein regen-global-objects
+	regen-test-levenshtein regen-global-objects regen-sbom
 	@echo
 	@echo "Note: make regen-stdlib-module-names and make regen-configure should be run manually"
 
@@ -2604,6 +2604,10 @@ autoconf:
 .PHONY: regen-configure
 regen-configure:
 	$(srcdir)/Tools/build/regen-configure.sh
+
+.PHONY: regen-sbom
+regen-sbom:
+	$(PYTHON_FOR_REGEN) $(srcdir)/Tools/build/generate_sbom.py
 
 # Create a tags file for vi
 tags::

--- a/Misc/sbom.spdx.json
+++ b/Misc/sbom.spdx.json
@@ -1,0 +1,2918 @@
+{
+  "SPDXID": "SPDXRef-DOCUMENT",
+  "files": [
+    {
+      "SPDXID": "SPDXRef-FILE-Modules-expat-COPYING",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "39e6f567a10e36b2e77727e98e60bbcb3eb3af0b"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "122f2c27000472a201d337b9b31f7eb2b52d091b02857061a8880371612d9534"
+        }
+      ],
+      "fileName": "Modules/expat/COPYING"
+    },
+    {
+      "SPDXID": "SPDXRef-FILE-Modules-expat-ascii.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "b0235fa3cf845a7d68e8e66dd344d5e32e8951b5"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "42f8b392c70366743eacbc60ce021389ccaa333598dd49eef6ee5c93698ca205"
+        }
+      ],
+      "fileName": "Modules/expat/ascii.h"
+    },
+    {
+      "SPDXID": "SPDXRef-FILE-Modules-expat-asciitab.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "cbb53d16ca1f35ee9c9e296116efd222ae611ed9"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "1cc0ae749019fc0e488cd1cf245f6beaa6d4f7c55a1fc797e5aa40a408bc266b"
+        }
+      ],
+      "fileName": "Modules/expat/asciitab.h"
+    },
+    {
+      "SPDXID": "SPDXRef-FILE-Modules-expat-expat.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "ab7bb32514d170592dfb3f76e41bbdc075a4e7e0"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "f521acdad222644365b0e81a33bcd6939a98c91b225c47582cc84bd73d96febc"
+        }
+      ],
+      "fileName": "Modules/expat/expat.h"
+    },
+    {
+      "SPDXID": "SPDXRef-FILE-Modules-expat-expat-config.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "73627287302ee3e84347c4fe21f37a9cb828bc3b"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "f17e59f9d95eeb05694c02508aa284d332616c22cbe2e6a802d8a0710310eaab"
+        }
+      ],
+      "fileName": "Modules/expat/expat_config.h"
+    },
+    {
+      "SPDXID": "SPDXRef-FILE-Modules-expat-expat-external.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "b70ce53fdc25ae482681ae2f6623c3c8edc9c1b7"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "86afb425ec9999eb4f1ec9ab2fb41c58c4aa5cb9bf934b8c94264670fc5a961d"
+        }
+      ],
+      "fileName": "Modules/expat/expat_external.h"
+    },
+    {
+      "SPDXID": "SPDXRef-FILE-Modules-expat-iasciitab.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "1b0e9014c0baa4c6254d2b5e6a67c70148309c34"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "ad8b01e9f323cc4208bcd22241df383d7e8641fe3c8b3415aa513de82531f89f"
+        }
+      ],
+      "fileName": "Modules/expat/iasciitab.h"
+    },
+    {
+      "SPDXID": "SPDXRef-FILE-Modules-expat-internal.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "2790d37e7de2f13dccc4f4fb352cbdf9ed6abaa2"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "d2efe5a1018449968a689f444cca432e3d5875aba6ad08ee18ca235d64f41bb9"
+        }
+      ],
+      "fileName": "Modules/expat/internal.h"
+    },
+    {
+      "SPDXID": "SPDXRef-FILE-Modules-expat-latin1tab.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "d335ecca380e331a0ea7dc33838a4decd93ec1e4"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "eab66226da100372e01e42e1cbcd8ac2bbbb5c1b5f95d735289cc85c7a8fc2ba"
+        }
+      ],
+      "fileName": "Modules/expat/latin1tab.h"
+    },
+    {
+      "SPDXID": "SPDXRef-FILE-Modules-expat-nametab.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "cf2bc9626c945826602ba9170786e9a2a44645e4"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "67dcf415d37a4b692a6a8bb46f990c02d83f2ef3d01a65cd61c8594a084246f2"
+        }
+      ],
+      "fileName": "Modules/expat/nametab.h"
+    },
+    {
+      "SPDXID": "SPDXRef-FILE-Modules-expat-pyexpatns.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "baa44fe4581895d42e8d5e83d8ce6a69b1c34dbe"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "33a7b9ac8bf4571e23272cdf644c6f9808bd44c66b149e3c41ab3870d1888609"
+        }
+      ],
+      "fileName": "Modules/expat/pyexpatns.h"
+    },
+    {
+      "SPDXID": "SPDXRef-FILE-Modules-expat-siphash.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "2b984f806f10fbfbf72d8d1b7ba2992413c15299"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "fbce56cd680e690043bbf572188cc2d0a25dbfc0d47ac8cb98eb3de768d4e694"
+        }
+      ],
+      "fileName": "Modules/expat/siphash.h"
+    },
+    {
+      "SPDXID": "SPDXRef-FILE-Modules-expat-utf8tab.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "b77c8fcfb551553c81d6fbd94c798c8aa04ad021"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "8cd26bd461d334d5e1caedb3af4518d401749f2fc66d56208542b29085159c18"
+        }
+      ],
+      "fileName": "Modules/expat/utf8tab.h"
+    },
+    {
+      "SPDXID": "SPDXRef-FILE-Modules-expat-winconfig.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "e774ae6ee9391aa6ffb8f775fb74e48f4b428959"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "3c71cea9a6174718542331971a35db317902b2433be9d8dd1cb24239b635c0cc"
+        }
+      ],
+      "fileName": "Modules/expat/winconfig.h"
+    },
+    {
+      "SPDXID": "SPDXRef-FILE-Modules-expat-xmlparse.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "b580e827e16baa6b035586ffcd4d90301e5a353f"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "483518bbd69338eefc706cd7fc0b6039df2d3e347f64097989059ed6d2385a1e"
+        }
+      ],
+      "fileName": "Modules/expat/xmlparse.c"
+    },
+    {
+      "SPDXID": "SPDXRef-FILE-Modules-expat-xmlrole.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "5ef21312af73deb2428be3fe97a65244608e76de"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "6fcf8c72ac0112c1b98bd2039c632a66b4c3dc516ce7c1f981390951121ef3c0"
+        }
+      ],
+      "fileName": "Modules/expat/xmlrole.c"
+    },
+    {
+      "SPDXID": "SPDXRef-FILE-Modules-expat-xmlrole.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "c1a4ea6356643d0820edb9c024c20ad2aaf562dc"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "2b5d674be6ef20c7e3f69295176d75e68c5616e4dfce0a186fdd5e2ed8315f7a"
+        }
+      ],
+      "fileName": "Modules/expat/xmlrole.h"
+    },
+    {
+      "SPDXID": "SPDXRef-FILE-Modules-expat-xmltok.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "e6d66ae9fd61d7950c62c5d87693c30a707e8577"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "1110f651bdccfa765ad3d6f3857a35887ab35fc0fe7f3f3488fde2b238b482e3"
+        }
+      ],
+      "fileName": "Modules/expat/xmltok.c"
+    },
+    {
+      "SPDXID": "SPDXRef-FILE-Modules-expat-xmltok.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "9c2a544875fd08ba9c2397296c97263518a410aa"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "4299a03828b98bfe47ec6809f6e279252954a9a911dc7e0f19551bd74e3af971"
+        }
+      ],
+      "fileName": "Modules/expat/xmltok.h"
+    },
+    {
+      "SPDXID": "SPDXRef-FILE-Modules-expat-xmltok-impl.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "aa96882de8e3d1d3083124b595aa911efe44e5ad"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "0fbcba7931707c60301305dab78d2298d96447d0a5513926d8b18135228c0818"
+        }
+      ],
+      "fileName": "Modules/expat/xmltok_impl.c"
+    },
+    {
+      "SPDXID": "SPDXRef-FILE-Modules-expat-xmltok-impl.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "788332fe8040bed71172cddedb69abd848cc62f7"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "f05ad4fe5e98429a7349ff04f57192cac58c324601f2a2e5e697ab0bc05d36d5"
+        }
+      ],
+      "fileName": "Modules/expat/xmltok_impl.h"
+    },
+    {
+      "SPDXID": "SPDXRef-FILE-Modules-expat-xmltok-ns.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "2d82d0a1201f78d478b30d108ff8fc27ee3e2672"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "6ce6d03193279078d55280150fe91e7370370b504a6c123a79182f28341f3e90"
+        }
+      ],
+      "fileName": "Modules/expat/xmltok_ns.c"
+    },
+    {
+      "SPDXID": "SPDXRef-FILE-Modules-hacl-Hacl-Hash-MD5.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "f77449b2b4eb99f1da0938633cc558baf9c444fb"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "0f252967debca5b35362ca53951ea16ca8bb97a19a1d24f6695f44d50010859e"
+        }
+      ],
+      "fileName": "Modules/_hacl/Hacl_Hash_MD5.c"
+    },
+    {
+      "SPDXID": "SPDXRef-FILE-Modules-hacl-Hacl-Hash-MD5.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "c24e6779a91c840f3d65d24abbce225b608b676e"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "9cd062e782801013e3cacaba583e44e1b5e682e217d20208d5323354d42011f1"
+        }
+      ],
+      "fileName": "Modules/_hacl/Hacl_Hash_MD5.h"
+    },
+    {
+      "SPDXID": "SPDXRef-FILE-Modules-hacl-Hacl-Hash-SHA1.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "560f6ff541b5eff480ea047b147f4212bb0db7ed"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "0ade3ab264e912d7b4e5cdcf773db8c63e4440540d295922d74b06bcfc74c77a"
+        }
+      ],
+      "fileName": "Modules/_hacl/Hacl_Hash_SHA1.c"
+    },
+    {
+      "SPDXID": "SPDXRef-FILE-Modules-hacl-Hacl-Hash-SHA1.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "853b77d45379146faaeac5fe899b28db386ad13c"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "b13eb14f91582703819235ea7c8f807bb93e4f1e6b695499dc1d86021dc39e72"
+        }
+      ],
+      "fileName": "Modules/_hacl/Hacl_Hash_SHA1.h"
+    },
+    {
+      "SPDXID": "SPDXRef-FILE-Modules-hacl-Hacl-Hash-SHA2.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "667120b6100c946cdaa442f1173c723339923071"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "b189459b863341a3a9c5c78c0208b6554a2f2ac26e0748fbd4432a91db21fae6"
+        }
+      ],
+      "fileName": "Modules/_hacl/Hacl_Hash_SHA2.c"
+    },
+    {
+      "SPDXID": "SPDXRef-FILE-Modules-hacl-Hacl-Hash-SHA2.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "81db38b0b920e63ec33c7109d1144c35cf091da0"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "631c9ba19c1c2c835bb63d3f2f22b8d76fb535edfed3c254ff2a52f12af3fe61"
+        }
+      ],
+      "fileName": "Modules/_hacl/Hacl_Hash_SHA2.h"
+    },
+    {
+      "SPDXID": "SPDXRef-FILE-Modules-hacl-Hacl-Hash-SHA3.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "9c832b98a2f2a68202d2da016fb718965d7b7602"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "38d350d1184238966cfa821a59ae00343f362182b6c2fbea7f2651763d757fb7"
+        }
+      ],
+      "fileName": "Modules/_hacl/Hacl_Hash_SHA3.c"
+    },
+    {
+      "SPDXID": "SPDXRef-FILE-Modules-hacl-Hacl-Hash-SHA3.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "ecc766fb6f7ee85e902b593b61b41e5a728fca34"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "bae290a94366a2460f51e8468144baaade91d9048db111e10d2e2ffddc3f98cf"
+        }
+      ],
+      "fileName": "Modules/_hacl/Hacl_Hash_SHA3.h"
+    },
+    {
+      "SPDXID": "SPDXRef-FILE-Modules-hacl-Hacl-Streaming-Types.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "ab7b4d9465a2765a07f8d5bccace7182b28ed1b8"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "26913613f3b4f8ffff0a3e211a5ebc849159094e5e11de0a31fcb95b6105b74c"
+        }
+      ],
+      "fileName": "Modules/_hacl/Hacl_Streaming_Types.h"
+    },
+    {
+      "SPDXID": "SPDXRef-FILE-Modules-hacl-include-krml-FStar-UInt128-Verified.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "2ea61d6a236147462045f65c20311819d74db80c"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "2c22b4d49ba06d6a3053cdc66405bd5ae953a28fcfed1ab164e8f5e0f6e2fb8b"
+        }
+      ],
+      "fileName": "Modules/_hacl/include/krml/FStar_UInt128_Verified.h"
+    },
+    {
+      "SPDXID": "SPDXRef-FILE-Modules-hacl-include-krml-FStar-UInt-8-16-32-64.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "1a647d841180ac8ca667afa968c353425e81ad0d"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "e5d1c5854833bec7ea02e227ec35bd7b49c5fb9e0f339efa0dd83e1595f722d4"
+        }
+      ],
+      "fileName": "Modules/_hacl/include/krml/FStar_UInt_8_16_32_64.h"
+    },
+    {
+      "SPDXID": "SPDXRef-FILE-Modules-hacl-include-krml-fstar-uint128-struct-endianness.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "1987119a563a8fdc5966286e274f716dbcea77ee"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "fe57e1bc5ce3224d106e36cb8829b5399c63a68a70b0ccd0c91d82a4565c8869"
+        }
+      ],
+      "fileName": "Modules/_hacl/include/krml/fstar_uint128_struct_endianness.h"
+    },
+    {
+      "SPDXID": "SPDXRef-FILE-Modules-hacl-include-krml-internal-target.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "903c9eb76b01f3a95c04c3bc841c2fb71dea5403"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "08ec602c7f90a1540389c0cfc95769fa7fec251e7ca143ef83c0b9f7afcf89a7"
+        }
+      ],
+      "fileName": "Modules/_hacl/include/krml/internal/target.h"
+    },
+    {
+      "SPDXID": "SPDXRef-FILE-Modules-hacl-include-krml-lowstar-endianness.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "964e09bd99ff2366afd6193b59863fc925e7fb05"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "3734c7942bec9a434e16df069fa45bdcb84b130f14417bc5f7bfe8546272d9f5"
+        }
+      ],
+      "fileName": "Modules/_hacl/include/krml/lowstar_endianness.h"
+    },
+    {
+      "SPDXID": "SPDXRef-FILE-Modules-hacl-include-krml-types.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "df8e0ed74a5970d09d3cc4c6e7c6c7a4c4e5015c"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "de7444c345caa4c47902c4380500356a3ee7e199d2aab84fd8c4960410154f3d"
+        }
+      ],
+      "fileName": "Modules/_hacl/include/krml/types.h"
+    },
+    {
+      "SPDXID": "SPDXRef-FILE-Modules-hacl-internal-Hacl-Hash-MD5.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "5dd4ee3c835a0d176a6e9fecbe9752fd1474ff41"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "d82ef594cba44203576d67b047240316bb3c542912ebb7034afa1e07888cec56"
+        }
+      ],
+      "fileName": "Modules/_hacl/internal/Hacl_Hash_MD5.h"
+    },
+    {
+      "SPDXID": "SPDXRef-FILE-Modules-hacl-internal-Hacl-Hash-SHA1.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "515b3082eb7c30597773e1c63ec46688f6da3634"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "10aacf847006b8e0dfb64d5c327443f954db6718b4aec712fb3268230df6a752"
+        }
+      ],
+      "fileName": "Modules/_hacl/internal/Hacl_Hash_SHA1.h"
+    },
+    {
+      "SPDXID": "SPDXRef-FILE-Modules-hacl-internal-Hacl-Hash-SHA2.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "a044ec12b70ba97b67e9a312827d6270452a20ca"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "a1426b54fa7273ba5b50817c25b2b26fc85c4d1befb14092cd27dc4c99439463"
+        }
+      ],
+      "fileName": "Modules/_hacl/internal/Hacl_Hash_SHA2.h"
+    },
+    {
+      "SPDXID": "SPDXRef-FILE-Modules-hacl-internal-Hacl-Hash-SHA3.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "cfb7b520c39a73cb84c541d370455f92b998781f"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "fd41997f9e96b3c9a3337b1b51fab965a1e21b0c16f353d156f1a1fa00709fbf"
+        }
+      ],
+      "fileName": "Modules/_hacl/internal/Hacl_Hash_SHA3.h"
+    },
+    {
+      "SPDXID": "SPDXRef-FILE-Modules-hacl-python-hacl-namespaces.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "f5c7b3ed911af6c8d582e8b3714b0c36195dc994"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "07de72398b12957e014e97b9ac197bceef12d6d6505c2bfe8b23ee17b94ec5fa"
+        }
+      ],
+      "fileName": "Modules/_hacl/python_hacl_namespaces.h"
+    },
+    {
+      "SPDXID": "SPDXRef-FILE-Modules-blake2-impl-blake2-config.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "ff5e3ae2360adf7279a9c54d12a1d32e16a1f223"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "1eb919e885244e43cdf7b2104ad30dc9271513478c0026f6bfb4bad6e2f0ab42"
+        }
+      ],
+      "fileName": "Modules/_blake2/impl/blake2-config.h"
+    },
+    {
+      "SPDXID": "SPDXRef-FILE-Modules-blake2-impl-blake2-impl.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "28b947b43bdc680b9f4335712bb2a5f2d5d32623"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "4277092643b289f1d36d32cf0fd2efc30ead8bdd99342e5da3b3609dd8ea7d86"
+        }
+      ],
+      "fileName": "Modules/_blake2/impl/blake2-impl.h"
+    },
+    {
+      "SPDXID": "SPDXRef-FILE-Modules-blake2-impl-blake2.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "caa3da7953109d0d2961e3b686d2d285c484b901"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "2f6c9d0ecf70be474f2853b52394993625a32960e0a64eae147ef97a3a5c1460"
+        }
+      ],
+      "fileName": "Modules/_blake2/impl/blake2.h"
+    },
+    {
+      "SPDXID": "SPDXRef-FILE-Modules-blake2-impl-blake2b-load-sse2.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "029a98f87a178936d9e5211c7798b3e0fc622f94"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "b392a6e7b43813a05609e994db5fc3552c5912bd482efc781daa0778eb56ab4e"
+        }
+      ],
+      "fileName": "Modules/_blake2/impl/blake2b-load-sse2.h"
+    },
+    {
+      "SPDXID": "SPDXRef-FILE-Modules-blake2-impl-blake2b-load-sse41.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "fb466dd72344170d09e311e5ea12de99ce071357"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "cc3072c92164142bf2f9dda4e6c08db61be68ec15a95442415e861090d08f6a2"
+        }
+      ],
+      "fileName": "Modules/_blake2/impl/blake2b-load-sse41.h"
+    },
+    {
+      "SPDXID": "SPDXRef-FILE-Modules-blake2-impl-blake2b-ref.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "4c0d79128cf891a95b1f668031d55c0c6d2e0270"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "07b257d44e9cc2d95d4911629c92138feafd16d63fef0a5fa7b38914dfd82349"
+        }
+      ],
+      "fileName": "Modules/_blake2/impl/blake2b-ref.c"
+    },
+    {
+      "SPDXID": "SPDXRef-FILE-Modules-blake2-impl-blake2b-round.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "4c7418e2026417c9c6736fcd305a31f23e05a661"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "fa34a60c2d198a0585033f43fd4003f4ba279c9ebcabdf5d6650def0e6d1e914"
+        }
+      ],
+      "fileName": "Modules/_blake2/impl/blake2b-round.h"
+    },
+    {
+      "SPDXID": "SPDXRef-FILE-Modules-blake2-impl-blake2b.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "6fa074693aa7305018dfa8db48010a8ef1050ad4"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "c8c6dd861ac193d4a0e836242ff44900f83423f86d2c2940c8c4c1e41fbd5812"
+        }
+      ],
+      "fileName": "Modules/_blake2/impl/blake2b.c"
+    },
+    {
+      "SPDXID": "SPDXRef-FILE-Modules-blake2-impl-blake2s-load-sse2.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "ad3f79b6cbe3fd812722114a0d5d08064e69e4d0"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "57f1ac6c09f4a50d95811529062220eab4f29cec3805bc6081dec00426c6df62"
+        }
+      ],
+      "fileName": "Modules/_blake2/impl/blake2s-load-sse2.h"
+    },
+    {
+      "SPDXID": "SPDXRef-FILE-Modules-blake2-impl-blake2s-load-sse41.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "51c32d79f419f3d2eb9875cd9a7f5c0d7892f8a8"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "ecc9e09adcbe098629eafd305596bed8d7004be1d83f326995def42bbde93b23"
+        }
+      ],
+      "fileName": "Modules/_blake2/impl/blake2s-load-sse41.h"
+    },
+    {
+      "SPDXID": "SPDXRef-FILE-Modules-blake2-impl-blake2s-load-xop.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "2749a7ba0104b765d4f56f13faf70b6eb89cf203"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "8bc95595cec4c50f5d70f2b330d3798de07cc784e8890791b3328890e602d5c5"
+        }
+      ],
+      "fileName": "Modules/_blake2/impl/blake2s-load-xop.h"
+    },
+    {
+      "SPDXID": "SPDXRef-FILE-Modules-blake2-impl-blake2s-ref.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "883fcfe85f9063819f21b1100296d1f9eb55bac1"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "9715c00d0f11587a139b07fa26678e6d26e44d3d4910b96158d158da2b022bfb"
+        }
+      ],
+      "fileName": "Modules/_blake2/impl/blake2s-ref.c"
+    },
+    {
+      "SPDXID": "SPDXRef-FILE-Modules-blake2-impl-blake2s-round.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "5d9f69adda40ed163b287b9ed4cedb35b88f2daa"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "65d90111c89c43bb18a9e1d1a4fdbd9f85bebd1ff00129335b85995d0f30ee8b"
+        }
+      ],
+      "fileName": "Modules/_blake2/impl/blake2s-round.h"
+    },
+    {
+      "SPDXID": "SPDXRef-FILE-Modules-blake2-impl-blake2s.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "d2691353fa54ac6ffcd7c0a294984dc9d7968ef7"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "cfd7948c9fd50e9f9c62f8a93b20a254d1d510a862d1092af4f187b7c1a859a3"
+        }
+      ],
+      "fileName": "Modules/_blake2/impl/blake2s.c"
+    },
+    {
+      "SPDXID": "SPDXRef-FILE-Lib-ctypes-macholib-init-.py",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "0fbc026a9771d9675e7094790b5b945334d3cb53"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "1e77c01eec8f167ed10b754f153c0c743c8e5196ae9c81dffc08f129ab56dbfd"
+        }
+      ],
+      "fileName": "Lib/ctypes/macholib/__init__.py"
+    },
+    {
+      "SPDXID": "SPDXRef-FILE-Lib-ctypes-macholib-dyld.py",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "4a78ebd73ce4167c722689781a15fe0b4578e967"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "eb8e7b17f1533bc3e86e23e8695f7a5e4b7a99ef1b1575d10af54f389161b655"
+        }
+      ],
+      "fileName": "Lib/ctypes/macholib/dyld.py"
+    },
+    {
+      "SPDXID": "SPDXRef-FILE-Lib-ctypes-macholib-dylib.py",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "f339420cc01bd01f8d0da19b6102f099075e8bcd"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "f19ee056b18165cc6735efab0b4ca3508be9405b9646c38113316c15e8278a6f"
+        }
+      ],
+      "fileName": "Lib/ctypes/macholib/dylib.py"
+    },
+    {
+      "SPDXID": "SPDXRef-FILE-Lib-ctypes-macholib-framework.py",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "0b219f58467d7f193fa1de0c1b118485840d855b"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "302439e40d9cbdd61b8b7cffd0b7e1278a6811b635044ee366a36e0d991f62da"
+        }
+      ],
+      "fileName": "Lib/ctypes/macholib/framework.py"
+    },
+    {
+      "SPDXID": "SPDXRef-FILE-Modules-decimal-libmpdec-README.txt",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "bda6e0bd6121f7069b420bdc0bc7c49414d948d1"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "89926cd0fe6cfb33a2b5b7416c101e9b5d42b0d639d348e0871acf6ffc8258a3"
+        }
+      ],
+      "fileName": "Modules/_decimal/libmpdec/README.txt"
+    },
+    {
+      "SPDXID": "SPDXRef-FILE-Modules-decimal-libmpdec-basearith.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "33757ce2ec0c93c1b5e03c45a495563a00e498ae"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "ad498362c31a5b99ab19fce320ac540cf14c5c4ec09478f0ad3858da1428113d"
+        }
+      ],
+      "fileName": "Modules/_decimal/libmpdec/basearith.c"
+    },
+    {
+      "SPDXID": "SPDXRef-FILE-Modules-decimal-libmpdec-basearith.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "bf03919412c068e6969e7ac48850f91bfcd3b2b1"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "2eaac88a71b9bcf3144396c12dcfeced573e0e550a0050d75b9ed3903248596d"
+        }
+      ],
+      "fileName": "Modules/_decimal/libmpdec/basearith.h"
+    },
+    {
+      "SPDXID": "SPDXRef-FILE-Modules-decimal-libmpdec-bench.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "c925b7f26754ae182aaa461d51802e8b6a2bb5e9"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "007e38542ec8d9d8805fe243b5390d79211b9360e2797a20079e833e68ad9e45"
+        }
+      ],
+      "fileName": "Modules/_decimal/libmpdec/bench.c"
+    },
+    {
+      "SPDXID": "SPDXRef-FILE-Modules-decimal-libmpdec-bench-full.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "cb22686269685a53a17afdea9ed984714e399d9d"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "1b9e892d4b268deea835ec8906f20a1e5d25e037b2e698edcd34315613f3608c"
+        }
+      ],
+      "fileName": "Modules/_decimal/libmpdec/bench_full.c"
+    },
+    {
+      "SPDXID": "SPDXRef-FILE-Modules-decimal-libmpdec-bits.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "fc91c2450cdf1e785d1347411662294c3945eb27"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "ce7741e58ea761a24250c0bfa10058cec8c4fd220dca70a41de3927a2e4f5376"
+        }
+      ],
+      "fileName": "Modules/_decimal/libmpdec/bits.h"
+    },
+    {
+      "SPDXID": "SPDXRef-FILE-Modules-decimal-libmpdec-constants.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "7187c18916b0a546ec19b4fc4bec43d0d9fb5fc2"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "cd430b8657cf8a616916e02f9bd5ca044d5fc19e69333f5d427e1fdb90b0864b"
+        }
+      ],
+      "fileName": "Modules/_decimal/libmpdec/constants.c"
+    },
+    {
+      "SPDXID": "SPDXRef-FILE-Modules-decimal-libmpdec-constants.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "af9cbd016fb0ef0b30ced49c0aa4ce2ca3c20125"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "19dc46df04abb7ee08e9a403f87c8aac8d4a077efcce314c597f8b73e22884f2"
+        }
+      ],
+      "fileName": "Modules/_decimal/libmpdec/constants.h"
+    },
+    {
+      "SPDXID": "SPDXRef-FILE-Modules-decimal-libmpdec-context.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "666162870230bebd3f2383020d908806fd03909e"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "9a265d366f31894aad78bca7fcdc1457bc4a3aa3887ca231b7d78e41f79541c0"
+        }
+      ],
+      "fileName": "Modules/_decimal/libmpdec/context.c"
+    },
+    {
+      "SPDXID": "SPDXRef-FILE-Modules-decimal-libmpdec-convolute.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "0545547a8b37b922fbe2574fbad8fc3bf16f1d33"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "66fe27b9bb37039cad5be32b105ed509e5aefa15c1957a9058af8ee23cddc97a"
+        }
+      ],
+      "fileName": "Modules/_decimal/libmpdec/convolute.c"
+    },
+    {
+      "SPDXID": "SPDXRef-FILE-Modules-decimal-libmpdec-convolute.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "05ff0936c5bb08f40d460f5843004a1cc0751d9b"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "c00d17450c2b8e1d7f1eb8a084f7e6a68f257a453f8701600e860bf357c531d7"
+        }
+      ],
+      "fileName": "Modules/_decimal/libmpdec/convolute.h"
+    },
+    {
+      "SPDXID": "SPDXRef-FILE-Modules-decimal-libmpdec-crt.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "fe8176849bc99a306332ba25caa4e91bfa3c6f7d"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "1f4e65c44864c3e911a6e91f33adec76765293e90553459e3ebce35a58898dba"
+        }
+      ],
+      "fileName": "Modules/_decimal/libmpdec/crt.c"
+    },
+    {
+      "SPDXID": "SPDXRef-FILE-Modules-decimal-libmpdec-crt.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "1930b9e0910014b3479aec4e940f02118d9e4a08"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "7d31f1d0dd73b62964dab0f7a1724473bf87f1f95d8febf0b40c15430ae9a47c"
+        }
+      ],
+      "fileName": "Modules/_decimal/libmpdec/crt.h"
+    },
+    {
+      "SPDXID": "SPDXRef-FILE-Modules-decimal-libmpdec-difradix2.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "415c51e7d7f517b6366bec2a809610d0d38ada14"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "0a9fef8a374f55277e9f6000b7277bb037b9763c32b156c29950422b057498bd"
+        }
+      ],
+      "fileName": "Modules/_decimal/libmpdec/difradix2.c"
+    },
+    {
+      "SPDXID": "SPDXRef-FILE-Modules-decimal-libmpdec-difradix2.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "d8a998c3bee4c3d9059ba7bf9ae6a8b64649c2ba"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "5c6766496224de657400995b58b64db3e7084004bf00daebdd7e08d0c5995243"
+        }
+      ],
+      "fileName": "Modules/_decimal/libmpdec/difradix2.h"
+    },
+    {
+      "SPDXID": "SPDXRef-FILE-Modules-decimal-libmpdec-examples-README.txt",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "158f6ad18edf348efa4fdd7cf61114c77c1d22e9"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "7b0da2758097a2688f06b3c7ca46b2ebc8329addbd28bb4f5fe95626cc81f8a9"
+        }
+      ],
+      "fileName": "Modules/_decimal/libmpdec/examples/README.txt"
+    },
+    {
+      "SPDXID": "SPDXRef-FILE-Modules-decimal-libmpdec-examples-compare.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "ef80ba26847287fb351ab0df0a78b5f08ba0b5b7"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "452666ee4eb10a8cf0a926cb3bcf5e95b5c361fa129dbdfe27b654e6d640417e"
+        }
+      ],
+      "fileName": "Modules/_decimal/libmpdec/examples/compare.c"
+    },
+    {
+      "SPDXID": "SPDXRef-FILE-Modules-decimal-libmpdec-examples-div.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "6ca3a369b3d1e140fdc93c4fdbedb724f7daf969"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "6d369f5a24d0bb1e7cb6a4f8b0e97a273260e7668c8a540a8fcc92e039f7af2e"
+        }
+      ],
+      "fileName": "Modules/_decimal/libmpdec/examples/div.c"
+    },
+    {
+      "SPDXID": "SPDXRef-FILE-Modules-decimal-libmpdec-examples-divmod.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "3872a28b4f77e07e1760256067ea338a8dd183f8"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "5db54bae75ac3d7fa12f1bb0f7ce1bf797df86a81030e8c3ce44d3b1f9b958b7"
+        }
+      ],
+      "fileName": "Modules/_decimal/libmpdec/examples/divmod.c"
+    },
+    {
+      "SPDXID": "SPDXRef-FILE-Modules-decimal-libmpdec-examples-multiply.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "25dbc94fd4ee5dec21061d2d40dd5d0f88849cb1"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "22ed39b18fa740a27aacfd29a7bb40066be24500ba49b9b1f24e2af1e039fcd9"
+        }
+      ],
+      "fileName": "Modules/_decimal/libmpdec/examples/multiply.c"
+    },
+    {
+      "SPDXID": "SPDXRef-FILE-Modules-decimal-libmpdec-examples-pow.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "13d3b7657dc2dc5000fea428f57963d520792ef7"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "cd8c037649b3d4d6897c9acd2f92f3f9d5390433061d5e48623a5d526a3f4f9c"
+        }
+      ],
+      "fileName": "Modules/_decimal/libmpdec/examples/pow.c"
+    },
+    {
+      "SPDXID": "SPDXRef-FILE-Modules-decimal-libmpdec-examples-powmod.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "1f7e6c3d3e38df52bbcec0f5a180a8f328679618"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "e29614b43abf1856b656a84d6b67c22cc5dc7af8cbae8ddc7acf17022220ee12"
+        }
+      ],
+      "fileName": "Modules/_decimal/libmpdec/examples/powmod.c"
+    },
+    {
+      "SPDXID": "SPDXRef-FILE-Modules-decimal-libmpdec-examples-shift.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "0bd9ce89c7987d1109eb7b0c8f1f9a1298e1422e"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "203f2dbf11d115580cb3c7c524ac6ccca2a7b31d89545db1b6263381b5de2b6a"
+        }
+      ],
+      "fileName": "Modules/_decimal/libmpdec/examples/shift.c"
+    },
+    {
+      "SPDXID": "SPDXRef-FILE-Modules-decimal-libmpdec-examples-sqrt.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "b401ba0814e17c9164c0df26e01cc0a355382f46"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "f3dc2ce321833bbd4b3d1d9ea6fa2e0bcc1bfe1e39abb8d55be53e46c33949db"
+        }
+      ],
+      "fileName": "Modules/_decimal/libmpdec/examples/sqrt.c"
+    },
+    {
+      "SPDXID": "SPDXRef-FILE-Modules-decimal-libmpdec-fnt.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "060615ddef089a5a8f879a57e4968d920972a0e2"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "a9f923524d53a9445769f27405375ec3d95fa804bb11db5ee249ae047f11cfce"
+        }
+      ],
+      "fileName": "Modules/_decimal/libmpdec/fnt.c"
+    },
+    {
+      "SPDXID": "SPDXRef-FILE-Modules-decimal-libmpdec-fnt.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "b205043ebeaf065b16505a299342a992654f19b0"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "3b03e69adf78fde68c8f87d33595d557237581d33fc067e1039eed9e9f2cc44c"
+        }
+      ],
+      "fileName": "Modules/_decimal/libmpdec/fnt.h"
+    },
+    {
+      "SPDXID": "SPDXRef-FILE-Modules-decimal-libmpdec-fourstep.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "702c27599b43280c94906235d7e1a74193ba701b"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "cf2e69b946ec14b087e523c0ff606553070d13c23e851fb0ba1df51a728017e6"
+        }
+      ],
+      "fileName": "Modules/_decimal/libmpdec/fourstep.c"
+    },
+    {
+      "SPDXID": "SPDXRef-FILE-Modules-decimal-libmpdec-fourstep.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "ee5291c265ef1f5ae373bc243a4d96975eb3e7b5"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "dbaced03b52d0f880c377b86c943bcb36f24d557c99a5e9732df3ad5debb5917"
+        }
+      ],
+      "fileName": "Modules/_decimal/libmpdec/fourstep.h"
+    },
+    {
+      "SPDXID": "SPDXRef-FILE-Modules-decimal-libmpdec-io.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "12402bcf7f0161adb83f78163f41cc10a5e5de5f"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "cba044c76b6bc3ae6cfa49df1121cad7552140157b9e61e11cbb6580cc5d74cf"
+        }
+      ],
+      "fileName": "Modules/_decimal/libmpdec/io.c"
+    },
+    {
+      "SPDXID": "SPDXRef-FILE-Modules-decimal-libmpdec-io.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "28c653cd40b1ce46575e41f5dbfda5f6dd0db4d1"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "259eab89fe27914e0e39e61199094a357ac60d86b2aab613c909040ff64a4a0c"
+        }
+      ],
+      "fileName": "Modules/_decimal/libmpdec/io.h"
+    },
+    {
+      "SPDXID": "SPDXRef-FILE-Modules-decimal-libmpdec-literature-REFERENCES.txt",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "218d1d7bedb335cd2c31eae89a15873c3139e13f"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "a57e8bed93ded481ef264166aec2c49d1a7f3252f29a873ee41fff053cfd9c20"
+        }
+      ],
+      "fileName": "Modules/_decimal/libmpdec/literature/REFERENCES.txt"
+    },
+    {
+      "SPDXID": "SPDXRef-FILE-Modules-decimal-libmpdec-literature-bignum.txt",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "f67eab2431336cf6eeafb30cdafd7e54c251def3"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "dc34aa122c208ce79e3fc6baee8628094ffaf6a662862dd5647836241f6ebd79"
+        }
+      ],
+      "fileName": "Modules/_decimal/libmpdec/literature/bignum.txt"
+    },
+    {
+      "SPDXID": "SPDXRef-FILE-Modules-decimal-libmpdec-literature-fnt.py",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "a58cfbcd8ea57d66ddfd11fb5a170138c8bbfb3a"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "122de20eebf87274af2d02072251a94500e7df2d5ef29e81aeabeda991c079e3"
+        }
+      ],
+      "fileName": "Modules/_decimal/libmpdec/literature/fnt.py"
+    },
+    {
+      "SPDXID": "SPDXRef-FILE-Modules-decimal-libmpdec-literature-matrix-transform.txt",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "9a947f6b660150cbd457c4458da2956a36c5824d"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "592659e7192e3a939b797f5bc7455455834a285f5d8b643ccd780b5114914f73"
+        }
+      ],
+      "fileName": "Modules/_decimal/libmpdec/literature/matrix-transform.txt"
+    },
+    {
+      "SPDXID": "SPDXRef-FILE-Modules-decimal-libmpdec-literature-mulmod-64.txt",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "69fe9afb8353b5a2b57917469c51c64ac518169d"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "229a80ca940c594a32e3345412370cbc097043fe59c66a6153cbcf01e7837266"
+        }
+      ],
+      "fileName": "Modules/_decimal/libmpdec/literature/mulmod-64.txt"
+    },
+    {
+      "SPDXID": "SPDXRef-FILE-Modules-decimal-libmpdec-literature-mulmod-ppro.txt",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "720d468a1f51098036c7a0c869810fff22ed9b79"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "f3549fc73f697a087267c7b042e30a409e191cbba69a2c0902685e507fbae9f7"
+        }
+      ],
+      "fileName": "Modules/_decimal/libmpdec/literature/mulmod-ppro.txt"
+    },
+    {
+      "SPDXID": "SPDXRef-FILE-Modules-decimal-libmpdec-literature-six-step.txt",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "6815ec3a39baebebe7b3f51d45d10c180a659f17"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "bf15f73910a173c98fca9db56122b6cc71983668fa8b934c46ca21a57398ec54"
+        }
+      ],
+      "fileName": "Modules/_decimal/libmpdec/literature/six-step.txt"
+    },
+    {
+      "SPDXID": "SPDXRef-FILE-Modules-decimal-libmpdec-literature-umodarith.lisp",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "c91ac4438e661ce78f86e981257546e5adff39ae"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "783a1b4b9b7143677b0c3d30ffaf28aa0cb01956409031fa38ed8011970bdee0"
+        }
+      ],
+      "fileName": "Modules/_decimal/libmpdec/literature/umodarith.lisp"
+    },
+    {
+      "SPDXID": "SPDXRef-FILE-Modules-decimal-libmpdec-mpalloc.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "7e8dfb4b7a801b48c501969b001153203b14679e"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "5ba2f4c80302e71fb216aa247c858e0bf6c8cfabffe7980ac17d4d023c0fef2b"
+        }
+      ],
+      "fileName": "Modules/_decimal/libmpdec/mpalloc.c"
+    },
+    {
+      "SPDXID": "SPDXRef-FILE-Modules-decimal-libmpdec-mpalloc.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "bccb6a6ae76fd7f6c8a9102a78958bcad7862950"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "f7412521de38afb837fcabc2b1d48b971b86bfaa55f3f40d58ff9e46e92debd3"
+        }
+      ],
+      "fileName": "Modules/_decimal/libmpdec/mpalloc.h"
+    },
+    {
+      "SPDXID": "SPDXRef-FILE-Modules-decimal-libmpdec-mpdecimal.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "f4539afb1ace58c52d18ffd0cc7704f53ca55182"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "4f89b8095e408a18deff79cfb605299e615bae747898eb105d8936064f7fb626"
+        }
+      ],
+      "fileName": "Modules/_decimal/libmpdec/mpdecimal.c"
+    },
+    {
+      "SPDXID": "SPDXRef-FILE-Modules-decimal-libmpdec-mpdecimal.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "4b80e25ac49b7e1ea0d1e84967ee32a3d111fc4c"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "ea0b9c6b296c13aed6ecaa50b463e39a9c1bdc059b84f50507fd8247b2e660f9"
+        }
+      ],
+      "fileName": "Modules/_decimal/libmpdec/mpdecimal.h"
+    },
+    {
+      "SPDXID": "SPDXRef-FILE-Modules-decimal-libmpdec-mpsignal.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "5c7305a6db0fddf64c6d97e29d3b0c402e3d5d6e"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "653171cf2549719478417db7e9800fa0f9d99c02dec6da6876329ccf2c07b93f"
+        }
+      ],
+      "fileName": "Modules/_decimal/libmpdec/mpsignal.c"
+    },
+    {
+      "SPDXID": "SPDXRef-FILE-Modules-decimal-libmpdec-numbertheory.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "d736b874c43777ca021dde5289ea718893f39219"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "bdbf2e246f341a3ba3f6f9d8759e7cb222eb9b15f9ed1e7c9f6a59cbb9f8bc91"
+        }
+      ],
+      "fileName": "Modules/_decimal/libmpdec/numbertheory.c"
+    },
+    {
+      "SPDXID": "SPDXRef-FILE-Modules-decimal-libmpdec-numbertheory.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "d341508d8c6dd4c4cbd8b99afc8029945f9bbe0d"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "2f7d5b40af508fa6ac86f5d62101fa3bf683c63b24aa87c9548e3fdd13abc57b"
+        }
+      ],
+      "fileName": "Modules/_decimal/libmpdec/numbertheory.h"
+    },
+    {
+      "SPDXID": "SPDXRef-FILE-Modules-decimal-libmpdec-sixstep.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "cbd05d68bb3940d0d7d0818b14cc03b090a4dd74"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "7602aaf98ec9525bc4b3cab9631615e1be2efd9af894002ef4e3f5ec63924fcf"
+        }
+      ],
+      "fileName": "Modules/_decimal/libmpdec/sixstep.c"
+    },
+    {
+      "SPDXID": "SPDXRef-FILE-Modules-decimal-libmpdec-sixstep.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "4c059463ec4b4522562dab24760fc64c172c9eee"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "a191366348b3d3dd49b9090ec5c77dbd77bb3a523c01ff32adafa137e5097ce7"
+        }
+      ],
+      "fileName": "Modules/_decimal/libmpdec/sixstep.h"
+    },
+    {
+      "SPDXID": "SPDXRef-FILE-Modules-decimal-libmpdec-transpose.c",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "cc5593ac9fdb60480cc23fc9d6f27d85670bd35f"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "2d12fcae512143a9376c8a0d4c1ba3008e420e024497a7e7ec64c6bec23fcddc"
+        }
+      ],
+      "fileName": "Modules/_decimal/libmpdec/transpose.c"
+    },
+    {
+      "SPDXID": "SPDXRef-FILE-Modules-decimal-libmpdec-transpose.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "2f616425756b6cbdf7d189744870b98b613455bd"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "fafeb2b901b2b41bf0df00be7d99b84df1a78e3cc1e582e09cbfc3b6d44d4abe"
+        }
+      ],
+      "fileName": "Modules/_decimal/libmpdec/transpose.h"
+    },
+    {
+      "SPDXID": "SPDXRef-FILE-Modules-decimal-libmpdec-typearith.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "b1e9341e173cc8e219ad4aa45fad36d92cce10d3"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "25e0a0703b51744277834e6b2398d7b7d2c17f92bf30f8b6f949e0486ae2b346"
+        }
+      ],
+      "fileName": "Modules/_decimal/libmpdec/typearith.h"
+    },
+    {
+      "SPDXID": "SPDXRef-FILE-Modules-decimal-libmpdec-umodarith.h",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "46f6483fce136cd3cc2f7516ee119a487d86333e"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "bfe1ddb2ca92906456b80745adcbe02c83cadac3ef69caa21bc09b7292cc152b"
+        }
+      ],
+      "fileName": "Modules/_decimal/libmpdec/umodarith.h"
+    },
+    {
+      "SPDXID": "SPDXRef-FILE-Modules-decimal-libmpdec-vcdiv64.asm",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "d0cc1052fcba08b773d935b0ae2dc6b80d0f2f68"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "aacc3e47ea8f41e8840c6c67f64ec96d54696a16889903098fa1aab56949a00f"
+        }
+      ],
+      "fileName": "Modules/_decimal/libmpdec/vcdiv64.asm"
+    },
+    {
+      "SPDXID": "SPDXRef-FILE-Lib-ensurepip-bundled-pip-23.3.2-py3-none-any.whl",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "8e48f55ab2965ee64bd55cc91a8077d184a33e30"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "5052d7889c1f9d05224cd41741acb7c5d6fa735ab34e339624a614eaaa7e7d76"
+        }
+      ],
+      "fileName": "Lib/ensurepip/_bundled/pip-23.3.2-py3-none-any.whl"
+    }
+  ],
+  "packages": [
+    {
+      "SPDXID": "SPDXRef-PACKAGE-expat",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "6b902ab103843592be5e99504f846ec109c1abb692e85347587f237a4ffa1033"
+        }
+      ],
+      "downloadLocation": "https://github.com/libexpat/libexpat/releases/download/R_2_5_0/expat-2.5.0.tar.gz",
+      "externalRefs": [
+        {
+          "referenceCategory": "SECURITY",
+          "referenceLocator": "cpe:2.3:a:libexpat_project:libexpat:2.5.0:*:*:*:*:*:*:*",
+          "referenceType": "cpe23Type"
+        }
+      ],
+      "licenseConcluded": "MIT",
+      "name": "expat",
+      "originator": "Organization: Expat development team",
+      "primaryPackagePurpose": "SOURCE",
+      "versionInfo": "2.5.0"
+    },
+    {
+      "SPDXID": "SPDXRef-PACKAGE-hacl-star",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "c23ac158b238c368389dc86bfc315263e5c0e57785da74144aea2cab9a3d51a2"
+        }
+      ],
+      "downloadLocation": "https://github.com/hacl-star/hacl-star/archive/521af282fdf6d60227335120f18ae9309a4b8e8c.zip",
+      "externalRefs": [
+        {
+          "referenceCategory": "SECURITY",
+          "referenceLocator": "cpe:2.3:a:hacl-star:hacl-star:521af282fdf6d60227335120f18ae9309a4b8e8c:*:*:*:*:*:*:*",
+          "referenceType": "cpe23Type"
+        }
+      ],
+      "licenseConcluded": "Apache-2.0",
+      "name": "hacl-star",
+      "originator": "Organization: HACL* Developers",
+      "primaryPackagePurpose": "SOURCE",
+      "versionInfo": "521af282fdf6d60227335120f18ae9309a4b8e8c"
+    },
+    {
+      "SPDXID": "SPDXRef-PACKAGE-libb2",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "53626fddce753c454a3fea581cbbc7fe9bbcf0bc70416d48fdbbf5d87ef6c72e"
+        }
+      ],
+      "downloadLocation": "https://github.com/BLAKE2/libb2/releases/download/v0.98.1/libb2-0.98.1.tar.gz",
+      "externalRefs": [
+        {
+          "referenceCategory": "SECURITY",
+          "referenceLocator": "cpe:2.3:a:blake2:libb2:0.98.1:*:*:*:*:*:*:*",
+          "referenceType": "cpe23Type"
+        }
+      ],
+      "licenseConcluded": "CC0-1.0",
+      "name": "libb2",
+      "originator": "Organization: BLAKE2 - fast secure hashing",
+      "primaryPackagePurpose": "SOURCE",
+      "versionInfo": "0.98.1"
+    },
+    {
+      "SPDXID": "SPDXRef-PACKAGE-macholib",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "c76f268f5054024e962f2515a0e522baf85313064f6740d80375afc850787a38"
+        }
+      ],
+      "downloadLocation": "https://files.pythonhosted.org/packages/ec/57/f0a712efc3ed982cf4038a3cee172057303b9be914c32c93b2fbec27f785/macholib-1.0.tar.gz",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE_MANAGER",
+          "referenceLocator": "pkg:pypi/macholib@1.0",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT",
+      "name": "macholib",
+      "originator": "Person: Ronald Oussoren (ronaldoussoren@mac.com)",
+      "primaryPackagePurpose": "SOURCE",
+      "versionInfo": "1.0"
+    },
+    {
+      "SPDXID": "SPDXRef-PACKAGE-mpdecimal",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "9f9cd4c041f99b5c49ffb7b59d9f12d95b683d88585608aa56a6307667b2b21f"
+        }
+      ],
+      "downloadLocation": "https://www.bytereef.org/software/mpdecimal/releases/mpdecimal-2.5.1.tar.gz",
+      "externalRefs": [
+        {
+          "referenceCategory": "SECURITY",
+          "referenceLocator": "cpe:2.3:a:bytereef:mpdecimal:2.5.1:*:*:*:*:*:*:*",
+          "referenceType": "cpe23Type"
+        }
+      ],
+      "licenseConcluded": "BSD-2-Clause",
+      "name": "mpdecimal",
+      "originator": "Organization: bytereef.org",
+      "primaryPackagePurpose": "SOURCE",
+      "versionInfo": "2.5.1"
+    },
+    {
+      "SPDXID": "SPDXRef-PACKAGE-cachecontrol",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "95dedbec849f46dda3137866dc28b9d133fc9af55f5b805ab1291833e4457aa4"
+        }
+      ],
+      "downloadLocation": "https://files.pythonhosted.org/packages/1d/e3/a22348e6226dcd585d5a4b5f0175b3a16dabfd3912cbeb02f321d00e56c7/cachecontrol-0.13.1-py3-none-any.whl",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE_MANAGER",
+          "referenceLocator": "pkg:pypi/cachecontrol@0.13.1",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT",
+      "name": "cachecontrol",
+      "primaryPackagePurpose": "SOURCE",
+      "versionInfo": "0.13.1"
+    },
+    {
+      "SPDXID": "SPDXRef-PACKAGE-colorama",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"
+        }
+      ],
+      "downloadLocation": "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE_MANAGER",
+          "referenceLocator": "pkg:pypi/colorama@0.4.6",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT",
+      "name": "colorama",
+      "primaryPackagePurpose": "SOURCE",
+      "versionInfo": "0.4.6"
+    },
+    {
+      "SPDXID": "SPDXRef-PACKAGE-distlib",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "f35c4b692542ca110de7ef0bea44d73981caeb34ca0b9b6b2e6d7790dda8f80e"
+        }
+      ],
+      "downloadLocation": "https://files.pythonhosted.org/packages/76/cb/6bbd2b10170ed991cf64e8c8b85e01f2fb38f95d1bc77617569e0b0b26ac/distlib-0.3.6-py2.py3-none-any.whl",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE_MANAGER",
+          "referenceLocator": "pkg:pypi/distlib@0.3.6",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT",
+      "name": "distlib",
+      "primaryPackagePurpose": "SOURCE",
+      "versionInfo": "0.3.6"
+    },
+    {
+      "SPDXID": "SPDXRef-PACKAGE-distro",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "99522ca3e365cac527b44bde033f64c6945d90eb9f769703caaec52b09bbd3ff"
+        }
+      ],
+      "downloadLocation": "https://files.pythonhosted.org/packages/f4/2c/c90a3adaf0ddb70afe193f5ebfb539612af57cffe677c3126be533df3098/distro-1.8.0-py3-none-any.whl",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE_MANAGER",
+          "referenceLocator": "pkg:pypi/distro@1.8.0",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT",
+      "name": "distro",
+      "primaryPackagePurpose": "SOURCE",
+      "versionInfo": "1.8.0"
+    },
+    {
+      "SPDXID": "SPDXRef-PACKAGE-msgpack",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "525228efd79bb831cf6830a732e2e80bc1b05436b086d4264814b4b2955b2fa9"
+        }
+      ],
+      "downloadLocation": "https://files.pythonhosted.org/packages/9f/4a/36d936e54cf71e23ad276564465f6a54fb129e3d61520b76e13e0bb29167/msgpack-1.0.5-cp310-cp310-macosx_10_9_universal2.whl",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE_MANAGER",
+          "referenceLocator": "pkg:pypi/msgpack@1.0.5",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT",
+      "name": "msgpack",
+      "primaryPackagePurpose": "SOURCE",
+      "versionInfo": "1.0.5"
+    },
+    {
+      "SPDXID": "SPDXRef-PACKAGE-packaging",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522"
+        }
+      ],
+      "downloadLocation": "https://files.pythonhosted.org/packages/05/8e/8de486cbd03baba4deef4142bd643a3e7bbe954a784dc1bb17142572d127/packaging-21.3-py3-none-any.whl",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE_MANAGER",
+          "referenceLocator": "pkg:pypi/packaging@21.3",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT",
+      "name": "packaging",
+      "primaryPackagePurpose": "SOURCE",
+      "versionInfo": "21.3"
+    },
+    {
+      "SPDXID": "SPDXRef-PACKAGE-platformdirs",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "cec7b889196b9144d088e4c57d9ceef7374f6c39694ad1577a0aab50d27ea28c"
+        }
+      ],
+      "downloadLocation": "https://files.pythonhosted.org/packages/9e/d8/563a9fc17153c588c8c2042d2f0f84a89057cdb1c30270f589c88b42d62c/platformdirs-3.8.1-py3-none-any.whl",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE_MANAGER",
+          "referenceLocator": "pkg:pypi/platformdirs@3.8.1",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT",
+      "name": "platformdirs",
+      "primaryPackagePurpose": "SOURCE",
+      "versionInfo": "3.8.1"
+    },
+    {
+      "SPDXID": "SPDXRef-PACKAGE-pyparsing",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "d554a96d1a7d3ddaf7183104485bc19fd80543ad6ac5bdb6426719d766fb06c1"
+        }
+      ],
+      "downloadLocation": "https://files.pythonhosted.org/packages/a4/24/6ae4c9c45cf99d96b06b5d99e25526c060303171fb0aea9da2bfd7dbde93/pyparsing-3.1.0-py3-none-any.whl",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE_MANAGER",
+          "referenceLocator": "pkg:pypi/pyparsing@3.1.0",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT",
+      "name": "pyparsing",
+      "primaryPackagePurpose": "SOURCE",
+      "versionInfo": "3.1.0"
+    },
+    {
+      "SPDXID": "SPDXRef-PACKAGE-pyproject-hooks",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "283c11acd6b928d2f6a7c73fa0d01cb2bdc5f07c57a2eeb6e83d5e56b97976f8"
+        }
+      ],
+      "downloadLocation": "https://files.pythonhosted.org/packages/d5/ea/9ae603de7fbb3df820b23a70f6aff92bf8c7770043254ad8d2dc9d6bcba4/pyproject_hooks-1.0.0-py3-none-any.whl",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE_MANAGER",
+          "referenceLocator": "pkg:pypi/pyproject-hooks@1.0.0",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT",
+      "name": "pyproject-hooks",
+      "primaryPackagePurpose": "SOURCE",
+      "versionInfo": "1.0.0"
+    },
+    {
+      "SPDXID": "SPDXRef-PACKAGE-requests",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "58cd2187c01e70e6e26505bca751777aa9f2ee0b7f4300988b709f44e013003f"
+        }
+      ],
+      "downloadLocation": "https://files.pythonhosted.org/packages/70/8e/0e2d847013cb52cd35b38c009bb167a1a26b2ce6cd6965bf26b47bc0bf44/requests-2.31.0-py3-none-any.whl",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE_MANAGER",
+          "referenceLocator": "pkg:pypi/requests@2.31.0",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT",
+      "name": "requests",
+      "primaryPackagePurpose": "SOURCE",
+      "versionInfo": "2.31.0"
+    },
+    {
+      "SPDXID": "SPDXRef-PACKAGE-certifi",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "92d6037539857d8206b8f6ae472e8b77db8058fec5937a1ef3f54304089edbb9"
+        }
+      ],
+      "downloadLocation": "https://files.pythonhosted.org/packages/4c/dd/2234eab22353ffc7d94e8d13177aaa050113286e93e7b40eae01fbf7c3d9/certifi-2023.7.22-py3-none-any.whl",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE_MANAGER",
+          "referenceLocator": "pkg:pypi/certifi@2023.7.22",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT",
+      "name": "certifi",
+      "primaryPackagePurpose": "SOURCE",
+      "versionInfo": "2023.7.22"
+    },
+    {
+      "SPDXID": "SPDXRef-PACKAGE-chardet",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "362777fb014af596ad31334fde1e8c327dfdb076e1960d1694662d46a6917ab9"
+        }
+      ],
+      "downloadLocation": "https://files.pythonhosted.org/packages/74/8f/8fc49109009e8d2169d94d72e6b1f4cd45c13d147ba7d6170fb41f22b08f/chardet-5.1.0-py3-none-any.whl",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE_MANAGER",
+          "referenceLocator": "pkg:pypi/chardet@5.1.0",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT",
+      "name": "chardet",
+      "primaryPackagePurpose": "SOURCE",
+      "versionInfo": "5.1.0"
+    },
+    {
+      "SPDXID": "SPDXRef-PACKAGE-idna",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "90b77e79eaa3eba6de819a0c442c0b4ceefc341a7a2ab77d7562bf49f425c5c2"
+        }
+      ],
+      "downloadLocation": "https://files.pythonhosted.org/packages/fc/34/3030de6f1370931b9dbb4dad48f6ab1015ab1d32447850b9fc94e60097be/idna-3.4-py3-none-any.whl",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE_MANAGER",
+          "referenceLocator": "pkg:pypi/idna@3.4",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT",
+      "name": "idna",
+      "primaryPackagePurpose": "SOURCE",
+      "versionInfo": "3.4"
+    },
+    {
+      "SPDXID": "SPDXRef-PACKAGE-rich",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "8f87bc7ee54675732fa66a05ebfe489e27264caeeff3728c945d25971b6485ec"
+        }
+      ],
+      "downloadLocation": "https://files.pythonhosted.org/packages/fc/1e/482e5eec0b89b593e81d78f819a9412849814e22225842b598908e7ac560/rich-13.4.2-py3-none-any.whl",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE_MANAGER",
+          "referenceLocator": "pkg:pypi/rich@13.4.2",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT",
+      "name": "rich",
+      "primaryPackagePurpose": "SOURCE",
+      "versionInfo": "13.4.2"
+    },
+    {
+      "SPDXID": "SPDXRef-PACKAGE-pygments",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "db2db3deb4b4179f399a09054b023b6a586b76499d36965813c71aa8ed7b5fd1"
+        }
+      ],
+      "downloadLocation": "https://files.pythonhosted.org/packages/34/a7/37c8d68532ba71549db4212cb036dbd6161b40e463aba336770e80c72f84/Pygments-2.15.1-py3-none-any.whl",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE_MANAGER",
+          "referenceLocator": "pkg:pypi/pygments@2.15.1",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT",
+      "name": "pygments",
+      "primaryPackagePurpose": "SOURCE",
+      "versionInfo": "2.15.1"
+    },
+    {
+      "SPDXID": "SPDXRef-PACKAGE-typing-extensions",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "440d5dd3af93b060174bf433bccd69b0babc3b15b1a8dca43789fd7f61514b36"
+        }
+      ],
+      "downloadLocation": "https://files.pythonhosted.org/packages/ec/6b/63cc3df74987c36fe26157ee12e09e8f9db4de771e0f3404263117e75b95/typing_extensions-4.7.1-py3-none-any.whl",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE_MANAGER",
+          "referenceLocator": "pkg:pypi/typing_extensions@4.7.1",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT",
+      "name": "typing_extensions",
+      "primaryPackagePurpose": "SOURCE",
+      "versionInfo": "4.7.1"
+    },
+    {
+      "SPDXID": "SPDXRef-PACKAGE-resolvelib",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "d2da45d1a8dfee81bdd591647783e340ef3bcb104b54c383f70d422ef5cc7dbf"
+        }
+      ],
+      "downloadLocation": "https://files.pythonhosted.org/packages/d2/fc/e9ccf0521607bcd244aa0b3fbd574f71b65e9ce6a112c83af988bbbe2e23/resolvelib-1.0.1-py2.py3-none-any.whl",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE_MANAGER",
+          "referenceLocator": "pkg:pypi/resolvelib@1.0.1",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT",
+      "name": "resolvelib",
+      "primaryPackagePurpose": "SOURCE",
+      "versionInfo": "1.0.1"
+    },
+    {
+      "SPDXID": "SPDXRef-PACKAGE-setuptools",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "11e52c67415a381d10d6b462ced9cfb97066179f0e871399e006c4ab101fc85f"
+        }
+      ],
+      "downloadLocation": "https://files.pythonhosted.org/packages/c7/42/be1c7bbdd83e1bfb160c94b9cafd8e25efc7400346cf7ccdbdb452c467fa/setuptools-68.0.0-py3-none-any.whl",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE_MANAGER",
+          "referenceLocator": "pkg:pypi/setuptools@68.0.0",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT",
+      "name": "setuptools",
+      "primaryPackagePurpose": "SOURCE",
+      "versionInfo": "68.0.0"
+    },
+    {
+      "SPDXID": "SPDXRef-PACKAGE-six",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
+        }
+      ],
+      "downloadLocation": "https://files.pythonhosted.org/packages/d9/5a/e7c31adbe875f2abbb91bd84cf2dc52d792b5a01506781dbcf25c91daf11/six-1.16.0-py2.py3-none-any.whl",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE_MANAGER",
+          "referenceLocator": "pkg:pypi/six@1.16.0",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT",
+      "name": "six",
+      "primaryPackagePurpose": "SOURCE",
+      "versionInfo": "1.16.0"
+    },
+    {
+      "SPDXID": "SPDXRef-PACKAGE-tenacity",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "2f277afb21b851637e8f52e6a613ff08734c347dc19ade928e519d7d2d8569b0"
+        }
+      ],
+      "downloadLocation": "https://files.pythonhosted.org/packages/e7/b0/c23bd61e1b32c9b96fbca996c87784e196a812da8d621d8d04851f6c8181/tenacity-8.2.2-py3-none-any.whl",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE_MANAGER",
+          "referenceLocator": "pkg:pypi/tenacity@8.2.2",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT",
+      "name": "tenacity",
+      "primaryPackagePurpose": "SOURCE",
+      "versionInfo": "8.2.2"
+    },
+    {
+      "SPDXID": "SPDXRef-PACKAGE-tomli",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc"
+        }
+      ],
+      "downloadLocation": "https://files.pythonhosted.org/packages/97/75/10a9ebee3fd790d20926a90a2547f0bf78f371b2f13aa822c759680ca7b9/tomli-2.0.1-py3-none-any.whl",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE_MANAGER",
+          "referenceLocator": "pkg:pypi/tomli@2.0.1",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT",
+      "name": "tomli",
+      "primaryPackagePurpose": "SOURCE",
+      "versionInfo": "2.0.1"
+    },
+    {
+      "SPDXID": "SPDXRef-PACKAGE-truststore",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "e37a5642ae9fc48caa8f120b6283d77225d600d224965a672c9e8ef49ce4bb4c"
+        }
+      ],
+      "downloadLocation": "https://files.pythonhosted.org/packages/20/56/7811d5439b6a56374f274a8672d8f18b4deadadeb3a9f0c86424b98b6f96/truststore-0.8.0-py3-none-any.whl",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE_MANAGER",
+          "referenceLocator": "pkg:pypi/truststore@0.8.0",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT",
+      "name": "truststore",
+      "primaryPackagePurpose": "SOURCE",
+      "versionInfo": "0.8.0"
+    },
+    {
+      "SPDXID": "SPDXRef-PACKAGE-webencodings",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "a0af1213f3c2226497a97e2b3aa01a7e4bee4f403f95be16fc9acd2947514a78"
+        }
+      ],
+      "downloadLocation": "https://files.pythonhosted.org/packages/f4/24/2a3e3df732393fed8b3ebf2ec078f05546de641fe1b667ee316ec1dcf3b7/webencodings-0.5.1-py2.py3-none-any.whl",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE_MANAGER",
+          "referenceLocator": "pkg:pypi/webencodings@0.5.1",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT",
+      "name": "webencodings",
+      "primaryPackagePurpose": "SOURCE",
+      "versionInfo": "0.5.1"
+    },
+    {
+      "SPDXID": "SPDXRef-PACKAGE-urllib3",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "94a757d178c9be92ef5539b8840d48dc9cf1b2709c9d6b588232a055c524458b"
+        }
+      ],
+      "downloadLocation": "https://files.pythonhosted.org/packages/48/fe/a5c6cc46e9fe9171d7ecf0f33ee7aae14642f8d74baa7af4d7840f9358be/urllib3-1.26.17-py2.py3-none-any.whl",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE_MANAGER",
+          "referenceLocator": "pkg:pypi/urllib3@1.26.17",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT",
+      "name": "urllib3",
+      "primaryPackagePurpose": "SOURCE",
+      "versionInfo": "1.26.17"
+    },
+    {
+      "SPDXID": "SPDXRef-PACKAGE-pip",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "5052d7889c1f9d05224cd41741acb7c5d6fa735ab34e339624a614eaaa7e7d76"
+        }
+      ],
+      "downloadLocation": "https://files.pythonhosted.org/packages/15/aa/3f4c7bcee2057a76562a5b33ecbd199be08cdb4443a02e26bd2c3cf6fc39/pip-23.3.2-py3-none-any.whl",
+      "externalRefs": [
+        {
+          "referenceCategory": "SECURITY",
+          "referenceLocator": "cpe:2.3:a:pypa:pip:23.3.2:*:*:*:*:*:*:*",
+          "referenceType": "cpe23Type"
+        },
+        {
+          "referenceCategory": "PACKAGE_MANAGER",
+          "referenceLocator": "pkg:pypi/pip@23.3.2",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT",
+      "name": "pip",
+      "originator": "Organization: Python Packaging Authority",
+      "primaryPackagePurpose": "SOURCE",
+      "versionInfo": "23.3.2"
+    }
+  ],
+  "relationships": [
+    {
+      "relatedSpdxElement": "SPDXRef-PACKAGE-cachecontrol",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-PACKAGE-pip"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-PACKAGE-certifi",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-PACKAGE-pip"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-PACKAGE-chardet",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-PACKAGE-pip"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-PACKAGE-colorama",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-PACKAGE-pip"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-PACKAGE-distlib",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-PACKAGE-pip"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-PACKAGE-distro",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-PACKAGE-pip"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-PACKAGE-idna",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-PACKAGE-pip"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-PACKAGE-msgpack",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-PACKAGE-pip"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-PACKAGE-packaging",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-PACKAGE-pip"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-PACKAGE-platformdirs",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-PACKAGE-pip"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-PACKAGE-pygments",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-PACKAGE-pip"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-PACKAGE-pyparsing",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-PACKAGE-pip"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-PACKAGE-pyproject-hooks",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-PACKAGE-pip"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-PACKAGE-requests",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-PACKAGE-pip"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-PACKAGE-resolvelib",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-PACKAGE-pip"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-PACKAGE-rich",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-PACKAGE-pip"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-PACKAGE-setuptools",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-PACKAGE-pip"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-PACKAGE-six",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-PACKAGE-pip"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-PACKAGE-tenacity",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-PACKAGE-pip"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-PACKAGE-tomli",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-PACKAGE-pip"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-PACKAGE-truststore",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-PACKAGE-pip"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-PACKAGE-typing-extensions",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-PACKAGE-pip"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-PACKAGE-urllib3",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-PACKAGE-pip"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-PACKAGE-webencodings",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-PACKAGE-pip"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-FILE-Modules-expat-COPYING",
+      "relationshipType": "CONTAINS",
+      "spdxElementId": "SPDXRef-PACKAGE-expat"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-FILE-Modules-expat-ascii.h",
+      "relationshipType": "CONTAINS",
+      "spdxElementId": "SPDXRef-PACKAGE-expat"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-FILE-Modules-expat-asciitab.h",
+      "relationshipType": "CONTAINS",
+      "spdxElementId": "SPDXRef-PACKAGE-expat"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-FILE-Modules-expat-expat.h",
+      "relationshipType": "CONTAINS",
+      "spdxElementId": "SPDXRef-PACKAGE-expat"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-FILE-Modules-expat-expat-config.h",
+      "relationshipType": "CONTAINS",
+      "spdxElementId": "SPDXRef-PACKAGE-expat"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-FILE-Modules-expat-expat-external.h",
+      "relationshipType": "CONTAINS",
+      "spdxElementId": "SPDXRef-PACKAGE-expat"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-FILE-Modules-expat-iasciitab.h",
+      "relationshipType": "CONTAINS",
+      "spdxElementId": "SPDXRef-PACKAGE-expat"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-FILE-Modules-expat-internal.h",
+      "relationshipType": "CONTAINS",
+      "spdxElementId": "SPDXRef-PACKAGE-expat"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-FILE-Modules-expat-latin1tab.h",
+      "relationshipType": "CONTAINS",
+      "spdxElementId": "SPDXRef-PACKAGE-expat"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-FILE-Modules-expat-nametab.h",
+      "relationshipType": "CONTAINS",
+      "spdxElementId": "SPDXRef-PACKAGE-expat"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-FILE-Modules-expat-pyexpatns.h",
+      "relationshipType": "CONTAINS",
+      "spdxElementId": "SPDXRef-PACKAGE-expat"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-FILE-Modules-expat-siphash.h",
+      "relationshipType": "CONTAINS",
+      "spdxElementId": "SPDXRef-PACKAGE-expat"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-FILE-Modules-expat-utf8tab.h",
+      "relationshipType": "CONTAINS",
+      "spdxElementId": "SPDXRef-PACKAGE-expat"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-FILE-Modules-expat-winconfig.h",
+      "relationshipType": "CONTAINS",
+      "spdxElementId": "SPDXRef-PACKAGE-expat"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-FILE-Modules-expat-xmlparse.c",
+      "relationshipType": "CONTAINS",
+      "spdxElementId": "SPDXRef-PACKAGE-expat"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-FILE-Modules-expat-xmlrole.c",
+      "relationshipType": "CONTAINS",
+      "spdxElementId": "SPDXRef-PACKAGE-expat"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-FILE-Modules-expat-xmlrole.h",
+      "relationshipType": "CONTAINS",
+      "spdxElementId": "SPDXRef-PACKAGE-expat"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-FILE-Modules-expat-xmltok.c",
+      "relationshipType": "CONTAINS",
+      "spdxElementId": "SPDXRef-PACKAGE-expat"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-FILE-Modules-expat-xmltok.h",
+      "relationshipType": "CONTAINS",
+      "spdxElementId": "SPDXRef-PACKAGE-expat"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-FILE-Modules-expat-xmltok-impl.c",
+      "relationshipType": "CONTAINS",
+      "spdxElementId": "SPDXRef-PACKAGE-expat"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-FILE-Modules-expat-xmltok-impl.h",
+      "relationshipType": "CONTAINS",
+      "spdxElementId": "SPDXRef-PACKAGE-expat"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-FILE-Modules-expat-xmltok-ns.c",
+      "relationshipType": "CONTAINS",
+      "spdxElementId": "SPDXRef-PACKAGE-expat"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-FILE-Modules-hacl-Hacl-Hash-MD5.c",
+      "relationshipType": "CONTAINS",
+      "spdxElementId": "SPDXRef-PACKAGE-hacl-star"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-FILE-Modules-hacl-Hacl-Hash-MD5.h",
+      "relationshipType": "CONTAINS",
+      "spdxElementId": "SPDXRef-PACKAGE-hacl-star"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-FILE-Modules-hacl-Hacl-Hash-SHA1.c",
+      "relationshipType": "CONTAINS",
+      "spdxElementId": "SPDXRef-PACKAGE-hacl-star"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-FILE-Modules-hacl-Hacl-Hash-SHA1.h",
+      "relationshipType": "CONTAINS",
+      "spdxElementId": "SPDXRef-PACKAGE-hacl-star"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-FILE-Modules-hacl-Hacl-Hash-SHA2.c",
+      "relationshipType": "CONTAINS",
+      "spdxElementId": "SPDXRef-PACKAGE-hacl-star"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-FILE-Modules-hacl-Hacl-Hash-SHA2.h",
+      "relationshipType": "CONTAINS",
+      "spdxElementId": "SPDXRef-PACKAGE-hacl-star"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-FILE-Modules-hacl-Hacl-Hash-SHA3.c",
+      "relationshipType": "CONTAINS",
+      "spdxElementId": "SPDXRef-PACKAGE-hacl-star"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-FILE-Modules-hacl-Hacl-Hash-SHA3.h",
+      "relationshipType": "CONTAINS",
+      "spdxElementId": "SPDXRef-PACKAGE-hacl-star"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-FILE-Modules-hacl-Hacl-Streaming-Types.h",
+      "relationshipType": "CONTAINS",
+      "spdxElementId": "SPDXRef-PACKAGE-hacl-star"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-FILE-Modules-hacl-include-krml-FStar-UInt128-Verified.h",
+      "relationshipType": "CONTAINS",
+      "spdxElementId": "SPDXRef-PACKAGE-hacl-star"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-FILE-Modules-hacl-include-krml-FStar-UInt-8-16-32-64.h",
+      "relationshipType": "CONTAINS",
+      "spdxElementId": "SPDXRef-PACKAGE-hacl-star"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-FILE-Modules-hacl-include-krml-fstar-uint128-struct-endianness.h",
+      "relationshipType": "CONTAINS",
+      "spdxElementId": "SPDXRef-PACKAGE-hacl-star"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-FILE-Modules-hacl-include-krml-internal-target.h",
+      "relationshipType": "CONTAINS",
+      "spdxElementId": "SPDXRef-PACKAGE-hacl-star"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-FILE-Modules-hacl-include-krml-lowstar-endianness.h",
+      "relationshipType": "CONTAINS",
+      "spdxElementId": "SPDXRef-PACKAGE-hacl-star"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-FILE-Modules-hacl-include-krml-types.h",
+      "relationshipType": "CONTAINS",
+      "spdxElementId": "SPDXRef-PACKAGE-hacl-star"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-FILE-Modules-hacl-internal-Hacl-Hash-MD5.h",
+      "relationshipType": "CONTAINS",
+      "spdxElementId": "SPDXRef-PACKAGE-hacl-star"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-FILE-Modules-hacl-internal-Hacl-Hash-SHA1.h",
+      "relationshipType": "CONTAINS",
+      "spdxElementId": "SPDXRef-PACKAGE-hacl-star"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-FILE-Modules-hacl-internal-Hacl-Hash-SHA2.h",
+      "relationshipType": "CONTAINS",
+      "spdxElementId": "SPDXRef-PACKAGE-hacl-star"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-FILE-Modules-hacl-internal-Hacl-Hash-SHA3.h",
+      "relationshipType": "CONTAINS",
+      "spdxElementId": "SPDXRef-PACKAGE-hacl-star"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-FILE-Modules-hacl-python-hacl-namespaces.h",
+      "relationshipType": "CONTAINS",
+      "spdxElementId": "SPDXRef-PACKAGE-hacl-star"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-FILE-Modules-blake2-impl-blake2-config.h",
+      "relationshipType": "CONTAINS",
+      "spdxElementId": "SPDXRef-PACKAGE-libb2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-FILE-Modules-blake2-impl-blake2-impl.h",
+      "relationshipType": "CONTAINS",
+      "spdxElementId": "SPDXRef-PACKAGE-libb2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-FILE-Modules-blake2-impl-blake2.h",
+      "relationshipType": "CONTAINS",
+      "spdxElementId": "SPDXRef-PACKAGE-libb2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-FILE-Modules-blake2-impl-blake2b-load-sse2.h",
+      "relationshipType": "CONTAINS",
+      "spdxElementId": "SPDXRef-PACKAGE-libb2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-FILE-Modules-blake2-impl-blake2b-load-sse41.h",
+      "relationshipType": "CONTAINS",
+      "spdxElementId": "SPDXRef-PACKAGE-libb2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-FILE-Modules-blake2-impl-blake2b-ref.c",
+      "relationshipType": "CONTAINS",
+      "spdxElementId": "SPDXRef-PACKAGE-libb2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-FILE-Modules-blake2-impl-blake2b-round.h",
+      "relationshipType": "CONTAINS",
+      "spdxElementId": "SPDXRef-PACKAGE-libb2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-FILE-Modules-blake2-impl-blake2b.c",
+      "relationshipType": "CONTAINS",
+      "spdxElementId": "SPDXRef-PACKAGE-libb2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-FILE-Modules-blake2-impl-blake2s-load-sse2.h",
+      "relationshipType": "CONTAINS",
+      "spdxElementId": "SPDXRef-PACKAGE-libb2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-FILE-Modules-blake2-impl-blake2s-load-sse41.h",
+      "relationshipType": "CONTAINS",
+      "spdxElementId": "SPDXRef-PACKAGE-libb2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-FILE-Modules-blake2-impl-blake2s-load-xop.h",
+      "relationshipType": "CONTAINS",
+      "spdxElementId": "SPDXRef-PACKAGE-libb2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-FILE-Modules-blake2-impl-blake2s-ref.c",
+      "relationshipType": "CONTAINS",
+      "spdxElementId": "SPDXRef-PACKAGE-libb2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-FILE-Modules-blake2-impl-blake2s-round.h",
+      "relationshipType": "CONTAINS",
+      "spdxElementId": "SPDXRef-PACKAGE-libb2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-FILE-Modules-blake2-impl-blake2s.c",
+      "relationshipType": "CONTAINS",
+      "spdxElementId": "SPDXRef-PACKAGE-libb2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-FILE-Lib-ctypes-macholib-init-.py",
+      "relationshipType": "CONTAINS",
+      "spdxElementId": "SPDXRef-PACKAGE-macholib"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-FILE-Lib-ctypes-macholib-dyld.py",
+      "relationshipType": "CONTAINS",
+      "spdxElementId": "SPDXRef-PACKAGE-macholib"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-FILE-Lib-ctypes-macholib-dylib.py",
+      "relationshipType": "CONTAINS",
+      "spdxElementId": "SPDXRef-PACKAGE-macholib"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-FILE-Lib-ctypes-macholib-framework.py",
+      "relationshipType": "CONTAINS",
+      "spdxElementId": "SPDXRef-PACKAGE-macholib"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-FILE-Modules-decimal-libmpdec-README.txt",
+      "relationshipType": "CONTAINS",
+      "spdxElementId": "SPDXRef-PACKAGE-mpdecimal"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-FILE-Modules-decimal-libmpdec-basearith.c",
+      "relationshipType": "CONTAINS",
+      "spdxElementId": "SPDXRef-PACKAGE-mpdecimal"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-FILE-Modules-decimal-libmpdec-basearith.h",
+      "relationshipType": "CONTAINS",
+      "spdxElementId": "SPDXRef-PACKAGE-mpdecimal"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-FILE-Modules-decimal-libmpdec-bench.c",
+      "relationshipType": "CONTAINS",
+      "spdxElementId": "SPDXRef-PACKAGE-mpdecimal"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-FILE-Modules-decimal-libmpdec-bench-full.c",
+      "relationshipType": "CONTAINS",
+      "spdxElementId": "SPDXRef-PACKAGE-mpdecimal"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-FILE-Modules-decimal-libmpdec-bits.h",
+      "relationshipType": "CONTAINS",
+      "spdxElementId": "SPDXRef-PACKAGE-mpdecimal"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-FILE-Modules-decimal-libmpdec-constants.c",
+      "relationshipType": "CONTAINS",
+      "spdxElementId": "SPDXRef-PACKAGE-mpdecimal"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-FILE-Modules-decimal-libmpdec-constants.h",
+      "relationshipType": "CONTAINS",
+      "spdxElementId": "SPDXRef-PACKAGE-mpdecimal"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-FILE-Modules-decimal-libmpdec-context.c",
+      "relationshipType": "CONTAINS",
+      "spdxElementId": "SPDXRef-PACKAGE-mpdecimal"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-FILE-Modules-decimal-libmpdec-convolute.c",
+      "relationshipType": "CONTAINS",
+      "spdxElementId": "SPDXRef-PACKAGE-mpdecimal"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-FILE-Modules-decimal-libmpdec-convolute.h",
+      "relationshipType": "CONTAINS",
+      "spdxElementId": "SPDXRef-PACKAGE-mpdecimal"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-FILE-Modules-decimal-libmpdec-crt.c",
+      "relationshipType": "CONTAINS",
+      "spdxElementId": "SPDXRef-PACKAGE-mpdecimal"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-FILE-Modules-decimal-libmpdec-crt.h",
+      "relationshipType": "CONTAINS",
+      "spdxElementId": "SPDXRef-PACKAGE-mpdecimal"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-FILE-Modules-decimal-libmpdec-difradix2.c",
+      "relationshipType": "CONTAINS",
+      "spdxElementId": "SPDXRef-PACKAGE-mpdecimal"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-FILE-Modules-decimal-libmpdec-difradix2.h",
+      "relationshipType": "CONTAINS",
+      "spdxElementId": "SPDXRef-PACKAGE-mpdecimal"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-FILE-Modules-decimal-libmpdec-examples-README.txt",
+      "relationshipType": "CONTAINS",
+      "spdxElementId": "SPDXRef-PACKAGE-mpdecimal"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-FILE-Modules-decimal-libmpdec-examples-compare.c",
+      "relationshipType": "CONTAINS",
+      "spdxElementId": "SPDXRef-PACKAGE-mpdecimal"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-FILE-Modules-decimal-libmpdec-examples-div.c",
+      "relationshipType": "CONTAINS",
+      "spdxElementId": "SPDXRef-PACKAGE-mpdecimal"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-FILE-Modules-decimal-libmpdec-examples-divmod.c",
+      "relationshipType": "CONTAINS",
+      "spdxElementId": "SPDXRef-PACKAGE-mpdecimal"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-FILE-Modules-decimal-libmpdec-examples-multiply.c",
+      "relationshipType": "CONTAINS",
+      "spdxElementId": "SPDXRef-PACKAGE-mpdecimal"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-FILE-Modules-decimal-libmpdec-examples-pow.c",
+      "relationshipType": "CONTAINS",
+      "spdxElementId": "SPDXRef-PACKAGE-mpdecimal"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-FILE-Modules-decimal-libmpdec-examples-powmod.c",
+      "relationshipType": "CONTAINS",
+      "spdxElementId": "SPDXRef-PACKAGE-mpdecimal"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-FILE-Modules-decimal-libmpdec-examples-shift.c",
+      "relationshipType": "CONTAINS",
+      "spdxElementId": "SPDXRef-PACKAGE-mpdecimal"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-FILE-Modules-decimal-libmpdec-examples-sqrt.c",
+      "relationshipType": "CONTAINS",
+      "spdxElementId": "SPDXRef-PACKAGE-mpdecimal"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-FILE-Modules-decimal-libmpdec-fnt.c",
+      "relationshipType": "CONTAINS",
+      "spdxElementId": "SPDXRef-PACKAGE-mpdecimal"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-FILE-Modules-decimal-libmpdec-fnt.h",
+      "relationshipType": "CONTAINS",
+      "spdxElementId": "SPDXRef-PACKAGE-mpdecimal"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-FILE-Modules-decimal-libmpdec-fourstep.c",
+      "relationshipType": "CONTAINS",
+      "spdxElementId": "SPDXRef-PACKAGE-mpdecimal"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-FILE-Modules-decimal-libmpdec-fourstep.h",
+      "relationshipType": "CONTAINS",
+      "spdxElementId": "SPDXRef-PACKAGE-mpdecimal"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-FILE-Modules-decimal-libmpdec-io.c",
+      "relationshipType": "CONTAINS",
+      "spdxElementId": "SPDXRef-PACKAGE-mpdecimal"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-FILE-Modules-decimal-libmpdec-io.h",
+      "relationshipType": "CONTAINS",
+      "spdxElementId": "SPDXRef-PACKAGE-mpdecimal"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-FILE-Modules-decimal-libmpdec-literature-REFERENCES.txt",
+      "relationshipType": "CONTAINS",
+      "spdxElementId": "SPDXRef-PACKAGE-mpdecimal"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-FILE-Modules-decimal-libmpdec-literature-bignum.txt",
+      "relationshipType": "CONTAINS",
+      "spdxElementId": "SPDXRef-PACKAGE-mpdecimal"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-FILE-Modules-decimal-libmpdec-literature-fnt.py",
+      "relationshipType": "CONTAINS",
+      "spdxElementId": "SPDXRef-PACKAGE-mpdecimal"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-FILE-Modules-decimal-libmpdec-literature-matrix-transform.txt",
+      "relationshipType": "CONTAINS",
+      "spdxElementId": "SPDXRef-PACKAGE-mpdecimal"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-FILE-Modules-decimal-libmpdec-literature-mulmod-64.txt",
+      "relationshipType": "CONTAINS",
+      "spdxElementId": "SPDXRef-PACKAGE-mpdecimal"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-FILE-Modules-decimal-libmpdec-literature-mulmod-ppro.txt",
+      "relationshipType": "CONTAINS",
+      "spdxElementId": "SPDXRef-PACKAGE-mpdecimal"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-FILE-Modules-decimal-libmpdec-literature-six-step.txt",
+      "relationshipType": "CONTAINS",
+      "spdxElementId": "SPDXRef-PACKAGE-mpdecimal"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-FILE-Modules-decimal-libmpdec-literature-umodarith.lisp",
+      "relationshipType": "CONTAINS",
+      "spdxElementId": "SPDXRef-PACKAGE-mpdecimal"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-FILE-Modules-decimal-libmpdec-mpalloc.c",
+      "relationshipType": "CONTAINS",
+      "spdxElementId": "SPDXRef-PACKAGE-mpdecimal"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-FILE-Modules-decimal-libmpdec-mpalloc.h",
+      "relationshipType": "CONTAINS",
+      "spdxElementId": "SPDXRef-PACKAGE-mpdecimal"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-FILE-Modules-decimal-libmpdec-mpdecimal.c",
+      "relationshipType": "CONTAINS",
+      "spdxElementId": "SPDXRef-PACKAGE-mpdecimal"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-FILE-Modules-decimal-libmpdec-mpdecimal.h",
+      "relationshipType": "CONTAINS",
+      "spdxElementId": "SPDXRef-PACKAGE-mpdecimal"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-FILE-Modules-decimal-libmpdec-mpsignal.c",
+      "relationshipType": "CONTAINS",
+      "spdxElementId": "SPDXRef-PACKAGE-mpdecimal"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-FILE-Modules-decimal-libmpdec-numbertheory.c",
+      "relationshipType": "CONTAINS",
+      "spdxElementId": "SPDXRef-PACKAGE-mpdecimal"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-FILE-Modules-decimal-libmpdec-numbertheory.h",
+      "relationshipType": "CONTAINS",
+      "spdxElementId": "SPDXRef-PACKAGE-mpdecimal"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-FILE-Modules-decimal-libmpdec-sixstep.c",
+      "relationshipType": "CONTAINS",
+      "spdxElementId": "SPDXRef-PACKAGE-mpdecimal"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-FILE-Modules-decimal-libmpdec-sixstep.h",
+      "relationshipType": "CONTAINS",
+      "spdxElementId": "SPDXRef-PACKAGE-mpdecimal"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-FILE-Modules-decimal-libmpdec-transpose.c",
+      "relationshipType": "CONTAINS",
+      "spdxElementId": "SPDXRef-PACKAGE-mpdecimal"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-FILE-Modules-decimal-libmpdec-transpose.h",
+      "relationshipType": "CONTAINS",
+      "spdxElementId": "SPDXRef-PACKAGE-mpdecimal"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-FILE-Modules-decimal-libmpdec-typearith.h",
+      "relationshipType": "CONTAINS",
+      "spdxElementId": "SPDXRef-PACKAGE-mpdecimal"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-FILE-Modules-decimal-libmpdec-umodarith.h",
+      "relationshipType": "CONTAINS",
+      "spdxElementId": "SPDXRef-PACKAGE-mpdecimal"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-FILE-Modules-decimal-libmpdec-vcdiv64.asm",
+      "relationshipType": "CONTAINS",
+      "spdxElementId": "SPDXRef-PACKAGE-mpdecimal"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-FILE-Lib-ensurepip-bundled-pip-23.3.2-py3-none-any.whl",
+      "relationshipType": "CONTAINS",
+      "spdxElementId": "SPDXRef-PACKAGE-pip"
+    }
+  ],
+  "spdxVersion": "SPDX-2.3"
+}

--- a/Tools/build/generate_sbom.py
+++ b/Tools/build/generate_sbom.py
@@ -1,0 +1,474 @@
+"""Tool for generating Software Bill of Materials (SBOM) for Python's dependencies"""
+import os
+import re
+import hashlib
+import json
+import glob
+import pathlib
+import subprocess
+import sys
+import typing
+import zipfile
+from urllib.request import urlopen
+
+CPYTHON_ROOT_DIR = pathlib.Path(__file__).parent.parent.parent
+
+# Before adding a new entry to this list, double check that
+# the license expression is a valid SPDX license expression:
+# See: https://spdx.org/licenses
+ALLOWED_LICENSE_EXPRESSIONS = {
+    "Apache-2.0",
+    "Apache-2.0 OR BSD-2-Clause",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "CC0-1.0",
+    "ISC",
+    "LGPL-2.1-only",
+    "MIT",
+    "MPL-2.0",
+    "Python-2.0.1",
+}
+
+# Properties which are required for our purposes.
+REQUIRED_PROPERTIES_PACKAGE = frozenset([
+    "SPDXID",
+    "name",
+    "versionInfo",
+    "downloadLocation",
+    "checksums",
+    "licenseConcluded",
+    "externalRefs",
+    "primaryPackagePurpose",
+])
+
+
+class PackageFiles(typing.NamedTuple):
+    """Structure for describing the files of a package"""
+    include: list[str] | None
+    exclude: list[str] | None = None
+
+
+# SBOMS don't have a method to specify the sources of files
+# so we need to do that external to the SBOM itself. Add new
+# values to 'exclude' if we create new files within tracked
+# directories that aren't sourced from third-party packages.
+PACKAGE_TO_FILES = {
+    # NOTE: pip's entry in this structure is automatically generated in
+    # the 'discover_pip_sbom_package()' function below.
+    "mpdecimal": PackageFiles(
+        include=["Modules/_decimal/libmpdec/**"]
+    ),
+    "expat": PackageFiles(
+        include=["Modules/expat/**"]
+    ),
+    "macholib": PackageFiles(
+        include=["Lib/ctypes/macholib/**"],
+        exclude=[
+            "Lib/ctypes/macholib/README.ctypes",
+            "Lib/ctypes/macholib/fetch_macholib",
+            "Lib/ctypes/macholib/fetch_macholib.bat",
+        ],
+    ),
+    "libb2": PackageFiles(
+        include=["Modules/_blake2/impl/**"]
+    ),
+    "hacl-star": PackageFiles(
+        include=["Modules/_hacl/**"],
+        exclude=[
+            "Modules/_hacl/refresh.sh",
+            "Modules/_hacl/README.md",
+            "Modules/_hacl/python_hacl_namespace.h",
+        ]
+    ),
+}
+
+
+def spdx_id(value: str) -> str:
+    """Encode a value into characters that are valid in an SPDX ID"""
+    return re.sub(r"[^a-zA-Z0-9.\-]+", "-", value)
+
+
+def error_if(value: bool, error_message: str) -> None:
+    """Prints an error if a comparison fails along with a link to the devguide"""
+    if value:
+        print(error_message)
+        print("See 'https://devguide.python.org/developer-workflow/sbom' for more information.")
+        sys.exit(1)
+
+
+def filter_gitignored_paths(paths: list[str]) -> list[str]:
+    """
+    Filter out paths excluded by the gitignore file.
+    The output of 'git check-ignore --non-matching --verbose' looks
+    like this for non-matching (included) files:
+
+        '::<whitespace><path>'
+
+    And looks like this for matching (excluded) files:
+
+        '.gitignore:9:*.a    Tools/lib.a'
+    """
+    # Filter out files in gitignore.
+    # Non-matching files show up as '::<whitespace><path>'
+    git_check_ignore_proc = subprocess.run(
+        ["git", "check-ignore", "--verbose", "--non-matching", *paths],
+        cwd=CPYTHON_ROOT_DIR,
+        check=False,
+        stdout=subprocess.PIPE,
+    )
+    # 1 means matches, 0 means no matches.
+    assert git_check_ignore_proc.returncode in (0, 1)
+
+    # Return the list of paths sorted
+    git_check_ignore_lines = git_check_ignore_proc.stdout.decode().splitlines()
+    return sorted([line.split()[-1] for line in git_check_ignore_lines if line.startswith("::")])
+
+
+def fetch_package_metadata_from_pypi(project: str, version: str, filename: str | None = None) -> tuple[str, str] | None:
+    """
+    Fetches the SHA256 checksum and download location from PyPI.
+    If we're given a filename then we match with that, otherwise we use wheels.
+    """
+    # Get pip's download location from PyPI. Check that the checksum is correct too.
+    try:
+        raw_text = urlopen(f"https://pypi.org/pypi/{project}/{version}/json").read()
+        release_metadata = json.loads(raw_text)
+        url: dict[str, typing.Any]
+
+        # Look for a matching artifact filename and then check
+        # its remote checksum to the local one.
+        for url in release_metadata["urls"]:
+            # pip can only use Python-only dependencies, so there's
+            # no risk of picking the 'incorrect' wheel here.
+            if (
+                (filename is None and url["packagetype"] == "bdist_wheel")
+                or (filename is not None and url["filename"] == filename)
+            ):
+                break
+        else:
+            raise ValueError(f"No matching filename on PyPI for '{filename}'")
+
+        # Successfully found the download URL for the matching artifact.
+        download_url = url["url"]
+        checksum_sha256 = url["digests"]["sha256"]
+        return download_url, checksum_sha256
+
+    except (OSError, ValueError) as e:
+        # Fail if we're running in CI where we should have an internet connection.
+        error_if(
+            "CI" in os.environ,
+            f"Couldn't fetch metadata for project '{project}' from PyPI: {e}"
+        )
+        return None
+
+
+def find_ensurepip_pip_wheel() -> pathlib.Path | None:
+    """Try to find the pip wheel bundled in ensurepip. If missing return None"""
+
+    ensurepip_bundled_dir = CPYTHON_ROOT_DIR / "Lib/ensurepip/_bundled"
+
+    pip_wheels = []
+    try:
+        for wheel_filename in os.listdir(ensurepip_bundled_dir):
+            if wheel_filename.startswith("pip-"):
+                pip_wheels.append(wheel_filename)
+            else:
+                print(f"Unexpected wheel in ensurepip: '{wheel_filename}'")
+                sys.exit(1)
+
+    # Ignore this error, likely caused by downstream distributors
+    # deleting the 'ensurepip/_bundled' directory.
+    except FileNotFoundError:
+        pass
+
+    if len(pip_wheels) == 0:
+        return None
+    elif len(pip_wheels) > 1:
+        print("Multiple pip wheels detected in 'Lib/ensurepip/_bundled'")
+        sys.exit(1)
+    # Otherwise return the one pip wheel.
+    return ensurepip_bundled_dir / pip_wheels[0]
+
+
+def maybe_remove_pip_and_deps_from_sbom(sbom_data: dict[str, typing.Any]) -> None:
+    """
+    Removes pip and its dependencies from the SBOM data
+    if the pip wheel is removed from ensurepip. This is done
+    by redistributors of Python and pip.
+    """
+
+    # If there's a wheel we don't remove anything.
+    if find_ensurepip_pip_wheel() is not None:
+        return
+
+    # Otherwise we traverse the relationships
+    # to find dependent packages to remove.
+    sbom_pip_spdx_id = spdx_id("SPDXRef-PACKAGE-pip")
+    sbom_spdx_ids_to_remove = {sbom_pip_spdx_id}
+
+    # Find all package SPDXIDs that pip depends on.
+    for sbom_relationship in sbom_data["relationships"]:
+        if (
+            sbom_relationship["relationshipType"] == "DEPENDS_ON"
+            and sbom_relationship["spdxElementId"] == sbom_pip_spdx_id
+        ):
+            sbom_spdx_ids_to_remove.add(sbom_relationship["relatedSpdxElement"])
+
+    # Remove all the packages and relationships.
+    sbom_data["packages"] = [
+        sbom_package for sbom_package in sbom_data["packages"]
+        if sbom_package["SPDXID"] not in sbom_spdx_ids_to_remove
+    ]
+    sbom_data["relationships"] = [
+        sbom_relationship for sbom_relationship in sbom_data["relationships"]
+        if sbom_relationship["relatedSpdxElement"] not in sbom_spdx_ids_to_remove
+    ]
+
+
+def discover_pip_sbom_package(sbom_data: dict[str, typing.Any]) -> None:
+    """pip is a part of a packaging ecosystem (Python, surprise!) so it's actually
+    automatable to discover the metadata we need like the version and checksums
+    so let's do that on behalf of our friends at the PyPA. This function also
+    discovers vendored packages within pip and fetches their metadata.
+    """
+    global PACKAGE_TO_FILES
+
+    pip_wheel_filepath = find_ensurepip_pip_wheel()
+    if pip_wheel_filepath is None:
+        return  # There's no pip wheel, nothing to discover.
+
+    # Add the wheel filename to the list of files so the SBOM file
+    # and relationship generator can work its magic on the wheel too.
+    PACKAGE_TO_FILES["pip"] = PackageFiles(
+        include=[str(pip_wheel_filepath.relative_to(CPYTHON_ROOT_DIR))]
+    )
+
+    # Wheel filename format puts the version right after the project name.
+    pip_version = pip_wheel_filepath.name.split("-")[1]
+    pip_checksum_sha256 = hashlib.sha256(
+        pip_wheel_filepath.read_bytes()
+    ).hexdigest()
+
+    pip_metadata = fetch_package_metadata_from_pypi(
+        project="pip",
+        version=pip_version,
+        filename=pip_wheel_filepath.name,
+    )
+    # We couldn't fetch any metadata from PyPI,
+    # so we give up on verifying if we're not in CI.
+    if pip_metadata is None:
+        return
+
+    pip_download_url, pip_actual_sha256 = pip_metadata
+    if pip_actual_sha256 != pip_checksum_sha256:
+        raise ValueError("Unexpected")
+
+    # Parse 'pip/_vendor/vendor.txt' from the wheel for sub-dependencies.
+    with zipfile.ZipFile(pip_wheel_filepath) as whl:
+        vendor_txt_data = whl.read("pip/_vendor/vendor.txt").decode()
+
+        # With this version regex we're assuming that pip isn't using pre-releases.
+        # If any version doesn't match we get a failure below, so we're safe doing this.
+        version_pin_re = re.compile(r"^([a-zA-Z0-9_.-]+)==([0-9.]*[0-9])$")
+        sbom_pip_dependency_spdx_ids = set()
+        for line in vendor_txt_data.splitlines():
+            line = line.partition("#")[0].strip()  # Strip comments and whitespace.
+            if not line:  # Skip empty lines.
+                continue
+
+            # Non-empty lines we must be able to match.
+            match = version_pin_re.match(line)
+            error_if(match is None, f"Couldn't parse line from pip vendor.txt: '{line}'")
+            assert match is not None  # Make mypy happy.
+
+            # Parse out and normalize the project name.
+            project_name, project_version = match.groups()
+            project_name = project_name.lower()
+
+            # At this point if pip's metadata fetch succeeded we should
+            # expect this request to also succeed.
+            project_metadata = (
+                fetch_package_metadata_from_pypi(project_name, project_version)
+            )
+            assert project_metadata is not None
+            project_download_url, project_checksum_sha256 = project_metadata
+
+            # Update our SBOM data with what we received from PyPI.
+            # Don't overwrite any existing values.
+            sbom_project_spdx_id = spdx_id(f"SPDXRef-PACKAGE-{project_name}")
+            sbom_pip_dependency_spdx_ids.add(sbom_project_spdx_id)
+            for package in sbom_data["packages"]:
+                if package["SPDXID"] != sbom_project_spdx_id:
+                    continue
+
+                # Only thing missing from this blob is the `licenseConcluded`,
+                # that needs to be triaged by human maintainers if the list changes.
+                package.update({
+                    "SPDXID": sbom_project_spdx_id,
+                    "name": project_name,
+                    "versionInfo": project_version,
+                    "downloadLocation": project_download_url,
+                    "checksums": [
+                        {"algorithm": "SHA256", "checksumValue": project_checksum_sha256}
+                    ],
+                    "externalRefs": [
+                        {
+                            "referenceCategory": "PACKAGE_MANAGER",
+                            "referenceLocator": f"pkg:pypi/{project_name}@{project_version}",
+                            "referenceType": "purl",
+                        },
+                    ],
+                    "primaryPackagePurpose": "SOURCE"
+                })
+                break
+
+            PACKAGE_TO_FILES[project_name] = PackageFiles(include=None)
+
+    # Remove pip from the existing SBOM packages if it's there
+    # and then overwrite its entry with our own generated one.
+    sbom_pip_spdx_id = spdx_id("SPDXRef-PACKAGE-pip")
+    sbom_data["packages"] = [
+        sbom_package
+        for sbom_package in sbom_data["packages"]
+        if sbom_package["name"] != "pip"
+    ]
+    sbom_data["packages"].append(
+        {
+            "SPDXID": sbom_pip_spdx_id,
+            "name": "pip",
+            "versionInfo": pip_version,
+            "originator": "Organization: Python Packaging Authority",
+            "licenseConcluded": "MIT",
+            "downloadLocation": pip_download_url,
+            "checksums": [
+                {"algorithm": "SHA256", "checksumValue": pip_checksum_sha256}
+            ],
+            "externalRefs": [
+                {
+                    "referenceCategory": "SECURITY",
+                    "referenceLocator": f"cpe:2.3:a:pypa:pip:{pip_version}:*:*:*:*:*:*:*",
+                    "referenceType": "cpe23Type",
+                },
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": f"pkg:pypi/pip@{pip_version}",
+                    "referenceType": "purl",
+                },
+            ],
+            "primaryPackagePurpose": "SOURCE",
+        }
+    )
+    for sbom_dep_spdx_id in sorted(sbom_pip_dependency_spdx_ids):
+        sbom_data["relationships"].append({
+            "spdxElementId": sbom_pip_spdx_id,
+            "relatedSpdxElement": sbom_dep_spdx_id,
+            "relationshipType": "DEPENDS_ON"
+        })
+
+
+def main() -> None:
+    sbom_path = CPYTHON_ROOT_DIR / "Misc/sbom.spdx.json"
+    sbom_data = json.loads(sbom_path.read_bytes())
+
+    # Check if pip should be removed if the wheel is missing.
+    # We can't reset the SBOM relationship data until checking this.
+    maybe_remove_pip_and_deps_from_sbom(sbom_data)
+
+    # We regenerate all of this information. Package information
+    # should be preserved though since that is edited by humans.
+    sbom_data["files"] = []
+    sbom_data["relationships"] = []
+
+    # Insert pip's SBOM metadata from the wheel.
+    discover_pip_sbom_package(sbom_data)
+
+    # Ensure all packages in this tool are represented also in the SBOM file.
+    error_if(
+        {package["name"] for package in sbom_data["packages"]} != set(PACKAGE_TO_FILES),
+        "Packages defined in SBOM tool don't match those defined in SBOM file.",
+    )
+
+    # Make a bunch of assertions about the SBOM data to ensure it's consistent.
+    for package in sbom_data["packages"]:
+        # Properties and ID must be properly formed.
+        error_if(
+            "name" not in package,
+            "Package is missing the 'name' field"
+        )
+        missing_required_keys = REQUIRED_PROPERTIES_PACKAGE - set(package.keys())
+        error_if(
+            bool(missing_required_keys),
+            f"Package '{package['name']}' is missing required fields: {missing_required_keys}",
+        )
+        error_if(
+            package["SPDXID"] != spdx_id(f"SPDXRef-PACKAGE-{package['name']}"),
+            f"Package '{package['name']}' has a malformed SPDXID",
+        )
+
+        # Version must be in the download and external references.
+        version = package["versionInfo"]
+        error_if(
+            version not in package["downloadLocation"],
+            f"Version '{version}' for package '{package['name']} not in 'downloadLocation' field",
+        )
+        error_if(
+            any(version not in ref["referenceLocator"] for ref in package["externalRefs"]),
+            (
+                f"Version '{version}' for package '{package['name']} not in "
+                f"all 'externalRefs[].referenceLocator' fields"
+            ),
+        )
+
+        # License must be on the approved list for SPDX.
+        license_concluded = package["licenseConcluded"]
+        error_if(
+            license_concluded not in ALLOWED_LICENSE_EXPRESSIONS,
+            f"License identifier '{license_concluded}' not in SBOM tool allowlist"
+        )
+
+    # We call 'sorted()' here a lot to avoid filesystem scan order issues.
+    for name, files in sorted(PACKAGE_TO_FILES.items()):
+        package_spdx_id = spdx_id(f"SPDXRef-PACKAGE-{name}")
+        exclude = files.exclude or ()
+        for include in sorted(files.include or ()):
+            # Find all the paths and then filter them through .gitignore.
+            paths = glob.glob(include, root_dir=CPYTHON_ROOT_DIR, recursive=True)
+            paths = filter_gitignored_paths(paths)
+            error_if(
+                len(paths) == 0,
+                f"No valid paths found at path '{include}' for package '{name}",
+            )
+
+            for path in paths:
+                # Skip directories and excluded files
+                if not (CPYTHON_ROOT_DIR / path).is_file() or path in exclude:
+                    continue
+
+                # SPDX requires SHA1 to be used for files, but we provide SHA256 too.
+                data = (CPYTHON_ROOT_DIR / path).read_bytes()
+                checksum_sha1 = hashlib.sha1(data).hexdigest()
+                checksum_sha256 = hashlib.sha256(data).hexdigest()
+
+                file_spdx_id = spdx_id(f"SPDXRef-FILE-{path}")
+                sbom_data["files"].append({
+                    "SPDXID": file_spdx_id,
+                    "fileName": path,
+                    "checksums": [
+                        {"algorithm": "SHA1", "checksumValue": checksum_sha1},
+                        {"algorithm": "SHA256", "checksumValue": checksum_sha256},
+                    ],
+                })
+
+                # Tie each file back to its respective package.
+                sbom_data["relationships"].append({
+                    "spdxElementId": package_spdx_id,
+                    "relatedSpdxElement": file_spdx_id,
+                    "relationshipType": "CONTAINS",
+                })
+
+    # Update the SBOM on disk
+    sbom_path.write_text(json.dumps(sbom_data, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This PR backports the following PRs to the 3.12 branch which has an identical SBOM to the `main` branch. 3.11 and earlier all have substantial differences (by including `setuptools` which has multiple layers of dependency vendoring). I [proposed backporting to previous branches](https://discuss.python.org/t/create-and-distribute-software-bill-of-materials-sbom-for-python-artifacts/39293/17) on discuss.python.org.

- https://github.com/python/cpython/pull/112303
- https://github.com/python/cpython/pull/112854
- https://github.com/python/cpython/pull/113490
- https://github.com/python/cpython/pull/114450

As a data point to limit fear of breaking builds of downstream distributors, we received feedback from @befeleme in https://github.com/python/cpython/issues/114240 and https://github.com/python/cpython/issues/114244 which appear to have been resolved in https://github.com/python/cpython/pull/114450.

<!-- gh-issue-number: gh-112302 -->
* Issue: gh-112302
<!-- /gh-issue-number -->
