### PR TITLE
gh-116590: Fix unused `current_thread_holds_gil` function warning

### DIFF
--- a/Python/ceval_gil.c
+++ b/Python/ceval_gil.c
@@ -417,6 +417,7 @@ PyEval_ThreadsInitialized(void)
     return _PyEval_ThreadsInitialized();
 }
 
+#ifndef NDEBUG
 static inline int
 current_thread_holds_gil(struct _gil_runtime_state *gil, PyThreadState *tstate)
 {
@@ -425,6 +426,7 @@ current_thread_holds_gil(struct _gil_runtime_state *gil, PyThreadState *tstate)
     }
     return _Py_atomic_load_int_relaxed(&gil->locked);
 }
+#endif
 
 static void
 init_shared_gil(PyInterpreterState *interp, struct _gil_runtime_state *gil)


### PR DESCRIPTION


<!-- gh-issue-number: gh-116590 -->
* Issue: gh-116590
<!-- /gh-issue-number -->
