### PR TITLE
gh-115142: Skip ``test__xxsubinterpreters`` if ``_testinternalcapi`` is not available

### DIFF
--- a/Lib/test/test__xxsubinterpreters.py
+++ b/Lib/test/test__xxsubinterpreters.py
@@ -7,7 +7,6 @@ from textwrap import dedent
 import threading
 import unittest
 
-import _testinternalcapi
 from test import support
 from test.support import import_helper
 from test.support import os_helper
@@ -15,6 +14,7 @@ from test.support import script_helper
 
 
 interpreters = import_helper.import_module('_xxsubinterpreters')
+_testinternalcapi = import_helper.import_module('_testinternalcapi')
 from _xxsubinterpreters import InterpreterNotFoundError
 
 


### PR DESCRIPTION


<!-- gh-issue-number: gh-115142 -->
* Issue: gh-115142
<!-- /gh-issue-number -->
