### PR TITLE
Docs: add link roles with Sphinx extlinks

### DIFF
--- a/Doc/conf.py
+++ b/Doc/conf.py
@@ -24,6 +24,7 @@ extensions = [
     'pyspecific',
     'sphinx.ext.coverage',
     'sphinx.ext.doctest',
+    'sphinx.ext.extlinks',
 ]
 
 # Skip if downstream redistributors haven't installed them
@@ -513,6 +514,16 @@ linkcheck_ignore = [
     r'https://unix.org/version2/whatsnew/lp64_wp.html',
 ]
 
+# Options for sphinx.ext.extlinks
+# -------------------------------
+
+# This config is a dictionary of external sites,
+# mapping unique short aliases to a base URL and a prefix.
+# https://www.sphinx-doc.org/en/master/usage/extensions/extlinks.html
+extlinks = {
+    "cve": ("https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-%s", "CVE-%s"),
+}
+extlinks_detect_hardcoded_links = True
 
 # Options for extensions
 # ----------------------

--- a/Doc/conf.py
+++ b/Doc/conf.py
@@ -12,6 +12,8 @@ import time
 sys.path.append(os.path.abspath('tools/extensions'))
 sys.path.append(os.path.abspath('includes'))
 
+from pyspecific import SOURCE_URI
+
 # General configuration
 # ---------------------
 
@@ -524,6 +526,7 @@ extlinks = {
     "cve": ("https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-%s", "CVE-%s"),
     "cwe": ("https://cwe.mitre.org/data/definitions/%s.html", "CWE-%s"),
     "pypi": ("https://pypi.org/project/%s/", "%s"),
+    "source": (SOURCE_URI, "%s"),
 }
 extlinks_detect_hardcoded_links = True
 

--- a/Doc/conf.py
+++ b/Doc/conf.py
@@ -522,6 +522,7 @@ linkcheck_ignore = [
 # https://www.sphinx-doc.org/en/master/usage/extensions/extlinks.html
 extlinks = {
     "cve": ("https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-%s", "CVE-%s"),
+    "cwe": ("https://cwe.mitre.org/data/definitions/%s.html", "CWE-%s"),
 }
 extlinks_detect_hardcoded_links = True
 

--- a/Doc/conf.py
+++ b/Doc/conf.py
@@ -523,6 +523,7 @@ linkcheck_ignore = [
 extlinks = {
     "cve": ("https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-%s", "CVE-%s"),
     "cwe": ("https://cwe.mitre.org/data/definitions/%s.html", "CWE-%s"),
+    "pypi": ("https://pypi.org/project/%s/", "%s"),
 }
 extlinks_detect_hardcoded_links = True
 

--- a/Doc/faq/library.rst
+++ b/Doc/faq/library.rst
@@ -616,8 +616,7 @@ use ``p.read(n)``.
    ("ptys") instead of pipes. Or you can use a Python interface to Don Libes'
    "expect" library.  A Python extension that interfaces to expect is called
    "expy" and available from https://expectpy.sourceforge.net.  A pure Python
-   solution that works like expect is `pexpect
-   <https://pypi.org/project/pexpect/>`_.
+   solution that works like expect is :pypi:`pexpect`.
 
 
 How do I access the serial (RS232) port?
@@ -625,7 +624,7 @@ How do I access the serial (RS232) port?
 
 For Win32, OSX, Linux, BSD, Jython, IronPython:
 
-   https://pypi.org/project/pyserial/
+   :pypi:`pyserial`
 
 For Unix, see a Usenet post by Mitch Chapman:
 

--- a/Doc/howto/curses.rst
+++ b/Doc/howto/curses.rst
@@ -43,7 +43,7 @@ appearance---and the curses library will figure out what control codes
 need to be sent to the terminal to produce the right output.  curses
 doesn't provide many user-interface concepts such as buttons, checkboxes,
 or dialogs; if you need such features, consider a user interface library such as
-`Urwid <https://pypi.org/project/urwid/>`_.
+:pypi:`Urwid`.
 
 The curses library was originally written for BSD Unix; the later System V
 versions of Unix from AT&T added many enhancements and new functions. BSD curses
@@ -56,8 +56,7 @@ versions of curses carried by some proprietary Unixes may not support
 everything, though.
 
 The Windows version of Python doesn't include the :mod:`curses`
-module.  A ported version called `UniCurses
-<https://pypi.org/project/UniCurses>`_ is available.
+module.  A ported version called :pypi:`UniCurses` is available.
 
 
 The Python curses module
@@ -429,8 +428,7 @@ User Input
 
 The C curses library offers only very simple input mechanisms. Python's
 :mod:`curses` module adds a basic text-input widget.  (Other libraries
-such as `Urwid <https://pypi.org/project/urwid/>`_ have more extensive
-collections of widgets.)
+such as :pypi:`Urwid` have more extensive collections of widgets.)
 
 There are two methods for getting input from a window:
 

--- a/Doc/howto/logging-cookbook.rst
+++ b/Doc/howto/logging-cookbook.rst
@@ -1912,7 +1912,7 @@ Subclassing QueueHandler and QueueListener- a ``pynng`` example
 ---------------------------------------------------------------
 
 In a similar way to the above section, we can implement a listener and handler
-using `pynng <https://pypi.org/project/pynng/>`_, which is a Python binding to
+using :pypi:`pynng`, which is a Python binding to
 `NNG <https://nng.nanomsg.org/>`_, billed as a spiritual successor to ZeroMQ.
 The following snippets illustrate -- you can test them in an environment which has
 ``pynng`` installed. Just for variety, we present the listener first.
@@ -3575,9 +3575,8 @@ A Qt GUI for logging
 
 A question that comes up from time to time is about how to log to a GUI
 application. The `Qt <https://www.qt.io/>`_ framework is a popular
-cross-platform UI framework with Python bindings using `PySide2
-<https://pypi.org/project/PySide2/>`_ or `PyQt5
-<https://pypi.org/project/PyQt5/>`_ libraries.
+cross-platform UI framework with Python bindings using :pypi:`PySide2`
+or :pypi:`PyQt5` libraries.
 
 The following example shows how to log to a Qt GUI. This introduces a simple
 ``QtHandler`` class which takes a callable, which should be a slot in the main

--- a/Doc/library/codecs.rst
+++ b/Doc/library/codecs.rst
@@ -1478,7 +1478,7 @@ Internationalized Domain Names (IDN)). It builds upon the ``punycode`` encoding
 and :mod:`stringprep`.
 
 If you need the IDNA 2008 standard from :rfc:`5891` and :rfc:`5895`, use the
-third-party `idna module <https://pypi.org/project/idna/>`_.
+third-party :pypi:`idna` module.
 
 These RFCs together define a protocol to support non-ASCII characters in domain
 names. A domain name containing non-ASCII characters (such as

--- a/Doc/library/datetime.rst
+++ b/Doc/library/datetime.rst
@@ -37,7 +37,7 @@ on efficient attribute extraction for output formatting and manipulation.
    Package `dateutil <https://dateutil.readthedocs.io/en/stable/>`_
       Third-party library with expanded time zone and parsing support.
 
-   Package `DateType <https://pypi.org/project/datetype/>`_
+   Package :pypi:`DateType`
       Third-party library that introduces distinct static types to e.g. allow
       :term:`static type checkers <static type checker>`
       to differentiate between naive and aware datetimes.

--- a/Doc/library/importlib.metadata.rst
+++ b/Doc/library/importlib.metadata.rst
@@ -26,7 +26,7 @@ this package can eliminate the need to use the older and less efficient
 
 ``importlib.metadata`` operates on third-party *distribution packages*
 installed into Python's ``site-packages`` directory via tools such as
-`pip <https://pypi.org/project/pip/>`_.
+:pypi:`pip`.
 Specifically, it works with distributions with discoverable
 ``dist-info`` or ``egg-info`` directories,
 and metadata defined by the `Core metadata specifications <https://packaging.python.org/en/latest/specifications/core-metadata/#core-metadata>`_.
@@ -177,7 +177,7 @@ for more information on entry points, their definition, and usage.
    no parameters and always returned a dictionary of entry points, keyed
    by group. With ``importlib_metadata`` 5.0 and Python 3.12,
    ``entry_points`` always returns an ``EntryPoints`` object. See
-   `backports.entry_points_selectable <https://pypi.org/project/backports.entry-points-selectable>`_
+   :pypi:`backports.entry_points_selectable`
    for compatibility options.
 
 .. versionchanged:: 3.13

--- a/Doc/library/itertools.rst
+++ b/Doc/library/itertools.rst
@@ -791,7 +791,7 @@ recipes.  Currently, the ``sliding_window()``, ``iter_index()``, and ``sieve()``
 recipes are being tested to see whether they prove their worth.
 
 Substantially all of these recipes and many, many others can be installed from
-the `more-itertools project <https://pypi.org/project/more-itertools/>`_ found
+the :pypi:`more-itertools` project found
 on the Python Package Index::
 
     python -m pip install more-itertools

--- a/Doc/library/re.rst
+++ b/Doc/library/re.rst
@@ -48,7 +48,7 @@ fine-tuning parameters.
 
 .. seealso::
 
-   The third-party `regex <https://pypi.org/project/regex/>`_ module,
+   The third-party :pypi:`regex` module,
    which has an API compatible with the standard library :mod:`re` module,
    but offers additional functionality and a more thorough Unicode support.
 

--- a/Doc/library/secrets.rst
+++ b/Doc/library/secrets.rst
@@ -155,7 +155,7 @@ Generate an eight-character alphanumeric password:
 .. note::
 
    Applications should not
-   `store passwords in a recoverable format <https://cwe.mitre.org/data/definitions/257.html>`_,
+   :cwe:`store passwords in a recoverable format <257>`,
    whether plain text or encrypted.  They should be salted and hashed
    using a cryptographically strong one-way (irreversible) hash function.
 

--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -5559,8 +5559,7 @@ a string to a binary integer or a binary integer to a string in linear time,
 have sub-quadratic complexity. Converting a large value such as ``int('1' *
 500_000)`` can take over a second on a fast CPU.
 
-Limiting conversion size offers a practical way to avoid `CVE-2020-10735
-<https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-10735>`_.
+Limiting conversion size offers a practical way to avoid :cve:`2020-10735`.
 
 The limit is applied to the number of digit characters in the input or output
 string when a non-linear conversion algorithm would be involved.  Underscores

--- a/Doc/library/tomllib.rst
+++ b/Doc/library/tomllib.rst
@@ -19,14 +19,14 @@ support writing TOML.
 
 .. seealso::
 
-    The `Tomli-W package <https://pypi.org/project/tomli-w/>`__
+    The :pypi:`Tomli-W package <tomli-w>`
     is a TOML writer that can be used in conjunction with this module,
     providing a write API familiar to users of the standard library
     :mod:`marshal` and :mod:`pickle` modules.
 
 .. seealso::
 
-    The `TOML Kit package <https://pypi.org/project/tomlkit/>`__
+    The :pypi:`TOML Kit package <tomlkit>`
     is a style-preserving TOML library with both read and write capability.
     It is a recommended replacement for this module for editing already
     existing TOML files.

--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -39,7 +39,7 @@ they can also be more complex. The :mod:`typing` module provides a vocabulary of
 more advanced type hints.
 
 New features are frequently added to the ``typing`` module.
-The `typing_extensions <https://pypi.org/project/typing-extensions/>`_ package
+The :pypi:`typing_extensions` package
 provides backports of these new features to older versions of Python.
 
 .. seealso::

--- a/Doc/library/unittest.mock.rst
+++ b/Doc/library/unittest.mock.rst
@@ -35,7 +35,7 @@ is based on the 'action -> assertion' pattern instead of 'record -> replay'
 used by many mocking frameworks.
 
 There is a backport of :mod:`unittest.mock` for earlier versions of Python,
-available as `mock on PyPI <https://pypi.org/project/mock>`_.
+available as :pypi:`mock` on PyPI.
 
 
 Quick Guide

--- a/Doc/library/venv.rst
+++ b/Doc/library/venv.rst
@@ -27,7 +27,7 @@ optionally be isolated from the packages in the base environment,
 so only those explicitly installed in the virtual environment are available.
 
 When used from within a virtual environment, common installation tools such as
-`pip`_ will install Python packages into a virtual environment
+:pypi:`pip` will install Python packages into a virtual environment
 without needing to be told to do so explicitly.
 
 A virtual environment is (amongst other things):
@@ -614,7 +614,3 @@ subclass which installs setuptools and pip into a created virtual environment::
 
 This script is also available for download `online
 <https://gist.github.com/vsajip/4673395>`_.
-
-
-.. _setuptools: https://pypi.org/project/setuptools/
-.. _pip: https://pypi.org/project/pip/

--- a/Doc/library/xml.rst
+++ b/Doc/library/xml.rst
@@ -126,7 +126,7 @@ large tokens
   be used to cause denial of service in the application parsing XML.
   The issue is known as :cve:`2023-52425`.
 
-The documentation for `defusedxml`_ on PyPI has further information about
+The documentation for :pypi:`defusedxml` on PyPI has further information about
 all known attack vectors with examples and references.
 
 .. _defusedxml-package:
@@ -134,14 +134,13 @@ all known attack vectors with examples and references.
 The :mod:`!defusedxml` Package
 ------------------------------
 
-`defusedxml`_ is a pure Python package with modified subclasses of all stdlib
+:pypi:`defusedxml` is a pure Python package with modified subclasses of all stdlib
 XML parsers that prevent any potentially malicious operation. Use of this
 package is recommended for any server code that parses untrusted XML data. The
 package also ships with example exploits and extended documentation on more
 XML exploits such as XPath injection.
 
 
-.. _defusedxml: https://pypi.org/project/defusedxml/
 .. _Billion Laughs: https://en.wikipedia.org/wiki/Billion_laughs
 .. _ZIP bomb: https://en.wikipedia.org/wiki/Zip_bomb
 .. _DTD: https://en.wikipedia.org/wiki/Document_type_definition

--- a/Doc/library/xml.rst
+++ b/Doc/library/xml.rst
@@ -124,8 +124,7 @@ large tokens
   Expat needs to re-parse unfinished tokens; without the protection
   introduced in Expat 2.6.0, this can lead to quadratic runtime that can
   be used to cause denial of service in the application parsing XML.
-  The issue is known as
-  `CVE-2023-52425 <https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-52425>`_.
+  The issue is known as :cve:`2023-52425`.
 
 The documentation for `defusedxml`_ on PyPI has further information about
 all known attack vectors with examples and references.

--- a/Doc/library/zipfile.rst
+++ b/Doc/library/zipfile.rst
@@ -632,7 +632,7 @@ Path objects are traversable using the ``/`` operator or ``joinpath``.
       Prior to 3.10, ``joinpath`` was undocumented and accepted
       exactly one parameter.
 
-The `zipp <https://pypi.org/project/zipp>`_ project provides backports
+The :pypi:`zipp` project provides backports
 of the latest path object functionality to older Pythons. Use
 ``zipp.Path`` in place of ``zipfile.Path`` for early access to
 changes.

--- a/Doc/library/zoneinfo.rst
+++ b/Doc/library/zoneinfo.rst
@@ -17,7 +17,7 @@ The :mod:`zoneinfo` module provides a concrete time zone implementation to
 support the IANA time zone database as originally specified in :pep:`615`. By
 default, :mod:`zoneinfo` uses the system's time zone data if available; if no
 system time zone data is available, the library will fall back to using the
-first-party `tzdata`_ package available on PyPI.
+first-party :pypi:`tzdata` package available on PyPI.
 
 .. seealso::
 
@@ -25,7 +25,7 @@ first-party `tzdata`_ package available on PyPI.
         Provides the :class:`~datetime.time` and :class:`~datetime.datetime`
         types with which the :class:`ZoneInfo` class is designed to be used.
 
-    Package `tzdata`_
+    Package :pypi:`tzdata`
         First-party package maintained by the CPython core developers to supply
         time zone data via PyPI.
 
@@ -93,7 +93,7 @@ Data sources
 
 The ``zoneinfo`` module does not directly provide time zone data, and instead
 pulls time zone information from the system time zone database or the
-first-party PyPI package `tzdata`_, if available. Some systems, including
+first-party PyPI package :pypi:`tzdata`, if available. Some systems, including
 notably Windows systems, do not have an IANA database available, and so for
 projects targeting cross-platform compatibility that require time zone data, it
 is recommended to declare a dependency on tzdata. If neither system data nor
@@ -413,5 +413,3 @@ Exceptions and warnings
     be filtered out, such as a relative path.
 
 .. Links and references:
-
-.. _tzdata: https://pypi.org/project/tzdata/

--- a/Doc/tools/extensions/pyspecific.py
+++ b/Doc/tools/extensions/pyspecific.py
@@ -26,7 +26,6 @@ from sphinx.errors import NoUri
 from sphinx.locale import _ as sphinx_gettext
 from sphinx.util import logging
 from sphinx.util.docutils import SphinxDirective
-from sphinx.util.nodes import split_explicit_title
 from sphinx.writers.text import TextWriter, TextTranslator
 
 try:
@@ -39,6 +38,7 @@ except ImportError:
 
 ISSUE_URI = 'https://bugs.python.org/issue?@action=redirect&bpo=%s'
 GH_ISSUE_URI = 'https://github.com/python/cpython/issues/%s'
+# Used in conf.py and updated here by python/release-tools/run_release.py
 SOURCE_URI = 'https://github.com/python/cpython/tree/main/%s'
 
 # monkey-patch reST parser to disable alphabetic and roman enumerated lists
@@ -53,6 +53,7 @@ Body.enum.converters['loweralpha'] = \
 from sphinx.domains import std
 
 std.token_re = re.compile(r'`((~?[\w-]*:)?\w+)`')
+
 
 # Support for marking up and linking to bugs.python.org issues
 
@@ -82,16 +83,6 @@ def gh_issue_role(typ, rawtext, text, lineno, inliner, options={}, content=[]):
         return [prb], [msg]
     text = 'gh-' + issue
     refnode = nodes.reference(text, text, refuri=GH_ISSUE_URI % issue)
-    return [refnode], []
-
-
-# Support for linking to Python source files easily
-
-def source_role(typ, rawtext, text, lineno, inliner, options={}, content=[]):
-    has_t, title, target = split_explicit_title(text)
-    title = utils.unescape(title)
-    target = utils.unescape(target)
-    refnode = nodes.reference(title, title, refuri=SOURCE_URI % target)
     return [refnode], []
 
 
@@ -192,7 +183,6 @@ class Availability(SphinxDirective):
             )
 
         return platforms
-
 
 
 # Support for documenting audit event
@@ -710,7 +700,6 @@ def patch_pairindextypes(app, _env) -> None:
 def setup(app):
     app.add_role('issue', issue_role)
     app.add_role('gh', gh_issue_role)
-    app.add_role('source', source_role)
     app.add_directive('impl-detail', ImplementationDetail)
     app.add_directive('availability', Availability)
     app.add_directive('audit-event', AuditEvent)

--- a/Doc/using/mac.rst
+++ b/Doc/using/mac.rst
@@ -145,7 +145,7 @@ There are several options for building GUI applications on the Mac with Python.
 
 *PyObjC* is a Python binding to Apple's Objective-C/Cocoa framework, which is
 the foundation of most modern Mac development. Information on PyObjC is
-available from https://pypi.org/project/pyobjc/.
+available from :pypi:`pyobjc`.
 
 The standard Python GUI toolkit is :mod:`tkinter`, based on the cross-platform
 Tk toolkit (https://www.tcl.tk). An Aqua-native version of Tk is bundled with
@@ -177,7 +177,7 @@ Distributing Python Applications
 A range of tools exist for converting your Python code into a standalone
 distributable application:
 
-* `py2app <https://pypi.org/project/py2app/>`__: Supports creating macOS ``.app``
+* :pypi:`py2app`: Supports creating macOS ``.app``
   bundles from a Python project.
 
 * `Briefcase <https://briefcase.readthedocs.io>`__: Part of the `BeeWare Project

--- a/Doc/using/windows.rst
+++ b/Doc/using/windows.rst
@@ -1285,7 +1285,7 @@ The Windows-specific standard modules are documented in
 PyWin32
 -------
 
-The `PyWin32 <https://pypi.org/project/pywin32>`_ module by Mark Hammond
+The :pypi:`PyWin32` module by Mark Hammond
 is a collection of modules for advanced Windows-specific support.  This includes
 utilities for:
 

--- a/Doc/whatsnew/2.6.rst
+++ b/Doc/whatsnew/2.6.rst
@@ -3015,8 +3015,7 @@ Changes to Python's build process and to the C API include:
   ``PyRun_SimpleString("sys.path.pop(0)\n")`` afterwards to discard
   the first ``sys.path`` component.
 
-  Security issue reported as `CVE-2008-5983
-  <http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2008-5983>`_;
+  Security issue reported as :cve:`2008-5983`;
   discussed in :gh:`50003`, and fixed by Antoine Pitrou.
 
 * The BerkeleyDB module now has a C API object, available as

--- a/Doc/whatsnew/2.7.rst
+++ b/Doc/whatsnew/2.7.rst
@@ -1831,8 +1831,7 @@ The :mod:`unittest` module was greatly enhanced; many
 new features were added.  Most of these features were implemented
 by Michael Foord, unless otherwise noted.  The enhanced version of
 the module is downloadable separately for use with Python versions 2.4 to 2.6,
-packaged as the :mod:`!unittest2` package, from
-https://pypi.org/project/unittest2.
+packaged as the :mod:`!unittest2` package, from :pypi:`unittest2`.
 
 When used from the command line, the module can automatically discover
 tests.  It's not as fancy as `py.test <https://pytest.org>`__ or

--- a/Doc/whatsnew/2.7.rst
+++ b/Doc/whatsnew/2.7.rst
@@ -2178,8 +2178,7 @@ Changes to Python's build process and to the C API include:
   whether the application should be using :c:func:`!PySys_SetArgvEx`
   with *updatepath* set to false.
 
-  Security issue reported as `CVE-2008-5983
-  <https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2008-5983>`_;
+  Security issue reported as :cve:`2008-5983`;
   discussed in :issue:`5753`, and fixed by Antoine Pitrou.
 
 * New macros: the Python header files now define the following macros:
@@ -2626,7 +2625,7 @@ with the first of those changes appearing in the Python 2.7.7 release.
   2 applications. (Contributed by Alex Gaynor; :issue:`21304`.)
 
 * OpenSSL 1.0.1h was upgraded for the official Windows installers published on
-  python.org. (contributed by Zachary Ware in :issue:`21671` for CVE-2014-0224)
+  python.org. (Contributed by Zachary Ware in :issue:`21671` for :cve:`2014-0224`.)
 
 :pep:`466` related features added in Python 2.7.9:
 

--- a/Doc/whatsnew/3.10.rst
+++ b/Doc/whatsnew/3.10.rst
@@ -2331,8 +2331,7 @@ Converting between :class:`int` and :class:`str` in bases other than 2
 (binary), 4, 8 (octal), 16 (hexadecimal), or 32 such as base 10 (decimal)
 now raises a :exc:`ValueError` if the number of digits in string form is
 above a limit to avoid potential denial of service attacks due to the
-algorithmic complexity. This is a mitigation for `CVE-2020-10735
-<https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-10735>`_.
+algorithmic complexity. This is a mitigation for :cve:`2020-10735`.
 This limit can be configured or disabled by environment variable, command
 line flag, or :mod:`sys` APIs. See the :ref:`integer string conversion
 length limitation <int_max_str_digits>` documentation.  The default limit

--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -2027,7 +2027,7 @@ Removed C APIs are :ref:`listed separately <whatsnew311-c-api-removed>`.
   (and corresponding :c:macro:`!EXPERIMENTAL_ISOLATED_SUBINTERPRETERS` macro)
   have been removed.
 
-* `Pynche <https://pypi.org/project/pynche/>`_
+* :pypi:`Pynche`
   --- The Pythonically Natural Color and Hue Editor --- has been moved out
   of ``Tools/scripts`` and is `being developed independently
   <https://gitlab.com/warsaw/pynche/-/tree/main>`_ from the Python source tree.

--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -544,8 +544,7 @@ Other CPython Implementation Changes
   (binary), 4, 8 (octal), 16 (hexadecimal), or 32 such as base 10 (decimal)
   now raises a :exc:`ValueError` if the number of digits in string form is
   above a limit to avoid potential denial of service attacks due to the
-  algorithmic complexity. This is a mitigation for `CVE-2020-10735
-  <https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-10735>`_.
+  algorithmic complexity. This is a mitigation for :cve:`2020-10735`.
   This limit can be configured or disabled by environment variable, command
   line flag, or :mod:`sys` APIs. See the :ref:`integer string conversion
   length limitation <int_max_str_digits>` documentation.  The default limit

--- a/Doc/whatsnew/3.12.rst
+++ b/Doc/whatsnew/3.12.rst
@@ -1659,7 +1659,7 @@ smtpd
 
 * The ``smtpd`` module has been removed according to the schedule in :pep:`594`,
   having been deprecated in Python 3.4.7 and 3.5.4.
-  Use :pypi:`aiosmtpd` PyPI module or any other
+  Use the :pypi:`aiosmtpd` PyPI module or any other
   :mod:`asyncio`-based server instead.
   (Contributed by Oleg Iarygin in :gh:`93243`.)
 
@@ -1699,8 +1699,8 @@ ssl
   instead, create a :class:`ssl.SSLContext` object and call its
   :class:`ssl.SSLContext.wrap_socket` method. Any package that still uses
   :func:`!ssl.wrap_socket` is broken and insecure. The function neither sends a
-  SNI TLS extension nor validates server hostname. Code is subject to :cwe:`295`
-  Improper Certificate Validation.
+  SNI TLS extension nor validates the server hostname. Code is subject to :cwe:`295`
+  (Improper Certificate Validation).
   (Contributed by Victor Stinner in :gh:`94199`.)
 
 unittest

--- a/Doc/whatsnew/3.12.rst
+++ b/Doc/whatsnew/3.12.rst
@@ -1701,9 +1701,8 @@ ssl
   instead, create a :class:`ssl.SSLContext` object and call its
   :class:`ssl.SSLContext.wrap_socket` method. Any package that still uses
   :func:`!ssl.wrap_socket` is broken and insecure. The function neither sends a
-  SNI TLS extension nor validates server hostname. Code is subject to `CWE-295
-  <https://cwe.mitre.org/data/definitions/295.html>`_: Improper Certificate
-  Validation.
+  SNI TLS extension nor validates server hostname. Code is subject to :cwe:`295`
+  Improper Certificate Validation.
   (Contributed by Victor Stinner in :gh:`94199`.)
 
 unittest

--- a/Doc/whatsnew/3.12.rst
+++ b/Doc/whatsnew/3.12.rst
@@ -1659,11 +1659,9 @@ smtpd
 
 * The ``smtpd`` module has been removed according to the schedule in :pep:`594`,
   having been deprecated in Python 3.4.7 and 3.5.4.
-  Use aiosmtpd_ PyPI module or any other
+  Use :pypi:`aiosmtpd` PyPI module or any other
   :mod:`asyncio`-based server instead.
   (Contributed by Oleg Iarygin in :gh:`93243`.)
-
-.. _aiosmtpd: https://pypi.org/project/aiosmtpd/
 
 sqlite3
 -------
@@ -1831,7 +1829,7 @@ Changes in the Python API
 
 * Remove the ``asyncore``-based ``smtpd`` module deprecated in Python 3.4.7
   and 3.5.4.  A recommended replacement is the
-  :mod:`asyncio`-based aiosmtpd_ PyPI module.
+  :mod:`asyncio`-based :pypi:`aiosmtpd` PyPI module.
 
 * :func:`shlex.split`: Passing ``None`` for *s* argument now raises an
   exception, rather than reading :data:`sys.stdin`. The feature was deprecated

--- a/Doc/whatsnew/3.13.rst
+++ b/Doc/whatsnew/3.13.rst
@@ -1359,7 +1359,7 @@ PEP 594: dead batteries
     (Contributed by Victor Stinner in :gh:`104773`.)
 
   * :mod:`!nntplib`:
-    the PyPI :pypi:`nntplib` project can be used instead.
+    the :pypi:`nntplib` PyPI project can be used instead.
     (Contributed by Victor Stinner in :gh:`104773`.)
 
   * :mod:`!ossaudiodev`: use the

--- a/Doc/whatsnew/3.13.rst
+++ b/Doc/whatsnew/3.13.rst
@@ -1306,9 +1306,8 @@ PEP 594: dead batteries
 
     * ``cgi.FieldStorage`` can typically be replaced with
       :func:`urllib.parse.parse_qsl` for ``GET`` and ``HEAD`` requests,
-      and the :mod:`email.message` module or `multipart
-      <https://pypi.org/project/multipart/>`__ PyPI project for ``POST`` and
-      ``PUT``.
+      and the :mod:`email.message` module or :pypi:`multipart`
+      PyPI project for ``POST`` and ``PUT``.
 
     * ``cgi.parse()`` can be replaced by calling :func:`urllib.parse.parse_qs`
       directly on the desired query string, except for ``multipart/form-data``
@@ -1326,7 +1325,7 @@ PEP 594: dead batteries
     * ``cgi.parse_multipart()`` can be replaced with the functionality in the
       :mod:`email` package (e.g. :class:`email.message.EmailMessage` and
       :class:`email.message.Message`) which implements the same MIME RFCs, or
-      with the `multipart <https://pypi.org/project/multipart/>`__ PyPI project.
+      with the :pypi:`multipart` PyPI project.
 
     (Contributed by Victor Stinner in :gh:`104773`.)
 
@@ -1334,21 +1333,19 @@ PEP 594: dead batteries
     The :mod:`hashlib` module is a potential replacement for certain use cases.
     Otherwise, the following PyPI projects can be used:
 
-    * `bcrypt <https://pypi.org/project/bcrypt/>`_:
+    * :pypi:`bcrypt`:
       Modern password hashing for your software and your servers.
-    * `passlib <https://pypi.org/project/passlib/>`_:
+    * :pypi:`passlib`:
       Comprehensive password hashing framework supporting over 30 schemes.
-    * `argon2-cffi <https://pypi.org/project/argon2-cffi/>`_:
+    * :pypi:`argon2-cffi`:
       The secure Argon2 password hashing algorithm.
-    * `legacycrypt <https://pypi.org/project/legacycrypt/>`_:
+    * :pypi:`legacycrypt`:
       Wrapper to the POSIX crypt library call and associated functionality.
 
     (Contributed by Victor Stinner in :gh:`104773`.)
 
-  * :mod:`!imghdr`: use the projects
-    `filetype <https://pypi.org/project/filetype/>`_,
-    `puremagic <https://pypi.org/project/puremagic/>`_,
-    or `python-magic <https://pypi.org/project/python-magic/>`_ instead.
+  * :mod:`!imghdr`: use the projects :pypi:`filetype`,
+    :pypi:`puremagic`, or :pypi:`python-magic` instead.
     (Contributed by Victor Stinner in :gh:`104773`.)
 
   * :mod:`!mailcap`.
@@ -1362,8 +1359,7 @@ PEP 594: dead batteries
     (Contributed by Victor Stinner in :gh:`104773`.)
 
   * :mod:`!nntplib`:
-    the `PyPI nntplib project <https://pypi.org/project/nntplib/>`_
-    can be used instead.
+    the PyPI :pypi:`nntplib` project can be used instead.
     (Contributed by Victor Stinner in :gh:`104773`.)
 
   * :mod:`!ossaudiodev`: use the
@@ -1373,23 +1369,19 @@ PEP 594: dead batteries
   * :mod:`!pipes`: use the :mod:`subprocess` module instead.
     (Contributed by Victor Stinner in :gh:`104773`.)
 
-  * :mod:`!sndhdr`: use the projects
-    `filetype <https://pypi.org/project/filetype/>`_,
-    `puremagic <https://pypi.org/project/puremagic/>`_, or
-    `python-magic <https://pypi.org/project/python-magic/>`_ instead.
+  * :mod:`!sndhdr`: use the projects :pypi:`filetype_,
+    :pypi:`puremagic`, or :pypi:`python-magic` instead.
     (Contributed by Victor Stinner in :gh:`104773`.)
 
   * :mod:`!spwd`:
-    the `python-pam project <https://pypi.org/project/python-pam/>`_
-    can be used instead.
+    the :pypi:`python-pam` project can be used instead.
     (Contributed by Victor Stinner in :gh:`104773`.)
 
   * :mod:`!sunau`.
     (Contributed by Victor Stinner in :gh:`104773`.)
 
-  * :mod:`!telnetlib`, use the projects
-    `telnetlib3 <https://pypi.org/project/telnetlib3/>`_ or
-    `Exscript <https://pypi.org/project/Exscript/>`_ instead.
+  * :mod:`!telnetlib`, use the projects :pypi:`telnetlib3 ` or
+    :pypi:`Exscript` instead.
     (Contributed by Victor Stinner in :gh:`104773`.)
 
   * :mod:`!uu`: the :mod:`base64` module is a modern alternative.

--- a/Doc/whatsnew/3.13.rst
+++ b/Doc/whatsnew/3.13.rst
@@ -185,7 +185,7 @@ Other Language Changes
 
   (Contributed by Victor Stinner in :gh:`114570`.)
 
-* Allow controlling Expat >=2.6.0 reparse deferral (CVE-2023-52425)
+* Allow controlling Expat >=2.6.0 reparse deferral (:cve:`2023-52425`)
   by adding five new methods:
 
   * :meth:`xml.etree.ElementTree.XMLParser.flush`
@@ -393,7 +393,7 @@ email
   ``getattr(email.utils, 'supports_strict_parsing', False)`` can be use to
   check if the *strict* parameter is available.
   (Contributed by Thomas Dwyer and Victor Stinner for :gh:`102988` to improve
-  the CVE-2023-27043 fix.)
+  the :cve:`2023-27043` fix.)
 
 fractions
 ---------

--- a/Doc/whatsnew/3.5.rst
+++ b/Doc/whatsnew/3.5.rst
@@ -951,7 +951,7 @@ New :class:`~collections.abc.Awaitable`, :class:`~collections.abc.Coroutine`,
 (Contributed by Yury Selivanov in :issue:`24184`.)
 
 For earlier Python versions, a backport of the new ABCs is available in an
-external `PyPI package <https://pypi.org/project/backports_abc>`_.
+external :pypi:`PyPI package <backports_abc>`.
 
 
 compileall

--- a/Doc/whatsnew/3.7.rst
+++ b/Doc/whatsnew/3.7.rst
@@ -2609,8 +2609,7 @@ Converting between :class:`int` and :class:`str` in bases other than 2
 (binary), 4, 8 (octal), 16 (hexadecimal), or 32 such as base 10 (decimal)
 now raises a :exc:`ValueError` if the number of digits in string form is
 above a limit to avoid potential denial of service attacks due to the
-algorithmic complexity. This is a mitigation for `CVE-2020-10735
-<https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-10735>`_.
+algorithmic complexity. This is a mitigation for :cve:`2020-10735`.
 This limit can be configured or disabled by environment variable, command
 line flag, or :mod:`sys` APIs. See the :ref:`integer string conversion
 length limitation <int_max_str_digits>` documentation.  The default limit

--- a/Doc/whatsnew/3.8.rst
+++ b/Doc/whatsnew/3.8.rst
@@ -2337,8 +2337,7 @@ Converting between :class:`int` and :class:`str` in bases other than 2
 (binary), 4, 8 (octal), 16 (hexadecimal), or 32 such as base 10 (decimal)
 now raises a :exc:`ValueError` if the number of digits in string form is
 above a limit to avoid potential denial of service attacks due to the
-algorithmic complexity. This is a mitigation for `CVE-2020-10735
-<https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-10735>`_.
+algorithmic complexity. This is a mitigation for :cve:`2020-10735`.
 This limit can be configured or disabled by environment variable, command
 line flag, or :mod:`sys` APIs. See the :ref:`integer string conversion
 length limitation <int_max_str_digits>` documentation.  The default limit

--- a/Doc/whatsnew/3.9.rst
+++ b/Doc/whatsnew/3.9.rst
@@ -300,11 +300,8 @@ Example::
 
 
 As a fall-back source of data for platforms that don't ship the IANA database,
-the |tzdata|_ module was released as a first-party package -- distributed via
+the :pypi:`tzdata` module was released as a first-party package -- distributed via
 PyPI and maintained by the CPython core team.
-
-.. |tzdata| replace:: ``tzdata``
-.. _tzdata: https://pypi.org/project/tzdata/
 
 .. seealso::
 

--- a/Doc/whatsnew/3.9.rst
+++ b/Doc/whatsnew/3.9.rst
@@ -1592,8 +1592,7 @@ Converting between :class:`int` and :class:`str` in bases other than 2
 (binary), 4, 8 (octal), 16 (hexadecimal), or 32 such as base 10 (decimal)
 now raises a :exc:`ValueError` if the number of digits in string form is
 above a limit to avoid potential denial of service attacks due to the
-algorithmic complexity. This is a mitigation for `CVE-2020-10735
-<https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-10735>`_.
+algorithmic complexity. This is a mitigation for :cve:`2020-10735`.
 This limit can be configured or disabled by environment variable, command
 line flag, or :mod:`sys` APIs. See the :ref:`integer string conversion
 length limitation <int_max_str_digits>` documentation.  The default limit

--- a/Doc/whatsnew/index.rst
+++ b/Doc/whatsnew/index.rst
@@ -34,8 +34,8 @@ anyone wishing to stay up-to-date after a new release.
    2.1.rst
    2.0.rst
 
-The "Changelog" is an HTML version of the `file built
-<https://pypi.org/project/blurb>`_ from the contents of the
+The "Changelog" is an HTML version of the :pypi:`file built<blurb>`
+from the contents of the
 :source:`Misc/NEWS.d` directory tree, which contains *all* nontrivial changes
 to Python for the current version.
 

--- a/Misc/NEWS.d/3.10.0a1.rst
+++ b/Misc/NEWS.d/3.10.0a1.rst
@@ -5,7 +5,7 @@
 .. section: Security
 
 Fixes ``python3x._pth`` being ignored on Windows, caused by the fix for
-:issue:`29778` (CVE-2020-15801).
+:issue:`29778` (:cve:`2020-15801`).
 
 ..
 
@@ -25,7 +25,7 @@ events.
 .. section: Security
 
 Ensure :file:`python3.dll` is loaded from correct locations when Python is
-embedded (CVE-2020-15523).
+embedded (:cve:`2020-15523`).
 
 ..
 
@@ -1596,7 +1596,7 @@ UnpicklingError instead of crashing.
 .. section: Library
 
 Avoid infinite loop when reading specially crafted TAR files using the
-tarfile module (CVE-2019-20907).
+tarfile module (:cve:`2019-20907`).
 
 ..
 

--- a/Misc/NEWS.d/3.10.0a7.rst
+++ b/Misc/NEWS.d/3.10.0a7.rst
@@ -4,7 +4,7 @@
 .. release date: 2021-04-05
 .. section: Security
 
-CVE-2021-3426: Remove the ``getfile`` feature of the :mod:`pydoc` module
+:cve:`2021-3426`: Remove the ``getfile`` feature of the :mod:`pydoc` module
 which could be abused to read arbitrary files on the disk (directory
 traversal vulnerability). Moreover, even source code of Python modules can
 contain sensitive data like passwords. Vulnerability reported by David

--- a/Misc/NEWS.d/3.11.0a1.rst
+++ b/Misc/NEWS.d/3.11.0a1.rst
@@ -38,7 +38,7 @@ significant performance overhead when loading from ``.pyc`` files.
 .. section: Security
 
 Update the vendored copy of libexpat to 2.4.1 (from 2.2.8) to get the fix
-for the CVE-2013-0340 "Billion Laughs" vulnerability. This copy is most used
+for the :cve:`2013-0340` "Billion Laughs" vulnerability. This copy is most used
 on Windows and macOS.
 
 ..

--- a/Misc/NEWS.d/3.11.0a7.rst
+++ b/Misc/NEWS.d/3.11.0a7.rst
@@ -1421,7 +1421,7 @@ Patch by Victor Stinner.
 .. nonce: IB0XL4
 .. section: Windows
 
-Update ``zlib`` to v1.2.12 to resolve CVE-2018-25032.
+Update ``zlib`` to v1.2.12 to resolve :cve:`2018-25032`.
 
 ..
 
@@ -1472,8 +1472,8 @@ Update Windows installer to use SQLite 3.38.1.
 .. nonce: SPrGS9
 .. section: Windows
 
-Update bzip2 to 1.0.8 in Windows builds to mitigate CVE-2016-3189 and
-CVE-2019-12900
+Update bzip2 to 1.0.8 in Windows builds to mitigate :cve:`2016-3189` and
+:cve:`2019-12900`.
 
 ..
 
@@ -1482,7 +1482,7 @@ CVE-2019-12900
 .. nonce: Ufd4tG
 .. section: Windows
 
-Prevent CVE-2022-26488 by ensuring the Add to PATH option in the Windows
+Prevent :cve:`2022-26488` by ensuring the Add to PATH option in the Windows
 installer uses the correct path when being repaired.
 
 ..

--- a/Misc/NEWS.d/3.12.0a1.rst
+++ b/Misc/NEWS.d/3.12.0a1.rst
@@ -3200,9 +3200,8 @@ Remove the :func:`ssl.wrap_socket` function, deprecated in Python 3.7:
 instead, create a :class:`ssl.SSLContext` object and call its
 :class:`ssl.SSLContext.wrap_socket` method. Any package that still uses
 :func:`ssl.wrap_socket` is broken and insecure. The function neither sends a
-SNI TLS extension nor validates server hostname. Code is subject to `CWE-295
-<https://cwe.mitre.org/data/definitions/295.html>`_: Improper Certificate
-Validation. Patch by Victor Stinner.
+SNI TLS extension nor validates server hostname. Code is subject to :cwe:`295`
+Improper Certificate Validation. Patch by Victor Stinner.
 
 ..
 

--- a/Misc/NEWS.d/3.12.0a1.rst
+++ b/Misc/NEWS.d/3.12.0a1.rst
@@ -29,8 +29,7 @@ process. This was a potential privilege escalation. Filesystem based socket
 permissions restrict this to the *forkserver* process user as was the
 default in Python 3.8 and earlier.
 
-This prevents Linux `CVE-2022-42919
-<https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-42919>`_.
+This prevents Linux :cve:`2022-42919`.
 
 ..
 
@@ -4403,8 +4402,7 @@ Remove extra row
 .. section: Documentation
 
 Deprecated tools ``make suspicious`` and ``rstlint.py`` are now removed.
-They have been replaced by `spinx-lint
-<https://pypi.org/project/sphinx-lint/>`_.
+They have been replaced by :pypi:`sphinx-lint`.
 
 ..
 

--- a/Misc/NEWS.d/3.12.0a2.rst
+++ b/Misc/NEWS.d/3.12.0a2.rst
@@ -968,7 +968,7 @@ if :option:`--with-system-expat` is passed to :program:`configure`.
 .. nonce: 0f6e_N
 .. section: Windows
 
-Update Windows builds to zlib v1.2.13.  v1.2.12 has CVE-2022-37434, but the
+Update Windows builds to zlib v1.2.13.  v1.2.12 has :cve:`2022-37434`, but the
 vulnerable ``inflateGetHeader`` API is not used by Python.
 
 ..

--- a/Misc/NEWS.d/3.12.0a6.rst
+++ b/Misc/NEWS.d/3.12.0a6.rst
@@ -15,7 +15,7 @@ from the HACL* project.
 .. section: Security
 
 Updated the OpenSSL version used in Windows and macOS binary release builds
-to 1.1.1t to address CVE-2023-0286, CVE-2022-4303, and CVE-2022-4303 per
+to 1.1.1t to address :cve:`2023-0286`, :cve:`2022-4303`, and :cve:`2022-4303` per
 `the OpenSSL 2023-02-07 security advisory
 <https://www.openssl.org/news/secadv/20230207.txt>`_.
 

--- a/Misc/NEWS.d/3.12.0b1.rst
+++ b/Misc/NEWS.d/3.12.0b1.rst
@@ -37,7 +37,7 @@ or lacks SHA3.
 
 :func:`urllib.parse.urlsplit` now strips leading C0 control and space
 characters following the specification for URLs defined by WHATWG in
-response to CVE-2023-24329. Patch by Illia Volochii.
+response to :cve:`2023-24329`. Patch by Illia Volochii.
 
 ..
 

--- a/Misc/NEWS.d/3.13.0a1.rst
+++ b/Misc/NEWS.d/3.13.0a1.rst
@@ -8,9 +8,7 @@ Fixed an issue where instances of :class:`ssl.SSLSocket` were vulnerable to
 a bypass of the TLS handshake and included protections (like certificate
 verification) and treating sent unencrypted data as if it were
 post-handshake TLS encrypted data.  Security issue reported as
-`CVE-2023-40217
-<https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-40217>`_ by Aapo
-Oksman. Patch by Gregory P. Smith.
+:cve:`2023-40217` by Aapo Oksman. Patch by Gregory P. Smith.
 
 ..
 
@@ -4184,8 +4182,7 @@ Hugo van Kemenade.
 .. section: Library
 
 :pep:`594`: Remove the :mod:`!spwd` module, deprecated in Python 3.11: the
-`python-pam project <https://pypi.org/project/python-pam/>`_ can be used
-instead. Patch by Victor Stinner.
+:pypi:`python-pam` project can be used instead. Patch by Victor Stinner.
 
 ..
 

--- a/Misc/NEWS.d/3.13.0a3.rst
+++ b/Misc/NEWS.d/3.13.0a3.rst
@@ -1551,7 +1551,7 @@ optional *strict* parameter to these two functions: use ``strict=False`` to
 get the old behavior, accept malformed inputs. ``getattr(email.utils,
 'supports_strict_parsing', False)`` can be use to check if the *strict*
 paramater is available. Patch by Thomas Dwyer and Victor Stinner to improve
-the CVE-2023-27043 fix.
+the :cve:`2023-27043` fix.
 
 ..
 

--- a/Misc/NEWS.d/3.13.0a5.rst
+++ b/Misc/NEWS.d/3.13.0a5.rst
@@ -4,7 +4,7 @@
 .. release date: 2024-03-12
 .. section: Security
 
-Allow controlling Expat >=2.6.0 reparse deferral (CVE-2023-52425) by adding
+Allow controlling Expat >=2.6.0 reparse deferral (:cve:`2023-52425`) by adding
 five new methods:
 
 * :meth:`xml.etree.ElementTree.XMLParser.flush`
@@ -875,7 +875,7 @@ Add 'default' and 'version' help text for localization in argparse.
 .. nonce: fb9a0R
 .. section: Documentation
 
-Document CVE-2023-52425 of Expat <2.6.0 under "XML vulnerabilities".
+Document :cve:`2023-52425` of Expat <2.6.0 under "XML vulnerabilities".
 
 ..
 

--- a/Misc/NEWS.d/3.5.0a1.rst
+++ b/Misc/NEWS.d/3.5.0a1.rst
@@ -1284,7 +1284,7 @@ Add function :func:`sys.is_finalizing` to know about interpreter shutdown.
 .. section: Library
 
 Add a default limit for the amount of data xmlrpclib.gzip_decode will
-return. This resolves CVE-2013-1753.
+return. This resolves :cve:`2013-1753`.
 
 ..
 
@@ -4030,7 +4030,7 @@ unittest.mock.MagicMock now supports division. Patch by Johannes Baiter.
 .. section: Library
 
 Fix arbitrary memory access in JSONDecoder.raw_decode with a negative second
-parameter. Bug reported by Guido Vranken. (See also: CVE-2014-4616)
+parameter. Bug reported by Guido Vranken. (See also: :cve:`2014-4616`)
 
 ..
 

--- a/Misc/NEWS.d/3.5.2rc1.rst
+++ b/Misc/NEWS.d/3.5.2rc1.rst
@@ -5,7 +5,7 @@
 .. original section: Library
 .. section: Security
 
-Update expat to 2.1.1, fixes CVE-2015-1283.
+Update expat to 2.1.1, fixes :cve:`2015-1283`.
 
 ..
 
@@ -15,8 +15,8 @@ Update expat to 2.1.1, fixes CVE-2015-1283.
 .. original section: Library
 .. section: Security
 
-Fix TLS stripping vulnerability in smtplib, CVE-2016-0772. Reported by Team
-Oststrom
+Fix TLS stripping vulnerability in smtplib, :cve:`2016-0772`. Reported by Team
+Oststrom.
 
 ..
 

--- a/Misc/NEWS.d/3.5.3rc1.rst
+++ b/Misc/NEWS.d/3.5.3rc1.rst
@@ -1048,7 +1048,7 @@ certs.
 .. section: Library
 
 Remove 3DES from ssl module's default cipher list to counter measure sweet32
-attack (CVE-2016-2183).
+attack (:cve:`2016-2183`).
 
 ..
 
@@ -1251,7 +1251,7 @@ Fix possible integer overflow in the _csv module for large record lengths.
 .. nonce: OnuO9s
 .. section: Library
 
-Prevent HTTPoxy attack (CVE-2016-1000110). Ignore the HTTP_PROXY variable
+Prevent HTTPoxy attack (:cve:`2016-1000110`). Ignore the HTTP_PROXY variable
 when REQUEST_METHOD environment is set, which indicates that the script is
 in CGI mode.
 

--- a/Misc/NEWS.d/3.5.4rc1.rst
+++ b/Misc/NEWS.d/3.5.4rc1.rst
@@ -17,10 +17,10 @@ passing other environment variables and command arguments.
 .. section: Security
 
 Upgrade expat copy from 2.2.0 to 2.2.1 to get fixes of multiple security
-vulnerabilities including: CVE-2017-9233 (External entity infinite loop
-DoS), CVE-2016-9063 (Integer overflow, re-fix), CVE-2016-0718 (Fix
-regression bugs from 2.2.0's fix to CVE-2016-0718) and CVE-2012-0876
-(Counter hash flooding with SipHash). Note: the CVE-2016-5300 (Use
+vulnerabilities including: :cve:`2017-9233` (External entity infinite loop
+DoS), :cve:`2016-9063` (Integer overflow, re-fix), :cve:`2016-0718` (Fix
+regression bugs from 2.2.0's fix to :cve:`2016-0718`) and :cve:`2012-0876`
+(Counter hash flooding with SipHash). Note: the :cve:`2016-5300` (Use
 os-specific entropy sources like getrandom) doesn't impact Python, since Python
 already gets entropy from the OS to set the expat secret using
 ``XML_SetHashSalt()``.
@@ -46,8 +46,8 @@ authentication (``login@host``).
 .. original section: Library
 .. section: Security
 
-Update expat copy from 2.1.1 to 2.2.0 to get fixes of CVE-2016-0718 and
-CVE-2016-4472. See https://sourceforge.net/p/expat/bugs/537/ for more
+Update expat copy from 2.1.1 to 2.2.0 to get fixes of :cve:`2016-0718` and
+:cve:`2016-4472`. See https://sourceforge.net/p/expat/bugs/537/ for more
 information.
 
 ..

--- a/Misc/NEWS.d/3.5.5rc1.rst
+++ b/Misc/NEWS.d/3.5.5rc1.rst
@@ -24,7 +24,7 @@ also be affected)
 .. nonce: Fd8kId
 .. section: Security
 
-Fixed possible integer overflow in PyBytes_DecodeEscape, CVE-2017-1000158.
+Fixed possible integer overflow in PyBytes_DecodeEscape, :cve:`2017-1000158`.
 Original patch by Jay Bosamiya; rebased to Python 3 by Miro Hrončok.
 
 ..

--- a/Misc/NEWS.d/3.6.0a2.rst
+++ b/Misc/NEWS.d/3.6.0a2.rst
@@ -5,7 +5,7 @@
 .. original section: Library
 .. section: Security
 
-Update expat to 2.1.1, fixes CVE-2015-1283.
+Update expat to 2.1.1, fixes :cve:`2015-1283`.
 
 ..
 
@@ -15,7 +15,7 @@ Update expat to 2.1.1, fixes CVE-2015-1283.
 .. original section: Library
 .. section: Security
 
-Fix TLS stripping vulnerability in smtplib, CVE-2016-0772. Reported by Team
+Fix TLS stripping vulnerability in smtplib, :cve:`2016-0772`. Reported by Team
 Oststrom.
 
 ..

--- a/Misc/NEWS.d/3.6.0a4.rst
+++ b/Misc/NEWS.d/3.6.0a4.rst
@@ -359,7 +359,7 @@ Fix possible integer overflow in the _csv module for large record lengths.
 .. nonce: OnuO9s
 .. section: Library
 
-Prevent HTTPoxy attack (CVE-2016-1000110). Ignore the HTTP_PROXY variable
+Prevent HTTPoxy attack (:cve:`2016-1000110`). Ignore the HTTP_PROXY variable
 when REQUEST_METHOD environment is set, which indicates that the script is
 in CGI mode.
 

--- a/Misc/NEWS.d/3.6.0b1.rst
+++ b/Misc/NEWS.d/3.6.0b1.rst
@@ -949,7 +949,7 @@ Add scrypt (password-based key derivation function) to hashlib module
 .. section: Library
 
 Remove 3DES from ssl module's default cipher list to counter measure sweet32
-attack (CVE-2016-2183).
+attack (:cve:`2016-2183`).
 
 ..
 

--- a/Misc/NEWS.d/3.6.2rc1.rst
+++ b/Misc/NEWS.d/3.6.2rc1.rst
@@ -5,8 +5,8 @@
 .. original section: Library
 .. section: Security
 
-Update expat copy from 2.1.1 to 2.2.0 to get fixes of CVE-2016-0718 and
-CVE-2016-4472. See https://sourceforge.net/p/expat/bugs/537/ for more
+Update expat copy from 2.1.1 to 2.2.0 to get fixes of :cve:`2016-0718` and
+:cve:`2016-4472`. See https://sourceforge.net/p/expat/bugs/537/ for more
 information.
 
 ..

--- a/Misc/NEWS.d/3.6.2rc2.rst
+++ b/Misc/NEWS.d/3.6.2rc2.rst
@@ -17,10 +17,10 @@ passing other environment variables and command arguments.
 .. section: Security
 
 Upgrade expat copy from 2.2.0 to 2.2.1 to get fixes of multiple security
-vulnerabilities including: CVE-2017-9233 (External entity infinite loop
-DoS), CVE-2016-9063 (Integer overflow, re-fix), CVE-2016-0718 (Fix
-regression bugs from 2.2.0's fix to CVE-2016-0718) and CVE-2012-0876
-(Counter hash flooding with SipHash). Note: the CVE-2016-5300 (Use
+vulnerabilities including: :cve:`2017-9233` (External entity infinite loop
+DoS), :cve:`2016-9063` (Integer overflow, re-fix), :cve:`2016-0718` (Fix
+regression bugs from 2.2.0's fix to :cve:`2016-0718`) and :cve:`2012-0876`
+(Counter hash flooding with SipHash). Note: the :cve:`2016-5300` (Use
 os-specific entropy sources like getrandom) doesn't impact Python, since
 Python already gets entropy from the OS to set the expat secret using
 ``XML_SetHashSalt()``.

--- a/Misc/NEWS.d/3.6.5rc1.rst
+++ b/Misc/NEWS.d/3.6.5rc1.rst
@@ -15,7 +15,7 @@ Minimal fix to prevent buffer overrun in os.symlink on Windows
 
 Regexes in difflib and poplib were vulnerable to catastrophic backtracking.
 These regexes formed potential DOS vectors (REDOS). They have been
-refactored. This resolves CVE-2018-1060 and CVE-2018-1061. Patch by Jamie
+refactored. This resolves :cve:`2018-1060` and :cve:`2018-1061`. Patch by Jamie
 Davis.
 
 ..

--- a/Misc/NEWS.d/3.7.0a1.rst
+++ b/Misc/NEWS.d/3.7.0a1.rst
@@ -46,10 +46,10 @@ passing other environment variables and command arguments.
 .. section: Security
 
 Upgrade expat copy from 2.2.0 to 2.2.1 to get fixes of multiple security
-vulnerabilities including: CVE-2017-9233 (External entity infinite loop
-DoS), CVE-2016-9063 (Integer overflow, re-fix), CVE-2016-0718 (Fix
-regression bugs from 2.2.0's fix to CVE-2016-0718) and CVE-2012-0876
-(Counter hash flooding with SipHash). Note: the CVE-2016-5300 (Use
+vulnerabilities including: :cve:`2017-9233` (External entity infinite loop
+DoS), :cve:`2016-9063` (Integer overflow, re-fix), :cve:`2016-0718` (Fix
+regression bugs from 2.2.0's fix to :cve:`2016-0718`) and :cve:`2012-0876`
+(Counter hash flooding with SipHash). Note: the :cve:`2016-5300` (Use
 os-specific entropy sources like getrandom) doesn't impact Python, since Python
 already gets entropy from the OS to set the expat secret using
 ``XML_SetHashSalt()``.
@@ -75,8 +75,8 @@ authentication (``login@host``).
 .. original section: Library
 .. section: Security
 
-Update expat copy from 2.1.1 to 2.2.0 to get fixes of CVE-2016-0718 and
-CVE-2016-4472. See https://sourceforge.net/p/expat/bugs/537/ for more
+Update expat copy from 2.1.1 to 2.2.0 to get fixes of :cve:`2016-0718` and
+:cve:`2016-4472`. See https://sourceforge.net/p/expat/bugs/537/ for more
 information.
 
 ..

--- a/Misc/NEWS.d/3.7.0b3.rst
+++ b/Misc/NEWS.d/3.7.0b3.rst
@@ -4,7 +4,7 @@
 .. release date: 2018-03-29
 .. section: Security
 
-Harden ssl module against LibreSSL CVE-2018-8970.
+Harden ssl module against LibreSSL :cve:`2018-8970`.
 X509_VERIFY_PARAM_set1_host() is called with an explicit namelen. A new test
 ensures that NULL bytes are not allowed.
 
@@ -26,7 +26,7 @@ Minimal fix to prevent buffer overrun in os.symlink on Windows
 
 Regexes in difflib and poplib were vulnerable to catastrophic backtracking.
 These regexes formed potential DOS vectors (REDOS). They have been
-refactored. This resolves CVE-2018-1060 and CVE-2018-1061. Patch by Jamie
+refactored. This resolves :cve:`2018-1060` and :cve:`2018-1061`. Patch by Jamie
 Davis.
 
 ..

--- a/Misc/NEWS.d/3.8.0a1.rst
+++ b/Misc/NEWS.d/3.8.0a1.rst
@@ -4,7 +4,7 @@
 .. release date: 2019-02-03
 .. section: Security
 
-[CVE-2019-5010] Fix a NULL pointer deref in ssl module. The cert parser did
+:cve:`2019-5010`: Fix a NULL pointer deref in ssl module. The cert parser did
 not handle CRL distribution points with empty DP or URI correctly. A
 malicious or buggy certificate can result into segfault. Vulnerability
 (TALOS-2018-0758) reported by Colin Read and Nicolas Edet of Cisco.
@@ -50,7 +50,7 @@ files or create network connections.
 .. nonce: Ua9jMv
 .. section: Security
 
-CVE-2018-14647: The C accelerated _elementtree module now initializes hash
+:cve:`2018-14647`: The C accelerated _elementtree module now initializes hash
 randomization salt from _Py_HashSecret instead of libexpat's default CSPRNG.
 
 ..
@@ -89,7 +89,7 @@ Fixed thread-safety of error handling in _ssl.
 .. nonce: TzSN4x
 .. section: Security
 
-Harden ssl module against LibreSSL CVE-2018-8970.
+Harden ssl module against LibreSSL :cve:`2018-8970`.
 X509_VERIFY_PARAM_set1_host() is called with an explicit namelen. A new test
 ensures that NULL bytes are not allowed.
 
@@ -111,7 +111,7 @@ Minimal fix to prevent buffer overrun in os.symlink on Windows
 
 Regexes in difflib and poplib were vulnerable to catastrophic backtracking.
 These regexes formed potential DOS vectors (REDOS). They have been
-refactored. This resolves CVE-2018-1060 and CVE-2018-1061. Patch by Jamie
+refactored. This resolves :cve:`2018-1060` and :cve:`2018-1061`. Patch by Jamie
 Davis.
 
 ..

--- a/Misc/NEWS.d/3.8.0a4.rst
+++ b/Misc/NEWS.d/3.8.0a4.rst
@@ -13,7 +13,7 @@ Fixes mishandling of pre-normalization characters in urlsplit().
 .. nonce: 51E-DA
 .. section: Security
 
-Address CVE-2019-9740 by disallowing URL paths with embedded whitespace or
+Address :cve:`2019-9740` by disallowing URL paths with embedded whitespace or
 control characters through into the underlying http client request.  Such
 potentially malicious header injection URLs now cause an
 http.client.InvalidURL exception to be raised.

--- a/Misc/NEWS.d/3.8.0b1.rst
+++ b/Misc/NEWS.d/3.8.0b1.rst
@@ -4,7 +4,7 @@
 .. release date: 2019-06-04
 .. section: Security
 
-CVE-2019-9948: Avoid file reading by disallowing ``local-file://`` and
+:cve:`2019-9948`: Avoid file reading by disallowing ``local-file://`` and
 ``local_file://`` URL schemes in ``URLopener().open()`` and
 ``URLopener().retrieve()`` of :mod:`urllib.request`.
 

--- a/Misc/NEWS.d/3.9.0a1.rst
+++ b/Misc/NEWS.d/3.9.0a1.rst
@@ -44,7 +44,7 @@ rendering the document page as HTML. (Contributed by Donghee Na in
 .. section: Security
 
 Update vendorized expat library version to 2.2.8, which resolves
-CVE-2019-15903.
+:cve:`2019-15903`.
 
 ..
 

--- a/Misc/NEWS.d/3.9.0a5.rst
+++ b/Misc/NEWS.d/3.9.0a5.rst
@@ -5,7 +5,7 @@
 .. section: Security
 
 Disallow control characters in hostnames in http.client, addressing
-CVE-2019-18348. Such potentially malicious header injection URLs now cause a
+:cve:`2019-18348`. Such potentially malicious header injection URLs now cause a
 InvalidURL to be raised.
 
 ..

--- a/Misc/NEWS.d/3.9.0a6.rst
+++ b/Misc/NEWS.d/3.9.0a6.rst
@@ -23,7 +23,7 @@ header injection attacks.
 .. nonce: B299Yq
 .. section: Security
 
-CVE-2020-8492: The :class:`~urllib.request.AbstractBasicAuthHandler` class
+:cve:`2020-8492`: The :class:`~urllib.request.AbstractBasicAuthHandler` class
 of the :mod:`urllib.request` module uses an inefficient regular expression
 which can be exploited by an attacker to cause a denial of service. Fix the
 regex to prevent the catastrophic backtracking. Vulnerability reported by


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

The `extlinks` Sphinx module (since Sphinx 1.0) allows us to easily create roles by defining a dict mapping to `conf.py`:

* https://www.sphinx-doc.org/en/master/usage/extensions/extlinks.html

We can use this to replace the custom `:source:` role defined in `Doc/tools/extension/pyspecific.py` with a single dict entry.

It's also useful to add handy roles for CVEs, CWEs, and PyPI project links. If the URL scheme changes in the future (as has happened with PyPI, and others when going http->https) we can update all the links by only changing one line of config.

This PR also adds links to a number previously unlinked CVE IDs.

I'll add these new roles to the devguide after merge:

* https://devguide.python.org/documentation/markup/#roles

---

We could also replace the custom `:gh:` and `:issue:` roles, but they perform useful validation (no BPO issues numbered 47261 - 400000, no GitHub issues < 32426).


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--117850.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->