### PR TITLE
gh-116493: Remove `_winreg` imports from `platform.py`

### DIFF
--- a/Lib/platform.py
+++ b/Lib/platform.py
@@ -370,10 +370,7 @@ def win32_is_iot():
 
 def win32_edition():
     try:
-        try:
-            import winreg
-        except ImportError:
-            import _winreg as winreg
+        import winreg
     except ImportError:
         pass
     else:
@@ -432,10 +429,7 @@ def _win32_ver(version, csd, ptype):
                 csd = 'SP' + csd[13:]
 
     try:
-        try:
-            import winreg
-        except ImportError:
-            import _winreg as winreg
+        import winreg
     except ImportError:
         pass
     else:


### PR DESCRIPTION
I am not sure about whether this should be backported or not.

<!-- gh-issue-number: gh-116493 -->
* Issue: gh-116493
<!-- /gh-issue-number -->
