### PR TITLE
gh-116180: check if globals is NULL and set error in run_eval_code_obj()

### DIFF
--- a/Python/pythonrun.c
+++ b/Python/pythonrun.c
@@ -1287,6 +1287,10 @@ run_eval_code_obj(PyThreadState *tstate, PyCodeObject *co, PyObject *globals, Py
             return NULL;
         }
     }
+    if (globals == NULL) {
+        PyErr_SetString(PyExc_TypeError, "globals are NULL");
+        return NULL;
+    }
 
     v = PyEval_EvalCode((PyObject*)co, globals, locals);
     if (!v && _PyErr_Occurred(tstate) == PyExc_KeyboardInterrupt) {


### PR DESCRIPTION
Add globals NULL check in [run_eval_code_obj](https://github.com/python/cpython/blob/3.10/Python/pythonrun.c#L1266) to avoid possible segmentation fault

<!-- gh-issue-number: gh-116180 -->
* Issue: gh-116180
<!-- /gh-issue-number -->
