### PR TITLE
gh-115773: Add missing preprocessor guard in _testexternalinspection

### DIFF
--- a/Modules/_testexternalinspection.c
+++ b/Modules/_testexternalinspection.c
@@ -352,7 +352,7 @@ ssize_t
 read_memory(pid_t pid, void* remote_address, size_t len, void* dst)
 {
     ssize_t total_bytes_read = 0;
-#ifdef __linux__
+#if defined(__linux__) && HAVE_PROCESS_VM_READV
     struct iovec local[1];
     struct iovec remote[1];
     ssize_t result = 0;


### PR DESCRIPTION
Android currently uses [Clang 17](https://www.redhat.com/en/blog/new-warnings-and-errors-clang-16), which by default disables implicit declarations of C functions. This means the call to `process_vm_readv` in _testexternalinspection.c must be guarded by a preprocessor check, otherwise compilation will fail:

```
../../../Modules/_testexternalinspection.c:367:16: error: call to undeclared function 'process_vm_readv'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
        read = process_vm_readv(pid, local, 1, remote, 1, 0);
               ^
1 error generated.
make: *** [Modules/_testexternalinspection.o] Error 1
```

This will eventually affect other platforms as they upgrade Clang.

<!-- gh-issue-number: gh-115773 -->
* Issue: gh-115773
<!-- /gh-issue-number -->
