### PR TITLE
gh-115596: Fix `ProgramPriorityTests` in `test_os` permanently changing the process priority

### DIFF
--- a/Lib/test/test_os.py
+++ b/Lib/test/test_os.py
@@ -3505,7 +3505,6 @@ class LoginTests(unittest.TestCase):
 class ProgramPriorityTests(unittest.TestCase):
     """Tests for os.getpriority() and os.setpriority()."""
 
-    @support.requires_subprocess()
     def test_set_get_priority(self):
         base = os.getpriority(os.PRIO_PROCESS, os.getpid())
         code = f"""if 1:

--- a/Lib/test/test_os.py
+++ b/Lib/test/test_os.py
@@ -3515,9 +3515,8 @@ class ProgramPriorityTests(unittest.TestCase):
         """
 
         # Subprocess inherits the current process' priority.
-        proc = subprocess.run([sys.executable, "-c", code], check=True,
-                              stdout=subprocess.PIPE, text=True)
-        new_prio = int(proc.stdout.rstrip())
+        _, out, _ = assert_python_ok("-c", code)
+        new_prio = int(out.decode("utf-8"))
         # nice value cap is 19 for linux and 20 for FreeBSD
         if base >= 19 and new_prio <= base:
             raise unittest.SkipTest("unable to reliably test setpriority "

--- a/Lib/test/test_os.py
+++ b/Lib/test/test_os.py
@@ -3515,7 +3515,7 @@ class ProgramPriorityTests(unittest.TestCase):
 
         # Subprocess inherits the current process' priority.
         _, out, _ = assert_python_ok("-c", code)
-        new_prio = int(out.decode("utf-8"))
+        new_prio = int(out)
         # nice value cap is 19 for linux and 20 for FreeBSD
         if base >= 19 and new_prio <= base:
             raise unittest.SkipTest("unable to reliably test setpriority "

--- a/Misc/NEWS.d/next/Tests/2024-02-17-08-25-01.gh-issue-115596.RGPCrR.rst
+++ b/Misc/NEWS.d/next/Tests/2024-02-17-08-25-01.gh-issue-115596.RGPCrR.rst
@@ -1,0 +1,2 @@
+Fix ``ProgramPriorityTests`` in ``test_os`` permanently changing the process
+priority.


### PR DESCRIPTION
Fixes #115596

Runs the priority setting logic from `ProgramPriorityTests.test_set_get_priority`  in a subprocess to prevent the priority change from taking permanent effect.

<!-- gh-issue-number: gh-115596 -->
* Issue: gh-115596
<!-- /gh-issue-number -->
