### PR TITLE
GH-117066: Tier 2 optimizer: Don't throw away good traces if we can't optimize them perfectly.

### DIFF
--- a/Python/optimizer_analysis.c
+++ b/Python/optimizer_analysis.c
@@ -421,6 +421,7 @@ hit_bottom:
     // retrying later.
     DPRINTF(3, "\n");
     DPRINTF(1, "Hit bottom in abstract interpreter\n");
+    _Py_uop_abstractcontext_fini(ctx);
     return 0;
 done:
     /* Cannot optimize further, but there would be no benefit

--- a/Python/optimizer_analysis.c
+++ b/Python/optimizer_analysis.c
@@ -416,10 +416,12 @@ error:
 hit_bottom:
     // Attempted to push a "bottom" (contradition) symbol onto the stack.
     // This means that the abstract interpreter has hit unreachable code.
-    // We *could* generate an _EXIT_TRACE or _FATAL_ERROR here, but it's
-    // simpler to just leave the rest of the trace alone.
+    // We *could* generate an _EXIT_TRACE or _FATAL_ERROR here, but hitting
+    // bottom indicates type instability, so we are probably better off
+    // retrying later.
     DPRINTF(3, "\n");
     DPRINTF(1, "Hit bottom in abstract interpreter\n");
+    return 0;
 done:
     /* Cannot optimize further, but there would be no benefit
      * in retrying later */

--- a/Python/optimizer_analysis.c
+++ b/Python/optimizer_analysis.c
@@ -406,24 +406,25 @@ optimize_uops(
 out_of_space:
     DPRINTF(3, "\n");
     DPRINTF(1, "Out of space in abstract interpreter\n");
-    _Py_uop_abstractcontext_fini(ctx);
-    return 0;
-
+    goto done;
 error:
     DPRINTF(3, "\n");
     DPRINTF(1, "Encountered error in abstract interpreter\n");
     _Py_uop_abstractcontext_fini(ctx);
-    return 0;
+    return -1;
 
 hit_bottom:
     // Attempted to push a "bottom" (contradition) symbol onto the stack.
     // This means that the abstract interpreter has hit unreachable code.
     // We *could* generate an _EXIT_TRACE or _FATAL_ERROR here, but it's
-    // simpler to just admit failure and not create the executor.
+    // simpler to just leave the rest of the trace alone.
     DPRINTF(3, "\n");
     DPRINTF(1, "Hit bottom in abstract interpreter\n");
+done:
+    /* Cannot optimize further, but there would be no benefit
+     * in retrying later */
     _Py_uop_abstractcontext_fini(ctx);
-    return 0;
+    return 1;
 }
 
 

--- a/Python/optimizer_bytecodes.c
+++ b/Python/optimizer_bytecodes.c
@@ -546,7 +546,9 @@ dummy_func(void) {
         PyFunctionObject *func = (PyFunctionObject *)(this_instr + 2)->operand;
         DPRINTF(3, "func: %p ", func);
         if (func == NULL) {
-            goto error;
+            DPRINTF(3, "\n");
+            DPRINTF(1, "Missing function\n");
+            goto done;
         }
         PyCodeObject *co = (PyCodeObject *)func->func_code;
 

--- a/Python/optimizer_cases.c.h
+++ b/Python/optimizer_cases.c.h
@@ -1599,7 +1599,9 @@
             PyFunctionObject *func = (PyFunctionObject *)(this_instr + 2)->operand;
             DPRINTF(3, "func: %p ", func);
             if (func == NULL) {
-                goto error;
+                DPRINTF(3, "\n");
+                DPRINTF(1, "Missing function\n");
+                goto done;
             }
             PyCodeObject *co = (PyCodeObject *)func->func_code;
             assert(self_or_null != NULL);


### PR DESCRIPTION
Increases the optimizer success ratio from less than 5% to over 98%, with only a very small reduction in mean executed trace length.

From the [stats](https://github.com/faster-cpython/benchmarking-public/blob/main/results/bm-20240319-3.13.0a5%2B-f012ce0-PYTHON_UOPS/bm-20240319-azure-x86_64-faster%252dcpython-optimizer_trim_trace-3.13.0a5%2B-f012ce0-pystats-vs-base.md):
<table>
<thead>
<tr>
<th align="left"></th>
<th align="right">Base Count</th>
<th align="right">Base Ratio</th>
<th align="right">Head Count</th>
<th align="right">Head Ratio</th>
<th align="right">Change</th>
</tr>
</thead>
<tbody>
<tr>
<td align="left">
Optimizer attempts
<details>
<summary>ⓘ</summary>

The number of times the trace optimizer (_Py_uop_analyze_and_optimize) was run.
</details>
</td>
<td align="right">2,326,046</td>
<td align="right"></td>
<td align="right">116,993</td>
<td align="right"></td>
<td align="right">-95.0%</td>
</tr>
<tr>
<td align="left">
Optimizer successes
<details>
<summary>ⓘ</summary>

The number of traces that were successfully optimized.
</details>
</td>
<td align="right">100,887</td>
<td align="right">4.3%</td>
<td align="right">115,008</td>
<td align="right">98.3%</td>
<td align="right">14.0%</td>
</tr>

</tbody>
</table>


<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-117066 -->
* Issue: gh-117066
<!-- /gh-issue-number -->
