### PR TITLE
gh-105712: Use appropriate regex to detect negative numbers in arguments

### DIFF
--- a/Lib/argparse.py
+++ b/Lib/argparse.py
@@ -1399,7 +1399,7 @@ class _ActionsContainer(object):
         self._defaults = {}
 
         # determines whether an "option" looks like a negative number
-        self._negative_number_matcher = _re.compile(r'^-\d+$|^-\d*\.\d+$')
+        self._negative_number_matcher = _re.compile(r'^-\d+$|^-\d*\.\d+$|^-\d*\.?\d+e[+-]?\d+$')
 
         # whether or not there are any optionals that look like negative
         # numbers -- uses a list so it can be shared and edited

--- a/Misc/NEWS.d/next/Library/2024-02-01-02-09-29.gh-issue-105712.rnlreu.rst
+++ b/Misc/NEWS.d/next/Library/2024-02-01-02-09-29.gh-issue-105712.rnlreu.rst
@@ -1,0 +1,8 @@
+Fix the issue that::
+
+    parser.add_argument("-p", "--param", type=float)
+    args = parser.parse_args()
+
+fails to correctly deal with `-p -3e12`, thinking that `-3e12` is an option,
+not a parameter to one. That's because the old regex was too restrictive.
+This fixes that with no found downsides.


### PR DESCRIPTION
Fix the issue that::

    parser.add_argument("-p", "--param", type=float)
    args = parser.parse_args()

fails to correctly deal with `-p -3e12`, thinking that `-3e12` is an option,
not a parameter to one. That's because the old regex was too restrictive.
This fixes that with no found downsides.


<!-- gh-issue-number: gh-105712 -->
* Issue: gh-105712
<!-- /gh-issue-number -->
