### PR TITLE
GH-117841: Speed up `pathlib.Path.glob()` on Windows by using `lexists()`

### DIFF
--- a/Lib/glob.py
+++ b/Lib/glob.py
@@ -510,7 +510,7 @@ class _Globber:
         """
         if exists:
             # Optimization: this path is already known to exist, e.g. because
-            # it was returned from os.scandir(), so we skip calling lstat().
+            # it was returned from os.scandir(), so we skip calling lexists().
             yield path
         elif self.lexists(path):
             yield path

--- a/Lib/glob.py
+++ b/Lib/glob.py
@@ -339,7 +339,7 @@ class _Globber:
 
     # Low-level methods
 
-    lstat = staticmethod(os.lstat)
+    lexists = staticmethod(os.path.lexists)
     scandir = staticmethod(os.scandir)
     parse_entry = operator.attrgetter('path')
     concat_path = operator.add
@@ -512,12 +512,8 @@ class _Globber:
             # Optimization: this path is already known to exist, e.g. because
             # it was returned from os.scandir(), so we skip calling lstat().
             yield path
-        else:
-            try:
-                self.lstat(path)
-                yield path
-            except OSError:
-                pass
+        elif self.lexists(path):
+            yield path
 
     @classmethod
     def walk(cls, root, top_down, on_error, follow_symlinks):

--- a/Lib/pathlib/_abc.py
+++ b/Lib/pathlib/_abc.py
@@ -44,8 +44,16 @@ def _is_case_sensitive(parser):
 
 
 class Globber(glob._Globber):
-    lstat = operator.methodcaller('lstat')
     add_slash = operator.methodcaller('joinpath', '')
+
+    @staticmethod
+    def lexists(path):
+        # Emulate os.path.lexists(), which never raises OSError.
+        try:
+            path.stat(follow_symlinks=False)
+        except (OSError, ValueError):
+            return False
+        return True
 
     @staticmethod
     def scandir(path):

--- a/Misc/NEWS.d/next/Library/2024-04-13-22-23-48.gh-issue-117842.ZGoQqd.rst
+++ b/Misc/NEWS.d/next/Library/2024-04-13-22-23-48.gh-issue-117842.ZGoQqd.rst
@@ -1,0 +1,2 @@
+Speed up :meth:`pathlib.Path.glob` on Windows by using fast implementation
+of :func:`os.path.lexists`.


### PR DESCRIPTION
Use `os.path.lexists()` rather than `os.lstat()` to test whether paths exist. This is equivalent on POSIX, but faster on Windows.

Depends on #117842


<!-- gh-issue-number: gh-117841 -->
* Issue: gh-117841
<!-- /gh-issue-number -->
