### PR TITLE
gh-117146: Expose/document warnings.WarningMessage

### DIFF
--- a/Doc/library/warnings.rst
+++ b/Doc/library/warnings.rst
@@ -581,10 +581,9 @@ Available Context Managers
     and the :func:`showwarning` function.
     If the *record* argument is :const:`False` (the default) the context manager
     returns :class:`None` on entry. If *record* is :const:`True`, a list is
-    returned that is progressively populated with objects as seen by a custom
-    :func:`showwarning` function (which also suppresses output to ``sys.stdout``).
-    Each object in the list has attributes with the same names as the arguments to
-    :func:`showwarning`.
+    returned that is progressively populated with :class:`WarningMessage` objects
+    as seen by a custom :func:`showwarning` function (which also suppresses output
+    to ``sys.stdout``).
 
     The *module* argument takes a module that will be used instead of the
     module returned when you import :mod:`warnings` whose filter will be
@@ -606,3 +605,15 @@ Available Context Managers
     .. versionchanged:: 3.11
 
         Added the *action*, *category*, *lineno*, and *append* parameters.
+
+:class:`WarningMessage` Objects
+-------------------------------
+
+A :class:`WarningMessage` object represents a warning along with information about it's emission. It
+is primarily used by :class:`catch_warnings` with *record* set to :const:`True` to record warnings.
+
+.. class:: WarningMessage(message, category, filename, lineno, file=None, line=None, source=None)
+
+   The *message*, *category*, *filename*, *lineno*, *file*, *line*, have the same meaning as they
+   have in :func:`showwarning`. *source* is optionally given to indicate the destroyed object which
+   emitted a :exc:`ResourceWarning`.

--- a/Doc/library/warnings.rst
+++ b/Doc/library/warnings.rst
@@ -614,6 +614,6 @@ is primarily used by :class:`catch_warnings` with *record* set to :const:`True` 
 
 .. class:: WarningMessage(message, category, filename, lineno, file=None, line=None, source=None)
 
-   The *message*, *category*, *filename*, *lineno*, *file*, *line*, have the same meaning as they
-   have in :func:`showwarning`. *source* is optionally given to indicate the destroyed object which
+   *message*, *category*, *filename*, *lineno*, *file* and *line* have the same meaning as
+   in :func:`showwarning`. *source* is optionally given to indicate the destroyed object which
    emitted a :exc:`ResourceWarning`.

--- a/Doc/library/warnings.rst
+++ b/Doc/library/warnings.rst
@@ -609,7 +609,7 @@ Available Context Managers
 :class:`WarningMessage` Objects
 -------------------------------
 
-A :class:`WarningMessage` object represents a warning along with information about it's emission. It
+A :class:`WarningMessage` object represents a warning along with information about its emission. It
 is primarily used by :class:`catch_warnings` with *record* set to :const:`True` to record warnings.
 
 .. class:: WarningMessage(message, category, filename, lineno, file=None, line=None, source=None)

--- a/Lib/test/test_warnings/__init__.py
+++ b/Lib/test/test_warnings/__init__.py
@@ -93,7 +93,8 @@ class PublicAPITests(BaseTest):
         self.assertTrue(hasattr(self.module, '__all__'))
         target_api = ["warn", "warn_explicit", "showwarning",
                       "formatwarning", "filterwarnings", "simplefilter",
-                      "resetwarnings", "catch_warnings", "deprecated"]
+                      "resetwarnings", "catch_warnings", "deprecated",
+                      "WarningMessage"]
         self.assertSetEqual(set(self.module.__all__),
                             set(target_api))
 

--- a/Lib/warnings.py
+++ b/Lib/warnings.py
@@ -5,7 +5,8 @@ import sys
 
 __all__ = ["warn", "warn_explicit", "showwarning",
            "formatwarning", "filterwarnings", "simplefilter",
-           "resetwarnings", "catch_warnings", "deprecated"]
+           "resetwarnings", "catch_warnings", "deprecated",
+           "WarningMessage"]
 
 def showwarning(message, category, filename, lineno, file=None, line=None):
     """Hook to write a warning to a file; replace if you like."""

--- a/Misc/NEWS.d/next/Documentation/2024-03-22-03-45-21.gh-issue-117146.--QGtr.rst
+++ b/Misc/NEWS.d/next/Documentation/2024-03-22-03-45-21.gh-issue-117146.--QGtr.rst
@@ -1,1 +1,1 @@
-Expose and document `warnings.WarningMessage`
+Expose and document :class:`warnings.WarningMessage`.

--- a/Misc/NEWS.d/next/Documentation/2024-03-22-03-45-21.gh-issue-117146.--QGtr.rst
+++ b/Misc/NEWS.d/next/Documentation/2024-03-22-03-45-21.gh-issue-117146.--QGtr.rst
@@ -1,0 +1,1 @@
+Expose and document `warnings.WarningMessage`


### PR DESCRIPTION
# gh-117146: Expose/document warnings.WarningMessage

This change exposes `warnings.WarningMessage` as it is already returned by a public facing function: `catch_warnings`. Mention it in the docs and add it to `__all__`


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--117147.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->