### PR TITLE
gh-116243: Add a high-performance C level implementation of `all_equal`

### DIFF
--- a/Include/object.h
+++ b/Include/object.h
@@ -584,6 +584,7 @@ PyAPI_FUNC(Py_hash_t) PyObject_Hash(PyObject *);
 PyAPI_FUNC(Py_hash_t) PyObject_HashNotImplemented(PyObject *);
 PyAPI_FUNC(int) PyObject_IsTrue(PyObject *);
 PyAPI_FUNC(int) PyObject_Not(PyObject *);
+PyAPI_FUNC(int) PyObject_IsEqual(PyObject *, PyObject *);
 PyAPI_FUNC(int) PyCallable_Check(PyObject *);
 PyAPI_FUNC(void) PyObject_ClearWeakRefs(PyObject *);
 

--- a/Lib/test/test_builtin.py
+++ b/Lib/test/test_builtin.py
@@ -218,6 +218,16 @@ class BuiltinTest(unittest.TestCase):
         S = [50, 40, 60]
         self.assertEqual(all(x > 42 for x in S), False)
 
+    def test_all_equal(self):
+        self.assertEqual(all_equal([1, 1, 1]), True)
+        self.assertEqual(all_equal([1, 2, 3]), False)
+        self.assertEqual(all_equal([1, None, 1]), False)
+        self.assertRaises(RuntimeError, all_equal, TestFailingIter())
+        self.assertRaises(TypeError, all_equal, 10)                 # Non-iterable
+        self.assertRaises(TypeError, all_equal)                     # No args
+        self.assertRaises(TypeError, all_equal, [2, 4, 6], [])      # Too many args
+        self.assertEqual(all_equal([]), True)                       # Empty iterator
+
     def test_any(self):
         self.assertEqual(any([None, None, None]), False)
         self.assertEqual(any([None, 4, None]), True)

--- a/Lib/test/test_builtin.py
+++ b/Lib/test/test_builtin.py
@@ -219,14 +219,14 @@ class BuiltinTest(unittest.TestCase):
         self.assertEqual(all(x > 42 for x in S), False)
 
     def test_all_equal(self):
-        self.assertEqual(all_equal([1, 1, 1]), True)
-        self.assertEqual(all_equal([1, 2, 3]), False)
-        self.assertEqual(all_equal([1, None, 1]), False)
+        self.assertTrue(all_equal([1, 1, 1]))
+        self.assertFalse(all_equal([1, 2, 3]))
+        self.assertFalse(all_equal([1, None, 1]))
         self.assertRaises(RuntimeError, all_equal, TestFailingIter())
         self.assertRaises(TypeError, all_equal, 10)                 # Non-iterable
         self.assertRaises(TypeError, all_equal)                     # No args
         self.assertRaises(TypeError, all_equal, [2, 4, 6], [])      # Too many args
-        self.assertEqual(all_equal([]), True)                       # Empty iterator
+        self.assertTrue(all_equal([]))                              # Empty iterator
 
     def test_any(self):
         self.assertEqual(any([None, None, None]), False)

--- a/Objects/object.c
+++ b/Objects/object.c
@@ -1852,6 +1852,23 @@ PyObject_Not(PyObject *v)
     return res == 0;
 }
 
+/* Test whether two objects are equal */
+
+int PyObject_IsEqual(PyObject *self, PyObject *other)
+{
+    PyObject* res = _Py_BaseObject_RichCompare(self, other, Py_EQ);
+
+    if (res == Py_True)
+        return 1;
+    else if (res == Py_False)
+        return 0;
+    else if (res == Py_NotImplemented)
+        return 0;
+    else
+        return 0;
+}
+
+
 /* Test whether an object can be called */
 
 int

--- a/Python/clinic/bltinmodule.c.h
+++ b/Python/clinic/bltinmodule.c.h
@@ -138,6 +138,17 @@ PyDoc_STRVAR(builtin_any__doc__,
 "\n"
 "If the iterable is empty, return False.");
 
+#define BUILTIN_ALL_EQUAL_METHODDEF     \
+    {"all_equal", (PyCFunction)builtin_all_equal, METH_O, builtin_all_equal__doc__},
+
+PyDoc_STRVAR(builtin_all_equal__doc__,
+"all_equal($module, iterable, /)\n"
+"--\n"
+"\n"
+"Return True if x in the iterable are equal.\n"
+"\n"
+"If the iterable is empty, return False.");
+
 #define BUILTIN_ANY_METHODDEF    \
     {"any", (PyCFunction)builtin_any, METH_O, builtin_any__doc__},
 


### PR DESCRIPTION
- Added an initial version of `all_equal`, may expect this to work and compile
- added `PyObject_IsEqual`

<!-- gh-issue-number: gh-116243 -->
* Issue: gh-116243
<!-- /gh-issue-number -->
