### PR TITLE
[3.12] gh-113655: Increase stack reserve size on Windows for when running PGO

### DIFF
--- a/PCbuild/python.vcxproj
+++ b/PCbuild/python.vcxproj
@@ -96,6 +96,7 @@
       <SubSystem>Console</SubSystem>
       <StackReserveSize Condition="$(Configuration) != 'Debug'">2000000</StackReserveSize>
       <StackReserveSize Condition="$(Configuration) == 'Debug'">8000000</StackReserveSize>
+      <StackReserveSize Condition="$(Configuration) == 'PGInstrument'">8000000</StackReserveSize>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/PCbuild/pythonw.vcxproj
+++ b/PCbuild/pythonw.vcxproj
@@ -91,6 +91,7 @@
     <Link>
       <StackReserveSize Condition="$(Configuration) != 'Debug'">2000000</StackReserveSize>
       <StackReserveSize Condition="$(Configuration) == 'Debug'">8000000</StackReserveSize>
+      <StackReserveSize Condition="$(Configuration) == 'PGInstrument'">8000000</StackReserveSize>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>


### PR DESCRIPTION
Not sure whether this is the same underlying cause as #113655, but it's essentially the same fix, so linking it to the same issue.

<!-- gh-issue-number: gh-113655 -->
* Issue: gh-113655
<!-- /gh-issue-number -->
