### PR TITLE
gh-117657: Quiet more TSAN warnings due to incorrect modeling of compare/exchange

### DIFF
--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -2003,7 +2003,7 @@ tstate_try_attach(PyThreadState *tstate)
 static void
 tstate_set_detached(PyThreadState *tstate, int detached_state)
 {
-    assert(tstate->state == _Py_THREAD_ATTACHED);
+    assert(_Py_atomic_load_int_relaxed(&tstate->state) == _Py_THREAD_ATTACHED);
 #ifdef Py_GIL_DISABLED
     _Py_atomic_store_int(&tstate->state, detached_state);
 #else
@@ -2068,7 +2068,7 @@ static void
 detach_thread(PyThreadState *tstate, int detached_state)
 {
     // XXX assert(tstate_is_alive(tstate) && tstate_is_bound(tstate));
-    assert(tstate->state == _Py_THREAD_ATTACHED);
+    assert(_Py_atomic_load_int_relaxed(&tstate->state) == _Py_THREAD_ATTACHED);
     assert(tstate == current_fast_get());
     if (tstate->critical_section != 0) {
         _PyCriticalSection_SuspendAll(tstate);


### PR DESCRIPTION
TSAN reports ([example](https://gist.github.com/mpage/e68802b781b312e84348940cea0618f5)) data races between the non-atomic loads of `tstate->state` in `detach_thread()` and `tstate_set_detached()`:

https://github.com/python/cpython/blob/eca53620e3ff1f2e7d621360a513ac34a1b35aa3/Python/pystate.c#L2067-L2080

https://github.com/python/cpython/blob/eca53620e3ff1f2e7d621360a513ac34a1b35aa3/Python/pystate.c#L2003-L2008

and the atomic compare/exchange of `tstate->state` in `park_detached_threads()`:

https://github.com/python/cpython/blob/eca53620e3ff1f2e7d621360a513ac34a1b35aa3/Python/pystate.c#L2159-L2170

I believe this is due to a bug with how TSAN models compare/exchange. Note that this appears to be a different issue than what we're seeing in https://github.com/python/cpython/pull/117828; the compare/exhange is succeeding in this case.

According to the standard,

> If one evaluation modifies a memory location, and the other reads or modifies the same memory location, and if at least one of the evaluations is not an atomic operation, the behavior of the program is undefined (the program has a data race) unless there exists a happens-before relationship between these two evaluations.

However, according to the standard, A strongly happens-before B if any of the following are true:

> 1) A is sequenced-before B.
> 2) A synchronizes-with B.
> 3) A strongly happens-before X, and X strongly happens-before B.

Using this we can establish a happens-before relationship between each non-atomic load and the compare/exchange:

1. Each non-atomic load is sequenced-before the seq-cst store to `tstate->state` that happens in `tstate_set_detached()`. Therefore, each non-atomic load happens-before the seq-cst store.
2. The seq-cst store to `tstate->state` in `tstate_set_detached()` synchronizes-with the compare/exchange to `tstate->state` in `park_detached_threads()`. Thus the seq-cst store happens-before the compare/exchange.
3. (1) and (2) establish the happens-before relationship between each non-atomic load and the compare/exchange on `tstate->state`, therefore they should not be flagged as a data races.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-117657 -->
* Issue: gh-117657
<!-- /gh-issue-number -->
