### PR TITLE
gh-115282: Fix direct invocation of `test_traceback.py`

### DIFF
--- a/Lib/test/test_traceback.py
+++ b/Lib/test/test_traceback.py
@@ -3124,10 +3124,13 @@ class TestTracebackException(unittest.TestCase):
         class MyException(Exception):
             pass
 
-        self.do_test_smoke(
-            MyException('bad things happened'),
-            ('test.test_traceback.TestTracebackException.'
-             'test_smoke_user_exception.<locals>.MyException'))
+        if __name__ == '__main__':
+            expected = ('TestTracebackException.'
+                        'test_smoke_user_exception.<locals>.MyException')
+        else:
+            expected = ('test.test_traceback.TestTracebackException.'
+                        'test_smoke_user_exception.<locals>.MyException')
+        self.do_test_smoke(MyException('bad things happened'), expected)
 
     def test_from_exception(self):
         # Check all the parameters are accepted.


### PR DESCRIPTION
After:

```
» ./python.exe Lib/test/test_traceback.py
..................................................................................................................................................................................................................................................................................................................................................
----------------------------------------------------------------------
Ran 338 tests in 2.104s

OK
```                                                                                           
```                                                 
» ./python.exe -m test test_traceback
Using random seed: 3645079937
0:00:00 load avg: 2.51 Run 1 test sequentially
0:00:00 load avg: 2.51 [1/1] test_traceback

== Tests result: SUCCESS ==

1 test OK.

Total duration: 1.1 sec
Total tests: run=338 skipped=1
Total test files: run=1/1
Result: SUCCESS
```

<!-- gh-issue-number: gh-115282 -->
* Issue: gh-115282
<!-- /gh-issue-number -->
