### PR TITLE
gh-116535: Fix distracting "TypeError" in example code

### DIFF
--- a/Doc/library/dataclasses.rst
+++ b/Doc/library/dataclasses.rst
@@ -719,7 +719,7 @@ Using dataclasses, *if* this code was valid::
   class D:
       x: list = []      # This code raises ValueError
       def add(self, element):
-          self.x += element
+          self.x.append(element)
 
 it would generate code similar to::
 
@@ -728,7 +728,7 @@ it would generate code similar to::
       def __init__(self, x=x):
           self.x = x
       def add(self, element):
-          self.x += element
+          self.x.append(element)
 
   assert D().x is D().x
 


### PR DESCRIPTION
Fix: `TypeError: 'int' object is not iterable`  when you call the sample code:

Note this is *not* the advertised (and expected) ValueError, which is fixed by using `field`

```python
@dataclass
class D:
    x: list = []      # This code no longer raises ValueError
    def add(self, element):
        self.x += element # calling this (with an int element) raises TypeError
```

<!-- gh-issue-number: gh-116535 -->
* Issue: gh-116535
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--116538.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->