### PR TITLE
gh-117178: Recover lazy loading of self-referential modules

### DIFF
--- a/Lib/test/test_importlib/test_lazy.py
+++ b/Lib/test/test_importlib/test_lazy.py
@@ -178,6 +178,23 @@ class LazyLoaderTests(unittest.TestCase):
             # Or multiple load attempts
             self.assertEqual(loader.load_count, 1)
 
+    def test_lazy_self_referential_modules(self):
+        # Directory modules with submodules that reference the parent can attempt to access
+        # the parent module during a load. Verify that this common pattern works with lazy loading.
+        # json is a good example in the stdlib.
+        json_modules = [name for name in sys.modules if name.startswith('json')]
+        with test_util.uncache(*json_modules):
+            # Standard lazy loading, unwrapped
+            spec = util.find_spec('json')
+            loader = util.LazyLoader(spec.loader)
+            spec.loader = loader
+            module = util.module_from_spec(spec)
+            sys.modules['json'] = module
+            loader.exec_module(module)
+
+            # Trigger load with attribute lookup
+            module.loads
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/Lib/test/test_importlib/test_lazy.py
+++ b/Lib/test/test_importlib/test_lazy.py
@@ -192,8 +192,9 @@ class LazyLoaderTests(unittest.TestCase):
             sys.modules['json'] = module
             loader.exec_module(module)
 
-            # Trigger load with attribute lookup
-            module.loads
+            # Trigger load with attribute lookup, ensure expected behavior
+            test_load = module.loads('{}')
+            self.assertEqual(test_load, {})
 
 
 if __name__ == '__main__':

--- a/Misc/NEWS.d/next/Library/2024-03-23-14-26-18.gh-issue-117178.vTisTG.rst
+++ b/Misc/NEWS.d/next/Library/2024-03-23-14-26-18.gh-issue-117178.vTisTG.rst
@@ -1,0 +1,2 @@
+Fix regression in lazy loading of self-referential modules, introduced in
+gh-114781.


### PR DESCRIPTION
The fix is not to condition reentrant lookups on the attribute name but make a best-effort attempt to return the attribute. Because these requests are coming from the originating thread, modules that happily load eagerly should load lazily.

Test fails before and passes after fix.

<!-- gh-issue-number: gh-117178 -->
* Issue: gh-117178
<!-- /gh-issue-number -->
