### PR TITLE
Fix format of dataclasses' `unsafe_hash` default value

### DIFF
--- a/Doc/library/dataclasses.rst
+++ b/Doc/library/dataclasses.rst
@@ -121,7 +121,7 @@ Module contents
      :meth:`!__le__`, :meth:`!__gt__`, or :meth:`!__ge__`, then
      :exc:`TypeError` is raised.
 
-   - *unsafe_hash*: If ``False`` (the default), a :meth:`~object.__hash__` method
+   - *unsafe_hash*: If false (the default), a :meth:`~object.__hash__` method
      is generated according to how *eq* and *frozen* are set.
 
      :meth:`!__hash__` is used by built-in :meth:`hash`, and when objects are

--- a/Doc/library/dataclasses.rst
+++ b/Doc/library/dataclasses.rst
@@ -121,8 +121,10 @@ Module contents
      :meth:`!__le__`, :meth:`!__gt__`, or :meth:`!__ge__`, then
      :exc:`TypeError` is raised.
 
-   - *unsafe_hash*: If false (the default), a :meth:`~object.__hash__` method
-     is generated according to how *eq* and *frozen* are set.
+   - *unsafe_hash*: If true, force ``dataclasses`` to create a
+     :meth:`~object.__hash__` method, even when it may not be safe to do so.
+     Otherwise, generate a :meth:`~object.__hash__` method according to how
+     *eq* and *frozen* are set. The default value is ``False``.
 
      :meth:`!__hash__` is used by built-in :meth:`hash`, and when objects are
      added to hashed collections such as dictionaries and sets.  Having a

--- a/Doc/library/dataclasses.rst
+++ b/Doc/library/dataclasses.rst
@@ -124,7 +124,8 @@ Module contents
    - *unsafe_hash*: If true, force ``dataclasses`` to create a
      :meth:`~object.__hash__` method, even though it may not be safe to do so.
      Otherwise, generate a :meth:`~object.__hash__` method according to how
-     *eq* and *frozen* are set. The default value is ``False``.
+     *eq* and *frozen* are set.
+     The default value is ``False``.
 
      :meth:`!__hash__` is used by built-in :meth:`hash`, and when objects are
      added to hashed collections such as dictionaries and sets.  Having a

--- a/Doc/library/dataclasses.rst
+++ b/Doc/library/dataclasses.rst
@@ -122,7 +122,7 @@ Module contents
      :exc:`TypeError` is raised.
 
    - *unsafe_hash*: If true, force ``dataclasses`` to create a
-     :meth:`~object.__hash__` method, even when it may not be safe to do so.
+     :meth:`~object.__hash__` method, even though it may not be safe to do so.
      Otherwise, generate a :meth:`~object.__hash__` method according to how
      *eq* and *frozen* are set. The default value is ``False``.
 


### PR DESCRIPTION
To be in line with the other parameters. I wonder what is the precedent here: should every default value be wrapped in preformatted text? For the other dataclass parameters, only the default value is, but not the actual _if true/false_:

```rst
``order``: If true (the default is ``False``)
```

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--116532.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->