### PR TITLE
gh-96398: Detect GCC compatible compilers in configure

### DIFF
--- a/configure
+++ b/configure
@@ -6317,6 +6317,34 @@ fi
 
 
 
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for GCC compatible compiler" >&5
+printf %s "checking for GCC compatible compiler... " >&6; }
+if test ${ac_cv_gcc_compat+y}
+then :
+  printf %s "(cached) " >&6
+else $as_nop
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+                #if !defined(__GNUC__)
+                  #error "not GCC compatible"
+                #else
+                  /* GCC compatible! */
+                #endif
+
+_ACEOF
+if ac_fn_c_try_cpp "$LINENO"
+then :
+  ac_cv_gcc_compat=yes
+else $as_nop
+  ac_cv_gcc_compat=no
+fi
+rm -f conftest.err conftest.i conftest.$ac_ext
+fi
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_gcc_compat" >&5
+printf "%s\n" "$ac_cv_gcc_compat" >&6; }
+
+
 
 preset_cxx="$CXX"
 if test -z "$CXX"
@@ -11578,7 +11606,6 @@ else $as_nop
 printf "%s\n" "#define size_t unsigned int" >>confdefs.h
 
 fi
-
 
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for uid_t in sys/types.h" >&5
 printf %s "checking for uid_t in sys/types.h... " >&6; }

--- a/configure.ac
+++ b/configure.ac
@@ -1025,6 +1025,18 @@ rm -f conftest.c conftest.out
 # _POSIX_SOURCE, _POSIX_1_SOURCE, and more
 AC_USE_SYSTEM_EXTENSIONS
 
+AC_CACHE_CHECK([for GCC compatible compiler],
+               [ac_cv_gcc_compat],
+               [AC_PREPROC_IFELSE([AC_LANG_SOURCE([
+                #if !defined(__GNUC__)
+                  #error "not GCC compatible"
+                #else
+                  /* GCC compatible! */
+                #endif
+               ], [])],
+               [ac_cv_gcc_compat=yes],
+               [ac_cv_gcc_compat=no])])
+
 AC_SUBST([CXX])
 
 preset_cxx="$CXX"


### PR DESCRIPTION
Introduce a cached variable $ac_cv_gcc_compat and set it to 'yes' if
the C preprocessor defines the __GNUC__ macro.


<!-- gh-issue-number: gh-96398 -->
* Issue: gh-96398
<!-- /gh-issue-number -->
