### PR TITLE
[3.11] gh-115274: Fix direct invocation of testmock/testpatch.py (GH-115275)

### DIFF
--- a/Lib/unittest/test/testmock/testpatch.py
+++ b/Lib/unittest/test/testmock/testpatch.py
@@ -1912,7 +1912,7 @@ class PatchTest(unittest.TestCase):
 
         with patch.object(foo, '__module__', "testpatch2"):
             self.assertEqual(foo.__module__, "testpatch2")
-        self.assertEqual(foo.__module__, 'unittest.test.testmock.testpatch')
+        self.assertEqual(foo.__module__, __name__)
 
         with patch.object(foo, '__annotations__', dict([('s', 1, )])):
             self.assertEqual(foo.__annotations__, dict([('s', 1, )]))


### PR DESCRIPTION
(cherry picked from commit f8e9c57067e32baab4ed2fd824b892c52ecb7225)

Co-authored-by: Nikita Sobolev <mail@sobolevn.me>

<!-- gh-issue-number: gh-115274 -->
* Issue: gh-115274
<!-- /gh-issue-number -->
