### PR TITLE
gh-115663: Remove 'regen-sbom' from the 'regen-all' target

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -162,7 +162,7 @@ jobs:
       - name: Build CPython
         run: |
           make -j4 regen-all
-          make regen-stdlib-module-names
+          make regen-stdlib-module-names regen-sbom
       - name: Check for changes
         run: |
           git add -u

--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -1627,10 +1627,10 @@ regen-unicodedata:
 regen-all: regen-cases regen-typeslots \
 	regen-token regen-ast regen-keyword regen-sre regen-frozen \
 	regen-pegen-metaparser regen-pegen regen-test-frozenmain \
-	regen-test-levenshtein regen-global-objects regen-sbom regen-jit
+	regen-test-levenshtein regen-global-objects regen-jit
 	@echo
 	@echo "Note: make regen-stdlib-module-names, make regen-limited-abi, "
-	@echo "make regen-configure and make regen-unicodedata should be run manually"
+	@echo "make regen-configure, make regen-sbom, and make regen-unicodedata should be run manually"
 
 ############################################################################
 # Special rules for object files


### PR DESCRIPTION
This PR removes the `regen-sbom` target from `regen-all`, since it's only meant to be run by CPython CI and not by downstream distributors.

<!-- gh-issue-number: gh-115663 -->
* Issue: gh-115663
<!-- /gh-issue-number -->
