### PR TITLE
pre-commit: add `check-case-conflict` and `check-merge-conflict`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,6 +14,8 @@ repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.5.0
     hooks:
+      - id: check-case-conflict
+      - id: check-merge-conflict
       - id: check-toml
         exclude: ^Lib/test/test_tomllib/
       - id: check-yaml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.2.0
+    rev: v0.3.4
     hooks:
       - id: ruff
         name: Run Ruff on Lib/test/


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

There was a recent docs failures due to accidentally committing a merge conflict in a backport, and the problem wasn't obvious at all from the logs:

```
PATH=./venv/bin:$PATH sphinx-build -b html -d build/doctrees -j auto  -q -W --keep-going . build/html 
/home/runner/work/cpython/cpython/Doc/library/dataclasses.rst:437: WARNING: Explicit markup ends without a blank line; unexpected unindent.
/home/runner/work/cpython/cpython/Doc/library/dataclasses.rst:440: WARNING: Definition list ends without a blank line; unexpected unindent.
/home/runner/work/cpython/cpython/Doc/library/dataclasses.rst:440: CRITICAL: Missing matching underline for section title overline.

=======
   specified on the call to :func:`!replace` so that they can be passed to
   :meth:`!__init__` and :meth:`__post_init__`.
/home/runner/work/cpython/cpython/Doc/library/dataclasses.rst:450: WARNING: Block quote ends without a blank line; unexpected unindent.
/home/runner/work/cpython/cpython/Doc/library/dataclasses.rst:453: WARNING: Definition list ends without a blank line; unexpected unindent.
/home/runner/work/cpython/cpython/Doc/library/dataclasses.rst:453: CRITICAL: Missing matching underline for section title overline.

=======
   :func:`!replace`.  They are not copied from the source object, but
   rather are initialized in :meth:`__post_init__`, if they're
/home/runner/work/cpython/cpython/Doc/library/dataclasses.rst:5[29](https://github.com/python/cpython/actions/runs/8395286301/job/22994240268#step:5:30): ERROR: Unexpected indentation.
/home/runner/work/cpython/cpython/Doc/library/dataclasses.rst:535: WARNING: Block quote ends without a blank line; unexpected unindent.
/home/runner/work/cpython/cpython/Doc/library/dataclasses.rst:539: ERROR: Unexpected indentation.
```

`check-merge-conflict` from https://github.com/pre-commit/pre-commit-hooks can help prevent and diagnose merge conflicts more easily. `check-case-conflict` is another useful one we can add from the same set.
