### PR TITLE
gh-88118: Fix some test_multiprocessing flakiness.

### DIFF
--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -3513,15 +3513,20 @@ class _TestListener(BaseTestCase):
             client = self.connection.Client(addr, authkey=authkey)
             client.send(1729)
 
-        key = b""
+        key = b''
 
         with self.connection.Listener(authkey=key) as listener:
-            threading.Thread(target=run, args=(listener.address, key)).start()
-            with listener.accept() as d:
-                self.assertEqual(d.recv(), 1729)
+            thread = threading.Thread(target=run, args=(listener.address, key))
+            thread.start()
+            try:
+                with listener.accept() as d:
+                    self.assertEqual(d.recv(), 1729)
+            finally:
+                thread.join()
 
         if self.TYPE == 'processes':
-            self.assertRaises(OSError, listener.accept)
+            with self.assertRaises(OSError):
+                listener.accept()
 
     @unittest.skipUnless(util.abstract_sockets_supported,
                          "test needs abstract socket support")


### PR DESCRIPTION
Potentially introduced by https://github.com/python/cpython/pull/25845

not joining that thread likely leads to recently observed "environment changed" logically passing but overall failing tests seen on some buildbots similar to:

```
1 test altered the execution environment (env changed):
    test.test_multiprocessing_fork.test_processes

2 re-run tests:
    test.test_multiprocessing_fork.test_processes
    test.test_multiprocessing_forkserver.test_processes
```

<!-- gh-issue-number: gh-88118 -->
* Issue: gh-88118
<!-- /gh-issue-number -->
