### PR TITLE
Docs: replace Harry Potter reference with Monty Python

### DIFF
--- a/Doc/library/doctest.rst
+++ b/Doc/library/doctest.rst
@@ -800,18 +800,18 @@ guarantee about output.  For example, when printing a set, Python doesn't
 guarantee that the element is printed in any particular order, so a test like ::
 
    >>> foo()
-   {"Hermione", "Harry"}
+   {"spam", "eggs"}
 
 is vulnerable!  One workaround is to do ::
 
-   >>> foo() == {"Hermione", "Harry"}
+   >>> foo() == {"spam", "eggs"}
    True
 
 instead.  Another is to do ::
 
    >>> d = sorted(foo())
    >>> d
-   ['Harry', 'Hermione']
+   ['eggs', 'spam']
 
 There are others, but you get the idea.
 


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

Harry Potter's author has publicly expressed opinions that contribute to the unsafety of transgender people.

I have no doubt that this reference was added in good faith, especially considering that it was contributed 17 years ago, shortly after Twitter's inception (and presumably before JK Rowling signed up), but I think that keeping it around now would send off the wrong message to trans folks that this community doesn't care about them.

I stumbled upon this particular instance simply by reading docs, but I didn't find more.

Luke and Leia seemed like a good replacement here as another mix-gendered pair of main characters from an extremely popular franchise with names that start with the same letter.



<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--118130.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->