### PR TITLE
gh-117953: Add Internal struct _Py_ext_module_loader_info

### DIFF
--- a/Include/internal/pycore_importdl.h
+++ b/Include/internal/pycore_importdl.h
@@ -25,6 +25,7 @@ struct _Py_ext_module_loader_info {
     PyObject *name;
     PyObject *name_encoded;
     const char *hook_prefix;
+    const char *newcontext;
 };
 extern void _Py_ext_module_loader_info_clear(
     struct _Py_ext_module_loader_info *info);

--- a/Include/internal/pycore_importdl.h
+++ b/Include/internal/pycore_importdl.h
@@ -28,9 +28,9 @@ struct _Py_ext_module_loader_info {
 };
 extern void _Py_ext_module_loader_info_clear(
     struct _Py_ext_module_loader_info *info);
-extern int _Py_ext_module_loader_info_from_spec(
-    PyObject *spec,
-    struct _Py_ext_module_loader_info *info);
+extern int _Py_ext_module_loader_info_init_from_spec(
+    struct _Py_ext_module_loader_info *info,
+    PyObject *spec);
 
 extern PyObject *_PyImport_LoadDynamicModuleWithSpec(
     struct _Py_ext_module_loader_info *info,

--- a/Include/internal/pycore_importdl.h
+++ b/Include/internal/pycore_importdl.h
@@ -29,6 +29,10 @@ struct _Py_ext_module_loader_info {
 };
 extern void _Py_ext_module_loader_info_clear(
     struct _Py_ext_module_loader_info *info);
+extern int _Py_ext_module_loader_info_init(
+    struct _Py_ext_module_loader_info *info,
+    PyObject *name,
+    PyObject *filename);
 extern int _Py_ext_module_loader_info_init_from_spec(
     struct _Py_ext_module_loader_info *info,
     PyObject *spec);

--- a/Include/internal/pycore_importdl.h
+++ b/Include/internal/pycore_importdl.h
@@ -19,6 +19,9 @@ typedef PyObject *(*PyModInitFunction)(void);
 
 struct _Py_ext_module_loader_info {
     PyObject *path;
+#ifndef MS_WINDOWS
+    PyObject *path_encoded;
+#endif
     PyObject *name;
     PyObject *name_encoded;
     const char *hook_prefix;

--- a/Include/internal/pycore_importdl.h
+++ b/Include/internal/pycore_importdl.h
@@ -24,6 +24,9 @@ struct _Py_ext_module_loader_info {
 #endif
     PyObject *name;
     PyObject *name_encoded;
+    /* path is always a borrowed ref of name or filename,
+     * depending on if it's builtin or not. */
+    PyObject *path;
     const char *hook_prefix;
     const char *newcontext;
 };

--- a/Include/internal/pycore_importdl.h
+++ b/Include/internal/pycore_importdl.h
@@ -29,7 +29,10 @@ extern int _Py_ext_module_loader_info_from_spec(
     PyObject *spec,
     struct _Py_ext_module_loader_info *info);
 
-extern PyObject *_PyImport_LoadDynamicModuleWithSpec(PyObject *spec, FILE *);
+extern PyObject *_PyImport_LoadDynamicModuleWithSpec(
+    struct _Py_ext_module_loader_info *info,
+    PyObject *spec,
+    FILE *fp);
 
 
 /* Max length of module suffix searched for -- accommodates "module.slb" */

--- a/Include/internal/pycore_importdl.h
+++ b/Include/internal/pycore_importdl.h
@@ -18,9 +18,9 @@ extern const char *_PyImport_DynLoadFiletab[];
 typedef PyObject *(*PyModInitFunction)(void);
 
 struct _Py_ext_module_loader_info {
-    PyObject *path;
+    PyObject *filename;
 #ifndef MS_WINDOWS
-    PyObject *path_encoded;
+    PyObject *filename_encoded;
 #endif
     PyObject *name;
     PyObject *name_encoded;

--- a/Include/internal/pycore_importdl.h
+++ b/Include/internal/pycore_importdl.h
@@ -14,9 +14,23 @@ extern "C" {
 
 extern const char *_PyImport_DynLoadFiletab[];
 
-extern PyObject *_PyImport_LoadDynamicModuleWithSpec(PyObject *spec, FILE *);
 
 typedef PyObject *(*PyModInitFunction)(void);
+
+struct _Py_ext_module_loader_info {
+    PyObject *path;
+    PyObject *name;
+    PyObject *name_encoded;
+    const char *hook_prefix;
+};
+extern void _Py_ext_module_loader_info_clear(
+    struct _Py_ext_module_loader_info *info);
+extern int _Py_ext_module_loader_info_from_spec(
+    PyObject *spec,
+    struct _Py_ext_module_loader_info *info);
+
+extern PyObject *_PyImport_LoadDynamicModuleWithSpec(PyObject *spec, FILE *);
+
 
 /* Max length of module suffix searched for -- accommodates "module.slb" */
 #define MAXSUFFIXSIZE 12

--- a/Python/import.c
+++ b/Python/import.c
@@ -3887,13 +3887,13 @@ _imp_create_dynamic_impl(PyObject *module, PyObject *spec, PyObject *file)
     }
 
     PyThreadState *tstate = _PyThreadState_GET();
-    mod = import_find_extension(tstate, info.name, info.path);
+    mod = import_find_extension(tstate, info.name, info.filename);
     if (mod != NULL || _PyErr_Occurred(tstate)) {
         assert(mod == NULL || !_PyErr_Occurred(tstate));
         goto finally;
     }
 
-    if (PySys_Audit("import", "OOOOO", info.name, info.path,
+    if (PySys_Audit("import", "OOOOO", info.name, info.filename,
                     Py_None, Py_None, Py_None) < 0)
     {
         goto finally;
@@ -3905,7 +3905,7 @@ _imp_create_dynamic_impl(PyObject *module, PyObject *spec, PyObject *file)
      * _PyImport_GetModInitFunc(), but it isn't clear if the intervening
      * code relies on fp still being open. */
     if (file != NULL) {
-        fp = _Py_fopen_obj(info.path, "r");
+        fp = _Py_fopen_obj(info.filename, "r");
         if (fp == NULL) {
             goto finally;
         }

--- a/Python/import.c
+++ b/Python/import.c
@@ -1328,11 +1328,11 @@ _PyImport_FixupExtensionObject(PyObject *mod, PyObject *name,
 
 
 static PyObject *
-import_find_extension(PyThreadState *tstate, PyObject *name,
-                      PyObject *path)
+import_find_extension(PyThreadState *tstate,
+                      struct _Py_ext_module_loader_info *info)
 {
     /* Only single-phase init modules will be in the cache. */
-    PyModuleDef *def = _extensions_cache_get(path, name);
+    PyModuleDef *def = _extensions_cache_get(info->path, info->name);
     if (def == NULL) {
         return NULL;
     }
@@ -1340,7 +1340,7 @@ import_find_extension(PyThreadState *tstate, PyObject *name,
     /* It may have been successfully imported previously
        in an interpreter that allows legacy modules
        but is not allowed in the current interpreter. */
-    const char *name_buf = PyUnicode_AsUTF8(name);
+    const char *name_buf = PyUnicode_AsUTF8(info->name);
     assert(name_buf != NULL);
     if (_PyImport_CheckSubinterpIncompatibleExtensionAllowed(name_buf) < 0) {
         return NULL;
@@ -1355,12 +1355,13 @@ import_find_extension(PyThreadState *tstate, PyObject *name,
         if (m_copy == NULL) {
             /* It might be a core module (e.g. sys & builtins),
                for which we don't set m_copy. */
-            m_copy = get_core_module_dict(tstate->interp, name, path);
+            m_copy = get_core_module_dict(
+                    tstate->interp, info->name, info->path);
             if (m_copy == NULL) {
                 return NULL;
             }
         }
-        mod = import_add_module(tstate, name);
+        mod = import_add_module(tstate, info->name);
         if (mod == NULL) {
             return NULL;
         }
@@ -1378,15 +1379,16 @@ import_find_extension(PyThreadState *tstate, PyObject *name,
         if (def->m_base.m_init == NULL)
             return NULL;
         mod = def->m_base.m_init();
-        if (mod == NULL)
+        if (mod == NULL) {
             return NULL;
-        if (PyObject_SetItem(modules, name, mod) == -1) {
+        }
+        if (PyObject_SetItem(modules, info->name, mod) == -1) {
             Py_DECREF(mod);
             return NULL;
         }
     }
     if (_modules_by_index_set(tstate->interp, def, mod) < 0) {
-        PyMapping_DelItem(modules, name);
+        PyMapping_DelItem(modules, info->name);
         Py_DECREF(mod);
         return NULL;
     }
@@ -1394,7 +1396,7 @@ import_find_extension(PyThreadState *tstate, PyObject *name,
     int verbose = _PyInterpreterState_GetConfig(tstate->interp)->verbose;
     if (verbose) {
         PySys_FormatStderr("import %U # previously loaded (%R)\n",
-                           name, path);
+                           info->name, info->path);
     }
     return mod;
 }
@@ -1505,44 +1507,56 @@ static PyObject*
 create_builtin(PyThreadState *tstate, PyObject *name, PyObject *spec)
 {
     PyModuleDef *def = NULL;
-    PyObject *mod = import_find_extension(tstate, name, name);
+
+    struct _Py_ext_module_loader_info info;
+    if (_Py_ext_module_loader_info_init(&info, name, NULL) < 0) {
+        return NULL;
+    }
+
+    PyObject *mod = import_find_extension(tstate, &info);
     if (mod || _PyErr_Occurred(tstate)) {
-        return mod;
+        goto finally;
     }
 
     struct _inittab *found = NULL;
     for (struct _inittab *p = INITTAB; p->name != NULL; p++) {
-        if (_PyUnicode_EqualToASCIIString(name, p->name)) {
+        if (_PyUnicode_EqualToASCIIString(info.name, p->name)) {
             found = p;
         }
     }
     if (found == NULL) {
         // not found
-        Py_RETURN_NONE;
+        mod = Py_NewRef(Py_None);
+        goto finally;
     }
 
     PyModInitFunction p0 = (PyModInitFunction)found->initfunc;
     if (p0 == NULL) {
         /* Cannot re-init internal module ("sys" or "builtins") */
-        assert(is_core_module(tstate->interp, name, name));
-        return import_add_module(tstate, name);
+        assert(is_core_module(tstate->interp, info.name, info.path));
+        mod = import_add_module(tstate, info.name);
+        goto finally;
     }
 
     mod = p0();
     if (mod == NULL) {
-        return NULL;
+        goto finally;
     }
 
     if (PyObject_TypeCheck(mod, &PyModuleDef_Type)) {
         def = (PyModuleDef*)mod;
         assert(!is_singlephase(def));
-        return PyModule_FromDefAndSpec(def, spec);
+        mod = PyModule_FromDefAndSpec(def, spec);
+        if (mod == NULL) {
+            goto finally;
+        }
     }
     else {
         assert(PyModule_Check(mod));
         def = PyModule_GetDef(mod);
         if (def == NULL) {
-            return NULL;
+            Py_CLEAR(mod);
+            goto finally;
         }
         assert(is_singlephase(def));
 
@@ -1553,22 +1567,29 @@ create_builtin(PyThreadState *tstate, PyObject *name, PyObject *spec)
         // gh-88216: Extensions and def->m_base.m_copy can be updated
         // when the extension module doesn't support sub-interpreters.
         if (def->m_size == -1
-                && !is_core_module(tstate->interp, name, name))
+                && !is_core_module(tstate->interp, info.name, info.path))
         {
             singlephase.m_dict = PyModule_GetDict(mod);
             assert(singlephase.m_dict != NULL);
         }
         if (update_global_state_for_extension(
-                tstate, name, name, def, &singlephase) < 0)
+                tstate, info.name, info.path, def, &singlephase) < 0)
         {
-            return NULL;
+            Py_CLEAR(mod);
+            goto finally;
         }
         PyObject *modules = get_modules_dict(tstate, true);
-        if (finish_singlephase_extension(tstate, mod, def, name, modules) < 0) {
-            return NULL;
+        if (finish_singlephase_extension(
+                tstate, mod, def, info.name, modules) < 0)
+        {
+            Py_CLEAR(mod);
+            goto finally;
         }
-        return mod;
     }
+
+finally:
+    _Py_ext_module_loader_info_clear(&info);
+    return mod;
 }
 
 
@@ -3887,7 +3908,7 @@ _imp_create_dynamic_impl(PyObject *module, PyObject *spec, PyObject *file)
     }
 
     PyThreadState *tstate = _PyThreadState_GET();
-    mod = import_find_extension(tstate, info.name, info.filename);
+    mod = import_find_extension(tstate, &info);
     if (mod != NULL || _PyErr_Occurred(tstate)) {
         assert(mod == NULL || !_PyErr_Occurred(tstate));
         goto finally;

--- a/Python/import.c
+++ b/Python/import.c
@@ -3882,7 +3882,7 @@ _imp_create_dynamic_impl(PyObject *module, PyObject *spec, PyObject *file)
     FILE *fp;
 
     struct _Py_ext_module_loader_info info;
-    if (_Py_ext_module_loader_info_from_spec(spec, &info) < 0) {
+    if (_Py_ext_module_loader_info_init_from_spec(&info, spec) < 0) {
         return NULL;
     }
 

--- a/Python/importdl.c
+++ b/Python/importdl.c
@@ -105,8 +105,9 @@ _Py_ext_module_loader_info_clear(struct _Py_ext_module_loader_info *info)
 }
 
 int
-_Py_ext_module_loader_info_from_spec(PyObject *spec,
-                                     struct _Py_ext_module_loader_info *p_info)
+_Py_ext_module_loader_info_init_from_spec(
+                            struct _Py_ext_module_loader_info *p_info,
+                            PyObject *spec)
 {
     struct _Py_ext_module_loader_info info = {0};
 

--- a/Python/importdl.c
+++ b/Python/importdl.c
@@ -128,6 +128,12 @@ _Py_ext_module_loader_info_init_from_spec(
         return -1;
     }
 
+    info.newcontext = PyUnicode_AsUTF8(info.name);
+    if (info.newcontext == NULL) {
+        _Py_ext_module_loader_info_clear(&info);
+        return -1;
+    }
+
     info.path = PyObject_GetAttrString(spec, "origin");
     if (info.path == NULL) {
         _Py_ext_module_loader_info_clear(&info);
@@ -152,15 +158,10 @@ _PyImport_LoadDynamicModuleWithSpec(struct _Py_ext_module_loader_info *info,
 {
     PyObject *m = NULL;
     const char *name_buf = PyBytes_AS_STRING(info->name_encoded);
-    const char *oldcontext, *newcontext;
+    const char *oldcontext;
     dl_funcptr exportfunc;
     PyModInitFunction p0;
     PyModuleDef *def;
-
-    newcontext = PyUnicode_AsUTF8(info->name);
-    if (newcontext == NULL) {
-        goto error;
-    }
 
 #ifdef MS_WINDOWS
     exportfunc = _PyImport_FindSharedFuncptrWindows(
@@ -191,7 +192,7 @@ _PyImport_LoadDynamicModuleWithSpec(struct _Py_ext_module_loader_info *info,
     p0 = (PyModInitFunction)exportfunc;
 
     /* Package context is needed for single-phase init */
-    oldcontext = _PyImport_SwapPackageContext(newcontext);
+    oldcontext = _PyImport_SwapPackageContext(info->newcontext);
     m = p0();
     _PyImport_SwapPackageContext(oldcontext);
 

--- a/Python/importdl.c
+++ b/Python/importdl.c
@@ -147,6 +147,11 @@ _Py_ext_module_loader_info_init(struct _Py_ext_module_loader_info *p_info,
             return -1;
         }
 #endif
+
+        info.path = info.filename;
+    }
+    else {
+        info.path = info.name;
     }
 
     *p_info = info;

--- a/Python/importdl.c
+++ b/Python/importdl.c
@@ -97,47 +97,51 @@ void
 _Py_ext_module_loader_info_clear(struct _Py_ext_module_loader_info *info)
 {
     Py_CLEAR(info->path);
+#ifndef MS_WINDOWS
+    Py_CLEAR(info->path_encoded);
+#endif
     Py_CLEAR(info->name);
     Py_CLEAR(info->name_encoded);
 }
 
 int
 _Py_ext_module_loader_info_from_spec(PyObject *spec,
-                                     struct _Py_ext_module_loader_info *info)
+                                     struct _Py_ext_module_loader_info *p_info)
 {
-    PyObject *name_unicode = NULL, *name = NULL, *path = NULL;
-    const char *hook_prefix;
+    struct _Py_ext_module_loader_info info = {0};
 
-    name_unicode = PyObject_GetAttrString(spec, "name");
-    if (name_unicode == NULL) {
+    info.name = PyObject_GetAttrString(spec, "name");
+    if (info.name == NULL) {
         return -1;
     }
-    if (!PyUnicode_Check(name_unicode)) {
+    if (!PyUnicode_Check(info.name)) {
         PyErr_SetString(PyExc_TypeError,
                         "spec.name must be a string");
-        Py_DECREF(name_unicode);
+        _Py_ext_module_loader_info_clear(&info);
         return -1;
     }
 
-    name = get_encoded_name(name_unicode, &hook_prefix);
-    if (name == NULL) {
-        Py_DECREF(name_unicode);
+    info.name_encoded = get_encoded_name(info.name, &info.hook_prefix);
+    if (info.name_encoded == NULL) {
+        _Py_ext_module_loader_info_clear(&info);
         return -1;
     }
 
-    path = PyObject_GetAttrString(spec, "origin");
-    if (path == NULL) {
-        Py_DECREF(name_unicode);
-        Py_DECREF(name);
+    info.path = PyObject_GetAttrString(spec, "origin");
+    if (info.path == NULL) {
+        _Py_ext_module_loader_info_clear(&info);
         return -1;
     }
 
-    *info = (struct _Py_ext_module_loader_info){
-        .path=path,
-        .name=name_unicode,
-        .name_encoded=name,
-        .hook_prefix=hook_prefix,
-    };
+#ifndef MS_WINDOWS
+    info.path_encoded = PyUnicode_EncodeFSDefault(info.path);
+    if (info.path_encoded == NULL) {
+        _Py_ext_module_loader_info_clear(&info);
+        return -1;
+    }
+#endif
+
+    *p_info = info;
     return 0;
 }
 
@@ -145,10 +149,6 @@ PyObject *
 _PyImport_LoadDynamicModuleWithSpec(struct _Py_ext_module_loader_info *info,
                                     PyObject *spec, FILE *fp)
 {
-#ifndef MS_WINDOWS
-    PyObject *pathbytes = NULL;
-    const char *path_buf;
-#endif
     PyObject *m = NULL;
     const char *name_buf = PyBytes_AS_STRING(info->name_encoded);
     const char *oldcontext, *newcontext;
@@ -165,14 +165,11 @@ _PyImport_LoadDynamicModuleWithSpec(struct _Py_ext_module_loader_info *info,
     exportfunc = _PyImport_FindSharedFuncptrWindows(
             info->hook_prefix, name_buf, info->path, fp);
 #else
-    pathbytes = PyUnicode_EncodeFSDefault(info->path);
-    if (pathbytes == NULL) {
-        goto error;
+    {
+        const char *path_buf = PyBytes_AS_STRING(info->path_encoded);
+        exportfunc = _PyImport_FindSharedFuncptr(
+                        info->hook_prefix, name_buf, path_buf, fp);
     }
-    path_buf = PyBytes_AS_STRING(pathbytes);
-    exportfunc = _PyImport_FindSharedFuncptr(
-            info->hook_prefix, name_buf, path_buf, fp);
-    Py_DECREF(pathbytes);
 #endif
 
     if (exportfunc == NULL) {


### PR DESCRIPTION
I've pulled this out of https://github.com/python/cpython/pull/118116.

This helps with a later change that splits up `_PyImport_LoadDynamicModuleWithSpec()`.

<!-- gh-issue-number: gh-117953 -->
* Issue: gh-117953
<!-- /gh-issue-number -->
