### PR TITLE
gh-111926: Simplify weakref creation logic

### DIFF
--- a/Objects/weakrefobject.c
+++ b/Objects/weakrefobject.c
@@ -807,8 +807,8 @@ PyWeakref_NewRef(PyObject *ob, PyObject *callback)
         result = new_weakref(ob, callback);
         if (result != NULL) {
             if (callback == NULL) {
-                if (ref == NULL)
-                    insert_head(result, list);
+                assert(ref == NULL);
+                insert_head(result, list);
             }
             else {
                 PyWeakReference *prev;

--- a/Objects/weakrefobject.c
+++ b/Objects/weakrefobject.c
@@ -801,24 +801,14 @@ PyWeakref_NewRef(PyObject *ob, PyObject *callback)
     if (result != NULL)
         Py_INCREF(result);
     else {
-        /* Note: new_weakref() can trigger cyclic GC, so the weakref
-           list on ob can be mutated.  This means that the ref and
-           proxy pointers we got back earlier may have been collected,
-           so we need to compute these values again before we use
-           them. */
+        /* We do not need to recompute ref/proxy; new_weakref() cannot
+           trigger GC.
+        */
         result = new_weakref(ob, callback);
         if (result != NULL) {
-            get_basic_refs(*list, &ref, &proxy);
             if (callback == NULL) {
                 if (ref == NULL)
                     insert_head(result, list);
-                else {
-                    /* Someone else added a ref without a callback
-                       during GC.  Return that one instead of this one
-                       to avoid violating the invariants of the list
-                       of weakrefs for ob. */
-                    Py_SETREF(result, (PyWeakReference*)Py_NewRef(ref));
-                }
             }
             else {
                 PyWeakReference *prev;


### PR DESCRIPTION
Since 3.12 allocating a GC object cannot immediately trigger GC. This allows us to simplify the logic for creating the canonical callback-less weakref.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-111926 -->
* Issue: gh-111926
<!-- /gh-issue-number -->
