### PR TITLE
gh-113317: Change how Argument Clinic lists converters

### DIFF
--- a/Lib/test/test_clinic.py
+++ b/Lib/test/test_clinic.py
@@ -2657,6 +2657,7 @@ class ClinicExternalTest(TestCase):
                 float()
                 int()
                 long()
+                object()
                 Py_ssize_t()
                 size_t()
                 unsigned_int()

--- a/Tools/clinic/clinic.py
+++ b/Tools/clinic/clinic.py
@@ -1988,11 +1988,8 @@ def parse_file(
     libclinic.write_file(output, cooked)
 
 
-def create_parser_namespace() -> dict[str, Any]:
-    global _BASE_PARSER_NAMESPACE
-    if _BASE_PARSER_NAMESPACE is not None:
-        return _BASE_PARSER_NAMESPACE.copy()
-
+@functools.cache
+def _create_parser_base_namespace() -> dict[str, Any]:
     ns = dict(
         CConverter=CConverter,
         CReturnConverter=CReturnConverter,
@@ -2006,10 +2003,13 @@ def create_parser_namespace() -> dict[str, Any]:
         ns[f'{name}_converter'] = converter
     for name, return_converter in return_converters.items():
         ns[f'{name}_return_converter'] = return_converter
+    return ns
 
-    _BASE_PARSER_NAMESPACE = ns
-    return _BASE_PARSER_NAMESPACE.copy()
-_BASE_PARSER_NAMESPACE = None
+
+def create_parser_namespace() -> dict[str, Any]:
+    base_namespace = _create_parser_base_namespace()
+    return base_namespace.copy()
+
 
 
 class PythonParser:

--- a/Tools/clinic/clinic.py
+++ b/Tools/clinic/clinic.py
@@ -56,7 +56,7 @@ from libclinic.language import Language, PythonLanguage
 from libclinic.block_parser import Block, BlockParser
 from libclinic.crenderdata import CRenderData, Include, TemplateDict
 from libclinic.converter import (
-    CConverter, CConverterClassT,
+    CConverter, CConverterClassT, ConverterType,
     converters, legacy_converters)
 
 
@@ -5001,8 +5001,8 @@ def run_clinic(parser: argparse.ArgumentParser, ns: argparse.Namespace) -> None:
             parser.error(
                 "can't specify --converters and a filename at the same time"
             )
-        converter_list: list[tuple[str, str, Any]] = []
-        return_converter_list: list[tuple[str, str, Any]] = []
+        converter_list: list[tuple[str, str, ConverterType]] = []
+        return_converter_list: list[tuple[str, str, ReturnConverterType]] = []
 
         for name, converter in converters.items():
             converter_list.append((

--- a/Tools/clinic/clinic.py
+++ b/Tools/clinic/clinic.py
@@ -5008,9 +5008,9 @@ def run_clinic(parser: argparse.ArgumentParser, ns: argparse.Namespace) -> None:
             parser.error(
                 "can't specify --converters and a filename at the same time"
             )
-        any_converter_type = ConverterType | ReturnConverterType
-        converter_list: list[tuple[str, any_converter_type]] = []
-        return_converter_list: list[tuple[str, any_converter_type]] = []
+        AnyConverterType = ConverterType | ReturnConverterType
+        converter_list: list[tuple[str, AnyConverterType]] = []
+        return_converter_list: list[tuple[str, AnyConverterType]] = []
 
         for name, converter in converters.items():
             converter_list.append((

--- a/Tools/clinic/clinic.py
+++ b/Tools/clinic/clinic.py
@@ -1988,7 +1988,7 @@ def parse_file(
     libclinic.write_file(output, cooked)
 
 
-def create_python_parser_namespace() -> dict[str, Any]:
+def create_parser_namespace() -> dict[str, Any]:
     ns = dict(
         CConverter=CConverter,
         CReturnConverter=CReturnConverter,
@@ -2006,7 +2006,7 @@ def create_python_parser_namespace() -> dict[str, Any]:
 
 class PythonParser:
     def __init__(self, clinic: Clinic) -> None:
-        self.namespace = create_python_parser_namespace()
+        self.namespace = create_parser_namespace()
 
     def parse(self, block: Block) -> None:
         ns = dict(self.namespace)

--- a/Tools/clinic/clinic.py
+++ b/Tools/clinic/clinic.py
@@ -1988,7 +1988,7 @@ def parse_file(
     libclinic.write_file(output, cooked)
 
 
-def create_python_parser_namespace():
+def create_python_parser_namespace() -> dict[str, Any]:
     ns = dict(
         CConverter=CConverter,
         CReturnConverter=CReturnConverter,
@@ -1999,8 +1999,8 @@ def create_python_parser_namespace():
     )
     for name, converter in converters.items():
         ns[f'{name}_converter'] = converter
-    for name, converter in return_converters.items():
-        ns[f'{name}_return_converter'] = converter
+    for name, return_converter in return_converters.items():
+        ns[f'{name}_return_converter'] = return_converter
     return ns
 
 
@@ -5001,8 +5001,8 @@ def run_clinic(parser: argparse.ArgumentParser, ns: argparse.Namespace) -> None:
             parser.error(
                 "can't specify --converters and a filename at the same time"
             )
-        converter_list: list[tuple[str, str]] = []
-        return_converter_list: list[tuple[str, str]] = []
+        converter_list: list[tuple[str, str, Any]] = []
+        return_converter_list: list[tuple[str, str, Any]] = []
 
         for name, converter in converters.items():
             converter_list.append((
@@ -5010,11 +5010,11 @@ def run_clinic(parser: argparse.ArgumentParser, ns: argparse.Namespace) -> None:
                 name,
                 converter,
             ))
-        for name, converter in return_converters.items():
+        for name, return_converter in return_converters.items():
             return_converter_list.append((
                 f'{name}_return_converter',
                 name,
-                converter
+                return_converter
             ))
 
         print()


### PR DESCRIPTION
* Add a new create_python_parser_namespace() function for PythonParser to pass objects to executed code.
* In run_clinic(), list converters using 'converters' and 'return_converters' dictionarties.
* test_clinic: add 'object()' return converter.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-113317 -->
* Issue: gh-113317
<!-- /gh-issue-number -->
