### PR TITLE
gh-109653: Reduce import overhead of uuid module on Linux

### DIFF
--- a/Lib/uuid.py
+++ b/Lib/uuid.py
@@ -53,8 +53,11 @@ from enum import Enum, _simple_enum
 __author__ = 'Ka-Ping Yee <ping@zesty.ca>'
 
 # The recognized platforms - known behaviors
-if sys.platform in ('win32', 'darwin', 'emscripten', 'wasi'):
+if sys.platform in {'win32', 'darwin', 'emscripten', 'wasi'}:
     _AIX = _LINUX = False
+elif sys.platform == 'linux':
+    _LINUX = True
+    _AIX = False
 else:
     import platform
     _platform_system = platform.system()

--- a/Misc/NEWS.d/next/Documentation/2024-02-08-08-51-37.gh-issue-109653.QHLW4w.rst
+++ b/Misc/NEWS.d/next/Documentation/2024-02-08-08-51-37.gh-issue-109653.QHLW4w.rst
@@ -1,0 +1,1 @@
+Improve import time of :mod:`uuid` on Linux.


### PR DESCRIPTION
This follows in the footsteps of #21586
This speeds up import uuid by about 6ms on Linux.

Before:
```
λ hyperfine -w 4 "./python -c 'import uuid'"
Benchmark 1: ./python -c 'import uuid'
  Time (mean ± σ):      20.4 ms ±   0.4 ms    [User: 16.7 ms, System: 3.8 ms]
  Range (min … max):    19.6 ms …  21.8 ms    136 runs
```
After:
```
λ hyperfine -w 4 "./python -c 'import uuid'"
Benchmark 1: ./python -c 'import uuid'
  Time (mean ± σ):      14.5 ms ±   0.3 ms    [User: 11.5 ms, System: 3.2 ms]
  Range (min … max):    13.9 ms …  16.0 ms    175 runs
```

<!-- gh-issue-number: gh-109653 -->
* Issue: gh-109653
<!-- /gh-issue-number -->
