### PR TITLE
gh-117755: Skip test_io.test_constructor() on s390x

### DIFF
--- a/Lib/test/test_io.py
+++ b/Lib/test/test_io.py
@@ -40,7 +40,8 @@ from test import support
 from test.support.script_helper import (
     assert_python_ok, assert_python_failure, run_python_until_end)
 from test.support import (
-    import_helper, is_apple, os_helper, skip_if_sanitizer, threading_helper, warnings_helper
+    import_helper, is_apple, os_helper, skip_if_sanitizer, threading_helper, warnings_helper,
+    skip_on_s390x
 )
 from test.support.os_helper import FakePath
 
@@ -1700,6 +1701,9 @@ class CBufferedReaderTest(BufferedReaderTest, SizeofTest):
     @skip_if_sanitizer(memory=True, address=True, thread=True,
                        reason="sanitizer defaults to crashing "
                        "instead of returning NULL for malloc failure.")
+    # gh-117755: The test allocates 9 223 372 036 854 775 807 bytes
+    # (0x7fffffffffffffff) and mimalloc fails with a division by zero on s390x.
+    @skip_on_s390x
     def test_constructor(self):
         BufferedReaderTest.test_constructor(self)
         # The allocation can succeed on 32-bit builds, e.g. with more
@@ -2068,6 +2072,9 @@ class CBufferedWriterTest(BufferedWriterTest, SizeofTest):
     @skip_if_sanitizer(memory=True, address=True, thread=True,
                        reason="sanitizer defaults to crashing "
                        "instead of returning NULL for malloc failure.")
+    # gh-117755: The test allocates 9 223 372 036 854 775 807 bytes
+    # (0x7fffffffffffffff) and mimalloc fails with a division by zero on s390x.
+    @skip_on_s390x
     def test_constructor(self):
         BufferedWriterTest.test_constructor(self)
         # The allocation can succeed on 32-bit builds, e.g. with more
@@ -2590,6 +2597,9 @@ class CBufferedRandomTest(BufferedRandomTest, SizeofTest):
     @skip_if_sanitizer(memory=True, address=True, thread=True,
                        reason="sanitizer defaults to crashing "
                        "instead of returning NULL for malloc failure.")
+    # gh-117755: The test allocates 9 223 372 036 854 775 807 bytes
+    # (0x7fffffffffffffff) and mimalloc fails with a division by zero on s390x.
+    @skip_on_s390x
     def test_constructor(self):
         BufferedRandomTest.test_constructor(self)
         # The allocation can succeed on 32-bit builds, e.g. with more


### PR DESCRIPTION
The test allocates 9 223 372 036 854 775 807 bytes (0x7fffffffffffffff) and mimalloc fails with a division by zero on s390x.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-117755 -->
* Issue: gh-117755
<!-- /gh-issue-number -->
