### PR TITLE
GH-115986 Fix `pprint` documentation

### DIFF
--- a/Doc/library/pprint.rst
+++ b/Doc/library/pprint.rst
@@ -51,7 +51,7 @@ Functions
                      compact=False, sort_dicts=True, underscore_numbers=False)
 
    Prints the formatted representation of *object* on *stream*, followed by a
-   newline.  If *stream* is ``None``, ``sys.stdout`` is used. This may be used
+   newline.  If *stream* is ``None``, :data:`sys.stdout` is used. This may be used
    in the interactive interpreter instead of the :func:`print` function for
    inspecting values (you can even reassign ``print = pprint.pprint`` for use
    within a scope).
@@ -136,9 +136,9 @@ This module defines one class:
    Construct a :class:`PrettyPrinter` instance.  This constructor understands
    several keyword parameters.
 
-   *stream* (default ``sys.stdout``) is a :term:`file-like object` to
+   *stream* (default :data:`sys.stdout`) is a :term:`file-like object` to
    which the output will be written by calling its :meth:`!write` method.
-   If both *stream* and ``sys.stdout`` are ``None``, then
+   If both *stream* and :data:`sys.stdout` are ``None``, then
    :meth:`~PrettyPrinter.pprint` silently returns.
 
    Other values configure the manner in which nesting of complex data
@@ -179,7 +179,7 @@ This module defines one class:
       Added the *underscore_numbers* parameter.
 
    .. versionchanged:: 3.11
-      No longer attempts to write to ``sys.stdout`` if it is ``None``.
+      No longer attempts to write to :data:`sys.stdout` if it is ``None``.
 
       >>> import pprint
       >>> stuff = ['spam', 'eggs', 'lumberjack', 'knights', 'ni']

--- a/Doc/library/pprint.rst
+++ b/Doc/library/pprint.rst
@@ -41,7 +41,7 @@ Functions
    Prints the formatted representation of *object* followed by a newline.
    If *sort_dicts* is false (the default), dictionaries will be displayed with
    their keys in insertion order, otherwise the dict keys will be sorted.
-   *args* and *kwargs* will be passed to :func:`pprint` as formatting
+   *args* and *kwargs* will be passed to :func:`pprint.pprint` as formatting
    parameters.
 
    .. versionadded:: 3.8
@@ -263,7 +263,7 @@ are converted to strings.  The default implementation uses the internals of the
 Example
 -------
 
-To demonstrate several uses of the :func:`pprint` function and its parameters,
+To demonstrate several uses of the :func:`pprint.pprint` function and its parameters,
 let's fetch information about a project from `PyPI <https://pypi.org>`_::
 
    >>> import json
@@ -272,7 +272,7 @@ let's fetch information about a project from `PyPI <https://pypi.org>`_::
    >>> with urlopen('https://pypi.org/pypi/sampleproject/json') as resp:
    ...     project_info = json.load(resp)['info']
 
-In its basic form, :func:`pprint` shows the whole object::
+In its basic form, :func:`pprint.pprint` shows the whole object::
 
    >>> pprint.pprint(project_info)
    {'author': 'The Python Packaging Authority',

--- a/Doc/library/pprint.rst
+++ b/Doc/library/pprint.rst
@@ -136,9 +136,9 @@ This module defines one class:
    Construct a :class:`PrettyPrinter` instance.  This constructor understands
    several keyword parameters.
 
-   *stream* (default :data:`sys.stdout`) is a :term:`file-like object` to
+   *stream* (default :data:`!sys.stdout`) is a :term:`file-like object` to
    which the output will be written by calling its :meth:`!write` method.
-   If both *stream* and :data:`sys.stdout` are ``None``, then
+   If both *stream* and :data:`!sys.stdout` are ``None``, then
    :meth:`~PrettyPrinter.pprint` silently returns.
 
    Other values configure the manner in which nesting of complex data
@@ -179,7 +179,7 @@ This module defines one class:
       Added the *underscore_numbers* parameter.
 
    .. versionchanged:: 3.11
-      No longer attempts to write to :data:`sys.stdout` if it is ``None``.
+      No longer attempts to write to :data:`!sys.stdout` if it is ``None``.
 
       >>> import pprint
       >>> stuff = ['spam', 'eggs', 'lumberjack', 'knights', 'ni']

--- a/Doc/library/pprint.rst
+++ b/Doc/library/pprint.rst
@@ -100,8 +100,6 @@ Functions
    :exc:`RecursionError` if it fails to detect a recursive object.
 
 
-One more support function is also defined:
-
 .. function:: saferepr(object)
 
    Return a string representation of *object*, protected against recursion in

--- a/Doc/library/pprint.rst
+++ b/Doc/library/pprint.rst
@@ -62,7 +62,7 @@ Functions
    described in its documentation above.
 
    Note that *sort_dicts* default value is true, which might be an unintuitive
-   behavior; you will most likely want to use the :func:`pprint.pp` function
+   behavior; you will most likely want to use the :func:`~pprint.pp` function
    or set this parameter to ``False``.
 
       >>> import pprint

--- a/Doc/library/pprint.rst
+++ b/Doc/library/pprint.rst
@@ -41,7 +41,7 @@ Functions
    Prints the formatted representation of *object* followed by a newline.
    If *sort_dicts* is false (the default), dictionaries will be displayed with
    their keys in insertion order, otherwise the dict keys will be sorted.
-   *args* and *kwargs* will be passed to :func:`pprint.pprint` as formatting
+   *args* and *kwargs* will be passed to :func:`~pprint.pprint` as formatting
    parameters.
 
    .. versionadded:: 3.8
@@ -267,7 +267,7 @@ are converted to strings.  The default implementation uses the internals of the
 Example
 -------
 
-To demonstrate several uses of the :func:`pprint.pprint` function and its parameters,
+To demonstrate several uses of the :func:`~pprint.pprint` function and its parameters,
 let's fetch information about a project from `PyPI <https://pypi.org>`_::
 
    >>> import json
@@ -276,7 +276,7 @@ let's fetch information about a project from `PyPI <https://pypi.org>`_::
    >>> with urlopen('https://pypi.org/pypi/sampleproject/json') as resp:
    ...     project_info = json.load(resp)['info']
 
-In its basic form, :func:`pprint.pprint` shows the whole object::
+In its basic form, :func:`~pprint.pprint` shows the whole object::
 
    >>> pprint.pprint(project_info)
    {'author': 'The Python Packaging Authority',

--- a/Doc/library/pprint.rst
+++ b/Doc/library/pprint.rst
@@ -61,10 +61,6 @@ Functions
    :class:`PrettyPrinter` constructor and their meanings are as
    described in its documentation above.
 
-   Note that *sort_dicts* default value is true, which might be an unintuitive
-   behavior; you will most likely want to use the :func:`~pprint.pp` function
-   or set this parameter to ``False``.
-
       >>> import pprint
       >>> stuff = ['spam', 'eggs', 'lumberjack', 'knights', 'ni']
       >>> stuff.insert(0, stuff)

--- a/Doc/library/pprint.rst
+++ b/Doc/library/pprint.rst
@@ -31,7 +31,95 @@ Dictionaries are sorted by key before the display is computed.
 .. versionchanged:: 3.10
    Added support for pretty-printing :class:`dataclasses.dataclass`.
 
-The :mod:`pprint` module defines one class:
+.. _pprint-functions:
+
+Functions
+---------
+
+.. function:: pp(object, *args, sort_dicts=False, **kwargs)
+
+   Prints the formatted representation of *object* followed by a newline.
+   If *sort_dicts* is false (the default), dictionaries will be displayed with
+   their keys in insertion order, otherwise the dict keys will be sorted.
+   *args* and *kwargs* will be passed to :func:`pprint` as formatting
+   parameters.
+
+   .. versionadded:: 3.8
+
+
+.. function:: pprint(object, stream=None, indent=1, width=80, depth=None, *, \
+                     compact=False, sort_dicts=True, underscore_numbers=False)
+
+   Prints the formatted representation of *object* on *stream*, followed by a
+   newline.  If *stream* is ``None``, ``sys.stdout`` is used. This may be used
+   in the interactive interpreter instead of the :func:`print` function for
+   inspecting values (you can even reassign ``print = pprint.pprint`` for use
+   within a scope).
+
+   The configuration parameters *stream*, *indent*, *width*, *depth*,
+   *compact*, *sort_dicts* and *underscore_numbers* are passed to the
+   :class:`PrettyPrinter` constructor and their meanings are as
+   described in its documentation above.
+
+      >>> import pprint
+      >>> stuff = ['spam', 'eggs', 'lumberjack', 'knights', 'ni']
+      >>> stuff.insert(0, stuff)
+      >>> pprint.pprint(stuff)
+      [<Recursion on list with id=...>,
+       'spam',
+       'eggs',
+       'lumberjack',
+       'knights',
+       'ni']
+
+.. function:: pformat(object, indent=1, width=80, depth=None, *, \
+                      compact=False, sort_dicts=True, underscore_numbers=False)
+
+   Return the formatted representation of *object* as a string.  *indent*,
+   *width*, *depth*, *compact*, *sort_dicts* and *underscore_numbers* are
+   passed to the :class:`PrettyPrinter` constructor as formatting parameters
+   and their meanings are as described in its documentation above.
+
+
+.. function:: isreadable(object)
+
+   .. index:: pair: built-in function; eval
+
+   Determine if the formatted representation of *object* is "readable", or can be
+   used to reconstruct the value using :func:`eval`.  This always returns ``False``
+   for recursive objects.
+
+      >>> pprint.isreadable(stuff)
+      False
+
+
+.. function:: isrecursive(object)
+
+   Determine if *object* requires a recursive representation.  This function is
+   subject to the same limitations as noted in :func:`saferepr` below and may raise an
+   :exc:`RecursionError` if it fails to detect a recursive object.
+
+
+One more support function is also defined:
+
+.. function:: saferepr(object)
+
+   Return a string representation of *object*, protected against recursion in
+   some common data structures, namely instances of :class:`dict`, :class:`list`
+   and :class:`tuple` or subclasses whose ``__repr__`` has not been overridden.  If the
+   representation of object exposes a recursive entry, the recursive reference
+   will be represented as ``<Recursion on typename with id=number>``.  The
+   representation is not otherwise formatted.
+
+   >>> pprint.saferepr(stuff)
+   "[<Recursion on list with id=...>, 'spam', 'eggs', 'lumberjack', 'knights', 'ni']"
+
+.. _prettyprinter-objects:
+
+PrettyPrinter Objects
+---------------------
+
+This module defines one class:
 
 .. First the implementation class:
 
@@ -112,89 +200,6 @@ The :mod:`pprint` module defines one class:
       >>> pp.pprint(tup)
       ('spam', ('eggs', ('lumberjack', ('knights', ('ni', ('dead', (...)))))))
 
-.. function:: pformat(object, indent=1, width=80, depth=None, *, \
-                      compact=False, sort_dicts=True, underscore_numbers=False)
-
-   Return the formatted representation of *object* as a string.  *indent*,
-   *width*, *depth*, *compact*, *sort_dicts* and *underscore_numbers* are
-   passed to the :class:`PrettyPrinter` constructor as formatting parameters
-   and their meanings are as described in its documentation above.
-
-
-.. function:: pp(object, *args, sort_dicts=False, **kwargs)
-
-   Prints the formatted representation of *object* followed by a newline.
-   If *sort_dicts* is false (the default), dictionaries will be displayed with
-   their keys in insertion order, otherwise the dict keys will be sorted.
-   *args* and *kwargs* will be passed to :func:`pprint` as formatting
-   parameters.
-
-   .. versionadded:: 3.8
-
-
-.. function:: pprint(object, stream=None, indent=1, width=80, depth=None, *, \
-                     compact=False, sort_dicts=True, underscore_numbers=False)
-
-   Prints the formatted representation of *object* on *stream*, followed by a
-   newline.  If *stream* is ``None``, ``sys.stdout`` is used. This may be used
-   in the interactive interpreter instead of the :func:`print` function for
-   inspecting values (you can even reassign ``print = pprint.pprint`` for use
-   within a scope).
-
-   The configuration parameters *stream*, *indent*, *width*, *depth*,
-   *compact*, *sort_dicts* and *underscore_numbers* are passed to the
-   :class:`PrettyPrinter` constructor and their meanings are as
-   described in its documentation above.
-
-      >>> import pprint
-      >>> stuff = ['spam', 'eggs', 'lumberjack', 'knights', 'ni']
-      >>> stuff.insert(0, stuff)
-      >>> pprint.pprint(stuff)
-      [<Recursion on list with id=...>,
-       'spam',
-       'eggs',
-       'lumberjack',
-       'knights',
-       'ni']
-
-.. function:: isreadable(object)
-
-   .. index:: pair: built-in function; eval
-
-   Determine if the formatted representation of *object* is "readable", or can be
-   used to reconstruct the value using :func:`eval`.  This always returns ``False``
-   for recursive objects.
-
-      >>> pprint.isreadable(stuff)
-      False
-
-
-.. function:: isrecursive(object)
-
-   Determine if *object* requires a recursive representation.  This function is
-   subject to the same limitations as noted in :func:`saferepr` below and may raise an
-   :exc:`RecursionError` if it fails to detect a recursive object.
-
-
-One more support function is also defined:
-
-.. function:: saferepr(object)
-
-   Return a string representation of *object*, protected against recursion in
-   some common data structures, namely instances of :class:`dict`, :class:`list`
-   and :class:`tuple` or subclasses whose ``__repr__`` has not been overridden.  If the
-   representation of object exposes a recursive entry, the recursive reference
-   will be represented as ``<Recursion on typename with id=number>``.  The
-   representation is not otherwise formatted.
-
-   >>> pprint.saferepr(stuff)
-   "[<Recursion on list with id=...>, 'spam', 'eggs', 'lumberjack', 'knights', 'ni']"
-
-
-.. _prettyprinter-objects:
-
-PrettyPrinter Objects
----------------------
 
 :class:`PrettyPrinter` instances have the following methods:
 

--- a/Doc/library/pprint.rst
+++ b/Doc/library/pprint.rst
@@ -62,7 +62,7 @@ Functions
    described in its documentation above.
 
    Note that *sort_dicts* default value is true, which might be an unintuitive
-   behavior; you will most likely want to use the :func:`print.pp` function
+   behavior; you will most likely want to use the :func:`pprint.pp` function
    or set this parameter to ``False``.
 
       >>> import pprint

--- a/Doc/library/pprint.rst
+++ b/Doc/library/pprint.rst
@@ -61,6 +61,10 @@ Functions
    :class:`PrettyPrinter` constructor and their meanings are as
    described in its documentation above.
 
+   Note that *sort_dicts* default value is true, which might be an unintuitive
+   behavior; you will most likely want to use the :func:`print.pp` function
+   or set this parameter to ``False``.
+
       >>> import pprint
       >>> stuff = ['spam', 'eggs', 'lumberjack', 'knights', 'ni']
       >>> stuff.insert(0, stuff)


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
I decided to separate the solution in 2 PRs. One PR is for fixing positions, references and including information that `pprint.pprint` function is unintuitive. And the other one would include setting up `pp` as default.

At first I thought that message about `pprint.pprint` being unintuitive might be divisive/hard to write, but later I figured out that it's a small change and fits current PR. Examples with `pprint.pp` might be divisive though, so once this PR is accepted, another PR is going to be introduced with the change.

<!-- gh-issue-number: gh-115986 -->
* Issue: gh-115986
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--116019.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->