### PR TITLE
gh-114909: Add --first-weekday option to usage message

### DIFF
--- a/Doc/library/calendar.rst
+++ b/Doc/library/calendar.rst
@@ -512,7 +512,7 @@ to interactively print a calendar.
 
    python -m calendar [-h] [-L LOCALE] [-e ENCODING] [-t {text,html}]
                       [-w WIDTH] [-l LINES] [-s SPACING] [-m MONTHS] [-c CSS]
-                      [year] [month]
+                      [-f FIRST_WEEKDAY] [year] [month]
 
 
 For example, to print a calendar for the year 2000:
@@ -586,12 +586,13 @@ The following options are accepted:
    or as an HTML document.
 
 
-.. option:: --first-weekday WEEKDAY, -f WEEKDAY
+.. option:: --first-weekday FIRST_WEEKDAY, -f FIRST_WEEKDAY
 
    The weekday to start each week.
    Must be a number between 0 (Monday) and 6 (Sunday).
    Defaults to 0.
 
+   .. versionadded:: 3.13
 
 .. option:: year
 


### PR DESCRIPTION
Use `FIRST_WEEKDAY` rather than `WEEKDAY` to be in agreement with the command line help message.

Note which Python version the option was added to.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-114909 -->
* Issue: gh-114909
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--114910.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->