### PR TITLE
gh-117657: Add a couple more TSAN suppressions

### DIFF
--- a/Tools/tsan/suppressions_free_threading.txt
+++ b/Tools/tsan/suppressions_free_threading.txt
@@ -25,6 +25,8 @@ race:_PyInterpreterState_IsRunningMain
 race:_PyObject_GC_IS_SHARED
 race:_PyObject_GC_SET_SHARED
 race:_PyObject_GC_TRACK
+# https://gist.github.com/mpage/0a24eb2dd458441ededb498e9b0e5de8
+race:_PyParkingLot_Park
 race:_PyType_HasFeature
 race:assign_version_tag
 race:compare_unicode_unicode
@@ -44,3 +46,6 @@ race:set_inheritable
 race:start_the_world
 race:tstate_set_detached
 race:unicode_hash
+
+# https://gist.github.com/mpage/6962e8870606cfc960e159b407a0cb40
+thread:pthread_create


### PR DESCRIPTION
I kicked off 50 runs of the TSAN tests using GH actions and haven't seen any TSAN warnings with these additions.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-117657 -->
* Issue: gh-117657
<!-- /gh-issue-number -->
