### PR TITLE
Make `python -m tomllib` convert toml (in) to json (out)

### DIFF
--- a/Lib/tomllib/__init__.py
+++ b/Lib/tomllib/__init__.py
@@ -8,3 +8,10 @@ from ._parser import TOMLDecodeError, load, loads
 
 # Pretend this exception was created here.
 TOMLDecodeError.__module__ = __name__
+
+
+if __name__ == '__main__':
+    import json
+    import sys
+
+    json.dump(load(sys.stdin.buffer), sys.stdout)

--- a/Misc/NEWS.d/next/Library/2024-02-19-22-15-53.gh-issue-115699.a3ea24.rst
+++ b/Misc/NEWS.d/next/Library/2024-02-19-22-15-53.gh-issue-115699.a3ea24.rst
@@ -1,0 +1,1 @@
+Make ``python -m tomllib`` convert toml (from stdin) to json (on stdout).


### PR DESCRIPTION
(Note: I didn't create a separate issue/discussion post for this because I figured the implementation itself is so trivial that it's better to just have a PR for it that either gets merged or rejected.)

This means `python -m tomllib` can be a universal shell tool for parsing toml files on stdin.

I had a use case for this in a shell script recently. I wanted to use toml for a config file since it's easier for humans to read/write than JSON, but it's annoying to install a whole dependency just to parse it. Since Python is almost universally available I decided to use `python -c 'import sys, tomllib, json; json.dump(tomllib.load(sys.stdin.buffer), sys.stdout)' < config.toml` to convert it into JSON for easier massaging with `jq` (which I always have installed).

This would make that 92-character snippet from the previous paragraph into a 17-character snippet. 🙂 I can't think of anything else that `tomllib`'s main block could/should do -- and this seems to be to be a useful enough behavior that it's worth adding.

I'm curious for others' thoughts!