### PR TITLE
[3.12] gh-115011: Improve support of __index__() in setters of members with unsigned integer type (GH-115029)

### DIFF
--- a/Lib/test/test_capi/test_structmembers.py
+++ b/Lib/test/test_capi/test_structmembers.py
@@ -81,36 +81,22 @@ class ReadWriteTests:
             self._test_warn(name, maxval+1, minval)
             self._test_warn(name, hardmaxval)
 
-        if indexlimit is None:
-            indexlimit = hardlimit
-        if not indexlimit:
+        if indexlimit is False:
             self.assertRaises(TypeError, setattr, ts, name, Index(minval))
             self.assertRaises(TypeError, setattr, ts, name, Index(maxval))
         else:
-            hardminindexval, hardmaxindexval = indexlimit
             self._test_write(name, Index(minval), minval)
-            if minval < hardminindexval:
-                self._test_write(name, Index(hardminindexval), hardminindexval)
-            if maxval < hardmaxindexval:
-                self._test_write(name, Index(maxval), maxval)
-            else:
-                self._test_write(name, Index(hardmaxindexval), hardmaxindexval)
-            self._test_overflow(name, Index(hardminindexval-1))
-            if name in ('T_UINT', 'T_ULONG'):
-                self.assertRaises(TypeError, setattr, self.ts, name,
-                                  Index(hardmaxindexval+1))
-                self.assertRaises(TypeError, setattr, self.ts, name,
-                                  Index(2**1000))
-            else:
-                self._test_overflow(name, Index(hardmaxindexval+1))
-                self._test_overflow(name, Index(2**1000))
+            self._test_write(name, Index(maxval), maxval)
+            self._test_overflow(name, Index(hardminval-1))
+            self._test_overflow(name, Index(hardmaxval+1))
+            self._test_overflow(name, Index(2**1000))
             self._test_overflow(name, Index(-2**1000))
-            if hardminindexval < minval and name != 'T_ULONGLONG':
-                self._test_warn(name, Index(hardminindexval))
-                self._test_warn(name, Index(minval-1))
-            if maxval < hardmaxindexval:
-                self._test_warn(name, Index(maxval+1))
-                self._test_warn(name, Index(hardmaxindexval))
+            if hardminval < minval:
+                self._test_warn(name, Index(hardminval))
+                self._test_warn(name, Index(minval-1), maxval)
+            if maxval < hardmaxval:
+                self._test_warn(name, Index(maxval+1), minval)
+                self._test_warn(name, Index(hardmaxval))
 
     def test_bool(self):
         ts = self.ts
@@ -138,14 +124,12 @@ class ReadWriteTests:
         self._test_int_range('T_INT', INT_MIN, INT_MAX,
                              hardlimit=(LONG_MIN, LONG_MAX))
         self._test_int_range('T_UINT', 0, UINT_MAX,
-                             hardlimit=(LONG_MIN, ULONG_MAX),
-                             indexlimit=(LONG_MIN, LONG_MAX))
+                             hardlimit=(LONG_MIN, ULONG_MAX))
 
     def test_long(self):
         self._test_int_range('T_LONG', LONG_MIN, LONG_MAX)
         self._test_int_range('T_ULONG', 0, ULONG_MAX,
-                             hardlimit=(LONG_MIN, ULONG_MAX),
-                             indexlimit=(LONG_MIN, LONG_MAX))
+                             hardlimit=(LONG_MIN, ULONG_MAX))
 
     def test_py_ssize_t(self):
         self._test_int_range('T_PYSSIZET', PY_SSIZE_T_MIN, PY_SSIZE_T_MAX, indexlimit=False)
@@ -153,7 +137,7 @@ class ReadWriteTests:
     def test_longlong(self):
         self._test_int_range('T_LONGLONG', LLONG_MIN, LLONG_MAX)
         self._test_int_range('T_ULONGLONG', 0, ULLONG_MAX,
-                             indexlimit=(LONG_MIN, LONG_MAX))
+                             hardlimit=(LONG_MIN, ULLONG_MAX))
 
     def test_bad_assignments(self):
         ts = self.ts

--- a/Misc/NEWS.d/next/Core and Builtins/2024-02-05-12-40-26.gh-issue-115011.L1AKF5.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2024-02-05-12-40-26.gh-issue-115011.L1AKF5.rst
@@ -1,0 +1,3 @@
+Setters for members with an unsigned integer type now support the same range
+of valid values for objects that has a :meth:`~object.__index__` method as
+for :class:`int`.


### PR DESCRIPTION
Setters for members with an unsigned integer type now support the same range of valid values for objects that has a __index__() method as for int.

Previously, Py_T_UINT, Py_T_ULONG and Py_T_ULLONG did not support objects that has a __index__() method larger than LONG_MAX.

Py_T_ULLONG did not support negative ints. Now it supports them and emits a RuntimeWarning.
(cherry picked from commit d9d6909697501a2604d5895f9f88aeec61274ab0)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-115011 -->
* Issue: gh-115011
<!-- /gh-issue-number -->
