### PR TITLE
gh-117709: Add vectorcall support to `str()`

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2024-04-10-22-16-18.gh-issue-117709.-_1YL0.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2024-04-10-22-16-18.gh-issue-117709.-_1YL0.rst
@@ -1,0 +1,2 @@
+Speed up calls to :func:`str` by using the :pep:`590` ``vectorcall`` calling
+convention. Patch by Erlend Aasland.

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -14671,14 +14671,16 @@ static PyObject *
 unicode_vectorcall(PyObject *type, PyObject *const *args,
                    size_t nargsf, PyObject *kwnames)
 {
+    assert(Py_Is(_PyType_CAST(type), &PyUnicode_Type));
+
     Py_ssize_t nargs = PyVectorcall_NARGS(nargsf);
     Py_ssize_t nkwargs = (kwnames) ? PyTuple_GET_SIZE(kwnames) : 0;
     if (nargs == 0 && nkwargs == 0) {
-        return unicode_new_impl(_PyType_CAST(type), NULL, NULL, NULL);
+        return unicode_get_empty();
     }
     PyObject *object = args[0];
     if (nargs == 1 && nkwargs == 0) {
-        return unicode_new_impl(_PyType_CAST(type), object, NULL, NULL);
+        return PyObject_Str(object);
     }
     if (nargs + nkwargs == 2) {
         const char *encoding;
@@ -14712,7 +14714,7 @@ unicode_vectorcall(PyObject *type, PyObject *const *args,
         else {
             return fallback_to_tp_call(type, nargs, nkwargs, args, kwnames);
         }
-        return unicode_new_impl(_PyType_CAST(type), object, encoding, errors);
+        return PyUnicode_FromEncodedObject(object, encoding, errors);
     }
     if (nargs + nkwargs == 3) {
         if (nkwargs == 1) {
@@ -14734,7 +14736,7 @@ unicode_vectorcall(PyObject *type, PyObject *const *args,
         if (errors == NULL) {
             return NULL;
         }
-        return unicode_new_impl(_PyType_CAST(type), object, encoding, errors);
+        return PyUnicode_FromEncodedObject(object, encoding, errors);
     }
     if (nargs > 3) {
         PyErr_Format(PyExc_TypeError,

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -14665,8 +14665,8 @@ unicode_vectorcall(PyObject *type, PyObject *const *args,
         return PyObject_Str(object);
     }
     if (nargs + nkwargs == 2) {
-        const char *encoding;
-        const char *errors;
+        const char *encoding = NULL;
+        const char *errors = NULL;
         if (nkwargs == 1) {
             PyObject *key = PyTuple_GET_ITEM(kwnames, 0);
             if (_PyUnicode_EqualToASCIIString(key, "encoding")) {
@@ -14674,14 +14674,12 @@ unicode_vectorcall(PyObject *type, PyObject *const *args,
                 if (encoding == NULL) {
                     return NULL;
                 }
-                errors = NULL;
             }
             else if (_PyUnicode_EqualToASCIIString(key, "errors")) {
                 errors = as_const_char(args[1], "errors");
                 if (errors == NULL) {
                     return NULL;
                 }
-                encoding = NULL;
             }
             else {
                 PyErr_Format(PyExc_TypeError,
@@ -14691,7 +14689,6 @@ unicode_vectorcall(PyObject *type, PyObject *const *args,
         }
         else if (nkwargs == 0) {
             encoding = as_const_char(args[1], "encoding");
-            errors = NULL;
         }
         else {
             return fallback_to_tp_call(type, nargs, nkwargs, args, kwnames);

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -14618,10 +14618,12 @@ unicode_new_impl(PyTypeObject *type, PyObject *x, const char *encoding,
 }
 
 static const char *
-as_const_char(PyObject *obj)
+as_const_char(PyObject *obj, const char *name)
 {
     if (!PyUnicode_Check(obj)) {
-        _PyArg_BadArgument("str", "argument", "str", obj);
+        PyErr_Format(PyExc_TypeError,
+                     "str() argument '%s' must be str, not %T",
+                     name, obj);
         return NULL;
     }
     Py_ssize_t sz;
@@ -14684,14 +14686,14 @@ unicode_vectorcall(PyObject *type, PyObject *const *args,
         if (nkwargs == 1) {
             PyObject *kw0 = PyTuple_GET_ITEM(kwnames, 0);
             if (_PyUnicode_EqualToASCIIString(kw0, "encoding")) {
-                encoding = as_const_char(args[1]);
+                encoding = as_const_char(args[1], "encoding");
                 if (encoding == NULL) {
                     return NULL;
                 }
                 errors = NULL;
             }
             else if (_PyUnicode_EqualToASCIIString(kw0, "errors")) {
-                errors = as_const_char(args[1]);
+                errors = as_const_char(args[1], "errors");
                 if (errors == NULL) {
                     return NULL;
                 }
@@ -14704,7 +14706,7 @@ unicode_vectorcall(PyObject *type, PyObject *const *args,
             }
         }
         else if (nkwargs == 0) {
-            encoding = as_const_char(args[1]);
+            encoding = as_const_char(args[1], "encoding");
             errors = NULL;
         }
         else {
@@ -14726,11 +14728,11 @@ unicode_vectorcall(PyObject *type, PyObject *const *args,
             return fallback_to_tp_call(type, nargs, nkwargs, args, kwnames);
         }
         PyObject *object = args[0];
-        const char *encoding = as_const_char(args[1]);
+        const char *encoding = as_const_char(args[1], "encoding");
         if (encoding == NULL) {
             return NULL;
         }
-        const char *errors = as_const_char(args[2]);
+        const char *errors = as_const_char(args[2], "errors");
         if (errors == NULL) {
             return NULL;
         }

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -14686,15 +14686,15 @@ unicode_vectorcall(PyObject *type, PyObject *const *args,
         const char *encoding;
         const char *errors;
         if (nkwargs == 1) {
-            PyObject *kw0 = PyTuple_GET_ITEM(kwnames, 0);
-            if (_PyUnicode_EqualToASCIIString(kw0, "encoding")) {
+            PyObject *key = PyTuple_GET_ITEM(kwnames, 0);
+            if (_PyUnicode_EqualToASCIIString(key, "encoding")) {
                 encoding = as_const_char(args[1], "encoding");
                 if (encoding == NULL) {
                     return NULL;
                 }
                 errors = NULL;
             }
-            else if (_PyUnicode_EqualToASCIIString(kw0, "errors")) {
+            else if (_PyUnicode_EqualToASCIIString(key, "errors")) {
                 errors = as_const_char(args[1], "errors");
                 if (errors == NULL) {
                     return NULL;
@@ -14703,7 +14703,7 @@ unicode_vectorcall(PyObject *type, PyObject *const *args,
             }
             else {
                 PyErr_Format(PyExc_TypeError,
-                    "'%S' is an invalid keyword argument for str()", kw0);
+                    "'%S' is an invalid keyword argument for str()", key);
                 return NULL;
             }
         }
@@ -14718,10 +14718,10 @@ unicode_vectorcall(PyObject *type, PyObject *const *args,
     }
     if (nargs + nkwargs == 3) {
         if (nkwargs == 1) {
-            PyObject *kw0 = PyTuple_GET_ITEM(kwnames, 0);
-            if (!_PyUnicode_EqualToASCIIString(kw0, "errors")) {
+            PyObject *key = PyTuple_GET_ITEM(kwnames, 0);
+            if (!_PyUnicode_EqualToASCIIString(key, "errors")) {
                 PyErr_Format(PyExc_TypeError,
-                    "'%S' is an invalid keyword argument for str()", kw0);
+                    "'%S' is an invalid keyword argument for str()", key);
                 return NULL;
             }
         }

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -14674,7 +14674,7 @@ unicode_vectorcall(PyObject *type, PyObject *const *args,
     Py_ssize_t nargs = PyVectorcall_NARGS(nargsf);
     Py_ssize_t nkwargs = (kwnames) ? PyTuple_GET_SIZE(kwnames) : 0;
     if (nargs == 0 && nkwargs == 0) {
-        return unicode_get_empty();
+        return unicode_new_impl(_PyType_CAST(type), NULL, NULL, NULL);
     }
     PyObject *object = args[0];
     if (nargs == 1 && nkwargs == 0) {
@@ -14712,7 +14712,6 @@ unicode_vectorcall(PyObject *type, PyObject *const *args,
         else {
             return fallback_to_tp_call(type, nargs, nkwargs, args, kwnames);
         }
-        PyObject *object = args[0];
         return unicode_new_impl(_PyType_CAST(type), object, encoding, errors);
     }
     if (nargs + nkwargs == 3) {
@@ -14727,7 +14726,6 @@ unicode_vectorcall(PyObject *type, PyObject *const *args,
         else if (nkwargs != 0) {
             return fallback_to_tp_call(type, nargs, nkwargs, args, kwnames);
         }
-        PyObject *object = args[0];
         const char *encoding = as_const_char(args[1], "encoding");
         if (encoding == NULL) {
             return NULL;

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -14703,7 +14703,7 @@ unicode_vectorcall(PyObject *type, PyObject *const *args,
             }
             else {
                 PyErr_Format(PyExc_TypeError,
-                    "'%S' is an invalid keyword argument for str()", key);
+                    "str() got an unexpected keyword argument %R", key);
                 return NULL;
             }
         }
@@ -14721,7 +14721,7 @@ unicode_vectorcall(PyObject *type, PyObject *const *args,
             PyObject *key = PyTuple_GET_ITEM(kwnames, 0);
             if (!_PyUnicode_EqualToASCIIString(key, "errors")) {
                 PyErr_Format(PyExc_TypeError,
-                    "'%S' is an invalid keyword argument for str()", key);
+                    "str() got an unexpected keyword argument %R", key);
                 return NULL;
             }
         }


### PR DESCRIPTION
IMO, this is bordering too much complexity, even though the speedup is considerable for some of the cases. We consider adding a simplified variant first.

<!-- gh-issue-number: gh-117709 -->
* Issue: gh-117709
<!-- /gh-issue-number -->
