### PR TITLE
[gh-117657] _Py_MergeZeroLocalRefcount isn't loading ob_ref_shared with strong enough semantics

### DIFF
--- a/Objects/object.c
+++ b/Objects/object.c
@@ -374,7 +374,7 @@ _Py_MergeZeroLocalRefcount(PyObject *op)
     assert(op->ob_ref_local == 0);
 
     _Py_atomic_store_uintptr_relaxed(&op->ob_tid, 0);
-    Py_ssize_t shared = _Py_atomic_load_ssize_relaxed(&op->ob_ref_shared);
+    Py_ssize_t shared = _Py_atomic_load_ssize_acquire(&op->ob_ref_shared);
     if (shared == 0) {
         // Fast-path: shared refcount is zero (including flags)
         _Py_Dealloc(op);


### PR DESCRIPTION
In the nogil-integration branch there's some intermittent TSAN warnings like these:

https://gist.github.com/DinoV/52b7131cb149b9ebb2e965970c4ae9e8

It looks like we're racing on the loading of `ob_ref_shared` in `_Py_MergeZeroLocalRefcount` because we're doing a relaxed load, leading to the object potentially being freed while another thread holds a reference to it. This is occurring because with a lock-free read from the inline values there's no other synchronization points with the thread which owns the object.

This just changes the read to be acquire.

<!-- gh-issue-number: gh-117657 -->
* Issue: gh-117657
<!-- /gh-issue-number -->
