### PR TITLE
gh-115859: Re-enable T2 optimizer pass by default

### DIFF
--- a/Include/internal/pycore_optimizer.h
+++ b/Include/internal/pycore_optimizer.h
@@ -95,6 +95,8 @@ extern void _Py_uop_sym_set_null(_Py_UopsSymbol *sym);
 extern void _Py_uop_sym_set_non_null(_Py_UopsSymbol *sym);
 extern void _Py_uop_sym_set_type(_Py_UopsSymbol *sym, PyTypeObject *typ);
 extern void _Py_uop_sym_set_const(_Py_UopsSymbol *sym, PyObject *const_val);
+extern bool _Py_uop_sym_is_bottom(_Py_UopsSymbol *sym);
+
 
 extern int _Py_uop_abstractcontext_init(_Py_UOpsContext *ctx);
 extern void _Py_uop_abstractcontext_fini(_Py_UOpsContext *ctx);

--- a/Lib/test/test_capi/test_opt.py
+++ b/Lib/test/test_capi/test_opt.py
@@ -890,5 +890,20 @@ class TestUopsOptimization(unittest.TestCase):
         self.assertLessEqual(len(guard_both_float_count), 1)
         self.assertIn("_COMPARE_OP_STR", uops)
 
+    def test_type_inconsistency(self):
+        def testfunc(n):
+            for i in range(n):
+                x = _test_global + _test_global
+        # Must be a real global else it won't be optimized to _LOAD_CONST_INLINE
+        global _test_global
+        _test_global = 0
+        _, ex = self._run_with_optimizer(testfunc, 16)
+        self.assertIsNone(ex)
+        _test_global = 1.2
+        _, ex = self._run_with_optimizer(testfunc, 16)
+        self.assertIsNotNone(ex)
+        self.assertIn("_BINARY_OP_ADD_INT", get_opnames(ex))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/Lib/test/test_capi/test_opt.py
+++ b/Lib/test/test_capi/test_opt.py
@@ -902,7 +902,9 @@ class TestUopsOptimization(unittest.TestCase):
         _test_global = 1.2
         _, ex = self._run_with_optimizer(testfunc, 16)
         self.assertIsNotNone(ex)
-        self.assertIn("_BINARY_OP_ADD_INT", get_opnames(ex))
+        uops = get_opnames(ex)
+        self.assertIn("_GUARD_BOTH_INT", uops)
+        self.assertIn("_BINARY_OP_ADD_INT", uops)
 
 
 if __name__ == "__main__":

--- a/Lib/test/test_capi/test_opt.py
+++ b/Lib/test/test_capi/test_opt.py
@@ -210,6 +210,8 @@ class TestExecutorInvalidation(unittest.TestCase):
         exe = get_first_executor(f)
         self.assertIsNone(exe)
 
+
+@unittest.skipIf(os.getenv("PYTHON_UOPS_OPTIMIZE") == "0", "Needs uop optimizer to run.")
 class TestUops(unittest.TestCase):
 
     def test_basic_loop(self):
@@ -570,7 +572,7 @@ class TestUops(unittest.TestCase):
         self.assertLessEqual(count, 2)
 
 
-@unittest.skipIf(os.getenv("PYTHONUOPSOPTIMIZE", default=0) == 0, "Needs uop optimizer to run.")
+@unittest.skipIf(os.getenv("PYTHON_UOPS_OPTIMIZE") == "0", "Needs uop optimizer to run.")
 class TestUopsOptimization(unittest.TestCase):
 
     def _run_with_optimizer(self, testfunc, arg):

--- a/Python/optimizer.c
+++ b/Python/optimizer.c
@@ -1008,8 +1008,8 @@ uop_optimize(
         return err;
     }
     OPT_STAT_INC(traces_created);
-    char *uop_optimize = Py_GETENV("PYTHONUOPSOPTIMIZE");
-    if (uop_optimize == NULL || *uop_optimize > '0') {
+    char *env_var = Py_GETENV("PYTHON_UOPS_OPTIMIZE");
+    if (env_var == NULL || *env_var == '\0' || *env_var > '0') {
         err = _Py_uop_analyze_and_optimize(frame, buffer,
                                            UOP_MAX_TRACE_LENGTH,
                                            curr_stackentries, &dependencies);

--- a/Python/optimizer_analysis.c
+++ b/Python/optimizer_analysis.c
@@ -511,12 +511,9 @@ _Py_uop_analyze_and_optimize(
 
     peephole_opt(frame, buffer, buffer_size);
 
-    char *uop_optimize = Py_GETENV("PYTHONUOPSOPTIMIZE");
-    if (uop_optimize != NULL && *uop_optimize > '0') {
-        err = optimize_uops(
-            (PyCodeObject *)frame->f_executable, buffer,
-            buffer_size, curr_stacklen, dependencies);
-    }
+    err = optimize_uops(
+        (PyCodeObject *)frame->f_executable, buffer,
+        buffer_size, curr_stacklen, dependencies);
 
     if (err == 0) {
         goto not_ready;

--- a/Python/optimizer_analysis.c
+++ b/Python/optimizer_analysis.c
@@ -297,6 +297,7 @@ remove_globals(_PyInterpreterFrame *frame, _PyUOpInstruction *buffer,
 #define sym_set_non_null _Py_uop_sym_set_non_null
 #define sym_set_type _Py_uop_sym_set_type
 #define sym_set_const _Py_uop_sym_set_const
+#define sym_is_bottom _Py_uop_sym_is_bottom
 #define frame_new _Py_uop_frame_new
 #define frame_pop _Py_uop_frame_pop
 

--- a/Python/optimizer_bytecodes.c
+++ b/Python/optimizer_bytecodes.c
@@ -108,7 +108,9 @@ dummy_func(void) {
     }
 
     op(_BINARY_OP_ADD_INT, (left, right -- res)) {
-        if (sym_is_const(left) && sym_is_const(right)) {
+        if (sym_is_const(left) && sym_is_const(right) &&
+            sym_matches_type(left, &PyLong_Type) && sym_matches_type(right, &PyLong_Type))
+        {
             assert(PyLong_CheckExact(sym_get_const(left)));
             assert(PyLong_CheckExact(sym_get_const(right)));
             PyObject *temp = _PyLong_Add((PyLongObject *)sym_get_const(left),
@@ -127,7 +129,9 @@ dummy_func(void) {
     }
 
     op(_BINARY_OP_SUBTRACT_INT, (left, right -- res)) {
-        if (sym_is_const(left) && sym_is_const(right)) {
+        if (sym_is_const(left) && sym_is_const(right) &&
+            sym_matches_type(left, &PyLong_Type) && sym_matches_type(right, &PyLong_Type))
+        {
             assert(PyLong_CheckExact(sym_get_const(left)));
             assert(PyLong_CheckExact(sym_get_const(right)));
             PyObject *temp = _PyLong_Subtract((PyLongObject *)sym_get_const(left),
@@ -146,7 +150,9 @@ dummy_func(void) {
     }
 
     op(_BINARY_OP_MULTIPLY_INT, (left, right -- res)) {
-        if (sym_is_const(left) && sym_is_const(right)) {
+        if (sym_is_const(left) && sym_is_const(right) &&
+            sym_matches_type(left, &PyLong_Type) && sym_matches_type(right, &PyLong_Type))
+        {
             assert(PyLong_CheckExact(sym_get_const(left)));
             assert(PyLong_CheckExact(sym_get_const(right)));
             PyObject *temp = _PyLong_Multiply((PyLongObject *)sym_get_const(left),
@@ -165,7 +171,9 @@ dummy_func(void) {
     }
 
     op(_BINARY_OP_ADD_FLOAT, (left, right -- res)) {
-        if (sym_is_const(left) && sym_is_const(right)) {
+        if (sym_is_const(left) && sym_is_const(right) &&
+            sym_matches_type(left, &PyFloat_Type) && sym_matches_type(right, &PyFloat_Type))
+        {
             assert(PyFloat_CheckExact(sym_get_const(left)));
             assert(PyFloat_CheckExact(sym_get_const(right)));
             PyObject *temp = PyFloat_FromDouble(
@@ -185,7 +193,9 @@ dummy_func(void) {
     }
 
     op(_BINARY_OP_SUBTRACT_FLOAT, (left, right -- res)) {
-        if (sym_is_const(left) && sym_is_const(right)) {
+        if (sym_is_const(left) && sym_is_const(right) &&
+            sym_matches_type(left, &PyFloat_Type) && sym_matches_type(right, &PyFloat_Type))
+        {
             assert(PyFloat_CheckExact(sym_get_const(left)));
             assert(PyFloat_CheckExact(sym_get_const(right)));
             PyObject *temp = PyFloat_FromDouble(
@@ -205,7 +215,9 @@ dummy_func(void) {
     }
 
     op(_BINARY_OP_MULTIPLY_FLOAT, (left, right -- res)) {
-        if (sym_is_const(left) && sym_is_const(right)) {
+        if (sym_is_const(left) && sym_is_const(right) &&
+            sym_matches_type(left, &PyFloat_Type) && sym_matches_type(right, &PyFloat_Type))
+        {
             assert(PyFloat_CheckExact(sym_get_const(left)));
             assert(PyFloat_CheckExact(sym_get_const(right)));
             PyObject *temp = PyFloat_FromDouble(

--- a/Python/optimizer_bytecodes.c
+++ b/Python/optimizer_bytecodes.c
@@ -25,6 +25,7 @@ typedef struct _Py_UOpsAbstractFrame _Py_UOpsAbstractFrame;
 #define sym_set_non_null _Py_uop_sym_set_non_null
 #define sym_set_type _Py_uop_sym_set_type
 #define sym_set_const _Py_uop_sym_set_const
+#define sym_is_bottom _Py_uop_sym_is_bottom
 #define frame_new _Py_uop_frame_new
 #define frame_pop _Py_uop_frame_pop
 

--- a/Python/optimizer_bytecodes.c
+++ b/Python/optimizer_bytecodes.c
@@ -119,6 +119,7 @@ dummy_func(void) {
             OUT_OF_SPACE_IF_NULL(res = sym_new_const(ctx, temp));
             // TODO gh-115506:
             // replace opcode with constant propagated one and add tests!
+            Py_DECREF(temp);
         }
         else {
             OUT_OF_SPACE_IF_NULL(res = sym_new_type(ctx, &PyLong_Type));
@@ -137,6 +138,7 @@ dummy_func(void) {
             OUT_OF_SPACE_IF_NULL(res = sym_new_const(ctx, temp));
             // TODO gh-115506:
             // replace opcode with constant propagated one and add tests!
+            Py_DECREF(temp);
         }
         else {
             OUT_OF_SPACE_IF_NULL(res = sym_new_type(ctx, &PyLong_Type));
@@ -155,6 +157,7 @@ dummy_func(void) {
             OUT_OF_SPACE_IF_NULL(res = sym_new_const(ctx, temp));
             // TODO gh-115506:
             // replace opcode with constant propagated one and add tests!
+            Py_DECREF(temp);
         }
         else {
             OUT_OF_SPACE_IF_NULL(res = sym_new_type(ctx, &PyLong_Type));
@@ -171,9 +174,10 @@ dummy_func(void) {
             if (temp == NULL) {
                 goto error;
             }
-            res = sym_new_const(ctx, temp);
+            OUT_OF_SPACE_IF_NULL(res = sym_new_const(ctx, temp));
             // TODO gh-115506:
             // replace opcode with constant propagated one and update tests!
+            Py_DECREF(temp);
         }
         else {
             OUT_OF_SPACE_IF_NULL(res = sym_new_type(ctx, &PyFloat_Type));
@@ -190,9 +194,10 @@ dummy_func(void) {
             if (temp == NULL) {
                 goto error;
             }
-            res = sym_new_const(ctx, temp);
+            OUT_OF_SPACE_IF_NULL(res = sym_new_const(ctx, temp));
             // TODO gh-115506:
             // replace opcode with constant propagated one and update tests!
+            Py_DECREF(temp);
         }
         else {
             OUT_OF_SPACE_IF_NULL(res = sym_new_type(ctx, &PyFloat_Type));
@@ -209,9 +214,10 @@ dummy_func(void) {
             if (temp == NULL) {
                 goto error;
             }
-            res = sym_new_const(ctx, temp);
+            OUT_OF_SPACE_IF_NULL(res = sym_new_const(ctx, temp));
             // TODO gh-115506:
             // replace opcode with constant propagated one and update tests!
+            Py_DECREF(temp);
         }
         else {
             OUT_OF_SPACE_IF_NULL(res = sym_new_type(ctx, &PyFloat_Type));

--- a/Python/optimizer_bytecodes.c
+++ b/Python/optimizer_bytecodes.c
@@ -118,10 +118,11 @@ dummy_func(void) {
             if (temp == NULL) {
                 goto error;
             }
-            OUT_OF_SPACE_IF_NULL(res = sym_new_const(ctx, temp));
+            res = sym_new_const(ctx, temp);
+            Py_DECREF(temp);
+            OUT_OF_SPACE_IF_NULL(res);
             // TODO gh-115506:
             // replace opcode with constant propagated one and add tests!
-            Py_DECREF(temp);
         }
         else {
             OUT_OF_SPACE_IF_NULL(res = sym_new_type(ctx, &PyLong_Type));
@@ -139,10 +140,11 @@ dummy_func(void) {
             if (temp == NULL) {
                 goto error;
             }
-            OUT_OF_SPACE_IF_NULL(res = sym_new_const(ctx, temp));
+            res = sym_new_const(ctx, temp);
+            Py_DECREF(temp);
+            OUT_OF_SPACE_IF_NULL(res);
             // TODO gh-115506:
             // replace opcode with constant propagated one and add tests!
-            Py_DECREF(temp);
         }
         else {
             OUT_OF_SPACE_IF_NULL(res = sym_new_type(ctx, &PyLong_Type));
@@ -160,10 +162,11 @@ dummy_func(void) {
             if (temp == NULL) {
                 goto error;
             }
-            OUT_OF_SPACE_IF_NULL(res = sym_new_const(ctx, temp));
+            res = sym_new_const(ctx, temp);
+            Py_DECREF(temp);
+            OUT_OF_SPACE_IF_NULL(res);
             // TODO gh-115506:
             // replace opcode with constant propagated one and add tests!
-            Py_DECREF(temp);
         }
         else {
             OUT_OF_SPACE_IF_NULL(res = sym_new_type(ctx, &PyLong_Type));
@@ -182,10 +185,11 @@ dummy_func(void) {
             if (temp == NULL) {
                 goto error;
             }
-            OUT_OF_SPACE_IF_NULL(res = sym_new_const(ctx, temp));
+            res = sym_new_const(ctx, temp);
+            Py_DECREF(temp);
+            OUT_OF_SPACE_IF_NULL(res);
             // TODO gh-115506:
             // replace opcode with constant propagated one and update tests!
-            Py_DECREF(temp);
         }
         else {
             OUT_OF_SPACE_IF_NULL(res = sym_new_type(ctx, &PyFloat_Type));
@@ -204,10 +208,11 @@ dummy_func(void) {
             if (temp == NULL) {
                 goto error;
             }
-            OUT_OF_SPACE_IF_NULL(res = sym_new_const(ctx, temp));
+            res = sym_new_const(ctx, temp);
+            Py_DECREF(temp);
+            OUT_OF_SPACE_IF_NULL(res);
             // TODO gh-115506:
             // replace opcode with constant propagated one and update tests!
-            Py_DECREF(temp);
         }
         else {
             OUT_OF_SPACE_IF_NULL(res = sym_new_type(ctx, &PyFloat_Type));
@@ -226,10 +231,11 @@ dummy_func(void) {
             if (temp == NULL) {
                 goto error;
             }
-            OUT_OF_SPACE_IF_NULL(res = sym_new_const(ctx, temp));
+            res = sym_new_const(ctx, temp);
+            Py_DECREF(temp);
+            OUT_OF_SPACE_IF_NULL(res);
             // TODO gh-115506:
             // replace opcode with constant propagated one and update tests!
-            Py_DECREF(temp);
         }
         else {
             OUT_OF_SPACE_IF_NULL(res = sym_new_type(ctx, &PyFloat_Type));

--- a/Python/optimizer_cases.c.h
+++ b/Python/optimizer_cases.c.h
@@ -183,7 +183,9 @@
             _Py_UopsSymbol *res;
             right = stack_pointer[-1];
             left = stack_pointer[-2];
-            if (sym_is_const(left) && sym_is_const(right)) {
+            if (sym_is_const(left) && sym_is_const(right) &&
+                sym_matches_type(left, &PyLong_Type) && sym_matches_type(right, &PyLong_Type))
+            {
                 assert(PyLong_CheckExact(sym_get_const(left)));
                 assert(PyLong_CheckExact(sym_get_const(right)));
                 PyObject *temp = _PyLong_Multiply((PyLongObject *)sym_get_const(left),
@@ -210,7 +212,9 @@
             _Py_UopsSymbol *res;
             right = stack_pointer[-1];
             left = stack_pointer[-2];
-            if (sym_is_const(left) && sym_is_const(right)) {
+            if (sym_is_const(left) && sym_is_const(right) &&
+                sym_matches_type(left, &PyLong_Type) && sym_matches_type(right, &PyLong_Type))
+            {
                 assert(PyLong_CheckExact(sym_get_const(left)));
                 assert(PyLong_CheckExact(sym_get_const(right)));
                 PyObject *temp = _PyLong_Add((PyLongObject *)sym_get_const(left),
@@ -237,7 +241,9 @@
             _Py_UopsSymbol *res;
             right = stack_pointer[-1];
             left = stack_pointer[-2];
-            if (sym_is_const(left) && sym_is_const(right)) {
+            if (sym_is_const(left) && sym_is_const(right) &&
+                sym_matches_type(left, &PyLong_Type) && sym_matches_type(right, &PyLong_Type))
+            {
                 assert(PyLong_CheckExact(sym_get_const(left)));
                 assert(PyLong_CheckExact(sym_get_const(right)));
                 PyObject *temp = _PyLong_Subtract((PyLongObject *)sym_get_const(left),
@@ -278,7 +284,9 @@
             _Py_UopsSymbol *res;
             right = stack_pointer[-1];
             left = stack_pointer[-2];
-            if (sym_is_const(left) && sym_is_const(right)) {
+            if (sym_is_const(left) && sym_is_const(right) &&
+                sym_matches_type(left, &PyFloat_Type) && sym_matches_type(right, &PyFloat_Type))
+            {
                 assert(PyFloat_CheckExact(sym_get_const(left)));
                 assert(PyFloat_CheckExact(sym_get_const(right)));
                 PyObject *temp = PyFloat_FromDouble(
@@ -306,7 +314,9 @@
             _Py_UopsSymbol *res;
             right = stack_pointer[-1];
             left = stack_pointer[-2];
-            if (sym_is_const(left) && sym_is_const(right)) {
+            if (sym_is_const(left) && sym_is_const(right) &&
+                sym_matches_type(left, &PyFloat_Type) && sym_matches_type(right, &PyFloat_Type))
+            {
                 assert(PyFloat_CheckExact(sym_get_const(left)));
                 assert(PyFloat_CheckExact(sym_get_const(right)));
                 PyObject *temp = PyFloat_FromDouble(
@@ -334,7 +344,9 @@
             _Py_UopsSymbol *res;
             right = stack_pointer[-1];
             left = stack_pointer[-2];
-            if (sym_is_const(left) && sym_is_const(right)) {
+            if (sym_is_const(left) && sym_is_const(right) &&
+                sym_matches_type(left, &PyFloat_Type) && sym_matches_type(right, &PyFloat_Type))
+            {
                 assert(PyFloat_CheckExact(sym_get_const(left)));
                 assert(PyFloat_CheckExact(sym_get_const(right)));
                 PyObject *temp = PyFloat_FromDouble(

--- a/Python/optimizer_cases.c.h
+++ b/Python/optimizer_cases.c.h
@@ -194,6 +194,7 @@
                 OUT_OF_SPACE_IF_NULL(res = sym_new_const(ctx, temp));
                 // TODO gh-115506:
                 // replace opcode with constant propagated one and add tests!
+                Py_DECREF(temp);
             }
             else {
                 OUT_OF_SPACE_IF_NULL(res = sym_new_type(ctx, &PyLong_Type));
@@ -220,6 +221,7 @@
                 OUT_OF_SPACE_IF_NULL(res = sym_new_const(ctx, temp));
                 // TODO gh-115506:
                 // replace opcode with constant propagated one and add tests!
+                Py_DECREF(temp);
             }
             else {
                 OUT_OF_SPACE_IF_NULL(res = sym_new_type(ctx, &PyLong_Type));
@@ -246,6 +248,7 @@
                 OUT_OF_SPACE_IF_NULL(res = sym_new_const(ctx, temp));
                 // TODO gh-115506:
                 // replace opcode with constant propagated one and add tests!
+                Py_DECREF(temp);
             }
             else {
                 OUT_OF_SPACE_IF_NULL(res = sym_new_type(ctx, &PyLong_Type));
@@ -284,9 +287,10 @@
                 if (temp == NULL) {
                     goto error;
                 }
-                res = sym_new_const(ctx, temp);
+                OUT_OF_SPACE_IF_NULL(res = sym_new_const(ctx, temp));
                 // TODO gh-115506:
                 // replace opcode with constant propagated one and update tests!
+                Py_DECREF(temp);
             }
             else {
                 OUT_OF_SPACE_IF_NULL(res = sym_new_type(ctx, &PyFloat_Type));
@@ -311,9 +315,10 @@
                 if (temp == NULL) {
                     goto error;
                 }
-                res = sym_new_const(ctx, temp);
+                OUT_OF_SPACE_IF_NULL(res = sym_new_const(ctx, temp));
                 // TODO gh-115506:
                 // replace opcode with constant propagated one and update tests!
+                Py_DECREF(temp);
             }
             else {
                 OUT_OF_SPACE_IF_NULL(res = sym_new_type(ctx, &PyFloat_Type));
@@ -338,9 +343,10 @@
                 if (temp == NULL) {
                     goto error;
                 }
-                res = sym_new_const(ctx, temp);
+                OUT_OF_SPACE_IF_NULL(res = sym_new_const(ctx, temp));
                 // TODO gh-115506:
                 // replace opcode with constant propagated one and update tests!
+                Py_DECREF(temp);
             }
             else {
                 OUT_OF_SPACE_IF_NULL(res = sym_new_type(ctx, &PyFloat_Type));

--- a/Python/optimizer_cases.c.h
+++ b/Python/optimizer_cases.c.h
@@ -193,10 +193,11 @@
                 if (temp == NULL) {
                     goto error;
                 }
-                OUT_OF_SPACE_IF_NULL(res = sym_new_const(ctx, temp));
+                res = sym_new_const(ctx, temp);
+                Py_DECREF(temp);
+                OUT_OF_SPACE_IF_NULL(res);
                 // TODO gh-115506:
                 // replace opcode with constant propagated one and add tests!
-                Py_DECREF(temp);
             }
             else {
                 OUT_OF_SPACE_IF_NULL(res = sym_new_type(ctx, &PyLong_Type));
@@ -222,10 +223,11 @@
                 if (temp == NULL) {
                     goto error;
                 }
-                OUT_OF_SPACE_IF_NULL(res = sym_new_const(ctx, temp));
+                res = sym_new_const(ctx, temp);
+                Py_DECREF(temp);
+                OUT_OF_SPACE_IF_NULL(res);
                 // TODO gh-115506:
                 // replace opcode with constant propagated one and add tests!
-                Py_DECREF(temp);
             }
             else {
                 OUT_OF_SPACE_IF_NULL(res = sym_new_type(ctx, &PyLong_Type));
@@ -251,10 +253,11 @@
                 if (temp == NULL) {
                     goto error;
                 }
-                OUT_OF_SPACE_IF_NULL(res = sym_new_const(ctx, temp));
+                res = sym_new_const(ctx, temp);
+                Py_DECREF(temp);
+                OUT_OF_SPACE_IF_NULL(res);
                 // TODO gh-115506:
                 // replace opcode with constant propagated one and add tests!
-                Py_DECREF(temp);
             }
             else {
                 OUT_OF_SPACE_IF_NULL(res = sym_new_type(ctx, &PyLong_Type));
@@ -295,10 +298,11 @@
                 if (temp == NULL) {
                     goto error;
                 }
-                OUT_OF_SPACE_IF_NULL(res = sym_new_const(ctx, temp));
+                res = sym_new_const(ctx, temp);
+                Py_DECREF(temp);
+                OUT_OF_SPACE_IF_NULL(res);
                 // TODO gh-115506:
                 // replace opcode with constant propagated one and update tests!
-                Py_DECREF(temp);
             }
             else {
                 OUT_OF_SPACE_IF_NULL(res = sym_new_type(ctx, &PyFloat_Type));
@@ -325,10 +329,11 @@
                 if (temp == NULL) {
                     goto error;
                 }
-                OUT_OF_SPACE_IF_NULL(res = sym_new_const(ctx, temp));
+                res = sym_new_const(ctx, temp);
+                Py_DECREF(temp);
+                OUT_OF_SPACE_IF_NULL(res);
                 // TODO gh-115506:
                 // replace opcode with constant propagated one and update tests!
-                Py_DECREF(temp);
             }
             else {
                 OUT_OF_SPACE_IF_NULL(res = sym_new_type(ctx, &PyFloat_Type));
@@ -355,10 +360,11 @@
                 if (temp == NULL) {
                     goto error;
                 }
-                OUT_OF_SPACE_IF_NULL(res = sym_new_const(ctx, temp));
+                res = sym_new_const(ctx, temp);
+                Py_DECREF(temp);
+                OUT_OF_SPACE_IF_NULL(res);
                 // TODO gh-115506:
                 // replace opcode with constant propagated one and update tests!
-                Py_DECREF(temp);
             }
             else {
                 OUT_OF_SPACE_IF_NULL(res = sym_new_type(ctx, &PyFloat_Type));

--- a/Python/optimizer_symbols.c
+++ b/Python/optimizer_symbols.c
@@ -77,7 +77,7 @@ sym_set_bottom(_Py_UopsSymbol *sym)
     Py_CLEAR(sym->const_val);
 }
 
-static inline bool
+bool
 _Py_uop_sym_is_bottom(_Py_UopsSymbol *sym)
 {
     if ((sym->flags & IS_NULL) && (sym->flags & NOT_NULL)) {


### PR DESCRIPTION
This undoes the *temporary* default disabling of the T2 optimizer pass in gh-115860.

- Add a new test that reproduces Brandt's example from gh-115859; it indeed crashes before gh-116028 with PYTHONUOPSOPTIMIZE=1
- Re-enable the optimizer pass in T2, stop checking PYTHONUOPSOPTIMIZE
- Rename the env var to disable T2 entirely to PYTHON_UOPS_OPTIMIZE (must be explicitly set to 0 to disable)
- Fix skipIf conditions on tests in test_opt.py accordingly
- Export sym_is_bottom() (for debugging)
- Fix various things in the `_BINARY_OP_` specializations in the abstract interpreter:
  - DECREF(temp)
  - out-of-space check after sym_new_const()
  - add sym_matches_type() checks, so even if we somehow reach a binary op with symbolic constants of the wrong type on the stack we won't trigger the type assert

@Fidget-Spinner Please review when you get up. :-)

Fixes gh-115859.