### PR TITLE
Fix rendering of null character in ast.rst

### DIFF
--- a/Doc/library/ast.rst
+++ b/Doc/library/ast.rst
@@ -2187,7 +2187,7 @@ and classes for traversing abstract syntax trees:
    ``await`` as variable names.  The lowest supported version is
    ``(3, 7)``; the highest is ``sys.version_info[0:2]``.
 
-   If source contains a null character ('\0'), :exc:`ValueError` is raised.
+   If source contains a null character (``\0``), :exc:`ValueError` is raised.
 
    .. warning::
       Note that successfully parsing source code into an AST object doesn't


### PR DESCRIPTION
On main it looks like:
<img width="536" alt="Screenshot 2024-02-28 at 2 45 58 PM" src="https://github.com/python/cpython/assets/12621235/24679bf8-c20f-4169-88a4-927f6250e0b9">


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--116080.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->