### PR TITLE
gh-96471: Correct documentation for asyncio queue shutdown

### DIFF
--- a/Doc/library/asyncio-queue.rst
+++ b/Doc/library/asyncio-queue.rst
@@ -106,9 +106,10 @@ Queue
       raise once the queue is empty. Set *immediate* to true to make
       :meth:`~Queue.get` raise immediately instead.
 
-      All blocked callers of :meth:`~Queue.put` will be unblocked. If
-      *immediate* is true, also unblock callers of :meth:`~Queue.get`
-      and :meth:`~Queue.join`.
+      All blocked callers of :meth:`~Queue.put` and :meth:`~Queue.get`
+      will be unblocked. If *immediate* is true, a task will be marked
+      as done for each remaining item in the queue, which may unblock
+      callers of :meth:`~Queue.join`.
 
       .. versionadded:: 3.13
 

--- a/Doc/whatsnew/3.13.rst
+++ b/Doc/whatsnew/3.13.rst
@@ -298,7 +298,7 @@ asyncio
 
 * Add :meth:`asyncio.Queue.shutdown` (along with
   :exc:`asyncio.QueueShutDown`) for queue termination.
-  (Contributed by Laurie Opperman in :gh:`104228`.)
+  (Contributed by Laurie Opperman and Yves Duprat in :gh:`104228`.)
 
 base64
 ------

--- a/Lib/asyncio/queues.py
+++ b/Lib/asyncio/queues.py
@@ -267,6 +267,7 @@ class Queue(mixins._LoopBoundMixin):
                     self._unfinished_tasks -= 1
             if self._unfinished_tasks == 0:
                 self._finished.set()
+        # All getters need to re-check queue-empty to raise ShutDown
         while self._getters:
             getter = self._getters.popleft()
             if not getter.done():

--- a/Lib/asyncio/queues.py
+++ b/Lib/asyncio/queues.py
@@ -256,8 +256,9 @@ class Queue(mixins._LoopBoundMixin):
         By default, gets will only raise once the queue is empty. Set
         'immediate' to True to make gets raise immediately instead.
 
-        All blocked callers of put() will be unblocked, and also get()
-        and join() if 'immediate'.
+        All blocked callers of put() and get() will be unblocked. If
+        'immediate', a task is marked as done for each item remaining in
+        the queue, which may unblock callers of join().
         """
         self._is_shutdown = True
         if immediate:


### PR DESCRIPTION
Fix documentation of behaviour introduced by #104228

* Gets are always unblocked (see https://github.com/python/cpython/pull/104228#discussion_r1554646081)
* Add comment for reason why gets are always unblocked
* Acknowledge Yves D (see https://github.com/python/cpython/pull/104228#discussion_r1554646226)

<!-- gh-issue-number: gh-96471 -->
* Issue: gh-96471
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--117621.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->