### PR TITLE
gh-117648: Remove unneeded and imprecise NEWS entry

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2024-04-08-20-26-15.gh-issue-117648.NzVEa7.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2024-04-08-20-26-15.gh-issue-117648.NzVEa7.rst
@@ -1,1 +1,0 @@
-Speedup :func:`os.path.join` by up to 6% on Windows.


### PR DESCRIPTION
I'm not sure a NEWS entry is needed for this change; alternatively, it should be made more accurate.

<!-- gh-issue-number: gh-117648 -->
* Issue: gh-117648
<!-- /gh-issue-number -->
