### PR TITLE
gh-117233: Detect libcrypto BLAKE2, Shake, SHA3, and Truncated-SHA512 support at hashlib build time

### DIFF
--- a/Misc/NEWS.d/next/Security/2024-03-25-21-25-28.gh-issue-117233.E4CyI_.rst
+++ b/Misc/NEWS.d/next/Security/2024-03-25-21-25-28.gh-issue-117233.E4CyI_.rst
@@ -1,1 +1,3 @@
-Detect BLAKE2 support in linked cryptography library. This change now allows CPython to build against cryptography/SSL libraries that don't fully support BLAKE2.
+Detect BLAKE2, SHA3, Shake, & truncated SHA512 support in the OpenSSL-ish
+libcrypto library at build time.  This allows :mod:`hashlib` to be used with
+libraries that do not to support every algorithm that upstream OpenSSL does.

--- a/Misc/NEWS.d/next/Security/2024-03-25-21-25-28.gh-issue-117233.E4CyI_.rst
+++ b/Misc/NEWS.d/next/Security/2024-03-25-21-25-28.gh-issue-117233.E4CyI_.rst
@@ -1,0 +1,1 @@
+Detect BLAKE2 support in linked cryptography library. This change now allows CPython to build against cryptography/SSL libraries that don't fully support BLAKE2.

--- a/Modules/_hashopenssl.c
+++ b/Modules/_hashopenssl.c
@@ -45,9 +45,16 @@
 #define MUNCH_SIZE INT_MAX
 
 #define PY_OPENSSL_HAS_SCRYPT 1
+#if defined(NID_sha512_224) && defined(NID_sha512_256)
+#define PY_OPENSSL_HAS_SHA512_2XX 1
+#endif
+#if defined(NID_sha3_224) && defined(NID_sha3_256) && defined(NID_sha3_384) && defined(NID_sha3_512)
 #define PY_OPENSSL_HAS_SHA3 1
+#endif
+#if defined(NID_shake128) && defined(NID_shake256)
 #define PY_OPENSSL_HAS_SHAKE 1
-#if defined(NID_blake2s256) || defined(NID_blake2b512)
+#endif
+#if defined(NID_blake2s256) && defined(NID_blake2b512)
 #define PY_OPENSSL_HAS_BLAKE2 1
 #endif
 
@@ -90,25 +97,44 @@ typedef struct {
     PY_EVP_MD *evp_nosecurity;
 } py_hashentry_t;
 
+// Fundamental to TLS, assumed always present in any libcrypto:
 #define Py_hash_md5 "md5"
 #define Py_hash_sha1 "sha1"
 #define Py_hash_sha224 "sha224"
 #define Py_hash_sha256 "sha256"
 #define Py_hash_sha384 "sha384"
 #define Py_hash_sha512 "sha512"
-#define Py_hash_sha512_224 "sha512_224"
-#define Py_hash_sha512_256 "sha512_256"
-#define Py_hash_sha3_224 "sha3_224"
-#define Py_hash_sha3_256 "sha3_256"
-#define Py_hash_sha3_384 "sha3_384"
-#define Py_hash_sha3_512 "sha3_512"
-#define Py_hash_shake_128 "shake_128"
-#define Py_hash_shake_256 "shake_256"
+
+// Not all OpenSSL-like libcrypto libraries provide these:
+#if defined(NID_sha512_224)
+# define Py_hash_sha512_224 "sha512_224"
+#endif
+#if defined(NID_sha512_512)
+# define Py_hash_sha512_256 "sha512_256"
+#endif
+#if defined(NID_sha3_224)
+# define Py_hash_sha3_224 "sha3_224"
+#endif
+#if defined(NID_sha3_256)
+# define Py_hash_sha3_256 "sha3_256"
+#endif
+#if defined(NID_sha3_384)
+# define Py_hash_sha3_384 "sha3_384"
+#endif
+#if defined(NID_sha3_512)
+# define Py_hash_sha3_512 "sha3_512"
+#endif
+#if defined(NID_shake128)
+# define Py_hash_shake_128 "shake_128"
+#endif
+#if defined(NID_shake256)
+# define Py_hash_shake_256 "shake_256"
+#endif
 #if defined(NID_blake2s256)
-#define Py_hash_blake2s "blake2s"
+# define Py_hash_blake2s "blake2s"
 #endif
 #if defined(NID_blake2b512)
-#define Py_hash_blake2b "blake2b"
+# define Py_hash_blake2b "blake2b"
 #endif
 
 #define PY_HASH_ENTRY(py_name, py_alias, ossl_name, ossl_nid) \
@@ -125,21 +151,37 @@ static const py_hashentry_t py_hashes[] = {
     PY_HASH_ENTRY(Py_hash_sha384, "SHA384", SN_sha384, NID_sha384),
     PY_HASH_ENTRY(Py_hash_sha512, "SHA512", SN_sha512, NID_sha512),
     /* truncated sha2 */
+#ifdef Py_hash_sha512_224
     PY_HASH_ENTRY(Py_hash_sha512_224, "SHA512_224", SN_sha512_224, NID_sha512_224),
+#endif
+#ifdef Py_hash_sha512_256
     PY_HASH_ENTRY(Py_hash_sha512_256, "SHA512_256", SN_sha512_256, NID_sha512_256),
+#endif
     /* sha3 */
+#ifdef Py_hash_sha3_224
     PY_HASH_ENTRY(Py_hash_sha3_224, NULL, SN_sha3_224, NID_sha3_224),
+#endif
+#ifdef Py_hash_sha3_256
     PY_HASH_ENTRY(Py_hash_sha3_256, NULL, SN_sha3_256, NID_sha3_256),
+#endif
+#ifdef Py_hash_sha3_384
     PY_HASH_ENTRY(Py_hash_sha3_384, NULL, SN_sha3_384, NID_sha3_384),
+#endif
+#ifdef Py_hash_sha3_512
     PY_HASH_ENTRY(Py_hash_sha3_512, NULL, SN_sha3_512, NID_sha3_512),
+#endif
     /* sha3 shake */
+#ifdef Py_hash_shake_128
     PY_HASH_ENTRY(Py_hash_shake_128, NULL, SN_shake128, NID_shake128),
+#endif
+#ifdef Py_hash_shake_256
     PY_HASH_ENTRY(Py_hash_shake_256, NULL, SN_shake256, NID_shake256),
+#endif
     /* blake2 digest */
-#if defined(NID_blake2s256)
+#ifdef Py_hash_blake2s
     PY_HASH_ENTRY(Py_hash_blake2s, "blake2s256", SN_blake2s256, NID_blake2s256),
 #endif
-#if defined(NID_blake2s256)
+#ifdef Py_hash_blake2b
     PY_HASH_ENTRY(Py_hash_blake2b, "blake2b512", SN_blake2b512, NID_blake2b512),
 #endif
     PY_HASH_ENTRY(NULL, NULL, NULL, 0),

--- a/Modules/_hashopenssl.c
+++ b/Modules/_hashopenssl.c
@@ -106,7 +106,7 @@ typedef struct {
 #if defined(NID_sha512_224)
 # define Py_hash_sha512_224 "sha512_224"
 #endif
-#if defined(NID_sha512_512)
+#if defined(NID_sha512_256)
 # define Py_hash_sha512_256 "sha512_256"
 #endif
 #if defined(NID_sha3_224)

--- a/Modules/_hashopenssl.c
+++ b/Modules/_hashopenssl.c
@@ -47,7 +47,9 @@
 #define PY_OPENSSL_HAS_SCRYPT 1
 #define PY_OPENSSL_HAS_SHA3 1
 #define PY_OPENSSL_HAS_SHAKE 1
+#if defined(NID_blake2s256) || defined(NID_blake2b512)
 #define PY_OPENSSL_HAS_BLAKE2 1
+#endif
 
 #if OPENSSL_VERSION_NUMBER >= 0x30000000L
 #define PY_EVP_MD EVP_MD
@@ -102,8 +104,12 @@ typedef struct {
 #define Py_hash_sha3_512 "sha3_512"
 #define Py_hash_shake_128 "shake_128"
 #define Py_hash_shake_256 "shake_256"
+#if defined(NID_blake2s256)
 #define Py_hash_blake2s "blake2s"
+#endif
+#if defined(NID_blake2b512)
 #define Py_hash_blake2b "blake2b"
+#endif
 
 #define PY_HASH_ENTRY(py_name, py_alias, ossl_name, ossl_nid) \
     {py_name, py_alias, ossl_name, ossl_nid, 0, NULL, NULL}
@@ -130,8 +136,12 @@ static const py_hashentry_t py_hashes[] = {
     PY_HASH_ENTRY(Py_hash_shake_128, NULL, SN_shake128, NID_shake128),
     PY_HASH_ENTRY(Py_hash_shake_256, NULL, SN_shake256, NID_shake256),
     /* blake2 digest */
+#if defined(NID_blake2s256)
     PY_HASH_ENTRY(Py_hash_blake2s, "blake2s256", SN_blake2s256, NID_blake2s256),
+#endif
+#if defined(NID_blake2s256)
     PY_HASH_ENTRY(Py_hash_blake2b, "blake2b512", SN_blake2b512, NID_blake2b512),
+#endif
     PY_HASH_ENTRY(NULL, NULL, NULL, 0),
 };
 

--- a/Modules/_hashopenssl.c
+++ b/Modules/_hashopenssl.c
@@ -45,16 +45,13 @@
 #define MUNCH_SIZE INT_MAX
 
 #define PY_OPENSSL_HAS_SCRYPT 1
-#if defined(NID_sha512_224) && defined(NID_sha512_256)
-#define PY_OPENSSL_HAS_SHA512_2XX 1
-#endif
 #if defined(NID_sha3_224) && defined(NID_sha3_256) && defined(NID_sha3_384) && defined(NID_sha3_512)
 #define PY_OPENSSL_HAS_SHA3 1
 #endif
-#if defined(NID_shake128) && defined(NID_shake256)
+#if defined(NID_shake128) || defined(NID_shake256)
 #define PY_OPENSSL_HAS_SHAKE 1
 #endif
-#if defined(NID_blake2s256) && defined(NID_blake2b512)
+#if defined(NID_blake2s256) || defined(NID_blake2b512)
 #define PY_OPENSSL_HAS_BLAKE2 1
 #endif
 


### PR DESCRIPTION
# Notes

While OpenSSL supports both "b" and "s" variants of the BLAKE2 hash
function, other cryptographic libraries may lack support for one or both
of the variants. This commit modifies `hashlib`'s C code to detect
whether or not the linked libcrypto supports each BLAKE2 variant, and
elides references to each variant's NID accordingly. In cases where the
underlying libcrypto doesn't fully support BLAKE2, CPython's
`./configure` script can be given the following flag to use CPython's
interned BLAKE2 implementation: `--with-builtin-hashlib-hashes=blake2`.

This pull request implements Issue #117233.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-117233 -->
* Issue: gh-117233
<!-- /gh-issue-number -->
