### PR TITLE
gh-117187: Fix XML tests for vanilla Expat <2.6.0

### DIFF
--- a/Lib/test/test_sax.py
+++ b/Lib/test/test_sax.py
@@ -1215,10 +1215,10 @@ class ExpatReaderTest(XmlTestBase):
 
         self.assertEqual(result.getvalue(), start + b"<doc>text</doc>")
 
+    @unittest.skipIf(pyexpat.version_info < (2, 6, 0),
+                     f'Expat {pyexpat.version_info} does not '
+                     'support reparse deferral')
     def test_flush_reparse_deferral_enabled(self):
-        if pyexpat.version_info < (2, 6, 0):
-            self.skipTest(f'Expat {pyexpat.version_info} does not support reparse deferral')
-
         result = BytesIO()
         xmlgen = XMLGenerator(result)
         parser = create_parser()

--- a/Lib/test/test_sax.py
+++ b/Lib/test/test_sax.py
@@ -1251,8 +1251,8 @@ class ExpatReaderTest(XmlTestBase):
 
         if pyexpat.version_info >= (2, 6, 0):
             parser._parser.SetReparseDeferralEnabled(False)
+            self.assertEqual(result.getvalue(), start)  # i.e. no elements started
 
-        self.assertEqual(result.getvalue(), start)  # i.e. no elements started
         self.assertFalse(parser._parser.GetReparseDeferralEnabled())
 
         parser.flush()

--- a/Lib/test/test_xml_etree.py
+++ b/Lib/test/test_xml_etree.py
@@ -1707,11 +1707,10 @@ class XMLPullParserTest(unittest.TestCase):
         with self.assertRaises(ValueError):
             ET.XMLPullParser(events=('start', 'end', 'bogus'))
 
+    @unittest.skipIf(pyexpat.version_info < (2, 6, 0),
+                     f'Expat {pyexpat.version_info} does not '
+                     'support reparse deferral')
     def test_flush_reparse_deferral_enabled(self):
-        if pyexpat.version_info < (2, 6, 0):
-            self.skipTest(f'Expat {pyexpat.version_info} does not '
-                          'support reparse deferral')
-
         parser = ET.XMLPullParser(events=('start', 'end'))
 
         for chunk in ("<doc", ">"):

--- a/Lib/test/test_xml_etree.py
+++ b/Lib/test/test_xml_etree.py
@@ -1742,8 +1742,8 @@ class XMLPullParserTest(unittest.TestCase):
                 self.skipTest(f'XMLParser.(Get|Set)ReparseDeferralEnabled '
                               'methods not available in C')
             parser._parser._parser.SetReparseDeferralEnabled(False)
+            self.assert_event_tags(parser, [])  # i.e. no elements started
 
-        self.assert_event_tags(parser, [])  # i.e. no elements started
         if ET is pyET:
             self.assertFalse(parser._parser._parser.GetReparseDeferralEnabled())
 

--- a/Misc/NEWS.d/next/Tests/2024-03-24-23-49-25.gh-issue-117187.eMLT5n.rst
+++ b/Misc/NEWS.d/next/Tests/2024-03-24-23-49-25.gh-issue-117187.eMLT5n.rst
@@ -1,0 +1,1 @@
+Fix XML tests for vanilla Expat <2.6.0.


### PR DESCRIPTION
Please someone add labels…

- `needs backport to 3.8`
- `needs backport to 3.9`
- `needs backport to 3.10`
- `needs backport to 3.11`
- `needs backport to 3.12`

…for me. Thank you! :pray: 

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-117187 -->
* Issue: gh-117187
<!-- /gh-issue-number -->
