### PR TITLE
gh-110850: Add PyTime_TimeUnchecked() function

### DIFF
--- a/Doc/c-api/time.rst
+++ b/Doc/c-api/time.rst
@@ -61,15 +61,30 @@ with the :term:`GIL` held.
    Read the monotonic clock.
    See :func:`time.monotonic` for important details on this clock.
 
+.. c:function:: PyTime_t PyTime_MonotonicUnchecked()
+
+   Similar to :func:`PyTime_Monotonic()`, but return ``0`` and silently ignore
+   the error if reading the clock fails.
+
 .. c:function:: int PyTime_PerfCounter(PyTime_t *result)
 
    Read the performance counter.
    See :func:`time.perf_counter` for important details on this clock.
 
+.. c:function:: PyTime_t PyTime_PerfCounterUnchecked()
+
+   Similar to :func:`PyTime_PerfCounter()`, but return ``0`` and silently
+   ignore the error if reading the clock fails.
+
 .. c:function:: int PyTime_Time(PyTime_t *result)
 
    Read the “wall clock” time.
    See :func:`time.time` for details important on this clock.
+
+.. c:function:: PyTime_t PyTime_TimeUnchecked()
+
+   Similar to :func:`PyTime_Time()`, but return ``0`` and silently ignore the
+   error if reading the clock fails.
 
 
 Conversion functions

--- a/Doc/c-api/time.rst
+++ b/Doc/c-api/time.rst
@@ -66,6 +66,9 @@ with the :term:`GIL` held.
    Similar to :func:`PyTime_Monotonic()`, but return ``0`` and silently ignore
    the error if reading the clock fails.
 
+   The caller doesn't have to hold the GIL; the function does not raise an
+   exception on error.
+
 .. c:function:: int PyTime_PerfCounter(PyTime_t *result)
 
    Read the performance counter.
@@ -76,6 +79,9 @@ with the :term:`GIL` held.
    Similar to :func:`PyTime_PerfCounter()`, but return ``0`` and silently
    ignore the error if reading the clock fails.
 
+   The caller doesn't have to hold the GIL; the function does not raise an
+   exception on error.
+
 .. c:function:: int PyTime_Time(PyTime_t *result)
 
    Read the “wall clock” time.
@@ -85,6 +91,9 @@ with the :term:`GIL` held.
 
    Similar to :func:`PyTime_Time()`, but return ``0`` and silently ignore the
    error if reading the clock fails.
+
+   The caller doesn't have to hold the GIL; the function does not raise an
+   exception on error.
 
 
 Conversion functions

--- a/Doc/c-api/time.rst
+++ b/Doc/c-api/time.rst
@@ -63,8 +63,8 @@ with the :term:`GIL` held.
 
 .. c:function:: PyTime_t PyTime_MonotonicUnchecked()
 
-   Similar to :func:`PyTime_Monotonic()`, but return ``0`` and silently ignore
-   the error if reading the clock fails.
+   Similar to :c:func:`PyTime_Monotonic()`, but return ``0`` and silently
+   ignore the error if reading the clock fails.
 
    The caller doesn't have to hold the GIL; the function does not raise an
    exception on error.
@@ -76,7 +76,7 @@ with the :term:`GIL` held.
 
 .. c:function:: PyTime_t PyTime_PerfCounterUnchecked()
 
-   Similar to :func:`PyTime_PerfCounter()`, but return ``0`` and silently
+   Similar to :c:func:`PyTime_PerfCounter()`, but return ``0`` and silently
    ignore the error if reading the clock fails.
 
    The caller doesn't have to hold the GIL; the function does not raise an
@@ -89,7 +89,7 @@ with the :term:`GIL` held.
 
 .. c:function:: PyTime_t PyTime_TimeUnchecked()
 
-   Similar to :func:`PyTime_Time()`, but return ``0`` and silently ignore the
+   Similar to :c:func:`PyTime_Time()`, but return ``0`` and silently ignore the
    error if reading the clock fails.
 
    The caller doesn't have to hold the GIL; the function does not raise an

--- a/Doc/whatsnew/3.13.rst
+++ b/Doc/whatsnew/3.13.rst
@@ -1573,7 +1573,7 @@ New Features
     :c:func:`PyTime_Time` functions.
   * :c:func:`PyTime_MonotonicUnchecked`, :c:func:`PyTime_PerfCounterUnchecked`
     and :c:func:`PyTime_TimeUnchecked`: similar to previous functions, but
-    ignores errors.
+    ignores errors and doesn't require to hold the GIL.
 
   (Contributed by Victor Stinner and Petr Viktorin in :gh:`110850`.)
 

--- a/Doc/whatsnew/3.13.rst
+++ b/Doc/whatsnew/3.13.rst
@@ -1571,6 +1571,9 @@ New Features
   * :c:func:`PyTime_AsSecondsDouble`
     :c:func:`PyTime_Monotonic`, :c:func:`PyTime_PerfCounter`, and
     :c:func:`PyTime_Time` functions.
+  * :c:func:`PyTime_MonotonicUnchecked`, :c:func:`PyTime_PerfCounterUnchecked`
+    and :c:func:`PyTime_TimeUnchecked`: similar to previous functions, but
+    ignores errors.
 
   (Contributed by Victor Stinner and Petr Viktorin in :gh:`110850`.)
 

--- a/Include/cpython/pytime.h
+++ b/Include/cpython/pytime.h
@@ -15,6 +15,9 @@ PyAPI_FUNC(double) PyTime_AsSecondsDouble(PyTime_t t);
 PyAPI_FUNC(int) PyTime_Monotonic(PyTime_t *result);
 PyAPI_FUNC(int) PyTime_PerfCounter(PyTime_t *result);
 PyAPI_FUNC(int) PyTime_Time(PyTime_t *result);
+PyAPI_FUNC(PyTime_t) PyTime_MonotonicUnchecked(void);
+PyAPI_FUNC(PyTime_t) PyTime_PerfCounterUnchecked(void);
+PyAPI_FUNC(PyTime_t) PyTime_TimeUnchecked(void);
 
 #ifdef __cplusplus
 }

--- a/Include/internal/pycore_time.h
+++ b/Include/internal/pycore_time.h
@@ -247,13 +247,10 @@ typedef struct {
     double resolution;
 } _Py_clock_info_t;
 
-// Similar to PyTime_Time() but silently ignore the error and return 0 if the
-// internal clock fails.
-//
-// Use _PyTime_TimeWithInfo() or the public PyTime_Time() to check
-// for failure.
-// Export for '_random' shared extension.
-PyAPI_FUNC(PyTime_t) _PyTime_TimeUnchecked(void);
+// Backward compatibility
+#define _PyTime_TimeUnchecked PyTime_TimeUnchecked
+#define _PyTime_MonotonicUnchecked PyTime_MonotonicUnchecked
+#define _PyTime_PerfCounterUnchecked PyTime_PerfCounterUnchecked
 
 // Get the current time from the system clock.
 // On success, set *t and *info (if not NULL), and return 0.
@@ -261,14 +258,6 @@ PyAPI_FUNC(PyTime_t) _PyTime_TimeUnchecked(void);
 extern int _PyTime_TimeWithInfo(
     PyTime_t *t,
     _Py_clock_info_t *info);
-
-// Similar to PyTime_Monotonic() but silently ignore the error and return 0 if
-// the internal clock fails.
-//
-// Use _PyTime_MonotonicWithInfo() or the public PyTime_Monotonic()
-// to check for failure.
-// Export for '_random' shared extension.
-PyAPI_FUNC(PyTime_t) _PyTime_MonotonicUnchecked(void);
 
 // Get the time of a monotonic clock, i.e. a clock that cannot go backwards.
 // The clock is not affected by system clock updates. The reference point of
@@ -293,14 +282,6 @@ PyAPI_FUNC(int) _PyTime_localtime(time_t t, struct tm *tm);
 // Return 0 on success, raise an exception and return -1 on error.
 // Export for '_datetime' shared extension.
 PyAPI_FUNC(int) _PyTime_gmtime(time_t t, struct tm *tm);
-
-// Similar to PyTime_PerfCounter() but silently ignore the error and return 0
-// if the internal clock fails.
-//
-// Use _PyTime_PerfCounterWithInfo() or the public PyTime_PerfCounter() to
-// check for failure.
-// Export for '_lsprof' shared extension.
-PyAPI_FUNC(PyTime_t) _PyTime_PerfCounterUnchecked(void);
 
 
 // Get the performance counter: clock with the highest available resolution to
@@ -352,6 +333,8 @@ extern PyTime_t _PyTimeFraction_Mul(
 extern double _PyTimeFraction_Resolution(
     const _PyTimeFraction *frac);
 
+
+extern PyStatus _PyTime_Init(void);
 
 #ifdef __cplusplus
 }

--- a/Lib/test/test_capi/test_time.py
+++ b/Lib/test/test_capi/test_time.py
@@ -8,7 +8,7 @@ PyTime_MIN = _testcapi.PyTime_MIN
 PyTime_MAX = _testcapi.PyTime_MAX
 SEC_TO_NS = 10 ** 9
 DAY_TO_SEC = (24 * 60 * 60)
-# Worst clock resolution: maximum delta between two clock reads.
+# Worst clock resolution in seconds: maximum delta between two clock reads.
 CLOCK_RES = 0.050
 
 
@@ -59,13 +59,16 @@ class CAPITest(unittest.TestCase):
                                  ns_to_sec(ns))
 
     def test_monotonic(self):
-        # Test PyTime_Monotonic()
+        # Test PyTime_Monotonic() and PyTime_MonotonicUnchecked()
         self.check_clock(_testcapi.PyTime_Monotonic, time.monotonic)
+        self.check_clock(_testcapi.PyTime_MonotonicUnchecked, time.monotonic)
 
     def test_perf_counter(self):
-        # Test PyTime_PerfCounter()
+        # Test PyTime_PerfCounter() and PyTime_PerfCounterUnchecked()
         self.check_clock(_testcapi.PyTime_PerfCounter, time.perf_counter)
+        self.check_clock(_testcapi.PyTime_PerfCounterUnchecked, time.perf_counter)
 
     def test_time(self):
-        # Test PyTime_time()
+        # Test PyTime_Time() and PyTime_TimeUnchecked()
         self.check_clock(_testcapi.PyTime_Time, time.time)
+        self.check_clock(_testcapi.PyTime_TimeUnchecked, time.time)

--- a/Misc/NEWS.d/next/C API/2024-02-26-22-23-24.gh-issue-110850.nlLqWV.rst
+++ b/Misc/NEWS.d/next/C API/2024-02-26-22-23-24.gh-issue-110850.nlLqWV.rst
@@ -1,0 +1,7 @@
+Add functions:
+
+* :c:func:`PyTime_MonotonicUnchecked`
+* :c:func:`PyTime_PerfCounterUnchecked`
+* :c:func:`PyTime_TimeUnchecked`
+
+Patch by Victor Stinner.

--- a/Modules/_testcapi/time.c
+++ b/Modules/_testcapi/time.c
@@ -59,6 +59,14 @@ test_pytime_monotonic(PyObject *Py_UNUSED(self), PyObject *Py_UNUSED(args))
 
 
 static PyObject*
+test_pytime_monotonic_unchecked(PyObject *Py_UNUSED(self), PyObject *Py_UNUSED(args))
+{
+    PyTime_t t = PyTime_MonotonicUnchecked();
+    return pytime_as_float(t);
+}
+
+
+static PyObject*
 test_pytime_perf_counter(PyObject *Py_UNUSED(self), PyObject *Py_UNUSED(args))
 {
     PyTime_t t;
@@ -67,6 +75,14 @@ test_pytime_perf_counter(PyObject *Py_UNUSED(self), PyObject *Py_UNUSED(args))
         return NULL;
     }
     assert(res == 0);
+    return pytime_as_float(t);
+}
+
+
+static PyObject*
+test_pytime_perf_counter_unchecked(PyObject *Py_UNUSED(self), PyObject *Py_UNUSED(args))
+{
+    PyTime_t t = PyTime_PerfCounterUnchecked();
     return pytime_as_float(t);
 }
 
@@ -84,11 +100,22 @@ test_pytime_time(PyObject *Py_UNUSED(self), PyObject *Py_UNUSED(args))
 }
 
 
+static PyObject*
+test_pytime_time_unchecked(PyObject *Py_UNUSED(self), PyObject *Py_UNUSED(args))
+{
+    PyTime_t t = PyTime_TimeUnchecked();
+    return pytime_as_float(t);
+}
+
+
 static PyMethodDef test_methods[] = {
     {"PyTime_AsSecondsDouble", test_pytime_assecondsdouble, METH_VARARGS},
     {"PyTime_Monotonic", test_pytime_monotonic, METH_NOARGS},
+    {"PyTime_MonotonicUnchecked", test_pytime_monotonic_unchecked, METH_NOARGS},
     {"PyTime_PerfCounter", test_pytime_perf_counter, METH_NOARGS},
+    {"PyTime_PerfCounterUnchecked", test_pytime_perf_counter_unchecked, METH_NOARGS},
     {"PyTime_Time", test_pytime_time, METH_NOARGS},
+    {"PyTime_TimeUnchecked", test_pytime_time_unchecked, METH_NOARGS},
     {NULL},
 };
 

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -27,6 +27,7 @@
 #include "pycore_setobject.h"     // _PySet_NextEntry()
 #include "pycore_sliceobject.h"   // _PySlice_Fini()
 #include "pycore_sysmodule.h"     // _PySys_ClearAuditHooks()
+#include "pycore_time.h"          // _PyTime_Init()
 #include "pycore_traceback.h"     // _Py_DumpTracebackThreads()
 #include "pycore_typeobject.h"    // _PyTypes_InitTypes()
 #include "pycore_typevarobject.h" // _Py_clear_generic_types()
@@ -524,6 +525,11 @@ pycore_init_runtime(_PyRuntimeState *runtime,
     _PyRuntimeState_SetFinalizing(runtime, NULL);
 
     _Py_InitVersion();
+
+    status = _PyTime_Init();
+    if (_PyStatus_EXCEPTION(status)) {
+        return status;
+    }
 
     status = _Py_HashRandomization_Init(config);
     if (_PyStatus_EXCEPTION(status)) {


### PR DESCRIPTION
Add functions:

* PyTime_MonotonicUnchecked()
* PyTime_PerfCounterUnchecked()
* PyTime_TimeUnchecked()

Python now fails with a fatal error at startup if reading the system clock, the monotonic clock or the perf counter clock fails.

Add py_perf_counter() function to factorize code.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-110850 -->
* Issue: gh-110850
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--115973.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->