### PR TITLE
gh-118121: Fix `test_doctest.test_look_in_unwrapped`

### DIFF
--- a/Lib/test/test_doctest/test_doctest.py
+++ b/Lib/test/test_doctest/test_doctest.py
@@ -2545,12 +2545,27 @@ class Wrapper:
         self.func(*args, **kwargs)
 
 @Wrapper
-def test_look_in_unwrapped():
+def wrapped():
     """
     Docstrings in wrapped functions must be detected as well.
 
     >>> 'one other test'
     'one other test'
+    """
+
+def test_look_in_unwrapped():
+    """
+    Ensure that wrapped doctests work correctly.
+
+    >>> import doctest
+    >>> doctest.run_docstring_examples(
+    ...     wrapped, {}, name=wrapped.__name__, verbose=True)
+    Finding tests in wrapped
+    Trying:
+        'one other test'
+    Expecting:
+        'one other test'
+    ok
     """
 
 @doctest_skip_if(support.check_impl_detail(cpython=False))


### PR DESCRIPTION
After we can check that tests are actually executed. Let's pretend that they are not by removing the doctest from `wrapped`:

```
Failed example:
    doctest.run_docstring_examples(
        wrapped, {}, name=wrapped.__name__, verbose=True)
Expected:
    Finding tests in wrapped
    Trying:
        'one other test'
    Expecting:
        'one other test'
    ok
Got:
    Finding tests in wrapped
```

@AlexWaygood you reviewed the last commit to `test_doctest`, maybe you are also interested in this one? :)

<!-- gh-issue-number: gh-118121 -->
* Issue: gh-118121
<!-- /gh-issue-number -->
