### PR TITLE
gh-110693: Use a Larger Queue for Per-Interpreter Pending Calls

### DIFF
--- a/Include/internal/pycore_ceval_state.h
+++ b/Include/internal/pycore_ceval_state.h
@@ -20,7 +20,7 @@ struct _pending_call {
     int flags;
 };
 
-#define PENDINGCALLSARRAYSIZE 32
+#define PENDINGCALLSARRAYSIZE 300
 
 #define MAXPENDINGCALLS PENDINGCALLSARRAYSIZE
 /* For interpreter-level pending calls, we want to avoid spending too
@@ -31,7 +31,9 @@ struct _pending_call {
 #  define MAXPENDINGCALLSLOOP MAXPENDINGCALLS
 #endif
 
-#define MAXPENDINGCALLS_MAIN PENDINGCALLSARRAYSIZE
+/* We keep the number small to preserve as much compatibility
+   as possible with earlier versions. */
+#define MAXPENDINGCALLS_MAIN 32
 /* For the main thread, we want to make sure all pending calls are
    run at once, for the sake of prompt signal handling.  This is
    unlikely to cause any problems since there should be very few

--- a/Lib/test/test_capi/test_misc.py
+++ b/Lib/test/test_capi/test_misc.py
@@ -1570,9 +1570,9 @@ class TestPendingCalls(unittest.TestCase):
             self.assertEqual(added, maxpending)
 
         with self.subTest('not main-only'):
-            # Per-interpreter pending calls has the same low limit
+            # Per-interpreter pending calls has a much higher limit
             # on how many may be pending at a time.
-            maxpending = 32
+            maxpending = 300
 
             l = []
             added = self.pendingcalls_submit(l, 1, main=False)


### PR DESCRIPTION
This is an improvement over the status quo, reducing the likelihood of completely filling the pending calls queue.  However, the problem won't go away completely unless we move to an unbounded linked list or add a mechanism for waiting until the queue isn't full.

FYI, I picked 300 because it is substantially larger, but not so large it will waste much memory.  Each item in the array is 20 bytes, so an array of 300 is 6kB (per interpreter).  Previously it was about 1/10th of that.

<!-- gh-issue-number: gh-110693 -->
* Issue: gh-110693
<!-- /gh-issue-number -->
