### PR TITLE
gh-118224: Load default OpenSSL provider for nonsecurity algorithms

### DIFF
--- a/Misc/NEWS.d/next/Build/2024-04-24-16-58-45.gh-issue-118224.wnjFHn.rst
+++ b/Misc/NEWS.d/next/Build/2024-04-24-16-58-45.gh-issue-118224.wnjFHn.rst
@@ -1,0 +1,1 @@
+Hashlib now supports using default OpenSSL provider instead of builtin fallback for nonsecurity hashes on hosts otherwise only using base and fips providers. This makes build configuration ``--with-builtin-hashlib-hashes=blake2`` fully supported on OpenSSL FIPS hosts.


### PR DESCRIPTION
When OpenSSL is configured to only load "base+fips" providers into the Null library context, md5 might not be available at all. In such cases currently CPython fallsback to internal hashlib implementation is there is one - as there might not be if one compiles python with --with-builtin-hashlib-hashes=blake2. With this change "default" provider is attempted to be loaded to access nonsecurity hashes.

It is FedRAMP/FIPS compliance by-pass. This issue may allow using md5 without specifying "usedforsecurity=False" on systems otherwise configured to be in FIPS-mode only. And is the primary reason why documentation mentions that certain distributions of python remove md5 module altogether.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-118224 -->
* Issue: gh-118224
<!-- /gh-issue-number -->
