### PR TITLE
gh-115941: Documentation: dictobjects.c: changing the doc block section of the file

### DIFF
--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -21,6 +21,7 @@ layout:
 | dk_log2_size        |
 | dk_log2_index_bytes |
 | dk_kind             |
+| dk_version          |
 | dk_usable           |
 | dk_nentries         |
 +---------------------+
@@ -55,7 +56,7 @@ The DictObject can be in one of two forms.
 Either:
   A combined table:
     ma_values == NULL, dk_refcnt == 1.
-    Values are stored in the me_value field of the PyDictKeysObject.
+    Values are stored in the me_value field of the PyDictKeyEntry.
 Or:
   A split table:
     ma_values != NULL, dk_refcnt >= 1


### PR DESCRIPTION
Fixing the documentation block section of the code in `dictobjects.c`

This PR fixes the changes proposed in the issue: #115941. The `dk_version` field has been added and a corresponding change to `PyDictKeyEntry`, as proposed.  

<!-- gh-issue-number: gh-115941 -->
* Issue: gh-115941
<!-- /gh-issue-number -->
