### PR TITLE
gh-67230: Add versionadded notes for QUOTE_NOTNULL and QUOTE_STRINGS

### DIFF
--- a/Doc/library/csv.rst
+++ b/Doc/library/csv.rst
@@ -351,6 +351,8 @@ The :mod:`csv` module defines the following constants:
    Instructs :class:`reader` objects to interpret an empty (unquoted) field as None and
    to otherwise behave as :data:`QUOTE_ALL`.
 
+   .. versionadded:: 3.12
+
 .. data:: QUOTE_STRINGS
 
    Instructs :class:`writer` objects to always place quotes around fields
@@ -359,6 +361,8 @@ The :mod:`csv` module defines the following constants:
 
    Instructs :class:`reader` objects to interpret an empty (unquoted) string as ``None`` and
    to otherwise behave as :data:`QUOTE_NONNUMERIC`.
+
+   .. versionadded:: 3.12
 
 The :mod:`csv` module defines the following exception:
 


### PR DESCRIPTION
As @GPHemsley pointed out, #29469 omitted `versionadded` notes for the 2 new items.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--114816.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->

<!-- gh-issue-number: gh-67230 -->
* Issue: gh-67230
<!-- /gh-issue-number -->
