### PR TITLE
[3.12] Remove more stray backticks from NEWS files (GH-115374)

### DIFF
--- a/Misc/NEWS.d/3.12.0a1.rst
+++ b/Misc/NEWS.d/3.12.0a1.rst
@@ -2722,7 +2722,7 @@ on future on an error - e.g. TimeoutError or KeyboardInterrupt.
 Fix a :mod:`sqlite3` regression where ``*args`` and ``**kwds`` were
 incorrectly relayed from :py:func:`~sqlite3.connect` to the
 :class:`~sqlite3.Connection` factory. The regression was introduced in
-3.11a1 with PR 24421 (:gh:`85128`). Patch by Erlend E. Aasland.`
+3.11a1 with PR 24421 (:gh:`85128`). Patch by Erlend E. Aasland.
 
 ..
 
@@ -2988,7 +2988,7 @@ Kumar Aditya.
 .. section: Library
 
 Fix crash in :class:`struct.Struct` when it was not completely initialized
-by initializing it in :meth:`~object.__new__``.  Patch by Kumar Aditya.
+by initializing it in :meth:`~object.__new__`.  Patch by Kumar Aditya.
 
 ..
 

--- a/Misc/NEWS.d/3.12.0b1.rst
+++ b/Misc/NEWS.d/3.12.0b1.rst
@@ -563,10 +563,10 @@ Complex function calls are now faster and consume no C stack space.
 .. nonce: fvgsCl
 .. section: Core and Builtins
 
-``len()`` for 0-dimensional :class:`memoryview`` objects (such as
+``len()`` for 0-dimensional :class:`memoryview` objects (such as
 ``memoryview(ctypes.c_uint8(42))``) now raises a :exc:`TypeError`.
 Previously this returned ``1``, which was not consistent with ``mem_0d[0]``
-raising an :exc:`IndexError``.
+raising an :exc:`IndexError`.
 
 ..
 


### PR DESCRIPTION
* Remove stray backtick from NEWS file

* Remove more stray backticks from 3.12.0a1.rst

* Remove another stray backtick in 3.13.0a1.rst (cherry picked from commit 02b63239f1e91f8a03c0b455c5201e6d07f642ab)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

The conflict was:

```
➤ Changes to be committed
#
#       modified:  [1] Misc/NEWS.d/3.12.0a1.rst
#       modified:  [2] Misc/NEWS.d/3.12.0b1.rst
#
➤ Unmerged paths
#
#       deleted by us:  [3] Misc/NEWS.d/3.13.0a1.rst
#
```

Resolved with `git rm Misc/NEWS.d/3.13.0a1.rst`.
