### PR TITLE
gh-86357: argparse: use str() consistently and explicitly to print choices

### DIFF
--- a/Lib/argparse.py
+++ b/Lib/argparse.py
@@ -547,8 +547,7 @@ class HelpFormatter(object):
         if action.metavar is not None:
             result = action.metavar
         elif action.choices is not None:
-            choice_strs = [str(choice) for choice in action.choices]
-            result = '{%s}' % ','.join(choice_strs)
+            result = '{%s}' % ','.join(map(str, action.choices))
         else:
             result = default_metavar
 
@@ -599,8 +598,7 @@ class HelpFormatter(object):
             elif hasattr(value, '__name__'):
                 params[name] = value.__name__
         if params.get('choices') is not None:
-            choices_str = ', '.join([str(c) for c in params['choices']])
-            params['choices'] = choices_str
+            params['choices'] = ', '.join(map(str, params['choices']))
         return help_string % params
 
     def _iter_indented_subactions(self, action):
@@ -717,7 +715,7 @@ def _get_action_name(argument):
     elif argument.dest not in (None, SUPPRESS):
         return argument.dest
     elif argument.choices:
-        return '{' + ','.join(argument.choices) + '}'
+        return '{%s}' % ','.join(map(str, argument.choices))
     else:
         return None
 
@@ -2607,8 +2605,8 @@ class ArgumentParser(_AttributeHolder, _ActionsContainer):
             if isinstance(choices, str):
                 choices = iter(choices)
             if value not in choices:
-                args = {'value': value,
-                        'choices': ', '.join(map(repr, action.choices))}
+                args = {'value': str(value),
+                        'choices': ', '.join(map(str, action.choices))}
                 msg = _('invalid choice: %(value)r (choose from %(choices)s)')
                 raise ArgumentError(action, msg % args)
 

--- a/Misc/NEWS.d/next/Library/2024-04-19-05-58-50.gh-issue-117766.J3xepp.rst
+++ b/Misc/NEWS.d/next/Library/2024-04-19-05-58-50.gh-issue-117766.J3xepp.rst
@@ -1,0 +1,1 @@
+Always use :func:`str` to print ``choices`` in :mod:`argparse`.


### PR DESCRIPTION
This commit replaces `repr()` with `str()`, as the former should never be used for normal user-facing printing, and makes it explicit and consistent across the library.

For example I tried using `StrEnum` for choices and it printed `choose from <Enum.FOO: 'foo'>, ...` instead of `choose from foo, ...`.


<!-- gh-issue-number: gh-118839 -->
* Issue: gh-118839
<!-- /gh-issue-number -->

- https://github.com/python/cpython/issues/61181
- https://github.com/python/cpython/issues/86667
- https://github.com/python/cpython/issues/60672

<!-- gh-issue-number: gh-86357 -->
* Issue: gh-86357
<!-- /gh-issue-number -->
