### PR TITLE
gh-117310: Remove extra DECREF on "no ciphers" error path in `_ssl._SSLContext` constructor

### DIFF
--- a/Misc/NEWS.d/next/Library/2024-03-27-21-05-52.gh-issue-117310.Bt2wox.rst
+++ b/Misc/NEWS.d/next/Library/2024-03-27-21-05-52.gh-issue-117310.Bt2wox.rst
@@ -1,0 +1,3 @@
+Fixed an implausible extra DECREF related crash in :mod:`ssl` when creating
+a new ``_ssl._SSLContext`` if the build was linked against a non-functional
+SSL library whos C ``SSL_CTX_set_cipher_list()`` API reports failure.

--- a/Misc/NEWS.d/next/Library/2024-03-27-21-05-52.gh-issue-117310.Bt2wox.rst
+++ b/Misc/NEWS.d/next/Library/2024-03-27-21-05-52.gh-issue-117310.Bt2wox.rst
@@ -1,3 +1,4 @@
-Fixed an implausible extra DECREF related crash in :mod:`ssl` when creating
-a new ``_ssl._SSLContext`` if the build was linked against a non-functional
-SSL library whos C ``SSL_CTX_set_cipher_list()`` API reports failure.
+Fixed an unlikely early & extra ``Py_DECREF`` triggered crash in :mod:`ssl`
+when creating a new ``_ssl._SSLContext`` if CPython was built implausibly such
+that the default cipher list is empty **or** the SSL library it was linked
+against reports a failure from its C ``SSL_CTX_set_cipher_list()`` API.

--- a/Modules/_ssl.c
+++ b/Modules/_ssl.c
@@ -3166,7 +3166,6 @@ _ssl__SSLContext_impl(PyTypeObject *type, int proto_version)
         result = SSL_CTX_set_cipher_list(ctx, "HIGH:!aNULL:!eNULL");
     }
     if (result == 0) {
-        Py_DECREF(self);
         ERR_clear_error();
         PyErr_SetString(get_state_ctx(self)->PySSLErrorObject,
                         "No cipher can be selected.");


### PR DESCRIPTION
This doesn't come up in practice in any normal supported build config as `PY_SSL_DEFAULT_CIPHER_STRING` should
always be properly defined by `configure.ac` and the values the linked against SSL library sees should always find a cipher.

This codepath crashes without this fix.  (self is used right after the decref that deallocates it, and the `goto error` path does its own decref even if that ordering had been correct)

Found while working on getting CPython to link with a build of an alternate SSL library in #116399 when not everything was really working as it should yet... ;)

I did not try and prevent this in `configure.ac` as that isn't how the error came up - i've got a differently non-functional build in my work in progress tree that exposed it.

```
./configure --with-ssl-default-suites="" && make test
...
test test_ssl crashed -- Traceback (most recent call last):
...
  File "/.../Lib/test/test_ssl.py", line 232, in has_tls_version
    ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
  File "/.../Lib/ssl.py", line 438, in __new__
    self = _SSLContext.__new__(cls, protocol)
ssl.SSLError: ('No cipher can be selected.',)

test_ssl failed (uncaught exception)
```

That would SIGSEGV before this PR.

---

I would love this to be a Modules/_ssl.c build failure when the #define is `""` but the C preprocessor doesn't comprehend how to test for that at compile time in any reasonable manner.

<!-- gh-issue-number: gh-117310 -->
* Issue: gh-117310
<!-- /gh-issue-number -->
