### PR TITLE
CI: Only test free-threading with faster macOS M1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -206,6 +206,8 @@ jobs:
     uses: ./.github/workflows/reusable-macos.yml
     with:
       config_hash: ${{ needs.check_source.outputs.config_hash }}
+      # macos-14 is M1, macos-13 is Intel
+      os-matrix: '["macos-14", "macos-13"]'
 
   build_macos_free_threading:
     name: 'macOS (free-threading)'
@@ -215,6 +217,8 @@ jobs:
     with:
       config_hash: ${{ needs.check_source.outputs.config_hash }}
       free-threading: true
+      # macos-14 is M1
+      os-matrix: '["macos-14"]'
 
   build_ubuntu:
     name: 'Ubuntu'

--- a/.github/workflows/reusable-macos.yml
+++ b/.github/workflows/reusable-macos.yml
@@ -8,6 +8,9 @@ on:
         required: false
         type: boolean
         default: false
+      os-matrix:
+        required: false
+        type: string
 
 jobs:
   build_macos:
@@ -22,10 +25,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [
-          "macos-14",  # M1
-          "macos-13",  # Intel
-        ]
+        os: ${{fromJson(inputs.os-matrix)}}
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


We used to only have a single macOS Intel job in the CI.

But we have recently quadrupled it:

* x2 for free-threading ([GH-111449](https://github.com/python/cpython/pull/111449))
* x2 for macOS M1 ([GH-114766](https://github.com/python/cpython/pull/114766))

Plus we occasionally have a couple testing the JIT, but they only trigger when relevant files are modified.

Unfortunately, we're limited to a maximum of 5 concurrent macOS jobs:

* https://docs.github.com/en/actions/learn-github-actions/usage-limits-billing-and-administration#usage-limits

This means at busy times, jobs can be queued for a long time waiting for free macOS runners. In the meantime, the other jobs have finished, but we need to sit around until one of the five runners becomes free.

We've run in to this once per week for the last three weeks, during European evening/US daytime.

* Last night: ~105m
* Last week: ~100m
* The week before: ~90m

To mitigate, let's remove some macOS jobs.

We can't remove them from the regular build, because they're needed to maintain [PEP 11's Tier 1 support](https://peps.python.org/pep-0011/#tier-1). So let's start by removing one macOS test job for the free-threading build.

Here's macOS job times for five recent builds. `macos-13` is Intel, `macOS-14` is M1.

```
macOS / (macos-13)    11m 8s
macOS / (macos-13)    13m 40s
macOS / (macos-13)    9m 2s
macOS / (macos-13)    9m 52s
macOS / (macos-13)    9m 9s

macOS / (macos-14)    6m 36s
macOS / (macos-14)    6m 38s
macOS / (macos-14)    6m 50s
macOS / (macos-14)    7m 29s
macOS / (macos-14)    8m 46s
```
```
macOS (free-threading) / (macos-13)    14m 23s
macOS (free-threading) / (macos-13)    14m 47s
macOS (free-threading) / (macos-13)    18m 46s
macOS (free-threading) / (macos-13)    26m 22s
macOS (free-threading) / (macos-13)    28m 53s

macOS (free-threading) / (macos-14)    10m 3s
macOS (free-threading) / (macos-14)    7m 36s
macOS (free-threading) / (macos-14)    7m 39s
macOS (free-threading) / (macos-14)    7m 52s
macOS (free-threading) / (macos-14)    8m 46s
```

M1 is much faster (~8 mins), so let's remove the slower free-threading Intel job (~20 mins).

If the problem persists, we can remove the free-threading M1 job as well.

And hopefully GitHub will be able to increase the number of concurrent macOS jobs in the future, especially as the free-threading work matures. 🤞
