### PR TITLE
gh-103092: Add a mutex to make the random state of rotatingtree concurrent-safe

### DIFF
--- a/Misc/NEWS.d/next/Library/2024-02-12-11-42-48.gh-issue-103092.sGMKr0.rst
+++ b/Misc/NEWS.d/next/Library/2024-02-12-11-42-48.gh-issue-103092.sGMKr0.rst
@@ -1,0 +1,1 @@
+Isolate :mod:`_lsprof` (apply :pep:`687`).

--- a/Modules/_lsprof.c
+++ b/Modules/_lsprof.c
@@ -1004,9 +1004,7 @@ _lsprof_exec(PyObject *module)
 
 static PyModuleDef_Slot _lsprofslots[] = {
     {Py_mod_exec, _lsprof_exec},
-    // XXX gh-103092: fix isolation.
-    {Py_mod_multiple_interpreters, Py_MOD_MULTIPLE_INTERPRETERS_NOT_SUPPORTED},
-    //{Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
+    {Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
     {0, NULL}
 };
 

--- a/Modules/rotatingtree.c
+++ b/Modules/rotatingtree.c
@@ -1,3 +1,9 @@
+#ifndef Py_BUILD_CORE_BUILTIN
+#  define Py_BUILD_CORE_MODULE 1
+#endif
+
+#include "Python.h"
+#include "pycore_lock.h"
 #include "rotatingtree.h"
 
 #define KEY_LOWER_THAN(key1, key2)  ((char*)(key1) < (char*)(key2))
@@ -10,17 +16,20 @@
 
 static unsigned int random_value = 1;
 static unsigned int random_stream = 0;
+static PyMutex random_mutex = (PyMutex){0};
 
 static int
 randombits(int bits)
 {
     int result;
+    PyMutex_Lock(&random_mutex);
     if (random_stream < (1U << bits)) {
         random_value *= 1082527;
         random_stream = random_value;
     }
     result = random_stream & ((1<<bits)-1);
     random_stream >>= bits;
+    PyMutex_Unlock(&random_mutex);
     return result;
 }
 

--- a/Modules/rotatingtree.c
+++ b/Modules/rotatingtree.c
@@ -16,7 +16,9 @@
 
 static unsigned int random_value = 1;
 static unsigned int random_stream = 0;
-static PyMutex random_mutex = (PyMutex){0};
+#define _zero 0
+static PyMutex random_mutex = {0};
+#undef _zero
 
 static int
 randombits(int bits)

--- a/Modules/rotatingtree.c
+++ b/Modules/rotatingtree.c
@@ -16,9 +16,7 @@
 
 static unsigned int random_value = 1;
 static unsigned int random_stream = 0;
-#define _zero 0
 static PyMutex random_mutex = {0};
-#undef _zero
 
 static int
 randombits(int bits)

--- a/Tools/c-analyzer/cpython/globals-to-fix.tsv
+++ b/Tools/c-analyzer/cpython/globals-to-fix.tsv
@@ -480,3 +480,4 @@ Modules/readline.c	-	sigwinch_ohandler	-
 Modules/readline.c	-	completed_input_string	-
 Modules/rotatingtree.c	-	random_stream	-
 Modules/rotatingtree.c	-	random_value	-
+Modules/rotatingtree.c	-	random_mutex	-


### PR DESCRIPTION
The only two static variables, `random_value` and `random_stream`, in `rotatingtree.c` (which is only used by `_lsprof` module) are just the state of a pseudo-random generator. They can be shared between interpreters if we add a mutex to make them concurrent-safe. And this work can be done easily, and make the `_lsprofile` module isolated.

Another way to isolate `_lsprof` is to store the two variables in module state. This will involve more work and review of modifications to existing functions to pass the module state. See #115130.

Adding the mutex does not introduce a noticeable performance decrease. See the comment below for a micro benchmark.

@erlend-aasland 

<!-- gh-issue-number: gh-103092 -->
* Issue: gh-103092
<!-- /gh-issue-number -->
