### PR TITLE
pathlib ABCs: raise `UnsupportedOperation` directly.

### DIFF
--- a/Lib/pathlib/__init__.py
+++ b/Lib/pathlib/__init__.py
@@ -514,9 +514,8 @@ class Path(_abc.PathBase, PurePath):
     as_uri = PurePath.as_uri
 
     @classmethod
-    def _unsupported(cls, method_name):
-        msg = f"{cls.__name__}.{method_name}() is unsupported on this system"
-        raise UnsupportedOperation(msg)
+    def _unsupported_msg(cls, attribute):
+        return f"{cls.__name__}.{attribute} is unsupported on this system"
 
     def __init__(self, *args, **kwargs):
         if kwargs:

--- a/Lib/pathlib/_abc.py
+++ b/Lib/pathlib/_abc.py
@@ -149,39 +149,39 @@ class PathModuleBase:
     """
 
     @classmethod
-    def _unsupported(cls, attr):
-        raise UnsupportedOperation(f"{cls.__name__}.{attr} is unsupported")
+    def _unsupported_msg(cls, attribute):
+        return f"{cls.__name__}.{attribute} is unsupported"
 
     @property
     def sep(self):
         """The character used to separate path components."""
-        self._unsupported('sep')
+        raise UnsupportedOperation(self._unsupported_msg('sep'))
 
     def join(self, path, *paths):
         """Join path segments."""
-        self._unsupported('join()')
+        raise UnsupportedOperation(self._unsupported_msg('join()'))
 
     def split(self, path):
         """Split the path into a pair (head, tail), where *head* is everything
         before the final path separator, and *tail* is everything after.
         Either part may be empty.
         """
-        self._unsupported('split()')
+        raise UnsupportedOperation(self._unsupported_msg('split()'))
 
     def splitdrive(self, path):
         """Split the path into a 2-item tuple (drive, tail), where *drive* is
         a device name or mount point, and *tail* is everything after the
         drive. Either part may be empty."""
-        self._unsupported('splitdrive()')
+        raise UnsupportedOperation(self._unsupported_msg('splitdrive()'))
 
     def normcase(self, path):
         """Normalize the case of the path."""
-        self._unsupported('normcase()')
+        raise UnsupportedOperation(self._unsupported_msg('normcase()'))
 
     def isabs(self, path):
         """Returns whether the path is absolute, i.e. unaffected by the
         current directory or drive."""
-        self._unsupported('isabs()')
+        raise UnsupportedOperation(self._unsupported_msg('isabs()'))
 
 
 class PurePathBase:
@@ -505,16 +505,15 @@ class PathBase(PurePathBase):
     _max_symlinks = 40
 
     @classmethod
-    def _unsupported(cls, method_name):
-        msg = f"{cls.__name__}.{method_name}() is unsupported"
-        raise UnsupportedOperation(msg)
+    def _unsupported_msg(cls, attribute):
+        return f"{cls.__name__}.{attribute} is unsupported"
 
     def stat(self, *, follow_symlinks=True):
         """
         Return the result of the stat() system call on this path, like
         os.stat() does.
         """
-        self._unsupported("stat")
+        raise UnsupportedOperation(self._unsupported_msg('stat()'))
 
     def lstat(self):
         """
@@ -703,7 +702,7 @@ class PathBase(PurePathBase):
         Open the file pointed by this path and return a file object, as
         the built-in open() function does.
         """
-        self._unsupported("open")
+        raise UnsupportedOperation(self._unsupported_msg('open()'))
 
     def read_bytes(self):
         """
@@ -744,7 +743,7 @@ class PathBase(PurePathBase):
         The children are yielded in arbitrary order, and the
         special entries '.' and '..' are not included.
         """
-        self._unsupported("iterdir")
+        raise UnsupportedOperation(self._unsupported_msg('iterdir()'))
 
     def _scandir(self):
         # Emulate os.scandir(), which returns an object that can be used as a
@@ -871,7 +870,7 @@ class PathBase(PurePathBase):
 
         Use resolve() to resolve symlinks and remove '..' segments.
         """
-        self._unsupported("absolute")
+        raise UnsupportedOperation(self._unsupported_msg('absolute()'))
 
     @classmethod
     def cwd(cls):
@@ -886,7 +885,7 @@ class PathBase(PurePathBase):
         """ Return a new path with expanded ~ and ~user constructs
         (as returned by os.path.expanduser)
         """
-        self._unsupported("expanduser")
+        raise UnsupportedOperation(self._unsupported_msg('expanduser()'))
 
     @classmethod
     def home(cls):
@@ -898,7 +897,7 @@ class PathBase(PurePathBase):
         """
         Return the path to which the symbolic link points.
         """
-        self._unsupported("readlink")
+        raise UnsupportedOperation(self._unsupported_msg('readlink()'))
     readlink._supported = False
 
     def resolve(self, strict=False):
@@ -973,7 +972,7 @@ class PathBase(PurePathBase):
         Make this path a symlink pointing to the target path.
         Note the order of arguments (link, target) is the reverse of os.symlink.
         """
-        self._unsupported("symlink_to")
+        raise UnsupportedOperation(self._unsupported_msg('symlink_to()'))
 
     def hardlink_to(self, target):
         """
@@ -981,19 +980,19 @@ class PathBase(PurePathBase):
 
         Note the order of arguments (self, target) is the reverse of os.link's.
         """
-        self._unsupported("hardlink_to")
+        raise UnsupportedOperation(self._unsupported_msg('hardlink_to()'))
 
     def touch(self, mode=0o666, exist_ok=True):
         """
         Create this file with the given access mode, if it doesn't exist.
         """
-        self._unsupported("touch")
+        raise UnsupportedOperation(self._unsupported_msg('touch()'))
 
     def mkdir(self, mode=0o777, parents=False, exist_ok=False):
         """
         Create a new directory at this given path.
         """
-        self._unsupported("mkdir")
+        raise UnsupportedOperation(self._unsupported_msg('mkdir()'))
 
     def rename(self, target):
         """
@@ -1005,7 +1004,7 @@ class PathBase(PurePathBase):
 
         Returns the new Path instance pointing to the target path.
         """
-        self._unsupported("rename")
+        raise UnsupportedOperation(self._unsupported_msg('rename()'))
 
     def replace(self, target):
         """
@@ -1017,13 +1016,13 @@ class PathBase(PurePathBase):
 
         Returns the new Path instance pointing to the target path.
         """
-        self._unsupported("replace")
+        raise UnsupportedOperation(self._unsupported_msg('replace()'))
 
     def chmod(self, mode, *, follow_symlinks=True):
         """
         Change the permissions of the path, like os.chmod().
         """
-        self._unsupported("chmod")
+        raise UnsupportedOperation(self._unsupported_msg('chmod()'))
 
     def lchmod(self, mode):
         """
@@ -1037,31 +1036,31 @@ class PathBase(PurePathBase):
         Remove this file or link.
         If the path is a directory, use rmdir() instead.
         """
-        self._unsupported("unlink")
+        raise UnsupportedOperation(self._unsupported_msg('unlink()'))
 
     def rmdir(self):
         """
         Remove this directory.  The directory must be empty.
         """
-        self._unsupported("rmdir")
+        raise UnsupportedOperation(self._unsupported_msg('rmdir()'))
 
     def owner(self, *, follow_symlinks=True):
         """
         Return the login name of the file owner.
         """
-        self._unsupported("owner")
+        raise UnsupportedOperation(self._unsupported_msg('owner()'))
 
     def group(self, *, follow_symlinks=True):
         """
         Return the group name of the file gid.
         """
-        self._unsupported("group")
+        raise UnsupportedOperation(self._unsupported_msg('group()'))
 
     @classmethod
     def from_uri(cls, uri):
         """Return a new path from the given 'file' URI."""
-        cls._unsupported("from_uri")
+        raise UnsupportedOperation(cls._unsupported_msg('from_uri()'))
 
     def as_uri(self):
         """Return the path as a URI."""
-        self._unsupported("as_uri")
+        raise UnsupportedOperation(self._unsupported_msg('as_uri()'))


### PR DESCRIPTION
Raise `UnsupportedOperation` directly, rather than via an `_unsupported()` helper, to give human readers and IDEs/typecheckers/etc a bigger hint that these methods are abstract.
