### PR TITLE
gh-115258: Temporarily disable test on Windows

### DIFF
--- a/Lib/test/test_queue.py
+++ b/Lib/test/test_queue.py
@@ -409,6 +409,8 @@ class BaseQueueTestMixin(BlockingTestMixin):
     def test_shutdown_all_methods_in_many_threads(self):
         return self._shutdown_all_methods_in_many_threads(False)
 
+    @unittest.skipIf(sys.platform == 'win32' and Py_GIL_DISABLED,
+                     "test times out (gh-115258)")
     def test_shutdown_immediate_all_methods_in_many_threads(self):
         return self._shutdown_all_methods_in_many_threads(True)
 

--- a/Lib/test/test_queue.py
+++ b/Lib/test/test_queue.py
@@ -10,7 +10,6 @@ import weakref
 from test.support import gc_collect
 from test.support import import_helper
 from test.support import threading_helper
-from test.support import Py_GIL_DISABLED
 
 # queue module depends on threading primitives
 threading_helper.requires_working_threading(module=True)
@@ -404,13 +403,11 @@ class BaseQueueTestMixin(BlockingTestMixin):
         for thread in ps[1:]:
             thread.join()
 
-    @unittest.skipIf(sys.platform == 'win32' and Py_GIL_DISABLED,
-                     "test times out (gh-115258)")
+    @unittest.skipIf(sys.platform == 'win32', "test times out (gh-115258)")
     def test_shutdown_all_methods_in_many_threads(self):
         return self._shutdown_all_methods_in_many_threads(False)
 
-    @unittest.skipIf(sys.platform == 'win32' and Py_GIL_DISABLED,
-                     "test times out (gh-115258)")
+    @unittest.skipIf(sys.platform == 'win32', "test times out (gh-115258)")
     def test_shutdown_immediate_all_methods_in_many_threads(self):
         return self._shutdown_all_methods_in_many_threads(True)
 

--- a/Lib/test/test_queue.py
+++ b/Lib/test/test_queue.py
@@ -2,6 +2,7 @@
 # to ensure the Queue locks remain stable.
 import itertools
 import random
+import sys
 import threading
 import time
 import unittest
@@ -9,6 +10,7 @@ import weakref
 from test.support import gc_collect
 from test.support import import_helper
 from test.support import threading_helper
+from test.support import Py_GIL_DISABLED
 
 # queue module depends on threading primitives
 threading_helper.requires_working_threading(module=True)
@@ -402,6 +404,8 @@ class BaseQueueTestMixin(BlockingTestMixin):
         for thread in ps[1:]:
             thread.join()
 
+    @unittest.skipIf(sys.platform == 'win32' and Py_GIL_DISABLED,
+                     "test times out (gh-115258)")
     def test_shutdown_all_methods_in_many_threads(self):
         return self._shutdown_all_methods_in_many_threads(False)
 

--- a/Lib/test/test_queue.py
+++ b/Lib/test/test_queue.py
@@ -403,11 +403,11 @@ class BaseQueueTestMixin(BlockingTestMixin):
         for thread in ps[1:]:
             thread.join()
 
-    @unittest.skipIf(sys.platform == 'win32', "test times out (gh-115258)")
+    @unittest.skipIf(sys.platform == "win32", "test times out (gh-115258)")
     def test_shutdown_all_methods_in_many_threads(self):
         return self._shutdown_all_methods_in_many_threads(False)
 
-    @unittest.skipIf(sys.platform == 'win32', "test times out (gh-115258)")
+    @unittest.skipIf(sys.platform == "win32", "test times out (gh-115258)")
     def test_shutdown_immediate_all_methods_in_many_threads(self):
         return self._shutdown_all_methods_in_many_threads(True)
 


### PR DESCRIPTION
The "test_shutdown_all_methods_in_many_threads" test times out on the Windows CI. This skips the test on that platform until we figure out the root cause.


<!-- gh-issue-number: gh-115258 -->
* Issue: gh-115258
<!-- /gh-issue-number -->
