### PR TITLE
gh-101100: Fix dangling refs in bdb.rst

### DIFF
--- a/Doc/library/bdb.rst
+++ b/Doc/library/bdb.rst
@@ -148,7 +148,7 @@ The :mod:`bdb` module also defines two classes:
 
    .. method:: reset()
 
-      Set the :attr:`botframe`, :attr:`!stopframe`, :attr:`!returnframe` and
+      Set the :attr:`!botframe`, :attr:`!stopframe`, :attr:`!returnframe` and
       :attr:`quitting <Bdb.set_quit>` attributes with values ready to start debugging.
 
    .. method:: trace_dispatch(frame, event, arg)
@@ -292,6 +292,8 @@ The :mod:`bdb` module also defines two classes:
       set the system trace function to ``None``.
 
    .. method:: set_quit()
+
+      .. index:: single: quitting (bdb.Bdb attribute)
 
       Set the :attr:`!quitting` attribute to ``True``.  This raises :exc:`BdbQuit` in
       the next call to one of the :meth:`!dispatch_\*` methods.

--- a/Doc/library/bdb.rst
+++ b/Doc/library/bdb.rst
@@ -148,8 +148,8 @@ The :mod:`bdb` module also defines two classes:
 
    .. method:: reset()
 
-      Set the :attr:`botframe`, :attr:`stopframe`, :attr:`returnframe` and
-      :attr:`quitting` attributes with values ready to start debugging.
+      `Set the :attr:`botframe`, :attr:`!stopframe`, :attr:`!returnframe` and
+      :attr:`quitting <Bdb.set_quit>` attributes with values ready to start debugging.
 
    .. method:: trace_dispatch(frame, event, arg)
 
@@ -182,7 +182,7 @@ The :mod:`bdb` module also defines two classes:
 
       If the debugger should stop on the current line, invoke the
       :meth:`user_line` method (which should be overridden in subclasses).
-      Raise a :exc:`BdbQuit` exception if the :attr:`Bdb.quitting` flag is set
+      Raise a :exc:`BdbQuit` exception if the :attr:`quitting  <Bdb.set_quit>` flag is set
       (which can be set from :meth:`user_line`).  Return a reference to the
       :meth:`trace_dispatch` method for further tracing in that scope.
 
@@ -190,7 +190,7 @@ The :mod:`bdb` module also defines two classes:
 
       If the debugger should stop on this function call, invoke the
       :meth:`user_call` method (which should be overridden in subclasses).
-      Raise a :exc:`BdbQuit` exception if the :attr:`Bdb.quitting` flag is set
+      Raise a :exc:`BdbQuit` exception if the :attr:`quitting  <Bdb.set_quit>` flag is set
       (which can be set from :meth:`user_call`).  Return a reference to the
       :meth:`trace_dispatch` method for further tracing in that scope.
 
@@ -198,7 +198,7 @@ The :mod:`bdb` module also defines two classes:
 
       If the debugger should stop on this function return, invoke the
       :meth:`user_return` method (which should be overridden in subclasses).
-      Raise a :exc:`BdbQuit` exception if the :attr:`Bdb.quitting` flag is set
+      Raise a :exc:`BdbQuit` exception if the :attr:`quitting  <Bdb.set_quit>` flag is set
       (which can be set from :meth:`user_return`).  Return a reference to the
       :meth:`trace_dispatch` method for further tracing in that scope.
 
@@ -206,7 +206,7 @@ The :mod:`bdb` module also defines two classes:
 
       If the debugger should stop at this exception, invokes the
       :meth:`user_exception` method (which should be overridden in subclasses).
-      Raise a :exc:`BdbQuit` exception if the :attr:`Bdb.quitting` flag is set
+      Raise a :exc:`BdbQuit` exception if the :attr:`quitting  <Bdb.set_quit>` flag is set
       (which can be set from :meth:`user_exception`).  Return a reference to the
       :meth:`trace_dispatch` method for further tracing in that scope.
 
@@ -293,7 +293,7 @@ The :mod:`bdb` module also defines two classes:
 
    .. method:: set_quit()
 
-      Set the :attr:`quitting` attribute to ``True``.  This raises :exc:`BdbQuit` in
+      Set the :attr:`!quitting` attribute to ``True``.  This raises :exc:`BdbQuit` in
       the next call to one of the :meth:`!dispatch_\*` methods.
 
 
@@ -383,7 +383,7 @@ The :mod:`bdb` module also defines two classes:
    .. method:: run(cmd, globals=None, locals=None)
 
       Debug a statement executed via the :func:`exec` function.  *globals*
-      defaults to :attr:`__main__.__dict__`, *locals* defaults to *globals*.
+      defaults to :attr:`!__main__.__dict__`, *locals* defaults to *globals*.
 
    .. method:: runeval(expr, globals=None, locals=None)
 

--- a/Doc/library/bdb.rst
+++ b/Doc/library/bdb.rst
@@ -148,7 +148,7 @@ The :mod:`bdb` module also defines two classes:
 
    .. method:: reset()
 
-      `Set the :attr:`botframe`, :attr:`!stopframe`, :attr:`!returnframe` and
+      Set the :attr:`botframe`, :attr:`!stopframe`, :attr:`!returnframe` and
       :attr:`quitting <Bdb.set_quit>` attributes with values ready to start debugging.
 
    .. method:: trace_dispatch(frame, event, arg)

--- a/Doc/tools/.nitignore
+++ b/Doc/tools/.nitignore
@@ -22,7 +22,6 @@ Doc/library/ast.rst
 Doc/library/asyncio-extending.rst
 Doc/library/asyncio-policy.rst
 Doc/library/asyncio-subprocess.rst
-Doc/library/bdb.rst
 Doc/library/collections.rst
 Doc/library/dbm.rst
 Doc/library/decimal.rst


### PR DESCRIPTION
This should be fairly straightforward. I did one thing that isn't maybe strictly kosher. The `Bdb.quitting` attribute isn't directly documented, but is mentioned in the description of `Bdb.set_quit()`. I linked those occurrences to the description of `set_quit`.

<!-- gh-issue-number: gh-101100 -->
* Issue: gh-101100
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--114983.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->