### PR TITLE
gh-83648: Add missing `deprecated` arg in argparse.rst

### DIFF
--- a/Doc/library/argparse.rst
+++ b/Doc/library/argparse.rst
@@ -745,7 +745,7 @@ The add_argument() method
 
 .. method:: ArgumentParser.add_argument(name or flags..., [action], [nargs], \
                            [const], [default], [type], [choices], [required], \
-                           [help], [metavar], [dest])
+                           [help], [metavar], [dest], [deprecated])
 
    Define how a single command-line argument should be parsed.  Each parameter
    has its own more detailed description below, but in short they are:


### PR DESCRIPTION
I added the missing `deprecated` argument in the function declaration in the argparse.rst file.

There is no corresponding GitHub issue number. Should I create one or do we use a `skip issue` label?


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--115640.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->

<!-- gh-issue-number: gh-83648 -->
* Issue: gh-83648
<!-- /gh-issue-number -->
