### PR TITLE
gh-115405: add versionadded tag for co_qualname in code objects documentation

### DIFF
--- a/Doc/reference/datamodel.rst
+++ b/Doc/reference/datamodel.rst
@@ -1134,6 +1134,8 @@ Special read-only attributes
    * - .. attribute:: codeobject.co_qualname
      - The fully qualified function name
 
+       .. versionadded:: 3.11
+
    * - .. attribute:: codeobject.co_argcount
      - The total number of positional :term:`parameters <parameter>`
        (including positional-only parameters and parameters with default values)


### PR DESCRIPTION
Fix https://github.com/python/cpython/issues/115405

> Usually documentation includes deprecated or "new in version" tags for all features.
> 
> the field co_qualname in code objects was added in python 3.11 but the documentation does not precise that, and it feels like it was always defined
> 
> https://docs.python.org/3/reference/datamodel.html#index-58


<!-- gh-issue-number: gh-115405 -->
* Issue: gh-115405
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--115411.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->