### PR TITLE
gh-90848: Fixed create_autospec ignoring configure_mock style kwargs

### DIFF
--- a/Lib/test/test_unittest/testmock/testmock.py
+++ b/Lib/test/test_unittest/testmock/testmock.py
@@ -115,6 +115,26 @@ class MockTest(unittest.TestCase):
         with self.assertRaises(TypeError):
             mock()
 
+    def test_create_autospec_should_be_configurable_by_kwargs(self):
+        """If kwargs are given to set side_effect & return_value, the function
+        must configure the parent mock during initialization."""
+        class Result:
+            def get_result(self):
+                pass
+
+        mocked_result = 'mocked value'
+        class_mock = create_autospec(spec=Result, **{
+            # Test both side_effect & return_value which is why the 2nd
+            # parameter of side_effect is DEFAULT.
+            'return_value.get_result.side_effect': [ValueError, DEFAULT],
+            'return_value.get_result.return_value': mocked_result})
+        with self.assertRaises(ValueError):
+            class_mock().get_result()
+        # Call it again to test return_value.
+        self.assertEqual(class_mock().get_result(), mocked_result)
+        # Only the parent mock should be configurable because the user will
+        # pass kwargs with respect to the parent mock.
+        self.assertEqual(class_mock().return_value.get_result.side_effect, None)
 
     def test_repr(self):
         mock = Mock(name='foo')

--- a/Lib/test/test_unittest/testmock/testmock.py
+++ b/Lib/test/test_unittest/testmock/testmock.py
@@ -116,25 +116,18 @@ class MockTest(unittest.TestCase):
             mock()
 
     def test_create_autospec_should_be_configurable_by_kwargs(self):
-        """If kwargs are given to set side_effect & return_value, the function
-        must configure the parent mock during initialization."""
-        class Result:
-            def get_result(self):
-                pass
-
+        """If kwargs are given to configure mock, the function must configure
+        the parent mock during initialization."""
         mocked_result = 'mocked value'
-        class_mock = create_autospec(spec=Result, **{
-            # Test both side_effect & return_value which is why the 2nd
-            # parameter of side_effect is DEFAULT.
-            'return_value.get_result.side_effect': [ValueError, DEFAULT],
-            'return_value.get_result.return_value': mocked_result})
+        class_mock = create_autospec(spec=Something, **{
+            'return_value.meth.side_effect': [ValueError, DEFAULT],
+            'return_value.meth.return_value': mocked_result})
         with self.assertRaises(ValueError):
-            class_mock().get_result()
-        # Call it again to test return_value.
-        self.assertEqual(class_mock().get_result(), mocked_result)
+            class_mock().meth(a=None, b=None, c=None)
+        self.assertEqual(class_mock().meth(a=None, b=None, c=None), mocked_result)
         # Only the parent mock should be configurable because the user will
         # pass kwargs with respect to the parent mock.
-        self.assertEqual(class_mock().return_value.get_result.side_effect, None)
+        self.assertEqual(class_mock().return_value.meth.side_effect, None)
 
     def test_repr(self):
         mock = Mock(name='foo')

--- a/Lib/unittest/mock.py
+++ b/Lib/unittest/mock.py
@@ -2788,8 +2788,8 @@ def create_autospec(spec, spec_set=False, instance=False, _parent=None,
     if _parent is not None and not instance:
         _parent._mock_children[_name] = mock
 
-    wrapped = kwargs.get('wraps')
-
+    # Pop "wraps" from kwargs because it will not be used again.
+    wrapped = kwargs.pop('wraps', None)
     if is_type and not instance and 'return_value' not in kwargs:
         mock.return_value = create_autospec(spec, spec_set, instance=True,
                                             _name='()', _parent=mock,
@@ -2814,12 +2814,12 @@ def create_autospec(spec, spec_set=False, instance=False, _parent=None,
         except AttributeError:
             continue
 
-        kwargs = {'spec': original}
+        child_kwargs = {'spec': original}
         # Wrap child attributes also.
         if wrapped and hasattr(wrapped, entry):
-            kwargs.update(wraps=original)
+            child_kwargs.update(wraps=original)
         if spec_set:
-            kwargs = {'spec_set': original}
+            child_kwargs = {'spec_set': original}
 
         if not isinstance(original, FunctionTypes):
             new = _SpecState(original, spec_set, mock, entry, instance)
@@ -2830,14 +2830,13 @@ def create_autospec(spec, spec_set=False, instance=False, _parent=None,
                 parent = mock.mock
 
             skipfirst = _must_skip(spec, entry, is_type)
-            kwargs['_eat_self'] = skipfirst
+            child_kwargs['_eat_self'] = skipfirst
             if iscoroutinefunction(original):
                 child_klass = AsyncMock
             else:
                 child_klass = MagicMock
             new = child_klass(parent=parent, name=entry, _new_name=entry,
-                              _new_parent=parent,
-                              **kwargs)
+                              _new_parent=parent, **child_kwargs)
             mock._mock_children[entry] = new
             new.return_value = child_klass()
             _check_signature(original, new, skipfirst=skipfirst)
@@ -2848,6 +2847,11 @@ def create_autospec(spec, spec_set=False, instance=False, _parent=None,
         # setting as an instance attribute?
         if isinstance(new, FunctionTypes):
             setattr(mock, entry, new)
+    # kwargs are passed with respect to the parent mock so, they are not used
+    # for creating return_value of the parent mock. So, this condition
+    # should be true only for the parent mock if kwargs are given.
+    if _is_instance_mock(mock) and kwargs:
+        mock.configure_mock(**kwargs)
 
     return mock
 

--- a/Lib/unittest/mock.py
+++ b/Lib/unittest/mock.py
@@ -2788,7 +2788,7 @@ def create_autospec(spec, spec_set=False, instance=False, _parent=None,
     if _parent is not None and not instance:
         _parent._mock_children[_name] = mock
 
-    # Pop "wraps" from kwargs because it will not be used again.
+    # Pop wraps from kwargs because it must not be passed to configure_mock.
     wrapped = kwargs.pop('wraps', None)
     if is_type and not instance and 'return_value' not in kwargs:
         mock.return_value = create_autospec(spec, spec_set, instance=True,

--- a/Misc/NEWS.d/next/Library/2024-04-22-21-54-12.gh-issue-90848.5jHEEc.rst
+++ b/Misc/NEWS.d/next/Library/2024-04-22-21-54-12.gh-issue-90848.5jHEEc.rst
@@ -1,0 +1,1 @@
+Fixed :func:`unittest.mock.create_autospec` to configure parent mock with keyword arguments.


### PR DESCRIPTION
# Fix for:
<!-- gh-issue-number: gh-90848-->
* Issue: gh-90848
<!-- /gh-issue-number -->

# Description
All mocks can be pre-configured with `side_effect` and `return_value` by passing them to `kwargs` which are consumed by the [Mock class](https://docs.python.org/3/library/unittest.mock.html#unittest.mock.Mock). But `unittest.mock.create_autospec` function is ignoring kwargs so, the user has to configure them later in the code after the initialization of the mock.

# Test To Reproduce
```python
from unittest import mock

import pytest


class Result:
    def get_result(self):
        pass


@pytest.mark.xfail
def test_result():
    class_mock = create_autospec(spec=Result, **{'return_value.get_result.side_effect': ValueError})
    with pytest.raises(ValueError):
        classmock().get_result()


def test_result_configure_later():
    class_mock = create_autospec(spec=Result)
    class_mock.return_value.get_result.side_effect = ValueError
    with pytest.raises(ValueError):
        classmock().get_result()
```

# Details
This is the line 👇 which is consuming `kwargs` during the initialization of the mock:
https://github.com/python/cpython/blob/85f727c5fb2afa60affa9ae3396ce4149cf5215d/Lib/unittest/mock.py#L2774-L2777

Here 👇 we are overriding the `return_value` of the mock by creating a new mock on it but this is not the problem:
https://github.com/python/cpython/blob/85f727c5fb2afa60affa9ae3396ce4149cf5215d/Lib/unittest/mock.py#L2793-L2797

As it is being called recursively 👆, the attributes of the _specced_ object will also be mocked by creating **child mocks** 👇:
https://github.com/python/cpython/blob/85f727c5fb2afa60affa9ae3396ce4149cf5215d/Lib/unittest/mock.py#L2838-L2841

Then the child mocks are set on the recursive mock 👇:
https://github.com/python/cpython/blob/85f727c5fb2afa60affa9ae3396ce4149cf5215d/Lib/unittest/mock.py#L2849-L2851

This 👆 is the cause of the issue. We have set new child attribute mock which is not configured.

# Fix Suggested by @tirkarthi 

```diff

+    if _is_instance_mock(mock) and kwargs:
+        mock.configure_mock(**kwargs)

      return mock
```

# Code Changes
1. Added the above patch which will configure the parent mock **only** at the end because the user will pass `kwargs` with respect to the parent mock.
2. Renamed local variable `kwargs` to `child_kwargs` because it was shadowing the name of the argument which is now being used to configure the parent mock.
3. This 👇 should be popped because it will not be used again when configuring the parent mock at the end.
```diff
-    wrapped = kwargs.get('wraps')
+    # Pop wraps from kwargs because it must not be passed to configure_mock.
+    wrapped = kwargs.pop('wraps', None)
```

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
