### PR TITLE
gh-101100: Fix `load_module` ref

### DIFF
--- a/Doc/glossary.rst
+++ b/Doc/glossary.rst
@@ -754,7 +754,7 @@ Glossary
 
    loader
       An object that loads a module. It must define a method named
-      :meth:`load_module`. A loader is typically returned by a
+      :meth:`!load_module`. A loader is typically returned by a
       :term:`finder`. See :pep:`302` for details and
       :class:`importlib.abc.Loader` for an :term:`abstract base class`.
 

--- a/Doc/glossary.rst
+++ b/Doc/glossary.rst
@@ -754,7 +754,7 @@ Glossary
 
    loader
       An object that loads a module. It must define a method named
-      :meth:`!load_module`. A loader is typically returned by a
+      :meth:`~importlib.abc.Loader.load_module`. A loader is typically returned by a
       :term:`finder`. See :pep:`302` for details and
       :class:`importlib.abc.Loader` for an :term:`abstract base class`.
 


### PR DESCRIPTION
Text describes a user-provided method, perhaps only described in detail in `PEP 302`.


<!-- gh-issue-number: gh-101100 -->
* Issue: gh-101100
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--114982.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->