### PR TITLE
gh-115538: Remove PYTHONHOME's trailing slash in generated python.bat

### DIFF
--- a/PCbuild/python.vcxproj
+++ b/PCbuild/python.vcxproj
@@ -145,7 +145,7 @@ set PYTHONPATH=$(PySourcePath)Lib
 @rem and using it outside of that context is ill-advised.
 @echo Running $(Configuration)^|$(Platform) interpreter...
 @setlocal
-@set PYTHONHOME=$(PySourcePath)
+@set PYTHONHOME=$(PySourcePath.TrimEnd('\'))
 @"$(OutDir)$(PyExeName)$(PyDebugExt).exe" %*
 </_Content>
       <_ExistingContent Condition="Exists('$(PySourcePath)python.bat')">$([System.IO.File]::ReadAllText('$(PySourcePath)python.bat'))</_ExistingContent>


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-115538 -->
* Issue: gh-115538
<!-- /gh-issue-number -->
