### PR TITLE
gh-108901: Add `inspect.Signature.from_frame`

### DIFF
--- a/Doc/library/inspect.rst
+++ b/Doc/library/inspect.rst
@@ -822,6 +822,12 @@ function.
        Return a :class:`Signature` (or its subclass) object for a given
        :ref:`frame object <frame-objects>`.
 
+       Notice that it is impossible to get signatures
+       with annotations from frames.
+       Because annotations are stored in functions.
+       Also note that default parameter values might
+       be modified inside the frame.
+
        .. versionadded:: 3.13
 
 

--- a/Doc/library/inspect.rst
+++ b/Doc/library/inspect.rst
@@ -823,11 +823,10 @@ function.
        :ref:`frame object <frame-objects>`.
 
        Notice that it is impossible to get signatures
-       with annotations from frames,
+       with defaults or annotations from frames,
        because annotations are stored
-       in function inside :attr:`~function.__annotations__` attribute.
-       Also note that default values are populated from frame's variables,
-       not real function's default values.
+       in a function inside ``__defaults__``, ``__kwdefaults__``,
+       and ``__annotations__`` attributes.
 
        .. versionadded:: 3.13
 

--- a/Doc/library/inspect.rst
+++ b/Doc/library/inspect.rst
@@ -823,10 +823,11 @@ function.
        :ref:`frame object <frame-objects>`.
 
        Notice that it is impossible to get signatures
-       with annotations from frames.
-       Because annotations are stored in functions.
-       Also note that default parameter values might
-       be modified inside the frame.
+       with annotations from frames,
+       because annotations are stored
+       in function inside :attr:`~function.__annotations__` attribute.
+       Also note that default value are populated from frame's variables,
+       not real function's default values.
 
        .. versionadded:: 3.13
 

--- a/Doc/library/inspect.rst
+++ b/Doc/library/inspect.rst
@@ -817,6 +817,13 @@ function.
        .. versionchanged:: 3.10
          The *globals*, *locals*, and *eval_str* parameters were added.
 
+   .. classmethod:: Signature.from_frame(frame)
+
+       Return a :class:`Signature` (or its subclass) object for a given
+       :ref:`frame object <frame-objects>`.
+
+       .. versionadded:: 3.13
+
 
 .. class:: Parameter(name, kind, *, default=Parameter.empty, annotation=Parameter.empty)
 

--- a/Doc/library/inspect.rst
+++ b/Doc/library/inspect.rst
@@ -826,7 +826,7 @@ function.
        with annotations from frames,
        because annotations are stored
        in function inside :attr:`~function.__annotations__` attribute.
-       Also note that default value are populated from frame's variables,
+       Also note that default values are populated from frame's variables,
        not real function's default values.
 
        .. versionadded:: 3.13

--- a/Doc/whatsnew/3.13.rst
+++ b/Doc/whatsnew/3.13.rst
@@ -364,8 +364,7 @@ built on debug mode <debug-build>`.
 inspect
 -------
 
-* Add :meth:`inspect.Signature.from_frame` to get signatures from frame objects
-  and to replace the old :func:`inspect.getargvalues` API.
+* Add :meth:`inspect.Signature.from_frame` to get signatures from frame objects.
 
 ipaddress
 ---------

--- a/Doc/whatsnew/3.13.rst
+++ b/Doc/whatsnew/3.13.rst
@@ -361,6 +361,12 @@ and only logged in :ref:`Python Development Mode <devmode>` or on :ref:`Python
 built on debug mode <debug-build>`.
 (Contributed by Victor Stinner in :gh:`62948`.)
 
+inspect
+-------
+
+* Add :meth:`inspect.Signature.from_frame` to get signatures from frame objects
+  and to replace the old :func:`inspect.getargvalues` API.
+
 ipaddress
 ---------
 

--- a/Lib/inspect.py
+++ b/Lib/inspect.py
@@ -3120,7 +3120,7 @@ class Signature:
         with annotations from frames,
         because annotations are stored
         in function inside ``__annotations__`` attribute.
-        Also note that default value are populated from frame's variables,
+        Also note that default values are populated from frame's variables,
         not real function's default values.
         """
         if not isframe(frame):

--- a/Lib/inspect.py
+++ b/Lib/inspect.py
@@ -3108,7 +3108,15 @@ class Signature:
 
     @classmethod
     def from_frame(cls, frame):
-        """Constructs Signature from a given frame object."""
+        """
+        Constructs Signature from a given frame object.
+
+        Notice that it is impossible to get signatures
+        with annotations from frames.
+        Because annotations are stored in functions.
+        Also note that default parameter values might
+        be modified inside the frame.
+        """
         if not isframe(frame):
             raise TypeError(f'Frame object expected, got: {type(frame)}')
 

--- a/Lib/inspect.py
+++ b/Lib/inspect.py
@@ -2419,7 +2419,12 @@ def _signature_from_function(cls, func, skip_bound_arg=True,
     Parameter = cls._parameter_cls
 
     # Parameter information.
-    annotations = get_annotations(func, globals=globals, locals=locals, eval_str=eval_str)
+    annotations = get_annotations(
+        func,
+        globals=globals,
+        locals=locals,
+        eval_str=eval_str,
+    )
     return _signature_from_code(
         func.__code__,
         annotations=annotations,
@@ -3112,10 +3117,11 @@ class Signature:
         Constructs Signature from a given frame object.
 
         Notice that it is impossible to get signatures
-        with annotations from frames.
-        Because annotations are stored in functions.
-        Also note that default parameter values might
-        be modified inside the frame.
+        with annotations from frames,
+        because annotations are stored
+        in function inside ``__annotations__`` attribute.
+        Also note that default value are populated from frame's variables,
+        not real function's default values.
         """
         if not isframe(frame):
             raise TypeError(f'Frame object expected, got: {type(frame)}')

--- a/Lib/inspect.py
+++ b/Lib/inspect.py
@@ -3117,36 +3117,19 @@ class Signature:
         Constructs Signature from a given frame object.
 
         Notice that it is impossible to get signatures
-        with annotations from frames,
+        with defaults or annotations from frames,
         because annotations are stored
-        in function inside ``__annotations__`` attribute.
-        Also note that default values are populated from frame's variables,
-        not real function's default values.
+        in a function inside ``__defaults__``, ``__kwdefaults__``,
+        and ``__annotations__`` attributes.
         """
         if not isframe(frame):
             raise TypeError(f'Frame object expected, got: {type(frame)}')
 
-        func_code = frame.f_code
-        pos_count = func_code.co_argcount
-        arg_names = func_code.co_varnames
-        keyword_only_count = func_code.co_kwonlyargcount
-
-        defaults = []
-        kwdefaults = {}
-        if frame.f_locals:
-            for name in arg_names[:pos_count]:
-                if name in frame.f_locals:
-                    defaults.append(frame.f_locals[name])
-
-            for name in arg_names[pos_count : pos_count + keyword_only_count]:
-                if name in frame.f_locals:
-                    kwdefaults.update({name: frame.f_locals[name]})
-
         return _signature_from_code(
-            func_code,
+            frame.f_code,
             annotations={},
-            defaults=defaults,
-            kwdefaults=kwdefaults,
+            defaults=(),
+            kwdefaults={},
             cls=cls,
             is_duck_function=False,
         )

--- a/Lib/test/test_inspect/test_inspect.py
+++ b/Lib/test/test_inspect/test_inspect.py
@@ -4631,7 +4631,7 @@ class TestSignatureFromFrame(unittest.TestCase):
 
         inner(1, 2, d=4)
         self.assertEqual(str(inspect.Signature.from_frame(ns['fr'])),
-                         '(a=1, /, b=2, *e, c=3, d=4, **f)')
+                         '(a, /, b, *e, c, d, **f)')
 
     def test_from_frame_with_pos_only_defaults(self):
         ns = {}
@@ -4640,7 +4640,7 @@ class TestSignatureFromFrame(unittest.TestCase):
 
         inner(d=4)
         self.assertEqual(str(inspect.Signature.from_frame(ns['fr'])),
-                         '(a=1, /, b=2, *e, c=3, d=4, **f)')
+                         '(a, /, b, *e, c, d, **f)')
 
     def test_from_frame_no_locals(self):
         ns = {}
@@ -4658,7 +4658,7 @@ class TestSignatureFromFrame(unittest.TestCase):
 
         inner(a=1)
         self.assertEqual(str(inspect.Signature.from_frame(ns['fr'])),
-                         '(*, a=1, b=2, **c)')
+                         '(*, a, b, **c)')
 
     def test_from_frame_no_kw(self):
         ns = {}
@@ -4667,7 +4667,7 @@ class TestSignatureFromFrame(unittest.TestCase):
 
         inner(1, 2)
         self.assertEqual(str(inspect.Signature.from_frame(ns['fr'])),
-                         '(a=1, /, b=2, *c)')
+                         '(a, /, b, *c)')
 
     def test_from_frame_with_nonlocal(self):
         fr = None
@@ -4677,7 +4677,7 @@ class TestSignatureFromFrame(unittest.TestCase):
 
         inner(1, 2)
         self.assertEqual(str(inspect.Signature.from_frame(fr)),
-                         '(a=1, /, b=2, *c)')
+                         '(a, /, b, *c)')
 
     def test_clear_frame(self):
         ns = {}
@@ -4694,12 +4694,10 @@ class TestSignatureFromFrame(unittest.TestCase):
         class _A:
             def inner(self, a, *, b):
                 ns['fr'] = inspect.currentframe()
-            def __repr__(self):
-                return '_A'
 
         _A().inner(1, b=2)
         self.assertEqual(str(inspect.Signature.from_frame(ns['fr'])),
-                         '(self=_A, a=1, *, b=2)')
+                         '(self, a, *, b)')
 
     def test_from_frame_defaults_change(self):
         ns = {}
@@ -4710,13 +4708,13 @@ class TestSignatureFromFrame(unittest.TestCase):
 
         inner()
         self.assertEqual(str(inspect.Signature.from_frame(ns['fr'])),
-                         '(a=3, /, c=5, *, b=4)')
+                         '(a, /, c, *, b)')
 
     def test_from_frame_mod(self):
         self.assertEqual(str(inspect.Signature.from_frame(mod.fr)),
-                         '(x=11, y=14)')
+                         '(x, y)')
         self.assertEqual(str(inspect.Signature.from_frame(mod.fr.f_back)),
-                         '(a=7, /, b=8, c=9, d=3, e=4, f=5, *g, **h)')
+                         '(a, /, b, c, d, e, f, *g, **h)')
 
     def test_from_not_frame(self):
         with self.assertRaisesRegex(TypeError, 'Frame object expected'):

--- a/Lib/test/test_inspect/test_inspect.py
+++ b/Lib/test/test_inspect/test_inspect.py
@@ -4624,7 +4624,7 @@ class TestSignatureObject(unittest.TestCase):
 
 
 class TestSignatureFromFrame(unittest.TestCase):
-    def test_signature_from_frame(self):
+    def test_from_frame(self):
         ns = {}
         def inner(a, /, b, *e, c: int = 3, d, **f) -> None:
             ns['fr'] = inspect.currentframe()
@@ -4633,7 +4633,7 @@ class TestSignatureFromFrame(unittest.TestCase):
         self.assertEqual(str(inspect.Signature.from_frame(ns['fr'])),
                          '(a=1, /, b=2, *e, c=3, d=4, **f)')
 
-    def test_signature_with_pos_only_defaults(self):
+    def test_from_frame_with_pos_only_defaults(self):
         ns = {}
         def inner(a=1, /, b=2, *e, c: int = 3, d, **f) -> None:
             ns['fr'] = inspect.currentframe()
@@ -4642,7 +4642,7 @@ class TestSignatureFromFrame(unittest.TestCase):
         self.assertEqual(str(inspect.Signature.from_frame(ns['fr'])),
                          '(a=1, /, b=2, *e, c=3, d=4, **f)')
 
-    def test_signature_from_frame_no_locals(self):
+    def test_from_frame_no_locals(self):
         ns = {}
         def inner():
             ns['fr'] = inspect.currentframe()
@@ -4651,7 +4651,7 @@ class TestSignatureFromFrame(unittest.TestCase):
         self.assertEqual(str(inspect.Signature.from_frame(ns['fr'])),
                          '()')
 
-    def test_signature_from_frame_no_pos(self):
+    def test_from_frame_no_pos(self):
         ns = {}
         def inner(*, a, b=2, **c):
             ns['fr'] = inspect.currentframe()
@@ -4660,7 +4660,7 @@ class TestSignatureFromFrame(unittest.TestCase):
         self.assertEqual(str(inspect.Signature.from_frame(ns['fr'])),
                          '(*, a=1, b=2, **c)')
 
-    def test_signature_from_frame_no_kw(self):
+    def test_from_frame_no_kw(self):
         ns = {}
         def inner(a, /, b, *c):
             ns['fr'] = inspect.currentframe()
@@ -4669,7 +4669,7 @@ class TestSignatureFromFrame(unittest.TestCase):
         self.assertEqual(str(inspect.Signature.from_frame(ns['fr'])),
                          '(a=1, /, b=2, *c)')
 
-    def test_signature_from_frame_with_nonlocal(self):
+    def test_from_frame_with_nonlocal(self):
         fr = None
         def inner(a, /, b, *c):
             nonlocal fr
@@ -4679,7 +4679,7 @@ class TestSignatureFromFrame(unittest.TestCase):
         self.assertEqual(str(inspect.Signature.from_frame(fr)),
                          '(a=1, /, b=2, *c)')
 
-    def test_signature_from_method_frame(self):
+    def test_from_method_frame(self):
         ns = {}
         class _A:
             def inner(self, a, *, b):
@@ -4691,7 +4691,7 @@ class TestSignatureFromFrame(unittest.TestCase):
         self.assertEqual(str(inspect.Signature.from_frame(ns['fr'])),
                          '(self=_A, a=1, *, b=2)')
 
-    def test_signature_from_frame_defaults_change(self):
+    def test_from_frame_defaults_change(self):
         ns = {}
         def inner(a=1, /, c=5, *, b=2):
             a = 3
@@ -4702,13 +4702,13 @@ class TestSignatureFromFrame(unittest.TestCase):
         self.assertEqual(str(inspect.Signature.from_frame(ns['fr'])),
                          '(a=3, /, c=5, *, b=4)')
 
-    def test_signature_from_frame_mod(self):
+    def test_from_frame_mod(self):
         self.assertEqual(str(inspect.Signature.from_frame(mod.fr)),
                          '(x=11, y=14)')
         self.assertEqual(str(inspect.Signature.from_frame(mod.fr.f_back)),
                          '(a=7, /, b=8, c=9, d=3, e=4, f=5, *g, **h)')
 
-    def test_signature_from_not_frame(self):
+    def test_from_not_frame(self):
         with self.assertRaisesRegex(TypeError, 'Frame object expected'):
             inspect.Signature.from_frame(lambda: ...)
 

--- a/Lib/test/test_inspect/test_inspect.py
+++ b/Lib/test/test_inspect/test_inspect.py
@@ -4623,6 +4623,96 @@ class TestSignatureObject(unittest.TestCase):
         self.assertEqual(inspect.signature(D2), inspect.signature(D1))
 
 
+class TestSignatureFromFrame(unittest.TestCase):
+    def test_signature_from_frame(self):
+        ns = {}
+        def inner(a, /, b, *e, c: int = 3, d, **f) -> None:
+            ns['fr'] = inspect.currentframe()
+
+        inner(1, 2, d=4)
+        self.assertEqual(str(inspect.Signature.from_frame(ns['fr'])),
+                         '(a=1, /, b=2, *e, c=3, d=4, **f)')
+
+    def test_signature_with_pos_only_defaults(self):
+        ns = {}
+        def inner(a=1, /, b=2, *e, c: int = 3, d, **f) -> None:
+            ns['fr'] = inspect.currentframe()
+
+        inner(d=4)
+        self.assertEqual(str(inspect.Signature.from_frame(ns['fr'])),
+                         '(a=1, /, b=2, *e, c=3, d=4, **f)')
+
+    def test_signature_from_frame_no_locals(self):
+        ns = {}
+        def inner():
+            ns['fr'] = inspect.currentframe()
+
+        inner()
+        self.assertEqual(str(inspect.Signature.from_frame(ns['fr'])),
+                         '()')
+
+    def test_signature_from_frame_no_pos(self):
+        ns = {}
+        def inner(*, a, b=2, **c):
+            ns['fr'] = inspect.currentframe()
+
+        inner(a=1)
+        self.assertEqual(str(inspect.Signature.from_frame(ns['fr'])),
+                         '(*, a=1, b=2, **c)')
+
+    def test_signature_from_frame_no_kw(self):
+        ns = {}
+        def inner(a, /, b, *c):
+            ns['fr'] = inspect.currentframe()
+
+        inner(1, 2)
+        self.assertEqual(str(inspect.Signature.from_frame(ns['fr'])),
+                         '(a=1, /, b=2, *c)')
+
+    def test_signature_from_frame_with_nonlocal(self):
+        fr = None
+        def inner(a, /, b, *c):
+            nonlocal fr
+            fr = inspect.currentframe()
+
+        inner(1, 2)
+        self.assertEqual(str(inspect.Signature.from_frame(fr)),
+                         '(a=1, /, b=2, *c)')
+
+    def test_signature_from_method_frame(self):
+        ns = {}
+        class _A:
+            def inner(self, a, *, b):
+                ns['fr'] = inspect.currentframe()
+            def __repr__(self):
+                return '_A'
+
+        _A().inner(1, b=2)
+        self.assertEqual(str(inspect.Signature.from_frame(ns['fr'])),
+                         '(self=_A, a=1, *, b=2)')
+
+    def test_signature_from_frame_defaults_change(self):
+        ns = {}
+        def inner(a=1, /, c=5, *, b=2):
+            a = 3
+            ns['fr'] = inspect.currentframe()
+            b = 4
+
+        inner()
+        self.assertEqual(str(inspect.Signature.from_frame(ns['fr'])),
+                         '(a=3, /, c=5, *, b=4)')
+
+    def test_signature_from_frame_mod(self):
+        self.assertEqual(str(inspect.Signature.from_frame(mod.fr)),
+                         '(x=11, y=14)')
+        self.assertEqual(str(inspect.Signature.from_frame(mod.fr.f_back)),
+                         '(a=7, /, b=8, c=9, d=3, e=4, f=5, *g, **h)')
+
+    def test_signature_from_not_frame(self):
+        with self.assertRaisesRegex(TypeError, 'Frame object expected'):
+            inspect.Signature.from_frame(lambda: ...)
+
+
 class TestParameterObject(unittest.TestCase):
     def test_signature_parameter_kinds(self):
         P = inspect.Parameter

--- a/Lib/test/test_inspect/test_inspect.py
+++ b/Lib/test/test_inspect/test_inspect.py
@@ -4679,6 +4679,16 @@ class TestSignatureFromFrame(unittest.TestCase):
         self.assertEqual(str(inspect.Signature.from_frame(fr)),
                          '(a=1, /, b=2, *c)')
 
+    def test_clear_frame(self):
+        ns = {}
+        def inner(a=1, /, c=5, *, b=2):
+            ns['fr'] = inspect.currentframe()
+
+        inner()
+        ns['fr'].clear()
+        self.assertEqual(str(inspect.Signature.from_frame(ns['fr'])),
+                         '(a, /, c, *, b)')
+
     def test_from_method_frame(self):
         ns = {}
         class _A:

--- a/Misc/NEWS.d/next/Library/2024-03-09-12-55-44.gh-issue-108901.s9VClL.rst
+++ b/Misc/NEWS.d/next/Library/2024-03-09-12-55-44.gh-issue-108901.s9VClL.rst
@@ -1,2 +1,2 @@
-Add :meth:`inspect.Signature.from_frame` to get a singature
+Add :meth:`inspect.Signature.from_frame` to get a signature
 from a frame object.

--- a/Misc/NEWS.d/next/Library/2024-03-09-12-55-44.gh-issue-108901.s9VClL.rst
+++ b/Misc/NEWS.d/next/Library/2024-03-09-12-55-44.gh-issue-108901.s9VClL.rst
@@ -1,3 +1,2 @@
-Add :meth:`inspect.Signature.from_frame` to get a singature from a frame
-object, it will be used as a new alternative for older
-:func:`inspect.getargvalues` and :func:`inspect.formatargvalues`.
+Add :meth:`inspect.Signature.from_frame` to get a singature
+from a frame object.

--- a/Misc/NEWS.d/next/Library/2024-03-09-12-55-44.gh-issue-108901.s9VClL.rst
+++ b/Misc/NEWS.d/next/Library/2024-03-09-12-55-44.gh-issue-108901.s9VClL.rst
@@ -1,0 +1,3 @@
+Add :meth:`inspect.Signature.from_frame` to get a singature from a frame
+object, it will be used as a new alternative for older
+:func:`inspect.getargvalues` and :func:`inspect.formatargvalues`.


### PR DESCRIPTION
I had to go with a bigger diff, but easier code and probably more optimal one.
The main reason was that creating `types.FunctionType` is not trivial, for example, it required the correct amount of `__closure__` vars for a code object. So, let's not create it: it will reduce the amount of possible errors.

First PR: https://github.com/python/cpython/pull/112639

<!-- gh-issue-number: gh-108901 -->
* Issue: gh-108901
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--116537.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->