### PR TITLE
gh-117121: Add pystats to JIT

### DIFF
--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -990,6 +990,7 @@ enter_tier_two:
     #define DPRINTF(level, ...)
 #endif
 
+    ; // dummy statement after a label, before a declaration
     uint16_t uopcode;
 #ifdef Py_STATS
     uint64_t trace_uop_execution_counter = 0;

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -990,7 +990,6 @@ enter_tier_two:
     #define DPRINTF(level, ...)
 #endif
 
-    OPT_STAT_INC(traces_executed);
     uint16_t uopcode;
 #ifdef Py_STATS
     uint64_t trace_uop_execution_counter = 0;

--- a/Python/ceval_macros.h
+++ b/Python/ceval_macros.h
@@ -392,6 +392,7 @@ stack_pointer = _PyFrame_GetStackPointer(frame);
 #ifdef _Py_JIT
 #define GOTO_TIER_TWO(EXECUTOR)                        \
 do {                                                   \
+    OPT_STAT_INC(traces_executed);                     \
     jit_func jitted = (EXECUTOR)->jit_code;            \
     next_instr = jitted(frame, stack_pointer, tstate); \
     Py_DECREF(tstate->previous_executor);              \
@@ -406,6 +407,7 @@ do {                                                   \
 #else
 #define GOTO_TIER_TWO(EXECUTOR) \
 do { \
+    OPT_STAT_INC(traces_executed); \
     next_uop = (EXECUTOR)->trace; \
     assert(next_uop->opcode == _START_EXECUTOR || next_uop->opcode == _COLD_EXIT); \
     goto enter_tier_two; \


### PR DESCRIPTION
This adds most of the missing pystats to JIT builds.  I confirmed that I got everything by finding all of the calls to `OPT_STAT_INC` in the Tier 2 loop in `ceval.c`, and then compared the resulting output of this vs. a Tier 2 run.

As mentioned in #117121, this does not track run length, which would require an additional local variable to track that and the fallout / differences from non-pystats builds that would create.  I think it's fine to leave that as follow-on work for now, as this simple stuff will get most of what we need from these stats.

<!-- gh-issue-number: gh-117121 -->
* Issue: gh-117121
<!-- /gh-issue-number -->
