### PR TITLE
gh-114628: Display csv.Error without context

### DIFF
--- a/Lib/csv.py
+++ b/Lib/csv.py
@@ -113,8 +113,8 @@ class Dialect:
         try:
             _Dialect(self)
         except TypeError as e:
-            # We do this for compatibility with py2.3
-            raise Error(str(e))
+            # Re-raise to get a traceback showing more user code.
+            raise Error(str(e)) from None
 
 class excel(Dialect):
     """Describe the usual properties of Excel-generated CSV files."""

--- a/Misc/NEWS.d/next/Library/2024-02-04-13-17-33.gh-issue-114628.WJpqqS.rst
+++ b/Misc/NEWS.d/next/Library/2024-02-04-13-17-33.gh-issue-114628.WJpqqS.rst
@@ -1,0 +1,2 @@
+When csv.Error is raised when handling TypeError, do not print the TypeError
+traceback.


### PR DESCRIPTION
When cvs.Error is raised when TypeError is caught, the TypeError display and 'During handling' note is just noise with duplicate information.  Suppress with 'from None'.

<!-- gh-issue-number: gh-114628 -->
* Issue: gh-114628
<!-- /gh-issue-number -->
