### PR TITLE
Fix a typo in dictobject.c documentation

### DIFF
--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -1866,7 +1866,7 @@ actually be smaller than the old one.
 If a table is split (its keys and hashes are shared, its values are not),
 then the values are temporarily copied into the table, it is resized as
 a combined table, then the me_value slots in the old table are NULLed out.
-After resizing a table is always combined.
+After resizing, a table is always combined.
 
 This function supports:
  - Unicode split -> Unicode combined or Generic


### PR DESCRIPTION
# Fix a typo in dictobject.c documentation

This change fixes grammar in a comment in `dictobject.c`. Its true purpose is to kick off the CLA process so that I & other developers can contribute to CPython on behalf of Hudson River Trading.

Tagging @willingc as requested!