### PR TITLE
[3.12] gh-116780: Fix `test_inspect` in `-OO` mode (GH-116788)

### DIFF
--- a/Lib/test/test_inspect/test_inspect.py
+++ b/Lib/test/test_inspect/test_inspect.py
@@ -4949,6 +4949,7 @@ class TestSignatureDefinitions(unittest.TestCase):
         with self.assertRaises(ValueError):
             inspect.signature(func)
 
+    @support.requires_docstrings
     def test_base_class_have_text_signature(self):
         # see issue 43118
         from test.typinganndata.ann_module7 import BufferedReader


### PR DESCRIPTION
(cherry picked from commit f20dfb7569a769da50cd75f4932b9abe78e55d75)

Note that `test_class_inside_conditional` does not need to be skipped anymore, because there was a behavior change of `inspect.getsource` in 3.13 which started using `.__doc__` in https://github.com/python/cpython/pull/106815

@serhiy-storchaka @gaogaotiantian is that expected? 

<!-- gh-issue-number: gh-116780 -->
* Issue: gh-116780
<!-- /gh-issue-number -->
