### PR TITLE
gh-117691: Add an appropriate stacklevel for PEP-706 tarfile deprecation warnings

### DIFF
--- a/Lib/tarfile.py
+++ b/Lib/tarfile.py
@@ -2247,7 +2247,7 @@ class TarFile(object):
                     'Python 3.14 will, by default, filter extracted tar '
                     + 'archives and reject files or modify their metadata. '
                     + 'Use the filter argument to control this behavior.',
-                    DeprecationWarning)
+                    DeprecationWarning, stacklevel=3)
                 return fully_trusted_filter
             if isinstance(filter, str):
                 raise TypeError(

--- a/Lib/test/test_tarfile.py
+++ b/Lib/test/test_tarfile.py
@@ -738,6 +738,31 @@ class MiscReadTestBase(CommonReadTest):
         finally:
             os_helper.rmtree(DIR)
 
+    def test_deprecation_if_no_filter_passed_to_extractall(self):
+        DIR = pathlib.Path(TEMPDIR) / "extractall"
+        with (
+            os_helper.temp_dir(DIR),
+            tarfile.open(tarname, encoding="iso8859-1") as tar
+        ):
+            directories = [t for t in tar if t.isdir()]
+            with self.assertWarnsRegex(DeprecationWarning, "Use the filter argument") as cm:
+                tar.extractall(DIR, directories)
+            # check that the stacklevel of the deprecation warning is correct:
+            self.assertEqual(cm.filename, __file__)
+
+    def test_deprecation_if_no_filter_passed_to_extract(self):
+        dirtype = "ustar/dirtype"
+        DIR = pathlib.Path(TEMPDIR) / "extractall"
+        with (
+            os_helper.temp_dir(DIR),
+            tarfile.open(tarname, encoding="iso8859-1") as tar
+        ):
+            tarinfo = tar.getmember(dirtype)
+            with self.assertWarnsRegex(DeprecationWarning, "Use the filter argument") as cm:
+                tar.extract(tarinfo, path=DIR)
+            # check that the stacklevel of the deprecation warning is correct:
+            self.assertEqual(cm.filename, __file__)
+
     def test_extractall_pathlike_name(self):
         DIR = pathlib.Path(TEMPDIR) / "extractall"
         with os_helper.temp_dir(DIR), \

--- a/Misc/NEWS.d/next/Library/2024-04-14-15-59-28.gh-issue-117691.1mtREE.rst
+++ b/Misc/NEWS.d/next/Library/2024-04-14-15-59-28.gh-issue-117691.1mtREE.rst
@@ -1,0 +1,5 @@
+Improve the error messages emitted by :mod:`tarfile` deprecation warnings
+relating to PEP 706. If a ``filter`` argument is not provided to
+``extract()`` or ``extractall``, the deprecation warning now points to the
+line in the user's code where the relevant function was called. Patch by
+Alex Waygood.


### PR DESCRIPTION


<!-- gh-issue-number: gh-117691 -->
* Issue: gh-117691
<!-- /gh-issue-number -->
