### PR TITLE
gh-112529: Use _PyThread_Id() in mimalloc (free-threaded build)

### DIFF
--- a/Include/internal/mimalloc/mimalloc/prim.h
+++ b/Include/internal/mimalloc/mimalloc/prim.h
@@ -131,7 +131,13 @@ extern bool _mi_process_is_initialized;             // has mi_process_init been 
 
 static inline mi_threadid_t _mi_prim_thread_id(void) mi_attr_noexcept;
 
-#if defined(_WIN32)
+#ifdef MI_PRIM_THREAD_ID
+
+static inline mi_threadid_t _mi_prim_thread_id(void) mi_attr_noexcept {
+  return MI_PRIM_THREAD_ID();
+}
+
+#elif defined(_WIN32)
 
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>

--- a/Include/internal/pycore_mimalloc.h
+++ b/Include/internal/pycore_mimalloc.h
@@ -20,9 +20,12 @@ typedef enum {
 #include "pycore_pymem.h"
 
 #ifdef WITH_MIMALLOC
-#define MI_DEBUG_UNINIT     PYMEM_CLEANBYTE
-#define MI_DEBUG_FREED      PYMEM_DEADBYTE
-#define MI_DEBUG_PADDING    PYMEM_FORBIDDENBYTE
+#  ifdef Py_GIL_DISABLED
+#    define MI_PRIM_THREAD_ID   _Py_ThreadId
+#  endif
+#  define MI_DEBUG_UNINIT     PYMEM_CLEANBYTE
+#  define MI_DEBUG_FREED      PYMEM_DEADBYTE
+#  define MI_DEBUG_PADDING    PYMEM_FORBIDDENBYTE
 #ifdef Py_DEBUG
 #  define MI_DEBUG 1
 #else


### PR DESCRIPTION
The free-threaded GC uses mimallocs segment thread IDs to restore the overwritten `ob_tid` thread ids in PyObjects. For that reason, it's important that PyObjects and mimalloc use the same identifiers.


<!-- gh-issue-number: gh-112529 -->
* Issue: gh-112529
<!-- /gh-issue-number -->
