### PR TITLE
gh-117968: Make the test for closed file more safe in the C API tests

### DIFF
--- a/Modules/_testcapi/run.c
+++ b/Modules/_testcapi/run.c
@@ -74,8 +74,10 @@ run_fileexflags(PyObject *mod, PyObject *pos_args)
 
     result = PyRun_FileExFlags(fp, filename, start, globals, locals, closeit, pflags);
 
-#if !defined(__wasi__)
-    /* The behavior of fileno() after fclose() is undefined. */
+#if defined(__linux__) || defined(MS_WINDOWS) || defined(__APPLE__)
+    /* The behavior of fileno() after fclose() is undefined, but it is
+     * the only practical way to check whether the file was closed.
+     * Only test this on the known platforms. */
     if (closeit && result && fileno(fp) >= 0) {
         PyErr_SetString(PyExc_AssertionError, "File was not closed after excution");
         Py_DECREF(result);


### PR DESCRIPTION
The behavior of fileno() after fclose() is undefined, but it is the only practical way to check whether the file was closed. Only test this on the known platforms (Linux, Windows, macOS), where we already tested that it works.


<!-- gh-issue-number: gh-117968 -->
* Issue: gh-117968
<!-- /gh-issue-number -->
