### PR TITLE
gh-56374: Clarify documentation of nonlocal

### DIFF
--- a/Doc/reference/simple_stmts.rst
+++ b/Doc/reference/simple_stmts.rst
@@ -1006,24 +1006,28 @@ The :keyword:`!nonlocal` statement
 .. productionlist:: python-grammar
    nonlocal_stmt: "nonlocal" `identifier` ("," `identifier`)*
 
-The :keyword:`nonlocal` statement causes the listed identifiers to refer to
-previously bound variables in the nearest enclosing scope excluding globals.
-This is important because the default behavior for binding is to search the
-local namespace first.  The statement allows encapsulated code to rebind
-variables outside of the local scope besides the global (module) scope.
+When the definition of a function or class is nested (enclosed) within
+the definitions of other functions, its nonlocal scopes are the local
+scopes of the enclosing functions. The :keyword:`nonlocal` statement
+causes the listed identifiers to refer to names previously bound in
+nonlocal scopes. It allows encapsulated code to rebind such nonlocal
+identifiers.  If a name is bound in more than one nonlocal scope, the
+nearest binding is used. If a name is not bound in any nonlocal scope,
+or if there is no nonlocal scope, a SyntaxError is raised.
 
-Names listed in a :keyword:`nonlocal` statement, unlike those listed in a
-:keyword:`global` statement, must refer to pre-existing bindings in an
-enclosing scope (the scope in which a new binding should be created cannot
-be determined unambiguously).
-
-Names listed in a :keyword:`nonlocal` statement must not collide with
-pre-existing bindings in the local scope.
+The nonlocal statement applies to the entire scope of a function or
+class body. A SyntaxError is raised if a variable is used or
+assigned to prior to its nonlocal declaration in the scope.
 
 .. seealso::
 
    :pep:`3104` - Access to Names in Outer Scopes
       The specification for the :keyword:`nonlocal` statement.
+
+**Programmer's note:** :keyword:`nonlocal` is a directive to the parser
+and applies only to code parsed along with it.  See the note for the
+`!global` statement.
+
 
 .. _type:
 

--- a/Doc/reference/simple_stmts.rst
+++ b/Doc/reference/simple_stmts.rst
@@ -1026,7 +1026,7 @@ assigned to prior to its nonlocal declaration in the scope.
 
 **Programmer's note:** :keyword:`nonlocal` is a directive to the parser
 and applies only to code parsed along with it.  See the note for the
-`!global` statement.
+`global` statement.
 
 
 .. _type:

--- a/Doc/reference/simple_stmts.rst
+++ b/Doc/reference/simple_stmts.rst
@@ -1016,7 +1016,7 @@ nearest binding is used. If a name is not bound in any nonlocal scope,
 or if there is no nonlocal scope, a SyntaxError is raised.
 
 The nonlocal statement applies to the entire scope of a function or
-class body. A SyntaxError is raised if a variable is used or
+class body. A :exc:`SyntaxError` is raised if a variable is used or
 assigned to prior to its nonlocal declaration in the scope.
 
 .. seealso::

--- a/Doc/reference/simple_stmts.rst
+++ b/Doc/reference/simple_stmts.rst
@@ -1013,7 +1013,7 @@ causes the listed identifiers to refer to names previously bound in
 nonlocal scopes. It allows encapsulated code to rebind such nonlocal
 identifiers.  If a name is bound in more than one nonlocal scope, the
 nearest binding is used. If a name is not bound in any nonlocal scope,
-or if there is no nonlocal scope, a SyntaxError is raised.
+or if there is no nonlocal scope, a :exc:`SyntaxError` is raised.
 
 The nonlocal statement applies to the entire scope of a function or
 class body. A :exc:`SyntaxError` is raised if a variable is used or

--- a/Doc/reference/simple_stmts.rst
+++ b/Doc/reference/simple_stmts.rst
@@ -1026,7 +1026,7 @@ assigned to prior to its nonlocal declaration in the scope.
 
 **Programmer's note:** :keyword:`nonlocal` is a directive to the parser
 and applies only to code parsed along with it.  See the note for the
-`global` statement.
+:keyword:`global` statement.
 
 
 .. _type:


### PR DESCRIPTION
Define 'nonlocal scopes' first, and in a way that excludes class scopes.
Rearrange some of the doc.  Add "Programmer's note".

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-56374 -->
* Issue: gh-56374
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--116942.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->