### PR TITLE
gh-113964: Restore the ability to start threads from atexit handler functions.

### DIFF
--- a/Doc/library/atexit.rst
+++ b/Doc/library/atexit.rst
@@ -48,16 +48,21 @@ a cleanup function is undefined.
    This function returns *func*, which makes it possible to use it as a
    decorator.
 
-   .. warning::
-       Starting new threads or calling :func:`os.fork` from a registered
-       function can lead to race condition between the main Python
-       runtime thread freeing thread states while internal :mod:`threading`
-       routines or the new process try to use that state. This can lead to
-       crashes rather than clean shutdown.
+   .. note::
+       Calling :func:`os.fork` from a registered function can lead to race
+       condition between the main Python runtime thread freeing thread states
+       while internal :mod:`threading` routines or the new process try to use
+       that state. This can lead to crashes rather than clean shutdown. In
+       Python versions prior to 3.12 starting a new thread from a registered
+       atexit handler function could lead to similar problems.
 
    .. versionchanged:: 3.12
        Attempts to start a new thread or :func:`os.fork` a new process
        in a registered function now leads to :exc:`RuntimeError`.
+
+   .. versionchanged:: 3.13
+       The ability to start a new thread from a registered function has been
+       restored.
 
 .. function:: unregister(func)
 

--- a/Include/internal/pycore_atexit.h
+++ b/Include/internal/pycore_atexit.h
@@ -52,6 +52,10 @@ struct atexit_state {
     atexit_py_callback **callbacks;
     int ncallbacks;
     int callback_len;
+
+    // Used to prevent registering of new atexit functions once atexit
+    // processing has started.  Boolean, use atomic access.
+    int handler_calling_started;
 };
 
 // Export for '_xxinterpchannels' shared extension

--- a/Include/internal/pycore_interp.h
+++ b/Include/internal/pycore_interp.h
@@ -102,7 +102,7 @@ struct _is {
        In order to be effective, this must be set to 0 during or right
        after allocation. */
     int _initialized;
-    int finalizing;
+    int started_finalization;  /* set early, used to block some actions. */
 
     uintptr_t last_restart_version;
     struct pythreads {
@@ -125,7 +125,7 @@ struct _is {
        Get runtime from tstate: tstate->interp->runtime. */
     struct pyruntimestate *runtime;
 
-    /* Set by Py_EndInterpreter().
+    /* Set by Py_EndInterpreter() & Py_FinalizeEx().
 
        Use _PyInterpreterState_GetFinalizing()
        and _PyInterpreterState_SetFinalizing()

--- a/Lib/multiprocessing/process.py
+++ b/Lib/multiprocessing/process.py
@@ -329,6 +329,9 @@ class BaseProcess(object):
             sys.stderr.write('Process %s:\n' % self.name)
             traceback.print_exc()
         finally:
+            # bpo-18966: Explicitly Join threads: .popen_fork.Popen.launch()
+            # and .forkserver._main() both call os._exit() after this which
+            # skips that.
             threading._shutdown()
             util.info('process exiting with exitcode %d' % exitcode)
             util._flush_std_streams()

--- a/Lib/test/test_threading.py
+++ b/Lib/test/test_threading.py
@@ -1161,7 +1161,7 @@ class ThreadTests(BaseTestCase):
             import _thread
 
             def f():
-                print("should be printed")
+                pass
 
             def exit_handler():
                 _thread.start_new_thread(f, ())
@@ -1169,10 +1169,9 @@ class ThreadTests(BaseTestCase):
             atexit.register(exit_handler)
         """
         _, out, err = assert_python_ok("-c", code)
-        self.assertEqual(out.strip(), b'should be printed',
-                         msg=err.decode('utf-8', errors='replace'))
+        self.assertEqual(err.strip(), b'')
 
-    def test_start_new_thread_at_exit(self):
+    def test_start_threading_thread_at_exit(self):
         # gh-113964: atexit needs to be able to start threads.
         code = """if 1:
             import atexit

--- a/Lib/test/test_threading.py
+++ b/Lib/test/test_threading.py
@@ -1155,12 +1155,13 @@ class ThreadTests(BaseTestCase):
         self.assertEqual(err, b'')
 
     def test_start_new_thread_at_exit(self):
+        # The low level private API version of gh-113964.
         code = """if 1:
             import atexit
             import _thread
 
             def f():
-                print("shouldn't be printed")
+                print("should be printed")
 
             def exit_handler():
                 _thread.start_new_thread(f, ())
@@ -1168,8 +1169,27 @@ class ThreadTests(BaseTestCase):
             atexit.register(exit_handler)
         """
         _, out, err = assert_python_ok("-c", code)
-        self.assertEqual(out, b'')
-        self.assertIn(b"can't create new thread at interpreter shutdown", err)
+        self.assertEqual(out.strip(), b'should be printed',
+                         msg=err.decode('utf-8', errors='replace'))
+
+    def test_start_new_thread_at_exit(self):
+        # gh-113964: atexit needs to be able to start threads.
+        code = """if 1:
+            import atexit
+            import threading
+
+            def f():
+                print("should also be printed")
+
+            def exit_handler():
+                threading.Thread(target=f).start()
+
+            atexit.register(exit_handler)
+        """
+        _, out, err = assert_python_ok("-c", code)
+        self.assertEqual(out.strip(), b'should also be printed',
+                         msg=err.decode('utf-8', errors='replace'))
+
 
 class ThreadJoinOnShutdown(BaseTestCase):
 

--- a/Misc/NEWS.d/next/Core and Builtins/2024-03-19-01-40-25.gh-issue-113964.QzVjUV.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2024-03-19-01-40-25.gh-issue-113964.QzVjUV.rst
@@ -1,0 +1,5 @@
+Restores the ability to spawn threads from :mod:`atexit` handlers. The
+interpreter finalization code will join non-daemon threads spawned from that
+context before exiting.  No atexit handlers can be registered once atexit
+handler processing has started and none will remain to run after threads
+spawned during atexit processing exit.

--- a/Modules/_posixsubprocess.c
+++ b/Modules/_posixsubprocess.c
@@ -1031,7 +1031,7 @@ subprocess_fork_exec_impl(PyObject *module, PyObject *process_args,
     Py_ssize_t fds_to_keep_len = PyTuple_GET_SIZE(py_fds_to_keep);
 
     PyInterpreterState *interp = _PyInterpreterState_GET();
-    if ((preexec_fn != Py_None) && interp->finalizing) {
+    if ((preexec_fn != Py_None) && interp->started_finalization) {
         PyErr_SetString(PyExc_PythonFinalizationError,
                         "preexec_fn not supported at interpreter shutdown");
         return NULL;

--- a/Modules/_threadmodule.c
+++ b/Modules/_threadmodule.c
@@ -1729,7 +1729,9 @@ do_start_new_thread(thread_module_state *state, PyObject *func, PyObject *args,
                         "thread is not supported for isolated subinterpreters");
         return -1;
     }
-    if (interp->finalizing) {
+    if (_PyInterpreterState_GetFinalizing(interp)) {
+        // interp->started_finalizing is set too early; exit handlers may
+        // have a need to spawn cleanup threads that finalize waits on.
         PyErr_SetString(PyExc_PythonFinalizationError,
                         "can't create new thread at interpreter shutdown");
         return -1;

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -7842,7 +7842,7 @@ os_fork1_impl(PyObject *module)
     pid_t pid;
 
     PyInterpreterState *interp = _PyInterpreterState_GET();
-    if (interp->finalizing) {
+    if (interp->started_finalization) {
         PyErr_SetString(PyExc_PythonFinalizationError,
                         "can't fork at interpreter shutdown");
         return NULL;
@@ -7886,7 +7886,7 @@ os_fork_impl(PyObject *module)
 {
     pid_t pid;
     PyInterpreterState *interp = _PyInterpreterState_GET();
-    if (interp->finalizing) {
+    if (interp->started_finalization) {
         PyErr_SetString(PyExc_PythonFinalizationError,
                         "can't fork at interpreter shutdown");
         return NULL;
@@ -8719,7 +8719,7 @@ os_forkpty_impl(PyObject *module)
     pid_t pid;
 
     PyInterpreterState *interp = _PyInterpreterState_GET();
-    if (interp->finalizing) {
+    if (interp->started_finalization) {
         PyErr_SetString(PyExc_PythonFinalizationError,
                         "can't fork at interpreter shutdown");
         return NULL;

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -505,7 +505,7 @@ unicode_check_encoding_errors(const char *encoding, const char *errors)
 
     /* Disable checks during Python finalization. For example, it allows to
        call _PyObject_Dump() during finalization for debugging purpose. */
-    if (interp->finalizing) {
+    if (interp->started_finalization) {
         return 0;
     }
 


### PR DESCRIPTION
In 3.12 we removed the ability to start threads from within an `atexit.register()` handler function context as Python interpreter finalization was starting.

Users were relying on this, sometimes indirectly, for reasonable seeming reasons.

This restores that ability by doing one final thread joining cleanup pass after atexit handlers if any threads are found to remain.

The unittests altered in sibling CL #116677 that this PR modifies and builds upon should be retained.

_Ideally_ we'd also backport this to 3.12 as a bugfix to restore that ability. But that backport may be challenging.

<!-- gh-issue-number: gh-113964 -->
* Issue: gh-113964
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--116982.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->