### PR TITLE
gh-118201 - Disable the flaky POSIX test_confstr test on iOS

### DIFF
--- a/Lib/test/test_posix.py
+++ b/Lib/test/test_posix.py
@@ -564,6 +564,7 @@ class PosixTester(unittest.TestCase):
 
     @unittest.skipUnless(hasattr(posix, 'confstr'),
                          'test needs posix.confstr()')
+    @unittest.skipIf(support.is_apple_mobile, "gh-118201: Test is flaky on iOS")
     def test_confstr(self):
         self.assertRaises(ValueError, posix.confstr, "CS_garbage")
         self.assertEqual(len(posix.confstr("CS_PATH")) > 0, True)


### PR DESCRIPTION
[About 1 in 10 builds](https://buildbot.python.org/all/#/builders/1380) appear to be failing on iOS due to the `test.test_posix.PosixTester.test_confstr` test. The next buildbot run almost always passes, with no other changes. 

For want of a real fix, this PR skips that test on iOS to avoid misleading test failures from the buildbot.

I agree this isn't a very satisfying "fix", but I've been unable to reproduce the issue locally. However, in defence of the fix: the feature that is failing doesn't have much utility on iOS. It's no help knowing where the POSIX standard utilities are located (which is what is returned by the value `CS_PATH`), because you can't invoke them anyway. The other common values passed to `confstr()` appear to be GNU C dependent (FreeBSD only documents `CS_PATH`).

There's also precedent for this approach - there's a couple of other tests in the suite that are skipped as being "flaky" under specific build conditions.

If this is merged, we can keep the underlying ticket open on the off chance that someone *is* affected by the issue, or is able to find a way to reproduce it.

<!-- gh-issue-number: gh-118201 -->
* Issue: gh-118201
<!-- /gh-issue-number -->
