### PR TITLE
gh-115391: Fix "comparison of integers of different signs" warning in `longobject.c`

### DIFF
--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -1135,7 +1135,7 @@ PyLong_AsNativeBytes(PyObject* vv, void* buffer, Py_ssize_t n, int endianness)
         if (n <= 0) {
             // nothing to do!
         }
-        else if (n <= sizeof(cv.b)) {
+        else if (n <= (Py_ssize_t)sizeof(cv.b)) {
 #if PY_LITTLE_ENDIAN
             if (little_endian) {
                 memcpy(buffer, cv.b, n);


### PR DESCRIPTION
I think it is safe to just cast unsigned value to signed here, with minimal overflow risk, because we define `cv.v = _PyLong_CompactValue(v);`

CC original author and reviewers.

<!-- gh-issue-number: gh-115391 -->
* Issue: gh-115391
<!-- /gh-issue-number -->
