### PR TITLE
gh-118218: Reuse return tuple in itertools.pairwise

### DIFF
--- a/Lib/test/test_itertools.py
+++ b/Lib/test/test_itertools.py
@@ -1822,6 +1822,13 @@ class TestBasicOps(unittest.TestCase):
         self.assertTrue(gc.is_tracked(next(it)))
 
     @support.cpython_only
+    def test_pairwise_result_gc(self):
+        # Ditto for pairwise.
+        it = pairwise([None, None])
+        gc.collect()
+        self.assertTrue(gc.is_tracked(next(it)))
+
+    @support.cpython_only
     def test_immutable_types(self):
         from itertools import _grouper, _tee, _tee_dataobject
         dataset = (

--- a/Misc/NEWS.d/next/Library/2024-04-24-07-45-08.gh-issue-118218.m1OHbN.rst
+++ b/Misc/NEWS.d/next/Library/2024-04-24-07-45-08.gh-issue-118218.m1OHbN.rst
@@ -1,1 +1,1 @@
-Speed up :func:`itertools.pairwise` by up to 1.8x
+Speed up :func:`itertools.pairwise` in the common case by up to 1.8x.

--- a/Misc/NEWS.d/next/Library/2024-04-24-07-45-08.gh-issue-118218.m1OHbN.rst
+++ b/Misc/NEWS.d/next/Library/2024-04-24-07-45-08.gh-issue-118218.m1OHbN.rst
@@ -1,0 +1,1 @@
+Speed up :func:`itertools.pairwise` by up to 1.8x

--- a/Modules/itertoolsmodule.c
+++ b/Modules/itertoolsmodule.c
@@ -270,6 +270,7 @@ typedef struct {
     PyObject_HEAD
     PyObject *it;
     PyObject *old;
+    PyObject* result;
 } pairwiseobject;
 
 /*[clinic input]
@@ -301,6 +302,11 @@ pairwise_new_impl(PyTypeObject *type, PyObject *iterable)
     }
     po->it = it;
     po->old = NULL;
+    po->result = PyTuple_Pack(2, Py_None, Py_None);
+    if (po->result == NULL) {
+        Py_DECREF(po);
+        return NULL;
+    }
     return (PyObject *)po;
 }
 
@@ -311,6 +317,7 @@ pairwise_dealloc(pairwiseobject *po)
     PyObject_GC_UnTrack(po);
     Py_XDECREF(po->it);
     Py_XDECREF(po->old);
+    Py_XDECREF(po->result);
     tp->tp_free(po);
     Py_DECREF(tp);
 }
@@ -321,6 +328,7 @@ pairwise_traverse(pairwiseobject *po, visitproc visit, void *arg)
     Py_VISIT(Py_TYPE(po));
     Py_VISIT(po->it);
     Py_VISIT(po->old);
+    Py_VISIT(po->result);
     return 0;
 }
 
@@ -355,8 +363,30 @@ pairwise_next(pairwiseobject *po)
         Py_DECREF(old);
         return NULL;
     }
-    /* Future optimization: Reuse the result tuple as we do in enumerate() */
-    result = PyTuple_Pack(2, old, new);
+
+    result = po->result;
+    if (Py_REFCNT(result) == 1) {
+        Py_INCREF(result);
+        PyObject *last_old = PyTuple_GET_ITEM(result, 0);
+        PyObject *last_new = PyTuple_GET_ITEM(result, 1);
+        PyTuple_SET_ITEM(result, 0, Py_NewRef(old));
+        PyTuple_SET_ITEM(result, 1, Py_NewRef(new));
+        Py_DECREF(last_old);
+        Py_DECREF(last_new);
+        // bpo-42536: The GC may have untracked this result tuple. Since we're
+        // recycling it, make sure it's tracked again:
+        if (!_PyObject_GC_IS_TRACKED(result)) {
+            _PyObject_GC_TRACK(result);
+        }
+    }
+    else {
+        result = PyTuple_New(2);
+        if (result != NULL) {
+            PyTuple_SET_ITEM(result, 0, Py_NewRef(old));
+            PyTuple_SET_ITEM(result, 1, Py_NewRef(new));
+        }
+    }
+
     Py_XSETREF(po->old, new);
     Py_DECREF(old);
     return result;

--- a/Modules/itertoolsmodule.c
+++ b/Modules/itertoolsmodule.c
@@ -270,7 +270,7 @@ typedef struct {
     PyObject_HEAD
     PyObject *it;
     PyObject *old;
-    PyObject* result;
+    PyObject *result;
 } pairwiseobject;
 
 /*[clinic input]


### PR DESCRIPTION
As per the comment, this is shamelessly based off of enumobject.c

With this change:
```
b1(1)            min=152.8us mean=155.5us ± 3.8us (25 repeats, 1000 loops)
b2(1)            min=149.0us mean=159.1us ± 8.8us (25 repeats, 1000 loops)
b3(1)            min=232.6us mean=242.5us ± 11.7us (25 repeats, 1000 loops)
b1(10)           min=279.2us mean=296.9us ± 16.6us (25 repeats, 1000 loops)
b2(10)           min=249.5us mean=259.2us ± 12.2us (25 repeats, 1000 loops)
b3(10)           min=386.6us mean=398.8us ± 10.1us (25 repeats, 1000 loops)
b1(1000)         min=20.3ms mean=20.7ms ± 0.5ms (25 repeats, 1000 loops)
b2(1000)         min=16.7ms mean=17.1ms ± 0.2ms (25 repeats, 1000 loops)
b3(1000)         min=26.0ms mean=26.2ms ± 0.3ms (25 repeats, 1000 loops)
```
Without this change:
```
b1(1)            min=142.2us mean=143.0us ± 0.9us (25 repeats, 1000 loops)
b2(1)            min=142.7us mean=143.3us ± 1.0us (25 repeats, 1000 loops)
b3(1)            min=219.8us mean=227.2us ± 4.4us (25 repeats, 1000 loops)
b1(10)           min=314.2us mean=323.8us ± 4.1us (25 repeats, 1000 loops)
b2(10)           min=335.4us mean=341.8us ± 5.1us (25 repeats, 1000 loops)
b3(10)           min=362.0us mean=386.2us ± 14.9us (25 repeats, 1000 loops)
b1(1000)         min=26.5ms mean=27.3ms ± 0.3ms (25 repeats, 1000 loops)
b2(1000)         min=29.8ms mean=30.2ms ± 0.2ms (25 repeats, 1000 loops)
b3(1000)         min=26.0ms mean=26.5ms ± 0.4ms (25 repeats, 1000 loops)
```

Benchmarking script:
<details>

```python
import statistics
import time
import timeit
from itertools import pairwise

def b1(n):
    for x in pairwise(range(n)):
        pass

def b2(n):
    for a, b in pairwise(range(n)):
        pass

def b3(n):
    list(pairwise(range(n)))


def format_time(t):
    if t >= 1e9:
        return f'{t/1e9:.1f}s'
    if t >= 1e6:
        return f'{t/1e6:.1f}ms'
    if t >= 1e3:
        return f'{t/1e3:.1f}us'
    return f'{t:.1f}ns'


def format_mean_stdev(ts):
    mean = statistics.mean(ts)
    stdev = statistics.stdev(ts)
    if mean >= 1e9:
        return f'{mean/1e9:.1f}s ± {stdev/1e9:.1f}s'
    if mean >= 1e6:
        return f'{mean/1e6:.1f}ms ± {stdev/1e6:.1f}ms'
    if mean >= 1e3:
        return f'{mean/1e3:.1f}us ± {stdev/1e3:.1f}us'
    return f'{mean:.1f}ns ± {stdev:.1f}ns'


def bench(stmt):
    repeat = 25
    number = 1000
    timings = timeit.repeat(
        stmt, globals=globals(), repeat=repeat, number=number, timer=time.perf_counter_ns
    )
    print(
        f'{stmt:16} '
        f'min={format_time(min(timings))} '
        f'mean={format_mean_stdev(timings)} '
        f'({repeat} repeats, {number} loops)'
    )

bench('b1(1)')
bench('b2(1)')
bench('b3(1)')

bench('b1(10)')
bench('b2(10)')
bench('b3(10)')

bench('b1(1000)')
bench('b2(1000)')
bench('b3(1000)')

```
</details>

<!-- gh-issue-number: gh-118218 -->
* Issue: gh-118218
<!-- /gh-issue-number -->
