### PR TITLE
gh-116515: Clear thread-local state before tstate_delete_common()

### DIFF
--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -1609,6 +1609,7 @@ tstate_delete_common(PyThreadState *tstate)
 {
     assert(tstate->_status.cleared && !tstate->_status.finalized);
     assert(tstate->state != _Py_THREAD_ATTACHED);
+    tstate_verify_not_active(tstate);
 
     PyInterpreterState *interp = tstate->interp;
     if (interp == NULL) {
@@ -1687,8 +1688,8 @@ _PyThreadState_DeleteCurrent(PyThreadState *tstate)
     _Py_qsbr_detach(((_PyThreadStateImpl *)tstate)->qsbr);
 #endif
     tstate_set_detached(tstate, _Py_THREAD_DETACHED);
-    tstate_delete_common(tstate);
     current_fast_clear(tstate->interp->runtime);
+    tstate_delete_common(tstate);
     _PyEval_ReleaseLock(tstate->interp, NULL);
     free_threadstate((_PyThreadStateImpl *)tstate);
 }


### PR DESCRIPTION
This moves `current_fast_clear()` up so that the current thread state is `NULL` while running `tstate_delete_common()`.

This doesn't fix any bugs, but it means that we are more consistent that `_PyThreadState_GET() != NULL` means that the thread is "attached".

<!-- gh-issue-number: gh-116515 -->
* Issue: gh-116515
<!-- /gh-issue-number -->
