### PR TITLE
gh-110850: Cleanup pycore_time.h includes

### DIFF
--- a/Include/internal/pycore_import.h
+++ b/Include/internal/pycore_import.h
@@ -11,7 +11,6 @@ extern "C" {
 
 #include "pycore_lock.h"          // PyMutex
 #include "pycore_hashtable.h"     // _Py_hashtable_t
-#include "pycore_time.h"          // PyTime_t
 
 extern int _PyImport_IsInitialized(PyInterpreterState *);
 

--- a/Include/internal/pycore_lock.h
+++ b/Include/internal/pycore_lock.h
@@ -13,8 +13,6 @@ extern "C" {
 #  error "this header requires Py_BUILD_CORE define"
 #endif
 
-#include "pycore_time.h"          // PyTime_t
-
 
 // A mutex that occupies one byte. The lock can be zero initialized.
 //

--- a/Include/internal/pycore_parking_lot.h
+++ b/Include/internal/pycore_parking_lot.h
@@ -18,8 +18,6 @@ extern "C" {
 #  error "this header requires Py_BUILD_CORE define"
 #endif
 
-#include "pycore_time.h"        // PyTime_t
-
 
 enum {
     // The thread was unparked by another thread.

--- a/Include/internal/pycore_semaphore.h
+++ b/Include/internal/pycore_semaphore.h
@@ -8,7 +8,6 @@
 #endif
 
 #include "pycore_pythread.h"      // _POSIX_SEMAPHORES
-#include "pycore_time.h"          // PyTime_t
 
 #ifdef MS_WINDOWS
 #   define WIN32_LEAN_AND_MEAN

--- a/Modules/_datetimemodule.c
+++ b/Modules/_datetimemodule.c
@@ -14,6 +14,8 @@
 #include "Python.h"
 #include "pycore_long.h"          // _PyLong_GetOne()
 #include "pycore_object.h"        // _PyObject_Init()
+#include "pycore_time.h"          // _PyTime_ObjectToTime_t()
+
 #include "datetime.h"
 
 

--- a/Modules/_lsprof.c
+++ b/Modules/_lsprof.c
@@ -6,6 +6,7 @@
 #include "pycore_call.h"          // _PyObject_CallNoArgs()
 #include "pycore_ceval.h"         // _PyEval_SetProfile()
 #include "pycore_pystate.h"       // _PyThreadState_GET()
+#include "pycore_time.h"          // _PyTime_FromNanosecondsObject()
 
 #include "rotatingtree.h"
 

--- a/Modules/_randommodule.c
+++ b/Modules/_randommodule.c
@@ -75,6 +75,7 @@
 #include "pycore_modsupport.h"    // _PyArg_NoKeywords()
 #include "pycore_moduleobject.h"  // _PyModule_GetState()
 #include "pycore_pylifecycle.h"   // _PyOS_URandomNonblock()
+#include "pycore_time.h"          // _PyTime_GetSystemClock()
 
 #ifdef HAVE_UNISTD_H
 #  include <unistd.h>             // getpid()

--- a/Modules/_ssl.c
+++ b/Modules/_ssl.c
@@ -28,6 +28,7 @@
 #include "Python.h"
 #include "pycore_fileutils.h"     // _PyIsSelectable_fd()
 #include "pycore_pyerrors.h"      // _PyErr_ChainExceptions1()
+#include "pycore_time.h"          // _PyDeadline_Init()
 #include "pycore_weakref.h"       // _PyWeakref_GET_REF()
 
 /* Include symbols from _socket module */

--- a/Modules/_testinternalcapi/test_lock.c
+++ b/Modules/_testinternalcapi/test_lock.c
@@ -1,8 +1,9 @@
 // C Extension module to test pycore_lock.h API
 
 #include "parts.h"
-
 #include "pycore_lock.h"
+#include "pycore_time.h"          // _PyTime_GetMonotonicClock()
+
 #include "clinic/test_lock.c.h"
 
 #ifdef MS_WINDOWS

--- a/Modules/_threadmodule.c
+++ b/Modules/_threadmodule.c
@@ -9,6 +9,7 @@
 #include "pycore_pylifecycle.h"
 #include "pycore_pystate.h"       // _PyThreadState_SetCurrent()
 #include "pycore_sysmodule.h"     // _PySys_GetAttr()
+#include "pycore_time.h"          // _PyTime_FromSeconds()
 #include "pycore_weakref.h"       // _PyWeakref_GET_REF()
 
 #include <stdbool.h>

--- a/Modules/faulthandler.c
+++ b/Modules/faulthandler.c
@@ -4,6 +4,7 @@
 #include "pycore_pystate.h"       // _PyThreadState_GET()
 #include "pycore_signal.h"        // Py_NSIG
 #include "pycore_sysmodule.h"     // _PySys_GetAttr()
+#include "pycore_time.h"          // _PyTime_FromSecondsObject()
 #include "pycore_traceback.h"     // _Py_DumpTracebackThreads
 
 #ifdef HAVE_UNISTD_H

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -23,6 +23,7 @@
 #include "pycore_pylifecycle.h"   // _PyOS_URandom()
 #include "pycore_pystate.h"       // _PyInterpreterState_GET()
 #include "pycore_signal.h"        // Py_NSIG
+#include "pycore_time.h"          // _PyLong_FromTime_t()
 
 #ifdef HAVE_UNISTD_H
 #  include <unistd.h>             // symlink()

--- a/Modules/signalmodule.c
+++ b/Modules/signalmodule.c
@@ -13,6 +13,7 @@
 #include "pycore_pyerrors.h"      // _PyErr_SetString()
 #include "pycore_pystate.h"       // _PyThreadState_GET()
 #include "pycore_signal.h"        // _Py_RestoreSignals()
+#include "pycore_time.h"          // _PyTime_FromSecondsObject()
 
 #ifndef MS_WINDOWS
 #  include "posixmodule.h"        // _PyLong_FromUid()

--- a/Modules/socketmodule.c
+++ b/Modules/socketmodule.c
@@ -109,6 +109,7 @@ Local naming conventions:
 #include "pycore_capsule.h"       // _PyCapsule_SetTraverse()
 #include "pycore_fileutils.h"     // _Py_set_inheritable()
 #include "pycore_moduleobject.h"  // _PyModule_GetState
+#include "pycore_time.h"          // _PyTime_AsMilliseconds()
 
 #ifdef _Py_MEMORY_SANITIZER
 #  include <sanitizer/msan_interface.h>

--- a/Modules/socketmodule.h
+++ b/Modules/socketmodule.h
@@ -1,7 +1,5 @@
 /* Socket module header file */
 
-#include "pycore_time.h"          // PyTime_t
-
 /* Includes needed for the sockaddr_* symbols below */
 #ifndef MS_WINDOWS
 #ifdef __VMS

--- a/Modules/timemodule.c
+++ b/Modules/timemodule.c
@@ -5,6 +5,7 @@
 #include "pycore_moduleobject.h"  // _PyModule_GetState()
 #include "pycore_namespace.h"     // _PyNamespace_New()
 #include "pycore_runtime.h"       // _Py_ID()
+#include "pycore_time.h"          // _PyTimeFraction
 
 #include <time.h>                 // clock()
 #ifdef HAVE_SYS_TIMES_H

--- a/Python/gc.c
+++ b/Python/gc.c
@@ -12,6 +12,7 @@
 #include "pycore_object_alloc.h"  // _PyObject_MallocWithType()
 #include "pycore_pyerrors.h"
 #include "pycore_pystate.h"       // _PyThreadState_GET()
+#include "pycore_time.h"          // _PyTime_GetPerfCounter()
 #include "pycore_weakref.h"       // _PyWeakref_ClearRef()
 #include "pydtrace.h"
 

--- a/Python/gc_free_threading.c
+++ b/Python/gc_free_threading.c
@@ -11,6 +11,7 @@
 #include "pycore_object_stack.h"
 #include "pycore_pyerrors.h"
 #include "pycore_pystate.h"       // _PyThreadState_GET()
+#include "pycore_time.h"          // _PyTime_GetPerfCounter()
 #include "pycore_tstate.h"        // _PyThreadStateImpl
 #include "pycore_weakref.h"       // _PyWeakref_ClearRef()
 #include "pydtrace.h"

--- a/Python/import.c
+++ b/Python/import.c
@@ -13,6 +13,7 @@
 #include "pycore_pymem.h"         // _PyMem_SetDefaultAllocator()
 #include "pycore_pystate.h"       // _PyInterpreterState_GET()
 #include "pycore_sysmodule.h"     // _PySys_Audit()
+#include "pycore_time.h"          // _PyTime_GetPerfCounter()
 #include "pycore_weakref.h"       // _PyWeakref_GET_REF()
 
 #include "marshal.h"              // PyMarshal_ReadObjectFromString()

--- a/Python/lock.c
+++ b/Python/lock.c
@@ -5,12 +5,13 @@
 #include "pycore_lock.h"
 #include "pycore_parking_lot.h"
 #include "pycore_semaphore.h"
+#include "pycore_time.h"          // _PyTime_GetMonotonicClock()
 
 #ifdef MS_WINDOWS
-#define WIN32_LEAN_AND_MEAN
-#include <windows.h>        // SwitchToThread()
+#  define WIN32_LEAN_AND_MEAN
+#  include <windows.h>        // SwitchToThread()
 #elif defined(HAVE_SCHED_H)
-#include <sched.h>          // sched_yield()
+#  include <sched.h>          // sched_yield()
 #endif
 
 // If a thread waits on a lock for longer than TIME_TO_BE_FAIR_NS (1 ms), then

--- a/Python/parking_lot.c
+++ b/Python/parking_lot.c
@@ -1,11 +1,12 @@
 #include "Python.h"
 
 #include "pycore_llist.h"
-#include "pycore_lock.h"        // _PyRawMutex
+#include "pycore_lock.h"          // _PyRawMutex
 #include "pycore_parking_lot.h"
-#include "pycore_pyerrors.h"    // _Py_FatalErrorFormat
-#include "pycore_pystate.h"     // _PyThreadState_GET
-#include "pycore_semaphore.h"   // _PySemaphore
+#include "pycore_pyerrors.h"      // _Py_FatalErrorFormat
+#include "pycore_pystate.h"       // _PyThreadState_GET
+#include "pycore_semaphore.h"     // _PySemaphore
+#include "pycore_time.h"          //_PyTime_GetMonotonicClock()
 
 #include <stdbool.h>
 

--- a/Python/thread_nt.h
+++ b/Python/thread_nt.h
@@ -1,4 +1,5 @@
-#include "pycore_interp.h"    // _PyInterpreterState.threads.stacksize
+#include "pycore_interp.h"        // _PyInterpreterState.threads.stacksize
+#include "pycore_time.h"          // _PyTime_AsMicroseconds()
 
 /* This code implemented by Dag.Gruneau@elsa.preseco.comm.se */
 /* Fast NonRecursiveMutex support by Yakov Markovitch, markovitch@iso.ru */

--- a/Python/thread_pthread.h
+++ b/Python/thread_pthread.h
@@ -1,5 +1,6 @@
 #include "pycore_interp.h"        // _PyInterpreterState.threads.stacksize
 #include "pycore_pythread.h"      // _POSIX_SEMAPHORES
+#include "pycore_time.h"          // _PyTime_FromMicrosecondsClamup()
 
 /* Posix threads interface */
 


### PR DESCRIPTION
<pycore_time.h> include is no longer needed to get the PyTime_t type in internal header files. This type is now provided by <Python.h> include. Add <pycore_time.h> includes to C files instead.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-110850 -->
* Issue: gh-110850
<!-- /gh-issue-number -->
