### PR TITLE
[3.12] gh-117535: Ignore makeup file name "sys" for warnings

### DIFF
--- a/Lib/warnings.py
+++ b/Lib/warnings.py
@@ -36,7 +36,7 @@ def _formatwarnmsg_impl(msg):
     category = msg.category.__name__
     s =  f"{msg.filename}:{msg.lineno}: {category}: {msg.message}\n"
 
-    # "sys" is a makeup file name when we are not able to get the frame
+    # "sys" is a made up file name when we are not able to get the frame
     # so do not try to get the source line
     if msg.line is None and msg.filename != "sys":
         try:

--- a/Lib/warnings.py
+++ b/Lib/warnings.py
@@ -36,7 +36,9 @@ def _formatwarnmsg_impl(msg):
     category = msg.category.__name__
     s =  f"{msg.filename}:{msg.lineno}: {category}: {msg.message}\n"
 
-    if msg.line is None:
+    # "sys" is a makeup file name when we are not able to get the frame
+    # so do not try to get the source line
+    if msg.line is None and msg.filename != "sys":
         try:
             import linecache
             line = linecache.getline(msg.filename, msg.lineno)

--- a/Misc/NEWS.d/next/Library/2024-04-17-23-38-06.gh-issue-117535.4Fgjlq.rst
+++ b/Misc/NEWS.d/next/Library/2024-04-17-23-38-06.gh-issue-117535.4Fgjlq.rst
@@ -1,1 +1,1 @@
-Do not try to get the source line for makeup file name "sys" in :mod:`warnings`
+Do not try to get the source line for made up file name "sys" in :mod:`warnings`.

--- a/Misc/NEWS.d/next/Library/2024-04-17-23-38-06.gh-issue-117535.4Fgjlq.rst
+++ b/Misc/NEWS.d/next/Library/2024-04-17-23-38-06.gh-issue-117535.4Fgjlq.rst
@@ -1,0 +1,1 @@
+Do not try to get the source line for makeup file name "sys" in :mod:`warnings`


### PR DESCRIPTION
`"sys"` is a makeup filename in

```python
    except ValueError:
        globals = sys.__dict__
        filename = "sys"
        lineno = 1
```

so we should never try to get the source code for it. Otherwise if there happens to be a `sys` file in `sys.path`, the first line will be displayed.

This is a backward compatible patch for backport only. We will have some new solution for main

<!-- gh-issue-number: gh-117535 -->
* Issue: gh-117535
<!-- /gh-issue-number -->
