### PR TITLE
gh-117182: Allow lazily loaded modules to modify their own __class__

### DIFF
--- a/Misc/NEWS.d/next/Library/2024-03-23-12-28-05.gh-issue-117182.a0KANW.rst
+++ b/Misc/NEWS.d/next/Library/2024-03-23-12-28-05.gh-issue-117182.a0KANW.rst
@@ -1,0 +1,2 @@
+Lazy-loading of modules that modify their own ``__class__`` no longer
+reverts the ``__class__`` to :class:`types.ModuleType`.


### PR DESCRIPTION
This PR resolves #117182. The meat of the PR is to check whether the module modified its own `__class__` during load, and only set the default class if not.

I also realized that the `LazyLoader` saves the original `__class__` in the `loader_state` dict. I haven't found a case where that `__class__` isn't `ModuleType`, but if it ever does occur, it does make sense to restore that type. And if that type for some reason overrides `__getattribute__`, it would make sense to use that instead of `object.__getattribute__`.

<!-- gh-issue-number: gh-117182 -->
* Issue: gh-117182
<!-- /gh-issue-number -->
