### PR TITLE
Tweak wording for dataclasses.replace

### DIFF
--- a/Doc/library/dataclasses.rst
+++ b/Doc/library/dataclasses.rst
@@ -430,8 +430,8 @@ Module contents
 
    Creates a new object of the same type as ``obj``, replacing
    fields with values from ``changes``.  If ``obj`` is not a Data
-   Class, raises :exc:`TypeError`.  If keys in ``changes`` are not correct
-   field names for the given dataclass, raises :exc:`TypeError`.
+   Class, raises :exc:`TypeError`.  If keys in ``changes`` are not
+   field names of the given dataclass, raises :exc:`TypeError`.
 
    The newly returned object is created by calling the :meth:`~object.__init__`
    method of the dataclass.  This ensures that

--- a/Doc/library/dataclasses.rst
+++ b/Doc/library/dataclasses.rst
@@ -430,8 +430,8 @@ Module contents
 
    Creates a new object of the same type as ``obj``, replacing
    fields with values from ``changes``.  If ``obj`` is not a Data
-   Class, raises :exc:`TypeError`.  If values in ``changes`` do not
-   specify fields, raises :exc:`TypeError`.
+   Class, raises :exc:`TypeError`.  If keys in ``changes`` are not correct
+   field names for the given dataclass, raises :exc:`TypeError`.
 
    The newly returned object is created by calling the :meth:`~object.__init__`
    method of the dataclass.  This ensures that


### PR DESCRIPTION
The initial phrasing mentioned values, when it's actually the keys that are in question.
It also could mean that passing no kwarg at all was invalid, since in that case `**changes` does not technically specify a field. So, this clarifies that `dataclasses.replace(obj)` is a valid way to shallow-clone a dataclass object, even though I didn't write it explicitly.

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--117758.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->