### PR TITLE
gh-112040: Support parallel pystats collection

### DIFF
--- a/Doc/using/configure.rst
+++ b/Doc/using/configure.rst
@@ -245,9 +245,10 @@ General Options
      * :func:`!sys._stats_clear`: Clears the statistics.
      * :func:`!sys._stats_dump`: Dump statistics to file, and clears the statistics.
 
-   The statistics will be dumped to a arbitrary (probably unique) file in
-   ``/tmp/py_stats/`` (Unix) or ``C:\temp\py_stats\`` (Windows). If that
-   directory does not exist, results will be printed on stderr.
+   The statistics will be dumped to a file in the directory specifed by the
+   environment variable ``PYTHON_PYSTATS_DIR`` (or ``/tmp/py_stats/`` (Unix) or
+   ``C:\temp\py_stats\`` (Windows) if not specified). If that directory does not
+   exist, results will be printed on stderr.
 
    Use ``Tools/scripts/summarize_stats.py`` to read the stats.
 

--- a/Include/internal/pycore_pystats.h
+++ b/Include/internal/pycore_pystats.h
@@ -12,6 +12,7 @@ extern "C" {
 extern void _Py_StatsOn(void);
 extern void _Py_StatsOff(void);
 extern void _Py_StatsClear(void);
+extern int _Py_StatsSetDir(const char *dirname);
 extern int _Py_PrintSpecializationStats(int to_file);
 #endif
 

--- a/Python/initconfig.c
+++ b/Python/initconfig.c
@@ -2218,6 +2218,10 @@ config_read(PyConfig *config, int compute_path_config)
     if (config->_pystats < 0) {
         config->_pystats = 0;
     }
+
+    if (!_Py_StatsSetDir(getenv("PYTHON_PYSTATS_DIR"))) {
+        return _PyStatus_ERR("PYTHON_PYSTATS_DIR too long");
+    }
 #endif
 
     status = config_read_complex_options(config);

--- a/Python/specialize.c
+++ b/Python/specialize.c
@@ -345,7 +345,8 @@ _Py_StatsSetDir(const char *dirname)
             return 0;
         }
         _Py_stats_dir = dirname;
-    } else {
+    }
+    else {
 # ifdef MS_WINDOWS
         _Py_stats_dir = "c:\\temp\\py_stats\\";
 # else

--- a/Python/specialize.c
+++ b/Python/specialize.c
@@ -366,12 +366,15 @@ _Py_PrintSpecializationStats(int to_file)
 
     FILE *out = stderr;
     if (to_file) {
+        const char *dirname = getenv("PYTHON_PYSTATS_DIR");
         /* Write to a file instead of stderr. */
+        if (dirname == NULL) {
 # ifdef MS_WINDOWS
-        const char *dirname = "c:\\temp\\py_stats\\";
+            dirname = "c:\\temp\\py_stats\\";
 # else
-        const char *dirname = "/tmp/py_stats/";
+            dirname = "/tmp/py_stats/";
 # endif
+        }
         /* Use random 160 bit number as file name,
         * to avoid both accidental collisions and
         * symlink attacks. */
@@ -383,8 +386,8 @@ _Py_PrintSpecializationStats(int to_file)
             hex_name[2*i+1] = Py_hexdigits[(rand[i]>>4)&15];
         }
         hex_name[40] = '\0';
-        char buf[64];
-        assert(strlen(dirname) + 40 + strlen(".txt") < 64);
+        char buf[128];
+        assert(strlen(dirname) + 40 + strlen(".txt") < 128);
         sprintf(buf, "%s%s.txt", dirname, hex_name);
         FILE *fout = fopen(buf, "w");
         if (fout) {

--- a/Python/specialize.c
+++ b/Python/specialize.c
@@ -341,12 +341,12 @@ _Py_StatsSetDir(const char *dirname)
     _Py_stats_dir = NULL;
 
     if (dirname != NULL) {
-        if (strlen(dirname) > (PYSTATS_FILENAME_BUFSIZE - 44 - 1)) {
+        if (strnlen(dirname, PYSTATS_FILENAME_BUFSIZE) >
+            (PYSTATS_FILENAME_BUFSIZE - 44 - 1)) {
             return 0;
         }
         _Py_stats_dir = dirname;
-    }
-    else {
+    } else {
 # ifdef MS_WINDOWS
         _Py_stats_dir = "c:\\temp\\py_stats\\";
 # else

--- a/Python/specialize.c
+++ b/Python/specialize.c
@@ -341,7 +341,7 @@ _Py_StatsSetDir(const char *dirname)
     _Py_stats_dir = NULL;
 
     if (dirname != NULL) {
-        if (strlen(dirname) > (PYSTATS_FILENAME_BUFSIZE - 44 - 5)) {
+        if (strlen(dirname) > (PYSTATS_FILENAME_BUFSIZE - 44 - 1)) {
             return 0;
         }
         _Py_stats_dir = dirname;


### PR DESCRIPTION
This adds an environment variable to choose a pystats output directory so that stats collection can run in parallel without results being intermingled.


<!-- gh-issue-number: gh-112040 -->
* Issue: gh-112040
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--118255.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->