### PR TITLE
Remove stray backtick in NEWS entry

### DIFF
--- a/Misc/NEWS.d/next/Library/2024-02-09-07-20-16.gh-issue-115165.yfJLXA.rst
+++ b/Misc/NEWS.d/next/Library/2024-02-09-07-20-16.gh-issue-115165.yfJLXA.rst
@@ -1,4 +1,4 @@
 Most exceptions are now ignored when attempting to set the ``__orig_class__``
 attribute on objects returned when calling :mod:`typing` generic aliases
 (including generic aliases created using :data:`typing.Annotated`).
-Previously only :exc:`AttributeError`` was ignored. Patch by Dave Shawley.
+Previously only :exc:`AttributeError` was ignored. Patch by Dave Shawley.


### PR DESCRIPTION
This removes a stray backtick that I noticed in a NEWS entry, introduced in #115213.

@hugovk, do we run `sphinx-lint` on NEWS entries?