### PR TITLE
gh-115133: test_xml_etree.py: Fix for Expat >=2.6.0 with reparse deferral (fixes #115133)

### DIFF
--- a/Lib/test/test_xml_etree.py
+++ b/Lib/test/test_xml_etree.py
@@ -1483,6 +1483,7 @@ class XMLPullParserTest(unittest.TestCase):
     def test_simple_xml(self):
         for chunk_size in (None, 1, 5):
             with self.subTest(chunk_size=chunk_size):
+                expected_events = []
                 parser = ET.XMLPullParser()
                 self.assert_event_tags(parser, [])
                 self._feed(parser, "<!-- comment -->\n", chunk_size)
@@ -1492,16 +1493,17 @@ class XMLPullParserTest(unittest.TestCase):
                            chunk_size)
                 self.assert_event_tags(parser, [])
                 self._feed(parser, ">\n", chunk_size)
-                self.assert_event_tags(parser, [('end', 'element')])
+                expected_events += [('end', 'element')]
                 self._feed(parser, "<element>text</element>tail\n", chunk_size)
                 self._feed(parser, "<empty-element/>\n", chunk_size)
-                self.assert_event_tags(parser, [
+                expected_events += [
                     ('end', 'element'),
                     ('end', 'empty-element'),
-                    ])
+                    ]
                 self._feed(parser, "</root>\n", chunk_size)
-                self.assert_event_tags(parser, [('end', 'root')])
+                expected_events += [('end', 'root')]
                 self.assertIsNone(parser.close())
+                self.assert_event_tags(parser, expected_events)
 
     def test_feed_while_iterating(self):
         parser = ET.XMLPullParser()

--- a/Misc/NEWS.d/next/Tests/2024-02-07-15-49-37.gh-issue-115133.WBajNr.rst
+++ b/Misc/NEWS.d/next/Tests/2024-02-07-15-49-37.gh-issue-115133.WBajNr.rst
@@ -1,0 +1,1 @@
+Fix etree XMLPullParser tests for Expat >=2.6.0 with reparse deferral


### PR DESCRIPTION
Fixes #115133

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-115133 -->
* Issue: gh-115133
<!-- /gh-issue-number -->
