### PR TITLE
gh-117349: Speedup `os.path`

### DIFF
--- a/Lib/ntpath.py
+++ b/Lib/ntpath.py
@@ -32,12 +32,6 @@ __all__ = ["normcase","isabs","join","splitdrive","splitroot","split","splitext"
            "samefile", "sameopenfile", "samestat", "commonpath", "isjunction",
            "isdevdrive"]
 
-def _get_bothseps(path):
-    if isinstance(path, bytes):
-        return b'\\/'
-    else:
-        return '\\/'
-
 # Normalize the case of a pathname and map slashes to backslashes.
 # Other normalizations (such as optimizing '../' away) are not done
 # (this is done by normpath).
@@ -230,7 +224,7 @@ def split(p):
     Return tuple (head, tail) where tail is everything after the final slash.
     Either part may be empty."""
     p = os.fspath(p)
-    seps = _get_bothseps(p)
+    seps = b'\\/' if isinstance(p, bytes) else '\\/'
     d, r, p = splitroot(p)
     # set i to index beyond p's last slash
     i = len(p)
@@ -301,7 +295,7 @@ def ismount(path):
     """Test whether a path is a mount point (a drive root, the root of a
     share, or a mounted volume)"""
     path = os.fspath(path)
-    seps = _get_bothseps(path)
+    seps = b'\\/' if isinstance(path, bytes) else '\\/'
     path = abspath(path)
     drive, root, rest = splitroot(path)
     if drive and drive[0] in seps:
@@ -366,13 +360,15 @@ def expanduser(path):
     If user or $HOME is unknown, do nothing."""
     path = os.fspath(path)
     if isinstance(path, bytes):
+        seps = b'\\/'
         tilde = b'~'
     else:
+        seps = '\\/'
         tilde = '~'
     if not path.startswith(tilde):
         return path
     i, n = 1, len(path)
-    while i < n and path[i] not in _get_bothseps(path):
+    while i < n and path[i] not in seps:
         i += 1
 
     if 'USERPROFILE' in os.environ:
@@ -433,6 +429,7 @@ def expandvars(path):
         brace = b'{'
         rbrace = b'}'
         dollar = b'$'
+        empty = b''
         environ = getattr(os, 'environb', None)
     else:
         if '$' not in path and '%' not in path:
@@ -444,8 +441,9 @@ def expandvars(path):
         brace = '{'
         rbrace = '}'
         dollar = '$'
+        empty = ''
         environ = os.environ
-    res = path[:0]
+    res = empty
     index = 0
     pathlen = len(path)
     while index < pathlen:
@@ -504,7 +502,7 @@ def expandvars(path):
                         value = dollar + brace + var + rbrace
                     res += value
             else:
-                var = path[:0]
+                var = empty
                 index += 1
                 c = path[index:index + 1]
                 while c and c in varchars:

--- a/Lib/ntpath.py
+++ b/Lib/ntpath.py
@@ -108,8 +108,6 @@ def join(path, *paths):
         seps = '\\/'
         colon_seps = ':\\/'
     try:
-        if not paths:
-            path[:0] + sep  #23780: Ensure compatible data type even if p is null.
         result_drive, result_root, result_path = splitroot(path)
         for p in map(os.fspath, paths):
             p_drive, p_root, p_path = splitroot(p)

--- a/Lib/ntpath.py
+++ b/Lib/ntpath.py
@@ -822,7 +822,7 @@ def relpath(path, start=None):
         rel_list = [pardir] * (len(start_list)-i) + path_list[i:]
         if not rel_list:
             return curdir
-        return join(*rel_list)
+        return sep.join(rel_list)
     except (TypeError, ValueError, AttributeError, BytesWarning, DeprecationWarning):
         genericpath._check_arg_types('relpath', path, start)
         raise

--- a/Lib/ntpath.py
+++ b/Lib/ntpath.py
@@ -785,36 +785,33 @@ supports_unicode_filenames = True
 def relpath(path, start=None):
     """Return a relative version of a path"""
     path = os.fspath(path)
-    if not path:
-        raise ValueError("no path specified")
-
     if isinstance(path, bytes):
         sep = b'\\'
         curdir = b'.'
         pardir = b'..'
-        getcwd = os.getcwdb
     else:
         sep = '\\'
         curdir = '.'
         pardir = '..'
-        getcwd = os.getcwd
 
     if start is None:
         start = curdir
-    else:
-        start = os.fspath(start)
 
+    if not path:
+        raise ValueError("no path specified")
+
+    start = os.fspath(start)
     try:
-        start_abs = getcwd() if not start or start == curdir else abspath(start)
-        path_abs = abspath(path)
+        start_abs = abspath(normpath(start))
+        path_abs = abspath(normpath(path))
         start_drive, _, start_rest = splitroot(start_abs)
         path_drive, _, path_rest = splitroot(path_abs)
         if normcase(start_drive) != normcase(path_drive):
             raise ValueError("path is on mount %r, start on mount %r" % (
                 path_drive, start_drive))
 
-        start_list = start_rest.split(sep) if start_rest else []
-        path_list = path_rest.split(sep) if path_rest else []
+        start_list = [x for x in start_rest.split(sep) if x]
+        path_list = [x for x in path_rest.split(sep) if x]
         # Work out how much of the filepath is shared by start and path.
         i = 0
         for e1, e2 in zip(start_list, path_list):
@@ -825,7 +822,7 @@ def relpath(path, start=None):
         rel_list = [pardir] * (len(start_list)-i) + path_list[i:]
         if not rel_list:
             return curdir
-        return sep.join(rel_list)
+        return join(*rel_list)
     except (TypeError, ValueError, AttributeError, BytesWarning, DeprecationWarning):
         genericpath._check_arg_types('relpath', path, start)
         raise

--- a/Lib/ntpath.py
+++ b/Lib/ntpath.py
@@ -782,7 +782,11 @@ supports_unicode_filenames = True
 
 def relpath(path, start=None):
     """Return a relative version of a path"""
+
     path = os.fspath(path)
+    if not path:
+        raise ValueError("no path specified")
+
     if isinstance(path, bytes):
         sep = b'\\'
         curdir = b'.'
@@ -794,11 +798,9 @@ def relpath(path, start=None):
 
     if start is None:
         start = curdir
+    else:
+        start = os.fspath(start)
 
-    if not path:
-        raise ValueError("no path specified")
-
-    start = os.fspath(start)
     try:
         start_abs = abspath(normpath(start))
         path_abs = abspath(normpath(path))

--- a/Lib/ntpath.py
+++ b/Lib/ntpath.py
@@ -429,7 +429,6 @@ def expandvars(path):
         brace = b'{'
         rbrace = b'}'
         dollar = b'$'
-        empty = b''
         environ = getattr(os, 'environb', None)
     else:
         if '$' not in path and '%' not in path:
@@ -441,9 +440,8 @@ def expandvars(path):
         brace = '{'
         rbrace = '}'
         dollar = '$'
-        empty = ''
         environ = os.environ
-    res = empty
+    res = path[:0]
     index = 0
     pathlen = len(path)
     while index < pathlen:
@@ -502,7 +500,7 @@ def expandvars(path):
                         value = dollar + brace + var + rbrace
                     res += value
             else:
-                var = empty
+                var = path[:0]
                 index += 1
                 c = path[index:index + 1]
                 while c and c in varchars:

--- a/Lib/ntpath.py
+++ b/Lib/ntpath.py
@@ -810,8 +810,8 @@ def relpath(path, start=None):
             raise ValueError("path is on mount %r, start on mount %r" % (
                 path_drive, start_drive))
 
-        start_list = [x for x in start_rest.split(sep) if x]
-        path_list = [x for x in path_rest.split(sep) if x]
+        start_list = start_rest.split(sep) if start_rest else []
+        path_list = path_rest.split(sep) if path_rest else []
         # Work out how much of the filepath is shared by start and path.
         i = 0
         for e1, e2 in zip(start_list, path_list):

--- a/Lib/ntpath.py
+++ b/Lib/ntpath.py
@@ -784,7 +784,6 @@ supports_unicode_filenames = True
 
 def relpath(path, start=None):
     """Return a relative version of a path"""
-
     path = os.fspath(path)
     if not path:
         raise ValueError("no path specified")

--- a/Lib/ntpath.py
+++ b/Lib/ntpath.py
@@ -563,10 +563,8 @@ except ImportError:
                     i += 1
             else:
                 i += 1
-        # If the path is now empty, substitute '.'
-        if not prefix and not comps:
-            comps.append(curdir)
-        return prefix + sep.join(comps)
+        path = prefix + sep.join(comps)
+        return path or curdir
 
 else:
     def normpath(path):
@@ -636,8 +634,9 @@ else:
         allowed_winerror = 1, 2, 3, 5, 21, 32, 50, 67, 87, 4390, 4392, 4393
 
         seen = set()
-        while normcase(path) not in seen:
-            seen.add(normcase(path))
+        normp = normcase(path)
+        while normp not in seen:
+            seen.add(normp)
             try:
                 old_path = path
                 path = _nt_readlink(path)
@@ -651,6 +650,7 @@ else:
                         path = old_path
                         break
                     path = normpath(join(dirname(old_path), path))
+                    normp = normcase(path)
             except OSError as ex:
                 if ex.winerror in allowed_winerror:
                     break

--- a/Lib/ntpath.py
+++ b/Lib/ntpath.py
@@ -791,10 +791,12 @@ def relpath(path, start=None):
         sep = b'\\'
         curdir = b'.'
         pardir = b'..'
+        getcwd = os.getcwdb
     else:
         sep = '\\'
         curdir = '.'
         pardir = '..'
+        getcwd = os.getcwd
 
     if start is None:
         start = curdir
@@ -802,8 +804,8 @@ def relpath(path, start=None):
         start = os.fspath(start)
 
     try:
-        start_abs = abspath(normpath(start))
-        path_abs = abspath(normpath(path))
+        start_abs = getcwd() if not start or start == curdir else abspath(start)
+        path_abs = abspath(path)
         start_drive, _, start_rest = splitroot(start_abs)
         path_drive, _, path_rest = splitroot(path_abs)
         if normcase(start_drive) != normcase(path_drive):

--- a/Lib/ntpath.py
+++ b/Lib/ntpath.py
@@ -587,9 +587,13 @@ def _abspath_fallback(path):
     path = os.fspath(path)
     if not isabs(path):
         if isinstance(path, bytes):
+            curdir = b'.'
             cwd = os.getcwdb()
         else:
+            curdir = '.'
             cwd = os.getcwd()
+        if not path or path == curdir:
+            return cwd
         path = join(cwd, path)
     return normpath(path)
 
@@ -716,7 +720,7 @@ else:
             prefix = b'\\\\?\\'
             unc_prefix = b'\\\\?\\UNC\\'
             new_unc_prefix = b'\\\\'
-            cwd = os.getcwdb()
+            getcwd = os.getcwdb
             # bpo-38081: Special case for realpath(b'nul')
             devnull = b'nul'
             if normcase(path) == devnull:
@@ -725,14 +729,14 @@ else:
             prefix = '\\\\?\\'
             unc_prefix = '\\\\?\\UNC\\'
             new_unc_prefix = '\\\\'
-            cwd = os.getcwd()
+            getcwd = os.getcwd
             # bpo-38081: Special case for realpath('nul')
             devnull = 'nul'
             if normcase(path) == devnull:
                 return '\\\\.\\NUL'
         had_prefix = path.startswith(prefix)
         if not had_prefix and not isabs(path):
-            path = join(cwd, path)
+            path = join(getcwd(), path)
         try:
             path = _getfinalpathname(path)
             initial_winerror = 0

--- a/Lib/ntpath.py
+++ b/Lib/ntpath.py
@@ -585,13 +585,9 @@ def _abspath_fallback(path):
     path = os.fspath(path)
     if not isabs(path):
         if isinstance(path, bytes):
-            curdir = b'.'
             cwd = os.getcwdb()
         else:
-            curdir = '.'
             cwd = os.getcwd()
-        if not path or path == curdir:
-            return cwd
         path = join(cwd, path)
     return normpath(path)
 
@@ -650,7 +646,7 @@ else:
                         path = old_path
                         break
                     path = normpath(join(dirname(old_path), path))
-                    normp = normcase(path)
+                normp = normcase(path)
             except OSError as ex:
                 if ex.winerror in allowed_winerror:
                     break

--- a/Lib/posixpath.py
+++ b/Lib/posixpath.py
@@ -547,11 +547,9 @@ def commonpath(paths):
     if isinstance(paths[0], bytes):
         sep = b'/'
         curdir = b'.'
-        empty = b''
     else:
         sep = '/'
         curdir = '.'
-        empty = ''
 
     try:
         split_paths = [path.split(sep) for path in paths]
@@ -568,7 +566,7 @@ def commonpath(paths):
                 common = s1[:i]
                 break
 
-        prefix = sep if paths[0].startswith(sep) else empty
+        prefix = sep if paths[0].startswith(sep) else sep[:0]
         return prefix + sep.join(common)
     except (TypeError, AttributeError):
         genericpath._check_arg_types('commonpath', *paths)

--- a/Lib/posixpath.py
+++ b/Lib/posixpath.py
@@ -511,8 +511,10 @@ def relpath(path, start=None):
         start = os.fspath(start)
 
     try:
-        start_list = [x for x in abspath(start).split(sep) if x]
-        path_list = [x for x in abspath(path).split(sep) if x]
+        start_rest = abspath(start).lstrip(sep)
+        path_rest = abspath(path).lstrip(sep)
+        start_list = start_rest.split(sep) if start_rest else []
+        path_list = path_rest.split(sep) if path_rest else []
         # Work out how much of the filepath is shared by start and path.
         i = len(commonprefix([start_list, path_list]))
 

--- a/Lib/posixpath.py
+++ b/Lib/posixpath.py
@@ -348,7 +348,7 @@ except ImportError:
             sep = '/'
             dot = '.'
             dotdot = '..'
-        if not path:
+        if not path or path == dot:
             return dot
         _, initial_slashes, path = splitroot(path)
         comps = path.split(sep)
@@ -500,10 +500,12 @@ def relpath(path, start=None):
         curdir = b'.'
         sep = b'/'
         pardir = b'..'
+        getcwd = os.getcwdb
     else:
         curdir = '.'
         sep = '/'
         pardir = '..'
+        getcwd = os.getcwd
 
     if start is None:
         start = curdir
@@ -511,10 +513,12 @@ def relpath(path, start=None):
         start = os.fspath(start)
 
     try:
-        start_rest = abspath(start).lstrip(sep)
-        path_rest = abspath(path).lstrip(sep)
-        start_list = start_rest.split(sep) if start_rest else []
-        path_list = path_rest.split(sep) if path_rest else []
+        start_abs = getcwd() if not start or start == curdir else abspath(start)
+        path_abs = abspath(path)
+        start_tail = start_abs.lstrip(sep)
+        path_tail = path_abs.lstrip(sep)
+        start_list = start_tail.split(sep) if start_tail else []
+        path_list = path_tail.split(sep) if path_tail else []
         # Work out how much of the filepath is shared by start and path.
         i = len(commonprefix([start_list, path_list]))
 

--- a/Lib/posixpath.py
+++ b/Lib/posixpath.py
@@ -378,11 +378,17 @@ def abspath(path):
     """Return an absolute path."""
     path = os.fspath(path)
     if isinstance(path, bytes):
-        if not path.startswith(b'/'):
-            path = join(os.getcwdb(), path)
+        sep = b'/'
+        curdir = b'.'
+        getcwd = os.getcwdb
     else:
-        if not path.startswith('/'):
-            path = join(os.getcwd(), path)
+        sep = '/'
+        curdir = '.'
+        getcwd = os.getcwd
+    if not path.startswith(sep):
+        if not path or path == curdir:
+            return getcwd()
+        path = join(getcwd(), path)
     return normpath(path)
 
 

--- a/Lib/posixpath.py
+++ b/Lib/posixpath.py
@@ -184,6 +184,7 @@ def dirname(p):
 
 def ismount(path):
     """Test whether a path is a mount point"""
+    path = os.fspath(path)
     try:
         s1 = os.lstat(path)
     except (OSError, ValueError):
@@ -194,7 +195,6 @@ def ismount(path):
         if stat.S_ISLNK(s1.st_mode):
             return False
 
-    path = os.fspath(path)
     if isinstance(path, bytes):
         parent = join(path, b'..')
     else:
@@ -519,7 +519,7 @@ def relpath(path, start=None):
         rel_list = [pardir] * (len(start_list)-i) + path_list[i:]
         if not rel_list:
             return curdir
-        return join(*rel_list)
+        return sep.join(rel_list)
     except (TypeError, AttributeError, BytesWarning, DeprecationWarning):
         genericpath._check_arg_types('relpath', path, start)
         raise

--- a/Lib/posixpath.py
+++ b/Lib/posixpath.py
@@ -506,12 +506,10 @@ def relpath(path, start=None):
         curdir = b'.'
         sep = b'/'
         pardir = b'..'
-        getcwd = os.getcwdb
     else:
         curdir = '.'
         sep = '/'
         pardir = '..'
-        getcwd = os.getcwd
 
     if start is None:
         start = curdir
@@ -519,19 +517,15 @@ def relpath(path, start=None):
         start = os.fspath(start)
 
     try:
-        start_abs = getcwd() if not start or start == curdir else abspath(start)
-        path_abs = abspath(path)
-        start_tail = start_abs.lstrip(sep)
-        path_tail = path_abs.lstrip(sep)
-        start_list = start_tail.split(sep) if start_tail else []
-        path_list = path_tail.split(sep) if path_tail else []
+        start_list = [x for x in abspath(start).split(sep) if x]
+        path_list = [x for x in abspath(path).split(sep) if x]
         # Work out how much of the filepath is shared by start and path.
         i = len(commonprefix([start_list, path_list]))
 
         rel_list = [pardir] * (len(start_list)-i) + path_list[i:]
         if not rel_list:
             return curdir
-        return sep.join(rel_list)
+        return join(*rel_list)
     except (TypeError, AttributeError, BytesWarning, DeprecationWarning):
         genericpath._check_arg_types('relpath', path, start)
         raise

--- a/Lib/posixpath.py
+++ b/Lib/posixpath.py
@@ -553,9 +553,11 @@ def commonpath(paths):
     if isinstance(paths[0], bytes):
         sep = b'/'
         curdir = b'.'
+        empty = b''
     else:
         sep = '/'
         curdir = '.'
+        empty = ''
 
     try:
         split_paths = [path.split(sep) for path in paths]
@@ -572,7 +574,7 @@ def commonpath(paths):
                 common = s1[:i]
                 break
 
-        prefix = sep if paths[0].startswith(sep) else sep[:0]
+        prefix = sep if paths[0].startswith(sep) else empty
         return prefix + sep.join(common)
     except (TypeError, AttributeError):
         genericpath._check_arg_types('commonpath', *paths)

--- a/Lib/posixpath.py
+++ b/Lib/posixpath.py
@@ -554,10 +554,8 @@ def commonpath(paths):
     try:
         split_paths = [path.split(sep) for path in paths]
 
-        try:
-            isabs, = set(p[:1] == sep for p in paths)
-        except ValueError:
-            raise ValueError("Can't mix absolute and relative paths") from None
+        if len({p.startswith(sep) for p in paths}) != 1:
+            raise ValueError("Can't mix absolute and relative paths")
 
         split_paths = [[c for c in s if c and c != curdir] for s in split_paths]
         s1 = min(split_paths)
@@ -568,7 +566,7 @@ def commonpath(paths):
                 common = s1[:i]
                 break
 
-        prefix = sep if isabs else sep[:0]
+        prefix = sep if paths[0].startswith(sep) else sep[:0]
         return prefix + sep.join(common)
     except (TypeError, AttributeError):
         genericpath._check_arg_types('commonpath', *paths)

--- a/Lib/posixpath.py
+++ b/Lib/posixpath.py
@@ -71,8 +71,6 @@ def join(a, *p):
     sep = b'/' if isinstance(a, bytes) else '/'
     path = a
     try:
-        if not p:
-            path[:0] + sep  #23780: Ensure compatible data type even if p is null.
         for b in map(os.fspath, p):
             if b.startswith(sep) or not path:  # startswith ensures no mixing
                 path = b
@@ -155,7 +153,7 @@ def splitroot(p):
     else:
         # Precisely two leading slashes, e.g.: '//foo'. Implementation defined per POSIX, see
         # https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap04.html#tag_04_13
-        return empty, p[:2], p[2:]
+        return empty, sep + sep, p[2:]
 
 
 # Return the tail (basename) part of a path, same as split(path)[1].
@@ -225,11 +223,11 @@ def expanduser(path):
     do nothing."""
     path = os.fspath(path)
     if isinstance(path, bytes):
-        tilde = b'~'
         sep = b'/'
+        tilde = b'~'
     else:
-        tilde = '~'
         sep = '/'
+        tilde = '~'
     if not path.startswith(tilde):
         return path
     i = path.find(sep, 1)
@@ -271,11 +269,8 @@ def expanduser(path):
         return path
     if isinstance(path, bytes):
         userhome = os.fsencode(userhome)
-        root = b'/'
-    else:
-        root = '/'
-    userhome = userhome.rstrip(root)
-    return (userhome + path[i:]) or root
+    userhome = userhome.rstrip(sep)
+    return (userhome + path[i:]) or sep
 
 
 # Expand paths containing shell variable substitutions.

--- a/Lib/test/test_posixpath.py
+++ b/Lib/test/test_posixpath.py
@@ -56,6 +56,8 @@ class PosixPathTest(unittest.TestCase):
         self.assertEqual(fn(b"/foo", b"bar", b"baz"),          b"/foo/bar/baz")
         self.assertEqual(fn(b"/foo/", b"bar/", b"baz/"),       b"/foo/bar/baz/")
 
+        self.assertEqual(fn("a", ""),          "a/")
+        self.assertEqual(fn("a", "", ""),      "a/")
         self.assertEqual(fn("a", "b"),         "a/b")
         self.assertEqual(fn("a", "b/"),        "a/b/")
         self.assertEqual(fn("a/", "b"),        "a/b")

--- a/Misc/NEWS.d/next/Core and Builtins/2024-04-07-19-03-53.gh-issue-117609.J-C6J2.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2024-04-07-19-03-53.gh-issue-117609.J-C6J2.rst
@@ -1,0 +1,1 @@
+Speedup some functions in :mod:`os.path`.


### PR DESCRIPTION
Benchmark:

- `ntpath.py`
    ```bat
    ::test.bat
    @echo off
    echo join() && python -m timeit -s "import before.ntpath" "before.ntpath.join('foo')" && python -m timeit -s "import after.ntpath" "after.ntpath.join('foo')"
    echo split() && python -m timeit -s "import before.ntpath" "before.ntpath.split('foo')" && python -m timeit -s "import after.ntpath" "after.ntpath.split('foo')"
    echo ismount() && python -m timeit -s "import before.ntpath" "before.ntpath.ismount('//')" && python -m timeit -s "import after.ntpath" "after.ntpath.ismount('//')"
    echo expanduser() && python -m timeit -s "import before.ntpath" "before.ntpath.expanduser('~')" && python -m timeit -s "import after.ntpath" "after.ntpath.expanduser('~')"
    echo expanduser('~' + 'a' * 100) && python -m timeit -s "import before.ntpath" "before.ntpath.expanduser('~' + 'a' * 100)" && python -m timeit -s "import after.ntpath" "after.ntpath.expanduser('~' + 'a' * 100)"
    echo realpath(): cwd && python -m timeit -s "import os" "cwd = os.getcwd()" && python -m timeit -s "import os" "getcwd = os.getcwd; cwd = getcwd()"
    echo realpath('C:/'): cwd && python -m timeit -s "import os" "cwd = os.getcwd()" && python -m timeit -s "import os" "getcwd = os.getcwd"
    ```

    ```none
    join()
    500000 loops, best of 5: 693 nsec per loop # before
    500000 loops, best of 5: 650 nsec per loop # after
    # -> 1.07x faster
    split()
    500000 loops, best of 5: 866 nsec per loop # before
    500000 loops, best of 5: 799 nsec per loop # after
    # -> 1.08x faster
    ismount()
    200000 loops, best of 5: 1.19 usec per loop # before
    200000 loops, best of 5: 1.13 usec per loop # after
    # -> 1.05x faster
    expanduser()
    500000 loops, best of 5: 973 nsec per loop # before
    500000 loops, best of 5: 967 nsec per loop # after
    # -> no difference
    expanduser('~' + 'a' * 100)
    20000 loops, best of 5: 18 usec per loop # before
    20000 loops, best of 5: 11.2 usec per loop # after
    # -> 1.61x faster (for long users)
    realpath(): cwd 
    1000000 loops, best of 5: 228 nsec per loop # before
    1000000 loops, best of 5: 236 nsec per loop # after
    # -> only 8 nsec slower
    realpath('C:/'): cwd 
    1000000 loops, best of 5: 232 nsec per loop # before
    20000000 loops, best of 5: 16.3 nsec per loop # after
    # -> always 16.3 nsec (for absolute paths)
    ```
- `posixpath.py`
    ```shell
    # test.sh
    echo "isabs()" && python -m timeit -s "import before.posixpath" "before.posixpath.isabs('/')" && python -m timeit -s "import after.posixpath" "after.posixpath.isabs('/')"
    echo "join()" && python -m timeit -s "import before.posixpath" "before.posixpath.join('foo')" && python -m timeit -s "import after.posixpath" "after.posixpath.join('foo')"
    echo "split()" && python -m timeit -s "import before.posixpath" "before.posixpath.split('foo')" && python -m timeit -s "import after.posixpath" "after.posixpath.split('foo')"
    echo "basename()" && python -m timeit -s "import before.posixpath" "before.posixpath.basename('foo')" && python -m timeit -s "import after.posixpath" "after.posixpath.basename('foo')"
    echo "dirname()" && python -m timeit -s "import before.posixpath" "before.posixpath.dirname('foo')" && python -m timeit -s "import after.posixpath" "after.posixpath.dirname('foo')"
    echo "expanduser()" && python -m timeit -s "import before.posixpath" "before.posixpath.expanduser('~')" && python -m timeit -s "import after.posixpath" "after.posixpath.expanduser('~')"
    echo "abspath()" && python -m timeit -s "import before.posixpath" "before.posixpath.abspath('foo')" && python -m timeit -s "import after.posixpath" "after.posixpath.abspath('foo')"
    echo "abspath('.')" && python -m timeit -s "import before.posixpath" "before.posixpath.abspath('.')" && python -m timeit -s "import after.posixpath" "after.posixpath.abspath('.')"
    echo "commonpath()" && python -m timeit -s "import before.posixpath" "before.posixpath.commonpath(['/'])" && python -m timeit -s "import after.posixpath" "after.posixpath.commonpath(['/'])"
    ```
    
    ```none
    isabs()
    1000000 loops, best of 5: 230 nsec per loop # before
    1000000 loops, best of 5: 207 nsec per loop # after
    # -> 1.11x faster
    join()
    1000000 loops, best of 5: 322 nsec per loop # before
    1000000 loops, best of 5: 244 nsec per loop # after
    # -> 1.32x faster
    split()
    1000000 loops, best of 5: 348 nsec per loop # before
    1000000 loops, best of 5: 323 nsec per loop # after
    # -> 1.08x faster
    basename()
    1000000 loops, best of 5: 285 nsec per loop # before
    1000000 loops, best of 5: 263 nsec per loop # after
    # -> 1.08x faster
    dirname()
    1000000 loops, best of 5: 290 nsec per loop # before
    1000000 loops, best of 5: 259 nsec per loop # after
    # -> 1.12x faster
    expanduser()
    200000 loops, best of 5: 1.35 usec per loop # before
    200000 loops, best of 5: 1.25 usec per loop # after
    # -> 1.08x faster
    abspath()
    20000 loops, best of 5: 16.7 usec per loop # before
    20000 loops, best of 5: 16.8 usec per loop # after
    # -> no difference
    abspath('.')
    20000 loops, best of 5: 17 usec per loop # before
    20000 loops, best of 5: 15.1 usec per loop # after
    # -> 1.13x faster (for relative paths)
    commonpath()
    200000 loops, best of 5: 1.62 usec per loop # before
    200000 loops, best of 5: 1.48 usec per loop # after
    # -> 1.09x faster
    ```

<!-- gh-issue-number: gh-117609 -->
* Issue: gh-117609
<!-- /gh-issue-number -->


<!-- gh-issue-number: gh-117349 -->
* Issue: gh-117349
<!-- /gh-issue-number -->
