### PR TITLE
gh-117172: Reduce the c stack limit for coverage build

### DIFF
--- a/Include/cpython/pystate.h
+++ b/Include/cpython/pystate.h
@@ -204,6 +204,9 @@ struct _ts {
 #  else
 #    define Py_C_RECURSION_LIMIT 500
 #  endif
+#elif defined(Py_COVERAGE)
+   // With gcov, the stack usage is higher.
+#  define Py_C_RECURSION_LIMIT 500
 #elif defined(__wasi__)
    // Based on wasmtime 16.
 #  define Py_C_RECURSION_LIMIT 500

--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -796,7 +796,7 @@ bolt-opt:
 coverage:
 	@echo "Building with support for coverage checking:"
 	$(MAKE) clean
-	$(MAKE) @DEF_MAKE_RULE@ CFLAGS="$(CFLAGS) -O0 -pg --coverage" LDFLAGS="$(LDFLAGS) --coverage"
+	$(MAKE) @DEF_MAKE_RULE@ CFLAGS="$(CFLAGS) -O0 -pg --coverage -DPy_COVERAGE" LDFLAGS="$(LDFLAGS) --coverage"
 
 .PHONY: coverage-lcov
 coverage-lcov:

--- a/Misc/NEWS.d/next/Core and Builtins/2024-03-25-23-12-03.gh-issue-117172.x8ag4o.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2024-03-25-23-12-03.gh-issue-117172.x8ag4o.rst
@@ -1,0 +1,1 @@
+Added `Py_COVERAGE` macro in coverage build and reduce c stack limit in coverage build.

--- a/Misc/NEWS.d/next/Core and Builtins/2024-03-25-23-12-03.gh-issue-117172.x8ag4o.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2024-03-25-23-12-03.gh-issue-117172.x8ag4o.rst
@@ -1,1 +1,1 @@
-Added `Py_COVERAGE` macro in coverage build and reduce c stack limit in coverage build.
+Added ``Py_COVERAGE`` macro in coverage build and reduce c stack limit in coverage build.


### PR DESCRIPTION
WIth gcov enabled, the stack usage is significantly higher. The C stack will overflow with a limit of `10000`. `500` is kind of arbitrary but it inlines with debug build. Also I confirmed that the failed test passes with `500`.

Unfortunately enabling gcov does not give us a macro to check against (as far as I'm aware), so I added a macro `Py_COVERAGE` (similart to `Py_DEBUG`) when build with `coverage`. Not sure if that's the best way to solve the issue.

<!-- gh-issue-number: gh-117172 -->
* Issue: gh-117172
<!-- /gh-issue-number -->
