### PR TITLE
gh-116767: fix crash on 'async with' with many context managers

### DIFF
--- a/Include/cpython/code.h
+++ b/Include/cpython/code.h
@@ -226,7 +226,7 @@ struct PyCodeObject _PyCode_DEF(1);
 */
 #define PY_PARSER_REQUIRES_FUTURE_KEYWORD
 
-#define CO_MAXBLOCKS 20 /* Max static block nesting within a function */
+#define CO_MAXBLOCKS 21 /* Max static block nesting within a function */
 
 PyAPI_DATA(PyTypeObject) PyCode_Type;
 

--- a/Lib/test/test_syntax.py
+++ b/Lib/test/test_syntax.py
@@ -2393,12 +2393,13 @@ if x:
             return code
 
         CO_MAXBLOCKS = 20  # static nesting limit of the compiler
+        MAX_MANAGERS = CO_MAXBLOCKS - 1  # One for the StopIteration block
 
-        for n in range(CO_MAXBLOCKS):
+        for n in range(MAX_MANAGERS):
             with self.subTest(f"within range: {n=}"):
                 compile(get_code(n), "<string>", "exec")
 
-        for n in range(CO_MAXBLOCKS, CO_MAXBLOCKS + 5):
+        for n in range(MAX_MANAGERS, MAX_MANAGERS + 5):
             with self.subTest(f"out of range: {n=}"):
                 self._check_error(get_code(n), "too many statically nested blocks")
 

--- a/Lib/test/test_syntax.py
+++ b/Lib/test/test_syntax.py
@@ -2418,12 +2418,13 @@ if x:
             return "".join(code)
 
         CO_MAXBLOCKS = 20  # static nesting limit of the compiler
+        MAX_MANAGERS = CO_MAXBLOCKS - 1  # One for the StopIteration block
 
-        for n in range(CO_MAXBLOCKS):
+        for n in range(MAX_MANAGERS):
             with self.subTest(f"within range: {n=}"):
                 compile(get_code(n), "<string>", "exec")
 
-        for n in range(CO_MAXBLOCKS, CO_MAXBLOCKS + 5):
+        for n in range(MAX_MANAGERS, MAX_MANAGERS + 5):
             with self.subTest(f"out of range: {n=}"):
                 self._check_error(get_code(n), "too many statically nested blocks")
 

--- a/Lib/test/test_syntax.py
+++ b/Lib/test/test_syntax.py
@@ -2392,7 +2392,7 @@ if x:
             code += "): yield a"
             return code
 
-        CO_MAXBLOCKS = 20  # static nesting limit of the compiler
+        CO_MAXBLOCKS = 21  # static nesting limit of the compiler
         MAX_MANAGERS = CO_MAXBLOCKS - 1  # One for the StopIteration block
 
         for n in range(MAX_MANAGERS):
@@ -2418,7 +2418,7 @@ if x:
             code.append("): yield a")
             return "".join(code)
 
-        CO_MAXBLOCKS = 20  # static nesting limit of the compiler
+        CO_MAXBLOCKS = 21  # static nesting limit of the compiler
         MAX_MANAGERS = CO_MAXBLOCKS - 1  # One for the StopIteration block
 
         for n in range(MAX_MANAGERS):
@@ -2563,7 +2563,8 @@ while 1:
                   while 20:
                    while 21:
                     while 22:
-                     break
+                     while 23:
+                      break
 """
         self._check_error(source, "too many statically nested blocks")
 

--- a/Misc/NEWS.d/next/Core and Builtins/2024-04-27-16-23-29.gh-issue-116767.z9UFpr.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2024-04-27-16-23-29.gh-issue-116767.z9UFpr.rst
@@ -1,0 +1,1 @@
+Fix crash in compiler on 'async with' that has many context managers.

--- a/Python/compile.c
+++ b/Python/compile.c
@@ -113,7 +113,8 @@ compiler IR.
 
 enum fblocktype { WHILE_LOOP, FOR_LOOP, TRY_EXCEPT, FINALLY_TRY, FINALLY_END,
                   WITH, ASYNC_WITH, HANDLER_CLEANUP, POP_VALUE, EXCEPTION_HANDLER,
-                  EXCEPTION_GROUP_HANDLER, ASYNC_COMPREHENSION_GENERATOR };
+                  EXCEPTION_GROUP_HANDLER, ASYNC_COMPREHENSION_GENERATOR,
+                  STOP_ITERATION };
 
 struct fblockinfo {
     enum fblocktype fb_type;
@@ -1503,6 +1504,7 @@ compiler_unwind_fblock(struct compiler *c, location *ploc,
         case EXCEPTION_HANDLER:
         case EXCEPTION_GROUP_HANDLER:
         case ASYNC_COMPREHENSION_GENERATOR:
+        case STOP_ITERATION:
             return SUCCESS;
 
         case FOR_LOOP:
@@ -2232,6 +2234,16 @@ compiler_function_body(struct compiler *c, stmt_ty s, int is_async, Py_ssize_t f
     c->u->u_metadata.u_argcount = asdl_seq_LEN(args->args);
     c->u->u_metadata.u_posonlyargcount = asdl_seq_LEN(args->posonlyargs);
     c->u->u_metadata.u_kwonlyargcount = asdl_seq_LEN(args->kwonlyargs);
+
+    NEW_JUMP_TARGET_LABEL(c, start);
+    USE_LABEL(c, start);
+    if (c->u->u_ste->ste_coroutine || c->u->u_ste->ste_generator) {
+        /* wrap_in_stopiteration_handler will push a block, so we need to account for that */
+        RETURN_IF_ERROR(
+            compiler_push_fblock(c, NO_LOCATION, STOP_ITERATION,
+                                 start, NO_LABEL, NULL));
+    }
+
     for (Py_ssize_t i = first_instr; i < asdl_seq_LEN(body); i++) {
         VISIT_IN_SCOPE(c, stmt, (stmt_ty)asdl_seq_GET(body, i));
     }
@@ -2240,6 +2252,7 @@ compiler_function_body(struct compiler *c, stmt_ty s, int is_async, Py_ssize_t f
             compiler_exit_scope(c);
             return ERROR;
         }
+        compiler_pop_fblock(c, STOP_ITERATION, start);
     }
     PyCodeObject *co = optimize_and_assemble(c, 1);
     compiler_exit_scope(c);

--- a/Python/compile.c
+++ b/Python/compile.c
@@ -2237,7 +2237,8 @@ compiler_function_body(struct compiler *c, stmt_ty s, int is_async, Py_ssize_t f
 
     NEW_JUMP_TARGET_LABEL(c, start);
     USE_LABEL(c, start);
-    if (c->u->u_ste->ste_coroutine || c->u->u_ste->ste_generator) {
+    bool add_stopiteration_handler = c->u->u_ste->ste_coroutine || c->u->u_ste->ste_generator;
+    if (add_stopiteration_handler) {
         /* wrap_in_stopiteration_handler will push a block, so we need to account for that */
         RETURN_IF_ERROR(
             compiler_push_fblock(c, NO_LOCATION, STOP_ITERATION,
@@ -2247,7 +2248,7 @@ compiler_function_body(struct compiler *c, stmt_ty s, int is_async, Py_ssize_t f
     for (Py_ssize_t i = first_instr; i < asdl_seq_LEN(body); i++) {
         VISIT_IN_SCOPE(c, stmt, (stmt_ty)asdl_seq_GET(body, i));
     }
-    if (c->u->u_ste->ste_coroutine || c->u->u_ste->ste_generator) {
+    if (add_stopiteration_handler) {
         if (wrap_in_stopiteration_handler(c) < 0) {
             compiler_exit_scope(c);
             return ERROR;

--- a/Python/flowgraph.c
+++ b/Python/flowgraph.c
@@ -263,7 +263,7 @@ basicblock_insert_instruction(basicblock *block, int pos, cfg_instr *instr) {
 }
 
 /* For debugging purposes only */
-#if 0
+#if 1
 static void
 dump_instr(cfg_instr *i)
 {

--- a/Python/flowgraph.c
+++ b/Python/flowgraph.c
@@ -263,7 +263,7 @@ basicblock_insert_instruction(basicblock *block, int pos, cfg_instr *instr) {
 }
 
 /* For debugging purposes only */
-#if 1
+#if 0
 static void
 dump_instr(cfg_instr *i)
 {


### PR DESCRIPTION
Fixes #116767.

<!-- gh-issue-number: gh-116767 -->
* Issue: gh-116767
<!-- /gh-issue-number -->
