### PR TITLE
gh-118207: Rename the COMMON_FIELDS macro in funcobject.h and undef it after use

### DIFF
--- a/Include/cpython/funcobject.h
+++ b/Include/cpython/funcobject.h
@@ -60,6 +60,8 @@ typedef struct {
      */
 } PyFunctionObject;
 
+#undef COMMON_FIELDS
+
 PyAPI_DATA(PyTypeObject) PyFunction_Type;
 
 #define PyFunction_Check(op) Py_IS_TYPE((op), &PyFunction_Type)

--- a/Include/cpython/funcobject.h
+++ b/Include/cpython/funcobject.h
@@ -8,7 +8,7 @@ extern "C" {
 #endif
 
 
-#define COMMON_FIELDS(PREFIX) \
+#define _Py_COMMON_FIELDS(PREFIX) \
     PyObject *PREFIX ## globals; \
     PyObject *PREFIX ## builtins; \
     PyObject *PREFIX ## name; \
@@ -19,7 +19,7 @@ extern "C" {
     PyObject *PREFIX ## closure;     /* NULL or a tuple of cell objects */
 
 typedef struct {
-    COMMON_FIELDS(fc_)
+    _Py_COMMON_FIELDS(fc_)
 } PyFrameConstructor;
 
 /* Function objects and code objects should not be confused with each other:
@@ -35,7 +35,7 @@ typedef struct {
 
 typedef struct {
     PyObject_HEAD
-    COMMON_FIELDS(func_)
+    _Py_COMMON_FIELDS(func_)
     PyObject *func_doc;         /* The __doc__ attribute, can be anything */
     PyObject *func_dict;        /* The __dict__ attribute, a dict or NULL */
     PyObject *func_weakreflist; /* List of weak references */
@@ -60,7 +60,7 @@ typedef struct {
      */
 } PyFunctionObject;
 
-#undef COMMON_FIELDS
+#undef _Py_COMMON_FIELDS
 
 PyAPI_DATA(PyTypeObject) PyFunction_Type;
 


### PR DESCRIPTION


<!-- gh-issue-number: gh-118207 -->
* Issue: gh-118207
<!-- /gh-issue-number -->
