### PR TITLE
gh-117657: Fix data race in `_Py_IsImmortal`

### DIFF
--- a/Include/object.h
+++ b/Include/object.h
@@ -349,7 +349,8 @@ static inline Py_ssize_t Py_SIZE(PyObject *ob) {
 static inline Py_ALWAYS_INLINE int _Py_IsImmortal(PyObject *op)
 {
 #if defined(Py_GIL_DISABLED)
-    return (op->ob_ref_local == _Py_IMMORTAL_REFCNT_LOCAL);
+    return (_Py_atomic_load_uint32_relaxed(&op->ob_ref_local) ==
+            _Py_IMMORTAL_REFCNT_LOCAL);
 #elif SIZEOF_VOID_P > 4
     return (_Py_CAST(PY_INT32_T, op->ob_refcnt) < 0);
 #else

--- a/Tools/tsan/suppressions_free_threading.txt
+++ b/Tools/tsan/suppressions_free_threading.txt
@@ -14,7 +14,6 @@ race:set_allocator_unlocked
 race:_add_to_weak_set
 race:_in_weak_set
 race:_mi_heap_delayed_free_partial
-race:_Py_IsImmortal
 race:_Py_IsOwnedByCurrentThread
 race:_PyEval_EvalFrameDefault
 race:_PyFunction_SetVersion


### PR DESCRIPTION
The load of `ob_ref_local`:

https://github.com/python/cpython/blob/4b10e209c76f9f36f8ae2e4d713b3a01591c1856/Include/object.h#L352

races with stores ([example](https://gist.github.com/mpage/7e2028b3ca811deb350f705bc3c737ca)):

https://github.com/python/cpython/blob/4b10e209c76f9f36f8ae2e4d713b3a01591c1856/Include/object.h#L883

Using a relaxed load is sufficient; stores to the field are relaxed.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-117657 -->
* Issue: gh-117657
<!-- /gh-issue-number -->
