### PR TITLE
gh-115421: List all test subdirs in `Makefile` by `makesetup`

### DIFF
--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -25,6 +25,7 @@ MODSHARED_NAMES=   _MODSHARED_NAMES_
 MODDISABLED_NAMES= _MODDISABLED_NAMES_
 MODOBJS=           _MODOBJS_
 MODLIBS=           _MODLIBS_
+TESTSUBDIRS=       _TESTSUBDIRS_
 
 # === Variables set by configure
 VERSION=	@VERSION@
@@ -2233,139 +2234,6 @@ LIBSUBDIRS=	asyncio \
 		zipfile zipfile/_path \
 		zoneinfo \
 		__phello__
-TESTSUBDIRS=	idlelib/idle_test \
-		test \
-		test/archivetestdata \
-		test/audiodata \
-		test/certdata \
-		test/certdata/capath \
-		test/cjkencodings \
-		test/configdata \
-		test/crashers \
-		test/data \
-		test/decimaltestdata \
-		test/dtracedata \
-		test/encoded_modules \
-		test/leakers \
-		test/libregrtest \
-		test/mathdata \
-		test/regrtestdata \
-		test/regrtestdata/import_from_tests \
-		test/regrtestdata/import_from_tests/test_regrtest_b \
-		test/subprocessdata \
-		test/support \
-		test/support/_hypothesis_stubs \
-		test/support/interpreters \
-		test/test_asyncio \
-		test/test_capi \
-		test/test_concurrent_futures \
-		test/test_cppext \
-		test/test_ctypes \
-		test/test_dataclasses \
-		test/test_doctest \
-		test/test_email \
-		test/test_email/data \
-		test/test_future_stmt \
-		test/test_gdb \
-		test/test_import \
-		test/test_import/data \
-		test/test_import/data/circular_imports \
-		test/test_import/data/circular_imports/subpkg \
-		test/test_import/data/circular_imports/subpkg2 \
-		test/test_import/data/circular_imports/subpkg2/parent \
-		test/test_import/data/package \
-		test/test_import/data/package2 \
-		test/test_import/data/unwritable \
-		test/test_importlib \
-		test/test_importlib/builtin \
-		test/test_importlib/data \
-		test/test_importlib/extension \
-		test/test_importlib/frozen \
-		test/test_importlib/import_ \
-		test/test_importlib/namespace_pkgs \
-		test/test_importlib/namespace_pkgs/both_portions \
-		test/test_importlib/namespace_pkgs/both_portions/foo \
-		test/test_importlib/namespace_pkgs/module_and_namespace_package \
-		test/test_importlib/namespace_pkgs/module_and_namespace_package/a_test \
-		test/test_importlib/namespace_pkgs/not_a_namespace_pkg \
-		test/test_importlib/namespace_pkgs/not_a_namespace_pkg/foo \
-		test/test_importlib/namespace_pkgs/portion1 \
-		test/test_importlib/namespace_pkgs/portion1/foo \
-		test/test_importlib/namespace_pkgs/portion2 \
-		test/test_importlib/namespace_pkgs/portion2/foo \
-		test/test_importlib/namespace_pkgs/project1 \
-		test/test_importlib/namespace_pkgs/project1/parent \
-		test/test_importlib/namespace_pkgs/project1/parent/child \
-		test/test_importlib/namespace_pkgs/project2 \
-		test/test_importlib/namespace_pkgs/project2/parent \
-		test/test_importlib/namespace_pkgs/project2/parent/child \
-		test/test_importlib/namespace_pkgs/project3 \
-		test/test_importlib/namespace_pkgs/project3/parent \
-		test/test_importlib/namespace_pkgs/project3/parent/child \
-		test/test_importlib/partial \
-		test/test_importlib/resources \
-		test/test_importlib/resources/data01 \
-		test/test_importlib/resources/data01/subdirectory \
-		test/test_importlib/resources/data02 \
-		test/test_importlib/resources/data02/one \
-		test/test_importlib/resources/data02/subdirectory \
-		test/test_importlib/resources/data02/subdirectory/subsubdir \
-		test/test_importlib/resources/data02/two \
-		test/test_importlib/resources/data03 \
-		test/test_importlib/resources/data03/namespace \
-		test/test_importlib/resources/data03/namespace/portion1 \
-		test/test_importlib/resources/data03/namespace/portion2 \
-		test/test_importlib/resources/namespacedata01 \
-		test/test_importlib/resources/zipdata01 \
-		test/test_importlib/resources/zipdata02 \
-		test/test_importlib/source \
-		test/test_inspect \
-		test/test_interpreters \
-		test/test_json \
-		test/test_module \
-		test/test_multiprocessing_fork \
-		test/test_multiprocessing_forkserver \
-		test/test_multiprocessing_spawn \
-		test/test_pathlib \
-		test/test_peg_generator \
-		test/test_pydoc \
-		test/test_sqlite3 \
-		test/test_tkinter \
-		test/test_tomllib \
-		test/test_tomllib/data \
-		test/test_tomllib/data/invalid \
-		test/test_tomllib/data/invalid/array \
-		test/test_tomllib/data/invalid/array-of-tables \
-		test/test_tomllib/data/invalid/boolean \
-		test/test_tomllib/data/invalid/dates-and-times \
-		test/test_tomllib/data/invalid/dotted-keys \
-		test/test_tomllib/data/invalid/inline-table \
-		test/test_tomllib/data/invalid/keys-and-vals \
-		test/test_tomllib/data/invalid/literal-str \
-		test/test_tomllib/data/invalid/multiline-basic-str \
-		test/test_tomllib/data/invalid/multiline-literal-str \
-		test/test_tomllib/data/invalid/table \
-		test/test_tomllib/data/valid \
-		test/test_tomllib/data/valid/array \
-		test/test_tomllib/data/valid/dates-and-times \
-		test/test_tomllib/data/valid/multiline-basic-str \
-		test/test_tools \
-		test/test_ttk \
-		test/test_unittest \
-		test/test_unittest/testmock \
-		test/test_warnings \
-		test/test_warnings/data \
-		test/test_zipfile \
-		test/test_zipfile/_path \
-		test/test_zoneinfo \
-		test/test_zoneinfo/data \
-		test/tkinterdata \
-		test/tokenizedata \
-		test/tracedmodules \
-		test/typinganndata \
-		test/wheeldata \
-		test/xmltestdata \
-		test/xmltestdata/c14n-20
 
 COMPILEALL_OPTS=-j0
 

--- a/Modules/makesetup
+++ b/Modules/makesetup
@@ -37,6 +37,7 @@ set -e
 # - replace _MODOBJS_ by the list of objects from Setup (except for
 #   Setup files after a -n option)
 # - replace _MODLIBS_ by the list of libraries from Setup
+# - replace _TESTSUBDIRS_ by the list of test directories
 # - for each object file mentioned in Setup, append a rule
 #   '<file>.o: <file>.c; <build commands>' to the end of the Makefile
 # - for each module mentioned in Setup, append a rule
@@ -342,6 +343,9 @@ sed -e 's/[ 	]*#.*//' -e '/^[ 	]*$/d' |
 		echo "s%_MODDISABLED_NAMES_%$DISABLED%" >>$sedf
 		echo "s%_MODOBJS_%$OBJS%" >>$sedf
 		echo "s%_MODLIBS_%$LIBS%" >>$sedf
+		# We used to have some test modules not installed, see gh-115421
+		TESTSUBDIRS="$(cd Lib; find test -type d -not -path '*/__pycache__' | tr '\n' ' ')"
+		echo "s%_TESTSUBDIRS_%$TESTSUBDIRS%" >> $sedf
 		echo "/Definitions added by makesetup/r $sedr" >>$sedf
 		sed -f $sedf $makepre >Makefile
 		cat $rulesf >>Makefile


### PR DESCRIPTION
It produces:

```
TESTSUBDIRS=       test test/test_cppext test/test_pathlib test/test_inspect test/mathdata test/test_gdb test/test_tomllib test/test_tomllib/data test/test_tomllib/data/valid test/test_tomllib/data/valid/array test/test_tomllib/data/valid/multiline-basic-str test/test_tomllib/data/valid/dates-and-times test/test_tomllib/data/invalid test/test_tomllib/data/invalid/array test/test_tomllib/data/invalid/keys-and-vals test/test_tomllib/data/invalid/inline-table test/test_tomllib/data/invalid/multiline-basic-str test/test_tomllib/data/invalid/literal-str test/test_tomllib/data/invalid/dotted-keys test/test_tomllib/data/invalid/table test/test_tomllib/data/invalid/boolean test/test_tomllib/data/invalid/dates-and-times test/test_tomllib/data/invalid/multiline-literal-str test/test_tomllib/data/invalid/array-of-tables test/test_module test/test_pydoc test/crashers test/test_json test/test_ttk test/test_peg_generator test/test_tools test/audiodata test/typinganndata test/test_tkinter test/test_importlib test/test_importlib/extension test/test_importlib/partial test/test_importlib/resources test/test_importlib/resources/namespacedata01 test/test_importlib/resources/zipdata01 test/test_importlib/resources/data02 test/test_importlib/resources/data02/subdirectory test/test_importlib/resources/data02/subdirectory/subsubdir test/test_importlib/resources/data02/one test/test_importlib/resources/data02/two test/test_importlib/resources/data03 test/test_importlib/resources/data03/namespace test/test_importlib/resources/data03/namespace/portion2 test/test_importlib/resources/data03/namespace/portion1 test/test_importlib/resources/zipdata02 test/test_importlib/resources/data01 test/test_importlib/resources/data01/subdirectory test/test_importlib/source test/test_importlib/import_ test/test_importlib/namespace_pkgs test/test_importlib/namespace_pkgs/project1 test/test_importlib/namespace_pkgs/project1/parent test/test_importlib/namespace_pkgs/project1/parent/child test/test_importlib/namespace_pkgs/portion2 test/test_importlib/namespace_pkgs/portion2/foo test/test_importlib/namespace_pkgs/not_a_namespace_pkg test/test_importlib/namespace_pkgs/not_a_namespace_pkg/foo test/test_importlib/namespace_pkgs/project3 test/test_importlib/namespace_pkgs/project3/parent test/test_importlib/namespace_pkgs/project3/parent/child test/test_importlib/namespace_pkgs/project2 test/test_importlib/namespace_pkgs/project2/parent test/test_importlib/namespace_pkgs/project2/parent/child test/test_importlib/namespace_pkgs/module_and_namespace_package test/test_importlib/namespace_pkgs/module_and_namespace_package/a_test test/test_importlib/namespace_pkgs/both_portions test/test_importlib/namespace_pkgs/both_portions/foo test/test_importlib/namespace_pkgs/portion1 test/test_importlib/namespace_pkgs/portion1/foo test/test_importlib/frozen test/test_importlib/data test/test_importlib/builtin test/test_ctypes test/test_future_stmt test/dtracedata test/tracedmodules test/test_doctest test/tokenizedata test/test_zipfile test/test_zipfile/_path test/test_multiprocessing_spawn test/decimaltestdata test/xmltestdata test/xmltestdata/c14n-20 test/test_xml test/encoded_modules test/cjkencodings test/test_warnings test/test_warnings/data test/test_multiprocessing_forkserver test/regrtestdata test/regrtestdata/import_from_tests test/regrtestdata/import_from_tests/test_regrtest_b test/archivetestdata test/test_unittest test/test_unittest/testmock test/test_sqlite3 test/certdata test/certdata/capath test/test_import test/test_import/data test/test_import/data/package2 test/test_import/data/circular_imports test/test_import/data/circular_imports/subpkg test/test_import/data/circular_imports/subpkg2 test/test_import/data/circular_imports/subpkg2/parent test/test_import/data/unwritable test/test_import/data/package test/test_zoneinfo test/test_zoneinfo/data test/support test/support/interpreters test/support/_hypothesis_stubs test/tkinterdata test/test_interpreters test/test_dataclasses test/test_concurrent_futures test/test_multiprocessing_fork test/test_capi test/leakers test/wheeldata test/test_email test/test_email/data test/test_asyncio test/libregrtest test/data test/subprocessdata test/configdata 
```

And here's what is installed:

```
» tree -d temp/usr/local/lib/python3.13/test/
temp/usr/local/lib/python3.13/test/
├── __pycache__
├── archivetestdata
│   └── __pycache__
├── audiodata
├── certdata
│   ├── __pycache__
│   └── capath
├── cjkencodings
├── configdata
├── crashers
│   └── __pycache__
├── data
├── decimaltestdata
├── dtracedata
│   └── __pycache__
├── encoded_modules
│   └── __pycache__
├── leakers
│   └── __pycache__
├── libregrtest
│   └── __pycache__
├── mathdata
├── regrtestdata
│   └── import_from_tests
│       ├── __pycache__
│       └── test_regrtest_b
│           └── __pycache__
├── subprocessdata
│   └── __pycache__
├── support
│   ├── __pycache__
│   ├── _hypothesis_stubs
│   │   └── __pycache__
│   └── interpreters
│       └── __pycache__
├── test_asyncio
│   └── __pycache__
├── test_capi
│   └── __pycache__
├── test_concurrent_futures
│   └── __pycache__
├── test_cppext
│   └── __pycache__
├── test_ctypes
│   └── __pycache__
├── test_dataclasses
│   └── __pycache__
├── test_doctest
│   └── __pycache__
├── test_email
│   ├── __pycache__
│   └── data
├── test_future_stmt
│   └── __pycache__
├── test_gdb
│   └── __pycache__
├── test_import
│   ├── __pycache__
│   └── data
│       ├── __pycache__
│       ├── circular_imports
│       │   ├── __pycache__
│       │   ├── subpkg
│       │   │   └── __pycache__
│       │   └── subpkg2
│       │       ├── __pycache__
│       │       └── parent
│       │           └── __pycache__
│       ├── package
│       │   └── __pycache__
│       ├── package2
│       │   └── __pycache__
│       └── unwritable
│           └── __pycache__
├── test_importlib
│   ├── __pycache__
│   ├── builtin
│   │   └── __pycache__
│   ├── data
│   │   └── __pycache__
│   ├── extension
│   │   └── __pycache__
│   ├── frozen
│   │   └── __pycache__
│   ├── import_
│   │   └── __pycache__
│   ├── namespace_pkgs
│   │   ├── both_portions
│   │   │   └── foo
│   │   │       └── __pycache__
│   │   ├── module_and_namespace_package
│   │   │   ├── __pycache__
│   │   │   └── a_test
│   │   ├── not_a_namespace_pkg
│   │   │   └── foo
│   │   │       └── __pycache__
│   │   ├── portion1
│   │   │   └── foo
│   │   │       └── __pycache__
│   │   ├── portion2
│   │   │   └── foo
│   │   │       └── __pycache__
│   │   ├── project1
│   │   │   └── parent
│   │   │       └── child
│   │   │           └── __pycache__
│   │   ├── project2
│   │   │   └── parent
│   │   │       └── child
│   │   │           └── __pycache__
│   │   └── project3
│   │       └── parent
│   │           └── child
│   │               └── __pycache__
│   ├── partial
│   │   └── __pycache__
│   ├── resources
│   │   ├── __pycache__
│   │   ├── data01
│   │   │   ├── __pycache__
│   │   │   └── subdirectory
│   │   │       └── __pycache__
│   │   ├── data02
│   │   │   ├── __pycache__
│   │   │   ├── one
│   │   │   │   └── __pycache__
│   │   │   ├── subdirectory
│   │   │   │   └── subsubdir
│   │   │   └── two
│   │   │       └── __pycache__
│   │   ├── data03
│   │   │   ├── __pycache__
│   │   │   └── namespace
│   │   │       ├── portion1
│   │   │       │   └── __pycache__
│   │   │       └── portion2
│   │   │           └── __pycache__
│   │   ├── namespacedata01
│   │   ├── zipdata01
│   │   │   └── __pycache__
│   │   └── zipdata02
│   │       └── __pycache__
│   └── source
│       └── __pycache__
├── test_inspect
│   └── __pycache__
├── test_interpreters
│   └── __pycache__
├── test_json
│   └── __pycache__
├── test_module
│   └── __pycache__
├── test_multiprocessing_fork
│   └── __pycache__
├── test_multiprocessing_forkserver
│   └── __pycache__
├── test_multiprocessing_spawn
│   └── __pycache__
├── test_pathlib
│   └── __pycache__
├── test_peg_generator
│   └── __pycache__
├── test_pydoc
│   └── __pycache__
├── test_sqlite3
│   └── __pycache__
├── test_tkinter
│   └── __pycache__
├── test_tomllib
│   ├── __pycache__
│   └── data
│       ├── invalid
│       │   ├── array
│       │   ├── array-of-tables
│       │   ├── boolean
│       │   ├── dates-and-times
│       │   ├── dotted-keys
│       │   ├── inline-table
│       │   ├── keys-and-vals
│       │   ├── literal-str
│       │   ├── multiline-basic-str
│       │   ├── multiline-literal-str
│       │   └── table
│       └── valid
│           ├── array
│           ├── dates-and-times
│           └── multiline-basic-str
├── test_tools
│   └── __pycache__
├── test_ttk
│   └── __pycache__
├── test_unittest
│   ├── __pycache__
│   └── testmock
│       └── __pycache__
├── test_warnings
│   ├── __pycache__
│   └── data
│       └── __pycache__
├── test_xml
├── test_zipfile
│   ├── __pycache__
│   └── _path
│       └── __pycache__
├── test_zoneinfo
│   ├── __pycache__
│   └── data
│       └── __pycache__
├── tkinterdata
├── tokenizedata
│   └── __pycache__
├── tracedmodules
│   └── __pycache__
├── typinganndata
│   └── __pycache__
├── wheeldata
└── xmltestdata
    └── c14n-20

219 directories
```

Note that `__pycache__` directories are created by compile job and they are not copied.

This is the first time I touch `makesetup`, so please, be very careful during the review :)

<!-- gh-issue-number: gh-115421 -->
* Issue: gh-115421
<!-- /gh-issue-number -->
