### PR TITLE
gh-79382: Fix recursive glob() with trailing "**"

### DIFF
--- a/Lib/glob.py
+++ b/Lib/glob.py
@@ -132,7 +132,8 @@ def glob1(dirname, pattern):
 
 def _glob2(dirname, pattern, dir_fd, dironly, include_hidden=False):
     assert _isrecursive(pattern)
-    yield pattern[:0]
+    if not dirname or _isdir(dirname, dir_fd):
+        yield pattern[:0]
     yield from _rlistdir(dirname, dir_fd, dironly,
                          include_hidden=include_hidden)
 

--- a/Lib/test/test_glob.py
+++ b/Lib/test/test_glob.py
@@ -333,6 +333,17 @@ class GlobTests(unittest.TestCase):
             eq(glob.glob('**', recursive=True, include_hidden=True),
                [join(*i) for i in full+rec])
 
+    def test_glob_non_directory(self):
+        eq = self.assertSequencesEqual_noorder
+        eq(self.rglob('EF'), self.joins(('EF',)))
+        eq(self.rglob('EF', ''), [])
+        eq(self.rglob('EF', '*'), [])
+        eq(self.rglob('EF', '**'), [])
+        eq(self.rglob('nonexistent'), [])
+        eq(self.rglob('nonexistent', ''), [])
+        eq(self.rglob('nonexistent', '*'), [])
+        eq(self.rglob('nonexistent', '**'), [])
+
     def test_glob_many_open_files(self):
         depth = 30
         base = os.path.join(self.tempdir, 'deep')

--- a/Misc/NEWS.d/next/Library/2024-02-07-12-37-52.gh-issue-79382.Yz_5WB.rst
+++ b/Misc/NEWS.d/next/Library/2024-02-07-12-37-52.gh-issue-79382.Yz_5WB.rst
@@ -1,0 +1,2 @@
+Trailing ``**`` no longer allows to match files and non-existing paths in
+recursive :func:`~glob.glob`.


### PR DESCRIPTION
Trailing "**" no longer allows to match files and non-existing paths in recursive glob().

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-79382 -->
* Issue: gh-79382
<!-- /gh-issue-number -->
