### PR TITLE
gh-115398: Revert `PyExpat_CAPI_MAGIC` version bump

### DIFF
--- a/Include/pyexpat.h
+++ b/Include/pyexpat.h
@@ -3,7 +3,7 @@
 
 /* note: you must import expat.h before importing this module! */
 
-#define PyExpat_CAPI_MAGIC  "pyexpat.expat_CAPI 1.2"
+#define PyExpat_CAPI_MAGIC  "pyexpat.expat_CAPI 1.1"
 #define PyExpat_CAPSULE_NAME "pyexpat.expat_CAPI"
 
 struct PyExpat_CAPI


### PR DESCRIPTION
This reverts part of commit eda2963378a3c292cf6bb202bb00e94e46ee6d90 from #116301 because it is both hurting and unnecessary, https://github.com/python/cpython/pull/115623#discussion_r1493801590 explains in detail why.

CC @encukou @gpshead @serhiy-storchaka (alphabetical order)

PS: Could someone add label `skip-news` for me please, I lack permissions to. Thanks! :pray: 

<!-- gh-issue-number: gh-115398 -->
* Issue: gh-115398
<!-- /gh-issue-number -->
