### PR TITLE
Fix markup of `win32_ver` in `platform.rst`

### DIFF
--- a/Doc/library/platform.rst
+++ b/Doc/library/platform.rst
@@ -214,8 +214,8 @@ Windows Platform
    default to an empty string).
 
    As a hint: *ptype* is ``'Uniprocessor Free'`` on single processor NT machines
-   and ``'Multiprocessor Free'`` on multi processor machines. The *'Free'* refers
-   to the OS version being free of debugging code. It could also state *'Checked'*
+   and ``'Multiprocessor Free'`` on multi processor machines. The ``'Free'`` refers
+   to the OS version being free of debugging code. It could also state ``'Checked'``
    which means the OS version uses debugging code, i.e. code that checks arguments,
    ranges, etc.
 


### PR DESCRIPTION
It used to look like this:
<img width="780" alt="Снимок экрана 2024-03-08 в 11 54 44" src="https://github.com/python/cpython/assets/4660275/4a9a3c0d-d9c6-477a-a1b5-7d27f1b3edbe">

Which was not very correct. Now all strings will have the same style.

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--116492.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->