### PR TITLE
doc: Use super() in subclassed JSONEncoder examples

### DIFF
--- a/Doc/library/json.rst
+++ b/Doc/library/json.rst
@@ -106,7 +106,7 @@ Extending :class:`JSONEncoder`::
     ...         if isinstance(obj, complex):
     ...             return [obj.real, obj.imag]
     ...         # Let the base class default method raise the TypeError
-    ...         return json.JSONEncoder.default(self, obj)
+    ...         return super().default(obj)
     ...
     >>> json.dumps(2 + 1j, cls=ComplexEncoder)
     '[2.0, 1.0]'
@@ -504,7 +504,7 @@ Encoders and Decoders
             else:
                 return list(iterable)
             # Let the base class default method raise the TypeError
-            return json.JSONEncoder.default(self, o)
+            return super().default(o)
 
 
    .. method:: encode(o)

--- a/Lib/json/encoder.py
+++ b/Lib/json/encoder.py
@@ -174,7 +174,7 @@ class JSONEncoder(object):
                 else:
                     return list(iterable)
                 # Let the base class default method raise the TypeError
-                return JSONEncoder.default(self, o)
+                return super().default(o)
 
         """
         raise TypeError(f'Object of type {o.__class__.__name__} '


### PR DESCRIPTION
Replace calls to `json.JSONEncoder.default(self, obj)` simply by `super().default(obj)` within the examples of the documentation.

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--115565.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->