### PR TITLE
gh-113157: Document and test __get__ for MethodType

### DIFF
--- a/Doc/howto/descriptor.rst
+++ b/Doc/howto/descriptor.rst
@@ -1192,6 +1192,10 @@ roughly equivalent to:
             "Emulate method_getattro() in Objects/classobject.c"
             return getattr(self.__func__, name)
 
+        def __get__(self, obj, objtype=None):
+            "Emulate method_descr_get() in Objects/classobject.c"
+            return self
+
 To support automatic creation of methods, functions include the
 :meth:`__get__` method for binding methods during attribute access.  This
 means that functions are non-data descriptors that return bound methods
@@ -1216,6 +1220,18 @@ descriptor works in practice:
     class D:
         def f(self, x):
              return x
+
+    class D2:
+        pass
+
+.. doctest::
+    :hide:
+
+    >>> d = D()
+    >>> d2 = D2()
+    >>> d2.f = d.f.__get__(d2, D2)
+    >>> d2.f() is d
+    True
 
 The function has a :term:`qualified name` attribute to support introspection:
 

--- a/Doc/howto/descriptor.rst
+++ b/Doc/howto/descriptor.rst
@@ -1218,8 +1218,8 @@ descriptor works in practice:
 .. testcode::
 
     class D:
-        def f(self, x):
-             return x
+        def f(self):
+             return self
 
     class D2:
         pass


### PR DESCRIPTION
This is part of the bug fix in gh-113157.

Since the bugfix was only applied to the head, don't backport this.

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--115492.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->