### PR TITLE
gh-115403: Remove extra colon after "Examples" in datetime documentation

### DIFF
--- a/Doc/library/datetime.rst
+++ b/Doc/library/datetime.rst
@@ -1811,7 +1811,9 @@ Other constructor:
       be truncated).
    4. Fractional hours and minutes are not supported.
 
-   Examples::
+   Examples:
+
+   .. doctest::
 
        >>> from datetime import time
        >>> time.fromisoformat('04:23:01')

--- a/Doc/library/datetime.rst
+++ b/Doc/library/datetime.rst
@@ -1813,8 +1813,6 @@ Other constructor:
 
    Examples::
 
-   .. doctest::
-
        >>> from datetime import time
        >>> time.fromisoformat('04:23:01')
        datetime.time(4, 23, 1)


### PR DESCRIPTION
<!-- gh-issue-number: gh-115403 -->
* Issue: gh-115403
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--115452.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->