### PR TITLE
gh-118331: Handle errors in _PyObject_SetManagedDict

### DIFF
--- a/Include/cpython/object.h
+++ b/Include/cpython/object.h
@@ -493,7 +493,7 @@ do { \
 PyAPI_FUNC(void *) PyObject_GetItemData(PyObject *obj);
 
 PyAPI_FUNC(int) PyObject_VisitManagedDict(PyObject *obj, visitproc visit, void *arg);
-PyAPI_FUNC(void) _PyObject_SetManagedDict(PyObject *obj, PyObject *new_dict);
+PyAPI_FUNC(int) _PyObject_SetManagedDict(PyObject *obj, PyObject *new_dict);
 PyAPI_FUNC(void) PyObject_ClearManagedDict(PyObject *obj);
 
 #define TYPE_MAX_WATCHERS 8

--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -7131,6 +7131,8 @@ int
 _PyDict_DetachFromObject(PyDictObject *mp, PyObject *obj)
 {
     _Py_CRITICAL_SECTION_ASSERT_OBJECT_LOCKED(obj);
+    assert(_PyObject_ManagedDictPointer(obj)->dict == mp);
+    assert(_PyObject_InlineValuesConsistencyCheck(obj));
 
     if (FT_ATOMIC_LOAD_PTR_RELAXED(mp->ma_values) != _PyObject_InlineValues(obj)) {
         return 0;

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -3167,7 +3167,7 @@ subtype_setdict(PyObject *obj, PyObject *value, void *context)
     }
 
     if (Py_TYPE(obj)->tp_flags & Py_TPFLAGS_MANAGED_DICT) {
-        _PyObject_SetManagedDict(obj, value);
+        return _PyObject_SetManagedDict(obj, value);
     }
     else {
         dictptr = _PyObject_ComputedDictPointer(obj);


### PR DESCRIPTION
When detaching a dict, the copy_values call may fail due to out-of-memory errors. This can be triggered by `test_no_memory` in `test_repl`.


<!-- gh-issue-number: gh-118331 -->
* Issue: gh-118331
<!-- /gh-issue-number -->
