### PR TITLE
gh-101100: Fix Sphinx warnings in `whatsnew/3.9.rst`

### DIFF
--- a/Doc/whatsnew/3.7.rst
+++ b/Doc/whatsnew/3.7.rst
@@ -669,8 +669,8 @@ include:
 * The new :func:`asyncio.current_task` function returns the currently running
   :class:`~asyncio.Task` instance, and the new :func:`asyncio.all_tasks`
   function returns a set of all existing ``Task`` instances in a given loop.
-  The :meth:`Task.current_task() <asyncio.Task.current_task>` and
-  :meth:`Task.all_tasks() <asyncio.Task.all_tasks>` methods have been deprecated.
+  The :meth:`!Task.current_task` and
+  :meth:`!Task.all_tasks` methods have been deprecated.
   (Contributed by Andrew Svetlov in :issue:`32250`.)
 
 * The new *provisional* :class:`~asyncio.BufferedProtocol` class allows
@@ -1969,7 +1969,7 @@ asynchronous context manager must be used in order to acquire and release
 the synchronization resource.
 (Contributed by Andrew Svetlov in :issue:`32253`.)
 
-The :meth:`asyncio.Task.current_task` and :meth:`asyncio.Task.all_tasks`
+The :meth:`!asyncio.Task.current_task` and :meth:`!asyncio.Task.all_tasks`
 methods have been deprecated.
 (Contributed by Andrew Svetlov in :issue:`32250`.)
 

--- a/Doc/whatsnew/3.9.rst
+++ b/Doc/whatsnew/3.9.rst
@@ -81,13 +81,13 @@ Interpreter improvements:
 * a number of Python builtins (range, tuple, set, frozenset, list, dict) are
   now sped up using :pep:`590` vectorcall;
 * garbage collection does not block on resurrected objects;
-* a number of Python modules (:mod:`_abc`, :mod:`!audioop`, :mod:`_bz2`,
-  :mod:`_codecs`, :mod:`_contextvars`, :mod:`!_crypt`, :mod:`_functools`,
-  :mod:`_json`, :mod:`_locale`, :mod:`math`, :mod:`operator`, :mod:`resource`,
-  :mod:`time`, :mod:`_weakref`) now use multiphase initialization as defined
+* a number of Python modules (:mod:`!_abc`, :mod:`!audioop`, :mod:`!_bz2`,
+  :mod:`!_codecs`, :mod:`!_contextvars`, :mod:`!_crypt`, :mod:`!_functools`,
+  :mod:`!_json`, :mod:`!_locale`, :mod:`math`, :mod:`operator`, :mod:`resource`,
+  :mod:`time`, :mod:`!_weakref`) now use multiphase initialization as defined
   by PEP 489;
 * a number of standard library modules (:mod:`!audioop`, :mod:`ast`, :mod:`grp`,
-  :mod:`_hashlib`, :mod:`pwd`, :mod:`_posixsubprocess`, :mod:`random`,
+  :mod:`!_hashlib`, :mod:`pwd`, :mod:`!_posixsubprocess`, :mod:`random`,
   :mod:`select`, :mod:`struct`, :mod:`termios`, :mod:`zlib`) are now using
   the stable ABI defined by PEP 384.
 
@@ -203,7 +203,7 @@ The :mod:`ast` module uses the new parser and produces the same AST as
 the old parser.
 
 In Python 3.10, the old parser will be deleted and so will all
-functionality that depends on it (primarily the :mod:`parser` module,
+functionality that depends on it (primarily the :mod:`!parser` module,
 which has long been deprecated).  In Python 3.9 *only*, you can switch
 back to the LL(1) parser using a command line switch (``-X
 oldparser``) or an environment variable (``PYTHONOLDPARSER=1``).
@@ -366,7 +366,7 @@ wait until the cancellation is complete also in the case when *timeout* is
 <= 0, like it does with positive timeouts.
 (Contributed by Elvis Pranskevichus in :issue:`32751`.)
 
-:mod:`asyncio` now raises :exc:`TyperError` when calling incompatible
+:mod:`asyncio` now raises :exc:`TypeError` when calling incompatible
 methods with an :class:`ssl.SSLSocket` socket.
 (Contributed by Ido Michael in :issue:`37404`.)
 
@@ -589,7 +589,7 @@ a non-blocking socket. (Contributed by Donghee Na in :issue:`39259`.)
 os
 --
 
-Added :const:`~os.CLD_KILLED` and :const:`~os.CLD_STOPPED` for :attr:`si_code`.
+Added :const:`~os.CLD_KILLED` and :const:`~os.CLD_STOPPED` for :attr:`!si_code`.
 (Contributed by Donghee Na in :issue:`38493`.)
 
 Exposed the Linux-specific :func:`os.pidfd_open` (:issue:`38692`) and
@@ -861,7 +861,7 @@ Deprecated
   Python versions it will raise a :exc:`TypeError` for all floats.
   (Contributed by Serhiy Storchaka in :issue:`37315`.)
 
-* The :mod:`parser` and :mod:`symbol` modules are deprecated and will be
+* The :mod:`!parser` and :mod:`!symbol` modules are deprecated and will be
   removed in future versions of Python. For the majority of use cases,
   users can leverage the Abstract Syntax Tree (AST) generation and compilation
   stage, using the :mod:`ast` module.
@@ -889,7 +889,7 @@ Deprecated
   it for writing and silencing a warning.
   (Contributed by Serhiy Storchaka in :issue:`28286`.)
 
-* Deprecated the ``split()`` method of :class:`_tkinter.TkappType` in
+* Deprecated the ``split()`` method of :class:`!_tkinter.TkappType` in
   favour of the ``splitlist()`` method which has more consistent and
   predicable behavior.
   (Contributed by Serhiy Storchaka in :issue:`38371`.)
@@ -898,11 +898,11 @@ Deprecated
   deprecated and will be removed in version 3.11.
   (Contributed by Yury Selivanov and Kyle Stanley in :issue:`34790`.)
 
-* binhex4 and hexbin4 standards are now deprecated. The :mod:`binhex` module
+* binhex4 and hexbin4 standards are now deprecated. The :mod:`!binhex` module
   and the following :mod:`binascii` functions are now deprecated:
 
-  * :func:`~binascii.b2a_hqx`, :func:`~binascii.a2b_hqx`
-  * :func:`~binascii.rlecode_hqx`, :func:`~binascii.rledecode_hqx`
+  * :func:`!b2a_hqx`, :func:`!a2b_hqx`
+  * :func:`!rlecode_hqx`, :func:`!rledecode_hqx`
 
   (Contributed by Victor Stinner in :issue:`39353`.)
 
@@ -950,7 +950,7 @@ Deprecated
 Removed
 =======
 
-* The erroneous version at :data:`unittest.mock.__version__` has been removed.
+* The erroneous version at :data:`!unittest.mock.__version__` has been removed.
 
 * :class:`!nntplib.NNTP`: ``xpath()`` and ``xgtitle()`` methods have been removed.
   These methods are deprecated since Python 3.3. Generally, these extensions
@@ -987,7 +987,7 @@ Removed
   removed. They were deprecated since Python 3.7.
   (Contributed by Victor Stinner in :issue:`37320`.)
 
-* The :meth:`~threading.Thread.isAlive()` method of :class:`threading.Thread`
+* The :meth:`!isAlive()` method of :class:`threading.Thread`
   has been removed. It was deprecated since Python 3.8.
   Use :meth:`~threading.Thread.is_alive()` instead.
   (Contributed by Donghee Na in :issue:`37804`.)
@@ -1035,7 +1035,7 @@ Removed
   ``asyncio.Condition`` and ``asyncio.Semaphore``.
   (Contributed by Andrew Svetlov in :issue:`34793`.)
 
-* The :func:`sys.getcounts` function, the ``-X showalloccount`` command line
+* The :func:`!sys.getcounts` function, the ``-X showalloccount`` command line
   option and the ``show_alloc_count`` field of the C structure
   :c:type:`PyConfig` have been removed. They required a special Python build by
   defining ``COUNT_ALLOCS`` macro.
@@ -1046,11 +1046,11 @@ Removed
   the ``__annotations__`` attribute instead.
   (Contributed by Serhiy Storchaka in :issue:`40182`.)
 
-* The :meth:`symtable.SymbolTable.has_exec` method has been removed. It was
+* The :meth:`!symtable.SymbolTable.has_exec` method has been removed. It was
   deprecated since 2006, and only returning ``False`` when it's called.
   (Contributed by Batuhan Taskaya in :issue:`40208`)
 
-* The :meth:`asyncio.Task.current_task` and :meth:`asyncio.Task.all_tasks`
+* The :meth:`!asyncio.Task.current_task` and :meth:`!asyncio.Task.all_tasks`
   have been removed. They were deprecated since Python 3.7 and you can use
   :func:`asyncio.current_task` and :func:`asyncio.all_tasks` instead.
   (Contributed by Rémi Lapeyre in :issue:`40967`)
@@ -1230,7 +1230,7 @@ Build Changes
 * The ``COUNT_ALLOCS`` special build macro has been removed.
   (Contributed by Victor Stinner in :issue:`39489`.)
 
-* On non-Windows platforms, the :c:func:`setenv` and :c:func:`unsetenv`
+* On non-Windows platforms, the :c:func:`!setenv` and :c:func:`!unsetenv`
   functions are now required to build Python.
   (Contributed by Victor Stinner in :issue:`39395`.)
 
@@ -1319,7 +1319,7 @@ New Features
   the garbage collector respectively.
   (Contributed by Pablo Galindo Salgado in :issue:`40241`.)
 
-* Added :c:func:`_PyObject_FunctionStr` to get a user-friendly string
+* Added :c:func:`!_PyObject_FunctionStr` to get a user-friendly string
   representation of a function-like object.
   (Patch by Jeroen Demeyer in :issue:`37645`.)
 
@@ -1361,7 +1361,7 @@ Porting to Python 3.9
   and refers to a constant string.
   (Contributed by Serhiy Storchaka in :issue:`38650`.)
 
-* The :c:type:`PyGC_Head` structure is now opaque. It is only defined in the
+* The :c:type:`!PyGC_Head` structure is now opaque. It is only defined in the
   internal C API (``pycore_gc.h``).
   (Contributed by Victor Stinner in :issue:`40241`.)
 
@@ -1384,12 +1384,12 @@ Porting to Python 3.9
 
   * :c:func:`PyObject_IS_GC` macro was converted to a function.
 
-  * The :c:func:`PyObject_NEW` macro becomes an alias to the
-    :c:macro:`PyObject_New` macro, and the :c:func:`PyObject_NEW_VAR` macro
+  * The :c:func:`!PyObject_NEW` macro becomes an alias to the
+    :c:macro:`PyObject_New` macro, and the :c:func:`!PyObject_NEW_VAR` macro
     becomes an alias to the :c:macro:`PyObject_NewVar` macro. They no longer
     access directly the :c:member:`PyTypeObject.tp_basicsize` member.
 
-  * :c:func:`PyObject_GET_WEAKREFS_LISTPTR` macro was converted to a function:
+  * :c:func:`!PyObject_GET_WEAKREFS_LISTPTR` macro was converted to a function:
     the macro accessed directly the :c:member:`PyTypeObject.tp_weaklistoffset`
     member.
 

--- a/Misc/NEWS.d/3.10.0a1.rst
+++ b/Misc/NEWS.d/3.10.0a1.rst
@@ -1861,8 +1861,8 @@ bundled versions of ``pip`` and ``setuptools``.  Patch by Krzysztof Konopko.
 .. nonce: _dx3OO
 .. section: Library
 
-Removed :meth:`asyncio.Task.current_task` and
-:meth:`asyncio.Task.all_tasks`. Patch contributed by Rémi Lapeyre.
+Removed :meth:`!asyncio.Task.current_task` and
+:meth:`!asyncio.Task.all_tasks`. Patch contributed by Rémi Lapeyre.
 
 ..
 

--- a/Misc/NEWS.d/3.11.0a4.rst
+++ b/Misc/NEWS.d/3.11.0a4.rst
@@ -7,7 +7,7 @@
 :c:func:`Py_EndInterpreter` now explicitly untracks all objects currently
 tracked by the GC. Previously, if an object was used later by another
 interpreter, calling :c:func:`PyObject_GC_UnTrack` on the object crashed if
-the previous or the next object of the :c:type:`PyGC_Head` structure became
+the previous or the next object of the :c:type:`!PyGC_Head` structure became
 a dangling pointer. Patch by Victor Stinner.
 
 ..

--- a/Misc/NEWS.d/3.9.0a1.rst
+++ b/Misc/NEWS.d/3.9.0a1.rst
@@ -5616,7 +5616,7 @@ heap type
 .. nonce: 4DcUaI
 .. section: C API
 
-Add :c:func:`_PyObject_FunctionStr` to get a user-friendly string
+Add :c:func:`!_PyObject_FunctionStr` to get a user-friendly string
 representation of a function-like object. Patch by Jeroen Demeyer.
 
 ..

--- a/Misc/NEWS.d/3.9.0a2.rst
+++ b/Misc/NEWS.d/3.9.0a2.rst
@@ -844,7 +844,7 @@ test.regrtest now can receive a list of test patterns to ignore (using the
 .. nonce: cNsA7S
 .. section: Build
 
-:mod:`asyncio` now raises :exc:`TyperError` when calling incompatible
+:mod:`asyncio` now raises :exc:`TypeError` when calling incompatible
 methods with an :class:`ssl.SSLSocket` socket.  Patch by Ido Michael.
 
 ..

--- a/Misc/NEWS.d/3.9.0a6.rst
+++ b/Misc/NEWS.d/3.9.0a6.rst
@@ -564,7 +564,7 @@ Implement traverse and clear slots in _abc._abc_data type.
 .. nonce: 3rO_q7
 .. section: Library
 
-Remove deprecated :meth:`symtable.SymbolTable.has_exec`.
+Remove deprecated :meth:`!symtable.SymbolTable.has_exec`.
 
 ..
 
@@ -1118,7 +1118,7 @@ into an exit code.
 .. nonce: _FOf7E
 .. section: C API
 
-Move the :c:type:`PyGC_Head` structure to the internal C API.
+Move the :c:type:`!PyGC_Head` structure to the internal C API.
 
 ..
 
@@ -1149,8 +1149,8 @@ the garbage collector respectively. Patch by Pablo Galindo.
 .. nonce: Seuh3D
 .. section: C API
 
-The :c:func:`PyObject_NEW` macro becomes an alias to the
-:c:func:`PyObject_New` macro, and the :c:func:`PyObject_NEW_VAR` macro
+The :c:func:`!PyObject_NEW` macro becomes an alias to the
+:c:func:`PyObject_New` macro, and the :c:func:`!PyObject_NEW_VAR` macro
 becomes an alias to the :c:func:`PyObject_NewVar` macro, to hide
 implementation details. They no longer access directly the
 :c:member:`PyTypeObject.tp_basicsize` member.
@@ -1174,7 +1174,7 @@ used.
 .. nonce: 6nFYbY
 .. section: C API
 
-Convert the :c:func:`PyObject_GET_WEAKREFS_LISTPTR` macro to a function to
+Convert the :c:func:`!PyObject_GET_WEAKREFS_LISTPTR` macro to a function to
 hide implementation details: the macro accessed directly to the
 :c:member:`PyTypeObject.tp_weaklistoffset` member.
 


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

Fix 34 warnings in `whatsnew/3.9.rst`:

```
whatsnew/3.9.rst:84: WARNING: py:mod reference target not found: _abc
whatsnew/3.9.rst:84: WARNING: py:mod reference target not found: _bz2
whatsnew/3.9.rst:84: WARNING: py:mod reference target not found: _codecs
whatsnew/3.9.rst:84: WARNING: py:mod reference target not found: _contextvars
whatsnew/3.9.rst:84: WARNING: py:mod reference target not found: _functools
whatsnew/3.9.rst:84: WARNING: py:mod reference target not found: _json
whatsnew/3.9.rst:84: WARNING: py:mod reference target not found: _locale
whatsnew/3.9.rst:84: WARNING: py:mod reference target not found: _weakref
whatsnew/3.9.rst:89: WARNING: py:mod reference target not found: _hashlib
whatsnew/3.9.rst:89: WARNING: py:mod reference target not found: _posixsubprocess
whatsnew/3.9.rst:205: WARNING: py:mod reference target not found: parser
whatsnew/3.9.rst:369: WARNING: py:exc reference target not found: TyperError
whatsnew/3.9.rst:592: WARNING: py:attr reference target not found: si_code
whatsnew/3.9.rst:864: WARNING: py:mod reference target not found: parser
whatsnew/3.9.rst:864: WARNING: py:mod reference target not found: symbol
whatsnew/3.9.rst:892: WARNING: py:class reference target not found: _tkinter.TkappType
whatsnew/3.9.rst:901: WARNING: py:mod reference target not found: binhex
whatsnew/3.9.rst:904: WARNING: py:func reference target not found: binascii.b2a_hqx
whatsnew/3.9.rst:904: WARNING: py:func reference target not found: binascii.a2b_hqx
whatsnew/3.9.rst:905: WARNING: py:func reference target not found: binascii.rlecode_hqx
whatsnew/3.9.rst:905: WARNING: py:func reference target not found: binascii.rledecode_hqx
whatsnew/3.9.rst:953: WARNING: py:data reference target not found: unittest.mock.__version__
whatsnew/3.9.rst:990: WARNING: py:meth reference target not found: threading.Thread.isAlive
whatsnew/3.9.rst:1038: WARNING: py:func reference target not found: sys.getcounts
whatsnew/3.9.rst:1049: WARNING: py:meth reference target not found: symtable.SymbolTable.has_exec
whatsnew/3.9.rst:1053: WARNING: py:meth reference target not found: asyncio.Task.current_task
whatsnew/3.9.rst:1053: WARNING: py:meth reference target not found: asyncio.Task.all_tasks
whatsnew/3.9.rst:1233: WARNING: c:func reference target not found: setenv
whatsnew/3.9.rst:1233: WARNING: c:func reference target not found: unsetenv
whatsnew/3.9.rst:1322: WARNING: c:func reference target not found: _PyObject_FunctionStr
whatsnew/3.9.rst:1364: WARNING: c:type reference target not found: PyGC_Head
whatsnew/3.9.rst:1387: WARNING: c:func reference target not found: PyObject_NEW
whatsnew/3.9.rst:1387: WARNING: c:func reference target not found: PyObject_NEW_VAR
whatsnew/3.9.rst:1392: WARNING: c:func reference target not found: PyObject_GET_WEAKREFS_LISTPTR
```

Plus related fixes in other files.

These 6 remain, which could benefit from being documented, will leave for a later decision:

```
whatsnew/3.9.rst:426: WARNING: py:const reference target not found: fcntl.F_OFD_GETLK
whatsnew/3.9.rst:426: WARNING: py:const reference target not found: fcntl.F_OFD_SETLK
whatsnew/3.9.rst:426: WARNING: py:const reference target not found: fcntl.F_OFD_SETLKW
whatsnew/3.9.rst:646: WARNING: py:attr reference target not found: random.Random.randbytes
whatsnew/3.9.rst:778: WARNING: py:func reference target not found: set.difference_update
whatsnew/3.9.rst:1140: WARNING: py:func reference target not found: encodings.normalize_encoding
```



<!-- gh-issue-number: gh-101100 -->
* Issue: gh-101100
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--118364.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->