### PR TITLE
gh-117711: Only check for 'test/wheeldata' when it's actually used

### DIFF
--- a/Lib/test/test_tools/test_makefile.py
+++ b/Lib/test/test_tools/test_makefile.py
@@ -67,6 +67,9 @@ class TestMakefile(unittest.TestCase):
                 )
                 used.append(relpath)
 
+        if sysconfig.get_config_var('WHEEL_PKG_DIR'):
+            test_dirs.remove('test/wheeldata')
+
         # Check that there are no extra entries:
         unique_test_dirs = set(test_dirs)
         self.assertSetEqual(unique_test_dirs, set(used))

--- a/Lib/test/test_tools/test_makefile.py
+++ b/Lib/test/test_tools/test_makefile.py
@@ -67,6 +67,7 @@ class TestMakefile(unittest.TestCase):
                 )
                 used.append(relpath)
 
+        # Don't check the wheel dir when Python is built --with-wheel-pkg-dir
         if sysconfig.get_config_var('WHEEL_PKG_DIR'):
             test_dirs.remove('test/wheeldata')
 


### PR DESCRIPTION
It's possible to build Python with option `--with-wheel-pkg-dir` pointing to a custom wheel directory. Don't include the directory in the test set if the wheels are used from a different location.
Currently testing the patch in Fedora Linux.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-117711 -->
* Issue: gh-117711
<!-- /gh-issue-number -->
