### PR TITLE
gh-102402: Fix logging test_relativeCreated_has_higher_precision() leak

### DIFF
--- a/Lib/test/test_logging.py
+++ b/Lib/test/test_logging.py
@@ -4569,6 +4569,8 @@ class FormatterTest(unittest.TestCase, AssertErrorMessage):
             self.assertEqual(record.msecs, want)
             self.assertEqual(record.created, ns / 1e9)
 
+    # The test overrides a private attribute
+    @support.cpython_only
     def test_relativeCreated_has_higher_precision(self):
         # See issue gh-102402
         ns = 1_677_903_920_000_998_503  # approx. 2023-03-04 04:25:20 UTC

--- a/Lib/test/test_logging.py
+++ b/Lib/test/test_logging.py
@@ -4573,23 +4573,19 @@ class FormatterTest(unittest.TestCase, AssertErrorMessage):
         # See issue gh-102402
         ns = 1_677_903_920_000_998_503  # approx. 2023-03-04 04:25:20 UTC
         offsets_ns = (200, 500, 12_354, 99_999, 1_677_903_456_999_123_456)
-        orig_modules = import_helper._save_and_remove_modules(['logging'])
-        try:
-            with patch("time.time_ns") as patched_ns:
-                # mock for module import
-                patched_ns.return_value = ns
-                import logging
-                for offset_ns in offsets_ns:
-                    new_ns = ns + offset_ns
-                    # mock for log record creation
-                    patched_ns.return_value = new_ns
-                    record = logging.makeLogRecord({'msg': 'test'})
-                    self.assertAlmostEqual(record.created, new_ns / 1e9, places=6)
-                    # After PR gh-102412, precision (places) increases from 3 to 7
-                    self.assertAlmostEqual(record.relativeCreated, offset_ns / 1e6, places=7)
-        finally:
-            import_helper._save_and_remove_modules(['logging'])
-            sys.modules.update(orig_modules)
+
+        with (patch("time.time_ns") as time_ns_mock,
+              support.swap_attr(logging, '_startTime', ns)):
+            for offset_ns in offsets_ns:
+                # mock for log record creation
+                new_ns = ns + offset_ns
+                time_ns_mock.return_value = new_ns
+
+                record = logging.makeLogRecord({'msg': 'test'})
+                self.assertAlmostEqual(record.created, new_ns / 1e9, places=6)
+
+                # After PR gh-102412, precision (places) increases from 3 to 7
+                self.assertAlmostEqual(record.relativeCreated, offset_ns / 1e6, places=7)
 
 
 class TestBufferingFormatter(logging.BufferingFormatter):


### PR DESCRIPTION
Fix a reference leak in test_relativeCreated_has_higher_precision() of test_logging: don't reimport the logging the logging module.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-102402 -->
* Issue: gh-102402
<!-- /gh-issue-number -->
