### PR TITLE
gh-113317, Argument Clinic: Add DSLParser.fail() method

### DIFF
--- a/Lib/test/test_clinic.py
+++ b/Lib/test/test_clinic.py
@@ -2390,7 +2390,7 @@ class ClinicParserTest(TestCase):
             docstring1
             docstring2
         """
-        self.expect_failure(block, err, lineno=0)
+        self.expect_failure(block, err, lineno=3)
 
     def test_state_func_docstring_only_one_param_template(self):
         err = "You may not specify {parameters} more than once in a docstring!"
@@ -2404,7 +2404,7 @@ class ClinicParserTest(TestCase):
             these are the params again:
                 {parameters}
         """
-        self.expect_failure(block, err, lineno=0)
+        self.expect_failure(block, err, lineno=7)
 
 
 class ClinicExternalTest(TestCase):


### PR DESCRIPTION
* Add 'lineno' parameter to DSLParser.format_docstring() method.
* DSLParser.do_post_block_processing_cleanup() now pass 'lineno' to format_docstring() and so log the line number on error.

This change prepares the code to move the fail() function to a Clinic.fail() method to avoid the 'clinic' global variable.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-113317 -->
* Issue: gh-113317
<!-- /gh-issue-number -->
