### PR TITLE
gh-112536: Define `_Py_THREAD_SANITIZER` on GCC when TSan is enabled

### DIFF
--- a/Include/pyport.h
+++ b/Include/pyport.h
@@ -572,6 +572,9 @@ extern "C" {
 #  if defined(__SANITIZE_ADDRESS__)
 #    define _Py_ADDRESS_SANITIZER
 #  endif
+#  if defined(__SANITIZE_THREAD__)
+#    define _Py_THREAD_SANITIZER
+#  endif
 #endif
 
 


### PR DESCRIPTION
The `__has_feature(thread_sanitizer)` is a Clang-ism. Although new versions of GCC implement `__has_feature`, the `defined(__has_feature)` check still fails on GCC so we don't use that code path.


<!-- gh-issue-number: gh-112536 -->
* Issue: gh-112536
<!-- /gh-issue-number -->
