### PR TITLE
gh-115796: fix exception table construction in _testinternalcapi.assemble_code_object

### DIFF
--- a/Misc/NEWS.d/next/Tests/2024-02-22-00-17-06.gh-issue-115796.d4hpKy.rst
+++ b/Misc/NEWS.d/next/Tests/2024-02-22-00-17-06.gh-issue-115796.d4hpKy.rst
@@ -1,0 +1,2 @@
+Make '_testinternalcapi.assemble_code_object' construct the exception table
+for the code object.

--- a/Python/flowgraph.c
+++ b/Python/flowgraph.c
@@ -665,12 +665,6 @@ translate_jump_labels_to_targets(basicblock *entryblock)
     return SUCCESS;
 }
 
-int
-_PyCfg_JumpLabelsToTargets(cfg_builder *g)
-{
-    return translate_jump_labels_to_targets(g->g_entryblock);
-}
-
 static int
 mark_except_handlers(basicblock *entryblock) {
 #ifndef NDEBUG
@@ -2788,5 +2782,16 @@ _PyCfg_OptimizedCfgToInstructionSequence(cfg_builder *g,
         return ERROR;
     }
 
+    return SUCCESS;
+}
+
+/* This is used by _PyCompile_Assemble to fill in the jump and exception
+ * targets in a synthetic CFG (which is not the ouptut of the builtin compiler).
+ */
+int
+_PyCfg_JumpLabelsToTargets(cfg_builder *g)
+{
+    RETURN_IF_ERROR(translate_jump_labels_to_targets(g->g_entryblock));
+    RETURN_IF_ERROR(label_exception_targets(g->g_entryblock));
     return SUCCESS;
 }


### PR DESCRIPTION
Fixes #115796.

<!-- gh-issue-number: gh-115796 -->
* Issue: gh-115796
<!-- /gh-issue-number -->
