### PR TITLE
gh-115421: Update the list of installed test subdirectories.

### DIFF
--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -2226,13 +2226,13 @@ LIBSUBDIRS=	asyncio \
 		__phello__
 TESTSUBDIRS=	idlelib/idle_test \
 		test \
-		test/audiodata \
 		test/archivetestdata \
+		test/audiodata \
 		test/certdata \
 		test/certdata/capath \
 		test/cjkencodings \
-		test/crashers \
 		test/configdata \
+		test/crashers \
 		test/data \
 		test/decimaltestdata \
 		test/dtracedata \
@@ -2246,8 +2246,10 @@ TESTSUBDIRS=	idlelib/idle_test \
 		test/subprocessdata \
 		test/support \
 		test/support/_hypothesis_stubs \
+		test/support/interpreters \
 		test/test_asyncio \
 		test/test_capi \
+		test/test_concurrent_futures \
 		test/test_cppext \
 		test/test_ctypes \
 		test/test_dataclasses \
@@ -2256,7 +2258,6 @@ TESTSUBDIRS=	idlelib/idle_test \
 		test/test_email/data \
 		test/test_future_stmt \
 		test/test_gdb \
-		test/test_inspect \
 		test/test_import \
 		test/test_import/data \
 		test/test_import/data/circular_imports \
@@ -2309,8 +2310,13 @@ TESTSUBDIRS=	idlelib/idle_test \
 		test/test_importlib/resources/zipdata01 \
 		test/test_importlib/resources/zipdata02 \
 		test/test_importlib/source \
+		test/test_inspect \
+		test/test_interpreters \
 		test/test_json \
 		test/test_module \
+		test/test_multiprocessing_fork \
+		test/test_multiprocessing_forkserver \
+		test/test_multiprocessing_spawn \
 		test/test_pathlib \
 		test/test_peg_generator \
 		test/test_pydoc \


### PR DESCRIPTION
Update the list of installed test subdirectories with all newly added subdirectories of Lib/test, so that the tests in those directories are properly installed. Also sort the list alphabetically so it's easy to update/check in the future.


<!-- gh-issue-number: gh-115421 -->
* Issue: gh-115421
<!-- /gh-issue-number -->
