### PR TITLE
gh-110850: Replace private _PyTime_MAX with public PyTime_MAX

### DIFF
--- a/Include/internal/pycore_time.h
+++ b/Include/internal/pycore_time.h
@@ -318,10 +318,6 @@ extern int _PyTime_PerfCounterWithInfo(
     PyTime_t *t,
     _Py_clock_info_t *info);
 
-// Alias for backward compatibility
-#define _PyTime_MIN PyTime_MIN
-#define _PyTime_MAX PyTime_MAX
-
 
 // --- _PyDeadline -----------------------------------------------------------
 
@@ -352,7 +348,7 @@ extern int _PyTimeFraction_Set(
     PyTime_t denom);
 
 // Compute ticks * frac.numer / frac.denom.
-// Clamp to [_PyTime_MIN; _PyTime_MAX] on overflow.
+// Clamp to [PyTime_MIN; PyTime_MAX] on overflow.
 extern PyTime_t _PyTimeFraction_Mul(
     PyTime_t ticks,
     const _PyTimeFraction *frac);

--- a/Modules/_threadmodule.c
+++ b/Modules/_threadmodule.c
@@ -1948,7 +1948,7 @@ thread_module_exec(PyObject *module)
 
     // TIMEOUT_MAX
     double timeout_max = (double)PY_TIMEOUT_MAX * 1e-6;
-    double time_max = PyTime_AsSecondsDouble(_PyTime_MAX);
+    double time_max = PyTime_AsSecondsDouble(PyTime_MAX);
     timeout_max = Py_MIN(timeout_max, time_max);
     // Round towards minus infinity
     timeout_max = floor(timeout_max);

--- a/Python/thread_pthread.h
+++ b/Python/thread_pthread.h
@@ -486,9 +486,9 @@ PyThread_acquire_lock_timed(PyThread_type_lock lock, PY_TIMEOUT_T microseconds,
     if (microseconds >= 0) {
         // bpo-41710: PyThread_acquire_lock_timed() cannot report timeout
         // overflow to the caller, so clamp the timeout to
-        // [_PyTime_MIN, _PyTime_MAX].
+        // [PyTime_MIN, PyTime_MAX].
         //
-        // _PyTime_MAX nanoseconds is around 292.3 years.
+        // PyTime_MAX nanoseconds is around 292.3 years.
         //
         // _thread.Lock.acquire() and _thread.RLock.acquire() raise an
         // OverflowError if microseconds is greater than PY_TIMEOUT_MAX.


### PR DESCRIPTION
Remove references to the old names _PyTime_MIN
and _PyTime_MAX, now that PyTime_MIN and
PyTime_MAX are public.

Replace also _PyTime_MIN with PyTime_MIN.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-110850 -->
* Issue: gh-110850
<!-- /gh-issue-number -->
