### PR TITLE
GH-117086: Fix function version numbering

### DIFF
--- a/Include/cpython/code.h
+++ b/Include/cpython/code.h
@@ -156,7 +156,7 @@ typedef struct {
     int co_ncellvars;             /* total number of cell variables */         \
     int co_nfreevars;             /* number of free variables */               \
     uint32_t co_version;          /* version number */                         \
-                                                                               \
+    int32_t co_expected_number_of_defaults;                                    \
     PyObject *co_localsplusnames; /* tuple mapping offsets to names */         \
     PyObject *co_localspluskinds; /* Bytes mapping to local kinds (one byte    \
                                      per variable) */                          \
@@ -170,6 +170,7 @@ typedef struct {
     uintptr_t _co_instrumentation_version; /* current instrumentation version */ \
     _PyCoMonitoringData *_co_monitoring; /* Monitoring data */                 \
     int _co_firsttraceable;       /* index of first traceable instruction */   \
+    uint64_t co_expected_globals_version;                                      \
     /* Scratch space for extra data relating to the code object.               \
        Type is a void* to keep the format private in codeobject.c to force     \
        people to go through the proper APIs. */                                \

--- a/Objects/codeobject.c
+++ b/Objects/codeobject.c
@@ -414,11 +414,9 @@ init_code(PyCodeObject *co, struct _PyCodeConstructor *con)
     co->co_framesize = nlocalsplus + con->stacksize + FRAME_SPECIALS_SIZE;
     co->co_ncellvars = ncellvars;
     co->co_nfreevars = nfreevars;
-    PyInterpreterState *interp = _PyInterpreterState_GET();
-    co->co_version = interp->func_state.next_version;
-    if (interp->func_state.next_version != 0) {
-        interp->func_state.next_version++;
-    }
+    co->co_version = 0;
+    co->co_expected_globals_version = 0;
+    co->co_expected_number_of_defaults = -1;
     co->_co_monitoring = NULL;
     co->_co_instrumentation_version = 0;
     /* not set */

--- a/Python/bytecodes.c
+++ b/Python/bytecodes.c
@@ -3829,14 +3829,29 @@ dummy_func(
             PyFunctionObject *func_obj = (PyFunctionObject *)
                 PyFunction_New(codeobj, GLOBALS());
 
-            Py_DECREF(codeobj);
             if (func_obj == NULL) {
                 GOTO_ERROR(error);
             }
-
-            _PyFunction_SetVersion(
-                func_obj, ((PyCodeObject *)codeobj)->co_version);
+            PyCodeObject *code = (PyCodeObject *)codeobj;
+            if (code->co_version == 0) {
+                code->co_version = tstate->interp->func_state.next_version;
+                if (tstate->interp->func_state.next_version != 0) {
+                    tstate->interp->func_state.next_version++;
+                }
+                assert(code->co_expected_globals_version == 0);
+                if (PyDict_CheckExact(GLOBALS())) {
+                    code->co_expected_globals_version = ((PyDictObject *)GLOBALS())->ma_version_tag;
+                }
+                _PyFunction_SetVersion(func_obj, code->co_version);
+            }
+            else {
+                if (PyDict_CheckExact(GLOBALS()) &&
+                    code->co_expected_globals_version == ((PyDictObject *)GLOBALS())->ma_version_tag) {
+                    _PyFunction_SetVersion(func_obj, code->co_version);
+                }
+            }
             func = (PyObject *)func_obj;
+            Py_DECREF(codeobj);
         }
 
         inst(SET_FUNCTION_ATTRIBUTE, (attr, func -- func)) {
@@ -3860,6 +3875,13 @@ dummy_func(
                     assert(PyTuple_CheckExact(attr));
                     assert(func_obj->func_defaults == NULL);
                     func_obj->func_defaults = attr;
+                    PyCodeObject *code = (PyCodeObject *)func_obj->func_code;
+                    if (code->co_expected_number_of_defaults < 0) {
+                        code->co_expected_number_of_defaults = (int32_t)PyTuple_GET_SIZE(attr);
+                    }
+                    else if (code->co_expected_number_of_defaults != PyTuple_GET_SIZE(attr)) {
+                        func_obj->func_version = 0;
+                    }
                     break;
                 default:
                     Py_UNREACHABLE();

--- a/Python/bytecodes.c
+++ b/Python/bytecodes.c
@@ -3833,7 +3833,10 @@ dummy_func(
                 GOTO_ERROR(error);
             }
             PyCodeObject *code = (PyCodeObject *)codeobj;
-            if (code->co_version == 0) {
+            if (func_obj->func_builtins != tstate->interp->builtins) {
+                _PyFunction_SetVersion(func_obj, 0);
+            }
+            else if (code->co_version == 0) {
                 code->co_version = tstate->interp->func_state.next_version;
                 if (tstate->interp->func_state.next_version != 0) {
                     tstate->interp->func_state.next_version++;

--- a/Python/executor_cases.c.h
+++ b/Python/executor_cases.c.h
@@ -3510,7 +3510,10 @@
                 GOTO_ERROR(error);
             }
             PyCodeObject *code = (PyCodeObject *)codeobj;
-            if (code->co_version == 0) {
+            if (func_obj->func_builtins != tstate->interp->builtins) {
+                _PyFunction_SetVersion(func_obj, 0);
+            }
+            else if (code->co_version == 0) {
                 code->co_version = tstate->interp->func_state.next_version;
                 if (tstate->interp->func_state.next_version != 0) {
                     tstate->interp->func_state.next_version++;

--- a/Python/executor_cases.c.h
+++ b/Python/executor_cases.c.h
@@ -3506,13 +3506,29 @@
             codeobj = stack_pointer[-1];
             PyFunctionObject *func_obj = (PyFunctionObject *)
             PyFunction_New(codeobj, GLOBALS());
-            Py_DECREF(codeobj);
             if (func_obj == NULL) {
                 GOTO_ERROR(error);
             }
-            _PyFunction_SetVersion(
-                                   func_obj, ((PyCodeObject *)codeobj)->co_version);
+            PyCodeObject *code = (PyCodeObject *)codeobj;
+            if (code->co_version == 0) {
+                code->co_version = tstate->interp->func_state.next_version;
+                if (tstate->interp->func_state.next_version != 0) {
+                    tstate->interp->func_state.next_version++;
+                }
+                assert(code->co_expected_globals_version == 0);
+                if (PyDict_CheckExact(GLOBALS())) {
+                    code->co_expected_globals_version = ((PyDictObject *)GLOBALS())->ma_version_tag;
+                }
+                _PyFunction_SetVersion(func_obj, code->co_version);
+            }
+            else {
+                if (PyDict_CheckExact(GLOBALS()) &&
+                    code->co_expected_globals_version == ((PyDictObject *)GLOBALS())->ma_version_tag) {
+                    _PyFunction_SetVersion(func_obj, code->co_version);
+                }
+            }
             func = (PyObject *)func_obj;
+            Py_DECREF(codeobj);
             stack_pointer[-1] = func;
             break;
         }
@@ -3543,6 +3559,13 @@
                 assert(PyTuple_CheckExact(attr));
                 assert(func_obj->func_defaults == NULL);
                 func_obj->func_defaults = attr;
+                PyCodeObject *code = (PyCodeObject *)func_obj->func_code;
+                if (code->co_expected_number_of_defaults < 0) {
+                    code->co_expected_number_of_defaults = (int32_t)PyTuple_GET_SIZE(attr);
+                }
+                else if (code->co_expected_number_of_defaults != PyTuple_GET_SIZE(attr)) {
+                    func_obj->func_version = 0;
+                }
                 break;
                 default:
                 Py_UNREACHABLE();

--- a/Python/generated_cases.c.h
+++ b/Python/generated_cases.c.h
@@ -4593,7 +4593,10 @@
                 GOTO_ERROR(error);
             }
             PyCodeObject *code = (PyCodeObject *)codeobj;
-            if (code->co_version == 0) {
+            if (func_obj->func_builtins != tstate->interp->builtins) {
+                _PyFunction_SetVersion(func_obj, 0);
+            }
+            else if (code->co_version == 0) {
                 code->co_version = tstate->interp->func_state.next_version;
                 if (tstate->interp->func_state.next_version != 0) {
                     tstate->interp->func_state.next_version++;


### PR DESCRIPTION
Tracks not only the code object, but the globals and number of defaults when issuing function version numbers.

Fixes #117051

<!-- gh-issue-number: gh-117086 -->
* Issue: gh-117086
<!-- /gh-issue-number -->
