### PR TITLE
gh-76785: Fix Windows Refleak in test_interpreters

### DIFF
--- a/Lib/test/test_interpreters/test_api.py
+++ b/Lib/test/test_interpreters/test_api.py
@@ -174,9 +174,6 @@ class GetCurrentTests(TestBase):
 
     @requires_test_modules
     def test_created_with_capi(self):
-        last = 0
-        for id, *_ in _interpreters.list_all():
-            last = max(last, id)
         expected = _testinternalcapi.next_interpreter_id()
         text = self.run_temp_from_capi(f"""
             import {interpreters.__name__} as interpreters

--- a/Lib/test/test_interpreters/utils.py
+++ b/Lib/test/test_interpreters/utils.py
@@ -17,10 +17,13 @@ import unittest
 import warnings
 
 from test import support
-from test.support import os_helper
-from test.support import import_helper
 
-_interpreters = import_helper.import_module('_xxsubinterpreters')
+# We would use test.support.import_helper.import_module(),
+# but the indirect import of test.support.os_helper causes refleaks.
+try:
+    import _xxsubinterpreters as _interpreters
+except ImportError as exc:
+    raise unittest.SkipTest(str(exc))
 from test.support import interpreters
 
 
@@ -399,6 +402,7 @@ class TestBase(unittest.TestCase):
     def temp_dir(self):
         tempdir = tempfile.mkdtemp()
         tempdir = os.path.realpath(tempdir)
+        from test.support import os_helper
         self.addCleanup(lambda: os_helper.rmtree(tempdir))
         return tempdir
 


### PR DESCRIPTION
gh-117662 introduced some refleaks, or, rather, exposed some existing refleaks.  The leaks are coming when test.support.os_helper is imported in a "legacy" interpreter.  I've updated test.test_interpreters.utils to avoid importing os_helper, which fixes the leaks.  I'll address the root cause separately.

<!-- gh-issue-number: gh-76785 -->
* Issue: gh-76785
<!-- /gh-issue-number -->
