### PR TITLE
gh-117645: Skip test_dynamic global specialization on WASI

### DIFF
--- a/Lib/test/test_dynamic.py
+++ b/Lib/test/test_dynamic.py
@@ -4,7 +4,7 @@ import builtins
 import sys
 import unittest
 
-from test.support import is_wasi, Py_DEBUG, swap_item, swap_attr
+from test.support import is_wasi, swap_item, swap_attr
 
 
 class RebindBuiltinsTests(unittest.TestCase):
@@ -134,7 +134,7 @@ class RebindBuiltinsTests(unittest.TestCase):
 
         self.assertEqual(foo(), 7)
 
-    @unittest.skipIf(is_wasi and Py_DEBUG, "stack depth too shallow in pydebug WASI")
+    @unittest.skipIf(is_wasi, "stack depth too shallow in WASI")
     def test_load_global_specialization_failure_keeps_oparg(self):
         # https://github.com/python/cpython/issues/91625
         class MyGlobals(dict):


### PR DESCRIPTION
Skip test_load_global_specialization_failure_keeps_oparg() of test_dynamic on WASI build. The test uses too much stack memory.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-117645 -->
* Issue: gh-117645
<!-- /gh-issue-number -->
