### PR TITLE
gh-112903: Handle non-types in _BaseGenericAlias.__mro_entries__()

### DIFF
--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -1136,6 +1136,9 @@ class _BaseGenericAlias(_Final, _root=True):
         if self.__origin__ not in bases:
             res.append(self.__origin__)
         i = bases.index(self)
+        # The goal here is to only add Generic to the MRO if nothing else in the
+        # MRO is already a subclass of Generic; otherwise we risk failure to
+        # linearize a consistent MRO.
         for b in bases[i+1:]:
             if isinstance(b, _BaseGenericAlias):
                 break

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -1137,7 +1137,14 @@ class _BaseGenericAlias(_Final, _root=True):
             res.append(self.__origin__)
         i = bases.index(self)
         for b in bases[i+1:]:
-            if isinstance(b, _BaseGenericAlias) or issubclass(b, Generic):
+            if isinstance(b, _BaseGenericAlias):
+                break
+            if not isinstance(b, type):
+                meth = getattr(b, "__mro_entries__", None)
+                nb = meth(bases) if meth else None
+                if isinstance(nb, tuple) and any(issubclass(b2, Generic) for b2 in nb):
+                    break
+            elif issubclass(b, Generic):
                 break
         else:
             res.append(Generic)

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -1136,13 +1136,12 @@ class _BaseGenericAlias(_Final, _root=True):
         if self.__origin__ not in bases:
             res.append(self.__origin__)
 
-        # Check if any base that occurs after us in the bases list is either
-        # itself a subclass of Generic, or something which will add a subclass
-        # of Generic via its __mro_entries__ (which includes another
-        # _BaseGenericAlias). If not, add Generic ourselves. The goal is to
-        # ensure that Generic (or a subclass) will appear exactly once in the
-        # final bases list. If we let it appear multiple times, we risk "can't
-        # form a consistent MRO" errors.
+        # Check if any base that occurs after us in `bases` is either itself a
+        # subclass of Generic, or something which will add a subclass of Generic
+        # to `__bases__` via its `__mro_entries__`. If not, add Generic
+        # ourselves. The goal is to ensure that Generic (or a subclass) will
+        # appear exactly once in the final bases tuple. If we let it appear
+        # multiple times, we risk "can't form a consistent MRO" errors.
         i = bases.index(self)
         for b in bases[i+1:]:
             if isinstance(b, _BaseGenericAlias):

--- a/Misc/NEWS.d/next/Library/2024-02-08-17-04-58.gh-issue-112903.SN_vUs.rst
+++ b/Misc/NEWS.d/next/Library/2024-02-08-17-04-58.gh-issue-112903.SN_vUs.rst
@@ -1,2 +1,2 @@
 Fix "issubclass() arg 1 must be a class" errors in certain cases of multiple
-inheritance with generic aliases.
+inheritance with generic aliases (regression in early 3.13 alpha releases.)

--- a/Misc/NEWS.d/next/Library/2024-02-08-17-04-58.gh-issue-112903.SN_vUs.rst
+++ b/Misc/NEWS.d/next/Library/2024-02-08-17-04-58.gh-issue-112903.SN_vUs.rst
@@ -1,0 +1,2 @@
+Fix "issubclass() arg 1 must be a class" errors in certain cases of multiple
+inheritance with generic aliases.

--- a/Misc/NEWS.d/next/Library/2024-02-08-17-04-58.gh-issue-112903.SN_vUs.rst
+++ b/Misc/NEWS.d/next/Library/2024-02-08-17-04-58.gh-issue-112903.SN_vUs.rst
@@ -1,2 +1,2 @@
 Fix "issubclass() arg 1 must be a class" errors in certain cases of multiple
-inheritance with generic aliases (regression in early 3.13 alpha releases.)
+inheritance with generic aliases (regression in early 3.13 alpha releases).


### PR DESCRIPTION
The tuple of bases passed to an `__mro_entries__()` method is the original set of bases. This means that it can validly include non-type objects which define an `__mro_entries__()` method themselves. So it is not safe for an `__mro_entries__()` implementation to assume that all the bases passed to it are types. But `_BaseGenericAlias` currently wrongly assumes this (it calls `issubclass()` on them.)

In this PR, we avoid calling `issubclass` on anything that is not a type.

We also have to maintain the intended invariant that we only add `typing.Generic` to the MRO if nothing else in the MRO will be a subclass of `Generic` (otherwise we will run into "can't form consistent MRO" errors.) In order to do this reliably, we must ourselves call `__mro_entries__()` on non-types in `bases`, to see if the replacement MRO entries include any `Generic` subclasses.

<!-- gh-issue-number: gh-112903 -->
* Issue: gh-112903
<!-- /gh-issue-number -->
