### PR TITLE
[3.12] gh-115664: Fix ordering of more versionadded and versionchanged directives (GH-116298)

### DIFF
--- a/Doc/c-api/contextvars.rst
+++ b/Doc/c-api/contextvars.rst
@@ -6,6 +6,8 @@ Context Variables Objects
 -------------------------
 
 .. _contextvarsobjects_pointertype_change:
+.. versionadded:: 3.7
+
 .. versionchanged:: 3.7.1
 
    .. note::
@@ -23,8 +25,6 @@ Context Variables Objects
 
       See :issue:`34762` for more details.
 
-
-.. versionadded:: 3.7
 
 This section details the public C API for the :mod:`contextvars` module.
 

--- a/Doc/c-api/import.rst
+++ b/Doc/c-api/import.rst
@@ -292,7 +292,7 @@ Importing Modules
 
       The module name, as an ASCII encoded string.
 
-   .. c: member:: PyObject* (*initfunc)(void)
+   .. c:member:: PyObject* (*initfunc)(void)
 
       Initialization function for a module built into the interpreter.
 

--- a/Doc/c-api/init.rst
+++ b/Doc/c-api/init.rst
@@ -1822,13 +1822,13 @@ pointer and a void pointer argument.
       function is generally **not** suitable for calling Python code from
       arbitrary C threads.  Instead, use the :ref:`PyGILState API<gilstate>`.
 
+   .. versionadded:: 3.1
+
    .. versionchanged:: 3.9
       If this function is called in a subinterpreter, the function *func* is
       now scheduled to be called from the subinterpreter, rather than being
       called from the main interpreter. Each subinterpreter now has its own
       list of scheduled calls.
-
-   .. versionadded:: 3.1
 
 .. _profiling:
 

--- a/Doc/c-api/refcounting.rst
+++ b/Doc/c-api/refcounting.rst
@@ -23,11 +23,11 @@ of Python objects.
 
    Use the :c:func:`Py_SET_REFCNT()` function to set an object reference count.
 
-   .. versionchanged:: 3.11
-      The parameter type is no longer :c:expr:`const PyObject*`.
-
    .. versionchanged:: 3.10
       :c:func:`Py_REFCNT()` is changed to the inline static function.
+
+   .. versionchanged:: 3.11
+      The parameter type is no longer :c:expr:`const PyObject*`.
 
 
 .. c:function:: void Py_SET_REFCNT(PyObject *o, Py_ssize_t refcnt)

--- a/Doc/library/asyncio-eventloop.rst
+++ b/Doc/library/asyncio-eventloop.rst
@@ -605,6 +605,9 @@ Opening network connections
       The *family*, *proto*, *flags*, *reuse_address*, *reuse_port*,
       *allow_broadcast*, and *sock* parameters were added.
 
+   .. versionchanged:: 3.8
+      Added support for Windows.
+
    .. versionchanged:: 3.8.1
       The *reuse_address* parameter is no longer supported, as using
       :ref:`socket.SO_REUSEADDR <socket-unix-constants>`
@@ -621,9 +624,6 @@ Opening network connections
       is used instead, which specifically
       prevents processes with differing UIDs from assigning sockets to the same
       socket address.
-
-   .. versionchanged:: 3.8
-      Added support for Windows.
 
    .. versionchanged:: 3.11
       The *reuse_address* parameter, disabled since Python 3.8.1,

--- a/Doc/library/bz2.rst
+++ b/Doc/library/bz2.rst
@@ -156,7 +156,6 @@ The :mod:`bz2` module contains:
       Support was added for *filename* being a :term:`file object` instead of an
       actual filename.
 
-   .. versionchanged:: 3.3
       The ``'a'`` (append) mode was added, along with support for reading
       multi-stream files.
 

--- a/Doc/library/collections.rst
+++ b/Doc/library/collections.rst
@@ -343,7 +343,7 @@ superset relationships: ``==``, ``!=``, ``<``, ``<=``, ``>``, ``>=``.
 All of those tests treat missing elements as having zero counts so that
 ``Counter(a=1) == Counter(a=1, b=0)`` returns true.
 
-.. versionadded:: 3.10
+.. versionchanged:: 3.10
    Rich comparison operations were added.
 
 .. versionchanged:: 3.10

--- a/Doc/library/faulthandler.rst
+++ b/Doc/library/faulthandler.rst
@@ -118,11 +118,11 @@ Dumping the tracebacks after a timeout
 
    This function is implemented using a watchdog thread.
 
-   .. versionchanged:: 3.7
-      This function is now always available.
-
    .. versionchanged:: 3.5
       Added support for passing file descriptor to this function.
+
+   .. versionchanged:: 3.7
+      This function is now always available.
 
 .. function:: cancel_dump_traceback_later()
 

--- a/Doc/library/functools.rst
+++ b/Doc/library/functools.rst
@@ -665,13 +665,9 @@ The :mod:`functools` module defines the following functions:
    on the wrapper function). :exc:`AttributeError` is still raised if the
    wrapper function itself is missing any attributes named in *updated*.
 
-   .. versionadded:: 3.2
-      Automatic addition of the ``__wrapped__`` attribute.
-
-   .. versionadded:: 3.2
-      Copying of the ``__annotations__`` attribute by default.
-
    .. versionchanged:: 3.2
+      The ``__wrapped__`` attribute is now automatically added.
+      The ``__annotations__`` attribute is now copied by default.
       Missing attributes no longer trigger an :exc:`AttributeError`.
 
    .. versionchanged:: 3.4

--- a/Doc/library/hashlib.rst
+++ b/Doc/library/hashlib.rst
@@ -77,8 +77,6 @@ accessible by name via :func:`new`.  See :data:`algorithms_available`.
    SHA3 (Keccak) and SHAKE constructors :func:`sha3_224`, :func:`sha3_256`,
    :func:`sha3_384`, :func:`sha3_512`, :func:`shake_128`, :func:`shake_256`
    were added.
-
-.. versionadded:: 3.6
    :func:`blake2b` and :func:`blake2s` were added.
 
 .. _hashlib-usedforsecurity:

--- a/Doc/library/importlib.metadata.rst
+++ b/Doc/library/importlib.metadata.rst
@@ -217,7 +217,6 @@ all the metadata in a JSON-compatible form per :PEP:`566`::
    The ``Description`` is now included in the metadata when presented
    through the payload. Line continuation characters have been removed.
 
-.. versionadded:: 3.10
    The ``json`` attribute was added.
 
 

--- a/Doc/library/os.rst
+++ b/Doc/library/os.rst
@@ -2544,7 +2544,6 @@ features:
    .. versionchanged:: 3.8
       Accepts a :term:`path-like object` and a bytes object on Windows.
 
-   .. versionchanged:: 3.8
       Added support for directory junctions, and changed to return the
       substitution path (which typically includes ``\\?\`` prefix) rather
       than the optional "print name" field that was previously returned.
@@ -3045,21 +3044,21 @@ features:
 
       Time of most recent access expressed in nanoseconds as an integer.
 
-      .. versionadded: 3.3
+      .. versionadded:: 3.3
 
    .. attribute:: st_mtime_ns
 
       Time of most recent content modification expressed in nanoseconds as an
       integer.
 
-      .. versionadded: 3.3
+      .. versionadded:: 3.3
 
    .. attribute:: st_ctime_ns
 
       Time of most recent metadata change expressed in nanoseconds as an
       integer.
 
-      .. versionadded: 3.3
+      .. versionadded:: 3.3
 
       .. versionchanged:: 3.12
          ``st_ctime_ns`` is deprecated on Windows. Use ``st_birthtime_ns``
@@ -3187,10 +3186,10 @@ features:
       Windows now returns the file index as :attr:`st_ino` when
       available.
 
-   .. versionadded:: 3.7
+   .. versionchanged:: 3.7
       Added the :attr:`st_fstype` member to Solaris/derivatives.
 
-   .. versionadded:: 3.8
+   .. versionchanged:: 3.8
       Added the :attr:`st_reparse_tag` member on Windows.
 
    .. versionchanged:: 3.8
@@ -3204,16 +3203,13 @@ features:
       platforms, but for now still contains creation time.
       Use :attr:`st_birthtime` for the creation time.
 
-   .. versionchanged:: 3.12
       On Windows, :attr:`st_ino` may now be up to 128 bits, depending
       on the file system. Previously it would not be above 64 bits, and
       larger file identifiers would be arbitrarily packed.
 
-   .. versionchanged:: 3.12
       On Windows, :attr:`st_rdev` no longer returns a value. Previously
       it would contain the same as :attr:`st_dev`, which was incorrect.
 
-   .. versionadded:: 3.12
       Added the :attr:`st_birthtime` member on Windows.
 
 
@@ -4215,14 +4211,14 @@ written in Python, such as a mail server's external command delivery program.
       On macOS the use of this function is unsafe when mixed with using
       higher-level system APIs, and that includes using :mod:`urllib.request`.
 
+   .. versionchanged:: 3.8
+      Calling ``forkpty()`` in a subinterpreter is no longer supported
+      (:exc:`RuntimeError` is raised).
+
    .. versionchanged:: 3.12
       If Python is able to detect that your process has multiple
       threads, this now raises a :exc:`DeprecationWarning`. See the
       longer explanation on :func:`os.fork`.
-
-   .. versionchanged:: 3.8
-      Calling ``forkpty()`` in a subinterpreter is no longer supported
-      (:exc:`RuntimeError` is raised).
 
    .. availability:: Unix, not Emscripten, not WASI.
 
@@ -5390,19 +5386,19 @@ Random numbers
       easy-to-use interface to the random number generator provided by your
       platform, please see :class:`random.SystemRandom`.
 
-   .. versionchanged:: 3.6.0
-      On Linux, ``getrandom()`` is now used in blocking mode to increase the
-      security.
-
-   .. versionchanged:: 3.5.2
-      On Linux, if the ``getrandom()`` syscall blocks (the urandom entropy pool
-      is not initialized yet), fall back on reading ``/dev/urandom``.
-
    .. versionchanged:: 3.5
       On Linux 3.17 and newer, the ``getrandom()`` syscall is now used
       when available.  On OpenBSD 5.6 and newer, the C ``getentropy()``
       function is now used. These functions avoid the usage of an internal file
       descriptor.
+
+   .. versionchanged:: 3.5.2
+      On Linux, if the ``getrandom()`` syscall blocks (the urandom entropy pool
+      is not initialized yet), fall back on reading ``/dev/urandom``.
+
+   .. versionchanged:: 3.6
+      On Linux, ``getrandom()`` is now used in blocking mode to increase the
+      security.
 
    .. versionchanged:: 3.11
       On Windows, ``BCryptGenRandom()`` is used instead of ``CryptGenRandom()``

--- a/Doc/library/pdb.rst
+++ b/Doc/library/pdb.rst
@@ -288,14 +288,14 @@ typed at the debugger prompt.  This is particularly useful for aliases.  If both
 files exist, the one in the home directory is read first and aliases defined there
 can be overridden by the local file.
 
-.. versionchanged:: 3.11
-   :file:`.pdbrc` is now read with ``'utf-8'`` encoding. Previously, it was read
-   with the system locale encoding.
-
 .. versionchanged:: 3.2
    :file:`.pdbrc` can now contain commands that continue debugging, such as
    :pdbcmd:`continue` or :pdbcmd:`next`.  Previously, these commands had no
    effect.
+
+.. versionchanged:: 3.11
+   :file:`.pdbrc` is now read with ``'utf-8'`` encoding. Previously, it was read
+   with the system locale encoding.
 
 
 .. pdbcommand:: h(elp) [command]

--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -1491,8 +1491,7 @@ objects that compare equal might have different :attr:`~range.start`,
    sequence of values they define (instead of comparing based on
    object identity).
 
-.. versionadded:: 3.3
-   The :attr:`~range.start`, :attr:`~range.stop` and :attr:`~range.step`
+   Added the :attr:`~range.start`, :attr:`~range.stop` and :attr:`~range.step`
    attributes.
 
 .. seealso::

--- a/Doc/library/threading.rst
+++ b/Doc/library/threading.rst
@@ -360,11 +360,11 @@ since it is impossible to detect the termination of alien threads.
    base class constructor (``Thread.__init__()``) before doing anything else to
    the thread.
 
+   .. versionchanged:: 3.3
+      Added the *daemon* parameter.
+
    .. versionchanged:: 3.10
       Use the *target* name if *name* argument is omitted.
-
-   .. versionchanged:: 3.3
-      Added the *daemon* argument.
 
    .. method:: start()
 

--- a/Doc/library/time.rst
+++ b/Doc/library/time.rst
@@ -381,15 +381,14 @@ Functions
    * Or use ``nanosleep()`` if available (resolution: 1 nanosecond);
    * Or use ``select()`` (resolution: 1 microsecond).
 
-   .. versionchanged:: 3.11
-      On Unix, the ``clock_nanosleep()`` and ``nanosleep()`` functions are now
-      used if available. On Windows, a waitable timer is now used.
-
    .. versionchanged:: 3.5
       The function now sleeps at least *secs* even if the sleep is interrupted
       by a signal, except if the signal handler raises an exception (see
       :pep:`475` for the rationale).
 
+   .. versionchanged:: 3.11
+      On Unix, the ``clock_nanosleep()`` and ``nanosleep()`` functions are now
+      used if available. On Windows, a waitable timer is now used.
 
 .. index::
    single: % (percent); datetime format

--- a/Doc/library/turtle.rst
+++ b/Doc/library/turtle.rst
@@ -598,7 +598,7 @@ Turtle motion
       >>> turtle.pos()
       (20.00,30.00)
 
-   .. versionadded: 3.12
+   .. versionadded:: 3.12
 
 
 .. function:: setx(x)

--- a/Doc/library/urllib.request.rst
+++ b/Doc/library/urllib.request.rst
@@ -105,11 +105,9 @@ The :mod:`urllib.request` module defines the following functions:
    .. versionchanged:: 3.2
       *cafile* and *capath* were added.
 
-   .. versionchanged:: 3.2
       HTTPS virtual hosts are now supported if possible (that is, if
       :const:`ssl.HAS_SNI` is true).
 
-   .. versionadded:: 3.2
       *data* can be an iterable object.
 
    .. versionchanged:: 3.3

--- a/Doc/reference/lexical_analysis.rst
+++ b/Doc/reference/lexical_analysis.rst
@@ -514,7 +514,6 @@ is not supported.
    The ``'rb'`` prefix of raw bytes literals has been added as a synonym
    of ``'br'``.
 
-.. versionadded:: 3.3
    Support for the unicode legacy literal (``u'value'``) was reintroduced
    to simplify the maintenance of dual Python 2.x and 3.x codebases.
    See :pep:`414` for more information.

--- a/Doc/reference/simple_stmts.rst
+++ b/Doc/reference/simple_stmts.rst
@@ -664,8 +664,7 @@ and information about handling exceptions is in section :ref:`try`.
 .. versionchanged:: 3.3
     :const:`None` is now permitted as ``Y`` in ``raise X from Y``.
 
-.. versionadded:: 3.3
-    The :attr:`~BaseException.__suppress_context__` attribute to suppress
+    Added the :attr:`~BaseException.__suppress_context__` attribute to suppress
     automatic display of the exception context.
 
 .. versionchanged:: 3.11

--- a/Doc/using/cmdline.rst
+++ b/Doc/using/cmdline.rst
@@ -375,10 +375,10 @@ Miscellaneous options
    :envvar:`PYTHONHASHSEED` allows you to set a fixed value for the hash
    seed secret.
 
+   .. versionadded:: 3.2.3
+
    .. versionchanged:: 3.7
       The option is no longer ignored.
-
-   .. versionadded:: 3.2.3
 
 
 .. option:: -s
@@ -550,23 +550,22 @@ Miscellaneous options
    It also allows passing arbitrary values and retrieving them through the
    :data:`sys._xoptions` dictionary.
 
-   .. versionchanged:: 3.2
-      The :option:`-X` option was added.
+   .. versionadded:: 3.2
 
-   .. versionadded:: 3.3
-      The ``-X faulthandler`` option.
+   .. versionchanged:: 3.3
+      Added the ``-X faulthandler`` option.
 
-   .. versionadded:: 3.4
-      The ``-X showrefcount`` and ``-X tracemalloc`` options.
+   .. versionchanged:: 3.4
+      Added the ``-X showrefcount`` and ``-X tracemalloc`` options.
 
-   .. versionadded:: 3.6
-      The ``-X showalloccount`` option.
+   .. versionchanged:: 3.6
+      Added the ``-X showalloccount`` option.
 
-   .. versionadded:: 3.7
-      The ``-X importtime``, ``-X dev`` and ``-X utf8`` options.
+   .. versionchanged:: 3.7
+      Added the ``-X importtime``, ``-X dev`` and ``-X utf8`` options.
 
-   .. versionadded:: 3.8
-      The ``-X pycache_prefix`` option. The ``-X dev`` option now logs
+   .. versionchanged:: 3.8
+      Added the ``-X pycache_prefix`` option. The ``-X dev`` option now logs
       ``close()`` exceptions in :class:`io.IOBase` destructor.
 
    .. versionchanged:: 3.9
@@ -575,21 +574,16 @@ Miscellaneous options
 
       The ``-X showalloccount`` option has been removed.
 
-   .. versionadded:: 3.10
-      The ``-X warn_default_encoding`` option.
+   .. versionchanged:: 3.10
+      Added the ``-X warn_default_encoding`` option.
       Removed the ``-X oldparser`` option.
 
-   .. versionadded:: 3.11
-      The ``-X no_debug_ranges`` option.
+   .. versionchanged:: 3.11
+      Added the ``-X no_debug_ranges``, ``-X frozen_modules`` and
+      ``-X int_max_str_digits`` options.
 
-   .. versionadded:: 3.11
-      The ``-X frozen_modules`` option.
-
-   .. versionadded:: 3.11
-      The ``-X int_max_str_digits`` option.
-
-   .. versionadded:: 3.12
-      The ``-X perf`` option.
+   .. versionchanged:: 3.12
+      Added the ``-X perf`` option.
 
 
 Options you shouldn't use
@@ -909,10 +903,10 @@ conflict.
    * ``malloc_debug``: same as ``malloc`` but also install debug hooks.
    * ``pymalloc_debug``: same as ``pymalloc`` but also install debug hooks.
 
+   .. versionadded:: 3.6
+
    .. versionchanged:: 3.7
       Added the ``"default"`` allocator.
-
-   .. versionadded:: 3.6
 
 
 .. envvar:: PYTHONMALLOCSTATS


### PR DESCRIPTION
(cherry picked from commit 808a77612fb89b125d25efac2788522a100e8a6d)


<!-- gh-issue-number: gh-115664 -->
* Issue: gh-115664
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--116450.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->