### PR TITLE
gh-118455: Fix mangle_from_ default value in email.policy.Policy.__doc__

### DIFF
--- a/Lib/email/_policybase.py
+++ b/Lib/email/_policybase.py
@@ -152,7 +152,7 @@ class Policy(_PolicyBase, metaclass=abc.ABCMeta):
     mangle_from_        -- a flag that, when True escapes From_ lines in the
                            body of the message by putting a `>' in front of
                            them. This is used when the message is being
-                           serialized by a generator. Default: True.
+                           serialized by a generator. Default: False.
 
     message_factory     -- the class to use to create new message objects.
                            If the value is None, the default is Message.

--- a/Misc/NEWS.d/next/Library/2024-04-30-22-18-30.gh-issue-118455._XnYvo.rst
+++ b/Misc/NEWS.d/next/Library/2024-04-30-22-18-30.gh-issue-118455._XnYvo.rst
@@ -1,1 +1,0 @@
-Correct default value of mangle_from\_ in email.policy.Policy docstring

--- a/Misc/NEWS.d/next/Library/2024-04-30-22-18-30.gh-issue-118455._XnYvo.rst
+++ b/Misc/NEWS.d/next/Library/2024-04-30-22-18-30.gh-issue-118455._XnYvo.rst
@@ -1,0 +1,1 @@
+Correct default value of mangle_from\_ in email.policy.Policy docstring


### PR DESCRIPTION
The docstring says it defaults to True, but it actually defaults to False. Only the Compat32 subclass overrides that, if I understand correctly (cc @bitdancer ).

<!-- gh-issue-number: gh-118455 -->
* Issue: gh-118455
<!-- /gh-issue-number -->
