### PR TITLE
Modernize roundrobin() recipe and improve variable names

### DIFF
--- a/Doc/library/itertools.rst
+++ b/Doc/library/itertools.rst
@@ -947,10 +947,10 @@ which incur interpreter overhead.
        "Visit input iterables in a cycle until each is exhausted."
        # roundrobin('ABC', 'D', 'EF') --> A D E B F C
        # Algorithm credited to George Sakkis
-       iterators = cycle(map(iter, iterables))
-       for cutoff in reversed(range(len(iterables))):
+       iterators = map(iter, iterables)
+       for num_active in reversed(range(len(iterables) + 1)):
+           iterators = cycle(islice(iterators, num_active))
            yield from map(next, iterators)
-           iterators = cycle(islice(iterators, cutoff))
 
    def partition(predicate, iterable):
        """Partition entries into false entries and true entries.

--- a/Doc/library/itertools.rst
+++ b/Doc/library/itertools.rst
@@ -946,17 +946,11 @@ which incur interpreter overhead.
    def roundrobin(*iterables):
        "Visit input iterables in a cycle until each is exhausted."
        # roundrobin('ABC', 'D', 'EF') --> A D E B F C
-       # Recipe credited to George Sakkis
-       num_active = len(iterables)
-       nexts = cycle(iter(it).__next__ for it in iterables)
-       while num_active:
-           try:
-               for next in nexts:
-                   yield next()
-           except StopIteration:
-               # Remove the iterator we just exhausted from the cycle.
-               num_active -= 1
-               nexts = cycle(islice(nexts, num_active))
+       # Algorithm credited to George Sakkis
+       iterators = cycle(map(iter, iterables))
+       for cutoff in reversed(range(len(iterables))):
+           yield from map(next, iterators)
+           iterators = cycle(islice(iterators, cutoff))
 
    def partition(predicate, iterable):
        """Partition entries into false entries and true entries.
@@ -1570,6 +1564,9 @@ The following recipes have a more mathematical flavor:
 
     >>> list(roundrobin('abc', 'd', 'ef'))
     ['a', 'd', 'e', 'b', 'f', 'c']
+    >>> ranges = [range(5, 1000), range(4, 3000), range(0), range(3, 2000), range(2, 5000), range(1, 3500)]
+    >>> collections.Counter(roundrobin(ranges)) == collections.Counter(ranges)
+    True
 
     >>> def is_odd(x):
     ...     return x % 2 == 1

--- a/Doc/library/itertools.rst
+++ b/Doc/library/itertools.rst
@@ -1104,8 +1104,8 @@ The following recipes have a more mathematical flavor:
        "Count of natural numbers up to n that are coprime to n."
        # https://mathworld.wolfram.com/TotientFunction.html
        # totient(12) --> 4 because len([1, 5, 7, 11]) == 4
-       for p in unique_justseen(factor(n)):
-           n -= n // p
+       for prime in unique_justseen(factor(n)):
+           n -= n // prime
        return n
 
 

--- a/Doc/library/itertools.rst
+++ b/Doc/library/itertools.rst
@@ -932,14 +932,14 @@ which incur interpreter overhead.
        # grouper('ABCDEFG', 3, fillvalue='x') --> ABC DEF Gxx
        # grouper('ABCDEFG', 3, incomplete='strict') --> ABC DEF ValueError
        # grouper('ABCDEFG', 3, incomplete='ignore') --> ABC DEF
-       args = [iter(iterable)] * n
+       iterators = [iter(iterable)] * n
        match incomplete:
            case 'fill':
-               return zip_longest(*args, fillvalue=fillvalue)
+               return zip_longest(*iterators, fillvalue=fillvalue)
            case 'strict':
-               return zip(*args, strict=True)
+               return zip(*iterators, strict=True)
            case 'ignore':
-               return zip(*args)
+               return zip(*iterators)
            case _:
                raise ValueError('Expected fill, strict, or ignore')
 

--- a/Doc/library/itertools.rst
+++ b/Doc/library/itertools.rst
@@ -1104,8 +1104,8 @@ The following recipes have a more mathematical flavor:
        "Count of natural numbers up to n that are coprime to n."
        # https://mathworld.wolfram.com/TotientFunction.html
        # totient(12) --> 4 because len([1, 5, 7, 11]) == 4
-       for prime in unique_justseen(factor(n)):
-           n -= n // prime
+       for p in unique_justseen(factor(n)):
+           n -= n // p
        return n
 
 

--- a/Doc/library/itertools.rst
+++ b/Doc/library/itertools.rst
@@ -948,7 +948,7 @@ which incur interpreter overhead.
        # roundrobin('ABC', 'D', 'EF') --> A D E B F C
        # Algorithm credited to George Sakkis
        iterators = map(iter, iterables)
-       for num_active in reversed(range(len(iterables) + 1)):
+       for num_active in range(len(iterables), 0, -1):
            iterators = cycle(islice(iterators, num_active))
            yield from map(next, iterators)
 

--- a/Doc/library/itertools.rst
+++ b/Doc/library/itertools.rst
@@ -997,10 +997,10 @@ The following recipes have a more mathematical flavor:
        s = list(iterable)
        return chain.from_iterable(combinations(s, r) for r in range(len(s)+1))
 
-   def sum_of_squares(it):
+   def sum_of_squares(iterable):
        "Add up the squares of the input values."
        # sum_of_squares([10, 20, 30]) --> 1400
-       return math.sumprod(*tee(it))
+       return math.sumprod(*tee(iterable))
 
    def reshape(matrix, cols):
        "Reshape a 2-D matrix to have a given number of columns."


### PR DESCRIPTION
Besides being more idiomatic, compact, and easier to read, the new `roundrobin()` is very slightly faster (< 1% on my build).

Also added another test for `roundrobin()`.

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--116710.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->