### PR TITLE
gh-110467: Fix EOF occurred in violation of protocol starting Python3.10 on large requests

### DIFF
--- a/Lib/test/test_ssl.py
+++ b/Lib/test/test_ssl.py
@@ -2405,6 +2405,10 @@ class ThreadedEchoServer(threading.Thread):
                             print(
                                 f" Connection reset by peer: {self.addr}"
                             )
+
+                            self.close()
+                            self.running = False
+                            return
                         else:
                             handle_error("Test server failure:\n")
                     try:

--- a/Lib/test/test_ssl.py
+++ b/Lib/test/test_ssl.py
@@ -3096,8 +3096,8 @@ class ThreadedTests(unittest.TestCase):
                                         suppress_ragged_eofs=False) as s:
             s.connect((HOST, server.port))
             with self.assertRaisesRegex(
-                ssl.SSLError,
-                'alert unknown ca|EOF occurred'
+                (ssl.SSLError, OSError),
+                '(alert unknown ca|EOF occurred|ConnectionResetError)'
             ):
                 # TLS 1.3 perform client cert exchange after handshake
                 s.write(b'data')
@@ -4449,8 +4449,8 @@ class TestPostHandshakeAuth(unittest.TestCase):
                 # test sometimes fails with EOF error. Test passes as long as
                 # server aborts connection with an error.
                 with self.assertRaisesRegex(
-                    ssl.SSLError,
-                    '(certificate required|EOF occurred)'
+                    (ssl.SSLError, OSError),
+                    '(certificate required|EOF occurred|ConnectionResetError)'
                 ):
                     # receive CertificateRequest
                     data = s.recv(1024)

--- a/Lib/test/test_ssl.py
+++ b/Lib/test/test_ssl.py
@@ -3097,7 +3097,7 @@ class ThreadedTests(unittest.TestCase):
             s.connect((HOST, server.port))
             with self.assertRaisesRegex(
                 (ssl.SSLError, OSError),
-                '(alert unknown ca|EOF occurred|ConnectionResetError)'
+                '(alert unknown ca|EOF occurred|closed by the remote host)'
             ):
                 # TLS 1.3 perform client cert exchange after handshake
                 s.write(b'data')
@@ -4450,7 +4450,7 @@ class TestPostHandshakeAuth(unittest.TestCase):
                 # server aborts connection with an error.
                 with self.assertRaisesRegex(
                     (ssl.SSLError, OSError),
-                    '(certificate required|EOF occurred|ConnectionResetError)'
+                    '(certificate required|EOF occurred|closed by the remote host)'
                 ):
                     # receive CertificateRequest
                     data = s.recv(1024)

--- a/Lib/test/test_ssl.py
+++ b/Lib/test/test_ssl.py
@@ -2397,20 +2397,19 @@ class ThreadedEchoServer(threading.Thread):
                         self.write(msg.lower())
                 except OSError as e:
                     # handles SSLError and socket errors
-                    if self.server.chatty and support.verbose:
-                        if isinstance(e, ConnectionError):
-                            # OpenSSL 1.1.1 sometimes raises
-                            # ConnectionResetError when connection is not
-                            # shut down gracefully.
-                            print(
-                                f" Connection reset by peer: {self.addr}"
-                            )
+                    if isinstance(e, ConnectionError):
+                        # OpenSSL 1.1.1 sometimes raises
+                        # ConnectionResetError when connection is not
+                        # shut down gracefully.
+                        print(
+                            f" Connection reset by peer: {self.addr}"
+                        )
 
-                            self.close()
-                            self.running = False
-                            return
-                        else:
-                            handle_error("Test server failure:\n")
+                        self.close()
+                        self.running = False
+                        return
+                    if self.server.chatty and support.verbose:
+                        handle_error("Test server failure:\n")
                     try:
                         self.write(b"ERROR\n")
                     except OSError:

--- a/Misc/NEWS.d/next/Library/2024-02-11-19-11-54.gh-issue-110467.lIaa2u.rst
+++ b/Misc/NEWS.d/next/Library/2024-02-11-19-11-54.gh-issue-110467.lIaa2u.rst
@@ -1,0 +1,2 @@
+Fix :c:func:`PySSL_SetError` : Modify retval handling logic for handling
+SSL_ERROR_SYSCALL.

--- a/Misc/NEWS.d/next/Library/2024-02-18-09-48-11.gh-issue-115627.HGchj0.rst
+++ b/Misc/NEWS.d/next/Library/2024-02-18-09-48-11.gh-issue-115627.HGchj0.rst
@@ -1,0 +1,2 @@
+Fix :c:func:`PySSL_SetError` : Modify retval handling logic for handling
+SSL_ERROR_SYSCALL.

--- a/Modules/_ssl.c
+++ b/Modules/_ssl.c
@@ -645,11 +645,11 @@ PySSL_SetError(PySSLSocket *sslsock, int ret, const char *filename, int lineno)
         {
             if (e == 0) {
                 PySocketSockObject *s = GET_SOCKET(sslsock);
-                if (ret == 0 || (((PyObject *)s) == Py_None)) {
+                if (((PyObject *)s) == Py_None) {
                     p = PY_SSL_ERROR_EOF;
                     type = state->PySSLEOFErrorObject;
                     errstr = "EOF occurred in violation of protocol";
-                } else if (s && ret == -1) {
+                } else {
                     /* underlying BIO reported an I/O error */
                     ERR_clear_error();
 #ifdef MS_WINDOWS
@@ -666,10 +666,6 @@ PySSL_SetError(PySSLSocket *sslsock, int ret, const char *filename, int lineno)
                         type = state->PySSLEOFErrorObject;
                         errstr = "EOF occurred in violation of protocol";
                     }
-                } else { /* possible? */
-                    p = PY_SSL_ERROR_SYSCALL;
-                    type = state->PySSLSyscallErrorObject;
-                    errstr = "Some I/O error occurred";
                 }
             } else {
                 if (ERR_GET_LIB(e) == ERR_LIB_SSL &&


### PR DESCRIPTION
In the process of upgrading from Python 3.9 to 3.10, 'SSL_write()' was changed to 'SSL_write_ex()'.

At this time, the range of the return value of each function was different and corresponded within the function '_ssl__SSLSocket_write_impl', but the function 'PySSL_SetError' did not correspond to this.

Therefore, even if there is 'err.c' in 'SSL_ERROR_SYSCALL', the return value of 'SSL_write_ex' is always 0, so it cannot enter the condition statement.

If this commitment is approved, all of 3.10, 3.11, and 3.12 are backportable.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-110467 -->
* Issue: gh-110467
<!-- /gh-issue-number -->
