### PR TITLE
gh-115106 docs: `enum.Flag.__iter__()` did not exist prior to Python 3.11

### DIFF
--- a/Doc/library/enum.rst
+++ b/Doc/library/enum.rst
@@ -534,9 +534,7 @@ Data Types
          >>> list(purple)
          [<Color.RED: 1>, <Color.BLUE: 4>]
 
-      .. versionchanged:: 3.11
-
-         Aliases are no longer returned during iteration.
+      .. versionadded:: 3.11
 
    .. method:: __len__(self):
 


### PR DESCRIPTION
(The existing documentation suggests there has been some change to the behavior of `Flag.__iter__()` starting in Python 3.11; this is misleading at best.)

I have no experience with PRs, so please forgive any deficiencies in this submission.

As corrected:
![Screenshot 2024-02-06 at 17 04 32](https://github.com/python/cpython/assets/38001514/888436e9-1a9b-463d-b739-993f2734c57b)


<!-- gh-issue-number: gh-115106 -->
* Issue: gh-115106
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--115107.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->