### PR TITLE
gh-110850: Expose _PyTime_TimeUnchecked function for now

### DIFF
--- a/Include/cpython/pytime.h
+++ b/Include/cpython/pytime.h
@@ -16,6 +16,14 @@ PyAPI_FUNC(int) PyTime_Monotonic(PyTime_t *result);
 PyAPI_FUNC(int) PyTime_PerfCounter(PyTime_t *result);
 PyAPI_FUNC(int) PyTime_Time(PyTime_t *result);
 
+// Expose internal API until we figure out what to do about it,
+// see https://github.com/capi-workgroup/decisions/issues/15
+// Do not use; like any names with a leading underscore, these may go away
+// at any time.
+PyAPI_FUNC(PyTime_t) _PyTime_TimeUnchecked(void);
+PyAPI_FUNC(PyTime_t) _PyTime_MonotonicUnchecked(void);
+PyAPI_FUNC(PyTime_t) _PyTime_PerfCounterUnchecked(void);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
This should unblock #110850 as a release blocker,
while C-API WG decides what API should be added
(https://github.com/capi-workgroup/decisions/issues/15).



<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-110850 -->
* Issue: gh-110850
<!-- /gh-issue-number -->
