### PR TITLE
gh-115398: Increment PyExpat_CAPI_MAGIC for SetReparseDeferralEnabled addition

### DIFF
--- a/Include/pyexpat.h
+++ b/Include/pyexpat.h
@@ -3,7 +3,7 @@
 
 /* note: you must import expat.h before importing this module! */
 
-#define PyExpat_CAPI_MAGIC  "pyexpat.expat_CAPI 1.1"
+#define PyExpat_CAPI_MAGIC  "pyexpat.expat_CAPI 1.2"
 #define PyExpat_CAPSULE_NAME "pyexpat.expat_CAPI"
 
 struct PyExpat_CAPI

--- a/Misc/NEWS.d/next/Security/2024-02-18-03-14-40.gh-issue-115398.tzvxH8.rst
+++ b/Misc/NEWS.d/next/Security/2024-02-18-03-14-40.gh-issue-115398.tzvxH8.rst
@@ -1,8 +1,8 @@
 Allow controlling Expat >=2.6.0 reparse deferral (CVE-2023-52425) by adding
 five new methods:
 
-* ``xml.etree.ElementTree.XMLParser.flush``
-* ``xml.etree.ElementTree.XMLPullParser.flush``
-* ``xml.parsers.expat.xmlparser.GetReparseDeferralEnabled``
-* ``xml.parsers.expat.xmlparser.SetReparseDeferralEnabled``
-* ``xml.sax.expatreader.ExpatParser.flush``
+* :meth:`xml.etree.ElementTree.XMLParser.flush`
+* :meth:`xml.etree.ElementTree.XMLPullParser.flush`
+* :meth:`xml.parsers.expat.xmlparser.GetReparseDeferralEnabled`
+* :meth:`xml.parsers.expat.xmlparser.SetReparseDeferralEnabled`
+* :meth:`xml.sax.expatreader.ExpatParser.flush`


### PR DESCRIPTION
Increment PyExpat_CAPI_MAGIC due to SetReparseDeferralEnabled addition.

This is a followup to git commit 6a95676bb526261434dd068d6c49927c44d24a9b from Github PR #115623.

Also ReSTify's the NEWS entry.

<!-- gh-issue-number: gh-115398 -->
* Issue: gh-115398
<!-- /gh-issue-number -->
