### PR TITLE
gh-115254: Fix `test_property` with `-00` mode

### DIFF
--- a/Lib/test/test_property.py
+++ b/Lib/test/test_property.py
@@ -224,6 +224,7 @@ class PropertySubSlots(property):
 
 class PropertySubclassTests(unittest.TestCase):
 
+    @support.requires_docstrings
     def test_slots_docstring_copy_exception(self):
         # A special case error that we preserve despite the GH-98963 behavior
         # that would otherwise silently ignore this error.


### PR DESCRIPTION
It now passes with both modes.

<!-- gh-issue-number: gh-115254 -->
* Issue: gh-115254
<!-- /gh-issue-number -->
