### PR TITLE
gh-117657: use relaxed loads for checking dict keys immortality

### DIFF
--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -441,7 +441,7 @@ static void free_keys_object(PyDictKeysObject *keys, bool use_qsbr);
 static inline void
 dictkeys_incref(PyDictKeysObject *dk)
 {
-    if (dk->dk_refcnt == _Py_IMMORTAL_REFCNT) {
+    if (FT_ATOMIC_LOAD_SSIZE_RELAXED(dk->dk_refcnt) == _Py_IMMORTAL_REFCNT) {
         return;
     }
 #ifdef Py_REF_DEBUG
@@ -453,7 +453,7 @@ dictkeys_incref(PyDictKeysObject *dk)
 static inline void
 dictkeys_decref(PyInterpreterState *interp, PyDictKeysObject *dk, bool use_qsbr)
 {
-    if (dk->dk_refcnt == _Py_IMMORTAL_REFCNT) {
+    if (FT_ATOMIC_LOAD_SSIZE_RELAXED(dk->dk_refcnt) == _Py_IMMORTAL_REFCNT) {
         return;
     }
     assert(dk->dk_refcnt > 0);

--- a/Tools/tsan/suppressions_free_threading.txt
+++ b/Tools/tsan/suppressions_free_threading.txt
@@ -29,8 +29,6 @@ race:_PyType_HasFeature
 race:assign_version_tag
 race:compare_unicode_unicode
 race:delitem_common
-race:dictkeys_decref
-race:dictkeys_incref
 race:dictresize
 race:gc_collect_main
 race:gc_restore_tid


### PR DESCRIPTION
Checking for immortality of dict keys is reported as a TSAN violation, we just need relaxed loads

<!-- gh-issue-number: gh-117657 -->
* Issue: gh-117657
<!-- /gh-issue-number -->
