### PR TITLE
gh-115712: Support CSV dialects with delimiter=' ' and skipinitialspace=True

### DIFF
--- a/Misc/NEWS.d/next/Library/2024-02-20-16-42-54.gh-issue-115712.EXVMXw.rst
+++ b/Misc/NEWS.d/next/Library/2024-02-20-16-42-54.gh-issue-115712.EXVMXw.rst
@@ -1,0 +1,4 @@
+Restore support of space delimiter with ``skipinitialspace=True`` in
+:mod:`csv`. :func:`csv.writer()` now quotes empty fields if delimiter is a
+space and skipinitialspace is true and raises exception if quoting is not
+possible.


### PR DESCRIPTION
Restore support of such combination, disabled in gh-113796.

csv.writer() now quotes empty fields if delimiter is a space and skipinitialspace is true and raises exception if quoting is not possible.


<!-- gh-issue-number: gh-115712 -->
* Issue: gh-115712
<!-- /gh-issue-number -->
