### PR TITLE
[3.9] gh-111239: Update Windows build to use zlib 1.3.1 (GH-114877)

### DIFF
--- a/Misc/NEWS.d/next/Windows/2024-02-01-14-35-05.gh-issue-111239.SO7SUF.rst
+++ b/Misc/NEWS.d/next/Windows/2024-02-01-14-35-05.gh-issue-111239.SO7SUF.rst
@@ -1,0 +1,1 @@
+Update Windows builds to use zlib v1.3.1.

--- a/PCbuild/get_externals.bat
+++ b/PCbuild/get_externals.bat
@@ -59,7 +59,7 @@ if NOT "%IncludeTkinterSrc%"=="false" set libraries=%libraries% tcl-core-8.6.12.
 if NOT "%IncludeTkinterSrc%"=="false" set libraries=%libraries% tk-8.6.12.0
 if NOT "%IncludeTkinterSrc%"=="false" set libraries=%libraries% tix-8.4.3.6
 set libraries=%libraries%                                       xz-5.2.5
-set libraries=%libraries%                                       zlib-1.2.12
+set libraries=%libraries%                                       zlib-1.3.1
 
 for %%e in (%libraries%) do (
     if exist "%EXTERNALS_DIR%\%%e" (

--- a/PCbuild/python.props
+++ b/PCbuild/python.props
@@ -72,7 +72,7 @@
     <opensslOutDir Condition="$(opensslOutDir) == ''">$(ExternalsDir)openssl-bin-1.1.1w\$(ArchName)\</opensslOutDir>
     <opensslIncludeDir Condition="$(opensslIncludeDir) == ''">$(opensslOutDir)include</opensslIncludeDir>
     <nasmDir Condition="$(nasmDir) == ''">$(ExternalsDir)\nasm-2.11.06\</nasmDir>
-    <zlibDir Condition="$(zlibDir) == ''">$(ExternalsDir)\zlib-1.2.12\</zlibDir>
+    <zlibDir Condition="$(zlibDir) == ''">$(ExternalsDir)\zlib-1.3.1\</zlibDir>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
(cherry picked from commit 618d7256e78da8200f6e2c6235094a1ef885dca4)


<!-- gh-issue-number: gh-111239 -->
* Issue: gh-111239
<!-- /gh-issue-number -->
