### PR TITLE
gh-117657: Fix data races in the method cache in free-threaded builds

### DIFF
--- a/Tools/tsan/suppressions_free_threading.txt
+++ b/Tools/tsan/suppressions_free_threading.txt
@@ -47,5 +47,4 @@ race:set_inheritable
 race:start_the_world
 race:tstate_set_detached
 race:unicode_hash
-race:update_cache
 race:update_cache_gil_disabled


### PR DESCRIPTION
These are technically data races, but I think they're benign (to the extent that that is actually possible). We update cache entries non-atomically:

https://github.com/python/cpython/blob/a23fa3368e50866f31d6fc1c66a9a5ca2a580239/Objects/typeobject.c#L4974-L4984

 but read them atomically from another thread:

https://github.com/python/cpython/blob/a23fa3368e50866f31d6fc1c66a9a5ca2a580239/Objects/typeobject.c#L5046-L5051

and there's nothing that establishes a happens-before relationship between the reads and writes that I can see. 

In practice I don't think this matters much. We care about always reading the entire entry atomically, and the sequence lock enforces that.

Sample races reported by TSAN:

- https://gist.github.com/mpage/8633aacbf11303bdfdbda2c0e644d43d
- https://gist.github.com/mpage/70d5758968c0225384a2ace448122d09
- https://gist.github.com/mpage/33436b62af0d2e688f36c4ecb9171dee

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-117657 -->
* Issue: gh-117657
<!-- /gh-issue-number -->
