### PR TITLE
gh-115986: Fix inaccuracies in pprint docs

### DIFF
--- a/Doc/library/pprint.rst
+++ b/Doc/library/pprint.rst
@@ -59,7 +59,7 @@ Functions
    The configuration parameters *stream*, *indent*, *width*, *depth*,
    *compact*, *sort_dicts* and *underscore_numbers* are passed to the
    :class:`PrettyPrinter` constructor and their meanings are as
-   described in its documentation above.
+   described in its documentation below.
 
       >>> import pprint
       >>> stuff = ['spam', 'eggs', 'lumberjack', 'knights', 'ni']
@@ -78,7 +78,7 @@ Functions
    Return the formatted representation of *object* as a string.  *indent*,
    *width*, *depth*, *compact*, *sort_dicts* and *underscore_numbers* are
    passed to the :class:`PrettyPrinter` constructor as formatting parameters
-   and their meanings are as described in its documentation above.
+   and their meanings are as described in its documentation below.
 
 
 .. function:: isreadable(object)


### PR DESCRIPTION
Since we moved class in GH-116019 (#116019), we didn't change `above`/`below` references, this PR fixes that. It's as small as typo fix and doesn't require an issue.

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--116104.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->

- #115986

<!-- gh-issue-number: gh-115986 -->
* Issue: gh-115986
<!-- /gh-issue-number -->
