### PR TITLE
[3.11] gh-115886: Handle embedded null characters in shared memory name (GH-115887)

### DIFF
--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -3932,6 +3932,21 @@ class _TestSharedMemory(BaseTestCase):
         # test_multiprocessing_spawn, etc) in parallel.
         return prefix + str(os.getpid())
 
+    def test_shared_memory_name_with_embedded_null(self):
+        name_tsmb = self._new_shm_name('test01_null')
+        sms = shared_memory.SharedMemory(name_tsmb, create=True, size=512)
+        self.addCleanup(sms.unlink)
+        with self.assertRaises(ValueError):
+            shared_memory.SharedMemory(name_tsmb + '\0a', create=False, size=512)
+        if shared_memory._USE_POSIX:
+            orig_name = sms._name
+            try:
+                sms._name = orig_name + '\0a'
+                with self.assertRaises(ValueError):
+                    sms.unlink()
+            finally:
+                sms._name = orig_name
+
     def test_shared_memory_basics(self):
         name_tsmb = self._new_shm_name('test01_tsmb')
         sms = shared_memory.SharedMemory(name_tsmb, create=True, size=512)
@@ -4066,7 +4081,7 @@ class _TestSharedMemory(BaseTestCase):
             self.addCleanup(shm2.unlink)
             self.assertEqual(shm2._name, names[1])
 
-    def test_invalid_shared_memory_cration(self):
+    def test_invalid_shared_memory_creation(self):
         # Test creating a shared memory segment with negative size
         with self.assertRaises(ValueError):
             sms_invalid = shared_memory.SharedMemory(create=True, size=-1)

--- a/Misc/NEWS.d/next/Library/2024-02-24-18-48-14.gh-issue-115886.rgM6AF.rst
+++ b/Misc/NEWS.d/next/Library/2024-02-24-18-48-14.gh-issue-115886.rgM6AF.rst
@@ -1,0 +1,2 @@
+Fix silent truncation of the name with an embedded null character in
+:class:`multiprocessing.shared_memory.SharedMemory`.

--- a/Modules/_multiprocessing/posixshmem.c
+++ b/Modules/_multiprocessing/posixshmem.c
@@ -42,8 +42,13 @@ _posixshmem_shm_open_impl(PyObject *module, PyObject *path, int flags,
 {
     int fd;
     int async_err = 0;
-    const char *name = PyUnicode_AsUTF8(path);
+    Py_ssize_t name_size;
+    const char *name = PyUnicode_AsUTF8AndSize(path, &name_size);
     if (name == NULL) {
+        return -1;
+    }
+    if (strlen(name) != (size_t)name_size) {
+        PyErr_SetString(PyExc_ValueError, "embedded null character");
         return -1;
     }
     do {
@@ -81,8 +86,13 @@ _posixshmem_shm_unlink_impl(PyObject *module, PyObject *path)
 {
     int rv;
     int async_err = 0;
-    const char *name = PyUnicode_AsUTF8(path);
+    Py_ssize_t name_size;
+    const char *name = PyUnicode_AsUTF8AndSize(path, &name_size);
     if (name == NULL) {
+        return NULL;
+    }
+    if (strlen(name) != (size_t)name_size) {
+        PyErr_SetString(PyExc_ValueError, "embedded null character");
         return NULL;
     }
     do {


### PR DESCRIPTION
shm_open() and shm_unlink() now check for embedded null characters in the name and raise an error instead of silently truncating it.
(cherry picked from commit 79811ededd160b6e8bcfbe4b0f9d5b4589280f19)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-115886 -->
* Issue: gh-115886
<!-- /gh-issue-number -->
