### PR TITLE
Re-document __signature__ as a feature

### DIFF
--- a/Doc/library/inspect.rst
+++ b/Doc/library/inspect.rst
@@ -665,6 +665,16 @@ function.
    Accepts a wide range of Python callables, from plain functions and classes to
    :func:`functools.partial` objects.
 
+   If the passed object has a :attr:`!__signature__` attribute containing
+   an instance of :class:`Signature`, this function returns it.
+   If the attribute contains None, it is ignored.
+
+   .. impl-detail::
+
+      The behavior when the :attr:`!__signature__` attribute contains a value of
+      any other type is an implementation detail and subject to
+      unannounced changes. Consult the source code for current semantics.
+
    For objects defined in modules using stringized annotations
    (``from __future__ import annotations``), :func:`signature` will
    attempt to automatically un-stringize the annotations using
@@ -698,13 +708,6 @@ function.
       Some callables may not be introspectable in certain implementations of
       Python.  For example, in CPython, some built-in functions defined in
       C provide no metadata about their arguments.
-
-   .. impl-detail::
-
-      If the passed object has a :attr:`!__signature__` attribute,
-      we may use it to create the signature.
-      The exact semantics are an implementation detail and are subject to
-      unannounced changes. Consult the source code for current semantics.
 
 
 .. class:: Signature(parameters=None, *, return_annotation=Signature.empty)


### PR DESCRIPTION
This seeks to re-resolve #106310, and improve #116086 in resolving #115937.

The original pull request for #106310, #106311, documented the behavior as the original PEP362 described it : any object found in `__signature__` and not None would be returned by inspect.signature. But in fact, since 2014 apparently, a type guard allowing only instances of Signature to pass, or else raise an exception. The documentation was in fact inaccurate as a result.

Other changes to the inspect.signature function occurred through #100039 where it gained implementation-detail support for strings and callables to be set as `__signature__`, something which I'm trying to roll back. Regardless, the latest change to the documentation which sought to address the discrepancies between the doc and the implementation, #115937, demoted the Signature-in-`__signature__` behavior from a feature to a vague implementation detail.

My proposition is to document things the following way:
- Signature objects in `__signature__` are returned as-is by the inspect.signature function
- None is ignored and the behavior is as if `__signature__` was not set
- Behavior for any other value is an implementation detail.

That way, uses of `__signature__` as a cache or as a way to hide undocumented parameters remains guaranteed, while allowing the strings and callables support to be decided and to evolve separately.

I kept the "consult the source code for current semantics" line in an effort to limit changes to a minimum, but I would be in favor of removing it.

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--116124.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->