### PR TITLE
gh-115068: Add address to ConnectionRefusedError message

### DIFF
--- a/Lib/socket.py
+++ b/Lib/socket.py
@@ -285,6 +285,14 @@ class socket(_socket.socket):
         sock.settimeout(self.gettimeout())
         return sock
 
+    def connect(self, address):
+        """Connect to a remote socket at address."""
+        try:
+            super().connect(address)
+        except ConnectionRefusedError as exc:
+            exc.strerror = f'{exc.strerror}: {address}'
+            raise
+
     def accept(self):
         """accept() -> (socket object, address info)
 

--- a/Lib/test/test_socket.py
+++ b/Lib/test/test_socket.py
@@ -5340,7 +5340,8 @@ class NetworkConnectionNoServer(unittest.TestCase):
         port = socket_helper.find_unused_port()
         cli = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         self.addCleanup(cli.close)
-        with self.assertRaises(OSError) as cm:
+        expected_err_msg = f"Connection refused: ('localhost', {port})"
+        with self.assertRaises(OSError, msg=expected_err_msg) as cm:
             cli.connect((HOST, port))
         self.assertEqual(cm.exception.errno, errno.ECONNREFUSED)
 

--- a/Lib/test/test_socket.py
+++ b/Lib/test/test_socket.py
@@ -5340,7 +5340,7 @@ class NetworkConnectionNoServer(unittest.TestCase):
         port = socket_helper.find_unused_port()
         cli = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         self.addCleanup(cli.close)
-        expected_regex = (f"\\[Errno 111] Connection refused: \\('localhost', "
+        expected_regex = (f"\\[\\w+ \\d+] [a-zA-Z ]+: \\('localhost', "
                           f"{port}\\)")
         with self.assertRaisesRegex(OSError, expected_regex) as cm:
             cli.connect((HOST, port))

--- a/Lib/test/test_socket.py
+++ b/Lib/test/test_socket.py
@@ -5340,8 +5340,9 @@ class NetworkConnectionNoServer(unittest.TestCase):
         port = socket_helper.find_unused_port()
         cli = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         self.addCleanup(cli.close)
-        expected_err_msg = f"Connection refused: ('localhost', {port})"
-        with self.assertRaises(OSError, msg=expected_err_msg) as cm:
+        expected_regex = (f"\\[Errno 111] Connection refused: \\('localhost', "
+                          f"{port}\\)")
+        with self.assertRaisesRegex(OSError, expected_regex) as cm:
             cli.connect((HOST, port))
         self.assertEqual(cm.exception.errno, errno.ECONNREFUSED)
 

--- a/Misc/NEWS.d/next/Core and Builtins/2024-02-20-16-20-10.gh-issue-115068.fN2R8C.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2024-02-20-16-20-10.gh-issue-115068.fN2R8C.rst
@@ -1,0 +1,2 @@
+Add the address to the error message if :exc:`ConnectionRefusedError` is
+raised when :meth:`socket.socket.connect` is called.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

Resolves #115068 

We override the C implementation of `socket.connect` using the Python implementation and call the function of the super class (the C implementation). If `ConnectionRefusedError` is raised, we simply catch it, modify the error message to include the address, and then raise it back again. There are other solutions, but I believe this is the simplest solution.

It is easy to also do this too for other exceptions raised. However, I was not sure if it would be out of scope, so for now we only catch `ConnectionRefusedError` in particular.

<!-- gh-issue-number: gh-115068 -->
* Issue: gh-115068
<!-- /gh-issue-number -->
