### PR TITLE
gh-110190: Fix ctypes structs with array on Windows ARM64

### DIFF
--- a/Misc/NEWS.d/next/Library/2024-01-30-15-34-08.gh-issue-110190.Z5PQQX.rst
+++ b/Misc/NEWS.d/next/Library/2024-01-30-15-34-08.gh-issue-110190.Z5PQQX.rst
@@ -1,0 +1,1 @@
+Fix ctypes structs with array on Windows ARM64 platform by setting ``MAX_STRUCT_SIZE`` to 32 in stgdict. Patch by Diego Russo

--- a/Modules/_ctypes/stgdict.c
+++ b/Modules/_ctypes/stgdict.c
@@ -707,7 +707,7 @@ PyCStructUnionType_update_stgdict(PyObject *type, PyObject *fields, int isStruct
 /*
  * The value of MAX_STRUCT_SIZE depends on the platform Python is running on.
  */
-#if defined(__aarch64__) || defined(__arm__)
+#if defined(__aarch64__) || defined(__arm__) || defined(_M_ARM64)
 #  define MAX_STRUCT_SIZE 32
 #elif defined(__powerpc64__)
 #  define MAX_STRUCT_SIZE 64


### PR DESCRIPTION
Fix the same issue of PR #112959 on Windows ARM64 platform when using MSVC compiler.
MSVC predefined platform preprocessor macro is _M_ARM64.


<!-- gh-issue-number: gh-110190 -->
* Issue: gh-110190
<!-- /gh-issue-number -->
