### PR TITLE
gh-117313: Fix re-folding email messages containing non-standard line separators

### DIFF
--- a/Lib/email/policy.py
+++ b/Lib/email/policy.py
@@ -21,7 +21,7 @@ __all__ = [
     'HTTP',
     ]
 
-linesep_splitter = re.compile(r'\n|\r')
+linesep_splitter = re.compile(r'\n|\r\n?')
 
 @_extend_docstrings
 class EmailPolicy(Policy):
@@ -205,7 +205,8 @@ class EmailPolicy(Policy):
         if hasattr(value, 'name'):
             return value.fold(policy=self)
         maxlen = self.max_line_length if self.max_line_length else sys.maxsize
-        lines = value.splitlines()
+        # We can't use splitlines here because it splits on more than \r and \n.
+        lines = linesep_splitter.split(value)
         refold = (self.refold_source == 'all' or
                   self.refold_source == 'long' and
                     (lines and len(lines[0])+len(name)+2 > maxlen or

--- a/Misc/NEWS.d/next/Library/2024-03-29-15-14-51.gh-issue-117313.ks_ONu.rst
+++ b/Misc/NEWS.d/next/Library/2024-03-29-15-14-51.gh-issue-117313.ks_ONu.rst
@@ -1,0 +1,4 @@
+Only treat ``'\n'``, ``'\r'`` and ``'\r\n'`` as line separators in
+re-folding the :mod:`email` messages. Preserve control characters ``'\v'``,
+``'\f'``, ``'\x1c'``, ``'\x1d'`` and ``'\x1e'`` and Unicode line separators
+``'\x85'``, ``'\u2028'`` and ``'\u2029'`` as is.


### PR DESCRIPTION
Only treat '\n', '\r' and '\r\n' as line separators in re-folding the email messages.  Preserve control characters '\v', '\f', '\x1c', '\x1d' and '\x1e' and Unicode line separators '\x85', '\u2028' and '\u2029' as is.


<!-- gh-issue-number: gh-117313 -->
* Issue: gh-117313
<!-- /gh-issue-number -->
