### PR TITLE
[3.12] gh-90300: Remove reference to PYTHON_FROZEN_MODULES in Python CLI help

### DIFF
--- a/Python/initconfig.c
+++ b/Python/initconfig.c
@@ -82,8 +82,7 @@ The following implementation-specific options are available:\n\
 -X faulthandler: dump the Python traceback on fatal errors;\n\
          also PYTHONFAULTHANDLER\n\
 -X frozen_modules=[on|off]: whether to use frozen modules; the default is \"on\"\n\
-         for installed Python and \"off\" for a local build;\n\
-         also PYTHON_FROZEN_MODULES\n\
+         for installed Python and \"off\" for a local build\n\
 -X importtime: show how long each import takes; also PYTHONPROFILEIMPORTTIME\n\
 -X int_max_str_digits=N: limit the size of int<->str conversions;\n\
          0 disables the limit; also PYTHONINTMAXSTRDIGITS\n\


### PR DESCRIPTION
Fix error introduced in 4be9fa896117bf07dc944a29c98dd18b71dd6c74.


<!-- gh-issue-number: gh-90300 -->
* Issue: gh-90300
<!-- /gh-issue-number -->
