### PR TITLE
gh-115398: Expose Expat >=2.6.0 reparse deferral API (CVE-2023-52425)

### DIFF
--- a/Doc/library/pyexpat.rst
+++ b/Doc/library/pyexpat.rst
@@ -196,13 +196,13 @@ XMLParser Objects
    :exc:`ExpatError` to be raised with the :attr:`code` attribute set to
    ``errors.codes[errors.XML_ERROR_CANT_CHANGE_FEATURE_ONCE_PARSING]``.
 
+.. method:: xmlparser.SetReparseDeferralEnabled(enabled)
+
 .. warning::
 
    Calling ``SetReparseDeferralEnabled(False)`` has security implications,
    as detailed below; please make sure to understand these consequences
    prior to using the ``SetReparseDeferralEnabled`` method.
-
-.. method:: xmlparser.SetReparseDeferralEnabled(enabled)
 
    Expat 2.6.0 introduced a security mechanism called "reparse deferral"
    where instead of causing denial of service through quadratic runtime

--- a/Doc/library/pyexpat.rst
+++ b/Doc/library/pyexpat.rst
@@ -217,10 +217,14 @@ XMLParser Objects
    Calling ``SetReparseDeferralEnabled(True)`` allows re-enabling reparse
    deferral.
 
+   .. versionadded:: 3.13
+
 .. method:: xmlparser.GetReparseDeferralEnabled()
 
    Returns whether reparse deferral is currently enabled for the given
    Expat parser instance.
+
+   .. versionadded:: 3.13
 
 
 :class:`xmlparser` objects have the following attributes:

--- a/Doc/library/pyexpat.rst
+++ b/Doc/library/pyexpat.rst
@@ -198,11 +198,11 @@ XMLParser Objects
 
 .. method:: xmlparser.SetReparseDeferralEnabled(enabled)
 
-.. warning::
+   .. warning::
 
-   Calling ``SetReparseDeferralEnabled(False)`` has security implications,
-   as detailed below; please make sure to understand these consequences
-   prior to using the ``SetReparseDeferralEnabled`` method.
+      Calling ``SetReparseDeferralEnabled(False)`` has security implications,
+      as detailed below; please make sure to understand these consequences
+      prior to using the ``SetReparseDeferralEnabled`` method.
 
    Expat 2.6.0 introduced a security mechanism called "reparse deferral"
    where instead of causing denial of service through quadratic runtime

--- a/Doc/library/pyexpat.rst
+++ b/Doc/library/pyexpat.rst
@@ -196,6 +196,33 @@ XMLParser Objects
    :exc:`ExpatError` to be raised with the :attr:`code` attribute set to
    ``errors.codes[errors.XML_ERROR_CANT_CHANGE_FEATURE_ONCE_PARSING]``.
 
+.. warning::
+
+   Calling ``SetReparseDeferralEnabled(False)`` has security implications,
+   as detailed below; please make sure to understand these consequences
+   prior to using the ``SetReparseDeferralEnabled`` method.
+
+.. method:: xmlparser.SetReparseDeferralEnabled(enabled)
+
+   Expat 2.6.0 introduced a security mechanism called "reparse deferral"
+   where instead of causing denial of service through quadratic runtime
+   from reparsing large tokens, reparsing of unfinished tokens is now delayed
+   by default until a sufficient amount of input is reached.
+   Due to this delay, registered handlers may — depending of the sizing of
+   input chunks pushed to Expat — no longer be called right after pushing new
+   input to the parser.  Where immediate feedback and taking over responsiblity
+   of protecting against denial of service from large tokens are both wanted,
+   calling ``SetReparseDeferralEnabled(False)`` disables reparse deferral
+   for the current Expat parser instance, temporarily or altogether.
+   Calling ``SetReparseDeferralEnabled(True)`` allows re-enabling reparse
+   deferral.
+
+.. method:: xmlparser.GetReparseDeferralEnabled()
+
+   Returns whether reparse deferral is currently enabled for the given
+   Expat parser instance.
+
+
 :class:`xmlparser` objects have the following attributes:
 
 

--- a/Doc/library/xml.etree.elementtree.rst
+++ b/Doc/library/xml.etree.elementtree.rst
@@ -166,6 +166,11 @@ data but would still like to have incremental parsing capabilities, take a look
 at :func:`iterparse`.  It can be useful when you're reading a large XML document
 and don't want to hold it wholly in memory.
 
+Where _immediate_ feedback through events is wanted, calling method
+:meth:`XMLPullParser.flush` can help reduce delay;
+please make sure to study the related security notes.
+
+
 Finding interesting elements
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/Doc/library/xml.etree.elementtree.rst
+++ b/Doc/library/xml.etree.elementtree.rst
@@ -1387,6 +1387,16 @@ XMLParser Objects
 
       Feeds data to the parser.  *data* is encoded data.
 
+
+   .. method:: flush()
+
+      Triggers parsing of any previously fed unparsed data, which can be
+      used to ensure more immediate feedback, in particular with Expat >=2.6.0.
+      The implementation of :meth:`flush` temporarily disables reparse deferral
+      with Expat (if currently enabled) and triggers a reparse.
+      Disabling reparse deferral has security consequences; please see
+      :meth:`xml.parsers.expat.xmlparser.SetReparseDeferralEnabled` for details.
+
    :meth:`XMLParser.feed` calls *target*\'s ``start(tag, attrs_dict)`` method
    for each opening tag, its ``end(tag)`` method for each closing tag, and data
    is processed by method ``data(data)``.  For further supported callback

--- a/Doc/library/xml.etree.elementtree.rst
+++ b/Doc/library/xml.etree.elementtree.rst
@@ -1458,6 +1458,15 @@ XMLPullParser Objects
 
       Feed the given bytes data to the parser.
 
+   .. method:: flush()
+
+      Triggers parsing of any previously fed unparsed data, which can be
+      used to ensure more immediate feedback, in particular with Expat >=2.6.0.
+      The implementation of :meth:`flush` temporarily disables reparse deferral
+      with Expat (if currently enabled) and triggers a reparse.
+      Disabling reparse deferral has security consequences; please see
+      :meth:`xml.parsers.expat.xmlparser.SetReparseDeferralEnabled` for details.
+
    .. method:: close()
 
       Signal the parser that the data stream is terminated. Unlike

--- a/Doc/library/xml.etree.elementtree.rst
+++ b/Doc/library/xml.etree.elementtree.rst
@@ -166,7 +166,7 @@ data but would still like to have incremental parsing capabilities, take a look
 at :func:`iterparse`.  It can be useful when you're reading a large XML document
 and don't want to hold it wholly in memory.
 
-Where _immediate_ feedback through events is wanted, calling method
+Where *immediate* feedback through events is wanted, calling method
 :meth:`XMLPullParser.flush` can help reduce delay;
 please make sure to study the related security notes.
 

--- a/Doc/library/xml.etree.elementtree.rst
+++ b/Doc/library/xml.etree.elementtree.rst
@@ -1402,6 +1402,9 @@ XMLParser Objects
       Disabling reparse deferral has security consequences; please see
       :meth:`xml.parsers.expat.xmlparser.SetReparseDeferralEnabled` for details.
 
+      .. versionadded:: 3.13
+
+
    :meth:`XMLParser.feed` calls *target*\'s ``start(tag, attrs_dict)`` method
    for each opening tag, its ``end(tag)`` method for each closing tag, and data
    is processed by method ``data(data)``.  For further supported callback
@@ -1471,6 +1474,8 @@ XMLPullParser Objects
       with Expat (if currently enabled) and triggers a reparse.
       Disabling reparse deferral has security consequences; please see
       :meth:`xml.parsers.expat.xmlparser.SetReparseDeferralEnabled` for details.
+
+      .. versionadded:: 3.13
 
    .. method:: close()
 

--- a/Doc/whatsnew/3.13.rst
+++ b/Doc/whatsnew/3.13.rst
@@ -181,7 +181,7 @@ Other Language Changes
   * :meth:`xml.etree.ElementTree.XMLPullParser.flush`
   * :meth:`xml.parsers.expat.xmlparser.GetReparseDeferralEnabled`
   * :meth:`xml.parsers.expat.xmlparser.SetReparseDeferralEnabled`
-  * :meth:`xml.sax.expatreader.ExpatParser.flush`
+  * :meth:`!xml.sax.expatreader.ExpatParser.flush`
 
   (Contributed by Sebastian Pipping in :gh:`115623`.)
 

--- a/Doc/whatsnew/3.13.rst
+++ b/Doc/whatsnew/3.13.rst
@@ -177,10 +177,10 @@ Other Language Changes
 * Allow controlling Expat >=2.6.0 reparse deferral (CVE-2023-52425)
   by adding five new methods:
 
-  * :meth:`pyexpat.xmlparser.GetReparseDeferralEnabled`
-  * :meth:`pyexpat.xmlparser.SetReparseDeferralEnabled`
   * :meth:`xml.etree.ElementTree.XMLParser.flush`
   * :meth:`xml.etree.ElementTree.XMLPullParser.flush`
+  * :meth:`xml.parsers.expat.xmlparser.GetReparseDeferralEnabled`
+  * :meth:`xml.parsers.expat.xmlparser.SetReparseDeferralEnabled`
   * :meth:`xml.sax.expatreader.ExpatParser.flush`
 
   (Contributed by Sebastian Pipping in :gh:`115623`.)

--- a/Doc/whatsnew/3.13.rst
+++ b/Doc/whatsnew/3.13.rst
@@ -174,6 +174,17 @@ Other Language Changes
 
   (Contributed by Victor Stinner in :gh:`114570`.)
 
+* Allow controlling Expat >=2.6.0 reparse deferral (CVE-2023-52425)
+  by adding five new methods:
+
+  * :meth:`pyexpat.xmlparser.GetReparseDeferralEnabled`
+  * :meth:`pyexpat.xmlparser.SetReparseDeferralEnabled`
+  * :meth:`xml.etree.ElementTree.XMLParser.flush`
+  * :meth:`xml.etree.ElementTree.XMLPullParser.flush`
+  * :meth:`xml.sax.expatreader.ExpatParser.flush`
+
+  (Contributed by Sebastian Pipping in :gh:`115623`.)
+
 
 New Modules
 ===========

--- a/Include/pyexpat.h
+++ b/Include/pyexpat.h
@@ -50,6 +50,8 @@ struct PyExpat_CAPI
         void *encodingHandlerData, const XML_Char *name, XML_Encoding *info);
     /* might be none for expat < 2.1.0 */
     int (*SetHashSalt)(XML_Parser parser, unsigned long hash_salt);
+    /* might be none for expat < 2.6.0 */
+    XML_Bool (*SetReparseDeferralEnabled)(XML_Parser parser, XML_Bool enabled);
     /* always add new stuff to the end! */
 };
 

--- a/Include/pyexpat.h
+++ b/Include/pyexpat.h
@@ -48,9 +48,9 @@ struct PyExpat_CAPI
     enum XML_Status (*SetEncoding)(XML_Parser parser, const XML_Char *encoding);
     int (*DefaultUnknownEncodingHandler)(
         void *encodingHandlerData, const XML_Char *name, XML_Encoding *info);
-    /* might be none for expat < 2.1.0 */
+    /* might be NULL for expat < 2.1.0 */
     int (*SetHashSalt)(XML_Parser parser, unsigned long hash_salt);
-    /* might be none for expat < 2.6.0 */
+    /* might be NULL for expat < 2.6.0 */
     XML_Bool (*SetReparseDeferralEnabled)(XML_Parser parser, XML_Bool enabled);
     /* always add new stuff to the end! */
 };

--- a/Lib/test/test_pyexpat.py
+++ b/Lib/test/test_pyexpat.py
@@ -756,17 +756,6 @@ class ForeignDTDTests(unittest.TestCase):
 
 
 class ReparseDeferralTest(unittest.TestCase):
-    def test_getter_initial_value(self):
-        if expat.version_info >= (2, 6, 0):
-            expected = True
-        else:
-            expected = False
-
-        parser = expat.ParserCreate()
-        actual = parser.GetReparseDeferralEnabled()
-
-        self.assertEqual(actual, expected)
-
     def test_getter_setter_round_trip(self):
         parser = expat.ParserCreate()
         enabled = (expat.version_info >= (2, 6, 0))

--- a/Lib/test/test_pyexpat.py
+++ b/Lib/test/test_pyexpat.py
@@ -793,7 +793,7 @@ class ReparseDeferralTest(unittest.TestCase):
 
     def test_reparse_deferral_enabled(self):
         if expat.version_info < (2, 6, 0):
-            return
+            self.skipTest(f'Expat {expat.version_info} does not support reparse deferral')
 
         started = []
 

--- a/Lib/test/test_pyexpat.py
+++ b/Lib/test/test_pyexpat.py
@@ -768,7 +768,8 @@ class ReparseDeferralTest(unittest.TestCase):
 
     def test_reparse_deferral_enabled(self):
         if expat.version_info < (2, 6, 0):
-            self.skipTest(f'Expat {expat.version_info} does not support reparse deferral')
+            self.skipTest(f'Expat {expat.version_info} does not '
+                          'support reparse deferral')
 
         started = []
 

--- a/Lib/test/test_pyexpat.py
+++ b/Lib/test/test_pyexpat.py
@@ -772,13 +772,9 @@ class ReparseDeferralTest(unittest.TestCase):
         enabled = (expat.version_info >= (2, 6, 0))
 
         self.assertIs(parser.GetReparseDeferralEnabled(), enabled)
-
         parser.SetReparseDeferralEnabled(False)
-
         self.assertIs(parser.GetReparseDeferralEnabled(), False)
-
         parser.SetReparseDeferralEnabled(True)
-
         self.assertIs(parser.GetReparseDeferralEnabled(), enabled)
 
     def test_reparse_deferral_enabled(self):

--- a/Lib/test/test_pyexpat.py
+++ b/Lib/test/test_pyexpat.py
@@ -755,5 +755,83 @@ class ForeignDTDTests(unittest.TestCase):
         self.assertEqual(handler_call_args, [("bar", "baz")])
 
 
+class ReparseDeferralTest(unittest.TestCase):
+    def test_getter_initial_value(self):
+        if expat.version_info >= (2, 6, 0):
+            expected = True
+        else:
+            expected = False
+
+        parser = expat.ParserCreate()
+        actual = parser.GetReparseDeferralEnabled()
+
+        self.assertEqual(actual, expected)
+
+    def test_getter_setter_round_trip(self):
+        parser = expat.ParserCreate()
+        was_enabled = parser.GetReparseDeferralEnabled()
+
+        # We'll flip the value back and forth, and we expect ..
+        if expat.version_info >= (2, 6, 0):
+            # that flipping worked both ways for >=2.6.0
+            expected_1 = not was_enabled
+            expected_2 = was_enabled
+        else:
+            # that flipping did not have any effect for <2.6.0
+            expected_1 = False
+            expected_2 = False
+
+        parser.SetReparseDeferralEnabled(expected_1)
+        actual_1 = parser.GetReparseDeferralEnabled()
+
+        self.assertEqual(actual_1, expected_1)
+
+        parser.SetReparseDeferralEnabled(expected_2)
+        actual_2 = parser.GetReparseDeferralEnabled()
+
+        self.assertEqual(actual_2, expected_2)
+
+    def test_reparse_deferral_enabled(self):
+        if expat.version_info < (2, 6, 0):
+            return
+
+        started = []
+
+        def start_element(name, _):
+            started.append(name)
+
+        parser = expat.ParserCreate()
+        parser.StartElementHandler = start_element
+        self.assertTrue(parser.GetReparseDeferralEnabled())
+
+        for chunk in (b'<doc', b'/>'):
+            parser.Parse(chunk, False)
+
+        # The key test: Have handlers already fired?  Expecting: no.
+        self.assertEqual(started, [])
+
+        parser.Parse(b'', True)
+
+        self.assertEqual(started, ['doc'])
+
+    def test_reparse_deferral_disabled(self):
+        started = []
+
+        def start_element(name, _):
+            started.append(name)
+
+        parser = expat.ParserCreate()
+        parser.StartElementHandler = start_element
+        if expat.version_info >= (2, 6, 0):
+            parser.SetReparseDeferralEnabled(False)
+        self.assertFalse(parser.GetReparseDeferralEnabled())
+
+        for chunk in (b'<doc', b'/>'):
+            parser.Parse(chunk, False)
+
+        # The key test: Have handlers already fired?  Expecting: yes.
+        self.assertEqual(started, ['doc'])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/Lib/test/test_pyexpat.py
+++ b/Lib/test/test_pyexpat.py
@@ -769,27 +769,17 @@ class ReparseDeferralTest(unittest.TestCase):
 
     def test_getter_setter_round_trip(self):
         parser = expat.ParserCreate()
-        was_enabled = parser.GetReparseDeferralEnabled()
+        enabled = (expat.version_info >= (2, 6, 0))
 
-        # We'll flip the value back and forth, and we expect ..
-        if expat.version_info >= (2, 6, 0):
-            # that flipping worked both ways for >=2.6.0
-            expected_1 = not was_enabled
-            expected_2 = was_enabled
-        else:
-            # that flipping did not have any effect for <2.6.0
-            expected_1 = False
-            expected_2 = False
+        self.assertIs(parser.GetReparseDeferralEnabled(), enabled)
 
-        parser.SetReparseDeferralEnabled(expected_1)
-        actual_1 = parser.GetReparseDeferralEnabled()
+        parser.SetReparseDeferralEnabled(False)
 
-        self.assertEqual(actual_1, expected_1)
+        self.assertIs(parser.GetReparseDeferralEnabled(), False)
 
-        parser.SetReparseDeferralEnabled(expected_2)
-        actual_2 = parser.GetReparseDeferralEnabled()
+        parser.SetReparseDeferralEnabled(True)
 
-        self.assertEqual(actual_2, expected_2)
+        self.assertIs(parser.GetReparseDeferralEnabled(), enabled)
 
     def test_reparse_deferral_enabled(self):
         if expat.version_info < (2, 6, 0):

--- a/Lib/test/test_sax.py
+++ b/Lib/test/test_sax.py
@@ -1217,7 +1217,7 @@ class ExpatReaderTest(XmlTestBase):
 
     def test_flush_reparse_deferral_enabled(self):
         if pyexpat.version_info < (2, 6, 0):
-            return
+            self.skipTest(f'Expat {pyexpat.version_info} does not support reparse deferral')
 
         result = BytesIO()
         xmlgen = XMLGenerator(result)

--- a/Lib/test/test_xml_etree.py
+++ b/Lib/test/test_xml_etree.py
@@ -121,10 +121,6 @@ ATTLIST_XML = """\
 </foo>
 """
 
-fails_with_expat_2_6_0 = (unittest.expectedFailure
-                        if pyexpat.version_info >= (2, 6, 0) else
-                        lambda test: test)
-
 def checkwarnings(*filters, quiet=False):
     def decorator(test):
         def newtest(*args, **kwargs):
@@ -1468,6 +1464,7 @@ class XMLPullParserTest(unittest.TestCase):
         else:
             for i in range(0, len(data), chunk_size):
                 parser.feed(data[i:i+chunk_size])
+        parser.flush()
 
     def assert_events(self, parser, expected, max_events=None):
         self.assertEqual(
@@ -1506,11 +1503,9 @@ class XMLPullParserTest(unittest.TestCase):
         self.assert_event_tags(parser, [('end', 'root')])
         self.assertIsNone(parser.close())
 
-    @fails_with_expat_2_6_0
     def test_simple_xml_chunk_1(self):
         self.test_simple_xml(chunk_size=1)
 
-    @fails_with_expat_2_6_0
     def test_simple_xml_chunk_5(self):
         self.test_simple_xml(chunk_size=5)
 

--- a/Lib/test/test_xml_etree.py
+++ b/Lib/test/test_xml_etree.py
@@ -1713,19 +1713,18 @@ class XMLPullParserTest(unittest.TestCase):
                           'support reparse deferral')
 
         parser = ET.XMLPullParser(events=('start', 'end'))
-        is_python = hasattr(parser._parser, '_parser')  # rather than C
 
         for chunk in ("<doc", ">"):
             parser.feed(chunk)
 
         self.assert_event_tags(parser, [])  # i.e. no elements started
-        if is_python:
+        if ET is pyET:
             self.assertTrue(parser._parser._parser.GetReparseDeferralEnabled())
 
         parser.flush()
 
         self.assert_event_tags(parser, [('start', 'doc')])
-        if is_python:
+        if ET is pyET:
             self.assertTrue(parser._parser._parser.GetReparseDeferralEnabled())
 
         parser.feed("</doc>")
@@ -1735,25 +1734,24 @@ class XMLPullParserTest(unittest.TestCase):
 
     def test_flush_reparse_deferral_disabled(self):
         parser = ET.XMLPullParser(events=('start', 'end'))
-        is_python = hasattr(parser._parser, '_parser')  # rather than C
 
         for chunk in ("<doc", ">"):
             parser.feed(chunk)
 
         if pyexpat.version_info >= (2, 6, 0):
-            if not is_python:
+            if not ET is pyET:
                 self.skipTest(f'XMLParser.(Get|Set)ReparseDeferralEnabled '
                               'methods not available in C')
             parser._parser._parser.SetReparseDeferralEnabled(False)
 
         self.assert_event_tags(parser, [])  # i.e. no elements started
-        if is_python:
+        if ET is pyET:
             self.assertFalse(parser._parser._parser.GetReparseDeferralEnabled())
 
         parser.flush()
 
         self.assert_event_tags(parser, [('start', 'doc')])
-        if is_python:
+        if ET is pyET:
             self.assertFalse(parser._parser._parser.GetReparseDeferralEnabled())
 
         parser.feed("</doc>")

--- a/Lib/test/test_xml_etree.py
+++ b/Lib/test/test_xml_etree.py
@@ -1737,22 +1737,24 @@ class XMLPullParserTest(unittest.TestCase):
         parser = ET.XMLPullParser(events=('start', 'end'))
         is_python = hasattr(parser._parser, '_parser')  # rather than C
 
-        if not is_python:
-            self.skipTest(f'XMLParser.(Get|Set)ReparseDeferralEnabled methods not available in C')
-
         for chunk in ("<doc", ">"):
             parser.feed(chunk)
 
         if pyexpat.version_info >= (2, 6, 0):
+            if not is_python:
+                self.skipTest(f'XMLParser.(Get|Set)ReparseDeferralEnabled '
+                              'methods not available in C')
             parser._parser._parser.SetReparseDeferralEnabled(False)
 
         self.assert_event_tags(parser, [])  # i.e. no elements started
-        self.assertFalse(parser._parser._parser.GetReparseDeferralEnabled())
+        if is_python:
+            self.assertFalse(parser._parser._parser.GetReparseDeferralEnabled())
 
         parser.flush()
 
         self.assert_event_tags(parser, [('start', 'doc')])
-        self.assertFalse(parser._parser._parser.GetReparseDeferralEnabled())
+        if is_python:
+            self.assertFalse(parser._parser._parser.GetReparseDeferralEnabled())
 
         parser.feed("</doc>")
         parser.close()

--- a/Lib/test/test_xml_etree.py
+++ b/Lib/test/test_xml_etree.py
@@ -1709,7 +1709,8 @@ class XMLPullParserTest(unittest.TestCase):
 
     def test_flush_reparse_deferral_enabled(self):
         if pyexpat.version_info < (2, 6, 0):
-            self.skipTest(f'Expat {pyexpat.version_info} does not support reparse deferral')
+            self.skipTest(f'Expat {pyexpat.version_info} does not '
+                          'support reparse deferral')
 
         parser = ET.XMLPullParser(events=('start', 'end'))
         is_python = hasattr(parser._parser, '_parser')  # rather than C

--- a/Lib/test/test_xml_etree.py
+++ b/Lib/test/test_xml_etree.py
@@ -1712,17 +1712,20 @@ class XMLPullParserTest(unittest.TestCase):
             self.skipTest(f'Expat {pyexpat.version_info} does not support reparse deferral')
 
         parser = ET.XMLPullParser(events=('start', 'end'))
+        is_python = hasattr(parser._parser, '_parser')  # rather than C
 
         for chunk in ("<doc", ">"):
             parser.feed(chunk)
 
         self.assert_event_tags(parser, [])  # i.e. no elements started
-        self.assertTrue(parser._parser._parser.GetReparseDeferralEnabled())
+        if is_python:
+            self.assertTrue(parser._parser._parser.GetReparseDeferralEnabled())
 
         parser.flush()
 
         self.assert_event_tags(parser, [('start', 'doc')])
-        self.assertTrue(parser._parser._parser.GetReparseDeferralEnabled())
+        if is_python:
+            self.assertTrue(parser._parser._parser.GetReparseDeferralEnabled())
 
         parser.feed("</doc>")
         parser.close()
@@ -1731,6 +1734,10 @@ class XMLPullParserTest(unittest.TestCase):
 
     def test_flush_reparse_deferral_disabled(self):
         parser = ET.XMLPullParser(events=('start', 'end'))
+        is_python = hasattr(parser._parser, '_parser')  # rather than C
+
+        if not is_python:
+            self.skipTest(f'XMLParser.(Get|Set)ReparseDeferralEnabled methods not available in C')
 
         for chunk in ("<doc", ">"):
             parser.feed(chunk)

--- a/Lib/test/test_xml_etree.py
+++ b/Lib/test/test_xml_etree.py
@@ -1458,13 +1458,14 @@ class ElementTreeTest(unittest.TestCase):
 
 class XMLPullParserTest(unittest.TestCase):
 
-    def _feed(self, parser, data, chunk_size=None):
+    def _feed(self, parser, data, chunk_size=None, flush=False):
         if chunk_size is None:
             parser.feed(data)
         else:
             for i in range(0, len(data), chunk_size):
                 parser.feed(data[i:i+chunk_size])
-        parser.flush()
+        if flush:
+            parser.flush()
 
     def assert_events(self, parser, expected, max_events=None):
         self.assertEqual(
@@ -1482,32 +1483,32 @@ class XMLPullParserTest(unittest.TestCase):
         self.assertEqual([(action, elem.tag) for action, elem in events],
                          expected)
 
-    def test_simple_xml(self, chunk_size=None):
+    def test_simple_xml(self, chunk_size=None, flush=False):
         parser = ET.XMLPullParser()
         self.assert_event_tags(parser, [])
-        self._feed(parser, "<!-- comment -->\n", chunk_size)
+        self._feed(parser, "<!-- comment -->\n", chunk_size, flush)
         self.assert_event_tags(parser, [])
         self._feed(parser,
                    "<root>\n  <element key='value'>text</element",
-                   chunk_size)
+                   chunk_size, flush)
         self.assert_event_tags(parser, [])
-        self._feed(parser, ">\n", chunk_size)
+        self._feed(parser, ">\n", chunk_size, flush)
         self.assert_event_tags(parser, [('end', 'element')])
-        self._feed(parser, "<element>text</element>tail\n", chunk_size)
-        self._feed(parser, "<empty-element/>\n", chunk_size)
+        self._feed(parser, "<element>text</element>tail\n", chunk_size, flush)
+        self._feed(parser, "<empty-element/>\n", chunk_size, flush)
         self.assert_event_tags(parser, [
             ('end', 'element'),
             ('end', 'empty-element'),
             ])
-        self._feed(parser, "</root>\n", chunk_size)
+        self._feed(parser, "</root>\n", chunk_size, flush)
         self.assert_event_tags(parser, [('end', 'root')])
         self.assertIsNone(parser.close())
 
     def test_simple_xml_chunk_1(self):
-        self.test_simple_xml(chunk_size=1)
+        self.test_simple_xml(chunk_size=1, flush=True)
 
     def test_simple_xml_chunk_5(self):
-        self.test_simple_xml(chunk_size=5)
+        self.test_simple_xml(chunk_size=5, flush=True)
 
     def test_simple_xml_chunk_22(self):
         self.test_simple_xml(chunk_size=22)

--- a/Lib/xml/etree/ElementTree.py
+++ b/Lib/xml/etree/ElementTree.py
@@ -1320,6 +1320,11 @@ class XMLPullParser:
             else:
                 yield event
 
+    def flush(self):
+        if self._parser is None:
+            raise ValueError("flush() called after end of stream")
+        self._parser.flush()
+
 
 def XML(text, parser=None):
     """Parse XML document from string constant.

--- a/Lib/xml/etree/ElementTree.py
+++ b/Lib/xml/etree/ElementTree.py
@@ -1726,6 +1726,17 @@ class XMLParser:
             del self.parser, self._parser
             del self.target, self._target
 
+    def flush(self):
+        if not self.parser.GetReparseDeferralEnabled():
+            return
+
+        self.parser.SetReparseDeferralEnabled(False)
+        try:
+            self.parser.Parse(b"", False)
+        except self._error as v:
+            self._raiseerror(v)
+        finally:
+            self.parser.SetReparseDeferralEnabled(True)
 
 # --------------------------------------------------------------------
 # C14N 2.0

--- a/Lib/xml/etree/ElementTree.py
+++ b/Lib/xml/etree/ElementTree.py
@@ -1732,16 +1732,17 @@ class XMLParser:
             del self.target, self._target
 
     def flush(self):
-        if not self.parser.GetReparseDeferralEnabled():
-            return
+        was_enabled = self.parser.GetReparseDeferralEnabled()
 
-        self.parser.SetReparseDeferralEnabled(False)
+        if was_enabled:
+            self.parser.SetReparseDeferralEnabled(False)
         try:
             self.parser.Parse(b"", False)
         except self._error as v:
             self._raiseerror(v)
         finally:
-            self.parser.SetReparseDeferralEnabled(True)
+            if was_enabled:
+                self.parser.SetReparseDeferralEnabled(True)
 
 # --------------------------------------------------------------------
 # C14N 2.0

--- a/Lib/xml/etree/ElementTree.py
+++ b/Lib/xml/etree/ElementTree.py
@@ -1733,16 +1733,13 @@ class XMLParser:
 
     def flush(self):
         was_enabled = self.parser.GetReparseDeferralEnabled()
-
-        if was_enabled:
-            self.parser.SetReparseDeferralEnabled(False)
         try:
+            self.parser.SetReparseDeferralEnabled(False)
             self.parser.Parse(b"", False)
         except self._error as v:
             self._raiseerror(v)
         finally:
-            if was_enabled:
-                self.parser.SetReparseDeferralEnabled(True)
+            self.parser.SetReparseDeferralEnabled(was_enabled)
 
 # --------------------------------------------------------------------
 # C14N 2.0

--- a/Lib/xml/sax/expatreader.py
+++ b/Lib/xml/sax/expatreader.py
@@ -214,6 +214,22 @@ class ExpatParser(xmlreader.IncrementalParser, xmlreader.Locator):
             # FIXME: when to invoke error()?
             self._err_handler.fatalError(exc)
 
+    def flush(self):
+        if self._parser is None:
+            return
+
+        if not self._parser.GetReparseDeferralEnabled():
+            return
+
+        self._parser.SetReparseDeferralEnabled(False)
+        try:
+            self._parser.Parse(b"", False)
+        except expat.error as e:
+            exc = SAXParseException(expat.ErrorString(e.code), e, self)
+            self._err_handler.fatalError(exc)
+        finally:
+            self._parser.SetReparseDeferralEnabled(True)
+
     def _close_source(self):
         source = self._source
         try:

--- a/Lib/xml/sax/expatreader.py
+++ b/Lib/xml/sax/expatreader.py
@@ -218,17 +218,18 @@ class ExpatParser(xmlreader.IncrementalParser, xmlreader.Locator):
         if self._parser is None:
             return
 
-        if not self._parser.GetReparseDeferralEnabled():
-            return
+        was_enabled = self._parser.GetReparseDeferralEnabled()
 
-        self._parser.SetReparseDeferralEnabled(False)
+        if was_enabled:
+            self._parser.SetReparseDeferralEnabled(False)
         try:
             self._parser.Parse(b"", False)
         except expat.error as e:
             exc = SAXParseException(expat.ErrorString(e.code), e, self)
             self._err_handler.fatalError(exc)
         finally:
-            self._parser.SetReparseDeferralEnabled(True)
+            if was_enabled:
+                self._parser.SetReparseDeferralEnabled(True)
 
     def _close_source(self):
         source = self._source

--- a/Lib/xml/sax/expatreader.py
+++ b/Lib/xml/sax/expatreader.py
@@ -219,17 +219,14 @@ class ExpatParser(xmlreader.IncrementalParser, xmlreader.Locator):
             return
 
         was_enabled = self._parser.GetReparseDeferralEnabled()
-
-        if was_enabled:
-            self._parser.SetReparseDeferralEnabled(False)
         try:
+            self._parser.SetReparseDeferralEnabled(False)
             self._parser.Parse(b"", False)
         except expat.error as e:
             exc = SAXParseException(expat.ErrorString(e.code), e, self)
             self._err_handler.fatalError(exc)
         finally:
-            if was_enabled:
-                self._parser.SetReparseDeferralEnabled(True)
+            self._parser.SetReparseDeferralEnabled(was_enabled)
 
     def _close_source(self):
         source = self._source

--- a/Misc/NEWS.d/next/Security/2024-02-18-03-14-40.gh-issue-115398.tzvxH8.rst
+++ b/Misc/NEWS.d/next/Security/2024-02-18-03-14-40.gh-issue-115398.tzvxH8.rst
@@ -1,0 +1,8 @@
+Allow controlling Expat >=2.6.0 reparse deferral (CVE-2023-52425) by adding
+five new methods:
+
+* ``pyexpat.xmlparser.GetReparseDeferralEnabled``
+* ``pyexpat.xmlparser.SetReparseDeferralEnabled``
+* ``xml.etree.ElementTree.XMLParser.flush``
+* ``xml.etree.ElementTree.XMLPullParser.flush``
+* ``xml.sax.expatreader.ExpatParser.flush``

--- a/Misc/NEWS.d/next/Security/2024-02-18-03-14-40.gh-issue-115398.tzvxH8.rst
+++ b/Misc/NEWS.d/next/Security/2024-02-18-03-14-40.gh-issue-115398.tzvxH8.rst
@@ -1,8 +1,8 @@
 Allow controlling Expat >=2.6.0 reparse deferral (CVE-2023-52425) by adding
 five new methods:
 
-* ``pyexpat.xmlparser.GetReparseDeferralEnabled``
-* ``pyexpat.xmlparser.SetReparseDeferralEnabled``
 * ``xml.etree.ElementTree.XMLParser.flush``
 * ``xml.etree.ElementTree.XMLPullParser.flush``
+* ``xml.parsers.expat.xmlparser.GetReparseDeferralEnabled``
+* ``xml.parsers.expat.xmlparser.SetReparseDeferralEnabled``
 * ``xml.sax.expatreader.ExpatParser.flush``

--- a/Misc/sbom.spdx.json
+++ b/Misc/sbom.spdx.json
@@ -132,11 +132,11 @@
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "baa44fe4581895d42e8d5e83d8ce6a69b1c34dbe"
+          "checksumValue": "f50c899172acd93fc539007bfb43315b83d407e4"
         },
         {
           "algorithm": "SHA256",
-          "checksumValue": "33a7b9ac8bf4571e23272cdf644c6f9808bd44c66b149e3c41ab3870d1888609"
+          "checksumValue": "d571b8258cfaa067a20adef553e5fcedd6671ca4a8841483496de031bd904567"
         }
       ],
       "fileName": "Modules/expat/pyexpatns.h"

--- a/Modules/_elementtree.c
+++ b/Modules/_elementtree.c
@@ -3895,6 +3895,34 @@ _elementtree_XMLParser_close_impl(XMLParserObject *self)
 }
 
 /*[clinic input]
+_elementtree.XMLParser.flush
+
+[clinic start generated code]*/
+
+static PyObject *
+_elementtree_XMLParser_flush_impl(XMLParserObject *self)
+/*[clinic end generated code: output=42fdb8795ca24509 input=effbecdb28715949]*/
+{
+    if (!_check_xmlparser(self)) {
+        return NULL;
+    }
+
+    elementtreestate *st = self->state;
+
+    if (EXPAT(st, SetReparseDeferralEnabled) == NULL) {
+        Py_RETURN_NONE;
+    }
+
+    EXPAT(st, SetReparseDeferralEnabled)(self->parser, XML_FALSE);
+
+    PyObject *res = expat_parse(st, self, "", 0, XML_FALSE);
+
+    EXPAT(st, SetReparseDeferralEnabled)(self->parser, XML_TRUE);
+
+    return res;
+}
+
+/*[clinic input]
 _elementtree.XMLParser.feed
 
     data: object
@@ -4288,6 +4316,7 @@ static PyType_Spec treebuilder_spec = {
 static PyMethodDef xmlparser_methods[] = {
     _ELEMENTTREE_XMLPARSER_FEED_METHODDEF
     _ELEMENTTREE_XMLPARSER_CLOSE_METHODDEF
+    _ELEMENTTREE_XMLPARSER_FLUSH_METHODDEF
     _ELEMENTTREE_XMLPARSER__PARSE_WHOLE_METHODDEF
     _ELEMENTTREE_XMLPARSER__SETEVENTS_METHODDEF
     {NULL, NULL}

--- a/Modules/_elementtree.c
+++ b/Modules/_elementtree.c
@@ -3913,6 +3913,12 @@ _elementtree_XMLParser_flush_impl(XMLParserObject *self)
         Py_RETURN_NONE;
     }
 
+    // NOTE: The Expat parser in the C implementation of ElementTree is not
+    //       exposed to the outside; as a result we known that reparse deferall
+    //       is currently enabled, or we would not even have access to function
+    //       XML_SetReparseDeferralEnabled in the first place (which we checked
+    //       for, a few lines up).
+
     EXPAT(st, SetReparseDeferralEnabled)(self->parser, XML_FALSE);
 
     PyObject *res = expat_parse(st, self, "", 0, XML_FALSE);

--- a/Modules/_elementtree.c
+++ b/Modules/_elementtree.c
@@ -3914,7 +3914,7 @@ _elementtree_XMLParser_flush_impl(XMLParserObject *self)
     }
 
     // NOTE: The Expat parser in the C implementation of ElementTree is not
-    //       exposed to the outside; as a result we known that reparse deferall
+    //       exposed to the outside; as a result we known that reparse deferral
     //       is currently enabled, or we would not even have access to function
     //       XML_SetReparseDeferralEnabled in the first place (which we checked
     //       for, a few lines up).

--- a/Modules/clinic/_elementtree.c.h
+++ b/Modules/clinic/_elementtree.c.h
@@ -1169,6 +1169,23 @@ _elementtree_XMLParser_close(XMLParserObject *self, PyObject *Py_UNUSED(ignored)
     return _elementtree_XMLParser_close_impl(self);
 }
 
+PyDoc_STRVAR(_elementtree_XMLParser_flush__doc__,
+"flush($self, /)\n"
+"--\n"
+"\n");
+
+#define _ELEMENTTREE_XMLPARSER_FLUSH_METHODDEF    \
+    {"flush", (PyCFunction)_elementtree_XMLParser_flush, METH_NOARGS, _elementtree_XMLParser_flush__doc__},
+
+static PyObject *
+_elementtree_XMLParser_flush_impl(XMLParserObject *self);
+
+static PyObject *
+_elementtree_XMLParser_flush(XMLParserObject *self, PyObject *Py_UNUSED(ignored))
+{
+    return _elementtree_XMLParser_flush_impl(self);
+}
+
 PyDoc_STRVAR(_elementtree_XMLParser_feed__doc__,
 "feed($self, data, /)\n"
 "--\n"
@@ -1219,4 +1236,4 @@ skip_optional:
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=218ec9e6a889f796 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=aed9f53eeb0404e0 input=a9049054013a1b77]*/

--- a/Modules/clinic/pyexpat.c.h
+++ b/Modules/clinic/pyexpat.c.h
@@ -8,6 +8,53 @@ preserve
 #endif
 #include "pycore_modsupport.h"    // _PyArg_UnpackKeywords()
 
+PyDoc_STRVAR(pyexpat_xmlparser_SetReparseDeferralEnabled__doc__,
+"SetReparseDeferralEnabled($self, enabled, /)\n"
+"--\n"
+"\n"
+"Enable/Disable reparse deferral; enabled by default with Expat >=2.6.0.");
+
+#define PYEXPAT_XMLPARSER_SETREPARSEDEFERRALENABLED_METHODDEF    \
+    {"SetReparseDeferralEnabled", (PyCFunction)pyexpat_xmlparser_SetReparseDeferralEnabled, METH_O, pyexpat_xmlparser_SetReparseDeferralEnabled__doc__},
+
+static PyObject *
+pyexpat_xmlparser_SetReparseDeferralEnabled_impl(xmlparseobject *self,
+                                                 int enabled);
+
+static PyObject *
+pyexpat_xmlparser_SetReparseDeferralEnabled(xmlparseobject *self, PyObject *arg)
+{
+    PyObject *return_value = NULL;
+    int enabled;
+
+    enabled = PyObject_IsTrue(arg);
+    if (enabled < 0) {
+        goto exit;
+    }
+    return_value = pyexpat_xmlparser_SetReparseDeferralEnabled_impl(self, enabled);
+
+exit:
+    return return_value;
+}
+
+PyDoc_STRVAR(pyexpat_xmlparser_GetReparseDeferralEnabled__doc__,
+"GetReparseDeferralEnabled($self, /)\n"
+"--\n"
+"\n"
+"Retrieve reparse deferral enabled status; always returns false with Expat <2.6.0.");
+
+#define PYEXPAT_XMLPARSER_GETREPARSEDEFERRALENABLED_METHODDEF    \
+    {"GetReparseDeferralEnabled", (PyCFunction)pyexpat_xmlparser_GetReparseDeferralEnabled, METH_NOARGS, pyexpat_xmlparser_GetReparseDeferralEnabled__doc__},
+
+static PyObject *
+pyexpat_xmlparser_GetReparseDeferralEnabled_impl(xmlparseobject *self);
+
+static PyObject *
+pyexpat_xmlparser_GetReparseDeferralEnabled(xmlparseobject *self, PyObject *Py_UNUSED(ignored))
+{
+    return pyexpat_xmlparser_GetReparseDeferralEnabled_impl(self);
+}
+
 PyDoc_STRVAR(pyexpat_xmlparser_Parse__doc__,
 "Parse($self, data, isfinal=False, /)\n"
 "--\n"
@@ -498,4 +545,4 @@ exit:
 #ifndef PYEXPAT_XMLPARSER_USEFOREIGNDTD_METHODDEF
     #define PYEXPAT_XMLPARSER_USEFOREIGNDTD_METHODDEF
 #endif /* !defined(PYEXPAT_XMLPARSER_USEFOREIGNDTD_METHODDEF) */
-/*[clinic end generated code: output=48c4296e43777df4 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=892e48e41f9b6e4b input=a9049054013a1b77]*/

--- a/Modules/expat/pyexpatns.h
+++ b/Modules/expat/pyexpatns.h
@@ -108,6 +108,7 @@
 #define XML_SetNotStandaloneHandler     PyExpat_XML_SetNotStandaloneHandler
 #define XML_SetParamEntityParsing       PyExpat_XML_SetParamEntityParsing
 #define XML_SetProcessingInstructionHandler PyExpat_XML_SetProcessingInstructionHandler
+#define XML_SetReparseDeferralEnabled   PyExpat_XML_SetReparseDeferralEnabled
 #define XML_SetReturnNSTriplet          PyExpat_XML_SetReturnNSTriplet
 #define XML_SetSkippedEntityHandler     PyExpat_XML_SetSkippedEntityHandler
 #define XML_SetStartCdataSectionHandler PyExpat_XML_SetStartCdataSectionHandler

--- a/Modules/pyexpat.c
+++ b/Modules/pyexpat.c
@@ -2067,6 +2067,11 @@ pyexpat_exec(PyObject *mod)
 #else
     capi->SetHashSalt = NULL;
 #endif
+#if XML_COMBINED_VERSION >= 20600
+    capi->SetReparseDeferralEnabled = XML_SetReparseDeferralEnabled;
+#else
+    capi->SetReparseDeferralEnabled = NULL;
+#endif
 
     /* export using capsule */
     PyObject *capi_object = PyCapsule_New(capi, PyExpat_CAPSULE_NAME,

--- a/Modules/pyexpat.c
+++ b/Modules/pyexpat.c
@@ -7,6 +7,7 @@
 #include "pycore_pyhash.h"        // _Py_HashSecret
 #include "pycore_traceback.h"     // _PyTraceback_Add()
 
+#include <stdbool.h>
 #include <stddef.h>               // offsetof()
 #include "expat.h"
 #include "pyexpat.h"
@@ -81,6 +82,12 @@ typedef struct {
                                 /* NULL if not enabled */
     int buffer_size;            /* Size of buffer, in XML_Char units */
     int buffer_used;            /* Buffer units in use */
+    bool reparse_deferral_enabled; /* Whether to defer reparsing of
+                                   unfinished XML tokens; a de-facto cache of
+                                   what Expat has the authority on, for lack
+                                   of a getter API function
+                                   "XML_GetReparseDeferralEnabled" in Expat
+                                   2.6.0 */
     PyObject *intern;           /* Dictionary to intern strings */
     PyObject **handlers;
 } xmlparseobject;
@@ -704,6 +711,40 @@ get_parse_result(pyexpat_state *state, xmlparseobject *self, int rv)
 #define MAX_CHUNK_SIZE (1 << 20)
 
 /*[clinic input]
+pyexpat.xmlparser.SetReparseDeferralEnabled
+
+    enabled: bool
+    /
+
+Enable/Disable reparse deferral; enabled by default with Expat >=2.6.0.
+[clinic start generated code]*/
+
+static PyObject *
+pyexpat_xmlparser_SetReparseDeferralEnabled_impl(xmlparseobject *self,
+                                                 int enabled)
+/*[clinic end generated code: output=5ec539e3b63c8c49 input=021eb9e0bafc32c5]*/
+{
+#if XML_COMBINED_VERSION >= 20600
+    XML_SetReparseDeferralEnabled(self->itself, enabled ? XML_TRUE : XML_FALSE);
+    self->reparse_deferral_enabled = (bool)enabled;
+#endif
+    Py_RETURN_NONE;
+}
+
+/*[clinic input]
+pyexpat.xmlparser.GetReparseDeferralEnabled
+
+Retrieve reparse deferral enabled status; always returns false with Expat <2.6.0.
+[clinic start generated code]*/
+
+static PyObject *
+pyexpat_xmlparser_GetReparseDeferralEnabled_impl(xmlparseobject *self)
+/*[clinic end generated code: output=4e91312e88a595a8 input=54b5f11d32b20f3e]*/
+{
+    return PyBool_FromLong(self->reparse_deferral_enabled);
+}
+
+/*[clinic input]
 pyexpat.xmlparser.Parse
 
     cls: defining_class
@@ -1063,6 +1104,8 @@ static struct PyMethodDef xmlparse_methods[] = {
 #if XML_COMBINED_VERSION >= 19505
     PYEXPAT_XMLPARSER_USEFOREIGNDTD_METHODDEF
 #endif
+    PYEXPAT_XMLPARSER_SETREPARSEDEFERRALENABLED_METHODDEF
+    PYEXPAT_XMLPARSER_GETREPARSEDEFERRALENABLED_METHODDEF
     {NULL, NULL}  /* sentinel */
 };
 
@@ -1158,6 +1201,11 @@ newxmlparseobject(pyexpat_state *state, const char *encoding,
     self->ns_prefixes = 0;
     self->handlers = NULL;
     self->intern = Py_XNewRef(intern);
+#if XML_COMBINED_VERSION >= 20600
+    self->reparse_deferral_enabled = true;
+#else
+    self->reparse_deferral_enabled = false;
+#endif
 
     /* namespace_separator is either NULL or contains one char + \0 */
     self->itself = XML_ParserCreate_MM(encoding, &ExpatMemoryHandler,


### PR DESCRIPTION
### Mission

Allow controlling Expat >=2.6.0 reparse deferral (CVE-2023-52425) by adding five new methods:

- `xml.etree.ElementTree.XMLParser.flush`
- `xml.etree.ElementTree.XMLPullParser.flush`
- `xml.parsers.expat.xmlparser.GetReparseDeferralEnabled`
- `xml.parsers.expat.xmlparser.SetReparseDeferralEnabled`
- `xml.sax.expatreader.ExpatParser.flush`

Based on the "flush" idea from https://github.com/python/cpython/pull/115138#issuecomment-1932444270 .

### Notes

- Please treat as a security fix related to CVE-2023-52425.
- Please note that this is my first contact with the [CPython Argument Clinic](https://devguide.python.org/development-tools/clinic/).
- I'm happy to add more end user documentation once it is clear how you feel about the technical aspects of this pull request.
- Looking forward to your review :beers: 

CC @serhiy-storchaka 

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-115398 -->
* Issue: gh-115398
<!-- /gh-issue-number -->
