### PR TITLE
Fix note in Enum.__new__ docs

### DIFF
--- a/Doc/library/enum.rst
+++ b/Doc/library/enum.rst
@@ -279,7 +279,7 @@ Data Types
          >>> Color.RED.value
          1
 
-      Value of the member, can be set in :meth:`~object.__new__`.
+      Value of the member, can be set in :meth:`~Enum.__new__`.
 
       .. note:: Enum member values
 
@@ -299,7 +299,7 @@ Data Types
 
    .. attribute:: Enum._value_
 
-      Value of the member, can be set in :meth:`~object.__new__`.
+      Value of the member, can be set in :meth:`~Enum.__new__`.
 
    .. attribute:: Enum._order_
 
@@ -827,7 +827,7 @@ Supported ``__dunder__`` names
 :attr:`~EnumType.__members__` is a read-only ordered mapping of ``member_name``:``member``
 items.  It is only available on the class.
 
-:meth:`~object.__new__`, if specified, must create and return the enum members;
+:meth:`~Enum.__new__`, if specified, must create and return the enum members;
 it is also a very good idea to set the member's :attr:`!_value_` appropriately.
 Once all the members are created it is no longer used.
 

--- a/Doc/library/enum.rst
+++ b/Doc/library/enum.rst
@@ -407,8 +407,8 @@ Data Types
 
       results in the call ``int('1a', 16)`` and a value of ``17`` for the member.
 
-      ..note:: When writing a custom ``__new__``, do not use ``super().__new__`` --
-               call the appropriate ``__new__`` instead.
+      .. note:: When writing a custom ``__new__``, do not use ``super().__new__`` --
+                call the appropriate ``__new__`` instead.
 
    .. method:: Enum.__repr__(self)
 


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

Was introduced in https://github.com/python/cpython/pull/116065

Should be backported to 3.12

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: <https://cpython-previews--118284.org.readthedocs.build/en/118284/library/enum.html#enum.Enum.__new__>

<!-- readthedocs-preview cpython-previews end -->