### PR TITLE
gh-117535: Change unknown filename of warnings from `sys` to `<sys>`

### DIFF
--- a/Lib/test/test_warnings/__init__.py
+++ b/Lib/test/test_warnings/__init__.py
@@ -1388,7 +1388,7 @@ a=A()
         # Issue #21925: Emitting a ResourceWarning late during the Python
         # shutdown must be logged.
 
-        expected = b"<sys>:1: ResourceWarning: unclosed file "
+        expected = b"<sys>:0: ResourceWarning: unclosed file "
 
         # don't import the warnings module
         # (_warnings will try to import it)

--- a/Lib/test/test_warnings/__init__.py
+++ b/Lib/test/test_warnings/__init__.py
@@ -489,7 +489,7 @@ class WarnTests(BaseTest):
 
                 warning_tests.inner("spam7", stacklevel=9999)
                 self.assertEqual(os.path.basename(w[-1].filename),
-                                    "sys")
+                                    "<sys>")
 
     def test_stacklevel_import(self):
         # Issue #24305: With stacklevel=2, module-level warnings should work.
@@ -1388,7 +1388,7 @@ a=A()
         # Issue #21925: Emitting a ResourceWarning late during the Python
         # shutdown must be logged.
 
-        expected = b"sys:1: ResourceWarning: unclosed file "
+        expected = b"<sys>:1: ResourceWarning: unclosed file "
 
         # don't import the warnings module
         # (_warnings will try to import it)

--- a/Lib/warnings.py
+++ b/Lib/warnings.py
@@ -332,7 +332,7 @@ def warn(message, category=None, stacklevel=1, source=None,
                     raise ValueError
     except ValueError:
         globals = sys.__dict__
-        filename = "sys"
+        filename = "<sys>"
         lineno = 1
     else:
         globals = frame.f_globals

--- a/Lib/warnings.py
+++ b/Lib/warnings.py
@@ -333,7 +333,7 @@ def warn(message, category=None, stacklevel=1, source=None,
     except ValueError:
         globals = sys.__dict__
         filename = "<sys>"
-        lineno = 1
+        lineno = 0
     else:
         globals = frame.f_globals
         filename = frame.f_code.co_filename

--- a/Misc/NEWS.d/next/Library/2024-04-18-00-35-11.gh-issue-117535.0m6SIM.rst
+++ b/Misc/NEWS.d/next/Library/2024-04-18-00-35-11.gh-issue-117535.0m6SIM.rst
@@ -1,0 +1,1 @@
+Change the unknown filename of :mod:`warnings` from ``sys`` to ``<sys>`` to clarify that it's not a real filename.

--- a/Python/_warnings.c
+++ b/Python/_warnings.c
@@ -894,7 +894,7 @@ setup_context(Py_ssize_t stack_level,
 
     if (f == NULL) {
         globals = interp->sysdict;
-        *filename = PyUnicode_FromString("sys");
+        *filename = PyUnicode_FromString("<sys>");
         *lineno = 1;
     }
     else {

--- a/Python/_warnings.c
+++ b/Python/_warnings.c
@@ -895,7 +895,7 @@ setup_context(Py_ssize_t stack_level,
     if (f == NULL) {
         globals = interp->sysdict;
         *filename = PyUnicode_FromString("<sys>");
-        *lineno = 1;
+        *lineno = 0;
     }
     else {
         globals = f->f_frame->f_globals;


### PR DESCRIPTION
The filename `sys` could be a real file in the file system and `linecache` will try to read the content of the file and print it out. Using `<sys>` will avoid the confusion and let `linecache` know this is not a real file.

<!-- gh-issue-number: gh-117535 -->
* Issue: gh-117535
<!-- /gh-issue-number -->
