### PR TITLE
gh-111926: Simplify proxy creation logic

### DIFF
--- a/Objects/weakrefobject.c
+++ b/Objects/weakrefobject.c
@@ -858,11 +858,9 @@ PyWeakref_NewProxy(PyObject *ob, PyObject *callback)
     if (result != NULL)
         Py_INCREF(result);
     else {
-        /* Note: new_weakref() can trigger cyclic GC, so the weakref
-           list on ob can be mutated.  This means that the ref and
-           proxy pointers we got back earlier may have been collected,
-           so we need to compute these values again before we use
-           them. */
+        /* We do not need to recompute ref/proxy; new_weakref cannot
+           trigger GC.
+        */
         result = new_weakref(ob, callback);
         if (result != NULL) {
             PyWeakReference *prev;
@@ -873,16 +871,7 @@ PyWeakref_NewProxy(PyObject *ob, PyObject *callback)
             else {
                 Py_SET_TYPE(result, &_PyWeakref_ProxyType);
             }
-            get_basic_refs(*list, &ref, &proxy);
             if (callback == NULL) {
-                if (proxy != NULL) {
-                    /* Someone else added a proxy without a callback
-                       during GC.  Return that one instead of this one
-                       to avoid violating the invariants of the list
-                       of weakrefs for ob. */
-                    Py_SETREF(result, (PyWeakReference*)Py_NewRef(proxy));
-                    goto skip_insert;
-                }
                 prev = ref;
             }
             else
@@ -892,8 +881,6 @@ PyWeakref_NewProxy(PyObject *ob, PyObject *callback)
                 insert_head(result, list);
             else
                 insert_after(result, prev);
-        skip_insert:
-            ;
         }
     }
     return (PyObject *) result;


### PR DESCRIPTION
Since 3.12 allocating a GC-able object cannot trigger GC. This allows us to simplify the logic for creating the canonical callback-less proxy object.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-111926 -->
* Issue: gh-111926
<!-- /gh-issue-number -->
