### PR TITLE
gh-115836: Don't use hardcoded line numbers in test_monitoring

### DIFF
--- a/Lib/test/test_monitoring.py
+++ b/Lib/test/test_monitoring.py
@@ -35,6 +35,9 @@ TEST_TOOL = 2
 TEST_TOOL2 = 3
 TEST_TOOL3 = 4
 
+def nth_line(func, offset):
+    return func.__code__.co_firstlineno + offset
+
 class MonitoringBasicTest(unittest.TestCase):
 
     def test_has_objects(self):
@@ -529,8 +532,8 @@ class LineMonitoringTest(MonitoringTestBase, unittest.TestCase):
             f1()
             sys.monitoring.set_events(TEST_TOOL, 0)
             sys.monitoring.register_callback(TEST_TOOL, E.LINE, None)
-            start = LineMonitoringTest.test_lines_single.__code__.co_firstlineno
-            self.assertEqual(events, [start+7, 16, start+8])
+            start = nth_line(LineMonitoringTest.test_lines_single, 0)
+            self.assertEqual(events, [start+7, nth_line(f1, 1), start+8])
         finally:
             sys.monitoring.set_events(TEST_TOOL, 0)
             sys.monitoring.register_callback(TEST_TOOL, E.LINE, None)
@@ -547,8 +550,13 @@ class LineMonitoringTest(MonitoringTestBase, unittest.TestCase):
             floop()
             sys.monitoring.set_events(TEST_TOOL, 0)
             sys.monitoring.register_callback(TEST_TOOL, E.LINE, None)
-            start = LineMonitoringTest.test_lines_loop.__code__.co_firstlineno
-            self.assertEqual(events, [start+7, 23, 24, 23, 24, 23, start+8])
+            start = nth_line(LineMonitoringTest.test_lines_loop, 0)
+            floop_1 = nth_line(floop, 1)
+            floop_2 = nth_line(floop, 2)
+            self.assertEqual(
+                events,
+                [start+7, floop_1, floop_2, floop_1, floop_2, floop_1, start+8]
+            )
         finally:
             sys.monitoring.set_events(TEST_TOOL, 0)
             sys.monitoring.register_callback(TEST_TOOL, E.LINE, None)
@@ -569,8 +577,8 @@ class LineMonitoringTest(MonitoringTestBase, unittest.TestCase):
             sys.monitoring.set_events(TEST_TOOL, 0); sys.monitoring.set_events(TEST_TOOL2, 0)
             sys.monitoring.register_callback(TEST_TOOL, E.LINE, None)
             sys.monitoring.register_callback(TEST_TOOL2, E.LINE, None)
-            start = LineMonitoringTest.test_lines_two.__code__.co_firstlineno
-            expected = [start+10, 16, start+11]
+            start = nth_line(LineMonitoringTest.test_lines_two, 0)
+            expected = [start+10, nth_line(f1, 1), start+11]
             self.assertEqual(events, expected)
             self.assertEqual(events2, expected)
         finally:

--- a/Misc/NEWS.d/next/Tests/2024-02-23-01-35-25.gh-issue-115836.GDw5Ut.rst
+++ b/Misc/NEWS.d/next/Tests/2024-02-23-01-35-25.gh-issue-115836.GDw5Ut.rst
@@ -1,1 +1,0 @@
-Stop using hardcoded line numbers in ``test_monitoring``.

--- a/Misc/NEWS.d/next/Tests/2024-02-23-01-35-25.gh-issue-115836.GDw5Ut.rst
+++ b/Misc/NEWS.d/next/Tests/2024-02-23-01-35-25.gh-issue-115836.GDw5Ut.rst
@@ -1,0 +1,1 @@
+Stop using hardcoded line numbers in ``test_monitoring``.


### PR DESCRIPTION
Some of the expected line numbers are already offsets from `co_firstlineno`, but a few more needed to be converted.

- Issue: gh-115836
