### PR TITLE
gh-117787: Autoconf: fix bashisms/semantic breakage of iOS checks

### DIFF
--- a/configure
+++ b/configure
@@ -24334,7 +24334,7 @@ if test "$PY_ENABLE_SHARED" = "1" && ( test -n "$ANDROID_API_LEVEL" || test "$MA
 fi
 
 # On iOS the shared libraries must be linked with the Python framework
-if test "$ac_sys_system" == "iOS"; then
+if test "$ac_sys_system" = "iOS"; then
   MODULE_DEPS_SHARED="$MODULE_DEPS_SHARED \$(PYTHONFRAMEWORKDIR)/\$(PYTHONFRAMEWORK)"
 fi
 

--- a/configure.ac
+++ b/configure.ac
@@ -6053,7 +6053,7 @@ if test "$PY_ENABLE_SHARED" = "1" && ( test -n "$ANDROID_API_LEVEL" || test "$MA
 fi
 
 # On iOS the shared libraries must be linked with the Python framework
-if test "$ac_sys_system" == "iOS"; then
+if test "$ac_sys_system" = "iOS"; then
   MODULE_DEPS_SHARED="$MODULE_DEPS_SHARED \$(PYTHONFRAMEWORKDIR)/\$(PYTHONFRAMEWORK)"
 fi
 


### PR DESCRIPTION
In commit bee7bb3310b356e99e3a0f75f23efbc97f1b0a24, support was added for iOS. Although many string comparisons were added to configure.ac, one of them used some code only valid in GNU bash.

Bash provides the standard `test XXX = YYY` or `[ XXX = YYY ]` utilities. It also provides the ability to spell the equals sign as a double equals. This does nothing whatsoever -- it adds no new functionality to bash, it forbids nothing, it is literally an exact alias.

It should never be used under any circumstances. Honestly, bash itself should really drop support for it. Certainly, all developers must immediately forget that it exists. Using it is non-portable and does not work in /bin/sh scripts such as configure scripts, and it results in dangerous muscle memory when used in bash scripts because it makes people unthinkingly use the double equals even in /bin/sh scripts. To add insult to injury, it makes scripts take up more disk space (by a whole byte! and sometimes even a few bytes... ;) ;))

Anyway, in terms of practical difference, this results in:

POSIX sh systems such as:
- macOS if /private/var/select/sh is tweaked
- Linux if /bin/sh is dash and the unofficial cctools-port toolchain is used

always reporting that ac_sys_system is NOT iOS, and never adding the python framework to MODULE_DEPS_SHARED, even when the rest of the CPython build is configured for iOS.

```
It also reports a bad status message in the output of ./configure, which I caught via Gentoo's QA framework:

 * QA Notice: Abnormal configure code *
 * ./configure: 24692: test: Linux: unexpected operator
```

<!-- gh-issue-number: gh-117787 -->
* Issue: gh-117787
<!-- /gh-issue-number -->
