### PR TITLE
gh-117584: Raise TypeError for non-paths in `posixpath.relpath()`

### DIFF
--- a/Lib/posixpath.py
+++ b/Lib/posixpath.py
@@ -502,10 +502,10 @@ supports_unicode_filenames = (sys.platform == 'darwin')
 def relpath(path, start=None):
     """Return a relative version of a path"""
 
+    path = os.fspath(path)
     if not path:
         raise ValueError("no path specified")
 
-    path = os.fspath(path)
     if isinstance(path, bytes):
         curdir = b'.'
         sep = b'/'

--- a/Lib/test/test_posixpath.py
+++ b/Lib/test/test_posixpath.py
@@ -650,6 +650,7 @@ class PosixPathTest(unittest.TestCase):
         (real_getcwd, os.getcwd) = (os.getcwd, lambda: r"/home/user/bar")
         try:
             curdir = os.path.split(os.getcwd())[-1]
+            self.assertRaises(TypeError, posixpath.relpath, None)
             self.assertRaises(ValueError, posixpath.relpath, "")
             self.assertEqual(posixpath.relpath("a"), "a")
             self.assertEqual(posixpath.relpath(posixpath.abspath("a")), "a")

--- a/Misc/NEWS.d/next/Core and Builtins/2024-04-06-16-42-34.gh-issue-117584.hqk9Hn.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2024-04-06-16-42-34.gh-issue-117584.hqk9Hn.rst
@@ -1,1 +1,1 @@
-Raise :exec:`TypeError` for non-paths in :func:`posixpath.relpath()`.
+Raise TypeError for non-paths in :func:`posixpath.relpath()`.

--- a/Misc/NEWS.d/next/Core and Builtins/2024-04-06-16-42-34.gh-issue-117584.hqk9Hn.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2024-04-06-16-42-34.gh-issue-117584.hqk9Hn.rst
@@ -1,1 +1,1 @@
-Raise TypeError for non-paths in :func:`posixpath.relpath()`.
+Raise :exec:`TypeError` for non-paths in :func:`posixpath.relpath()`.

--- a/Misc/NEWS.d/next/Core and Builtins/2024-04-06-16-42-34.gh-issue-117584.hqk9Hn.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2024-04-06-16-42-34.gh-issue-117584.hqk9Hn.rst
@@ -1,0 +1,1 @@
+Raise TypeError for non-paths in :func:`posixpath.relpath()`.

--- a/Misc/NEWS.d/next/Core and Builtins/2024-04-06-16-42-34.gh-issue-117584.hqk9Hn.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2024-04-06-16-42-34.gh-issue-117584.hqk9Hn.rst
@@ -1,1 +1,1 @@
-Raise TypeError for non-paths in :func:`posixpath.relpath()`.
+Raise :exc:`TypeError` for non-paths in :func:`posixpath.relpath()`.


### PR DESCRIPTION


<!-- gh-issue-number: gh-117584 -->
* Issue: gh-117584
<!-- /gh-issue-number -->
