### PR TITLE
gh-117394: Reduce syscalls for `posixpath.ismount`

### DIFF
--- a/Lib/posixpath.py
+++ b/Lib/posixpath.py
@@ -202,12 +202,7 @@ def ismount(path):
         if stat.S_ISLNK(s1.st_mode):
             return False
 
-    path = os.fspath(path)
-    if isinstance(path, bytes):
-        parent = join(path, b'..')
-    else:
-        parent = join(path, '..')
-    parent = realpath(parent)
+    parent = dirname(abspath(path))
     try:
         s2 = os.lstat(parent)
     except (OSError, ValueError):

--- a/Lib/posixpath.py
+++ b/Lib/posixpath.py
@@ -204,7 +204,7 @@ def ismount(path):
 
     parent = dirname(abspath(path))
     try:
-        s2 = os.lstat(parent)
+        s2 = os.stat(parent)
     except (OSError, ValueError):
         return False
 

--- a/Lib/test/test_posixpath.py
+++ b/Lib/test/test_posixpath.py
@@ -242,6 +242,7 @@ class PosixPathTest(unittest.TestCase):
     def test_ismount_different_device(self):
         # Simulate the path being on a different device from its parent by
         # mocking out st_dev.
+        save_stat = os.stat
         save_lstat = os.lstat
         def fake_lstat(path):
             st_ino = 0
@@ -251,15 +252,17 @@ class PosixPathTest(unittest.TestCase):
                 st_ino = 1
             return posix.stat_result((0, st_ino, st_dev, 0, 0, 0, 0, 0, 0, 0))
         try:
-            os.lstat = fake_lstat
+            os.stat = os.lstat = fake_lstat
             self.assertIs(posixpath.ismount(ABSTFN), True)
         finally:
+            os.stat = save_stat
             os.lstat = save_lstat
 
     @unittest.skipIf(posix is None, "Test requires posix module")
     def test_ismount_directory_not_readable(self):
         # issue #2466: Simulate ismount run on a directory that is not
         # readable, which used to return False.
+        save_stat = os.stat
         save_lstat = os.lstat
         def fake_lstat(path):
             st_ino = 0
@@ -273,9 +276,10 @@ class PosixPathTest(unittest.TestCase):
                 st_ino = 1
             return posix.stat_result((0, st_ino, st_dev, 0, 0, 0, 0, 0, 0, 0))
         try:
-            os.lstat = fake_lstat
+            os.stat = os.lstat = fake_lstat
             self.assertIs(posixpath.ismount(ABSTFN), True)
         finally:
+            os.stat = save_stat
             os.lstat = save_lstat
 
     def test_isjunction(self):

--- a/Misc/NEWS.d/next/Core and Builtins/2024-03-30-19-34-51.gh-issue-117394.qCepkD.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2024-03-30-19-34-51.gh-issue-117394.qCepkD.rst
@@ -1,0 +1,1 @@
+Reduce syscalls for :func:`posixpath.ismount`.

--- a/Misc/NEWS.d/next/Core and Builtins/2024-03-30-19-34-51.gh-issue-117394.qCepkD.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2024-03-30-19-34-51.gh-issue-117394.qCepkD.rst
@@ -1,1 +1,2 @@
-Reduce syscalls for :func:`posixpath.ismount`.
+Speedup :func:`os.path.ismount` on Unix systems by reducing the number of
+syscalls.


### PR DESCRIPTION
Benchmark:

```none
python -m timeit -s "import before.posixpath" "before.posixpath.ismount('/Volumes/2GB_001')" && python -m timeit -s "import after.posixpath" "after.posixpath.ismount('/Volumes/2GB_001')"
10000 loops, best of 5: 21.3 usec per loop # before
50000 loops, best of 5: 8.5 usec per loop # after
# -> 2.51x faster
```

<!-- gh-issue-number: gh-117394 -->
* Issue: gh-117394
<!-- /gh-issue-number -->
