### PR TITLE
gh-70647: Add detail to error message when parsing a bad day of month.

### DIFF
--- a/Modules/_datetimemodule.c
+++ b/Modules/_datetimemodule.c
@@ -481,8 +481,9 @@ check_date_args(int year, int month, int day)
         return -1;
     }
     if (day < 1 || day > days_in_month(year, month)) {
-        PyErr_SetString(PyExc_ValueError,
-                        "day is out of range for month");
+        PyErr_Format(PyExc_ValueError,
+                     "day %i is out of range for month %i in year %i",
+		     day, month, year);
         return -1;
     }
     return 0;


### PR DESCRIPTION
The presence of the values in the error message gives a stronger hint as to what went wrong.

```python
>>> datetime.strptime("2.29", "%m.%d")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
    datetime.strptime("2.29", "%m.%d")
    ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
  File ".../Lib/_strptime.py", line 565, in _strptime_datetime
    return cls(*args)
           ~~~^^^^^^^
ValueError: day 29 is out of range for month 2 in year 1900
```

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-70647 -->
* Issue: gh-70647
<!-- /gh-issue-number -->
