### PR TITLE
gh-94808: Fix refcounting in PyObject_Print tests

### DIFF
--- a/Modules/_testcapi/object.c
+++ b/Modules/_testcapi/object.c
@@ -76,6 +76,8 @@ pyobject_print_noref_object(PyObject *self, PyObject *args)
 
     if (PyObject_Print(test_string, fp, 0) < 0){
         fclose(fp);
+        Py_SET_REFCNT(test_string, 1);
+        Py_DECREF(test_string);
         return NULL;
     }
 
@@ -105,10 +107,12 @@ pyobject_print_os_error(PyObject *self, PyObject *args)
 
     if (PyObject_Print(test_string, fp, 0) < 0) {
         fclose(fp);
+        Py_DECREF(test_string);
         return NULL;
     }
 
     fclose(fp);
+    Py_DECREF(test_string);
 
     Py_RETURN_NONE;
 }


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-94808 -->
* Issue: gh-94808
<!-- /gh-issue-number -->
