### PR TITLE
gh-110190: Fix ctypes structs with array on SPARC

### DIFF
--- a/Misc/NEWS.d/next/Library/2024-04-24-16-23-04.gh-issue-110190.TGd5qx.rst
+++ b/Misc/NEWS.d/next/Library/2024-04-24-16-23-04.gh-issue-110190.TGd5qx.rst
@@ -1,0 +1,2 @@
+Fix ctypes structs with array on SPARC by setting ``MAX_STRUCT_SIZE`` to 32
+in stgdict. Patch by Jakub Kulik

--- a/Modules/_ctypes/stgdict.c
+++ b/Modules/_ctypes/stgdict.c
@@ -606,7 +606,7 @@ PyCStructUnionType_update_stginfo(PyObject *type, PyObject *fields, int isStruct
 /*
  * The value of MAX_STRUCT_SIZE depends on the platform Python is running on.
  */
-#if defined(__aarch64__) || defined(__arm__) || defined(_M_ARM64)
+#if defined(__aarch64__) || defined(__arm__) || defined(_M_ARM64) || defined(__sparc__)
 #  define MAX_STRUCT_SIZE 32
 #elif defined(__powerpc64__)
 #  define MAX_STRUCT_SIZE 64


### PR DESCRIPTION
Fix the same issue as PR #114753 on SPARC.


<!-- gh-issue-number: gh-110190 -->
* Issue: gh-110190
<!-- /gh-issue-number -->
