### PR TITLE
gh-117639: Special case for "" & "." in `posixpath.abspath()`

### DIFF
--- a/Lib/posixpath.py
+++ b/Lib/posixpath.py
@@ -388,11 +388,17 @@ def abspath(path):
     """Return an absolute path."""
     path = os.fspath(path)
     if isinstance(path, bytes):
-        if not path.startswith(b'/'):
-            path = join(os.getcwdb(), path)
+        sep = b'/'
+        curdir = b'.'
+        getcwd = os.getcwdb
     else:
-        if not path.startswith('/'):
-            path = join(os.getcwd(), path)
+        sep = '/'
+        curdir = '.'
+        getcwd = os.getcwd
+    if not path.startswith(sep):
+        if not path or path == curdir:
+            return getcwd()
+        path = join(getcwd(), path)
     return normpath(path)
 
 

--- a/Misc/NEWS.d/next/Core and Builtins/2024-04-08-15-04-51.gh-issue-117639.ca4N3t.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2024-04-08-15-04-51.gh-issue-117639.ca4N3t.rst
@@ -1,1 +1,1 @@
-Speedup :func:`os.path.abspath()` by up to 13% on Unix for the current directory.
+Speedup :func:`os.path.abspath()` by up to 13% on Unix for "" & ".".

--- a/Misc/NEWS.d/next/Core and Builtins/2024-04-08-15-04-51.gh-issue-117639.ca4N3t.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2024-04-08-15-04-51.gh-issue-117639.ca4N3t.rst
@@ -1,0 +1,1 @@
+Speedup :func:`os.path.abspath()` by up to 13% on Unix for the current directory.


### PR DESCRIPTION
Benchmark:

```shell
# test.sh
echo "abspath()" && python -m timeit -s "import before.posixpath" "before.posixpath.abspath('foo')" && python -m timeit -s "import after.posixpath" "after.posixpath.abspath('foo')"
echo "abspath('.')" && python -m timeit -s "import before.posixpath" "before.posixpath.abspath('.')" && python -m timeit -s "import after.posixpath" "after.posixpath.abspath('.')"
echo "relpath()" && python -m timeit -s "import before.posixpath" "before.posixpath.relpath('foo', 'bar')" && python -m timeit -s "import after.posixpath" "after.posixpath.relpath('foo', 'bar')"
echo "relpath('foo')" && python -m timeit -s "import before.posixpath" "before.posixpath.relpath('foo')" && python -m timeit -s "import after.posixpath" "after.posixpath.relpath('foo')"
echo "relpath('/')" && python -m timeit -s "import before.posixpath" "before.posixpath.relpath('/')" && python -m timeit -s "import after.posixpath" "after.posixpath.relpath('/')"
```
    
```none
abspath()
20000 loops, best of 5: 17.7 usec per loop # before
20000 loops, best of 5: 17.4 usec per loop # after
# -> 1.02x faster
abspath('.')
20000 loops, best of 5: 18.1 usec per loop # before
20000 loops, best of 5: 15.7 usec per loop # after
# -> 1.15x faster (for '' & '.')
relpath()
10000 loops, best of 5: 39.4 usec per loop # before
10000 loops, best of 5: 39.8 usec per loop # after
# -> no difference
relpath('foo')
5000 loops, best of 5: 38.9 usec per loop # before
10000 loops, best of 5: 37.4 usec per loop # after
# -> 1.04x faster (for a single relative path)
relpath('/')
10000 loops, best of 5: 22 usec per loop # before
10000 loops, best of 5: 20.7 usec per loop # after
# -> 1.06x faster (for a single absolute path)
```

<!-- gh-issue-number: gh-117639 -->
* Issue: gh-117639
<!-- /gh-issue-number -->
