### PR TITLE
gh-96471: Correct docs for queue shutdown raises

### DIFF
--- a/Doc/library/queue.rst
+++ b/Doc/library/queue.rst
@@ -188,9 +188,7 @@ fully processed by daemon consumer threads.
    that had been :meth:`put` into the queue).
 
    Raises a :exc:`ValueError` if called more times than there were items placed in
-   the queue.
-
-   Raises :exc:`ShutDown` if the queue has been shut down immediately.
+   the queue, or after an immediate shutdown.
 
 
 .. method:: Queue.join()
@@ -201,8 +199,6 @@ fully processed by daemon consumer threads.
    The count goes down whenever a consumer thread calls :meth:`task_done` to
    indicate that the item was retrieved and all work on it is complete.  When the
    count of unfinished tasks drops to zero, :meth:`join` unblocks.
-
-   Raises :exc:`ShutDown` if the queue has been shut down immediately.
 
 
 Example of how to wait for enqueued tasks to be completed::

--- a/Doc/library/queue.rst
+++ b/Doc/library/queue.rst
@@ -187,7 +187,7 @@ fully processed by daemon consumer threads.
    processed (meaning that a :meth:`task_done` call was received for every item
    that had been :meth:`put` into the queue).
 
-   :meth:`shutdown(immediate=True)` calls :meth:`task_done` for each remaining item
+   ``shutdown(immediate=True)`` calls :meth:`task_done` for each remaining item
    in the queue.
 
    Raises a :exc:`ValueError` if called more times than there were items placed in

--- a/Doc/library/queue.rst
+++ b/Doc/library/queue.rst
@@ -187,8 +187,11 @@ fully processed by daemon consumer threads.
    processed (meaning that a :meth:`task_done` call was received for every item
    that had been :meth:`put` into the queue).
 
+   :meth:`shutdown(immediate=True)` calls :meth:`task_done` for each remaining item
+   in the queue.
+
    Raises a :exc:`ValueError` if called more times than there were items placed in
-   the queue, or after an immediate shutdown.
+   the queue.
 
 
 .. method:: Queue.join()

--- a/Lib/queue.py
+++ b/Lib/queue.py
@@ -72,8 +72,11 @@ class Queue:
         have been processed (meaning that a task_done() call was received
         for every item that had been put() into the queue).
 
+        shutdown(immediate=True) calls task_done() for each remaining item in
+        the queue.
+
         Raises a ValueError if called more times than there were items
-        placed in the queue, or after an immediate shutdown.
+        placed in the queue.
         '''
         with self.all_tasks_done:
             unfinished = self.unfinished_tasks - 1

--- a/Lib/queue.py
+++ b/Lib/queue.py
@@ -73,9 +73,7 @@ class Queue:
         for every item that had been put() into the queue).
 
         Raises a ValueError if called more times than there were items
-        placed in the queue.
-
-        Raises ShutDown if the queue has been shut down immediately.
+        placed in the queue, or after an immediate shutdown.
         '''
         with self.all_tasks_done:
             unfinished = self.unfinished_tasks - 1
@@ -93,8 +91,6 @@ class Queue:
         to indicate the item was retrieved and all work on it is complete.
 
         When the count of unfinished tasks drops to zero, join() unblocks.
-
-        Raises ShutDown if the queue has been shut down immediately.
         '''
         with self.all_tasks_done:
             while self.unfinished_tasks:
@@ -227,13 +223,13 @@ class Queue:
         return self.get(block=False)
 
     def shutdown(self, immediate=False):
-        '''Shut-down the queue, making queue gets and puts raise.
+        '''Shut-down the queue, making queue gets and puts raise ShutDown.
 
         By default, gets will only raise once the queue is empty. Set
         'immediate' to True to make gets raise immediately instead.
 
         All blocked callers of put() will be unblocked, and also get()
-        and join() if 'immediate'. The ShutDown exception is raised.
+        and join() if 'immediate'.
         '''
         with self.mutex:
             self.is_shutdown = True

--- a/Lib/queue.py
+++ b/Lib/queue.py
@@ -234,7 +234,6 @@ class Queue:
         with self.mutex:
             self.is_shutdown = True
             if immediate:
-                n_items = self._qsize()
                 while self._qsize():
                     self._get()
                     if self.unfinished_tasks > 0:


### PR DESCRIPTION
* Remove "raises ShutDown" from `Queue.join()` and `Queue.task_done()` documentation (including doc-string)
* Clarify `Queue.shutdown()` behaviour (it doesn't raise itself, but causes other methods to raise)
* Add that `Queue.task_done()` is called by `Queue.shutdown(immediate=True)` for each item in the queue

Caused by: #104750 

<!-- gh-issue-number: gh-96471 -->
* Issue: gh-96471
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--115838.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->