### PR TITLE
gh-117503: Fix test for posixpath.expanduser() when pw_dir ends with /

### DIFF
--- a/Lib/test/test_posixpath.py
+++ b/Lib/test/test_posixpath.py
@@ -351,6 +351,7 @@ class PosixPathTest(unittest.TestCase):
         for e in pwd.getpwall():
             name = e.pw_name
             home = e.pw_dir
+            home = home.rstrip('/') or '/'
             self.assertEqual(posixpath.expanduser('~' + name), home)
             self.assertEqual(posixpath.expanduser(os.fsencode('~' + name)),
                              os.fsencode(home))


### PR DESCRIPTION


<!-- gh-issue-number: gh-117503 -->
* Issue: gh-117503
<!-- /gh-issue-number -->
