### PR TITLE
[3.11] gh-115009: Update macOS installer to use SQLite 3.45.1 (#115066)

### DIFF
--- a/Mac/BuildScript/build-installer.py
+++ b/Mac/BuildScript/build-installer.py
@@ -358,9 +358,9 @@ def library_recipes():
                   ),
           ),
           dict(
-              name="SQLite 3.43.1",
-              url="https://sqlite.org/2023/sqlite-autoconf-3430100.tar.gz",
-              checksum="77e61befe9c3298da0504f87772a24b0",
+              name="SQLite 3.45.1",
+              url="https://sqlite.org/2024/sqlite-autoconf-3450100.tar.gz",
+              checksum="cd9c27841b7a5932c9897651e20b86c701dd740556989b01ca596fcfa3d49a0a",
               extra_cflags=('-Os '
                             '-DSQLITE_ENABLE_FTS5 '
                             '-DSQLITE_ENABLE_FTS4 '

--- a/Misc/NEWS.d/next/macOS/2024-02-06-09-01-10.gh-issue-115009.ysau7e.rst
+++ b/Misc/NEWS.d/next/macOS/2024-02-06-09-01-10.gh-issue-115009.ysau7e.rst
@@ -1,0 +1,1 @@
+Update macOS installer to use SQLite 3.45.1.


### PR DESCRIPTION
(cherry picked from commit 13eb5215c9de9dd302f116ef0bca4ae23b02842b)

Co-authored-by: Ned Deily <nad@python.org>


<!-- gh-issue-number: gh-115009 -->
* Issue: gh-115009
<!-- /gh-issue-number -->
