### PR TITLE
gh-116417: Fix make check-c-globals for _testlimitedcapi

### DIFF
--- a/Modules/_testcapi/unicode.c
+++ b/Modules/_testcapi/unicode.c
@@ -3,8 +3,6 @@
 #include "parts.h"
 #include "util.h"
 
-static struct PyModuleDef *_testcapimodule = NULL;  // set at initialization
-
 static PyObject *
 codec_incrementalencoder(PyObject *self, PyObject *args)
 {
@@ -2098,8 +2096,6 @@ static PyMethodDef TestMethods[] = {
 
 int
 _PyTestCapi_Init_Unicode(PyObject *m) {
-    _testcapimodule = PyModule_GetDef(m);
-
     if (PyModule_AddFunctions(m, TestMethods) < 0) {
         return -1;
     }

--- a/Tools/c-analyzer/c_parser/preprocessor/gcc.py
+++ b/Tools/c-analyzer/c_parser/preprocessor/gcc.py
@@ -7,6 +7,7 @@ from . import common as _common
 FILES_WITHOUT_INTERNAL_CAPI = frozenset((
     # Modules/
     '_testcapimodule.c',
+    '_testlimitedcapi.c',
     '_testclinic_limited.c',
     'xxlimited.c',
     'xxlimited_35.c',

--- a/Tools/c-analyzer/cpython/ignored.tsv
+++ b/Tools/c-analyzer/cpython/ignored.tsv
@@ -444,7 +444,6 @@ Modules/_testcapi/heaptype.c	-	_testcapimodule	-
 Modules/_testcapi/mem.c	-	FmData	-
 Modules/_testcapi/mem.c	-	FmHook	-
 Modules/_testcapi/structmember.c	-	test_structmembersType_OldAPI	-
-Modules/_testcapi/unicode.c	-	_testcapimodule	-
 Modules/_testcapi/watchers.c	-	g_dict_watch_events	-
 Modules/_testcapi/watchers.c	-	g_dict_watchers_installed	-
 Modules/_testcapi/watchers.c	-	g_type_modified_events	-


### PR DESCRIPTION
* Remove unused '_testcapimodule' global in Modules/_testcapi/unicode.c.
* Update c-analyzer to not use the internal C API in _testlimitedcapi.c.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-116417 -->
* Issue: gh-116417
<!-- /gh-issue-number -->
