### PR TITLE
[3.12] gh-118042: Fix error in Telnet.__del__ when __init__() was not called

### DIFF
--- a/Lib/telnetlib.py
+++ b/Lib/telnetlib.py
@@ -195,6 +195,7 @@ class Telnet:
         No other action is done afterwards by telnetlib.
 
     """
+    sock = None  # for __del__()
 
     def __init__(self, host=None, port=0,
                  timeout=socket._GLOBAL_DEFAULT_TIMEOUT):

--- a/Misc/NEWS.d/next/Library/2024-04-25-12-02-06.gh-issue-118042.2EcdHf.rst
+++ b/Misc/NEWS.d/next/Library/2024-04-25-12-02-06.gh-issue-118042.2EcdHf.rst
@@ -1,0 +1,2 @@
+Fix an unraisable exception in :meth:`telnetlib.Telnet.__del__` when the
+``__init__()`` method was not called.


### PR DESCRIPTION
I have not added tests, because it is not worth the effort. The `telnetlib` module is removed in 3.13.

<!-- gh-issue-number: gh-118042 -->
* Issue: gh-118042
<!-- /gh-issue-number -->
