### PR TITLE
gh-115320: Refactor `get_hash_info` in `sysmodule.c` not to swallow errors

### DIFF
--- a/Python/sysmodule.c
+++ b/Python/sysmodule.c
@@ -1523,7 +1523,7 @@ get_hash_info(PyThreadState *tstate)
     SET_HASH_INFO_ITEM(PyLong_FromLong(hashfunc->seed_bits));
     SET_HASH_INFO_ITEM(PyLong_FromLong(Py_HASH_CUTOFF));
 
-#undef SET_ITEM
+#undef SET_HASH_INFO_ITEM
 
     return hash_info;
 }

--- a/Python/sysmodule.c
+++ b/Python/sysmodule.c
@@ -1503,10 +1503,10 @@ get_hash_info(PyThreadState *tstate)
     }
     hashfunc = PyHash_GetFuncDef();
 
-#define SET_HASH_INFO_ITEM(call)                             \
+#define SET_HASH_INFO_ITEM(CALL)                             \
     do {                                                     \
-        PyObject *item = call;                               \
-        if (_PyErr_Occurred(tstate)) {                       \
+        PyObject *item = (CALL);                             \
+        if (item == NULL) {                                  \
             Py_CLEAR(hash_info);                             \
             return NULL;                                     \
         }                                                    \

--- a/Python/sysmodule.c
+++ b/Python/sysmodule.c
@@ -1505,7 +1505,7 @@ get_hash_info(PyThreadState *tstate)
 
 #define SET_HASH_INFO_ITEM(item)                             \
     do {                                                     \
-        if (item == NULL) {                                  \
+        if (_PyErr_Occurred(tstate)) {                       \
             Py_CLEAR(hash_info);                             \
             return NULL;                                     \
         }                                                    \

--- a/Python/sysmodule.c
+++ b/Python/sysmodule.c
@@ -1503,8 +1503,9 @@ get_hash_info(PyThreadState *tstate)
     }
     hashfunc = PyHash_GetFuncDef();
 
-#define SET_HASH_INFO_ITEM(item)                             \
+#define SET_HASH_INFO_ITEM(call)                             \
     do {                                                     \
+        PyObject *item = call;                               \
         if (_PyErr_Occurred(tstate)) {                       \
             Py_CLEAR(hash_info);                             \
             return NULL;                                     \

--- a/Python/sysmodule.c
+++ b/Python/sysmodule.c
@@ -1498,31 +1498,32 @@ get_hash_info(PyThreadState *tstate)
     int field = 0;
     PyHash_FuncDef *hashfunc;
     hash_info = PyStructSequence_New(&Hash_InfoType);
-    if (hash_info == NULL)
-        return NULL;
-    hashfunc = PyHash_GetFuncDef();
-    PyStructSequence_SET_ITEM(hash_info, field++,
-                              PyLong_FromLong(8*sizeof(Py_hash_t)));
-    PyStructSequence_SET_ITEM(hash_info, field++,
-                              PyLong_FromSsize_t(_PyHASH_MODULUS));
-    PyStructSequence_SET_ITEM(hash_info, field++,
-                              PyLong_FromLong(_PyHASH_INF));
-    PyStructSequence_SET_ITEM(hash_info, field++,
-                              PyLong_FromLong(0));  // This is no longer used
-    PyStructSequence_SET_ITEM(hash_info, field++,
-                              PyLong_FromLong(_PyHASH_IMAG));
-    PyStructSequence_SET_ITEM(hash_info, field++,
-                              PyUnicode_FromString(hashfunc->name));
-    PyStructSequence_SET_ITEM(hash_info, field++,
-                              PyLong_FromLong(hashfunc->hash_bits));
-    PyStructSequence_SET_ITEM(hash_info, field++,
-                              PyLong_FromLong(hashfunc->seed_bits));
-    PyStructSequence_SET_ITEM(hash_info, field++,
-                              PyLong_FromLong(Py_HASH_CUTOFF));
-    if (_PyErr_Occurred(tstate)) {
-        Py_CLEAR(hash_info);
+    if (hash_info == NULL) {
         return NULL;
     }
+    hashfunc = PyHash_GetFuncDef();
+
+#define SET_HASH_INFO_ITEM(item)                             \
+    do {                                                     \
+        if (item == NULL) {                                  \
+            Py_CLEAR(hash_info);                             \
+            return NULL;                                     \
+        }                                                    \
+        PyStructSequence_SET_ITEM(hash_info, field++, item); \
+    } while(0)
+
+    SET_HASH_INFO_ITEM(PyLong_FromLong(8 * sizeof(Py_hash_t)));
+    SET_HASH_INFO_ITEM(PyLong_FromSsize_t(_PyHASH_MODULUS));
+    SET_HASH_INFO_ITEM(PyLong_FromLong(_PyHASH_INF));
+    SET_HASH_INFO_ITEM(PyLong_FromLong(0));  // This is no longer used
+    SET_HASH_INFO_ITEM(PyLong_FromLong(_PyHASH_IMAG));
+    SET_HASH_INFO_ITEM(PyUnicode_FromString(hashfunc->name));
+    SET_HASH_INFO_ITEM(PyLong_FromLong(hashfunc->hash_bits));
+    SET_HASH_INFO_ITEM(PyLong_FromLong(hashfunc->seed_bits));
+    SET_HASH_INFO_ITEM(PyLong_FromLong(Py_HASH_CUTOFF));
+
+#undef SET_ITEM
+
     return hash_info;
 }
 /*[clinic input]


### PR DESCRIPTION
The error here is unlikely, but possible in theory.
The change itself is quite straight-forward.

Skipping news, because there are no user-facing changes.

<!-- gh-issue-number: gh-115320 -->
* Issue: gh-115320
<!-- /gh-issue-number -->
