### PR TITLE
gh-115765: Don't use deprecated AC_EGREP_* macros in configure.ac

### DIFF
--- a/aclocal.m4
+++ b/aclocal.m4
@@ -275,62 +275,6 @@ AC_DEFUN([AX_CHECK_OPENSSL], [
     AC_SUBST([OPENSSL_LDFLAGS])
 ])
 
-# ===========================================================================
-#     https://www.gnu.org/software/autoconf-archive/ax_check_typedef.html
-# ===========================================================================
-#
-# SYNOPSIS
-#
-#   AX_CHECK_TYPEDEF(TYPEDEF, HEADER [, ACTION-IF-FOUND [, ACTION-IF-NOT-FOUND ]])
-#
-# DESCRIPTION
-#
-#   Check if the given typedef-name is recognized as a type. The trick is to
-#   use a sizeof(TYPEDEF) and see if the compiler is happy with that.
-#
-#   This can be thought of as a mixture of AC_CHECK_TYPE(TYPEDEF,DEFAULT)
-#   and AC_CHECK_LIB(LIBRARY,FUNCTION,ACTION-IF-FOUND,ACTION-IF-NOT-FOUND).
-#
-#   A convenience macro AX_CHECK_TYPEDEF_ is provided that will not emit any
-#   message to the user - it just executes one of the actions.
-#
-# LICENSE
-#
-#   Copyright (c) 2008 Guido U. Draheim <guidod@gmx.de>
-#
-#   Copying and distribution of this file, with or without modification, are
-#   permitted in any medium without royalty provided the copyright notice
-#   and this notice are preserved.  This file is offered as-is, without any
-#   warranty.
-
-#serial 8
-
-AU_ALIAS([AC_CHECK_TYPEDEF], [AX_CHECK_TYPEDEF])
-AC_DEFUN([AX_CHECK_TYPEDEF_],
-[dnl
-ac_lib_var=`echo $1['_']$2 | sed 'y%./+-%__p_%'`
-AC_CACHE_VAL(ac_cv_lib_$ac_lib_var,
-[ eval "ac_cv_type_$ac_lib_var='not-found'"
-  ac_cv_check_typedef_header=`echo ifelse([$2], , stddef.h, $2)`
-  AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <$ac_cv_check_typedef_header>]],
-    [[int x = sizeof($1); x = x;]])],
-    [eval "ac_cv_type_$ac_lib_var=yes"],
-    [eval "ac_cv_type_$ac_lib_var=no"])
-  if test `eval echo '$ac_cv_type_'$ac_lib_var` = "no" ; then
-     ifelse([$4], , :, $4)
-  else
-     ifelse([$3], , :, $3)
-  fi
-])])
-
-dnl AX_CHECK_TYPEDEF(TYPEDEF, HEADER [, ACTION-IF-FOUND,
-dnl    [, ACTION-IF-NOT-FOUND ]])
-AC_DEFUN([AX_CHECK_TYPEDEF],
-[dnl
- AC_MSG_CHECKING([for $1 in $2])
- AX_CHECK_TYPEDEF_($1,$2,AC_MSG_RESULT(yes),AC_MSG_RESULT(no))dnl
-])
-
 # pkg.m4 - Macros to locate and utilise pkg-config.   -*- Autoconf -*-
 # serial 12 (pkg-config-0.29.2)
 

--- a/aclocal.m4
+++ b/aclocal.m4
@@ -275,6 +275,62 @@ AC_DEFUN([AX_CHECK_OPENSSL], [
     AC_SUBST([OPENSSL_LDFLAGS])
 ])
 
+# ===========================================================================
+#     https://www.gnu.org/software/autoconf-archive/ax_check_typedef.html
+# ===========================================================================
+#
+# SYNOPSIS
+#
+#   AX_CHECK_TYPEDEF(TYPEDEF, HEADER [, ACTION-IF-FOUND [, ACTION-IF-NOT-FOUND ]])
+#
+# DESCRIPTION
+#
+#   Check if the given typedef-name is recognized as a type. The trick is to
+#   use a sizeof(TYPEDEF) and see if the compiler is happy with that.
+#
+#   This can be thought of as a mixture of AC_CHECK_TYPE(TYPEDEF,DEFAULT)
+#   and AC_CHECK_LIB(LIBRARY,FUNCTION,ACTION-IF-FOUND,ACTION-IF-NOT-FOUND).
+#
+#   A convenience macro AX_CHECK_TYPEDEF_ is provided that will not emit any
+#   message to the user - it just executes one of the actions.
+#
+# LICENSE
+#
+#   Copyright (c) 2008 Guido U. Draheim <guidod@gmx.de>
+#
+#   Copying and distribution of this file, with or without modification, are
+#   permitted in any medium without royalty provided the copyright notice
+#   and this notice are preserved.  This file is offered as-is, without any
+#   warranty.
+
+#serial 8
+
+AU_ALIAS([AC_CHECK_TYPEDEF], [AX_CHECK_TYPEDEF])
+AC_DEFUN([AX_CHECK_TYPEDEF_],
+[dnl
+ac_lib_var=`echo $1['_']$2 | sed 'y%./+-%__p_%'`
+AC_CACHE_VAL(ac_cv_lib_$ac_lib_var,
+[ eval "ac_cv_type_$ac_lib_var='not-found'"
+  ac_cv_check_typedef_header=`echo ifelse([$2], , stddef.h, $2)`
+  AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <$ac_cv_check_typedef_header>]],
+    [[int x = sizeof($1); x = x;]])],
+    [eval "ac_cv_type_$ac_lib_var=yes"],
+    [eval "ac_cv_type_$ac_lib_var=no"])
+  if test `eval echo '$ac_cv_type_'$ac_lib_var` = "no" ; then
+     ifelse([$4], , :, $4)
+  else
+     ifelse([$3], , :, $3)
+  fi
+])])
+
+dnl AX_CHECK_TYPEDEF(TYPEDEF, HEADER [, ACTION-IF-FOUND,
+dnl    [, ACTION-IF-NOT-FOUND ]])
+AC_DEFUN([AX_CHECK_TYPEDEF],
+[dnl
+ AC_MSG_CHECKING([for $1 in $2])
+ AX_CHECK_TYPEDEF_($1,$2,AC_MSG_RESULT(yes),AC_MSG_RESULT(no))dnl
+])
+
 # pkg.m4 - Macros to locate and utilise pkg-config.   -*- Autoconf -*-
 # serial 12 (pkg-config-0.29.2)
 

--- a/configure
+++ b/configure
@@ -11223,7 +11223,7 @@ fi
 
 
 # Check for clock_t in time.h.
-ac_fn_c_check_type "$LINENO" "clock_t" "ac_cv_type_clock_t" "#include time.h
+ac_fn_c_check_type "$LINENO" "clock_t" "ac_cv_type_clock_t" "#include <time.h>
 "
 if test "x$ac_cv_type_clock_t" = xyes
 then :
@@ -11232,12 +11232,9 @@ printf "%s\n" "#define HAVE_CLOCK_T 1" >>confdefs.h
 
 
 else $as_nop
-  if test "x$ac_cv_type_clock_t" = xno
-then :
 
 printf "%s\n" "#define clock_t long" >>confdefs.h
 
-fi
 fi
 
 
@@ -16090,13 +16087,6 @@ printf %s "checking for _POSIX_THREADS in unistd.h... " >&6; }
 #error "check failed"
 #endif
 
-int
-main (void)
-{
-
-  ;
-  return 0;
-}
 _ACEOF
 if ac_fn_c_try_cpp "$LINENO"
 then :
@@ -16622,13 +16612,6 @@ printf %s "checking ipv6 stack type... " >&6; }
 #error "check failed"
 #endif
 
-int
-main (void)
-{
-
-  ;
-  return 0;
-}
 _ACEOF
 if ac_fn_c_try_cpp "$LINENO"
 then :
@@ -16648,13 +16631,6 @@ rm -f conftest.err conftest.i conftest.$ac_ext
 #error "check failed"
 #endif
 
-int
-main (void)
-{
-
-  ;
-  return 0;
-}
 _ACEOF
 if ac_fn_c_try_cpp "$LINENO"
 then :
@@ -16677,13 +16653,6 @@ rm -f conftest.err conftest.i conftest.$ac_ext
 #error "check failed"
 #endif
 
-int
-main (void)
-{
-
-  ;
-  return 0;
-}
 _ACEOF
 if ac_fn_c_try_cpp "$LINENO"
 then :
@@ -16720,13 +16689,6 @@ rm -f conftest.err conftest.i conftest.$ac_ext
 #error "check failed"
 #endif
 
-int
-main (void)
-{
-
-  ;
-  return 0;
-}
 _ACEOF
 if ac_fn_c_try_cpp "$LINENO"
 then :
@@ -16748,13 +16710,6 @@ rm -f conftest.err conftest.i conftest.$ac_ext
 #error "check failed"
 #endif
 
-int
-main (void)
-{
-
-  ;
-  return 0;
-}
 _ACEOF
 if ac_fn_c_try_cpp "$LINENO"
 then :
@@ -16777,13 +16732,6 @@ rm -f conftest.err conftest.i conftest.$ac_ext
 #error "check failed"
 #endif
 
-int
-main (void)
-{
-
-  ;
-  return 0;
-}
 _ACEOF
 if ac_fn_c_try_cpp "$LINENO"
 then :

--- a/configure
+++ b/configure
@@ -11221,7 +11221,6 @@ fi
 
 
 # checks for typedefs
-
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for clock_t in time.h" >&5
 printf %s "checking for clock_t in time.h... " >&6; }
 if test ${ac_cv_clock_t_time_h+y}
@@ -11229,19 +11228,42 @@ then :
   printf %s "(cached) " >&6
 else $as_nop
 
+   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for clock_t in time.h" >&5
+printf %s "checking for clock_t in time.h... " >&6; }
+ ac_lib_var=`echo clock_t'_'time.h | sed 'y%./+-%__p_%'`
+if eval test \${ac_cv_lib_$ac_lib_var+y}
+then :
+  printf %s "(cached) " >&6
+else $as_nop
+   eval "ac_cv_type_$ac_lib_var='not-found'"
+  ac_cv_check_typedef_header=`echo time.h`
   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
-#include <time.h>
-
+#include <$ac_cv_check_typedef_header>
+int
+main (void)
+{
+int x = sizeof(clock_t); x = x;
+  ;
+  return 0;
+}
 _ACEOF
-if (eval "$ac_cpp conftest.$ac_ext") 2>&5 |
-  $EGREP "clock_t" >/dev/null 2>&1
+if ac_fn_c_try_compile "$LINENO"
 then :
-  ac_cv_clock_t_time_h=yes
+  eval "ac_cv_type_$ac_lib_var=yes"
 else $as_nop
-  ac_cv_clock_t_time_h=no
+  eval "ac_cv_type_$ac_lib_var=no"
 fi
-rm -rf conftest*
+rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
+  if test `eval echo '$ac_cv_type_'$ac_lib_var` = "no" ; then
+     { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
+printf "%s\n" "no" >&6; }
+  else
+     { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+printf "%s\n" "yes" >&6; }
+  fi
+
+fi
 
 
 fi
@@ -11456,6 +11478,7 @@ else $as_nop
 printf "%s\n" "#define size_t unsigned int" >>confdefs.h
 
 fi
+
 
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for uid_t in sys/types.h" >&5
 printf %s "checking for uid_t in sys/types.h... " >&6; }

--- a/configure
+++ b/configure
@@ -16117,6 +16117,7 @@ printf %s "checking for _POSIX_THREADS in unistd.h... " >&6; }
 /* end confdefs.h.  */
 
 #include <unistd.h>
+
 #if defined(_POSIX_THREADS)
 /* pass */
 #else
@@ -16648,6 +16649,7 @@ printf %s "checking ipv6 stack type... " >&6; }
 /* end confdefs.h.  */
 
 #include <netinet/in.h>
+
 #if defined(IPV6_INRIA_VERSION)
 /* pass */
 #else
@@ -16673,6 +16675,7 @@ rm -f conftest.err conftest.i conftest.$ac_ext
 /* end confdefs.h.  */
 
 #include <netinet/in.h>
+
 #if defined(__KAME__)
 /* pass */
 #else
@@ -16701,6 +16704,7 @@ rm -f conftest.err conftest.i conftest.$ac_ext
 /* end confdefs.h.  */
 
 #include <features.h>
+
 #if defined(__GLIBC__) && ((__GLIBC__ == 2 && __GLIBC_MINOR__ >= 1) || (__GLIBC__ > 2))
 /* pass */
 #else
@@ -16743,9 +16747,7 @@ rm -f conftest.err conftest.i conftest.$ac_ext
 /* end confdefs.h.  */
 
 #include <sys/param.h>
-                         ipv6type=$i
-                          ipv6lib=inet6
-                          ipv6libdir=/usr/local/v6/lib
+
 #if defined(_TOSHIBA_INET6)
 /* pass */
 #else
@@ -16762,7 +16764,9 @@ main (void)
 _ACEOF
 if ac_fn_c_try_cpp "$LINENO"
 then :
-
+  ipv6type=$i
+                          ipv6lib=inet6
+                          ipv6libdir=/usr/local/v6/lib
 fi
 rm -f conftest.err conftest.i conftest.$ac_ext
 			;;
@@ -16771,6 +16775,7 @@ rm -f conftest.err conftest.i conftest.$ac_ext
 /* end confdefs.h.  */
 
 #include </usr/local/v6/include/sys/v6config.h>
+
 #if defined(__V6D__)
 /* pass */
 #else

--- a/configure
+++ b/configure
@@ -3490,6 +3490,8 @@ ac_compiler_gnu=$ac_cv_c_compiler_gnu
 
 
 
+
+
 if test "$srcdir" != . -a "$srcdir" != "$(pwd)"; then
     # If we're building out-of-tree, we need to make sure the following
     # resources get picked up before their $srcdir counterparts.
@@ -16092,20 +16094,27 @@ printf %s "checking for _POSIX_THREADS in unistd.h... " >&6; }
 /* end confdefs.h.  */
 
 #include <unistd.h>
-#ifdef _POSIX_THREADS
-yes
+#if defined(_POSIX_THREADS)
+/* pass */
+#else
+#error "not defined"
 #endif
 
+int
+main (void)
+{
+
+  ;
+  return 0;
+}
 _ACEOF
-if (eval "$ac_cpp conftest.$ac_ext") 2>&5 |
-  $EGREP "yes" >/dev/null 2>&1
+if ac_fn_c_try_cpp "$LINENO"
 then :
   unistd_defines_pthreads=yes
 else $as_nop
   unistd_defines_pthreads=no
 fi
-rm -rf conftest*
-
+rm -f conftest.err conftest.i conftest.$ac_ext
     { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $unistd_defines_pthreads" >&5
 printf "%s\n" "$unistd_defines_pthreads" >&6; }
 
@@ -16616,37 +16625,53 @@ printf %s "checking ipv6 stack type... " >&6; }
 /* end confdefs.h.  */
 
 #include <netinet/in.h>
-#ifdef IPV6_INRIA_VERSION
-yes
+#if defined(IPV6_INRIA_VERSION)
+/* pass */
+#else
+#error "not defined"
 #endif
+
+int
+main (void)
+{
+
+  ;
+  return 0;
+}
 _ACEOF
-if (eval "$ac_cpp conftest.$ac_ext") 2>&5 |
-  $EGREP "yes" >/dev/null 2>&1
+if ac_fn_c_try_cpp "$LINENO"
 then :
   ipv6type=$i
 fi
-rm -rf conftest*
-
+rm -f conftest.err conftest.i conftest.$ac_ext
 			;;
 		kame)
 						cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
 #include <netinet/in.h>
-#ifdef __KAME__
-yes
+#if defined(__KAME__)
+/* pass */
+#else
+#error "not defined"
 #endif
-_ACEOF
-if (eval "$ac_cpp conftest.$ac_ext") 2>&5 |
-  $EGREP "yes" >/dev/null 2>&1
-then :
-  ipv6type=$i;
-				ipv6lib=inet6
-				ipv6libdir=/usr/local/v6/lib
-				ipv6trylibc=yes
-fi
-rm -rf conftest*
 
+int
+main (void)
+{
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_cpp "$LINENO"
+then :
+  ipv6type=$i
+                          ipv6lib=inet6
+                          ipv6libdir=/usr/local/v6/lib
+                          ipv6trylibc=yes
+fi
+rm -f conftest.err conftest.i conftest.$ac_ext
 			;;
 		linux-glibc)
 						cat confdefs.h - <<_ACEOF >conftest.$ac_ext
@@ -16654,17 +16679,25 @@ rm -rf conftest*
 
 #include <features.h>
 #if defined(__GLIBC__) && ((__GLIBC__ == 2 && __GLIBC_MINOR__ >= 1) || (__GLIBC__ > 2))
-yes
+/* pass */
+#else
+#error "not defined"
 #endif
-_ACEOF
-if (eval "$ac_cpp conftest.$ac_ext") 2>&5 |
-  $EGREP "yes" >/dev/null 2>&1
-then :
-  ipv6type=$i;
-				ipv6trylibc=yes
-fi
-rm -rf conftest*
 
+int
+main (void)
+{
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_cpp "$LINENO"
+then :
+  ipv6type=$i
+                          ipv6trylibc=yes
+fi
+rm -f conftest.err conftest.i conftest.$ac_ext
 			;;
 		linux-inet6)
 						if test -d /usr/inet6; then
@@ -16687,55 +16720,68 @@ rm -rf conftest*
 /* end confdefs.h.  */
 
 #include <sys/param.h>
-#ifdef _TOSHIBA_INET6
-yes
+                         ipv6type=$i
+                          ipv6lib=inet6
+                          ipv6libdir=/usr/local/v6/lib
+#if defined(_TOSHIBA_INET6)
+/* pass */
+#else
+#error "not defined"
 #endif
-_ACEOF
-if (eval "$ac_cpp conftest.$ac_ext") 2>&5 |
-  $EGREP "yes" >/dev/null 2>&1
-then :
-  ipv6type=$i;
-				ipv6lib=inet6;
-				ipv6libdir=/usr/local/v6/lib
-fi
-rm -rf conftest*
 
+int
+main (void)
+{
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_cpp "$LINENO"
+then :
+
+fi
+rm -f conftest.err conftest.i conftest.$ac_ext
 			;;
 		v6d)
 			cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
 #include </usr/local/v6/include/sys/v6config.h>
-#ifdef __V6D__
-yes
+#if defined(__V6D__)
+/* pass */
+#else
+#error "not defined"
 #endif
-_ACEOF
-if (eval "$ac_cpp conftest.$ac_ext") 2>&5 |
-  $EGREP "yes" >/dev/null 2>&1
-then :
-  ipv6type=$i;
-				ipv6lib=v6;
-				ipv6libdir=/usr/local/v6/lib;
-				BASECFLAGS="-I/usr/local/v6/include $BASECFLAGS"
-fi
-rm -rf conftest*
 
+int
+main (void)
+{
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_cpp "$LINENO"
+then :
+  ipv6type=$i
+                          ipv6lib=v6
+                          ipv6libdir=/usr/local/v6/lib
+                          BASECFLAGS="-I/usr/local/v6/include $BASECFLAGS"
+fi
+rm -f conftest.err conftest.i conftest.$ac_ext
 			;;
 		zeta)
 			cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
-
 #include <sys/param.h>
-#ifdef _ZETA_MINAMI_INET6
-yes
-#endif
 _ACEOF
 if (eval "$ac_cpp conftest.$ac_ext") 2>&5 |
-  $EGREP "yes" >/dev/null 2>&1
+  $EGREP "defined(_ZETA_MINAMI_INET6)" >/dev/null 2>&1
 then :
-  ipv6type=$i;
-				ipv6lib=inet6;
-				ipv6libdir=/usr/local/v6/lib
+  ipv6type=$i
+                          ipv6lib=inet6
+                          ipv6libdir=/usr/local/v6/lib
 fi
 rm -rf conftest*
 

--- a/configure
+++ b/configure
@@ -11222,63 +11222,24 @@ then :
 fi
 
 
-# checks for typedefs
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for clock_t in time.h" >&5
-printf %s "checking for clock_t in time.h... " >&6; }
-if test ${ac_cv_clock_t_time_h+y}
+# Check for clock_t in time.h.
+ac_fn_c_check_type "$LINENO" "clock_t" "ac_cv_type_clock_t" "#include time.h
+"
+if test "x$ac_cv_type_clock_t" = xyes
 then :
-  printf %s "(cached) " >&6
+
+printf "%s\n" "#define HAVE_CLOCK_T 1" >>confdefs.h
+
+
 else $as_nop
-
-   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for clock_t in time.h" >&5
-printf %s "checking for clock_t in time.h... " >&6; }
- ac_lib_var=`echo clock_t'_'time.h | sed 'y%./+-%__p_%'`
-if eval test \${ac_cv_lib_$ac_lib_var+y}
+  if test "x$ac_cv_type_clock_t" = xno
 then :
-  printf %s "(cached) " >&6
-else $as_nop
-   eval "ac_cv_type_$ac_lib_var='not-found'"
-  ac_cv_check_typedef_header=`echo time.h`
-  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-#include <$ac_cv_check_typedef_header>
-int
-main (void)
-{
-int x = sizeof(clock_t); x = x;
-  ;
-  return 0;
-}
-_ACEOF
-if ac_fn_c_try_compile "$LINENO"
-then :
-  eval "ac_cv_type_$ac_lib_var=yes"
-else $as_nop
-  eval "ac_cv_type_$ac_lib_var=no"
-fi
-rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
-  if test `eval echo '$ac_cv_type_'$ac_lib_var` = "no" ; then
-     { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
-printf "%s\n" "no" >&6; }
-  else
-     { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-printf "%s\n" "yes" >&6; }
-  fi
-
-fi
-
-
-fi
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_clock_t_time_h" >&5
-printf "%s\n" "$ac_cv_clock_t_time_h" >&6; }
-if test "x$ac_cv_clock_t_time_h" = xno
-then :
-
 
 printf "%s\n" "#define clock_t long" >>confdefs.h
 
-
 fi
+fi
+
 
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for makedev" >&5
 printf %s "checking for makedev... " >&6; }
@@ -16126,7 +16087,7 @@ printf %s "checking for _POSIX_THREADS in unistd.h... " >&6; }
 #if defined(_POSIX_THREADS)
 /* pass */
 #else
-#error "not defined"
+#error "check failed"
 #endif
 
 int
@@ -16658,7 +16619,7 @@ printf %s "checking ipv6 stack type... " >&6; }
 #if defined(IPV6_INRIA_VERSION)
 /* pass */
 #else
-#error "not defined"
+#error "check failed"
 #endif
 
 int
@@ -16684,7 +16645,7 @@ rm -f conftest.err conftest.i conftest.$ac_ext
 #if defined(__KAME__)
 /* pass */
 #else
-#error "not defined"
+#error "check failed"
 #endif
 
 int
@@ -16713,7 +16674,7 @@ rm -f conftest.err conftest.i conftest.$ac_ext
 #if defined(__GLIBC__) && ((__GLIBC__ == 2 && __GLIBC_MINOR__ >= 1) || (__GLIBC__ > 2))
 /* pass */
 #else
-#error "not defined"
+#error "check failed"
 #endif
 
 int
@@ -16756,7 +16717,7 @@ rm -f conftest.err conftest.i conftest.$ac_ext
 #if defined(_TOSHIBA_INET6)
 /* pass */
 #else
-#error "not defined"
+#error "check failed"
 #endif
 
 int
@@ -16784,7 +16745,7 @@ rm -f conftest.err conftest.i conftest.$ac_ext
 #if defined(__V6D__)
 /* pass */
 #else
-#error "not defined"
+#error "check failed"
 #endif
 
 int
@@ -16813,7 +16774,7 @@ rm -f conftest.err conftest.i conftest.$ac_ext
 #if defined(_ZETA_MINAMI_INET6)
 /* pass */
 #else
-#error "not defined"
+#error "check failed"
 #endif
 
 int

--- a/configure
+++ b/configure
@@ -16802,17 +16802,30 @@ rm -f conftest.err conftest.i conftest.$ac_ext
 		zeta)
 			cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
+
 #include <sys/param.h>
+
+#if defined(_ZETA_MINAMI_INET6)
+/* pass */
+#else
+#error "not defined"
+#endif
+
+int
+main (void)
+{
+
+  ;
+  return 0;
+}
 _ACEOF
-if (eval "$ac_cpp conftest.$ac_ext") 2>&5 |
-  $EGREP "defined(_ZETA_MINAMI_INET6)" >/dev/null 2>&1
+if ac_fn_c_try_cpp "$LINENO"
 then :
   ipv6type=$i
                           ipv6lib=inet6
                           ipv6libdir=/usr/local/v6/lib
 fi
-rm -rf conftest*
-
+rm -f conftest.err conftest.i conftest.$ac_ext
 			;;
 		esac
 		if test "$ipv6type" != "unknown"; then

--- a/configure.ac
+++ b/configure.ac
@@ -73,6 +73,17 @@ AC_DEFUN([PY_CHECK_FUNC],
   AS_VAR_POPDEF([py_define])
 ])
 
+dnl PY_CHECK_CPP(CPP_CHECK, [INCLUDES], [ACTION-IF-FOUND], [ACTION-IF-NOT-FOUND])
+AC_DEFUN([PY_CHECK_CPP],
+         [AC_PREPROC_IFELSE([AC_LANG_PROGRAM([
+$2
+@%:@if $1
+/* pass */
+#else
+#error "not defined"
+#endif
+])], [$3], [$4])])
+
 dnl PY_CHECK_LIB(LIBRARY, FUNCTION, [ACTION-IF-FOUND], [ACTION-IF-NOT-FOUND], [OTHER-LIBRARIES])
 dnl Like AC_CHECK_LIB() but does not modify LIBS
 AC_DEFUN([PY_CHECK_LIB],
@@ -4252,13 +4263,10 @@ else
     # define _POSIX_THREADS in unistd.h. Some apparently don't
     # (e.g. gnu pth with pthread emulation)
     AC_MSG_CHECKING([for _POSIX_THREADS in unistd.h])
-    AC_EGREP_CPP([yes],
-    [
-#include <unistd.h>
-#ifdef _POSIX_THREADS
-yes
-#endif
-    ], unistd_defines_pthreads=yes, unistd_defines_pthreads=no)
+    PY_CHECK_CPP([defined(_POSIX_THREADS)],
+                 [@%:@include <unistd.h>],
+                 [unistd_defines_pthreads=yes],
+                 [unistd_defines_pthreads=no])
     AC_MSG_RESULT([$unistd_defines_pthreads])
 
     AC_DEFINE([_REENTRANT])
@@ -4438,34 +4446,25 @@ if test "$ipv6" = yes -a "$cross_compiling" = no; then
 		case $i in
 		inria)
 			dnl http://www.kame.net/
-			AC_EGREP_CPP([yes], [
-#include <netinet/in.h>
-#ifdef IPV6_INRIA_VERSION
-yes
-@%:@endif],
-				[ipv6type=$i])
+			PY_CHECK_CPP([defined(IPV6_INRIA_VERSION)],
+                         [@%:@include <netinet/in.h>],
+				         [ipv6type=$i])
 			;;
 		kame)
 			dnl http://www.kame.net/
-			AC_EGREP_CPP([yes], [
-#include <netinet/in.h>
-#ifdef __KAME__
-yes
-@%:@endif],
-				[ipv6type=$i;
-				ipv6lib=inet6
-				ipv6libdir=/usr/local/v6/lib
-				ipv6trylibc=yes])
+			PY_CHECK_CPP([defined(__KAME__)],
+                         [@%:@include <netinet/in.h>],
+                         [ipv6type=$i
+                          ipv6lib=inet6
+                          ipv6libdir=/usr/local/v6/lib
+                          ipv6trylibc=yes])
 			;;
 		linux-glibc)
 			dnl http://www.v6.linux.or.jp/
-			AC_EGREP_CPP([yes], [
-#include <features.h>
-#if defined(__GLIBC__) && ((__GLIBC__ == 2 && __GLIBC_MINOR__ >= 1) || (__GLIBC__ > 2))
-yes
-@%:@endif],
-				[ipv6type=$i;
-				ipv6trylibc=yes])
+			PY_CHECK_CPP([defined(__GLIBC__) && ((__GLIBC__ == 2 && __GLIBC_MINOR__ >= 1) || (__GLIBC__ > 2))],
+                         [@%:@include <features.h>],
+                         [ipv6type=$i
+                          ipv6trylibc=yes])
 			;;
 		linux-inet6)
 			dnl http://www.v6.linux.or.jp/
@@ -4485,35 +4484,26 @@ yes
                         fi
 			;;
 		toshiba)
-			AC_EGREP_CPP([yes], [
-#include <sys/param.h>
-#ifdef _TOSHIBA_INET6
-yes
-@%:@endif],
-				[ipv6type=$i;
-				ipv6lib=inet6;
-				ipv6libdir=/usr/local/v6/lib])
+			PY_CHECK_CPP([defined(_TOSHIBA_INET6)],
+                         [@%:@include <sys/param.h>]
+                         [ipv6type=$i
+                          ipv6lib=inet6
+                          ipv6libdir=/usr/local/v6/lib])
 			;;
 		v6d)
-			AC_EGREP_CPP([yes], [
-#include </usr/local/v6/include/sys/v6config.h>
-#ifdef __V6D__
-yes
-@%:@endif],
-				[ipv6type=$i;
-				ipv6lib=v6;
-				ipv6libdir=/usr/local/v6/lib;
-				BASECFLAGS="-I/usr/local/v6/include $BASECFLAGS"])
+			PY_CHECK_CPP([defined(__V6D__)],
+                         [@%:@include </usr/local/v6/include/sys/v6config.h>],
+                         [ipv6type=$i
+                          ipv6lib=v6
+                          ipv6libdir=/usr/local/v6/lib
+                          BASECFLAGS="-I/usr/local/v6/include $BASECFLAGS"])
 			;;
 		zeta)
-			AC_EGREP_CPP([yes], [
-#include <sys/param.h>
-#ifdef _ZETA_MINAMI_INET6
-yes
-@%:@endif],
-				[ipv6type=$i;
-				ipv6lib=inet6;
-				ipv6libdir=/usr/local/v6/lib])
+			AC_EGREP_CPP([defined(_ZETA_MINAMI_INET6)],
+                         [@%:@include <sys/param.h>],
+                         [ipv6type=$i
+                          ipv6lib=inet6
+                          ipv6libdir=/usr/local/v6/lib])
 			;;
 		esac
 		if test "$ipv6type" != "unknown"; then

--- a/configure.ac
+++ b/configure.ac
@@ -4499,8 +4499,8 @@ if test "$ipv6" = yes -a "$cross_compiling" = no; then
                           BASECFLAGS="-I/usr/local/v6/include $BASECFLAGS"])
 			;;
 		zeta)
-			AC_EGREP_CPP([defined(_ZETA_MINAMI_INET6)],
-                         [@%:@include <sys/param.h>],
+			PY_CHECK_CPP([defined(_ZETA_MINAMI_INET6)],
+                         [sys/param.h],
                          [ipv6type=$i
                           ipv6lib=inet6
                           ipv6libdir=/usr/local/v6/lib])

--- a/configure.ac
+++ b/configure.ac
@@ -73,14 +73,14 @@ AC_DEFUN([PY_CHECK_FUNC],
   AS_VAR_POPDEF([py_define])
 ])
 
-dnl PY_CHECK_CPP(CPP_CHECK, [LIST-OF-INCLUDES], [ACTION-IF-FOUND], [ACTION-IF-NOT-FOUND])
+dnl PY_CHECK_CPP(CPP_CHECK, [LIST-OF-INCLUDES], [ACTION-IF-TRUE], [ACTION-IF-FALSE])
 AC_DEFUN([PY_CHECK_CPP],
          [AC_PREPROC_IFELSE([AC_LANG_PROGRAM([
 m4_foreach_w([incl], [$2], [@%:@include <incl> m4_newline])
 @%:@if $1
 /* pass */
 #else
-#error "not defined"
+#error "check failed"
 #endif
 ])], [$3], [$4])])
 
@@ -2838,15 +2838,13 @@ AC_CHECK_HEADERS(
 #endif
 ])
 
-# checks for typedefs
-AC_CACHE_CHECK([for clock_t in time.h], [ac_cv_clock_t_time_h], [
-  AX_CHECK_TYPEDEF([clock_t], [time.h], [ac_cv_clock_t_time_h=yes], [ac_cv_clock_t_time_h=no])
-])
-dnl checks for "no"
-AS_VAR_IF([ac_cv_clock_t_time_h], [no], [
-  AC_DEFINE([clock_t], [long],
-            [Define to 'long' if <time.h> doesn't define.])
-])
+# Check for clock_t in time.h.
+AC_CHECK_TYPES([clock_t],
+               [],
+               [AS_VAR_IF([ac_cv_type_clock_t], [no],
+                          [AC_DEFINE([clock_t], [long],
+                                     ["Define to 'long' if <time.h> doesn't define."])])],
+               [@%:@include time.h])
 
 AC_CACHE_CHECK([for makedev], [ac_cv_func_makedev], [
 AC_LINK_IFELSE([AC_LANG_PROGRAM([[

--- a/configure.ac
+++ b/configure.ac
@@ -2843,7 +2843,7 @@ AC_CHECK_TYPES([clock_t],
                [],
                [AS_VAR_IF([ac_cv_type_clock_t], [no],
                           [AC_DEFINE([clock_t], [long],
-                                     ["Define to 'long' if <time.h> doesn't define."])])],
+                                     [Define to 'long' if <time.h> does not define clock_t.])])],
                [@%:@include time.h])
 
 AC_CACHE_CHECK([for makedev], [ac_cv_func_makedev], [

--- a/configure.ac
+++ b/configure.ac
@@ -75,7 +75,7 @@ AC_DEFUN([PY_CHECK_FUNC],
 
 dnl PY_CHECK_CPP(CPP_CHECK, [LIST-OF-INCLUDES], [ACTION-IF-TRUE], [ACTION-IF-FALSE])
 AC_DEFUN([PY_CHECK_CPP],
-         [AC_PREPROC_IFELSE([AC_LANG_PROGRAM([
+         [AC_PREPROC_IFELSE([AC_LANG_SOURCE([
 m4_foreach_w([incl], [$2], [@%:@include <incl> m4_newline])
 @%:@if $1
 /* pass */
@@ -2839,12 +2839,10 @@ AC_CHECK_HEADERS(
 ])
 
 # Check for clock_t in time.h.
-AC_CHECK_TYPES([clock_t],
-               [],
-               [AS_VAR_IF([ac_cv_type_clock_t], [no],
-                          [AC_DEFINE([clock_t], [long],
-                                     [Define to 'long' if <time.h> does not define clock_t.])])],
-               [@%:@include time.h])
+AC_CHECK_TYPES([clock_t], [],
+               [AC_DEFINE([clock_t], [long],
+                          [Define to 'long' if <time.h> does not define clock_t.])],
+               [@%:@include <time.h>])
 
 AC_CACHE_CHECK([for makedev], [ac_cv_func_makedev], [
 AC_LINK_IFELSE([AC_LANG_PROGRAM([[

--- a/configure.ac
+++ b/configure.ac
@@ -73,10 +73,10 @@ AC_DEFUN([PY_CHECK_FUNC],
   AS_VAR_POPDEF([py_define])
 ])
 
-dnl PY_CHECK_CPP(CPP_CHECK, [INCLUDES], [ACTION-IF-FOUND], [ACTION-IF-NOT-FOUND])
+dnl PY_CHECK_CPP(CPP_CHECK, [LIST-OF-INCLUDES], [ACTION-IF-FOUND], [ACTION-IF-NOT-FOUND])
 AC_DEFUN([PY_CHECK_CPP],
          [AC_PREPROC_IFELSE([AC_LANG_PROGRAM([
-$2
+m4_foreach_w([incl], [$2], [@%:@include <incl> m4_newline])
 @%:@if $1
 /* pass */
 #else
@@ -4264,7 +4264,7 @@ else
     # (e.g. gnu pth with pthread emulation)
     AC_MSG_CHECKING([for _POSIX_THREADS in unistd.h])
     PY_CHECK_CPP([defined(_POSIX_THREADS)],
-                 [@%:@include <unistd.h>],
+                 [unistd.h],
                  [unistd_defines_pthreads=yes],
                  [unistd_defines_pthreads=no])
     AC_MSG_RESULT([$unistd_defines_pthreads])
@@ -4447,13 +4447,13 @@ if test "$ipv6" = yes -a "$cross_compiling" = no; then
 		inria)
 			dnl http://www.kame.net/
 			PY_CHECK_CPP([defined(IPV6_INRIA_VERSION)],
-                         [@%:@include <netinet/in.h>],
+                         [netinet/in.h],
 				         [ipv6type=$i])
 			;;
 		kame)
 			dnl http://www.kame.net/
 			PY_CHECK_CPP([defined(__KAME__)],
-                         [@%:@include <netinet/in.h>],
+                         [netinet/in.h],
                          [ipv6type=$i
                           ipv6lib=inet6
                           ipv6libdir=/usr/local/v6/lib
@@ -4462,7 +4462,7 @@ if test "$ipv6" = yes -a "$cross_compiling" = no; then
 		linux-glibc)
 			dnl http://www.v6.linux.or.jp/
 			PY_CHECK_CPP([defined(__GLIBC__) && ((__GLIBC__ == 2 && __GLIBC_MINOR__ >= 1) || (__GLIBC__ > 2))],
-                         [@%:@include <features.h>],
+                         [features.h],
                          [ipv6type=$i
                           ipv6trylibc=yes])
 			;;
@@ -4485,14 +4485,14 @@ if test "$ipv6" = yes -a "$cross_compiling" = no; then
 			;;
 		toshiba)
 			PY_CHECK_CPP([defined(_TOSHIBA_INET6)],
-                         [@%:@include <sys/param.h>]
+                         [sys/param.h],
                          [ipv6type=$i
                           ipv6lib=inet6
                           ipv6libdir=/usr/local/v6/lib])
 			;;
 		v6d)
 			PY_CHECK_CPP([defined(__V6D__)],
-                         [@%:@include </usr/local/v6/include/sys/v6config.h>],
+                         [/usr/local/v6/include/sys/v6config.h],
                          [ipv6type=$i
                           ipv6lib=v6
                           ipv6libdir=/usr/local/v6/lib

--- a/configure.ac
+++ b/configure.ac
@@ -2839,7 +2839,7 @@ AC_CHECK_HEADERS(
 
 # checks for typedefs
 AC_CACHE_CHECK([for clock_t in time.h], [ac_cv_clock_t_time_h], [
-  AC_EGREP_HEADER([clock_t], [time.h], [ac_cv_clock_t_time_h=yes], [ac_cv_clock_t_time_h=no])
+  AX_CHECK_TYPEDEF([clock_t], [time.h], [ac_cv_clock_t_time_h=yes], [ac_cv_clock_t_time_h=no])
 ])
 dnl checks for "no"
 AS_VAR_IF([ac_cv_clock_t_time_h], [no], [

--- a/pyconfig.h.in
+++ b/pyconfig.h.in
@@ -157,6 +157,9 @@
 /* Define to 1 if you have the `clock_settime' function. */
 #undef HAVE_CLOCK_SETTIME
 
+/* Define to 1 if the system has the type `clock_t'. */
+#undef HAVE_CLOCK_T
+
 /* Define to 1 if you have the `closefrom' function. */
 #undef HAVE_CLOSEFROM
 
@@ -1938,7 +1941,7 @@
 /* Define on FreeBSD to activate all library features */
 #undef __BSD_VISIBLE
 
-/* Define to 'long' if <time.h> doesn't define. */
+/* "Define to 'long' if <time.h> doesn't define." */
 #undef clock_t
 
 /* Define to empty if `const' does not conform to ANSI C. */

--- a/pyconfig.h.in
+++ b/pyconfig.h.in
@@ -1941,7 +1941,7 @@
 /* Define on FreeBSD to activate all library features */
 #undef __BSD_VISIBLE
 
-/* "Define to 'long' if <time.h> doesn't define." */
+/* Define to 'long' if <time.h> does not define clock_t. */
 #undef clock_t
 
 /* Define to empty if `const' does not conform to ANSI C. */


### PR DESCRIPTION
See Autoconf docs:

- https://www.gnu.org/software/autoconf/manual/autoconf-2.72/html_node/Running-the-Preprocessor.html#index-AC_005fEGREP_005fHEADER-1

<!-- gh-issue-number: gh-115765 -->
* Issue: gh-115765
<!-- /gh-issue-number -->
