### PR TITLE
gh-116751: Inline _PyArg_CheckPositional() in Argument Clinic

### DIFF
--- a/Lib/test/clinic.test.c
+++ b/Lib/test/clinic.test.c
@@ -42,7 +42,19 @@ test_object_converter(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *c;
     PyUnicode_Object *d;
 
-    if (!_PyArg_CheckPositional("test_object_converter", nargs, 4, 4)) {
+    if (nargs < 4) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 4 arguments, got %zd",
+            "test_object_converter", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 4) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 4 arguments, got %zd",
+            "test_object_converter", nargs);
         goto exit;
     }
     a = args[0];
@@ -64,7 +76,7 @@ exit:
 static PyObject *
 test_object_converter_impl(PyObject *module, PyObject *a, PyObject *b,
                            PyObject *c, PyUnicode_Object *d)
-/*[clinic end generated code: output=886f4f9b598726b6 input=005e6a8a711a869b]*/
+/*[clinic end generated code: output=ffcfeaae15858f71 input=005e6a8a711a869b]*/
 
 
 /*[clinic input]
@@ -94,7 +106,19 @@ cloned(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *c;
     PyUnicode_Object *d;
 
-    if (!_PyArg_CheckPositional("cloned", nargs, 4, 4)) {
+    if (nargs < 4) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 4 arguments, got %zd",
+            "cloned", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 4) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 4 arguments, got %zd",
+            "cloned", nargs);
         goto exit;
     }
     a = args[0];
@@ -116,7 +140,7 @@ exit:
 static PyObject *
 cloned_impl(PyObject *module, PyObject *a, PyObject *b, PyObject *c,
             PyUnicode_Object *d)
-/*[clinic end generated code: output=026b483e27c38065 input=0543614019d6fcc7]*/
+/*[clinic end generated code: output=225e72957fc91863 input=0543614019d6fcc7]*/
 
 
 /*[clinic input]
@@ -167,7 +191,19 @@ test_objects_converter(PyObject *module, PyObject *const *args, Py_ssize_t nargs
     PyObject *a;
     PyObject *b = NULL;
 
-    if (!_PyArg_CheckPositional("test_objects_converter", nargs, 1, 2)) {
+    if (nargs < 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 1 argument, got %zd",
+            "test_objects_converter", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 2 arguments, got %zd",
+            "test_objects_converter", nargs);
         goto exit;
     }
     a = args[0];
@@ -184,7 +220,7 @@ exit:
 
 static PyObject *
 test_objects_converter_impl(PyObject *module, PyObject *a, PyObject *b)
-/*[clinic end generated code: output=fc26328b79d46bb7 input=4cbb3d9edd2a36f3]*/
+/*[clinic end generated code: output=a492440d30974984 input=4cbb3d9edd2a36f3]*/
 
 
 /*[clinic input]
@@ -234,7 +270,19 @@ test_object_converter_subclass_of(PyObject *module, PyObject *const *args, Py_ss
     PyObject *i;
     PyObject *j;
 
-    if (!_PyArg_CheckPositional("test_object_converter_subclass_of", nargs, 10, 10)) {
+    if (nargs < 10) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 10 arguments, got %zd",
+            "test_object_converter_subclass_of", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 10) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 10 arguments, got %zd",
+            "test_object_converter_subclass_of", nargs);
         goto exit;
     }
     if (!PyLong_Check(args[0])) {
@@ -298,7 +346,7 @@ test_object_converter_subclass_of_impl(PyObject *module, PyObject *a,
                                        PyObject *b, PyObject *c, PyObject *d,
                                        PyObject *e, PyObject *f, PyObject *g,
                                        PyObject *h, PyObject *i, PyObject *j)
-/*[clinic end generated code: output=e4b07c9a54479a40 input=31b06b772d5f983e]*/
+/*[clinic end generated code: output=f0895e703d8bab06 input=31b06b772d5f983e]*/
 
 
 /*[clinic input]
@@ -453,7 +501,19 @@ test_bool_converter(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     int b = 1;
     int c = 1;
 
-    if (!_PyArg_CheckPositional("test_bool_converter", nargs, 0, 3)) {
+    if (nargs < 0) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 0 arguments, got %zd",
+            "test_bool_converter", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 3) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 3 arguments, got %zd",
+            "test_bool_converter", nargs);
         goto exit;
     }
     if (nargs < 1) {
@@ -486,7 +546,7 @@ exit:
 
 static PyObject *
 test_bool_converter_impl(PyObject *module, int a, int b, int c)
-/*[clinic end generated code: output=3190e46490de0644 input=939854fa9f248c60]*/
+/*[clinic end generated code: output=1bba450db9c98eb4 input=939854fa9f248c60]*/
 
 
 /*[clinic input]
@@ -544,7 +604,19 @@ test_char_converter(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     char m = '\x00';
     char n = '\xff';
 
-    if (!_PyArg_CheckPositional("test_char_converter", nargs, 0, 14)) {
+    if (nargs < 0) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 0 arguments, got %zd",
+            "test_char_converter", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 14) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 14 arguments, got %zd",
+            "test_char_converter", nargs);
         goto exit;
     }
     if (nargs < 1) {
@@ -740,7 +812,7 @@ static PyObject *
 test_char_converter_impl(PyObject *module, char a, char b, char c, char d,
                          char e, char f, char g, char h, char i, char j,
                          char k, char l, char m, char n)
-/*[clinic end generated code: output=98589f02422fe6b1 input=e42330417a44feac]*/
+/*[clinic end generated code: output=2f8e1446c89d94e8 input=e42330417a44feac]*/
 
 
 /*[clinic input]
@@ -773,7 +845,19 @@ test_unsigned_char_converter(PyObject *module, PyObject *const *args, Py_ssize_t
     unsigned char b = 34;
     unsigned char c = 56;
 
-    if (!_PyArg_CheckPositional("test_unsigned_char_converter", nargs, 0, 3)) {
+    if (nargs < 0) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 0 arguments, got %zd",
+            "test_unsigned_char_converter", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 3) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 3 arguments, got %zd",
+            "test_unsigned_char_converter", nargs);
         goto exit;
     }
     if (nargs < 1) {
@@ -842,7 +926,7 @@ exit:
 static PyObject *
 test_unsigned_char_converter_impl(PyObject *module, unsigned char a,
                                   unsigned char b, unsigned char c)
-/*[clinic end generated code: output=45920dbedc22eb55 input=021414060993e289]*/
+/*[clinic end generated code: output=93982eb408e4a2e6 input=021414060993e289]*/
 
 
 /*[clinic input]
@@ -870,7 +954,19 @@ test_short_converter(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *return_value = NULL;
     short a = 12;
 
-    if (!_PyArg_CheckPositional("test_short_converter", nargs, 0, 1)) {
+    if (nargs < 0) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 0 arguments, got %zd",
+            "test_short_converter", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 1 argument, got %zd",
+            "test_short_converter", nargs);
         goto exit;
     }
     if (nargs < 1) {
@@ -904,7 +1000,7 @@ exit:
 
 static PyObject *
 test_short_converter_impl(PyObject *module, short a)
-/*[clinic end generated code: output=a580945bd6963d45 input=6a8a7a509a498ff4]*/
+/*[clinic end generated code: output=48951905574d550c input=6a8a7a509a498ff4]*/
 
 
 /*[clinic input]
@@ -937,7 +1033,19 @@ test_unsigned_short_converter(PyObject *module, PyObject *const *args, Py_ssize_
     unsigned short b = 34;
     unsigned short c = 56;
 
-    if (!_PyArg_CheckPositional("test_unsigned_short_converter", nargs, 0, 3)) {
+    if (nargs < 0) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 0 arguments, got %zd",
+            "test_unsigned_short_converter", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 3) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 3 arguments, got %zd",
+            "test_unsigned_short_converter", nargs);
         goto exit;
     }
     if (nargs < 1) {
@@ -969,7 +1077,7 @@ exit:
 static PyObject *
 test_unsigned_short_converter_impl(PyObject *module, unsigned short a,
                                    unsigned short b, unsigned short c)
-/*[clinic end generated code: output=e6e990df729114fc input=cdfd8eff3d9176b4]*/
+/*[clinic end generated code: output=67d3fde3193f94c5 input=cdfd8eff3d9176b4]*/
 
 
 /*[clinic input]
@@ -1003,7 +1111,19 @@ test_int_converter(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     int c = 45;
     myenum d = 67;
 
-    if (!_PyArg_CheckPositional("test_int_converter", nargs, 0, 4)) {
+    if (nargs < 0) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 0 arguments, got %zd",
+            "test_int_converter", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 4) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 4 arguments, got %zd",
+            "test_int_converter", nargs);
         goto exit;
     }
     if (nargs < 1) {
@@ -1048,7 +1168,7 @@ exit:
 
 static PyObject *
 test_int_converter_impl(PyObject *module, int a, int b, int c, myenum d)
-/*[clinic end generated code: output=5aed87a7589eefb2 input=d20541fc1ca0553e]*/
+/*[clinic end generated code: output=d5f0cdb197fe8d57 input=d20541fc1ca0553e]*/
 
 
 /*[clinic input]
@@ -1081,7 +1201,19 @@ test_unsigned_int_converter(PyObject *module, PyObject *const *args, Py_ssize_t 
     unsigned int b = 34;
     unsigned int c = 56;
 
-    if (!_PyArg_CheckPositional("test_unsigned_int_converter", nargs, 0, 3)) {
+    if (nargs < 0) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 0 arguments, got %zd",
+            "test_unsigned_int_converter", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 3) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 3 arguments, got %zd",
+            "test_unsigned_int_converter", nargs);
         goto exit;
     }
     if (nargs < 1) {
@@ -1113,7 +1245,7 @@ exit:
 static PyObject *
 test_unsigned_int_converter_impl(PyObject *module, unsigned int a,
                                  unsigned int b, unsigned int c)
-/*[clinic end generated code: output=f9cdbe410ccc98a3 input=5533534828b62fc0]*/
+/*[clinic end generated code: output=c5df9211847dbbc7 input=5533534828b62fc0]*/
 
 
 /*[clinic input]
@@ -1141,7 +1273,19 @@ test_long_converter(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *return_value = NULL;
     long a = 12;
 
-    if (!_PyArg_CheckPositional("test_long_converter", nargs, 0, 1)) {
+    if (nargs < 0) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 0 arguments, got %zd",
+            "test_long_converter", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 1 argument, got %zd",
+            "test_long_converter", nargs);
         goto exit;
     }
     if (nargs < 1) {
@@ -1160,7 +1304,7 @@ exit:
 
 static PyObject *
 test_long_converter_impl(PyObject *module, long a)
-/*[clinic end generated code: output=02b3a83495c1d236 input=d2179e3c9cdcde89]*/
+/*[clinic end generated code: output=61fd1b5603d8abaf input=d2179e3c9cdcde89]*/
 
 
 /*[clinic input]
@@ -1193,7 +1337,19 @@ test_unsigned_long_converter(PyObject *module, PyObject *const *args, Py_ssize_t
     unsigned long b = 34;
     unsigned long c = 56;
 
-    if (!_PyArg_CheckPositional("test_unsigned_long_converter", nargs, 0, 3)) {
+    if (nargs < 0) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 0 arguments, got %zd",
+            "test_unsigned_long_converter", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 3) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 3 arguments, got %zd",
+            "test_unsigned_long_converter", nargs);
         goto exit;
     }
     if (nargs < 1) {
@@ -1226,7 +1382,7 @@ exit:
 static PyObject *
 test_unsigned_long_converter_impl(PyObject *module, unsigned long a,
                                   unsigned long b, unsigned long c)
-/*[clinic end generated code: output=540bb0ba2894e1fe input=f450d94cae1ef73b]*/
+/*[clinic end generated code: output=d0213f63c8590774 input=f450d94cae1ef73b]*/
 
 
 /*[clinic input]
@@ -1254,7 +1410,19 @@ test_long_long_converter(PyObject *module, PyObject *const *args, Py_ssize_t nar
     PyObject *return_value = NULL;
     long long a = 12;
 
-    if (!_PyArg_CheckPositional("test_long_long_converter", nargs, 0, 1)) {
+    if (nargs < 0) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 0 arguments, got %zd",
+            "test_long_long_converter", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 1 argument, got %zd",
+            "test_long_long_converter", nargs);
         goto exit;
     }
     if (nargs < 1) {
@@ -1273,7 +1441,7 @@ exit:
 
 static PyObject *
 test_long_long_converter_impl(PyObject *module, long long a)
-/*[clinic end generated code: output=f9d4ed79ad2db857 input=d5fc81577ff4dd02]*/
+/*[clinic end generated code: output=7f59f2640ed78dfe input=d5fc81577ff4dd02]*/
 
 
 /*[clinic input]
@@ -1308,7 +1476,19 @@ test_unsigned_long_long_converter(PyObject *module, PyObject *const *args, Py_ss
     unsigned long long b = 34;
     unsigned long long c = 56;
 
-    if (!_PyArg_CheckPositional("test_unsigned_long_long_converter", nargs, 0, 3)) {
+    if (nargs < 0) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 0 arguments, got %zd",
+            "test_unsigned_long_long_converter", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 3) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 3 arguments, got %zd",
+            "test_unsigned_long_long_converter", nargs);
         goto exit;
     }
     if (nargs < 1) {
@@ -1343,7 +1523,7 @@ test_unsigned_long_long_converter_impl(PyObject *module,
                                        unsigned long long a,
                                        unsigned long long b,
                                        unsigned long long c)
-/*[clinic end generated code: output=3d69994f618b46bb input=a15115dc41866ff4]*/
+/*[clinic end generated code: output=cf04833f2c201ddc input=a15115dc41866ff4]*/
 
 
 /*[clinic input]
@@ -1376,7 +1556,19 @@ test_Py_ssize_t_converter(PyObject *module, PyObject *const *args, Py_ssize_t na
     Py_ssize_t b = 34;
     Py_ssize_t c = 56;
 
-    if (!_PyArg_CheckPositional("test_Py_ssize_t_converter", nargs, 0, 3)) {
+    if (nargs < 0) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 0 arguments, got %zd",
+            "test_Py_ssize_t_converter", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 3) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 3 arguments, got %zd",
+            "test_Py_ssize_t_converter", nargs);
         goto exit;
     }
     if (nargs < 1) {
@@ -1425,7 +1617,7 @@ exit:
 static PyObject *
 test_Py_ssize_t_converter_impl(PyObject *module, Py_ssize_t a, Py_ssize_t b,
                                Py_ssize_t c)
-/*[clinic end generated code: output=48214bc3d01f4dd7 input=3855f184bb3f299d]*/
+/*[clinic end generated code: output=40adacbe897cbb7a input=3855f184bb3f299d]*/
 
 
 /*[clinic input]
@@ -1458,7 +1650,19 @@ test_slice_index_converter(PyObject *module, PyObject *const *args, Py_ssize_t n
     Py_ssize_t b = 34;
     Py_ssize_t c = 56;
 
-    if (!_PyArg_CheckPositional("test_slice_index_converter", nargs, 0, 3)) {
+    if (nargs < 0) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 0 arguments, got %zd",
+            "test_slice_index_converter", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 3) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 3 arguments, got %zd",
+            "test_slice_index_converter", nargs);
         goto exit;
     }
     if (nargs < 1) {
@@ -1489,7 +1693,7 @@ exit:
 static PyObject *
 test_slice_index_converter_impl(PyObject *module, Py_ssize_t a, Py_ssize_t b,
                                 Py_ssize_t c)
-/*[clinic end generated code: output=67506ed999361212 input=edeadb0ee126f531]*/
+/*[clinic end generated code: output=e0c01c417004b527 input=edeadb0ee126f531]*/
 
 
 /*[clinic input]
@@ -1517,7 +1721,19 @@ test_size_t_converter(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *return_value = NULL;
     size_t a = 12;
 
-    if (!_PyArg_CheckPositional("test_size_t_converter", nargs, 0, 1)) {
+    if (nargs < 0) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 0 arguments, got %zd",
+            "test_size_t_converter", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 1 argument, got %zd",
+            "test_size_t_converter", nargs);
         goto exit;
     }
     if (nargs < 1) {
@@ -1535,7 +1751,7 @@ exit:
 
 static PyObject *
 test_size_t_converter_impl(PyObject *module, size_t a)
-/*[clinic end generated code: output=1653ecb5cbf775aa input=52e93a0fed0f1fb3]*/
+/*[clinic end generated code: output=412552ddfaac1a06 input=52e93a0fed0f1fb3]*/
 
 
 /*[clinic input]
@@ -1563,7 +1779,19 @@ test_float_converter(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *return_value = NULL;
     float a = 12.5;
 
-    if (!_PyArg_CheckPositional("test_float_converter", nargs, 0, 1)) {
+    if (nargs < 0) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 0 arguments, got %zd",
+            "test_float_converter", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 1 argument, got %zd",
+            "test_float_converter", nargs);
         goto exit;
     }
     if (nargs < 1) {
@@ -1588,7 +1816,7 @@ exit:
 
 static PyObject *
 test_float_converter_impl(PyObject *module, float a)
-/*[clinic end generated code: output=36ad006990a8a91e input=259c0d98eca35034]*/
+/*[clinic end generated code: output=4c8c102f65b9b66e input=259c0d98eca35034]*/
 
 
 /*[clinic input]
@@ -1616,7 +1844,19 @@ test_double_converter(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *return_value = NULL;
     double a = 12.5;
 
-    if (!_PyArg_CheckPositional("test_double_converter", nargs, 0, 1)) {
+    if (nargs < 0) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 0 arguments, got %zd",
+            "test_double_converter", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 1 argument, got %zd",
+            "test_double_converter", nargs);
         goto exit;
     }
     if (nargs < 1) {
@@ -1641,7 +1881,7 @@ exit:
 
 static PyObject *
 test_double_converter_impl(PyObject *module, double a)
-/*[clinic end generated code: output=7435925592bac795 input=c6a9945706a41c27]*/
+/*[clinic end generated code: output=c41c1064cd2d8a22 input=c6a9945706a41c27]*/
 
 
 /*[clinic input]
@@ -3958,7 +4198,11 @@ test_vararg_and_posonly(PyObject *module, PyObject *const *args, Py_ssize_t narg
     PyObject *a;
     PyObject *__clinic_args = NULL;
 
-    if (!_PyArg_CheckPositional("test_vararg_and_posonly", nargs, 1, PY_SSIZE_T_MAX)) {
+    if (nargs < 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 1 argument, got %zd",
+            "test_vararg_and_posonly", nargs);
         goto exit;
     }
     a = args[0];
@@ -3978,7 +4222,7 @@ exit:
 
 static PyObject *
 test_vararg_and_posonly_impl(PyObject *module, PyObject *a, PyObject *args)
-/*[clinic end generated code: output=79b75dc07decc8d6 input=08dc2bf7afbf1613]*/
+/*[clinic end generated code: output=8407a3fd6895a4ff input=08dc2bf7afbf1613]*/
 
 /*[clinic input]
 test_vararg
@@ -4746,7 +4990,11 @@ Test___init__(PyObject *self, PyObject *args, PyObject *kwargs)
         !_PyArg_NoKeywords("Test", kwargs)) {
         goto exit;
     }
-    if (!_PyArg_CheckPositional("Test", PyTuple_GET_SIZE(args), 0, PY_SSIZE_T_MAX)) {
+    if (PyTuple_GET_SIZE(args) < 0) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 0 arguments, got %zd",
+            "Test", PyTuple_GET_SIZE(args));
         goto exit;
     }
     __clinic_args = PyTuple_GetSlice(0, -1);
@@ -4759,7 +5007,7 @@ exit:
 
 static int
 Test___init___impl(TestObj *self, PyObject *args)
-/*[clinic end generated code: output=0ed1009fe0dcf98d input=96c3ddc0cd38fc0c]*/
+/*[clinic end generated code: output=49f8fbb49a81d912 input=96c3ddc0cd38fc0c]*/
 
 
 /*[clinic input]
@@ -4790,7 +5038,11 @@ Test(PyTypeObject *type, PyObject *args, PyObject *kwargs)
         !_PyArg_NoKeywords("Test", kwargs)) {
         goto exit;
     }
-    if (!_PyArg_CheckPositional("Test", PyTuple_GET_SIZE(args), 0, PY_SSIZE_T_MAX)) {
+    if (PyTuple_GET_SIZE(args) < 0) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 0 arguments, got %zd",
+            "Test", PyTuple_GET_SIZE(args));
         goto exit;
     }
     __clinic_args = PyTuple_GetSlice(0, -1);
@@ -4803,7 +5055,7 @@ exit:
 
 static PyObject *
 Test_impl(PyTypeObject *type, PyObject *args)
-/*[clinic end generated code: output=8b219f6633e2a2e9 input=26a672e2e9750120]*/
+/*[clinic end generated code: output=57b881199060d24a input=26a672e2e9750120]*/
 
 
 /*[clinic input]
@@ -5663,7 +5915,19 @@ test_critical_section_object2(PyObject *module, PyObject *const *args, Py_ssize_
     PyObject *a;
     PyObject *b;
 
-    if (!_PyArg_CheckPositional("test_critical_section_object2", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "test_critical_section_object2", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "test_critical_section_object2", nargs);
         goto exit;
     }
     if (!PyUnicode_Check(args[0])) {
@@ -5687,7 +5951,7 @@ exit:
 static PyObject *
 test_critical_section_object2_impl(PyObject *module, PyObject *a,
                                    PyObject *b)
-/*[clinic end generated code: output=d73a1657c18df17a input=638824e41419a466]*/
+/*[clinic end generated code: output=b49b4606d115da25 input=638824e41419a466]*/
 
 PyDoc_STRVAR(test_critical_section_object2__doc__,
 "test_critical_section_object2($module, a, b, /)\n"

--- a/Modules/_io/clinic/_iomodule.c.h
+++ b/Modules/_io/clinic/_iomodule.c.h
@@ -325,7 +325,19 @@ _io_text_encoding(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *encoding;
     int stacklevel = 2;
 
-    if (!_PyArg_CheckPositional("text_encoding", nargs, 1, 2)) {
+    if (nargs < 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 1 argument, got %zd",
+            "text_encoding", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 2 arguments, got %zd",
+            "text_encoding", nargs);
         goto exit;
     }
     encoding = args[0];
@@ -404,4 +416,4 @@ _io_open_code(PyObject *module, PyObject *const *args, Py_ssize_t nargs, PyObjec
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=5d60f4e778a600a4 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=b0af1cb7a128565d input=a9049054013a1b77]*/

--- a/Modules/_io/clinic/bufferedio.c.h
+++ b/Modules/_io/clinic/bufferedio.c.h
@@ -609,7 +609,19 @@ _io__Buffered_peek(buffered *self, PyObject *const *args, Py_ssize_t nargs)
     PyObject *return_value = NULL;
     Py_ssize_t size = 0;
 
-    if (!_PyArg_CheckPositional("peek", nargs, 0, 1)) {
+    if (nargs < 0) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 0 arguments, got %zd",
+            "peek", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 1 argument, got %zd",
+            "peek", nargs);
         goto exit;
     }
     if (nargs < 1) {
@@ -653,7 +665,19 @@ _io__Buffered_read(buffered *self, PyObject *const *args, Py_ssize_t nargs)
     PyObject *return_value = NULL;
     Py_ssize_t n = -1;
 
-    if (!_PyArg_CheckPositional("read", nargs, 0, 1)) {
+    if (nargs < 0) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 0 arguments, got %zd",
+            "read", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 1 argument, got %zd",
+            "read", nargs);
         goto exit;
     }
     if (nargs < 1) {
@@ -688,7 +712,19 @@ _io__Buffered_read1(buffered *self, PyObject *const *args, Py_ssize_t nargs)
     PyObject *return_value = NULL;
     Py_ssize_t n = -1;
 
-    if (!_PyArg_CheckPositional("read1", nargs, 0, 1)) {
+    if (nargs < 0) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 0 arguments, got %zd",
+            "read1", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 1 argument, got %zd",
+            "read1", nargs);
         goto exit;
     }
     if (nargs < 1) {
@@ -800,7 +836,19 @@ _io__Buffered_readline(buffered *self, PyObject *const *args, Py_ssize_t nargs)
     PyObject *return_value = NULL;
     Py_ssize_t size = -1;
 
-    if (!_PyArg_CheckPositional("readline", nargs, 0, 1)) {
+    if (nargs < 0) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 0 arguments, got %zd",
+            "readline", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 1 argument, got %zd",
+            "readline", nargs);
         goto exit;
     }
     if (nargs < 1) {
@@ -859,7 +907,19 @@ _io__Buffered_seek(buffered *self, PyObject *const *args, Py_ssize_t nargs)
     PyObject *targetobj;
     int whence = 0;
 
-    if (!_PyArg_CheckPositional("seek", nargs, 1, 2)) {
+    if (nargs < 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 1 argument, got %zd",
+            "seek", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 2 arguments, got %zd",
+            "seek", nargs);
         goto exit;
     }
     targetobj = args[0];
@@ -1142,7 +1202,19 @@ _io_BufferedRWPair___init__(PyObject *self, PyObject *args, PyObject *kwargs)
         !_PyArg_NoKeywords("BufferedRWPair", kwargs)) {
         goto exit;
     }
-    if (!_PyArg_CheckPositional("BufferedRWPair", PyTuple_GET_SIZE(args), 2, 3)) {
+    if (PyTuple_GET_SIZE(args) < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 2 arguments, got %zd",
+            "BufferedRWPair", PyTuple_GET_SIZE(args));
+        goto exit;
+    }
+
+    if (PyTuple_GET_SIZE(args) != 0 && PyTuple_GET_SIZE(args) > 3) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 3 arguments, got %zd",
+            "BufferedRWPair", PyTuple_GET_SIZE(args));
         goto exit;
     }
     reader = PyTuple_GET_ITEM(args, 0);
@@ -1245,4 +1317,4 @@ skip_optional_pos:
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=4249187a725a3b3e input=a9049054013a1b77]*/
+/*[clinic end generated code: output=ca3c1970142cab70 input=a9049054013a1b77]*/

--- a/Modules/_io/clinic/bytesio.c.h
+++ b/Modules/_io/clinic/bytesio.c.h
@@ -7,7 +7,7 @@ preserve
 #  include "pycore_runtime.h"     // _Py_ID()
 #endif
 #include "pycore_abstract.h"      // _Py_convert_optional_to_ssize_t()
-#include "pycore_modsupport.h"    // _PyArg_CheckPositional()
+#include "pycore_modsupport.h"    // _PyArg_BadArgument()
 
 PyDoc_STRVAR(_io_BytesIO_readable__doc__,
 "readable($self, /)\n"
@@ -180,7 +180,19 @@ _io_BytesIO_read(bytesio *self, PyObject *const *args, Py_ssize_t nargs)
     PyObject *return_value = NULL;
     Py_ssize_t size = -1;
 
-    if (!_PyArg_CheckPositional("read", nargs, 0, 1)) {
+    if (nargs < 0) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 0 arguments, got %zd",
+            "read", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 1 argument, got %zd",
+            "read", nargs);
         goto exit;
     }
     if (nargs < 1) {
@@ -217,7 +229,19 @@ _io_BytesIO_read1(bytesio *self, PyObject *const *args, Py_ssize_t nargs)
     PyObject *return_value = NULL;
     Py_ssize_t size = -1;
 
-    if (!_PyArg_CheckPositional("read1", nargs, 0, 1)) {
+    if (nargs < 0) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 0 arguments, got %zd",
+            "read1", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 1 argument, got %zd",
+            "read1", nargs);
         goto exit;
     }
     if (nargs < 1) {
@@ -255,7 +279,19 @@ _io_BytesIO_readline(bytesio *self, PyObject *const *args, Py_ssize_t nargs)
     PyObject *return_value = NULL;
     Py_ssize_t size = -1;
 
-    if (!_PyArg_CheckPositional("readline", nargs, 0, 1)) {
+    if (nargs < 0) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 0 arguments, got %zd",
+            "readline", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 1 argument, got %zd",
+            "readline", nargs);
         goto exit;
     }
     if (nargs < 1) {
@@ -293,7 +329,19 @@ _io_BytesIO_readlines(bytesio *self, PyObject *const *args, Py_ssize_t nargs)
     PyObject *return_value = NULL;
     PyObject *arg = Py_None;
 
-    if (!_PyArg_CheckPositional("readlines", nargs, 0, 1)) {
+    if (nargs < 0) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 0 arguments, got %zd",
+            "readlines", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 1 argument, got %zd",
+            "readlines", nargs);
         goto exit;
     }
     if (nargs < 1) {
@@ -364,7 +412,19 @@ _io_BytesIO_truncate(bytesio *self, PyObject *const *args, Py_ssize_t nargs)
     PyObject *return_value = NULL;
     Py_ssize_t size = self->pos;
 
-    if (!_PyArg_CheckPositional("truncate", nargs, 0, 1)) {
+    if (nargs < 0) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 0 arguments, got %zd",
+            "truncate", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 1 argument, got %zd",
+            "truncate", nargs);
         goto exit;
     }
     if (nargs < 1) {
@@ -405,7 +465,19 @@ _io_BytesIO_seek(bytesio *self, PyObject *const *args, Py_ssize_t nargs)
     Py_ssize_t pos;
     int whence = 0;
 
-    if (!_PyArg_CheckPositional("seek", nargs, 1, 2)) {
+    if (nargs < 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 1 argument, got %zd",
+            "seek", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 2 arguments, got %zd",
+            "seek", nargs);
         goto exit;
     }
     {
@@ -534,4 +606,4 @@ skip_optional_pos:
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=ef116925b8b9e535 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=2ce69d01bd2dcf0f input=a9049054013a1b77]*/

--- a/Modules/_io/clinic/fileio.c.h
+++ b/Modules/_io/clinic/fileio.c.h
@@ -415,7 +415,19 @@ _io_FileIO_seek(fileio *self, PyObject *const *args, Py_ssize_t nargs)
     PyObject *pos;
     int whence = 0;
 
-    if (!_PyArg_CheckPositional("seek", nargs, 1, 2)) {
+    if (nargs < 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 1 argument, got %zd",
+            "seek", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 2 arguments, got %zd",
+            "seek", nargs);
         goto exit;
     }
     pos = args[0];
@@ -528,4 +540,4 @@ _io_FileIO_isatty(fileio *self, PyObject *Py_UNUSED(ignored))
 #ifndef _IO_FILEIO_TRUNCATE_METHODDEF
     #define _IO_FILEIO_TRUNCATE_METHODDEF
 #endif /* !defined(_IO_FILEIO_TRUNCATE_METHODDEF) */
-/*[clinic end generated code: output=e3d9446b4087020e input=a9049054013a1b77]*/
+/*[clinic end generated code: output=324f5d7900fb39d5 input=a9049054013a1b77]*/

--- a/Modules/_io/clinic/iobase.c.h
+++ b/Modules/_io/clinic/iobase.c.h
@@ -313,7 +313,19 @@ _io__IOBase_readline(PyObject *self, PyObject *const *args, Py_ssize_t nargs)
     PyObject *return_value = NULL;
     Py_ssize_t limit = -1;
 
-    if (!_PyArg_CheckPositional("readline", nargs, 0, 1)) {
+    if (nargs < 0) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 0 arguments, got %zd",
+            "readline", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 1 argument, got %zd",
+            "readline", nargs);
         goto exit;
     }
     if (nargs < 1) {
@@ -351,7 +363,19 @@ _io__IOBase_readlines(PyObject *self, PyObject *const *args, Py_ssize_t nargs)
     PyObject *return_value = NULL;
     Py_ssize_t hint = -1;
 
-    if (!_PyArg_CheckPositional("readlines", nargs, 0, 1)) {
+    if (nargs < 0) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 0 arguments, got %zd",
+            "readlines", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 1 argument, got %zd",
+            "readlines", nargs);
         goto exit;
     }
     if (nargs < 1) {
@@ -396,7 +420,19 @@ _io__RawIOBase_read(PyObject *self, PyObject *const *args, Py_ssize_t nargs)
     PyObject *return_value = NULL;
     Py_ssize_t n = -1;
 
-    if (!_PyArg_CheckPositional("read", nargs, 0, 1)) {
+    if (nargs < 0) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 0 arguments, got %zd",
+            "read", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 1 argument, got %zd",
+            "read", nargs);
         goto exit;
     }
     if (nargs < 1) {
@@ -438,4 +474,4 @@ _io__RawIOBase_readall(PyObject *self, PyObject *Py_UNUSED(ignored))
 {
     return _io__RawIOBase_readall_impl(self);
 }
-/*[clinic end generated code: output=e7326fbefc52bfba input=a9049054013a1b77]*/
+/*[clinic end generated code: output=7c60e26bd3796f65 input=a9049054013a1b77]*/

--- a/Modules/_io/clinic/stringio.c.h
+++ b/Modules/_io/clinic/stringio.c.h
@@ -8,7 +8,7 @@ preserve
 #endif
 #include "pycore_abstract.h"      // _Py_convert_optional_to_ssize_t()
 #include "pycore_critical_section.h"// Py_BEGIN_CRITICAL_SECTION()
-#include "pycore_modsupport.h"    // _PyArg_CheckPositional()
+#include "pycore_modsupport.h"    // _PyArg_UnpackKeywords()
 
 PyDoc_STRVAR(_io_StringIO_getvalue__doc__,
 "getvalue($self, /)\n"
@@ -79,7 +79,19 @@ _io_StringIO_read(stringio *self, PyObject *const *args, Py_ssize_t nargs)
     PyObject *return_value = NULL;
     Py_ssize_t size = -1;
 
-    if (!_PyArg_CheckPositional("read", nargs, 0, 1)) {
+    if (nargs < 0) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 0 arguments, got %zd",
+            "read", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 1 argument, got %zd",
+            "read", nargs);
         goto exit;
     }
     if (nargs < 1) {
@@ -117,7 +129,19 @@ _io_StringIO_readline(stringio *self, PyObject *const *args, Py_ssize_t nargs)
     PyObject *return_value = NULL;
     Py_ssize_t size = -1;
 
-    if (!_PyArg_CheckPositional("readline", nargs, 0, 1)) {
+    if (nargs < 0) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 0 arguments, got %zd",
+            "readline", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 1 argument, got %zd",
+            "readline", nargs);
         goto exit;
     }
     if (nargs < 1) {
@@ -157,7 +181,19 @@ _io_StringIO_truncate(stringio *self, PyObject *const *args, Py_ssize_t nargs)
     PyObject *return_value = NULL;
     Py_ssize_t size = self->pos;
 
-    if (!_PyArg_CheckPositional("truncate", nargs, 0, 1)) {
+    if (nargs < 0) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 0 arguments, got %zd",
+            "truncate", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 1 argument, got %zd",
+            "truncate", nargs);
         goto exit;
     }
     if (nargs < 1) {
@@ -200,7 +236,19 @@ _io_StringIO_seek(stringio *self, PyObject *const *args, Py_ssize_t nargs)
     Py_ssize_t pos;
     int whence = 0;
 
-    if (!_PyArg_CheckPositional("seek", nargs, 1, 2)) {
+    if (nargs < 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 1 argument, got %zd",
+            "seek", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 2 arguments, got %zd",
+            "seek", nargs);
         goto exit;
     }
     {
@@ -555,4 +603,4 @@ _io_StringIO_newlines_get(stringio *self, void *Py_UNUSED(context))
 
     return return_value;
 }
-/*[clinic end generated code: output=9ffea20cd32d4cd8 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=ebf32fa48369fa00 input=a9049054013a1b77]*/

--- a/Modules/_io/clinic/textio.c.h
+++ b/Modules/_io/clinic/textio.c.h
@@ -792,7 +792,19 @@ _io_TextIOWrapper_read(textio *self, PyObject *const *args, Py_ssize_t nargs)
     PyObject *return_value = NULL;
     Py_ssize_t n = -1;
 
-    if (!_PyArg_CheckPositional("read", nargs, 0, 1)) {
+    if (nargs < 0) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 0 arguments, got %zd",
+            "read", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 1 argument, got %zd",
+            "read", nargs);
         goto exit;
     }
     if (nargs < 1) {
@@ -827,7 +839,19 @@ _io_TextIOWrapper_readline(textio *self, PyObject *const *args, Py_ssize_t nargs
     PyObject *return_value = NULL;
     Py_ssize_t size = -1;
 
-    if (!_PyArg_CheckPositional("readline", nargs, 0, 1)) {
+    if (nargs < 0) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 0 arguments, got %zd",
+            "readline", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 1 argument, got %zd",
+            "readline", nargs);
         goto exit;
     }
     if (nargs < 1) {
@@ -890,7 +914,19 @@ _io_TextIOWrapper_seek(textio *self, PyObject *const *args, Py_ssize_t nargs)
     PyObject *cookieObj;
     int whence = 0;
 
-    if (!_PyArg_CheckPositional("seek", nargs, 1, 2)) {
+    if (nargs < 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 1 argument, got %zd",
+            "seek", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 2 arguments, got %zd",
+            "seek", nargs);
         goto exit;
     }
     cookieObj = args[0];
@@ -954,7 +990,19 @@ _io_TextIOWrapper_truncate(textio *self, PyObject *const *args, Py_ssize_t nargs
     PyObject *return_value = NULL;
     PyObject *pos = Py_None;
 
-    if (!_PyArg_CheckPositional("truncate", nargs, 0, 1)) {
+    if (nargs < 0) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 0 arguments, got %zd",
+            "truncate", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 1 argument, got %zd",
+            "truncate", nargs);
         goto exit;
     }
     if (nargs < 1) {
@@ -1292,4 +1340,4 @@ _io_TextIOWrapper__CHUNK_SIZE_set(textio *self, PyObject *value, void *Py_UNUSED
 
     return return_value;
 }
-/*[clinic end generated code: output=93a5a91a22100a28 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=8d870d890e0f9e20 input=a9049054013a1b77]*/

--- a/Modules/_multiprocessing/clinic/multiprocessing.c.h
+++ b/Modules/_multiprocessing/clinic/multiprocessing.c.h
@@ -2,7 +2,7 @@
 preserve
 [clinic start generated code]*/
 
-#include "pycore_modsupport.h"    // _PyArg_CheckPositional()
+#include "pycore_modsupport.h"    // _PyArg_BadArgument()
 
 #if defined(MS_WINDOWS)
 
@@ -55,7 +55,19 @@ _multiprocessing_recv(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     HANDLE handle;
     int size;
 
-    if (!_PyArg_CheckPositional("recv", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "recv", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "recv", nargs);
         goto exit;
     }
     handle = PyLong_AsVoidPtr(args[0]);
@@ -94,7 +106,19 @@ _multiprocessing_send(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     HANDLE handle;
     Py_buffer buf = {NULL, NULL};
 
-    if (!_PyArg_CheckPositional("send", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "send", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "send", nargs);
         goto exit;
     }
     handle = PyLong_AsVoidPtr(args[0]);
@@ -164,4 +188,4 @@ exit:
 #ifndef _MULTIPROCESSING_SEND_METHODDEF
     #define _MULTIPROCESSING_SEND_METHODDEF
 #endif /* !defined(_MULTIPROCESSING_SEND_METHODDEF) */
-/*[clinic end generated code: output=73b4cb8428d816da input=a9049054013a1b77]*/
+/*[clinic end generated code: output=8a1cb32b216f522e input=a9049054013a1b77]*/

--- a/Modules/_multiprocessing/clinic/semaphore.c.h
+++ b/Modules/_multiprocessing/clinic/semaphore.c.h
@@ -479,7 +479,19 @@ _multiprocessing_SemLock___exit__(SemLockObject *self, PyObject *const *args, Py
     PyObject *exc_value = Py_None;
     PyObject *exc_tb = Py_None;
 
-    if (!_PyArg_CheckPositional("__exit__", nargs, 0, 3)) {
+    if (nargs < 0) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 0 arguments, got %zd",
+            "__exit__", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 3) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 3 arguments, got %zd",
+            "__exit__", nargs);
         goto exit;
     }
     if (nargs < 1) {
@@ -542,4 +554,4 @@ exit:
 #ifndef _MULTIPROCESSING_SEMLOCK___EXIT___METHODDEF
     #define _MULTIPROCESSING_SEMLOCK___EXIT___METHODDEF
 #endif /* !defined(_MULTIPROCESSING_SEMLOCK___EXIT___METHODDEF) */
-/*[clinic end generated code: output=d57992037e6770b6 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=e40df6f465e506cf input=a9049054013a1b77]*/

--- a/Modules/_sqlite/clinic/blob.c.h
+++ b/Modules/_sqlite/clinic/blob.c.h
@@ -2,7 +2,7 @@
 preserve
 [clinic start generated code]*/
 
-#include "pycore_modsupport.h"    // _PyArg_CheckPositional()
+#include "pycore_modsupport.h"    // _PyArg_BadArgument()
 
 PyDoc_STRVAR(blob_close__doc__,
 "close($self, /)\n"
@@ -47,7 +47,19 @@ blob_read(pysqlite_Blob *self, PyObject *const *args, Py_ssize_t nargs)
     PyObject *return_value = NULL;
     int length = -1;
 
-    if (!_PyArg_CheckPositional("read", nargs, 0, 1)) {
+    if (nargs < 0) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 0 arguments, got %zd",
+            "read", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 1 argument, got %zd",
+            "read", nargs);
         goto exit;
     }
     if (nargs < 1) {
@@ -122,7 +134,19 @@ blob_seek(pysqlite_Blob *self, PyObject *const *args, Py_ssize_t nargs)
     int offset;
     int origin = 0;
 
-    if (!_PyArg_CheckPositional("seek", nargs, 1, 2)) {
+    if (nargs < 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 1 argument, got %zd",
+            "seek", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 2 arguments, got %zd",
+            "seek", nargs);
         goto exit;
     }
     offset = PyLong_AsInt(args[0]);
@@ -200,7 +224,19 @@ blob_exit(pysqlite_Blob *self, PyObject *const *args, Py_ssize_t nargs)
     PyObject *val;
     PyObject *tb;
 
-    if (!_PyArg_CheckPositional("__exit__", nargs, 3, 3)) {
+    if (nargs < 3) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 3 arguments, got %zd",
+            "__exit__", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 3) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 3 arguments, got %zd",
+            "__exit__", nargs);
         goto exit;
     }
     type = args[0];
@@ -211,4 +247,4 @@ blob_exit(pysqlite_Blob *self, PyObject *const *args, Py_ssize_t nargs)
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=31abd55660e0c5af input=a9049054013a1b77]*/
+/*[clinic end generated code: output=6f2cb5af66942802 input=a9049054013a1b77]*/

--- a/Modules/_sqlite/clinic/connection.c.h
+++ b/Modules/_sqlite/clinic/connection.c.h
@@ -1122,7 +1122,19 @@ pysqlite_connection_execute(pysqlite_Connection *self, PyObject *const *args, Py
     PyObject *sql;
     PyObject *parameters = NULL;
 
-    if (!_PyArg_CheckPositional("execute", nargs, 1, 2)) {
+    if (nargs < 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 1 argument, got %zd",
+            "execute", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 2 arguments, got %zd",
+            "execute", nargs);
         goto exit;
     }
     if (!PyUnicode_Check(args[0])) {
@@ -1161,7 +1173,19 @@ pysqlite_connection_executemany(pysqlite_Connection *self, PyObject *const *args
     PyObject *sql;
     PyObject *parameters;
 
-    if (!_PyArg_CheckPositional("executemany", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "executemany", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "executemany", nargs);
         goto exit;
     }
     if (!PyUnicode_Check(args[0])) {
@@ -1679,7 +1703,19 @@ pysqlite_connection_exit(pysqlite_Connection *self, PyObject *const *args, Py_ss
     PyObject *exc_value;
     PyObject *exc_tb;
 
-    if (!_PyArg_CheckPositional("__exit__", nargs, 3, 3)) {
+    if (nargs < 3) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 3 arguments, got %zd",
+            "__exit__", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 3) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 3 arguments, got %zd",
+            "__exit__", nargs);
         goto exit;
     }
     exc_type = args[0];
@@ -1720,7 +1756,19 @@ setlimit(pysqlite_Connection *self, PyObject *const *args, Py_ssize_t nargs)
     int category;
     int limit;
 
-    if (!_PyArg_CheckPositional("setlimit", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "setlimit", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "setlimit", nargs);
         goto exit;
     }
     category = PyLong_AsInt(args[0]);
@@ -1790,7 +1838,19 @@ setconfig(pysqlite_Connection *self, PyObject *const *args, Py_ssize_t nargs)
     int op;
     int enable = 1;
 
-    if (!_PyArg_CheckPositional("setconfig", nargs, 1, 2)) {
+    if (nargs < 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 1 argument, got %zd",
+            "setconfig", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 2 arguments, got %zd",
+            "setconfig", nargs);
         goto exit;
     }
     op = PyLong_AsInt(args[0]);
@@ -1866,4 +1926,4 @@ exit:
 #ifndef DESERIALIZE_METHODDEF
     #define DESERIALIZE_METHODDEF
 #endif /* !defined(DESERIALIZE_METHODDEF) */
-/*[clinic end generated code: output=3c6d0b748fac016f input=a9049054013a1b77]*/
+/*[clinic end generated code: output=4b3425c168774ba7 input=a9049054013a1b77]*/

--- a/Modules/_sqlite/clinic/cursor.c.h
+++ b/Modules/_sqlite/clinic/cursor.c.h
@@ -6,7 +6,7 @@ preserve
 #  include "pycore_gc.h"          // PyGC_Head
 #  include "pycore_runtime.h"     // _Py_ID()
 #endif
-#include "pycore_modsupport.h"    // _PyArg_CheckPositional()
+#include "pycore_modsupport.h"    // _PyArg_BadArgument()
 
 static int
 pysqlite_cursor_init_impl(pysqlite_Cursor *self,
@@ -24,7 +24,19 @@ pysqlite_cursor_init(PyObject *self, PyObject *args, PyObject *kwargs)
         !_PyArg_NoKeywords("Cursor", kwargs)) {
         goto exit;
     }
-    if (!_PyArg_CheckPositional("Cursor", PyTuple_GET_SIZE(args), 1, 1)) {
+    if (PyTuple_GET_SIZE(args) < 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 1 argument, got %zd",
+            "Cursor", PyTuple_GET_SIZE(args));
+        goto exit;
+    }
+
+    if (PyTuple_GET_SIZE(args) != 0 && PyTuple_GET_SIZE(args) > 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 1 argument, got %zd",
+            "Cursor", PyTuple_GET_SIZE(args));
         goto exit;
     }
     if (!PyObject_TypeCheck(PyTuple_GET_ITEM(args, 0), clinic_state()->ConnectionType)) {
@@ -58,7 +70,19 @@ pysqlite_cursor_execute(pysqlite_Cursor *self, PyObject *const *args, Py_ssize_t
     PyObject *sql;
     PyObject *parameters = NULL;
 
-    if (!_PyArg_CheckPositional("execute", nargs, 1, 2)) {
+    if (nargs < 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 1 argument, got %zd",
+            "execute", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 2 arguments, got %zd",
+            "execute", nargs);
         goto exit;
     }
     if (!PyUnicode_Check(args[0])) {
@@ -97,7 +121,19 @@ pysqlite_cursor_executemany(pysqlite_Cursor *self, PyObject *const *args, Py_ssi
     PyObject *sql;
     PyObject *seq_of_parameters;
 
-    if (!_PyArg_CheckPositional("executemany", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "executemany", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "executemany", nargs);
         goto exit;
     }
     if (!PyUnicode_Check(args[0])) {
@@ -281,7 +317,19 @@ pysqlite_cursor_setoutputsize(pysqlite_Cursor *self, PyObject *const *args, Py_s
     PyObject *size;
     PyObject *column = Py_None;
 
-    if (!_PyArg_CheckPositional("setoutputsize", nargs, 1, 2)) {
+    if (nargs < 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 1 argument, got %zd",
+            "setoutputsize", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 2 arguments, got %zd",
+            "setoutputsize", nargs);
         goto exit;
     }
     size = args[0];
@@ -313,4 +361,4 @@ pysqlite_cursor_close(pysqlite_Cursor *self, PyObject *Py_UNUSED(ignored))
 {
     return pysqlite_cursor_close_impl(self);
 }
-/*[clinic end generated code: output=a8ce095c3c80cf65 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=a494d8e20d5cb611 input=a9049054013a1b77]*/

--- a/Modules/_sqlite/clinic/module.c.h
+++ b/Modules/_sqlite/clinic/module.c.h
@@ -95,7 +95,19 @@ pysqlite_register_adapter(PyObject *module, PyObject *const *args, Py_ssize_t na
     PyTypeObject *type;
     PyObject *caster;
 
-    if (!_PyArg_CheckPositional("register_adapter", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "register_adapter", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "register_adapter", nargs);
         goto exit;
     }
     type = (PyTypeObject *)args[0];
@@ -126,7 +138,19 @@ pysqlite_register_converter(PyObject *module, PyObject *const *args, Py_ssize_t 
     PyObject *orig_name;
     PyObject *callable;
 
-    if (!_PyArg_CheckPositional("register_converter", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "register_converter", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "register_converter", nargs);
         goto exit;
     }
     if (!PyUnicode_Check(args[0])) {
@@ -190,7 +214,19 @@ pysqlite_adapt(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *proto = (PyObject *)clinic_state()->PrepareProtocolType;
     PyObject *alt = NULL;
 
-    if (!_PyArg_CheckPositional("adapt", nargs, 1, 3)) {
+    if (nargs < 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 1 argument, got %zd",
+            "adapt", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 3) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 3 arguments, got %zd",
+            "adapt", nargs);
         goto exit;
     }
     obj = args[0];
@@ -208,4 +244,4 @@ skip_optional:
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=457ab0fdbb9e1880 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=d0937044e2e77683 input=a9049054013a1b77]*/

--- a/Modules/_sqlite/clinic/row.c.h
+++ b/Modules/_sqlite/clinic/row.c.h
@@ -2,7 +2,7 @@
 preserve
 [clinic start generated code]*/
 
-#include "pycore_modsupport.h"    // _PyArg_CheckPositional()
+#include "pycore_modsupport.h"    // _PyArg_BadArgument()
 
 static PyObject *
 pysqlite_row_new_impl(PyTypeObject *type, pysqlite_Cursor *cursor,
@@ -20,7 +20,19 @@ pysqlite_row_new(PyTypeObject *type, PyObject *args, PyObject *kwargs)
         !_PyArg_NoKeywords("Row", kwargs)) {
         goto exit;
     }
-    if (!_PyArg_CheckPositional("Row", PyTuple_GET_SIZE(args), 2, 2)) {
+    if (PyTuple_GET_SIZE(args) < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "Row", PyTuple_GET_SIZE(args));
+        goto exit;
+    }
+
+    if (PyTuple_GET_SIZE(args) != 0 && PyTuple_GET_SIZE(args) > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "Row", PyTuple_GET_SIZE(args));
         goto exit;
     }
     if (!PyObject_TypeCheck(PyTuple_GET_ITEM(args, 0), clinic_state()->CursorType)) {
@@ -56,4 +68,4 @@ pysqlite_row_keys(pysqlite_Row *self, PyObject *Py_UNUSED(ignored))
 {
     return pysqlite_row_keys_impl(self);
 }
-/*[clinic end generated code: output=788bf817acc02b8e input=a9049054013a1b77]*/
+/*[clinic end generated code: output=7efd2aabfbeca2db input=a9049054013a1b77]*/

--- a/Modules/_sre/clinic/sre.c.h
+++ b/Modules/_sre/clinic/sre.c.h
@@ -1093,7 +1093,19 @@ _sre_template(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *pattern;
     PyObject *template;
 
-    if (!_PyArg_CheckPositional("template", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "template", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "template", nargs);
         goto exit;
     }
     pattern = args[0];
@@ -1308,7 +1320,19 @@ _sre_SRE_Match_start(MatchObject *self, PyObject *const *args, Py_ssize_t nargs)
     PyObject *group = NULL;
     Py_ssize_t _return_value;
 
-    if (!_PyArg_CheckPositional("start", nargs, 0, 1)) {
+    if (nargs < 0) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 0 arguments, got %zd",
+            "start", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 1 argument, got %zd",
+            "start", nargs);
         goto exit;
     }
     if (nargs < 1) {
@@ -1345,7 +1369,19 @@ _sre_SRE_Match_end(MatchObject *self, PyObject *const *args, Py_ssize_t nargs)
     PyObject *group = NULL;
     Py_ssize_t _return_value;
 
-    if (!_PyArg_CheckPositional("end", nargs, 0, 1)) {
+    if (nargs < 0) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 0 arguments, got %zd",
+            "end", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 1 argument, got %zd",
+            "end", nargs);
         goto exit;
     }
     if (nargs < 1) {
@@ -1381,7 +1417,19 @@ _sre_SRE_Match_span(MatchObject *self, PyObject *const *args, Py_ssize_t nargs)
     PyObject *return_value = NULL;
     PyObject *group = NULL;
 
-    if (!_PyArg_CheckPositional("span", nargs, 0, 1)) {
+    if (nargs < 0) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 0 arguments, got %zd",
+            "span", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 1 argument, got %zd",
+            "span", nargs);
         goto exit;
     }
     if (nargs < 1) {
@@ -1461,4 +1509,4 @@ _sre_SRE_Scanner_search(ScannerObject *self, PyTypeObject *cls, PyObject *const 
     }
     return _sre_SRE_Scanner_search_impl(self, cls);
 }
-/*[clinic end generated code: output=c3e711f0b2f43d66 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=300a1c9c145293d8 input=a9049054013a1b77]*/

--- a/Modules/_testcapi/clinic/exceptions.c.h
+++ b/Modules/_testcapi/clinic/exceptions.c.h
@@ -6,7 +6,7 @@ preserve
 #  include "pycore_gc.h"          // PyGC_Head
 #  include "pycore_runtime.h"     // _Py_ID()
 #endif
-#include "pycore_modsupport.h"    // _PyArg_CheckPositional()
+#include "pycore_modsupport.h"    // _PyArg_UnpackKeywords()
 
 PyDoc_STRVAR(_testcapi_err_set_raised__doc__,
 "err_set_raised($module, exception, /)\n"
@@ -35,7 +35,19 @@ _testcapi_exception_print(PyObject *module, PyObject *const *args, Py_ssize_t na
     PyObject *exc;
     int legacy = 0;
 
-    if (!_PyArg_CheckPositional("exception_print", nargs, 1, 2)) {
+    if (nargs < 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 1 argument, got %zd",
+            "exception_print", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 2 arguments, got %zd",
+            "exception_print", nargs);
         goto exit;
     }
     exc = args[0];
@@ -174,7 +186,19 @@ _testcapi_exc_set_object(PyObject *module, PyObject *const *args, Py_ssize_t nar
     PyObject *exc;
     PyObject *obj;
 
-    if (!_PyArg_CheckPositional("exc_set_object", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "exc_set_object", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "exc_set_object", nargs);
         goto exit;
     }
     exc = args[0];
@@ -204,7 +228,19 @@ _testcapi_exc_set_object_fetch(PyObject *module, PyObject *const *args, Py_ssize
     PyObject *exc;
     PyObject *obj;
 
-    if (!_PyArg_CheckPositional("exc_set_object_fetch", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "exc_set_object_fetch", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "exc_set_object_fetch", nargs);
         goto exit;
     }
     exc = args[0];
@@ -295,7 +331,19 @@ _testcapi_raise_exception(PyObject *module, PyObject *const *args, Py_ssize_t na
     PyObject *exc;
     int num_args;
 
-    if (!_PyArg_CheckPositional("raise_exception", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "raise_exception", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "raise_exception", nargs);
         goto exit;
     }
     exc = args[0];
@@ -375,7 +423,19 @@ _testcapi_set_exc_info(PyObject *module, PyObject *const *args, Py_ssize_t nargs
     PyObject *new_value;
     PyObject *new_tb;
 
-    if (!_PyArg_CheckPositional("set_exc_info", nargs, 3, 3)) {
+    if (nargs < 3) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 3 arguments, got %zd",
+            "set_exc_info", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 3) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 3 arguments, got %zd",
+            "set_exc_info", nargs);
         goto exit;
     }
     new_type = args[0];
@@ -415,7 +475,19 @@ _testcapi_traceback_print(PyObject *module, PyObject *const *args, Py_ssize_t na
     PyObject *traceback;
     PyObject *file;
 
-    if (!_PyArg_CheckPositional("traceback_print", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "traceback_print", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "traceback_print", nargs);
         goto exit;
     }
     traceback = args[0];
@@ -446,7 +518,19 @@ _testcapi_unstable_exc_prep_reraise_star(PyObject *module, PyObject *const *args
     PyObject *orig;
     PyObject *excs;
 
-    if (!_PyArg_CheckPositional("unstable_exc_prep_reraise_star", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "unstable_exc_prep_reraise_star", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "unstable_exc_prep_reraise_star", nargs);
         goto exit;
     }
     orig = args[0];
@@ -456,4 +540,4 @@ _testcapi_unstable_exc_prep_reraise_star(PyObject *module, PyObject *const *args
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=0b11ef105030a48e input=a9049054013a1b77]*/
+/*[clinic end generated code: output=ebf6eeabff03e65b input=a9049054013a1b77]*/

--- a/Modules/_testcapi/clinic/float.c.h
+++ b/Modules/_testcapi/clinic/float.c.h
@@ -2,7 +2,7 @@
 preserve
 [clinic start generated code]*/
 
-#include "pycore_modsupport.h"    // _PyArg_CheckPositional()
+#include "pycore_modsupport.h"    // _PyArg_ParseStack()
 
 PyDoc_STRVAR(_testcapi_float_pack__doc__,
 "float_pack($module, size, d, le, /)\n"
@@ -24,7 +24,19 @@ _testcapi_float_pack(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     double d;
     int le;
 
-    if (!_PyArg_CheckPositional("float_pack", nargs, 3, 3)) {
+    if (nargs < 3) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 3 arguments, got %zd",
+            "float_pack", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 3) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 3 arguments, got %zd",
+            "float_pack", nargs);
         goto exit;
     }
     size = PyLong_AsInt(args[0]);
@@ -81,4 +93,4 @@ _testcapi_float_unpack(PyObject *module, PyObject *const *args, Py_ssize_t nargs
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=b43dfd3a77fe04ba input=a9049054013a1b77]*/
+/*[clinic end generated code: output=49c315676c86c396 input=a9049054013a1b77]*/

--- a/Modules/_testcapi/clinic/vectorcall.c.h
+++ b/Modules/_testcapi/clinic/vectorcall.c.h
@@ -2,7 +2,7 @@
 preserve
 [clinic start generated code]*/
 
-#include "pycore_modsupport.h"    // _PyArg_CheckPositional()
+#include "pycore_modsupport.h"    // _PyArg_BadArgument()
 
 PyDoc_STRVAR(_testcapi_pyobject_fastcalldict__doc__,
 "pyobject_fastcalldict($module, func, func_args, kwargs, /)\n"
@@ -24,7 +24,19 @@ _testcapi_pyobject_fastcalldict(PyObject *module, PyObject *const *args, Py_ssiz
     PyObject *func_args;
     PyObject *__clinic_kwargs;
 
-    if (!_PyArg_CheckPositional("pyobject_fastcalldict", nargs, 3, 3)) {
+    if (nargs < 3) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 3 arguments, got %zd",
+            "pyobject_fastcalldict", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 3) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 3 arguments, got %zd",
+            "pyobject_fastcalldict", nargs);
         goto exit;
     }
     func = args[0];
@@ -56,7 +68,19 @@ _testcapi_pyobject_vectorcall(PyObject *module, PyObject *const *args, Py_ssize_
     PyObject *func_args;
     PyObject *__clinic_kwnames;
 
-    if (!_PyArg_CheckPositional("pyobject_vectorcall", nargs, 3, 3)) {
+    if (nargs < 3) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 3 arguments, got %zd",
+            "pyobject_vectorcall", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 3) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 3 arguments, got %zd",
+            "pyobject_vectorcall", nargs);
         goto exit;
     }
     func = args[0];
@@ -88,7 +112,19 @@ _testcapi_pyvectorcall_call(PyObject *module, PyObject *const *args, Py_ssize_t 
     PyObject *argstuple;
     PyObject *__clinic_kwargs = NULL;
 
-    if (!_PyArg_CheckPositional("pyvectorcall_call", nargs, 2, 3)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 2 arguments, got %zd",
+            "pyvectorcall_call", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 3) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 3 arguments, got %zd",
+            "pyvectorcall_call", nargs);
         goto exit;
     }
     func = args[0];
@@ -155,7 +191,19 @@ _testcapi_make_vectorcall_class(PyObject *module, PyObject *const *args, Py_ssiz
     PyObject *return_value = NULL;
     PyTypeObject *base = NULL;
 
-    if (!_PyArg_CheckPositional("make_vectorcall_class", nargs, 0, 1)) {
+    if (nargs < 0) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 0 arguments, got %zd",
+            "make_vectorcall_class", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 1 argument, got %zd",
+            "make_vectorcall_class", nargs);
         goto exit;
     }
     if (nargs < 1) {
@@ -206,4 +254,4 @@ _testcapi_has_vectorcall_flag(PyObject *module, PyObject *arg)
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=210ae67caab177ba input=a9049054013a1b77]*/
+/*[clinic end generated code: output=a7f876ad7c8727ce input=a9049054013a1b77]*/

--- a/Modules/_testcapi/clinic/watchers.c.h
+++ b/Modules/_testcapi/clinic/watchers.c.h
@@ -2,8 +2,6 @@
 preserve
 [clinic start generated code]*/
 
-#include "pycore_modsupport.h"    // _PyArg_CheckPositional()
-
 PyDoc_STRVAR(_testcapi_watch_dict__doc__,
 "watch_dict($module, watcher_id, dict, /)\n"
 "--\n"
@@ -22,7 +20,19 @@ _testcapi_watch_dict(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     int watcher_id;
     PyObject *dict;
 
-    if (!_PyArg_CheckPositional("watch_dict", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "watch_dict", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "watch_dict", nargs);
         goto exit;
     }
     watcher_id = PyLong_AsInt(args[0]);
@@ -54,7 +64,19 @@ _testcapi_unwatch_dict(PyObject *module, PyObject *const *args, Py_ssize_t nargs
     int watcher_id;
     PyObject *dict;
 
-    if (!_PyArg_CheckPositional("unwatch_dict", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "unwatch_dict", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "unwatch_dict", nargs);
         goto exit;
     }
     watcher_id = PyLong_AsInt(args[0]);
@@ -86,7 +108,19 @@ _testcapi_watch_type(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     int watcher_id;
     PyObject *type;
 
-    if (!_PyArg_CheckPositional("watch_type", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "watch_type", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "watch_type", nargs);
         goto exit;
     }
     watcher_id = PyLong_AsInt(args[0]);
@@ -118,7 +152,19 @@ _testcapi_unwatch_type(PyObject *module, PyObject *const *args, Py_ssize_t nargs
     int watcher_id;
     PyObject *type;
 
-    if (!_PyArg_CheckPositional("unwatch_type", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "unwatch_type", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "unwatch_type", nargs);
         goto exit;
     }
     watcher_id = PyLong_AsInt(args[0]);
@@ -151,7 +197,19 @@ _testcapi_set_func_defaults_via_capi(PyObject *module, PyObject *const *args, Py
     PyObject *func;
     PyObject *defaults;
 
-    if (!_PyArg_CheckPositional("set_func_defaults_via_capi", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "set_func_defaults_via_capi", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "set_func_defaults_via_capi", nargs);
         goto exit;
     }
     func = args[0];
@@ -181,7 +239,19 @@ _testcapi_set_func_kwdefaults_via_capi(PyObject *module, PyObject *const *args, 
     PyObject *func;
     PyObject *defaults;
 
-    if (!_PyArg_CheckPositional("set_func_kwdefaults_via_capi", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "set_func_kwdefaults_via_capi", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "set_func_kwdefaults_via_capi", nargs);
         goto exit;
     }
     func = args[0];
@@ -191,4 +261,4 @@ _testcapi_set_func_kwdefaults_via_capi(PyObject *module, PyObject *const *args, 
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=0e07ce7f295917a5 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=2869b7c4f48f7886 input=a9049054013a1b77]*/

--- a/Modules/_testinternalcapi/clinic/test_lock.c.h
+++ b/Modules/_testinternalcapi/clinic/test_lock.c.h
@@ -3,7 +3,6 @@ preserve
 [clinic start generated code]*/
 
 #include "pycore_abstract.h"      // _PyNumber_Index()
-#include "pycore_modsupport.h"    // _PyArg_CheckPositional()
 
 PyDoc_STRVAR(_testinternalcapi_benchmark_locks__doc__,
 "benchmark_locks($module, num_threads, use_pymutex=True,\n"
@@ -30,7 +29,19 @@ _testinternalcapi_benchmark_locks(PyObject *module, PyObject *const *args, Py_ss
     int critical_section_length = 1;
     int time_ms = 1000;
 
-    if (!_PyArg_CheckPositional("benchmark_locks", nargs, 1, 4)) {
+    if (nargs < 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 1 argument, got %zd",
+            "benchmark_locks", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 4) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 4 arguments, got %zd",
+            "benchmark_locks", nargs);
         goto exit;
     }
     {
@@ -72,4 +83,4 @@ skip_optional:
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=105105d759c0c271 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=e233fd132ab048e1 input=a9049054013a1b77]*/

--- a/Modules/cjkcodecs/clinic/multibytecodec.c.h
+++ b/Modules/cjkcodecs/clinic/multibytecodec.c.h
@@ -470,7 +470,19 @@ _multibytecodec_MultibyteStreamReader_read(MultibyteStreamReaderObject *self, Py
     PyObject *return_value = NULL;
     PyObject *sizeobj = Py_None;
 
-    if (!_PyArg_CheckPositional("read", nargs, 0, 1)) {
+    if (nargs < 0) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 0 arguments, got %zd",
+            "read", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 1 argument, got %zd",
+            "read", nargs);
         goto exit;
     }
     if (nargs < 1) {
@@ -502,7 +514,19 @@ _multibytecodec_MultibyteStreamReader_readline(MultibyteStreamReaderObject *self
     PyObject *return_value = NULL;
     PyObject *sizeobj = Py_None;
 
-    if (!_PyArg_CheckPositional("readline", nargs, 0, 1)) {
+    if (nargs < 0) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 0 arguments, got %zd",
+            "readline", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 1 argument, got %zd",
+            "readline", nargs);
         goto exit;
     }
     if (nargs < 1) {
@@ -534,7 +558,19 @@ _multibytecodec_MultibyteStreamReader_readlines(MultibyteStreamReaderObject *sel
     PyObject *return_value = NULL;
     PyObject *sizehintobj = Py_None;
 
-    if (!_PyArg_CheckPositional("readlines", nargs, 0, 1)) {
+    if (nargs < 0) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 0 arguments, got %zd",
+            "readlines", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 1 argument, got %zd",
+            "readlines", nargs);
         goto exit;
     }
     if (nargs < 1) {
@@ -682,4 +718,4 @@ PyDoc_STRVAR(_multibytecodec___create_codec__doc__,
 
 #define _MULTIBYTECODEC___CREATE_CODEC_METHODDEF    \
     {"__create_codec", (PyCFunction)_multibytecodec___create_codec, METH_O, _multibytecodec___create_codec__doc__},
-/*[clinic end generated code: output=ee767a6d93c7108a input=a9049054013a1b77]*/
+/*[clinic end generated code: output=5dfc4ca17f8ad508 input=a9049054013a1b77]*/

--- a/Modules/clinic/_abc.c.h
+++ b/Modules/clinic/_abc.c.h
@@ -2,8 +2,6 @@
 preserve
 [clinic start generated code]*/
 
-#include "pycore_modsupport.h"    // _PyArg_CheckPositional()
-
 PyDoc_STRVAR(_abc__reset_registry__doc__,
 "_reset_registry($module, self, /)\n"
 "--\n"
@@ -67,7 +65,19 @@ _abc__abc_register(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *self;
     PyObject *subclass;
 
-    if (!_PyArg_CheckPositional("_abc_register", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "_abc_register", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "_abc_register", nargs);
         goto exit;
     }
     self = args[0];
@@ -98,7 +108,19 @@ _abc__abc_instancecheck(PyObject *module, PyObject *const *args, Py_ssize_t narg
     PyObject *self;
     PyObject *instance;
 
-    if (!_PyArg_CheckPositional("_abc_instancecheck", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "_abc_instancecheck", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "_abc_instancecheck", nargs);
         goto exit;
     }
     self = args[0];
@@ -129,7 +151,19 @@ _abc__abc_subclasscheck(PyObject *module, PyObject *const *args, Py_ssize_t narg
     PyObject *self;
     PyObject *subclass;
 
-    if (!_PyArg_CheckPositional("_abc_subclasscheck", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "_abc_subclasscheck", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "_abc_subclasscheck", nargs);
         goto exit;
     }
     self = args[0];
@@ -161,4 +195,4 @@ _abc_get_cache_token(PyObject *module, PyObject *Py_UNUSED(ignored))
 {
     return _abc_get_cache_token_impl(module);
 }
-/*[clinic end generated code: output=1989b6716c950e17 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=6000b9eadb347306 input=a9049054013a1b77]*/

--- a/Modules/clinic/_bz2module.c.h
+++ b/Modules/clinic/_bz2module.c.h
@@ -93,7 +93,19 @@ _bz2_BZ2Compressor(PyTypeObject *type, PyObject *args, PyObject *kwargs)
         !_PyArg_NoKeywords("BZ2Compressor", kwargs)) {
         goto exit;
     }
-    if (!_PyArg_CheckPositional("BZ2Compressor", PyTuple_GET_SIZE(args), 0, 1)) {
+    if (PyTuple_GET_SIZE(args) < 0) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 0 arguments, got %zd",
+            "BZ2Compressor", PyTuple_GET_SIZE(args));
+        goto exit;
+    }
+
+    if (PyTuple_GET_SIZE(args) != 0 && PyTuple_GET_SIZE(args) > 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 1 argument, got %zd",
+            "BZ2Compressor", PyTuple_GET_SIZE(args));
         goto exit;
     }
     if (PyTuple_GET_SIZE(args) < 1) {
@@ -234,4 +246,4 @@ _bz2_BZ2Decompressor(PyTypeObject *type, PyObject *args, PyObject *kwargs)
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=8daa62f47cc4853d input=a9049054013a1b77]*/
+/*[clinic end generated code: output=fe371ed886dae33d input=a9049054013a1b77]*/

--- a/Modules/clinic/_codecsmodule.c.h
+++ b/Modules/clinic/_codecsmodule.c.h
@@ -288,7 +288,19 @@ _codecs_escape_decode(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     Py_buffer data = {NULL, NULL};
     const char *errors = NULL;
 
-    if (!_PyArg_CheckPositional("escape_decode", nargs, 1, 2)) {
+    if (nargs < 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 1 argument, got %zd",
+            "escape_decode", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 2 arguments, got %zd",
+            "escape_decode", nargs);
         goto exit;
     }
     if (PyUnicode_Check(args[0])) {
@@ -358,7 +370,19 @@ _codecs_escape_encode(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *data;
     const char *errors = NULL;
 
-    if (!_PyArg_CheckPositional("escape_encode", nargs, 1, 2)) {
+    if (nargs < 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 1 argument, got %zd",
+            "escape_encode", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 2 arguments, got %zd",
+            "escape_encode", nargs);
         goto exit;
     }
     if (!PyBytes_Check(args[0])) {
@@ -414,7 +438,19 @@ _codecs_utf_7_decode(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     const char *errors = NULL;
     int final = 0;
 
-    if (!_PyArg_CheckPositional("utf_7_decode", nargs, 1, 3)) {
+    if (nargs < 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 1 argument, got %zd",
+            "utf_7_decode", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 3) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 3 arguments, got %zd",
+            "utf_7_decode", nargs);
         goto exit;
     }
     if (PyObject_GetBuffer(args[0], &data, PyBUF_SIMPLE) != 0) {
@@ -480,7 +516,19 @@ _codecs_utf_8_decode(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     const char *errors = NULL;
     int final = 0;
 
-    if (!_PyArg_CheckPositional("utf_8_decode", nargs, 1, 3)) {
+    if (nargs < 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 1 argument, got %zd",
+            "utf_8_decode", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 3) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 3 arguments, got %zd",
+            "utf_8_decode", nargs);
         goto exit;
     }
     if (PyObject_GetBuffer(args[0], &data, PyBUF_SIMPLE) != 0) {
@@ -546,7 +594,19 @@ _codecs_utf_16_decode(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     const char *errors = NULL;
     int final = 0;
 
-    if (!_PyArg_CheckPositional("utf_16_decode", nargs, 1, 3)) {
+    if (nargs < 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 1 argument, got %zd",
+            "utf_16_decode", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 3) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 3 arguments, got %zd",
+            "utf_16_decode", nargs);
         goto exit;
     }
     if (PyObject_GetBuffer(args[0], &data, PyBUF_SIMPLE) != 0) {
@@ -612,7 +672,19 @@ _codecs_utf_16_le_decode(PyObject *module, PyObject *const *args, Py_ssize_t nar
     const char *errors = NULL;
     int final = 0;
 
-    if (!_PyArg_CheckPositional("utf_16_le_decode", nargs, 1, 3)) {
+    if (nargs < 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 1 argument, got %zd",
+            "utf_16_le_decode", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 3) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 3 arguments, got %zd",
+            "utf_16_le_decode", nargs);
         goto exit;
     }
     if (PyObject_GetBuffer(args[0], &data, PyBUF_SIMPLE) != 0) {
@@ -678,7 +750,19 @@ _codecs_utf_16_be_decode(PyObject *module, PyObject *const *args, Py_ssize_t nar
     const char *errors = NULL;
     int final = 0;
 
-    if (!_PyArg_CheckPositional("utf_16_be_decode", nargs, 1, 3)) {
+    if (nargs < 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 1 argument, got %zd",
+            "utf_16_be_decode", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 3) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 3 arguments, got %zd",
+            "utf_16_be_decode", nargs);
         goto exit;
     }
     if (PyObject_GetBuffer(args[0], &data, PyBUF_SIMPLE) != 0) {
@@ -746,7 +830,19 @@ _codecs_utf_16_ex_decode(PyObject *module, PyObject *const *args, Py_ssize_t nar
     int byteorder = 0;
     int final = 0;
 
-    if (!_PyArg_CheckPositional("utf_16_ex_decode", nargs, 1, 4)) {
+    if (nargs < 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 1 argument, got %zd",
+            "utf_16_ex_decode", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 4) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 4 arguments, got %zd",
+            "utf_16_ex_decode", nargs);
         goto exit;
     }
     if (PyObject_GetBuffer(args[0], &data, PyBUF_SIMPLE) != 0) {
@@ -819,7 +915,19 @@ _codecs_utf_32_decode(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     const char *errors = NULL;
     int final = 0;
 
-    if (!_PyArg_CheckPositional("utf_32_decode", nargs, 1, 3)) {
+    if (nargs < 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 1 argument, got %zd",
+            "utf_32_decode", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 3) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 3 arguments, got %zd",
+            "utf_32_decode", nargs);
         goto exit;
     }
     if (PyObject_GetBuffer(args[0], &data, PyBUF_SIMPLE) != 0) {
@@ -885,7 +993,19 @@ _codecs_utf_32_le_decode(PyObject *module, PyObject *const *args, Py_ssize_t nar
     const char *errors = NULL;
     int final = 0;
 
-    if (!_PyArg_CheckPositional("utf_32_le_decode", nargs, 1, 3)) {
+    if (nargs < 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 1 argument, got %zd",
+            "utf_32_le_decode", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 3) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 3 arguments, got %zd",
+            "utf_32_le_decode", nargs);
         goto exit;
     }
     if (PyObject_GetBuffer(args[0], &data, PyBUF_SIMPLE) != 0) {
@@ -951,7 +1071,19 @@ _codecs_utf_32_be_decode(PyObject *module, PyObject *const *args, Py_ssize_t nar
     const char *errors = NULL;
     int final = 0;
 
-    if (!_PyArg_CheckPositional("utf_32_be_decode", nargs, 1, 3)) {
+    if (nargs < 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 1 argument, got %zd",
+            "utf_32_be_decode", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 3) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 3 arguments, got %zd",
+            "utf_32_be_decode", nargs);
         goto exit;
     }
     if (PyObject_GetBuffer(args[0], &data, PyBUF_SIMPLE) != 0) {
@@ -1019,7 +1151,19 @@ _codecs_utf_32_ex_decode(PyObject *module, PyObject *const *args, Py_ssize_t nar
     int byteorder = 0;
     int final = 0;
 
-    if (!_PyArg_CheckPositional("utf_32_ex_decode", nargs, 1, 4)) {
+    if (nargs < 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 1 argument, got %zd",
+            "utf_32_ex_decode", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 4) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 4 arguments, got %zd",
+            "utf_32_ex_decode", nargs);
         goto exit;
     }
     if (PyObject_GetBuffer(args[0], &data, PyBUF_SIMPLE) != 0) {
@@ -1092,7 +1236,19 @@ _codecs_unicode_escape_decode(PyObject *module, PyObject *const *args, Py_ssize_
     const char *errors = NULL;
     int final = 1;
 
-    if (!_PyArg_CheckPositional("unicode_escape_decode", nargs, 1, 3)) {
+    if (nargs < 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 1 argument, got %zd",
+            "unicode_escape_decode", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 3) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 3 arguments, got %zd",
+            "unicode_escape_decode", nargs);
         goto exit;
     }
     if (PyUnicode_Check(args[0])) {
@@ -1170,7 +1326,19 @@ _codecs_raw_unicode_escape_decode(PyObject *module, PyObject *const *args, Py_ss
     const char *errors = NULL;
     int final = 1;
 
-    if (!_PyArg_CheckPositional("raw_unicode_escape_decode", nargs, 1, 3)) {
+    if (nargs < 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 1 argument, got %zd",
+            "raw_unicode_escape_decode", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 3) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 3 arguments, got %zd",
+            "raw_unicode_escape_decode", nargs);
         goto exit;
     }
     if (PyUnicode_Check(args[0])) {
@@ -1247,7 +1415,19 @@ _codecs_latin_1_decode(PyObject *module, PyObject *const *args, Py_ssize_t nargs
     Py_buffer data = {NULL, NULL};
     const char *errors = NULL;
 
-    if (!_PyArg_CheckPositional("latin_1_decode", nargs, 1, 2)) {
+    if (nargs < 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 1 argument, got %zd",
+            "latin_1_decode", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 2 arguments, got %zd",
+            "latin_1_decode", nargs);
         goto exit;
     }
     if (PyObject_GetBuffer(args[0], &data, PyBUF_SIMPLE) != 0) {
@@ -1305,7 +1485,19 @@ _codecs_ascii_decode(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     Py_buffer data = {NULL, NULL};
     const char *errors = NULL;
 
-    if (!_PyArg_CheckPositional("ascii_decode", nargs, 1, 2)) {
+    if (nargs < 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 1 argument, got %zd",
+            "ascii_decode", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 2 arguments, got %zd",
+            "ascii_decode", nargs);
         goto exit;
     }
     if (PyObject_GetBuffer(args[0], &data, PyBUF_SIMPLE) != 0) {
@@ -1364,7 +1556,19 @@ _codecs_charmap_decode(PyObject *module, PyObject *const *args, Py_ssize_t nargs
     const char *errors = NULL;
     PyObject *mapping = Py_None;
 
-    if (!_PyArg_CheckPositional("charmap_decode", nargs, 1, 3)) {
+    if (nargs < 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 1 argument, got %zd",
+            "charmap_decode", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 3) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 3 arguments, got %zd",
+            "charmap_decode", nargs);
         goto exit;
     }
     if (PyObject_GetBuffer(args[0], &data, PyBUF_SIMPLE) != 0) {
@@ -1429,7 +1633,19 @@ _codecs_mbcs_decode(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     const char *errors = NULL;
     int final = 0;
 
-    if (!_PyArg_CheckPositional("mbcs_decode", nargs, 1, 3)) {
+    if (nargs < 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 1 argument, got %zd",
+            "mbcs_decode", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 3) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 3 arguments, got %zd",
+            "mbcs_decode", nargs);
         goto exit;
     }
     if (PyObject_GetBuffer(args[0], &data, PyBUF_SIMPLE) != 0) {
@@ -1499,7 +1715,19 @@ _codecs_oem_decode(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     const char *errors = NULL;
     int final = 0;
 
-    if (!_PyArg_CheckPositional("oem_decode", nargs, 1, 3)) {
+    if (nargs < 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 1 argument, got %zd",
+            "oem_decode", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 3) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 3 arguments, got %zd",
+            "oem_decode", nargs);
         goto exit;
     }
     if (PyObject_GetBuffer(args[0], &data, PyBUF_SIMPLE) != 0) {
@@ -1570,7 +1798,19 @@ _codecs_code_page_decode(PyObject *module, PyObject *const *args, Py_ssize_t nar
     const char *errors = NULL;
     int final = 0;
 
-    if (!_PyArg_CheckPositional("code_page_decode", nargs, 2, 4)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 2 arguments, got %zd",
+            "code_page_decode", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 4) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 4 arguments, got %zd",
+            "code_page_decode", nargs);
         goto exit;
     }
     codepage = PyLong_AsInt(args[0]);
@@ -1641,7 +1881,19 @@ _codecs_readbuffer_encode(PyObject *module, PyObject *const *args, Py_ssize_t na
     Py_buffer data = {NULL, NULL};
     const char *errors = NULL;
 
-    if (!_PyArg_CheckPositional("readbuffer_encode", nargs, 1, 2)) {
+    if (nargs < 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 1 argument, got %zd",
+            "readbuffer_encode", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 2 arguments, got %zd",
+            "readbuffer_encode", nargs);
         goto exit;
     }
     if (PyUnicode_Check(args[0])) {
@@ -1711,7 +1963,19 @@ _codecs_utf_7_encode(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *str;
     const char *errors = NULL;
 
-    if (!_PyArg_CheckPositional("utf_7_encode", nargs, 1, 2)) {
+    if (nargs < 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 1 argument, got %zd",
+            "utf_7_encode", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 2 arguments, got %zd",
+            "utf_7_encode", nargs);
         goto exit;
     }
     if (!PyUnicode_Check(args[0])) {
@@ -1766,7 +2030,19 @@ _codecs_utf_8_encode(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *str;
     const char *errors = NULL;
 
-    if (!_PyArg_CheckPositional("utf_8_encode", nargs, 1, 2)) {
+    if (nargs < 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 1 argument, got %zd",
+            "utf_8_encode", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 2 arguments, got %zd",
+            "utf_8_encode", nargs);
         goto exit;
     }
     if (!PyUnicode_Check(args[0])) {
@@ -1822,7 +2098,19 @@ _codecs_utf_16_encode(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     const char *errors = NULL;
     int byteorder = 0;
 
-    if (!_PyArg_CheckPositional("utf_16_encode", nargs, 1, 3)) {
+    if (nargs < 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 1 argument, got %zd",
+            "utf_16_encode", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 3) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 3 arguments, got %zd",
+            "utf_16_encode", nargs);
         goto exit;
     }
     if (!PyUnicode_Check(args[0])) {
@@ -1884,7 +2172,19 @@ _codecs_utf_16_le_encode(PyObject *module, PyObject *const *args, Py_ssize_t nar
     PyObject *str;
     const char *errors = NULL;
 
-    if (!_PyArg_CheckPositional("utf_16_le_encode", nargs, 1, 2)) {
+    if (nargs < 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 1 argument, got %zd",
+            "utf_16_le_encode", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 2 arguments, got %zd",
+            "utf_16_le_encode", nargs);
         goto exit;
     }
     if (!PyUnicode_Check(args[0])) {
@@ -1939,7 +2239,19 @@ _codecs_utf_16_be_encode(PyObject *module, PyObject *const *args, Py_ssize_t nar
     PyObject *str;
     const char *errors = NULL;
 
-    if (!_PyArg_CheckPositional("utf_16_be_encode", nargs, 1, 2)) {
+    if (nargs < 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 1 argument, got %zd",
+            "utf_16_be_encode", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 2 arguments, got %zd",
+            "utf_16_be_encode", nargs);
         goto exit;
     }
     if (!PyUnicode_Check(args[0])) {
@@ -1995,7 +2307,19 @@ _codecs_utf_32_encode(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     const char *errors = NULL;
     int byteorder = 0;
 
-    if (!_PyArg_CheckPositional("utf_32_encode", nargs, 1, 3)) {
+    if (nargs < 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 1 argument, got %zd",
+            "utf_32_encode", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 3) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 3 arguments, got %zd",
+            "utf_32_encode", nargs);
         goto exit;
     }
     if (!PyUnicode_Check(args[0])) {
@@ -2057,7 +2381,19 @@ _codecs_utf_32_le_encode(PyObject *module, PyObject *const *args, Py_ssize_t nar
     PyObject *str;
     const char *errors = NULL;
 
-    if (!_PyArg_CheckPositional("utf_32_le_encode", nargs, 1, 2)) {
+    if (nargs < 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 1 argument, got %zd",
+            "utf_32_le_encode", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 2 arguments, got %zd",
+            "utf_32_le_encode", nargs);
         goto exit;
     }
     if (!PyUnicode_Check(args[0])) {
@@ -2112,7 +2448,19 @@ _codecs_utf_32_be_encode(PyObject *module, PyObject *const *args, Py_ssize_t nar
     PyObject *str;
     const char *errors = NULL;
 
-    if (!_PyArg_CheckPositional("utf_32_be_encode", nargs, 1, 2)) {
+    if (nargs < 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 1 argument, got %zd",
+            "utf_32_be_encode", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 2 arguments, got %zd",
+            "utf_32_be_encode", nargs);
         goto exit;
     }
     if (!PyUnicode_Check(args[0])) {
@@ -2167,7 +2515,19 @@ _codecs_unicode_escape_encode(PyObject *module, PyObject *const *args, Py_ssize_
     PyObject *str;
     const char *errors = NULL;
 
-    if (!_PyArg_CheckPositional("unicode_escape_encode", nargs, 1, 2)) {
+    if (nargs < 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 1 argument, got %zd",
+            "unicode_escape_encode", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 2 arguments, got %zd",
+            "unicode_escape_encode", nargs);
         goto exit;
     }
     if (!PyUnicode_Check(args[0])) {
@@ -2222,7 +2582,19 @@ _codecs_raw_unicode_escape_encode(PyObject *module, PyObject *const *args, Py_ss
     PyObject *str;
     const char *errors = NULL;
 
-    if (!_PyArg_CheckPositional("raw_unicode_escape_encode", nargs, 1, 2)) {
+    if (nargs < 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 1 argument, got %zd",
+            "raw_unicode_escape_encode", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 2 arguments, got %zd",
+            "raw_unicode_escape_encode", nargs);
         goto exit;
     }
     if (!PyUnicode_Check(args[0])) {
@@ -2277,7 +2649,19 @@ _codecs_latin_1_encode(PyObject *module, PyObject *const *args, Py_ssize_t nargs
     PyObject *str;
     const char *errors = NULL;
 
-    if (!_PyArg_CheckPositional("latin_1_encode", nargs, 1, 2)) {
+    if (nargs < 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 1 argument, got %zd",
+            "latin_1_encode", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 2 arguments, got %zd",
+            "latin_1_encode", nargs);
         goto exit;
     }
     if (!PyUnicode_Check(args[0])) {
@@ -2332,7 +2716,19 @@ _codecs_ascii_encode(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *str;
     const char *errors = NULL;
 
-    if (!_PyArg_CheckPositional("ascii_encode", nargs, 1, 2)) {
+    if (nargs < 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 1 argument, got %zd",
+            "ascii_encode", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 2 arguments, got %zd",
+            "ascii_encode", nargs);
         goto exit;
     }
     if (!PyUnicode_Check(args[0])) {
@@ -2388,7 +2784,19 @@ _codecs_charmap_encode(PyObject *module, PyObject *const *args, Py_ssize_t nargs
     const char *errors = NULL;
     PyObject *mapping = Py_None;
 
-    if (!_PyArg_CheckPositional("charmap_encode", nargs, 1, 3)) {
+    if (nargs < 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 1 argument, got %zd",
+            "charmap_encode", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 3) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 3 arguments, got %zd",
+            "charmap_encode", nargs);
         goto exit;
     }
     if (!PyUnicode_Check(args[0])) {
@@ -2476,7 +2884,19 @@ _codecs_mbcs_encode(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *str;
     const char *errors = NULL;
 
-    if (!_PyArg_CheckPositional("mbcs_encode", nargs, 1, 2)) {
+    if (nargs < 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 1 argument, got %zd",
+            "mbcs_encode", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 2 arguments, got %zd",
+            "mbcs_encode", nargs);
         goto exit;
     }
     if (!PyUnicode_Check(args[0])) {
@@ -2534,7 +2954,19 @@ _codecs_oem_encode(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *str;
     const char *errors = NULL;
 
-    if (!_PyArg_CheckPositional("oem_encode", nargs, 1, 2)) {
+    if (nargs < 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 1 argument, got %zd",
+            "oem_encode", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 2 arguments, got %zd",
+            "oem_encode", nargs);
         goto exit;
     }
     if (!PyUnicode_Check(args[0])) {
@@ -2594,7 +3026,19 @@ _codecs_code_page_encode(PyObject *module, PyObject *const *args, Py_ssize_t nar
     PyObject *str;
     const char *errors = NULL;
 
-    if (!_PyArg_CheckPositional("code_page_encode", nargs, 2, 3)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 2 arguments, got %zd",
+            "code_page_encode", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 3) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 3 arguments, got %zd",
+            "code_page_encode", nargs);
         goto exit;
     }
     code_page = PyLong_AsInt(args[0]);
@@ -2660,7 +3104,19 @@ _codecs_register_error(PyObject *module, PyObject *const *args, Py_ssize_t nargs
     const char *errors;
     PyObject *handler;
 
-    if (!_PyArg_CheckPositional("register_error", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "register_error", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "register_error", nargs);
         goto exit;
     }
     if (!PyUnicode_Check(args[0])) {
@@ -2746,4 +3202,4 @@ exit:
 #ifndef _CODECS_CODE_PAGE_ENCODE_METHODDEF
     #define _CODECS_CODE_PAGE_ENCODE_METHODDEF
 #endif /* !defined(_CODECS_CODE_PAGE_ENCODE_METHODDEF) */
-/*[clinic end generated code: output=e50d5fdf65bd45fa input=a9049054013a1b77]*/
+/*[clinic end generated code: output=056a7c2b35245af1 input=a9049054013a1b77]*/

--- a/Modules/clinic/_collectionsmodule.c.h
+++ b/Modules/clinic/_collectionsmodule.c.h
@@ -8,7 +8,7 @@ preserve
 #endif
 #include "pycore_abstract.h"      // _PyNumber_Index()
 #include "pycore_critical_section.h"// Py_BEGIN_CRITICAL_SECTION()
-#include "pycore_modsupport.h"    // _PyArg_CheckPositional()
+#include "pycore_modsupport.h"    // _PyArg_UnpackKeywords()
 
 PyDoc_STRVAR(deque_pop__doc__,
 "pop($self, /)\n"
@@ -244,7 +244,19 @@ deque_rotate(dequeobject *deque, PyObject *const *args, Py_ssize_t nargs)
     PyObject *return_value = NULL;
     Py_ssize_t n = 1;
 
-    if (!_PyArg_CheckPositional("rotate", nargs, 0, 1)) {
+    if (nargs < 0) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 0 arguments, got %zd",
+            "rotate", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 1 argument, got %zd",
+            "rotate", nargs);
         goto exit;
     }
     if (nargs < 1) {
@@ -342,7 +354,19 @@ deque_index(dequeobject *deque, PyObject *const *args, Py_ssize_t nargs)
     Py_ssize_t start = 0;
     Py_ssize_t stop = Py_SIZE(deque);
 
-    if (!_PyArg_CheckPositional("index", nargs, 1, 3)) {
+    if (nargs < 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 1 argument, got %zd",
+            "index", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 3) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 3 arguments, got %zd",
+            "index", nargs);
         goto exit;
     }
     v = args[0];
@@ -386,7 +410,19 @@ deque_insert(dequeobject *deque, PyObject *const *args, Py_ssize_t nargs)
     Py_ssize_t index;
     PyObject *value;
 
-    if (!_PyArg_CheckPositional("insert", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "insert", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "insert", nargs);
         goto exit;
     }
     {
@@ -582,7 +618,19 @@ _collections__count_elements(PyObject *module, PyObject *const *args, Py_ssize_t
     PyObject *mapping;
     PyObject *iterable;
 
-    if (!_PyArg_CheckPositional("_count_elements", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "_count_elements", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "_count_elements", nargs);
         goto exit;
     }
     mapping = args[0];
@@ -608,7 +656,19 @@ tuplegetter_new(PyTypeObject *type, PyObject *args, PyObject *kwargs)
         !_PyArg_NoKeywords("_tuplegetter", kwargs)) {
         goto exit;
     }
-    if (!_PyArg_CheckPositional("_tuplegetter", PyTuple_GET_SIZE(args), 2, 2)) {
+    if (PyTuple_GET_SIZE(args) < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "_tuplegetter", PyTuple_GET_SIZE(args));
+        goto exit;
+    }
+
+    if (PyTuple_GET_SIZE(args) != 0 && PyTuple_GET_SIZE(args) > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "_tuplegetter", PyTuple_GET_SIZE(args));
         goto exit;
     }
     {
@@ -629,4 +689,4 @@ tuplegetter_new(PyTypeObject *type, PyObject *args, PyObject *kwargs)
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=64c32b16df7be07a input=a9049054013a1b77]*/
+/*[clinic end generated code: output=1177cad9397f75c6 input=a9049054013a1b77]*/

--- a/Modules/clinic/_cursesmodule.c.h
+++ b/Modules/clinic/_cursesmodule.c.h
@@ -6,7 +6,7 @@ preserve
 #  include "pycore_gc.h"          // PyGC_Head
 #  include "pycore_runtime.h"     // _Py_ID()
 #endif
-#include "pycore_modsupport.h"    // _PyArg_CheckPositional()
+#include "pycore_modsupport.h"    // _PyArg_BadArgument()
 
 PyDoc_STRVAR(_curses_window_addch__doc__,
 "addch([y, x,] ch, [attr=_curses.A_NORMAL])\n"
@@ -251,7 +251,19 @@ _curses_window_bkgd(PyCursesWindowObject *self, PyObject *const *args, Py_ssize_
     PyObject *ch;
     long attr = A_NORMAL;
 
-    if (!_PyArg_CheckPositional("bkgd", nargs, 1, 2)) {
+    if (nargs < 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 1 argument, got %zd",
+            "bkgd", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 2 arguments, got %zd",
+            "bkgd", nargs);
         goto exit;
     }
     ch = args[0];
@@ -378,7 +390,19 @@ _curses_window_bkgdset(PyCursesWindowObject *self, PyObject *const *args, Py_ssi
     PyObject *ch;
     long attr = A_NORMAL;
 
-    if (!_PyArg_CheckPositional("bkgdset", nargs, 1, 2)) {
+    if (nargs < 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 1 argument, got %zd",
+            "bkgdset", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 2 arguments, got %zd",
+            "bkgdset", nargs);
         goto exit;
     }
     ch = args[0];
@@ -449,7 +473,19 @@ _curses_window_border(PyCursesWindowObject *self, PyObject *const *args, Py_ssiz
     PyObject *bl = NULL;
     PyObject *br = NULL;
 
-    if (!_PyArg_CheckPositional("border", nargs, 0, 8)) {
+    if (nargs < 0) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 0 arguments, got %zd",
+            "border", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 8) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 8 arguments, got %zd",
+            "border", nargs);
         goto exit;
     }
     if (nargs < 1) {
@@ -661,7 +697,19 @@ _curses_window_echochar(PyCursesWindowObject *self, PyObject *const *args, Py_ss
     PyObject *ch;
     long attr = A_NORMAL;
 
-    if (!_PyArg_CheckPositional("echochar", nargs, 1, 2)) {
+    if (nargs < 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 1 argument, got %zd",
+            "echochar", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 2 arguments, got %zd",
+            "echochar", nargs);
         goto exit;
     }
     ch = args[0];
@@ -705,7 +753,19 @@ _curses_window_enclose(PyCursesWindowObject *self, PyObject *const *args, Py_ssi
     int y;
     int x;
 
-    if (!_PyArg_CheckPositional("enclose", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "enclose", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "enclose", nargs);
         goto exit;
     }
     y = PyLong_AsInt(args[0]);
@@ -1505,7 +1565,19 @@ _curses_window_redrawln(PyCursesWindowObject *self, PyObject *const *args, Py_ss
     int beg;
     int num;
 
-    if (!_PyArg_CheckPositional("redrawln", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "redrawln", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "redrawln", nargs);
         goto exit;
     }
     beg = PyLong_AsInt(args[0]);
@@ -1604,7 +1676,19 @@ _curses_window_setscrreg(PyCursesWindowObject *self, PyObject *const *args, Py_s
     int top;
     int bottom;
 
-    if (!_PyArg_CheckPositional("setscrreg", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "setscrreg", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "setscrreg", nargs);
         goto exit;
     }
     top = PyLong_AsInt(args[0]);
@@ -1935,7 +2019,19 @@ _curses_cbreak(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *return_value = NULL;
     int flag = 1;
 
-    if (!_PyArg_CheckPositional("cbreak", nargs, 0, 1)) {
+    if (nargs < 0) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 0 arguments, got %zd",
+            "cbreak", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 1 argument, got %zd",
+            "cbreak", nargs);
         goto exit;
     }
     if (nargs < 1) {
@@ -2171,7 +2267,19 @@ _curses_echo(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *return_value = NULL;
     int flag = 1;
 
-    if (!_PyArg_CheckPositional("echo", nargs, 0, 1)) {
+    if (nargs < 0) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 0 arguments, got %zd",
+            "echo", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 1 argument, got %zd",
+            "echo", nargs);
         goto exit;
     }
     if (nargs < 1) {
@@ -2341,7 +2449,19 @@ _curses_ungetmouse(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     int z;
     unsigned long bstate;
 
-    if (!_PyArg_CheckPositional("ungetmouse", nargs, 5, 5)) {
+    if (nargs < 5) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 5 arguments, got %zd",
+            "ungetmouse", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 5) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 5 arguments, got %zd",
+            "ungetmouse", nargs);
         goto exit;
     }
     {
@@ -2572,7 +2692,19 @@ _curses_init_color(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     short g;
     short b;
 
-    if (!_PyArg_CheckPositional("init_color", nargs, 4, 4)) {
+    if (nargs < 4) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 4 arguments, got %zd",
+            "init_color", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 4) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 4 arguments, got %zd",
+            "init_color", nargs);
         goto exit;
     }
     if (!color_converter(args[0], &color_number)) {
@@ -2623,7 +2755,19 @@ _curses_init_pair(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     int fg;
     int bg;
 
-    if (!_PyArg_CheckPositional("init_pair", nargs, 3, 3)) {
+    if (nargs < 3) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 3 arguments, got %zd",
+            "init_pair", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 3) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 3 arguments, got %zd",
+            "init_pair", nargs);
         goto exit;
     }
     if (!pair_converter(args[0], &pair_number)) {
@@ -2954,7 +3098,19 @@ _curses_is_term_resized(PyObject *module, PyObject *const *args, Py_ssize_t narg
     int nlines;
     int ncols;
 
-    if (!_PyArg_CheckPositional("is_term_resized", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "is_term_resized", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "is_term_resized", nargs);
         goto exit;
     }
     nlines = PyLong_AsInt(args[0]);
@@ -3211,7 +3367,19 @@ _curses_newpad(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     int nlines;
     int ncols;
 
-    if (!_PyArg_CheckPositional("newpad", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "newpad", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "newpad", nargs);
         goto exit;
     }
     nlines = PyLong_AsInt(args[0]);
@@ -3307,7 +3475,19 @@ _curses_nl(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *return_value = NULL;
     int flag = 1;
 
-    if (!_PyArg_CheckPositional("nl", nargs, 0, 1)) {
+    if (nargs < 0) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 0 arguments, got %zd",
+            "nl", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 1 argument, got %zd",
+            "nl", nargs);
         goto exit;
     }
     if (nargs < 1) {
@@ -3539,7 +3719,19 @@ _curses_qiflush(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *return_value = NULL;
     int flag = 1;
 
-    if (!_PyArg_CheckPositional("qiflush", nargs, 0, 1)) {
+    if (nargs < 0) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 0 arguments, got %zd",
+            "qiflush", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 1 argument, got %zd",
+            "qiflush", nargs);
         goto exit;
     }
     if (nargs < 1) {
@@ -3602,7 +3794,19 @@ _curses_raw(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *return_value = NULL;
     int flag = 1;
 
-    if (!_PyArg_CheckPositional("raw", nargs, 0, 1)) {
+    if (nargs < 0) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 0 arguments, got %zd",
+            "raw", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 1 argument, got %zd",
+            "raw", nargs);
         goto exit;
     }
     if (nargs < 1) {
@@ -3702,7 +3906,19 @@ _curses_resizeterm(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     int nlines;
     int ncols;
 
-    if (!_PyArg_CheckPositional("resizeterm", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "resizeterm", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "resizeterm", nargs);
         goto exit;
     }
     nlines = PyLong_AsInt(args[0]);
@@ -3753,7 +3969,19 @@ _curses_resize_term(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     int nlines;
     int ncols;
 
-    if (!_PyArg_CheckPositional("resize_term", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "resize_term", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "resize_term", nargs);
         goto exit;
     }
     nlines = PyLong_AsInt(args[0]);
@@ -3818,7 +4046,19 @@ _curses_setsyx(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     int y;
     int x;
 
-    if (!_PyArg_CheckPositional("setsyx", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "setsyx", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "setsyx", nargs);
         goto exit;
     }
     y = PyLong_AsInt(args[0]);
@@ -4318,4 +4558,4 @@ _curses_has_extended_color_support(PyObject *module, PyObject *Py_UNUSED(ignored
 #ifndef _CURSES_USE_DEFAULT_COLORS_METHODDEF
     #define _CURSES_USE_DEFAULT_COLORS_METHODDEF
 #endif /* !defined(_CURSES_USE_DEFAULT_COLORS_METHODDEF) */
-/*[clinic end generated code: output=96887782374f070a input=a9049054013a1b77]*/
+/*[clinic end generated code: output=9692746c6f87e211 input=a9049054013a1b77]*/

--- a/Modules/clinic/_dbmmodule.c.h
+++ b/Modules/clinic/_dbmmodule.c.h
@@ -185,7 +185,19 @@ dbmopen(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     const char *flags = "r";
     int mode = 438;
 
-    if (!_PyArg_CheckPositional("open", nargs, 1, 3)) {
+    if (nargs < 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 1 argument, got %zd",
+            "open", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 3) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 3 arguments, got %zd",
+            "open", nargs);
         goto exit;
     }
     filename = args[0];
@@ -218,4 +230,4 @@ skip_optional:
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=743ce0cea116747e input=a9049054013a1b77]*/
+/*[clinic end generated code: output=64164936919b866f input=a9049054013a1b77]*/

--- a/Modules/clinic/_elementtree.c.h
+++ b/Modules/clinic/_elementtree.c.h
@@ -670,7 +670,19 @@ _elementtree_Element_insert(ElementObject *self, PyObject *const *args, Py_ssize
     Py_ssize_t index;
     PyObject *subelement;
 
-    if (!_PyArg_CheckPositional("insert", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "insert", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "insert", nargs);
         goto exit;
     }
     {
@@ -826,7 +838,19 @@ _elementtree_Element_set(ElementObject *self, PyObject *const *args, Py_ssize_t 
     PyObject *key;
     PyObject *value;
 
-    if (!_PyArg_CheckPositional("set", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "set", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "set", nargs);
         goto exit;
     }
     key = args[0];
@@ -954,7 +978,19 @@ _elementtree__set_factories(PyObject *module, PyObject *const *args, Py_ssize_t 
     PyObject *comment_factory;
     PyObject *pi_factory;
 
-    if (!_PyArg_CheckPositional("_set_factories", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "_set_factories", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "_set_factories", nargs);
         goto exit;
     }
     comment_factory = args[0];
@@ -1008,7 +1044,19 @@ _elementtree_TreeBuilder_pi(TreeBuilderObject *self, PyObject *const *args, Py_s
     PyObject *target;
     PyObject *text = Py_None;
 
-    if (!_PyArg_CheckPositional("pi", nargs, 1, 2)) {
+    if (nargs < 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 1 argument, got %zd",
+            "pi", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 2 arguments, got %zd",
+            "pi", nargs);
         goto exit;
     }
     target = args[0];
@@ -1059,7 +1107,19 @@ _elementtree_TreeBuilder_start(TreeBuilderObject *self, PyObject *const *args, P
     PyObject *tag;
     PyObject *attrs;
 
-    if (!_PyArg_CheckPositional("start", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "start", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "start", nargs);
         goto exit;
     }
     tag = args[0];
@@ -1222,7 +1282,19 @@ _elementtree_XMLParser__setevents(XMLParserObject *self, PyObject *const *args, 
     PyObject *events_queue;
     PyObject *events_to_report = Py_None;
 
-    if (!_PyArg_CheckPositional("_setevents", nargs, 1, 2)) {
+    if (nargs < 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 1 argument, got %zd",
+            "_setevents", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 2 arguments, got %zd",
+            "_setevents", nargs);
         goto exit;
     }
     events_queue = args[0];
@@ -1236,4 +1308,4 @@ skip_optional:
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=aed9f53eeb0404e0 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=8783d7fb0ca66ab8 input=a9049054013a1b77]*/

--- a/Modules/clinic/_gdbmmodule.c.h
+++ b/Modules/clinic/_gdbmmodule.c.h
@@ -2,7 +2,7 @@
 preserve
 [clinic start generated code]*/
 
-#include "pycore_modsupport.h"    // _PyArg_CheckPositional()
+#include "pycore_modsupport.h"    // _PyArg_UnpackKeywords()
 
 PyDoc_STRVAR(_gdbm_gdbm_get__doc__,
 "get($self, key, default=None, /)\n"
@@ -23,7 +23,19 @@ _gdbm_gdbm_get(gdbmobject *self, PyObject *const *args, Py_ssize_t nargs)
     PyObject *key;
     PyObject *default_value = Py_None;
 
-    if (!_PyArg_CheckPositional("get", nargs, 1, 2)) {
+    if (nargs < 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 1 argument, got %zd",
+            "get", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 2 arguments, got %zd",
+            "get", nargs);
         goto exit;
     }
     key = args[0];
@@ -58,7 +70,19 @@ _gdbm_gdbm_setdefault(gdbmobject *self, PyObject *const *args, Py_ssize_t nargs)
     PyObject *key;
     PyObject *default_value = Py_None;
 
-    if (!_PyArg_CheckPositional("setdefault", nargs, 1, 2)) {
+    if (nargs < 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 1 argument, got %zd",
+            "setdefault", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 2 arguments, got %zd",
+            "setdefault", nargs);
         goto exit;
     }
     key = args[0];
@@ -307,7 +331,19 @@ dbmopen(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     const char *flags = "r";
     int mode = 438;
 
-    if (!_PyArg_CheckPositional("open", nargs, 1, 3)) {
+    if (nargs < 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 1 argument, got %zd",
+            "open", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 3) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 3 arguments, got %zd",
+            "open", nargs);
         goto exit;
     }
     filename = args[0];
@@ -340,4 +376,4 @@ skip_optional:
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=6b4c19905ac9967d input=a9049054013a1b77]*/
+/*[clinic end generated code: output=d7acbd17fd42e312 input=a9049054013a1b77]*/

--- a/Modules/clinic/_hashopenssl.c.h
+++ b/Modules/clinic/_hashopenssl.c.h
@@ -1778,7 +1778,19 @@ _hashlib_compare_digest(PyObject *module, PyObject *const *args, Py_ssize_t narg
     PyObject *a;
     PyObject *b;
 
-    if (!_PyArg_CheckPositional("compare_digest", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "compare_digest", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "compare_digest", nargs);
         goto exit;
     }
     a = args[0];
@@ -1824,4 +1836,4 @@ exit:
 #ifndef _HASHLIB_SCRYPT_METHODDEF
     #define _HASHLIB_SCRYPT_METHODDEF
 #endif /* !defined(_HASHLIB_SCRYPT_METHODDEF) */
-/*[clinic end generated code: output=b7eddeb3d6ccdeec input=a9049054013a1b77]*/
+/*[clinic end generated code: output=6d6154780e0a7463 input=a9049054013a1b77]*/

--- a/Modules/clinic/_heapqmodule.c.h
+++ b/Modules/clinic/_heapqmodule.c.h
@@ -2,7 +2,7 @@
 preserve
 [clinic start generated code]*/
 
-#include "pycore_modsupport.h"    // _PyArg_CheckPositional()
+#include "pycore_modsupport.h"    // _PyArg_BadArgument()
 
 PyDoc_STRVAR(_heapq_heappush__doc__,
 "heappush($module, heap, item, /)\n"
@@ -23,7 +23,19 @@ _heapq_heappush(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *heap;
     PyObject *item;
 
-    if (!_PyArg_CheckPositional("heappush", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "heappush", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "heappush", nargs);
         goto exit;
     }
     if (!PyList_Check(args[0])) {
@@ -94,7 +106,19 @@ _heapq_heapreplace(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *heap;
     PyObject *item;
 
-    if (!_PyArg_CheckPositional("heapreplace", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "heapreplace", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "heapreplace", nargs);
         goto exit;
     }
     if (!PyList_Check(args[0])) {
@@ -131,7 +155,19 @@ _heapq_heappushpop(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *heap;
     PyObject *item;
 
-    if (!_PyArg_CheckPositional("heappushpop", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "heappushpop", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "heappushpop", nargs);
         goto exit;
     }
     if (!PyList_Check(args[0])) {
@@ -224,7 +260,19 @@ _heapq__heapreplace_max(PyObject *module, PyObject *const *args, Py_ssize_t narg
     PyObject *heap;
     PyObject *item;
 
-    if (!_PyArg_CheckPositional("_heapreplace_max", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "_heapreplace_max", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "_heapreplace_max", nargs);
         goto exit;
     }
     if (!PyList_Check(args[0])) {
@@ -267,4 +315,4 @@ _heapq__heapify_max(PyObject *module, PyObject *arg)
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=05f2afdf3bc54c9d input=a9049054013a1b77]*/
+/*[clinic end generated code: output=d00077081225bcc8 input=a9049054013a1b77]*/

--- a/Modules/clinic/_localemodule.c.h
+++ b/Modules/clinic/_localemodule.c.h
@@ -2,7 +2,7 @@
 preserve
 [clinic start generated code]*/
 
-#include "pycore_modsupport.h"    // _PyArg_CheckPositional()
+#include "pycore_modsupport.h"    // _PyArg_BadArgument()
 
 PyDoc_STRVAR(_locale_setlocale__doc__,
 "setlocale($module, category, locale=<unrepresentable>, /)\n"
@@ -23,7 +23,19 @@ _locale_setlocale(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     int category;
     const char *locale = NULL;
 
-    if (!_PyArg_CheckPositional("setlocale", nargs, 1, 2)) {
+    if (nargs < 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 1 argument, got %zd",
+            "setlocale", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 2 arguments, got %zd",
+            "setlocale", nargs);
         goto exit;
     }
     category = PyLong_AsInt(args[0]);
@@ -97,7 +109,19 @@ _locale_strcoll(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *os1;
     PyObject *os2;
 
-    if (!_PyArg_CheckPositional("strcoll", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "strcoll", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "strcoll", nargs);
         goto exit;
     }
     if (!PyUnicode_Check(args[0])) {
@@ -270,7 +294,19 @@ _locale_dgettext(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     const char *domain;
     const char *in;
 
-    if (!_PyArg_CheckPositional("dgettext", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "dgettext", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "dgettext", nargs);
         goto exit;
     }
     if (args[0] == Py_None) {
@@ -335,7 +371,19 @@ _locale_dcgettext(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     const char *msgid;
     int category;
 
-    if (!_PyArg_CheckPositional("dcgettext", nargs, 3, 3)) {
+    if (nargs < 3) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 3 arguments, got %zd",
+            "dcgettext", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 3) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 3 arguments, got %zd",
+            "dcgettext", nargs);
         goto exit;
     }
     if (args[0] == Py_None) {
@@ -449,7 +497,19 @@ _locale_bindtextdomain(PyObject *module, PyObject *const *args, Py_ssize_t nargs
     const char *domain;
     PyObject *dirname_obj;
 
-    if (!_PyArg_CheckPositional("bindtextdomain", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "bindtextdomain", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "bindtextdomain", nargs);
         goto exit;
     }
     if (!PyUnicode_Check(args[0])) {
@@ -496,7 +556,19 @@ _locale_bind_textdomain_codeset(PyObject *module, PyObject *const *args, Py_ssiz
     const char *domain;
     const char *codeset;
 
-    if (!_PyArg_CheckPositional("bind_textdomain_codeset", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "bind_textdomain_codeset", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "bind_textdomain_codeset", nargs);
         goto exit;
     }
     if (!PyUnicode_Check(args[0])) {
@@ -595,4 +667,4 @@ _locale_getencoding(PyObject *module, PyObject *Py_UNUSED(ignored))
 #ifndef _LOCALE_BIND_TEXTDOMAIN_CODESET_METHODDEF
     #define _LOCALE_BIND_TEXTDOMAIN_CODESET_METHODDEF
 #endif /* !defined(_LOCALE_BIND_TEXTDOMAIN_CODESET_METHODDEF) */
-/*[clinic end generated code: output=034a3c219466d207 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=c61136a1f13324f2 input=a9049054013a1b77]*/

--- a/Modules/clinic/_lzmamodule.c.h
+++ b/Modules/clinic/_lzmamodule.c.h
@@ -308,7 +308,19 @@ _lzma__decode_filter_properties(PyObject *module, PyObject *const *args, Py_ssiz
     lzma_vli filter_id;
     Py_buffer encoded_props = {NULL, NULL};
 
-    if (!_PyArg_CheckPositional("_decode_filter_properties", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "_decode_filter_properties", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "_decode_filter_properties", nargs);
         goto exit;
     }
     if (!lzma_vli_converter(args[0], &filter_id)) {
@@ -327,4 +339,4 @@ exit:
 
     return return_value;
 }
-/*[clinic end generated code: output=5e79c05ace76dc96 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=990872aeeed8bbcc input=a9049054013a1b77]*/

--- a/Modules/clinic/_operator.c.h
+++ b/Modules/clinic/_operator.c.h
@@ -3,7 +3,6 @@ preserve
 [clinic start generated code]*/
 
 #include "pycore_abstract.h"      // _PyNumber_Index()
-#include "pycore_modsupport.h"    // _PyArg_CheckPositional()
 
 PyDoc_STRVAR(_operator_truth__doc__,
 "truth($module, a, /)\n"
@@ -52,7 +51,19 @@ _operator_add(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *a;
     PyObject *b;
 
-    if (!_PyArg_CheckPositional("add", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "add", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "add", nargs);
         goto exit;
     }
     a = args[0];
@@ -82,7 +93,19 @@ _operator_sub(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *a;
     PyObject *b;
 
-    if (!_PyArg_CheckPositional("sub", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "sub", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "sub", nargs);
         goto exit;
     }
     a = args[0];
@@ -112,7 +135,19 @@ _operator_mul(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *a;
     PyObject *b;
 
-    if (!_PyArg_CheckPositional("mul", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "mul", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "mul", nargs);
         goto exit;
     }
     a = args[0];
@@ -142,7 +177,19 @@ _operator_matmul(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *a;
     PyObject *b;
 
-    if (!_PyArg_CheckPositional("matmul", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "matmul", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "matmul", nargs);
         goto exit;
     }
     a = args[0];
@@ -172,7 +219,19 @@ _operator_floordiv(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *a;
     PyObject *b;
 
-    if (!_PyArg_CheckPositional("floordiv", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "floordiv", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "floordiv", nargs);
         goto exit;
     }
     a = args[0];
@@ -202,7 +261,19 @@ _operator_truediv(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *a;
     PyObject *b;
 
-    if (!_PyArg_CheckPositional("truediv", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "truediv", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "truediv", nargs);
         goto exit;
     }
     a = args[0];
@@ -232,7 +303,19 @@ _operator_mod(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *a;
     PyObject *b;
 
-    if (!_PyArg_CheckPositional("mod", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "mod", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "mod", nargs);
         goto exit;
     }
     a = args[0];
@@ -307,7 +390,19 @@ _operator_lshift(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *a;
     PyObject *b;
 
-    if (!_PyArg_CheckPositional("lshift", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "lshift", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "lshift", nargs);
         goto exit;
     }
     a = args[0];
@@ -337,7 +432,19 @@ _operator_rshift(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *a;
     PyObject *b;
 
-    if (!_PyArg_CheckPositional("rshift", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "rshift", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "rshift", nargs);
         goto exit;
     }
     a = args[0];
@@ -395,7 +502,19 @@ _operator_and_(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *a;
     PyObject *b;
 
-    if (!_PyArg_CheckPositional("and_", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "and_", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "and_", nargs);
         goto exit;
     }
     a = args[0];
@@ -425,7 +544,19 @@ _operator_xor(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *a;
     PyObject *b;
 
-    if (!_PyArg_CheckPositional("xor", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "xor", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "xor", nargs);
         goto exit;
     }
     a = args[0];
@@ -455,7 +586,19 @@ _operator_or_(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *a;
     PyObject *b;
 
-    if (!_PyArg_CheckPositional("or_", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "or_", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "or_", nargs);
         goto exit;
     }
     a = args[0];
@@ -485,7 +628,19 @@ _operator_iadd(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *a;
     PyObject *b;
 
-    if (!_PyArg_CheckPositional("iadd", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "iadd", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "iadd", nargs);
         goto exit;
     }
     a = args[0];
@@ -515,7 +670,19 @@ _operator_isub(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *a;
     PyObject *b;
 
-    if (!_PyArg_CheckPositional("isub", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "isub", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "isub", nargs);
         goto exit;
     }
     a = args[0];
@@ -545,7 +712,19 @@ _operator_imul(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *a;
     PyObject *b;
 
-    if (!_PyArg_CheckPositional("imul", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "imul", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "imul", nargs);
         goto exit;
     }
     a = args[0];
@@ -575,7 +754,19 @@ _operator_imatmul(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *a;
     PyObject *b;
 
-    if (!_PyArg_CheckPositional("imatmul", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "imatmul", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "imatmul", nargs);
         goto exit;
     }
     a = args[0];
@@ -605,7 +796,19 @@ _operator_ifloordiv(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *a;
     PyObject *b;
 
-    if (!_PyArg_CheckPositional("ifloordiv", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "ifloordiv", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "ifloordiv", nargs);
         goto exit;
     }
     a = args[0];
@@ -635,7 +838,19 @@ _operator_itruediv(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *a;
     PyObject *b;
 
-    if (!_PyArg_CheckPositional("itruediv", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "itruediv", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "itruediv", nargs);
         goto exit;
     }
     a = args[0];
@@ -665,7 +880,19 @@ _operator_imod(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *a;
     PyObject *b;
 
-    if (!_PyArg_CheckPositional("imod", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "imod", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "imod", nargs);
         goto exit;
     }
     a = args[0];
@@ -695,7 +922,19 @@ _operator_ilshift(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *a;
     PyObject *b;
 
-    if (!_PyArg_CheckPositional("ilshift", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "ilshift", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "ilshift", nargs);
         goto exit;
     }
     a = args[0];
@@ -725,7 +964,19 @@ _operator_irshift(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *a;
     PyObject *b;
 
-    if (!_PyArg_CheckPositional("irshift", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "irshift", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "irshift", nargs);
         goto exit;
     }
     a = args[0];
@@ -755,7 +1006,19 @@ _operator_iand(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *a;
     PyObject *b;
 
-    if (!_PyArg_CheckPositional("iand", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "iand", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "iand", nargs);
         goto exit;
     }
     a = args[0];
@@ -785,7 +1048,19 @@ _operator_ixor(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *a;
     PyObject *b;
 
-    if (!_PyArg_CheckPositional("ixor", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "ixor", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "ixor", nargs);
         goto exit;
     }
     a = args[0];
@@ -815,7 +1090,19 @@ _operator_ior(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *a;
     PyObject *b;
 
-    if (!_PyArg_CheckPositional("ior", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "ior", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "ior", nargs);
         goto exit;
     }
     a = args[0];
@@ -845,7 +1132,19 @@ _operator_concat(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *a;
     PyObject *b;
 
-    if (!_PyArg_CheckPositional("concat", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "concat", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "concat", nargs);
         goto exit;
     }
     a = args[0];
@@ -875,7 +1174,19 @@ _operator_iconcat(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *a;
     PyObject *b;
 
-    if (!_PyArg_CheckPositional("iconcat", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "iconcat", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "iconcat", nargs);
         goto exit;
     }
     a = args[0];
@@ -906,7 +1217,19 @@ _operator_contains(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *b;
     int _return_value;
 
-    if (!_PyArg_CheckPositional("contains", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "contains", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "contains", nargs);
         goto exit;
     }
     a = args[0];
@@ -941,7 +1264,19 @@ _operator_indexOf(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *b;
     Py_ssize_t _return_value;
 
-    if (!_PyArg_CheckPositional("indexOf", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "indexOf", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "indexOf", nargs);
         goto exit;
     }
     a = args[0];
@@ -976,7 +1311,19 @@ _operator_countOf(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *b;
     Py_ssize_t _return_value;
 
-    if (!_PyArg_CheckPositional("countOf", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "countOf", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "countOf", nargs);
         goto exit;
     }
     a = args[0];
@@ -1010,7 +1357,19 @@ _operator_getitem(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *a;
     PyObject *b;
 
-    if (!_PyArg_CheckPositional("getitem", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "getitem", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "getitem", nargs);
         goto exit;
     }
     a = args[0];
@@ -1042,7 +1401,19 @@ _operator_setitem(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *b;
     PyObject *c;
 
-    if (!_PyArg_CheckPositional("setitem", nargs, 3, 3)) {
+    if (nargs < 3) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 3 arguments, got %zd",
+            "setitem", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 3) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 3 arguments, got %zd",
+            "setitem", nargs);
         goto exit;
     }
     a = args[0];
@@ -1073,7 +1444,19 @@ _operator_delitem(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *a;
     PyObject *b;
 
-    if (!_PyArg_CheckPositional("delitem", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "delitem", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "delitem", nargs);
         goto exit;
     }
     a = args[0];
@@ -1103,7 +1486,19 @@ _operator_eq(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *a;
     PyObject *b;
 
-    if (!_PyArg_CheckPositional("eq", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "eq", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "eq", nargs);
         goto exit;
     }
     a = args[0];
@@ -1133,7 +1528,19 @@ _operator_ne(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *a;
     PyObject *b;
 
-    if (!_PyArg_CheckPositional("ne", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "ne", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "ne", nargs);
         goto exit;
     }
     a = args[0];
@@ -1163,7 +1570,19 @@ _operator_lt(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *a;
     PyObject *b;
 
-    if (!_PyArg_CheckPositional("lt", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "lt", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "lt", nargs);
         goto exit;
     }
     a = args[0];
@@ -1193,7 +1612,19 @@ _operator_le(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *a;
     PyObject *b;
 
-    if (!_PyArg_CheckPositional("le", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "le", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "le", nargs);
         goto exit;
     }
     a = args[0];
@@ -1223,7 +1654,19 @@ _operator_gt(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *a;
     PyObject *b;
 
-    if (!_PyArg_CheckPositional("gt", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "gt", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "gt", nargs);
         goto exit;
     }
     a = args[0];
@@ -1253,7 +1696,19 @@ _operator_ge(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *a;
     PyObject *b;
 
-    if (!_PyArg_CheckPositional("ge", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "ge", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "ge", nargs);
         goto exit;
     }
     a = args[0];
@@ -1283,7 +1738,19 @@ _operator_pow(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *a;
     PyObject *b;
 
-    if (!_PyArg_CheckPositional("pow", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "pow", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "pow", nargs);
         goto exit;
     }
     a = args[0];
@@ -1313,7 +1780,19 @@ _operator_ipow(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *a;
     PyObject *b;
 
-    if (!_PyArg_CheckPositional("ipow", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "ipow", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "ipow", nargs);
         goto exit;
     }
     a = args[0];
@@ -1352,7 +1831,19 @@ _operator_is_(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *a;
     PyObject *b;
 
-    if (!_PyArg_CheckPositional("is_", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "is_", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "is_", nargs);
         goto exit;
     }
     a = args[0];
@@ -1382,7 +1873,19 @@ _operator_is_not(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *a;
     PyObject *b;
 
-    if (!_PyArg_CheckPositional("is_not", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "is_not", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "is_not", nargs);
         goto exit;
     }
     a = args[0];
@@ -1420,7 +1923,19 @@ _operator_length_hint(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     Py_ssize_t default_value = 0;
     Py_ssize_t _return_value;
 
-    if (!_PyArg_CheckPositional("length_hint", nargs, 1, 2)) {
+    if (nargs < 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 1 argument, got %zd",
+            "length_hint", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 2 arguments, got %zd",
+            "length_hint", nargs);
         goto exit;
     }
     obj = args[0];
@@ -1479,7 +1994,19 @@ _operator__compare_digest(PyObject *module, PyObject *const *args, Py_ssize_t na
     PyObject *a;
     PyObject *b;
 
-    if (!_PyArg_CheckPositional("_compare_digest", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "_compare_digest", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "_compare_digest", nargs);
         goto exit;
     }
     a = args[0];
@@ -1489,4 +2016,4 @@ _operator__compare_digest(PyObject *module, PyObject *const *args, Py_ssize_t na
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=ddbba2cd943571eb input=a9049054013a1b77]*/
+/*[clinic end generated code: output=aaf3389c57b6d18a input=a9049054013a1b77]*/

--- a/Modules/clinic/_posixsubprocess.c.h
+++ b/Modules/clinic/_posixsubprocess.c.h
@@ -2,7 +2,7 @@
 preserve
 [clinic start generated code]*/
 
-#include "pycore_modsupport.h"    // _PyArg_CheckPositional()
+#include "pycore_modsupport.h"    // _PyArg_BadArgument()
 
 PyDoc_STRVAR(subprocess_fork_exec__doc__,
 "fork_exec($module, args, executable_list, close_fds, pass_fds, cwd,\n"
@@ -78,7 +78,19 @@ subprocess_fork_exec(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *preexec_fn;
     int allow_vfork;
 
-    if (!_PyArg_CheckPositional("fork_exec", nargs, 23, 23)) {
+    if (nargs < 23) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 23 arguments, got %zd",
+            "fork_exec", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 23) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 23 arguments, got %zd",
+            "fork_exec", nargs);
         goto exit;
     }
     process_args = args[0];
@@ -155,4 +167,4 @@ subprocess_fork_exec(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=48555f5965a871be input=a9049054013a1b77]*/
+/*[clinic end generated code: output=7f67b1af64fc99c8 input=a9049054013a1b77]*/

--- a/Modules/clinic/_randommodule.c.h
+++ b/Modules/clinic/_randommodule.c.h
@@ -3,7 +3,6 @@ preserve
 [clinic start generated code]*/
 
 #include "pycore_critical_section.h"// Py_BEGIN_CRITICAL_SECTION()
-#include "pycore_modsupport.h"    // _PyArg_CheckPositional()
 
 PyDoc_STRVAR(_random_Random_random__doc__,
 "random($self, /)\n"
@@ -50,7 +49,19 @@ _random_Random_seed(RandomObject *self, PyObject *const *args, Py_ssize_t nargs)
     PyObject *return_value = NULL;
     PyObject *n = Py_None;
 
-    if (!_PyArg_CheckPositional("seed", nargs, 0, 1)) {
+    if (nargs < 0) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 0 arguments, got %zd",
+            "seed", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 1 argument, got %zd",
+            "seed", nargs);
         goto exit;
     }
     if (nargs < 1) {
@@ -143,4 +154,4 @@ _random_Random_getrandbits(RandomObject *self, PyObject *arg)
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=bf49ece1d341b1b6 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=d4123284b77ffb26 input=a9049054013a1b77]*/

--- a/Modules/clinic/_ssl.c.h
+++ b/Modules/clinic/_ssl.c.h
@@ -7,7 +7,7 @@ preserve
 #  include "pycore_runtime.h"     // _Py_ID()
 #endif
 #include "pycore_abstract.h"      // _PyNumber_Index()
-#include "pycore_modsupport.h"    // _PyArg_CheckPositional()
+#include "pycore_modsupport.h"    // _PyArg_BadArgument()
 
 PyDoc_STRVAR(_ssl__SSLSocket_do_handshake__doc__,
 "do_handshake($self, /)\n"
@@ -78,7 +78,19 @@ _ssl__SSLSocket_getpeercert(PySSLSocket *self, PyObject *const *args, Py_ssize_t
     PyObject *return_value = NULL;
     int binary_mode = 0;
 
-    if (!_PyArg_CheckPositional("getpeercert", nargs, 0, 1)) {
+    if (nargs < 0) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 0 arguments, got %zd",
+            "getpeercert", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 1 argument, got %zd",
+            "getpeercert", nargs);
         goto exit;
     }
     if (nargs < 1) {
@@ -439,7 +451,19 @@ _ssl__SSLContext(PyTypeObject *type, PyObject *args, PyObject *kwargs)
         !_PyArg_NoKeywords("_SSLContext", kwargs)) {
         goto exit;
     }
-    if (!_PyArg_CheckPositional("_SSLContext", PyTuple_GET_SIZE(args), 1, 1)) {
+    if (PyTuple_GET_SIZE(args) < 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 1 argument, got %zd",
+            "_SSLContext", PyTuple_GET_SIZE(args));
+        goto exit;
+    }
+
+    if (PyTuple_GET_SIZE(args) != 0 && PyTuple_GET_SIZE(args) > 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 1 argument, got %zd",
+            "_SSLContext", PyTuple_GET_SIZE(args));
         goto exit;
     }
     proto_version = PyLong_AsInt(PyTuple_GET_ITEM(args, 0));
@@ -1195,7 +1219,19 @@ _ssl_MemoryBIO_read(PySSLMemoryBIO *self, PyObject *const *args, Py_ssize_t narg
     PyObject *return_value = NULL;
     int len = -1;
 
-    if (!_PyArg_CheckPositional("read", nargs, 0, 1)) {
+    if (nargs < 0) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 0 arguments, got %zd",
+            "read", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 1 argument, got %zd",
+            "read", nargs);
         goto exit;
     }
     if (nargs < 1) {
@@ -1288,7 +1324,19 @@ _ssl_RAND_add(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     Py_buffer view = {NULL, NULL};
     double entropy;
 
-    if (!_PyArg_CheckPositional("RAND_add", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "RAND_add", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "RAND_add", nargs);
         goto exit;
     }
     if (PyUnicode_Check(args[0])) {
@@ -1664,4 +1712,4 @@ exit:
 #ifndef _SSL_ENUM_CRLS_METHODDEF
     #define _SSL_ENUM_CRLS_METHODDEF
 #endif /* !defined(_SSL_ENUM_CRLS_METHODDEF) */
-/*[clinic end generated code: output=fd1c3378fbba5240 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=e26c084df9258e9c input=a9049054013a1b77]*/

--- a/Modules/clinic/_statisticsmodule.c.h
+++ b/Modules/clinic/_statisticsmodule.c.h
@@ -2,8 +2,6 @@
 preserve
 [clinic start generated code]*/
 
-#include "pycore_modsupport.h"    // _PyArg_CheckPositional()
-
 PyDoc_STRVAR(_statistics__normal_dist_inv_cdf__doc__,
 "_normal_dist_inv_cdf($module, p, mu, sigma, /)\n"
 "--\n"
@@ -25,7 +23,19 @@ _statistics__normal_dist_inv_cdf(PyObject *module, PyObject *const *args, Py_ssi
     double sigma;
     double _return_value;
 
-    if (!_PyArg_CheckPositional("_normal_dist_inv_cdf", nargs, 3, 3)) {
+    if (nargs < 3) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 3 arguments, got %zd",
+            "_normal_dist_inv_cdf", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 3) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 3 arguments, got %zd",
+            "_normal_dist_inv_cdf", nargs);
         goto exit;
     }
     if (PyFloat_CheckExact(args[0])) {
@@ -67,4 +77,4 @@ _statistics__normal_dist_inv_cdf(PyObject *module, PyObject *const *args, Py_ssi
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=e7cead17f9f3e19f input=a9049054013a1b77]*/
+/*[clinic end generated code: output=ce13934ae01e4f59 input=a9049054013a1b77]*/

--- a/Modules/clinic/_struct.c.h
+++ b/Modules/clinic/_struct.c.h
@@ -283,7 +283,19 @@ unpack(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyStructObject *s_object = NULL;
     Py_buffer buffer = {NULL, NULL};
 
-    if (!_PyArg_CheckPositional("unpack", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "unpack", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "unpack", nargs);
         goto exit;
     }
     if (!cache_struct_converter(module, args[0], &s_object)) {
@@ -421,7 +433,19 @@ iter_unpack(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyStructObject *s_object = NULL;
     PyObject *buffer;
 
-    if (!_PyArg_CheckPositional("iter_unpack", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "iter_unpack", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "iter_unpack", nargs);
         goto exit;
     }
     if (!cache_struct_converter(module, args[0], &s_object)) {
@@ -436,4 +460,4 @@ exit:
 
     return return_value;
 }
-/*[clinic end generated code: output=67bd299e5d72fee0 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=650985a084c91ef2 input=a9049054013a1b77]*/

--- a/Modules/clinic/_suggestions.c.h
+++ b/Modules/clinic/_suggestions.c.h
@@ -2,7 +2,7 @@
 preserve
 [clinic start generated code]*/
 
-#include "pycore_modsupport.h"    // _PyArg_CheckPositional()
+#include "pycore_modsupport.h"    // _PyArg_BadArgument()
 
 PyDoc_STRVAR(_suggestions__generate_suggestions__doc__,
 "_generate_suggestions($module, candidates, item, /)\n"
@@ -24,7 +24,19 @@ _suggestions__generate_suggestions(PyObject *module, PyObject *const *args, Py_s
     PyObject *candidates;
     PyObject *item;
 
-    if (!_PyArg_CheckPositional("_generate_suggestions", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "_generate_suggestions", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "_generate_suggestions", nargs);
         goto exit;
     }
     candidates = args[0];
@@ -38,4 +50,4 @@ _suggestions__generate_suggestions(PyObject *module, PyObject *const *args, Py_s
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=1d8e963cdae30b13 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=fd15494b20682645 input=a9049054013a1b77]*/

--- a/Modules/clinic/_testclinic.c.h
+++ b/Modules/clinic/_testclinic.c.h
@@ -7,7 +7,7 @@ preserve
 #endif
 #include "pycore_abstract.h"      // _PyNumber_Index()
 #include "pycore_long.h"          // _PyLong_UnsignedShort_Converter()
-#include "pycore_modsupport.h"    // _PyArg_CheckPositional()
+#include "pycore_modsupport.h"    // _PyArg_BadArgument()
 #include "pycore_runtime.h"       // _Py_ID()
 
 PyDoc_STRVAR(test_empty_function__doc__,
@@ -45,7 +45,19 @@ objects_converter(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *a;
     PyObject *b = NULL;
 
-    if (!_PyArg_CheckPositional("objects_converter", nargs, 1, 2)) {
+    if (nargs < 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 1 argument, got %zd",
+            "objects_converter", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 2 arguments, got %zd",
+            "objects_converter", nargs);
         goto exit;
     }
     a = args[0];
@@ -163,7 +175,19 @@ bool_converter(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     int b = 1;
     int c = 1;
 
-    if (!_PyArg_CheckPositional("bool_converter", nargs, 0, 3)) {
+    if (nargs < 0) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 0 arguments, got %zd",
+            "bool_converter", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 3) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 3 arguments, got %zd",
+            "bool_converter", nargs);
         goto exit;
     }
     if (nargs < 1) {
@@ -228,7 +252,19 @@ char_converter(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     char m = '\x00';
     char n = '\xff';
 
-    if (!_PyArg_CheckPositional("char_converter", nargs, 0, 14)) {
+    if (nargs < 0) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 0 arguments, got %zd",
+            "char_converter", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 14) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 14 arguments, got %zd",
+            "char_converter", nargs);
         goto exit;
     }
     if (nargs < 1) {
@@ -440,7 +476,19 @@ unsigned_char_converter(PyObject *module, PyObject *const *args, Py_ssize_t narg
     unsigned char b = 34;
     unsigned char c = 56;
 
-    if (!_PyArg_CheckPositional("unsigned_char_converter", nargs, 0, 3)) {
+    if (nargs < 0) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 0 arguments, got %zd",
+            "unsigned_char_converter", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 3) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 3 arguments, got %zd",
+            "unsigned_char_converter", nargs);
         goto exit;
     }
     if (nargs < 1) {
@@ -523,7 +571,19 @@ short_converter(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *return_value = NULL;
     short a = 12;
 
-    if (!_PyArg_CheckPositional("short_converter", nargs, 0, 1)) {
+    if (nargs < 0) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 0 arguments, got %zd",
+            "short_converter", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 1 argument, got %zd",
+            "short_converter", nargs);
         goto exit;
     }
     if (nargs < 1) {
@@ -575,7 +635,19 @@ unsigned_short_converter(PyObject *module, PyObject *const *args, Py_ssize_t nar
     unsigned short b = 34;
     unsigned short c = 56;
 
-    if (!_PyArg_CheckPositional("unsigned_short_converter", nargs, 0, 3)) {
+    if (nargs < 0) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 0 arguments, got %zd",
+            "unsigned_short_converter", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 3) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 3 arguments, got %zd",
+            "unsigned_short_converter", nargs);
         goto exit;
     }
     if (nargs < 1) {
@@ -623,7 +695,19 @@ int_converter(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     int b = 34;
     int c = 45;
 
-    if (!_PyArg_CheckPositional("int_converter", nargs, 0, 3)) {
+    if (nargs < 0) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 0 arguments, got %zd",
+            "int_converter", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 3) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 3 arguments, got %zd",
+            "int_converter", nargs);
         goto exit;
     }
     if (nargs < 1) {
@@ -679,7 +763,19 @@ unsigned_int_converter(PyObject *module, PyObject *const *args, Py_ssize_t nargs
     unsigned int b = 34;
     unsigned int c = 56;
 
-    if (!_PyArg_CheckPositional("unsigned_int_converter", nargs, 0, 3)) {
+    if (nargs < 0) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 0 arguments, got %zd",
+            "unsigned_int_converter", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 3) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 3 arguments, got %zd",
+            "unsigned_int_converter", nargs);
         goto exit;
     }
     if (nargs < 1) {
@@ -725,7 +821,19 @@ long_converter(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *return_value = NULL;
     long a = 12;
 
-    if (!_PyArg_CheckPositional("long_converter", nargs, 0, 1)) {
+    if (nargs < 0) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 0 arguments, got %zd",
+            "long_converter", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 1 argument, got %zd",
+            "long_converter", nargs);
         goto exit;
     }
     if (nargs < 1) {
@@ -762,7 +870,19 @@ unsigned_long_converter(PyObject *module, PyObject *const *args, Py_ssize_t narg
     unsigned long b = 34;
     unsigned long c = 56;
 
-    if (!_PyArg_CheckPositional("unsigned_long_converter", nargs, 0, 3)) {
+    if (nargs < 0) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 0 arguments, got %zd",
+            "unsigned_long_converter", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 3) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 3 arguments, got %zd",
+            "unsigned_long_converter", nargs);
         goto exit;
     }
     if (nargs < 1) {
@@ -809,7 +929,19 @@ long_long_converter(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *return_value = NULL;
     long long a = 12;
 
-    if (!_PyArg_CheckPositional("long_long_converter", nargs, 0, 1)) {
+    if (nargs < 0) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 0 arguments, got %zd",
+            "long_long_converter", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 1 argument, got %zd",
+            "long_long_converter", nargs);
         goto exit;
     }
     if (nargs < 1) {
@@ -846,7 +978,19 @@ unsigned_long_long_converter(PyObject *module, PyObject *const *args, Py_ssize_t
     unsigned long long b = 34;
     unsigned long long c = 56;
 
-    if (!_PyArg_CheckPositional("unsigned_long_long_converter", nargs, 0, 3)) {
+    if (nargs < 0) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 0 arguments, got %zd",
+            "unsigned_long_long_converter", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 3) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 3 arguments, got %zd",
+            "unsigned_long_long_converter", nargs);
         goto exit;
     }
     if (nargs < 1) {
@@ -896,7 +1040,19 @@ py_ssize_t_converter(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     Py_ssize_t b = 34;
     Py_ssize_t c = 56;
 
-    if (!_PyArg_CheckPositional("py_ssize_t_converter", nargs, 0, 3)) {
+    if (nargs < 0) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 0 arguments, got %zd",
+            "py_ssize_t_converter", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 3) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 3 arguments, got %zd",
+            "py_ssize_t_converter", nargs);
         goto exit;
     }
     if (nargs < 1) {
@@ -962,7 +1118,19 @@ slice_index_converter(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     Py_ssize_t b = 34;
     Py_ssize_t c = 56;
 
-    if (!_PyArg_CheckPositional("slice_index_converter", nargs, 0, 3)) {
+    if (nargs < 0) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 0 arguments, got %zd",
+            "slice_index_converter", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 3) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 3 arguments, got %zd",
+            "slice_index_converter", nargs);
         goto exit;
     }
     if (nargs < 1) {
@@ -1007,7 +1175,19 @@ size_t_converter(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *return_value = NULL;
     size_t a = 12;
 
-    if (!_PyArg_CheckPositional("size_t_converter", nargs, 0, 1)) {
+    if (nargs < 0) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 0 arguments, got %zd",
+            "size_t_converter", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 1 argument, got %zd",
+            "size_t_converter", nargs);
         goto exit;
     }
     if (nargs < 1) {
@@ -1040,7 +1220,19 @@ float_converter(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *return_value = NULL;
     float a = 12.5;
 
-    if (!_PyArg_CheckPositional("float_converter", nargs, 0, 1)) {
+    if (nargs < 0) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 0 arguments, got %zd",
+            "float_converter", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 1 argument, got %zd",
+            "float_converter", nargs);
         goto exit;
     }
     if (nargs < 1) {
@@ -1080,7 +1272,19 @@ double_converter(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *return_value = NULL;
     double a = 12.5;
 
-    if (!_PyArg_CheckPositional("double_converter", nargs, 0, 1)) {
+    if (nargs < 0) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 0 arguments, got %zd",
+            "double_converter", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 1 argument, got %zd",
+            "double_converter", nargs);
         goto exit;
     }
     if (nargs < 1) {
@@ -2400,7 +2604,11 @@ vararg_and_posonly(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *a;
     PyObject *__clinic_args = NULL;
 
-    if (!_PyArg_CheckPositional("vararg_and_posonly", nargs, 1, PY_SSIZE_T_MAX)) {
+    if (nargs < 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 1 argument, got %zd",
+            "vararg_and_posonly", nargs);
         goto exit;
     }
     a = args[0];
@@ -2764,7 +2972,11 @@ gh_99233_refcount(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *return_value = NULL;
     PyObject *__clinic_args = NULL;
 
-    if (!_PyArg_CheckPositional("gh_99233_refcount", nargs, 0, PY_SSIZE_T_MAX)) {
+    if (nargs < 0) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 0 arguments, got %zd",
+            "gh_99233_refcount", nargs);
         goto exit;
     }
     __clinic_args = PyTuple_New(nargs - 0);
@@ -3163,4 +3375,4 @@ _testclinic_TestClass_meth_method_no_params(PyObject *self, PyTypeObject *cls, P
     }
     return _testclinic_TestClass_meth_method_no_params_impl(self, cls);
 }
-/*[clinic end generated code: output=6520c1ca5392a3f0 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=a53fc44d5eb6e98e input=a9049054013a1b77]*/

--- a/Modules/clinic/_testclinic_depr.c.h
+++ b/Modules/clinic/_testclinic_depr.c.h
@@ -7,7 +7,7 @@ preserve
 #endif
 #include "pycore_abstract.h"      // _PyNumber_Index()
 #include "pycore_long.h"          // _PyLong_UnsignedShort_Converter()
-#include "pycore_modsupport.h"    // _PyArg_CheckPositional()
+#include "pycore_modsupport.h"    // _PyArg_BadArgument()
 #include "pycore_runtime.h"       // _Py_ID()
 
 PyDoc_STRVAR(depr_star_new__doc__,
@@ -2393,4 +2393,4 @@ depr_multi(PyObject *module, PyObject *const *args, Py_ssize_t nargs, PyObject *
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=2c19d1804ba6e53b input=a9049054013a1b77]*/
+/*[clinic end generated code: output=4f75462666db5ed0 input=a9049054013a1b77]*/

--- a/Modules/clinic/_tkinter.c.h
+++ b/Modules/clinic/_tkinter.c.h
@@ -343,7 +343,19 @@ _tkinter_tkapp_createcommand(TkappObject *self, PyObject *const *args, Py_ssize_
     const char *name;
     PyObject *func;
 
-    if (!_PyArg_CheckPositional("createcommand", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "createcommand", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "createcommand", nargs);
         goto exit;
     }
     if (!PyUnicode_Check(args[0])) {
@@ -424,7 +436,19 @@ _tkinter_tkapp_createfilehandler(TkappObject *self, PyObject *const *args, Py_ss
     int mask;
     PyObject *func;
 
-    if (!_PyArg_CheckPositional("createfilehandler", nargs, 3, 3)) {
+    if (nargs < 3) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 3 arguments, got %zd",
+            "createfilehandler", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 3) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 3 arguments, got %zd",
+            "createfilehandler", nargs);
         goto exit;
     }
     file = args[0];
@@ -489,7 +513,19 @@ _tkinter_tkapp_createtimerhandler(TkappObject *self, PyObject *const *args, Py_s
     int milliseconds;
     PyObject *func;
 
-    if (!_PyArg_CheckPositional("createtimerhandler", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "createtimerhandler", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "createtimerhandler", nargs);
         goto exit;
     }
     milliseconds = PyLong_AsInt(args[0]);
@@ -520,7 +556,19 @@ _tkinter_tkapp_mainloop(TkappObject *self, PyObject *const *args, Py_ssize_t nar
     PyObject *return_value = NULL;
     int threshold = 0;
 
-    if (!_PyArg_CheckPositional("mainloop", nargs, 0, 1)) {
+    if (nargs < 0) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 0 arguments, got %zd",
+            "mainloop", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 1 argument, got %zd",
+            "mainloop", nargs);
         goto exit;
     }
     if (nargs < 1) {
@@ -554,7 +602,19 @@ _tkinter_tkapp_dooneevent(TkappObject *self, PyObject *const *args, Py_ssize_t n
     PyObject *return_value = NULL;
     int flags = 0;
 
-    if (!_PyArg_CheckPositional("dooneevent", nargs, 0, 1)) {
+    if (nargs < 0) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 0 arguments, got %zd",
+            "dooneevent", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 1 argument, got %zd",
+            "dooneevent", nargs);
         goto exit;
     }
     if (nargs < 1) {
@@ -684,7 +744,19 @@ _tkinter_create(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     int sync = 0;
     const char *use = NULL;
 
-    if (!_PyArg_CheckPositional("create", nargs, 0, 8)) {
+    if (nargs < 0) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 0 arguments, got %zd",
+            "create", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 8) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 8 arguments, got %zd",
+            "create", nargs);
         goto exit;
     }
     if (nargs < 1) {
@@ -861,4 +933,4 @@ exit:
 #ifndef _TKINTER_TKAPP_DELETEFILEHANDLER_METHODDEF
     #define _TKINTER_TKAPP_DELETEFILEHANDLER_METHODDEF
 #endif /* !defined(_TKINTER_TKAPP_DELETEFILEHANDLER_METHODDEF) */
-/*[clinic end generated code: output=d447501ec5aa9447 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=49d0f6f4142c15dd input=a9049054013a1b77]*/

--- a/Modules/clinic/_tracemalloc.c.h
+++ b/Modules/clinic/_tracemalloc.c.h
@@ -2,8 +2,6 @@
 preserve
 [clinic start generated code]*/
 
-#include "pycore_modsupport.h"    // _PyArg_CheckPositional()
-
 PyDoc_STRVAR(_tracemalloc_is_tracing__doc__,
 "is_tracing($module, /)\n"
 "--\n"
@@ -97,7 +95,19 @@ _tracemalloc_start(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *return_value = NULL;
     int nframe = 1;
 
-    if (!_PyArg_CheckPositional("start", nargs, 0, 1)) {
+    if (nargs < 0) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 0 arguments, got %zd",
+            "start", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 1 argument, got %zd",
+            "start", nargs);
         goto exit;
     }
     if (nargs < 1) {
@@ -214,4 +224,4 @@ _tracemalloc_reset_peak(PyObject *module, PyObject *Py_UNUSED(ignored))
 {
     return _tracemalloc_reset_peak_impl(module);
 }
-/*[clinic end generated code: output=9d4d884b156c2ddb input=a9049054013a1b77]*/
+/*[clinic end generated code: output=3a90b524ba9d9d15 input=a9049054013a1b77]*/

--- a/Modules/clinic/_weakref.c.h
+++ b/Modules/clinic/_weakref.c.h
@@ -3,7 +3,7 @@ preserve
 [clinic start generated code]*/
 
 #include "pycore_critical_section.h"// Py_BEGIN_CRITICAL_SECTION()
-#include "pycore_modsupport.h"    // _PyArg_CheckPositional()
+#include "pycore_modsupport.h"    // _PyArg_BadArgument()
 
 PyDoc_STRVAR(_weakref_getweakrefcount__doc__,
 "getweakrefcount($module, object, /)\n"
@@ -55,7 +55,19 @@ _weakref__remove_dead_weakref(PyObject *module, PyObject *const *args, Py_ssize_
     PyObject *dct;
     PyObject *key;
 
-    if (!_PyArg_CheckPositional("_remove_dead_weakref", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "_remove_dead_weakref", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "_remove_dead_weakref", nargs);
         goto exit;
     }
     if (!PyDict_Check(args[0])) {
@@ -116,7 +128,19 @@ _weakref_proxy(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *object;
     PyObject *callback = NULL;
 
-    if (!_PyArg_CheckPositional("proxy", nargs, 1, 2)) {
+    if (nargs < 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 1 argument, got %zd",
+            "proxy", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 2 arguments, got %zd",
+            "proxy", nargs);
         goto exit;
     }
     object = args[0];
@@ -130,4 +154,4 @@ skip_optional:
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=d5d30707212a9870 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=c0cb4aed58bdd4db input=a9049054013a1b77]*/

--- a/Modules/clinic/_winapi.c.h
+++ b/Modules/clinic/_winapi.c.h
@@ -337,7 +337,19 @@ _winapi_CreateJunction(PyObject *module, PyObject *const *args, Py_ssize_t nargs
     LPCWSTR src_path = NULL;
     LPCWSTR dst_path = NULL;
 
-    if (!_PyArg_CheckPositional("CreateJunction", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "CreateJunction", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "CreateJunction", nargs);
         goto exit;
     }
     if (!PyUnicode_Check(args[0])) {
@@ -1978,4 +1990,4 @@ exit:
 
     return return_value;
 }
-/*[clinic end generated code: output=1f5bbcfa8d1847c5 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=c0af1431bcf06467 input=a9049054013a1b77]*/

--- a/Modules/clinic/arraymodule.c.h
+++ b/Modules/clinic/arraymodule.c.h
@@ -3,7 +3,7 @@ preserve
 [clinic start generated code]*/
 
 #include "pycore_abstract.h"      // _PyNumber_Index()
-#include "pycore_modsupport.h"    // _PyArg_CheckPositional()
+#include "pycore_modsupport.h"    // _PyArg_UnpackKeywords()
 
 PyDoc_STRVAR(array_array_clear__doc__,
 "clear($self, /)\n"
@@ -82,7 +82,19 @@ array_array_index(arrayobject *self, PyObject *const *args, Py_ssize_t nargs)
     Py_ssize_t start = 0;
     Py_ssize_t stop = PY_SSIZE_T_MAX;
 
-    if (!_PyArg_CheckPositional("index", nargs, 1, 3)) {
+    if (nargs < 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 1 argument, got %zd",
+            "index", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 3) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 3 arguments, got %zd",
+            "index", nargs);
         goto exit;
     }
     v = args[0];
@@ -134,7 +146,19 @@ array_array_pop(arrayobject *self, PyObject *const *args, Py_ssize_t nargs)
     PyObject *return_value = NULL;
     Py_ssize_t i = -1;
 
-    if (!_PyArg_CheckPositional("pop", nargs, 0, 1)) {
+    if (nargs < 0) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 0 arguments, got %zd",
+            "pop", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 1 argument, got %zd",
+            "pop", nargs);
         goto exit;
     }
     if (nargs < 1) {
@@ -221,7 +245,19 @@ array_array_insert(arrayobject *self, PyObject *const *args, Py_ssize_t nargs)
     Py_ssize_t i;
     PyObject *v;
 
-    if (!_PyArg_CheckPositional("insert", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "insert", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "insert", nargs);
         goto exit;
     }
     {
@@ -587,7 +623,19 @@ array__array_reconstructor(PyObject *module, PyObject *const *args, Py_ssize_t n
     enum machine_format_code mformat_code;
     PyObject *items;
 
-    if (!_PyArg_CheckPositional("_array_reconstructor", nargs, 4, 4)) {
+    if (nargs < 4) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 4 arguments, got %zd",
+            "_array_reconstructor", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 4) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 4 arguments, got %zd",
+            "_array_reconstructor", nargs);
         goto exit;
     }
     arraytype = (PyTypeObject *)args[0];
@@ -685,4 +733,4 @@ PyDoc_STRVAR(array_arrayiterator___setstate____doc__,
 
 #define ARRAY_ARRAYITERATOR___SETSTATE___METHODDEF    \
     {"__setstate__", (PyCFunction)array_arrayiterator___setstate__, METH_O, array_arrayiterator___setstate____doc__},
-/*[clinic end generated code: output=52c55d9b1d026c1c input=a9049054013a1b77]*/
+/*[clinic end generated code: output=a947705a7756d8c7 input=a9049054013a1b77]*/

--- a/Modules/clinic/binascii.c.h
+++ b/Modules/clinic/binascii.c.h
@@ -277,7 +277,19 @@ binascii_crc_hqx(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     Py_buffer data = {NULL, NULL};
     unsigned int crc;
 
-    if (!_PyArg_CheckPositional("crc_hqx", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "crc_hqx", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "crc_hqx", nargs);
         goto exit;
     }
     if (PyObject_GetBuffer(args[0], &data, PyBUF_SIMPLE) != 0) {
@@ -318,7 +330,19 @@ binascii_crc32(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     unsigned int crc = 0;
     unsigned int _return_value;
 
-    if (!_PyArg_CheckPositional("crc32", nargs, 1, 2)) {
+    if (nargs < 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 1 argument, got %zd",
+            "crc32", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 2 arguments, got %zd",
+            "crc32", nargs);
         goto exit;
     }
     if (PyObject_GetBuffer(args[0], &data, PyBUF_SIMPLE) != 0) {
@@ -767,4 +791,4 @@ exit:
 
     return return_value;
 }
-/*[clinic end generated code: output=968767b663ed889d input=a9049054013a1b77]*/
+/*[clinic end generated code: output=0ba970559f0be05a input=a9049054013a1b77]*/

--- a/Modules/clinic/cmathmodule.c.h
+++ b/Modules/clinic/cmathmodule.c.h
@@ -6,7 +6,7 @@ preserve
 #  include "pycore_gc.h"          // PyGC_Head
 #  include "pycore_runtime.h"     // _Py_ID()
 #endif
-#include "pycore_modsupport.h"    // _PyArg_CheckPositional()
+#include "pycore_modsupport.h"    // _PyArg_UnpackKeywords()
 
 PyDoc_STRVAR(cmath_acos__doc__,
 "acos($module, z, /)\n"
@@ -659,7 +659,19 @@ cmath_log(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     Py_complex x;
     PyObject *y_obj = NULL;
 
-    if (!_PyArg_CheckPositional("log", nargs, 1, 2)) {
+    if (nargs < 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 1 argument, got %zd",
+            "log", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 2 arguments, got %zd",
+            "log", nargs);
         goto exit;
     }
     x = PyComplex_AsCComplex(args[0]);
@@ -754,7 +766,19 @@ cmath_rect(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     double r;
     double phi;
 
-    if (!_PyArg_CheckPositional("rect", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "rect", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "rect", nargs);
         goto exit;
     }
     if (PyFloat_CheckExact(args[0])) {
@@ -982,4 +1006,4 @@ skip_optional_kwonly:
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=364093af55bfe53f input=a9049054013a1b77]*/
+/*[clinic end generated code: output=ff0bc5efb97a106e input=a9049054013a1b77]*/

--- a/Modules/clinic/fcntlmodule.c.h
+++ b/Modules/clinic/fcntlmodule.c.h
@@ -3,7 +3,6 @@ preserve
 [clinic start generated code]*/
 
 #include "pycore_fileutils.h"     // _PyLong_FileDescriptor_Converter()
-#include "pycore_modsupport.h"    // _PyArg_CheckPositional()
 
 PyDoc_STRVAR(fcntl_fcntl__doc__,
 "fcntl($module, fd, cmd, arg=0, /)\n"
@@ -35,7 +34,19 @@ fcntl_fcntl(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     int code;
     PyObject *arg = NULL;
 
-    if (!_PyArg_CheckPositional("fcntl", nargs, 2, 3)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 2 arguments, got %zd",
+            "fcntl", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 3) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 3 arguments, got %zd",
+            "fcntl", nargs);
         goto exit;
     }
     if (!_PyLong_FileDescriptor_Converter(args[0], &fd)) {
@@ -105,7 +116,19 @@ fcntl_ioctl(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *ob_arg = NULL;
     int mutate_arg = 1;
 
-    if (!_PyArg_CheckPositional("ioctl", nargs, 2, 4)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 2 arguments, got %zd",
+            "ioctl", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 4) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 4 arguments, got %zd",
+            "ioctl", nargs);
         goto exit;
     }
     if (!_PyLong_FileDescriptor_Converter(args[0], &fd)) {
@@ -155,7 +178,19 @@ fcntl_flock(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     int fd;
     int code;
 
-    if (!_PyArg_CheckPositional("flock", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "flock", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "flock", nargs);
         goto exit;
     }
     if (!_PyLong_FileDescriptor_Converter(args[0], &fd)) {
@@ -215,7 +250,19 @@ fcntl_lockf(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *startobj = NULL;
     int whence = 0;
 
-    if (!_PyArg_CheckPositional("lockf", nargs, 2, 5)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 2 arguments, got %zd",
+            "lockf", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 5) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 5 arguments, got %zd",
+            "lockf", nargs);
         goto exit;
     }
     if (!_PyLong_FileDescriptor_Converter(args[0], &fd)) {
@@ -246,4 +293,4 @@ skip_optional:
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=732e33ba92042031 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=8cb41dddac8c5ef9 input=a9049054013a1b77]*/

--- a/Modules/clinic/gcmodule.c.h
+++ b/Modules/clinic/gcmodule.c.h
@@ -320,7 +320,11 @@ gc_get_referrers(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *return_value = NULL;
     PyObject *__clinic_args = NULL;
 
-    if (!_PyArg_CheckPositional("get_referrers", nargs, 0, PY_SSIZE_T_MAX)) {
+    if (nargs < 0) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 0 arguments, got %zd",
+            "get_referrers", nargs);
         goto exit;
     }
     __clinic_args = PyTuple_New(nargs - 0);
@@ -355,7 +359,11 @@ gc_get_referents(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *return_value = NULL;
     PyObject *__clinic_args = NULL;
 
-    if (!_PyArg_CheckPositional("get_referents", nargs, 0, PY_SSIZE_T_MAX)) {
+    if (nargs < 0) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 0 arguments, got %zd",
+            "get_referents", nargs);
         goto exit;
     }
     __clinic_args = PyTuple_New(nargs - 0);
@@ -585,4 +593,4 @@ gc_get_freeze_count(PyObject *module, PyObject *Py_UNUSED(ignored))
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=0a7e91917adcb937 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=e9fc1273bd8854e8 input=a9049054013a1b77]*/

--- a/Modules/clinic/itertoolsmodule.c.h
+++ b/Modules/clinic/itertoolsmodule.c.h
@@ -124,7 +124,19 @@ pairwise_new(PyTypeObject *type, PyObject *args, PyObject *kwargs)
         !_PyArg_NoKeywords("pairwise", kwargs)) {
         goto exit;
     }
-    if (!_PyArg_CheckPositional("pairwise", PyTuple_GET_SIZE(args), 1, 1)) {
+    if (PyTuple_GET_SIZE(args) < 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 1 argument, got %zd",
+            "pairwise", PyTuple_GET_SIZE(args));
+        goto exit;
+    }
+
+    if (PyTuple_GET_SIZE(args) != 0 && PyTuple_GET_SIZE(args) > 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 1 argument, got %zd",
+            "pairwise", PyTuple_GET_SIZE(args));
         goto exit;
     }
     iterable = PyTuple_GET_ITEM(args, 0);
@@ -218,7 +230,19 @@ itertools__grouper(PyTypeObject *type, PyObject *args, PyObject *kwargs)
         !_PyArg_NoKeywords("_grouper", kwargs)) {
         goto exit;
     }
-    if (!_PyArg_CheckPositional("_grouper", PyTuple_GET_SIZE(args), 2, 2)) {
+    if (PyTuple_GET_SIZE(args) < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "_grouper", PyTuple_GET_SIZE(args));
+        goto exit;
+    }
+
+    if (PyTuple_GET_SIZE(args) != 0 && PyTuple_GET_SIZE(args) > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "_grouper", PyTuple_GET_SIZE(args));
         goto exit;
     }
     if (!PyObject_TypeCheck(PyTuple_GET_ITEM(args, 0), clinic_state_by_cls()->groupby_type)) {
@@ -256,7 +280,19 @@ itertools_teedataobject(PyTypeObject *type, PyObject *args, PyObject *kwargs)
         !_PyArg_NoKeywords("teedataobject", kwargs)) {
         goto exit;
     }
-    if (!_PyArg_CheckPositional("teedataobject", PyTuple_GET_SIZE(args), 3, 3)) {
+    if (PyTuple_GET_SIZE(args) < 3) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 3 arguments, got %zd",
+            "teedataobject", PyTuple_GET_SIZE(args));
+        goto exit;
+    }
+
+    if (PyTuple_GET_SIZE(args) != 0 && PyTuple_GET_SIZE(args) > 3) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 3 arguments, got %zd",
+            "teedataobject", PyTuple_GET_SIZE(args));
         goto exit;
     }
     it = PyTuple_GET_ITEM(args, 0);
@@ -292,7 +328,19 @@ itertools__tee(PyTypeObject *type, PyObject *args, PyObject *kwargs)
         !_PyArg_NoKeywords("_tee", kwargs)) {
         goto exit;
     }
-    if (!_PyArg_CheckPositional("_tee", PyTuple_GET_SIZE(args), 1, 1)) {
+    if (PyTuple_GET_SIZE(args) < 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 1 argument, got %zd",
+            "_tee", PyTuple_GET_SIZE(args));
+        goto exit;
+    }
+
+    if (PyTuple_GET_SIZE(args) != 0 && PyTuple_GET_SIZE(args) > 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 1 argument, got %zd",
+            "_tee", PyTuple_GET_SIZE(args));
         goto exit;
     }
     iterable = PyTuple_GET_ITEM(args, 0);
@@ -321,7 +369,19 @@ itertools_tee(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *iterable;
     Py_ssize_t n = 2;
 
-    if (!_PyArg_CheckPositional("tee", nargs, 1, 2)) {
+    if (nargs < 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 1 argument, got %zd",
+            "tee", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 2 arguments, got %zd",
+            "tee", nargs);
         goto exit;
     }
     iterable = args[0];
@@ -367,7 +427,19 @@ itertools_cycle(PyTypeObject *type, PyObject *args, PyObject *kwargs)
         !_PyArg_NoKeywords("cycle", kwargs)) {
         goto exit;
     }
-    if (!_PyArg_CheckPositional("cycle", PyTuple_GET_SIZE(args), 1, 1)) {
+    if (PyTuple_GET_SIZE(args) < 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 1 argument, got %zd",
+            "cycle", PyTuple_GET_SIZE(args));
+        goto exit;
+    }
+
+    if (PyTuple_GET_SIZE(args) != 0 && PyTuple_GET_SIZE(args) > 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 1 argument, got %zd",
+            "cycle", PyTuple_GET_SIZE(args));
         goto exit;
     }
     iterable = PyTuple_GET_ITEM(args, 0);
@@ -400,7 +472,19 @@ itertools_dropwhile(PyTypeObject *type, PyObject *args, PyObject *kwargs)
         !_PyArg_NoKeywords("dropwhile", kwargs)) {
         goto exit;
     }
-    if (!_PyArg_CheckPositional("dropwhile", PyTuple_GET_SIZE(args), 2, 2)) {
+    if (PyTuple_GET_SIZE(args) < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "dropwhile", PyTuple_GET_SIZE(args));
+        goto exit;
+    }
+
+    if (PyTuple_GET_SIZE(args) != 0 && PyTuple_GET_SIZE(args) > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "dropwhile", PyTuple_GET_SIZE(args));
         goto exit;
     }
     func = PyTuple_GET_ITEM(args, 0);
@@ -432,7 +516,19 @@ itertools_takewhile(PyTypeObject *type, PyObject *args, PyObject *kwargs)
         !_PyArg_NoKeywords("takewhile", kwargs)) {
         goto exit;
     }
-    if (!_PyArg_CheckPositional("takewhile", PyTuple_GET_SIZE(args), 2, 2)) {
+    if (PyTuple_GET_SIZE(args) < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "takewhile", PyTuple_GET_SIZE(args));
+        goto exit;
+    }
+
+    if (PyTuple_GET_SIZE(args) != 0 && PyTuple_GET_SIZE(args) > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "takewhile", PyTuple_GET_SIZE(args));
         goto exit;
     }
     func = PyTuple_GET_ITEM(args, 0);
@@ -464,7 +560,19 @@ itertools_starmap(PyTypeObject *type, PyObject *args, PyObject *kwargs)
         !_PyArg_NoKeywords("starmap", kwargs)) {
         goto exit;
     }
-    if (!_PyArg_CheckPositional("starmap", PyTuple_GET_SIZE(args), 2, 2)) {
+    if (PyTuple_GET_SIZE(args) < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "starmap", PyTuple_GET_SIZE(args));
+        goto exit;
+    }
+
+    if (PyTuple_GET_SIZE(args) != 0 && PyTuple_GET_SIZE(args) > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "starmap", PyTuple_GET_SIZE(args));
         goto exit;
     }
     func = PyTuple_GET_ITEM(args, 0);
@@ -844,7 +952,19 @@ itertools_filterfalse(PyTypeObject *type, PyObject *args, PyObject *kwargs)
         !_PyArg_NoKeywords("filterfalse", kwargs)) {
         goto exit;
     }
-    if (!_PyArg_CheckPositional("filterfalse", PyTuple_GET_SIZE(args), 2, 2)) {
+    if (PyTuple_GET_SIZE(args) < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "filterfalse", PyTuple_GET_SIZE(args));
+        goto exit;
+    }
+
+    if (PyTuple_GET_SIZE(args) != 0 && PyTuple_GET_SIZE(args) > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "filterfalse", PyTuple_GET_SIZE(args));
         goto exit;
     }
     func = PyTuple_GET_ITEM(args, 0);
@@ -928,4 +1048,4 @@ skip_optional_pos:
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=c6a515f765da86b5 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=70003b4d9f4e066e input=a9049054013a1b77]*/

--- a/Modules/clinic/mathmodule.c.h
+++ b/Modules/clinic/mathmodule.c.h
@@ -6,7 +6,7 @@ preserve
 #  include "pycore_gc.h"          // PyGC_Head
 #  include "pycore_runtime.h"     // _Py_ID()
 #endif
-#include "pycore_modsupport.h"    // _PyArg_CheckPositional()
+#include "pycore_modsupport.h"    // _PyArg_UnpackKeywords()
 
 PyDoc_STRVAR(math_ceil__doc__,
 "ceil($module, x, /)\n"
@@ -130,7 +130,19 @@ math_ldexp(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     double x;
     PyObject *i;
 
-    if (!_PyArg_CheckPositional("ldexp", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "ldexp", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "ldexp", nargs);
         goto exit;
     }
     if (PyFloat_CheckExact(args[0])) {
@@ -225,7 +237,19 @@ math_fmod(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     double x;
     double y;
 
-    if (!_PyArg_CheckPositional("fmod", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "fmod", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "fmod", nargs);
         goto exit;
     }
     if (PyFloat_CheckExact(args[0])) {
@@ -279,7 +303,19 @@ math_dist(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *p;
     PyObject *q;
 
-    if (!_PyArg_CheckPositional("dist", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "dist", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "dist", nargs);
         goto exit;
     }
     p = args[0];
@@ -316,7 +352,19 @@ math_sumprod(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *p;
     PyObject *q;
 
-    if (!_PyArg_CheckPositional("sumprod", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "sumprod", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "sumprod", nargs);
         goto exit;
     }
     p = args[0];
@@ -346,7 +394,19 @@ math_pow(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     double x;
     double y;
 
-    if (!_PyArg_CheckPositional("pow", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "pow", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "pow", nargs);
         goto exit;
     }
     if (PyFloat_CheckExact(args[0])) {
@@ -770,7 +830,19 @@ math_perm(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *n;
     PyObject *k = Py_None;
 
-    if (!_PyArg_CheckPositional("perm", nargs, 1, 2)) {
+    if (nargs < 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 1 argument, got %zd",
+            "perm", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 2 arguments, got %zd",
+            "perm", nargs);
         goto exit;
     }
     n = args[0];
@@ -814,7 +886,19 @@ math_comb(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *n;
     PyObject *k;
 
-    if (!_PyArg_CheckPositional("comb", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "comb", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "comb", nargs);
         goto exit;
     }
     n = args[0];
@@ -950,4 +1034,4 @@ math_ulp(PyObject *module, PyObject *arg)
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=6b2eeaed8d8a76d5 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=4321f9bb43f168be input=a9049054013a1b77]*/

--- a/Modules/clinic/overlapped.c.h
+++ b/Modules/clinic/overlapped.c.h
@@ -7,7 +7,7 @@ preserve
 #  include "pycore_runtime.h"     // _Py_ID()
 #endif
 #include "pycore_long.h"          // _PyLong_UnsignedLong_Converter()
-#include "pycore_modsupport.h"    // _PyArg_CheckPositional()
+#include "pycore_modsupport.h"    // _PyArg_BadArgument()
 
 PyDoc_STRVAR(_overlapped_CreateIoCompletionPort__doc__,
 "CreateIoCompletionPort($module, handle, port, key, concurrency, /)\n"
@@ -33,7 +33,19 @@ _overlapped_CreateIoCompletionPort(PyObject *module, PyObject *const *args, Py_s
     ULONG_PTR CompletionKey;
     DWORD NumberOfConcurrentThreads;
 
-    if (!_PyArg_CheckPositional("CreateIoCompletionPort", nargs, 4, 4)) {
+    if (nargs < 4) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 4 arguments, got %zd",
+            "CreateIoCompletionPort", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 4) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 4 arguments, got %zd",
+            "CreateIoCompletionPort", nargs);
         goto exit;
     }
     FileHandle = PyLong_AsVoidPtr(args[0]);
@@ -80,7 +92,19 @@ _overlapped_GetQueuedCompletionStatus(PyObject *module, PyObject *const *args, P
     HANDLE CompletionPort;
     DWORD Milliseconds;
 
-    if (!_PyArg_CheckPositional("GetQueuedCompletionStatus", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "GetQueuedCompletionStatus", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "GetQueuedCompletionStatus", nargs);
         goto exit;
     }
     CompletionPort = PyLong_AsVoidPtr(args[0]);
@@ -121,7 +145,19 @@ _overlapped_PostQueuedCompletionStatus(PyObject *module, PyObject *const *args, 
     ULONG_PTR CompletionKey;
     OVERLAPPED *Overlapped;
 
-    if (!_PyArg_CheckPositional("PostQueuedCompletionStatus", nargs, 4, 4)) {
+    if (nargs < 4) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 4 arguments, got %zd",
+            "PostQueuedCompletionStatus", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 4) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 4 arguments, got %zd",
+            "PostQueuedCompletionStatus", nargs);
         goto exit;
     }
     CompletionPort = PyLong_AsVoidPtr(args[0]);
@@ -170,7 +206,19 @@ _overlapped_RegisterWaitWithQueue(PyObject *module, PyObject *const *args, Py_ss
     OVERLAPPED *Overlapped;
     DWORD Milliseconds;
 
-    if (!_PyArg_CheckPositional("RegisterWaitWithQueue", nargs, 4, 4)) {
+    if (nargs < 4) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 4 arguments, got %zd",
+            "RegisterWaitWithQueue", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 4) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 4 arguments, got %zd",
+            "RegisterWaitWithQueue", nargs);
         goto exit;
     }
     Object = PyLong_AsVoidPtr(args[0]);
@@ -242,7 +290,19 @@ _overlapped_UnregisterWaitEx(PyObject *module, PyObject *const *args, Py_ssize_t
     HANDLE WaitHandle;
     HANDLE Event;
 
-    if (!_PyArg_CheckPositional("UnregisterWaitEx", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "UnregisterWaitEx", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "UnregisterWaitEx", nargs);
         goto exit;
     }
     WaitHandle = PyLong_AsVoidPtr(args[0]);
@@ -285,7 +345,19 @@ _overlapped_CreateEvent(PyObject *module, PyObject *const *args, Py_ssize_t narg
     BOOL InitialState;
     const wchar_t *Name = NULL;
 
-    if (!_PyArg_CheckPositional("CreateEvent", nargs, 4, 4)) {
+    if (nargs < 4) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 4 arguments, got %zd",
+            "CreateEvent", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 4) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 4 arguments, got %zd",
+            "CreateEvent", nargs);
         goto exit;
     }
     EventAttributes = args[0];
@@ -396,7 +468,19 @@ _overlapped_BindLocal(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     HANDLE Socket;
     int Family;
 
-    if (!_PyArg_CheckPositional("BindLocal", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "BindLocal", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "BindLocal", nargs);
         goto exit;
     }
     Socket = PyLong_AsVoidPtr(args[0]);
@@ -541,7 +625,19 @@ _overlapped_Overlapped_getresult(OverlappedObject *self, PyObject *const *args, 
     PyObject *return_value = NULL;
     BOOL wait = FALSE;
 
-    if (!_PyArg_CheckPositional("getresult", nargs, 0, 1)) {
+    if (nargs < 0) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 0 arguments, got %zd",
+            "getresult", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 1 argument, got %zd",
+            "getresult", nargs);
         goto exit;
     }
     if (nargs < 1) {
@@ -578,7 +674,19 @@ _overlapped_Overlapped_ReadFile(OverlappedObject *self, PyObject *const *args, P
     HANDLE handle;
     DWORD size;
 
-    if (!_PyArg_CheckPositional("ReadFile", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "ReadFile", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "ReadFile", nargs);
         goto exit;
     }
     handle = PyLong_AsVoidPtr(args[0]);
@@ -614,7 +722,19 @@ _overlapped_Overlapped_ReadFileInto(OverlappedObject *self, PyObject *const *arg
     HANDLE handle;
     Py_buffer bufobj = {NULL, NULL};
 
-    if (!_PyArg_CheckPositional("ReadFileInto", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "ReadFileInto", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "ReadFileInto", nargs);
         goto exit;
     }
     handle = PyLong_AsVoidPtr(args[0]);
@@ -656,7 +776,19 @@ _overlapped_Overlapped_WSARecv(OverlappedObject *self, PyObject *const *args, Py
     DWORD size;
     DWORD flags = 0;
 
-    if (!_PyArg_CheckPositional("WSARecv", nargs, 2, 3)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 2 arguments, got %zd",
+            "WSARecv", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 3) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 3 arguments, got %zd",
+            "WSARecv", nargs);
         goto exit;
     }
     handle = PyLong_AsVoidPtr(args[0]);
@@ -701,7 +833,19 @@ _overlapped_Overlapped_WSARecvInto(OverlappedObject *self, PyObject *const *args
     Py_buffer bufobj = {NULL, NULL};
     DWORD flags;
 
-    if (!_PyArg_CheckPositional("WSARecvInto", nargs, 3, 3)) {
+    if (nargs < 3) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 3 arguments, got %zd",
+            "WSARecvInto", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 3) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 3 arguments, got %zd",
+            "WSARecvInto", nargs);
         goto exit;
     }
     handle = PyLong_AsVoidPtr(args[0]);
@@ -745,7 +889,19 @@ _overlapped_Overlapped_WriteFile(OverlappedObject *self, PyObject *const *args, 
     HANDLE handle;
     Py_buffer bufobj = {NULL, NULL};
 
-    if (!_PyArg_CheckPositional("WriteFile", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "WriteFile", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "WriteFile", nargs);
         goto exit;
     }
     handle = PyLong_AsVoidPtr(args[0]);
@@ -787,7 +943,19 @@ _overlapped_Overlapped_WSASend(OverlappedObject *self, PyObject *const *args, Py
     Py_buffer bufobj = {NULL, NULL};
     DWORD flags;
 
-    if (!_PyArg_CheckPositional("WSASend", nargs, 3, 3)) {
+    if (nargs < 3) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 3 arguments, got %zd",
+            "WSASend", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 3) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 3 arguments, got %zd",
+            "WSASend", nargs);
         goto exit;
     }
     handle = PyLong_AsVoidPtr(args[0]);
@@ -832,7 +1000,19 @@ _overlapped_Overlapped_AcceptEx(OverlappedObject *self, PyObject *const *args, P
     HANDLE ListenSocket;
     HANDLE AcceptSocket;
 
-    if (!_PyArg_CheckPositional("AcceptEx", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "AcceptEx", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "AcceptEx", nargs);
         goto exit;
     }
     ListenSocket = PyLong_AsVoidPtr(args[0]);
@@ -872,7 +1052,19 @@ _overlapped_Overlapped_ConnectEx(OverlappedObject *self, PyObject *const *args, 
     HANDLE ConnectSocket;
     PyObject *AddressObj;
 
-    if (!_PyArg_CheckPositional("ConnectEx", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "ConnectEx", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "ConnectEx", nargs);
         goto exit;
     }
     ConnectSocket = PyLong_AsVoidPtr(args[0]);
@@ -909,7 +1101,19 @@ _overlapped_Overlapped_DisconnectEx(OverlappedObject *self, PyObject *const *arg
     HANDLE Socket;
     DWORD flags;
 
-    if (!_PyArg_CheckPositional("DisconnectEx", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "DisconnectEx", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "DisconnectEx", nargs);
         goto exit;
     }
     Socket = PyLong_AsVoidPtr(args[0]);
@@ -954,7 +1158,19 @@ _overlapped_Overlapped_TransmitFile(OverlappedObject *self, PyObject *const *arg
     DWORD count_per_send;
     DWORD flags;
 
-    if (!_PyArg_CheckPositional("TransmitFile", nargs, 7, 7)) {
+    if (nargs < 7) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 7 arguments, got %zd",
+            "TransmitFile", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 7) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 7 arguments, got %zd",
+            "TransmitFile", nargs);
         goto exit;
     }
     Socket = PyLong_AsVoidPtr(args[0]);
@@ -1071,7 +1287,19 @@ _overlapped_WSAConnect(PyObject *module, PyObject *const *args, Py_ssize_t nargs
     HANDLE ConnectSocket;
     PyObject *AddressObj;
 
-    if (!_PyArg_CheckPositional("WSAConnect", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "WSAConnect", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "WSAConnect", nargs);
         goto exit;
     }
     ConnectSocket = PyLong_AsVoidPtr(args[0]);
@@ -1112,7 +1340,19 @@ _overlapped_Overlapped_WSASendTo(OverlappedObject *self, PyObject *const *args, 
     DWORD flags;
     PyObject *AddressObj;
 
-    if (!_PyArg_CheckPositional("WSASendTo", nargs, 4, 4)) {
+    if (nargs < 4) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 4 arguments, got %zd",
+            "WSASendTo", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 4) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 4 arguments, got %zd",
+            "WSASendTo", nargs);
         goto exit;
     }
     handle = PyLong_AsVoidPtr(args[0]);
@@ -1163,7 +1403,19 @@ _overlapped_Overlapped_WSARecvFrom(OverlappedObject *self, PyObject *const *args
     DWORD size;
     DWORD flags = 0;
 
-    if (!_PyArg_CheckPositional("WSARecvFrom", nargs, 2, 3)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 2 arguments, got %zd",
+            "WSARecvFrom", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 3) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 3 arguments, got %zd",
+            "WSARecvFrom", nargs);
         goto exit;
     }
     handle = PyLong_AsVoidPtr(args[0]);
@@ -1209,7 +1461,19 @@ _overlapped_Overlapped_WSARecvFromInto(OverlappedObject *self, PyObject *const *
     DWORD size;
     DWORD flags = 0;
 
-    if (!_PyArg_CheckPositional("WSARecvFromInto", nargs, 3, 4)) {
+    if (nargs < 3) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 3 arguments, got %zd",
+            "WSARecvFromInto", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 4) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 4 arguments, got %zd",
+            "WSARecvFromInto", nargs);
         goto exit;
     }
     handle = PyLong_AsVoidPtr(args[0]);
@@ -1239,4 +1503,4 @@ exit:
 
     return return_value;
 }
-/*[clinic end generated code: output=958cbddbcc355f47 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=60d1625859411afa input=a9049054013a1b77]*/

--- a/Modules/clinic/posixmodule.c.h
+++ b/Modules/clinic/posixmodule.c.h
@@ -3372,7 +3372,19 @@ os_execv(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     path_t path = PATH_T_INITIALIZE("execv", "path", 0, 0);
     PyObject *argv;
 
-    if (!_PyArg_CheckPositional("execv", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "execv", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "execv", nargs);
         goto exit;
     }
     if (!path_converter(args[0], &path)) {
@@ -3794,7 +3806,19 @@ os_spawnv(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     path_t path = PATH_T_INITIALIZE("spawnv", "path", 0, 0);
     PyObject *argv;
 
-    if (!_PyArg_CheckPositional("spawnv", nargs, 3, 3)) {
+    if (nargs < 3) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 3 arguments, got %zd",
+            "spawnv", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 3) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 3 arguments, got %zd",
+            "spawnv", nargs);
         goto exit;
     }
     mode = PyLong_AsInt(args[0]);
@@ -3849,7 +3873,19 @@ os_spawnve(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *argv;
     PyObject *env;
 
-    if (!_PyArg_CheckPositional("spawnve", nargs, 4, 4)) {
+    if (nargs < 4) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 4 arguments, got %zd",
+            "spawnve", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 4) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 4 arguments, got %zd",
+            "spawnve", nargs);
         goto exit;
     }
     mode = PyLong_AsInt(args[0]);
@@ -4816,7 +4852,19 @@ os_getgrouplist(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     const char *user;
     int basegid;
 
-    if (!_PyArg_CheckPositional("getgrouplist", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "getgrouplist", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "getgrouplist", nargs);
         goto exit;
     }
     if (!PyUnicode_Check(args[0])) {
@@ -4870,7 +4918,19 @@ os_getgrouplist(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     const char *user;
     gid_t basegid;
 
-    if (!_PyArg_CheckPositional("getgrouplist", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "getgrouplist", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "getgrouplist", nargs);
         goto exit;
     }
     if (!PyUnicode_Check(args[0])) {
@@ -4944,7 +5004,19 @@ os_initgroups(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *oname = NULL;
     int gid;
 
-    if (!_PyArg_CheckPositional("initgroups", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "initgroups", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "initgroups", nargs);
         goto exit;
     }
     if (!PyUnicode_FSConverter(args[0], &oname)) {
@@ -4990,7 +5062,19 @@ os_initgroups(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *oname = NULL;
     gid_t gid;
 
-    if (!_PyArg_CheckPositional("initgroups", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "initgroups", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "initgroups", nargs);
         goto exit;
     }
     if (!PyUnicode_FSConverter(args[0], &oname)) {
@@ -5392,7 +5476,19 @@ os_setreuid(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     uid_t ruid;
     uid_t euid;
 
-    if (!_PyArg_CheckPositional("setreuid", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "setreuid", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "setreuid", nargs);
         goto exit;
     }
     if (!_Py_Uid_Converter(args[0], &ruid)) {
@@ -5430,7 +5526,19 @@ os_setregid(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     gid_t rgid;
     gid_t egid;
 
-    if (!_PyArg_CheckPositional("setregid", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "setregid", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "setregid", nargs);
         goto exit;
     }
     if (!_Py_Gid_Converter(args[0], &rgid)) {
@@ -6866,7 +6974,19 @@ os_closerange(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     int fd_low;
     int fd_high;
 
-    if (!_PyArg_CheckPositional("closerange", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "closerange", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "closerange", nargs);
         goto exit;
     }
     fd_low = PyLong_AsInt(args[0]);
@@ -7027,7 +7147,19 @@ os_lockf(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     int command;
     Py_off_t length;
 
-    if (!_PyArg_CheckPositional("lockf", nargs, 3, 3)) {
+    if (nargs < 3) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 3 arguments, got %zd",
+            "lockf", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 3) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 3 arguments, got %zd",
+            "lockf", nargs);
         goto exit;
     }
     fd = PyLong_AsInt(args[0]);
@@ -7082,7 +7214,19 @@ os_lseek(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     int how;
     Py_off_t _return_value;
 
-    if (!_PyArg_CheckPositional("lseek", nargs, 3, 3)) {
+    if (nargs < 3) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 3 arguments, got %zd",
+            "lseek", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 3) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 3 arguments, got %zd",
+            "lseek", nargs);
         goto exit;
     }
     fd = PyLong_AsInt(args[0]);
@@ -7125,7 +7269,19 @@ os_read(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     int fd;
     Py_ssize_t length;
 
-    if (!_PyArg_CheckPositional("read", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "read", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "read", nargs);
         goto exit;
     }
     fd = PyLong_AsInt(args[0]);
@@ -7180,7 +7336,19 @@ os_readv(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *buffers;
     Py_ssize_t _return_value;
 
-    if (!_PyArg_CheckPositional("readv", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "readv", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "readv", nargs);
         goto exit;
     }
     fd = PyLong_AsInt(args[0]);
@@ -7225,7 +7393,19 @@ os_pread(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     Py_ssize_t length;
     Py_off_t offset;
 
-    if (!_PyArg_CheckPositional("pread", nargs, 3, 3)) {
+    if (nargs < 3) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 3 arguments, got %zd",
+            "pread", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 3) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 3 arguments, got %zd",
+            "pread", nargs);
         goto exit;
     }
     fd = PyLong_AsInt(args[0]);
@@ -7294,7 +7474,19 @@ os_preadv(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     int flags = 0;
     Py_ssize_t _return_value;
 
-    if (!_PyArg_CheckPositional("preadv", nargs, 3, 4)) {
+    if (nargs < 3) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 3 arguments, got %zd",
+            "preadv", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 4) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 4 arguments, got %zd",
+            "preadv", nargs);
         goto exit;
     }
     fd = PyLong_AsInt(args[0]);
@@ -7345,7 +7537,19 @@ os_write(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     Py_buffer data = {NULL, NULL};
     Py_ssize_t _return_value;
 
-    if (!_PyArg_CheckPositional("write", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "write", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "write", nargs);
         goto exit;
     }
     fd = PyLong_AsInt(args[0]);
@@ -7688,7 +7892,19 @@ os__fcopyfile(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     int out_fd;
     int flags;
 
-    if (!_PyArg_CheckPositional("_fcopyfile", nargs, 3, 3)) {
+    if (nargs < 3) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 3 arguments, got %zd",
+            "_fcopyfile", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 3) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 3 arguments, got %zd",
+            "_fcopyfile", nargs);
         goto exit;
     }
     in_fd = PyLong_AsInt(args[0]);
@@ -7896,7 +8112,19 @@ os_writev(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *buffers;
     Py_ssize_t _return_value;
 
-    if (!_PyArg_CheckPositional("writev", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "writev", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "writev", nargs);
         goto exit;
     }
     fd = PyLong_AsInt(args[0]);
@@ -7943,7 +8171,19 @@ os_pwrite(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     Py_off_t offset;
     Py_ssize_t _return_value;
 
-    if (!_PyArg_CheckPositional("pwrite", nargs, 3, 3)) {
+    if (nargs < 3) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 3 arguments, got %zd",
+            "pwrite", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 3) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 3 arguments, got %zd",
+            "pwrite", nargs);
         goto exit;
     }
     fd = PyLong_AsInt(args[0]);
@@ -8013,7 +8253,19 @@ os_pwritev(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     int flags = 0;
     Py_ssize_t _return_value;
 
-    if (!_PyArg_CheckPositional("pwritev", nargs, 3, 4)) {
+    if (nargs < 3) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 3 arguments, got %zd",
+            "pwritev", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 4) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 4 arguments, got %zd",
+            "pwritev", nargs);
         goto exit;
     }
     fd = PyLong_AsInt(args[0]);
@@ -8572,7 +8824,19 @@ os_makedev(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     int minor;
     dev_t _return_value;
 
-    if (!_PyArg_CheckPositional("makedev", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "makedev", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "makedev", nargs);
         goto exit;
     }
     major = PyLong_AsInt(args[0]);
@@ -8616,7 +8880,19 @@ os_ftruncate(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     int fd;
     Py_off_t length;
 
-    if (!_PyArg_CheckPositional("ftruncate", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "ftruncate", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "ftruncate", nargs);
         goto exit;
     }
     fd = PyLong_AsInt(args[0]);
@@ -8731,7 +9007,19 @@ os_posix_fallocate(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     Py_off_t offset;
     Py_off_t length;
 
-    if (!_PyArg_CheckPositional("posix_fallocate", nargs, 3, 3)) {
+    if (nargs < 3) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 3 arguments, got %zd",
+            "posix_fallocate", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 3) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 3 arguments, got %zd",
+            "posix_fallocate", nargs);
         goto exit;
     }
     fd = PyLong_AsInt(args[0]);
@@ -8784,7 +9072,19 @@ os_posix_fadvise(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     Py_off_t length;
     int advice;
 
-    if (!_PyArg_CheckPositional("posix_fadvise", nargs, 4, 4)) {
+    if (nargs < 4) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 4 arguments, got %zd",
+            "posix_fadvise", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 4) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 4 arguments, got %zd",
+            "posix_fadvise", nargs);
         goto exit;
     }
     fd = PyLong_AsInt(args[0]);
@@ -8830,7 +9130,19 @@ os_putenv(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *name;
     PyObject *value;
 
-    if (!_PyArg_CheckPositional("putenv", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "putenv", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "putenv", nargs);
         goto exit;
     }
     if (!PyUnicode_Check(args[0])) {
@@ -8872,7 +9184,19 @@ os_putenv(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *name = NULL;
     PyObject *value = NULL;
 
-    if (!_PyArg_CheckPositional("putenv", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "putenv", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "putenv", nargs);
         goto exit;
     }
     if (!PyUnicode_FSConverter(args[0], &name)) {
@@ -9688,7 +10012,19 @@ os_fpathconf(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     int name;
     long _return_value;
 
-    if (!_PyArg_CheckPositional("fpathconf", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "fpathconf", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "fpathconf", nargs);
         goto exit;
     }
     if (!_PyLong_FileDescriptor_Converter(args[0], &fd)) {
@@ -10128,7 +10464,19 @@ os_setresuid(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     uid_t euid;
     uid_t suid;
 
-    if (!_PyArg_CheckPositional("setresuid", nargs, 3, 3)) {
+    if (nargs < 3) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 3 arguments, got %zd",
+            "setresuid", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 3) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 3 arguments, got %zd",
+            "setresuid", nargs);
         goto exit;
     }
     if (!_Py_Uid_Converter(args[0], &ruid)) {
@@ -10170,7 +10518,19 @@ os_setresgid(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     gid_t egid;
     gid_t sgid;
 
-    if (!_PyArg_CheckPositional("setresgid", nargs, 3, 3)) {
+    if (nargs < 3) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 3 arguments, got %zd",
+            "setresgid", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 3) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 3 arguments, got %zd",
+            "setresgid", nargs);
         goto exit;
     }
     if (!_Py_Gid_Converter(args[0], &rgid)) {
@@ -10942,7 +11302,19 @@ os_get_terminal_size(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *return_value = NULL;
     int fd = fileno(stdout);
 
-    if (!_PyArg_CheckPositional("get_terminal_size", nargs, 0, 1)) {
+    if (nargs < 0) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 0 arguments, got %zd",
+            "get_terminal_size", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 1 argument, got %zd",
+            "get_terminal_size", nargs);
         goto exit;
     }
     if (nargs < 1) {
@@ -11033,7 +11405,19 @@ os_set_inheritable(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     int fd;
     int inheritable;
 
-    if (!_PyArg_CheckPositional("set_inheritable", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "set_inheritable", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "set_inheritable", nargs);
         goto exit;
     }
     fd = PyLong_AsInt(args[0]);
@@ -11177,7 +11561,19 @@ os_set_blocking(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     int fd;
     int blocking;
 
-    if (!_PyArg_CheckPositional("set_blocking", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "set_blocking", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "set_blocking", nargs);
         goto exit;
     }
     fd = PyLong_AsInt(args[0]);
@@ -12588,4 +12984,4 @@ os__supports_virtual_terminal(PyObject *module, PyObject *Py_UNUSED(ignored))
 #ifndef OS__SUPPORTS_VIRTUAL_TERMINAL_METHODDEF
     #define OS__SUPPORTS_VIRTUAL_TERMINAL_METHODDEF
 #endif /* !defined(OS__SUPPORTS_VIRTUAL_TERMINAL_METHODDEF) */
-/*[clinic end generated code: output=2965306970f31c5d input=a9049054013a1b77]*/
+/*[clinic end generated code: output=6003f3560161505e input=a9049054013a1b77]*/

--- a/Modules/clinic/readline.c.h
+++ b/Modules/clinic/readline.c.h
@@ -2,7 +2,7 @@
 preserve
 [clinic start generated code]*/
 
-#include "pycore_modsupport.h"    // _PyArg_CheckPositional()
+#include "pycore_modsupport.h"    // _PyArg_BadArgument()
 
 PyDoc_STRVAR(readline_parse_and_bind__doc__,
 "parse_and_bind($module, string, /)\n"
@@ -33,7 +33,19 @@ readline_read_init_file(PyObject *module, PyObject *const *args, Py_ssize_t narg
     PyObject *return_value = NULL;
     PyObject *filename_obj = Py_None;
 
-    if (!_PyArg_CheckPositional("read_init_file", nargs, 0, 1)) {
+    if (nargs < 0) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 0 arguments, got %zd",
+            "read_init_file", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 1 argument, got %zd",
+            "read_init_file", nargs);
         goto exit;
     }
     if (nargs < 1) {
@@ -67,7 +79,19 @@ readline_read_history_file(PyObject *module, PyObject *const *args, Py_ssize_t n
     PyObject *return_value = NULL;
     PyObject *filename_obj = Py_None;
 
-    if (!_PyArg_CheckPositional("read_history_file", nargs, 0, 1)) {
+    if (nargs < 0) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 0 arguments, got %zd",
+            "read_history_file", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 1 argument, got %zd",
+            "read_history_file", nargs);
         goto exit;
     }
     if (nargs < 1) {
@@ -101,7 +125,19 @@ readline_write_history_file(PyObject *module, PyObject *const *args, Py_ssize_t 
     PyObject *return_value = NULL;
     PyObject *filename_obj = Py_None;
 
-    if (!_PyArg_CheckPositional("write_history_file", nargs, 0, 1)) {
+    if (nargs < 0) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 0 arguments, got %zd",
+            "write_history_file", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 1 argument, got %zd",
+            "write_history_file", nargs);
         goto exit;
     }
     if (nargs < 1) {
@@ -139,7 +175,19 @@ readline_append_history_file(PyObject *module, PyObject *const *args, Py_ssize_t
     int nelements;
     PyObject *filename_obj = Py_None;
 
-    if (!_PyArg_CheckPositional("append_history_file", nargs, 1, 2)) {
+    if (nargs < 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 1 argument, got %zd",
+            "append_history_file", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 2 arguments, got %zd",
+            "append_history_file", nargs);
         goto exit;
     }
     nelements = PyLong_AsInt(args[0]);
@@ -230,7 +278,19 @@ readline_set_completion_display_matches_hook(PyObject *module, PyObject *const *
     PyObject *return_value = NULL;
     PyObject *function = Py_None;
 
-    if (!_PyArg_CheckPositional("set_completion_display_matches_hook", nargs, 0, 1)) {
+    if (nargs < 0) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 0 arguments, got %zd",
+            "set_completion_display_matches_hook", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 1 argument, got %zd",
+            "set_completion_display_matches_hook", nargs);
         goto exit;
     }
     if (nargs < 1) {
@@ -265,7 +325,19 @@ readline_set_startup_hook(PyObject *module, PyObject *const *args, Py_ssize_t na
     PyObject *return_value = NULL;
     PyObject *function = Py_None;
 
-    if (!_PyArg_CheckPositional("set_startup_hook", nargs, 0, 1)) {
+    if (nargs < 0) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 0 arguments, got %zd",
+            "set_startup_hook", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 1 argument, got %zd",
+            "set_startup_hook", nargs);
         goto exit;
     }
     if (nargs < 1) {
@@ -303,7 +375,19 @@ readline_set_pre_input_hook(PyObject *module, PyObject *const *args, Py_ssize_t 
     PyObject *return_value = NULL;
     PyObject *function = Py_None;
 
-    if (!_PyArg_CheckPositional("set_pre_input_hook", nargs, 0, 1)) {
+    if (nargs < 0) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 0 arguments, got %zd",
+            "set_pre_input_hook", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 1 argument, got %zd",
+            "set_pre_input_hook", nargs);
         goto exit;
     }
     if (nargs < 1) {
@@ -432,7 +516,19 @@ readline_replace_history_item(PyObject *module, PyObject *const *args, Py_ssize_
     int entry_number;
     PyObject *line;
 
-    if (!_PyArg_CheckPositional("replace_history_item", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "replace_history_item", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "replace_history_item", nargs);
         goto exit;
     }
     entry_number = PyLong_AsInt(args[0]);
@@ -528,7 +624,19 @@ readline_set_completer(PyObject *module, PyObject *const *args, Py_ssize_t nargs
     PyObject *return_value = NULL;
     PyObject *function = Py_None;
 
-    if (!_PyArg_CheckPositional("set_completer", nargs, 0, 1)) {
+    if (nargs < 0) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 0 arguments, got %zd",
+            "set_completer", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 1 argument, got %zd",
+            "set_completer", nargs);
         goto exit;
     }
     if (nargs < 1) {
@@ -684,4 +792,4 @@ readline_redisplay(PyObject *module, PyObject *Py_UNUSED(ignored))
 #ifndef READLINE_CLEAR_HISTORY_METHODDEF
     #define READLINE_CLEAR_HISTORY_METHODDEF
 #endif /* !defined(READLINE_CLEAR_HISTORY_METHODDEF) */
-/*[clinic end generated code: output=358ab465285c7949 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=1dee9364886f03ce input=a9049054013a1b77]*/

--- a/Modules/clinic/selectmodule.c.h
+++ b/Modules/clinic/selectmodule.c.h
@@ -8,7 +8,7 @@ preserve
 #endif
 #include "pycore_fileutils.h"     // _PyLong_FileDescriptor_Converter()
 #include "pycore_long.h"          // _PyLong_UnsignedShort_Converter()
-#include "pycore_modsupport.h"    // _PyArg_CheckPositional()
+#include "pycore_modsupport.h"    // _PyArg_UnpackKeywords()
 
 PyDoc_STRVAR(select_select__doc__,
 "select($module, rlist, wlist, xlist, timeout=None, /)\n"
@@ -53,7 +53,19 @@ select_select(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *xlist;
     PyObject *timeout_obj = Py_None;
 
-    if (!_PyArg_CheckPositional("select", nargs, 3, 4)) {
+    if (nargs < 3) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 3 arguments, got %zd",
+            "select", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 4) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 4 arguments, got %zd",
+            "select", nargs);
         goto exit;
     }
     rlist = args[0];
@@ -97,7 +109,19 @@ select_poll_register(pollObject *self, PyObject *const *args, Py_ssize_t nargs)
     int fd;
     unsigned short eventmask = POLLIN | POLLPRI | POLLOUT;
 
-    if (!_PyArg_CheckPositional("register", nargs, 1, 2)) {
+    if (nargs < 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 1 argument, got %zd",
+            "register", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 2 arguments, got %zd",
+            "register", nargs);
         goto exit;
     }
     if (!_PyLong_FileDescriptor_Converter(args[0], &fd)) {
@@ -145,7 +169,19 @@ select_poll_modify(pollObject *self, PyObject *const *args, Py_ssize_t nargs)
     int fd;
     unsigned short eventmask;
 
-    if (!_PyArg_CheckPositional("modify", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "modify", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "modify", nargs);
         goto exit;
     }
     if (!_PyLong_FileDescriptor_Converter(args[0], &fd)) {
@@ -220,7 +256,19 @@ select_poll_poll(pollObject *self, PyObject *const *args, Py_ssize_t nargs)
     PyObject *return_value = NULL;
     PyObject *timeout_obj = Py_None;
 
-    if (!_PyArg_CheckPositional("poll", nargs, 0, 1)) {
+    if (nargs < 0) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 0 arguments, got %zd",
+            "poll", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 1 argument, got %zd",
+            "poll", nargs);
         goto exit;
     }
     if (nargs < 1) {
@@ -265,7 +313,19 @@ select_devpoll_register(devpollObject *self, PyObject *const *args, Py_ssize_t n
     int fd;
     unsigned short eventmask = POLLIN | POLLPRI | POLLOUT;
 
-    if (!_PyArg_CheckPositional("register", nargs, 1, 2)) {
+    if (nargs < 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 1 argument, got %zd",
+            "register", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 2 arguments, got %zd",
+            "register", nargs);
         goto exit;
     }
     if (!_PyLong_FileDescriptor_Converter(args[0], &fd)) {
@@ -315,7 +375,19 @@ select_devpoll_modify(devpollObject *self, PyObject *const *args, Py_ssize_t nar
     int fd;
     unsigned short eventmask = POLLIN | POLLPRI | POLLOUT;
 
-    if (!_PyArg_CheckPositional("modify", nargs, 1, 2)) {
+    if (nargs < 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 1 argument, got %zd",
+            "modify", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 2 arguments, got %zd",
+            "modify", nargs);
         goto exit;
     }
     if (!_PyLong_FileDescriptor_Converter(args[0], &fd)) {
@@ -394,7 +466,19 @@ select_devpoll_poll(devpollObject *self, PyObject *const *args, Py_ssize_t nargs
     PyObject *return_value = NULL;
     PyObject *timeout_obj = Py_None;
 
-    if (!_PyArg_CheckPositional("poll", nargs, 0, 1)) {
+    if (nargs < 0) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 0 arguments, got %zd",
+            "poll", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 1 argument, got %zd",
+            "poll", nargs);
         goto exit;
     }
     if (nargs < 1) {
@@ -1012,7 +1096,19 @@ select_epoll___exit__(pyEpoll_Object *self, PyObject *const *args, Py_ssize_t na
     PyObject *exc_value = Py_None;
     PyObject *exc_tb = Py_None;
 
-    if (!_PyArg_CheckPositional("__exit__", nargs, 0, 3)) {
+    if (nargs < 0) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 0 arguments, got %zd",
+            "__exit__", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 3) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 3 arguments, got %zd",
+            "__exit__", nargs);
         goto exit;
     }
     if (nargs < 1) {
@@ -1191,7 +1287,19 @@ select_kqueue_control(kqueue_queue_Object *self, PyObject *const *args, Py_ssize
     int maxevents;
     PyObject *otimeout = Py_None;
 
-    if (!_PyArg_CheckPositional("control", nargs, 2, 3)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 2 arguments, got %zd",
+            "control", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 3) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 3 arguments, got %zd",
+            "control", nargs);
         goto exit;
     }
     changelist = args[0];
@@ -1311,4 +1419,4 @@ exit:
 #ifndef SELECT_KQUEUE_CONTROL_METHODDEF
     #define SELECT_KQUEUE_CONTROL_METHODDEF
 #endif /* !defined(SELECT_KQUEUE_CONTROL_METHODDEF) */
-/*[clinic end generated code: output=4c2dcb31cb17c2c6 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=4b62d25fbb18c236 input=a9049054013a1b77]*/

--- a/Modules/clinic/signalmodule.c.h
+++ b/Modules/clinic/signalmodule.c.h
@@ -2,7 +2,7 @@
 preserve
 [clinic start generated code]*/
 
-#include "pycore_modsupport.h"    // _PyArg_CheckPositional()
+#include "pycore_modsupport.h"    // _PyArg_BadArgument()
 
 PyDoc_STRVAR(signal_default_int_handler__doc__,
 "default_int_handler($module, signalnum, frame, /)\n"
@@ -26,7 +26,19 @@ signal_default_int_handler(PyObject *module, PyObject *const *args, Py_ssize_t n
     int signalnum;
     PyObject *frame;
 
-    if (!_PyArg_CheckPositional("default_int_handler", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "default_int_handler", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "default_int_handler", nargs);
         goto exit;
     }
     signalnum = PyLong_AsInt(args[0]);
@@ -153,7 +165,19 @@ signal_signal(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     int signalnum;
     PyObject *handler;
 
-    if (!_PyArg_CheckPositional("signal", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "signal", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "signal", nargs);
         goto exit;
     }
     signalnum = PyLong_AsInt(args[0]);
@@ -257,7 +281,19 @@ signal_siginterrupt(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     int signalnum;
     int flag;
 
-    if (!_PyArg_CheckPositional("siginterrupt", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "siginterrupt", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "siginterrupt", nargs);
         goto exit;
     }
     signalnum = PyLong_AsInt(args[0]);
@@ -304,7 +340,19 @@ signal_setitimer(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *seconds;
     PyObject *interval = NULL;
 
-    if (!_PyArg_CheckPositional("setitimer", nargs, 2, 3)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 2 arguments, got %zd",
+            "setitimer", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 3) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 3 arguments, got %zd",
+            "setitimer", nargs);
         goto exit;
     }
     which = PyLong_AsInt(args[0]);
@@ -378,7 +426,19 @@ signal_pthread_sigmask(PyObject *module, PyObject *const *args, Py_ssize_t nargs
     int how;
     sigset_t mask;
 
-    if (!_PyArg_CheckPositional("pthread_sigmask", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "pthread_sigmask", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "pthread_sigmask", nargs);
         goto exit;
     }
     how = PyLong_AsInt(args[0]);
@@ -538,7 +598,19 @@ signal_sigtimedwait(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     sigset_t sigset;
     PyObject *timeout_obj;
 
-    if (!_PyArg_CheckPositional("sigtimedwait", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "sigtimedwait", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "sigtimedwait", nargs);
         goto exit;
     }
     if (!_Py_Sigset_Converter(args[0], &sigset)) {
@@ -575,7 +647,19 @@ signal_pthread_kill(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     unsigned long thread_id;
     int signalnum;
 
-    if (!_PyArg_CheckPositional("pthread_kill", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "pthread_kill", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "pthread_kill", nargs);
         goto exit;
     }
     if (!PyLong_Check(args[0])) {
@@ -619,7 +703,19 @@ signal_pidfd_send_signal(PyObject *module, PyObject *const *args, Py_ssize_t nar
     PyObject *siginfo = Py_None;
     int flags = 0;
 
-    if (!_PyArg_CheckPositional("pidfd_send_signal", nargs, 2, 4)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 2 arguments, got %zd",
+            "pidfd_send_signal", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 4) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 4 arguments, got %zd",
+            "pidfd_send_signal", nargs);
         goto exit;
     }
     pidfd = PyLong_AsInt(args[0]);
@@ -701,4 +797,4 @@ exit:
 #ifndef SIGNAL_PIDFD_SEND_SIGNAL_METHODDEF
     #define SIGNAL_PIDFD_SEND_SIGNAL_METHODDEF
 #endif /* !defined(SIGNAL_PIDFD_SEND_SIGNAL_METHODDEF) */
-/*[clinic end generated code: output=5a9928cb2dc75b5f input=a9049054013a1b77]*/
+/*[clinic end generated code: output=5a3acd127ff105c9 input=a9049054013a1b77]*/

--- a/Modules/clinic/symtablemodule.c.h
+++ b/Modules/clinic/symtablemodule.c.h
@@ -2,7 +2,7 @@
 preserve
 [clinic start generated code]*/
 
-#include "pycore_modsupport.h"    // _PyArg_CheckPositional()
+#include "pycore_modsupport.h"    // _PyArg_BadArgument()
 
 PyDoc_STRVAR(_symtable_symtable__doc__,
 "symtable($module, source, filename, startstr, /)\n"
@@ -25,7 +25,19 @@ _symtable_symtable(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *filename;
     const char *startstr;
 
-    if (!_PyArg_CheckPositional("symtable", nargs, 3, 3)) {
+    if (nargs < 3) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 3 arguments, got %zd",
+            "symtable", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 3) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 3 arguments, got %zd",
+            "symtable", nargs);
         goto exit;
     }
     source = args[0];
@@ -50,4 +62,4 @@ _symtable_symtable(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=931964a76a72f850 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=9c4a9ad16f718124 input=a9049054013a1b77]*/

--- a/Modules/clinic/termios.c.h
+++ b/Modules/clinic/termios.c.h
@@ -3,7 +3,6 @@ preserve
 [clinic start generated code]*/
 
 #include "pycore_fileutils.h"     // _PyLong_FileDescriptor_Converter()
-#include "pycore_modsupport.h"    // _PyArg_CheckPositional()
 
 PyDoc_STRVAR(termios_tcgetattr__doc__,
 "tcgetattr($module, fd, /)\n"
@@ -66,7 +65,19 @@ termios_tcsetattr(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     int when;
     PyObject *term;
 
-    if (!_PyArg_CheckPositional("tcsetattr", nargs, 3, 3)) {
+    if (nargs < 3) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 3 arguments, got %zd",
+            "tcsetattr", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 3) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 3 arguments, got %zd",
+            "tcsetattr", nargs);
         goto exit;
     }
     if (!_PyLong_FileDescriptor_Converter(args[0], &fd)) {
@@ -105,7 +116,19 @@ termios_tcsendbreak(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     int fd;
     int duration;
 
-    if (!_PyArg_CheckPositional("tcsendbreak", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "tcsendbreak", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "tcsendbreak", nargs);
         goto exit;
     }
     if (!_PyLong_FileDescriptor_Converter(args[0], &fd)) {
@@ -171,7 +194,19 @@ termios_tcflush(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     int fd;
     int queue;
 
-    if (!_PyArg_CheckPositional("tcflush", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "tcflush", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "tcflush", nargs);
         goto exit;
     }
     if (!_PyLong_FileDescriptor_Converter(args[0], &fd)) {
@@ -210,7 +245,19 @@ termios_tcflow(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     int fd;
     int action;
 
-    if (!_PyArg_CheckPositional("tcflow", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "tcflow", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "tcflow", nargs);
         goto exit;
     }
     if (!_PyLong_FileDescriptor_Converter(args[0], &fd)) {
@@ -277,7 +324,19 @@ termios_tcsetwinsize(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     int fd;
     PyObject *winsz;
 
-    if (!_PyArg_CheckPositional("tcsetwinsize", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "tcsetwinsize", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "tcsetwinsize", nargs);
         goto exit;
     }
     if (!_PyLong_FileDescriptor_Converter(args[0], &fd)) {
@@ -289,4 +348,4 @@ termios_tcsetwinsize(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=f31382658135c774 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=f3e6852f693d0891 input=a9049054013a1b77]*/

--- a/Modules/clinic/unicodedata.c.h
+++ b/Modules/clinic/unicodedata.c.h
@@ -2,7 +2,7 @@
 preserve
 [clinic start generated code]*/
 
-#include "pycore_modsupport.h"    // _PyArg_CheckPositional()
+#include "pycore_modsupport.h"    // _PyArg_BadArgument()
 
 PyDoc_STRVAR(unicodedata_UCD_decimal__doc__,
 "decimal($self, chr, default=<unrepresentable>, /)\n"
@@ -28,7 +28,19 @@ unicodedata_UCD_decimal(PyObject *self, PyObject *const *args, Py_ssize_t nargs)
     int chr;
     PyObject *default_value = NULL;
 
-    if (!_PyArg_CheckPositional("decimal", nargs, 1, 2)) {
+    if (nargs < 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 1 argument, got %zd",
+            "decimal", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 2 arguments, got %zd",
+            "decimal", nargs);
         goto exit;
     }
     if (!PyUnicode_Check(args[0])) {
@@ -74,7 +86,19 @@ unicodedata_UCD_digit(PyObject *self, PyObject *const *args, Py_ssize_t nargs)
     int chr;
     PyObject *default_value = NULL;
 
-    if (!_PyArg_CheckPositional("digit", nargs, 1, 2)) {
+    if (nargs < 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 1 argument, got %zd",
+            "digit", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 2 arguments, got %zd",
+            "digit", nargs);
         goto exit;
     }
     if (!PyUnicode_Check(args[0])) {
@@ -121,7 +145,19 @@ unicodedata_UCD_numeric(PyObject *self, PyObject *const *args, Py_ssize_t nargs)
     int chr;
     PyObject *default_value = NULL;
 
-    if (!_PyArg_CheckPositional("numeric", nargs, 1, 2)) {
+    if (nargs < 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 1 argument, got %zd",
+            "numeric", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 2 arguments, got %zd",
+            "numeric", nargs);
         goto exit;
     }
     if (!PyUnicode_Check(args[0])) {
@@ -383,7 +419,19 @@ unicodedata_UCD_is_normalized(PyObject *self, PyObject *const *args, Py_ssize_t 
     PyObject *form;
     PyObject *input;
 
-    if (!_PyArg_CheckPositional("is_normalized", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "is_normalized", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "is_normalized", nargs);
         goto exit;
     }
     if (!PyUnicode_Check(args[0])) {
@@ -424,7 +472,19 @@ unicodedata_UCD_normalize(PyObject *self, PyObject *const *args, Py_ssize_t narg
     PyObject *form;
     PyObject *input;
 
-    if (!_PyArg_CheckPositional("normalize", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "normalize", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "normalize", nargs);
         goto exit;
     }
     if (!PyUnicode_Check(args[0])) {
@@ -465,7 +525,19 @@ unicodedata_UCD_name(PyObject *self, PyObject *const *args, Py_ssize_t nargs)
     int chr;
     PyObject *default_value = NULL;
 
-    if (!_PyArg_CheckPositional("name", nargs, 1, 2)) {
+    if (nargs < 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 1 argument, got %zd",
+            "name", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 2 arguments, got %zd",
+            "name", nargs);
         goto exit;
     }
     if (!PyUnicode_Check(args[0])) {
@@ -519,4 +591,4 @@ unicodedata_UCD_lookup(PyObject *self, PyObject *arg)
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=ea30f89007b2bfff input=a9049054013a1b77]*/
+/*[clinic end generated code: output=5a1470f0d0cabae6 input=a9049054013a1b77]*/

--- a/Modules/clinic/zlibmodule.c.h
+++ b/Modules/clinic/zlibmodule.c.h
@@ -996,7 +996,19 @@ zlib_adler32(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     Py_buffer data = {NULL, NULL};
     unsigned int value = 1;
 
-    if (!_PyArg_CheckPositional("adler32", nargs, 1, 2)) {
+    if (nargs < 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 1 argument, got %zd",
+            "adler32", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 2 arguments, got %zd",
+            "adler32", nargs);
         goto exit;
     }
     if (PyObject_GetBuffer(args[0], &data, PyBUF_SIMPLE) != 0) {
@@ -1046,7 +1058,19 @@ zlib_crc32(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     unsigned int value = 0;
     unsigned int _return_value;
 
-    if (!_PyArg_CheckPositional("crc32", nargs, 1, 2)) {
+    if (nargs < 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 1 argument, got %zd",
+            "crc32", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 2 arguments, got %zd",
+            "crc32", nargs);
         goto exit;
     }
     if (PyObject_GetBuffer(args[0], &data, PyBUF_SIMPLE) != 0) {
@@ -1098,4 +1122,4 @@ exit:
 #ifndef ZLIB_DECOMPRESS___DEEPCOPY___METHODDEF
     #define ZLIB_DECOMPRESS___DEEPCOPY___METHODDEF
 #endif /* !defined(ZLIB_DECOMPRESS___DEEPCOPY___METHODDEF) */
-/*[clinic end generated code: output=8bb840fb6af43dd4 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=36641a8f664a6d98 input=a9049054013a1b77]*/

--- a/Objects/clinic/bytearrayobject.c.h
+++ b/Objects/clinic/bytearrayobject.c.h
@@ -302,7 +302,19 @@ bytearray_maketrans(void *null, PyObject *const *args, Py_ssize_t nargs)
     Py_buffer frm = {NULL, NULL};
     Py_buffer to = {NULL, NULL};
 
-    if (!_PyArg_CheckPositional("maketrans", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "maketrans", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "maketrans", nargs);
         goto exit;
     }
     if (PyObject_GetBuffer(args[0], &frm, PyBUF_SIMPLE) != 0) {
@@ -354,7 +366,19 @@ bytearray_replace(PyByteArrayObject *self, PyObject *const *args, Py_ssize_t nar
     Py_buffer new = {NULL, NULL};
     Py_ssize_t count = -1;
 
-    if (!_PyArg_CheckPositional("replace", nargs, 2, 3)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 2 arguments, got %zd",
+            "replace", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 3) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 3 arguments, got %zd",
+            "replace", nargs);
         goto exit;
     }
     if (PyObject_GetBuffer(args[0], &old, PyBUF_SIMPLE) != 0) {
@@ -645,7 +669,19 @@ bytearray_insert(PyByteArrayObject *self, PyObject *const *args, Py_ssize_t narg
     Py_ssize_t index;
     int item;
 
-    if (!_PyArg_CheckPositional("insert", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "insert", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "insert", nargs);
         goto exit;
     }
     {
@@ -735,7 +771,19 @@ bytearray_pop(PyByteArrayObject *self, PyObject *const *args, Py_ssize_t nargs)
     PyObject *return_value = NULL;
     Py_ssize_t index = -1;
 
-    if (!_PyArg_CheckPositional("pop", nargs, 0, 1)) {
+    if (nargs < 0) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 0 arguments, got %zd",
+            "pop", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 1 argument, got %zd",
+            "pop", nargs);
         goto exit;
     }
     if (nargs < 1) {
@@ -810,7 +858,19 @@ bytearray_strip(PyByteArrayObject *self, PyObject *const *args, Py_ssize_t nargs
     PyObject *return_value = NULL;
     PyObject *bytes = Py_None;
 
-    if (!_PyArg_CheckPositional("strip", nargs, 0, 1)) {
+    if (nargs < 0) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 0 arguments, got %zd",
+            "strip", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 1 argument, got %zd",
+            "strip", nargs);
         goto exit;
     }
     if (nargs < 1) {
@@ -844,7 +904,19 @@ bytearray_lstrip(PyByteArrayObject *self, PyObject *const *args, Py_ssize_t narg
     PyObject *return_value = NULL;
     PyObject *bytes = Py_None;
 
-    if (!_PyArg_CheckPositional("lstrip", nargs, 0, 1)) {
+    if (nargs < 0) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 0 arguments, got %zd",
+            "lstrip", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 1 argument, got %zd",
+            "lstrip", nargs);
         goto exit;
     }
     if (nargs < 1) {
@@ -878,7 +950,19 @@ bytearray_rstrip(PyByteArrayObject *self, PyObject *const *args, Py_ssize_t narg
     PyObject *return_value = NULL;
     PyObject *bytes = Py_None;
 
-    if (!_PyArg_CheckPositional("rstrip", nargs, 0, 1)) {
+    if (nargs < 0) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 0 arguments, got %zd",
+            "rstrip", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 1 argument, got %zd",
+            "rstrip", nargs);
         goto exit;
     }
     if (nargs < 1) {
@@ -1227,7 +1311,19 @@ bytearray_reduce_ex(PyByteArrayObject *self, PyObject *const *args, Py_ssize_t n
     PyObject *return_value = NULL;
     int proto = 0;
 
-    if (!_PyArg_CheckPositional("__reduce_ex__", nargs, 0, 1)) {
+    if (nargs < 0) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 0 arguments, got %zd",
+            "__reduce_ex__", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 1 argument, got %zd",
+            "__reduce_ex__", nargs);
         goto exit;
     }
     if (nargs < 1) {
@@ -1261,4 +1357,4 @@ bytearray_sizeof(PyByteArrayObject *self, PyObject *Py_UNUSED(ignored))
 {
     return bytearray_sizeof_impl(self);
 }
-/*[clinic end generated code: output=0797a5e03cda2a16 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=2575cce6036fc69b input=a9049054013a1b77]*/

--- a/Objects/clinic/bytesobject.c.h
+++ b/Objects/clinic/bytesobject.c.h
@@ -314,7 +314,19 @@ bytes_strip(PyBytesObject *self, PyObject *const *args, Py_ssize_t nargs)
     PyObject *return_value = NULL;
     PyObject *bytes = Py_None;
 
-    if (!_PyArg_CheckPositional("strip", nargs, 0, 1)) {
+    if (nargs < 0) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 0 arguments, got %zd",
+            "strip", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 1 argument, got %zd",
+            "strip", nargs);
         goto exit;
     }
     if (nargs < 1) {
@@ -348,7 +360,19 @@ bytes_lstrip(PyBytesObject *self, PyObject *const *args, Py_ssize_t nargs)
     PyObject *return_value = NULL;
     PyObject *bytes = Py_None;
 
-    if (!_PyArg_CheckPositional("lstrip", nargs, 0, 1)) {
+    if (nargs < 0) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 0 arguments, got %zd",
+            "lstrip", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 1 argument, got %zd",
+            "lstrip", nargs);
         goto exit;
     }
     if (nargs < 1) {
@@ -382,7 +406,19 @@ bytes_rstrip(PyBytesObject *self, PyObject *const *args, Py_ssize_t nargs)
     PyObject *return_value = NULL;
     PyObject *bytes = Py_None;
 
-    if (!_PyArg_CheckPositional("rstrip", nargs, 0, 1)) {
+    if (nargs < 0) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 0 arguments, got %zd",
+            "rstrip", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 1 argument, got %zd",
+            "rstrip", nargs);
         goto exit;
     }
     if (nargs < 1) {
@@ -489,7 +525,19 @@ bytes_maketrans(void *null, PyObject *const *args, Py_ssize_t nargs)
     Py_buffer frm = {NULL, NULL};
     Py_buffer to = {NULL, NULL};
 
-    if (!_PyArg_CheckPositional("maketrans", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "maketrans", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "maketrans", nargs);
         goto exit;
     }
     if (PyObject_GetBuffer(args[0], &frm, PyBUF_SIMPLE) != 0) {
@@ -541,7 +589,19 @@ bytes_replace(PyBytesObject *self, PyObject *const *args, Py_ssize_t nargs)
     Py_buffer new = {NULL, NULL};
     Py_ssize_t count = -1;
 
-    if (!_PyArg_CheckPositional("replace", nargs, 2, 3)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 2 arguments, got %zd",
+            "replace", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 3) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 3 arguments, got %zd",
+            "replace", nargs);
         goto exit;
     }
     if (PyObject_GetBuffer(args[0], &old, PyBUF_SIMPLE) != 0) {
@@ -1029,4 +1089,4 @@ skip_optional_pos:
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=8a49dbbd78914a6f input=a9049054013a1b77]*/
+/*[clinic end generated code: output=bbf8fb568d2767c5 input=a9049054013a1b77]*/

--- a/Objects/clinic/classobject.c.h
+++ b/Objects/clinic/classobject.c.h
@@ -2,7 +2,7 @@
 preserve
 [clinic start generated code]*/
 
-#include "pycore_modsupport.h"    // _PyArg_CheckPositional()
+#include "pycore_modsupport.h"    // _PyArg_NoKeywords()
 
 PyDoc_STRVAR(method___reduce____doc__,
 "__reduce__($self, /)\n"
@@ -42,7 +42,19 @@ method_new(PyTypeObject *type, PyObject *args, PyObject *kwargs)
         !_PyArg_NoKeywords("method", kwargs)) {
         goto exit;
     }
-    if (!_PyArg_CheckPositional("method", PyTuple_GET_SIZE(args), 2, 2)) {
+    if (PyTuple_GET_SIZE(args) < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "method", PyTuple_GET_SIZE(args));
+        goto exit;
+    }
+
+    if (PyTuple_GET_SIZE(args) != 0 && PyTuple_GET_SIZE(args) > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "method", PyTuple_GET_SIZE(args));
         goto exit;
     }
     function = PyTuple_GET_ITEM(args, 0);
@@ -73,7 +85,19 @@ instancemethod_new(PyTypeObject *type, PyObject *args, PyObject *kwargs)
         !_PyArg_NoKeywords("instancemethod", kwargs)) {
         goto exit;
     }
-    if (!_PyArg_CheckPositional("instancemethod", PyTuple_GET_SIZE(args), 1, 1)) {
+    if (PyTuple_GET_SIZE(args) < 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 1 argument, got %zd",
+            "instancemethod", PyTuple_GET_SIZE(args));
+        goto exit;
+    }
+
+    if (PyTuple_GET_SIZE(args) != 0 && PyTuple_GET_SIZE(args) > 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 1 argument, got %zd",
+            "instancemethod", PyTuple_GET_SIZE(args));
         goto exit;
     }
     function = PyTuple_GET_ITEM(args, 0);
@@ -82,4 +106,4 @@ instancemethod_new(PyTypeObject *type, PyObject *args, PyObject *kwargs)
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=5a5e3f2d0726f189 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=f25d0b51e94fe9dc input=a9049054013a1b77]*/

--- a/Objects/clinic/codeobject.c.h
+++ b/Objects/clinic/codeobject.c.h
@@ -6,7 +6,7 @@ preserve
 #  include "pycore_gc.h"          // PyGC_Head
 #  include "pycore_runtime.h"     // _Py_ID()
 #endif
-#include "pycore_modsupport.h"    // _PyArg_CheckPositional()
+#include "pycore_modsupport.h"    // _PyArg_BadArgument()
 
 PyDoc_STRVAR(code_new__doc__,
 "code(argcount, posonlyargcount, kwonlyargcount, nlocals, stacksize,\n"
@@ -54,7 +54,19 @@ code_new(PyTypeObject *type, PyObject *args, PyObject *kwargs)
         !_PyArg_NoKeywords("code", kwargs)) {
         goto exit;
     }
-    if (!_PyArg_CheckPositional("code", PyTuple_GET_SIZE(args), 16, 18)) {
+    if (PyTuple_GET_SIZE(args) < 16) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 16 arguments, got %zd",
+            "code", PyTuple_GET_SIZE(args));
+        goto exit;
+    }
+
+    if (PyTuple_GET_SIZE(args) != 0 && PyTuple_GET_SIZE(args) > 18) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 18 arguments, got %zd",
+            "code", PyTuple_GET_SIZE(args));
         goto exit;
     }
     argcount = PyLong_AsInt(PyTuple_GET_ITEM(args, 0));
@@ -464,4 +476,4 @@ code__varname_from_oparg(PyCodeObject *self, PyObject *const *args, Py_ssize_t n
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=d604263a3ca72a0f input=a9049054013a1b77]*/
+/*[clinic end generated code: output=46301f0686762260 input=a9049054013a1b77]*/

--- a/Objects/clinic/dictobject.c.h
+++ b/Objects/clinic/dictobject.c.h
@@ -3,7 +3,6 @@ preserve
 [clinic start generated code]*/
 
 #include "pycore_critical_section.h"// Py_BEGIN_CRITICAL_SECTION()
-#include "pycore_modsupport.h"    // _PyArg_CheckPositional()
 
 PyDoc_STRVAR(dict_fromkeys__doc__,
 "fromkeys($type, iterable, value=None, /)\n"
@@ -24,7 +23,19 @@ dict_fromkeys(PyTypeObject *type, PyObject *const *args, Py_ssize_t nargs)
     PyObject *iterable;
     PyObject *value = Py_None;
 
-    if (!_PyArg_CheckPositional("fromkeys", nargs, 1, 2)) {
+    if (nargs < 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 1 argument, got %zd",
+            "fromkeys", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 2 arguments, got %zd",
+            "fromkeys", nargs);
         goto exit;
     }
     iterable = args[0];
@@ -85,7 +96,19 @@ dict_get(PyDictObject *self, PyObject *const *args, Py_ssize_t nargs)
     PyObject *key;
     PyObject *default_value = Py_None;
 
-    if (!_PyArg_CheckPositional("get", nargs, 1, 2)) {
+    if (nargs < 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 1 argument, got %zd",
+            "get", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 2 arguments, got %zd",
+            "get", nargs);
         goto exit;
     }
     key = args[0];
@@ -124,7 +147,19 @@ dict_setdefault(PyDictObject *self, PyObject *const *args, Py_ssize_t nargs)
     PyObject *key;
     PyObject *default_value = Py_None;
 
-    if (!_PyArg_CheckPositional("setdefault", nargs, 1, 2)) {
+    if (nargs < 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 1 argument, got %zd",
+            "setdefault", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 2 arguments, got %zd",
+            "setdefault", nargs);
         goto exit;
     }
     key = args[0];
@@ -181,7 +216,19 @@ dict_pop(PyDictObject *self, PyObject *const *args, Py_ssize_t nargs)
     PyObject *key;
     PyObject *default_value = NULL;
 
-    if (!_PyArg_CheckPositional("pop", nargs, 1, 2)) {
+    if (nargs < 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 1 argument, got %zd",
+            "pop", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 2 arguments, got %zd",
+            "pop", nargs);
         goto exit;
     }
     key = args[0];
@@ -312,4 +359,4 @@ dict_values(PyDictObject *self, PyObject *Py_UNUSED(ignored))
 {
     return dict_values_impl(self);
 }
-/*[clinic end generated code: output=f3dd5f3fb8122aef input=a9049054013a1b77]*/
+/*[clinic end generated code: output=5d9736a719319c4a input=a9049054013a1b77]*/

--- a/Objects/clinic/enumobject.c.h
+++ b/Objects/clinic/enumobject.c.h
@@ -98,7 +98,19 @@ reversed_new(PyTypeObject *type, PyObject *args, PyObject *kwargs)
         !_PyArg_NoKeywords("reversed", kwargs)) {
         goto exit;
     }
-    if (!_PyArg_CheckPositional("reversed", PyTuple_GET_SIZE(args), 1, 1)) {
+    if (PyTuple_GET_SIZE(args) < 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 1 argument, got %zd",
+            "reversed", PyTuple_GET_SIZE(args));
+        goto exit;
+    }
+
+    if (PyTuple_GET_SIZE(args) != 0 && PyTuple_GET_SIZE(args) > 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 1 argument, got %zd",
+            "reversed", PyTuple_GET_SIZE(args));
         goto exit;
     }
     seq = PyTuple_GET_ITEM(args, 0);
@@ -107,4 +119,4 @@ reversed_new(PyTypeObject *type, PyObject *args, PyObject *kwargs)
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=5c48a9a482a52e91 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=1340df5ee1ac4418 input=a9049054013a1b77]*/

--- a/Objects/clinic/floatobject.c.h
+++ b/Objects/clinic/floatobject.c.h
@@ -2,7 +2,7 @@
 preserve
 [clinic start generated code]*/
 
-#include "pycore_modsupport.h"    // _PyArg_CheckPositional()
+#include "pycore_modsupport.h"    // _PyArg_NoKeywords()
 
 PyDoc_STRVAR(float_is_integer__doc__,
 "is_integer($self, /)\n"
@@ -96,7 +96,19 @@ float___round__(PyObject *self, PyObject *const *args, Py_ssize_t nargs)
     PyObject *return_value = NULL;
     PyObject *o_ndigits = Py_None;
 
-    if (!_PyArg_CheckPositional("__round__", nargs, 0, 1)) {
+    if (nargs < 0) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 0 arguments, got %zd",
+            "__round__", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 1 argument, got %zd",
+            "__round__", nargs);
         goto exit;
     }
     if (nargs < 1) {
@@ -213,7 +225,19 @@ float_new(PyTypeObject *type, PyObject *args, PyObject *kwargs)
         !_PyArg_NoKeywords("float", kwargs)) {
         goto exit;
     }
-    if (!_PyArg_CheckPositional("float", PyTuple_GET_SIZE(args), 0, 1)) {
+    if (PyTuple_GET_SIZE(args) < 0) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 0 arguments, got %zd",
+            "float", PyTuple_GET_SIZE(args));
+        goto exit;
+    }
+
+    if (PyTuple_GET_SIZE(args) != 0 && PyTuple_GET_SIZE(args) > 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 1 argument, got %zd",
+            "float", PyTuple_GET_SIZE(args));
         goto exit;
     }
     if (PyTuple_GET_SIZE(args) < 1) {
@@ -318,4 +342,4 @@ float___format__(PyObject *self, PyObject *arg)
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=c79743c8551c30d9 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=ee032f6401dc3156 input=a9049054013a1b77]*/

--- a/Objects/clinic/listobject.c.h
+++ b/Objects/clinic/listobject.c.h
@@ -8,7 +8,7 @@ preserve
 #endif
 #include "pycore_abstract.h"      // _PyNumber_Index()
 #include "pycore_critical_section.h"// Py_BEGIN_CRITICAL_SECTION()
-#include "pycore_modsupport.h"    // _PyArg_CheckPositional()
+#include "pycore_modsupport.h"    // _PyArg_UnpackKeywords()
 
 PyDoc_STRVAR(list_insert__doc__,
 "insert($self, index, object, /)\n"
@@ -29,7 +29,19 @@ list_insert(PyListObject *self, PyObject *const *args, Py_ssize_t nargs)
     Py_ssize_t index;
     PyObject *object;
 
-    if (!_PyArg_CheckPositional("insert", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "insert", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "insert", nargs);
         goto exit;
     }
     {
@@ -154,7 +166,19 @@ list_pop(PyListObject *self, PyObject *const *args, Py_ssize_t nargs)
     PyObject *return_value = NULL;
     Py_ssize_t index = -1;
 
-    if (!_PyArg_CheckPositional("pop", nargs, 0, 1)) {
+    if (nargs < 0) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 0 arguments, got %zd",
+            "pop", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 1 argument, got %zd",
+            "pop", nargs);
         goto exit;
     }
     if (nargs < 1) {
@@ -308,7 +332,19 @@ list_index(PyListObject *self, PyObject *const *args, Py_ssize_t nargs)
     Py_ssize_t start = 0;
     Py_ssize_t stop = PY_SSIZE_T_MAX;
 
-    if (!_PyArg_CheckPositional("index", nargs, 1, 3)) {
+    if (nargs < 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 1 argument, got %zd",
+            "index", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 3) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 3 arguments, got %zd",
+            "index", nargs);
         goto exit;
     }
     value = args[0];
@@ -390,7 +426,19 @@ list___init__(PyObject *self, PyObject *args, PyObject *kwargs)
         !_PyArg_NoKeywords("list", kwargs)) {
         goto exit;
     }
-    if (!_PyArg_CheckPositional("list", PyTuple_GET_SIZE(args), 0, 1)) {
+    if (PyTuple_GET_SIZE(args) < 0) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 0 arguments, got %zd",
+            "list", PyTuple_GET_SIZE(args));
+        goto exit;
+    }
+
+    if (PyTuple_GET_SIZE(args) != 0 && PyTuple_GET_SIZE(args) > 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 1 argument, got %zd",
+            "list", PyTuple_GET_SIZE(args));
         goto exit;
     }
     if (PyTuple_GET_SIZE(args) < 1) {
@@ -439,4 +487,4 @@ list___reversed__(PyListObject *self, PyObject *Py_UNUSED(ignored))
 {
     return list___reversed___impl(self);
 }
-/*[clinic end generated code: output=854957a1d4a89bbd input=a9049054013a1b77]*/
+/*[clinic end generated code: output=a59bf83c3310bf5d input=a9049054013a1b77]*/

--- a/Objects/clinic/longobject.c.h
+++ b/Objects/clinic/longobject.c.h
@@ -135,7 +135,19 @@ int___round__(PyObject *self, PyObject *const *args, Py_ssize_t nargs)
     PyObject *return_value = NULL;
     PyObject *o_ndigits = NULL;
 
-    if (!_PyArg_CheckPositional("__round__", nargs, 0, 1)) {
+    if (nargs < 0) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 0 arguments, got %zd",
+            "__round__", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 1 argument, got %zd",
+            "__round__", nargs);
         goto exit;
     }
     if (nargs < 1) {
@@ -476,4 +488,4 @@ int_is_integer(PyObject *self, PyObject *Py_UNUSED(ignored))
 {
     return int_is_integer_impl(self);
 }
-/*[clinic end generated code: output=7e6e57246e55911f input=a9049054013a1b77]*/
+/*[clinic end generated code: output=d24ff1abe1e67126 input=a9049054013a1b77]*/

--- a/Objects/clinic/setobject.c.h
+++ b/Objects/clinic/setobject.c.h
@@ -3,7 +3,6 @@ preserve
 [clinic start generated code]*/
 
 #include "pycore_critical_section.h"// Py_BEGIN_CRITICAL_SECTION()
-#include "pycore_modsupport.h"    // _PyArg_CheckPositional()
 
 PyDoc_STRVAR(set_pop__doc__,
 "pop($self, /)\n"
@@ -49,7 +48,11 @@ set_update(PySetObject *so, PyObject *const *args, Py_ssize_t nargs)
     PyObject *return_value = NULL;
     PyObject *__clinic_args = NULL;
 
-    if (!_PyArg_CheckPositional("update", nargs, 0, PY_SSIZE_T_MAX)) {
+    if (nargs < 0) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 0 arguments, got %zd",
+            "update", nargs);
         goto exit;
     }
     __clinic_args = PyTuple_New(nargs - 0);
@@ -156,7 +159,11 @@ set_union(PySetObject *so, PyObject *const *args, Py_ssize_t nargs)
     PyObject *return_value = NULL;
     PyObject *__clinic_args = NULL;
 
-    if (!_PyArg_CheckPositional("union", nargs, 0, PY_SSIZE_T_MAX)) {
+    if (nargs < 0) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 0 arguments, got %zd",
+            "union", nargs);
         goto exit;
     }
     __clinic_args = PyTuple_New(nargs - 0);
@@ -191,7 +198,11 @@ set_intersection_multi(PySetObject *so, PyObject *const *args, Py_ssize_t nargs)
     PyObject *return_value = NULL;
     PyObject *__clinic_args = NULL;
 
-    if (!_PyArg_CheckPositional("intersection", nargs, 0, PY_SSIZE_T_MAX)) {
+    if (nargs < 0) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 0 arguments, got %zd",
+            "intersection", nargs);
         goto exit;
     }
     __clinic_args = PyTuple_New(nargs - 0);
@@ -226,7 +237,11 @@ set_intersection_update_multi(PySetObject *so, PyObject *const *args, Py_ssize_t
     PyObject *return_value = NULL;
     PyObject *__clinic_args = NULL;
 
-    if (!_PyArg_CheckPositional("intersection_update", nargs, 0, PY_SSIZE_T_MAX)) {
+    if (nargs < 0) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 0 arguments, got %zd",
+            "intersection_update", nargs);
         goto exit;
     }
     __clinic_args = PyTuple_New(nargs - 0);
@@ -285,7 +300,11 @@ set_difference_update(PySetObject *so, PyObject *const *args, Py_ssize_t nargs)
     PyObject *return_value = NULL;
     PyObject *__clinic_args = NULL;
 
-    if (!_PyArg_CheckPositional("difference_update", nargs, 0, PY_SSIZE_T_MAX)) {
+    if (nargs < 0) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 0 arguments, got %zd",
+            "difference_update", nargs);
         goto exit;
     }
     __clinic_args = PyTuple_New(nargs - 0);
@@ -320,7 +339,11 @@ set_difference_multi(PySetObject *so, PyObject *const *args, Py_ssize_t nargs)
     PyObject *return_value = NULL;
     PyObject *__clinic_args = NULL;
 
-    if (!_PyArg_CheckPositional("difference", nargs, 0, PY_SSIZE_T_MAX)) {
+    if (nargs < 0) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 0 arguments, got %zd",
+            "difference", nargs);
         goto exit;
     }
     __clinic_args = PyTuple_New(nargs - 0);
@@ -568,4 +591,4 @@ set___sizeof__(PySetObject *so, PyObject *Py_UNUSED(ignored))
 
     return return_value;
 }
-/*[clinic end generated code: output=de4ee725bd29f758 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=fc75fe62c2129a58 input=a9049054013a1b77]*/

--- a/Objects/clinic/tupleobject.c.h
+++ b/Objects/clinic/tupleobject.c.h
@@ -2,7 +2,7 @@
 preserve
 [clinic start generated code]*/
 
-#include "pycore_modsupport.h"    // _PyArg_CheckPositional()
+#include "pycore_modsupport.h"    // _PyArg_NoKeywords()
 
 PyDoc_STRVAR(tuple_index__doc__,
 "index($self, value, start=0, stop=sys.maxsize, /)\n"
@@ -27,7 +27,19 @@ tuple_index(PyTupleObject *self, PyObject *const *args, Py_ssize_t nargs)
     Py_ssize_t start = 0;
     Py_ssize_t stop = PY_SSIZE_T_MAX;
 
-    if (!_PyArg_CheckPositional("index", nargs, 1, 3)) {
+    if (nargs < 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 1 argument, got %zd",
+            "index", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 3) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 3 arguments, got %zd",
+            "index", nargs);
         goto exit;
     }
     value = args[0];
@@ -84,7 +96,19 @@ tuple_new(PyTypeObject *type, PyObject *args, PyObject *kwargs)
         !_PyArg_NoKeywords("tuple", kwargs)) {
         goto exit;
     }
-    if (!_PyArg_CheckPositional("tuple", PyTuple_GET_SIZE(args), 0, 1)) {
+    if (PyTuple_GET_SIZE(args) < 0) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 0 arguments, got %zd",
+            "tuple", PyTuple_GET_SIZE(args));
+        goto exit;
+    }
+
+    if (PyTuple_GET_SIZE(args) != 0 && PyTuple_GET_SIZE(args) > 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 1 argument, got %zd",
+            "tuple", PyTuple_GET_SIZE(args));
         goto exit;
     }
     if (PyTuple_GET_SIZE(args) < 1) {
@@ -114,4 +138,4 @@ tuple___getnewargs__(PyTupleObject *self, PyObject *Py_UNUSED(ignored))
 {
     return tuple___getnewargs___impl(self);
 }
-/*[clinic end generated code: output=a6a9abba5d121f4c input=a9049054013a1b77]*/
+/*[clinic end generated code: output=47028d691a554a19 input=a9049054013a1b77]*/

--- a/Objects/clinic/typevarobject.c.h
+++ b/Objects/clinic/typevarobject.c.h
@@ -366,7 +366,19 @@ paramspec_typing_prepare_subst(paramspecobject *self, PyObject *const *args, Py_
     PyObject *alias;
     PyObject *__clinic_args;
 
-    if (!_PyArg_CheckPositional("__typing_prepare_subst__", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "__typing_prepare_subst__", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "__typing_prepare_subst__", nargs);
         goto exit;
     }
     alias = args[0];
@@ -479,7 +491,19 @@ typevartuple_typing_prepare_subst(typevartupleobject *self, PyObject *const *arg
     PyObject *alias;
     PyObject *__clinic_args;
 
-    if (!_PyArg_CheckPositional("__typing_prepare_subst__", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "__typing_prepare_subst__", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "__typing_prepare_subst__", nargs);
         goto exit;
     }
     alias = args[0];
@@ -591,4 +615,4 @@ skip_optional_kwonly:
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=5a582d9d89ad787b input=a9049054013a1b77]*/
+/*[clinic end generated code: output=4776da545b12e4d1 input=a9049054013a1b77]*/

--- a/Objects/clinic/unicodeobject.c.h
+++ b/Objects/clinic/unicodeobject.c.h
@@ -7,7 +7,7 @@ preserve
 #  include "pycore_runtime.h"     // _Py_ID()
 #endif
 #include "pycore_abstract.h"      // _PyNumber_Index()
-#include "pycore_modsupport.h"    // _PyArg_CheckPositional()
+#include "pycore_modsupport.h"    // _PyArg_UnpackKeywords()
 
 PyDoc_STRVAR(EncodingMap_size__doc__,
 "size($self, /)\n"
@@ -108,7 +108,19 @@ unicode_center(PyObject *self, PyObject *const *args, Py_ssize_t nargs)
     Py_ssize_t width;
     Py_UCS4 fillchar = ' ';
 
-    if (!_PyArg_CheckPositional("center", nargs, 1, 2)) {
+    if (nargs < 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 1 argument, got %zd",
+            "center", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 2 arguments, got %zd",
+            "center", nargs);
         goto exit;
     }
     {
@@ -588,7 +600,19 @@ unicode_ljust(PyObject *self, PyObject *const *args, Py_ssize_t nargs)
     Py_ssize_t width;
     Py_UCS4 fillchar = ' ';
 
-    if (!_PyArg_CheckPositional("ljust", nargs, 1, 2)) {
+    if (nargs < 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 1 argument, got %zd",
+            "ljust", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 2 arguments, got %zd",
+            "ljust", nargs);
         goto exit;
     }
     {
@@ -654,7 +678,19 @@ unicode_strip(PyObject *self, PyObject *const *args, Py_ssize_t nargs)
     PyObject *return_value = NULL;
     PyObject *chars = Py_None;
 
-    if (!_PyArg_CheckPositional("strip", nargs, 0, 1)) {
+    if (nargs < 0) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 0 arguments, got %zd",
+            "strip", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 1 argument, got %zd",
+            "strip", nargs);
         goto exit;
     }
     if (nargs < 1) {
@@ -688,7 +724,19 @@ unicode_lstrip(PyObject *self, PyObject *const *args, Py_ssize_t nargs)
     PyObject *return_value = NULL;
     PyObject *chars = Py_None;
 
-    if (!_PyArg_CheckPositional("lstrip", nargs, 0, 1)) {
+    if (nargs < 0) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 0 arguments, got %zd",
+            "lstrip", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 1 argument, got %zd",
+            "lstrip", nargs);
         goto exit;
     }
     if (nargs < 1) {
@@ -722,7 +770,19 @@ unicode_rstrip(PyObject *self, PyObject *const *args, Py_ssize_t nargs)
     PyObject *return_value = NULL;
     PyObject *chars = Py_None;
 
-    if (!_PyArg_CheckPositional("rstrip", nargs, 0, 1)) {
+    if (nargs < 0) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 0 arguments, got %zd",
+            "rstrip", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 1 argument, got %zd",
+            "rstrip", nargs);
         goto exit;
     }
     if (nargs < 1) {
@@ -913,7 +973,19 @@ unicode_rjust(PyObject *self, PyObject *const *args, Py_ssize_t nargs)
     Py_ssize_t width;
     Py_UCS4 fillchar = ' ';
 
-    if (!_PyArg_CheckPositional("rjust", nargs, 1, 2)) {
+    if (nargs < 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 1 argument, got %zd",
+            "rjust", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 2 arguments, got %zd",
+            "rjust", nargs);
         goto exit;
     }
     {
@@ -1269,7 +1341,19 @@ unicode_maketrans(void *null, PyObject *const *args, Py_ssize_t nargs)
     PyObject *y = NULL;
     PyObject *z = NULL;
 
-    if (!_PyArg_CheckPositional("maketrans", nargs, 1, 3)) {
+    if (nargs < 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 1 argument, got %zd",
+            "maketrans", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 3) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 3 arguments, got %zd",
+            "maketrans", nargs);
         goto exit;
     }
     x = args[0];
@@ -1507,4 +1591,4 @@ skip_optional_pos:
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=1aab29bab5201c78 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=fdb2dc9bfcbd5b93 input=a9049054013a1b77]*/

--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -125,6 +125,7 @@ As a consequence of this, split keys have a maximum size of 16.
 #include "pycore_freelist.h"             // _PyFreeListState_GET()
 #include "pycore_gc.h"                   // _PyObject_GC_IS_TRACKED()
 #include "pycore_object.h"               // _PyObject_GC_TRACK(), _PyDebugAllocatorStats()
+#include "pycore_modsupport.h"           // _PyArg_CheckPositional()
 #include "pycore_pyatomic_ft_wrappers.h" // FT_ATOMIC_LOAD_SSIZE_RELAXED
 #include "pycore_pyerrors.h"             // _PyErr_GetRaisedException()
 #include "pycore_pystate.h"              // _PyThreadState_GET()

--- a/Objects/stringlib/clinic/transmogrify.h.h
+++ b/Objects/stringlib/clinic/transmogrify.h.h
@@ -95,7 +95,19 @@ stringlib_ljust(PyObject *self, PyObject *const *args, Py_ssize_t nargs)
     Py_ssize_t width;
     char fillchar = ' ';
 
-    if (!_PyArg_CheckPositional("ljust", nargs, 1, 2)) {
+    if (nargs < 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 1 argument, got %zd",
+            "ljust", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 2 arguments, got %zd",
+            "ljust", nargs);
         goto exit;
     }
     {
@@ -151,7 +163,19 @@ stringlib_rjust(PyObject *self, PyObject *const *args, Py_ssize_t nargs)
     Py_ssize_t width;
     char fillchar = ' ';
 
-    if (!_PyArg_CheckPositional("rjust", nargs, 1, 2)) {
+    if (nargs < 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 1 argument, got %zd",
+            "rjust", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 2 arguments, got %zd",
+            "rjust", nargs);
         goto exit;
     }
     {
@@ -207,7 +231,19 @@ stringlib_center(PyObject *self, PyObject *const *args, Py_ssize_t nargs)
     Py_ssize_t width;
     char fillchar = ' ';
 
-    if (!_PyArg_CheckPositional("center", nargs, 1, 2)) {
+    if (nargs < 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 1 argument, got %zd",
+            "center", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 2 arguments, got %zd",
+            "center", nargs);
         goto exit;
     }
     {
@@ -279,4 +315,4 @@ stringlib_zfill(PyObject *self, PyObject *arg)
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=b409bdf9ab68d5a6 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=dee1938a7140a9d7 input=a9049054013a1b77]*/

--- a/PC/clinic/msvcrtmodule.c.h
+++ b/PC/clinic/msvcrtmodule.c.h
@@ -2,7 +2,7 @@
 preserve
 [clinic start generated code]*/
 
-#include "pycore_modsupport.h"    // _PyArg_CheckPositional()
+#include "pycore_modsupport.h"    // _PyArg_BadArgument()
 
 PyDoc_STRVAR(msvcrt_heapmin__doc__,
 "heapmin($module, /)\n"
@@ -52,7 +52,19 @@ msvcrt_locking(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     int mode;
     long nbytes;
 
-    if (!_PyArg_CheckPositional("locking", nargs, 3, 3)) {
+    if (nargs < 3) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 3 arguments, got %zd",
+            "locking", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 3) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 3 arguments, got %zd",
+            "locking", nargs);
         goto exit;
     }
     fd = PyLong_AsInt(args[0]);
@@ -98,7 +110,19 @@ msvcrt_setmode(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     int flags;
     long _return_value;
 
-    if (!_PyArg_CheckPositional("setmode", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "setmode", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "setmode", nargs);
         goto exit;
     }
     fd = PyLong_AsInt(args[0]);
@@ -143,7 +167,19 @@ msvcrt_open_osfhandle(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     int flags;
     long _return_value;
 
-    if (!_PyArg_CheckPositional("open_osfhandle", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "open_osfhandle", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "open_osfhandle", nargs);
         goto exit;
     }
     handle = PyLong_AsVoidPtr(args[0]);
@@ -507,7 +543,19 @@ msvcrt_CrtSetReportFile(PyObject *module, PyObject *const *args, Py_ssize_t narg
     void *file;
     void *_return_value;
 
-    if (!_PyArg_CheckPositional("CrtSetReportFile", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "CrtSetReportFile", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "CrtSetReportFile", nargs);
         goto exit;
     }
     type = PyLong_AsInt(args[0]);
@@ -554,7 +602,19 @@ msvcrt_CrtSetReportMode(PyObject *module, PyObject *const *args, Py_ssize_t narg
     int mode;
     long _return_value;
 
-    if (!_PyArg_CheckPositional("CrtSetReportMode", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "CrtSetReportMode", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "CrtSetReportMode", nargs);
         goto exit;
     }
     type = PyLong_AsInt(args[0]);
@@ -697,4 +757,4 @@ exit:
 #ifndef MSVCRT_GETERRORMODE_METHODDEF
     #define MSVCRT_GETERRORMODE_METHODDEF
 #endif /* !defined(MSVCRT_GETERRORMODE_METHODDEF) */
-/*[clinic end generated code: output=de9687b46212c2ed input=a9049054013a1b77]*/
+/*[clinic end generated code: output=79b34c44ab1f2fce input=a9049054013a1b77]*/

--- a/PC/clinic/winreg.c.h
+++ b/PC/clinic/winreg.c.h
@@ -7,7 +7,7 @@ preserve
 #  include "pycore_runtime.h"     // _Py_ID()
 #endif
 #include "pycore_long.h"          // _PyLong_UnsignedLong_Converter()
-#include "pycore_modsupport.h"    // _PyArg_CheckPositional()
+#include "pycore_modsupport.h"    // _PyArg_BadArgument()
 
 #if (defined(MS_WINDOWS_DESKTOP) || defined(MS_WINDOWS_SYSTEM) || defined(MS_WINDOWS_GAMES))
 
@@ -112,7 +112,19 @@ winreg_HKEYType___exit__(PyHKEYObject *self, PyObject *const *args, Py_ssize_t n
     PyObject *exc_value;
     PyObject *traceback;
 
-    if (!_PyArg_CheckPositional("__exit__", nargs, 3, 3)) {
+    if (nargs < 3) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 3 arguments, got %zd",
+            "__exit__", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 3) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 3 arguments, got %zd",
+            "__exit__", nargs);
         goto exit;
     }
     exc_type = args[0];
@@ -177,7 +189,19 @@ winreg_ConnectRegistry(PyObject *module, PyObject *const *args, Py_ssize_t nargs
     HKEY key;
     HKEY _return_value;
 
-    if (!_PyArg_CheckPositional("ConnectRegistry", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "ConnectRegistry", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "ConnectRegistry", nargs);
         goto exit;
     }
     if (args[0] == Py_None) {
@@ -246,7 +270,19 @@ winreg_CreateKey(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     const wchar_t *sub_key = NULL;
     HKEY _return_value;
 
-    if (!_PyArg_CheckPositional("CreateKey", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "CreateKey", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "CreateKey", nargs);
         goto exit;
     }
     if (!clinic_HKEY_converter(_PyModule_GetState(module), args[0], &key)) {
@@ -436,7 +472,19 @@ winreg_DeleteKey(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     HKEY key;
     const wchar_t *sub_key = NULL;
 
-    if (!_PyArg_CheckPositional("DeleteKey", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "DeleteKey", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "DeleteKey", nargs);
         goto exit;
     }
     if (!clinic_HKEY_converter(_PyModule_GetState(module), args[0], &key)) {
@@ -603,7 +651,19 @@ winreg_DeleteValue(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     HKEY key;
     const wchar_t *value = NULL;
 
-    if (!_PyArg_CheckPositional("DeleteValue", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "DeleteValue", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "DeleteValue", nargs);
         goto exit;
     }
     if (!clinic_HKEY_converter(_PyModule_GetState(module), args[0], &key)) {
@@ -663,7 +723,19 @@ winreg_EnumKey(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     HKEY key;
     int index;
 
-    if (!_PyArg_CheckPositional("EnumKey", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "EnumKey", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "EnumKey", nargs);
         goto exit;
     }
     if (!clinic_HKEY_converter(_PyModule_GetState(module), args[0], &key)) {
@@ -720,7 +792,19 @@ winreg_EnumValue(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     HKEY key;
     int index;
 
-    if (!_PyArg_CheckPositional("EnumValue", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "EnumValue", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "EnumValue", nargs);
         goto exit;
     }
     if (!clinic_HKEY_converter(_PyModule_GetState(module), args[0], &key)) {
@@ -866,7 +950,19 @@ winreg_LoadKey(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     const wchar_t *sub_key = NULL;
     const wchar_t *file_name = NULL;
 
-    if (!_PyArg_CheckPositional("LoadKey", nargs, 3, 3)) {
+    if (nargs < 3) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 3 arguments, got %zd",
+            "LoadKey", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 3) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 3 arguments, got %zd",
+            "LoadKey", nargs);
         goto exit;
     }
     if (!clinic_HKEY_converter(_PyModule_GetState(module), args[0], &key)) {
@@ -1210,7 +1306,19 @@ winreg_QueryValue(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     HKEY key;
     const wchar_t *sub_key = NULL;
 
-    if (!_PyArg_CheckPositional("QueryValue", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "QueryValue", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "QueryValue", nargs);
         goto exit;
     }
     if (!clinic_HKEY_converter(_PyModule_GetState(module), args[0], &key)) {
@@ -1271,7 +1379,19 @@ winreg_QueryValueEx(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     HKEY key;
     const wchar_t *name = NULL;
 
-    if (!_PyArg_CheckPositional("QueryValueEx", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "QueryValueEx", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "QueryValueEx", nargs);
         goto exit;
     }
     if (!clinic_HKEY_converter(_PyModule_GetState(module), args[0], &key)) {
@@ -1337,7 +1457,19 @@ winreg_SaveKey(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     HKEY key;
     const wchar_t *file_name = NULL;
 
-    if (!_PyArg_CheckPositional("SaveKey", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "SaveKey", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "SaveKey", nargs);
         goto exit;
     }
     if (!clinic_HKEY_converter(_PyModule_GetState(module), args[0], &key)) {
@@ -1406,7 +1538,19 @@ winreg_SetValue(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     DWORD type;
     PyObject *value_obj;
 
-    if (!_PyArg_CheckPositional("SetValue", nargs, 4, 4)) {
+    if (nargs < 4) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 4 arguments, got %zd",
+            "SetValue", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 4) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 4 arguments, got %zd",
+            "SetValue", nargs);
         goto exit;
     }
     if (!clinic_HKEY_converter(_PyModule_GetState(module), args[0], &key)) {
@@ -1506,7 +1650,19 @@ winreg_SetValueEx(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     DWORD type;
     PyObject *value;
 
-    if (!_PyArg_CheckPositional("SetValueEx", nargs, 5, 5)) {
+    if (nargs < 5) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 5 arguments, got %zd",
+            "SetValueEx", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 5) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 5 arguments, got %zd",
+            "SetValueEx", nargs);
         goto exit;
     }
     if (!clinic_HKEY_converter(_PyModule_GetState(module), args[0], &key)) {
@@ -1762,4 +1918,4 @@ exit:
 #ifndef WINREG_QUERYREFLECTIONKEY_METHODDEF
     #define WINREG_QUERYREFLECTIONKEY_METHODDEF
 #endif /* !defined(WINREG_QUERYREFLECTIONKEY_METHODDEF) */
-/*[clinic end generated code: output=1ee4098b2f143b6a input=a9049054013a1b77]*/
+/*[clinic end generated code: output=bcd8bf5b5b66a23b input=a9049054013a1b77]*/

--- a/Python/clinic/bltinmodule.c.h
+++ b/Python/clinic/bltinmodule.c.h
@@ -205,7 +205,19 @@ builtin_format(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *value;
     PyObject *format_spec = NULL;
 
-    if (!_PyArg_CheckPositional("format", nargs, 1, 2)) {
+    if (nargs < 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 1 argument, got %zd",
+            "format", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 2 arguments, got %zd",
+            "format", nargs);
         goto exit;
     }
     value = args[0];
@@ -383,7 +395,19 @@ builtin_divmod(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *x;
     PyObject *y;
 
-    if (!_PyArg_CheckPositional("divmod", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "divmod", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "divmod", nargs);
         goto exit;
     }
     x = args[0];
@@ -421,7 +445,19 @@ builtin_eval(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *globals = Py_None;
     PyObject *locals = Py_None;
 
-    if (!_PyArg_CheckPositional("eval", nargs, 1, 3)) {
+    if (nargs < 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 1 argument, got %zd",
+            "eval", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 3) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 3 arguments, got %zd",
+            "eval", nargs);
         goto exit;
     }
     source = args[0];
@@ -566,7 +602,19 @@ builtin_hasattr(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *obj;
     PyObject *name;
 
-    if (!_PyArg_CheckPositional("hasattr", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "hasattr", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "hasattr", nargs);
         goto exit;
     }
     obj = args[0];
@@ -612,7 +660,19 @@ builtin_setattr(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *name;
     PyObject *value;
 
-    if (!_PyArg_CheckPositional("setattr", nargs, 3, 3)) {
+    if (nargs < 3) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 3 arguments, got %zd",
+            "setattr", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 3) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 3 arguments, got %zd",
+            "setattr", nargs);
         goto exit;
     }
     obj = args[0];
@@ -645,7 +705,19 @@ builtin_delattr(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *obj;
     PyObject *name;
 
-    if (!_PyArg_CheckPositional("delattr", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "delattr", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "delattr", nargs);
         goto exit;
     }
     obj = args[0];
@@ -712,7 +784,19 @@ builtin_anext(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *aiterator;
     PyObject *default_value = NULL;
 
-    if (!_PyArg_CheckPositional("anext", nargs, 1, 2)) {
+    if (nargs < 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 1 argument, got %zd",
+            "anext", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 2 arguments, got %zd",
+            "anext", nargs);
         goto exit;
     }
     aiterator = args[0];
@@ -968,7 +1052,19 @@ builtin_input(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *return_value = NULL;
     PyObject *prompt = NULL;
 
-    if (!_PyArg_CheckPositional("input", nargs, 0, 1)) {
+    if (nargs < 0) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 0 arguments, got %zd",
+            "input", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 1 argument, got %zd",
+            "input", nargs);
         goto exit;
     }
     if (nargs < 1) {
@@ -1148,7 +1244,19 @@ builtin_isinstance(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *obj;
     PyObject *class_or_tuple;
 
-    if (!_PyArg_CheckPositional("isinstance", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "isinstance", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "isinstance", nargs);
         goto exit;
     }
     obj = args[0];
@@ -1183,7 +1291,19 @@ builtin_issubclass(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *cls;
     PyObject *class_or_tuple;
 
-    if (!_PyArg_CheckPositional("issubclass", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "issubclass", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "issubclass", nargs);
         goto exit;
     }
     cls = args[0];
@@ -1193,4 +1313,4 @@ builtin_issubclass(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=643a8d5f900e0c36 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=8aff570d810cb1fe input=a9049054013a1b77]*/

--- a/Python/clinic/context.c.h
+++ b/Python/clinic/context.c.h
@@ -2,8 +2,6 @@
 preserve
 [clinic start generated code]*/
 
-#include "pycore_modsupport.h"    // _PyArg_CheckPositional()
-
 PyDoc_STRVAR(_contextvars_Context_get__doc__,
 "get($self, key, default=None, /)\n"
 "--\n"
@@ -27,7 +25,19 @@ _contextvars_Context_get(PyContext *self, PyObject *const *args, Py_ssize_t narg
     PyObject *key;
     PyObject *default_value = Py_None;
 
-    if (!_PyArg_CheckPositional("get", nargs, 1, 2)) {
+    if (nargs < 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 1 argument, got %zd",
+            "get", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 2 arguments, got %zd",
+            "get", nargs);
         goto exit;
     }
     key = args[0];
@@ -140,7 +150,19 @@ _contextvars_ContextVar_get(PyContextVar *self, PyObject *const *args, Py_ssize_
     PyObject *return_value = NULL;
     PyObject *default_value = NULL;
 
-    if (!_PyArg_CheckPositional("get", nargs, 0, 1)) {
+    if (nargs < 0) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 0 arguments, got %zd",
+            "get", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 1 argument, got %zd",
+            "get", nargs);
         goto exit;
     }
     if (nargs < 1) {
@@ -179,4 +201,4 @@ PyDoc_STRVAR(_contextvars_ContextVar_reset__doc__,
 
 #define _CONTEXTVARS_CONTEXTVAR_RESET_METHODDEF    \
     {"reset", (PyCFunction)_contextvars_ContextVar_reset, METH_O, _contextvars_ContextVar_reset__doc__},
-/*[clinic end generated code: output=b667826178444c3f input=a9049054013a1b77]*/
+/*[clinic end generated code: output=84ed71f390ea61fd input=a9049054013a1b77]*/

--- a/Python/clinic/import.c.h
+++ b/Python/clinic/import.c.h
@@ -6,7 +6,7 @@ preserve
 #  include "pycore_gc.h"          // PyGC_Head
 #  include "pycore_runtime.h"     // _Py_ID()
 #endif
-#include "pycore_modsupport.h"    // _PyArg_CheckPositional()
+#include "pycore_modsupport.h"    // _PyArg_BadArgument()
 
 PyDoc_STRVAR(_imp_lock_held__doc__,
 "lock_held($module, /)\n"
@@ -94,7 +94,19 @@ _imp__fix_co_filename(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyCodeObject *code;
     PyObject *path;
 
-    if (!_PyArg_CheckPositional("_fix_co_filename", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "_fix_co_filename", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "_fix_co_filename", nargs);
         goto exit;
     }
     if (!PyObject_TypeCheck(args[0], &PyCode_Type)) {
@@ -266,7 +278,19 @@ _imp_get_frozen_object(PyObject *module, PyObject *const *args, Py_ssize_t nargs
     PyObject *name;
     PyObject *dataobj = Py_None;
 
-    if (!_PyArg_CheckPositional("get_frozen_object", nargs, 1, 2)) {
+    if (nargs < 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 1 argument, got %zd",
+            "get_frozen_object", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 2 arguments, got %zd",
+            "get_frozen_object", nargs);
         goto exit;
     }
     if (!PyUnicode_Check(args[0])) {
@@ -473,7 +497,19 @@ _imp_create_dynamic(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *spec;
     PyObject *file = NULL;
 
-    if (!_PyArg_CheckPositional("create_dynamic", nargs, 1, 2)) {
+    if (nargs < 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 1 argument, got %zd",
+            "create_dynamic", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 2 arguments, got %zd",
+            "create_dynamic", nargs);
         goto exit;
     }
     spec = args[0];
@@ -623,4 +659,4 @@ exit:
 #ifndef _IMP_EXEC_DYNAMIC_METHODDEF
     #define _IMP_EXEC_DYNAMIC_METHODDEF
 #endif /* !defined(_IMP_EXEC_DYNAMIC_METHODDEF) */
-/*[clinic end generated code: output=dbd63707bd40b07c input=a9049054013a1b77]*/
+/*[clinic end generated code: output=bfcbf6a98b42d84a input=a9049054013a1b77]*/

--- a/Python/clinic/instrumentation.c.h
+++ b/Python/clinic/instrumentation.c.h
@@ -2,8 +2,6 @@
 preserve
 [clinic start generated code]*/
 
-#include "pycore_modsupport.h"    // _PyArg_CheckPositional()
-
 PyDoc_STRVAR(monitoring_use_tool_id__doc__,
 "use_tool_id($module, tool_id, name, /)\n"
 "--\n"
@@ -22,7 +20,19 @@ monitoring_use_tool_id(PyObject *module, PyObject *const *args, Py_ssize_t nargs
     int tool_id;
     PyObject *name;
 
-    if (!_PyArg_CheckPositional("use_tool_id", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "use_tool_id", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "use_tool_id", nargs);
         goto exit;
     }
     tool_id = PyLong_AsInt(args[0]);
@@ -110,7 +120,19 @@ monitoring_register_callback(PyObject *module, PyObject *const *args, Py_ssize_t
     int event;
     PyObject *func;
 
-    if (!_PyArg_CheckPositional("register_callback", nargs, 3, 3)) {
+    if (nargs < 3) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 3 arguments, got %zd",
+            "register_callback", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 3) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 3 arguments, got %zd",
+            "register_callback", nargs);
         goto exit;
     }
     tool_id = PyLong_AsInt(args[0]);
@@ -178,7 +200,19 @@ monitoring_set_events(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     int tool_id;
     int event_set;
 
-    if (!_PyArg_CheckPositional("set_events", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "set_events", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "set_events", nargs);
         goto exit;
     }
     tool_id = PyLong_AsInt(args[0]);
@@ -215,7 +249,19 @@ monitoring_get_local_events(PyObject *module, PyObject *const *args, Py_ssize_t 
     PyObject *code;
     int _return_value;
 
-    if (!_PyArg_CheckPositional("get_local_events", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "get_local_events", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "get_local_events", nargs);
         goto exit;
     }
     tool_id = PyLong_AsInt(args[0]);
@@ -253,7 +299,19 @@ monitoring_set_local_events(PyObject *module, PyObject *const *args, Py_ssize_t 
     PyObject *code;
     int event_set;
 
-    if (!_PyArg_CheckPositional("set_local_events", nargs, 3, 3)) {
+    if (nargs < 3) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 3 arguments, got %zd",
+            "set_local_events", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 3) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 3 arguments, got %zd",
+            "set_local_events", nargs);
         goto exit;
     }
     tool_id = PyLong_AsInt(args[0]);
@@ -304,4 +362,4 @@ monitoring__all_events(PyObject *module, PyObject *Py_UNUSED(ignored))
 {
     return monitoring__all_events_impl(module);
 }
-/*[clinic end generated code: output=14ffc0884a6de50a input=a9049054013a1b77]*/
+/*[clinic end generated code: output=5331355dc515a844 input=a9049054013a1b77]*/

--- a/Python/clinic/sysmodule.c.h
+++ b/Python/clinic/sysmodule.c.h
@@ -93,7 +93,19 @@ sys_excepthook(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *value;
     PyObject *traceback;
 
-    if (!_PyArg_CheckPositional("excepthook", nargs, 3, 3)) {
+    if (nargs < 3) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 3 arguments, got %zd",
+            "excepthook", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 3) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 3 arguments, got %zd",
+            "excepthook", nargs);
         goto exit;
     }
     exctype = args[0];
@@ -188,7 +200,19 @@ sys_exit(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *return_value = NULL;
     PyObject *status = Py_None;
 
-    if (!_PyArg_CheckPositional("exit", nargs, 0, 1)) {
+    if (nargs < 0) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 0 arguments, got %zd",
+            "exit", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 1 argument, got %zd",
+            "exit", nargs);
         goto exit;
     }
     if (nargs < 1) {
@@ -997,7 +1021,19 @@ sys__getframe(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *return_value = NULL;
     int depth = 0;
 
-    if (!_PyArg_CheckPositional("_getframe", nargs, 0, 1)) {
+    if (nargs < 0) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at least 0 arguments, got %zd",
+            "_getframe", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected at most 1 argument, got %zd",
+            "_getframe", nargs);
         goto exit;
     }
     if (nargs < 1) {
@@ -1077,7 +1113,19 @@ sys_call_tracing(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *func;
     PyObject *funcargs;
 
-    if (!_PyArg_CheckPositional("call_tracing", nargs, 2, 2)) {
+    if (nargs < 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "call_tracing", nargs);
+        goto exit;
+    }
+
+    if (nargs != 0 && nargs > 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s expected 2 arguments, got %zd",
+            "call_tracing", nargs);
         goto exit;
     }
     func = args[0];
@@ -1504,4 +1552,4 @@ exit:
 #ifndef SYS_GETANDROIDAPILEVEL_METHODDEF
     #define SYS_GETANDROIDAPILEVEL_METHODDEF
 #endif /* !defined(SYS_GETANDROIDAPILEVEL_METHODDEF) */
-/*[clinic end generated code: output=b8b1c53e04c3b20c input=a9049054013a1b77]*/
+/*[clinic end generated code: output=7f34366518d34673 input=a9049054013a1b77]*/

--- a/Tools/clinic/clinic.py
+++ b/Tools/clinic/clinic.py
@@ -1022,6 +1022,7 @@ class CLanguage(Language):
                 """, indent=4)
 
                 if max_args != self.NO_VARARG:
+                    assert isinstance(max_args, int)
                     assert min_pos <= max_args, (min_pos, max_args)
                     nargs_atmost = ("" if min_pos == max_args else "at most ")
                     nargs_max_plural = ("" if max_args == 1 else "s")


### PR DESCRIPTION
* Compute "at least", "at most" and plural at build time (in Argument Clinic), rather than at runtime.
* Don't format the function name in the format string to reduce the Python executable size, C compilers merge same format strings.
* Make the generated code compatible with the limited C API.
* Only clinic.py was modified manually, other changes are generated code.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-116751 -->
* Issue: gh-116751
<!-- /gh-issue-number -->
