### PR TITLE
gh-114099: Modify preprocessor symbol usage to support older macOS SDKs

### DIFF
--- a/Misc/NEWS.d/next/macOS/2024-04-19-08-40-00.gh-issue-114099._iDfrQ.rst
+++ b/Misc/NEWS.d/next/macOS/2024-04-19-08-40-00.gh-issue-114099._iDfrQ.rst
@@ -1,0 +1,1 @@
+iOS preprocessor symbol usage was made compatible with older macOS SDKs.

--- a/Misc/platform_triplet.c
+++ b/Misc/platform_triplet.c
@@ -246,8 +246,9 @@ PLATFORM_TRIPLET=i386-gnu
 # endif
 #elif defined(__APPLE__)
 #  include "TargetConditionals.h"
-#  if TARGET_OS_IOS
-#    if TARGET_OS_SIMULATOR
+// Older macOS SDKs do not define TARGET_OS_*
+#  if defined(TARGET_OS_IOS) && TARGET_OS_IOS
+#    if defined(TARGET_OS_SIMULATOR) && TARGET_OS_SIMULATOR
 #      if __x86_64__
 PLATFORM_TRIPLET=x86_64-iphonesimulator
 #      else
@@ -256,7 +257,8 @@ PLATFORM_TRIPLET=arm64-iphonesimulator
 #    else
 PLATFORM_TRIPLET=arm64-iphoneos
 #    endif
-#  elif TARGET_OS_OSX
+// Older macOS SDKs do not define TARGET_OS_OSX
+#  elif !defined(TARGET_OS_OSX) || TARGET_OS_OSX
 PLATFORM_TRIPLET=darwin
 #  else
 #    error unknown Apple platform

--- a/Modules/_testexternalinspection.c
+++ b/Modules/_testexternalinspection.c
@@ -17,6 +17,10 @@
 
 #if defined(__APPLE__)
 #  include <TargetConditionals.h>
+// Older macOS SDKs do not define TARGET_OS_OSX
+#  if !defined(TARGET_OS_OSX)
+#     define TARGET_OS_OSX 1
+#  endif
 #  if TARGET_OS_OSX
 #    include <libproc.h>
 #    include <mach-o/fat.h>

--- a/Python/marshal.c
+++ b/Python/marshal.c
@@ -41,7 +41,8 @@ module marshal
 #elif defined(__wasi__)
 #  define MAX_MARSHAL_STACK_DEPTH 1500
 // TARGET_OS_IPHONE covers any non-macOS Apple platform.
-#elif defined(__APPLE__) && TARGET_OS_IPHONE
+// It won't be defined on older macOS SDKs
+#elif defined(__APPLE__) && defined(TARGET_OS_IPHONE) && TARGET_OS_IPHONE
 #  define MAX_MARSHAL_STACK_DEPTH 1500
 #else
 #  define MAX_MARSHAL_STACK_DEPTH 2000


### PR DESCRIPTION
Older macOS SDKs don't expose the `TARGET_OS_*` symbols; this PR makes the preprocessor usage compatible with those older SDKs.

As discussed on PR #117887, this consolidates the two separate PRs (#117887 and #117892, both submitted by @jmroot) with an additional change to `Python/marshal.c`, and tags the fix against the iOS feature that introduced the issue.

Fixes #117891
Fixes #117886