### PR TITLE
gh-117682: Allow IDLE not to be installed at configure time

### DIFF
--- a/Doc/using/configure.rst
+++ b/Doc/using/configure.rst
@@ -498,6 +498,13 @@ Install Options
 
    .. versionadded:: 3.6
 
+.. option:: --without-idle
+
+   Do not install IDLE, Python's Integrated Development and Learning Environment
+   (it is installed by default).
+
+   .. versionadded:: 3.13
+
 
 Performance options
 -------------------

--- a/Doc/using/configure.rst
+++ b/Doc/using/configure.rst
@@ -500,8 +500,7 @@ Install Options
 
 .. option:: --without-idle
 
-   Do not install IDLE, Python's Integrated Development and Learning Environment
-   (it is installed by default).
+   Do not install :term:`IDLE`.
 
    .. versionadded:: 3.13
 

--- a/Lib/test/test_tools/test_makefile.py
+++ b/Lib/test/test_tools/test_makefile.py
@@ -38,10 +38,10 @@ class TestMakefile(unittest.TestCase):
     @unittest.skipUnless(support.TEST_MODULES_ENABLED, "requires test modules")
     def test_makefile_test_folders(self):
         test_dirs = self.list_test_dirs()
-        idle_test = 'idlelib/idle_test'
-        self.assertIn(idle_test, test_dirs)
+        test_capi = 'test/test_capi'
+        self.assertIn(test_capi, test_dirs)
 
-        used = [idle_test]
+        used = [test_capi]
         for dirpath, dirs, files in os.walk(support.TEST_HOME_DIR):
             dirname = os.path.basename(dirpath)
             # Skip temporary dirs:

--- a/Mac/Makefile.in
+++ b/Mac/Makefile.in
@@ -6,6 +6,7 @@ VERSION=@VERSION@
 ABIFLAGS=@ABIFLAGS@
 LDVERSION=@LDVERSION@
 ENSUREPIP=@ENSUREPIP@
+IDLE=@IDLE@
 builddir = ..
 srcdir=@srcdir@
 prefix=@prefix@
@@ -63,7 +64,6 @@ installunixtools:
 	fi
 	cd "$(DESTDIR)$(FRAMEWORKUNIXTOOLSPREFIX)/bin" && \
 	for fn in \
-			idle3 \
 			pydoc3 \
 			python3 \
 			python3-config \
@@ -112,6 +112,16 @@ installunixtools:
 			$(LN) -s $(BINDIR)/$${fn} $${fn} ;\
 		done ;\
 	fi
+	-if test "x$(IDLE)" != "xno" ; then \
+		cd "$(DESTDIR)$(FRAMEWORKUNIXTOOLSPREFIX)/bin" && \
+		for fn in \
+				idle3 \
+				; \
+		do \
+			rm -f $${fn} ;\
+			$(LN) -s $(BINDIR)/$${fn} $${fn} ;\
+		done ;\
+	fi
 
 #
 # Like installunixtools, but only install links to the versioned binaries.
@@ -122,7 +132,6 @@ altinstallunixtools:
 	fi
 	cd "$(DESTDIR)$(FRAMEWORKUNIXTOOLSPREFIX)/bin" && \
 	for fn in \
-			idle$(VERSION) \
 			pydoc$(VERSION) \
 			python$(VERSION) \
 			python$(LDVERSION)-config \
@@ -165,6 +174,16 @@ altinstallunixtools:
 		cd "$(DESTDIR)$(FRAMEWORKUNIXTOOLSPREFIX)/bin" && \
 		for fn in \
 				pip$(VERSION) \
+				; \
+		do \
+			rm -f $${fn} ;\
+			$(LN) -s $(BINDIR)/$${fn} $${fn} ;\
+		done ;\
+	fi
+	-if test "x$(IDLE)" != "xno" ; then \
+		cd "$(DESTDIR)$(FRAMEWORKUNIXTOOLSPREFIX)/bin" && \
+		for fn in \
+				idle$(VERSION) \
 				; \
 		do \
 			rm -f $${fn} ;\
@@ -233,32 +252,38 @@ install_Python:
 
 
 install_IDLE:
-	test -d "$(DESTDIR)$(PYTHONAPPSDIR)" || mkdir -p "$(DESTDIR)$(PYTHONAPPSDIR)"
-	-test -d "$(DESTDIR)$(PYTHONAPPSDIR)/IDLE.app" && rm -rf "$(DESTDIR)$(PYTHONAPPSDIR)/IDLE.app"
-	/bin/cp -PR "$(srcdir)/IDLE/IDLE.app" "$(DESTDIR)$(PYTHONAPPSDIR)"
-	ln -sf "$(INSTALLED_PYTHONAPP)" "$(DESTDIR)$(PYTHONAPPSDIR)/IDLE.app/Contents/MacOS/Python"
-	sed -e "s!%prefix%!$(prefix)!g" -e 's!%exe%!$(PYTHONFRAMEWORK)!g' < "$(srcdir)/IDLE/IDLE.app/Contents/MacOS/IDLE" > "$(DESTDIR)$(PYTHONAPPSDIR)/IDLE.app/Contents/MacOS/IDLE"
-	sed "s!%version%!`$(RUNSHARED) $(BUILDPYTHON) -c 'import platform; print(platform.python_version())'`!g" < "$(srcdir)/IDLE/IDLE.app/Contents/Info.plist" > "$(DESTDIR)$(PYTHONAPPSDIR)/IDLE.app/Contents/Info.plist"
-	if [ -f "$(DESTDIR)$(LIBDEST)/idlelib/config-main.def" ]; then \
-		/bin/cp -p "$(DESTDIR)$(LIBDEST)/idlelib/config-main.def" \
-			"$(DESTDIR)$(LIBDEST)/idlelib/config-main.def~" ; \
-		sed -e 's!name= IDLE Classic Windows!name= IDLE Classic OSX!g' \
-			< "$(DESTDIR)$(LIBDEST)/idlelib/config-main.def~" \
-			> "$(DESTDIR)$(LIBDEST)/idlelib/config-main.def" ; \
-		rm "$(DESTDIR)$(LIBDEST)/idlelib/config-main.def~" ; \
+	if test "x$(IDLE)" != "xno" ; then \
+		test -d "$(DESTDIR)$(PYTHONAPPSDIR)" || mkdir -p "$(DESTDIR)$(PYTHONAPPSDIR)" ; \
 	fi
-	if [ -f "$(DESTDIR)$(LIBDEST)/idlelib/config-extensions.def" ]; then \
-		/bin/cp -p "$(DESTDIR)$(LIBDEST)/idlelib/config-extensions.def" \
-			"$(DESTDIR)$(LIBDEST)/idlelib/config-extensions.def~" ; \
-		sed -e 's!zoom-height=<Alt-Key-2>!zoom-height=<Option-Key-0>!g' \
-			-e 's!<Alt-Key-!<Option-Key-!g' \
-			< "$(DESTDIR)$(LIBDEST)/idlelib/config-extensions.def~" \
-			> "$(DESTDIR)$(LIBDEST)/idlelib/config-extensions.def" ; \
-		rm "$(DESTDIR)$(LIBDEST)/idlelib/config-extensions.def~" ; \
+	-if test "x$(IDLE)" != "xno" ; then \
+		test -d "$(DESTDIR)$(PYTHONAPPSDIR)/IDLE.app" && rm -rf "$(DESTDIR)$(PYTHONAPPSDIR)/IDLE.app" ; \
 	fi
-	touch "$(DESTDIR)$(PYTHONAPPSDIR)/IDLE.app"
-	chmod -R ugo+rX,go-w "$(DESTDIR)$(PYTHONAPPSDIR)/IDLE.app"
-	chmod ugo+x "$(DESTDIR)$(PYTHONAPPSDIR)/IDLE.app/Contents/MacOS/IDLE"
+	if test "x$(IDLE)" != "xno" ; then \
+		/bin/cp -PR "$(srcdir)/IDLE/IDLE.app" "$(DESTDIR)$(PYTHONAPPSDIR)" ; \
+		ln -sf "$(INSTALLED_PYTHONAPP)" "$(DESTDIR)$(PYTHONAPPSDIR)/IDLE.app/Contents/MacOS/Python" ; \
+		sed -e "s!%prefix%!$(prefix)!g" -e 's!%exe%!$(PYTHONFRAMEWORK)!g' < "$(srcdir)/IDLE/IDLE.app/Contents/MacOS/IDLE" > "$(DESTDIR)$(PYTHONAPPSDIR)/IDLE.app/Contents/MacOS/IDLE" ; \
+		sed "s!%version%!`$(RUNSHARED) $(BUILDPYTHON) -c 'import platform; print(platform.python_version())'`!g" < "$(srcdir)/IDLE/IDLE.app/Contents/Info.plist" > "$(DESTDIR)$(PYTHONAPPSDIR)/IDLE.app/Contents/Info.plist" ; \
+		if [ -f "$(DESTDIR)$(LIBDEST)/idlelib/config-main.def" ]; then \
+			/bin/cp -p "$(DESTDIR)$(LIBDEST)/idlelib/config-main.def" \
+				"$(DESTDIR)$(LIBDEST)/idlelib/config-main.def~" ; \
+			sed -e 's!name= IDLE Classic Windows!name= IDLE Classic OSX!g' \
+				< "$(DESTDIR)$(LIBDEST)/idlelib/config-main.def~" \
+				> "$(DESTDIR)$(LIBDEST)/idlelib/config-main.def" ; \
+			rm "$(DESTDIR)$(LIBDEST)/idlelib/config-main.def~" ; \
+		fi ; \
+		if [ -f "$(DESTDIR)$(LIBDEST)/idlelib/config-extensions.def" ]; then \
+			/bin/cp -p "$(DESTDIR)$(LIBDEST)/idlelib/config-extensions.def" \
+				"$(DESTDIR)$(LIBDEST)/idlelib/config-extensions.def~" ; \
+			sed -e 's!zoom-height=<Alt-Key-2>!zoom-height=<Option-Key-0>!g' \
+				-e 's!<Alt-Key-!<Option-Key-!g' \
+				< "$(DESTDIR)$(LIBDEST)/idlelib/config-extensions.def~" \
+				> "$(DESTDIR)$(LIBDEST)/idlelib/config-extensions.def" ; \
+			rm "$(DESTDIR)$(LIBDEST)/idlelib/config-extensions.def~" ; \
+		fi ; \
+		touch "$(DESTDIR)$(PYTHONAPPSDIR)/IDLE.app" ; \
+		chmod -R ugo+rX,go-w "$(DESTDIR)$(PYTHONAPPSDIR)/IDLE.app" ; \
+		chmod ugo+x "$(DESTDIR)$(PYTHONAPPSDIR)/IDLE.app/Contents/MacOS/IDLE" ; \
+	fi
 
 $(INSTALLED_PYTHONAPP): install_Python
 

--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -213,6 +213,9 @@ RUNSHARED=       @RUNSHARED@
 # ensurepip options
 ENSUREPIP=      @ENSUREPIP@
 
+# Option to control the installation of IDLE
+IDLE=@IDLE@
+
 # Internal static libraries
 LIBMPDEC_A= Modules/_decimal/libmpdec/libmpdec.a
 LIBEXPAT_A= Modules/expat/libexpat.a
@@ -2263,8 +2266,10 @@ bininstall: commoninstall altbininstall
 	(cd $(DESTDIR)$(LIBPC); $(LN) -s python-$(VERSION).pc python3.pc)
 	-rm -f $(DESTDIR)$(LIBPC)/python3-embed.pc
 	(cd $(DESTDIR)$(LIBPC); $(LN) -s python-$(VERSION)-embed.pc python3-embed.pc)
-	-rm -f $(DESTDIR)$(BINDIR)/idle3
-	(cd $(DESTDIR)$(BINDIR); $(LN) -s idle$(VERSION) idle3)
+	-if test "x$(IDLE)" != "xno" ; then \
+		rm -f $(DESTDIR)$(BINDIR)/idle3 ; \
+		(cd $(DESTDIR)$(BINDIR); $(LN) -s idle$(VERSION) idle3) ; \
+	fi
 	-rm -f $(DESTDIR)$(BINDIR)/pydoc3
 	(cd $(DESTDIR)$(BINDIR); $(LN) -s pydoc$(VERSION) pydoc3)
 	if test "x$(LIPO_32BIT_FLAGS)" != "x" ; then \
@@ -2297,6 +2302,7 @@ maninstall:	altmaninstall
 	(cd $(DESTDIR)$(MANDIR)/man1; $(LN) -s python$(VERSION).1 python3.1)
 
 # Install the library
+IDLELIBSUBDIRS=idlelib idlelib/Icons
 XMLLIBSUBDIRS=  xml xml/dom xml/etree xml/parsers xml/sax
 LIBSUBDIRS=	asyncio \
 		collections \
@@ -2310,7 +2316,6 @@ LIBSUBDIRS=	asyncio \
 		ensurepip ensurepip/_bundled \
 		html \
 		http \
-		idlelib idlelib/Icons \
 		importlib importlib/resources importlib/metadata \
 		json \
 		logging \
@@ -2333,8 +2338,8 @@ LIBSUBDIRS=	asyncio \
 		zipfile zipfile/_path \
 		zoneinfo \
 		__phello__
-TESTSUBDIRS=	idlelib/idle_test \
-		test \
+IDLETESTSUBDIRS=idlelib/idle_test
+TESTSUBDIRS=test \
 		test/archivetestdata \
 		test/audiodata \
 		test/certdata \
@@ -2488,8 +2493,16 @@ libinstall:	all $(srcdir)/Modules/xxmodule.c
 		else	true; \
 		fi; \
 	done
+	@if test "x$(IDLE)" != "xno"; then \
+		subdirs="$(LIBSUBDIRS) $(IDLELIBSUBDIRS)"; \
+	else \
+		subdirs="$(LIBSUBDIRS)"; \
+	fi
 	@if test "$(TEST_MODULES)" = yes; then \
 		subdirs="$(LIBSUBDIRS) $(TESTSUBDIRS)"; \
+		if test "x$(IDLE)" != "xno"; then \
+			subdirs="$(LIBSUBDIRS) $(IDLETESTSUBDIRS)"; \
+		fi; \
 	else \
 		subdirs="$(LIBSUBDIRS)"; \
 	fi; \
@@ -2516,6 +2529,9 @@ libinstall:	all $(srcdir)/Modules/xxmodule.c
 	done
 	@if test "$(TEST_MODULES)" = yes; then \
 		subdirs="$(LIBSUBDIRS) $(TESTSUBDIRS)"; \
+		if test "x$(IDLE)" != "xno"; then \
+			subdirs="$(LIBSUBDIRS) $(IDLETESTSUBDIRS)"; \
+		fi; \
 	else \
 		subdirs="$(LIBSUBDIRS)"; \
 	fi; \
@@ -2534,6 +2550,7 @@ libinstall:	all $(srcdir)/Modules/xxmodule.c
 			*~) ;; \
 			*) \
 				if test -d $$i; then continue; fi; \
+				if test `basename $$i` = test_idle.py -a "x$(IDLE)" = "xno"; then continue; fi; \
 				if test -x $$i; then \
 				    echo $(INSTALL_SCRIPT) $$i $$b; \
 				    $(INSTALL_SCRIPT) $$i $(DESTDIR)$$b; \
@@ -2676,7 +2693,9 @@ libainstall: all scripts
 	$(INSTALL_SCRIPT) $(srcdir)/install-sh $(DESTDIR)$(LIBPL)/install-sh
 	$(INSTALL_SCRIPT) python-config.py $(DESTDIR)$(LIBPL)/python-config.py
 	$(INSTALL_SCRIPT) python-config $(DESTDIR)$(BINDIR)/python$(LDVERSION)-config
-	$(INSTALL_SCRIPT) $(SCRIPT_IDLE) $(DESTDIR)$(BINDIR)/idle$(VERSION)
+	if test "x$(IDLE)" != "xno" ; then \
+		$(INSTALL_SCRIPT) $(SCRIPT_IDLE) $(DESTDIR)$(BINDIR)/idle$(VERSION) ; \
+	fi
 	$(INSTALL_SCRIPT) $(SCRIPT_PYDOC) $(DESTDIR)$(BINDIR)/pydoc$(VERSION)
 	@if [ -s Modules/python.exp -a \
 		"`echo $(MACHDEP) | sed 's/^\(...\).*/\1/'`" = "aix" ]; then \

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -1315,6 +1315,7 @@ Stefan Norberg
 Tim Northover
 Joe Norton
 Neal Norwitz
+Chris Novakovic
 Mikhail Novikov
 Michal Nowikowski
 Steffen Daode Nurpmeso

--- a/Misc/NEWS.d/next/IDLE/2024-04-09-16-39-23.gh-issue-117682.342a2Y.rst
+++ b/Misc/NEWS.d/next/IDLE/2024-04-09-16-39-23.gh-issue-117682.342a2Y.rst
@@ -1,0 +1,2 @@
+The ``configure`` script now supports the ``--without-idle`` option, which
+causes IDLE not to be installed. IDLE is still installed by default.

--- a/configure
+++ b/configure
@@ -824,6 +824,7 @@ LIBB2_CFLAGS
 OPENSSL_LDFLAGS
 OPENSSL_LIBS
 OPENSSL_INCLUDES
+IDLE
 ENSUREPIP
 SRCDIRS
 THREADHEADERS
@@ -1121,6 +1122,7 @@ with_wheel_pkg_dir
 with_readline
 with_computed_gotos
 with_ensurepip
+with_idle
 with_openssl
 with_openssl_rpath
 with_ssl_default_suites
@@ -1924,6 +1926,8 @@ Optional Packages:
   --with-ensurepip[=install|upgrade|no]
                           "install" or "upgrade" using bundled pip (default is
                           upgrade)
+  --without-idle          do not install Integrated Development and Learning
+                          Environment
   --with-openssl=DIR      root of the OpenSSL directory
   --with-openssl-rpath=[DIR|auto|no]
                           Set runtime library directory (rpath) for OpenSSL
@@ -27521,6 +27525,31 @@ case $with_ensurepip in #(
 esac
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ENSUREPIP" >&5
 printf "%s\n" "$ENSUREPIP" >&6; }
+
+
+# IDLE option
+IDLE=yes
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for --with-idle" >&5
+printf %s "checking for --with-idle... " >&6; }
+
+# Check whether --with-idle was given.
+if test ${with_idle+y}
+then :
+  withval=$with_idle;
+if test "$withval" = no
+then
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
+printf "%s\n" "no" >&6; };
+  IDLE=no
+else
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+printf "%s\n" "yes" >&6; };
+fi
+else $as_nop
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+printf "%s\n" "yes" >&6; }
+fi
+
 
 
 # check if the dirent structure of a d_type field and DT_UNKNOWN is defined

--- a/configure.ac
+++ b/configure.ac
@@ -6953,6 +6953,23 @@ AS_CASE([$with_ensurepip],
 AC_MSG_RESULT([$ENSUREPIP])
 AC_SUBST([ENSUREPIP])
 
+# IDLE option
+IDLE=yes
+AC_MSG_CHECKING([for --with-idle])
+AC_ARG_WITH([idle],
+  AS_HELP_STRING([--without-idle],
+                 [do not install Integrated Development and Learning Environment]),
+[
+if test "$withval" = no
+then
+  AC_MSG_RESULT([no]);
+  IDLE=no
+else
+  AC_MSG_RESULT([yes]);
+fi],
+[AC_MSG_RESULT([yes])])
+AC_SUBST([IDLE])
+
 # check if the dirent structure of a d_type field and DT_UNKNOWN is defined
 AC_CACHE_CHECK([if the dirent structure of a d_type field], [ac_cv_dirent_d_type], [
 AC_LINK_IFELSE(


### PR DESCRIPTION
Add a new configure option, `--without-idle`, that controls whether or not to install IDLE. It is installed by default for backwards compatibility.

<!-- gh-issue-number: gh-117682 -->
* Issue: gh-117682
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--117684.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->