### PR TITLE
gh-118401: Docs: Use Sphinx short options

### DIFF
--- a/.github/workflows/reusable-docs.yml
+++ b/.github/workflows/reusable-docs.yml
@@ -55,7 +55,7 @@ jobs:
       run: |
         set -Eeuo pipefail
         # Build docs with the '-n' (nit-picky) option; write warnings to file
-        make -C Doc/ PYTHON=../python SPHINXOPTS="--quiet --nitpicky --fail-on-warning --keep-going --warning-file sphinx-warnings.txt" html
+        make -C Doc/ PYTHON=../python SPHINXOPTS="-q -n -W --keep-going -w sphinx-warnings.txt" html
     - name: 'Check warnings'
       if: github.event_name == 'pull_request'
       run: |


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

On PRs which haven't synced with `main` yet, they're still installing Sphinx 7.2 instead of 7.3. That's fine.

But when the CI runs, GitHub is using the workflow from `main` that has the 7.3-only long options, and not the workflow from their own branch that has the 7.2-and-7.3 short options. This is surprising.

Quick fix: they can update their PR branches with `main`, but this will be disruptive for more PRs.

Better fix: keep short options in the workflow for longer, perhaps until we upgrade Sphinx to 7.4 or 8.0.


<!-- gh-issue-number: gh-118401 -->
* Issue: gh-118401
<!-- /gh-issue-number -->
