### PR TITLE
[tests]: Fix incorrect usage of ``support.requires_gil_enabled``

### DIFF
--- a/Lib/test/test_capi/test_mem.py
+++ b/Lib/test/test_capi/test_mem.py
@@ -153,7 +153,7 @@ class PyMemDebugTests(unittest.TestCase):
 
 
 # free-threading requires mimalloc (not malloc)
-@support.requires_gil_enabled
+@support.requires_gil_enabled()
 class PyMemMallocDebugTests(PyMemDebugTests):
     PYTHONMALLOC = 'malloc_debug'
 

--- a/Lib/test/test_gdb/test_backtrace.py
+++ b/Lib/test/test_gdb/test_backtrace.py
@@ -49,7 +49,7 @@ Traceback \(most recent call first\):
 
     @unittest.skipIf(python_is_optimized(),
                      "Python was compiled with optimizations")
-    @support.requires_gil_enabled
+    @support.requires_gil_enabled()
     @support.requires_resource('cpu')
     def test_threads(self):
         'Verify that "py-bt" indicates threads that are waiting for the GIL'


### PR DESCRIPTION
``test_capi.test_mem`` before:

<details>

```python
./python.exe -m test -v test_capi -m PyMemMallocDebugTests
== CPython 3.13.0a6+ (heads/main-dirty:1446024124, Apr 23 2024, 08:21:10) [Clang 15.0.0 (clang-1500.1.0.2.5)]
== macOS-14.2.1-arm64-arm-64bit-Mach-O little-endian
== Python build: debug
== cwd: /Users/admin/Projects/cpython/build/test_python_worker_6699æ
== CPU count: 8
== encodings: locale=UTF-8 FS=utf-8
== resources: all test resources are disabled, use -u option to unskip tests

Using random seed: 359039614
0:00:00 load avg: 3.50 Run 1 test sequentially
0:00:00 load avg: 3.50 [1/1] test_capi

----------------------------------------------------------------------
Ran 0 tests in 0.000s

NO TESTS RAN
test_capi ran no tests

== Tests result: NO TESTS RAN ==

1 test run no tests:
    test_capi

Total duration: 133 ms
Total tests: run=0 (filtered)
Total test files: run=1/1 (filtered) run_no_tests=1
Result: NO TESTS RAN
```
</details>

After:
<details>

```python
./python.exe -m test -v test_capi -m PyMemMallocDebugTests
== CPython 3.13.0a6+ (heads/main-dirty:1446024124, Apr 23 2024, 08:21:10) [Clang 15.0.0 (clang-1500.1.0.2.5)]
== macOS-14.2.1-arm64-arm-64bit-Mach-O little-endian
== Python build: debug
== cwd: /Users/admin/Projects/cpython/build/test_python_worker_6722æ
== CPU count: 8
== encodings: locale=UTF-8 FS=utf-8
== resources: all test resources are disabled, use -u option to unskip tests

Using random seed: 2140682917
0:00:00 load avg: 1.72 Run 1 test sequentially
0:00:00 load avg: 1.72 [1/1] test_capi
test_api_misuse (test.test_capi.test_mem.PyMemMallocDebugTests.test_api_misuse) ... ok
test_buffer_overflow (test.test_capi.test_mem.PyMemMallocDebugTests.test_buffer_overflow) ... ok
test_pymem_malloc_without_gil (test.test_capi.test_mem.PyMemMallocDebugTests.test_pymem_malloc_without_gil) ... ok
test_pyobject_forbidden_bytes_is_freed (test.test_capi.test_mem.PyMemMallocDebugTests.test_pyobject_forbidden_bytes_is_freed) ... ok
test_pyobject_freed_is_freed (test.test_capi.test_mem.PyMemMallocDebugTests.test_pyobject_freed_is_freed) ... ok
test_pyobject_malloc_without_gil (test.test_capi.test_mem.PyMemMallocDebugTests.test_pyobject_malloc_without_gil) ... ok
test_pyobject_null_is_freed (test.test_capi.test_mem.PyMemMallocDebugTests.test_pyobject_null_is_freed) ... ok
test_pyobject_uninitialized_is_freed (test.test_capi.test_mem.PyMemMallocDebugTests.test_pyobject_uninitialized_is_freed) ... ok
test_set_nomemory (test.test_capi.test_mem.PyMemMallocDebugTests.test_set_nomemory) ... ok

----------------------------------------------------------------------
Ran 9 tests in 0.312s

OK

== Tests result: SUCCESS ==

1 test OK.

Total duration: 453 ms
Total tests: run=9 (filtered)
Total test files: run=1/1 (filtered)
Result: SUCCESS
```
</details>

The same as in #118079 is applied to the ``test_gdb.test_backtrace.test_threads``.