### PR TITLE
gh-117705: Add `follow_symlinks` to `os.path.exists()`

### DIFF
--- a/Doc/library/os.path.rst
+++ b/Doc/library/os.path.rst
@@ -131,7 +131,7 @@ the :mod:`glob` module.)
 
    Return ``True`` if *path* refers to an existing path or an open
    file descriptor.  Returns ``False`` for broken symbolic links if
-   follow_symlinks is set, otherwise ``True``.  On
+   *follow_symlinks* is set, otherwise ``True``.  On
    some platforms, this function may return ``False`` if permission is
    not granted to execute :func:`os.stat` on the requested file, even
    if the *path* physically exists.

--- a/Doc/library/os.path.rst
+++ b/Doc/library/os.path.rst
@@ -127,10 +127,11 @@ the :mod:`glob` module.)
       Accepts a :term:`path-like object`.
 
 
-.. function:: exists(path)
+.. function:: exists(path, *, follow_symlinks=True)
 
    Return ``True`` if *path* refers to an existing path or an open
-   file descriptor.  Returns ``False`` for broken symbolic links.  On
+   file descriptor.  Returns ``False`` for broken symbolic links if
+   follow_symlinks is set, otherwise ``True``.  On
    some platforms, this function may return ``False`` if permission is
    not granted to execute :func:`os.stat` on the requested file, even
    if the *path* physically exists.
@@ -142,6 +143,8 @@ the :mod:`glob` module.)
    .. versionchanged:: 3.6
       Accepts a :term:`path-like object`.
 
+   .. versionchanged:: 3.13
+      Added the *follow_symlinks* parameter.
 
 .. function:: lexists(path)
 

--- a/Lib/genericpath.py
+++ b/Lib/genericpath.py
@@ -14,7 +14,8 @@ __all__ = ['commonprefix', 'exists', 'getatime', 'getctime', 'getmtime',
 # Does a path exist?
 # This is false for dangling symbolic links on systems that support them.
 def exists(path):
-    """Test whether a path exists.  Returns False for broken symbolic links"""
+    """Test whether a path exists.  Returns False for broken symbolic links
+    if follow_symlinks is set, otherwise True"""
     try:
         os.stat(path)
     except (OSError, ValueError):

--- a/Lib/genericpath.py
+++ b/Lib/genericpath.py
@@ -13,11 +13,11 @@ __all__ = ['commonprefix', 'exists', 'getatime', 'getctime', 'getmtime',
 
 # Does a path exist?
 # This is false for dangling symbolic links on systems that support them.
-def exists(path):
+def exists(path, *, follow_symlinks=True):
     """Test whether a path exists.  Returns False for broken symbolic links
     if follow_symlinks is set, otherwise True"""
     try:
-        os.stat(path)
+        os.stat(path, follow_symlinks=follow_symlinks)
     except (OSError, ValueError):
         return False
     return True

--- a/Lib/ntpath.py
+++ b/Lib/ntpath.py
@@ -898,12 +898,8 @@ try:
     from nt import _path_isdir as isdir
     from nt import _path_isfile as isfile
     from nt import _path_islink as islink
-    from nt import _path_exists
-
-    def exists(path, *, follow_symlinks=True):
-        """Test whether a path exists.  Returns False for broken symbolic links
-        if follow_symlinks is set, otherwise True"""
-        return _path_exists(path) if follow_symlinks else lexists(path)
+    from nt import _path_exists as exists
+    from nt import _path_lexists as lexists
 except ImportError:
     # Use genericpath.* as imported above
     pass

--- a/Lib/ntpath.py
+++ b/Lib/ntpath.py
@@ -898,7 +898,12 @@ try:
     from nt import _path_isdir as isdir
     from nt import _path_isfile as isfile
     from nt import _path_islink as islink
-    from nt import _path_exists as exists
+    from nt import _path_exists
+
+    def exists(path, *, follow_symlinks=True):
+        """Test whether a path exists.  Returns False for broken symbolic links
+        if follow_symlinks is set, otherwise True"""
+        return _path_exists(path) if follow_symlinks else lexists(path)
 except ImportError:
     # Use genericpath.* as imported above
     pass

--- a/Lib/test/test_genericpath.py
+++ b/Lib/test/test_genericpath.py
@@ -128,31 +128,39 @@ class GenericTest:
         )
 
     def test_exists(self):
+        def check_exists(filename, expected):
+            bfilename = os.fsencode(filename)
+            self.assertIs(self.pathmodule.exists(filename), expected)
+            self.assertIs(self.pathmodule.exists(bfilename), expected)
+            self.assertIs(self.pathmodule.exists(filename, follow_symlinks=True),
+                          expected)
+            self.assertIs(self.pathmodule.exists(bfilename, follow_symlinks=True),
+                          expected)
+
+        def check_lexists(filename, expected):
+            bfilename = os.fsencode(filename)
+            self.assertIs(self.pathmodule.lexists(filename), expected)
+            self.assertIs(self.pathmodule.lexists(bfilename), expected)
+            self.assertIs(self.pathmodule.exists(filename, follow_symlinks=False),
+                          expected)
+            self.assertIs(self.pathmodule.exists(bfilename, follow_symlinks=False),
+                          expected)
+
         filename = os_helper.TESTFN
-        bfilename = os.fsencode(filename)
         self.addCleanup(os_helper.unlink, filename)
 
-        self.assertIs(self.pathmodule.exists(filename), False)
-        self.assertIs(self.pathmodule.exists(bfilename), False)
+        check_exists(filename, False)
+        check_lexists(filename, False)
 
         create_file(filename)
 
-        self.assertIs(self.pathmodule.exists(filename), True)
-        self.assertIs(self.pathmodule.exists(bfilename), True)
+        check_exists(filename, True)
+        check_exists(filename + '\udfff', False)
+        check_exists(filename + '\x00', False)
 
-        self.assertIs(self.pathmodule.exists(filename + '\udfff'), False)
-        self.assertIs(self.pathmodule.exists(bfilename + b'\xff'), False)
-        self.assertIs(self.pathmodule.exists(filename + '\x00'), False)
-        self.assertIs(self.pathmodule.exists(bfilename + b'\x00'), False)
-
-        if self.pathmodule is not genericpath:
-            self.assertIs(self.pathmodule.lexists(filename), True)
-            self.assertIs(self.pathmodule.lexists(bfilename), True)
-
-            self.assertIs(self.pathmodule.lexists(filename + '\udfff'), False)
-            self.assertIs(self.pathmodule.lexists(bfilename + b'\xff'), False)
-            self.assertIs(self.pathmodule.lexists(filename + '\x00'), False)
-            self.assertIs(self.pathmodule.lexists(bfilename + b'\x00'), False)
+        check_lexists(filename, True)
+        check_lexists(filename + '\udfff', False)
+        check_lexists(filename + '\x00', False)
 
     @unittest.skipUnless(hasattr(os, "pipe"), "requires os.pipe()")
     @unittest.skipIf(is_emscripten, "Emscripten pipe fds have no stat")

--- a/Lib/test/test_genericpath.py
+++ b/Lib/test/test_genericpath.py
@@ -147,6 +147,7 @@ class GenericTest:
                           expected)
 
         filename = os_helper.TESTFN
+        bfilename = os.fsencode(filename)
         self.addCleanup(os_helper.unlink, filename)
 
         check_exists(filename, False)
@@ -155,11 +156,13 @@ class GenericTest:
         create_file(filename)
 
         check_exists(filename, True)
-        check_exists(filename + '\udfff', False)
+        self.assertIs(self.pathmodule.exists(filename + '\udfff'), False)
+        self.assertIs(self.pathmodule.exists(bfilename + b'\xff'), False)
         check_exists(filename + '\x00', False)
 
         check_lexists(filename, True)
-        check_lexists(filename + '\udfff', False)
+        self.assertIs(self.pathmodule.lexists(filename + '\udfff'), False)
+        self.assertIs(self.pathmodule.lexists(bfilename + b'\xff'), False)
         check_lexists(filename + '\x00', False)
 
     @unittest.skipUnless(hasattr(os, "pipe"), "requires os.pipe()")

--- a/Lib/test/test_ntpath.py
+++ b/Lib/test/test_ntpath.py
@@ -1,3 +1,4 @@
+import genericpath
 import inspect
 import ntpath
 import os
@@ -1113,8 +1114,7 @@ class TestNtpath(NtpathTestCase):
         self.assertFalse(inspect.isfunction(os.path.isfile))
         self.assertTrue(os.path.islink is nt._path_islink)
         self.assertFalse(inspect.isfunction(os.path.islink))
-        self.assertTrue(os.path.exists is nt._path_exists)
-        self.assertFalse(inspect.isfunction(os.path.exists))
+        self.assertFalse(os.path.exists is genericpath.exists)
 
     @unittest.skipIf(os.name != 'nt', "Dev Drives only exist on Win32")
     def test_isdevdrive(self):

--- a/Lib/test/test_ntpath.py
+++ b/Lib/test/test_ntpath.py
@@ -1,4 +1,3 @@
-import genericpath
 import inspect
 import ntpath
 import os
@@ -1114,7 +1113,10 @@ class TestNtpath(NtpathTestCase):
         self.assertFalse(inspect.isfunction(os.path.isfile))
         self.assertTrue(os.path.islink is nt._path_islink)
         self.assertFalse(inspect.isfunction(os.path.islink))
-        self.assertFalse(os.path.exists is genericpath.exists)
+        self.assertTrue(os.path.exists is nt._path_exists)
+        self.assertFalse(inspect.isfunction(os.path.exists))
+        self.assertTrue(os.path.lexists is nt._path_lexists)
+        self.assertFalse(inspect.isfunction(os.path.lexists))
 
     @unittest.skipIf(os.name != 'nt', "Dev Drives only exist on Win32")
     def test_isdevdrive(self):

--- a/Misc/NEWS.d/next/Core and Builtins/2024-04-10-20-41-15.gh-issue-117705.2pDs7H.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2024-04-10-20-41-15.gh-issue-117705.2pDs7H.rst
@@ -1,0 +1,1 @@
+Added the *follow_symlinks* parameter to :func:`os.path.exists`.

--- a/Modules/clinic/posixmodule.c.h
+++ b/Modules/clinic/posixmodule.c.h
@@ -2133,19 +2133,99 @@ exit:
 #if defined(MS_WINDOWS)
 
 PyDoc_STRVAR(os__path_exists__doc__,
-"_path_exists($module, /, path)\n"
+"_path_exists($module, /, path, follow_symlinks=True)\n"
 "--\n"
 "\n"
-"Test whether a path exists.  Returns False for broken symbolic links");
+"Test whether a path exists.  Returns False for broken symbolic links\n"
+"\n"
+"  path\n"
+"    Path to be tested; can be a string, bytes object, a path-like object,\n"
+"    or an integer that references an open file descriptor.\n"
+"  follow_symlinks\n"
+"    If False, and the last element of the path is a symbolic link, do not\n"
+"    test the target of the symbolic link.");
 
 #define OS__PATH_EXISTS_METHODDEF    \
     {"_path_exists", _PyCFunction_CAST(os__path_exists), METH_FASTCALL|METH_KEYWORDS, os__path_exists__doc__},
 
 static PyObject *
-os__path_exists_impl(PyObject *module, PyObject *path);
+os__path_exists_impl(PyObject *module, PyObject *path, int follow_symlinks);
 
 static PyObject *
 os__path_exists(PyObject *module, PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames)
+{
+    PyObject *return_value = NULL;
+    #if defined(Py_BUILD_CORE) && !defined(Py_BUILD_CORE_MODULE)
+
+    #define NUM_KEYWORDS 2
+    static struct {
+        PyGC_Head _this_is_not_used;
+        PyObject_VAR_HEAD
+        PyObject *ob_item[NUM_KEYWORDS];
+    } _kwtuple = {
+        .ob_base = PyVarObject_HEAD_INIT(&PyTuple_Type, NUM_KEYWORDS)
+        .ob_item = { &_Py_ID(path), &_Py_ID(follow_symlinks), },
+    };
+    #undef NUM_KEYWORDS
+    #define KWTUPLE (&_kwtuple.ob_base.ob_base)
+
+    #else  // !Py_BUILD_CORE
+    #  define KWTUPLE NULL
+    #endif  // !Py_BUILD_CORE
+
+    static const char * const _keywords[] = {"path", "follow_symlinks", NULL};
+    static _PyArg_Parser _parser = {
+        .keywords = _keywords,
+        .fname = "_path_exists",
+        .kwtuple = KWTUPLE,
+    };
+    #undef KWTUPLE
+    PyObject *argsbuf[2];
+    Py_ssize_t noptargs = nargs + (kwnames ? PyTuple_GET_SIZE(kwnames) : 0) - 1;
+    PyObject *path;
+    int follow_symlinks = 1;
+
+    args = _PyArg_UnpackKeywords(args, nargs, NULL, kwnames, &_parser, 1, 2, 0, argsbuf);
+    if (!args) {
+        goto exit;
+    }
+    path = args[0];
+    if (!noptargs) {
+        goto skip_optional_pos;
+    }
+    follow_symlinks = PyObject_IsTrue(args[1]);
+    if (follow_symlinks < 0) {
+        goto exit;
+    }
+skip_optional_pos:
+    return_value = os__path_exists_impl(module, path, follow_symlinks);
+
+exit:
+    return return_value;
+}
+
+#endif /* defined(MS_WINDOWS) */
+
+#if defined(MS_WINDOWS)
+
+PyDoc_STRVAR(os__path_lexists__doc__,
+"_path_lexists($module, /, path)\n"
+"--\n"
+"\n"
+"Test whether a path exists.  Returns True for broken symbolic links\n"
+"\n"
+"  path\n"
+"    Path to be tested; can be a string, bytes object, a path-like object,\n"
+"    or an integer that references an open file descriptor.");
+
+#define OS__PATH_LEXISTS_METHODDEF    \
+    {"_path_lexists", _PyCFunction_CAST(os__path_lexists), METH_FASTCALL|METH_KEYWORDS, os__path_lexists__doc__},
+
+static PyObject *
+os__path_lexists_impl(PyObject *module, PyObject *path);
+
+static PyObject *
+os__path_lexists(PyObject *module, PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     #if defined(Py_BUILD_CORE) && !defined(Py_BUILD_CORE_MODULE)
@@ -2169,7 +2249,7 @@ os__path_exists(PyObject *module, PyObject *const *args, Py_ssize_t nargs, PyObj
     static const char * const _keywords[] = {"path", NULL};
     static _PyArg_Parser _parser = {
         .keywords = _keywords,
-        .fname = "_path_exists",
+        .fname = "_path_lexists",
         .kwtuple = KWTUPLE,
     };
     #undef KWTUPLE
@@ -2181,7 +2261,7 @@ os__path_exists(PyObject *module, PyObject *const *args, Py_ssize_t nargs, PyObj
         goto exit;
     }
     path = args[0];
-    return_value = os__path_exists_impl(module, path);
+    return_value = os__path_lexists_impl(module, path);
 
 exit:
     return return_value;
@@ -12051,6 +12131,10 @@ os__supports_virtual_terminal(PyObject *module, PyObject *Py_UNUSED(ignored))
     #define OS__PATH_EXISTS_METHODDEF
 #endif /* !defined(OS__PATH_EXISTS_METHODDEF) */
 
+#ifndef OS__PATH_LEXISTS_METHODDEF
+    #define OS__PATH_LEXISTS_METHODDEF
+#endif /* !defined(OS__PATH_LEXISTS_METHODDEF) */
+
 #ifndef OS__PATH_ISLINK_METHODDEF
     #define OS__PATH_ISLINK_METHODDEF
 #endif /* !defined(OS__PATH_ISLINK_METHODDEF) */
@@ -12602,4 +12686,4 @@ os__supports_virtual_terminal(PyObject *module, PyObject *Py_UNUSED(ignored))
 #ifndef OS__SUPPORTS_VIRTUAL_TERMINAL_METHODDEF
     #define OS__SUPPORTS_VIRTUAL_TERMINAL_METHODDEF
 #endif /* !defined(OS__SUPPORTS_VIRTUAL_TERMINAL_METHODDEF) */
-/*[clinic end generated code: output=511f0788a6b90db0 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=3cfe2a1ba37c496d input=a9049054013a1b77]*/


### PR DESCRIPTION
Benchmark:

```bat
::test.bat
@echo off
echo existent && python -m timeit -s "import ntpath" "ntpath.lexists('test.bat')" && PCbuild\amd64\python.exe -m timeit -s "import ntpath" "ntpath.lexists('test.bat')"
echo non-existent && python -m timeit -s "import ntpath" "ntpath.lexists('foo.bar')" && PCbuild\amd64\python.exe -m timeit -s "import ntpath" "ntpath.lexists('foo.bar')"
```

```none
existent 
5000 loops, best of 5: 47.9 usec per loop # before
5000 loops, best of 5: 46.8 usec per loop # after
# -> 1.02x faster
non-existent
10000 loops, best of 5: 21.8 usec per loop # before
20000 loops, best of 5: 16 usec per loop # after
# -> 1.36x faster
```

<!-- gh-issue-number: gh-117705-->
* Issue: gh-117705
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--117729.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->