### PR TITLE
[3.12] gh-97959: Fix rendering of routines in pydoc (GH-113941)

### DIFF
--- a/Lib/test/pydocfodder.py
+++ b/Lib/test/pydocfodder.py
@@ -2,6 +2,12 @@
 
 import types
 
+def global_func(x, y):
+    """Module global function"""
+
+def global_func2(x, y):
+    """Module global function 2"""
+
 class A:
     "A class."
 
@@ -26,7 +32,7 @@ class A:
         "A class method defined in A."
     A_classmethod = classmethod(A_classmethod)
 
-    def A_staticmethod():
+    def A_staticmethod(x, y):
         "A static method defined in A."
     A_staticmethod = staticmethod(A_staticmethod)
 
@@ -60,6 +66,28 @@ class B(A):
         "Method defined in B and D."
     def BCD_method(self):
         "Method defined in B, C and D."
+
+    @classmethod
+    def B_classmethod(cls, x):
+        "A class method defined in B."
+
+    global_func = global_func  # same name
+    global_func_alias = global_func
+    global_func2_alias = global_func2
+    B_classmethod_alias = B_classmethod
+    A_classmethod_ref = A.A_classmethod
+    A_staticmethod = A.A_staticmethod  # same name
+    A_staticmethod_alias = A.A_staticmethod
+    A_method_ref = A().A_method
+    A_method_alias = A.A_method
+    B_method_alias = B_method
+    __repr__ = object.__repr__  # same name
+    object_repr = object.__repr__
+    get = {}.get  # same name
+    dict_get = {}.get
+
+B.B_classmethod_ref = B.B_classmethod
+
 
 class C(A):
     "A class, derived from A."
@@ -136,3 +164,21 @@ class FunkyProperties(object):
 
 submodule = types.ModuleType(__name__ + '.submodule',
     """A submodule, which should appear in its parent's summary""")
+
+global_func_alias = global_func
+A_classmethod = A.A_classmethod  # same name
+A_classmethod2 = A.A_classmethod
+A_classmethod3 = B.A_classmethod
+A_staticmethod = A.A_staticmethod  # same name
+A_staticmethod_alias = A.A_staticmethod
+A_staticmethod_ref = A().A_staticmethod
+A_staticmethod_ref2 = B().A_staticmethod
+A_method = A().A_method  # same name
+A_method2 = A().A_method
+A_method3 = B().A_method
+B_method = B.B_method  # same name
+B_method2 = B.B_method
+count = list.count  # same name
+list_count = list.count
+get = {}.get  # same name
+dict_get = {}.get

--- a/Lib/test/test_enum.py
+++ b/Lib/test/test_enum.py
@@ -4752,22 +4752,22 @@ class Color(enum.Enum)
  |      The value of the Enum member.
  |
  |  ----------------------------------------------------------------------
- |  Methods inherited from enum.EnumType:
+ |  Static methods inherited from enum.EnumType:
  |
- |  __contains__(value) from enum.EnumType
+ |  __contains__(value)
  |      Return True if `value` is in `cls`.
  |
  |      `value` is in `cls` if:
  |      1) `value` is a member of `cls`, or
  |      2) `value` is the value of one of the `cls`'s members.
  |
- |  __getitem__(name) from enum.EnumType
+ |  __getitem__(name)
  |      Return the member matching `name`.
  |
- |  __iter__() from enum.EnumType
+ |  __iter__()
  |      Return members in definition order.
  |
- |  __len__() from enum.EnumType
+ |  __len__()
  |      Return the number of members (no aliases)
  |
  |  ----------------------------------------------------------------------

--- a/Misc/NEWS.d/next/Library/2024-01-11-15-10-53.gh-issue-97959.UOj6d4.rst
+++ b/Misc/NEWS.d/next/Library/2024-01-11-15-10-53.gh-issue-97959.UOj6d4.rst
@@ -1,0 +1,7 @@
+Fix rendering class methods, bound methods, method and function aliases in
+:mod:`pydoc`. Class methods no longer have "method of builtins.type
+instance" note. Corresponding notes are now added for class and unbound
+methods. Method and function aliases now have references to the module or
+the class where the origin was defined if it differs from the current. Bound
+methods are now listed in the static methods section. Methods of builtin
+classes are now supported as well as methods of Python classes.


### PR DESCRIPTION
* Class methods no longer have "method of builtins.type instance" note.
* Corresponding notes are now added for class and unbound methods.
* Method and function aliases now have references to the module or the class where the origin was defined if it differs from the current.
* Bound methods are now listed in the static methods section.
* Methods of builtin classes are now supported as well as methods of Python classes.

(cherry picked from commit 2939ad02be62110ffa2ac6c4d9211c85e1d1720f)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-97959 -->
* Issue: gh-97959
<!-- /gh-issue-number -->
