### PR TITLE
gh-111358: Fix timeout behaviour in BaseEventLoop.shutdown_default_executor

### DIFF
--- a/Lib/asyncio/base_events.py
+++ b/Lib/asyncio/base_events.py
@@ -45,6 +45,7 @@ from . import protocols
 from . import sslproto
 from . import staggered
 from . import tasks
+from . import timeouts
 from . import transports
 from . import trsock
 from .log import logger
@@ -598,23 +599,24 @@ class BaseEventLoop(events.AbstractEventLoop):
         thread = threading.Thread(target=self._do_shutdown, args=(future,))
         thread.start()
         try:
-            await future
-        finally:
-            thread.join(timeout)
-
-        if thread.is_alive():
+            async with timeouts.timeout(timeout):
+                await future
+        except TimeoutError:
             warnings.warn("The executor did not finishing joining "
-                             f"its threads within {timeout} seconds.",
-                             RuntimeWarning, stacklevel=2)
+                          f"its threads within {timeout} seconds.",
+                          RuntimeWarning, stacklevel=2)
             self._default_executor.shutdown(wait=False)
+        else:
+            thread.join()
 
     def _do_shutdown(self, future):
         try:
             self._default_executor.shutdown(wait=True)
             if not self.is_closed():
-                self.call_soon_threadsafe(future.set_result, None)
+                self.call_soon_threadsafe(futures._set_result_unless_cancelled,
+                                          future, None)
         except Exception as ex:
-            if not self.is_closed():
+            if not self.is_closed() and not future.cancelled():
                 self.call_soon_threadsafe(future.set_exception, ex)
 
     def _check_running(self):

--- a/Lib/test/test_asyncio/test_base_events.py
+++ b/Lib/test/test_asyncio/test_base_events.py
@@ -231,6 +231,24 @@ class BaseEventLoopTests(test_utils.TestCase):
 
         self.assertIsNone(self.loop._default_executor)
 
+    def test_shutdown_default_executor_timeout(self):
+        class DummyExecutor(concurrent.futures.ThreadPoolExecutor):
+            def shutdown(self, wait=True, *, cancel_futures=False):
+                if wait:
+                    time.sleep(0.1)
+
+        self.loop._process_events = mock.Mock()
+        self.loop._write_to_self = mock.Mock()
+        executor = DummyExecutor()
+        self.loop.set_default_executor(executor)
+
+        with warnings.catch_warnings(record=True) as w:
+            self.loop.run_until_complete(
+                self.loop.shutdown_default_executor(timeout=0.01))
+
+        self.assertEqual(len(w), 1)
+        self.assertIsInstance(w[0].message, RuntimeWarning)
+
     def test_call_soon(self):
         def cb():
             pass

--- a/Lib/test/test_asyncio/test_base_events.py
+++ b/Lib/test/test_asyncio/test_base_events.py
@@ -242,13 +242,10 @@ class BaseEventLoopTests(test_utils.TestCase):
         executor = DummyExecutor()
         self.loop.set_default_executor(executor)
 
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter("default")
+        with self.assertWarnsRegex(RuntimeWarning,
+                                   "The executor did not finishing joining"):
             self.loop.run_until_complete(
                 self.loop.shutdown_default_executor(timeout=0.01))
-
-        self.assertEqual(len(w), 1)
-        self.assertIsInstance(w[0].message, RuntimeWarning)
 
     def test_call_soon(self):
         def cb():

--- a/Lib/test/test_asyncio/test_base_events.py
+++ b/Lib/test/test_asyncio/test_base_events.py
@@ -243,6 +243,7 @@ class BaseEventLoopTests(test_utils.TestCase):
         self.loop.set_default_executor(executor)
 
         with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("default")
             self.loop.run_until_complete(
                 self.loop.shutdown_default_executor(timeout=0.01))
 

--- a/Misc/NEWS.d/next/Library/2024-02-18-12-18-12.gh-issue-111358.9yJUMD.rst
+++ b/Misc/NEWS.d/next/Library/2024-02-18-12-18-12.gh-issue-111358.9yJUMD.rst
@@ -1,0 +1,2 @@
+Fix a bug in :meth:`asyncio.BaseEventLoop.shutdown_default_executor` to
+ensure the timeout passed to the coroutine behaves as expected.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

Fixes the timeout behaviour in `asyncio.BaseEventLoop.shutdown_default_executor` to ensure that the coroutine correctly times-out when awaiting the shutdown thread.

If the timeout is reaching, the thread is left to run, and is not joined (since waiting for the thread to join in this case would exceed the timeout). The Executor is shutdown without waiting.

Minor updates to `_do_shutdown` to ensure future isn't cancelled. This is necessary since the thread can still run and attempt to set the future result/exception

<!-- gh-issue-number: gh-111358 -->
* Issue: gh-111358
<!-- /gh-issue-number -->
