### PR TITLE
Revert "gh-106023: Update What's New in 3.13: _PyObject_FastCall() (#117633)"

### DIFF
--- a/Doc/whatsnew/3.13.rst
+++ b/Doc/whatsnew/3.13.rst
@@ -2010,6 +2010,11 @@ Removed
 
   (Contributed by Victor Stinner in :gh:`105182`.)
 
+* Remove private ``_PyObject_FastCall()`` function:
+  use ``PyObject_Vectorcall()`` which is available since Python 3.8
+  (:pep:`590`).
+  (Contributed by Victor Stinner in :gh:`106023`.)
+
 * Remove ``cpython/pytime.h`` header file: it only contained private functions.
   (Contributed by Victor Stinner in :gh:`106316`.)
 


### PR DESCRIPTION
This reverts commit 9a12f5d1c19dee1f89684be776680aeaf117be5b.

I was wrong: the _PyObject_FastCall() function was removed. But we kept the _PyObject_FastCallDict() function.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-106023 -->
* Issue: gh-106023
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--117676.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->