### PR TITLE
gh-114887 Reject only sockets of type SOCK_STREAM in create_datagram_endpoint(), improve exception message.

### DIFF
--- a/Lib/asyncio/base_events.py
+++ b/Lib/asyncio/base_events.py
@@ -1281,9 +1281,9 @@ class BaseEventLoop(events.AbstractEventLoop):
                                        allow_broadcast=None, sock=None):
         """Create datagram connection."""
         if sock is not None:
-            if sock.type != socket.SOCK_DGRAM:
+            if sock.type == socket.SOCK_STREAM:
                 raise ValueError(
-                    f'A UDP Socket was expected, got {sock!r}')
+                    f'A datagram socket was expected, got {sock!r}')
             if (local_addr or remote_addr or
                     family or proto or flags or
                     reuse_port or allow_broadcast):

--- a/Lib/test/test_asyncio/test_base_events.py
+++ b/Lib/test/test_asyncio/test_base_events.py
@@ -1191,7 +1191,7 @@ class BaseEventLoopWithSelectorTests(test_utils.TestCase):
         with sock:
             coro = self.loop.create_datagram_endpoint(MyProto, sock=sock)
             with self.assertRaisesRegex(ValueError,
-                                        'A UDP Socket was expected'):
+                                        'A datagram socket was expected'):
                 self.loop.run_until_complete(coro)
 
     def test_create_connection_no_host_port_sock(self):

--- a/Misc/NEWS.d/next/Core and Builtins/2024-02-03-04-07-18.gh-issue-114887.uLSFmN.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2024-02-03-04-07-18.gh-issue-114887.uLSFmN.rst
@@ -1,0 +1,2 @@
+Changed socket type validation in :meth:`~asyncio.loop.create_datagram_endpoint` to accept all non-stream sockets.
+This fixes a regression in compatibility with raw sockets.


### PR DESCRIPTION
Backporting fix for #114887 to 3.11

<!-- gh-issue-number: gh-114887 -->
* Issue: gh-114887
<!-- /gh-issue-number -->
