### PR TITLE
gh-71042: Add `platform.android_ver`

### DIFF
--- a/Doc/library/platform.rst
+++ b/Doc/library/platform.rst
@@ -313,25 +313,27 @@ Android Platform
    with the following attributes. Values which cannot be determined are set to
    the defaults given as parameters.
 
-   * ``release`` - Android version, as a string (e.g. ``"14"``)
+   * ``release`` - Android version, as a string (e.g. ``"14"``).
 
-   * ``api_level`` - API level, as an integer (e.g. ``34``)
+   * ``api_level`` - API level of the running device, as an integer (e.g. ``34``
+     for Android 14). To get the API level which Python was built against, see
+     :func:`sys.getandroidapilevel`.
 
    * ``manufacturer`` - `Manufacturer name
-     <https://developer.android.com/reference/android/os/Build#MANUFACTURER>`__
+     <https://developer.android.com/reference/android/os/Build#MANUFACTURER>`__.
 
    * ``model`` - `Model name
      <https://developer.android.com/reference/android/os/Build#MODEL>`__ –
-     typically the marketing name or model number
+     typically the marketing name or model number.
 
    * ``device`` - `Device name
      <https://developer.android.com/reference/android/os/Build#DEVICE>`__ –
-     typically the model number or a codename
+     typically the model number or a codename.
 
    * ``is_emulator`` - ``True`` if the device is an emulator; ``False`` if it's
-     a physical device
+     a physical device.
 
-   See the `list of known model and device names
+   Google maintains a `list of known model and device names
    <https://storage.googleapis.com/play_public/supported_devices.html>`__.
 
    .. versionadded:: 3.13

--- a/Doc/library/platform.rst
+++ b/Doc/library/platform.rst
@@ -317,21 +317,21 @@ Android Platform
 
    * ``api_level`` - API level, as an integer (e.g. ``34``)
 
-   * ``manufacturer`` - `manufacturer name
+   * ``manufacturer`` - `Manufacturer name
      <https://developer.android.com/reference/android/os/Build#MANUFACTURER>`__
 
-   * ``model`` - `model name
+   * ``model`` - `Model name
      <https://developer.android.com/reference/android/os/Build#MODEL>`__ –
      typically the marketing name or model number
 
-   * ``device`` - `device name
+   * ``device`` - `Device name
      <https://developer.android.com/reference/android/os/Build#DEVICE>`__ –
      typically the model number or a codename
 
    * ``is_emulator`` - ``True`` if the device is an emulator; ``False`` if it's
      a physical device
 
-   For a list of known model and device names, see `here
+   See the `list of known model and device names
    <https://storage.googleapis.com/play_public/supported_devices.html>`__.
 
    .. versionadded:: 3.13

--- a/Doc/library/platform.rst
+++ b/Doc/library/platform.rst
@@ -301,3 +301,34 @@ Linux Platforms
           return ids
 
    .. versionadded:: 3.10
+
+
+Android Platform
+----------------
+
+.. function:: android_ver(release="", api_level=0, min_api_level=0, \
+                          manufacturer="", model="", device="")
+
+   Get Android device information. Returns a :func:`~collections.namedtuple`
+   with the following attributes. Values which cannot be determined are set to
+   the defaults given as parameters.
+
+   * ``release`` - Android version of the device, as a string (e.g. ``"14"``)
+   * ``api_level`` - API level of the device, as an integer (e.g. ``34``)
+   * ``min_api_level`` - Minimum API level this build of Python can run on, as
+      an integer (e.g. ``23``).
+   * ``manufacturer`` - `manufacturer
+      <https://developer.android.com/reference/android/os/Build#MANUFACTURER>`__
+      of the device, as a string (e.g. ``"Google"``)
+   * ``model`` - `model name
+      <https://developer.android.com/reference/android/os/Build#MODEL>`__ of the
+      device, as a string (e.g. ``"Pixel 7"``)
+   * ``device`` - `device name
+      <https://developer.android.com/reference/android/os/Build#DEVICE>`__ of
+      the device, as a string (e.g. ``"panther"``)
+
+   Which one of ``model`` and ``device`` is more likely to be unique, and which
+   one is more likely to resemble the marketing name, varies between different
+   manufacturers.
+
+   .. versionadded:: 3.13

--- a/Doc/library/platform.rst
+++ b/Doc/library/platform.rst
@@ -142,18 +142,11 @@ Cross Platform
    Returns the system's release, e.g. ``'2.2.0'`` or ``'NT'``. An empty string is
    returned if the value cannot be determined.
 
-   .. versionchanged:: 3.13
-      On Android, this now returns the Android version rather than the Linux
-      kernel version.
-
 
 .. function:: system()
 
    Returns the system/OS name, such as ``'Linux'``, ``'Darwin'``, ``'Java'``,
    ``'Windows'``. An empty string is returned if the value cannot be determined.
-
-   .. versionchanged:: 3.13
-      On Android, this now returns ``'Android'`` rather than ``'Linux'``.
 
 
 .. function:: system_alias(system, release, version)
@@ -329,18 +322,16 @@ Android Platform
 
    * ``manufacturer`` - `manufacturer name
      <https://developer.android.com/reference/android/os/Build#MANUFACTURER>`__
-     (e.g. ``"Google"``)
 
    * ``model`` - `model name
-     <https://developer.android.com/reference/android/os/Build#MODEL>`__
-     (e.g. ``"Pixel 7"``)
+     <https://developer.android.com/reference/android/os/Build#MODEL>`__ –
+     typically the marketing name or model number
 
    * ``device`` - `device name
-     <https://developer.android.com/reference/android/os/Build#DEVICE>`__
-     (e.g. ``"panther"``)
+     <https://developer.android.com/reference/android/os/Build#DEVICE>`__ –
+     typically the model number or a codename
 
-   Which one of ``model`` and ``device`` is more likely to distinguish different
-   device variants, and which one is more likely to resemble the marketing name,
-   varies between different manufacturers.
+   For a list of known model and device names, see `here
+   <https://storage.googleapis.com/play_public/supported_devices.html>`__.
 
    .. versionadded:: 3.13

--- a/Doc/library/platform.rst
+++ b/Doc/library/platform.rst
@@ -306,8 +306,8 @@ Linux Platforms
 Android Platform
 ----------------
 
-.. function:: android_ver(release="", api_level=0, \
-                          manufacturer="", model="", device="")
+.. function:: android_ver(release="", api_level=0, manufacturer="", \
+                          model="", device="", is_emulator=False)
 
    Get Android device information. Returns a :func:`~collections.namedtuple`
    with the following attributes. Values which cannot be determined are set to
@@ -327,6 +327,9 @@ Android Platform
    * ``device`` - `device name
      <https://developer.android.com/reference/android/os/Build#DEVICE>`__ –
      typically the model number or a codename
+
+   * ``is_emulator`` - ``True`` if the device is an emulator; ``False`` if it's
+     a physical device
 
    For a list of known model and device names, see `here
    <https://storage.googleapis.com/play_public/supported_devices.html>`__.

--- a/Doc/library/platform.rst
+++ b/Doc/library/platform.rst
@@ -142,11 +142,18 @@ Cross Platform
    Returns the system's release, e.g. ``'2.2.0'`` or ``'NT'``. An empty string is
    returned if the value cannot be determined.
 
+   .. versionchanged:: 3.13
+      On Android, this now returns the Android version rather than the Linux
+      kernel version.
+
 
 .. function:: system()
 
    Returns the system/OS name, such as ``'Linux'``, ``'Darwin'``, ``'Java'``,
    ``'Windows'``. An empty string is returned if the value cannot be determined.
+
+   .. versionchanged:: 3.13
+      On Android, this now returns ``'Android'`` rather than ``'Linux'``.
 
 
 .. function:: system_alias(system, release, version)
@@ -313,22 +320,27 @@ Android Platform
    with the following attributes. Values which cannot be determined are set to
    the defaults given as parameters.
 
-   * ``release`` - Android version of the device, as a string (e.g. ``"14"``)
-   * ``api_level`` - API level of the device, as an integer (e.g. ``34``)
-   * ``min_api_level`` - Minimum API level this build of Python can run on, as
-      an integer (e.g. ``23``).
-   * ``manufacturer`` - `manufacturer
-      <https://developer.android.com/reference/android/os/Build#MANUFACTURER>`__
-      of the device, as a string (e.g. ``"Google"``)
-   * ``model`` - `model name
-      <https://developer.android.com/reference/android/os/Build#MODEL>`__ of the
-      device, as a string (e.g. ``"Pixel 7"``)
-   * ``device`` - `device name
-      <https://developer.android.com/reference/android/os/Build#DEVICE>`__ of
-      the device, as a string (e.g. ``"panther"``)
+   * ``release`` - Android version, as a string (e.g. ``"14"``)
 
-   Which one of ``model`` and ``device`` is more likely to be unique, and which
-   one is more likely to resemble the marketing name, varies between different
-   manufacturers.
+   * ``api_level`` - API level, as an integer (e.g. ``34``)
+
+   * ``min_api_level`` - Minimum API level this build of Python can run on, as
+     an integer (e.g. ``21``)
+
+   * ``manufacturer`` - `manufacturer name
+     <https://developer.android.com/reference/android/os/Build#MANUFACTURER>`__
+     (e.g. ``"Google"``)
+
+   * ``model`` - `model name
+     <https://developer.android.com/reference/android/os/Build#MODEL>`__
+     (e.g. ``"Pixel 7"``)
+
+   * ``device`` - `device name
+     <https://developer.android.com/reference/android/os/Build#DEVICE>`__
+     (e.g. ``"panther"``)
+
+   Which one of ``model`` and ``device`` is more likely to distinguish different
+   device variants, and which one is more likely to resemble the marketing name,
+   varies between different manufacturers.
 
    .. versionadded:: 3.13

--- a/Doc/library/platform.rst
+++ b/Doc/library/platform.rst
@@ -306,7 +306,7 @@ Linux Platforms
 Android Platform
 ----------------
 
-.. function:: android_ver(release="", api_level=0, min_api_level=0, \
+.. function:: android_ver(release="", api_level=0, \
                           manufacturer="", model="", device="")
 
    Get Android device information. Returns a :func:`~collections.namedtuple`
@@ -316,9 +316,6 @@ Android Platform
    * ``release`` - Android version, as a string (e.g. ``"14"``)
 
    * ``api_level`` - API level, as an integer (e.g. ``34``)
-
-   * ``min_api_level`` - Minimum API level this build of Python can run on, as
-     an integer (e.g. ``21``)
 
    * ``manufacturer`` - `manufacturer name
      <https://developer.android.com/reference/android/os/Build#MANUFACTURER>`__

--- a/Doc/library/sys.rst
+++ b/Doc/library/sys.rst
@@ -753,7 +753,9 @@ always available.
 
 .. function:: getandroidapilevel()
 
-   Return the build time API version of Android as an integer.
+   Return the build-time API level of Android as an integer. This represents the
+   minimum version of Android this build of Python can run on. For runtime
+   version information, see :func:`platform.android_ver`.
 
    .. availability:: Android.
 

--- a/Lib/platform.py
+++ b/Lib/platform.py
@@ -544,13 +544,10 @@ def java_ver(release='', vendor='', vminfo=('', '', ''), osinfo=('', '', '')):
 
 
 AndroidVer = collections.namedtuple(
-    "AndroidVer",
-    "release api_level min_api_level manufacturer model device")
+    "AndroidVer", "release api_level manufacturer model device")
 
-def android_ver(release="", api_level=0, min_api_level=0,
-                manufacturer="", model="", device=""):
+def android_ver(release="", api_level=0, manufacturer="", model="", device=""):
     if sys.platform == "android":
-        min_api_level = sys.getandroidapilevel()
         try:
             from ctypes import CDLL, c_char_p, create_string_buffer
         except ImportError:
@@ -577,8 +574,7 @@ def android_ver(release="", api_level=0, min_api_level=0,
             model = getprop("ro.product.model", model)
             device = getprop("ro.product.device", device)
 
-    return AndroidVer(
-        release, api_level, min_api_level, manufacturer, model, device)
+    return AndroidVer(release, api_level, manufacturer, model, device)
 
 
 ### System name aliasing

--- a/Lib/test/pythoninfo.py
+++ b/Lib/test/pythoninfo.py
@@ -179,6 +179,9 @@ def collect_platform(info_add):
             info_add(f'platform.freedesktop_os_release[{key}]',
                      os_release[key])
 
+    if sys.platform == 'android':
+        info_add('platform.android_ver', platform.android_ver())
+
 
 def collect_locale(info_add):
     import locale

--- a/Lib/test/pythoninfo.py
+++ b/Lib/test/pythoninfo.py
@@ -180,7 +180,7 @@ def collect_platform(info_add):
                      os_release[key])
 
     if sys.platform == 'android':
-        info_add('platform.android_ver', platform.android_ver())
+        call_func(info_add, 'platform.android_ver', platform, 'android_ver')
 
 
 def collect_locale(info_add):

--- a/Lib/test/support/__init__.py
+++ b/Lib/test/support/__init__.py
@@ -1795,7 +1795,7 @@ _old_android_emulator = None
 def setswitchinterval(interval):
     # Setting a very low gil interval on the Android emulator causes python
     # to hang (issue #26939).
-    minimum_interval = 1e-4
+    minimum_interval = 1e-4   # 100 us
     if is_android and interval < minimum_interval:
         global _old_android_emulator
         if _old_android_emulator is None:

--- a/Lib/test/support/__init__.py
+++ b/Lib/test/support/__init__.py
@@ -1791,18 +1791,18 @@ def missing_compiler_executable(cmd_names=[]):
             return cmd[0]
 
 
-_is_android_emulator = None
+_old_android_emulator = None
 def setswitchinterval(interval):
     # Setting a very low gil interval on the Android emulator causes python
     # to hang (issue #26939).
-    minimum_interval = 1e-5
+    minimum_interval = 1e-4
     if is_android and interval < minimum_interval:
-        global _is_android_emulator
-        if _is_android_emulator is None:
-            import subprocess
-            _is_android_emulator = (subprocess.check_output(
-                               ['getprop', 'ro.kernel.qemu']).strip() == b'1')
-        if _is_android_emulator:
+        global _old_android_emulator
+        if _old_android_emulator is None:
+            import platform
+            av = platform.android_ver()
+            _old_android_emulator = av.is_emulator and av.api_level < 24
+        if _old_android_emulator:
             interval = minimum_interval
     return sys.setswitchinterval(interval)
 

--- a/Lib/test/test_asyncio/test_base_events.py
+++ b/Lib/test/test_asyncio/test_base_events.py
@@ -3,6 +3,7 @@
 import concurrent.futures
 import errno
 import math
+import platform
 import socket
 import sys
 import threading
@@ -1430,6 +1431,10 @@ class BaseEventLoopWithSelectorTests(test_utils.TestCase):
         self._test_create_connection_ip_addr(m_socket, False)
 
     @patch_socket
+    @unittest.skipIf(
+        support.is_android and platform.android_ver().api_level < 23,
+        "Issue #26936: this fails on Android before API level 23"
+    )
     def test_create_connection_service_name(self, m_socket):
         m_socket.getaddrinfo = socket.getaddrinfo
         sock = m_socket.socket.return_value

--- a/Lib/test/test_asyncio/test_base_events.py
+++ b/Lib/test/test_asyncio/test_base_events.py
@@ -1433,7 +1433,7 @@ class BaseEventLoopWithSelectorTests(test_utils.TestCase):
     @patch_socket
     @unittest.skipIf(
         support.is_android and platform.android_ver().api_level < 23,
-        "Issue #26936: this fails on Android before API level 23"
+        "Issue gh-71123: this fails on Android before API level 23"
     )
     def test_create_connection_service_name(self, m_socket):
         m_socket.getaddrinfo = socket.getaddrinfo

--- a/Lib/test/test_platform.py
+++ b/Lib/test/test_platform.py
@@ -446,7 +446,7 @@ class PlatformTest(unittest.TestCase):
     def test_android_ver(self):
         res = platform.android_ver()
         self.assertIsInstance(res, tuple)
-        self.assertEqual(res, (res.release, res.api_level, res.min_api_level,
+        self.assertEqual(res, (res.release, res.api_level,
                                res.manufacturer, res.model, res.device))
 
         if sys.platform == "android":
@@ -456,29 +456,21 @@ class PlatformTest(unittest.TestCase):
                     self.assertIsInstance(value, str)
                     self.assertGreater(len(value), 0)
 
-            for name in ["api_level", "min_api_level"]:
-                with self.subTest(name):
-                    value = getattr(res, name)
-                    self.assertIsInstance(value, int)
-                    self.assertGreater(value, 0)
-
-            self.assertEqual(res.min_api_level, sys.getandroidapilevel())
-            self.assertGreaterEqual(res.api_level, res.min_api_level)
+            self.assertIsInstance(res.api_level, int)
+            self.assertGreaterEqual(res.api_level, sys.getandroidapilevel())
 
         # When not running on Android, it should return the default values.
         else:
             self.assertEqual(res.release, "")
             self.assertEqual(res.api_level, 0)
-            self.assertEqual(res.min_api_level, 0)
             self.assertEqual(res.manufacturer, "")
             self.assertEqual(res.model, "")
             self.assertEqual(res.device, "")
 
             # Default values may also be overridden using parameters.
-            res = platform.android_ver("alpha", 1, 2, "bravo", "charlie", "delta")
+            res = platform.android_ver("alpha", 1, "bravo", "charlie", "delta")
             self.assertEqual(res.release, "alpha")
             self.assertEqual(res.api_level, 1)
-            self.assertEqual(res.min_api_level, 2)
             self.assertEqual(res.manufacturer, "bravo")
             self.assertEqual(res.model, "charlie")
             self.assertEqual(res.device, "delta")

--- a/Lib/test/test_platform.py
+++ b/Lib/test/test_platform.py
@@ -446,18 +446,20 @@ class PlatformTest(unittest.TestCase):
     def test_android_ver(self):
         res = platform.android_ver()
         self.assertIsInstance(res, tuple)
-        self.assertEqual(res, (res.release, res.api_level,
-                               res.manufacturer, res.model, res.device))
+        self.assertEqual(res, (res.release, res.api_level, res.manufacturer,
+                               res.model, res.device, res.is_emulator))
 
         if sys.platform == "android":
             for name in ["release", "manufacturer", "model", "device"]:
                 with self.subTest(name):
                     value = getattr(res, name)
                     self.assertIsInstance(value, str)
-                    self.assertGreater(len(value), 0)
+                    self.assertNotEqual(value, "")
 
             self.assertIsInstance(res.api_level, int)
             self.assertGreaterEqual(res.api_level, sys.getandroidapilevel())
+
+            self.assertIsInstance(res.is_emulator, bool)
 
         # When not running on Android, it should return the default values.
         else:
@@ -466,15 +468,17 @@ class PlatformTest(unittest.TestCase):
             self.assertEqual(res.manufacturer, "")
             self.assertEqual(res.model, "")
             self.assertEqual(res.device, "")
+            self.assertEqual(res.is_emulator, False)
 
             # Default values may also be overridden using parameters.
-            res = platform.android_ver("alpha", 1, "bravo", "charlie", "delta")
+            res = platform.android_ver(
+                "alpha", 1, "bravo", "charlie", "delta", True)
             self.assertEqual(res.release, "alpha")
             self.assertEqual(res.api_level, 1)
             self.assertEqual(res.manufacturer, "bravo")
             self.assertEqual(res.model, "charlie")
             self.assertEqual(res.device, "delta")
-
+            self.assertEqual(res.is_emulator, True)
 
     @support.cpython_only
     def test__comparable_version(self):

--- a/Lib/test/test_socket.py
+++ b/Lib/test/test_socket.py
@@ -1220,7 +1220,7 @@ class GeneralModuleTests(unittest.TestCase):
         else:
             raise OSError
         # Try same call with optional protocol omitted
-        # Issue #26936: this fails on Android before API level 23.
+        # Issue gh-71123: this fails on Android before API level 23.
         if not (support.is_android and platform.android_ver().api_level < 23):
             port2 = socket.getservbyname(service)
             eq(port, port2)

--- a/Lib/test/test_socket.py
+++ b/Lib/test/test_socket.py
@@ -209,7 +209,10 @@ HAVE_SOCKET_QIPCRTR = _have_socket_qipcrtr()
 
 HAVE_SOCKET_VSOCK = _have_socket_vsock()
 
-HAVE_SOCKET_UDPLITE = hasattr(socket, "IPPROTO_UDPLITE")
+# Older Android versions block UDPLITE with SELinux.
+HAVE_SOCKET_UDPLITE = (
+    hasattr(socket, "IPPROTO_UDPLITE")
+    and not (support.is_android and platform.android_ver().api_level < 29))
 
 HAVE_SOCKET_BLUETOOTH = _have_socket_bluetooth()
 

--- a/Lib/test/test_socket.py
+++ b/Lib/test/test_socket.py
@@ -1217,8 +1217,8 @@ class GeneralModuleTests(unittest.TestCase):
         else:
             raise OSError
         # Try same call with optional protocol omitted
-        # Issue #26936: Android getservbyname() was broken before API 23.
-        if (not support.is_android) or sys.getandroidapilevel() >= 23:
+        # Issue #26936: this fails on Android before API level 23.
+        if not (support.is_android and platform.android_ver().api_level < 23):
             port2 = socket.getservbyname(service)
             eq(port, port2)
         # Try udp, but don't barf if it doesn't exist
@@ -1229,8 +1229,9 @@ class GeneralModuleTests(unittest.TestCase):
         else:
             eq(udpport, port)
         # Now make sure the lookup by port returns the same service name
-        # Issue #26936: Android getservbyport() is broken.
-        if not support.is_android:
+        # Issue #26936: when the protocol is omitted, this fails on Android
+        # before API level 28.
+        if not (support.is_android and platform.android_ver().api_level < 28):
             eq(socket.getservbyport(port2), service)
         eq(socket.getservbyport(port, 'tcp'), service)
         if udpport is not None:
@@ -1575,8 +1576,8 @@ class GeneralModuleTests(unittest.TestCase):
             socket.getaddrinfo('::1', 80)
         # port can be a string service name such as "http", a numeric
         # port number or None
-        # Issue #26936: Android getaddrinfo() was broken before API level 23.
-        if (not support.is_android) or sys.getandroidapilevel() >= 23:
+        # Issue #26936: this fails on Android before API level 23.
+        if not (support.is_android and platform.android_ver().api_level < 23):
             socket.getaddrinfo(HOST, "http")
         socket.getaddrinfo(HOST, 80)
         socket.getaddrinfo(HOST, None)

--- a/Misc/NEWS.d/next/Library/2024-03-12-19-32-17.gh-issue-71042.oI0Ron.rst
+++ b/Misc/NEWS.d/next/Library/2024-03-12-19-32-17.gh-issue-71042.oI0Ron.rst
@@ -1,0 +1,2 @@
+Add :func:`platform.android_ver`, which provides device and OS information
+on Android.


### PR DESCRIPTION
This PR implements the `platform.android_ver` function specified in [PEP 738](https://peps.python.org/pep-0738/#platform). 

It also uses the new function to do the following:

* Implement `platform.system` and `platform.release` as specified in the PEP
* Skip tests of some socket functionality which is broken on older versions of Android

<!-- gh-issue-number: gh-71042 -->
* Fixes #71042
* Fixes #76391
* Fixes #83032 
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--116674.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->