### PR TITLE
gh-116869: Build test_cext with -Werror=declaration-after-statement

### DIFF
--- a/Lib/test/test_cext/__init__.py
+++ b/Lib/test/test_cext/__init__.py
@@ -1,5 +1,7 @@
 # gh-116869: Build a basic C test extension to check that the Python C API
 # does not emit C compiler warnings.
+#
+# Python C API must build with -Werror=declaration-after-statement.
 
 import os.path
 import shutil

--- a/Lib/test/test_cext/setup.py
+++ b/Lib/test/test_cext/setup.py
@@ -16,6 +16,10 @@ if not support.MS_WINDOWS:
         # The purpose of test_cext extension is to check that building a C
         # extension using the Python C API does not emit C compiler warnings.
         '-Werror',
+
+        # gh-116869: The Python C API must build with
+        # -Werror=declaration-after-statement.
+        '-Werror=declaration-after-statement',
     ]
 else:
     # Don't pass any compiler flag to MSVC


### PR DESCRIPTION
Make sure that the C API does not emit compiler warnings when built with -Werror=declaration-after-statement.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-116869 -->
* Issue: gh-116869
<!-- /gh-issue-number -->
