### PR TITLE
gh-116386: Fix format string "%ld" warning in `_xxinterpqueuesmodule`

### DIFF
--- a/Modules/_xxinterpqueuesmodule.c
+++ b/Modules/_xxinterpqueuesmodule.c
@@ -759,7 +759,7 @@ _queuerefs_clear(_queueref *head)
 #ifdef Py_DEBUG
     if (queue->items.count > 0) {
         fprintf(stderr, "queue %" PRId64 " still holds %" PRId64 " items\n",
-                qid, queue->items.count);
+                qid, (int64_t)queue->items.count);
     }
 #endif
         _queue_free(queue);

--- a/Modules/_xxinterpqueuesmodule.c
+++ b/Modules/_xxinterpqueuesmodule.c
@@ -758,8 +758,8 @@ _queuerefs_clear(_queueref *head)
         _queue_kill_and_wait(queue);
 #ifdef Py_DEBUG
     if (queue->items.count > 0) {
-        fprintf(stderr, "queue %" PRId64 " still holds %" PRId64 " items\n",
-                qid, (int64_t)queue->items.count);
+        fprintf(stderr, "queue %" PRId64 " still holds %zd items\n",
+                qid, queue->items.count);
     }
 #endif
         _queue_free(queue);


### PR DESCRIPTION
No warnings should be generate on GitHub. Locally this passes just fine.

<!-- gh-issue-number: gh-116386 -->
* Issue: gh-116386
<!-- /gh-issue-number -->
