### PR TITLE
gh-88494: Reduce CLOCK_RES to 1 ms in tests

### DIFF
--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -84,9 +84,9 @@ if support.HAVE_ASAN_FORK_BUG:
     raise unittest.SkipTest("libasan has a pthread_create() dead lock related to thread+fork")
 
 
-# gh-110666: Tolerate a difference of 100 ms when comparing timings
+# gh-110666: Tolerate a difference of 1 ms when comparing timings
 # (clock resolution)
-CLOCK_RES = 0.100
+CLOCK_RES = 0.001
 
 
 def latin(s):

--- a/Lib/test/test_asyncio/test_windows_events.py
+++ b/Lib/test/test_asyncio/test_windows_events.py
@@ -177,6 +177,10 @@ class ProactorTests(WindowsEventsTestCase):
         event = _overlapped.CreateEvent(None, True, False, None)
         self.addCleanup(_winapi.CloseHandle, event)
 
+        # RegisterWaitForSingleObject() has a resolution of 15.6 ms.
+        # Tolerate 50 ms difference when comparing timings.
+        CLOCK_RES = 0.050
+
         # Wait for unset event with 0.5s timeout;
         # result should be False at timeout
         timeout = 0.5
@@ -187,7 +191,7 @@ class ProactorTests(WindowsEventsTestCase):
 
         self.assertEqual(done, False)
         self.assertFalse(fut.result())
-        self.assertGreaterEqual(elapsed, timeout - test_utils.CLOCK_RES)
+        self.assertGreaterEqual(elapsed, timeout - CLOCK_RES)
 
         _overlapped.SetEvent(event)
 

--- a/Lib/test/test_asyncio/utils.py
+++ b/Lib/test/test_asyncio/utils.py
@@ -36,10 +36,8 @@ from test.support import socket_helper
 from test.support import threading_helper
 
 
-# Use the maximum known clock resolution (gh-75191, gh-110088): Windows
-# GetTickCount64() has a resolution of 15.6 ms. Use 50 ms to tolerate rounding
-# issues.
-CLOCK_RES = 0.050
+# Tolerate 1 ms difference when comparing timings.
+CLOCK_RES = 0.001
 
 
 def data_file(*filename):

--- a/Lib/test/test_capi/test_time.py
+++ b/Lib/test/test_capi/test_time.py
@@ -9,7 +9,7 @@ PyTime_MAX = _testcapi.PyTime_MAX
 SEC_TO_NS = 10 ** 9
 DAY_TO_SEC = (24 * 60 * 60)
 # Worst clock resolution: maximum delta between two clock reads.
-CLOCK_RES = 0.050
+CLOCK_RES = 0.001
 
 
 class CAPITest(unittest.TestCase):


### PR DESCRIPTION
On Windows, time.monotonic() now calls QueryPerformanceCounter() which has a resolution of 100 ns. Reduce CLOCK_RES from 50 or 100 ms to 1 ms.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-88494 -->
* Issue: gh-88494
<!-- /gh-issue-number -->
