### PR TITLE
gh-116764: Fix regressions in urllib.parse.parse_qsl()

### DIFF
--- a/Lib/urllib/parse.py
+++ b/Lib/urllib/parse.py
@@ -775,6 +775,8 @@ def parse_qsl(qs, keep_blank_values=False, strict_parsing=False,
     else:
         if not qs:
             return []
+        # Use memoryview() to reject integers and iterables,
+        # acceptable by the bytes constructor.
         qs = bytes(memoryview(qs))
         if isinstance(separator, str):
             separator = bytes(separator, 'ascii')

--- a/Lib/urllib/parse.py
+++ b/Lib/urllib/parse.py
@@ -773,7 +773,9 @@ def parse_qsl(qs, keep_blank_values=False, strict_parsing=False,
         def _unquote(s):
             return unquote_plus(s, encoding=encoding, errors=errors)
     else:
-        qs = bytes(qs)
+        if not qs:
+            return []
+        qs = bytes(memoryview(qs))
         if isinstance(separator, str):
             separator = bytes(separator, 'ascii')
         eq = b'='

--- a/Misc/NEWS.d/next/Library/2024-03-14-14-01-46.gh-issue-116764.moB3Lc.rst
+++ b/Misc/NEWS.d/next/Library/2024-03-14-14-01-46.gh-issue-116764.moB3Lc.rst
@@ -1,0 +1,4 @@
+Restore support of ``None`` and other false values in :mod:`urllib.parse`
+functions :func:`~urllib.parse.parse_qs` and
+:func:`~urllib.parse.parse_qsl`. Also, they now raise a TypeError for
+non-zero integers and non-empty sequences.


### PR DESCRIPTION
* Restore support of None and other false values (fix regression introduced in gh-74668).
* Raise TypeError for non-zero integers and non-empty sequences.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-116764 -->
* Issue: gh-116764
<!-- /gh-issue-number -->
