### PR TITLE
gh-114099: Add preprocessor declarations to support compilation on iOS

### DIFF
--- a/Include/internal/pycore_faulthandler.h
+++ b/Include/internal/pycore_faulthandler.h
@@ -12,6 +12,14 @@ extern "C" {
 #  include <signal.h>             // sigaction
 #endif
 
+#ifdef __APPLE__
+#  include "TargetConditionals.h"
+#endif /* __APPLE__ */
+
+// tvOS and watchOS don't provide a number of important POSIX functions.
+#if TARGET_OS_TV || TARGET_OS_WATCH
+#  undef HAVE_SIGALTSTACK
+#endif /* TVOS || WATCHOS */
 
 #ifndef MS_WINDOWS
    /* register() is useless on Windows, because only SIGSEGV, SIGABRT and

--- a/Misc/NEWS.d/next/Library/2024-02-05-14-55-19.gh-issue-114099.iHk3Zn.rst
+++ b/Misc/NEWS.d/next/Library/2024-02-05-14-55-19.gh-issue-114099.iHk3Zn.rst
@@ -1,0 +1,2 @@
+Preprocessor directives to support compilation on iOS/tvOS/watchOS were
+added.

--- a/Misc/platform_triplet.c
+++ b/Misc/platform_triplet.c
@@ -233,7 +233,42 @@ PLATFORM_TRIPLET=i386-gnu
 #   error unknown platform triplet
 # endif
 #elif defined(__APPLE__)
+#  include "TargetConditionals.h"
+#  if TARGET_OS_IOS
+#    if TARGET_OS_SIMULATOR
+#      if __x86_64__
+PLATFORM_TRIPLET=iphonesimulator-x86_64
+#      else
+PLATFORM_TRIPLET=iphonesimulator-arm64
+#      endif
+#    else
+PLATFORM_TRIPLET=iphoneos-arm64
+#    endif
+#  elif TARGET_OS_TV
+#    if TARGET_OS_SIMULATOR
+#      if __x86_64__
+PLATFORM_TRIPLET=appletvsimulator-x86_64
+#      else
+PLATFORM_TRIPLET=appletvsimulator-arm64
+#      endif
+#    else
+PLATFORM_TRIPLET=appletvos-arm64
+#    endif
+#  elif TARGET_OS_WATCH
+#    if TARGET_OS_SIMULATOR
+#      if __x86_64__
+PLATFORM_TRIPLET=watchsimulator-x86_64
+#      else
+PLATFORM_TRIPLET=watchsimulator-arm64
+#      endif
+#    else
+PLATFORM_TRIPLET=watchos-arm64_32
+#    endif
+#  elif TARGET_OS_OSX
 PLATFORM_TRIPLET=darwin
+#  else
+#    error unknown Apple platform
+#  endif
 #elif defined(__VXWORKS__)
 PLATFORM_TRIPLET=vxworks
 #elif defined(__wasm32__)

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -92,6 +92,8 @@
 
 #include <mach/mach.h>
 
+#include "TargetConditionals.h"
+
 #if defined(__has_builtin)
 #if __has_builtin(__builtin_available)
 #define HAVE_BUILTIN_AVAILABLE 1
@@ -375,6 +377,13 @@ corresponding Unix manual entries for more information on calls.");
 #  define HAVE_FSYNC      1
 #  define fsync _commit
 #endif  /* ! __WATCOMC__ || __QNX__ */
+
+// iOS/tvOS/watchOS *define* some POSIX methods,
+// but raise a compiler error if they are used.
+#if TARGET_OS_IPHONE
+#  undef HAVE_GETGROUPS
+#  undef HAVE_SYSTEM
+#endif
 
 /*[clinic input]
 # one of the few times we lie about this name!

--- a/Modules/pwdmodule.c
+++ b/Modules/pwdmodule.c
@@ -1,6 +1,10 @@
 
 /* UNIX password file access module */
 
+#ifdef __APPLE__
+#  include "TargetConditionals.h"
+#endif /* __APPLE__ */
+
 #include "Python.h"
 #include "posixmodule.h"
 
@@ -183,6 +187,22 @@ pwd_getpwuid(PyObject *module, PyObject *uidobj)
         if (nomem == 1) {
             return PyErr_NoMemory();
         }
+
+// iPhone has a "user" with UID 501, username "mobile"; but the simulator
+// doesn't reflect this. Generate a simulated response.
+#if TARGET_OS_SIMULATOR
+        if (uid == 501) {
+            struct passwd mp;
+            mp.pw_name = "mobile";
+            mp.pw_passwd = "/smx7MYTQIi2M";
+            mp.pw_uid = 501;
+            mp.pw_gid = 501;
+            mp.pw_gecos = "Mobile User";
+            mp.pw_dir = "/var/mobile";
+            mp.pw_shell = "/bin/sh";
+            return mkpwent(module, &mp);
+        }
+#endif
         PyObject *uid_obj = _PyLong_FromUid(uid);
         if (uid_obj == NULL)
             return NULL;
@@ -266,6 +286,22 @@ pwd_getpwnam_impl(PyObject *module, PyObject *name)
             PyErr_NoMemory();
         }
         else {
+// iPhone has a "user" with UID 501, username "mobile"; but the simulator
+// doesn't reflect this. Generate a simulated response.
+#if TARGET_OS_SIMULATOR
+            if (strcmp(name, "mobile") == 0) {
+                struct passwd mp;
+                mp.pw_name = "mobile";
+                mp.pw_passwd = "/smx7MYTQIi2M";
+                mp.pw_uid = 501;
+                mp.pw_gid = 501;
+                mp.pw_gecos = "Mobile User";
+                mp.pw_dir = "/var/mobile";
+                mp.pw_shell = "/bin/sh";
+                retval = mkpwent(module, &mp);
+                goto out;
+            }
+#endif
             PyErr_Format(PyExc_KeyError,
                          "getpwnam(): name not found: %R", name);
         }

--- a/Modules/timemodule.c
+++ b/Modules/timemodule.c
@@ -6,6 +6,10 @@
 #include "pycore_namespace.h"     // _PyNamespace_New()
 #include "pycore_runtime.h"       // _Py_ID()
 
+#ifdef __APPLE__
+#  include "TargetConditionals.h"
+#endif /* __APPLE__ */
+
 #include <time.h>                 // clock()
 #ifdef HAVE_SYS_TIMES_H
 #  include <sys/times.h>          // times()
@@ -59,6 +63,10 @@
 #  define HAVE_CLOCK_GETTIME_RUNTIME 1
 #endif
 
+// iOS/tvOS/watchOS *define* clock_settime, but it can't be used
+#if TARGET_OS_IPHONE
+#   undef HAVE_CLOCK_SETTIME
+#endif
 
 #define SEC_TO_NS (1000 * 1000 * 1000)
 

--- a/Python/bootstrap_hash.c
+++ b/Python/bootstrap_hash.c
@@ -40,6 +40,16 @@
 #endif
 
 
+#ifdef __APPLE__
+#  include "TargetConditionals.h"
+#endif /* __APPLE__ */
+
+// iOS/tvOS/watchOS *define* some POSIX methods,
+// but raise a compiler error if they are used.
+#if TARGET_OS_IPHONE
+#  undef HAVE_GETENTROPY
+#endif
+
 #ifdef Py_DEBUG
 int _Py_HashSecret_Initialized = 0;
 #else

--- a/Python/dynload_shlib.c
+++ b/Python/dynload_shlib.c
@@ -28,6 +28,10 @@
 #define LEAD_UNDERSCORE ""
 #endif
 
+#ifdef __APPLE__
+#  include "TargetConditionals.h"
+#endif /* __APPLE__ */
+
 /* The .so extension module ABI tag, supplied by the Makefile via
    Makefile.pre.in and configure.  This is used to discriminate between
    incompatible .so files so that extensions for different Python builds can
@@ -38,12 +42,21 @@ const char *_PyImport_DynLoadFiletab[] = {
 #ifdef __CYGWIN__
     ".dll",
 #else  /* !__CYGWIN__ */
-    "." SOABI ".so",
-#ifdef ALT_SOABI
-    "." ALT_SOABI ".so",
-#endif
-    ".abi" PYTHON_ABI_STRING ".so",
-    ".so",
+#  ifdef __APPLE__
+#    if TARGET_OS_IPHONE
+#      define SHLIB_SUFFIX ".dylib"
+#    else
+#      define SHLIB_SUFFIX ".so"
+#    endif
+#  else
+#    define SHLIB_SUFFIX ".so"
+#  endif
+    "." SOABI SHLIB_SUFFIX,
+#  ifdef ALT_SOABI
+    "." ALT_SOABI SHLIB_SUFFIX,
+#  endif
+    ".abi" PYTHON_ABI_STRING SHLIB_SUFFIX,
+    SHLIB_SUFFIX,
 #endif  /* __CYGWIN__ */
     NULL,
 };

--- a/Python/marshal.c
+++ b/Python/marshal.c
@@ -14,6 +14,10 @@
 #include "pycore_setobject.h"     // _PySet_NextEntry()
 #include "marshal.h"              // Py_MARSHAL_VERSION
 
+#ifdef __APPLE__
+#  include "TargetConditionals.h"
+#endif /* __APPLE__ */
+
 /*[clinic input]
 module marshal
 [clinic start generated code]*/
@@ -33,11 +37,15 @@ module marshal
  * #if defined(MS_WINDOWS) && defined(_DEBUG)
  */
 #if defined(MS_WINDOWS)
-#define MAX_MARSHAL_STACK_DEPTH 1000
+#  define MAX_MARSHAL_STACK_DEPTH 1000
 #elif defined(__wasi__)
-#define MAX_MARSHAL_STACK_DEPTH 1500
+#  define MAX_MARSHAL_STACK_DEPTH 1500
 #else
-#define MAX_MARSHAL_STACK_DEPTH 2000
+#  if TARGET_OS_IPHONE
+#    define MAX_MARSHAL_STACK_DEPTH 1500
+#  else
+#    define MAX_MARSHAL_STACK_DEPTH 2000
+#  endif
 #endif
 
 #define TYPE_NULL               '0'


### PR DESCRIPTION
Part of the PEP 730 work to add iOS support.

Adds preprocessor declarations to C code to support compilation of the standard library on iOS/tvOS/watchOS.

These changes involve:
* Explicitly disabling methods that are detected by `configure`, but raise a compilation or runtime error if actually used. 
* Allowing for the required `.dylib` extension on iOS dynamic libraries
* Setting the marshalling stack depth
* Providing a simulated response for the "user" on an iOS simulator
* Providing a `PLATFORM_TRIPLET` based on compiler behavior

The preprocessor symbols used to identify Apple platforms are all provided by the `TargetConditionals.h` header, and form a heirarchy: 
 * `TARGET_OS_IPHONE` - Generated code will run on a variant of iOS (firmware, devices, simulator)
   * `TARGET_OS_IOS` - Generated code will run on iOS
     * `TARGET_OS_MACCATALYST`- Generated code will run on macOS
   * `TARGET_OS_TV` - Generated code will run on tvOS
   * `TARGET_OS_WATCH` - Generated code will run on watchOS
 * `TARGET_OS_SIMULATOR` - Generated code will run on an iOS, tvOS, watchOS, or visionOS simulator

Of particular note: `TARGET_OS_IPHONE` is *any* "iPhone like" device - including iOS, tvOS, watchOS, and visionOS. `TARGET_OS_IOS` is iOS only.

<!-- gh-issue-number: gh-114099 -->
* Issue: gh-114099
<!-- /gh-issue-number -->
