### PR TITLE
Fix indentation of "versionchanged" in datetime.rst

### DIFF
--- a/Doc/library/datetime.rst
+++ b/Doc/library/datetime.rst
@@ -1214,9 +1214,9 @@ Supported operations:
    attributes, the comparison acts as comparands were first converted to UTC
    datetimes except that the implementation never overflows.
 
-   .. versionchanged:: 3.3
-      Equality comparisons between aware and naive :class:`.datetime`
-      instances don't raise :exc:`TypeError`.
+.. versionchanged:: 3.3
+   Equality comparisons between aware and naive :class:`.datetime`
+   instances don't raise :exc:`TypeError`.
 
 Instance methods:
 


### PR DESCRIPTION
Follow up of #114749.

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--114933.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->