### PR TITLE
gh-116932: Add notes on how to report python documentation theme bugs

### DIFF
--- a/Doc/bugs.rst
+++ b/Doc/bugs.rst
@@ -22,6 +22,10 @@ have a suggestion on how to fix it, include that as well.
 You can also open a discussion item on our
 `Documentation Discourse forum <https://discuss.python.org/c/documentation/26>`_.
 
+If you find a bug in the theme (HTML / CSS / JavaScript) of the
+documentation, please submit a bug report on the `python-doc-theme bug
+tracker <https://github.com/python/python-docs-theme>`_.
+
 If you're short on time, you can also email documentation bug reports to
 docs@python.org (behavioral bugs can be sent to python-list@python.org).
 'docs@' is a mailing list run by volunteers; your request will be noticed,

--- a/Misc/NEWS.d/next/Documentation/2024-04-17-22-16-19.gh-issue-116932.lETyxa.rst
+++ b/Misc/NEWS.d/next/Documentation/2024-04-17-22-16-19.gh-issue-116932.lETyxa.rst
@@ -1,0 +1,1 @@
+Add notes on how to report python documentation theme bugs


### PR DESCRIPTION
Fix #116932

<!-- gh-issue-number: gh-116932 -->
* Issue: gh-116932
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--117989.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->