### PR TITLE
gh-115249: Fix `test_descr` with `-OO` mode

### DIFF
--- a/Lib/test/test_descr.py
+++ b/Lib/test/test_descr.py
@@ -1594,7 +1594,11 @@ class ClassPropertiesAndMethods(unittest.TestCase):
 
         cm = classmethod(f)
         cm_dict = {'__annotations__': {},
-                   '__doc__': "f docstring",
+                   '__doc__': (
+                       "f docstring"
+                       if support.HAVE_DOCSTRINGS
+                       else None
+                    ),
                    '__module__': __name__,
                    '__name__': 'f',
                    '__qualname__': f.__qualname__}


### PR DESCRIPTION
Now it passes with both `-00` and without.

<!-- gh-issue-number: gh-115249 -->
* Issue: gh-115249
<!-- /gh-issue-number -->
