### PR TITLE
gh-117127: glob tests: Reopen dir_fd to pick up directory changes

### DIFF
--- a/Lib/test/test_glob.py
+++ b/Lib/test/test_glob.py
@@ -41,6 +41,11 @@ class GlobTests(unittest.TestCase):
             os.symlink(self.norm('broken'), self.norm('sym1'))
             os.symlink('broken', self.norm('sym2'))
             os.symlink(os.path.join('a', 'bcd'), self.norm('sym3'))
+        self.open_dirfd()
+
+    def open_dirfd(self):
+        if self.dir_fd is not None:
+            os.close(self.dir_fd)
         if {os.open, os.stat} <= os.supports_dir_fd and os.scandir in os.supports_fd:
             self.dir_fd = os.open(self.tempdir, os.O_RDONLY | os.O_DIRECTORY)
         else:
@@ -350,6 +355,10 @@ class GlobTests(unittest.TestCase):
     def test_glob_named_pipe(self):
         path = os.path.join(self.tempdir, 'mypipe')
         os.mkfifo(path)
+
+        # gh-117127: Reopen self.dir_fd to pick up directory changes
+        self.open_dirfd()
+
         self.assertEqual(self.rglob('mypipe'), [path])
         self.assertEqual(self.rglob('mypipe*'), [path])
         self.assertEqual(self.rglob('mypipe', ''), [])


### PR DESCRIPTION
This fixes the issue for me, but I might be missing context

cc @serhiy-storchaka, who added the test
cc @barneygale -- I think I recall you talking about optimizing globs; this might be interesting to you?

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-117127 -->
* Issue: gh-117127
<!-- /gh-issue-number -->
