### PR TITLE
gh-112075: Add gc shared bits

### DIFF
--- a/Include/internal/pycore_gc.h
+++ b/Include/internal/pycore_gc.h
@@ -71,13 +71,16 @@ static inline int _PyObject_GC_MAY_BE_TRACKED(PyObject *obj) {
 
 #ifdef Py_GIL_DISABLED
 
+/* True if an object is shared between multiple threads and
+ * needs special purpose when freeing to do the possibility
+ * of in-flight lock-free reads occuring */
 static inline int _PyObject_GC_IS_SHARED(PyObject *op) {
     return (op->ob_gc_bits & _PyGC_BITS_SHARED) != 0;
 }
 #define _PyObject_GC_IS_SHARED(op) _PyObject_GC_IS_SHARED(_Py_CAST(PyObject*, op))
 
-static inline int _PyObject_GC_SET_SHARED(PyObject *op) {
-    return op->ob_gc_bits |= _PyGC_BITS_SHARED;
+static inline void _PyObject_GC_SET_SHARED(PyObject *op) {
+    op->ob_gc_bits |= _PyGC_BITS_SHARED;
 }
 #define _PyObject_GC_SET_SHARED(op) _PyObject_GC_SET_SHARED(_Py_CAST(PyObject*, op))
 

--- a/Include/internal/pycore_gc.h
+++ b/Include/internal/pycore_gc.h
@@ -43,6 +43,7 @@ static inline PyObject* _Py_FROM_GC(PyGC_Head *gc) {
 #  define _PyGC_BITS_FINALIZED      (2)
 #  define _PyGC_BITS_UNREACHABLE    (4)
 #  define _PyGC_BITS_FROZEN         (8)
+#  define _PyGC_BITS_SHARED         (16)
 #endif
 
 /* True if the object is currently tracked by the GC. */
@@ -68,6 +69,19 @@ static inline int _PyObject_GC_MAY_BE_TRACKED(PyObject *obj) {
     return 1;
 }
 
+#ifdef Py_GIL_DISABLED
+
+static inline int _PyObject_GC_IS_SHARED(PyObject *op) {
+    return (op->ob_gc_bits & _PyGC_BITS_SHARED) != 0;
+}
+#define _PyObject_GC_IS_SHARED(op) _PyObject_GC_IS_SHARED(_Py_CAST(PyObject*, op))
+
+static inline int _PyObject_GC_SET_SHARED(PyObject *op) {
+    return op->ob_gc_bits |= _PyGC_BITS_SHARED;
+}
+#define _PyObject_GC_SET_SHARED(op) _PyObject_GC_SET_SHARED(_Py_CAST(PyObject*, op))
+
+#endif
 
 /* Bit flags for _gc_prev */
 /* Bit 0 is set when tp_finalize is called */


### PR DESCRIPTION
This adds the GC shared flags for objects to the gc bit states in free-threaded builds.  This will allow marking objects as being shared so that we can use QSBR to free them, enabling lock-free readers for dict (and other) objects.

<!-- gh-issue-number: gh-112075 -->
* Issue: gh-112075
<!-- /gh-issue-number -->
