### PR TITLE
GH-114847: Raise FileNotFoundError when getcwd() returns '(unreachable)'

### DIFF
--- a/Misc/NEWS.d/next/Library/2024-04-02-20-30-12.gh-issue-114848.YX4pEc.rst
+++ b/Misc/NEWS.d/next/Library/2024-04-02-20-30-12.gh-issue-114848.YX4pEc.rst
@@ -1,0 +1,2 @@
+Raise :exc:`FileNotFoundError` when ``getcwd()`` returns '(unreachable)',
+which can happen on Linux >= 2.6.36 with glibc < 2.27.

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -4098,19 +4098,6 @@ posix_getcwd(int use_bytes)
         PyMem_RawFree(buf);
         return NULL;
     }
-#ifdef __linux__
-    if (buf[0] != '/') {
-        /*
-         * On Linux >= 2.6.36 with glibc < 2.27, getcwd() can return a
-         * relative pathname starting with '(unreachable)'. We detect this
-         * and fail with ENOENT, matching newer glibc behaviour.
-         */
-        errno = ENOENT;
-        posix_error();
-        PyMem_RawFree(buf);
-        return NULL;
-    }
-#endif
 
     PyObject *obj;
     if (use_bytes) {
@@ -4119,6 +4106,19 @@ posix_getcwd(int use_bytes)
     else {
         obj = PyUnicode_DecodeFSDefault(buf);
     }
+#ifdef __linux__
+    if (buf[0] != '/') {
+        /*
+         * On Linux >= 2.6.36 with glibc < 2.27, getcwd() can return a
+         * relative pathname starting with '(unreachable)'. We detect this
+         * and fail with ENOENT, matching newer glibc behaviour.
+         */
+        errno = ENOENT;
+        path_object_error(obj);
+        PyMem_RawFree(buf);
+        return NULL;
+    }
+#endif
     PyMem_RawFree(buf);
 
     return obj;

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -4098,6 +4098,19 @@ posix_getcwd(int use_bytes)
         PyMem_RawFree(buf);
         return NULL;
     }
+#ifdef __linux__
+    if (buf[0] != '/') {
+        /*
+         * On Linux >= 2.6.36 with glibc < 2.27, getcwd() can return a
+         * relative pathname starting with '(unreachable)'. We detect this
+         * and fail with ENOENT, matching newer glibc behaviour.
+         */
+        errno = ENOENT;
+        posix_error();
+        PyMem_RawFree(buf);
+        return NULL;
+    }
+#endif
 
     PyObject *obj;
     if (use_bytes) {

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -4119,6 +4119,7 @@ posix_getcwd(int use_bytes)
         return NULL;
     }
 #endif
+    assert(buf[0] == '/');
     PyMem_RawFree(buf);
 
     return obj;


### PR DESCRIPTION
On Linux >= 2.6.36 with glibc < 2.27, `getcwd()` can return a relative pathname starting with '(unreachable)'. We detect this and fail with ENOENT, matching new glibc behaviour.

See https://sourceware.org/bugzilla/show_bug.cgi?id=18203


<!-- gh-issue-number: gh-114847 -->
* Issue: gh-114847
<!-- /gh-issue-number -->
