### PR TITLE
gh-96398: Purge Emscripten code from configure.ac

### DIFF
--- a/configure
+++ b/configure
@@ -8680,13 +8680,6 @@ fi
           ;;
       esac
       ;;
-    *emcc*)
-      if test "$Py_LTO_POLICY" != "default"; then
-        as_fn_error $? "emcc supports only default lto." "$LINENO" 5
-      fi
-      LTOFLAGS="-flto"
-      LTOCFLAGS="-flto"
-      ;;
     *gcc*)
       if test $Py_LTO_POLICY = thin
       then

--- a/configure.ac
+++ b/configure.ac
@@ -1956,13 +1956,6 @@ if test "$Py_LTO" = 'true' ; then
           ;;
       esac
       ;;
-    *emcc*)
-      if test "$Py_LTO_POLICY" != "default"; then
-        AC_MSG_ERROR([emcc supports only default lto.])
-      fi
-      LTOFLAGS="-flto"
-      LTOCFLAGS="-flto"
-      ;;
     *gcc*)
       if test $Py_LTO_POLICY = thin
       then


### PR DESCRIPTION
See gh-113632 and python/peps#3612: Emscripten is no longer supported


<!-- gh-issue-number: gh-96398 -->
* Issue: gh-96398
<!-- /gh-issue-number -->
