### PR TITLE
gh-115225: Parsing fractions correctly in datetime.time.fromisoformat

### DIFF
--- a/Lib/_pydatetime.py
+++ b/Lib/_pydatetime.py
@@ -372,10 +372,7 @@ _FRACTION_CORRECTION = [100000, 10000, 1000, 100, 10]
 
 
 def _parse_hh_mm_ss_ff(tstr):
-    # Parses things of the forms
-    # HH[{.,}fff[fff]]
-    # HH[:?MM[{.,}fff[fff]]]
-    # HH[:?MM[:?SS[{.,}fff[fff]]]]
+    # Parses things of the form HH[:?MM[:?SS[{.,}fff[fff]]]]
     len_str = len(tstr)
 
     time_comps = [0, 0, 0, 0]
@@ -419,9 +416,8 @@ def _parse_hh_mm_ss_ff(tstr):
 
             extra_time = float("." + tstr[pos:(pos+to_parse)])
             while comp < 2:
-                time_comps[comp + 1] = int(extra_time * 60)
-                extra_time = extra_time * 60 - time_comps[comp + 1]
-                comp += 1
+                element = "hour" if comp == 0 else "minute"
+                raise ValueError(f"Fractional {element} not supported")
             if comp == 2:
                 time_comps[comp + 1] = int(extra_time * 1e6)
 

--- a/Misc/NEWS.d/next/Library/2024-02-11-20-56-52.gh-issue-115225.8uXOZy.rst
+++ b/Misc/NEWS.d/next/Library/2024-02-11-20-56-52.gh-issue-115225.8uXOZy.rst
@@ -1,2 +1,2 @@
 ISO8601 Format recommends "a decimal fraction may be added to the lowest order time element present." 
-Thus "T0314.15" should be valid and yield "03:14:09", but currently yields "03:14:00.150000". This has been corrected, with the addition of handling cases of "T03.50" as "03:30", "T0320.25" as "03:20:15" and "T032010.15" as "03:20:10.15".
+Thus "T0314.15" should be valid and yield "03:14:09", but currently yields "03:14:00.150000". Due to deliberate choice, such an expression would now throw a ValueError because such a string is more likely a typo than an actual fractional value.

--- a/Misc/NEWS.d/next/Library/2024-02-11-20-56-52.gh-issue-115225.8uXOZy.rst
+++ b/Misc/NEWS.d/next/Library/2024-02-11-20-56-52.gh-issue-115225.8uXOZy.rst
@@ -1,2 +1,2 @@
-ISO8601 Format recommends "a decimal fraction may be added to the lowest order time element present." 
+ISO8601 Format recommends "a decimal fraction may be added to the lowest order time element present."
 Thus "T0314.15" should be valid and yield "03:14:09", but currently yields "03:14:00.150000". Due to deliberate choice, such an expression would now throw a ValueError because such a string is more likely a typo than an actual fractional value.

--- a/Misc/NEWS.d/next/Library/2024-02-11-20-56-52.gh-issue-115225.8uXOZy.rst
+++ b/Misc/NEWS.d/next/Library/2024-02-11-20-56-52.gh-issue-115225.8uXOZy.rst
@@ -1,0 +1,2 @@
+ISO8601 Format recommends "a decimal fraction may be added to the lowest order time element present." 
+Thus "T0314.15" should be valid and yield "03:14:09", but currently yields "03:14:00.150000". This has been corrected, with the addition of handling cases of "T03.50" as "03:30", "T0320.25" as "03:20:15" and "T032010.15" as "03:20:10.15".

--- a/Modules/_datetimemodule.c
+++ b/Modules/_datetimemodule.c
@@ -855,7 +855,7 @@ parse_hh_mm_ss_ff(const char *tstr, const char *tstr_end, int *hour,
         else if (c == '.' || c == ',') {
             has_decimal = 1;
             break;
-        } 
+        }
         else if (!has_separator) {
             --p;
         } else {

--- a/Modules/_datetimemodule.c
+++ b/Modules/_datetimemodule.c
@@ -879,7 +879,7 @@ parse_hh_mm_ss_ff(const char *tstr, const char *tstr_end, int *hour,
         return -3;
     }
 
-    static int dividing_factor[] = {
+    int dividing_factor[] = {
         10, 100, 1000, 10000, 100000, 1000000
     };
 

--- a/Modules/_datetimemodule.c
+++ b/Modules/_datetimemodule.c
@@ -882,18 +882,13 @@ parse_hh_mm_ss_ff(const char *tstr, const char *tstr_end, int *hour,
     static int dividing_factor[] = {
         10, 100, 1000, 10000, 100000, 1000000
     };
-    int *pointers[] = {
-        minute, second, microsecond
-    };
 
     float extra_time = extra_time_digits / (dividing_factor[to_parse - 1] * 1.);
     while (i < 2) {
-        *pointers[i] = (extra_time * 60);
-        extra_time = (extra_time * 60) - *pointers[i];
-        i++;
+        return -3;
     }
     if (i == 2) {
-        *pointers[i] = (extra_time * dividing_factor[5]);
+        *microsecond = (extra_time * dividing_factor[5]);
     }
 
     while (is_digit(*p) && p < p_end) {

--- a/datetime_test.py
+++ b/datetime_test.py
@@ -1,4 +1,0 @@
-import datetime as dt
-
-time = dt.time.fromisoformat("T1205.50")
-print(time)

--- a/datetime_test.py
+++ b/datetime_test.py
@@ -1,0 +1,4 @@
+import datetime as dt
+
+time = dt.time.fromisoformat("T1205.50")
+print(time)


### PR DESCRIPTION
[Issue#115225](https://github.com/python/cpython/issues/115225) is regarding the incorrect behavior of `datetime.time.fromisoformat`.

@xitop points out in ISO8601 specified that a decimal fraction may be added to the lowest-order time element present. The OP also mentions that the current docs says fractional minutes/hours are not supported, and recommends to throw `ValueError`.

I found the current version had tried to parse fractional quantities somewhat but incorrectly, so I opted for including fractional time element and not raising an exception. Changed `Lib/_pydatetime.py` and `Modules/_datetimemodule.c`. All `datetime` tests are ok.