### PR TITLE
gh-114920: Make iterable and subscriptable the `Namespace` object in `argparse` lib

### DIFF
--- a/Lib/argparse.py
+++ b/Lib/argparse.py
@@ -1333,6 +1333,7 @@ class FileType(object):
 # Optional and Positional Parsing
 # ===========================
 
+
 class Namespace(_AttributeHolder):
     """Simple object for storing attributes.
 
@@ -1351,6 +1352,13 @@ class Namespace(_AttributeHolder):
 
     def __contains__(self, key):
         return key in self.__dict__
+
+    def __iter__(self):
+        for key, value in self.__dict__.items():
+            yield {key: value}
+
+    def __getitem__(self, item):
+        return getattr(self, item)
 
 
 class _ActionsContainer(object):

--- a/Lib/argparse.py
+++ b/Lib/argparse.py
@@ -1355,7 +1355,7 @@ class Namespace(_AttributeHolder):
 
     def __iter__(self):
         for key, value in self.__dict__.items():
-            yield {key: value}
+            yield key, value
 
     def __getitem__(self, item):
         return getattr(self, item)

--- a/Lib/argparse.py
+++ b/Lib/argparse.py
@@ -1354,8 +1354,7 @@ class Namespace(_AttributeHolder):
         return key in self.__dict__
 
     def __iter__(self):
-        for key, value in self.__dict__.items():
-            yield key, value
+        yield from self.__dict__.items()
 
     def __getitem__(self, item):
         return getattr(self, item)

--- a/Lib/test/test_argparse.py
+++ b/Lib/test/test_argparse.py
@@ -5763,6 +5763,30 @@ class TestExitOnError(TestCase):
             self.parser.parse_args('--integers a'.split())
 
 
+class TestIterationOnNS(TestCase):
+
+    def setUp(self):
+        self.parser = argparse.ArgumentParser()
+        self.parser.add_argument('--test_1', action="store_true")
+        self.parser.add_argument('--test_2', type=str, default="a")
+        self.parser.add_argument('--test_3', type=int, default=0)
+        self.local_ns = self.parser.parse_args()
+
+    def test_iteration_ns(self):
+        for arg in self.local_ns:
+            self.assertIn(arg, ['test_1', 'test_2', 'test_3'])
+
+
+class TestSubscriptableNS(TestCase):
+    def setUp(self):
+        self.parser = argparse.ArgumentParser()
+        self.parser.add_argument('--test_1', type=str, default="a")
+        self.local_ns = self.parser.parse_args()
+
+    def test_iteration_ns(self):
+        self.assertEqual(self.local_ns["test_1"], "a")
+
+
 def tearDownModule():
     # Remove global references to avoid looking like we have refleaks.
     RFile.seen = {}

--- a/Lib/test/test_argparse.py
+++ b/Lib/test/test_argparse.py
@@ -5770,21 +5770,21 @@ class TestIterationOnNS(TestCase):
         self.parser.add_argument('--test_1', action="store_true")
         self.parser.add_argument('--test_2', type=str, default="a")
         self.parser.add_argument('--test_3', type=int, default=0)
-        self.local_ns = self.parser.parse_args()
+        self.local_ns = self.parser.parse_args('--test_1 --test_2 b --test_3 1'.split())
 
     def test_iteration_ns(self):
         for arg in self.local_ns:
-            self.assertIn(arg, ['test_1', 'test_2', 'test_3'])
+            self.assertIn(arg, [{'test_1': True}, {'test_2': 'b'}, {'test_3': 1}])
 
 
 class TestSubscriptableNS(TestCase):
     def setUp(self):
         self.parser = argparse.ArgumentParser()
-        self.parser.add_argument('--test_1', type=str, default="a")
-        self.local_ns = self.parser.parse_args()
+        self.parser.add_argument('--test', type=str, default="a")
+        self.local_ns = self.parser.parse_args('--test b'.split())
 
-    def test_iteration_ns(self):
-        self.assertEqual(self.local_ns["test_1"], "a")
+    def test_subscriptable_ns(self):
+        self.assertEqual(self.local_ns["test"], "b")
 
 
 def tearDownModule():

--- a/Lib/test/test_argparse.py
+++ b/Lib/test/test_argparse.py
@@ -5770,11 +5770,18 @@ class TestIterationOnNS(TestCase):
         self.parser.add_argument('--test_1', action="store_true")
         self.parser.add_argument('--test_2', type=str, default="a")
         self.parser.add_argument('--test_3', type=int, default=0)
-        self.local_ns = self.parser.parse_args('--test_1 --test_2 b --test_3 1'.split())
 
     def test_iteration_ns(self):
-        for arg in self.local_ns:
+        local_ns = self.parser.parse_args('--test_1 --test_2 b --test_3 1'.split())
+        for arg in local_ns:
             self.assertIn(arg, [{'test_1': True}, {'test_2': 'b'}, {'test_3': 1}])
+
+    def test_known_args_iteration_ns(self):
+        local_ns = self.parser.parse_known_args('--test_2 b --test_3 1 --test_4'.split())
+        # The parse_known_args returns tuple where the Namespace object is placed first
+        # then the unknown args in a list.
+        for arg in local_ns[0]:
+            self.assertIn(arg, [{'test_1': False}, {'test_2': 'b'}, {'test_3': 1}])
 
 
 class TestSubscriptableNS(TestCase):

--- a/Lib/test/test_argparse.py
+++ b/Lib/test/test_argparse.py
@@ -5773,15 +5773,17 @@ class TestIterationOnNS(TestCase):
 
     def test_iteration_ns(self):
         local_ns = self.parser.parse_args('--test_1 --test_2 b --test_3 1'.split())
-        for arg in local_ns:
-            self.assertIn(arg, [{'test_1': True}, {'test_2': 'b'}, {'test_3': 1}])
+        for key, value in local_ns:
+            self.assertIn(key, ["test_1", "test_2", "test_3"])
+            self.assertIn(value, [True, "b", 1])
 
     def test_known_args_iteration_ns(self):
         local_ns = self.parser.parse_known_args('--test_2 b --test_3 1 --test_4'.split())
         # The parse_known_args returns tuple where the Namespace object is placed first
         # then the unknown args in a list.
-        for arg in local_ns[0]:
-            self.assertIn(arg, [{'test_1': False}, {'test_2': 'b'}, {'test_3': 1}])
+        for key, value in local_ns[0]:
+            self.assertIn(key, ['test_1', 'test_2', 'test_3'])
+            self.assertIn(value, [False, 'b', 1])
 
 
 class TestSubscriptableNS(TestCase):

--- a/Misc/NEWS.d/next/Library/2024-02-02-17-38-05.gh-issue-114920.n5x4mN.rst
+++ b/Misc/NEWS.d/next/Library/2024-02-02-17-38-05.gh-issue-114920.n5x4mN.rst
@@ -1,0 +1,1 @@
+Make iterable the Namespace object in argparse lib


### PR DESCRIPTION
With this change the `Namespace` will be iterable and subscriptable. 

Issue reference: https://github.com/python/cpython/issues/114920

**For example:**

```python
import argparse

parser: argparse.ArgumentParser = argparse.ArgumentParser(description=__doc__)

parser.add_argument(
    "--test_1",
    action="store_true",
)

parser.add_argument(
    "--test_2",
    type=str,
)

parser.add_argument(
    "--test_3",
    type=int,
    default=0
)

args = parser.parse_args()
for x in args:
    print(x)
```

**Test:**

```
>>> python3 test_2.py
{'test_1': False}
{'test_2': None}
{'test_3': 0}

>>> python3 test_2.py --test_3 5 --test_1
{'test_1': True}
{'test_2': None}
{'test_3': 5}
```

Without my change the same behavior can be done only with tricky and ugly solutions, like:

```python
args = parser.parse_args()

for x in vars(args):
    print({x: getattr(args, x)})
```

Furthermore, with the `__getitem__` method implementation, the `Namespace` object is subscriptable, so it's possible to get the value directly from the object, like:

```
args = parser.parse_args()

print(args["test_1"])
```

<!-- gh-issue-number: gh-114920 -->
* Issue: gh-114920
<!-- /gh-issue-number -->
