### PR TITLE
gh-117151: optimize BufferedWriter(), do not buffer writes that are the buffer size

### DIFF
--- a/Modules/_io/bufferedio.c
+++ b/Modules/_io/bufferedio.c
@@ -2092,7 +2092,7 @@ _io_BufferedWriter_write_impl(buffered *self, Py_buffer *buffer)
         self->raw_pos = 0;
     }
     avail = Py_SAFE_DOWNCAST(self->buffer_size - self->pos, Py_off_t, Py_ssize_t);
-    if (buffer->len <= avail) {
+    if (buffer->len <= avail && buffer->len < self->buffer_size) {
         memcpy(self->buffer + self->pos, buffer->buf, buffer->len);
         if (!VALID_WRITE_BUFFER(self) || self->write_pos > self->pos) {
             self->write_pos = self->pos;
@@ -2161,7 +2161,7 @@ _io_BufferedWriter_write_impl(buffered *self, Py_buffer *buffer)
     /* Then write buf itself. At this point the buffer has been emptied. */
     remaining = buffer->len;
     written = 0;
-    while (remaining > self->buffer_size) {
+    while (remaining >= self->buffer_size) {
         Py_ssize_t n = _bufferedwriter_raw_write(
             self, (char *) buffer->buf + written, buffer->len - written);
         if (n == -1) {


### PR DESCRIPTION
gh-117151: optimize BufferedWriter(), do not buffer writes that are the buffer size

Hello,

I am having a look at the buffering code as part of the linked discussion, #gh-117151
One thing that was puzzling me is finding the buffering code slightly slower than the non-buffering code, given the same conditions, so I started having a deeper look into it.

Could I get a second pair of eyes on this old piece of code?
`BufferedWriter()` is buffering calls that are the exact same size as the buffer. 
It's a very common case to read/write in blocks of the exact buffer size. 
I think this might actually be the primary use case, reading in chunks from disk/network and writing to disk.

I think it shouldn't buffer in that case. It's costing an extra memory copy and the buffer will be full and have to be written in the next call anyway.

Thoughts?
