### PR TITLE
gh-114875: Add `getgrent` as a prerequisite for building the `grp` module

### DIFF
--- a/Misc/NEWS.d/next/Build/2024-02-01-20-08-11.gh-issue-114875.x_2iZ9.rst
+++ b/Misc/NEWS.d/next/Build/2024-02-01-20-08-11.gh-issue-114875.x_2iZ9.rst
@@ -1,1 +1,1 @@
-Add ``getgrent`` as a prerequisite for building the :mod:`grp` module.
+Add :c:func:`!getgrent` as a prerequisite for building the :mod:`grp` module.

--- a/Misc/NEWS.d/next/Build/2024-02-01-20-08-11.gh-issue-114875.x_2iZ9.rst
+++ b/Misc/NEWS.d/next/Build/2024-02-01-20-08-11.gh-issue-114875.x_2iZ9.rst
@@ -1,0 +1,1 @@
+Add ``getgrent`` as a prerequisite for building the :mod:`grp` module.

--- a/configure
+++ b/configure
@@ -28907,8 +28907,8 @@ then :
 
     if true
 then :
-  if test "$ac_cv_func_getgrent" = yes &&
-   test "$ac_cv_func_getgrgid" = yes -o "$ac_cv_func_getgrgid_r" = yes
+  if test "$ac_cv_func_getgrent" = "yes" &&
+   { test "$ac_cv_func_getgrgid" = "yes" || test "$ac_cv_func_getgrgid_r" = "yes"; }
 then :
   py_cv_module_grp=yes
 else $as_nop

--- a/configure
+++ b/configure
@@ -17445,6 +17445,12 @@ then :
   printf "%s\n" "#define HAVE_GETGID 1" >>confdefs.h
 
 fi
+ac_fn_c_check_func "$LINENO" "getgrent" "ac_cv_func_getgrent"
+if test "x$ac_cv_func_getgrent" = xyes
+then :
+  printf "%s\n" "#define HAVE_GETGRENT 1" >>confdefs.h
+
+fi
 ac_fn_c_check_func "$LINENO" "getgrgid" "ac_cv_func_getgrgid"
 if test "x$ac_cv_func_getgrgid" = xyes
 then :
@@ -28901,7 +28907,8 @@ then :
 
     if true
 then :
-  if test "$ac_cv_func_getgrgid" = yes -o "$ac_cv_func_getgrgid_r" = yes
+  if test "$ac_cv_func_getgrent" = yes &&
+   test "$ac_cv_func_getgrgid" = yes -o "$ac_cv_func_getgrgid_r" = yes
 then :
   py_cv_module_grp=yes
 else $as_nop

--- a/configure.ac
+++ b/configure.ac
@@ -4767,7 +4767,7 @@ AC_CHECK_FUNCS([ \
   copy_file_range ctermid dup dup3 execv explicit_bzero explicit_memset \
   faccessat fchmod fchmodat fchown fchownat fdopendir fdwalk fexecve \
   fork fork1 fpathconf fstatat ftime ftruncate futimens futimes futimesat \
-  gai_strerror getegid getentropy geteuid getgid getgrgid getgrgid_r \
+  gai_strerror getegid getentropy geteuid getgid getgrent getgrgid getgrgid_r \
   getgrnam_r getgrouplist getgroups gethostname getitimer getloadavg getlogin \
   getpeername getpgid getpid getppid getpriority _getpty \
   getpwent getpwnam_r getpwuid getpwuid_r getresgid getresuid getrusage getsid getspent \
@@ -7293,7 +7293,9 @@ PY_STDLIB_MOD([_socket],
                     -a "$ac_cv_header_netinet_in_h" = "yes"]))
 
 dnl platform specific extensions
-PY_STDLIB_MOD([grp], [], [test "$ac_cv_func_getgrgid" = yes -o "$ac_cv_func_getgrgid_r" = yes])
+PY_STDLIB_MOD([grp], [],
+  [test "$ac_cv_func_getgrent" = yes &&
+   test "$ac_cv_func_getgrgid" = yes -o "$ac_cv_func_getgrgid_r" = yes])
 PY_STDLIB_MOD([pwd], [], [test "$ac_cv_func_getpwuid" = yes -o "$ac_cv_func_getpwuid_r" = yes])
 PY_STDLIB_MOD([resource], [], [test "$ac_cv_header_sys_resource_h" = yes])
 PY_STDLIB_MOD([_scproxy],

--- a/configure.ac
+++ b/configure.ac
@@ -7294,8 +7294,8 @@ PY_STDLIB_MOD([_socket],
 
 dnl platform specific extensions
 PY_STDLIB_MOD([grp], [],
-  [test "$ac_cv_func_getgrent" = yes &&
-   test "$ac_cv_func_getgrgid" = yes -o "$ac_cv_func_getgrgid_r" = yes])
+  [test "$ac_cv_func_getgrent" = "yes" &&
+   { test "$ac_cv_func_getgrgid" = "yes" || test "$ac_cv_func_getgrgid_r" = "yes"; }])
 PY_STDLIB_MOD([pwd], [], [test "$ac_cv_func_getpwuid" = yes -o "$ac_cv_func_getpwuid_r" = yes])
 PY_STDLIB_MOD([resource], [], [test "$ac_cv_header_sys_resource_h" = yes])
 PY_STDLIB_MOD([_scproxy],

--- a/pyconfig.h.in
+++ b/pyconfig.h.in
@@ -474,6 +474,9 @@
 /* Define to 1 if you have the `getgid' function. */
 #undef HAVE_GETGID
 
+/* Define to 1 if you have the `getgrent' function. */
+#undef HAVE_GETGRENT
+
 /* Define to 1 if you have the `getgrgid' function. */
 #undef HAVE_GETGRGID
 


### PR DESCRIPTION
This allows the module to be correctly skipped on older versions of Android which don't have `getgrent` and related functions:
```
checking for getgrent... no
checking for getgrgid... yes
checking for getgrgid_r... no
[...]
checking for stdlib extension module grp... missing
```

<!-- gh-issue-number: gh-114875 -->
* Fixes: gh-114875
<!-- /gh-issue-number -->
