### PR TITLE
setobject: remove out of date docstring info

### DIFF
--- a/Objects/setobject.c
+++ b/Objects/setobject.c
@@ -2,7 +2,7 @@
 /* set object implementation
 
    Written and maintained by Raymond D. Hettinger <python@rcn.com>
-   Derived from Lib/sets.py and Objects/dictobject.c.
+   Derived from Objects/dictobject.c.
 
    The basic lookup function used by all operations.
    This is based on Algorithm D from Knuth Vol. 3, Sec. 6.4.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
# Remove Lib/sets.py from docstring
The Lib/sets.py doesn't exist anymore, however it is still in the doctoring of the Objects/setobject.c
https://github.com/python/cpython/blob/40f4d641a93b1cba89be4bc7b26cdb481e0450d5/Objects/setobject.c#L2-L5
skip issue