### PR TITLE
gh-108277: Make test_os tolerate 10 ms diff for timerfd on Android emulators

### DIFF
--- a/Lib/test/test_os.py
+++ b/Lib/test/test_os.py
@@ -13,6 +13,7 @@ import itertools
 import locale
 import os
 import pickle
+import platform
 import select
 import selectors
 import shutil
@@ -4085,8 +4086,14 @@ class EventfdTests(unittest.TestCase):
 @unittest.skipUnless(hasattr(os, 'timerfd_create'), 'requires os.timerfd_create')
 @support.requires_linux_version(2, 6, 30)
 class TimerfdTests(unittest.TestCase):
-    # Tolerate a difference of 10 ms
-    CLOCK_RES_PLACES = 2
+    if sys.platform == "android" and platform.android_ver().is_emulator:
+        # Tolerate a difference of 10 ms (1 ms is not reliably achievable on
+        # slower machines).
+        CLOCK_RES_PLACES = 2
+    else:
+        # Tolerate a difference of 1 ms
+        CLOCK_RES_PLACES = 3
+
     CLOCK_RES = 10 ** -CLOCK_RES_PLACES
     CLOCK_RES_NS = 10 ** (9 - CLOCK_RES_PLACES)
 

--- a/Lib/test/test_os.py
+++ b/Lib/test/test_os.py
@@ -4086,12 +4086,11 @@ class EventfdTests(unittest.TestCase):
 @unittest.skipUnless(hasattr(os, 'timerfd_create'), 'requires os.timerfd_create')
 @support.requires_linux_version(2, 6, 30)
 class TimerfdTests(unittest.TestCase):
+    # 1 ms accuracy is reliably achievable on every platform except Android
+    # emulators, where we allow 10 ms (gh-108277).
     if sys.platform == "android" and platform.android_ver().is_emulator:
-        # Tolerate a difference of 10 ms (1 ms is not reliably achievable on
-        # slower machines).
         CLOCK_RES_PLACES = 2
     else:
-        # Tolerate a difference of 1 ms
         CLOCK_RES_PLACES = 3
 
     CLOCK_RES = 10 ** -CLOCK_RES_PLACES

--- a/Lib/test/test_os.py
+++ b/Lib/test/test_os.py
@@ -4085,9 +4085,10 @@ class EventfdTests(unittest.TestCase):
 @unittest.skipUnless(hasattr(os, 'timerfd_create'), 'requires os.timerfd_create')
 @support.requires_linux_version(2, 6, 30)
 class TimerfdTests(unittest.TestCase):
-    # Tolerate a difference of 1 ms
-    CLOCK_RES_NS = 1_000_000
-    CLOCK_RES = CLOCK_RES_NS * 1e-9
+    # Tolerate a difference of 10 ms
+    CLOCK_RES_PLACES = 2
+    CLOCK_RES = 10 ** -CLOCK_RES_PLACES
+    CLOCK_RES_NS = 10 ** (9 - CLOCK_RES_PLACES)
 
     def timerfd_create(self, *args, **kwargs):
         fd = os.timerfd_create(*args, **kwargs)
@@ -4109,18 +4110,18 @@ class TimerfdTests(unittest.TestCase):
 
         # 1st call
         next_expiration, interval2 = os.timerfd_settime(fd, initial=initial_expiration, interval=interval)
-        self.assertAlmostEqual(interval2, 0.0, places=3)
-        self.assertAlmostEqual(next_expiration, 0.0, places=3)
+        self.assertAlmostEqual(interval2, 0.0, places=self.CLOCK_RES_PLACES)
+        self.assertAlmostEqual(next_expiration, 0.0, places=self.CLOCK_RES_PLACES)
 
         # 2nd call
         next_expiration, interval2 = os.timerfd_settime(fd, initial=initial_expiration, interval=interval)
-        self.assertAlmostEqual(interval2, interval, places=3)
-        self.assertAlmostEqual(next_expiration, initial_expiration, places=3)
+        self.assertAlmostEqual(interval2, interval, places=self.CLOCK_RES_PLACES)
+        self.assertAlmostEqual(next_expiration, initial_expiration, places=self.CLOCK_RES_PLACES)
 
         # timerfd_gettime
         next_expiration, interval2 = os.timerfd_gettime(fd)
-        self.assertAlmostEqual(interval2, interval, places=3)
-        self.assertAlmostEqual(next_expiration, initial_expiration, places=3)
+        self.assertAlmostEqual(interval2, interval, places=self.CLOCK_RES_PLACES)
+        self.assertAlmostEqual(next_expiration, initial_expiration, places=self.CLOCK_RES_PLACES)
 
     def test_timerfd_non_blocking(self):
         fd = self.timerfd_create(time.CLOCK_REALTIME, flags=os.TFD_NONBLOCK)
@@ -4174,8 +4175,8 @@ class TimerfdTests(unittest.TestCase):
 
         # timerfd_gettime
         next_expiration, interval2 = os.timerfd_gettime(fd)
-        self.assertAlmostEqual(interval2, interval, places=3)
-        self.assertAlmostEqual(next_expiration, initial_expiration, places=3)
+        self.assertAlmostEqual(interval2, interval, places=self.CLOCK_RES_PLACES)
+        self.assertAlmostEqual(next_expiration, initial_expiration, places=self.CLOCK_RES_PLACES)
 
         count = 3
         t = time.perf_counter()
@@ -4206,8 +4207,8 @@ class TimerfdTests(unittest.TestCase):
         # timerfd_gettime
         # Note: timerfd_gettime returns relative values even if TFD_TIMER_ABSTIME is specified.
         next_expiration, interval2 = os.timerfd_gettime(fd)
-        self.assertAlmostEqual(interval2, interval, places=3)
-        self.assertAlmostEqual(next_expiration, offset, places=3)
+        self.assertAlmostEqual(interval2, interval, places=self.CLOCK_RES_PLACES)
+        self.assertAlmostEqual(next_expiration, offset, places=self.CLOCK_RES_PLACES)
 
         t = time.perf_counter()
         count_signaled = self.read_count_signaled(fd)


### PR DESCRIPTION
These tests currently have a tolerance of 1 ms, but when testing on an Android emulator on a relatively slow laptop, I find they sometimes fail because they experienced a delay of 2 ms.

As @vstinner said at https://github.com/python/cpython/issues/108277#issuecomment-1756489653:

> I don't think that Python should test the operating system itself, it should just test that it's thin wrapper to OS functions "seem to work".

So increasing the tolerance to 10 ms seems reasonable.

This PR also fixes a mistake in the tests, where CLOCK_RES was calculated using a multiplication rather than a division, causing all of its assertions to succeed trivially.

<!-- gh-issue-number: gh-108277 -->
* Issue: gh-108277
<!-- /gh-issue-number -->
