### PR TITLE
gh-117084: Fix zip extraction bug

### DIFF
--- a/Lib/zipfile/__init__.py
+++ b/Lib/zipfile/__init__.py
@@ -605,7 +605,7 @@ class ZipInfo:
 
     def is_dir(self):
         """Return True if this archive member is a directory."""
-        return self.filename.endswith('/')
+        return self.filename.endswith('/') or self.filename.endswith('\\')
 
 
 # ZIP encryption uses the CRC32 one-byte primitive for scrambling some

--- a/Misc/NEWS.d/next/Core and Builtins/2024-03-20-15-54-25.gh-issue-117084.uj1NbR.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2024-03-20-15-54-25.gh-issue-117084.uj1NbR.rst
@@ -1,0 +1,1 @@
+Fix extraction of  ZIP files created on windows

--- a/Misc/NEWS.d/next/Core and Builtins/2024-03-20-15-54-25.gh-issue-117084.uj1NbR.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2024-03-20-15-54-25.gh-issue-117084.uj1NbR.rst
@@ -1,1 +1,1 @@
-Fix extraction of  ZIP files created on windows
+Fix extraction of zip files created on Windows


### PR DESCRIPTION
On Windows a directory is ending in \\ and not /.

This is the smallest fix i could think of. 
Not sure if there are edge cases with files containing `\\` at the end.

<!-- gh-issue-number: gh-117084 -->
* Issue: gh-117084
<!-- /gh-issue-number -->
