### PR TITLE
Improve all_equal() recipe

### DIFF
--- a/Doc/library/itertools.rst
+++ b/Doc/library/itertools.rst
@@ -863,10 +863,9 @@ which incur interpreter overhead.
        "Given a predicate that returns True or False, count the True results."
        return sum(map(pred, iterable))
 
-   def all_equal(iterable):
+   def all_equal(iterable, key=None):
        "Returns True if all the elements are equal to each other."
-       g = groupby(iterable)
-       return next(g, True) and not next(g, False)
+       return len(take(2, groupby(iterable, key))) <= 1
 
    def first_true(iterable, default=False, pred=None):
        """Returns the first true value in the iterable.
@@ -1224,6 +1223,8 @@ The following recipes have a more mathematical flavor:
     True
 
     >>> [all_equal(s) for s in ('', 'A', 'AAAA', 'AAAB', 'AAABA')]
+    [True, True, True, False, False]
+    >>> [all_equal(s, key=str.casefold) for s in ('', 'A', 'AaAa', 'AAAB', 'AAABA')]
     [True, True, True, False, False]
 
     >>> quantify(range(99), lambda x: x%2==0)


### PR DESCRIPTION
1) Add key-function to demonstrate an essential feature of `groupby()`
2) Replace conjunction of `next()` calls with more straightforward `len()` / `take()` logic.
3) Add more tests

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--116081.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->