### PR TITLE
gh-115480: Type and constant propagation for int BINARY_OPs

### DIFF
--- a/Python/optimizer_analysis.c
+++ b/Python/optimizer_analysis.c
@@ -341,6 +341,18 @@ sym_new_const(_Py_UOpsAbstractInterpContext *ctx, PyObject *const_val)
     return temp;
 }
 
+static inline bool
+is_const(_Py_UOpsSymType *sym)
+{
+    return sym->const_val != NULL;
+}
+
+static inline PyObject *
+get_const(_Py_UOpsSymType *sym)
+{
+    return sym->const_val;
+}
+
 static _Py_UOpsSymType*
 sym_new_null(_Py_UOpsAbstractInterpContext *ctx)
 {

--- a/Python/tier2_redundancy_eliminator_bytecodes.c
+++ b/Python/tier2_redundancy_eliminator_bytecodes.c
@@ -81,12 +81,53 @@ dummy_func(void) {
 
 
     op(_BINARY_OP_ADD_INT, (left, right -- res)) {
-        // TODO constant propagation
-        (void)left;
-        (void)right;
-        res = sym_new_known_type(ctx, &PyLong_Type);
-        if (res == NULL) {
-            goto out_of_space;
+        if (is_const(left) && is_const(right)) {
+            PyObject *temp = _PyLong_Add(get_const(left), get_const(right));
+            if (temp == NULL) {
+                goto error;
+            }
+            res = sym_new_const(ctx, temp);
+            // TODO replace opcode with constant propagated one and add tests!
+        }
+        else {
+            res = sym_new_known_type(ctx, &PyLong_Type);
+            if (res == NULL) {
+                goto out_of_space;
+            }
+        }
+    }
+
+    op(_BINARY_OP_SUBTRACT_INT, (left, right -- res)) {
+        if (is_const(left) && is_const(right)) {
+            PyObject *temp = _PyLong_Subtract(get_const(left), get_const(right));
+            if (temp == NULL) {
+                goto error;
+            }
+            res = sym_new_const(ctx, temp);
+            // TODO replace opcode with constant propagated one and add tests!
+        }
+        else {
+            res = sym_new_known_type(ctx, &PyLong_Type);
+            if (res == NULL) {
+                goto out_of_space;
+            }
+        }
+    }
+
+    op(_BINARY_OP_MULTIPLY_INT, (left, right -- res)) {
+        if (is_const(left) && is_const(right)) {
+            PyObject *temp = _PyLong_Multiply(get_const(left), get_const(right));
+            if (temp == NULL) {
+                goto error;
+            }
+            res = sym_new_const(ctx, temp);
+            // TODO replace opcode with constant propagated one and add tests!
+        }
+        else {
+            res = sym_new_known_type(ctx, &PyLong_Type);
+            if (res == NULL) {
+                goto out_of_space;
+            }
         }
     }
 

--- a/Python/tier2_redundancy_eliminator_bytecodes.c
+++ b/Python/tier2_redundancy_eliminator_bytecodes.c
@@ -82,7 +82,10 @@ dummy_func(void) {
 
     op(_BINARY_OP_ADD_INT, (left, right -- res)) {
         if (is_const(left) && is_const(right)) {
-            PyObject *temp = _PyLong_Add(get_const(left), get_const(right));
+            assert(PyLong_CheckExact(get_const(left)));
+            assert(PyLong_CheckExact(get_const(right)));
+            PyObject *temp = _PyLong_Add((PyLongObject *)get_const(left),
+                                         (PyLongObject *)get_const(right));
             if (temp == NULL) {
                 goto error;
             }
@@ -99,7 +102,10 @@ dummy_func(void) {
 
     op(_BINARY_OP_SUBTRACT_INT, (left, right -- res)) {
         if (is_const(left) && is_const(right)) {
-            PyObject *temp = _PyLong_Subtract(get_const(left), get_const(right));
+            assert(PyLong_CheckExact(get_const(left)));
+            assert(PyLong_CheckExact(get_const(right)));
+            PyObject *temp = _PyLong_Subtract((PyLongObject *)get_const(left),
+                                              (PyLongObject *)get_const(right));
             if (temp == NULL) {
                 goto error;
             }
@@ -116,7 +122,10 @@ dummy_func(void) {
 
     op(_BINARY_OP_MULTIPLY_INT, (left, right -- res)) {
         if (is_const(left) && is_const(right)) {
-            PyObject *temp = _PyLong_Multiply(get_const(left), get_const(right));
+            assert(PyLong_CheckExact(get_const(left)));
+            assert(PyLong_CheckExact(get_const(right)));
+            PyObject *temp = _PyLong_Multiply((PyLongObject *)get_const(left),
+                                              (PyLongObject *)get_const(right));
             if (temp == NULL) {
                 goto error;
             }

--- a/Python/tier2_redundancy_eliminator_cases.c.h
+++ b/Python/tier2_redundancy_eliminator_cases.c.h
@@ -180,9 +180,25 @@
         }
 
         case _BINARY_OP_MULTIPLY_INT: {
+            _Py_UOpsSymType *right;
+            _Py_UOpsSymType *left;
             _Py_UOpsSymType *res;
-            res = sym_new_unknown(ctx);
-            if (res == NULL) goto out_of_space;
+            right = stack_pointer[-1];
+            left = stack_pointer[-2];
+            if (is_const(left) && is_const(right)) {
+                PyObject *temp = _PyLong_Multiply(get_const(left), get_const(right));
+                if (temp == NULL) {
+                    goto error;
+                }
+                res = sym_new_const(ctx, temp);
+                // TODO replace opcode with constant propagated one and add tests!
+            }
+            else {
+                res = sym_new_known_type(ctx, &PyLong_Type);
+                if (res == NULL) {
+                    goto out_of_space;
+                }
+            }
             stack_pointer[-2] = res;
             stack_pointer += -1;
             break;
@@ -194,12 +210,19 @@
             _Py_UOpsSymType *res;
             right = stack_pointer[-1];
             left = stack_pointer[-2];
-            // TODO constant propagation
-            (void)left;
-            (void)right;
-            res = sym_new_known_type(ctx, &PyLong_Type);
-            if (res == NULL) {
-                goto out_of_space;
+            if (is_const(left) && is_const(right)) {
+                PyObject *temp = _PyLong_Add(get_const(left), get_const(right));
+                if (temp == NULL) {
+                    goto error;
+                }
+                res = sym_new_const(ctx, temp);
+                // TODO replace opcode with constant propagated one and add tests!
+            }
+            else {
+                res = sym_new_known_type(ctx, &PyLong_Type);
+                if (res == NULL) {
+                    goto out_of_space;
+                }
             }
             stack_pointer[-2] = res;
             stack_pointer += -1;
@@ -207,9 +230,25 @@
         }
 
         case _BINARY_OP_SUBTRACT_INT: {
+            _Py_UOpsSymType *right;
+            _Py_UOpsSymType *left;
             _Py_UOpsSymType *res;
-            res = sym_new_unknown(ctx);
-            if (res == NULL) goto out_of_space;
+            right = stack_pointer[-1];
+            left = stack_pointer[-2];
+            if (is_const(left) && is_const(right)) {
+                PyObject *temp = _PyLong_Subtract(get_const(left), get_const(right));
+                if (temp == NULL) {
+                    goto error;
+                }
+                res = sym_new_const(ctx, temp);
+                // TODO replace opcode with constant propagated one and add tests!
+            }
+            else {
+                res = sym_new_known_type(ctx, &PyLong_Type);
+                if (res == NULL) {
+                    goto out_of_space;
+                }
+            }
             stack_pointer[-2] = res;
             stack_pointer += -1;
             break;

--- a/Python/tier2_redundancy_eliminator_cases.c.h
+++ b/Python/tier2_redundancy_eliminator_cases.c.h
@@ -186,7 +186,10 @@
             right = stack_pointer[-1];
             left = stack_pointer[-2];
             if (is_const(left) && is_const(right)) {
-                PyObject *temp = _PyLong_Multiply(get_const(left), get_const(right));
+                assert(PyLong_CheckExact(get_const(left)));
+                assert(PyLong_CheckExact(get_const(right)));
+                PyObject *temp = _PyLong_Multiply((PyLongObject *)get_const(left),
+                    (PyLongObject *)get_const(right));
                 if (temp == NULL) {
                     goto error;
                 }
@@ -211,7 +214,10 @@
             right = stack_pointer[-1];
             left = stack_pointer[-2];
             if (is_const(left) && is_const(right)) {
-                PyObject *temp = _PyLong_Add(get_const(left), get_const(right));
+                assert(PyLong_CheckExact(get_const(left)));
+                assert(PyLong_CheckExact(get_const(right)));
+                PyObject *temp = _PyLong_Add((PyLongObject *)get_const(left),
+                    (PyLongObject *)get_const(right));
                 if (temp == NULL) {
                     goto error;
                 }
@@ -236,7 +242,10 @@
             right = stack_pointer[-1];
             left = stack_pointer[-2];
             if (is_const(left) && is_const(right)) {
-                PyObject *temp = _PyLong_Subtract(get_const(left), get_const(right));
+                assert(PyLong_CheckExact(get_const(left)));
+                assert(PyLong_CheckExact(get_const(right)));
+                PyObject *temp = _PyLong_Subtract((PyLongObject *)get_const(left),
+                    (PyLongObject *)get_const(right));
                 if (temp == NULL) {
                     goto error;
                 }


### PR DESCRIPTION
Small PR to add type/constant propagation for `_BINARY_OP_ADD/SUBTRACT/MULTIPLY_INT`.

<!-- gh-issue-number: gh-115480 -->
* Issue: gh-115480
<!-- /gh-issue-number -->
