### PR TITLE
gh-116576: Fix `Tools/scripts/sortperf.py` sorting the same list

### DIFF
--- a/Tools/scripts/sortperf.py
+++ b/Tools/scripts/sortperf.py
@@ -130,7 +130,8 @@ class Benchmark:
 
     def _prepare_data(self, loops: int) -> list[float]:
         bench = BENCHMARKS[self._name]
-        return [bench(self._size, self._random)] * loops
+        data = bench(self._size, self._random)
+        return [data.copy() for _ in range(loops)]
 
 
 def add_cmdline_args(cmd: list[str], args) -> None:


### PR DESCRIPTION
Before:

```
» python Tools/scripts/sortperf.py
.....................
list_sort: Mean +- std dev: 29.7 us +- 0.1 us
.....................
list_sort_ascending: Mean +- std dev: 29.3 us +- 0.1 us
.....................
list_sort_ascending_exchanged: Mean +- std dev: 29.3 us +- 0.0 us
.....................
list_sort_ascending_one_percent: Mean +- std dev: 29.3 us +- 0.0 us
.....................
list_sort_ascending_random: Mean +- std dev: 29.3 us +- 0.1 us
.....................
list_sort_descending: Mean +- std dev: 29.3 us +- 0.1 us
.....................
list_sort_duplicates: Mean +- std dev: 30.3 us +- 1.1 us
.....................
list_sort_equal: Mean +- std dev: 29.0 us +- 0.1 us
.....................
list_sort_worst_case: Mean +- std dev: 29.1 us +- 0.1 us
```

After:

```
» python Tools/scripts/sortperf.py 
.....................
list_sort: Mean +- std dev: 1.33 ms +- 0.01 ms
.....................
list_sort_ascending: Mean +- std dev: 30.5 us +- 1.0 us
.....................
list_sort_ascending_exchanged: Mean +- std dev: 35.3 us +- 1.9 us
.....................
list_sort_ascending_one_percent: Mean +- std dev: 86.8 us +- 3.1 us
.....................
list_sort_ascending_random: Mean +- std dev: 34.8 us +- 1.1 us
.....................
list_sort_descending: Mean +- std dev: 33.4 us +- 0.6 us
.....................
list_sort_duplicates: Mean +- std dev: 456 us +- 8 us
.....................
list_sort_equal: Mean +- std dev: 29.8 us +- 0.6 us
.....................
list_sort_worst_case: Mean +- std dev: 59.7 us +- 1.2 us
```

Refs https://github.com/python/cpython/pull/114687

<!-- gh-issue-number: gh-116576 -->
* Issue: gh-116576
<!-- /gh-issue-number -->
