### PR TITLE
GH-113655 Lower C recursion limit from 4000 to 3000 on Windows.

### DIFF
--- a/Include/cpython/pystate.h
+++ b/Include/cpython/pystate.h
@@ -229,7 +229,7 @@ struct _ts {
 #elif defined(__s390x__)
 #  define Py_C_RECURSION_LIMIT 800
 #elif defined(_WIN32)
-#  define Py_C_RECURSION_LIMIT 4000
+#  define Py_C_RECURSION_LIMIT 3000
 #elif defined(_Py_ADDRESS_SANITIZER)
 #  define Py_C_RECURSION_LIMIT 4000
 #else


### PR DESCRIPTION
As well as https://github.com/python/cpython/issues/113655, I'm also seeing stack overflows with the JIT: https://github.com/python/cpython/pull/114592

<!-- gh-issue-number: gh-113655 -->
* Issue: gh-113655
<!-- /gh-issue-number -->
