### PR TITLE
GH-115060: Speed up `pathlib.Path.glob()` by omitting initial `stat()`

### DIFF
--- a/Doc/library/pathlib.rst
+++ b/Doc/library/pathlib.rst
@@ -1004,9 +1004,6 @@ call fails (for example because the path doesn't exist).
    .. seealso::
       :ref:`pathlib-pattern-language` documentation.
 
-   This method suppresses any :exc:`OSError` exceptions that are raised while
-   scanning the filesystem.
-
    By default, or when the *case_sensitive* keyword-only argument is set to
    ``None``, this method matches paths using platform-specific casing rules:
    typically, case-sensitive on POSIX, and case-insensitive on Windows.
@@ -1026,6 +1023,11 @@ call fails (for example because the path doesn't exist).
 
    .. versionchanged:: 3.13
       The *pattern* parameter accepts a :term:`path-like object`.
+
+   .. versionchanged:: 3.13
+      Any :exc:`OSError` exceptions raised from scanning the filesystem are
+      suppressed. In previous versions, such exceptions are suppressed in many
+      cases, but not all.
 
 
 .. method:: Path.rglob(pattern, *, case_sensitive=None, recurse_symlinks=False)

--- a/Doc/library/pathlib.rst
+++ b/Doc/library/pathlib.rst
@@ -1004,9 +1004,7 @@ call fails (for example because the path doesn't exist).
    .. seealso::
       :ref:`pathlib-pattern-language` documentation.
 
-   This method calls :meth:`Path.is_dir` on the top-level directory and
-   propagates any :exc:`OSError` exception that is raised. Subsequent
-   :exc:`OSError` exceptions from scanning directories are suppressed.
+   This method suppresses any :exc:`OSError` exceptions raised while scanning.
 
    By default, or when the *case_sensitive* keyword-only argument is set to
    ``None``, this method matches paths using platform-specific casing rules:

--- a/Doc/library/pathlib.rst
+++ b/Doc/library/pathlib.rst
@@ -1004,7 +1004,8 @@ call fails (for example because the path doesn't exist).
    .. seealso::
       :ref:`pathlib-pattern-language` documentation.
 
-   This method suppresses any :exc:`OSError` exceptions raised while scanning.
+   This method suppresses any :exc:`OSError` exceptions that are raised while
+   scanning the filesystem.
 
    By default, or when the *case_sensitive* keyword-only argument is set to
    ``None``, this method matches paths using platform-specific casing rules:

--- a/Lib/pathlib/__init__.py
+++ b/Lib/pathlib/__init__.py
@@ -607,11 +607,9 @@ class Path(_abc.PathBase, PurePath):
         if raw[-1] in (self.parser.sep, self.parser.altsep):
             # GH-65238: pathlib doesn't preserve trailing slash. Add it back.
             parts.append('')
-        if not self.is_dir():
-            return iter([])
         select = self._glob_selector(parts[::-1], case_sensitive, recurse_symlinks)
         root = str(self)
-        paths = select(root, exists=True)
+        paths = select(root)
 
         # Normalize results
         if root == '.':

--- a/Lib/pathlib/_abc.py
+++ b/Lib/pathlib/_abc.py
@@ -705,10 +705,8 @@ class PathBase(PurePathBase):
         anchor, parts = pattern._stack
         if anchor:
             raise NotImplementedError("Non-relative patterns are unsupported")
-        if not self.is_dir():
-            return iter([])
         select = self._glob_selector(parts, case_sensitive, recurse_symlinks)
-        return select(self, exists=True)
+        return select(self)
 
     def rglob(self, pattern, *, case_sensitive=None, recurse_symlinks=True):
         """Recursively yield all existing files (of any kind, including

--- a/Lib/test/test_pathlib/test_pathlib.py
+++ b/Lib/test/test_pathlib/test_pathlib.py
@@ -1263,6 +1263,13 @@ class PathTest(test_pathlib_abc.DummyPathTest, PurePathTest):
             self.assertEqual(
                 set(P('.').glob('**/*/*')), {P("dirD/fileD")})
 
+    def test_glob_inaccessible(self):
+        P = self.cls
+        p = P(self.base, "mydir1", "mydir2")
+        p.mkdir(parents=True)
+        p.parent.chmod(0)
+        self.assertEqual(set(p.glob('*')), set())
+
     def test_rglob_pathlike(self):
         P = self.cls
         p = P(self.base, "dirC")

--- a/Lib/test/test_pathlib/test_pathlib_abc.py
+++ b/Lib/test/test_pathlib/test_pathlib_abc.py
@@ -8,6 +8,7 @@ import unittest
 from pathlib._abc import UnsupportedOperation, ParserBase, PurePathBase, PathBase
 import posixpath
 
+from test.support import is_wasi
 from test.support.os_helper import TESTFN
 
 
@@ -1920,6 +1921,8 @@ class DummyPathTest(DummyPurePathTest):
                   }
         self.assertEqual(given, {p / x for x in expect})
 
+    # See https://github.com/WebAssembly/wasi-filesystem/issues/26
+    @unittest.skipIf(is_wasi, "WASI resolution of '..' parts doesn't match POSIX")
     def test_glob_dotdot(self):
         # ".." is not special in globs.
         P = self.cls

--- a/Misc/NEWS.d/next/Library/2024-04-13-01-45-15.gh-issue-115060.IxoM03.rst
+++ b/Misc/NEWS.d/next/Library/2024-04-13-01-45-15.gh-issue-115060.IxoM03.rst
@@ -1,0 +1,3 @@
+Speed up :meth:`pathlib.Path.glob` my omitting an initial
+:meth:`~pathlib.Path.is_dir` call. As a result of this change,
+:meth:`~pathlib.Path.glob` can no longer raise :exc:`OSError`.

--- a/Misc/NEWS.d/next/Library/2024-04-13-01-45-15.gh-issue-115060.IxoM03.rst
+++ b/Misc/NEWS.d/next/Library/2024-04-13-01-45-15.gh-issue-115060.IxoM03.rst
@@ -1,3 +1,3 @@
-Speed up :meth:`pathlib.Path.glob` my omitting an initial
+Speed up :meth:`pathlib.Path.glob` by omitting an initial
 :meth:`~pathlib.Path.is_dir` call. As a result of this change,
 :meth:`~pathlib.Path.glob` can no longer raise :exc:`OSError`.


### PR DESCRIPTION
Since 6258844c, paths that might not exist can be fed into pathlib's globbing implementation, which will call `os.scandir()` / `os.lstat()` only when strictly necessary. This allows us to drop an initial `self.is_dir()` call, which saves a `stat()`.

```bash
$ ./python -m timeit -s "from pathlib import Path; p = Path.cwd()" "list(p.glob('Lib'))"
20000 loops, best of 5: 13.6 usec per loop
20000 loops, best of 5: 10.4 usec per loop
# --> 1.31x faster

$ ./python -m timeit -s "from pathlib import Path; p = Path.cwd()" "list(p.glob('*.py'))"
5000 loops, best of 5: 88.4 usec per loop
5000 loops, best of 5: 83.8 usec per loop
# --> 1.05x faster

$ ./python -m timeit -s "from pathlib import Path; p = Path.cwd()" "list(p.glob('*'))"
2000 loops, best of 5: 145 usec per loop
2000 loops, best of 5: 139 usec per loop
# --> 1.04x faster
```

<!-- gh-issue-number: gh-115060 -->
* Issue: gh-115060
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--117831.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->