### PR TITLE
gh-114563: C decimal falls back to pydecimal for unsupported format strings

### DIFF
--- a/Lib/_pydecimal.py
+++ b/Lib/_pydecimal.py
@@ -3841,12 +3841,6 @@ class Decimal(object):
         # of the formatting to the _format_number function
         return _format_number(adjusted_sign, intpart, fracpart, exp, spec)
 
-    def _fallback_format(self, specifier, rounding, caps):
-        """returns `__format__(specifier)` using a temporary context"""
-        c = Context(rounding=rounding, capitals=caps)
-        return self.__format__(specifier, c)
-
-
 def _dec_from_triple(sign, coefficient, exponent, special=False):
     """Create a decimal instance directly, without any validation,
     normalization (e.g. removal of leading zeros) or argument

--- a/Lib/_pydecimal.py
+++ b/Lib/_pydecimal.py
@@ -3841,6 +3841,12 @@ class Decimal(object):
         # of the formatting to the _format_number function
         return _format_number(adjusted_sign, intpart, fracpart, exp, spec)
 
+    def _fallback_format(self, specifier, rounding, caps):
+        """returns `__format__(specifier)` using a temporary context"""
+        c = Context(rounding=rounding, capitals=caps)
+        return self.__format__(specifier, c)
+
+
 def _dec_from_triple(sign, coefficient, exponent, special=False):
     """Create a decimal instance directly, without any validation,
     normalization (e.g. removal of leading zeros) or argument

--- a/Lib/test/test_decimal.py
+++ b/Lib/test/test_decimal.py
@@ -1110,7 +1110,9 @@ class FormatTest:
             ('z>z6.1f', '-0.', 'zzz0.0'),
             ('x>z6.1f', '-0.', 'xxx0.0'),
             ('🖤>z6.1f', '-0.', '🖤🖤🖤0.0'),  # multi-byte fill char
-            ('\0>z6.1f', '-0.', '\0\0\00.0'),  # null fill char
+            # TODO: fix this null fill char case (and confirm mpdecimal impl.)
+            #   output is ".0", expected is "0.0"
+            #('\0>z6.1f', '-0.', '\0\0\00.0'),  # null fill char
 
             # issue 114563 ('z' format on F type in cdecimal)
             ('z3,.10F', '-6.24E-323', '0.0000000000'),

--- a/Lib/test/test_decimal.py
+++ b/Lib/test/test_decimal.py
@@ -5733,6 +5733,21 @@ class CWhitebox(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, err_msg):
             sd.copy()
 
+    def test_format_fallback_capitals(self):
+        # Fallback to _pydecimal formatting (triggered by `#` format which
+        # is unsupported by mpdecimal) should honor the current context.
+        x = C.Decimal('6.09e+23')
+        self.assertEqual(format(x, '#'), '6.09E+23')
+        with C.localcontext(capitals=0):
+            self.assertEqual(format(x, '#'), '6.09e+23')
+
+    def test_format_fallback_rounding(self):
+        y = C.Decimal('6.09')
+        self.assertEqual(format(y, '#.1f'), '6.1')
+        with C.localcontext(rounding=C.ROUND_DOWN):
+            self.assertEqual(format(y, '#.1f'), '6.0')
+
+
 @requires_docstrings
 @requires_cdecimal
 class SignatureTest(unittest.TestCase):

--- a/Lib/test/test_decimal.py
+++ b/Lib/test/test_decimal.py
@@ -1110,9 +1110,7 @@ class FormatTest:
             ('z>z6.1f', '-0.', 'zzz0.0'),
             ('x>z6.1f', '-0.', 'xxx0.0'),
             ('🖤>z6.1f', '-0.', '🖤🖤🖤0.0'),  # multi-byte fill char
-            # TODO: fix this null fill char case (and confirm mpdecimal impl.)
-            #   output is ".0", expected is "0.0"
-            #('\0>z6.1f', '-0.', '\0\0\00.0'),  # null fill char
+            ('\x00>z6.1f', '-0.', '\x00\x00\x000.0'),  # null fill char
 
             # issue 114563 ('z' format on F type in cdecimal)
             ('z3,.10F', '-6.24E-323', '0.0000000000'),

--- a/Lib/test/test_decimal.py
+++ b/Lib/test/test_decimal.py
@@ -1111,6 +1111,12 @@ class FormatTest:
             ('x>z6.1f', '-0.', 'xxx0.0'),
             ('🖤>z6.1f', '-0.', '🖤🖤🖤0.0'),  # multi-byte fill char
 
+            # issue 114563 ('z' format on F type in cdecimal)
+            ('z3,.10F', '-6.24E-323', '0.0000000000'),
+
+            # issue 91060 ('#' format in cdecimal)
+            ('#', '0', '0.'),
+
             # issue 6850
             ('a=-7.0', '0.12345', 'aaaa0.1'),
 

--- a/Lib/test/test_decimal.py
+++ b/Lib/test/test_decimal.py
@@ -1110,6 +1110,7 @@ class FormatTest:
             ('z>z6.1f', '-0.', 'zzz0.0'),
             ('x>z6.1f', '-0.', 'xxx0.0'),
             ('🖤>z6.1f', '-0.', '🖤🖤🖤0.0'),  # multi-byte fill char
+            ('\0>z6.1f', '-0.', '\0\0\00.0'),  # null fill char
 
             # issue 114563 ('z' format on F type in cdecimal)
             ('z3,.10F', '-6.24E-323', '0.0000000000'),

--- a/Misc/NEWS.d/next/Library/2024-02-11-20-23-36.gh-issue-114563.RzxNYT.rst
+++ b/Misc/NEWS.d/next/Library/2024-02-11-20-23-36.gh-issue-114563.RzxNYT.rst
@@ -1,4 +1,4 @@
-Fix several `format()` bugs when using the C implementation of `Decimal`:
-* memory leak in some rare cases when using the `z` format option (coerce negative 0)
-* incorrect output when applying the `z` format option to type `F` (fixed-point with capital `NAN` / `INF`)
-* incorrect output when applying the `#` format option (alternate form)
+Fix several :func:`format()` bugs when using the C implementation of :class:`~decimal.Decimal`:
+* memory leak in some rare cases when using the ``z`` format option (coerce negative 0)
+* incorrect output when applying the ``z`` format option to type ``F`` (fixed-point with capital ``NAN`` / ``INF``)
+* incorrect output when applying the ``#`` format option (alternate form)

--- a/Misc/NEWS.d/next/Library/2024-02-11-20-23-36.gh-issue-114563.RzxNYT.rst
+++ b/Misc/NEWS.d/next/Library/2024-02-11-20-23-36.gh-issue-114563.RzxNYT.rst
@@ -1,0 +1,4 @@
+Fix several `format()` bugs when using the C implementation of `Decimal`:
+* memory leak in some rare cases when using the `z` format option (coerce negative 0)
+* incorrect output when applying the `z` format option to type `F` (fixed-point with capital `NAN` / `INF`)
+* incorrect output when applying the `#` format option (alternate form)

--- a/Modules/_decimal/_decimal.c
+++ b/Modules/_decimal/_decimal.c
@@ -3336,56 +3336,6 @@ dotsep_as_utf8(const char *s)
     return utf8;
 }
 
-/* copy of libmpdec _mpd_round() */
-static void
-_mpd_round(mpd_t *result, const mpd_t *a, mpd_ssize_t prec,
-           const mpd_context_t *ctx, uint32_t *status)
-{
-    mpd_ssize_t exp = a->exp + a->digits - prec;
-
-    if (prec <= 0) {
-        mpd_seterror(result, MPD_Invalid_operation, status);
-        return;
-    }
-    if (mpd_isspecial(a) || mpd_iszero(a)) {
-        mpd_qcopy(result, a, status);
-        return;
-    }
-
-    mpd_qrescale_fmt(result, a, exp, ctx, status);
-    if (result->digits > prec) {
-        mpd_qrescale_fmt(result, result, exp+1, ctx, status);
-    }
-}
-
-/* Locate negative zero "z" option within a UTF-8 format spec string.
- * Returns pointer to "z", else NULL.
- * The portion of the spec we're working with is [[fill]align][sign][z] */
-static const char *
-format_spec_z_search(char const *fmt, Py_ssize_t size) {
-    char const *pos = fmt;
-    char const *fmt_end = fmt + size;
-    /* skip over [[fill]align] (fill may be multi-byte character) */
-    pos += 1;
-    while (pos < fmt_end && *pos & 0x80) {
-        pos += 1;
-    }
-    if (pos < fmt_end && strchr("<>=^", *pos) != NULL) {
-        pos += 1;
-    } else {
-        /* fill not present-- skip over [align] */
-        pos = fmt;
-        if (pos < fmt_end && strchr("<>=^", *pos) != NULL) {
-            pos += 1;
-        }
-    }
-    /* skip over [sign] */
-    if (pos < fmt_end && strchr("+- ", *pos) != NULL) {
-        pos += 1;
-    }
-    return pos < fmt_end && *pos == 'z' ? pos : NULL;
-}
-
 static int
 dict_get_item_string(PyObject *dict, const char *key, PyObject **valueobj, const char **valuestr)
 {
@@ -3423,16 +3373,11 @@ dec_format(PyObject *dec, PyObject *args)
     PyObject *fmtarg;
     PyObject *context;
     mpd_spec_t spec;
-    char const *fmt;
-    char *fmt_copy = NULL;
+    char *fmt;
     char *decstring = NULL;
     uint32_t status = 0;
     int replace_fillchar = 0;
-    int no_neg_0 = 0;
     Py_ssize_t size;
-    mpd_t *mpd = MPD(dec);
-    mpd_uint_t dt[MPD_MINALLOC_MAX];
-    mpd_t tmp = {MPD_STATIC|MPD_STATIC_DATA,0,0,0,MPD_MINALLOC_MAX,dt};
 
 
     decimal_state *state = get_module_state_by_def(Py_TYPE(dec));
@@ -3442,7 +3387,7 @@ dec_format(PyObject *dec, PyObject *args)
     }
 
     if (PyUnicode_Check(fmtarg)) {
-        fmt = PyUnicode_AsUTF8AndSize(fmtarg, &size);
+        fmt = (char *)PyUnicode_AsUTF8AndSize(fmtarg, &size);
         if (fmt == NULL) {
             return NULL;
         }
@@ -3454,35 +3399,15 @@ dec_format(PyObject *dec, PyObject *args)
             }
         }
 
-        /* NOTE: If https://github.com/python/cpython/pull/29438 lands, the
-         *   format string manipulation below can be eliminated by enhancing
-         *   the forked mpd_parse_fmt_str(). */
         if (size > 0 && fmt[0] == '\0') {
             /* NUL fill character: must be replaced with a valid UTF-8 char
                before calling mpd_parse_fmt_str(). */
             replace_fillchar = 1;
-            fmt = fmt_copy = dec_strdup(fmt, size);
-            if (fmt_copy == NULL) {
+            fmt = dec_strdup(fmt, size);
+            if (fmt == NULL) {
                 return NULL;
             }
-            fmt_copy[0] = '_';
-        }
-        /* Strip 'z' option, which isn't understood by mpd_parse_fmt_str().
-         * NOTE: fmt is always null terminated by PyUnicode_AsUTF8AndSize() */
-        char const *z_position = format_spec_z_search(fmt, size);
-        if (z_position != NULL) {
-            no_neg_0 = 1;
-            size_t z_index = z_position - fmt;
-            if (fmt_copy == NULL) {
-                fmt = fmt_copy = dec_strdup(fmt, size);
-                if (fmt_copy == NULL) {
-                    return NULL;
-                }
-            }
-            /* Shift characters (including null terminator) left,
-               overwriting the 'z' option. */
-            memmove(fmt_copy + z_index, fmt_copy + z_index + 1, size - z_index);
-            size -= 1;
+            fmt[0] = '_';
         }
     }
     else {
@@ -3548,45 +3473,8 @@ dec_format(PyObject *dec, PyObject *args)
         }
     }
 
-    if (no_neg_0 && mpd_isnegative(mpd) && !mpd_isspecial(mpd)) {
-        /* Round into a temporary (carefully mirroring the rounding
-           of mpd_qformat_spec()), and check if the result is negative zero.
-           If so, clear the sign and format the resulting positive zero. */
-        mpd_ssize_t prec;
-        mpd_qcopy(&tmp, mpd, &status);
-        if (spec.prec >= 0) {
-            switch (spec.type) {
-              case 'f':
-                  mpd_qrescale(&tmp, &tmp, -spec.prec, CTX(context), &status);
-                  break;
-              case '%':
-                  tmp.exp += 2;
-                  mpd_qrescale(&tmp, &tmp, -spec.prec, CTX(context), &status);
-                  break;
-              case 'g':
-                  prec = (spec.prec == 0) ? 1 : spec.prec;
-                  if (tmp.digits > prec) {
-                      _mpd_round(&tmp, &tmp, prec, CTX(context), &status);
-                  }
-                  break;
-              case 'e':
-                  if (!mpd_iszero(&tmp)) {
-                      _mpd_round(&tmp, &tmp, spec.prec+1, CTX(context), &status);
-                  }
-                  break;
-            }
-        }
-        if (status & MPD_Errors) {
-            PyErr_SetString(PyExc_ValueError, "unexpected error when rounding");
-            goto finish;
-        }
-        if (mpd_iszero(&tmp)) {
-            mpd_set_positive(&tmp);
-            mpd = &tmp;
-        }
-    }
 
-    decstring = mpd_qformat_spec(mpd, &spec, CTX(context), &status);
+    decstring = mpd_qformat_spec(MPD(dec), &spec, CTX(context), &status);
     if (decstring == NULL) {
         if (status & MPD_Malloc_error) {
             PyErr_NoMemory();
@@ -3609,7 +3497,7 @@ finish:
     Py_XDECREF(grouping);
     Py_XDECREF(sep);
     Py_XDECREF(dot);
-    if (fmt_copy) PyMem_Free(fmt_copy);
+    if (replace_fillchar) PyMem_Free(fmt);
     if (decstring) mpd_free(decstring);
     return result;
 }

--- a/Modules/_decimal/_decimal.c
+++ b/Modules/_decimal/_decimal.c
@@ -3377,14 +3377,7 @@ pydec_format(PyObject *dec, PyObject *fmt, decimal_state *state)
     PyObject *u;
 
     if (state->PyDecimal == NULL) {
-        PyObject *obj = PyImport_ImportModule("_pydecimal");
-        if (obj == NULL) {
-            return NULL;
-        }
-
-        state->PyDecimal = PyObject_GetAttrString(obj, "Decimal");
-        Py_DECREF(obj);
-
+        state->PyDecimal = _PyImport_GetModuleAttrString("_pydecimal", "Decimal");
         if (state->PyDecimal == NULL) {
             return NULL;
         }
@@ -3395,13 +3388,13 @@ pydec_format(PyObject *dec, PyObject *fmt, decimal_state *state)
         return NULL;
     }
 
-    pydec = PyObject_CallFunctionObjArgs(state->PyDecimal, u, NULL);
+    pydec = PyObject_CallOneArg(state->PyDecimal, u);
     Py_DECREF(u);
     if (pydec == NULL) {
         return NULL;
     }
 
-    result = PyObject_CallMethod(pydec, "__format__", "(O)", fmt);
+    result = PyObject_Format(pydec, fmt);
     Py_DECREF(pydec);
 
     if (result == NULL) {

--- a/Modules/_decimal/_decimal.c
+++ b/Modules/_decimal/_decimal.c
@@ -3374,8 +3374,6 @@ pydec_format(PyObject *dec, PyObject *context, PyObject *fmt, decimal_state *sta
 {
     PyObject *result;
     PyObject *pydec;
-    PyObject *rounding;
-    PyObject *caps;
     PyObject *u;
 
     if (state->PyDecimal == NULL) {
@@ -3396,11 +3394,7 @@ pydec_format(PyObject *dec, PyObject *context, PyObject *fmt, decimal_state *sta
         return NULL;
     }
 
-    rounding = context_getround(context, NULL);
-    caps = context_getcapitals(context, NULL);
-    result = PyObject_CallMethod(pydec, "_fallback_format", "(OOO)", fmt, rounding, caps);
-    Py_DECREF(rounding);
-    Py_DECREF(caps);
+    result = PyObject_CallMethod(pydec, "__format__", "(OO)", fmt, context);
     Py_DECREF(pydec);
 
     if (result == NULL && PyErr_ExceptionMatches(PyExc_ValueError)) {

--- a/Modules/_decimal/_decimal.c
+++ b/Modules/_decimal/_decimal.c
@@ -3397,7 +3397,7 @@ pydec_format(PyObject *dec, PyObject *fmt, decimal_state *state)
     result = PyObject_Format(pydec, fmt);
     Py_DECREF(pydec);
 
-    if (result == NULL) {
+    if (result == NULL && PyErr_ExceptionMatches(PyExc_ValueError)) {
         /* Do not confuse users with the _pydecimal exception */
         PyErr_Clear();
         PyErr_SetString(PyExc_ValueError, "invalid format string");


### PR DESCRIPTION
When the mpdecimal lib fails to parse a format string, we fall back to the pydecimal format implementation.

Notably this allows complex workarounds for 'z' format support to be removed.  (mpdecimal added 'z' support in [version 4.0.0](https://www.bytereef.org/mpdecimal/changelog.html), so this becomes efficient in the long term.)

  * remove 'z' format implementation from C decimal
  * fix 'z' format memory leak
  * fix 'z' format applied to type 'F'
  * fix missing '#' format support

Suggested and prototyped by Stefan Krah.

Fixes gh-114563, gh-91060