### PR TITLE
GH-113710: Fix updating of dict version tag and add watched dict stats

### DIFF
--- a/Include/cpython/pystats.h
+++ b/Include/cpython/pystats.h
@@ -133,6 +133,8 @@ typedef struct _rare_event_stats {
     uint64_t builtin_dict;
     /* Modifying a function, e.g. func.__defaults__ = ..., etc. */
     uint64_t func_modification;
+    /* Modifying a dict that is being watched */
+    uint64_t watched_dict_modification;
 } RareEventStats;
 
 typedef struct _stats {

--- a/Include/cpython/pystats.h
+++ b/Include/cpython/pystats.h
@@ -135,6 +135,7 @@ typedef struct _rare_event_stats {
     uint64_t func_modification;
     /* Modifying a dict that is being watched */
     uint64_t watched_dict_modification;
+    uint64_t watched_globals_modification;
 } RareEventStats;
 
 typedef struct _stats {

--- a/Include/internal/pycore_dict.h
+++ b/Include/internal/pycore_dict.h
@@ -236,7 +236,7 @@ _PyDict_NotifyEvent(PyInterpreterState *interp,
     assert(Py_REFCNT((PyObject*)mp) > 0);
     int watcher_bits = mp->ma_version_tag & DICT_WATCHER_MASK;
     if (watcher_bits) {
-        RARE_EVENT_INC(watched_dict_modification);
+        RARE_EVENT_STAT_INC(watched_dict_modification);
         _PyDict_SendEvent(watcher_bits, event, mp, key, value);
         return DICT_NEXT_VERSION(interp) | watcher_bits;
     }

--- a/Include/internal/pycore_dict.h
+++ b/Include/internal/pycore_dict.h
@@ -236,6 +236,7 @@ _PyDict_NotifyEvent(PyInterpreterState *interp,
     assert(Py_REFCNT((PyObject*)mp) > 0);
     int watcher_bits = mp->ma_version_tag & DICT_WATCHER_MASK;
     if (watcher_bits) {
+        RARE_EVENT_INC(watched_dict_modification);
         _PyDict_SendEvent(watcher_bits, event, mp, key, value);
         return DICT_NEXT_VERSION(interp) | watcher_bits;
     }

--- a/Include/internal/pycore_dict.h
+++ b/Include/internal/pycore_dict.h
@@ -209,6 +209,7 @@ static inline PyDictUnicodeEntry* DK_UNICODE_ENTRIES(PyDictKeysObject *dk) {
 
 #define DICT_VERSION_INCREMENT (1 << (DICT_MAX_WATCHERS + DICT_WATCHED_MUTATION_BITS))
 #define DICT_WATCHER_MASK ((1 << DICT_MAX_WATCHERS) - 1)
+#define DICT_WATCHER_AND_MODIFICATION_MASK ((1 << (DICT_MAX_WATCHERS + DICT_WATCHED_MUTATION_BITS)) - 1)
 
 #ifdef Py_GIL_DISABLED
 #define DICT_NEXT_VERSION(INTERP) \
@@ -238,9 +239,8 @@ _PyDict_NotifyEvent(PyInterpreterState *interp,
     if (watcher_bits) {
         RARE_EVENT_STAT_INC(watched_dict_modification);
         _PyDict_SendEvent(watcher_bits, event, mp, key, value);
-        return DICT_NEXT_VERSION(interp) | watcher_bits;
     }
-    return DICT_NEXT_VERSION(interp);
+    return DICT_NEXT_VERSION(interp) | (mp->ma_version_tag & DICT_WATCHER_AND_MODIFICATION_MASK);
 }
 
 extern PyObject *_PyObject_MakeDictFromInstanceAttributes(PyObject *obj, PyDictValues *values);

--- a/Python/optimizer_analysis.c
+++ b/Python/optimizer_analysis.c
@@ -37,9 +37,6 @@ static int
 globals_watcher_callback(PyDict_WatchEvent event, PyObject* dict,
                          PyObject* key, PyObject* new_value)
 {
-    if (event == PyDict_EVENT_CLONED) {
-        return 0;
-    }
     uint64_t watched_mutations = get_mutations(dict);
     if (watched_mutations < _Py_MAX_ALLOWED_GLOBALS_MODIFICATIONS) {
         _Py_Executors_InvalidateDependency(_PyInterpreterState_GET(), dict);

--- a/Python/optimizer_analysis.c
+++ b/Python/optimizer_analysis.c
@@ -38,6 +38,7 @@ globals_watcher_callback(PyDict_WatchEvent event, PyObject* dict,
                          PyObject* key, PyObject* new_value)
 {
     uint64_t watched_mutations = get_mutations(dict);
+    RARE_EVENT_STAT_INC(watched_globals_modification);
     if (watched_mutations < _Py_MAX_ALLOWED_GLOBALS_MODIFICATIONS) {
         _Py_Executors_InvalidateDependency(_PyInterpreterState_GET(), dict);
         increment_mutations(dict);

--- a/Python/optimizer_analysis.c
+++ b/Python/optimizer_analysis.c
@@ -37,16 +37,11 @@ static int
 globals_watcher_callback(PyDict_WatchEvent event, PyObject* dict,
                          PyObject* key, PyObject* new_value)
 {
-    assert(((PyDictObject *)dict)->ma_version_tag & 2);
-    int watched_mutations = get_mutations(dict);
-    printf("globals_watcher_callback called. dict %p, %d\n", dict, watched_mutations);
     RARE_EVENT_STAT_INC(watched_globals_modification);
-    assert(watched_mutations < _Py_MAX_ALLOWED_GLOBALS_MODIFICATIONS);
+    assert(get_mutations(dict) < _Py_MAX_ALLOWED_GLOBALS_MODIFICATIONS);
     _Py_Executors_InvalidateDependency(_PyInterpreterState_GET(), dict);
-    PyDict_Unwatch(GLOBALS_WATCHER_ID, dict);
-    assert((((PyDictObject *)dict)->ma_version_tag & DICT_WATCHER_MASK) == 0);
     increment_mutations(dict);
-    assert(get_mutations(dict) == watched_mutations + 1);
+    PyDict_Unwatch(GLOBALS_WATCHER_ID, dict);
     return 0;
 }
 

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -614,9 +614,6 @@ builtins_dict_watcher(PyDict_WatchEvent event, PyObject *dict, PyObject *key, Py
     if (interp->rare_events.builtin_dict < _Py_MAX_ALLOWED_BUILTINS_MODIFICATIONS) {
         _Py_Executors_InvalidateAll(interp);
     }
-    else {
-        PyDict_Unwatch(0, interp->builtins);
-    }
     RARE_EVENT_INTERP_INC(interp, builtin_dict);
     return 0;
 }

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -611,8 +611,11 @@ static int
 builtins_dict_watcher(PyDict_WatchEvent event, PyObject *dict, PyObject *key, PyObject *new_value)
 {
     PyInterpreterState *interp = _PyInterpreterState_GET();
-    if (event != PyDict_EVENT_CLONED && interp->rare_events.builtin_dict < _Py_MAX_ALLOWED_BUILTINS_MODIFICATIONS) {
+    if (interp->rare_events.builtin_dict < _Py_MAX_ALLOWED_BUILTINS_MODIFICATIONS) {
         _Py_Executors_InvalidateAll(interp);
+    }
+    else {
+        PyDict_Unwatch(0, interp->builtins);
     }
     RARE_EVENT_INTERP_INC(interp, builtin_dict);
     return 0;

--- a/Python/specialize.c
+++ b/Python/specialize.c
@@ -276,6 +276,7 @@ print_rare_event_stats(FILE *out, RareEventStats *stats)
     fprintf(out, "Rare event (builtin_dict): %" PRIu64 "\n", stats->builtin_dict);
     fprintf(out, "Rare event (func_modification): %" PRIu64 "\n", stats->func_modification);
     fprintf(out, "Rare event (watched_dict_modification): %" PRIu64 "\n", stats->watched_dict_modification);
+    fprintf(out, "Rare event (watched_globals_modification): %" PRIu64 "\n", stats->watched_globals_modification);
 }
 
 static void

--- a/Python/specialize.c
+++ b/Python/specialize.c
@@ -275,6 +275,7 @@ print_rare_event_stats(FILE *out, RareEventStats *stats)
     fprintf(out, "Rare event (set_eval_frame_func): %" PRIu64 "\n", stats->set_eval_frame_func);
     fprintf(out, "Rare event (builtin_dict): %" PRIu64 "\n", stats->builtin_dict);
     fprintf(out, "Rare event (func_modification): %" PRIu64 "\n", stats->func_modification);
+    fprintf(out, "Rare event (watched_dict_modification): %" PRIu64 "\n", stats->watched_dict_modification);
 }
 
 static void

--- a/Tools/scripts/summarize_stats.py
+++ b/Tools/scripts/summarize_stats.py
@@ -416,7 +416,7 @@ class Stats:
         prefix = "Rare event "
         return [
             (key[len(prefix) + 1:-1], val)
-            for key, val in self._data.items()
+            for key.replace("_", " "), val in self._data.items()
             if key.startswith(prefix)
         ]
 

--- a/Tools/scripts/summarize_stats.py
+++ b/Tools/scripts/summarize_stats.py
@@ -415,8 +415,8 @@ class Stats:
     def get_rare_events(self) -> list[tuple[str, int]]:
         prefix = "Rare event "
         return [
-            (key[len(prefix) + 1:-1], val)
-            for key.replace("_", " "), val in self._data.items()
+            (key[len(prefix) + 1:-1].replace("_", " "), val)
+            for key, val in self._data.items()
             if key.startswith(prefix)
         ]
 


### PR DESCRIPTION
Fixes a regression introduced by https://github.com/python/cpython/pull/114592 where mutating a global variable would cause repeated de-optimizations.

<!-- gh-issue-number: gh-113710 -->
* Issue: gh-113710
<!-- /gh-issue-number -->
