### PR TITLE
gh-101100: Update .nitignore (after accepting library/test.rst changes)

### DIFF
--- a/Doc/tools/.nitignore
+++ b/Doc/tools/.nitignore
@@ -64,7 +64,6 @@ Doc/library/ssl.rst
 Doc/library/stdtypes.rst
 Doc/library/subprocess.rst
 Doc/library/termios.rst
-Doc/library/test.rst
 Doc/library/tkinter.rst
 Doc/library/tkinter.scrolledtext.rst
 Doc/library/tkinter.ttk.rst


### PR DESCRIPTION
No longer required after the change to `library/test.rst` is accepted


<!-- gh-issue-number: gh-101100 -->
* Issue: gh-101100
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--114770.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->