### PR TITLE
gh-117953: Split Up _PyImport_LoadDynamicModuleWithSpec()

### DIFF
--- a/Include/internal/pycore_import.h
+++ b/Include/internal/pycore_import.h
@@ -29,9 +29,6 @@ extern int _PyImport_FixupBuiltin(
     const char *name,            /* UTF-8 encoded string */
     PyObject *modules
     );
-// We could probably drop this:
-extern int _PyImport_FixupExtensionObject(PyObject*, PyObject *,
-                                          PyObject *, PyObject *);
 
 // Export for many shared extensions, like '_json'
 PyAPI_FUNC(PyObject*) _PyImport_GetModuleAttr(PyObject *, PyObject *);
@@ -55,7 +52,7 @@ struct _import_runtime_state {
            Only legacy (single-phase init) extension modules are added
            and only if they support multiple initialization (m_size >- 0)
            or are imported in the main interpreter.
-           This is initialized lazily in _PyImport_FixupExtensionObject().
+           This is initialized lazily in fix_up_extension() in import.c.
            Modules are added there and looked up in _imp.find_extension(). */
         _Py_hashtable_t *hashtable;
     } extensions;

--- a/Include/internal/pycore_importdl.h
+++ b/Include/internal/pycore_importdl.h
@@ -40,6 +40,15 @@ extern int _Py_ext_module_loader_info_init_from_spec(
     struct _Py_ext_module_loader_info *info,
     PyObject *spec);
 
+struct _Py_ext_module_loader_result {
+    PyModuleDef *def;
+    PyObject *module;
+};
+extern int _PyImport_RunDynamicModule(
+    struct _Py_ext_module_loader_info *info,
+    FILE *fp,
+    struct _Py_ext_module_loader_result *res);
+
 extern PyObject *_PyImport_LoadDynamicModuleWithSpec(
     struct _Py_ext_module_loader_info *info,
     PyObject *spec,

--- a/Include/internal/pycore_importdl.h
+++ b/Include/internal/pycore_importdl.h
@@ -44,10 +44,13 @@ struct _Py_ext_module_loader_result {
     PyModuleDef *def;
     PyObject *module;
 };
-extern int _PyImport_RunDynamicModule(
+extern PyModInitFunction _PyImport_GetModInitFunc(
     struct _Py_ext_module_loader_info *info,
-    FILE *fp,
-    struct _Py_ext_module_loader_result *res);
+    FILE *fp);
+extern int _PyImport_RunModInitFunc(
+    PyModInitFunction p0,
+    struct _Py_ext_module_loader_info *info,
+    struct _Py_ext_module_loader_result *p_res);
 
 
 /* Max length of module suffix searched for -- accommodates "module.slb" */

--- a/Include/internal/pycore_importdl.h
+++ b/Include/internal/pycore_importdl.h
@@ -49,11 +49,6 @@ extern int _PyImport_RunDynamicModule(
     FILE *fp,
     struct _Py_ext_module_loader_result *res);
 
-extern PyObject *_PyImport_LoadDynamicModuleWithSpec(
-    struct _Py_ext_module_loader_info *info,
-    PyObject *spec,
-    FILE *fp);
-
 
 /* Max length of module suffix searched for -- accommodates "module.slb" */
 #define MAXSUFFIXSIZE 12

--- a/Include/moduleobject.h
+++ b/Include/moduleobject.h
@@ -53,7 +53,7 @@ typedef struct PyModuleDef_Base {
   /* A copy of the module's __dict__ after the first time it was loaded.
      This is only set/used for legacy modules that do not support
      multiple initializations.
-     It is set by _PyImport_FixupExtensionObject(). */
+     It is set by fix_up_extension() in import.c. */
   PyObject* m_copy;
 } PyModuleDef_Base;
 

--- a/Python/import.c
+++ b/Python/import.c
@@ -3955,11 +3955,6 @@ _imp_create_dynamic_impl(PyObject *module, PyObject *spec, PyObject *file)
             goto finally;
         }
 
-        /* Remember the filename as the __file__ attribute */
-        if (PyModule_AddObjectRef(mod, "__file__", info.filename) < 0) {
-            PyErr_Clear(); /* Not important enough to report */
-        }
-
         PyObject *modules = get_modules_dict(tstate, true);
         if (_PyImport_FixupExtensionObject(
                 mod, info.name, info.filename, modules) < 0)

--- a/Python/import.c
+++ b/Python/import.c
@@ -3934,7 +3934,6 @@ _imp_create_dynamic_impl(PyObject *module, PyObject *spec, PyObject *file)
         assert(is_singlephase(def));
         assert(!is_core_module(tstate->interp, info.name, info.filename));
         assert(!is_core_module(tstate->interp, info.name, info.name));
-        mod = Py_NewRef(mod);
 
         const char *name_buf = PyBytes_AS_STRING(info.name_encoded);
         if (_PyImport_CheckSubinterpIncompatibleExtensionAllowed(name_buf) < 0) {

--- a/Python/import.c
+++ b/Python/import.c
@@ -1431,6 +1431,90 @@ clear_singlephase_extension(PyInterpreterState *interp,
     return 0;
 }
 
+static PyObject *
+create_dynamic(PyThreadState *tstate, struct _Py_ext_module_loader_info *info,
+               PyObject *file, PyObject *spec)
+{
+    PyObject *mod = NULL;
+
+    /* We would move this (and the fclose() below) into
+     * _PyImport_GetModInitFunc(), but it isn't clear if the intervening
+     * code relies on fp still being open. */
+    FILE *fp;
+    if (file != NULL) {
+        fp = _Py_fopen_obj(info->filename, "r");
+        if (fp == NULL) {
+            goto finally;
+        }
+    }
+    else {
+        fp = NULL;
+    }
+
+    PyModInitFunction p0 = _PyImport_GetModInitFunc(info, fp);
+    if (p0 == NULL) {
+        goto finally;
+    }
+
+    struct _Py_ext_module_loader_result res;
+    if (_PyImport_RunModInitFunc(p0, info, &res) < 0) {
+        assert(PyErr_Occurred());
+        goto finally;
+    }
+
+    if (res.module == NULL) {
+        //assert(!is_singlephase(res.def));
+        mod = PyModule_FromDefAndSpec(res.def, spec);
+    }
+    else {
+        assert(is_singlephase(res.def));
+        assert(!is_core_module(tstate->interp, info->name, info->filename));
+        assert(!is_core_module(tstate->interp, info->name, info->name));
+        mod = Py_NewRef(res.module);
+
+        const char *name_buf = PyBytes_AS_STRING(info->name_encoded);
+        if (_PyImport_CheckSubinterpIncompatibleExtensionAllowed(name_buf) < 0) {
+            Py_CLEAR(mod);
+            goto finally;
+        }
+
+        /* Remember the filename as the __file__ attribute */
+        if (PyModule_AddObjectRef(mod, "__file__", info->filename) < 0) {
+            PyErr_Clear(); /* Not important enough to report */
+        }
+
+        struct singlephase_global_update singlephase = {0};
+        // gh-88216: Extensions and def->m_base.m_copy can be updated
+        // when the extension module doesn't support sub-interpreters.
+        if (res.def->m_size == -1) {
+            singlephase.m_dict = PyModule_GetDict(mod);
+            assert(singlephase.m_dict != NULL);
+        }
+        if (update_global_state_for_extension(
+                tstate, info->filename, info->name, res.def, &singlephase) < 0)
+        {
+            Py_CLEAR(mod);
+            goto finally;
+        }
+
+        PyObject *modules = get_modules_dict(tstate, true);
+        if (finish_singlephase_extension(
+                tstate, mod, res.def, info->name, modules) < 0)
+        {
+            Py_CLEAR(mod);
+            goto finally;
+        }
+    }
+
+    // XXX Shouldn't this happen in the error cases too.
+    if (fp) {
+        fclose(fp);
+    }
+
+finally:
+    return mod;
+}
+
 
 /*******************/
 /* builtin modules */
@@ -3921,62 +4005,10 @@ _imp_create_dynamic_impl(PyObject *module, PyObject *spec, PyObject *file)
         goto finally;
     }
 
-    /* We would move this (and the fclose() below) into
-     * _PyImport_GetModInitFunc(), but it isn't clear if the intervening
-     * code relies on fp still being open. */
-    FILE *fp;
-    if (file != NULL) {
-        fp = _Py_fopen_obj(info.filename, "r");
-        if (fp == NULL) {
-            goto finally;
-        }
-    }
-    else {
-        fp = NULL;
-    }
-
-    PyModInitFunction p0 = _PyImport_GetModInitFunc(&info, fp);
-    if (p0 == NULL) {
+    /* Is multi-phase init or this is the first time being loaded. */
+    mod = create_dynamic(tstate, &info, file, spec);
+    if (mod == NULL) {
         goto finally;
-    }
-
-    struct _Py_ext_module_loader_result res;
-    if (_PyImport_RunModInitFunc(p0, &info, &res) < 0) {
-        assert(PyErr_Occurred());
-        return NULL;
-    }
-
-    if (res.module == NULL) {
-        //assert(!is_singlephase(res.def));
-        mod = PyModule_FromDefAndSpec(res.def, spec);
-    }
-    else {
-        assert(is_singlephase(res.def));
-        mod = Py_NewRef(res.module);
-
-        const char *name_buf = PyBytes_AS_STRING(info.name_encoded);
-        if (_PyImport_CheckSubinterpIncompatibleExtensionAllowed(name_buf) < 0) {
-            Py_CLEAR(mod);
-            goto finally;
-        }
-
-        /* Remember the filename as the __file__ attribute */
-        if (PyModule_AddObjectRef(mod, "__file__", info.filename) < 0) {
-            PyErr_Clear(); /* Not important enough to report */
-        }
-
-        PyObject *modules = get_modules_dict(tstate, true);
-        if (_PyImport_FixupExtensionObject(
-                mod, info.name, info.filename, modules) < 0)
-        {
-            Py_CLEAR(mod);
-            goto finally;
-        }
-    }
-
-    // XXX Shouldn't this happen in the error cases too.
-    if (fp) {
-        fclose(fp);
     }
 
 finally:

--- a/Python/import.c
+++ b/Python/import.c
@@ -3942,6 +3942,9 @@ _imp_create_dynamic_impl(PyObject *module, PyObject *spec, PyObject *file)
             goto finally;
         }
 
+        /* Remember pointer to module init function. */
+        res.def->m_base.m_init = p0;
+
         /* Remember the filename as the __file__ attribute */
         if (PyModule_AddObjectRef(mod, "__file__", info.filename) < 0) {
             PyErr_Clear(); /* Not important enough to report */

--- a/Python/importdl.c
+++ b/Python/importdl.c
@@ -278,6 +278,7 @@ _PyImport_RunModInitFunc(PyModInitFunction p0,
 
         res.def = PyModule_GetDef(m);
         if (res.def == NULL) {
+            PyErr_Clear();
             PyErr_Format(PyExc_SystemError,
                          "initialization of %s did not return an extension "
                          "module", name_buf);
@@ -288,10 +289,12 @@ _PyImport_RunModInitFunc(PyModInitFunction p0,
         res.def->m_base.m_init = p0;
     }
 
+    assert(!PyErr_Occurred());
     *p_res = res;
     return 0;
 
 error:
+    assert(PyErr_Occurred());
     Py_CLEAR(res.module);
     res.def = NULL;
     *p_res = res;

--- a/Python/importdl.c
+++ b/Python/importdl.c
@@ -175,23 +175,12 @@ _Py_ext_module_loader_info_init_from_spec(
 }
 
 
-int
-_PyImport_RunDynamicModule(struct _Py_ext_module_loader_info *info,
-                           FILE *fp,
-                           struct _Py_ext_module_loader_result *res)
+static PyModInitFunction
+_PyImport_GetModInitFunc(struct _Py_ext_module_loader_info *info,
+                         FILE *fp)
 {
-    PyObject *m = NULL;
     const char *name_buf = PyBytes_AS_STRING(info->name_encoded);
-    const char *oldcontext, *newcontext;
     dl_funcptr exportfunc;
-    PyModInitFunction p0;
-    PyModuleDef *def;
-
-    newcontext = PyUnicode_AsUTF8(info->name);
-    if (newcontext == NULL) {
-        return -1;
-    }
-
 #ifdef MS_WINDOWS
     exportfunc = _PyImport_FindSharedFuncptrWindows(
             info->hook_prefix, name_buf, info->filename, fp);
@@ -215,14 +204,25 @@ _PyImport_RunDynamicModule(struct _Py_ext_module_loader_info *info,
                 Py_DECREF(msg);
             }
         }
-        return -1;
+        return NULL;
     }
 
-    p0 = (PyModInitFunction)exportfunc;
+    return (PyModInitFunction)exportfunc;
+}
+
+static int
+_PyImport_RunModInitFunc(PyModInitFunction p0,
+                         struct _Py_ext_module_loader_info *info,
+                         struct _Py_ext_module_loader_result *p_res)
+{
+    struct _Py_ext_module_loader_result res = {
+        .singlephase=-1,
+    };
+    const char *name_buf = PyBytes_AS_STRING(info->name_encoded);
 
     /* Package context is needed for single-phase init */
-    oldcontext = _PyImport_SwapPackageContext(info->newcontext);
-    m = p0();
+    const char *oldcontext = _PyImport_SwapPackageContext(info->newcontext);
+    PyObject *m = p0();
     _PyImport_SwapPackageContext(oldcontext);
 
     if (m == NULL) {
@@ -232,15 +232,19 @@ _PyImport_RunDynamicModule(struct _Py_ext_module_loader_info *info,
                 "initialization of %s failed without raising an exception",
                 name_buf);
         }
-        return -1;
+        goto error;
     } else if (PyErr_Occurred()) {
         _PyErr_FormatFromCause(
             PyExc_SystemError,
             "initialization of %s raised unreported exception",
             name_buf);
+        /* We would probably be correct to decref m here,
+         * but we weren't doing so before,
+         * so we stick with doing nothing. */
         m = NULL;
-        return -1;
+        goto error;
     }
+
     if (Py_IS_TYPE(m, NULL)) {
         /* This can happen when a PyModuleDef is returned without calling
          * PyModuleDef_Init on it
@@ -248,14 +252,16 @@ _PyImport_RunDynamicModule(struct _Py_ext_module_loader_info *info,
         PyErr_Format(PyExc_SystemError,
                      "init function of %s returned uninitialized object",
                      name_buf);
+        /* Likewise, decref'ing here makes sense.  However, the original
+         * code has a note about "prevent segfault in DECREF",
+         * so we play it safe and leave it alone. */
         m = NULL; /* prevent segfault in DECREF */
-        return -1;
+        goto error;
     }
 
     if (PyObject_TypeCheck(m, &PyModuleDef_Type)) {
         /* multi-phase init */
-        def = (PyModuleDef *)m;
-        m = NULL;
+        res.def = (PyModuleDef *)m;
         /* Run PyModule_FromDefAndSpec() to finish loading the module. */
     }
     else if (info->hook_prefix == nonascii_prefix) {
@@ -270,26 +276,54 @@ _PyImport_RunDynamicModule(struct _Py_ext_module_loader_info *info,
     }
     else {
         /* single-phase init (legacy) */
+        res.module = m;
 
-        def = PyModule_GetDef(m);
-        if (def == NULL) {
+        res.def = PyModule_GetDef(m);
+        if (res.def == NULL) {
             PyErr_Format(PyExc_SystemError,
                          "initialization of %s did not return an extension "
                          "module", name_buf);
-            Py_DECREF(m);
-            return -1;
+            goto error;
         }
 
         /* Remember pointer to module init function. */
-        def->m_base.m_init = p0;
+        res.def->m_base.m_init = p0;
+    }
+
+    *p_res = res;
+    return 0;
+
+error:
+    Py_CLEAR(res.module);
+    res.def = NULL;
+    *p_res = res;
+    return -1;
+}
+
+int
+_PyImport_RunDynamicModule(struct _Py_ext_module_loader_info *info,
+                           FILE *fp,
+                           struct _Py_ext_module_loader_result *res)
+{
+    PyModInitFunction p0 = _PyImport_GetModInitFunc(info, fp);
+    if (p0 == NULL) {
+        return -1;
+    }
+
+    if (_PyImport_RunModInitFunc(p0, info, res) < 0) {
+        return -1;
+    }
+
+    if (res->module != NULL) {
+        /* Remember the filename as the __file__ attribute */
+        if (PyModule_AddObjectRef(res->module, "__file__", info->filename) < 0) {
+            PyErr_Clear(); /* Not important enough to report */
+        }
 
         /* Run _PyImport_FixupExtensionObject() to finish loading the module. */
     }
+    /* else: Run PyModule_FromDefAndSpec() to finish loading the module. */
 
-    *res = (struct _Py_ext_module_loader_result){
-        .def=def,
-        .module=m,
-    };
     return 0;
 }
 

--- a/Python/importdl.c
+++ b/Python/importdl.c
@@ -175,7 +175,7 @@ _Py_ext_module_loader_info_init_from_spec(
 }
 
 
-static PyModInitFunction
+PyModInitFunction
 _PyImport_GetModInitFunc(struct _Py_ext_module_loader_info *info,
                          FILE *fp)
 {
@@ -210,14 +210,12 @@ _PyImport_GetModInitFunc(struct _Py_ext_module_loader_info *info,
     return (PyModInitFunction)exportfunc;
 }
 
-static int
+int
 _PyImport_RunModInitFunc(PyModInitFunction p0,
                          struct _Py_ext_module_loader_info *info,
                          struct _Py_ext_module_loader_result *p_res)
 {
-    struct _Py_ext_module_loader_result res = {
-        .singlephase=-1,
-    };
+    struct _Py_ext_module_loader_result res = {0};
     const char *name_buf = PyBytes_AS_STRING(info->name_encoded);
 
     /* Package context is needed for single-phase init */
@@ -298,33 +296,6 @@ error:
     res.def = NULL;
     *p_res = res;
     return -1;
-}
-
-int
-_PyImport_RunDynamicModule(struct _Py_ext_module_loader_info *info,
-                           FILE *fp,
-                           struct _Py_ext_module_loader_result *res)
-{
-    PyModInitFunction p0 = _PyImport_GetModInitFunc(info, fp);
-    if (p0 == NULL) {
-        return -1;
-    }
-
-    if (_PyImport_RunModInitFunc(p0, info, res) < 0) {
-        return -1;
-    }
-
-    if (res->module != NULL) {
-        /* Remember the filename as the __file__ attribute */
-        if (PyModule_AddObjectRef(res->module, "__file__", info->filename) < 0) {
-            PyErr_Clear(); /* Not important enough to report */
-        }
-
-        /* Run _PyImport_FixupExtensionObject() to finish loading the module. */
-    }
-    /* else: Run PyModule_FromDefAndSpec() to finish loading the module. */
-
-    return 0;
 }
 
 #endif /* HAVE_DYNAMIC_LOADING */

--- a/Python/importdl.c
+++ b/Python/importdl.c
@@ -218,10 +218,14 @@ _PyImport_RunModInitFunc(PyModInitFunction p0,
     struct _Py_ext_module_loader_result res = {0};
     const char *name_buf = PyBytes_AS_STRING(info->name_encoded);
 
+    /* Call the module init function. */
+
     /* Package context is needed for single-phase init */
     const char *oldcontext = _PyImport_SwapPackageContext(info->newcontext);
     PyObject *m = p0();
     _PyImport_SwapPackageContext(oldcontext);
+
+    /* Validate the result (and populate "res". */
 
     if (m == NULL) {
         if (!PyErr_Occurred()) {
@@ -284,9 +288,6 @@ _PyImport_RunModInitFunc(PyModInitFunction p0,
                          "module", name_buf);
             goto error;
         }
-
-        /* Remember pointer to module init function. */
-        res.def->m_base.m_init = p0;
     }
 
     assert(!PyErr_Occurred());


### PR DESCRIPTION
I've pulled this out of https://github.com/python/cpython/pull/118116.

Basically, I've turned most of `_PyImport_LoadDynamicModuleWithSpec()` into two new functions (`_PyImport_GetModInitFunc()` and `_PyImport_RunModInitFunc()`) and moved the rest of it out into `_imp_create_dynamic_impl()`.  There shouldn't be any changes in behavior.

This change makes some future changes simpler.  This is particularly relevant to potentially calling each module init function in the main interpreter first.  Thus the critical part of the PR is the addition of `_PyImport_RunModInitFunc()`, which is strictly focused on running the init func and validating the result.  A later PR will take it a step farther by capturing error information rather than raising exceptions.

FWIW, this change also helps readers by clarifying a bit more about what happens when an extension/builtin module is imported.

<!-- gh-issue-number: gh-117953 -->
* Issue: gh-117953
<!-- /gh-issue-number -->
