### PR TITLE
gh-115009: Update macOS installer to use SQLite 3.45.3.

### DIFF
--- a/Mac/BuildScript/build-installer.py
+++ b/Mac/BuildScript/build-installer.py
@@ -359,9 +359,9 @@ def library_recipes():
                   ),
           ),
           dict(
-              name="SQLite 3.45.1",
-              url="https://sqlite.org/2024/sqlite-autoconf-3450100.tar.gz",
-              checksum="cd9c27841b7a5932c9897651e20b86c701dd740556989b01ca596fcfa3d49a0a",
+              name="SQLite 3.45.3",
+              url="https://sqlite.org/2024/sqlite-autoconf-3450300.tar.gz",
+              checksum="b2809ca53124c19c60f42bf627736eae011afdcc205bb48270a5ee9a38191531",
               extra_cflags=('-Os '
                             '-DSQLITE_ENABLE_FTS5 '
                             '-DSQLITE_ENABLE_FTS4 '

--- a/Misc/NEWS.d/next/macOS/2024-04-15-21-19-39.gh-issue-115009.IdxH9N.rst
+++ b/Misc/NEWS.d/next/macOS/2024-04-15-21-19-39.gh-issue-115009.IdxH9N.rst
@@ -1,0 +1,1 @@
+Update macOS installer to use SQLite 3.45.3.


### PR DESCRIPTION


<!-- gh-issue-number: gh-115009 -->
* Issue: gh-115009
<!-- /gh-issue-number -->
