### PR TITLE
gh-116484: Fix collisions between Checkbutton and ttk.Checkbutton default names

### DIFF
--- a/Lib/test/test_ttk/test_widgets.py
+++ b/Lib/test/test_ttk/test_widgets.py
@@ -285,8 +285,28 @@ class CheckbuttonTest(AbstractLabelTest, unittest.TestCase):
                 b.pack()
                 buttons.append(b)
         variables = [str(b['variable']) for b in buttons]
-        print(variables)
         self.assertEqual(len(set(variables)), 4, variables)
+
+    def test_unique_variables2(self):
+        buttons = []
+        f = ttk.Frame(self.root)
+        f.pack()
+        f = ttk.Frame(self.root)
+        f.pack()
+        for j in 'AB':
+            b = tkinter.Checkbutton(f, text=j)
+            b.pack()
+            buttons.append(b)
+        # Should be larger than the number of all previously created
+        # tkinter.Checkbutton widgets:
+        for j in range(100):
+            b = ttk.Checkbutton(f, text=str(j))
+            b.pack()
+            buttons.append(b)
+        names = [str(b) for b in buttons]
+        self.assertEqual(len(set(names)), len(buttons), names)
+        variables = [str(b['variable']) for b in buttons]
+        self.assertEqual(len(set(variables)), len(buttons), variables)
 
 
 @add_standard_options(IntegerSizeTests, StandardTtkOptionsTests)

--- a/Lib/tkinter/__init__.py
+++ b/Lib/tkinter/__init__.py
@@ -3166,11 +3166,16 @@ class Checkbutton(Widget):
         Widget.__init__(self, master, 'checkbutton', cnf, kw)
 
     def _setup(self, master, cnf):
+        # Because Checkbutton defaults to a variable with the same name as
+        # the widget, Checkbutton default names must be globally unique,
+        # not just unique within the parent widget.
         if not cnf.get('name'):
             global _checkbutton_count
             name = self.__class__.__name__.lower()
             _checkbutton_count += 1
-            cnf['name'] = f'!{name}{_checkbutton_count}'
+            # To avoid collisions with ttk.Checkbutton, use the different
+            # name template.
+            cnf['name'] = f'!{name}_{_checkbutton_count}'
         super()._setup(master, cnf)
 
     def deselect(self):

--- a/Lib/tkinter/__init__.py
+++ b/Lib/tkinter/__init__.py
@@ -3175,7 +3175,7 @@ class Checkbutton(Widget):
             _checkbutton_count += 1
             # To avoid collisions with ttk.Checkbutton, use the different
             # name template.
-            cnf['name'] = f'!{name}_{_checkbutton_count}'
+            cnf['name'] = f'!{name}-{_checkbutton_count}'
         super()._setup(master, cnf)
 
     def deselect(self):

--- a/Misc/NEWS.d/next/Library/2024-03-08-11-31-49.gh-issue-116484.VMAsU7.rst
+++ b/Misc/NEWS.d/next/Library/2024-03-08-11-31-49.gh-issue-116484.VMAsU7.rst
@@ -1,0 +1,3 @@
+Change automatically generated :class:`tkinter.Checkbutton` widget names to
+avoid collisions with automatically generated
+:class:`tkinter.ttk.Checkbutton` widget names within the same parent widget.


### PR DESCRIPTION
Change automatically generated tkinter.Checkbutton widget names to avoid collisions with automatically generated tkinter.ttk.Checkbutton widget names within the same parent widget.


<!-- gh-issue-number: gh-116484 -->
* Issue: gh-116484
<!-- /gh-issue-number -->
