### PR TITLE
gh-117507: avoid patch as a class decorator to mutate an inherited method

### DIFF
--- a/Lib/test/test_unittest/testmock/testpatch.py
+++ b/Lib/test/test_unittest/testmock/testpatch.py
@@ -1979,5 +1979,32 @@ class PatchTest(unittest.TestCase):
             test()
 
 
+    def test_method_patched_by_subclass(self):
+        @patch('%s.something' % __name__, 1)
+        class Foo:
+            def test(self):
+                return something
+
+        @patch('%s.something' % __name__, 2)
+        class Bar(Foo):
+            pass
+
+        self.assertEqual(Foo().test(), 1)
+
+
+class AsyncPatchTest(unittest.IsolatedAsyncioTestCase):
+    async def test_async_method_patched_by_subclass(self):
+        @patch('%s.something' % __name__, 1)
+        class Foo:
+            async def test_async(self):
+                return something
+
+        @patch('%s.something' % __name__, 2)
+        class Bar(Foo):
+            pass
+
+        self.assertEqual(await Foo().test_async(), 1)
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
# Avoid patch as a class decorator to mutate an inherited method

```
gh-117507: avoid patch as a class decorator to mutate an inherited method
```