### PR TITLE
Uncomment one grammar test

### DIFF
--- a/Lib/test/test_grammar.py
+++ b/Lib/test/test_grammar.py
@@ -164,7 +164,7 @@ class TokenTests(unittest.TestCase):
         x = 3.14
         x = 314.
         x = 0.314
-        # XXX x = 000.314
+        x = 000.314
         x = .314
         x = 3e14
         x = 3E14


### PR DESCRIPTION
This test was commented for 18 years :)
Since https://github.com/python/cpython/blame/51aefc5bf907ddffaaf083ded0de773adcdf08c8/Lib/test/test_grammar.py#L167C19-L167C23

I don't see a point in keeping it commented. There are no other tests for floats with multiple starting zeros in this file. Let's enable it!