### PR TITLE
Better example of shallow dict export of a dataclass

### DIFF
--- a/Doc/library/dataclasses.rst
+++ b/Doc/library/dataclasses.rst
@@ -362,7 +362,7 @@ Module contents
 
    To create a shallow copy, the following workaround may be used::
 
-     dict((field.name, getattr(obj, field.name)) for field in fields(obj))
+     {field.name: getattr(obj, field.name) for field in fields(obj)}
 
    :func:`!asdict` raises :exc:`TypeError` if ``obj`` is not a dataclass
    instance.


### PR DESCRIPTION
Avoids a function call, avoid unnecessary inner parentheses.

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--117812.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->