### PR TITLE
gh-117634: Remove `_get_[both]sep[s]()` calls in `os.path`

### DIFF
--- a/Lib/ntpath.py
+++ b/Lib/ntpath.py
@@ -32,12 +32,6 @@ __all__ = ["normcase","isabs","join","splitdrive","splitroot","split","splitext"
            "samefile", "sameopenfile", "samestat", "commonpath", "isjunction",
            "isdevdrive"]
 
-def _get_bothseps(path):
-    if isinstance(path, bytes):
-        return b'\\/'
-    else:
-        return '\\/'
-
 # Normalize the case of a pathname and map slashes to backslashes.
 # Other normalizations (such as optimizing '../' away) are not done
 # (this is done by normpath).
@@ -232,7 +226,7 @@ def split(p):
     Return tuple (head, tail) where tail is everything after the final slash.
     Either part may be empty."""
     p = os.fspath(p)
-    seps = _get_bothseps(p)
+    seps = b'\\/' if isinstance(p, bytes) else '\\/'
     d, r, p = splitroot(p)
     # set i to index beyond p's last slash
     i = len(p)
@@ -303,7 +297,7 @@ def ismount(path):
     """Test whether a path is a mount point (a drive root, the root of a
     share, or a mounted volume)"""
     path = os.fspath(path)
-    seps = _get_bothseps(path)
+    seps = b'\\/' if isinstance(path, bytes) else '\\/'
     path = abspath(path)
     drive, root, rest = splitroot(path)
     if drive and drive[0] in seps:
@@ -368,13 +362,15 @@ def expanduser(path):
     If user or $HOME is unknown, do nothing."""
     path = os.fspath(path)
     if isinstance(path, bytes):
+        seps = b'\\/'
         tilde = b'~'
     else:
+        seps = '\\/'
         tilde = '~'
     if not path.startswith(tilde):
         return path
     i, n = 1, len(path)
-    while i < n and path[i] not in _get_bothseps(path):
+    while i < n and path[i] not in seps:
         i += 1
 
     if 'USERPROFILE' in os.environ:

--- a/Lib/posixpath.py
+++ b/Lib/posixpath.py
@@ -38,12 +38,6 @@ __all__ = ["normcase","isabs","join","splitdrive","splitroot","split","splitext"
            "commonpath", "isjunction","isdevdrive"]
 
 
-def _get_sep(path):
-    if isinstance(path, bytes):
-        return b'/'
-    else:
-        return '/'
-
 # Normalize the case of a pathname.  Trivial in Posix, string.lower on Mac.
 # On MS-DOS this may also turn slashes into backslashes; however, other
 # normalizations (such as optimizing '../' away) are not allowed
@@ -60,7 +54,7 @@ def normcase(s):
 def isabs(s):
     """Test whether a path is absolute"""
     s = os.fspath(s)
-    sep = _get_sep(s)
+    sep = b'/' if isinstance(s, bytes) else '/'
     return s.startswith(sep)
 
 
@@ -74,7 +68,7 @@ def join(a, *p):
     will be discarded.  An empty last part will result in a path that
     ends with a separator."""
     a = os.fspath(a)
-    sep = _get_sep(a)
+    sep = b'/' if isinstance(a, bytes) else '/'
     path = a
     try:
         if not p:
@@ -101,7 +95,7 @@ def split(p):
     """Split a pathname.  Returns tuple "(head, tail)" where "tail" is
     everything after the final slash.  Either part may be empty."""
     p = os.fspath(p)
-    sep = _get_sep(p)
+    sep = b'/' if isinstance(p, bytes) else '/'
     i = p.rfind(sep) + 1
     head, tail = p[:i], p[i:]
     if head and head != sep*len(head):
@@ -169,7 +163,7 @@ def splitroot(p):
 def basename(p):
     """Returns the final component of a pathname"""
     p = os.fspath(p)
-    sep = _get_sep(p)
+    sep = b'/' if isinstance(p, bytes) else '/'
     i = p.rfind(sep) + 1
     return p[i:]
 
@@ -179,7 +173,7 @@ def basename(p):
 def dirname(p):
     """Returns the directory component of a pathname"""
     p = os.fspath(p)
-    sep = _get_sep(p)
+    sep = b'/' if isinstance(p, bytes) else '/'
     i = p.rfind(sep) + 1
     head = p[:i]
     if head and head != sep*len(head):
@@ -231,12 +225,13 @@ def expanduser(path):
     do nothing."""
     path = os.fspath(path)
     if isinstance(path, bytes):
+        sep = b'/'
         tilde = b'~'
     else:
+        sep = '/'
         tilde = '~'
     if not path.startswith(tilde):
         return path
-    sep = _get_sep(path)
     i = path.find(sep, 1)
     if i < 0:
         i = len(path)

--- a/Lib/posixpath.py
+++ b/Lib/posixpath.py
@@ -271,11 +271,8 @@ def expanduser(path):
         return path
     if isinstance(path, bytes):
         userhome = os.fsencode(userhome)
-        root = b'/'
-    else:
-        root = '/'
-    userhome = userhome.rstrip(root)
-    return (userhome + path[i:]) or root
+    userhome = userhome.rstrip(sep)
+    return (userhome + path[i:]) or sep
 
 
 # Expand paths containing shell variable substitutions.

--- a/Misc/NEWS.d/next/Core and Builtins/2024-04-08-13-25-39.gh-issue-117634.W12mzZ.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2024-04-08-13-25-39.gh-issue-117634.W12mzZ.rst
@@ -1,0 +1,1 @@
+Speed up several functions in :mod:`os.path` by 5-12%, and :func:`os.path.expanduser()` by 61% for long users.

--- a/Misc/NEWS.d/next/Core and Builtins/2024-04-08-13-25-39.gh-issue-117634.W12mzZ.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2024-04-08-13-25-39.gh-issue-117634.W12mzZ.rst
@@ -1,1 +1,1 @@
-Speed up several functions in :mod:`os.path` by 5-12%, and :func:`os.path.expanduser()` by 61% for long users.
+Speed up several functions in :mod:`os.path`.


### PR DESCRIPTION
### Benchmark

#### ntpath.py

```bat
::test.bat
@echo off
echo split() && python -m timeit -s "import before.ntpath" "before.ntpath.split('foo')" && python -m timeit -s "import after.ntpath" "after.ntpath.split('foo')"
echo ismount() && python -m timeit -s "import before.ntpath" "before.ntpath.ismount('//')" && python -m timeit -s "import after.ntpath" "after.ntpath.ismount('//')"
echo expanduser() && python -m timeit -s "import before.ntpath" "before.ntpath.expanduser('~')" && python -m timeit -s "import after.ntpath" "after.ntpath.expanduser('~')"
echo expanduser('~' + 'a' * 100) && python -m timeit -s "import before.ntpath" "before.ntpath.expanduser('~' + 'a' * 100)" && python -m timeit -s "import after.ntpath" "after.ntpath.expanduser('~' + 'a' * 100)"
```

```none
split()
500000 loops, best of 5: 867 nsec per loop # before
500000 loops, best of 5: 801 nsec per loop # after
# -> 1.08x faster
ismount()
200000 loops, best of 5: 1.21 usec per loop # before
200000 loops, best of 5: 1.16 usec per loop # after
# -> 1.04x faster
expanduser()
500000 loops, best of 5: 977 nsec per loop # before
500000 loops, best of 5: 965 nsec per loop # after
# -> no difference
expanduser('~' + 'a' * 100)
20000 loops, best of 5: 18 usec per loop # before
20000 loops, best of 5: 11.3 usec per loop # after
# -> 1.59x faster (for long usernames)
```

#### posixpath.py

```shell
# test.sh
echo "isabs()" && python -m timeit -s "import before.posixpath" "before.posixpath.isabs('/')" && python -m timeit -s "import after.posixpath" "after.posixpath.isabs('/')"
echo "join()" && python -m timeit -s "import before.posixpath" "before.posixpath.join('foo')" && python -m timeit -s "import after.posixpath" "after.posixpath.join('foo')"
echo "split()" && python -m timeit -s "import before.posixpath" "before.posixpath.split('foo')" && python -m timeit -s "import after.posixpath" "after.posixpath.split('foo')"
echo "basename()" && python -m timeit -s "import before.posixpath" "before.posixpath.basename('foo')" && python -m timeit -s "import after.posixpath" "after.posixpath.basename('foo')"
echo "dirname()" && python -m timeit -s "import before.posixpath" "before.posixpath.dirname('foo')" && python -m timeit -s "import after.posixpath" "after.posixpath.dirname('foo')"
echo "expanduser()" && python -m timeit -s "import before.posixpath" "before.posixpath.expanduser('~')" && python -m timeit -s "import after.posixpath" "after.posixpath.expanduser('~')"
```

```none
isabs()
1000000 loops, best of 5: 235 nsec per loop # before
1000000 loops, best of 5: 204 nsec per loop # after
# -> 1.15x faster
join()
1000000 loops, best of 5: 322 nsec per loop # before
1000000 loops, best of 5: 303 nsec per loop # after
# -> 1.06x faster
split()
1000000 loops, best of 5: 351 nsec per loop # before
1000000 loops, best of 5: 339 nsec per loop # after
# -> 1.04x faster
basename()
1000000 loops, best of 5: 284 nsec per loop # before
1000000 loops, best of 5: 257 nsec per loop # after
# -> 1.11x faster
dirname()
1000000 loops, best of 5: 286 nsec per loop # before
1000000 loops, best of 5: 262 nsec per loop # after
# -> 1.09x faster
expanduser()
200000 loops, best of 5: 1.38 usec per loop # before
200000 loops, best of 5: 1.26 usec per loop # after
# -> 1.10 faster
```

<!-- gh-issue-number: gh-117634 -->
* Issue: gh-117634
<!-- /gh-issue-number -->
