### PR TITLE
gh-117338: Handle leading `//` for `posixpath.realpath`

### DIFF
--- a/Lib/test/test_posixpath.py
+++ b/Lib/test/test_posixpath.py
@@ -637,6 +637,11 @@ class PosixPathTest(unittest.TestCase):
             safe_rmdir(ABSTFN + "/k")
             safe_rmdir(ABSTFN)
 
+    @skip_if_ABSTFN_contains_backslash
+    def test_realpath_double_slash(self):
+        # gh-117201: Handle leading `//` for `posixpath.realpath`
+        self.assertEqual(realpath("//foo"), "/foo")
+
     def test_relpath(self):
         (real_getcwd, os.getcwd) = (os.getcwd, lambda: r"/home/user/bar")
         try:

--- a/Lib/test/test_posixpath.py
+++ b/Lib/test/test_posixpath.py
@@ -639,8 +639,8 @@ class PosixPathTest(unittest.TestCase):
 
     @skip_if_ABSTFN_contains_backslash
     def test_realpath_double_slash(self):
-        # gh-117201: Handle leading `//` for `posixpath.realpath`
-        self.assertEqual(realpath("//foo"), "/foo")
+        # gh-117338: Handle leading `//` for `posixpath.realpath`
+        self.assertEqual(realpath("//foo"), "//foo")
 
     def test_relpath(self):
         (real_getcwd, os.getcwd) = (os.getcwd, lambda: r"/home/user/bar")

--- a/Misc/NEWS.d/next/Core and Builtins/2024-03-28-19-32-17.gh-issue-117338.b1_tPG.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2024-03-28-19-32-17.gh-issue-117338.b1_tPG.rst
@@ -1,0 +1,1 @@
+Handle leading ``//`` for :func:`posixpath.realpath` using :func:`posixpath.splitroot`.


### PR DESCRIPTION
Benchmark:

```none
python -m timeit -s "from test import realpath1" "realpath1('foo/../../..')" && python -m timeit -s "from test import realpath2" "realpath2('foo/../../..')"
10000 loops, best of 5: 23.5 usec per loop # before
10000 loops, best of 5: 23.6 usec per loop # after
# -> no difference
```

<!-- gh-issue-number: gh-117338 -->
* Issue: gh-117338
<!-- /gh-issue-number -->
