### PR TITLE
gh-118074: Immortal executors are not GC-able

### DIFF
--- a/Python/optimizer.c
+++ b/Python/optimizer.c
@@ -397,10 +397,7 @@ executor_traverse(PyObject *o, visitproc visit, void *arg)
 static int
 executor_is_gc(PyObject *o)
 {
-    if ((PyObject *)&COLD_EXITS[0] <= o && o < (PyObject *)&COLD_EXITS[COLD_EXIT_COUNT]) {
-        return 0;
-    }
-    return 1;
+    return !_Py_IsImmortal(o);
 }
 
 PyTypeObject _PyUOpExecutor_Type = {


### PR DESCRIPTION
Better version of gh-118117. Just check for immortality instead of an address range check.