### PR TITLE
gh-115059: Flush the underlying write buffer in io.BufferedRandom.read1()

### DIFF
--- a/Lib/test/test_io.py
+++ b/Lib/test/test_io.py
@@ -2497,6 +2497,28 @@ class BufferedRandomTest(BufferedReaderTest, BufferedWriterTest):
                 f.flush()
                 self.assertEqual(raw.getvalue(), b'a2c')
 
+    def test_read1_after_write(self):
+        with self.BytesIO(b'abcdef') as raw:
+            with self.tp(raw, 3) as f:
+                f.write(b"1")
+                self.assertEqual(f.read1(1), b'b')
+                f.flush()
+                self.assertEqual(raw.getvalue(), b'1bcdef')
+        with self.BytesIO(b'abcdef') as raw:
+            with self.tp(raw, 3) as f:
+                f.write(b"1")
+                self.assertEqual(f.read1(), b'bcd')
+                f.flush()
+                self.assertEqual(raw.getvalue(), b'1bcdef')
+        with self.BytesIO(b'abcdef') as raw:
+            with self.tp(raw, 3) as f:
+                f.write(b"1")
+                # XXX: read(100) returns different numbers of bytes
+                # in Python and C implementations.
+                self.assertEqual(f.read1(100)[:3], b'bcd')
+                f.flush()
+                self.assertEqual(raw.getvalue(), b'1bcdef')
+
     def test_interleaved_readline_write(self):
         with self.BytesIO(b'ab\ncdef\ng\n') as raw:
             with self.tp(raw) as f:
@@ -2508,6 +2530,36 @@ class BufferedRandomTest(BufferedReaderTest, BufferedWriterTest):
                 self.assertEqual(f.readline(), b'\n')
                 f.flush()
                 self.assertEqual(raw.getvalue(), b'1b\n2def\n3\n')
+
+    def test_xxx(self):
+        with self.BytesIO(b'abcdefgh') as raw:
+            with self.tp(raw) as f:
+                f.write(b'123')
+                self.assertEqual(f.read(), b'defgh')
+                f.write(b'456')
+                f.flush()
+                self.assertEqual(raw.getvalue(), b'123defgh456')
+        with self.BytesIO(b'abcdefgh') as raw:
+            with self.tp(raw) as f:
+                f.write(b'123')
+                self.assertEqual(f.read(3), b'def')
+                f.write(b'456')
+                f.flush()
+                self.assertEqual(raw.getvalue(), b'123def456')
+        with self.BytesIO(b'abcdefgh') as raw:
+            with self.tp(raw) as f:
+                f.write(b'123')
+                self.assertEqual(f.read1(), b'defgh')
+                f.write(b'456')
+                f.flush()
+                self.assertEqual(raw.getvalue(), b'123defgh456')
+        with self.BytesIO(b'abcdefgh') as raw:
+            with self.tp(raw) as f:
+                f.write(b'123')
+                self.assertEqual(f.read1(3), b'def')
+                f.write(b'456')
+                f.flush()
+                self.assertEqual(raw.getvalue(), b'123def456')
 
     # You can't construct a BufferedRandom over a non-seekable stream.
     test_unseekable = None

--- a/Misc/NEWS.d/next/Library/2024-02-08-13-26-14.gh-issue-115059.DqP9dr.rst
+++ b/Misc/NEWS.d/next/Library/2024-02-08-13-26-14.gh-issue-115059.DqP9dr.rst
@@ -1,0 +1,1 @@
+:meth:`io.BufferedRandom.read1` now flushes the underlying write buffer.

--- a/Modules/_io/bufferedio.c
+++ b/Modules/_io/bufferedio.c
@@ -1050,6 +1050,16 @@ _io__Buffered_read1_impl(buffered *self, Py_ssize_t n)
         Py_DECREF(res);
         return NULL;
     }
+    /* Flush the write buffer if necessary */
+    if (self->writable) {
+        PyObject *r = buffered_flush_and_rewind_unlocked(self);
+        if (r == NULL) {
+            LEAVE_BUFFERED(self)
+            Py_DECREF(res);
+            return NULL;
+        }
+        Py_DECREF(r);
+    }
     _bufferedreader_reset_buf(self);
     r = _bufferedreader_raw_read(self, PyBytes_AS_STRING(res), n);
     LEAVE_BUFFERED(self)


### PR DESCRIPTION


<!-- gh-issue-number: gh-115059 -->
* Issue: gh-115059
<!-- /gh-issue-number -->
