### PR TITLE
gh-117804: Autoconf: silence some clang warnings for PGO builds

### DIFF
--- a/configure
+++ b/configure
@@ -8826,7 +8826,7 @@ case "$CC_BASENAME" in
   *clang*)
     # Any changes made here should be reflected in the GCC+Darwin case below
     PGO_PROF_GEN_FLAG="-fprofile-instr-generate"
-    PGO_PROF_USE_FLAG=" -fprofile-instr-use=code.profclangd -Wno-profile-instr-unprofiled -Wno-profile-instr-out-of-date "
+    PGO_PROF_USE_FLAG=" -fprofile-instr-use=code.profclangd -Wno-profile-instr-unprofiled "
     LLVM_PROF_MERGER="${LLVM_PROFDATA} merge -output=code.profclangd *.profclangr"
     LLVM_PROF_FILE="LLVM_PROFILE_FILE=\"\$(shell pwd)/code-%p.profclangr\""
     if test $LLVM_PROF_FOUND = not-found
@@ -8842,7 +8842,7 @@ case "$CC_BASENAME" in
     case $ac_sys_system in
       Darwin*)
         PGO_PROF_GEN_FLAG="-fprofile-instr-generate"
-        PGO_PROF_USE_FLAG=" -fprofile-instr-use=code.profclangd -Wno-profile-instr-unprofiled -Wno-profile-instr-out-of-date "
+        PGO_PROF_USE_FLAG=" -fprofile-instr-use=code.profclangd -Wno-profile-instr-unprofiled "
         LLVM_PROF_MERGER="${LLVM_PROFDATA} merge -output=code.profclangd *.profclangr"
         LLVM_PROF_FILE="LLVM_PROFILE_FILE=\"\$(shell pwd)/code-%p.profclangr\""
         if test "${LLVM_PROF_FOUND}" = "not-found"

--- a/configure
+++ b/configure
@@ -8826,7 +8826,7 @@ case "$CC_BASENAME" in
   *clang*)
     # Any changes made here should be reflected in the GCC+Darwin case below
     PGO_PROF_GEN_FLAG="-fprofile-instr-generate"
-    PGO_PROF_USE_FLAG="-fprofile-instr-use=code.profclangd"
+    PGO_PROF_USE_FLAG=" -fprofile-instr-use=code.profclangd -Wno-profile-instr-unprofiled -Wno-profile-instr-out-of-date "
     LLVM_PROF_MERGER="${LLVM_PROFDATA} merge -output=code.profclangd *.profclangr"
     LLVM_PROF_FILE="LLVM_PROFILE_FILE=\"code-%p.profclangr\""
     if test $LLVM_PROF_FOUND = not-found
@@ -8842,7 +8842,7 @@ case "$CC_BASENAME" in
     case $ac_sys_system in
       Darwin*)
         PGO_PROF_GEN_FLAG="-fprofile-instr-generate"
-        PGO_PROF_USE_FLAG="-fprofile-instr-use=code.profclangd"
+        PGO_PROF_USE_FLAG=" -fprofile-instr-use=code.profclangd -Wno-profile-instr-unprofiled -Wno-profile-instr-out-of-date "
         LLVM_PROF_MERGER="${LLVM_PROFDATA} merge -output=code.profclangd *.profclangr"
         LLVM_PROF_FILE="LLVM_PROFILE_FILE=\"code-%p.profclangr\""
         if test "${LLVM_PROF_FOUND}" = "not-found"

--- a/configure.ac
+++ b/configure.ac
@@ -2014,7 +2014,6 @@ case "$CC_BASENAME" in
     PGO_PROF_USE_FLAG=m4_normalize("
         -fprofile-instr-use=code.profclangd
         -Wno-profile-instr-unprofiled
-        -Wno-profile-instr-out-of-date
     ")
     LLVM_PROF_MERGER="${LLVM_PROFDATA} merge -output=code.profclangd *.profclangr"
     LLVM_PROF_FILE="LLVM_PROFILE_FILE=\"\$(shell pwd)/code-%p.profclangr\""
@@ -2034,7 +2033,6 @@ case "$CC_BASENAME" in
         PGO_PROF_USE_FLAG=m4_normalize("
             -fprofile-instr-use=code.profclangd
             -Wno-profile-instr-unprofiled
-            -Wno-profile-instr-out-of-date
         ")
         LLVM_PROF_MERGER="${LLVM_PROFDATA} merge -output=code.profclangd *.profclangr"
         LLVM_PROF_FILE="LLVM_PROFILE_FILE=\"\$(shell pwd)/code-%p.profclangr\""

--- a/configure.ac
+++ b/configure.ac
@@ -2011,7 +2011,11 @@ case "$CC_BASENAME" in
   *clang*)
     # Any changes made here should be reflected in the GCC+Darwin case below
     PGO_PROF_GEN_FLAG="-fprofile-instr-generate"
-    PGO_PROF_USE_FLAG="-fprofile-instr-use=code.profclangd"
+    PGO_PROF_USE_FLAG=m4_normalize("
+        -fprofile-instr-use=code.profclangd
+        -Wno-profile-instr-unprofiled
+        -Wno-profile-instr-out-of-date
+    ")
     LLVM_PROF_MERGER="${LLVM_PROFDATA} merge -output=code.profclangd *.profclangr"
     LLVM_PROF_FILE="LLVM_PROFILE_FILE=\"code-%p.profclangr\""
     if test $LLVM_PROF_FOUND = not-found
@@ -2027,7 +2031,11 @@ case "$CC_BASENAME" in
     case $ac_sys_system in
       Darwin*)
         PGO_PROF_GEN_FLAG="-fprofile-instr-generate"
-        PGO_PROF_USE_FLAG="-fprofile-instr-use=code.profclangd"
+        PGO_PROF_USE_FLAG=m4_normalize("
+            -fprofile-instr-use=code.profclangd
+            -Wno-profile-instr-unprofiled
+            -Wno-profile-instr-out-of-date
+        ")
         LLVM_PROF_MERGER="${LLVM_PROFDATA} merge -output=code.profclangd *.profclangr"
         LLVM_PROF_FILE="LLVM_PROFILE_FILE=\"code-%p.profclangr\""
         if test "${LLVM_PROF_FOUND}" = "not-found"


### PR DESCRIPTION
* `-Wno-profile-instr-unprofiled` for source files without profile data
~~* `-Wno-profile-instr-out-of-date` for _bootstrap_python.c~~ <= solve this in a follow-up PR


<!-- gh-issue-number: gh-117752 -->
* Original issue: gh-117752
<!-- /gh-issue-number -->


<!-- gh-issue-number: gh-117804 -->
* Retargeted to issue: gh-117804
<!-- /gh-issue-number -->
