### PR TITLE
gh-118235: Skip RAISE_SYNTAX_ERROR rules in the grammar spec

### DIFF
--- a/Doc/tools/extensions/peg_highlight.py
+++ b/Doc/tools/extensions/peg_highlight.py
@@ -16,6 +16,7 @@ class PEGLexer(RegexLexer):
         - Rule types
         - Rule options
         - Rules named `invalid_*` or `incorrect_*`
+        - Rules with `RAISE_SYNTAX_ERROR`
     """
 
     name = "PEG"
@@ -59,6 +60,7 @@ class PEGLexer(RegexLexer):
             (r"^(\s+\|\s+.*invalid_\w+.*\n)", bygroups(None)),
             (r"^(\s+\|\s+.*incorrect_\w+.*\n)", bygroups(None)),
             (r"^(#.*invalid syntax.*(?:.|\n)*)", bygroups(None),),
+            (r"^(\s+\|\s+.*\{[^}]*RAISE_SYNTAX_ERROR[^}]*\})\n", bygroups(None)),
         ],
         "root": [
             include("invalids"),


### PR DESCRIPTION
I'm not too comfortable with regular expressions, and this looks like piling on another hack, but this highlighter rule strips all the current `RAISE_SYNTAX_ERROR` alternatives:

A diff of the rendered page:
```diff
@@ -498,9 +498,7 @@
 
 type_param:
     | NAME [type_param_bound] 
-    | '*' NAME ':' expression 
     | '*' NAME 
-    | '**' NAME ':' expression 
     | '**' NAME 
 
 type_param_bound: ':' expression 
@@ -771,7 +769,6 @@
 for_if_clause:
     | 'async' 'for' star_targets 'in' ~ disjunction ('if' disjunction )* 
     | 'for' star_targets 'in' ~ disjunction ('if' disjunction )* 
-    | 'async'? 'for' (bitwise_or (',' bitwise_or)* [',']) !'in' 
 
 listcomp:
     | '[' named_expression for_if_clauses ']' 
@@ -802,7 +799,6 @@
 
 starred_expression:
     | '*' expression 
-    | '*' 
 
 kwarg_or_starred:
     | NAME '=' expression 
```

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-118235 -->
* Issue: gh-118235
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--118237.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->