### PR TITLE
gh-88352: Make TimedRotatingFileHandler tests more stable

### DIFF
--- a/Lib/test/test_logging.py
+++ b/Lib/test/test_logging.py
@@ -6080,7 +6080,7 @@ class TimedRotatingFileHandlerTest(BaseFileTest):
                     print(tf.read())
         self.assertTrue(found, msg=msg)
 
-    def test_rollover_at_midnight(self):
+    def test_rollover_at_midnight(self, weekly=False):
         os_helper.unlink(self.fn)
         now = datetime.datetime.now()
         atTime = now.time()
@@ -6092,9 +6092,10 @@ class TimedRotatingFileHandlerTest(BaseFileTest):
             atTime = now.time()
         atTime = atTime.replace(microsecond=0)
         fmt = logging.Formatter('%(asctime)s %(message)s')
+        when = f'W{now.weekday()}' if weekly else 'MIDNIGHT'
         for i in range(3):
             fh = logging.handlers.TimedRotatingFileHandler(
-                self.fn, encoding="utf-8", when='MIDNIGHT', atTime=atTime)
+                self.fn, encoding="utf-8", when=when, atTime=atTime)
             fh.setFormatter(fmt)
             r2 = logging.makeLogRecord({'msg': f'testing1 {i}'})
             fh.emit(r2)
@@ -6107,12 +6108,12 @@ class TimedRotatingFileHandlerTest(BaseFileTest):
         os.utime(self.fn, (now.timestamp() - 1,)*2)
         for i in range(2):
             fh = logging.handlers.TimedRotatingFileHandler(
-                self.fn, encoding="utf-8", when='MIDNIGHT', atTime=atTime)
+                self.fn, encoding="utf-8", when=when, atTime=atTime)
             fh.setFormatter(fmt)
             r2 = logging.makeLogRecord({'msg': f'testing2 {i}'})
             fh.emit(r2)
             fh.close()
-        rolloverDate = now - datetime.timedelta(days=1)
+        rolloverDate = now - datetime.timedelta(days=7 if weekly else 1)
         otherfn = f'{self.fn}.{rolloverDate:%Y-%m-%d}'
         self.assertLogFile(otherfn)
         with open(self.fn, encoding="utf-8") as f:
@@ -6123,46 +6124,7 @@ class TimedRotatingFileHandlerTest(BaseFileTest):
                 self.assertIn(f'testing1 {i}', line)
 
     def test_rollover_at_weekday(self):
-        os_helper.unlink(self.fn)
-        now = datetime.datetime.now()
-        atTime = now.time()
-        if not 0.1 < atTime.microsecond/1e6 < 0.9:
-            # The test requires all records to be emitted within
-            # the range of the same whole second.
-            time.sleep((0.1 - atTime.microsecond/1e6) % 1.0)
-            now = datetime.datetime.now()
-            atTime = now.time()
-        atTime = atTime.replace(microsecond=0)
-        fmt = logging.Formatter('%(asctime)s %(message)s')
-        for i in range(3):
-            fh = logging.handlers.TimedRotatingFileHandler(
-                self.fn, encoding="utf-8", when=f'W{now.weekday()}', atTime=atTime)
-            fh.setFormatter(fmt)
-            r2 = logging.makeLogRecord({'msg': f'testing1 {i}'})
-            fh.emit(r2)
-            fh.close()
-        self.assertLogFile(self.fn)
-        with open(self.fn, encoding="utf-8") as f:
-            for i, line in enumerate(f):
-                self.assertIn(f'testing1 {i}', line)
-
-        os.utime(self.fn, (now.timestamp() - 1,)*2)
-        for i in range(2):
-            fh = logging.handlers.TimedRotatingFileHandler(
-                self.fn, encoding="utf-8", when=f'W{now.weekday()}', atTime=atTime)
-            fh.setFormatter(fmt)
-            r2 = logging.makeLogRecord({'msg': f'testing2 {i}'})
-            fh.emit(r2)
-            fh.close()
-        rolloverDate = now - datetime.timedelta(days=7)
-        otherfn = f'{self.fn}.{rolloverDate:%Y-%m-%d}'
-        self.assertLogFile(otherfn)
-        with open(self.fn, encoding="utf-8") as f:
-            for i, line in enumerate(f):
-                self.assertIn(f'testing2 {i}', line)
-        with open(otherfn, encoding="utf-8") as f:
-            for i, line in enumerate(f):
-                self.assertIn(f'testing1 {i}', line)
+        self.test_rollover_at_midnight(weekly=True)
 
     def test_invalid(self):
         assertRaises = self.assertRaises


### PR DESCRIPTION
The tests failed (with less than 1% probability) if for example the file was created at 11:46:03.999, but the record was emitted at 11:46:04.001, with atTime=11:46:04, which caused an unexpected rollover. Ensure that the tests are always run within the range of the same whole second.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-88352 -->
* Issue: gh-88352
<!-- /gh-issue-number -->
