### PR TITLE
gh-114779: Do not include `InitVar` fields into `__match_args__`

### DIFF
--- a/Lib/dataclasses.py
+++ b/Lib/dataclasses.py
@@ -1150,7 +1150,10 @@ def _process_class(cls, init, repr, eq, order, unsafe_hash, frozen,
     if match_args:
         # I could probably compute this once
         _set_new_attribute(cls, '__match_args__',
-                           tuple(f.name for f in std_init_fields))
+                           tuple(f.name
+                                 for f in std_init_fields
+                                 # Only include regular fields, not `InitVar`s
+                                 if f._field_type is _FIELD))
 
     # It's an error to specify weakref_slot if slots is False.
     if weakref_slot and not slots:

--- a/Lib/test/test_dataclasses/__init__.py
+++ b/Lib/test/test_dataclasses/__init__.py
@@ -4363,6 +4363,15 @@ class TestMatchArgs(unittest.TestCase):
         C = make_dataclass('C', [('x', int), ('y', int)], namespace={'__match_args__': ('z',)})
         self.assertEqual(C.__match_args__, ('z',))
 
+    def test_match_args_with_classvar_and_initvar(self):
+        @dataclass
+        class A:
+            a: ClassVar[int]
+            b: InitVar[int]
+            c: int
+
+        self.assertEqual(A.__match_args__, ('c',))
+
 
 class TestKeywordArgs(unittest.TestCase):
     def test_no_classvar_kwarg(self):

--- a/Misc/NEWS.d/next/Library/2024-01-31-10-56-07.gh-issue-114779.0Iy9pX.rst
+++ b/Misc/NEWS.d/next/Library/2024-01-31-10-56-07.gh-issue-114779.0Iy9pX.rst
@@ -1,0 +1,2 @@
+Do not include :data:`dataclasses.InitVar` fields into
+:data:`~object.__match_args__`.


### PR DESCRIPTION
This now makes much more sense. Plus, there was no `ClassVar` + `__match_args__` test.

<!-- gh-issue-number: gh-114779 -->
* Issue: gh-114779
<!-- /gh-issue-number -->
