### PR TITLE
chg: :zap: optimize Future's read only method by removing useless con…

### DIFF
--- a/Lib/concurrent/futures/_base.py
+++ b/Lib/concurrent/futures/_base.py
@@ -382,18 +382,15 @@ class Future(object):
 
     def cancelled(self):
         """Return True if the future was cancelled."""
-        with self._condition:
-            return self._state in [CANCELLED, CANCELLED_AND_NOTIFIED]
+        return self._state in [CANCELLED, CANCELLED_AND_NOTIFIED]
 
     def running(self):
         """Return True if the future is currently executing."""
-        with self._condition:
-            return self._state == RUNNING
+        return self._state == RUNNING
 
     def done(self):
         """Return True if the future was cancelled or finished executing."""
-        with self._condition:
-            return self._state in [CANCELLED, CANCELLED_AND_NOTIFIED, FINISHED]
+        return self._state in [CANCELLED, CANCELLED_AND_NOTIFIED, FINISHED]
 
     def __get_result(self):
         if self._exception:


### PR DESCRIPTION
…ditional variable usage

# Optimize away Future read only method

```
Changes made:
remove conditional variable used in 3 methods:
1. Future.done()
2. Future.cancelled()
3. Future.running()
```

The usage of conditional variables here is useless because in and == operations are atomic and because these are read operations anyways. Hence this won't affect thread safety of Python code