### PR TITLE
gh-112069: Adapt set/frozenset methods to Argument Clinic

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2024-02-07-00-18-42.gh-issue-112069.jRDRR5.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2024-02-07-00-18-42.gh-issue-112069.jRDRR5.rst
@@ -1,0 +1,1 @@
+Convert set and frozenset methods to Argument Clinic

--- a/Misc/NEWS.d/next/Core and Builtins/2024-02-07-00-18-42.gh-issue-112069.jRDRR5.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2024-02-07-00-18-42.gh-issue-112069.jRDRR5.rst
@@ -1,1 +1,1 @@
-Convert set and frozenset methods to Argument Clinic
+Convert :class:`set` and :class:`frozenset` methods to Argument Clinic.

--- a/Misc/NEWS.d/next/Core and Builtins/2024-02-07-00-18-42.gh-issue-112069.jRDRR5.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2024-02-07-00-18-42.gh-issue-112069.jRDRR5.rst
@@ -1,1 +1,1 @@
-Convert :class:`set` and :class:`frozenset` methods to Argument Clinic.
+Adapt :class:`set` and :class:`frozenset` methods to Argument Clinic.

--- a/Objects/clinic/setobject.c.h
+++ b/Objects/clinic/setobject.c.h
@@ -1,0 +1,201 @@
+/*[clinic input]
+preserve
+[clinic start generated code]*/
+
+PyDoc_STRVAR(set_pop__doc__,
+"pop($self, /)\n"
+"--\n"
+"\n"
+"Remove and return an arbitrary set element.\n"
+"\n"
+"Raises KeyError if the set is empty.");
+
+#define SET_POP_METHODDEF    \
+    {"pop", (PyCFunction)set_pop, METH_NOARGS, set_pop__doc__},
+
+static PyObject *
+set_pop_impl(PySetObject *self);
+
+static PyObject *
+set_pop(PySetObject *self, PyObject *Py_UNUSED(ignored))
+{
+    return set_pop_impl(self);
+}
+
+PyDoc_STRVAR(set_copy__doc__,
+"copy($self, /)\n"
+"--\n"
+"\n"
+"Return a shallow copy of a set.");
+
+#define SET_COPY_METHODDEF    \
+    {"copy", (PyCFunction)set_copy, METH_NOARGS, set_copy__doc__},
+
+static PyObject *
+set_copy_impl(PySetObject *self);
+
+static PyObject *
+set_copy(PySetObject *self, PyObject *Py_UNUSED(ignored))
+{
+    return set_copy_impl(self);
+}
+
+PyDoc_STRVAR(frozenset_copy__doc__,
+"copy($self, /)\n"
+"--\n"
+"\n"
+"Return a shallow copy of a set.");
+
+#define FROZENSET_COPY_METHODDEF    \
+    {"copy", (PyCFunction)frozenset_copy, METH_NOARGS, frozenset_copy__doc__},
+
+static PyObject *
+frozenset_copy_impl(PySetObject *self);
+
+static PyObject *
+frozenset_copy(PySetObject *self, PyObject *Py_UNUSED(ignored))
+{
+    return frozenset_copy_impl(self);
+}
+
+PyDoc_STRVAR(set_clear__doc__,
+"clear($self, /)\n"
+"--\n"
+"\n"
+"Remove all elements from this set.");
+
+#define SET_CLEAR_METHODDEF    \
+    {"clear", (PyCFunction)set_clear, METH_NOARGS, set_clear__doc__},
+
+static PyObject *
+set_clear_impl(PySetObject *self);
+
+static PyObject *
+set_clear(PySetObject *self, PyObject *Py_UNUSED(ignored))
+{
+    return set_clear_impl(self);
+}
+
+PyDoc_STRVAR(set_isdisjoint__doc__,
+"isdisjoint($self, other, /)\n"
+"--\n"
+"\n"
+"Return True if two sets have a null intersection.");
+
+#define SET_ISDISJOINT_METHODDEF    \
+    {"isdisjoint", (PyCFunction)set_isdisjoint, METH_O, set_isdisjoint__doc__},
+
+PyDoc_STRVAR(set_symmetric_difference_update__doc__,
+"symmetric_difference_update($self, other, /)\n"
+"--\n"
+"\n"
+"Update the set, keeping only elements found in either set, but not in both.");
+
+#define SET_SYMMETRIC_DIFFERENCE_UPDATE_METHODDEF    \
+    {"symmetric_difference_update", (PyCFunction)set_symmetric_difference_update, METH_O, set_symmetric_difference_update__doc__},
+
+PyDoc_STRVAR(set_symmetric_difference__doc__,
+"symmetric_difference($self, other, /)\n"
+"--\n"
+"\n"
+"Return a new set with elements in either the set or other but not both.");
+
+#define SET_SYMMETRIC_DIFFERENCE_METHODDEF    \
+    {"symmetric_difference", (PyCFunction)set_symmetric_difference, METH_O, set_symmetric_difference__doc__},
+
+PyDoc_STRVAR(set_issubset__doc__,
+"issubset($self, other, /)\n"
+"--\n"
+"\n"
+"Report whether another set contains this set.");
+
+#define SET_ISSUBSET_METHODDEF    \
+    {"issubset", (PyCFunction)set_issubset, METH_O, set_issubset__doc__},
+
+PyDoc_STRVAR(set_issuperset__doc__,
+"issuperset($self, other, /)\n"
+"--\n"
+"\n"
+"Report whether this set contains another set.");
+
+#define SET_ISSUPERSET_METHODDEF    \
+    {"issuperset", (PyCFunction)set_issuperset, METH_O, set_issuperset__doc__},
+
+PyDoc_STRVAR(set_add__doc__,
+"add($self, object, /)\n"
+"--\n"
+"\n"
+"Add an element to a set.\n"
+"\n"
+"This has no effect if the element is already present.");
+
+#define SET_ADD_METHODDEF    \
+    {"add", (PyCFunction)set_add, METH_O, set_add__doc__},
+
+PyDoc_STRVAR(set___contains____doc__,
+"__contains__($self, object, /)\n"
+"--\n"
+"\n"
+"x.__contains__(y) <==> y in x.");
+
+#define SET___CONTAINS___METHODDEF    \
+    {"__contains__", (PyCFunction)set___contains__, METH_O, set___contains____doc__},
+
+PyDoc_STRVAR(set_remove__doc__,
+"remove($self, key, /)\n"
+"--\n"
+"\n"
+"Remove an element from a set; it must be a member.\n"
+"\n"
+"If the element is not a member, raise a KeyError.");
+
+#define SET_REMOVE_METHODDEF    \
+    {"remove", (PyCFunction)set_remove, METH_O, set_remove__doc__},
+
+PyDoc_STRVAR(set_discard__doc__,
+"discard($self, key, /)\n"
+"--\n"
+"\n"
+"Remove an element from a set if it is a member.\n"
+"\n"
+"Unlike set.remove(), the discard() method does not raise\n"
+"an exception when an element is missing from the set.");
+
+#define SET_DISCARD_METHODDEF    \
+    {"discard", (PyCFunction)set_discard, METH_O, set_discard__doc__},
+
+PyDoc_STRVAR(set___reduce____doc__,
+"__reduce__($self, /)\n"
+"--\n"
+"\n");
+
+#define SET___REDUCE___METHODDEF    \
+    {"__reduce__", (PyCFunction)set___reduce__, METH_NOARGS, set___reduce____doc__},
+
+static PyObject *
+set___reduce___impl(PySetObject *self);
+
+static PyObject *
+set___reduce__(PySetObject *self, PyObject *Py_UNUSED(ignored))
+{
+    return set___reduce___impl(self);
+}
+
+PyDoc_STRVAR(set___sizeof____doc__,
+"__sizeof__($self, /)\n"
+"--\n"
+"\n"
+"S.__sizeof__() -> size of S in memory, in bytes.");
+
+#define SET___SIZEOF___METHODDEF    \
+    {"__sizeof__", (PyCFunction)set___sizeof__, METH_NOARGS, set___sizeof____doc__},
+
+static PyObject *
+set___sizeof___impl(PySetObject *self);
+
+static PyObject *
+set___sizeof__(PySetObject *self, PyObject *Py_UNUSED(ignored))
+{
+    return set___sizeof___impl(self);
+}
+/*[clinic end generated code: output=37e660dbf15cd755 input=a9049054013a1b77]*/

--- a/Objects/clinic/setobject.c.h
+++ b/Objects/clinic/setobject.c.h
@@ -16,12 +16,12 @@ PyDoc_STRVAR(set_pop__doc__,
     {"pop", (PyCFunction)set_pop, METH_NOARGS, set_pop__doc__},
 
 static PyObject *
-set_pop_impl(PySetObject *self);
+set_pop_impl(PySetObject *so);
 
 static PyObject *
-set_pop(PySetObject *self, PyObject *Py_UNUSED(ignored))
+set_pop(PySetObject *so, PyObject *Py_UNUSED(ignored))
 {
-    return set_pop_impl(self);
+    return set_pop_impl(so);
 }
 
 PyDoc_STRVAR(set_update__doc__,
@@ -34,10 +34,10 @@ PyDoc_STRVAR(set_update__doc__,
     {"update", _PyCFunction_CAST(set_update), METH_FASTCALL, set_update__doc__},
 
 static PyObject *
-set_update_impl(PySetObject *self, PyObject *args);
+set_update_impl(PySetObject *so, PyObject *args);
 
 static PyObject *
-set_update(PySetObject *self, PyObject *const *args, Py_ssize_t nargs)
+set_update(PySetObject *so, PyObject *const *args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     PyObject *__clinic_args = NULL;
@@ -52,7 +52,7 @@ set_update(PySetObject *self, PyObject *const *args, Py_ssize_t nargs)
     for (Py_ssize_t i = 0; i < nargs - 0; ++i) {
         PyTuple_SET_ITEM(__clinic_args, i, Py_NewRef(args[0 + i]));
     }
-    return_value = set_update_impl(self, __clinic_args);
+    return_value = set_update_impl(so, __clinic_args);
 
 exit:
     Py_XDECREF(__clinic_args);
@@ -69,12 +69,12 @@ PyDoc_STRVAR(set_copy__doc__,
     {"copy", (PyCFunction)set_copy, METH_NOARGS, set_copy__doc__},
 
 static PyObject *
-set_copy_impl(PySetObject *self);
+set_copy_impl(PySetObject *so);
 
 static PyObject *
-set_copy(PySetObject *self, PyObject *Py_UNUSED(ignored))
+set_copy(PySetObject *so, PyObject *Py_UNUSED(ignored))
 {
-    return set_copy_impl(self);
+    return set_copy_impl(so);
 }
 
 PyDoc_STRVAR(frozenset_copy__doc__,
@@ -87,12 +87,12 @@ PyDoc_STRVAR(frozenset_copy__doc__,
     {"copy", (PyCFunction)frozenset_copy, METH_NOARGS, frozenset_copy__doc__},
 
 static PyObject *
-frozenset_copy_impl(PySetObject *self);
+frozenset_copy_impl(PySetObject *so);
 
 static PyObject *
-frozenset_copy(PySetObject *self, PyObject *Py_UNUSED(ignored))
+frozenset_copy(PySetObject *so, PyObject *Py_UNUSED(ignored))
 {
-    return frozenset_copy_impl(self);
+    return frozenset_copy_impl(so);
 }
 
 PyDoc_STRVAR(set_clear__doc__,
@@ -105,12 +105,12 @@ PyDoc_STRVAR(set_clear__doc__,
     {"clear", (PyCFunction)set_clear, METH_NOARGS, set_clear__doc__},
 
 static PyObject *
-set_clear_impl(PySetObject *self);
+set_clear_impl(PySetObject *so);
 
 static PyObject *
-set_clear(PySetObject *self, PyObject *Py_UNUSED(ignored))
+set_clear(PySetObject *so, PyObject *Py_UNUSED(ignored))
 {
-    return set_clear_impl(self);
+    return set_clear_impl(so);
 }
 
 PyDoc_STRVAR(set_union__doc__,
@@ -123,10 +123,10 @@ PyDoc_STRVAR(set_union__doc__,
     {"union", _PyCFunction_CAST(set_union), METH_FASTCALL, set_union__doc__},
 
 static PyObject *
-set_union_impl(PySetObject *self, PyObject *args);
+set_union_impl(PySetObject *so, PyObject *args);
 
 static PyObject *
-set_union(PySetObject *self, PyObject *const *args, Py_ssize_t nargs)
+set_union(PySetObject *so, PyObject *const *args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     PyObject *__clinic_args = NULL;
@@ -141,7 +141,7 @@ set_union(PySetObject *self, PyObject *const *args, Py_ssize_t nargs)
     for (Py_ssize_t i = 0; i < nargs - 0; ++i) {
         PyTuple_SET_ITEM(__clinic_args, i, Py_NewRef(args[0 + i]));
     }
-    return_value = set_union_impl(self, __clinic_args);
+    return_value = set_union_impl(so, __clinic_args);
 
 exit:
     Py_XDECREF(__clinic_args);
@@ -158,10 +158,10 @@ PyDoc_STRVAR(set_intersection_multi__doc__,
     {"intersection", _PyCFunction_CAST(set_intersection_multi), METH_FASTCALL, set_intersection_multi__doc__},
 
 static PyObject *
-set_intersection_multi_impl(PySetObject *self, PyObject *args);
+set_intersection_multi_impl(PySetObject *so, PyObject *args);
 
 static PyObject *
-set_intersection_multi(PySetObject *self, PyObject *const *args, Py_ssize_t nargs)
+set_intersection_multi(PySetObject *so, PyObject *const *args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     PyObject *__clinic_args = NULL;
@@ -176,7 +176,7 @@ set_intersection_multi(PySetObject *self, PyObject *const *args, Py_ssize_t narg
     for (Py_ssize_t i = 0; i < nargs - 0; ++i) {
         PyTuple_SET_ITEM(__clinic_args, i, Py_NewRef(args[0 + i]));
     }
-    return_value = set_intersection_multi_impl(self, __clinic_args);
+    return_value = set_intersection_multi_impl(so, __clinic_args);
 
 exit:
     Py_XDECREF(__clinic_args);
@@ -193,10 +193,10 @@ PyDoc_STRVAR(set_intersection_update_multi__doc__,
     {"intersection_update", _PyCFunction_CAST(set_intersection_update_multi), METH_FASTCALL, set_intersection_update_multi__doc__},
 
 static PyObject *
-set_intersection_update_multi_impl(PySetObject *self, PyObject *args);
+set_intersection_update_multi_impl(PySetObject *so, PyObject *args);
 
 static PyObject *
-set_intersection_update_multi(PySetObject *self, PyObject *const *args, Py_ssize_t nargs)
+set_intersection_update_multi(PySetObject *so, PyObject *const *args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     PyObject *__clinic_args = NULL;
@@ -211,7 +211,7 @@ set_intersection_update_multi(PySetObject *self, PyObject *const *args, Py_ssize
     for (Py_ssize_t i = 0; i < nargs - 0; ++i) {
         PyTuple_SET_ITEM(__clinic_args, i, Py_NewRef(args[0 + i]));
     }
-    return_value = set_intersection_update_multi_impl(self, __clinic_args);
+    return_value = set_intersection_update_multi_impl(so, __clinic_args);
 
 exit:
     Py_XDECREF(__clinic_args);
@@ -237,10 +237,10 @@ PyDoc_STRVAR(set_difference_update__doc__,
     {"difference_update", _PyCFunction_CAST(set_difference_update), METH_FASTCALL, set_difference_update__doc__},
 
 static PyObject *
-set_difference_update_impl(PySetObject *self, PyObject *args);
+set_difference_update_impl(PySetObject *so, PyObject *args);
 
 static PyObject *
-set_difference_update(PySetObject *self, PyObject *const *args, Py_ssize_t nargs)
+set_difference_update(PySetObject *so, PyObject *const *args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     PyObject *__clinic_args = NULL;
@@ -255,7 +255,7 @@ set_difference_update(PySetObject *self, PyObject *const *args, Py_ssize_t nargs
     for (Py_ssize_t i = 0; i < nargs - 0; ++i) {
         PyTuple_SET_ITEM(__clinic_args, i, Py_NewRef(args[0 + i]));
     }
-    return_value = set_difference_update_impl(self, __clinic_args);
+    return_value = set_difference_update_impl(so, __clinic_args);
 
 exit:
     Py_XDECREF(__clinic_args);
@@ -272,10 +272,10 @@ PyDoc_STRVAR(set_difference_multi__doc__,
     {"difference", _PyCFunction_CAST(set_difference_multi), METH_FASTCALL, set_difference_multi__doc__},
 
 static PyObject *
-set_difference_multi_impl(PySetObject *self, PyObject *args);
+set_difference_multi_impl(PySetObject *so, PyObject *args);
 
 static PyObject *
-set_difference_multi(PySetObject *self, PyObject *const *args, Py_ssize_t nargs)
+set_difference_multi(PySetObject *so, PyObject *const *args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     PyObject *__clinic_args = NULL;
@@ -290,7 +290,7 @@ set_difference_multi(PySetObject *self, PyObject *const *args, Py_ssize_t nargs)
     for (Py_ssize_t i = 0; i < nargs - 0; ++i) {
         PyTuple_SET_ITEM(__clinic_args, i, Py_NewRef(args[0 + i]));
     }
-    return_value = set_difference_multi_impl(self, __clinic_args);
+    return_value = set_difference_multi_impl(so, __clinic_args);
 
 exit:
     Py_XDECREF(__clinic_args);
@@ -385,12 +385,12 @@ PyDoc_STRVAR(set___reduce____doc__,
     {"__reduce__", (PyCFunction)set___reduce__, METH_NOARGS, set___reduce____doc__},
 
 static PyObject *
-set___reduce___impl(PySetObject *self);
+set___reduce___impl(PySetObject *so);
 
 static PyObject *
-set___reduce__(PySetObject *self, PyObject *Py_UNUSED(ignored))
+set___reduce__(PySetObject *so, PyObject *Py_UNUSED(ignored))
 {
-    return set___reduce___impl(self);
+    return set___reduce___impl(so);
 }
 
 PyDoc_STRVAR(set___sizeof____doc__,
@@ -403,11 +403,11 @@ PyDoc_STRVAR(set___sizeof____doc__,
     {"__sizeof__", (PyCFunction)set___sizeof__, METH_NOARGS, set___sizeof____doc__},
 
 static PyObject *
-set___sizeof___impl(PySetObject *self);
+set___sizeof___impl(PySetObject *so);
 
 static PyObject *
-set___sizeof__(PySetObject *self, PyObject *Py_UNUSED(ignored))
+set___sizeof__(PySetObject *so, PyObject *Py_UNUSED(ignored))
 {
-    return set___sizeof___impl(self);
+    return set___sizeof___impl(so);
 }
-/*[clinic end generated code: output=65d5a0a49654e8ee input=a9049054013a1b77]*/
+/*[clinic end generated code: output=ff816e6e7e27b60e input=a9049054013a1b77]*/

--- a/Objects/clinic/setobject.c.h
+++ b/Objects/clinic/setobject.c.h
@@ -2,6 +2,8 @@
 preserve
 [clinic start generated code]*/
 
+#include "pycore_modsupport.h"    // _PyArg_CheckPositional()
+
 PyDoc_STRVAR(set_pop__doc__,
 "pop($self, /)\n"
 "--\n"
@@ -20,6 +22,41 @@ static PyObject *
 set_pop(PySetObject *self, PyObject *Py_UNUSED(ignored))
 {
     return set_pop_impl(self);
+}
+
+PyDoc_STRVAR(set_update__doc__,
+"update($self, /, *args)\n"
+"--\n"
+"\n"
+"Update the set, adding elements from all others.");
+
+#define SET_UPDATE_METHODDEF    \
+    {"update", _PyCFunction_CAST(set_update), METH_FASTCALL, set_update__doc__},
+
+static PyObject *
+set_update_impl(PySetObject *self, PyObject *args);
+
+static PyObject *
+set_update(PySetObject *self, PyObject *const *args, Py_ssize_t nargs)
+{
+    PyObject *return_value = NULL;
+    PyObject *__clinic_args = NULL;
+
+    if (!_PyArg_CheckPositional("update", nargs, 0, PY_SSIZE_T_MAX)) {
+        goto exit;
+    }
+    __clinic_args = PyTuple_New(nargs - 0);
+    if (!__clinic_args) {
+        goto exit;
+    }
+    for (Py_ssize_t i = 0; i < nargs - 0; ++i) {
+        PyTuple_SET_ITEM(__clinic_args, i, Py_NewRef(args[0 + i]));
+    }
+    return_value = set_update_impl(self, __clinic_args);
+
+exit:
+    Py_XDECREF(__clinic_args);
+    return return_value;
 }
 
 PyDoc_STRVAR(set_copy__doc__,
@@ -76,6 +113,111 @@ set_clear(PySetObject *self, PyObject *Py_UNUSED(ignored))
     return set_clear_impl(self);
 }
 
+PyDoc_STRVAR(set_union__doc__,
+"union($self, /, *args)\n"
+"--\n"
+"\n"
+"Return a new set with elements from the set and all others.");
+
+#define SET_UNION_METHODDEF    \
+    {"union", _PyCFunction_CAST(set_union), METH_FASTCALL, set_union__doc__},
+
+static PyObject *
+set_union_impl(PySetObject *self, PyObject *args);
+
+static PyObject *
+set_union(PySetObject *self, PyObject *const *args, Py_ssize_t nargs)
+{
+    PyObject *return_value = NULL;
+    PyObject *__clinic_args = NULL;
+
+    if (!_PyArg_CheckPositional("union", nargs, 0, PY_SSIZE_T_MAX)) {
+        goto exit;
+    }
+    __clinic_args = PyTuple_New(nargs - 0);
+    if (!__clinic_args) {
+        goto exit;
+    }
+    for (Py_ssize_t i = 0; i < nargs - 0; ++i) {
+        PyTuple_SET_ITEM(__clinic_args, i, Py_NewRef(args[0 + i]));
+    }
+    return_value = set_union_impl(self, __clinic_args);
+
+exit:
+    Py_XDECREF(__clinic_args);
+    return return_value;
+}
+
+PyDoc_STRVAR(set_intersection_multi__doc__,
+"intersection($self, /, *args)\n"
+"--\n"
+"\n"
+"Return a new set with elements common to the set and all others.");
+
+#define SET_INTERSECTION_MULTI_METHODDEF    \
+    {"intersection", _PyCFunction_CAST(set_intersection_multi), METH_FASTCALL, set_intersection_multi__doc__},
+
+static PyObject *
+set_intersection_multi_impl(PySetObject *self, PyObject *args);
+
+static PyObject *
+set_intersection_multi(PySetObject *self, PyObject *const *args, Py_ssize_t nargs)
+{
+    PyObject *return_value = NULL;
+    PyObject *__clinic_args = NULL;
+
+    if (!_PyArg_CheckPositional("intersection", nargs, 0, PY_SSIZE_T_MAX)) {
+        goto exit;
+    }
+    __clinic_args = PyTuple_New(nargs - 0);
+    if (!__clinic_args) {
+        goto exit;
+    }
+    for (Py_ssize_t i = 0; i < nargs - 0; ++i) {
+        PyTuple_SET_ITEM(__clinic_args, i, Py_NewRef(args[0 + i]));
+    }
+    return_value = set_intersection_multi_impl(self, __clinic_args);
+
+exit:
+    Py_XDECREF(__clinic_args);
+    return return_value;
+}
+
+PyDoc_STRVAR(set_intersection_update_multi__doc__,
+"intersection_update($self, /, *args)\n"
+"--\n"
+"\n"
+"Update the set, keeping only elements found in it and all others.");
+
+#define SET_INTERSECTION_UPDATE_MULTI_METHODDEF    \
+    {"intersection_update", _PyCFunction_CAST(set_intersection_update_multi), METH_FASTCALL, set_intersection_update_multi__doc__},
+
+static PyObject *
+set_intersection_update_multi_impl(PySetObject *self, PyObject *args);
+
+static PyObject *
+set_intersection_update_multi(PySetObject *self, PyObject *const *args, Py_ssize_t nargs)
+{
+    PyObject *return_value = NULL;
+    PyObject *__clinic_args = NULL;
+
+    if (!_PyArg_CheckPositional("intersection_update", nargs, 0, PY_SSIZE_T_MAX)) {
+        goto exit;
+    }
+    __clinic_args = PyTuple_New(nargs - 0);
+    if (!__clinic_args) {
+        goto exit;
+    }
+    for (Py_ssize_t i = 0; i < nargs - 0; ++i) {
+        PyTuple_SET_ITEM(__clinic_args, i, Py_NewRef(args[0 + i]));
+    }
+    return_value = set_intersection_update_multi_impl(self, __clinic_args);
+
+exit:
+    Py_XDECREF(__clinic_args);
+    return return_value;
+}
+
 PyDoc_STRVAR(set_isdisjoint__doc__,
 "isdisjoint($self, other, /)\n"
 "--\n"
@@ -84,6 +226,76 @@ PyDoc_STRVAR(set_isdisjoint__doc__,
 
 #define SET_ISDISJOINT_METHODDEF    \
     {"isdisjoint", (PyCFunction)set_isdisjoint, METH_O, set_isdisjoint__doc__},
+
+PyDoc_STRVAR(set_difference_update__doc__,
+"difference_update($self, /, *args)\n"
+"--\n"
+"\n"
+"Update the set, removing elements found in others.");
+
+#define SET_DIFFERENCE_UPDATE_METHODDEF    \
+    {"difference_update", _PyCFunction_CAST(set_difference_update), METH_FASTCALL, set_difference_update__doc__},
+
+static PyObject *
+set_difference_update_impl(PySetObject *self, PyObject *args);
+
+static PyObject *
+set_difference_update(PySetObject *self, PyObject *const *args, Py_ssize_t nargs)
+{
+    PyObject *return_value = NULL;
+    PyObject *__clinic_args = NULL;
+
+    if (!_PyArg_CheckPositional("difference_update", nargs, 0, PY_SSIZE_T_MAX)) {
+        goto exit;
+    }
+    __clinic_args = PyTuple_New(nargs - 0);
+    if (!__clinic_args) {
+        goto exit;
+    }
+    for (Py_ssize_t i = 0; i < nargs - 0; ++i) {
+        PyTuple_SET_ITEM(__clinic_args, i, Py_NewRef(args[0 + i]));
+    }
+    return_value = set_difference_update_impl(self, __clinic_args);
+
+exit:
+    Py_XDECREF(__clinic_args);
+    return return_value;
+}
+
+PyDoc_STRVAR(set_difference_multi__doc__,
+"difference($self, /, *args)\n"
+"--\n"
+"\n"
+"Return a new set with elements in the set that are not in the others.");
+
+#define SET_DIFFERENCE_MULTI_METHODDEF    \
+    {"difference", _PyCFunction_CAST(set_difference_multi), METH_FASTCALL, set_difference_multi__doc__},
+
+static PyObject *
+set_difference_multi_impl(PySetObject *self, PyObject *args);
+
+static PyObject *
+set_difference_multi(PySetObject *self, PyObject *const *args, Py_ssize_t nargs)
+{
+    PyObject *return_value = NULL;
+    PyObject *__clinic_args = NULL;
+
+    if (!_PyArg_CheckPositional("difference", nargs, 0, PY_SSIZE_T_MAX)) {
+        goto exit;
+    }
+    __clinic_args = PyTuple_New(nargs - 0);
+    if (!__clinic_args) {
+        goto exit;
+    }
+    for (Py_ssize_t i = 0; i < nargs - 0; ++i) {
+        PyTuple_SET_ITEM(__clinic_args, i, Py_NewRef(args[0 + i]));
+    }
+    return_value = set_difference_multi_impl(self, __clinic_args);
+
+exit:
+    Py_XDECREF(__clinic_args);
+    return return_value;
+}
 
 PyDoc_STRVAR(set_symmetric_difference_update__doc__,
 "symmetric_difference_update($self, other, /)\n"
@@ -198,4 +410,4 @@ set___sizeof__(PySetObject *self, PyObject *Py_UNUSED(ignored))
 {
     return set___sizeof___impl(self);
 }
-/*[clinic end generated code: output=37e660dbf15cd755 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=37d87f4add269f73 input=a9049054013a1b77]*/

--- a/Objects/clinic/setobject.c.h
+++ b/Objects/clinic/setobject.c.h
@@ -25,7 +25,7 @@ set_pop(PySetObject *so, PyObject *Py_UNUSED(ignored))
 }
 
 PyDoc_STRVAR(set_update__doc__,
-"update($self, /, *args)\n"
+"update($self, /, *others)\n"
 "--\n"
 "\n"
 "Update the set, adding elements from all others.");
@@ -114,7 +114,7 @@ set_clear(PySetObject *so, PyObject *Py_UNUSED(ignored))
 }
 
 PyDoc_STRVAR(set_union__doc__,
-"union($self, /, *args)\n"
+"union($self, /, *others)\n"
 "--\n"
 "\n"
 "Return a new set with elements from the set and all others.");
@@ -149,7 +149,7 @@ exit:
 }
 
 PyDoc_STRVAR(set_intersection_multi__doc__,
-"intersection($self, /, *args)\n"
+"intersection($self, /, *others)\n"
 "--\n"
 "\n"
 "Return a new set with elements common to the set and all others.");
@@ -184,7 +184,7 @@ exit:
 }
 
 PyDoc_STRVAR(set_intersection_update_multi__doc__,
-"intersection_update($self, /, *args)\n"
+"intersection_update($self, /, *others)\n"
 "--\n"
 "\n"
 "Update the set, keeping only elements found in it and all others.");
@@ -228,7 +228,7 @@ PyDoc_STRVAR(set_isdisjoint__doc__,
     {"isdisjoint", (PyCFunction)set_isdisjoint, METH_O, set_isdisjoint__doc__},
 
 PyDoc_STRVAR(set_difference_update__doc__,
-"difference_update($self, /, *args)\n"
+"difference_update($self, /, *others)\n"
 "--\n"
 "\n"
 "Update the set, removing elements found in others.");
@@ -263,7 +263,7 @@ exit:
 }
 
 PyDoc_STRVAR(set_difference_multi__doc__,
-"difference($self, /, *args)\n"
+"difference($self, /, *others)\n"
 "--\n"
 "\n"
 "Return a new set with elements in the set that are not in the others.");
@@ -410,4 +410,4 @@ set___sizeof__(PySetObject *so, PyObject *Py_UNUSED(ignored))
 {
     return set___sizeof___impl(so);
 }
-/*[clinic end generated code: output=2f8fb6e5ecc61832 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=596eac0cb2d68c8b input=a9049054013a1b77]*/

--- a/Objects/clinic/setobject.c.h
+++ b/Objects/clinic/setobject.c.h
@@ -334,7 +334,7 @@ PyDoc_STRVAR(set_issuperset__doc__,
     {"issuperset", (PyCFunction)set_issuperset, METH_O, set_issuperset__doc__},
 
 PyDoc_STRVAR(set_add__doc__,
-"add($self, object, /)\n"
+"add($self, key, /)\n"
 "--\n"
 "\n"
 "Add an element to a set.\n"
@@ -410,4 +410,4 @@ set___sizeof__(PySetObject *so, PyObject *Py_UNUSED(ignored))
 {
     return set___sizeof___impl(so);
 }
-/*[clinic end generated code: output=ff816e6e7e27b60e input=a9049054013a1b77]*/
+/*[clinic end generated code: output=fe260176c78a966f input=a9049054013a1b77]*/

--- a/Objects/clinic/setobject.c.h
+++ b/Objects/clinic/setobject.c.h
@@ -379,7 +379,8 @@ PyDoc_STRVAR(set_discard__doc__,
 PyDoc_STRVAR(set___reduce____doc__,
 "__reduce__($self, /)\n"
 "--\n"
-"\n");
+"\n"
+"Return state information for pickling.");
 
 #define SET___REDUCE___METHODDEF    \
     {"__reduce__", (PyCFunction)set___reduce__, METH_NOARGS, set___reduce____doc__},
@@ -410,4 +411,4 @@ set___sizeof__(PySetObject *so, PyObject *Py_UNUSED(ignored))
 {
     return set___sizeof___impl(so);
 }
-/*[clinic end generated code: output=be9624a2053d5a76 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=34a30591148da884 input=a9049054013a1b77]*/

--- a/Objects/clinic/setobject.c.h
+++ b/Objects/clinic/setobject.c.h
@@ -334,7 +334,7 @@ PyDoc_STRVAR(set_issuperset__doc__,
     {"issuperset", (PyCFunction)set_issuperset, METH_O, set_issuperset__doc__},
 
 PyDoc_STRVAR(set_add__doc__,
-"add($self, key, /)\n"
+"add($self, object, /)\n"
 "--\n"
 "\n"
 "Add an element to a set.\n"
@@ -345,7 +345,7 @@ PyDoc_STRVAR(set_add__doc__,
     {"add", (PyCFunction)set_add, METH_O, set_add__doc__},
 
 PyDoc_STRVAR(set___contains____doc__,
-"__contains__($self, key, /)\n"
+"__contains__($self, object, /)\n"
 "--\n"
 "\n"
 "x.__contains__(y) <==> y in x.");
@@ -354,7 +354,7 @@ PyDoc_STRVAR(set___contains____doc__,
     {"__contains__", (PyCFunction)set___contains__, METH_O|METH_COEXIST, set___contains____doc__},
 
 PyDoc_STRVAR(set_remove__doc__,
-"remove($self, key, /)\n"
+"remove($self, object, /)\n"
 "--\n"
 "\n"
 "Remove an element from a set; it must be a member.\n"
@@ -365,7 +365,7 @@ PyDoc_STRVAR(set_remove__doc__,
     {"remove", (PyCFunction)set_remove, METH_O, set_remove__doc__},
 
 PyDoc_STRVAR(set_discard__doc__,
-"discard($self, key, /)\n"
+"discard($self, object, /)\n"
 "--\n"
 "\n"
 "Remove an element from a set if it is a member.\n"
@@ -410,4 +410,4 @@ set___sizeof__(PySetObject *so, PyObject *Py_UNUSED(ignored))
 {
     return set___sizeof___impl(so);
 }
-/*[clinic end generated code: output=596eac0cb2d68c8b input=a9049054013a1b77]*/
+/*[clinic end generated code: output=be9624a2053d5a76 input=a9049054013a1b77]*/

--- a/Objects/clinic/setobject.c.h
+++ b/Objects/clinic/setobject.c.h
@@ -351,7 +351,7 @@ PyDoc_STRVAR(set___contains____doc__,
 "x.__contains__(y) <==> y in x.");
 
 #define SET___CONTAINS___METHODDEF    \
-    {"__contains__", (PyCFunction)set___contains__, METH_O, set___contains____doc__},
+    {"__contains__", (PyCFunction)set___contains__, METH_O|METH_COEXIST, set___contains____doc__},
 
 PyDoc_STRVAR(set_remove__doc__,
 "remove($self, key, /)\n"
@@ -410,4 +410,4 @@ set___sizeof__(PySetObject *self, PyObject *Py_UNUSED(ignored))
 {
     return set___sizeof___impl(self);
 }
-/*[clinic end generated code: output=37d87f4add269f73 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=65d5a0a49654e8ee input=a9049054013a1b77]*/

--- a/Objects/clinic/setobject.c.h
+++ b/Objects/clinic/setobject.c.h
@@ -345,7 +345,7 @@ PyDoc_STRVAR(set_add__doc__,
     {"add", (PyCFunction)set_add, METH_O, set_add__doc__},
 
 PyDoc_STRVAR(set___contains____doc__,
-"__contains__($self, object, /)\n"
+"__contains__($self, key, /)\n"
 "--\n"
 "\n"
 "x.__contains__(y) <==> y in x.");
@@ -410,4 +410,4 @@ set___sizeof__(PySetObject *so, PyObject *Py_UNUSED(ignored))
 {
     return set___sizeof___impl(so);
 }
-/*[clinic end generated code: output=fe260176c78a966f input=a9049054013a1b77]*/
+/*[clinic end generated code: output=2f8fb6e5ecc61832 input=a9049054013a1b77]*/

--- a/Objects/setobject.c
+++ b/Objects/setobject.c
@@ -2107,6 +2107,7 @@ set_discard(PySetObject *so, PyObject *key)
 set.__reduce__
     so: setobject
 
+Return state information for pickling.
 [clinic start generated code]*/
 
 static PyObject *

--- a/Objects/setobject.c
+++ b/Objects/setobject.c
@@ -2028,19 +2028,19 @@ set_contains(PySetObject *so, PyObject *key)
 set.__contains__
 
     so: setobject
-    object: object
+    key: object
     /
 
 x.__contains__(y) <==> y in x.
 [clinic start generated code]*/
 
 static PyObject *
-set___contains__(PySetObject *so, PyObject *object)
-/*[clinic end generated code: output=6d8f64ba8d2916b8 input=17757c9340b19260]*/
+set___contains__(PySetObject *so, PyObject *key)
+/*[clinic end generated code: output=b5948bc5c590d3ca input=f21c9825df8663e2]*/
 {
     long result;
 
-    result = set_contains(so, object);
+    result = set_contains(so, key);
     if (result < 0)
         return NULL;
     return PyBool_FromLong(result);

--- a/Objects/setobject.c
+++ b/Objects/setobject.c
@@ -948,24 +948,28 @@ exit:
     return 0;
 }
 
+/*[clinic input]
+set.update
+
+    *args: object
+    /
+
+Update the set, adding elements from all others.
+[clinic start generated code]*/
+
 static PyObject *
-set_update(PySetObject *so, PyObject *args)
+set_update_impl(PySetObject *self, PyObject *args)
+/*[clinic end generated code: output=efaf3d49e9611bda input=71713e1a28691fcd]*/
 {
     Py_ssize_t i;
 
     for (i=0 ; i<PyTuple_GET_SIZE(args) ; i++) {
         PyObject *other = PyTuple_GET_ITEM(args, i);
-        if (set_update_internal(so, other))
+        if (set_update_internal(self, other))
             return NULL;
     }
     Py_RETURN_NONE;
 }
-
-PyDoc_STRVAR(update_doc,
-"update($self, /, *others)\n\
---\n\
-\n\
-Update the set, adding elements from all others.");
 
 /* XXX Todo:
    If aligned memory allocations become available, make the
@@ -1157,20 +1161,30 @@ set_clear_impl(PySetObject *self)
     Py_RETURN_NONE;
 }
 
+/*[clinic input]
+set.union
+
+    *args: object
+    /
+
+Return a new set with elements from the set and all others.
+[clinic start generated code]*/
+
 static PyObject *
-set_union(PySetObject *so, PyObject *args)
+set_union_impl(PySetObject *self, PyObject *args)
+/*[clinic end generated code: output=5e33934d81d0a329 input=106fa6f2c3972f37]*/
 {
     PySetObject *result;
     PyObject *other;
     Py_ssize_t i;
 
-    result = (PySetObject *)set_copy(so, NULL);
+    result = (PySetObject *)set_copy(self, NULL);
     if (result == NULL)
         return NULL;
 
     for (i=0 ; i<PyTuple_GET_SIZE(args) ; i++) {
         other = PyTuple_GET_ITEM(args, i);
-        if ((PyObject *)so == other)
+        if ((PyObject *)self == other)
             continue;
         if (set_update_internal(result, other)) {
             Py_DECREF(result);
@@ -1179,12 +1193,6 @@ set_union(PySetObject *so, PyObject *args)
     }
     return (PyObject *)result;
 }
-
-PyDoc_STRVAR(union_doc,
-"union($self, /, *others)\n\
---\n\
-\n\
-Return a new set with elements from the set and all others.");
 
 static PyObject *
 set_or(PySetObject *so, PyObject *other)
@@ -1300,15 +1308,25 @@ set_intersection(PySetObject *so, PyObject *other)
     return NULL;
 }
 
+/*[clinic input]
+set.intersection as set_intersection_multi
+
+    *args: object
+    /
+
+Return a new set with elements common to the set and all others.
+[clinic start generated code]*/
+
 static PyObject *
-set_intersection_multi(PySetObject *so, PyObject *args)
+set_intersection_multi_impl(PySetObject *self, PyObject *args)
+/*[clinic end generated code: output=dbdd037cc40eb5d8 input=a14c68f7f2435f4c]*/
 {
     Py_ssize_t i;
 
     if (PyTuple_GET_SIZE(args) == 0)
-        return set_copy(so, NULL);
+        return set_copy(self, NULL);
 
-    PyObject *result = Py_NewRef(so);
+    PyObject *result = Py_NewRef(self);
     for (i=0 ; i<PyTuple_GET_SIZE(args) ; i++) {
         PyObject *other = PyTuple_GET_ITEM(args, i);
         PyObject *newresult = set_intersection((PySetObject *)result, other);
@@ -1320,12 +1338,6 @@ set_intersection_multi(PySetObject *so, PyObject *args)
     }
     return result;
 }
-
-PyDoc_STRVAR(intersection_doc,
-"intersection($self, /, *others)\n\
---\n\
-\n\
-Return a new set with elements common to the set and all others.");
 
 static PyObject *
 set_intersection_update(PySetObject *so, PyObject *other)
@@ -1340,24 +1352,28 @@ set_intersection_update(PySetObject *so, PyObject *other)
     Py_RETURN_NONE;
 }
 
+/*[clinic input]
+set.intersection_update as set_intersection_update_multi
+
+    *args: object
+    /
+
+Update the set, keeping only elements found in it and all others.
+[clinic start generated code]*/
+
 static PyObject *
-set_intersection_update_multi(PySetObject *so, PyObject *args)
+set_intersection_update_multi_impl(PySetObject *self, PyObject *args)
+/*[clinic end generated code: output=526c2a852b0b14b5 input=0ae6a0e699ecc583]*/
 {
     PyObject *tmp;
 
-    tmp = set_intersection_multi(so, args);
+    tmp = set_intersection_multi_impl(self, args);
     if (tmp == NULL)
         return NULL;
-    set_swap_bodies(so, (PySetObject *)tmp);
+    set_swap_bodies(self, (PySetObject *)tmp);
     Py_DECREF(tmp);
     Py_RETURN_NONE;
 }
-
-PyDoc_STRVAR(intersection_update_doc,
-"intersection_update($self, /, *others)\n\
---\n\
-\n\
-Update the set, keeping only elements found in it and all others.");
 
 static PyObject *
 set_and(PySetObject *so, PyObject *other)
@@ -1383,6 +1399,7 @@ set_iand(PySetObject *so, PyObject *other)
 
 /*[clinic input]
 set.isdisjoint
+
     other: object
     /
 
@@ -1391,7 +1408,7 @@ Return True if two sets have a null intersection.
 
 static PyObject *
 set_isdisjoint(PySetObject *self, PyObject *other)
-/*[clinic end generated code: output=8b185ae5ab9b8e44 input=7c3df6c51abd2aec]*/
+/*[clinic end generated code: output=8b185ae5ab9b8e44 input=640023e29f94cb40]*/
 {
     PyObject *key, *it, *tmp;
     int rv;
@@ -1507,24 +1524,28 @@ set_difference_update_internal(PySetObject *so, PyObject *other)
     return set_table_resize(so, so->used>50000 ? so->used*2 : so->used*4);
 }
 
+/*[clinic input]
+set.difference_update
+
+    *args: object
+    /
+
+Update the set, removing elements found in others.
+[clinic start generated code]*/
+
 static PyObject *
-set_difference_update(PySetObject *so, PyObject *args)
+set_difference_update_impl(PySetObject *self, PyObject *args)
+/*[clinic end generated code: output=eda858511229d686 input=b45087cd5539c982]*/
 {
     Py_ssize_t i;
 
     for (i=0 ; i<PyTuple_GET_SIZE(args) ; i++) {
         PyObject *other = PyTuple_GET_ITEM(args, i);
-        if (set_difference_update_internal(so, other))
+        if (set_difference_update_internal(self, other))
             return NULL;
     }
     Py_RETURN_NONE;
 }
-
-PyDoc_STRVAR(difference_update_doc,
-"difference_update($self, /, *others)\n\
---\n\
-\n\
-Update the set, removing elements found in others.");
 
 static PyObject *
 set_copy_and_difference(PySetObject *so, PyObject *other)
@@ -1616,17 +1637,27 @@ set_difference(PySetObject *so, PyObject *other)
     return result;
 }
 
+/*[clinic input]
+set.difference as set_difference_multi
+
+    *args: object
+    /
+
+Return a new set with elements in the set that are not in the others.
+[clinic start generated code]*/
+
 static PyObject *
-set_difference_multi(PySetObject *so, PyObject *args)
+set_difference_multi_impl(PySetObject *self, PyObject *args)
+/*[clinic end generated code: output=073e94724f240a6d input=95b48a72f1c103ac]*/
 {
     Py_ssize_t i;
     PyObject *result, *other;
 
     if (PyTuple_GET_SIZE(args) == 0)
-        return set_copy(so, NULL);
+        return set_copy(self, NULL);
 
     other = PyTuple_GET_ITEM(args, 0);
-    result = set_difference(so, other);
+    result = set_difference(self, other);
     if (result == NULL)
         return NULL;
 
@@ -1640,11 +1671,6 @@ set_difference_multi(PySetObject *so, PyObject *args)
     return result;
 }
 
-PyDoc_STRVAR(difference_doc,
-"difference($self, /, *others)\n\
---\n\
-\n\
-Return a new set with elements in the set that are not in the others.");
 static PyObject *
 set_sub(PySetObject *so, PyObject *other)
 {
@@ -2169,14 +2195,10 @@ static PyMethodDef set_methods[] = {
     SET___CONTAINS___METHODDEF
     SET_COPY_METHODDEF
     SET_DISCARD_METHODDEF
-    {"difference",      (PyCFunction)set_difference_multi,      METH_VARARGS,
-     difference_doc},
-    {"difference_update",       (PyCFunction)set_difference_update,     METH_VARARGS,
-     difference_update_doc},
-    {"intersection",(PyCFunction)set_intersection_multi,        METH_VARARGS,
-     intersection_doc},
-    {"intersection_update",(PyCFunction)set_intersection_update_multi,          METH_VARARGS,
-     intersection_update_doc},
+    SET_DIFFERENCE_MULTI_METHODDEF
+    SET_DIFFERENCE_UPDATE_METHODDEF
+    SET_INTERSECTION_MULTI_METHODDEF
+    SET_INTERSECTION_UPDATE_MULTI_METHODDEF
     SET_ISDISJOINT_METHODDEF
     SET_ISSUBSET_METHODDEF
     SET_ISSUPERSET_METHODDEF
@@ -2186,10 +2208,8 @@ static PyMethodDef set_methods[] = {
     SET___SIZEOF___METHODDEF
     SET_SYMMETRIC_DIFFERENCE_METHODDEF
     SET_SYMMETRIC_DIFFERENCE_UPDATE_METHODDEF
-    {"union",           (PyCFunction)set_union,         METH_VARARGS,
-     union_doc},
-    {"update",          (PyCFunction)set_update,        METH_VARARGS,
-     update_doc},
+    SET_UNION_METHODDEF
+    SET_UPDATE_METHODDEF
     {"__class_getitem__", Py_GenericAlias, METH_O|METH_CLASS, PyDoc_STR("See PEP 585")},
     {NULL,              NULL}   /* sentinel */
 };
@@ -2284,18 +2304,15 @@ PyTypeObject PySet_Type = {
 static PyMethodDef frozenset_methods[] = {
     SET___CONTAINS___METHODDEF
     FROZENSET_COPY_METHODDEF
-    {"difference",      (PyCFunction)set_difference_multi,      METH_VARARGS,
-     difference_doc},
-    {"intersection",    (PyCFunction)set_intersection_multi,    METH_VARARGS,
-     intersection_doc},
+    SET_DIFFERENCE_MULTI_METHODDEF
+    SET_INTERSECTION_MULTI_METHODDEF
     SET_ISDISJOINT_METHODDEF
     SET_ISSUBSET_METHODDEF
     SET_ISSUPERSET_METHODDEF
     SET___REDUCE___METHODDEF
     SET___SIZEOF___METHODDEF
     SET_SYMMETRIC_DIFFERENCE_METHODDEF
-    {"union",           (PyCFunction)set_union,         METH_VARARGS,
-     union_doc},
+    SET_UNION_METHODDEF
     {"__class_getitem__", Py_GenericAlias, METH_O|METH_CLASS, PyDoc_STR("See PEP 585")},
     {NULL,              NULL}   /* sentinel */
 };

--- a/Objects/setobject.c
+++ b/Objects/setobject.c
@@ -48,6 +48,12 @@ class frozenset "PySetObject *" "&PyFrozenSet_Type"
 [clinic start generated code]*/
 /*[clinic end generated code: output=da39a3ee5e6b4b0d input=97ad1d3e9f117079]*/
 
+/*[python input]
+class setobject_converter(self_converter):
+    type = "PySetObject *"
+[python start generated code]*/
+/*[python end generated code: output=da39a3ee5e6b4b0d input=33a44506d4d57793]*/
+
 /* Object used as dummy key to fill deleted entries */
 static PyObject _dummy_struct;
 
@@ -641,34 +647,36 @@ set_merge(PySetObject *so, PyObject *otherset)
 /*[clinic input]
 set.pop
 
+    so: setobject
+
 Remove and return an arbitrary set element.
 
 Raises KeyError if the set is empty.
 [clinic start generated code]*/
 
 static PyObject *
-set_pop_impl(PySetObject *self)
-/*[clinic end generated code: output=bf7ef01d2a364703 input=4a02ec3ab60c88fb]*/
+set_pop_impl(PySetObject *so)
+/*[clinic end generated code: output=4d65180f1271871b input=a48194117ea1e63a]*/
 {
     /* Make sure the search finger is in bounds */
-    setentry *entry = self->table + (self->finger & self->mask);
-    setentry *limit = self->table + self->mask;
+    setentry *entry = so->table + (so->finger & so->mask);
+    setentry *limit = so->table + so->mask;
     PyObject *key;
 
-    if (self->used == 0) {
+    if (so->used == 0) {
         PyErr_SetString(PyExc_KeyError, "pop from an empty set");
         return NULL;
     }
     while (entry->key == NULL || entry->key==dummy) {
         entry++;
         if (entry > limit)
-            entry = self->table;
+            entry = so->table;
     }
     key = entry->key;
     entry->key = dummy;
     entry->hash = -1;
-    self->used--;
-    self->finger = entry - self->table + 1;   /* next place to start */
+    so->used--;
+    so->finger = entry - so->table + 1;   /* next place to start */
     return key;
 }
 
@@ -951,6 +959,7 @@ exit:
 /*[clinic input]
 set.update
 
+    so: setobject
     *args: object
     /
 
@@ -958,14 +967,14 @@ Update the set, adding elements from all others.
 [clinic start generated code]*/
 
 static PyObject *
-set_update_impl(PySetObject *self, PyObject *args)
-/*[clinic end generated code: output=efaf3d49e9611bda input=71713e1a28691fcd]*/
+set_update_impl(PySetObject *so, PyObject *args)
+/*[clinic end generated code: output=34f6371704974c8a input=a4dc6ead0d0dd452]*/
 {
     Py_ssize_t i;
 
     for (i=0 ; i<PyTuple_GET_SIZE(args) ; i++) {
         PyObject *other = PyTuple_GET_ITEM(args, i);
-        if (set_update_internal(self, other))
+        if (set_update_internal(so, other))
             return NULL;
     }
     Py_RETURN_NONE;
@@ -1121,49 +1130,56 @@ set_swap_bodies(PySetObject *a, PySetObject *b)
 /*[clinic input]
 set.copy
 
+    so: setobject
+
 Return a shallow copy of a set.
 [clinic start generated code]*/
 
 static PyObject *
-set_copy_impl(PySetObject *self)
-/*[clinic end generated code: output=db3ef842e70a8bda input=506bf38397e748ab]*/
+set_copy_impl(PySetObject *so)
+/*[clinic end generated code: output=c9223a1e1cc6b041 input=9bb66f7d227269a5]*/
 {
-    return make_new_set_basetype(Py_TYPE(self), (PyObject *)self);
+    return make_new_set_basetype(Py_TYPE(so), (PyObject *)so);
 }
 
 /*[clinic input]
 frozenset.copy
 
+    so: setobject
+
 Return a shallow copy of a set.
 [clinic start generated code]*/
 
 static PyObject *
-frozenset_copy_impl(PySetObject *self)
-/*[clinic end generated code: output=3ff78c0546ebeafd input=b10118ca804b0780]*/
+frozenset_copy_impl(PySetObject *so)
+/*[clinic end generated code: output=b356263526af9e70 input=ed001ffd5277ddd3]*/
 {
-    if (PyFrozenSet_CheckExact(self)) {
-        return Py_NewRef(self);
+    if (PyFrozenSet_CheckExact(so)) {
+        return Py_NewRef(so);
     }
-    return set_copy(self, NULL);
+    return set_copy(so, NULL);
 }
 
 /*[clinic input]
 set.clear
 
+    so: setobject
+
 Remove all elements from this set.
 [clinic start generated code]*/
 
 static PyObject *
-set_clear_impl(PySetObject *self)
-/*[clinic end generated code: output=13dbb9952f84dbcf input=ac9375b8119b6561]*/
+set_clear_impl(PySetObject *so)
+/*[clinic end generated code: output=4e71d5a83904161a input=3c560e2f9ae62e5c]*/
 {
-    set_clear_internal(self);
+    set_clear_internal(so);
     Py_RETURN_NONE;
 }
 
 /*[clinic input]
 set.union
 
+    so: setobject
     *args: object
     /
 
@@ -1171,20 +1187,20 @@ Return a new set with elements from the set and all others.
 [clinic start generated code]*/
 
 static PyObject *
-set_union_impl(PySetObject *self, PyObject *args)
-/*[clinic end generated code: output=5e33934d81d0a329 input=106fa6f2c3972f37]*/
+set_union_impl(PySetObject *so, PyObject *args)
+/*[clinic end generated code: output=2c83d05a446a1477 input=24ed124df9b6221c]*/
 {
     PySetObject *result;
     PyObject *other;
     Py_ssize_t i;
 
-    result = (PySetObject *)set_copy(self, NULL);
+    result = (PySetObject *)set_copy(so, NULL);
     if (result == NULL)
         return NULL;
 
     for (i=0 ; i<PyTuple_GET_SIZE(args) ; i++) {
         other = PyTuple_GET_ITEM(args, i);
-        if ((PyObject *)self == other)
+        if ((PyObject *)so == other)
             continue;
         if (set_update_internal(result, other)) {
             Py_DECREF(result);
@@ -1311,6 +1327,7 @@ set_intersection(PySetObject *so, PyObject *other)
 /*[clinic input]
 set.intersection as set_intersection_multi
 
+    so: setobject
     *args: object
     /
 
@@ -1318,15 +1335,15 @@ Return a new set with elements common to the set and all others.
 [clinic start generated code]*/
 
 static PyObject *
-set_intersection_multi_impl(PySetObject *self, PyObject *args)
-/*[clinic end generated code: output=dbdd037cc40eb5d8 input=a14c68f7f2435f4c]*/
+set_intersection_multi_impl(PySetObject *so, PyObject *args)
+/*[clinic end generated code: output=2406ef3387adbe2f input=7f9106301a661635]*/
 {
     Py_ssize_t i;
 
     if (PyTuple_GET_SIZE(args) == 0)
-        return set_copy(self, NULL);
+        return set_copy(so, NULL);
 
-    PyObject *result = Py_NewRef(self);
+    PyObject *result = Py_NewRef(so);
     for (i=0 ; i<PyTuple_GET_SIZE(args) ; i++) {
         PyObject *other = PyTuple_GET_ITEM(args, i);
         PyObject *newresult = set_intersection((PySetObject *)result, other);
@@ -1355,6 +1372,7 @@ set_intersection_update(PySetObject *so, PyObject *other)
 /*[clinic input]
 set.intersection_update as set_intersection_update_multi
 
+    so: setobject
     *args: object
     /
 
@@ -1362,15 +1380,15 @@ Update the set, keeping only elements found in it and all others.
 [clinic start generated code]*/
 
 static PyObject *
-set_intersection_update_multi_impl(PySetObject *self, PyObject *args)
-/*[clinic end generated code: output=526c2a852b0b14b5 input=0ae6a0e699ecc583]*/
+set_intersection_update_multi_impl(PySetObject *so, PyObject *args)
+/*[clinic end generated code: output=251c1f729063609d input=a0ea42761174e112]*/
 {
     PyObject *tmp;
 
-    tmp = set_intersection_multi_impl(self, args);
+    tmp = set_intersection_multi_impl(so, args);
     if (tmp == NULL)
         return NULL;
-    set_swap_bodies(self, (PySetObject *)tmp);
+    set_swap_bodies(so, (PySetObject *)tmp);
     Py_DECREF(tmp);
     Py_RETURN_NONE;
 }
@@ -1527,6 +1545,7 @@ set_difference_update_internal(PySetObject *so, PyObject *other)
 /*[clinic input]
 set.difference_update
 
+    so: setobject
     *args: object
     /
 
@@ -1534,14 +1553,14 @@ Update the set, removing elements found in others.
 [clinic start generated code]*/
 
 static PyObject *
-set_difference_update_impl(PySetObject *self, PyObject *args)
-/*[clinic end generated code: output=eda858511229d686 input=b45087cd5539c982]*/
+set_difference_update_impl(PySetObject *so, PyObject *args)
+/*[clinic end generated code: output=28685b2fc63e41c4 input=baadad04cef724f4]*/
 {
     Py_ssize_t i;
 
     for (i=0 ; i<PyTuple_GET_SIZE(args) ; i++) {
         PyObject *other = PyTuple_GET_ITEM(args, i);
-        if (set_difference_update_internal(self, other))
+        if (set_difference_update_internal(so, other))
             return NULL;
     }
     Py_RETURN_NONE;
@@ -1640,6 +1659,7 @@ set_difference(PySetObject *so, PyObject *other)
 /*[clinic input]
 set.difference as set_difference_multi
 
+    so: setobject
     *args: object
     /
 
@@ -1647,17 +1667,17 @@ Return a new set with elements in the set that are not in the others.
 [clinic start generated code]*/
 
 static PyObject *
-set_difference_multi_impl(PySetObject *self, PyObject *args)
-/*[clinic end generated code: output=073e94724f240a6d input=95b48a72f1c103ac]*/
+set_difference_multi_impl(PySetObject *so, PyObject *args)
+/*[clinic end generated code: output=3130c3bb3cac873d input=ec08ed06cc3db726]*/
 {
     Py_ssize_t i;
     PyObject *result, *other;
 
     if (PyTuple_GET_SIZE(args) == 0)
-        return set_copy(self, NULL);
+        return set_copy(so, NULL);
 
     other = PyTuple_GET_ITEM(args, 0);
-    result = set_difference(self, other);
+    result = set_difference(so, other);
     if (result == NULL)
         return NULL;
 
@@ -2096,24 +2116,26 @@ set_discard(PySetObject *self, PyObject *key)
 /*[clinic input]
 set.__reduce__
 
+    so: setobject
+
 [clinic start generated code]*/
 
 static PyObject *
-set___reduce___impl(PySetObject *self)
-/*[clinic end generated code: output=aa78615d54922c94 input=ed41fd7020072eb5]*/
+set___reduce___impl(PySetObject *so)
+/*[clinic end generated code: output=9af7d0e029df87ee input=4706de8175a7ba2e]*/
 {
     PyObject *keys=NULL, *args=NULL, *result=NULL, *state=NULL;
 
-    keys = PySequence_List((PyObject *)self);
+    keys = PySequence_List((PyObject *)so);
     if (keys == NULL)
         goto done;
     args = PyTuple_Pack(1, keys);
     if (args == NULL)
         goto done;
-    state = _PyObject_GetState((PyObject *)self);
+    state = _PyObject_GetState((PyObject *)so);
     if (state == NULL)
         goto done;
-    result = PyTuple_Pack(3, Py_TYPE(self), args, state);
+    result = PyTuple_Pack(3, Py_TYPE(so), args, state);
 done:
     Py_XDECREF(args);
     Py_XDECREF(keys);
@@ -2124,16 +2146,18 @@ done:
 /*[clinic input]
 set.__sizeof__
 
+    so: setobject
+
 S.__sizeof__() -> size of S in memory, in bytes.
 [clinic start generated code]*/
 
 static PyObject *
-set___sizeof___impl(PySetObject *self)
-/*[clinic end generated code: output=4678b5337e64f0d2 input=ddc9a6cd98b26850]*/
+set___sizeof___impl(PySetObject *so)
+/*[clinic end generated code: output=4bfa3df7bd38ed88 input=9e20ae73953cacf2]*/
 {
-    size_t res = _PyObject_SIZE(Py_TYPE(self));
-    if (self->table != self->smalltable) {
-        res += ((size_t)self->mask + 1) * sizeof(setentry);
+    size_t res = _PyObject_SIZE(Py_TYPE(so));
+    if (so->table != so->smalltable) {
+        res += ((size_t)so->mask + 1) * sizeof(setentry);
     }
     return PyLong_FromSize_t(res);
 }

--- a/Objects/setobject.c
+++ b/Objects/setobject.c
@@ -1418,6 +1418,7 @@ set_iand(PySetObject *so, PyObject *other)
 /*[clinic input]
 set.isdisjoint
 
+    so: setobject
     other: object
     /
 
@@ -1425,14 +1426,14 @@ Return True if two sets have a null intersection.
 [clinic start generated code]*/
 
 static PyObject *
-set_isdisjoint(PySetObject *self, PyObject *other)
-/*[clinic end generated code: output=8b185ae5ab9b8e44 input=640023e29f94cb40]*/
+set_isdisjoint(PySetObject *so, PyObject *other)
+/*[clinic end generated code: output=a92bbf9a2db6a3da input=370c62423287239a]*/
 {
     PyObject *key, *it, *tmp;
     int rv;
 
-    if ((PyObject *)self == other) {
-        if (PySet_GET_SIZE(self) == 0)
+    if ((PyObject *)so == other) {
+        if (PySet_GET_SIZE(so) == 0)
             Py_RETURN_TRUE;
         else
             Py_RETURN_FALSE;
@@ -1442,15 +1443,15 @@ set_isdisjoint(PySetObject *self, PyObject *other)
         Py_ssize_t pos = 0;
         setentry *entry;
 
-        if (PySet_GET_SIZE(other) > PySet_GET_SIZE(self)) {
-            tmp = (PyObject *)self;
-            self = (PySetObject *)other;
+        if (PySet_GET_SIZE(other) > PySet_GET_SIZE(so)) {
+            tmp = (PyObject *)so;
+            so = (PySetObject *)other;
             other = tmp;
         }
         while (set_next((PySetObject *)other, &pos, &entry)) {
             PyObject *key = entry->key;
             Py_INCREF(key);
-            rv = set_contains_entry(self, key, entry->hash);
+            rv = set_contains_entry(so, key, entry->hash);
             Py_DECREF(key);
             if (rv < 0) {
                 return NULL;
@@ -1467,7 +1468,7 @@ set_isdisjoint(PySetObject *self, PyObject *other)
         return NULL;
 
     while ((key = PyIter_Next(it)) != NULL) {
-        rv = set_contains_key(self, key);
+        rv = set_contains_key(so, key);
         Py_DECREF(key);
         if (rv < 0) {
             Py_DECREF(it);
@@ -1739,6 +1740,7 @@ set_symmetric_difference_update_dict(PySetObject *so, PyObject *other)
 /*[clinic input]
 set.symmetric_difference_update
 
+    so: setobject
     other: object
     /
 
@@ -1746,8 +1748,8 @@ Update the set, keeping only elements found in either set, but not in both.
 [clinic start generated code]*/
 
 static PyObject *
-set_symmetric_difference_update(PySetObject *self, PyObject *other)
-/*[clinic end generated code: output=3cf078be0891c22a input=231837ddd88b8781]*/
+set_symmetric_difference_update(PySetObject *so, PyObject *other)
+/*[clinic end generated code: output=fbb049c0806028de input=70e02c8b48a9a59e]*/
 {
     PySetObject *otherset;
     PyObject *key;
@@ -1756,14 +1758,14 @@ set_symmetric_difference_update(PySetObject *self, PyObject *other)
     setentry *entry;
     int rv;
 
-    if ((PyObject *)self == other)
-        return set_clear(self, NULL);
+    if ((PyObject *)so == other)
+        return set_clear(so, NULL);
 
     if (PyDict_CheckExact(other)) {
         PyObject *res;
 
         Py_BEGIN_CRITICAL_SECTION(other);
-        res = set_symmetric_difference_update_dict(self, other);
+        res = set_symmetric_difference_update_dict(so, other);
         Py_END_CRITICAL_SECTION();
 
         return res;
@@ -1772,7 +1774,7 @@ set_symmetric_difference_update(PySetObject *self, PyObject *other)
     if (PyAnySet_Check(other)) {
         otherset = (PySetObject *)Py_NewRef(other);
     } else {
-        otherset = (PySetObject *)make_new_set_basetype(Py_TYPE(self), other);
+        otherset = (PySetObject *)make_new_set_basetype(Py_TYPE(so), other);
         if (otherset == NULL)
             return NULL;
     }
@@ -1781,14 +1783,14 @@ set_symmetric_difference_update(PySetObject *self, PyObject *other)
         key = entry->key;
         hash = entry->hash;
         Py_INCREF(key);
-        rv = set_discard_entry(self, key, hash);
+        rv = set_discard_entry(so, key, hash);
         if (rv < 0) {
             Py_DECREF(otherset);
             Py_DECREF(key);
             return NULL;
         }
         if (rv == DISCARD_NOTFOUND) {
-            if (set_add_entry(self, key, hash)) {
+            if (set_add_entry(so, key, hash)) {
                 Py_DECREF(otherset);
                 Py_DECREF(key);
                 return NULL;
@@ -1803,6 +1805,7 @@ set_symmetric_difference_update(PySetObject *self, PyObject *other)
 /*[clinic input]
 set.symmetric_difference
 
+    so: setobject
     other: object
     /
 
@@ -1810,16 +1813,16 @@ Return a new set with elements in either the set or other but not both.
 [clinic start generated code]*/
 
 static PyObject *
-set_symmetric_difference(PySetObject *self, PyObject *other)
-/*[clinic end generated code: output=03941c1b5dfcff31 input=48971a6ed58e4919]*/
+set_symmetric_difference(PySetObject *so, PyObject *other)
+/*[clinic end generated code: output=f95364211b88775a input=f43dc971880c8685]*/
 {
     PyObject *rv;
     PySetObject *otherset;
 
-    otherset = (PySetObject *)make_new_set_basetype(Py_TYPE(self), other);
+    otherset = (PySetObject *)make_new_set_basetype(Py_TYPE(so), other);
     if (otherset == NULL)
         return NULL;
-    rv = set_symmetric_difference_update(otherset, (PyObject *)self);
+    rv = set_symmetric_difference_update(otherset, (PyObject *)so);
     if (rv == NULL) {
         Py_DECREF(otherset);
         return NULL;
@@ -1853,6 +1856,7 @@ set_ixor(PySetObject *so, PyObject *other)
 /*[clinic input]
 set.issubset
 
+    so: setobject
     other: object
     /
 
@@ -1860,26 +1864,26 @@ Report whether another set contains this set.
 [clinic start generated code]*/
 
 static PyObject *
-set_issubset(PySetObject *self, PyObject *other)
-/*[clinic end generated code: output=22e2a0324b4da0fa input=e1de2fc15128eb1f]*/
+set_issubset(PySetObject *so, PyObject *other)
+/*[clinic end generated code: output=78aef1f377aedef1 input=e141f29d1ac23b11]*/
 {
     setentry *entry;
     Py_ssize_t pos = 0;
     int rv;
 
     if (!PyAnySet_Check(other)) {
-        PyObject *tmp = set_intersection(self, other);
+        PyObject *tmp = set_intersection(so, other);
         if (tmp == NULL) {
             return NULL;
         }
-        int result = (PySet_GET_SIZE(tmp) == PySet_GET_SIZE(self));
+        int result = (PySet_GET_SIZE(tmp) == PySet_GET_SIZE(so));
         Py_DECREF(tmp);
         return PyBool_FromLong(result);
     }
-    if (PySet_GET_SIZE(self) > PySet_GET_SIZE(other))
+    if (PySet_GET_SIZE(so) > PySet_GET_SIZE(other))
         Py_RETURN_FALSE;
 
-    while (set_next(self, &pos, &entry)) {
+    while (set_next(so, &pos, &entry)) {
         PyObject *key = entry->key;
         Py_INCREF(key);
         rv = set_contains_entry((PySetObject *)other, key, entry->hash);
@@ -1897,6 +1901,7 @@ set_issubset(PySetObject *self, PyObject *other)
 /*[clinic input]
 set.issuperset
 
+    so: setobject
     other: object
     /
 
@@ -1904,11 +1909,11 @@ Report whether this set contains another set.
 [clinic start generated code]*/
 
 static PyObject *
-set_issuperset(PySetObject *self, PyObject *other)
-/*[clinic end generated code: output=76a4fd9cd31b6068 input=e6e12cc6d8a5c0ec]*/
+set_issuperset(PySetObject *so, PyObject *other)
+/*[clinic end generated code: output=7d2b71dd714a7ec7 input=d5ba4e35213dcbc6]*/
 {
     if (PyAnySet_Check(other)) {
-        return set_issubset((PySetObject *)other, (PyObject *)self);
+        return set_issubset((PySetObject *)other, (PyObject *)so);
     }
 
     PyObject *key, *it = PyObject_GetIter(other);
@@ -1916,7 +1921,7 @@ set_issuperset(PySetObject *self, PyObject *other)
         return NULL;
     }
     while ((key = PyIter_Next(it)) != NULL) {
-        int rv = set_contains_key(self, key);
+        int rv = set_contains_key(so, key);
         Py_DECREF(key);
         if (rv < 0) {
             Py_DECREF(it);
@@ -1980,7 +1985,8 @@ set_richcompare(PySetObject *v, PyObject *w, int op)
 /*[clinic input]
 set.add
 
-    object: object
+    so: setobject
+    key: object
     /
 
 Add an element to a set.
@@ -1989,10 +1995,10 @@ This has no effect if the element is already present.
 [clinic start generated code]*/
 
 static PyObject *
-set_add(PySetObject *self, PyObject *object)
-/*[clinic end generated code: output=49e7b9e48e514776 input=45fe4bb3fd4ac15a]*/
+set_add(PySetObject *so, PyObject *key)
+/*[clinic end generated code: output=cd9c2d5c2069c2ba input=ba32da84433b0020]*/
 {
-    if (set_add_key(self, object))
+    if (set_add_key(so, key))
         return NULL;
     Py_RETURN_NONE;
 }
@@ -2021,6 +2027,7 @@ set_contains(PySetObject *so, PyObject *key)
 @coexist
 set.__contains__
 
+    so: setobject
     object: object
     /
 
@@ -2028,12 +2035,12 @@ x.__contains__(y) <==> y in x.
 [clinic start generated code]*/
 
 static PyObject *
-set___contains__(PySetObject *self, PyObject *object)
-/*[clinic end generated code: output=ab16b6b74faa51d0 input=767c2b14e150304f]*/
+set___contains__(PySetObject *so, PyObject *object)
+/*[clinic end generated code: output=6d8f64ba8d2916b8 input=17757c9340b19260]*/
 {
     long result;
 
-    result = set_contains(self, object);
+    result = set_contains(so, object);
     if (result < 0)
         return NULL;
     return PyBool_FromLong(result);
@@ -2042,6 +2049,7 @@ set___contains__(PySetObject *self, PyObject *object)
 /*[clinic input]
 set.remove
 
+    so: setobject
     key: object
     /
 
@@ -2051,13 +2059,13 @@ If the element is not a member, raise a KeyError.
 [clinic start generated code]*/
 
 static PyObject *
-set_remove(PySetObject *self, PyObject *key)
-/*[clinic end generated code: output=7445fdb79bdd7d1e input=a8496bae9b5516b9]*/
+set_remove(PySetObject *so, PyObject *key)
+/*[clinic end generated code: output=08ae496d0cd2b8c1 input=9f46b172495667d3]*/
 {
     PyObject *tmpkey;
     int rv;
 
-    rv = set_discard_key(self, key);
+    rv = set_discard_key(so, key);
     if (rv < 0) {
         if (!PySet_Check(key) || !PyErr_ExceptionMatches(PyExc_TypeError))
             return NULL;
@@ -2065,7 +2073,7 @@ set_remove(PySetObject *self, PyObject *key)
         tmpkey = make_new_set(&PyFrozenSet_Type, key);
         if (tmpkey == NULL)
             return NULL;
-        rv = set_discard_key(self, tmpkey);
+        rv = set_discard_key(so, tmpkey);
         Py_DECREF(tmpkey);
         if (rv < 0)
             return NULL;
@@ -2081,6 +2089,7 @@ set_remove(PySetObject *self, PyObject *key)
 /*[clinic input]
 set.discard
 
+    so: setobject
     key: object
     /
 
@@ -2091,13 +2100,13 @@ an exception when an element is missing from the set.
 [clinic start generated code]*/
 
 static PyObject *
-set_discard(PySetObject *self, PyObject *key)
-/*[clinic end generated code: output=c5936b1b65b6c38d input=ef84e3850d614d47]*/
+set_discard(PySetObject *so, PyObject *key)
+/*[clinic end generated code: output=9181b60d7bb7d480 input=02d39a71285ea0ba]*/
 {
     PyObject *tmpkey;
     int rv;
 
-    rv = set_discard_key(self, key);
+    rv = set_discard_key(so, key);
     if (rv < 0) {
         if (!PySet_Check(key) || !PyErr_ExceptionMatches(PyExc_TypeError))
             return NULL;
@@ -2105,7 +2114,7 @@ set_discard(PySetObject *self, PyObject *key)
         tmpkey = make_new_set(&PyFrozenSet_Type, key);
         if (tmpkey == NULL)
             return NULL;
-        rv = set_discard_key(self, tmpkey);
+        rv = set_discard_key(so, tmpkey);
         Py_DECREF(tmpkey);
         if (rv < 0)
             return NULL;

--- a/Objects/setobject.c
+++ b/Objects/setobject.c
@@ -960,7 +960,7 @@ exit:
 set.update
 
     so: setobject
-    *args: object
+    *others as args: object
     /
 
 Update the set, adding elements from all others.
@@ -968,7 +968,7 @@ Update the set, adding elements from all others.
 
 static PyObject *
 set_update_impl(PySetObject *so, PyObject *args)
-/*[clinic end generated code: output=34f6371704974c8a input=a4dc6ead0d0dd452]*/
+/*[clinic end generated code: output=34f6371704974c8a input=168d9ce3461b7d8d]*/
 {
     Py_ssize_t i;
 
@@ -1180,7 +1180,7 @@ set_clear_impl(PySetObject *so)
 set.union
 
     so: setobject
-    *args: object
+    *others as args: object
     /
 
 Return a new set with elements from the set and all others.
@@ -1188,7 +1188,7 @@ Return a new set with elements from the set and all others.
 
 static PyObject *
 set_union_impl(PySetObject *so, PyObject *args)
-/*[clinic end generated code: output=2c83d05a446a1477 input=24ed124df9b6221c]*/
+/*[clinic end generated code: output=2c83d05a446a1477 input=8a088a2719769c81]*/
 {
     PySetObject *result;
     PyObject *other;
@@ -1328,7 +1328,7 @@ set_intersection(PySetObject *so, PyObject *other)
 set.intersection as set_intersection_multi
 
     so: setobject
-    *args: object
+    *others as args: object
     /
 
 Return a new set with elements common to the set and all others.
@@ -1336,7 +1336,7 @@ Return a new set with elements common to the set and all others.
 
 static PyObject *
 set_intersection_multi_impl(PySetObject *so, PyObject *args)
-/*[clinic end generated code: output=2406ef3387adbe2f input=7f9106301a661635]*/
+/*[clinic end generated code: output=2406ef3387adbe2f input=c0c49c1ebe63df11]*/
 {
     Py_ssize_t i;
 
@@ -1373,7 +1373,7 @@ set_intersection_update(PySetObject *so, PyObject *other)
 set.intersection_update as set_intersection_update_multi
 
     so: setobject
-    *args: object
+    *others as args: object
     /
 
 Update the set, keeping only elements found in it and all others.
@@ -1381,7 +1381,7 @@ Update the set, keeping only elements found in it and all others.
 
 static PyObject *
 set_intersection_update_multi_impl(PySetObject *so, PyObject *args)
-/*[clinic end generated code: output=251c1f729063609d input=a0ea42761174e112]*/
+/*[clinic end generated code: output=251c1f729063609d input=e502454eef02d349]*/
 {
     PyObject *tmp;
 
@@ -1547,7 +1547,7 @@ set_difference_update_internal(PySetObject *so, PyObject *other)
 set.difference_update
 
     so: setobject
-    *args: object
+    *others as args: object
     /
 
 Update the set, removing elements found in others.
@@ -1555,7 +1555,7 @@ Update the set, removing elements found in others.
 
 static PyObject *
 set_difference_update_impl(PySetObject *so, PyObject *args)
-/*[clinic end generated code: output=28685b2fc63e41c4 input=baadad04cef724f4]*/
+/*[clinic end generated code: output=28685b2fc63e41c4 input=7b7380a788c4bb7c]*/
 {
     Py_ssize_t i;
 
@@ -1661,7 +1661,7 @@ set_difference(PySetObject *so, PyObject *other)
 set.difference as set_difference_multi
 
     so: setobject
-    *args: object
+    *others as args: object
     /
 
 Return a new set with elements in the set that are not in the others.
@@ -1669,7 +1669,7 @@ Return a new set with elements in the set that are not in the others.
 
 static PyObject *
 set_difference_multi_impl(PySetObject *so, PyObject *args)
-/*[clinic end generated code: output=3130c3bb3cac873d input=ec08ed06cc3db726]*/
+/*[clinic end generated code: output=3130c3bb3cac873d input=03248e240ee359a2]*/
 {
     Py_ssize_t i;
     PyObject *result, *other;

--- a/Objects/setobject.c
+++ b/Objects/setobject.c
@@ -32,14 +32,14 @@
 */
 
 #include "Python.h"
-#include "pycore_ceval.h"            // _PyEval_GetBuiltin()
-#include "pycore_critical_section.h" // Py_BEGIN_CRITICAL_SECTION, Py_END_CRITICAL_SECTION
-#include "pycore_dict.h"             // _PyDict_Contains_KnownHash()
-#include "pycore_modsupport.h"       // _PyArg_NoKwnames()
-#include "pycore_object.h"           // _PyObject_GC_UNTRACK()
-#include "pycore_pyerrors.h"         // _PyErr_SetKeyError()
-#include "pycore_setobject.h"        // _PySet_NextEntry() definition
-#include <stddef.h>                  // offsetof()
+#include "pycore_ceval.h"               // _PyEval_GetBuiltin()
+#include "pycore_critical_section.h"    // Py_BEGIN_CRITICAL_SECTION, Py_END_CRITICAL_SECTION
+#include "pycore_dict.h"                // _PyDict_Contains_KnownHash()
+#include "pycore_modsupport.h"          // _PyArg_NoKwnames()
+#include "pycore_object.h"              // _PyObject_GC_UNTRACK()
+#include "pycore_pyerrors.h"            // _PyErr_SetKeyError()
+#include "pycore_setobject.h"           // _PySet_NextEntry() definition
+#include <stddef.h>                     // offsetof()
 #include "clinic/setobject.c.h"
 
 /*[clinic input]

--- a/Objects/setobject.c
+++ b/Objects/setobject.c
@@ -1998,6 +1998,7 @@ set_contains(PySetObject *so, PyObject *key)
 }
 
 /*[clinic input]
+@coexist
 set.__contains__
 
     object: object
@@ -2008,7 +2009,7 @@ x.__contains__(y) <==> y in x.
 
 static PyObject *
 set___contains__(PySetObject *self, PyObject *object)
-/*[clinic end generated code: output=ab16b6b74faa51d0 input=1cced4c72f2d7665]*/
+/*[clinic end generated code: output=ab16b6b74faa51d0 input=767c2b14e150304f]*/
 {
     long result;
 

--- a/Objects/setobject.c
+++ b/Objects/setobject.c
@@ -2112,7 +2112,7 @@ Return state information for pickling.
 
 static PyObject *
 set___reduce___impl(PySetObject *so)
-/*[clinic end generated code: output=9af7d0e029df87ee input=afaa92e0850f63f9]*/
+/*[clinic end generated code: output=9af7d0e029df87ee input=531375e87a24a449]*/
 {
     PyObject *keys=NULL, *args=NULL, *result=NULL, *state=NULL;
 

--- a/Objects/setobject.c
+++ b/Objects/setobject.c
@@ -1970,7 +1970,7 @@ set_richcompare(PySetObject *v, PyObject *w, int op)
 /*[clinic input]
 set.add
     so: setobject
-    key: object
+    object as key: object
     /
 
 Add an element to a set.
@@ -1980,7 +1980,7 @@ This has no effect if the element is already present.
 
 static PyObject *
 set_add(PySetObject *so, PyObject *key)
-/*[clinic end generated code: output=cd9c2d5c2069c2ba input=fc19e5024a02a819]*/
+/*[clinic end generated code: output=cd9c2d5c2069c2ba input=96f1efe029e47972]*/
 {
     if (set_add_key(so, key))
         return NULL;
@@ -2011,7 +2011,7 @@ set_contains(PySetObject *so, PyObject *key)
 @coexist
 set.__contains__
     so: setobject
-    key: object
+    object as key: object
     /
 
 x.__contains__(y) <==> y in x.
@@ -2019,7 +2019,7 @@ x.__contains__(y) <==> y in x.
 
 static PyObject *
 set___contains__(PySetObject *so, PyObject *key)
-/*[clinic end generated code: output=b5948bc5c590d3ca input=95c79b822b6e6823]*/
+/*[clinic end generated code: output=b5948bc5c590d3ca input=cf4c72db704e4cf0]*/
 {
     long result;
 
@@ -2032,7 +2032,7 @@ set___contains__(PySetObject *so, PyObject *key)
 /*[clinic input]
 set.remove
     so: setobject
-    key: object
+    object as key: object
     /
 
 Remove an element from a set; it must be a member.
@@ -2042,7 +2042,7 @@ If the element is not a member, raise a KeyError.
 
 static PyObject *
 set_remove(PySetObject *so, PyObject *key)
-/*[clinic end generated code: output=08ae496d0cd2b8c1 input=a792bc2b76d2d98d]*/
+/*[clinic end generated code: output=08ae496d0cd2b8c1 input=10132515dfe8ebd7]*/
 {
     PyObject *tmpkey;
     int rv;
@@ -2071,7 +2071,7 @@ set_remove(PySetObject *so, PyObject *key)
 /*[clinic input]
 set.discard
     so: setobject
-    key: object
+    object as key: object
     /
 
 Remove an element from a set if it is a member.
@@ -2082,7 +2082,7 @@ an exception when an element is missing from the set.
 
 static PyObject *
 set_discard(PySetObject *so, PyObject *key)
-/*[clinic end generated code: output=9181b60d7bb7d480 input=e05529cea3b4b295]*/
+/*[clinic end generated code: output=9181b60d7bb7d480 input=82a689eba94d5ad9]*/
 {
     PyObject *tmpkey;
     int rv;

--- a/Objects/setobject.c
+++ b/Objects/setobject.c
@@ -646,7 +646,6 @@ set_merge(PySetObject *so, PyObject *otherset)
 
 /*[clinic input]
 set.pop
-
     so: setobject
 
 Remove and return an arbitrary set element.
@@ -656,7 +655,7 @@ Raises KeyError if the set is empty.
 
 static PyObject *
 set_pop_impl(PySetObject *so)
-/*[clinic end generated code: output=4d65180f1271871b input=a48194117ea1e63a]*/
+/*[clinic end generated code: output=4d65180f1271871b input=4a3f5552e660a260]*/
 {
     /* Make sure the search finger is in bounds */
     setentry *entry = so->table + (so->finger & so->mask);
@@ -958,7 +957,6 @@ exit:
 
 /*[clinic input]
 set.update
-
     so: setobject
     *others as args: object
     /
@@ -968,7 +966,7 @@ Update the set, adding elements from all others.
 
 static PyObject *
 set_update_impl(PySetObject *so, PyObject *args)
-/*[clinic end generated code: output=34f6371704974c8a input=168d9ce3461b7d8d]*/
+/*[clinic end generated code: output=34f6371704974c8a input=eb47c4fbaeb3286e]*/
 {
     Py_ssize_t i;
 
@@ -1129,7 +1127,6 @@ set_swap_bodies(PySetObject *a, PySetObject *b)
 
 /*[clinic input]
 set.copy
-
     so: setobject
 
 Return a shallow copy of a set.
@@ -1137,14 +1134,13 @@ Return a shallow copy of a set.
 
 static PyObject *
 set_copy_impl(PySetObject *so)
-/*[clinic end generated code: output=c9223a1e1cc6b041 input=9bb66f7d227269a5]*/
+/*[clinic end generated code: output=c9223a1e1cc6b041 input=2b80b288d47b8cf1]*/
 {
     return make_new_set_basetype(Py_TYPE(so), (PyObject *)so);
 }
 
 /*[clinic input]
 frozenset.copy
-
     so: setobject
 
 Return a shallow copy of a set.
@@ -1152,7 +1148,7 @@ Return a shallow copy of a set.
 
 static PyObject *
 frozenset_copy_impl(PySetObject *so)
-/*[clinic end generated code: output=b356263526af9e70 input=ed001ffd5277ddd3]*/
+/*[clinic end generated code: output=b356263526af9e70 input=3dc65577d344eff7]*/
 {
     if (PyFrozenSet_CheckExact(so)) {
         return Py_NewRef(so);
@@ -1162,7 +1158,6 @@ frozenset_copy_impl(PySetObject *so)
 
 /*[clinic input]
 set.clear
-
     so: setobject
 
 Remove all elements from this set.
@@ -1170,7 +1165,7 @@ Remove all elements from this set.
 
 static PyObject *
 set_clear_impl(PySetObject *so)
-/*[clinic end generated code: output=4e71d5a83904161a input=3c560e2f9ae62e5c]*/
+/*[clinic end generated code: output=4e71d5a83904161a input=74ac19794da81a39]*/
 {
     set_clear_internal(so);
     Py_RETURN_NONE;
@@ -1178,7 +1173,6 @@ set_clear_impl(PySetObject *so)
 
 /*[clinic input]
 set.union
-
     so: setobject
     *others as args: object
     /
@@ -1188,7 +1182,7 @@ Return a new set with elements from the set and all others.
 
 static PyObject *
 set_union_impl(PySetObject *so, PyObject *args)
-/*[clinic end generated code: output=2c83d05a446a1477 input=8a088a2719769c81]*/
+/*[clinic end generated code: output=2c83d05a446a1477 input=2e2024fa1e40ac84]*/
 {
     PySetObject *result;
     PyObject *other;
@@ -1326,7 +1320,6 @@ set_intersection(PySetObject *so, PyObject *other)
 
 /*[clinic input]
 set.intersection as set_intersection_multi
-
     so: setobject
     *others as args: object
     /
@@ -1336,7 +1329,7 @@ Return a new set with elements common to the set and all others.
 
 static PyObject *
 set_intersection_multi_impl(PySetObject *so, PyObject *args)
-/*[clinic end generated code: output=2406ef3387adbe2f input=c0c49c1ebe63df11]*/
+/*[clinic end generated code: output=2406ef3387adbe2f input=04108ea6d7f0532b]*/
 {
     Py_ssize_t i;
 
@@ -1371,7 +1364,6 @@ set_intersection_update(PySetObject *so, PyObject *other)
 
 /*[clinic input]
 set.intersection_update as set_intersection_update_multi
-
     so: setobject
     *others as args: object
     /
@@ -1381,7 +1373,7 @@ Update the set, keeping only elements found in it and all others.
 
 static PyObject *
 set_intersection_update_multi_impl(PySetObject *so, PyObject *args)
-/*[clinic end generated code: output=251c1f729063609d input=e502454eef02d349]*/
+/*[clinic end generated code: output=251c1f729063609d input=ff8f119f97458d16]*/
 {
     PyObject *tmp;
 
@@ -1417,7 +1409,6 @@ set_iand(PySetObject *so, PyObject *other)
 
 /*[clinic input]
 set.isdisjoint
-
     so: setobject
     other: object
     /
@@ -1427,7 +1418,7 @@ Return True if two sets have a null intersection.
 
 static PyObject *
 set_isdisjoint(PySetObject *so, PyObject *other)
-/*[clinic end generated code: output=a92bbf9a2db6a3da input=370c62423287239a]*/
+/*[clinic end generated code: output=a92bbf9a2db6a3da input=c254ddec8a2326e3]*/
 {
     PyObject *key, *it, *tmp;
     int rv;
@@ -1545,7 +1536,6 @@ set_difference_update_internal(PySetObject *so, PyObject *other)
 
 /*[clinic input]
 set.difference_update
-
     so: setobject
     *others as args: object
     /
@@ -1555,7 +1545,7 @@ Update the set, removing elements found in others.
 
 static PyObject *
 set_difference_update_impl(PySetObject *so, PyObject *args)
-/*[clinic end generated code: output=28685b2fc63e41c4 input=7b7380a788c4bb7c]*/
+/*[clinic end generated code: output=28685b2fc63e41c4 input=e7abb43c9f2c5a73]*/
 {
     Py_ssize_t i;
 
@@ -1659,7 +1649,6 @@ set_difference(PySetObject *so, PyObject *other)
 
 /*[clinic input]
 set.difference as set_difference_multi
-
     so: setobject
     *others as args: object
     /
@@ -1669,7 +1658,7 @@ Return a new set with elements in the set that are not in the others.
 
 static PyObject *
 set_difference_multi_impl(PySetObject *so, PyObject *args)
-/*[clinic end generated code: output=3130c3bb3cac873d input=03248e240ee359a2]*/
+/*[clinic end generated code: output=3130c3bb3cac873d input=d8ae9bb6d518ab95]*/
 {
     Py_ssize_t i;
     PyObject *result, *other;
@@ -1739,7 +1728,6 @@ set_symmetric_difference_update_dict(PySetObject *so, PyObject *other)
 
 /*[clinic input]
 set.symmetric_difference_update
-
     so: setobject
     other: object
     /
@@ -1749,7 +1737,7 @@ Update the set, keeping only elements found in either set, but not in both.
 
 static PyObject *
 set_symmetric_difference_update(PySetObject *so, PyObject *other)
-/*[clinic end generated code: output=fbb049c0806028de input=70e02c8b48a9a59e]*/
+/*[clinic end generated code: output=fbb049c0806028de input=a50acf0365e1f0a5]*/
 {
     PySetObject *otherset;
     PyObject *key;
@@ -1804,7 +1792,6 @@ set_symmetric_difference_update(PySetObject *so, PyObject *other)
 
 /*[clinic input]
 set.symmetric_difference
-
     so: setobject
     other: object
     /
@@ -1814,7 +1801,7 @@ Return a new set with elements in either the set or other but not both.
 
 static PyObject *
 set_symmetric_difference(PySetObject *so, PyObject *other)
-/*[clinic end generated code: output=f95364211b88775a input=f43dc971880c8685]*/
+/*[clinic end generated code: output=f95364211b88775a input=f18af370ad72ebac]*/
 {
     PyObject *rv;
     PySetObject *otherset;
@@ -1855,7 +1842,6 @@ set_ixor(PySetObject *so, PyObject *other)
 
 /*[clinic input]
 set.issubset
-
     so: setobject
     other: object
     /
@@ -1865,7 +1851,7 @@ Report whether another set contains this set.
 
 static PyObject *
 set_issubset(PySetObject *so, PyObject *other)
-/*[clinic end generated code: output=78aef1f377aedef1 input=e141f29d1ac23b11]*/
+/*[clinic end generated code: output=78aef1f377aedef1 input=37fbc579b609db0c]*/
 {
     setentry *entry;
     Py_ssize_t pos = 0;
@@ -1900,7 +1886,6 @@ set_issubset(PySetObject *so, PyObject *other)
 
 /*[clinic input]
 set.issuperset
-
     so: setobject
     other: object
     /
@@ -1910,7 +1895,7 @@ Report whether this set contains another set.
 
 static PyObject *
 set_issuperset(PySetObject *so, PyObject *other)
-/*[clinic end generated code: output=7d2b71dd714a7ec7 input=d5ba4e35213dcbc6]*/
+/*[clinic end generated code: output=7d2b71dd714a7ec7 input=fd5dab052f2e9bb3]*/
 {
     if (PyAnySet_Check(other)) {
         return set_issubset((PySetObject *)other, (PyObject *)so);
@@ -1984,7 +1969,6 @@ set_richcompare(PySetObject *v, PyObject *w, int op)
 
 /*[clinic input]
 set.add
-
     so: setobject
     key: object
     /
@@ -1996,7 +1980,7 @@ This has no effect if the element is already present.
 
 static PyObject *
 set_add(PySetObject *so, PyObject *key)
-/*[clinic end generated code: output=cd9c2d5c2069c2ba input=ba32da84433b0020]*/
+/*[clinic end generated code: output=cd9c2d5c2069c2ba input=fc19e5024a02a819]*/
 {
     if (set_add_key(so, key))
         return NULL;
@@ -2026,7 +2010,6 @@ set_contains(PySetObject *so, PyObject *key)
 /*[clinic input]
 @coexist
 set.__contains__
-
     so: setobject
     key: object
     /
@@ -2036,7 +2019,7 @@ x.__contains__(y) <==> y in x.
 
 static PyObject *
 set___contains__(PySetObject *so, PyObject *key)
-/*[clinic end generated code: output=b5948bc5c590d3ca input=f21c9825df8663e2]*/
+/*[clinic end generated code: output=b5948bc5c590d3ca input=95c79b822b6e6823]*/
 {
     long result;
 
@@ -2048,7 +2031,6 @@ set___contains__(PySetObject *so, PyObject *key)
 
 /*[clinic input]
 set.remove
-
     so: setobject
     key: object
     /
@@ -2060,7 +2042,7 @@ If the element is not a member, raise a KeyError.
 
 static PyObject *
 set_remove(PySetObject *so, PyObject *key)
-/*[clinic end generated code: output=08ae496d0cd2b8c1 input=9f46b172495667d3]*/
+/*[clinic end generated code: output=08ae496d0cd2b8c1 input=a792bc2b76d2d98d]*/
 {
     PyObject *tmpkey;
     int rv;
@@ -2088,7 +2070,6 @@ set_remove(PySetObject *so, PyObject *key)
 
 /*[clinic input]
 set.discard
-
     so: setobject
     key: object
     /
@@ -2101,7 +2082,7 @@ an exception when an element is missing from the set.
 
 static PyObject *
 set_discard(PySetObject *so, PyObject *key)
-/*[clinic end generated code: output=9181b60d7bb7d480 input=02d39a71285ea0ba]*/
+/*[clinic end generated code: output=9181b60d7bb7d480 input=e05529cea3b4b295]*/
 {
     PyObject *tmpkey;
     int rv;
@@ -2124,14 +2105,13 @@ set_discard(PySetObject *so, PyObject *key)
 
 /*[clinic input]
 set.__reduce__
-
     so: setobject
 
 [clinic start generated code]*/
 
 static PyObject *
 set___reduce___impl(PySetObject *so)
-/*[clinic end generated code: output=9af7d0e029df87ee input=4706de8175a7ba2e]*/
+/*[clinic end generated code: output=9af7d0e029df87ee input=afaa92e0850f63f9]*/
 {
     PyObject *keys=NULL, *args=NULL, *result=NULL, *state=NULL;
 
@@ -2154,7 +2134,6 @@ done:
 
 /*[clinic input]
 set.__sizeof__
-
     so: setobject
 
 S.__sizeof__() -> size of S in memory, in bytes.
@@ -2162,7 +2141,7 @@ S.__sizeof__() -> size of S in memory, in bytes.
 
 static PyObject *
 set___sizeof___impl(PySetObject *so)
-/*[clinic end generated code: output=4bfa3df7bd38ed88 input=9e20ae73953cacf2]*/
+/*[clinic end generated code: output=4bfa3df7bd38ed88 input=0f214fc2225319fc]*/
 {
     size_t res = _PyObject_SIZE(Py_TYPE(so));
     if (so->table != so->smalltable) {


### PR DESCRIPTION
This is the first to step to making the set object thread-safe in free threading Python. See [this PR](https://github.com/python/cpython/pull/113800) for reference. As suggested, I am splitting the PR into one which first adds AC support and then a followup PR which adds thread safety.

<!-- gh-issue-number: gh-112069 -->
* Issue: gh-112069
<!-- /gh-issue-number -->
