### PR TITLE
GH-106747: Prepare pathlib globbing for dir_fd support.

### DIFF
--- a/Lib/pathlib/__init__.py
+++ b/Lib/pathlib/__init__.py
@@ -454,8 +454,8 @@ class PurePath(_abc.PurePathBase):
         return prefix + quote_from_bytes(os.fsencode(path))
 
     @property
-    def _pattern_stack(self):
-        """Stack of path components, to be used with patterns in glob()."""
+    def _pattern_parts(self):
+        """List of path components, to be used with patterns in glob()."""
         parts = self._tail.copy()
         pattern = self._raw_path
         if self.anchor:
@@ -465,8 +465,7 @@ class PurePath(_abc.PurePathBase):
         elif pattern[-1] in (self.pathmod.sep, self.pathmod.altsep):
             # GH-65238: pathlib doesn't preserve trailing slash. Add it back.
             parts.append('')
-        parts.reverse()
-        return parts
+        return tuple(parts)
 
     @property
     def _pattern_str(self):


### PR DESCRIPTION
The present implementation of `pathlib.Path.glob()` creates a series of 'selectors' that each handle a part of the pattern. The selectors are connected together in `glob()`, without the use of recursion. One very subtle property of this scheme is that each selector is exhausted *before* its successor selector - for example when globbing `*/*.py`, the selector for `*` is exhausted prior to the selector for `*.py`. This doesn't make any difference when globbing strings, but it does prevent us from adding `dir_fd` support, because there's no good moment to call `os.close(fd)` after opening a directory for scanning.

This patch refactors globbing to work much as it did in 3.12, where each selector is responsible for creating and feeding its own successor. This inverts the order of selector exhaustion, and so will make it much easier to add `dir_fd` support.

There's one behaviour change here: I've removed deduplication of results, and so in some quite specific circumstances (multiple non-consecutive `**` segments in pattern, and either `follow_symlinks=None` or `..` segments separating them), `glob()` can yield the same path more than once. Note that `glob.glob()` can also yield duplicate results - see GH-104269.


<!-- gh-issue-number: gh-106747 -->
* Issue: gh-106747
<!-- /gh-issue-number -->
