### PR TITLE
gh-118476: update the example implementation for islice in docs

### DIFF
--- a/Doc/library/itertools.rst
+++ b/Doc/library/itertools.rst
@@ -508,10 +508,10 @@ loops that truncate the stream.
           stop = s.stop
           step = s.step if s.step is not None else 1
           for i, element in enumerate(iterable):
-              if stop is not None and i >= stop:
-                  return
               if i >= start and (i - start) % step == 0:
                   yield element
+              if stop is not None and i + 1 >= stop:
+                  return
 
 
 .. function:: pairwise(iterable)

--- a/Doc/library/itertools.rst
+++ b/Doc/library/itertools.rst
@@ -504,24 +504,14 @@ loops that truncate the stream.
           # islice('ABCDEFG', 2, None) → C D E F G
           # islice('ABCDEFG', 0, None, 2) → A C E G
           s = slice(*args)
-          start, stop, step = s.start or 0, s.stop or sys.maxsize, s.step or 1
-          it = iter(range(start, stop, step))
-          try:
-              nexti = next(it)
-          except StopIteration:
-              # Consume *iterable* up to the *start* position.
-              for i, element in zip(range(start), iterable):
-                  pass
-              return
-          try:
-              for i, element in enumerate(iterable):
-                  if i == nexti:
-                      yield element
-                      nexti = next(it)
-          except StopIteration:
-              # Consume to *stop*.
-              for i, element in zip(range(i + 1, stop), iterable):
-                  pass
+          start = s.start if s.start is not None else 0
+          stop = s.stop
+          step = s.step if s.step is not None else 1
+          for i, element in enumerate(iterable):
+              if stop is not None and i >= stop:
+                  return
+              if i >= start and (i - start) % step == 0:
+                  yield element
 
 
 .. function:: pairwise(iterable)

--- a/Doc/library/itertools.rst
+++ b/Doc/library/itertools.rst
@@ -507,8 +507,14 @@ loops that truncate the stream.
           start = s.start if s.start is not None else 0
           stop = s.stop
           step = s.step if s.step is not None else 1
-          for i, element in enumerate(iterable):
-              if i >= start and (i - start) % step == 0:
+          it = iter(iterable)
+          for _ in zip(range(start), it):
+              # Consume up to *start* position
+              pass
+          if stop is not None and stop <= start:
+              return
+          for i, element in enumerate(iterable, start):
+              if (i - start) % step == 0:
                   yield element
               if stop is not None and i + 1 >= stop:
                   return

--- a/Doc/library/itertools.rst
+++ b/Doc/library/itertools.rst
@@ -513,7 +513,7 @@ loops that truncate the stream.
               pass
           if stop is not None and stop <= start:
               return
-          for i, element in enumerate(iterable, start):
+          for i, element in enumerate(it, start):
               if (i - start) % step == 0:
                   yield element
               if stop is not None and i + 1 >= stop:


### PR DESCRIPTION
* The previous version was needlessly complicated
* It was also wrong since it overwrote stop == 0 to maxsize so

```
list(islice([1,2,3], 0))
```

looked like it returned `[1,2,3]` rather than `[]`.

Fixes #118476 

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--118466.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->

<!-- gh-issue-number: gh-118476 -->
* Issue: gh-118476
<!-- /gh-issue-number -->
