### PR TITLE
gh-118413: Fix test_release_task_refs on free-threaded build

### DIFF
--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -2804,7 +2804,6 @@ class _TestPool(BaseTestCase):
         # check that we indeed waited for all jobs
         self.assertGreater(time.monotonic() - t_start, 0.9)
 
-    @support.requires_gil_enabled("gh-118413: test is flaky with GIL disabled")
     def test_release_task_refs(self):
         # Issue #29861: task arguments and results should not be kept
         # alive after we are done with them.
@@ -2813,8 +2812,8 @@ class _TestPool(BaseTestCase):
         self.pool.map(identity, objs)
 
         del objs
-        gc.collect()  # For PyPy or other GCs.
         time.sleep(DELTA)  # let threaded cleanup code run
+        support.gc_collect()  # For PyPy or other GCs.
         self.assertEqual(set(wr() for wr in refs), {None})
         # With a process pool, copies of the objects are returned, check
         # they were released too.


### PR DESCRIPTION
The `time.sleep()` call should happen before the GC to give the worker threads time to clean-up their remaining references to objs. Additionally, use `support.gc_collect()` instead of `gc.collect()` just in case the extra GC calls matter.

<!-- gh-issue-number: gh-118413 -->
* Issue: gh-118413
<!-- /gh-issue-number -->
