### PR TITLE
Add fuzz target for Plistlib. plistlib.dumps(), plistlib.loads()

### DIFF
--- a/Modules/_xxtestfuzz/fuzz_plistlib_loads_corpus/Info.plist
+++ b/Modules/_xxtestfuzz/fuzz_plistlib_loads_corpus/Info.plist
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>English</string>
+	<key>CFBundleDocumentTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeExtensions</key>
+			<array>
+				<string>py</string>
+				<string>pyi</string>
+				<string>pyw</string>
+			</array>
+			<key>CFBundleTypeIconFile</key>
+			<string>PythonSource.icns</string>
+			<key>CFBundleTypeName</key>
+			<string>Python Script</string>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+		</dict>
+		<dict>
+			<key>CFBundleTypeExtensions</key>
+			<array>
+				<string>pyc</string>
+				<string>pyo</string>
+			</array>
+			<key>CFBundleTypeIconFile</key>
+			<string>PythonCompiled.icns</string>
+			<key>CFBundleTypeName</key>
+			<string>Python Bytecode Document</string>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+		</dict>
+	</array>
+	<key>CFBundleExecutable</key>
+	<string>IDLE</string>
+	<key>CFBundleGetInfoString</key>
+	<string>%version%, © 2001-2023 Python Software Foundation</string>
+	<key>CFBundleIconFile</key>
+	<string>IDLE.icns</string>
+	<key>CFBundleIdentifier</key>
+	<string>org.python.IDLE</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>IDLE</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>%version%</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>%version%</string>
+	<key>NSHighResolutionCapable</key>
+	<true/>
+	<key>CFBundleAllowMixedLocalizations</key>
+	<true/>
+</dict>
+</plist>

--- a/Modules/_xxtestfuzz/fuzz_plistlib_loads_corpus/dict.plist
+++ b/Modules/_xxtestfuzz/fuzz_plistlib_loads_corpus/dict.plist
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>1</key>
+	<string>2</string>
+	<key>2</key>
+	<string>3</string>
+	<key>3</key>
+	<string>some_data</string>
+</dict>
+</plist>

--- a/Modules/_xxtestfuzz/fuzz_plistlib_loads_corpus/tuple.plist
+++ b/Modules/_xxtestfuzz/fuzz_plistlib_loads_corpus/tuple.plist
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<array>
+	<string>1</string>
+	<string>2</string>
+	<string>3</string>
+	<string>4</string>
+	<string>some_string</string>
+</array>
+</plist>

--- a/Modules/_xxtestfuzz/fuzz_tests.txt
+++ b/Modules/_xxtestfuzz/fuzz_tests.txt
@@ -7,3 +7,4 @@ fuzz_sre_match
 fuzz_csv_reader
 fuzz_struct_unpack
 fuzz_ast_literal_eval
+fuzz_plistlib


### PR DESCRIPTION
This PR adds a new fuzz target for the plistlib.dumps(), plistlib.loads() methods.

Trying to loads() from fuzzers data. Then dumps() data , and loads() from dumped.

Added Mac/IDLE/IDLE.app/Contents/Info.plist into fuzz_plistlib_loads_corpus/ as initial corpus and two simple plist examples.


by Andrei Iakunin, <iakuninaa@altlinux.org>