### PR TITLE
gh-117752: Autoconf: fix -fno-semantic-interposition check

### DIFF
--- a/configure
+++ b/configure
@@ -8241,13 +8241,13 @@ if test "$Py_OPT" = 'true' ; then
     *gcc*)
       { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether C compiler accepts -fno-semantic-interposition" >&5
 printf %s "checking whether C compiler accepts -fno-semantic-interposition... " >&6; }
-if test ${ax_cv_check_cflags___fno_semantic_interposition+y}
+if test ${ax_cv_check_cflags__Werror__fno_semantic_interposition+y}
 then :
   printf %s "(cached) " >&6
 else $as_nop
 
   ax_check_save_flags=$CFLAGS
-  CFLAGS="$CFLAGS  -fno-semantic-interposition"
+  CFLAGS="$CFLAGS -Werror -fno-semantic-interposition"
   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
@@ -8261,16 +8261,16 @@ main (void)
 _ACEOF
 if ac_fn_c_try_compile "$LINENO"
 then :
-  ax_cv_check_cflags___fno_semantic_interposition=yes
+  ax_cv_check_cflags__Werror__fno_semantic_interposition=yes
 else $as_nop
-  ax_cv_check_cflags___fno_semantic_interposition=no
+  ax_cv_check_cflags__Werror__fno_semantic_interposition=no
 fi
 rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
   CFLAGS=$ax_check_save_flags
 fi
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ax_cv_check_cflags___fno_semantic_interposition" >&5
-printf "%s\n" "$ax_cv_check_cflags___fno_semantic_interposition" >&6; }
-if test "x$ax_cv_check_cflags___fno_semantic_interposition" = xyes
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ax_cv_check_cflags__Werror__fno_semantic_interposition" >&5
+printf "%s\n" "$ax_cv_check_cflags__Werror__fno_semantic_interposition" >&6; }
+if test "x$ax_cv_check_cflags__Werror__fno_semantic_interposition" = xyes
 then :
 
       CFLAGS_NODIST="$CFLAGS_NODIST -fno-semantic-interposition"

--- a/configure.ac
+++ b/configure.ac
@@ -1799,7 +1799,7 @@ if test "$Py_OPT" = 'true' ; then
       AX_CHECK_COMPILE_FLAG([-fno-semantic-interposition],[
       CFLAGS_NODIST="$CFLAGS_NODIST -fno-semantic-interposition"
       LDFLAGS_NODIST="$LDFLAGS_NODIST -fno-semantic-interposition"
-      ])
+      ], [], [-Werror])
       ;;
   esac
 elif test "$ac_sys_system" = "Emscripten" -o "$ac_sys_system" = "WASI"; then


### PR DESCRIPTION
Force the compiler to issue an error if the flag is not supported.


<!-- gh-issue-number: gh-117752 -->
* Issue: gh-117752
<!-- /gh-issue-number -->
