### PR TITLE
Argument Clinic: remove --limited command line option

### DIFF
--- a/Lib/test/test_clinic.py
+++ b/Lib/test/test_clinic.py
@@ -724,7 +724,7 @@ class ParseFileUnitTest(TestCase):
     ):
         errmsg = re.escape(dedent(expected_error).strip())
         with self.assertRaisesRegex(ClinicError, errmsg):
-            parse_file(filename, limited_capi=False)
+            parse_file(filename)
 
     def test_parse_file_no_extension(self) -> None:
         self.expect_parsing_failure(

--- a/Tools/clinic/libclinic/cli.py
+++ b/Tools/clinic/libclinic/cli.py
@@ -49,7 +49,6 @@ extensions['py'] = PythonLanguage
 def parse_file(
         filename: str,
         *,
-        limited_capi: bool,
         output: str | None = None,
         verify: bool = True,
 ) -> None:
@@ -73,6 +72,7 @@ def parse_file(
     if not find_start_re.search(raw):
         return
 
+    limited_capi = False
     if LIMITED_CAPI_REGEX.search(raw):
         limited_capi = True
 
@@ -112,8 +112,6 @@ For more information see https://devguide.python.org/development-tools/clinic/""
     cmdline.add_argument("--exclude", type=str, action="append",
                          help=("a file to exclude in --make mode; "
                                "can be given multiple times"))
-    cmdline.add_argument("--limited", dest="limited_capi", action='store_true',
-                         help="use the Limited C API")
     cmdline.add_argument("filename", metavar="FILE", type=str, nargs="*",
                          help="the list of files to process")
     return cmdline
@@ -202,8 +200,7 @@ def run_clinic(parser: argparse.ArgumentParser, ns: argparse.Namespace) -> None:
                     continue
                 if ns.verbose:
                     print(path)
-                parse_file(path,
-                           verify=not ns.force, limited_capi=ns.limited_capi)
+                parse_file(path, verify=not ns.force)
         return
 
     if not ns.filename:
@@ -215,8 +212,7 @@ def run_clinic(parser: argparse.ArgumentParser, ns: argparse.Namespace) -> None:
     for filename in ns.filename:
         if ns.verbose:
             print(filename)
-        parse_file(filename, output=ns.output,
-                   verify=not ns.force, limited_capi=ns.limited_capi)
+        parse_file(filename, output=ns.output, verify=not ns.force)
 
 
 def main(argv: list[str] | None = None) -> NoReturn:


### PR DESCRIPTION
This option is not used and using it can be misleading. C files targeting the limited C API should use instead:

  #define Py_LIMITED_API 0x030c0000

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
