### PR TITLE
gh-117636: Remove redundant type check in `os.path.join()`

### DIFF
--- a/Lib/ntpath.py
+++ b/Lib/ntpath.py
@@ -108,8 +108,6 @@ def join(path, *paths):
         seps = '\\/'
         colon_seps = ':\\/'
     try:
-        if not paths:
-            path[:0] + sep  #23780: Ensure compatible data type even if p is null.
         result_drive, result_root, result_path = splitroot(path)
         for p in map(os.fspath, paths):
             p_drive, p_root, p_path = splitroot(p)

--- a/Lib/posixpath.py
+++ b/Lib/posixpath.py
@@ -77,12 +77,10 @@ def join(a, *p):
     sep = _get_sep(a)
     path = a
     try:
-        if not p:
-            path[:0] + sep  #23780: Ensure compatible data type even if p is null.
         for b in map(os.fspath, p):
-            if b.startswith(sep):
+            if b.startswith(sep) or not path:
                 path = b
-            elif not path or path.endswith(sep):
+            elif path.endswith(sep):
                 path += b
             else:
                 path += sep + b

--- a/Lib/test/test_posixpath.py
+++ b/Lib/test/test_posixpath.py
@@ -56,6 +56,8 @@ class PosixPathTest(unittest.TestCase):
         self.assertEqual(fn(b"/foo", b"bar", b"baz"),          b"/foo/bar/baz")
         self.assertEqual(fn(b"/foo/", b"bar/", b"baz/"),       b"/foo/bar/baz/")
 
+        self.assertEqual(fn("a", ""),          "a/")
+        self.assertEqual(fn("a", "", ""),      "a/")
         self.assertEqual(fn("a", "b"),         "a/b")
         self.assertEqual(fn("a", "b/"),        "a/b/")
         self.assertEqual(fn("a/", "b"),        "a/b")

--- a/Misc/NEWS.d/next/Core and Builtins/2024-04-08-14-33-38.gh-issue-117636.exnRKd.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2024-04-08-14-33-38.gh-issue-117636.exnRKd.rst
@@ -1,1 +1,1 @@
-Speedup :func:`os.path.join()` by up to 1.1 times on Windows, up to 1.? times on Unix.
+Speedup :func:`os.path.join()` by up to 7% on Windows and ?% times on Unix.

--- a/Misc/NEWS.d/next/Core and Builtins/2024-04-08-14-33-38.gh-issue-117636.exnRKd.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2024-04-08-14-33-38.gh-issue-117636.exnRKd.rst
@@ -1,0 +1,1 @@
+Speedup :func:`os.path.join()` by up to 1.1 times on Windows, up to 1.? times on Unix.

--- a/Misc/NEWS.d/next/Core and Builtins/2024-04-08-14-33-38.gh-issue-117636.exnRKd.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2024-04-08-14-33-38.gh-issue-117636.exnRKd.rst
@@ -1,1 +1,1 @@
-Speedup :func:`os.path.join()` by up to 7% on Windows and 24% times on Unix for few components.
+Speedup :func:`os.path.join()`.

--- a/Misc/NEWS.d/next/Core and Builtins/2024-04-08-14-33-38.gh-issue-117636.exnRKd.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2024-04-08-14-33-38.gh-issue-117636.exnRKd.rst
@@ -1,1 +1,1 @@
-Speedup :func:`os.path.join()`.
+Speedup :func:`os.path.join`.

--- a/Misc/NEWS.d/next/Core and Builtins/2024-04-08-14-33-38.gh-issue-117636.exnRKd.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2024-04-08-14-33-38.gh-issue-117636.exnRKd.rst
@@ -1,1 +1,1 @@
-Speedup :func:`os.path.join()` by up to 7% on Windows and ?% times on Unix.
+Speedup :func:`os.path.join()` by up to 7% on Windows and 24% times on Unix for few components.


### PR DESCRIPTION
### Benchmark:

#### ntpath.py

<details><summary>script</summary>

```bat
::test.bat
@echo off
echo 1 item && python -m timeit -s "import before.ntpath" "before.ntpath.join('foo')" && python -m timeit -s "import after.ntpath" "after.ntpath.join('foo')"
echo 10 items && python -m timeit -s "import before.ntpath; paths = ['foo'] * 10" "before.ntpath.join(*paths)" && python -m timeit -s "import after.ntpath; paths = ['foo'] * 10" "after.ntpath.join(*paths)"
echo 100 items && python -m timeit -s "import before.ntpath; paths = ['foo'] * 100" "before.ntpath.join(*paths)" && python -m timeit -s "import after.ntpath; paths = ['foo'] * 100" "after.ntpath.join(*paths)"
```
</details>

```none
1 item
500000 loops, best of 5: 699 nsec per loop # before
500000 loops, best of 5: 648 nsec per loop # after
# -> 1.08x faster
10 items
50000 loops, best of 5: 5.48 usec per loop # before
50000 loops, best of 5: 5.52 usec per loop # after
# -> no difference
100 items
5000 loops, best of 5: 54.1 usec per loop # before
5000 loops, best of 5: 54 usec per loop # after
# -> no difference
```

#### posixpath.py

<details><summary>script</summary>

```shell
# test.sh
echo 1 item && python -m timeit -s "import before.posixpath" "before.posixpath.join('foo')" && python -m timeit -s "import after.posixpath" "after.posixpath.join('foo')"
echo 10 items && python -m timeit -s "import before.posixpath; paths = ['foo'] * 10" "before.posixpath.join(*paths)" && python -m timeit -s "import after.posixpath; paths = ['foo'] * 10" "after.posixpath.join(*paths)"
echo 100 items && python -m timeit -s "import before.posixpath; paths = ['foo'] * 100" "before.posixpath.join(*paths)" && python -m timeit -s "import after.posixpath; paths = ['foo'] * 100" "after.posixpath.join(*paths)"
```
</details>

```none
1 item
1000000 loops, best of 5: 335 nsec per loop # before
1000000 loops, best of 5: 271 nsec per loop # after
# -> 1.24x faster
10 items
50000 loops, best of 5: 3.43 usec per loop # before
100000 loops, best of 5: 3.35 usec per loop # after
# -> 1.02x faster
100 items
10000 loops, best of 5: 34.4 usec per loop # before
10000 loops, best of 5: 34.1 usec per loop # after
# -> no difference
```

<!-- gh-issue-number: gh-117636 -->
* Issue: gh-117636
<!-- /gh-issue-number -->
