### PR TITLE
[3.12] gh-116040: [Enum] fix by-value calls when second value is falsey (GH-116072)

### DIFF
--- a/Lib/enum.py
+++ b/Lib/enum.py
@@ -166,6 +166,13 @@ def _dedent(text):
         lines[j] = l[i:]
     return '\n'.join(lines)
 
+class _not_given:
+    def __repr__(self):
+        return('<not given>')
+    def __bool__(self):
+        return False
+_not_given = _not_given()
+
 class _auto_null:
     def __repr__(self):
         return '_auto_null'
@@ -718,7 +725,7 @@ class EnumType(type):
         """
         return True
 
-    def __call__(cls, value, names=None, *values, module=None, qualname=None, type=None, start=1, boundary=None):
+    def __call__(cls, value, names=_not_given, *values, module=None, qualname=None, type=None, start=1, boundary=None):
         """
         Either returns an existing member, or creates a new enum class.
 
@@ -747,18 +754,18 @@ class EnumType(type):
         """
         if cls._member_map_:
             # simple value lookup if members exist
-            if names:
+            if names is not _not_given:
                 value = (value, names) + values
             return cls.__new__(cls, value)
         # otherwise, functional API: we're creating a new Enum type
-        if names is None and type is None:
+        if names is _not_given and type is None:
             # no body? no data-type? possibly wrong usage
             raise TypeError(
                     f"{cls} has no members; specify `names=()` if you meant to create a new, empty, enum"
                     )
         return cls._create_(
                 class_name=value,
-                names=names,
+                names=names or None,
                 module=module,
                 qualname=qualname,
                 type=type,

--- a/Lib/test/test_enum.py
+++ b/Lib/test/test_enum.py
@@ -3312,65 +3312,6 @@ class TestSpecial(unittest.TestCase):
                     member._value_ = Base(value)
                     return member
 
-    def test_extra_member_creation(self):
-        class IDEnumMeta(EnumMeta):
-            def __new__(metacls, cls, bases, classdict, **kwds):
-                # add new entries to classdict
-                for name in classdict.member_names:
-                    classdict[f'{name}_DESC'] = f'-{classdict[name]}'
-                return super().__new__(metacls, cls, bases, classdict, **kwds)
-        class IDEnum(StrEnum, metaclass=IDEnumMeta):
-            pass
-        class MyEnum(IDEnum):
-            ID = 'id'
-            NAME = 'name'
-        self.assertEqual(list(MyEnum), [MyEnum.ID, MyEnum.NAME, MyEnum.ID_DESC, MyEnum.NAME_DESC])
-
-    def test_add_alias(self):
-        class mixin:
-            @property
-            def ORG(self):
-                return 'huh'
-        class Color(mixin, Enum):
-            RED = 1
-            GREEN = 2
-            BLUE = 3
-        Color.RED._add_alias_('ROJO')
-        self.assertIs(Color.RED, Color['ROJO'])
-        self.assertIs(Color.RED, Color.ROJO)
-        Color.BLUE._add_alias_('ORG')
-        self.assertIs(Color.BLUE, Color['ORG'])
-        self.assertIs(Color.BLUE, Color.ORG)
-        self.assertEqual(Color.RED.ORG, 'huh')
-        self.assertEqual(Color.GREEN.ORG, 'huh')
-        self.assertEqual(Color.BLUE.ORG, 'huh')
-        self.assertEqual(Color.ORG.ORG, 'huh')
-
-    def test_add_value_alias_after_creation(self):
-        class Color(Enum):
-            RED = 1
-            GREEN = 2
-            BLUE = 3
-        Color.RED._add_value_alias_(5)
-        self.assertIs(Color.RED, Color(5))
-
-    def test_add_value_alias_during_creation(self):
-        class Types(Enum):
-            Unknown = 0,
-            Source  = 1, 'src'
-            NetList = 2, 'nl'
-            def __new__(cls, int_value, *value_aliases):
-                member = object.__new__(cls)
-                member._value_ = int_value
-                for alias in value_aliases:
-                    member._add_value_alias_(alias)
-                return member
-        self.assertIs(Types(0), Types.Unknown)
-        self.assertIs(Types(1), Types.Source)
-        self.assertIs(Types('src'), Types.Source)
-        self.assertIs(Types(2), Types.NetList)
-        self.assertIs(Types('nl'), Types.NetList)
-
     def test_second_tuple_item_is_falsey(self):
         class Cardinal(Enum):
             RIGHT = (1, 0)

--- a/Misc/NEWS.d/next/Library/2024-02-28-13-10-17.gh-issue-116040.wDidHd.rst
+++ b/Misc/NEWS.d/next/Library/2024-02-28-13-10-17.gh-issue-116040.wDidHd.rst
@@ -1,0 +1,1 @@
+[Enum] fix by-value calls when second value is falsey; e.g. Cardinal(1, 0)


### PR DESCRIPTION
e.g Cardinal(1, 0)

(cherry picked from commit 13ffd4bd9f529b6a5fe33741fbd57f14b4b80137)


<!-- gh-issue-number: gh-116040 -->
* Issue: gh-116040
<!-- /gh-issue-number -->
