### PR TITLE
gh-108562: Revert enabling -fstrict-overflow for libmpdec

### DIFF
--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -1213,7 +1213,7 @@ PYTHON_HEADERS= \
 
 ##########################################################################
 # Build static libmpdec.a
-LIBMPDEC_CFLAGS=$(PY_STDMODULE_CFLAGS) @LIBMPDEC_CFLAGS@ $(CCSHARED)
+LIBMPDEC_CFLAGS=@LIBMPDEC_CFLAGS@ $(PY_STDMODULE_CFLAGS) $(CCSHARED)
 
 # "%.o: %c" is not portable
 Modules/_decimal/libmpdec/basearith.o: $(srcdir)/Modules/_decimal/libmpdec/basearith.c $(LIBMPDEC_HEADERS) $(PYTHON_HEADERS)

--- a/configure
+++ b/configure
@@ -14516,13 +14516,6 @@ else $as_nop
   LIBMPDEC_LDFLAGS="-lm \$(LIBMPDEC_A)"
   LIBMPDEC_INTERNAL="\$(LIBMPDEC_HEADERS) \$(LIBMPDEC_A)"
 
-    if test "x$ac_cv_cc_supports_fstrict_overflow" = xyes
-then :
-
-    as_fn_append LIBMPDEC_CFLAGS " -fstrict-overflow"
-
-fi
-
     if test "x$with_pydebug" = xyes
 then :
 

--- a/configure.ac
+++ b/configure.ac
@@ -3896,11 +3896,6 @@ AS_VAR_IF([with_system_libmpdec], [yes], [
   LIBMPDEC_LDFLAGS="-lm \$(LIBMPDEC_A)"
   LIBMPDEC_INTERNAL="\$(LIBMPDEC_HEADERS) \$(LIBMPDEC_A)"
 
-  dnl Enable strict-overflow for libmpdec, if available, see GH-108562
-  AS_VAR_IF([ac_cv_cc_supports_fstrict_overflow], [yes], [
-    AS_VAR_APPEND([LIBMPDEC_CFLAGS], [" -fstrict-overflow"])
-  ])
-
   dnl Disable forced inlining in debug builds, see GH-94847
   AS_VAR_IF([with_pydebug], [yes], [
     AS_VAR_APPEND([LIBMPDEC_CFLAGS], [" -DTEST_COVERAGE"])


### PR DESCRIPTION
Reverts -fstrict-overflow for libmpdec, added in #114751.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-108562 -->
* Issue: gh-108562
<!-- /gh-issue-number -->
