### PR TITLE
GH-115060: Speed up `pathlib.Path.glob()` by removing redundant regex matching

### DIFF
--- a/Lib/pathlib/__init__.py
+++ b/Lib/pathlib/__init__.py
@@ -587,9 +587,13 @@ class Path(_abc.PathBase, PurePath):
     def _scandir(self):
         return os.scandir(self)
 
+    def _entry_str(self, entry):
+        # Transform an entry yielded from _scandir() into a path string.
+        return entry.name if str(self) == '.' else entry.path
+
     def _make_child_entry(self, entry):
         # Transform an entry yielded from _scandir() into a path object.
-        path_str = entry.name if str(self) == '.' else entry.path
+        path_str = self._entry_str(entry)
         path = self.with_segments(path_str)
         path._str = path_str
         path._drv = self.drive

--- a/Lib/pathlib/__init__.py
+++ b/Lib/pathlib/__init__.py
@@ -587,13 +587,14 @@ class Path(_abc.PathBase, PurePath):
     def _scandir(self):
         return os.scandir(self)
 
-    def _entry_str(self, entry):
+    @classmethod
+    def _entry_str(cls, entry):
         # Transform an entry yielded from _scandir() into a path string.
-        return entry.name if str(self) == '.' else entry.path
+        return entry.path
 
     def _make_child_entry(self, entry):
         # Transform an entry yielded from _scandir() into a path object.
-        path_str = self._entry_str(entry)
+        path_str = entry.name if str(self) == '.' else entry.path
         path = self.with_segments(path_str)
         path._str = path_str
         path._drv = self.drive

--- a/Lib/pathlib/__init__.py
+++ b/Lib/pathlib/__init__.py
@@ -587,14 +587,13 @@ class Path(_abc.PathBase, PurePath):
     def _scandir(self):
         return os.scandir(self)
 
-    @classmethod
-    def _entry_str(cls, entry):
+    def _entry_str(self, entry):
         # Transform an entry yielded from _scandir() into a path string.
-        return entry.path
+        return entry.name if str(self) == '.' else entry.path
 
     def _make_child_entry(self, entry):
         # Transform an entry yielded from _scandir() into a path object.
-        path_str = entry.name if str(self) == '.' else entry.path
+        path_str = self._entry_str(entry)
         path = self.with_segments(path_str)
         path._str = path_str
         path._drv = self.drive

--- a/Lib/pathlib/__init__.py
+++ b/Lib/pathlib/__init__.py
@@ -587,13 +587,13 @@ class Path(_abc.PathBase, PurePath):
     def _scandir(self):
         return os.scandir(self)
 
-    def _entry_str(self, entry):
+    def _direntry_str(self, entry):
         # Transform an entry yielded from _scandir() into a path string.
         return entry.name if str(self) == '.' else entry.path
 
-    def _make_child_entry(self, entry):
+    def _make_child_direntry(self, entry):
         # Transform an entry yielded from _scandir() into a path object.
-        path_str = self._entry_str(entry)
+        path_str = self._direntry_str(entry)
         path = self.with_segments(path_str)
         path._str = path_str
         path._drv = self.drive

--- a/Lib/pathlib/_abc.py
+++ b/Lib/pathlib/_abc.py
@@ -95,7 +95,8 @@ def _select_recursive(parent_paths, dir_only, follow_symlinks, match):
     if follow_symlinks is None:
         follow_symlinks = False
     for parent_path in parent_paths:
-        prefix_len = len(str(parent_path._make_child_relpath('_'))) - 1
+        if match is not None:
+            prefix_len = len(str(parent_path._make_child_relpath('_'))) - 1
         paths = [parent_path._make_child_relpath('')]
         while paths:
             path = paths.pop()

--- a/Lib/pathlib/_abc.py
+++ b/Lib/pathlib/_abc.py
@@ -753,7 +753,8 @@ class PathBase(PurePathBase):
         from contextlib import nullcontext
         return nullcontext(self.iterdir())
 
-    def _entry_str(self, entry):
+    @classmethod
+    def _entry_str(cls, entry):
         # Transform an entry yielded from _scandir() into a path string.
         return str(entry)
 

--- a/Lib/pathlib/_abc.py
+++ b/Lib/pathlib/_abc.py
@@ -96,11 +96,11 @@ def _select_recursive(parent_paths, dir_only, follow_symlinks, match):
         follow_symlinks = False
     for parent_path in parent_paths:
         if match is not None:
-            prefix_len = len(str(parent_path._make_child_relpath('_'))) - 1
+            parent_len = len(str(parent_path._make_child_relpath('_'))) - 1
         paths = [parent_path._make_child_relpath('')]
         while paths:
             path = paths.pop()
-            if match is None or match(str(path), prefix_len):
+            if match is None or match(str(path), parent_len):
                 yield path
             try:
                 # We must close the scandir() object before proceeding to
@@ -118,7 +118,7 @@ def _select_recursive(parent_paths, dir_only, follow_symlinks, match):
                     except OSError:
                         pass
                     if not dir_only:
-                        if match is None or match(path._entry_str(entry), prefix_len):
+                        if match is None or match(path._entry_str(entry), parent_len):
                             yield path._make_child_entry(entry)
 
 

--- a/Lib/pathlib/_abc.py
+++ b/Lib/pathlib/_abc.py
@@ -753,8 +753,7 @@ class PathBase(PurePathBase):
         from contextlib import nullcontext
         return nullcontext(self.iterdir())
 
-    @classmethod
-    def _entry_str(cls, entry):
+    def _entry_str(self, entry):
         # Transform an entry yielded from _scandir() into a path string.
         return str(entry)
 

--- a/Lib/pathlib/_abc.py
+++ b/Lib/pathlib/_abc.py
@@ -799,7 +799,7 @@ class PathBase(PurePathBase):
         while stack:
             part = stack.pop()
             if part in specials:
-                # Join special segment (e.g. '..') onto paths.
+                # Join special component (e.g. '..') onto paths.
                 paths = _select_special(paths, part)
 
             elif part == '**':
@@ -814,8 +814,8 @@ class PathBase(PurePathBase):
                     while stack and stack[-1] not in specials:
                         part += sep + stack.pop()
 
-                # If the previous loop consumed pattern segments, compile an
-                # re.Pattern object based on those segments.
+                # If the previous loop consumed pattern components, compile an
+                # re.Pattern object based on those components.
                 match = _compile_pattern(part, sep, case_sensitive) if part != '**' else None
 
                 # Recursively walk directories, filtering by type and regex.
@@ -830,8 +830,8 @@ class PathBase(PurePathBase):
                 raise ValueError("Invalid pattern: '**' can only be an entire path component")
 
             else:
-                # If the pattern segment isn't '*', compile an re.Pattern
-                # object based on the segment.
+                # If the pattern component isn't '*', compile an re.Pattern
+                # object based on the component.
                 match = _compile_pattern(part, sep, case_sensitive) if part != '*' else None
 
                 # Iterate over directories' children filtering by type and regex.

--- a/Lib/pathlib/_abc.py
+++ b/Lib/pathlib/_abc.py
@@ -117,9 +117,8 @@ def _select_recursive(parent_paths, dir_only, follow_symlinks, match):
                     except OSError:
                         pass
                     if not dir_only:
-                        file_path = path._make_child_entry(entry)
-                        if match is None or match(str(file_path), prefix_len):
-                            yield file_path
+                        if match is None or match(path._entry_str(entry), prefix_len):
+                            yield path._make_child_entry(entry)
 
 
 def _select_unique(paths):
@@ -753,6 +752,10 @@ class PathBase(PurePathBase):
         # context manager. This method is called by walk() and glob().
         from contextlib import nullcontext
         return nullcontext(self.iterdir())
+
+    def _entry_str(self, entry):
+        # Transform an entry yielded from _scandir() into a path string.
+        return str(entry)
 
     def _make_child_entry(self, entry):
         # Transform an entry yielded from _scandir() into a path object.

--- a/Lib/pathlib/_abc.py
+++ b/Lib/pathlib/_abc.py
@@ -86,21 +86,28 @@ def _select_children(parent_paths, dir_only, follow_symlinks, match):
                             continue
                     except OSError:
                         continue
+                # Avoid cost of making a path object for non-matching paths by
+                # matching against the os.DirEntry.name string.
                 if match is None or match(entry.name):
-                    yield parent_path._make_child_entry(entry)
+                    yield parent_path._make_child_direntry(entry)
 
 
 def _select_recursive(parent_paths, dir_only, follow_symlinks, match):
-    """Yield given paths and all their subdirectories, recursively."""
+    """Yield given paths and all their children, recursively, filtering by
+    string and type.
+    """
     if follow_symlinks is None:
         follow_symlinks = False
     for parent_path in parent_paths:
         if match is not None:
+            # If we're filtering paths through a regex, record the length of
+            # the parent path. We'll pass it to match(path, pos=...) later.
             parent_len = len(str(parent_path._make_child_relpath('_'))) - 1
         paths = [parent_path._make_child_relpath('')]
         while paths:
             path = paths.pop()
             if match is None or match(str(path), parent_len):
+                # Yield *directory* path that matches pattern (if any).
                 yield path
             try:
                 # We must close the scandir() object before proceeding to
@@ -111,15 +118,22 @@ def _select_recursive(parent_paths, dir_only, follow_symlinks, match):
                 pass
             else:
                 for entry in entries:
+                    # Handle directory entry.
                     try:
                         if entry.is_dir(follow_symlinks=follow_symlinks):
-                            paths.append(path._make_child_entry(entry))
+                            # Recurse into this directory.
+                            paths.append(path._make_child_direntry(entry))
                             continue
                     except OSError:
                         pass
+
+                    # Handle file entry.
                     if not dir_only:
-                        if match is None or match(path._entry_str(entry), parent_len):
-                            yield path._make_child_entry(entry)
+                        # Avoid cost of making a path object for non-matching
+                        # files by matching against the os.DirEntry object.
+                        if match is None or match(path._direntry_str(entry), parent_len):
+                            # Yield *file* path that matches pattern (if any).
+                            yield path._make_child_direntry(entry)
 
 
 def _select_unique(paths):
@@ -754,12 +768,14 @@ class PathBase(PurePathBase):
         from contextlib import nullcontext
         return nullcontext(self.iterdir())
 
-    def _entry_str(self, entry):
+    def _direntry_str(self, entry):
         # Transform an entry yielded from _scandir() into a path string.
+        # PathBase._scandir() yields PathBase objects, so use str().
         return str(entry)
 
-    def _make_child_entry(self, entry):
+    def _make_child_direntry(self, entry):
         # Transform an entry yielded from _scandir() into a path object.
+        # PathBase._scandir() yields PathBase objects, so this is a no-op.
         return entry
 
     def _make_child_relpath(self, name):
@@ -783,31 +799,43 @@ class PathBase(PurePathBase):
         while stack:
             part = stack.pop()
             if part in specials:
+                # Join special segment (e.g. '..') onto paths.
                 paths = _select_special(paths, part)
+
             elif part == '**':
-                # Consume adjacent '**' components.
+                # Consume following '**' components, which have no effect.
                 while stack and stack[-1] == '**':
                     stack.pop()
 
-                # Consume adjacent non-special components and enable post-walk
-                # regex filtering, provided we're treating symlinks consistently.
+                # Consume following non-special components, provided we're
+                # treating symlinks consistently. Each component is joined
+                # onto 'part', which is used to generate an re.Pattern object.
                 if follow_symlinks is not None:
                     while stack and stack[-1] not in specials:
                         part += sep + stack.pop()
 
-                dir_only = bool(stack)
+                # If the previous loop consumed pattern segments, compile an
+                # re.Pattern object based on those segments.
                 match = _compile_pattern(part, sep, case_sensitive) if part != '**' else None
-                paths = _select_recursive(paths, dir_only, follow_symlinks, match)
+
+                # Recursively walk directories, filtering by type and regex.
+                paths = _select_recursive(paths, bool(stack), follow_symlinks, match)
+
+                # De-duplicate if we've already seen a '**' component.
                 if deduplicate_paths:
-                    # De-duplicate if we've already seen a '**' component.
                     paths = _select_unique(paths)
                 deduplicate_paths = True
+
             elif '**' in part:
                 raise ValueError("Invalid pattern: '**' can only be an entire path component")
+
             else:
-                dir_only = bool(stack)
+                # If the pattern segment isn't '*', compile an re.Pattern
+                # object based on the segment.
                 match = _compile_pattern(part, sep, case_sensitive) if part != '*' else None
-                paths = _select_children(paths, dir_only, follow_symlinks, match)
+
+                # Iterate over directories' children filtering by type and regex.
+                paths = _select_children(paths, bool(stack), follow_symlinks, match)
         return paths
 
     def rglob(self, pattern, *, case_sensitive=None, follow_symlinks=None):
@@ -856,7 +884,7 @@ class PathBase(PurePathBase):
 
                     if is_dir:
                         if not top_down:
-                            paths.append(path._make_child_entry(entry))
+                            paths.append(path._make_child_direntry(entry))
                         dirnames.append(entry.name)
                     else:
                         filenames.append(entry.name)

--- a/Lib/test/test_pathlib/test_pathlib.py
+++ b/Lib/test/test_pathlib/test_pathlib.py
@@ -1250,6 +1250,12 @@ class PathTest(test_pathlib_abc.DummyPathTest, PurePathTest):
         self.assertEqual(expect, set(p.glob(P(pattern))))
         self.assertEqual(expect, set(p.glob(FakePath(pattern))))
 
+    @needs_symlinks
+    def test_glob_dot(self):
+        P = self.cls
+        with os_helper.change_cwd(P(self.base, "dirC")):
+            self.assertEqual(set(P('.').glob('**/*/*')), {P("dirD/fileD")})
+
     def test_rglob_pathlike(self):
         P = self.cls
         p = P(self.base, "dirC")

--- a/Lib/test/test_pathlib/test_pathlib.py
+++ b/Lib/test/test_pathlib/test_pathlib.py
@@ -1254,7 +1254,14 @@ class PathTest(test_pathlib_abc.DummyPathTest, PurePathTest):
     def test_glob_dot(self):
         P = self.cls
         with os_helper.change_cwd(P(self.base, "dirC")):
-            self.assertEqual(set(P('.').glob('**/*/*')), {P("dirD/fileD")})
+            self.assertEqual(
+                set(P('.').glob('*')), {P("fileC"), P("novel.txt"), P("dirD")})
+            self.assertEqual(
+                set(P('.').glob('**')), {P("fileC"), P("novel.txt"), P("dirD"), P("dirD/fileD"), P(".")})
+            self.assertEqual(
+                set(P('.').glob('**/*')), {P("fileC"), P("novel.txt"), P("dirD"), P("dirD/fileD")})
+            self.assertEqual(
+                set(P('.').glob('**/*/*')), {P("dirD/fileD")})
 
     def test_rglob_pathlike(self):
         P = self.cls

--- a/Misc/NEWS.d/next/Library/2024-02-06-03-55-46.gh-issue-115060.EkWRpP.rst
+++ b/Misc/NEWS.d/next/Library/2024-02-06-03-55-46.gh-issue-115060.EkWRpP.rst
@@ -1,0 +1,1 @@
+Speed up :meth:`pathlib.Path.glob` by removing redundant regex matching.


### PR DESCRIPTION
When expanding and filtering paths for a `**` wildcard segment, build an `re.Pattern` object from the subsequent pattern parts, rather than the entire pattern, and match against the `os.DirEntry` object prior to instantiating a path object.

Also skip compiling a pattern when expanding a `*` wildcard segment.


<!-- gh-issue-number: gh-115060 -->
* Issue: gh-115060
<!-- /gh-issue-number -->
