### PR TITLE
gh-117503: Fix support of non-ASCII user names in posixpath.expanduser()

### DIFF
--- a/Lib/posixpath.py
+++ b/Lib/posixpath.py
@@ -263,7 +263,7 @@ def expanduser(path):
             return path
         name = path[1:i]
         if isinstance(name, bytes):
-            name = name.decode('ascii')
+            name = os.fsdecode(name)
         try:
             pwent = pwd.getpwnam(name)
         except KeyError:

--- a/Lib/test/test_posixpath.py
+++ b/Lib/test/test_posixpath.py
@@ -342,6 +342,17 @@ class PosixPathTest(unittest.TestCase):
                 for path in ('~', '~/.local', '~vstinner/'):
                     self.assertEqual(posixpath.expanduser(path), path)
 
+    @unittest.skipIf(sys.platform == "vxworks",
+                     "no home directory on VxWorks")
+    def test_expanduser_pwd2(self):
+        pwd = import_helper.import_module('pwd')
+        for e in pwd.getpwall():
+            name = e.pw_name
+            home = e.pw_dir
+            self.assertEqual(posixpath.expanduser('~' + name), home)
+            self.assertEqual(posixpath.expanduser(os.fsencode('~' + name)),
+                             os.fsencode(home))
+
     NORMPATH_CASES = [
         ("", "."),
         ("/", "/"),

--- a/Misc/NEWS.d/next/Library/2024-04-03-15-04-23.gh-issue-117503.NMfwup.rst
+++ b/Misc/NEWS.d/next/Library/2024-04-03-15-04-23.gh-issue-117503.NMfwup.rst
@@ -1,0 +1,2 @@
+Fix support of non-ASCII user names in bytes paths in
+:func:`os.path.expanduser` on Posix.


### PR DESCRIPTION
They are now supported in bytes paths as well as in string paths.


<!-- gh-issue-number: gh-117503 -->
* Issue: gh-117503
<!-- /gh-issue-number -->
