### PR TITLE
[3.12] gh-116811: Ensure MetadataPathFinder.invalidate_caches is reachable when delegated through PathFinder. (GH-116812)

### DIFF
--- a/Lib/importlib/_bootstrap_external.py
+++ b/Lib/importlib/_bootstrap_external.py
@@ -1450,6 +1450,9 @@ class PathFinder:
         # https://bugs.python.org/issue45703
         _NamespacePath._epoch += 1
 
+        from importlib.metadata import MetadataPathFinder
+        MetadataPathFinder.invalidate_caches()
+
     @staticmethod
     def _path_hooks(path):
         """Search sys.path_hooks for a finder for 'path'."""

--- a/Lib/importlib/metadata/__init__.py
+++ b/Lib/importlib/metadata/__init__.py
@@ -795,6 +795,7 @@ class MetadataPathFinder(DistributionFinder):
             path.search(prepared) for path in map(FastPath, paths)
         )
 
+    @classmethod
     def invalidate_caches(cls):
         FastPath.__new__.cache_clear()
 

--- a/Misc/NEWS.d/next/Library/2024-03-14-10-01-23.gh-issue-116811._h5iKP.rst
+++ b/Misc/NEWS.d/next/Library/2024-03-14-10-01-23.gh-issue-116811._h5iKP.rst
@@ -1,0 +1,2 @@
+In ``PathFinder.invalidate_caches``, delegate to
+``MetadataPathFinder.invalidate_caches``.


### PR DESCRIPTION

* Make MetadataPathFinder a proper classmethod.

* In PathFinder.invalidate_caches, also invoke MetadataPathFinder.invalidate_caches.

* Add blurb (cherry picked from commit 5f52d20a93908196f74271db8437cc1ba7e1e262)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-116811 -->
* Issue: gh-116811
<!-- /gh-issue-number -->
