### PR TITLE
Remove `ConverterKeywordDict` alias in `clinic.py`

### DIFF
--- a/Tools/clinic/clinic.py
+++ b/Tools/clinic/clinic.py
@@ -4069,8 +4069,6 @@ class str_converter(CConverter):
 # mapping from arguments to format unit *and* registers the
 # legacy C converter for that format unit.
 #
-ConverterKeywordDict = dict[str, TypeSet | bool]
-
 def r(format_unit: str,
       *,
       accept: TypeSet,
@@ -4086,7 +4084,7 @@ def r(format_unit: str,
         #
         # also don't add the converter for 's' because
         # the metaclass for CConverter adds it for us.
-        kwargs: ConverterKeywordDict = {}
+        kwargs: dict[str, Any] = {}
         if accept != {str}:
             kwargs['accept'] = accept
         if zeroes:


### PR DESCRIPTION
Context: https://github.com/python/mypy/pull/16939#issuecomment-1960882007

New mypy version detected this typing problem: `dict[str, TypeSet | bool]` is not the correct type for `**kwargs` of `str_converter.__init__`:

```diff
CPython (Argument Clinic) (https://github.com/python/cpython)
+ Tools/clinic/clinic.py:4094: error: Argument 1 to "str_converter" has incompatible type "**dict[str, set[type[object]] | bool]"; expected "str"  [arg-type]
+ Tools/clinic/clinic.py:4094: error: Argument 1 to "str_converter" has incompatible type "**dict[str, set[type[object]] | bool]"; expected "Function"  [arg-type]
+ Tools/clinic/clinic.py:4094: error: Argument 1 to "str_converter" has incompatible type "**dict[str, set[type[object]] | bool]"; expected "str | None"  [arg-type]
+ Tools/clinic/clinic.py:4094: error: Argument 1 to "str_converter" has incompatible type "**dict[str, set[type[object]] | bool]"; expected "str | Literal[Sentinels.unspecified]"  [arg-type]
+ Tools/clinic/clinic.py:4094: error: Argument 1 to "str_converter" has incompatible type "**dict[str, set[type[object]] | bool]"; expected "bool"  [arg-type]
```

(the error message looks cryptic).

`str_converter.__init__` has this type:

```python
def __init__(self,
             # Positional args:
             name: str,
             py_name: str,
             function: Function,
             default: object = unspecified,
             *,  # Keyword only args:
             c_default: str | None = None,
             py_default: str | None = None,
             annotation: str | Literal[Sentinels.unspecified] = unspecified,
             unused: bool = False,
             **kwargs: Any
    ) -> None:
```

So, basically you can only say that `**kwargs` can be `dict[str, Any]`.
This is why I removed this alias.