### PR TITLE
gh-115664: Fix chronological ordering of versionadded and versionchanged directives

### DIFF
--- a/Doc/library/codecs.rst
+++ b/Doc/library/codecs.rst
@@ -1541,12 +1541,12 @@ This module implements the ANSI codepage (CP_ACP).
 
 .. availability:: Windows.
 
-.. versionchanged:: 3.3
-   Support any error handler.
-
 .. versionchanged:: 3.2
    Before 3.2, the *errors* argument was ignored; ``'replace'`` was always used
    to encode, and ``'ignore'`` to decode.
+
+.. versionchanged:: 3.3
+   Support any error handler.
 
 
 :mod:`encodings.utf_8_sig` --- UTF-8 codec with BOM signature

--- a/Doc/library/math.rst
+++ b/Doc/library/math.rst
@@ -239,10 +239,10 @@ Number-theoretic and representation functions
 
    See also :func:`math.ulp`.
 
+   .. versionadded:: 3.9
+
    .. versionchanged:: 3.12
       Added the *steps* argument.
-
-   .. versionadded:: 3.9
 
 .. function:: perm(n, k=None)
 
@@ -680,10 +680,10 @@ Constants
       >>> math.isnan(float('nan'))
       True
 
+   .. versionadded:: 3.5
+
    .. versionchanged:: 3.11
       It is now always available.
-
-   .. versionadded:: 3.5
 
 
 .. impl-detail::

--- a/Doc/library/shutil.rst
+++ b/Doc/library/shutil.rst
@@ -274,15 +274,15 @@ Directory and files operations
 
    .. audit-event:: shutil.copytree src,dst shutil.copytree
 
-   .. versionchanged:: 3.3
-      Copy metadata when *symlinks* is false.
-      Now returns *dst*.
-
    .. versionchanged:: 3.2
       Added the *copy_function* argument to be able to provide a custom copy
       function.
       Added the *ignore_dangling_symlinks* argument to silence dangling symlinks
       errors when *symlinks* is false.
+
+   .. versionchanged:: 3.3
+      Copy metadata when *symlinks* is false.
+      Now returns *dst*.
 
    .. versionchanged:: 3.8
       Platform-specific fast-copy syscalls may be used internally in order to

--- a/Doc/library/sys.rst
+++ b/Doc/library/sys.rst
@@ -16,11 +16,11 @@ always available.
    On POSIX systems where Python was built with the standard ``configure``
    script, this contains the ABI flags as specified by :pep:`3149`.
 
+   .. versionadded:: 3.2
+
    .. versionchanged:: 3.8
       Default flags became an empty string (``m`` flag for pymalloc has been
       removed).
-
-   .. versionadded:: 3.2
 
    .. availability:: Unix.
 

--- a/Doc/library/venv.rst
+++ b/Doc/library/venv.rst
@@ -286,14 +286,14 @@ creation according to their needs, the :class:`EnvBuilder` class.
           the virtual environment.
 
 
-        .. versionchanged:: 3.12
-           The attribute ``lib_path`` was added to the context, and the context
-           object was documented.
-
         .. versionchanged:: 3.11
            The *venv*
            :ref:`sysconfig installation scheme <installation_paths>`
            is used to construct the paths of the created directories.
+
+        .. versionchanged:: 3.12
+           The attribute ``lib_path`` was added to the context, and the context
+           object was documented.
 
     .. method:: create_configuration(context)
 

--- a/Doc/using/venv-create.inc
+++ b/Doc/using/venv-create.inc
@@ -14,13 +14,13 @@ used at environment creation time). It also creates an (initially empty)
 ``Lib\site-packages``). If an existing directory is specified, it will be
 re-used.
 
+.. versionchanged:: 3.5
+   The use of ``venv`` is now recommended for creating virtual environments.
+
 .. deprecated:: 3.6
    ``pyvenv`` was the recommended tool for creating virtual environments for
    Python 3.3 and 3.4, and is
    :ref:`deprecated in Python 3.6 <whatsnew36-venv>`.
-
-.. versionchanged:: 3.5
-   The use of ``venv`` is now recommended for creating virtual environments.
 
 .. highlight:: none
 


### PR DESCRIPTION
Part of #115664.

More chronological order fixes for `versionadded` and `versionchanged` directives.

<!-- gh-issue-number: gh-115664 -->
* Issue: gh-115664
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--115676.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->