### PR TITLE
gh-116057: Use relative recursion limits when testing `os.walk` and `Path.walk`

### DIFF
--- a/Lib/test/test_os.py
+++ b/Lib/test/test_os.py
@@ -34,7 +34,7 @@ from test import support
 from test.support import import_helper
 from test.support import os_helper
 from test.support import socket_helper
-from test.support import set_recursion_limit
+from test.support import infinite_recursion
 from test.support import warnings_helper
 from platform import win32_is_iot
 
@@ -1496,7 +1496,7 @@ class WalkTests(unittest.TestCase):
     def test_walk_above_recursion_limit(self):
         depth = 50
         os.makedirs(os.path.join(self.walk_path, *(['d'] * depth)))
-        with set_recursion_limit(depth - 5):
+        with infinite_recursion(depth - 5):
             all = list(self.walk(self.walk_path))
 
         sub2_path = self.sub2_tree[0]

--- a/Lib/test/test_pathlib/test_pathlib.py
+++ b/Lib/test/test_pathlib/test_pathlib.py
@@ -15,7 +15,7 @@ from urllib.request import pathname2url
 
 from test.support import import_helper
 from test.support import is_emscripten, is_wasi
-from test.support import set_recursion_limit
+from test.support import infinite_recursion
 from test.support import os_helper
 from test.support.os_helper import TESTFN, FakePath
 from test.test_pathlib import test_pathlib_abc
@@ -1199,7 +1199,7 @@ class PathTest(test_pathlib_abc.DummyPathTest, PurePathTest):
         path = base.joinpath(*(['d'] * directory_depth))
         path.mkdir(parents=True)
 
-        with set_recursion_limit(recursion_limit):
+        with infinite_recursion(recursion_limit):
             list(base.walk())
             list(base.walk(top_down=False))
 
@@ -1239,7 +1239,7 @@ class PathTest(test_pathlib_abc.DummyPathTest, PurePathTest):
         path = base.joinpath(*(['d'] * directory_depth))
         path.mkdir(parents=True)
 
-        with set_recursion_limit(recursion_limit):
+        with infinite_recursion(recursion_limit):
             list(base.glob('**/'))
 
     def test_glob_pathlike(self):

--- a/Misc/NEWS.d/next/Tests/2024-02-28-17-48-47.gh-issue-116057.Fl-YG8.rst
+++ b/Misc/NEWS.d/next/Tests/2024-02-28-17-48-47.gh-issue-116057.Fl-YG8.rst
@@ -1,1 +1,0 @@
-Use relative recursion limits when testing ``os.walk`` and ``Path.walk``.

--- a/Misc/NEWS.d/next/Tests/2024-02-28-17-48-47.gh-issue-116057.Fl-YG8.rst
+++ b/Misc/NEWS.d/next/Tests/2024-02-28-17-48-47.gh-issue-116057.Fl-YG8.rst
@@ -1,0 +1,1 @@
+Use relative recursion limits when testing ``os.walk`` and ``Path.walk``.


### PR DESCRIPTION

<!-- gh-issue-number: gh-116057 -->
* Fixes gh-116057
<!-- /gh-issue-number -->
