### PR TITLE
gh-117225: Document colour use in `doctest`

### DIFF
--- a/Doc/using/cmdline.rst
+++ b/Doc/using/cmdline.rst
@@ -632,11 +632,11 @@ behavior can be controlled by setting different environment variables.
 
 Setting the environment variable ``TERM`` to ``dumb`` will disable color.
 
-If the environment variable ``FORCE_COLOR`` is set, then color will be
+If the |FORCE_COLOR|_ environment variable is set, then color will be
 enabled regardless of the value of TERM. This is useful on CI systems which
 aren’t terminals but can still display ANSI escape sequences.
 
-If the environment variable ``NO_COLOR`` is set, Python will disable all color
+If the |NO_COLOR|_ environment variable is set, Python will disable all color
 in the output. This takes precedence over ``FORCE_COLOR``.
 
 All these environment variables are used also by other tools to control color
@@ -644,6 +644,14 @@ output. To control the color output only in the Python interpreter, the
 :envvar:`PYTHON_COLORS` environment variable can be used. This variable takes
 precedence over ``NO_COLOR``, which in turn takes precedence over
 ``FORCE_COLOR``.
+
+.. Apparently this how you hack together a formatted link:
+
+.. |FORCE_COLOR| replace:: ``FORCE_COLOR``
+.. _FORCE_COLOR: https://force-color.org/
+
+.. |NO_COLOR| replace:: ``NO_COLOR``
+.. _NO_COLOR: https://no-color.org/
 
 Options you shouldn't use
 ~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/Doc/whatsnew/3.13.rst
+++ b/Doc/whatsnew/3.13.rst
@@ -100,9 +100,17 @@ Improved Error Messages
 
 * The interpreter now colorizes error messages when displaying tracebacks by default.
   This feature can be controlled via the new :envvar:`PYTHON_COLORS` environment
-  variable as well as the canonical ``NO_COLOR`` and ``FORCE_COLOR`` environment
+  variable as well as the canonical |NO_COLOR|_ and |FORCE_COLOR|_ environment
   variables. See also :ref:`using-on-controlling-color`.
   (Contributed by Pablo Galindo Salgado in :gh:`112730`.)
+
+.. Apparently this how you hack together a formatted link:
+
+.. |FORCE_COLOR| replace:: ``FORCE_COLOR``
+.. _FORCE_COLOR: https://force-color.org/
+
+.. |NO_COLOR| replace:: ``NO_COLOR``
+.. _NO_COLOR: https://no-color.org/
 
 * A common mistake is to write a script with the same name as a
   standard library module. When this results in errors, we now
@@ -436,6 +444,12 @@ doctest
   tests. Add :attr:`doctest.DocTestRunner.skips` and
   :attr:`doctest.TestResults.skipped` attributes.
   (Contributed by Victor Stinner in :gh:`108794`.)
+
+* Color is added to the output by default.
+  This can be controlled via the new :envvar:`PYTHON_COLORS` environment
+  variable as well as the canonical |NO_COLOR|_ and |FORCE_COLOR|_ environment
+  variables. See also :ref:`using-on-controlling-color`.
+  (Contributed by Hugo van Kemenade in :gh:`117225`.)
 
 email
 -----


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

Document the additions in https://github.com/python/cpython/pull/117583.

Perhaps also a short entry in the [What's New summary](https://docs.python.org/3.13/whatsnew/3.13.html#summary-release-highlights) linking to the traceback and doctest sections?



<!-- gh-issue-number: gh-117225 -->
* Issue: gh-117225
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--118268.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->