### PR TITLE
Quick test to see if removing the tier2 interpreter speeds up tier1

### DIFF
--- a/Include/internal/pycore_code.h
+++ b/Include/internal/pycore_code.h
@@ -300,7 +300,7 @@ extern int _PyStaticCode_Init(PyCodeObject *co);
 #define STAT_INC(opname, name) do { if (_Py_stats) _Py_stats->opcode_stats[opname].specialization.name++; } while (0)
 #define STAT_DEC(opname, name) do { if (_Py_stats) _Py_stats->opcode_stats[opname].specialization.name--; } while (0)
 #define OPCODE_EXE_INC(opname) do { if (_Py_stats) _Py_stats->opcode_stats[opname].execution_count++; } while (0)
-#define CALL_STAT_INC(name) do { if (_Py_stats) _Py_stats->call_stats.name++; } while (0)
+#define REAL_CALL_STAT_INC(name) do { if (_Py_stats) _Py_stats->call_stats.name++; } while (0)
 #define OBJECT_STAT_INC(name) do { if (_Py_stats) _Py_stats->object_stats.name++; } while (0)
 #define OBJECT_STAT_INC_COND(name, cond) \
     do { if (_Py_stats && cond) _Py_stats->object_stats.name++; } while (0)
@@ -329,7 +329,7 @@ PyAPI_FUNC(PyObject*) _Py_GetSpecializationStats(void);
 #define STAT_INC(opname, name) ((void)0)
 #define STAT_DEC(opname, name) ((void)0)
 #define OPCODE_EXE_INC(opname) ((void)0)
-#define CALL_STAT_INC(name) ((void)0)
+#define REAL_CALL_STAT_INC(name) ((void)0)
 #define OBJECT_STAT_INC(name) ((void)0)
 #define OBJECT_STAT_INC_COND(name, cond) ((void)0)
 #define EVAL_CALL_STAT_INC(name) ((void)0)
@@ -342,6 +342,9 @@ PyAPI_FUNC(PyObject*) _Py_GetSpecializationStats(void);
 #define OPT_HIST(length, name) ((void)0)
 #define RARE_EVENT_STAT_INC(name) ((void)0)
 #endif  // !Py_STATS
+
+// We do a little dance here so we can redefine and restore CALL_STAT_INC
+#define CALL_STAT_INC(name) REAL_CALL_STAT_INC(name)
 
 // Utility functions for reading/writing 32/64-bit values in the inline caches.
 // Great care should be taken to ensure that these functions remain correct and

--- a/Include/internal/pycore_jit.h
+++ b/Include/internal/pycore_jit.h
@@ -11,6 +11,10 @@ extern "C" {
 
 #ifdef _Py_JIT
 
+#ifdef _Py_NOTIER2
+#  error "can't define _Py_JIT and _Py_NOTIER2 at the same time"
+#endif
+
 typedef _Py_CODEUNIT *(*jit_func)(_PyInterpreterFrame *frame, PyObject **stack_pointer, PyThreadState *tstate);
 
 int _PyJIT_Compile(_PyExecutorObject *executor, const _PyUOpInstruction *trace, size_t length);

--- a/Lib/test/support/__init__.py
+++ b/Lib/test/support/__init__.py
@@ -1188,6 +1188,10 @@ def requires_specialization(test):
         _opcode.ENABLE_SPECIALIZATION, "requires specialization")(test)
 
 
+def requires_tier2(test):
+    return unittest.skipIf(_opcode.NOTIER2, "requires tier2")(test)
+
+
 #=======================================================================
 # Check for the presence of docstrings.
 

--- a/Lib/test/test_capi/test_opt.py
+++ b/Lib/test/test_capi/test_opt.py
@@ -7,7 +7,7 @@ import os
 
 import _opcode
 
-from test.support import script_helper, requires_specialization, import_helper
+from test.support import script_helper, requires_specialization, requires_tier2, import_helper
 
 _testinternalcapi = import_helper.import_module("_testinternalcapi")
 
@@ -33,6 +33,7 @@ def clear_executors(func):
         func.__code__ = func.__code__.replace()
 
 
+@requires_tier2
 @requires_specialization
 class TestOptimizerAPI(unittest.TestCase):
 
@@ -136,6 +137,7 @@ def get_opnames(ex):
 
 
 @requires_specialization
+@requires_tier2
 class TestExecutorInvalidation(unittest.TestCase):
 
     def setUp(self):
@@ -215,6 +217,7 @@ class TestExecutorInvalidation(unittest.TestCase):
 
 
 @requires_specialization
+@requires_tier2
 @unittest.skipIf(os.getenv("PYTHON_UOPS_OPTIMIZE") == "0", "Needs uop optimizer to run.")
 class TestUops(unittest.TestCase):
 
@@ -579,6 +582,7 @@ class TestUops(unittest.TestCase):
 
 
 @requires_specialization
+@requires_tier2
 @unittest.skipIf(os.getenv("PYTHON_UOPS_OPTIMIZE") == "0", "Needs uop optimizer to run.")
 class TestUopsOptimization(unittest.TestCase):
 

--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -100,7 +100,7 @@ CONFIGURE_LDFLAGS=	@LDFLAGS@
 # command line to append to these values without stomping the pre-set
 # values.
 PY_CFLAGS=	$(BASECFLAGS) $(OPT) $(CONFIGURE_CFLAGS) $(CFLAGS) $(EXTRA_CFLAGS)
-PY_CFLAGS_NODIST=$(CONFIGURE_CFLAGS_NODIST) $(CFLAGS_NODIST) -I$(srcdir)/Include/internal -I$(srcdir)/Include/internal/mimalloc
+PY_CFLAGS_NODIST=$(CONFIGURE_CFLAGS_NODIST) $(CFLAGS_NODIST) -I$(srcdir)/Include/internal -I$(srcdir)/Include/internal/mimalloc -D_Py_NOTIER2
 # Both CPPFLAGS and LDFLAGS need to contain the shell's value for setup.py to
 # be able to build extension modules using the directories specified in the
 # environment variables

--- a/Modules/_opcode.c
+++ b/Modules/_opcode.c
@@ -394,6 +394,14 @@ _opcode_exec(PyObject *m) {
     if (PyModule_AddIntMacro(m, ENABLE_SPECIALIZATION) < 0) {
         return -1;
     }
+#ifdef _Py_NOTIER2
+    int notier2 = 1;
+#else
+    int notier2 = 0;
+#endif
+    if (PyModule_AddIntConstant(m, "NOTIER2", notier2) < 0) {
+        return -1;
+    }
     return 0;
 }
 

--- a/Python/bytecodes.c
+++ b/Python/bytecodes.c
@@ -2339,6 +2339,7 @@ dummy_func(
             CHECK_EVAL_BREAKER();
             assert(oparg <= INSTR_OFFSET());
             JUMPBY(-oparg);
+            #ifndef _Py_NOTIER2
             #if ENABLE_SPECIALIZATION
             _Py_BackoffCounter counter = this_instr[1].counter;
             if (backoff_counter_triggers(counter) && this_instr->op.code == JUMP_BACKWARD) {
@@ -2364,6 +2365,7 @@ dummy_func(
                 ADVANCE_ADAPTIVE_COUNTER(this_instr[1].counter);
             }
             #endif  /* ENABLE_SPECIALIZATION */
+            #endif  /* _Py_NOTIER2 */
         }
 
         pseudo(JUMP) = {
@@ -2377,6 +2379,9 @@ dummy_func(
         };
 
         tier1 inst(ENTER_EXECUTOR, (--)) {
+            #ifdef _Py_NOTIER2
+            assert(0);
+            #else
             CHECK_EVAL_BREAKER();
             PyCodeObject *code = _PyFrame_GetCode(frame);
             _PyExecutorObject *executor = code->co_executors->executors[oparg & 255];
@@ -2387,6 +2392,7 @@ dummy_func(
             tstate->previous_executor = Py_None;
             Py_INCREF(executor);
             GOTO_TIER_TWO(executor);
+            #endif  // _Py_NOTIER2
         }
 
         replaced op(_POP_JUMP_IF_FALSE, (cond -- )) {

--- a/Python/bytecodes.c
+++ b/Python/bytecodes.c
@@ -2398,8 +2398,10 @@ dummy_func(
         replaced op(_POP_JUMP_IF_FALSE, (cond -- )) {
             assert(PyBool_Check(cond));
             int flag = Py_IsFalse(cond);
+            #ifndef _Py_NOTIER2
             #if ENABLE_SPECIALIZATION
             this_instr[1].cache = (this_instr[1].cache << 1) | flag;
+            #endif
             #endif
             JUMPBY(oparg * flag);
         }
@@ -2407,8 +2409,10 @@ dummy_func(
         replaced op(_POP_JUMP_IF_TRUE, (cond -- )) {
             assert(PyBool_Check(cond));
             int flag = Py_IsTrue(cond);
+            #ifndef _Py_NOTIER2
             #if ENABLE_SPECIALIZATION
             this_instr[1].cache = (this_instr[1].cache << 1) | flag;
+            #endif
             #endif
             JUMPBY(oparg * flag);
         }
@@ -3979,8 +3983,10 @@ dummy_func(
             assert(PyBool_Check(cond));
             int flag = Py_IsTrue(cond);
             int offset = flag * oparg;
+            #ifndef _Py_NOTIER2
             #if ENABLE_SPECIALIZATION
             this_instr[1].cache = (this_instr[1].cache << 1) | flag;
+            #endif
             #endif
             INSTRUMENTED_JUMP(this_instr, next_instr + offset, PY_MONITORING_EVENT_BRANCH);
         }
@@ -3990,8 +3996,10 @@ dummy_func(
             assert(PyBool_Check(cond));
             int flag = Py_IsFalse(cond);
             int offset = flag * oparg;
+            #ifndef _Py_NOTIER2
             #if ENABLE_SPECIALIZATION
             this_instr[1].cache = (this_instr[1].cache << 1) | flag;
+            #endif
             #endif
             INSTRUMENTED_JUMP(this_instr, next_instr + offset, PY_MONITORING_EVENT_BRANCH);
         }
@@ -4007,8 +4015,10 @@ dummy_func(
                 Py_DECREF(value);
                 offset = 0;
             }
+            #ifndef _Py_NOTIER2
             #if ENABLE_SPECIALIZATION
             this_instr[1].cache = (this_instr[1].cache << 1) | flag;
+            #endif
             #endif
             INSTRUMENTED_JUMP(this_instr, next_instr + offset, PY_MONITORING_EVENT_BRANCH);
         }
@@ -4024,8 +4034,10 @@ dummy_func(
                 Py_DECREF(value);
                 offset = oparg;
             }
+            #ifndef _Py_NOTIER2
             #if ENABLE_SPECIALIZATION
             this_instr[1].cache = (this_instr[1].cache << 1) | !nflag;
+            #endif
             #endif
             INSTRUMENTED_JUMP(this_instr, next_instr + offset, PY_MONITORING_EVENT_BRANCH);
         }

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -754,10 +754,12 @@ _PyEval_EvalFrameDefault(PyThreadState *tstate, _PyInterpreterFrame *frame, int 
     _Py_CODEUNIT *next_instr;
     PyObject **stack_pointer;
 
+#ifndef _Py_NOTIER2
 #ifndef _Py_JIT
     /* Tier 2 interpreter state */
     _PyExecutorObject *current_executor = NULL;
     const _PyUOpInstruction *next_uop = NULL;
+#endif
 #endif
 
 start_frame:
@@ -958,6 +960,7 @@ resume_with_error:
     goto error;
 
 
+#ifndef _Py_NOTIER2
 
 // Tier 2 is also here!
 enter_tier_two:
@@ -1107,6 +1110,8 @@ exit_to_trace:
     GOTO_TIER_TWO(exit->executor);
 
 #endif  // _Py_JIT
+
+#endif  // _Py_NOTIER2
 
 }
 

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -678,6 +678,7 @@ extern void _PyUOpPrint(const _PyUOpInstruction *uop);
  * so consume 3 units of C stack */
 #define PY_EVAL_C_STACK_UNITS 2
 
+#ifndef _Py_NOTIER2
 #if defined(_MSC_VER) && defined(_Py_USING_PGO)
 /* gh-111786: _PyEval_EvalFrameDefault is too large to optimize for speed with
    PGO on MSVC. Disable that optimization temporarily. If this is fixed
@@ -685,6 +686,7 @@ extern void _PyUOpPrint(const _PyUOpInstruction *uop);
  */
 #  pragma optimize("t", off)
 /* This setting is reversed below following _PyEval_EvalFrameDefault */
+#endif
 #endif
 
 PyObject* _Py_HOT_FUNCTION
@@ -1119,7 +1121,9 @@ exit_to_trace:
 #  pragma GCC diagnostic pop
 #elif defined(_MSC_VER) /* MS_WINDOWS */
 #  pragma warning(pop)
+#ifdef _Py_NOTIER2
 #  pragma optimize("", on)
+#endif
 #endif
 
 static void

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -1115,6 +1115,17 @@ exit_to_trace:
 
 #endif  // _Py_NOTIER2
 
+// Undefine the macros we redefined, to avoid using the wrong ones below
+#undef LOAD_IP
+#undef GOTO_ERROR
+#undef ENABLE_SPECIALIZATION
+#undef STAT_INC
+#undef STAT_DEC
+#undef CALL_STAT_INC
+
+// Restore this one
+#define CALL_STAT_INC(name) REAL_CALL_STAT_INC(name)
+
 }
 
 #if defined(__GNUC__)

--- a/Python/generated_cases.c.h
+++ b/Python/generated_cases.c.h
@@ -2501,6 +2501,9 @@
             frame->instr_ptr = next_instr;
             next_instr += 1;
             INSTRUCTION_STATS(ENTER_EXECUTOR);
+            #ifdef _Py_NOTIER2
+            assert(0);
+            #else
             CHECK_EVAL_BREAKER();
             PyCodeObject *code = _PyFrame_GetCode(frame);
             _PyExecutorObject *executor = code->co_executors->executors[oparg & 255];
@@ -2511,6 +2514,7 @@
             tstate->previous_executor = Py_None;
             Py_INCREF(executor);
             GOTO_TIER_TWO(executor);
+            #endif  // _Py_NOTIER2
             DISPATCH();
         }
 
@@ -3414,6 +3418,7 @@
             CHECK_EVAL_BREAKER();
             assert(oparg <= INSTR_OFFSET());
             JUMPBY(-oparg);
+            #ifndef _Py_NOTIER2
             #if ENABLE_SPECIALIZATION
             _Py_BackoffCounter counter = this_instr[1].counter;
             if (backoff_counter_triggers(counter) && this_instr->op.code == JUMP_BACKWARD) {
@@ -3439,6 +3444,7 @@
                 ADVANCE_ADAPTIVE_COUNTER(this_instr[1].counter);
             }
             #endif  /* ENABLE_SPECIALIZATION */
+            #endif  /* _Py_NOTIER2 */
             DISPATCH();
         }
 

--- a/Python/generated_cases.c.h
+++ b/Python/generated_cases.c.h
@@ -3195,8 +3195,10 @@
             assert(PyBool_Check(cond));
             int flag = Py_IsFalse(cond);
             int offset = flag * oparg;
+            #ifndef _Py_NOTIER2
             #if ENABLE_SPECIALIZATION
             this_instr[1].cache = (this_instr[1].cache << 1) | flag;
+            #endif
             #endif
             INSTRUMENTED_JUMP(this_instr, next_instr + offset, PY_MONITORING_EVENT_BRANCH);
             DISPATCH();
@@ -3218,8 +3220,10 @@
                 Py_DECREF(value);
                 offset = 0;
             }
+            #ifndef _Py_NOTIER2
             #if ENABLE_SPECIALIZATION
             this_instr[1].cache = (this_instr[1].cache << 1) | flag;
+            #endif
             #endif
             INSTRUMENTED_JUMP(this_instr, next_instr + offset, PY_MONITORING_EVENT_BRANCH);
             DISPATCH();
@@ -3241,8 +3245,10 @@
                 Py_DECREF(value);
                 offset = oparg;
             }
+            #ifndef _Py_NOTIER2
             #if ENABLE_SPECIALIZATION
             this_instr[1].cache = (this_instr[1].cache << 1) | !nflag;
+            #endif
             #endif
             INSTRUMENTED_JUMP(this_instr, next_instr + offset, PY_MONITORING_EVENT_BRANCH);
             DISPATCH();
@@ -3258,8 +3264,10 @@
             assert(PyBool_Check(cond));
             int flag = Py_IsTrue(cond);
             int offset = flag * oparg;
+            #ifndef _Py_NOTIER2
             #if ENABLE_SPECIALIZATION
             this_instr[1].cache = (this_instr[1].cache << 1) | flag;
+            #endif
             #endif
             INSTRUMENTED_JUMP(this_instr, next_instr + offset, PY_MONITORING_EVENT_BRANCH);
             DISPATCH();
@@ -4716,8 +4724,10 @@
             cond = stack_pointer[-1];
             assert(PyBool_Check(cond));
             int flag = Py_IsFalse(cond);
+            #ifndef _Py_NOTIER2
             #if ENABLE_SPECIALIZATION
             this_instr[1].cache = (this_instr[1].cache << 1) | flag;
+            #endif
             #endif
             JUMPBY(oparg * flag);
             stack_pointer += -1;
@@ -4749,8 +4759,10 @@
             {
                 assert(PyBool_Check(cond));
                 int flag = Py_IsTrue(cond);
+                #ifndef _Py_NOTIER2
                 #if ENABLE_SPECIALIZATION
                 this_instr[1].cache = (this_instr[1].cache << 1) | flag;
+                #endif
                 #endif
                 JUMPBY(oparg * flag);
             }
@@ -4783,8 +4795,10 @@
             {
                 assert(PyBool_Check(cond));
                 int flag = Py_IsFalse(cond);
+                #ifndef _Py_NOTIER2
                 #if ENABLE_SPECIALIZATION
                 this_instr[1].cache = (this_instr[1].cache << 1) | flag;
+                #endif
                 #endif
                 JUMPBY(oparg * flag);
             }
@@ -4802,8 +4816,10 @@
             cond = stack_pointer[-1];
             assert(PyBool_Check(cond));
             int flag = Py_IsTrue(cond);
+            #ifndef _Py_NOTIER2
             #if ENABLE_SPECIALIZATION
             this_instr[1].cache = (this_instr[1].cache << 1) | flag;
+            #endif
             #endif
             JUMPBY(oparg * flag);
             stack_pointer += -1;

--- a/configure
+++ b/configure
@@ -1087,6 +1087,7 @@ with_pydebug
 with_trace_refs
 enable_pystats
 with_assertions
+enable_tier2
 enable_experimental_jit
 enable_optimizations
 with_lto
@@ -1815,6 +1816,7 @@ Optional Features:
   --disable-gil           enable experimental support for running without the
                           GIL (default is no)
   --enable-pystats        enable internal statistics gathering (default is no)
+  --disable-tier2         disable tier 2 interpreter support (default is no)
   --enable-experimental-jit
                           build the experimental just-in-time compiler
                           (default is no)
@@ -8206,6 +8208,34 @@ printf "%s\n" "implied by --with-pydebug" >&6; }
 else
   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
 printf "%s\n" "no" >&6; }
+fi
+
+# Check for --disable-tier2
+# --disable-tier2
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for --disable-tier2" >&5
+printf %s "checking for --disable-tier2... " >&6; }
+# Check whether --enable-tier2 was given.
+if test ${enable_tier2+y}
+then :
+  enableval=$enable_tier2; if test "x$enable_tier2" = xyes
+then :
+  disable_tier2=no
+else $as_nop
+  disable_tier2=yes
+fi
+else $as_nop
+  disable_tier2=no
+
+fi
+
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $disable_tier2" >&5
+printf "%s\n" "$disable_tier2" >&6; }
+
+if test "$disable_tier2" = "yes"
+then
+
+printf "%s\n" "#define _Py_NOTIER2 1" >>confdefs.h
+
 fi
 
 # Check for --enable-experimental-jit:

--- a/configure.ac
+++ b/configure.ac
@@ -1762,6 +1762,21 @@ else
   AC_MSG_RESULT([no])
 fi
 
+# Check for --disable-tier2
+# --disable-tier2
+AC_MSG_CHECKING([for --disable-tier2])
+AC_ARG_ENABLE([tier2],
+  [AS_HELP_STRING([--disable-tier2], [disable tier 2 interpreter support (default is no)])],
+  [AS_VAR_IF([enable_tier2], [yes], [disable_tier2=no], [disable_tier2=yes])], [disable_tier2=no]
+)
+AC_MSG_RESULT([$disable_tier2])
+
+if test "$disable_tier2" = "yes"
+then
+  AC_DEFINE([_Py_NOTIER2], [1],
+            [Define if you want to disable the tier 2 interpreter entirely])
+fi
+
 # Check for --enable-experimental-jit:
 AC_MSG_CHECKING([for --enable-experimental-jit])
 AC_ARG_ENABLE([experimental-jit],

--- a/pyconfig.h.in
+++ b/pyconfig.h.in
@@ -1923,6 +1923,9 @@
 /* framework name */
 #undef _PYTHONFRAMEWORK
 
+/* Define if you want to disable the tier 2 interpreter entirely */
+#undef _Py_NOTIER2
+
 /* Define to force use of thread-safe errno, h_errno, and other functions */
 #undef _REENTRANT
 


### PR DESCRIPTION
Because this is just a quick test, I used a hack to define the crucial env var, `_Py_NOTIER2`, by hard-coding it in Makefile.pre.in. **If** this shows enough of an improvement for Tier 1 that we'd like to have this option, that hack should be replaced with a new configure option. (Adding configure options looks like black magic to me, and IIRC requires using a Docker image to build, so I'm putting that off until after we've seen benchmark results.)

Because of that hack, this fails all the JIT tests. I'll just be ignoring that.

There's also a weird test failure in the WASI build, which I'll also ignore unless we decide to move ahead with this.