### PR TITLE
gh-116404: Handle errors correctly in `wait_helper` in `posixmodule`

### DIFF
--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -9577,38 +9577,49 @@ wait_helper(PyObject *module, pid_t pid, int status, struct rusage *ru)
     if (!result)
         return NULL;
 
+    PyObject *pidObject = PyLong_FromPid(pid);
+    if (pidObject == NULL) {
+        goto error;
+    }
+    int pos = 0;
+
 #ifndef doubletime
 #define doubletime(TV) ((double)(TV).tv_sec + (TV).tv_usec * 0.000001)
 #endif
 
-    PyStructSequence_SET_ITEM(result, 0,
-                              PyFloat_FromDouble(doubletime(ru->ru_utime)));
-    PyStructSequence_SET_ITEM(result, 1,
-                              PyFloat_FromDouble(doubletime(ru->ru_stime)));
-#define SET_INT(result, index, value)\
-        PyStructSequence_SET_ITEM(result, index, PyLong_FromLong(value))
-    SET_INT(result, 2, ru->ru_maxrss);
-    SET_INT(result, 3, ru->ru_ixrss);
-    SET_INT(result, 4, ru->ru_idrss);
-    SET_INT(result, 5, ru->ru_isrss);
-    SET_INT(result, 6, ru->ru_minflt);
-    SET_INT(result, 7, ru->ru_majflt);
-    SET_INT(result, 8, ru->ru_nswap);
-    SET_INT(result, 9, ru->ru_inblock);
-    SET_INT(result, 10, ru->ru_oublock);
-    SET_INT(result, 11, ru->ru_msgsnd);
-    SET_INT(result, 12, ru->ru_msgrcv);
-    SET_INT(result, 13, ru->ru_nsignals);
-    SET_INT(result, 14, ru->ru_nvcsw);
-    SET_INT(result, 15, ru->ru_nivcsw);
-#undef SET_INT
+#define SET_RESULT(CALL)                                     \
+    do {                                                     \
+        PyObject *item = (CALL);                             \
+        if (item == NULL) {                                  \
+            goto error;                                      \
+        }                                                    \
+        PyStructSequence_SET_ITEM(result, pos++, item);      \
+    } while(0)
 
-    if (PyErr_Occurred()) {
-        Py_DECREF(result);
-        return NULL;
-    }
+    SET_RESULT(PyFloat_FromDouble(doubletime(ru->ru_utime)));
+    SET_RESULT(PyFloat_FromDouble(doubletime(ru->ru_stime)));
+    SET_RESULT(PyLong_FromLong(ru->ru_maxrss));
+    SET_RESULT(PyLong_FromLong(ru->ru_ixrss));
+    SET_RESULT(PyLong_FromLong(ru->ru_idrss));
+    SET_RESULT(PyLong_FromLong(ru->ru_isrss));
+    SET_RESULT(PyLong_FromLong(ru->ru_minflt));
+    SET_RESULT(PyLong_FromLong(ru->ru_majflt));
+    SET_RESULT(PyLong_FromLong(ru->ru_nswap));
+    SET_RESULT(PyLong_FromLong(ru->ru_inblock));
+    SET_RESULT(PyLong_FromLong(ru->ru_oublock));
+    SET_RESULT(PyLong_FromLong(ru->ru_msgsnd));
+    SET_RESULT(PyLong_FromLong(ru->ru_msgrcv));
+    SET_RESULT(PyLong_FromLong(ru->ru_nsignals));
+    SET_RESULT(PyLong_FromLong(ru->ru_nvcsw));
+    SET_RESULT(PyLong_FromLong(ru->ru_nivcsw));
+#undef SET_RESULT
 
-    return Py_BuildValue("NiN", PyLong_FromPid(pid), status, result);
+    return Py_BuildValue("NiN", pidObject, status, result);
+
+error:
+    Py_XDECREF(pidObject);
+    Py_DECREF(result);
+    return NULL;
 }
 #endif /* HAVE_WAIT3 || HAVE_WAIT4 */
 

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -9577,10 +9577,6 @@ wait_helper(PyObject *module, pid_t pid, int status, struct rusage *ru)
     if (!result)
         return NULL;
 
-    PyObject *pidObject = PyLong_FromPid(pid);
-    if (pidObject == NULL) {
-        goto error;
-    }
     int pos = 0;
 
 #ifndef doubletime
@@ -9591,7 +9587,8 @@ wait_helper(PyObject *module, pid_t pid, int status, struct rusage *ru)
     do {                                                     \
         PyObject *item = (CALL);                             \
         if (item == NULL) {                                  \
-            goto error;                                      \
+            Py_DECREF(result);                               \
+            return NULL;                                     \
         }                                                    \
         PyStructSequence_SET_ITEM(result, pos++, item);      \
     } while(0)
@@ -9614,12 +9611,7 @@ wait_helper(PyObject *module, pid_t pid, int status, struct rusage *ru)
     SET_RESULT(PyLong_FromLong(ru->ru_nivcsw));
 #undef SET_RESULT
 
-    return Py_BuildValue("NiN", pidObject, status, result);
-
-error:
-    Py_XDECREF(pidObject);
-    Py_DECREF(result);
-    return NULL;
+    return Py_BuildValue("NiN", PyLong_FromPid(pid), status, result);
 }
 #endif /* HAVE_WAIT3 || HAVE_WAIT4 */
 


### PR DESCRIPTION
This would need backports to 3.12 and 3.11: https://github.com/python/cpython/blob/3.11/Modules/posixmodule.c#L8395-L8426

I've also noticed really strange refleak output (it is the same before and after):

```
» ./python.exe -m test -R 3:3 test_wait4 test_wait3 
Using random seed: 3926646517
0:00:00 load avg: 1.33 Run 2 tests sequentially
0:00:00 load avg: 1.33 [1/2] test_wait4
beginning 6 repetitions. Showing number of leaks (. for 0 or less, X for 10 or more)
123:456
XX. .1.
test_wait4 leaked [-1, 1, 0] memory blocks, sum=0 (this is fine)
0:00:30 load avg: 1.71 [2/2] test_wait3 -- test_wait4 passed in 30.5 sec
beginning 6 repetitions. Showing number of leaks (. for 0 or less, X for 10 or more)
123:456
XX. ...
test_wait3 passed in 30.6 sec

== Tests result: SUCCESS ==

All 2 tests OK.

Total duration: 1 min 1 sec
Total tests: run=5
Total test files: run=2/2
Result: SUCCESS
```

<!-- gh-issue-number: gh-116404 -->
* Issue: gh-116404
<!-- /gh-issue-number -->
