### PR TITLE
gh-116604: Check for `gcstate->enabled` in _Py_RunGC in free-threaded build

### DIFF
--- a/Python/gc_free_threading.c
+++ b/Python/gc_free_threading.c
@@ -1603,6 +1603,10 @@ _PyObject_GC_Link(PyObject *op)
 void
 _Py_RunGC(PyThreadState *tstate)
 {
+    GCState *gcstate = get_gc_state();
+    if (!gcstate->enabled) {
+        return;
+    }
     gc_collect_main(tstate, 0, _Py_GC_REASON_HEAP);
 }
 


### PR DESCRIPTION
This isn't strictly necessary because the implementation of `gc_should_collect` already checks `gcstate->enabled` in the free-threaded build, but it seems like a good idea until the common pieces of gc.c and gc_free_threading.c are refactored out.


<!-- gh-issue-number: gh-116604 -->
* Issue: gh-116604
<!-- /gh-issue-number -->
