### PR TITLE
gh-116646: Remove _PyLong_FileDescriptor_Converter()

### DIFF
--- a/Include/internal/pycore_fileutils.h
+++ b/Include/internal/pycore_fileutils.h
@@ -312,9 +312,6 @@ extern HRESULT PathCchSkipRoot(const wchar_t *pszPath, const wchar_t **ppszRootE
 #  define _Py_END_SUPPRESS_IPH
 #endif /* _MSC_VER >= 1900 */
 
-// Export for 'select' shared extension (Argument Clinic code)
-PyAPI_FUNC(int) _PyLong_FileDescriptor_Converter(PyObject *, void *);
-
 // Export for test_peg_generator
 PyAPI_FUNC(char*) _Py_UniversalNewlineFgetsWithSize(char *, int, FILE*, PyObject *, size_t*);
 

--- a/Modules/_testclinic_limited.c
+++ b/Modules/_testclinic_limited.c
@@ -105,12 +105,30 @@ my_double_sum_impl(PyObject *module, double x, double y)
 }
 
 
+/*[clinic input]
+get_file_descriptor -> int
+
+    file as fd: fildes
+    /
+
+Get a file descriptor.
+[clinic start generated code]*/
+
+static int
+get_file_descriptor_impl(PyObject *module, int fd)
+/*[clinic end generated code: output=80051ebad54db8a8 input=82e2a1418848cd5b]*/
+{
+    return fd;
+}
+
+
 static PyMethodDef tester_methods[] = {
     TEST_EMPTY_FUNCTION_METHODDEF
     MY_INT_FUNC_METHODDEF
     MY_INT_SUM_METHODDEF
     MY_FLOAT_SUM_METHODDEF
     MY_DOUBLE_SUM_METHODDEF
+    GET_FILE_DESCRIPTOR_METHODDEF
     {NULL, NULL}
 };
 

--- a/Modules/clinic/_testclinic_limited.c.h
+++ b/Modules/clinic/_testclinic_limited.c.h
@@ -173,4 +173,39 @@ my_double_sum(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=bb9f6b8c5d9e6a79 input=a9049054013a1b77]*/
+
+PyDoc_STRVAR(get_file_descriptor__doc__,
+"get_file_descriptor($module, file, /)\n"
+"--\n"
+"\n"
+"Get a file descriptor.");
+
+#define GET_FILE_DESCRIPTOR_METHODDEF    \
+    {"get_file_descriptor", (PyCFunction)get_file_descriptor, METH_O, get_file_descriptor__doc__},
+
+static int
+get_file_descriptor_impl(PyObject *module, int fd);
+
+static PyObject *
+get_file_descriptor(PyObject *module, PyObject *arg)
+{
+    PyObject *return_value = NULL;
+    int fd;
+    int _return_value;
+
+    {
+        fd = PyObject_AsFileDescriptor(arg);
+        if (fd < 0) {
+            goto exit;
+        }
+    }
+    _return_value = get_file_descriptor_impl(module, fd);
+    if ((_return_value == -1) && PyErr_Occurred()) {
+        goto exit;
+    }
+    return_value = PyLong_FromLong((long)_return_value);
+
+exit:
+    return return_value;
+}
+/*[clinic end generated code: output=3265fc10800561ba input=a9049054013a1b77]*/

--- a/Modules/clinic/fcntlmodule.c.h
+++ b/Modules/clinic/fcntlmodule.c.h
@@ -2,7 +2,6 @@
 preserve
 [clinic start generated code]*/
 
-#include "pycore_fileutils.h"     // _PyLong_FileDescriptor_Converter()
 #include "pycore_modsupport.h"    // _PyArg_CheckPositional()
 
 PyDoc_STRVAR(fcntl_fcntl__doc__,
@@ -38,8 +37,11 @@ fcntl_fcntl(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     if (!_PyArg_CheckPositional("fcntl", nargs, 2, 3)) {
         goto exit;
     }
-    if (!_PyLong_FileDescriptor_Converter(args[0], &fd)) {
-        goto exit;
+    {
+        fd = PyObject_AsFileDescriptor(args[0]);
+        if (fd < 0) {
+            goto exit;
+        }
     }
     code = PyLong_AsInt(args[1]);
     if (code == -1 && PyErr_Occurred()) {
@@ -108,8 +110,11 @@ fcntl_ioctl(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     if (!_PyArg_CheckPositional("ioctl", nargs, 2, 4)) {
         goto exit;
     }
-    if (!_PyLong_FileDescriptor_Converter(args[0], &fd)) {
-        goto exit;
+    {
+        fd = PyObject_AsFileDescriptor(args[0]);
+        if (fd < 0) {
+            goto exit;
+        }
     }
     code = (unsigned int)PyLong_AsUnsignedLongMask(args[1]);
     if (code == (unsigned int)-1 && PyErr_Occurred()) {
@@ -158,8 +163,11 @@ fcntl_flock(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     if (!_PyArg_CheckPositional("flock", nargs, 2, 2)) {
         goto exit;
     }
-    if (!_PyLong_FileDescriptor_Converter(args[0], &fd)) {
-        goto exit;
+    {
+        fd = PyObject_AsFileDescriptor(args[0]);
+        if (fd < 0) {
+            goto exit;
+        }
     }
     code = PyLong_AsInt(args[1]);
     if (code == -1 && PyErr_Occurred()) {
@@ -218,8 +226,11 @@ fcntl_lockf(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     if (!_PyArg_CheckPositional("lockf", nargs, 2, 5)) {
         goto exit;
     }
-    if (!_PyLong_FileDescriptor_Converter(args[0], &fd)) {
-        goto exit;
+    {
+        fd = PyObject_AsFileDescriptor(args[0]);
+        if (fd < 0) {
+            goto exit;
+        }
     }
     code = PyLong_AsInt(args[1]);
     if (code == -1 && PyErr_Occurred()) {
@@ -246,4 +257,4 @@ skip_optional:
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=732e33ba92042031 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=8447e45cbd0dfc34 input=a9049054013a1b77]*/

--- a/Modules/clinic/posixmodule.c.h
+++ b/Modules/clinic/posixmodule.c.h
@@ -7,7 +7,6 @@ preserve
 #  include "pycore_runtime.h"     // _Py_ID()
 #endif
 #include "pycore_abstract.h"      // _PyNumber_Index()
-#include "pycore_fileutils.h"     // _PyLong_FileDescriptor_Converter()
 #include "pycore_long.h"          // _PyLong_UnsignedInt_Converter()
 #include "pycore_modsupport.h"    // _PyArg_UnpackKeywords()
 
@@ -481,8 +480,11 @@ os_fchdir(PyObject *module, PyObject *const *args, Py_ssize_t nargs, PyObject *k
     if (!args) {
         goto exit;
     }
-    if (!_PyLong_FileDescriptor_Converter(args[0], &fd)) {
-        goto exit;
+    {
+        fd = PyObject_AsFileDescriptor(args[0]);
+        if (fd < 0) {
+            goto exit;
+        }
     }
     return_value = os_fchdir_impl(module, fd);
 
@@ -1024,8 +1026,11 @@ os_fsync(PyObject *module, PyObject *const *args, Py_ssize_t nargs, PyObject *kw
     if (!args) {
         goto exit;
     }
-    if (!_PyLong_FileDescriptor_Converter(args[0], &fd)) {
-        goto exit;
+    {
+        fd = PyObject_AsFileDescriptor(args[0]);
+        if (fd < 0) {
+            goto exit;
+        }
     }
     return_value = os_fsync_impl(module, fd);
 
@@ -1107,8 +1112,11 @@ os_fdatasync(PyObject *module, PyObject *const *args, Py_ssize_t nargs, PyObject
     if (!args) {
         goto exit;
     }
-    if (!_PyLong_FileDescriptor_Converter(args[0], &fd)) {
-        goto exit;
+    {
+        fd = PyObject_AsFileDescriptor(args[0]);
+        if (fd < 0) {
+            goto exit;
+        }
     }
     return_value = os_fdatasync_impl(module, fd);
 
@@ -4531,8 +4539,11 @@ os_grantpt(PyObject *module, PyObject *arg)
     PyObject *return_value = NULL;
     int fd;
 
-    if (!_PyLong_FileDescriptor_Converter(arg, &fd)) {
-        goto exit;
+    {
+        fd = PyObject_AsFileDescriptor(arg);
+        if (fd < 0) {
+            goto exit;
+        }
     }
     return_value = os_grantpt_impl(module, fd);
 
@@ -4567,8 +4578,11 @@ os_unlockpt(PyObject *module, PyObject *arg)
     PyObject *return_value = NULL;
     int fd;
 
-    if (!_PyLong_FileDescriptor_Converter(arg, &fd)) {
-        goto exit;
+    {
+        fd = PyObject_AsFileDescriptor(arg);
+        if (fd < 0) {
+            goto exit;
+        }
     }
     return_value = os_unlockpt_impl(module, fd);
 
@@ -4604,8 +4618,11 @@ os_ptsname(PyObject *module, PyObject *arg)
     PyObject *return_value = NULL;
     int fd;
 
-    if (!_PyLong_FileDescriptor_Converter(arg, &fd)) {
-        goto exit;
+    {
+        fd = PyObject_AsFileDescriptor(arg);
+        if (fd < 0) {
+            goto exit;
+        }
     }
     return_value = os_ptsname_impl(module, fd);
 
@@ -4664,8 +4681,11 @@ os_login_tty(PyObject *module, PyObject *arg)
     PyObject *return_value = NULL;
     int fd;
 
-    if (!_PyLong_FileDescriptor_Converter(arg, &fd)) {
-        goto exit;
+    {
+        fd = PyObject_AsFileDescriptor(arg);
+        if (fd < 0) {
+            goto exit;
+        }
     }
     return_value = os_login_tty_impl(module, fd);
 
@@ -5881,8 +5901,11 @@ os_setns(PyObject *module, PyObject *const *args, Py_ssize_t nargs, PyObject *kw
     if (!args) {
         goto exit;
     }
-    if (!_PyLong_FileDescriptor_Converter(args[0], &fd)) {
-        goto exit;
+    {
+        fd = PyObject_AsFileDescriptor(args[0]);
+        if (fd < 0) {
+            goto exit;
+        }
     }
     if (!noptargs) {
         goto skip_optional_pos;
@@ -6322,8 +6345,11 @@ os_timerfd_settime(PyObject *module, PyObject *const *args, Py_ssize_t nargs, Py
     if (!args) {
         goto exit;
     }
-    if (!_PyLong_FileDescriptor_Converter(args[0], &fd)) {
-        goto exit;
+    {
+        fd = PyObject_AsFileDescriptor(args[0]);
+        if (fd < 0) {
+            goto exit;
+        }
     }
     if (!noptargs) {
         goto skip_optional_kwonly;
@@ -6435,8 +6461,11 @@ os_timerfd_settime_ns(PyObject *module, PyObject *const *args, Py_ssize_t nargs,
     if (!args) {
         goto exit;
     }
-    if (!_PyLong_FileDescriptor_Converter(args[0], &fd)) {
-        goto exit;
+    {
+        fd = PyObject_AsFileDescriptor(args[0]);
+        if (fd < 0) {
+            goto exit;
+        }
     }
     if (!noptargs) {
         goto skip_optional_kwonly;
@@ -6495,8 +6524,11 @@ os_timerfd_gettime(PyObject *module, PyObject *arg)
     PyObject *return_value = NULL;
     int fd;
 
-    if (!_PyLong_FileDescriptor_Converter(arg, &fd)) {
-        goto exit;
+    {
+        fd = PyObject_AsFileDescriptor(arg);
+        if (fd < 0) {
+            goto exit;
+        }
     }
     return_value = os_timerfd_gettime_impl(module, fd);
 
@@ -6529,8 +6561,11 @@ os_timerfd_gettime_ns(PyObject *module, PyObject *arg)
     PyObject *return_value = NULL;
     int fd;
 
-    if (!_PyLong_FileDescriptor_Converter(arg, &fd)) {
-        goto exit;
+    {
+        fd = PyObject_AsFileDescriptor(arg);
+        if (fd < 0) {
+            goto exit;
+        }
     }
     return_value = os_timerfd_gettime_ns_impl(module, fd);
 
@@ -9691,8 +9726,11 @@ os_fpathconf(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     if (!_PyArg_CheckPositional("fpathconf", nargs, 2, 2)) {
         goto exit;
     }
-    if (!_PyLong_FileDescriptor_Converter(args[0], &fd)) {
-        goto exit;
+    {
+        fd = PyObject_AsFileDescriptor(args[0]);
+        if (fd < 0) {
+            goto exit;
+        }
     }
     if (!conv_path_confname(args[1], &name)) {
         goto exit;
@@ -10834,8 +10872,11 @@ os_eventfd_read(PyObject *module, PyObject *const *args, Py_ssize_t nargs, PyObj
     if (!args) {
         goto exit;
     }
-    if (!_PyLong_FileDescriptor_Converter(args[0], &fd)) {
-        goto exit;
+    {
+        fd = PyObject_AsFileDescriptor(args[0]);
+        if (fd < 0) {
+            goto exit;
+        }
     }
     return_value = os_eventfd_read_impl(module, fd);
 
@@ -10896,8 +10937,11 @@ os_eventfd_write(PyObject *module, PyObject *const *args, Py_ssize_t nargs, PyOb
     if (!args) {
         goto exit;
     }
-    if (!_PyLong_FileDescriptor_Converter(args[0], &fd)) {
-        goto exit;
+    {
+        fd = PyObject_AsFileDescriptor(args[0]);
+        if (fd < 0) {
+            goto exit;
+        }
     }
     if (!_PyLong_UnsignedLongLong_Converter(args[1], &value)) {
         goto exit;
@@ -12588,4 +12632,4 @@ os__supports_virtual_terminal(PyObject *module, PyObject *Py_UNUSED(ignored))
 #ifndef OS__SUPPORTS_VIRTUAL_TERMINAL_METHODDEF
     #define OS__SUPPORTS_VIRTUAL_TERMINAL_METHODDEF
 #endif /* !defined(OS__SUPPORTS_VIRTUAL_TERMINAL_METHODDEF) */
-/*[clinic end generated code: output=2965306970f31c5d input=a9049054013a1b77]*/
+/*[clinic end generated code: output=c4a6b942cd0b1eb7 input=a9049054013a1b77]*/

--- a/Modules/clinic/selectmodule.c.h
+++ b/Modules/clinic/selectmodule.c.h
@@ -6,7 +6,6 @@ preserve
 #  include "pycore_gc.h"          // PyGC_Head
 #  include "pycore_runtime.h"     // _Py_ID()
 #endif
-#include "pycore_fileutils.h"     // _PyLong_FileDescriptor_Converter()
 #include "pycore_long.h"          // _PyLong_UnsignedShort_Converter()
 #include "pycore_modsupport.h"    // _PyArg_CheckPositional()
 
@@ -100,8 +99,11 @@ select_poll_register(pollObject *self, PyObject *const *args, Py_ssize_t nargs)
     if (!_PyArg_CheckPositional("register", nargs, 1, 2)) {
         goto exit;
     }
-    if (!_PyLong_FileDescriptor_Converter(args[0], &fd)) {
-        goto exit;
+    {
+        fd = PyObject_AsFileDescriptor(args[0]);
+        if (fd < 0) {
+            goto exit;
+        }
     }
     if (nargs < 2) {
         goto skip_optional;
@@ -148,8 +150,11 @@ select_poll_modify(pollObject *self, PyObject *const *args, Py_ssize_t nargs)
     if (!_PyArg_CheckPositional("modify", nargs, 2, 2)) {
         goto exit;
     }
-    if (!_PyLong_FileDescriptor_Converter(args[0], &fd)) {
-        goto exit;
+    {
+        fd = PyObject_AsFileDescriptor(args[0]);
+        if (fd < 0) {
+            goto exit;
+        }
     }
     if (!_PyLong_UnsignedShort_Converter(args[1], &eventmask)) {
         goto exit;
@@ -182,8 +187,11 @@ select_poll_unregister(pollObject *self, PyObject *arg)
     PyObject *return_value = NULL;
     int fd;
 
-    if (!_PyLong_FileDescriptor_Converter(arg, &fd)) {
-        goto exit;
+    {
+        fd = PyObject_AsFileDescriptor(arg);
+        if (fd < 0) {
+            goto exit;
+        }
     }
     return_value = select_poll_unregister_impl(self, fd);
 
@@ -268,8 +276,11 @@ select_devpoll_register(devpollObject *self, PyObject *const *args, Py_ssize_t n
     if (!_PyArg_CheckPositional("register", nargs, 1, 2)) {
         goto exit;
     }
-    if (!_PyLong_FileDescriptor_Converter(args[0], &fd)) {
-        goto exit;
+    {
+        fd = PyObject_AsFileDescriptor(args[0]);
+        if (fd < 0) {
+            goto exit;
+        }
     }
     if (nargs < 2) {
         goto skip_optional;
@@ -318,8 +329,11 @@ select_devpoll_modify(devpollObject *self, PyObject *const *args, Py_ssize_t nar
     if (!_PyArg_CheckPositional("modify", nargs, 1, 2)) {
         goto exit;
     }
-    if (!_PyLong_FileDescriptor_Converter(args[0], &fd)) {
-        goto exit;
+    {
+        fd = PyObject_AsFileDescriptor(args[0]);
+        if (fd < 0) {
+            goto exit;
+        }
     }
     if (nargs < 2) {
         goto skip_optional;
@@ -356,8 +370,11 @@ select_devpoll_unregister(devpollObject *self, PyObject *arg)
     PyObject *return_value = NULL;
     int fd;
 
-    if (!_PyLong_FileDescriptor_Converter(arg, &fd)) {
-        goto exit;
+    {
+        fd = PyObject_AsFileDescriptor(arg);
+        if (fd < 0) {
+            goto exit;
+        }
     }
     return_value = select_devpoll_unregister_impl(self, fd);
 
@@ -730,8 +747,11 @@ select_epoll_register(pyEpoll_Object *self, PyObject *const *args, Py_ssize_t na
     if (!args) {
         goto exit;
     }
-    if (!_PyLong_FileDescriptor_Converter(args[0], &fd)) {
-        goto exit;
+    {
+        fd = PyObject_AsFileDescriptor(args[0]);
+        if (fd < 0) {
+            goto exit;
+        }
     }
     if (!noptargs) {
         goto skip_optional_pos;
@@ -806,8 +826,11 @@ select_epoll_modify(pyEpoll_Object *self, PyObject *const *args, Py_ssize_t narg
     if (!args) {
         goto exit;
     }
-    if (!_PyLong_FileDescriptor_Converter(args[0], &fd)) {
-        goto exit;
+    {
+        fd = PyObject_AsFileDescriptor(args[0]);
+        if (fd < 0) {
+            goto exit;
+        }
     }
     eventmask = (unsigned int)PyLong_AsUnsignedLongMask(args[1]);
     if (eventmask == (unsigned int)-1 && PyErr_Occurred()) {
@@ -874,8 +897,11 @@ select_epoll_unregister(pyEpoll_Object *self, PyObject *const *args, Py_ssize_t 
     if (!args) {
         goto exit;
     }
-    if (!_PyLong_FileDescriptor_Converter(args[0], &fd)) {
-        goto exit;
+    {
+        fd = PyObject_AsFileDescriptor(args[0]);
+        if (fd < 0) {
+            goto exit;
+        }
     }
     return_value = select_epoll_unregister_impl(self, fd);
 
@@ -1311,4 +1337,4 @@ exit:
 #ifndef SELECT_KQUEUE_CONTROL_METHODDEF
     #define SELECT_KQUEUE_CONTROL_METHODDEF
 #endif /* !defined(SELECT_KQUEUE_CONTROL_METHODDEF) */
-/*[clinic end generated code: output=4c2dcb31cb17c2c6 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=99880802eca5a086 input=a9049054013a1b77]*/

--- a/Modules/clinic/termios.c.h
+++ b/Modules/clinic/termios.c.h
@@ -2,7 +2,6 @@
 preserve
 [clinic start generated code]*/
 
-#include "pycore_fileutils.h"     // _PyLong_FileDescriptor_Converter()
 #include "pycore_modsupport.h"    // _PyArg_CheckPositional()
 
 PyDoc_STRVAR(termios_tcgetattr__doc__,
@@ -30,8 +29,11 @@ termios_tcgetattr(PyObject *module, PyObject *arg)
     PyObject *return_value = NULL;
     int fd;
 
-    if (!_PyLong_FileDescriptor_Converter(arg, &fd)) {
-        goto exit;
+    {
+        fd = PyObject_AsFileDescriptor(arg);
+        if (fd < 0) {
+            goto exit;
+        }
     }
     return_value = termios_tcgetattr_impl(module, fd);
 
@@ -69,8 +71,11 @@ termios_tcsetattr(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     if (!_PyArg_CheckPositional("tcsetattr", nargs, 3, 3)) {
         goto exit;
     }
-    if (!_PyLong_FileDescriptor_Converter(args[0], &fd)) {
-        goto exit;
+    {
+        fd = PyObject_AsFileDescriptor(args[0]);
+        if (fd < 0) {
+            goto exit;
+        }
     }
     when = PyLong_AsInt(args[1]);
     if (when == -1 && PyErr_Occurred()) {
@@ -108,8 +113,11 @@ termios_tcsendbreak(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     if (!_PyArg_CheckPositional("tcsendbreak", nargs, 2, 2)) {
         goto exit;
     }
-    if (!_PyLong_FileDescriptor_Converter(args[0], &fd)) {
-        goto exit;
+    {
+        fd = PyObject_AsFileDescriptor(args[0]);
+        if (fd < 0) {
+            goto exit;
+        }
     }
     duration = PyLong_AsInt(args[1]);
     if (duration == -1 && PyErr_Occurred()) {
@@ -139,8 +147,11 @@ termios_tcdrain(PyObject *module, PyObject *arg)
     PyObject *return_value = NULL;
     int fd;
 
-    if (!_PyLong_FileDescriptor_Converter(arg, &fd)) {
-        goto exit;
+    {
+        fd = PyObject_AsFileDescriptor(arg);
+        if (fd < 0) {
+            goto exit;
+        }
     }
     return_value = termios_tcdrain_impl(module, fd);
 
@@ -174,8 +185,11 @@ termios_tcflush(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     if (!_PyArg_CheckPositional("tcflush", nargs, 2, 2)) {
         goto exit;
     }
-    if (!_PyLong_FileDescriptor_Converter(args[0], &fd)) {
-        goto exit;
+    {
+        fd = PyObject_AsFileDescriptor(args[0]);
+        if (fd < 0) {
+            goto exit;
+        }
     }
     queue = PyLong_AsInt(args[1]);
     if (queue == -1 && PyErr_Occurred()) {
@@ -213,8 +227,11 @@ termios_tcflow(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     if (!_PyArg_CheckPositional("tcflow", nargs, 2, 2)) {
         goto exit;
     }
-    if (!_PyLong_FileDescriptor_Converter(args[0], &fd)) {
-        goto exit;
+    {
+        fd = PyObject_AsFileDescriptor(args[0]);
+        if (fd < 0) {
+            goto exit;
+        }
     }
     action = PyLong_AsInt(args[1]);
     if (action == -1 && PyErr_Occurred()) {
@@ -246,8 +263,11 @@ termios_tcgetwinsize(PyObject *module, PyObject *arg)
     PyObject *return_value = NULL;
     int fd;
 
-    if (!_PyLong_FileDescriptor_Converter(arg, &fd)) {
-        goto exit;
+    {
+        fd = PyObject_AsFileDescriptor(arg);
+        if (fd < 0) {
+            goto exit;
+        }
     }
     return_value = termios_tcgetwinsize_impl(module, fd);
 
@@ -280,8 +300,11 @@ termios_tcsetwinsize(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     if (!_PyArg_CheckPositional("tcsetwinsize", nargs, 2, 2)) {
         goto exit;
     }
-    if (!_PyLong_FileDescriptor_Converter(args[0], &fd)) {
-        goto exit;
+    {
+        fd = PyObject_AsFileDescriptor(args[0]);
+        if (fd < 0) {
+            goto exit;
+        }
     }
     winsz = args[1];
     return_value = termios_tcsetwinsize_impl(module, fd, winsz);
@@ -289,4 +312,4 @@ termios_tcsetwinsize(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=f31382658135c774 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=6af6952aebd7a2d2 input=a9049054013a1b77]*/

--- a/Objects/fileobject.c
+++ b/Objects/fileobject.c
@@ -220,17 +220,6 @@ PyObject_AsFileDescriptor(PyObject *o)
     return fd;
 }
 
-int
-_PyLong_FileDescriptor_Converter(PyObject *o, void *ptr)
-{
-    int fd = PyObject_AsFileDescriptor(o);
-    if (fd == -1) {
-        return 0;
-    }
-    *(int *)ptr = fd;
-    return 1;
-}
-
 char *
 _Py_UniversalNewlineFgetsWithSize(char *buf, int n, FILE *stream, PyObject *fobj, size_t* size)
 {

--- a/Tools/clinic/clinic.py
+++ b/Tools/clinic/clinic.py
@@ -3844,17 +3844,15 @@ class size_t_converter(CConverter):
 
 class fildes_converter(CConverter):
     type = 'int'
-    converter = '_PyLong_FileDescriptor_Converter'
+    format_unit = ''
 
-    def converter_init(self, *, accept: TypeSet = {int, NoneType}) -> None:
-        self.add_include('pycore_fileutils.h',
-                         '_PyLong_FileDescriptor_Converter()')
-
-    def _parse_arg(self, argname: str, displayname: str) -> str | None:
+    def parse_arg(self, argname: str, displayname: str, *, limited_capi: bool) -> str | None:
         return self.format_code("""
-            {paramname} = PyObject_AsFileDescriptor({argname});
-            if ({paramname} == -1) {{{{
-                goto exit;
+            {{{{
+                {paramname} = PyObject_AsFileDescriptor({argname});
+                if ({paramname} < 0) {{{{
+                    goto exit;
+                }}}}
             }}}}
             """,
             argname=argname)


### PR DESCRIPTION
Argument Clinic now calls directly PyObject_AsFileDescriptor() for the "fildes" format.

Add tests on the "fildes" format in _testclinic_limited.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-116646 -->
* Issue: gh-116646
<!-- /gh-issue-number -->
