### PR TITLE
gh-116731: Fix refleaks in importlib tests

### DIFF
--- a/Lib/importlib/_bootstrap_external.py
+++ b/Lib/importlib/_bootstrap_external.py
@@ -1470,6 +1470,9 @@ class PathFinder:
         # https://bugs.python.org/issue45703
         _NamespacePath._epoch += 1
 
+        from importlib.metadata import MetadataPathFinder
+        MetadataPathFinder().invalidate_caches()
+
     @staticmethod
     def _path_hooks(path):
         """Search sys.path_hooks for a finder for 'path'."""

--- a/Lib/test/test_importlib/resources/test_files.py
+++ b/Lib/test/test_importlib/resources/test_files.py
@@ -3,6 +3,7 @@ import textwrap
 import unittest
 import warnings
 import importlib
+import inspect
 import contextlib
 
 from importlib import resources
@@ -90,6 +91,12 @@ class ModulesFilesTests(SiteDir, unittest.TestCase):
 
 
 class ImplicitContextFilesTests(SiteDir, unittest.TestCase):
+
+    def tearDown(self):
+        # clean up inspect state to avoid ref leaks (#116731)
+        inspect._filesbymodname.clear()
+        inspect.modulesbyfile.clear()
+
     def test_implicit_files(self):
         """
         Without any parameter, files() will infer the location as the caller.

--- a/Lib/test/test_importlib/test_main.py
+++ b/Lib/test/test_importlib/test_main.py
@@ -2,6 +2,7 @@ import re
 import pickle
 import unittest
 import warnings
+import importlib
 import importlib.metadata
 import contextlib
 from test.support import os_helper
@@ -36,6 +37,9 @@ def suppress_known_deprecation():
 
 class BasicTests(fixtures.DistInfoPkg, unittest.TestCase):
     version_pattern = r'\d+\.\d+(\.\d)?'
+
+    def tearDown(self):
+        importlib.invalidate_caches()
 
     def test_retrieves_version_of_self(self):
         dist = Distribution.from_name('distinfo-pkg')

--- a/Lib/test/test_importlib/test_metadata_api.py
+++ b/Lib/test/test_importlib/test_metadata_api.py
@@ -37,6 +37,9 @@ class APITests(
 ):
     version_pattern = r'\d+\.\d+(\.\d)?'
 
+    def tearDown(self):
+        importlib.invalidate_caches()
+
     def test_retrieves_version_of_self(self):
         pkg_version = version('egginfo-pkg')
         assert isinstance(pkg_version, str)

--- a/Misc/NEWS.d/next/Tests/2024-03-13-16-59-56.gh-issue-116731.s2xTyz.rst
+++ b/Misc/NEWS.d/next/Tests/2024-03-13-16-59-56.gh-issue-116731.s2xTyz.rst
@@ -1,0 +1,2 @@
+Fixed nuisance refleaks warnings in tests for importlib.metadata and
+importlib.resources.


### PR DESCRIPTION
- **In PathFinder.invalidate_caches, also invoke MetadataPathFinder.invalidate_caches.**
- **Invoke invalidate_caches in tests exhibiting refleaks.**
- **Address ref leak in inspect triggered by call to `files()`.**
- **Add blurb**

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-116731 -->
* Issue: gh-116731
<!-- /gh-issue-number -->
