### PR TITLE
[3.12] gh-118272: Clear generator frame's locals when the generator is closed

### DIFF
--- a/Include/internal/pycore_frame.h
+++ b/Include/internal/pycore_frame.h
@@ -213,6 +213,9 @@ _PyFrame_GetFrameObject(_PyInterpreterFrame *frame)
     return _PyFrame_MakeAndSetFrameObject(frame);
 }
 
+void
+_PyFrame_ClearLocals(_PyInterpreterFrame *frame);
+
 /* Clears all references in the frame.
  * If take is non-zero, then the _PyInterpreterFrame frame
  * may be transferred to the frame object it references

--- a/Lib/test/test_generators.py
+++ b/Lib/test/test_generators.py
@@ -450,6 +450,26 @@ class ExceptionTest(unittest.TestCase):
         self.assertIsInstance(cm.exception.value, StopIteration)
         self.assertEqual(cm.exception.value.value, 2)
 
+    def test_close_releases_frame_locals(self):
+        # See gh-118272
+
+        class Foo:
+            pass
+
+        f = Foo()
+        f_wr = weakref.ref(f)
+
+        def genfn():
+            a = f
+            yield
+
+        g = genfn()
+        next(g)
+        del f
+        g.close()
+        support.gc_collect()
+        self.assertIsNone(f_wr())
+
 
 class GeneratorThrowTest(unittest.TestCase):
 

--- a/Misc/NEWS.d/next/Core and Builtins/2024-04-30-23-06-10.gh-issue-118272.5ptjk_.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2024-04-30-23-06-10.gh-issue-118272.5ptjk_.rst
@@ -1,0 +1,2 @@
+Fix bug where ``generator.close`` does not free the generator frame's
+locals.

--- a/Objects/genobject.c
+++ b/Objects/genobject.c
@@ -403,6 +403,7 @@ gen_close(PyGenObject *gen, PyObject *args)
          * StopIteration. */
         if (exception_handler_depth == 1) {
             gen->gi_frame_state = FRAME_COMPLETED;
+            _PyFrame_ClearLocals((_PyInterpreterFrame *)gen->gi_iframe);
             Py_RETURN_NONE;
         }
     }

--- a/Python/frame.c
+++ b/Python/frame.c
@@ -119,10 +119,11 @@ void
 _PyFrame_ClearLocals(_PyInterpreterFrame *frame)
 {
     assert(frame->stacktop >= 0);
-    for (int i = 0; i < frame->stacktop; i++) {
+    int stacktop = frame->stacktop;
+    frame->stacktop = 0;
+    for (int i = 0; i < stacktop; i++) {
         Py_XDECREF(frame->localsplus[i]);
     }
-    frame->stacktop = 0;
     Py_CLEAR(frame->f_locals);
 }
 

--- a/Python/frame.c
+++ b/Python/frame.c
@@ -116,6 +116,17 @@ take_ownership(PyFrameObject *f, _PyInterpreterFrame *frame)
 }
 
 void
+_PyFrame_ClearLocals(_PyInterpreterFrame *frame)
+{
+    assert(frame->stacktop >= 0);
+    for (int i = 0; i < frame->stacktop; i++) {
+        Py_XDECREF(frame->localsplus[i]);
+    }
+    frame->stacktop = 0;
+    Py_CLEAR(frame->f_locals);
+}
+
+void
 _PyFrame_ClearExceptCode(_PyInterpreterFrame *frame)
 {
     /* It is the responsibility of the owning generator/coroutine
@@ -135,12 +146,8 @@ _PyFrame_ClearExceptCode(_PyInterpreterFrame *frame)
         }
         Py_DECREF(f);
     }
-    assert(frame->stacktop >= 0);
-    for (int i = 0; i < frame->stacktop; i++) {
-        Py_XDECREF(frame->localsplus[i]);
-    }
+    _PyFrame_ClearLocals(frame);
     Py_XDECREF(frame->frame_obj);
-    Py_XDECREF(frame->f_locals);
     Py_DECREF(frame->f_funcobj);
 }
 


### PR DESCRIPTION
Manual backport of https://github.com/python/cpython/pull/118277.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-118272 -->
* Issue: gh-118272
<!-- /gh-issue-number -->
