### PR TITLE
gh-113308: Restore `uuid._load_system_functions` for 3.13

### DIFF
--- a/Lib/uuid.py
+++ b/Lib/uuid.py
@@ -579,6 +579,14 @@ except ImportError:
     _UuidCreate = None
 
 
+def _load_system_functions():
+    """[DEPRECATED] no-op since Python 3.9."""
+    import warnings
+    warnings.warn("This private function will go away by Python 3.15;"
+                  " it has been a no-op since 3.9.", DeprecationWarning,
+                  stacklevel=2)
+
+
 def _unix_getnode():
     """Get the hardware address on Unix using the _uuid extension module."""
     if _generate_time_safe:

--- a/Misc/NEWS.d/next/Library/2024-04-13-01-37-37.gh-issue-113308.6S_qUi.rst
+++ b/Misc/NEWS.d/next/Library/2024-04-13-01-37-37.gh-issue-113308.6S_qUi.rst
@@ -1,0 +1,3 @@
+The do nothing private ``uuid._load_system_functions()`` function has been
+restored to appease a PyPI library that calls it to unblock 3.13 testing by
+others.  It now triggers a :exc:`DeprecationWarning` instead.


### PR DESCRIPTION
The do nothing private ``uuid._load_system_functions()`` function has been restored to appease a PyPI library that calls it to unblock 3.13 testing by others.  It now triggers a :exc:`DeprecationWarning` instead.

This should deal with users blocked by the library on PyPI using the no-op from testing on 3.13: 
https://github.com/spulec/freezegun/pull/534#issuecomment-2052726667

<!-- gh-issue-number: gh-113308 -->
* Issue: gh-113308
<!-- /gh-issue-number -->
