### PR TITLE
gh-117376: Make code objects use deferred reference counting

### DIFF
--- a/Lib/test/test_capi/test_watchers.py
+++ b/Lib/test/test_capi/test_watchers.py
@@ -1,7 +1,7 @@
 import unittest
 
 from contextlib import contextmanager, ExitStack
-from test.support import catch_unraisable_exception, import_helper
+from test.support import catch_unraisable_exception, import_helper, gc_collect
 
 
 # Skip this test if the _testcapi module isn't available.
@@ -372,6 +372,7 @@ class TestCodeObjectWatchers(unittest.TestCase):
 
     def assert_event_counts(self, exp_created_0, exp_destroyed_0,
                             exp_created_1, exp_destroyed_1):
+        gc_collect()  # code objects are collected by GC in free-threaded build
         self.assertEqual(
             exp_created_0, _testcapi.get_code_watcher_num_created_events(0))
         self.assertEqual(
@@ -432,6 +433,7 @@ class TestCodeObjectWatchers(unittest.TestCase):
         with self.code_watcher(2):
             with catch_unraisable_exception() as cm:
                 del co
+                gc_collect()
 
                 self.assertEqual(str(cm.unraisable.exc_value), "boom!")
 

--- a/Lib/test/test_gc.py
+++ b/Lib/test/test_gc.py
@@ -226,7 +226,9 @@ class GCTests(unittest.TestCase):
         exec("def f(): pass\n", d)
         gc.collect()
         del d
-        self.assertEqual(gc.collect(), 2)
+        # In the free-threaded build, the count returned by `gc.collect()`
+        # is 3 because it includes f's code object.
+        self.assertIn(gc.collect(), (2, 3))
 
     def test_function_tp_clear_leaves_consistent_state(self):
         # https://github.com/python/cpython/issues/91636


### PR DESCRIPTION
We want code objects to use deferred reference counting in the free-threaded build. This requires them to be tracked by the GC, so we enable `Py_TPFLAGS_HAVE_GC` in the free-threaded build, but not the default build.


<!-- gh-issue-number: gh-117376 -->
* Issue: gh-117376
<!-- /gh-issue-number -->
