### PR TITLE
gh-115421: Test that our Makefile has all needed test folders

### DIFF
--- a/Lib/test/test_tools/test_makefile.py
+++ b/Lib/test/test_tools/test_makefile.py
@@ -22,6 +22,11 @@ class TestMakefile(unittest.TestCase):
             for line in f:
                 if line.startswith('TESTSUBDIRS='):
                     found_testsubdirs = True
+                    result.append(
+                        line.removeprefix('TESTSUBDIRS=').replace(
+                            '\\', '',
+                        ).strip(),
+                    )
                     continue
                 if found_testsubdirs:
                     if '\t' not in line:

--- a/Lib/test/test_tools/test_makefile.py
+++ b/Lib/test/test_tools/test_makefile.py
@@ -5,8 +5,9 @@ Tests for `Makefile`.
 import os
 import unittest
 from test import support
+import sysconfig
 
-MAKEFILE = os.path.join(support.REPO_ROOT, 'Makefile')
+MAKEFILE = sysconfig.get_makefile_filename()
 
 if not support.check_impl_detail(cpython=True):
     raise unittest.SkipTest('cpython only')
@@ -59,8 +60,5 @@ class TestMakefile(unittest.TestCase):
 
         # Check that there are no extra entries:
         unique_test_dirs = set(test_dirs)
-        self.assertEqual(
-            unique_test_dirs.symmetric_difference(set(used)),
-            set(),
-        )
+        self.assertSetEqual(unique_test_dirs, set(used))
         self.assertEqual(len(test_dirs), len(unique_test_dirs))

--- a/Lib/test/test_tools/test_makefile.py
+++ b/Lib/test/test_tools/test_makefile.py
@@ -6,36 +6,31 @@ import os
 import unittest
 from test import support
 
-SPLITTER = '@-----@'
 MAKEFILE = os.path.join(support.REPO_ROOT, 'Makefile')
 
 if not support.check_impl_detail(cpython=True):
     raise unittest.SkipTest('cpython only')
-if support.MS_WINDOWS:
-    raise unittest.SkipTest('Windows does not support make')
 if not os.path.exists(MAKEFILE) or not os.path.isfile(MAKEFILE):
     raise unittest.SkipTest('Makefile could not be found')
 
-try:
-    import _testcapi
-except ImportError:
-    TEST_MODULES = False
-else:
-    TEST_MODULES = True
 
-
-@support.requires_subprocess()
 class TestMakefile(unittest.TestCase):
     def list_test_dirs(self):
-        import subprocess
-        return subprocess.check_output(
-            ['make', '-s', '-C', support.REPO_ROOT, 'listtestmodules'],
-            universal_newlines=True,
-            encoding='utf-8',
-        )
+        result = []
+        found_testsubdirs = False
+        with open(MAKEFILE, 'r', encoding='utf-8') as f:
+            for line in f:
+                if line.startswith('TESTSUBDIRS='):
+                    found_testsubdirs = True
+                    continue
+                if found_testsubdirs:
+                    if '\t' not in line:
+                        break
+                    result.append(line.replace('\\', '').strip())
+        return result
 
-    def check_existing_test_modules(self, result):
-        test_dirs = list(filter(None, result.split(' ')))
+    def test_makefile_test_folders(self):
+        test_dirs = self.list_test_dirs()
         idle_test = 'idlelib/idle_test'
         self.assertIn(idle_test, test_dirs)
 
@@ -64,19 +59,3 @@ class TestMakefile(unittest.TestCase):
             set(),
         )
         self.assertEqual(len(test_dirs), len(unique_test_dirs))
-
-    def check_missing_test_modules(self, result):
-        self.assertEqual(result, '')
-
-    def test_makefile_test_folders(self):
-        result = self.list_test_dirs().strip()
-        self.assertEqual(
-            result.count(SPLITTER), 1,
-            msg=f'{SPLITTER} should be contained in the output exactly once',
-        )
-        _, actual_result = result.split(SPLITTER)
-        actual_result = actual_result.strip()
-        if TEST_MODULES:
-            self.check_existing_test_modules(actual_result)
-        else:
-            self.check_missing_test_modules(actual_result)

--- a/Lib/test/test_tools/test_makefile.py
+++ b/Lib/test/test_tools/test_makefile.py
@@ -27,7 +27,7 @@ class TestMakefile(unittest.TestCase):
     def list_test_dirs(self):
         import subprocess
         return subprocess.check_output(
-            ['make', '-C', support.REPO_ROOT, 'listtestmodules'],
+            ['make', '-s', '-C', support.REPO_ROOT, 'listtestmodules'],
             universal_newlines=True,
             encoding='utf-8',
         )

--- a/Lib/test/test_tools/test_makefile.py
+++ b/Lib/test/test_tools/test_makefile.py
@@ -1,0 +1,66 @@
+"""
+Tests for `Makefile`.
+"""
+
+import os
+import unittest
+from test import support
+
+MAKEFILE = os.path.join(support.REPO_ROOT, 'Makefile')
+
+if not support.check_impl_detail(cpython=True):
+    raise unittest.SkipTest('cpython only')
+if support.MS_WINDOWS:
+    raise unittest.SkipTest('Windows does not support make')
+if not os.path.exists(MAKEFILE) or not os.path.isfile(MAKEFILE):
+    raise unittest.SkipTest('Makefile could not be found')
+
+try:
+    import _testcapi
+except ImportError:
+    TEST_MODULES = False
+else:
+    TEST_MODULES = True
+
+@support.requires_subprocess()
+class TestMakefile(unittest.TestCase):
+    def list_test_dirs(self):
+        import subprocess
+        return subprocess.check_output(
+            ['make', '-C', support.REPO_ROOT, 'listtestmodules'],
+            universal_newlines=True,
+            encoding='utf-8',
+        )
+
+    def check_existing_test_modules(self, result):
+        test_dirs = result.split(' ')
+        idle_test = 'idlelib/idle_test'
+        self.assertIn(idle_test, test_dirs)
+
+        used = [idle_test]
+        for dirpath, _, _ in os.walk(support.TEST_HOME_DIR):
+            dirname = os.path.basename(dirpath)
+            if dirname == '__pycache__':
+                continue
+            with self.subTest(dirpath=dirpath):
+                relpath = os.path.relpath(dirpath, support.STDLIB_DIR)
+                self.assertIn(relpath, test_dirs)
+                used.append(relpath)
+
+        # Check that there are no extra entries:
+        unique_test_dirs = set(test_dirs)
+        self.assertEqual(
+            unique_test_dirs.symmetric_difference(set(used)),
+            set(),
+        )
+        self.assertEqual(len(test_dirs), len(unique_test_dirs))
+
+    def check_missing_test_modules(self, result):
+        self.assertEqual(result, '')
+
+    def test_makefile_test_folders(self):
+        result = self.list_test_dirs().strip()
+        if TEST_MODULES:
+            self.check_existing_test_modules(result)
+        else:
+            self.check_missing_test_modules(result)

--- a/Lib/test/test_tools/test_makefile.py
+++ b/Lib/test/test_tools/test_makefile.py
@@ -35,7 +35,7 @@ class TestMakefile(unittest.TestCase):
         )
 
     def check_existing_test_modules(self, result):
-        test_dirs = result.split(' ')
+        test_dirs = list(filter(None, result.split(' ')))
         idle_test = 'idlelib/idle_test'
         self.assertIn(idle_test, test_dirs)
 
@@ -44,8 +44,9 @@ class TestMakefile(unittest.TestCase):
             dirname = os.path.basename(dirpath)
             if dirname == '__pycache__':
                 continue
-            with self.subTest(dirpath=dirpath):
-                relpath = os.path.relpath(dirpath, support.STDLIB_DIR)
+
+            relpath = os.path.relpath(dirpath, support.STDLIB_DIR)
+            with self.subTest(relpath=relpath):
                 self.assertIn(
                     relpath,
                     test_dirs,

--- a/Lib/test/test_tools/test_makefile.py
+++ b/Lib/test/test_tools/test_makefile.py
@@ -71,7 +71,7 @@ class TestMakefile(unittest.TestCase):
         result = self.list_test_dirs().strip()
         self.assertEqual(
             result.count(SPLITTER), 1,
-            msg=f'{SPLITTER} is contained in result multiple times',
+            msg=f'{SPLITTER} should be contained in the output exactly once',
         )
         _, actual_result = result.split(SPLITTER)
         actual_result = actual_result.strip()

--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -2235,7 +2235,8 @@ LIBSUBDIRS=	asyncio \
 		zipfile zipfile/_path \
 		zoneinfo \
 		__phello__
-TESTSUBDIRS=	idlelib/idle_test \
+TESTSUBDIRS=\
+		idlelib/idle_test \
 		test \
 		test/archivetestdata \
 		test/audiodata \
@@ -2372,14 +2373,6 @@ TESTSUBDIRS=	idlelib/idle_test \
 COMPILEALL_OPTS=-j0
 
 TEST_MODULES=@TEST_MODULES@
-
-# This is needed for `test_makefile`:
-.PHONY: listtestmodules
-listtestmodules:
-	@echo "@-----@"
-	@if test "$(TEST_MODULES)" = yes; then \
-		echo "$(TESTSUBDIRS)"; \
-	fi
 
 .PHONY: libinstall
 libinstall:	all $(srcdir)/Modules/xxmodule.c

--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -2235,8 +2235,7 @@ LIBSUBDIRS=	asyncio \
 		zipfile zipfile/_path \
 		zoneinfo \
 		__phello__
-TESTSUBDIRS=\
-		idlelib/idle_test \
+TESTSUBDIRS=	idlelib/idle_test \
 		test \
 		test/archivetestdata \
 		test/audiodata \

--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -2373,6 +2373,7 @@ COMPILEALL_OPTS=-j0
 
 TEST_MODULES=@TEST_MODULES@
 
+# This is needed for `test_makefile`:
 .PHONY: listtestmodules
 listtestmodules:
 	@echo "@-----@"

--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -2373,6 +2373,12 @@ COMPILEALL_OPTS=-j0
 
 TEST_MODULES=@TEST_MODULES@
 
+.PHONY: listtestmodules
+listtestmodules:
+	@if test "$(TEST_MODULES)" = yes; then \
+		echo "$(TESTSUBDIRS)"; \
+	fi
+
 .PHONY: libinstall
 libinstall:	all $(srcdir)/Modules/xxmodule.c
 	@for i in $(SCRIPTDIR) $(LIBDEST); \

--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -2237,7 +2237,6 @@ LIBSUBDIRS=	asyncio \
 		__phello__
 TESTSUBDIRS=	idlelib/idle_test \
 		test \
-		test/archivetestdata \
 		test/audiodata \
 		test/certdata \
 		test/certdata/capath \

--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -2237,6 +2237,7 @@ LIBSUBDIRS=	asyncio \
 		__phello__
 TESTSUBDIRS=	idlelib/idle_test \
 		test \
+		test/archivetestdata \
 		test/audiodata \
 		test/certdata \
 		test/certdata/capath \
@@ -2374,6 +2375,7 @@ TEST_MODULES=@TEST_MODULES@
 
 .PHONY: listtestmodules
 listtestmodules:
+	@echo "@-----@"
 	@if test "$(TEST_MODULES)" = yes; then \
 		echo "$(TESTSUBDIRS)"; \
 	fi


### PR DESCRIPTION
This PR is the alternative to https://github.com/python/cpython/pull/115511

While we would still have to keep adding directories to `TESTSUBDIRS` manually, we would now have a test to catch any cases where people forget to update / remove these entries.

This test works with `--disable-test-modules` as well.

Which approach do you like best?

<!-- gh-issue-number: gh-115421 -->
* Issue: gh-115421
<!-- /gh-issue-number -->
