### PR TITLE
gh-117303: Don't detach in `PyThreadState_DeleteCurrent()`

### DIFF
--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -1658,7 +1658,6 @@ static void
 tstate_delete_common(PyThreadState *tstate)
 {
     assert(tstate->_status.cleared && !tstate->_status.finalized);
-    assert(tstate->state != _Py_THREAD_ATTACHED);
     tstate_verify_not_active(tstate);
     assert(!_PyThreadState_IsRunningMain(tstate));
 
@@ -1738,7 +1737,6 @@ _PyThreadState_DeleteCurrent(PyThreadState *tstate)
 #ifdef Py_GIL_DISABLED
     _Py_qsbr_detach(((_PyThreadStateImpl *)tstate)->qsbr);
 #endif
-    tstate_set_detached(tstate, _Py_THREAD_DETACHED);
     current_fast_clear(tstate->interp->runtime);
     tstate_delete_common(tstate);
     _PyEval_ReleaseLock(tstate->interp, NULL);


### PR DESCRIPTION
This fixes a crash in `test_threading.test_reinit_tls_after_fork()` when running with the GIL disabled. We already properly handle the case where the thread state is `_Py_THREAD_ATTACHED` in `tstate_delete_common()` -- we just need to remove an assertion.

Keeping the thread attached means that a stop-the-world pause, such as for a `fork()`, won't commence until we remove our thread state from the interpreter's linked list. This prevents a crash when the child process tries to clean up the dead thread states.

<!-- gh-issue-number: gh-117303 -->
* Issue: gh-117303
<!-- /gh-issue-number -->
