### PR TITLE
gh-115627: Fix PySSL_SetError handling SSL_ERROR_SYSCALL

### DIFF
--- a/Lib/test/test_ssl.py
+++ b/Lib/test/test_ssl.py
@@ -3168,8 +3168,8 @@ class ThreadedTests(unittest.TestCase):
                                         suppress_ragged_eofs=False) as s:
             s.connect((HOST, server.port))
             with self.assertRaisesRegex(
-                ssl.SSLError,
-                'alert unknown ca|EOF occurred|TLSV1_ALERT_UNKNOWN_CA'
+                OSError,
+                'alert unknown ca|EOF occurred|TLSV1_ALERT_UNKNOWN_CA|closed by the remote host|Connection reset by peer'
             ):
                 # TLS 1.3 perform client cert exchange after handshake
                 s.write(b'data')
@@ -4534,7 +4534,7 @@ class TestPostHandshakeAuth(unittest.TestCase):
                 # test sometimes fails with EOF error. Test passes as long as
                 # server aborts connection with an error.
                 with self.assertRaisesRegex(
-                    (ssl.SSLError, OSError),
+                    OSError,
                     '(certificate required|EOF occurred|closed by the remote host)'
                 ):
                     # receive CertificateRequest

--- a/Lib/test/test_ssl.py
+++ b/Lib/test/test_ssl.py
@@ -4535,7 +4535,7 @@ class TestPostHandshakeAuth(unittest.TestCase):
                 # server aborts connection with an error.
                 with self.assertRaisesRegex(
                     OSError,
-                    '(certificate required|EOF occurred|closed by the remote host)'
+                    'certificate required|EOF occurred|closed by the remote host|Connection reset by peer'
                 ):
                     # receive CertificateRequest
                     data = s.recv(1024)

--- a/Lib/test/test_ssl.py
+++ b/Lib/test/test_ssl.py
@@ -2433,9 +2433,8 @@ class ThreadedEchoServer(threading.Thread):
                         # OpenSSL 1.1.1 sometimes raises
                         # ConnectionResetError when connection is not
                         # shut down gracefully.
-                        print(
-                            f" Connection reset by peer: {self.addr}"
-                        )
+                        if self.server.chatty and support.verbose:
+                            print(f" Connection reset by peer: {self.addr}")
 
                         self.close()
                         self.running = False

--- a/Misc/NEWS.d/next/Library/2024-02-18-09-50-31.gh-issue-115627.HGchj0.rst
+++ b/Misc/NEWS.d/next/Library/2024-02-18-09-50-31.gh-issue-115627.HGchj0.rst
@@ -1,0 +1,2 @@
+Fix :c:func:`PySSL_SetError` : Modify retval handling logic for handling
+SSL_ERROR_SYSCALL.

--- a/Misc/NEWS.d/next/Library/2024-02-18-09-50-31.gh-issue-115627.HGchj0.rst
+++ b/Misc/NEWS.d/next/Library/2024-02-18-09-50-31.gh-issue-115627.HGchj0.rst
@@ -1,2 +1,2 @@
-FIX the ssl module error handling of connection terminate by peer.
-it throws OSError instead of EOFError.
+Fix the :mod:`ssl` module error handling of connection terminate by peer.
+It now throws an OSError with the appropriate error code instead of an EOFError.

--- a/Misc/NEWS.d/next/Library/2024-02-18-09-50-31.gh-issue-115627.HGchj0.rst
+++ b/Misc/NEWS.d/next/Library/2024-02-18-09-50-31.gh-issue-115627.HGchj0.rst
@@ -1,2 +1,2 @@
-Fix :c:func:`PySSL_SetError` : Modify retval handling logic for handling
-SSL_ERROR_SYSCALL.
+FIX the ssl module error handling of connection terminate by peer.
+it throws OSError instead of EOFError.

--- a/Modules/_ssl.c
+++ b/Modules/_ssl.c
@@ -649,7 +649,7 @@ PySSL_SetError(PySSLSocket *sslsock, const char *filename, int lineno)
                     p = PY_SSL_ERROR_EOF;
                     type = state->PySSLEOFErrorObject;
                     errstr = "EOF occurred in violation of protocol";
-                } else {
+                } else if (s) {
                     /* underlying BIO reported an I/O error */
                     ERR_clear_error();
 #ifdef MS_WINDOWS
@@ -666,6 +666,10 @@ PySSL_SetError(PySSLSocket *sslsock, const char *filename, int lineno)
                         type = state->PySSLEOFErrorObject;
                         errstr = "EOF occurred in violation of protocol";
                     }
+                } else { /* possible? */
+                    p = PY_SSL_ERROR_SYSCALL;
+                    type = state->PySSLSyscallErrorObject;
+                    errstr = "Some I/O error occurred";
                 }
             } else {
                 if (ERR_GET_LIB(e) == ERR_LIB_SSL &&

--- a/Modules/_ssl.c
+++ b/Modules/_ssl.c
@@ -646,11 +646,11 @@ PySSL_SetError(PySSLSocket *sslsock, int ret, const char *filename, int lineno)
         {
             if (e == 0) {
                 PySocketSockObject *s = GET_SOCKET(sslsock);
-                if (ret == 0 || (((PyObject *)s) == Py_None)) {
+                if (((PyObject *)s) == Py_None) {
                     p = PY_SSL_ERROR_EOF;
                     type = state->PySSLEOFErrorObject;
                     errstr = "EOF occurred in violation of protocol";
-                } else if (s && ret == -1) {
+                } else {
                     /* underlying BIO reported an I/O error */
                     ERR_clear_error();
 #ifdef MS_WINDOWS
@@ -667,10 +667,6 @@ PySSL_SetError(PySSLSocket *sslsock, int ret, const char *filename, int lineno)
                         type = state->PySSLEOFErrorObject;
                         errstr = "EOF occurred in violation of protocol";
                     }
-                } else { /* possible? */
-                    p = PY_SSL_ERROR_SYSCALL;
-                    type = state->PySSLSyscallErrorObject;
-                    errstr = "Some I/O error occurred";
                 }
             } else {
                 if (ERR_GET_LIB(e) == ERR_LIB_SSL &&

--- a/Modules/_ssl.c
+++ b/Modules/_ssl.c
@@ -599,7 +599,7 @@ PySSL_ChainExceptions(PySSLSocket *sslsock) {
 }
 
 static PyObject *
-PySSL_SetError(PySSLSocket *sslsock, int ret, const char *filename, int lineno)
+PySSL_SetError(PySSLSocket *sslsock, const char *filename, int lineno)
 {
     PyObject *type;
     char *errstr = NULL;
@@ -612,7 +612,6 @@ PySSL_SetError(PySSLSocket *sslsock, int ret, const char *filename, int lineno)
     _sslmodulestate *state = get_state_sock(sslsock);
     type = state->PySSLErrorObject;
 
-    assert(ret <= 0);
     e = ERR_peek_last_error();
 
     if (sslsock->ssl != NULL) {
@@ -1026,7 +1025,7 @@ _ssl__SSLSocket_do_handshake_impl(PySSLSocket *self)
              err.ssl == SSL_ERROR_WANT_WRITE);
     Py_XDECREF(sock);
     if (ret < 1)
-        return PySSL_SetError(self, ret, __FILE__, __LINE__);
+        return PySSL_SetError(self, __FILE__, __LINE__);
     if (PySSL_ChainExceptions(self) < 0)
         return NULL;
     Py_RETURN_NONE;
@@ -2433,7 +2432,7 @@ _ssl__SSLSocket_write_impl(PySSLSocket *self, Py_buffer *b)
 
     Py_XDECREF(sock);
     if (retval == 0)
-        return PySSL_SetError(self, retval, __FILE__, __LINE__);
+        return PySSL_SetError(self, __FILE__, __LINE__);
     if (PySSL_ChainExceptions(self) < 0)
         return NULL;
     return PyLong_FromSize_t(count);
@@ -2463,7 +2462,7 @@ _ssl__SSLSocket_pending_impl(PySSLSocket *self)
     self->err = err;
 
     if (count < 0)
-        return PySSL_SetError(self, count, __FILE__, __LINE__);
+        return PySSL_SetError(self, __FILE__, __LINE__);
     else
         return PyLong_FromLong(count);
 }
@@ -2586,7 +2585,7 @@ _ssl__SSLSocket_read_impl(PySSLSocket *self, Py_ssize_t len,
              err.ssl == SSL_ERROR_WANT_WRITE);
 
     if (retval == 0) {
-        PySSL_SetError(self, retval, __FILE__, __LINE__);
+        PySSL_SetError(self, __FILE__, __LINE__);
         goto error;
     }
     if (self->exc != NULL)
@@ -2712,7 +2711,7 @@ _ssl__SSLSocket_shutdown_impl(PySSLSocket *self)
     }
     if (ret < 0) {
         Py_XDECREF(sock);
-        PySSL_SetError(self, ret, __FILE__, __LINE__);
+        PySSL_SetError(self, __FILE__, __LINE__);
         return NULL;
     }
     if (self->exc != NULL)


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

The SSL_write() and SSL_read() used in python 3.9 were modified from python 3.10 to SSL_write_ex() and SSL_read_ex(), and the return value was fixed to 0 on error.

I modified it so that OSError can be returned correctly, not EOF, when retval is 0.

<!-- gh-issue-number: gh-115627 -->
* Issue: gh-115627
<!-- /gh-issue-number -->
