### PR TITLE
gh-114790: Do not execute `workflows/require-pr-label.yml` on forks

### DIFF
--- a/.github/workflows/require-pr-label.yml
+++ b/.github/workflows/require-pr-label.yml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   label:
     name: DO-NOT-MERGE / unresolved review
-    if: github.repository == 'python/cpython'
+    if: github.repository_owner == 'python'
     runs-on: ubuntu-latest
     timeout-minutes: 10
 

--- a/.github/workflows/require-pr-label.yml
+++ b/.github/workflows/require-pr-label.yml
@@ -11,6 +11,7 @@ permissions:
 jobs:
   label:
     name: DO-NOT-MERGE / unresolved review
+    if: github.repository == 'python/cpython'
     runs-on: ubuntu-latest
     timeout-minutes: 10
 


### PR DESCRIPTION
Sadly, we cannot completely skip it on `on:` level, but we can skip it on `jobs:` level.

<!-- gh-issue-number: gh-114790 -->
* Issue: gh-114790
<!-- /gh-issue-number -->
