### PR TITLE
gh-116869: Enable -Werror in test_cext for Free Threading

### DIFF
--- a/Lib/test/test_cext/setup.py
+++ b/Lib/test/test_cext/setup.py
@@ -11,17 +11,19 @@ from setuptools import setup, Extension
 
 
 SOURCE = 'extension.c'
-if not support.MS_WINDOWS and not support.Py_GIL_DISABLED:
+if not support.MS_WINDOWS:
     # C compiler flags for GCC and clang
     CFLAGS = [
         # The purpose of test_cext extension is to check that building a C
         # extension using the Python C API does not emit C compiler warnings.
         '-Werror',
-
-        # gh-116869: The Python C API must be compatible with building
-        # with the -Werror=declaration-after-statement compiler flag.
-        '-Werror=declaration-after-statement',
     ]
+    if not support.Py_GIL_DISABLED:
+        CFLAGS.append(
+            # gh-116869: The Python C API must be compatible with building
+            # with the -Werror=declaration-after-statement compiler flag.
+            '-Werror=declaration-after-statement',
+        )
 else:
     # Don't pass any compiler flag to MSVC
     CFLAGS = []


### PR DESCRIPTION
Check for warnings, but don't enable the compiler flag -Werror=declaration-after-statement.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-116869 -->
* Issue: gh-116869
<!-- /gh-issue-number -->
