### PR TITLE
gh-116886: Temporarily disable CIfuzz (memory)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -514,7 +514,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        sanitizer: [address, undefined, memory]
+        # sanitizer: [address, undefined, memory]  -- memory skipped temporarily until GH-116886 is solved.
+        sanitizer: [address, undefined]
     steps:
       - name: Build fuzzers (${{ matrix.sanitizer }})
         id: build


### PR DESCRIPTION
This is to unblock others until the underlying issue is solved.


<!-- gh-issue-number: gh-116886 -->
* Issue: gh-116886
<!-- /gh-issue-number -->
