### PR TITLE
gh-118216: Don't consider dotted `__future__` imports

### DIFF
--- a/Doc/whatsnew/3.13.rst
+++ b/Doc/whatsnew/3.13.rst
@@ -288,6 +288,10 @@ Other Language Changes
   class scopes are not inlined into their parent scope. (Contributed by
   Jelle Zijlstra in :gh:`109118` and :gh:`118160`.)
 
+* ``from __future__ import ...`` statements are now just normal
+  relative imports if dots are present before the module name.
+  (Contributed by Jeremiah Gabriel Pascual in :gh:`118216`.)
+
 
 New Modules
 ===========

--- a/Lib/test/test_future_stmt/test_future.py
+++ b/Lib/test/test_future_stmt/test_future.py
@@ -203,6 +203,20 @@ class FutureTest(unittest.TestCase):
         out = kill_python(p)
         self.assertNotIn(b'SyntaxError: invalid syntax', out)
 
+    def test_future_dotted_import(self):
+        with self.assertRaises(ImportError):
+            from .__future__ import annotations
+
+        with self.assertRaises(ImportError):
+            from __future__ import print_function
+            from ...__future__ import annotations
+
+        code = """
+            from .__future__ import nested_scopes
+            from __future__ import barry_as_FLUFL
+        """
+        self.assertSyntaxError(code, lineno=2)
+
 class AnnotationsFutureTestCase(unittest.TestCase):
     template = dedent(
         """

--- a/Lib/test/test_future_stmt/test_future.py
+++ b/Lib/test/test_future_stmt/test_future.py
@@ -205,11 +205,16 @@ class FutureTest(unittest.TestCase):
 
     def test_future_dotted_import(self):
         with self.assertRaises(ImportError):
-            from .__future__ import annotations
+            exec("from .__future__ import spam")
 
-        with self.assertRaises(ImportError):
+        code = dedent(
+            """
             from __future__ import print_function
-            from ...__future__ import annotations
+            from ...__future__ import ham
+            """
+        )
+        with self.assertRaises(ImportError):
+            exec(code)
 
         code = """
             from .__future__ import nested_scopes

--- a/Misc/NEWS.d/next/Core and Builtins/2024-04-25-11-48-28.gh-issue-118216.SVg700.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2024-04-25-11-48-28.gh-issue-118216.SVg700.rst
@@ -1,1 +1,1 @@
-Don't consider `__future__` imports with dots before the module name.
+Don't consider :mod:`__future__` imports with dots before the module name.

--- a/Misc/NEWS.d/next/Core and Builtins/2024-04-25-11-48-28.gh-issue-118216.SVg700.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2024-04-25-11-48-28.gh-issue-118216.SVg700.rst
@@ -1,0 +1,1 @@
+Don't consider `__future__` imports with dots before the module name.

--- a/Python/compile.c
+++ b/Python/compile.c
@@ -3849,7 +3849,7 @@ compiler_from_import(struct compiler *c, stmt_ty s)
     }
 
     if (location_is_after(LOC(s), c->c_future.ff_location) &&
-        s->v.ImportFrom.module &&
+        s->v.ImportFrom.module && s->v.ImportFrom.level == 0 &&
         _PyUnicode_EqualToASCIIString(s->v.ImportFrom.module, "__future__"))
     {
         Py_DECREF(names);

--- a/Python/future.c
+++ b/Python/future.c
@@ -77,7 +77,7 @@ future_parse(_PyFutureFeatures *ff, mod_ty mod, PyObject *filename)
          *  are another future statement and a doc string.
          */
 
-        if (s->kind == ImportFrom_kind) {
+        if (s->kind == ImportFrom_kind && s->v.ImportFrom.level == 0) {
             identifier modname = s->v.ImportFrom.module;
             if (modname &&
                 _PyUnicode_EqualToASCIIString(modname, "__future__")) {


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
Add checking for the number of dots before the module name alongside `__future__` name checks in `Python/future.c` and `Python/compile.c`. Basically makes a `__future__` import only be considered one when no dots are present before the module name.

<!-- gh-issue-number: gh-118216 -->
* Issue: gh-118216
<!-- /gh-issue-number -->
