### PR TITLE
gh-116960: Disambiguate json decoder error message

### DIFF
--- a/Lib/json/decoder.py
+++ b/Lib/json/decoder.py
@@ -161,7 +161,7 @@ def JSONObject(s_and_end, strict, scan_once, object_hook, object_pairs_hook,
             return pairs, end + 1
         elif nextchar != '"':
             raise JSONDecodeError(
-                "Expecting property name enclosed in double quotes", s, end)
+                "Missing property name or property name not enclosed in double quotes", s, end)
     end += 1
     while True:
         key, end = scanstring(s, end, strict)

--- a/Misc/NEWS.d/next/Library/2024-03-18-15-20-39.gh-issue-116960.tFVk69.rst
+++ b/Misc/NEWS.d/next/Library/2024-03-18-15-20-39.gh-issue-116960.tFVk69.rst
@@ -1,0 +1,1 @@
+When JSON Decoder encounters a trailing comma (and thus a missing next property), its error message is now less misleading.


### PR DESCRIPTION
A better JSON decoder error message when a trailing comma is found (i.e. a property is missing)

<!-- gh-issue-number: gh-116960 -->
* Issue: gh-116960
<!-- /gh-issue-number -->
