### PR TITLE
[3.12] gh-116604: Correctly honor the gc status when calling _Py_RunGC (GH-116628)

### DIFF
--- a/Lib/test/test_gc.py
+++ b/Lib/test/test_gc.py
@@ -1387,6 +1387,31 @@ class GCTogglingTests(unittest.TestCase):
             # empty __dict__.
             self.assertEqual(x, None)
 
+    def test_indirect_calls_with_gc_disabled(self):
+        junk = []
+        i = 0
+        detector = GC_Detector()
+        while not detector.gc_happened:
+            i += 1
+            if i > 10000:
+                self.fail("gc didn't happen after 10000 iterations")
+            junk.append([])  # this will eventually trigger gc
+
+        try:
+            gc.disable()
+            junk = []
+            i = 0
+            detector = GC_Detector()
+            while not detector.gc_happened:
+                i += 1
+                if i > 10000:
+                    break
+                junk.append([])  # this may eventually trigger gc (if it is enabled)
+
+            self.assertEqual(i, 10001)
+        finally:
+            gc.enable()
+
 
 class PythonFinalizationTests(unittest.TestCase):
     def test_ast_fini(self):

--- a/Misc/NEWS.d/next/Core and Builtins/2024-03-11-22-24-59.gh-issue-116604.LCEzAT.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2024-03-11-22-24-59.gh-issue-116604.LCEzAT.rst
@@ -1,0 +1,3 @@
+Respect the status of the garbage collector when indirect calls are made via
+:c:func:`PyErr_CheckSignals` and the evaluation breaker. Patch by Pablo
+Galindo

--- a/Modules/gcmodule.c
+++ b/Modules/gcmodule.c
@@ -2288,6 +2288,9 @@ void
 _Py_RunGC(PyThreadState *tstate)
 {
     GCState *gcstate = &tstate->interp->gc;
+    if (!gcstate->enabled) {
+        return;
+    } 
     gcstate->collecting = 1;
     gc_collect_generations(tstate);
     gcstate->collecting = 0;


### PR DESCRIPTION
…
(cherry picked from commit 02918aa96117781261cb1a564e37a861b01eb883)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-116604 -->
* Issue: gh-116604
<!-- /gh-issue-number -->
