### PR TITLE
gh-114539: Clarify implicit launching of shells by subprocess

### DIFF
--- a/Doc/library/subprocess.rst
+++ b/Doc/library/subprocess.rst
@@ -754,8 +754,8 @@ Exceptions defined in this module all inherit from :exc:`SubprocessError`.
 Security Considerations
 -----------------------
 
-Unlike some other popen functions, this implementation will never
-implicitly call a system shell.  This means that all characters,
+Unlike some other popen functions, this library will not
+implicitly choose to call a system shell.  This means that all characters,
 including shell metacharacters, can safely be passed to child processes.
 If the shell is invoked explicitly, via ``shell=True``, it is the application's
 responsibility to ensure that all whitespace and metacharacters are
@@ -763,6 +763,13 @@ quoted appropriately to avoid
 `shell injection <https://en.wikipedia.org/wiki/Shell_injection#Shell_injection>`_
 vulnerabilities. On :ref:`some platforms <shlex-quote-warning>`, it is possible
 to use :func:`shlex.quote` for this escaping.
+
+On Windows, batch files (:file:`*.bat` or :file:`*.cmd`) may be launched by the
+operating system in a system shell regardless of the arguments passed to this
+library. This could result in arguments being parsed according to shell rules,
+but without any escaping added by Python. If you are intentionally launching a
+batch file with arguments from untrusted sources, consider passing
+``shell=True`` to allow Python to escape special characters.
 
 
 Popen Objects

--- a/Doc/library/subprocess.rst
+++ b/Doc/library/subprocess.rst
@@ -769,7 +769,8 @@ operating system in a system shell regardless of the arguments passed to this
 library. This could result in arguments being parsed according to shell rules,
 but without any escaping added by Python. If you are intentionally launching a
 batch file with arguments from untrusted sources, consider passing
-``shell=True`` to allow Python to escape special characters.
+``shell=True`` to allow Python to escape special characters. See :gh:`114539`
+for additional discussion.
 
 
 Popen Objects


### PR DESCRIPTION
This is the same issue as recently disclosed by Rust (CVE-2024-24576), but as it is intentional operating system behaviour, we consider it to not be a Python vulnerability. If an attacker can influence the executable argument and other arguments, no reasonable validation can detect this case (without actually launching the executable and seeing what happens), and the app is exploitable already.

Rust was already detecting whether the executable was a batch file and changing their behaviour, which is why they chose to apply a fix. Python does no such detection, but relies exclusively on the `shell` argument.

<!-- gh-issue-number: gh-114539 -->
* Issue: gh-114539
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--117996.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->