### PR TITLE
Fix sort order for "locale encoding" glossary item

### DIFF
--- a/Doc/glossary.rst
+++ b/Doc/glossary.rst
@@ -754,7 +754,7 @@ Glossary
 
       On Android and VxWorks, Python uses ``"utf-8"`` as the locale encoding.
 
-      ``locale.getencoding()`` can be used to get the locale encoding.
+      :func:`locale.getencoding` can be used to get the locale encoding.
 
       See also the :term:`filesystem encoding and error handler`.
 

--- a/Doc/glossary.rst
+++ b/Doc/glossary.rst
@@ -727,18 +727,6 @@ Glossary
       thread removes *key* from *mapping* after the test, but before the lookup.
       This issue can be solved with locks or by using the EAFP approach.
 
-   locale encoding
-      On Unix, it is the encoding of the LC_CTYPE locale. It can be set with
-      :func:`locale.setlocale(locale.LC_CTYPE, new_locale) <locale.setlocale>`.
-
-      On Windows, it is the ANSI code page (ex: ``"cp1252"``).
-
-      On Android and VxWorks, Python uses ``"utf-8"`` as the locale encoding.
-
-      ``locale.getencoding()`` can be used to get the locale encoding.
-
-      See also the :term:`filesystem encoding and error handler`.
-
    list
       A built-in Python :term:`sequence`.  Despite its name it is more akin
       to an array in other languages than to a linked list since access to
@@ -757,6 +745,18 @@ Glossary
       :meth:`load_module`. A loader is typically returned by a
       :term:`finder`. See :pep:`302` for details and
       :class:`importlib.abc.Loader` for an :term:`abstract base class`.
+
+   locale encoding
+      On Unix, it is the encoding of the LC_CTYPE locale. It can be set with
+      :func:`locale.setlocale(locale.LC_CTYPE, new_locale) <locale.setlocale>`.
+
+      On Windows, it is the ANSI code page (ex: ``"cp1252"``).
+
+      On Android and VxWorks, Python uses ``"utf-8"`` as the locale encoding.
+
+      ``locale.getencoding()`` can be used to get the locale encoding.
+
+      See also the :term:`filesystem encoding and error handler`.
 
    magic method
       .. index:: pair: magic; method


### PR DESCRIPTION
This fixes the alphabetical sorting for locale-encoding in the glossary. This issue was noticed by Stefan2 and posted on Discourse: https://discuss.python.org/t/glossary-locale-order/46578


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--115794.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->