### PR TITLE
CI: Process stale issues twice per day

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -2,7 +2,7 @@ name: Mark stale pull requests
 
 on:
   schedule:
-  - cron: "0 0 * * *"
+  - cron: "0 */12 * * *"
 
 permissions:
   pull-requests: write


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

This action starts with the first issue, then moves on to the next. Once it's processed a batch, it saves its progress in a small cache file.

As detailed in https://github.com/python/cpython/issues/113858, the rest of the CI generates lots of large cache files, which means the (small) actions/stale cache file has been cleared out by the time the next daily cron triggers.

This means the action starts again at the top, and reprocesses the same batch over and over, never making progress.

Let's try running [twice a day](https://crontab.guru/#0_*/12_*_*_*). This should hopefully keep the "last access" of the cache file fresher, meaning it's not cleared out. We could later also try 3 or 4 times per day.