### PR TITLE
gh-85283: Build pwd extension with the limited C API

### DIFF
--- a/Doc/whatsnew/3.13.rst
+++ b/Doc/whatsnew/3.13.rst
@@ -1469,7 +1469,7 @@ Build Changes
 * Building CPython now requires a compiler with support for the C11 atomic
   library, GCC built-in atomic functions, or MSVC interlocked intrinsics.
 
-* The ``errno``, ``fcntl``, ``grp``, ``md5``, ``resource``, ``winsound``,
+* The ``errno``, ``fcntl``, ``grp``, ``md5``, ``pwd``, ``resource``, ``winsound``,
   ``_ctypes_test``, ``_multiprocessing.posixshmem``, ``_scproxy``, ``_stat``,
   ``_testimportmultiple`` and ``_uuid`` C extensions are now built with the
   :ref:`limited C API <limited-c-api>`.

--- a/Misc/NEWS.d/next/C API/2024-03-14-10-33-58.gh-issue-85283.LOgmdU.rst
+++ b/Misc/NEWS.d/next/C API/2024-03-14-10-33-58.gh-issue-85283.LOgmdU.rst
@@ -1,2 +1,2 @@
-The ``fcntl`` and ``grp`` C extensions are now built with the :ref:`limited
+The ``fcntl``, ``grp`` and ``pwd`` C extensions are now built with the :ref:`limited
 C API <limited-c-api>`. (Contributed by Victor Stinner in :gh:`85283`.)

--- a/Modules/clinic/pwdmodule.c.h
+++ b/Modules/clinic/pwdmodule.c.h
@@ -2,8 +2,6 @@
 preserve
 [clinic start generated code]*/
 
-#include "pycore_modsupport.h"    // _PyArg_BadArgument()
-
 PyDoc_STRVAR(pwd_getpwuid__doc__,
 "getpwuid($module, uidobj, /)\n"
 "--\n"
@@ -36,7 +34,7 @@ pwd_getpwnam(PyObject *module, PyObject *arg)
     PyObject *name;
 
     if (!PyUnicode_Check(arg)) {
-        _PyArg_BadArgument("getpwnam", "argument", "str", arg);
+        PyErr_Format(PyExc_TypeError, "getpwnam() argument must be str, not %T", arg);
         goto exit;
     }
     name = arg;
@@ -73,4 +71,4 @@ pwd_getpwall(PyObject *module, PyObject *Py_UNUSED(ignored))
 #ifndef PWD_GETPWALL_METHODDEF
     #define PWD_GETPWALL_METHODDEF
 #endif /* !defined(PWD_GETPWALL_METHODDEF) */
-/*[clinic end generated code: output=5a8fb12939ff4ea3 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=dac88d500f6d6f49 input=a9049054013a1b77]*/

--- a/Modules/pwdmodule.c
+++ b/Modules/pwdmodule.c
@@ -1,9 +1,16 @@
 
 /* UNIX password file access module */
 
+// Need limited C API version 3.13 for PyMem_RawRealloc()
+#include "pyconfig.h"   // Py_GIL_DISABLED
+#ifndef Py_GIL_DISABLED
+#  define Py_LIMITED_API 0x030d0000
+#endif
+
 #include "Python.h"
 #include "posixmodule.h"
 
+#include <errno.h>                // ERANGE
 #include <pwd.h>                  // getpwuid()
 #include <unistd.h>               // sysconf()
 
@@ -83,7 +90,7 @@ mkpwent(PyObject *module, struct passwd *p)
         if (item == NULL) {                                  \
             goto error;                                      \
         }                                                    \
-        PyStructSequence_SET_ITEM(v, setIndex++, item);      \
+        PyStructSequence_SetItem(v, setIndex++, item);       \
     } while(0)
 
     SET_STRING(p->pw_name);

--- a/Tools/clinic/libclinic/converter.py
+++ b/Tools/clinic/libclinic/converter.py
@@ -426,13 +426,12 @@ class CConverter(metaclass=CConverterAutoRegister):
         if limited_capi:
             if expected_literal:
                 return (f'PyErr_Format(PyExc_TypeError, '
-                        f'"{{{{name}}}}() {displayname} must be {expected}, not %.50s", '
-                        f'{{argname}} == Py_None ? "None" : Py_TYPE({{argname}})->tp_name);')
+                        f'"{{{{name}}}}() {displayname} must be {expected}, not %T", '
+                        f'{{argname}});')
             else:
                 return (f'PyErr_Format(PyExc_TypeError, '
-                        f'"{{{{name}}}}() {displayname} must be %.50s, not %.50s", '
-                        f'"{expected}", '
-                        f'{{argname}} == Py_None ? "None" : Py_TYPE({{argname}})->tp_name);')
+                        f'"{{{{name}}}}() {displayname} must be %s, not %T", '
+                        f'"{expected}", {{argname}});')
         else:
             if expected_literal:
                 expected = f'"{expected}"'


### PR DESCRIPTION
Argument Clinic now uses the PEP 737 "%T" format to format type name for the limited C API.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-85283 -->
* Issue: gh-85283
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--116841.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->