### PR TITLE
Remove Alex Waygood as an Argument Clinic CODEOWNER

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -230,8 +230,8 @@ Doc/c-api/stable.rst          @encukou
 **/*zipfile/_path/*           @jaraco
 
 # Argument Clinic
-/Tools/clinic/**              @erlend-aasland @AlexWaygood
-/Lib/test/test_clinic.py      @erlend-aasland @AlexWaygood
+/Tools/clinic/**              @erlend-aasland
+/Lib/test/test_clinic.py      @erlend-aasland
 Doc/howto/clinic.rst          @erlend-aasland
 
 # Subinterpreters


### PR DESCRIPTION
@erlend-aasland and I have done a lot of refactoring work on Argument Clinic over the last year, and it's been a lot of fun! However, there's a lot more to do.

I'm about to start a new job (hooray!), which, unfortunately, means I'm probably not going to be able to keep up with AC development over the next few months with the same level of detail as I have previously (😞). I trust @erlend-aasland, @vstinner, @corona10 and other Argument-Clinic-curious core devs to do a good job with AC in the meantime :)