### PR TITLE
linecache: Fix docstring location

### DIFF
--- a/Lib/linecache.py
+++ b/Lib/linecache.py
@@ -78,16 +78,15 @@ def checkcache(filename=None):
 
 
 def updatecache(filename, module_globals=None):
-    # These imports are not at top level because linecache is in the critical
-    # path of the interpreter startup and importing os and sys take a lot of time
-    # and slow down the startup sequence.
-    import os
-    import sys
-
     """Update a cache entry and return its list of lines.
     If something's wrong, print a message, discard the cache entry,
     and return an empty list."""
 
+    # These imports are not at top level because linecache is in the critical
+    # path of the interpreter startup and importing os and sys take a lot of time
+    # and slows down the startup sequence.
+    import os
+    import sys
     import tokenize
 
     if filename in cache:


### PR DESCRIPTION
gh-117501 put some code before the docstring, so now it is no longer
recognized as a docstring.