### PR TITLE
gh-115714: Don't use CLOCK_PROCESS_CPUTIME_ID and times() on WASI

### DIFF
--- a/Misc/NEWS.d/next/Library/2024-02-22-12-10-18.gh-issue-115714.P2JsU1.rst
+++ b/Misc/NEWS.d/next/Library/2024-02-22-12-10-18.gh-issue-115714.P2JsU1.rst
@@ -1,0 +1,4 @@
+On WASI, the :mod:`time` module no longer get process time using ``times()``
+or ``CLOCK_PROCESS_CPUTIME_ID``, system API is that is unreliable and is
+likely to be removed from WASI. The affected clock functions fall back to
+calling ``clock()``.

--- a/Modules/timemodule.c
+++ b/Modules/timemodule.c
@@ -76,7 +76,8 @@ static int pysleep(PyTime_t timeout);
 
 typedef struct {
     PyTypeObject *struct_time_type;
-#ifdef HAVE_TIMES
+// gh-115714: Don't use times() on WASI.
+#if defined(HAVE_TIMES) && !defined(__wasi__)
     // times() clock frequency in hertz
     _PyTimeFraction times_base;
 #endif
@@ -1211,7 +1212,8 @@ PyDoc_STRVAR(perf_counter_ns_doc,
 Performance counter for benchmarking as nanoseconds.");
 
 
-#ifdef HAVE_TIMES
+// gh-115714: Don't use times() on WASI.
+#if defined(HAVE_TIMES) && !defined(__wasi__)
 static int
 process_time_times(time_module_state *state, PyTime_t *tp,
                    _Py_clock_info_t *info)
@@ -1280,8 +1282,10 @@ py_process_time(time_module_state *state, PyTime_t *tp,
 #else
 
     /* clock_gettime */
+// gh-115714: Don't use CLOCK_PROCESS_CPUTIME_ID on WASI.
 #if defined(HAVE_CLOCK_GETTIME) \
-    && (defined(CLOCK_PROCESS_CPUTIME_ID) || defined(CLOCK_PROF))
+    && (defined(CLOCK_PROCESS_CPUTIME_ID) || defined(CLOCK_PROF)) \
+    && !defined(__wasi__)
     struct timespec ts;
 
     if (HAVE_CLOCK_GETTIME_RUNTIME) {
@@ -1343,7 +1347,8 @@ py_process_time(time_module_state *state, PyTime_t *tp,
 #endif
 
     /* times() */
-#ifdef HAVE_TIMES
+// gh-115714: Don't use times() on WASI.
+#if defined(HAVE_TIMES) && !defined(__wasi__)
     int res = process_time_times(state, tp, info);
     if (res < 0) {
         return -1;
@@ -2071,7 +2076,8 @@ time_exec(PyObject *module)
     }
 #endif
 
-#ifdef HAVE_TIMES
+// gh-115714: Don't use times() on WASI.
+#if defined(HAVE_TIMES) && !defined(__wasi__)
     long ticks_per_second;
     if (_Py_GetTicksPerSecond(&ticks_per_second) < 0) {
         PyErr_SetString(PyExc_RuntimeError,


### PR DESCRIPTION
Either the results of these functions are too large, or `sysconf(_SC_CLK_TCK)` (`_Py_GetTicksPerSecond`) is too small.

wasi-libc is considering removing process time locks entirely: https://github.com/WebAssembly/wasi-libc/issues/266

This removes them from Python's `time` early. `time.process_time()` falls back to `clock()`:

```
>>> import time
>>> time.time(); time.process_time()
1708512528.3618634
14.538878902
>>> time.time(); time.process_time()
1708512529.045383
15.222434329
>>> time.get_clock_info('process_time')
namespace(implementation='clock()', monotonic=True, adjustable=False, resolution=1e-09)
```


<!-- gh-issue-number: gh-115714 -->
* Issue: gh-115714
<!-- /gh-issue-number -->
