### PR TITLE
gh-115618: Remove improper Py_XDECREFs in property methods

### DIFF
--- a/Lib/test/test_property.py
+++ b/Lib/test/test_property.py
@@ -183,6 +183,24 @@ class PropertyTests(unittest.TestCase):
             fake_prop.__init__('fget', 'fset', 'fdel', 'doc')
         self.assertAlmostEqual(gettotalrefcount() - refs_before, 0, delta=10)
 
+    @support.refcount_test
+    def test_gh_115618(self):
+        # Py_XDECREF() was improperly called for None argument
+        # in property methods.
+        gettotalrefcount = support.get_attribute(sys, 'gettotalrefcount')
+        prop = property()
+        refs_before = gettotalrefcount()
+        for i in range(100):
+            prop = prop.getter(None)
+        self.assertIsNone(prop.fget)
+        for i in range(100):
+            prop = prop.setter(None)
+        self.assertIsNone(prop.fset)
+        for i in range(100):
+            prop = prop.deleter(None)
+        self.assertIsNone(prop.fdel)
+        self.assertAlmostEqual(gettotalrefcount() - refs_before, 0, delta=10)
+
     def test_property_set_name_incorrect_args(self):
         p = property()
 

--- a/Misc/NEWS.d/next/Library/2024-02-17-18-47-12.gh-issue-115618.napiNp.rst
+++ b/Misc/NEWS.d/next/Library/2024-02-17-18-47-12.gh-issue-115618.napiNp.rst
@@ -1,0 +1,3 @@
+Fix improper decreasing the reference count for ``None`` argument in
+:class:`property` methods :meth:`~property.getter`, :meth:`~property.setter`
+and :meth:`~property.deleter`.

--- a/Objects/descrobject.c
+++ b/Objects/descrobject.c
@@ -1730,15 +1730,12 @@ property_copy(PyObject *old, PyObject *get, PyObject *set, PyObject *del)
         return NULL;
 
     if (get == NULL || get == Py_None) {
-        Py_XDECREF(get);
         get = pold->prop_get ? pold->prop_get : Py_None;
     }
     if (set == NULL || set == Py_None) {
-        Py_XDECREF(set);
         set = pold->prop_set ? pold->prop_set : Py_None;
     }
     if (del == NULL || del == Py_None) {
-        Py_XDECREF(del);
         del = pold->prop_del ? pold->prop_del : Py_None;
     }
     if (pold->getter_doc && get != Py_None) {


### PR DESCRIPTION


<!-- gh-issue-number: gh-115618 -->
* Issue: gh-115618
<!-- /gh-issue-number -->
