### PR TITLE
fixed "TypeError: '>=' not supported between instances of 'int' and '…

### DIFF
--- a/Lib/logging/handlers.py
+++ b/Lib/logging/handlers.py
@@ -1371,7 +1371,7 @@ class MemoryHandler(BufferingHandler):
         capacity exceeded. To prevent this, set ``flushOnClose`` to ``False``.
         """
         BufferingHandler.__init__(self, capacity)
-        self.flushLevel = flushLevel
+        self.flushLevel = logging._checkLevel(flushLevel)
         self.target = target
         # See Issue #26559 for why this has been added
         self.flushOnClose = flushOnClose


### PR DESCRIPTION
fix for error
```
logging/handlers.py", line 1364, in shouldFlush
    (record.levelno >= self.flushLevel)
TypeError: '>=' not supported between instances of 'int' and 'str'
```
when setting up from `logging.config.dictConfig()` with e.g. json: `"flushLevel": "ERROR",`
