### PR TITLE
Doc: Render version/language selector on Read the Docs

### DIFF
--- a/Doc/tools/templates/layout.html
+++ b/Doc/tools/templates/layout.html
@@ -85,13 +85,20 @@
         </select>
         `;
 
-        const selectVersionElement = document.querySelector("li.switchers div.version_switcher_placeholder");
-        selectVersionElement.innerHTML = versionSelect;
-        document.querySelector("li.switchers div.version_switcher_placeholder").addEventListener("change", onSwitch);
+         // Query all the placeholders because there are different ones for Desktop/Mobile
+         let placeholders = document.querySelectorAll(".version_switcher_placeholder");
+         for (placeholder of placeholders) {
+             placeholder.innerHTML = versionSelect;
+             let selectElement = placeholder.querySelector("select");
+             selectElement.addEventListener("change", onSwitch);
+         }
 
-        const selectLanguageElement = document.querySelector("li.switchers div.language_switcher_placeholder");
-        selectLanguageElement.innerHTML = languageSelect;
-        document.querySelector("li.switchers div.language_switcher_placeholder select").addEventListener("change", onSwitch);
+         placeholders = document.querySelectorAll(".language_switcher_placeholder");
+         for (placeholder of placeholders) {
+             placeholder.innerHTML = languageSelect;
+             let selectElement = placeholder.querySelector("select");
+             selectElement.addEventListener("change", onSwitch);
+         }
      });
  });
 </script>

--- a/Doc/tools/templates/layout.html
+++ b/Doc/tools/templates/layout.html
@@ -51,80 +51,80 @@
  }
 
  document.addEventListener("readthedocs-addons-data-ready", function(event) {
-     event.detail.initialize();
-     event.detail.data().then((config) => {
-        // Add some mocked hardcoded versions pointing to the official
-        // documentation while migrating to Read the Docs.
-        // These are only for testing purposes.
-        // TODO: remove them when managing all the versions on Read the Docs,
-        // since all the "active, built and not hidden" versions will be shown automatically.
-        let versions = config.versions.active.concat([
-            {
-                slug: "dev (3.13)",
-                urls: {
-                    documentation: "https://docs.python.org/3.13/",
-                }
-            },
-            {
-                slug: "3.12",
-                urls: {
-                    documentation: "https://docs.python.org/3.12/",
-                }
-            },
-            {
-                slug: "3.11",
-                urls: {
-                    documentation: "https://docs.python.org/3.11/",
-                }
-            },
-        ]);
+   const config = event.detail.data()
 
-        const versionSelect = `
-        <select id="version_select">
-        ${ versions.map(
-            (version) => `
-            <option
-                value="${ version.slug }"
-                ${ config.versions.current.slug === version.slug ? 'selected="selected"' : '' }
-                data-url="${ version.urls.documentation }">
-                ${ version.slug }
-            </option>`
-        ).join("\n") }
-        </select>
-        `;
+   // Add some mocked hardcoded versions pointing to the official
+   // documentation while migrating to Read the Docs.
+   // These are only for testing purposes.
+   // TODO: remove them when managing all the versions on Read the Docs,
+   // since all the "active, built and not hidden" versions will be shown automatically.
+   let versions = config.versions.active.concat([
+       {
+           slug: "dev (3.13)",
+           urls: {
+               documentation: "https://docs.python.org/3.13/",
+           }
+       },
+       {
+           slug: "3.12",
+           urls: {
+               documentation: "https://docs.python.org/3.12/",
+           }
+       },
+       {
+           slug: "3.11",
+           urls: {
+               documentation: "https://docs.python.org/3.11/",
+           }
+       },
+   ]);
 
-        let languages = config.projects.translations.concat(config.projects.current);
-        languages = languages.sort((a, b) => a.language.name.localeCompare(b.language.name));
+   const versionSelect = `
+   <select id="version_select">
+   ${ versions.map(
+       (version) => `
+       <option
+           value="${ version.slug }"
+           ${ config.versions.current.slug === version.slug ? 'selected="selected"' : '' }
+           data-url="${ version.urls.documentation }">
+           ${ version.slug }
+       </option>`
+   ).join("\n") }
+   </select>
+   `;
 
-        const languageSelect = `
-        <select id="language_select">
-        ${ languages.map(
-            (translation) => `
-            <option
-                value="${ translation.slug }"
-                ${ config.projects.current.slug === translation.slug ? 'selected="selected"' : '' }
-                data-url="${ translation.urls.documentation }">
-                ${ translation.language.name }
-            </option>`
-        ).join("\n") }
-        </select>
-        `;
+   // Prepend the current language to the options on the selector
+   let languages = config.projects.translations.concat(config.projects.current);
+   languages = languages.sort((a, b) => a.language.name.localeCompare(b.language.name));
 
-         // Query all the placeholders because there are different ones for Desktop/Mobile
-         let placeholders = document.querySelectorAll(".version_switcher_placeholder");
-         for (placeholder of placeholders) {
-             placeholder.innerHTML = versionSelect;
-             let selectElement = placeholder.querySelector("select");
-             selectElement.addEventListener("change", onSwitch);
-         }
+   const languageSelect = `
+   <select id="language_select">
+   ${ languages.map(
+       (translation) => `
+       <option
+           value="${ translation.slug }"
+           ${ config.projects.current.slug === translation.slug ? 'selected="selected"' : '' }
+           data-url="${ translation.urls.documentation }">
+           ${ translation.language.name }
+       </option>`
+   ).join("\n") }
+   </select>
+   `;
 
-         placeholders = document.querySelectorAll(".language_switcher_placeholder");
-         for (placeholder of placeholders) {
-             placeholder.innerHTML = languageSelect;
-             let selectElement = placeholder.querySelector("select");
-             selectElement.addEventListener("change", onSwitch);
-         }
-     });
+   // Query all the placeholders because there are different ones for Desktop/Mobile
+   const versionPlaceholders = document.querySelectorAll(".version_switcher_placeholder");
+   for (placeholder of versionPlaceholders) {
+       placeholder.innerHTML = versionSelect;
+       let selectElement = placeholder.querySelector("select");
+       selectElement.addEventListener("change", onSwitch);
+   }
+
+   const languagePlaceholders = document.querySelectorAll(".language_switcher_placeholder");
+   for (placeholder of languagePlaceholders) {
+       placeholder.innerHTML = languageSelect;
+       let selectElement = placeholder.querySelector("select");
+       selectElement.addEventListener("change", onSwitch);
+   }
  });
 </script>
 {% endblock %}

--- a/Doc/tools/templates/layout.html
+++ b/Doc/tools/templates/layout.html
@@ -53,10 +53,35 @@
  document.addEventListener("readthedocs-addons-data-ready", function(event) {
      event.detail.initialize();
      event.detail.data().then((config) => {
-        // TODO: add `selected="selected"` to option
+        // Add some mocked hardcoded versions pointing to the official
+        // documentation while migrating to Read the Docs.
+        // These are only for testing purposes.
+        // TODO: remove them when managing all the versions on Read the Docs,
+        // since all the "active, built and not hidden" versions will be shown automatically.
+        let versions = config.versions.active.concat([
+            {
+                slug: "dev (3.13)",
+                urls: {
+                    documentation: "https://docs.python.org/3.13/",
+                }
+            },
+            {
+                slug: "3.12",
+                urls: {
+                    documentation: "https://docs.python.org/3.12/",
+                }
+            },
+            {
+                slug: "3.11",
+                urls: {
+                    documentation: "https://docs.python.org/3.11/",
+                }
+            },
+        ]);
+
         const versionSelect = `
         <select id="version_select">
-        ${ config.versions.active.map(
+        ${ versions.map(
             (version) => `
             <option
                 value="${ version.slug }"

--- a/Doc/tools/templates/layout.html
+++ b/Doc/tools/templates/layout.html
@@ -42,7 +42,7 @@
     </style>
 {{ super() }}
 
-<meta name="readthedocs-addons-api-version" content="0">
+<meta name="readthedocs-addons-api-version" content="1">
 <script type="text/javascript">
  function onSwitch(event) {
      const option = event.target.selectedIndex;
@@ -51,49 +51,48 @@
  }
 
  document.addEventListener("readthedocs-addons-data-ready", function(event) {
-     const config = event.detail;
-     const languageMapping = {
-         en: "English",
-         es: "Spanish",
-         // ...
-     }
+     event.detail.initialize();
+     event.detail.data().then((config) => {
+        // TODO: add `selected="selected"` to option
+        const versionSelect = `
+        <select id="version_select">
+        ${ config.versions.active.map(
+            (version) => `
+            <option
+                value="${ version.slug }"
+                ${ config.versions.current.slug === version.slug ? 'selected="selected"' : '' }
+                data-url="${ version.urls.documentation }">
+                ${ version.slug }
+            </option>`
+        ).join("\n") }
+        </select>
+        `;
 
-     // TODO: add `selected="selected"` to option
-     const versionSelect = `
-     <select id="version_select">
-     ${ config.addons.flyout.versions.map(
-         (version) => `
-           <option
-               value="${ version.slug }"
-               ${ config.versions.current.slug === version.slug ? 'selected="selected"' : '' }
-               data-url="${ version.url }">
-               ${ version.slug }
-           </option>`
-     ).join("\n") }
-     </select>
-     `;
+        let languages = config.projects.translations.concat(config.projects.current);
+        languages = languages.sort((a, b) => a.language.name.localeCompare(b.language.name));
 
-     const languageSelect = `
-     <select id="language_select">
-     ${ config.addons.flyout.translations.map(
-         (translation) => `
-         <option
-             value="${ translation.slug }"
-             ${ config.projects.current.language.code === translation.slug ? 'selected="selected"' : '' }
-             data-url="${ translation.url }">
-             ${ languageMapping[translation.slug] }
-         </option>`
-     ).join("\n") }
-     </select>
-     `;
+        const languageSelect = `
+        <select id="language_select">
+        ${ languages.map(
+            (translation) => `
+            <option
+                value="${ translation.slug }"
+                ${ config.projects.current.slug === translation.slug ? 'selected="selected"' : '' }
+                data-url="${ translation.urls.documentation }">
+                ${ translation.language.name }
+            </option>`
+        ).join("\n") }
+        </select>
+        `;
 
-    const selectVersionElement = document.querySelector("li.switchers div.version_switcher_placeholder");
-    selectVersionElement.innerHTML = versionSelect;
-    document.querySelector("li.switchers div.version_switcher_placeholder").addEventListener("change", onSwitch);
+        const selectVersionElement = document.querySelector("li.switchers div.version_switcher_placeholder");
+        selectVersionElement.innerHTML = versionSelect;
+        document.querySelector("li.switchers div.version_switcher_placeholder").addEventListener("change", onSwitch);
 
-    const selectLanguageElement = document.querySelector("li.switchers div.language_switcher_placeholder");
-    selectLanguageElement.innerHTML = languageSelect;
-    document.querySelector("li.switchers div.language_switcher_placeholder select").addEventListener("change", onSwitch);
+        const selectLanguageElement = document.querySelector("li.switchers div.language_switcher_placeholder");
+        selectLanguageElement.innerHTML = languageSelect;
+        document.querySelector("li.switchers div.language_switcher_placeholder select").addEventListener("change", onSwitch);
+     });
  });
 </script>
 {% endblock %}

--- a/Doc/tools/templates/layout.html
+++ b/Doc/tools/templates/layout.html
@@ -41,4 +41,59 @@
       {{ "}" }}
     </style>
 {{ super() }}
+
+<meta name="readthedocs-addons-api-version" content="0">
+<script type="text/javascript">
+ function onSwitch(event) {
+     const option = event.target.selectedIndex;
+     const item = event.target.options[option];
+     window.location.href = item.dataset.url;
+ }
+
+ document.addEventListener("readthedocs-addons-data-ready", function(event) {
+     const config = event.detail;
+     const languageMapping = {
+         en: "English",
+         es: "Spanish",
+         // ...
+     }
+
+     // TODO: add `selected="selected"` to option
+     const versionSelect = `
+     <select id="version_select">
+     ${ config.addons.flyout.versions.map(
+         (version) => `
+           <option
+               value="${ version.slug }"
+               ${ config.versions.current.slug === version.slug ? 'selected="selected"' : '' }
+               data-url="${ version.url }">
+               ${ version.slug }
+           </option>`
+     ).join("\n") }
+     </select>
+     `;
+
+     const languageSelect = `
+     <select id="language_select">
+     ${ config.addons.flyout.translations.map(
+         (translation) => `
+         <option
+             value="${ translation.slug }"
+             ${ config.projects.current.language.code === translation.slug ? 'selected="selected"' : '' }
+             data-url="${ translation.url }">
+             ${ languageMapping[translation.slug] }
+         </option>`
+     ).join("\n") }
+     </select>
+     `;
+
+    const selectVersionElement = document.querySelector("li.switchers div.version_switcher_placeholder");
+    selectVersionElement.innerHTML = versionSelect;
+    document.querySelector("li.switchers div.version_switcher_placeholder").addEventListener("change", onSwitch);
+
+    const selectLanguageElement = document.querySelector("li.switchers div.language_switcher_placeholder");
+    selectLanguageElement.innerHTML = languageSelect;
+    document.querySelector("li.switchers div.language_switcher_placeholder select").addEventListener("change", onSwitch);
+ });
+</script>
 {% endblock %}


### PR DESCRIPTION
Integrate the new Read the Docs Addons into the Python Docs Sphinx theme to render versions and languages selector nicely, using the JavaScript `readthedocs-addons-data-ready` custom event triggered by the Read the Docs Addons.

References:

* Discord thread: https://discord.com/channels/935215565872693329/1159601953265942589
* Implementation of Addons JavaScript `CustomEvent`: https://github.com/readthedocs/addons/pull/64
* Conversation about using Read the Docs: https://github.com/python/docs-community/issues/5
* Example of a similar integration on Read the Docs Sphinx theme: https://github.com/readthedocs/sphinx_rtd_theme/pull/1526


I'm opening this PR here as a POC to continue the conversation on the Discord thread linked.

### Example

This example was built locally on a development Read the Docs instance. The languages and versions shown in the example are:

* translations configured on the development Read the Docs instance
* active, built and not hidden versions on the development Read the Docs instance

It shows `readthedocs-selector` because it's the branch where I was making these changes. It shows `latest`, because I forgot to disable it 😄

![Peek 2024-03-18 17-54](https://github.com/python/cpython/assets/244656/1053b20c-c215-49fb-9c5d-5c473a36da54)


> Note this PR is not linked to any issue yet since it comes from a Discord conversation


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--116966.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->