### PR TITLE
gh-109802: Add coverage test for complex_abs()

### DIFF
--- a/Lib/test/test_complex.py
+++ b/Lib/test/test_complex.py
@@ -598,7 +598,7 @@ class ComplexTest(unittest.TestCase):
         for num in nums:
             self.assertAlmostEqual((num.real**2 + num.imag**2)  ** 0.5, abs(num))
 
-        self.assertRaises(OverflowError, abs, complex(*[DBL_MAX]*2))
+        self.assertRaises(OverflowError, abs, complex(DBL_MAX, DBL_MAX))
 
     def test_repr_str(self):
         def test(v, expected, test_fn=self.assertEqual):

--- a/Lib/test/test_complex.py
+++ b/Lib/test/test_complex.py
@@ -10,6 +10,7 @@ import operator
 
 INF = float("inf")
 NAN = float("nan")
+DBL_MAX = sys.float_info.max
 # These tests ensure that complex math does the right thing
 
 ZERO_DIVISION = (
@@ -596,6 +597,8 @@ class ComplexTest(unittest.TestCase):
         nums = [complex(x/3., y/7.) for x in range(-9,9) for y in range(-9,9)]
         for num in nums:
             self.assertAlmostEqual((num.real**2 + num.imag**2)  ** 0.5, abs(num))
+
+        self.assertRaises(OverflowError, abs, complex(*[DBL_MAX]*2))
 
     def test_repr_str(self):
         def test(v, expected, test_fn=self.assertEqual):


### PR DESCRIPTION
This tests overflow on L594.

// line numbers wrt to 0f2fa6150b

-----------------------------

N.B.  This factor out last test from #109642.  Actually this tested in test_cmath.py, but I think it worth to keep complexobject.c tests in test_complex.py and test_capi/test_complex.py.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-109802 -->
* Issue: gh-109802
<!-- /gh-issue-number -->
