### PR TITLE
Revert "gh-110119: Temporarily skip test_cppext on --disable-gil builds. (#110123)"

### DIFF
--- a/Lib/test/test_cppext/__init__.py
+++ b/Lib/test/test_cppext/__init__.py
@@ -12,10 +12,6 @@ SOURCE = os.path.join(os.path.dirname(__file__), 'extension.cpp')
 SETUP = os.path.join(os.path.dirname(__file__), 'setup.py')
 
 
-# gh-110119: pip does not currently support 't' in the ABI flag use by
-# --disable-gil builds. Once it does, we can remove this skip.
-@unittest.skipIf(support.Py_GIL_DISABLED,
-                 'test does not work with --disable-gil')
 @support.requires_subprocess()
 class TestCPPExt(unittest.TestCase):
     @support.requires_resource('cpu')


### PR DESCRIPTION
The `test_cppext` can run now that the `wheel` package is updated.

This reverts commit 2973970af8fb3f117ab2e8ab2d82e8a541fcb1da.


<!-- gh-issue-number: gh-110119 -->
* Issue: gh-110119
<!-- /gh-issue-number -->
