### PR TITLE
gh-117606: Truncate extremely long error message in `test_exceptions`

### DIFF
--- a/Lib/test/test_exceptions.py
+++ b/Lib/test/test_exceptions.py
@@ -1451,7 +1451,8 @@ class ExceptionTests(unittest.TestCase):
         """
         rc, out, err = script_helper.assert_python_failure("-c", code)
         self.assertEqual(rc, 1)
-        self.assertIn(b'RecursionError: maximum recursion depth exceeded', err)
+        expected = b'RecursionError: maximum recursion depth exceeded'
+        self.assertTrue(expected in err, msg=f"{expected} not found in {err[:3_000]!r}... (truncated)")
         self.assertIn(b'Done.', out)
 
 

--- a/Lib/test/test_exceptions.py
+++ b/Lib/test/test_exceptions.py
@@ -1452,7 +1452,7 @@ class ExceptionTests(unittest.TestCase):
         rc, out, err = script_helper.assert_python_failure("-c", code)
         self.assertEqual(rc, 1)
         expected = b'RecursionError: maximum recursion depth exceeded'
-        self.assertTrue(expected in err, msg=f"{expected} not found in {err[:3_000]!r}... (truncated)")
+        self.assertTrue(expected in err, msg=f"{expected!r} not found in {err[:3_000]!r}... (truncated)")
         self.assertIn(b'Done.', out)
 
 


### PR DESCRIPTION


<!-- gh-issue-number: gh-117606 -->
* Issue: gh-117606
<!-- /gh-issue-number -->
