### PR TITLE
Test: Get the smtp test server using os.getenv()

### DIFF
--- a/Lib/test/test_smtpnet.py
+++ b/Lib/test/test_smtpnet.py
@@ -2,12 +2,15 @@ import unittest
 from test import support
 from test.support import import_helper
 from test.support import socket_helper
+import os
 import smtplib
 import socket
 
 ssl = import_helper.import_module("ssl")
 
 support.requires("network")
+
+SMTP_TEST_SERVER = os.getenv('SMTP_TEST_SERVER', 'smtp.gmail.com')
 
 def check_ssl_verifiy(host, port):
     context = ssl.create_default_context()
@@ -22,7 +25,7 @@ def check_ssl_verifiy(host, port):
 
 
 class SmtpTest(unittest.TestCase):
-    testServer = 'smtp.gmail.com'
+    testServer = SMTP_TEST_SERVER
     remotePort = 587
 
     def test_connect_starttls(self):
@@ -44,7 +47,7 @@ class SmtpTest(unittest.TestCase):
 
 
 class SmtpSSLTest(unittest.TestCase):
-    testServer = 'smtp.gmail.com'
+    testServer = SMTP_TEST_SERVER
     remotePort = 465
 
     def test_connect(self):

--- a/Lib/test/test_smtpnet.py
+++ b/Lib/test/test_smtpnet.py
@@ -10,7 +10,7 @@ ssl = import_helper.import_module("ssl")
 
 support.requires("network")
 
-SMTP_TEST_SERVER = os.getenv('SMTP_TEST_SERVER', 'smtp.gmail.com')
+SMTP_TEST_SERVER = os.getenv('CPYTHON_TEST_SMTP_SERVER', 'smtp.gmail.com')
 
 def check_ssl_verifiy(host, port):
     context = ssl.create_default_context()


### PR DESCRIPTION
The smtp test server can be set via SMTP_TEST_SERVER environment variable. If not set, it uses the default value smtp.gmail.com This is needed because the network I'm on filters access to smtp.gmail.com resulting in a failing test.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
