### PR TITLE
gh-117649: Fix file descriptor leak in (expected) failing test case

### DIFF
--- a/Lib/test/test_capi/test_misc.py
+++ b/Lib/test/test_capi/test_misc.py
@@ -2139,6 +2139,9 @@ class SubinterpreterTest(unittest.TestCase):
             }
 
             r, w = os.pipe()
+            if Py_GIL_DISABLED:
+                # gh-117649: The test fails before `w` is closed
+                self.addCleanup(os.close, w)
             script = textwrap.dedent(f'''
                 from test.test_capi.check_config import run_singlephase_check
                 run_singlephase_check({override}, {w})


### PR DESCRIPTION
The test case is currently expected to fail in the free-threaded build. However, it fails before it gets a chance to close the write end of the pipe.


<!-- gh-issue-number: gh-117649 -->
* Issue: gh-117649
<!-- /gh-issue-number -->
