### PR TITLE
gh-111506: Error if the limited API is used in free-threaded build

### DIFF
--- a/Include/Python.h
+++ b/Include/Python.h
@@ -45,6 +45,8 @@
 #  endif
 #endif
 
+// gh-111506: The free-threaded build is not compatible with the limited API
+// or the stable ABI.
 #if defined(Py_LIMITED_API) && defined(Py_GIL_DISABLED)
 #  error "The limited API is not currently supported in the free-threaded build"
 #endif

--- a/Include/Python.h
+++ b/Include/Python.h
@@ -45,6 +45,9 @@
 #  endif
 #endif
 
+#if defined(Py_LIMITED_API) && defined(Py_GIL_DISABLED)
+#  error "The limited API is not currently supported in the free-threaded build"
+#endif
 
 // Include Python header files
 #include "pyport.h"


### PR DESCRIPTION
Issue a build time error if both `Py_LIMITED_API` and `Py_GIL_DISABLED` are defined.

Without this, extensions may compile (with warnings), but crash on import.

<!-- gh-issue-number: gh-111506 -->
* Issue: gh-111506
<!-- /gh-issue-number -->
