### PR TITLE
gh-118345: Fix `os.path.abspath()` & `posixpath.abspath()` for relative paths on the other platform

### DIFF
--- a/Lib/ntpath.py
+++ b/Lib/ntpath.py
@@ -646,6 +646,8 @@ except ImportError:
     # realpath is a no-op on systems without _getfinalpathname support.
     def realpath(path, *, strict=False):
         """Return an absolute path."""
+        if strict:
+            raise NotImplementedError('realpath: strict unavailable on this platform')
         return abspath(path)
 else:
     def _readlink_deep(path):

--- a/Lib/ntpath.py
+++ b/Lib/ntpath.py
@@ -644,7 +644,9 @@ try:
     from nt import _findfirstfile, _getfinalpathname, readlink as _nt_readlink
 except ImportError:
     # realpath is a no-op on systems without _getfinalpathname support.
-    realpath = abspath
+    def realpath(path, *, strict=False):
+        """Return an absolute path."""
+        return abspath(path)
 else:
     def _readlink_deep(path):
         # These error codes indicate that we should stop reading links and

--- a/Lib/posixpath.py
+++ b/Lib/posixpath.py
@@ -434,6 +434,8 @@ if os.name == "nt":
     # realpath is a no-op on Windows.
     def realpath(path, *, strict=False):
         """Return an absolute path."""
+        if strict:
+            raise NotImplementedError('realpath: strict unavailable on this platform')
         return abspath(path)
 else:
     def realpath(filename, *, strict=False):

--- a/Lib/posixpath.py
+++ b/Lib/posixpath.py
@@ -406,16 +406,25 @@ else:
         return _path_normpath(path) or "."
 
 
-def abspath(path):
-    """Return an absolute path."""
-    path = os.fspath(path)
-    if isinstance(path, bytes):
-        if not path.startswith(b'/'):
-            path = join(os.getcwdb(), path)
-    else:
-        if not path.startswith('/'):
-            path = join(os.getcwd(), path)
-    return normpath(path)
+if os.name == "nt":  # not running on Unix - mock up something sensible
+    def abspath(path):
+        """Return an absolute path."""
+        path = os.fspath(path)
+        sep = _get_sep(path)
+        if not path.startswith(sep):
+            path = sep + path
+        return normpath(path)
+else:  # use native Unix method on Unix
+    def abspath(path):
+        """Return an absolute path."""
+        path = os.fspath(path)
+        if isinstance(path, bytes):
+            if not path.startswith(b'/'):
+                path = join(os.getcwdb(), path)
+        else:
+            if not path.startswith('/'):
+                path = join(os.getcwd(), path)
+        return normpath(path)
 
 
 # Return a canonical path (i.e. the absolute location of a file on the

--- a/Lib/test/test_ntpath.py
+++ b/Lib/test/test_ntpath.py
@@ -376,16 +376,18 @@ class TestNtpath(NtpathTestCase):
         tester("ntpath.normpath('\\\\')", '\\\\')
         tester("ntpath.normpath('//?/UNC/server/share/..')", '\\\\?\\UNC\\server\\share\\')
 
+    @unittest.skipUnless(HAVE_GETFINALPATHNAME, 'need _getfinalpathname')
     def test_realpath_curdir(self):
-        expected = ntpath.normpath(os.getcwd())
+        expected = os.getcwd()
         tester("ntpath.realpath('.')", expected)
         tester("ntpath.realpath('./.')", expected)
         tester("ntpath.realpath('/'.join(['.'] * 100))", expected)
         tester("ntpath.realpath('.\\.')", expected)
         tester("ntpath.realpath('\\'.join(['.'] * 100))", expected)
 
+    @unittest.skipUnless(HAVE_GETFINALPATHNAME, 'need _getfinalpathname')
     def test_realpath_pardir(self):
-        expected = ntpath.normpath(os.getcwd())
+        expected = os.getcwd()
         tester("ntpath.realpath('..')", ntpath.dirname(expected))
         tester("ntpath.realpath('../..')",
                ntpath.dirname(ntpath.dirname(expected)))
@@ -839,6 +841,7 @@ class TestNtpath(NtpathTestCase):
             drive, _ = ntpath.splitdrive(cwd_dir)
             tester('ntpath.abspath("/abc/")', drive + "\\abc")
 
+    @unittest.skipUnless(nt, "relpath requires 'nt' module")
     def test_relpath(self):
         tester('ntpath.relpath("a")', 'a')
         tester('ntpath.relpath(ntpath.abspath("a"))', 'a')

--- a/Lib/test/test_posixpath.py
+++ b/Lib/test/test_posixpath.py
@@ -20,16 +20,6 @@ except ImportError:
 
 ABSTFN = abspath(os_helper.TESTFN)
 
-def skip_if_ABSTFN_contains_backslash(test):
-    """
-    On Windows, posixpath.abspath still returns paths with backslashes
-    instead of posix forward slashes. If this is the case, several tests
-    fail, so skip them.
-    """
-    found_backslash = '\\' in ABSTFN
-    msg = "ABSTFN is not a posix path - tests fail"
-    return [test, unittest.skip(msg)(test)][found_backslash]
-
 def safe_rmdir(dirname):
     try:
         os.rmdir(dirname)
@@ -419,7 +409,7 @@ class PosixPathTest(unittest.TestCase):
                 result = posixpath.normpath(path)
                 self.assertEqual(result, expected)
 
-    @skip_if_ABSTFN_contains_backslash
+    @unittest.skipUnless(posix, "realpath requires 'posix' module")
     def test_realpath_curdir(self):
         self.assertEqual(realpath('.'), os.getcwd())
         self.assertEqual(realpath('./.'), os.getcwd())
@@ -429,7 +419,7 @@ class PosixPathTest(unittest.TestCase):
         self.assertEqual(realpath(b'./.'), os.getcwdb())
         self.assertEqual(realpath(b'/'.join([b'.'] * 100)), os.getcwdb())
 
-    @skip_if_ABSTFN_contains_backslash
+    @unittest.skipUnless(posix, "realpath requires 'posix' module")
     def test_realpath_pardir(self):
         self.assertEqual(realpath('..'), dirname(os.getcwd()))
         self.assertEqual(realpath('../..'), dirname(dirname(os.getcwd())))
@@ -440,7 +430,7 @@ class PosixPathTest(unittest.TestCase):
         self.assertEqual(realpath(b'/'.join([b'..'] * 100)), b'/')
 
     @os_helper.skip_unless_symlink
-    @skip_if_ABSTFN_contains_backslash
+    @unittest.skipUnless(posix, "realpath requires 'posix' module")
     def test_realpath_basic(self):
         # Basic operation.
         try:
@@ -450,7 +440,7 @@ class PosixPathTest(unittest.TestCase):
             os_helper.unlink(ABSTFN)
 
     @os_helper.skip_unless_symlink
-    @skip_if_ABSTFN_contains_backslash
+    @unittest.skipUnless(posix, "realpath requires 'posix' module")
     def test_realpath_strict(self):
         # Bug #43757: raise FileNotFoundError in strict mode if we encounter
         # a path that does not exist.
@@ -462,7 +452,7 @@ class PosixPathTest(unittest.TestCase):
             os_helper.unlink(ABSTFN)
 
     @os_helper.skip_unless_symlink
-    @skip_if_ABSTFN_contains_backslash
+    @unittest.skipUnless(posix, "realpath requires 'posix' module")
     def test_realpath_relative(self):
         try:
             os.symlink(posixpath.relpath(ABSTFN+"1"), ABSTFN)
@@ -471,7 +461,7 @@ class PosixPathTest(unittest.TestCase):
             os_helper.unlink(ABSTFN)
 
     @os_helper.skip_unless_symlink
-    @skip_if_ABSTFN_contains_backslash
+    @unittest.skipUnless(posix, "realpath requires 'posix' module")
     def test_realpath_missing_pardir(self):
         try:
             os.symlink(os_helper.TESTFN + "1", os_helper.TESTFN)
@@ -480,7 +470,7 @@ class PosixPathTest(unittest.TestCase):
             os_helper.unlink(os_helper.TESTFN)
 
     @os_helper.skip_unless_symlink
-    @skip_if_ABSTFN_contains_backslash
+    @unittest.skipUnless(posix, "realpath requires 'posix' module")
     def test_realpath_symlink_loops(self):
         # Bug #930024, return the path unchanged if we get into an infinite
         # symlink loop in non-strict mode (default).
@@ -521,7 +511,7 @@ class PosixPathTest(unittest.TestCase):
             os_helper.unlink(ABSTFN+"a")
 
     @os_helper.skip_unless_symlink
-    @skip_if_ABSTFN_contains_backslash
+    @unittest.skipUnless(posix, "realpath requires 'posix' module")
     def test_realpath_symlink_loops_strict(self):
         # Bug #43757, raise OSError if we get into an infinite symlink loop in
         # strict mode.
@@ -562,7 +552,7 @@ class PosixPathTest(unittest.TestCase):
             os_helper.unlink(ABSTFN+"a")
 
     @os_helper.skip_unless_symlink
-    @skip_if_ABSTFN_contains_backslash
+    @unittest.skipUnless(posix, "realpath requires 'posix' module")
     def test_realpath_repeated_indirect_symlinks(self):
         # Issue #6975.
         try:
@@ -576,7 +566,7 @@ class PosixPathTest(unittest.TestCase):
             safe_rmdir(ABSTFN)
 
     @os_helper.skip_unless_symlink
-    @skip_if_ABSTFN_contains_backslash
+    @unittest.skipUnless(posix, "realpath requires 'posix' module")
     def test_realpath_deep_recursion(self):
         depth = 10
         try:
@@ -595,7 +585,7 @@ class PosixPathTest(unittest.TestCase):
             safe_rmdir(ABSTFN)
 
     @os_helper.skip_unless_symlink
-    @skip_if_ABSTFN_contains_backslash
+    @unittest.skipUnless(posix, "realpath requires 'posix' module")
     def test_realpath_resolve_parents(self):
         # We also need to resolve any symlinks in the parents of a relative
         # path passed to realpath. E.g.: current working directory is
@@ -614,7 +604,7 @@ class PosixPathTest(unittest.TestCase):
             safe_rmdir(ABSTFN)
 
     @os_helper.skip_unless_symlink
-    @skip_if_ABSTFN_contains_backslash
+    @unittest.skipUnless(posix, "realpath requires 'posix' module")
     def test_realpath_resolve_before_normalizing(self):
         # Bug #990669: Symbolic links should be resolved before we
         # normalize the path. E.g.: if we have directories 'a', 'k' and 'y'
@@ -642,7 +632,7 @@ class PosixPathTest(unittest.TestCase):
             safe_rmdir(ABSTFN)
 
     @os_helper.skip_unless_symlink
-    @skip_if_ABSTFN_contains_backslash
+    @unittest.skipUnless(posix, "realpath requires 'posix' module")
     def test_realpath_resolve_first(self):
         # Bug #1213894: The first component of the path, if not absolute,
         # must be resolved too.
@@ -660,6 +650,7 @@ class PosixPathTest(unittest.TestCase):
             safe_rmdir(ABSTFN + "/k")
             safe_rmdir(ABSTFN)
 
+    @unittest.skipUnless(posix, "relpath requires 'posix' module")
     def test_relpath(self):
         (real_getcwd, os.getcwd) = (os.getcwd, lambda: r"/home/user/bar")
         try:
@@ -687,6 +678,7 @@ class PosixPathTest(unittest.TestCase):
         finally:
             os.getcwd = real_getcwd
 
+    @unittest.skipUnless(posix, "relpath requires 'posix' module")
     def test_relpath_bytes(self):
         (real_getcwdb, os.getcwdb) = (os.getcwdb, lambda: br"/home/user/bar")
         try:

--- a/Misc/NEWS.d/next/Core and Builtins/2024-04-27-14-39-02.gh-issue-118345.-TITAI.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2024-04-27-14-39-02.gh-issue-118345.-TITAI.rst
@@ -1,1 +1,1 @@
-Fix func:`ntpath.abspath` & func:`posixpath.abspath` for relative paths on the other platform`.
+Fix :func:`ntpath.abspath` & :func:`posixpath.abspath` for relative paths on the other platform`.

--- a/Misc/NEWS.d/next/Core and Builtins/2024-04-27-14-39-02.gh-issue-118345.-TITAI.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2024-04-27-14-39-02.gh-issue-118345.-TITAI.rst
@@ -1,0 +1,1 @@
+Fix func:`ntpath.abspath` & func:`posixpath.abspath` for relative paths on the other platform`.

--- a/Misc/NEWS.d/next/Core and Builtins/2024-04-27-14-39-02.gh-issue-118345.-TITAI.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2024-04-27-14-39-02.gh-issue-118345.-TITAI.rst
@@ -1,1 +1,1 @@
-Fix :func:`ntpath.abspath` & :func:`posixpath.abspath` for relative paths on the other platform`.
+Fix :func:`ntpath.abspath`, :func:`posixpath.abspath` & :func:`posixpath.realpath` for relative paths on the other platform`.


### PR DESCRIPTION
Ideally merged after #117855, then we don't need to check `os.name` for `posixpath.abspath()`.
It looks like we need to use if for `posixpath.realpath()` though.

<!-- gh-issue-number: gh-118345 -->
* Issue: gh-118345
<!-- /gh-issue-number -->
