### PR TITLE
gh-117873: Use positional-only parameters in _posixshmem

### DIFF
--- a/Modules/_multiprocessing/clinic/posixshmem.c.h
+++ b/Modules/_multiprocessing/clinic/posixshmem.c.h
@@ -5,7 +5,7 @@ preserve
 #if defined(HAVE_SHM_OPEN)
 
 PyDoc_STRVAR(_posixshmem_shm_open__doc__,
-"shm_open($module, /, path, flags, mode=511)\n"
+"shm_open($module, path, /, flags, mode=511)\n"
 "--\n"
 "\n"
 "Open a shared memory object.  Returns a file descriptor (integer).");
@@ -21,7 +21,7 @@ static PyObject *
 _posixshmem_shm_open(PyObject *module, PyObject *args, PyObject *kwargs)
 {
     PyObject *return_value = NULL;
-    static char *_keywords[] = {"path", "flags", "mode", NULL};
+    static char *_keywords[] = {"", "flags", "mode", NULL};
     PyObject *path;
     int flags;
     int mode = 511;
@@ -45,7 +45,7 @@ exit:
 #if defined(HAVE_SHM_UNLINK)
 
 PyDoc_STRVAR(_posixshmem_shm_unlink__doc__,
-"shm_unlink($module, /, path)\n"
+"shm_unlink($module, path, /)\n"
 "--\n"
 "\n"
 "Remove a shared memory object (similar to unlink()).\n"
@@ -55,21 +55,22 @@ PyDoc_STRVAR(_posixshmem_shm_unlink__doc__,
 "region.");
 
 #define _POSIXSHMEM_SHM_UNLINK_METHODDEF    \
-    {"shm_unlink", (PyCFunction)(void(*)(void))_posixshmem_shm_unlink, METH_VARARGS|METH_KEYWORDS, _posixshmem_shm_unlink__doc__},
+    {"shm_unlink", (PyCFunction)_posixshmem_shm_unlink, METH_O, _posixshmem_shm_unlink__doc__},
 
 static PyObject *
 _posixshmem_shm_unlink_impl(PyObject *module, PyObject *path);
 
 static PyObject *
-_posixshmem_shm_unlink(PyObject *module, PyObject *args, PyObject *kwargs)
+_posixshmem_shm_unlink(PyObject *module, PyObject *arg)
 {
     PyObject *return_value = NULL;
-    static char *_keywords[] = {"path", NULL};
     PyObject *path;
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "U:shm_unlink", _keywords,
-        &path))
+    if (!PyUnicode_Check(arg)) {
+        PyErr_Format(PyExc_TypeError, "shm_unlink() argument must be str, not %T", arg);
         goto exit;
+    }
+    path = arg;
     return_value = _posixshmem_shm_unlink_impl(module, path);
 
 exit:
@@ -85,4 +86,4 @@ exit:
 #ifndef _POSIXSHMEM_SHM_UNLINK_METHODDEF
     #define _POSIXSHMEM_SHM_UNLINK_METHODDEF
 #endif /* !defined(_POSIXSHMEM_SHM_UNLINK_METHODDEF) */
-/*[clinic end generated code: output=be0661dbed83ea23 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=649877fc45a65129 input=a9049054013a1b77]*/

--- a/Modules/_multiprocessing/posixshmem.c
+++ b/Modules/_multiprocessing/posixshmem.c
@@ -32,6 +32,7 @@ module _posixshmem
 /*[clinic input]
 _posixshmem.shm_open -> int
     path: unicode
+    /
     flags: int
     mode: int = 0o777
 
@@ -44,7 +45,7 @@ Open a shared memory object.  Returns a file descriptor (integer).
 static int
 _posixshmem_shm_open_impl(PyObject *module, PyObject *path, int flags,
                           int mode)
-/*[clinic end generated code: output=8d110171a4fa20df input=e83b58fa802fac25]*/
+/*[clinic end generated code: output=8d110171a4fa20df input=0585935e1d3c8050]*/
 {
     int fd;
     int async_err = 0;
@@ -77,6 +78,7 @@ _posixshmem_shm_open_impl(PyObject *module, PyObject *path, int flags,
 /*[clinic input]
 _posixshmem.shm_unlink
     path: unicode
+    /
 
 Remove a shared memory object (similar to unlink()).
 
@@ -88,7 +90,7 @@ region.
 
 static PyObject *
 _posixshmem_shm_unlink_impl(PyObject *module, PyObject *path)
-/*[clinic end generated code: output=42f8b23d134b9ff5 input=8dc0f87143e3b300]*/
+/*[clinic end generated code: output=42f8b23d134b9ff5 input=298369d013dcad63]*/
 {
     int rv;
     int async_err = 0;


### PR DESCRIPTION
* shm_unlink() parameter becomes positional-only.
* shm_open() first parameter (path) becomes positional-only, the two following parameters remain positional-or-keyword.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-117873 -->
* Issue: gh-117873
<!-- /gh-issue-number -->
