### PR TITLE
gh-110850: Cleanup PyTime API: PyTime_t are nanoseconds

### DIFF
--- a/Include/internal/pycore_time.h
+++ b/Include/internal/pycore_time.h
@@ -140,17 +140,13 @@ PyAPI_FUNC(PyTime_t) _PyTime_FromSecondsDouble(double seconds, _PyTime_round_t r
 #define _PYTIME_FROMSECONDS(seconds) \
             ((PyTime_t)(seconds) * (1000 * 1000 * 1000))
 
-// Create a timestamp from a number of nanoseconds.
-// Export for '_testinternalcapi' shared extension.
-PyAPI_FUNC(PyTime_t) _PyTime_FromNanoseconds(PyTime_t ns);
-
 // Create a timestamp from a number of microseconds.
 // Clamp to [PyTime_MIN; PyTime_MAX] on overflow.
 extern PyTime_t _PyTime_FromMicrosecondsClamp(PyTime_t us);
 
-// Create a timestamp from nanoseconds (Python int).
+// Create a timestamp from a Python int object (number of nanoseconds).
 // Export for '_lsprof' shared extension.
-PyAPI_FUNC(int) _PyTime_FromNanosecondsObject(PyTime_t *t,
+PyAPI_FUNC(int) _PyTime_FromLong(PyTime_t *t,
     PyObject *obj);
 
 // Convert a number of seconds (Python float or int) to a timestamp.
@@ -183,10 +179,9 @@ extern PyTime_t _PyTime_As100Nanoseconds(PyTime_t t,
     _PyTime_round_t round);
 #endif
 
-// Convert timestamp to a number of nanoseconds (10^-9 seconds) as a Python int
-// object.
+// Convert a timestamp (number of nanoseconds) as a Python int object.
 // Export for '_testinternalcapi' shared extension.
-PyAPI_FUNC(PyObject*) _PyTime_AsNanosecondsObject(PyTime_t t);
+PyAPI_FUNC(PyObject*) _PyTime_AsLong(PyTime_t t);
 
 #ifndef MS_WINDOWS
 // Create a timestamp from a timeval structure.

--- a/Modules/_lsprof.c
+++ b/Modules/_lsprof.c
@@ -6,7 +6,7 @@
 #include "pycore_call.h"          // _PyObject_CallNoArgs()
 #include "pycore_ceval.h"         // _PyEval_SetProfile()
 #include "pycore_pystate.h"       // _PyThreadState_GET()
-#include "pycore_time.h"          // _PyTime_FromNanosecondsObject()
+#include "pycore_time.h"          // _PyTime_FromLong()
 
 #include "rotatingtree.h"
 
@@ -98,7 +98,7 @@ static PyTime_t CallExternalTimer(ProfilerObject *pObj)
     if (pObj->externalTimerUnit > 0.0) {
         /* interpret the result as an integer that will be scaled
            in profiler_getstats() */
-        err = _PyTime_FromNanosecondsObject(&result, o);
+        err = _PyTime_FromLong(&result, o);
     }
     else {
         /* interpret the result as a double measured in seconds.

--- a/Modules/_testinternalcapi/pytime.c
+++ b/Modules/_testinternalcapi/pytime.c
@@ -17,7 +17,7 @@ test_pytime_fromseconds(PyObject *self, PyObject *args)
         return NULL;
     }
     PyTime_t ts = _PyTime_FromSeconds(seconds);
-    return _PyTime_AsNanosecondsObject(ts);
+    return _PyTime_AsLong(ts);
 }
 
 static int
@@ -49,7 +49,7 @@ test_pytime_fromsecondsobject(PyObject *self, PyObject *args)
     if (_PyTime_FromSecondsObject(&ts, obj, round) == -1) {
         return NULL;
     }
-    return _PyTime_AsNanosecondsObject(ts);
+    return _PyTime_AsLong(ts);
 }
 
 static PyObject *
@@ -64,7 +64,7 @@ test_PyTime_AsTimeval(PyObject *self, PyObject *args)
         return NULL;
     }
     PyTime_t t;
-    if (_PyTime_FromNanosecondsObject(&t, obj) < 0) {
+    if (_PyTime_FromLong(&t, obj) < 0) {
         return NULL;
     }
     struct timeval tv;
@@ -91,7 +91,7 @@ test_PyTime_AsTimeval_clamp(PyObject *self, PyObject *args)
         return NULL;
     }
     PyTime_t t;
-    if (_PyTime_FromNanosecondsObject(&t, obj) < 0) {
+    if (_PyTime_FromLong(&t, obj) < 0) {
         return NULL;
     }
     struct timeval tv;
@@ -113,7 +113,7 @@ test_PyTime_AsTimespec(PyObject *self, PyObject *args)
         return NULL;
     }
     PyTime_t t;
-    if (_PyTime_FromNanosecondsObject(&t, obj) < 0) {
+    if (_PyTime_FromLong(&t, obj) < 0) {
         return NULL;
     }
     struct timespec ts;
@@ -131,7 +131,7 @@ test_PyTime_AsTimespec_clamp(PyObject *self, PyObject *args)
         return NULL;
     }
     PyTime_t t;
-    if (_PyTime_FromNanosecondsObject(&t, obj) < 0) {
+    if (_PyTime_FromLong(&t, obj) < 0) {
         return NULL;
     }
     struct timespec ts;
@@ -149,15 +149,14 @@ test_PyTime_AsMilliseconds(PyObject *self, PyObject *args)
         return NULL;
     }
     PyTime_t t;
-    if (_PyTime_FromNanosecondsObject(&t, obj) < 0) {
+    if (_PyTime_FromLong(&t, obj) < 0) {
         return NULL;
     }
     if (check_time_rounding(round) < 0) {
         return NULL;
     }
     PyTime_t ms = _PyTime_AsMilliseconds(t, round);
-    PyTime_t ns = _PyTime_FromNanoseconds(ms);
-    return _PyTime_AsNanosecondsObject(ns);
+    return _PyTime_AsLong(ms);
 }
 
 static PyObject *
@@ -169,15 +168,14 @@ test_PyTime_AsMicroseconds(PyObject *self, PyObject *args)
         return NULL;
     }
     PyTime_t t;
-    if (_PyTime_FromNanosecondsObject(&t, obj) < 0) {
+    if (_PyTime_FromLong(&t, obj) < 0) {
         return NULL;
     }
     if (check_time_rounding(round) < 0) {
         return NULL;
     }
     PyTime_t us = _PyTime_AsMicroseconds(t, round);
-    PyTime_t ns = _PyTime_FromNanoseconds(us);
-    return _PyTime_AsNanosecondsObject(ns);
+    return _PyTime_AsLong(us);
 }
 
 static PyObject *

--- a/Modules/timemodule.c
+++ b/Modules/timemodule.c
@@ -127,7 +127,7 @@ time_time_ns(PyObject *self, PyObject *unused)
     if (PyTime_Time(&t) < 0) {
         return NULL;
     }
-    return _PyTime_AsNanosecondsObject(t);
+    return _PyTime_AsLong(t);
 }
 
 PyDoc_STRVAR(time_ns_doc,
@@ -164,8 +164,7 @@ py_clock(time_module_state *state, PyTime_t *tp, _Py_clock_info_t *info)
                         "or its value cannot be represented");
         return -1;
     }
-    PyTime_t ns = _PyTimeFraction_Mul(ticks, base);
-    *tp = _PyTime_FromNanoseconds(ns);
+    *tp = _PyTimeFraction_Mul(ticks, base);
     return 0;
 }
 #endif /* HAVE_CLOCK */
@@ -259,7 +258,7 @@ time_clock_gettime_ns_impl(PyObject *module, clockid_t clk_id)
     if (_PyTime_FromTimespec(&t, &ts) < 0) {
         return NULL;
     }
-    return _PyTime_AsNanosecondsObject(t);
+    return _PyTime_AsLong(t);
 }
 #endif   /* HAVE_CLOCK_GETTIME */
 
@@ -308,7 +307,7 @@ time_clock_settime_ns(PyObject *self, PyObject *args)
         return NULL;
     }
 
-    if (_PyTime_FromNanosecondsObject(&t, obj) < 0) {
+    if (_PyTime_FromLong(&t, obj) < 0) {
         return NULL;
     }
     if (_PyTime_AsTimespec(t, &ts) == -1) {
@@ -1170,7 +1169,7 @@ time_monotonic_ns(PyObject *self, PyObject *unused)
     if (PyTime_Monotonic(&t) < 0) {
         return NULL;
     }
-    return _PyTime_AsNanosecondsObject(t);
+    return _PyTime_AsLong(t);
 }
 
 PyDoc_STRVAR(monotonic_ns_doc,
@@ -1202,7 +1201,7 @@ time_perf_counter_ns(PyObject *self, PyObject *unused)
     if (PyTime_PerfCounter(&t) < 0) {
         return NULL;
     }
-    return _PyTime_AsNanosecondsObject(t);
+    return _PyTime_AsLong(t);
 }
 
 PyDoc_STRVAR(perf_counter_ns_doc,
@@ -1233,7 +1232,7 @@ process_time_times(time_module_state *state, PyTime_t *tp,
     PyTime_t ns;
     ns = _PyTimeFraction_Mul(process.tms_utime, base);
     ns += _PyTimeFraction_Mul(process.tms_stime, base);
-    *tp = _PyTime_FromNanoseconds(ns);
+    *tp = ns;
     return 1;
 }
 #endif
@@ -1247,7 +1246,7 @@ py_process_time(time_module_state *state, PyTime_t *tp,
     HANDLE process;
     FILETIME creation_time, exit_time, kernel_time, user_time;
     ULARGE_INTEGER large;
-    PyTime_t ktime, utime, t;
+    PyTime_t ktime, utime;
     BOOL ok;
 
     process = GetCurrentProcess();
@@ -1274,8 +1273,7 @@ py_process_time(time_module_state *state, PyTime_t *tp,
     utime = large.QuadPart;
 
     /* ktime and utime have a resolution of 100 nanoseconds */
-    t = _PyTime_FromNanoseconds((ktime + utime) * 100);
-    *tp = t;
+    *tp = (ktime + utime) * 100;
     return 0;
 #else
 
@@ -1383,7 +1381,7 @@ time_process_time_ns(PyObject *module, PyObject *unused)
     if (py_process_time(state, &t, NULL) < 0) {
         return NULL;
     }
-    return _PyTime_AsNanosecondsObject(t);
+    return _PyTime_AsLong(t);
 }
 
 PyDoc_STRVAR(process_time_ns_doc,
@@ -1401,7 +1399,7 @@ _PyTime_GetThreadTimeWithInfo(PyTime_t *tp, _Py_clock_info_t *info)
     HANDLE thread;
     FILETIME creation_time, exit_time, kernel_time, user_time;
     ULARGE_INTEGER large;
-    PyTime_t ktime, utime, t;
+    PyTime_t ktime, utime;
     BOOL ok;
 
     thread =  GetCurrentThread();
@@ -1428,8 +1426,7 @@ _PyTime_GetThreadTimeWithInfo(PyTime_t *tp, _Py_clock_info_t *info)
     utime = large.QuadPart;
 
     /* ktime and utime have a resolution of 100 nanoseconds */
-    t = _PyTime_FromNanoseconds((ktime + utime) * 100);
-    *tp = t;
+    *tp = (ktime + utime) * 100;
     return 0;
 }
 
@@ -1453,7 +1450,7 @@ _PyTime_GetThreadTimeWithInfo(PyTime_t *tp, _Py_clock_info_t *info)
         info->adjustable = 0;
         info->resolution = 1e-9;
     }
-    *tp = _PyTime_FromNanoseconds(tc.stime + tc.utime);
+    *tp = (tc.stime + tc.utime);
     return 0;
 }
 
@@ -1470,7 +1467,7 @@ _PyTime_GetThreadTimeWithInfo(PyTime_t *tp, _Py_clock_info_t *info)
         info->monotonic = 1;
         info->adjustable = 0;
     }
-    *tp = _PyTime_FromNanoseconds(gethrvtime());
+    *tp = gethrvtime();
     return 0;
 }
 
@@ -1550,7 +1547,7 @@ time_thread_time_ns(PyObject *self, PyObject *unused)
     if (_PyTime_GetThreadTimeWithInfo(&t, NULL) < 0) {
         return NULL;
     }
-    return _PyTime_AsNanosecondsObject(t);
+    return _PyTime_AsLong(t);
 }
 
 PyDoc_STRVAR(thread_time_ns_doc,

--- a/Python/pytime.c
+++ b/Python/pytime.c
@@ -108,22 +108,6 @@ pytime_overflow(void)
 }
 
 
-static inline PyTime_t
-pytime_from_nanoseconds(PyTime_t t)
-{
-    // PyTime_t is a number of nanoseconds
-    return t;
-}
-
-
-static inline PyTime_t
-pytime_as_nanoseconds(PyTime_t t)
-{
-    // PyTime_t is a number of nanoseconds: see pytime_from_nanoseconds()
-    return t;
-}
-
-
 // Compute t1 + t2. Clamp to [PyTime_MIN; PyTime_MAX] on overflow.
 static inline int
 pytime_add(PyTime_t *t1, PyTime_t t2)
@@ -466,14 +450,7 @@ _PyTime_FromSeconds(int seconds)
     assert((t >= 0 && t <= PyTime_MAX / SEC_TO_NS)
            || (t < 0 && t >= PyTime_MIN / SEC_TO_NS));
     t *= SEC_TO_NS;
-    return pytime_from_nanoseconds(t);
-}
-
-
-PyTime_t
-_PyTime_FromNanoseconds(PyTime_t ns)
-{
-    return pytime_from_nanoseconds(ns);
+    return t;
 }
 
 
@@ -481,14 +458,13 @@ PyTime_t
 _PyTime_FromMicrosecondsClamp(PyTime_t us)
 {
     PyTime_t ns = _PyTime_Mul(us, US_TO_NS);
-    return pytime_from_nanoseconds(ns);
+    return ns;
 }
 
 
 int
-_PyTime_FromNanosecondsObject(PyTime_t *tp, PyObject *obj)
+_PyTime_FromLong(PyTime_t *tp, PyObject *obj)
 {
-
     if (!PyLong_Check(obj)) {
         PyErr_Format(PyExc_TypeError, "expect int, got %s",
                      Py_TYPE(obj)->tp_name);
@@ -506,7 +482,7 @@ _PyTime_FromNanosecondsObject(PyTime_t *tp, PyObject *obj)
     }
 
     PyTime_t t = (PyTime_t)nsec;
-    *tp = pytime_from_nanoseconds(t);
+    *tp = t;
     return 0;
 }
 
@@ -526,7 +502,7 @@ pytime_fromtimespec(PyTime_t *tp, const struct timespec *ts, int raise_exc)
     tv_nsec = ts->tv_nsec;
     int res2 = pytime_add(&t, tv_nsec);
 
-    *tp = pytime_from_nanoseconds(t);
+    *tp = t;
 
     if (raise_exc && (res1 < 0 || res2 < 0)) {
         pytime_overflow();
@@ -556,7 +532,7 @@ pytime_fromtimeval(PyTime_t *tp, struct timeval *tv, int raise_exc)
     PyTime_t usec = (PyTime_t)tv->tv_usec * US_TO_NS;
     int res2 = pytime_add(&t, usec);
 
-    *tp = pytime_from_nanoseconds(t);
+    *tp = t;
 
     if (raise_exc && (res1 < 0 || res2 < 0)) {
         pytime_overflow();
@@ -593,7 +569,7 @@ pytime_from_double(PyTime_t *tp, double value, _PyTime_round_t round,
     }
     PyTime_t ns = (PyTime_t)d;
 
-    *tp = pytime_from_nanoseconds(ns);
+    *tp = ns;
     return 0;
 }
 
@@ -628,7 +604,7 @@ pytime_from_object(PyTime_t *tp, PyObject *obj, _PyTime_round_t round,
             return -1;
         }
 
-        *tp = pytime_from_nanoseconds(ns);
+        *tp = ns;
         return 0;
     }
 }
@@ -649,12 +625,11 @@ _PyTime_FromMillisecondsObject(PyTime_t *tp, PyObject *obj, _PyTime_round_t roun
 
 
 double
-PyTime_AsSecondsDouble(PyTime_t t)
+PyTime_AsSecondsDouble(PyTime_t ns)
 {
     /* volatile avoids optimization changing how numbers are rounded */
     volatile double d;
 
-    PyTime_t ns = pytime_as_nanoseconds(t);
     if (ns % SEC_TO_NS == 0) {
         /* Divide using integers to avoid rounding issues on the integer part.
            1e-9 cannot be stored exactly in IEEE 64-bit. */
@@ -670,9 +645,8 @@ PyTime_AsSecondsDouble(PyTime_t t)
 
 
 PyObject *
-_PyTime_AsNanosecondsObject(PyTime_t t)
+_PyTime_AsLong(PyTime_t ns)
 {
-    PyTime_t ns =  pytime_as_nanoseconds(t);
     static_assert(sizeof(long long) >= sizeof(PyTime_t),
                   "PyTime_t is larger than long long");
     return PyLong_FromLongLong((long long)ns);
@@ -786,35 +760,31 @@ pytime_divmod(const PyTime_t t, const PyTime_t k,
 
 #ifdef MS_WINDOWS
 PyTime_t
-_PyTime_As100Nanoseconds(PyTime_t t, _PyTime_round_t round)
+_PyTime_As100Nanoseconds(PyTime_t ns, _PyTime_round_t round)
 {
-    PyTime_t ns = pytime_as_nanoseconds(t);
     return pytime_divide(ns, NS_TO_100NS, round);
 }
 #endif
 
 
 PyTime_t
-_PyTime_AsMicroseconds(PyTime_t t, _PyTime_round_t round)
+_PyTime_AsMicroseconds(PyTime_t ns, _PyTime_round_t round)
 {
-    PyTime_t ns = pytime_as_nanoseconds(t);
     return pytime_divide(ns, NS_TO_US, round);
 }
 
 
 PyTime_t
-_PyTime_AsMilliseconds(PyTime_t t, _PyTime_round_t round)
+_PyTime_AsMilliseconds(PyTime_t ns, _PyTime_round_t round)
 {
-    PyTime_t ns = pytime_as_nanoseconds(t);
     return pytime_divide(ns, NS_TO_MS, round);
 }
 
 
 static int
-pytime_as_timeval(PyTime_t t, PyTime_t *ptv_sec, int *ptv_usec,
+pytime_as_timeval(PyTime_t ns, PyTime_t *ptv_sec, int *ptv_usec,
                   _PyTime_round_t round)
 {
-    PyTime_t ns = pytime_as_nanoseconds(t);
     PyTime_t us = pytime_divide(ns, US_TO_NS, round);
 
     PyTime_t tv_sec, tv_usec;
@@ -886,9 +856,8 @@ _PyTime_AsTimevalTime_t(PyTime_t t, time_t *p_secs, int *us,
 
 #if defined(HAVE_CLOCK_GETTIME) || defined(HAVE_KQUEUE)
 static int
-pytime_as_timespec(PyTime_t t, struct timespec *ts, int raise_exc)
+pytime_as_timespec(PyTime_t ns, struct timespec *ts, int raise_exc)
 {
-    PyTime_t ns = pytime_as_nanoseconds(t);
     PyTime_t tv_sec, tv_nsec;
     int res = pytime_divmod(ns, SEC_TO_NS, &tv_sec, &tv_nsec);
 
@@ -936,7 +905,7 @@ py_get_system_clock(PyTime_t *tp, _Py_clock_info_t *info, int raise_exc)
        the 1st january 1601 and the 1st january 1970 (369 years + 89 leap
        days). */
     PyTime_t ns = large.QuadPart * 100 - 11644473600000000000;
-    *tp = pytime_from_nanoseconds(ns);
+    *tp = ns;
     if (info) {
         DWORD timeAdjustment, timeIncrement;
         BOOL isTimeAdjustmentDisabled, ok;
@@ -1160,12 +1129,10 @@ py_get_monotonic_clock(PyTime_t *tp, _Py_clock_info_t *info, int raise_exc)
     PyTime_t ticks = (PyTime_t)uticks;
 
     PyTime_t ns = _PyTimeFraction_Mul(ticks, &base);
-    *tp = pytime_from_nanoseconds(ns);
+    *tp = ns;
 
 #elif defined(__hpux)
-    hrtime_t time;
-
-    time = gethrtime();
+    hrtime_t time = gethrtime();
     if (time == -1) {
         if (raise_exc) {
             PyErr_SetFromErrno(PyExc_OSError);
@@ -1173,7 +1140,7 @@ py_get_monotonic_clock(PyTime_t *tp, _Py_clock_info_t *info, int raise_exc)
         return -1;
     }
 
-    *tp = pytime_from_nanoseconds(time);
+    *tp = time;
 
     if (info) {
         info->implementation = "gethrtime()";
@@ -1316,7 +1283,7 @@ py_get_win_perf_counter(PyTime_t *tp, _Py_clock_info_t *info, int raise_exc)
     ticks = (PyTime_t)ticksll;
 
     PyTime_t ns = _PyTimeFraction_Mul(ticks, &base);
-    *tp = pytime_from_nanoseconds(ns);
+    *tp = ns;
     return 0;
 }
 #endif  // MS_WINDOWS

--- a/Python/pytime.c
+++ b/Python/pytime.c
@@ -255,7 +255,7 @@ _PyTime_AsTime_t(PyTime_t t, time_t *t2)
 // Convert PyTime_t to long.
 // Return 0 on success. Return -1 and clamp the value on overflow.
 static int
-_PyTime_AsLong(PyTime_t t, long *t2)
+_PyTime_AsCLong(PyTime_t t, long *t2)
 {
 #if SIZEOF_LONG < _SIZEOF_PYTIME_T
     if ((PyTime_t)LONG_MAX < t) {
@@ -805,7 +805,7 @@ pytime_as_timeval_struct(PyTime_t t, struct timeval *tv,
     int res2;
 #ifdef MS_WINDOWS
     // On Windows, timeval.tv_sec type is long
-    res2 = _PyTime_AsLong(tv_sec, &tv->tv_sec);
+    res2 = _PyTime_AsCLong(tv_sec, &tv->tv_sec);
 #else
     res2 = _PyTime_AsTime_t(tv_sec, &tv->tv_sec);
 #endif

--- a/Python/thread.c
+++ b/Python/thread.c
@@ -20,8 +20,8 @@
 
 // Define PY_TIMEOUT_MAX constant.
 #ifdef _POSIX_THREADS
-   // PyThread_acquire_lock_timed() uses _PyTime_FromNanoseconds(us * 1000),
-   // convert microseconds to nanoseconds.
+   // PyThread_acquire_lock_timed() uses (us * 1000) to convert microseconds
+   // to nanoseconds.
 #  define PY_TIMEOUT_MAX_VALUE (LLONG_MAX / 1000)
 #elif defined (NT_THREADS)
    // WaitForSingleObject() accepts timeout in milliseconds in the range

--- a/Python/thread_nt.h
+++ b/Python/thread_nt.h
@@ -77,7 +77,7 @@ EnterNonRecursiveMutex(PNRMUTEX mutex, DWORD milliseconds)
         }
     } else if (milliseconds != 0) {
         /* wait at least until the deadline */
-        PyTime_t nanoseconds = _PyTime_FromNanoseconds((PyTime_t)milliseconds * 1000000);
+        PyTime_t nanoseconds = (PyTime_t)milliseconds * (1000 * 1000);
         PyTime_t deadline = _PyTime_Add(_PyTime_PerfCounterUnchecked(), nanoseconds);
         while (mutex->locked) {
             PyTime_t microseconds = _PyTime_AsMicroseconds(nanoseconds,

--- a/Python/thread_pthread.h
+++ b/Python/thread_pthread.h
@@ -495,7 +495,7 @@ PyThread_acquire_lock_timed(PyThread_type_lock lock, PY_TIMEOUT_T microseconds,
         timeout = _PyTime_FromMicrosecondsClamp(microseconds);
     }
     else {
-        timeout = _PyTime_FromNanoseconds(-1);
+        timeout = -1;
     }
 
 #ifdef HAVE_SEM_CLOCKWAIT


### PR DESCRIPTION
PyTime_t no longer uses an arbitrary unit, it's always a number of nanoseconds (64-bit signed integer).

* Rename _PyTime_FromNanosecondsObject() to _PyTime_FromLong().
* Rename _PyTime_AsNanosecondsObject() to _PyTime_AsLong().
* Remove pytime_from_nanoseconds().
* Remove pytime_as_nanoseconds().
* Remove _PyTime_FromNanoseconds().

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-110850 -->
* Issue: gh-110850
<!-- /gh-issue-number -->
