### PR TITLE
[3.11] gh-87115: Set `__main__.__spec__` to `None` in pdb (GH-116141)

### DIFF
--- a/Lib/pdb.py
+++ b/Lib/pdb.py
@@ -153,6 +153,7 @@ class _ScriptTarget(str):
             __name__='__main__',
             __file__=self,
             __builtins__=__builtins__,
+            __spec__=None,
         )
 
     @property

--- a/Lib/test/test_pdb.py
+++ b/Lib/test/test_pdb.py
@@ -1862,6 +1862,18 @@ def bœr():
             ('bœr', 1),
         )
 
+    def test_spec(self):
+        # Test that __main__.__spec__ is set to None when running a script
+        script = """
+            import __main__
+            print(__main__.__spec__)
+        """
+
+        commands = "continue"
+
+        stdout, _ = self.run_pdb_script(script, commands)
+        self.assertIn('None', stdout)
+
     def test_issue7964(self):
         # open the file as binary so we can force \r\n newline
         with open(os_helper.TESTFN, 'wb') as f:

--- a/Misc/NEWS.d/next/Library/2024-02-29-20-06-06.gh-issue-87115.FVMiOR.rst
+++ b/Misc/NEWS.d/next/Library/2024-02-29-20-06-06.gh-issue-87115.FVMiOR.rst
@@ -1,0 +1,1 @@
+Set ``__main__.__spec__`` to ``None`` when running a script with :mod:`pdb`


### PR DESCRIPTION
(cherry picked from commit ccfc042bbf31e53c44b8aae444afd8365b798422)

Co-authored-by: Tian Gao <gaogaotiantian@hotmail.com>

<!-- gh-issue-number: gh-87115 -->
* Issue: gh-87115
<!-- /gh-issue-number -->
