### PR TITLE
gh-115165: Fix Annotated for immutable types

### DIFF
--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -4323,6 +4323,13 @@ class GenericTests(BaseTestCase):
         c.bar = 'abc'
         self.assertEqual(c.__dict__, {'bar': 'abc'})
 
+    def test_getattr_exceptions(self):
+        class Immutable[T]:
+            def __setattr__(self, key, value):
+                raise RuntimeError("immutable")
+
+        Immutable[int]()
+
     def test_subscripted_generics_as_proxies(self):
         T = TypeVar('T')
         class C(Generic[T]):

--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -8756,6 +8756,16 @@ class AnnotatedTests(BaseTestCase):
         self.assertIs(type(field_c2.__metadata__[0]), float)
         self.assertIs(type(field_c3.__metadata__[0]), bool)
 
+    def test_annotated_callable_returning_immutable(self):
+        class C:
+            def __setattr__(self, name, value):
+                raise Exception('should be ignored')
+
+        class A(str): ...
+
+        annotated = Annotated[C, A("A")]
+        self.assertIsInstance(annotated(), C)
+
 
 class TypeAliasTests(BaseTestCase):
     def test_canonical_usage_with_variable_annotation(self):

--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -8492,6 +8492,14 @@ class AnnotatedTests(BaseTestCase):
         self.assertEqual(MyCount([4, 4, 5]), {4: 2, 5: 1})
         self.assertEqual(MyCount[int]([4, 4, 5]), {4: 2, 5: 1})
 
+    def test_instantiate_immutable(self):
+        class C:
+            def __setattr__(self, key, value):
+                raise Exception("should be ignored")
+
+        A = Annotated[C, "a decoration"]
+        self.assertIsInstance(A(), C)
+
     def test_cannot_instantiate_forward(self):
         A = Annotated["int", (5, 6)]
         with self.assertRaises(TypeError):
@@ -8755,16 +8763,6 @@ class AnnotatedTests(BaseTestCase):
         self.assertIs(type(field_c1.__metadata__[0]), int)
         self.assertIs(type(field_c2.__metadata__[0]), float)
         self.assertIs(type(field_c3.__metadata__[0]), bool)
-
-    def test_annotated_callable_returning_immutable(self):
-        class C:
-            def __setattr__(self, name, value):
-                raise Exception('should be ignored')
-
-        class A(str): ...
-
-        annotated = Annotated[C, A("A")]
-        self.assertIsInstance(annotated(), C)
 
 
 class TypeAliasTests(BaseTestCase):

--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -4323,12 +4323,15 @@ class GenericTests(BaseTestCase):
         c.bar = 'abc'
         self.assertEqual(c.__dict__, {'bar': 'abc'})
 
-    def test_getattr_exceptions(self):
+    def test_setattr_exceptions(self):
         class Immutable[T]:
             def __setattr__(self, key, value):
                 raise RuntimeError("immutable")
 
-        Immutable[int]()
+        # gh-115165: This used to cause RuntimeError to be raised
+        # when we tried to set `__orig_class__` on the `Immutable` instance
+        # returned by the `Immutable[int]()` call
+        self.assertIsInstance(Immutable[int](), Immutable)
 
     def test_subscripted_generics_as_proxies(self):
         T = TypeVar('T')
@@ -8505,6 +8508,9 @@ class AnnotatedTests(BaseTestCase):
                 raise Exception("should be ignored")
 
         A = Annotated[C, "a decoration"]
+        # gh-115165: This used to cause RuntimeError to be raised
+        # when we tried to set `__orig_class__` on the `C` instance
+        # returned by the `A()` call
         self.assertIsInstance(A(), C)
 
     def test_cannot_instantiate_forward(self):

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -1127,6 +1127,8 @@ class _BaseGenericAlias(_Final, _root=True):
         result = self.__origin__(*args, **kwargs)
         try:
             result.__orig_class__ = self
+        # Some objects raise TypeError (or something even more exotic)
+        # if you try to set attributes on them; guarding against that here
         except Exception:
             pass
         return result

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -1127,7 +1127,7 @@ class _BaseGenericAlias(_Final, _root=True):
         result = self.__origin__(*args, **kwargs)
         try:
             result.__orig_class__ = self
-        except AttributeError:
+        except Exception:
             pass
         return result
 

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -1128,7 +1128,7 @@ class _BaseGenericAlias(_Final, _root=True):
         try:
             result.__orig_class__ = self
         # Some objects raise TypeError (or something even more exotic)
-        # if you try to set attributes on them; guarding against that here
+        # if you try to set attributes on them; we guard against that here
         except Exception:
             pass
         return result

--- a/Misc/NEWS.d/next/Library/2024-02-09-07-20-16.gh-issue-115165.yfJLXA.rst
+++ b/Misc/NEWS.d/next/Library/2024-02-09-07-20-16.gh-issue-115165.yfJLXA.rst
@@ -1,3 +1,4 @@
-``typing.Annotated`` now ignores most exceptions when attempting to set the
-``__orig_class__`` attribute on objects returned when calling a generic alias.
+Most exceptions are now ignored when attempting to set the ``__orig_class__``
+attribute on objects returned when calling :mod:`typing` generic aliases
+(including generic aliases created using :data:`typing.Annotated`).
 Previously only :exc:`AttributeError`` was ignored. Patch by Dave Shawley.

--- a/Misc/NEWS.d/next/Library/2024-02-09-07-20-16.gh-issue-115165.yfJLXA.rst
+++ b/Misc/NEWS.d/next/Library/2024-02-09-07-20-16.gh-issue-115165.yfJLXA.rst
@@ -1,3 +1,3 @@
-``typing.Annotated`` ignores exceptions when setting the ``__orig_class__``
-attribute on objects returned from a callable. Previously only ``TypeError``
-was ignored.
+``typing.Annotated`` now ignores most exceptions when attempting to set the
+``__orig_class__`` attribute on objects returned when calling a generic alias.
+Previously only :exc:`AttributeError`` was ignored. Patch by Dave Shawley.

--- a/Misc/NEWS.d/next/Library/2024-02-09-07-20-16.gh-issue-115165.yfJLXA.rst
+++ b/Misc/NEWS.d/next/Library/2024-02-09-07-20-16.gh-issue-115165.yfJLXA.rst
@@ -1,0 +1,3 @@
+``typing.Annotated`` ignores exceptions when setting the ``__orig_class__``
+attribute on objects returned from a callable. Previously only ``TypeError``
+was ignored.


### PR DESCRIPTION
This PR widens the list of ignored exceptions when setting the `__orig_class__` attribute on the return value from an annotated callable. Only `AttributeError` was caught yet instances can raise any `Exception` from `__setattr__`.  After this PR, it will catch any `Exception` instead. This change was motivated by the `uuid.UUID.__setattr__` implementation raises `TypeError`.

<!-- gh-issue-number: gh-115165 -->
* Issue: gh-115165
<!-- /gh-issue-number -->
