### PR TITLE
gh-115490: Work around test.support.interpreters.channels not handling unloading

### DIFF
--- a/Lib/test/libregrtest/main.py
+++ b/Lib/test/libregrtest/main.py
@@ -335,10 +335,15 @@ class Regrtest:
 
             result = self.run_test(test_name, runtests, tracer)
 
-            # Unload the newly imported test modules (best effort finalization)
+            # Unload the newly imported test modules (best effort
+            # finalization). To work around gh-115490, don't unload
+            # test.support.interpreters and its submodules even if they
+            # weren't loaded before.
+            keep = "test.support.interpreters"
             new_modules = [module for module in sys.modules
                            if module not in save_modules and
-                                module.startswith(("test.", "test_"))]
+                                module.startswith(("test.", "test_"))
+                                and not module.startswith(keep)]
             for module in new_modules:
                 sys.modules.pop(module, None)
                 # Remove the attribute of the parent module.


### PR DESCRIPTION
Work around test.support.interpreters.channels not handling unloading, which regrtest does when running tests sequentially, by explicitly skipping the unloads of test.support.interpreters and its submodules.

This can be rolled back once test.support.interpreters.channels supports unloading, if we are keeping sequential runs in the same process around.


<!-- gh-issue-number: gh-115490 -->
* Issue: gh-115490
<!-- /gh-issue-number -->
