### PR TITLE
DOC: cpython/Lib/collections:Counter.elements: fix docstring

### DIFF
--- a/Lib/collections/__init__.py
+++ b/Lib/collections/__init__.py
@@ -639,14 +639,15 @@ class Counter(dict):
         >>> sorted(c.elements())
         ['A', 'A', 'B', 'B', 'C', 'C']
 
-        # Knuth's example for prime factors of 1836:  2**2 * 3**3 * 17**1
+        Knuth's example for prime factors of 1836:  ``2**2 * 3**3 * 17**1``:
+        
         >>> import math
         >>> prime_factors = Counter({2: 2, 3: 3, 17: 1})
         >>> math.prod(prime_factors.elements())
         1836
 
         Note, if an element's count has been set to zero or is a negative
-        number, elements() will ignore it.
+        number, ``elements()`` will ignore it.
 
         '''
         # Emulate Bag.do from Smalltalk and Multiset.begin from C++.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

- Noticed this due to https://www.nltk.org/api/nltk.probability.FreqDist.html#nltk.probability.FreqDist.elements
- https://docs.python.org/3/library/collections.html#collections.Counter.elements https://github.com/python/cpython/blob/main/Doc/library/collections.rst#counter-objects doesn't have auto-apidoc because it's narrative docs, and doesn't also mention that setting the value to <=0 causes the element to be omitted from `elements()`