### PR TITLE
gh-101732: Modules/_ssl.c: use Y2038 compatible openssl function when available

### DIFF
--- a/Misc/NEWS.d/next/Library/2024-04-30-12-59-04.gh-issue-101732.29zUDu.rst
+++ b/Misc/NEWS.d/next/Library/2024-04-30-12-59-04.gh-issue-101732.29zUDu.rst
@@ -1,0 +1,1 @@
+Use a Y2038 compatible openssl time function when available.

--- a/Modules/_ssl.c
+++ b/Modules/_ssl.c
@@ -5329,7 +5329,11 @@ PySSLSession_clear(PySSLSession *self)
 
 static PyObject *
 PySSLSession_get_time(PySSLSession *self, void *closure) {
+#if OPENSSL_VERSION_NUMBER >= 0x30300000L
+    return _PyLong_FromTime_t(SSL_SESSION_get_time_ex(self->session));
+#else
     return PyLong_FromLong(SSL_SESSION_get_time(self->session));
+#endif
 }
 
 PyDoc_STRVAR(PySSLSession_get_time_doc,


### PR DESCRIPTION


<!-- gh-issue-number: gh-101732 -->
* Issue: gh-101732
<!-- /gh-issue-number -->
