### PR TITLE
gh-117657: Quiet TSAN warnings about remaining non-atomic accesses of `tstate->state`

### DIFF
--- a/Python/parking_lot.c
+++ b/Python/parking_lot.c
@@ -194,7 +194,8 @@ _PySemaphore_Wait(_PySemaphore *sema, PyTime_t timeout, int detach)
     PyThreadState *tstate = NULL;
     if (detach) {
         tstate = _PyThreadState_GET();
-        if (tstate && tstate->state == _Py_THREAD_ATTACHED) {
+        if (tstate && _Py_atomic_load_int_relaxed(&tstate->state) ==
+                          _Py_THREAD_ATTACHED) {
             // Only detach if we are attached
             PyEval_ReleaseThread(tstate);
         }

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -2096,7 +2096,7 @@ _PyThreadState_Suspend(PyThreadState *tstate)
 {
     _PyRuntimeState *runtime = &_PyRuntime;
 
-    assert(tstate->state == _Py_THREAD_ATTACHED);
+    assert(_Py_atomic_load_int_relaxed(&tstate->state) == _Py_THREAD_ATTACHED);
 
     struct _stoptheworld_state *stw = NULL;
     HEAD_LOCK(runtime);


### PR DESCRIPTION
These should be the last instances of TSAN warning of data races when accessing `tstate->state` non-atomically.

TSAN reports a race ([example](https://gist.github.com/mpage/4ee21646183499c42b16d886b93bebe6)) between accessing `tstate->state` in `_PyThreadState_Suspend()`:

https://github.com/python/cpython/blob/fc21c7f7a731d64f7e4f0e82469f78fa9c104bbd/Python/pystate.c#L2099

 and the compare/exchange in `park_detached_threads()`:

https://github.com/python/cpython/blob/fc21c7f7a731d64f7e4f0e82469f78fa9c104bbd/Python/pystate.c#L2172-L2173

This is a false positive due to TSAN modeling failed compare/exchange operations as writes.

TSAN also reports a race ([example](https://gist.github.com/mpage/eac4a27020f988aeede0bebfd786eecd)) between accessing `tstate->state` in `_PySemaphore_Wait()`:

https://github.com/python/cpython/blob/fc21c7f7a731d64f7e4f0e82469f78fa9c104bbd/Python/parking_lot.c#L197

 and the compare/exchange in `park_detached_threads()` above. This is the same issue that we saw in gh-117830.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-117657 -->
* Issue: gh-117657
<!-- /gh-issue-number -->
