### PR TITLE
seticon.m : Add [NSImage alloc] initWithContentsOfFile to the autorelease pool.

### DIFF
--- a/Mac/BuildScript/seticon.m
+++ b/Mac/BuildScript/seticon.m
@@ -18,7 +18,7 @@ int main(int argc, char** argv)
 	[NSApplication sharedApplication];
 
 	[[NSWorkspace sharedWorkspace]
-		setIcon: [[NSImage alloc] initWithContentsOfFile: iconPath]
+		setIcon: [[[NSImage alloc] initWithContentsOfFile: iconPath] autorelease]
 		forFile: filePath
 		options: 0];
 	[pool release];


### PR DESCRIPTION
initWithContentsOfFile does not add the NSImage to the release pool when it should.