### PR TITLE
remove pointless variable initializations in unicode_format

### DIFF
--- a/Objects/stringlib/unicode_format.h
+++ b/Objects/stringlib/unicode_format.h
@@ -321,14 +321,13 @@ field_name_split(PyObject *str, Py_ssize_t start, Py_ssize_t end, SubString *fir
                  Py_ssize_t *first_idx, FieldNameIterator *rest,
                  AutoNumber *auto_number)
 {
-    Py_UCS4 c;
     Py_ssize_t i = start;
     int field_name_is_empty;
     int using_numeric_index;
 
     /* find the part up until the first '.' or '[' */
     while (i < end) {
-        switch (c = PyUnicode_READ_CHAR(str, i++)) {
+        switch (PyUnicode_READ_CHAR(str, i++)) {
         case '[':
         case '.':
             /* backup so that we this character is available to the
@@ -620,7 +619,7 @@ parse_field(SubString *str, SubString *field_name, SubString *format_spec,
         format_spec->start = str->start;
         count = 1;
         while (str->start < str->end) {
-            switch ((c = PyUnicode_READ_CHAR(str->str, str->start++))) {
+            switch (PyUnicode_READ_CHAR(str->str, str->start++)) {
             case '{':
                 *format_spec_needs_expanding = 1;
                 count++;


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

Same as https://github.com/python/cpython/pull/116675
