### PR TITLE
gh-110819: Fix ‘kind’ may be used uninitialized warning in `longobject`

### DIFF
--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -1965,7 +1965,6 @@ long_to_decimal_string_internal(PyObject *aa,
     digit *pout, *pin, rem, tenpow;
     int negative;
     int d;
-    int kind = 0;
 
     assert(writer == NULL || bytes_writer == NULL);
 
@@ -2080,7 +2079,6 @@ long_to_decimal_string_internal(PyObject *aa,
             Py_DECREF(scratch);
             return -1;
         }
-        kind = writer->kind;
     }
     else if (bytes_writer) {
         *bytes_str = _PyBytesWriter_Prepare(bytes_writer, *bytes_str, strlen);
@@ -2095,7 +2093,6 @@ long_to_decimal_string_internal(PyObject *aa,
             Py_DECREF(scratch);
             return -1;
         }
-        kind = PyUnicode_KIND(str);
     }
 
 #define WRITE_DIGITS(p)                                               \
@@ -2143,19 +2140,23 @@ long_to_decimal_string_internal(PyObject *aa,
         WRITE_DIGITS(p);
         assert(p == *bytes_str);
     }
-    else if (kind == PyUnicode_1BYTE_KIND) {
-        Py_UCS1 *p;
-        WRITE_UNICODE_DIGITS(Py_UCS1);
-    }
-    else if (kind == PyUnicode_2BYTE_KIND) {
-        Py_UCS2 *p;
-        WRITE_UNICODE_DIGITS(Py_UCS2);
-    }
     else {
-        Py_UCS4 *p;
-        assert (kind == PyUnicode_4BYTE_KIND);
-        WRITE_UNICODE_DIGITS(Py_UCS4);
+        int kind = writer ? writer->kind : PyUnicode_KIND(str);
+        if (kind == PyUnicode_1BYTE_KIND) {
+            Py_UCS1 *p;
+            WRITE_UNICODE_DIGITS(Py_UCS1);
+        }
+        else if (kind == PyUnicode_2BYTE_KIND) {
+            Py_UCS2 *p;
+            WRITE_UNICODE_DIGITS(Py_UCS2);
+        }
+        else {
+            assert (kind == PyUnicode_4BYTE_KIND);
+            Py_UCS4 *p;
+            WRITE_UNICODE_DIGITS(Py_UCS4);
+        }
     }
+
 #undef WRITE_DIGITS
 #undef WRITE_UNICODE_DIGITS
 
@@ -2196,7 +2197,6 @@ long_format_binary(PyObject *aa, int base, int alternate,
     PyObject *v = NULL;
     Py_ssize_t sz;
     Py_ssize_t size_a;
-    int kind = 0;
     int negative;
     int bits;
 
@@ -2249,7 +2249,6 @@ long_format_binary(PyObject *aa, int base, int alternate,
     if (writer) {
         if (_PyUnicodeWriter_Prepare(writer, sz, 'x') == -1)
             return -1;
-        kind = writer->kind;
     }
     else if (bytes_writer) {
         *bytes_str = _PyBytesWriter_Prepare(bytes_writer, *bytes_str, sz);
@@ -2260,7 +2259,6 @@ long_format_binary(PyObject *aa, int base, int alternate,
         v = PyUnicode_New(sz, 'x');
         if (v == NULL)
             return -1;
-        kind = PyUnicode_KIND(v);
     }
 
 #define WRITE_DIGITS(p)                                                 \
@@ -2321,19 +2319,23 @@ long_format_binary(PyObject *aa, int base, int alternate,
         WRITE_DIGITS(p);
         assert(p == *bytes_str);
     }
-    else if (kind == PyUnicode_1BYTE_KIND) {
-        Py_UCS1 *p;
-        WRITE_UNICODE_DIGITS(Py_UCS1);
-    }
-    else if (kind == PyUnicode_2BYTE_KIND) {
-        Py_UCS2 *p;
-        WRITE_UNICODE_DIGITS(Py_UCS2);
-    }
     else {
-        Py_UCS4 *p;
-        assert (kind == PyUnicode_4BYTE_KIND);
-        WRITE_UNICODE_DIGITS(Py_UCS4);
+        int kind = writer ? writer->kind : PyUnicode_KIND(v);
+        if (kind == PyUnicode_1BYTE_KIND) {
+            Py_UCS1 *p;
+            WRITE_UNICODE_DIGITS(Py_UCS1);
+        }
+        else if (kind == PyUnicode_2BYTE_KIND) {
+            Py_UCS2 *p;
+            WRITE_UNICODE_DIGITS(Py_UCS2);
+        }
+        else {
+            assert (kind == PyUnicode_4BYTE_KIND);
+            Py_UCS4 *p;
+            WRITE_UNICODE_DIGITS(Py_UCS4);
+        }
     }
+
 #undef WRITE_DIGITS
 #undef WRITE_UNICODE_DIGITS
 

--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -1965,7 +1965,9 @@ long_to_decimal_string_internal(PyObject *aa,
     digit *pout, *pin, rem, tenpow;
     int negative;
     int d;
-    int kind;
+    int kind = 0;
+
+    assert(writer == NULL || bytes_writer == NULL);
 
     a = (PyLongObject *)aa;
     if (a == NULL || !PyLong_Check(a)) {
@@ -2194,11 +2196,12 @@ long_format_binary(PyObject *aa, int base, int alternate,
     PyObject *v = NULL;
     Py_ssize_t sz;
     Py_ssize_t size_a;
-    int kind;
+    int kind = 0;
     int negative;
     int bits;
 
     assert(base == 2 || base == 8 || base == 16);
+    assert(writer == NULL || bytes_writer == NULL);
     if (a == NULL || !PyLong_Check(a)) {
         PyErr_BadInternalCall();
         return -1;

--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -1966,6 +1966,7 @@ long_to_decimal_string_internal(PyObject *aa,
     int negative;
     int d;
 
+    // writer or bytes_writer can be used, but not both at the same time.
     assert(writer == NULL || bytes_writer == NULL);
 
     a = (PyLongObject *)aa;
@@ -2201,6 +2202,7 @@ long_format_binary(PyObject *aa, int base, int alternate,
     int bits;
 
     assert(base == 2 || base == 8 || base == 16);
+    // writer or bytes_writer can be used, but not both at the same time.
     assert(writer == NULL || bytes_writer == NULL);
     if (a == NULL || !PyLong_Check(a)) {
         PyErr_BadInternalCall();


### PR DESCRIPTION
I've also added an `assert` to make sure that both parameters `writer` and `bytes_writer` cannot be passed at the same time.

<!-- gh-issue-number: gh-116592 -->
* Issue: gh-116592
<!-- /gh-issue-number -->


<!-- gh-issue-number: gh-110819 -->
* Issue: gh-110819
<!-- /gh-issue-number -->
