### PR TITLE
gh-87115: Set `__main__.__spec__` to `None` in pdb

### DIFF
--- a/Lib/pdb.py
+++ b/Lib/pdb.py
@@ -188,6 +188,7 @@ class _ScriptTarget(str):
             __name__='__main__',
             __file__=self,
             __builtins__=__builtins__,
+            __spec__=None,
         )
 
     @property

--- a/Lib/test/test_pdb.py
+++ b/Lib/test/test_pdb.py
@@ -2695,6 +2695,18 @@ def bœr():
             ('bœr', 2),
         )
 
+    def test_spec(self):
+        # Test that __main__.__spec__ is set to None when running a script
+        script = """
+            import __main__
+            print(__main__.__spec__)
+        """
+
+        commands = "continue"
+
+        stdout, _ = self.run_pdb_script(script, commands)
+        self.assertIn('None', stdout)
+
     def test_find_function_first_executable_line(self):
         code = textwrap.dedent("""\
             def foo(): pass

--- a/Misc/NEWS.d/next/Library/2024-02-29-20-06-06.gh-issue-87115.FVMiOR.rst
+++ b/Misc/NEWS.d/next/Library/2024-02-29-20-06-06.gh-issue-87115.FVMiOR.rst
@@ -1,0 +1,1 @@
+Set ``__main__.__spec__`` to ``None`` when running a script with :mod:`pdb`


### PR DESCRIPTION
`__main__.__spec__` should be `None` when running a script, but `pdb` does not set it in the namespace. This breaks some code that relies on it (that `__spec__` exists in `__main__`).

<!-- gh-issue-number: gh-87115 -->
* Issue: gh-87115
<!-- /gh-issue-number -->
