### PR TITLE
Small change: Delete obsolete comment from copyreg.py

### DIFF
--- a/Lib/copyreg.py
+++ b/Lib/copyreg.py
@@ -1,8 +1,4 @@
-"""Helper to provide extensibility for pickle.
-
-This is only useful to add pickle support for extension types defined in
-C, not for instances of user-defined classes.
-"""
+"""Helper to provide extensibility for pickle."""
 
 __all__ = ["pickle", "constructor",
            "add_extension", "remove_extension", "clear_extension_cache"]


### PR DESCRIPTION
A comment states that copyreg is only useful for C objects, not for user-defined classes, which is at odds with its documentation.

See more at https://stackoverflow.com/q/78087188/3358488