### PR TITLE
[3.10] gh-100454: Fix running SSL tests with OpenSSL 3.1+ (GH-100456)

### DIFF
--- a/Misc/NEWS.d/next/Tests/2022-12-23-13-29-55.gh-issue-100454.3no0cW.rst
+++ b/Misc/NEWS.d/next/Tests/2022-12-23-13-29-55.gh-issue-100454.3no0cW.rst
@@ -1,0 +1,1 @@
+Fix SSL tests CI for OpenSSL 3.1+

--- a/Tools/ssl/multissltests.py
+++ b/Tools/ssl/multissltests.py
@@ -404,15 +404,15 @@ class BuildOpenSSL(AbstractBuilder):
     depend_target = 'depend'
 
     def _post_install(self):
-        if self.version.startswith("3.0"):
-            self._post_install_300()
+        if self.version.startswith("3."):
+            self._post_install_3xx()
 
     def _build_src(self, config_args=()):
-        if self.version.startswith("3.0"):
+        if self.version.startswith("3."):
             config_args += ("enable-fips",)
         super()._build_src(config_args)
 
-    def _post_install_300(self):
+    def _post_install_3xx(self):
         # create ssl/ subdir with example configs
         # Install FIPS module
         self._subprocess_call(


### PR DESCRIPTION
This fixes Ubuntu pipeline with OpenSSL 3.1+

<!-- gh-issue-number: gh-100454 -->
* Issue: gh-100454
<!-- /gh-issue-number -->
