### PR TITLE
gh-114709: Mark commonpath behaviour as changed in 3.13

### DIFF
--- a/Doc/library/os.path.rst
+++ b/Doc/library/os.path.rst
@@ -93,7 +93,7 @@ the :mod:`glob` module.)
       Accepts a sequence of :term:`path-like objects <path-like object>`.
 
    .. versionchanged:: 3.13
-      Accepts an iterable of :term:`path-like objects <path-like object>`.
+      Any iterable can now be passed, rather than just sequences.
 
 
 .. function:: commonprefix(list)

--- a/Doc/library/os.path.rst
+++ b/Doc/library/os.path.rst
@@ -90,6 +90,9 @@ the :mod:`glob` module.)
    .. versionadded:: 3.5
 
    .. versionchanged:: 3.6
+      Accepts a sequence of :term:`path-like objects <path-like object>`.
+
+   .. versionchanged:: 3.13
       Accepts an iterable of :term:`path-like objects <path-like object>`.
 
 


### PR DESCRIPTION
From Serhiy's feedback in https://github.com/python/cpython/pull/114710

<!-- gh-issue-number: gh-114709 -->
* Issue: gh-114709
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--115639.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->