### PR TITLE
Revert "gh-116886: Temporarily disable CIfuzz (memory) (#117018)"

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -514,8 +514,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # sanitizer: [address, undefined, memory]  -- memory skipped temporarily until GH-116886 is solved.
-        sanitizer: [address, undefined]
+        sanitizer: [address, undefined, memory]
     steps:
       - name: Build fuzzers (${{ matrix.sanitizer }})
         id: build


### PR DESCRIPTION
This reverts #117018

I expect the issue to be fixed based on https://github.com/google/oss-fuzz/pull/11708#issuecomment-2006442396 and https://github.com/actions/runner-images/issues/9491.


<!-- gh-issue-number: gh-116886 -->
* Issue: gh-116886
<!-- /gh-issue-number -->
