### PR TITLE
gh-115931: Fix `SyntaxWarning`s in `test_unparse`

### DIFF
--- a/Lib/test/test_unparse.py
+++ b/Lib/test/test_unparse.py
@@ -650,9 +650,16 @@ class CosmeticTestCase(ASTTestCase):
         self.check_ast_roundtrip("""f'''""\"''\\'{""\"\\n\\"'''""\" '''\\n'''}''' """)
 
     def test_backslash_in_format_spec(self):
-        self.check_ast_roundtrip("""f"{x:\\ }" """)
+        with self.assertWarns(SyntaxWarning):
+            self.check_ast_roundtrip("""f"{x:\\ }" """)
+        self.check_ast_roundtrip("""f"{x:\\n}" """)
+
         self.check_ast_roundtrip("""f"{x:\\\\ }" """)
-        self.check_ast_roundtrip("""f"{x:\\\\\\ }" """)
+
+        with self.assertWarns(SyntaxWarning):
+            self.check_ast_roundtrip("""f"{x:\\\\\\ }" """)
+        self.check_ast_roundtrip("""f"{x:\\\\\\n}" """)
+
         self.check_ast_roundtrip("""f"{x:\\\\\\\\ }" """)
 
     def test_quote_in_format_spec(self):

--- a/Lib/test/test_unparse.py
+++ b/Lib/test/test_unparse.py
@@ -650,13 +650,15 @@ class CosmeticTestCase(ASTTestCase):
         self.check_ast_roundtrip("""f'''""\"''\\'{""\"\\n\\"'''""\" '''\\n'''}''' """)
 
     def test_backslash_in_format_spec(self):
-        with self.assertWarns(SyntaxWarning):
+        import re
+        msg = re.escape("invalid escape sequence '\\ '")
+        with self.assertWarnsRegex(SyntaxWarning, msg):
             self.check_ast_roundtrip("""f"{x:\\ }" """)
         self.check_ast_roundtrip("""f"{x:\\n}" """)
 
         self.check_ast_roundtrip("""f"{x:\\\\ }" """)
 
-        with self.assertWarns(SyntaxWarning):
+        with self.assertWarnsRegex(SyntaxWarning, msg):
             self.check_ast_roundtrip("""f"{x:\\\\\\ }" """)
         self.check_ast_roundtrip("""f"{x:\\\\\\n}" """)
 


### PR DESCRIPTION
Refs:
- https://github.com/python/cpython/issues/112364
- https://github.com/python/cpython/pull/115696

The problem is that the odd amount of `\` produces the `\ ` escape sequence that is not valid.
So, I added two expected warnings + I added two extra cases with valid escape sequences `\n`.

Thanks a lot to @Eclips4 for the report!
CC @15r10nk

<!-- gh-issue-number: gh-115931 -->
* Issue: gh-115931
<!-- /gh-issue-number -->
