### PR TITLE
gh-112075: _Py_dict_lookup needs to lock shared keys

### DIFF
--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -1756,12 +1756,8 @@ insertdict(PyInterpreterState *interp, PyDictObject *mp,
         // to do a threadsafe lookup here.  This is basically the split-key
         // half of _Py_dict_lookup_threadsafe and avoids locking the
         // shared keys if we can
-        if (PyUnicode_CheckExact(key)) {
-            ix = unicodekeys_lookup_unicode_threadsafe(dk, key, hash);
-        }
-        else {
-            ix = unicodekeys_lookup_generic_threadsafe(mp, dk, key, hash);
-        }
+        assert(PyUnicode_CheckExact(key));
+        ix = unicodekeys_lookup_unicode_threadsafe(dk, key, hash);
 
         if (ix >= 0) {
             old_value = mp->ma_values->values[ix];

--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -1714,7 +1714,7 @@ insert_combined_dict(PyInterpreterState *interp, PyDictObject *mp,
     return 0;
 }
 
-static int
+static Py_ssize_t
 insert_split_key(PyDictKeysObject *keys, PyObject *key, Py_hash_t hash)
 {
     assert(PyUnicode_CheckExact(key));

--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -1188,9 +1188,13 @@ _PyDictKeys_StringLookup(PyDictKeysObject* dk, PyObject *key)
     return unicodekeys_lookup_unicode(dk, key, hash);
 }
 
+#ifdef Py_GIL_DISABLED
+
 static Py_ssize_t
 unicodekeys_lookup_unicode_threadsafe(PyDictKeysObject* dk, PyObject *key,
                                       Py_hash_t hash);
+
+#endif
 
 /*
 The basic lookup function used by all operations.


### PR DESCRIPTION
`_Py_dict_lookup` needs to lock the shared keys if we have a split dictionary.  If we're looking up with a non-exact unicode we need to also incref the keys as the lookup could mutate the keys and we could lose the last reference.

`insertdict` is updated to avoid contention on the shared dict lookup by calling the threadsafe unicode lookup directly and only falling back to `_Py_dict_lookup` if the thread safe lookup can't succeed.

<!-- gh-issue-number: gh-112075 -->
* Issue: gh-112075
<!-- /gh-issue-number -->
