### PR TITLE
gh-108724: Fix _PySemaphore_Wait call during thread deletion

### DIFF
--- a/Python/parking_lot.c
+++ b/Python/parking_lot.c
@@ -194,14 +194,17 @@ _PySemaphore_Wait(_PySemaphore *sema, PyTime_t timeout, int detach)
     PyThreadState *tstate = NULL;
     if (detach) {
         tstate = _PyThreadState_GET();
-        if (tstate) {
-            PyEval_ReleaseThread(tstate);
+        // Only detach if we are attached
+        if (tstate && tstate->state != _Py_THREAD_ATTACHED) {
+            tstate = NULL;
         }
     }
 
+    if (tstate) {
+        PyEval_ReleaseThread(tstate);
+    }
     int res = _PySemaphore_PlatformWait(sema, timeout);
-
-    if (detach && tstate) {
+    if (tstate) {
         PyEval_AcquireThread(tstate);
     }
     return res;

--- a/Python/parking_lot.c
+++ b/Python/parking_lot.c
@@ -194,12 +194,12 @@ _PySemaphore_Wait(_PySemaphore *sema, PyTime_t timeout, int detach)
     PyThreadState *tstate = NULL;
     if (detach) {
         tstate = _PyThreadState_GET();
-        // Only detach if we are attached
-        if (tstate && tstate->state != _Py_THREAD_ATTACHED) {
-            tstate = NULL;
-        }
-        if (tstate) {
+        if (tstate && tstate->state == _Py_THREAD_ATTACHED) {
+            // Only detach if we are attached
             PyEval_ReleaseThread(tstate);
+        }
+        else {
+            tstate = NULL;
         }
     }
     int res = _PySemaphore_PlatformWait(sema, timeout);

--- a/Python/parking_lot.c
+++ b/Python/parking_lot.c
@@ -198,10 +198,9 @@ _PySemaphore_Wait(_PySemaphore *sema, PyTime_t timeout, int detach)
         if (tstate && tstate->state != _Py_THREAD_ATTACHED) {
             tstate = NULL;
         }
-    }
-
-    if (tstate) {
-        PyEval_ReleaseThread(tstate);
+        if (tstate) {
+            PyEval_ReleaseThread(tstate);
+        }
     }
     int res = _PySemaphore_PlatformWait(sema, timeout);
     if (tstate) {


### PR DESCRIPTION
In general, when `_PyThreadState_GET()` is non-NULL then the current thread is "attached", but there is a small window during `PyThreadState_DeleteCurrent()` where that's not true: `tstate_delete_common()` is called when the thread is detached, but before current_fast_clear().

This updates `_PySemaphore_Wait()` to handle that case.


<!-- gh-issue-number: gh-108724 -->
* Issue: gh-108724
<!-- /gh-issue-number -->
