### PR TITLE
gh-112075: Support freeing object memory via QSBR

### DIFF
--- a/Include/internal/pycore_pymem.h
+++ b/Include/internal/pycore_pymem.h
@@ -119,6 +119,9 @@ extern int _PyMem_DebugEnabled(void);
 // Enqueue a pointer to be freed possibly after some delay.
 extern void _PyMem_FreeDelayed(void *ptr);
 
+// Enqueue an object to be freed possibly after some delay
+extern void _PyObject_FreeDelayed(void *ptr);
+
 // Periodically process delayed free requests.
 extern void _PyMem_ProcessDelayed(PyThreadState *tstate);
 

--- a/Objects/obmalloc.c
+++ b/Objects/obmalloc.c
@@ -957,7 +957,7 @@ _PyMem_Strdup(const char *str)
 
 // A pointer to be freed once the QSBR read sequence reaches qsbr_goal.
 struct _mem_work_item {
-    void *ptr;
+    uintptr_t ptr; // lowest bit tagged 1 for objects freed with PyObject_Free
     uint64_t qsbr_goal;
 };
 
@@ -971,16 +971,27 @@ struct _mem_work_chunk {
     struct _mem_work_item array[WORK_ITEMS_PER_CHUNK];
 };
 
-void
-_PyMem_FreeDelayed(void *ptr)
+static void
+free_work_item(uintptr_t ptr)
+{
+    if (ptr & 0x01) {
+        PyObject_Free((char *)(ptr - 1));
+    }
+    else {
+        PyMem_Free((void *)ptr);
+    }
+}
+
+static void
+free_delayed(uintptr_t ptr)
 {
 #ifndef Py_GIL_DISABLED
-    PyMem_Free(ptr);
+    free_work_item(ptr);
 #else
     if (_PyRuntime.stoptheworld.world_stopped) {
         // Free immediately if the world is stopped, including during
         // interpreter shutdown.
-        PyMem_Free(ptr);
+        free_work_item(ptr);
         return;
     }
 
@@ -1007,7 +1018,7 @@ _PyMem_FreeDelayed(void *ptr)
     if (buf == NULL) {
         // failed to allocate a buffer, free immediately
         _PyEval_StopTheWorld(tstate->base.interp);
-        PyMem_Free(ptr);
+        free_work_item(ptr);
         _PyEval_StartTheWorld(tstate->base.interp);
         return;
     }
@@ -1022,6 +1033,20 @@ _PyMem_FreeDelayed(void *ptr)
         _PyMem_ProcessDelayed((PyThreadState *)tstate);
     }
 #endif
+}
+
+void
+_PyMem_FreeDelayed(void *ptr)
+{
+    assert(!((uintptr_t)ptr & 0x01));
+    free_delayed((uintptr_t)ptr);
+}
+
+void
+_PyObject_FreeDelayed(void *ptr)
+{
+    assert(!((uintptr_t)ptr & 0x01));
+    free_delayed(((uintptr_t)ptr)|0x01);
 }
 
 static struct _mem_work_chunk *
@@ -1043,7 +1068,7 @@ process_queue(struct llist_node *head, struct _qsbr_thread_state *qsbr,
                 return;
             }
 
-            PyMem_Free(item->ptr);
+            free_work_item(item->ptr);
             buf->rd_idx++;
         }
 
@@ -1130,7 +1155,7 @@ _PyMem_FiniDelayed(PyInterpreterState *interp)
             // Free the remaining items immediately. There should be no other
             // threads accessing the memory at this point during shutdown.
             struct _mem_work_item *item = &buf->array[buf->rd_idx];
-            PyMem_Free(item->ptr);
+            free_work_item(item->ptr);
             buf->rd_idx++;
         }
 

--- a/Python/gc_free_threading.c
+++ b/Python/gc_free_threading.c
@@ -1692,6 +1692,7 @@ PyObject_GC_Del(void *op)
 {
     size_t presize = _PyType_PreHeaderSize(((PyObject *)op)->ob_type);
     if (_PyObject_GC_IS_TRACKED(op)) {
+        _PyObject_GC_UNTRACK(op);
 #ifdef Py_DEBUG
         PyObject *exc = PyErr_GetRaisedException();
         if (PyErr_WarnExplicitFormat(PyExc_ResourceWarning, "gc", 0,
@@ -1704,8 +1705,13 @@ PyObject_GC_Del(void *op)
     }
 
     record_deallocation(_PyThreadState_GET());
-
-    PyObject_Free(((char *)op)-presize);
+    PyObject *self = (PyObject *)op;
+    if (_PyObject_GC_IS_SHARED_INLINE(self)) {
+        _PyObject_FreeDelayed(((char *)op)-presize);
+    }
+    else {
+        PyObject_Free(((char *)op)-presize);
+    }
 }
 
 int


### PR DESCRIPTION
Adds support for freeing GC objects with QSBR.  This will enable objects with in-lined values to be freed.

Currently this is just freeing any object that gets shared as being freed by QSBR.  We may want to break this into 2 bits so that when we mark a dict or a list as shared that the underlying object gets freed and only the values get delayed.

<!-- gh-issue-number: gh-112075 -->
* Issue: gh-112075
<!-- /gh-issue-number -->
