### PR TITLE
[3.9] gh-118224: Load default OpenSSL provider for nonsecurity algorithms (GH-118236)

### DIFF
--- a/Misc/NEWS.d/next/Build/2024-04-24-16-58-45.gh-issue-118224.wnjFHn.rst
+++ b/Misc/NEWS.d/next/Build/2024-04-24-16-58-45.gh-issue-118224.wnjFHn.rst
@@ -1,0 +1,1 @@
+Hashlib now supports using default OpenSSL provider instead of builtin fallback for nonsecurity hashes on hosts otherwise only using base and fips providers. This makes build configuration ``--with-builtin-hashlib-hashes=blake2`` fully supported on OpenSSL FIPS hosts.

--- a/Modules/_hashopenssl.c
+++ b/Modules/_hashopenssl.c
@@ -90,6 +90,7 @@ HMAC_CTX_get_md(const HMAC_CTX *ctx)
 #endif
 
 #if OPENSSL_VERSION_NUMBER >= 0x30000000L
+#include <openssl/provider.h>
 #define PY_EVP_MD EVP_MD
 #define PY_EVP_MD_fetch(algorithm, properties) EVP_MD_fetch(NULL, algorithm, properties)
 #define PY_EVP_MD_up_ref(md) EVP_MD_up_ref(md)
@@ -262,6 +263,17 @@ typedef struct {
     _Py_hashtable_t *hashtable;
 } _hashlibstate;
 
+static void try_load_default_provider(void) {
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L
+    /* Load the default config file, and expected providers */
+    OPENSSL_init_crypto(OPENSSL_INIT_LOAD_CONFIG, NULL);
+    if (!OSSL_PROVIDER_available(NULL, "default")) {
+	/* System is configured without the default provider */
+        OSSL_PROVIDER_load(NULL, "default");
+    }
+#endif
+}
+
 static inline _hashlibstate*
 get_hashlib_state(PyObject *module)
 {
@@ -392,6 +404,7 @@ py_digest_by_name(PyObject *module, const char *name, enum Py_hash_type py_ht)
             break;
         case Py_ht_evp_nosecurity:
             if (entry->evp_nosecurity == NULL) {
+                try_load_default_provider();
                 entry->evp_nosecurity = PY_EVP_MD_fetch(entry->ossl_name, "-fips");
             }
             digest = entry->evp_nosecurity;
@@ -409,6 +422,7 @@ py_digest_by_name(PyObject *module, const char *name, enum Py_hash_type py_ht)
             digest = PY_EVP_MD_fetch(name, NULL);
             break;
         case Py_ht_evp_nosecurity:
+            try_load_default_provider();
             digest = PY_EVP_MD_fetch(name, "-fips");
             break;
         }


### PR DESCRIPTION
When OpenSSL is configured to only load "base+fips" providers into the Null library context, md5 might not be available at all. In such cases currently CPython fallsback to internal hashlib implementation is there is one - as there might not be if one compiles python with --with-builtin-hashlib-hashes=blake2. With this change "default" provider is attempted to be loaded to access nonsecurity hashes.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-118224 -->
* Issue: gh-118224
<!-- /gh-issue-number -->
