### PR TITLE
gh-115142: Skip `test_optimizer` if `_testinternalcapi` module is not available.

### DIFF
--- a/Lib/test/test_optimizer.py
+++ b/Lib/test/test_optimizer.py
@@ -1,6 +1,9 @@
-import _testinternalcapi
 import unittest
 import types
+from test.support import import_helper
+
+
+_testinternalcapi = import_helper.import_module("_testinternalcapi")
 
 
 class TestRareEventCounters(unittest.TestCase):


### PR DESCRIPTION


<!-- gh-issue-number: gh-115142 -->
* Issue: gh-115142
<!-- /gh-issue-number -->
