### PR TITLE
gh-117507: avoid mock.patch as a class decorator to mutate an inherited method

### DIFF
--- a/Lib/test/test_unittest/testmock/testpatch.py
+++ b/Lib/test/test_unittest/testmock/testpatch.py
@@ -1979,5 +1979,86 @@ class PatchTest(unittest.TestCase):
             test()
 
 
+    def test_method_patched_by_subclass1(self):
+        @patch('%s.something' % __name__, 1)
+        class Foo:
+            def test(self):
+                return something
+
+        @patch('%s.something' % __name__, 2)
+        class Bar(Foo):
+            pass
+
+        self.assertEqual(Foo().test(), 1)
+        self.assertEqual(Bar().test(), 2)
+
+
+    def test_method_patched_by_subclass2(self):
+        class Foo:
+            def test(self):
+                return something
+
+        @patch('%s.something' % __name__, 2)
+        class Bar(Foo):
+            pass
+
+        self.assertEqual(Bar().test(), 2)
+
+
+    def test_method_patched_by_subclass3(self):
+        class Foo: ...
+
+        class Mixin:
+            def test(self):
+                return something
+
+        @patch('%s.something' % __name__, 2)
+        class Bar(Foo, Mixin):
+            pass
+
+        self.assertEqual(Bar().test(), 2)
+
+
+class AsyncPatchTest(unittest.IsolatedAsyncioTestCase):
+    async def test_async_method_patched_by_subclass1(self):
+        @patch('%s.something' % __name__, 1)
+        class Foo:
+            async def test_async(self):
+                return something
+
+        @patch('%s.something' % __name__, 2)
+        class Bar(Foo):
+            pass
+
+        self.assertEqual(await Foo().test_async(), 1)
+        self.assertEqual(await Bar().test_async(), 2)
+
+
+    async def test_async_method_patched_by_subclass2(self):
+        class Foo:
+            async def test_async(self):
+                return something
+
+        @patch('%s.something' % __name__, 2)
+        class Bar(Foo):
+            pass
+
+        self.assertEqual(await Bar().test_async(), 2)
+
+
+    async def test_async_method_patched_by_subclass3(self):
+        class Foo: ...
+
+        class Mixin:
+            async def test_async(self):
+                return something
+
+        @patch('%s.something' % __name__, 2)
+        class Bar(Foo, Mixin):
+            pass
+
+        self.assertEqual(await Bar().test_async(), 2)
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/Lib/test/test_unittest/testmock/testpatch.py
+++ b/Lib/test/test_unittest/testmock/testpatch.py
@@ -1996,7 +1996,7 @@ class PatchTest(unittest.TestCase):
         self.assertEqual(Foo().test(), 1)
         self.assertEqual(Bar().test(), 2)
         self.assertEqual(Baz().test(), 3)
-    
+
 
     def test_method_patched_by_subclass2(self):
         class Foo:

--- a/Lib/test/test_unittest/testmock/testpatch.py
+++ b/Lib/test/test_unittest/testmock/testpatch.py
@@ -1989,9 +1989,14 @@ class PatchTest(unittest.TestCase):
         class Bar(Foo):
             pass
 
+        @patch('%s.something' % __name__, 3)
+        class Baz(Foo):
+            pass
+
         self.assertEqual(Foo().test(), 1)
         self.assertEqual(Bar().test(), 2)
-
+        self.assertEqual(Baz().test(), 3)
+    
 
     def test_method_patched_by_subclass2(self):
         class Foo:
@@ -2002,11 +2007,13 @@ class PatchTest(unittest.TestCase):
         class Bar(Foo):
             pass
 
+        self.assertEqual(Foo().test(), something)
         self.assertEqual(Bar().test(), 2)
 
 
     def test_method_patched_by_subclass3(self):
-        class Foo: ...
+        class Foo:
+            pass
 
         class Mixin:
             def test(self):
@@ -2030,8 +2037,13 @@ class AsyncPatchTest(unittest.IsolatedAsyncioTestCase):
         class Bar(Foo):
             pass
 
+        @patch('%s.something' % __name__, 3)
+        class Baz(Foo):
+            pass
+
         self.assertEqual(await Foo().test_async(), 1)
         self.assertEqual(await Bar().test_async(), 2)
+        self.assertEqual(await Baz().test_async(), 3)
 
 
     async def test_async_method_patched_by_subclass2(self):
@@ -2043,11 +2055,13 @@ class AsyncPatchTest(unittest.IsolatedAsyncioTestCase):
         class Bar(Foo):
             pass
 
+        self.assertEqual(await Foo().test_async(), something)
         self.assertEqual(await Bar().test_async(), 2)
 
 
     async def test_async_method_patched_by_subclass3(self):
-        class Foo: ...
+        class Foo:
+            pass
 
         class Mixin:
             async def test_async(self):

--- a/Lib/unittest/mock.py
+++ b/Lib/unittest/mock.py
@@ -1369,12 +1369,12 @@ class _patch(object):
         return patcher
 
 
-    def __call__(self, func):
+    def __call__(self, func, is_inherited=False):
         if isinstance(func, type):
             return self.decorate_class(func)
         if inspect.iscoroutinefunction(func):
-            return self.decorate_async_callable(func)
-        return self.decorate_callable(func)
+            return self.decorate_async_callable(func, is_inherited=is_inherited)
+        return self.decorate_callable(func, is_inherited=is_inherited)
 
 
     def decorate_class(self, klass):
@@ -1387,54 +1387,63 @@ class _patch(object):
                 continue
 
             patcher = self.copy()
-            setattr(klass, attr, patcher(attr_value))
+            setattr(klass, attr, patcher(attr_value,
+                # avoid mutating a method if it's inherited
+                is_inherited=getattr(
+                    _safe_super(klass, klass), attr, _missing
+                ) is attr_value
+            ))
         return klass
 
 
     @contextlib.contextmanager
     def decoration_helper(self, patched, args, keywargs):
+        # patchings from the parent class should be applied first
+        patchings_chain = []
+        while hasattr(patched, 'patchings'):
+            patchings_chain.append(patched.patchings)
+            patched = patched.__wrapped__
         extra_args = []
         with contextlib.ExitStack() as exit_stack:
-            for patching in patched.patchings:
-                arg = exit_stack.enter_context(patching)
-                if patching.attribute_name is not None:
-                    keywargs.update(arg)
-                elif patching.new is DEFAULT:
-                    extra_args.append(arg)
+            for patchings in reversed(patchings_chain):
+                for patching in patchings:
+                    arg = exit_stack.enter_context(patching)
+                    if patching.attribute_name is not None:
+                        keywargs.update(arg)
+                    elif patching.new is DEFAULT:
+                        extra_args.append(arg)
 
             args += tuple(extra_args)
-            yield (args, keywargs)
+            yield (patched, args, keywargs)
 
 
-    def decorate_callable(self, func):
+    def decorate_callable(self, func, *, is_inherited=False):
         # NB. Keep the method in sync with decorate_async_callable()
-        if hasattr(func, 'patchings'):
+        if hasattr(func, 'patchings') and not is_inherited:
             func.patchings.append(self)
             return func
 
         @wraps(func)
         def patched(*args, **keywargs):
-            with self.decoration_helper(patched,
-                                        args,
-                                        keywargs) as (newargs, newkeywargs):
-                return func(*newargs, **newkeywargs)
+            with self.decoration_helper(patched, args, keywargs) as (
+                    newfunc, newargs, newkeywargs):
+                return newfunc(*newargs, **newkeywargs)
 
         patched.patchings = [self]
         return patched
 
 
-    def decorate_async_callable(self, func):
+    def decorate_async_callable(self, func, *, is_inherited=False):
         # NB. Keep the method in sync with decorate_callable()
-        if hasattr(func, 'patchings'):
+        if hasattr(func, 'patchings') and not is_inherited:
             func.patchings.append(self)
             return func
 
         @wraps(func)
         async def patched(*args, **keywargs):
-            with self.decoration_helper(patched,
-                                        args,
-                                        keywargs) as (newargs, newkeywargs):
-                return await func(*newargs, **newkeywargs)
+            with self.decoration_helper(patched, args, keywargs) as (
+                    newfunc, newargs, newkeywargs):
+                return await newfunc(*newargs, **newkeywargs)
 
         patched.patchings = [self]
         return patched

--- a/Lib/unittest/mock.py
+++ b/Lib/unittest/mock.py
@@ -1369,7 +1369,7 @@ class _patch(object):
         return patcher
 
 
-    def __call__(self, func, is_inherited=False):
+    def __call__(self, func, *, is_inherited=False):
         if isinstance(func, type):
             return self.decorate_class(func)
         if inspect.iscoroutinefunction(func):

--- a/Misc/NEWS.d/next/Library/2024-04-09-17-32-13.gh-issue-117507.JvCR2c.rst
+++ b/Misc/NEWS.d/next/Library/2024-04-09-17-32-13.gh-issue-117507.JvCR2c.rst
@@ -1,0 +1,1 @@
+Fixed :func:`unittest.mock.patch` as a class decorator from mutating a method inherited from a parent class.


### PR DESCRIPTION
# Avoid mock.patch as a class decorator to mutate an inherited method

gh-117507: mock.patch as a class decorator should make the callable decorator return a new callable instead of mutating the given callable if it is found to be a method inherited from a parent classs so to prevent the method in the parent class from being mutated by decorating a subclass. Patches for a subclass are applied after those for a parent class.