### PR TITLE
remove pointless variable initialization in socketmodule

### DIFF
--- a/Modules/socketmodule.c
+++ b/Modules/socketmodule.c
@@ -1701,7 +1701,6 @@ idna_converter(PyObject *obj, struct maybe_idna *data)
         return 1;
     }
     data->obj = NULL;
-    len = -1;
     if (PyBytes_Check(obj)) {
         data->buf = PyBytes_AsString(obj);
         len = PyBytes_Size(obj);


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
This value is never read, so this assignment is meaningless and will be optimized away at compile time. The issue was not created and the new entry was skipped because the changes are not visible to the user.