### PR TITLE
gh-118209: Add structured exception handling to mmap module

### DIFF
--- a/Doc/whatsnew/3.13.rst
+++ b/Doc/whatsnew/3.13.rst
@@ -568,6 +568,9 @@ mmap
 * :class:`mmap.mmap` now has a *trackfd* parameter on Unix; if it is ``False``,
   the file descriptor specified by *fileno* will not be duplicated.
   (Contributed by Zackery Spytz and Petr Viktorin in :gh:`78502`.)
+:class:`mmap.mmap` is now protected from crashing on Windows when the mapped memory
+  is inaccessible due to file system errors or access violations.
+  (Contributed by Jannis Weigend in :gh:`118209`.)
 
 opcode
 ------

--- a/Doc/whatsnew/3.13.rst
+++ b/Doc/whatsnew/3.13.rst
@@ -568,7 +568,7 @@ mmap
 * :class:`mmap.mmap` now has a *trackfd* parameter on Unix; if it is ``False``,
   the file descriptor specified by *fileno* will not be duplicated.
   (Contributed by Zackery Spytz and Petr Viktorin in :gh:`78502`.)
-:class:`mmap.mmap` is now protected from crashing on Windows when the mapped memory
+* :class:`mmap.mmap` is now protected from crashing on Windows when the mapped memory
   is inaccessible due to file system errors or access violations.
   (Contributed by Jannis Weigend in :gh:`118209`.)
 

--- a/Lib/test/test_mmap.py
+++ b/Lib/test/test_mmap.py
@@ -1141,8 +1141,6 @@ class MmapTests(unittest.TestCase):
             import os
             from contextlib import suppress
 
-            if os.path.exists(TESTFN):
-                os.unlink(TESTFN)
 
             PAGESIZE = mmap.PAGESIZE
             PAGE_NOACCESS = 0x01

--- a/Lib/test/test_mmap.py
+++ b/Lib/test/test_mmap.py
@@ -1113,8 +1113,8 @@ class MmapTests(unittest.TestCase):
                     list(m)  # test mmap_item
         """)
         rt, stdout, stderr = assert_python_ok("-c", code)
-        self.assertEqual(stdout.rstrip(), b'')
-        self.assertEqual(stderr.rstrip(), b'')
+        self.assertEqual(stdout.strip(), b'')
+        self.assertEqual(stderr.strip(), b'')
 
     @unittest.skipUnless(os.name == 'nt', 'requires Windows')
     @unittest.skipUnless(hasattr(mmap.mmap, '_protect'), 'test needs debug build')

--- a/Lib/test/test_mmap.py
+++ b/Lib/test/test_mmap.py
@@ -1088,30 +1088,43 @@ class MmapTests(unittest.TestCase):
                 m._protect(PAGE_NOACCESS, 0, PAGESIZE)
                 with suppress(OSError):
                     m.read(PAGESIZE)
+                    assert False, 'mmap.read() did not raise'
                 with suppress(OSError):
                     m.read_byte()
+                    assert False, 'mmap.read_byte() did not raise'
                 with suppress(OSError):
                     m.readline()
+                    assert False, 'mmap.readline() did not raise'
                 with suppress(OSError):
                     m.write(b'A'* PAGESIZE)
+                    assert False, 'mmap.write() did not raise'
                 with suppress(OSError):
                     m.write_byte(0)
+                    assert False, 'mmap.write_byte() did not raise'
                 with suppress(OSError):
                     m[0]  # test mmap_subscript
+                    assert False, 'mmap.__getitem__() did not raise'
                 with suppress(OSError):
                     m[0:10]  # test mmap_subscript
+                    assert False, 'mmap.__getitem__() did not raise'
                 with suppress(OSError):
                     m[0:10:2]  # test mmap_subscript
+                    assert False, 'mmap.__getitem__() did not raise'
                 with suppress(OSError):
                     m[0] = 1
+                    assert False, 'mmap.__setitem__() did not raise'
                 with suppress(OSError):
                     m[0:10] = b'A'* 10
+                    assert False, 'mmap.__setitem__() did not raise'
                 with suppress(OSError):
                     m[0:10:2] = b'A'* 5
+                    assert False, 'mmap.__setitem__() did not raise'
                 with suppress(OSError):
                     m.move(0, 10, 1)
+                    assert False, 'mmap.move() did not raise'
                 with suppress(OSError):
                     list(m)  # test mmap_item
+                    assert False, 'mmap.__getitem__() did not raise'
         """)
         rt, stdout, stderr = assert_python_ok("-c", code)
         self.assertEqual(stdout.strip(), b'')
@@ -1142,6 +1155,7 @@ class MmapTests(unittest.TestCase):
                 m._protect(PAGE_NOACCESS, 0, PAGESIZE)
                 with suppress(OSError):
                     m.find(b'A')
+                    assert False, 'mmap.find() did not raise'
         """)
         assert_python_ok("-c", code)
 

--- a/Lib/test/test_mmap.py
+++ b/Lib/test/test_mmap.py
@@ -1066,9 +1066,12 @@ class MmapTests(unittest.TestCase):
     
         code = textwrap.dedent("""
             from test.support.os_helper import TESTFN
+            import faulthandler
             import mmap
             import os
             from contextlib import suppress
+
+            faulthandler.disable()
 
             if os.path.exists(TESTFN):
                 os.unlink(TESTFN)
@@ -1109,9 +1112,9 @@ class MmapTests(unittest.TestCase):
                 with suppress(OSError):
                     list(m)  # test mmap_item
         """)
-        # stderr includes "Windows fatal exception: access violation" logs,
-        # even when the access violations are correctly transformed into exceptions
-        assert_python_ok("-c", code)
+        rt, stdout, stderr = assert_python_ok("-c", code)
+        self.assertEqual(stdout.rstrip(), b'')
+        self.assertEqual(stderr.rstrip(), b'')
 
     @unittest.skipUnless(os.name == 'nt', 'requires Windows')
     @unittest.skipUnless(hasattr(mmap.mmap, '_protect'), 'test needs debug build')

--- a/Lib/test/test_mmap.py
+++ b/Lib/test/test_mmap.py
@@ -1071,6 +1071,7 @@ class MmapTests(unittest.TestCase):
             import os
             from contextlib import suppress
 
+            # Prevent logging access violations to stderr.
             faulthandler.disable()
 
             if os.path.exists(TESTFN):

--- a/Lib/test/test_mmap.py
+++ b/Lib/test/test_mmap.py
@@ -1063,7 +1063,7 @@ class MmapTests(unittest.TestCase):
     @unittest.skipUnless(os.name == 'nt', 'requires Windows')
     @unittest.skipUnless(hasattr(mmap.mmap, '_protect'), 'test needs debug build')
     def test_access_violations(self):
-    
+
         code = textwrap.dedent("""
             from test.support.os_helper import TESTFN
             import faulthandler
@@ -1120,7 +1120,7 @@ class MmapTests(unittest.TestCase):
     @unittest.skipUnless(hasattr(mmap.mmap, '_protect'), 'test needs debug build')
     @unittest.expectedFailure
     def test_access_violations_fail(self):
-    
+
         code = textwrap.dedent("""
             from test.support.os_helper import TESTFN
             import mmap

--- a/Lib/test/test_mmap.py
+++ b/Lib/test/test_mmap.py
@@ -1059,6 +1059,7 @@ class MmapTests(unittest.TestCase):
                     m.write_byte(X())
 
     @unittest.skipUnless(os.name == 'nt', 'requires Windows')
+    @unittest.skipUnless(hasattr(mmap.mmap, '_protect'), 'test needs debug build')
     def test_access_violations(self):
         PAGE_NOACCESS = 0x01
 

--- a/Misc/NEWS.d/next/Windows/2024-04-24-05-16-32.gh-issue-118209.Ryyzlz.rst
+++ b/Misc/NEWS.d/next/Windows/2024-04-24-05-16-32.gh-issue-118209.Ryyzlz.rst
@@ -1,1 +1,1 @@
-Fix crash in :func:`mmap.read` on Windows when the underlying file operation raises errors.
+Fix crashes in :func:`mmap.read`, :func:`mmap.read_byte` and :func:`mmap.write` on Windows when the underlying file operation raises errors.

--- a/Misc/NEWS.d/next/Windows/2024-04-24-05-16-32.gh-issue-118209.Ryyzlz.rst
+++ b/Misc/NEWS.d/next/Windows/2024-04-24-05-16-32.gh-issue-118209.Ryyzlz.rst
@@ -1,1 +1,2 @@
-Fix crashes in :func:`mmap.read`, :func:`mmap.read_byte` and :func:`mmap.write` on Windows when the underlying file operation raises errors.
+Fix crashes in :func:`mmap.read`, :func:`mmap.read_byte`, :func:`mmap.write`
+and :func:`mmap.write_byte` on Windows when the underlying file operation raises errors.

--- a/Misc/NEWS.d/next/Windows/2024-04-24-05-16-32.gh-issue-118209.Ryyzlz.rst
+++ b/Misc/NEWS.d/next/Windows/2024-04-24-05-16-32.gh-issue-118209.Ryyzlz.rst
@@ -1,2 +1,12 @@
-Fix crashes in :func:`mmap.read`, :func:`mmap.read_byte`, :func:`mmap.write`
-and :func:`mmap.write_byte` on Windows when the underlying file operation raises errors.
+Fix crashes in
+
+* :func:`mmap.move`
+* :func:`mmap.read`
+* :func:`mmap.read_byte`
+* :func:`mmap.readline`
+* :func:`mmap.write`
+* :func:`mmap.write_byte`
+* :func:`mmap.__getitem__`
+* :func:`mmap.__setitem__`
+
+on Windows when the underlying file operation raises errors or an access violation occurs.

--- a/Misc/NEWS.d/next/Windows/2024-04-24-05-16-32.gh-issue-118209.Ryyzlz.rst
+++ b/Misc/NEWS.d/next/Windows/2024-04-24-05-16-32.gh-issue-118209.Ryyzlz.rst
@@ -1,0 +1,1 @@
+Fix crash in :func:`mmap.read` on Windows when the underlying file operation raises errors.

--- a/Misc/NEWS.d/next/Windows/2024-04-24-05-16-32.gh-issue-118209.Ryyzlz.rst
+++ b/Misc/NEWS.d/next/Windows/2024-04-24-05-16-32.gh-issue-118209.Ryyzlz.rst
@@ -1,12 +1,2 @@
-Fix crashes in
-
-* :func:`mmap.move`
-* :func:`mmap.read`
-* :func:`mmap.read_byte`
-* :func:`mmap.readline`
-* :func:`mmap.write`
-* :func:`mmap.write_byte`
-* :func:`mmap.__getitem__`
-* :func:`mmap.__setitem__`
-
-on Windows when the underlying file operation raises errors or an access violation occurs.
+Avoid crashing in :mod:`mmap` on Windows when the mapped memory is inaccessible
+due to file system errors or access violations.

--- a/Modules/mmapmodule.c
+++ b/Modules/mmapmodule.c
@@ -486,10 +486,15 @@ mmap_write_method(mmap_object *self,
     }
 
     CHECK_VALID_OR_RELEASE(NULL, data);
-    memcpy(&self->data[self->pos], data.buf, data.len);
-    self->pos += data.len;
-    PyBuffer_Release(&data);
-    return PyLong_FromSsize_t(data.len);
+    if (safe_memcpy(self->data + self->pos, data.buf, data.len) < 0) {
+        PyBuffer_Release(&data);
+        return NULL;
+    }
+    else {
+        self->pos += data.len;
+        PyBuffer_Release(&data);
+        return PyLong_FromSsize_t(data.len);
+    }
 }
 
 static PyObject *

--- a/Modules/mmapmodule.c
+++ b/Modules/mmapmodule.c
@@ -357,7 +357,7 @@ mmap_read_method(mmap_object *self,
     if (result == NULL) {
         return NULL;
     }
-    if (safe_memcpy(((PyBytesObject *) result)->ob_sval, self->data + self->pos, num_bytes) < 0) {
+    if (safe_memcpy(PyBytes_AS_STRING(result), self->data + self->pos, num_bytes) < 0) {
         Py_CLEAR(result);
     }
     else {

--- a/Modules/mmapmodule.c
+++ b/Modules/mmapmodule.c
@@ -303,7 +303,7 @@ mmap_read_byte_method(mmap_object *self,
         return NULL;
     }
     unsigned char dest;
-    if (safe_memcpy(dest, self->data + self->pos, 1) < 0) {
+    if (safe_memcpy(&dest, self->data + self->pos, 1) < 0) {
         return NULL;
     }
     else {

--- a/Modules/mmapmodule.c
+++ b/Modules/mmapmodule.c
@@ -319,7 +319,7 @@ mmap_read_method(mmap_object *self,
     if (num_bytes < 0 || num_bytes > remaining)
         num_bytes = remaining;
 
-    #if defined(MS_WIN32) && !defined(DONT_USE_SEH)
+#if defined(MS_WIN32) && !defined(DONT_USE_SEH)
     EXCEPTION_RECORD record;
     __try {
         result = PyBytes_FromStringAndSize(&self->data[self->pos], num_bytes);
@@ -330,10 +330,10 @@ mmap_read_method(mmap_object *self,
         PyErr_SetFromWindowsErr(code);
         result = NULL;
     }
-    #else
+#else
     result = PyBytes_FromStringAndSize(&self->data[self->pos], num_bytes);
     self->pos += num_bytes;
-    #endif
+#endif
 
     return result;
 }

--- a/Modules/mmapmodule.c
+++ b/Modules/mmapmodule.c
@@ -257,7 +257,7 @@ do {                                                                    \
 
 #if defined(MS_WIN32) && !defined(DONT_USE_SEH)
 static DWORD
-HandlePageException(EXCEPTION_POINTERS *ptrs, EXCEPTION_RECORD *record)
+filter_page_exception(EXCEPTION_POINTERS *ptrs, EXCEPTION_RECORD *record)
 {
     *record = *ptrs->ExceptionRecord;
     if (ptrs->ExceptionRecord->ExceptionCode == EXCEPTION_IN_PAGE_ERROR) {
@@ -281,7 +281,7 @@ safe_memcpy(void *restrict dest, const void *restrict src, size_t count) {
         memcpy(dest, src, count);
         return 0;
     }
-    __except (HandlePageException(GetExceptionInformation(), &record)) {
+    __except (filter_page_exception(GetExceptionInformation(), &record)) {
         NTSTATUS status = record.ExceptionInformation[2];
         ULONG code = LsaNtStatusToWinError(status);
         PyErr_SetFromWindowsErr(code);

--- a/Modules/mmapmodule.c
+++ b/Modules/mmapmodule.c
@@ -26,8 +26,6 @@
 #include "pycore_abstract.h"      // _Py_convert_optional_to_ssize_t()
 #include "pycore_bytesobject.h"   // _PyBytes_Find()
 #include "pycore_fileutils.h"     // _Py_stat_struct
-#include "pycore_global_objects.h"// _Py_SINGLETON
-#include "pycore_runtime.h"       // _PyRuntime
 
 #include <stddef.h>               // offsetof()
 #ifndef MS_WINDOWS
@@ -258,11 +256,6 @@ do {                                                                    \
 } while (0)
 #endif /* UNIX */
 
-// copied from bytesobject.c
-#define CHARACTERS _Py_SINGLETON(bytes_characters)
-#define CHARACTER(ch) \
-     ((PyBytesObject *)&(CHARACTERS[ch]));
-
 #if defined(MS_WIN32) && !defined(DONT_USE_SEH)
 static DWORD
 filter_page_exception(EXCEPTION_POINTERS *ptrs, EXCEPTION_RECORD *record)
@@ -385,10 +378,9 @@ _read_mmap_mem(mmap_object *self, char *start, size_t num_bytes) {
             return NULL;
         }
         else {
-            PyBytesObject *op = CHARACTER(dest & 255);
-            assert(_Py_IsImmortal(op));
+            PyObject *result = PyBytes_FromStringAndSize(&dest, 1);
             self->pos += 1;
-            return (PyObject *)op;
+            return result;
         }
     }
     else {
@@ -1124,9 +1116,7 @@ mmap_item(mmap_object *self, Py_ssize_t i)
         return NULL;
     }
     else {
-        PyBytesObject *op = CHARACTER(dest & 255);
-        assert(_Py_IsImmortal(op));
-        return (PyObject *)op;
+        return PyBytes_FromStringAndSize(&dest, 1);
     }
 }
 

--- a/Modules/mmapmodule.c
+++ b/Modules/mmapmodule.c
@@ -1275,7 +1275,8 @@ mmap_ass_subscript(mmap_object *self, PyObject *item, PyObject *value)
         }
         CHECK_VALID(-1);
 
-        if (safe_byte_copy(self->data + i, (char *) &v) < 0) {
+        char v_char = (char) v;
+        if (safe_byte_copy(self->data + i, &v_char) < 0) {
             return -1;
         }
         else {

--- a/Modules/mmapmodule.c
+++ b/Modules/mmapmodule.c
@@ -277,7 +277,7 @@ filter_page_exception(EXCEPTION_POINTERS *ptrs, EXCEPTION_RECORD *record)
 #endif
 
 #if defined(MS_WIN32) && !defined(DONT_USE_SEH)
-#define HANDLE_INVALID_MEM(sourcecode) \
+#define HANDLE_INVALID_MEM(sourcecode)                                     \
 do {                                                                       \
     EXCEPTION_RECORD record;                                               \
     __try {                                                                \
@@ -290,7 +290,7 @@ do {                                                                       \
             PyErr_SetFromWindowsErr(code);                                 \
         }                                                                  \
         else if (record.ExceptionCode == EXCEPTION_ACCESS_VIOLATION) {     \
-            PyErr_SetFromWindowsErr(ERROR_NOACCESS);                                 \
+            PyErr_SetFromWindowsErr(ERROR_NOACCESS);                       \
         }                                                                  \
         return -1;                                                         \
     }                                                                      \

--- a/Modules/mmapmodule.c
+++ b/Modules/mmapmodule.c
@@ -511,13 +511,17 @@ mmap_write_byte_method(mmap_object *self,
         return NULL;
 
     CHECK_VALID(NULL);
-    if (self->pos < self->size) {
-        self->data[self->pos++] = value;
-        Py_RETURN_NONE;
-    }
-    else {
+    if (self->pos >= self->size) {
         PyErr_SetString(PyExc_ValueError, "write byte out of range");
         return NULL;
+    }
+
+    if (safe_memcpy(self->data + self->pos, value, 1) < 0) {
+        return NULL;
+    }
+    else {
+        self->pos++;
+        Py_RETURN_NONE;
     }
 }
 

--- a/Modules/mmapmodule.c
+++ b/Modules/mmapmodule.c
@@ -346,7 +346,7 @@ do {                                                                            
 #endif
 
 int
-safe_memcpy(void *restrict dest, const void *restrict src, size_t count)
+safe_memcpy(void *dest, const void *src, size_t count)
 {
     HANDLE_INVALID_MEM(
         memcpy(dest, src, count);

--- a/Modules/mmapmodule.c
+++ b/Modules/mmapmodule.c
@@ -256,28 +256,31 @@ do {                                                                    \
 } while (0)
 #endif /* UNIX */
 
-#if defined(MS_WIN32) && !defined(DONT_USE_SEH)
+#if defined(MS_WINDOWS) && !defined(DONT_USE_SEH)
 static DWORD
 filter_page_exception(EXCEPTION_POINTERS *ptrs, EXCEPTION_RECORD *record)
 {
     *record = *ptrs->ExceptionRecord;
-    if (record->ExceptionCode == EXCEPTION_IN_PAGE_ERROR
-        || record->ExceptionCode == EXCEPTION_ACCESS_VIOLATION) {
+    if (record->ExceptionCode == EXCEPTION_IN_PAGE_ERROR ||
+        record->ExceptionCode == EXCEPTION_ACCESS_VIOLATION)
+    {
         return EXCEPTION_EXECUTE_HANDLER;
     }
     return EXCEPTION_CONTINUE_SEARCH;
 }
 
 static DWORD
-filter_page_exception_method(mmap_object *self, EXCEPTION_POINTERS *ptrs, EXCEPTION_RECORD *record)
+filter_page_exception_method(mmap_object *self, EXCEPTION_POINTERS *ptrs,
+                             EXCEPTION_RECORD *record)
 {
     *record = *ptrs->ExceptionRecord;
-    if (record->ExceptionCode == EXCEPTION_IN_PAGE_ERROR
-        || record->ExceptionCode == EXCEPTION_ACCESS_VIOLATION) {
+    if (record->ExceptionCode == EXCEPTION_IN_PAGE_ERROR ||
+        record->ExceptionCode == EXCEPTION_ACCESS_VIOLATION)
+    {
 
         ULONG_PTR address = record->ExceptionInformation[1];
-        if (address >= (ULONG_PTR) self->data
-            && address < (ULONG_PTR) self->data + (ULONG_PTR) self->size)
+        if (address >= (ULONG_PTR) self->data &&
+            address < (ULONG_PTR) self->data + (ULONG_PTR) self->size)
         {
             return EXCEPTION_EXECUTE_HANDLER;
         }
@@ -286,7 +289,7 @@ filter_page_exception_method(mmap_object *self, EXCEPTION_POINTERS *ptrs, EXCEPT
 }
 #endif
 
-#if defined(MS_WIN32) && !defined(DONT_USE_SEH)
+#if defined(MS_WINDOWS) && !defined(DONT_USE_SEH)
 #define HANDLE_INVALID_MEM(sourcecode)                                     \
 do {                                                                       \
     EXCEPTION_RECORD record;                                               \
@@ -294,8 +297,8 @@ do {                                                                       \
         sourcecode                                                         \
     }                                                                      \
     __except (filter_page_exception(GetExceptionInformation(), &record)) { \
-        assert(record.ExceptionCode == EXCEPTION_IN_PAGE_ERROR             \
-               || record.ExceptionCode == EXCEPTION_ACCESS_VIOLATION);     \
+        assert(record.ExceptionCode == EXCEPTION_IN_PAGE_ERROR ||          \
+               record.ExceptionCode == EXCEPTION_ACCESS_VIOLATION);        \
         if (record.ExceptionCode == EXCEPTION_IN_PAGE_ERROR) {             \
             NTSTATUS status = (NTSTATUS) record.ExceptionInformation[2];   \
             ULONG code = LsaNtStatusToWinError(status);                    \
@@ -314,7 +317,7 @@ do {                                                                       \
 } while (0)
 #endif
 
-#if defined(MS_WIN32) && !defined(DONT_USE_SEH)
+#if defined(MS_WINDOWS) && !defined(DONT_USE_SEH)
 #define HANDLE_INVALID_MEM_METHOD(self, sourcecode)                                     \
 do {                                                                                    \
     EXCEPTION_RECORD record;                                                            \
@@ -322,8 +325,8 @@ do {                                                                            
         sourcecode                                                                      \
     }                                                                                   \
     __except (filter_page_exception_method(self, GetExceptionInformation(), &record)) { \
-        assert(record.ExceptionCode == EXCEPTION_IN_PAGE_ERROR                          \
-               || record.ExceptionCode == EXCEPTION_ACCESS_VIOLATION);                  \
+        assert(record.ExceptionCode == EXCEPTION_IN_PAGE_ERROR ||                       \
+               record.ExceptionCode == EXCEPTION_ACCESS_VIOLATION);                     \
         if (record.ExceptionCode == EXCEPTION_IN_PAGE_ERROR) {                          \
             NTSTATUS status = (NTSTATUS) record.ExceptionInformation[2];                \
             ULONG code = LsaNtStatusToWinError(status);                                 \
@@ -343,7 +346,8 @@ do {                                                                            
 #endif
 
 int
-safe_memcpy(void *restrict dest, const void *restrict src, size_t count) {
+safe_memcpy(void *restrict dest, const void *restrict src, size_t count)
+{
     HANDLE_INVALID_MEM(
         memcpy(dest, src, count);
     );
@@ -351,7 +355,8 @@ safe_memcpy(void *restrict dest, const void *restrict src, size_t count) {
 }
 
 int
-safe_byte_copy(char *dest, const char *src) {
+safe_byte_copy(char *dest, const char *src)
+{
     HANDLE_INVALID_MEM(
         *dest = *src;
     );
@@ -359,7 +364,8 @@ safe_byte_copy(char *dest, const char *src) {
 }
 
 int
-safe_memchr(char **out, const void *ptr, int ch, size_t count) {
+safe_memchr(char **out, const void *ptr, int ch, size_t count)
+{
     HANDLE_INVALID_MEM(
         *out = (char *) memchr(ptr, ch, count);
     );
@@ -367,7 +373,8 @@ safe_memchr(char **out, const void *ptr, int ch, size_t count) {
 }
 
 int
-safe_memmove(void *dest, const void *src, size_t count) {
+safe_memmove(void *dest, const void *src, size_t count)
+{
     HANDLE_INVALID_MEM(
         memmove(dest, src, count);
     );
@@ -375,7 +382,9 @@ safe_memmove(void *dest, const void *src, size_t count) {
 }
 
 int
-safe_copy_from_slice(char *dest, const char *src, Py_ssize_t start, Py_ssize_t step, Py_ssize_t slicelen) {
+safe_copy_from_slice(char *dest, const char *src, Py_ssize_t start,
+                     Py_ssize_t step, Py_ssize_t slicelen)
+{
     HANDLE_INVALID_MEM(
         size_t cur;
         Py_ssize_t i;
@@ -387,7 +396,9 @@ safe_copy_from_slice(char *dest, const char *src, Py_ssize_t start, Py_ssize_t s
 }
 
 int
-safe_copy_to_slice(char *dest, const char *src, Py_ssize_t start, Py_ssize_t step, Py_ssize_t slicelen) {
+safe_copy_to_slice(char *dest, const char *src, Py_ssize_t start,
+                   Py_ssize_t step, Py_ssize_t slicelen)
+{
     HANDLE_INVALID_MEM(
         size_t cur;
         Py_ssize_t i;
@@ -401,8 +412,9 @@ safe_copy_to_slice(char *dest, const char *src, Py_ssize_t start, Py_ssize_t ste
 
 int
 _safe_PyBytes_Find(Py_ssize_t *out, mmap_object *self, const char *haystack,
-                   Py_ssize_t len_haystack, const char *needle, Py_ssize_t len_needle,
-                   Py_ssize_t offset) {
+                   Py_ssize_t len_haystack, const char *needle,
+                   Py_ssize_t len_needle, Py_ssize_t offset)
+{
     HANDLE_INVALID_MEM_METHOD(self,
         *out = _PyBytes_Find(haystack, len_haystack, needle, len_needle, offset);
     );
@@ -410,11 +422,14 @@ _safe_PyBytes_Find(Py_ssize_t *out, mmap_object *self, const char *haystack,
 }
 
 int
-_safe_PyBytes_ReverseFind(Py_ssize_t *out, mmap_object *self, const char *haystack,
-                          Py_ssize_t len_haystack, const char *needle, Py_ssize_t len_needle,
-                          Py_ssize_t offset) {
+_safe_PyBytes_ReverseFind(Py_ssize_t *out, mmap_object *self,
+                          const char *haystack, Py_ssize_t len_haystack,
+                          const char *needle, Py_ssize_t len_needle,
+                          Py_ssize_t offset)
+{
     HANDLE_INVALID_MEM_METHOD(self,
-        *out = _PyBytes_ReverseFind(haystack, len_haystack, needle, len_needle, offset);
+        *out = _PyBytes_ReverseFind(haystack, len_haystack, needle, len_needle,
+                                    offset);
     );
     return 0;
 }
@@ -505,7 +520,8 @@ mmap_read_method(mmap_object *self,
     if (num_bytes < 0 || num_bytes > remaining)
         num_bytes = remaining;
 
-    PyObject *result = _safe_PyBytes_FromStringAndSize(self->data + self->pos, num_bytes);
+    PyObject *result = _safe_PyBytes_FromStringAndSize(self->data + self->pos,
+                                                       num_bytes);
     if (result != NULL) {
         self->pos += num_bytes;
     }
@@ -551,7 +567,8 @@ mmap_gfind(mmap_object *self,
             assert(0 <= start && start <= end && end <= self->size);
             if (_safe_PyBytes_ReverseFind(&index, self,
                 self->data + start, end - start,
-                view.buf, view.len, start) < 0) {
+                view.buf, view.len, start) < 0)
+            {
                 result = NULL;
             }
             else {
@@ -562,7 +579,8 @@ mmap_gfind(mmap_object *self,
             assert(0 <= start && start <= end && end <= self->size);
             if (_safe_PyBytes_Find(&index, self,
                 self->data + start, end - start,
-                view.buf, view.len, start) < 0) {
+                view.buf, view.len, start) < 0)
+            {
                 result = NULL;
             }
             else {
@@ -1087,7 +1105,9 @@ mmap_protect_method(mmap_object *self, PyObject *args) {
         return NULL;
     }
 
-    if (VirtualProtect((void *) (self->data + start), length, flNewProtect, &flOldProtect) == 0) {
+    if (!VirtualProtect((void *) (self->data + start), length, flNewProtect,
+                        &flOldProtect))
+    {
         PyErr_SetFromWindowsErr(GetLastError());
         return NULL;
     }
@@ -1263,7 +1283,9 @@ mmap_subscript(mmap_object *self, PyObject *item)
             if (result_buf == NULL)
                 return PyErr_NoMemory();
 
-            if (safe_copy_to_slice(result_buf, self->data, start, step, slicelen) < 0) {
+            if (safe_copy_to_slice(result_buf, self->data, start, step,
+                                   slicelen) < 0)
+            {
                 result = NULL;
             }
             else {
@@ -1390,7 +1412,9 @@ mmap_ass_subscript(mmap_object *self, PyObject *item, PyObject *value)
             }
         }
         else {
-            if (safe_copy_from_slice(self->data, (char *)vbuf.buf, start, step, slicelen) < 0) {
+            if (safe_copy_from_slice(self->data, (char *)vbuf.buf, start, step,
+                                     slicelen) < 0)
+            {
                 result = -1;
             }
         }

--- a/Modules/mmapmodule.c
+++ b/Modules/mmapmodule.c
@@ -318,30 +318,31 @@ do {                                                                       \
 #endif
 
 #if defined(MS_WINDOWS) && !defined(DONT_USE_SEH)
-#define HANDLE_INVALID_MEM_METHOD(self, sourcecode)                                     \
-do {                                                                                    \
-    EXCEPTION_RECORD record;                                                            \
-    __try {                                                                             \
-        sourcecode                                                                      \
-    }                                                                                   \
-    __except (filter_page_exception_method(self, GetExceptionInformation(), &record)) { \
-        assert(record.ExceptionCode == EXCEPTION_IN_PAGE_ERROR ||                       \
-               record.ExceptionCode == EXCEPTION_ACCESS_VIOLATION);                     \
-        if (record.ExceptionCode == EXCEPTION_IN_PAGE_ERROR) {                          \
-            NTSTATUS status = (NTSTATUS) record.ExceptionInformation[2];                \
-            ULONG code = LsaNtStatusToWinError(status);                                 \
-            PyErr_SetFromWindowsErr(code);                                              \
-        }                                                                               \
-        else if (record.ExceptionCode == EXCEPTION_ACCESS_VIOLATION) {                  \
-            PyErr_SetFromWindowsErr(ERROR_NOACCESS);                                    \
-        }                                                                               \
-        return -1;                                                                      \
-    }                                                                                   \
+#define HANDLE_INVALID_MEM_METHOD(self, sourcecode)                           \
+do {                                                                          \
+    EXCEPTION_RECORD record;                                                  \
+    __try {                                                                   \
+        sourcecode                                                            \
+    }                                                                         \
+    __except (filter_page_exception_method(self, GetExceptionInformation(),   \
+                                           &record)) {                        \
+        assert(record.ExceptionCode == EXCEPTION_IN_PAGE_ERROR ||             \
+               record.ExceptionCode == EXCEPTION_ACCESS_VIOLATION);           \
+        if (record.ExceptionCode == EXCEPTION_IN_PAGE_ERROR) {                \
+            NTSTATUS status = (NTSTATUS) record.ExceptionInformation[2];      \
+            ULONG code = LsaNtStatusToWinError(status);                       \
+            PyErr_SetFromWindowsErr(code);                                    \
+        }                                                                     \
+        else if (record.ExceptionCode == EXCEPTION_ACCESS_VIOLATION) {        \
+            PyErr_SetFromWindowsErr(ERROR_NOACCESS);                          \
+        }                                                                     \
+        return -1;                                                            \
+    }                                                                         \
 } while (0)
 #else
-#define HANDLE_INVALID_MEM_METHOD(self, sourcecode)                                     \
-do {                                                                                    \
-    sourcecode                                                                          \
+#define HANDLE_INVALID_MEM_METHOD(self, sourcecode)                           \
+do {                                                                          \
+    sourcecode                                                                \
 } while (0)
 #endif
 


### PR DESCRIPTION
If `DONT_USE_SEH` is not defined, catch page errors and access violations when reading/writing the mmap pointer and convert it into a Python exception.

Methods done:
- `mmap_read_method`
- `mmap_read_byte_method`
- `mmap_read_line_method`
- `mmap_write_method`
- `mmap_write_byte_method`
- `mmap_item`
- `mmap_subscript`
- `mmap_ass_item`
- `mmap_ass_subscript`
- `mmap_move_method`
- `mmap_gfind` (hopefully I didn't miss any resource handling here)

Other comments:
- `LsaNtStatusToWinError` is equivalent to `RtlNtStatusToDosError` (see comment below). So I am using this since it's easier to call.
- one other tiny bug is fixed in `mmap_read_line_method`. Previously the file pointer would still be advanced in case of a memory allocation error.

Issues with the PR:
- other methods should be handled as well, but I want to wait on some feedback first
  - `mmap_resize_method`

I don't know how to fix:
- `mmap_buffer_getbuf`: this creates a buffer object without actually reading from memory (yet). This will cause issues when the buffer is read in other parts of the code. The only way to fix this would be make all buffer methods SEH aware also... :(

See
- https://learn.microsoft.com/en-us/windows/win32/api/memoryapi/nf-memoryapi-mapviewoffile#remarks
- https://learn.microsoft.com/en-us/windows/win32/memory/reading-and-writing-from-a-file-view
- https://learn.microsoft.com/en-us/windows/win32/api/winnt/ns-winnt-exception_record

<!-- gh-issue-number: gh-118209 -->
* Issue: gh-118209
<!-- /gh-issue-number -->
