### PR TITLE
gh-111239: Update Windows build to use zlib 1.3.1

### DIFF
--- a/Misc/NEWS.d/next/Windows/2024-02-01-14-35-05.gh-issue-111239.SO7SUF.rst
+++ b/Misc/NEWS.d/next/Windows/2024-02-01-14-35-05.gh-issue-111239.SO7SUF.rst
@@ -1,0 +1,1 @@
+Update Windows builds to use zlib v1.3.1.

--- a/PCbuild/get_externals.bat
+++ b/PCbuild/get_externals.bat
@@ -58,7 +58,7 @@ set libraries=%libraries%                                       sqlite-3.44.2.0
 if NOT "%IncludeTkinterSrc%"=="false" set libraries=%libraries% tcl-core-8.6.13.1
 if NOT "%IncludeTkinterSrc%"=="false" set libraries=%libraries% tk-8.6.13.1
 set libraries=%libraries%                                       xz-5.2.5
-set libraries=%libraries%                                       zlib-1.2.13
+set libraries=%libraries%                                       zlib-1.3.1
 
 for %%e in (%libraries%) do (
     if exist "%EXTERNALS_DIR%\%%e" (

--- a/PCbuild/python.props
+++ b/PCbuild/python.props
@@ -78,7 +78,7 @@
     <opensslOutDir Condition="$(opensslOutDir) == ''">$(ExternalsDir)openssl-bin-3.0.11\$(ArchName)\</opensslOutDir>
     <opensslIncludeDir Condition="$(opensslIncludeDir) == ''">$(opensslOutDir)include</opensslIncludeDir>
     <nasmDir Condition="$(nasmDir) == ''">$(ExternalsDir)\nasm-2.11.06\</nasmDir>
-    <zlibDir Condition="$(zlibDir) == ''">$(ExternalsDir)\zlib-1.2.13\</zlibDir>
+    <zlibDir Condition="$(zlibDir) == ''">$(ExternalsDir)\zlib-1.3.1\</zlibDir>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
zlib v1.3.1 fixes CVE-2023-45853, which does not affect CPython.

Edit: Apparently that CVE has been updated to point at `pyminizip` rather than `zlib` itself, at least in GitHub.  Either way, this update brings us up to date and removes the possibility of someone complaining that we're using an insecure version of zlib :)


<!-- gh-issue-number: gh-111239 -->
* Issue: gh-111239
<!-- /gh-issue-number -->
