### PR TITLE
GH-115060: Speed up `pathlib.Path.glob()` by not scanning literal parts

### DIFF
--- a/Lib/glob.py
+++ b/Lib/glob.py
@@ -331,9 +331,10 @@ class _Globber:
     """Class providing shell-style pattern matching and globbing.
     """
 
-    def __init__(self,  sep, case_sensitive, recursive=False):
+    def __init__(self, sep, case_sensitive, case_pedantic=False, recursive=False):
         self.sep = sep
         self.case_sensitive = case_sensitive
+        self.case_pedantic = case_pedantic
         self.recursive = recursive
 
     # Low-level methods
@@ -373,6 +374,8 @@ class _Globber:
             selector = self.recursive_selector
         elif part in _special_parts:
             selector = self.special_selector
+        elif not self.case_pedantic and magic_check.search(part) is None:
+            selector = self.literal_selector
         else:
             selector = self.wildcard_selector
         return selector(part, parts)
@@ -386,6 +389,23 @@ class _Globber:
             path = self.concat_path(self.add_slash(path), part)
             return select_next(path, exists)
         return select_special
+
+    def literal_selector(self, part, parts):
+        """Returns a function that selects a literal descendant of a path.
+        """
+
+        # Optimization: consume and join any subsequent literal parts here,
+        # rather than leaving them for the next selector. This reduces the
+        # number of string concatenation operations and calls to add_slash().
+        while parts and magic_check.search(parts[-1]) is None:
+            part += self.sep + parts.pop()
+
+        select_next = self.selector(parts)
+
+        def select_literal(path, exists=False):
+            path = self.concat_path(self.add_slash(path), part)
+            return select_next(path, exists=False)
+        return select_literal
 
     def wildcard_selector(self, part, parts):
         """Returns a function that selects direct children of a given path,

--- a/Lib/pathlib/_abc.py
+++ b/Lib/pathlib/_abc.py
@@ -696,6 +696,9 @@ class PathBase(PurePathBase):
             case_sensitive = _is_case_sensitive(self.parser)
             case_pedantic = False
         else:
+            # The user has expressed a case sensitivity choice, but we don't
+            # know the case sensitivity of the underlying filesystem, so we
+            # must use scandir() for everything, including non-wildcard parts.
             case_pedantic = True
         recursive = True if recurse_symlinks else glob._no_recurse_symlinks
         globber = self._globber(self.parser.sep, case_sensitive, case_pedantic, recursive)

--- a/Lib/pathlib/_abc.py
+++ b/Lib/pathlib/_abc.py
@@ -694,8 +694,11 @@ class PathBase(PurePathBase):
     def _glob_selector(self, parts, case_sensitive, recurse_symlinks):
         if case_sensitive is None:
             case_sensitive = _is_case_sensitive(self.parser)
+            case_pedantic = False
+        else:
+            case_pedantic = True
         recursive = True if recurse_symlinks else glob._no_recurse_symlinks
-        globber = self._globber(self.parser.sep, case_sensitive, recursive)
+        globber = self._globber(self.parser.sep, case_sensitive, case_pedantic, recursive)
         return globber.selector(parts)
 
     def glob(self, pattern, *, case_sensitive=None, recurse_symlinks=True):

--- a/Lib/test/test_pathlib/test_pathlib_abc.py
+++ b/Lib/test/test_pathlib/test_pathlib_abc.py
@@ -1856,7 +1856,7 @@ class DummyPathTest(DummyPurePathTest):
     def test_rglob_posix(self):
         P = self.cls
         p = P(self.base, "dirC")
-        q = p / "dirC" / "FILEd"
+        q = p / "dirC" / "dirD" / "FILEd"
         given = set(p.rglob("FILEd"))
         expect = {q} if q.exists() else set()
         self.assertEqual(given, expect)
@@ -1934,7 +1934,7 @@ class DummyPathTest(DummyPurePathTest):
             self.assertEqual(set(p.glob("xyzzy/..")), set())
         else:
             # ".." segments are normalized first on Windows, so this path is stat()able.
-            self.assertEqual(set(p.glob("xyzzy/..")), { P(self.base, "zyzzy", "..") })
+            self.assertEqual(set(p.glob("xyzzy/..")), { P(self.base, "xyzzy", "..") })
         self.assertEqual(set(p.glob("/".join([".."] * 50))), { P(self.base, *[".."] * 50)})
 
     @needs_symlinks

--- a/Lib/test/test_pathlib/test_pathlib_abc.py
+++ b/Lib/test/test_pathlib/test_pathlib_abc.py
@@ -1429,10 +1429,10 @@ class DummyPath(PathBase):
         return "{}({!r})".format(self.__class__.__name__, self.as_posix())
 
     def stat(self, *, follow_symlinks=True):
-        if follow_symlinks:
-            path = str(self.resolve())
+        if follow_symlinks or self.name in ('', '.', '..'):
+            path = str(self.resolve(strict=True))
         else:
-            path = str(self.parent.resolve() / self.name)
+            path = str(self.parent.resolve(strict=True) / self.name)
         if path in self._files:
             st_mode = stat.S_IFREG
         elif path in self._directories:

--- a/Lib/test/test_pathlib/test_pathlib_abc.py
+++ b/Lib/test/test_pathlib/test_pathlib_abc.py
@@ -1856,7 +1856,7 @@ class DummyPathTest(DummyPurePathTest):
     def test_rglob_posix(self):
         P = self.cls
         p = P(self.base, "dirC")
-        q = p / "dirC" / "dirD" / "FILEd"
+        q = p / "dirD" / "FILEd"
         given = set(p.rglob("FILEd"))
         expect = {q} if q.exists() else set()
         self.assertEqual(given, expect)

--- a/Misc/NEWS.d/next/Library/2024-04-10-22-35-24.gh-issue-115060.XEVuOb.rst
+++ b/Misc/NEWS.d/next/Library/2024-04-10-22-35-24.gh-issue-115060.XEVuOb.rst
@@ -1,0 +1,2 @@
+Speed up :meth:`pathlib.Path.glob` by not scanning directories for
+non-wildcard pattern segments.


### PR DESCRIPTION
Don't bother calling `os.scandir()` to scan for literal pattern segments, like `foo` in `foo/*.py`. Instead, append the segment(s) as-is and call through to the next selector with `exists=False`, which signals that the path might not exist. Subsequent selectors will call `os.scandir()` or `os.lstat()` to filter out missing paths as needed.

Timings:

```bash
$ ./python -m timeit -s "from pathlib import Path; p = Path.cwd()" "list(p.glob('Lib'))"
5000 loops, best of 5: 69.4 usec per loop
20000 loops, best of 5: 13.6 usec per loop
# --> 5.1x faster

$ ./python -m timeit -s "from pathlib import Path; p = Path.cwd()" "list(p.glob('Lib/'))"
5000 loops, best of 5: 73.3 usec per loop
20000 loops, best of 5: 14.2 usec per loop
# --> 5.16x faster

$ ./python -m timeit -s "from pathlib import Path; p = Path.cwd()" "list(p.glob('Lib/*'))"
1000 loops, best of 5: 362 usec per loop
1000 loops, best of 5: 301 usec per loop
# --> 1.2x faster

$ ./python -m timeit -s "from pathlib import Path; p = Path.cwd()" "list(p.glob('Lib/*/__init__.py'))"
200 loops, best of 5: 1.18 msec per loop
1000 loops, best of 5: 273 usec per loop
# --> 4.32x faster

$ ./python -m timeit -s "from pathlib import Path; p = Path.cwd()" "list(p.glob('Lib/**/__init__.py'))"
50 loops, best of 5: 9.46 msec per loop
50 loops, best of 5: 5.72 msec per loop
# --> 1.65x faster

$ ./python -m timeit -s "from pathlib import Path; p = Path.cwd()" "list(p.glob('Lib/pathlib/__init__.py'))"
1000 loops, best of 5: 210 usec per loop
20000 loops, best of 5: 14.9 usec per loop
# --> 14.1x faster
```

<!-- gh-issue-number: gh-115060 -->
* Issue: gh-115060
<!-- /gh-issue-number -->
