### PR TITLE
gh-117467: Add preserving of mailbox owner on flush

### DIFF
--- a/Lib/mailbox.py
+++ b/Lib/mailbox.py
@@ -755,7 +755,7 @@ class _singlefileMailbox(Mailbox):
         os.chmod(new_file.name, info.st_mode)
         try:
             os.chown(new_file.name, info.st_uid, info.st_gid)
-        except:
+        except (AttributeError, OSError):
             pass
         try:
             os.rename(new_file.name, self._path)

--- a/Lib/mailbox.py
+++ b/Lib/mailbox.py
@@ -750,9 +750,13 @@ class _singlefileMailbox(Mailbox):
         _sync_close(new_file)
         # self._file is about to get replaced, so no need to sync.
         self._file.close()
-        # Make sure the new file's mode is the same as the old file's
-        mode = os.stat(self._path).st_mode
-        os.chmod(new_file.name, mode)
+        # Make sure the new file's mode and owner are the same as the old file's
+        info = os.stat(self._path)
+        os.chmod(new_file.name, info.st_mode)
+        try:
+            os.chown(new_file.name, info.st_uid, info.st_gid)
+        except:
+            pass
         try:
             os.rename(new_file.name, self._path)
         except FileExistsError:

--- a/Lib/test/test_mailbox.py
+++ b/Lib/test/test_mailbox.py
@@ -9,6 +9,7 @@ import re
 import io
 import tempfile
 from test import support
+from test.support import import_helper
 from test.support import os_helper
 from test.support import refleak_helper
 from test.support import socket_helper
@@ -1080,6 +1081,47 @@ class _TestSingleFile(TestMailbox):
         self._box.flush()
 
         self.assertEqual(os.stat(self._path).st_mode, mode)
+
+    @unittest.skipUnless(hasattr(os, 'chown'), 'requires os.chown')
+    def test_ownership_after_flush(self):
+        # See issue gh-117467
+
+        pwd = import_helper.import_module('pwd')
+        grp = import_helper.import_module('grp')
+        st = os.stat(self._path)
+
+        for e in pwd.getpwall():
+            if e.pw_uid != st.st_uid:
+                other_uid = e.pw_uid
+                break
+        else:
+            self.skipTest("test needs more than one user")
+
+        for e in grp.getgrall():
+            if e.gr_gid != st.st_gid:
+                other_gid = e.gr_gid
+                break
+        else:
+            self.skipTest("test needs more than one group")
+
+        try:
+            os.chown(self._path, other_uid, other_gid)
+        except OSError:
+            self.skipTest('test needs root privilege')
+        # Change permissions as in test_permissions_after_flush.
+        mode = st.st_mode | 0o666
+        os.chmod(self._path, mode)
+
+        self._box.add(self._template % 0)
+        i = self._box.add(self._template % 1)
+        # Need to remove one message to make flush() create a new file
+        self._box.remove(i)
+        self._box.flush()
+
+        st = os.stat(self._path)
+        self.assertEqual(st.st_uid, other_uid)
+        self.assertEqual(st.st_gid, other_gid)
+        self.assertEqual(st.st_mode, mode)
 
 
 class _TestMboxMMDF(_TestSingleFile):

--- a/Misc/NEWS.d/next/Library/2024-04-03-18-36-53.gh-issue-117467.l6rWlj.rst
+++ b/Misc/NEWS.d/next/Library/2024-04-03-18-36-53.gh-issue-117467.l6rWlj.rst
@@ -1,0 +1,2 @@
+Preserve mailbox ownership when rewriting in :func:`mailbox.mbox.flush`.
+Patch by Tony Mountifield.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
Fixes #117467.

Copy owner and group from the old file to the new when rewriting a mailbox. Ignore any failure from `os.chown()`, which may be platform-dependent.

<!-- gh-issue-number: gh-117467 -->
* Issue: gh-117467
<!-- /gh-issue-number -->
