### PR TITLE
gh-99108: Update and check HACL* version information

### DIFF
--- a/Misc/sbom.spdx.json
+++ b/Misc/sbom.spdx.json
@@ -1584,14 +1584,14 @@
       "checksums": [
         {
           "algorithm": "SHA256",
-          "checksumValue": "c23ac158b238c368389dc86bfc315263e5c0e57785da74144aea2cab9a3d51a2"
+          "checksumValue": "e31e4ca10da91c585793c0eaf1b98aee3cb43e3a58d3d8d478593e5a6bd82927"
         }
       ],
-      "downloadLocation": "https://github.com/hacl-star/hacl-star/archive/521af282fdf6d60227335120f18ae9309a4b8e8c.zip",
+      "downloadLocation": "https://github.com/hacl-star/hacl-star/archive/bb3d0dc8d9d15a5cd51094d5b69e70aa09005ff0.zip",
       "externalRefs": [
         {
           "referenceCategory": "SECURITY",
-          "referenceLocator": "cpe:2.3:a:hacl-star:hacl-star:521af282fdf6d60227335120f18ae9309a4b8e8c:*:*:*:*:*:*:*",
+          "referenceLocator": "cpe:2.3:a:hacl-star:hacl-star:bb3d0dc8d9d15a5cd51094d5b69e70aa09005ff0:*:*:*:*:*:*:*",
           "referenceType": "cpe23Type"
         }
       ],
@@ -1599,7 +1599,7 @@
       "name": "hacl-star",
       "originator": "Organization: HACL* Developers",
       "primaryPackagePurpose": "SOURCE",
-      "versionInfo": "521af282fdf6d60227335120f18ae9309a4b8e8c"
+      "versionInfo": "bb3d0dc8d9d15a5cd51094d5b69e70aa09005ff0"
     },
     {
       "SPDXID": "SPDXRef-PACKAGE-libb2",

--- a/Tools/build/generate_sbom.py
+++ b/Tools/build/generate_sbom.py
@@ -186,10 +186,11 @@ def check_sbom_packages(sbom_data: dict[str, typing.Any]) -> None:
         # HACL* specifies its expected rev in a refresh script.
         if package["name"] == "hacl-star":
             hacl_refresh_sh = (CPYTHON_ROOT_DIR / "Modules/_hacl/refresh.sh").read_text()
-            hacl_expected_rev = re.search(
+            hacl_expected_rev_match = re.search(
                 r"expected_hacl_star_rev=([0-9a-f]{40})",
                 hacl_refresh_sh
-            ).group(1)
+            )
+            hacl_expected_rev = hacl_expected_rev_match and hacl_expected_rev_match.group(1)
 
             error_if(
                 hacl_expected_rev != version,

--- a/Tools/build/generate_sbom.py
+++ b/Tools/build/generate_sbom.py
@@ -183,6 +183,19 @@ def check_sbom_packages(sbom_data: dict[str, typing.Any]) -> None:
             ),
         )
 
+        # HACL* specifies its expected rev in a refresh script.
+        if package["name"] == "hacl-star":
+            hacl_refresh_sh = (CPYTHON_ROOT_DIR / "Modules/_hacl/refresh.sh").read_text()
+            hacl_expected_rev = re.search(
+                r"expected_hacl_star_rev=([0-9a-f]{40})",
+                hacl_refresh_sh
+            ).group(1)
+
+            error_if(
+                hacl_expected_rev != version,
+                "HACL* SBOM version doesn't match value in 'Modules/_hacl/refresh.sh'"
+            )
+
         # License must be on the approved list for SPDX.
         license_concluded = package["licenseConcluded"]
         error_if(


### PR DESCRIPTION
Follow-up from https://github.com/python/cpython/pull/117237 which fixes the version for HACL* in the SBOM document and adds a check to SBOM tooling to ensure the value is always updated appropriately to the value in `refresh.sh`.

cc @msprotz 

<!-- gh-issue-number: gh-99108 -->
* Issue: gh-99108
<!-- /gh-issue-number -->
