### PR TITLE
Fix version directive indents

### DIFF
--- a/Doc/library/decimal.rst
+++ b/Doc/library/decimal.rst
@@ -1517,7 +1517,7 @@ are also included in the pure Python version for compatibility.
    the C version uses a thread-local rather than a coroutine-local context and the value
    is ``False``.  This is slightly faster in some nested context scenarios.
 
-.. versionadded:: 3.8.3
+   .. versionadded:: 3.8.3
 
 
 Rounding modes

--- a/Doc/library/ipaddress.rst
+++ b/Doc/library/ipaddress.rst
@@ -334,13 +334,13 @@ write code that handles both IP versions correctly.  Address objects are
    .. attribute:: is_multicast
    .. attribute:: is_private
    .. attribute:: is_global
+
+      .. versionadded:: 3.4
+
    .. attribute:: is_unspecified
    .. attribute:: is_reserved
    .. attribute:: is_loopback
    .. attribute:: is_link_local
-
-      .. versionadded:: 3.4
-         is_global
 
    .. attribute:: is_site_local
 

--- a/Doc/library/ssl.rst
+++ b/Doc/library/ssl.rst
@@ -1820,7 +1820,7 @@ to speed up repeated connections from the same clients.
    .. versionchanged:: 3.6
       *session* argument was added.
 
-    .. versionchanged:: 3.7
+   .. versionchanged:: 3.7
       The method returns an instance of :attr:`SSLContext.sslsocket_class`
       instead of hard-coded :class:`SSLSocket`.
 

--- a/Doc/library/urllib.request.rst
+++ b/Doc/library/urllib.request.rst
@@ -113,9 +113,9 @@ The :mod:`urllib.request` module defines the following functions:
       ``http/1.1`` when no *context* is given. Custom *context* should set
       ALPN protocols with :meth:`~ssl.SSLContext.set_alpn_protocols`.
 
-    .. versionchanged:: 3.13
-       Remove *cafile*, *capath* and *cadefault* parameters: use the *context*
-       parameter instead.
+   .. versionchanged:: 3.13
+      Remove *cafile*, *capath* and *cadefault* parameters: use the *context*
+      parameter instead.
 
 
 .. function:: install_opener(opener)


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

We've added colour to the version change directives: https://github.com/python/python-docs-theme/pull/185

This has made it more obvious when some are misaligned to the thing they relate to. There will be more but this PR fixes some.

<img width="804" alt="image" src="https://github.com/python/cpython/assets/1324225/1fa63ab2-56d2-496e-8f7c-6d39c31f0843">

https://docs.python.org/3.13/library/decimal.html#constants


<img width="795" alt="image" src="https://github.com/python/cpython/assets/1324225/329f0942-93f6-4f27-a79b-60104d9a411c">


https://docs.python.org/3.13/library/ipaddress.html#ipaddress.IPv6Address

<img width="764" alt="image" src="https://github.com/python/cpython/assets/1324225/24138f45-7e0c-44ae-9008-ea1571f43106">


https://docs.python.org/3.13/library/ssl.html#ssl.SSLContext.wrap_socket

<img width="799" alt="image" src="https://github.com/python/cpython/assets/1324225/fb1781bd-6130-4eb8-ae02-8393d2b1b00c">


https://docs.python.org/3.13/library/urllib.request.html#urllib.request.urlopen

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--117719.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->