### PR TITLE
gh-116159: argparse: performance improvement parsing large number of options

### DIFF
--- a/Lib/argparse.py
+++ b/Lib/argparse.py
@@ -2153,10 +2153,11 @@ class ArgumentParser(_AttributeHolder, _ActionsContainer):
         while start_index <= max_option_string_index:
 
             # consume any Positionals preceding the next option
-            next_option_string_index = min([
-                index
-                for index in option_string_indices
-                if index >= start_index])
+            next_option_string_index = start_index
+            while next_option_string_index <= max_option_string_index:
+                if next_option_string_index in option_string_indices:
+                    break
+                next_option_string_index += 1
             if start_index != next_option_string_index:
                 positionals_end_index = consume_positionals(start_index)
 


### PR DESCRIPTION
When parsing positional vs optional arguments, the use of min with a
list comprehension inside of a loop results in quadratic time based
on the number of optional arguments given. When combined with use of
prefix based argument files and a large number of optional flags, this
can result in extremely slow parsing behavior.

This replaces the min call with a simple loop with a short circuit to
break at the next optional argument.

Example test case that exercises this performance behavior:
https://gist.github.com/amyreese/b825bc092210ea7b64287f033dc995d8

The test case parses a list of arguments that contains 30,000 copies
of `--flag=something`. Using latest 3.12 or 3.13 from main, this takes
roughly 15-16 seconds to parse. With the proposed fix, this only takes
80 milliseconds.

Before:

```console
$ ~/opt/cpython/bin/python3.13 -VV
Python 3.13.0a4+ (heads/main:0656509033, Feb 29 2024, 11:59:43) [Clang 15.0.0 (clang-1500.1.0.2.5)]

$ ~/opt/cpython/bin/python3.13 test_many_flags.py
parsed args in 15,195,914 µs
```

With fix:

```console
$ ~/opt/cpython/bin/python3.13 -VV
Python 3.13.0a4+ (heads/argparse-options:968aa13a1d, Feb 29 2024, 13:34:49) [Clang 15.0.0 (clang-1500.1.0.2.5)]

$ ~/opt/cpython/bin/python3.13 test_many_flags.py
parsed args in 79,787 µs
```

Co-authored-by: Zsolt Dollenstein <zsol.zsol@gmail.com>


<!-- gh-issue-number: gh-116159 -->
* Issue: gh-116159
<!-- /gh-issue-number -->
