### PR TITLE
gh-117648: Improve performance of os.join by replacing map with a direct method …

### DIFF
--- a/Lib/ntpath.py
+++ b/Lib/ntpath.py
@@ -111,7 +111,7 @@ def join(path, *paths):
         if not paths:
             path[:0] + sep  #23780: Ensure compatible data type even if p is null.
         result_drive, result_root, result_path = splitroot(path)
-        for p in map(os.fspath, paths):
+        for p in paths:
             p_drive, p_root, p_path = splitroot(p)
             if p_root:
                 # Second path is absolute

--- a/Lib/posixpath.py
+++ b/Lib/posixpath.py
@@ -79,7 +79,8 @@ def join(a, *p):
     try:
         if not p:
             path[:0] + sep  #23780: Ensure compatible data type even if p is null.
-        for b in map(os.fspath, p):
+        for b in p:
+            b = os.fspath(b)
             if b.startswith(sep):
                 path = b
             elif not path or path.endswith(sep):

--- a/Misc/NEWS.d/next/Core and Builtins/2024-04-08-20-26-15.gh-issue-117648.NzVEa7.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2024-04-08-20-26-15.gh-issue-117648.NzVEa7.rst
@@ -1,0 +1,1 @@
+Speedup :func:`os.path.join` by up to 6% on Windows and up to ?% on Unix.

--- a/Misc/NEWS.d/next/Core and Builtins/2024-04-08-20-26-15.gh-issue-117648.NzVEa7.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2024-04-08-20-26-15.gh-issue-117648.NzVEa7.rst
@@ -1,1 +1,1 @@
-Speedup :func:`os.path.join` by up to 6% on Windows and up to ?% on Unix.
+Speedup :func:`os.path.join` by up to 6% on Windows.


### PR DESCRIPTION
…call

### Benchmark

#### ntpath.py

<details><summary>script</summary>

```bat
::test.bat
@echo off
echo 1 item && python -m timeit -s "import before.ntpath" "before.ntpath.join('foo')" && python -m timeit -s "import after.ntpath" "after.ntpath.join('foo')"
echo 10 items && python -m timeit -s "import before.ntpath; paths = ['foo'] * 10" "before.ntpath.join(*paths)" && python -m timeit -s "import after.ntpath; paths = ['foo'] * 10" "after.ntpath.join(*paths)"
echo 100 items && python -m timeit -s "import before.ntpath; paths = ['foo'] * 100" "before.ntpath.join(*paths)" && python -m timeit -s "import after.ntpath; paths = ['foo'] * 100" "after.ntpath.join(*paths)"
```
</details>

```none
1 item
500000 loops, best of 5: 699 nsec per loop # before
500000 loops, best of 5: 612 nsec per loop # after
# -> 1.14x faster
10 items
50000 loops, best of 5: 5.47 usec per loop # before
50000 loops, best of 5: 5.18 usec per loop # after
# -> 1.06x faster
100 items
5000 loops, best of 5: 54.6 usec per loop # before
5000 loops, best of 5: 51.9 usec per loop # after
# -> 1.05x faster
```

#### posixpath.py

<details><summary>script</summary>

```sh
# test.sh
echo 1 item && python -m timeit -s "import before.posixpath" "before.posixpath.join('foo')" && python -m timeit -s "import after.posixpath" "after.posixpath.join('foo')"
echo 10 items && python -m timeit -s "import before.posixpath; paths = ['foo'] * 10" "before.posixpath.join(*paths)" && python -m timeit -s "import after.posixpath; paths = ['foo'] * 10" "after.posixpath.join(*paths)"
echo 100 items && python -m timeit -s "import before.posixpath; paths = ['foo'] * 100" "before.posixpath.join(*paths)" && python -m timeit -s "import after.posixpath; paths = ['foo'] * 100" "after.posixpath.join(*paths)"
```
</details>

```none
1 item
1000000 loops, best of 5: 325 nsec per loop # before
1000000 loops, best of 5: 241 nsec per loop # after
# -> 1.35x faster
10 items
100000 loops, best of 5: 3.33 usec per loop # before
100000 loops, best of 5: 3.32 usec per loop # after
# -> no difference
100 items
10000 loops, best of 5: 33.8 usec per loop # before
10000 loops, best of 5: 34.1 usec per loop # after
# -> no difference
```

<!-- gh-issue-number: gh-117648 -->
* Issue: gh-117648
<!-- /gh-issue-number -->
