### PR TITLE
Fix broken format in error for bad input in summarize_stats.py

### DIFF
--- a/Tools/scripts/summarize_stats.py
+++ b/Tools/scripts/summarize_stats.py
@@ -114,7 +114,7 @@ def load_raw_data(input: Path) -> RawData:
         return data
 
     else:
-        raise ValueError(f"{input:r} is not a file or directory path")
+        raise ValueError(f"{input} is not a file or directory path")
 
 
 def save_raw_data(data: RawData, json_output: TextIO):


### PR DESCRIPTION
I just ran into this. When you pass the script a non-existent input file, you get a traceback like this:
```
Traceback (most recent call last):
  File "/Users/guido/cpython/Tools/scripts/summarize_stats.py", line 1446, in <module>
    main()
    ~~~~^^
  File "/Users/guido/cpython/Tools/scripts/summarize_stats.py", line 1442, in main
    output_stats(args.inputs, json_output=args.json_output)
    ~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/guido/cpython/Tools/scripts/summarize_stats.py", line 1407, in output_stats
    head_data = load_raw_data(Path(inputs[1]))
                ~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "/Users/guido/cpython/Tools/scripts/summarize_stats.py", line 117, in load_raw_data
    raise ValueError(f"{input:r} is not a file or directory path")
                       ^^^^^^^^^
TypeError: unsupported format string passed to PosixPath.__format__
```
CC: @mdboom