### PR TITLE
gh-117891: handle undefined TARGET_OS_OSX

### DIFF
--- a/Modules/_testexternalinspection.c
+++ b/Modules/_testexternalinspection.c
@@ -17,6 +17,11 @@
 
 #if defined(__APPLE__)
 #  include <TargetConditionals.h>
+// TARGET_OS_OSX is not defined by older macOS SDKs. It is always
+// defined to 0 when targeting iOS.
+#  ifndef TARGET_OS_OSX
+#    define TARGET_OS_OSX 1
+#  endif
 #  if TARGET_OS_OSX
 #    include <libproc.h>
 #    include <mach-o/fat.h>


### PR DESCRIPTION
This macro is not defined by older macOS SDKs, and the code in `Modules/_testexternalinspection.c` previously didn't distinguish between it being undefined and being defined to 0.


<!-- gh-issue-number: gh-117891 -->
* Issue: gh-117891
<!-- /gh-issue-number -->
