### PR TITLE
gh-116682: stdout may be empty in test_cancel_futures_wait_false

### DIFF
--- a/Lib/test/test_concurrent_futures/test_shutdown.py
+++ b/Lib/test/test_concurrent_futures/test_shutdown.py
@@ -247,7 +247,9 @@ class ThreadPoolShutdownTest(ThreadPoolMixin, ExecutorShutdownTest, BaseTestCase
         # Errors in atexit hooks don't change the process exit code, check
         # stderr manually.
         self.assertFalse(err)
-        self.assertEqual(out.strip(), b"apple")
+        # gh-116682: stdout may be empty if shutdown happens before task
+        # starts executing.
+        self.assertIn(out.strip(), [b"apple", b""])
 
 
 class ProcessPoolShutdownTest(ExecutorShutdownTest):


### PR DESCRIPTION
If the shutdown() call happens before the worker thread starts executing the task then nothing will be printed to stdout.

<!-- gh-issue-number: gh-116682 -->
* Issue: gh-116682
<!-- /gh-issue-number -->
