### PR TITLE
Autoconf: aarch64-apple-darwin/clang is now a tier 1 platform

### DIFF
--- a/configure
+++ b/configure
@@ -6979,14 +6979,14 @@ case $host/$ac_cv_cc_name in #(
     PY_SUPPORT_TIER=1 ;; #(
     x86_64-apple-darwin*/clang) :
     PY_SUPPORT_TIER=1 ;; #(
+    aarch64-apple-darwin*/clang) :
+    PY_SUPPORT_TIER=1 ;; #(
     i686-pc-windows-msvc/msvc) :
     PY_SUPPORT_TIER=1 ;; #(
     x86_64-pc-windows-msvc/msvc) :
     PY_SUPPORT_TIER=1 ;; #(
 
-  aarch64-apple-darwin*/clang) :
-    PY_SUPPORT_TIER=2 ;; #(
-    aarch64-*-linux-gnu/gcc) :
+  aarch64-*-linux-gnu/gcc) :
     PY_SUPPORT_TIER=2 ;; #(
     aarch64-*-linux-gnu/clang) :
     PY_SUPPORT_TIER=2 ;; #(

--- a/configure.ac
+++ b/configure.ac
@@ -1131,10 +1131,10 @@ AC_MSG_CHECKING([for PEP 11 support tier])
 AS_CASE([$host/$ac_cv_cc_name],
   [x86_64-*-linux-gnu/gcc],          [PY_SUPPORT_TIER=1], dnl Linux on AMD64, any vendor, glibc, gcc
   [x86_64-apple-darwin*/clang],      [PY_SUPPORT_TIER=1], dnl macOS on Intel, any version
+  [aarch64-apple-darwin*/clang],     [PY_SUPPORT_TIER=1], dnl macOS on M1, any version
   [i686-pc-windows-msvc/msvc],       [PY_SUPPORT_TIER=1], dnl 32bit Windows on Intel, MSVC
   [x86_64-pc-windows-msvc/msvc],     [PY_SUPPORT_TIER=1], dnl 64bit Windows on AMD64, MSVC
 
-  [aarch64-apple-darwin*/clang],     [PY_SUPPORT_TIER=2], dnl macOS on M1, any version
   [aarch64-*-linux-gnu/gcc],         [PY_SUPPORT_TIER=2], dnl Linux ARM64, glibc, gcc+clang
   [aarch64-*-linux-gnu/clang],       [PY_SUPPORT_TIER=2],
   [powerpc64le-*-linux-gnu/gcc],     [PY_SUPPORT_TIER=2], dnl Linux on PPC64 little endian, glibc, gcc


### PR DESCRIPTION
See also python/pep#3705
