### PR TITLE
gh-115091: Remove a left-over sentence that refers to Py_OptimizeFlag from ctypes documentation

### DIFF
--- a/Doc/library/ctypes.rst
+++ b/Doc/library/ctypes.rst
@@ -1113,10 +1113,6 @@ api::
    >>> print(hex(version.value))
    0x30c00a0
 
-If the interpreter would have been started with :option:`-O`, the sample would
-have printed ``c_long(1)``, or ``c_long(2)`` if :option:`-OO` would have been
-specified.
-
 An extended example which also demonstrates the use of pointers accesses the
 :c:data:`PyImport_FrozenModules` pointer exported by Python.
 


### PR DESCRIPTION
Remove a left-over sentence that refers to an [example that was present in Python 3.11 and was using `Py_OptimizeFlag`](https://docs.python.org/3.11/library/ctypes.html#accessing-values-exported-from-dlls).

Should be also backported to 3.12 tip?

<!-- gh-issue-number: gh-115091 -->
* Issue: gh-115091
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--115092.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->