### PR TITLE
gh-112075: Make _PyDict_LoadGlobal thread safe

### DIFF
--- a/Include/internal/pycore_dict.h
+++ b/Include/internal/pycore_dict.h
@@ -97,6 +97,7 @@ extern void _PyDictKeys_DecRef(PyDictKeysObject *keys);
  * -1 when no entry found, -3 when compare raises error.
  */
 extern Py_ssize_t _Py_dict_lookup(PyDictObject *mp, PyObject *key, Py_hash_t hash, PyObject **value_addr);
+extern Py_ssize_t _Py_dict_lookup_threadsafe(PyDictObject *mp, PyObject *key, Py_hash_t hash, PyObject **value_addr);
 
 extern Py_ssize_t _PyDict_LookupIndex(PyDictObject *, PyObject *);
 extern Py_ssize_t _PyDictKeys_StringLookup(PyDictKeysObject* dictkeys, PyObject *key);

--- a/Objects/odictobject.c
+++ b/Objects/odictobject.c
@@ -535,8 +535,12 @@ _odict_get_index_raw(PyODictObject *od, PyObject *key, Py_hash_t hash)
     PyObject *value = NULL;
     PyDictKeysObject *keys = ((PyDictObject *)od)->ma_keys;
     Py_ssize_t ix;
-
+#ifdef Py_GIL_DISABLED
+    ix = _Py_dict_lookup_threadsafe((PyDictObject *)od, key, hash, &value);
+    Py_XDECREF(value);
+#else
     ix = _Py_dict_lookup((PyDictObject *)od, key, hash, &value);
+#endif
     if (ix == DKIX_EMPTY) {
         return keys->dk_nentries;  /* index of new entry */
     }

--- a/Python/bytecodes.c
+++ b/Python/bytecodes.c
@@ -1426,7 +1426,6 @@ dummy_func(
                     }
                     ERROR_IF(true, error);
                 }
-                Py_INCREF(res);
             }
             else {
                 /* Slow-path if globals or builtins is not a dict */

--- a/Python/executor_cases.c.h
+++ b/Python/executor_cases.c.h
@@ -1254,7 +1254,6 @@
                     }
                     if (true) JUMP_TO_ERROR();
                 }
-                Py_INCREF(res);
             }
             else {
                 /* Slow-path if globals or builtins is not a dict */

--- a/Python/generated_cases.c.h
+++ b/Python/generated_cases.c.h
@@ -4269,7 +4269,6 @@
                         }
                         if (true) goto error;
                     }
-                    Py_INCREF(res);
                 }
                 else {
                     /* Slow-path if globals or builtins is not a dict */


### PR DESCRIPTION
Currently `_PyDict_LoadGlobal` is using the non-thread safe `_Py_dict_lookup` and isn't locking the dictionaries.  This switches to using the thread safe version and modifies the function to return a new reference.

It also adds an assertion for `_Py_dict_lookup` that the dictionary should be locked, and fixes up ordered dict to use the thread safe version where the assertion trips.

<!-- gh-issue-number: gh-112075 -->
* Issue: gh-112075
<!-- /gh-issue-number -->
