### PR TITLE
gh-117344: Skip flaky tests in free-threaded build

### DIFF
--- a/Lib/test/test_concurrent_futures/test_process_pool.py
+++ b/Lib/test/test_concurrent_futures/test_process_pool.py
@@ -116,6 +116,7 @@ class ProcessPoolExecutorTest(ExecutorTest):
         for _ in range(job_count):
             sem.release()
 
+    @unittest.skipIf(support.Py_GIL_DISABLED, "gh-117344: test is flaky without the GIL")
     def test_idle_process_reuse_one(self):
         executor = self.executor
         assert executor._max_workers >= 4

--- a/Lib/test/test_concurrent_futures/test_thread_pool.py
+++ b/Lib/test/test_concurrent_futures/test_thread_pool.py
@@ -41,6 +41,7 @@ class ThreadPoolExecutorTest(ThreadPoolMixin, ExecutorTest, BaseTestCase):
             sem.release()
         executor.shutdown(wait=True)
 
+    @unittest.skipIf(support.Py_GIL_DISABLED, "gh-117344: test is flaky without the GIL")
     def test_idle_thread_reuse(self):
         executor = self.executor_type()
         executor.submit(mul, 21, 2).result()


### PR DESCRIPTION
The tests are not reliable with the GIL disabled. In theory, they can fail with the GIL enabled too, but the failures are much more likely with the GIL disabled.

The underlying problem is that the worker thread/process completes the Future before incrementing the `_idle_semaphore`. Subsequent submission may start a new thread or process if they happen before `_idle_semaphore` is incremented.

<!-- gh-issue-number: gh-117344 -->
* Issue: gh-117344
<!-- /gh-issue-number -->
