### PR TITLE
gh-114737: Revert change to ElementTree.iterparse "root" attribute

### DIFF
--- a/Lib/test/test_xml_etree.py
+++ b/Lib/test/test_xml_etree.py
@@ -536,6 +536,7 @@ class ElementTreeTest(unittest.TestCase):
         iterparse = ET.iterparse
 
         context = iterparse(SIMPLE_XMLFILE)
+        self.assertIsNone(context.root)
         action, elem = next(context)
         self.assertEqual((action, elem.tag), ('end', 'element'))
         self.assertEqual([(action, elem.tag) for action, elem in context], [

--- a/Lib/test/test_xml_etree.py
+++ b/Lib/test/test_xml_etree.py
@@ -538,6 +538,7 @@ class ElementTreeTest(unittest.TestCase):
         context = iterparse(SIMPLE_XMLFILE)
         self.assertIsNone(context.root)
         action, elem = next(context)
+        self.assertIsNone(context.root)
         self.assertEqual((action, elem.tag), ('end', 'element'))
         self.assertEqual([(action, elem.tag) for action, elem in context], [
                 ('end', 'element'),

--- a/Lib/xml/etree/ElementTree.py
+++ b/Lib/xml/etree/ElementTree.py
@@ -1258,7 +1258,6 @@ def iterparse(source, events=None, parser=None):
     it = IterParseIterator()
     it.root = None
     wr = weakref.ref(it)
-    del iterator, IterParseIterator
     return it
 
 

--- a/Lib/xml/etree/ElementTree.py
+++ b/Lib/xml/etree/ElementTree.py
@@ -1256,8 +1256,9 @@ def iterparse(source, events=None, parser=None):
                 source.close()
 
     it = IterParseIterator()
+    it.root = None
     wr = weakref.ref(it)
-    del IterParseIterator
+    del iterator, IterParseIterator
     return it
 
 


### PR DESCRIPTION
Prior to gh-114269, the iterator returned by ElementTree.iterparse was initialized with the root attribute as None. This restores the previous behavior.

Thanks to Prometheus3375 for pointing this out.


<!-- gh-issue-number: gh-114737 -->
* Issue: gh-114737
<!-- /gh-issue-number -->
