### PR TITLE
gh-101100: Fix class reference in library/test.rst

### DIFF
--- a/Doc/library/test.rst
+++ b/Doc/library/test.rst
@@ -143,7 +143,7 @@ guidelines to be followed:
          arg = (1, 2, 3)
 
   When using this pattern, remember that all classes that inherit from
-  :class:`unittest.TestCase` are run as tests.  The :class:`Mixin` class in the example above
+  :class:`unittest.TestCase` are run as tests.  The :class:`!TestFuncAcceptsSequencesMixin` class in the example above
   does not have any data and so can't be run by itself, thus it does not
   inherit from :class:`unittest.TestCase`.
 


### PR DESCRIPTION
The text clearly seems to be referencing `TestFuncAcceptsSequencesMixin`, for which no target is available. Name the class properly and suppress the dangling reference.


<!-- gh-issue-number: gh-101100 -->
* Issue: gh-101100
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--114769.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->