### PR TITLE
gh-114788: Do not run JIT workflow on unrelated changes

### DIFF
--- a/.github/workflows/jit.yml
+++ b/.github/workflows/jit.yml
@@ -2,12 +2,10 @@ name: JIT
 on:
   pull_request:
     paths:
-    - '**/*jit*/**'
-    - '**/*jit*.*'
+      - '**jit**'
   push:
     paths:
-    - '**/*jit/**'
-    - '**/*jit*.*'
+      - '**jit**'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/jit.yml
+++ b/.github/workflows/jit.yml
@@ -3,9 +3,11 @@ on:
   pull_request:
     paths:
       - '**jit**'
+      - 'Python/bytecodes.c'
   push:
     paths:
       - '**jit**'
+      - 'Python/bytecodes.c'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/jit.yml
+++ b/.github/workflows/jit.yml
@@ -3,9 +3,11 @@ on:
   pull_request:
     paths:
     - '**/*jit/**'
+    - '**/*jit.*'
   push:
     paths:
     - '**/*jit/**'
+    - '**/*jit.*'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/jit.yml
+++ b/.github/workflows/jit.yml
@@ -1,10 +1,17 @@
 name: JIT
 on:
   pull_request:
-    paths: '**jit**'
+    paths:
+    - '**/*jit/**'
   push:
-    paths: '**jit**'
+    paths:
+    - '**/*jit/**'
   workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   jit:
     name: ${{ matrix.target }} (${{ matrix.debug && 'Debug' || 'Release' }})

--- a/.github/workflows/jit.yml
+++ b/.github/workflows/jit.yml
@@ -2,12 +2,12 @@ name: JIT
 on:
   pull_request:
     paths:
-    - '**/*jit/**'
-    - '**/*jit.*'
+    - '**/*jit*/**'
+    - '**/*jit*.*'
   push:
     paths:
     - '**/*jit/**'
-    - '**/*jit.*'
+    - '**/*jit*.*'
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
First change is about `concurrency:`. We simply cancel previous runs not to waste resources.

Second, docs say that `paths` should be like this:
<img width="701" alt="Снимок экрана 2024-01-31 в 11 44 41" src="https://github.com/python/cpython/assets/4660275/eac722f3-b04c-4a89-8a0e-55d673bbd66f">

Plus, I also included `**/*jit*.*` to match any files with `jit` prefix or suffix in its name.

First run: changed `jit.yml` 
<img width="977" alt="Снимок экрана 2024-01-31 в 11 50 33" src="https://github.com/python/cpython/assets/4660275/75d4a832-c85b-4348-9f54-ac2bf2d6c435">

JIT workflow is there ✅ 

Second run: added a PR to this branch in my fork with unrelated changes.

<img width="915" alt="Снимок экрана 2024-01-31 в 11 58 56" src="https://github.com/python/cpython/assets/4660275/9878da2d-52fc-4729-bca0-b14a0848fdb4">


No JIT workflow ✅ 

<!-- gh-issue-number: gh-114788 -->
* Issue: gh-114788
<!-- /gh-issue-number -->
