### PR TITLE
GH-113464: Add a warning when building the JIT

### DIFF
--- a/Tools/jit/_llvm.py
+++ b/Tools/jit/_llvm.py
@@ -1,4 +1,5 @@
 """Utilities for invoking LLVM tools."""
+
 import asyncio
 import functools
 import os

--- a/Tools/jit/_schema.py
+++ b/Tools/jit/_schema.py
@@ -1,4 +1,5 @@
 """Schema for the JSON produced by llvm-readobj --elf-output-style=JSON."""
+
 import typing
 
 HoleKind: typing.TypeAlias = typing.Literal[

--- a/Tools/jit/_stencils.py
+++ b/Tools/jit/_stencils.py
@@ -1,4 +1,5 @@
 """Core data structures for compiled code templates."""
+
 import dataclasses
 import enum
 import sys
@@ -29,7 +30,7 @@ class HoleValue(enum.Enum):
     OPARG = enum.auto()
     # The current uop's operand on 64-bit platforms (exposed as _JIT_OPERAND):
     OPERAND = enum.auto()
-    # The current uop's operand on 32-bit platforms (exposed as _JIT_OPERAND_HI and _JIT_OPERAND_LO):
+    # The current uop's operand on 32-bit platforms (exposed as _JIT_OPERAND_HI/LO):
     OPERAND_HI = enum.auto()
     OPERAND_LO = enum.auto()
     # The current uop's target (exposed as _JIT_TARGET):
@@ -203,9 +204,8 @@ class StencilGroup:
         """Fix up all GOT and internal relocations for this stencil group."""
         for hole in self.code.holes.copy():
             if (
-                hole.kind in {
-                    "R_AARCH64_CALL26", "R_AARCH64_JUMP26", "ARM64_RELOC_BRANCH26"
-                }
+                hole.kind
+                in {"R_AARCH64_CALL26", "R_AARCH64_JUMP26", "ARM64_RELOC_BRANCH26"}
                 and hole.value is HoleValue.ZERO
             ):
                 self.code.pad(alignment)

--- a/Tools/jit/_targets.py
+++ b/Tools/jit/_targets.py
@@ -1,4 +1,5 @@
 """Target-specific code generation, parsing, and processing."""
+
 import asyncio
 import dataclasses
 import hashlib
@@ -42,7 +43,6 @@ class _Target(typing.Generic[_S, _R]):
     prefix: str = ""
     stable: bool = False
     debug: bool = False
-    force: bool = False
     verbose: bool = False
 
     def _compute_digest(self, out: pathlib.Path) -> str:
@@ -187,7 +187,9 @@ class _Target(typing.Generic[_S, _R]):
                     tasks.append(group.create_task(coro, name=opname))
         return {task.get_name(): task.result() for task in tasks}
 
-    def build(self, out: pathlib.Path, *, comment: str = "") -> None:
+    def build(
+        self, out: pathlib.Path, *, comment: str = "", force: bool = False
+    ) -> None:
         """Build jit_stencils.h in the given directory."""
         if not self.stable:
             warning = f"JIT support for {self.triple} is still experimental!"
@@ -197,7 +199,7 @@ class _Target(typing.Generic[_S, _R]):
         digest = f"// {self._compute_digest(out)}\n"
         jit_stencils = out / "jit_stencils.h"
         if (
-            not self.force
+            not force
             and jit_stencils.exists()
             and jit_stencils.read_text().startswith(digest)
         ):
@@ -456,9 +458,7 @@ class _MachO(
             } | {
                 "Offset": offset,
                 "Symbol": {"Name": s},
-                "Type": {
-                    "Name": "X86_64_RELOC_BRANCH" | "X86_64_RELOC_SIGNED" as kind
-                },
+                "Type": {"Name": "X86_64_RELOC_BRANCH" | "X86_64_RELOC_SIGNED" as kind},
             }:
                 offset += base
                 s = s.removeprefix(self.prefix)
@@ -484,26 +484,29 @@ class _MachO(
         return _stencils.Hole(offset, kind, value, symbol, addend)
 
 
-def target(host: str) -> _COFF | _ELF | _MachO:
+def get_target(host: str) -> _COFF | _ELF | _MachO:
     """Build a _Target for the given host "triple" and options."""
     # ghccc currently crashes Clang when combined with musttail on aarch64. :(
+    target: _COFF | _ELF | _MachO
     if re.fullmatch(r"aarch64-apple-darwin.*", host):
-        return _MachO(host, alignment=8, prefix="_")
-    if re.fullmatch(r"aarch64-pc-windows-msvc", host):
+        target = _MachO(host, alignment=8, prefix="_")
+    elif re.fullmatch(r"aarch64-pc-windows-msvc", host):
         args = ["-fms-runtime-lib=dll"]
-        return _COFF(host, alignment=8, args=args)
-    if re.fullmatch(r"aarch64-.*-linux-gnu", host):
+        target = _COFF(host, alignment=8, args=args)
+    elif re.fullmatch(r"aarch64-.*-linux-gnu", host):
         args = ["-fpic"]
-        return _ELF(host, alignment=8, args=args)
-    if re.fullmatch(r"i686-pc-windows-msvc", host):
+        target = _ELF(host, alignment=8, args=args)
+    elif re.fullmatch(r"i686-pc-windows-msvc", host):
         args = ["-DPy_NO_ENABLE_SHARED"]
-        return _COFF(host, args=args, ghccc=True, prefix="_")
-    if re.fullmatch(r"x86_64-apple-darwin.*", host):
-        return _MachO(host, ghccc=True, prefix="_")
-    if re.fullmatch(r"x86_64-pc-windows-msvc", host):
+        target = _COFF(host, args=args, ghccc=True, prefix="_")
+    elif re.fullmatch(r"x86_64-apple-darwin.*", host):
+        target = _MachO(host, ghccc=True, prefix="_")
+    elif re.fullmatch(r"x86_64-pc-windows-msvc", host):
         args = ["-fms-runtime-lib=dll"]
-        return _COFF(host, args=args, ghccc=True)
-    if re.fullmatch(r"x86_64-.*-linux-gnu", host):
+        target = _COFF(host, args=args, ghccc=True)
+    elif re.fullmatch(r"x86_64-.*-linux-gnu", host):
         args = ["-fpic"]
-        return _ELF(host, args=args, ghccc=True)
-    raise ValueError(host)
+        target = _ELF(host, args=args, ghccc=True)
+    else:
+        raise ValueError(host)
+    return target

--- a/Tools/jit/_targets.py
+++ b/Tools/jit/_targets.py
@@ -40,6 +40,7 @@ class _Target(typing.Generic[_S, _R]):
     args: typing.Sequence[str] = ()
     ghccc: bool = False
     prefix: str = ""
+    stable: bool = False
     debug: bool = False
     force: bool = False
     verbose: bool = False
@@ -188,6 +189,11 @@ class _Target(typing.Generic[_S, _R]):
 
     def build(self, out: pathlib.Path, *, comment: str = "") -> None:
         """Build jit_stencils.h in the given directory."""
+        if not self.stable:
+            warning = f"JIT support for {self.triple} is still experimental!"
+            request = "Please report any issues you encounter.".center(len(warning))
+            outline = "=" * len(warning)
+            print("\n".join(["", outline, warning, request, outline, ""]))
         digest = f"// {self._compute_digest(out)}\n"
         jit_stencils = out / "jit_stencils.h"
         if (
@@ -478,7 +484,7 @@ class _MachO(
         return _stencils.Hole(offset, kind, value, symbol, addend)
 
 
-def get_target(host: str) -> _COFF | _ELF | _MachO:
+def target(host: str) -> _COFF | _ELF | _MachO:
     """Build a _Target for the given host "triple" and options."""
     # ghccc currently crashes Clang when combined with musttail on aarch64. :(
     if re.fullmatch(r"aarch64-apple-darwin.*", host):

--- a/Tools/jit/_writer.py
+++ b/Tools/jit/_writer.py
@@ -1,4 +1,5 @@
 """Utilities for writing StencilGroups out to a C header file."""
+
 import typing
 
 import _schema

--- a/Tools/jit/build.py
+++ b/Tools/jit/build.py
@@ -1,4 +1,5 @@
 """Build an experimental just-in-time compiler for CPython."""
+
 import argparse
 import pathlib
 import shlex
@@ -10,7 +11,7 @@ if __name__ == "__main__":
     comment = f"$ {shlex.join([sys.executable] + sys.argv)}"
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
-        "target", type=_targets.target, help="a PEP 11 target triple to compile for"
+        "target", type=_targets.get_target, help="a PEP 11 target triple to compile for"
     )
     parser.add_argument(
         "-d", "--debug", action="store_true", help="compile for a debug build of Python"
@@ -23,6 +24,5 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
     args.target.debug = args.debug
-    args.target.force = args.force
     args.target.verbose = args.verbose
-    args.target.build(pathlib.Path.cwd(), comment=comment)
+    args.target.build(pathlib.Path.cwd(), comment=comment, force=args.force)

--- a/Tools/jit/build.py
+++ b/Tools/jit/build.py
@@ -10,7 +10,7 @@ if __name__ == "__main__":
     comment = f"$ {shlex.join([sys.executable] + sys.argv)}"
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
-        "target", type=_targets.get_target, help="a PEP 11 target triple to compile for"
+        "target", type=_targets.target, help="a PEP 11 target triple to compile for"
     )
     parser.add_argument(
         "-d", "--debug", action="store_true", help="compile for a debug build of Python"


### PR DESCRIPTION
PEP 744 makes a bunch of promises once "the JIT builds successfully without displaying warnings to the user". We don't currently do that... so we should.

This PR adds a small banner during JIT builds reminding the user that JIT support for their platform is still experimental, and asking them to report any bugs. This banner is on by default, but can be disabled per-target as they become stable.

This PR also includes a few mostly-cosmetic changes to appease `mypy`, `black`, and `pylint`. They're in separate commits, so they're easier to review.

<!-- gh-issue-number: gh-113464 -->
* Issue: gh-113464
<!-- /gh-issue-number -->
