### PR TITLE
gh-112720: make it easier to subclass and modify dis.ArgResolver's jump arg resolution

### DIFF
--- a/Lib/test/test_dis.py
+++ b/Lib/test/test_dis.py
@@ -1998,7 +1998,7 @@ class InstructionTests(InstructionTestCase):
             arg_resolver = MyArgResolver(*init_args)
             return arg_resolver.get_argval_argrepr(opcode, oparg, offset)
     
-        offset = 42               
+        offset = 42
         self.assertEqual(f(opcode.opmap["JUMP_BACKWARD"], 1, offset), (2, 'to L4'))
         self.assertEqual(f(opcode.opmap["SETUP_FINALLY"], 2, offset), (3, 'to L6'))
 

--- a/Lib/test/test_dis.py
+++ b/Lib/test/test_dis.py
@@ -1986,6 +1986,23 @@ class InstructionTests(InstructionTestCase):
         self.assertEqual(f(opcode.opmap["BINARY_OP"], 3, *args), (3, '<<'))
         self.assertEqual(f(opcode.opmap["CALL_INTRINSIC_1"], 2, *args), (2, 'INTRINSIC_IMPORT_STAR'))
 
+    def test_custom_arg_resolver(self):
+        class MyArgResolver(dis.ArgResolver):
+            def offset_from_jump_arg(self, op, arg, offset):
+                return arg + 1
+
+            def get_label_for_offset(self, offset):
+                return 2 * offset
+
+        def f(opcode, oparg, offset, *init_args):
+            arg_resolver = MyArgResolver(*init_args)
+            return arg_resolver.get_argval_argrepr(opcode, oparg, offset)
+    
+        offset = 42               
+        self.assertEqual(f(opcode.opmap["JUMP_BACKWARD"], 1, offset), (2, 'to L4'))
+        self.assertEqual(f(opcode.opmap["SETUP_FINALLY"], 2, offset), (3, 'to L6'))
+
+
     def get_instructions(self, code):
         return dis._get_instructions_bytes(code)
 

--- a/Lib/test/test_dis.py
+++ b/Lib/test/test_dis.py
@@ -1997,7 +1997,6 @@ class InstructionTests(InstructionTestCase):
         def f(opcode, oparg, offset, *init_args):
             arg_resolver = MyArgResolver(*init_args)
             return arg_resolver.get_argval_argrepr(opcode, oparg, offset)
-    
         offset = 42
         self.assertEqual(f(opcode.opmap["JUMP_BACKWARD"], 1, offset), (2, 'to L4'))
         self.assertEqual(f(opcode.opmap["SETUP_FINALLY"], 2, offset), (3, 'to L6'))

--- a/Misc/NEWS.d/next/Library/2024-02-16-16-40-10.gh-issue-112720.io6_Ac.rst
+++ b/Misc/NEWS.d/next/Library/2024-02-16-16-40-10.gh-issue-112720.io6_Ac.rst
@@ -1,0 +1,2 @@
+Refactor :class:`dis.ArgResolver` to make it possible to subclass and change
+the way jump args are interpreted.


### PR DESCRIPTION
This is useful when using dis to display an intermediate, or custom, instruction stream. In that case the jump args may have different meaning than in actual bytecode.

<!-- gh-issue-number: gh-112720 -->
* Issue: gh-112720
<!-- /gh-issue-number -->
