### PR TITLE
[3.11] gh-116831: Fixes tests for c extension in WASI for Python 3.11 (GH-116831)

### DIFF
--- a/Lib/test/test_imp.py
+++ b/Lib/test/test_imp.py
@@ -10,6 +10,7 @@ from test.support import import_helper
 from test.support import os_helper
 from test.support import script_helper
 from test.support import warnings_helper
+from test.support import is_wasi
 import unittest
 import warnings
 imp = warnings_helper.import_deprecated('imp')
@@ -23,6 +24,8 @@ def requires_load_dynamic(meth):
     """Decorator to skip a test if not running under CPython or lacking
     imp.load_dynamic()."""
     meth = support.cpython_only(meth)
+    if is_wasi:
+        return unittest.skipIf(True, 'Not supoorted in WASI')(meth)
     return unittest.skipIf(getattr(imp, 'load_dynamic', None) is None,
                            'imp.load_dynamic() required')(meth)
 


### PR DESCRIPTION
We can skip the C extension based tests under WASI.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-116831 -->
* Issue: gh-116831
<!-- /gh-issue-number -->
