### PR TITLE
gh-115806: Improve configure output

### DIFF
--- a/configure
+++ b/configure
@@ -7386,11 +7386,15 @@ else # shared is disabled
       ;;
   esac
 fi
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $LDLIBRARY" >&5
+printf "%s\n" "$LDLIBRARY" >&6; }
 
 if test "$cross_compiling" = yes; then
   RUNSHARED=
 fi
 
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking HOSTRUNNER" >&5
+printf %s "checking HOSTRUNNER... " >&6; }
 
 if test -z "$HOSTRUNNER"
 then
@@ -7574,17 +7578,12 @@ fi
 esac
 fi
 
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking HOSTRUNNER" >&5
-printf %s "checking HOSTRUNNER... " >&6; }
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $HOSTRUNNER" >&5
 printf "%s\n" "$HOSTRUNNER" >&6; }
 
 if test -n "$HOSTRUNNER"; then
     PYTHON_FOR_BUILD="_PYTHON_HOSTRUNNER='$HOSTRUNNER' $PYTHON_FOR_BUILD"
 fi
-
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $LDLIBRARY" >&5
-printf "%s\n" "$LDLIBRARY" >&6; }
 
 # LIBRARY_DEPS, LINK_PYTHON_OBJS and LINK_PYTHON_DEPS variable
 case $ac_sys_system/$ac_sys_emscripten_target in #(

--- a/configure
+++ b/configure
@@ -16749,26 +16749,37 @@ rm -rf conftest*
 printf "%s\n" "$ipv6type" >&6; }
 fi
 
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking ipv6 library" >&5
-printf %s "checking ipv6 library... " >&6; }
-if test "$ipv6" = "yes" -a "$ipv6lib" != "none"; then
-	if test -d $ipv6libdir -a -f $ipv6libdir/lib$ipv6lib.a; then
-		LIBS="-L$ipv6libdir -l$ipv6lib $LIBS"
-		{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: lib$ipv6lib" >&5
-printf "%s\n" "lib$ipv6lib" >&6; }
-	else
-    if test "x$ipv6trylibc" = xyes
+if test "x$ipv6" = xyes
 then :
 
-      { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: libc" >&5
+    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking ipv6 library" >&5
+printf %s "checking ipv6 library... " >&6; }
+    if test "x$ipv6lib" = xnone
+then :
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: none" >&5
+printf "%s\n" "none" >&6; }
+else $as_nop
+
+        if test -d $ipv6libdir -a -f $ipv6libdir/lib$ipv6lib.a; then
+            LIBS="-L$ipv6libdir -l$ipv6lib $LIBS"
+            { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: lib$ipv6lib" >&5
+printf "%s\n" "lib$ipv6lib" >&6; }
+        else
+            if test "x$ipv6trylibc" = xyes
+then :
+
+              { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: libc" >&5
 printf "%s\n" "libc" >&6; }
 
 else $as_nop
 
-      as_fn_error $? "No $ipv6lib library found; cannot continue. You need to fetch lib$ipv6lib.a from appropriate ipv6 kit and compile beforehand." "$LINENO" 5
+              as_fn_error $? "No $ipv6lib library found; cannot continue. You need to fetch lib$ipv6lib.a from appropriate ipv6 kit and compile beforehand." "$LINENO" 5
 
 fi
-	fi
+        fi
+
+fi
+
 fi
 
 

--- a/configure
+++ b/configure
@@ -16753,31 +16753,26 @@ rm -rf conftest*
 printf "%s\n" "$ipv6type" >&6; }
 fi
 
-if test "x$ipv6" = xyes
-then :
-
-    noipv6found="No $ipv6lib library found; cannot continue. You need to fetch lib$ipv6lib.a from appropriate ipv6 kit and compile beforehand."
+if test "$ipv6" = "yes" -a "$ipv6lib" != "none"; then
     { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking ipv6 library" >&5
 printf %s "checking ipv6 library... " >&6; }
-    if test "x$ipv6lib" = xnone
-then :
-  as_fn_error $? "$noipv6found" "$LINENO" 5
-fi
-    if test -d $ipv6libdir -a -f $ipv6libdir/lib$ipv6lib.a; then
-        LIBS="-L$ipv6libdir -l$ipv6lib $LIBS"
-        { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: lib$ipv6lib" >&5
+	if test -d $ipv6libdir -a -f $ipv6libdir/lib$ipv6lib.a; then
+		LIBS="-L$ipv6libdir -l$ipv6lib $LIBS"
+		{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: lib$ipv6lib" >&5
 printf "%s\n" "lib$ipv6lib" >&6; }
-    else
-        if test "x$ipv6trylibc" = xyes
+	else
+    if test "x$ipv6trylibc" = xyes
 then :
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: libc" >&5
-printf "%s\n" "libc" >&6; }
-else $as_nop
-  as_fn_error $? "$noipv6found" "$LINENO" 5
-fi
-    fi
-    { noipv6found=; unset noipv6found;}
 
+      { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: libc" >&5
+printf "%s\n" "libc" >&6; }
+
+else $as_nop
+
+      as_fn_error $? "No $ipv6lib library found; cannot continue. You need to fetch lib$ipv6lib.a from appropriate ipv6 kit and compile beforehand." "$LINENO" 5
+
+fi
+	fi
 fi
 
 

--- a/configure
+++ b/configure
@@ -16749,17 +16749,19 @@ rm -rf conftest*
 printf "%s\n" "$ipv6type" >&6; }
 fi
 
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking ipv6 library" >&5
+printf %s "checking ipv6 library... " >&6; }
 if test "$ipv6" = "yes" -a "$ipv6lib" != "none"; then
 	if test -d $ipv6libdir -a -f $ipv6libdir/lib$ipv6lib.a; then
 		LIBS="-L$ipv6libdir -l$ipv6lib $LIBS"
-		{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: using lib$ipv6lib" >&5
-printf "%s\n" "$as_me: using lib$ipv6lib" >&6;}
+		{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: lib$ipv6lib" >&5
+printf "%s\n" "lib$ipv6lib" >&6; }
 	else
     if test "x$ipv6trylibc" = xyes
 then :
 
-      { printf "%s\n" "$as_me:${as_lineno-$LINENO}: using libc" >&5
-printf "%s\n" "$as_me: using libc" >&6;}
+      { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: libc" >&5
+printf "%s\n" "libc" >&6; }
 
 else $as_nop
 

--- a/configure
+++ b/configure
@@ -16756,7 +16756,7 @@ fi
 if test "x$ipv6" = xyes
 then :
 
-    noipv6found=No $ipv6lib library found; cannot continue. You need to fetch lib$ipv6lib.a from appropriate ipv6 kit and compile beforehand.
+    noipv6found="No $ipv6lib library found; cannot continue. You need to fetch lib$ipv6lib.a from appropriate ipv6 kit and compile beforehand."
     { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking ipv6 library" >&5
 printf %s "checking ipv6 library... " >&6; }
     if test "x$ipv6lib" = xnone

--- a/configure
+++ b/configure
@@ -16752,33 +16752,27 @@ fi
 if test "x$ipv6" = xyes
 then :
 
+    noipv6found=No $ipv6lib library found; cannot continue. You need to fetch lib$ipv6lib.a from appropriate ipv6 kit and compile beforehand.
     { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking ipv6 library" >&5
 printf %s "checking ipv6 library... " >&6; }
     if test "x$ipv6lib" = xnone
 then :
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: none" >&5
-printf "%s\n" "none" >&6; }
-else $as_nop
-
-        if test -d $ipv6libdir -a -f $ipv6libdir/lib$ipv6lib.a; then
-            LIBS="-L$ipv6libdir -l$ipv6lib $LIBS"
-            { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: lib$ipv6lib" >&5
+  as_fn_error $? "$noipv6found" "$LINENO" 5
+fi
+    if test -d $ipv6libdir -a -f $ipv6libdir/lib$ipv6lib.a; then
+        LIBS="-L$ipv6libdir -l$ipv6lib $LIBS"
+        { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: lib$ipv6lib" >&5
 printf "%s\n" "lib$ipv6lib" >&6; }
-        else
-            if test "x$ipv6trylibc" = xyes
+    else
+        if test "x$ipv6trylibc" = xyes
 then :
-
-              { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: libc" >&5
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: libc" >&5
 printf "%s\n" "libc" >&6; }
-
 else $as_nop
-
-              as_fn_error $? "No $ipv6lib library found; cannot continue. You need to fetch lib$ipv6lib.a from appropriate ipv6 kit and compile beforehand." "$LINENO" 5
-
+  as_fn_error $? "$noipv6found" "$LINENO" 5
 fi
-        fi
-
-fi
+    fi
+    { noipv6found=; unset noipv6found;}
 
 fi
 

--- a/configure.ac
+++ b/configure.ac
@@ -4522,13 +4522,14 @@ yes
 	AC_MSG_RESULT([$ipv6type])
 fi
 
+AC_MSG_CHECKING([ipv6 library])
 if test "$ipv6" = "yes" -a "$ipv6lib" != "none"; then
 	if test -d $ipv6libdir -a -f $ipv6libdir/lib$ipv6lib.a; then
 		LIBS="-L$ipv6libdir -l$ipv6lib $LIBS"
-		AC_MSG_NOTICE([using lib$ipv6lib])
+		AC_MSG_RESULT([lib$ipv6lib])
 	else
     AS_VAR_IF([ipv6trylibc], [yes], [
-      AC_MSG_NOTICE([using libc])
+      AC_MSG_RESULT([libc])
     ], [
       AC_MSG_ERROR([m4_normalize([
         No $ipv6lib library found; cannot continue.

--- a/configure.ac
+++ b/configure.ac
@@ -4522,23 +4522,25 @@ yes
 	AC_MSG_RESULT([$ipv6type])
 fi
 
-AC_MSG_CHECKING([ipv6 library])
-if test "$ipv6" = "yes" -a "$ipv6lib" != "none"; then
-	if test -d $ipv6libdir -a -f $ipv6libdir/lib$ipv6lib.a; then
-		LIBS="-L$ipv6libdir -l$ipv6lib $LIBS"
-		AC_MSG_RESULT([lib$ipv6lib])
-	else
-    AS_VAR_IF([ipv6trylibc], [yes], [
-      AC_MSG_RESULT([libc])
-    ], [
-      AC_MSG_ERROR([m4_normalize([
-        No $ipv6lib library found; cannot continue.
-        You need to fetch lib$ipv6lib.a from appropriate
-        ipv6 kit and compile beforehand.
-      ])])
+AS_VAR_IF([ipv6], [yes], [
+    AC_MSG_CHECKING([ipv6 library])
+    AS_VAR_IF([ipv6lib], [none], [AC_MSG_RESULT([none])], [
+        if test -d $ipv6libdir -a -f $ipv6libdir/lib$ipv6lib.a; then
+            LIBS="-L$ipv6libdir -l$ipv6lib $LIBS"
+            AC_MSG_RESULT([lib$ipv6lib])
+        else
+            AS_VAR_IF([ipv6trylibc], [yes], [
+              AC_MSG_RESULT([libc])
+            ], [
+              AC_MSG_ERROR([m4_normalize([
+                No $ipv6lib library found; cannot continue.
+                You need to fetch lib$ipv6lib.a from appropriate
+                ipv6 kit and compile beforehand.
+              ])])
+            ])
+        fi
     ])
-	fi
-fi
+])
 
 
 AC_CACHE_CHECK([CAN_RAW_FD_FRAMES], [ac_cv_can_raw_fd_frames], [

--- a/configure.ac
+++ b/configure.ac
@@ -4523,9 +4523,9 @@ fi
 AS_VAR_IF([ipv6], [yes], [
     AS_VAR_SET([noipv6found],
                [m4_normalize([
-                No $ipv6lib library found; cannot continue.
+                "No $ipv6lib library found; cannot continue.
                 You need to fetch lib$ipv6lib.a from appropriate
-                ipv6 kit and compile beforehand.])])
+                ipv6 kit and compile beforehand."])])
     AC_MSG_CHECKING([ipv6 library])
     AS_VAR_IF([ipv6lib], [none], [AC_MSG_ERROR([$noipv6found])])
     if test -d $ipv6libdir -a -f $ipv6libdir/lib$ipv6lib.a; then

--- a/configure.ac
+++ b/configure.ac
@@ -4523,23 +4523,22 @@ yes
 fi
 
 AS_VAR_IF([ipv6], [yes], [
-    AC_MSG_CHECKING([ipv6 library])
-    AS_VAR_IF([ipv6lib], [none], [AC_MSG_RESULT([none])], [
-        if test -d $ipv6libdir -a -f $ipv6libdir/lib$ipv6lib.a; then
-            LIBS="-L$ipv6libdir -l$ipv6lib $LIBS"
-            AC_MSG_RESULT([lib$ipv6lib])
-        else
-            AS_VAR_IF([ipv6trylibc], [yes], [
-              AC_MSG_RESULT([libc])
-            ], [
-              AC_MSG_ERROR([m4_normalize([
+    AS_VAR_SET([noipv6found],
+               [m4_normalize([
                 No $ipv6lib library found; cannot continue.
                 You need to fetch lib$ipv6lib.a from appropriate
-                ipv6 kit and compile beforehand.
-              ])])
-            ])
-        fi
-    ])
+                ipv6 kit and compile beforehand.])])
+    AC_MSG_CHECKING([ipv6 library])
+    AS_VAR_IF([ipv6lib], [none], [AC_MSG_ERROR([$noipv6found])])
+    if test -d $ipv6libdir -a -f $ipv6libdir/lib$ipv6lib.a; then
+        LIBS="-L$ipv6libdir -l$ipv6lib $LIBS"
+        AC_MSG_RESULT([lib$ipv6lib])
+    else
+        AS_VAR_IF([ipv6trylibc], [yes],
+                  [AC_MSG_RESULT([libc])],
+                  [AC_MSG_ERROR([$noipv6found])])
+    fi
+    AS_UNSET([noipv6found])
 ])
 
 

--- a/configure.ac
+++ b/configure.ac
@@ -4520,24 +4520,23 @@ yes
 	AC_MSG_RESULT([$ipv6type])
 fi
 
-AS_VAR_IF([ipv6], [yes], [
-    AS_VAR_SET([noipv6found],
-               [m4_normalize([
-                "No $ipv6lib library found; cannot continue.
-                You need to fetch lib$ipv6lib.a from appropriate
-                ipv6 kit and compile beforehand."])])
+if test "$ipv6" = "yes" -a "$ipv6lib" != "none"; then
     AC_MSG_CHECKING([ipv6 library])
-    AS_VAR_IF([ipv6lib], [none], [AC_MSG_ERROR([$noipv6found])])
-    if test -d $ipv6libdir -a -f $ipv6libdir/lib$ipv6lib.a; then
-        LIBS="-L$ipv6libdir -l$ipv6lib $LIBS"
-        AC_MSG_RESULT([lib$ipv6lib])
-    else
-        AS_VAR_IF([ipv6trylibc], [yes],
-                  [AC_MSG_RESULT([libc])],
-                  [AC_MSG_ERROR([$noipv6found])])
-    fi
-    AS_UNSET([noipv6found])
-])
+	if test -d $ipv6libdir -a -f $ipv6libdir/lib$ipv6lib.a; then
+		LIBS="-L$ipv6libdir -l$ipv6lib $LIBS"
+		AC_MSG_RESULT([lib$ipv6lib])
+	else
+    AS_VAR_IF([ipv6trylibc], [yes], [
+      AC_MSG_RESULT([libc])
+    ], [
+      AC_MSG_ERROR([m4_normalize([
+        No $ipv6lib library found; cannot continue.
+        You need to fetch lib$ipv6lib.a from appropriate
+        ipv6 kit and compile beforehand.
+      ])])
+    ])
+	fi
+fi
 
 
 AC_CACHE_CHECK([CAN_RAW_FD_FRAMES], [ac_cv_can_raw_fd_frames], [

--- a/configure.ac
+++ b/configure.ac
@@ -1415,11 +1415,13 @@ else # shared is disabled
       ;;
   esac
 fi
+AC_MSG_RESULT([$LDLIBRARY])
 
 if test "$cross_compiling" = yes; then
   RUNSHARED=
 fi
 
+AC_MSG_CHECKING([HOSTRUNNER])
 AC_ARG_VAR([HOSTRUNNER], [Program to run CPython for the host platform])
 if test -z "$HOSTRUNNER"
 then
@@ -1465,15 +1467,12 @@ then
   )
 fi
 AC_SUBST([HOSTRUNNER])
-AC_MSG_CHECKING([HOSTRUNNER])
 AC_MSG_RESULT([$HOSTRUNNER])
 
 if test -n "$HOSTRUNNER"; then
   dnl Pass hostrunner variable as env var in order to expand shell expressions.
   PYTHON_FOR_BUILD="_PYTHON_HOSTRUNNER='$HOSTRUNNER' $PYTHON_FOR_BUILD"
 fi
-
-AC_MSG_RESULT([$LDLIBRARY])
 
 # LIBRARY_DEPS, LINK_PYTHON_OBJS and LINK_PYTHON_DEPS variable
 AS_CASE([$ac_sys_system/$ac_sys_emscripten_target],


### PR DESCRIPTION
- make sure LDLIBRARY and HOSTRUNNER checks don't overlap
- make the ipv6 library check less subtle
- ~~always fail if ipv6 library was not found~~

Configure output before this PR:

```console
$ ./configure
[...]
checking LDLIBRARY... checking HOSTRUNNER...
libpython$(VERSION)$(ABIFLAGS).a
[...]
checking ipv6 stack type... kame
configure: using libc
```

Configure output with this PR:

```console
$ ./configure
[...]
checking LDLIBRARY... libpython$(VERSION)$(ABIFLAGS).a
checking HOSTRUNNER...
[...]
checking ipv6 stack type... kame
checking ipv6 library... libc
```

<!-- gh-issue-number: gh-115806 -->
* Issue: gh-115806
<!-- /gh-issue-number -->
