### PR TITLE
Remove tests_gui variables from Tkinter tests

### DIFF
--- a/Lib/test/test_tkinter/test_geometry_managers.py
+++ b/Lib/test/test_tkinter/test_geometry_managers.py
@@ -893,9 +893,5 @@ class GridTest(AbstractWidgetTest, unittest.TestCase):
         self.assertEqual(self.root.grid_slaves(row=1, column=1), [d, c])
 
 
-tests_gui = (
-    PackTest, PlaceTest, GridTest,
-)
-
 if __name__ == '__main__':
     unittest.main()

--- a/Lib/test/test_tkinter/test_widgets.py
+++ b/Lib/test/test_tkinter/test_widgets.py
@@ -1479,13 +1479,5 @@ class DefaultRootTest(AbstractDefaultRootTest, unittest.TestCase):
         self._test_widget(tkinter.Label)
 
 
-tests_gui = (
-        ButtonTest, CanvasTest, CheckbuttonTest, EntryTest,
-        FrameTest, LabelFrameTest,LabelTest, ListboxTest,
-        MenubuttonTest, MenuTest, MessageTest, OptionMenuTest,
-        PanedWindowTest, RadiobuttonTest, ScaleTest, ScrollbarTest,
-        SpinboxTest, TextTest, ToplevelTest, DefaultRootTest,
-)
-
 if __name__ == '__main__':
     unittest.main()

--- a/Lib/test/test_ttk/test_widgets.py
+++ b/Lib/test/test_ttk/test_widgets.py
@@ -1879,13 +1879,5 @@ class DefaultRootTest(AbstractDefaultRootTest, unittest.TestCase):
         self._test_widget(ttk.Label)
 
 
-tests_gui = (
-        ButtonTest, CheckbuttonTest, ComboboxTest, EntryTest,
-        FrameTest, LabelFrameTest, LabelTest, MenubuttonTest,
-        NotebookTest, PanedWindowTest, ProgressbarTest,
-        RadiobuttonTest, ScaleTest, ScrollbarTest, SeparatorTest,
-        SizegripTest, SpinboxTest, TreeviewTest, WidgetTest, DefaultRootTest,
-        )
-
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
They were only used in runtktests.py which was removed in f59ed3c310a7ceebf2a56a84ea969a7f75d95b64 (bpo-45229).
