### PR TITLE
gh-115937: Remove implementation details from inspect.signature() docs

### DIFF
--- a/Doc/library/inspect.rst
+++ b/Doc/library/inspect.rst
@@ -699,7 +699,7 @@ function.
       Python.  For example, in CPython, some built-in functions defined in
       C provide no metadata about their arguments.
 
-   .. note::
+   .. impl-detail::
 
       If the passed object has a :attr:`!__signature__` attribute,
       we may use it to create the signature.

--- a/Doc/library/inspect.rst
+++ b/Doc/library/inspect.rst
@@ -665,9 +665,6 @@ function.
    Accepts a wide range of Python callables, from plain functions and classes to
    :func:`functools.partial` objects.
 
-   If the passed object has a ``__signature__`` attribute, this function
-   returns it without further computations.
-
    For objects defined in modules using stringized annotations
    (``from __future__ import annotations``), :func:`signature` will
    attempt to automatically un-stringize the annotations using
@@ -701,6 +698,12 @@ function.
       Some callables may not be introspectable in certain implementations of
       Python.  For example, in CPython, some built-in functions defined in
       C provide no metadata about their arguments.
+
+   .. note::
+
+      We may use the :attr:`!__signature__` attribute to create the signature.
+      The exact semantics are an implementation detail and are subject to
+      unannounced changes. Consult the source code for current semantics.
 
 
 .. class:: Signature(parameters=None, *, return_annotation=Signature.empty)

--- a/Doc/library/inspect.rst
+++ b/Doc/library/inspect.rst
@@ -701,7 +701,8 @@ function.
 
    .. note::
 
-      If the passed object has a :attr:`!__signature__` attribute, we may use it to create the signature.
+      If the passed object has a :attr:`!__signature__` attribute,
+      we may use it to create the signature.
       The exact semantics are an implementation detail and are subject to
       unannounced changes. Consult the source code for current semantics.
 

--- a/Doc/library/inspect.rst
+++ b/Doc/library/inspect.rst
@@ -701,7 +701,7 @@ function.
 
    .. note::
 
-      We may use the :attr:`!__signature__` attribute to create the signature.
+      If the passed object has a :attr:`!__signature__` attribute, we may use it to create the signature.
       The exact semantics are an implementation detail and are subject to
       unannounced changes. Consult the source code for current semantics.
 


### PR DESCRIPTION
Co-authored-by: Carol Willing <carolcode@willingconsulting.com>
Co-authored-by: Gregory P. Smith <greg@krypto.org>
Co-authored-by: Jelle Zijlstra <jelle.zijlstra@gmail.com>

<!-- gh-issue-number: gh-115937 -->
* Issue: gh-115937
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--116086.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->