### PR TITLE
gh-74416: Fix and speed up `issubclass(X, X)` with custom metaclasses

### DIFF
--- a/Lib/test/test_abc.py
+++ b/Lib/test/test_abc.py
@@ -467,8 +467,8 @@ def test_factory(abc_ABCMeta, abc_get_cache_token):
                     if cls is A:
                         return 'foo' in C.__dict__
                     return NotImplemented
-            self.assertFalse(issubclass(A, A))
-            self.assertFalse(issubclass(A, (A,)))
+            self.assertTrue(issubclass(A, A))
+            self.assertTrue(issubclass(A, (A,)))
             class B:
                 foo = 42
             self.assertTrue(issubclass(B, A))
@@ -477,6 +477,21 @@ def test_factory(abc_ABCMeta, abc_get_cache_token):
                 spam = 42
             self.assertFalse(issubclass(C, A))
             self.assertFalse(issubclass(C, (A,)))
+
+        def test_class_is_sublcass_of_iteself(self):
+            class Meta(type):
+                def __subclasscheck__(self, other):
+                    return False
+
+            class X(metaclass=Meta):
+                pass
+
+            class Y(X):
+                pass
+
+            self.assertTrue(issubclass(X, X))
+            self.assertTrue(issubclass(Y, Y))
+            self.assertFalse(issubclass(Y, X))
 
         def test_all_new_methods_are_called(self):
             class A(metaclass=abc_ABCMeta):

--- a/Lib/test/test_abc.py
+++ b/Lib/test/test_abc.py
@@ -478,7 +478,7 @@ def test_factory(abc_ABCMeta, abc_get_cache_token):
             self.assertFalse(issubclass(C, A))
             self.assertFalse(issubclass(C, (A,)))
 
-        def test_class_is_sublcass_of_iteself(self):
+        def test_class_is_subclass_of_itself(self):
             class Meta(type):
                 def __subclasscheck__(self, other):
                     return False

--- a/Lib/test/test_capi/test_exceptions.py
+++ b/Lib/test/test_capi/test_exceptions.py
@@ -173,11 +173,14 @@ class Test_ErrSetAndRestore(unittest.TestCase):
             def __subclasscheck__(cls, sub):
                 1/0
 
-        class Broken(Exception, metaclass=Meta):
+        class SemiBroken(Exception, metaclass=Meta):
+            pass
+
+        class Broken(SemiBroken):
             pass
 
         with self.assertRaises(ZeroDivisionError) as e:
-            _testcapi.exc_set_object(Broken, Broken())
+            _testcapi.exc_set_object(SemiBroken, Broken())
 
     def test_set_object_and_fetch(self):
         class Broken(Exception):

--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -220,6 +220,10 @@ class NoReturnTests(BottomTypeTestsMixin, BaseTestCase):
     def test_repr(self):
         self.assertEqual(repr(NoReturn), 'typing.NoReturn')
 
+    def test_subclass_type_error(self):
+        with self.assertRaises(TypeError):
+            issubclass(Employee, self.bottom_type)
+
     def test_get_type_hints(self):
         def some(arg: NoReturn) -> NoReturn: ...
         def some_str(arg: 'NoReturn') -> 'typing.NoReturn': ...
@@ -4250,7 +4254,6 @@ class GenericTests(BaseTestCase):
             with self.subTest(typ=typ):
                 self.assertRaises(TypeError, issubclass, typ, object)
                 self.assertRaises(TypeError, issubclass, typ, type)
-                self.assertRaises(TypeError, issubclass, typ, typ)
                 self.assertRaises(TypeError, issubclass, object, typ)
 
                 # isinstance is fine:

--- a/Misc/NEWS.d/next/Core and Builtins/2024-04-07-05-31-48.gh-issue-74416.NTWACb.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2024-04-07-05-31-48.gh-issue-74416.NTWACb.rst
@@ -1,0 +1,3 @@
+Speed up ``PyObject_IsSubclass`` in the common case that both classes are
+same. Fixed behavior of function ``PyObject_IsSubclass`` in accordance with
+the fact that the class is considered a subclass of itself

--- a/Objects/abstract.c
+++ b/Objects/abstract.c
@@ -2766,13 +2766,15 @@ recursive_issubclass(PyObject *derived, PyObject *cls)
 static int
 object_issubclass(PyThreadState *tstate, PyObject *derived, PyObject *cls)
 {
+    /* Quick test for an exact match */
+    if((PyTypeObject*)derived == (PyTypeObject*)cls){
+        return 1;
+    }
+    
     PyObject *checker;
 
     /* We know what type's __subclasscheck__ does. */
     if (PyType_CheckExact(cls)) {
-        /* Quick test for an exact match */
-        if (derived == cls)
-            return 1;
         return recursive_issubclass(derived, cls);
     }
 

--- a/Objects/abstract.c
+++ b/Objects/abstract.c
@@ -2770,7 +2770,7 @@ object_issubclass(PyThreadState *tstate, PyObject *derived, PyObject *cls)
     if((PyTypeObject*)derived == (PyTypeObject*)cls){
         return 1;
     }
-    
+
     PyObject *checker;
 
     /* We know what type's __subclasscheck__ does. */


### PR DESCRIPTION
Fixes: #74416 

<!-- gh-issue-number: gh-74416 -->
* Issue: gh-74416
<!-- /gh-issue-number -->
