### PR TITLE
gh-112087: Make `list.extend(dict)` behave atomically

### DIFF
--- a/Objects/listobject.c
+++ b/Objects/listobject.c
@@ -1374,6 +1374,11 @@ _list_extend(PyListObject *self, PyObject *iterable)
         res = list_extend_set(self, (PySetObject *)iterable);
         Py_END_CRITICAL_SECTION2();
     }
+    else if (PyDict_CheckExact(iterable)) {
+        Py_BEGIN_CRITICAL_SECTION2(self, iterable);
+        res = list_extend_dict(self, (PyDictObject *)iterable, 0 /*keys*/);
+        Py_END_CRITICAL_SECTION2();
+    }
     else if (Py_IS_TYPE(iterable, &PyDictKeys_Type)) {
         PyDictObject *dict = ((_PyDictViewObject *)iterable)->dv_dict;
         Py_BEGIN_CRITICAL_SECTION2(self, dict);


### PR DESCRIPTION
Add a special case for `list.extend(dict)` and `list(dict)` so that those patterns behave atomically with respect to modifications to the list or dictionary when the GIL is disabled.

This is required by multiprocessing, which assumes that `list(_finalizer_registry)` is atomic.

<!-- gh-issue-number: gh-112087 -->
* Issue: gh-112087
<!-- /gh-issue-number -->