### PR TITLE
gh-114258: Argument Clinic: refactor getset implementation

### DIFF
--- a/Lib/test/clinic.test.c
+++ b/Lib/test/clinic.test.c
@@ -5004,12 +5004,16 @@ Test_property_set_impl(TestObj *self, PyObject *value);
 static int
 Test_property_set(TestObj *self, PyObject *value, void *Py_UNUSED(context))
 {
-    return Test_property_set_impl(self, value);
+    int return_value;
+
+    return_value = Test_property_set_impl(self, value);
+
+    return return_value;
 }
 
 static int
 Test_property_set_impl(TestObj *self, PyObject *value)
-/*[clinic end generated code: output=9797cd03c5204ddb input=3bc3f46a23c83a88]*/
+/*[clinic end generated code: output=d51023f17c4ac3a1 input=3bc3f46a23c83a88]*/
 
 /*[clinic input]
 output push

--- a/Lib/test/clinic.test.c
+++ b/Lib/test/clinic.test.c
@@ -5350,7 +5350,6 @@ Test___init__(PyObject *self, PyObject *args, PyObject *kwargs)
 {
     int return_value = -1;
     PyTypeObject *base_tp = TestType;
-    long _return_value;
 
     if ((Py_IS_TYPE(self, base_tp) ||
          Py_TYPE(self)->tp_new == base_tp->tp_new) &&
@@ -5362,11 +5361,7 @@ Test___init__(PyObject *self, PyObject *args, PyObject *kwargs)
         !_PyArg_NoKeywords("Test", kwargs)) {
         goto exit;
     }
-    _return_value = Test___init___impl((TestObj *)self);
-    if ((_return_value == -1) && PyErr_Occurred()) {
-        goto exit;
-    }
-    return_value = PyLong_FromLong(_return_value);
+    return_value = Test___init___impl((TestObj *)self);
 
 exit:
     return return_value;
@@ -5374,7 +5369,7 @@ exit:
 
 static long
 Test___init___impl(TestObj *self)
-/*[clinic end generated code: output=daf6ee12c4e443fb input=311af0dc7f17e8e9]*/
+/*[clinic end generated code: output=9f3704989ab1f6eb input=311af0dc7f17e8e9]*/
 
 
 /*[clinic input]

--- a/Lib/test/test_clinic.py
+++ b/Lib/test/test_clinic.py
@@ -2167,7 +2167,7 @@ class ClinicParserTest(TestCase):
                        obj: int
                        /
                 """
-                expected_error = f"{annotation} method cannot define parameters"
+                expected_error = f"{annotation} methods cannot define parameters"
                 self.expect_failure(block, expected_error)
 
     def test_setter_docstring(self):

--- a/Lib/test/test_clinic.py
+++ b/Lib/test/test_clinic.py
@@ -2651,7 +2651,6 @@ class ClinicExternalTest(TestCase):
                 long()
                 Py_ssize_t()
                 size_t()
-                type_slot_int()
                 unsigned_int()
                 unsigned_long()
 
@@ -3937,7 +3936,7 @@ class ClinicReprTests(unittest.TestCase):
             cls=None,
             c_basename=None,
             full_name='foofoo',
-            return_converter=clinic.type_slot_int_return_converter(),
+            return_converter=clinic.int_return_converter(),
             kind=clinic.FunctionKind.METHOD_INIT,
             coexist=False
         )

--- a/Lib/test/test_clinic.py
+++ b/Lib/test/test_clinic.py
@@ -2647,11 +2647,11 @@ class ClinicExternalTest(TestCase):
                 bool()
                 double()
                 float()
-                init()
                 int()
                 long()
                 Py_ssize_t()
                 size_t()
+                type_slot_int()
                 unsigned_int()
                 unsigned_long()
 
@@ -3937,7 +3937,7 @@ class ClinicReprTests(unittest.TestCase):
             cls=None,
             c_basename=None,
             full_name='foofoo',
-            return_converter=clinic.init_return_converter(),
+            return_converter=clinic.type_slot_int_return_converter(),
             kind=clinic.FunctionKind.METHOD_INIT,
             coexist=False
         )

--- a/Tools/clinic/clinic.py
+++ b/Tools/clinic/clinic.py
@@ -859,9 +859,6 @@ class CLanguage(Language):
             limited_capi = False
 
         parsearg: str | None
-        if f.kind in {GETTER, SETTER} and parameters:
-            fail(f"@{f.kind.name.lower()} method cannot define parameters")
-
         if not parameters:
             parser_code: list[str] | None
             if f.kind is GETTER:
@@ -5291,6 +5288,10 @@ class DSLParser:
         # if this line is not indented, we have no parameters
         if not self.indent.infer(line):
             return self.next(self.state_function_docstring, line)
+
+        if self.function.kind in {GETTER, SETTER}:
+            getset = self.function.kind.name.lower()
+            fail(f"@{getset} methods cannot define parameters")
 
         self.parameter_continuation = ''
         return self.next(self.state_parameter, line)

--- a/Tools/clinic/clinic.py
+++ b/Tools/clinic/clinic.py
@@ -5280,6 +5280,7 @@ class DSLParser:
         if not self.indent.infer(line):
             return self.next(self.state_function_docstring, line)
 
+        assert self.function
         if self.function.kind in {GETTER, SETTER}:
             getset = self.function.kind.name.lower()
             fail(f"@{getset} methods cannot define parameters")

--- a/Tools/clinic/clinic.py
+++ b/Tools/clinic/clinic.py
@@ -5272,7 +5272,7 @@ class DSLParser:
         if not self.indent.infer(line):
             return self.next(self.state_function_docstring, line)
 
-        assert self.function
+        assert self.function is not None
         if self.function.kind in {GETTER, SETTER}:
             getset = self.function.kind.name.lower()
             fail(f"@{getset} methods cannot define parameters")

--- a/Tools/clinic/clinic.py
+++ b/Tools/clinic/clinic.py
@@ -1612,7 +1612,8 @@ class CLanguage(Language):
         for converter in converters:
             converter.set_template_dict(template_dict)
 
-        f.return_converter.render(f, data)
+        if f.kind not in {SETTER, METHOD_INIT}:
+            f.return_converter.render(f, data)
         template_dict['impl_return_type'] = f.return_converter.type
 
         template_dict['declarations'] = libclinic.format_escape("\n".join(data.declarations))
@@ -4558,15 +4559,6 @@ class int_return_converter(long_return_converter):
     cast = '(long)'
 
 
-class type_slot_int_return_converter(long_return_converter):
-    """Special return converter for type slots functions that return int."""
-    type = 'int'
-    cast = '(long)'
-
-    def render(self, function: Function, data: CRenderData) -> None:
-        pass
-
-
 class unsigned_long_return_converter(long_return_converter):
     type = 'unsigned long'
     conversion_fn = 'PyLong_FromUnsignedLong'
@@ -5098,7 +5090,7 @@ class DSLParser:
                 fail(f"Badly formed annotation for {full_name!r}: {forced_converter!r}")
 
         if self.kind in {METHOD_INIT, SETTER}:
-            return type_slot_int_return_converter()
+            return int_return_converter()
         return CReturnConverter()
 
     def parse_cloned_function(self, names: FunctionNames, existing: str) -> None:

--- a/Tools/clinic/clinic.py
+++ b/Tools/clinic/clinic.py
@@ -1613,11 +1613,7 @@ class CLanguage(Language):
             converter.set_template_dict(template_dict)
 
         f.return_converter.render(f, data)
-        if f.kind is SETTER:
-            # All setters return an int.
-            template_dict['impl_return_type'] = 'int'
-        else:
-            template_dict['impl_return_type'] = f.return_converter.type
+        template_dict['impl_return_type'] = f.return_converter.type
 
         template_dict['declarations'] = libclinic.format_escape("\n".join(data.declarations))
         template_dict['initializers'] = "\n\n".join(data.initializers)
@@ -4562,18 +4558,13 @@ class int_return_converter(long_return_converter):
     cast = '(long)'
 
 
-class init_return_converter(long_return_converter):
-    """
-    Special return converter for __init__ functions.
-    """
+class type_slot_int_return_converter(long_return_converter):
+    """Special return converter for type slots functions that return int."""
     type = 'int'
     cast = '(long)'
 
-    def render(
-            self,
-            function: Function,
-            data: CRenderData
-    ) -> None: ...
+    def render(self, function: Function, data: CRenderData) -> None:
+        pass
 
 
 class unsigned_long_return_converter(long_return_converter):
@@ -5106,8 +5097,8 @@ class DSLParser:
             except ValueError:
                 fail(f"Badly formed annotation for {full_name!r}: {forced_converter!r}")
 
-        if self.kind is METHOD_INIT:
-            return init_return_converter()
+        if self.kind in {METHOD_INIT, SETTER}:
+            return type_slot_int_return_converter()
         return CReturnConverter()
 
     def parse_cloned_function(self, names: FunctionNames, existing: str) -> None:


### PR DESCRIPTION
Yak-shaving for type slot support:

- move param corner case `fail()` from the generator to the parser
- assign a return converter for setters during parsing, instead of hacking the output generator
- rename the "init return converter" to "type slot int return converter"

TODO:
- [ ] remove the implicitly added `@setter` param; instead require this to be specified (for a follow-up PR)

<!-- gh-issue-number: gh-114258 -->
* Issue: gh-114258
<!-- /gh-issue-number -->
