### PR TITLE
gh-114887: Perform bitwise comparisons with SOCK_DGRAM and SOCK_STEAM

### DIFF
--- a/Lib/asyncio/base_events.py
+++ b/Lib/asyncio/base_events.py
@@ -107,9 +107,9 @@ def _ipaddr_info(host, port, family, type, proto, flowinfo=0, scopeid=0):
             host is None:
         return None
 
-    if type == socket.SOCK_STREAM:
+    if type & socket.SOCK_STREAM:
         proto = socket.IPPROTO_TCP
-    elif type == socket.SOCK_DGRAM:
+    elif type & socket.SOCK_DGRAM:
         proto = socket.IPPROTO_UDP
     else:
         return None
@@ -1159,7 +1159,7 @@ class BaseEventLoop(events.AbstractEventLoop):
             if sock is None:
                 raise ValueError(
                     'host and port was not specified and no sock specified')
-            if sock.type != socket.SOCK_STREAM:
+            if not sock.type & socket.SOCK_STREAM:
                 # We allow AF_INET, AF_INET6, AF_UNIX as long as they
                 # are SOCK_STREAM.
                 # We support passing AF_UNIX sockets even though we have
@@ -1340,7 +1340,7 @@ class BaseEventLoop(events.AbstractEventLoop):
                                        allow_broadcast=None, sock=None):
         """Create datagram connection."""
         if sock is not None:
-            if sock.type != socket.SOCK_DGRAM:
+            if not sock.type & socket.SOCK_DGRAM:
                 raise ValueError(
                     f'A UDP Socket was expected, got {sock!r}')
             if (local_addr or remote_addr or
@@ -1610,7 +1610,7 @@ class BaseEventLoop(events.AbstractEventLoop):
         else:
             if sock is None:
                 raise ValueError('Neither host/port nor sock were specified')
-            if sock.type != socket.SOCK_STREAM:
+            if not sock.type & socket.SOCK_STREAM:
                 raise ValueError(f'A Stream Socket was expected, got {sock!r}')
             sockets = [sock]
 
@@ -1635,7 +1635,7 @@ class BaseEventLoop(events.AbstractEventLoop):
             *, ssl=None,
             ssl_handshake_timeout=None,
             ssl_shutdown_timeout=None):
-        if sock.type != socket.SOCK_STREAM:
+        if not sock.type & socket.SOCK_STREAM:
             raise ValueError(f'A Stream Socket was expected, got {sock!r}')
 
         if ssl_handshake_timeout is not None and not ssl:

--- a/Lib/asyncio/unix_events.py
+++ b/Lib/asyncio/unix_events.py
@@ -269,7 +269,7 @@ class _UnixSelectorEventLoop(selector_events.BaseSelectorEventLoop):
             if sock is None:
                 raise ValueError('no path and sock were specified')
             if (sock.family != socket.AF_UNIX or
-                    sock.type != socket.SOCK_STREAM):
+                    not sock.type & socket.SOCK_STREAM):
                 raise ValueError(
                     f'A UNIX Domain Stream Socket was expected, got {sock!r}')
             sock.setblocking(False)
@@ -337,7 +337,7 @@ class _UnixSelectorEventLoop(selector_events.BaseSelectorEventLoop):
                     'path was not specified, and no sock specified')
 
             if (sock.family != socket.AF_UNIX or
-                    sock.type != socket.SOCK_STREAM):
+                    not sock.type & socket.SOCK_STREAM):
                 raise ValueError(
                     f'A UNIX Domain Stream Socket was expected, got {sock!r}')
 


### PR DESCRIPTION
Details in #114887 

This change is technically incorrect as SOCK_STREAM and SOCK_DGRAM are not actually bitwise comparators.

<!-- gh-issue-number: gh-114887 -->
* Issue: gh-114887
<!-- /gh-issue-number -->
