### PR TITLE
gh-101100: Fix Sphinx warnings in `whatsnew/3.1.rst`

### DIFF
--- a/Doc/tools/.nitignore
+++ b/Doc/tools/.nitignore
@@ -86,7 +86,6 @@ Doc/whatsnew/2.5.rst
 Doc/whatsnew/2.6.rst
 Doc/whatsnew/2.7.rst
 Doc/whatsnew/3.0.rst
-Doc/whatsnew/3.1.rst
 Doc/whatsnew/3.2.rst
 Doc/whatsnew/3.3.rst
 Doc/whatsnew/3.4.rst

--- a/Doc/whatsnew/3.1.rst
+++ b/Doc/whatsnew/3.1.rst
@@ -174,7 +174,7 @@ Some smaller changes made to the core Python language are:
 
   (Contributed by Eric Smith; :issue:`5237`.)
 
-* The :func:`string.maketrans` function is deprecated and is replaced by new
+* The :func:`!string.maketrans` function is deprecated and is replaced by new
   static methods, :meth:`bytes.maketrans` and :meth:`bytearray.maketrans`.
   This change solves the confusion around which types were supported by the
   :mod:`string` module. Now, :class:`str`, :class:`bytes`, and
@@ -381,16 +381,20 @@ New, Improved, and Deprecated Modules
               x / 0
 
   In addition, several new assertion methods were added including
-  :func:`assertSetEqual`, :func:`assertDictEqual`,
-  :func:`assertDictContainsSubset`, :func:`assertListEqual`,
-  :func:`assertTupleEqual`, :func:`assertSequenceEqual`,
-  :func:`assertRaisesRegexp`, :func:`assertIsNone`,
-  and :func:`assertIsNotNone`.
+  :meth:`~unittest.TestCase.assertSetEqual`,
+  :meth:`~unittest.TestCase.assertDictEqual`,
+  :meth:`!assertDictContainsSubset`,
+  :meth:`~unittest.TestCase.assertListEqual`,
+  :meth:`~unittest.TestCase.assertTupleEqual`,
+  :meth:`~unittest.TestCase.assertSequenceEqual`,
+  :meth:`assertRaisesRegexp() <unittest.TestCase.assertRaisesRegex>`,
+  :meth:`~unittest.TestCase.assertIsNone`,
+  and :meth:`~unittest.TestCase.assertIsNotNone`.
 
   (Contributed by Benjamin Peterson and Antoine Pitrou.)
 
-* The :mod:`io` module has three new constants for the :meth:`seek`
-  method :data:`SEEK_SET`, :data:`SEEK_CUR`, and :data:`SEEK_END`.
+* The :mod:`io` module has three new constants for the :meth:`~io.IOBase.seek`
+  method: :data:`~os.SEEK_SET`, :data:`~os.SEEK_CUR`, and :data:`~os.SEEK_END`.
 
 * The :data:`sys.version_info` tuple is now a named tuple::
 

--- a/Doc/whatsnew/3.1.rst
+++ b/Doc/whatsnew/3.1.rst
@@ -81,7 +81,7 @@ Support was also added for third-party tools like `PyYAML <https://pyyaml.org/>`
       written by Raymond Hettinger.
 
 Since an ordered dictionary remembers its insertion order, it can be used
-in conjuction with sorting to make a sorted dictionary::
+in conjunction with sorting to make a sorted dictionary::
 
     >>> # regular unsorted dictionary
     >>> d = {'banana': 3, 'apple':4, 'pear': 1, 'orange': 2}


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

Fix 14 Sphinx warnings:

```
Doc/whatsnew/3.1.rst:177: WARNING: py:func reference target not found: string.maketrans
Doc/whatsnew/3.1.rst:383: WARNING: py:func reference target not found: assertSetEqual
Doc/whatsnew/3.1.rst:383: WARNING: py:func reference target not found: assertDictEqual
Doc/whatsnew/3.1.rst:383: WARNING: py:func reference target not found: assertDictContainsSubset
Doc/whatsnew/3.1.rst:383: WARNING: py:func reference target not found: assertListEqual
Doc/whatsnew/3.1.rst:383: WARNING: py:func reference target not found: assertTupleEqual
Doc/whatsnew/3.1.rst:383: WARNING: py:func reference target not found: assertSequenceEqual
Doc/whatsnew/3.1.rst:383: WARNING: py:func reference target not found: assertRaisesRegexp
Doc/whatsnew/3.1.rst:383: WARNING: py:func reference target not found: assertIsNone
Doc/whatsnew/3.1.rst:383: WARNING: py:func reference target not found: assertIsNotNone
Doc/whatsnew/3.1.rst:392: WARNING: py:meth reference target not found: seek
Doc/whatsnew/3.1.rst:392: WARNING: py:data reference target not found: SEEK_SET
Doc/whatsnew/3.1.rst:392: WARNING: py:data reference target not found: SEEK_CUR
Doc/whatsnew/3.1.rst:392: WARNING: py:data reference target not found: SEEK_END
```


<!-- gh-issue-number: gh-101100 -->
* Issue: gh-101100
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--115575.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->