### PR TITLE
[3.12] gh-115142: Skip ``test__xxsubinterpreters`` if ``_testcapi`` is not available

### DIFF
--- a/Lib/test/test__xxsubinterpreters.py
+++ b/Lib/test/test__xxsubinterpreters.py
@@ -7,14 +7,13 @@ from textwrap import dedent
 import threading
 import unittest
 
-import _testcapi
 from test import support
 from test.support import import_helper
 from test.support import script_helper
 
 
 interpreters = import_helper.import_module('_xxsubinterpreters')
-
+_testcapi = import_helper.import_module('_testcapi')
 
 ##################################
 # helpers


### PR DESCRIPTION
This is a backport of #116507 to 3.12 branch. 
