### PR TITLE
gh-59598: Ignore leading whitespace in `JSONDecoder.raw_decode`

### DIFF
--- a/Doc/library/json.rst
+++ b/Doc/library/json.rst
@@ -402,6 +402,9 @@ Encoders and Decoders
       This can be used to decode a JSON document from a string that may have
       extraneous data at the end.
 
+   .. versionchanged:: 3.14
+      Now ignores any leading whitespace instead of returning an error
+
 
 .. class:: JSONEncoder(*, skipkeys=False, ensure_ascii=True, check_circular=True, allow_nan=True, sort_keys=False, indent=None, separators=None, default=None)
 

--- a/Lib/json/decoder.py
+++ b/Lib/json/decoder.py
@@ -341,23 +341,27 @@ class JSONDecoder(object):
         containing a JSON document).
 
         """
-        obj, end = self.raw_decode(s, idx=_w(s, 0).end())
+        obj, end = self.raw_decode(s)
         end = _w(s, end).end()
         if end != len(s):
             raise JSONDecodeError("Extra data", s, end)
         return obj
 
-    def raw_decode(self, s, idx=0):
+    def raw_decode(self, s, idx=0, _w=WHITESPACE.match):
         """Decode a JSON document from ``s`` (a ``str`` beginning with
         a JSON document) and return a 2-tuple of the Python
         representation and the index in ``s`` where the document ended.
+        Whitespace at the beginning of the document will be ignored.
+
+        Optionally, ``idx`` can be used to specify an offset in ``s``
+        where the document begins.
 
         This can be used to decode a JSON document from a string that may
         have extraneous data at the end.
 
         """
         try:
-            obj, end = self.scan_once(s, idx)
+            obj, end = self.scan_once(s, idx=_w(s, idx).end())
         except StopIteration as err:
             raise JSONDecodeError("Expecting value", s, err.value) from None
         return obj, end

--- a/Lib/test/test_json/test_decode.py
+++ b/Lib/test/test_json/test_decode.py
@@ -124,6 +124,20 @@ class TestDecode:
             with self.assertRaises(ValueError):
                 self.loads('1' * (maxdigits + 1))
 
+class TestRawDecode:
+    def test_whitespace(self):
+        decoder = self.json.JSONDecoder()
+        self.assertEqual(decoder.raw_decode(' {}'), ({}, 3))
+        self.assertEqual(decoder.raw_decode('  []'), ([], 4))
+        self.assertEqual(decoder.raw_decode('   ""'), ('', 5))
+        s = '  {   "key"    :    "value"    ,  "k":"v"    } \n' \
+            ' { "key": "value",  "k" :"v"} '
+        val1, n1 = decoder.raw_decode(s)
+        val2, n2 = decoder.raw_decode(s[n1:])
+        self.assertEqual(val1, {"key":"value", "k":"v"})
+        self.assertEqual(val2, {"key":"value", "k":"v"})
 
 class TestPyDecode(TestDecode, PyTest): pass
 class TestCDecode(TestDecode, CTest): pass
+class TestPyRawDecode(TestRawDecode, PyTest): pass
+class TestCRawDecode(TestRawDecode, CTest): pass

--- a/Misc/NEWS.d/next/Library/2024-04-22-07-05-05.gh-issue-59598.LyEKW3.rst
+++ b/Misc/NEWS.d/next/Library/2024-04-22-07-05-05.gh-issue-59598.LyEKW3.rst
@@ -1,0 +1,1 @@
+Ignore leading whitespace in :func:`JSONDecoder.raw_decode`


### PR DESCRIPTION
Based on Bayard's patch in https://bugs.python.org/issue15393
Fixes #59598 

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-59598 -->
* Issue: gh-59598
<!-- /gh-issue-number -->
