### PR TITLE
gh-115491: Fix Clang compiler warning

### DIFF
--- a/Objects/mimalloc/alloc.c
+++ b/Objects/mimalloc/alloc.c
@@ -27,7 +27,7 @@ terms of the MIT license. A copy of the license can be found in the file
 // ------------------------------------------------------
 
 #if (MI_DEBUG>0)
-static void mi_debug_fill(mi_page_t* page, mi_block_t* block, int c, size_t size) {
+static inline void mi_debug_fill(mi_page_t* page, mi_block_t* block, int c, size_t size) {
   size_t offset = (size_t)page->debug_offset;
   if (offset < size) {
     memset((char*)block + offset, c, size - offset);


### PR DESCRIPTION
This fixes a warning due to a `static` function used in a `extern inline` function:

```
Objects/mimalloc/alloc.c:77:5: warning: static function 'mi_debug_fill' is used in an inline function with external linkage [-Wstatic-in-inline]
    mi_debug_fill(page, block, MI_DEBUG_UNINIT, mi_page_usable_block_size(page));
```

<!-- gh-issue-number: gh-115491 -->
* Issue: gh-115491
<!-- /gh-issue-number -->
