### PR TITLE
gh-113743: Use per-interpreter locks for types

### DIFF
--- a/Include/internal/pycore_typeobject.h
+++ b/Include/internal/pycore_typeobject.h
@@ -22,7 +22,6 @@ struct _types_runtime_state {
     // bpo-42745: next_version_tag remains shared by all interpreters
     // because of static types.
     unsigned int next_version_tag;
-    PyMutex type_mutex;
 };
 
 
@@ -71,6 +70,7 @@ struct types_state {
     struct type_cache type_cache;
     size_t num_builtins_initialized;
     static_builtin_state builtins[_Py_MAX_STATIC_BUILTIN_TYPES];
+    PyMutex mutex;
 };
 
 

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -60,17 +60,18 @@ class object "PyObject *" "&PyBaseObject_Type"
 // in odd behaviors w.r.t. running with the GIL as the outer type lock could
 // be released and reacquired during a subclass update if there's contention
 // on the subclass lock.
+#define TYPE_LOCK &PyInterpreterState_Get()->types.mutex
 #define BEGIN_TYPE_LOCK()                                               \
     {                                                                   \
         _PyCriticalSection _cs;                                         \
-        _PyCriticalSection_Begin(&_cs, &_PyRuntime.types.type_mutex);   \
+        _PyCriticalSection_Begin(&_cs, TYPE_LOCK);                      \
 
 #define END_TYPE_LOCK()                                                 \
         _PyCriticalSection_End(&_cs);                                   \
     }
 
 #define ASSERT_TYPE_LOCK_HELD() \
-    _Py_CRITICAL_SECTION_ASSERT_MUTEX_LOCKED(&_PyRuntime.types.type_mutex)
+    _Py_CRITICAL_SECTION_ASSERT_MUTEX_LOCKED(TYPE_LOCK)
 
 #else
 

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -395,7 +395,7 @@ _Py_COMP_DIAG_POP
         &(runtime)->atexit.mutex, \
         &(runtime)->audit_hooks.mutex, \
         &(runtime)->allocators.mutex, \
-        &(runtime)->types.type_mutex, \
+        &(runtime)->_main_interpreter.types.mutex, \
     }
 
 static void


### PR DESCRIPTION
The global lock causes heavy contention in `test_interpreters`, this moves it to be per-interpreter.  This makes `_PyStaticType_InitBuiltin` not entirely thread safe anymore, but that can be dealt with later.



<!-- gh-issue-number: gh-113743 -->
* Issue: gh-113743
<!-- /gh-issue-number -->
