### PR TITLE
gh-117440: Make `syslog` thread-safe in free-threaded builds

### DIFF
--- a/Modules/clinic/syslogmodule.c.h
+++ b/Modules/clinic/syslogmodule.c.h
@@ -6,6 +6,7 @@ preserve
 #  include "pycore_gc.h"          // PyGC_Head
 #  include "pycore_runtime.h"     // _Py_ID()
 #endif
+#include "pycore_critical_section.h"// Py_BEGIN_CRITICAL_SECTION()
 #include "pycore_modsupport.h"    // _PyArg_UnpackKeywords()
 
 PyDoc_STRVAR(syslog_openlog__doc__,
@@ -88,7 +89,9 @@ syslog_openlog(PyObject *module, PyObject *const *args, Py_ssize_t nargs, PyObje
         goto exit;
     }
 skip_optional_pos:
+    Py_BEGIN_CRITICAL_SECTION(module);
     return_value = syslog_openlog_impl(module, ident, logopt, facility);
+    Py_END_CRITICAL_SECTION();
 
 exit:
     return return_value;
@@ -129,7 +132,9 @@ syslog_syslog(PyObject *module, PyObject *args)
             PyErr_SetString(PyExc_TypeError, "syslog.syslog requires 1 to 2 arguments");
             goto exit;
     }
+    Py_BEGIN_CRITICAL_SECTION(module);
     return_value = syslog_syslog_impl(module, group_left_1, priority, message);
+    Py_END_CRITICAL_SECTION();
 
 exit:
     return return_value;
@@ -150,7 +155,13 @@ syslog_closelog_impl(PyObject *module);
 static PyObject *
 syslog_closelog(PyObject *module, PyObject *Py_UNUSED(ignored))
 {
-    return syslog_closelog_impl(module);
+    PyObject *return_value = NULL;
+
+    Py_BEGIN_CRITICAL_SECTION(module);
+    return_value = syslog_closelog_impl(module);
+    Py_END_CRITICAL_SECTION();
+
+    return return_value;
 }
 
 PyDoc_STRVAR(syslog_setlogmask__doc__,
@@ -251,4 +262,4 @@ syslog_LOG_UPTO(PyObject *module, PyObject *arg)
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=86ca2fd84b2da98e input=a9049054013a1b77]*/
+/*[clinic end generated code: output=8d25899bd31969d3 input=a9049054013a1b77]*/

--- a/Modules/syslogmodule.c
+++ b/Modules/syslogmodule.c
@@ -132,6 +132,7 @@ syslog_get_argv(void)
 
 
 /*[clinic input]
+@critical_section
 syslog.openlog
 
     ident: unicode = NULL
@@ -144,7 +145,7 @@ Set logging options of subsequent syslog() calls.
 static PyObject *
 syslog_openlog_impl(PyObject *module, PyObject *ident, long logopt,
                     long facility)
-/*[clinic end generated code: output=5476c12829b6eb75 input=8a987a96a586eee7]*/
+/*[clinic end generated code: output=5476c12829b6eb75 input=ee700b8786f81c23]*/
 {
     // Since the sys.openlog changes the process level state of syslog library,
     // this operation is only allowed for the main interpreter.
@@ -189,6 +190,7 @@ syslog_openlog_impl(PyObject *module, PyObject *ident, long logopt,
 
 
 /*[clinic input]
+@critical_section
 syslog.syslog
 
     [
@@ -205,7 +207,7 @@ Send the string message to the system logger.
 static PyObject *
 syslog_syslog_impl(PyObject *module, int group_left_1, int priority,
                    const char *message)
-/*[clinic end generated code: output=c3dbc73445a0e078 input=ac83d92b12ea3d4e]*/
+/*[clinic end generated code: output=c3dbc73445a0e078 input=6588ddb0b113af8e]*/
 {
     if (PySys_Audit("syslog.syslog", "is", priority, message) < 0) {
         return NULL;
@@ -243,6 +245,7 @@ syslog_syslog_impl(PyObject *module, int group_left_1, int priority,
 
 
 /*[clinic input]
+@critical_section
 syslog.closelog
 
 Reset the syslog module values and call the system library closelog().
@@ -250,7 +253,7 @@ Reset the syslog module values and call the system library closelog().
 
 static PyObject *
 syslog_closelog_impl(PyObject *module)
-/*[clinic end generated code: output=97890a80a24b1b84 input=fb77a54d447acf07]*/
+/*[clinic end generated code: output=97890a80a24b1b84 input=167f489868bd5a72]*/
 {
     // Since the sys.closelog changes the process level state of syslog library,
     // this operation is only allowed for the main interpreter.


### PR DESCRIPTION
Use critical sections to protect access to the syslog module.


<!-- gh-issue-number: gh-117440 -->
* Issue: gh-117440
<!-- /gh-issue-number -->
