### PR TITLE
gh-114944: Fix race between `_PyParkingLot_Park` and `_PyParkingLot_UnparkAll` when handling interrupts

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2024-02-03-01-48-38.gh-issue-114944.4J5ELD.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2024-02-03-01-48-38.gh-issue-114944.4J5ELD.rst
@@ -1,0 +1,1 @@
+Fixes a race between ``PyParkingLot_Park`` and ``_PyParkingLot_UnparkAll``.

--- a/Python/parking_lot.c
+++ b/Python/parking_lot.c
@@ -356,7 +356,6 @@ _PyParkingLot_Unpark(const void *addr, _Py_unpark_fn_t *fn, void *arg)
 void
 _PyParkingLot_UnparkAll(const void *addr)
 {
-    struct llist_node *node;
     struct llist_node head = LLIST_INIT(head);
     Bucket *bucket = &buckets[((uintptr_t)addr) % NUM_BUCKETS];
 
@@ -364,6 +363,7 @@ _PyParkingLot_UnparkAll(const void *addr)
     dequeue_all(bucket, addr, &head);
     _PyRawMutex_Unlock(&bucket->mutex);
 
+    struct llist_node *node;
     llist_for_each_safe(node, &head) {
         struct wait_entry *waiter = llist_data(node, struct wait_entry, node);
         llist_remove(node);

--- a/Python/parking_lot.c
+++ b/Python/parking_lot.c
@@ -244,6 +244,7 @@ dequeue(Bucket *bucket, const void *address)
         if (wait->addr == (uintptr_t)address) {
             llist_remove(node);
             --bucket->num_waiters;
+            wait->is_unparking = true;
             return wait;
         }
     }
@@ -262,6 +263,7 @@ dequeue_all(Bucket *bucket, const void *address, struct llist_node *dst)
             llist_remove(node);
             llist_insert_tail(dst, node);
             --bucket->num_waiters;
+            wait->is_unparking = true;
         }
     }
 }
@@ -337,8 +339,6 @@ _PyParkingLot_Unpark(const void *addr, _Py_unpark_fn_t *fn, void *arg)
     _PyRawMutex_Lock(&bucket->mutex);
     struct wait_entry *waiter = dequeue(bucket, addr);
     if (waiter) {
-        waiter->is_unparking = true;
-
         int has_more_waiters = (bucket->num_waiters > 0);
         fn(arg, waiter->park_arg, has_more_waiters);
     }
@@ -362,10 +362,6 @@ _PyParkingLot_UnparkAll(const void *addr)
 
     _PyRawMutex_Lock(&bucket->mutex);
     dequeue_all(bucket, addr, &head);
-    llist_for_each(node, &head) {
-        struct wait_entry *waiter = llist_data(node, struct wait_entry, node);
-        waiter->is_unparking = true;
-    }
     _PyRawMutex_Unlock(&bucket->mutex);
 
     llist_for_each_safe(node, &head) {

--- a/Python/parking_lot.c
+++ b/Python/parking_lot.c
@@ -356,14 +356,18 @@ _PyParkingLot_Unpark(const void *addr, _Py_unpark_fn_t *fn, void *arg)
 void
 _PyParkingLot_UnparkAll(const void *addr)
 {
+    struct llist_node *node;
     struct llist_node head = LLIST_INIT(head);
     Bucket *bucket = &buckets[((uintptr_t)addr) % NUM_BUCKETS];
 
     _PyRawMutex_Lock(&bucket->mutex);
     dequeue_all(bucket, addr, &head);
+    llist_for_each(node, &head) {
+        struct wait_entry *waiter = llist_data(node, struct wait_entry, node);
+        waiter->is_unparking = true;
+    }
     _PyRawMutex_Unlock(&bucket->mutex);
 
-    struct llist_node *node;
     llist_for_each_safe(node, &head) {
         struct wait_entry *waiter = llist_data(node, struct wait_entry, node);
         llist_remove(node);


### PR DESCRIPTION
There is a potential race when `_PyParkingLot_UnparkAll` is executing in one thread and another thread is unblocked because of an interrupt in `_PyParkingLot_Park`. Consider the following scenario:

1. Thread T0 is blocked[^1] in `_PyParkingLot_Park` on address `A`.
2. Thread T1 executes `_PyParkingLot_UnparkAll` on address `A`. It finds the `wait_entry` for `T0` and unlinks[^2] its list node.
3. Immediately after (2), T0 is woken up due to an interrupt. It then segfaults trying to unlink[^3] the node that was previously unlinked in (2).

To fix this we mark each waiter as unparking before releasing the bucket lock. `_PyParkingLot_Park` will wait to handle the coming wakeup, and not attempt to unlink the node, when this field is set. `_PyParkingLot_Unpark` does this already, presumably to handle this case.

[^1]: https://github.com/python/cpython/blob/f35c7c070ca6b49c5d6a97be34e6c02f828f5873/Python/parking_lot.c#L303
[^2]: https://github.com/python/cpython/blob/f35c7c070ca6b49c5d6a97be34e6c02f828f5873/Python/parking_lot.c#L369
[^3]: https://github.com/python/cpython/blob/f35c7c070ca6b49c5d6a97be34e6c02f828f5873/Python/parking_lot.c#L320

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-114944 -->
* Issue: gh-114944
<!-- /gh-issue-number -->
