### PR TITLE
gh-105716: Fix _PyInterpreterState_IsRunningMain() For Embedders

### DIFF
--- a/Python/frozenmain.c
+++ b/Python/frozenmain.c
@@ -54,6 +54,12 @@ Py_FrozenMain(int argc, char **argv)
         Py_ExitStatusException(status);
     }
 
+    PyInterpreterState *interp = PyInterpreterState_Get();
+    if (_PyInterpreterState_SetRunningMain(interp) < 0) {
+        PyErr_Print();
+        exit(1);
+    }
+
 #ifdef MS_WINDOWS
     PyWinFreeze_ExeInit();
 #endif
@@ -83,6 +89,9 @@ Py_FrozenMain(int argc, char **argv)
 #ifdef MS_WINDOWS
     PyWinFreeze_ExeTerm();
 #endif
+
+    _PyInterpreterState_SetNotRunningMain(interp);
+
     if (Py_FinalizeEx() < 0) {
         sts = 120;
     }

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -1042,10 +1042,12 @@ _PyInterpreterState_IsRunningMain(PyInterpreterState *interp)
     if (interp->threads.main != NULL) {
         return 1;
     }
-    // For now, we assume the main interpreter is always running.
-    if (_Py_IsMainInterpreter(interp)) {
-        return 1;
-    }
+    // Embedders might not know to call _PyInterpreterState_SetRunningMain(),
+    // so their main thread wouldn't show it is running the main interpreter's
+    // program.  (Py_Main() doesn't have this problem.)  For now this isn't
+    // critical.  If it were, we would need to infer "running main" from other
+    // information, like if it's the main interpreter.  We used to do that
+    // but the naive approach led to some inconsistencies that caused problems.
     return 0;
 }
 
@@ -1067,9 +1069,8 @@ _PyThreadState_IsRunningMain(PyThreadState *tstate)
     if (interp->threads.main != NULL) {
         return tstate == interp->threads.main;
     }
-    if (_Py_IsMainInterpreter(interp)) {
-        return tstate->thread_id == interp->runtime->main_thread;
-    }
+    // See the note in _PyInterpreterState_IsRunningMain() about
+    // possible false negatives here for embedders.
     return 0;
 }
 

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -1051,17 +1051,6 @@ _PyInterpreterState_IsRunningMain(PyInterpreterState *interp)
     return 0;
 }
 
-#ifndef NDEBUG
-static int
-is_running_main(PyThreadState *tstate)
-{
-    if (tstate->interp->threads.main != NULL) {
-        return tstate == tstate->interp->threads.main;
-    }
-    return 0;
-}
-#endif
-
 int
 _PyThreadState_IsRunningMain(PyThreadState *tstate)
 {
@@ -1572,7 +1561,7 @@ PyThreadState_Clear(PyThreadState *tstate)
 {
     assert(tstate->_status.initialized && !tstate->_status.cleared);
     assert(current_fast_get()->interp == tstate->interp);
-    assert(!is_running_main(tstate));
+    assert(!_PyThreadState_IsRunningMain(tstate));
     // XXX assert(!tstate->_status.bound || tstate->_status.unbound);
     tstate->_status.finalizing = 1;  // just in case
 
@@ -1671,7 +1660,7 @@ tstate_delete_common(PyThreadState *tstate)
     assert(tstate->_status.cleared && !tstate->_status.finalized);
     assert(tstate->state != _Py_THREAD_ATTACHED);
     tstate_verify_not_active(tstate);
-    assert(!is_running_main(tstate));
+    assert(!_PyThreadState_IsRunningMain(tstate));
 
     PyInterpreterState *interp = tstate->interp;
     if (interp == NULL) {


### PR DESCRIPTION
When I added `_PyInterpreterState_IsRunningMain()` and friends last year, I tried to accommodate applications that embed Python but don't call `_PyInterpreterState_SetRunningMain()` (not that they're expected to).  That mostly worked fine until my recent changes in gh-117049, where the subtleties with the fallback code led to failures; the change ended up breaking test_tools.test_freeze, which exercises a basic embedding situation.

The simplest fix is to drop the fallback code I originally added to `_PyInterpreterState_IsRunningMain()` (and later to `_PyThreadState_IsRunningMain()`).  I've kept the fallback in the _xxsubinterpreters module though.  I've also updated `Py_FrozenMain()` to call `_PyInterpreterState_SetRunningMain()`.

<!-- gh-issue-number: gh-105716 -->
* Issue: gh-105716
<!-- /gh-issue-number -->
