### PR TITLE
gh-117431: Improve performance of startswith, endswith, count and find methods for strings and bytes

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2024-04-01-21-15-35.gh-issue-117431.UBT4zj.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2024-04-01-21-15-35.gh-issue-117431.UBT4zj.rst
@@ -1,0 +1,1 @@
+Improve performance of startswith, endswith, count and find methods for strings and bytes.

--- a/Objects/stringlib/find.h
+++ b/Objects/stringlib/find.h
@@ -91,6 +91,15 @@ STRINGLIB(parse_args_finds)(const char * function_name, PyObject *args,
     Py_ssize_t tmp_start = 0;
     Py_ssize_t tmp_end = PY_SSIZE_T_MAX;
     PyObject *obj_start=Py_None, *obj_end=Py_None;
+
+    if (PyTuple_GET_SIZE(args) == 1) {
+        // fast path
+        *start = tmp_start;
+        *end = tmp_end;
+        *subobj = Py_NewRef(PyTuple_GET_ITEM(args, 0));
+        return 1;
+    }
+
     char format[FORMAT_BUFFER_SIZE] = "O|OO:";
     size_t len = strlen(format);
 

--- a/Objects/stringlib/find.h
+++ b/Objects/stringlib/find.h
@@ -96,7 +96,7 @@ STRINGLIB(parse_args_finds)(const char * function_name, PyObject *args,
         // fast path
         *start = tmp_start;
         *end = tmp_end;
-        *subobj = Py_NewRef(PyTuple_GET_ITEM(args, 0));
+        *subobj = PyTuple_GET_ITEM(args, 0);
         return 1;
     }
 


### PR DESCRIPTION
Benchmarks (non-PGO):

```
main: python -m timeit -s "s = 'abcdef'" "s.startswith('abc')"
5000000 loops, best of 5: 63.8 nsec per loop

pr: python -m timeit -s "s = 'abcdef'" "s.startswith('abc')"
5000000 loops, best of 5: 42.3 nsec per loop
```

```
main: python -m timeit -s "s = 'abcdef'" "s.count('a')"
5000000 loops, best of 5: 70 nsec per loop

pr: python -m timeit -s "s = 'abcdef'" "s.count('a')"
5000000 loops, best of 5: 51.4 nsec per loop
```

```
main: python -m timeit -s "s = b'abcdef'" "s.startswith(b'q')"
5000000 loops, best of 5: 68.3 nsec per loop

pr: python -m timeit -s "s = b'abcdef'" "s.startswith(b'q')"
5000000 loops, best of 5: 44.5 nsec per loop
```

Notes:
* We could also add a fast path for the case where there are 2 or 3 arguments. Since all arguments are positional only, for 1, 2 or 3 arguments the parsing cannot fail. That will increase performance for the 2 and 3 argument case, but it adds some more complexity.
 
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-117431 -->
* Issue: gh-117431
<!-- /gh-issue-number -->
