### PR TITLE
gh-117995: Don't raise DeprecationWarnings for indexed nameless params

### DIFF
--- a/Lib/test/test_sqlite3/test_dbapi.py
+++ b/Lib/test/test_sqlite3/test_dbapi.py
@@ -28,6 +28,7 @@ import sys
 import threading
 import unittest
 import urllib.parse
+import warnings
 
 from test.support import (
     SHORT_TIMEOUT, check_disallow_instantiation, requires_subprocess,
@@ -894,9 +895,11 @@ class CursorTests(unittest.TestCase):
             ("select ?2, ?1", (1, 2), (2, 1)),
         ):
             with self.subTest(query=query, params=params):
-                cu = self.cu.execute(query, params)
-                actual, = cu.fetchall()
-                self.assertEqual(actual, expected)
+                with warnings.catch_warnings(record=True) as cm:
+                    cu = self.cu.execute(query, params)
+                    actual, = cu.fetchall()
+                    self.assertEqual(actual, expected)
+                self.assertEqual(cm, [])
 
     def test_execute_too_many_params(self):
         category = sqlite.SQLITE_LIMIT_VARIABLE_NUMBER

--- a/Lib/test/test_sqlite3/test_dbapi.py
+++ b/Lib/test/test_sqlite3/test_dbapi.py
@@ -895,7 +895,7 @@ class CursorTests(unittest.TestCase):
             ("select ?2, ?1", (1, 2), (2, 1)),
         ):
             with self.subTest(query=query, params=params):
-                with warnings.catch_warnings(record=True):
+                with warnings.catch_warnings():
                     warnings.simplefilter("error", DeprecationWarning)
                     cu = self.cu.execute(query, params)
                     actual, = cu.fetchall()

--- a/Lib/test/test_sqlite3/test_dbapi.py
+++ b/Lib/test/test_sqlite3/test_dbapi.py
@@ -895,11 +895,11 @@ class CursorTests(unittest.TestCase):
             ("select ?2, ?1", (1, 2), (2, 1)),
         ):
             with self.subTest(query=query, params=params):
-                with warnings.catch_warnings(record=True) as cm:
+                with warnings.catch_warnings(record=True):
+                    warnings.simplefilter("error", DeprecationWarning)
                     cu = self.cu.execute(query, params)
                     actual, = cu.fetchall()
                     self.assertEqual(actual, expected)
-                self.assertEqual(cm, [])
 
     def test_execute_too_many_params(self):
         category = sqlite.SQLITE_LIMIT_VARIABLE_NUMBER

--- a/Lib/test/test_sqlite3/test_dbapi.py
+++ b/Lib/test/test_sqlite3/test_dbapi.py
@@ -887,6 +887,17 @@ class CursorTests(unittest.TestCase):
                     self.cu.execute(query, params)
                 self.assertEqual(cm.filename,  __file__)
 
+    def test_execute_indexed_nameless_params(self):
+        # See gh-117995: "'?1' is considered a named placeholder"
+        for query, params, expected in (
+            ("select ?1, ?2", (1, 2), (1, 2)),
+            ("select ?2, ?1", (1, 2), (2, 1)),
+        ):
+            with self.subTest(query=query, params=params):
+                cu = self.cu.execute(query, params)
+                actual, = cu.fetchall()
+                self.assertEqual(actual, expected)
+
     def test_execute_too_many_params(self):
         category = sqlite.SQLITE_LIMIT_VARIABLE_NUMBER
         msg = "too many SQL variables"

--- a/Misc/NEWS.d/next/Library/2024-04-17-19-41-59.gh-issue-117995.Vt76Rv.rst
+++ b/Misc/NEWS.d/next/Library/2024-04-17-19-41-59.gh-issue-117995.Vt76Rv.rst
@@ -1,0 +1,2 @@
+Don't raise :exc:`DeprecationWarning` when a :term:`sequence` of parameters
+is used to bind indexed, nameless placeholders. See also :gh:`100668`.

--- a/Modules/_sqlite/cursor.c
+++ b/Modules/_sqlite/cursor.c
@@ -669,7 +669,7 @@ bind_parameters(pysqlite_state *state, pysqlite_Statement *self,
         }
         for (i = 0; i < num_params; i++) {
             const char *name = sqlite3_bind_parameter_name(self->st, i+1);
-            if (name != NULL) {
+            if (name != NULL && name[0] != '?') {
                 int ret = PyErr_WarnFormat(PyExc_DeprecationWarning, 1,
                         "Binding %d ('%s') is a named parameter, but you "
                         "supplied a sequence which requires nameless (qmark) "


### PR DESCRIPTION
Filter out `?NNN` type placeholders when looking for named params.


<!-- gh-issue-number: gh-117995 -->
* Issue: gh-117995
<!-- /gh-issue-number -->
