### PR TITLE
Remove bogus syntax error marker in csv doc

### DIFF
--- a/Doc/library/csv.rst
+++ b/Doc/library/csv.rst
@@ -244,7 +244,6 @@ The :mod:`csv` module defines the following classes:
 
        with open('students.csv', 'w', newline='') as csvfile:
            writer = csv.writer(csvfile, dialect='unix')
-                                        ^^^^^^^^^^^^^^
 
 
 .. class:: excel()


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--115017.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->