### PR TITLE
gh-111726: Cleanup test files after running sqlite3 doctest

### DIFF
--- a/Doc/library/sqlite3.rst
+++ b/Doc/library/sqlite3.rst
@@ -2747,3 +2747,11 @@ regardless of the value of :attr:`~Connection.isolation_level`.
 
 .. _SQLite transaction behaviour:
    https://www.sqlite.org/lang_transaction.html#deferred_immediate_and_exclusive_transactions
+
+.. testcleanup::
+
+   import os
+   os.remove("backup.db")
+   os.remove("dump.sql")
+   os.remove("example.db")
+   os.remove("tutorial.db")


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

When running `make -C Doc/ PYTHON=../python.exe doctest` on `main` I'm left with some untracked test files:

```
➤ Untracked files
#
#      untracked:  [1] Doc/backup.db
#      untracked:  [2] Doc/dump.sql
#      untracked:  [3] Doc/example.db
#      untracked:  [4] Doc/tutorial.db
```

We don't need them, let's delete them after the doctest. 

I did it as a single `testcleanup` block at the end of the file. Is this okay or should I make a few localised blocks near where each file is created?


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--117604.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->