### PR TITLE
gh-117174: Add a new route in linecache to fetch interactive source code

### DIFF
--- a/Lib/_pyrepl/console.py
+++ b/Lib/_pyrepl/console.py
@@ -24,6 +24,7 @@ import _colorize  # type: ignore[import-not-found]
 from abc import ABC, abstractmethod
 import ast
 import code
+import linecache
 from dataclasses import dataclass, field
 import os.path
 import sys
@@ -193,6 +194,7 @@ class InteractiveColoredConsole(code.InteractiveConsole):
             item = wrapper([stmt])
             try:
                 code = self.compile.compiler(item, filename, the_symbol)
+                linecache._register_code(code, source, filename)
             except SyntaxError as e:
                 if e.args[0] == "'await' outside function":
                     python = os.path.basename(sys.executable)

--- a/Lib/_pyrepl/simple_interact.py
+++ b/Lib/_pyrepl/simple_interact.py
@@ -26,7 +26,6 @@ allowing multiline input and multiline history entries.
 from __future__ import annotations
 
 import _sitebuiltins
-import linecache
 import functools
 import os
 import sys
@@ -148,7 +147,6 @@ def run_multiline_interactive_console(
                 continue
 
             input_name = f"<python-input-{input_n}>"
-            linecache._register_code(input_name, statement, "<stdin>")  # type: ignore[attr-defined]
             more = console.push(_strip_final_indent(statement), filename=input_name, _symbol="single")  # type: ignore[call-arg]
             assert not more
             input_n += 1

--- a/Lib/inspect.py
+++ b/Lib/inspect.py
@@ -969,7 +969,7 @@ def findsource(object):
     if module:
         lines = linecache.getlines(file, module.__dict__)
         if not lines and file.startswith('<') and hasattr(object, "__code__"):
-            lines = linecache._getlines_from_code(object.__code__, module.__dict__)
+            lines = linecache._getlines_from_code(object.__code__)
     else:
         lines = linecache.getlines(file)
     if not lines:

--- a/Lib/inspect.py
+++ b/Lib/inspect.py
@@ -968,6 +968,8 @@ def findsource(object):
     module = getmodule(object, file)
     if module:
         lines = linecache.getlines(file, module.__dict__)
+        if not lines and file.startswith('<') and hasattr(object, "__code__"):
+            lines = linecache._getlines_from_code(object.__code__, module.__dict__)
     else:
         lines = linecache.getlines(file)
     if not lines:

--- a/Lib/linecache.py
+++ b/Lib/linecache.py
@@ -45,14 +45,14 @@ def getlines(filename, module_globals=None):
         return []
 
 
-def _getline_from_code(filename, lineno, module_globals=None):
-    lines = _getlines_from_code(filename, module_globals)
+def _getline_from_code(filename, lineno):
+    lines = _getlines_from_code(filename)
     if 1 <= lineno <= len(lines):
         return lines[lineno - 1]
     return ''
 
 
-def _getlines_from_code(code, module_globals=None):
+def _getlines_from_code(code):
     code_id = id(code)
     if code_id in _interactive_cache:
         entry = _interactive_cache[code_id]

--- a/Lib/linecache.py
+++ b/Lib/linecache.py
@@ -53,10 +53,11 @@ def _getline_from_code(filename, lineno, module_globals=None):
 
 
 def _getlines_from_code(code, module_globals=None):
-    if code in _interactive_cache:
-        entry = _interactive_cache[code]
+    code_id = id(code)
+    if code_id in _interactive_cache:
+        entry = _interactive_cache[code_id]
         if len(entry) != 1:
-            return _interactive_cache[code][2]
+            return _interactive_cache[code_id][2]
     return []
 
 
@@ -226,4 +227,4 @@ def _register_code(code, string, name):
         for const in code.co_consts:
             if isinstance(const, type(code)):
                 stack.append(const)
-        _interactive_cache[code] = entry
+        _interactive_cache[id(code)] = entry

--- a/Lib/linecache.py
+++ b/Lib/linecache.py
@@ -104,9 +104,13 @@ def updatecache(filename, module_globals=None):
     # These imports are not at top level because linecache is in the critical
     # path of the interpreter startup and importing os and sys take a lot of time
     # and slows down the startup sequence.
-    import os
-    import sys
-    import tokenize
+    try:
+        import os
+        import sys
+        import tokenize
+    except ImportError:
+        # These import can fail if the interpreter is shutting down
+        return []
 
     if filename in cache:
         if len(cache[filename]) != 1:

--- a/Lib/test/test_capi/test_exceptions.py
+++ b/Lib/test/test_capi/test_exceptions.py
@@ -85,9 +85,7 @@ class Test_Exceptions(unittest.TestCase):
         warnings = proc.err.splitlines()
         self.assertEqual(warnings, [
             b'<string>:6: RuntimeWarning: Testing PyErr_WarnEx',
-            b'  foo()  # line 6',
             b'<string>:9: RuntimeWarning: Testing PyErr_WarnEx',
-            b'  foo()  # line 9',
         ])
 
     def test_warn_during_finalization(self):

--- a/Lib/test/test_gdb/gdb_sample.py
+++ b/Lib/test/test_gdb/gdb_sample.py
@@ -1,4 +1,5 @@
 # Sample script for use by test_gdb
+from _typing import _idfunc
 
 def foo(a, b, c):
     bar(a=a, b=b, c=c)
@@ -7,6 +8,6 @@ def bar(a, b, c):
     baz(a, b, c)
 
 def baz(*args):
-    id(42)
+    _idfunc(42)
 
 foo(1, 2, 3)

--- a/Lib/test/test_gdb/test_misc.py
+++ b/Lib/test/test_gdb/test_misc.py
@@ -35,14 +35,14 @@ class PyListTests(DebuggerTests):
         bt = self.get_stack_trace(script=SAMPLE_SCRIPT,
                                   cmds_after_breakpoint=['py-list'])
 
-        self.assertListing('   5    \n'
-                           '   6    def bar(a, b, c):\n'
-                           '   7        baz(a, b, c)\n'
-                           '   8    \n'
-                           '   9    def baz(*args):\n'
-                           ' >10        id(42)\n'
-                           '  11    \n'
-                           '  12    foo(1, 2, 3)\n',
+        self.assertListing('   6    \n'
+                           '   7    def bar(a, b, c):\n'
+                           '   8        baz(a, b, c)\n'
+                           '   9    \n'
+                           '  10    def baz(*args):\n'
+                           ' >11        _idfunc(42)\n'
+                           '  12    \n'
+                           '  13    foo(1, 2, 3)\n',
                            bt)
 
     def test_one_abs_arg(self):
@@ -50,25 +50,27 @@ class PyListTests(DebuggerTests):
         bt = self.get_stack_trace(script=SAMPLE_SCRIPT,
                                   cmds_after_breakpoint=['py-list 9'])
 
-        self.assertListing('   9    def baz(*args):\n'
-                           ' >10        id(42)\n'
-                           '  11    \n'
-                           '  12    foo(1, 2, 3)\n',
+        self.assertListing('  10    def baz(*args):\n'
+                           ' >11        _idfunc(42)\n'
+                           '  12    \n'
+                           '  13    foo(1, 2, 3)\n',
                            bt)
 
     def test_two_abs_args(self):
         'Verify the "py-list" command with two absolute arguments'
         bt = self.get_stack_trace(script=SAMPLE_SCRIPT,
-                                  cmds_after_breakpoint=['py-list 1,3'])
+                                  cmds_after_breakpoint=['py-list 1,4'])
 
         self.assertListing('   1    # Sample script for use by test_gdb\n'
-                           '   2    \n'
-                           '   3    def foo(a, b, c):\n',
+                           '   2    from _typing import _idfunc\n'
+                           '   3    \n'
+                           '   4    def foo(a, b, c):\n',
                            bt)
 
 SAMPLE_WITH_C_CALL = """
 
 from _testcapi import pyobject_vectorcall
+from _typing import _idfunc
 
 def foo(a, b, c):
     bar(a, b, c)
@@ -77,7 +79,7 @@ def bar(a, b, c):
     pyobject_vectorcall(baz, (a, b, c), None)
 
 def baz(*args):
-    id(42)
+    _idfunc(42)
 
 foo(1, 2, 3)
 
@@ -94,7 +96,7 @@ class StackNavigationTests(DebuggerTests):
                                   cmds_after_breakpoint=['py-up', 'py-up'])
         self.assertMultilineMatches(bt,
                                     r'''^.*
-#[0-9]+ Frame 0x-?[0-9a-f]+, for file <string>, line 12, in baz \(args=\(1, 2, 3\)\)
+#[0-9]+ Frame 0x-?[0-9a-f]+, for file <string>, line 13, in baz \(args=\(1, 2, 3\)\)
 #[0-9]+ <built-in method pyobject_vectorcall of module object at remote 0x[0-9a-f]+>
 $''')
 
@@ -123,9 +125,9 @@ $''')
                                   cmds_after_breakpoint=['py-up', 'py-up', 'py-down'])
         self.assertMultilineMatches(bt,
                                     r'''^.*
-#[0-9]+ Frame 0x-?[0-9a-f]+, for file <string>, line 12, in baz \(args=\(1, 2, 3\)\)
+#[0-9]+ Frame 0x-?[0-9a-f]+, for file <string>, line 13, in baz \(args=\(1, 2, 3\)\)
 #[0-9]+ <built-in method pyobject_vectorcall of module object at remote 0x[0-9a-f]+>
-#[0-9]+ Frame 0x-?[0-9a-f]+, for file <string>, line 12, in baz \(args=\(1, 2, 3\)\)
+#[0-9]+ Frame 0x-?[0-9a-f]+, for file <string>, line 13, in baz \(args=\(1, 2, 3\)\)
 $''')
 
 class PyPrintTests(DebuggerTests):

--- a/Lib/test/test_gdb/util.py
+++ b/Lib/test/test_gdb/util.py
@@ -16,7 +16,7 @@ CHECKOUT_HOOK_PATH = os.path.join(os.path.dirname(sys.executable),
                                   'python-gdb.py')
 
 SAMPLE_SCRIPT = os.path.join(os.path.dirname(__file__), 'gdb_sample.py')
-BREAKPOINT_FN = 'builtin_id'
+BREAKPOINT_FN = '_typing__idfunc'
 
 PYTHONHASHSEED = '123'
 

--- a/Lib/test/test_io.py
+++ b/Lib/test/test_io.py
@@ -4558,11 +4558,11 @@ class MiscIOTest(unittest.TestCase):
         ''')
         proc = assert_python_ok('-X', 'warn_default_encoding', '-c', code)
         warnings = proc.err.splitlines()
-        self.assertEqual(len(warnings), 4)
+        self.assertEqual(len(warnings), 2)
         self.assertTrue(
             warnings[0].startswith(b"<string>:5: EncodingWarning: "))
         self.assertTrue(
-            warnings[2].startswith(b"<string>:8: EncodingWarning: "))
+            warnings[1].startswith(b"<string>:8: EncodingWarning: "))
 
     def test_text_encoding(self):
         # PEP 597, bpo-47000. io.text_encoding() returns "locale" or "utf-8"

--- a/Lib/test/test_linecache.py
+++ b/Lib/test/test_linecache.py
@@ -8,6 +8,7 @@ import tokenize
 from importlib.machinery import ModuleSpec
 from test import support
 from test.support import os_helper
+from test.support.script_helper import assert_python_ok
 
 
 FILENAME = linecache.__file__
@@ -311,6 +312,12 @@ class LineCacheTests(unittest.TestCase):
         # just to be sure that we did not mess with cache
         linecache.clearcache()
 
+    def test_linecache_python_string(self):
+        cmdline = "import linecache;assert len(linecache.cache) == 0"
+        retcode, stdout, stderr = assert_python_ok('-c', cmdline)
+        self.assertEqual(retcode, 0)
+        self.assertEqual(stdout, b'')
+        self.assertEqual(stderr, b'')
 
 class LineCacheInvalidationTests(unittest.TestCase):
     def setUp(self):

--- a/Lib/test/test_repl.py
+++ b/Lib/test/test_repl.py
@@ -213,7 +213,7 @@ class TestInteractiveInterpreter(unittest.TestCase):
         p.stdin.write(user_input)
         user_input2 = dedent("""
         import linecache
-        print(linecache.cache['<stdin>-1'])
+        print(linecache._interactive_cache[foo.__code__])
         """)
         p.stdin.write(user_input2)
         output = kill_python(p)

--- a/Lib/test/test_repl.py
+++ b/Lib/test/test_repl.py
@@ -213,7 +213,7 @@ class TestInteractiveInterpreter(unittest.TestCase):
         p.stdin.write(user_input)
         user_input2 = dedent("""
         import linecache
-        print(linecache._interactive_cache[foo.__code__])
+        print(linecache._interactive_cache[id(foo.__code__)])
         """)
         p.stdin.write(user_input2)
         output = kill_python(p)

--- a/Lib/test/test_subprocess.py
+++ b/Lib/test/test_subprocess.py
@@ -1821,9 +1821,9 @@ class RunFuncTestCase(BaseTestCase):
         cp = subprocess.run([sys.executable, "-Xwarn_default_encoding", "-c", code],
                             capture_output=True)
         lines = cp.stderr.splitlines()
-        self.assertEqual(len(lines), 4, lines)
+        self.assertEqual(len(lines), 2, lines)
         self.assertTrue(lines[0].startswith(b"<string>:2: EncodingWarning: "))
-        self.assertTrue(lines[2].startswith(b"<string>:3: EncodingWarning: "))
+        self.assertTrue(lines[1].startswith(b"<string>:3: EncodingWarning: "))
 
 
 def _get_test_grp_name():

--- a/Lib/traceback.py
+++ b/Lib/traceback.py
@@ -288,7 +288,7 @@ class FrameSummary:
     """
 
     __slots__ = ('filename', 'lineno', 'end_lineno', 'colno', 'end_colno',
-                 'name', '_lines', '_lines_dedented', 'locals', '_frame')
+                 'name', '_lines', '_lines_dedented', 'locals', '_code')
 
     def __init__(self, filename, lineno, name, *, lookup_line=True,
             locals=None, line=None,
@@ -308,7 +308,7 @@ class FrameSummary:
         self.colno = colno
         self.end_colno = end_colno
         self.name = name
-        self._frame = kwargs.get("_frame")
+        self._code = kwargs.get("_code")
         self._lines = line
         self._lines_dedented = None
         if lookup_line:
@@ -348,11 +348,9 @@ class FrameSummary:
             lines = []
             for lineno in range(self.lineno, self.end_lineno + 1):
                 # treat errors (empty string) and empty lines (newline) as the same
-                line = None
-                if self._frame is not None and self.filename.startswith("<"):
-                    line = linecache._getline_from_code(self._frame.f_code, lineno, self._frame.f_globals).rstrip()
-                if line is None:
-                    line = linecache.getline(self.filename, lineno).rstrip()
+                line = linecache.getline(self.filename, lineno).rstrip()
+                if not line and self._code is not None and self.filename.startswith("<"):
+                    line = linecache._getline_from_code(self._code, lineno).rstrip()
                 lines.append(line)
             self._lines = "\n".join(lines) + "\n"
 
@@ -490,7 +488,7 @@ class StackSummary(list):
                 FrameSummary(filename, lineno, name,
                     lookup_line=False, locals=f_locals,
                     end_lineno=end_lineno, colno=colno, end_colno=end_colno,
-                    _frame=f,
+                    _code=f.f_code,
                 )
             )
         for filename in fnames:

--- a/Lib/traceback.py
+++ b/Lib/traceback.py
@@ -288,11 +288,11 @@ class FrameSummary:
     """
 
     __slots__ = ('filename', 'lineno', 'end_lineno', 'colno', 'end_colno',
-                 'name', '_lines', '_lines_dedented', 'locals')
+                 'name', '_lines', '_lines_dedented', 'locals', '_frame')
 
     def __init__(self, filename, lineno, name, *, lookup_line=True,
             locals=None, line=None,
-            end_lineno=None, colno=None, end_colno=None):
+            end_lineno=None, colno=None, end_colno=None, **kwargs):
         """Construct a FrameSummary.
 
         :param lookup_line: If True, `linecache` is consulted for the source
@@ -308,6 +308,7 @@ class FrameSummary:
         self.colno = colno
         self.end_colno = end_colno
         self.name = name
+        self._frame = kwargs.get("_frame")
         self._lines = line
         self._lines_dedented = None
         if lookup_line:
@@ -347,7 +348,12 @@ class FrameSummary:
             lines = []
             for lineno in range(self.lineno, self.end_lineno + 1):
                 # treat errors (empty string) and empty lines (newline) as the same
-                lines.append(linecache.getline(self.filename, lineno).rstrip())
+                line = None
+                if self._frame is not None and self.filename.startswith("<"):
+                    line = linecache._getline_from_code(self._frame.f_code, lineno, self._frame.f_globals).rstrip()
+                if line is None:
+                    line = linecache.getline(self.filename, lineno).rstrip()
+                lines.append(line)
             self._lines = "\n".join(lines) + "\n"
 
     @property
@@ -480,9 +486,13 @@ class StackSummary(list):
                 f_locals = f.f_locals
             else:
                 f_locals = None
-            result.append(FrameSummary(
-                filename, lineno, name, lookup_line=False, locals=f_locals,
-                end_lineno=end_lineno, colno=colno, end_colno=end_colno))
+            result.append(
+                FrameSummary(filename, lineno, name,
+                    lookup_line=False, locals=f_locals,
+                    end_lineno=end_lineno, colno=colno, end_colno=end_colno,
+                    _frame=f,
+                )
+            )
         for filename in fnames:
             linecache.checkcache(filename)
 

--- a/Python/pythonrun.c
+++ b/Python/pythonrun.c
@@ -1383,7 +1383,7 @@ run_mod(mod_ty mod, PyObject *filename, PyObject *globals, PyObject *locals,
 
         PyObject* result = PyObject_CallFunction(
             print_tb_func, "OOO",
-            interactive_filename,
+            co,
             interactive_src,
             filename
         );


### PR DESCRIPTION
Using <string> leads to confusion when linecache it's populated with
<string> entries as the inspect module heavily relies on it. An example:

./python -c "import inspect;x=eval('lambda x: x');print(inspect.getsource(x))"

The code above should trigger an exception because we should not be able
to get the source of x (it's dynamically generated) but if we use
<string> as name for interactive code it will return gives the full string.


<!-- gh-issue-number: gh-117174 -->
* Issue: gh-117174
<!-- /gh-issue-number -->
