### PR TITLE
gh-117267: Ensure DirEntry.stat().st_ctime still contains creation time during deprecation period

### DIFF
--- a/Misc/NEWS.d/next/Windows/2024-03-28-22-12-00.gh-issue-117267.K_tki1.rst
+++ b/Misc/NEWS.d/next/Windows/2024-03-28-22-12-00.gh-issue-117267.K_tki1.rst
@@ -1,0 +1,5 @@
+Ensure ``DirEntry.stat().st_ctime`` behaves consistently with
+:func:`os.stat` during the deprecation period of ``st_ctime`` by containing
+the same value as ``st_birthtime``. After the deprecation period,
+``st_ctime`` will be the metadata change time (or unavailable through
+``DirEntry``), and only ``st_birthtime`` will contain the creation time.

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -15816,6 +15816,10 @@ DirEntry_from_find_data(PyObject *module, path_t *path, WIN32_FIND_DATAW *dataW)
     find_data_to_file_info(dataW, &file_info, &reparse_tag);
     _Py_attribute_data_to_stat(&file_info, reparse_tag, NULL, NULL, &entry->win32_lstat);
 
+    /* ctime is only deprecated from 3.12, so we copy birthtime across */
+    entry->win32_lstat.st_ctime = entry->win32_lstat.st_birthtime;
+    entry->win32_lstat.st_ctime_nsec = entry->win32_lstat.st_birthtime_nsec;
+
     return (PyObject *)entry;
 
 error:


### PR DESCRIPTION


<!-- gh-issue-number: gh-117267 -->
* Issue: gh-117267
<!-- /gh-issue-number -->
