### PR TITLE
gh-115572: Move `codeobject.replace()` docs to the data model

### DIFF
--- a/Doc/library/types.rst
+++ b/Doc/library/types.rst
@@ -188,7 +188,7 @@ Standard names are defined for the following types:
 
    .. index:: pair: built-in function; compile
 
-   The type for :ref:`code objects <code-objects>` such as returned by :func:`compile`.
+   The type of :ref:`code objects <code-objects>` such as returned by :func:`compile`.
 
    .. audit-event:: code.__new__ code,filename,name,argcount,posonlyargcount,kwonlyargcount,nlocals,stacksize,flags types.CodeType
 

--- a/Doc/library/types.rst
+++ b/Doc/library/types.rst
@@ -188,21 +188,13 @@ Standard names are defined for the following types:
 
    .. index:: pair: built-in function; compile
 
-   The type for code objects such as returned by :func:`compile`.
+   The type for :ref:`code objects <code-objects>` such as returned by :func:`compile`.
 
    .. audit-event:: code.__new__ code,filename,name,argcount,posonlyargcount,kwonlyargcount,nlocals,stacksize,flags types.CodeType
 
    Note that the audited arguments may not match the names or positions
    required by the initializer.  The audit event only occurs for direct
    instantiation of code objects, and is not raised for normal compilation.
-
-   .. method:: CodeType.replace(**kwargs)
-
-     Return a copy of the code object with new values for the specified fields.
-
-     Code objects are also supported by generic function :func:`copy.replace`.
-
-     .. versionadded:: 3.8
 
 .. data:: CellType
 

--- a/Doc/reference/datamodel.rst
+++ b/Doc/reference/datamodel.rst
@@ -1296,7 +1296,7 @@ Methods on code objects
 
    Return a copy of the code object with new values for the specified fields.
 
-   Code objects are also supported by generic function :func:`copy.replace`.
+   Code objects are also supported by the generic function :func:`copy.replace`.
 
    .. versionadded:: 3.8
 

--- a/Doc/reference/datamodel.rst
+++ b/Doc/reference/datamodel.rst
@@ -1292,6 +1292,14 @@ Methods on code objects
       :pep:`626` - Precise line numbers for debugging and other tools.
          The PEP that introduced the :meth:`!co_lines` method.
 
+.. method:: codeobject.replace(**kwargs)
+
+   Return a copy of the code object with new values for the specified fields.
+
+   Code objects are also supported by generic function :func:`copy.replace`.
+
+   .. versionadded:: 3.8
+
 
 .. _frame-objects:
 


### PR DESCRIPTION
Move ```codeobject.replace()``` docs from types/CodeType to Data Model/Code objects

<!-- gh-issue-number: gh-115572 -->
* Issue: gh-115572
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--115631.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->