### PR TITLE
gh-116303: Don't build xxlimited and xxlimited_35 if --disable-test-modules is given

### DIFF
--- a/configure
+++ b/configure
@@ -31185,7 +31185,7 @@ printf %s "checking for stdlib extension module xxlimited... " >&6; }
         if test "$py_cv_module_xxlimited" != "n/a"
 then :
 
-    if true
+    if test "$TEST_MODULES" = yes
 then :
   if test "$ac_cv_func_dlopen" = yes
 then :
@@ -31223,7 +31223,7 @@ printf %s "checking for stdlib extension module xxlimited_35... " >&6; }
         if test "$py_cv_module_xxlimited_35" != "n/a"
 then :
 
-    if true
+    if test "$TEST_MODULES" = yes
 then :
   if test "$ac_cv_func_dlopen" = yes
 then :

--- a/configure.ac
+++ b/configure.ac
@@ -7661,8 +7661,8 @@ PY_STDLIB_MOD([_ctypes_test],
 
 dnl Limited API template modules.
 dnl Emscripten does not support shared libraries yet.
-PY_STDLIB_MOD([xxlimited], [], [test "$ac_cv_func_dlopen" = yes])
-PY_STDLIB_MOD([xxlimited_35], [], [test "$ac_cv_func_dlopen" = yes])
+PY_STDLIB_MOD([xxlimited], [test "$TEST_MODULES" = yes], [test "$ac_cv_func_dlopen" = yes])
+PY_STDLIB_MOD([xxlimited_35], [test "$TEST_MODULES" = yes], [test "$ac_cv_func_dlopen" = yes])
 
 # substitute multiline block, must come after last PY_STDLIB_MOD()
 AC_SUBST([MODULE_BLOCK])


### PR DESCRIPTION


<!-- gh-issue-number: gh-116303 -->
* Issue: gh-116303
<!-- /gh-issue-number -->
