### PR TITLE
gh-116785: Fix direct invocation of `test_inspect`

### DIFF
--- a/Lib/test/test_inspect/test_inspect.py
+++ b/Lib/test/test_inspect/test_inspect.py
@@ -40,11 +40,11 @@ from test.support.script_helper import assert_python_ok, assert_python_failure, 
 from test.support import has_subprocess_support, SuppressCrashReport
 from test import support
 
-from . import inspect_fodder as mod
-from . import inspect_fodder2 as mod2
-from . import inspect_stock_annotations
-from . import inspect_stringized_annotations
-from . import inspect_stringized_annotations_2
+from test.test_inspect import inspect_fodder as mod
+from test.test_inspect import inspect_fodder2 as mod2
+from test.test_inspect import inspect_stock_annotations
+from test.test_inspect import inspect_stringized_annotations
+from test.test_inspect import inspect_stringized_annotations_2
 
 
 # Functions tested in this suite:


### PR DESCRIPTION
@hugovk @vstinner could you please take a look? :)

After this change:

```
» ./python.exe Lib/test/test_inspect/test_inspect.py
........................................................................................................................................................................................................................................................................................................
----------------------------------------------------------------------
Ran 296 tests in 0.542s

OK
```

<!-- gh-issue-number: gh-116785 -->
* Issue: gh-116785
<!-- /gh-issue-number -->
