### PR TITLE
[3.12] gh-115142: Skip ``test_capi.test_dict.py`` if ``_testcapi`` an…

### DIFF
--- a/Lib/test/test_capi/test_dict.py
+++ b/Lib/test/test_capi/test_dict.py
@@ -4,7 +4,9 @@ from collections import OrderedDict, UserDict
 from types import MappingProxyType
 from test import support
 from test.support import import_helper
-import _testcapi
+
+
+_testcapi = import_helper.import_module("_testcapi")
 
 
 NULL = None


### PR DESCRIPTION
…d ``_testlimitedcapi`` are not available (GH-117588)

(cherry picked from commit dfcae4379f2cc4d352a180f9fef2381570aa9bcb)


gh-115142: Skip test_dict if _testcapi and _testlimitedcapi is not available

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
