### PR TITLE
gh-117549: Match declaration order for _Py_BackoffCounter initializer

### DIFF
--- a/Include/internal/pycore_backoff.h
+++ b/Include/internal/pycore_backoff.h
@@ -44,7 +44,7 @@ make_backoff_counter(uint16_t value, uint16_t backoff)
 {
     assert(backoff <= 15);
     assert(value <= 0xFFF);
-    return (_Py_BackoffCounter){.value = value, .backoff = backoff};
+    return (_Py_BackoffCounter){.backoff = backoff, .value = value};
 }
 
 static inline _Py_BackoffCounter


### PR DESCRIPTION
This is to fix the build for Scipy, which includes this header from C++ code which seems to really care about such things.

To be clear, I didn't confirm that this fixes the Scipy build -- there are a bunch of other patches required to its build system to even compile with Python 3.13 and I'm not sure it's worth the effort there.

But this warning seems legitimate and the fix is harmless.  It's possible there are other errors in Scipy behind it, but this is the only struct initializer added in #117144.

<!-- gh-issue-number: gh-117549 -->
* Issue: gh-117549
<!-- /gh-issue-number -->
