### PR TITLE
gh-118214 Give clearer information about platform-specific variations on the locale page

### DIFF
--- a/Doc/library/locale.rst
+++ b/Doc/library/locale.rst
@@ -16,6 +16,10 @@ functionality. The POSIX locale mechanism allows programmers to deal with
 certain cultural issues in an application, without requiring the programmer to
 know all the specifics of each country where the software is executed.
 
+.. note::
+
+   Some functions and options are not available on all systems.
+
 .. index:: pair: module; _locale
 
 The :mod:`locale` module is implemented on top of the :mod:`!_locale` module,
@@ -158,14 +162,17 @@ The :mod:`locale` module defines the following exception and functions:
 
 .. function:: nl_langinfo(option)
 
-   Return some locale-specific information as a string.  This function is not
-   available on all systems, and the set of possible options might also vary
-   across platforms.  The possible argument values are numbers, for which
-   symbolic constants are available in the locale module.
+   Returns locale-specific information as a string. 
 
-   The :func:`nl_langinfo` function accepts one of the following keys.  Most
-   descriptions are taken from the corresponding description in the GNU C
-   library.
+
+.. Note::
+
+   This function is not available on all systems, and the set of possible options might also vary
+   across platforms.
+
+   *option* may be one of the following constants. 
+   Most descriptions are taken from the corresponding description in the GNU C library.
+
 
    .. data:: CODESET
 
@@ -525,7 +532,9 @@ The :mod:`locale` module defines the following exception and functions:
    system, like those returned by :func:`os.strerror` might be affected by this
    category.
 
-   This value may not be available on operating systems not conforming to the
+.. note::
+
+   This value may not be available on systems not conforming to the
    POSIX standard, most notably Windows.
 
 

--- a/Doc/library/locale.rst
+++ b/Doc/library/locale.rst
@@ -164,7 +164,6 @@ The :mod:`locale` module defines the following exception and functions:
 
    Returns locale-specific information as a string.
 
-
    .. note::
 
       This function is not available on all systems, and the set of possible options
@@ -174,7 +173,6 @@ The :mod:`locale` module defines the following exception and functions:
    *option* may be one of the following constants. Most
    descriptions are taken from the corresponding description in the GNU C
    library.
-
 
    .. data:: CODESET
 
@@ -536,7 +534,7 @@ The :mod:`locale` module defines the following exception and functions:
 
    .. note::
 
-      This value may not be available on systems not conforming to the
+      This category may not be available on systems not conforming to the
       POSIX standard, most notably Windows.
 
 

--- a/Doc/library/locale.rst
+++ b/Doc/library/locale.rst
@@ -170,6 +170,7 @@ The :mod:`locale` module defines the following exception and functions:
    This function is not available on all systems, and the set of possible options 
    also varies across systems.
 
+
    *option* may be one of the following constants. Most
    descriptions are taken from the corresponding description in the GNU C 
    library.

--- a/Doc/library/locale.rst
+++ b/Doc/library/locale.rst
@@ -162,17 +162,17 @@ The :mod:`locale` module defines the following exception and functions:
 
 .. function:: nl_langinfo(option)
 
-   Returns locale-specific information as a string. 
+   Returns locale-specific information as a string.
 
 
 .. note::
 
-   This function is not available on all systems, and the set of possible options 
-   also varies across systems.
+      This function is not available on all systems, and the set of possible options
+      also varies across systems.
 
 
    *option* may be one of the following constants. Most
-   descriptions are taken from the corresponding description in the GNU C 
+   descriptions are taken from the corresponding description in the GNU C
    library.
 
 

--- a/Doc/library/locale.rst
+++ b/Doc/library/locale.rst
@@ -165,13 +165,14 @@ The :mod:`locale` module defines the following exception and functions:
    Returns locale-specific information as a string. 
 
 
-.. Note::
+.. note::
 
-   This function is not available on all systems, and the set of possible options might also vary
-   across platforms.
+   This function is not available on all systems, and the set of possible options 
+   also varies across systems.
 
-   *option* may be one of the following constants. 
-   Most descriptions are taken from the corresponding description in the GNU C library.
+   *option* may be one of the following constants. Most
+   descriptions are taken from the corresponding description in the GNU C 
+   library.
 
 
    .. data:: CODESET

--- a/Doc/library/locale.rst
+++ b/Doc/library/locale.rst
@@ -165,7 +165,7 @@ The :mod:`locale` module defines the following exception and functions:
    Returns locale-specific information as a string.
 
 
-.. note::
+   .. note::
 
       This function is not available on all systems, and the set of possible options
       also varies across systems.
@@ -534,10 +534,10 @@ The :mod:`locale` module defines the following exception and functions:
    system, like those returned by :func:`os.strerror` might be affected by this
    category.
 
-.. note::
+   .. note::
 
-   This value may not be available on systems not conforming to the
-   POSIX standard, most notably Windows.
+      This value may not be available on systems not conforming to the
+      POSIX standard, most notably Windows.
 
 
 .. data:: LC_NUMERIC


### PR DESCRIPTION
Converted comments about platform-specific variations to notes to make them clearer. 
Cleaned up description of nl_langinfo()
Used 'systems' instead of 'operating systems' and 'platforms' in a couple of places for more consistency of terminology.




<!-- gh-issue-number: gh-118214 -->
* Issue: gh-118214
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--118217.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->