### PR TITLE
Docs: make the `whatsnew-typing-py312` anchor point to things that were new in the typing module

### DIFF
--- a/Doc/whatsnew/3.12.rst
+++ b/Doc/whatsnew/3.12.rst
@@ -927,8 +927,6 @@ tempfile
 * :func:`tempfile.mkdtemp` now always returns an absolute path, even if the
   argument provided to the *dir* parameter is a relative path.
 
-.. _whatsnew-typing-py312:
-
 threading
 ---------
 
@@ -962,6 +960,8 @@ types
 * Add :func:`types.get_original_bases` to allow for further introspection of
   :ref:`user-defined-generics` when subclassed. (Contributed by
   James Hilton-Balfe and Alex Waygood in :gh:`101827`.)
+
+.. _whatsnew-typing-py312:
 
 typing
 ------


### PR DESCRIPTION
not sure how these got separated, but they apparently did

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--117904.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->