### PR TITLE
gh-116740: allows when disallow and allow rule are equivalent in robots.txt

### DIFF
--- a/Lib/test/test_robotparser.py
+++ b/Lib/test/test_robotparser.py
@@ -374,7 +374,10 @@ class NetworkTestCase(unittest.TestCase):
     def test_can_fetch(self):
         self.assertTrue(self.parser.can_fetch('*', self.url('elsewhere')))
         self.assertFalse(self.parser.can_fetch('Nutch', self.base_url))
-        self.assertFalse(self.parser.can_fetch('Nutch', self.url('brian')))
+        # The robots.txt in this test case disallows '/' only except /brian
+        # against Nutch. So, Nutch should be allowed to access brian per
+        # the section 2.2.2 in https://www.rfc-editor.org/rfc/rfc9309.html
+        self.assertTrue(self.parser.can_fetch('Nutch', self.url('brian')))
         self.assertFalse(self.parser.can_fetch('Nutch', self.url('webstats')))
         self.assertFalse(self.parser.can_fetch('*', self.url('webstats')))
         self.assertTrue(self.parser.can_fetch('*', self.base_url))

--- a/Lib/urllib/robotparser.py
+++ b/Lib/urllib/robotparser.py
@@ -267,7 +267,10 @@ class Entry:
         """Preconditions:
         - our agent applies to this entry
         - filename is URL decoded"""
+        allowance = True
         for line in self.rulelines:
             if line.applies_to(filename):
-                return line.allowance
-        return True
+                allowance = line.allowance
+                if allowance:
+                    return True
+        return allowance

--- a/Misc/NEWS.d/next/Library/2024-03-13-22-34-40.gh-issue-116740.QqgarC.rst
+++ b/Misc/NEWS.d/next/Library/2024-03-13-22-34-40.gh-issue-116740.QqgarC.rst
@@ -1,0 +1,1 @@
+change the behavior of :meth:`RobotFileParser.can_fetch` to return True when disallow and allow rule are equivalent in robots.txt


### PR DESCRIPTION
This changes RobotFileParser.can_fetch to return True when the disallow rule and the allow rule are equivalent in the robots.txt by following the section 2.2.2 in https://www.rfc-editor.org/rfc/rfc9309.html

The original behavior of robotparser.py was following non-standard internet draft http://www.robotstxt.org/norobots-rfc.txt section 3.2.2 which has been written in 1999 "The first match found is used". So, it returned False in the same use case. But it's no longer valid behavior compare to IEFT RFC 9309.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-116740 -->
* Issue: gh-116740
<!-- /gh-issue-number -->
