### PR TITLE
gh-116622: Redirect stdout and stderr to system log when embedded in an Android app

### DIFF
--- a/Lib/_android_support.py
+++ b/Lib/_android_support.py
@@ -47,6 +47,10 @@ class TextLogStream(io.TextIOWrapper):
             raise TypeError(
                 f"write() argument must be str, not {type(s).__name__}")
 
+        # In case `s` is a str subclass that writes itself to stdout or stderr
+        # when we call its methods, convert it to an actual str.
+        s = str.__str__(s)
+
         # We want to emit one log message per line wherever possible, so split
         # the string before sending it to the superclass. Note that
         # "".splitlines() == [], so nothing will be logged for an empty string.

--- a/Lib/_android_support.py
+++ b/Lib/_android_support.py
@@ -71,11 +71,14 @@ class BinaryLogStream(io.RawIOBase):
         return True
 
     def write(self, b):
-        if hasattr(b, "__buffer__"):
-            b_out = bytes(b)
-        else:
+        try:
+            memoryview(b)
+        except TypeError:
             raise TypeError(
-                f"write() argument must be bytes-like, not {type(b).__name__}")
+                f"write() argument must be bytes-like, not {type(b).__name__}"
+            ) from None
+        else:
+            b_out = bytes(b)
 
         # Encode null bytes using "modified UTF-8" to avoid truncating the
         # message.

--- a/Lib/_android_support.py
+++ b/Lib/_android_support.py
@@ -1,0 +1,99 @@
+import io
+import sys
+from ctypes import CDLL, c_char_p, c_int
+
+
+# The maximum length of a log message in bytes, including the level marker and
+# tag, is defined as LOGGER_ENTRY_MAX_PAYLOAD in
+# platform/system/logging/liblog/include/log/log.h. As of API level 30, messages
+# longer than this will be be truncated by logcat. This limit has already been
+# reduced at least once in the history of Android (from 4076 to 4068 between API
+# level 23 and 26), so leave some headroom.
+MAX_BYTES_PER_WRITE = 4000
+
+# UTF-8 uses a maximum of 4 bytes per character, so limiting text writes to this
+# size ensures that TextIOWrapper can always avoid exceeding MAX_BYTES_PER_WRITE.
+# However, if the actual number of bytes per character is smaller than that,
+# then TextIOWrapper may still join multiple consecutive text writes into binary
+# writes containing a larger number of characters.
+MAX_CHARS_PER_WRITE = MAX_BYTES_PER_WRITE // 4
+
+
+# When embedded in an app on current versions of Android, there's no easy way to
+# monitor the C-level stdout and stderr. The testbed comes with a .c file to
+# redirect them to the system log using a pipe, but that wouldn't be convenient
+# or appropriate for all apps. So we redirect at the Python level instead.
+def init_streams():
+    if sys.executable:
+        return  # Not embedded in an app.
+
+    # Despite its name, this function is part of the public API
+    # (https://developer.android.com/ndk/reference/group/logging).
+    # Use `getattr` to avoid private name mangling.
+    global android_log_write
+    android_log_write = getattr(CDLL("liblog.so"), "__android_log_write")
+    android_log_write.argtypes = (c_int, c_char_p, c_char_p)
+
+    # These log levels match those used by Java's System.out and System.err.
+    ANDROID_LOG_INFO = 4
+    ANDROID_LOG_WARN = 5
+
+    sys.stdout = TextLogStream(
+        ANDROID_LOG_INFO, "python.stdout", errors=sys.stdout.errors)
+    sys.stderr = TextLogStream(
+        ANDROID_LOG_WARN, "python.stderr", errors=sys.stderr.errors)
+
+
+class TextLogStream(io.TextIOWrapper):
+    def __init__(self, level, tag, **kwargs):
+        kwargs.setdefault("encoding", "UTF-8")
+        kwargs.setdefault("line_buffering", True)
+        super().__init__(BinaryLogStream(level, tag), **kwargs)
+        self._CHUNK_SIZE = MAX_BYTES_PER_WRITE
+
+    def __repr__(self):
+        return f"<TextLogStream {self.buffer.tag!r}>"
+
+    def write(self, s):
+        if not isinstance(s, str):
+            raise TypeError(
+                f"write() argument must be str, not {type(s).__name__}")
+
+        # We want to emit one log message per line wherever possible, so split
+        # the string before sending it to the superclass. Note that
+        # "".splitlines() == [], so nothing will be logged for an empty string.
+        for line, line_keepends in zip(
+            s.splitlines(), s.splitlines(keepends=True)
+        ):
+            # Simplify the later stages by translating all newlines into "\n".
+            if line != line_keepends:
+                line += "\n"
+            while line:
+                super().write(line[:MAX_CHARS_PER_WRITE])
+                line = line[MAX_CHARS_PER_WRITE:]
+
+        return len(s)
+
+
+class BinaryLogStream(io.RawIOBase):
+    def __init__(self, level, tag):
+        self.level = level
+        self.tag = tag
+
+    def __repr__(self):
+        return f"<BinaryLogStream {self.tag!r}>"
+
+    def writable(self):
+        return True
+
+    def write(self, b):
+        if hasattr(b, "__buffer__"):
+            b = bytes(b)
+        else:
+            raise TypeError(
+                f"write() argument must be bytes-like, not {type(b).__name__}")
+
+        # Writing an empty string to the stream should have no effect.
+        if b:
+            android_log_write(self.level, self.tag.encode("UTF-8"), b)
+        return len(b)

--- a/Lib/_android_support.py
+++ b/Lib/_android_support.py
@@ -81,14 +81,17 @@ class BinaryLogStream(io.RawIOBase):
             raise TypeError(
                 f"write() argument must be bytes-like, not {type(b).__name__}"
             ) from None
-        else:
-            b_out = bytes(b)
 
-        # Encode null bytes using "modified UTF-8" to avoid truncating the
-        # message.
-        b_out = b_out.replace(b"\x00", b"\xc0\x80")
+        b_out = bytes(b)
+        b_len = len(b_out)  # May be different from len(b) if b is an array.
 
         # Writing an empty string to the stream should have no effect.
         if b_out:
+            # Encode null bytes using "modified UTF-8" to avoid truncating the
+            # message. This should not affect the return value, as the caller
+            # may be expecting it to match the length of the input.
+            b_out = b_out.replace(b"\x00", b"\xc0\x80")
+
             self.android_log_write(self.prio, self.tag, b_out)
-        return len(b)
+
+        return b_len

--- a/Lib/_android_support.py
+++ b/Lib/_android_support.py
@@ -53,7 +53,7 @@ class TextLogStream(io.TextIOWrapper):
         for line, line_keepends in zip(
             s.splitlines(), s.splitlines(keepends=True)
         ):
-            # Simplify the later stages by translating all newlines into "\n".
+            # Normalize all newlines to "\n".
             if line != line_keepends:
                 line += "\n"
             while line:

--- a/Lib/test/test_android.py
+++ b/Lib/test/test_android.py
@@ -117,9 +117,7 @@ class TestAndroidOutput(unittest.TestCase):
                     write("\u4e2d\u6587")  # Chinese
 
                     # Non-BMP emoji
-                    write("\U0001f600",
-                          [r"\xed\xa0\xbd\xed\xb8\x80" if api_level < 23
-                           else "\U0001f600"])
+                    write("\U0001f600")
 
                     # Null characters will truncate a message.
                     write("\u0000", [] if api_level < 24 else [""])
@@ -223,9 +221,7 @@ class TestAndroidOutput(unittest.TestCase):
                 write(b"\xe4\xb8\xad\xe6\x96\x87")  # Chinese
 
                 # Non-BMP emoji
-                write(b"\xf0\x9f\x98\x80",
-                      [r"\xed\xa0\xbd\xed\xb8\x80" if api_level < 23
-                       else "\U0001f600"])
+                write(b"\xf0\x9f\x98\x80")
 
                 # Null characters will truncate a message.
                 write(b"\x00", [] if api_level < 24 else [""])

--- a/Lib/test/test_android.py
+++ b/Lib/test/test_android.py
@@ -5,7 +5,6 @@ import subprocess
 import sys
 import unittest
 from contextlib import contextmanager
-from ctypes import CDLL, c_char_p, c_int
 from threading import Thread
 from time import time
 
@@ -37,6 +36,7 @@ class TestAndroidOutput(unittest.TestCase):
             self.logcat_process.stdout.close()
         Thread(target=logcat_thread).start()
 
+        from ctypes import CDLL, c_char_p, c_int
         android_log_write = getattr(CDLL("liblog.so"), "__android_log_write")
         android_log_write.argtypes = (c_int, c_char_p, c_char_p)
         ANDROID_LOG_INFO = 4

--- a/Lib/test/test_android.py
+++ b/Lib/test/test_android.py
@@ -154,6 +154,16 @@ class TestAndroidOutput(unittest.TestCase):
                 write("hello\r\nworld\r\n", ["hello", "world"])
                 write("\r\n", [""])
 
+                # String subclasses are accepted, and if their methods write
+                # themselves, this doesn't cause infinite recursion.
+                class CustomStr(str):
+                    def splitlines(self, *args, **kwargs):
+                        sys.stdout.write(self)
+                        return super().splitlines(*args, **kwargs)
+
+                write(CustomStr("custom\n"), ["custom"])
+
+                # Non-string classes are not accepted.
                 for obj in [b"", b"hello", None, 42]:
                     with self.subTest(obj=obj):
                         with self.assertRaisesRegex(

--- a/Lib/test/test_android.py
+++ b/Lib/test/test_android.py
@@ -119,11 +119,11 @@ class TestAndroidOutput(unittest.TestCase):
                     # Non-BMP emoji
                     write("\U0001f600")
 
-                    # Null characters will truncate a message.
-                    write("\u0000", [] if api_level < 24 else [""])
-                    write("a\u0000", ["a"])
-                    write("\u0000b", [] if api_level < 24 else [""])
-                    write("a\u0000b", ["a"])
+                    # Null characters are logged using "modified UTF-8".
+                    write("\u0000", [r"\xc0\x80"])
+                    write("a\u0000", [r"a\xc0\x80"])
+                    write("\u0000b", [r"\xc0\x80b"])
+                    write("a\u0000b", [r"a\xc0\x80b"])
 
                 # Multi-line messages. Avoid identical consecutive lines, as
                 # they may activate "chatty" filtering and break the tests.
@@ -223,11 +223,11 @@ class TestAndroidOutput(unittest.TestCase):
                 # Non-BMP emoji
                 write(b"\xf0\x9f\x98\x80")
 
-                # Null characters will truncate a message.
-                write(b"\x00", [] if api_level < 24 else [""])
-                write(b"a\x00", ["a"])
-                write(b"\x00b", [] if api_level < 24 else [""])
-                write(b"a\x00b", ["a"])
+                # Null characters are logged using "modified UTF-8".
+                write(b"\x00", [r"\xc0\x80"])
+                write(b"a\x00", [r"a\xc0\x80"])
+                write(b"\x00b", [r"\xc0\x80b"])
+                write(b"a\x00b", [r"a\xc0\x80b"])
 
                 # Invalid UTF-8
                 write(b"\xff", [r"\xff"])

--- a/Lib/test/test_android.py
+++ b/Lib/test/test_android.py
@@ -17,6 +17,10 @@ api_level = platform.android_ver().api_level
 
 
 # Test redirection of stdout and stderr to the Android log.
+@unittest.skipIf(
+    api_level < 23 and platform.machine() == "aarch64",
+    "SELinux blocks reading logs on older ARM64 emulators"
+)
 class TestAndroidOutput(unittest.TestCase):
     maxDiff = None
 
@@ -118,9 +122,9 @@ class TestAndroidOutput(unittest.TestCase):
                            else "\U0001f600"])
 
                     # Null characters will truncate a message.
-                    write("\u0000", [""])
+                    write("\u0000", [] if api_level < 24 else [""])
                     write("a\u0000", ["a"])
-                    write("\u0000b", [""])
+                    write("\u0000b", [] if api_level < 24 else [""])
                     write("a\u0000b", ["a"])
 
                 # Multi-line messages. Avoid identical consecutive lines, as
@@ -224,9 +228,9 @@ class TestAndroidOutput(unittest.TestCase):
                        else "\U0001f600"])
 
                 # Null characters will truncate a message.
-                write(b"\x00", [""])
+                write(b"\x00", [] if api_level < 24 else [""])
                 write(b"a\x00", ["a"])
-                write(b"\x00b", [""])
+                write(b"\x00b", [] if api_level < 24 else [""])
                 write(b"a\x00b", ["a"])
 
                 # Invalid UTF-8

--- a/Lib/test/test_android.py
+++ b/Lib/test/test_android.py
@@ -6,6 +6,7 @@ import sys
 import unittest
 from contextlib import contextmanager
 from threading import Thread
+from test.support import LOOPBACK_TIMEOUT
 from time import time
 
 
@@ -69,7 +70,7 @@ class TestAndroidOutput(unittest.TestCase):
 
     def tearDown(self):
         self.logcat_process.terminate()
-        self.logcat_process.wait(0.1)
+        self.logcat_process.wait(LOOPBACK_TIMEOUT)
 
     @contextmanager
     def unbuffered(self, stream):
@@ -171,9 +172,10 @@ class TestAndroidOutput(unittest.TestCase):
                 stream.flush()
                 self.assert_log(level, tag, "helloworld")
 
-                # Long lines are split into blocks of 1000 *characters*, but
-                # TextIOWrapper should then join them back together as much as
-                # possible without exceeding 4000 UTF-8 *bytes*.
+                # Long lines are split into blocks of 1000 characters
+                # (MAX_CHARS_PER_WRITE), but TextIOWrapper should then join them
+                # back together as much as possible without exceeding 4000 UTF-8
+                # bytes (MAX_BYTES_PER_WRITE).
                 #
                 # ASCII (1 byte per character)
                 write(("foobar" * 700) + "\n",

--- a/Lib/test/test_android.py
+++ b/Lib/test/test_android.py
@@ -121,11 +121,17 @@ class TestAndroidOutput(unittest.TestCase):
                     # Non-BMP emoji
                     write("\U0001f600")
 
+                    # Non-encodable surrogates
+                    write("\ud800\udc00", ["\\ud800\\udc00"])
+
+                    # Code used by surrogateescape (which isn't enabled here)
+                    write("\udc80", ["\\udc80"])
+
                     # Null characters are logged using "modified UTF-8".
-                    write("\u0000", [r"\xc0\x80"])
-                    write("a\u0000", [r"a\xc0\x80"])
-                    write("\u0000b", [r"\xc0\x80b"])
-                    write("a\u0000b", [r"a\xc0\x80b"])
+                    write("\u0000", ["\\xc0\\x80"])
+                    write("a\u0000", ["a\\xc0\\x80"])
+                    write("\u0000b", ["\\xc0\\x80b"])
+                    write("a\u0000b", ["a\\xc0\\x80b"])
 
                 # Multi-line messages. Avoid identical consecutive lines, as
                 # they may activate "chatty" filtering and break the tests.
@@ -154,6 +160,12 @@ class TestAndroidOutput(unittest.TestCase):
                 write("hello\r\n", ["hello"])
                 write("hello\r\nworld\r\n", ["hello", "world"])
                 write("\r\n", [""])
+
+                # Non-standard line separators should be preserved.
+                write("before form feed\x0cafter form feed\n",
+                      ["before form feed\x0cafter form feed"])
+                write("before line separator\u2028after line separator\n",
+                      ["before line separator\u2028after line separator"])
 
                 # String subclasses are accepted, and if their methods write
                 # themselves, this doesn't cause infinite recursion.
@@ -238,17 +250,17 @@ class TestAndroidOutput(unittest.TestCase):
                 # Non-BMP emoji
                 write(b"\xf0\x9f\x98\x80")
 
-                # Null characters are logged using "modified UTF-8".
-                write(b"\x00", [r"\xc0\x80"])
-                write(b"a\x00", [r"a\xc0\x80"])
-                write(b"\x00b", [r"\xc0\x80b"])
-                write(b"a\x00b", [r"a\xc0\x80b"])
+                # Null bytes are logged using "modified UTF-8".
+                write(b"\x00", ["\\xc0\\x80"])
+                write(b"a\x00", ["a\\xc0\\x80"])
+                write(b"\x00b", ["\\xc0\\x80b"])
+                write(b"a\x00b", ["a\\xc0\\x80b"])
 
                 # Invalid UTF-8
-                write(b"\xff", [r"\xff"])
-                write(b"a\xff", [r"a\xff"])
-                write(b"\xffb", [r"\xffb"])
-                write(b"a\xffb", [r"a\xffb"])
+                write(b"\xff", ["\\xff"])
+                write(b"a\xff", ["a\\xff"])
+                write(b"\xffb", ["\\xffb"])
+                write(b"a\xffb", ["a\\xffb"])
 
                 # Log entries containing newlines are shown differently by
                 # `logcat -v tag`, `logcat -v long`, and Android Studio. We

--- a/Lib/test/test_android.py
+++ b/Lib/test/test_android.py
@@ -1,0 +1,269 @@
+import platform
+import queue
+import re
+import subprocess
+import sys
+import unittest
+from contextlib import contextmanager
+from ctypes import CDLL, c_char_p, c_int
+from threading import Thread
+from time import time
+
+
+if sys.platform != "android":
+    raise unittest.SkipTest("Android-specific")
+
+api_level = platform.android_ver().api_level
+
+
+# Test redirection of stdout and stderr to the Android log.
+class TestAndroidOutput(unittest.TestCase):
+    maxDiff = None
+
+    def setUp(self):
+        self.logcat_process = subprocess.Popen(
+            ["logcat", "-v", "tag"], stdout=subprocess.PIPE,
+            errors="backslashreplace"
+        )
+        self.logcat_queue = queue.Queue()
+
+        def logcat_thread():
+            for line in self.logcat_process.stdout:
+                self.logcat_queue.put(line.rstrip("\n"))
+            self.logcat_process.stdout.close()
+        Thread(target=logcat_thread).start()
+
+        android_log_write = getattr(CDLL("liblog.so"), "__android_log_write")
+        android_log_write.argtypes = (c_int, c_char_p, c_char_p)
+        ANDROID_LOG_INFO = 4
+
+        # Separate tests using a marker line with a different tag.
+        tag, message = "python.test", f"{self.id()} {time()}"
+        android_log_write(
+            ANDROID_LOG_INFO, tag.encode("UTF-8"), message.encode("UTF-8"))
+        self.assert_log("I", tag, message, skip=True, timeout=5)
+
+    def assert_logs(self, level, tag, expected, **kwargs):
+        for line in expected:
+            self.assert_log(level, tag, line, **kwargs)
+
+    def assert_log(self, level, tag, expected, *, skip=False, timeout=0.5):
+        deadline = time() + timeout
+        while True:
+            try:
+                line = self.logcat_queue.get(timeout=(deadline - time()))
+            except queue.Empty:
+                self.fail(f"line not found: {expected!r}")
+            if match := re.fullmatch(fr"(.)/{tag}: (.*)", line):
+                try:
+                    self.assertEqual(level, match[1])
+                    self.assertEqual(expected, match[2])
+                    break
+                except AssertionError:
+                    if not skip:
+                        raise
+
+    def tearDown(self):
+        self.logcat_process.terminate()
+        self.logcat_process.wait(0.1)
+
+    @contextmanager
+    def unbuffered(self, stream):
+        stream.reconfigure(write_through=True)
+        try:
+            yield
+        finally:
+            stream.reconfigure(write_through=False)
+
+    def test_str(self):
+        for stream_name, level in [("stdout", "I"), ("stderr", "W")]:
+            with self.subTest(stream=stream_name):
+                stream = getattr(sys, stream_name)
+                tag = f"python.{stream_name}"
+                self.assertEqual(f"<TextLogStream '{tag}'>", repr(stream))
+
+                self.assertTrue(stream.writable())
+                self.assertFalse(stream.readable())
+                self.assertEqual("UTF-8", stream.encoding)
+                self.assertTrue(stream.line_buffering)
+                self.assertFalse(stream.write_through)
+
+                # stderr is backslashreplace by default; stdout is configured
+                # that way by libregrtest.main.
+                self.assertEqual("backslashreplace", stream.errors)
+
+                def write(s, lines=None):
+                    self.assertEqual(len(s), stream.write(s))
+                    if lines is None:
+                        lines = [s]
+                    self.assert_logs(level, tag, lines)
+
+                # Single-line messages,
+                with self.unbuffered(stream):
+                    write("", [])
+
+                    write("a")
+                    write("Hello")
+                    write("Hello world")
+                    write(" ")
+                    write("  ")
+
+                    # Non-ASCII text
+                    write("ol\u00e9")  # Spanish
+                    write("\u4e2d\u6587")  # Chinese
+
+                    # Non-BMP emoji
+                    write("\U0001f600",
+                          [r"\xed\xa0\xbd\xed\xb8\x80" if api_level < 23
+                           else "\U0001f600"])
+
+                    # Null characters will truncate a message.
+                    write("\u0000", [""])
+                    write("a\u0000", ["a"])
+                    write("\u0000b", [""])
+                    write("a\u0000b", ["a"])
+
+                # Multi-line messages. Avoid identical consecutive lines, as
+                # they may activate "chatty" filtering and break the tests.
+                write("\nx", [""])
+                write("\na\n", ["x", "a"])
+                write("\n", [""])
+                write("b\n", ["b"])
+                write("c\n\n", ["c", ""])
+                write("d\ne", ["d"])
+                write("xx", [])
+                write("f\n\ng", ["exxf", ""])
+                write("\n", ["g"])
+
+                with self.unbuffered(stream):
+                    write("\nx", ["", "x"])
+                    write("\na\n", ["", "a"])
+                    write("\n", [""])
+                    write("b\n", ["b"])
+                    write("c\n\n", ["c", ""])
+                    write("d\ne", ["d", "e"])
+                    write("xx", ["xx"])
+                    write("f\n\ng", ["f", "", "g"])
+                    write("\n", [""])
+
+                # "\r\n" should be translated into "\n".
+                write("hello\r\n", ["hello"])
+                write("hello\r\nworld\r\n", ["hello", "world"])
+                write("\r\n", [""])
+
+                for obj in [b"", b"hello", None, 42]:
+                    with self.subTest(obj=obj):
+                        with self.assertRaisesRegex(
+                            TypeError,
+                            fr"write\(\) argument must be str, not "
+                            fr"{type(obj).__name__}"
+                        ):
+                            stream.write(obj)
+
+                # Manual flushing is supported.
+                write("hello", [])
+                stream.flush()
+                self.assert_log(level, tag, "hello")
+                write("hello", [])
+                write("world", [])
+                stream.flush()
+                self.assert_log(level, tag, "helloworld")
+
+                # Long lines are split into blocks of 1000 *characters*, but
+                # TextIOWrapper should then join them back together as much as
+                # possible without exceeding 4000 UTF-8 *bytes*.
+                #
+                # ASCII (1 byte per character)
+                write(("foobar" * 700) + "\n",
+                      [("foobar" * 666) + "foob",  # 4000 bytes
+                       "ar" + ("foobar" * 33)])  # 200 bytes
+
+                # "Full-width" digits 0-9 (3 bytes per character)
+                s = "\uff10\uff11\uff12\uff13\uff14\uff15\uff16\uff17\uff18\uff19"
+                write((s * 150) + "\n",
+                      [s * 100,  # 3000 bytes
+                       s * 50])  # 1500 bytes
+
+                s = "0123456789"
+                write(s * 200, [])
+                write(s * 150, [])
+                write(s * 51, [s * 350])  # 3500 bytes
+                write("\n", [s * 51])  # 510 bytes
+
+    def test_bytes(self):
+        for stream_name, level in [("stdout", "I"), ("stderr", "W")]:
+            with self.subTest(stream=stream_name):
+                stream = getattr(sys, stream_name).buffer
+                tag = f"python.{stream_name}"
+                self.assertEqual(f"<BinaryLogStream '{tag}'>", repr(stream))
+                self.assertTrue(stream.writable())
+                self.assertFalse(stream.readable())
+
+                def write(b, lines=None):
+                    self.assertEqual(len(b), stream.write(b))
+                    if lines is None:
+                        lines = [b.decode()]
+                    self.assert_logs(level, tag, lines)
+
+                # Single-line messages,
+                write(b"", [])
+
+                write(b"a")
+                write(b"Hello")
+                write(b"Hello world")
+                write(b" ")
+                write(b"  ")
+
+                # Non-ASCII text
+                write(b"ol\xc3\xa9")  # Spanish
+                write(b"\xe4\xb8\xad\xe6\x96\x87")  # Chinese
+
+                # Non-BMP emoji
+                write(b"\xf0\x9f\x98\x80",
+                      [r"\xed\xa0\xbd\xed\xb8\x80" if api_level < 23
+                       else "\U0001f600"])
+
+                # Null characters will truncate a message.
+                write(b"\x00", [""])
+                write(b"a\x00", ["a"])
+                write(b"\x00b", [""])
+                write(b"a\x00b", ["a"])
+
+                # Invalid UTF-8
+                write(b"\xff", [r"\xff"])
+                write(b"a\xff", [r"a\xff"])
+                write(b"\xffb", [r"\xffb"])
+                write(b"a\xffb", [r"a\xffb"])
+
+                # Log entries containing newlines are shown differently by
+                # `logcat -v tag`, `logcat -v long`, and Android Studio. We
+                # currently use `logcat -v tag`, which shows each line as if it
+                # was a separate log entry, but strips a single trailing
+                # newline.
+                #
+                # On newer versions of Android, all three of the above tools (or
+                # maybe Logcat itself) will also strip any number of leading
+                # newlines.
+                write(b"\nx", ["", "x"] if api_level < 30 else ["x"])
+                write(b"\na\n", ["", "a"] if api_level < 30 else ["a"])
+                write(b"\n", [""])
+                write(b"b\n", ["b"])
+                write(b"c\n\n", ["c", ""])
+                write(b"d\ne", ["d", "e"])
+                write(b"xx", ["xx"])
+                write(b"f\n\ng", ["f", "", "g"])
+                write(b"\n", [""])
+
+                # "\r\n" should be translated into "\n".
+                write(b"hello\r\n", ["hello"])
+                write(b"hello\r\nworld\r\n", ["hello", "world"])
+                write(b"\r\n", [""])
+
+                for obj in ["", "hello", None, 42]:
+                    with self.subTest(obj=obj):
+                        with self.assertRaisesRegex(
+                            TypeError,
+                            fr"write\(\) argument must be bytes-like, not "
+                            fr"{type(obj).__name__}"
+                        ):
+                            stream.write(obj)

--- a/Lib/test/test_android.py
+++ b/Lib/test/test_android.py
@@ -251,16 +251,16 @@ class TestAndroidOutput(unittest.TestCase):
                 write(b"\xf0\x9f\x98\x80")
 
                 # Null bytes are logged using "modified UTF-8".
-                write(b"\x00", ["\\xc0\\x80"])
-                write(b"a\x00", ["a\\xc0\\x80"])
-                write(b"\x00b", ["\\xc0\\x80b"])
-                write(b"a\x00b", ["a\\xc0\\x80b"])
+                write(b"\x00", [r"\xc0\x80"])
+                write(b"a\x00", [r"a\xc0\x80"])
+                write(b"\x00b", [r"\xc0\x80b"])
+                write(b"a\x00b", [r"a\xc0\x80b"])
 
                 # Invalid UTF-8
-                write(b"\xff", ["\\xff"])
-                write(b"a\xff", ["a\\xff"])
-                write(b"\xffb", ["\\xffb"])
-                write(b"a\xffb", ["a\\xffb"])
+                write(b"\xff", [r"\xff"])
+                write(b"a\xff", [r"a\xff"])
+                write(b"\xffb", [r"\xffb"])
+                write(b"a\xffb", [r"a\xffb"])
 
                 # Log entries containing newlines are shown differently by
                 # `logcat -v tag`, `logcat -v long`, and Android Studio. We

--- a/Misc/NEWS.d/next/Core and Builtins/2024-04-17-22-49-15.gh-issue-116622.tthNUF.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2024-04-17-22-49-15.gh-issue-116622.tthNUF.rst
@@ -1,0 +1,1 @@
+Redirect stdout and stderr to system log when embedded in an Android app.

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -2736,10 +2736,11 @@ static PyObject *
 android_log_write_impl(PyObject *self, PyObject *args)
 {
     int prio = 0;
-    char *tag = NULL;
-    char *text = NULL;
-    if (!PyArg_ParseTuple(args, "isy", &prio, &tag, &text))
+    const char *tag = NULL;
+    const char *text = NULL;
+    if (!PyArg_ParseTuple(args, "isy", &prio, &tag, &text)) {
         return NULL;
+    }
 
     // Despite its name, this function is part of the public API
     // (https://developer.android.com/ndk/reference/group/logging).
@@ -2762,19 +2763,22 @@ init_android_streams(PyThreadState *tstate)
     PyObject *result = NULL;
 
     _android_support = PyImport_ImportModule("_android_support");
-    if (_android_support == NULL)
+    if (_android_support == NULL) {
         goto error;
+    }
 
     android_log_write = PyCFunction_New(&android_log_write_method, NULL);
-    if (android_log_write == NULL)
+    if (android_log_write == NULL) {
         goto error;
+    }
 
     // These log priorities match those used by Java's System.out and System.err.
     result = PyObject_CallMethod(
         _android_support, "init_streams", "Oii",
         android_log_write, ANDROID_LOG_INFO, ANDROID_LOG_WARN);
-    if (result == NULL)
+    if (result == NULL) {
         goto error;
+    }
 
     goto done;
 

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -2738,8 +2738,7 @@ android_log_write_impl(PyObject *self, PyObject *args)
     int prio = 0;
     char *tag = NULL;
     char *text = NULL;
-    Py_ssize_t *text_len = 0;
-    if (!PyArg_ParseTuple(args, "iss#", &prio, &tag, &text, &text_len))
+    if (!PyArg_ParseTuple(args, "isy", &prio, &tag, &text))
         return NULL;
 
     // Despite its name, this function is part of the public API

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -71,7 +71,9 @@ static PyStatus add_main_module(PyInterpreterState *interp);
 static PyStatus init_import_site(void);
 static PyStatus init_set_builtins_open(void);
 static PyStatus init_sys_streams(PyThreadState *tstate);
+#ifdef __ANDROID__
 static void init_android_streams(PyThreadState *tstate);
+#endif
 static void wait_for_thread_shutdown(PyThreadState *tstate);
 static void call_ll_exitfuncs(_PyRuntimeState *runtime);
 
@@ -2724,6 +2726,7 @@ done:
 }
 
 
+#ifdef __ANDROID__
 /* Redirecting streams to the log is a convenience, but won't be critical for
    every app, so failures of this function are non-fatal. */
 static void
@@ -2744,6 +2747,7 @@ init_android_streams(PyThreadState *tstate)
     }
     Py_XDECREF(_android_support);
 }
+#endif
 
 
 static void

--- a/Python/stdlib_module_names.h
+++ b/Python/stdlib_module_names.h
@@ -5,6 +5,7 @@ static const char* _Py_stdlib_module_names[] = {
 "__future__",
 "_abc",
 "_aix_support",
+"_android_support",
 "_ast",
 "_asyncio",
 "_bisect",

--- a/configure
+++ b/configure
@@ -7096,6 +7096,9 @@ printf "%s\n" "$ANDROID_API_LEVEL" >&6; }
 printf "%s\n" "#define ANDROID_API_LEVEL $ANDROID_API_LEVEL" >>confdefs.h
 
 
+  # For __android_log_write in pylifecycle.c.
+  LIBS="$LIBS -llog"
+
   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for the Android arm ABI" >&5
 printf %s "checking for the Android arm ABI... " >&6; }
   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $_arm_arch" >&5

--- a/configure
+++ b/configure
@@ -7096,7 +7096,7 @@ printf "%s\n" "$ANDROID_API_LEVEL" >&6; }
 printf "%s\n" "#define ANDROID_API_LEVEL $ANDROID_API_LEVEL" >>confdefs.h
 
 
-  # For __android_log_write in pylifecycle.c.
+  # For __android_log_write() in Python/pylifecycle.c.
   LIBS="$LIBS -llog"
 
   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for the Android arm ABI" >&5

--- a/configure.ac
+++ b/configure.ac
@@ -1192,6 +1192,9 @@ if $CPP $CPPFLAGS conftest.c >conftest.out 2>/dev/null; then
   AC_DEFINE_UNQUOTED([ANDROID_API_LEVEL], [$ANDROID_API_LEVEL],
                      [The Android API level.])
 
+  # For __android_log_write in pylifecycle.c.
+  LIBS="$LIBS -llog"
+
   AC_MSG_CHECKING([for the Android arm ABI])
   AC_MSG_RESULT([$_arm_arch])
   if test "$_arm_arch" = 7; then

--- a/configure.ac
+++ b/configure.ac
@@ -1192,7 +1192,7 @@ if $CPP $CPPFLAGS conftest.c >conftest.out 2>/dev/null; then
   AC_DEFINE_UNQUOTED([ANDROID_API_LEVEL], [$ANDROID_API_LEVEL],
                      [The Android API level.])
 
-  # For __android_log_write in pylifecycle.c.
+  # For __android_log_write() in Python/pylifecycle.c.
   LIBS="$LIBS -llog"
 
   AC_MSG_CHECKING([for the Android arm ABI])


### PR DESCRIPTION
When embedded in an app on current versions of Android, there's no easy way to monitor the process's stdout and stderr. So, as specified in [PEP 738](https://peps.python.org/pep-0738/#sys), this PR redirects them to the system log, which can be viewed using the developer tools.

<!-- gh-issue-number: gh-116622 -->
* Issue: gh-116622
<!-- /gh-issue-number -->
