### PR TITLE
gh-115720: Show number of leaks in huntrleaks progress reports

### DIFF
--- a/Lib/test/libregrtest/refleak.py
+++ b/Lib/test/libregrtest/refleak.py
@@ -88,9 +88,12 @@ def runtest_refleak(test_name, test_func,
     rc_before = alloc_before = fd_before = interned_before = 0
 
     if not quiet:
-        print("beginning", repcount, "repetitions", file=sys.stderr)
-        print(("1234567890"*(repcount//10 + 1))[:repcount], file=sys.stderr,
-              flush=True)
+        print("beginning", repcount, "repetitions. Showing number of leaks "
+                "(. for zero, X for 10 or more)",
+              file=sys.stderr)
+        numbers = ("1234567890"*(repcount//10 + 1))[:repcount]
+        numbers = numbers[:warmups] + ':' + numbers[warmups:]
+        print(numbers, file=sys.stderr, flush=True)
 
     results = None
     dash_R_cleanup(fs, ps, pic, zdc, abcs)
@@ -116,12 +119,24 @@ def runtest_refleak(test_name, test_func,
         rc_after = gettotalrefcount() - interned_after * 2
         fd_after = fd_count()
 
-        if not quiet:
-            print('.', end='', file=sys.stderr, flush=True)
-
         rc_deltas[i] = get_pooled_int(rc_after - rc_before)
         alloc_deltas[i] = get_pooled_int(alloc_after - alloc_before)
         fd_deltas[i] = get_pooled_int(fd_after - fd_before)
+
+        if not quiet:
+            # use max, not sum, so total_leaks is one of the pooled ints
+            total_leaks = max(rc_deltas[i], alloc_deltas[i], fd_deltas[i])
+            if total_leaks <= 0:
+                symbol = '.'
+            elif total_leaks < 10:
+                symbol = str(total_leaks)
+            else:
+                symbol = 'X'
+            if i == warmups:
+                print(' ', end='', file=sys.stderr, flush=True)
+            print(symbol, end='', file=sys.stderr, flush=True)
+            del total_leaks
+            del symbol
 
         alloc_before = alloc_after
         rc_before = rc_after

--- a/Lib/test/libregrtest/refleak.py
+++ b/Lib/test/libregrtest/refleak.py
@@ -129,7 +129,9 @@ def runtest_refleak(test_name, test_func,
             if total_leaks <= 0:
                 symbol = '.'
             elif total_leaks < 10:
-                symbol = str(total_leaks)
+                symbol = (
+                    '.', '1', '2', '3', '4', '5', '6', '7', '8', '9',
+                    )[total_leaks]
             else:
                 symbol = 'X'
             if i == warmups:

--- a/Lib/test/libregrtest/refleak.py
+++ b/Lib/test/libregrtest/refleak.py
@@ -89,7 +89,7 @@ def runtest_refleak(test_name, test_func,
 
     if not quiet:
         print("beginning", repcount, "repetitions. Showing number of leaks "
-                "(. for zero, X for 10 or more)",
+                "(. for 0 or less, X for 10 or more)",
               file=sys.stderr)
         numbers = ("1234567890"*(repcount//10 + 1))[:repcount]
         numbers = numbers[:warmups] + ':' + numbers[warmups:]
@@ -175,14 +175,20 @@ def runtest_refleak(test_name, test_func,
     ]:
         # ignore warmup runs
         deltas = deltas[warmups:]
-        if checker(deltas):
+        failing = checker(deltas)
+        suspicious = any(deltas)
+        if failing or suspicious:
             msg = '%s leaked %s %s, sum=%s' % (
                 test_name, deltas, item_name, sum(deltas))
-            print(msg, file=sys.stderr, flush=True)
-            with open(filename, "a", encoding="utf-8") as refrep:
-                print(msg, file=refrep)
-                refrep.flush()
-            failed = True
+            print(msg, end='', file=sys.stderr)
+            if failing:
+                print(file=sys.stderr, flush=True)
+                with open(filename, "a", encoding="utf-8") as refrep:
+                    print(msg, file=refrep)
+                    refrep.flush()
+                failed = True
+            else:
+                print(' (this is fine)', file=sys.stderr, flush=True)
     return (failed, results)
 
 

--- a/Lib/test/test_regrtest.py
+++ b/Lib/test/test_regrtest.py
@@ -1171,8 +1171,8 @@ class ArgsTestCase(BaseTestCase):
                                 stderr=subprocess.STDOUT)
         self.check_executed_tests(output, [test], failed=test, stats=1)
 
-        line = 'beginning 6 repetitions\n123456\n......\n'
-        self.check_line(output, re.escape(line))
+        line = r'beginning 6 repetitions. .*\n123:456\n[.0-9X]{3} 111\n'
+        self.check_line(output, line)
 
         line2 = '%s leaked [1, 1, 1] %s, sum=3\n' % (test, what)
         self.assertIn(line2, output)

--- a/Misc/NEWS.d/next/Tests/2024-02-20-15-47-41.gh-issue-115720.w8i8UG.rst
+++ b/Misc/NEWS.d/next/Tests/2024-02-20-15-47-41.gh-issue-115720.w8i8UG.rst
@@ -1,0 +1,2 @@
+Leak tests (``-R``, ``--huntrleaks``) now show a summary of the number of
+leaks found in each iteration.


### PR DESCRIPTION
Instead of showing a dot for each iteration, show:
- '.' for warmup or no leaks
- number of leaks for 1-9
- 'X' if there are more leaks

Also, separate warmup runs by a colon & space.

This allows more insight into what's going on. It's especially useful for rapid iteration (like bisecting).



<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-115720 -->
* Issue: gh-115720
<!-- /gh-issue-number -->
