### PR TITLE
gh-80361: Fix TypeError in email.Message.get_payload()

### DIFF
--- a/Lib/email/message.py
+++ b/Lib/email/message.py
@@ -294,7 +294,7 @@ class Message:
                 try:
                     bpayload = payload.encode('ascii', 'surrogateescape')
                     try:
-                        payload = bpayload.decode(self.get_param('charset', 'ascii'), 'replace')
+                        payload = bpayload.decode(self.get_content_charset('ascii'), 'replace')
                     except LookupError:
                         payload = bpayload.decode('ascii', 'replace')
                 except UnicodeEncodeError:

--- a/Lib/test/test_email/test_email.py
+++ b/Lib/test/test_email/test_email.py
@@ -4181,6 +4181,21 @@ class Test8BitBytesHandling(TestEmailBase):
         self.assertEqual(msg.get_payload(decode=True),
                          '<,.V<W1A; á \n'.encode('utf-8'))
 
+    def test_rfc2231_charset_8bit_CTE(self):
+        m = textwrap.dedent("""\
+        From: foo@bar.com
+        To: baz
+        Mime-Version: 1.0
+        Content-Type: text/plain; charset*=ansi-x3.4-1968''utf-8
+        Content-Transfer-Encoding: 8bit
+
+        pöstal
+        """).encode('utf-8')
+        msg = email.message_from_bytes(m)
+        self.assertEqual(msg.get_payload(), "pöstal\n")
+        self.assertEqual(msg.get_payload(decode=True),
+                         "pöstal\n".encode('utf-8'))
+
 
     headertest_headers = (
         ('From: foo@bar.com', ('From', 'foo@bar.com')),

--- a/Misc/NEWS.d/next/Library/2024-04-17-18-00-30.gh-issue-80361.RstWg-.rst
+++ b/Misc/NEWS.d/next/Library/2024-04-17-18-00-30.gh-issue-80361.RstWg-.rst
@@ -1,0 +1,2 @@
+Fix TypeError in :func:`email.Message.get_payload` when the charset is :rfc:`2231`
+encoded.


### PR DESCRIPTION
It was raised when the charset is rfc2231 encoded, e.g.:

   Content-Type: text/plain; charset*=ansi-x3.4-1968''utf-8


<!-- gh-issue-number: gh-80361 -->
* Issue: gh-80361
<!-- /gh-issue-number -->
