### PR TITLE
gh-112529: Stop the world around gc.get_referents

### DIFF
--- a/Modules/gcmodule.c
+++ b/Modules/gcmodule.c
@@ -239,14 +239,15 @@ static int
 append_referrents(PyObject *result, PyObject *args)
 {
     for (Py_ssize_t i = 0; i < PyTuple_GET_SIZE(args); i++) {
-        traverseproc traverse;
         PyObject *obj = PyTuple_GET_ITEM(args, i);
+        if (!_PyObject_IS_GC(obj)) {
+            continue;
+        }
 
-        if (!_PyObject_IS_GC(obj))
+        traverseproc traverse = Py_TYPE(obj)->tp_traverse;
+        if (!traverse) {
             continue;
-        traverse = Py_TYPE(obj)->tp_traverse;
-        if (!traverse)
-            continue;
+        }
         if (traverse(obj, referentsvisit, result)) {
             return -1;
         }

--- a/Modules/gcmodule.c
+++ b/Modules/gcmodule.c
@@ -235,6 +235,25 @@ referentsvisit(PyObject *obj, void *arg)
     return PyList_Append(list, obj) < 0;
 }
 
+static int
+append_referrents(PyObject *result, PyObject *args)
+{
+    for (Py_ssize_t i = 0; i < PyTuple_GET_SIZE(args); i++) {
+        traverseproc traverse;
+        PyObject *obj = PyTuple_GET_ITEM(args, i);
+
+        if (!_PyObject_IS_GC(obj))
+            continue;
+        traverse = Py_TYPE(obj)->tp_traverse;
+        if (! traverse)
+            continue;
+        if (traverse(obj, referentsvisit, result)) {
+            return -1;
+        }
+    }
+    return 0;
+}
+
 /*[clinic input]
 gc.get_referents
 
@@ -247,29 +266,24 @@ static PyObject *
 gc_get_referents_impl(PyObject *module, PyObject *args)
 /*[clinic end generated code: output=d47dc02cefd06fe8 input=b3ceab0c34038cbf]*/
 {
-    Py_ssize_t i;
     if (PySys_Audit("gc.get_referents", "(O)", args) < 0) {
         return NULL;
     }
+    PyInterpreterState *interp = _PyInterpreterState_GET();
     PyObject *result = PyList_New(0);
 
     if (result == NULL)
         return NULL;
 
-    for (i = 0; i < PyTuple_GET_SIZE(args); i++) {
-        traverseproc traverse;
-        PyObject *obj = PyTuple_GET_ITEM(args, i);
+    // NOTE: stop the world is a no-op in default build
+    _PyEval_StopTheWorld(interp);
+    int err = append_referrents(result, args);
+    _PyEval_StartTheWorld(interp);
 
-        if (!_PyObject_IS_GC(obj))
-            continue;
-        traverse = Py_TYPE(obj)->tp_traverse;
-        if (! traverse)
-            continue;
-        if (traverse(obj, referentsvisit, result)) {
-            Py_DECREF(result);
-            return NULL;
-        }
+    if (err < 0) {
+        Py_CLEAR(result);
     }
+
     return result;
 }
 

--- a/Modules/gcmodule.c
+++ b/Modules/gcmodule.c
@@ -245,7 +245,7 @@ append_referrents(PyObject *result, PyObject *args)
         if (!_PyObject_IS_GC(obj))
             continue;
         traverse = Py_TYPE(obj)->tp_traverse;
-        if (! traverse)
+        if (!traverse)
             continue;
         if (traverse(obj, referentsvisit, result)) {
             return -1;


### PR DESCRIPTION
We do not want to add locking in tp_traverse slot implementations. Instead, stop-the-world when calling gc.get_referents. Note that the the stop-the-world call is a no-op in the default build.


<!-- gh-issue-number: gh-112529 -->
* Issue: gh-112529
<!-- /gh-issue-number -->
