### PR TITLE
gh-115450: Fix direct invocation of `test_desctut`

### DIFF
--- a/Lib/test/test_descrtut.py
+++ b/Lib/test/test_descrtut.py
@@ -39,16 +39,16 @@ test_1 = """
 Here's the new type at work:
 
     >>> print(defaultdict)              # show our type
-    <class 'test.test_descrtut.defaultdict'>
+    <class '%(modname)s.defaultdict'>
     >>> print(type(defaultdict))        # its metatype
     <class 'type'>
     >>> a = defaultdict(default=0.0)    # create an instance
     >>> print(a)                        # show the instance
     {}
     >>> print(type(a))                  # show its type
-    <class 'test.test_descrtut.defaultdict'>
+    <class '%(modname)s.defaultdict'>
     >>> print(a.__class__)              # show its class
-    <class 'test.test_descrtut.defaultdict'>
+    <class '%(modname)s.defaultdict'>
     >>> print(type(a) is a.__class__)   # its type is its class
     True
     >>> a[1] = 3.25                     # modify the instance
@@ -99,7 +99,7 @@ just like classic classes:
     >>> print(sortdict(a.__dict__))
     {'default': -1000, 'x1': 100, 'x2': 200}
     >>>
-"""
+""" % {'modname': __name__}
 
 class defaultdict2(dict):
     __slots__ = ['default']
@@ -264,19 +264,19 @@ implicit first argument that is the *class* for which they are invoked.
     ...         print("classmethod", cls, y)
 
     >>> C.foo(1)
-    classmethod <class 'test.test_descrtut.C'> 1
+    classmethod <class '%(modname)s.C'> 1
     >>> c = C()
     >>> c.foo(1)
-    classmethod <class 'test.test_descrtut.C'> 1
+    classmethod <class '%(modname)s.C'> 1
 
     >>> class D(C):
     ...     pass
 
     >>> D.foo(1)
-    classmethod <class 'test.test_descrtut.D'> 1
+    classmethod <class '%(modname)s.D'> 1
     >>> d = D()
     >>> d.foo(1)
-    classmethod <class 'test.test_descrtut.D'> 1
+    classmethod <class '%(modname)s.D'> 1
 
 This prints "classmethod __main__.D 1" both times; in other words, the
 class passed as the first argument of foo() is the class involved in the
@@ -292,18 +292,18 @@ But notice this:
 
     >>> E.foo(1)
     E.foo() called
-    classmethod <class 'test.test_descrtut.C'> 1
+    classmethod <class '%(modname)s.C'> 1
     >>> e = E()
     >>> e.foo(1)
     E.foo() called
-    classmethod <class 'test.test_descrtut.C'> 1
+    classmethod <class '%(modname)s.C'> 1
 
 In this example, the call to C.foo() from E.foo() will see class C as its
 first argument, not class E. This is to be expected, since the call
 specifies the class C. But it stresses the difference between these class
 methods and methods defined in metaclasses (where an upcall to a metamethod
 would pass the target class as an explicit first argument).
-"""
+""" % {'modname': __name__}
 
 test_5 = """
 


### PR DESCRIPTION
Both ways now work:

```
» ./python.exe -m test test_descrtut
Using random seed: 363654913
0:00:00 load avg: 1.49 Run 1 test sequentially
0:00:00 load avg: 1.49 [1/1] test_descrtut

== Tests result: SUCCESS ==

1 test OK.

Total duration: 31 ms
Total tests: run=8
Total test files: run=1/1
Result: SUCCESS
```

and

```
» ./python.exe Lib/test/test_descrtut.py
........
----------------------------------------------------------------------
Ran 8 tests in 0.007s

OK
```

<!-- gh-issue-number: gh-115450 -->
* Issue: gh-115450
<!-- /gh-issue-number -->
