### PR TITLE
[3.12] gh-112536: Add --tsan test for reasonable TSAN execution times. (gh-116601)

### DIFF
--- a/Lib/test/libregrtest/cmdline.py
+++ b/Lib/test/libregrtest/cmdline.py
@@ -164,6 +164,7 @@ class Namespace(argparse.Namespace):
         self.match_tests: TestFilter = []
         self.pgo = False
         self.pgo_extended = False
+        self.tsan = False
         self.worker_json = None
         self.start = None
         self.timeout = None
@@ -333,6 +334,8 @@ def _create_parser():
                        help='enable Profile Guided Optimization (PGO) training')
     group.add_argument('--pgo-extended', action='store_true',
                        help='enable extended PGO training (slower training)')
+    group.add_argument('--tsan', dest='tsan', action='store_true',
+                       help='run a subset of test cases that are proper for the TSAN test')
     group.add_argument('--fail-env-changed', action='store_true',
                        help='if a test file alters the environment, mark '
                             'the test as failed')

--- a/Lib/test/libregrtest/main.py
+++ b/Lib/test/libregrtest/main.py
@@ -18,6 +18,7 @@ from .results import TestResults, EXITCODE_INTERRUPTED
 from .runtests import RunTests, HuntRefleak
 from .setup import setup_process, setup_test_dir
 from .single import run_single_test, PROGRESS_MIN_TIME
+from .tsan import setup_tsan_tests
 from .utils import (
     StrPath, StrJSON, TestName, TestList, TestTuple, TestFilter,
     strip_py_suffix, count, format_duration,
@@ -56,6 +57,7 @@ class Regrtest:
         self.quiet: bool = ns.quiet
         self.pgo: bool = ns.pgo
         self.pgo_extended: bool = ns.pgo_extended
+        self.tsan: bool = ns.tsan
 
         # Test results
         self.results: TestResults = TestResults()
@@ -181,6 +183,9 @@ class Regrtest:
         if self.pgo:
             # add default PGO tests if no tests are specified
             setup_pgo_tests(self.cmdline_args, self.pgo_extended)
+
+        if self.tsan:
+            setup_tsan_tests(self.cmdline_args)
 
         exclude_tests = set()
         if self.exclude:

--- a/Lib/test/libregrtest/tsan.py
+++ b/Lib/test/libregrtest/tsan.py
@@ -1,0 +1,24 @@
+# Set of tests run by default if --tsan is specified.  The tests below were
+# chosen because they use threads and run in a reasonable amount of time.
+
+TSAN_TESTS = [
+    'test_code',
+    'test_enum',
+    'test_functools',
+    'test_httpservers',
+    'test_imaplib',
+    'test_importlib',
+    'test_io',
+    'test_logging',
+    'test_ssl',
+    'test_syslog',
+    'test_thread',
+    'test_threadedtempfile',
+    'test_threading_local',
+    'test_threadsignals',
+]
+
+
+def setup_tsan_tests(cmdline_args):
+    if not cmdline_args:
+        cmdline_args[:] = TSAN_TESTS[:]

--- a/Lib/test/libregrtest/tsan.py
+++ b/Lib/test/libregrtest/tsan.py
@@ -2,6 +2,7 @@
 # chosen because they use threads and run in a reasonable amount of time.
 
 TSAN_TESTS = [
+    'test_capi',
     'test_code',
     'test_enum',
     'test_functools',
@@ -11,6 +12,9 @@ TSAN_TESTS = [
     'test_io',
     'test_logging',
     'test_queue',
+    'test_signal',
+    'test_socket',
+    'test_sqlite3',
     'test_ssl',
     'test_syslog',
     'test_thread',

--- a/Lib/test/libregrtest/tsan.py
+++ b/Lib/test/libregrtest/tsan.py
@@ -15,6 +15,7 @@ TSAN_TESTS = [
     'test_syslog',
     'test_thread',
     'test_threadedtempfile',
+    'test_threading',
     'test_threading_local',
     'test_threadsignals',
     'test_weakref',

--- a/Lib/test/libregrtest/tsan.py
+++ b/Lib/test/libregrtest/tsan.py
@@ -10,12 +10,14 @@ TSAN_TESTS = [
     'test_importlib',
     'test_io',
     'test_logging',
+    'test_queue',
     'test_ssl',
     'test_syslog',
     'test_thread',
     'test_threadedtempfile',
     'test_threading_local',
     'test_threadsignals',
+    'test_weakref',
 ]
 
 

--- a/Lib/test/support/script_helper.py
+++ b/Lib/test/support/script_helper.py
@@ -64,8 +64,8 @@ class _PythonRunResult(collections.namedtuple("_PythonRunResult",
     """Helper for reporting Python subprocess run results"""
     def fail(self, cmd_line):
         """Provide helpful details about failed subcommand runs"""
-        # Limit to 80 lines to ASCII characters
-        maxlen = 80 * 100
+        # Limit to 300 lines of ASCII characters
+        maxlen = 300 * 100
         out, err = self.out, self.err
         if len(out) > maxlen:
             out = b'(... truncated stdout ...)' + out[-maxlen:]

--- a/Misc/NEWS.d/next/Tests/2024-03-11-23-20-28.gh-issue-112536.Qv1RrX.rst
+++ b/Misc/NEWS.d/next/Tests/2024-03-11-23-20-28.gh-issue-112536.Qv1RrX.rst
@@ -1,0 +1,2 @@
+Add --tsan to test.regrtest for running TSAN tests in reasonable execution
+times. Patch by Donghee Na.

--- a/Modules/_testcapi/mem.c
+++ b/Modules/_testcapi/mem.c
@@ -580,8 +580,8 @@ check_pyobject_forbidden_bytes_is_freed(PyObject *self,
 static PyObject *
 check_pyobject_freed_is_freed(PyObject *self, PyObject *Py_UNUSED(args))
 {
-    /* This test would fail if run with the address sanitizer */
-#ifdef _Py_ADDRESS_SANITIZER
+    /* ASan or TSan would report an use-after-free error */
+#if defined(_Py_ADDRESS_SANITIZER) || defined(_Py_THREAD_SANITIZER)
     Py_RETURN_NONE;
 #else
     PyObject *op = PyObject_CallNoArgs((PyObject *)&PyBaseObject_Type);

--- a/Tools/tsan/supressions.txt
+++ b/Tools/tsan/supressions.txt
@@ -1,0 +1,5 @@
+## reference: https://github.com/google/sanitizers/wiki/ThreadSanitizerSuppressions
+race:get_allocator_unlocked
+race:set_allocator_unlocked
+race:mi_heap_visit_pages
+race:_mi_heap_delayed_free_partial

--- a/Tools/tsan/supressions.txt
+++ b/Tools/tsan/supressions.txt
@@ -1,5 +1,3 @@
 ## reference: https://github.com/google/sanitizers/wiki/ThreadSanitizerSuppressions
 race:get_allocator_unlocked
 race:set_allocator_unlocked
-race:mi_heap_visit_pages
-race:_mi_heap_delayed_free_partial


### PR DESCRIPTION
(cherry picked from commit https://github.com/python/cpython/commit/ebf29b3a02d5b42a747e271e9cfc4dd73c01ebe6)

Also backport gh-116896, gh-116898, gh-116911: these are all adding to the list of TSan tests.

Co-authored-by: Donghee Na <donghee.na@python.org>

<!-- gh-issue-number: gh-112536 -->
* Issue: gh-112536
<!-- /gh-issue-number -->
