### PR TITLE
gh-115881: Ensure `ast.parse()` parses conditional context managers even with low `feature_version` passed

### DIFF
--- a/Grammar/python.gram
+++ b/Grammar/python.gram
@@ -393,7 +393,7 @@ for_stmt[stmt_ty]:
 with_stmt[stmt_ty]:
     | invalid_with_stmt_indent
     | 'with' '(' a[asdl_withitem_seq*]=','.with_item+ ','? ')' ':' tc=[TYPE_COMMENT] b=block {
-       CHECK_VERSION(stmt_ty, 9, "Parenthesized context managers are", _PyAST_With(a, b, NEW_TYPE_COMMENT(p, tc), EXTRA)) }
+       _PyAST_With(a, b, NEW_TYPE_COMMENT(p, tc), EXTRA) }
     | 'with' a[asdl_withitem_seq*]=','.with_item+ ':' tc=[TYPE_COMMENT] b=block {
         _PyAST_With(a, b, NEW_TYPE_COMMENT(p, tc), EXTRA) }
     | 'async' 'with' '(' a[asdl_withitem_seq*]=','.with_item+ ','? ')' ':' b=block {

--- a/Lib/test/test_ast.py
+++ b/Lib/test/test_ast.py
@@ -1058,6 +1058,10 @@ class AST_Tests(unittest.TestCase):
         with self.assertRaises(SyntaxError):
             ast.parse('(x := 0)', feature_version=(3, 7))
 
+    def test_conditional_context_managers_parse_with_low_feature_version(self):
+        # regression test for gh-115881
+        ast.parse('with (x() if y else z()): ...', feature_version=(3, 8))
+
     def test_exception_groups_feature_version(self):
         code = dedent('''
         try: ...

--- a/Lib/test/test_ast.py
+++ b/Lib/test/test_ast.py
@@ -1045,14 +1045,6 @@ class AST_Tests(unittest.TestCase):
         with self.assertRaises(SyntaxError):
             ast.parse('lambda x=1, /: ...', feature_version=(3, 7))
 
-    def test_parenthesized_with_feature_version(self):
-        ast.parse('with (CtxManager() as example): ...', feature_version=(3, 10))
-        # While advertised as a feature in Python 3.10, this was allowed starting 3.9
-        ast.parse('with (CtxManager() as example): ...', feature_version=(3, 9))
-        with self.assertRaises(SyntaxError):
-            ast.parse('with (CtxManager() as example): ...', feature_version=(3, 8))
-        ast.parse('with CtxManager() as example: ...', feature_version=(3, 8))
-
     def test_assignment_expression_feature_version(self):
         ast.parse('(x := 0)', feature_version=(3, 8))
         with self.assertRaises(SyntaxError):

--- a/Lib/test/test_type_comments.py
+++ b/Lib/test/test_type_comments.py
@@ -309,7 +309,7 @@ class TypeCommentTests(unittest.TestCase):
         self.assertEqual(tree.body[0].type_comment, None)
 
     def test_parenthesized_withstmt(self):
-        for tree in self.parse_all(parenthesized_withstmt, minver=9):
+        for tree in self.parse_all(parenthesized_withstmt):
             self.assertEqual(tree.body[0].type_comment, "int")
             self.assertEqual(tree.body[1].type_comment, "int")
         tree = self.classic_parse(parenthesized_withstmt)

--- a/Misc/NEWS.d/next/Library/2024-02-25-19-20-05.gh-issue-115881.ro_Kuw.rst
+++ b/Misc/NEWS.d/next/Library/2024-02-25-19-20-05.gh-issue-115881.ro_Kuw.rst
@@ -1,4 +1,4 @@
-Fix issue where `ast.parse()` would incorrectly flag conditional context
-managers (such as `with (x() if y else z()): ...`) as invalid syntax if
-`feature_version=(3, 8)` was passed. This reverts changes to the
+Fix issue where :func:`ast.parse` would incorrectly flag conditional context
+managers (such as ``with (x() if y else z()): ...``) as invalid syntax if
+``feature_version=(3, 8)`` was passed. This reverts changes to the
 grammar made as part of gh-94949.

--- a/Misc/NEWS.d/next/Library/2024-02-25-19-20-05.gh-issue-115881.ro_Kuw.rst
+++ b/Misc/NEWS.d/next/Library/2024-02-25-19-20-05.gh-issue-115881.ro_Kuw.rst
@@ -1,0 +1,4 @@
+Fix issue where `ast.parse()` would incorrectly flag conditional context
+managers (such as `with (x() if y else z()): ...`) as invalid syntax if
+`feature_version=(3, 8)` was passed. This reverts changes to the
+grammar made as part of gh-94949.

--- a/Parser/parser.c
+++ b/Parser/parser.c
@@ -6603,7 +6603,7 @@ with_stmt_rule(Parser *p)
             UNUSED(_end_lineno); // Only used by EXTRA macro
             int _end_col_offset = _token->end_col_offset;
             UNUSED(_end_col_offset); // Only used by EXTRA macro
-            _res = CHECK_VERSION ( stmt_ty , 9 , "Parenthesized context managers are" , _PyAST_With ( a , b , NEW_TYPE_COMMENT ( p , tc ) , EXTRA ) );
+            _res = _PyAST_With ( a , b , NEW_TYPE_COMMENT ( p , tc ) , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 p->level--;


### PR DESCRIPTION


<!-- gh-issue-number: gh-115881 -->
* Issue: gh-115881
<!-- /gh-issue-number -->
