### PR TITLE
Renamed match identifier names in re module docs

### DIFF
--- a/Doc/library/re.rst
+++ b/Doc/library/re.rst
@@ -1325,9 +1325,9 @@ Since :meth:`~Pattern.match` and :meth:`~Pattern.search` return ``None``
 when there is no match, you can test whether there was a match with a simple
 ``if`` statement::
 
-   match = re.search(pattern, string)
-   if match:
-       process(match)
+   matched = re.search(pattern, string)
+   if matched:
+       process(matched)
 
 .. class:: Match
 
@@ -1547,10 +1547,10 @@ Checking for a Pair
 In this example, we'll use the following helper function to display match
 objects a little more gracefully::
 
-   def displaymatch(match):
-       if match is None:
+   def displaymatch(matchobj):
+       if matchobj is None:
            return None
-       return '<Match: %r, groups=%r>' % (match.group(), match.groups())
+       return '<Match: %r, groups=%r>' % (matchobj.group(), matchobj.groups())
 
 Suppose you are writing a poker program where a player's hand is represented as
 a 5-character string with each character representing a card, "a" for ace, "k"


### PR DESCRIPTION
Just a simple docs change so `match` is not used as an identifier name in regex code examples.

Since the `match` statement was added in 3.10 I found it confusing that in the docs for the `re` module there are some identifier names that are also called `match`. It is not an error because the `match` keyword is a soft keyword but I still think it is better not to use it as an identifier name, especially in code examples in the docs.

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--116119.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->