### PR TITLE
gh-71052: Enable test_concurrent_futures on platforms that support threading but not multiprocessing

### DIFF
--- a/Lib/multiprocessing/queues.py
+++ b/Lib/multiprocessing/queues.py
@@ -20,8 +20,6 @@ import errno
 
 from queue import Empty, Full
 
-import _multiprocessing
-
 from . import connection
 from . import context
 _ForkingPickler = context.reduction.ForkingPickler

--- a/Lib/test/test___all__.py
+++ b/Lib/test/test___all__.py
@@ -5,11 +5,6 @@ import os
 import sys
 import types
 
-try:
-    import _multiprocessing
-except ModuleNotFoundError:
-    _multiprocessing = None
-
 
 if support.check_sanitizer(address=True, memory=True):
     SKIP_MODULES = frozenset((
@@ -35,17 +30,6 @@ class FailedImport(RuntimeError):
 
 
 class AllTest(unittest.TestCase):
-
-    def setUp(self):
-        # concurrent.futures uses a __getattr__ hook. Its __all__ triggers
-        # import of a submodule, which fails when _multiprocessing is not
-        # available.
-        if _multiprocessing is None:
-            sys.modules["_multiprocessing"] = types.ModuleType("_multiprocessing")
-
-    def tearDown(self):
-        if _multiprocessing is None:
-            sys.modules.pop("_multiprocessing")
 
     def check_all(self, modname):
         names = {}

--- a/Lib/test/test_concurrent_futures/__init__.py
+++ b/Lib/test/test_concurrent_futures/__init__.py
@@ -3,8 +3,6 @@ import unittest
 from test import support
 from test.support import import_helper
 
-# Skip tests if _multiprocessing wasn't built.
-import_helper.import_module('_multiprocessing')
 
 if support.check_sanitizer(address=True, memory=True):
     # gh-90791: Skip the test because it is too slow when Python is built

--- a/Lib/test/test_concurrent_futures/test_init.py
+++ b/Lib/test/test_concurrent_futures/test_init.py
@@ -5,6 +5,8 @@ import time
 import unittest
 import sys
 from concurrent.futures._base import BrokenExecutor
+from concurrent.futures.process import _check_system_limits
+
 from logging.handlers import QueueHandler
 
 from test import support
@@ -117,6 +119,11 @@ class FailingInitializerResourcesTest(unittest.TestCase):
     """
 
     def _test(self, test_class):
+        try:
+            _check_system_limits()
+        except NotImplementedError:
+            self.skipTest("ProcessPoolExecutor unavailable on this system")
+
         runner = unittest.TextTestRunner()
         runner.run(test_class('test_initializer'))
 

--- a/Lib/test/test_concurrent_futures/util.py
+++ b/Lib/test/test_concurrent_futures/util.py
@@ -136,6 +136,12 @@ def create_executor_tests(remote_globals, mixin, bases=(BaseTestCase,),
 
 
 def setup_module():
-    unittest.addModuleCleanup(multiprocessing.util._cleanup_tests)
+    try:
+        _check_system_limits()
+    except NotImplementedError:
+        pass
+    else:
+        unittest.addModuleCleanup(multiprocessing.util._cleanup_tests)
+
     thread_info = threading_helper.threading_setup()
     unittest.addModuleCleanup(threading_helper.threading_cleanup, *thread_info)

--- a/Misc/NEWS.d/next/Tests/2024-02-25-15-58-28.gh-issue-71052.lxBjqY.rst
+++ b/Misc/NEWS.d/next/Tests/2024-02-25-15-58-28.gh-issue-71052.lxBjqY.rst
@@ -1,0 +1,2 @@
+Enable ``test_concurrent_futures`` on platforms that support threading but not
+multiprocessing.


### PR DESCRIPTION
`test_concurrent_futures` was previously skipped on platforms that don't support multiprocessing. Android and iOS don't support multiprocessing, but they do support threading, so this PR gives them test coverage of the threading-related parts of `concurrent.futures`. A couple of more focused skips were added to exclude the process-related tests.

I also had to remove an unused import of `_multiprocessing` from `multiprocessing.queues`. This allows `multiprocessing.queues` to be imported on platforms that don't support multiprocessing, as long as the code doesn't actually create a queue. 

Other places which are helped by this change include:

* `test___all__`, which no longer needs a multiprocessing-specific workaround.

* `logging.config`, which imports `multiprocessing.queue` only to do an `isinstance` check. No code changes were required here.

<!-- gh-issue-number: gh-71052 -->
* Issue: gh-71052
<!-- /gh-issue-number -->
