### PR TITLE
gh-117291: Explain usage of nullbytes in Array(c_char).value

### DIFF
--- a/Doc/library/multiprocessing.rst
+++ b/Doc/library/multiprocessing.rst
@@ -1724,6 +1724,9 @@ inherited by child processes.
 
    Note that an array of :data:`ctypes.c_char` has *value* and *raw*
    attributes which allow one to use it to store and retrieve strings.
+   While *raw* allows interaction with a bytes-object the full size of the
+   array, reading *value* will terminate after a null-byte, like most
+   programming languages handle strings.
 
 
 The :mod:`!multiprocessing.sharedctypes` module

--- a/Doc/library/multiprocessing.rst
+++ b/Doc/library/multiprocessing.rst
@@ -1723,9 +1723,9 @@ inherited by child processes.
    Note that *lock* is a keyword only argument.
 
    Note that an array of :data:`ctypes.c_char` has *value* and *raw*
-   attributes which allow one to use it to store and retrieve strings.
-   While *raw* allows interaction with a bytes-object the full size of the
-   array, reading *value* will terminate after a null-byte, like most
+   attributes which allow one to use it to store and retrieve byte strings.
+   While *raw* allows interaction with a :class:`bytes` object the full size of
+   the array, reading *value* will terminate after a null byte, like most
    programming languages handle strings.
 
 

--- a/Doc/library/multiprocessing.rst
+++ b/Doc/library/multiprocessing.rst
@@ -1723,7 +1723,7 @@ inherited by child processes.
    Note that *lock* is a keyword only argument.
 
    Note that an array of :data:`ctypes.c_char` has *value* and *raw*
-   attributes which allow one to use it to store and retrieve byte strings.
+   attributes which can both be used to store and retrieve byte strings.
    While *raw* allows interaction with a :class:`bytes` object the full size of
    the array, reading *value* will terminate after a null byte, like most
    programming languages handle strings.


### PR DESCRIPTION
Fixes #117291 

Currently, the docs only briefly mention `value` and `raw` attributes of a `Array(c_char)`. This PR extends the note to inform users that reading a `value` might give a different value than was set beforehand iff null-bytes are part of this value.

<!-- gh-issue-number: gh-117291 -->
* Issue: gh-117291
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--117292.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->