### PR TITLE
gh-114058: Only allow immortal constants in tier 2

### DIFF
--- a/Python/optimizer_analysis.c
+++ b/Python/optimizer_analysis.c
@@ -214,7 +214,8 @@ ctx_frame_pop(
 }
 
 
-// Only accepts immortal constants.
+// Only accepts immortal constants or borrowed constants that will be kept alive
+// elsewhere.
 static _Py_UOpsSymType*
 sym_new(_Py_UOpsAbstractInterpContext *ctx,
                                PyObject *const_val)
@@ -309,7 +310,7 @@ sym_new_known_type(_Py_UOpsAbstractInterpContext *ctx,
     return res;
 }
 
-// Steals a reference to const_val if it is not immortal.
+// Decrefs const_val if it is not immortal and discards it.
 static inline _Py_UOpsSymType*
 sym_new_const(_Py_UOpsAbstractInterpContext *ctx, PyObject *const_val)
 {

--- a/Python/optimizer_analysis.c
+++ b/Python/optimizer_analysis.c
@@ -323,8 +323,7 @@ sym_new_const(_Py_UOpsAbstractInterpContext *ctx, PyObject *const_val)
         return NULL;
     }
     sym_set_type(temp, Py_TYPE(const_val));
-    sym_set_flag(temp, KNOWN);
-    sym_set_flag(temp, NOT_NULL);
+    sym_set_flag(temp, KNOWN | NOT_NULL);
     // If the constant is not immortal, discard it.
     if (_Py_IsImmortal(const_val))  {
         sym_set_flag(temp, TRUE_CONST);
@@ -350,9 +349,7 @@ sym_new_const_borrow(_Py_UOpsAbstractInterpContext *ctx, PyObject *const_val)
         return NULL;
     }
     sym_set_type(temp, Py_TYPE(const_val));
-    sym_set_flag(temp, KNOWN);
-    sym_set_flag(temp, NOT_NULL);
-    sym_set_flag(temp, TRUE_CONST);
+    sym_set_flag(temp, KNOWN | NOT_NULL | TRUE_CONST);
     return temp;
 }
 

--- a/Python/tier2_redundancy_eliminator_bytecodes.c
+++ b/Python/tier2_redundancy_eliminator_bytecodes.c
@@ -204,7 +204,7 @@ dummy_func(void) {
     }
 
     op(_LOAD_CONST_INLINE, (ptr/4 -- value)) {
-        OUT_OF_SPACE_IF_NULL(value = sym_new_const(ctx, ptr));
+        OUT_OF_SPACE_IF_NULL(value = sym_new_const(ctx, Py_NewRef(ptr)));
     }
 
     op(_LOAD_CONST_INLINE_BORROW, (ptr/4 -- value)) {
@@ -212,7 +212,7 @@ dummy_func(void) {
     }
 
     op(_LOAD_CONST_INLINE_WITH_NULL, (ptr/4 -- value, null)) {
-        OUT_OF_SPACE_IF_NULL(value = sym_new_const(ctx, ptr));
+        OUT_OF_SPACE_IF_NULL(value = sym_new_const(ctx, Py_NewRef(ptr)));
         OUT_OF_SPACE_IF_NULL(null = sym_new_null(ctx));
     }
 

--- a/Python/tier2_redundancy_eliminator_bytecodes.c
+++ b/Python/tier2_redundancy_eliminator_bytecodes.c
@@ -204,7 +204,7 @@ dummy_func(void) {
     }
 
     op(_LOAD_CONST_INLINE, (ptr/4 -- value)) {
-        OUT_OF_SPACE_IF_NULL(value = sym_new_const(ctx, Py_NewRef(ptr)));
+        OUT_OF_SPACE_IF_NULL(value = sym_new_const_borrow(ctx, ptr));
     }
 
     op(_LOAD_CONST_INLINE_BORROW, (ptr/4 -- value)) {
@@ -212,7 +212,7 @@ dummy_func(void) {
     }
 
     op(_LOAD_CONST_INLINE_WITH_NULL, (ptr/4 -- value, null)) {
-        OUT_OF_SPACE_IF_NULL(value = sym_new_const(ctx, Py_NewRef(ptr)));
+        OUT_OF_SPACE_IF_NULL(value = sym_new_const_borrow(ctx, ptr));
         OUT_OF_SPACE_IF_NULL(null = sym_new_null(ctx));
     }
 

--- a/Python/tier2_redundancy_eliminator_cases.c.h
+++ b/Python/tier2_redundancy_eliminator_cases.c.h
@@ -1692,7 +1692,7 @@
         case _LOAD_CONST_INLINE: {
             _Py_UOpsSymType *value;
             PyObject *ptr = (PyObject *)this_instr->operand;
-            OUT_OF_SPACE_IF_NULL(value = sym_new_const(ctx, Py_NewRef(ptr)));
+            OUT_OF_SPACE_IF_NULL(value = sym_new_const_borrow(ctx, ptr));
             stack_pointer[0] = value;
             stack_pointer += 1;
             break;
@@ -1711,7 +1711,7 @@
             _Py_UOpsSymType *value;
             _Py_UOpsSymType *null;
             PyObject *ptr = (PyObject *)this_instr->operand;
-            OUT_OF_SPACE_IF_NULL(value = sym_new_const(ctx, Py_NewRef(ptr)));
+            OUT_OF_SPACE_IF_NULL(value = sym_new_const_borrow(ctx, ptr));
             OUT_OF_SPACE_IF_NULL(null = sym_new_null(ctx));
             stack_pointer[0] = value;
             stack_pointer[1] = null;

--- a/Python/tier2_redundancy_eliminator_cases.c.h
+++ b/Python/tier2_redundancy_eliminator_cases.c.h
@@ -1692,7 +1692,7 @@
         case _LOAD_CONST_INLINE: {
             _Py_UOpsSymType *value;
             PyObject *ptr = (PyObject *)this_instr->operand;
-            OUT_OF_SPACE_IF_NULL(value = sym_new_const(ctx, ptr));
+            OUT_OF_SPACE_IF_NULL(value = sym_new_const(ctx, Py_NewRef(ptr)));
             stack_pointer[0] = value;
             stack_pointer += 1;
             break;
@@ -1711,7 +1711,7 @@
             _Py_UOpsSymType *value;
             _Py_UOpsSymType *null;
             PyObject *ptr = (PyObject *)this_instr->operand;
-            OUT_OF_SPACE_IF_NULL(value = sym_new_const(ctx, ptr));
+            OUT_OF_SPACE_IF_NULL(value = sym_new_const(ctx, Py_NewRef(ptr)));
             OUT_OF_SPACE_IF_NULL(null = sym_new_null(ctx));
             stack_pointer[0] = value;
             stack_pointer[1] = null;


### PR DESCRIPTION
This PR bans all non-immortal constant propagated values, except for values that have a strong reference guaranteed (like _LOAD_CONST_INLINE).

<!-- gh-issue-number: gh-114058 -->
* Issue: gh-114058
<!-- /gh-issue-number -->
