### PR TITLE
gh-71052: Add test exclusions to support running the test suite on Android

### DIFF
--- a/Lib/test/support/os_helper.py
+++ b/Lib/test/support/os_helper.py
@@ -198,6 +198,23 @@ def skip_unless_symlink(test):
     return test if ok else unittest.skip(msg)(test)
 
 
+_can_hardlink = None
+
+def can_hardlink():
+    global _can_hardlink
+    if _can_hardlink is None:
+        # Android blocks hard links using SELinux
+        # (https://stackoverflow.com/q/32365690).
+        _can_hardlink = hasattr(os, "link") and not support.is_android
+    return _can_hardlink
+
+
+def skip_unless_hardlink(test):
+    ok = can_hardlink()
+    msg = "requires hardlink support"
+    return test if ok else unittest.skip(msg)(test)
+
+
 _can_xattr = None
 
 

--- a/Lib/test/test_asyncio/test_subprocess.py
+++ b/Lib/test/test_asyncio/test_subprocess.py
@@ -13,6 +13,8 @@ from test.test_asyncio import utils as test_utils
 from test import support
 from test.support import os_helper
 
+if not support.has_subprocess_support:
+    raise unittest.SkipTest("test module requires subprocess")
 
 if support.MS_WINDOWS:
     import msvcrt
@@ -47,7 +49,6 @@ class TestSubprocessTransport(base_subprocess.BaseSubprocessTransport):
         self._proc.pid = -1
 
 
-@support.requires_subprocess()
 class SubprocessTransportTests(test_utils.TestCase):
     def setUp(self):
         super().setUp()
@@ -111,7 +112,6 @@ class SubprocessTransportTests(test_utils.TestCase):
         transport.close()
 
 
-@support.requires_subprocess()
 class SubprocessMixin:
 
     def test_stdin_stdout(self):

--- a/Lib/test/test_compileall.py
+++ b/Lib/test/test_compileall.py
@@ -977,7 +977,7 @@ class CommandLineTestsNoSourceEpoch(CommandLineTestsBase,
 
 
 
-@unittest.skipUnless(hasattr(os, 'link'), 'requires os.link')
+@os_helper.skip_unless_hardlink
 class HardlinkDedupTestsBase:
     # Test hardlink_dupes parameter of compileall.compile_dir()
 

--- a/Lib/test/test_fcntl.py
+++ b/Lib/test/test_fcntl.py
@@ -129,7 +129,8 @@ class TestFcntl(unittest.TestCase):
             fcntl.fcntl(BadFile(INT_MIN - 1), fcntl.F_SETFL, os.O_NONBLOCK)
 
     @unittest.skipIf(
-        platform.machine().startswith('arm') and platform.system() == 'Linux',
+        any(platform.machine().startswith(name) for name in ["arm", "aarch"])
+        and platform.system() in ["Linux", "Android"],
         "ARM Linux returns EINVAL for F_NOTIFY DN_MULTISHOT")
     def test_fcntl_64_bit(self):
         # Issue #1309352: fcntl shouldn't fail when the third arg fits in a

--- a/Lib/test/test_fcntl.py
+++ b/Lib/test/test_fcntl.py
@@ -129,8 +129,8 @@ class TestFcntl(unittest.TestCase):
             fcntl.fcntl(BadFile(INT_MIN - 1), fcntl.F_SETFL, os.O_NONBLOCK)
 
     @unittest.skipIf(
-        any(platform.machine().startswith(name) for name in ["arm", "aarch"])
-        and platform.system() in ["Linux", "Android"],
+        any(platform.machine().startswith(name) for name in {"arm", "aarch"})
+        and platform.system() in {"Linux", "Android"},
         "ARM Linux returns EINVAL for F_NOTIFY DN_MULTISHOT")
     def test_fcntl_64_bit(self):
         # Issue #1309352: fcntl shouldn't fail when the third arg fits in a

--- a/Lib/test/test_interpreters/test_lifecycle.py
+++ b/Lib/test/test_interpreters/test_lifecycle.py
@@ -164,6 +164,7 @@ class StartupTests(TestBase):
 
 class FinalizationTests(TestBase):
 
+    @support.requires_subprocess()
     def test_gh_109793(self):
         # Make sure finalization finishes and the correct error code
         # is reported, even when subinterpreters get cleaned up at the end.

--- a/Lib/test/test_pathlib/test_pathlib.py
+++ b/Lib/test/test_pathlib/test_pathlib.py
@@ -796,7 +796,7 @@ class PathTest(test_pathlib_abc.DummyPathTest, PurePathTest):
         self.assertFileNotFound(p.stat)
         self.assertFileNotFound(p.unlink)
 
-    @unittest.skipUnless(hasattr(os, "link"), "os.link() is not present")
+    @os_helper.skip_unless_hardlink
     def test_hardlink_to(self):
         P = self.cls(self.base)
         target = P / 'fileA'

--- a/Lib/test/test_posix.py
+++ b/Lib/test/test_posix.py
@@ -1270,9 +1270,10 @@ class PosixTester(unittest.TestCase):
         self.assertIn(mine, possible_schedulers)
         try:
             parent = posix.sched_getscheduler(os.getppid())
-        except OSError as e:
-            if e.errno != errno.EPERM:
-                raise
+        except PermissionError:
+            # POSIX specifies EPERM, but Android returns EACCES. Both errno
+            # values are mapped to PermissionError.
+            pass
         else:
             self.assertIn(parent, possible_schedulers)
         self.assertRaises(OSError, posix.sched_getscheduler, -1)
@@ -1287,9 +1288,8 @@ class PosixTester(unittest.TestCase):
             try:
                 posix.sched_setscheduler(0, mine, param)
                 posix.sched_setparam(0, param)
-            except OSError as e:
-                if e.errno != errno.EPERM:
-                    raise
+            except PermissionError:
+                pass
             self.assertRaises(OSError, posix.sched_setparam, -1, param)
 
         self.assertRaises(OSError, posix.sched_setscheduler, -1, mine, param)

--- a/Lib/test/test_pty.py
+++ b/Lib/test/test_pty.py
@@ -1,7 +1,7 @@
 import sys
 import unittest
 from test.support import (
-    is_apple_mobile, is_emscripten, is_wasi, reap_children, verbose
+    is_android, is_apple_mobile, is_emscripten, is_wasi, reap_children, verbose
 )
 from test.support.import_helper import import_module
 from test.support.os_helper import TESTFN, unlink
@@ -9,9 +9,8 @@ from test.support.os_helper import TESTFN, unlink
 # Skip these tests if termios is not available
 import_module('termios')
 
-# Skip tests on WASM platforms, plus iOS/tvOS/watchOS
-if is_apple_mobile or is_emscripten or is_wasi:
-    raise unittest.SkipTest(f"pty tests not required on {sys.platform}")
+if is_android or is_apple_mobile or is_emscripten or is_wasi:
+    raise unittest.SkipTest(f"pty is not available on this platform")
 
 import errno
 import os

--- a/Lib/test/test_pty.py
+++ b/Lib/test/test_pty.py
@@ -1,4 +1,3 @@
-import sys
 import unittest
 from test.support import (
     is_android, is_apple_mobile, is_emscripten, is_wasi, reap_children, verbose
@@ -10,7 +9,7 @@ from test.support.os_helper import TESTFN, unlink
 import_module('termios')
 
 if is_android or is_apple_mobile or is_emscripten or is_wasi:
-    raise unittest.SkipTest(f"pty is not available on this platform")
+    raise unittest.SkipTest("pty is not available on this platform")
 
 import errno
 import os

--- a/Lib/test/test_venv.py
+++ b/Lib/test/test_venv.py
@@ -19,8 +19,9 @@ import sysconfig
 import tempfile
 from test.support import (captured_stdout, captured_stderr,
                           skip_if_broken_multiprocessing_synchronize, verbose,
-                          requires_subprocess, is_apple_mobile, is_emscripten,
-                          is_wasi, requires_venv_with_pip, TEST_HOME_DIR,
+                          requires_subprocess, is_android, is_apple_mobile,
+                          is_emscripten, is_wasi,
+                          requires_venv_with_pip, TEST_HOME_DIR,
                           requires_resource, copy_python_src_ignore)
 from test.support.os_helper import (can_symlink, EnvironmentVarGuard, rmtree)
 import unittest
@@ -39,10 +40,8 @@ requireVenvCreate = unittest.skipUnless(
     or sys._base_executable != sys.executable,
     'cannot run venv.create from within a venv on this platform')
 
-# Skip tests on WASM platforms, plus iOS/tvOS/watchOS
-if is_apple_mobile or is_emscripten or is_wasi:
-    raise unittest.SkipTest(f"venv tests not required on {sys.platform}")
-
+if is_android or is_apple_mobile or is_emscripten or is_wasi:
+    raise unittest.SkipTest("venv is not available on this platform")
 
 @requires_subprocess()
 def check_output(cmd, encoding=None):

--- a/Misc/NEWS.d/next/Tests/2024-02-25-16-28-26.gh-issue-71052.lSb9EC.rst
+++ b/Misc/NEWS.d/next/Tests/2024-02-25-16-28-26.gh-issue-71052.lSb9EC.rst
@@ -1,0 +1,1 @@
+Add test exclusions to support running the test suite on Android.


### PR DESCRIPTION
This PR builds on #114889 by @freakboy3742. It marks Android as not supporting subprocesses, and skips some additional tests  which can't be run on this platform.

Some multiprocessing-related test changes have been submitted separately in #115917.

<!-- gh-issue-number: gh-71052 -->
* Issue: gh-71052
<!-- /gh-issue-number -->
