### PR TITLE
gh-115167: Exclude vcruntime140_threads.dll with Visual Studio 2022 version 17.8

### DIFF
--- a/Misc/NEWS.d/next/Build/2024-02-08-19-36-20.gh-issue-115167.LB9nDK.rst
+++ b/Misc/NEWS.d/next/Build/2024-02-08-19-36-20.gh-issue-115167.LB9nDK.rst
@@ -1,0 +1,1 @@
+Avoid vendoring ``vcruntime140_threads.dll`` when building with Visual Studio 2022 version 17.8.

--- a/PCbuild/pyproject.props
+++ b/PCbuild/pyproject.props
@@ -250,7 +250,7 @@ public override bool Execute() {
       <VCRuntimeDLL Include="$(VCRuntimeDLL)" />
     </ItemGroup>
     <ItemGroup Condition="$(VCInstallDir) != '' and $(VCRuntimeDLL) == ''">
-      <VCRuntimeDLL Include="$(VCRedistDir)\Microsoft.VC*.CRT\vcruntime*.dll" />
+      <VCRuntimeDLL Include="$(VCRedistDir)\Microsoft.VC*.CRT\vcruntime*.dll" Exclude="$(VCRedistDir)\Microsoft.VC*.CRT\vcruntime*_threads.dll" />
     </ItemGroup>
 
     <Warning Text="vcruntime*.dll not found under $(VCRedistDir)." Condition="@(VCRuntimeDLL) == ''" />


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
Visual Studio 2022 version 17.8 introduced support for C11 threads, provided by `vcruntime140_threads.dll`. When building locally with `Tools\msi\buildrelease.bat` using this Visual Studio version, avoid vendoring `vcruntime140_threads.dll` in the Python distribution.

<!-- gh-issue-number: gh-115167 -->
* Issue: gh-115167
<!-- /gh-issue-number -->
