### PR TITLE
gh-115420: Fix translation of exception hander targets by _testinternalcapi.optimize_cfg.

### DIFF
--- a/Lib/test/test_peepholer.py
+++ b/Lib/test/test_peepholer.py
@@ -1065,6 +1065,22 @@ class DirectCfgOptimizerTests(CfgOptimizationTestCase):
         ]
         self.cfg_optimization_test(insts, expected_insts, consts=list(range(5)))
 
+    def test_except_handler_label(self):
+        insts = [
+            ('SETUP_FINALLY', handler := self.Label(), 10),
+            ('POP_BLOCK', 0, -1),
+            ('RETURN_CONST', 1, 11),
+            handler,
+            ('RETURN_CONST', 2, 12),
+        ]
+        expected_insts = [
+            ('SETUP_FINALLY', handler := self.Label(), 10),
+            ('RETURN_CONST', 1, 11),
+            handler,
+            ('RETURN_CONST', 2, 12),
+        ]
+        self.cfg_optimization_test(insts, expected_insts, consts=list(range(5)))
+
     def test_no_unsafe_static_swap(self):
         # We can't change order of two stores to the same location
         insts = [

--- a/Misc/NEWS.d/next/Tests/2024-02-13-18-24-04.gh-issue-115420.-dlzfI.rst
+++ b/Misc/NEWS.d/next/Tests/2024-02-13-18-24-04.gh-issue-115420.-dlzfI.rst
@@ -1,0 +1,2 @@
+Fix translation of exception hander targets by
+``_testinternalcapi.optimize_cfg``.

--- a/Python/flowgraph.c
+++ b/Python/flowgraph.c
@@ -2729,7 +2729,7 @@ _PyCfg_ToInstructionSequence(cfg_builder *g, _PyCompile_InstructionSequence *seq
         RETURN_IF_ERROR(_PyCompile_InstructionSequence_UseLabel(seq, b->b_label.id));
         for (int i = 0; i < b->b_iused; i++) {
             cfg_instr *instr = &b->b_instr[i];
-            if (OPCODE_HAS_JUMP(instr->i_opcode)) {
+            if (OPCODE_HAS_JUMP(instr->i_opcode) || is_block_push(instr)) {
                 instr->i_oparg = instr->i_target->b_label.id;
             }
             RETURN_IF_ERROR(


### PR DESCRIPTION

Fixes #115420.



<!-- gh-issue-number: gh-115420 -->
* Issue: gh-115420
<!-- /gh-issue-number -->
