### PR TITLE
[3.12] gh-90329: Add _winapi.GetLongPathName and GetShortPathName and use in venv to reduce warnings (GH-117817)

### DIFF
--- a/Lib/test/test_venv.py
+++ b/Lib/test/test_venv.py
@@ -640,77 +640,6 @@ class BasicTest(BaseTest):
                 error_message = f"CR LF found in line {i}"
                 self.assertFalse(line.endswith(b'\r\n'), error_message)
 
-<<<<<<< HEAD
-=======
-    @requireVenvCreate
-    def test_scm_ignore_files_git(self):
-        """
-        Test that a .gitignore file is created when "git" is specified.
-        The file should contain a `*\n` line.
-        """
-        self.run_with_capture(venv.create, self.env_dir,
-                              scm_ignore_files={'git'})
-        file_lines = self.get_text_file_contents('.gitignore').splitlines()
-        self.assertIn('*', file_lines)
-
-    @requireVenvCreate
-    def test_create_scm_ignore_files_multiple(self):
-        """
-        Test that ``scm_ignore_files`` can work with multiple SCMs.
-        """
-        bzrignore_name = ".bzrignore"
-        contents = "# For Bazaar.\n*\n"
-
-        class BzrEnvBuilder(venv.EnvBuilder):
-            def create_bzr_ignore_file(self, context):
-                gitignore_path = os.path.join(context.env_dir, bzrignore_name)
-                with open(gitignore_path, 'w', encoding='utf-8') as file:
-                    file.write(contents)
-
-        builder = BzrEnvBuilder(scm_ignore_files={'git', 'bzr'})
-        self.run_with_capture(builder.create, self.env_dir)
-
-        gitignore_lines = self.get_text_file_contents('.gitignore').splitlines()
-        self.assertIn('*', gitignore_lines)
-
-        bzrignore = self.get_text_file_contents(bzrignore_name)
-        self.assertEqual(bzrignore, contents)
-
-    @requireVenvCreate
-    def test_create_scm_ignore_files_empty(self):
-        """
-        Test that no default ignore files are created when ``scm_ignore_files``
-        is empty.
-        """
-        # scm_ignore_files is set to frozenset() by default.
-        self.run_with_capture(venv.create, self.env_dir)
-        with self.assertRaises(FileNotFoundError):
-            self.get_text_file_contents('.gitignore')
-
-        self.assertIn("--without-scm-ignore-files",
-                      self.get_text_file_contents('pyvenv.cfg'))
-
-    @requireVenvCreate
-    def test_cli_with_scm_ignore_files(self):
-        """
-        Test that default SCM ignore files are created by default via the CLI.
-        """
-        self.run_with_capture(venv.main, ['--without-pip', self.env_dir])
-
-        gitignore_lines = self.get_text_file_contents('.gitignore').splitlines()
-        self.assertIn('*', gitignore_lines)
-
-    @requireVenvCreate
-    def test_cli_without_scm_ignore_files(self):
-        """
-        Test that ``--without-scm-ignore-files`` doesn't create SCM ignore files.
-        """
-        args = ['--without-pip', '--without-scm-ignore-files', self.env_dir]
-        self.run_with_capture(venv.main, args)
-
-        with self.assertRaises(FileNotFoundError):
-            self.get_text_file_contents('.gitignore')
-
     def test_venv_same_path(self):
         same_path = venv.EnvBuilder._same_path
         if sys.platform == 'win32':
@@ -741,7 +670,6 @@ class BasicTest(BaseTest):
                 else:
                     self.assertFalse(same_path(path1, path2))
 
->>>>>>> 185999bb3a (gh-90329: Add _winapi.GetLongPathName and GetShortPathName and use in venv to reduce warnings (GH-117817))
 @requireVenvCreate
 class EnsurePipTest(BaseTest):
     """Test venv module installation of pip."""

--- a/Lib/test/test_winapi.py
+++ b/Lib/test/test_winapi.py
@@ -1,0 +1,129 @@
+# Test the Windows-only _winapi module
+
+import os
+import pathlib
+import random
+import re
+import threading
+import time
+import unittest
+from test.support import import_helper
+
+_winapi = import_helper.import_module('_winapi', required_on=['win'])
+
+MAXIMUM_WAIT_OBJECTS = 64
+MAXIMUM_BATCHED_WAIT_OBJECTS = (MAXIMUM_WAIT_OBJECTS - 1) ** 2
+
+class WinAPIBatchedWaitForMultipleObjectsTests(unittest.TestCase):
+    def _events_waitall_test(self, n):
+        evts = [_winapi.CreateEventW(0, False, False, None) for _ in range(n)]
+
+        with self.assertRaises(TimeoutError):
+            _winapi.BatchedWaitForMultipleObjects(evts, True, 100)
+
+        # Ensure no errors raised when all are triggered
+        for e in evts:
+            _winapi.SetEvent(e)
+        try:
+            _winapi.BatchedWaitForMultipleObjects(evts, True, 100)
+        except TimeoutError:
+            self.fail("expected wait to complete immediately")
+
+        # Choose 8 events to set, distributed throughout the list, to make sure
+        # we don't always have them in the first chunk
+        chosen = [i * (len(evts) // 8) for i in range(8)]
+
+        # Replace events with invalid handles to make sure we fail
+        for i in chosen:
+            old_evt = evts[i]
+            evts[i] = -1
+            with self.assertRaises(OSError):
+                _winapi.BatchedWaitForMultipleObjects(evts, True, 100)
+            evts[i] = old_evt
+
+
+    def _events_waitany_test(self, n):
+        evts = [_winapi.CreateEventW(0, False, False, None) for _ in range(n)]
+
+        with self.assertRaises(TimeoutError):
+            _winapi.BatchedWaitForMultipleObjects(evts, False, 100)
+
+        # Choose 8 events to set, distributed throughout the list, to make sure
+        # we don't always have them in the first chunk
+        chosen = [i * (len(evts) // 8) for i in range(8)]
+
+        # Trigger one by one. They are auto-reset events, so will only trigger once
+        for i in chosen:
+            with self.subTest(f"trigger event {i} of {len(evts)}"):
+                _winapi.SetEvent(evts[i])
+                triggered = _winapi.BatchedWaitForMultipleObjects(evts, False, 10000)
+                self.assertSetEqual(set(triggered), {i})
+
+        # Trigger all at once. This may require multiple calls
+        for i in chosen:
+            _winapi.SetEvent(evts[i])
+        triggered = set()
+        while len(triggered) < len(chosen):
+            triggered.update(_winapi.BatchedWaitForMultipleObjects(evts, False, 10000))
+        self.assertSetEqual(triggered, set(chosen))
+
+        # Replace events with invalid handles to make sure we fail
+        for i in chosen:
+            with self.subTest(f"corrupt event {i} of {len(evts)}"):
+                old_evt = evts[i]
+                evts[i] = -1
+                with self.assertRaises(OSError):
+                    _winapi.BatchedWaitForMultipleObjects(evts, False, 100)
+                evts[i] = old_evt
+
+
+    def test_few_events_waitall(self):
+        self._events_waitall_test(16)
+
+    def test_many_events_waitall(self):
+        self._events_waitall_test(256)
+
+    def test_max_events_waitall(self):
+        self._events_waitall_test(MAXIMUM_BATCHED_WAIT_OBJECTS)
+
+
+    def test_few_events_waitany(self):
+        self._events_waitany_test(16)
+
+    def test_many_events_waitany(self):
+        self._events_waitany_test(256)
+
+    def test_max_events_waitany(self):
+        self._events_waitany_test(MAXIMUM_BATCHED_WAIT_OBJECTS)
+
+
+class WinAPITests(unittest.TestCase):
+    def test_getlongpathname(self):
+        testfn = pathlib.Path(os.getenv("ProgramFiles")).parents[-1] / "PROGRA~1"
+        if not os.path.isdir(testfn):
+            raise unittest.SkipTest("require x:\\PROGRA~1 to test")
+
+        # pathlib.Path will be rejected - only str is accepted
+        with self.assertRaises(TypeError):
+            _winapi.GetLongPathName(testfn)
+
+        actual = _winapi.GetLongPathName(os.fsdecode(testfn))
+
+        # Can't assume that PROGRA~1 expands to any particular variation, so
+        # ensure it matches any one of them.
+        candidates = set(testfn.parent.glob("Progra*"))
+        self.assertIn(pathlib.Path(actual), candidates)
+
+    def test_getshortpathname(self):
+        testfn = pathlib.Path(os.getenv("ProgramFiles"))
+        if not os.path.isdir(testfn):
+            raise unittest.SkipTest("require '%ProgramFiles%' to test")
+
+        # pathlib.Path will be rejected - only str is accepted
+        with self.assertRaises(TypeError):
+            _winapi.GetShortPathName(testfn)
+
+        actual = _winapi.GetShortPathName(os.fsdecode(testfn))
+
+        # Should contain "PROGRA~" but we can't predict the number
+        self.assertIsNotNone(re.match(r".\:\\PROGRA~\d", actual.upper()), actual)

--- a/Lib/test/test_winapi.py
+++ b/Lib/test/test_winapi.py
@@ -2,100 +2,11 @@
 
 import os
 import pathlib
-import random
 import re
-import threading
-import time
 import unittest
 from test.support import import_helper
 
 _winapi = import_helper.import_module('_winapi', required_on=['win'])
-
-MAXIMUM_WAIT_OBJECTS = 64
-MAXIMUM_BATCHED_WAIT_OBJECTS = (MAXIMUM_WAIT_OBJECTS - 1) ** 2
-
-class WinAPIBatchedWaitForMultipleObjectsTests(unittest.TestCase):
-    def _events_waitall_test(self, n):
-        evts = [_winapi.CreateEventW(0, False, False, None) for _ in range(n)]
-
-        with self.assertRaises(TimeoutError):
-            _winapi.BatchedWaitForMultipleObjects(evts, True, 100)
-
-        # Ensure no errors raised when all are triggered
-        for e in evts:
-            _winapi.SetEvent(e)
-        try:
-            _winapi.BatchedWaitForMultipleObjects(evts, True, 100)
-        except TimeoutError:
-            self.fail("expected wait to complete immediately")
-
-        # Choose 8 events to set, distributed throughout the list, to make sure
-        # we don't always have them in the first chunk
-        chosen = [i * (len(evts) // 8) for i in range(8)]
-
-        # Replace events with invalid handles to make sure we fail
-        for i in chosen:
-            old_evt = evts[i]
-            evts[i] = -1
-            with self.assertRaises(OSError):
-                _winapi.BatchedWaitForMultipleObjects(evts, True, 100)
-            evts[i] = old_evt
-
-
-    def _events_waitany_test(self, n):
-        evts = [_winapi.CreateEventW(0, False, False, None) for _ in range(n)]
-
-        with self.assertRaises(TimeoutError):
-            _winapi.BatchedWaitForMultipleObjects(evts, False, 100)
-
-        # Choose 8 events to set, distributed throughout the list, to make sure
-        # we don't always have them in the first chunk
-        chosen = [i * (len(evts) // 8) for i in range(8)]
-
-        # Trigger one by one. They are auto-reset events, so will only trigger once
-        for i in chosen:
-            with self.subTest(f"trigger event {i} of {len(evts)}"):
-                _winapi.SetEvent(evts[i])
-                triggered = _winapi.BatchedWaitForMultipleObjects(evts, False, 10000)
-                self.assertSetEqual(set(triggered), {i})
-
-        # Trigger all at once. This may require multiple calls
-        for i in chosen:
-            _winapi.SetEvent(evts[i])
-        triggered = set()
-        while len(triggered) < len(chosen):
-            triggered.update(_winapi.BatchedWaitForMultipleObjects(evts, False, 10000))
-        self.assertSetEqual(triggered, set(chosen))
-
-        # Replace events with invalid handles to make sure we fail
-        for i in chosen:
-            with self.subTest(f"corrupt event {i} of {len(evts)}"):
-                old_evt = evts[i]
-                evts[i] = -1
-                with self.assertRaises(OSError):
-                    _winapi.BatchedWaitForMultipleObjects(evts, False, 100)
-                evts[i] = old_evt
-
-
-    def test_few_events_waitall(self):
-        self._events_waitall_test(16)
-
-    def test_many_events_waitall(self):
-        self._events_waitall_test(256)
-
-    def test_max_events_waitall(self):
-        self._events_waitall_test(MAXIMUM_BATCHED_WAIT_OBJECTS)
-
-
-    def test_few_events_waitany(self):
-        self._events_waitany_test(16)
-
-    def test_many_events_waitany(self):
-        self._events_waitany_test(256)
-
-    def test_max_events_waitany(self):
-        self._events_waitany_test(MAXIMUM_BATCHED_WAIT_OBJECTS)
-
 
 class WinAPITests(unittest.TestCase):
     def test_getlongpathname(self):

--- a/Lib/venv/__init__.py
+++ b/Lib/venv/__init__.py
@@ -102,6 +102,33 @@ class EnvBuilder:
         }
         return sysconfig.get_path(name, scheme='venv', vars=vars)
 
+    @classmethod
+    def _same_path(cls, path1, path2):
+        """Check whether two paths appear the same.
+
+        Whether they refer to the same file is irrelevant; we're testing for
+        whether a human reader would look at the path string and easily tell
+        that they're the same file.
+        """
+        if sys.platform == 'win32':
+            if os.path.normcase(path1) == os.path.normcase(path2):
+                return True
+            # gh-90329: Don't display a warning for short/long names
+            import _winapi
+            try:
+                path1 = _winapi.GetLongPathName(os.fsdecode(path1))
+            except OSError:
+                pass
+            try:
+                path2 = _winapi.GetLongPathName(os.fsdecode(path2))
+            except OSError:
+                pass
+            if os.path.normcase(path1) == os.path.normcase(path2):
+                return True
+            return False
+        else:
+            return path1 == path2
+
     def ensure_directories(self, env_dir):
         """
         Create the directories for the environment.
@@ -162,7 +189,7 @@ class EnvBuilder:
             # bpo-45337: Fix up env_exec_cmd to account for file system redirections.
             # Some redirects only apply to CreateFile and not CreateProcess
             real_env_exe = os.path.realpath(context.env_exe)
-            if os.path.normcase(real_env_exe) != os.path.normcase(context.env_exe):
+            if not self._same_path(real_env_exe, context.env_exe):
                 logger.warning('Actual environment location may have moved due to '
                                'redirects, links or junctions.\n'
                                '  Requested location: "%s"\n'

--- a/Misc/NEWS.d/next/Windows/2024-04-12-14-02-58.gh-issue-90329.YpEeaO.rst
+++ b/Misc/NEWS.d/next/Windows/2024-04-12-14-02-58.gh-issue-90329.YpEeaO.rst
@@ -1,0 +1,5 @@
+Suppress the warning displayed on virtual environment creation when the
+requested and created paths differ only by a short (8.3 style) name.
+Warnings will continue to be shown if a junction or symlink in the path
+caused the venv to be created in a different location than originally
+requested.

--- a/Modules/_winapi.c
+++ b/Modules/_winapi.c
@@ -1452,6 +1452,49 @@ _winapi_GetLastError_impl(PyObject *module)
     return GetLastError();
 }
 
+
+/*[clinic input]
+_winapi.GetLongPathName
+
+    path: LPCWSTR
+
+Return the long version of the provided path.
+
+If the path is already in its long form, returns the same value.
+
+The path must already be a 'str'. If the type is not known, use
+os.fsdecode before calling this function.
+[clinic start generated code]*/
+
+static PyObject *
+_winapi_GetLongPathName_impl(PyObject *module, LPCWSTR path)
+/*[clinic end generated code: output=c4774b080275a2d0 input=9872e211e3a4a88f]*/
+{
+    DWORD cchBuffer;
+    PyObject *result = NULL;
+
+    Py_BEGIN_ALLOW_THREADS
+    cchBuffer = GetLongPathNameW(path, NULL, 0);
+    Py_END_ALLOW_THREADS
+    if (cchBuffer) {
+        WCHAR *buffer = (WCHAR *)PyMem_Malloc(cchBuffer * sizeof(WCHAR));
+        if (buffer) {
+            Py_BEGIN_ALLOW_THREADS
+            cchBuffer = GetLongPathNameW(path, buffer, cchBuffer);
+            Py_END_ALLOW_THREADS
+            if (cchBuffer) {
+                result = PyUnicode_FromWideChar(buffer, cchBuffer);
+            } else {
+                PyErr_SetFromWindowsErr(0);
+            }
+            PyMem_Free((void *)buffer);
+        }
+    } else {
+        PyErr_SetFromWindowsErr(0);
+    }
+    return result;
+}
+
 /*[clinic input]
 _winapi.GetModuleFileName
 
@@ -1484,6 +1527,48 @@ _winapi_GetModuleFileName_impl(PyObject *module, HMODULE module_handle)
         return PyErr_SetFromWindowsErr(GetLastError());
 
     return PyUnicode_FromWideChar(filename, wcslen(filename));
+}
+
+/*[clinic input]
+_winapi.GetShortPathName
+
+    path: LPCWSTR
+
+Return the short version of the provided path.
+
+If the path is already in its short form, returns the same value.
+
+The path must already be a 'str'. If the type is not known, use
+os.fsdecode before calling this function.
+[clinic start generated code]*/
+
+static PyObject *
+_winapi_GetShortPathName_impl(PyObject *module, LPCWSTR path)
+/*[clinic end generated code: output=dab6ae494c621e81 input=43fa349aaf2ac718]*/
+{
+    DWORD cchBuffer;
+    PyObject *result = NULL;
+
+    Py_BEGIN_ALLOW_THREADS
+    cchBuffer = GetShortPathNameW(path, NULL, 0);
+    Py_END_ALLOW_THREADS
+    if (cchBuffer) {
+        WCHAR *buffer = (WCHAR *)PyMem_Malloc(cchBuffer * sizeof(WCHAR));
+        if (buffer) {
+            Py_BEGIN_ALLOW_THREADS
+            cchBuffer = GetShortPathNameW(path, buffer, cchBuffer);
+            Py_END_ALLOW_THREADS
+            if (cchBuffer) {
+                result = PyUnicode_FromWideChar(buffer, cchBuffer);
+            } else {
+                PyErr_SetFromWindowsErr(0);
+            }
+            PyMem_Free((void *)buffer);
+        }
+    } else {
+        PyErr_SetFromWindowsErr(0);
+    }
+    return result;
 }
 
 /*[clinic input]
@@ -2345,7 +2430,9 @@ static PyMethodDef winapi_functions[] = {
     _WINAPI_GETCURRENTPROCESS_METHODDEF
     _WINAPI_GETEXITCODEPROCESS_METHODDEF
     _WINAPI_GETLASTERROR_METHODDEF
+    _WINAPI_GETLONGPATHNAME_METHODDEF
     _WINAPI_GETMODULEFILENAME_METHODDEF
+    _WINAPI_GETSHORTPATHNAME_METHODDEF
     _WINAPI_GETSTDHANDLE_METHODDEF
     _WINAPI_GETVERSION_METHODDEF
     _WINAPI_MAPVIEWOFFILE_METHODDEF

--- a/Modules/clinic/_winapi.c.h
+++ b/Modules/clinic/_winapi.c.h
@@ -604,6 +604,76 @@ exit:
     return return_value;
 }
 
+PyDoc_STRVAR(_winapi_GetLongPathName__doc__,
+"GetLongPathName($module, /, path)\n"
+"--\n"
+"\n"
+"Return the long version of the provided path.\n"
+"\n"
+"If the path is already in its long form, returns the same value.\n"
+"\n"
+"The path must already be a \'str\'. If the type is not known, use\n"
+"os.fsdecode before calling this function.");
+
+#define _WINAPI_GETLONGPATHNAME_METHODDEF    \
+    {"GetLongPathName", _PyCFunction_CAST(_winapi_GetLongPathName), METH_FASTCALL|METH_KEYWORDS, _winapi_GetLongPathName__doc__},
+
+static PyObject *
+_winapi_GetLongPathName_impl(PyObject *module, LPCWSTR path);
+
+static PyObject *
+_winapi_GetLongPathName(PyObject *module, PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames)
+{
+    PyObject *return_value = NULL;
+    #if defined(Py_BUILD_CORE) && !defined(Py_BUILD_CORE_MODULE)
+
+    #define NUM_KEYWORDS 1
+    static struct {
+        PyGC_Head _this_is_not_used;
+        PyObject_VAR_HEAD
+        PyObject *ob_item[NUM_KEYWORDS];
+    } _kwtuple = {
+        .ob_base = PyVarObject_HEAD_INIT(&PyTuple_Type, NUM_KEYWORDS)
+        .ob_item = { &_Py_ID(path), },
+    };
+    #undef NUM_KEYWORDS
+    #define KWTUPLE (&_kwtuple.ob_base.ob_base)
+
+    #else  // !Py_BUILD_CORE
+    #  define KWTUPLE NULL
+    #endif  // !Py_BUILD_CORE
+
+    static const char * const _keywords[] = {"path", NULL};
+    static _PyArg_Parser _parser = {
+        .keywords = _keywords,
+        .fname = "GetLongPathName",
+        .kwtuple = KWTUPLE,
+    };
+    #undef KWTUPLE
+    PyObject *argsbuf[1];
+    LPCWSTR path = NULL;
+
+    args = _PyArg_UnpackKeywords(args, nargs, NULL, kwnames, &_parser, 1, 1, 0, argsbuf);
+    if (!args) {
+        goto exit;
+    }
+    if (!PyUnicode_Check(args[0])) {
+        _PyArg_BadArgument("GetLongPathName", "argument 'path'", "str", args[0]);
+        goto exit;
+    }
+    path = PyUnicode_AsWideCharString(args[0], NULL);
+    if (path == NULL) {
+        goto exit;
+    }
+    return_value = _winapi_GetLongPathName_impl(module, path);
+
+exit:
+    /* Cleanup for path */
+    PyMem_Free((void *)path);
+
+    return return_value;
+}
+
 PyDoc_STRVAR(_winapi_GetModuleFileName__doc__,
 "GetModuleFileName($module, module_handle, /)\n"
 "--\n"
@@ -635,6 +705,76 @@ _winapi_GetModuleFileName(PyObject *module, PyObject *arg)
     return_value = _winapi_GetModuleFileName_impl(module, module_handle);
 
 exit:
+    return return_value;
+}
+
+PyDoc_STRVAR(_winapi_GetShortPathName__doc__,
+"GetShortPathName($module, /, path)\n"
+"--\n"
+"\n"
+"Return the short version of the provided path.\n"
+"\n"
+"If the path is already in its short form, returns the same value.\n"
+"\n"
+"The path must already be a \'str\'. If the type is not known, use\n"
+"os.fsdecode before calling this function.");
+
+#define _WINAPI_GETSHORTPATHNAME_METHODDEF    \
+    {"GetShortPathName", _PyCFunction_CAST(_winapi_GetShortPathName), METH_FASTCALL|METH_KEYWORDS, _winapi_GetShortPathName__doc__},
+
+static PyObject *
+_winapi_GetShortPathName_impl(PyObject *module, LPCWSTR path);
+
+static PyObject *
+_winapi_GetShortPathName(PyObject *module, PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames)
+{
+    PyObject *return_value = NULL;
+    #if defined(Py_BUILD_CORE) && !defined(Py_BUILD_CORE_MODULE)
+
+    #define NUM_KEYWORDS 1
+    static struct {
+        PyGC_Head _this_is_not_used;
+        PyObject_VAR_HEAD
+        PyObject *ob_item[NUM_KEYWORDS];
+    } _kwtuple = {
+        .ob_base = PyVarObject_HEAD_INIT(&PyTuple_Type, NUM_KEYWORDS)
+        .ob_item = { &_Py_ID(path), },
+    };
+    #undef NUM_KEYWORDS
+    #define KWTUPLE (&_kwtuple.ob_base.ob_base)
+
+    #else  // !Py_BUILD_CORE
+    #  define KWTUPLE NULL
+    #endif  // !Py_BUILD_CORE
+
+    static const char * const _keywords[] = {"path", NULL};
+    static _PyArg_Parser _parser = {
+        .keywords = _keywords,
+        .fname = "GetShortPathName",
+        .kwtuple = KWTUPLE,
+    };
+    #undef KWTUPLE
+    PyObject *argsbuf[1];
+    LPCWSTR path = NULL;
+
+    args = _PyArg_UnpackKeywords(args, nargs, NULL, kwnames, &_parser, 1, 1, 0, argsbuf);
+    if (!args) {
+        goto exit;
+    }
+    if (!PyUnicode_Check(args[0])) {
+        _PyArg_BadArgument("GetShortPathName", "argument 'path'", "str", args[0]);
+        goto exit;
+    }
+    path = PyUnicode_AsWideCharString(args[0], NULL);
+    if (path == NULL) {
+        goto exit;
+    }
+    return_value = _winapi_GetShortPathName_impl(module, path);
+
+exit:
+    /* Cleanup for path */
+    PyMem_Free((void *)path);
+
     return return_value;
 }
 
@@ -1482,4 +1622,4 @@ exit:
 
     return return_value;
 }
-/*[clinic end generated code: output=a1f20d03c363db1d input=a9049054013a1b77]*/
+/*[clinic end generated code: output=ba2d5ae3f23701b7 input=a9049054013a1b77]*/


### PR DESCRIPTION


<!-- gh-issue-number: gh-90329 -->
* Issue: gh-90329
<!-- /gh-issue-number -->
