### PR TITLE
gh-109118: Allow lambdas in annotation scopes in classes

### DIFF
--- a/Doc/whatsnew/3.13.rst
+++ b/Doc/whatsnew/3.13.rst
@@ -215,6 +215,9 @@ Other Language Changes
   ones if configured to do so.
   (Contributed by Pedro Sousa Lacerda in :gh:`66449`.)
 
+* :ref:`annotation scope <annotation-scopes>` within class scopes can now
+  contain lambdas. (Contributed by Jelle Zijlstra in :gh:`109118`.)
+
 
 New Modules
 ===========

--- a/Misc/NEWS.d/next/Core and Builtins/2024-04-17-17-52-32.gh-issue-109118.q9iPEI.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2024-04-17-17-52-32.gh-issue-109118.q9iPEI.rst
@@ -1,0 +1,2 @@
+:ref:`annotation scope <annotation-scopes>` within class scopes can now
+contain lambdas.

--- a/Python/symtable.c
+++ b/Python/symtable.c
@@ -2140,17 +2140,6 @@ symtable_visit_expr(struct symtable *st, expr_ty e)
         VISIT(st, expr, e->v.UnaryOp.operand);
         break;
     case Lambda_kind: {
-        if (st->st_cur->ste_can_see_class_scope) {
-            // gh-109118
-            PyErr_Format(PyExc_SyntaxError,
-                         "Cannot use lambda in annotation scope within class scope");
-            PyErr_RangedSyntaxLocationObject(st->st_filename,
-                                              e->lineno,
-                                              e->col_offset + 1,
-                                              e->end_lineno,
-                                              e->end_col_offset + 1);
-            VISIT_QUIT(st, 0);
-        }
         if (e->v.Lambda.args->defaults)
             VISIT_SEQ(st, expr, e->v.Lambda.args->defaults);
         if (e->v.Lambda.args->kw_defaults)


### PR DESCRIPTION


<!-- gh-issue-number: gh-109118 -->
* Issue: gh-109118
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--118019.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->