### PR TITLE
GH-117546: Fix symlink resolution in `os.path.realpath('loop/../link')`

### DIFF
--- a/Doc/library/os.path.rst
+++ b/Doc/library/os.path.rst
@@ -409,9 +409,8 @@ the :mod:`glob` module.)
    style names such as ``C:\\PROGRA~1`` to ``C:\\Program Files``.
 
    If a path doesn't exist or a symlink loop is encountered, and *strict* is
-   ``True``, :exc:`OSError` is raised. If *strict* is ``False``, the path is
-   resolved as far as possible and any remainder is appended without checking
-   whether it exists.
+   ``True``, :exc:`OSError` is raised. If *strict* is ``False`` these errors
+   are ignored, and so the result might be missing or otherwise inaccessible.
 
    .. note::
       This function emulates the operating system's procedure for making a path

--- a/Lib/posixpath.py
+++ b/Lib/posixpath.py
@@ -430,11 +430,6 @@ symbolic links encountered in the path."""
     # the same links.
     seen = {}
 
-    # Whether we're calling lstat() and readlink() to resolve symlinks. If we
-    # encounter an OSError for a symlink loop in non-strict mode, this is
-    # switched off.
-    querying = True
-
     while rest:
         name = rest.pop()
         if name is None:
@@ -452,9 +447,6 @@ symbolic links encountered in the path."""
             newpath = path + name
         else:
             newpath = path + sep + name
-        if not querying:
-            path = newpath
-            continue
         try:
             st = os.lstat(newpath)
             if not stat.S_ISLNK(st.st_mode):
@@ -476,11 +468,8 @@ symbolic links encountered in the path."""
             if strict:
                 # Raise OSError(errno.ELOOP)
                 os.stat(newpath)
-            else:
-                # Return already resolved part + rest of the path unchanged.
-                path = newpath
-                querying = False
-                continue
+            path = newpath
+            continue
         seen[newpath] = None # not resolved symlink
         target = os.readlink(newpath)
         if target.startswith(sep):

--- a/Lib/test/test_posixpath.py
+++ b/Lib/test/test_posixpath.py
@@ -484,7 +484,7 @@ class PosixPathTest(unittest.TestCase):
             self.assertEqual(realpath(ABSTFN+"1/../x"), dirname(ABSTFN) + "/x")
             os.symlink(ABSTFN+"x", ABSTFN+"y")
             self.assertEqual(realpath(ABSTFN+"1/../" + basename(ABSTFN) + "y"),
-                             ABSTFN + "y")
+                             ABSTFN + "x")
             self.assertEqual(realpath(ABSTFN+"1/../" + basename(ABSTFN) + "1"),
                              ABSTFN + "1")
 

--- a/Misc/NEWS.d/next/Library/2024-04-05-13-38-53.gh-issue-117546.lWjhHE.rst
+++ b/Misc/NEWS.d/next/Library/2024-04-05-13-38-53.gh-issue-117546.lWjhHE.rst
@@ -1,0 +1,2 @@
+Fix issue where :func:`os.path.realpath` stopped resolving symlinks after
+encountering a symlink loop on POSIX.


### PR DESCRIPTION
Continue resolving symlink targets after encountering a symlink loop, which matches coreutils `realpath` behaviour. POSIX-only fix; Windows works differently.


<!-- gh-issue-number: gh-117546 -->
* Issue: gh-117546
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--117568.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->