### PR TITLE
gh-117142: ctypes: Migrate global closure freelist to module state

### DIFF
--- a/Include/internal/pycore_typeobject.h
+++ b/Include/internal/pycore_typeobject.h
@@ -137,7 +137,7 @@ _PyStaticType_GET_WEAKREFS_LISTPTR(static_builtin_state *state)
 }
 
 /* Like PyType_GetModule, but skips verification
- * that type is a heap type */
+ * that type is a heap type with an associated module */
 static inline PyObject *
 _PyType_GetModule(PyTypeObject *type)
 {

--- a/Include/internal/pycore_typeobject.h
+++ b/Include/internal/pycore_typeobject.h
@@ -136,6 +136,17 @@ _PyStaticType_GET_WEAKREFS_LISTPTR(static_builtin_state *state)
     return &state->tp_weaklist;
 }
 
+/* Like PyType_GetModule, but skips verification
+ * that type is a heap type */
+static inline PyObject *
+_PyType_GetModule(PyTypeObject *type)
+{
+    assert(PyType_Check(type));
+    assert(type->tp_flags & Py_TPFLAGS_HEAPTYPE);
+    PyHeapTypeObject *et = (PyHeapTypeObject *)type;
+    return et->ht_module;
+}
+
 /* Like PyType_GetModuleState, but skips verification
  * that type is a heap type with an associated module */
 static inline void *

--- a/Lib/test/test_ctypes/test_refcounts.py
+++ b/Lib/test/test_ctypes/test_refcounts.py
@@ -126,12 +126,12 @@ class ModuleIsolationTest(unittest.TestCase):
     def test_many_closures_per_module(self):
         # check if mmap() and munmap() get called multiple times
         script = (
-            "import ctypes, _ctypes;"
+            "import ctypes;"
             "pyfunc = lambda: 0;"
             "cfunc_type = ctypes.CFUNCTYPE(ctypes.c_int);"
             "cfuncs = [cfunc_type(pyfunc) for i in range(500)];"
-            "f = getattr(_ctypes, '_get_ffi_closure_containers_count', None);"
-            "n_containers = f and f();"
+            "ctype_type = ctypes.Union.__class__.__base__;"
+            "n_containers = ctype_type.get_ffi_closure_containers_count();"
             "exit(n_containers and n_containers < 2)"
         )
         script_helper.assert_python_ok("-c", script)

--- a/Lib/test/test_ctypes/test_refcounts.py
+++ b/Lib/test/test_ctypes/test_refcounts.py
@@ -123,6 +123,19 @@ class ModuleIsolationTest(unittest.TestCase):
         )
         script_helper.assert_python_ok("-c", script)
 
+    @unittest.skipUnless(support.Py_DEBUG, 'a method requires Py_DEBUG')
+    def test_many_closures_per_module(self):
+        # check if mmap() and munmap() get called multiple times
+        script = (
+            "import ctypes, _ctypes;"
+            "pyfunc = lambda: 0;"
+            "cfunc_type = ctypes.CFUNCTYPE(ctypes.c_int);"
+            "cfuncs = [cfunc_type(pyfunc) for i in range(500)];"
+            "n_containers = _ctypes._get_ffi_closure_containers_count();"
+            "exit(n_containers and n_containers < 2)"
+        )
+        script_helper.assert_python_ok("-c", script)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/Lib/test/test_ctypes/test_refcounts.py
+++ b/Lib/test/test_ctypes/test_refcounts.py
@@ -123,7 +123,6 @@ class ModuleIsolationTest(unittest.TestCase):
         )
         script_helper.assert_python_ok("-c", script)
 
-    @unittest.skipUnless(support.Py_DEBUG, 'a method requires Py_DEBUG')
     def test_many_closures_per_module(self):
         # check if mmap() and munmap() get called multiple times
         script = (
@@ -131,7 +130,8 @@ class ModuleIsolationTest(unittest.TestCase):
             "pyfunc = lambda: 0;"
             "cfunc_type = ctypes.CFUNCTYPE(ctypes.c_int);"
             "cfuncs = [cfunc_type(pyfunc) for i in range(500)];"
-            "n_containers = _ctypes._get_ffi_closure_containers_count();"
+            "f = getattr(_ctypes, '_get_ffi_closure_containers_count', None);"
+            "n_containers = f and f();"
             "exit(n_containers and n_containers < 2)"
         )
         script_helper.assert_python_ok("-c", script)

--- a/Modules/_ctypes/_ctypes.c
+++ b/Modules/_ctypes/_ctypes.c
@@ -558,12 +558,34 @@ _ctypes_CType_Type___sizeof___impl(PyObject *self, PyTypeObject *cls)
     return PyLong_FromSsize_t(size);
 }
 
+/*[clinic input]
+@classmethod
+_ctypes.CType_Type.get_ffi_closure_containers_count
+
+    cls: defining_class
+    /
+[clinic start generated code]*/
+
+static PyObject *
+_ctypes_CType_Type_get_ffi_closure_containers_count_impl(PyTypeObject *type,
+                                                         PyTypeObject *cls)
+/*[clinic end generated code: output=619f776a42f7c3aa input=285058c2f984defc]*/
+{
+#ifdef USING_MALLOC_CLOSURE_DOT_C
+    ctypes_state *st = get_module_state_by_class(cls);
+    return PyLong_FromSsize_t(st->malloc_closure.narenas);
+#else
+    Py_RETURN_NONE;
+#endif
+}
+
 static PyObject *
 CType_Type_repeat(PyObject *self, Py_ssize_t length);
 
 
 static PyMethodDef ctype_methods[] = {
     _CTYPES_CTYPE_TYPE___SIZEOF___METHODDEF
+    _CTYPES_CTYPE_TYPE_GET_FFI_CLOSURE_CONTAINERS_COUNT_METHODDEF
     {0},
 };
 

--- a/Modules/_ctypes/_ctypes.c
+++ b/Modules/_ctypes/_ctypes.c
@@ -5936,6 +5936,8 @@ module_clear(PyObject *module) {
     Py_CLEAR(st->PyComError_Type);
 #endif
     Py_CLEAR(st->PyCType_Type);
+    clear_malloc_closure_free_list(st);
+    memset(&st->malloc_closure, 0, sizeof(malloc_closure_state));
     return 0;
 }
 

--- a/Modules/_ctypes/_ctypes.c
+++ b/Modules/_ctypes/_ctypes.c
@@ -5936,8 +5936,10 @@ module_clear(PyObject *module) {
     Py_CLEAR(st->PyComError_Type);
 #endif
     Py_CLEAR(st->PyCType_Type);
+#ifdef USING_MALLOC_CLOSURE_DOT_C
     clear_malloc_closure_free_list(st);
     memset(&st->malloc_closure, 0, sizeof(malloc_closure_state));
+#endif
     return 0;
 }
 

--- a/Modules/_ctypes/_ctypes.c
+++ b/Modules/_ctypes/_ctypes.c
@@ -571,12 +571,8 @@ _ctypes_CType_Type_get_ffi_closure_containers_count_impl(PyTypeObject *type,
                                                          PyTypeObject *cls)
 /*[clinic end generated code: output=619f776a42f7c3aa input=285058c2f984defc]*/
 {
-#ifdef USING_MALLOC_CLOSURE_DOT_C
     ctypes_state *st = get_module_state_by_class(cls);
     return PyLong_FromSsize_t(st->malloc_closure.narenas);
-#else
-    Py_RETURN_NONE;
-#endif
 }
 
 static PyObject *
@@ -5958,10 +5954,8 @@ module_clear(PyObject *module) {
     Py_CLEAR(st->PyComError_Type);
 #endif
     Py_CLEAR(st->PyCType_Type);
-#ifdef USING_MALLOC_CLOSURE_DOT_C
     clear_malloc_closure_free_list(st);
     memset(&st->malloc_closure, 0, sizeof(malloc_closure_state));
-#endif
     return 0;
 }
 

--- a/Modules/_ctypes/callbacks.c
+++ b/Modules/_ctypes/callbacks.c
@@ -56,11 +56,7 @@ CThunkObject_dealloc(PyObject *myself)
     PyObject_GC_UnTrack(self);
     (void)CThunkObject_clear(myself);
     if (self->pcl_write) {
-        PyObject *module = _PyType_GetModule(tp);
-        if (module) {
-            ctypes_state *st = _PyModule_GetState(module);
-            Py_ffi_closure_free(st, self->pcl_write);
-        }
+        Py_ffi_closure_free(tp, self->pcl_write);
     }
     PyObject_GC_Del(self);
     Py_DECREF(tp);

--- a/Modules/_ctypes/callbacks.c
+++ b/Modules/_ctypes/callbacks.c
@@ -56,7 +56,11 @@ CThunkObject_dealloc(PyObject *myself)
     PyObject_GC_UnTrack(self);
     (void)CThunkObject_clear(myself);
     if (self->pcl_write) {
-        Py_ffi_closure_free(self->pcl_write);
+        PyObject *module = _PyType_GetModule(tp);
+        if (module) {
+            ctypes_state *st = _PyModule_GetState(module);
+            Py_ffi_closure_free(st, self->pcl_write);
+        }
     }
     PyObject_GC_Del(self);
     Py_DECREF(tp);
@@ -364,7 +368,7 @@ CThunkObject *_ctypes_alloc_callback(ctypes_state *st,
 
     assert(CThunk_CheckExact(st, (PyObject *)p));
 
-    p->pcl_write = Py_ffi_closure_alloc(sizeof(ffi_closure), &p->pcl_exec);
+    p->pcl_write = Py_ffi_closure_alloc(st, sizeof(ffi_closure), &p->pcl_exec);
     if (p->pcl_write == NULL) {
         PyErr_NoMemory();
         goto error;

--- a/Modules/_ctypes/callproc.c
+++ b/Modules/_ctypes/callproc.c
@@ -2063,12 +2063,18 @@ buffer_info(PyObject *self, PyObject *arg)
     return Py_BuildValue("siN", info->format, info->ndim, shape);
 }
 
+#ifdef Py_DEBUG
 static PyObject *
 get_malloc_closure_narenas(PyObject *self, PyObject *args)
 {
+#ifdef USING_MALLOC_CLOSURE_DOT_C
     ctypes_state *st = get_module_state(self);
     return PyLong_FromSsize_t(st->malloc_closure.narenas);
+#else
+    return PyLong_FromLong(0);
+#endif
 }
+#endif
 
 PyMethodDef _ctypes_module_methods[] = {
     {"get_errno", get_errno, METH_NOARGS},

--- a/Modules/_ctypes/callproc.c
+++ b/Modules/_ctypes/callproc.c
@@ -2063,7 +2063,12 @@ buffer_info(PyObject *self, PyObject *arg)
     return Py_BuildValue("siN", info->format, info->ndim, shape);
 }
 
-
+static PyObject *
+get_malloc_closure_narenas(PyObject *self, PyObject *args)
+{
+    ctypes_state *st = get_module_state(self);
+    return PyLong_FromSsize_t(st->malloc_closure.narenas);
+}
 
 PyMethodDef _ctypes_module_methods[] = {
     {"get_errno", get_errno, METH_NOARGS},
@@ -2099,6 +2104,9 @@ PyMethodDef _ctypes_module_methods[] = {
     {"PyObj_FromPtr", My_PyObj_FromPtr, METH_VARARGS },
     {"Py_INCREF", My_Py_INCREF, METH_O },
     {"Py_DECREF", My_Py_DECREF, METH_O },
+#ifdef Py_DEBUG
+    {"_get_ffi_closure_containers_count", get_malloc_closure_narenas, METH_NOARGS},
+#endif
     {NULL,      NULL}        /* Sentinel */
 };
 

--- a/Modules/_ctypes/callproc.c
+++ b/Modules/_ctypes/callproc.c
@@ -2063,6 +2063,8 @@ buffer_info(PyObject *self, PyObject *arg)
     return Py_BuildValue("siN", info->format, info->ndim, shape);
 }
 
+
+
 PyMethodDef _ctypes_module_methods[] = {
     {"get_errno", get_errno, METH_NOARGS},
     {"set_errno", set_errno, METH_VARARGS},

--- a/Modules/_ctypes/callproc.c
+++ b/Modules/_ctypes/callproc.c
@@ -2063,19 +2063,6 @@ buffer_info(PyObject *self, PyObject *arg)
     return Py_BuildValue("siN", info->format, info->ndim, shape);
 }
 
-#ifdef Py_DEBUG
-static PyObject *
-get_malloc_closure_narenas(PyObject *self, PyObject *args)
-{
-#ifdef USING_MALLOC_CLOSURE_DOT_C
-    ctypes_state *st = get_module_state(self);
-    return PyLong_FromSsize_t(st->malloc_closure.narenas);
-#else
-    Py_RETURN_NONE;
-#endif
-}
-#endif
-
 PyMethodDef _ctypes_module_methods[] = {
     {"get_errno", get_errno, METH_NOARGS},
     {"set_errno", set_errno, METH_VARARGS},
@@ -2110,9 +2097,6 @@ PyMethodDef _ctypes_module_methods[] = {
     {"PyObj_FromPtr", My_PyObj_FromPtr, METH_VARARGS },
     {"Py_INCREF", My_Py_INCREF, METH_O },
     {"Py_DECREF", My_Py_DECREF, METH_O },
-#ifdef Py_DEBUG
-    {"_get_ffi_closure_containers_count", get_malloc_closure_narenas, METH_NOARGS},
-#endif
     {NULL,      NULL}        /* Sentinel */
 };
 

--- a/Modules/_ctypes/callproc.c
+++ b/Modules/_ctypes/callproc.c
@@ -2071,7 +2071,7 @@ get_malloc_closure_narenas(PyObject *self, PyObject *args)
     ctypes_state *st = get_module_state(self);
     return PyLong_FromSsize_t(st->malloc_closure.narenas);
 #else
-    return PyLong_FromLong(0);
+    Py_RETURN_NONE;
 #endif
 }
 #endif

--- a/Modules/_ctypes/clinic/_ctypes.c.h
+++ b/Modules/_ctypes/clinic/_ctypes.c.h
@@ -27,6 +27,28 @@ _ctypes_CType_Type___sizeof__(PyObject *self, PyTypeObject *cls, PyObject *const
     return _ctypes_CType_Type___sizeof___impl(self, cls);
 }
 
+PyDoc_STRVAR(_ctypes_CType_Type_get_ffi_closure_containers_count__doc__,
+"get_ffi_closure_containers_count($type, /)\n"
+"--\n"
+"\n");
+
+#define _CTYPES_CTYPE_TYPE_GET_FFI_CLOSURE_CONTAINERS_COUNT_METHODDEF    \
+    {"get_ffi_closure_containers_count", _PyCFunction_CAST(_ctypes_CType_Type_get_ffi_closure_containers_count), METH_METHOD|METH_FASTCALL|METH_KEYWORDS|METH_CLASS, _ctypes_CType_Type_get_ffi_closure_containers_count__doc__},
+
+static PyObject *
+_ctypes_CType_Type_get_ffi_closure_containers_count_impl(PyTypeObject *type,
+                                                         PyTypeObject *cls);
+
+static PyObject *
+_ctypes_CType_Type_get_ffi_closure_containers_count(PyTypeObject *type, PyTypeObject *cls, PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames)
+{
+    if (nargs || (kwnames && PyTuple_GET_SIZE(kwnames))) {
+        PyErr_SetString(PyExc_TypeError, "get_ffi_closure_containers_count() takes no arguments");
+        return NULL;
+    }
+    return _ctypes_CType_Type_get_ffi_closure_containers_count_impl(type, cls);
+}
+
 PyDoc_STRVAR(CDataType_from_address__doc__,
 "from_address($self, value, /)\n"
 "--\n"
@@ -607,4 +629,4 @@ Simple_from_outparm(PyObject *self, PyTypeObject *cls, PyObject *const *args, Py
     }
     return Simple_from_outparm_impl(self, cls);
 }
-/*[clinic end generated code: output=9c6539a3559e6088 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=21ed02205e81ab88 input=a9049054013a1b77]*/

--- a/Modules/_ctypes/ctypes.h
+++ b/Modules/_ctypes/ctypes.h
@@ -39,7 +39,6 @@
 #include <Unknwn.h> // for IUnknown interface
 #endif
 
-#ifdef USING_MALLOC_CLOSURE_DOT_C
 typedef union _tagITEM {
     ffi_closure closure;
     union _tagITEM *next;
@@ -57,7 +56,6 @@ typedef struct {
     Py_ssize_t arena_size;
     Py_ssize_t narenas;
 } malloc_closure_state;
-#endif
 
 typedef struct {
     PyTypeObject *DictRemover_Type;
@@ -91,9 +89,7 @@ typedef struct {
     PyObject *error_object_name;  // callproc.c
     PyObject *PyExc_ArgError;
     PyObject *swapped_suffix;
-#ifdef USING_MALLOC_CLOSURE_DOT_C
     malloc_closure_state malloc_closure;
-#endif
 } ctypes_state;
 
 
@@ -479,6 +475,7 @@ void clear_malloc_closure_free_list(ctypes_state *st);
 #else
 #define Py_ffi_closure_free(tp, p) ffi_closure_free(p)
 #define Py_ffi_closure_alloc(st, size, codeloc) ffi_closure_alloc(size, codeloc)
+#define clear_malloc_closure_free_list(st) ((void)0)
 #endif
 
 

--- a/Modules/_ctypes/ctypes.h
+++ b/Modules/_ctypes/ctypes.h
@@ -39,6 +39,7 @@
 #include <Unknwn.h> // for IUnknown interface
 #endif
 
+#ifdef USING_MALLOC_CLOSURE_DOT_C
 typedef union _tagITEM {
     ffi_closure closure;
     union _tagITEM *next;
@@ -56,6 +57,7 @@ typedef struct {
     Py_ssize_t arena_size;
     Py_ssize_t narenas;
 } malloc_closure_state;
+#endif
 
 typedef struct {
     PyTypeObject *DictRemover_Type;
@@ -89,7 +91,9 @@ typedef struct {
     PyObject *error_object_name;  // callproc.c
     PyObject *PyExc_ArgError;
     PyObject *swapped_suffix;
+#ifdef USING_MALLOC_CLOSURE_DOT_C
     malloc_closure_state malloc_closure;
+#endif
 } ctypes_state;
 
 
@@ -469,13 +473,13 @@ extern int _ctypes_simple_instance(ctypes_state *st, PyObject *obj);
 PyObject *_ctypes_get_errobj(ctypes_state *st, int **pspace);
 
 #ifdef USING_MALLOC_CLOSURE_DOT_C
-void Py_ffi_closure_free(ctypes_state *st, void *p);
+void Py_ffi_closure_free(PyTypeObject *thunk_tp, void *p);
 void *Py_ffi_closure_alloc(ctypes_state *st, size_t size, void** codeloc);
+void clear_malloc_closure_free_list(ctypes_state *st);
 #else
-#define Py_ffi_closure_free(st, p) ffi_closure_free(p)
+#define Py_ffi_closure_free(tp, p) ffi_closure_free(p)
 #define Py_ffi_closure_alloc(st, size, codeloc) ffi_closure_alloc(size, codeloc)
 #endif
-void clear_malloc_closure_free_list(ctypes_state *st);
 
 
 /****************************************************************

--- a/Modules/_ctypes/malloc_closure.c
+++ b/Modules/_ctypes/malloc_closure.c
@@ -120,7 +120,7 @@ clear_malloc_closure_free_list(ctypes_state *state)
 
 /* put the item back into the free list */
 void
-Py_ffi_closure_free(ctypes_state *state, void *p)
+Py_ffi_closure_free(PyTypeObject *thunk_tp, void *p)
 {
 #ifdef HAVE_FFI_CLOSURE_ALLOC
 #ifdef USING_APPLE_OS_LIBFFI
@@ -136,6 +136,12 @@ Py_ffi_closure_free(ctypes_state *state, void *p)
     }
 #endif
 #endif
+    PyObject *module = _PyType_GetModule(thunk_tp);
+    if (module == NULL) {
+        return;
+    }
+    ctypes_state *state = get_module_state(module);
+
     malloc_closure_state *st = &state->malloc_closure;
     if (st->narenas <= 0) {
         return;

--- a/Tools/c-analyzer/cpython/globals-to-fix.tsv
+++ b/Tools/c-analyzer/cpython/globals-to-fix.tsv
@@ -447,7 +447,6 @@ Modules/_tkinter.c	-	trbInCmd	-
 ## other
 Include/datetime.h	-	PyDateTimeAPI	-
 Modules/_ctypes/cfield.c	_ctypes_get_fielddesc	initialized	-
-Modules/_ctypes/malloc_closure.c	-	_pagesize	-
 Modules/_cursesmodule.c	-	initialised	-
 Modules/_cursesmodule.c	-	initialised_setupterm	-
 Modules/_cursesmodule.c	-	initialisedcolors	-
@@ -461,7 +460,6 @@ Modules/readline.c	-	libedit_history_start	-
 ## state
 
 Modules/_ctypes/cfield.c	-	formattable	-
-Modules/_ctypes/malloc_closure.c	-	free_list	-
 Modules/_curses_panel.c	-	lop	-
 Modules/_ssl/debughelpers.c	_PySSL_keylog_callback	lock	-
 Modules/_tkinter.c	-	quitMainLoop	-


### PR DESCRIPTION
This introduces `_PyType_GetModule` static inline function into `pycore_typeobject.h` for the efficient module check during a finish.

See also #117874, which uses a type state instead.

cc @encukou


<!-- gh-issue-number: gh-117142 -->
* Issue: gh-117142
<!-- /gh-issue-number -->
