### PR TITLE
gh-116604: Fix test_gc on free-threaded build

### DIFF
--- a/Lib/test/support/__init__.py
+++ b/Lib/test/support/__init__.py
@@ -797,6 +797,16 @@ def disable_gc():
         if have_gc:
             gc.enable()
 
+@contextlib.contextmanager
+def gc_threshold(*args):
+    import gc
+    old_threshold = gc.get_threshold()
+    gc.set_threshold(*args)
+    try:
+        yield
+    finally:
+        gc.set_threshold(*old_threshold)
+
 
 def python_is_optimized():
     """Find if Python was built with optimizations."""

--- a/Lib/test/test_gc.py
+++ b/Lib/test/test_gc.py
@@ -5,7 +5,7 @@ from test.support import (verbose, refcount_test,
 from test.support.import_helper import import_module
 from test.support.os_helper import temp_dir, TESTFN, unlink
 from test.support.script_helper import assert_python_ok, make_script
-from test.support import threading_helper
+from test.support import threading_helper, gc_threshold
 
 import gc
 import sys
@@ -1330,6 +1330,7 @@ class GCTogglingTests(unittest.TestCase):
             # with an empty __dict__.
             self.assertEqual(x, None)
 
+    @gc_threshold(1000, 0, 0)
     def test_bug1055820d(self):
         # Corresponds to temp2d.py in the bug report.  This is very much like
         # test_bug1055820c, but uses a __del__ method instead of a weakref
@@ -1397,6 +1398,7 @@ class GCTogglingTests(unittest.TestCase):
             # empty __dict__.
             self.assertEqual(x, None)
 
+    @gc_threshold(1000, 0, 0)
     def test_indirect_calls_with_gc_disabled(self):
         junk = []
         i = 0


### PR DESCRIPTION
The free-threaded GC only does full collections, so it uses a threshold that is a maximum of a fixed value (default 2000) and proportional to the number of live objects. If there were many live objects after the previous collection, then the threshold may be larger than 10,000 causing `test_indirect_calls_with_gc_disabled` to fail.

This manually sets the threshold to `(1000, 0, 0)` for the test. The `0` disables the proportional scaling.

<!-- gh-issue-number: gh-116604 -->
* Issue: gh-116604
<!-- /gh-issue-number -->
