### PR TITLE
gh-117352: Handle `/:/` for `ntpath.isabs`

### DIFF
--- a/Lib/ntpath.py
+++ b/Lib/ntpath.py
@@ -93,10 +93,7 @@ def isabs(s):
         double_sep = '\\\\'
     s = s[:3].replace(altsep, sep)
     # Absolute: UNC, device, and paths with a drive and root.
-    return (
-        (s.startswith(colon_sep, 1) and not s.startswith(sep))
-        or s.startswith(double_sep)
-    )
+    return (s[1:3] == colon_sep and s[:1] != sep) or s[:2] == double_sep
 
 
 # Join two (or more) paths.

--- a/Lib/ntpath.py
+++ b/Lib/ntpath.py
@@ -93,7 +93,10 @@ def isabs(s):
         double_sep = '\\\\'
     s = s[:3].replace(altsep, sep)
     # Absolute: UNC, device, and paths with a drive and root.
-    return s.startswith(colon_sep, 1) or s.startswith(double_sep)
+    return (
+        (s.startswith(colon_sep, 1) and not s.startswith(sep))
+        or s.startswith(double_sep)
+    )
 
 
 # Join two (or more) paths.

--- a/Lib/ntpath.py
+++ b/Lib/ntpath.py
@@ -91,10 +91,10 @@ def isabs(s):
         colon_sep = ':\\'
     s = s[:3].replace(altsep, sep)
     # Absolute: UNC, device, and paths with a drive and root.
-    if s[:1] == sep:
-        return s[1:2] == sep
+    if s.startswith(sep):
+        return s.startswith(sep, 1)
     else:
-        return s[1:3] == colon_sep
+        return s.startswith(colon_sep, 1)
 
 # Join two (or more) paths.
 def join(path, *paths):

--- a/Lib/ntpath.py
+++ b/Lib/ntpath.py
@@ -85,16 +85,16 @@ def isabs(s):
         sep = b'\\'
         altsep = b'/'
         colon_sep = b':\\'
-        double_sep = b'\\\\'
     else:
         sep = '\\'
         altsep = '/'
         colon_sep = ':\\'
-        double_sep = '\\\\'
     s = s[:3].replace(altsep, sep)
     # Absolute: UNC, device, and paths with a drive and root.
-    return (s[1:3] == colon_sep and s[:1] != sep) or s[:2] == double_sep
-
+    if s[:1] == sep:
+        return s[1:2] == sep
+    else:
+        return s[1:3] == colon_sep
 
 # Join two (or more) paths.
 def join(path, *paths):

--- a/Lib/test/test_ntpath.py
+++ b/Lib/test/test_ntpath.py
@@ -234,11 +234,12 @@ class TestNtpath(NtpathTestCase):
         tester('ntpath.isabs("c:/foo/bar")', 1)
         tester('ntpath.isabs("\\\\conky\\mountpoint\\")', 1)
 
-        # gh-44626: paths with only a drive or root are not absolute.
+        # gh-44626 & gh-117352: paths with only a drive or root are not absolute.
         tester('ntpath.isabs("\\foo\\bar")', 0)
         tester('ntpath.isabs("/foo/bar")', 0)
         tester('ntpath.isabs("c:foo\\bar")', 0)
         tester('ntpath.isabs("c:foo/bar")', 0)
+        tester('ntpath.isabs("/:/foo/bar")', 0)
 
         # gh-96290: normal UNC paths and device paths without trailing backslashes
         tester('ntpath.isabs("\\\\conky\\mountpoint")', 1)

--- a/Misc/NEWS.d/next/Core and Builtins/2024-03-29-07-34-39.gh-issue-117352.-34fR4.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2024-03-29-07-34-39.gh-issue-117352.-34fR4.rst
@@ -1,0 +1,1 @@
+Handle ``/:`` for :func:`ntpath.isabs`.

--- a/Misc/NEWS.d/next/Core and Builtins/2024-03-29-07-34-39.gh-issue-117352.-34fR4.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2024-03-29-07-34-39.gh-issue-117352.-34fR4.rst
@@ -1,1 +1,1 @@
-Handle ``/:`` for :func:`ntpath.isabs`.
+Handle ``/:/`` for :func:`ntpath.isabs`.


### PR DESCRIPTION
Benchmark:

```shell
# test.sh
python -m timeit -s "import before.ntpath" "before.ntpath.isabs('C:/foo')"
python -m timeit -s "import after.ntpath" "after.ntpath.isabs('C:/foo')"
```

```none
500000 loops, best of 5: 398 nsec per loop # before
500000 loops, best of 5: 469 nsec per loop # after
# -> 1.18x slower
```

<!-- gh-issue-number: gh-117352 -->
* Issue: gh-117352
<!-- /gh-issue-number -->
