### PR TITLE
gh-115243: Fix crash in deque.index() when the deque is concurrently modified

### DIFF
--- a/Lib/test/test_deque.py
+++ b/Lib/test/test_deque.py
@@ -179,9 +179,8 @@ class TestBasic(unittest.TestCase):
             _ = d.count(3)
 
         d = deque([A()])
-        with self.assertRaises(RuntimeError ):
+        with self.assertRaises(RuntimeError):
             d.index(0)
-
 
     def test_extend(self):
         d = deque('a')

--- a/Lib/test/test_deque.py
+++ b/Lib/test/test_deque.py
@@ -166,7 +166,7 @@ class TestBasic(unittest.TestCase):
         with self.assertRaises(RuntimeError):
             n in d
 
-    def test_contains_count_stop_crashes(self):
+    def test_contains_count_index_stop_crashes(self):
         class A:
             def __eq__(self, other):
                 d.clear()
@@ -177,6 +177,11 @@ class TestBasic(unittest.TestCase):
         d = deque([A(), A()])
         with self.assertRaises(RuntimeError):
             _ = d.count(3)
+
+        d = deque([A()])
+        with self.assertRaises(RuntimeError ):
+            d.index(0)
+
 
     def test_extend(self):
         d = deque('a')

--- a/Misc/NEWS.d/next/Security/2024-02-12-00-33-01.gh-issue-115243.e1oGX8.rst
+++ b/Misc/NEWS.d/next/Security/2024-02-12-00-33-01.gh-issue-115243.e1oGX8.rst
@@ -1,2 +1,1 @@
-Fix possible crashes in :func:`deque.index` when calling
-:c:func:`PyObject_RichCompareBool`.
+Fix possible crashes in :meth:`collections.deque.index` when the deque is concurrently modified.

--- a/Misc/NEWS.d/next/Security/2024-02-12-00-33-01.gh-issue-115243.e1oGX8.rst
+++ b/Misc/NEWS.d/next/Security/2024-02-12-00-33-01.gh-issue-115243.e1oGX8.rst
@@ -1,1 +1,2 @@
-Fix possible crashes when operating with the functions in the :func:`deque.index`and custom comparison operators.
+Fix possible crashes in :func:`deque.index` when calling
+:c:func:`PyObject_RichCompareBool`.

--- a/Misc/NEWS.d/next/Security/2024-02-12-00-33-01.gh-issue-115243.e1oGX8.rst
+++ b/Misc/NEWS.d/next/Security/2024-02-12-00-33-01.gh-issue-115243.e1oGX8.rst
@@ -1,0 +1,1 @@
+Fix possible crashes when operating with the functions in the :func:`deque.index`and custom comparison operators.

--- a/Modules/_collectionsmodule.c
+++ b/Modules/_collectionsmodule.c
@@ -1218,7 +1218,7 @@ deque_index_impl(dequeobject *deque, PyObject *v, Py_ssize_t start,
     n = stop - i;
     while (--n >= 0) {
         CHECK_NOT_END(b);
-	item = Py_NewRef(b->data[index]);
+	    item = Py_NewRef(b->data[index]);
         cmp = PyObject_RichCompareBool(item, v, Py_EQ);
 	Py_DECREF(item);
         if (cmp > 0)

--- a/Modules/_collectionsmodule.c
+++ b/Modules/_collectionsmodule.c
@@ -1218,8 +1218,9 @@ deque_index_impl(dequeobject *deque, PyObject *v, Py_ssize_t start,
     n = stop - i;
     while (--n >= 0) {
         CHECK_NOT_END(b);
-        item = b->data[index];
+	item = Py_NewRef(b->data[index]);
         cmp = PyObject_RichCompareBool(item, v, Py_EQ);
+	Py_DECREF(item);
         if (cmp > 0)
             return PyLong_FromSsize_t(stop - n - 1);
         if (cmp < 0)

--- a/Modules/_collectionsmodule.c
+++ b/Modules/_collectionsmodule.c
@@ -1218,9 +1218,9 @@ deque_index_impl(dequeobject *deque, PyObject *v, Py_ssize_t start,
     n = stop - i;
     while (--n >= 0) {
         CHECK_NOT_END(b);
-	    item = Py_NewRef(b->data[index]);
+        item = Py_NewRef(b->data[index]);
         cmp = PyObject_RichCompareBool(item, v, Py_EQ);
-	Py_DECREF(item);
+        Py_DECREF(item);
         if (cmp > 0)
             return PyLong_FromSsize_t(stop - n - 1);
         if (cmp < 0)


### PR DESCRIPTION
Increase the reference count of item to prevent it from being freed


<!-- gh-issue-number: gh-115243 -->
* Issue: gh-115243
<!-- /gh-issue-number -->
