### PR TITLE
[3.10] gh-97032: avoid test_squeezer crash on macOS buildbots

### DIFF
--- a/Lib/idlelib/idle_test/test_squeezer.py
+++ b/Lib/idlelib/idle_test/test_squeezer.py
@@ -170,6 +170,7 @@ class SqueezerTest(unittest.TestCase):
 
     def test_write_stdout(self):
         """Test Squeezer's overriding of the EditorWindow's write() method."""
+        requires('gui')
         editwin = self.make_mock_editor_window()
 
         for text in ['', 'TEXT']:


### PR DESCRIPTION
!buildbot macOS

<!-- gh-issue-number: gh-97032 -->
* Issue: gh-97032
<!-- /gh-issue-number -->
