### PR TITLE
gh-116760: Fix pystats for trace attempts

### DIFF
--- a/Python/bytecodes.c
+++ b/Python/bytecodes.c
@@ -2349,7 +2349,6 @@ dummy_func(
             // Use '>=' not '>' so that the optimizer/backoff bits do not effect the result.
             // Double-check that the opcode isn't instrumented or something:
             if (offset_counter >= threshold && this_instr->op.code == JUMP_BACKWARD) {
-                OPT_STAT_INC(attempts);
                 _Py_CODEUNIT *start = this_instr;
                 /* Back up over EXTENDED_ARGs so optimizer sees the whole instruction */
                 while (oparg > 255) {

--- a/Python/generated_cases.c.h
+++ b/Python/generated_cases.c.h
@@ -3371,7 +3371,6 @@
             // Use '>=' not '>' so that the optimizer/backoff bits do not effect the result.
             // Double-check that the opcode isn't instrumented or something:
             if (offset_counter >= threshold && this_instr->op.code == JUMP_BACKWARD) {
-                OPT_STAT_INC(attempts);
                 _Py_CODEUNIT *start = this_instr;
                 /* Back up over EXTENDED_ARGs so optimizer sees the whole instruction */
                 while (oparg > 255) {

--- a/Python/optimizer.c
+++ b/Python/optimizer.c
@@ -1003,6 +1003,7 @@ uop_optimize(
     _PyBloomFilter dependencies;
     _Py_BloomFilter_Init(&dependencies);
     _PyUOpInstruction buffer[UOP_MAX_TRACE_LENGTH];
+    OPT_STAT_INC(attempts);
     int err = translate_bytecode_to_trace(frame, instr, buffer, UOP_MAX_TRACE_LENGTH, &dependencies);
     if (err <= 0) {
         // Error or nothing translated


### PR DESCRIPTION
There are now at least two bytecodes that may attempt to optimize, JUMP_BACK, and more recently, COLD_EXIT.

Only the JUMP_BACK was counting the attempt in the stats. This moves that counter to uop_optimize itself so it should always happen no matter where it is called from.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-116760 -->
* Issue: gh-116760
<!-- /gh-issue-number -->
