### PR TITLE
Use response.status instead of response.code in urllib.request

### DIFF
--- a/Lib/test/test_urllib2.py
+++ b/Lib/test/test_urllib2.py
@@ -299,9 +299,9 @@ class MockHeaders(dict):
 
 
 class MockResponse(io.StringIO):
-    def __init__(self, code, msg, headers, data, url=None):
+    def __init__(self, status, msg, headers, data, url=None):
         io.StringIO.__init__(self, data)
-        self.code, self.msg, self.headers, self.url = code, msg, headers, url
+        self.status, self.msg, self.headers, self.url = status, msg, headers, url
 
     def info(self):
         return self.headers

--- a/Lib/urllib/request.py
+++ b/Lib/urllib/request.py
@@ -596,7 +596,7 @@ class HTTPErrorProcessor(BaseHandler):
     handler_order = 1000  # after all other processing
 
     def http_response(self, request, response):
-        code, msg, hdrs = response.code, response.msg, response.info()
+        code, msg, hdrs = response.status, response.msg, response.info()
 
         # According to RFC 2616, "2xx" code indicates that the client's
         # request was successfully received, understood, and accepted.
@@ -1006,7 +1006,7 @@ class AbstractBasicAuthHandler:
 
     def http_response(self, req, response):
         if hasattr(self.passwd, 'is_authenticated'):
-            if 200 <= response.code < 300:
+            if 200 <= response.status < 300:
                 self.passwd.update_authenticated(req.full_url, True)
             else:
                 self.passwd.update_authenticated(req.full_url, False)


### PR DESCRIPTION
This way when mocking the response only the status attribute will be enough instead of both status and code.
This may be breaking other people mocks but HTTPResponse.code attribute is not documented.
