### PR TITLE
[3.11] Fix the PyGetSetDef documentation (GH-116056)

### DIFF
--- a/Doc/c-api/structures.rst
+++ b/Doc/c-api/structures.rst
@@ -570,13 +570,13 @@ Accessing attributes of extension types
    +-------------+------------------+-----------------------------------+
    | doc         | const char \*    | optional docstring                |
    +-------------+------------------+-----------------------------------+
-   | closure     | void \*          | optional function pointer,        |
+   | closure     | void \*          | optional user data pointer,       |
    |             |                  | providing additional data for     |
    |             |                  | getter and setter                 |
    +-------------+------------------+-----------------------------------+
 
    The ``get`` function takes one :c:expr:`PyObject*` parameter (the
-   instance) and a function pointer (the associated ``closure``)::
+   instance) and a user data pointer (the associated ``closure``)::
 
       typedef PyObject *(*getter)(PyObject *, void *);
 
@@ -584,7 +584,7 @@ Accessing attributes of extension types
    on failure.
 
    ``set`` functions take two :c:expr:`PyObject*` parameters (the instance and
-   the value to be set) and a function pointer (the associated ``closure``)::
+   the value to be set) and a user data pointer (the associated ``closure``)::
 
       typedef int (*setter)(PyObject *, PyObject *, void *);
 


### PR DESCRIPTION
closure is not a function pointer, it is a user data pointer.
(cherry picked from commit df594011089a83d151ac7000954665536f3461b5)


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--116368.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->