### PR TITLE
gh-114803: Mention that `@dataclass` should not be applied on enums

### DIFF
--- a/Doc/howto/enum.rst
+++ b/Doc/howto/enum.rst
@@ -506,7 +506,7 @@ to use the standard :func:`repr`.
 
 .. note::
 
-   Adding :func:`~dataclasses.dataclass` decorator to :type:`Enum`
+   Adding :func:`~dataclasses.dataclass` decorator to :class:`Enum`
    and its subclasses is not supported. It will not raise any errors,
    but it will produce very strange results at runtime::
 

--- a/Doc/howto/enum.rst
+++ b/Doc/howto/enum.rst
@@ -508,7 +508,8 @@ to use the standard :func:`repr`.
 
    Adding :func:`~dataclasses.dataclass` decorator to :class:`Enum`
    and its subclasses is not supported. It will not raise any errors,
-   but it will produce very strange results at runtime::
+   but it will produce very strange results at runtime, such as members
+   being equal to each other::
 
       @dataclass  # don't do this: it does not make any sense
       class Colors(Enum):

--- a/Doc/howto/enum.rst
+++ b/Doc/howto/enum.rst
@@ -510,9 +510,15 @@ to use the standard :func:`repr`.
    and its subclasses is not supported. It will not raise any errors,
    but it will produce very strange results at runtime::
 
-      @dataclass  # don't do this: it does not make any sense
-      class Colors(Enum):
-         red = 'red'
+      >>> @dataclass               # don't do this: it does not make any sense
+      ... class Color(Enum):
+      ...    RED = 1
+      ...    BLUE = 2
+      ...
+      >>> Color.RED is Color.BLUE
+      False
+      >>> Color.RED == Color.BLUE  # problem is here: they should not be equal
+      True
 
 
 Pickling

--- a/Doc/howto/enum.rst
+++ b/Doc/howto/enum.rst
@@ -497,12 +497,22 @@ the :meth:`~Enum.__repr__` omits the inherited class' name.  For example::
     >>> Creature.DOG
     <Creature.DOG: size='medium', legs=4>
 
-Use the :func:`!dataclass` argument ``repr=False``
+Use the :func:`~dataclasses.dataclass` argument ``repr=False``
 to use the standard :func:`repr`.
 
 .. versionchanged:: 3.12
    Only the dataclass fields are shown in the value area, not the dataclass'
    name.
+
+.. note::
+
+   Adding :func:`~dataclasses.dataclass` decorator to :type:`Enum`
+   and its subclasses is not supported. It will not raise any errors,
+   but it will produce very strange results at runtime::
+
+      @dataclass  # don't do this: it does not make any sense
+      class Colors(Enum):
+         red = 'red'
 
 
 Pickling


### PR DESCRIPTION
I am not sure about the code sample though: do we need this incorrect example? Or should I remove it?

<!-- gh-issue-number: gh-114803 -->
* Issue: gh-114803
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--114891.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->