### PR TITLE
gh-117431: Fix str.endswith docstring

### DIFF
--- a/Objects/clinic/unicodeobject.c.h
+++ b/Objects/clinic/unicodeobject.c.h
@@ -1421,12 +1421,12 @@ exit:
 }
 
 PyDoc_STRVAR(unicode_endswith__doc__,
-"endswith($self, prefix[, start[, end]], /)\n"
+"endswith($self, suffix[, start[, end]], /)\n"
 "--\n"
 "\n"
-"Return True if the string ends with the specified prefix, False otherwise.\n"
+"Return True if the string ends with the specified suffix, False otherwise.\n"
 "\n"
-"  prefix\n"
+"  suffix\n"
 "    A string or a tuple of strings to try.\n"
 "  start\n"
 "    Optional start position. Default: start of the string.\n"
@@ -1609,4 +1609,4 @@ skip_optional_pos:
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=e495e878d8283217 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=1734aa1fcc9b076a input=a9049054013a1b77]*/

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -13078,16 +13078,24 @@ unicode_startswith_impl(PyObject *self, PyObject *subobj, Py_ssize_t start,
 
 
 /*[clinic input]
-@text_signature "($self, prefix[, start[, end]], /)"
-str.endswith as unicode_endswith = str.startswith
+@text_signature "($self, suffix[, start[, end]], /)"
+str.endswith as unicode_endswith
 
-Return True if the string ends with the specified prefix, False otherwise.
+    suffix as subobj: object
+        A string or a tuple of strings to try.
+    start: slice_index(accept={int, NoneType}, c_default='0') = None
+        Optional start position. Default: start of the string.
+    end: slice_index(accept={int, NoneType}, c_default='PY_SSIZE_T_MAX') = None
+        Optional stop position. Default: end of the string.
+    /
+
+Return True if the string ends with the specified suffix, False otherwise.
 [clinic start generated code]*/
 
 static PyObject *
 unicode_endswith_impl(PyObject *self, PyObject *subobj, Py_ssize_t start,
                       Py_ssize_t end)
-/*[clinic end generated code: output=cce6f8ceb0102ca9 input=82cd5ce9e7623646]*/
+/*[clinic end generated code: output=cce6f8ceb0102ca9 input=00fbdc774a7d4d71]*/
 {
     if (PyTuple_Check(subobj)) {
         Py_ssize_t i;


### PR DESCRIPTION
The first parameter is named 'suffix', not 'prefix'.

Regression introduced by commit 444156ed


<!-- gh-issue-number: gh-117431 -->
* Issue: gh-117431
<!-- /gh-issue-number -->
