### PR TITLE
gh-118413: Temporarily skip `test_release_task_refs` in free-threaded builds

### DIFF
--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -2804,6 +2804,7 @@ class _TestPool(BaseTestCase):
         # check that we indeed waited for all jobs
         self.assertGreater(time.monotonic() - t_start, 0.9)
 
+    @support.requires_gil_enabled("gh-118413: test is flaky with GIL disabled")
     def test_release_task_refs(self):
         # Issue #29861: task arguments and results should not be kept
         # alive after we are done with them.


### PR DESCRIPTION
The test is flaky in the free-threaded build, especially on Windows. We'll need to figure out the root cause, but in the meantime skip the test.

<!-- gh-issue-number: gh-118413 -->
* Issue: gh-118413
<!-- /gh-issue-number -->
