### PR TITLE
gh-107674: Lazy load line number to improve performance of tracing

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2024-04-20-20-30-15.gh-issue-107674.GZPOP7.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2024-04-20-20-30-15.gh-issue-107674.GZPOP7.rst
@@ -1,0 +1,1 @@
+Lazy load frame line number to improve performance of tracing

--- a/Objects/frameobject.c
+++ b/Objects/frameobject.c
@@ -41,10 +41,19 @@ int
 PyFrame_GetLineNumber(PyFrameObject *f)
 {
     assert(f != NULL);
-    if (f->f_lineno == 0) {
+    if (f->f_lineno == -1) {
+        // We should calculate it once. If we can't get the line number,
+        // set f->f_lineno to 0.
         f->f_lineno = PyUnstable_InterpreterFrame_GetLine(f->f_frame);
+        if (f->f_lineno < 0) {
+            f->f_lineno = 0;
+        }
     }
-    return f->f_lineno;
+
+    if (f->f_lineno > 0) {
+        return f->f_lineno;
+    }
+    return PyUnstable_InterpreterFrame_GetLine(f->f_frame);
 }
 
 static PyObject *

--- a/Objects/frameobject.c
+++ b/Objects/frameobject.c
@@ -41,12 +41,10 @@ int
 PyFrame_GetLineNumber(PyFrameObject *f)
 {
     assert(f != NULL);
-    if (f->f_lineno != 0) {
-        return f->f_lineno;
+    if (f->f_lineno == 0) {
+        f->f_lineno = PyUnstable_InterpreterFrame_GetLine(f->f_frame);
     }
-    else {
-        return PyUnstable_InterpreterFrame_GetLine(f->f_frame);
-    }
+    return f->f_lineno;
 }
 
 static PyObject *

--- a/Objects/frameobject.c
+++ b/Objects/frameobject.c
@@ -47,6 +47,7 @@ PyFrame_GetLineNumber(PyFrameObject *f)
         f->f_lineno = PyUnstable_InterpreterFrame_GetLine(f->f_frame);
         if (f->f_lineno < 0) {
             f->f_lineno = 0;
+            return -1;
         }
     }
 

--- a/Python/instrumentation.c
+++ b/Python/instrumentation.c
@@ -1228,9 +1228,9 @@ _Py_call_instrumentation_line(PyThreadState *tstate, _PyInterpreterFrame* frame,
     int line = 0;
 
     if (line_delta == COMPUTED_LINE_LINENO_CHANGE) {
-        // We know the line number must changed, don't need to calculate the
-        // line number for now because we might not need it.
-        line = 0;
+        // We know the line number must have changed, don't need to calculate
+        // the line number for now because we might not need it.
+        line = -1;
     } else {
         line = compute_line(code, i, line_delta);
         assert(line >= 0);
@@ -1269,7 +1269,7 @@ _Py_call_instrumentation_line(PyThreadState *tstate, _PyInterpreterFrame* frame,
                 tstate->tracing++;
                 /* Call c_tracefunc directly, having set the line number. */
                 Py_INCREF(frame_obj);
-                if (line == 0 && line_delta > COMPUTED_LINE) {
+                if (line == -1 && line_delta > COMPUTED_LINE) {
                     /* Only assign f_lineno if it's easy to calculate, otherwise
                      * do lazy calculation by setting the f_lineno to 0.
                      */
@@ -1292,7 +1292,7 @@ _Py_call_instrumentation_line(PyThreadState *tstate, _PyInterpreterFrame* frame,
         goto done;
     }
 
-    if (line == 0) {
+    if (line == -1) {
         /* Need to calculate the line number now for monitoring events */
         line = compute_line(code, i, line_delta);
     }

--- a/Python/instrumentation.c
+++ b/Python/instrumentation.c
@@ -268,14 +268,15 @@ get_events(_Py_GlobalMonitors *m, int tool_id)
  * 8 bit value.
  * if line_delta == -128:
  *     line = None # represented as -1
- * elif line_delta == -127:
+ * elif line_delta == -127 or line_delta == -126:
  *     line = PyCode_Addr2Line(code, offset * sizeof(_Py_CODEUNIT));
  * else:
  *     line = first_line  + (offset >> OFFSET_SHIFT) + line_delta;
  */
 
 #define NO_LINE -128
-#define COMPUTED_LINE -127
+#define COMPUTED_LINE_LINENO_CHANGE -127
+#define COMPUTED_LINE -126
 
 #define OFFSET_SHIFT 4
 
@@ -302,7 +303,7 @@ compute_line(PyCodeObject *code, int offset, int8_t line_delta)
 
         return -1;
     }
-    assert(line_delta == COMPUTED_LINE);
+    assert(line_delta == COMPUTED_LINE || line_delta == COMPUTED_LINE_LINENO_CHANGE);
     /* Look it up */
     return PyCode_Addr2Line(code, offset * sizeof(_Py_CODEUNIT));
 }
@@ -1224,18 +1225,26 @@ _Py_call_instrumentation_line(PyThreadState *tstate, _PyInterpreterFrame* frame,
     }
     PyInterpreterState *interp = tstate->interp;
     int8_t line_delta = line_data->line_delta;
-    int line = compute_line(code, i, line_delta);
-    assert(line >= 0);
-    assert(prev != NULL);
-    int prev_index = (int)(prev - _PyCode_CODE(code));
-    int prev_line = _Py_Instrumentation_GetLine(code, prev_index);
-    if (prev_line == line) {
-        int prev_opcode = _PyCode_CODE(code)[prev_index].op.code;
-        /* RESUME and INSTRUMENTED_RESUME are needed for the operation of
-         * instrumentation, so must never be hidden by an INSTRUMENTED_LINE.
-         */
-        if (prev_opcode != RESUME && prev_opcode != INSTRUMENTED_RESUME) {
-            goto done;
+    int line = 0;
+
+    if (line_delta == COMPUTED_LINE_LINENO_CHANGE) {
+        // We know the line number must changed, don't need to calculate the
+        // line number for now because we might not need it.
+        line = 0;
+    } else {
+        line = compute_line(code, i, line_delta);
+        assert(line >= 0);
+        assert(prev != NULL);
+        int prev_index = (int)(prev - _PyCode_CODE(code));
+        int prev_line = _Py_Instrumentation_GetLine(code, prev_index);
+        if (prev_line == line) {
+            int prev_opcode = _PyCode_CODE(code)[prev_index].op.code;
+            /* RESUME and INSTRUMENTED_RESUME are needed for the operation of
+             * instrumentation, so must never be hidden by an INSTRUMENTED_LINE.
+             */
+            if (prev_opcode != RESUME && prev_opcode != INSTRUMENTED_RESUME) {
+                goto done;
+            }
         }
     }
 
@@ -1260,6 +1269,12 @@ _Py_call_instrumentation_line(PyThreadState *tstate, _PyInterpreterFrame* frame,
                 tstate->tracing++;
                 /* Call c_tracefunc directly, having set the line number. */
                 Py_INCREF(frame_obj);
+                if (line == 0 && line_delta > COMPUTED_LINE) {
+                    /* Only assign f_lineno if it's easy to calculate, otherwise
+                     * do lazy calculation by setting the f_lineno to 0.
+                     */
+                    line = compute_line(code, i, line_delta);
+                }
                 frame_obj->f_lineno = line;
                 int err = tstate->c_tracefunc(tstate->c_traceobj, frame_obj, PyTrace_LINE, Py_None);
                 frame_obj->f_lineno = 0;
@@ -1275,6 +1290,11 @@ _Py_call_instrumentation_line(PyThreadState *tstate, _PyInterpreterFrame* frame,
     }
     if (tools == 0) {
         goto done;
+    }
+
+    if (line == 0) {
+        /* Need to calculate the line number now for monitoring events */
+        line = compute_line(code, i, line_delta);
     }
     PyObject *line_obj = PyLong_FromLong(line);
     if (line_obj == NULL) {
@@ -1477,6 +1497,13 @@ initialize_lines(PyCodeObject *code)
                  */
                 if (line != current_line && line >= 0) {
                     line_data[i].original_opcode = opcode;
+                    if (line_data[i].line_delta == COMPUTED_LINE) {
+                        /* Label this line as a line with a line number change
+                         * which could help the monitoring callback to quickly
+                         * identify the line number change.
+                         */
+                        line_data[i].line_delta = COMPUTED_LINE_LINENO_CHANGE;
+                    }
                 }
                 else {
                     line_data[i].original_opcode = 0;
@@ -1529,6 +1556,11 @@ initialize_lines(PyCodeObject *code)
         assert(target >= 0);
         if (line_data[target].line_delta != NO_LINE) {
             line_data[target].original_opcode = _Py_GetBaseOpcode(code, target);
+            if (line_data[target].line_delta == COMPUTED_LINE_LINENO_CHANGE) {
+                // If the line is a jump target, we are not sure if the line
+                // number changes, so we set it to COMPUTED_LINE.
+                line_data[target].line_delta = COMPUTED_LINE;
+            }
         }
     }
     /* Scan exception table */

--- a/Python/legacy_tracing.c
+++ b/Python/legacy_tracing.c
@@ -174,6 +174,7 @@ call_trace_func(_PyLegacyEventHandler *self, PyObject *arg)
 
     Py_INCREF(frame);
     int err = tstate->c_tracefunc(tstate->c_traceobj, frame, self->event, arg);
+    frame->f_lineno = 0;
     Py_DECREF(frame);
     if (err) {
         return NULL;


### PR DESCRIPTION
The new monitoring mechanism has a huge performance regression when the function body (or the module body) is too long. It's not that uncommon to put a very large data structure (dict?) as a constant in a python file just because it's easy to load. This regression would make coverage and debugging miserable when the user uses libraries with such a file.

The core reason is line number calculation.

The line number for each opcode is calculated once when the monitoring line data is initialized. This part is relatively fast because it goes through the addresses linearly. So basically one pass to get the line numbers. However, as we are conservative on memory usage (for each byte code), we only have an 8-bit value to store the line number. Currently we are using a heuristic of shifting the index of the byte code and adjusting by an offset, which covers function under a couple hundred lines well. However, the performance is horrible when the heuristic does not work.

For each line event, we need to calculate two line numbers, line number of current and previous bytecode. If the heuristic does not work, we need to scan from the beginning of the address, which makes each calculate about O(N) to the length of the code object. That gives a O(N^2) complexity for really long code objects like the constant mentioned above.

For example, a dict with 3k lines takes about 0.03s to execute on my computer. With an empty trace function, it takes 0.3s. That's a 10x overhead for the mechanism itself. It would get worse when the dict is longer.

So, can we do better?

The reason we need both line numbers for the current and the previous bytecode, is that we need to compare whether the line number changed - if it does not change, we don't emit the event. However, that's some information that we already know when we initialize monitoring line data. If it's not a jump target, we have a guaranteed way to know whether that bytecode will trigger a line event.

Thus, we can add a new special value for the `line_delta` to indicate this bytecode must be a new line, to avoid having to calculate the previous line when the heuristic fails to work. That's 50% less workload.

Even better, considering that for `sys.settrace`, in many cases, we do not even need the line number, just whether it should be a new line event, we don't even have to calculate the current line number before we trigger the event. (Think of the `n` command of pdb, when the frame is not correct, it just continues). So we can make the line number lazy loaded, only calculate it when we need it. The mechanism is there, just need to hook it up.

I added the cache so we don't need to calculate it every time we try to access it. Fixed an issue that after exception event the `f_lineno` is not cleared to make it work.

After all the changes above, the dict with an empty trace function is as fast as no trace. I believe this will also improve the tracing mechanism in general whenever the heuristic does not work, with a very small cost of losing one offset.

<!-- gh-issue-number: gh-107674 -->
* Issue: gh-107674
<!-- /gh-issue-number -->
