### PR TITLE
Make the iter_except() recipe more compact.

### DIFF
--- a/Doc/library/itertools.rst
+++ b/Doc/library/itertools.rst
@@ -983,34 +983,15 @@ which incur interpreter overhead.
        """ Call a function repeatedly until an exception is raised.
 
        Converts a call-until-exception interface to an iterator interface.
-       Like builtins.iter(func, sentinel) but uses an exception instead
-       of a sentinel to end the loop.
-
-       Priority queue iterator:
-           iter_except(functools.partial(heappop, h), IndexError)
-
-       Non-blocking dictionary iterator:
-           iter_except(d.popitem, KeyError)
-
-       Non-blocking deque iterator:
-           iter_except(d.popleft, IndexError)
-
-       Non-blocking iterator over a producer Queue:
-           iter_except(q.get_nowait, Queue.Empty)
-
-       Non-blocking set iterator:
-           iter_except(s.pop, KeyError)
-
        """
+       # iter_except(d.popitem, KeyError) --> non-blocking dictionary iterator
        try:
            if first is not None:
-               # For database APIs needing an initial call to db.first()
                yield first()
            while True:
                yield func()
        except exception:
            pass
-
 
 
 The following recipes have a more mathematical flavor:


### PR DESCRIPTION
Only one example is needed.  The lengthy docstring was interfering with the readability of the recipes taken as a whole and distracting from the gestalt of the document.  Also, this function is no longer in the incubation phase.  After many years in the docs, it is not being used in practice.  In addition, this seems to be only useable in contexts where the input source gets consumed.