### PR TITLE
[3.11] gh-100985: Consistently wrap IPv6 IP address during CONNECT (GH-100986)

### DIFF
--- a/Lib/http/client.py
+++ b/Lib/http/client.py
@@ -907,17 +907,23 @@ class HTTPConnection:
                 host = host[:i]
             else:
                 port = self.default_port
-            if host and host[0] == '[' and host[-1] == ']':
-                host = host[1:-1]
+        if host and host[0] == '[' and host[-1] == ']':
+            host = host[1:-1]
 
         return (host, port)
 
     def set_debuglevel(self, level):
         self.debuglevel = level
 
+    def _wrap_ipv6(self, ip):
+        if b':' in ip and ip[0] != b'['[0]:
+            return b"[" + ip + b"]"
+        return ip
+
     def _tunnel(self):
         connect = b"CONNECT %s:%d HTTP/1.0\r\n" % (
-            self._tunnel_host.encode("ascii"), self._tunnel_port)
+            self._wrap_ipv6(self._tunnel_host.encode("ascii")),
+            self._tunnel_port)
         headers = [connect]
         for header, value in self._tunnel_headers.items():
             headers.append(f"{header}: {value}\r\n".encode("latin-1"))
@@ -1188,9 +1194,8 @@ class HTTPConnection:
 
                     # As per RFC 273, IPv6 address should be wrapped with []
                     # when used as Host header
-
+                    host_enc = self._wrap_ipv6(host_enc)
                     if ":" in host:
-                        host_enc = b'[' + host_enc + b']'
                         host_enc = _strip_ipv6_iface(host_enc)
 
                     if port == self.default_port:

--- a/Lib/test/test_httplib.py
+++ b/Lib/test/test_httplib.py
@@ -2267,6 +2267,22 @@ class TunnelTests(TestCase):
         self.assertIn(b'CONNECT destination.com', self.conn.sock.data)
         self.assertIn(b'Host: destination.com', self.conn.sock.data)
 
+    def test_connect_put_request_ipv6(self):
+        self.conn.set_tunnel('[1:2:3::4]', 1234)
+        self.conn.request('PUT', '/', '')
+        self.assertEqual(self.conn.sock.host, self.host)
+        self.assertEqual(self.conn.sock.port, client.HTTP_PORT)
+        self.assertIn(b'CONNECT [1:2:3::4]:1234', self.conn.sock.data)
+        self.assertIn(b'Host: [1:2:3::4]:1234', self.conn.sock.data)
+
+    def test_connect_put_request_ipv6_port(self):
+        self.conn.set_tunnel('[1:2:3::4]:1234')
+        self.conn.request('PUT', '/', '')
+        self.assertEqual(self.conn.sock.host, self.host)
+        self.assertEqual(self.conn.sock.port, client.HTTP_PORT)
+        self.assertIn(b'CONNECT [1:2:3::4]:1234', self.conn.sock.data)
+        self.assertIn(b'Host: [1:2:3::4]:1234', self.conn.sock.data)
+
     def test_tunnel_debuglog(self):
         expected_header = 'X-Dummy: 1'
         response_text = 'HTTP/1.0 200 OK\r\n{}\r\n\r\n'.format(expected_header)

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -740,6 +740,7 @@ Raymond Hettinger
 Lisa Hewus Fresh
 Kevan Heydon
 Wouter van Heyst
+Derek Higgins
 Kelsey Hightower
 Jason Hildebrand
 Ryan Hileman

--- a/Misc/NEWS.d/next/Library/2023-01-12-14-16-01.gh-issue-100985.GT5Fvd.rst
+++ b/Misc/NEWS.d/next/Library/2023-01-12-14-16-01.gh-issue-100985.GT5Fvd.rst
@@ -1,0 +1,2 @@
+Update HTTPSConnection to consistently wrap IPv6 Addresses when using a
+proxy.


### PR DESCRIPTION
Update _get_hostport to always remove square brackets from IPv6 addresses. Then add them if needed
in "CONNECT .." and "Host: ".
(cherry picked from commit 465db27cb983084e718a1fd9519b2726c96935cb)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-100985 -->
* Issue: gh-100985
<!-- /gh-issue-number -->
