### PR TITLE
gh-107674: Remove some unnecessary code in instrumentation code

### DIFF
--- a/Python/instrumentation.c
+++ b/Python/instrumentation.c
@@ -1197,7 +1197,7 @@ _Py_call_instrumentation_line(PyThreadState *tstate, _PyInterpreterFrame* frame,
     /* Special case sys.settrace to avoid boxing the line number,
      * only to immediately unbox it. */
     if (tools & (1 << PY_MONITORING_SYS_TRACE_ID)) {
-        if (tstate->c_tracefunc != NULL && line >= 0) {
+        if (tstate->c_tracefunc != NULL) {
             PyFrameObject *frame_obj = _PyFrame_GetFrameObject(frame);
             if (frame_obj == NULL) {
                 return -1;

--- a/Python/sysmodule.c
+++ b/Python/sysmodule.c
@@ -1079,9 +1079,6 @@ trace_trampoline(PyObject *self, PyFrameObject *frame,
     if (result != Py_None) {
         Py_XSETREF(frame->f_trace, result);
     }
-    else {
-        Py_DECREF(result);
-    }
     return 0;
 }
 

--- a/Python/sysmodule.c
+++ b/Python/sysmodule.c
@@ -1079,6 +1079,9 @@ trace_trampoline(PyObject *self, PyFrameObject *frame,
     if (result != Py_None) {
         Py_XSETREF(frame->f_trace, result);
     }
+    else {
+        Py_DECREF(result);
+    }
     return 0;
 }
 


### PR DESCRIPTION
This might not be super helpful but it's free and easy to justify. Also it makes the code cleaner, not messier. 
* `line >= 0` was already asserted above so the check is unnecessary
* `Py_None` is immortal now so `Py_DECREF` is a no-op.

<!-- gh-issue-number: gh-107674 -->
* Issue: gh-107674
<!-- /gh-issue-number -->
