### PR TITLE
gh-118079: Fix ``requires_singlephase_init`` helper

### DIFF
--- a/Lib/test/test_import/__init__.py
+++ b/Lib/test/test_import/__init__.py
@@ -159,9 +159,8 @@ def requires_singlephase_init(meth):
             finally:
                 restore__testsinglephase()
     meth = cpython_only(meth)
-    # gh-117649: free-threaded build does not currently support single-phase
-    # init modules in subinterpreters.
-    meth = requires_gil_enabled(meth)
+    msg = "gh-117694: free-threaded build does not currently support single-phase init modules in sub-interpreters"
+    meth = requires_gil_enabled(msg)(meth)
     return unittest.skipIf(_testsinglephase is None,
                            'test requires _testsinglephase module')(meth)
 


### PR DESCRIPTION
Before this PR tests which decorated with a ``requires_singlephase_init`` helper simply did not run because of an incorrect call to the ``requires_gil_enabled`` helper.

<!-- gh-issue-number: gh-118079 -->
* Issue: gh-118079
<!-- /gh-issue-number -->
