### PR TITLE
gh-115957: Close coroutine if the TaskGroup is inactive 

### DIFF
--- a/Doc/library/asyncio-task.rst
+++ b/Doc/library/asyncio-task.rst
@@ -335,6 +335,10 @@ and reliable way to wait for all tasks in the group to finish.
       Create a task in this task group.
       The signature matches that of :func:`asyncio.create_task`.
 
+      .. versionchanged:: 3.13
+
+         Close the given coroutine if the task group is not active.
+
 Example::
 
     async def main():

--- a/Doc/library/asyncio-task.rst
+++ b/Doc/library/asyncio-task.rst
@@ -334,6 +334,9 @@ and reliable way to wait for all tasks in the group to finish.
 
       Create a task in this task group.
       The signature matches that of :func:`asyncio.create_task`.
+      If the task group is inactive (e.g. not yet entered,
+      already finished, or in the process of shutting down),
+      we will close the given ``coro``.
 
       .. versionchanged:: 3.13
 

--- a/Doc/whatsnew/3.13.rst
+++ b/Doc/whatsnew/3.13.rst
@@ -187,7 +187,8 @@ Other Language Changes
 
 * When :func:`asyncio.TaskGroup.create_task` is called on an inactive
   :class:`asyncio.TaskGroup`, the given coroutine will be closed (which
-  prevents a :exc:`RuntimeWarning`).
+  prevents a :exc:`RuntimeWarning` about the given coroutine being
+  never awaited).
 
   (Contributed by Arthur Tacca and Jason Zhang in :gh:`115957`.)
 

--- a/Doc/whatsnew/3.13.rst
+++ b/Doc/whatsnew/3.13.rst
@@ -185,6 +185,11 @@ Other Language Changes
 
   (Contributed by Sebastian Pipping in :gh:`115623`.)
 
+* When :func:`asyncio.TaskGroup.create_task` is called on an inactive
+  :class:`asyncio.TaskGroup`, the given coroutine will be closed (which
+  prevents a :exc:`RuntimeWarning`).
+
+  (Contributed by Arthur Tacca and Jason Zhang in :gh:`115957`.)
 
 New Modules
 ===========

--- a/Lib/asyncio/taskgroups.py
+++ b/Lib/asyncio/taskgroups.py
@@ -154,10 +154,13 @@ class TaskGroup:
         Similar to `asyncio.create_task`.
         """
         if not self._entered:
+            coro.close()
             raise RuntimeError(f"TaskGroup {self!r} has not been entered")
         if self._exiting and not self._tasks:
+            coro.close()
             raise RuntimeError(f"TaskGroup {self!r} is finished")
         if self._aborting:
+            coro.close()
             raise RuntimeError(f"TaskGroup {self!r} is shutting down")
         if context is None:
             task = self._loop.create_task(coro, name=name)

--- a/Misc/NEWS.d/next/Library/2024-03-02-11-31-49.gh-issue-115957.C-3Z_U.rst
+++ b/Misc/NEWS.d/next/Library/2024-03-02-11-31-49.gh-issue-115957.C-3Z_U.rst
@@ -1,0 +1,1 @@
+When ``asyncio.TaskGroup.create_task`` is called on an inactive ``asyncio.TaskGroup``, the given coroutine will be closed (which prevents a  ``RuntimeWarning``).


### PR DESCRIPTION
This PR addresses the issue where when we call `TaskGroup.create_task()` with an inactive `TaskGroup`, we still get a `RuntimeWarning` for the coroutine. This change makes sure that the coroutine is closed in this case and updated the tests accordingly.

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--116009.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->

<!-- gh-issue-number: gh-115957 -->
* Issue: gh-115957
<!-- /gh-issue-number -->
