### PR TITLE
gh-117845: Detect libedit hook function signature in configure

### DIFF
--- a/Misc/NEWS.d/next/Build/2024-04-15-08-35-06.gh-issue-117845.IowzyW.rst
+++ b/Misc/NEWS.d/next/Build/2024-04-15-08-35-06.gh-issue-117845.IowzyW.rst
@@ -1,1 +1,1 @@
-Fixed function pointer type mismatch when building the readline module against recent libedit versions.
+Fix building against recent libedit versions by detecting readline hook signatures in :program:`configure`.

--- a/Misc/NEWS.d/next/Build/2024-04-15-08-35-06.gh-issue-117845.IowzyW.rst
+++ b/Misc/NEWS.d/next/Build/2024-04-15-08-35-06.gh-issue-117845.IowzyW.rst
@@ -1,0 +1,1 @@
+Fixed function pointer type mismatch when building the readline module against recent libedit versions.

--- a/Modules/readline.c
+++ b/Modules/readline.c
@@ -1041,7 +1041,7 @@ on_hook(PyObject *func)
 }
 
 static int
-#if defined(_RL_FUNCTION_TYPEDEF) || !defined(RL_STARTUP_HOOK_TAKES_ARGS)
+#if defined(_RL_FUNCTION_TYPEDEF) || !defined(Py_RL_STARTUP_HOOK_TAKES_ARGS)
 on_startup_hook(void)
 #else
 on_startup_hook(const char *Py_UNUSED(text), int Py_UNUSED(state))
@@ -1061,7 +1061,7 @@ on_startup_hook(const char *Py_UNUSED(text), int Py_UNUSED(state))
 
 #ifdef HAVE_RL_PRE_INPUT_HOOK
 static int
-#if defined(_RL_FUNCTION_TYPEDEF) || !defined(RL_STARTUP_HOOK_TAKES_ARGS)
+#if defined(_RL_FUNCTION_TYPEDEF) || !defined(Py_RL_STARTUP_HOOK_TAKES_ARGS)
 on_pre_input_hook(void)
 #else
 on_pre_input_hook(const char *Py_UNUSED(text), int Py_UNUSED(state))

--- a/Modules/readline.c
+++ b/Modules/readline.c
@@ -1041,7 +1041,7 @@ on_hook(PyObject *func)
 }
 
 static int
-#if defined(_RL_FUNCTION_TYPEDEF)
+#if defined(_RL_FUNCTION_TYPEDEF) || !defined(RL_STARTUP_HOOK_TAKES_ARGS)
 on_startup_hook(void)
 #else
 on_startup_hook(const char *Py_UNUSED(text), int Py_UNUSED(state))
@@ -1061,7 +1061,7 @@ on_startup_hook(const char *Py_UNUSED(text), int Py_UNUSED(state))
 
 #ifdef HAVE_RL_PRE_INPUT_HOOK
 static int
-#if defined(_RL_FUNCTION_TYPEDEF)
+#if defined(_RL_FUNCTION_TYPEDEF) || !defined(RL_STARTUP_HOOK_TAKES_ARGS)
 on_pre_input_hook(void)
 #else
 on_pre_input_hook(const char *Py_UNUSED(text), int Py_UNUSED(state))

--- a/configure
+++ b/configure
@@ -25367,6 +25367,57 @@ printf "%s\n" "#define HAVE_RL_COMPDISP_FUNC_T 1" >>confdefs.h
 fi
 
 
+    # Some editline versions declare rl_startup_hook as taking no args, others
+    # declare it as taking 2.
+    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking if rl_startup_hook takes arguments" >&5
+printf %s "checking if rl_startup_hook takes arguments... " >&6; }
+if test ${ac_cv_readline_rl_startup_hook_takes_args+y}
+then :
+  printf %s "(cached) " >&6
+else case e in #(
+  e)
+        cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+      #include <stdio.h> /* Must be first for Gnu Readline */
+      #ifdef WITH_EDITLINE
+      # include <editline/readline.h>
+      #else
+      # include <readline/readline.h>
+      # include <readline/history.h>
+      #endif
+
+                extern int test_hook_func(const char *text, int state);
+int
+main (void)
+{
+rl_startup_hook=test_hook_func;
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"
+then :
+  ac_cv_readline_rl_startup_hook_takes_args=yes
+else case e in #(
+  e) ac_cv_readline_rl_startup_hook_takes_args=no
+         ;;
+esac
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
+     ;;
+esac
+fi
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_readline_rl_startup_hook_takes_args" >&5
+printf "%s\n" "$ac_cv_readline_rl_startup_hook_takes_args" >&6; }
+    if test "x$ac_cv_readline_rl_startup_hook_takes_args" = xyes
+then :
+
+
+printf "%s\n" "#define RL_STARTUP_HOOK_TAKES_ARGS 1" >>confdefs.h
+
+
+fi
 
 
 CFLAGS=$save_CFLAGS

--- a/configure
+++ b/configure
@@ -25374,8 +25374,8 @@ printf %s "checking if rl_startup_hook takes arguments... " >&6; }
 if test ${ac_cv_readline_rl_startup_hook_takes_args+y}
 then :
   printf %s "(cached) " >&6
-else case e in #(
-  e)
+else $as_nop
+
         cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
@@ -25399,14 +25399,12 @@ _ACEOF
 if ac_fn_c_try_compile "$LINENO"
 then :
   ac_cv_readline_rl_startup_hook_takes_args=yes
-else case e in #(
-  e) ac_cv_readline_rl_startup_hook_takes_args=no
-         ;;
-esac
+else $as_nop
+  ac_cv_readline_rl_startup_hook_takes_args=no
+
 fi
 rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
-     ;;
-esac
+
 fi
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_readline_rl_startup_hook_takes_args" >&5
 printf "%s\n" "$ac_cv_readline_rl_startup_hook_takes_args" >&6; }
@@ -25414,10 +25412,11 @@ printf "%s\n" "$ac_cv_readline_rl_startup_hook_takes_args" >&6; }
 then :
 
 
-printf "%s\n" "#define RL_STARTUP_HOOK_TAKES_ARGS 1" >>confdefs.h
+printf "%s\n" "#define Py_RL_STARTUP_HOOK_TAKES_ARGS 1" >>confdefs.h
 
 
 fi
+
 
 
 CFLAGS=$save_CFLAGS

--- a/configure.ac
+++ b/configure.ac
@@ -6340,6 +6340,21 @@ AS_VAR_IF([with_readline], [no], [
     # in readline as well as newer editline (April 2023)
     AC_CHECK_TYPES([rl_compdisp_func_t], [], [], [readline_includes])
 
+    # Some editline versions declare rl_startup_hook as taking no args, others
+    # declare it as taking 2.
+    AC_CACHE_CHECK([if rl_startup_hook takes arguments], [ac_cv_readline_rl_startup_hook_takes_args], [
+        AC_COMPILE_IFELSE(
+            [AC_LANG_PROGRAM([readline_includes]
+                [[extern int test_hook_func(const char *text, int state);]],
+                [[rl_startup_hook=test_hook_func;]])],
+            [ac_cv_readline_rl_startup_hook_takes_args=yes],
+            [ac_cv_readline_rl_startup_hook_takes_args=no]
+        )
+    ])
+    AS_VAR_IF([ac_cv_readline_rl_startup_hook_takes_args], [yes], [
+      AC_DEFINE([RL_STARTUP_HOOK_TAKES_ARGS], [1], [Define if rl_startup_hook takes arguments])
+    ])
+
     m4_undefine([readline_includes])
   ])dnl WITH_SAVE_ENV()
 ])

--- a/configure.ac
+++ b/configure.ac
@@ -6345,14 +6345,14 @@ AS_VAR_IF([with_readline], [no], [
     AC_CACHE_CHECK([if rl_startup_hook takes arguments], [ac_cv_readline_rl_startup_hook_takes_args], [
         AC_COMPILE_IFELSE(
             [AC_LANG_PROGRAM([readline_includes]
-                [[extern int test_hook_func(const char *text, int state);]],
-                [[rl_startup_hook=test_hook_func;]])],
+                [extern int test_hook_func(const char *text, int state);],
+                [rl_startup_hook=test_hook_func;])],
             [ac_cv_readline_rl_startup_hook_takes_args=yes],
             [ac_cv_readline_rl_startup_hook_takes_args=no]
         )
     ])
     AS_VAR_IF([ac_cv_readline_rl_startup_hook_takes_args], [yes], [
-      AC_DEFINE([RL_STARTUP_HOOK_TAKES_ARGS], [1], [Define if rl_startup_hook takes arguments])
+      AC_DEFINE([Py_RL_STARTUP_HOOK_TAKES_ARGS], [1], [Define if rl_startup_hook takes arguments])
     ])
 
     m4_undefine([readline_includes])

--- a/pyconfig.h.in
+++ b/pyconfig.h.in
@@ -1659,6 +1659,9 @@
    SipHash13: 3, externally defined: 0 */
 #undef Py_HASH_ALGORITHM
 
+/* Define if rl_startup_hook takes arguments */
+#undef Py_RL_STARTUP_HOOK_TAKES_ARGS
+
 /* Define if you want to enable internal statistics gathering. */
 #undef Py_STATS
 
@@ -1670,9 +1673,6 @@
 
 /* assume C89 semantics that RETSIGTYPE is always void */
 #undef RETSIGTYPE
-
-/* Define if rl_startup_hook takes arguments */
-#undef RL_STARTUP_HOOK_TAKES_ARGS
 
 /* Define if setpgrp() must be called as setpgrp(0, 0). */
 #undef SETPGRP_HAVE_ARG

--- a/pyconfig.h.in
+++ b/pyconfig.h.in
@@ -1671,6 +1671,9 @@
 /* assume C89 semantics that RETSIGTYPE is always void */
 #undef RETSIGTYPE
 
+/* Define if rl_startup_hook takes arguments */
+#undef RL_STARTUP_HOOK_TAKES_ARGS
+
 /* Define if setpgrp() must be called as setpgrp(0, 0). */
 #undef SETPGRP_HAVE_ARG
 


### PR DESCRIPTION
Older libedit versions (like Apple's) use a different type signature for `rl_startup_hook` and `rl_pre_input_hook`. Add a configure check to determine which one is accepted.


<!-- gh-issue-number: gh-117845 -->
* Issue: gh-117845
<!-- /gh-issue-number -->
