### PR TITLE
gh-115103: Fix unregistering of QSBR state

### DIFF
--- a/Python/qsbr.c
+++ b/Python/qsbr.c
@@ -233,13 +233,17 @@ _Py_qsbr_register(_PyThreadStateImpl *tstate, PyInterpreterState *interp,
 void
 _Py_qsbr_unregister(_PyThreadStateImpl *tstate)
 {
-    struct _qsbr_thread_state *qsbr = tstate->qsbr;
-    struct _qsbr_shared *shared = qsbr->shared;
-
-    assert(qsbr->seq == 0 && "thread state must be detached");
+    struct _qsbr_shared *shared = tstate->qsbr->shared;
 
     PyMutex_Lock(&shared->mutex);
+    // NOTE: we must load (or reload) the thread state's qbsr inside the mutex
+    // because the array may have been resized (changing tstate->qsbr) while
+    // we waited to acquire the mutex.
+    struct _qsbr_thread_state *qsbr = tstate->qsbr;
+
+    assert(qsbr->seq == 0 && "thread state must be detached");
     assert(qsbr->allocated && qsbr->tstate == (PyThreadState *)tstate);
+
     tstate->qsbr = NULL;
     qsbr->tstate = NULL;
     qsbr->allocated = false;


### PR DESCRIPTION
If a thread blocks while waiting on the `shared->mutex` lock, the array of QSBR states may be reallocated. In other words, the value of`tstate->qsbr` may be different before and after the `PyMutex_Lock()` call, and using the previous value across the lock acquisition is not safe.

<!-- gh-issue-number: gh-115103 -->
* Issue: gh-115103
<!-- /gh-issue-number -->
