### PR TITLE
 gh-115914: double use init filename_obj value in pythonrun.c function PyRun_AnyFileExFlags

### DIFF
--- a/Python/pythonrun.c
+++ b/Python/pythonrun.c
@@ -89,16 +89,13 @@ int
 PyRun_AnyFileExFlags(FILE *fp, const char *filename, int closeit,
                      PyCompilerFlags *flags)
 {
-    PyObject *filename_obj;
+    PyObject *filename_obj = NULL;
     if (filename != NULL) {
         filename_obj = PyUnicode_DecodeFSDefault(filename);
         if (filename_obj == NULL) {
             PyErr_Print();
             return -1;
         }
-    }
-    else {
-        filename_obj = NULL;
     }
     int res = _PyRun_AnyFileObject(fp, filename_obj, closeit, flags);
     Py_XDECREF(filename_obj);


### PR DESCRIPTION

gh-115914: double init filename_obj value in pythonrun.c function PyRun_AnyFileExFlags

Improvement:

Simplifying the code. This change makes the code easier to understand because filename_obj is guaranteed to have an initial value, eliminating the need to check for that value in a separate else block. This makes the code cleaner and easier to read.

Reduced chance of error. Initializing variables before using them is good programming practice. This helps prevent errors caused by using uninitialized variables, which could lead to undefined behavior.

Efficiency: Although the change seems minor from a performance perspective, it does improve coding style by ensuring that all variables are properly initialized before use. In this case, the modification is more about code readability and maintainability than a direct performance increase.
