### PR TITLE
gh-115391: Fix compiler warning in `Objects/longobject.c`

### DIFF
--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -1135,7 +1135,7 @@ PyLong_AsNativeBytes(PyObject* vv, void* buffer, Py_ssize_t n, int endianness)
         if (n <= 0) {
             // nothing to do!
         }
-        else if (n <= sizeof(cv.b)) {
+        else if (n <= (Py_ssize_t)sizeof(cv.b)) {
 #if PY_LITTLE_ENDIAN
             if (little_endian) {
                 memcpy(buffer, cv.b, n);
@@ -1335,7 +1335,7 @@ PyLong_FromLongLong(long long ival)
     /* Count digits (at least two - smaller cases were handled above). */
     abs_ival = ival < 0 ? 0U-(unsigned long long)ival : (unsigned long long)ival;
     /* Do shift in two steps to avoid possible undefined behavior. */
-    t = (Py_ssize_t)(abs_ival >> PyLong_SHIFT >> PyLong_SHIFT);
+    t = abs_ival >> PyLong_SHIFT >> PyLong_SHIFT;
     ndigits = 2;
     while (t) {
         ++ndigits;

--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -1335,7 +1335,7 @@ PyLong_FromLongLong(long long ival)
     /* Count digits (at least two - smaller cases were handled above). */
     abs_ival = ival < 0 ? 0U-(unsigned long long)ival : (unsigned long long)ival;
     /* Do shift in two steps to avoid possible undefined behavior. */
-    t = abs_ival >> PyLong_SHIFT >> PyLong_SHIFT;
+    t = (Py_ssize_t)(abs_ival >> PyLong_SHIFT >> PyLong_SHIFT);
     ndigits = 2;
     while (t) {
         ++ndigits;


### PR DESCRIPTION
Popped up in https://github.com/python/cpython/pull/115367/files and  https://github.com/python/cpython/pull/115366/files

<!-- gh-issue-number: gh-115391 -->
* Issue: gh-115391
<!-- /gh-issue-number -->
