### PR TITLE
gh-118140: Make the``test_concurrent_futures.test_init`` quiet.

### DIFF
--- a/Lib/test/test_concurrent_futures/test_init.py
+++ b/Lib/test/test_concurrent_futures/test_init.py
@@ -4,6 +4,7 @@ import queue
 import time
 import unittest
 import sys
+import io
 from concurrent.futures._base import BrokenExecutor
 from concurrent.futures.process import _check_system_limits
 
@@ -124,7 +125,7 @@ class FailingInitializerResourcesTest(unittest.TestCase):
         except NotImplementedError:
             self.skipTest("ProcessPoolExecutor unavailable on this system")
 
-        runner = unittest.TextTestRunner()
+        runner = unittest.TextTestRunner(stream=io.StringIO())
         runner.run(test_class('test_initializer'))
 
         # GH-104090:


### PR DESCRIPTION
Before this PR:
```python
./python.exe -m test -q test_concurrent_futures -m test_init
Using random seed: 2943892526
0:00:00 load avg: 2.95 Run 8 tests sequentially
.
----------------------------------------------------------------------
Ran 1 test in 0.228s

OK
.
----------------------------------------------------------------------
Ran 1 test in 0.234s

OK
test_concurrent_futures.test_wait ran no tests

== Tests result: SUCCESS ==

7 tests run no tests:
    test_concurrent_futures.test_as_completed
    test_concurrent_futures.test_deadlock
    test_concurrent_futures.test_future
    test_concurrent_futures.test_process_pool
    test_concurrent_futures.test_shutdown
    test_concurrent_futures.test_thread_pool
    test_concurrent_futures.test_wait

Total duration: 1.8 sec
Total tests: run=10 (filtered)
Total test files: run=8/8 (filtered) run_no_tests=7
Result: SUCCESS
```

After:
```python
./python.exe -m test -q test_concurrent_futures -m test_init               
Using random seed: 4087315254
0:00:00 load avg: 3.30 Run 8 tests sequentially
test_concurrent_futures.test_wait ran no tests

== Tests result: SUCCESS ==

7 tests run no tests:
    test_concurrent_futures.test_as_completed
    test_concurrent_futures.test_deadlock
    test_concurrent_futures.test_future
    test_concurrent_futures.test_process_pool
    test_concurrent_futures.test_shutdown
    test_concurrent_futures.test_thread_pool
    test_concurrent_futures.test_wait

Total duration: 1.8 sec
Total tests: run=10 (filtered)
Total test files: run=8/8 (filtered) run_no_tests=7
Result: SUCCESS
```

<!-- gh-issue-number: gh-118140 -->
* Issue: gh-118140
<!-- /gh-issue-number -->
