### PR TITLE
gh-117281: [weakref] Fix crash in `proxy_repr` 

### DIFF
--- a/Lib/test/test_weakref.py
+++ b/Lib/test/test_weakref.py
@@ -116,6 +116,21 @@ class ReferencesTestCase(TestBase):
         del o
         repr(wr)
 
+    def test_proxy_repr(self):
+        class A:
+            pass
+        a = A()
+        wp = weakref.proxy(a)
+        self.assertRegex(repr(wp), '<weakproxy at 0x.* to A at 0x.*>')
+
+        # gh-117281: Interpreter shouldn't crash when calling repr on proxy with a
+        # dead object.
+        del a
+        with self.assertRaisesRegex(
+                ReferenceError,
+                'weakly-referenced object no longer exists'):
+            repr(wp)
+
     def test_repr_failure_gh99184(self):
         class MyConfig(dict):
             def __getattr__(self, x):

--- a/Objects/weakrefobject.c
+++ b/Objects/weakrefobject.c
@@ -471,7 +471,7 @@ static PyObject *
 proxy_repr(PyObject *proxy)
 {
     PyObject *obj = _PyWeakref_GET_REF(proxy);
-    if (!proxy_check_ref(obj) && PyErr_Occurred()) {
+    if (!proxy_check_ref(obj)) {
         return NULL;
     }
     PyObject *repr = PyUnicode_FromFormat(

--- a/Objects/weakrefobject.c
+++ b/Objects/weakrefobject.c
@@ -471,6 +471,9 @@ static PyObject *
 proxy_repr(PyObject *proxy)
 {
     PyObject *obj = _PyWeakref_GET_REF(proxy);
+    if (!proxy_check_ref(obj) && PyErr_Occurred()) {
+        return NULL;
+    }
     PyObject *repr = PyUnicode_FromFormat(
         "<weakproxy at %p to %s at %p>",
         proxy, Py_TYPE(obj)->tp_name, obj);


### PR DESCRIPTION
It's important to note that this is a behavioral change.
Previously (in versions 3.12 and older) calling repr on an object with an already dead object worked:

```python
import weakref

class A: pass

proxy = weakref.proxy(A())
print(repr(proxy))
```
```python
python3.12 example.py
<weakproxy at 0x7f9d214da2f0 to NoneType at 0x7f9d21ff8100>
```
This happens due to usage of `PyWeakref_GET_OBJECT` in `proxy_repr` which returns a `None` if the referred object is not alive.
But starting from cb388c9a85a8dd6817ea7d969f53657002df6272, `proxy_repr` uses a `_PyWeakref_GET_REF` which doesn't return a `None` if referent no longer lives; it's returns a `NULL` value.

So, now calling repr on a proxy with a dead referent results in `ReferenceError`:
```python
./python example.py
Traceback (most recent call last):
  File "/home/eclips4/CLionProjects/cpython/example.py", line 6, in <module>
    print(repr(proxy))
          ~~~~^^^^^^^
ReferenceError: weakly-referenced object no longer exists
```

It's probably worth mentioning in the `What's new` category, but I would like to hear Victor's opinion first.

<!-- gh-issue-number: gh-117281 -->
* Issue: gh-117281
<!-- /gh-issue-number -->
