### PR TITLE
gh-116869: Fix redefinition of the _PyOptimizerObject type

### DIFF
--- a/Include/cpython/optimizer.h
+++ b/Include/cpython/optimizer.h
@@ -65,7 +65,7 @@ typedef int (*optimize_func)(
     _Py_CODEUNIT *instr, _PyExecutorObject **exec_ptr,
     int curr_stackentries);
 
-typedef struct _PyOptimizerObject {
+struct _PyOptimizerObject {
     PyObject_HEAD
     optimize_func optimize;
     /* These thresholds are treated as signed so do not exceed INT16_MAX
@@ -74,7 +74,7 @@ typedef struct _PyOptimizerObject {
     uint16_t side_threshold;
     uint16_t backedge_threshold;
     /* Data needed by the optimizer goes here, but is opaque to the VM */
-} _PyOptimizerObject;
+};
 
 /** Test support **/
 typedef struct {


### PR DESCRIPTION
Defining a type twice is a C11 feature and so makes the C API incompatible with C99. Fix the issue by only defining the type once.

Example of warning (treated as an error):

    In file included from Include/Python.h:122:
    Include/cpython/optimizer.h:77:3: error: redefinition of typedef
    '_PyOptimizerObject' is a C11 feature [-Werror,-Wtypedef-redefinition]
    } _PyOptimizerObject;
    ^
    build/Include/cpython/optimizer.h:60:35: note: previous definition is here
    typedef struct _PyOptimizerObject _PyOptimizerObject;
                                    ^

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-116869 -->
* Issue: gh-116869
<!-- /gh-issue-number -->
