### PR TITLE
gh-116731: libregrtest: Clear inspect & importlib.metadata caches in clear_caches

### DIFF
--- a/Lib/test/libregrtest/utils.py
+++ b/Lib/test/libregrtest/utils.py
@@ -276,6 +276,15 @@ def clear_caches():
         pass
     else:
         inspect._shadowed_dict_from_mro_tuple.cache_clear()
+        inspect._filesbymodname.clear()
+        inspect.modulesbyfile.clear()
+
+    try:
+        importlib_metadata = sys.modules['importlib.metadata']
+    except KeyError:
+        pass
+    else:
+        importlib_metadata.FastPath.__new__.cache_clear()
 
 
 def get_build_info():


### PR DESCRIPTION
Thanks to @jaraco for investigation (i.e. the hard part of the fix)

Clearing the inspect caches isn't entirely correct -- see #116804.
This PR is a minimal change to get the buildbots green.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-116731 -->
* Issue: gh-116731
<!-- /gh-issue-number -->
