### PR TITLE
gh-115582: Make default PC/pyconfig.h work for free-threaded builds with manual /DPy_GIL_DISABLED

### DIFF
--- a/Misc/NEWS.d/next/Windows/2024-02-23-11-43-43.gh-issue-115582.sk1XPi.rst
+++ b/Misc/NEWS.d/next/Windows/2024-02-23-11-43-43.gh-issue-115582.sk1XPi.rst
@@ -1,3 +1,3 @@
 Building extensions intended for free-threaded builds of CPython now require
-defining :env:`Py_GIL_DISABLED` manually when using a regular install. This
+defining :envvar:`Py_GIL_DISABLED` manually when using a regular install. This
 is expected to change in future releases.

--- a/Misc/NEWS.d/next/Windows/2024-02-23-11-43-43.gh-issue-115582.sk1XPi.rst
+++ b/Misc/NEWS.d/next/Windows/2024-02-23-11-43-43.gh-issue-115582.sk1XPi.rst
@@ -1,3 +1,3 @@
 Building extensions intended for free-threaded builds of CPython now require
-defining :envvar:`Py_GIL_DISABLED` manually when using a regular install. This
+compiling with ``/DPy_GIL_DISABLED`` manually when using a regular install. This
 is expected to change in future releases.

--- a/Misc/NEWS.d/next/Windows/2024-02-23-11-43-43.gh-issue-115582.sk1XPi.rst
+++ b/Misc/NEWS.d/next/Windows/2024-02-23-11-43-43.gh-issue-115582.sk1XPi.rst
@@ -1,0 +1,3 @@
+Building extensions intended for free-threaded builds of CPython now require
+defining :env:`Py_GIL_DISABLED` manually when using a regular install. This
+is expected to change in future releases.

--- a/PC/pyconfig.h.in
+++ b/PC/pyconfig.h.in
@@ -95,7 +95,12 @@ WIN32 is still required for the locale module.
 #endif /* Py_BUILD_CORE || Py_BUILD_CORE_BUILTIN || Py_BUILD_CORE_MODULE */
 
 /* Define to 1 if you want to disable the GIL */
-#undef Py_GIL_DISABLED
+/* Uncomment the definition for free-threaded builds, or define it manually
+ * when compiling extension modules. Note that we test with #ifdef, so
+ * defining as 0 will still disable the GIL. */
+#ifndef Py_GIL_DISABLED
+/* #define Py_GIL_DISABLED 1 */
+#endif
 
 /* Compiler specific defines */
 

--- a/PCbuild/pythoncore.vcxproj
+++ b/PCbuild/pythoncore.vcxproj
@@ -677,7 +677,7 @@
       <OldPyConfigH Condition="Exists('$(IntDir)pyconfig.h')">$([System.IO.File]::ReadAllText('$(IntDir)pyconfig.h'))</OldPyConfigH>
     </PropertyGroup>
     <PropertyGroup Condition="$(DisableGil) == 'true'">
-      <PyConfigHText>$(PyConfigHText.Replace('#undef Py_GIL_DISABLED', '#define Py_GIL_DISABLED 1'))</PyConfigHText>
+      <PyConfigHText>$(PyConfigHText.Replace('/* #define Py_GIL_DISABLED 1 */', '#define Py_GIL_DISABLED 1'))</PyConfigHText>
     </PropertyGroup>
     <Message Text="Updating pyconfig.h" Condition="$(PyConfigHText.TrimEnd()) != $(OldPyConfigH.TrimEnd())" />
     <WriteLinesToFile File="$(IntDir)pyconfig.h"


### PR DESCRIPTION


<!-- gh-issue-number: gh-115582 -->
* Issue: gh-115582
<!-- /gh-issue-number -->
