### PR TITLE
gh-118374: Add ``ctx`` argument to ``ast.Name`` calls

### DIFF
--- a/Lib/test/test_ast.py
+++ b/Lib/test/test_ast.py
@@ -1353,13 +1353,13 @@ Module(
             [],
             [ast.keyword('a', ast.Constant(None))],
             [],
-            [ast.Name('dataclass')],
+            [ast.Name('dataclass', ctx=ast.Load())],
         )
         self.assertEqual(ast.dump(node),
-            "ClassDef(name='T', keywords=[keyword(arg='a', value=Constant(value=None))], decorator_list=[Name(id='dataclass')])",
+            "ClassDef(name='T', keywords=[keyword(arg='a', value=Constant(value=None))], decorator_list=[Name(id='dataclass', ctx=Load())])",
         )
         self.assertEqual(ast.dump(node, annotate_fields=False),
-            "ClassDef('T', [], [keyword('a', Constant(None))], [], [Name('dataclass')])",
+            "ClassDef('T', [], [keyword('a', Constant(None))], [], [Name('dataclass', Load())])",
         )
 
     def test_dump_show_empty(self):


### PR DESCRIPTION
Before this PR:
```python
./python.exe -m test -q test_ast
Using random seed: 2061872940
0:00:00 load avg: 4.08 Run 1 test sequentially
/Users/admin/Projects/cpython/Lib/test/test_ast.py:1356: DeprecationWarning: Name.__init__ missing 1 required positional argument: 'ctx'. This will become an error in Python 3.15.
  [ast.Name('dataclass')],

== Tests result: SUCCESS ==

Total duration: 3.3 sec
Total tests: run=168 skipped=1
Total test files: run=1/1
Result: SUCCESS
```

After this PR:
```python
./python.exe -m test -q test_ast                     
Using random seed: 491163465
0:00:00 load avg: 6.26 Run 1 test sequentially

== Tests result: SUCCESS ==

Total duration: 955 ms
Total tests: run=168 skipped=1
Total test files: run=1/1
Result: SUCCESS
```


<!-- gh-issue-number: gh-118374 -->
* Issue: gh-118374
<!-- /gh-issue-number -->
