### PR TITLE
gh-116869: Enable test_cext and test_cppext on Free Threading build

### DIFF
--- a/Lib/test/test_cext/__init__.py
+++ b/Lib/test/test_cext/__init__.py
@@ -13,10 +13,16 @@ SOURCE = os.path.join(os.path.dirname(__file__), 'extension.c')
 SETUP = os.path.join(os.path.dirname(__file__), 'setup.py')
 
 
-# gh-110119: pip does not currently support 't' in the ABI flag use by
-# --disable-gil builds. Once it does, we can remove this skip.
-@unittest.skipIf(support.Py_GIL_DISABLED,
-                 'test does not work with --disable-gil')
+# With MSVC, the linker fails with: cannot open file 'python311.lib'
+# https://github.com/python/cpython/pull/32175#issuecomment-1111175897
+@unittest.skipIf(support.MS_WINDOWS, 'test fails on Windows')
+# Building and running an extension in clang sanitizing mode is not
+# straightforward
+@unittest.skipIf(
+    '-fsanitize' in (sysconfig.get_config_var('PY_CFLAGS') or ''),
+    'test does not work with analyzing builds')
+# the test uses venv+pip: skip if it's not available
+@support.requires_venv_with_pip()
 @support.requires_subprocess()
 @support.requires_resource('cpu')
 class TestExt(unittest.TestCase):
@@ -26,16 +32,6 @@ class TestExt(unittest.TestCase):
     def test_build_c11(self):
         self.check_build('c11', '_test_c11_ext')
 
-    # With MSVC, the linker fails with: cannot open file 'python311.lib'
-    # https://github.com/python/cpython/pull/32175#issuecomment-1111175897
-    @unittest.skipIf(support.MS_WINDOWS, 'test fails on Windows')
-    # Building and running an extension in clang sanitizing mode is not
-    # straightforward
-    @unittest.skipIf(
-        '-fsanitize' in (sysconfig.get_config_var('PY_CFLAGS') or ''),
-        'test does not work with analyzing builds')
-    # the test uses venv+pip: skip if it's not available
-    @support.requires_venv_with_pip()
     def check_build(self, clang_std, extension_name):
         venv_dir = 'env'
         with support.setup_venv_with_pip_setuptools_wheel(venv_dir) as python_exe:

--- a/Lib/test/test_cext/__init__.py
+++ b/Lib/test/test_cext/__init__.py
@@ -4,7 +4,6 @@
 import os.path
 import shutil
 import subprocess
-import sysconfig
 import unittest
 from test import support
 
@@ -18,9 +17,8 @@ SETUP = os.path.join(os.path.dirname(__file__), 'setup.py')
 @unittest.skipIf(support.MS_WINDOWS, 'test fails on Windows')
 # Building and running an extension in clang sanitizing mode is not
 # straightforward
-@unittest.skipIf(
-    '-fsanitize' in (sysconfig.get_config_var('PY_CFLAGS') or ''),
-    'test does not work with analyzing builds')
+@support.skip_if_sanitizer('test does not work with analyzing builds',
+                           address=True, memory=True, ub=True, thread=True)
 # the test uses venv+pip: skip if it's not available
 @support.requires_venv_with_pip()
 @support.requires_subprocess()

--- a/Lib/test/test_cppext/__init__.py
+++ b/Lib/test/test_cppext/__init__.py
@@ -4,7 +4,6 @@ import os.path
 import shutil
 import unittest
 import subprocess
-import sysconfig
 from test import support
 
 
@@ -17,9 +16,8 @@ SETUP = os.path.join(os.path.dirname(__file__), 'setup.py')
 @unittest.skipIf(support.MS_WINDOWS, 'test fails on Windows')
 # Building and running an extension in clang sanitizing mode is not
 # straightforward
-@unittest.skipIf(
-    '-fsanitize' in (sysconfig.get_config_var('PY_CFLAGS') or ''),
-    'test does not work with analyzing builds')
+@support.skip_if_sanitizer('test does not work with analyzing builds',
+                           address=True, memory=True, ub=True, thread=True)
 # the test uses venv+pip: skip if it's not available
 @support.requires_venv_with_pip()
 @support.requires_subprocess()

--- a/Lib/test/test_cppext/__init__.py
+++ b/Lib/test/test_cppext/__init__.py
@@ -12,30 +12,25 @@ SOURCE = os.path.join(os.path.dirname(__file__), 'extension.cpp')
 SETUP = os.path.join(os.path.dirname(__file__), 'setup.py')
 
 
-# gh-110119: pip does not currently support 't' in the ABI flag use by
-# --disable-gil builds. Once it does, we can remove this skip.
-@unittest.skipIf(support.Py_GIL_DISABLED,
-                 'test does not work with --disable-gil')
+# With MSVC, the linker fails with: cannot open file 'python311.lib'
+# https://github.com/python/cpython/pull/32175#issuecomment-1111175897
+@unittest.skipIf(support.MS_WINDOWS, 'test fails on Windows')
+# Building and running an extension in clang sanitizing mode is not
+# straightforward
+@unittest.skipIf(
+    '-fsanitize' in (sysconfig.get_config_var('PY_CFLAGS') or ''),
+    'test does not work with analyzing builds')
+# the test uses venv+pip: skip if it's not available
+@support.requires_venv_with_pip()
 @support.requires_subprocess()
+@support.requires_resource('cpu')
 class TestCPPExt(unittest.TestCase):
-    @support.requires_resource('cpu')
     def test_build_cpp11(self):
         self.check_build(False, '_testcpp11ext')
 
-    @support.requires_resource('cpu')
     def test_build_cpp03(self):
         self.check_build(True, '_testcpp03ext')
 
-    # With MSVC, the linker fails with: cannot open file 'python311.lib'
-    # https://github.com/python/cpython/pull/32175#issuecomment-1111175897
-    @unittest.skipIf(support.MS_WINDOWS, 'test fails on Windows')
-    # Building and running an extension in clang sanitizing mode is not
-    # straightforward
-    @unittest.skipIf(
-        '-fsanitize' in (sysconfig.get_config_var('PY_CFLAGS') or ''),
-        'test does not work with analyzing builds')
-    # the test uses venv+pip: skip if it's not available
-    @support.requires_venv_with_pip()
     def check_build(self, std_cpp03, extension_name):
         venv_dir = 'env'
         with support.setup_venv_with_pip_setuptools_wheel(venv_dir) as python_exe:


### PR DESCRIPTION
Remove the "if Py_GIL_DISABLED" skip and move all "skip" decorators to the class.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-116869 -->
* Issue: gh-116869
<!-- /gh-issue-number -->
