### PR TITLE
gh-116622: Android sysconfig updates

### DIFF
--- a/Android/android-env.sh
+++ b/Android/android-env.sh
@@ -61,6 +61,12 @@ done
 export CFLAGS=""
 export LDFLAGS="-Wl,--build-id=sha1 -Wl,--no-rosegment"
 
+# Unlike Linux, Android does not implicitly use a dlopened library to resolve
+# relocations in subsequently-loaded libraries, even if RTLD_GLOBAL is used
+# (https://github.com/android/ndk/issues/1244). So any library that fails to
+# build with this flag, would also fail to load at runtime.
+LDFLAGS="$LDFLAGS -Wl,--no-undefined"
+
 # Many packages get away with omitting -lm on Linux, but Android is stricter.
 LDFLAGS="$LDFLAGS -lm"
 

--- a/Lib/sysconfig/__init__.py
+++ b/Lib/sysconfig/__init__.py
@@ -601,10 +601,22 @@ def get_platform():
     machine = machine.replace('/', '-')
 
     if osname[:5] == "linux":
-        # At least on Linux/Intel, 'machine' is the processor --
-        # i386, etc.
-        # XXX what about Alpha, SPARC, etc?
-        return  f"{osname}-{machine}"
+        if sys.platform == "android":
+            osname = "android"
+            release = get_config_var("ANDROID_API_LEVEL")
+
+            # Wheel tags use the ABI names from Android's own tools.
+            machine = {
+                "x86_64": "x86_64",
+                "i686": "x86",
+                "aarch64": "arm64_v8a",
+                "armv7l": "armeabi_v7a",
+            }[machine]
+        else:
+            # At least on Linux/Intel, 'machine' is the processor --
+            # i386, etc.
+            # XXX what about Alpha, SPARC, etc?
+            return  f"{osname}-{machine}"
     elif osname[:5] == "sunos":
         if release[0] >= "5":           # SunOS 5 == Solaris 2
             osname = "solaris"

--- a/Lib/test/test_sysconfig.py
+++ b/Lib/test/test_sysconfig.py
@@ -232,6 +232,11 @@ class TestSysConfig(unittest.TestCase):
         self.assertTrue(cvars)
 
     def test_get_platform(self):
+        # Check the actual platform returns something reasonable.
+        actual_platform = get_platform()
+        self.assertIsInstance(actual_platform, str)
+        self.assertTrue(actual_platform)
+
         # windows XP, 32bits
         os.name = 'nt'
         sys.version = ('2.4.4 (#71, Oct 18 2006, 08:34:43) '
@@ -346,6 +351,21 @@ class TestSysConfig(unittest.TestCase):
                     '#1 Mon Apr 30 17:25:38 CEST 2007', 'i686'))
 
         self.assertEqual(get_platform(), 'linux-i686')
+
+        # Android
+        os.name = 'posix'
+        sys.platform = 'android'
+        get_config_vars()['ANDROID_API_LEVEL'] = 9
+        for machine, abi in {
+            'x86_64': 'x86_64',
+            'i686': 'x86',
+            'aarch64': 'arm64_v8a',
+            'armv7l': 'armeabi_v7a',
+        }.items():
+            with self.subTest(machine):
+                self._set_uname(('Linux', 'localhost', '3.18.91+',
+                                '#1 Tue Jan 9 20:35:43 UTC 2018', machine))
+                self.assertEqual(get_platform(), f'android-9-{abi}')
 
         # XXX more platforms to tests here
 

--- a/Misc/NEWS.d/next/Library/2024-04-27-20-34-56.gh-issue-116622.YlQgXv.rst
+++ b/Misc/NEWS.d/next/Library/2024-04-27-20-34-56.gh-issue-116622.YlQgXv.rst
@@ -1,0 +1,2 @@
+On Android, :any:`sysconfig.get_platform` now returns the format specified
+by :pep:`738`.

--- a/configure
+++ b/configure
@@ -7011,8 +7011,13 @@ case $host/$ac_cv_cc_name in #(
     PY_SUPPORT_TIER=3 ;; #(
     aarch64-apple-ios*/clang) :
     PY_SUPPORT_TIER=3 ;; #(
+    aarch64-*-linux-android/clang) :
+    PY_SUPPORT_TIER=3 ;; #(
+    x86_64-*-linux-android/clang) :
+    PY_SUPPORT_TIER=3 ;; #(
   *) :
-      PY_SUPPORT_TIER=0
+
+  PY_SUPPORT_TIER=0
  ;;
 esac
 

--- a/configure.ac
+++ b/configure.ac
@@ -1148,6 +1148,9 @@ AS_CASE([$host/$ac_cv_cc_name],
   [x86_64-*-freebsd*/clang],         [PY_SUPPORT_TIER=3], dnl FreeBSD on AMD64
   [aarch64-apple-ios*-simulator/clang],   [PY_SUPPORT_TIER=3], dnl iOS Simulator on arm64
   [aarch64-apple-ios*/clang],             [PY_SUPPORT_TIER=3], dnl iOS on ARM64
+  [aarch64-*-linux-android/clang],   [PY_SUPPORT_TIER=3], dnl Android on ARM64
+  [x86_64-*-linux-android/clang],    [PY_SUPPORT_TIER=3], dnl Android on AMD64
+
   [PY_SUPPORT_TIER=0]
 )
 


### PR DESCRIPTION
This is the final feature PR for adding Android support. All that remains after this is test infrastructure and documentation updates.

* Implemented `sysconfig.get_platform` in the format specified by [PEP 738](https://peps.python.org/pep-0738/#packaging).

* Added the `-Wl,--no-undefined` linker flag, both for CPython itself, and for third-party packages built using the sysconfig LDFLAGS. Based on past experience of building packages for Android, this can save a lot of time by detecting problems at compile time which would otherwise happen at runtime.

* Added Android to the Tier 3 support list.

<!-- gh-issue-number: gh-116622 -->
* Issue: gh-116622
<!-- /gh-issue-number -->
