### PR TITLE
gh-117483: Accept "Broken pipe" as valid error message in `test_wrong_cert_tls13`

### DIFF
--- a/Lib/test/test_ssl.py
+++ b/Lib/test/test_ssl.py
@@ -3169,7 +3169,9 @@ class ThreadedTests(unittest.TestCase):
             s.connect((HOST, server.port))
             with self.assertRaisesRegex(
                 OSError,
-                'alert unknown ca|EOF occurred|TLSV1_ALERT_UNKNOWN_CA|closed by the remote host|Connection reset by peer'
+                'alert unknown ca|EOF occurred|TLSV1_ALERT_UNKNOWN_CA|'
+                'closed by the remote host|Connection reset by peer|'
+                'Broken pipe'
             ):
                 # TLS 1.3 perform client cert exchange after handshake
                 s.write(b'data')


### PR DESCRIPTION
On macOS, the closed connection can lead to a "Broken pipe" error instead of a "Connection reset by peer" error.


<!-- gh-issue-number: gh-117483 -->
* Issue: gh-117483
<!-- /gh-issue-number -->
