### PR TITLE
Bump ruff to 0.2.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.1.7
+    rev: v0.2.0
     hooks:
       - id: ruff
         name: Run Ruff on Lib/test/

--- a/Lib/test/.ruff.toml
+++ b/Lib/test/.ruff.toml
@@ -1,7 +1,4 @@
 fix = true
-select = [
-    "F811",  # Redefinition of unused variable (useful for finding test methods with the same name)
-]
 extend-exclude = [
     # Excluded (run with the other AC files in its own separate ruff job in pre-commit)
     "test_clinic.py",
@@ -20,4 +17,9 @@ extend-exclude = [
     "test_import/__init__.py",
     "test_pkg.py",
     "test_yield_from.py",
+]
+
+[lint]
+select = [
+    "F811",  # Redefinition of unused variable (useful for finding test methods with the same name)
 ]

--- a/Tools/clinic/.ruff.toml
+++ b/Tools/clinic/.ruff.toml
@@ -1,5 +1,7 @@
 target-version = "py310"
 fix = true
+
+[lint]
 select = [
     "F",  # Enable all pyflakes rules
     "UP",  # Enable all pyupgrade rules by default


### PR DESCRIPTION
Fix these DeprecationWarnings if you run `ruff` directly on `Lib/test` or `Tools/clinic` (which unfortunately you don't see if you run it via pre-commit, since pre-commit swallows all output from the underlying hook unless the hook returns a non-zero exit code):

```
warning: The top-level linter settings are deprecated in favour of their counterparts in the `lint` section. Please update the following options in `Lib\test\.ruff.toml`:
  - 'select' -> 'lint.select'
```

```
warning: The top-level linter settings are deprecated in favour of their counterparts in the `lint` section. Please update the following options in `Tools\clinic\.ruff.toml`:
  - 'ignore' -> 'lint.ignore'
  - 'select' -> 'lint.select'
  - 'unfixable' -> 'lint.unfixable'
``` 