### PR TITLE
Improve readability in the docs for Popen capture_output

### DIFF
--- a/Doc/library/subprocess.rst
+++ b/Doc/library/subprocess.rst
@@ -50,10 +50,10 @@ underlying :class:`Popen` interface can be used directly.
    this function are passed through to that interface. (*timeout*,  *input*,
    *check*, and *capture_output* are not.)
 
-   If *capture_output* is true, stdout and stderr will be captured.
-   When used, the internal :class:`Popen` object is automatically created with
-   ``stdout=PIPE`` and ``stderr=PIPE``. The *stdout* and *stderr* arguments may
-   not be supplied at the same time as *capture_output*.  If you wish to capture
+   If *capture_output* is true, stdout and stderr will be captured. In this
+   scenario, the internal :class:`Popen` object is automatically created with
+   ``stdout=PIPE`` and ``stderr=PIPE``. You must not specify any values for
+   *stdout* and *stderr* arguments in this case. If you wish to capture
    and combine both streams into one, use ``stdout=PIPE`` and ``stderr=STDOUT``
    instead of *capture_output*.
 


### PR DESCRIPTION
This is a trivial documentation change. I had to read this paragraph way too many times today before I understood what it was saying.

1. The phrase "When used" was throwing me off. I think the original author meant "When this feature is used".

I changed it to "In this scenario", which flows better coming from the previous sentence.

2. After reading the whole paragraph some more, I took issue with the sentence:

> The *stdout* and *stderr* arguments may not be supplied at the same time as *capture_output*.

The code from subprocess.py is:

```
    if capture_output:
        if kwargs.get('stdout') is not None or kwargs.get('stderr') is not None:
            raise ValueError('stdout and stderr arguments may not be used '
                             'with capture_output.')
        kwargs['stdout'] = PIPE
        kwargs['stderr'] = PIPE
```

It seems to me like *supplying* `capture_output=False` along with `stdout` and `stderr` kwargs is just fine. 

Another critique (which is probably beating a dead horse at this point) is that "at the same time" isn't completely correct, it's more like "in the same instance".

I think the word "you" fits well in this sentence. Some people have taken issue with the use of the word "you" in technical documentation ([Avoid addressing the user directly when writing docs?](https://discuss.python.org/t/avoid-addressing-the-user-directly-when-writing-docs/11671/1)), but readability trumps dogma. Anyways, the last sentence already addresses "you", and I see other places in this page doing the same as well. I think it's a great style to use for both the writer and the reader.

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--115581.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->