### PR TITLE
gh-116851: remove "from ctypes import *" from ctypes documents

### DIFF
--- a/Doc/library/ctypes.rst
+++ b/Doc/library/ctypes.rst
@@ -93,7 +93,6 @@ Accessing functions from loaded dlls
 
 Functions are accessed as attributes of dll objects::
 
-   >>> from ctypes import *
    >>> libc.printf
    <_FuncPtr object at 0x...>
    >>> print(windll.kernel32.GetModuleHandleA)  # doctest: +WINDOWS


### PR DESCRIPTION
remove import statement "from ctypes import *" from some code snippet before "libc", because "libc" cannot import ctypes, it cause ambiguous

<!-- gh-issue-number: gh-116851 -->
* Issue: gh-116851
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--116852.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->