### PR TITLE
gh-114828: parenthesize non-atomic macro definitions in pycore_symtable.h

### DIFF
--- a/Include/internal/pycore_symtable.h
+++ b/Include/internal/pycore_symtable.h
@@ -109,18 +109,18 @@ extern PyObject* _Py_Mangle(PyObject *p, PyObject *name);
 
 /* Flags for def-use information */
 
-#define DEF_GLOBAL 1           /* global stmt */
-#define DEF_LOCAL 2            /* assignment in code block */
-#define DEF_PARAM 2<<1         /* formal parameter */
-#define DEF_NONLOCAL 2<<2      /* nonlocal stmt */
-#define USE 2<<3               /* name is used */
-#define DEF_FREE 2<<4          /* name used but not defined in nested block */
-#define DEF_FREE_CLASS 2<<5    /* free variable from class's method */
-#define DEF_IMPORT 2<<6        /* assignment occurred via import */
-#define DEF_ANNOT 2<<7         /* this name is annotated */
-#define DEF_COMP_ITER 2<<8     /* this name is a comprehension iteration variable */
-#define DEF_TYPE_PARAM 2<<9    /* this name is a type parameter */
-#define DEF_COMP_CELL 2<<10    /* this name is a cell in an inlined comprehension */
+#define DEF_GLOBAL 1             /* global stmt */
+#define DEF_LOCAL 2              /* assignment in code block */
+#define DEF_PARAM (2<<1)         /* formal parameter */
+#define DEF_NONLOCAL (2<<2)      /* nonlocal stmt */
+#define USE (2<<3)               /* name is used */
+#define DEF_FREE (2<<4)          /* name used but not defined in nested block */
+#define DEF_FREE_CLASS (2<<5)    /* free variable from class's method */
+#define DEF_IMPORT (2<<6)        /* assignment occurred via import */
+#define DEF_ANNOT (2<<7)         /* this name is annotated */
+#define DEF_COMP_ITER (2<<8)     /* this name is a comprehension iteration variable */
+#define DEF_TYPE_PARAM (2<<9)    /* this name is a type parameter */
+#define DEF_COMP_CELL (2<<10)    /* this name is a cell in an inlined comprehension */
 
 #define DEF_BOUND (DEF_LOCAL | DEF_PARAM | DEF_IMPORT)
 


### PR DESCRIPTION
In #115139, I used the expression `~DEF_FREE` as a mask to clear the `DEF_FREE` bit in a symbol table entry.

Unfortunately, `DEF_FREE` is defined as `#define DEF_FREE 2<<4`, so this macro-expands to `~2<<4`, and the bitwise negation binds more tightly than the bit-shift, so this actually meant `(~2)<<4` rather than the `~(2<<4)` which I intended.

This is why non-atomic macro bodies should always be parenthesized!

Fix it by parenthesizing all the non-atomic definitions in `pycore_symtable.h`, which not only fixes my `~DEF_FREE`, but also prevents anyone else making the same mistake in future.

<!-- gh-issue-number: gh-114828 -->
* Issue: gh-114828
<!-- /gh-issue-number -->
