### PR TITLE
gh-116307: Proper fix for 'mod' leaking across importlib tests

### DIFF
--- a/Lib/test/support/import_helper.py
+++ b/Lib/test/support/import_helper.py
@@ -268,6 +268,18 @@ def modules_cleanup(oldmodules):
     sys.modules.update(oldmodules)
 
 
+@contextlib.contextmanager
+def isolated_modules():
+    """
+    Save modules on entry and cleanup on exit.
+    """
+    (saved,) = modules_setup()
+    try:
+        yield
+    finally:
+        modules_cleanup(saved)
+
+
 def mock_register_at_fork(func):
     # bpo-30599: Mock os.register_at_fork() when importing the random module,
     # since this function doesn't allow to unregister callbacks and would leak

--- a/Lib/test/test_importlib/resources/test_files.py
+++ b/Lib/test/test_importlib/resources/test_files.py
@@ -70,7 +70,7 @@ class SiteDir:
         self.addCleanup(self.fixtures.close)
         self.site_dir = self.fixtures.enter_context(os_helper.temp_dir())
         self.fixtures.enter_context(import_helper.DirsOnSysPath(self.site_dir))
-        self.fixtures.enter_context(import_helper.CleanImport())
+        self.fixtures.enter_context(import_helper.isolated_modules())
 
 
 class ModulesFilesTests(SiteDir, unittest.TestCase):

--- a/Misc/NEWS.d/next/Tests/2024-03-06-11-00-36.gh-issue-116307.Uij0t_.rst
+++ b/Misc/NEWS.d/next/Tests/2024-03-06-11-00-36.gh-issue-116307.Uij0t_.rst
@@ -1,0 +1,3 @@
+Added import helper ``isolated_modules`` as ``CleanImport`` does not remove
+modules imported during the context. Use it in importlib.resources tests to
+avoid leaving ``mod`` around to impede importlib.metadata tests.


### PR DESCRIPTION
As discovered in https://github.com/python/cpython/pull/116307#issuecomment-1979699344, addresses an issue in importlib.resources tests where a module imported for test can leak to other tests.