### PR TITLE
gh-116522: Stop the world before fork() and during shutdown

### DIFF
--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -7737,10 +7737,15 @@ os_register_at_fork_impl(PyObject *module, PyObject *before,
 // running in the process. Best effort, silent if unable to count threads.
 // Constraint: Quick. Never overcounts. Never leaves an error set.
 //
-// This code might do an import, thus acquiring the import lock, which
-// PyOS_BeforeFork() also does.  As this should only be called from
-// the parent process, it is in the same thread so that works.
-static void warn_about_fork_with_threads(const char* name) {
+// This should only be called from the parent process after
+// PyOS_AfterFork_Parent().
+static void
+warn_about_fork_with_threads(const char* name)
+{
+    // It's not safe to issue the warning while the world is stopped, because
+    // other threads might be holding locks that we need, which would deadlock.
+    assert(!_PyRuntime.stoptheworld.world_stopped);
+
     // TODO: Consider making an `os` module API to return the current number
     // of threads in the process. That'd presumably use this platform code but
     // raise an error rather than using the inaccurate fallback.
@@ -7866,6 +7871,7 @@ os_fork1_impl(PyObject *module)
     } else {
         /* parent: release the import lock. */
         PyOS_AfterFork_Parent();
+        // After PyOS_AfterFork_Parent() starts the world to avoid deadlock.
         warn_about_fork_with_threads("fork1");
     }
     if (pid == -1) {
@@ -7914,6 +7920,7 @@ os_fork_impl(PyObject *module)
     } else {
         /* parent: release the import lock. */
         PyOS_AfterFork_Parent();
+        // After PyOS_AfterFork_Parent() starts the world to avoid deadlock.
         warn_about_fork_with_threads("fork");
     }
     if (pid == -1) {
@@ -8745,6 +8752,7 @@ os_forkpty_impl(PyObject *module)
     } else {
         /* parent: release the import lock. */
         PyOS_AfterFork_Parent();
+        // After PyOS_AfterFork_Parent() starts the world to avoid deadlock.
         warn_about_fork_with_threads("forkpty");
     }
     if (pid == -1) {

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -1911,15 +1911,15 @@ Py_FinalizeEx(void)
     int malloc_stats = tstate->interp->config.malloc_stats;
 #endif
 
+    /* Ensure that remaining threads are detached */
+    _PyEval_StopTheWorldAll(runtime);
+
     /* Remaining daemon threads will automatically exit
        when they attempt to take the GIL (ex: PyEval_RestoreThread()). */
     _PyInterpreterState_SetFinalizing(tstate->interp, tstate);
     _PyRuntimeState_SetFinalizing(runtime, tstate);
     runtime->initialized = 0;
     runtime->core_initialized = 0;
-
-    /* Ensure that remaining threads are detached */
-    _PyEval_StopTheWorldAll(runtime);
 
     // XXX Call something like _PyImport_Disable() here?
 

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -1918,6 +1918,9 @@ Py_FinalizeEx(void)
     runtime->initialized = 0;
     runtime->core_initialized = 0;
 
+    /* Ensure that remaining threads are detached */
+    _PyEval_StopTheWorldAll(runtime);
+
     // XXX Call something like _PyImport_Disable() here?
 
     /* Destroy the state of all threads of the interpreter, except of the

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -1715,6 +1715,10 @@ _PyThreadState_DeleteExcept(PyThreadState *tstate)
     PyInterpreterState *interp = tstate->interp;
     _PyRuntimeState *runtime = interp->runtime;
 
+#ifdef Py_GIL_DISABLED
+    assert(runtime->stoptheworld.world_stopped);
+#endif
+
     HEAD_LOCK(runtime);
     /* Remove all thread states, except tstate, from the linked list of
        thread states.  This will allow calling PyThreadState_Clear()
@@ -1732,6 +1736,8 @@ _PyThreadState_DeleteExcept(PyThreadState *tstate)
     tstate->prev = tstate->next = NULL;
     interp->threads.head = tstate;
     HEAD_UNLOCK(runtime);
+
+    _PyEval_StartTheWorldAll(runtime);
 
     /* Clear and deallocate all stale thread states.  Even if this
        executes Python code, we should be safe since it executes


### PR DESCRIPTION
This changes the free-threaded build to perform a stop-the-world pause before deleting other thread states when forking and during shutdown. This fixes some crashes when using multiprocessing and during shutdown when running with `PYTHON_GIL=0`.

This also changes `PyOS_BeforeFork` to acquire the runtime lock (i.e., `HEAD_LOCK(&_PyRuntime)`) before forking to ensure that data protected by the runtime lock (and not just the GIL or stop-the-world) is in a consistent state before forking.

The `warn_about_fork_with_threads` is not safe to call during a stop-the-world pause or while holding the runtime lock, so it's moved after `PyOS_AfterFork_Parent()`.

<!-- gh-issue-number: gh-116522 -->
* Issue: gh-116522
<!-- /gh-issue-number -->
