### PR TITLE
gh-117008: Fix functools test_recursive_pickle()

### DIFF
--- a/Include/cpython/pystate.h
+++ b/Include/cpython/pystate.h
@@ -209,6 +209,8 @@ struct _ts {
 #  define Py_C_RECURSION_LIMIT 500
 #elif defined(__s390x__)
 #  define Py_C_RECURSION_LIMIT 800
+#elif defined(_WIN32) && defined(_M_ARM64)
+#  define Py_C_RECURSION_LIMIT 1000
 #elif defined(_WIN32)
 #  define Py_C_RECURSION_LIMIT 3000
 #elif defined(_Py_ADDRESS_SANITIZER)

--- a/Lib/test/test_functools.py
+++ b/Lib/test/test_functools.py
@@ -334,8 +334,9 @@ class TestPartial:
             f.__setstate__((f, (), {}, {}))
             try:
                 for proto in range(pickle.HIGHEST_PROTOCOL + 1):
-                    with self.assertRaises(RecursionError):
-                        pickle.dumps(f, proto)
+                    with support.infinite_recursion():
+                        with self.assertRaises(RecursionError):
+                            pickle.dumps(f, proto)
             finally:
                 f.__setstate__((capture, (), {}, {}))
 

--- a/Lib/test/test_functools.py
+++ b/Lib/test/test_functools.py
@@ -334,7 +334,8 @@ class TestPartial:
             f.__setstate__((f, (), {}, {}))
             try:
                 for proto in range(pickle.HIGHEST_PROTOCOL + 1):
-                    with support.infinite_recursion():
+                    # gh-117008: Small limit since pickle uses C stack memory
+                    with support.infinite_recursion(100):
                         with self.assertRaises(RecursionError):
                             pickle.dumps(f, proto)
             finally:


### PR DESCRIPTION
Use support.infinite_recursion() in test_recursive_pickle() of test_functools to prevent a stack overflow on "ARM64 Windows Non-Debug" buildbot.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-117008 -->
* Issue: gh-117008
<!-- /gh-issue-number -->
