### PR TITLE
GH-117586: Speed up `pathlib.Path.walk()` by working with strings

### DIFF
--- a/Lib/glob.py
+++ b/Lib/glob.py
@@ -498,3 +498,40 @@ class _Globber:
                 yield path
             except OSError:
                 pass
+
+    @classmethod
+    def walk(cls, root, top_down, on_error, follow_symlinks):
+        """Walk the directory tree from the given root, similar to os.walk().
+        """
+        paths = [root]
+        while paths:
+            path = paths.pop()
+            if isinstance(path, tuple):
+                yield path
+                continue
+            try:
+                with cls.scandir(path) as scandir_it:
+                    dirnames = []
+                    filenames = []
+                    if not top_down:
+                        paths.append((path, dirnames, filenames))
+                    for entry in scandir_it:
+                        name = entry.name
+                        try:
+                            if entry.is_dir(follow_symlinks=follow_symlinks):
+                                if not top_down:
+                                    paths.append(cls.parse_entry(entry))
+                                dirnames.append(name)
+                            else:
+                                filenames.append(name)
+                        except OSError:
+                            filenames.append(name)
+            except OSError as error:
+                if on_error is not None:
+                    on_error(error)
+            else:
+                if top_down:
+                    yield path, dirnames, filenames
+                    if dirnames:
+                        prefix = cls.add_slash(path)
+                        paths += [cls.concat_path(prefix, d) for d in reversed(dirnames)]

--- a/Misc/NEWS.d/next/Library/2024-04-10-21-08-32.gh-issue-117586.UCL__1.rst
+++ b/Misc/NEWS.d/next/Library/2024-04-10-21-08-32.gh-issue-117586.UCL__1.rst
@@ -1,0 +1,1 @@
+Speed up :meth:`pathlib.Path.walk` by working with strings internally.


### PR DESCRIPTION
Move `pathlib.Path.walk()` implementation into `glob._Globber`. The new `glob._Globber.walk()` classmethod works with strings internally, which is a little faster than generating `Path` objects and keeping them normalized. The `pathlib.Path.walk()` method converts the strings back to path objects.

In the private pathlib ABCs, our existing subclass of `_Globber` ensures that `PathBase` instances are used throughout.

Follow-up to #117589.

Timings:

```bash
$ ./python -m timeit -s "from pathlib import Path; p = Path.cwd()" "list(p.walk())"
10 loops, best of 5: 29.8 msec per loop  # before
10 loops, best of 5: 28.9 msec per loop  # after
# --> 1.03x faster
```

Speedup is nothing to write home about, but this PR has the benefit of keeping closely-related recursive-directory-walking code together, and removing some redundant private pathlib methods.

<!-- gh-issue-number: gh-117586 -->
* Issue: gh-117586
<!-- /gh-issue-number -->
