### PR TITLE
gh-117536: Fix asyncio _asyncgen_finalizer_hook()

### DIFF
--- a/Lib/test/test_asyncgen.py
+++ b/Lib/test/test_asyncgen.py
@@ -1570,13 +1570,8 @@ class AsyncGenAsyncioTest(unittest.TestCase):
 
         message, = messages
         self.assertIsInstance(message['exception'], ZeroDivisionError)
-        self.assertIn('unhandled exception during asyncio.run() shutdown',
+        self.assertIn('an error occurred during closing of asynchronous generator ',
                       message['message'])
-        with self.assertWarnsRegex(RuntimeWarning,
-                f"coroutine method 'aclose' of '{async_iterate.__qualname__}' "
-                f"was never awaited"):
-            del message, messages
-            gc_collect()
 
     def test_async_gen_expression_01(self):
         async def arange(n):
@@ -1630,10 +1625,6 @@ class AsyncGenAsyncioTest(unittest.TestCase):
         asyncio.run(main())
 
         self.assertEqual([], messages)
-        with self.assertWarnsRegex(RuntimeWarning,
-                f"coroutine method 'aclose' of '{async_iterate.__qualname__}' "
-                f"was never awaited"):
-            gc_collect()
 
     def test_async_gen_await_same_anext_coro_twice(self):
         async def async_iterate():

--- a/Lib/test/test_asyncio/test_base_events.py
+++ b/Lib/test/test_asyncio/test_base_events.py
@@ -1058,11 +1058,27 @@ class BaseEventLoopTests(test_utils.TestCase):
             finally:
                 ns['state'] = 'finalized'
 
-        async def reproducer():
+        async def reproducer(agen):
             async for item in agen():
                 break
 
-        asyncio.run(reproducer())
+        asyncio.run(reproducer(agen))
+        self.assertEqual(ns['state'], 'finalized')
+
+        # Similar than previous test, but the generator uses 'await' in the
+        # finally block.
+        ns['state'] = 'not started'
+        async def agen_await():
+            try:
+                ns['state'] = 'started'
+                yield 0
+                yield 1
+            finally:
+                ns['state'] = 'await'
+                await asyncio.sleep(0)
+                ns['state'] = 'finalized'
+
+        asyncio.run(reproducer(agen_await))
         self.assertEqual(ns['state'], 'finalized')
 
 

--- a/Lib/test/test_asyncio/test_base_events.py
+++ b/Lib/test/test_asyncio/test_base_events.py
@@ -1050,7 +1050,7 @@ class BaseEventLoopTests(test_utils.TestCase):
         # calling shutdown_asyncgens().
 
         ns = {'state': 'not started'}
-        async def agen():
+        async def agen_basic():
             try:
                 ns['state'] = 'started'
                 yield 0
@@ -1062,7 +1062,7 @@ class BaseEventLoopTests(test_utils.TestCase):
             async for item in agen():
                 break
 
-        asyncio.run(reproducer(agen))
+        asyncio.run(reproducer(agen_basic))
         self.assertEqual(ns['state'], 'finalized')
 
         # Similar than previous test, but the generator uses 'await' in the

--- a/Misc/NEWS.d/next/Library/2024-04-11-14-11-02.gh-issue-117536.0jp7ep.rst
+++ b/Misc/NEWS.d/next/Library/2024-04-11-14-11-02.gh-issue-117536.0jp7ep.rst
@@ -1,0 +1,2 @@
+:mod:`asyncio`: Make the finalization of asynchronous generators more
+reliable. Patch by Victor Stinner.


### PR DESCRIPTION
Make the finalization of asynchronous generators more reliable.

Store a strong reference to the asynchronous generator which is being closed to make sure that shutdown_asyncgens() can close it even if asyncio.run() cancels all tasks.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-117536 -->
* Issue: gh-117536
<!-- /gh-issue-number -->
