### PR TITLE
gh-112844: Fix xz CPE identifier

### DIFF
--- a/Misc/externals.spdx.json
+++ b/Misc/externals.spdx.json
@@ -161,7 +161,7 @@
       "externalRefs": [
         {
           "referenceCategory": "SECURITY",
-          "referenceLocator": "cpe:2.3:a:xz_project:xz:5.2.5:*:*:*:*:*:*:*",
+          "referenceLocator": "cpe:2.3:a:tukaani:xz:5.2.5:*:*:*:*:*:*:*",
           "referenceType": "cpe23Type"
         }
       ],


### PR DESCRIPTION
Previous CPE identifier was for an xz Go package, not for the upstream package (isn't CPE fun?) Confirmed that this CPE works to detect the recent backdoor CVE by manually faking the metadata for 5.6.1 and running Grype. Will need a backport to 3.12 as well.

<!-- gh-issue-number: gh-112844 -->
* Issue: gh-112844
<!-- /gh-issue-number -->
