### PR TITLE
GH-115816: Assorted naming and formatting changes to improve maintainability.

### DIFF
--- a/Include/internal/pycore_optimizer.h
+++ b/Include/internal/pycore_optimizer.h
@@ -97,13 +97,13 @@ extern void _Py_uop_sym_set_type(_Py_UopsSymbol *sym, PyTypeObject *tp);
 extern int _Py_uop_abstractcontext_init(_Py_UOpsContext *ctx);
 extern void _Py_uop_abstractcontext_fini(_Py_UOpsContext *ctx);
 
-extern _Py_UOpsAbstractFrame *_Py_uop_ctx_frame_new(
+extern _Py_UOpsAbstractFrame *_Py_uop_frame_new(
     _Py_UOpsContext *ctx,
     PyCodeObject *co,
     _Py_UopsSymbol **localsplus_start,
     int n_locals_already_filled,
     int curr_stackentries);
-extern int _Py_uop_ctx_frame_pop(_Py_UOpsContext *ctx);
+extern int _Py_uop_frame_pop(_Py_UOpsContext *ctx);
 
 PyAPI_FUNC(PyObject *) _Py_uop_symbols_test(PyObject *self, PyObject *ignored);
 

--- a/Include/internal/pycore_optimizer.h
+++ b/Include/internal/pycore_optimizer.h
@@ -38,9 +38,7 @@ struct _Py_UOpsSymType {
 // Holds locals, stack, locals, stack ... co_consts (in that order)
 #define MAX_ABSTRACT_INTERP_SIZE 4096
 
-#define OVERALLOCATE_FACTOR 5
-
-#define TY_ARENA_SIZE (UOP_MAX_TRACE_LENGTH * OVERALLOCATE_FACTOR)
+#define TY_ARENA_SIZE (UOP_MAX_TRACE_LENGTH * 5)
 
 // Need extras for root frame and for overflow frame (see TRACE_STACK_PUSH())
 #define MAX_ABSTRACT_FRAME_DEPTH (TRACE_STACK_SIZE + 2)
@@ -107,8 +105,7 @@ extern _Py_UOpsAbstractFrame *_Py_uop_ctx_frame_new(
     int curr_stackentries);
 extern int _Py_uop_ctx_frame_pop(_Py_UOpsAbstractInterpContext *ctx);
 
-PyAPI_FUNC(PyObject *)
-_Py_uop_symbols_test(PyObject *self, PyObject *ignored);
+PyAPI_FUNC(PyObject *) _Py_uop_symbols_test(PyObject *self, PyObject *ignored);
 
 #ifdef __cplusplus
 }

--- a/Include/internal/pycore_optimizer.h
+++ b/Include/internal/pycore_optimizer.h
@@ -28,7 +28,7 @@ extern PyTypeObject _PyUOpOptimizer_Type;
 
 /* Symbols */
 
-struct _Py_UOpsSymType {
+struct _Py_UopsSymbol {
     int flags;
     PyTypeObject *typ;
     // constant propagated value (might be NULL)
@@ -43,16 +43,16 @@ struct _Py_UOpsSymType {
 // Need extras for root frame and for overflow frame (see TRACE_STACK_PUSH())
 #define MAX_ABSTRACT_FRAME_DEPTH (TRACE_STACK_SIZE + 2)
 
-typedef struct _Py_UOpsSymType _Py_UOpsSymType;
+typedef struct _Py_UopsSymbol _Py_UopsSymbol;
 
 struct _Py_UOpsAbstractFrame {
     // Max stacklen
     int stack_len;
     int locals_len;
 
-    _Py_UOpsSymType **stack_pointer;
-    _Py_UOpsSymType **stack;
-    _Py_UOpsSymType **locals;
+    _Py_UopsSymbol **stack_pointer;
+    _Py_UopsSymbol **stack;
+    _Py_UopsSymbol **locals;
 };
 
 typedef struct _Py_UOpsAbstractFrame _Py_UOpsAbstractFrame;
@@ -60,10 +60,10 @@ typedef struct _Py_UOpsAbstractFrame _Py_UOpsAbstractFrame;
 typedef struct ty_arena {
     int ty_curr_number;
     int ty_max_number;
-    _Py_UOpsSymType arena[TY_ARENA_SIZE];
+    _Py_UopsSymbol arena[TY_ARENA_SIZE];
 } ty_arena;
 
-struct _Py_UOpsAbstractInterpContext {
+struct _Py_UOpsContext {
     PyObject_HEAD
     // The current "executing" frame.
     _Py_UOpsAbstractFrame *frame;
@@ -73,37 +73,37 @@ struct _Py_UOpsAbstractInterpContext {
     // Arena for the symbolic types.
     ty_arena t_arena;
 
-    _Py_UOpsSymType **n_consumed;
-    _Py_UOpsSymType **limit;
-    _Py_UOpsSymType *locals_and_stack[MAX_ABSTRACT_INTERP_SIZE];
+    _Py_UopsSymbol **n_consumed;
+    _Py_UopsSymbol **limit;
+    _Py_UopsSymbol *locals_and_stack[MAX_ABSTRACT_INTERP_SIZE];
 };
 
-typedef struct _Py_UOpsAbstractInterpContext _Py_UOpsAbstractInterpContext;
+typedef struct _Py_UOpsContext _Py_UOpsContext;
 
-extern bool _Py_uop_sym_is_null(_Py_UOpsSymType *sym);
-extern bool _Py_uop_sym_is_not_null(_Py_UOpsSymType *sym);
-extern bool _Py_uop_sym_is_const(_Py_UOpsSymType *sym);
-extern PyObject *_Py_uop_sym_get_const(_Py_UOpsSymType *sym);
-extern _Py_UOpsSymType *_Py_uop_sym_new_unknown(_Py_UOpsAbstractInterpContext *ctx);
-extern _Py_UOpsSymType *_Py_uop_sym_new_not_null(_Py_UOpsAbstractInterpContext *ctx);
-extern _Py_UOpsSymType *_Py_uop_sym_new_type(
-    _Py_UOpsAbstractInterpContext *ctx, PyTypeObject *typ);
-extern _Py_UOpsSymType *_Py_uop_sym_new_const(_Py_UOpsAbstractInterpContext *ctx, PyObject *const_val);
-extern _Py_UOpsSymType *_Py_uop_sym_new_null(_Py_UOpsAbstractInterpContext *ctx);
-extern bool _Py_uop_sym_matches_type(_Py_UOpsSymType *sym, PyTypeObject *typ);
-extern void _Py_uop_sym_set_null(_Py_UOpsSymType *sym);
-extern void _Py_uop_sym_set_type(_Py_UOpsSymType *sym, PyTypeObject *tp);
+extern bool _Py_uop_sym_is_null(_Py_UopsSymbol *sym);
+extern bool _Py_uop_sym_is_not_null(_Py_UopsSymbol *sym);
+extern bool _Py_uop_sym_is_const(_Py_UopsSymbol *sym);
+extern PyObject *_Py_uop_sym_get_const(_Py_UopsSymbol *sym);
+extern _Py_UopsSymbol *_Py_uop_sym_new_unknown(_Py_UOpsContext *ctx);
+extern _Py_UopsSymbol *_Py_uop_sym_new_not_null(_Py_UOpsContext *ctx);
+extern _Py_UopsSymbol *_Py_uop_sym_new_type(
+    _Py_UOpsContext *ctx, PyTypeObject *typ);
+extern _Py_UopsSymbol *_Py_uop_sym_new_const(_Py_UOpsContext *ctx, PyObject *const_val);
+extern _Py_UopsSymbol *_Py_uop_sym_new_null(_Py_UOpsContext *ctx);
+extern bool _Py_uop_sym_matches_type(_Py_UopsSymbol *sym, PyTypeObject *typ);
+extern void _Py_uop_sym_set_null(_Py_UopsSymbol *sym);
+extern void _Py_uop_sym_set_type(_Py_UopsSymbol *sym, PyTypeObject *tp);
 
-extern int _Py_uop_abstractcontext_init(_Py_UOpsAbstractInterpContext *ctx);
-extern void _Py_uop_abstractcontext_fini(_Py_UOpsAbstractInterpContext *ctx);
+extern int _Py_uop_abstractcontext_init(_Py_UOpsContext *ctx);
+extern void _Py_uop_abstractcontext_fini(_Py_UOpsContext *ctx);
 
 extern _Py_UOpsAbstractFrame *_Py_uop_ctx_frame_new(
-    _Py_UOpsAbstractInterpContext *ctx,
+    _Py_UOpsContext *ctx,
     PyCodeObject *co,
-    _Py_UOpsSymType **localsplus_start,
+    _Py_UopsSymbol **localsplus_start,
     int n_locals_already_filled,
     int curr_stackentries);
-extern int _Py_uop_ctx_frame_pop(_Py_UOpsAbstractInterpContext *ctx);
+extern int _Py_uop_ctx_frame_pop(_Py_UOpsContext *ctx);
 
 PyAPI_FUNC(PyObject *) _Py_uop_symbols_test(PyObject *self, PyObject *ignored);
 

--- a/Lib/test/test_generated_cases.py
+++ b/Lib/test/test_generated_cases.py
@@ -890,8 +890,8 @@ class TestGeneratedAbstractCases(unittest.TestCase):
         """
         output = """
         case OP: {
-            _Py_UOpsSymType *arg1;
-            _Py_UOpsSymType *out;
+            _Py_UopsSymbol *arg1;
+            _Py_UopsSymbol *out;
             arg1 = stack_pointer[-1];
             eggs();
             stack_pointer[-1] = out;
@@ -899,7 +899,7 @@ class TestGeneratedAbstractCases(unittest.TestCase):
         }
 
         case OP2: {
-            _Py_UOpsSymType *out;
+            _Py_UopsSymbol *out;
             out = _Py_uop_sym_new_unknown(ctx);
             if (out == NULL) goto out_of_space;
             stack_pointer[-1] = out;
@@ -924,7 +924,7 @@ class TestGeneratedAbstractCases(unittest.TestCase):
         """
         output = """
         case OP: {
-            _Py_UOpsSymType *out;
+            _Py_UopsSymbol *out;
             out = _Py_uop_sym_new_unknown(ctx);
             if (out == NULL) goto out_of_space;
             stack_pointer[-1] = out;
@@ -932,8 +932,8 @@ class TestGeneratedAbstractCases(unittest.TestCase):
         }
 
         case OP2: {
-            _Py_UOpsSymType *arg1;
-            _Py_UOpsSymType *out;
+            _Py_UopsSymbol *arg1;
+            _Py_UopsSymbol *out;
             arg1 = stack_pointer[-1];
             stack_pointer[-1] = out;
             break;

--- a/Modules/_testinternalcapi.c
+++ b/Modules/_testinternalcapi.c
@@ -24,7 +24,7 @@
 #include "pycore_interp.h"        // _PyInterpreterState_GetConfigCopy()
 #include "pycore_long.h"          // _PyLong_Sign()
 #include "pycore_object.h"        // _PyObject_IsFreed()
-#include "pycore_optimizer.h"     // _Py_UOpsSymType, etc.
+#include "pycore_optimizer.h"     // _Py_UopsSymbol, etc.
 #include "pycore_pathconfig.h"    // _PyPathConfig_ClearGlobal()
 #include "pycore_pyerrors.h"      // _PyErr_ChainExceptions1()
 #include "pycore_pystate.h"       // _PyThreadState_GET()

--- a/Python/optimizer_analysis.c
+++ b/Python/optimizer_analysis.c
@@ -282,6 +282,23 @@ remove_globals(_PyInterpreterFrame *frame, _PyUOpInstruction *buffer,
     } while (0);
 
 
+/* Shortened forms for convenience, used in optimizer_bytecodes.c */
+#define sym_is_not_null _Py_uop_sym_is_not_null
+#define sym_is_const _Py_uop_sym_is_const
+#define sym_get_const _Py_uop_sym_get_const
+#define sym_new_unknown _Py_uop_sym_new_unknown
+#define sym_new_not_null _Py_uop_sym_new_not_null
+#define sym_new_type _Py_uop_sym_new_type
+#define sym_is_null _Py_uop_sym_is_null
+#define sym_new_const _Py_uop_sym_new_const
+#define sym_new_null _Py_uop_sym_new_null
+#define sym_matches_type _Py_uop_sym_matches_type
+#define sym_set_null _Py_uop_sym_set_null
+#define sym_set_type _Py_uop_sym_set_type
+#define frame_new _Py_uop_frame_new
+#define frame_pop _Py_uop_frame_pop
+
+
 /* 1 for success, 0 for not ready, cannot error at the moment. */
 static int
 optimize_uops(
@@ -299,7 +316,7 @@ optimize_uops(
     if (_Py_uop_abstractcontext_init(ctx) < 0) {
         goto out_of_space;
     }
-    _Py_UOpsAbstractFrame *frame = _Py_uop_ctx_frame_new(ctx, co, ctx->n_consumed, 0, curr_stacklen);
+    _Py_UOpsAbstractFrame *frame = _Py_uop_frame_new(ctx, co, ctx->n_consumed, 0, curr_stacklen);
     if (frame == NULL) {
         return -1;
     }

--- a/Python/optimizer_analysis.c
+++ b/Python/optimizer_analysis.c
@@ -293,8 +293,8 @@ optimize_uops(
 )
 {
 
-    _Py_UOpsAbstractInterpContext context;
-    _Py_UOpsAbstractInterpContext *ctx = &context;
+    _Py_UOpsContext context;
+    _Py_UOpsContext *ctx = &context;
 
     if (_Py_uop_abstractcontext_init(ctx) < 0) {
         goto out_of_space;
@@ -313,7 +313,7 @@ optimize_uops(
         int oparg = this_instr->oparg;
         uint32_t opcode = this_instr->opcode;
 
-        _Py_UOpsSymType **stack_pointer = ctx->frame->stack_pointer;
+        _Py_UopsSymbol **stack_pointer = ctx->frame->stack_pointer;
 
         DPRINTF(3, "Abstract interpreting %s:%d ",
                 _PyUOpName(opcode),

--- a/Python/optimizer_bytecodes.c
+++ b/Python/optimizer_bytecodes.c
@@ -1,4 +1,5 @@
 #include "Python.h"
+#include "pycore_optimizer.h"
 #include "pycore_uops.h"
 #include "pycore_uop_ids.h"
 #include "internal/pycore_moduleobject.h"
@@ -8,6 +9,22 @@
 typedef struct _Py_UopsSymbol _Py_UopsSymbol;
 typedef struct _Py_UOpsContext _Py_UOpsContext;
 typedef struct _Py_UOpsAbstractFrame _Py_UOpsAbstractFrame;
+
+/* Shortened forms for convenience */
+#define sym_is_not_null _Py_uop_sym_is_not_null
+#define sym_is_const _Py_uop_sym_is_const
+#define sym_get_const _Py_uop_sym_get_const
+#define sym_new_unknown _Py_uop_sym_new_unknown
+#define sym_new_not_null _Py_uop_sym_new_not_null
+#define sym_new_type _Py_uop_sym_new_type
+#define sym_is_null _Py_uop_sym_is_null
+#define sym_new_const _Py_uop_sym_new_const
+#define sym_new_null _Py_uop_sym_new_null
+#define sym_matches_type _Py_uop_sym_matches_type
+#define sym_set_null _Py_uop_sym_set_null
+#define sym_set_type _Py_uop_sym_set_type
+#define frame_new _Py_uop_frame_new
+#define frame_pop _Py_uop_frame_pop
 
 static int
 dummy_func(void) {
@@ -33,7 +50,7 @@ dummy_func(void) {
     op(_LOAD_FAST_CHECK, (-- value)) {
         value = GETLOCAL(oparg);
         // We guarantee this will error - just bail and don't optimize it.
-        if (_Py_uop_sym_is_null(value)) {
+        if (sym_is_null(value)) {
             goto out_of_space;
         }
     }
@@ -45,7 +62,7 @@ dummy_func(void) {
     op(_LOAD_FAST_AND_CLEAR, (-- value)) {
         value = GETLOCAL(oparg);
         _Py_UopsSymbol *temp;
-        OUT_OF_SPACE_IF_NULL(temp = _Py_uop_sym_new_null(ctx));
+        OUT_OF_SPACE_IF_NULL(temp = sym_new_null(ctx));
         GETLOCAL(oparg) = temp;
     }
 
@@ -54,147 +71,147 @@ dummy_func(void) {
     }
 
     op(_PUSH_NULL, (-- res)) {
-        res = _Py_uop_sym_new_null(ctx);
+        res = sym_new_null(ctx);
         if (res == NULL) {
             goto out_of_space;
         };
     }
 
     op(_GUARD_BOTH_INT, (left, right -- left, right)) {
-        if (_Py_uop_sym_matches_type(left, &PyLong_Type) &&
-            _Py_uop_sym_matches_type(right, &PyLong_Type)) {
+        if (sym_matches_type(left, &PyLong_Type) &&
+            sym_matches_type(right, &PyLong_Type)) {
             REPLACE_OP(this_instr, _NOP, 0, 0);
         }
-        _Py_uop_sym_set_type(left, &PyLong_Type);
-        _Py_uop_sym_set_type(right, &PyLong_Type);
+        sym_set_type(left, &PyLong_Type);
+        sym_set_type(right, &PyLong_Type);
     }
 
     op(_GUARD_BOTH_FLOAT, (left, right -- left, right)) {
-        if (_Py_uop_sym_matches_type(left, &PyFloat_Type) &&
-            _Py_uop_sym_matches_type(right, &PyFloat_Type)) {
+        if (sym_matches_type(left, &PyFloat_Type) &&
+            sym_matches_type(right, &PyFloat_Type)) {
             REPLACE_OP(this_instr, _NOP, 0 ,0);
         }
-        _Py_uop_sym_set_type(left, &PyFloat_Type);
-        _Py_uop_sym_set_type(right, &PyFloat_Type);
+        sym_set_type(left, &PyFloat_Type);
+        sym_set_type(right, &PyFloat_Type);
     }
 
     op(_GUARD_BOTH_UNICODE, (left, right -- left, right)) {
-        if (_Py_uop_sym_matches_type(left, &PyUnicode_Type) &&
-            _Py_uop_sym_matches_type(right, &PyUnicode_Type)) {
+        if (sym_matches_type(left, &PyUnicode_Type) &&
+            sym_matches_type(right, &PyUnicode_Type)) {
             REPLACE_OP(this_instr, _NOP, 0 ,0);
         }
-        _Py_uop_sym_set_type(left, &PyUnicode_Type);
-        _Py_uop_sym_set_type(right, &PyUnicode_Type);
+        sym_set_type(left, &PyUnicode_Type);
+        sym_set_type(right, &PyUnicode_Type);
     }
 
     op(_BINARY_OP_ADD_INT, (left, right -- res)) {
-        if (_Py_uop_sym_is_const(left) && _Py_uop_sym_is_const(right)) {
-            assert(PyLong_CheckExact(_Py_uop_sym_get_const(left)));
-            assert(PyLong_CheckExact(_Py_uop_sym_get_const(right)));
-            PyObject *temp = _PyLong_Add((PyLongObject *)_Py_uop_sym_get_const(left),
-                                         (PyLongObject *)_Py_uop_sym_get_const(right));
+        if (sym_is_const(left) && sym_is_const(right)) {
+            assert(PyLong_CheckExact(sym_get_const(left)));
+            assert(PyLong_CheckExact(sym_get_const(right)));
+            PyObject *temp = _PyLong_Add((PyLongObject *)sym_get_const(left),
+                                         (PyLongObject *)sym_get_const(right));
             if (temp == NULL) {
                 goto error;
             }
-            OUT_OF_SPACE_IF_NULL(res = _Py_uop_sym_new_const(ctx, temp));
+            OUT_OF_SPACE_IF_NULL(res = sym_new_const(ctx, temp));
             // TODO gh-115506:
             // replace opcode with constant propagated one and add tests!
         }
         else {
-            OUT_OF_SPACE_IF_NULL(res = _Py_uop_sym_new_type(ctx, &PyLong_Type));
+            OUT_OF_SPACE_IF_NULL(res = sym_new_type(ctx, &PyLong_Type));
         }
     }
 
     op(_BINARY_OP_SUBTRACT_INT, (left, right -- res)) {
-        if (_Py_uop_sym_is_const(left) && _Py_uop_sym_is_const(right)) {
-            assert(PyLong_CheckExact(_Py_uop_sym_get_const(left)));
-            assert(PyLong_CheckExact(_Py_uop_sym_get_const(right)));
-            PyObject *temp = _PyLong_Subtract((PyLongObject *)_Py_uop_sym_get_const(left),
-                                              (PyLongObject *)_Py_uop_sym_get_const(right));
+        if (sym_is_const(left) && sym_is_const(right)) {
+            assert(PyLong_CheckExact(sym_get_const(left)));
+            assert(PyLong_CheckExact(sym_get_const(right)));
+            PyObject *temp = _PyLong_Subtract((PyLongObject *)sym_get_const(left),
+                                              (PyLongObject *)sym_get_const(right));
             if (temp == NULL) {
                 goto error;
             }
-            OUT_OF_SPACE_IF_NULL(res = _Py_uop_sym_new_const(ctx, temp));
+            OUT_OF_SPACE_IF_NULL(res = sym_new_const(ctx, temp));
             // TODO gh-115506:
             // replace opcode with constant propagated one and add tests!
         }
         else {
-            OUT_OF_SPACE_IF_NULL(res = _Py_uop_sym_new_type(ctx, &PyLong_Type));
+            OUT_OF_SPACE_IF_NULL(res = sym_new_type(ctx, &PyLong_Type));
         }
     }
 
     op(_BINARY_OP_MULTIPLY_INT, (left, right -- res)) {
-        if (_Py_uop_sym_is_const(left) && _Py_uop_sym_is_const(right)) {
-            assert(PyLong_CheckExact(_Py_uop_sym_get_const(left)));
-            assert(PyLong_CheckExact(_Py_uop_sym_get_const(right)));
-            PyObject *temp = _PyLong_Multiply((PyLongObject *)_Py_uop_sym_get_const(left),
-                                              (PyLongObject *)_Py_uop_sym_get_const(right));
+        if (sym_is_const(left) && sym_is_const(right)) {
+            assert(PyLong_CheckExact(sym_get_const(left)));
+            assert(PyLong_CheckExact(sym_get_const(right)));
+            PyObject *temp = _PyLong_Multiply((PyLongObject *)sym_get_const(left),
+                                              (PyLongObject *)sym_get_const(right));
             if (temp == NULL) {
                 goto error;
             }
-            OUT_OF_SPACE_IF_NULL(res = _Py_uop_sym_new_const(ctx, temp));
+            OUT_OF_SPACE_IF_NULL(res = sym_new_const(ctx, temp));
             // TODO gh-115506:
             // replace opcode with constant propagated one and add tests!
         }
         else {
-            OUT_OF_SPACE_IF_NULL(res = _Py_uop_sym_new_type(ctx, &PyLong_Type));
+            OUT_OF_SPACE_IF_NULL(res = sym_new_type(ctx, &PyLong_Type));
         }
     }
 
     op(_BINARY_OP_ADD_FLOAT, (left, right -- res)) {
-        if (_Py_uop_sym_is_const(left) && _Py_uop_sym_is_const(right)) {
-            assert(PyFloat_CheckExact(_Py_uop_sym_get_const(left)));
-            assert(PyFloat_CheckExact(_Py_uop_sym_get_const(right)));
+        if (sym_is_const(left) && sym_is_const(right)) {
+            assert(PyFloat_CheckExact(sym_get_const(left)));
+            assert(PyFloat_CheckExact(sym_get_const(right)));
             PyObject *temp = PyFloat_FromDouble(
-                PyFloat_AS_DOUBLE(_Py_uop_sym_get_const(left)) +
-                PyFloat_AS_DOUBLE(_Py_uop_sym_get_const(right)));
+                PyFloat_AS_DOUBLE(sym_get_const(left)) +
+                PyFloat_AS_DOUBLE(sym_get_const(right)));
             if (temp == NULL) {
                 goto error;
             }
-            res = _Py_uop_sym_new_const(ctx, temp);
+            res = sym_new_const(ctx, temp);
             // TODO gh-115506:
             // replace opcode with constant propagated one and update tests!
         }
         else {
-            OUT_OF_SPACE_IF_NULL(res = _Py_uop_sym_new_type(ctx, &PyFloat_Type));
+            OUT_OF_SPACE_IF_NULL(res = sym_new_type(ctx, &PyFloat_Type));
         }
     }
 
     op(_BINARY_OP_SUBTRACT_FLOAT, (left, right -- res)) {
-        if (_Py_uop_sym_is_const(left) && _Py_uop_sym_is_const(right)) {
-            assert(PyFloat_CheckExact(_Py_uop_sym_get_const(left)));
-            assert(PyFloat_CheckExact(_Py_uop_sym_get_const(right)));
+        if (sym_is_const(left) && sym_is_const(right)) {
+            assert(PyFloat_CheckExact(sym_get_const(left)));
+            assert(PyFloat_CheckExact(sym_get_const(right)));
             PyObject *temp = PyFloat_FromDouble(
-                PyFloat_AS_DOUBLE(_Py_uop_sym_get_const(left)) -
-                PyFloat_AS_DOUBLE(_Py_uop_sym_get_const(right)));
+                PyFloat_AS_DOUBLE(sym_get_const(left)) -
+                PyFloat_AS_DOUBLE(sym_get_const(right)));
             if (temp == NULL) {
                 goto error;
             }
-            res = _Py_uop_sym_new_const(ctx, temp);
+            res = sym_new_const(ctx, temp);
             // TODO gh-115506:
             // replace opcode with constant propagated one and update tests!
         }
         else {
-            OUT_OF_SPACE_IF_NULL(res = _Py_uop_sym_new_type(ctx, &PyFloat_Type));
+            OUT_OF_SPACE_IF_NULL(res = sym_new_type(ctx, &PyFloat_Type));
         }
     }
 
     op(_BINARY_OP_MULTIPLY_FLOAT, (left, right -- res)) {
-        if (_Py_uop_sym_is_const(left) && _Py_uop_sym_is_const(right)) {
-            assert(PyFloat_CheckExact(_Py_uop_sym_get_const(left)));
-            assert(PyFloat_CheckExact(_Py_uop_sym_get_const(right)));
+        if (sym_is_const(left) && sym_is_const(right)) {
+            assert(PyFloat_CheckExact(sym_get_const(left)));
+            assert(PyFloat_CheckExact(sym_get_const(right)));
             PyObject *temp = PyFloat_FromDouble(
-                PyFloat_AS_DOUBLE(_Py_uop_sym_get_const(left)) *
-                PyFloat_AS_DOUBLE(_Py_uop_sym_get_const(right)));
+                PyFloat_AS_DOUBLE(sym_get_const(left)) *
+                PyFloat_AS_DOUBLE(sym_get_const(right)));
             if (temp == NULL) {
                 goto error;
             }
-            res = _Py_uop_sym_new_const(ctx, temp);
+            res = sym_new_const(ctx, temp);
             // TODO gh-115506:
             // replace opcode with constant propagated one and update tests!
         }
         else {
-            OUT_OF_SPACE_IF_NULL(res = _Py_uop_sym_new_type(ctx, &PyFloat_Type));
+            OUT_OF_SPACE_IF_NULL(res = sym_new_type(ctx, &PyFloat_Type));
         }
     }
 
@@ -205,21 +222,21 @@ dummy_func(void) {
     }
 
     op(_LOAD_CONST_INLINE, (ptr/4 -- value)) {
-        OUT_OF_SPACE_IF_NULL(value = _Py_uop_sym_new_const(ctx, ptr));
+        OUT_OF_SPACE_IF_NULL(value = sym_new_const(ctx, ptr));
     }
 
     op(_LOAD_CONST_INLINE_BORROW, (ptr/4 -- value)) {
-        OUT_OF_SPACE_IF_NULL(value = _Py_uop_sym_new_const(ctx, ptr));
+        OUT_OF_SPACE_IF_NULL(value = sym_new_const(ctx, ptr));
     }
 
     op(_LOAD_CONST_INLINE_WITH_NULL, (ptr/4 -- value, null)) {
-        OUT_OF_SPACE_IF_NULL(value = _Py_uop_sym_new_const(ctx, ptr));
-        OUT_OF_SPACE_IF_NULL(null = _Py_uop_sym_new_null(ctx));
+        OUT_OF_SPACE_IF_NULL(value = sym_new_const(ctx, ptr));
+        OUT_OF_SPACE_IF_NULL(null = sym_new_null(ctx));
     }
 
     op(_LOAD_CONST_INLINE_BORROW_WITH_NULL, (ptr/4 -- value, null)) {
-        OUT_OF_SPACE_IF_NULL(value = _Py_uop_sym_new_const(ctx, ptr));
-        OUT_OF_SPACE_IF_NULL(null = _Py_uop_sym_new_null(ctx));
+        OUT_OF_SPACE_IF_NULL(value = sym_new_const(ctx, ptr));
+        OUT_OF_SPACE_IF_NULL(null = sym_new_null(ctx));
     }
 
 
@@ -240,8 +257,8 @@ dummy_func(void) {
 
     op(_CHECK_ATTR_MODULE, (dict_version/2, owner -- owner)) {
         (void)dict_version;
-        if (_Py_uop_sym_is_const(owner)) {
-            PyObject *cnst = _Py_uop_sym_get_const(owner);
+        if (sym_is_const(owner)) {
+            PyObject *cnst = sym_get_const(owner);
             if (PyModule_CheckExact(cnst)) {
                 PyModuleObject *mod = (PyModuleObject *)cnst;
                 PyObject *dict = mod->md_dict;
@@ -257,23 +274,23 @@ dummy_func(void) {
 
     op(_LOAD_ATTR_MODULE, (index/1, owner -- attr, null if (oparg & 1))) {
         (void)index;
-        OUT_OF_SPACE_IF_NULL(null = _Py_uop_sym_new_null(ctx));
+        OUT_OF_SPACE_IF_NULL(null = sym_new_null(ctx));
         attr = NULL;
         if (this_instr[-1].opcode == _NOP) {
             // Preceding _CHECK_ATTR_MODULE was removed: mod is const and dict is watched.
-            assert(_Py_uop_sym_is_const(owner));
-            PyModuleObject *mod = (PyModuleObject *)_Py_uop_sym_get_const(owner);
+            assert(sym_is_const(owner));
+            PyModuleObject *mod = (PyModuleObject *)sym_get_const(owner);
             assert(PyModule_CheckExact(mod));
             PyObject *dict = mod->md_dict;
             PyObject *res = convert_global_to_const(this_instr, dict);
             if (res != NULL) {
                 this_instr[-1].opcode = _POP_TOP;
-                OUT_OF_SPACE_IF_NULL(attr = _Py_uop_sym_new_const(ctx, res));
+                OUT_OF_SPACE_IF_NULL(attr = sym_new_const(ctx, res));
             }
         }
         if (attr == NULL) {
             /* No conversion made. We don't know what `attr` is. */
-            OUT_OF_SPACE_IF_NULL(attr = _Py_uop_sym_new_not_null(ctx));
+            OUT_OF_SPACE_IF_NULL(attr = sym_new_not_null(ctx));
         }
     }
 
@@ -297,38 +314,38 @@ dummy_func(void) {
 
     op(_LOAD_ATTR_METHOD_WITH_VALUES, (descr/4, owner -- attr, self if (1))) {
         (void)descr;
-        OUT_OF_SPACE_IF_NULL(attr = _Py_uop_sym_new_not_null(ctx));
+        OUT_OF_SPACE_IF_NULL(attr = sym_new_not_null(ctx));
         self = owner;
     }
 
     op(_LOAD_ATTR_METHOD_NO_DICT, (descr/4, owner -- attr, self if (1))) {
         (void)descr;
-        OUT_OF_SPACE_IF_NULL(attr = _Py_uop_sym_new_not_null(ctx));
+        OUT_OF_SPACE_IF_NULL(attr = sym_new_not_null(ctx));
         self = owner;
     }
 
     op(_LOAD_ATTR_METHOD_LAZY_DICT, (descr/4, owner -- attr, self if (1))) {
         (void)descr;
-        OUT_OF_SPACE_IF_NULL(attr = _Py_uop_sym_new_not_null(ctx));
+        OUT_OF_SPACE_IF_NULL(attr = sym_new_not_null(ctx));
         self = owner;
     }
 
     op(_INIT_CALL_BOUND_METHOD_EXACT_ARGS, (callable, unused, unused[oparg] -- func, self, unused[oparg])) {
         (void)callable;
-        OUT_OF_SPACE_IF_NULL(func = _Py_uop_sym_new_not_null(ctx));
-        OUT_OF_SPACE_IF_NULL(self = _Py_uop_sym_new_not_null(ctx));
+        OUT_OF_SPACE_IF_NULL(func = sym_new_not_null(ctx));
+        OUT_OF_SPACE_IF_NULL(self = sym_new_not_null(ctx));
     }
 
 
     op(_CHECK_FUNCTION_EXACT_ARGS, (func_version/2, callable, self_or_null, unused[oparg] -- callable, self_or_null, unused[oparg])) {
-        _Py_uop_sym_set_type(callable, &PyFunction_Type);
+        sym_set_type(callable, &PyFunction_Type);
         (void)self_or_null;
         (void)func_version;
     }
 
     op(_CHECK_CALL_BOUND_METHOD_EXACT_ARGS, (callable, null, unused[oparg] -- callable, null, unused[oparg])) {
-        _Py_uop_sym_set_null(null);
-        _Py_uop_sym_set_type(callable, &PyMethod_Type);
+        sym_set_null(null);
+        sym_set_type(callable, &PyMethod_Type);
     }
 
     op(_INIT_CALL_PY_EXACT_ARGS, (callable, self_or_null, args[oparg] -- new_frame: _Py_UOpsAbstractFrame *)) {
@@ -344,7 +361,7 @@ dummy_func(void) {
 
         assert(self_or_null != NULL);
         assert(args != NULL);
-        if (_Py_uop_sym_is_not_null(self_or_null)) {
+        if (sym_is_not_null(self_or_null)) {
             // Bound method fiddling, same as _INIT_CALL_PY_EXACT_ARGS in VM
             args--;
             argcount++;
@@ -355,18 +372,18 @@ dummy_func(void) {
         // Can determine statically, so we interleave the new locals
         // and make the current stack the new locals.
         // This also sets up for true call inlining.
-        if (_Py_uop_sym_is_null(self_or_null) || _Py_uop_sym_is_not_null(self_or_null)) {
+        if (sym_is_null(self_or_null) || sym_is_not_null(self_or_null)) {
             localsplus_start = args;
             n_locals_already_filled = argcount;
         }
         OUT_OF_SPACE_IF_NULL(new_frame =
-                             _Py_uop_ctx_frame_new(ctx, co, localsplus_start, n_locals_already_filled, 0));
+                             frame_new(ctx, co, localsplus_start, n_locals_already_filled, 0));
     }
 
     op(_POP_FRAME, (retval -- res)) {
         SYNC_SP();
         ctx->frame->stack_pointer = stack_pointer;
-        _Py_uop_ctx_frame_pop(ctx);
+        frame_pop(ctx);
         stack_pointer = ctx->frame->stack_pointer;
         res = retval;
     }
@@ -383,7 +400,7 @@ dummy_func(void) {
         /* This has to be done manually */
         (void)seq;
         for (int i = 0; i < oparg; i++) {
-            OUT_OF_SPACE_IF_NULL(values[i] = _Py_uop_sym_new_unknown(ctx));
+            OUT_OF_SPACE_IF_NULL(values[i] = sym_new_unknown(ctx));
         }
     }
 
@@ -392,12 +409,12 @@ dummy_func(void) {
         (void)seq;
         int totalargs = (oparg & 0xFF) + (oparg >> 8) + 1;
         for (int i = 0; i < totalargs; i++) {
-            OUT_OF_SPACE_IF_NULL(values[i] = _Py_uop_sym_new_unknown(ctx));
+            OUT_OF_SPACE_IF_NULL(values[i] = sym_new_unknown(ctx));
         }
     }
 
     op(_ITER_NEXT_RANGE, (iter -- iter, next)) {
-       OUT_OF_SPACE_IF_NULL(next = _Py_uop_sym_new_type(ctx, &PyLong_Type));
+       OUT_OF_SPACE_IF_NULL(next = sym_new_type(ctx, &PyLong_Type));
        (void)iter;
     }
 

--- a/Python/optimizer_bytecodes.c
+++ b/Python/optimizer_bytecodes.c
@@ -5,8 +5,8 @@
 
 #define op(name, ...) /* NAME is ignored */
 
-typedef struct _Py_UOpsSymType _Py_UOpsSymType;
-typedef struct _Py_UOpsAbstractInterpContext _Py_UOpsAbstractInterpContext;
+typedef struct _Py_UopsSymbol _Py_UopsSymbol;
+typedef struct _Py_UOpsContext _Py_UOpsContext;
 typedef struct _Py_UOpsAbstractFrame _Py_UOpsAbstractFrame;
 
 static int
@@ -14,16 +14,16 @@ dummy_func(void) {
 
     PyCodeObject *code;
     int oparg;
-    _Py_UOpsSymType *flag;
-    _Py_UOpsSymType *left;
-    _Py_UOpsSymType *right;
-    _Py_UOpsSymType *value;
-    _Py_UOpsSymType *res;
-    _Py_UOpsSymType *iter;
-    _Py_UOpsSymType *top;
-    _Py_UOpsSymType *bottom;
+    _Py_UopsSymbol *flag;
+    _Py_UopsSymbol *left;
+    _Py_UopsSymbol *right;
+    _Py_UopsSymbol *value;
+    _Py_UopsSymbol *res;
+    _Py_UopsSymbol *iter;
+    _Py_UopsSymbol *top;
+    _Py_UopsSymbol *bottom;
     _Py_UOpsAbstractFrame *frame;
-    _Py_UOpsAbstractInterpContext *ctx;
+    _Py_UOpsContext *ctx;
     _PyUOpInstruction *this_instr;
     _PyBloomFilter *dependencies;
     int modified;
@@ -44,7 +44,7 @@ dummy_func(void) {
 
     op(_LOAD_FAST_AND_CLEAR, (-- value)) {
         value = GETLOCAL(oparg);
-        _Py_UOpsSymType *temp;
+        _Py_UopsSymbol *temp;
         OUT_OF_SPACE_IF_NULL(temp = _Py_uop_sym_new_null(ctx));
         GETLOCAL(oparg) = temp;
     }
@@ -350,7 +350,7 @@ dummy_func(void) {
             argcount++;
         }
 
-        _Py_UOpsSymType **localsplus_start = ctx->n_consumed;
+        _Py_UopsSymbol **localsplus_start = ctx->n_consumed;
         int n_locals_already_filled = 0;
         // Can determine statically, so we interleave the new locals
         // and make the current stack the new locals.

--- a/Python/optimizer_cases.c.h
+++ b/Python/optimizer_cases.c.h
@@ -14,7 +14,7 @@
         /* _INSTRUMENTED_RESUME is not a viable micro-op for tier 2 */
 
         case _LOAD_FAST_CHECK: {
-            _Py_UOpsSymType *value;
+            _Py_UopsSymbol *value;
             value = GETLOCAL(oparg);
             // We guarantee this will error - just bail and don't optimize it.
             if (_Py_uop_sym_is_null(value)) {
@@ -26,7 +26,7 @@
         }
 
         case _LOAD_FAST: {
-            _Py_UOpsSymType *value;
+            _Py_UopsSymbol *value;
             value = GETLOCAL(oparg);
             stack_pointer[0] = value;
             stack_pointer += 1;
@@ -34,9 +34,9 @@
         }
 
         case _LOAD_FAST_AND_CLEAR: {
-            _Py_UOpsSymType *value;
+            _Py_UopsSymbol *value;
             value = GETLOCAL(oparg);
-            _Py_UOpsSymType *temp;
+            _Py_UopsSymbol *temp;
             OUT_OF_SPACE_IF_NULL(temp = _Py_uop_sym_new_null(ctx));
             GETLOCAL(oparg) = temp;
             stack_pointer[0] = value;
@@ -45,7 +45,7 @@
         }
 
         case _LOAD_CONST: {
-            _Py_UOpsSymType *value;
+            _Py_UopsSymbol *value;
             // There should be no LOAD_CONST. It should be all
             // replaced by peephole_opt.
             Py_UNREACHABLE();
@@ -55,7 +55,7 @@
         }
 
         case _STORE_FAST: {
-            _Py_UOpsSymType *value;
+            _Py_UopsSymbol *value;
             value = stack_pointer[-1];
             GETLOCAL(oparg) = value;
             stack_pointer += -1;
@@ -68,7 +68,7 @@
         }
 
         case _PUSH_NULL: {
-            _Py_UOpsSymType *res;
+            _Py_UopsSymbol *res;
             res = _Py_uop_sym_new_null(ctx);
             if (res == NULL) {
                 goto out_of_space;
@@ -79,7 +79,7 @@
         }
 
         case _END_SEND: {
-            _Py_UOpsSymType *value;
+            _Py_UopsSymbol *value;
             value = _Py_uop_sym_new_unknown(ctx);
             if (value == NULL) goto out_of_space;
             stack_pointer[-2] = value;
@@ -88,7 +88,7 @@
         }
 
         case _UNARY_NEGATIVE: {
-            _Py_UOpsSymType *res;
+            _Py_UopsSymbol *res;
             res = _Py_uop_sym_new_unknown(ctx);
             if (res == NULL) goto out_of_space;
             stack_pointer[-1] = res;
@@ -96,7 +96,7 @@
         }
 
         case _UNARY_NOT: {
-            _Py_UOpsSymType *res;
+            _Py_UopsSymbol *res;
             res = _Py_uop_sym_new_unknown(ctx);
             if (res == NULL) goto out_of_space;
             stack_pointer[-1] = res;
@@ -104,7 +104,7 @@
         }
 
         case _TO_BOOL: {
-            _Py_UOpsSymType *res;
+            _Py_UopsSymbol *res;
             res = _Py_uop_sym_new_unknown(ctx);
             if (res == NULL) goto out_of_space;
             stack_pointer[-1] = res;
@@ -116,7 +116,7 @@
         }
 
         case _TO_BOOL_INT: {
-            _Py_UOpsSymType *res;
+            _Py_UopsSymbol *res;
             res = _Py_uop_sym_new_unknown(ctx);
             if (res == NULL) goto out_of_space;
             stack_pointer[-1] = res;
@@ -124,7 +124,7 @@
         }
 
         case _TO_BOOL_LIST: {
-            _Py_UOpsSymType *res;
+            _Py_UopsSymbol *res;
             res = _Py_uop_sym_new_unknown(ctx);
             if (res == NULL) goto out_of_space;
             stack_pointer[-1] = res;
@@ -132,7 +132,7 @@
         }
 
         case _TO_BOOL_NONE: {
-            _Py_UOpsSymType *res;
+            _Py_UopsSymbol *res;
             res = _Py_uop_sym_new_unknown(ctx);
             if (res == NULL) goto out_of_space;
             stack_pointer[-1] = res;
@@ -140,7 +140,7 @@
         }
 
         case _TO_BOOL_STR: {
-            _Py_UOpsSymType *res;
+            _Py_UopsSymbol *res;
             res = _Py_uop_sym_new_unknown(ctx);
             if (res == NULL) goto out_of_space;
             stack_pointer[-1] = res;
@@ -148,7 +148,7 @@
         }
 
         case _TO_BOOL_ALWAYS_TRUE: {
-            _Py_UOpsSymType *res;
+            _Py_UopsSymbol *res;
             res = _Py_uop_sym_new_unknown(ctx);
             if (res == NULL) goto out_of_space;
             stack_pointer[-1] = res;
@@ -156,7 +156,7 @@
         }
 
         case _UNARY_INVERT: {
-            _Py_UOpsSymType *res;
+            _Py_UopsSymbol *res;
             res = _Py_uop_sym_new_unknown(ctx);
             if (res == NULL) goto out_of_space;
             stack_pointer[-1] = res;
@@ -164,8 +164,8 @@
         }
 
         case _GUARD_BOTH_INT: {
-            _Py_UOpsSymType *right;
-            _Py_UOpsSymType *left;
+            _Py_UopsSymbol *right;
+            _Py_UopsSymbol *left;
             right = stack_pointer[-1];
             left = stack_pointer[-2];
             if (_Py_uop_sym_matches_type(left, &PyLong_Type) &&
@@ -178,9 +178,9 @@
         }
 
         case _BINARY_OP_MULTIPLY_INT: {
-            _Py_UOpsSymType *right;
-            _Py_UOpsSymType *left;
-            _Py_UOpsSymType *res;
+            _Py_UopsSymbol *right;
+            _Py_UopsSymbol *left;
+            _Py_UopsSymbol *res;
             right = stack_pointer[-1];
             left = stack_pointer[-2];
             if (_Py_uop_sym_is_const(left) && _Py_uop_sym_is_const(right)) {
@@ -204,9 +204,9 @@
         }
 
         case _BINARY_OP_ADD_INT: {
-            _Py_UOpsSymType *right;
-            _Py_UOpsSymType *left;
-            _Py_UOpsSymType *res;
+            _Py_UopsSymbol *right;
+            _Py_UopsSymbol *left;
+            _Py_UopsSymbol *res;
             right = stack_pointer[-1];
             left = stack_pointer[-2];
             if (_Py_uop_sym_is_const(left) && _Py_uop_sym_is_const(right)) {
@@ -230,9 +230,9 @@
         }
 
         case _BINARY_OP_SUBTRACT_INT: {
-            _Py_UOpsSymType *right;
-            _Py_UOpsSymType *left;
-            _Py_UOpsSymType *res;
+            _Py_UopsSymbol *right;
+            _Py_UopsSymbol *left;
+            _Py_UopsSymbol *res;
             right = stack_pointer[-1];
             left = stack_pointer[-2];
             if (_Py_uop_sym_is_const(left) && _Py_uop_sym_is_const(right)) {
@@ -256,8 +256,8 @@
         }
 
         case _GUARD_BOTH_FLOAT: {
-            _Py_UOpsSymType *right;
-            _Py_UOpsSymType *left;
+            _Py_UopsSymbol *right;
+            _Py_UopsSymbol *left;
             right = stack_pointer[-1];
             left = stack_pointer[-2];
             if (_Py_uop_sym_matches_type(left, &PyFloat_Type) &&
@@ -270,9 +270,9 @@
         }
 
         case _BINARY_OP_MULTIPLY_FLOAT: {
-            _Py_UOpsSymType *right;
-            _Py_UOpsSymType *left;
-            _Py_UOpsSymType *res;
+            _Py_UopsSymbol *right;
+            _Py_UopsSymbol *left;
+            _Py_UopsSymbol *res;
             right = stack_pointer[-1];
             left = stack_pointer[-2];
             if (_Py_uop_sym_is_const(left) && _Py_uop_sym_is_const(right)) {
@@ -297,9 +297,9 @@
         }
 
         case _BINARY_OP_ADD_FLOAT: {
-            _Py_UOpsSymType *right;
-            _Py_UOpsSymType *left;
-            _Py_UOpsSymType *res;
+            _Py_UopsSymbol *right;
+            _Py_UopsSymbol *left;
+            _Py_UopsSymbol *res;
             right = stack_pointer[-1];
             left = stack_pointer[-2];
             if (_Py_uop_sym_is_const(left) && _Py_uop_sym_is_const(right)) {
@@ -324,9 +324,9 @@
         }
 
         case _BINARY_OP_SUBTRACT_FLOAT: {
-            _Py_UOpsSymType *right;
-            _Py_UOpsSymType *left;
-            _Py_UOpsSymType *res;
+            _Py_UopsSymbol *right;
+            _Py_UopsSymbol *left;
+            _Py_UopsSymbol *res;
             right = stack_pointer[-1];
             left = stack_pointer[-2];
             if (_Py_uop_sym_is_const(left) && _Py_uop_sym_is_const(right)) {
@@ -351,8 +351,8 @@
         }
 
         case _GUARD_BOTH_UNICODE: {
-            _Py_UOpsSymType *right;
-            _Py_UOpsSymType *left;
+            _Py_UopsSymbol *right;
+            _Py_UopsSymbol *left;
             right = stack_pointer[-1];
             left = stack_pointer[-2];
             if (_Py_uop_sym_matches_type(left, &PyUnicode_Type) &&
@@ -365,7 +365,7 @@
         }
 
         case _BINARY_OP_ADD_UNICODE: {
-            _Py_UOpsSymType *res;
+            _Py_UopsSymbol *res;
             res = _Py_uop_sym_new_unknown(ctx);
             if (res == NULL) goto out_of_space;
             stack_pointer[-2] = res;
@@ -374,7 +374,7 @@
         }
 
         case _BINARY_SUBSCR: {
-            _Py_UOpsSymType *res;
+            _Py_UopsSymbol *res;
             res = _Py_uop_sym_new_unknown(ctx);
             if (res == NULL) goto out_of_space;
             stack_pointer[-2] = res;
@@ -383,7 +383,7 @@
         }
 
         case _BINARY_SLICE: {
-            _Py_UOpsSymType *res;
+            _Py_UopsSymbol *res;
             res = _Py_uop_sym_new_unknown(ctx);
             if (res == NULL) goto out_of_space;
             stack_pointer[-3] = res;
@@ -397,7 +397,7 @@
         }
 
         case _BINARY_SUBSCR_LIST_INT: {
-            _Py_UOpsSymType *res;
+            _Py_UopsSymbol *res;
             res = _Py_uop_sym_new_unknown(ctx);
             if (res == NULL) goto out_of_space;
             stack_pointer[-2] = res;
@@ -406,7 +406,7 @@
         }
 
         case _BINARY_SUBSCR_STR_INT: {
-            _Py_UOpsSymType *res;
+            _Py_UopsSymbol *res;
             res = _Py_uop_sym_new_unknown(ctx);
             if (res == NULL) goto out_of_space;
             stack_pointer[-2] = res;
@@ -415,7 +415,7 @@
         }
 
         case _BINARY_SUBSCR_TUPLE_INT: {
-            _Py_UOpsSymType *res;
+            _Py_UopsSymbol *res;
             res = _Py_uop_sym_new_unknown(ctx);
             if (res == NULL) goto out_of_space;
             stack_pointer[-2] = res;
@@ -424,7 +424,7 @@
         }
 
         case _BINARY_SUBSCR_DICT: {
-            _Py_UOpsSymType *res;
+            _Py_UopsSymbol *res;
             res = _Py_uop_sym_new_unknown(ctx);
             if (res == NULL) goto out_of_space;
             stack_pointer[-2] = res;
@@ -465,7 +465,7 @@
         }
 
         case _CALL_INTRINSIC_1: {
-            _Py_UOpsSymType *res;
+            _Py_UopsSymbol *res;
             res = _Py_uop_sym_new_unknown(ctx);
             if (res == NULL) goto out_of_space;
             stack_pointer[-1] = res;
@@ -473,7 +473,7 @@
         }
 
         case _CALL_INTRINSIC_2: {
-            _Py_UOpsSymType *res;
+            _Py_UopsSymbol *res;
             res = _Py_uop_sym_new_unknown(ctx);
             if (res == NULL) goto out_of_space;
             stack_pointer[-2] = res;
@@ -482,8 +482,8 @@
         }
 
         case _POP_FRAME: {
-            _Py_UOpsSymType *retval;
-            _Py_UOpsSymType *res;
+            _Py_UopsSymbol *retval;
+            _Py_UopsSymbol *res;
             retval = stack_pointer[-1];
             stack_pointer += -1;
             ctx->frame->stack_pointer = stack_pointer;
@@ -500,7 +500,7 @@
         /* _INSTRUMENTED_RETURN_CONST is not a viable micro-op for tier 2 */
 
         case _GET_AITER: {
-            _Py_UOpsSymType *iter;
+            _Py_UopsSymbol *iter;
             iter = _Py_uop_sym_new_unknown(ctx);
             if (iter == NULL) goto out_of_space;
             stack_pointer[-1] = iter;
@@ -508,7 +508,7 @@
         }
 
         case _GET_ANEXT: {
-            _Py_UOpsSymType *awaitable;
+            _Py_UopsSymbol *awaitable;
             awaitable = _Py_uop_sym_new_unknown(ctx);
             if (awaitable == NULL) goto out_of_space;
             stack_pointer[0] = awaitable;
@@ -517,7 +517,7 @@
         }
 
         case _GET_AWAITABLE: {
-            _Py_UOpsSymType *iter;
+            _Py_UopsSymbol *iter;
             iter = _Py_uop_sym_new_unknown(ctx);
             if (iter == NULL) goto out_of_space;
             stack_pointer[-1] = iter;
@@ -536,7 +536,7 @@
         }
 
         case _LOAD_ASSERTION_ERROR: {
-            _Py_UOpsSymType *value;
+            _Py_UopsSymbol *value;
             value = _Py_uop_sym_new_unknown(ctx);
             if (value == NULL) goto out_of_space;
             stack_pointer[0] = value;
@@ -545,7 +545,7 @@
         }
 
         case _LOAD_BUILD_CLASS: {
-            _Py_UOpsSymType *bc;
+            _Py_UopsSymbol *bc;
             bc = _Py_uop_sym_new_unknown(ctx);
             if (bc == NULL) goto out_of_space;
             stack_pointer[0] = bc;
@@ -563,8 +563,8 @@
         }
 
         case _UNPACK_SEQUENCE: {
-            _Py_UOpsSymType *seq;
-            _Py_UOpsSymType **values;
+            _Py_UopsSymbol *seq;
+            _Py_UopsSymbol **values;
             seq = stack_pointer[-1];
             values = &stack_pointer[-1];
             /* This has to be done manually */
@@ -577,7 +577,7 @@
         }
 
         case _UNPACK_SEQUENCE_TWO_TUPLE: {
-            _Py_UOpsSymType **values;
+            _Py_UopsSymbol **values;
             values = &stack_pointer[-1];
             for (int _i = oparg; --_i >= 0;) {
                 values[_i] = _Py_uop_sym_new_unknown(ctx);
@@ -588,7 +588,7 @@
         }
 
         case _UNPACK_SEQUENCE_TUPLE: {
-            _Py_UOpsSymType **values;
+            _Py_UopsSymbol **values;
             values = &stack_pointer[-1];
             for (int _i = oparg; --_i >= 0;) {
                 values[_i] = _Py_uop_sym_new_unknown(ctx);
@@ -599,7 +599,7 @@
         }
 
         case _UNPACK_SEQUENCE_LIST: {
-            _Py_UOpsSymType **values;
+            _Py_UopsSymbol **values;
             values = &stack_pointer[-1];
             for (int _i = oparg; --_i >= 0;) {
                 values[_i] = _Py_uop_sym_new_unknown(ctx);
@@ -610,8 +610,8 @@
         }
 
         case _UNPACK_EX: {
-            _Py_UOpsSymType *seq;
-            _Py_UOpsSymType **values;
+            _Py_UopsSymbol *seq;
+            _Py_UopsSymbol **values;
             seq = stack_pointer[-1];
             values = &stack_pointer[-1];
             /* This has to be done manually */
@@ -644,7 +644,7 @@
         }
 
         case _LOAD_LOCALS: {
-            _Py_UOpsSymType *locals;
+            _Py_UopsSymbol *locals;
             locals = _Py_uop_sym_new_unknown(ctx);
             if (locals == NULL) goto out_of_space;
             stack_pointer[0] = locals;
@@ -653,7 +653,7 @@
         }
 
         case _LOAD_FROM_DICT_OR_GLOBALS: {
-            _Py_UOpsSymType *v;
+            _Py_UopsSymbol *v;
             v = _Py_uop_sym_new_unknown(ctx);
             if (v == NULL) goto out_of_space;
             stack_pointer[-1] = v;
@@ -661,7 +661,7 @@
         }
 
         case _LOAD_NAME: {
-            _Py_UOpsSymType *v;
+            _Py_UopsSymbol *v;
             v = _Py_uop_sym_new_unknown(ctx);
             if (v == NULL) goto out_of_space;
             stack_pointer[0] = v;
@@ -670,8 +670,8 @@
         }
 
         case _LOAD_GLOBAL: {
-            _Py_UOpsSymType *res;
-            _Py_UOpsSymType *null = NULL;
+            _Py_UopsSymbol *res;
+            _Py_UopsSymbol *null = NULL;
             res = _Py_uop_sym_new_unknown(ctx);
             if (res == NULL) goto out_of_space;
             null = _Py_uop_sym_new_null(ctx);
@@ -691,8 +691,8 @@
         }
 
         case _LOAD_GLOBAL_MODULE: {
-            _Py_UOpsSymType *res;
-            _Py_UOpsSymType *null = NULL;
+            _Py_UopsSymbol *res;
+            _Py_UopsSymbol *null = NULL;
             res = _Py_uop_sym_new_unknown(ctx);
             if (res == NULL) goto out_of_space;
             null = _Py_uop_sym_new_null(ctx);
@@ -704,8 +704,8 @@
         }
 
         case _LOAD_GLOBAL_BUILTINS: {
-            _Py_UOpsSymType *res;
-            _Py_UOpsSymType *null = NULL;
+            _Py_UopsSymbol *res;
+            _Py_UopsSymbol *null = NULL;
             res = _Py_uop_sym_new_unknown(ctx);
             if (res == NULL) goto out_of_space;
             null = _Py_uop_sym_new_null(ctx);
@@ -729,7 +729,7 @@
         }
 
         case _LOAD_FROM_DICT_OR_DEREF: {
-            _Py_UOpsSymType *value;
+            _Py_UopsSymbol *value;
             value = _Py_uop_sym_new_unknown(ctx);
             if (value == NULL) goto out_of_space;
             stack_pointer[-1] = value;
@@ -737,7 +737,7 @@
         }
 
         case _LOAD_DEREF: {
-            _Py_UOpsSymType *value;
+            _Py_UopsSymbol *value;
             value = _Py_uop_sym_new_unknown(ctx);
             if (value == NULL) goto out_of_space;
             stack_pointer[0] = value;
@@ -755,7 +755,7 @@
         }
 
         case _BUILD_STRING: {
-            _Py_UOpsSymType *str;
+            _Py_UopsSymbol *str;
             str = _Py_uop_sym_new_unknown(ctx);
             if (str == NULL) goto out_of_space;
             stack_pointer[-oparg] = str;
@@ -764,7 +764,7 @@
         }
 
         case _BUILD_TUPLE: {
-            _Py_UOpsSymType *tup;
+            _Py_UopsSymbol *tup;
             tup = _Py_uop_sym_new_unknown(ctx);
             if (tup == NULL) goto out_of_space;
             stack_pointer[-oparg] = tup;
@@ -773,7 +773,7 @@
         }
 
         case _BUILD_LIST: {
-            _Py_UOpsSymType *list;
+            _Py_UopsSymbol *list;
             list = _Py_uop_sym_new_unknown(ctx);
             if (list == NULL) goto out_of_space;
             stack_pointer[-oparg] = list;
@@ -792,7 +792,7 @@
         }
 
         case _BUILD_SET: {
-            _Py_UOpsSymType *set;
+            _Py_UopsSymbol *set;
             set = _Py_uop_sym_new_unknown(ctx);
             if (set == NULL) goto out_of_space;
             stack_pointer[-oparg] = set;
@@ -801,7 +801,7 @@
         }
 
         case _BUILD_MAP: {
-            _Py_UOpsSymType *map;
+            _Py_UopsSymbol *map;
             map = _Py_uop_sym_new_unknown(ctx);
             if (map == NULL) goto out_of_space;
             stack_pointer[-oparg*2] = map;
@@ -814,7 +814,7 @@
         }
 
         case _BUILD_CONST_KEY_MAP: {
-            _Py_UOpsSymType *map;
+            _Py_UopsSymbol *map;
             map = _Py_uop_sym_new_unknown(ctx);
             if (map == NULL) goto out_of_space;
             stack_pointer[-1 - oparg] = map;
@@ -840,7 +840,7 @@
         /* _INSTRUMENTED_LOAD_SUPER_ATTR is not a viable micro-op for tier 2 */
 
         case _LOAD_SUPER_ATTR_ATTR: {
-            _Py_UOpsSymType *attr;
+            _Py_UopsSymbol *attr;
             attr = _Py_uop_sym_new_unknown(ctx);
             if (attr == NULL) goto out_of_space;
             stack_pointer[-3] = attr;
@@ -849,8 +849,8 @@
         }
 
         case _LOAD_SUPER_ATTR_METHOD: {
-            _Py_UOpsSymType *attr;
-            _Py_UOpsSymType *self_or_null;
+            _Py_UopsSymbol *attr;
+            _Py_UopsSymbol *self_or_null;
             attr = _Py_uop_sym_new_unknown(ctx);
             if (attr == NULL) goto out_of_space;
             self_or_null = _Py_uop_sym_new_unknown(ctx);
@@ -862,8 +862,8 @@
         }
 
         case _LOAD_ATTR: {
-            _Py_UOpsSymType *attr;
-            _Py_UOpsSymType *self_or_null = NULL;
+            _Py_UopsSymbol *attr;
+            _Py_UopsSymbol *self_or_null = NULL;
             attr = _Py_uop_sym_new_unknown(ctx);
             if (attr == NULL) goto out_of_space;
             self_or_null = _Py_uop_sym_new_unknown(ctx);
@@ -883,9 +883,9 @@
         }
 
         case _LOAD_ATTR_INSTANCE_VALUE: {
-            _Py_UOpsSymType *owner;
-            _Py_UOpsSymType *attr;
-            _Py_UOpsSymType *null = NULL;
+            _Py_UopsSymbol *owner;
+            _Py_UopsSymbol *attr;
+            _Py_UopsSymbol *null = NULL;
             owner = stack_pointer[-1];
             uint16_t index = (uint16_t)this_instr->operand;
             _LOAD_ATTR_NOT_NULL
@@ -898,7 +898,7 @@
         }
 
         case _CHECK_ATTR_MODULE: {
-            _Py_UOpsSymType *owner;
+            _Py_UopsSymbol *owner;
             owner = stack_pointer[-1];
             uint32_t dict_version = (uint32_t)this_instr->operand;
             (void)dict_version;
@@ -919,9 +919,9 @@
         }
 
         case _LOAD_ATTR_MODULE: {
-            _Py_UOpsSymType *owner;
-            _Py_UOpsSymType *attr;
-            _Py_UOpsSymType *null = NULL;
+            _Py_UopsSymbol *owner;
+            _Py_UopsSymbol *attr;
+            _Py_UopsSymbol *null = NULL;
             owner = stack_pointer[-1];
             uint16_t index = (uint16_t)this_instr->operand;
             (void)index;
@@ -954,9 +954,9 @@
         }
 
         case _LOAD_ATTR_WITH_HINT: {
-            _Py_UOpsSymType *owner;
-            _Py_UOpsSymType *attr;
-            _Py_UOpsSymType *null = NULL;
+            _Py_UopsSymbol *owner;
+            _Py_UopsSymbol *attr;
+            _Py_UopsSymbol *null = NULL;
             owner = stack_pointer[-1];
             uint16_t hint = (uint16_t)this_instr->operand;
             _LOAD_ATTR_NOT_NULL
@@ -969,9 +969,9 @@
         }
 
         case _LOAD_ATTR_SLOT: {
-            _Py_UOpsSymType *owner;
-            _Py_UOpsSymType *attr;
-            _Py_UOpsSymType *null = NULL;
+            _Py_UopsSymbol *owner;
+            _Py_UopsSymbol *attr;
+            _Py_UopsSymbol *null = NULL;
             owner = stack_pointer[-1];
             uint16_t index = (uint16_t)this_instr->operand;
             _LOAD_ATTR_NOT_NULL
@@ -988,9 +988,9 @@
         }
 
         case _LOAD_ATTR_CLASS: {
-            _Py_UOpsSymType *owner;
-            _Py_UOpsSymType *attr;
-            _Py_UOpsSymType *null = NULL;
+            _Py_UopsSymbol *owner;
+            _Py_UopsSymbol *attr;
+            _Py_UopsSymbol *null = NULL;
             owner = stack_pointer[-1];
             PyObject *descr = (PyObject *)this_instr->operand;
             _LOAD_ATTR_NOT_NULL
@@ -1023,7 +1023,7 @@
         }
 
         case _COMPARE_OP: {
-            _Py_UOpsSymType *res;
+            _Py_UopsSymbol *res;
             res = _Py_uop_sym_new_unknown(ctx);
             if (res == NULL) goto out_of_space;
             stack_pointer[-2] = res;
@@ -1032,7 +1032,7 @@
         }
 
         case _COMPARE_OP_FLOAT: {
-            _Py_UOpsSymType *res;
+            _Py_UopsSymbol *res;
             res = _Py_uop_sym_new_unknown(ctx);
             if (res == NULL) goto out_of_space;
             stack_pointer[-2] = res;
@@ -1041,7 +1041,7 @@
         }
 
         case _COMPARE_OP_INT: {
-            _Py_UOpsSymType *res;
+            _Py_UopsSymbol *res;
             res = _Py_uop_sym_new_unknown(ctx);
             if (res == NULL) goto out_of_space;
             stack_pointer[-2] = res;
@@ -1050,7 +1050,7 @@
         }
 
         case _COMPARE_OP_STR: {
-            _Py_UOpsSymType *res;
+            _Py_UopsSymbol *res;
             res = _Py_uop_sym_new_unknown(ctx);
             if (res == NULL) goto out_of_space;
             stack_pointer[-2] = res;
@@ -1059,7 +1059,7 @@
         }
 
         case _IS_OP: {
-            _Py_UOpsSymType *b;
+            _Py_UopsSymbol *b;
             b = _Py_uop_sym_new_unknown(ctx);
             if (b == NULL) goto out_of_space;
             stack_pointer[-2] = b;
@@ -1068,7 +1068,7 @@
         }
 
         case _CONTAINS_OP: {
-            _Py_UOpsSymType *b;
+            _Py_UopsSymbol *b;
             b = _Py_uop_sym_new_unknown(ctx);
             if (b == NULL) goto out_of_space;
             stack_pointer[-2] = b;
@@ -1077,8 +1077,8 @@
         }
 
         case _CHECK_EG_MATCH: {
-            _Py_UOpsSymType *rest;
-            _Py_UOpsSymType *match;
+            _Py_UopsSymbol *rest;
+            _Py_UopsSymbol *match;
             rest = _Py_uop_sym_new_unknown(ctx);
             if (rest == NULL) goto out_of_space;
             match = _Py_uop_sym_new_unknown(ctx);
@@ -1089,7 +1089,7 @@
         }
 
         case _CHECK_EXC_MATCH: {
-            _Py_UOpsSymType *b;
+            _Py_UopsSymbol *b;
             b = _Py_uop_sym_new_unknown(ctx);
             if (b == NULL) goto out_of_space;
             stack_pointer[-1] = b;
@@ -1101,7 +1101,7 @@
         /* _POP_JUMP_IF_TRUE is not a viable micro-op for tier 2 */
 
         case _IS_NONE: {
-            _Py_UOpsSymType *b;
+            _Py_UopsSymbol *b;
             b = _Py_uop_sym_new_unknown(ctx);
             if (b == NULL) goto out_of_space;
             stack_pointer[-1] = b;
@@ -1109,7 +1109,7 @@
         }
 
         case _GET_LEN: {
-            _Py_UOpsSymType *len_o;
+            _Py_UopsSymbol *len_o;
             len_o = _Py_uop_sym_new_unknown(ctx);
             if (len_o == NULL) goto out_of_space;
             stack_pointer[0] = len_o;
@@ -1118,7 +1118,7 @@
         }
 
         case _MATCH_CLASS: {
-            _Py_UOpsSymType *attrs;
+            _Py_UopsSymbol *attrs;
             attrs = _Py_uop_sym_new_unknown(ctx);
             if (attrs == NULL) goto out_of_space;
             stack_pointer[-3] = attrs;
@@ -1127,7 +1127,7 @@
         }
 
         case _MATCH_MAPPING: {
-            _Py_UOpsSymType *res;
+            _Py_UopsSymbol *res;
             res = _Py_uop_sym_new_unknown(ctx);
             if (res == NULL) goto out_of_space;
             stack_pointer[0] = res;
@@ -1136,7 +1136,7 @@
         }
 
         case _MATCH_SEQUENCE: {
-            _Py_UOpsSymType *res;
+            _Py_UopsSymbol *res;
             res = _Py_uop_sym_new_unknown(ctx);
             if (res == NULL) goto out_of_space;
             stack_pointer[0] = res;
@@ -1145,7 +1145,7 @@
         }
 
         case _MATCH_KEYS: {
-            _Py_UOpsSymType *values_or_none;
+            _Py_UopsSymbol *values_or_none;
             values_or_none = _Py_uop_sym_new_unknown(ctx);
             if (values_or_none == NULL) goto out_of_space;
             stack_pointer[0] = values_or_none;
@@ -1154,7 +1154,7 @@
         }
 
         case _GET_ITER: {
-            _Py_UOpsSymType *iter;
+            _Py_UopsSymbol *iter;
             iter = _Py_uop_sym_new_unknown(ctx);
             if (iter == NULL) goto out_of_space;
             stack_pointer[-1] = iter;
@@ -1162,7 +1162,7 @@
         }
 
         case _GET_YIELD_FROM_ITER: {
-            _Py_UOpsSymType *iter;
+            _Py_UopsSymbol *iter;
             iter = _Py_uop_sym_new_unknown(ctx);
             if (iter == NULL) goto out_of_space;
             stack_pointer[-1] = iter;
@@ -1172,7 +1172,7 @@
         /* _FOR_ITER is not a viable micro-op for tier 2 */
 
         case _FOR_ITER_TIER_TWO: {
-            _Py_UOpsSymType *next;
+            _Py_UopsSymbol *next;
             next = _Py_uop_sym_new_unknown(ctx);
             if (next == NULL) goto out_of_space;
             stack_pointer[0] = next;
@@ -1193,7 +1193,7 @@
         }
 
         case _ITER_NEXT_LIST: {
-            _Py_UOpsSymType *next;
+            _Py_UopsSymbol *next;
             next = _Py_uop_sym_new_unknown(ctx);
             if (next == NULL) goto out_of_space;
             stack_pointer[0] = next;
@@ -1212,7 +1212,7 @@
         }
 
         case _ITER_NEXT_TUPLE: {
-            _Py_UOpsSymType *next;
+            _Py_UopsSymbol *next;
             next = _Py_uop_sym_new_unknown(ctx);
             if (next == NULL) goto out_of_space;
             stack_pointer[0] = next;
@@ -1231,8 +1231,8 @@
         }
 
         case _ITER_NEXT_RANGE: {
-            _Py_UOpsSymType *iter;
-            _Py_UOpsSymType *next;
+            _Py_UopsSymbol *iter;
+            _Py_UopsSymbol *next;
             iter = stack_pointer[-1];
             OUT_OF_SPACE_IF_NULL(next = _Py_uop_sym_new_type(ctx, &PyLong_Type));
             (void)iter;
@@ -1244,8 +1244,8 @@
         /* _FOR_ITER_GEN is not a viable micro-op for tier 2 */
 
         case _BEFORE_ASYNC_WITH: {
-            _Py_UOpsSymType *exit;
-            _Py_UOpsSymType *res;
+            _Py_UopsSymbol *exit;
+            _Py_UopsSymbol *res;
             exit = _Py_uop_sym_new_unknown(ctx);
             if (exit == NULL) goto out_of_space;
             res = _Py_uop_sym_new_unknown(ctx);
@@ -1257,8 +1257,8 @@
         }
 
         case _BEFORE_WITH: {
-            _Py_UOpsSymType *exit;
-            _Py_UOpsSymType *res;
+            _Py_UopsSymbol *exit;
+            _Py_UopsSymbol *res;
             exit = _Py_uop_sym_new_unknown(ctx);
             if (exit == NULL) goto out_of_space;
             res = _Py_uop_sym_new_unknown(ctx);
@@ -1270,7 +1270,7 @@
         }
 
         case _WITH_EXCEPT_START: {
-            _Py_UOpsSymType *res;
+            _Py_UopsSymbol *res;
             res = _Py_uop_sym_new_unknown(ctx);
             if (res == NULL) goto out_of_space;
             stack_pointer[0] = res;
@@ -1279,8 +1279,8 @@
         }
 
         case _PUSH_EXC_INFO: {
-            _Py_UOpsSymType *prev_exc;
-            _Py_UOpsSymType *new_exc;
+            _Py_UopsSymbol *prev_exc;
+            _Py_UopsSymbol *new_exc;
             prev_exc = _Py_uop_sym_new_unknown(ctx);
             if (prev_exc == NULL) goto out_of_space;
             new_exc = _Py_uop_sym_new_unknown(ctx);
@@ -1300,9 +1300,9 @@
         }
 
         case _LOAD_ATTR_METHOD_WITH_VALUES: {
-            _Py_UOpsSymType *owner;
-            _Py_UOpsSymType *attr;
-            _Py_UOpsSymType *self = NULL;
+            _Py_UopsSymbol *owner;
+            _Py_UopsSymbol *attr;
+            _Py_UopsSymbol *self = NULL;
             owner = stack_pointer[-1];
             PyObject *descr = (PyObject *)this_instr->operand;
             (void)descr;
@@ -1315,9 +1315,9 @@
         }
 
         case _LOAD_ATTR_METHOD_NO_DICT: {
-            _Py_UOpsSymType *owner;
-            _Py_UOpsSymType *attr;
-            _Py_UOpsSymType *self = NULL;
+            _Py_UopsSymbol *owner;
+            _Py_UopsSymbol *attr;
+            _Py_UopsSymbol *self = NULL;
             owner = stack_pointer[-1];
             PyObject *descr = (PyObject *)this_instr->operand;
             (void)descr;
@@ -1330,7 +1330,7 @@
         }
 
         case _LOAD_ATTR_NONDESCRIPTOR_WITH_VALUES: {
-            _Py_UOpsSymType *attr;
+            _Py_UopsSymbol *attr;
             attr = _Py_uop_sym_new_unknown(ctx);
             if (attr == NULL) goto out_of_space;
             stack_pointer[-1] = attr;
@@ -1338,7 +1338,7 @@
         }
 
         case _LOAD_ATTR_NONDESCRIPTOR_NO_DICT: {
-            _Py_UOpsSymType *attr;
+            _Py_UopsSymbol *attr;
             attr = _Py_uop_sym_new_unknown(ctx);
             if (attr == NULL) goto out_of_space;
             stack_pointer[-1] = attr;
@@ -1350,9 +1350,9 @@
         }
 
         case _LOAD_ATTR_METHOD_LAZY_DICT: {
-            _Py_UOpsSymType *owner;
-            _Py_UOpsSymType *attr;
-            _Py_UOpsSymType *self = NULL;
+            _Py_UopsSymbol *owner;
+            _Py_UopsSymbol *attr;
+            _Py_UopsSymbol *self = NULL;
             owner = stack_pointer[-1];
             PyObject *descr = (PyObject *)this_instr->operand;
             (void)descr;
@@ -1369,8 +1369,8 @@
         /* _CALL is not a viable micro-op for tier 2 */
 
         case _CHECK_CALL_BOUND_METHOD_EXACT_ARGS: {
-            _Py_UOpsSymType *null;
-            _Py_UOpsSymType *callable;
+            _Py_UopsSymbol *null;
+            _Py_UopsSymbol *callable;
             null = stack_pointer[-1 - oparg];
             callable = stack_pointer[-2 - oparg];
             _Py_uop_sym_set_null(null);
@@ -1379,9 +1379,9 @@
         }
 
         case _INIT_CALL_BOUND_METHOD_EXACT_ARGS: {
-            _Py_UOpsSymType *callable;
-            _Py_UOpsSymType *func;
-            _Py_UOpsSymType *self;
+            _Py_UopsSymbol *callable;
+            _Py_UopsSymbol *func;
+            _Py_UopsSymbol *self;
             callable = stack_pointer[-2 - oparg];
             (void)callable;
             OUT_OF_SPACE_IF_NULL(func = _Py_uop_sym_new_not_null(ctx));
@@ -1396,8 +1396,8 @@
         }
 
         case _CHECK_FUNCTION_EXACT_ARGS: {
-            _Py_UOpsSymType *self_or_null;
-            _Py_UOpsSymType *callable;
+            _Py_UopsSymbol *self_or_null;
+            _Py_UopsSymbol *callable;
             self_or_null = stack_pointer[-1 - oparg];
             callable = stack_pointer[-2 - oparg];
             uint32_t func_version = (uint32_t)this_instr->operand;
@@ -1412,9 +1412,9 @@
         }
 
         case _INIT_CALL_PY_EXACT_ARGS: {
-            _Py_UOpsSymType **args;
-            _Py_UOpsSymType *self_or_null;
-            _Py_UOpsSymType *callable;
+            _Py_UopsSymbol **args;
+            _Py_UopsSymbol *self_or_null;
+            _Py_UopsSymbol *callable;
             _Py_UOpsAbstractFrame *new_frame;
             args = &stack_pointer[-oparg];
             self_or_null = stack_pointer[-1 - oparg];
@@ -1433,7 +1433,7 @@
                 args--;
                 argcount++;
             }
-            _Py_UOpsSymType **localsplus_start = ctx->n_consumed;
+            _Py_UopsSymbol **localsplus_start = ctx->n_consumed;
             int n_locals_already_filled = 0;
             // Can determine statically, so we interleave the new locals
             // and make the current stack the new locals.
@@ -1444,7 +1444,7 @@
             }
             OUT_OF_SPACE_IF_NULL(new_frame =
                              _Py_uop_ctx_frame_new(ctx, co, localsplus_start, n_locals_already_filled, 0));
-            stack_pointer[-2 - oparg] = (_Py_UOpsSymType *)new_frame;
+            stack_pointer[-2 - oparg] = (_Py_UopsSymbol *)new_frame;
             stack_pointer += -1 - oparg;
             break;
         }
@@ -1463,7 +1463,7 @@
         /* _CALL_PY_WITH_DEFAULTS is not a viable micro-op for tier 2 */
 
         case _CALL_TYPE_1: {
-            _Py_UOpsSymType *res;
+            _Py_UopsSymbol *res;
             res = _Py_uop_sym_new_unknown(ctx);
             if (res == NULL) goto out_of_space;
             stack_pointer[-2 - oparg] = res;
@@ -1472,7 +1472,7 @@
         }
 
         case _CALL_STR_1: {
-            _Py_UOpsSymType *res;
+            _Py_UopsSymbol *res;
             res = _Py_uop_sym_new_unknown(ctx);
             if (res == NULL) goto out_of_space;
             stack_pointer[-2 - oparg] = res;
@@ -1481,7 +1481,7 @@
         }
 
         case _CALL_TUPLE_1: {
-            _Py_UOpsSymType *res;
+            _Py_UopsSymbol *res;
             res = _Py_uop_sym_new_unknown(ctx);
             if (res == NULL) goto out_of_space;
             stack_pointer[-2 - oparg] = res;
@@ -1497,7 +1497,7 @@
         }
 
         case _CALL_BUILTIN_CLASS: {
-            _Py_UOpsSymType *res;
+            _Py_UopsSymbol *res;
             res = _Py_uop_sym_new_unknown(ctx);
             if (res == NULL) goto out_of_space;
             stack_pointer[-2 - oparg] = res;
@@ -1506,7 +1506,7 @@
         }
 
         case _CALL_BUILTIN_O: {
-            _Py_UOpsSymType *res;
+            _Py_UopsSymbol *res;
             res = _Py_uop_sym_new_unknown(ctx);
             if (res == NULL) goto out_of_space;
             stack_pointer[-2 - oparg] = res;
@@ -1515,7 +1515,7 @@
         }
 
         case _CALL_BUILTIN_FAST: {
-            _Py_UOpsSymType *res;
+            _Py_UopsSymbol *res;
             res = _Py_uop_sym_new_unknown(ctx);
             if (res == NULL) goto out_of_space;
             stack_pointer[-2 - oparg] = res;
@@ -1524,7 +1524,7 @@
         }
 
         case _CALL_BUILTIN_FAST_WITH_KEYWORDS: {
-            _Py_UOpsSymType *res;
+            _Py_UopsSymbol *res;
             res = _Py_uop_sym_new_unknown(ctx);
             if (res == NULL) goto out_of_space;
             stack_pointer[-2 - oparg] = res;
@@ -1533,7 +1533,7 @@
         }
 
         case _CALL_LEN: {
-            _Py_UOpsSymType *res;
+            _Py_UopsSymbol *res;
             res = _Py_uop_sym_new_unknown(ctx);
             if (res == NULL) goto out_of_space;
             stack_pointer[-2 - oparg] = res;
@@ -1542,7 +1542,7 @@
         }
 
         case _CALL_ISINSTANCE: {
-            _Py_UOpsSymType *res;
+            _Py_UopsSymbol *res;
             res = _Py_uop_sym_new_unknown(ctx);
             if (res == NULL) goto out_of_space;
             stack_pointer[-2 - oparg] = res;
@@ -1551,7 +1551,7 @@
         }
 
         case _CALL_METHOD_DESCRIPTOR_O: {
-            _Py_UOpsSymType *res;
+            _Py_UopsSymbol *res;
             res = _Py_uop_sym_new_unknown(ctx);
             if (res == NULL) goto out_of_space;
             stack_pointer[-2 - oparg] = res;
@@ -1560,7 +1560,7 @@
         }
 
         case _CALL_METHOD_DESCRIPTOR_FAST_WITH_KEYWORDS: {
-            _Py_UOpsSymType *res;
+            _Py_UopsSymbol *res;
             res = _Py_uop_sym_new_unknown(ctx);
             if (res == NULL) goto out_of_space;
             stack_pointer[-2 - oparg] = res;
@@ -1569,7 +1569,7 @@
         }
 
         case _CALL_METHOD_DESCRIPTOR_NOARGS: {
-            _Py_UOpsSymType *res;
+            _Py_UopsSymbol *res;
             res = _Py_uop_sym_new_unknown(ctx);
             if (res == NULL) goto out_of_space;
             stack_pointer[-2 - oparg] = res;
@@ -1578,7 +1578,7 @@
         }
 
         case _CALL_METHOD_DESCRIPTOR_FAST: {
-            _Py_UOpsSymType *res;
+            _Py_UopsSymbol *res;
             res = _Py_uop_sym_new_unknown(ctx);
             if (res == NULL) goto out_of_space;
             stack_pointer[-2 - oparg] = res;
@@ -1595,7 +1595,7 @@
         /* _CALL_FUNCTION_EX is not a viable micro-op for tier 2 */
 
         case _MAKE_FUNCTION: {
-            _Py_UOpsSymType *func;
+            _Py_UopsSymbol *func;
             func = _Py_uop_sym_new_unknown(ctx);
             if (func == NULL) goto out_of_space;
             stack_pointer[-1] = func;
@@ -1603,7 +1603,7 @@
         }
 
         case _SET_FUNCTION_ATTRIBUTE: {
-            _Py_UOpsSymType *func;
+            _Py_UopsSymbol *func;
             func = _Py_uop_sym_new_unknown(ctx);
             if (func == NULL) goto out_of_space;
             stack_pointer[-2] = func;
@@ -1612,7 +1612,7 @@
         }
 
         case _BUILD_SLICE: {
-            _Py_UOpsSymType *slice;
+            _Py_UopsSymbol *slice;
             slice = _Py_uop_sym_new_unknown(ctx);
             if (slice == NULL) goto out_of_space;
             stack_pointer[-2 - ((oparg == 3) ? 1 : 0)] = slice;
@@ -1621,7 +1621,7 @@
         }
 
         case _CONVERT_VALUE: {
-            _Py_UOpsSymType *result;
+            _Py_UopsSymbol *result;
             result = _Py_uop_sym_new_unknown(ctx);
             if (result == NULL) goto out_of_space;
             stack_pointer[-1] = result;
@@ -1629,7 +1629,7 @@
         }
 
         case _FORMAT_SIMPLE: {
-            _Py_UOpsSymType *res;
+            _Py_UopsSymbol *res;
             res = _Py_uop_sym_new_unknown(ctx);
             if (res == NULL) goto out_of_space;
             stack_pointer[-1] = res;
@@ -1637,7 +1637,7 @@
         }
 
         case _FORMAT_WITH_SPEC: {
-            _Py_UOpsSymType *res;
+            _Py_UopsSymbol *res;
             res = _Py_uop_sym_new_unknown(ctx);
             if (res == NULL) goto out_of_space;
             stack_pointer[-2] = res;
@@ -1646,8 +1646,8 @@
         }
 
         case _COPY: {
-            _Py_UOpsSymType *bottom;
-            _Py_UOpsSymType *top;
+            _Py_UopsSymbol *bottom;
+            _Py_UopsSymbol *top;
             bottom = stack_pointer[-1 - (oparg-1)];
             assert(oparg > 0);
             top = bottom;
@@ -1657,7 +1657,7 @@
         }
 
         case _BINARY_OP: {
-            _Py_UOpsSymType *res;
+            _Py_UopsSymbol *res;
             res = _Py_uop_sym_new_unknown(ctx);
             if (res == NULL) goto out_of_space;
             stack_pointer[-2] = res;
@@ -1666,8 +1666,8 @@
         }
 
         case _SWAP: {
-            _Py_UOpsSymType *top;
-            _Py_UOpsSymType *bottom;
+            _Py_UopsSymbol *top;
+            _Py_UopsSymbol *bottom;
             top = stack_pointer[-1];
             bottom = stack_pointer[-2 - (oparg-2)];
             stack_pointer[-2 - (oparg-2)] = top;
@@ -1730,7 +1730,7 @@
         }
 
         case _LOAD_CONST_INLINE: {
-            _Py_UOpsSymType *value;
+            _Py_UopsSymbol *value;
             PyObject *ptr = (PyObject *)this_instr->operand;
             OUT_OF_SPACE_IF_NULL(value = _Py_uop_sym_new_const(ctx, ptr));
             stack_pointer[0] = value;
@@ -1739,7 +1739,7 @@
         }
 
         case _LOAD_CONST_INLINE_BORROW: {
-            _Py_UOpsSymType *value;
+            _Py_UopsSymbol *value;
             PyObject *ptr = (PyObject *)this_instr->operand;
             OUT_OF_SPACE_IF_NULL(value = _Py_uop_sym_new_const(ctx, ptr));
             stack_pointer[0] = value;
@@ -1748,8 +1748,8 @@
         }
 
         case _LOAD_CONST_INLINE_WITH_NULL: {
-            _Py_UOpsSymType *value;
-            _Py_UOpsSymType *null;
+            _Py_UopsSymbol *value;
+            _Py_UopsSymbol *null;
             PyObject *ptr = (PyObject *)this_instr->operand;
             OUT_OF_SPACE_IF_NULL(value = _Py_uop_sym_new_const(ctx, ptr));
             OUT_OF_SPACE_IF_NULL(null = _Py_uop_sym_new_null(ctx));
@@ -1760,8 +1760,8 @@
         }
 
         case _LOAD_CONST_INLINE_BORROW_WITH_NULL: {
-            _Py_UOpsSymType *value;
-            _Py_UOpsSymType *null;
+            _Py_UopsSymbol *value;
+            _Py_UopsSymbol *null;
             PyObject *ptr = (PyObject *)this_instr->operand;
             OUT_OF_SPACE_IF_NULL(value = _Py_uop_sym_new_const(ctx, ptr));
             OUT_OF_SPACE_IF_NULL(null = _Py_uop_sym_new_null(ctx));

--- a/Python/optimizer_cases.c.h
+++ b/Python/optimizer_cases.c.h
@@ -17,7 +17,7 @@
             _Py_UopsSymbol *value;
             value = GETLOCAL(oparg);
             // We guarantee this will error - just bail and don't optimize it.
-            if (_Py_uop_sym_is_null(value)) {
+            if (sym_is_null(value)) {
                 goto out_of_space;
             }
             stack_pointer[0] = value;
@@ -37,7 +37,7 @@
             _Py_UopsSymbol *value;
             value = GETLOCAL(oparg);
             _Py_UopsSymbol *temp;
-            OUT_OF_SPACE_IF_NULL(temp = _Py_uop_sym_new_null(ctx));
+            OUT_OF_SPACE_IF_NULL(temp = sym_new_null(ctx));
             GETLOCAL(oparg) = temp;
             stack_pointer[0] = value;
             stack_pointer += 1;
@@ -69,7 +69,7 @@
 
         case _PUSH_NULL: {
             _Py_UopsSymbol *res;
-            res = _Py_uop_sym_new_null(ctx);
+            res = sym_new_null(ctx);
             if (res == NULL) {
                 goto out_of_space;
             };
@@ -168,12 +168,12 @@
             _Py_UopsSymbol *left;
             right = stack_pointer[-1];
             left = stack_pointer[-2];
-            if (_Py_uop_sym_matches_type(left, &PyLong_Type) &&
-                _Py_uop_sym_matches_type(right, &PyLong_Type)) {
+            if (sym_matches_type(left, &PyLong_Type) &&
+                sym_matches_type(right, &PyLong_Type)) {
                 REPLACE_OP(this_instr, _NOP, 0, 0);
             }
-            _Py_uop_sym_set_type(left, &PyLong_Type);
-            _Py_uop_sym_set_type(right, &PyLong_Type);
+            sym_set_type(left, &PyLong_Type);
+            sym_set_type(right, &PyLong_Type);
             break;
         }
 
@@ -183,20 +183,20 @@
             _Py_UopsSymbol *res;
             right = stack_pointer[-1];
             left = stack_pointer[-2];
-            if (_Py_uop_sym_is_const(left) && _Py_uop_sym_is_const(right)) {
-                assert(PyLong_CheckExact(_Py_uop_sym_get_const(left)));
-                assert(PyLong_CheckExact(_Py_uop_sym_get_const(right)));
-                PyObject *temp = _PyLong_Multiply((PyLongObject *)_Py_uop_sym_get_const(left),
-                    (PyLongObject *)_Py_uop_sym_get_const(right));
+            if (sym_is_const(left) && sym_is_const(right)) {
+                assert(PyLong_CheckExact(sym_get_const(left)));
+                assert(PyLong_CheckExact(sym_get_const(right)));
+                PyObject *temp = _PyLong_Multiply((PyLongObject *)sym_get_const(left),
+                    (PyLongObject *)sym_get_const(right));
                 if (temp == NULL) {
                     goto error;
                 }
-                OUT_OF_SPACE_IF_NULL(res = _Py_uop_sym_new_const(ctx, temp));
+                OUT_OF_SPACE_IF_NULL(res = sym_new_const(ctx, temp));
                 // TODO gh-115506:
                 // replace opcode with constant propagated one and add tests!
             }
             else {
-                OUT_OF_SPACE_IF_NULL(res = _Py_uop_sym_new_type(ctx, &PyLong_Type));
+                OUT_OF_SPACE_IF_NULL(res = sym_new_type(ctx, &PyLong_Type));
             }
             stack_pointer[-2] = res;
             stack_pointer += -1;
@@ -209,20 +209,20 @@
             _Py_UopsSymbol *res;
             right = stack_pointer[-1];
             left = stack_pointer[-2];
-            if (_Py_uop_sym_is_const(left) && _Py_uop_sym_is_const(right)) {
-                assert(PyLong_CheckExact(_Py_uop_sym_get_const(left)));
-                assert(PyLong_CheckExact(_Py_uop_sym_get_const(right)));
-                PyObject *temp = _PyLong_Add((PyLongObject *)_Py_uop_sym_get_const(left),
-                    (PyLongObject *)_Py_uop_sym_get_const(right));
+            if (sym_is_const(left) && sym_is_const(right)) {
+                assert(PyLong_CheckExact(sym_get_const(left)));
+                assert(PyLong_CheckExact(sym_get_const(right)));
+                PyObject *temp = _PyLong_Add((PyLongObject *)sym_get_const(left),
+                    (PyLongObject *)sym_get_const(right));
                 if (temp == NULL) {
                     goto error;
                 }
-                OUT_OF_SPACE_IF_NULL(res = _Py_uop_sym_new_const(ctx, temp));
+                OUT_OF_SPACE_IF_NULL(res = sym_new_const(ctx, temp));
                 // TODO gh-115506:
                 // replace opcode with constant propagated one and add tests!
             }
             else {
-                OUT_OF_SPACE_IF_NULL(res = _Py_uop_sym_new_type(ctx, &PyLong_Type));
+                OUT_OF_SPACE_IF_NULL(res = sym_new_type(ctx, &PyLong_Type));
             }
             stack_pointer[-2] = res;
             stack_pointer += -1;
@@ -235,20 +235,20 @@
             _Py_UopsSymbol *res;
             right = stack_pointer[-1];
             left = stack_pointer[-2];
-            if (_Py_uop_sym_is_const(left) && _Py_uop_sym_is_const(right)) {
-                assert(PyLong_CheckExact(_Py_uop_sym_get_const(left)));
-                assert(PyLong_CheckExact(_Py_uop_sym_get_const(right)));
-                PyObject *temp = _PyLong_Subtract((PyLongObject *)_Py_uop_sym_get_const(left),
-                    (PyLongObject *)_Py_uop_sym_get_const(right));
+            if (sym_is_const(left) && sym_is_const(right)) {
+                assert(PyLong_CheckExact(sym_get_const(left)));
+                assert(PyLong_CheckExact(sym_get_const(right)));
+                PyObject *temp = _PyLong_Subtract((PyLongObject *)sym_get_const(left),
+                    (PyLongObject *)sym_get_const(right));
                 if (temp == NULL) {
                     goto error;
                 }
-                OUT_OF_SPACE_IF_NULL(res = _Py_uop_sym_new_const(ctx, temp));
+                OUT_OF_SPACE_IF_NULL(res = sym_new_const(ctx, temp));
                 // TODO gh-115506:
                 // replace opcode with constant propagated one and add tests!
             }
             else {
-                OUT_OF_SPACE_IF_NULL(res = _Py_uop_sym_new_type(ctx, &PyLong_Type));
+                OUT_OF_SPACE_IF_NULL(res = sym_new_type(ctx, &PyLong_Type));
             }
             stack_pointer[-2] = res;
             stack_pointer += -1;
@@ -260,12 +260,12 @@
             _Py_UopsSymbol *left;
             right = stack_pointer[-1];
             left = stack_pointer[-2];
-            if (_Py_uop_sym_matches_type(left, &PyFloat_Type) &&
-                _Py_uop_sym_matches_type(right, &PyFloat_Type)) {
+            if (sym_matches_type(left, &PyFloat_Type) &&
+                sym_matches_type(right, &PyFloat_Type)) {
                 REPLACE_OP(this_instr, _NOP, 0 ,0);
             }
-            _Py_uop_sym_set_type(left, &PyFloat_Type);
-            _Py_uop_sym_set_type(right, &PyFloat_Type);
+            sym_set_type(left, &PyFloat_Type);
+            sym_set_type(right, &PyFloat_Type);
             break;
         }
 
@@ -275,21 +275,21 @@
             _Py_UopsSymbol *res;
             right = stack_pointer[-1];
             left = stack_pointer[-2];
-            if (_Py_uop_sym_is_const(left) && _Py_uop_sym_is_const(right)) {
-                assert(PyFloat_CheckExact(_Py_uop_sym_get_const(left)));
-                assert(PyFloat_CheckExact(_Py_uop_sym_get_const(right)));
+            if (sym_is_const(left) && sym_is_const(right)) {
+                assert(PyFloat_CheckExact(sym_get_const(left)));
+                assert(PyFloat_CheckExact(sym_get_const(right)));
                 PyObject *temp = PyFloat_FromDouble(
-                    PyFloat_AS_DOUBLE(_Py_uop_sym_get_const(left)) *
-                    PyFloat_AS_DOUBLE(_Py_uop_sym_get_const(right)));
+                    PyFloat_AS_DOUBLE(sym_get_const(left)) *
+                    PyFloat_AS_DOUBLE(sym_get_const(right)));
                 if (temp == NULL) {
                     goto error;
                 }
-                res = _Py_uop_sym_new_const(ctx, temp);
+                res = sym_new_const(ctx, temp);
                 // TODO gh-115506:
                 // replace opcode with constant propagated one and update tests!
             }
             else {
-                OUT_OF_SPACE_IF_NULL(res = _Py_uop_sym_new_type(ctx, &PyFloat_Type));
+                OUT_OF_SPACE_IF_NULL(res = sym_new_type(ctx, &PyFloat_Type));
             }
             stack_pointer[-2] = res;
             stack_pointer += -1;
@@ -302,21 +302,21 @@
             _Py_UopsSymbol *res;
             right = stack_pointer[-1];
             left = stack_pointer[-2];
-            if (_Py_uop_sym_is_const(left) && _Py_uop_sym_is_const(right)) {
-                assert(PyFloat_CheckExact(_Py_uop_sym_get_const(left)));
-                assert(PyFloat_CheckExact(_Py_uop_sym_get_const(right)));
+            if (sym_is_const(left) && sym_is_const(right)) {
+                assert(PyFloat_CheckExact(sym_get_const(left)));
+                assert(PyFloat_CheckExact(sym_get_const(right)));
                 PyObject *temp = PyFloat_FromDouble(
-                    PyFloat_AS_DOUBLE(_Py_uop_sym_get_const(left)) +
-                    PyFloat_AS_DOUBLE(_Py_uop_sym_get_const(right)));
+                    PyFloat_AS_DOUBLE(sym_get_const(left)) +
+                    PyFloat_AS_DOUBLE(sym_get_const(right)));
                 if (temp == NULL) {
                     goto error;
                 }
-                res = _Py_uop_sym_new_const(ctx, temp);
+                res = sym_new_const(ctx, temp);
                 // TODO gh-115506:
                 // replace opcode with constant propagated one and update tests!
             }
             else {
-                OUT_OF_SPACE_IF_NULL(res = _Py_uop_sym_new_type(ctx, &PyFloat_Type));
+                OUT_OF_SPACE_IF_NULL(res = sym_new_type(ctx, &PyFloat_Type));
             }
             stack_pointer[-2] = res;
             stack_pointer += -1;
@@ -329,21 +329,21 @@
             _Py_UopsSymbol *res;
             right = stack_pointer[-1];
             left = stack_pointer[-2];
-            if (_Py_uop_sym_is_const(left) && _Py_uop_sym_is_const(right)) {
-                assert(PyFloat_CheckExact(_Py_uop_sym_get_const(left)));
-                assert(PyFloat_CheckExact(_Py_uop_sym_get_const(right)));
+            if (sym_is_const(left) && sym_is_const(right)) {
+                assert(PyFloat_CheckExact(sym_get_const(left)));
+                assert(PyFloat_CheckExact(sym_get_const(right)));
                 PyObject *temp = PyFloat_FromDouble(
-                    PyFloat_AS_DOUBLE(_Py_uop_sym_get_const(left)) -
-                    PyFloat_AS_DOUBLE(_Py_uop_sym_get_const(right)));
+                    PyFloat_AS_DOUBLE(sym_get_const(left)) -
+                    PyFloat_AS_DOUBLE(sym_get_const(right)));
                 if (temp == NULL) {
                     goto error;
                 }
-                res = _Py_uop_sym_new_const(ctx, temp);
+                res = sym_new_const(ctx, temp);
                 // TODO gh-115506:
                 // replace opcode with constant propagated one and update tests!
             }
             else {
-                OUT_OF_SPACE_IF_NULL(res = _Py_uop_sym_new_type(ctx, &PyFloat_Type));
+                OUT_OF_SPACE_IF_NULL(res = sym_new_type(ctx, &PyFloat_Type));
             }
             stack_pointer[-2] = res;
             stack_pointer += -1;
@@ -355,12 +355,12 @@
             _Py_UopsSymbol *left;
             right = stack_pointer[-1];
             left = stack_pointer[-2];
-            if (_Py_uop_sym_matches_type(left, &PyUnicode_Type) &&
-                _Py_uop_sym_matches_type(right, &PyUnicode_Type)) {
+            if (sym_matches_type(left, &PyUnicode_Type) &&
+                sym_matches_type(right, &PyUnicode_Type)) {
                 REPLACE_OP(this_instr, _NOP, 0 ,0);
             }
-            _Py_uop_sym_set_type(left, &PyUnicode_Type);
-            _Py_uop_sym_set_type(right, &PyUnicode_Type);
+            sym_set_type(left, &PyUnicode_Type);
+            sym_set_type(right, &PyUnicode_Type);
             break;
         }
 
@@ -487,7 +487,7 @@
             retval = stack_pointer[-1];
             stack_pointer += -1;
             ctx->frame->stack_pointer = stack_pointer;
-            _Py_uop_ctx_frame_pop(ctx);
+            frame_pop(ctx);
             stack_pointer = ctx->frame->stack_pointer;
             res = retval;
             stack_pointer[0] = res;
@@ -570,7 +570,7 @@
             /* This has to be done manually */
             (void)seq;
             for (int i = 0; i < oparg; i++) {
-                OUT_OF_SPACE_IF_NULL(values[i] = _Py_uop_sym_new_unknown(ctx));
+                OUT_OF_SPACE_IF_NULL(values[i] = sym_new_unknown(ctx));
             }
             stack_pointer += -1 + oparg;
             break;
@@ -618,7 +618,7 @@
             (void)seq;
             int totalargs = (oparg & 0xFF) + (oparg >> 8) + 1;
             for (int i = 0; i < totalargs; i++) {
-                OUT_OF_SPACE_IF_NULL(values[i] = _Py_uop_sym_new_unknown(ctx));
+                OUT_OF_SPACE_IF_NULL(values[i] = sym_new_unknown(ctx));
             }
             stack_pointer += (oparg >> 8) + (oparg & 0xFF);
             break;
@@ -902,8 +902,8 @@
             owner = stack_pointer[-1];
             uint32_t dict_version = (uint32_t)this_instr->operand;
             (void)dict_version;
-            if (_Py_uop_sym_is_const(owner)) {
-                PyObject *cnst = _Py_uop_sym_get_const(owner);
+            if (sym_is_const(owner)) {
+                PyObject *cnst = sym_get_const(owner);
                 if (PyModule_CheckExact(cnst)) {
                     PyModuleObject *mod = (PyModuleObject *)cnst;
                     PyObject *dict = mod->md_dict;
@@ -925,23 +925,23 @@
             owner = stack_pointer[-1];
             uint16_t index = (uint16_t)this_instr->operand;
             (void)index;
-            OUT_OF_SPACE_IF_NULL(null = _Py_uop_sym_new_null(ctx));
+            OUT_OF_SPACE_IF_NULL(null = sym_new_null(ctx));
             attr = NULL;
             if (this_instr[-1].opcode == _NOP) {
                 // Preceding _CHECK_ATTR_MODULE was removed: mod is const and dict is watched.
-                assert(_Py_uop_sym_is_const(owner));
-                PyModuleObject *mod = (PyModuleObject *)_Py_uop_sym_get_const(owner);
+                assert(sym_is_const(owner));
+                PyModuleObject *mod = (PyModuleObject *)sym_get_const(owner);
                 assert(PyModule_CheckExact(mod));
                 PyObject *dict = mod->md_dict;
                 PyObject *res = convert_global_to_const(this_instr, dict);
                 if (res != NULL) {
                     this_instr[-1].opcode = _POP_TOP;
-                    OUT_OF_SPACE_IF_NULL(attr = _Py_uop_sym_new_const(ctx, res));
+                    OUT_OF_SPACE_IF_NULL(attr = sym_new_const(ctx, res));
                 }
             }
             if (attr == NULL) {
                 /* No conversion made. We don't know what `attr` is. */
-                OUT_OF_SPACE_IF_NULL(attr = _Py_uop_sym_new_not_null(ctx));
+                OUT_OF_SPACE_IF_NULL(attr = sym_new_not_null(ctx));
             }
             stack_pointer[-1] = attr;
             if (oparg & 1) stack_pointer[0] = null;
@@ -1234,7 +1234,7 @@
             _Py_UopsSymbol *iter;
             _Py_UopsSymbol *next;
             iter = stack_pointer[-1];
-            OUT_OF_SPACE_IF_NULL(next = _Py_uop_sym_new_type(ctx, &PyLong_Type));
+            OUT_OF_SPACE_IF_NULL(next = sym_new_type(ctx, &PyLong_Type));
             (void)iter;
             stack_pointer[0] = next;
             stack_pointer += 1;
@@ -1306,7 +1306,7 @@
             owner = stack_pointer[-1];
             PyObject *descr = (PyObject *)this_instr->operand;
             (void)descr;
-            OUT_OF_SPACE_IF_NULL(attr = _Py_uop_sym_new_not_null(ctx));
+            OUT_OF_SPACE_IF_NULL(attr = sym_new_not_null(ctx));
             self = owner;
             stack_pointer[-1] = attr;
             stack_pointer[0] = self;
@@ -1321,7 +1321,7 @@
             owner = stack_pointer[-1];
             PyObject *descr = (PyObject *)this_instr->operand;
             (void)descr;
-            OUT_OF_SPACE_IF_NULL(attr = _Py_uop_sym_new_not_null(ctx));
+            OUT_OF_SPACE_IF_NULL(attr = sym_new_not_null(ctx));
             self = owner;
             stack_pointer[-1] = attr;
             stack_pointer[0] = self;
@@ -1356,7 +1356,7 @@
             owner = stack_pointer[-1];
             PyObject *descr = (PyObject *)this_instr->operand;
             (void)descr;
-            OUT_OF_SPACE_IF_NULL(attr = _Py_uop_sym_new_not_null(ctx));
+            OUT_OF_SPACE_IF_NULL(attr = sym_new_not_null(ctx));
             self = owner;
             stack_pointer[-1] = attr;
             stack_pointer[0] = self;
@@ -1373,8 +1373,8 @@
             _Py_UopsSymbol *callable;
             null = stack_pointer[-1 - oparg];
             callable = stack_pointer[-2 - oparg];
-            _Py_uop_sym_set_null(null);
-            _Py_uop_sym_set_type(callable, &PyMethod_Type);
+            sym_set_null(null);
+            sym_set_type(callable, &PyMethod_Type);
             break;
         }
 
@@ -1384,8 +1384,8 @@
             _Py_UopsSymbol *self;
             callable = stack_pointer[-2 - oparg];
             (void)callable;
-            OUT_OF_SPACE_IF_NULL(func = _Py_uop_sym_new_not_null(ctx));
-            OUT_OF_SPACE_IF_NULL(self = _Py_uop_sym_new_not_null(ctx));
+            OUT_OF_SPACE_IF_NULL(func = sym_new_not_null(ctx));
+            OUT_OF_SPACE_IF_NULL(self = sym_new_not_null(ctx));
             stack_pointer[-2 - oparg] = func;
             stack_pointer[-1 - oparg] = self;
             break;
@@ -1401,7 +1401,7 @@
             self_or_null = stack_pointer[-1 - oparg];
             callable = stack_pointer[-2 - oparg];
             uint32_t func_version = (uint32_t)this_instr->operand;
-            _Py_uop_sym_set_type(callable, &PyFunction_Type);
+            sym_set_type(callable, &PyFunction_Type);
             (void)self_or_null;
             (void)func_version;
             break;
@@ -1428,7 +1428,7 @@
             PyCodeObject *co = (PyCodeObject *)func->func_code;
             assert(self_or_null != NULL);
             assert(args != NULL);
-            if (_Py_uop_sym_is_not_null(self_or_null)) {
+            if (sym_is_not_null(self_or_null)) {
                 // Bound method fiddling, same as _INIT_CALL_PY_EXACT_ARGS in VM
                 args--;
                 argcount++;
@@ -1438,12 +1438,12 @@
             // Can determine statically, so we interleave the new locals
             // and make the current stack the new locals.
             // This also sets up for true call inlining.
-            if (_Py_uop_sym_is_null(self_or_null) || _Py_uop_sym_is_not_null(self_or_null)) {
+            if (sym_is_null(self_or_null) || sym_is_not_null(self_or_null)) {
                 localsplus_start = args;
                 n_locals_already_filled = argcount;
             }
             OUT_OF_SPACE_IF_NULL(new_frame =
-                             _Py_uop_ctx_frame_new(ctx, co, localsplus_start, n_locals_already_filled, 0));
+                             frame_new(ctx, co, localsplus_start, n_locals_already_filled, 0));
             stack_pointer[-2 - oparg] = (_Py_UopsSymbol *)new_frame;
             stack_pointer += -1 - oparg;
             break;
@@ -1732,7 +1732,7 @@
         case _LOAD_CONST_INLINE: {
             _Py_UopsSymbol *value;
             PyObject *ptr = (PyObject *)this_instr->operand;
-            OUT_OF_SPACE_IF_NULL(value = _Py_uop_sym_new_const(ctx, ptr));
+            OUT_OF_SPACE_IF_NULL(value = sym_new_const(ctx, ptr));
             stack_pointer[0] = value;
             stack_pointer += 1;
             break;
@@ -1741,7 +1741,7 @@
         case _LOAD_CONST_INLINE_BORROW: {
             _Py_UopsSymbol *value;
             PyObject *ptr = (PyObject *)this_instr->operand;
-            OUT_OF_SPACE_IF_NULL(value = _Py_uop_sym_new_const(ctx, ptr));
+            OUT_OF_SPACE_IF_NULL(value = sym_new_const(ctx, ptr));
             stack_pointer[0] = value;
             stack_pointer += 1;
             break;
@@ -1751,8 +1751,8 @@
             _Py_UopsSymbol *value;
             _Py_UopsSymbol *null;
             PyObject *ptr = (PyObject *)this_instr->operand;
-            OUT_OF_SPACE_IF_NULL(value = _Py_uop_sym_new_const(ctx, ptr));
-            OUT_OF_SPACE_IF_NULL(null = _Py_uop_sym_new_null(ctx));
+            OUT_OF_SPACE_IF_NULL(value = sym_new_const(ctx, ptr));
+            OUT_OF_SPACE_IF_NULL(null = sym_new_null(ctx));
             stack_pointer[0] = value;
             stack_pointer[1] = null;
             stack_pointer += 2;
@@ -1763,8 +1763,8 @@
             _Py_UopsSymbol *value;
             _Py_UopsSymbol *null;
             PyObject *ptr = (PyObject *)this_instr->operand;
-            OUT_OF_SPACE_IF_NULL(value = _Py_uop_sym_new_const(ctx, ptr));
-            OUT_OF_SPACE_IF_NULL(null = _Py_uop_sym_new_null(ctx));
+            OUT_OF_SPACE_IF_NULL(value = sym_new_const(ctx, ptr));
+            OUT_OF_SPACE_IF_NULL(null = sym_new_null(ctx));
             stack_pointer[0] = value;
             stack_pointer[1] = null;
             stack_pointer += 2;

--- a/Python/optimizer_symbols.c
+++ b/Python/optimizer_symbols.c
@@ -32,7 +32,7 @@ static inline int get_lltrace(void) {
 #endif
 
 // Takes a borrowed reference to const_val, turns that into a strong reference.
-static _Py_UOpsSymType*
+static _Py_UOpsSymType *
 sym_new(_Py_UOpsAbstractInterpContext *ctx, PyObject *const_val)
 {
     _Py_UOpsSymType *self = &ctx->t_arena.arena[ctx->t_arena.ty_curr_number];
@@ -111,7 +111,7 @@ _Py_uop_sym_set_null(_Py_UOpsSymType *sym)
 _Py_UOpsSymType *
 _Py_uop_sym_new_unknown(_Py_UOpsAbstractInterpContext *ctx)
 {
-    return sym_new(ctx,NULL);
+    return sym_new(ctx, NULL);
 }
 
 _Py_UOpsSymType *
@@ -139,14 +139,11 @@ _Py_uop_sym_new_type(_Py_UOpsAbstractInterpContext *ctx,
 }
 
 // Takes a borrowed reference to const_val.
-_Py_UOpsSymType*
+_Py_UOpsSymType *
 _Py_uop_sym_new_const(_Py_UOpsAbstractInterpContext *ctx, PyObject *const_val)
 {
     assert(const_val != NULL);
-    _Py_UOpsSymType *temp = sym_new(
-        ctx,
-        const_val
-    );
+    _Py_UOpsSymType *temp = sym_new(ctx, const_val);
     if (temp == NULL) {
         return NULL;
     }
@@ -157,7 +154,7 @@ _Py_uop_sym_new_const(_Py_UOpsAbstractInterpContext *ctx, PyObject *const_val)
     return temp;
 }
 
-_Py_UOpsSymType*
+_Py_UOpsSymType *
 _Py_uop_sym_new_null(_Py_UOpsAbstractInterpContext *ctx)
 {
     _Py_UOpsSymType *null_sym = _Py_uop_sym_new_unknown(ctx);
@@ -185,8 +182,7 @@ _Py_uop_ctx_frame_new(
     PyCodeObject *co,
     _Py_UOpsSymType **localsplus_start,
     int n_locals_already_filled,
-    int curr_stackentries
-)
+    int curr_stackentries)
 {
     assert(ctx->curr_frame_depth < MAX_ABSTRACT_FRAME_DEPTH);
     _Py_UOpsAbstractFrame *frame = &ctx->frames[ctx->curr_frame_depth];
@@ -239,9 +235,7 @@ _Py_uop_abstractcontext_fini(_Py_UOpsAbstractInterpContext *ctx)
 }
 
 int
-_Py_uop_abstractcontext_init(
-    _Py_UOpsAbstractInterpContext *ctx
-)
+_Py_uop_abstractcontext_init(_Py_UOpsAbstractInterpContext *ctx)
 {
     ctx->limit = ctx->locals_and_stack + MAX_ABSTRACT_INTERP_SIZE;
     ctx->n_consumed = ctx->locals_and_stack;
@@ -262,12 +256,9 @@ _Py_uop_abstractcontext_init(
 }
 
 int
-_Py_uop_ctx_frame_pop(
-    _Py_UOpsAbstractInterpContext *ctx
-)
+_Py_uop_ctx_frame_pop(_Py_UOpsAbstractInterpContext *ctx)
 {
     _Py_UOpsAbstractFrame *frame = ctx->frame;
-
     ctx->n_consumed = frame->locals;
     ctx->curr_frame_depth--;
     assert(ctx->curr_frame_depth >= 1);
@@ -288,7 +279,7 @@ do { \
 
 /*
 static _Py_UOpsSymType *
-make_bottom(_Py_UOpsAbstractInterpContext *ctx)
+make_contradiction(_Py_UOpsAbstractInterpContext *ctx)
 {
     _Py_UOpsSymType *sym = _Py_uop_sym_new_unknown(ctx);
     _Py_uop_sym_set_null(sym);
@@ -312,17 +303,17 @@ _Py_uop_symbols_test(PyObject *Py_UNUSED(self), PyObject *Py_UNUSED(ignored))
     TEST_PREDICATE(!_Py_uop_sym_is_const(top), "unknown is a constant");
     // TEST_PREDICATE(_Py_uop_sym_get_const(top) == NULL, "unknown as constant is not NULL");
 
-    // _Py_UOpsSymType *bottom = make_bottom(ctx);
-    // TEST_PREDICATE(_Py_uop_sym_is_null(bottom), "bottom is NULL is not true");
-    // TEST_PREDICATE(_Py_uop_sym_is_not_null(bottom), "bottom is not NULL is not true");
-    // TEST_PREDICATE(_Py_uop_sym_is_const(bottom), "bottom is a constant is not true");
+    // _Py_UOpsSymType *contradiction = make_contradiction(ctx);
+    // TEST_PREDICATE(_Py_uop_sym_is_null(contradiction), "contradiction is NULL is not true");
+    // TEST_PREDICATE(_Py_uop_sym_is_not_null(contradiction), "contradiction is not NULL is not true");
+    // TEST_PREDICATE(_Py_uop_sym_is_const(contradiction), "contradiction is a constant is not true");
 
     _Py_UOpsSymType *int_type = _Py_uop_sym_new_type(ctx, &PyLong_Type);
     TEST_PREDICATE(_Py_uop_sym_matches_type(int_type, &PyLong_Type), "inconsistent type");
     _Py_uop_sym_set_type(int_type, &PyLong_Type);
     TEST_PREDICATE(_Py_uop_sym_matches_type(int_type, &PyLong_Type), "inconsistent type");
     _Py_uop_sym_set_type(int_type, &PyFloat_Type);
-    // TEST_PREDICATE(_Py_uop_sym_matches_type(int_type, &PyLong_Type), "bottom doesn't match int");
+    // TEST_PREDICATE(_Py_uop_sym_matches_type(int_type, &PyLong_Type), "(int and float) doesn't match int");
 
     _Py_uop_abstractcontext_fini(ctx);
     Py_RETURN_NONE;

--- a/Python/optimizer_symbols.c
+++ b/Python/optimizer_symbols.c
@@ -32,10 +32,10 @@ static inline int get_lltrace(void) {
 #endif
 
 // Takes a borrowed reference to const_val, turns that into a strong reference.
-static _Py_UOpsSymType *
-sym_new(_Py_UOpsAbstractInterpContext *ctx, PyObject *const_val)
+static _Py_UopsSymbol *
+sym_new(_Py_UOpsContext *ctx, PyObject *const_val)
 {
-    _Py_UOpsSymType *self = &ctx->t_arena.arena[ctx->t_arena.ty_curr_number];
+    _Py_UopsSymbol *self = &ctx->t_arena.arena[ctx->t_arena.ty_curr_number];
     if (ctx->t_arena.ty_curr_number >= ctx->t_arena.ty_max_number) {
         OPT_STAT_INC(optimizer_failure_reason_no_memory);
         DPRINTF(1, "out of space for symbolic expression type\n");
@@ -54,37 +54,37 @@ sym_new(_Py_UOpsAbstractInterpContext *ctx, PyObject *const_val)
 }
 
 static inline void
-sym_set_flag(_Py_UOpsSymType *sym, int flag)
+sym_set_flag(_Py_UopsSymbol *sym, int flag)
 {
     sym->flags |= flag;
 }
 
 static inline bool
-sym_has_flag(_Py_UOpsSymType *sym, int flag)
+sym_has_flag(_Py_UopsSymbol *sym, int flag)
 {
     return (sym->flags & flag) != 0;
 }
 
 bool
-_Py_uop_sym_is_not_null(_Py_UOpsSymType *sym)
+_Py_uop_sym_is_not_null(_Py_UopsSymbol *sym)
 {
     return (sym->flags & (IS_NULL | NOT_NULL)) == NOT_NULL;
 }
 
 bool
-_Py_uop_sym_is_null(_Py_UOpsSymType *sym)
+_Py_uop_sym_is_null(_Py_UopsSymbol *sym)
 {
     return (sym->flags & (IS_NULL | NOT_NULL)) == IS_NULL;
 }
 
 bool
-_Py_uop_sym_is_const(_Py_UOpsSymType *sym)
+_Py_uop_sym_is_const(_Py_UopsSymbol *sym)
 {
     return (sym->flags & TRUE_CONST) != 0;
 }
 
 PyObject *
-_Py_uop_sym_get_const(_Py_UOpsSymType *sym)
+_Py_uop_sym_get_const(_Py_UopsSymbol *sym)
 {
     assert(_Py_uop_sym_is_const(sym));
     assert(sym->const_val);
@@ -92,7 +92,7 @@ _Py_uop_sym_get_const(_Py_UOpsSymType *sym)
 }
 
 void
-_Py_uop_sym_set_type(_Py_UOpsSymType *sym, PyTypeObject *tp)
+_Py_uop_sym_set_type(_Py_UopsSymbol *sym, PyTypeObject *tp)
 {
     assert(PyType_Check(tp));
     sym->typ = tp;
@@ -101,23 +101,23 @@ _Py_uop_sym_set_type(_Py_UOpsSymType *sym, PyTypeObject *tp)
 }
 
 void
-_Py_uop_sym_set_null(_Py_UOpsSymType *sym)
+_Py_uop_sym_set_null(_Py_UopsSymbol *sym)
 {
     sym_set_flag(sym, IS_NULL);
     sym_set_flag(sym, KNOWN);
 }
 
 
-_Py_UOpsSymType *
-_Py_uop_sym_new_unknown(_Py_UOpsAbstractInterpContext *ctx)
+_Py_UopsSymbol *
+_Py_uop_sym_new_unknown(_Py_UOpsContext *ctx)
 {
     return sym_new(ctx, NULL);
 }
 
-_Py_UOpsSymType *
-_Py_uop_sym_new_not_null(_Py_UOpsAbstractInterpContext *ctx)
+_Py_UopsSymbol *
+_Py_uop_sym_new_not_null(_Py_UOpsContext *ctx)
 {
-    _Py_UOpsSymType *res = _Py_uop_sym_new_unknown(ctx);
+    _Py_UopsSymbol *res = _Py_uop_sym_new_unknown(ctx);
     if (res == NULL) {
         return NULL;
     }
@@ -126,11 +126,11 @@ _Py_uop_sym_new_not_null(_Py_UOpsAbstractInterpContext *ctx)
     return res;
 }
 
-_Py_UOpsSymType *
-_Py_uop_sym_new_type(_Py_UOpsAbstractInterpContext *ctx,
+_Py_UopsSymbol *
+_Py_uop_sym_new_type(_Py_UOpsContext *ctx,
                       PyTypeObject *typ)
 {
-    _Py_UOpsSymType *res = sym_new(ctx,NULL);
+    _Py_UopsSymbol *res = sym_new(ctx,NULL);
     if (res == NULL) {
         return NULL;
     }
@@ -139,11 +139,11 @@ _Py_uop_sym_new_type(_Py_UOpsAbstractInterpContext *ctx,
 }
 
 // Takes a borrowed reference to const_val.
-_Py_UOpsSymType *
-_Py_uop_sym_new_const(_Py_UOpsAbstractInterpContext *ctx, PyObject *const_val)
+_Py_UopsSymbol *
+_Py_uop_sym_new_const(_Py_UOpsContext *ctx, PyObject *const_val)
 {
     assert(const_val != NULL);
-    _Py_UOpsSymType *temp = sym_new(ctx, const_val);
+    _Py_UopsSymbol *temp = sym_new(ctx, const_val);
     if (temp == NULL) {
         return NULL;
     }
@@ -154,10 +154,10 @@ _Py_uop_sym_new_const(_Py_UOpsAbstractInterpContext *ctx, PyObject *const_val)
     return temp;
 }
 
-_Py_UOpsSymType *
-_Py_uop_sym_new_null(_Py_UOpsAbstractInterpContext *ctx)
+_Py_UopsSymbol *
+_Py_uop_sym_new_null(_Py_UOpsContext *ctx)
 {
-    _Py_UOpsSymType *null_sym = _Py_uop_sym_new_unknown(ctx);
+    _Py_UopsSymbol *null_sym = _Py_uop_sym_new_unknown(ctx);
     if (null_sym == NULL) {
         return NULL;
     }
@@ -166,7 +166,7 @@ _Py_uop_sym_new_null(_Py_UOpsAbstractInterpContext *ctx)
 }
 
 bool
-_Py_uop_sym_matches_type(_Py_UOpsSymType *sym, PyTypeObject *typ)
+_Py_uop_sym_matches_type(_Py_UopsSymbol *sym, PyTypeObject *typ)
 {
     assert(typ == NULL || PyType_Check(typ));
     if (!sym_has_flag(sym, KNOWN)) {
@@ -178,9 +178,9 @@ _Py_uop_sym_matches_type(_Py_UOpsSymType *sym, PyTypeObject *typ)
 // 0 on success, -1 on error.
 _Py_UOpsAbstractFrame *
 _Py_uop_ctx_frame_new(
-    _Py_UOpsAbstractInterpContext *ctx,
+    _Py_UOpsContext *ctx,
     PyCodeObject *co,
-    _Py_UOpsSymType **localsplus_start,
+    _Py_UopsSymbol **localsplus_start,
     int n_locals_already_filled,
     int curr_stackentries)
 {
@@ -201,7 +201,7 @@ _Py_uop_ctx_frame_new(
 
     // Initialize with the initial state of all local variables
     for (int i = n_locals_already_filled; i < co->co_nlocalsplus; i++) {
-        _Py_UOpsSymType *local = _Py_uop_sym_new_unknown(ctx);
+        _Py_UopsSymbol *local = _Py_uop_sym_new_unknown(ctx);
         if (local == NULL) {
             return NULL;
         }
@@ -211,7 +211,7 @@ _Py_uop_ctx_frame_new(
 
     // Initialize the stack as well
     for (int i = 0; i < curr_stackentries; i++) {
-        _Py_UOpsSymType *stackvar = _Py_uop_sym_new_unknown(ctx);
+        _Py_UopsSymbol *stackvar = _Py_uop_sym_new_unknown(ctx);
         if (stackvar == NULL) {
             return NULL;
         }
@@ -222,7 +222,7 @@ _Py_uop_ctx_frame_new(
 }
 
 void
-_Py_uop_abstractcontext_fini(_Py_UOpsAbstractInterpContext *ctx)
+_Py_uop_abstractcontext_fini(_Py_UOpsContext *ctx)
 {
     if (ctx == NULL) {
         return;
@@ -235,7 +235,7 @@ _Py_uop_abstractcontext_fini(_Py_UOpsAbstractInterpContext *ctx)
 }
 
 int
-_Py_uop_abstractcontext_init(_Py_UOpsAbstractInterpContext *ctx)
+_Py_uop_abstractcontext_init(_Py_UOpsContext *ctx)
 {
     ctx->limit = ctx->locals_and_stack + MAX_ABSTRACT_INTERP_SIZE;
     ctx->n_consumed = ctx->locals_and_stack;
@@ -256,7 +256,7 @@ _Py_uop_abstractcontext_init(_Py_UOpsAbstractInterpContext *ctx)
 }
 
 int
-_Py_uop_ctx_frame_pop(_Py_UOpsAbstractInterpContext *ctx)
+_Py_uop_ctx_frame_pop(_Py_UOpsContext *ctx)
 {
     _Py_UOpsAbstractFrame *frame = ctx->frame;
     ctx->n_consumed = frame->locals;
@@ -278,10 +278,10 @@ do { \
 } while (0)
 
 /*
-static _Py_UOpsSymType *
-make_contradiction(_Py_UOpsAbstractInterpContext *ctx)
+static _Py_UopsSymbol *
+make_contradiction(_Py_UOpsContext *ctx)
 {
-    _Py_UOpsSymType *sym = _Py_uop_sym_new_unknown(ctx);
+    _Py_UopsSymbol *sym = _Py_uop_sym_new_unknown(ctx);
     _Py_uop_sym_set_null(sym);
     _Py_uop_sym_set_type(sym, &PyLong_Type);
     return sym;
@@ -290,11 +290,11 @@ make_contradiction(_Py_UOpsAbstractInterpContext *ctx)
 PyObject *
 _Py_uop_symbols_test(PyObject *Py_UNUSED(self), PyObject *Py_UNUSED(ignored))
 {
-    _Py_UOpsAbstractInterpContext context;
-    _Py_UOpsAbstractInterpContext *ctx = &context;
+    _Py_UOpsContext context;
+    _Py_UOpsContext *ctx = &context;
     _Py_uop_abstractcontext_init(ctx);
 
-    _Py_UOpsSymType *top = _Py_uop_sym_new_unknown(ctx);
+    _Py_UopsSymbol *top = _Py_uop_sym_new_unknown(ctx);
     if (top == NULL) {
         return NULL;
     }
@@ -303,12 +303,12 @@ _Py_uop_symbols_test(PyObject *Py_UNUSED(self), PyObject *Py_UNUSED(ignored))
     TEST_PREDICATE(!_Py_uop_sym_is_const(top), "unknown is a constant");
     // TEST_PREDICATE(_Py_uop_sym_get_const(top) == NULL, "unknown as constant is not NULL");
 
-    // _Py_UOpsSymType *contradiction = make_contradiction(ctx);
+    // _Py_UopsSymbol *contradiction = make_contradiction(ctx);
     // TEST_PREDICATE(_Py_uop_sym_is_null(contradiction), "contradiction is NULL is not true");
     // TEST_PREDICATE(_Py_uop_sym_is_not_null(contradiction), "contradiction is not NULL is not true");
     // TEST_PREDICATE(_Py_uop_sym_is_const(contradiction), "contradiction is a constant is not true");
 
-    _Py_UOpsSymType *int_type = _Py_uop_sym_new_type(ctx, &PyLong_Type);
+    _Py_UopsSymbol *int_type = _Py_uop_sym_new_type(ctx, &PyLong_Type);
     TEST_PREDICATE(_Py_uop_sym_matches_type(int_type, &PyLong_Type), "inconsistent type");
     _Py_uop_sym_set_type(int_type, &PyLong_Type);
     TEST_PREDICATE(_Py_uop_sym_matches_type(int_type, &PyLong_Type), "inconsistent type");

--- a/Python/optimizer_symbols.c
+++ b/Python/optimizer_symbols.c
@@ -177,7 +177,7 @@ _Py_uop_sym_matches_type(_Py_UopsSymbol *sym, PyTypeObject *typ)
 
 // 0 on success, -1 on error.
 _Py_UOpsAbstractFrame *
-_Py_uop_ctx_frame_new(
+_Py_uop_frame_new(
     _Py_UOpsContext *ctx,
     PyCodeObject *co,
     _Py_UopsSymbol **localsplus_start,
@@ -256,7 +256,7 @@ _Py_uop_abstractcontext_init(_Py_UOpsContext *ctx)
 }
 
 int
-_Py_uop_ctx_frame_pop(_Py_UOpsContext *ctx)
+_Py_uop_frame_pop(_Py_UOpsContext *ctx)
 {
     _Py_UOpsAbstractFrame *frame = ctx->frame;
     ctx->n_consumed = frame->locals;

--- a/Tools/cases_generator/optimizer_generator.py
+++ b/Tools/cases_generator/optimizer_generator.py
@@ -41,10 +41,10 @@ def validate_uop(override: Uop, uop: Uop) -> None:
 
 def type_name(var: StackItem) -> str:
     if var.is_array():
-        return f"_Py_UOpsSymType **"
+        return f"_Py_UopsSymbol **"
     if var.type:
         return var.type
-    return f"_Py_UOpsSymType *"
+    return f"_Py_UopsSymbol *"
 
 
 def declare_variables(uop: Uop, out: CWriter, skip_inputs: bool) -> None:
@@ -148,7 +148,7 @@ def write_uop(
                 if not var.peek or is_override:
                     out.emit(stack.push(var))
         out.start_line()
-        stack.flush(out, cast_type="_Py_UOpsSymType *")
+        stack.flush(out, cast_type="_Py_UopsSymbol *")
     except SizeMismatch as ex:
         raise analysis_error(ex.args[0], uop.body[0])
 


### PR DESCRIPTION
Follows suggestions by @gvanrossum on https://github.com/python/cpython/pull/115953.

* Renames two structs `_Py_UOpsSymType ` to `_Py_UopsSymbol` and `_Py_UOpsAbstractInterpContext ` to `_Py_UOpsContext`
* Adds macros defining `sym...` as `_Py_uop_sym_...` so we can use the short form in optimizer_bytecodes.c, improving readability.
* A few minor formating fixes
* Rename `bottom` to `contradiction`.

<!-- gh-issue-number: gh-115816 -->
* Issue: gh-115816
<!-- /gh-issue-number -->
