### PR TITLE
gh-101100: Fix Sphinx warnings in `library/faulthandler.rst`

### DIFF
--- a/Doc/library/faulthandler.rst
+++ b/Doc/library/faulthandler.rst
@@ -10,14 +10,15 @@
 
 This module contains functions to dump Python tracebacks explicitly, on a fault,
 after a timeout, or on a user signal. Call :func:`faulthandler.enable` to
-install fault handlers for the :const:`SIGSEGV`, :const:`SIGFPE`,
-:const:`SIGABRT`, :const:`SIGBUS`, and :const:`SIGILL` signals. You can also
+install fault handlers for the :const:`~signal.SIGSEGV`,
+:const:`~signal.SIGFPE`, :const:`~signal.SIGABRT`, :const:`~signal.SIGBUS`, and
+:const:`~signal.SIGILL` signals. You can also
 enable them at startup by setting the :envvar:`PYTHONFAULTHANDLER` environment
 variable or by using the :option:`-X` ``faulthandler`` command line option.
 
 The fault handler is compatible with system fault handlers like Apport or the
 Windows fault handler. The module uses an alternative stack for signal handlers
-if the :c:func:`sigaltstack` function is available. This allows it to dump the
+if the :c:func:`!sigaltstack` function is available. This allows it to dump the
 traceback even on a stack overflow.
 
 The fault handler is called on catastrophic cases and therefore can only use
@@ -70,8 +71,9 @@ Fault handler state
 
 .. function:: enable(file=sys.stderr, all_threads=True)
 
-   Enable the fault handler: install handlers for the :const:`SIGSEGV`,
-   :const:`SIGFPE`, :const:`SIGABRT`, :const:`SIGBUS` and :const:`SIGILL`
+   Enable the fault handler: install handlers for the :const:`~signal.SIGSEGV`,
+   :const:`~signal.SIGFPE`, :const:`~signal.SIGABRT`, :const:`~signal.SIGBUS`
+   and :const:`~signal.SIGILL`
    signals to dump the Python traceback. If *all_threads* is ``True``,
    produce tracebacks for every running thread. Otherwise, dump only the current
    thread.
@@ -106,8 +108,8 @@ Dumping the tracebacks after a timeout
 
    Dump the tracebacks of all threads, after a timeout of *timeout* seconds, or
    every *timeout* seconds if *repeat* is ``True``.  If *exit* is ``True``, call
-   :c:func:`_exit` with status=1 after dumping the tracebacks.  (Note
-   :c:func:`_exit` exits the process immediately, which means it doesn't do any
+   :c:func:`!_exit` with status=1 after dumping the tracebacks.  (Note
+   :c:func:`!_exit` exits the process immediately, which means it doesn't do any
    cleanup like flushing file buffers.) If the function is called twice, the new
    call replaces previous parameters and resets the timeout. The timer has a
    sub-second resolution.

--- a/Doc/tools/.nitignore
+++ b/Doc/tools/.nitignore
@@ -28,7 +28,6 @@ Doc/library/email.errors.rst
 Doc/library/email.parser.rst
 Doc/library/email.policy.rst
 Doc/library/exceptions.rst
-Doc/library/faulthandler.rst
 Doc/library/functools.rst
 Doc/library/http.cookiejar.rst
 Doc/library/http.server.rst


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
Fix 13 warnings:
```
library/faulthandler.rst:11: WARNING: py:const reference target not found: SIGSEGV
library/faulthandler.rst:11: WARNING: py:const reference target not found: SIGFPE
library/faulthandler.rst:11: WARNING: py:const reference target not found: SIGABRT
library/faulthandler.rst:11: WARNING: py:const reference target not found: SIGBUS
library/faulthandler.rst:11: WARNING: py:const reference target not found: SIGILL
library/faulthandler.rst:18: WARNING: c:func reference target not found: sigaltstack
library/faulthandler.rst:73: WARNING: py:const reference target not found: SIGSEGV
library/faulthandler.rst:73: WARNING: py:const reference target not found: SIGFPE
library/faulthandler.rst:73: WARNING: py:const reference target not found: SIGABRT
library/faulthandler.rst:73: WARNING: py:const reference target not found: SIGBUS
library/faulthandler.rst:73: WARNING: py:const reference target not found: SIGILL
library/faulthandler.rst:107: WARNING: c:func reference target not found: _exit
library/faulthandler.rst:107: WARNING: c:func reference target not found: _exit
```

Link the `SIG*` `py:const`s to the `signal` module, and add `!` to the `c:func`s which I don't think need documenting.


<!-- gh-issue-number: gh-101100 -->
* Issue: gh-101100
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--118353.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->