### PR TITLE
gh-117348: restore import time performance of configparser

### DIFF
--- a/Lib/configparser.py
+++ b/Lib/configparser.py
@@ -143,7 +143,7 @@ ConfigParser -- responsible for parsing a list of
         between keys and values are surrounded by spaces.
 """
 
-from collections.abc import MutableMapping
+from collections.abc import Iterable, MutableMapping
 from collections import ChainMap as _ChainMap
 import contextlib
 from dataclasses import dataclass, field
@@ -153,7 +153,6 @@ import itertools
 import os
 import re
 import sys
-from typing import Iterable
 
 __all__ = ("NoSectionError", "DuplicateOptionError", "DuplicateSectionError",
            "NoOptionError", "InterpolationError", "InterpolationDepthError",

--- a/Lib/configparser.py
+++ b/Lib/configparser.py
@@ -553,17 +553,12 @@ class _ReadState:
         self.errors = list()
 
 
-class _Prefixes(types.SimpleNamespace):
-    full : Iterable[str]
-    inline : Iterable[str]
-
-
 class _Line(str):
 
     def __new__(cls, val, *args, **kwargs):
         return super().__new__(cls, val)
 
-    def __init__(self, val, prefixes: _Prefixes):
+    def __init__(self, val, prefixes):
         self.prefixes = prefixes
 
     @functools.cached_property
@@ -656,7 +651,7 @@ class RawConfigParser(MutableMapping):
             else:
                 self._optcre = re.compile(self._OPT_TMPL.format(delim=d),
                                           re.VERBOSE)
-        self._prefixes = _Prefixes(
+        self._prefixes = types.SimpleNamespace(
             full=tuple(comment_prefixes or ()),
             inline=tuple(inline_comment_prefixes or ()),
         )

--- a/Lib/configparser.py
+++ b/Lib/configparser.py
@@ -143,16 +143,18 @@ ConfigParser -- responsible for parsing a list of
         between keys and values are surrounded by spaces.
 """
 
+# Do not import dataclasses; overhead is unacceptable (gh-117703)
+
 from collections.abc import Iterable, MutableMapping
 from collections import ChainMap as _ChainMap
 import contextlib
-from dataclasses import dataclass, field
 import functools
 import io
 import itertools
 import os
 import re
 import sys
+import types
 
 __all__ = ("NoSectionError", "DuplicateOptionError", "DuplicateSectionError",
            "NoOptionError", "InterpolationError", "InterpolationDepthError",
@@ -537,19 +539,21 @@ class ExtendedInterpolation(Interpolation):
                     "found: %r" % (rest,))
 
 
-@dataclass
-class _ReadState:
-    elements_added : set[str] = field(default_factory=set)
+class _ReadState(types.SimpleNamespace):
+    elements_added : set[str]
     cursect : dict[str, str] | None = None
     sectname : str | None = None
     optname : str | None = None
     lineno : int = 0
     indent_level : int = 0
-    errors : list[ParsingError] = field(default_factory=list)
+    errors : list[ParsingError]
+
+    def __init__(self):
+        self.elements_added = set()
+        self.errors = list()
 
 
-@dataclass
-class _Prefixes:
+class _Prefixes(types.SimpleNamespace):
     full : Iterable[str]
     inline : Iterable[str]
 

--- a/Lib/configparser.py
+++ b/Lib/configparser.py
@@ -539,7 +539,7 @@ class ExtendedInterpolation(Interpolation):
                     "found: %r" % (rest,))
 
 
-class _ReadState(types.SimpleNamespace):
+class _ReadState:
     elements_added : set[str]
     cursect : dict[str, str] | None = None
     sectname : str | None = None

--- a/Misc/NEWS.d/next/Library/2024-04-09-20-14-44.gh-issue-117348.A2NAAz.rst
+++ b/Misc/NEWS.d/next/Library/2024-04-09-20-14-44.gh-issue-117348.A2NAAz.rst
@@ -1,0 +1,2 @@
+Largely restored import time performance of configparser by avoiding
+dataclasses.


### PR DESCRIPTION
As requested in https://github.com/python/cpython/pull/117372#issuecomment-2029565336

- **Get Iterable from collections.abc.**
- **Replace dataclass with SimpleNamespace.**
- **Add blurb**

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-117348 -->
* Issue: gh-117348
<!-- /gh-issue-number -->
