### PR TITLE
gh-117411: move PyFutureFeatures to pycore_symtable.h and make it private

### DIFF
--- a/Include/cpython/compile.h
+++ b/Include/cpython/compile.h
@@ -49,11 +49,6 @@ typedef struct {
 
 /* Future feature support */
 
-typedef struct {
-    int ff_features;                    /* flags set by future statements */
-    _PyCompilerSrcLocation ff_location; /* location of last future statement */
-} PyFutureFeatures;
-
 #define FUTURE_NESTED_SCOPES "nested_scopes"
 #define FUTURE_GENERATORS "generators"
 #define FUTURE_DIVISION "division"

--- a/Include/cpython/compile.h
+++ b/Include/cpython/compile.h
@@ -32,21 +32,6 @@ typedef struct {
 #define _PyCompilerFlags_INIT \
     (PyCompilerFlags){.cf_flags = 0, .cf_feature_version = PY_MINOR_VERSION}
 
-/* source location information */
-typedef struct {
-    int lineno;
-    int end_lineno;
-    int col_offset;
-    int end_col_offset;
-} _PyCompilerSrcLocation;
-
-#define SRC_LOCATION_FROM_AST(n) \
-    (_PyCompilerSrcLocation){ \
-               .lineno = (n)->lineno, \
-               .end_lineno = (n)->end_lineno, \
-               .col_offset = (n)->col_offset, \
-               .end_col_offset = (n)->end_col_offset }
-
 /* Future feature support */
 
 #define FUTURE_NESTED_SCOPES "nested_scopes"

--- a/Include/internal/pycore_compile.h
+++ b/Include/internal/pycore_compile.h
@@ -8,6 +8,8 @@ extern "C" {
 #  error "this header requires Py_BUILD_CORE define"
 #endif
 
+#include "pycore_symtable.h"  // _Py_SourceLocation
+
 struct _arena;   // Type defined in pycore_pyarena.h
 struct _mod;     // Type defined in pycore_ast.h
 
@@ -27,7 +29,7 @@ extern int _PyCompile_AstOptimize(
     int optimize,
     struct _arena *arena);
 
-static const _PyCompilerSrcLocation NO_LOCATION = {-1, -1, -1, -1};
+struct _Py_SourceLocation;
 
 extern int _PyAST_Optimize(
     struct _mod *,
@@ -44,7 +46,7 @@ typedef struct {
 typedef struct {
     int i_opcode;
     int i_oparg;
-    _PyCompilerSrcLocation i_loc;
+    _Py_SourceLocation i_loc;
     _PyCompile_ExceptHandlerInfo i_except_handler_info;
 
     /* Used by the assembler */
@@ -65,7 +67,7 @@ typedef struct {
 int _PyCompile_InstructionSequence_UseLabel(_PyCompile_InstructionSequence *seq, int lbl);
 int _PyCompile_InstructionSequence_Addop(_PyCompile_InstructionSequence *seq,
                                          int opcode, int oparg,
-                                         _PyCompilerSrcLocation loc);
+                                         _Py_SourceLocation loc);
 int _PyCompile_InstructionSequence_ApplyLabelMap(_PyCompile_InstructionSequence *seq);
 
 typedef struct {

--- a/Include/internal/pycore_flowgraph.h
+++ b/Include/internal/pycore_flowgraph.h
@@ -18,7 +18,7 @@ typedef struct {
 struct _PyCfgBuilder;
 
 int _PyCfgBuilder_UseLabel(struct _PyCfgBuilder *g, _PyCfgJumpTargetLabel lbl);
-int _PyCfgBuilder_Addop(struct _PyCfgBuilder *g, int opcode, int oparg, _PyCompilerSrcLocation loc);
+int _PyCfgBuilder_Addop(struct _PyCfgBuilder *g, int opcode, int oparg, _Py_SourceLocation loc);
 
 struct _PyCfgBuilder* _PyCfgBuilder_New(void);
 void _PyCfgBuilder_Free(struct _PyCfgBuilder *g);

--- a/Include/internal/pycore_symtable.h
+++ b/Include/internal/pycore_symtable.h
@@ -29,6 +29,11 @@ typedef enum _comprehension_type {
     SetComprehension = 3,
     GeneratorExpression = 4 } _Py_comprehension_ty;
 
+typedef struct {
+    int ff_features;                    /* flags set by future statements */
+    _PyCompilerSrcLocation ff_location; /* location of last future statement */
+} _PyFutureFeatures;
+
 struct _symtable_entry;
 
 struct symtable {
@@ -44,7 +49,7 @@ struct symtable {
                                        consistency with the corresponding
                                        compiler structure */
     PyObject *st_private;           /* name of current class or NULL */
-    PyFutureFeatures *st_future;    /* module's future features that affect
+    _PyFutureFeatures *st_future;   /* module's future features that affect
                                        the symbol table */
     int recursion_depth;            /* current recursion depth */
     int recursion_limit;            /* recursion limit */
@@ -100,7 +105,7 @@ extern int _PyST_IsFunctionLike(PySTEntryObject *);
 extern struct symtable* _PySymtable_Build(
     struct _mod *mod,
     PyObject *filename,
-    PyFutureFeatures *future);
+    _PyFutureFeatures *future);
 extern PySTEntryObject* _PySymtable_Lookup(struct symtable *, void *);
 
 extern void _PySymtable_Free(struct symtable *);
@@ -150,7 +155,7 @@ extern struct symtable* _Py_SymtableStringObjectFlags(
 int _PyFuture_FromAST(
     struct _mod * mod,
     PyObject *filename,
-    PyFutureFeatures* futures);
+    _PyFutureFeatures* futures);
 
 #ifdef __cplusplus
 }

--- a/Include/internal/pycore_symtable.h
+++ b/Include/internal/pycore_symtable.h
@@ -29,9 +29,27 @@ typedef enum _comprehension_type {
     SetComprehension = 3,
     GeneratorExpression = 4 } _Py_comprehension_ty;
 
+/* source location information */
+typedef struct {
+    int lineno;
+    int end_lineno;
+    int col_offset;
+    int end_col_offset;
+} _Py_SourceLocation;
+
+#define SRC_LOCATION_FROM_AST(n) \
+    (_Py_SourceLocation){ \
+               .lineno = (n)->lineno, \
+               .end_lineno = (n)->end_lineno, \
+               .col_offset = (n)->col_offset, \
+               .end_col_offset = (n)->end_col_offset }
+
+static const _Py_SourceLocation NO_LOCATION = {-1, -1, -1, -1};
+
+/* __future__ information */
 typedef struct {
     int ff_features;                    /* flags set by future statements */
-    _PyCompilerSrcLocation ff_location; /* location of last future statement */
+    _Py_SourceLocation ff_location;     /* location of last future statement */
 } _PyFutureFeatures;
 
 struct _symtable_entry;

--- a/Misc/NEWS.d/next/Core and Builtins/2024-04-02-10-04-57.gh-issue-117411.YdyVmG.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2024-04-02-10-04-57.gh-issue-117411.YdyVmG.rst
@@ -1,0 +1,1 @@
+Move ``PyFutureFeatures`` to an internal header and make it private.

--- a/Python/assemble.c
+++ b/Python/assemble.c
@@ -5,6 +5,7 @@
 #include "pycore_compile.h"
 #include "pycore_opcode_utils.h"    // IS_BACKWARDS_JUMP_OPCODE
 #include "pycore_opcode_metadata.h" // is_pseudo_target, _PyOpcode_Caches
+#include "pycore_symtable.h"        // _Py_SourceLocation
 
 
 #define DEFAULT_CODE_SIZE 128
@@ -21,7 +22,7 @@
         return ERROR;       \
     }
 
-typedef _PyCompilerSrcLocation location;
+typedef _Py_SourceLocation location;
 typedef _PyCompile_Instruction instruction;
 typedef _PyCompile_InstructionSequence instr_sequence;
 

--- a/Python/compile.c
+++ b/Python/compile.c
@@ -408,7 +408,7 @@ handled by the symbol analysis pass.
 struct compiler {
     PyObject *c_filename;
     struct symtable *c_st;
-    PyFutureFeatures c_future;   /* module's __future__ */
+    _PyFutureFeatures c_future;  /* module's __future__ */
     PyCompilerFlags c_flags;
 
     int c_optimize;              /* optimization level */
@@ -585,7 +585,7 @@ int
 _PyCompile_AstOptimize(mod_ty mod, PyObject *filename, PyCompilerFlags *cf,
                        int optimize, PyArena *arena)
 {
-    PyFutureFeatures future;
+    _PyFutureFeatures future;
     if (!_PyFuture_FromAST(mod, filename, &future)) {
         return -1;
     }

--- a/Python/compile.c
+++ b/Python/compile.c
@@ -70,11 +70,11 @@
         ((C)->c_flags.cf_flags & PyCF_ALLOW_TOP_LEVEL_AWAIT) \
         && ((C)->u->u_ste->ste_type == ModuleBlock))
 
-typedef _PyCompilerSrcLocation location;
+typedef _Py_SourceLocation location;
 typedef struct _PyCfgBuilder cfg_builder;
 
 #define LOCATION(LNO, END_LNO, COL, END_COL) \
-    ((const _PyCompilerSrcLocation){(LNO), (END_LNO), (COL), (END_COL)})
+    ((const _Py_SourceLocation){(LNO), (END_LNO), (COL), (END_COL)})
 
 /* Return true if loc1 starts after loc2 ends. */
 static inline bool

--- a/Python/flowgraph.c
+++ b/Python/flowgraph.c
@@ -22,13 +22,13 @@
 
 #define DEFAULT_BLOCK_SIZE 16
 
-typedef _PyCompilerSrcLocation location;
+typedef _Py_SourceLocation location;
 typedef _PyCfgJumpTargetLabel jump_target_label;
 
 typedef struct _PyCfgInstruction {
     int i_opcode;
     int i_oparg;
-    _PyCompilerSrcLocation i_loc;
+    _Py_SourceLocation i_loc;
     struct _PyCfgBasicblock *i_target; /* target block (if jump instruction) */
     struct _PyCfgBasicblock *i_except; /* target block when exception is raised */
 } cfg_instr;
@@ -92,7 +92,7 @@ static const jump_target_label NO_LABEL = {-1};
 #define IS_LABEL(L) (!SAME_LABEL((L), (NO_LABEL)))
 
 #define LOCATION(LNO, END_LNO, COL, END_COL) \
-    ((const _PyCompilerSrcLocation){(LNO), (END_LNO), (COL), (END_COL)})
+    ((const _Py_SourceLocation){(LNO), (END_LNO), (COL), (END_COL)})
 
 static inline int
 is_block_push(cfg_instr *i)

--- a/Python/future.c
+++ b/Python/future.c
@@ -1,11 +1,12 @@
 #include "Python.h"
 #include "pycore_ast.h"           // _PyAST_GetDocString()
+#include "pycore_symtable.h"      // _PyFutureFeatures
 #include "pycore_unicodeobject.h" // _PyUnicode_EqualToASCIIString()
 
 #define UNDEFINED_FUTURE_FEATURE "future feature %.100s is not defined"
 
 static int
-future_check_features(PyFutureFeatures *ff, stmt_ty s, PyObject *filename)
+future_check_features(_PyFutureFeatures *ff, stmt_ty s, PyObject *filename)
 {
     int i;
 
@@ -53,7 +54,7 @@ future_check_features(PyFutureFeatures *ff, stmt_ty s, PyObject *filename)
 }
 
 static int
-future_parse(PyFutureFeatures *ff, mod_ty mod, PyObject *filename)
+future_parse(_PyFutureFeatures *ff, mod_ty mod, PyObject *filename)
 {
     if (!(mod->kind == Module_kind || mod->kind == Interactive_kind)) {
         return 1;
@@ -98,7 +99,7 @@ future_parse(PyFutureFeatures *ff, mod_ty mod, PyObject *filename)
 
 
 int
-_PyFuture_FromAST(mod_ty mod, PyObject *filename, PyFutureFeatures *ff)
+_PyFuture_FromAST(mod_ty mod, PyObject *filename, _PyFutureFeatures *ff)
 {
     ff->ff_features = 0;
     ff->ff_location = (_PyCompilerSrcLocation){-1, -1, -1, -1};

--- a/Python/future.c
+++ b/Python/future.c
@@ -102,7 +102,7 @@ int
 _PyFuture_FromAST(mod_ty mod, PyObject *filename, _PyFutureFeatures *ff)
 {
     ff->ff_features = 0;
-    ff->ff_location = (_PyCompilerSrcLocation){-1, -1, -1, -1};
+    ff->ff_location = (_Py_SourceLocation){-1, -1, -1, -1};
 
     if (!future_parse(ff, mod, filename)) {
         return 0;

--- a/Python/symtable.c
+++ b/Python/symtable.c
@@ -387,7 +387,7 @@ symtable_new(void)
 }
 
 struct symtable *
-_PySymtable_Build(mod_ty mod, PyObject *filename, PyFutureFeatures *future)
+_PySymtable_Build(mod_ty mod, PyObject *filename, _PyFutureFeatures *future)
 {
     struct symtable *st = symtable_new();
     asdl_stmt_seq *seq;
@@ -2757,7 +2757,7 @@ _Py_SymtableStringObjectFlags(const char *str, PyObject *filename,
         _PyArena_Free(arena);
         return NULL;
     }
-    PyFutureFeatures future;
+    _PyFutureFeatures future;
     if (!_PyFuture_FromAST(mod, filename, &future)) {
         _PyArena_Free(arena);
         return NULL;

--- a/Python/traceback.c
+++ b/Python/traceback.c
@@ -5,7 +5,6 @@
 
 #include "pycore_ast.h"           // asdl_seq_GET()
 #include "pycore_call.h"          // _PyObject_CallMethodFormat()
-#include "pycore_compile.h"       // _PyAST_Optimize()
 #include "pycore_fileutils.h"     // _Py_BEGIN_SUPPRESS_IPH
 #include "pycore_frame.h"         // _PyFrame_GetCode()
 #include "pycore_interp.h"        // PyInterpreterState.gc


### PR DESCRIPTION
``PyFutureFeatures``  is not used by any public APIs, so nobody should be relying on it.

Also move ``_PyCompilerSrcLocation`` along with it, and rename to ``_Py_SourceLocation`` so the symtable can use it.

Fixes #117411.

<!-- gh-issue-number: gh-117411 -->
* Issue: gh-117411
<!-- /gh-issue-number -->
