### PR TITLE
gh-116116: Backport PR #42 to fix building with clang-cl on windows-i686

### DIFF
--- a/Misc/NEWS.d/next/Build/2024-02-29-15-12-31.gh-issue-116117.eENkQK.rst
+++ b/Misc/NEWS.d/next/Build/2024-02-29-15-12-31.gh-issue-116117.eENkQK.rst
@@ -1,2 +1,2 @@
-Backport PR #42 to libb2 to fix compiling CPython on windows-i686 with
-clang-cl
+Backport ``libb2``'s PR #42 to fix compiling CPython on 32-bit Windows
+with ``clang-cl``.

--- a/Misc/NEWS.d/next/Build/2024-02-29-15-12-31.gh-issue-116117.eENkQK.rst
+++ b/Misc/NEWS.d/next/Build/2024-02-29-15-12-31.gh-issue-116117.eENkQK.rst
@@ -1,0 +1,2 @@
+Backport PR #42 to libb2 to fix compiling CPython on windows-i686 with
+clang-cl

--- a/Misc/sbom.spdx.json
+++ b/Misc/sbom.spdx.json
@@ -678,11 +678,11 @@
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "6fa074693aa7305018dfa8db48010a8ef1050ad4"
+          "checksumValue": "f935d64cc633c38e09fc2d89281c95edfbc1fb05"
         },
         {
           "algorithm": "SHA256",
-          "checksumValue": "c8c6dd861ac193d4a0e836242ff44900f83423f86d2c2940c8c4c1e41fbd5812"
+          "checksumValue": "b932aa273b2504606a48895a50ff08c883f7a68a7e4aced5daa909c43348605a"
         }
       ],
       "fileName": "Modules/_blake2/impl/blake2b.c"
@@ -762,11 +762,11 @@
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "d2691353fa54ac6ffcd7c0a294984dc9d7968ef7"
+          "checksumValue": "13ac5bb93578a7ee8f815b4e247e82c849992bbe"
         },
         {
           "algorithm": "SHA256",
-          "checksumValue": "cfd7948c9fd50e9f9c62f8a93b20a254d1d510a862d1092af4f187b7c1a859a3"
+          "checksumValue": "25ec5dd5c79f916307358059fe9f633781f27df1c0e0962c4fcccdda1feb93a7"
         }
       ],
       "fileName": "Modules/_blake2/impl/blake2s.c"

--- a/Modules/_blake2/impl/blake2b.c
+++ b/Modules/_blake2/impl/blake2b.c
@@ -27,7 +27,7 @@
 #if defined(HAVE_SSE2)
 #include <emmintrin.h>
 // MSVC only defines  _mm_set_epi64x for x86_64...
-#if defined(_MSC_VER) && !defined(_M_X64)
+#if defined(_MSC_VER) && !defined(_M_X64) && !defined(__clang__)
 static inline __m128i _mm_set_epi64x( const uint64_t u1, const uint64_t u0 )
 {
   return _mm_set_epi32( u1 >> 32, u1, u0 >> 32, u0 );

--- a/Modules/_blake2/impl/blake2s.c
+++ b/Modules/_blake2/impl/blake2s.c
@@ -27,7 +27,7 @@
 #if defined(HAVE_SSE2)
 #include <emmintrin.h>
 // MSVC only defines  _mm_set_epi64x for x86_64...
-#if defined(_MSC_VER) && !defined(_M_X64)
+#if defined(_MSC_VER) && !defined(_M_X64) && !defined(__clang__)
 static inline __m128i _mm_set_epi64x( const uint64_t u1, const uint64_t u0 )
 {
   return _mm_set_epi32( u1 >> 32, u1, u0 >> 32, u0 );


### PR DESCRIPTION
Backport [PR #42](https://github.com/blake2/libb2/pull/42) to work around the following compilation error:
```
In file included from $(SOURCE_ROOT)/python3/src/Modules/_blake2/blake2b_impl.c:30:
$(SOURCE_ROOT)/python3/src/Modules/_blake2/impl/blake2b.c(31,23): error: conflicting types for '_mm_set_epi64x'
static inline __m128i _mm_set_epi64x( const uint64_t u1, const uint64_t u0 )
                      ^
$(TOOL_ROOT)/clang/14.0.6/include/emmintrin.h(3613,1): note: previous definition is here
_mm_set_epi64x(long long __q1, long long __q0)
^
1 error generated.
```

<!-- gh-issue-number: gh-116116 -->
* Issue: gh-116116
<!-- /gh-issue-number -->
