### PR TITLE
gh-116472: Fix invalid newlines in XML attr

### DIFF
--- a/PCbuild/regen.targets
+++ b/PCbuild/regen.targets
@@ -150,9 +150,7 @@
           Condition="($(Platform) == 'Win32' or $(Platform) == 'x64') and
                      $(Configuration) != 'PGInstrument' and $(Configuration) != 'PGUpdate'">
     <Message Text="Regenerate @(_TestFrozenOutputs->'%(Filename)%(Extension)', ' ')" Importance="high" />
-    <Exec Command='setlocal
-set PYTHONPATH=$(PySourcePath)Lib
-"$(PythonExe)" Programs\freeze_test_frozenmain.py Programs\test_frozenmain.h'
+    <Exec Command='setlocal%0D%0Aset PYTHONPATH=$(PySourcePath)Lib%0D%0A"$(PythonExe)" Programs\freeze_test_frozenmain.py Programs\test_frozenmain.h'
           WorkingDirectory="$(PySourcePath)" />
   </Target>
 


### PR DESCRIPTION
Compliant XML readers normalize newlines in attributes to spaces (https://www.w3.org/TR/2006/REC-xml11-20060816/#AVNormalize). MSBuild apparently doesn't do that, but Python's minidom parser does. Android modifies this file with minidom (to include additional license texts from the dependencies we use) so the resulting file is re-written without the newlines, which breaks the build.

<!-- gh-issue-number: gh-116472 -->
* Issue: gh-116472
<!-- /gh-issue-number -->
