### PR TITLE
gh-117680: Fix msvc warning in instruction_sequence.c

### DIFF
--- a/Python/instruction_sequence.c
+++ b/Python/instruction_sequence.c
@@ -20,6 +20,8 @@ typedef _Py_SourceLocation location;
 #define INITIAL_INSTR_SEQUENCE_SIZE 100
 #define INITIAL_INSTR_SEQUENCE_LABELS_MAP_SIZE 10
 
+#include "clinic/instruction_sequence.c.h"
+
 #undef SUCCESS
 #undef ERROR
 #define SUCCESS 0
@@ -171,8 +173,6 @@ PyInstructionSequence_Fini(instr_sequence *seq) {
 class InstructionSequenceType "_PyInstructionSequence *" "&_PyInstructionSequence_Type"
 [clinic start generated code]*/
 /*[clinic end generated code: output=da39a3ee5e6b4b0d input=589963e07480390f]*/
-
-#include "clinic/instruction_sequence.c.h"
 
 static _PyInstructionSequence*
 inst_seq_create(void)


### PR DESCRIPTION
Fixes the following Windows-specific warning since #117629:

```
 Warning: ...\Windows Kits\10\Include\10.0.22621.0\um\wingdi.h(118,1):
 warning C4005: 'ERROR': macro redefinition [D:\a\...
         (compiling source file '../Python/instruction_sequence.c')
         D:\a\cpython\cpython\Python\instruction_sequence.c(26,1):
         see previous definition of 'ERROR'
```

`wingdi.h`:

```c
/* Region Flags */
#define ERROR               0
#define NULLREGION          1
...
```

cc @iritkatriel

<!-- gh-issue-number: gh-117680 -->
* Issue: gh-117680
<!-- /gh-issue-number -->
