### PR TITLE
GH-113710: Fix optimization of globals using `_CHECK_FUNCTION`

### DIFF
--- a/Python/bytecodes.c
+++ b/Python/bytecodes.c
@@ -4121,7 +4121,8 @@ dummy_func(
         }
 
         tier2 op(_CHECK_FUNCTION, (func_version/2 -- )) {
-            DEOPT_IF(frame->f_funcobj->func_version != func_version);
+            assert(PyFunction_Check(frame->f_funcobj));
+            DEOPT_IF(((PyFunctionObject *)frame->f_funcobj)->func_version != func_version);
         }
 
         /* Internal -- for testing executors */

--- a/Python/bytecodes.c
+++ b/Python/bytecodes.c
@@ -4120,8 +4120,8 @@ dummy_func(
             null = NULL;
         }
 
-        tier2 op(_CHECK_FUNCTION, (func/4 -- )) {
-            DEOPT_IF(frame->f_funcobj != func);
+        tier2 op(_CHECK_FUNCTION, (func_version/2 -- )) {
+            DEOPT_IF(frame->f_funcobj->func_version != func_version);
         }
 
         /* Internal -- for testing executors */

--- a/Python/executor_cases.c.h
+++ b/Python/executor_cases.c.h
@@ -3880,8 +3880,8 @@
         }
 
         case _CHECK_FUNCTION: {
-            PyObject *func = (PyObject *)CURRENT_OPERAND();
-            if (frame->f_funcobj != func) goto deoptimize;
+            uint32_t func_version = (uint32_t)CURRENT_OPERAND();
+            if (frame->f_funcobj->func_version != func_version) goto deoptimize;
             break;
         }
 

--- a/Python/executor_cases.c.h
+++ b/Python/executor_cases.c.h
@@ -3881,7 +3881,8 @@
 
         case _CHECK_FUNCTION: {
             uint32_t func_version = (uint32_t)CURRENT_OPERAND();
-            if (frame->f_funcobj->func_version != func_version) goto deoptimize;
+            assert(PyFunction_Check(frame->f_funcobj));
+            if (((PyFunctionObject *)frame->f_funcobj)->func_version != func_version) goto deoptimize;
             break;
         }
 

--- a/Python/optimizer_analysis.c
+++ b/Python/optimizer_analysis.c
@@ -141,9 +141,11 @@ remove_globals(_PyInterpreterFrame *frame, _PyUOpInstruction *buffer,
         return 1;
     }
     PyObject *globals = frame->f_globals;
-    assert(PyFunction_Check(((PyFunctionObject *)frame->f_funcobj)));
-    assert(((PyFunctionObject *)frame->f_funcobj)->func_builtins == builtins);
-    assert(((PyFunctionObject *)frame->f_funcobj)->func_globals == globals);
+    PyFunctionObject *function = (PyFunctionObject *)frame->f_funcobj;
+    assert(PyFunction_Check(function));
+    assert(function->func_builtins == builtins);
+    assert(function->func_globals == globals);
+    uint32_t function_version = _PyFunction_GetVersionForCurrentState(function);
     /* In order to treat globals as constants, we need to
      * know that the globals dict is the one we expected, and
      * that it hasn't changed
@@ -181,7 +183,7 @@ remove_globals(_PyInterpreterFrame *frame, _PyUOpInstruction *buffer,
                 }
                 else {
                     buffer[pc].opcode = _CHECK_FUNCTION;
-                    buffer[pc].operand = (uintptr_t)builtins;
+                    buffer[pc].operand = function_version;
                     function_checked |= 1;
                 }
                 break;
@@ -203,7 +205,7 @@ remove_globals(_PyInterpreterFrame *frame, _PyUOpInstruction *buffer,
                 }
                 else {
                     buffer[pc].opcode = _CHECK_FUNCTION;
-                    buffer[pc].operand = (uintptr_t)globals;
+                    buffer[pc].operand = function_version;
                     function_checked |= 1;
                 }
                 break;
@@ -227,7 +229,8 @@ remove_globals(_PyInterpreterFrame *frame, _PyUOpInstruction *buffer,
                     return 1;
                 }
                 assert(PyFunction_Check(func));
-                if (prechecked_function_version == func->func_version) {
+                function_version = func->func_version;
+                if (prechecked_function_version == function_version) {
                     function_checked |= 1;
                 }
                 prechecked_function_version = 0;
@@ -245,6 +248,7 @@ remove_globals(_PyInterpreterFrame *frame, _PyUOpInstruction *buffer,
                 function_checked >>= 1;
                 PyFunctionObject *func = (PyFunctionObject *)buffer[pc].operand;
                 assert(PyFunction_Check(func));
+                function_version = func->func_version;
                 globals = func->func_globals;
                 builtins = func->func_builtins;
                 break;


### PR DESCRIPTION
https://github.com/python/cpython/pull/116410 added an obvious bug: I didn't update the pointers used.
But there is more subtle bug: Using pointers rather than version numbers risks a new function appearing to be the old one.

This PR fixes both bugs.

<!-- gh-issue-number: gh-113710 -->
* Issue: gh-113710
<!-- /gh-issue-number -->
