### PR TITLE
gh-71052: Implement `ctypes.util.find_library` on Android

### DIFF
--- a/Doc/library/ctypes.rst
+++ b/Doc/library/ctypes.rst
@@ -1335,8 +1335,9 @@ Here are some examples::
    'libbz2.so.1.0'
    >>>
 
-On macOS, :func:`~ctypes.util.find_library` tries several predefined naming schemes and paths
-to locate the library, and returns a full pathname if successful::
+On macOS and Android, :func:`~ctypes.util.find_library` uses the system's
+standard naming schemes and paths to locate the library, and returns a full
+pathname if successful::
 
    >>> from ctypes.util import find_library
    >>> find_library("c")

--- a/Lib/ctypes/util.py
+++ b/Lib/ctypes/util.py
@@ -89,6 +89,15 @@ elif sys.platform.startswith("aix"):
 
     from ctypes._aix import find_library
 
+elif sys.platform == "android":
+    def find_library(name):
+        directory = "/system/lib"
+        if "64" in os.uname().machine:
+            directory += "64"
+
+        fname = f"{directory}/lib{name}.so"
+        return fname if os.path.isfile(fname) else None
+
 elif os.name == "posix":
     # Andreas Degert's find functions, using gcc, /sbin/ldconfig, objdump
     import re, tempfile

--- a/Lib/test/test_ctypes/test_find.py
+++ b/Lib/test/test_ctypes/test_find.py
@@ -132,9 +132,20 @@ class FindLibraryLinux(unittest.TestCase):
 @unittest.skipUnless(sys.platform == 'android', 'Test only valid for Android')
 class FindLibraryAndroid(unittest.TestCase):
     def test_find(self):
-        for name in ["c", "m", "z", "log"]:
+        for name in [
+            "c", "m",  # POSIX
+            "z",  # Non-POSIX, but present on Linux
+            "log",  # Not present on Linux
+        ]:
             with self.subTest(name=name):
-                self.assertIsNotNone(find_library(name))
+                path = find_library(name)
+                self.assertIsInstance(path, str)
+                self.assertEqual(
+                    os.path.dirname(path),
+                    "/system/lib64" if "64" in os.uname().machine
+                    else "/system/lib")
+                self.assertEqual(os.path.basename(path), f"lib{name}.so")
+                self.assertTrue(os.path.isfile(path), path)
 
         for name in ["libc", "nonexistent"]:
             with self.subTest(name=name):

--- a/Lib/test/test_ctypes/test_find.py
+++ b/Lib/test/test_ctypes/test_find.py
@@ -129,5 +129,17 @@ class FindLibraryLinux(unittest.TestCase):
         self.assertIsNone(find_library("libc"))
 
 
+@unittest.skipUnless(sys.platform == 'android', 'Test only valid for Android')
+class FindLibraryAndroid(unittest.TestCase):
+    def test_find(self):
+        for name in ["c", "m", "z", "log"]:
+            with self.subTest(name=name):
+                self.assertIsNotNone(find_library(name))
+
+        for name in ["libc", "nonexistent"]:
+            with self.subTest(name=name):
+                self.assertIsNone(find_library(name))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/Misc/NEWS.d/next/Library/2024-03-05-19-56-29.gh-issue-71052.PMDK--.rst
+++ b/Misc/NEWS.d/next/Library/2024-03-05-19-56-29.gh-issue-71052.PMDK--.rst
@@ -1,0 +1,1 @@
+Implement :func:`ctypes.util.find_library` on Android.


### PR DESCRIPTION
None of the existing `find_library` techniques work on Android. This PR adds a simple implementation based on the fact that the system library directory is always `/system/lib` on 32-bit devices, and `/system/lib64` on 64-bit devices.

<!-- gh-issue-number: gh-71052 -->
* Issue: gh-71052
<!-- /gh-issue-number -->
