### PR TITLE
gh-116631: Fix race condition in `test_shutdown_immediate_put_join`

### DIFF
--- a/Lib/test/test_queue.py
+++ b/Lib/test/test_queue.py
@@ -567,7 +567,6 @@ class BaseQueueTestMixin(BlockingTestMixin):
         results = []
         go = threading.Event()
         q.put("Y")
-        nb = q.qsize()
         # queue not fulled
 
         thrds = (
@@ -578,13 +577,19 @@ class BaseQueueTestMixin(BlockingTestMixin):
         for func, params in thrds:
             threads.append(threading.Thread(target=func, args=params))
             threads[-1].start()
-        self.assertEqual(q.unfinished_tasks, nb)
-        for i in range(nb):
-            t = threading.Thread(target=q.task_done)
-            t.start()
-            threads.append(t)
+        self.assertEqual(q.unfinished_tasks, 1)
+
         q.shutdown(immediate)
         go.set()
+
+        if immediate:
+            with self.assertRaises(self.queue.ShutDown):
+                q.get_nowait()
+        else:
+            task = q.get()
+            self.assertEqual(task, "Y")
+            q.task_done()
+
         for t in threads:
             t.join()
 

--- a/Lib/test/test_queue.py
+++ b/Lib/test/test_queue.py
@@ -586,8 +586,8 @@ class BaseQueueTestMixin(BlockingTestMixin):
             with self.assertRaises(self.queue.ShutDown):
                 q.get_nowait()
         else:
-            task = q.get()
-            self.assertEqual(task, "Y")
+            result = q.get()
+            self.assertEqual(result, "Y")
             q.task_done()
 
         for t in threads:


### PR DESCRIPTION
The test case had a race condition: if `q.task_done()` was executed after `shutdown(immediate=True)`, then it would raise an exception because the shutdown call already emptied the queue. This happened rarely with the GIL (due to the switching interval), but frequently in the free-threaded build with the GIL disabled.

<!-- gh-issue-number: gh-116631 -->
* Issue: gh-116631
<!-- /gh-issue-number -->
