### PR TITLE
gh-118201: Accomodate flaky behavior of `os.sysconf` on iOS

### DIFF
--- a/Lib/test/support/os_helper.py
+++ b/Lib/test/support/os_helper.py
@@ -632,7 +632,8 @@ def fd_count():
     if hasattr(os, 'sysconf'):
         try:
             MAXFD = os.sysconf("SC_OPEN_MAX")
-        except OSError:
+        except (OSError, ValueError):
+            # gh-118201: ValueError is raised intermittently on iOS
             pass
 
     old_modes = None

--- a/Lib/test/test_os.py
+++ b/Lib/test/test_os.py
@@ -2365,6 +2365,7 @@ class TestInvalidFD(unittest.TestCase):
         support.is_emscripten or support.is_wasi,
         "musl libc issue on Emscripten/WASI, bpo-46390"
     )
+    @unittest.skipIf(support.is_apple_mobile, "gh-118201: Test is flaky on iOS")
     def test_fpathconf(self):
         self.check(os.pathconf, "PC_NAME_MAX")
         self.check(os.fpathconf, "PC_NAME_MAX")


### PR DESCRIPTION
A follow on from #118452, addressing a similar class of flaky test on iOS. 

`os.sysconf()` appears to have flakiness similar to that observed with `posix.confstr()`. So far, it has been less common than the `test_posix` failure; as with the `test_posix` case, I've been unable to reproduce it locally, and the next CI pass almost always passes. 

One of the updates in this PR is in `os_helper`, which already has a failover case if `os.sysconf()` isn't available or doesn't work. I've done a test deliberately simulating the failure case (effectively using the constant value of `MAXFD` regardless of the sysconf value), and the tests that use this utility continue to pass on iOS.


<!-- gh-issue-number: gh-118201 -->
* Issue: gh-118201
<!-- /gh-issue-number -->
