### PR TITLE
Set proper permissions for `jit.yml` workflow

### DIFF
--- a/.github/workflows/jit.yml
+++ b/.github/workflows/jit.yml
@@ -12,6 +12,9 @@ on:
       - 'Python/optimizer*.c'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true


### PR DESCRIPTION
All other CI jobs have this set: 

https://github.com/python/cpython/blob/fefd5d97111364afa027ae580c3244f427dda59d/.github/workflows/lint.yml#L5-L6

https://github.com/python/cpython/blob/fefd5d97111364afa027ae580c3244f427dda59d/.github/workflows/mypy.yml#L21-L22

https://github.com/python/cpython/blob/fefd5d97111364afa027ae580c3244f427dda59d/.github/workflows/build.yml#L25-L26