### PR TITLE
gh-117215 Make the fromskey() signature match dict.fromkeys().

### DIFF
--- a/Lib/collections/__init__.py
+++ b/Lib/collections/__init__.py
@@ -1039,7 +1039,7 @@ class ChainMap(_collections_abc.MutableMapping):
 
     @classmethod
     def fromkeys(cls, iterable, value=None, /):
-        'Create a ChainMap with a single dict created from the iterable.'
+        'Create a new ChainMap with keys from thhe iterable and values set to value.'
         return cls(dict.fromkeys(iterable, value))
 
     def copy(self):

--- a/Lib/collections/__init__.py
+++ b/Lib/collections/__init__.py
@@ -1039,7 +1039,7 @@ class ChainMap(_collections_abc.MutableMapping):
 
     @classmethod
     def fromkeys(cls, iterable, value=None, /):
-        'Create a new ChainMap with keys from thhe iterable and values set to value.'
+        'Create a new ChainMap with keys from iterable and values set to value.'
         return cls(dict.fromkeys(iterable, value))
 
     def copy(self):

--- a/Lib/collections/__init__.py
+++ b/Lib/collections/__init__.py
@@ -1038,9 +1038,9 @@ class ChainMap(_collections_abc.MutableMapping):
         return f'{self.__class__.__name__}({", ".join(map(repr, self.maps))})'
 
     @classmethod
-    def fromkeys(cls, iterable, *args):
+    def fromkeys(cls, iterable, value=None, /):
         'Create a ChainMap with a single dict created from the iterable.'
-        return cls(dict.fromkeys(iterable, *args))
+        return cls(dict.fromkeys(iterable, value))
 
     def copy(self):
         'New ChainMap or subclass with a new copy of maps[0] and refs to maps[1:]'


### PR DESCRIPTION
This minor edit improves tooltips and help() without actually changing the API (everything that used to work still does and everything that didn't used to work still doesn't).

```
>>> help(dict.fromkeys)
fromkeys(iterable, value=None, /) class method of builtins.dict
    Create a new dictionary with keys from iterable and values set to value.

>>> help(ChainMap.fromkeys)
fromkeys(iterable, value=None, /) class method of collections.ChainMap
    Create a new ChainMap with keys from thhe iterable and values set to value.
```

<!-- gh-issue-number: gh-117215 -->
* Issue: gh-117215
<!-- /gh-issue-number -->
