### PR TITLE
gh-115482: Assume the Main Interpreter is Always Running "main"

### DIFF
--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -1044,7 +1044,14 @@ _PyInterpreterState_SetNotRunningMain(PyInterpreterState *interp)
 int
 _PyInterpreterState_IsRunningMain(PyInterpreterState *interp)
 {
-    return (interp->threads.main != NULL);
+    if (interp->threads.main != NULL) {
+        return 1;
+    }
+    // For now, we assume the main interpreter is always running.
+    if (_Py_IsMainInterpreter(interp)) {
+        return 1;
+    }
+    return 0;
 }
 
 int


### PR DESCRIPTION
This is a temporary fix to unblock embedders that do not call `Py_Main()`.

`_PyInterpreterState_IsRunningMain()` will always return true for the main interpreter, even in corner cases where it technically should not.  The (future) full solution will do the right thing in those corner cases.

<!-- gh-issue-number: gh-115482 -->
* Issue: gh-115482
<!-- /gh-issue-number -->
