### PR TITLE
gh-116603: Open docs external links in browser's new tab

### DIFF
--- a/Doc/conf.py
+++ b/Doc/conf.py
@@ -39,6 +39,12 @@ except ImportError:
     pass
 else:
     extensions.append('sphinxext.opengraph')
+try:
+    import sphinx_new_tab_link
+except ImportError:
+    pass
+else:
+    extensions.append('sphinx_new_tab_link')
 
 
 doctest_global_setup = '''

--- a/Doc/requirements.txt
+++ b/Doc/requirements.txt
@@ -13,6 +13,7 @@ blurb
 sphinx-autobuild
 sphinxext-opengraph==0.7.5
 sphinx-notfound-page==1.0.0
+sphinx-new-tab-link==0.3.1
 
 # The theme used by the documentation is stored separately, so we need
 # to install that as well.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

Hello,

# Solution

By this pull request, external sites open in **NEW tab** of browser.
Sphinx extension [sphinx-new-tab-link](https://github.com/ftnext/sphinx-new-tab-link) (which I created) supports this.
(It generates `<a href="..." target="_blank" rel="noopener noreferrer">`)

I confirmed `make html` passed and the issue's PEP 602 link opens in new tab.

# Details

In November 2023, Guido-san @gvanrossum came Japan and I (nikkie) gave the presentation.
Slide: https://docs.google.com/presentation/d/1mN4qaiC5EQDtBY5UIOvJEmiQiTMIi7rHG5j-4jEnyZA/edit#slide=id.g29efb69a6fc_0_52
Archive: https://youtu.be/aaZuEPmHiQY?si=iHoIb0XcPszwDCB6&t=2718

Guido-san said "thank you for making this and I'm going to promote this with a python documentation team,"
so I send this pull request.

Thank you.


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--116595.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->

<!-- gh-issue-number: gh-116603 -->
* Issue: gh-116603
<!-- /gh-issue-number -->
