### PR TITLE
gh-114626: Add again _PyCFunctionFastWithKeywords name

### DIFF
--- a/Include/methodobject.h
+++ b/Include/methodobject.h
@@ -31,7 +31,7 @@ typedef PyObject *(*PyCMethod)(PyObject *, PyTypeObject *, PyObject *const *,
 // Note that the underscore-prefixed names were documented in public docs;
 // people may be using them.
 typedef PyCFunctionFast _PyCFunctionFast;
-typedef PyCFunctionWithKeywords _PyCFunctionWithKeywords;
+typedef PyCFunctionFastWithKeywords _PyCFunctionFastWithKeywords;
 
 // Cast an function to the PyCFunction type to use it with PyMethodDef.
 //

--- a/Misc/NEWS.d/next/C API/2024-02-16-15-56-53.gh-issue-114626.ie2esA.rst
+++ b/Misc/NEWS.d/next/C API/2024-02-16-15-56-53.gh-issue-114626.ie2esA.rst
@@ -1,0 +1,4 @@
+Add again ``_PyCFunctionFastWithKeywords`` name, removed in Python 3.13
+alpha 4 by mistake.  Keep the old private ``_PyCFunctionFastWithKeywords``
+name (Python 3.7) as an alias to the new public name
+``PyCFunctionFastWithKeywords`` (Python 3.13a4). Patch by Victor Stinner.


### PR DESCRIPTION
Keep the old private _PyCFunctionFastWithKeywords name (Python 3.7) as an alias to the new public name PyCFunctionFastWithKeywords (Python 3.13a4).

_PyCFunctionWithKeywords doesn't exist in Python 3.13a3, whereas _PyCFunctionFastWithKeywords was removed in Python 3.13a4.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-114626 -->
* Issue: gh-114626
<!-- /gh-issue-number -->
