### PR TITLE
gh-112529: Simplify PyObject_GC_IsTracked and PyObject_GC_IsFinalized

### DIFF
--- a/Modules/clinic/gcmodule.c.h
+++ b/Modules/clinic/gcmodule.c.h
@@ -469,6 +469,25 @@ PyDoc_STRVAR(gc_is_tracked__doc__,
 #define GC_IS_TRACKED_METHODDEF    \
     {"is_tracked", (PyCFunction)gc_is_tracked, METH_O, gc_is_tracked__doc__},
 
+static int
+gc_is_tracked_impl(PyObject *module, PyObject *obj);
+
+static PyObject *
+gc_is_tracked(PyObject *module, PyObject *obj)
+{
+    PyObject *return_value = NULL;
+    int _return_value;
+
+    _return_value = gc_is_tracked_impl(module, obj);
+    if ((_return_value == -1) && PyErr_Occurred()) {
+        goto exit;
+    }
+    return_value = PyBool_FromLong((long)_return_value);
+
+exit:
+    return return_value;
+}
+
 PyDoc_STRVAR(gc_is_finalized__doc__,
 "is_finalized($module, obj, /)\n"
 "--\n"
@@ -477,6 +496,25 @@ PyDoc_STRVAR(gc_is_finalized__doc__,
 
 #define GC_IS_FINALIZED_METHODDEF    \
     {"is_finalized", (PyCFunction)gc_is_finalized, METH_O, gc_is_finalized__doc__},
+
+static int
+gc_is_finalized_impl(PyObject *module, PyObject *obj);
+
+static PyObject *
+gc_is_finalized(PyObject *module, PyObject *obj)
+{
+    PyObject *return_value = NULL;
+    int _return_value;
+
+    _return_value = gc_is_finalized_impl(module, obj);
+    if ((_return_value == -1) && PyErr_Occurred()) {
+        goto exit;
+    }
+    return_value = PyBool_FromLong((long)_return_value);
+
+exit:
+    return return_value;
+}
 
 PyDoc_STRVAR(gc_freeze__doc__,
 "freeze($module, /)\n"
@@ -547,4 +585,4 @@ gc_get_freeze_count(PyObject *module, PyObject *Py_UNUSED(ignored))
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=258f92524c1141fc input=a9049054013a1b77]*/
+/*[clinic end generated code: output=0a7e91917adcb937 input=a9049054013a1b77]*/

--- a/Modules/gcmodule.c
+++ b/Modules/gcmodule.c
@@ -358,7 +358,7 @@ error:
 
 
 /*[clinic input]
-gc.is_tracked
+gc.is_tracked -> bool
 
     obj: object
     /
@@ -368,21 +368,15 @@ Returns true if the object is tracked by the garbage collector.
 Simple atomic objects will return false.
 [clinic start generated code]*/
 
-static PyObject *
-gc_is_tracked(PyObject *module, PyObject *obj)
-/*[clinic end generated code: output=14f0103423b28e31 input=d83057f170ea2723]*/
+static int
+gc_is_tracked_impl(PyObject *module, PyObject *obj)
+/*[clinic end generated code: output=91c8d086b7f47a33 input=423b98ec680c3126]*/
 {
-    PyObject *result;
-
-    if (_PyObject_IS_GC(obj) && _PyObject_GC_IS_TRACKED(obj))
-        result = Py_True;
-    else
-        result = Py_False;
-    return Py_NewRef(result);
+    return PyObject_GC_IsTracked(obj);
 }
 
 /*[clinic input]
-gc.is_finalized
+gc.is_finalized -> bool
 
     obj: object
     /
@@ -390,14 +384,11 @@ gc.is_finalized
 Returns true if the object has been already finalized by the GC.
 [clinic start generated code]*/
 
-static PyObject *
-gc_is_finalized(PyObject *module, PyObject *obj)
-/*[clinic end generated code: output=e1516ac119a918ed input=201d0c58f69ae390]*/
+static int
+gc_is_finalized_impl(PyObject *module, PyObject *obj)
+/*[clinic end generated code: output=401ff5d6fc660429 input=ca4d111c8f8c4e3a]*/
 {
-    if (_PyObject_IS_GC(obj) && _PyGC_FINALIZED(obj)) {
-         Py_RETURN_TRUE;
-    }
-    Py_RETURN_FALSE;
+    return PyObject_GC_IsFinalized(obj);
 }
 
 /*[clinic input]

--- a/Python/gc_free_threading.c
+++ b/Python/gc_free_threading.c
@@ -1647,19 +1647,13 @@ PyObject_GC_Del(void *op)
 int
 PyObject_GC_IsTracked(PyObject* obj)
 {
-    if (_PyObject_IS_GC(obj) && _PyObject_GC_IS_TRACKED(obj)) {
-        return 1;
-    }
-    return 0;
+    return _PyObject_GC_IS_TRACKED(obj);
 }
 
 int
 PyObject_GC_IsFinalized(PyObject *obj)
 {
-    if (_PyObject_IS_GC(obj) && _PyGC_FINALIZED(obj)) {
-         return 1;
-    }
-    return 0;
+    return _PyGC_FINALIZED(obj);
 }
 
 struct custom_visitor_args {


### PR DESCRIPTION
Simplifies the implementations of `PyObject_GC_IsTracked()` and `PyObject_GC_IsFinalized()` in the free-threaded build's GC. The `_PyObject_IS_GC()` check is not necessary because every object in the free-threaded build has an `ob_gc_bits` field.

This also simplifies the Python bindings in gcmodule.c.


<!-- gh-issue-number: gh-112529 -->
* Issue: gh-112529
<!-- /gh-issue-number -->
