### PR TITLE
Docs: fix broken links

### DIFF
--- a/Doc/faq/extending.rst
+++ b/Doc/faq/extending.rst
@@ -50,7 +50,7 @@ to learn Python's C API.
 If you need to interface to some C or C++ library for which no Python extension
 currently exists, you can try wrapping the library's data types and functions
 with a tool such as `SWIG <https://www.swig.org>`_.  `SIP
-<https://riverbankcomputing.com/software/sip/intro>`__, `CXX
+<https://github.com/Python-SIP/sip>`__, `CXX
 <https://cxx.sourceforge.net/>`_ `Boost
 <https://www.boost.org/libs/python/doc/index.html>`_, or `Weave
 <https://github.com/scipy/weave>`_ are also

--- a/Doc/library/math.rst
+++ b/Doc/library/math.rst
@@ -592,7 +592,7 @@ Special functions
 
    The :func:`erf` function can be used to compute traditional statistical
    functions such as the `cumulative standard normal distribution
-   <https://en.wikipedia.org/wiki/Normal_distribution#Cumulative_distribution_functions>`_::
+   <https://en.wikipedia.org/wiki/Cumulative_distribution_function>`_::
 
      def phi(x):
          'Cumulative distribution function for the standard normal distribution'

--- a/Doc/library/pathlib.rst
+++ b/Doc/library/pathlib.rst
@@ -7,7 +7,7 @@
 
 .. versionadded:: 3.4
 
-**Source code:** :source:`Lib/pathlib.py`
+**Source code:** :source:`Lib/pathlib/`
 
 .. index:: single: path; operations
 

--- a/Doc/library/sqlite3.rst
+++ b/Doc/library/sqlite3.rst
@@ -1135,7 +1135,7 @@ Connection objects
       .. versionchanged:: 3.12
          Added the *entrypoint* parameter.
 
-   .. _Loading an Extension: https://www.sqlite.org/loadext.html#loading_an_extension_
+   .. _Loading an Extension: https://www.sqlite.org/loadext.html#loading_an_extension
 
    .. method:: iterdump(*, filter=None)
 

--- a/Doc/library/venv.rst
+++ b/Doc/library/venv.rst
@@ -54,7 +54,7 @@ See :pep:`405` for more background on Python virtual environments.
 .. seealso::
 
    `Python Packaging User Guide: Creating and using virtual environments
-   <https://packaging.python.org/guides/installing-using-pip-and-virtual-environments/#creating-a-virtual-environment>`__
+   <https://packaging.python.org/guides/installing-using-pip-and-virtual-environments/#create-and-use-virtual-environments>`__
 
 .. include:: ../includes/wasm-notavail.rst
 


### PR DESCRIPTION


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--116651.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->