### PR TITLE
gh-105813: Proof-of-concept: Add PY_DEFINE macro that wraps AC_DEFINE

### DIFF
--- a/configure
+++ b/configure
@@ -3490,6 +3490,9 @@ ac_compiler_gnu=$ac_cv_c_compiler_gnu
 
 
 
+
+
+
 if test "$srcdir" != . -a "$srcdir" != "$(pwd)"; then
     # If we're building out-of-tree, we need to make sure the following
     # resources get picked up before their $srcdir counterparts.
@@ -3823,6 +3826,9 @@ SOVERSION=1.0
 printf "%s\n" "#define _NETBSD_SOURCE 1" >>confdefs.h
 
 
+printf "%s\n" "#define Py__NETBSD_SOURCE 1" >>confdefs.h
+
+
 # The later definition of _XOPEN_SOURCE and _POSIX_C_SOURCE disables
 # certain features on FreeBSD, so we need __BSD_VISIBLE to re-enable
 # them.
@@ -3830,11 +3836,17 @@ printf "%s\n" "#define _NETBSD_SOURCE 1" >>confdefs.h
 printf "%s\n" "#define __BSD_VISIBLE 1" >>confdefs.h
 
 
+printf "%s\n" "#define Py___BSD_VISIBLE 1" >>confdefs.h
+
+
 # The later definition of _XOPEN_SOURCE and _POSIX_C_SOURCE disables
 # certain features on Mac OS X, so we need _DARWIN_C_SOURCE to re-enable
 # them.
 
 printf "%s\n" "#define _DARWIN_C_SOURCE 1" >>confdefs.h
+
+
+printf "%s\n" "#define Py__DARWIN_C_SOURCE 1" >>confdefs.h
 
 
 
@@ -4072,6 +4084,9 @@ then
 	SUNOS_VERSION=`echo $ac_sys_release | sed -e 's!\.\(0-9\)$!.0\1!g' | tr -d '.'`
 
 printf "%s\n" "#define Py_SUNOS_VERSION $SUNOS_VERSION" >>confdefs.h
+
+
+printf "%s\n" "#define Py_Py_SUNOS_VERSION $SUNOS_VERSION" >>confdefs.h
 
     fi
 fi
@@ -4337,6 +4352,9 @@ fi
 printf "%s\n" "#define _PYTHONFRAMEWORK \"${PYTHONFRAMEWORK}\"" >>confdefs.h
 
 
+printf "%s\n" "#define Py__PYTHONFRAMEWORK \"${PYTHONFRAMEWORK}\"" >>confdefs.h
+
+
 
 if test "$cross_compiling" = yes; then
 	case "$host" in
@@ -4389,6 +4407,9 @@ case $ac_sys_system/$ac_sys_release in
 
 printf "%s\n" "#define _BSD_SOURCE 1" >>confdefs.h
 
+
+printf "%s\n" "#define Py__BSD_SOURCE 1" >>confdefs.h
+
     ;;
   OpenBSD/*)
     # OpenBSD undoes our definition of __BSD_VISIBLE if _XOPEN_SOURCE is
@@ -4396,6 +4417,9 @@ printf "%s\n" "#define _BSD_SOURCE 1" >>confdefs.h
     # As this has a different meaning on Linux, only define it on OpenBSD
 
 printf "%s\n" "#define _BSD_SOURCE 1" >>confdefs.h
+
+
+printf "%s\n" "#define Py__BSD_SOURCE 1" >>confdefs.h
 
     ;;
   # Defining _XOPEN_SOURCE on NetBSD version prior to the introduction of
@@ -4456,6 +4480,9 @@ then
 printf "%s\n" "#define _XOPEN_SOURCE 700" >>confdefs.h
 
 
+printf "%s\n" "#define Py__XOPEN_SOURCE 700" >>confdefs.h
+
+
   # On Tru64 Unix 4.0F, defining _XOPEN_SOURCE also requires
   # definition of _XOPEN_SOURCE_EXTENDED and _POSIX_C_SOURCE, or else
   # several APIs are not declared. Since this is also needed in some
@@ -4464,8 +4491,14 @@ printf "%s\n" "#define _XOPEN_SOURCE 700" >>confdefs.h
 printf "%s\n" "#define _XOPEN_SOURCE_EXTENDED 1" >>confdefs.h
 
 
+printf "%s\n" "#define Py__XOPEN_SOURCE_EXTENDED 1" >>confdefs.h
+
+
 
 printf "%s\n" "#define _POSIX_C_SOURCE 200809L" >>confdefs.h
+
+
+printf "%s\n" "#define Py__POSIX_C_SOURCE 200809L" >>confdefs.h
 
 fi
 
@@ -4481,6 +4514,9 @@ if test $define_stdc_a1 = yes
 then
 
 printf "%s\n" "#define _INCLUDE__STDC_A1_SOURCE 1" >>confdefs.h
+
+
+printf "%s\n" "#define Py__INCLUDE__STDC_A1_SOURCE 1" >>confdefs.h
 
 fi
 
@@ -6876,6 +6912,9 @@ esac
 printf "%s\n" "#define PY_SUPPORT_TIER $PY_SUPPORT_TIER" >>confdefs.h
 
 
+printf "%s\n" "#define Py_PY_SUPPORT_TIER $PY_SUPPORT_TIER" >>confdefs.h
+
+
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for -Wl,--no-as-needed" >&5
 printf %s "checking for -Wl,--no-as-needed... " >&6; }
 if test ${ac_cv_wl_no_as_needed+y}
@@ -6934,6 +6973,9 @@ printf "%s\n" "$ANDROID_API_LEVEL" >&6; }
   fi
 
 printf "%s\n" "#define ANDROID_API_LEVEL $ANDROID_API_LEVEL" >>confdefs.h
+
+
+printf "%s\n" "#define Py_ANDROID_API_LEVEL $ANDROID_API_LEVEL" >>confdefs.h
 
 
   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for the Android arm ABI" >&5
@@ -7326,6 +7368,9 @@ if test $enable_shared = "yes"; then
   PY_ENABLE_SHARED=1
 
 printf "%s\n" "#define Py_ENABLE_SHARED 1" >>confdefs.h
+
+
+printf "%s\n" "#define Py_Py_ENABLE_SHARED 1" >>confdefs.h
 
   case $ac_sys_system in
     CYGWIN*)
@@ -7929,6 +7974,9 @@ then
 
 printf "%s\n" "#define Py_GIL_DISABLED 1" >>confdefs.h
 
+
+printf "%s\n" "#define Py_Py_GIL_DISABLED 1" >>confdefs.h
+
   # Add "t" for "threaded"
   ABIFLAGS="${ABIFLAGS}t"
 fi
@@ -7945,6 +7993,9 @@ if test "$withval" != no
 then
 
 printf "%s\n" "#define Py_DEBUG 1" >>confdefs.h
+
+
+printf "%s\n" "#define Py_Py_DEBUG 1" >>confdefs.h
 
   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
 printf "%s\n" "yes" >&6; };
@@ -7981,6 +8032,9 @@ then
 
 printf "%s\n" "#define Py_TRACE_REFS 1" >>confdefs.h
 
+
+printf "%s\n" "#define Py_Py_TRACE_REFS 1" >>confdefs.h
+
 fi
 
 
@@ -8004,6 +8058,9 @@ then :
 
 
 printf "%s\n" "#define Py_STATS 1" >>confdefs.h
+
+
+printf "%s\n" "#define Py_Py_STATS 1" >>confdefs.h
 
 
 fi
@@ -9330,10 +9387,19 @@ fi
 printf "%s\n" "#define _WASI_EMULATED_SIGNAL 1" >>confdefs.h
 
 
+printf "%s\n" "#define Py__WASI_EMULATED_SIGNAL 1" >>confdefs.h
+
+
 printf "%s\n" "#define _WASI_EMULATED_GETPID 1" >>confdefs.h
 
 
+printf "%s\n" "#define Py__WASI_EMULATED_GETPID 1" >>confdefs.h
+
+
 printf "%s\n" "#define _WASI_EMULATED_PROCESS_CLOCKS 1" >>confdefs.h
+
+
+printf "%s\n" "#define Py__WASI_EMULATED_PROCESS_CLOCKS 1" >>confdefs.h
 
     LIBS="$LIBS -lwasi-emulated-signal -lwasi-emulated-getpid -lwasi-emulated-process-clocks"
     echo "#define _WASI_EMULATED_SIGNAL 1" >> confdefs.h
@@ -10386,6 +10452,9 @@ fi
 printf "%s\n" "#define STDC_HEADERS 1" >>confdefs.h
 
 
+printf "%s\n" "#define Py_STDC_HEADERS 1" >>confdefs.h
+
+
 # checks for header files
 ac_fn_c_check_header_compile "$LINENO" "alloca.h" "ac_cv_header_alloca_h" "$ac_includes_default"
 if test "x$ac_cv_header_alloca_h" = xyes
@@ -11252,6 +11321,9 @@ then :
 printf "%s\n" "#define clock_t long" >>confdefs.h
 
 
+printf "%s\n" "#define Py_clock_t long" >>confdefs.h
+
+
 fi
 
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for makedev" >&5
@@ -11300,6 +11372,9 @@ then :
 
 
 printf "%s\n" "#define HAVE_MAKEDEV 1" >>confdefs.h
+
+
+printf "%s\n" "#define Py_HAVE_MAKEDEV 1" >>confdefs.h
 
 
 fi
@@ -11351,6 +11426,9 @@ then :
 printf "%s\n" "#define HAVE_HTOLE64 1" >>confdefs.h
 
 
+printf "%s\n" "#define Py_HAVE_HTOLE64 1" >>confdefs.h
+
+
 fi
 
 use_lfs=yes
@@ -11367,13 +11445,22 @@ AIX*)
 
 printf "%s\n" "#define _LARGE_FILES 1" >>confdefs.h
 
+
+printf "%s\n" "#define Py__LARGE_FILES 1" >>confdefs.h
+
     ;;
 esac
 
 printf "%s\n" "#define _LARGEFILE_SOURCE 1" >>confdefs.h
 
 
+printf "%s\n" "#define Py__LARGEFILE_SOURCE 1" >>confdefs.h
+
+
 printf "%s\n" "#define _FILE_OFFSET_BITS 64" >>confdefs.h
+
+
+printf "%s\n" "#define Py__FILE_OFFSET_BITS 64" >>confdefs.h
 
 fi
 
@@ -11445,6 +11532,9 @@ fi
 
 printf "%s\n" "#define RETSIGTYPE void" >>confdefs.h
 
+
+printf "%s\n" "#define Py_RETSIGTYPE void" >>confdefs.h
+
 ac_fn_c_check_type "$LINENO" "size_t" "ac_cv_type_size_t" "$ac_includes_default"
 if test "x$ac_cv_type_size_t" = xyes
 then :
@@ -11494,6 +11584,9 @@ then :
 
 printf "%s\n" "#define HAVE_SSIZE_T 1" >>confdefs.h
 
+
+printf "%s\n" "#define Py_HAVE_SSIZE_T 1" >>confdefs.h
+
 fi
 
 ac_fn_c_check_type "$LINENO" "__uint128_t" "ac_cv_type___uint128_t" "$ac_includes_default"
@@ -11501,6 +11594,9 @@ if test "x$ac_cv_type___uint128_t" = xyes
 then :
 
 printf "%s\n" "#define HAVE_GCC_UINT128_T 1" >>confdefs.h
+
+
+printf "%s\n" "#define Py_HAVE_GCC_UINT128_T 1" >>confdefs.h
 
 fi
 
@@ -12139,6 +12235,9 @@ then :
 
 printf "%s\n" "#define HAVE_LARGEFILE_SUPPORT 1" >>confdefs.h
 
+
+printf "%s\n" "#define Py_HAVE_LARGEFILE_SUPPORT 1" >>confdefs.h
+
   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
 printf "%s\n" "yes" >&6; }
 
@@ -12353,6 +12452,9 @@ then :
 printf "%s\n" "#define PTHREAD_KEY_T_IS_COMPATIBLE_WITH_INT 1" >>confdefs.h
 
 
+printf "%s\n" "#define Py_PTHREAD_KEY_T_IS_COMPATIBLE_WITH_INT 1" >>confdefs.h
+
+
 fi
 
 CC="$ac_save_cc"
@@ -12366,6 +12468,9 @@ then
 	# in the build location.
 
 printf "%s\n" "#define WITH_NEXT_FRAMEWORK 1" >>confdefs.h
+
+
+printf "%s\n" "#define Py_WITH_NEXT_FRAMEWORK 1" >>confdefs.h
 
 	{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
 printf "%s\n" "yes" >&6; }
@@ -12465,6 +12570,9 @@ case $ac_sys_system/$ac_sys_release in
   Darwin/*)
 
 printf "%s\n" "#define WITH_DYLD 1" >>confdefs.h
+
+
+printf "%s\n" "#define Py_WITH_DYLD 1" >>confdefs.h
 
     { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: always on for Darwin" >&5
 printf "%s\n" "always on for Darwin" >&6; }
@@ -12849,6 +12957,9 @@ then
 printf "%s\n" "#define THREAD_STACK_SIZE 0x$stack_size" >>confdefs.h
 
 
+printf "%s\n" "#define Py_THREAD_STACK_SIZE 0x$stack_size" >>confdefs.h
+
+
 		if test "$enable_framework"
 		then
 			LINKFORSHARED="$LINKFORSHARED "'$(PYTHONFRAMEWORKDIR)/Versions/$(VERSION)/$(PYTHONFRAMEWORK)'
@@ -12951,6 +13062,9 @@ then :
 
 
 printf "%s\n" "#define PY_HAVE_PERF_TRAMPOLINE 1" >>confdefs.h
+
+
+printf "%s\n" "#define Py_PY_HAVE_PERF_TRAMPOLINE 1" >>confdefs.h
 
   PERF_TRAMPOLINE_OBJ=Python/asm_trampoline.o
 
@@ -13291,6 +13405,8 @@ then :
   have_uuid=yes
             printf "%s\n" "#define HAVE_UUID_GENERATE_TIME_SAFE 1" >>confdefs.h
 
+          printf "%s\n" "#define Py_HAVE_UUID_GENERATE_TIME_SAFE 1" >>confdefs.h
+
 fi
 
 LIBS=$py_check_lib_save_LIBS
@@ -13417,6 +13533,8 @@ then :
   have_uuid=yes
             printf "%s\n" "#define HAVE_UUID_GENERATE_TIME_SAFE 1" >>confdefs.h
 
+          printf "%s\n" "#define Py_HAVE_UUID_GENERATE_TIME_SAFE 1" >>confdefs.h
+
 fi
 
 LIBS=$py_check_lib_save_LIBS
@@ -13448,7 +13566,11 @@ printf "%s\n" "yes" >&6; }
 	            have_uuid=yes
       printf "%s\n" "#define HAVE_UUID_H 1" >>confdefs.h
 
+          printf "%s\n" "#define Py_HAVE_UUID_H 1" >>confdefs.h
+
       printf "%s\n" "#define HAVE_UUID_GENERATE_TIME_SAFE 1" >>confdefs.h
+
+          printf "%s\n" "#define Py_HAVE_UUID_GENERATE_TIME_SAFE 1" >>confdefs.h
 
 
 fi
@@ -13591,6 +13713,9 @@ then :
 
 printf "%s\n" "#define WITH_LIBINTL 1" >>confdefs.h
 
+
+printf "%s\n" "#define Py_WITH_LIBINTL 1" >>confdefs.h
+
         LIBS="-lintl $LIBS"
 fi
 
@@ -13618,6 +13743,9 @@ then :
 
 printf "%s\n" "#define AIX_GENUINE_CPLUSPLUS 1" >>confdefs.h
 
+
+printf "%s\n" "#define Py_AIX_GENUINE_CPLUSPLUS 1" >>confdefs.h
+
 		  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
 printf "%s\n" "yes" >&6; }
 
@@ -13637,6 +13765,9 @@ printf %s "checking for the system builddate... " >&6; }
                AIX_BUILDDATE=$(lslpp -Lcq bos.mp64 | awk -F:  '{ print $NF }')
 
 printf "%s\n" "#define AIX_BUILDDATE $AIX_BUILDDATE" >>confdefs.h
+
+
+printf "%s\n" "#define Py_AIX_BUILDDATE $AIX_BUILDDATE" >>confdefs.h
 
                { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $AIX_BUILDDATE" >&5
 printf "%s\n" "$AIX_BUILDDATE" >&6; }
@@ -13689,6 +13820,9 @@ if test "$ac_cv_aligned_required" = yes ; then
 
 printf "%s\n" "#define HAVE_ALIGNED_REQUIRED 1" >>confdefs.h
 
+
+printf "%s\n" "#define Py_HAVE_ALIGNED_REQUIRED 1" >>confdefs.h
+
 fi
 
 # str, bytes and memoryview hash algorithm
@@ -13707,13 +13841,19 @@ case "$withval" in
     siphash13)
         printf "%s\n" "#define Py_HASH_ALGORITHM 3" >>confdefs.h
 
+          printf "%s\n" "#define Py_Py_HASH_ALGORITHM 3" >>confdefs.h
+
         ;;
     siphash24)
         printf "%s\n" "#define Py_HASH_ALGORITHM 1" >>confdefs.h
 
+          printf "%s\n" "#define Py_Py_HASH_ALGORITHM 1" >>confdefs.h
+
         ;;
     fnv)
         printf "%s\n" "#define Py_HASH_ALGORITHM 2" >>confdefs.h
+
+          printf "%s\n" "#define Py_Py_HASH_ALGORITHM 2" >>confdefs.h
 
         ;;
     *)
@@ -14306,6 +14446,9 @@ then :
 
 printf "%s\n" "#define HAVE_FFI_PREP_CIF_VAR 1" >>confdefs.h
 
+
+printf "%s\n" "#define Py_HAVE_FFI_PREP_CIF_VAR 1" >>confdefs.h
+
 fi
 
 
@@ -14345,6 +14488,9 @@ then :
 
 printf "%s\n" "#define HAVE_FFI_PREP_CLOSURE_LOC 1" >>confdefs.h
 
+
+printf "%s\n" "#define Py_HAVE_FFI_PREP_CLOSURE_LOC 1" >>confdefs.h
+
 fi
 
 
@@ -14383,6 +14529,9 @@ printf "%s\n" "$ac_cv_func_ffi_closure_alloc" >&6; }
 then :
 
 printf "%s\n" "#define HAVE_FFI_CLOSURE_ALLOC 1" >>confdefs.h
+
+
+printf "%s\n" "#define Py_HAVE_FFI_CLOSURE_ALLOC 1" >>confdefs.h
 
 fi
 
@@ -14455,6 +14604,9 @@ if test "$with_decimal_contextvar" != "no"
 then
 
 printf "%s\n" "#define WITH_DECIMAL_CONTEXTVAR 1" >>confdefs.h
+
+
+printf "%s\n" "#define Py_WITH_DECIMAL_CONTEXTVAR 1" >>confdefs.h
 
 fi
 
@@ -15249,6 +15401,9 @@ then :
 printf "%s\n" "#define PY_SQLITE_HAVE_SERIALIZE 1" >>confdefs.h
 
 
+printf "%s\n" "#define Py_PY_SQLITE_HAVE_SERIALIZE 1" >>confdefs.h
+
+
 fi
 
 
@@ -15289,6 +15444,9 @@ else $as_nop
 printf "%s\n" "yes" >&6; }
 
 printf "%s\n" "#define PY_SQLITE_ENABLE_LOAD_EXTENSION 1" >>confdefs.h
+
+
+printf "%s\n" "#define Py_PY_SQLITE_ENABLE_LOAD_EXTENSION 1" >>confdefs.h
 
 
 fi
@@ -15787,6 +15945,9 @@ then :
 printf "%s\n" "#define HAVE_GDBM_NDBM_H 1" >>confdefs.h
 
 
+printf "%s\n" "#define Py_HAVE_GDBM_NDBM_H 1" >>confdefs.h
+
+
 fi
 
 { ac_cv_header_gdbm_ndbm_h=; unset ac_cv_header_gdbm_ndbm_h;}
@@ -15812,6 +15973,9 @@ then :
 
 
 printf "%s\n" "#define HAVE_GDBM_DASH_NDBM_H 1" >>confdefs.h
+
+
+printf "%s\n" "#define Py_HAVE_GDBM_DASH_NDBM_H 1" >>confdefs.h
 
 
 fi
@@ -15962,6 +16126,9 @@ then :
 printf "%s\n" "#define HAVE_LIBDB 1" >>confdefs.h
 
 
+printf "%s\n" "#define Py_HAVE_LIBDB 1" >>confdefs.h
+
+
 fi
 
 fi
@@ -16044,14 +16211,16 @@ IFS=$as_save_IFS
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $DBM_CFLAGS $DBM_LIBS" >&5
 printf "%s\n" "$DBM_CFLAGS $DBM_LIBS" >&6; }
 
-# Templates for things AC_DEFINEd more than once.
-# For a single AC_DEFINE, no template is needed.
+# Templates for things PY_DEFINEd more than once.
+# For a single PY_DEFINE, no template is needed.
 
 
 if test "$ac_cv_pthread_is_default" = yes
 then
     # Defining _REENTRANT on system with POSIX threads should not hurt.
-    printf "%s\n" "#define _REENTRANT 1" >>confdefs.h
+    printf "%s\n" "#define _REENTRANT /**/" >>confdefs.h
+
+          printf "%s\n" "#define Py__REENTRANT /**/" >>confdefs.h
 
     posix_threads=yes
     if test "$ac_sys_system" = "SunOS"; then
@@ -16109,7 +16278,9 @@ rm -rf conftest*
     { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $unistd_defines_pthreads" >&5
 printf "%s\n" "$unistd_defines_pthreads" >&6; }
 
-    printf "%s\n" "#define _REENTRANT 1" >>confdefs.h
+    printf "%s\n" "#define _REENTRANT /**/" >>confdefs.h
+
+          printf "%s\n" "#define Py__REENTRANT /**/" >>confdefs.h
 
     # Just looking for pthread_create in libpthread is not enough:
     # on HP/UX, pthread.h renames pthread_create to a different symbol name.
@@ -16397,6 +16568,9 @@ if test "$posix_threads" = "yes"; then
 
 printf "%s\n" "#define _POSIX_THREADS 1" >>confdefs.h
 
+
+printf "%s\n" "#define Py__POSIX_THREADS 1" >>confdefs.h
+
       fi
 
       # Bug 662787: Using semaphores causes unexplicable hangs on Solaris 8.
@@ -16404,17 +16578,29 @@ printf "%s\n" "#define _POSIX_THREADS 1" >>confdefs.h
       SunOS/5.6)
 printf "%s\n" "#define HAVE_PTHREAD_DESTRUCTOR 1" >>confdefs.h
 
+
+printf "%s\n" "#define Py_HAVE_PTHREAD_DESTRUCTOR 1" >>confdefs.h
+
 		       ;;
       SunOS/5.8)
 printf "%s\n" "#define HAVE_BROKEN_POSIX_SEMAPHORES 1" >>confdefs.h
+
+
+printf "%s\n" "#define Py_HAVE_BROKEN_POSIX_SEMAPHORES 1" >>confdefs.h
 
 		       ;;
       AIX/*)
 printf "%s\n" "#define HAVE_BROKEN_POSIX_SEMAPHORES 1" >>confdefs.h
 
+
+printf "%s\n" "#define Py_HAVE_BROKEN_POSIX_SEMAPHORES 1" >>confdefs.h
+
 		       ;;
       NetBSD/*)
 printf "%s\n" "#define HAVE_BROKEN_POSIX_SEMAPHORES 1" >>confdefs.h
+
+
+printf "%s\n" "#define Py_HAVE_BROKEN_POSIX_SEMAPHORES 1" >>confdefs.h
 
 		       ;;
       esac
@@ -16464,6 +16650,9 @@ printf "%s\n" "$ac_cv_pthread_system_supported" >&6; }
 
 printf "%s\n" "#define PTHREAD_SYSTEM_SCHED_SUPPORTED 1" >>confdefs.h
 
+
+printf "%s\n" "#define Py_PTHREAD_SYSTEM_SCHED_SUPPORTED 1" >>confdefs.h
+
       fi
 
   for ac_func in pthread_sigmask
@@ -16476,6 +16665,9 @@ then :
         CYGWIN*)
 
 printf "%s\n" "#define HAVE_BROKEN_PTHREAD_SIGMASK 1" >>confdefs.h
+
+
+printf "%s\n" "#define Py_HAVE_BROKEN_PTHREAD_SIGMASK 1" >>confdefs.h
 
             ;;
         esac
@@ -16498,6 +16690,9 @@ then :
 printf "%s\n" "#define HAVE_PTHREAD_STUBS 1" >>confdefs.h
 
 
+printf "%s\n" "#define Py_HAVE_PTHREAD_STUBS 1" >>confdefs.h
+
+
 fi
 
 # Check for enable-ipv6
@@ -16515,7 +16710,9 @@ printf "%s\n" "no" >&6; }
        ;;
   *)   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
 printf "%s\n" "yes" >&6; }
-       printf "%s\n" "#define ENABLE_IPV6 1" >>confdefs.h
+       printf "%s\n" "#define ENABLE_IPV6 /**/" >>confdefs.h
+
+          printf "%s\n" "#define Py_ENABLE_IPV6 /**/" >>confdefs.h
 
        ipv6=yes
        ;;
@@ -16594,7 +16791,9 @@ rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
 fi
 
 if test "$ipv6" = "yes"; then
-	printf "%s\n" "#define ENABLE_IPV6 1" >>confdefs.h
+	printf "%s\n" "#define ENABLE_IPV6 /**/" >>confdefs.h
+
+          printf "%s\n" "#define Py_ENABLE_IPV6 /**/" >>confdefs.h
 
 fi
 
@@ -16807,6 +17006,9 @@ then :
 printf "%s\n" "#define HAVE_LINUX_CAN_RAW_FD_FRAMES 1" >>confdefs.h
 
 
+printf "%s\n" "#define Py_HAVE_LINUX_CAN_RAW_FD_FRAMES 1" >>confdefs.h
+
+
 fi
 
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for CAN_RAW_JOIN_FILTERS" >&5
@@ -16846,6 +17048,9 @@ then :
 printf "%s\n" "#define HAVE_LINUX_CAN_RAW_JOIN_FILTERS 1" >>confdefs.h
 
 
+printf "%s\n" "#define Py_HAVE_LINUX_CAN_RAW_JOIN_FILTERS 1" >>confdefs.h
+
+
 fi
 
 # Check for --with-doc-strings
@@ -16866,6 +17071,9 @@ if test "$with_doc_strings" != "no"
 then
 
 printf "%s\n" "#define WITH_DOC_STRINGS 1" >>confdefs.h
+
+
+printf "%s\n" "#define Py_WITH_DOC_STRINGS 1" >>confdefs.h
 
 fi
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $with_doc_strings" >&5
@@ -16915,6 +17123,9 @@ then :
 printf "%s\n" "#define HAVE_STD_ATOMIC 1" >>confdefs.h
 
 
+printf "%s\n" "#define Py_HAVE_STD_ATOMIC 1" >>confdefs.h
+
+
 fi
 
 # Check for GCC >= 4.7 and clang __atomic builtin functions
@@ -16958,6 +17169,9 @@ then :
 printf "%s\n" "#define HAVE_BUILTIN_ATOMIC 1" >>confdefs.h
 
 
+printf "%s\n" "#define Py_HAVE_BUILTIN_ATOMIC 1" >>confdefs.h
+
+
 fi
 
 # --with-mimalloc
@@ -16982,6 +17196,9 @@ if test "$with_mimalloc" != no; then
   with_mimalloc=yes
 
 printf "%s\n" "#define WITH_MIMALLOC 1" >>confdefs.h
+
+
+printf "%s\n" "#define Py_WITH_MIMALLOC 1" >>confdefs.h
 
   MIMALLOC_HEADERS='$(MIMALLOC_HEADERS)'
 
@@ -17022,6 +17239,9 @@ then
 
 printf "%s\n" "#define WITH_PYMALLOC 1" >>confdefs.h
 
+
+printf "%s\n" "#define Py_WITH_PYMALLOC 1" >>confdefs.h
+
 fi
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $with_pymalloc" >&5
 printf "%s\n" "$with_pymalloc" >&6; }
@@ -17047,6 +17267,9 @@ then
 
 printf "%s\n" "#define WITH_FREELISTS 1" >>confdefs.h
 
+
+printf "%s\n" "#define Py_WITH_FREELISTS 1" >>confdefs.h
+
 fi
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $with_freelists" >&5
 printf "%s\n" "$with_freelists" >&6; }
@@ -17070,6 +17293,9 @@ if test "$with_c_locale_coercion" != "no"
 then
 
 printf "%s\n" "#define PY_COERCE_C_LOCALE 1" >>confdefs.h
+
+
+printf "%s\n" "#define Py_PY_COERCE_C_LOCALE 1" >>confdefs.h
 
 fi
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $with_c_locale_coercion" >&5
@@ -17096,6 +17322,9 @@ if test "x$ac_cv_header_valgrind_valgrind_h" = xyes
 then :
 
 printf "%s\n" "#define WITH_VALGRIND 1" >>confdefs.h
+
+
+printf "%s\n" "#define Py_WITH_VALGRIND 1" >>confdefs.h
 
 else $as_nop
   as_fn_error $? "Valgrind support requested but headers not available" "$LINENO" 5
@@ -17182,6 +17411,9 @@ fi
 
 printf "%s\n" "#define WITH_DTRACE 1" >>confdefs.h
 
+
+printf "%s\n" "#define Py_WITH_DTRACE 1" >>confdefs.h
+
     DTRACE_HEADERS="Include/pydtrace_probes.h"
 
     # On OS X, DTrace providers do not need to be explicitly compiled and
@@ -17261,6 +17493,9 @@ if test "$DYNLOADFILE" != "dynload_stub.o"
 then
 
 printf "%s\n" "#define HAVE_DYNAMIC_LOADING 1" >>confdefs.h
+
+
+printf "%s\n" "#define Py_HAVE_DYNAMIC_LOADING 1" >>confdefs.h
 
 fi
 
@@ -18545,6 +18780,9 @@ then :
 
 printf "%s\n" "#define HAVE_DIRFD 1" >>confdefs.h
 
+
+printf "%s\n" "#define Py_HAVE_DIRFD 1" >>confdefs.h
+
 fi
 
 # For some functions, having a definition is not sufficient, since
@@ -18583,6 +18821,9 @@ printf "%s\n" "$ac_cv_func_chroot" >&6; }
 then :
 
 printf "%s\n" "#define HAVE_CHROOT 1" >>confdefs.h
+
+
+printf "%s\n" "#define Py_HAVE_CHROOT 1" >>confdefs.h
 
 fi
 
@@ -18623,6 +18864,9 @@ then :
 
 printf "%s\n" "#define HAVE_LINK 1" >>confdefs.h
 
+
+printf "%s\n" "#define Py_HAVE_LINK 1" >>confdefs.h
+
 fi
 
 
@@ -18661,6 +18905,9 @@ printf "%s\n" "$ac_cv_func_symlink" >&6; }
 then :
 
 printf "%s\n" "#define HAVE_SYMLINK 1" >>confdefs.h
+
+
+printf "%s\n" "#define Py_HAVE_SYMLINK 1" >>confdefs.h
 
 fi
 
@@ -18701,6 +18948,9 @@ then :
 
 printf "%s\n" "#define HAVE_FCHDIR 1" >>confdefs.h
 
+
+printf "%s\n" "#define Py_HAVE_FCHDIR 1" >>confdefs.h
+
 fi
 
 
@@ -18739,6 +18989,9 @@ printf "%s\n" "$ac_cv_func_fsync" >&6; }
 then :
 
 printf "%s\n" "#define HAVE_FSYNC 1" >>confdefs.h
+
+
+printf "%s\n" "#define Py_HAVE_FSYNC 1" >>confdefs.h
 
 fi
 
@@ -18779,6 +19032,9 @@ then :
 
 printf "%s\n" "#define HAVE_FDATASYNC 1" >>confdefs.h
 
+
+printf "%s\n" "#define Py_HAVE_FDATASYNC 1" >>confdefs.h
+
 fi
 
 
@@ -18818,6 +19074,9 @@ then :
 
 printf "%s\n" "#define HAVE_EPOLL 1" >>confdefs.h
 
+
+printf "%s\n" "#define Py_HAVE_EPOLL 1" >>confdefs.h
+
 fi
 
 
@@ -18856,6 +19115,9 @@ printf "%s\n" "$ac_cv_func_epoll_create1" >&6; }
 then :
 
 printf "%s\n" "#define HAVE_EPOLL_CREATE1 1" >>confdefs.h
+
+
+printf "%s\n" "#define Py_HAVE_EPOLL_CREATE1 1" >>confdefs.h
 
 fi
 
@@ -18899,6 +19161,9 @@ then :
 
 printf "%s\n" "#define HAVE_KQUEUE 1" >>confdefs.h
 
+
+printf "%s\n" "#define Py_HAVE_KQUEUE 1" >>confdefs.h
+
 fi
 
 
@@ -18941,6 +19206,9 @@ then :
 
 printf "%s\n" "#define HAVE_PRLIMIT 1" >>confdefs.h
 
+
+printf "%s\n" "#define Py_HAVE_PRLIMIT 1" >>confdefs.h
+
 fi
 
 
@@ -18980,6 +19248,9 @@ printf "%s\n" "$ac_cv_func__dyld_shared_cache_contains_path" >&6; }
 then :
 
 printf "%s\n" "#define HAVE_DYLD_SHARED_CACHE_CONTAINS_PATH 1" >>confdefs.h
+
+
+printf "%s\n" "#define Py_HAVE_DYLD_SHARED_CACHE_CONTAINS_PATH 1" >>confdefs.h
 
 fi
 
@@ -19028,6 +19299,9 @@ then :
 
 printf "%s\n" "#define HAVE_MEMFD_CREATE 1" >>confdefs.h
 
+
+printf "%s\n" "#define Py_HAVE_MEMFD_CREATE 1" >>confdefs.h
+
 fi
 
 
@@ -19072,6 +19346,9 @@ then :
 
 printf "%s\n" "#define HAVE_EVENTFD 1" >>confdefs.h
 
+
+printf "%s\n" "#define Py_HAVE_EVENTFD 1" >>confdefs.h
+
 fi
 
 
@@ -19115,6 +19392,9 @@ printf "%s\n" "$ac_cv_func_timerfd_create" >&6; }
 then :
 
 printf "%s\n" "#define HAVE_TIMERFD_CREATE 1" >>confdefs.h
+
+
+printf "%s\n" "#define Py_HAVE_TIMERFD_CREATE 1" >>confdefs.h
 
 fi
 
@@ -19161,6 +19441,9 @@ printf "%s\n" "$ac_cv_func_ctermid_r" >&6; }
 then :
 
 printf "%s\n" "#define HAVE_CTERMID_R 1" >>confdefs.h
+
+
+printf "%s\n" "#define Py_HAVE_CTERMID_R 1" >>confdefs.h
 
 fi
 
@@ -19288,6 +19571,9 @@ then :
 
 printf "%s\n" "#define HAVE_GETPAGESIZE 1" >>confdefs.h
 
+
+printf "%s\n" "#define Py_HAVE_GETPAGESIZE 1" >>confdefs.h
+
 fi
 
 
@@ -19327,6 +19613,9 @@ then :
 
 
 printf "%s\n" "#define HAVE_BROKEN_UNSETENV 1" >>confdefs.h
+
+
+printf "%s\n" "#define Py_HAVE_BROKEN_UNSETENV 1" >>confdefs.h
 
 
 fi
@@ -19519,6 +19808,9 @@ if test "$ac_cv_have_chflags" = yes ; then
 
 printf "%s\n" "#define HAVE_CHFLAGS 1" >>confdefs.h
 
+
+printf "%s\n" "#define Py_HAVE_CHFLAGS 1" >>confdefs.h
+
 fi
 
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for lchflags" >&5
@@ -19571,6 +19863,9 @@ fi
 if test "$ac_cv_have_lchflags" = yes ; then
 
 printf "%s\n" "#define HAVE_LCHFLAGS 1" >>confdefs.h
+
+
+printf "%s\n" "#define Py_HAVE_LCHFLAGS 1" >>confdefs.h
 
 fi
 
@@ -19761,6 +20056,8 @@ if test "x$ac_cv_lib_z_inflateCopy" = xyes
 then :
   printf "%s\n" "#define HAVE_ZLIB_COPY 1" >>confdefs.h
 
+          printf "%s\n" "#define Py_HAVE_ZLIB_COPY 1" >>confdefs.h
+
 fi
 
 LIBS=$py_check_lib_save_LIBS
@@ -19890,6 +20187,8 @@ if test "x$ac_cv_lib_z_inflateCopy" = xyes
 then :
   printf "%s\n" "#define HAVE_ZLIB_COPY 1" >>confdefs.h
 
+          printf "%s\n" "#define Py_HAVE_ZLIB_COPY 1" >>confdefs.h
+
 fi
 
 LIBS=$py_check_lib_save_LIBS
@@ -19912,6 +20211,8 @@ printf "%s\n" "yes" >&6; }
 
   have_zlib=yes
     printf "%s\n" "#define HAVE_ZLIB_COPY 1" >>confdefs.h
+
+          printf "%s\n" "#define Py_HAVE_ZLIB_COPY 1" >>confdefs.h
 
 
 fi
@@ -20431,6 +20732,9 @@ then :
 
 printf "%s\n" "#define HAVE_HSTRERROR 1" >>confdefs.h
 
+
+printf "%s\n" "#define Py_HAVE_HSTRERROR 1" >>confdefs.h
+
 fi
 
 
@@ -20469,6 +20773,9 @@ printf "%s\n" "$ac_cv_func_getservbyname" >&6; }
 then :
 
 printf "%s\n" "#define HAVE_GETSERVBYNAME 1" >>confdefs.h
+
+
+printf "%s\n" "#define Py_HAVE_GETSERVBYNAME 1" >>confdefs.h
 
 fi
 
@@ -20509,6 +20816,9 @@ then :
 
 printf "%s\n" "#define HAVE_GETSERVBYPORT 1" >>confdefs.h
 
+
+printf "%s\n" "#define Py_HAVE_GETSERVBYPORT 1" >>confdefs.h
+
 fi
 
 
@@ -20547,6 +20857,9 @@ printf "%s\n" "$ac_cv_func_gethostbyname" >&6; }
 then :
 
 printf "%s\n" "#define HAVE_GETHOSTBYNAME 1" >>confdefs.h
+
+
+printf "%s\n" "#define Py_HAVE_GETHOSTBYNAME 1" >>confdefs.h
 
 fi
 
@@ -20587,6 +20900,9 @@ then :
 
 printf "%s\n" "#define HAVE_GETHOSTBYADDR 1" >>confdefs.h
 
+
+printf "%s\n" "#define Py_HAVE_GETHOSTBYADDR 1" >>confdefs.h
+
 fi
 
 
@@ -20625,6 +20941,9 @@ printf "%s\n" "$ac_cv_func_getprotobyname" >&6; }
 then :
 
 printf "%s\n" "#define HAVE_GETPROTOBYNAME 1" >>confdefs.h
+
+
+printf "%s\n" "#define Py_HAVE_GETPROTOBYNAME 1" >>confdefs.h
 
 fi
 
@@ -20673,6 +20992,9 @@ then :
 
 printf "%s\n" "#define HAVE_INET_ATON 1" >>confdefs.h
 
+
+printf "%s\n" "#define Py_HAVE_INET_ATON 1" >>confdefs.h
+
 fi
 
 
@@ -20716,6 +21038,9 @@ printf "%s\n" "$ac_cv_func_inet_ntoa" >&6; }
 then :
 
 printf "%s\n" "#define HAVE_INET_NTOA 1" >>confdefs.h
+
+
+printf "%s\n" "#define Py_HAVE_INET_NTOA 1" >>confdefs.h
 
 fi
 
@@ -20761,6 +21086,9 @@ then :
 
 printf "%s\n" "#define HAVE_INET_PTON 1" >>confdefs.h
 
+
+printf "%s\n" "#define Py_HAVE_INET_PTON 1" >>confdefs.h
+
 fi
 
 
@@ -20804,6 +21132,9 @@ printf "%s\n" "$ac_cv_func_getpeername" >&6; }
 then :
 
 printf "%s\n" "#define HAVE_GETPEERNAME 1" >>confdefs.h
+
+
+printf "%s\n" "#define Py_HAVE_GETPEERNAME 1" >>confdefs.h
 
 fi
 
@@ -20849,6 +21180,9 @@ then :
 
 printf "%s\n" "#define HAVE_GETSOCKNAME 1" >>confdefs.h
 
+
+printf "%s\n" "#define Py_HAVE_GETSOCKNAME 1" >>confdefs.h
+
 fi
 
 
@@ -20892,6 +21226,9 @@ printf "%s\n" "$ac_cv_func_accept" >&6; }
 then :
 
 printf "%s\n" "#define HAVE_ACCEPT 1" >>confdefs.h
+
+
+printf "%s\n" "#define Py_HAVE_ACCEPT 1" >>confdefs.h
 
 fi
 
@@ -20937,6 +21274,9 @@ then :
 
 printf "%s\n" "#define HAVE_BIND 1" >>confdefs.h
 
+
+printf "%s\n" "#define Py_HAVE_BIND 1" >>confdefs.h
+
 fi
 
 
@@ -20980,6 +21320,9 @@ printf "%s\n" "$ac_cv_func_connect" >&6; }
 then :
 
 printf "%s\n" "#define HAVE_CONNECT 1" >>confdefs.h
+
+
+printf "%s\n" "#define Py_HAVE_CONNECT 1" >>confdefs.h
 
 fi
 
@@ -21025,6 +21368,9 @@ then :
 
 printf "%s\n" "#define HAVE_LISTEN 1" >>confdefs.h
 
+
+printf "%s\n" "#define Py_HAVE_LISTEN 1" >>confdefs.h
+
 fi
 
 
@@ -21068,6 +21414,9 @@ printf "%s\n" "$ac_cv_func_recvfrom" >&6; }
 then :
 
 printf "%s\n" "#define HAVE_RECVFROM 1" >>confdefs.h
+
+
+printf "%s\n" "#define Py_HAVE_RECVFROM 1" >>confdefs.h
 
 fi
 
@@ -21113,6 +21462,9 @@ then :
 
 printf "%s\n" "#define HAVE_SENDTO 1" >>confdefs.h
 
+
+printf "%s\n" "#define Py_HAVE_SENDTO 1" >>confdefs.h
+
 fi
 
 
@@ -21157,6 +21509,9 @@ then :
 
 printf "%s\n" "#define HAVE_SETSOCKOPT 1" >>confdefs.h
 
+
+printf "%s\n" "#define Py_HAVE_SETSOCKOPT 1" >>confdefs.h
+
 fi
 
 
@@ -21200,6 +21555,9 @@ printf "%s\n" "$ac_cv_func_socket" >&6; }
 then :
 
 printf "%s\n" "#define HAVE_SOCKET 1" >>confdefs.h
+
+
+printf "%s\n" "#define Py_HAVE_SOCKET 1" >>confdefs.h
 
 fi
 
@@ -21246,6 +21604,9 @@ printf "%s\n" "$ac_cv_func_setgroups" >&6; }
 then :
 
 printf "%s\n" "#define HAVE_SETGROUPS 1" >>confdefs.h
+
+
+printf "%s\n" "#define Py_HAVE_SETGROUPS 1" >>confdefs.h
 
 fi
 
@@ -21300,7 +21661,9 @@ fi
 printf "%s\n" "$ac_cv_lib_util_openpty" >&6; }
 if test "x$ac_cv_lib_util_openpty" = xyes
 then :
-  printf "%s\n" "#define HAVE_OPENPTY 1" >>confdefs.h
+  printf "%s\n" "#define HAVE_OPENPTY /**/" >>confdefs.h
+
+          printf "%s\n" "#define Py_HAVE_OPENPTY /**/" >>confdefs.h
  LIBS="$LIBS -lutil"
 else $as_nop
   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for openpty in -lbsd" >&5
@@ -21340,7 +21703,9 @@ fi
 printf "%s\n" "$ac_cv_lib_bsd_openpty" >&6; }
 if test "x$ac_cv_lib_bsd_openpty" = xyes
 then :
-  printf "%s\n" "#define HAVE_OPENPTY 1" >>confdefs.h
+  printf "%s\n" "#define HAVE_OPENPTY /**/" >>confdefs.h
+
+          printf "%s\n" "#define Py_HAVE_OPENPTY /**/" >>confdefs.h
  LIBS="$LIBS -lbsd"
 fi
 
@@ -21409,6 +21774,9 @@ then :
 printf "%s\n" "#define HAVE_LOGIN_TTY 1" >>confdefs.h
 
 
+printf "%s\n" "#define Py_HAVE_LOGIN_TTY 1" >>confdefs.h
+
+
 fi
 
 
@@ -21457,7 +21825,9 @@ fi
 printf "%s\n" "$ac_cv_lib_util_forkpty" >&6; }
 if test "x$ac_cv_lib_util_forkpty" = xyes
 then :
-  printf "%s\n" "#define HAVE_FORKPTY 1" >>confdefs.h
+  printf "%s\n" "#define HAVE_FORKPTY /**/" >>confdefs.h
+
+          printf "%s\n" "#define Py_HAVE_FORKPTY /**/" >>confdefs.h
  LIBS="$LIBS -lutil"
 else $as_nop
   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for forkpty in -lbsd" >&5
@@ -21497,7 +21867,9 @@ fi
 printf "%s\n" "$ac_cv_lib_bsd_forkpty" >&6; }
 if test "x$ac_cv_lib_bsd_forkpty" = xyes
 then :
-  printf "%s\n" "#define HAVE_FORKPTY 1" >>confdefs.h
+  printf "%s\n" "#define HAVE_FORKPTY /**/" >>confdefs.h
+
+          printf "%s\n" "#define Py_HAVE_FORKPTY /**/" >>confdefs.h
  LIBS="$LIBS -lbsd"
 fi
 
@@ -21583,6 +21955,9 @@ then :
 
 printf "%s\n" "#define GETPGRP_HAVE_ARG 1" >>confdefs.h
 
+
+printf "%s\n" "#define Py_GETPGRP_HAVE_ARG 1" >>confdefs.h
+
 fi
 rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
 fi
@@ -21610,6 +21985,9 @@ if ac_fn_c_try_compile "$LINENO"
 then :
 
 printf "%s\n" "#define SETPGRP_HAVE_ARG 1" >>confdefs.h
+
+
+printf "%s\n" "#define Py_SETPGRP_HAVE_ARG 1" >>confdefs.h
 
 fi
 rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
@@ -21683,8 +22061,13 @@ then :
         LIBS="$LIBS -lrt"
         printf "%s\n" "#define HAVE_CLOCK_GETTIME 1" >>confdefs.h
 
+          printf "%s\n" "#define Py_HAVE_CLOCK_GETTIME 1" >>confdefs.h
+
 
 printf "%s\n" "#define TIMEMODULE_LIB rt" >>confdefs.h
+
+
+printf "%s\n" "#define Py_TIMEMODULE_LIB rt" >>confdefs.h
 
 
 fi
@@ -21744,6 +22127,8 @@ then :
 
         printf "%s\n" "#define HAVE_CLOCK_GETRES 1" >>confdefs.h
 
+          printf "%s\n" "#define Py_HAVE_CLOCK_GETRES 1" >>confdefs.h
+
 
 fi
 
@@ -21801,6 +22186,8 @@ if test "x$ac_cv_lib_rt_clock_settime" = xyes
 then :
 
         printf "%s\n" "#define HAVE_CLOCK_SETTIME 1" >>confdefs.h
+
+          printf "%s\n" "#define Py_HAVE_CLOCK_SETTIME 1" >>confdefs.h
 
 
 fi
@@ -21860,6 +22247,8 @@ then :
 
         printf "%s\n" "#define HAVE_CLOCK_NANOSLEEP 1" >>confdefs.h
 
+          printf "%s\n" "#define Py_HAVE_CLOCK_NANOSLEEP 1" >>confdefs.h
+
 
 fi
 
@@ -21918,6 +22307,8 @@ then :
 
         printf "%s\n" "#define HAVE_NANOSLEEP 1" >>confdefs.h
 
+          printf "%s\n" "#define Py_HAVE_NANOSLEEP 1" >>confdefs.h
+
 
 fi
 
@@ -21974,10 +22365,16 @@ then :
 printf "%s\n" "#define HAVE_DEVICE_MACROS 1" >>confdefs.h
 
 
+printf "%s\n" "#define Py_HAVE_DEVICE_MACROS 1" >>confdefs.h
+
+
 fi
 
 
 printf "%s\n" "#define SYS_SELECT_WITH_SYS_TIME 1" >>confdefs.h
+
+
+printf "%s\n" "#define Py_SYS_SELECT_WITH_SYS_TIME 1" >>confdefs.h
 
 
 # On OSF/1 V5.1, getaddrinfo is available, but a define
@@ -22157,6 +22554,9 @@ fi
 else
 
 printf "%s\n" "#define HAVE_GETADDRINFO 1" >>confdefs.h
+
+
+printf "%s\n" "#define Py_HAVE_GETADDRINFO 1" >>confdefs.h
 
 fi
 
@@ -22396,6 +22796,9 @@ if test $ac_cv_header_time_altzone = yes; then
 
 printf "%s\n" "#define HAVE_ALTZONE 1" >>confdefs.h
 
+
+printf "%s\n" "#define Py_HAVE_ALTZONE 1" >>confdefs.h
+
 fi
 
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for addrinfo" >&5
@@ -22428,6 +22831,9 @@ printf "%s\n" "$ac_cv_struct_addrinfo" >&6; }
 if test $ac_cv_struct_addrinfo = yes; then
 
 printf "%s\n" "#define HAVE_ADDRINFO 1" >>confdefs.h
+
+
+printf "%s\n" "#define Py_HAVE_ADDRINFO 1" >>confdefs.h
 
 fi
 
@@ -22464,6 +22870,9 @@ if test $ac_cv_struct_sockaddr_storage = yes; then
 
 printf "%s\n" "#define HAVE_SOCKADDR_STORAGE 1" >>confdefs.h
 
+
+printf "%s\n" "#define Py_HAVE_SOCKADDR_STORAGE 1" >>confdefs.h
+
 fi
 
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for sockaddr_alg" >&5
@@ -22499,6 +22908,9 @@ printf "%s\n" "$ac_cv_struct_sockaddr_alg" >&6; }
 if test $ac_cv_struct_sockaddr_alg = yes; then
 
 printf "%s\n" "#define HAVE_SOCKADDR_ALG 1" >>confdefs.h
+
+
+printf "%s\n" "#define Py_HAVE_SOCKADDR_ALG 1" >>confdefs.h
 
 fi
 
@@ -22624,6 +23036,9 @@ then :
 printf "%s\n" "#define signed /**/" >>confdefs.h
 
 
+printf "%s\n" "#define Py_signed /**/" >>confdefs.h
+
+
 fi
 
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for prototypes" >&5
@@ -22660,6 +23075,9 @@ then :
 
 
 printf "%s\n" "#define HAVE_PROTOTYPES 1" >>confdefs.h
+
+
+printf "%s\n" "#define Py_HAVE_PROTOTYPES 1" >>confdefs.h
 
 
 fi
@@ -22703,6 +23121,9 @@ printf "%s\n" "$ac_cv_func_socketpair" >&6; }
 then :
 
 printf "%s\n" "#define HAVE_SOCKETPAIR 1" >>confdefs.h
+
+
+printf "%s\n" "#define Py_HAVE_SOCKETPAIR 1" >>confdefs.h
 
 fi
 
@@ -22748,6 +23169,9 @@ then :
 printf "%s\n" "#define HAVE_SOCKADDR_SA_LEN 1" >>confdefs.h
 
 
+printf "%s\n" "#define Py_HAVE_SOCKADDR_SA_LEN 1" >>confdefs.h
+
+
 fi
 
 # sigh -- gethostbyname_r is a mess; it can have 3, 5 or 6 arguments :-(
@@ -22756,7 +23180,9 @@ fi
 ac_fn_c_check_func "$LINENO" "gethostbyname_r" "ac_cv_func_gethostbyname_r"
 if test "x$ac_cv_func_gethostbyname_r" = xyes
 then :
-  printf "%s\n" "#define HAVE_GETHOSTBYNAME_R 1" >>confdefs.h
+  printf "%s\n" "#define HAVE_GETHOSTBYNAME_R /**/" >>confdefs.h
+
+          printf "%s\n" "#define Py_HAVE_GETHOSTBYNAME_R /**/" >>confdefs.h
 
   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking gethostbyname_r with 6 args" >&5
 printf %s "checking gethostbyname_r with 6 args... " >&6; }
@@ -22786,10 +23212,15 @@ _ACEOF
 if ac_fn_c_try_compile "$LINENO"
 then :
 
-    printf "%s\n" "#define HAVE_GETHOSTBYNAME_R 1" >>confdefs.h
+    printf "%s\n" "#define HAVE_GETHOSTBYNAME_R /**/" >>confdefs.h
+
+          printf "%s\n" "#define Py_HAVE_GETHOSTBYNAME_R /**/" >>confdefs.h
 
 
 printf "%s\n" "#define HAVE_GETHOSTBYNAME_R_6_ARG 1" >>confdefs.h
+
+
+printf "%s\n" "#define Py_HAVE_GETHOSTBYNAME_R_6_ARG 1" >>confdefs.h
 
     { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
 printf "%s\n" "yes" >&6; }
@@ -22824,10 +23255,15 @@ _ACEOF
 if ac_fn_c_try_compile "$LINENO"
 then :
 
-        printf "%s\n" "#define HAVE_GETHOSTBYNAME_R 1" >>confdefs.h
+        printf "%s\n" "#define HAVE_GETHOSTBYNAME_R /**/" >>confdefs.h
+
+          printf "%s\n" "#define Py_HAVE_GETHOSTBYNAME_R /**/" >>confdefs.h
 
 
 printf "%s\n" "#define HAVE_GETHOSTBYNAME_R_5_ARG 1" >>confdefs.h
+
+
+printf "%s\n" "#define Py_HAVE_GETHOSTBYNAME_R_5_ARG 1" >>confdefs.h
 
         { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
 printf "%s\n" "yes" >&6; }
@@ -22860,10 +23296,15 @@ _ACEOF
 if ac_fn_c_try_compile "$LINENO"
 then :
 
-            printf "%s\n" "#define HAVE_GETHOSTBYNAME_R 1" >>confdefs.h
+            printf "%s\n" "#define HAVE_GETHOSTBYNAME_R /**/" >>confdefs.h
+
+          printf "%s\n" "#define Py_HAVE_GETHOSTBYNAME_R /**/" >>confdefs.h
 
 
 printf "%s\n" "#define HAVE_GETHOSTBYNAME_R_3_ARG 1" >>confdefs.h
+
+
+printf "%s\n" "#define Py_HAVE_GETHOSTBYNAME_R_3_ARG 1" >>confdefs.h
 
             { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
 printf "%s\n" "yes" >&6; }
@@ -23056,6 +23497,9 @@ then :
 printf "%s\n" "#define HAVE_GCC_ASM_FOR_X64 1" >>confdefs.h
 
 
+printf "%s\n" "#define Py_HAVE_GCC_ASM_FOR_X64 1" >>confdefs.h
+
+
 fi
 
 # **************************************************
@@ -23123,10 +23567,16 @@ then
 
 printf "%s\n" "#define DOUBLE_IS_BIG_ENDIAN_IEEE754 1" >>confdefs.h
 
+
+printf "%s\n" "#define Py_DOUBLE_IS_BIG_ENDIAN_IEEE754 1" >>confdefs.h
+
 elif test "$ax_cv_c_float_words_bigendian" = "no"
 then
 
 printf "%s\n" "#define DOUBLE_IS_LITTLE_ENDIAN_IEEE754 1" >>confdefs.h
+
+
+printf "%s\n" "#define Py_DOUBLE_IS_LITTLE_ENDIAN_IEEE754 1" >>confdefs.h
 
 else
   # Some ARM platforms use a mixed-endian representation for doubles.
@@ -23137,6 +23587,9 @@ else
   # or little, then it must be this?
 
 printf "%s\n" "#define DOUBLE_IS_ARM_MIXED_ENDIAN_IEEE754 1" >>confdefs.h
+
+
+printf "%s\n" "#define Py_DOUBLE_IS_ARM_MIXED_ENDIAN_IEEE754 1" >>confdefs.h
 
 fi
 
@@ -23191,6 +23644,9 @@ then :
 printf "%s\n" "#define HAVE_GCC_ASM_FOR_X87 1" >>confdefs.h
 
 
+printf "%s\n" "#define Py_HAVE_GCC_ASM_FOR_X87 1" >>confdefs.h
+
+
 fi
 
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether we can use gcc inline assembler to get and set mc68881 fpcr" >&5
@@ -23232,6 +23688,9 @@ then :
 
 
 printf "%s\n" "#define HAVE_GCC_ASM_FOR_MC68881 1" >>confdefs.h
+
+
+printf "%s\n" "#define Py_HAVE_GCC_ASM_FOR_MC68881 1" >>confdefs.h
 
 
 fi
@@ -23299,6 +23758,9 @@ then :
 
 
 printf "%s\n" "#define X87_DOUBLE_ROUNDING 1" >>confdefs.h
+
+
+printf "%s\n" "#define Py_X87_DOUBLE_ROUNDING 1" >>confdefs.h
 
 
 fi
@@ -23383,6 +23845,9 @@ then :
 printf "%s\n" "#define POSIX_SEMAPHORES_NOT_ENABLED 1" >>confdefs.h
 
 
+printf "%s\n" "#define Py_POSIX_SEMAPHORES_NOT_ENABLED 1" >>confdefs.h
+
+
 fi
 
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for broken sem_getvalue" >&5
@@ -23441,6 +23906,9 @@ then :
 
 
 printf "%s\n" "#define HAVE_BROKEN_SEM_GETVALUE 1" >>confdefs.h
+
+
+printf "%s\n" "#define Py_HAVE_BROKEN_SEM_GETVALUE 1" >>confdefs.h
 
 
 fi
@@ -23541,6 +24009,9 @@ printf "%s\n" "$enable_big_digits" >&6; }
 printf "%s\n" "#define PYLONG_BITS_IN_DIGIT $enable_big_digits" >>confdefs.h
 
 
+printf "%s\n" "#define Py_PYLONG_BITS_IN_DIGIT $enable_big_digits" >>confdefs.h
+
+
 else $as_nop
   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no value specified" >&5
 printf "%s\n" "no value specified" >&6; }
@@ -23554,6 +24025,9 @@ then :
 
 
 printf "%s\n" "#define HAVE_WCHAR_H 1" >>confdefs.h
+
+
+printf "%s\n" "#define Py_HAVE_WCHAR_H 1" >>confdefs.h
 
   wchar_h="yes"
 
@@ -23652,6 +24126,9 @@ then
 
 printf "%s\n" "#define HAVE_USABLE_WCHAR_T 1" >>confdefs.h
 
+
+printf "%s\n" "#define Py_HAVE_USABLE_WCHAR_T 1" >>confdefs.h
+
   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
 printf "%s\n" "yes" >&6; }
 else
@@ -23669,6 +24146,9 @@ SunOS/*)
       # https://docs.oracle.com/cd/E37838_01/html/E61053/gmwke.html
 
 printf "%s\n" "#define HAVE_NON_UNICODE_WCHAR_T_REPRESENTATION 1" >>confdefs.h
+
+
+printf "%s\n" "#define Py_HAVE_NON_UNICODE_WCHAR_T_REPRESENTATION 1" >>confdefs.h
 
     fi
   fi
@@ -23946,6 +24426,9 @@ if test "$Py_DEBUG" = 'true'; then
 
 printf "%s\n" "#define ALT_SOABI \"${ALT_SOABI}\"" >>confdefs.h
 
+
+printf "%s\n" "#define Py_ALT_SOABI \"${ALT_SOABI}\"" >>confdefs.h
+
 fi
 
 
@@ -24074,6 +24557,9 @@ then
 
 printf "%s\n" "#define SIGNED_RIGHT_SHIFT_ZERO_FILLS 1" >>confdefs.h
 
+
+printf "%s\n" "#define Py_SIGNED_RIGHT_SHIFT_ZERO_FILLS 1" >>confdefs.h
+
 fi
 
 # check for getc_unlocked and related locking functions
@@ -24115,6 +24601,9 @@ if test "$ac_cv_have_getc_unlocked" = yes
 then
 
 printf "%s\n" "#define HAVE_GETC_UNLOCKED 1" >>confdefs.h
+
+
+printf "%s\n" "#define Py_HAVE_GETC_UNLOCKED 1" >>confdefs.h
 
 fi
 
@@ -24494,6 +24983,8 @@ then :
           LIBREADLINE=edit
           printf "%s\n" "#define WITH_EDITLINE 1" >>confdefs.h
 
+          printf "%s\n" "#define Py_WITH_EDITLINE 1" >>confdefs.h
+
           READLINE_CFLAGS=${LIBEDIT_CFLAGS-""}
           READLINE_LIBS=${LIBEDIT_LIBS-"-ledit"}
 
@@ -24575,6 +25066,8 @@ then :
           LIBREADLINE=edit
           printf "%s\n" "#define WITH_EDITLINE 1" >>confdefs.h
 
+          printf "%s\n" "#define Py_WITH_EDITLINE 1" >>confdefs.h
+
           READLINE_CFLAGS=${LIBEDIT_CFLAGS-""}
           READLINE_LIBS=${LIBEDIT_LIBS-"-ledit"}
 
@@ -24603,6 +25096,8 @@ else
 printf "%s\n" "yes" >&6; }
 
     printf "%s\n" "#define WITH_EDITLINE 1" >>confdefs.h
+
+          printf "%s\n" "#define Py_WITH_EDITLINE 1" >>confdefs.h
 
     LIBREADLINE=edit
     READLINE_CFLAGS=$LIBEDIT_CFLAGS
@@ -24657,6 +25152,9 @@ then :
 printf "%s\n" "#define HAVE_RL_COMPLETION_APPEND_CHARACTER 1" >>confdefs.h
 
 
+printf "%s\n" "#define Py_HAVE_RL_COMPLETION_APPEND_CHARACTER 1" >>confdefs.h
+
+
 fi
 
     ac_fn_check_decl "$LINENO" "rl_completion_suppress_append" "ac_cv_have_decl_rl_completion_suppress_append" "
@@ -24674,6 +25172,9 @@ then :
 
 
 printf "%s\n" "#define HAVE_RL_COMPLETION_SUPPRESS_APPEND 1" >>confdefs.h
+
+
+printf "%s\n" "#define Py_HAVE_RL_COMPLETION_SUPPRESS_APPEND 1" >>confdefs.h
 
 
 fi
@@ -24725,6 +25226,9 @@ then :
 printf "%s\n" "#define HAVE_RL_PRE_INPUT_HOOK 1" >>confdefs.h
 
 
+printf "%s\n" "#define Py_HAVE_RL_PRE_INPUT_HOOK 1" >>confdefs.h
+
+
 fi
 
     # also in 4.0
@@ -24772,6 +25276,9 @@ then :
 
 
 printf "%s\n" "#define HAVE_RL_COMPLETION_DISPLAY_MATCHES_HOOK 1" >>confdefs.h
+
+
+printf "%s\n" "#define Py_HAVE_RL_COMPLETION_DISPLAY_MATCHES_HOOK 1" >>confdefs.h
 
 
 fi
@@ -24823,6 +25330,9 @@ then :
 printf "%s\n" "#define HAVE_RL_RESIZE_TERMINAL 1" >>confdefs.h
 
 
+printf "%s\n" "#define Py_HAVE_RL_RESIZE_TERMINAL 1" >>confdefs.h
+
+
 fi
 
     # check for readline 4.2
@@ -24872,6 +25382,9 @@ then :
 printf "%s\n" "#define HAVE_RL_COMPLETION_MATCHES 1" >>confdefs.h
 
 
+printf "%s\n" "#define Py_HAVE_RL_COMPLETION_MATCHES 1" >>confdefs.h
+
+
 fi
 
     # also in readline 4.2
@@ -24890,6 +25403,9 @@ then :
 
 
 printf "%s\n" "#define HAVE_RL_CATCH_SIGNAL 1" >>confdefs.h
+
+
+printf "%s\n" "#define Py_HAVE_RL_CATCH_SIGNAL 1" >>confdefs.h
 
 
 fi
@@ -24940,6 +25456,9 @@ then :
 printf "%s\n" "#define HAVE_RL_APPEND_HISTORY 1" >>confdefs.h
 
 
+printf "%s\n" "#define Py_HAVE_RL_APPEND_HISTORY 1" >>confdefs.h
+
+
 fi
 
     # in readline as well as newer editline (April 2023)
@@ -24957,6 +25476,9 @@ if test "x$ac_cv_type_rl_compdisp_func_t" = xyes
 then :
 
 printf "%s\n" "#define HAVE_RL_COMPDISP_FUNC_T 1" >>confdefs.h
+
+
+printf "%s\n" "#define Py_HAVE_RL_COMPDISP_FUNC_T 1" >>confdefs.h
 
 fi
 
@@ -25014,6 +25536,9 @@ then
 
 printf "%s\n" "#define HAVE_BROKEN_NICE 1" >>confdefs.h
 
+
+printf "%s\n" "#define Py_HAVE_BROKEN_NICE 1" >>confdefs.h
+
 fi
 
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for broken poll()" >&5
@@ -25066,6 +25591,9 @@ if test "$ac_cv_broken_poll" = yes
 then
 
 printf "%s\n" "#define HAVE_BROKEN_POLL 1" >>confdefs.h
+
+
+printf "%s\n" "#define Py_HAVE_BROKEN_POLL 1" >>confdefs.h
 
 fi
 
@@ -25166,6 +25694,9 @@ then
 
 printf "%s\n" "#define HAVE_WORKING_TZSET 1" >>confdefs.h
 
+
+printf "%s\n" "#define Py_HAVE_WORKING_TZSET 1" >>confdefs.h
+
 fi
 
 # Look for subsecond timestamps in struct stat
@@ -25204,6 +25735,9 @@ then
 
 printf "%s\n" "#define HAVE_STAT_TV_NSEC 1" >>confdefs.h
 
+
+printf "%s\n" "#define Py_HAVE_STAT_TV_NSEC 1" >>confdefs.h
+
 fi
 
 # Look for BSD style subsecond timestamps in struct stat
@@ -25241,6 +25775,9 @@ if test "$ac_cv_stat_tv_nsec2" = yes
 then
 
 printf "%s\n" "#define HAVE_STAT_TV_NSEC2 1" >>confdefs.h
+
+
+printf "%s\n" "#define Py_HAVE_STAT_TV_NSEC2 1" >>confdefs.h
 
 fi
 
@@ -25372,6 +25909,8 @@ then :
 
           printf "%s\n" "#define HAVE_NCURSESW 1" >>confdefs.h
 
+          printf "%s\n" "#define Py_HAVE_NCURSESW 1" >>confdefs.h
+
           have_curses=ncursesw
           CURSES_CFLAGS=${CURSES_CFLAGS-""}
           CURSES_LIBS=${CURSES_LIBS-"-lncursesw"}
@@ -25436,6 +25975,8 @@ then :
 
           printf "%s\n" "#define HAVE_NCURSESW 1" >>confdefs.h
 
+          printf "%s\n" "#define Py_HAVE_NCURSESW 1" >>confdefs.h
+
           have_curses=ncursesw
           CURSES_CFLAGS=${CURSES_CFLAGS-""}
           CURSES_LIBS=${CURSES_LIBS-"-lncursesw"}
@@ -25457,6 +25998,8 @@ else
 printf "%s\n" "yes" >&6; }
 
       printf "%s\n" "#define HAVE_NCURSESW 1" >>confdefs.h
+
+          printf "%s\n" "#define Py_HAVE_NCURSESW 1" >>confdefs.h
 
       have_curses=ncursesw
 
@@ -25666,6 +26209,8 @@ if test "$have_curses" != no -a "$ac_sys_system" = "Darwin"; then
 
   as_fn_append CURSES_CFLAGS " -D_XOPEN_SOURCE_EXTENDED=1"
   printf "%s\n" "#define HAVE_NCURSESW 1" >>confdefs.h
+
+          printf "%s\n" "#define Py_HAVE_NCURSESW 1" >>confdefs.h
 
 fi
 
@@ -26165,6 +26710,9 @@ then
 
 printf "%s\n" "#define MVWDELCH_IS_EXPRESSION 1" >>confdefs.h
 
+
+printf "%s\n" "#define Py_MVWDELCH_IS_EXPRESSION 1" >>confdefs.h
+
 fi
 
 # Issue #25720: ncurses has introduced the NCURSES_OPAQUE symbol making opaque
@@ -26211,6 +26759,9 @@ then
 
 printf "%s\n" "#define WINDOW_HAS_FLAGS 1" >>confdefs.h
 
+
+printf "%s\n" "#define Py_WINDOW_HAS_FLAGS 1" >>confdefs.h
+
 fi
 
 
@@ -26253,6 +26804,9 @@ printf "%s\n" "$ac_cv_lib_curses_is_pad" >&6; }
 then :
 
 printf "%s\n" "#define HAVE_CURSES_IS_PAD 1" >>confdefs.h
+
+
+printf "%s\n" "#define Py_HAVE_CURSES_IS_PAD 1" >>confdefs.h
 
 fi
 
@@ -26297,6 +26851,9 @@ then :
 
 printf "%s\n" "#define HAVE_CURSES_IS_TERM_RESIZED 1" >>confdefs.h
 
+
+printf "%s\n" "#define Py_HAVE_CURSES_IS_TERM_RESIZED 1" >>confdefs.h
+
 fi
 
 
@@ -26339,6 +26896,9 @@ printf "%s\n" "$ac_cv_lib_curses_resize_term" >&6; }
 then :
 
 printf "%s\n" "#define HAVE_CURSES_RESIZE_TERM 1" >>confdefs.h
+
+
+printf "%s\n" "#define Py_HAVE_CURSES_RESIZE_TERM 1" >>confdefs.h
 
 fi
 
@@ -26383,6 +26943,9 @@ then :
 
 printf "%s\n" "#define HAVE_CURSES_RESIZETERM 1" >>confdefs.h
 
+
+printf "%s\n" "#define Py_HAVE_CURSES_RESIZETERM 1" >>confdefs.h
+
 fi
 
 
@@ -26425,6 +26988,9 @@ printf "%s\n" "$ac_cv_lib_curses_immedok" >&6; }
 then :
 
 printf "%s\n" "#define HAVE_CURSES_IMMEDOK 1" >>confdefs.h
+
+
+printf "%s\n" "#define Py_HAVE_CURSES_IMMEDOK 1" >>confdefs.h
 
 fi
 
@@ -26469,6 +27035,9 @@ then :
 
 printf "%s\n" "#define HAVE_CURSES_SYNCOK 1" >>confdefs.h
 
+
+printf "%s\n" "#define Py_HAVE_CURSES_SYNCOK 1" >>confdefs.h
+
 fi
 
 
@@ -26511,6 +27080,9 @@ printf "%s\n" "$ac_cv_lib_curses_wchgat" >&6; }
 then :
 
 printf "%s\n" "#define HAVE_CURSES_WCHGAT 1" >>confdefs.h
+
+
+printf "%s\n" "#define Py_HAVE_CURSES_WCHGAT 1" >>confdefs.h
 
 fi
 
@@ -26555,6 +27127,9 @@ then :
 
 printf "%s\n" "#define HAVE_CURSES_FILTER 1" >>confdefs.h
 
+
+printf "%s\n" "#define Py_HAVE_CURSES_FILTER 1" >>confdefs.h
+
 fi
 
 
@@ -26597,6 +27172,9 @@ printf "%s\n" "$ac_cv_lib_curses_has_key" >&6; }
 then :
 
 printf "%s\n" "#define HAVE_CURSES_HAS_KEY 1" >>confdefs.h
+
+
+printf "%s\n" "#define Py_HAVE_CURSES_HAS_KEY 1" >>confdefs.h
 
 fi
 
@@ -26641,6 +27219,9 @@ then :
 
 printf "%s\n" "#define HAVE_CURSES_TYPEAHEAD 1" >>confdefs.h
 
+
+printf "%s\n" "#define Py_HAVE_CURSES_TYPEAHEAD 1" >>confdefs.h
+
 fi
 
 
@@ -26683,6 +27264,9 @@ printf "%s\n" "$ac_cv_lib_curses_use_env" >&6; }
 then :
 
 printf "%s\n" "#define HAVE_CURSES_USE_ENV 1" >>confdefs.h
+
+
+printf "%s\n" "#define Py_HAVE_CURSES_USE_ENV 1" >>confdefs.h
 
 fi
 
@@ -26735,6 +27319,9 @@ if test "x$ac_cv_file__dev_ptmx" = xyes; then
 
 printf "%s\n" "#define HAVE_DEV_PTMX 1" >>confdefs.h
 
+
+printf "%s\n" "#define Py_HAVE_DEV_PTMX 1" >>confdefs.h
+
 fi
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for /dev/ptc" >&5
 printf %s "checking for /dev/ptc... " >&6; }
@@ -26761,6 +27348,9 @@ if test "x$ac_cv_file__dev_ptc" = xyes; then
 
 printf "%s\n" "#define HAVE_DEV_PTC 1" >>confdefs.h
 
+
+printf "%s\n" "#define Py_HAVE_DEV_PTC 1" >>confdefs.h
+
 fi
 
 if test $ac_sys_system = Darwin
@@ -26783,6 +27373,9 @@ then :
 else $as_nop
 
 printf "%s\n" "#define socklen_t int" >>confdefs.h
+
+
+printf "%s\n" "#define Py_socklen_t int" >>confdefs.h
 
 fi
 
@@ -26829,6 +27422,9 @@ then
 
 printf "%s\n" "#define HAVE_BROKEN_MBSTOWCS 1" >>confdefs.h
 
+
+printf "%s\n" "#define Py_HAVE_BROKEN_MBSTOWCS 1" >>confdefs.h
+
 fi
 
 # Check for --with-computed-gotos
@@ -26844,6 +27440,9 @@ then
 
 printf "%s\n" "#define USE_COMPUTED_GOTOS 1" >>confdefs.h
 
+
+printf "%s\n" "#define Py_USE_COMPUTED_GOTOS 1" >>confdefs.h
+
   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
 printf "%s\n" "yes" >&6; }
 fi
@@ -26851,6 +27450,9 @@ if test "$withval" = no
 then
 
 printf "%s\n" "#define USE_COMPUTED_GOTOS 0" >>confdefs.h
+
+
+printf "%s\n" "#define Py_USE_COMPUTED_GOTOS 0" >>confdefs.h
 
   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
 printf "%s\n" "no" >&6; }
@@ -26908,12 +27510,18 @@ case "$ac_cv_computed_gotos" in yes*)
 
 printf "%s\n" "#define HAVE_COMPUTED_GOTOS 1" >>confdefs.h
 
+
+printf "%s\n" "#define Py_HAVE_COMPUTED_GOTOS 1" >>confdefs.h
+
 esac
 
 case $ac_sys_system in
 AIX*)
 
 printf "%s\n" "#define HAVE_BROKEN_PIPE_BUF 1" >>confdefs.h
+
+
+printf "%s\n" "#define Py_HAVE_BROKEN_PIPE_BUF 1" >>confdefs.h
  ;;
 esac
 
@@ -27045,6 +27653,9 @@ if test "$have_glibc_memmove_bug" = yes; then
 
 printf "%s\n" "#define HAVE_GLIBC_MEMMOVE_BUG 1" >>confdefs.h
 
+
+printf "%s\n" "#define Py_HAVE_GLIBC_MEMMOVE_BUG 1" >>confdefs.h
+
 fi
 
 if test "$ac_cv_gcc_asm_for_x87" = yes; then
@@ -27097,6 +27708,9 @@ printf "%s\n" "$have_ipa_pure_const_bug" >&6; }
             if test "$have_ipa_pure_const_bug" = yes; then
 
 printf "%s\n" "#define HAVE_IPA_PURE_CONST_BUG 1" >>confdefs.h
+
+
+printf "%s\n" "#define Py_HAVE_IPA_PURE_CONST_BUG 1" >>confdefs.h
 
             fi
         ;;
@@ -27180,6 +27794,9 @@ then :
 printf "%s\n" "#define HAVE_DIRENT_D_TYPE 1" >>confdefs.h
 
 
+printf "%s\n" "#define Py_HAVE_DIRENT_D_TYPE 1" >>confdefs.h
+
+
 fi
 
 # check if the Linux getrandom() syscall is available
@@ -27230,6 +27847,9 @@ then :
 printf "%s\n" "#define HAVE_GETRANDOM_SYSCALL 1" >>confdefs.h
 
 
+printf "%s\n" "#define Py_HAVE_GETRANDOM_SYSCALL 1" >>confdefs.h
+
+
 fi
 
 # check if the getrandom() function is available
@@ -27277,6 +27897,9 @@ then :
 
 
 printf "%s\n" "#define HAVE_GETRANDOM 1" >>confdefs.h
+
+
+printf "%s\n" "#define Py_HAVE_GETRANDOM 1" >>confdefs.h
 
 
 fi
@@ -27846,15 +28469,23 @@ case "$withval" in
     python)
         printf "%s\n" "#define PY_SSL_DEFAULT_CIPHERS 1" >>confdefs.h
 
+          printf "%s\n" "#define Py_PY_SSL_DEFAULT_CIPHERS 1" >>confdefs.h
+
         ;;
     openssl)
         printf "%s\n" "#define PY_SSL_DEFAULT_CIPHERS 2" >>confdefs.h
+
+          printf "%s\n" "#define Py_PY_SSL_DEFAULT_CIPHERS 2" >>confdefs.h
 
         ;;
     *)
         printf "%s\n" "#define PY_SSL_DEFAULT_CIPHERS 0" >>confdefs.h
 
+          printf "%s\n" "#define Py_PY_SSL_DEFAULT_CIPHERS 0" >>confdefs.h
+
         printf "%s\n" "#define PY_SSL_DEFAULT_CIPHER_STRING \"$withval\"" >>confdefs.h
+
+          printf "%s\n" "#define Py_PY_SSL_DEFAULT_CIPHER_STRING \"$withval\"" >>confdefs.h
 
         ;;
 esac
@@ -27865,6 +28496,8 @@ else $as_nop
 printf "%s\n" "python" >&6; }
 printf "%s\n" "#define PY_SSL_DEFAULT_CIPHERS 1" >>confdefs.h
 
+          printf "%s\n" "#define Py_PY_SSL_DEFAULT_CIPHERS 1" >>confdefs.h
+
 
 fi
 
@@ -27873,6 +28506,9 @@ fi
 default_hashlib_hashes="md5,sha1,sha2,sha3,blake2"
 
 printf "%s\n" "#define PY_BUILTIN_HASHLIB_HASHES /**/" >>confdefs.h
+
+
+printf "%s\n" "#define Py_PY_BUILTIN_HASHLIB_HASHES /**/" >>confdefs.h
 
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for --with-builtin-hashlib-hashes" >&5
 printf %s "checking for --with-builtin-hashlib-hashes... " >&6; }
@@ -27899,6 +28535,8 @@ fi
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $with_builtin_hashlib_hashes" >&5
 printf "%s\n" "$with_builtin_hashlib_hashes" >&6; }
 printf "%s\n" "#define PY_BUILTIN_HASHLIB_HASHES \"$with_builtin_hashlib_hashes\"" >>confdefs.h
+
+          printf "%s\n" "#define Py_PY_BUILTIN_HASHLIB_HASHES \"$with_builtin_hashlib_hashes\"" >>confdefs.h
 
 
 as_save_IFS=$IFS
@@ -27998,6 +28636,9 @@ printf "%s\n" "yes" >&6; }
     have_libb2=yes
 
 printf "%s\n" "#define HAVE_LIBB2 1" >>confdefs.h
+
+
+printf "%s\n" "#define Py_HAVE_LIBB2 1" >>confdefs.h
 
 
 fi

--- a/configure.ac
+++ b/configure.ac
@@ -53,6 +53,13 @@ AC_DEFUN([WITH_SAVE_ENV],
 [RESTORE_ENV]
 )dnl
 
+AC_DEFUN([PY_DEFINE],
+         [AC_DEFINE([$1], [$2], [$3])
+          AC_DEFINE([[Py_]$1], [$2], [$3])])
+AC_DEFUN([PY_DEFINE_UNQUOTED],
+         [AC_DEFINE_UNQUOTED([$1], [$2], [$3])
+          AC_DEFINE_UNQUOTED([[Py_]$1], [$2], [$3])])
+
 dnl PY_CHECK_FUNC(FUNCTION, [INCLUDES], [AC_DEFINE-VAR])
 AC_DEFUN([PY_CHECK_FUNC],
 [ AS_VAR_PUSHDEF([py_var], [ac_cv_func_$1])
@@ -68,7 +75,7 @@ AC_DEFUN([PY_CHECK_FUNC],
   AS_VAR_IF(
     [py_var],
     [yes],
-    [AC_DEFINE([py_define], [1], [Define if you have the '$1' function.])])
+    [PY_DEFINE([py_define], [1], [Define if you have the '$1' function.])])
   AS_VAR_POPDEF([py_var])
   AS_VAR_POPDEF([py_define])
 ])
@@ -256,19 +263,19 @@ SOVERSION=1.0
 # The later definition of _XOPEN_SOURCE and _POSIX_C_SOURCE disables
 # certain features on NetBSD, so we need _NETBSD_SOURCE to re-enable
 # them.
-AC_DEFINE([_NETBSD_SOURCE], [1],
+PY_DEFINE([_NETBSD_SOURCE], [1],
           [Define on NetBSD to activate all library features])
 
 # The later definition of _XOPEN_SOURCE and _POSIX_C_SOURCE disables
 # certain features on FreeBSD, so we need __BSD_VISIBLE to re-enable
 # them.
-AC_DEFINE([__BSD_VISIBLE], [1],
+PY_DEFINE([__BSD_VISIBLE], [1],
           [Define on FreeBSD to activate all library features])
 
 # The later definition of _XOPEN_SOURCE and _POSIX_C_SOURCE disables
 # certain features on Mac OS X, so we need _DARWIN_C_SOURCE to re-enable
 # them.
-AC_DEFINE([_DARWIN_C_SOURCE], [1],
+PY_DEFINE([_DARWIN_C_SOURCE], [1],
           [Define on Darwin to activate all library features])
 
 
@@ -369,7 +376,7 @@ then
 	# For Solaris, there isn't an OS version specific macro defined
 	# in most compilers, so we define one here.
 	SUNOS_VERSION=`echo $ac_sys_release | sed -e 's!\.\([0-9]\)$!.0\1!g' | tr -d '.'`
-	AC_DEFINE_UNQUOTED([Py_SUNOS_VERSION], [$SUNOS_VERSION],
+	PY_DEFINE_UNQUOTED([Py_SUNOS_VERSION], [$SUNOS_VERSION],
 	                   [The version of SunOS/Solaris as reported by `uname -r' without the dot.])
     fi
 fi
@@ -616,7 +623,7 @@ AC_SUBST([FRAMEWORKUNIXTOOLSPREFIX])
 AC_SUBST([FRAMEWORKINSTALLAPPSPREFIX])
 AC_SUBST([INSTALLTARGETS])
 
-AC_DEFINE_UNQUOTED([_PYTHONFRAMEWORK], ["${PYTHONFRAMEWORK}"],
+PY_DEFINE_UNQUOTED([_PYTHONFRAMEWORK], ["${PYTHONFRAMEWORK}"],
                    [framework name])
 
 AC_SUBST([_PYTHON_HOST_PLATFORM])
@@ -669,14 +676,14 @@ case $ac_sys_system/$ac_sys_release in
     # OpenBSD undoes our definition of __BSD_VISIBLE if _XOPEN_SOURCE is
     # also defined. This can be overridden by defining _BSD_SOURCE
     # As this has a different meaning on Linux, only define it on OpenBSD
-    AC_DEFINE([_BSD_SOURCE], [1],
+    PY_DEFINE([_BSD_SOURCE], [1],
               [Define on OpenBSD to activate all library features])
     ;;
   OpenBSD/*)
     # OpenBSD undoes our definition of __BSD_VISIBLE if _XOPEN_SOURCE is
     # also defined. This can be overridden by defining _BSD_SOURCE
     # As this has a different meaning on Linux, only define it on OpenBSD
-    AC_DEFINE([_BSD_SOURCE], [1],
+    PY_DEFINE([_BSD_SOURCE], [1],
               [Define on OpenBSD to activate all library features])
     ;;
   # Defining _XOPEN_SOURCE on NetBSD version prior to the introduction of
@@ -733,17 +740,17 @@ esac
 if test $define_xopen_source = yes
 then
   # X/Open 7, incorporating POSIX.1-2008
-  AC_DEFINE([_XOPEN_SOURCE], [700],
+  PY_DEFINE([_XOPEN_SOURCE], [700],
             [Define to the level of X/Open that your system supports])
 
   # On Tru64 Unix 4.0F, defining _XOPEN_SOURCE also requires
   # definition of _XOPEN_SOURCE_EXTENDED and _POSIX_C_SOURCE, or else
   # several APIs are not declared. Since this is also needed in some
   # cases for HP-UX, we define it globally.
-  AC_DEFINE([_XOPEN_SOURCE_EXTENDED], [1],
+  PY_DEFINE([_XOPEN_SOURCE_EXTENDED], [1],
             [Define to activate Unix95-and-earlier features])
 
-  AC_DEFINE([_POSIX_C_SOURCE], [200809L],
+  PY_DEFINE([_POSIX_C_SOURCE], [200809L],
             [Define to activate features from IEEE Stds 1003.1-2008])
 fi
 
@@ -757,7 +764,7 @@ esac
 
 if test $define_stdc_a1 = yes
 then
-  AC_DEFINE([_INCLUDE__STDC_A1_SOURCE], [1],
+  PY_DEFINE([_INCLUDE__STDC_A1_SOURCE], [1],
             [Define to include mbstate_t for mbrtowc])
 fi
 
@@ -1029,7 +1036,7 @@ AS_CASE([$PY_SUPPORT_TIER],
   [AC_MSG_WARN([$host/$ac_cv_cc_name is not supported])]
 )
 
-AC_DEFINE_UNQUOTED([PY_SUPPORT_TIER], [$PY_SUPPORT_TIER], [PEP 11 Support tier (1, 2, 3 or 0 for unsupported)])
+PY_DEFINE_UNQUOTED([PY_SUPPORT_TIER], [$PY_SUPPORT_TIER], [PEP 11 Support tier (1, 2, 3 or 0 for unsupported)])
 
 AC_CACHE_CHECK([for -Wl,--no-as-needed], [ac_cv_wl_no_as_needed], [
   save_LDFLAGS="$LDFLAGS"
@@ -1060,7 +1067,7 @@ if $CPP $CPPFLAGS conftest.c >conftest.out 2>/dev/null; then
   if test -z "$ANDROID_API_LEVEL"; then
     AC_MSG_ERROR([Fatal: you must define __ANDROID_API__])
   fi
-  AC_DEFINE_UNQUOTED([ANDROID_API_LEVEL], [$ANDROID_API_LEVEL],
+  PY_DEFINE_UNQUOTED([ANDROID_API_LEVEL], [$ANDROID_API_LEVEL],
                      [The Android API level.])
 
   AC_MSG_CHECKING([for the Android arm ABI])
@@ -1355,7 +1362,7 @@ fi
 # Other platforms follow
 if test $enable_shared = "yes"; then
   PY_ENABLE_SHARED=1
-  AC_DEFINE([Py_ENABLE_SHARED], [1],
+  PY_DEFINE([Py_ENABLE_SHARED], [1],
             [Defined if Python is built as a shared library.])
   case $ac_sys_system in
     CYGWIN*)
@@ -1547,7 +1554,7 @@ AC_MSG_RESULT([$disable_gil])
 
 if test "$disable_gil" = "yes"
 then
-  AC_DEFINE([Py_GIL_DISABLED], [1],
+  PY_DEFINE([Py_GIL_DISABLED], [1],
             [Define if you want to disable the GIL])
   # Add "t" for "threaded"
   ABIFLAGS="${ABIFLAGS}t"
@@ -1560,7 +1567,7 @@ AC_ARG_WITH([pydebug],
 [
 if test "$withval" != no
 then
-  AC_DEFINE([Py_DEBUG], [1],
+  PY_DEFINE([Py_DEBUG], [1],
   [Define if you want to build an interpreter with many run-time checks.])
   AC_MSG_RESULT([yes]);
   Py_DEBUG='true'
@@ -1580,7 +1587,7 @@ AC_MSG_RESULT([$with_trace_refs])
 
 if test "$with_trace_refs" = "yes"
 then
-  AC_DEFINE([Py_TRACE_REFS], [1],
+  PY_DEFINE([Py_TRACE_REFS], [1],
             [Define if you want to enable tracing references for debugging purpose])
 fi
 
@@ -1597,7 +1604,7 @@ AC_ARG_ENABLE([pystats],
 AC_MSG_RESULT([$enable_pystats])
 
 AS_VAR_IF([enable_pystats], [yes], [
-  AC_DEFINE([Py_STATS], [1], [Define if you want to enable internal statistics gathering.])
+  PY_DEFINE([Py_STATS], [1], [Define if you want to enable internal statistics gathering.])
 ])
 
 # Check for --with-assertions.
@@ -2212,9 +2219,9 @@ AS_CASE([$ac_sys_system],
     ])
   ],
   [WASI], [
-    AC_DEFINE([_WASI_EMULATED_SIGNAL], [1], [Define to 1 if you want to emulate signals on WASI])
-    AC_DEFINE([_WASI_EMULATED_GETPID], [1], [Define to 1 if you want to emulate getpid() on WASI])
-    AC_DEFINE([_WASI_EMULATED_PROCESS_CLOCKS], [1], [Define to 1 if you want to emulate process clocks on WASI])
+    PY_DEFINE([_WASI_EMULATED_SIGNAL], [1], [Define to 1 if you want to emulate signals on WASI])
+    PY_DEFINE([_WASI_EMULATED_GETPID], [1], [Define to 1 if you want to emulate getpid() on WASI])
+    PY_DEFINE([_WASI_EMULATED_PROCESS_CLOCKS], [1], [Define to 1 if you want to emulate process clocks on WASI])
     LIBS="$LIBS -lwasi-emulated-signal -lwasi-emulated-getpid -lwasi-emulated-process-clocks"
     echo "#define _WASI_EMULATED_SIGNAL 1" >> confdefs.h
 
@@ -2747,12 +2754,12 @@ dnl AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
 dnl #define spam(name, doc) {#name, &name, #name "() -- " doc}
 dnl int foo;
 dnl struct {char *name; int *addr; char *doc;} desc = spam(foo, "something");
-dnl ]], [[;]])],[cpp_type=ansi],[AC_DEFINE(HAVE_OLD_CPP) cpp_type=traditional])
+dnl ]], [[;]])],[cpp_type=ansi],[PY_DEFINE(HAVE_OLD_CPP) cpp_type=traditional])
 dnl AC_MSG_RESULT($cpp_type)
 
 dnl autoconf 2.71 deprecates STDC_HEADERS, keep for backwards compatibility
 dnl assume C99 compilers provide ANSI C headers
-AC_DEFINE([STDC_HEADERS], [1],
+PY_DEFINE([STDC_HEADERS], [1],
           [Define to 1 if you have the ANSI C header files.])
 
 # checks for header files
@@ -2832,7 +2839,7 @@ AC_CACHE_CHECK([for clock_t in time.h], [ac_cv_clock_t_time_h], [
 ])
 dnl checks for "no"
 AS_VAR_IF([ac_cv_clock_t_time_h], [no], [
-  AC_DEFINE([clock_t], [long],
+  PY_DEFINE([clock_t], [long],
             [Define to 'long' if <time.h> doesn't define.])
 ])
 
@@ -2851,7 +2858,7 @@ AC_LINK_IFELSE([AC_LANG_PROGRAM([[
 ])
 
 AS_VAR_IF([ac_cv_func_makedev], [yes], [
-    AC_DEFINE([HAVE_MAKEDEV], [1],
+    PY_DEFINE([HAVE_MAKEDEV], [1],
               [Define this if you have the makedev macro.])
 ])
 
@@ -2869,7 +2876,7 @@ AC_LINK_IFELSE([AC_LANG_PROGRAM([[
 ])
 
 AS_VAR_IF([ac_cv_func_le64toh], [yes], [
-    AC_DEFINE([HAVE_HTOLE64], [1],
+    PY_DEFINE([HAVE_HTOLE64], [1],
               [Define this if you have le64toh()])
 ])
 
@@ -2884,13 +2891,13 @@ if test "$use_lfs" = "yes"; then
 # These may affect some typedefs
 case $ac_sys_system/$ac_sys_release in
 AIX*)
-    AC_DEFINE([_LARGE_FILES], [1],
+    PY_DEFINE([_LARGE_FILES], [1],
     [This must be defined on AIX systems to enable large file support.])
     ;;
 esac
-AC_DEFINE([_LARGEFILE_SOURCE], [1],
+PY_DEFINE([_LARGEFILE_SOURCE], [1],
 [This must be defined on some systems to enable large file support.])
-AC_DEFINE([_FILE_OFFSET_BITS], [64],
+PY_DEFINE([_FILE_OFFSET_BITS], [64],
 [This must be set to 64 on some systems to enable large file support.])
 fi
 
@@ -2905,15 +2912,15 @@ EOF
 AC_TYPE_MODE_T
 AC_TYPE_OFF_T
 AC_TYPE_PID_T
-AC_DEFINE_UNQUOTED([RETSIGTYPE],[void],[assume C89 semantics that RETSIGTYPE is always void])
+PY_DEFINE_UNQUOTED([RETSIGTYPE],[void],[assume C89 semantics that RETSIGTYPE is always void])
 AC_TYPE_SIZE_T
 AC_TYPE_UID_T
 
 AC_CHECK_TYPE([ssize_t],
-  AC_DEFINE([HAVE_SSIZE_T], [1],
+  PY_DEFINE([HAVE_SSIZE_T], [1],
             [Define if your compiler provides ssize_t]), [], [])
 AC_CHECK_TYPE([__uint128_t],
-  AC_DEFINE([HAVE_GCC_UINT128_T], [1],
+  PY_DEFINE([HAVE_GCC_UINT128_T], [1],
             [Define if your compiler provides __uint128_t]), [], [])
 
 # Sizes and alignments of various common basic types
@@ -2956,7 +2963,7 @@ AS_CASE([$ac_sys_system],
   [Emscripten], [have_largefile_support="no"]
 )
 AS_VAR_IF([have_largefile_support], [yes], [
-  AC_DEFINE([HAVE_LARGEFILE_SUPPORT], [1],
+  PY_DEFINE([HAVE_LARGEFILE_SUPPORT], [1],
   [Defined to enable large file support when an off_t is bigger than a long
    and long long is at least as big as an off_t. You may need
    to add some flags for configuration and compilation to enable this mode.
@@ -3013,7 +3020,7 @@ else
 fi
 ])
 AS_VAR_IF([ac_cv_pthread_key_t_is_arithmetic_type], [yes], [
-    AC_DEFINE([PTHREAD_KEY_T_IS_COMPATIBLE_WITH_INT], [1],
+    PY_DEFINE([PTHREAD_KEY_T_IS_COMPATIBLE_WITH_INT], [1],
               [Define if pthread_key_t is compatible with int.])
 ])
 
@@ -3025,7 +3032,7 @@ then
 	BASECFLAGS="$BASECFLAGS -fno-common -dynamic"
 	# -F. is needed to allow linking to the framework while
 	# in the build location.
-	AC_DEFINE([WITH_NEXT_FRAMEWORK], [1],
+	PY_DEFINE([WITH_NEXT_FRAMEWORK], [1],
          [Define if you want to produce an OpenStep/Rhapsody framework
          (shared library plus accessory files).])
 	AC_MSG_RESULT([yes])
@@ -3071,7 +3078,7 @@ fi
 AC_MSG_CHECKING([for dyld])
 case $ac_sys_system/$ac_sys_release in
   Darwin/*)
-    AC_DEFINE([WITH_DYLD], [1],
+    PY_DEFINE([WITH_DYLD], [1],
         [Define if you want to use the new-style (Openstep, Rhapsody, MacOS)
          dynamic linker (dyld) instead of the old-style (NextStep) dynamic
          linker (rld). Dyld is necessary to support frameworks.])
@@ -3384,7 +3391,7 @@ then
 
     LINKFORSHARED="-Wl,-stack_size,$stack_size $LINKFORSHARED"
 
-    AC_DEFINE_UNQUOTED([THREAD_STACK_SIZE],
+    PY_DEFINE_UNQUOTED([THREAD_STACK_SIZE],
         [0x$stack_size],
         [Custom thread stack size depending on chosen sanitizer runtimes.])
 
@@ -3475,7 +3482,7 @@ AS_CASE([$PLATFORM_TRIPLET],
 AC_MSG_RESULT([$perf_trampoline])
 
 AS_VAR_IF([perf_trampoline], [yes], [
-  AC_DEFINE([PY_HAVE_PERF_TRAMPOLINE], [1], [Define to 1 if you have the perf trampoline.])
+  PY_DEFINE([PY_HAVE_PERF_TRAMPOLINE], [1], [Define to 1 if you have the perf trampoline.])
   PERF_TRAMPOLINE_OBJ=Python/asm_trampoline.o
 
   dnl perf needs frame pointers for unwinding, include compiler option in debug builds
@@ -3515,8 +3522,8 @@ AS_VAR_IF([have_uuid], [missing], [
       [dnl linux-util's libuuid has uuid_generate_time_safe() since v2.20 (2011)
       dnl and provides <uuid.h>.
       have_uuid=yes
-      AC_DEFINE([HAVE_UUID_H], [1])
-      AC_DEFINE([HAVE_UUID_GENERATE_TIME_SAFE], [1])
+      PY_DEFINE([HAVE_UUID_H], [1])
+      PY_DEFINE([HAVE_UUID_GENERATE_TIME_SAFE], [1])
     ], [
       WITH_SAVE_ENV([
         CPPFLAGS="$CPPFLAGS $LIBUUID_CFLAGS"
@@ -3525,7 +3532,7 @@ AS_VAR_IF([have_uuid], [missing], [
           PY_CHECK_LIB([uuid], [uuid_generate_time], [have_uuid=yes])
           PY_CHECK_LIB([uuid], [uuid_generate_time_safe],
             [have_uuid=yes
-            AC_DEFINE([HAVE_UUID_GENERATE_TIME_SAFE], [1]) ]) ])
+            PY_DEFINE([HAVE_UUID_GENERATE_TIME_SAFE], [1]) ]) ])
         AS_VAR_IF([have_uuid], [yes], [
           LIBUUID_CFLAGS=${LIBUUID_CFLAGS-""}
           LIBUUID_LIBS=${LIBUUID_LIBS-"-luuid"}
@@ -3555,7 +3562,7 @@ AC_SEARCH_LIBS([sem_init], [pthread rt posix4])
 
 # check if we need libintl for locale functions
 AC_CHECK_LIB([intl], [textdomain],
-	[AC_DEFINE([WITH_LIBINTL], [1],
+	[PY_DEFINE([WITH_LIBINTL], [1],
 	[Define to 1 if libintl is needed for locale functions.])
         LIBS="-lintl $LIBS"])
 
@@ -3566,7 +3573,7 @@ case "$ac_sys_system" in
 		  AC_LANG_PROGRAM([[@%:@include <load.h>]],
 				  [[loadAndInit("", 0, "")]])
 		],[
-		  AC_DEFINE([AIX_GENUINE_CPLUSPLUS], [1],
+		  PY_DEFINE([AIX_GENUINE_CPLUSPLUS], [1],
                       [Define for AIX if your compiler is a genuine IBM xlC/xlC_r
                        and you want support for AIX C++ shared extension modules.])
 		  AC_MSG_RESULT([yes])
@@ -3579,7 +3586,7 @@ dnl The AIX_BUILDDATE is obtained from the kernel fileset - bos.mp64
 # as a baseline for bdist module packages
                AC_MSG_CHECKING([for the system builddate])
                AIX_BUILDDATE=$(lslpp -Lcq bos.mp64 | awk -F:  '{ print $NF }')
-               AC_DEFINE_UNQUOTED([AIX_BUILDDATE], [$AIX_BUILDDATE],
+               PY_DEFINE_UNQUOTED([AIX_BUILDDATE], [$AIX_BUILDDATE],
                    [BUILD_GNU_TYPE + AIX_BUILDDATE are used to construct the PEP425 tag of the build system.])
                AC_MSG_RESULT([$AIX_BUILDDATE])
                ;;
@@ -3606,7 +3613,7 @@ int main(void)
 [ac_cv_aligned_required=yes])
 ])
 if test "$ac_cv_aligned_required" = yes ; then
-  AC_DEFINE([HAVE_ALIGNED_REQUIRED], [1],
+  PY_DEFINE([HAVE_ALIGNED_REQUIRED], [1],
     [Define if aligned memory access is required])
 fi
 
@@ -3627,13 +3634,13 @@ AC_ARG_WITH(
 AC_MSG_RESULT([$withval])
 case "$withval" in
     siphash13)
-        AC_DEFINE([Py_HASH_ALGORITHM], [3])
+        PY_DEFINE([Py_HASH_ALGORITHM], [3])
         ;;
     siphash24)
-        AC_DEFINE([Py_HASH_ALGORITHM], [1])
+        PY_DEFINE([Py_HASH_ALGORITHM], [1])
         ;;
     fnv)
-        AC_DEFINE([Py_HASH_ALGORITHM], [2])
+        PY_DEFINE([Py_HASH_ALGORITHM], [2])
         ;;
     *)
         AC_MSG_ERROR([unknown hash algorithm '$withval'])
@@ -3830,7 +3837,7 @@ AC_ARG_WITH(
 
 if test "$with_decimal_contextvar" != "no"
 then
-    AC_DEFINE([WITH_DECIMAL_CONTEXTVAR], [1],
+    PY_DEFINE([WITH_DECIMAL_CONTEXTVAR], [1],
       [Define if you want build the _decimal module using a coroutine-local rather than a thread-local context])
 fi
 
@@ -3950,7 +3957,7 @@ dnl hence CPPFLAGS instead of CFLAGS.
         [have_sqlite3_load_extension=no]
       )
       AC_CHECK_LIB([sqlite3], [sqlite3_serialize], [
-        AC_DEFINE(
+        PY_DEFINE(
           [PY_SQLITE_HAVE_SERIALIZE], [1],
           [Define if SQLite was compiled with the serialize API]
         )
@@ -3975,7 +3982,7 @@ AC_ARG_ENABLE([loadable-sqlite-extensions],
       AC_MSG_WARN([Your version of SQLite does not support loadable extensions])
     ], [
       AC_MSG_RESULT([yes])
-      AC_DEFINE(
+      PY_DEFINE(
         [PY_SQLITE_ENABLE_LOAD_EXTENSION], [1],
         [Define to 1 to build the sqlite module with loadable extensions support.]
       )
@@ -4104,7 +4111,7 @@ AC_CACHE_VAL([ac_cv_header_gdbm_slash_ndbm_h], [
   )
 ])
 AS_VAR_IF([ac_cv_header_gdbm_slash_ndbm_h], [yes], [
-  AC_DEFINE([HAVE_GDBM_NDBM_H], [1], [Define to 1 if you have the <gdbm/ndbm.h> header file.])
+  PY_DEFINE([HAVE_GDBM_NDBM_H], [1], [Define to 1 if you have the <gdbm/ndbm.h> header file.])
 ])
 
 AS_UNSET([ac_cv_header_gdbm_ndbm_h])
@@ -4115,7 +4122,7 @@ AC_CACHE_VAL([ac_cv_header_gdbm_dash_ndbm_h], [
   )
 ])
 AS_VAR_IF([ac_cv_header_gdbm_dash_ndbm_h], [yes], [
-  AC_DEFINE([HAVE_GDBM_DASH_NDBM_H], [1], [Define to 1 if you have the <gdbm-ndbm.h> header file.])
+  PY_DEFINE([HAVE_GDBM_DASH_NDBM_H], [1], [Define to 1 if you have the <gdbm-ndbm.h> header file.])
 ])
 AS_UNSET([ac_cv_header_gdbm_ndbm_h])
 
@@ -4143,7 +4150,7 @@ AC_CHECK_HEADERS([db.h], [
     ])
   ])
   AS_VAR_IF([ac_cv_have_libdb], [yes], [
-    AC_DEFINE([HAVE_LIBDB], [1], [Define to 1 if you have the `db' library (-ldb).])
+    PY_DEFINE([HAVE_LIBDB], [1], [Define to 1 if you have the `db' library (-ldb).])
   ])
 ])
 
@@ -4209,15 +4216,15 @@ done
 IFS=$as_save_IFS
 AC_MSG_RESULT([$DBM_CFLAGS $DBM_LIBS])
 
-# Templates for things AC_DEFINEd more than once.
-# For a single AC_DEFINE, no template is needed.
+# Templates for things PY_DEFINEd more than once.
+# For a single PY_DEFINE, no template is needed.
 AH_TEMPLATE([_REENTRANT],
   [Define to force use of thread-safe errno, h_errno, and other functions])
 
 if test "$ac_cv_pthread_is_default" = yes
 then
     # Defining _REENTRANT on system with POSIX threads should not hurt.
-    AC_DEFINE([_REENTRANT])
+    PY_DEFINE([_REENTRANT])
     posix_threads=yes
     if test "$ac_sys_system" = "SunOS"; then
         CFLAGS="$CFLAGS -D_REENTRANT"
@@ -4261,7 +4268,7 @@ yes
     ], unistd_defines_pthreads=yes, unistd_defines_pthreads=no)
     AC_MSG_RESULT([$unistd_defines_pthreads])
 
-    AC_DEFINE([_REENTRANT])
+    PY_DEFINE([_REENTRANT])
     # Just looking for pthread_create in libpthread is not enough:
     # on HP/UX, pthread.h renames pthread_create to a different symbol name.
     # So we really have to include pthread.h, and then link.
@@ -4312,23 +4319,23 @@ fi
 
 if test "$posix_threads" = "yes"; then
       if test "$unistd_defines_pthreads" = "no"; then
-         AC_DEFINE([_POSIX_THREADS], [1],
+         PY_DEFINE([_POSIX_THREADS], [1],
          [Define if you have POSIX threads,
           and your system does not define that.])
       fi
 
       # Bug 662787: Using semaphores causes unexplicable hangs on Solaris 8.
       case  $ac_sys_system/$ac_sys_release in
-      SunOS/5.6) AC_DEFINE([HAVE_PTHREAD_DESTRUCTOR], [1],
+      SunOS/5.6) PY_DEFINE([HAVE_PTHREAD_DESTRUCTOR], [1],
                        [Defined for Solaris 2.6 bug in pthread header.])
 		       ;;
-      SunOS/5.8) AC_DEFINE([HAVE_BROKEN_POSIX_SEMAPHORES], [1],
+      SunOS/5.8) PY_DEFINE([HAVE_BROKEN_POSIX_SEMAPHORES], [1],
 		       [Define if the Posix semaphores do not work on your system])
 		       ;;
-      AIX/*) AC_DEFINE([HAVE_BROKEN_POSIX_SEMAPHORES], [1],
+      AIX/*) PY_DEFINE([HAVE_BROKEN_POSIX_SEMAPHORES], [1],
 		       [Define if the Posix semaphores do not work on your system])
 		       ;;
-      NetBSD/*) AC_DEFINE([HAVE_BROKEN_POSIX_SEMAPHORES], [1],
+      NetBSD/*) PY_DEFINE([HAVE_BROKEN_POSIX_SEMAPHORES], [1],
 		       [Define if the Posix semaphores do not work on your system])
 		       ;;
       esac
@@ -4353,13 +4360,13 @@ if test "$posix_threads" = "yes"; then
       [ac_cv_pthread_system_supported=no])
       ])
       if test "$ac_cv_pthread_system_supported" = "yes"; then
-        AC_DEFINE([PTHREAD_SYSTEM_SCHED_SUPPORTED], [1],
+        PY_DEFINE([PTHREAD_SYSTEM_SCHED_SUPPORTED], [1],
                   [Defined if PTHREAD_SCOPE_SYSTEM supported.])
       fi
       AC_CHECK_FUNCS([pthread_sigmask],
         [case $ac_sys_system in
         CYGWIN*)
-          AC_DEFINE([HAVE_BROKEN_PTHREAD_SIGMASK], [1],
+          PY_DEFINE([HAVE_BROKEN_PTHREAD_SIGMASK], [1],
             [Define if pthread_sigmask() does not work on your system.])
             ;;
         esac])
@@ -4367,7 +4374,7 @@ if test "$posix_threads" = "yes"; then
 fi
 
 AS_VAR_IF([posix_threads], [stub], [
-  AC_DEFINE([HAVE_PTHREAD_STUBS], [1], [Define if platform requires stubbed pthreads support])
+  PY_DEFINE([HAVE_PTHREAD_STUBS], [1], [Define if platform requires stubbed pthreads support])
 ])
 
 # Check for enable-ipv6
@@ -4384,7 +4391,7 @@ AC_ARG_ENABLE([ipv6],
        ipv6=no
        ;;
   *)   AC_MSG_RESULT([yes])
-       AC_DEFINE([ENABLE_IPV6])
+       PY_DEFINE([ENABLE_IPV6])
        ipv6=yes
        ;;
   esac ],
@@ -4423,7 +4430,7 @@ if test "$ipv6" = "yes"; then
 fi
 
 if test "$ipv6" = "yes"; then
-	AC_DEFINE([ENABLE_IPV6])
+	PY_DEFINE([ENABLE_IPV6])
 fi
 ])
 
@@ -4549,7 +4556,7 @@ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[ /* CAN_RAW_FD_FRAMES available check */
 [ac_cv_can_raw_fd_frames=no])
 ])
 AS_VAR_IF([ac_cv_can_raw_fd_frames], [yes], [
-    AC_DEFINE([HAVE_LINUX_CAN_RAW_FD_FRAMES], [1],
+    PY_DEFINE([HAVE_LINUX_CAN_RAW_FD_FRAMES], [1],
               [Define if compiling using Linux 3.6 or later.])
 ])
 
@@ -4561,7 +4568,7 @@ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
 [ac_cv_can_raw_join_filters=no])
 ])
 AS_VAR_IF([ac_cv_can_raw_join_filters], [yes], [
-    AC_DEFINE([HAVE_LINUX_CAN_RAW_JOIN_FILTERS], [1],
+    PY_DEFINE([HAVE_LINUX_CAN_RAW_JOIN_FILTERS], [1],
               [Define if compiling using Linux 4.1 or later.])
 ])
 
@@ -4576,7 +4583,7 @@ then with_doc_strings="yes"
 fi
 if test "$with_doc_strings" != "no"
 then
-    AC_DEFINE([WITH_DOC_STRINGS], [1],
+    PY_DEFINE([WITH_DOC_STRINGS], [1],
       [Define if you want documentation strings in extension modules])
 fi
 AC_MSG_RESULT([$with_doc_strings])
@@ -4600,7 +4607,7 @@ AC_LINK_IFELSE(
 ])
 
 AS_VAR_IF([ac_cv_header_stdatomic_h], [yes], [
-    AC_DEFINE(HAVE_STD_ATOMIC, 1,
+    PY_DEFINE([HAVE_STD_ATOMIC], [1],
               [Has stdatomic.h with atomic_int and atomic_uintptr_t])
 ])
 
@@ -4620,7 +4627,7 @@ AC_LINK_IFELSE(
 ])
 
 AS_VAR_IF([ac_cv_builtin_atomic], [yes], [
-    AC_DEFINE(HAVE_BUILTIN_ATOMIC, 1, [Has builtin __atomic_load_n() and __atomic_store_n() functions])
+    PY_DEFINE([HAVE_BUILTIN_ATOMIC], [1], [Has builtin __atomic_load_n() and __atomic_store_n() functions])
 ])
 
 # --with-mimalloc
@@ -4638,7 +4645,7 @@ if test "$with_mimalloc" != no; then
     AC_MSG_ERROR([mimalloc requires stdatomic.h, use --without-mimalloc to disable mimalloc.])
   fi
   with_mimalloc=yes
-  AC_DEFINE([WITH_MIMALLOC], [1], [Define if you want to compile in mimalloc memory allocator.])
+  PY_DEFINE([WITH_MIMALLOC], [1], [Define if you want to compile in mimalloc memory allocator.])
   AC_SUBST([MIMALLOC_HEADERS], ['$(MIMALLOC_HEADERS)'])
 elif test "$disable_gil" = "yes"; then
   AC_MSG_ERROR([--disable-gil requires mimalloc memory allocator (--with-mimalloc).])
@@ -4665,7 +4672,7 @@ then
 fi
 if test "$with_pymalloc" != "no"
 then
-    AC_DEFINE([WITH_PYMALLOC], [1],
+    PY_DEFINE([WITH_PYMALLOC], [1],
      [Define if you want to compile in Python-specific mallocs])
 fi
 AC_MSG_RESULT([$with_pymalloc])
@@ -4683,7 +4690,7 @@ then
 fi
 if test "$with_freelists" != "no"
 then
-    AC_DEFINE([WITH_FREELISTS], [1],
+    PY_DEFINE([WITH_FREELISTS], [1],
      [Define if you want to compile in object freelists optimization])
 fi
 AC_MSG_RESULT([$with_freelists])
@@ -4700,7 +4707,7 @@ then
 fi
 if test "$with_c_locale_coercion" != "no"
 then
-    AC_DEFINE([PY_COERCE_C_LOCALE], [1],
+    PY_DEFINE([PY_COERCE_C_LOCALE], [1],
       [Define if you want to coerce the C locale to a UTF-8 based locale])
 fi
 AC_MSG_RESULT([$with_c_locale_coercion])
@@ -4715,7 +4722,7 @@ AC_ARG_WITH(
 AC_MSG_RESULT([$with_valgrind])
 if test "$with_valgrind" != no; then
     AC_CHECK_HEADER([valgrind/valgrind.h],
-      [AC_DEFINE([WITH_VALGRIND], 1, [Define if you want pymalloc to be disabled when running under valgrind])],
+      [PY_DEFINE([WITH_VALGRIND], 1, [Define if you want pymalloc to be disabled when running under valgrind])],
       [AC_MSG_ERROR([Valgrind support requested but headers not available])]
     )
     OPT="-DDYNAMIC_ANNOTATIONS_ENABLED=1 $OPT"
@@ -4743,7 +4750,7 @@ then
     if test "$DTRACE" = "not found"; then
         AC_MSG_ERROR([dtrace command not found on \$PATH])
     fi
-    AC_DEFINE([WITH_DTRACE], [1],
+    PY_DEFINE([WITH_DTRACE], [1],
               [Define if you want to compile in DTrace support])
     DTRACE_HEADERS="Include/pydtrace_probes.h"
 
@@ -4805,7 +4812,7 @@ fi
 AC_MSG_RESULT([$DYNLOADFILE])
 if test "$DYNLOADFILE" != "dynload_stub.o"
 then
-	AC_DEFINE([HAVE_DYNAMIC_LOADING], [1],
+	PY_DEFINE([HAVE_DYNAMIC_LOADING], [1],
         [Defined when any dynamic module loading is enabled.])
 fi
 
@@ -4862,7 +4869,7 @@ if test "$MACHDEP" != linux; then
 fi
 
 AC_CHECK_DECL([dirfd],
-              [AC_DEFINE([HAVE_DIRFD], [1],
+              [PY_DEFINE([HAVE_DIRFD], [1],
                          [Define if you have the 'dirfd' function or macro.])],
               [],
               [@%:@include <sys/types.h>
@@ -4946,7 +4953,7 @@ AC_CACHE_CHECK([for broken unsetenv], [ac_cv_broken_unsetenv],
   )
 ])
 AS_VAR_IF([ac_cv_broken_unsetenv], [yes], [
-  AC_DEFINE([HAVE_BROKEN_UNSETENV], [1],
+  PY_DEFINE([HAVE_BROKEN_UNSETENV], [1],
             [Define if 'unsetenv' does not return an int.])
 ])
 
@@ -4980,7 +4987,7 @@ if test "$ac_cv_have_chflags" = cross ; then
   AC_CHECK_FUNC([chflags], [ac_cv_have_chflags="yes"], [ac_cv_have_chflags="no"])
 fi
 if test "$ac_cv_have_chflags" = yes ; then
-  AC_DEFINE([HAVE_CHFLAGS], [1],
+  PY_DEFINE([HAVE_CHFLAGS], [1],
             [Define to 1 if you have the 'chflags' function.])
 fi
 
@@ -5000,7 +5007,7 @@ if test "$ac_cv_have_lchflags" = cross ; then
   AC_CHECK_FUNC([lchflags], [ac_cv_have_lchflags="yes"], [ac_cv_have_lchflags="no"])
 fi
 if test "$ac_cv_have_lchflags" = yes ; then
-  AC_DEFINE([HAVE_LCHFLAGS], [1],
+  PY_DEFINE([HAVE_LCHFLAGS], [1],
             [Define to 1 if you have the 'lchflags' function.])
 fi
 
@@ -5013,7 +5020,7 @@ PY_CHECK_EMSCRIPTEN_PORT([ZLIB], [-sUSE_ZLIB])
 PKG_CHECK_MODULES([ZLIB], [zlib >= 1.2.0], [
   have_zlib=yes
   dnl zlib 1.2.0 (2003) added inflateCopy
-  AC_DEFINE([HAVE_ZLIB_COPY], [1])
+  PY_DEFINE([HAVE_ZLIB_COPY], [1])
 ], [
   WITH_SAVE_ENV([
     CPPFLAGS="$CPPFLAGS $ZLIB_CFLAGS"
@@ -5024,7 +5031,7 @@ PKG_CHECK_MODULES([ZLIB], [zlib >= 1.2.0], [
     AS_VAR_IF([have_zlib], [yes], [
       ZLIB_CFLAGS=${ZLIB_CFLAGS-""}
       ZLIB_LIBS=${ZLIB_LIBS-"-lz"}
-      PY_CHECK_LIB([z], [inflateCopy], [AC_DEFINE([HAVE_ZLIB_COPY], [1])])
+      PY_CHECK_LIB([z], [inflateCopy], [PY_DEFINE([HAVE_ZLIB_COPY], [1])])
     ])
   ])
 ])
@@ -5112,17 +5119,17 @@ PY_CHECK_FUNC([setgroups], [
 
 AC_CHECK_FUNCS([openpty], [],
   [AC_CHECK_LIB([util], [openpty],
-    [AC_DEFINE([HAVE_OPENPTY]) LIBS="$LIBS -lutil"],
+    [PY_DEFINE([HAVE_OPENPTY]) LIBS="$LIBS -lutil"],
     [AC_CHECK_LIB([bsd], [openpty],
-      [AC_DEFINE([HAVE_OPENPTY]) LIBS="$LIBS -lbsd"])])])
+      [PY_DEFINE([HAVE_OPENPTY]) LIBS="$LIBS -lbsd"])])])
 AC_SEARCH_LIBS([login_tty], [util],
- [AC_DEFINE([HAVE_LOGIN_TTY], [1], [Define to 1 if you have the `login_tty' function.])]
+ [PY_DEFINE([HAVE_LOGIN_TTY], [1], [Define to 1 if you have the `login_tty' function.])]
 )
 AC_CHECK_FUNCS([forkpty], [],
   [AC_CHECK_LIB([util], [forkpty],
-    [AC_DEFINE([HAVE_FORKPTY]) LIBS="$LIBS -lutil"],
+    [PY_DEFINE([HAVE_FORKPTY]) LIBS="$LIBS -lutil"],
     [AC_CHECK_LIB([bsd], [forkpty],
-      [AC_DEFINE([HAVE_FORKPTY]) LIBS="$LIBS -lbsd"])])])
+      [PY_DEFINE([HAVE_FORKPTY]) LIBS="$LIBS -lbsd"])])])
 
 # check for long file support functions
 AC_CHECK_FUNCS([fseek64 fseeko fstatvfs ftell64 ftello statvfs])
@@ -5132,14 +5139,14 @@ AC_CHECK_FUNCS([getpgrp],
   [AC_COMPILE_IFELSE(
     [AC_LANG_PROGRAM([@%:@include <unistd.h>],
       [getpgrp(0);])],
-    [AC_DEFINE([GETPGRP_HAVE_ARG], [1],
+    [PY_DEFINE([GETPGRP_HAVE_ARG], [1],
       [Define if getpgrp() must be called as getpgrp(0).])],
     [])])
 AC_CHECK_FUNCS([setpgrp],
   [AC_COMPILE_IFELSE(
     [AC_LANG_PROGRAM([@%:@include <unistd.h>],
       [setpgrp(0,0);])],
-    [AC_DEFINE([SETPGRP_HAVE_ARG], [1],
+    [PY_DEFINE([SETPGRP_HAVE_ARG], [1],
       [Define if setpgrp() must be called as setpgrp(0, 0).])],
   [])])
 
@@ -5149,33 +5156,33 @@ AC_CHECK_FUNCS([setns unshare])
 AC_CHECK_FUNCS([clock_gettime], [], [
     AC_CHECK_LIB([rt], [clock_gettime], [
         LIBS="$LIBS -lrt"
-        AC_DEFINE([HAVE_CLOCK_GETTIME], [1])
-        AC_DEFINE([TIMEMODULE_LIB], [rt],
+        PY_DEFINE([HAVE_CLOCK_GETTIME], [1])
+        PY_DEFINE([TIMEMODULE_LIB], [rt],
                   [Library needed by timemodule.c: librt may be needed for clock_gettime()])
     ])
 ])
 
 AC_CHECK_FUNCS([clock_getres], [], [
     AC_CHECK_LIB([rt], [clock_getres], [
-        AC_DEFINE([HAVE_CLOCK_GETRES], [1])
+        PY_DEFINE([HAVE_CLOCK_GETRES], [1])
     ])
 ])
 
 AC_CHECK_FUNCS([clock_settime], [], [
     AC_CHECK_LIB([rt], [clock_settime], [
-        AC_DEFINE([HAVE_CLOCK_SETTIME], [1])
+        PY_DEFINE([HAVE_CLOCK_SETTIME], [1])
     ])
 ])
 
 AC_CHECK_FUNCS([clock_nanosleep], [], [
     AC_CHECK_LIB([rt], [clock_nanosleep], [
-        AC_DEFINE([HAVE_CLOCK_NANOSLEEP], [1])
+        PY_DEFINE([HAVE_CLOCK_NANOSLEEP], [1])
     ])
 ])
 
 AC_CHECK_FUNCS([nanosleep], [], [
     AC_CHECK_LIB([rt], [nanosleep], [
-        AC_DEFINE([HAVE_NANOSLEEP], [1])
+        PY_DEFINE([HAVE_NANOSLEEP], [1])
     ])
 ])
 
@@ -5194,12 +5201,12 @@ AC_LINK_IFELSE([AC_LANG_PROGRAM([[
 ]])],[ac_cv_device_macros=yes], [ac_cv_device_macros=no])
 ])
 AS_VAR_IF([ac_cv_device_macros], [yes], [
-  AC_DEFINE([HAVE_DEVICE_MACROS], [1],
+  PY_DEFINE([HAVE_DEVICE_MACROS], [1],
 	    [Define to 1 if you have the device macros.])
 ])
 
 dnl no longer used, now always defined for backwards compatibility
-AC_DEFINE([SYS_SELECT_WITH_SYS_TIME], [1],
+PY_DEFINE([SYS_SELECT_WITH_SYS_TIME], [1],
   [Define if  you can safely include both <sys/select.h> and <sys/time.h>
    (which you can't on SCO ODT 3.0).])
 
@@ -5329,7 +5336,7 @@ then
     ])])
   ])
 else
-	AC_DEFINE([HAVE_GETADDRINFO], [1],
+	PY_DEFINE([HAVE_GETADDRINFO], [1],
       [Define if you have the getaddrinfo function.])
 fi
 
@@ -5357,7 +5364,7 @@ AC_CACHE_CHECK([for time.h that defines altzone], [ac_cv_header_time_altzone], [
     [ac_cv_header_time_altzone=no])
   ])
 if test $ac_cv_header_time_altzone = yes; then
-  AC_DEFINE([HAVE_ALTZONE], [1],
+  PY_DEFINE([HAVE_ALTZONE], [1],
     [Define this if your time.h defines altzone.])
 fi
 
@@ -5366,7 +5373,7 @@ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[@%:@include <netdb.h>]], [[struct addrinfo 
   [ac_cv_struct_addrinfo=yes],
   [ac_cv_struct_addrinfo=no]))
 if test $ac_cv_struct_addrinfo = yes; then
-	AC_DEFINE([HAVE_ADDRINFO], [1], [struct addrinfo (netdb.h)])
+	PY_DEFINE([HAVE_ADDRINFO], [1], [struct addrinfo (netdb.h)])
 fi
 
 AC_CACHE_CHECK([for sockaddr_storage], [ac_cv_struct_sockaddr_storage],
@@ -5376,7 +5383,7 @@ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
   [ac_cv_struct_sockaddr_storage=yes],
   [ac_cv_struct_sockaddr_storage=no]))
 if test $ac_cv_struct_sockaddr_storage = yes; then
-	AC_DEFINE([HAVE_SOCKADDR_STORAGE], [1],
+	PY_DEFINE([HAVE_SOCKADDR_STORAGE], [1],
       [struct sockaddr_storage (sys/socket.h)])
 fi
 
@@ -5388,7 +5395,7 @@ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
   [ac_cv_struct_sockaddr_alg=yes],
   [ac_cv_struct_sockaddr_alg=no]))
 if test $ac_cv_struct_sockaddr_alg = yes; then
-	AC_DEFINE([HAVE_SOCKADDR_ALG], [1],
+	PY_DEFINE([HAVE_SOCKADDR_ALG], [1],
       [struct sockaddr_alg (linux/if_alg.h)])
 fi
 
@@ -5401,7 +5408,7 @@ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[]], [[signed char c;]])],
   [ac_cv_working_signed_char_c=yes], [ac_cv_working_signed_char_c=no])
 ])
 AS_VAR_IF([ac_cv_working_signed_char_c], [no], [
-  AC_DEFINE([signed], [], [Define to empty if the keyword does not work.])
+  PY_DEFINE([signed], [], [Define to empty if the keyword does not work.])
 ])
 
 AC_CACHE_CHECK([for prototypes], [ac_cv_function_prototypes], [
@@ -5409,7 +5416,7 @@ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[int foo(int x) { return 0; }]], [[return fo
   [ac_cv_function_prototypes=yes], [ac_cv_function_prototypes=no])
 ])
 AS_VAR_IF([ac_cv_function_prototypes], [yes], [
-  AC_DEFINE([HAVE_PROTOTYPES], [1],
+  PY_DEFINE([HAVE_PROTOTYPES], [1],
      [Define if your compiler supports function prototype])
 ])
 
@@ -5428,7 +5435,7 @@ x.sa_len = 0;]])],
   [ac_cv_struct_sockaddr_sa_len=yes], [ac_cv_struct_sockaddr_sa_len=no])
 ])
 AS_VAR_IF([ac_cv_struct_sockaddr_sa_len], [yes], [
-   AC_DEFINE([HAVE_SOCKADDR_SA_LEN], [1],
+   PY_DEFINE([HAVE_SOCKADDR_SA_LEN], [1],
      [Define if sockaddr has sa_len member])
 ])
 
@@ -5437,7 +5444,7 @@ AH_TEMPLATE([HAVE_GETHOSTBYNAME_R],
   [Define this if you have some version of gethostbyname_r()])
 
 AC_CHECK_FUNC([gethostbyname_r],
-  [AC_DEFINE([HAVE_GETHOSTBYNAME_R])
+  [PY_DEFINE([HAVE_GETHOSTBYNAME_R])
   AC_MSG_CHECKING([gethostbyname_r with 6 args])
   OLD_CFLAGS=$CFLAGS
   CFLAGS="$CFLAGS $MY_CPPFLAGS $MY_THREAD_CPPFLAGS $MY_CFLAGS"
@@ -5452,8 +5459,8 @@ AC_CHECK_FUNC([gethostbyname_r],
 
     (void) gethostbyname_r(name, he, buffer, buflen, &res, &h_errnop)
   ]])],[
-    AC_DEFINE([HAVE_GETHOSTBYNAME_R])
-    AC_DEFINE([HAVE_GETHOSTBYNAME_R_6_ARG], [1],
+    PY_DEFINE([HAVE_GETHOSTBYNAME_R])
+    PY_DEFINE([HAVE_GETHOSTBYNAME_R_6_ARG], [1],
     [Define this if you have the 6-arg version of gethostbyname_r().])
     AC_MSG_RESULT([yes])
   ],[
@@ -5471,8 +5478,8 @@ AC_CHECK_FUNC([gethostbyname_r],
         (void) gethostbyname_r(name, he, buffer, buflen, &h_errnop)
       ]])],
       [
-        AC_DEFINE([HAVE_GETHOSTBYNAME_R])
-        AC_DEFINE([HAVE_GETHOSTBYNAME_R_5_ARG], [1],
+        PY_DEFINE([HAVE_GETHOSTBYNAME_R])
+        PY_DEFINE([HAVE_GETHOSTBYNAME_R_5_ARG], [1],
           [Define this if you have the 5-arg version of gethostbyname_r().])
         AC_MSG_RESULT([yes])
       ], [
@@ -5488,8 +5495,8 @@ AC_CHECK_FUNC([gethostbyname_r],
             (void) gethostbyname_r(name, he, &data);
           ]])],
           [
-            AC_DEFINE([HAVE_GETHOSTBYNAME_R])
-            AC_DEFINE([HAVE_GETHOSTBYNAME_R_3_ARG], [1],
+            PY_DEFINE([HAVE_GETHOSTBYNAME_R])
+            PY_DEFINE([HAVE_GETHOSTBYNAME_R_3_ARG], [1],
               [Define this if you have the 3-arg version of gethostbyname_r().])
             AC_MSG_RESULT([yes])
           ], [
@@ -5564,7 +5571,7 @@ AC_LINK_IFELSE([AC_LANG_PROGRAM([[]], [[
 ])
 
 AS_VAR_IF([ac_cv_gcc_asm_for_x64], [yes], [
-    AC_DEFINE([HAVE_GCC_ASM_FOR_X64], [1],
+    PY_DEFINE([HAVE_GCC_ASM_FOR_X64], [1],
     [Define if we can use x64 gcc inline assembler])
 ])
 
@@ -5575,12 +5582,12 @@ AS_VAR_IF([ac_cv_gcc_asm_for_x64], [yes], [
 AX_C_FLOAT_WORDS_BIGENDIAN
 if test "$ax_cv_c_float_words_bigendian" = "yes"
 then
-  AC_DEFINE([DOUBLE_IS_BIG_ENDIAN_IEEE754], [1],
+  PY_DEFINE([DOUBLE_IS_BIG_ENDIAN_IEEE754], [1],
   [Define if C doubles are 64-bit IEEE 754 binary format, stored
    with the most significant byte first])
 elif test "$ax_cv_c_float_words_bigendian" = "no"
 then
-  AC_DEFINE([DOUBLE_IS_LITTLE_ENDIAN_IEEE754], [1],
+  PY_DEFINE([DOUBLE_IS_LITTLE_ENDIAN_IEEE754], [1],
   [Define if C doubles are 64-bit IEEE 754 binary format, stored
    with the least significant byte first])
 else
@@ -5590,7 +5597,7 @@ else
   # conversions work.
   # FLOAT_WORDS_BIGENDIAN doesnt actually detect this case, but if it's not big
   # or little, then it must be this?
-  AC_DEFINE([DOUBLE_IS_ARM_MIXED_ENDIAN_IEEE754], [1],
+  PY_DEFINE([DOUBLE_IS_ARM_MIXED_ENDIAN_IEEE754], [1],
   [Define if C doubles are 64-bit IEEE 754 binary format, stored
    in ARM mixed-endian order (byte order 45670123)])
 fi
@@ -5613,7 +5620,7 @@ AC_LINK_IFELSE(   [AC_LANG_PROGRAM([[]], [[
 ]])],[ac_cv_gcc_asm_for_x87=yes],[ac_cv_gcc_asm_for_x87=no])
 ])
 AS_VAR_IF([ac_cv_gcc_asm_for_x87], [yes], [
-    AC_DEFINE([HAVE_GCC_ASM_FOR_X87], [1],
+    PY_DEFINE([HAVE_GCC_ASM_FOR_X87], [1],
     [Define if we can use gcc inline assembler to get and set x87 control word])
 ])
 
@@ -5625,7 +5632,7 @@ AC_LINK_IFELSE(   [AC_LANG_PROGRAM([[]], [[
 ]])],[ac_cv_gcc_asm_for_mc68881=yes],[ac_cv_gcc_asm_for_mc68881=no])
 ])
 AS_VAR_IF([ac_cv_gcc_asm_for_mc68881], [yes], [
-    AC_DEFINE([HAVE_GCC_ASM_FOR_MC68881], [1],
+    PY_DEFINE([HAVE_GCC_ASM_FOR_MC68881], [1],
     [Define if we can use gcc inline assembler to get and set mc68881 fpcr])
 ])
 
@@ -5665,7 +5672,7 @@ CC="$ac_save_cc"
 ])
 
 AS_VAR_IF([ac_cv_x87_double_rounding], [yes], [
-  AC_DEFINE([X87_DOUBLE_ROUNDING], [1],
+  PY_DEFINE([X87_DOUBLE_ROUNDING], [1],
   [Define if arithmetic is subject to x87-style double rounding issue])
 ])
 
@@ -5714,7 +5721,7 @@ AC_CACHE_CHECK([whether POSIX semaphores are enabled], [ac_cv_posix_semaphores_e
   [ac_cv_posix_semaphores_enabled=yes])
 )
 AS_VAR_IF([ac_cv_posix_semaphores_enabled], [no], [
-  AC_DEFINE(
+  PY_DEFINE(
     [POSIX_SEMAPHORES_NOT_ENABLED], [1],
     [Define if POSIX semaphores aren't enabled on your system]
   )
@@ -5751,7 +5758,7 @@ AC_CACHE_CHECK([for broken sem_getvalue], [ac_cv_broken_sem_getvalue],
   [ac_cv_broken_sem_getvalue=yes])
 )
 AS_VAR_IF([ac_cv_broken_sem_getvalue], [yes], [
-  AC_DEFINE(
+  PY_DEFINE(
     [HAVE_BROKEN_SEM_GETVALUE], [1],
     [define to 1 if your sem_getvalue is broken.]
   )
@@ -5774,14 +5781,14 @@ no)
   AC_MSG_ERROR([bad value $enable_big_digits for --enable-big-digits; value should be 15 or 30]) ;;
 esac
 AC_MSG_RESULT([$enable_big_digits])
-AC_DEFINE_UNQUOTED([PYLONG_BITS_IN_DIGIT], [$enable_big_digits],
+PY_DEFINE_UNQUOTED([PYLONG_BITS_IN_DIGIT], [$enable_big_digits],
   [Define as the preferred size in bits of long digits])
 ],
 [AC_MSG_RESULT([no value specified])])
 
 # check for wchar.h
 AC_CHECK_HEADER([wchar.h], [
-  AC_DEFINE([HAVE_WCHAR_H], [1],
+  PY_DEFINE([HAVE_WCHAR_H], [1],
   [Define if the compiler provides a wchar.h header file.])
   wchar_h="yes"
 ],
@@ -5819,7 +5826,7 @@ AC_MSG_CHECKING([whether wchar_t is usable])
 if test "$ac_cv_sizeof_wchar_t" -ge 2 \
           -a "$ac_cv_wchar_t_signed" = "no"
 then
-  AC_DEFINE([HAVE_USABLE_WCHAR_T], [1],
+  PY_DEFINE([HAVE_USABLE_WCHAR_T], [1],
   [Define if you have a useable wchar_t type defined in wchar.h; useable
    means wchar_t must be an unsigned type with at least 16 bits. (see
    Include/unicodeobject.h).])
@@ -5836,7 +5843,7 @@ SunOS/*)
       # bpo-43667: In Oracle Solaris, the internal form of wchar_t in
       # non-Unicode locales is not Unicode and hence cannot be used directly.
       # https://docs.oracle.com/cd/E37838_01/html/E61053/gmwke.html
-      AC_DEFINE([HAVE_NON_UNICODE_WCHAR_T_REPRESENTATION], [1],
+      PY_DEFINE([HAVE_NON_UNICODE_WCHAR_T_REPRESENTATION], [1],
       [Define if the internal form of wchar_t in non-Unicode locales
        is not Unicode.])
     fi
@@ -5876,7 +5883,7 @@ if test "$Py_DEBUG" = 'true'; then
   # Similar to SOABI but remove "d" flag from ABIFLAGS
   AC_SUBST([ALT_SOABI])
   ALT_SOABI='cpython-'`echo $VERSION | tr -d .``echo $ABIFLAGS | tr -d d`${SOABI_PLATFORM:+-$SOABI_PLATFORM}
-  AC_DEFINE_UNQUOTED([ALT_SOABI], ["${ALT_SOABI}"],
+  PY_DEFINE_UNQUOTED([ALT_SOABI], ["${ALT_SOABI}"],
             [Alternative SOABI used in debug build to load C extensions built in release mode])
 fi
 
@@ -5969,7 +5976,7 @@ int main(void)
 [ac_cv_rshift_extends_sign=yes])])
 if test "$ac_cv_rshift_extends_sign" = no
 then
-  AC_DEFINE([SIGNED_RIGHT_SHIFT_ZERO_FILLS], [1],
+  PY_DEFINE([SIGNED_RIGHT_SHIFT_ZERO_FILLS], [1],
   [Define if i>>j for signed int i does not extend the sign bit
    when i < 0])
 fi
@@ -5984,7 +5991,7 @@ AC_LINK_IFELSE([AC_LANG_PROGRAM([[@%:@include <stdio.h>]], [[
 ]])],[ac_cv_have_getc_unlocked=yes],[ac_cv_have_getc_unlocked=no])])
 if test "$ac_cv_have_getc_unlocked" = yes
 then
-  AC_DEFINE([HAVE_GETC_UNLOCKED], [1],
+  PY_DEFINE([HAVE_GETC_UNLOCKED], [1],
   [Define this if you have flockfile(), getc_unlocked(), and funlockfile()])
 fi
 
@@ -6038,7 +6045,7 @@ AS_VAR_IF([with_readline], [readline], [
 
 AS_VAR_IF([with_readline], [edit], [
   PKG_CHECK_MODULES([LIBEDIT], [libedit], [
-    AC_DEFINE([WITH_EDITLINE], [1])
+    PY_DEFINE([WITH_EDITLINE], [1])
     LIBREADLINE=edit
     READLINE_CFLAGS=$LIBEDIT_CFLAGS
     READLINE_LIBS=$LIBEDIT_LIBS
@@ -6049,7 +6056,7 @@ AS_VAR_IF([with_readline], [edit], [
       AC_CHECK_HEADERS([editline/readline.h], [
         AC_CHECK_LIB([edit], [readline], [
           LIBREADLINE=edit
-          AC_DEFINE([WITH_EDITLINE], [1])
+          PY_DEFINE([WITH_EDITLINE], [1])
           READLINE_CFLAGS=${LIBEDIT_CFLAGS-""}
           READLINE_LIBS=${LIBEDIT_LIBS-"-ledit"}
         ], [with_readline=no])
@@ -6084,11 +6091,11 @@ AS_VAR_IF([with_readline], [no], [
 
     # check for readline 2.2
     AC_CHECK_DECL([rl_completion_append_character], [
-      AC_DEFINE([HAVE_RL_COMPLETION_APPEND_CHARACTER], [1], [Define if you have readline 2.2])
+      PY_DEFINE([HAVE_RL_COMPLETION_APPEND_CHARACTER], [1], [Define if you have readline 2.2])
     ], [], [readline_includes])
 
     AC_CHECK_DECL([rl_completion_suppress_append], [
-      AC_DEFINE([HAVE_RL_COMPLETION_SUPPRESS_APPEND], [1], [Define if you have rl_completion_suppress_append])
+      PY_DEFINE([HAVE_RL_COMPLETION_SUPPRESS_APPEND], [1], [Define if you have rl_completion_suppress_append])
     ], [], [readline_includes])
 
     # check for readline 4.0
@@ -6099,7 +6106,7 @@ AS_VAR_IF([with_readline], [no], [
       )
     ])
     AS_VAR_IF([ac_cv_readline_rl_pre_input_hook], [yes], [
-      AC_DEFINE([HAVE_RL_PRE_INPUT_HOOK], [1], [Define if you have readline 4.0])
+      PY_DEFINE([HAVE_RL_PRE_INPUT_HOOK], [1], [Define if you have readline 4.0])
     ])
 
     # also in 4.0
@@ -6110,7 +6117,7 @@ AS_VAR_IF([with_readline], [no], [
       )
     ])
     AS_VAR_IF([ac_cv_readline_rl_completion_display_matches_hook], [yes], [
-      AC_DEFINE([HAVE_RL_COMPLETION_DISPLAY_MATCHES_HOOK], [1], [Define if you have readline 4.0])
+      PY_DEFINE([HAVE_RL_COMPLETION_DISPLAY_MATCHES_HOOK], [1], [Define if you have readline 4.0])
     ])
 
     # also in 4.0, but not in editline
@@ -6121,7 +6128,7 @@ AS_VAR_IF([with_readline], [no], [
       )
     ])
     AS_VAR_IF([ac_cv_readline_rl_resize_terminal], [yes], [
-      AC_DEFINE([HAVE_RL_RESIZE_TERMINAL], [1], [Define if you have readline 4.0])
+      PY_DEFINE([HAVE_RL_RESIZE_TERMINAL], [1], [Define if you have readline 4.0])
     ])
 
     # check for readline 4.2
@@ -6132,12 +6139,12 @@ AS_VAR_IF([with_readline], [no], [
       )
     ])
     AS_VAR_IF([ac_cv_readline_rl_completion_matches], [yes], [
-      AC_DEFINE([HAVE_RL_COMPLETION_MATCHES], [1], [Define if you have readline 4.2])
+      PY_DEFINE([HAVE_RL_COMPLETION_MATCHES], [1], [Define if you have readline 4.2])
     ])
 
     # also in readline 4.2
     AC_CHECK_DECL([rl_catch_signals], [
-      AC_DEFINE([HAVE_RL_CATCH_SIGNAL], [1], [Define if you can turn off readline's signal handling.])
+      PY_DEFINE([HAVE_RL_CATCH_SIGNAL], [1], [Define if you can turn off readline's signal handling.])
     ], [], [readline_includes])
 
     AC_CACHE_CHECK([for append_history in -l$LIBREADLINE], [ac_cv_readline_append_history], [
@@ -6147,12 +6154,12 @@ AS_VAR_IF([with_readline], [no], [
       )
     ])
     AS_VAR_IF([ac_cv_readline_append_history], [yes], [
-      AC_DEFINE([HAVE_RL_APPEND_HISTORY], [1], [Define if readline supports append_history])
+      PY_DEFINE([HAVE_RL_APPEND_HISTORY], [1], [Define if readline supports append_history])
     ])
 
     # in readline as well as newer editline (April 2023)
     AC_CHECK_TYPE([rl_compdisp_func_t],
-                  [AC_DEFINE([HAVE_RL_COMPDISP_FUNC_T], [1],
+                  [PY_DEFINE([HAVE_RL_COMPDISP_FUNC_T], [1],
                              [Define if readline supports rl_compdisp_func_t])],
                   [],
                   [readline_includes])
@@ -6178,7 +6185,7 @@ int main(void)
 [ac_cv_broken_nice=no])])
 if test "$ac_cv_broken_nice" = yes
 then
-  AC_DEFINE([HAVE_BROKEN_NICE], [1],
+  PY_DEFINE([HAVE_BROKEN_NICE], [1],
   [Define if nice() returns success/failure instead of the new priority.])
 fi
 
@@ -6208,7 +6215,7 @@ int main(void)
 [ac_cv_broken_poll=no]))
 if test "$ac_cv_broken_poll" = yes
 then
-  AC_DEFINE([HAVE_BROKEN_POLL], [1],
+  PY_DEFINE([HAVE_BROKEN_POLL], [1],
       [Define if poll() sets errno on invalid file descriptors.])
 fi
 
@@ -6283,7 +6290,7 @@ int main(void)
 [ac_cv_working_tzset=no])])
 if test "$ac_cv_working_tzset" = yes
 then
-  AC_DEFINE([HAVE_WORKING_TZSET], [1],
+  PY_DEFINE([HAVE_WORKING_TZSET], [1],
   [Define if tzset() actually switches the local timezone in a meaningful way.])
 fi
 
@@ -6297,7 +6304,7 @@ st.st_mtim.tv_nsec = 1;
 [ac_cv_stat_tv_nsec=no]))
 if test "$ac_cv_stat_tv_nsec" = yes
 then
-  AC_DEFINE([HAVE_STAT_TV_NSEC], [1],
+  PY_DEFINE([HAVE_STAT_TV_NSEC], [1],
   [Define if you have struct stat.st_mtim.tv_nsec])
 fi
 
@@ -6311,7 +6318,7 @@ st.st_mtimespec.tv_nsec = 1;
 [ac_cv_stat_tv_nsec2=no]))
 if test "$ac_cv_stat_tv_nsec2" = yes
 then
-  AC_DEFINE([HAVE_STAT_TV_NSEC2], [1],
+  PY_DEFINE([HAVE_STAT_TV_NSEC2], [1],
   [Define if you have struct stat.st_mtimensec])
 fi
 
@@ -6329,12 +6336,12 @@ AS_VAR_IF([ac_cv_header_ncurses_h], [yes], [
   if test "$ac_sys_system" != "Darwin"; then
     dnl On macOS, there is no separate /usr/lib/libncursesw nor libpanelw.
     PKG_CHECK_MODULES([CURSES], [ncursesw], [
-      AC_DEFINE([HAVE_NCURSESW], [1])
+      PY_DEFINE([HAVE_NCURSESW], [1])
       have_curses=ncursesw
     ], [
       WITH_SAVE_ENV([
         AC_CHECK_LIB([ncursesw], [initscr], [
-          AC_DEFINE([HAVE_NCURSESW], [1])
+          PY_DEFINE([HAVE_NCURSESW], [1])
           have_curses=ncursesw
           CURSES_CFLAGS=${CURSES_CFLAGS-""}
           CURSES_LIBS=${CURSES_LIBS-"-lncursesw"}
@@ -6373,7 +6380,7 @@ if test "$have_curses" != no -a "$ac_sys_system" = "Darwin"; then
   dnl _XOPEN_SOURCE_EXTENDED here for ncurses wide char support.
 
   AS_VAR_APPEND([CURSES_CFLAGS], [" -D_XOPEN_SOURCE_EXTENDED=1"])
-  AC_DEFINE([HAVE_NCURSESW], [1])
+  PY_DEFINE([HAVE_NCURSESW], [1])
 fi
 
 dnl TODO: detect "curses" and special cases tinfo, terminfo, or termcap
@@ -6457,7 +6464,7 @@ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[@%:@include <curses.h>]], [[
 
 if test "$ac_cv_mvwdelch_is_expression" = yes
 then
-  AC_DEFINE([MVWDELCH_IS_EXPRESSION], [1],
+  PY_DEFINE([MVWDELCH_IS_EXPRESSION], [1],
   [Define if mvwdelch in curses.h is an expression.])
 fi
 
@@ -6479,7 +6486,7 @@ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
 
 if test "$ac_cv_window_has_flags" = yes
 then
-  AC_DEFINE([WINDOW_HAS_FLAGS], [1],
+  PY_DEFINE([WINDOW_HAS_FLAGS], [1],
   [Define if WINDOW in curses.h offers a field _flags.])
 fi
 
@@ -6503,7 +6510,7 @@ AC_DEFUN([PY_CHECK_CURSES_FUNC],
   AS_VAR_IF(
     [py_var],
     [yes],
-    [AC_DEFINE([py_define], [1], [Define if you have the '$1' function.])])
+    [PY_DEFINE([py_define], [1], [Define if you have the '$1' function.])])
   AS_VAR_POPDEF([py_var])
   AS_VAR_POPDEF([py_define])
 ])
@@ -6539,12 +6546,12 @@ fi
 
 AC_CHECK_FILE([/dev/ptmx], [], [])
 if test "x$ac_cv_file__dev_ptmx" = xyes; then
-  AC_DEFINE([HAVE_DEV_PTMX], [1],
+  PY_DEFINE([HAVE_DEV_PTMX], [1],
   [Define to 1 if you have the /dev/ptmx device file.])
 fi
 AC_CHECK_FILE([/dev/ptc], [], [])
 if test "x$ac_cv_file__dev_ptc" = xyes; then
-  AC_DEFINE([HAVE_DEV_PTC], [1],
+  PY_DEFINE([HAVE_DEV_PTC], [1],
   [Define to 1 if you have the /dev/ptc device file.])
 fi
 
@@ -6555,7 +6562,7 @@ fi
 
 AC_CHECK_TYPE(
   [socklen_t], [],
-  [AC_DEFINE(
+  [PY_DEFINE(
     [socklen_t], [int],
     [Define to `int' if <sys/socket.h> does not define.]
   )], [
@@ -6584,7 +6591,7 @@ int main(void) {
 [ac_cv_broken_mbstowcs=no]))
 if test "$ac_cv_broken_mbstowcs" = yes
 then
-  AC_DEFINE([HAVE_BROKEN_MBSTOWCS], [1],
+  PY_DEFINE([HAVE_BROKEN_MBSTOWCS], [1],
   [Define if mbstowcs(NULL, "text", 0) does not return the number of
    wide chars that would be converted.])
 fi
@@ -6600,13 +6607,13 @@ AC_ARG_WITH(
 [
 if test "$withval" = yes
 then
-  AC_DEFINE([USE_COMPUTED_GOTOS], [1],
+  PY_DEFINE([USE_COMPUTED_GOTOS], [1],
   [Define if you want to use computed gotos in ceval.c.])
   AC_MSG_RESULT([yes])
 fi
 if test "$withval" = no
 then
-  AC_DEFINE([USE_COMPUTED_GOTOS], [0],
+  PY_DEFINE([USE_COMPUTED_GOTOS], [0],
   [Define if you want to use computed gotos in ceval.c.])
   AC_MSG_RESULT([no])
 fi
@@ -6634,13 +6641,13 @@ LABEL2:
    ac_cv_computed_gotos=no
  fi]))
 case "$ac_cv_computed_gotos" in yes*)
-  AC_DEFINE([HAVE_COMPUTED_GOTOS], [1],
+  PY_DEFINE([HAVE_COMPUTED_GOTOS], [1],
   [Define if the C compiler supports computed gotos.])
 esac
 
 case $ac_sys_system in
 AIX*)
-  AC_DEFINE([HAVE_BROKEN_PIPE_BUF], [1],
+  PY_DEFINE([HAVE_BROKEN_PIPE_BUF], [1],
     [Define if the system reports an invalid PIPE_BUF value.]) ;;
 esac
 
@@ -6725,7 +6732,7 @@ int main(void) {
 CFLAGS="$saved_cflags"
 AC_MSG_RESULT([$have_glibc_memmove_bug])
 if test "$have_glibc_memmove_bug" = yes; then
-    AC_DEFINE([HAVE_GLIBC_MEMMOVE_BUG], [1],
+    PY_DEFINE([HAVE_GLIBC_MEMMOVE_BUG], [1],
     [Define if glibc has incorrect _FORTIFY_SOURCE wrappers
      for memmove and bcopy.])
 fi
@@ -6762,7 +6769,7 @@ if test "$ac_cv_gcc_asm_for_x87" = yes; then
             CFLAGS="$saved_cflags"
             AC_MSG_RESULT([$have_ipa_pure_const_bug])
             if test "$have_ipa_pure_const_bug" = yes; then
-                AC_DEFINE([HAVE_IPA_PURE_CONST_BUG], [1],
+                PY_DEFINE([HAVE_IPA_PURE_CONST_BUG], [1],
                           [Define if gcc has the ipa-pure-const bug.])
             fi
         ;;
@@ -6806,7 +6813,7 @@ AC_LINK_IFELSE(
 ])
 
 AS_VAR_IF([ac_cv_dirent_d_type], [yes], [
-    AC_DEFINE([HAVE_DIRENT_D_TYPE], [1],
+    PY_DEFINE([HAVE_DIRENT_D_TYPE], [1],
               [Define to 1 if the dirent structure has a d_type field])
 ])
 
@@ -6833,7 +6840,7 @@ AC_LINK_IFELSE(
 ])
 
 AS_VAR_IF([ac_cv_getrandom_syscall], [yes], [
-    AC_DEFINE([HAVE_GETRANDOM_SYSCALL], [1],
+    PY_DEFINE([HAVE_GETRANDOM_SYSCALL], [1],
               [Define to 1 if the Linux getrandom() syscall is available])
 ])
 
@@ -6859,7 +6866,7 @@ AC_LINK_IFELSE(
 ])
 
 AS_VAR_IF([ac_cv_func_getrandom], [yes], [
-    AC_DEFINE([HAVE_GETRANDOM], [1],
+    PY_DEFINE([HAVE_GETRANDOM], [1],
               [Define to 1 if the getrandom() function is available])
 ])
 
@@ -7033,25 +7040,25 @@ AC_ARG_WITH(
 AC_MSG_RESULT([$withval])
 case "$withval" in
     python)
-        AC_DEFINE([PY_SSL_DEFAULT_CIPHERS], [1])
+        PY_DEFINE([PY_SSL_DEFAULT_CIPHERS], [1])
         ;;
     openssl)
-        AC_DEFINE([PY_SSL_DEFAULT_CIPHERS], [2])
+        PY_DEFINE([PY_SSL_DEFAULT_CIPHERS], [2])
         ;;
     *)
-        AC_DEFINE([PY_SSL_DEFAULT_CIPHERS], [0])
-        AC_DEFINE_UNQUOTED([PY_SSL_DEFAULT_CIPHER_STRING], ["$withval"])
+        PY_DEFINE([PY_SSL_DEFAULT_CIPHERS], [0])
+        PY_DEFINE_UNQUOTED([PY_SSL_DEFAULT_CIPHER_STRING], ["$withval"])
         ;;
 esac
 ],
 [
 AC_MSG_RESULT([python])
-AC_DEFINE([PY_SSL_DEFAULT_CIPHERS], [1])
+PY_DEFINE([PY_SSL_DEFAULT_CIPHERS], [1])
 ])
 
 # builtin hash modules
 default_hashlib_hashes="md5,sha1,sha2,sha3,blake2"
-AC_DEFINE([PY_BUILTIN_HASHLIB_HASHES], [], [enabled builtin hash modules]
+PY_DEFINE([PY_BUILTIN_HASHLIB_HASHES], [], [enabled builtin hash modules]
 )
 AC_MSG_CHECKING([for --with-builtin-hashlib-hashes])
 AC_ARG_WITH(
@@ -7068,7 +7075,7 @@ AC_ARG_WITH(
 ], [with_builtin_hashlib_hashes=$default_hashlib_hashes])
 
 AC_MSG_RESULT([$with_builtin_hashlib_hashes])
-AC_DEFINE_UNQUOTED([PY_BUILTIN_HASHLIB_HASHES],
+PY_DEFINE_UNQUOTED([PY_BUILTIN_HASHLIB_HASHES],
   ["$with_builtin_hashlib_hashes"])
 
 as_save_IFS=$IFS
@@ -7088,7 +7095,7 @@ dnl libb2 for blake2. _blake2 module falls back to vendored copy.
 AS_VAR_IF([with_builtin_blake2], [yes], [
   PKG_CHECK_MODULES([LIBB2], [libb2], [
     have_libb2=yes
-    AC_DEFINE([HAVE_LIBB2], [1],
+    PY_DEFINE([HAVE_LIBB2], [1],
               [Define to 1 if you want to build _blake2 module with libb2])
   ], [have_libb2=no])
 ])

--- a/pyconfig.h.in
+++ b/pyconfig.h.in
@@ -1647,6 +1647,126 @@
    SipHash13: 3, externally defined: 0 */
 #undef Py_HASH_ALGORITHM
 
+/* Define if you have the 'accept' function. */
+#undef Py_HAVE_ACCEPT
+
+/* Define if you have the 'bind' function. */
+#undef Py_HAVE_BIND
+
+/* Define if you have the 'chroot' function. */
+#undef Py_HAVE_CHROOT
+
+/* Define if you have the 'connect' function. */
+#undef Py_HAVE_CONNECT
+
+/* Define if you have the 'ctermid_r' function. */
+#undef Py_HAVE_CTERMID_R
+
+/* Define if you have the '_dyld_shared_cache_contains_path' function. */
+#undef Py_HAVE_DYLD_SHARED_CACHE_CONTAINS_PATH
+
+/* Define if you have the 'epoll_create' function. */
+#undef Py_HAVE_EPOLL
+
+/* Define if you have the 'epoll_create1' function. */
+#undef Py_HAVE_EPOLL_CREATE1
+
+/* Define if you have the 'eventfd' function. */
+#undef Py_HAVE_EVENTFD
+
+/* Define if you have the 'fchdir' function. */
+#undef Py_HAVE_FCHDIR
+
+/* Define if you have the 'fdatasync' function. */
+#undef Py_HAVE_FDATASYNC
+
+/* Define if you have the 'ffi_closure_alloc' function. */
+#undef Py_HAVE_FFI_CLOSURE_ALLOC
+
+/* Define if you have the 'ffi_prep_cif_var' function. */
+#undef Py_HAVE_FFI_PREP_CIF_VAR
+
+/* Define if you have the 'ffi_prep_closure_loc' function. */
+#undef Py_HAVE_FFI_PREP_CLOSURE_LOC
+
+/* Define if you have the 'fsync' function. */
+#undef Py_HAVE_FSYNC
+
+/* Define if you have the 'gethostbyaddr' function. */
+#undef Py_HAVE_GETHOSTBYADDR
+
+/* Define if you have the 'gethostbyname' function. */
+#undef Py_HAVE_GETHOSTBYNAME
+
+/* Define if you have the 'getpagesize' function. */
+#undef Py_HAVE_GETPAGESIZE
+
+/* Define if you have the 'getpeername' function. */
+#undef Py_HAVE_GETPEERNAME
+
+/* Define if you have the 'getprotobyname' function. */
+#undef Py_HAVE_GETPROTOBYNAME
+
+/* Define if you have the 'getservbyname' function. */
+#undef Py_HAVE_GETSERVBYNAME
+
+/* Define if you have the 'getservbyport' function. */
+#undef Py_HAVE_GETSERVBYPORT
+
+/* Define if you have the 'getsockname' function. */
+#undef Py_HAVE_GETSOCKNAME
+
+/* Define if you have the 'hstrerror' function. */
+#undef Py_HAVE_HSTRERROR
+
+/* Define if you have the 'inet_aton' function. */
+#undef Py_HAVE_INET_ATON
+
+/* Define if you have the 'inet_ntoa' function. */
+#undef Py_HAVE_INET_NTOA
+
+/* Define if you have the 'inet_pton' function. */
+#undef Py_HAVE_INET_PTON
+
+/* Define if you have the 'kqueue' function. */
+#undef Py_HAVE_KQUEUE
+
+/* Define if you have the 'link' function. */
+#undef Py_HAVE_LINK
+
+/* Define if you have the 'listen' function. */
+#undef Py_HAVE_LISTEN
+
+/* Define if you have the 'memfd_create' function. */
+#undef Py_HAVE_MEMFD_CREATE
+
+/* Define if you have the 'prlimit' function. */
+#undef Py_HAVE_PRLIMIT
+
+/* Define if you have the 'recvfrom' function. */
+#undef Py_HAVE_RECVFROM
+
+/* Define if you have the 'sendto' function. */
+#undef Py_HAVE_SENDTO
+
+/* Define if you have the 'setgroups' function. */
+#undef Py_HAVE_SETGROUPS
+
+/* Define if you have the 'setsockopt' function. */
+#undef Py_HAVE_SETSOCKOPT
+
+/* Define if you have the 'socket' function. */
+#undef Py_HAVE_SOCKET
+
+/* Define if you have the 'socketpair' function. */
+#undef Py_HAVE_SOCKETPAIR
+
+/* Define if you have the 'symlink' function. */
+#undef Py_HAVE_SYMLINK
+
+/* Define if you have the 'timerfd_create' function. */
+#undef Py_HAVE_TIMERFD_CREATE
+
 /* Define if you want to enable internal statistics gathering. */
 #undef Py_STATS
 


### PR DESCRIPTION
Add `AC_DEFINE_*()` wrapper that adds `Py_` namespaced macros in addition
to the existing ones.


<!-- gh-issue-number: gh-105813 -->
* Issue: gh-105813
<!-- /gh-issue-number -->
