### PR TITLE
gh-115634: Force the process pool to adjust when a process worker exits

### DIFF
--- a/Lib/concurrent/futures/process.py
+++ b/Lib/concurrent/futures/process.py
@@ -360,7 +360,7 @@ class _ExecutorManagerThread(threading.Thread):
                 if executor := self.executor_reference():
                     if process_exited:
                         with self.shutdown_lock:
-                            executor._adjust_process_count()
+                            executor._adjust_process_count(force=True)
                     else:
                         executor._idle_worker_semaphore.release()
                     del executor
@@ -753,9 +753,9 @@ class ProcessPoolExecutor(_base.Executor):
             _threads_wakeups[self._executor_manager_thread] = \
                 self._executor_manager_thread_wakeup
 
-    def _adjust_process_count(self):
+    def _adjust_process_count(self, force=False):
         # if there's an idle process, we don't need to spawn a new one.
-        if self._idle_worker_semaphore.acquire(blocking=False):
+        if self._idle_worker_semaphore.acquire(blocking=False) and not force:
             return
 
         process_count = len(self._processes)

--- a/Lib/concurrent/futures/process.py
+++ b/Lib/concurrent/futures/process.py
@@ -360,9 +360,10 @@ class _ExecutorManagerThread(threading.Thread):
                 if executor := self.executor_reference():
                     if process_exited:
                         with self.shutdown_lock:
-                            executor._adjust_process_count(force=True)
+                            executor._adjust_process_count()
                     else:
-                        executor._idle_worker_semaphore.release()
+                        with executor._idle_worker_lock:
+                            executor._idle_worker_number += 1
                     del executor
 
             if self.is_shutting_down():
@@ -707,7 +708,8 @@ class ProcessPoolExecutor(_base.Executor):
         # Shutdown is a two-step process.
         self._shutdown_thread = False
         self._shutdown_lock = threading.Lock()
-        self._idle_worker_semaphore = threading.Semaphore(0)
+        self._idle_worker_lock = threading.Lock()
+        self._idle_worker_number = 0
         self._broken = False
         self._queue_count = 0
         self._pending_work_items = {}
@@ -753,20 +755,22 @@ class ProcessPoolExecutor(_base.Executor):
             _threads_wakeups[self._executor_manager_thread] = \
                 self._executor_manager_thread_wakeup
 
-    def _adjust_process_count(self, force=False):
-        # if there's an idle process, we don't need to spawn a new one.
-        if self._idle_worker_semaphore.acquire(blocking=False) and not force:
-            return
+    def _adjust_process_count(self):
+        with self._idle_worker_lock:
+            # if there's an idle process, we don't need to spawn a new one.
+            if self._idle_worker_number > 0:
+                return
 
-        process_count = len(self._processes)
-        if process_count < self._max_workers:
-            # Assertion disabled as this codepath is also used to replace a
-            # worker that unexpectedly dies, even when using the 'fork' start
-            # method. That means there is still a potential deadlock bug. If a
-            # 'fork' mp_context worker dies, we'll be forking a new one when
-            # we know a thread is running (self._executor_manager_thread).
-            #assert self._safe_to_dynamically_spawn_children or not self._executor_manager_thread, 'https://github.com/python/cpython/issues/90622'
-            self._spawn_process()
+            process_count = len(self._processes)
+            if process_count < self._max_workers:
+                # Assertion disabled as this codepath is also used to replace a
+                # worker that unexpectedly dies, even when using the 'fork' start
+                # method. That means there is still a potential deadlock bug. If a
+                # 'fork' mp_context worker dies, we'll be forking a new one when
+                # we know a thread is running (self._executor_manager_thread).
+                #assert self._safe_to_dynamically_spawn_children or not self._executor_manager_thread, 'https://github.com/python/cpython/issues/90622'
+                self._spawn_process()
+                self._idle_worker_number += 1
 
     def _launch_processes(self):
         # https://github.com/python/cpython/issues/90622
@@ -808,6 +812,8 @@ class ProcessPoolExecutor(_base.Executor):
 
             if self._safe_to_dynamically_spawn_children:
                 self._adjust_process_count()
+                with self._idle_worker_lock:
+                    self._idle_worker_number -= 1
             self._start_executor_manager_thread()
             return f
     submit.__doc__ = _base.Executor.submit.__doc__

--- a/Lib/test/test_concurrent_futures/test_process_pool.py
+++ b/Lib/test/test_concurrent_futures/test_process_pool.py
@@ -168,6 +168,24 @@ class ProcessPoolExecutorTest(ExecutorTest):
 
         executor.shutdown()
 
+    def test_max_tasks_per_child_with_fast_submit(self):
+        # gh-115634:
+        # If many tasks are submitted quickly, the idle worker count
+        # would be wrong so the new worker won't be spawned.
+
+        context = self.get_context()
+        if context.get_start_method(allow_none=False) == "fork":
+            raise unittest.SkipTest("Incompatible with the fork start method.")
+
+        executor = self.executor_type(
+                1, mp_context=context, max_tasks_per_child=3)
+
+        # This will halt the process as there's no worker available and the
+        # pool won't spawn more
+        _ = [executor.submit(mul, i, i) for i in range(10)]
+
+        executor.shutdown()
+
     def test_max_tasks_per_child_defaults_to_spawn_context(self):
         # not using self.executor as we need to control construction.
         # arguably this could go in another class w/o that mixin.

--- a/Misc/NEWS.d/next/Library/2024-02-19-00-23-58.gh-issue-115634.wg-ec5.rst
+++ b/Misc/NEWS.d/next/Library/2024-02-19-00-23-58.gh-issue-115634.wg-ec5.rst
@@ -1,0 +1,1 @@
+Fixed the halt issue for :class:`ProcessPoolExecutor` when the task submission is fast to saturate **max_workers** and then all worker processes are killed due to **max_tasks_per_child**.


### PR DESCRIPTION
`concurrent.futures.ProcessPoolExecutor` fails to count the available worker processes which leads to a halt in the following program:

```python
from concurrent.futures import ProcessPoolExecutor
if __name__ == '__main__':
    with ProcessPoolExecutor(1, max_tasks_per_child=2) as exe:
        futs = [exe.submit(print, i) for i in range(10)]
```

This is a result of the combination of #19453 and #27373. #19453 introduces `_idle_worker_semaphore` to check if there are idle worker processes, which saved some time to spawning all the process unconditionally at start time. The calculation is smart - using a semaphore as the indicator, and acquire the semaphore for every submit. When it fails to acquire the semaphore, spawn a new worker process. If a result is returned from the process, release the semaphore because that means a worker process is available again.

The math works until the number of the process worker reaches the maximum number - then the semaphore is meaningless, because `submit` won't change it, or spawn a new process, but the returned results keep releasing it. That's fine, because upon that time, the purpose of the semaphore has served, it's not needed anymore.

However, #27373 came up, introducing another mechanism - `max_tasks_per_child`, which kills a worker process when certain tasks have been processed by it. Unfortunately, it re-used `_adjust_process_count` for its worker re-spawn, which is the mechanism above - checking the semaphore then decide whether a new worker process should be spawned.

As I mentioned, the semaphore is meaningless after the number of the worker process reaches maximum, so this mechanism simply won't work. After the worker process is killed, no process will be spawned because the pool manager believes there are more idle workers.

An example sequence with `max_workers = 1, max_tasks_per_child=2`

```
submit(0) - acquire semaphore(failed) - spawn worker process
submit(1) - acquire semaphore(failed) - reached max_worker, do nothing
process(0) - 1/2 for the worker process
get_result(0) - release semaphore(value=1)
process(1) - 2/2 for the worker process - exit and let the manager know it's dead
get_result(1) - realize the worker process is dead, do `_adjust_process_count`, which **acquires semaphore and succeeds**! No need to spawn any workers.
DEAD
```

I used the simplest way possible to fix this - force `_adjust_process_count` to check process numbers when a worker exits, which fixed the issue. We can do some smart math on the semaphore but I do believe we need to access the value of it, which is not in the public documentation so I'm a bit hesitated to do that.

<!-- gh-issue-number: gh-115634 -->
* Issue: gh-115634
<!-- /gh-issue-number -->
