### PR TITLE
gh-116012: Preserve GetLastError() across calls to TlsGetValue on Windows

### DIFF
--- a/Misc/NEWS.d/next/Windows/2024-02-27-23-21-55.gh-issue-116012.B9_IwM.rst
+++ b/Misc/NEWS.d/next/Windows/2024-02-27-23-21-55.gh-issue-116012.B9_IwM.rst
@@ -1,0 +1,1 @@
+Ensure the value of ``GetLastError()`` is preserved across GIL operations.

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -2528,16 +2528,7 @@ PyGILState_Check(void)
         return 0;
     }
 
-#ifdef MS_WINDOWS
-    int err = GetLastError();
-#endif
-
     PyThreadState *tcur = gilstate_tss_get(runtime);
-
-#ifdef MS_WINDOWS
-    SetLastError(err);
-#endif
-
     return (tstate == tcur);
 }
 

--- a/Python/thread_nt.h
+++ b/Python/thread_nt.h
@@ -513,5 +513,10 @@ void *
 PyThread_tss_get(Py_tss_t *key)
 {
     assert(key != NULL);
-    return TlsGetValue(key->_key);
+    int err = GetLastError();
+    void *r = TlsGetValue(key->_key);
+    if (r || !GetLastError()) {
+        SetLastError(err);
+    }
+    return r;
 }


### PR DESCRIPTION


<!-- gh-issue-number: gh-116012 -->
* Issue: gh-116012
<!-- /gh-issue-number -->
