### PR TITLE
gh-117873: Deprecate grp keyword arguments

### DIFF
--- a/Doc/whatsnew/3.14.rst
+++ b/Doc/whatsnew/3.14.rst
@@ -96,6 +96,9 @@ Optimizations
 Deprecated
 ==========
 
+* :mod:`grp`: Deprecate passing keyword arguments to :func:`grp.getgrgid` and
+  :func:`grp.getgrnam` functions.
+  (Contributed by Victor Stinner in :gh:`117873`.)
 
 
 Removed

--- a/Misc/NEWS.d/next/Library/2024-04-17-23-14-05.gh-issue-117873.3cf35E.rst
+++ b/Misc/NEWS.d/next/Library/2024-04-17-23-14-05.gh-issue-117873.3cf35E.rst
@@ -1,0 +1,2 @@
+:mod:`grp`: Deprecate passing keyword arguments to :func:`grp.getgrgid` and
+:func:`grp.getgrnam` functions. Patch by Victor Stinner.

--- a/Modules/clinic/grpmodule.c.h
+++ b/Modules/clinic/grpmodule.c.h
@@ -16,16 +16,36 @@ PyDoc_STRVAR(grp_getgrgid__doc__,
 static PyObject *
 grp_getgrgid_impl(PyObject *module, PyObject *id);
 
+// Emit compiler warnings when we get to Python 3.16.
+#if PY_VERSION_HEX >= 0x031000C0
+#  error "Update the clinic input of 'grp.getgrgid'."
+#elif PY_VERSION_HEX >= 0x031000A0
+#  ifdef _MSC_VER
+#    pragma message ("Update the clinic input of 'grp.getgrgid'.")
+#  else
+#    warning "Update the clinic input of 'grp.getgrgid'."
+#  endif
+#endif
+
 static PyObject *
 grp_getgrgid(PyObject *module, PyObject *args, PyObject *kwargs)
 {
     PyObject *return_value = NULL;
     static char *_keywords[] = {"id", NULL};
+    Py_ssize_t nargs = PyTuple_Size(args);
     PyObject *id;
 
     if (!PyArg_ParseTupleAndKeywords(args, kwargs, "O:getgrgid", _keywords,
         &id))
         goto exit;
+    if (nargs < 1) {
+        if (PyErr_WarnEx(PyExc_DeprecationWarning,
+                "Passing keyword argument 'id' to grp.getgrgid() is deprecated. "
+                "Parameter 'id' will become positional-only in Python 3.16.", 1))
+        {
+            goto exit;
+        }
+    }
     return_value = grp_getgrgid_impl(module, id);
 
 exit:
@@ -46,16 +66,36 @@ PyDoc_STRVAR(grp_getgrnam__doc__,
 static PyObject *
 grp_getgrnam_impl(PyObject *module, PyObject *name);
 
+// Emit compiler warnings when we get to Python 3.16.
+#if PY_VERSION_HEX >= 0x031000C0
+#  error "Update the clinic input of 'grp.getgrnam'."
+#elif PY_VERSION_HEX >= 0x031000A0
+#  ifdef _MSC_VER
+#    pragma message ("Update the clinic input of 'grp.getgrnam'.")
+#  else
+#    warning "Update the clinic input of 'grp.getgrnam'."
+#  endif
+#endif
+
 static PyObject *
 grp_getgrnam(PyObject *module, PyObject *args, PyObject *kwargs)
 {
     PyObject *return_value = NULL;
     static char *_keywords[] = {"name", NULL};
+    Py_ssize_t nargs = PyTuple_Size(args);
     PyObject *name;
 
     if (!PyArg_ParseTupleAndKeywords(args, kwargs, "U:getgrnam", _keywords,
         &name))
         goto exit;
+    if (nargs < 1) {
+        if (PyErr_WarnEx(PyExc_DeprecationWarning,
+                "Passing keyword argument 'name' to grp.getgrnam() is deprecated."
+                " Parameter 'name' will become positional-only in Python 3.16.", 1))
+        {
+            goto exit;
+        }
+    }
     return_value = grp_getgrnam_impl(module, name);
 
 exit:
@@ -82,4 +122,4 @@ grp_getgrall(PyObject *module, PyObject *Py_UNUSED(ignored))
 {
     return grp_getgrall_impl(module);
 }
-/*[clinic end generated code: output=81f180beb67fc585 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=1097d5192981d137 input=a9049054013a1b77]*/

--- a/Modules/grpmodule.c
+++ b/Modules/grpmodule.c
@@ -114,6 +114,7 @@ mkgrent(PyObject *module, struct group *p)
 grp.getgrgid
 
     id: object
+    / [from 3.16]
 
 Return the group database entry for the given numeric group ID.
 
@@ -122,7 +123,7 @@ If id is not valid, raise KeyError.
 
 static PyObject *
 grp_getgrgid_impl(PyObject *module, PyObject *id)
-/*[clinic end generated code: output=30797c289504a1ba input=15fa0e2ccf5cda25]*/
+/*[clinic end generated code: output=30797c289504a1ba input=b0f482517fa9c22a]*/
 {
     PyObject *retval = NULL;
     int nomem = 0;
@@ -194,6 +195,7 @@ grp_getgrgid_impl(PyObject *module, PyObject *id)
 grp.getgrnam
 
     name: unicode
+    / [from 3.16]
 
 Return the group database entry for the given group name.
 
@@ -202,7 +204,7 @@ If name is not valid, raise KeyError.
 
 static PyObject *
 grp_getgrnam_impl(PyObject *module, PyObject *name)
-/*[clinic end generated code: output=67905086f403c21c input=08ded29affa3c863]*/
+/*[clinic end generated code: output=67905086f403c21c input=bbcdbc9a8786c117]*/
 {
     char *buf = NULL, *buf2 = NULL, *name_chars;
     int nomem = 0;


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-117873 -->
* Issue: gh-117873
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--118010.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->