### PR TITLE
gh-115184: Fix refleak tracking issues in free-threaded build

### DIFF
--- a/Objects/mimalloc/heap.c
+++ b/Objects/mimalloc/heap.c
@@ -538,7 +538,6 @@ bool _mi_heap_area_visit_blocks(const mi_heap_area_t* area, mi_page_t *page, mi_
   mi_assert(page != NULL);
   if (page == NULL) return true;
 
-  _mi_page_free_collect(page,true);
   mi_assert_internal(page->local_free == NULL);
   if (page->used == 0) return true;
 
@@ -635,6 +634,7 @@ bool _mi_heap_area_visit_blocks(const mi_heap_area_t* area, mi_page_t *page, mi_
 typedef bool (mi_heap_area_visit_fun)(const mi_heap_t* heap, const mi_heap_area_ex_t* area, void* arg);
 
 void _mi_heap_area_init(mi_heap_area_t* area, mi_page_t* page) {
+  _mi_page_free_collect(page,true);
   const size_t bsize = mi_page_block_size(page);
   const size_t ubsize = mi_page_usable_block_size(page);
   area->reserved = page->reserved * bsize;


### PR DESCRIPTION
- We did not account for abandoned segments, which could miss blocks in programs that use multiple threads.
- The mimalloc heap traversal needed to call `_mi_page_free_collect` earlier in order to get an accurate count of live blocks.
- `_Py_DecRefSharedDebug` was missing a `_Py_IncRefTotal`, but this was mostly offset by a missing accounting in `_Py_ExplicitMergeRefcount`.
- get_num_global_allocated_blocks should pause other threads to ensure that traversing the mimalloc heaps is safe.


<!-- gh-issue-number: gh-115184 -->
* Issue: gh-115184
<!-- /gh-issue-number -->
