### PR TITLE
gh-115317: Rewrite changelog filter to use vanilla JavaScript

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,6 +1,6 @@
 root = true
 
-[*.{py,c,cpp,h,rst,md,yml}]
+[*.{py,c,cpp,h,js,rst,md,yml}]
 trim_trailing_whitespace = true
 insert_final_newline = true
 indent_style = space
@@ -11,5 +11,5 @@ indent_size = 4
 [*.rst]
 indent_size = 3
 
-[*.yml]
+[*.{js,yml}]
 indent_size = 2

--- a/Doc/tools/static/changelog_search.js
+++ b/Doc/tools/static/changelog_search.js
@@ -14,6 +14,7 @@ document.addEventListener('DOMContentLoaded', function() {
         catch (e) {
             return; // not a valid regex (yet)
         }
+        // find headers for the versions (What's new in Python X.Y.Z?)
         const h2s = document.querySelectorAll('#changelog h2');
         for(let h2 of h2s) {
             let sections_found = 0;
@@ -21,6 +22,7 @@ document.addEventListener('DOMContentLoaded', function() {
             const h3s = h2.parentNode.querySelectorAll('h3');
             for(let h3 of h3s) {
                 let entries_found = 0;
+                // find all the entries
                 const lis = h3.parentNode.querySelectorAll('li');
                 for(let li of lis) {
                     // check if the query matches the entry

--- a/Doc/tools/static/changelog_search.js
+++ b/Doc/tools/static/changelog_search.js
@@ -16,7 +16,7 @@ document.addEventListener('DOMContentLoaded', function() {
         }
         // find headers for the versions (What's new in Python X.Y.Z?)
         const h2s = document.querySelectorAll('#changelog h2');
-        for(let h2 of h2s) {
+        for(const h2 of h2s) {
             let sections_found = 0;
             // find headers for the sections (Core, Library, etc.)
             const h3s = h2.parentNode.querySelectorAll('h3');

--- a/Doc/tools/static/changelog_search.js
+++ b/Doc/tools/static/changelog_search.js
@@ -11,7 +11,7 @@ document.addEventListener("DOMContentLoaded", function () {
       ].join("\n"),
     );
 
-  function dofilter() {
+  function doFilter() {
     let query;
     try {
       query = new RegExp(document.querySelector("#searchbox").value, "i");
@@ -52,8 +52,8 @@ document.addEventListener("DOMContentLoaded", function () {
       }
     }
   }
-  document.querySelector("#searchbox").addEventListener("keyup", dofilter);
+  document.querySelector("#searchbox").addEventListener("keyup", doFilter);
   document
     .querySelector("#searchbox-submit")
-    .addEventListener("click", dofilter);
+    .addEventListener("click", doFilter);
 });

--- a/Doc/tools/static/changelog_search.js
+++ b/Doc/tools/static/changelog_search.js
@@ -43,10 +43,12 @@ document.addEventListener('DOMContentLoaded', function() {
                     h3.parentNode.style.display = 'none';
                 }
             }
-            if (sections_found > 0)
+            if (sections_found > 0) {
                 h2.parentNode.style.display = 'block';
-            else
+            }
+            else {
                 h2.parentNode.style.display = 'none';
+            }
         }
     }
     document.querySelector('#searchbox').addEventListener('keyup', dofilter);

--- a/Doc/tools/static/changelog_search.js
+++ b/Doc/tools/static/changelog_search.js
@@ -24,7 +24,7 @@ document.addEventListener("DOMContentLoaded", function () {
       let sections_found = 0;
       // find headers for the sections (Core, Library, etc.)
       const h3s = h2.parentNode.querySelectorAll("h3");
-      for (let h3 of h3s) {
+      for (const h3 of h3s) {
         let entries_found = 0;
         // find all the entries
         const lis = h3.parentNode.querySelectorAll("li");

--- a/Doc/tools/static/changelog_search.js
+++ b/Doc/tools/static/changelog_search.js
@@ -1,56 +1,59 @@
-document.addEventListener('DOMContentLoaded', function() {
-    // add the search form and bind the events
-    document.querySelector('h1').insertAdjacentHTML('afterend', [
-      '<p>Filter entries by content:',
-      '<input type="text" value="" id="searchbox" style="width: 50%">',
-      '<input type="submit" id="searchbox-submit" value="Filter"></p>'
-    ].join('\n'));
+document.addEventListener("DOMContentLoaded", function () {
+  // add the search form and bind the events
+  document
+    .querySelector("h1")
+    .insertAdjacentHTML(
+      "afterend",
+      [
+        "<p>Filter entries by content:",
+        '<input type="text" value="" id="searchbox" style="width: 50%">',
+        '<input type="submit" id="searchbox-submit" value="Filter"></p>',
+      ].join("\n"),
+    );
 
-    function dofilter() {
-        let query;
-        try {
-            query = new RegExp(document.querySelector('#searchbox').value, 'i');
-        }
-        catch (e) {
-            return; // not a valid regex (yet)
-        }
-        // find headers for the versions (What's new in Python X.Y.Z?)
-        const h2s = document.querySelectorAll('#changelog h2');
-        for(const h2 of h2s) {
-            let sections_found = 0;
-            // find headers for the sections (Core, Library, etc.)
-            const h3s = h2.parentNode.querySelectorAll('h3');
-            for(let h3 of h3s) {
-                let entries_found = 0;
-                // find all the entries
-                const lis = h3.parentNode.querySelectorAll('li');
-                for(let li of lis) {
-                    // check if the query matches the entry
-                    if (query.test(li.textContent)) {
-                        li.style.display = 'block';
-                        entries_found++;
-                    }
-                    else {
-                        li.style.display = 'none';
-                    }
-                }
-                // if there are entries, show the section, otherwise hide it
-                if (entries_found > 0) {
-                    h3.parentNode.style.display = 'block';
-                    sections_found++;
-                }
-                else {
-                    h3.parentNode.style.display = 'none';
-                }
-            }
-            if (sections_found > 0) {
-                h2.parentNode.style.display = 'block';
-            }
-            else {
-                h2.parentNode.style.display = 'none';
-            }
-        }
+  function dofilter() {
+    let query;
+    try {
+      query = new RegExp(document.querySelector("#searchbox").value, "i");
+    } catch (e) {
+      return; // not a valid regex (yet)
     }
-    document.querySelector('#searchbox').addEventListener('keyup', dofilter);
-    document.querySelector('#searchbox-submit').addEventListener('click', dofilter);
+    // find headers for the versions (What's new in Python X.Y.Z?)
+    const h2s = document.querySelectorAll("#changelog h2");
+    for (const h2 of h2s) {
+      let sections_found = 0;
+      // find headers for the sections (Core, Library, etc.)
+      const h3s = h2.parentNode.querySelectorAll("h3");
+      for (let h3 of h3s) {
+        let entries_found = 0;
+        // find all the entries
+        const lis = h3.parentNode.querySelectorAll("li");
+        for (let li of lis) {
+          // check if the query matches the entry
+          if (query.test(li.textContent)) {
+            li.style.display = "block";
+            entries_found++;
+          } else {
+            li.style.display = "none";
+          }
+        }
+        // if there are entries, show the section, otherwise hide it
+        if (entries_found > 0) {
+          h3.parentNode.style.display = "block";
+          sections_found++;
+        } else {
+          h3.parentNode.style.display = "none";
+        }
+      }
+      if (sections_found > 0) {
+        h2.parentNode.style.display = "block";
+      } else {
+        h2.parentNode.style.display = "none";
+      }
+    }
+  }
+  document.querySelector("#searchbox").addEventListener("keyup", dofilter);
+  document
+    .querySelector("#searchbox-submit")
+    .addEventListener("click", dofilter);
 });

--- a/Doc/tools/static/changelog_search.js
+++ b/Doc/tools/static/changelog_search.js
@@ -1,53 +1,52 @@
-$(document).ready(function() {
+document.addEventListener('DOMContentLoaded', function() {
     // add the search form and bind the events
-    $('h1').after([
+    document.querySelector('h1').insertAdjacentHTML('afterend', [
       '<p>Filter entries by content:',
       '<input type="text" value="" id="searchbox" style="width: 50%">',
       '<input type="submit" id="searchbox-submit" value="Filter"></p>'
     ].join('\n'));
 
     function dofilter() {
+        let query;
         try {
-            var query = new RegExp($('#searchbox').val(), 'i');
+            query = new RegExp(document.querySelector('#searchbox').value, 'i');
         }
         catch (e) {
             return; // not a valid regex (yet)
         }
-        // find headers for the versions (What's new in Python X.Y.Z?)
-        $('#changelog h2').each(function(index1, h2) {
-            var h2_parent = $(h2).parent();
-            var sections_found = 0;
+        const h2s = document.querySelectorAll('#changelog h2');
+        for(let h2 of h2s) {
+            let sections_found = 0;
             // find headers for the sections (Core, Library, etc.)
-            h2_parent.find('h3').each(function(index2, h3) {
-                var h3_parent = $(h3).parent();
-                var entries_found = 0;
-                // find all the entries
-                h3_parent.find('li').each(function(index3, li) {
-                    var li = $(li);
+            const h3s = h2.parentNode.querySelectorAll('h3');
+            for(let h3 of h3s) {
+                let entries_found = 0;
+                const lis = h3.parentNode.querySelectorAll('li');
+                for(let li of lis) {
                     // check if the query matches the entry
-                    if (query.test(li.text())) {
-                        li.show();
+                    if (query.test(li.textContent)) {
+                        li.style.display = 'block';
                         entries_found++;
                     }
                     else {
-                        li.hide();
+                        li.style.display = 'none';
                     }
-                });
+                }
                 // if there are entries, show the section, otherwise hide it
                 if (entries_found > 0) {
-                    h3_parent.show();
+                    h3.parentNode.style.display = 'block';
                     sections_found++;
                 }
                 else {
-                    h3_parent.hide();
+                    h3.parentNode.style.display = 'none';
                 }
-            });
+            }
             if (sections_found > 0)
-                h2_parent.show();
+                h2.parentNode.style.display = 'block';
             else
-                h2_parent.hide();
-        });
+                h2.parentNode.style.display = 'none';
+        }
     }
-    $('#searchbox').keyup(dofilter);
-    $('#searchbox-submit').click(dofilter);
+    document.querySelector('#searchbox').addEventListener('keyup', dofilter);
+    document.querySelector('#searchbox-submit').addEventListener('click', dofilter);
 });


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

Sphinx removed the jQuery library to improve performance, but the changelog filter was still using it. This PR rewrites it to use basic JavaScript. 


<!-- gh-issue-number: gh-115317 -->
* Issue: gh-115317
<!-- /gh-issue-number -->

# Demo

https://cpython-previews--115324.org.readthedocs.build/en/115324/whatsnew/changelog.html

