### PR TITLE
gh-117739: Update definition for global interpreter lock for 3.13 

### DIFF
--- a/Doc/glossary.rst
+++ b/Doc/glossary.rst
@@ -547,8 +547,8 @@ Glossary
       tasks such as compression or hashing.  Also, the GIL is always released
       when doing I/O.
 
-      As of Python 3.13, the GIL can be disabled using the ``--disable-gil``
-      build configuration or ``PYTHON_GIL=0`` environment variable. This feature
+      As of Python 3.13, the GIL can be disabled using the :option:`--disable-gil`
+      build configuration or :envvar:`PYTHON_GIL=0 <PYTHON_GIL>` environment variable. This feature
       enables improved performance for multi-threaded applications or on
       multi-core systems. For more details, see :pep:`703`.
 

--- a/Doc/glossary.rst
+++ b/Doc/glossary.rst
@@ -547,12 +547,10 @@ Glossary
       tasks such as compression or hashing.  Also, the GIL is always released
       when doing I/O.
 
-      Past efforts to create a "free-threaded" interpreter (one which locks
-      shared data at a much finer granularity) have not been successful
-      because performance suffered in the common single-processor case. It
-      is believed that overcoming this performance issue would make the
-      implementation much more complicated and therefore costlier to maintain.
-
+      As of Python 3.13, the GIL can be disabled using the `--disable-gil` build
+      configuration or `PYTHON_GIL=0` environment variable. This feature enables
+      improved performance for multi-threaded applications or on multi-core
+      systems. For more details, see :pep:`703`.
 
    hash-based pyc
       A bytecode cache file that uses the hash rather than the last-modified

--- a/Doc/glossary.rst
+++ b/Doc/glossary.rst
@@ -547,10 +547,10 @@ Glossary
       tasks such as compression or hashing.  Also, the GIL is always released
       when doing I/O.
 
-      As of Python 3.13, the GIL can be disabled using the `--disable-gil` build
-      configuration or `PYTHON_GIL=0` environment variable. This feature enables
-      improved performance for multi-threaded applications or on multi-core
-      systems. For more details, see :pep:`703`.
+      As of Python 3.13, the GIL can be disabled using the ``--disable-gil``
+      build configuration or ``PYTHON_GIL=0`` environment variable. This feature
+      enables improved performance for multi-threaded applications or on
+      multi-core systems. For more details, see :pep:`703`.
 
    hash-based pyc
       A bytecode cache file that uses the hash rather than the last-modified

--- a/Doc/glossary.rst
+++ b/Doc/glossary.rst
@@ -549,7 +549,7 @@ Glossary
 
       As of Python 3.13, the GIL can be disabled using the :option:`--disable-gil`
       build configuration. After building Python with this option, code must be
-      run with :option:`-X gil 0` or after setting the :envvar:`PYTHON_GIL=0 <PYTHON_GIL>`
+      run with :option:`-X gil 0 <-X>` or after setting the :envvar:`PYTHON_GIL=0 <PYTHON_GIL>`
       environment variable. This feature enables improved performance for
       multi-threaded applications and makes it easier to use multi-core CPUs
       efficiently. For more details, see :pep:`703`.

--- a/Doc/glossary.rst
+++ b/Doc/glossary.rst
@@ -549,7 +549,7 @@ Glossary
 
       As of Python 3.13, the GIL can be disabled using the :option:`--disable-gil`
       build configuration. After building Python with this option, code must be
-      run with :option:`-X gil 0` or after setting the :envvar:`PYTHON_GIL=0`
+      run with :option:`-X gil 0` or after setting the :envvar:`PYTHON_GIL=0 <PYTHON_GIL>`
       environment variable. This feature enables improved performance for
       multi-threaded applications and makes it easier to use multi-core CPUs
       efficiently. For more details, see :pep:`703`.

--- a/Doc/glossary.rst
+++ b/Doc/glossary.rst
@@ -548,9 +548,11 @@ Glossary
       when doing I/O.
 
       As of Python 3.13, the GIL can be disabled using the :option:`--disable-gil`
-      build configuration or :envvar:`PYTHON_GIL=0 <PYTHON_GIL>` environment variable. This feature
-      enables improved performance for multi-threaded applications or on
-      multi-core systems. For more details, see :pep:`703`.
+      build configuration. After building Python with this option, code must be
+      run with :option:`-X gil 0` or after setting the :envvar:`PYTHON_GIL=0`
+      environment variable. This feature enables improved performance for
+      multi-threaded applications and makes it easier to use multi-core CPUs
+      efficiently. For more details, see :pep:`703`.
 
    hash-based pyc
       A bytecode cache file that uses the hash rather than the last-modified


### PR DESCRIPTION


<!-- gh-issue-number: gh-117739 -->
* Issue: gh-117739
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--117740.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->