### PR TITLE
gh-115882: Add missing #include <Unknwn.h> on Windows

### DIFF
--- a/Misc/NEWS.d/next/Build/2024-02-24-12-50-43.gh-issue-115350.naQA6y.rst
+++ b/Misc/NEWS.d/next/Build/2024-02-24-12-50-43.gh-issue-115350.naQA6y.rst
@@ -1,0 +1,1 @@
+Fix building ctypes module with -DWIN32_LEAN_AND_MEAN defined

--- a/Modules/_ctypes/ctypes.h
+++ b/Modules/_ctypes/ctypes.h
@@ -32,6 +32,10 @@
 #endif
 #endif
 
+#ifdef MS_WIN32
+#include <Unknwn.h> // for IUnknown interface
+#endif
+
 typedef struct {
     PyTypeObject *DictRemover_Type;
     PyTypeObject *PyCArg_Type;


### PR DESCRIPTION
Fix building ctypes module with `-DWIN32_LEAN_AND_MEAN` defined.

See:
https://learn.microsoft.com/en-us/windows/win32/api/unknwn/nn-unknwn-iunknown

<!-- gh-issue-number: gh-115882 -->
* Issue: gh-115882
<!-- /gh-issue-number -->
