### PR TITLE
gh-88494: Use QueryPerformanceCounter() for time.monotonic()

### DIFF
--- a/Doc/library/time.rst
+++ b/Doc/library/time.rst
@@ -287,6 +287,15 @@ Functions
    The reference point of the returned value is undefined, so that only the
    difference between the results of two calls is valid.
 
+   Clock:
+
+   * On Windows, call ``QueryPerformanceCounter()`` and
+     ``QueryPerformanceFrequency()``.
+   * On macOS, call ``mach_absolute_time()`` and ``mach_timebase_info()``.
+   * On HP-UX, call ``gethrtime()``.
+   * Call ``clock_gettime(CLOCK_HIGHRES)`` if available.
+   * Otherwise, call ``clock_gettime(CLOCK_MONOTONIC)``.
+
    Use :func:`monotonic_ns` to avoid the precision loss caused by the
    :class:`float` type.
 
@@ -316,6 +325,11 @@ Functions
    point of the returned value is undefined, so that only the difference between
    the results of two calls is valid.
 
+   .. impl-detail::
+
+      On CPython, use the same clock than :func:`time.monotonic()` and is a
+      monotonic clock, i.e. a clock that cannot go backwards.
+
    Use :func:`perf_counter_ns` to avoid the precision loss caused by the
    :class:`float` type.
 
@@ -323,6 +337,10 @@ Functions
 
    .. versionchanged:: 3.10
       On Windows, the function is now system-wide.
+
+   .. versionchanged:: 3.13
+      Use the same clock than :func:`time.monotonic()`.
+
 
 .. function:: perf_counter_ns() -> int
 
@@ -665,6 +683,12 @@ Functions
    :func:`localtime` function. In both cases a
    :class:`struct_time` object is returned, from which the components
    of the calendar date may be accessed as attributes.
+
+   Clock:
+
+   * On Windows, call ``GetSystemTimeAsFileTime()``.
+   * Call ``clock_gettime(CLOCK_REALTIME)`` if available.
+   * Otherwise, call ``gettimeofday()``.
 
    Use :func:`time_ns` to avoid the precision loss caused by the :class:`float`
    type.

--- a/Doc/whatsnew/3.13.rst
+++ b/Doc/whatsnew/3.13.rst
@@ -552,6 +552,15 @@ sys
   This function is not guaranteed to exist in all implementations of Python.
   (Contributed by Serhiy Storchaka in :gh:`78573`.)
 
+time
+----
+
+* On Windows, :func:`time.monotonic()` now uses the
+  ``QueryPerformanceCounter()`` clock to have a resolution better than 1 us,
+  instead of the ``GetTickCount64()`` clock which has a resolution of 15.6 ms.
+  (Contributed by Victor Stinner in :gh:`88494`.)
+
+
 tkinter
 -------
 

--- a/Misc/NEWS.d/next/Windows/2024-03-14-09-14-21.gh-issue-88494.Bwfmp7.rst
+++ b/Misc/NEWS.d/next/Windows/2024-03-14-09-14-21.gh-issue-88494.Bwfmp7.rst
@@ -1,0 +1,4 @@
+On Windows, :func:`time.monotonic()` now uses the ``QueryPerformanceCounter()``
+clock to have a resolution better than 1 us, instead of the
+``GetTickCount64()`` clock which has a resolution of 15.6 ms. Patch by Victor
+Stinner.


### PR DESCRIPTION
On Windows, time.monotonic() now uses the QueryPerformanceCounter() clock to have a resolution better than 1 us, instead of the GetTickCount64() clock which has a resolution of 15.6 ms.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-88494 -->
* Issue: gh-88494
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--116781.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->