### PR TITLE
gh-67837, gh-112998: Fix dirs creation in concurrent extraction

### DIFF
--- a/Lib/tarfile.py
+++ b/Lib/tarfile.py
@@ -2411,7 +2411,7 @@ class TarFile(object):
         if upperdirs and not os.path.exists(upperdirs):
             # Create directories that are not part of the archive with
             # default permissions.
-            os.makedirs(upperdirs)
+            os.makedirs(upperdirs, exist_ok=True)
 
         if tarinfo.islnk() or tarinfo.issym():
             self._dbg(1, "%s -> %s" % (tarinfo.name, tarinfo.linkname))

--- a/Lib/test/archiver_tests.py
+++ b/Lib/test/archiver_tests.py
@@ -3,6 +3,7 @@
 import os
 import sys
 
+from test.support import swap_attr
 from test.support import os_helper
 
 class OverwriteTests:
@@ -153,3 +154,24 @@ class OverwriteTests:
                 self.extractall(ar)
         self.assertTrue(os.path.islink(target))
         self.assertFalse(os.path.exists(target2))
+
+    def test_concurrent_extract_dir(self):
+        target = os.path.join(self.testdir, 'test')
+        def concurrent_mkdir(*args, **kwargs):
+            orig_mkdir(*args, **kwargs)
+            orig_mkdir(*args, **kwargs)
+        with swap_attr(os, 'mkdir', concurrent_mkdir) as orig_mkdir:
+            with self.open(self.ar_with_dir) as ar:
+                self.extractall(ar)
+        self.assertTrue(os.path.isdir(target))
+
+    def test_concurrent_extract_implicit_dir(self):
+        target = os.path.join(self.testdir, 'test')
+        def concurrent_mkdir(*args, **kwargs):
+            orig_mkdir(*args, **kwargs)
+            orig_mkdir(*args, **kwargs)
+        with swap_attr(os, 'mkdir', concurrent_mkdir) as orig_mkdir:
+            with self.open(self.ar_with_implicit_dir) as ar:
+                self.extractall(ar)
+        self.assertTrue(os.path.isdir(target))
+        self.assertTrue(os.path.isfile(os.path.join(target, 'file')))

--- a/Lib/zipfile/__init__.py
+++ b/Lib/zipfile/__init__.py
@@ -1802,11 +1802,15 @@ class ZipFile:
         # Create all upper directories if necessary.
         upperdirs = os.path.dirname(targetpath)
         if upperdirs and not os.path.exists(upperdirs):
-            os.makedirs(upperdirs)
+            os.makedirs(upperdirs, exist_ok=True)
 
         if member.is_dir():
             if not os.path.isdir(targetpath):
-                os.mkdir(targetpath)
+                try:
+                    os.mkdir(targetpath)
+                except FileExistsError:
+                    if not os.path.isdir(targetpath):
+                        raise
             return targetpath
 
         with self.open(member, pwd=pwd) as source, \

--- a/Misc/NEWS.d/next/Library/2024-02-06-15-16-28.gh-issue-67837._JKa73.rst
+++ b/Misc/NEWS.d/next/Library/2024-02-06-15-16-28.gh-issue-67837._JKa73.rst
@@ -1,0 +1,2 @@
+Avoid race conditions in the creation of directories during concurrent
+extraction in :mod:`tarfile` and :mod:`zipfile`.


### PR DESCRIPTION
Avoid race conditions in the creation of directories during concurrent extraction in tarfile and zipfile.


<!-- gh-issue-number: gh-67837 -->
* Issue: gh-67837
<!-- /gh-issue-number -->
<!-- gh-issue-number: gh-112998 -->
* Issue: gh-112998
<!-- /gh-issue-number -->
