### PR TITLE
Add more information to JSON Decode error

### DIFF
--- a/Lib/json/decoder.py
+++ b/Lib/json/decoder.py
@@ -1,8 +1,8 @@
 """Implementation of JSONDecoder
 """
 import re
-
 from json import scanner
+
 try:
     from _json import scanstring as c_scanstring
 except ImportError:

--- a/Lib/json/decoder.py
+++ b/Lib/json/decoder.py
@@ -1,8 +1,8 @@
 """Implementation of JSONDecoder
 """
 import re
-from json import scanner
 
+from json import scanner
 try:
     from _json import scanstring as c_scanstring
 except ImportError:

--- a/Lib/json/decoder.py
+++ b/Lib/json/decoder.py
@@ -31,7 +31,8 @@ class JSONDecodeError(ValueError):
     def __init__(self, msg, doc, pos):
         lineno = doc.count('\n', 0, pos) + 1
         colno = pos - doc.rfind('\n', 0, pos)
-        errmsg = '%s: line %d column %d (char %d)' % (msg, lineno, colno, pos)
+        doc_type = type(doc)
+        errmsg = 'Got: %s with type: %s. Line %d column %d (char %d)' % (msg, doc_type, lineno, colno, pos)
         ValueError.__init__(self, errmsg)
         self.msg = msg
         self.doc = doc

--- a/Lib/test/test_json/test_decode.py
+++ b/Lib/test/test_json/test_decode.py
@@ -1,8 +1,8 @@
 import decimal
-from collections import OrderedDict
 from io import StringIO
+from collections import OrderedDict
+from test.test_json import PyTest, CTest
 from test import support
-from test.test_json import CTest, PyTest
 
 
 class TestDecode:

--- a/Lib/test/test_json/test_decode.py
+++ b/Lib/test/test_json/test_decode.py
@@ -1,8 +1,8 @@
 import decimal
-from io import StringIO
 from collections import OrderedDict
-from test.test_json import PyTest, CTest
+from io import StringIO
 from test import support
+from test.test_json import CTest, PyTest
 
 
 class TestDecode:
@@ -66,12 +66,12 @@ class TestDecode:
     def test_extra_data(self):
         s = '[1, 2, 3]5'
         msg = 'Extra data'
-        self.assertRaisesRegex(self.JSONDecodeError, msg, self.loads, s)
+        self.assertRaisesRegex(self.JSONDecodeError, f"Got: {s} with type: {type(s)}.", self.loads, s)
 
     def test_invalid_escape(self):
         s = '["abc\\y"]'
         msg = 'escape'
-        self.assertRaisesRegex(self.JSONDecodeError, msg, self.loads, s)
+        self.assertRaisesRegex(self.JSONDecodeError, f"Got: {s} with type: {type(s)}.", self.loads, s)
 
     def test_invalid_input_type(self):
         msg = 'the JSON object must be str'


### PR DESCRIPTION
I am missing more details in generic `JSONDecodeErrors` as e.g. when the input is empty/None I cannot see anything in the log and the message is confusing. I thought adding explicit object type could help as well as separating object from the actual error message.