### PR TITLE
gh-113743: Give _PyTypes_AfterFork a prototype.

### DIFF
--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -4943,7 +4943,7 @@ update_cache_gil_disabled(struct type_cache_entry *entry, PyObject *name,
 #endif
 
 void
-_PyTypes_AfterFork()
+_PyTypes_AfterFork(void)
 {
 #ifdef Py_GIL_DISABLED
     struct type_cache *cache = get_type_cache();


### PR DESCRIPTION
Fixes a compiler warning.


<!-- gh-issue-number: gh-113743 -->
* Issue: gh-113743
<!-- /gh-issue-number -->
