### PR TITLE
docs: announce venv creation before installing packages

### DIFF
--- a/Doc/Makefile
+++ b/Doc/Makefile
@@ -163,6 +163,7 @@ venv:
 		echo "venv already exists."; \
 		echo "To recreate it, remove it first with \`make clean-venv'."; \
 	else \
+		echo "Creating venv in $(VENVDIR)"; \
 		$(PYTHON) -m venv $(VENVDIR); \
 		$(VENVDIR)/bin/python3 -m pip install --upgrade pip; \
 		$(VENVDIR)/bin/python3 -m pip install -r $(REQUIREMENTS); \


### PR DESCRIPTION
Similar to https://github.com/python/devguide/pull/1291, announce the creation of the venv before a stream of scary package installation messages appear.

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--117036.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->