### PR TITLE
gh-112383: teach dis how to interpret ENTER_EXECUTOR

### DIFF
--- a/Lib/dis.py
+++ b/Lib/dis.py
@@ -204,8 +204,27 @@ def _deoptop(op):
     name = _all_opname[op]
     return _all_opmap[deoptmap[name]] if name in deoptmap else op
 
+import _testinternalcapi
 def _get_code_array(co, adaptive):
-    return co._co_code_adaptive if adaptive else co.co_code
+    if adaptive:
+        code = co._co_code_adaptive
+        res = []
+        found = False
+        for i in range(0, len(code), 2):
+            op, arg = code[i], code[i+1]
+            if op == ENTER_EXECUTOR:
+                try:
+                    ex = _testinternalcapi.get_executor(co, i)
+                except ValueError:
+                    ex = None
+                if ex:
+                    op, arg = ex.get_opcode(), ex.get_oparg()
+                    found = True
+            res.append(op.to_bytes())
+            res.append(arg.to_bytes())
+        return code if not found else b''.join(res)
+    else:
+        return co.co_code
 
 def code_info(x):
     """Formatted details of methods, functions, or code."""
@@ -514,8 +533,6 @@ class ArgResolver:
             argval = offset + 2 + signed_arg*2
             caches = _get_cache_size(_all_opname[deop])
             argval += 2 * caches
-            if deop == ENTER_EXECUTOR:
-                argval += 2
             return argval
         return None
 
@@ -680,8 +697,7 @@ def _parse_exception_table(code):
 
 def _is_backward_jump(op):
     return opname[op] in ('JUMP_BACKWARD',
-                          'JUMP_BACKWARD_NO_INTERRUPT',
-                          'ENTER_EXECUTOR')
+                          'JUMP_BACKWARD_NO_INTERRUPT')
 
 def _get_instructions_bytes(code, linestarts=None, line_offset=0, co_positions=None,
                             original_code=None, arg_resolver=None):

--- a/Lib/dis.py
+++ b/Lib/dis.py
@@ -17,6 +17,8 @@ from opcode import (
     _specialized_opmap,
 )
 
+from _opcode import get_executor
+
 __all__ = ["code_info", "dis", "disassemble", "distb", "disco",
            "findlinestarts", "findlabels", "show_code",
            "get_instructions", "Instruction", "Bytecode"] + _opcodes_all
@@ -204,7 +206,6 @@ def _deoptop(op):
     name = _all_opname[op]
     return _all_opmap[deoptmap[name]] if name in deoptmap else op
 
-import _testinternalcapi
 def _get_code_array(co, adaptive):
     if adaptive:
         code = co._co_code_adaptive
@@ -214,12 +215,14 @@ def _get_code_array(co, adaptive):
             op, arg = code[i], code[i+1]
             if op == ENTER_EXECUTOR:
                 try:
-                    ex = _testinternalcapi.get_executor(co, i)
+                    ex = get_executor(co, i)
                 except ValueError:
                     ex = None
+
                 if ex:
                     op, arg = ex.get_opcode(), ex.get_oparg()
                     found = True
+
             res.append(op.to_bytes())
             res.append(arg.to_bytes())
         return code if not found else b''.join(res)

--- a/Lib/test/test_capi/test_opt.py
+++ b/Lib/test/test_capi/test_opt.py
@@ -6,6 +6,7 @@ import unittest
 import gc
 import os
 
+import _opcode
 import _testinternalcapi
 
 from test.support import script_helper, requires_specialization
@@ -115,13 +116,11 @@ class TestOptimizerAPI(unittest.TestCase):
 def get_first_executor(func):
     code = func.__code__
     co_code = code.co_code
-    JUMP_BACKWARD = opcode.opmap["JUMP_BACKWARD"]
     for i in range(0, len(co_code), 2):
-        if co_code[i] == JUMP_BACKWARD:
-            try:
-                return _testinternalcapi.get_executor(code, i)
-            except ValueError:
-                pass
+        try:
+            return _opcode.get_executor(code, i)
+        except ValueError:
+            pass
     return None
 
 
@@ -760,17 +759,16 @@ class TestUopsOptimization(unittest.TestCase):
         result = script_helper.run_python_until_end('-c', textwrap.dedent("""
         import _testinternalcapi
         import opcode
+        import _opcode
 
         def get_first_executor(func):
             code = func.__code__
             co_code = code.co_code
-            JUMP_BACKWARD = opcode.opmap["JUMP_BACKWARD"]
             for i in range(0, len(co_code), 2):
-                if co_code[i] == JUMP_BACKWARD:
-                    try:
-                        return _testinternalcapi.get_executor(code, i)
-                    except ValueError:
-                        pass
+                try:
+                    return _opcode.get_executor(code, i)
+                except ValueError:
+                    pass
             return None
 
         def get_opnames(ex):

--- a/Lib/test/test_capi/test_opt.py
+++ b/Lib/test/test_capi/test_opt.py
@@ -1,5 +1,4 @@
 import contextlib
-import opcode
 import sys
 import textwrap
 import unittest

--- a/Lib/test/test_dis.py
+++ b/Lib/test/test_dis.py
@@ -1201,19 +1201,10 @@ class DisTests(DisTestBase):
     @cpython_only
     @requires_specialization
     def test_loop_quicken(self):
-        import _testinternalcapi
         # Loop can trigger a quicken where the loop is located
-        self.code_quicken(loop_test, 1)
+        self.code_quicken(loop_test, 4)
         got = self.get_disassembly(loop_test, adaptive=True)
         expected = dis_loop_test_quickened_code
-        if _testinternalcapi.get_optimizer():
-            # We *may* see ENTER_EXECUTOR in the disassembly. This is a
-            # temporary hack to keep the test working until dis is able to
-            # handle the instruction correctly (GH-112383):
-            got = got.replace(
-                "ENTER_EXECUTOR          16",
-                "JUMP_BACKWARD           16 (to L1)",
-            )
         self.do_disassembly_compare(got, expected)
 
     @cpython_only

--- a/Misc/NEWS.d/next/Library/2024-03-23-13-40-13.gh-issue-112383.XuHf3G.rst
+++ b/Misc/NEWS.d/next/Library/2024-03-23-13-40-13.gh-issue-112383.XuHf3G.rst
@@ -1,0 +1,1 @@
+Fix :mod:`dis` module's handling of `ENTER_EXECUTOR` instructions.

--- a/Misc/NEWS.d/next/Library/2024-03-23-13-40-13.gh-issue-112383.XuHf3G.rst
+++ b/Misc/NEWS.d/next/Library/2024-03-23-13-40-13.gh-issue-112383.XuHf3G.rst
@@ -1,1 +1,1 @@
-Fix :mod:`dis` module's handling of `ENTER_EXECUTOR` instructions.
+Fix :mod:`dis` module's handling of ``ENTER_EXECUTOR`` instructions.

--- a/Modules/_opcode.c
+++ b/Modules/_opcode.c
@@ -362,7 +362,9 @@ _opcode_get_executor_impl(PyObject *module, PyObject *code, int offset)
 /*[clinic end generated code: output=c035c7a47b16648f input=85eff93ea7aac282]*/
 {
     if (!PyCode_Check(code)) {
-         PyErr_SetString(PyExc_TypeError, "first argument must be a code object");
+        PyErr_Format(PyExc_TypeError,
+                     "expected a code object, not '%.100s'",
+                     Py_TYPE(code)->tp_name);
         return NULL;
     }
     return (PyObject *)PyUnstable_GetExecutor((PyCodeObject *)code, offset);

--- a/Modules/_opcode.c
+++ b/Modules/_opcode.c
@@ -347,6 +347,26 @@ _opcode_get_intrinsic2_descs_impl(PyObject *module)
     return list;
 }
 
+/*[clinic input]
+
+_opcode.get_executor
+
+  code: object
+  offset: int
+
+Return the executor object at offset in code if exists, None otherwise.
+[clinic start generated code]*/
+
+static PyObject *
+_opcode_get_executor_impl(PyObject *module, PyObject *code, int offset)
+/*[clinic end generated code: output=c035c7a47b16648f input=85eff93ea7aac282]*/
+{
+    if (!PyCode_Check(code)) {
+         PyErr_SetString(PyExc_TypeError, "first argument must be a code object");
+        return NULL;
+    }
+    return (PyObject *)PyUnstable_GetExecutor((PyCodeObject *)code, offset);
+}
 
 static PyMethodDef
 opcode_functions[] =  {
@@ -363,6 +383,7 @@ opcode_functions[] =  {
     _OPCODE_GET_NB_OPS_METHODDEF
     _OPCODE_GET_INTRINSIC1_DESCS_METHODDEF
     _OPCODE_GET_INTRINSIC2_DESCS_METHODDEF
+    _OPCODE_GET_EXECUTOR_METHODDEF
     {NULL, NULL, 0, NULL}
 };
 

--- a/Modules/_testinternalcapi.c
+++ b/Modules/_testinternalcapi.c
@@ -992,26 +992,6 @@ get_optimizer(PyObject *self, PyObject *Py_UNUSED(ignored))
 }
 
 static PyObject *
-get_executor(PyObject *self, PyObject *const *args, Py_ssize_t nargs)
-{
-
-    if (!_PyArg_CheckPositional("get_executor", nargs, 2, 2)) {
-        return NULL;
-    }
-    PyObject *code = args[0];
-    PyObject *offset = args[1];
-    long ioffset = PyLong_AsLong(offset);
-    if (ioffset == -1 && PyErr_Occurred()) {
-        return NULL;
-    }
-    if (!PyCode_Check(code)) {
-         PyErr_SetString(PyExc_TypeError, "first argument must be a code object");
-        return NULL;
-    }
-    return (PyObject *)PyUnstable_GetExecutor((PyCodeObject *)code, ioffset);
-}
-
-static PyObject *
 add_executor_dependency(PyObject *self, PyObject *args)
 {
     PyObject *exec;
@@ -1836,7 +1816,6 @@ static PyMethodDef module_functions[] = {
     {"iframe_getlasti", iframe_getlasti, METH_O, NULL},
     {"get_optimizer", get_optimizer,  METH_NOARGS, NULL},
     {"set_optimizer", set_optimizer,  METH_O, NULL},
-    {"get_executor", _PyCFunction_CAST(get_executor),  METH_FASTCALL, NULL},
     {"new_counter_optimizer", new_counter_optimizer, METH_NOARGS, NULL},
     {"new_uop_optimizer", new_uop_optimizer, METH_NOARGS, NULL},
     {"add_executor_dependency", add_executor_dependency, METH_VARARGS, NULL},

--- a/Modules/clinic/_opcode.c.h
+++ b/Modules/clinic/_opcode.c.h
@@ -668,4 +668,64 @@ _opcode_get_intrinsic2_descs(PyObject *module, PyObject *Py_UNUSED(ignored))
 {
     return _opcode_get_intrinsic2_descs_impl(module);
 }
-/*[clinic end generated code: output=a1052bb1deffb7f2 input=a9049054013a1b77]*/
+
+PyDoc_STRVAR(_opcode_get_executor__doc__,
+"get_executor($module, /, code, offset)\n"
+"--\n"
+"\n"
+"Return the executor object at offset in code if exists, None otherwise.");
+
+#define _OPCODE_GET_EXECUTOR_METHODDEF    \
+    {"get_executor", _PyCFunction_CAST(_opcode_get_executor), METH_FASTCALL|METH_KEYWORDS, _opcode_get_executor__doc__},
+
+static PyObject *
+_opcode_get_executor_impl(PyObject *module, PyObject *code, int offset);
+
+static PyObject *
+_opcode_get_executor(PyObject *module, PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames)
+{
+    PyObject *return_value = NULL;
+    #if defined(Py_BUILD_CORE) && !defined(Py_BUILD_CORE_MODULE)
+
+    #define NUM_KEYWORDS 2
+    static struct {
+        PyGC_Head _this_is_not_used;
+        PyObject_VAR_HEAD
+        PyObject *ob_item[NUM_KEYWORDS];
+    } _kwtuple = {
+        .ob_base = PyVarObject_HEAD_INIT(&PyTuple_Type, NUM_KEYWORDS)
+        .ob_item = { &_Py_ID(code), &_Py_ID(offset), },
+    };
+    #undef NUM_KEYWORDS
+    #define KWTUPLE (&_kwtuple.ob_base.ob_base)
+
+    #else  // !Py_BUILD_CORE
+    #  define KWTUPLE NULL
+    #endif  // !Py_BUILD_CORE
+
+    static const char * const _keywords[] = {"code", "offset", NULL};
+    static _PyArg_Parser _parser = {
+        .keywords = _keywords,
+        .fname = "get_executor",
+        .kwtuple = KWTUPLE,
+    };
+    #undef KWTUPLE
+    PyObject *argsbuf[2];
+    PyObject *code;
+    int offset;
+
+    args = _PyArg_UnpackKeywords(args, nargs, NULL, kwnames, &_parser, 2, 2, 0, argsbuf);
+    if (!args) {
+        goto exit;
+    }
+    code = args[0];
+    offset = PyLong_AsInt(args[1]);
+    if (offset == -1 && PyErr_Occurred()) {
+        goto exit;
+    }
+    return_value = _opcode_get_executor_impl(module, code, offset);
+
+exit:
+    return return_value;
+}
+/*[clinic end generated code: output=2dbb31b041b49c8f input=a9049054013a1b77]*/


### PR DESCRIPTION
Fixes #112383.

TODO:

- [x]  Move `get_executor` from `_testinternalcapi` to `_opcode`.
- [x] Add news.

~~Add test for get_executors (directly, not via dis tests).~~   (already exists in test_capi.test_opt)
<!-- gh-issue-number: gh-112383 -->
* Issue: gh-112383
<!-- /gh-issue-number -->
