### PR TITLE
[3.8] gh-115436: Avoid falling back to deprecated Apple-supplied Tcl/Tk 8.5 on macOS.

### DIFF
--- a/Misc/NEWS.d/next/macOS/2024-02-13-19-42-26.gh-issue-115436.pwFBjU.rst
+++ b/Misc/NEWS.d/next/macOS/2024-02-13-19-42-26.gh-issue-115436.pwFBjU.rst
@@ -1,0 +1,7 @@
+Avoid falling back to the deprecated Apple-supplied system Tcl/Tk 8.5 on
+macOS builds as this version is known to have many critical problems and
+causes Python test suite failures. This last-ditch fallback behavior was
+removed in Python 3.11 but is still causing problems for users and Python
+release testing for older security-fix-only branches like this one. With
+this change, building of `_tkinter` on macOS will be skipped if no other
+versions of Tcl/Tk can be found.

--- a/setup.py
+++ b/setup.py
@@ -1744,9 +1744,13 @@ class PyBuildExt(build_ext):
         # The _tkinter module, using frameworks. Since frameworks are quite
         # different the UNIX search logic is not sharable.
         from os.path import join, exists
+
+        # gh-115436: We no longer fall back to searching for the
+        #   Apple-supplied Tcl and Tk 8.5 in /System/Library/Frameworks
+        #   as their use causes too many problems for users. It seems
+        #   better to just skip building _tkinter at all in that case.
         framework_dirs = [
             '/Library/Frameworks',
-            '/System/Library/Frameworks/',
             join(os.getenv('HOME'), '/Library/Frameworks')
         ]
 


### PR DESCRIPTION


<!-- gh-issue-number: gh-115436 -->
* Issue: gh-115436
<!-- /gh-issue-number -->
