### PR TITLE
Addition to Issue#117783

### DIFF
--- a/Objects/weakrefobject.c
+++ b/Objects/weakrefobject.c
@@ -1019,8 +1019,10 @@ PyObject_ClearWeakRefs(PyObject *object)
         _PyWeakref_ClearWeakRefsExceptCallbacks(object);
         PyErr_WriteUnraisable(NULL);
         PyErr_SetRaisedException(exc);
+        Py_XDECREF(exc);  // Clean up the reference to the exception object
         return;
     }
+    Py_XDECREF(exc); // Clean up the reference if tuple creation is successful
 
     Py_ssize_t num_items = 0;
     for (int done = 0; !done;) {


### PR DESCRIPTION
Enhanced error handling in the `create_bound_method` function even when the bound object has been garbage collected, preventing `ReferenceError`. Additionally, exception handling for tuple operations which were previously unhandled were implemented.

- Issue: [Temporarily immortalize objects that use deferred reference counting #117783](https://github.com/python/cpython/issues/117783#issue-2238670752).