### PR TITLE
 gh-113317: Remove Argument Clinic global variable 'clinic'

### DIFF
--- a/Lib/test/test_clinic.py
+++ b/Lib/test/test_clinic.py
@@ -2390,7 +2390,7 @@ class ClinicParserTest(TestCase):
             docstring1
             docstring2
         """
-        self.expect_failure(block, err, lineno=0)
+        self.expect_failure(block, err, lineno=3)
 
     def test_state_func_docstring_only_one_param_template(self):
         err = "You may not specify {parameters} more than once in a docstring!"
@@ -2404,7 +2404,7 @@ class ClinicParserTest(TestCase):
             these are the params again:
                 {parameters}
         """
-        self.expect_failure(block, err, lineno=0)
+        self.expect_failure(block, err, lineno=7)
 
 
 class ClinicExternalTest(TestCase):


### PR DESCRIPTION
* Add Clinic.warn() and Clinic.fail() methods.
* Add filename parameter to BlockParser constructor.
* Add BlockParser.fail() method.
* Add DSLParser.fail() method.
* Pass lineno parameter to DSLParser.format_docstring(): more accurate error reporting.
* Convert a few DSLParser static methods to regular method to be able to call self.fail().
* Language.render() clinic parameter is now required: None is no longer accepted.
* Remove warn() function.
* Remove global variable 'clinic'.

fail() and warn() methods get filename and line number from the instance on which the method is called, rather than relying on a global variable 'clinic'.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-113317 -->
* Issue: gh-113317
<!-- /gh-issue-number -->
