### PR TITLE
gh-117205: Increase chunksize when compiling pyc in parallel

### DIFF
--- a/Lib/compileall.py
+++ b/Lib/compileall.py
@@ -116,7 +116,8 @@ def compile_dir(dir, maxlevels=None, ddir=None, force=False,
                                            prependdir=prependdir,
                                            limit_sl_dest=limit_sl_dest,
                                            hardlink_dupes=hardlink_dupes),
-                                   files)
+                                   files,
+                                   chunksize=4)
             success = min(results, default=True)
     else:
         for file in files:

--- a/Misc/NEWS.d/next/Library/2024-03-25-00-20-16.gh-issue-117205.yV7xGb.rst
+++ b/Misc/NEWS.d/next/Library/2024-03-25-00-20-16.gh-issue-117205.yV7xGb.rst
@@ -1,0 +1,1 @@
+Speed up :func:`compileall.compile_dir` by 20% when using multiprocessing by increasing ``chunksize``.


### PR DESCRIPTION
On a large, existing venv on my system, running: `python -m compileall -f -j 10 -qq .` with warm disk cache and without this change has timings of 41.7s, 42.9s, 42s. With this change, I get timings of 35.7s, 34.9s, 34.6s, for about a 20% speed up. chunksize=2 was a smaller speedup, chunksize=8 was no additional speedup.

This seems pretty straightforward, but let me know if you're interested in a more reproducible benchmark or running it on other systems.

<!-- gh-issue-number: gh-117205 -->
* Issue: gh-117205
<!-- /gh-issue-number -->
