### PR TITLE
docs: typo: tiny grammar change: "pointed by" -> "pointed to by"

### DIFF
--- a/Doc/library/os.rst
+++ b/Doc/library/os.rst
@@ -926,7 +926,7 @@ as internal buffering of data.
    If *offset_src* is None, then *src* is read from the current position;
    respectively for *offset_dst*.
 
-   In Linux kernel older than 5.3, the files pointed by *src* and *dst*
+   In Linux kernel older than 5.3, the files pointed to by *src* and *dst*
    must reside in the same filesystem, otherwise an :exc:`OSError` is
    raised with :attr:`~OSError.errno` set to :const:`errno.EXDEV`.
 
@@ -1720,7 +1720,7 @@ or `the MSDN <https://msdn.microsoft.com/en-us/library/z0kc8e3z.aspx>`_ on Windo
    At least one of the file descriptors must refer to a pipe. If *offset_src*
    is None, then *src* is read from the current position; respectively for
    *offset_dst*. The offset associated to the file descriptor that refers to a
-   pipe must be ``None``. The files pointed by *src* and *dst* must reside in
+   pipe must be ``None``. The files pointed to by *src* and *dst* must reside in
    the same filesystem, otherwise an :exc:`OSError` is raised with
    :attr:`~OSError.errno` set to :const:`errno.EXDEV`.
 

--- a/Doc/library/shutil.rst
+++ b/Doc/library/shutil.rst
@@ -242,7 +242,7 @@ Directory and files operations
    be copied as far as the platform allows; if false or omitted, the contents
    and metadata of the linked files are copied to the new tree.
 
-   When *symlinks* is false, if the file pointed by the symlink doesn't
+   When *symlinks* is false, if the file pointed to by the symlink doesn't
    exist, an exception will be added in the list of errors raised in
    an :exc:`Error` exception at the end of the copy process.
    You can set the optional *ignore_dangling_symlinks* flag to true if you

--- a/Doc/library/shutil.rst
+++ b/Doc/library/shutil.rst
@@ -447,7 +447,7 @@ Directory and files operations
    called.  If no *cmd* would be called, return ``None``.
 
    *mode* is a permission mask passed to :func:`os.access`, by default
-   determining if the file exists and executable.
+   determining if the file exists and is executable.
 
    When no *path* is specified, the results of :func:`os.environ` are used,
    returning either the "PATH" value or a fallback of :data:`os.defpath`.

--- a/Lib/pathlib/__init__.py
+++ b/Lib/pathlib/__init__.py
@@ -540,7 +540,7 @@ class Path(_abc.PathBase, PurePath):
     def open(self, mode='r', buffering=-1, encoding=None,
              errors=None, newline=None):
         """
-        Open the file pointed by this path and return a file object, as
+        Open the file pointed to by this path and return a file object, as
         the built-in open() function does.
         """
         if "b" not in mode:

--- a/Lib/pathlib/_abc.py
+++ b/Lib/pathlib/_abc.py
@@ -637,7 +637,7 @@ class PathBase(PurePathBase):
     def open(self, mode='r', buffering=-1, encoding=None,
              errors=None, newline=None):
         """
-        Open the file pointed by this path and return a file object, as
+        Open the file pointed to by this path and return a file object, as
         the built-in open() function does.
         """
         raise UnsupportedOperation(self._unsupported_msg('open()'))

--- a/Lib/shutil.py
+++ b/Lib/shutil.py
@@ -556,7 +556,7 @@ def copytree(src, dst, symlinks=False, ignore=None, copy_function=copy2,
     If the optional symlinks flag is true, symbolic links in the
     source tree result in symbolic links in the destination tree; if
     it is false, the contents of the files pointed to by symbolic
-    links are copied. If the file pointed by the symlink doesn't
+    links are copied. If the file pointed to by the symlink doesn't
     exist, an exception will be added in the list of errors raised in
     an Error exception at the end of the copy process.
 


### PR DESCRIPTION
This commit uses "file pointed to by" to replace "file pointed by" in
 - doc for `shutil.copytree`
 - docstring for `shutil.copytree`
 - docstring `_abc.PathBase.open`
 - docstring for `pathlib.Path.open`
 - doc for `os.copy_file_range`
 - doc for `os.splice`

The docs use "file pointed to by" more frequently than "file pointed by". 
So, this commit replaces the uses of "file pointed by" in order to make the 
uses consistent through the docs.

---
```bash
$ grep -ri 'pointed to by' cpython/
```
yields more results than
```bash
$ grep -ri 'pointed by' cpython/
```
---
Separately:

There are two occurrences of "tree pointed by":
 - in cpython/Doc/library/xml.etree.elementtree.rst for `xml.etree.ElementInclude.include`
 - in cpython/Lib/xml/etree/ElementInclude.py for `include`

For those uses of "tree pointed by", I expect "tree pointed to by" instead. 
However, I found enough uses online of (a) "tree pointed by" rather than 
(b) "tree pointed to by" to convince me that (a) is in common use.

So, this commit does not replace those occurrences of "tree pointed by" 
to "tree pointed to by". But I will replace them if a reviewer believes it is 
correct to replace them.


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--118411.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->