### PR TITLE
gh-117657: Quiet TSAN warning about a data race between `start_the_world()` and `tstate_try_attach()`

### DIFF
--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -2190,7 +2190,7 @@ start_the_world(struct _stoptheworld_state *stw)
     PyThreadState *t;
     _Py_FOR_EACH_THREAD(stw, i, t) {
         if (t != stw->requester) {
-            assert(t->state == _Py_THREAD_SUSPENDED);
+            assert(_Py_atomic_load_int(&t->state) == _Py_THREAD_SUSPENDED);
             _Py_atomic_store_int(&t->state, _Py_THREAD_DETACHED);
             _PyParkingLot_UnparkAll(&t->state);
         }

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -2190,7 +2190,8 @@ start_the_world(struct _stoptheworld_state *stw)
     PyThreadState *t;
     _Py_FOR_EACH_THREAD(stw, i, t) {
         if (t != stw->requester) {
-            assert(_Py_atomic_load_int(&t->state) == _Py_THREAD_SUSPENDED);
+            assert(_Py_atomic_load_int_relaxed(&t->state) ==
+                   _Py_THREAD_SUSPENDED);
             _Py_atomic_store_int(&t->state, _Py_THREAD_DETACHED);
             _PyParkingLot_UnparkAll(&t->state);
         }


### PR DESCRIPTION
TSAN erroneously reports a data race ([example](https://gist.github.com/mpage/b1665a09ff8e242a0441fb7d878e6658)) between the `_Py_atomic_compare_exchange_int` on `tstate->state` in `tstate_try_attach()`:

https://github.com/python/cpython/blob/069de14cb948f56b37e507f367b99c5563d3685e/Python/pystate.c#L1993-L1995

and the non-atomic load of `tstate->state` in `start_the_world()`:

https://github.com/python/cpython/blob/069de14cb948f56b37e507f367b99c5563d3685e/Python/pystate.c#L2251

The `_Py_atomic_compare_exchange_int` fails, but TSAN erroneously treats it as a store.


<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-117657 -->
* Issue: gh-117657
<!-- /gh-issue-number -->
