### PR TITLE
gh-117840: Fix indent to fix shlex syntax highlighting

### DIFF
--- a/Doc/library/shlex.rst
+++ b/Doc/library/shlex.rst
@@ -412,17 +412,17 @@ otherwise.  To illustrate, you can see the difference in the following snippet:
 .. doctest::
    :options: +NORMALIZE_WHITESPACE
 
-    >>> import shlex
-    >>> text = "a && b; c && d || e; f >'abc'; (def \"ghi\")"
-    >>> s = shlex.shlex(text, posix=True)
-    >>> s.whitespace_split = True
-    >>> list(s)
-    ['a', '&&', 'b;', 'c', '&&', 'd', '||', 'e;', 'f', '>abc;', '(def', 'ghi)']
-    >>> s = shlex.shlex(text, posix=True, punctuation_chars=True)
-    >>> s.whitespace_split = True
-    >>> list(s)
-    ['a', '&&', 'b', ';', 'c', '&&', 'd', '||', 'e', ';', 'f', '>', 'abc', ';',
-    '(', 'def', 'ghi', ')']
+   >>> import shlex
+   >>> text = "a && b; c && d || e; f >'abc'; (def \"ghi\")"
+   >>> s = shlex.shlex(text, posix=True)
+   >>> s.whitespace_split = True
+   >>> list(s)
+   ['a', '&&', 'b;', 'c', '&&', 'd', '||', 'e;', 'f', '>abc;', '(def', 'ghi)']
+   >>> s = shlex.shlex(text, posix=True, punctuation_chars=True)
+   >>> s.whitespace_split = True
+   >>> list(s)
+   ['a', '&&', 'b', ';', 'c', '&&', 'd', '||', 'e', ';', 'f', '>', 'abc', ';',
+   '(', 'def', 'ghi', ')']
 
 Of course, tokens will be returned which are not valid for shells, and you'll
 need to implement your own error checks on the returned tokens.
@@ -431,10 +431,10 @@ Instead of passing ``True`` as the value for the punctuation_chars parameter,
 you can pass a string with specific characters, which will be used to determine
 which characters constitute punctuation. For example::
 
-    >>> import shlex
-    >>> s = shlex.shlex("a && b || c", punctuation_chars="|")
-    >>> list(s)
-    ['a', '&', '&', 'b', '||', 'c']
+   >>> import shlex
+   >>> s = shlex.shlex("a && b || c", punctuation_chars="|")
+   >>> list(s)
+   ['a', '&', '&', 'b', '||', 'c']
 
 .. note:: When ``punctuation_chars`` is specified, the :attr:`~shlex.wordchars`
    attribute is augmented with the characters ``~-./*?=``.  That is because these


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

Fixes https://github.com/python/cpython/issues/117840.

Should be three-space indents: https://devguide.python.org/documentation/markup/#use-of-whitespace

The second block renders correctly with four, but let's make that consistent as well. The other code blocks use (multiples of) three.

# Before

<img width="816" alt="image" src="https://github.com/python/cpython/assets/1324225/1fa5d8ff-3118-4dbc-8931-58f7ce2232bc">

# After

<img width="816" alt="image" src="https://github.com/python/cpython/assets/1324225/dd9100a9-fb2f-43b4-aea2-906deebe5efb">


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--117843.org.readthedocs.build/en/117843/library/shlex.html#improved-compatibility-with-shells

<!-- readthedocs-preview cpython-previews end -->

<!-- gh-issue-number: gh-117840 -->
* Issue: gh-117840
<!-- /gh-issue-number -->
