### PR TITLE
gh-110918: Fix side effects of regrtest test_match_tests()

### DIFF
--- a/Lib/test/libregrtest/filter.py
+++ b/Lib/test/libregrtest/filter.py
@@ -27,6 +27,11 @@ def _is_full_match_test(pattern):
     return ('.' in pattern) and (not re.search(r'[?*\[\]]', pattern))
 
 
+def get_match_tests():
+    global _test_patterns
+    return _test_patterns
+
+
 def set_match_tests(patterns):
     global _test_matchers, _test_patterns
 

--- a/Lib/test/test_regrtest.py
+++ b/Lib/test/test_regrtest.py
@@ -27,7 +27,7 @@ from test.libregrtest import cmdline
 from test.libregrtest import main
 from test.libregrtest import setup
 from test.libregrtest import utils
-from test.libregrtest.filter import set_match_tests, match_test
+from test.libregrtest.filter import get_match_tests, set_match_tests, match_test
 from test.libregrtest.result import TestStats
 from test.libregrtest.utils import normalize_test_name
 
@@ -2297,6 +2297,10 @@ class TestUtils(unittest.TestCase):
 
             def id(self):
                 return self.test_id
+
+        # Restore patterns once the test completes
+        patterns = get_match_tests()
+        self.addCleanup(set_match_tests, patterns)
 
         test_access = Test('test.test_os.FileTests.test_access')
         test_chdir = Test('test.test_os.Win32ErrorTests.test_chdir')


### PR DESCRIPTION
test_match_tests now saves and restores patterns.

Add get_match_tests() function to libregrtest.filter.

Previously, running test_regrtest multiple times in a row only ran tests once: "./python -m test test_regrtest -R 3:3.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-110918 -->
* Issue: gh-110918
<!-- /gh-issue-number -->
