### PR TITLE
gh-94673: Clarify About Runtime State Related to Static Builtin Types

### DIFF
--- a/Include/internal/pycore_typeobject.h
+++ b/Include/internal/pycore_typeobject.h
@@ -22,6 +22,9 @@ struct _types_runtime_state {
     // bpo-42745: next_version_tag remains shared by all interpreters
     // because of static types.
     unsigned int next_version_tag;
+
+    /* See the note in struct types_state below. */
+    size_t next_builtin_index;
 };
 
 
@@ -96,8 +99,9 @@ struct types_state {
        Instead it is calculated the first time a type is initialized
        (by the main interpreter).  The index matches the order in which
        the type was initialized relative to the others.  The actual
-       value comes from the current value of num_builtins_initialized,
-       as each type is initialized for the main interpreter.
+       value comes from the current value of
+       _PyRuntimeState.types.next_builtin_index as each type
+       is initialized for the main interpreter.
 
        num_builtins_initialized is incremented once for each static
        builtin type.  Once initialization is over for a subinterpreter,

--- a/Include/internal/pycore_typeobject.h
+++ b/Include/internal/pycore_typeobject.h
@@ -89,8 +89,11 @@ struct types_state {
        Those objects are stored in the PyInterpreterState.types.builtins
        array, at the index corresponding to each specific static builtin
        type.  That index (a size_t value) is stored in the tp_subclasses
-       field (defined as void*).  We re-purposed the now-unused
+       field.  For static builtin types, we re-purposed the now-unused
        tp_subclasses to avoid adding another field to PyTypeObject.
+       In all other cases tp_subclasses holds a dict like before.
+       (The field was previously defined as PyObject*, but is now void*
+       to reflect its dual use.)
 
        The index for each static builtin type isn't statically assigned.
        Instead it is calculated the first time a type is initialized

--- a/Include/internal/pycore_typeobject.h
+++ b/Include/internal/pycore_typeobject.h
@@ -22,9 +22,6 @@ struct _types_runtime_state {
     // bpo-42745: next_version_tag remains shared by all interpreters
     // because of static types.
     unsigned int next_version_tag;
-
-    /* See the note in struct types_state below. */
-    size_t next_builtin_index;
 };
 
 
@@ -99,9 +96,8 @@ struct types_state {
        Instead it is calculated the first time a type is initialized
        (by the main interpreter).  The index matches the order in which
        the type was initialized relative to the others.  The actual
-       value comes from the current value of
-       _PyRuntimeState.types.next_builtin_index as each type
-       is initialized for the main interpreter.
+       value comes from the current value of num_builtins_initialized,
+       as each type is initialized for the main interpreter.
 
        num_builtins_initialized is incremented once for each static
        builtin type.  Once initialization is over for a subinterpreter,

--- a/Include/internal/pycore_typeobject.h
+++ b/Include/internal/pycore_typeobject.h
@@ -89,7 +89,7 @@ struct types_state {
        Those objects are stored in the PyInterpreterState.types.builtins
        array, at the index corresponding to each specific static builtin
        type.  That index (a size_t value) is stored in the tp_subclasses
-       field (defined as PyObject*).  We re-purposed the now-unused
+       field (defined as void*).  We re-purposed the now-unused
        tp_subclasses to avoid adding another field to PyTypeObject.
 
        The index for each static builtin type isn't statically assigned.

--- a/Include/internal/pycore_typeobject.h
+++ b/Include/internal/pycore_typeobject.h
@@ -68,6 +68,40 @@ struct types_state {
     unsigned int next_version_tag;
 
     struct type_cache type_cache;
+
+    /* Every static builtin type is initialized for each interpreter
+       during its own initialization, including for the main interpreter
+       during global runtime initialization.  This is done by calling
+       _PyStaticType_InitBuiltin().
+
+       The first time a static builtin type is initialized, all the
+       normal PyType_Ready() stuff happens.  The only difference from
+       normal is that there are three PyTypeObject fields holding
+       objects which are stored here (on PyInterpreterState) rather
+       than in the corresponding PyTypeObject fields.  Those are:
+       tp_dict (cls.__dict__), tp_subclasses (cls.__subclasses__),
+       and tp_weaklist.
+
+       When a subinterpreter is initialized, each static builtin type
+       is still initialized, but only the interpreter-specific portion,
+       namely those three objects.
+
+       Those objects are stored in the PyInterpreterState.types.builtins
+       array, at the index corresponding to each specific static builtin
+       type.  That index (a size_t value) is stored in the tp_subclasses
+       field (defined as PyObject*).  We re-purposed the now-unused
+       tp_subclasses to avoid adding another field to PyTypeObject.
+
+       The index for each static builtin type isn't statically assigned.
+       Instead it is calculated the first time a type is initialized
+       (by the main interpreter).  The index matches the order in which
+       the type was initialized relative to the others.  The actual
+       value comes from the current value of num_builtins_initialized,
+       as each type is initialized for the main interpreter.
+
+       num_builtins_initialized is incremented once for each static
+       builtin type.  Once initialization is over for a subinterpreter,
+       the value will be the same as for all other interpreters.  */
     size_t num_builtins_initialized;
     static_builtin_state builtins[_Py_MAX_STATIC_BUILTIN_TYPES];
     PyMutex mutex;

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -164,7 +164,11 @@ static_builtin_state_init(PyInterpreterState *interp, PyTypeObject *self)
 {
     if (!static_builtin_index_is_set(self)) {
         assert(_Py_IsMainInterpreter(interp));
-        static_builtin_index_set(self, interp->types.num_builtins_initialized);
+        assert(interp->types.num_builtins_initialized == \
+                interp->runtime->types.next_builtin_index);
+        static_builtin_index_set(self,
+                                 interp->runtime->types.next_builtin_index);
+        interp->runtime->types.next_builtin_index++;
     }
     else {
         assert(!_Py_IsMainInterpreter(interp));

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -162,12 +162,11 @@ _PyStaticType_GetState(PyInterpreterState *interp, PyTypeObject *self)
 static void
 static_builtin_state_init(PyInterpreterState *interp, PyTypeObject *self)
 {
-    if (!static_builtin_index_is_set(self)) {
-        assert(_Py_IsMainInterpreter(interp));
+    if (_Py_IsMainInterpreter(interp)) {
+        assert(!static_builtin_index_is_set(self));
         static_builtin_index_set(self, interp->types.num_builtins_initialized);
     }
     else {
-        assert(!_Py_IsMainInterpreter(interp));
         assert(static_builtin_index_get(self) == \
                 interp->types.num_builtins_initialized);
     }

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -163,7 +163,13 @@ static void
 static_builtin_state_init(PyInterpreterState *interp, PyTypeObject *self)
 {
     if (!static_builtin_index_is_set(self)) {
+        assert(_Py_IsMainInterpreter(interp));
         static_builtin_index_set(self, interp->types.num_builtins_initialized);
+    }
+    else {
+        assert(!_Py_IsMainInterpreter(interp));
+        assert(static_builtin_index_get(self) == \
+                interp->types.num_builtins_initialized);
     }
     static_builtin_state *state = static_builtin_state_get(interp, self);
 

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -164,11 +164,7 @@ static_builtin_state_init(PyInterpreterState *interp, PyTypeObject *self)
 {
     if (!static_builtin_index_is_set(self)) {
         assert(_Py_IsMainInterpreter(interp));
-        assert(interp->types.num_builtins_initialized == \
-                interp->runtime->types.next_builtin_index);
-        static_builtin_index_set(self,
-                                 interp->runtime->types.next_builtin_index);
-        interp->runtime->types.next_builtin_index++;
+        static_builtin_index_set(self, interp->types.num_builtins_initialized);
     }
     else {
         assert(!_Py_IsMainInterpreter(interp));

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -167,7 +167,7 @@ static_builtin_state_init(PyInterpreterState *interp, PyTypeObject *self)
         static_builtin_index_set(self, interp->types.num_builtins_initialized);
     }
     else {
-        assert(static_builtin_index_get(self) == \
+        assert(static_builtin_index_get(self) ==
                 interp->types.num_builtins_initialized);
     }
     static_builtin_state *state = static_builtin_state_get(interp, self);


### PR DESCRIPTION
Guido pointed out to me that some details about the per-interpreter state for the builtin types aren't especially clear.  I'm addressing that by:

* adding a comment explaining that state
* adding `_PyRuntimeState.types.next_builtin_index`
* adding some asserts to point out the relationship between each index and the interp/global runtime state

Regarding `next_builtin_index`, it replaces our use of the main interpreter's `interp->types.num_builtins_initialized` as the next index.  Even though it's technically redundant, the distinct global runtime field helps clarify explicitly that each index is from global state.

<!-- gh-issue-number: gh-94673 -->
* Issue: gh-94673
<!-- /gh-issue-number -->
