### PR TITLE
gh-76785: Update test.support.interpreters to Align With PEP 734

### DIFF
--- a/Lib/test/support/interpreters/__init__.py
+++ b/Lib/test/support/interpreters/__init__.py
@@ -16,19 +16,22 @@ __all__ = [
     'Interpreter',
     'InterpreterError', 'InterpreterNotFoundError', 'ExecFailure',
     'NotShareableError',
-    'create_queue', 'Queue', 'QueueEmpty', 'QueueFull',
+    'create_shared_queue', 'SharedQueue', 'QueueEmpty', 'QueueFull',
 ]
 
 
 _queuemod = None
 
 def __getattr__(name):
-    if name in ('Queue', 'QueueEmpty', 'QueueFull', 'create_queue'):
-        global create_queue, Queue, QueueEmpty, QueueFull
+    if name in ('QueueEmpty', 'QueueFull',
+                'SharedQueue', 'create_shared_queue'):
+        global QueueEmpty, QueueFull
+        global create_shared_queue, SharedQueue
         ns = globals()
         from .queues import (
-            create as create_queue,
-            Queue, QueueEmpty, QueueFull,
+            QueueEmpty, QueueFull,
+            create_shared as create_shared_queue,
+            SharedQueue,
         )
         return ns[name]
     else:

--- a/Lib/test/support/interpreters/__init__.py
+++ b/Lib/test/support/interpreters/__init__.py
@@ -6,7 +6,7 @@ import _xxsubinterpreters as _interpreters
 
 # aliases:
 from _xxsubinterpreters import (
-    InterpreterError, InterpreterNotFoundError,
+    InterpreterError, InterpreterNotFoundError, NotShareableError,
     is_shareable,
 )
 
@@ -15,6 +15,7 @@ __all__ = [
     'get_current', 'get_main', 'create', 'list_all', 'is_shareable',
     'Interpreter',
     'InterpreterError', 'InterpreterNotFoundError', 'ExecFailure',
+    'NotShareableError',
     'create_queue', 'Queue', 'QueueEmpty', 'QueueFull',
 ]
 

--- a/Lib/test/support/interpreters/__init__.py
+++ b/Lib/test/support/interpreters/__init__.py
@@ -16,27 +16,19 @@ __all__ = [
     'Interpreter',
     'InterpreterError', 'InterpreterNotFoundError', 'ExecFailure',
     'NotShareableError',
-    'create_shared_queue', 'create_queue',
-    'SharedQueue', 'Queue',
-    'QueueEmpty', 'QueueFull',
+    'create_queue', 'Queue', 'QueueEmpty', 'QueueFull',
 ]
 
 
 _queuemod = None
 
 def __getattr__(name):
-    if name in ('QueueEmpty', 'QueueFull',
-                'SharedQueue', 'create_shared_queue',
-                'Queue', 'create_queue'):
-        global QueueEmpty, QueueFull
-        global create_shared_queue, SharedQueue
-        global create_queue, Queue
+    if name in ('Queue', 'QueueEmpty', 'QueueFull', 'create_queue'):
+        global create_queue, Queue, QueueEmpty, QueueFull
         ns = globals()
         from .queues import (
-            QueueEmpty, QueueFull,
-            create_shared as create_shared_queue,
             create as create_queue,
-            SharedQueue, Queue,
+            Queue, QueueEmpty, QueueFull,
         )
         return ns[name]
     else:

--- a/Lib/test/support/interpreters/__init__.py
+++ b/Lib/test/support/interpreters/__init__.py
@@ -158,7 +158,7 @@ class Interpreter:
         ns = dict(ns, **kwargs) if ns is not None else kwargs
         _interpreters.set___main___attrs(self._id, ns)
 
-    def exec_sync(self, code, /):
+    def exec(self, code, /):
         """Run the given source code in the interpreter.
 
         This is essentially the same as calling the builtin "exec"
@@ -182,7 +182,7 @@ class Interpreter:
 
     def run(self, code, /):
         def task():
-            self.exec_sync(code)
+            self.exec(code)
         t = threading.Thread(target=task)
         t.start()
         return t

--- a/Lib/test/support/interpreters/__init__.py
+++ b/Lib/test/support/interpreters/__init__.py
@@ -16,7 +16,9 @@ __all__ = [
     'Interpreter',
     'InterpreterError', 'InterpreterNotFoundError', 'ExecFailure',
     'NotShareableError',
-    'create_shared_queue', 'SharedQueue', 'QueueEmpty', 'QueueFull',
+    'create_shared_queue', 'create_queue',
+    'SharedQueue', 'Queue',
+    'QueueEmpty', 'QueueFull',
 ]
 
 
@@ -24,14 +26,17 @@ _queuemod = None
 
 def __getattr__(name):
     if name in ('QueueEmpty', 'QueueFull',
-                'SharedQueue', 'create_shared_queue'):
+                'SharedQueue', 'create_shared_queue',
+                'Queue', 'create_queue'):
         global QueueEmpty, QueueFull
         global create_shared_queue, SharedQueue
+        global create_queue, Queue
         ns = globals()
         from .queues import (
             QueueEmpty, QueueFull,
             create_shared as create_shared_queue,
-            SharedQueue,
+            create as create_queue,
+            SharedQueue, Queue,
         )
         return ns[name]
     else:

--- a/Lib/test/support/interpreters/queues.py
+++ b/Lib/test/support/interpreters/queues.py
@@ -11,8 +11,8 @@ from _xxinterpqueues import (
 )
 
 __all__ = [
-    'create_shared', 'create', 'list_all',
-    'SharedQueue', 'Queue',
+    'create', 'list_all',
+    'Queue',
     'QueueError', 'QueueNotFoundError', 'QueueEmpty', 'QueueFull',
 ]
 
@@ -31,39 +31,25 @@ class QueueFull(_queues.QueueFull, queue.Full):
     """
 
 
-def create_shared(maxsize=0):
-    """Return a new cross-interpreter queue.
-
-    The queue may be used to pass data safely between interpreters.
-    Only "shareable" objects put into the queue.  The data is handled
-    with maximum efficiency.
-    """
-    qid = _queues.create(maxsize, sharedonly=True)
-    return SharedQueue(qid)
-
-
 def create(maxsize=0):
     """Return a new cross-interpreter queue.
 
     The queue may be used to pass data safely between interpreters.
-    Any object may be put into the queue.  Each is serialized, and thus
-    copied.  This approach is not as efficient as queues made with
-    create_shared().
     """
-    qid = _queues.create(maxsize, sharedonly=False)
+    qid = _queues.create(maxsize)
     return Queue(qid)
 
 
 def list_all():
     """Return a list of all open queues."""
-    return [SharedQueue(qid) if sharedonly else Queue(qid)
-            for qid, sharedonly in _queues.list_all()]
+    return [Queue(qid)
+            for qid in _queues.list_all()]
 
 
 
 _known_queues = weakref.WeakValueDictionary()
 
-class SharedQueue:
+class Queue:
     """A cross-interpreter queue."""
 
     def __new__(cls, id, /):
@@ -122,8 +108,6 @@ class SharedQueue:
             _delay=10 / 1000,  # 10 milliseconds
             ):
         """Add the object to the queue.
-
-        The object must be "shareable".
 
         This blocks while the queue is full.
         """
@@ -185,18 +169,4 @@ class SharedQueue:
             raise  # re-raise
 
 
-class Queue(SharedQueue):
-    """A cross-interpreter queue."""
-
-    def put(self, obj, timeout=None):
-        """Add the object to the queue.
-
-        All objects are supported.
-
-        This blocks while the queue is full.
-        """
-        super().put(obj, timeout)
-
-
-_queues._register_queue_type(SharedQueue)
 _queues._register_queue_type(Queue)

--- a/Lib/test/support/interpreters/queues.py
+++ b/Lib/test/support/interpreters/queues.py
@@ -11,8 +11,8 @@ from _xxinterpqueues import (
 )
 
 __all__ = [
-    'create', 'list_all',
-    'Queue',
+    'create_shared', 'list_all',
+    'SharedQueue',
     'QueueError', 'QueueNotFoundError', 'QueueEmpty', 'QueueFull',
 ]
 
@@ -31,25 +31,25 @@ class QueueFull(_queues.QueueFull, queue.Full):
     """
 
 
-def create(maxsize=0):
+def create_shared(maxsize=0):
     """Return a new cross-interpreter queue.
 
     The queue may be used to pass data safely between interpreters.
     """
     qid = _queues.create(maxsize)
-    return Queue(qid)
+    return SharedQueue(qid)
 
 
 def list_all():
     """Return a list of all open queues."""
-    return [Queue(qid)
+    return [SharedQueue(qid)
             for qid in _queues.list_all()]
 
 
 
 _known_queues = weakref.WeakValueDictionary()
 
-class Queue:
+class SharedQueue:
     """A cross-interpreter queue."""
 
     def __new__(cls, id, /):
@@ -169,4 +169,4 @@ class Queue:
             raise  # re-raise
 
 
-_queues._register_queue_type(Queue)
+_queues._register_queue_type(SharedQueue)

--- a/Lib/test/support/interpreters/queues.py
+++ b/Lib/test/support/interpreters/queues.py
@@ -153,7 +153,6 @@ class Queue:
             fmt = self._fmt
         else:
             fmt = _SHARED_ONLY if sharedonly else _PICKLED
-        fmt = _SHARED_ONLY if sharedonly else _PICKLED
         if fmt is _PICKLED:
             obj = pickle.dumps(obj)
         try:

--- a/Lib/test/test_interpreters/test_api.py
+++ b/Lib/test/test_interpreters/test_api.py
@@ -16,14 +16,14 @@ class ModuleTests(TestBase):
 
     def test_queue_aliases(self):
         first = [
-            interpreters.create_queue,
-            interpreters.Queue,
+            interpreters.create_shared_queue,
+            interpreters.SharedQueue,
             interpreters.QueueEmpty,
             interpreters.QueueFull,
         ]
         second = [
-            interpreters.create_queue,
-            interpreters.Queue,
+            interpreters.create_shared_queue,
+            interpreters.SharedQueue,
             interpreters.QueueEmpty,
             interpreters.QueueFull,
         ]

--- a/Lib/test/test_interpreters/test_api.py
+++ b/Lib/test/test_interpreters/test_api.py
@@ -503,9 +503,9 @@ class TestInterpreterPrepareMain(TestBase):
             interp.prepare_main(spam={'spam': 'eggs', 'foo': 'bar'})
 
         # Make sure neither was actually bound.
-        with self.assertRaises(interpreters.ExecFailure):
+        with self.assertRaises(interpreters.ExecutionFailed):
             interp.exec('print(foo)')
-        with self.assertRaises(interpreters.ExecFailure):
+        with self.assertRaises(interpreters.ExecutionFailed):
             interp.exec('print(spam)')
 
 
@@ -522,7 +522,7 @@ class TestInterpreterExec(TestBase):
 
     def test_failure(self):
         interp = interpreters.create()
-        with self.assertRaises(interpreters.ExecFailure):
+        with self.assertRaises(interpreters.ExecutionFailed):
             interp.exec('raise Exception')
 
     def test_display_preserved_exception(self):
@@ -555,8 +555,8 @@ class TestInterpreterExec(TestBase):
                 interp.exec(script)
                 ~~~~~~~~~~~^^^^^^^^
               {interpmod_line.strip()}
-                raise ExecFailure(excinfo)
-            test.support.interpreters.ExecFailure: RuntimeError: uh-oh!
+                raise ExecutionFailed(excinfo)
+            test.support.interpreters.ExecutionFailed: RuntimeError: uh-oh!
 
             Uncaught in the interpreter:
 
@@ -822,7 +822,7 @@ class TestInterpreterCall(TestBase):
                         raise Exception((args, kwargs))
                     interp.call(callable)
 
-        with self.assertRaises(interpreters.CallFailure):
+        with self.assertRaises(interpreters.ExecutionFailed):
             interp.call(call_func_failure)
 
     def test_call_in_thread(self):

--- a/Lib/test/test_interpreters/test_api.py
+++ b/Lib/test/test_interpreters/test_api.py
@@ -16,14 +16,14 @@ class ModuleTests(TestBase):
 
     def test_queue_aliases(self):
         first = [
-            interpreters.create_shared_queue,
-            interpreters.SharedQueue,
+            interpreters.create_queue,
+            interpreters.Queue,
             interpreters.QueueEmpty,
             interpreters.QueueFull,
         ]
         second = [
-            interpreters.create_shared_queue,
-            interpreters.SharedQueue,
+            interpreters.create_queue,
+            interpreters.Queue,
             interpreters.QueueEmpty,
             interpreters.QueueFull,
         ]

--- a/Lib/test/test_interpreters/test_channels.py
+++ b/Lib/test/test_interpreters/test_channels.py
@@ -120,7 +120,7 @@ class TestSendRecv(TestBase):
 
     def test_send_recv_same_interpreter(self):
         interp = interpreters.create()
-        interp.exec_sync(dedent("""
+        interp.exec(dedent("""
             from test.support.interpreters import channels
             r, s = channels.create()
             orig = b'spam'
@@ -193,7 +193,7 @@ class TestSendRecv(TestBase):
 
     def test_send_recv_nowait_same_interpreter(self):
         interp = interpreters.create()
-        interp.exec_sync(dedent("""
+        interp.exec(dedent("""
             from test.support.interpreters import channels
             r, s = channels.create()
             orig = b'spam'

--- a/Lib/test/test_interpreters/test_lifecycle.py
+++ b/Lib/test/test_interpreters/test_lifecycle.py
@@ -124,7 +124,7 @@ class StartupTests(TestBase):
             orig = sys.path[0]
 
             interp = interpreters.create()
-            interp.exec_sync(f"""if True:
+            interp.exec(f"""if True:
                 import json
                 import sys
                 print(json.dumps({{

--- a/Lib/test/test_interpreters/test_queues.py
+++ b/Lib/test/test_interpreters/test_queues.py
@@ -58,13 +58,13 @@ class QueueTests(TestBase):
 
         with self.subTest('same interpreter'):
             queue2 = queues.create()
-            queue1.put(queue2, sharedonly=True)
+            queue1.put(queue2, strictequiv=True)
             queue3 = queue1.get()
             self.assertIs(queue3, queue2)
 
         with self.subTest('from current interpreter'):
             queue4 = queues.create()
-            queue1.put(queue4, sharedonly=True)
+            queue1.put(queue4, strictequiv=True)
             out = _run_output(interp, dedent("""
                 queue4 = queue1.get()
                 print(queue4.id)
@@ -75,7 +75,7 @@ class QueueTests(TestBase):
         with self.subTest('from subinterpreter'):
             out = _run_output(interp, dedent("""
                 queue5 = queues.create()
-                queue1.put(queue5, sharedonly=True)
+                queue1.put(queue5, strictequiv=True)
                 print(queue5.id)
                 """))
             qid = int(out)
@@ -118,7 +118,7 @@ class TestQueueOps(TestBase):
     def test_empty(self):
         queue = queues.create()
         before = queue.empty()
-        queue.put(None, sharedonly=True)
+        queue.put(None, strictequiv=True)
         during = queue.empty()
         queue.get()
         after = queue.empty()
@@ -133,7 +133,7 @@ class TestQueueOps(TestBase):
         queue = queues.create(3)
         for _ in range(3):
             actual.append(queue.full())
-            queue.put(None, sharedonly=True)
+            queue.put(None, strictequiv=True)
         actual.append(queue.full())
         for _ in range(3):
             queue.get()
@@ -147,16 +147,16 @@ class TestQueueOps(TestBase):
         queue = queues.create()
         for _ in range(3):
             actual.append(queue.qsize())
-            queue.put(None, sharedonly=True)
+            queue.put(None, strictequiv=True)
         actual.append(queue.qsize())
         queue.get()
         actual.append(queue.qsize())
-        queue.put(None, sharedonly=True)
+        queue.put(None, strictequiv=True)
         actual.append(queue.qsize())
         for _ in range(3):
             queue.get()
             actual.append(queue.qsize())
-        queue.put(None, sharedonly=True)
+        queue.put(None, strictequiv=True)
         actual.append(queue.qsize())
         queue.get()
         actual.append(queue.qsize())
@@ -165,9 +165,9 @@ class TestQueueOps(TestBase):
 
     def test_put_get_main(self):
         expected = list(range(20))
-        for sharedonly in (True, False):
-            kwds = dict(sharedonly=sharedonly)
-            with self.subTest(f'sharedonly={sharedonly}'):
+        for strictequiv in (True, False):
+            kwds = dict(strictequiv=strictequiv)
+            with self.subTest(f'strictequiv={strictequiv}'):
                 queue = queues.create()
                 for i in range(20):
                     queue.put(i, **kwds)
@@ -176,9 +176,9 @@ class TestQueueOps(TestBase):
                 self.assertEqual(actual, expected)
 
     def test_put_timeout(self):
-        for sharedonly in (True, False):
-            kwds = dict(sharedonly=sharedonly)
-            with self.subTest(f'sharedonly={sharedonly}'):
+        for strictequiv in (True, False):
+            kwds = dict(strictequiv=strictequiv)
+            with self.subTest(f'strictequiv={strictequiv}'):
                 queue = queues.create(2)
                 queue.put(None, **kwds)
                 queue.put(None, **kwds)
@@ -188,9 +188,9 @@ class TestQueueOps(TestBase):
                 queue.put(None, **kwds)
 
     def test_put_nowait(self):
-        for sharedonly in (True, False):
-            kwds = dict(sharedonly=sharedonly)
-            with self.subTest(f'sharedonly={sharedonly}'):
+        for strictequiv in (True, False):
+            kwds = dict(strictequiv=strictequiv)
+            with self.subTest(f'strictequiv={strictequiv}'):
                 queue = queues.create(2)
                 queue.put_nowait(None, **kwds)
                 queue.put_nowait(None, **kwds)
@@ -199,7 +199,7 @@ class TestQueueOps(TestBase):
                 queue.get()
                 queue.put_nowait(None, **kwds)
 
-    def test_put_sharedonly(self):
+    def test_put_strictequiv(self):
         for obj in [
             None,
             True,
@@ -210,7 +210,7 @@ class TestQueueOps(TestBase):
         ]:
             with self.subTest(repr(obj)):
                 queue = queues.create()
-                queue.put(obj, sharedonly=True)
+                queue.put(obj, strictequiv=True)
                 obj2 = queue.get()
                 self.assertEqual(obj2, obj)
 
@@ -221,9 +221,9 @@ class TestQueueOps(TestBase):
             with self.subTest(repr(obj)):
                 queue = queues.create()
                 with self.assertRaises(interpreters.NotShareableError):
-                    queue.put(obj, sharedonly=True)
+                    queue.put(obj, strictequiv=True)
 
-    def test_put_not_sharedonly(self):
+    def test_put_not_strictequiv(self):
         for obj in [
             None,
             True,
@@ -237,7 +237,7 @@ class TestQueueOps(TestBase):
         ]:
             with self.subTest(repr(obj)):
                 queue = queues.create()
-                queue.put(obj, sharedonly=False)
+                queue.put(obj, strictequiv=False)
                 obj2 = queue.get()
                 self.assertEqual(obj2, obj)
 
@@ -251,9 +251,9 @@ class TestQueueOps(TestBase):
         with self.assertRaises(queues.QueueEmpty):
             queue.get_nowait()
 
-    def test_put_get_default_sharedonly(self):
+    def test_put_get_default_strictequiv(self):
         expected = list(range(20))
-        queue = queues.create(sharedonly=True)
+        queue = queues.create(strictequiv=True)
         for i in range(20):
             queue.put(i)
         actual = [queue.get() for _ in range(20)]
@@ -264,9 +264,9 @@ class TestQueueOps(TestBase):
         with self.assertRaises(interpreters.NotShareableError):
             queue.put(obj)
 
-    def test_put_get_default_not_sharedonly(self):
+    def test_put_get_default_not_strictequiv(self):
         expected = list(range(20))
-        queue = queues.create(sharedonly=False)
+        queue = queues.create(strictequiv=False)
         for i in range(20):
             queue.put(i)
         actual = [queue.get() for _ in range(20)]
@@ -285,7 +285,7 @@ class TestQueueOps(TestBase):
             from test.support.interpreters import queues
             queue = queues.create()
             orig = b'spam'
-            queue.put(orig, sharedonly=True)
+            queue.put(orig, strictequiv=True)
             obj = queue.get()
             assert obj == orig, 'expected: obj == orig'
             assert obj is not orig, 'expected: obj is not orig'
@@ -298,7 +298,7 @@ class TestQueueOps(TestBase):
         self.assertEqual(len(queues.list_all()), 2)
 
         obj1 = b'spam'
-        queue1.put(obj1, sharedonly=True)
+        queue1.put(obj1, strictequiv=True)
 
         out = _run_output(
             interp,
@@ -315,7 +315,7 @@ class TestQueueOps(TestBase):
                 obj2 = b'eggs'
                 print(id(obj2))
                 assert queue2.qsize() == 0, 'expected: queue2.qsize() == 0'
-                queue2.put(obj2, sharedonly=True)
+                queue2.put(obj2, strictequiv=True)
                 assert queue2.qsize() == 1, 'expected: queue2.qsize() == 1'
                 """))
         self.assertEqual(len(queues.list_all()), 2)
@@ -337,8 +337,8 @@ class TestQueueOps(TestBase):
                 queue = queues.Queue({queue.id})
                 obj1 = b'spam'
                 obj2 = b'eggs'
-                queue.put(obj1, sharedonly=True)
-                queue.put(obj2, sharedonly=True)
+                queue.put(obj1, strictequiv=True)
+                queue.put(obj2, strictequiv=True)
                 """))
         self.assertEqual(queue.qsize(), 2)
 
@@ -360,12 +360,12 @@ class TestQueueOps(TestBase):
                     break
                 except queues.QueueEmpty:
                     continue
-            queue2.put(obj, sharedonly=True)
+            queue2.put(obj, strictequiv=True)
         t = threading.Thread(target=f)
         t.start()
 
         orig = b'spam'
-        queue1.put(orig, sharedonly=True)
+        queue1.put(orig, strictequiv=True)
         obj = queue2.get()
         t.join()
 

--- a/Lib/test/test_interpreters/test_queues.py
+++ b/Lib/test/test_interpreters/test_queues.py
@@ -251,6 +251,34 @@ class TestQueueOps(TestBase):
         with self.assertRaises(queues.QueueEmpty):
             queue.get_nowait()
 
+    def test_put_get_default_sharedonly(self):
+        expected = list(range(20))
+        queue = queues.create(sharedonly=True)
+        for i in range(20):
+            queue.put(i)
+        actual = [queue.get() for _ in range(20)]
+
+        self.assertEqual(actual, expected)
+
+        obj = [1, 2, 3]  # lists are not shareable
+        with self.assertRaises(interpreters.NotShareableError):
+            queue.put(obj)
+
+    def test_put_get_default_not_sharedonly(self):
+        expected = list(range(20))
+        queue = queues.create(sharedonly=False)
+        for i in range(20):
+            queue.put(i)
+        actual = [queue.get() for _ in range(20)]
+
+        self.assertEqual(actual, expected)
+
+        obj = [1, 2, 3]  # lists are not shareable
+        queue.put(obj)
+        obj2 = queue.get()
+        self.assertEqual(obj, obj2)
+        self.assertIsNot(obj, obj2)
+
     def test_put_get_same_interpreter(self):
         interp = interpreters.create()
         interp.exec_sync(dedent("""

--- a/Lib/test/test_interpreters/test_queues.py
+++ b/Lib/test/test_interpreters/test_queues.py
@@ -20,50 +20,50 @@ class TestBase(TestBase):
                 pass
 
 
-class QueueTests(TestBase):
+class SharedQueueTests(TestBase):
 
     def test_create(self):
         with self.subTest('vanilla'):
-            queue = queues.create()
+            queue = queues.create_shared()
             self.assertEqual(queue.maxsize, 0)
 
         with self.subTest('small maxsize'):
-            queue = queues.create(3)
+            queue = queues.create_shared(3)
             self.assertEqual(queue.maxsize, 3)
 
         with self.subTest('big maxsize'):
-            queue = queues.create(100)
+            queue = queues.create_shared(100)
             self.assertEqual(queue.maxsize, 100)
 
         with self.subTest('no maxsize'):
-            queue = queues.create(0)
+            queue = queues.create_shared(0)
             self.assertEqual(queue.maxsize, 0)
 
         with self.subTest('negative maxsize'):
-            queue = queues.create(-10)
+            queue = queues.create_shared(-10)
             self.assertEqual(queue.maxsize, -10)
 
         with self.subTest('bad maxsize'):
             with self.assertRaises(TypeError):
-                queues.create('1')
+                queues.create_shared('1')
 
     def test_shareable(self):
-        queue1 = queues.create()
+        queue1 = queues.create_shared()
 
         interp = interpreters.create()
         interp.exec_sync(dedent(f"""
             from test.support.interpreters import queues
-            queue1 = queues.Queue({queue1.id})
+            queue1 = queues.SharedQueue({queue1.id})
             """));
 
         with self.subTest('same interpreter'):
-            queue2 = queues.create()
+            queue2 = queues.create_shared()
             queue1.put(queue2)
             queue3 = queue1.get()
             self.assertIs(queue3, queue2)
 
         with self.subTest('from current interpreter'):
-            queue4 = queues.create()
+            queue4 = queues.create_shared()
             queue1.put(queue4)
             out = _run_output(interp, dedent("""
                 queue4 = queue1.get()
@@ -74,7 +74,7 @@ class QueueTests(TestBase):
 
         with self.subTest('from subinterpreter'):
             out = _run_output(interp, dedent("""
-                queue5 = queues.create()
+                queue5 = queues.create_shared()
                 queue1.put(queue5)
                 print(queue5.id)
                 """))
@@ -83,40 +83,40 @@ class QueueTests(TestBase):
             self.assertEqual(queue5.id, qid)
 
     def test_id_type(self):
-        queue = queues.create()
+        queue = queues.create_shared()
         self.assertIsInstance(queue.id, int)
 
     def test_custom_id(self):
         with self.assertRaises(queues.QueueNotFoundError):
-            queues.Queue(1_000_000)
+            queues.SharedQueue(1_000_000)
 
     def test_id_readonly(self):
-        queue = queues.create()
+        queue = queues.create_shared()
         with self.assertRaises(AttributeError):
             queue.id = 1_000_000
 
     def test_maxsize_readonly(self):
-        queue = queues.create(10)
+        queue = queues.create_shared(10)
         with self.assertRaises(AttributeError):
             queue.maxsize = 1_000_000
 
     def test_hashable(self):
-        queue = queues.create()
+        queue = queues.create_shared()
         expected = hash(queue.id)
         actual = hash(queue)
         self.assertEqual(actual, expected)
 
     def test_equality(self):
-        queue1 = queues.create()
-        queue2 = queues.create()
+        queue1 = queues.create_shared()
+        queue2 = queues.create_shared()
         self.assertEqual(queue1, queue1)
         self.assertNotEqual(queue1, queue2)
 
 
-class TestQueueOps(TestBase):
+class TestSharedQueueOps(TestBase):
 
     def test_empty(self):
-        queue = queues.create()
+        queue = queues.create_shared()
         before = queue.empty()
         queue.put(None)
         during = queue.empty()
@@ -130,7 +130,7 @@ class TestQueueOps(TestBase):
     def test_full(self):
         expected = [False, False, False, True, False, False, False]
         actual = []
-        queue = queues.create(3)
+        queue = queues.create_shared(3)
         for _ in range(3):
             actual.append(queue.full())
             queue.put(None)
@@ -144,7 +144,7 @@ class TestQueueOps(TestBase):
     def test_qsize(self):
         expected = [0, 1, 2, 3, 2, 3, 2, 1, 0, 1, 0]
         actual = []
-        queue = queues.create()
+        queue = queues.create_shared()
         for _ in range(3):
             actual.append(queue.qsize())
             queue.put(None)
@@ -165,7 +165,7 @@ class TestQueueOps(TestBase):
 
     def test_put_get_main(self):
         expected = list(range(20))
-        queue = queues.create()
+        queue = queues.create_shared()
         for i in range(20):
             queue.put(i)
         actual = [queue.get() for _ in range(20)]
@@ -173,7 +173,7 @@ class TestQueueOps(TestBase):
         self.assertEqual(actual, expected)
 
     def test_put_timeout(self):
-        queue = queues.create(2)
+        queue = queues.create_shared(2)
         queue.put(None)
         queue.put(None)
         with self.assertRaises(queues.QueueFull):
@@ -182,7 +182,7 @@ class TestQueueOps(TestBase):
         queue.put(None)
 
     def test_put_nowait(self):
-        queue = queues.create(2)
+        queue = queues.create_shared(2)
         queue.put_nowait(None)
         queue.put_nowait(None)
         with self.assertRaises(queues.QueueFull):
@@ -191,12 +191,12 @@ class TestQueueOps(TestBase):
         queue.put_nowait(None)
 
     def test_get_timeout(self):
-        queue = queues.create()
+        queue = queues.create_shared()
         with self.assertRaises(queues.QueueEmpty):
             queue.get(timeout=0.1)
 
     def test_get_nowait(self):
-        queue = queues.create()
+        queue = queues.create_shared()
         with self.assertRaises(queues.QueueEmpty):
             queue.get_nowait()
 
@@ -204,7 +204,7 @@ class TestQueueOps(TestBase):
         interp = interpreters.create()
         interp.exec_sync(dedent("""
             from test.support.interpreters import queues
-            queue = queues.create()
+            queue = queues.create_shared()
             orig = b'spam'
             queue.put(orig)
             obj = queue.get()
@@ -214,8 +214,8 @@ class TestQueueOps(TestBase):
 
     def test_put_get_different_interpreters(self):
         interp = interpreters.create()
-        queue1 = queues.create()
-        queue2 = queues.create()
+        queue1 = queues.create_shared()
+        queue2 = queues.create_shared()
         self.assertEqual(len(queues.list_all()), 2)
 
         obj1 = b'spam'
@@ -225,8 +225,8 @@ class TestQueueOps(TestBase):
             interp,
             dedent(f"""
                 from test.support.interpreters import queues
-                queue1 = queues.Queue({queue1.id})
-                queue2 = queues.Queue({queue2.id})
+                queue1 = queues.SharedQueue({queue1.id})
+                queue2 = queues.SharedQueue({queue2.id})
                 assert queue1.qsize() == 1, 'expected: queue1.qsize() == 1'
                 obj = queue1.get()
                 assert queue1.qsize() == 0, 'expected: queue1.qsize() == 0'
@@ -249,13 +249,13 @@ class TestQueueOps(TestBase):
 
     def test_put_cleared_with_subinterpreter(self):
         interp = interpreters.create()
-        queue = queues.create()
+        queue = queues.create_shared()
 
         out = _run_output(
             interp,
             dedent(f"""
                 from test.support.interpreters import queues
-                queue = queues.Queue({queue.id})
+                queue = queues.SharedQueue({queue.id})
                 obj1 = b'spam'
                 obj2 = b'eggs'
                 queue.put(obj1)
@@ -271,8 +271,8 @@ class TestQueueOps(TestBase):
         self.assertEqual(queue.qsize(), 0)
 
     def test_put_get_different_threads(self):
-        queue1 = queues.create()
-        queue2 = queues.create()
+        queue1 = queues.create_shared()
+        queue2 = queues.create_shared()
 
         def f():
             while True:

--- a/Lib/test/test_interpreters/test_queues.py
+++ b/Lib/test/test_interpreters/test_queues.py
@@ -51,7 +51,7 @@ class QueueTests(TestBase):
         queue1 = queues.create()
 
         interp = interpreters.create()
-        interp.exec_sync(dedent(f"""
+        interp.exec(dedent(f"""
             from test.support.interpreters import queues
             queue1 = queues.Queue({queue1.id})
             """));
@@ -281,7 +281,7 @@ class TestQueueOps(TestBase):
 
     def test_put_get_same_interpreter(self):
         interp = interpreters.create()
-        interp.exec_sync(dedent("""
+        interp.exec(dedent("""
             from test.support.interpreters import queues
             queue = queues.create()
             orig = b'spam'

--- a/Lib/test/test_interpreters/test_queues.py
+++ b/Lib/test/test_interpreters/test_queues.py
@@ -58,13 +58,13 @@ class QueueTests(TestBase):
 
         with self.subTest('same interpreter'):
             queue2 = queues.create()
-            queue1.put(queue2)
+            queue1.put(queue2, sharedonly=True)
             queue3 = queue1.get()
             self.assertIs(queue3, queue2)
 
         with self.subTest('from current interpreter'):
             queue4 = queues.create()
-            queue1.put(queue4)
+            queue1.put(queue4, sharedonly=True)
             out = _run_output(interp, dedent("""
                 queue4 = queue1.get()
                 print(queue4.id)
@@ -75,7 +75,7 @@ class QueueTests(TestBase):
         with self.subTest('from subinterpreter'):
             out = _run_output(interp, dedent("""
                 queue5 = queues.create()
-                queue1.put(queue5)
+                queue1.put(queue5, sharedonly=True)
                 print(queue5.id)
                 """))
             qid = int(out)
@@ -118,7 +118,7 @@ class TestQueueOps(TestBase):
     def test_empty(self):
         queue = queues.create()
         before = queue.empty()
-        queue.put(None)
+        queue.put(None, sharedonly=True)
         during = queue.empty()
         queue.get()
         after = queue.empty()
@@ -133,7 +133,7 @@ class TestQueueOps(TestBase):
         queue = queues.create(3)
         for _ in range(3):
             actual.append(queue.full())
-            queue.put(None)
+            queue.put(None, sharedonly=True)
         actual.append(queue.full())
         for _ in range(3):
             queue.get()
@@ -147,16 +147,16 @@ class TestQueueOps(TestBase):
         queue = queues.create()
         for _ in range(3):
             actual.append(queue.qsize())
-            queue.put(None)
+            queue.put(None, sharedonly=True)
         actual.append(queue.qsize())
         queue.get()
         actual.append(queue.qsize())
-        queue.put(None)
+        queue.put(None, sharedonly=True)
         actual.append(queue.qsize())
         for _ in range(3):
             queue.get()
             actual.append(queue.qsize())
-        queue.put(None)
+        queue.put(None, sharedonly=True)
         actual.append(queue.qsize())
         queue.get()
         actual.append(queue.qsize())
@@ -165,30 +165,81 @@ class TestQueueOps(TestBase):
 
     def test_put_get_main(self):
         expected = list(range(20))
-        queue = queues.create()
-        for i in range(20):
-            queue.put(i)
-        actual = [queue.get() for _ in range(20)]
+        for sharedonly in (True, False):
+            kwds = dict(sharedonly=sharedonly)
+            with self.subTest(f'sharedonly={sharedonly}'):
+                queue = queues.create()
+                for i in range(20):
+                    queue.put(i, **kwds)
+                actual = [queue.get() for _ in range(20)]
 
-        self.assertEqual(actual, expected)
+                self.assertEqual(actual, expected)
 
     def test_put_timeout(self):
-        queue = queues.create(2)
-        queue.put(None)
-        queue.put(None)
-        with self.assertRaises(queues.QueueFull):
-            queue.put(None, timeout=0.1)
-        queue.get()
-        queue.put(None)
+        for sharedonly in (True, False):
+            kwds = dict(sharedonly=sharedonly)
+            with self.subTest(f'sharedonly={sharedonly}'):
+                queue = queues.create(2)
+                queue.put(None, **kwds)
+                queue.put(None, **kwds)
+                with self.assertRaises(queues.QueueFull):
+                    queue.put(None, timeout=0.1, **kwds)
+                queue.get()
+                queue.put(None, **kwds)
 
     def test_put_nowait(self):
-        queue = queues.create(2)
-        queue.put_nowait(None)
-        queue.put_nowait(None)
-        with self.assertRaises(queues.QueueFull):
-            queue.put_nowait(None)
-        queue.get()
-        queue.put_nowait(None)
+        for sharedonly in (True, False):
+            kwds = dict(sharedonly=sharedonly)
+            with self.subTest(f'sharedonly={sharedonly}'):
+                queue = queues.create(2)
+                queue.put_nowait(None, **kwds)
+                queue.put_nowait(None, **kwds)
+                with self.assertRaises(queues.QueueFull):
+                    queue.put_nowait(None, **kwds)
+                queue.get()
+                queue.put_nowait(None, **kwds)
+
+    def test_put_sharedonly(self):
+        for obj in [
+            None,
+            True,
+            10,
+            'spam',
+            b'spam',
+            (0, 'a'),
+        ]:
+            with self.subTest(repr(obj)):
+                queue = queues.create()
+                queue.put(obj, sharedonly=True)
+                obj2 = queue.get()
+                self.assertEqual(obj2, obj)
+
+        for obj in [
+            [1, 2, 3],
+            {'a': 13, 'b': 17},
+        ]:
+            with self.subTest(repr(obj)):
+                queue = queues.create()
+                with self.assertRaises(interpreters.NotShareableError):
+                    queue.put(obj, sharedonly=True)
+
+    def test_put_not_sharedonly(self):
+        for obj in [
+            None,
+            True,
+            10,
+            'spam',
+            b'spam',
+            (0, 'a'),
+            # not shareable
+            [1, 2, 3],
+            {'a': 13, 'b': 17},
+        ]:
+            with self.subTest(repr(obj)):
+                queue = queues.create()
+                queue.put(obj, sharedonly=False)
+                obj2 = queue.get()
+                self.assertEqual(obj2, obj)
 
     def test_get_timeout(self):
         queue = queues.create()
@@ -206,7 +257,7 @@ class TestQueueOps(TestBase):
             from test.support.interpreters import queues
             queue = queues.create()
             orig = b'spam'
-            queue.put(orig)
+            queue.put(orig, sharedonly=True)
             obj = queue.get()
             assert obj == orig, 'expected: obj == orig'
             assert obj is not orig, 'expected: obj is not orig'
@@ -219,7 +270,7 @@ class TestQueueOps(TestBase):
         self.assertEqual(len(queues.list_all()), 2)
 
         obj1 = b'spam'
-        queue1.put(obj1)
+        queue1.put(obj1, sharedonly=True)
 
         out = _run_output(
             interp,
@@ -236,7 +287,7 @@ class TestQueueOps(TestBase):
                 obj2 = b'eggs'
                 print(id(obj2))
                 assert queue2.qsize() == 0, 'expected: queue2.qsize() == 0'
-                queue2.put(obj2)
+                queue2.put(obj2, sharedonly=True)
                 assert queue2.qsize() == 1, 'expected: queue2.qsize() == 1'
                 """))
         self.assertEqual(len(queues.list_all()), 2)
@@ -258,8 +309,8 @@ class TestQueueOps(TestBase):
                 queue = queues.Queue({queue.id})
                 obj1 = b'spam'
                 obj2 = b'eggs'
-                queue.put(obj1)
-                queue.put(obj2)
+                queue.put(obj1, sharedonly=True)
+                queue.put(obj2, sharedonly=True)
                 """))
         self.assertEqual(queue.qsize(), 2)
 
@@ -281,12 +332,12 @@ class TestQueueOps(TestBase):
                     break
                 except queues.QueueEmpty:
                     continue
-            queue2.put(obj)
+            queue2.put(obj, sharedonly=True)
         t = threading.Thread(target=f)
         t.start()
 
         orig = b'spam'
-        queue1.put(orig)
+        queue1.put(orig, sharedonly=True)
         obj = queue2.get()
         t.join()
 

--- a/Lib/test/test_interpreters/utils.py
+++ b/Lib/test/test_interpreters/utils.py
@@ -4,8 +4,9 @@ import os.path
 import subprocess
 import sys
 import tempfile
-import threading
 from textwrap import dedent
+import threading
+import types
 import unittest
 
 from test import support
@@ -83,6 +84,18 @@ class TestBase(unittest.TestCase):
         tempdir = os.path.realpath(tempdir)
         self.addCleanup(lambda: os_helper.rmtree(tempdir))
         return tempdir
+
+    @contextlib.contextmanager
+    def captured_thread_exception(self):
+        ctx = types.SimpleNamespace(caught=None)
+        def excepthook(args):
+            ctx.caught = args
+        orig_excepthook = threading.excepthook
+        threading.excepthook = excepthook
+        try:
+            yield ctx
+        finally:
+            threading.excepthook = orig_excepthook
 
     def make_script(self, filename, dirname=None, text=None):
         if text:

--- a/Lib/test/test_interpreters/utils.py
+++ b/Lib/test/test_interpreters/utils.py
@@ -41,7 +41,7 @@ def _run_output(interp, request, init=None):
     with rpipe:
         if init:
             interp.prepare_main(init)
-        interp.exec_sync(script)
+        interp.exec(script)
         return rpipe.read()
 
 
@@ -49,7 +49,7 @@ def _run_output(interp, request, init=None):
 def _running(interp):
     r, w = os.pipe()
     def run():
-        interp.exec_sync(dedent(f"""
+        interp.exec(dedent(f"""
             # wait for "signal"
             with open({r}) as rpipe:
                 rpipe.read()

--- a/Lib/test/test_sys.py
+++ b/Lib/test/test_sys.py
@@ -729,7 +729,7 @@ class SysModuleTest(unittest.TestCase):
         self.assertIs(t, s)
 
         interp = interpreters.create()
-        interp.exec_sync(textwrap.dedent(f'''
+        interp.exec(textwrap.dedent(f'''
             import sys
             t = sys.intern({s!r})
             assert id(t) != {id(s)}, (id(t), {id(s)})
@@ -744,7 +744,7 @@ class SysModuleTest(unittest.TestCase):
         t = sys.intern(s)
 
         interp = interpreters.create()
-        interp.exec_sync(textwrap.dedent(f'''
+        interp.exec(textwrap.dedent(f'''
             import sys
             t = sys.intern({s!r})
             assert id(t) == {id(t)}, (id(t), {id(t)})

--- a/Lib/test/test_threading.py
+++ b/Lib/test/test_threading.py
@@ -1478,7 +1478,7 @@ class SubinterpThreadingTests(BaseTestCase):
         DONE = b'D'
 
         interp = interpreters.create()
-        interp.exec_sync(f"""if True:
+        interp.exec(f"""if True:
             import os
             import threading
             import time

--- a/Modules/_xxinterpqueuesmodule.c
+++ b/Modules/_xxinterpqueuesmodule.c
@@ -294,6 +294,8 @@ handle_queue_error(int err, PyObject *mod, int64_t qid)
     case ERR_QUEUES_ALLOC:
         PyErr_NoMemory();
         break;
+    case -1:
+        return -1;
     default:
         state = get_module_state(mod);
         assert(state->QueueError != NULL);

--- a/Modules/_xxsubinterpretersmodule.c
+++ b/Modules/_xxsubinterpretersmodule.c
@@ -903,6 +903,56 @@ If a function is provided, its code object is used and all its state\n\
 is ignored, including its __globals__ dict.");
 
 static PyObject *
+interp_call(PyObject *self, PyObject *args, PyObject *kwds)
+{
+    static char *kwlist[] = {"id", "callable", "args", "kwargs", NULL};
+    PyObject *id, *callable;
+    PyObject *args_obj = NULL;
+    PyObject *kwargs_obj = NULL;
+    if (!PyArg_ParseTupleAndKeywords(args, kwds,
+                                     "OO|OO:" MODULE_NAME_STR ".call", kwlist,
+                                     &id, &callable, &args_obj, &kwargs_obj)) {
+        return NULL;
+    }
+
+    if (args_obj != NULL) {
+        PyErr_SetString(PyExc_ValueError, "got unexpected args");
+        return NULL;
+    }
+    if (kwargs_obj != NULL) {
+        PyErr_SetString(PyExc_ValueError, "got unexpected kwargs");
+        return NULL;
+    }
+
+    PyObject *code = (PyObject *)convert_code_arg(callable, MODULE_NAME_STR ".call",
+                                                  "argument 2", "a function");
+    if (code == NULL) {
+        return NULL;
+    }
+
+    PyObject *excinfo = NULL;
+    int res = _interp_exec(self, id, code, NULL, &excinfo);
+    Py_DECREF(code);
+    if (res < 0) {
+        assert((excinfo == NULL) != (PyErr_Occurred() == NULL));
+        return excinfo;
+    }
+    Py_RETURN_NONE;
+}
+
+PyDoc_STRVAR(call_doc,
+"call(id, callable, args=None, kwargs=None)\n\
+\n\
+Call the provided object in the identified interpreter.\n\
+Pass the given args and kwargs, if possible.\n\
+\n\
+\"callable\" may be a plain function with no free vars that takes\n\
+no arguments.\n\
+\n\
+The function's code object is used and all its state\n\
+is ignored, including its __globals__ dict.");
+
+static PyObject *
 interp_run_string(PyObject *self, PyObject *args, PyObject *kwds)
 {
     static char *kwlist[] = {"id", "script", "shared", NULL};
@@ -1085,6 +1135,8 @@ static PyMethodDef module_functions[] = {
      METH_VARARGS | METH_KEYWORDS, is_running_doc},
     {"exec",                      _PyCFunction_CAST(interp_exec),
      METH_VARARGS | METH_KEYWORDS, exec_doc},
+    {"call",                      _PyCFunction_CAST(interp_call),
+     METH_VARARGS | METH_KEYWORDS, call_doc},
     {"run_string",                _PyCFunction_CAST(interp_run_string),
      METH_VARARGS | METH_KEYWORDS, run_string_doc},
     {"run_func",                  _PyCFunction_CAST(interp_run_func),

--- a/Modules/_xxsubinterpretersmodule.c
+++ b/Modules/_xxsubinterpretersmodule.c
@@ -1113,6 +1113,7 @@ The 'interpreters' module provides a more convenient interface.");
 static int
 module_exec(PyObject *mod)
 {
+    PyInterpreterState *interp = PyInterpreterState_Get();
     module_state *state = get_module_state(mod);
 
     // exceptions
@@ -1120,6 +1121,11 @@ module_exec(PyObject *mod)
         goto error;
     }
     if (PyModule_AddType(mod, (PyTypeObject *)PyExc_InterpreterNotFoundError) < 0) {
+        goto error;
+    }
+    PyObject *PyExc_NotShareableError = \
+                _PyInterpreterState_GetXIState(interp)->PyExc_NotShareableError;
+    if (PyModule_AddType(mod, (PyTypeObject *)PyExc_NotShareableError) < 0) {
         goto error;
     }
 


### PR DESCRIPTION
This brings the code under test.support.interpreters, and the corresponding extension modules, in line with recent updates to PEP 734.

(Note: PEP 734 has not been accepted at this time.  However, we are using an internal copy of the implementation in the test suite to exercise the existing subinterpreters feature.)

<!-- gh-issue-number: gh-76785 -->
* Issue: gh-76785
<!-- /gh-issue-number -->
