### PR TITLE
gh-116010: Remove link to deprecated PEP 6 in FAQ guide

### DIFF
--- a/Doc/faq/general.rst
+++ b/Doc/faq/general.rst
@@ -133,9 +133,10 @@ Python versions are numbered "A.B.C" or "A.B":
   changes.
 * *C* is the micro version number -- it is incremented for each bugfix release.
 
-See `Status of Python versions section of the Python's Developer Guide 
-<https://devguide.python.org/versions/>`__ for more information about bugfix
-releases.
+See `Status of Python versions section of the Python's Developer Guide
+<https://devguide.python.org/versions/>`__ for more information about
+bugfix releases. Also, consult :pep:`387` to learn more about Python's
+Backward Compatibilty policy.
 
 Not all releases are bugfix releases.  In the run-up to a new feature release, a
 series of development releases are made, denoted as alpha, beta, or release

--- a/Doc/faq/general.rst
+++ b/Doc/faq/general.rst
@@ -133,7 +133,9 @@ Python versions are numbered "A.B.C" or "A.B":
   changes.
 * *C* is the micro version number -- it is incremented for each bugfix release.
 
-See :pep:`6` for more information about bugfix releases.
+See `Status of Python versions section of the Python's Developer Guide 
+<https://devguide.python.org/versions/>`__ for more information about bugfix
+releases.
 
 Not all releases are bugfix releases.  In the run-up to a new feature release, a
 series of development releases are made, denoted as alpha, beta, or release

--- a/Doc/faq/general.rst
+++ b/Doc/faq/general.rst
@@ -133,11 +133,6 @@ Python versions are numbered "A.B.C" or "A.B":
   changes.
 * *C* is the micro version number -- it is incremented for each bugfix release.
 
-See the `Developer's Guide
-<https://devguide.python.org/developer-workflow/development-cycle/>`__ for more information about
-the development cycle, and :pep:`387` to learn more about Python's
-backward compatibility policy.
-
 Not all releases are bugfix releases.  In the run-up to a new feature release, a
 series of development releases are made, denoted as alpha, beta, or release
 candidate.  Alphas are early releases in which interfaces aren't yet finalized;
@@ -160,7 +155,11 @@ unreleased versions, built directly from the CPython development repository.  In
 practice, after a final minor release is made, the version is incremented to the
 next minor version, which becomes the "a0" version, e.g. "2.4a0".
 
-See also the documentation for :data:`sys.version`, :data:`sys.hexversion`, and
+See the `Developer's Guide
+<https://devguide.python.org/developer-workflow/development-cycle/>__`
+for more information about the development cycle, and
+:pep:`387` to learn more about Python's backward compatibility policy.  See also
+the documentation for :data:`sys.version`, :data:`sys.hexversion`, and
 :data:`sys.version_info`.
 
 

--- a/Doc/faq/general.rst
+++ b/Doc/faq/general.rst
@@ -133,10 +133,10 @@ Python versions are numbered "A.B.C" or "A.B":
   changes.
 * *C* is the micro version number -- it is incremented for each bugfix release.
 
-See `Status of Python versions section of the Python's Developer Guide
-<https://devguide.python.org/versions/>`__ for more information about
-bugfix releases. Also, consult :pep:`387` to learn more about Python's
-Backward Compatibilty policy.
+See the `Developer's Guide
+<https://devguide.python.org/developer-workflow/development-cycle/>`__ for more information about
+the development cycle, and :pep:`387` to learn more about Python's
+backward compatibility policy.
 
 Not all releases are bugfix releases.  In the run-up to a new feature release, a
 series of development releases are made, denoted as alpha, beta, or release

--- a/Doc/faq/general.rst
+++ b/Doc/faq/general.rst
@@ -156,7 +156,7 @@ practice, after a final minor release is made, the version is incremented to the
 next minor version, which becomes the "a0" version, e.g. "2.4a0".
 
 See the `Developer's Guide
-<https://devguide.python.org/developer-workflow/development-cycle/>__`
+<https://devguide.python.org/developer-workflow/development-cycle/>`__
 for more information about the development cycle, and
 :pep:`387` to learn more about Python's backward compatibility policy.  See also
 the documentation for :data:`sys.version`, :data:`sys.hexversion`, and


### PR DESCRIPTION
Remove link to deprecated PEP 6 in FAQ guide.

I looked for other mentions of PEP 6. I only found mentions in the translated docs.

Closes: https://github.com/python/cpython/issues/116010

<!-- gh-issue-number: gh-116010 -->
* Issue: gh-116010
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--116246.org.readthedocs.build/en/116246/faq/general.html#how-does-the-python-version-numbering-scheme-work

<!-- readthedocs-preview cpython-previews end -->