### PR TITLE
gh-116112: Fix `ResourceWarning` in `test_asyncio.test_stream`

### DIFF
--- a/Lib/test/test_asyncio/test_streams.py
+++ b/Lib/test/test_asyncio/test_streams.py
@@ -1188,6 +1188,7 @@ os.close(fd)
 
     def test_unhandled_cancel(self):
         async def handle_echo(reader, writer):
+            writer.close()
             asyncio.current_task().cancel()
         messages = self._basetest_unhandled_exceptions(handle_echo)
         self.assertEqual(messages, [])


### PR DESCRIPTION
I've done local testing:

```
» ./python.exe -We -m test test_asyncio.test_streams -m test_unhandled_cancel
Using random seed: 3038344157
0:00:00 load avg: 0.73 Run 1 test sequentially
0:00:00 load avg: 0.73 [1/1] test_asyncio.test_streams

== Tests result: SUCCESS ==

1 test OK.

Total duration: 194 ms
Total tests: run=1 (filtered)
Total test files: run=1/1 (filtered)
Result: SUCCESS
```

It works. This solution was proposed by @CendioOssman in https://github.com/python/cpython/issues/116112#issuecomment-1979059863

Co-authored-by: @CendioOssman

<!-- gh-issue-number: gh-116112 -->
* Issue: gh-116112
<!-- /gh-issue-number -->
