### PR TITLE
[3.8] gh-115133: Fix tests for XMLPullParser with Expat 2.6.0 (GH-115164

### DIFF
--- a/Lib/test/test_xml_etree.py
+++ b/Lib/test/test_xml_etree.py
@@ -14,6 +14,7 @@ import locale
 import operator
 import os
 import pickle
+import pyexpat
 import sys
 import textwrap
 import types
@@ -102,6 +103,12 @@ EXTERNAL_ENTITY_XML = """\
 ]>
 <document>&entity;</document>
 """
+
+
+fails_with_expat_2_6_0 = (unittest.expectedFailure
+                        if pyexpat.version_info >= (2, 6, 0) else
+                        lambda test: test)
+
 
 def checkwarnings(*filters, quiet=False):
     def decorator(test):
@@ -1266,28 +1273,37 @@ class XMLPullParserTest(unittest.TestCase):
         self.assertEqual([(action, elem.tag) for action, elem in events],
                          expected)
 
-    def test_simple_xml(self):
-        for chunk_size in (None, 1, 5):
-            with self.subTest(chunk_size=chunk_size):
-                parser = ET.XMLPullParser()
-                self.assert_event_tags(parser, [])
-                self._feed(parser, "<!-- comment -->\n", chunk_size)
-                self.assert_event_tags(parser, [])
-                self._feed(parser,
-                           "<root>\n  <element key='value'>text</element",
-                           chunk_size)
-                self.assert_event_tags(parser, [])
-                self._feed(parser, ">\n", chunk_size)
-                self.assert_event_tags(parser, [('end', 'element')])
-                self._feed(parser, "<element>text</element>tail\n", chunk_size)
-                self._feed(parser, "<empty-element/>\n", chunk_size)
-                self.assert_event_tags(parser, [
-                    ('end', 'element'),
-                    ('end', 'empty-element'),
-                    ])
-                self._feed(parser, "</root>\n", chunk_size)
-                self.assert_event_tags(parser, [('end', 'root')])
-                self.assertIsNone(parser.close())
+    def test_simple_xml(self, chunk_size=None):
+        parser = ET.XMLPullParser()
+        self.assert_event_tags(parser, [])
+        self._feed(parser, "<!-- comment -->\n", chunk_size)
+        self.assert_event_tags(parser, [])
+        self._feed(parser,
+                   "<root>\n  <element key='value'>text</element",
+                   chunk_size)
+        self.assert_event_tags(parser, [])
+        self._feed(parser, ">\n", chunk_size)
+        self.assert_event_tags(parser, [('end', 'element')])
+        self._feed(parser, "<element>text</element>tail\n", chunk_size)
+        self._feed(parser, "<empty-element/>\n", chunk_size)
+        self.assert_event_tags(parser, [
+            ('end', 'element'),
+            ('end', 'empty-element'),
+            ])
+        self._feed(parser, "</root>\n", chunk_size)
+        self.assert_event_tags(parser, [('end', 'root')])
+        self.assertIsNone(parser.close())
+
+    @fails_with_expat_2_6_0
+    def test_simple_xml_chunk_1(self):
+        self.test_simple_xml(chunk_size=1)
+
+    @fails_with_expat_2_6_0
+    def test_simple_xml_chunk_5(self):
+        self.test_simple_xml(chunk_size=5)
+
+    def test_simple_xml_chunk_22(self):
+        self.test_simple_xml(chunk_size=22)
 
     def test_feed_while_iterating(self):
         parser = ET.XMLPullParser()

--- a/Misc/NEWS.d/next/Library/2024-02-08-14-21-28.gh-issue-115133.ycl4ko.rst
+++ b/Misc/NEWS.d/next/Library/2024-02-08-14-21-28.gh-issue-115133.ycl4ko.rst
@@ -1,0 +1,2 @@
+Fix tests for :class:`~xml.etree.ElementTree.XMLPullParser` with Expat
+2.6.0.


### PR DESCRIPTION
Feeding the parser by too small chunks defers parsing to prevent CVE-2023-52425. Future versions of Expat may be more reactive. (cherry picked from commit 4a08e7b3431cd32a0daf22a33421cd3035343dc4)

<!-- gh-issue-number: gh-115133 -->
* Issue: gh-115133
<!-- /gh-issue-number -->
