### PR TITLE
gh-118416: Fix possible etree issues when registering default namespaces

### DIFF
--- a/Doc/library/xml.etree.elementtree.rst
+++ b/Doc/library/xml.etree.elementtree.rst
@@ -1179,7 +1179,9 @@ ElementTree Objects
       *xml_declaration* controls if an XML declaration should be added to the
       file.  Use ``False`` for never, ``True`` for always, ``None``
       for only if not US-ASCII or UTF-8 or Unicode (default is ``None``).
-      *default_namespace* sets the default XML namespace (for "xmlns").
+      *default_namespace* sets the default XML namespace (for "xmlns"). This
+      option takes precedence over a default namespace registered using
+      :func:`register_namespace`.
       *method* is either ``"xml"``, ``"html"`` or ``"text"`` (default is
       ``"xml"``).
       The keyword-only *short_empty_elements* parameter controls the formatting

--- a/Misc/NEWS.d/next/Library/2024-04-30-15-01-56.gh-issue-118416.3hzeti.rst
+++ b/Misc/NEWS.d/next/Library/2024-04-30-15-01-56.gh-issue-118416.3hzeti.rst
@@ -1,0 +1,3 @@
+Fix possible issues in :mod:`xml.etree.ElementTree` when serialising xml if
+a default namespace prefix (``""``) has been registered with
+:func:`xml.etree.ElementTree.register_namespace()`


### PR DESCRIPTION
In some circumstances, registering a default namespace prefix (`""`) with `xml.etree.ElementTree.register_namespace` could result in serialising incorrect xml

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-118416 -->
* Issue: gh-118416
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--118417.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->