### PR TITLE
gh-115441: Fix missing braces warning

### DIFF
--- a/Include/internal/pycore_runtime_init.h
+++ b/Include/internal/pycore_runtime_init.h
@@ -169,7 +169,6 @@ extern PyTypeObject _PyExc_MemoryError;
                 { .threshold = 10, }, \
             }, \
         }, \
-        .object_state = _py_object_state_INIT(INTERP), \
         .dtoa = _dtoa_state_INIT(&(INTERP)), \
         .dict_state = _dict_state_INIT, \
         .func_state = { \
@@ -205,16 +204,6 @@ extern PyTypeObject _PyExc_MemoryError;
         .py_recursion_limit = Py_DEFAULT_RECURSION_LIMIT, \
         .context_ver = 1, \
     }
-
-#ifdef Py_TRACE_REFS
-# define _py_object_state_INIT(INTERP) \
-    { \
-        .refchain = NULL, \
-    }
-#else
-# define _py_object_state_INIT(INTERP) \
-    { 0 }
-#endif
 
 
 // global objects


### PR DESCRIPTION
Removes `_py_object_state_INIT`. We want to initialize the `object_state` field to zero.


<!-- gh-issue-number: gh-115441 -->
* Issue: gh-115441
<!-- /gh-issue-number -->
