### PR TITLE
gh-116393: `glob.translate` match empty path parts with "**" when `recursive=True`

### DIFF
--- a/Doc/library/glob.rst
+++ b/Doc/library/glob.rst
@@ -126,7 +126,7 @@ The :mod:`glob` module defines the following functions:
       >>>
       >>> regex = glob.translate('**/*.txt', recursive=True, include_hidden=True)
       >>> regex
-      '(?s:(?:.+/)?[^/]*\\.txt)\\Z'
+      '(?s:(?:/|[^/]+/)*[^/]*\\.txt)\\Z'
       >>> reobj = re.compile(regex)
       >>> reobj.match('foo/bar/baz.txt')
       <re.Match object; span=(0, 15), match='foo/bar/baz.txt'>

--- a/Lib/glob.py
+++ b/Lib/glob.py
@@ -294,6 +294,8 @@ def translate(pat, *, recursive=False, include_hidden=False, seps=None):
             continue
         if recursive:
             if part == '**':
+                if idx == 0:
+                    results.append(fr'(?!{any_sep})')
                 if idx < last_part_idx:
                     if parts[idx + 1] != '**':
                         results.append(any_segments)

--- a/Lib/glob.py
+++ b/Lib/glob.py
@@ -276,13 +276,13 @@ def translate(pat, *, recursive=False, include_hidden=False, seps=None):
     not_sep = f'[^{escaped_seps}]'
     if include_hidden:
         one_last_segment = f'{not_sep}+'
-        one_segment = f'{one_last_segment}{any_sep}'
-        any_segments = f'(?:.+{any_sep})?'
+        one_segment = f'(?:{any_sep}|{one_last_segment}{any_sep})'
+        any_segments = f'{one_segment}*'
         any_last_segments = '.*'
     else:
         one_last_segment = f'[^{escaped_seps}.]{not_sep}*'
-        one_segment = f'{one_last_segment}{any_sep}'
-        any_segments = f'(?:{one_segment})*'
+        one_segment = f'(?:{any_sep}|{one_last_segment}{any_sep})'
+        any_segments = f'{one_segment}*'
         any_last_segments = f'{any_segments}(?:{one_last_segment})?'
 
     results = []

--- a/Lib/glob.py
+++ b/Lib/glob.py
@@ -294,8 +294,6 @@ def translate(pat, *, recursive=False, include_hidden=False, seps=None):
             continue
         if recursive:
             if part == '**':
-                if idx == 0:
-                    results.append(fr'(?!{any_sep})')
                 if idx < last_part_idx:
                     if parts[idx + 1] != '**':
                         results.append(any_segments)

--- a/Lib/test/test_glob.py
+++ b/Lib/test/test_glob.py
@@ -397,6 +397,8 @@ class GlobTests(unittest.TestCase):
         self.assertIsNotNone(match(os.path.join('foo', 'bar.txt')))
         self.assertIsNone(match(os.path.join('foo', '.bar.txt')))
         match = re.compile(glob.translate('**/*', recursive=True, include_hidden=True)).match
+        self.assertIsNotNone(match('baz'))
+        self.assertIsNone(match('/baz'))
         self.assertIsNotNone(match('foo//baz'))
         self.assertIsNotNone(match('.foo//baz'))
         self.assertIsNotNone(match('.foo/bar//baz'))
@@ -445,8 +447,9 @@ class GlobTests(unittest.TestCase):
             return glob.translate(pat, recursive=True, include_hidden=True, seps='/')
         self.assertEqual(fn('*'), r'(?s:[^/]+)\Z')
         self.assertEqual(fn('?'), r'(?s:[^/])\Z')
-        self.assertEqual(fn('**'), r'(?s:.*)\Z')
-        self.assertEqual(fn('**/**'), r'(?s:.*)\Z')
+        self.assertEqual(fn('**'), r'(?s:(?!/).*)\Z')
+        self.assertEqual(fn('/**'), r'(?s:/.*)\Z')
+        self.assertEqual(fn('**/**'), r'(?s:(?!/).*)\Z')
         self.assertRaises(ValueError, fn, '***')
         self.assertRaises(ValueError, fn, 'a**')
         self.assertRaises(ValueError, fn, '**b')
@@ -456,7 +459,7 @@ class GlobTests(unittest.TestCase):
         def fn(pat):
             return glob.translate(pat, recursive=True, include_hidden=True, seps=['/', '\\'])
         self.assertEqual(fn('foo/bar\\baz'), r'(?s:foo[/\\]bar[/\\]baz)\Z')
-        self.assertEqual(fn('**/*'), r'(?s:(?:[/\\]|[^/\\]+[/\\])*[^/\\]+)\Z')
+        self.assertEqual(fn('**/*'), r'(?s:(?![/\\])(?:[/\\]|[^/\\]+[/\\])*[^/\\]+)\Z')
 
 
 @skip_unless_symlink

--- a/Lib/test/test_glob.py
+++ b/Lib/test/test_glob.py
@@ -372,6 +372,7 @@ class GlobTests(unittest.TestCase):
         self.assertIsNotNone(match('foo'))
         self.assertIsNone(match('.foo'))
         self.assertIsNotNone(match(os.path.join('foo', 'bar')))
+        self.assertIsNotNone(match('foo//bar'))
         self.assertIsNone(match(os.path.join('foo', '.bar')))
         self.assertIsNone(match(os.path.join('.foo', 'bar')))
         self.assertIsNone(match(os.path.join('.foo', '.bar')))
@@ -380,6 +381,8 @@ class GlobTests(unittest.TestCase):
         self.assertIsNone(match(os.path.join('foo', '.bar')))
         self.assertIsNone(match(os.path.join('.foo', 'bar')))
         self.assertIsNone(match(os.path.join('.foo', '.bar')))
+        self.assertIsNotNone(match('foo//baz'))
+        self.assertIsNotNone(match('foo/bar//baz'))
         match = re.compile(glob.translate('*/**', recursive=True)).match
         self.assertIsNotNone(match(os.path.join('foo', 'bar')))
         self.assertIsNone(match(os.path.join('foo', '.bar')))
@@ -393,6 +396,10 @@ class GlobTests(unittest.TestCase):
         self.assertIsNone(match(os.path.join('foo', '.bar')))
         self.assertIsNotNone(match(os.path.join('foo', 'bar.txt')))
         self.assertIsNone(match(os.path.join('foo', '.bar.txt')))
+        match = re.compile(glob.translate('**/*', recursive=True, include_hidden=True)).match
+        self.assertIsNotNone(match('foo//baz'))
+        self.assertIsNotNone(match('.foo//baz'))
+        self.assertIsNotNone(match('.foo/bar//baz'))
 
     def test_translate(self):
         def fn(pat):
@@ -412,7 +419,7 @@ class GlobTests(unittest.TestCase):
         self.assertEqual(fn('a**'), r'(?s:a[^/]*)\Z')
         self.assertEqual(fn('**b'), r'(?s:(?!\.)[^/]*b)\Z')
         self.assertEqual(fn('/**/*/*.*/**'),
-                         r'(?s:/(?!\.)[^/]*/[^/.][^/]*/(?!\.)[^/]*\.[^/]*/(?!\.)[^/]*)\Z')
+                         r'(?s:/(?!\.)[^/]*/(?:/|[^/.][^/]*/)(?!\.)[^/]*\.[^/]*/(?!\.)[^/]*)\Z')
 
     def test_translate_include_hidden(self):
         def fn(pat):
@@ -431,7 +438,7 @@ class GlobTests(unittest.TestCase):
         self.assertEqual(fn('***'), r'(?s:[^/]*)\Z')
         self.assertEqual(fn('a**'), r'(?s:a[^/]*)\Z')
         self.assertEqual(fn('**b'), r'(?s:[^/]*b)\Z')
-        self.assertEqual(fn('/**/*/*.*/**'), r'(?s:/[^/]*/[^/]+/[^/]*\.[^/]*/[^/]*)\Z')
+        self.assertEqual(fn('/**/*/*.*/**'), r'(?s:/[^/]*/(?:/|[^/]+/)[^/]*\.[^/]*/[^/]*)\Z')
 
     def test_translate_recursive(self):
         def fn(pat):
@@ -443,13 +450,13 @@ class GlobTests(unittest.TestCase):
         self.assertRaises(ValueError, fn, '***')
         self.assertRaises(ValueError, fn, 'a**')
         self.assertRaises(ValueError, fn, '**b')
-        self.assertEqual(fn('/**/*/*.*/**'), r'(?s:/(?:.+/)?[^/]+/[^/]*\.[^/]*/.*)\Z')
+        self.assertEqual(fn('/**/*/*.*/**'), r'(?s:/(?:/|[^/]+/)*(?:/|[^/]+/)[^/]*\.[^/]*/.*)\Z')
 
     def test_translate_seps(self):
         def fn(pat):
             return glob.translate(pat, recursive=True, include_hidden=True, seps=['/', '\\'])
         self.assertEqual(fn('foo/bar\\baz'), r'(?s:foo[/\\]bar[/\\]baz)\Z')
-        self.assertEqual(fn('**/*'), r'(?s:(?:.+[/\\])?[^/\\]+)\Z')
+        self.assertEqual(fn('**/*'), r'(?s:(?:[/\\]|[^/\\]+[/\\])*[^/\\]+)\Z')
 
 
 @skip_unless_symlink

--- a/Lib/test/test_glob.py
+++ b/Lib/test/test_glob.py
@@ -397,8 +397,6 @@ class GlobTests(unittest.TestCase):
         self.assertIsNotNone(match(os.path.join('foo', 'bar.txt')))
         self.assertIsNone(match(os.path.join('foo', '.bar.txt')))
         match = re.compile(glob.translate('**/*', recursive=True, include_hidden=True)).match
-        self.assertIsNotNone(match('baz'))
-        self.assertIsNone(match('/baz'))
         self.assertIsNotNone(match('foo//baz'))
         self.assertIsNotNone(match('.foo//baz'))
         self.assertIsNotNone(match('.foo/bar//baz'))
@@ -447,9 +445,8 @@ class GlobTests(unittest.TestCase):
             return glob.translate(pat, recursive=True, include_hidden=True, seps='/')
         self.assertEqual(fn('*'), r'(?s:[^/]+)\Z')
         self.assertEqual(fn('?'), r'(?s:[^/])\Z')
-        self.assertEqual(fn('**'), r'(?s:(?!/).*)\Z')
-        self.assertEqual(fn('/**'), r'(?s:/.*)\Z')
-        self.assertEqual(fn('**/**'), r'(?s:(?!/).*)\Z')
+        self.assertEqual(fn('**'), r'(?s:.*)\Z')
+        self.assertEqual(fn('**/**'), r'(?s:.*)\Z')
         self.assertRaises(ValueError, fn, '***')
         self.assertRaises(ValueError, fn, 'a**')
         self.assertRaises(ValueError, fn, '**b')
@@ -459,7 +456,7 @@ class GlobTests(unittest.TestCase):
         def fn(pat):
             return glob.translate(pat, recursive=True, include_hidden=True, seps=['/', '\\'])
         self.assertEqual(fn('foo/bar\\baz'), r'(?s:foo[/\\]bar[/\\]baz)\Z')
-        self.assertEqual(fn('**/*'), r'(?s:(?![/\\])(?:[/\\]|[^/\\]+[/\\])*[^/\\]+)\Z')
+        self.assertEqual(fn('**/*'), r'(?s:(?:[/\\]|[^/\\]+[/\\])*[^/\\]+)\Z')
 
 
 @skip_unless_symlink

--- a/Misc/NEWS.d/next/Library/2024-03-10-17-19-09.gh-issue-116393.JmhKY4.rst
+++ b/Misc/NEWS.d/next/Library/2024-03-10-17-19-09.gh-issue-116393.JmhKY4.rst
@@ -1,0 +1,1 @@
+:func:`glob.translate` "**" can match empty path parts when recursive=True


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

Closes #116393 

Hello everyone,

this PR makes `glob.translate` match empty path parts (or consecutive path separators, i.e. `"foo//bar"`) with `"**"` when `recursive=True`.

When I first implemented the change, I noticed that a pattern that starts with `"**"` would also match paths that start with `"/"`, because they start with an 'empty part'. 

~So I added a negative lookahead to the beginning of the regex in case the pattern starts with `"**"`, see: 162430890039fdbae88230536b9951e110e2ba11~

~This prevents `glob.translate("**", recursive=True).match` from matching `"/foo"`, which is intuitive for me.~

edit: `"**"` matching "/" is in line with pathlib
```pycon
>>> import pathlib
>>> pathlib.Path("/").full_match("**")
True
```

Cheers,
Andreas


<!-- gh-issue-number: gh-116393 -->
* Issue: gh-116393
<!-- /gh-issue-number -->
