### PR TITLE
gh-115347: avoid emitting redundant NOP for the docstring with -OO

### DIFF
--- a/Lib/test/test_compile.py
+++ b/Lib/test/test_compile.py
@@ -824,6 +824,10 @@ class TestSpecifics(unittest.TestCase):
                     "docstring2"
                     return 42
 
+                class C:
+                    "docstring3"
+                    pass
+
                 return h
         """)
         for opt in [-1, 0, 1, 2]:

--- a/Lib/test/test_compile.py
+++ b/Lib/test/test_compile.py
@@ -1,4 +1,6 @@
+import contextlib
 import dis
+import io
 import math
 import os
 import unittest
@@ -811,6 +813,26 @@ class TestSpecifics(unittest.TestCase):
         self.assertEqual(
             'RETURN_CONST',
             list(dis.get_instructions(unused_code_at_end))[-1].opname)
+
+    @support.cpython_only
+    def test_docstring_omitted(self):
+        # See gh-115347
+        src = textwrap.dedent("""
+            def f():
+                "docstring1"
+                def h():
+                    "docstring2"
+                    return 42
+
+                return h
+        """)
+        for opt in [-1, 0, 1, 2]:
+            with self.subTest(opt=opt):
+                code = compile(src, "<test>", "exec", optimize=opt)
+                output = io.StringIO()
+                with contextlib.redirect_stdout(output):
+                    dis.dis(code)
+                self.assertNotIn('NOP' , output.getvalue())
 
     def test_dont_merge_constants(self):
         # Issue #25843: compile() must not merge constants which are equal

--- a/Misc/NEWS.d/next/Core and Builtins/2024-02-14-23-50-43.gh-issue-115347.VkHvQC.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2024-02-14-23-50-43.gh-issue-115347.VkHvQC.rst
@@ -1,0 +1,2 @@
+Fix bug where docstring was replaced by a redundant NOP when Python is run
+with ``-OO``.


### PR DESCRIPTION
Fixes #115347.



<!-- gh-issue-number: gh-115347 -->
* Issue: gh-115347
<!-- /gh-issue-number -->
