### PR TITLE
gh-74028: Introduce a prefetch parameter to Executor.map to handle large iterators

### DIFF
--- a/Doc/library/concurrent.futures.rst
+++ b/Doc/library/concurrent.futures.rst
@@ -39,7 +39,7 @@ Executor Objects
              future = executor.submit(pow, 323, 1235)
              print(future.result())
 
-   .. method:: map(fn, *iterables, timeout=None, chunksize=1)
+   .. method:: map(fn, *iterables, timeout=None, chunksize=1, prefetch=None)
 
       Similar to :func:`map(fn, *iterables) <map>` except:
 
@@ -65,8 +65,15 @@ Executor Objects
       performance compared to the default size of 1.  With
       :class:`ThreadPoolExecutor`, *chunksize* has no effect.
 
+      By default, all tasks are queued.  An explicit *prefetch* count may be
+      provided to specify how many extra tasks, beyond the number of workers,
+      should be queued.
+
       .. versionchanged:: 3.5
          Added the *chunksize* argument.
+
+      .. versionchanged:: 3.13
+         Added the *prefetch* argument.
 
    .. method:: shutdown(wait=True, *, cancel_futures=False)
 

--- a/Lib/concurrent/futures/process.py
+++ b/Lib/concurrent/futures/process.py
@@ -656,19 +656,17 @@ class ProcessPoolExecutor(_base.Executor):
         _check_system_limits()
 
         if max_workers is None:
-            self._max_workers = os.process_cpu_count() or 1
+            max_workers = os.process_cpu_count() or 1
             if sys.platform == 'win32':
-                self._max_workers = min(_MAX_WINDOWS_WORKERS,
-                                        self._max_workers)
+                max_workers = min(_MAX_WINDOWS_WORKERS, max_workers)
         else:
             if max_workers <= 0:
                 raise ValueError("max_workers must be greater than 0")
             elif (sys.platform == 'win32' and
-                max_workers > _MAX_WINDOWS_WORKERS):
+                  max_workers > _MAX_WINDOWS_WORKERS):
                 raise ValueError(
                     f"max_workers must be <= {_MAX_WINDOWS_WORKERS}")
-
-            self._max_workers = max_workers
+        super().__init__(max_workers)
 
         if mp_context is None:
             if max_tasks_per_child is not None:
@@ -812,7 +810,7 @@ class ProcessPoolExecutor(_base.Executor):
             return f
     submit.__doc__ = _base.Executor.submit.__doc__
 
-    def map(self, fn, *iterables, timeout=None, chunksize=1):
+    def map(self, fn, *iterables, timeout=None, chunksize=1, prefetch=None):
         """Returns an iterator equivalent to map(fn, iter).
 
         Args:
@@ -823,6 +821,8 @@ class ProcessPoolExecutor(_base.Executor):
             chunksize: If greater than one, the iterables will be chopped into
                 chunks of size chunksize and submitted to the process pool.
                 If set to one, the items in the list will be sent one at a time.
+            prefetch: The number of chunks to queue beyond the number of
+                workers on the executor. If None, all chunks are queued.
 
         Returns:
             An iterator equivalent to: map(func, *iterables) but the calls may
@@ -838,7 +838,7 @@ class ProcessPoolExecutor(_base.Executor):
 
         results = super().map(partial(_process_chunk, fn),
                               itertools.batched(zip(*iterables), chunksize),
-                              timeout=timeout)
+                              timeout=timeout, prefetch=prefetch)
         return _chain_from_iterable_of_lists(results)
 
     def shutdown(self, wait=True, *, cancel_futures=False):

--- a/Lib/concurrent/futures/thread.py
+++ b/Lib/concurrent/futures/thread.py
@@ -149,7 +149,7 @@ class ThreadPoolExecutor(_base.Executor):
         if initializer is not None and not callable(initializer):
             raise TypeError("initializer must be a callable")
 
-        self._max_workers = max_workers
+        super().__init__(max_workers)
         self._work_queue = queue.SimpleQueue()
         self._idle_semaphore = threading.Semaphore(0)
         self._threads = set()

--- a/Lib/test/test_concurrent_futures/test_thread_pool.py
+++ b/Lib/test/test_concurrent_futures/test_thread_pool.py
@@ -23,6 +23,19 @@ class ThreadPoolExecutorTest(ThreadPoolMixin, ExecutorTest, BaseTestCase):
         self.executor.shutdown(wait=True)
         self.assertCountEqual(finished, range(10))
 
+    def test_map_on_infinite_iterator(self):
+        import itertools
+        def identity(x):
+            return x
+
+        mapobj = self.executor.map(identity, itertools.count(0), prefetch=1)
+        # Get one result, which shows we handle infinite inputs
+        # without waiting for all work to be dispatched
+        res = next(mapobj)
+        mapobj.close()  # Make sure futures cancelled
+
+        self.assertEqual(res, 0)
+
     def test_default_workers(self):
         executor = self.executor_type()
         expected = min(32, (os.process_cpu_count() or 1) + 4)

--- a/Misc/NEWS.d/next/Library/2024-02-04-11-26-12.gh-issue-114948.4gMiWx.rst
+++ b/Misc/NEWS.d/next/Library/2024-02-04-11-26-12.gh-issue-114948.4gMiWx.rst
@@ -1,0 +1,1 @@
+Introduce a ``prefetch`` parameter to ``Executor.map``, so that large and even unbounded iterators can be handled.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

Introduce a `prefetch` parameter to `Executor.map`, so that large and even unbounded iterators can be handled. 
This is a continuation of https://github.com/python/cpython/pull/18566, with backward compatibility, which is to say when the new `prefetch` parameter is not specified, we default to the current behaviour.
cc @graingert @rdarder @kumaraditya303 @brianquinlan 

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--114975.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->

<!-- gh-issue-number: gh-114948 -->
* Issue: gh-114948
<!-- /gh-issue-number -->


<!-- gh-issue-number: gh-74028 -->
* Issue: gh-74028
<!-- /gh-issue-number -->
