### PR TITLE
[3.11] gh-109991: Update GitHub CI workflows to use OpenSSL 3.0.13. (GH-115050)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -232,7 +232,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        openssl_ver: [1.1.1w, 3.0.11, 3.1.3]
+        openssl_ver: [1.1.1w, 3.0.13, 3.1.5, 3.2.1]
     env:
       OPENSSL_VER: ${{ matrix.openssl_ver }}
       MULTISSL_DIR: ${{ github.workspace }}/multissl
@@ -286,7 +286,7 @@ jobs:
     needs: check_source
     if: needs.check_source.outputs.run_tests == 'true'
     env:
-      OPENSSL_VER: 3.0.11
+      OPENSSL_VER: 3.0.13
       PYTHONSTRICTEXTENSIONBUILD: 1
       ASAN_OPTIONS: detect_leaks=0:allocator_may_return_null=1:handle_segv=0
     steps:

--- a/.github/workflows/reusable-ubuntu.yml
+++ b/.github/workflows/reusable-ubuntu.yml
@@ -14,7 +14,7 @@ jobs:
     timeout-minutes: 60
     runs-on: ubuntu-20.04
     env:
-      OPENSSL_VER: 3.0.11
+      OPENSSL_VER: 3.0.13
       PYTHONSTRICTEXTENSIONBUILD: 1
     steps:
     - uses: actions/checkout@v4

--- a/Misc/NEWS.d/next/Tools-Demos/2024-02-05-19-00-32.gh-issue-109991.yJSEkw.rst
+++ b/Misc/NEWS.d/next/Tools-Demos/2024-02-05-19-00-32.gh-issue-109991.yJSEkw.rst
@@ -1,0 +1,2 @@
+Update GitHub CI workflows to use OpenSSL 3.0.13 and multissltests to use
+1.1.1w, 3.0.13, 3.1.5, and 3.2.1.

--- a/Tools/ssl/multissltests.py
+++ b/Tools/ssl/multissltests.py
@@ -48,8 +48,9 @@ OPENSSL_OLD_VERSIONS = [
 
 OPENSSL_RECENT_VERSIONS = [
     "1.1.1w",
-    "3.0.11",
-    "3.1.3",
+    "3.0.13",
+    "3.1.5",
+    "3.2.1",
 ]
 
 LIBRESSL_OLD_VERSIONS = [


### PR DESCRIPTION
Also update multissltests to use 1.1.1w, 3.0.13, 3.1.5, and 3.2.1.

(cherry picked from commit 299e16ca0f303a1e00bd0e04679862a5d4db5ab2)

<!-- gh-issue-number: gh-109991 -->
* Issue: gh-109991
<!-- /gh-issue-number -->
