### PR TITLE
gh-117505: Run ensurepip in isolated env in Windows installer

### DIFF
--- a/Misc/NEWS.d/next/Windows/2024-04-24-22-50-33.gh-issue-117505.gcTb_p.rst
+++ b/Misc/NEWS.d/next/Windows/2024-04-24-22-50-33.gh-issue-117505.gcTb_p.rst
@@ -1,0 +1,1 @@
+Fixes an issue with the Windows installer not running ensurepip in a fully isolated environment. This could cause unexpected interactions with the user site-packages.

--- a/Tools/msi/pip/pip.wxs
+++ b/Tools/msi/pip/pip.wxs
@@ -25,8 +25,8 @@
         <?endif ?>
         
         <!-- Install/uninstall pip -->
-        <CustomAction Id="SetUpdatePipCommandLine" Property="UpdatePip" Value='"[PYTHON_EXE]" -E -s -m ensurepip -U --default-pip' Execute="immediate" />
-        <CustomAction Id="SetRemovePipCommandLine" Property="UpdatePip" Value='"[PYTHON_EXE]" -E -s -B -m ensurepip._uninstall' Execute="immediate" />
+        <CustomAction Id="SetUpdatePipCommandLine" Property="UpdatePip" Value='"[PYTHON_EXE]" -I -m ensurepip -U --default-pip' Execute="immediate" />
+        <CustomAction Id="SetRemovePipCommandLine" Property="UpdatePip" Value='"[PYTHON_EXE]" -I -B -m ensurepip._uninstall' Execute="immediate" />
         
         <InstallExecuteSequence>
             <Custom Action="SetUpdatePipCommandLine" Before="UpdatePip">(&amp;DefaultFeature=3) AND NOT (!DefaultFeature=3)</Custom>


### PR DESCRIPTION
ensurepip forks a subprocess to run pip itself, but that subprocess only inherits a `-I` isolated mode flag (see `_run_pip()` in `Lib/ensurepip/__init__.py`), not the `-E -s` flags that the installer has been using. This means that parts of ensurepip don't actually run in an isolated environment and can make incorrect decisions based on packages installed in the user site-packages.

<!-- gh-issue-number: gh-117505 -->
* Issue: gh-117505
<!-- /gh-issue-number -->
