### PR TITLE
gh-116908: Only write to `_pending_calls.calls_to_do` with atomic operations

### DIFF
--- a/Python/ceval_gil.c
+++ b/Python/ceval_gil.c
@@ -671,7 +671,7 @@ _push_pending_call(struct _pending_calls *pending,
     pending->calls[i].flags = flags;
     pending->last = j;
     assert(pending->calls_to_do < NPENDINGCALLS);
-    pending->calls_to_do++;
+    _Py_atomic_add_int32(&pending->calls_to_do, 1);
     return 0;
 }
 
@@ -701,7 +701,7 @@ _pop_pending_call(struct _pending_calls *pending,
         pending->calls[i] = (struct _pending_call){0};
         pending->first = (i + 1) % NPENDINGCALLS;
         assert(pending->calls_to_do > 0);
-        pending->calls_to_do--;
+        _Py_atomic_add_int32(&pending->calls_to_do, -1);
     }
 }
 


### PR DESCRIPTION
These writes to `pending->calls_to_do` need to be atomic, because other threads can read (atomically) from `calls_to_do` without holding `pending->mutex`.

- Issue: gh-116908