### PR TITLE
gh-118030: Group definitions for `ParamSpecArgs` and `ParamSpecKwargs` in `typing.rst`

### DIFF
--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -1972,7 +1972,7 @@ without the dedicated syntax, as documented below.
       * :ref:`annotating-callables`
 
 .. data:: ParamSpecArgs
-.. data:: ParamSpecKwargs
+          ParamSpecKwargs
 
    Arguments and keyword arguments attributes of a :class:`ParamSpec`. The
    ``P.args`` attribute of a ``ParamSpec`` is an instance of ``ParamSpecArgs``,


### PR DESCRIPTION
![image](https://github.com/python/cpython/assets/65588599/b8cababc-af5e-4f26-bd45-5c3dffa3b8b4)

Becomes

![image](https://github.com/python/cpython/assets/65588599/bb38f6ea-a6f4-403e-b404-4bcb18623fa9)

<!-- gh-issue-number: gh-118030 -->
* Issue: gh-118030
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--118154.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->