### PR TITLE
Docs: Fix CVE link

### DIFF
--- a/Doc/c-api/init.rst
+++ b/Doc/c-api/init.rst
@@ -699,7 +699,7 @@ Process-wide parameters
       It is recommended that applications embedding the Python interpreter
       for purposes other than executing a single script pass ``0`` as *updatepath*,
       and update :data:`sys.path` themselves if desired.
-      See `CVE-2008-5983 <https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2008-5983>`_.
+      See :cve:`2008-5983`.
 
       On versions before 3.1.3, you can achieve the same effect by manually
       popping the first :data:`sys.path` element after having called


### PR DESCRIPTION
The ReadTheDocs build on a number of PRs is failing with a warning about this link (e.g. https://readthedocs.org/projects/cpython-previews/builds/24114657/).

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--118077.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->