### PR TITLE
gh-101100: Fix sphinx warnings in `c-api/gcsupport.rst`

### DIFF
--- a/Doc/c-api/gcsupport.rst
+++ b/Doc/c-api/gcsupport.rst
@@ -89,7 +89,7 @@ rules:
    Returns the resized object of type ``TYPE*`` (refers to any C type)
    or ``NULL`` on failure.
 
-   *op* must of type :c:expr:`PyVarObject *`
+   *op* must be of type :c:expr:`PyVarObject *`
    and must not be tracked by the collector yet.
    *newsize* must be of type :c:type:`Py_ssize_t`.
 

--- a/Doc/c-api/gcsupport.rst
+++ b/Doc/c-api/gcsupport.rst
@@ -83,10 +83,15 @@ rules:
    .. versionadded:: 3.12
 
 
-.. c:function:: TYPE* PyObject_GC_Resize(TYPE, PyVarObject *op, Py_ssize_t newsize)
+.. c:macro:: PyObject_GC_Resize(TYPE, op, newsize)
 
-   Resize an object allocated by :c:macro:`PyObject_NewVar`.  Returns the
-   resized object or ``NULL`` on failure.  *op* must not be tracked by the collector yet.
+   Resize an object allocated by :c:macro:`PyObject_NewVar`.
+   Returns the resized object of type ``TYPE*`` (refers to any C type)
+   or ``NULL`` on failure.
+
+   *op* must of type :c:expr:`PyVarObject *`
+   and must not be tracked by the collector yet.
+   *newsize* must be of type :c:type:`Py_ssize_t`.
 
 
 .. c:function:: void PyObject_GC_Track(PyObject *op)

--- a/Doc/tools/.nitignore
+++ b/Doc/tools/.nitignore
@@ -5,7 +5,6 @@
 Doc/c-api/descriptor.rst
 Doc/c-api/exceptions.rst
 Doc/c-api/float.rst
-Doc/c-api/gcsupport.rst
 Doc/c-api/init.rst
 Doc/c-api/init_config.rst
 Doc/c-api/intro.rst

--- a/Misc/NEWS.d/3.12.0b1.rst
+++ b/Misc/NEWS.d/3.12.0b1.rst
@@ -2371,7 +2371,7 @@ Add a new C-API function to eagerly assign a version tag to a PyTypeObject:
 .. nonce: _paFIF
 .. section: C API
 
-:c:func:`PyObject_GC_Resize` should calculate preheader size if needed.
+:c:macro:`PyObject_GC_Resize` should calculate preheader size if needed.
 Patch by Donghee Na.
 
 ..


### PR DESCRIPTION
Before:

```
/Users/sobolev/Desktop/cpython2/Doc/c-api/gcsupport.rst:86: WARNING: c:identifier reference target not found: TYPE
/Users/sobolev/Desktop/cpython2/Doc/c-api/gcsupport.rst:86: WARNING: c:identifier reference target not found: TYPE
```

I think that `PyObject_GC_Resize` should be documented as a macro. Because it is: https://github.com/python/cpython/blob/c8cf5d7d148944f2850f25b02334400dd0238cb0/Include/objimpl.h#L179-L180

Previous error was correct, there's no such thing as `TYPE` outside of the macro context.

<!-- gh-issue-number: gh-101100 -->
* Issue: gh-101100
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--114786.org.readthedocs.build/en/114786/c-api/gcsupport.html#c.PyObject_GC_Resize

<!-- readthedocs-preview cpython-previews end -->