### PR TITLE
docs: module page titles should not start with a link to themselves

### DIFF
--- a/Doc/library/__future__.rst
+++ b/Doc/library/__future__.rst
@@ -1,5 +1,5 @@
-:mod:`__future__` --- Future statement definitions
-==================================================
+:mod:`!__future__` --- Future statement definitions
+===================================================
 
 .. module:: __future__
    :synopsis: Future statement definitions

--- a/Doc/library/__main__.rst
+++ b/Doc/library/__main__.rst
@@ -1,5 +1,5 @@
-:mod:`__main__` --- Top-level code environment
-==============================================
+:mod:`!__main__` --- Top-level code environment
+===============================================
 
 .. module:: __main__
    :synopsis: The environment where top-level code is run. Covers command-line

--- a/Doc/library/_thread.rst
+++ b/Doc/library/_thread.rst
@@ -1,5 +1,5 @@
-:mod:`_thread` --- Low-level threading API
-==========================================
+:mod:`!_thread` --- Low-level threading API
+===========================================
 
 .. module:: _thread
    :synopsis: Low-level threading API.

--- a/Doc/library/abc.rst
+++ b/Doc/library/abc.rst
@@ -1,5 +1,5 @@
-:mod:`abc` --- Abstract Base Classes
-====================================
+:mod:`!abc` --- Abstract Base Classes
+=====================================
 
 .. module:: abc
    :synopsis: Abstract base classes according to :pep:`3119`.

--- a/Doc/library/argparse.rst
+++ b/Doc/library/argparse.rst
@@ -1,5 +1,5 @@
-:mod:`argparse` --- Parser for command-line options, arguments and sub-commands
-===============================================================================
+:mod:`!argparse` --- Parser for command-line options, arguments and sub-commands
+================================================================================
 
 .. module:: argparse
    :synopsis: Command-line option and argument parsing library.

--- a/Doc/library/array.rst
+++ b/Doc/library/array.rst
@@ -1,5 +1,5 @@
-:mod:`array` --- Efficient arrays of numeric values
-===================================================
+:mod:`!array` --- Efficient arrays of numeric values
+====================================================
 
 .. module:: array
    :synopsis: Space efficient arrays of uniformly typed numeric values.

--- a/Doc/library/ast.rst
+++ b/Doc/library/ast.rst
@@ -1,5 +1,5 @@
-:mod:`ast` --- Abstract Syntax Trees
-====================================
+:mod:`!ast` --- Abstract Syntax Trees
+=====================================
 
 .. module:: ast
    :synopsis: Abstract Syntax Tree classes and manipulation.

--- a/Doc/library/asyncio.rst
+++ b/Doc/library/asyncio.rst
@@ -1,5 +1,5 @@
-:mod:`asyncio` --- Asynchronous I/O
-===================================
+:mod:`!asyncio` --- Asynchronous I/O
+====================================
 
 .. module:: asyncio
    :synopsis: Asynchronous I/O.

--- a/Doc/library/atexit.rst
+++ b/Doc/library/atexit.rst
@@ -1,5 +1,5 @@
-:mod:`atexit` --- Exit handlers
-===============================
+:mod:`!atexit` --- Exit handlers
+================================
 
 .. module:: atexit
    :synopsis: Register and execute cleanup functions.

--- a/Doc/library/base64.rst
+++ b/Doc/library/base64.rst
@@ -1,5 +1,5 @@
-:mod:`base64` --- Base16, Base32, Base64, Base85 Data Encodings
-===============================================================
+:mod:`!base64` --- Base16, Base32, Base64, Base85 Data Encodings
+================================================================
 
 .. module:: base64
    :synopsis: RFC 4648: Base16, Base32, Base64 Data Encodings;

--- a/Doc/library/bdb.rst
+++ b/Doc/library/bdb.rst
@@ -1,5 +1,5 @@
-:mod:`bdb` --- Debugger framework
-=================================
+:mod:`!bdb` --- Debugger framework
+==================================
 
 .. module:: bdb
    :synopsis: Debugger framework.

--- a/Doc/library/binascii.rst
+++ b/Doc/library/binascii.rst
@@ -1,5 +1,5 @@
-:mod:`binascii` --- Convert between binary and ASCII
-====================================================
+:mod:`!binascii` --- Convert between binary and ASCII
+=====================================================
 
 .. module:: binascii
    :synopsis: Tools for converting between binary and various ASCII-encoded binary

--- a/Doc/library/bisect.rst
+++ b/Doc/library/bisect.rst
@@ -1,5 +1,5 @@
-:mod:`bisect` --- Array bisection algorithm
-===========================================
+:mod:`!bisect` --- Array bisection algorithm
+============================================
 
 .. module:: bisect
    :synopsis: Array bisection algorithms for binary searching.

--- a/Doc/library/builtins.rst
+++ b/Doc/library/builtins.rst
@@ -1,5 +1,5 @@
-:mod:`builtins` --- Built-in objects
-====================================
+:mod:`!builtins` --- Built-in objects
+=====================================
 
 .. module:: builtins
    :synopsis: The module that provides the built-in namespace.

--- a/Doc/library/bz2.rst
+++ b/Doc/library/bz2.rst
@@ -1,5 +1,5 @@
-:mod:`bz2` --- Support for :program:`bzip2` compression
-=======================================================
+:mod:`!bz2` --- Support for :program:`bzip2` compression
+========================================================
 
 .. module:: bz2
    :synopsis: Interfaces for bzip2 compression and decompression.

--- a/Doc/library/calendar.rst
+++ b/Doc/library/calendar.rst
@@ -1,5 +1,5 @@
-:mod:`calendar` --- General calendar-related functions
-======================================================
+:mod:`!calendar` --- General calendar-related functions
+=======================================================
 
 .. module:: calendar
    :synopsis: Functions for working with calendars, including some emulation

--- a/Doc/library/cmath.rst
+++ b/Doc/library/cmath.rst
@@ -1,5 +1,5 @@
-:mod:`cmath` --- Mathematical functions for complex numbers
-===========================================================
+:mod:`!cmath` --- Mathematical functions for complex numbers
+============================================================
 
 .. module:: cmath
    :synopsis: Mathematical functions for complex numbers.

--- a/Doc/library/cmd.rst
+++ b/Doc/library/cmd.rst
@@ -1,5 +1,5 @@
-:mod:`cmd` --- Support for line-oriented command interpreters
-=============================================================
+:mod:`!cmd` --- Support for line-oriented command interpreters
+==============================================================
 
 .. module:: cmd
    :synopsis: Build line-oriented command interpreters.

--- a/Doc/library/code.rst
+++ b/Doc/library/code.rst
@@ -1,5 +1,5 @@
-:mod:`code` --- Interpreter base classes
-========================================
+:mod:`!code` --- Interpreter base classes
+=========================================
 
 .. module:: code
    :synopsis: Facilities to implement read-eval-print loops.

--- a/Doc/library/codecs.rst
+++ b/Doc/library/codecs.rst
@@ -1,5 +1,5 @@
-:mod:`codecs` --- Codec registry and base classes
-=================================================
+:mod:`!codecs` --- Codec registry and base classes
+==================================================
 
 .. module:: codecs
    :synopsis: Encode and decode data and streams.

--- a/Doc/library/codeop.rst
+++ b/Doc/library/codeop.rst
@@ -1,5 +1,5 @@
-:mod:`codeop` --- Compile Python code
-=====================================
+:mod:`!codeop` --- Compile Python code
+======================================
 
 .. module:: codeop
    :synopsis: Compile (possibly incomplete) Python code.

--- a/Doc/library/collections.abc.rst
+++ b/Doc/library/collections.abc.rst
@@ -1,5 +1,5 @@
-:mod:`collections.abc` --- Abstract Base Classes for Containers
-===============================================================
+:mod:`!collections.abc` --- Abstract Base Classes for Containers
+================================================================
 
 .. module:: collections.abc
    :synopsis: Abstract base classes for containers

--- a/Doc/library/collections.rst
+++ b/Doc/library/collections.rst
@@ -1,5 +1,5 @@
-:mod:`collections` --- Container datatypes
-==========================================
+:mod:`!collections` --- Container datatypes
+===========================================
 
 .. module:: collections
     :synopsis: Container datatypes

--- a/Doc/library/colorsys.rst
+++ b/Doc/library/colorsys.rst
@@ -1,5 +1,5 @@
-:mod:`colorsys` --- Conversions between color systems
-=====================================================
+:mod:`!colorsys` --- Conversions between color systems
+======================================================
 
 .. module:: colorsys
    :synopsis: Conversion functions between RGB and other color systems.

--- a/Doc/library/compileall.rst
+++ b/Doc/library/compileall.rst
@@ -1,5 +1,5 @@
-:mod:`compileall` --- Byte-compile Python libraries
-===================================================
+:mod:`!compileall` --- Byte-compile Python libraries
+====================================================
 
 .. module:: compileall
    :synopsis: Tools for byte-compiling all Python source files in a directory tree.

--- a/Doc/library/concurrent.futures.rst
+++ b/Doc/library/concurrent.futures.rst
@@ -1,5 +1,5 @@
-:mod:`concurrent.futures` --- Launching parallel tasks
-======================================================
+:mod:`!concurrent.futures` --- Launching parallel tasks
+=======================================================
 
 .. module:: concurrent.futures
    :synopsis: Execute computations concurrently using threads or processes.

--- a/Doc/library/configparser.rst
+++ b/Doc/library/configparser.rst
@@ -1,5 +1,5 @@
-:mod:`configparser` --- Configuration file parser
-=================================================
+:mod:`!configparser` --- Configuration file parser
+==================================================
 
 .. module:: configparser
    :synopsis: Configuration file parser.

--- a/Doc/library/contextvars.rst
+++ b/Doc/library/contextvars.rst
@@ -1,5 +1,5 @@
-:mod:`contextvars` --- Context Variables
-========================================
+:mod:`!contextvars` --- Context Variables
+=========================================
 
 .. module:: contextvars
    :synopsis: Context Variables

--- a/Doc/library/copy.rst
+++ b/Doc/library/copy.rst
@@ -1,5 +1,5 @@
-:mod:`copy` --- Shallow and deep copy operations
-================================================
+:mod:`!copy` --- Shallow and deep copy operations
+=================================================
 
 .. module:: copy
    :synopsis: Shallow and deep copy operations.

--- a/Doc/library/copyreg.rst
+++ b/Doc/library/copyreg.rst
@@ -1,5 +1,5 @@
-:mod:`copyreg` --- Register :mod:`pickle` support functions
-===========================================================
+:mod:`!copyreg` --- Register :mod:`!pickle` support functions
+=============================================================
 
 .. module:: copyreg
    :synopsis: Register pickle support functions.

--- a/Doc/library/csv.rst
+++ b/Doc/library/csv.rst
@@ -1,5 +1,5 @@
-:mod:`csv` --- CSV File Reading and Writing
-===========================================
+:mod:`!csv` --- CSV File Reading and Writing
+============================================
 
 .. module:: csv
    :synopsis: Write and read tabular data to and from delimited files.

--- a/Doc/library/ctypes.rst
+++ b/Doc/library/ctypes.rst
@@ -1,5 +1,5 @@
-:mod:`ctypes` --- A foreign function library for Python
-=======================================================
+:mod:`!ctypes` --- A foreign function library for Python
+========================================================
 
 .. module:: ctypes
    :synopsis: A foreign function library for Python.

--- a/Doc/library/curses.ascii.rst
+++ b/Doc/library/curses.ascii.rst
@@ -1,5 +1,5 @@
-:mod:`curses.ascii` --- Utilities for ASCII characters
-======================================================
+:mod:`!curses.ascii` --- Utilities for ASCII characters
+=======================================================
 
 .. module:: curses.ascii
    :synopsis: Constants and set-membership functions for ASCII characters.

--- a/Doc/library/curses.panel.rst
+++ b/Doc/library/curses.panel.rst
@@ -1,5 +1,5 @@
-:mod:`curses.panel` --- A panel stack extension for curses
-==========================================================
+:mod:`!curses.panel` --- A panel stack extension for curses
+===========================================================
 
 .. module:: curses.panel
    :synopsis: A panel stack extension that adds depth to  curses windows.

--- a/Doc/library/curses.rst
+++ b/Doc/library/curses.rst
@@ -1,5 +1,5 @@
-:mod:`curses` --- Terminal handling for character-cell displays
-===============================================================
+:mod:`!curses` --- Terminal handling for character-cell displays
+================================================================
 
 .. module:: curses
    :synopsis: An interface to the curses library, providing portable

--- a/Doc/library/dataclasses.rst
+++ b/Doc/library/dataclasses.rst
@@ -1,5 +1,5 @@
-:mod:`dataclasses` --- Data Classes
-===================================
+:mod:`!dataclasses` --- Data Classes
+====================================
 
 .. module:: dataclasses
     :synopsis: Generate special methods on user-defined classes.

--- a/Doc/library/datetime.rst
+++ b/Doc/library/datetime.rst
@@ -1,5 +1,5 @@
-:mod:`datetime` --- Basic date and time types
-=============================================
+:mod:`!datetime` --- Basic date and time types
+==============================================
 
 .. module:: datetime
    :synopsis: Basic date and time types.

--- a/Doc/library/dbm.rst
+++ b/Doc/library/dbm.rst
@@ -1,5 +1,5 @@
-:mod:`dbm` --- Interfaces to Unix "databases"
-=============================================
+:mod:`!dbm` --- Interfaces to Unix "databases"
+==============================================
 
 .. module:: dbm
    :synopsis: Interfaces to various Unix "database" formats.

--- a/Doc/library/decimal.rst
+++ b/Doc/library/decimal.rst
@@ -1,5 +1,5 @@
-:mod:`decimal` --- Decimal fixed point and floating point arithmetic
-====================================================================
+:mod:`!decimal` --- Decimal fixed point and floating point arithmetic
+=====================================================================
 
 .. module:: decimal
    :synopsis: Implementation of the General Decimal Arithmetic  Specification.

--- a/Doc/library/difflib.rst
+++ b/Doc/library/difflib.rst
@@ -1,5 +1,5 @@
-:mod:`difflib` --- Helpers for computing deltas
-===============================================
+:mod:`!difflib` --- Helpers for computing deltas
+================================================
 
 .. module:: difflib
    :synopsis: Helpers for computing differences between objects.

--- a/Doc/library/dis.rst
+++ b/Doc/library/dis.rst
@@ -1,5 +1,5 @@
-:mod:`dis` --- Disassembler for Python bytecode
-===============================================
+:mod:`!dis` --- Disassembler for Python bytecode
+================================================
 
 .. module:: dis
    :synopsis: Disassembler for Python bytecode.

--- a/Doc/library/doctest.rst
+++ b/Doc/library/doctest.rst
@@ -1,5 +1,5 @@
-:mod:`doctest` --- Test interactive Python examples
-===================================================
+:mod:`!doctest` --- Test interactive Python examples
+====================================================
 
 .. module:: doctest
    :synopsis: Test pieces of code within docstrings.

--- a/Doc/library/email.charset.rst
+++ b/Doc/library/email.charset.rst
@@ -1,5 +1,5 @@
-:mod:`email.charset`: Representing character sets
--------------------------------------------------
+:mod:`!email.charset`: Representing character sets
+--------------------------------------------------
 
 .. module:: email.charset
    :synopsis: Character Sets

--- a/Doc/library/email.contentmanager.rst
+++ b/Doc/library/email.contentmanager.rst
@@ -1,5 +1,5 @@
-:mod:`email.contentmanager`: Managing MIME Content
---------------------------------------------------
+:mod:`!email.contentmanager`: Managing MIME Content
+---------------------------------------------------
 
 .. module:: email.contentmanager
    :synopsis: Storing and Retrieving Content from MIME Parts

--- a/Doc/library/email.encoders.rst
+++ b/Doc/library/email.encoders.rst
@@ -1,5 +1,5 @@
-:mod:`email.encoders`: Encoders
--------------------------------
+:mod:`!email.encoders`: Encoders
+--------------------------------
 
 .. module:: email.encoders
    :synopsis: Encoders for email message payloads.

--- a/Doc/library/email.errors.rst
+++ b/Doc/library/email.errors.rst
@@ -1,5 +1,5 @@
-:mod:`email.errors`: Exception and Defect classes
--------------------------------------------------
+:mod:`!email.errors`: Exception and Defect classes
+--------------------------------------------------
 
 .. module:: email.errors
    :synopsis: The exception classes used by the email package.

--- a/Doc/library/email.generator.rst
+++ b/Doc/library/email.generator.rst
@@ -1,5 +1,5 @@
-:mod:`email.generator`: Generating MIME documents
--------------------------------------------------
+:mod:`!email.generator`: Generating MIME documents
+--------------------------------------------------
 
 .. module:: email.generator
    :synopsis: Generate flat text email messages from a message structure.

--- a/Doc/library/email.header.rst
+++ b/Doc/library/email.header.rst
@@ -1,5 +1,5 @@
-:mod:`email.header`: Internationalized headers
-----------------------------------------------
+:mod:`!email.header`: Internationalized headers
+-----------------------------------------------
 
 .. module:: email.header
    :synopsis: Representing non-ASCII headers

--- a/Doc/library/email.headerregistry.rst
+++ b/Doc/library/email.headerregistry.rst
@@ -1,5 +1,5 @@
-:mod:`email.headerregistry`: Custom Header Objects
---------------------------------------------------
+:mod:`!email.headerregistry`: Custom Header Objects
+---------------------------------------------------
 
 .. module:: email.headerregistry
    :synopsis: Automatic Parsing of headers based on the field name

--- a/Doc/library/email.iterators.rst
+++ b/Doc/library/email.iterators.rst
@@ -1,5 +1,5 @@
-:mod:`email.iterators`: Iterators
----------------------------------
+:mod:`!email.iterators`: Iterators
+----------------------------------
 
 .. module:: email.iterators
    :synopsis: Iterate over a  message object tree.

--- a/Doc/library/email.message.rst
+++ b/Doc/library/email.message.rst
@@ -1,5 +1,5 @@
-:mod:`email.message`: Representing an email message
----------------------------------------------------
+:mod:`!email.message`: Representing an email message
+----------------------------------------------------
 
 .. module:: email.message
    :synopsis: The base class representing email messages.

--- a/Doc/library/email.mime.rst
+++ b/Doc/library/email.mime.rst
@@ -1,5 +1,5 @@
-:mod:`email.mime`: Creating email and MIME objects from scratch
----------------------------------------------------------------
+:mod:`!email.mime`: Creating email and MIME objects from scratch
+----------------------------------------------------------------
 
 .. module:: email.mime
    :synopsis: Build MIME messages.

--- a/Doc/library/email.parser.rst
+++ b/Doc/library/email.parser.rst
@@ -1,5 +1,5 @@
-:mod:`email.parser`: Parsing email messages
--------------------------------------------
+:mod:`!email.parser`: Parsing email messages
+--------------------------------------------
 
 .. module:: email.parser
    :synopsis: Parse flat text email messages to produce a message object structure.

--- a/Doc/library/email.policy.rst
+++ b/Doc/library/email.policy.rst
@@ -1,5 +1,5 @@
-:mod:`email.policy`: Policy Objects
------------------------------------
+:mod:`!email.policy`: Policy Objects
+------------------------------------
 
 .. module:: email.policy
    :synopsis: Controlling the parsing and generating of messages

--- a/Doc/library/email.rst
+++ b/Doc/library/email.rst
@@ -1,5 +1,5 @@
-:mod:`email` --- An email and MIME handling package
-===================================================
+:mod:`!email` --- An email and MIME handling package
+====================================================
 
 .. module:: email
    :synopsis: Package supporting the parsing, manipulating, and generating

--- a/Doc/library/email.utils.rst
+++ b/Doc/library/email.utils.rst
@@ -1,5 +1,5 @@
-:mod:`email.utils`: Miscellaneous utilities
--------------------------------------------
+:mod:`!email.utils`: Miscellaneous utilities
+--------------------------------------------
 
 .. module:: email.utils
    :synopsis: Miscellaneous email package utilities.

--- a/Doc/library/ensurepip.rst
+++ b/Doc/library/ensurepip.rst
@@ -1,5 +1,5 @@
-:mod:`ensurepip` --- Bootstrapping the ``pip`` installer
-========================================================
+:mod:`!ensurepip` --- Bootstrapping the ``pip`` installer
+=========================================================
 
 .. module:: ensurepip
    :synopsis: Bootstrapping the "pip" installer into an existing Python

--- a/Doc/library/enum.rst
+++ b/Doc/library/enum.rst
@@ -1,5 +1,5 @@
-:mod:`enum` --- Support for enumerations
-========================================
+:mod:`!enum` --- Support for enumerations
+=========================================
 
 .. module:: enum
    :synopsis: Implementation of an enumeration class.

--- a/Doc/library/errno.rst
+++ b/Doc/library/errno.rst
@@ -1,5 +1,5 @@
-:mod:`errno` --- Standard errno system symbols
-==============================================
+:mod:`!errno` --- Standard errno system symbols
+===============================================
 
 .. module:: errno
    :synopsis: Standard errno system symbols.

--- a/Doc/library/faulthandler.rst
+++ b/Doc/library/faulthandler.rst
@@ -1,5 +1,5 @@
-:mod:`faulthandler` --- Dump the Python traceback
-=================================================
+:mod:`!faulthandler` --- Dump the Python traceback
+==================================================
 
 .. module:: faulthandler
    :synopsis: Dump the Python traceback.

--- a/Doc/library/fcntl.rst
+++ b/Doc/library/fcntl.rst
@@ -1,5 +1,5 @@
-:mod:`fcntl` --- The ``fcntl`` and ``ioctl`` system calls
-=========================================================
+:mod:`!fcntl` --- The ``fcntl`` and ``ioctl`` system calls
+==========================================================
 
 .. module:: fcntl
    :platform: Unix

--- a/Doc/library/filecmp.rst
+++ b/Doc/library/filecmp.rst
@@ -1,5 +1,5 @@
-:mod:`filecmp` --- File and Directory Comparisons
-=================================================
+:mod:`!filecmp` --- File and Directory Comparisons
+==================================================
 
 .. module:: filecmp
    :synopsis: Compare files efficiently.

--- a/Doc/library/fileinput.rst
+++ b/Doc/library/fileinput.rst
@@ -1,5 +1,5 @@
-:mod:`fileinput` --- Iterate over lines from multiple input streams
-===================================================================
+:mod:`!fileinput` --- Iterate over lines from multiple input streams
+====================================================================
 
 .. module:: fileinput
    :synopsis: Loop over standard input or a list of files.

--- a/Doc/library/fnmatch.rst
+++ b/Doc/library/fnmatch.rst
@@ -1,5 +1,5 @@
-:mod:`fnmatch` --- Unix filename pattern matching
-=================================================
+:mod:`!fnmatch` --- Unix filename pattern matching
+==================================================
 
 .. module:: fnmatch
    :synopsis: Unix shell style filename pattern matching.

--- a/Doc/library/fractions.rst
+++ b/Doc/library/fractions.rst
@@ -1,5 +1,5 @@
-:mod:`fractions` --- Rational numbers
-=====================================
+:mod:`!fractions` --- Rational numbers
+======================================
 
 .. module:: fractions
    :synopsis: Rational numbers.

--- a/Doc/library/ftplib.rst
+++ b/Doc/library/ftplib.rst
@@ -1,5 +1,5 @@
-:mod:`ftplib` --- FTP protocol client
-=====================================
+:mod:`!ftplib` --- FTP protocol client
+======================================
 
 .. module:: ftplib
    :synopsis: FTP protocol client (requires sockets).

--- a/Doc/library/functools.rst
+++ b/Doc/library/functools.rst
@@ -1,5 +1,5 @@
-:mod:`functools` --- Higher-order functions and operations on callable objects
-==============================================================================
+:mod:`!functools` --- Higher-order functions and operations on callable objects
+===============================================================================
 
 .. module:: functools
    :synopsis: Higher-order functions and operations on callable objects.

--- a/Doc/library/gc.rst
+++ b/Doc/library/gc.rst
@@ -1,5 +1,5 @@
-:mod:`gc` --- Garbage Collector interface
-=========================================
+:mod:`!gc` --- Garbage Collector interface
+==========================================
 
 .. module:: gc
    :synopsis: Interface to the cycle-detecting garbage collector.

--- a/Doc/library/getopt.rst
+++ b/Doc/library/getopt.rst
@@ -1,5 +1,5 @@
-:mod:`getopt` --- C-style parser for command line options
-=========================================================
+:mod:`!getopt` --- C-style parser for command line options
+==========================================================
 
 .. module:: getopt
    :synopsis: Portable parser for command line options; support both short and

--- a/Doc/library/getpass.rst
+++ b/Doc/library/getpass.rst
@@ -1,5 +1,5 @@
-:mod:`getpass` --- Portable password input
-==========================================
+:mod:`!getpass` --- Portable password input
+===========================================
 
 .. module:: getpass
    :synopsis: Portable reading of passwords and retrieval of the userid.

--- a/Doc/library/gettext.rst
+++ b/Doc/library/gettext.rst
@@ -1,5 +1,5 @@
-:mod:`gettext` --- Multilingual internationalization services
-=============================================================
+:mod:`!gettext` --- Multilingual internationalization services
+==============================================================
 
 .. module:: gettext
    :synopsis: Multilingual internationalization services.

--- a/Doc/library/glob.rst
+++ b/Doc/library/glob.rst
@@ -1,5 +1,5 @@
-:mod:`glob` --- Unix style pathname pattern expansion
-=====================================================
+:mod:`!glob` --- Unix style pathname pattern expansion
+======================================================
 
 .. module:: glob
    :synopsis: Unix shell style pathname pattern expansion.

--- a/Doc/library/graphlib.rst
+++ b/Doc/library/graphlib.rst
@@ -1,5 +1,5 @@
-:mod:`graphlib` --- Functionality to operate with graph-like structures
-=========================================================================
+:mod:`!graphlib` --- Functionality to operate with graph-like structures
+========================================================================
 
 .. module:: graphlib
    :synopsis: Functionality to operate with graph-like structures

--- a/Doc/library/grp.rst
+++ b/Doc/library/grp.rst
@@ -1,5 +1,5 @@
-:mod:`grp` --- The group database
-=================================
+:mod:`!grp` --- The group database
+==================================
 
 .. module:: grp
    :platform: Unix

--- a/Doc/library/gzip.rst
+++ b/Doc/library/gzip.rst
@@ -1,5 +1,5 @@
-:mod:`gzip` --- Support for :program:`gzip` files
-=================================================
+:mod:`!gzip` --- Support for :program:`gzip` files
+==================================================
 
 .. module:: gzip
    :synopsis: Interfaces for gzip compression and decompression using file objects.

--- a/Doc/library/hashlib.rst
+++ b/Doc/library/hashlib.rst
@@ -1,5 +1,5 @@
-:mod:`hashlib` --- Secure hashes and message digests
-====================================================
+:mod:`!hashlib` --- Secure hashes and message digests
+=====================================================
 
 .. module:: hashlib
    :synopsis: Secure hash and message digest algorithms.

--- a/Doc/library/heapq.rst
+++ b/Doc/library/heapq.rst
@@ -1,5 +1,5 @@
-:mod:`heapq` --- Heap queue algorithm
-=====================================
+:mod:`!heapq` --- Heap queue algorithm
+======================================
 
 .. module:: heapq
    :synopsis: Heap queue algorithm (a.k.a. priority queue).

--- a/Doc/library/hmac.rst
+++ b/Doc/library/hmac.rst
@@ -1,5 +1,5 @@
-:mod:`hmac` --- Keyed-Hashing for Message Authentication
-========================================================
+:mod:`!hmac` --- Keyed-Hashing for Message Authentication
+=========================================================
 
 .. module:: hmac
    :synopsis: Keyed-Hashing for Message Authentication (HMAC) implementation

--- a/Doc/library/html.entities.rst
+++ b/Doc/library/html.entities.rst
@@ -1,5 +1,5 @@
-:mod:`html.entities` --- Definitions of HTML general entities
-=============================================================
+:mod:`!html.entities` --- Definitions of HTML general entities
+==============================================================
 
 .. module:: html.entities
    :synopsis: Definitions of HTML general entities.

--- a/Doc/library/html.parser.rst
+++ b/Doc/library/html.parser.rst
@@ -1,5 +1,5 @@
-:mod:`html.parser` --- Simple HTML and XHTML parser
-===================================================
+:mod:`!html.parser` --- Simple HTML and XHTML parser
+====================================================
 
 .. module:: html.parser
    :synopsis: A simple parser that can handle HTML and XHTML.

--- a/Doc/library/html.rst
+++ b/Doc/library/html.rst
@@ -1,5 +1,5 @@
-:mod:`html` --- HyperText Markup Language support
-=================================================
+:mod:`!html` --- HyperText Markup Language support
+==================================================
 
 .. module:: html
    :synopsis: Helpers for manipulating HTML.

--- a/Doc/library/http.client.rst
+++ b/Doc/library/http.client.rst
@@ -1,5 +1,5 @@
-:mod:`http.client` --- HTTP protocol client
-===========================================
+:mod:`!http.client` --- HTTP protocol client
+============================================
 
 .. module:: http.client
    :synopsis: HTTP and HTTPS protocol client (requires sockets).

--- a/Doc/library/http.cookiejar.rst
+++ b/Doc/library/http.cookiejar.rst
@@ -1,5 +1,5 @@
-:mod:`http.cookiejar` --- Cookie handling for HTTP clients
-==========================================================
+:mod:`!http.cookiejar` --- Cookie handling for HTTP clients
+===========================================================
 
 .. module:: http.cookiejar
    :synopsis: Classes for automatic handling of HTTP cookies.

--- a/Doc/library/http.cookies.rst
+++ b/Doc/library/http.cookies.rst
@@ -1,5 +1,5 @@
-:mod:`http.cookies` --- HTTP state management
-=============================================
+:mod:`!http.cookies` --- HTTP state management
+==============================================
 
 .. module:: http.cookies
    :synopsis: Support for HTTP state management (cookies).

--- a/Doc/library/http.rst
+++ b/Doc/library/http.rst
@@ -1,5 +1,5 @@
-:mod:`http` --- HTTP modules
-============================
+:mod:`!http` --- HTTP modules
+=============================
 
 .. module:: http
    :synopsis: HTTP status codes and messages

--- a/Doc/library/http.server.rst
+++ b/Doc/library/http.server.rst
@@ -1,5 +1,5 @@
-:mod:`http.server` --- HTTP servers
-===================================
+:mod:`!http.server` --- HTTP servers
+====================================
 
 .. module:: http.server
    :synopsis: HTTP server and request handlers.

--- a/Doc/library/imaplib.rst
+++ b/Doc/library/imaplib.rst
@@ -1,5 +1,5 @@
-:mod:`imaplib` --- IMAP4 protocol client
-========================================
+:mod:`!imaplib` --- IMAP4 protocol client
+=========================================
 
 .. module:: imaplib
    :synopsis: IMAP4 protocol client (requires sockets).

--- a/Doc/library/importlib.resources.abc.rst
+++ b/Doc/library/importlib.resources.abc.rst
@@ -1,5 +1,5 @@
-:mod:`importlib.resources.abc` -- Abstract base classes for resources
----------------------------------------------------------------------
+:mod:`!importlib.resources.abc` -- Abstract base classes for resources
+----------------------------------------------------------------------
 
 .. module:: importlib.resources.abc
     :synopsis: Abstract base classes for resources

--- a/Doc/library/importlib.resources.rst
+++ b/Doc/library/importlib.resources.rst
@@ -1,5 +1,5 @@
-:mod:`importlib.resources` -- Package resource reading, opening and access
---------------------------------------------------------------------------
+:mod:`!importlib.resources` -- Package resource reading, opening and access
+---------------------------------------------------------------------------
 
 .. module:: importlib.resources
     :synopsis: Package resource reading, opening, and access

--- a/Doc/library/inspect.rst
+++ b/Doc/library/inspect.rst
@@ -1,5 +1,5 @@
-:mod:`inspect` --- Inspect live objects
-=======================================
+:mod:`!inspect` --- Inspect live objects
+========================================
 
 .. testsetup:: *
 

--- a/Doc/library/io.rst
+++ b/Doc/library/io.rst
@@ -1,5 +1,5 @@
-:mod:`io` --- Core tools for working with streams
-=================================================
+:mod:`!io` --- Core tools for working with streams
+==================================================
 
 .. module:: io
    :synopsis: Core tools for working with streams.

--- a/Doc/library/ipaddress.rst
+++ b/Doc/library/ipaddress.rst
@@ -1,5 +1,5 @@
-:mod:`ipaddress` --- IPv4/IPv6 manipulation library
-===================================================
+:mod:`!ipaddress` --- IPv4/IPv6 manipulation library
+====================================================
 
 .. module:: ipaddress
    :synopsis: IPv4/IPv6 manipulation library.

--- a/Doc/library/itertools.rst
+++ b/Doc/library/itertools.rst
@@ -1,5 +1,5 @@
-:mod:`itertools` --- Functions creating iterators for efficient looping
-=======================================================================
+:mod:`!itertools` --- Functions creating iterators for efficient looping
+========================================================================
 
 .. module:: itertools
    :synopsis: Functions creating iterators for efficient looping.

--- a/Doc/library/json.rst
+++ b/Doc/library/json.rst
@@ -1,5 +1,5 @@
-:mod:`json` --- JSON encoder and decoder
-========================================
+:mod:`!json` --- JSON encoder and decoder
+=========================================
 
 .. module:: json
    :synopsis: Encode and decode the JSON format.

--- a/Doc/library/keyword.rst
+++ b/Doc/library/keyword.rst
@@ -1,5 +1,5 @@
-:mod:`keyword` --- Testing for Python keywords
-==============================================
+:mod:`!keyword` --- Testing for Python keywords
+===============================================
 
 .. module:: keyword
    :synopsis: Test whether a string is a keyword in Python.

--- a/Doc/library/linecache.rst
+++ b/Doc/library/linecache.rst
@@ -1,5 +1,5 @@
-:mod:`linecache` --- Random access to text lines
-================================================
+:mod:`!linecache` --- Random access to text lines
+=================================================
 
 .. module:: linecache
    :synopsis: Provides random access to individual lines from text files.

--- a/Doc/library/locale.rst
+++ b/Doc/library/locale.rst
@@ -1,5 +1,5 @@
-:mod:`locale` --- Internationalization services
-===============================================
+:mod:`!locale` --- Internationalization services
+================================================
 
 .. module:: locale
    :synopsis: Internationalization services.

--- a/Doc/library/logging.config.rst
+++ b/Doc/library/logging.config.rst
@@ -1,5 +1,5 @@
-:mod:`logging.config` --- Logging configuration
-===============================================
+:mod:`!logging.config` --- Logging configuration
+================================================
 
 .. module:: logging.config
    :synopsis: Configuration of the logging module.

--- a/Doc/library/logging.handlers.rst
+++ b/Doc/library/logging.handlers.rst
@@ -1,5 +1,5 @@
-:mod:`logging.handlers` --- Logging handlers
-============================================
+:mod:`!logging.handlers` --- Logging handlers
+=============================================
 
 .. module:: logging.handlers
    :synopsis: Handlers for the logging module.

--- a/Doc/library/logging.rst
+++ b/Doc/library/logging.rst
@@ -1,5 +1,5 @@
-:mod:`logging` --- Logging facility for Python
-==============================================
+:mod:`!logging` --- Logging facility for Python
+===============================================
 
 .. module:: logging
    :synopsis: Flexible event logging system for applications.

--- a/Doc/library/lzma.rst
+++ b/Doc/library/lzma.rst
@@ -1,5 +1,5 @@
-:mod:`lzma` --- Compression using the LZMA algorithm
-====================================================
+:mod:`!lzma` --- Compression using the LZMA algorithm
+=====================================================
 
 .. module:: lzma
    :synopsis: A Python wrapper for the liblzma compression library.

--- a/Doc/library/mailbox.rst
+++ b/Doc/library/mailbox.rst
@@ -1,5 +1,5 @@
-:mod:`mailbox` --- Manipulate mailboxes in various formats
-==========================================================
+:mod:`!mailbox` --- Manipulate mailboxes in various formats
+===========================================================
 
 .. module:: mailbox
    :synopsis: Manipulate mailboxes in various formats

--- a/Doc/library/marshal.rst
+++ b/Doc/library/marshal.rst
@@ -1,5 +1,5 @@
-:mod:`marshal` --- Internal Python object serialization
-=======================================================
+:mod:`!marshal` --- Internal Python object serialization
+========================================================
 
 .. module:: marshal
    :synopsis: Convert Python objects to streams of bytes and back (with different

--- a/Doc/library/math.rst
+++ b/Doc/library/math.rst
@@ -1,5 +1,5 @@
-:mod:`math` --- Mathematical functions
-======================================
+:mod:`!math` --- Mathematical functions
+=======================================
 
 .. module:: math
    :synopsis: Mathematical functions (sin() etc.).

--- a/Doc/library/mimetypes.rst
+++ b/Doc/library/mimetypes.rst
@@ -1,5 +1,5 @@
-:mod:`mimetypes` --- Map filenames to MIME types
-================================================
+:mod:`!mimetypes` --- Map filenames to MIME types
+=================================================
 
 .. module:: mimetypes
    :synopsis: Mapping of filename extensions to MIME types.

--- a/Doc/library/mmap.rst
+++ b/Doc/library/mmap.rst
@@ -1,5 +1,5 @@
-:mod:`mmap` --- Memory-mapped file support
-==========================================
+:mod:`!mmap` --- Memory-mapped file support
+===========================================
 
 .. module:: mmap
    :synopsis: Interface to memory-mapped files for Unix and Windows.

--- a/Doc/library/modulefinder.rst
+++ b/Doc/library/modulefinder.rst
@@ -1,5 +1,5 @@
-:mod:`modulefinder` --- Find modules used by a script
-=====================================================
+:mod:`!modulefinder` --- Find modules used by a script
+======================================================
 
 .. module:: modulefinder
    :synopsis: Find modules used by a script.

--- a/Doc/library/msvcrt.rst
+++ b/Doc/library/msvcrt.rst
@@ -1,5 +1,5 @@
-:mod:`msvcrt` --- Useful routines from the MS VC++ runtime
-==========================================================
+:mod:`!msvcrt` --- Useful routines from the MS VC++ runtime
+===========================================================
 
 .. module:: msvcrt
    :platform: Windows

--- a/Doc/library/multiprocessing.rst
+++ b/Doc/library/multiprocessing.rst
@@ -1,5 +1,5 @@
-:mod:`multiprocessing` --- Process-based parallelism
-====================================================
+:mod:`!multiprocessing` --- Process-based parallelism
+=====================================================
 
 .. module:: multiprocessing
    :synopsis: Process-based parallelism.

--- a/Doc/library/multiprocessing.shared_memory.rst
+++ b/Doc/library/multiprocessing.shared_memory.rst
@@ -1,5 +1,5 @@
-:mod:`multiprocessing.shared_memory` --- Shared memory for direct access across processes
-=========================================================================================
+:mod:`!multiprocessing.shared_memory` --- Shared memory for direct access across processes
+==========================================================================================
 
 .. module:: multiprocessing.shared_memory
    :synopsis: Provides shared memory for direct access across processes.

--- a/Doc/library/netrc.rst
+++ b/Doc/library/netrc.rst
@@ -1,6 +1,5 @@
-
-:mod:`netrc` --- netrc file processing
-======================================
+:mod:`!netrc` --- netrc file processing
+=======================================
 
 .. module:: netrc
    :synopsis: Loading of .netrc files.

--- a/Doc/library/numbers.rst
+++ b/Doc/library/numbers.rst
@@ -1,5 +1,5 @@
-:mod:`numbers` --- Numeric abstract base classes
-================================================
+:mod:`!numbers` --- Numeric abstract base classes
+=================================================
 
 .. module:: numbers
    :synopsis: Numeric abstract base classes (Complex, Real, Integral, etc.).

--- a/Doc/library/operator.rst
+++ b/Doc/library/operator.rst
@@ -1,5 +1,5 @@
-:mod:`operator` --- Standard operators as functions
-===================================================
+:mod:`!operator` --- Standard operators as functions
+====================================================
 
 .. module:: operator
    :synopsis: Functions corresponding to the standard operators.

--- a/Doc/library/optparse.rst
+++ b/Doc/library/optparse.rst
@@ -1,5 +1,5 @@
-:mod:`optparse` --- Parser for command line options
-===================================================
+:mod:`!optparse` --- Parser for command line options
+====================================================
 
 .. module:: optparse
    :synopsis: Command-line option parsing library.

--- a/Doc/library/os.path.rst
+++ b/Doc/library/os.path.rst
@@ -1,5 +1,5 @@
-:mod:`os.path` --- Common pathname manipulations
-================================================
+:mod:`!os.path` --- Common pathname manipulations
+=================================================
 
 .. module:: os.path
    :synopsis: Operations on pathnames.

--- a/Doc/library/os.rst
+++ b/Doc/library/os.rst
@@ -1,5 +1,5 @@
-:mod:`os` --- Miscellaneous operating system interfaces
-=======================================================
+:mod:`!os` --- Miscellaneous operating system interfaces
+========================================================
 
 .. module:: os
    :synopsis: Miscellaneous operating system interfaces.

--- a/Doc/library/pathlib.rst
+++ b/Doc/library/pathlib.rst
@@ -1,6 +1,5 @@
-
-:mod:`pathlib` --- Object-oriented filesystem paths
-===================================================
+:mod:`!pathlib` --- Object-oriented filesystem paths
+====================================================
 
 .. module:: pathlib
    :synopsis: Object-oriented filesystem paths

--- a/Doc/library/pickle.rst
+++ b/Doc/library/pickle.rst
@@ -1,5 +1,5 @@
-:mod:`pickle` --- Python object serialization
-=============================================
+:mod:`!pickle` --- Python object serialization
+==============================================
 
 .. module:: pickle
    :synopsis: Convert Python objects to streams of bytes and back.

--- a/Doc/library/pickletools.rst
+++ b/Doc/library/pickletools.rst
@@ -1,5 +1,5 @@
-:mod:`pickletools` --- Tools for pickle developers
-==================================================
+:mod:`!pickletools` --- Tools for pickle developers
+===================================================
 
 .. module:: pickletools
    :synopsis: Contains extensive comments about the pickle protocols and

--- a/Doc/library/pkgutil.rst
+++ b/Doc/library/pkgutil.rst
@@ -1,5 +1,5 @@
-:mod:`pkgutil` --- Package extension utility
-============================================
+:mod:`!pkgutil` --- Package extension utility
+=============================================
 
 .. module:: pkgutil
    :synopsis: Utilities for the import system.

--- a/Doc/library/platform.rst
+++ b/Doc/library/platform.rst
@@ -1,5 +1,5 @@
-:mod:`platform` ---  Access to underlying platform's identifying data
-=====================================================================
+:mod:`!platform` ---  Access to underlying platform's identifying data
+======================================================================
 
 .. module:: platform
    :synopsis: Retrieves as much platform identifying data as possible.

--- a/Doc/library/plistlib.rst
+++ b/Doc/library/plistlib.rst
@@ -1,5 +1,5 @@
-:mod:`plistlib` --- Generate and parse Apple ``.plist`` files
-=============================================================
+:mod:`!plistlib` --- Generate and parse Apple ``.plist`` files
+==============================================================
 
 .. module:: plistlib
    :synopsis: Generate and parse Apple plist files.

--- a/Doc/library/poplib.rst
+++ b/Doc/library/poplib.rst
@@ -1,5 +1,5 @@
-:mod:`poplib` --- POP3 protocol client
-======================================
+:mod:`!poplib` --- POP3 protocol client
+=======================================
 
 .. module:: poplib
    :synopsis: POP3 protocol client (requires sockets).

--- a/Doc/library/posix.rst
+++ b/Doc/library/posix.rst
@@ -1,5 +1,5 @@
-:mod:`posix` --- The most common POSIX system calls
-===================================================
+:mod:`!posix` --- The most common POSIX system calls
+====================================================
 
 .. module:: posix
    :platform: Unix

--- a/Doc/library/pprint.rst
+++ b/Doc/library/pprint.rst
@@ -1,5 +1,5 @@
-:mod:`pprint` --- Data pretty printer
-=====================================
+:mod:`!pprint` --- Data pretty printer
+======================================
 
 .. module:: pprint
    :synopsis: Data pretty printer.

--- a/Doc/library/pty.rst
+++ b/Doc/library/pty.rst
@@ -1,5 +1,5 @@
-:mod:`pty` --- Pseudo-terminal utilities
-========================================
+:mod:`!pty` --- Pseudo-terminal utilities
+=========================================
 
 .. module:: pty
    :platform: Unix

--- a/Doc/library/pwd.rst
+++ b/Doc/library/pwd.rst
@@ -1,5 +1,5 @@
-:mod:`pwd` --- The password database
-====================================
+:mod:`!pwd` --- The password database
+=====================================
 
 .. module:: pwd
    :platform: Unix

--- a/Doc/library/py_compile.rst
+++ b/Doc/library/py_compile.rst
@@ -1,5 +1,5 @@
-:mod:`py_compile` --- Compile Python source files
-=================================================
+:mod:`!py_compile` --- Compile Python source files
+==================================================
 
 .. module:: py_compile
    :synopsis: Generate byte-code files from Python source files.

--- a/Doc/library/pyclbr.rst
+++ b/Doc/library/pyclbr.rst
@@ -1,5 +1,5 @@
-:mod:`pyclbr` --- Python module browser support
-===============================================
+:mod:`!pyclbr` --- Python module browser support
+================================================
 
 .. module:: pyclbr
    :synopsis: Supports information extraction for a Python module browser.

--- a/Doc/library/pydoc.rst
+++ b/Doc/library/pydoc.rst
@@ -1,5 +1,5 @@
-:mod:`pydoc` --- Documentation generator and online help system
-===============================================================
+:mod:`!pydoc` --- Documentation generator and online help system
+================================================================
 
 .. module:: pydoc
    :synopsis: Documentation generator and online help system.

--- a/Doc/library/pyexpat.rst
+++ b/Doc/library/pyexpat.rst
@@ -1,5 +1,5 @@
-:mod:`xml.parsers.expat` --- Fast XML parsing using Expat
-=========================================================
+:mod:`!xml.parsers.expat` --- Fast XML parsing using Expat
+==========================================================
 
 .. module:: xml.parsers.expat
    :synopsis: An interface to the Expat non-validating XML parser.

--- a/Doc/library/queue.rst
+++ b/Doc/library/queue.rst
@@ -1,5 +1,5 @@
-:mod:`queue` --- A synchronized queue class
-===========================================
+:mod:`!queue` --- A synchronized queue class
+============================================
 
 .. module:: queue
    :synopsis: A synchronized queue class.

--- a/Doc/library/quopri.rst
+++ b/Doc/library/quopri.rst
@@ -1,5 +1,5 @@
-:mod:`quopri` --- Encode and decode MIME quoted-printable data
-==============================================================
+:mod:`!quopri` --- Encode and decode MIME quoted-printable data
+===============================================================
 
 .. module:: quopri
    :synopsis: Encode and decode files using the MIME quoted-printable encoding.

--- a/Doc/library/random.rst
+++ b/Doc/library/random.rst
@@ -1,5 +1,5 @@
-:mod:`random` --- Generate pseudo-random numbers
-================================================
+:mod:`!random` --- Generate pseudo-random numbers
+=================================================
 
 .. module:: random
    :synopsis: Generate pseudo-random numbers with various common distributions.

--- a/Doc/library/re.rst
+++ b/Doc/library/re.rst
@@ -1,5 +1,5 @@
-:mod:`re` --- Regular expression operations
-===========================================
+:mod:`!re` --- Regular expression operations
+============================================
 
 .. module:: re
    :synopsis: Regular expression operations.

--- a/Doc/library/readline.rst
+++ b/Doc/library/readline.rst
@@ -1,5 +1,5 @@
-:mod:`readline` --- GNU readline interface
-==========================================
+:mod:`!readline` --- GNU readline interface
+===========================================
 
 .. module:: readline
    :platform: Unix

--- a/Doc/library/reprlib.rst
+++ b/Doc/library/reprlib.rst
@@ -1,5 +1,5 @@
-:mod:`reprlib` --- Alternate :func:`repr` implementation
-========================================================
+:mod:`!reprlib` --- Alternate :func:`repr` implementation
+=========================================================
 
 .. module:: reprlib
    :synopsis: Alternate repr() implementation with size limits.

--- a/Doc/library/resource.rst
+++ b/Doc/library/resource.rst
@@ -1,5 +1,5 @@
-:mod:`resource` --- Resource usage information
-==============================================
+:mod:`!resource` --- Resource usage information
+===============================================
 
 .. module:: resource
    :platform: Unix

--- a/Doc/library/rlcompleter.rst
+++ b/Doc/library/rlcompleter.rst
@@ -1,5 +1,5 @@
-:mod:`rlcompleter` --- Completion function for GNU readline
-===========================================================
+:mod:`!rlcompleter` --- Completion function for GNU readline
+============================================================
 
 .. module:: rlcompleter
    :synopsis: Python identifier completion, suitable for the GNU readline library.

--- a/Doc/library/runpy.rst
+++ b/Doc/library/runpy.rst
@@ -1,5 +1,5 @@
-:mod:`runpy` --- Locating and executing Python modules
-======================================================
+:mod:`!runpy` --- Locating and executing Python modules
+=======================================================
 
 .. module:: runpy
    :synopsis: Locate and run Python modules without importing them first.

--- a/Doc/library/sched.rst
+++ b/Doc/library/sched.rst
@@ -1,5 +1,5 @@
-:mod:`sched` --- Event scheduler
-================================
+:mod:`!sched` --- Event scheduler
+=================================
 
 .. module:: sched
    :synopsis: General purpose event scheduler.

--- a/Doc/library/secrets.rst
+++ b/Doc/library/secrets.rst
@@ -1,5 +1,5 @@
-:mod:`secrets` --- Generate secure random numbers for managing secrets
-======================================================================
+:mod:`!secrets` --- Generate secure random numbers for managing secrets
+=======================================================================
 
 .. module:: secrets
    :synopsis: Generate secure random numbers for managing secrets.

--- a/Doc/library/select.rst
+++ b/Doc/library/select.rst
@@ -1,5 +1,5 @@
-:mod:`select` --- Waiting for I/O completion
-============================================
+:mod:`!select` --- Waiting for I/O completion
+=============================================
 
 .. module:: select
    :synopsis: Wait for I/O completion on multiple streams.

--- a/Doc/library/selectors.rst
+++ b/Doc/library/selectors.rst
@@ -1,5 +1,5 @@
-:mod:`selectors` --- High-level I/O multiplexing
-================================================
+:mod:`!selectors` --- High-level I/O multiplexing
+=================================================
 
 .. module:: selectors
    :synopsis: High-level I/O multiplexing.

--- a/Doc/library/shelve.rst
+++ b/Doc/library/shelve.rst
@@ -1,5 +1,5 @@
-:mod:`shelve` --- Python object persistence
-===========================================
+:mod:`!shelve` --- Python object persistence
+============================================
 
 .. module:: shelve
    :synopsis: Python object persistence.

--- a/Doc/library/shlex.rst
+++ b/Doc/library/shlex.rst
@@ -1,5 +1,5 @@
-:mod:`shlex` --- Simple lexical analysis
-========================================
+:mod:`!shlex` --- Simple lexical analysis
+=========================================
 
 .. module:: shlex
    :synopsis: Simple lexical analysis for Unix shell-like languages.

--- a/Doc/library/shutil.rst
+++ b/Doc/library/shutil.rst
@@ -1,5 +1,5 @@
-:mod:`shutil` --- High-level file operations
-============================================
+:mod:`!shutil` --- High-level file operations
+=============================================
 
 .. module:: shutil
    :synopsis: High-level file operations, including copying.

--- a/Doc/library/signal.rst
+++ b/Doc/library/signal.rst
@@ -1,5 +1,5 @@
-:mod:`signal` --- Set handlers for asynchronous events
-======================================================
+:mod:`!signal` --- Set handlers for asynchronous events
+=======================================================
 
 .. module:: signal
    :synopsis: Set handlers for asynchronous events.

--- a/Doc/library/site.rst
+++ b/Doc/library/site.rst
@@ -1,5 +1,5 @@
-:mod:`site` --- Site-specific configuration hook
-================================================
+:mod:`!site` --- Site-specific configuration hook
+=================================================
 
 .. module:: site
    :synopsis: Module responsible for site-specific configuration.

--- a/Doc/library/smtplib.rst
+++ b/Doc/library/smtplib.rst
@@ -1,5 +1,5 @@
-:mod:`smtplib` --- SMTP protocol client
-=======================================
+:mod:`!smtplib` --- SMTP protocol client
+========================================
 
 .. module:: smtplib
    :synopsis: SMTP protocol client (requires sockets).

--- a/Doc/library/socket.rst
+++ b/Doc/library/socket.rst
@@ -1,5 +1,5 @@
-:mod:`socket` --- Low-level networking interface
-================================================
+:mod:`!socket` --- Low-level networking interface
+=================================================
 
 .. module:: socket
    :synopsis: Low-level networking interface.

--- a/Doc/library/socketserver.rst
+++ b/Doc/library/socketserver.rst
@@ -1,5 +1,5 @@
-:mod:`socketserver` --- A framework for network servers
-=======================================================
+:mod:`!socketserver` --- A framework for network servers
+========================================================
 
 .. module:: socketserver
    :synopsis: A framework for network servers.

--- a/Doc/library/sqlite3.rst
+++ b/Doc/library/sqlite3.rst
@@ -1,5 +1,5 @@
-:mod:`sqlite3` --- DB-API 2.0 interface for SQLite databases
-============================================================
+:mod:`!sqlite3` --- DB-API 2.0 interface for SQLite databases
+=============================================================
 
 .. module:: sqlite3
    :synopsis: A DB-API 2.0 implementation using SQLite 3.x.

--- a/Doc/library/ssl.rst
+++ b/Doc/library/ssl.rst
@@ -1,5 +1,5 @@
-:mod:`ssl` --- TLS/SSL wrapper for socket objects
-=================================================
+:mod:`!ssl` --- TLS/SSL wrapper for socket objects
+==================================================
 
 .. module:: ssl
    :synopsis: TLS/SSL wrapper for socket objects

--- a/Doc/library/stat.rst
+++ b/Doc/library/stat.rst
@@ -1,5 +1,5 @@
-:mod:`stat` --- Interpreting :func:`~os.stat` results
-=====================================================
+:mod:`!stat` --- Interpreting :func:`~os.stat` results
+======================================================
 
 .. module:: stat
    :synopsis: Utilities for interpreting the results of os.stat(),

--- a/Doc/library/statistics.rst
+++ b/Doc/library/statistics.rst
@@ -1,5 +1,5 @@
-:mod:`statistics` --- Mathematical statistics functions
-=======================================================
+:mod:`!statistics` --- Mathematical statistics functions
+========================================================
 
 .. module:: statistics
    :synopsis: Mathematical statistics functions

--- a/Doc/library/string.rst
+++ b/Doc/library/string.rst
@@ -1,5 +1,5 @@
-:mod:`string` --- Common string operations
-==========================================
+:mod:`!string` --- Common string operations
+===========================================
 
 .. module:: string
    :synopsis: Common string operations.

--- a/Doc/library/stringprep.rst
+++ b/Doc/library/stringprep.rst
@@ -1,5 +1,5 @@
-:mod:`stringprep` --- Internet String Preparation
-=================================================
+:mod:`!stringprep` --- Internet String Preparation
+==================================================
 
 .. module:: stringprep
    :synopsis: String preparation, as per RFC 3453

--- a/Doc/library/struct.rst
+++ b/Doc/library/struct.rst
@@ -1,5 +1,5 @@
-:mod:`struct` --- Interpret bytes as packed binary data
-=======================================================
+:mod:`!struct` --- Interpret bytes as packed binary data
+========================================================
 
 .. testsetup:: *
 

--- a/Doc/library/subprocess.rst
+++ b/Doc/library/subprocess.rst
@@ -1,5 +1,5 @@
-:mod:`subprocess` --- Subprocess management
-===========================================
+:mod:`!subprocess` --- Subprocess management
+============================================
 
 .. module:: subprocess
    :synopsis: Subprocess management.

--- a/Doc/library/symtable.rst
+++ b/Doc/library/symtable.rst
@@ -1,5 +1,5 @@
-:mod:`symtable` --- Access to the compiler's symbol tables
-==========================================================
+:mod:`!symtable` --- Access to the compiler's symbol tables
+===========================================================
 
 .. module:: symtable
    :synopsis: Interface to the compiler's internal symbol tables.

--- a/Doc/library/sys.monitoring.rst
+++ b/Doc/library/sys.monitoring.rst
@@ -1,5 +1,5 @@
-:mod:`sys.monitoring` --- Execution event monitoring
-====================================================
+:mod:`!sys.monitoring` --- Execution event monitoring
+=====================================================
 
 .. module:: sys.monitoring
    :synopsis: Access and control event monitoring

--- a/Doc/library/sys.rst
+++ b/Doc/library/sys.rst
@@ -1,5 +1,5 @@
-:mod:`sys` --- System-specific parameters and functions
-=======================================================
+:mod:`!sys` --- System-specific parameters and functions
+========================================================
 
 .. module:: sys
    :synopsis: Access system-specific parameters and functions.

--- a/Doc/library/sysconfig.rst
+++ b/Doc/library/sysconfig.rst
@@ -1,5 +1,5 @@
-:mod:`sysconfig` --- Provide access to Python's configuration information
-=========================================================================
+:mod:`!sysconfig` --- Provide access to Python's configuration information
+==========================================================================
 
 .. module:: sysconfig
    :synopsis: Python's configuration information

--- a/Doc/library/syslog.rst
+++ b/Doc/library/syslog.rst
@@ -1,5 +1,5 @@
-:mod:`syslog` --- Unix syslog library routines
-==============================================
+:mod:`!syslog` --- Unix syslog library routines
+===============================================
 
 .. module:: syslog
    :platform: Unix

--- a/Doc/library/tabnanny.rst
+++ b/Doc/library/tabnanny.rst
@@ -1,5 +1,5 @@
-:mod:`tabnanny` --- Detection of ambiguous indentation
-======================================================
+:mod:`!tabnanny` --- Detection of ambiguous indentation
+=======================================================
 
 .. module:: tabnanny
    :synopsis: Tool for detecting white space related problems in Python

--- a/Doc/library/tarfile.rst
+++ b/Doc/library/tarfile.rst
@@ -1,5 +1,5 @@
-:mod:`tarfile` --- Read and write tar archive files
-===================================================
+:mod:`!tarfile` --- Read and write tar archive files
+====================================================
 
 .. module:: tarfile
    :synopsis: Read and write tar-format archive files.

--- a/Doc/library/tempfile.rst
+++ b/Doc/library/tempfile.rst
@@ -1,5 +1,5 @@
-:mod:`tempfile` --- Generate temporary files and directories
-============================================================
+:mod:`!tempfile` --- Generate temporary files and directories
+=============================================================
 
 .. module:: tempfile
    :synopsis: Generate temporary files and directories.

--- a/Doc/library/termios.rst
+++ b/Doc/library/termios.rst
@@ -1,5 +1,5 @@
-:mod:`termios` --- POSIX style tty control
-==========================================
+:mod:`!termios` --- POSIX style tty control
+===========================================
 
 .. module:: termios
    :platform: Unix

--- a/Doc/library/test.rst
+++ b/Doc/library/test.rst
@@ -1,5 +1,5 @@
-:mod:`test` --- Regression tests package for Python
-===================================================
+:mod:`!test` --- Regression tests package for Python
+====================================================
 
 .. module:: test
    :synopsis: Regression tests package containing the testing suite for Python.

--- a/Doc/library/textwrap.rst
+++ b/Doc/library/textwrap.rst
@@ -1,5 +1,5 @@
-:mod:`textwrap` --- Text wrapping and filling
-=============================================
+:mod:`!textwrap` --- Text wrapping and filling
+==============================================
 
 .. module:: textwrap
    :synopsis: Text wrapping and filling

--- a/Doc/library/threading.rst
+++ b/Doc/library/threading.rst
@@ -1,5 +1,5 @@
-:mod:`threading` --- Thread-based parallelism
-=============================================
+:mod:`!threading` --- Thread-based parallelism
+==============================================
 
 .. module:: threading
    :synopsis: Thread-based parallelism.

--- a/Doc/library/time.rst
+++ b/Doc/library/time.rst
@@ -1,5 +1,5 @@
-:mod:`time` --- Time access and conversions
-===========================================
+:mod:`!time` --- Time access and conversions
+============================================
 
 .. module:: time
    :synopsis: Time access and conversions.

--- a/Doc/library/timeit.rst
+++ b/Doc/library/timeit.rst
@@ -1,5 +1,5 @@
-:mod:`timeit` --- Measure execution time of small code snippets
-===============================================================
+:mod:`!timeit` --- Measure execution time of small code snippets
+================================================================
 
 .. module:: timeit
    :synopsis: Measure the execution time of small code snippets.

--- a/Doc/library/tkinter.colorchooser.rst
+++ b/Doc/library/tkinter.colorchooser.rst
@@ -1,5 +1,5 @@
-:mod:`tkinter.colorchooser` --- Color choosing dialog
-=====================================================
+:mod:`!tkinter.colorchooser` --- Color choosing dialog
+======================================================
 
 .. module:: tkinter.colorchooser
    :platform: Tk

--- a/Doc/library/tkinter.dnd.rst
+++ b/Doc/library/tkinter.dnd.rst
@@ -1,5 +1,5 @@
-:mod:`tkinter.dnd` --- Drag and drop support
-============================================
+:mod:`!tkinter.dnd` --- Drag and drop support
+=============================================
 
 .. module:: tkinter.dnd
    :platform: Tk

--- a/Doc/library/tkinter.font.rst
+++ b/Doc/library/tkinter.font.rst
@@ -1,5 +1,5 @@
-:mod:`tkinter.font` --- Tkinter font wrapper
-============================================
+:mod:`!tkinter.font` --- Tkinter font wrapper
+=============================================
 
 .. module:: tkinter.font
    :platform: Tk

--- a/Doc/library/tkinter.messagebox.rst
+++ b/Doc/library/tkinter.messagebox.rst
@@ -1,5 +1,5 @@
-:mod:`tkinter.messagebox` --- Tkinter message prompts
-=====================================================
+:mod:`!tkinter.messagebox` --- Tkinter message prompts
+======================================================
 
 .. module:: tkinter.messagebox
    :platform: Tk

--- a/Doc/library/tkinter.rst
+++ b/Doc/library/tkinter.rst
@@ -1,5 +1,5 @@
-:mod:`tkinter` --- Python interface to Tcl/Tk
-=============================================
+:mod:`!tkinter` --- Python interface to Tcl/Tk
+==============================================
 
 .. module:: tkinter
    :synopsis: Interface to Tcl/Tk for graphical user interfaces

--- a/Doc/library/tkinter.scrolledtext.rst
+++ b/Doc/library/tkinter.scrolledtext.rst
@@ -1,5 +1,5 @@
-:mod:`tkinter.scrolledtext` --- Scrolled Text Widget
-====================================================
+:mod:`!tkinter.scrolledtext` --- Scrolled Text Widget
+=====================================================
 
 .. module:: tkinter.scrolledtext
    :platform: Tk

--- a/Doc/library/tkinter.ttk.rst
+++ b/Doc/library/tkinter.ttk.rst
@@ -1,5 +1,5 @@
-:mod:`tkinter.ttk` --- Tk themed widgets
-========================================
+:mod:`!tkinter.ttk` --- Tk themed widgets
+=========================================
 
 .. module:: tkinter.ttk
    :synopsis: Tk themed widget set

--- a/Doc/library/token.rst
+++ b/Doc/library/token.rst
@@ -1,5 +1,5 @@
-:mod:`token` --- Constants used with Python parse trees
-=======================================================
+:mod:`!token` --- Constants used with Python parse trees
+========================================================
 
 .. module:: token
    :synopsis: Constants representing terminal nodes of the parse tree.

--- a/Doc/library/tokenize.rst
+++ b/Doc/library/tokenize.rst
@@ -1,5 +1,5 @@
-:mod:`tokenize` --- Tokenizer for Python source
-===============================================
+:mod:`!tokenize` --- Tokenizer for Python source
+================================================
 
 .. module:: tokenize
    :synopsis: Lexical scanner for Python source code.

--- a/Doc/library/tomllib.rst
+++ b/Doc/library/tomllib.rst
@@ -1,5 +1,5 @@
-:mod:`tomllib` --- Parse TOML files
-===================================
+:mod:`!tomllib` --- Parse TOML files
+====================================
 
 .. module:: tomllib
    :synopsis: Parse TOML files.

--- a/Doc/library/trace.rst
+++ b/Doc/library/trace.rst
@@ -1,5 +1,5 @@
-:mod:`trace` --- Trace or track Python statement execution
-==========================================================
+:mod:`!trace` --- Trace or track Python statement execution
+===========================================================
 
 .. module:: trace
    :synopsis: Trace or track Python statement execution.

--- a/Doc/library/traceback.rst
+++ b/Doc/library/traceback.rst
@@ -1,5 +1,5 @@
-:mod:`traceback` --- Print or retrieve a stack traceback
-========================================================
+:mod:`!traceback` --- Print or retrieve a stack traceback
+=========================================================
 
 .. module:: traceback
    :synopsis: Print or retrieve a stack traceback.

--- a/Doc/library/tracemalloc.rst
+++ b/Doc/library/tracemalloc.rst
@@ -1,5 +1,5 @@
-:mod:`tracemalloc` --- Trace memory allocations
-===============================================
+:mod:`!tracemalloc` --- Trace memory allocations
+================================================
 
 .. module:: tracemalloc
    :synopsis: Trace memory allocations.

--- a/Doc/library/tty.rst
+++ b/Doc/library/tty.rst
@@ -1,5 +1,5 @@
-:mod:`tty` --- Terminal control functions
-=========================================
+:mod:`!tty` --- Terminal control functions
+==========================================
 
 .. module:: tty
    :platform: Unix

--- a/Doc/library/types.rst
+++ b/Doc/library/types.rst
@@ -1,5 +1,5 @@
-:mod:`types` --- Dynamic type creation and names for built-in types
-===================================================================
+:mod:`!types` --- Dynamic type creation and names for built-in types
+====================================================================
 
 .. module:: types
    :synopsis: Names for built-in types.

--- a/Doc/library/unicodedata.rst
+++ b/Doc/library/unicodedata.rst
@@ -1,5 +1,5 @@
-:mod:`unicodedata` --- Unicode Database
-=======================================
+:mod:`!unicodedata` --- Unicode Database
+========================================
 
 .. module:: unicodedata
    :synopsis: Access the Unicode Database.

--- a/Doc/library/unittest.mock-examples.rst
+++ b/Doc/library/unittest.mock-examples.rst
@@ -1,5 +1,5 @@
-:mod:`unittest.mock` --- getting started
-========================================
+:mod:`!unittest.mock` --- getting started
+=========================================
 
 .. moduleauthor:: Michael Foord <michael@python.org>
 .. currentmodule:: unittest.mock

--- a/Doc/library/unittest.mock.rst
+++ b/Doc/library/unittest.mock.rst
@@ -1,6 +1,5 @@
-
-:mod:`unittest.mock` --- mock object library
-============================================
+:mod:`!unittest.mock` --- mock object library
+=============================================
 
 .. module:: unittest.mock
    :synopsis: Mock object library.

--- a/Doc/library/unittest.rst
+++ b/Doc/library/unittest.rst
@@ -1,5 +1,5 @@
-:mod:`unittest` --- Unit testing framework
-==========================================
+:mod:`!unittest` --- Unit testing framework
+===========================================
 
 .. module:: unittest
    :synopsis: Unit testing framework for Python.

--- a/Doc/library/urllib.error.rst
+++ b/Doc/library/urllib.error.rst
@@ -1,5 +1,5 @@
-:mod:`urllib.error` --- Exception classes raised by urllib.request
-==================================================================
+:mod:`!urllib.error` --- Exception classes raised by urllib.request
+===================================================================
 
 .. module:: urllib.error
    :synopsis: Exception classes raised by urllib.request.

--- a/Doc/library/urllib.parse.rst
+++ b/Doc/library/urllib.parse.rst
@@ -1,5 +1,5 @@
-:mod:`urllib.parse` --- Parse URLs into components
-==================================================
+:mod:`!urllib.parse` --- Parse URLs into components
+===================================================
 
 .. module:: urllib.parse
    :synopsis: Parse URLs into or assemble them from components.

--- a/Doc/library/urllib.request.rst
+++ b/Doc/library/urllib.request.rst
@@ -1,5 +1,5 @@
-:mod:`urllib.request` --- Extensible library for opening URLs
-=============================================================
+:mod:`!urllib.request` --- Extensible library for opening URLs
+==============================================================
 
 .. module:: urllib.request
    :synopsis: Extensible library for opening URLs.

--- a/Doc/library/urllib.robotparser.rst
+++ b/Doc/library/urllib.robotparser.rst
@@ -1,5 +1,5 @@
-:mod:`urllib.robotparser` ---  Parser for robots.txt
-====================================================
+:mod:`!urllib.robotparser` ---  Parser for robots.txt
+=====================================================
 
 .. module:: urllib.robotparser
    :synopsis: Load a robots.txt file and answer questions about

--- a/Doc/library/urllib.rst
+++ b/Doc/library/urllib.rst
@@ -1,5 +1,5 @@
-:mod:`urllib` --- URL handling modules
-======================================
+:mod:`!urllib` --- URL handling modules
+=======================================
 
 .. module:: urllib
 

--- a/Doc/library/uuid.rst
+++ b/Doc/library/uuid.rst
@@ -1,5 +1,5 @@
-:mod:`uuid` --- UUID objects according to :rfc:`4122`
-=====================================================
+:mod:`!uuid` --- UUID objects according to :rfc:`4122`
+======================================================
 
 .. module:: uuid
    :synopsis: UUID objects (universally unique identifiers) according to RFC 4122

--- a/Doc/library/venv.rst
+++ b/Doc/library/venv.rst
@@ -1,5 +1,5 @@
-:mod:`venv` --- Creation of virtual environments
-================================================
+:mod:`!venv` --- Creation of virtual environments
+=================================================
 
 .. module:: venv
    :synopsis: Creation of virtual environments.

--- a/Doc/library/warnings.rst
+++ b/Doc/library/warnings.rst
@@ -1,5 +1,5 @@
-:mod:`warnings` --- Warning control
-===================================
+:mod:`!warnings` --- Warning control
+====================================
 
 .. module:: warnings
    :synopsis: Issue warning messages and control their disposition.

--- a/Doc/library/wave.rst
+++ b/Doc/library/wave.rst
@@ -1,5 +1,5 @@
-:mod:`wave` --- Read and write WAV files
-========================================
+:mod:`!wave` --- Read and write WAV files
+=========================================
 
 .. module:: wave
    :synopsis: Provide an interface to the WAV sound format.

--- a/Doc/library/webbrowser.rst
+++ b/Doc/library/webbrowser.rst
@@ -1,5 +1,5 @@
-:mod:`webbrowser` --- Convenient web-browser controller
-=======================================================
+:mod:`!webbrowser` --- Convenient web-browser controller
+========================================================
 
 .. module:: webbrowser
    :synopsis: Easy-to-use controller for web browsers.

--- a/Doc/library/winreg.rst
+++ b/Doc/library/winreg.rst
@@ -1,5 +1,5 @@
-:mod:`winreg` --- Windows registry access
-=========================================
+:mod:`!winreg` --- Windows registry access
+==========================================
 
 .. module:: winreg
    :platform: Windows

--- a/Doc/library/winsound.rst
+++ b/Doc/library/winsound.rst
@@ -1,5 +1,5 @@
-:mod:`winsound` --- Sound-playing interface for Windows
-=======================================================
+:mod:`!winsound` --- Sound-playing interface for Windows
+========================================================
 
 .. module:: winsound
    :platform: Windows

--- a/Doc/library/wsgiref.rst
+++ b/Doc/library/wsgiref.rst
@@ -1,5 +1,5 @@
-:mod:`wsgiref` --- WSGI Utilities and Reference Implementation
-==============================================================
+:mod:`!wsgiref` --- WSGI Utilities and Reference Implementation
+===============================================================
 
 .. module:: wsgiref
    :synopsis: WSGI Utilities and Reference Implementation.

--- a/Doc/library/xml.dom.minidom.rst
+++ b/Doc/library/xml.dom.minidom.rst
@@ -1,5 +1,5 @@
-:mod:`xml.dom.minidom` --- Minimal DOM implementation
-=====================================================
+:mod:`!xml.dom.minidom` --- Minimal DOM implementation
+======================================================
 
 .. module:: xml.dom.minidom
    :synopsis: Minimal Document Object Model (DOM) implementation.

--- a/Doc/library/xml.dom.pulldom.rst
+++ b/Doc/library/xml.dom.pulldom.rst
@@ -1,5 +1,5 @@
-:mod:`xml.dom.pulldom` --- Support for building partial DOM trees
-=================================================================
+:mod:`!xml.dom.pulldom` --- Support for building partial DOM trees
+==================================================================
 
 .. module:: xml.dom.pulldom
    :synopsis: Support for building partial DOM trees from SAX events.

--- a/Doc/library/xml.dom.rst
+++ b/Doc/library/xml.dom.rst
@@ -1,5 +1,5 @@
-:mod:`xml.dom` --- The Document Object Model API
-================================================
+:mod:`!xml.dom` --- The Document Object Model API
+=================================================
 
 .. module:: xml.dom
    :synopsis: Document Object Model API for Python.

--- a/Doc/library/xml.etree.elementtree.rst
+++ b/Doc/library/xml.etree.elementtree.rst
@@ -1,5 +1,5 @@
-:mod:`xml.etree.ElementTree` --- The ElementTree XML API
-========================================================
+:mod:`!xml.etree.ElementTree` --- The ElementTree XML API
+=========================================================
 
 .. module:: xml.etree.ElementTree
    :synopsis: Implementation of the ElementTree API.

--- a/Doc/library/xml.sax.handler.rst
+++ b/Doc/library/xml.sax.handler.rst
@@ -1,5 +1,5 @@
-:mod:`xml.sax.handler` --- Base classes for SAX handlers
-========================================================
+:mod:`!xml.sax.handler` --- Base classes for SAX handlers
+=========================================================
 
 .. module:: xml.sax.handler
    :synopsis: Base classes for SAX event handlers.

--- a/Doc/library/xml.sax.reader.rst
+++ b/Doc/library/xml.sax.reader.rst
@@ -1,5 +1,5 @@
-:mod:`xml.sax.xmlreader` --- Interface for XML parsers
-======================================================
+:mod:`!xml.sax.xmlreader` --- Interface for XML parsers
+=======================================================
 
 .. module:: xml.sax.xmlreader
    :synopsis: Interface which SAX-compliant XML parsers must implement.

--- a/Doc/library/xml.sax.rst
+++ b/Doc/library/xml.sax.rst
@@ -1,5 +1,5 @@
-:mod:`xml.sax` --- Support for SAX2 parsers
-===========================================
+:mod:`!xml.sax` --- Support for SAX2 parsers
+============================================
 
 .. module:: xml.sax
    :synopsis: Package containing SAX2 base classes and convenience functions.

--- a/Doc/library/xml.sax.utils.rst
+++ b/Doc/library/xml.sax.utils.rst
@@ -1,5 +1,5 @@
-:mod:`xml.sax.saxutils` --- SAX Utilities
-=========================================
+:mod:`!xml.sax.saxutils` --- SAX Utilities
+==========================================
 
 .. module:: xml.sax.saxutils
    :synopsis: Convenience functions and classes for use with SAX.

--- a/Doc/library/xmlrpc.client.rst
+++ b/Doc/library/xmlrpc.client.rst
@@ -1,5 +1,5 @@
-:mod:`xmlrpc.client` --- XML-RPC client access
-==============================================
+:mod:`!xmlrpc.client` --- XML-RPC client access
+===============================================
 
 .. module:: xmlrpc.client
    :synopsis: XML-RPC client access.

--- a/Doc/library/xmlrpc.server.rst
+++ b/Doc/library/xmlrpc.server.rst
@@ -1,5 +1,5 @@
-:mod:`xmlrpc.server` --- Basic XML-RPC servers
-==============================================
+:mod:`!xmlrpc.server` --- Basic XML-RPC servers
+===============================================
 
 .. module:: xmlrpc.server
    :synopsis: Basic XML-RPC server implementations.

--- a/Doc/library/zipapp.rst
+++ b/Doc/library/zipapp.rst
@@ -1,5 +1,5 @@
-:mod:`zipapp` --- Manage executable Python zip archives
-=======================================================
+:mod:`!zipapp` --- Manage executable Python zip archives
+========================================================
 
 .. module:: zipapp
    :synopsis: Manage executable Python zip archives

--- a/Doc/library/zipfile.rst
+++ b/Doc/library/zipfile.rst
@@ -1,5 +1,5 @@
-:mod:`zipfile` --- Work with ZIP archives
-=========================================
+:mod:`!zipfile` --- Work with ZIP archives
+==========================================
 
 .. module:: zipfile
    :synopsis: Read and write ZIP-format archive files.

--- a/Doc/library/zipimport.rst
+++ b/Doc/library/zipimport.rst
@@ -1,5 +1,5 @@
-:mod:`zipimport` --- Import modules from Zip archives
-=====================================================
+:mod:`!zipimport` --- Import modules from Zip archives
+======================================================
 
 .. module:: zipimport
    :synopsis: Support for importing Python modules from ZIP archives.

--- a/Doc/library/zlib.rst
+++ b/Doc/library/zlib.rst
@@ -1,5 +1,5 @@
-:mod:`zlib` --- Compression compatible with :program:`gzip`
-===========================================================
+:mod:`!zlib` --- Compression compatible with :program:`gzip`
+============================================================
 
 .. module:: zlib
    :synopsis: Low-level interface to compression and decompression routines

--- a/Doc/library/zoneinfo.rst
+++ b/Doc/library/zoneinfo.rst
@@ -1,5 +1,5 @@
-:mod:`zoneinfo` --- IANA time zone support
-==========================================
+:mod:`!zoneinfo` --- IANA time zone support
+===========================================
 
 .. module:: zoneinfo
     :synopsis: IANA time zone support


### PR DESCRIPTION
The `:mod:` role used in the title of module pages turns into a link, but the link is to the same page.  That's distracting and unhelpful.  This uses the `!` prefix to instruct Sphinx to not make a link.

This was done with this thrown-together program:
```py
"""
Change every module page in the CPython docs 
so that the title doesn't link to itself.
"""

from pathlib import Path

# Edge cases:
# - modules with a blank line at the top.
# - modules that already had the !-prefix to suppress the link.
# - had to fix the rule length
# - pages that started with a link, but to the main module page.
#       unittest.mock-examples.rst
# - pages with slightly off names:
#       xml.sax.xmlreader is in xml.sax.reader.rst
#       xml.etree.ElementTree is in xml.etree.elementtree.rst
#       xml.parsers.expat is in pyexpat.rst
#       xml.sax.saxutils is in xml.sax.utils.rst
# - pages with two links in the title!
#       copyreg.rst

def fix_one_file(fpath):
    text = fpath.read_text().lstrip()
    if not text.startswith(":mod:`"):
        return
    if text.startswith(":mod:`!"):
        return
    lines = text.splitlines(keepends=True)
    modname = lines[0].split("`")[1]
    if modname != fpath.stem:
        print(f"WUT: {modname=}, {fpath.stem=}")
    lines[0] = lines[0].replace(":mod:`", ":mod:`!")
    lines[1] = lines[1][0] * (len(lines[0]) - 1) + "\n"
    fpath.write_text("".join(lines))
    print(f"Updated {fpath}")

for fname in Path(".").glob("**/*.rst"):
    fix_one_file(fname)
```

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--117099.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->