### PR TITLE
gh-117645: Increase WASI stack size from 512 KiB to 8 MiB

### DIFF
--- a/Include/cpython/pystate.h
+++ b/Include/cpython/pystate.h
@@ -198,14 +198,6 @@ struct _ts {
 #ifdef Py_DEBUG
    // A debug build is likely built with low optimization level which implies
    // higher stack memory usage than a release build: use a lower limit.
-#  if defined(__wasi__)
-     // Based on wasmtime 16.
-#    define Py_C_RECURSION_LIMIT 150
-#  else
-#    define Py_C_RECURSION_LIMIT 500
-#  endif
-#elif defined(__wasi__)
-   // Based on wasmtime 16.
 #  define Py_C_RECURSION_LIMIT 500
 #elif defined(__s390x__)
 #  define Py_C_RECURSION_LIMIT 800
@@ -219,6 +211,9 @@ struct _ts {
 #  define Py_C_RECURSION_LIMIT 3000
 #elif defined(_Py_ADDRESS_SANITIZER)
 #  define Py_C_RECURSION_LIMIT 4000
+#elif defined(__wasi__)
+   // Based on wasmtime 16.
+#  define Py_C_RECURSION_LIMIT 5000
 #else
    // This value is duplicated in Lib/test/support/__init__.py
 #  define Py_C_RECURSION_LIMIT 10000

--- a/Lib/test/test_dynamic.py
+++ b/Lib/test/test_dynamic.py
@@ -4,7 +4,7 @@ import builtins
 import sys
 import unittest
 
-from test.support import is_wasi, swap_item, swap_attr
+from test.support import is_wasi, swap_item, swap_attr, Py_DEBUG
 
 
 class RebindBuiltinsTests(unittest.TestCase):
@@ -134,7 +134,8 @@ class RebindBuiltinsTests(unittest.TestCase):
 
         self.assertEqual(foo(), 7)
 
-    @unittest.skipIf(is_wasi, "stack depth too shallow in WASI")
+    @unittest.skipIf(is_wasi and Py_DEBUG,
+                     "stack depth too shallow in WASI debug build")
     def test_load_global_specialization_failure_keeps_oparg(self):
         # https://github.com/python/cpython/issues/91625
         class MyGlobals(dict):

--- a/Lib/test/test_dynamic.py
+++ b/Lib/test/test_dynamic.py
@@ -4,7 +4,7 @@ import builtins
 import sys
 import unittest
 
-from test.support import is_wasi, swap_item, swap_attr, Py_DEBUG
+from test.support import swap_item, swap_attr
 
 
 class RebindBuiltinsTests(unittest.TestCase):
@@ -134,8 +134,6 @@ class RebindBuiltinsTests(unittest.TestCase):
 
         self.assertEqual(foo(), 7)
 
-    @unittest.skipIf(is_wasi and Py_DEBUG,
-                     "stack depth too shallow in WASI debug build")
     def test_load_global_specialization_failure_keeps_oparg(self):
         # https://github.com/python/cpython/issues/91625
         class MyGlobals(dict):

--- a/Misc/NEWS.d/next/Build/2024-04-09-12-59-06.gh-issue-117645.0oEVAa.rst
+++ b/Misc/NEWS.d/next/Build/2024-04-09-12-59-06.gh-issue-117645.0oEVAa.rst
@@ -1,0 +1,2 @@
+Increase WASI stack size from 512 KiB to 8 MiB and the initial memory from 10
+MiB to 20 MiB. Patch by Victor Stinner.

--- a/configure
+++ b/configure
@@ -9497,7 +9497,7 @@ then :
 
 fi
 
-            as_fn_append LDFLAGS_NODIST " -z stack-size=524288 -Wl,--stack-first -Wl,--initial-memory=10485760"
+                as_fn_append LDFLAGS_NODIST " -z stack-size=8388608 -Wl,--stack-first -Wl,--initial-memory=20971520"
 
  ;; #(
   *) :

--- a/configure.ac
+++ b/configure.ac
@@ -2359,8 +2359,8 @@ AS_CASE([$ac_sys_system],
       AS_VAR_APPEND([LDFLAGS_NODIST], [" -Wl,--max-memory=10485760"])
     ])
 
-    dnl gh-117645: increase initial memory to 20 MiB and stack size to 8 MiB,
-    dnl move stack first.
+    dnl gh-117645: Set the memory size to 20 MiB, the stack size to 8 MiB,
+    dnl and move the stack first.
     dnl https://github.com/WebAssembly/wasi-libc/issues/233
     AS_VAR_APPEND([LDFLAGS_NODIST], [" -z stack-size=8388608 -Wl,--stack-first -Wl,--initial-memory=20971520"])
   ]

--- a/configure.ac
+++ b/configure.ac
@@ -2359,9 +2359,10 @@ AS_CASE([$ac_sys_system],
       AS_VAR_APPEND([LDFLAGS_NODIST], [" -Wl,--max-memory=10485760"])
     ])
 
-    dnl increase initial memory and stack size, move stack first
+    dnl gh-117645: increase initial memory to 20 MiB and stack size to 8 MiB,
+    dnl move stack first.
     dnl https://github.com/WebAssembly/wasi-libc/issues/233
-    AS_VAR_APPEND([LDFLAGS_NODIST], [" -z stack-size=524288 -Wl,--stack-first -Wl,--initial-memory=10485760"])
+    AS_VAR_APPEND([LDFLAGS_NODIST], [" -z stack-size=8388608 -Wl,--stack-first -Wl,--initial-memory=20971520"])
   ]
 )
 


### PR DESCRIPTION
Increase also the initial memory from 10 MiB to 20 MiB.
    
Reenable test_dynamic on WASI release build.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-117645 -->
* Issue: gh-117645
<!-- /gh-issue-number -->
