### PR TITLE
gh-114807: multiprocessing: don't raise ImportError if _multiprocessing is missing

### DIFF
--- a/Lib/multiprocessing/connection.py
+++ b/Lib/multiprocessing/connection.py
@@ -19,7 +19,6 @@ import time
 import tempfile
 import itertools
 
-import _multiprocessing
 
 from . import util
 
@@ -28,6 +27,7 @@ from .context import reduction
 _ForkingPickler = reduction.ForkingPickler
 
 try:
+    import _multiprocessing
     import _winapi
     from _winapi import WAIT_OBJECT_0, WAIT_ABANDONED_0, WAIT_TIMEOUT, INFINITE
 except ImportError:


### PR DESCRIPTION
_multiprocessing is only used under the `if _winapi` block so I think it makes sense to move the import behind the same try/catch block. 


<!-- gh-issue-number: gh-114807 -->
* Issue: gh-114807
<!-- /gh-issue-number -->
