### PR TITLE
gh-115652: Fix indentation in the documentation of multiprocessing.get_start_method

### DIFF
--- a/Doc/library/multiprocessing.rst
+++ b/Doc/library/multiprocessing.rst
@@ -1084,11 +1084,11 @@ Miscellaneous
    The return value can be ``'fork'``, ``'spawn'``, ``'forkserver'``
    or ``None``.  See :ref:`multiprocessing-start-methods`.
 
-.. versionchanged:: 3.8
+   .. versionchanged:: 3.8
 
-   On macOS, the *spawn* start method is now the default.  The *fork* start
-   method should be considered unsafe as it can lead to crashes of the
-   subprocess. See :issue:`33725`.
+      On macOS, the *spawn* start method is now the default.  The *fork* start
+      method should be considered unsafe as it can lead to crashes of the
+      subprocess. See :issue:`33725`.
 
    .. versionadded:: 3.4
 

--- a/Doc/library/multiprocessing.rst
+++ b/Doc/library/multiprocessing.rst
@@ -1084,13 +1084,13 @@ Miscellaneous
    The return value can be ``'fork'``, ``'spawn'``, ``'forkserver'``
    or ``None``.  See :ref:`multiprocessing-start-methods`.
 
+   .. versionadded:: 3.4
+
    .. versionchanged:: 3.8
 
       On macOS, the *spawn* start method is now the default.  The *fork* start
       method should be considered unsafe as it can lead to crashes of the
       subprocess. See :issue:`33725`.
-
-   .. versionadded:: 3.4
 
 .. function:: set_executable(executable)
 


### PR DESCRIPTION
This PR fixes an erroneous indentation in the documentation of multiprocessing.get_start_method.

<!-- gh-issue-number: gh-115652 -->
* Issue: gh-115652
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--115658.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->