### PR TITLE
Give concurrent.future.Future the right module name

### DIFF
--- a/Lib/concurrent/futures/__init__.py
+++ b/Lib/concurrent/futures/__init__.py
@@ -33,6 +33,12 @@ __all__ = (
 )
 
 
+# Remove the _base name from the exposed module.
+Future.__module__ = CancelledError.__module__ = Executor.__module__ = (
+    'concurrent.futures'
+)
+
+
 def __dir__():
     return __all__ + ('__author__', '__doc__')
 

--- a/Lib/concurrent/futures/__init__.py
+++ b/Lib/concurrent/futures/__init__.py
@@ -47,5 +47,13 @@ if _interpreters:
     __all__.append('InterpreterPoolExecutor')
 
 
+# Set __module__ to the public location rather than the private _base module.
+Future.__module__ = 'concurrent.futures'
+Executor.__module__ = 'concurrent.futures'
+CancelledError.__module__ = 'concurrent.futures'
+InvalidStateError.__module__ = 'concurrent.futures'
+BrokenExecutor.__module__ = 'concurrent.futures'
+
+
 def __dir__():
     return __all__ + ['__author__', '__doc__']

--- a/Lib/test/test_concurrent_futures/test_future.py
+++ b/Lib/test/test_concurrent_futures/test_future.py
@@ -134,6 +134,16 @@ class FutureTests(BaseTestCase):
                 repr(SUCCESSFUL_FUTURE),
                 '<Future at 0x[0-9a-f]+ state=finished returned int>')
 
+    def test_class_str(self):
+        self.assertEqual(str(futures.Future),
+                         "<class 'concurrent.futures.Future'>")
+        self.assertEqual(str(futures.CancelledError),
+                         "<class 'concurrent.futures.CancelledError'>")
+        self.assertEqual(str(futures.TimeoutError),
+                         "<class 'TimeoutError'>")
+        self.assertEqual(str(futures.Executor),
+                         "<class 'concurrent.futures.Executor'>")
+
     def test_cancel(self):
         f1 = create_future(state=PENDING)
         f2 = create_future(state=RUNNING)

--- a/Lib/test/test_concurrent_futures/test_future.py
+++ b/Lib/test/test_concurrent_futures/test_future.py
@@ -135,6 +135,20 @@ class FutureTests(BaseTestCase):
                 repr(SUCCESSFUL_FUTURE),
                 '<Future at 0x[0-9a-f]+ state=finished returned int>')
 
+    def test_class_str(self):
+        self.assertEqual(str(futures.Future),
+                         "<class 'concurrent.futures.Future'>")
+        self.assertEqual(str(futures.CancelledError),
+                         "<class 'concurrent.futures.CancelledError'>")
+        self.assertEqual(str(futures.TimeoutError),
+                         "<class 'TimeoutError'>")
+        self.assertEqual(str(futures.Executor),
+                         "<class 'concurrent.futures.Executor'>")
+        self.assertEqual(str(futures.InvalidStateError),
+                         "<class 'concurrent.futures.InvalidStateError'>")
+        self.assertEqual(str(futures.BrokenExecutor),
+                         "<class 'concurrent.futures.BrokenExecutor'>")
+
     def test_cancel(self):
         f1 = create_future(state=PENDING)
         f2 = create_future(state=RUNNING)

--- a/Misc/NEWS.d/next/Library/2026-08-18-04-30-00.gh-issue-115386.aB3xYz.rst
+++ b/Misc/NEWS.d/next/Library/2026-08-18-04-30-00.gh-issue-115386.aB3xYz.rst
@@ -1,0 +1,5 @@
+Set ``__module__`` to ``concurrent.futures`` on the public classes
+``Future``, ``Executor``, ``CancelledError``, ``InvalidStateError`` and
+``BrokenExecutor``, so their ``repr`` and exception tracebacks reference the
+documented public location rather than the private ``concurrent.futures._base``
+module.


### PR DESCRIPTION
Currently the classes in ``concurrent.futures`` give unexpected/internal sub-package names for ``__str__`` of the class:

```
$ python3 -c "import concurrent.futures as f; print(f.Future)"
<class 'concurrent.futures._base.Future'>
```

After this change, they get the intended (and [documented](https://docs.python.org/3/library/concurrent.futures.html#concurrent.futures.Future)) location.

This is an aesthetic change to make it easier to correlate an object with its documentation, and does cause a noteworthy issue beyond that.

I did not include the executor implementations in this change as they are implemented in a non-private module. However, the documentation does state that [they come from ``concurrent.futures``](https://docs.python.org/3/library/concurrent.futures.html#concurrent.futures.ThreadPoolExecutor):

```
python3 -c "import concurrent.futures as f; print(f.ThreadPoolExecutor)"
<class 'concurrent.futures.thread.ThreadPoolExecutor'>
``` 


I did some research, and there are a few occurrences in the CPython implementation of re-defining ``__module__`` in this way (examples include [re](https://github.com/python/cpython/blob/ea25f32d5f7d9ae4358338a3fb49bba9b68051a5/Lib/re/_constants.py#L35), [abc](https://github.com/python/cpython/blob/ea25f32d5f7d9ae4358338a3fb49bba9b68051a5/Lib/abc.py#L90), and [io](https://github.com/python/cpython/blob/ea25f32d5f7d9ae4358338a3fb49bba9b68051a5/Lib/io.py#L62)).