### PR TITLE
gh-116325: Raise `SyntaxError` on ForwardRef with empty string arg

### DIFF
--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -5867,6 +5867,12 @@ class ForwardRefTests(BaseTestCase):
         with self.assertRaises(SyntaxError):
             get_type_hints(foo)
 
+    def test_syntax_error_empty_string(self):
+        for form in [typing.List, typing.Set, typing.Type, typing.Deque]:
+            with self.subTest(form=form):
+                with self.assertRaises(SyntaxError):
+                    form['']
+
     def test_name_error(self):
 
         def foo(a: 'Noode[T]'):

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -880,7 +880,7 @@ class ForwardRef(_Final, _root=True):
         # If we do `def f(*args: *Ts)`, then we'll have `arg = '*Ts'`.
         # Unfortunately, this isn't a valid expression on its own, so we
         # do the unpacking manually.
-        if arg and arg[0] == '*':
+        if arg.startswith('*'):
             arg_to_compile = f'({arg},)[0]'  # E.g. (*Ts,)[0] or (*tuple[int, int],)[0]
         else:
             arg_to_compile = arg

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -880,7 +880,7 @@ class ForwardRef(_Final, _root=True):
         # If we do `def f(*args: *Ts)`, then we'll have `arg = '*Ts'`.
         # Unfortunately, this isn't a valid expression on its own, so we
         # do the unpacking manually.
-        if arg[0] == '*':
+        if arg and arg[0] == '*':
             arg_to_compile = f'({arg},)[0]'  # E.g. (*Ts,)[0] or (*tuple[int, int],)[0]
         else:
             arg_to_compile = arg

--- a/Misc/NEWS.d/next/Library/2024-03-05-02-09-18.gh-issue-116325.FmlBYv.rst
+++ b/Misc/NEWS.d/next/Library/2024-03-05-02-09-18.gh-issue-116325.FmlBYv.rst
@@ -1,0 +1,2 @@
+:mod:`typing`: raise :exc:`SyntaxError` instead of :exc:`AttributeError`
+on forward references as empty strings.


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
    typing.Type['']
    ~~~~~~~~~~~^^^^
  File "/Users/sobolev/Desktop/cpython2/Lib/typing.py", line 389, in inner
    return _caches[func](*args, **kwds)
           ~~~~~~~~~~~~~^^^^^^^^^^^^^^^
  File "/Users/sobolev/Desktop/cpython2/Lib/typing.py", line 1458, in __getitem__
    params = tuple(_type_check(p, msg) for p in params)
             ~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/sobolev/Desktop/cpython2/Lib/typing.py", line 1458, in <genexpr>
    params = tuple(_type_check(p, msg) for p in params)
                   ~~~~~~~~~~~^^^^^^^^
  File "/Users/sobolev/Desktop/cpython2/Lib/typing.py", line 187, in _type_check
    arg = _type_convert(arg, module=module, allow_special_forms=allow_special_forms)
          ~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/sobolev/Desktop/cpython2/Lib/typing.py", line 165, in _type_convert
    return ForwardRef(arg, module=module, is_class=allow_special_forms)
           ~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/sobolev/Desktop/cpython2/Lib/typing.py", line 890, in __init__
    raise SyntaxError(f"Forward reference must be an expression -- got {arg!r}")
SyntaxError: Forward reference must be an expression -- got ''
```

<!-- gh-issue-number: gh-116325 -->
* Issue: gh-116325
<!-- /gh-issue-number -->
