### PR TITLE
docs: typo in 3.13 release notes

### DIFF
--- a/Doc/whatsnew/3.13.rst
+++ b/Doc/whatsnew/3.13.rst
@@ -407,7 +407,7 @@ gc
 --
 
 * The cyclic garbage collector is now incremental, which changes the meanings
-  of the results of :meth:`gc.get_threshold` and :meth:`gc.get_threshold` as
+  of the results of :meth:`gc.get_threshold` and :meth:`gc.set_threshold` as
   well as :meth:`gc.get_count` and :meth:`gc.get_stats`.
 * :meth:`gc.get_threshold` returns a three-tuple for backwards compatibility,
   the first value is the threshold for young collections, as before, the second


### PR DESCRIPTION
In the 3.13 release notes, `gc.get_threshold` is pointed to twice in this paragraph, rather than pointing to `gc.set_threshold` as well.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--117866.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->