### PR TITLE
gh-115816: Generate calls to sym_new_const() etc. without _Py_uop prefix

### DIFF
--- a/Lib/test/test_generated_cases.py
+++ b/Lib/test/test_generated_cases.py
@@ -900,7 +900,7 @@ class TestGeneratedAbstractCases(unittest.TestCase):
 
         case OP2: {
             _Py_UopsSymbol *out;
-            out = _Py_uop_sym_new_unknown(ctx);
+            out = sym_new_unknown(ctx);
             if (out == NULL) goto out_of_space;
             stack_pointer[-1] = out;
             break;
@@ -925,7 +925,7 @@ class TestGeneratedAbstractCases(unittest.TestCase):
         output = """
         case OP: {
             _Py_UopsSymbol *out;
-            out = _Py_uop_sym_new_unknown(ctx);
+            out = sym_new_unknown(ctx);
             if (out == NULL) goto out_of_space;
             stack_pointer[-1] = out;
             break;

--- a/Python/optimizer_cases.c.h
+++ b/Python/optimizer_cases.c.h
@@ -80,7 +80,7 @@
 
         case _END_SEND: {
             _Py_UopsSymbol *value;
-            value = _Py_uop_sym_new_unknown(ctx);
+            value = sym_new_unknown(ctx);
             if (value == NULL) goto out_of_space;
             stack_pointer[-2] = value;
             stack_pointer += -1;
@@ -89,7 +89,7 @@
 
         case _UNARY_NEGATIVE: {
             _Py_UopsSymbol *res;
-            res = _Py_uop_sym_new_unknown(ctx);
+            res = sym_new_unknown(ctx);
             if (res == NULL) goto out_of_space;
             stack_pointer[-1] = res;
             break;
@@ -97,7 +97,7 @@
 
         case _UNARY_NOT: {
             _Py_UopsSymbol *res;
-            res = _Py_uop_sym_new_unknown(ctx);
+            res = sym_new_unknown(ctx);
             if (res == NULL) goto out_of_space;
             stack_pointer[-1] = res;
             break;
@@ -105,7 +105,7 @@
 
         case _TO_BOOL: {
             _Py_UopsSymbol *res;
-            res = _Py_uop_sym_new_unknown(ctx);
+            res = sym_new_unknown(ctx);
             if (res == NULL) goto out_of_space;
             stack_pointer[-1] = res;
             break;
@@ -117,7 +117,7 @@
 
         case _TO_BOOL_INT: {
             _Py_UopsSymbol *res;
-            res = _Py_uop_sym_new_unknown(ctx);
+            res = sym_new_unknown(ctx);
             if (res == NULL) goto out_of_space;
             stack_pointer[-1] = res;
             break;
@@ -125,7 +125,7 @@
 
         case _TO_BOOL_LIST: {
             _Py_UopsSymbol *res;
-            res = _Py_uop_sym_new_unknown(ctx);
+            res = sym_new_unknown(ctx);
             if (res == NULL) goto out_of_space;
             stack_pointer[-1] = res;
             break;
@@ -133,7 +133,7 @@
 
         case _TO_BOOL_NONE: {
             _Py_UopsSymbol *res;
-            res = _Py_uop_sym_new_unknown(ctx);
+            res = sym_new_unknown(ctx);
             if (res == NULL) goto out_of_space;
             stack_pointer[-1] = res;
             break;
@@ -141,7 +141,7 @@
 
         case _TO_BOOL_STR: {
             _Py_UopsSymbol *res;
-            res = _Py_uop_sym_new_unknown(ctx);
+            res = sym_new_unknown(ctx);
             if (res == NULL) goto out_of_space;
             stack_pointer[-1] = res;
             break;
@@ -149,7 +149,7 @@
 
         case _TO_BOOL_ALWAYS_TRUE: {
             _Py_UopsSymbol *res;
-            res = _Py_uop_sym_new_unknown(ctx);
+            res = sym_new_unknown(ctx);
             if (res == NULL) goto out_of_space;
             stack_pointer[-1] = res;
             break;
@@ -157,7 +157,7 @@
 
         case _UNARY_INVERT: {
             _Py_UopsSymbol *res;
-            res = _Py_uop_sym_new_unknown(ctx);
+            res = sym_new_unknown(ctx);
             if (res == NULL) goto out_of_space;
             stack_pointer[-1] = res;
             break;
@@ -366,7 +366,7 @@
 
         case _BINARY_OP_ADD_UNICODE: {
             _Py_UopsSymbol *res;
-            res = _Py_uop_sym_new_unknown(ctx);
+            res = sym_new_unknown(ctx);
             if (res == NULL) goto out_of_space;
             stack_pointer[-2] = res;
             stack_pointer += -1;
@@ -375,7 +375,7 @@
 
         case _BINARY_SUBSCR: {
             _Py_UopsSymbol *res;
-            res = _Py_uop_sym_new_unknown(ctx);
+            res = sym_new_unknown(ctx);
             if (res == NULL) goto out_of_space;
             stack_pointer[-2] = res;
             stack_pointer += -1;
@@ -384,7 +384,7 @@
 
         case _BINARY_SLICE: {
             _Py_UopsSymbol *res;
-            res = _Py_uop_sym_new_unknown(ctx);
+            res = sym_new_unknown(ctx);
             if (res == NULL) goto out_of_space;
             stack_pointer[-3] = res;
             stack_pointer += -2;
@@ -398,7 +398,7 @@
 
         case _BINARY_SUBSCR_LIST_INT: {
             _Py_UopsSymbol *res;
-            res = _Py_uop_sym_new_unknown(ctx);
+            res = sym_new_unknown(ctx);
             if (res == NULL) goto out_of_space;
             stack_pointer[-2] = res;
             stack_pointer += -1;
@@ -407,7 +407,7 @@
 
         case _BINARY_SUBSCR_STR_INT: {
             _Py_UopsSymbol *res;
-            res = _Py_uop_sym_new_unknown(ctx);
+            res = sym_new_unknown(ctx);
             if (res == NULL) goto out_of_space;
             stack_pointer[-2] = res;
             stack_pointer += -1;
@@ -416,7 +416,7 @@
 
         case _BINARY_SUBSCR_TUPLE_INT: {
             _Py_UopsSymbol *res;
-            res = _Py_uop_sym_new_unknown(ctx);
+            res = sym_new_unknown(ctx);
             if (res == NULL) goto out_of_space;
             stack_pointer[-2] = res;
             stack_pointer += -1;
@@ -425,7 +425,7 @@
 
         case _BINARY_SUBSCR_DICT: {
             _Py_UopsSymbol *res;
-            res = _Py_uop_sym_new_unknown(ctx);
+            res = sym_new_unknown(ctx);
             if (res == NULL) goto out_of_space;
             stack_pointer[-2] = res;
             stack_pointer += -1;
@@ -466,7 +466,7 @@
 
         case _CALL_INTRINSIC_1: {
             _Py_UopsSymbol *res;
-            res = _Py_uop_sym_new_unknown(ctx);
+            res = sym_new_unknown(ctx);
             if (res == NULL) goto out_of_space;
             stack_pointer[-1] = res;
             break;
@@ -474,7 +474,7 @@
 
         case _CALL_INTRINSIC_2: {
             _Py_UopsSymbol *res;
-            res = _Py_uop_sym_new_unknown(ctx);
+            res = sym_new_unknown(ctx);
             if (res == NULL) goto out_of_space;
             stack_pointer[-2] = res;
             stack_pointer += -1;
@@ -501,7 +501,7 @@
 
         case _GET_AITER: {
             _Py_UopsSymbol *iter;
-            iter = _Py_uop_sym_new_unknown(ctx);
+            iter = sym_new_unknown(ctx);
             if (iter == NULL) goto out_of_space;
             stack_pointer[-1] = iter;
             break;
@@ -509,7 +509,7 @@
 
         case _GET_ANEXT: {
             _Py_UopsSymbol *awaitable;
-            awaitable = _Py_uop_sym_new_unknown(ctx);
+            awaitable = sym_new_unknown(ctx);
             if (awaitable == NULL) goto out_of_space;
             stack_pointer[0] = awaitable;
             stack_pointer += 1;
@@ -518,7 +518,7 @@
 
         case _GET_AWAITABLE: {
             _Py_UopsSymbol *iter;
-            iter = _Py_uop_sym_new_unknown(ctx);
+            iter = sym_new_unknown(ctx);
             if (iter == NULL) goto out_of_space;
             stack_pointer[-1] = iter;
             break;
@@ -537,7 +537,7 @@
 
         case _LOAD_ASSERTION_ERROR: {
             _Py_UopsSymbol *value;
-            value = _Py_uop_sym_new_unknown(ctx);
+            value = sym_new_unknown(ctx);
             if (value == NULL) goto out_of_space;
             stack_pointer[0] = value;
             stack_pointer += 1;
@@ -546,7 +546,7 @@
 
         case _LOAD_BUILD_CLASS: {
             _Py_UopsSymbol *bc;
-            bc = _Py_uop_sym_new_unknown(ctx);
+            bc = sym_new_unknown(ctx);
             if (bc == NULL) goto out_of_space;
             stack_pointer[0] = bc;
             stack_pointer += 1;
@@ -580,7 +580,7 @@
             _Py_UopsSymbol **values;
             values = &stack_pointer[-1];
             for (int _i = oparg; --_i >= 0;) {
-                values[_i] = _Py_uop_sym_new_unknown(ctx);
+                values[_i] = sym_new_unknown(ctx);
                 if (values[_i] == NULL) goto out_of_space;
             }
             stack_pointer += -1 + oparg;
@@ -591,7 +591,7 @@
             _Py_UopsSymbol **values;
             values = &stack_pointer[-1];
             for (int _i = oparg; --_i >= 0;) {
-                values[_i] = _Py_uop_sym_new_unknown(ctx);
+                values[_i] = sym_new_unknown(ctx);
                 if (values[_i] == NULL) goto out_of_space;
             }
             stack_pointer += -1 + oparg;
@@ -602,7 +602,7 @@
             _Py_UopsSymbol **values;
             values = &stack_pointer[-1];
             for (int _i = oparg; --_i >= 0;) {
-                values[_i] = _Py_uop_sym_new_unknown(ctx);
+                values[_i] = sym_new_unknown(ctx);
                 if (values[_i] == NULL) goto out_of_space;
             }
             stack_pointer += -1 + oparg;
@@ -645,7 +645,7 @@
 
         case _LOAD_LOCALS: {
             _Py_UopsSymbol *locals;
-            locals = _Py_uop_sym_new_unknown(ctx);
+            locals = sym_new_unknown(ctx);
             if (locals == NULL) goto out_of_space;
             stack_pointer[0] = locals;
             stack_pointer += 1;
@@ -654,7 +654,7 @@
 
         case _LOAD_FROM_DICT_OR_GLOBALS: {
             _Py_UopsSymbol *v;
-            v = _Py_uop_sym_new_unknown(ctx);
+            v = sym_new_unknown(ctx);
             if (v == NULL) goto out_of_space;
             stack_pointer[-1] = v;
             break;
@@ -662,7 +662,7 @@
 
         case _LOAD_NAME: {
             _Py_UopsSymbol *v;
-            v = _Py_uop_sym_new_unknown(ctx);
+            v = sym_new_unknown(ctx);
             if (v == NULL) goto out_of_space;
             stack_pointer[0] = v;
             stack_pointer += 1;
@@ -672,9 +672,9 @@
         case _LOAD_GLOBAL: {
             _Py_UopsSymbol *res;
             _Py_UopsSymbol *null = NULL;
-            res = _Py_uop_sym_new_unknown(ctx);
+            res = sym_new_unknown(ctx);
             if (res == NULL) goto out_of_space;
-            null = _Py_uop_sym_new_null(ctx);
+            null = sym_new_null(ctx);
             if (null == NULL) goto out_of_space;
             stack_pointer[0] = res;
             if (oparg & 1) stack_pointer[1] = null;
@@ -693,9 +693,9 @@
         case _LOAD_GLOBAL_MODULE: {
             _Py_UopsSymbol *res;
             _Py_UopsSymbol *null = NULL;
-            res = _Py_uop_sym_new_unknown(ctx);
+            res = sym_new_unknown(ctx);
             if (res == NULL) goto out_of_space;
-            null = _Py_uop_sym_new_null(ctx);
+            null = sym_new_null(ctx);
             if (null == NULL) goto out_of_space;
             stack_pointer[0] = res;
             if (oparg & 1) stack_pointer[1] = null;
@@ -706,9 +706,9 @@
         case _LOAD_GLOBAL_BUILTINS: {
             _Py_UopsSymbol *res;
             _Py_UopsSymbol *null = NULL;
-            res = _Py_uop_sym_new_unknown(ctx);
+            res = sym_new_unknown(ctx);
             if (res == NULL) goto out_of_space;
-            null = _Py_uop_sym_new_null(ctx);
+            null = sym_new_null(ctx);
             if (null == NULL) goto out_of_space;
             stack_pointer[0] = res;
             if (oparg & 1) stack_pointer[1] = null;
@@ -730,7 +730,7 @@
 
         case _LOAD_FROM_DICT_OR_DEREF: {
             _Py_UopsSymbol *value;
-            value = _Py_uop_sym_new_unknown(ctx);
+            value = sym_new_unknown(ctx);
             if (value == NULL) goto out_of_space;
             stack_pointer[-1] = value;
             break;
@@ -738,7 +738,7 @@
 
         case _LOAD_DEREF: {
             _Py_UopsSymbol *value;
-            value = _Py_uop_sym_new_unknown(ctx);
+            value = sym_new_unknown(ctx);
             if (value == NULL) goto out_of_space;
             stack_pointer[0] = value;
             stack_pointer += 1;
@@ -756,7 +756,7 @@
 
         case _BUILD_STRING: {
             _Py_UopsSymbol *str;
-            str = _Py_uop_sym_new_unknown(ctx);
+            str = sym_new_unknown(ctx);
             if (str == NULL) goto out_of_space;
             stack_pointer[-oparg] = str;
             stack_pointer += 1 - oparg;
@@ -765,7 +765,7 @@
 
         case _BUILD_TUPLE: {
             _Py_UopsSymbol *tup;
-            tup = _Py_uop_sym_new_unknown(ctx);
+            tup = sym_new_unknown(ctx);
             if (tup == NULL) goto out_of_space;
             stack_pointer[-oparg] = tup;
             stack_pointer += 1 - oparg;
@@ -774,7 +774,7 @@
 
         case _BUILD_LIST: {
             _Py_UopsSymbol *list;
-            list = _Py_uop_sym_new_unknown(ctx);
+            list = sym_new_unknown(ctx);
             if (list == NULL) goto out_of_space;
             stack_pointer[-oparg] = list;
             stack_pointer += 1 - oparg;
@@ -793,7 +793,7 @@
 
         case _BUILD_SET: {
             _Py_UopsSymbol *set;
-            set = _Py_uop_sym_new_unknown(ctx);
+            set = sym_new_unknown(ctx);
             if (set == NULL) goto out_of_space;
             stack_pointer[-oparg] = set;
             stack_pointer += 1 - oparg;
@@ -802,7 +802,7 @@
 
         case _BUILD_MAP: {
             _Py_UopsSymbol *map;
-            map = _Py_uop_sym_new_unknown(ctx);
+            map = sym_new_unknown(ctx);
             if (map == NULL) goto out_of_space;
             stack_pointer[-oparg*2] = map;
             stack_pointer += 1 - oparg*2;
@@ -815,7 +815,7 @@
 
         case _BUILD_CONST_KEY_MAP: {
             _Py_UopsSymbol *map;
-            map = _Py_uop_sym_new_unknown(ctx);
+            map = sym_new_unknown(ctx);
             if (map == NULL) goto out_of_space;
             stack_pointer[-1 - oparg] = map;
             stack_pointer += -oparg;
@@ -841,7 +841,7 @@
 
         case _LOAD_SUPER_ATTR_ATTR: {
             _Py_UopsSymbol *attr;
-            attr = _Py_uop_sym_new_unknown(ctx);
+            attr = sym_new_unknown(ctx);
             if (attr == NULL) goto out_of_space;
             stack_pointer[-3] = attr;
             stack_pointer += -2;
@@ -851,9 +851,9 @@
         case _LOAD_SUPER_ATTR_METHOD: {
             _Py_UopsSymbol *attr;
             _Py_UopsSymbol *self_or_null;
-            attr = _Py_uop_sym_new_unknown(ctx);
+            attr = sym_new_unknown(ctx);
             if (attr == NULL) goto out_of_space;
-            self_or_null = _Py_uop_sym_new_unknown(ctx);
+            self_or_null = sym_new_unknown(ctx);
             if (self_or_null == NULL) goto out_of_space;
             stack_pointer[-3] = attr;
             stack_pointer[-2] = self_or_null;
@@ -864,9 +864,9 @@
         case _LOAD_ATTR: {
             _Py_UopsSymbol *attr;
             _Py_UopsSymbol *self_or_null = NULL;
-            attr = _Py_uop_sym_new_unknown(ctx);
+            attr = sym_new_unknown(ctx);
             if (attr == NULL) goto out_of_space;
-            self_or_null = _Py_uop_sym_new_unknown(ctx);
+            self_or_null = sym_new_unknown(ctx);
             if (self_or_null == NULL) goto out_of_space;
             stack_pointer[-1] = attr;
             if (oparg & 1) stack_pointer[0] = self_or_null;
@@ -1024,7 +1024,7 @@
 
         case _COMPARE_OP: {
             _Py_UopsSymbol *res;
-            res = _Py_uop_sym_new_unknown(ctx);
+            res = sym_new_unknown(ctx);
             if (res == NULL) goto out_of_space;
             stack_pointer[-2] = res;
             stack_pointer += -1;
@@ -1033,7 +1033,7 @@
 
         case _COMPARE_OP_FLOAT: {
             _Py_UopsSymbol *res;
-            res = _Py_uop_sym_new_unknown(ctx);
+            res = sym_new_unknown(ctx);
             if (res == NULL) goto out_of_space;
             stack_pointer[-2] = res;
             stack_pointer += -1;
@@ -1042,7 +1042,7 @@
 
         case _COMPARE_OP_INT: {
             _Py_UopsSymbol *res;
-            res = _Py_uop_sym_new_unknown(ctx);
+            res = sym_new_unknown(ctx);
             if (res == NULL) goto out_of_space;
             stack_pointer[-2] = res;
             stack_pointer += -1;
@@ -1051,7 +1051,7 @@
 
         case _COMPARE_OP_STR: {
             _Py_UopsSymbol *res;
-            res = _Py_uop_sym_new_unknown(ctx);
+            res = sym_new_unknown(ctx);
             if (res == NULL) goto out_of_space;
             stack_pointer[-2] = res;
             stack_pointer += -1;
@@ -1060,7 +1060,7 @@
 
         case _IS_OP: {
             _Py_UopsSymbol *b;
-            b = _Py_uop_sym_new_unknown(ctx);
+            b = sym_new_unknown(ctx);
             if (b == NULL) goto out_of_space;
             stack_pointer[-2] = b;
             stack_pointer += -1;
@@ -1069,7 +1069,7 @@
 
         case _CONTAINS_OP: {
             _Py_UopsSymbol *b;
-            b = _Py_uop_sym_new_unknown(ctx);
+            b = sym_new_unknown(ctx);
             if (b == NULL) goto out_of_space;
             stack_pointer[-2] = b;
             stack_pointer += -1;
@@ -1079,9 +1079,9 @@
         case _CHECK_EG_MATCH: {
             _Py_UopsSymbol *rest;
             _Py_UopsSymbol *match;
-            rest = _Py_uop_sym_new_unknown(ctx);
+            rest = sym_new_unknown(ctx);
             if (rest == NULL) goto out_of_space;
-            match = _Py_uop_sym_new_unknown(ctx);
+            match = sym_new_unknown(ctx);
             if (match == NULL) goto out_of_space;
             stack_pointer[-2] = rest;
             stack_pointer[-1] = match;
@@ -1090,7 +1090,7 @@
 
         case _CHECK_EXC_MATCH: {
             _Py_UopsSymbol *b;
-            b = _Py_uop_sym_new_unknown(ctx);
+            b = sym_new_unknown(ctx);
             if (b == NULL) goto out_of_space;
             stack_pointer[-1] = b;
             break;
@@ -1102,7 +1102,7 @@
 
         case _IS_NONE: {
             _Py_UopsSymbol *b;
-            b = _Py_uop_sym_new_unknown(ctx);
+            b = sym_new_unknown(ctx);
             if (b == NULL) goto out_of_space;
             stack_pointer[-1] = b;
             break;
@@ -1110,7 +1110,7 @@
 
         case _GET_LEN: {
             _Py_UopsSymbol *len_o;
-            len_o = _Py_uop_sym_new_unknown(ctx);
+            len_o = sym_new_unknown(ctx);
             if (len_o == NULL) goto out_of_space;
             stack_pointer[0] = len_o;
             stack_pointer += 1;
@@ -1119,7 +1119,7 @@
 
         case _MATCH_CLASS: {
             _Py_UopsSymbol *attrs;
-            attrs = _Py_uop_sym_new_unknown(ctx);
+            attrs = sym_new_unknown(ctx);
             if (attrs == NULL) goto out_of_space;
             stack_pointer[-3] = attrs;
             stack_pointer += -2;
@@ -1128,7 +1128,7 @@
 
         case _MATCH_MAPPING: {
             _Py_UopsSymbol *res;
-            res = _Py_uop_sym_new_unknown(ctx);
+            res = sym_new_unknown(ctx);
             if (res == NULL) goto out_of_space;
             stack_pointer[0] = res;
             stack_pointer += 1;
@@ -1137,7 +1137,7 @@
 
         case _MATCH_SEQUENCE: {
             _Py_UopsSymbol *res;
-            res = _Py_uop_sym_new_unknown(ctx);
+            res = sym_new_unknown(ctx);
             if (res == NULL) goto out_of_space;
             stack_pointer[0] = res;
             stack_pointer += 1;
@@ -1146,7 +1146,7 @@
 
         case _MATCH_KEYS: {
             _Py_UopsSymbol *values_or_none;
-            values_or_none = _Py_uop_sym_new_unknown(ctx);
+            values_or_none = sym_new_unknown(ctx);
             if (values_or_none == NULL) goto out_of_space;
             stack_pointer[0] = values_or_none;
             stack_pointer += 1;
@@ -1155,7 +1155,7 @@
 
         case _GET_ITER: {
             _Py_UopsSymbol *iter;
-            iter = _Py_uop_sym_new_unknown(ctx);
+            iter = sym_new_unknown(ctx);
             if (iter == NULL) goto out_of_space;
             stack_pointer[-1] = iter;
             break;
@@ -1163,7 +1163,7 @@
 
         case _GET_YIELD_FROM_ITER: {
             _Py_UopsSymbol *iter;
-            iter = _Py_uop_sym_new_unknown(ctx);
+            iter = sym_new_unknown(ctx);
             if (iter == NULL) goto out_of_space;
             stack_pointer[-1] = iter;
             break;
@@ -1173,7 +1173,7 @@
 
         case _FOR_ITER_TIER_TWO: {
             _Py_UopsSymbol *next;
-            next = _Py_uop_sym_new_unknown(ctx);
+            next = sym_new_unknown(ctx);
             if (next == NULL) goto out_of_space;
             stack_pointer[0] = next;
             stack_pointer += 1;
@@ -1194,7 +1194,7 @@
 
         case _ITER_NEXT_LIST: {
             _Py_UopsSymbol *next;
-            next = _Py_uop_sym_new_unknown(ctx);
+            next = sym_new_unknown(ctx);
             if (next == NULL) goto out_of_space;
             stack_pointer[0] = next;
             stack_pointer += 1;
@@ -1213,7 +1213,7 @@
 
         case _ITER_NEXT_TUPLE: {
             _Py_UopsSymbol *next;
-            next = _Py_uop_sym_new_unknown(ctx);
+            next = sym_new_unknown(ctx);
             if (next == NULL) goto out_of_space;
             stack_pointer[0] = next;
             stack_pointer += 1;
@@ -1246,9 +1246,9 @@
         case _BEFORE_ASYNC_WITH: {
             _Py_UopsSymbol *exit;
             _Py_UopsSymbol *res;
-            exit = _Py_uop_sym_new_unknown(ctx);
+            exit = sym_new_unknown(ctx);
             if (exit == NULL) goto out_of_space;
-            res = _Py_uop_sym_new_unknown(ctx);
+            res = sym_new_unknown(ctx);
             if (res == NULL) goto out_of_space;
             stack_pointer[-1] = exit;
             stack_pointer[0] = res;
@@ -1259,9 +1259,9 @@
         case _BEFORE_WITH: {
             _Py_UopsSymbol *exit;
             _Py_UopsSymbol *res;
-            exit = _Py_uop_sym_new_unknown(ctx);
+            exit = sym_new_unknown(ctx);
             if (exit == NULL) goto out_of_space;
-            res = _Py_uop_sym_new_unknown(ctx);
+            res = sym_new_unknown(ctx);
             if (res == NULL) goto out_of_space;
             stack_pointer[-1] = exit;
             stack_pointer[0] = res;
@@ -1271,7 +1271,7 @@
 
         case _WITH_EXCEPT_START: {
             _Py_UopsSymbol *res;
-            res = _Py_uop_sym_new_unknown(ctx);
+            res = sym_new_unknown(ctx);
             if (res == NULL) goto out_of_space;
             stack_pointer[0] = res;
             stack_pointer += 1;
@@ -1281,9 +1281,9 @@
         case _PUSH_EXC_INFO: {
             _Py_UopsSymbol *prev_exc;
             _Py_UopsSymbol *new_exc;
-            prev_exc = _Py_uop_sym_new_unknown(ctx);
+            prev_exc = sym_new_unknown(ctx);
             if (prev_exc == NULL) goto out_of_space;
-            new_exc = _Py_uop_sym_new_unknown(ctx);
+            new_exc = sym_new_unknown(ctx);
             if (new_exc == NULL) goto out_of_space;
             stack_pointer[-1] = prev_exc;
             stack_pointer[0] = new_exc;
@@ -1331,7 +1331,7 @@
 
         case _LOAD_ATTR_NONDESCRIPTOR_WITH_VALUES: {
             _Py_UopsSymbol *attr;
-            attr = _Py_uop_sym_new_unknown(ctx);
+            attr = sym_new_unknown(ctx);
             if (attr == NULL) goto out_of_space;
             stack_pointer[-1] = attr;
             break;
@@ -1339,7 +1339,7 @@
 
         case _LOAD_ATTR_NONDESCRIPTOR_NO_DICT: {
             _Py_UopsSymbol *attr;
-            attr = _Py_uop_sym_new_unknown(ctx);
+            attr = sym_new_unknown(ctx);
             if (attr == NULL) goto out_of_space;
             stack_pointer[-1] = attr;
             break;
@@ -1464,7 +1464,7 @@
 
         case _CALL_TYPE_1: {
             _Py_UopsSymbol *res;
-            res = _Py_uop_sym_new_unknown(ctx);
+            res = sym_new_unknown(ctx);
             if (res == NULL) goto out_of_space;
             stack_pointer[-2 - oparg] = res;
             stack_pointer += -1 - oparg;
@@ -1473,7 +1473,7 @@
 
         case _CALL_STR_1: {
             _Py_UopsSymbol *res;
-            res = _Py_uop_sym_new_unknown(ctx);
+            res = sym_new_unknown(ctx);
             if (res == NULL) goto out_of_space;
             stack_pointer[-2 - oparg] = res;
             stack_pointer += -1 - oparg;
@@ -1482,7 +1482,7 @@
 
         case _CALL_TUPLE_1: {
             _Py_UopsSymbol *res;
-            res = _Py_uop_sym_new_unknown(ctx);
+            res = sym_new_unknown(ctx);
             if (res == NULL) goto out_of_space;
             stack_pointer[-2 - oparg] = res;
             stack_pointer += -1 - oparg;
@@ -1498,7 +1498,7 @@
 
         case _CALL_BUILTIN_CLASS: {
             _Py_UopsSymbol *res;
-            res = _Py_uop_sym_new_unknown(ctx);
+            res = sym_new_unknown(ctx);
             if (res == NULL) goto out_of_space;
             stack_pointer[-2 - oparg] = res;
             stack_pointer += -1 - oparg;
@@ -1507,7 +1507,7 @@
 
         case _CALL_BUILTIN_O: {
             _Py_UopsSymbol *res;
-            res = _Py_uop_sym_new_unknown(ctx);
+            res = sym_new_unknown(ctx);
             if (res == NULL) goto out_of_space;
             stack_pointer[-2 - oparg] = res;
             stack_pointer += -1 - oparg;
@@ -1516,7 +1516,7 @@
 
         case _CALL_BUILTIN_FAST: {
             _Py_UopsSymbol *res;
-            res = _Py_uop_sym_new_unknown(ctx);
+            res = sym_new_unknown(ctx);
             if (res == NULL) goto out_of_space;
             stack_pointer[-2 - oparg] = res;
             stack_pointer += -1 - oparg;
@@ -1525,7 +1525,7 @@
 
         case _CALL_BUILTIN_FAST_WITH_KEYWORDS: {
             _Py_UopsSymbol *res;
-            res = _Py_uop_sym_new_unknown(ctx);
+            res = sym_new_unknown(ctx);
             if (res == NULL) goto out_of_space;
             stack_pointer[-2 - oparg] = res;
             stack_pointer += -1 - oparg;
@@ -1534,7 +1534,7 @@
 
         case _CALL_LEN: {
             _Py_UopsSymbol *res;
-            res = _Py_uop_sym_new_unknown(ctx);
+            res = sym_new_unknown(ctx);
             if (res == NULL) goto out_of_space;
             stack_pointer[-2 - oparg] = res;
             stack_pointer += -1 - oparg;
@@ -1543,7 +1543,7 @@
 
         case _CALL_ISINSTANCE: {
             _Py_UopsSymbol *res;
-            res = _Py_uop_sym_new_unknown(ctx);
+            res = sym_new_unknown(ctx);
             if (res == NULL) goto out_of_space;
             stack_pointer[-2 - oparg] = res;
             stack_pointer += -1 - oparg;
@@ -1552,7 +1552,7 @@
 
         case _CALL_METHOD_DESCRIPTOR_O: {
             _Py_UopsSymbol *res;
-            res = _Py_uop_sym_new_unknown(ctx);
+            res = sym_new_unknown(ctx);
             if (res == NULL) goto out_of_space;
             stack_pointer[-2 - oparg] = res;
             stack_pointer += -1 - oparg;
@@ -1561,7 +1561,7 @@
 
         case _CALL_METHOD_DESCRIPTOR_FAST_WITH_KEYWORDS: {
             _Py_UopsSymbol *res;
-            res = _Py_uop_sym_new_unknown(ctx);
+            res = sym_new_unknown(ctx);
             if (res == NULL) goto out_of_space;
             stack_pointer[-2 - oparg] = res;
             stack_pointer += -1 - oparg;
@@ -1570,7 +1570,7 @@
 
         case _CALL_METHOD_DESCRIPTOR_NOARGS: {
             _Py_UopsSymbol *res;
-            res = _Py_uop_sym_new_unknown(ctx);
+            res = sym_new_unknown(ctx);
             if (res == NULL) goto out_of_space;
             stack_pointer[-2 - oparg] = res;
             stack_pointer += -1 - oparg;
@@ -1579,7 +1579,7 @@
 
         case _CALL_METHOD_DESCRIPTOR_FAST: {
             _Py_UopsSymbol *res;
-            res = _Py_uop_sym_new_unknown(ctx);
+            res = sym_new_unknown(ctx);
             if (res == NULL) goto out_of_space;
             stack_pointer[-2 - oparg] = res;
             stack_pointer += -1 - oparg;
@@ -1596,7 +1596,7 @@
 
         case _MAKE_FUNCTION: {
             _Py_UopsSymbol *func;
-            func = _Py_uop_sym_new_unknown(ctx);
+            func = sym_new_unknown(ctx);
             if (func == NULL) goto out_of_space;
             stack_pointer[-1] = func;
             break;
@@ -1604,7 +1604,7 @@
 
         case _SET_FUNCTION_ATTRIBUTE: {
             _Py_UopsSymbol *func;
-            func = _Py_uop_sym_new_unknown(ctx);
+            func = sym_new_unknown(ctx);
             if (func == NULL) goto out_of_space;
             stack_pointer[-2] = func;
             stack_pointer += -1;
@@ -1613,7 +1613,7 @@
 
         case _BUILD_SLICE: {
             _Py_UopsSymbol *slice;
-            slice = _Py_uop_sym_new_unknown(ctx);
+            slice = sym_new_unknown(ctx);
             if (slice == NULL) goto out_of_space;
             stack_pointer[-2 - ((oparg == 3) ? 1 : 0)] = slice;
             stack_pointer += -1 - ((oparg == 3) ? 1 : 0);
@@ -1622,7 +1622,7 @@
 
         case _CONVERT_VALUE: {
             _Py_UopsSymbol *result;
-            result = _Py_uop_sym_new_unknown(ctx);
+            result = sym_new_unknown(ctx);
             if (result == NULL) goto out_of_space;
             stack_pointer[-1] = result;
             break;
@@ -1630,7 +1630,7 @@
 
         case _FORMAT_SIMPLE: {
             _Py_UopsSymbol *res;
-            res = _Py_uop_sym_new_unknown(ctx);
+            res = sym_new_unknown(ctx);
             if (res == NULL) goto out_of_space;
             stack_pointer[-1] = res;
             break;
@@ -1638,7 +1638,7 @@
 
         case _FORMAT_WITH_SPEC: {
             _Py_UopsSymbol *res;
-            res = _Py_uop_sym_new_unknown(ctx);
+            res = sym_new_unknown(ctx);
             if (res == NULL) goto out_of_space;
             stack_pointer[-2] = res;
             stack_pointer += -1;
@@ -1658,7 +1658,7 @@
 
         case _BINARY_OP: {
             _Py_UopsSymbol *res;
-            res = _Py_uop_sym_new_unknown(ctx);
+            res = sym_new_unknown(ctx);
             if (res == NULL) goto out_of_space;
             stack_pointer[-2] = res;
             stack_pointer += -1;

--- a/Tools/cases_generator/optimizer_generator.py
+++ b/Tools/cases_generator/optimizer_generator.py
@@ -28,7 +28,7 @@ from generators_common import (
 from cwriter import CWriter
 from typing import TextIO, Iterator
 from lexer import Token
-from stack import StackOffset, Stack, SizeMismatch, UNUSED
+from stack import Stack, SizeMismatch, UNUSED
 
 DEFAULT_OUTPUT = ROOT / "Python/optimizer_cases.c.h"
 DEFAULT_ABSTRACT_INPUT = ROOT / "Python/optimizer_bytecodes.c"
@@ -87,14 +87,14 @@ def emit_default(out: CWriter, uop: Uop) -> None:
         if var.name != "unused" and not var.peek:
             if var.is_array():
                 out.emit(f"for (int _i = {var.size}; --_i >= 0;) {{\n")
-                out.emit(f"{var.name}[_i] = _Py_uop_sym_new_unknown(ctx);\n")
+                out.emit(f"{var.name}[_i] = sym_new_unknown(ctx);\n")
                 out.emit(f"if ({var.name}[_i] == NULL) goto out_of_space;\n")
                 out.emit("}\n")
             elif var.name == "null":
-                out.emit(f"{var.name} = _Py_uop_sym_new_null(ctx);\n")
+                out.emit(f"{var.name} = sym_new_null(ctx);\n")
                 out.emit(f"if ({var.name} == NULL) goto out_of_space;\n")
             else:
-                out.emit(f"{var.name} = _Py_uop_sym_new_unknown(ctx);\n")
+                out.emit(f"{var.name} = sym_new_unknown(ctx);\n")
                 out.emit(f"if ({var.name} == NULL) goto out_of_space;\n")
 
 


### PR DESCRIPTION
Looks like this was left behind by GH-115987. Basically a lot of diffs like this:
```
-            res = _Py_uop_sym_new_unknown(ctx);
+            res = sym_new_unknown(ctx);
```
I plan to merge this as soon as the tests pass.

<!-- gh-issue-number: gh-115816 -->
* Issue: gh-115816
<!-- /gh-issue-number -->
