### PR TITLE
gh-108562: fix compiler warnings for bundled libmpdec in the main

### DIFF
--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -937,7 +937,7 @@ python.worker.js: $(srcdir)/Tools/wasm/python.worker.js
 
 ##########################################################################
 # Build static libmpdec.a
-LIBMPDEC_CFLAGS=@LIBMPDEC_CFLAGS@ $(PY_STDMODULE_CFLAGS) $(CCSHARED)
+LIBMPDEC_CFLAGS=$(PY_STDMODULE_CFLAGS) @LIBMPDEC_CFLAGS@ $(CCSHARED)
 
 # "%.o: %c" is not portable
 Modules/_decimal/libmpdec/basearith.o: $(srcdir)/Modules/_decimal/libmpdec/basearith.c $(LIBMPDEC_HEADERS) $(PYTHON_HEADERS)

--- a/Misc/sbom.spdx.json
+++ b/Misc/sbom.spdx.json
@@ -1238,11 +1238,11 @@
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "12402bcf7f0161adb83f78163f41cc10a5e5de5f"
+          "checksumValue": "9dcb50e3f9c3245972731be5da0b28e7583198d9"
         },
         {
           "algorithm": "SHA256",
-          "checksumValue": "cba044c76b6bc3ae6cfa49df1121cad7552140157b9e61e11cbb6580cc5d74cf"
+          "checksumValue": "7cac49fef5e9d952ec9390bf81c54d83f1b5da32fdf76091c2f0770ed943b7fe"
         }
       ],
       "fileName": "Modules/_decimal/libmpdec/io.c"

--- a/Modules/_decimal/libmpdec/io.c
+++ b/Modules/_decimal/libmpdec/io.c
@@ -48,6 +48,7 @@
 #if defined(__GNUC__) && !defined(__INTEL_COMPILER) && __GNUC__ >= 7
   #pragma GCC diagnostic ignored "-Wimplicit-fallthrough"
   #pragma GCC diagnostic ignored "-Wmisleading-indentation"
+  #pragma GCC diagnostic ignored "-Warray-bounds"
 #endif
 
 

--- a/configure
+++ b/configure
@@ -14359,6 +14359,13 @@ else $as_nop
   LIBMPDEC_LDFLAGS="-lm \$(LIBMPDEC_A)"
   LIBMPDEC_INTERNAL="\$(LIBMPDEC_HEADERS) \$(LIBMPDEC_A)"
 
+    if test "x$ac_cv_cc_supports_fstrict_overflow" = xyes
+then :
+
+    as_fn_append LIBMPDEC_CFLAGS " -fstrict-overflow"
+
+fi
+
     if test "x$with_pydebug" = xyes
 then :
 

--- a/configure.ac
+++ b/configure.ac
@@ -3744,6 +3744,11 @@ AS_VAR_IF([with_system_libmpdec], [yes], [
   LIBMPDEC_LDFLAGS="-lm \$(LIBMPDEC_A)"
   LIBMPDEC_INTERNAL="\$(LIBMPDEC_HEADERS) \$(LIBMPDEC_A)"
 
+  dnl Enable strict-overflow for libmpdec, if available, see GH-108562
+  AS_VAR_IF([ac_cv_cc_supports_fstrict_overflow], [yes], [
+    AS_VAR_APPEND([LIBMPDEC_CFLAGS], [" -fstrict-overflow"])
+  ])
+
   dnl Disable forced inlining in debug builds, see GH-94847
   AS_VAR_IF([with_pydebug], [yes], [
     AS_VAR_APPEND([LIBMPDEC_CFLAGS], [" -DTEST_COVERAGE"])


### PR DESCRIPTION
This patch enable (if awailable) -fstrict-overflow for libmpdec and also shut off false positive warnings (-Warray-bounds).  The later part was backported from mpdecimal-4.0.0.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-108562 -->
* Issue: gh-108562
<!-- /gh-issue-number -->
