### PR TITLE
gh-115285: Fix `test_dataclasses` with `-OO` mode

### DIFF
--- a/Lib/test/test_dataclasses/__init__.py
+++ b/Lib/test/test_dataclasses/__init__.py
@@ -2218,16 +2218,14 @@ class TestDocString(unittest.TestCase):
         #  whitespace stripped.
         self.assertEqual(a.replace(' ', ''), b.replace(' ', ''))
 
+    @support.requires_docstrings
     def test_existing_docstring_not_overridden(self):
         @dataclass
         class C:
             """Lorem ipsum"""
             x: int
 
-        if support.HAVE_DOCSTRINGS:
-            self.assertEqual(C.__doc__, "Lorem ipsum")
-        else:
-            self.assertEqual(C.__doc__, "C(x: int)")
+        self.assertEqual(C.__doc__, "Lorem ipsum")
 
     def test_docstring_no_fields(self):
         @dataclass

--- a/Lib/test/test_dataclasses/__init__.py
+++ b/Lib/test/test_dataclasses/__init__.py
@@ -22,6 +22,8 @@ from functools import total_ordering
 import typing       # Needed for the string "typing.ClassVar[int]" to work as an annotation.
 import dataclasses  # Needed for the string "dataclasses.InitVar[int]" to work as an annotation.
 
+from test import support
+
 # Just any custom exception we can catch.
 class CustomError(Exception): pass
 
@@ -2222,7 +2224,10 @@ class TestDocString(unittest.TestCase):
             """Lorem ipsum"""
             x: int
 
-        self.assertEqual(C.__doc__, "Lorem ipsum")
+        if support.HAVE_DOCSTRINGS:
+            self.assertEqual(C.__doc__, "Lorem ipsum")
+        else:
+            self.assertEqual(C.__doc__, "C(x: int)")
 
     def test_docstring_no_fields(self):
         @dataclass


### PR DESCRIPTION
After it passes with both modes:

```
» ./python.exe -OO Lib/test/test_dataclasses/__init__.py
............................................................................................................................................................................................................................................
----------------------------------------------------------------------
Ran 236 tests in 0.230s

OK
```

```
» ./python.exe Lib/test/test_dataclasses/__init__.py    
............................................................................................................................................................................................................................................
----------------------------------------------------------------------
Ran 236 tests in 0.229s

OK
```

<!-- gh-issue-number: gh-115285 -->
* Issue: gh-115285
<!-- /gh-issue-number -->
