### PR TITLE
gh-89188: add `PyUnicode_Data` and `PyUnicode_GetKind`

### DIFF
--- a/Include/cpython/unicodeobject.h
+++ b/Include/cpython/unicodeobject.h
@@ -266,6 +266,12 @@ static inline void* PyUnicode_DATA(PyObject *op) {
 }
 #define PyUnicode_DATA(op) PyUnicode_DATA(_PyObject_CAST(op))
 
+/* Symbol to reexport PyUnicode_DATA without needing to read the contents
+   of the structure directly.
+*/
+PyAPI_FUNC(void *) PyUnicode_Data(PyObject *op);
+PyAPI_FUNC(int) PyUnicode_GetKind(PyObject *op);
+
 /* Return pointers to the canonical representation cast to unsigned char,
    Py_UCS2, or Py_UCS4 for direct character access.
    No checks are performed, use PyUnicode_KIND() before to ensure

--- a/Misc/NEWS.d/next/C API/2024-02-09-11-56-02.gh-issue-89188.42npsa.rst
+++ b/Misc/NEWS.d/next/C API/2024-02-09-11-56-02.gh-issue-89188.42npsa.rst
@@ -1,0 +1,1 @@
+Add ``PyUnicode_Data`` and ``PyUnicode_GetKind`` as alternatives to ``PyUnicode_DATA`` and ``PyUnicode_KIND`` which don't rely on the internal structure of unicode objects.

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -3863,6 +3863,22 @@ _PyUnicode_AsUTF8NoNUL(PyObject *unicode)
     return s;
 }
 
+void* PyUnicode_Data(PyObject *unicode) {
+    if (!PyUnicode_Check(unicode)) {
+        PyErr_BadArgument();
+        return NULL;
+    }
+    return PyUnicode_DATA(unicode);
+}
+
+int PyUnicode_GetKind(PyObject *unicode) {
+    if (!PyUnicode_Check(unicode)) {
+        PyErr_BadArgument();
+        return -1;
+    }
+    return PyUnicode_KIND(unicode);
+}
+
 /*
 PyUnicode_GetSize() has been deprecated since Python 3.3
 because it returned length of Py_UNICODE.


### PR DESCRIPTION
This is inspired by https://github.com/python/cpython/pull/102589#issuecomment-1478163864

The idea is to add `PyUnicode_Data` and `PyUnicode_GetKind` to the version-specific API as exported symbols, so that we can use these downstream in PyO3 instead of having a dependency on the C bitfield.

We built this on stream today with help of my chat; it was suggested by @mejrs that `PyUnicode_GetData` would be a better name for consistency.

I understood that @encukou didn't want these added to the stable ABI due to concerns about exposing PyUnicode encoding and also risk of dangling pointers. That's fine by me, the main aim here is just to get PyO3 off implementation details.

I guess we'll need tests and documentation too; I can add those if it looks like this API is acceptable to add.

<!-- gh-issue-number: gh-89188 -->
* Issue: gh-89188
<!-- /gh-issue-number -->
