### PR TITLE
gh-117692: Fix `AttributeError` in `DocTestFinder` on wrapped `builtin_or_method`

### DIFF
--- a/Lib/doctest.py
+++ b/Lib/doctest.py
@@ -1140,7 +1140,9 @@ class DocTestFinder:
             obj = obj.fget
         if inspect.isfunction(obj) and getattr(obj, '__doc__', None):
             # We don't use `docstring` var here, because `obj` can be changed.
-            obj = inspect.unwrap(obj).__code__
+            obj = getattr(inspect.unwrap(obj), '__code__', None)
+            if obj is None:
+                return None  # if there's no code, there's no lineno
         if inspect.istraceback(obj): obj = obj.tb_frame
         if inspect.isframe(obj): obj = obj.f_code
         if inspect.iscode(obj):

--- a/Lib/doctest.py
+++ b/Lib/doctest.py
@@ -1140,9 +1140,14 @@ class DocTestFinder:
             obj = obj.fget
         if inspect.isfunction(obj) and getattr(obj, '__doc__', None):
             # We don't use `docstring` var here, because `obj` can be changed.
-            obj = getattr(inspect.unwrap(obj), '__code__', None)
-            if obj is None:
-                return None  # if there's no code, there's no lineno
+            obj = inspect.unwrap(obj)
+            try:
+                obj = obj.__code__
+            except AttributeError:
+                # Functions implemented in C don't necessarily
+                # have a __code__ attribute.
+                # If there's no code, there's no lineno
+                return None
         if inspect.istraceback(obj): obj = obj.tb_frame
         if inspect.isframe(obj): obj = obj.f_code
         if inspect.iscode(obj):

--- a/Lib/test/test_doctest/test_doctest.py
+++ b/Lib/test/test_doctest/test_doctest.py
@@ -2553,6 +2553,20 @@ def test_look_in_unwrapped():
     'one other test'
     """
 
+@doctest_skip_if(support.check_impl_detail(cpython=False))
+def test_wrapped_c_func():
+    """
+    # https://github.com/python/cpython/issues/117692
+    >>> import binascii
+    >>> from test.test_doctest.decorator_mod import decorator
+
+    >>> c_func_wrapped = decorator(binascii.b2a_hex)
+    >>> tests = doctest.DocTestFinder(exclude_empty=False).find(c_func_wrapped)
+    >>> for test in tests:
+    ...    print(test.lineno, test.name)
+    None b2a_hex
+    """
+
 def test_unittest_reportflags():
     """Default unittest reporting flags can be set to control reporting
 

--- a/Misc/NEWS.d/next/Library/2024-04-09-23-22-21.gh-issue-117692.EciInD.rst
+++ b/Misc/NEWS.d/next/Library/2024-04-09-23-22-21.gh-issue-117692.EciInD.rst
@@ -1,0 +1,2 @@
+Fixes a bug when :class:`doctest.DocTestFinder` was failing on wrapped
+``builtin_function_or_method``.


### PR DESCRIPTION
Refs https://github.com/python/cpython/pull/115440
CC @brianschubert @lpsinger

<!-- gh-issue-number: gh-117692 -->
* Issue: gh-117692
<!-- /gh-issue-number -->
