### PR TITLE
GH-71362: Pickle `pathlib.PosixPath` and `WindowsPath` objects as `Path`

### DIFF
--- a/Lib/pathlib/__init__.py
+++ b/Lib/pathlib/__init__.py
@@ -529,6 +529,13 @@ class Path(_abc.PathBase, PurePath):
             cls = WindowsPath if os.name == 'nt' else PosixPath
         return object.__new__(cls)
 
+    def __reduce__(self):
+        cls = self.__class__
+        if cls is PosixPath or cls is WindowsPath:
+            # Allow unpickling on foreign operating systems.
+            cls = Path
+        return cls, self.parts
+
     def stat(self, *, follow_symlinks=True):
         """
         Return the result of the stat() system call on this path, like

--- a/Lib/test/test_pathlib/test_pathlib.py
+++ b/Lib/test/test_pathlib/test_pathlib.py
@@ -570,6 +570,7 @@ class PathTest(test_pathlib_abc.DummyPathTest, PurePathTest):
 
         p = P('foo')
         with unittest.mock.patch('pathlib.Path.__new__') as mock_new:
+            pp = pickle.loads(pickle.dumps(p))
             mock_new.assert_called_with(pathlib.Path, 'foo')
 
     def _test_cwd(self, p):

--- a/Lib/test/test_pathlib/test_pathlib.py
+++ b/Lib/test/test_pathlib/test_pathlib.py
@@ -563,6 +563,15 @@ class PathTest(test_pathlib_abc.DummyPathTest, PurePathTest):
         else:
             self.assertRaises(pathlib.UnsupportedOperation, self.cls)
 
+    def test_pickling_concrete(self):
+        P = self.cls
+        if P is not pathlib.PosixPath and P is not pathlib.WindowsPath:
+            self.skipTest("Only applies to direct Path subclasses")
+
+        p = P('foo')
+        with unittest.mock.patch('pathlib.Path.__new__') as mock_new:
+            mock_new.assert_called_with(pathlib.Path, 'foo')
+
     def _test_cwd(self, p):
         q = self.cls(os.getcwd())
         self.assertEqual(p, q)

--- a/Misc/NEWS.d/next/Library/2024-03-08-21-49-12.gh-issue-71362.gT-Rtw.rst
+++ b/Misc/NEWS.d/next/Library/2024-03-08-21-49-12.gh-issue-71362.gT-Rtw.rst
@@ -1,0 +1,5 @@
+:class:`pathlib.PosixPath` and :class:`~pathlib.WindowsPath` objects are now
+pickled as :class:`~pathlib.Path` objects, which allows them to be unpickled
+on any operating system. Care should be taken as paths may be interpreted
+differently; for example, ``"c:/"`` is an absolute path on Windows but not
+POSIX.


### PR DESCRIPTION
Allow `WindowsPath` objects pickled on Windows to be unpickled as `PosixPath` on POSIX, and vice-versa.


<!-- gh-issue-number: gh-71362 -->
* Issue: gh-71362
<!-- /gh-issue-number -->
