### PR TITLE
gh-117596: Fix realpath ValueError on null byte

### DIFF
--- a/Lib/posixpath.py
+++ b/Lib/posixpath.py
@@ -460,7 +460,7 @@ symbolic links encountered in the path."""
             if not stat.S_ISLNK(st.st_mode):
                 path = newpath
                 continue
-        except OSError:
+        except (OSError, ValueError):
             if strict:
                 raise
             path = newpath

--- a/Lib/test/test_posixpath.py
+++ b/Lib/test/test_posixpath.py
@@ -655,6 +655,15 @@ class PosixPathTest(unittest.TestCase):
         finally:
             safe_rmdir(ABSTFN)
 
+    @skip_if_ABSTFN_contains_backslash
+    def test_realpath_raises_value_error_on_null_byte_in_strict_mode(self):
+        path_with_null_byte = ABSTFN + "/\x00"
+        try:
+            os.mkdir(ABSTFN)
+            self.assertRaises(ValueError, realpath, path_with_null_byte, strict=True)
+        finally:
+            safe_rmdir(ABSTFN)
+
     def test_relpath(self):
         (real_getcwd, os.getcwd) = (os.getcwd, lambda: r"/home/user/bar")
         try:

--- a/Lib/test/test_posixpath.py
+++ b/Lib/test/test_posixpath.py
@@ -646,6 +646,15 @@ class PosixPathTest(unittest.TestCase):
             safe_rmdir(ABSTFN + "/k")
             safe_rmdir(ABSTFN)
 
+    @skip_if_ABSTFN_contains_backslash
+    def test_realpath_null_byte(self):
+        path_with_null_byte = ABSTFN + "/\x00"
+        try:
+            os.mkdir(ABSTFN)
+            self.assertEqual(realpath(path_with_null_byte), path_with_null_byte)
+        finally:
+            safe_rmdir(ABSTFN)
+
     def test_relpath(self):
         (real_getcwd, os.getcwd) = (os.getcwd, lambda: r"/home/user/bar")
         try:

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -773,6 +773,7 @@ Benjamin Hodgson
 Joerg-Cyril Hoehle
 Douwe Hoekstra
 Robert Hoelzl
+Stefan Hoelzl
 Gregor Hoffleit
 Chris Hoffman
 Tim Hoffmann

--- a/Misc/NEWS.d/next/Library/2024-04-07-06-46-43.gh-issue-117596.Mxo4gr.rst
+++ b/Misc/NEWS.d/next/Library/2024-04-07-06-46-43.gh-issue-117596.Mxo4gr.rst
@@ -1,0 +1,1 @@
+Fix :exc:`ValueError` when :func:`os.path.realpath` is called with a path containing a null byte. Patch by Stefan Hoelzl.

--- a/Misc/NEWS.d/next/Library/2024-04-07-06-46-43.gh-issue-117596.Mxo4gr.rst
+++ b/Misc/NEWS.d/next/Library/2024-04-07-06-46-43.gh-issue-117596.Mxo4gr.rst
@@ -1,1 +1,3 @@
-Fix :exc:`ValueError` when :func:`os.path.realpath` is called with a path containing a null byte. Patch by Stefan Hoelzl.
+Fix :exc:`ValueError` when :func:`os.path.realpath` is called
+with a path containing a null byte in non-strict mode.
+Patch by Stefan Hoelzl.


### PR DESCRIPTION
Calling os.path.realpath with a path containg a null byte ("\x00") it raised an ValueError on posix systems.

This fix will catch the ValueError similar to how other path operations are handling such an Error. e.g. `os.path.exists`, `os.path.ismount`, `os.fspath, os.path.islink`

The `ValueError` is initially raised by `os.lstat` the other mentioned path operations are handing this `ValueError` of `os.lstat`
https://github.com/python/cpython/blob/main/Lib/genericpath.py#L30
https://github.com/python/cpython/blob/main/Lib/genericpath.py#L20
https://github.com/python/cpython/blob/main/Lib/genericpath.py#L64
https://github.com/python/cpython/blob/main/Lib/posixpath.py#L197
https://github.com/python/cpython/blob/main/Lib/posixpath.py#L213

<!-- gh-issue-number: gh-117596 -->
* Issue: gh-117596
<!-- /gh-issue-number -->
