### PR TITLE
gh-116417: Fix WASI build of _testlimitedcapi

### DIFF
--- a/Modules/_testlimitedcapi.c
+++ b/Modules/_testlimitedcapi.c
@@ -26,28 +26,28 @@ PyInit__testlimitedcapi(void)
         return NULL;
     }
 
-    if (_PyTestCapi_Init_ByteArray(mod) < 0) {
+    if (_PyTestLimitedCAPI_Init_ByteArray(mod) < 0) {
         return NULL;
     }
-    if (_PyTestCapi_Init_Bytes(mod) < 0) {
+    if (_PyTestLimitedCAPI_Init_Bytes(mod) < 0) {
         return NULL;
     }
-    if (_PyTestCapi_Init_HeaptypeRelative(mod) < 0) {
+    if (_PyTestLimitedCAPI_Init_HeaptypeRelative(mod) < 0) {
         return NULL;
     }
-    if (_PyTestCapi_Init_List(mod) < 0) {
+    if (_PyTestLimitedCAPI_Init_List(mod) < 0) {
         return NULL;
     }
-    if (_PyTestCapi_Init_PyOS(mod) < 0) {
+    if (_PyTestLimitedCAPI_Init_PyOS(mod) < 0) {
         return NULL;
     }
-    if (_PyTestCapi_Init_Set(mod) < 0) {
+    if (_PyTestLimitedCAPI_Init_Set(mod) < 0) {
         return NULL;
     }
-    if (_PyTestCapi_Init_Sys(mod) < 0) {
+    if (_PyTestLimitedCAPI_Init_Sys(mod) < 0) {
         return NULL;
     }
-    if (_PyTestCapi_Init_VectorcallLimited(mod) < 0) {
+    if (_PyTestLimitedCAPI_Init_VectorcallLimited(mod) < 0) {
         return NULL;
     }
     return mod;

--- a/Modules/_testlimitedcapi/bytearray.c
+++ b/Modules/_testlimitedcapi/bytearray.c
@@ -113,7 +113,7 @@ static PyMethodDef test_methods[] = {
 };
 
 int
-_PyTestCapi_Init_ByteArray(PyObject *m)
+_PyTestLimitedCAPI_Init_ByteArray(PyObject *m)
 {
     if (PyModule_AddFunctions(m, test_methods) < 0) {
         return -1;

--- a/Modules/_testlimitedcapi/bytes.c
+++ b/Modules/_testlimitedcapi/bytes.c
@@ -245,7 +245,7 @@ static PyMethodDef test_methods[] = {
 };
 
 int
-_PyTestCapi_Init_Bytes(PyObject *m)
+_PyTestLimitedCAPI_Init_Bytes(PyObject *m)
 {
     if (PyModule_AddFunctions(m, test_methods) < 0) {
         return -1;

--- a/Modules/_testlimitedcapi/heaptype_relative.c
+++ b/Modules/_testlimitedcapi/heaptype_relative.c
@@ -331,7 +331,8 @@ static PyMethodDef TestMethods[] = {
 };
 
 int
-_PyTestCapi_Init_HeaptypeRelative(PyObject *m) {
+_PyTestLimitedCAPI_Init_HeaptypeRelative(PyObject *m)
+{
     if (PyModule_AddFunctions(m, TestMethods) < 0) {
         return -1;
     }

--- a/Modules/_testlimitedcapi/list.c
+++ b/Modules/_testlimitedcapi/list.c
@@ -159,7 +159,7 @@ static PyMethodDef test_methods[] = {
 };
 
 int
-_PyTestCapi_Init_List(PyObject *m)
+_PyTestLimitedCAPI_Init_List(PyObject *m)
 {
     if (PyModule_AddFunctions(m, test_methods) < 0) {
         return -1;

--- a/Modules/_testlimitedcapi/parts.h
+++ b/Modules/_testlimitedcapi/parts.h
@@ -22,13 +22,13 @@
 #  error "Py_BUILD_CORE macro must not be defined"
 #endif
 
-int _PyTestCapi_Init_ByteArray(PyObject *module);
-int _PyTestCapi_Init_Bytes(PyObject *module);
-int _PyTestCapi_Init_HeaptypeRelative(PyObject *module);
-int _PyTestCapi_Init_List(PyObject *module);
-int _PyTestCapi_Init_PyOS(PyObject *module);
-int _PyTestCapi_Init_Set(PyObject *module);
-int _PyTestCapi_Init_Sys(PyObject *module);
-int _PyTestCapi_Init_VectorcallLimited(PyObject *module);
+int _PyTestLimitedCAPI_Init_ByteArray(PyObject *module);
+int _PyTestLimitedCAPI_Init_Bytes(PyObject *module);
+int _PyTestLimitedCAPI_Init_HeaptypeRelative(PyObject *module);
+int _PyTestLimitedCAPI_Init_List(PyObject *module);
+int _PyTestLimitedCAPI_Init_PyOS(PyObject *module);
+int _PyTestLimitedCAPI_Init_Set(PyObject *module);
+int _PyTestLimitedCAPI_Init_Sys(PyObject *module);
+int _PyTestLimitedCAPI_Init_VectorcallLimited(PyObject *module);
 
 #endif // Py_TESTLIMITEDCAPI_PARTS_H

--- a/Modules/_testlimitedcapi/pyos.c
+++ b/Modules/_testlimitedcapi/pyos.c
@@ -50,7 +50,7 @@ static PyMethodDef test_methods[] = {
 };
 
 int
-_PyTestCapi_Init_PyOS(PyObject *mod)
+_PyTestLimitedCAPI_Init_PyOS(PyObject *mod)
 {
     if (PyModule_AddFunctions(mod, test_methods) < 0) {
         return -1;

--- a/Modules/_testlimitedcapi/set.c
+++ b/Modules/_testlimitedcapi/set.c
@@ -179,7 +179,7 @@ static PyMethodDef test_methods[] = {
 };
 
 int
-_PyTestCapi_Init_Set(PyObject *m)
+_PyTestLimitedCAPI_Init_Set(PyObject *m)
 {
     if (PyModule_AddFunctions(m, test_methods) < 0) {
         return -1;

--- a/Modules/_testlimitedcapi/sys.c
+++ b/Modules/_testlimitedcapi/sys.c
@@ -46,7 +46,7 @@ static PyMethodDef test_methods[] = {
 };
 
 int
-_PyTestCapi_Init_Sys(PyObject *m)
+_PyTestLimitedCAPI_Init_Sys(PyObject *m)
 {
     if (PyModule_AddFunctions(m, test_methods) < 0) {
         return -1;

--- a/Modules/_testlimitedcapi/vectorcall_limited.c
+++ b/Modules/_testlimitedcapi/vectorcall_limited.c
@@ -182,7 +182,8 @@ static PyMethodDef TestMethods[] = {
 };
 
 int
-_PyTestCapi_Init_VectorcallLimited(PyObject *m) {
+_PyTestLimitedCAPI_Init_VectorcallLimited(PyObject *m)
+{
     if (PyModule_AddFunctions(m, TestMethods) < 0) {
         return -1;
     }


### PR DESCRIPTION
Use different function names between _testcapi and _testlimitedcapi to not confuse the WASI linker.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-116417 -->
* Issue: gh-116417
<!-- /gh-issue-number -->
