### PR TITLE
gh-114466: explicitly define heap invariant

### DIFF
--- a/Doc/library/heapq.rst
+++ b/Doc/library/heapq.rst
@@ -17,7 +17,9 @@ This module provides an implementation of the heap queue algorithm, also known
 as the priority queue algorithm.
 
 Heaps are binary trees for which every parent node has a value less than or
-equal to any of its children.  This implementation uses arrays for which
+equal to any of its children.  We refer to this condition as the heap invariant.
+
+This implementation uses arrays for which
 ``heap[k] <= heap[2*k+1]`` and ``heap[k] <= heap[2*k+2]`` for all *k*, counting
 elements from zero.  For the sake of comparison, non-existing elements are
 considered to be infinite.  The interesting property of a heap is that its
@@ -319,4 +321,3 @@ applications, and I think it is good to keep a 'heap' module around. :-)
    backwards, and this was also used to avoid the rewinding time. Believe me, real
    good tape sorts were quite spectacular to watch! From all times, sorting has
    always been a Great Art! :-)
-


### PR DESCRIPTION
I think the choice of wording in these docs is great and doesn't need to change. However, it could be useful to explicitly define this term / the cost of doing so seems relatively low.

<!-- gh-issue-number: gh-114466 -->
* Issue: gh-114466
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--117778.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->