### PR TITLE
gh-117166: Ignore empty and temporary dirs in `test_makefile`

### DIFF
--- a/Lib/test/test_tools/test_makefile.py
+++ b/Lib/test/test_tools/test_makefile.py
@@ -51,7 +51,7 @@ class TestMakefile(unittest.TestCase):
             if not dirs and not files:
                 continue
             # Skip dirs with hidden-only files:
-            if all(filename.startswith('.') for filename in files):
+            if files and all(filename.startswith('.') for filename in files):
                 continue
 
             relpath = os.path.relpath(dirpath, support.STDLIB_DIR)

--- a/Lib/test/test_tools/test_makefile.py
+++ b/Lib/test/test_tools/test_makefile.py
@@ -51,7 +51,7 @@ class TestMakefile(unittest.TestCase):
             if not dirs and not files:
                 continue
             # Skip dirs with hidden-only files:
-            if not dirs and all(filename.startswith('.') for filename in files):
+            if all(filename.startswith('.') for filename in files):
                 continue
 
             relpath = os.path.relpath(dirpath, support.STDLIB_DIR)

--- a/Lib/test/test_tools/test_makefile.py
+++ b/Lib/test/test_tools/test_makefile.py
@@ -43,7 +43,11 @@ class TestMakefile(unittest.TestCase):
         used = [idle_test]
         for dirpath, _, _ in os.walk(support.TEST_HOME_DIR):
             dirname = os.path.basename(dirpath)
-            if dirname == '__pycache__':
+            if (
+                dirname == '__pycache__'
+                or dirname.startswith('.')
+                or not os.listdir(dirpath)
+            ):
                 continue
 
             relpath = os.path.relpath(dirpath, support.STDLIB_DIR)

--- a/Lib/test/test_tools/test_makefile.py
+++ b/Lib/test/test_tools/test_makefile.py
@@ -41,13 +41,17 @@ class TestMakefile(unittest.TestCase):
         self.assertIn(idle_test, test_dirs)
 
         used = [idle_test]
-        for dirpath, _, _ in os.walk(support.TEST_HOME_DIR):
+        for dirpath, dirs, files in os.walk(support.TEST_HOME_DIR):
             dirname = os.path.basename(dirpath)
-            if (
-                dirname == '__pycache__'
-                or dirname.startswith('.')
-                or not os.listdir(dirpath)
-            ):
+            # Skip temporary dirs:
+            if dirname == '__pycache__' or dirname.startswith('.'):
+                dirs.clear()  # do not process subfolders
+                continue
+            # Skip empty dirs:
+            if not dirs and not files:
+                continue
+            # Skip dirs with hidden-only files:
+            if not dirs and all(filename.startswith('.') for filename in files):
                 continue
 
             relpath = os.path.relpath(dirpath, support.STDLIB_DIR)


### PR DESCRIPTION
I've done local testing with:

```bash
mkdir Lib/test/.ruff_cache Lib/test/test_empty
touch Lib/test/.ruff_cache/file.py

./python.exe -m test test_tools.test_makefile
```

However, it won't work for cases where some `test_X` folder exists with some files.
Why? Because we can't reliably tell whether or not these files are needed for tests.
For example, I don't want to run `.gitignore` checks for all files in a directory. It might cause more problems then solve.

If you have such directories, then you have to clear / remove them manually.

<!-- gh-issue-number: gh-117166 -->
* Issue: gh-117166
<!-- /gh-issue-number -->
