### PR TITLE
GH-115060: Speed up `pathlib.Path.glob()` by skipping directory scanning

### DIFF
--- a/Doc/library/pathlib.rst
+++ b/Doc/library/pathlib.rst
@@ -1004,9 +1004,7 @@ call fails (for example because the path doesn't exist).
    .. seealso::
       :ref:`pathlib-pattern-language` documentation.
 
-   This method calls :meth:`Path.is_dir` on the top-level directory and
-   propagates any :exc:`OSError` exception that is raised. Subsequent
-   :exc:`OSError` exceptions from scanning directories are suppressed.
+   This method suppresses :exc:`OSError` exceptions.
 
    By default, or when the *case_sensitive* keyword-only argument is set to
    ``None``, this method matches paths using platform-specific casing rules:

--- a/Lib/pathlib/_abc.py
+++ b/Lib/pathlib/_abc.py
@@ -92,14 +92,19 @@ def _deselect_missing(paths):
             pass
 
 
-def _deselect_symlinks(paths):
+def _deselect_symlinks(paths, dir_only, follow_symlinks):
     """Yield the given paths, filtering out symlinks."""
+    if follow_symlinks is None:
+        follow_symlinks = True
     for path in paths:
-        try:
-            if not path.is_symlink():
-                yield path
-        except OSError:
-            pass
+        if follow_symlinks or not dir_only:
+            yield path
+        else:
+            try:
+                if not path.is_symlink():
+                    yield path
+            except OSError:
+                pass
 
 
 def _select_children(parent_paths, dir_only, follow_symlinks, match):
@@ -904,8 +909,7 @@ class PathBase(PurePathBase):
                 paths = _select_literal(paths, part)
 
                 # Filter out non-symlinks if requested.
-                if follow_symlinks is False:
-                    paths = _deselect_symlinks(paths)
+                paths = _deselect_symlinks(paths, bool(stack), follow_symlinks)
 
                 # Paths might not exist; mark them to be checked.
                 check_paths = True

--- a/Lib/pathlib/_abc.py
+++ b/Lib/pathlib/_abc.py
@@ -846,10 +846,10 @@ class PathBase(PurePathBase):
 
         stack = pattern._pattern_stack
         specials = ('', '.', '..')
-        check_paths = False
+        check_paths = True
         deduplicate_paths = False
         sep = self.pathmod.sep
-        paths = iter([self] if self.is_dir() else [])
+        paths = iter([self])
         while stack:
             part = stack.pop()
             if part in specials:

--- a/Lib/test/test_pathlib/test_pathlib_abc.py
+++ b/Lib/test/test_pathlib/test_pathlib_abc.py
@@ -1752,10 +1752,10 @@ class DummyPathTest(DummyPurePathTest):
     def test_glob_windows(self):
         P = self.cls
         p = P(self.base)
-        self.assertEqual(set(p.glob("FILEa")), { P(self.base, "fileA") })
+        self.assertEqual(set(p.glob("FILEa")), { P(self.base, "FILEa") })
         self.assertEqual(set(p.glob("*a\\")), { P(self.base, "dirA/") })
         self.assertEqual(set(p.glob("F*a")), { P(self.base, "fileA") })
-        self.assertEqual(set(map(str, p.glob("FILEa"))), {f"{p}\\fileA"})
+        self.assertEqual(set(map(str, p.glob("FILEa"))), {f"{p}\\FILEa"})
         self.assertEqual(set(map(str, p.glob("F*a"))), {f"{p}\\fileA"})
 
     def test_glob_empty_pattern(self):
@@ -1903,9 +1903,9 @@ class DummyPathTest(DummyPurePathTest):
     def test_rglob_windows(self):
         P = self.cls
         p = P(self.base, "dirC")
-        self.assertEqual(set(p.rglob("FILEd")), { P(self.base, "dirC/dirD/fileD") })
+        self.assertEqual(set(p.rglob("FILEd")), { P(self.base, "dirC/dirD/FILEd") })
         self.assertEqual(set(p.rglob("*\\")), { P(self.base, "dirC/dirD/") })
-        self.assertEqual(set(map(str, p.rglob("FILEd"))), {f"{p}\\dirD\\fileD"})
+        self.assertEqual(set(map(str, p.rglob("FILEd"))), {f"{p}\\dirD\\FILEd"})
 
     @needs_symlinks
     def test_rglob_follow_symlinks_common(self):
@@ -1993,8 +1993,19 @@ class DummyPathTest(DummyPurePathTest):
         self.assertEqual(set(p.glob("dirA/../file*")), { P(self.base, "dirA/../fileA") })
         self.assertEqual(set(p.glob("dirA/../file*/..")), set())
         self.assertEqual(set(p.glob("../xyzzy")), set())
-        self.assertEqual(set(p.glob("xyzzy/..")), set())
         self.assertEqual(set(p.glob("/".join([".."] * 50))), { P(self.base, *[".."] * 50)})
+
+    @needs_posix
+    def test_glob_dotdot_posix(self):
+        p = self.cls(self.base)
+        self.assertEqual(set(p.glob("xyzzy/..")), set())
+
+    @needs_windows
+    def test_glob_dotdot_windows(self):
+        # '..' segments are resolved first on Windows, so
+        # 'xyzzy' doesn't need to exist.
+        p = self.cls(self.base)
+        self.assertEqual(set(p.glob("xyzzy/..")), { p })
 
     @needs_symlinks
     def test_glob_permissions(self):

--- a/Lib/test/test_pathlib/test_pathlib_abc.py
+++ b/Lib/test/test_pathlib/test_pathlib_abc.py
@@ -1843,6 +1843,11 @@ class DummyPathTest(DummyPurePathTest):
         _check(p, "dir*/*/../dirD/**/", ["dirC/dirD/../dirD/"])
         _check(p, "*/dirD/**", ["dirC/dirD/", "dirC/dirD/fileD"])
         _check(p, "*/dirD/**/", ["dirC/dirD/"])
+        _check(p, "linkA", ["linkA"])
+        _check(p, "linkB", ["linkB"])
+        _check(p, "linkB/fileB", [])
+        _check(p, "dirA/linkC", ["dirA/linkC"])
+        _check(p, "dirA/linkC/fileB", [])
 
     def test_rglob_common(self):
         def _check(glob, expected):

--- a/Lib/test/test_pathlib/test_pathlib_abc.py
+++ b/Lib/test/test_pathlib/test_pathlib_abc.py
@@ -1431,7 +1431,7 @@ class DummyPath(PathBase):
         return "{}({!r})".format(self.__class__.__name__, self.as_posix())
 
     def stat(self, *, follow_symlinks=True):
-        if follow_symlinks or self.name == '..':
+        if follow_symlinks or not self.name or self.name == '.' or self.name == '..':
             path = str(self.resolve(strict=True))
         else:
             path = str(self.parent.resolve(strict=True) / self.name)

--- a/Lib/test/test_pathlib/test_pathlib_abc.py
+++ b/Lib/test/test_pathlib/test_pathlib_abc.py
@@ -1431,10 +1431,10 @@ class DummyPath(PathBase):
         return "{}({!r})".format(self.__class__.__name__, self.as_posix())
 
     def stat(self, *, follow_symlinks=True):
-        if follow_symlinks:
-            path = str(self.resolve())
+        if follow_symlinks or self.name == '..':
+            path = str(self.resolve(strict=True))
         else:
-            path = str(self.parent.resolve() / self.name)
+            path = str(self.parent.resolve(strict=True) / self.name)
         if path in self._files:
             st_mode = stat.S_IFREG
         elif path in self._directories:

--- a/Lib/test/test_pathlib/test_pathlib_abc.py
+++ b/Lib/test/test_pathlib/test_pathlib_abc.py
@@ -1997,15 +1997,17 @@ class DummyPathTest(DummyPurePathTest):
 
     @needs_posix
     def test_glob_dotdot_posix(self):
-        p = self.cls(self.base)
+        P = self.cls
+        p = P(self.base)
         self.assertEqual(set(p.glob("xyzzy/..")), set())
 
     @needs_windows
     def test_glob_dotdot_windows(self):
         # '..' segments are resolved first on Windows, so
         # 'xyzzy' doesn't need to exist.
-        p = self.cls(self.base)
-        self.assertEqual(set(p.glob("xyzzy/..")), { p })
+        P = self.cls
+        p = P(self.base)
+        self.assertEqual(set(p.glob("xyzzy/..")), { P(self.base, "xyzzy", "..") })
 
     @needs_symlinks
     def test_glob_permissions(self):

--- a/Misc/NEWS.d/next/Library/2024-02-29-20-42-48.gh-issue-115060.fofNVf.rst
+++ b/Misc/NEWS.d/next/Library/2024-02-29-20-42-48.gh-issue-115060.fofNVf.rst
@@ -1,0 +1,2 @@
+Speed up handling of non-wildcard pattern segments in
+:meth:`pathlib.Path.glob`.


### PR DESCRIPTION
For ordinary literal pattern segments (e.g. `foo/bar` in `foo/bar/../**`), skip calling `scandir()` on each segment, and instead call `exists()` or `is_dir()` as necessary to exclude missing paths. This only applies when *case_sensitive* is `None` (the default); otherwise we can't guarantee case sensitivity or realness with this approach. If *follow_symlinks* is `False` we also need to exclude symlinks from intermediate segments.

This restores an optimization that was removed in da1980a by some eejit. It's actually even faster because we don't `stat()` intermediate directories, and in some cases we can skip all filesystem access when expanding a literal part (e.g. when it's followed by a non-recursive wildcard segment).

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-115060 -->
* Issue: gh-115060
<!-- /gh-issue-number -->
