### PR TITLE
[3.9] gh-115349: Pin theme to fix code snippets

### DIFF
--- a/Doc/requirements.txt
+++ b/Doc/requirements.txt
@@ -17,6 +17,6 @@ blurb
 
 # The theme used by the documentation is stored separately, so we need
 # to install that as well.
-python-docs-theme>=2022.1
+python-docs-theme==2023.3.1
 
 -c constraints.txt


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

python-docs-theme [2023.3.1](https://github.com/python/python-docs-theme/releases/tag/2023.3.1) was the last release before the dark theme was released in [2023.7](https://github.com/python/python-docs-theme/releases/tag/2023.7).

The minimal fix is to pin to the last light-only version.

# Before

![image](https://github.com/python/cpython/assets/1324225/8becd790-b387-41c8-8070-e7b7155ce80c)

# After

![image](https://github.com/python/cpython/assets/1324225/24a91d79-c069-4312-96ca-7b443a0128ed)



<!-- gh-issue-number: gh-115349 -->
* Issue: gh-115349
<!-- /gh-issue-number -->
