### PR TITLE
gh-117281: Change weakref repr() to fully qualified name

### DIFF
--- a/Lib/test/test_weakref.py
+++ b/Lib/test/test_weakref.py
@@ -130,6 +130,19 @@ class ReferencesTestCase(TestBase):
         self.assertEqual(repr(ref),
                          f'<weakref at {id(ref):#x}; dead>')
 
+        # test type with __name__
+        class WithName:
+            @property
+            def __name__(self):
+                return "custom_name"
+
+        obj2 = WithName()
+        ref2 = weakref.ref(obj2)
+        self.assertEqual(repr(ref2),
+                         f"<weakref at {id(ref2):#x}; "
+                         f"to '{WithName.__module__}.{WithName.__qualname__}' "
+                         f"at {id(obj2):#x} (custom_name)>")
+
     def test_repr_failure_gh99184(self):
         class MyConfig(dict):
             def __getattr__(self, x):

--- a/Lib/test/test_weakref.py
+++ b/Lib/test/test_weakref.py
@@ -120,15 +120,15 @@ class ReferencesTestCase(TestBase):
     def test_ref_repr(self):
         obj = C()
         ref = weakref.ref(obj)
-        self.assertEqual(repr(ref),
-                         f"<weakref at {id(ref):#x}; "
-                         f"to '{C.__module__}.{C.__qualname__}' "
-                         f"at {id(obj):#x}>")
+        self.assertRegex(repr(ref),
+                         rf"<weakref at 0x[0-9a-fA-F]+; "
+                         rf"to '{C.__module__}.{C.__qualname__}' "
+                         rf"at 0x[0-9a-fA-F]+>")
 
         obj = None
         gc_collect()
-        self.assertEqual(repr(ref),
-                         f'<weakref at {id(ref):#x}; dead>')
+        self.assertRegex(repr(ref),
+                         rf'<weakref at 0x[0-9a-fA-F]+; dead>')
 
         # test type with __name__
         class WithName:
@@ -138,10 +138,10 @@ class ReferencesTestCase(TestBase):
 
         obj2 = WithName()
         ref2 = weakref.ref(obj2)
-        self.assertEqual(repr(ref2),
-                         f"<weakref at {id(ref2):#x}; "
-                         f"to '{WithName.__module__}.{WithName.__qualname__}' "
-                         f"at {id(obj2):#x} (custom_name)>")
+        self.assertRegex(repr(ref2),
+                         rf"<weakref at 0x[0-9a-fA-F]+; "
+                         rf"to '{WithName.__module__}.{WithName.__qualname__}' "
+                         rf"at 0x[0-9a-fA-F]+ \(custom_name\)>")
 
     def test_repr_failure_gh99184(self):
         class MyConfig(dict):
@@ -226,15 +226,15 @@ class ReferencesTestCase(TestBase):
     def test_proxy_repr(self):
         obj = C()
         ref = weakref.proxy(obj, self.callback)
-        self.assertEqual(repr(ref),
-                         f"<weakproxy at {id(ref):#x}; "
-                         f"to '{C.__module__}.{C.__qualname__}' "
-                         f"at {id(obj):#x}>")
+        self.assertRegex(repr(ref),
+                         rf"<weakproxy at 0x[0-9a-fA-F]+; "
+                         rf"to '{C.__module__}.{C.__qualname__}' "
+                         rf"at 0x[0-9a-fA-F]+>")
 
         obj = None
         gc_collect()
-        self.assertEqual(repr(ref),
-                         f'<weakproxy at {id(ref):#x}; dead>')
+        self.assertRegex(repr(ref),
+                         rf'<weakproxy at 0x[0-9a-fA-F]+; dead>')
 
     def check_basic_ref(self, factory):
         o = factory()

--- a/Lib/test/test_weakref.py
+++ b/Lib/test/test_weakref.py
@@ -116,6 +116,20 @@ class ReferencesTestCase(TestBase):
         del o
         repr(wr)
 
+    @support.cpython_only
+    def test_ref_repr(self):
+        obj = C()
+        ref = weakref.ref(obj)
+        self.assertEqual(repr(ref),
+                         f"<weakref at {id(ref):#x}; "
+                         f"to '{C.__module__}.{C.__qualname__}' "
+                         f"at {id(obj):#x}>")
+
+        obj = None
+        gc_collect()
+        self.assertEqual(repr(ref),
+                         f'<weakref at {id(ref):#x}; dead>')
+
     def test_repr_failure_gh99184(self):
         class MyConfig(dict):
             def __getattr__(self, x):
@@ -194,6 +208,20 @@ class ReferencesTestCase(TestBase):
         gc_collect()  # For PyPy or other GCs.
         self.assertRaises(ReferenceError, bool, ref3)
         self.assertEqual(self.cbcalled, 2)
+
+    @support.cpython_only
+    def test_proxy_repr(self):
+        obj = C()
+        ref = weakref.proxy(obj, self.callback)
+        self.assertEqual(repr(ref),
+                         f"<weakproxy at {id(ref):#x}; "
+                         f"to '{C.__module__}.{C.__qualname__}' "
+                         f"at {id(obj):#x}>")
+
+        obj = None
+        gc_collect()
+        self.assertEqual(repr(ref),
+                         f'<weakproxy at {id(ref):#x}; dead>')
 
     def check_basic_ref(self, factory):
         o = factory()

--- a/Objects/weakrefobject.c
+++ b/Objects/weakrefobject.c
@@ -177,13 +177,13 @@ weakref_repr(PyObject *self)
     PyObject *repr;
     if (name == NULL || !PyUnicode_Check(name)) {
         repr = PyUnicode_FromFormat(
-            "<weakref at %p; to '%s' at %p>",
-            self, Py_TYPE(obj)->tp_name, obj);
+            "<weakref at %p; to '%T' at %p>",
+            self, obj, obj);
     }
     else {
         repr = PyUnicode_FromFormat(
-            "<weakref at %p; to '%s' at %p (%U)>",
-            self, Py_TYPE(obj)->tp_name, obj, name);
+            "<weakref at %p; to '%T' at %p (%U)>",
+            self, obj, obj, name);
     }
     Py_DECREF(obj);
     Py_XDECREF(name);
@@ -471,10 +471,18 @@ static PyObject *
 proxy_repr(PyObject *proxy)
 {
     PyObject *obj = _PyWeakref_GET_REF(proxy);
-    PyObject *repr = PyUnicode_FromFormat(
-        "<weakproxy at %p to %s at %p>",
-        proxy, Py_TYPE(obj)->tp_name, obj);
-    Py_DECREF(obj);
+    PyObject *repr;
+    if (obj != NULL) {
+        repr = PyUnicode_FromFormat(
+            "<weakproxy at %p; to '%T' at %p>",
+            proxy, obj, obj);
+        Py_DECREF(obj);
+    }
+    else {
+        repr = PyUnicode_FromFormat(
+            "<weakproxy at %p; dead>",
+            proxy);
+    }
     return repr;
 }
 


### PR DESCRIPTION
Use the fully qualified type name in repr() of weakref.ref and weakref.proxy types.

Fix a crash in proxy_repr() when the reference is dead.

Add also test_ref_repr() and test_proxy_repr().

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-117281 -->
* Issue: gh-117281
<!-- /gh-issue-number -->
