### PR TITLE
gh-87804: Fix the refleak in error handling of `_pystatvfs_fromstructstatfs`

### DIFF
--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -12916,14 +12916,15 @@ _pystatvfs_fromstructstatfs(PyObject *module, struct statfs st) {
 
     _Static_assert(sizeof(st.f_blocks) == sizeof(long long), "assuming large file");
 
-#define SET_ITEM(v, index, item)                   \
-    do {                                           \
-        if (item == NULL) {                        \
-            Py_DECREF(v);                          \
-            return NULL;                           \
-        }                                          \
-        PyStructSequence_SET_ITEM(v, index, item); \
-    } while (0)                                    \
+#define SET_ITEM(v, index, expr)                    \
+    do {                                            \
+        PyObject *obj = (expr);                     \
+        if (obj == NULL || PyErr_Occurred()) {      \
+            Py_DECREF(v);                           \
+            return NULL;                            \
+        }                                           \
+        PyStructSequence_SET_ITEM(v, (index), obj); \
+    } while (0)                                     \
 
     SET_ITEM(v, 0, PyLong_FromLong((long) st.f_iosize));
     SET_ITEM(v, 1, PyLong_FromLong((long) st.f_bsize));

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -12920,10 +12920,10 @@ _pystatvfs_fromstructstatfs(PyObject *module, struct statfs st) {
     do {                                            \
         PyObject *obj = (EXPR);                     \
         if (obj == NULL || PyErr_Occurred()) {      \
-            Py_DECREF(V);                           \
+            Py_DECREF((V));                           \
             return NULL;                            \
         }                                           \
-        PyStructSequence_SET_ITEM(V, (INDEX), obj); \
+        PyStructSequence_SET_ITEM((V), (INDEX), obj); \
     } while (0)
 
     SET_ITEM(v, 0, PyLong_FromLong((long) st.f_iosize));

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -12916,14 +12916,14 @@ _pystatvfs_fromstructstatfs(PyObject *module, struct statfs st) {
 
     _Static_assert(sizeof(st.f_blocks) == sizeof(long long), "assuming large file");
 
-#define SET_ITEM(v, index, expr)                    \
+#define SET_ITEM(V, INDEX, EXPR)                    \
     do {                                            \
-        PyObject *obj = (expr);                     \
+        PyObject *obj = (EXPR);                     \
         if (obj == NULL || PyErr_Occurred()) {      \
-            Py_DECREF(v);                           \
+            Py_DECREF(V);                           \
             return NULL;                            \
         }                                           \
-        PyStructSequence_SET_ITEM(v, (index), obj); \
+        PyStructSequence_SET_ITEM(V, (INDEX), obj); \
     } while (0)
 
     SET_ITEM(v, 0, PyLong_FromLong((long) st.f_iosize));

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -12916,13 +12916,13 @@ _pystatvfs_fromstructstatfs(PyObject *module, struct statfs st) {
 
     _Static_assert(sizeof(st.f_blocks) == sizeof(long long), "assuming large file");
 
-#define SET_ITEM(V, INDEX, EXPR)                    \
-    do {                                            \
-        PyObject *obj = (EXPR);                     \
-        if (obj == NULL || PyErr_Occurred()) {      \
+#define SET_ITEM(V, INDEX, EXPR)                      \
+    do {                                              \
+        PyObject *obj = (EXPR);                       \
+        if (obj == NULL) {                            \
             Py_DECREF((V));                           \
-            return NULL;                            \
-        }                                           \
+            return NULL;                              \
+        }                                             \
         PyStructSequence_SET_ITEM((V), (INDEX), obj); \
     } while (0)
 

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -12916,14 +12916,14 @@ _pystatvfs_fromstructstatfs(PyObject *module, struct statfs st) {
 
     _Static_assert(sizeof(st.f_blocks) == sizeof(long long), "assuming large file");
 
-#define SET_ITEM(V, INDEX, EXPR)                      \
-    do {                                              \
-        PyObject *obj = (EXPR);                       \
-        if (obj == NULL) {                            \
-            Py_DECREF((V));                           \
-            return NULL;                              \
-        }                                             \
-        PyStructSequence_SET_ITEM((V), (INDEX), obj); \
+#define SET_ITEM(SEQ, INDEX, EXPR)                       \
+    do {                                                 \
+        PyObject *obj = (EXPR);                          \
+        if (obj == NULL) {                               \
+            Py_DECREF((SEQ));                            \
+            return NULL;                                 \
+        }                                                \
+        PyStructSequence_SET_ITEM((SEQ), (INDEX), obj);  \
     } while (0)
 
     SET_ITEM(v, 0, PyLong_FromLong((long) st.f_iosize));

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -12924,7 +12924,7 @@ _pystatvfs_fromstructstatfs(PyObject *module, struct statfs st) {
             return NULL;                            \
         }                                           \
         PyStructSequence_SET_ITEM(v, (index), obj); \
-    } while (0)                                     \
+    } while (0)
 
     SET_ITEM(v, 0, PyLong_FromLong((long) st.f_iosize));
     SET_ITEM(v, 1, PyLong_FromLong((long) st.f_bsize));


### PR DESCRIPTION
I messed up macro expansion rules, sorry!

It was:

```c
do { if (PyLong_FromLong((long) st.f_iosize) == ((void*)0)) { Py_DECREF("./Modules/posixmodule.c", 12928, ((PyObject*)((v)))); return ((void*)0); } PyStructSequence_SetItem(v, 0, PyLong_FromLong((long) st.f_iosize)); } while (0);
```

It is now:

```c
do { PyObject *obj = (PyLong_FromLong((long) st.f_iosize)); if (obj == ((void*)0) || PyErr_Occurred()) { Py_DECREF("./Modules/posixmodule.c", 12929, ((PyObject*)((v)))); return ((void*)0); } PyStructSequence_SetItem(v, (0), obj); } while (0);
```

<!-- gh-issue-number: gh-87804 -->
* Issue: gh-87804
<!-- /gh-issue-number -->
