### PR TITLE
gh-116874: Fix building _decimal module on ppc64le

### DIFF
--- a/Misc/NEWS.d/next/Build/2024-03-15-20-35-02.gh-issue-116874.ZGTL0M.rst
+++ b/Misc/NEWS.d/next/Build/2024-03-15-20-35-02.gh-issue-116874.ZGTL0M.rst
@@ -1,0 +1,1 @@
+Fix building _decimal module on ppc64le

--- a/Misc/sbom.spdx.json
+++ b/Misc/sbom.spdx.json
@@ -1406,11 +1406,11 @@
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "4b80e25ac49b7e1ea0d1e84967ee32a3d111fc4c"
+          "checksumValue": "a16dfd5d53933b52bcd62c7995b6f08502bdd313"
         },
         {
           "algorithm": "SHA256",
-          "checksumValue": "ea0b9c6b296c13aed6ecaa50b463e39a9c1bdc059b84f50507fd8247b2e660f9"
+          "checksumValue": "00af8f53d39cc8a1c9425897fa33a653a014b3720495822f4f29c877718084a4"
         }
       ],
       "fileName": "Modules/_decimal/libmpdec/mpdecimal.h"

--- a/Modules/_decimal/libmpdec/mpdecimal.h
+++ b/Modules/_decimal/libmpdec/mpdecimal.h
@@ -100,11 +100,11 @@ const char *mpd_version(void);
   #if defined(CONFIG_64) || defined(CONFIG_32)
     #error "cannot use CONFIG_64 or CONFIG_32 with UNIVERSAL."
   #endif
-  #if defined(__ppc__)
-    #define CONFIG_32
-    #define ANSI
-  #elif defined(__ppc64__)
+  #if defined(__ppc64__) || defined(__powerpc64__)
     #define CONFIG_64
+    #define ANSI
+  #elif defined(__ppc__)
+    #define CONFIG_32
     #define ANSI
   #elif defined(__i386__)
     #define CONFIG_32


### PR DESCRIPTION
```
In file included from python3/Modules/_decimal/libmpdec/basearith.c:34:
In file included from python3/Modules/_decimal/libmpdec/basearith.h:34:
python3/Modules/_decimal/libmpdec/typearith.h:612:4: error: "adapt mul_size_t() and mulmod_size_t()"
  #error "adapt mul_size_t() and mulmod_size_t()"
   ^
2 errors generated.
```

<!-- gh-issue-number: gh-116874 -->
* Issue: gh-116874
<!-- /gh-issue-number -->
