### PR TITLE
gh-102013: Move PyUnstable_GC_VisitObjects() to Include/cpython/objim…

### DIFF
--- a/Include/cpython/objimpl.h
+++ b/Include/cpython/objimpl.h
@@ -85,3 +85,20 @@ PyAPI_FUNC(PyObject **) PyObject_GET_WEAKREFS_LISTPTR(PyObject *op);
 
 PyAPI_FUNC(PyObject *) PyUnstable_Object_GC_NewWithExtraData(PyTypeObject *,
                                                              size_t);
+
+
+/* Visit all live GC-capable objects, similar to gc.get_objects(None). The
+ * supplied callback is called on every such object with the void* arg set
+ * to the supplied arg. Returning 0 from the callback ends iteration, returning
+ * 1 allows iteration to continue. Returning any other value may result in
+ * undefined behaviour.
+ *
+ * If new objects are (de)allocated by the callback it is undefined if they
+ * will be visited.
+
+ * Garbage collection is disabled during operation. Explicitly running a
+ * collection in the callback may lead to undefined behaviour e.g. visiting the
+ * same objects multiple times or not at all.
+ */
+typedef int (*gcvisitobjects_t)(PyObject*, void*);
+PyAPI_FUNC(void) PyUnstable_GC_VisitObjects(gcvisitobjects_t callback, void* arg);

--- a/Include/objimpl.h
+++ b/Include/objimpl.h
@@ -153,25 +153,6 @@ PyAPI_FUNC(int) PyGC_Enable(void);
 PyAPI_FUNC(int) PyGC_Disable(void);
 PyAPI_FUNC(int) PyGC_IsEnabled(void);
 
-
-#if !defined(Py_LIMITED_API)
-/* Visit all live GC-capable objects, similar to gc.get_objects(None). The
- * supplied callback is called on every such object with the void* arg set
- * to the supplied arg. Returning 0 from the callback ends iteration, returning
- * 1 allows iteration to continue. Returning any other value may result in
- * undefined behaviour.
- *
- * If new objects are (de)allocated by the callback it is undefined if they
- * will be visited.
-
- * Garbage collection is disabled during operation. Explicitly running a
- * collection in the callback may lead to undefined behaviour e.g. visiting the
- * same objects multiple times or not at all.
- */
-typedef int (*gcvisitobjects_t)(PyObject*, void*);
-PyAPI_FUNC(void) PyUnstable_GC_VisitObjects(gcvisitobjects_t callback, void* arg);
-#endif
-
 /* Test if a type has a GC head */
 #define PyType_IS_GC(t) PyType_HasFeature((t), Py_TPFLAGS_HAVE_GC)
 


### PR DESCRIPTION
…pl.h

Include/objimpl.h must only contain the limited C API, whereas PyUnstable_GC_VisitObjects() is excluded from the limited C API.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-102013 -->
* Issue: gh-102013
<!-- /gh-issue-number -->
