### PR TITLE
gh-118323: Document `&&` grammar syntax

### DIFF
--- a/Grammar/python.gram
+++ b/Grammar/python.gram
@@ -78,6 +78,8 @@ _PyPegen_parse(Parser *p)
 #   Fail if e can be parsed, without consuming any input.
 # ~
 #   Commit to the current alternative, even if it fails to parse.
+# &&e
+#   Eager parse e. Fail with SyntaxError if e cannot be parsed.
 #
 
 # STARTING RULES

--- a/Grammar/python.gram
+++ b/Grammar/python.gram
@@ -79,7 +79,8 @@ _PyPegen_parse(Parser *p)
 # ~
 #   Commit to the current alternative, even if it fails to parse.
 # &&e
-#   Eager parse e. Fail with SyntaxError if e cannot be parsed.
+#   Eager parse e. The parser will not backtrack and will immediately 
+#   fail with SyntaxError if e cannot be parsed.
 #
 
 # STARTING RULES


### PR DESCRIPTION
Better wording is welcome! 

<!-- gh-issue-number: gh-118323 -->
* Issue: gh-118323
<!-- /gh-issue-number -->
