### PR TITLE
gh-112075: Fix race in constructing dict for instance

### DIFF
--- a/Include/internal/pycore_dict.h
+++ b/Include/internal/pycore_dict.h
@@ -105,10 +105,10 @@ PyAPI_FUNC(PyObject *)_PyDict_LoadGlobal(PyDictObject *, PyDictObject *, PyObjec
 
 /* Consumes references to key and value */
 PyAPI_FUNC(int) _PyDict_SetItem_Take2(PyDictObject *op, PyObject *key, PyObject *value);
-extern int _PyObjectDict_SetItem(PyTypeObject *tp, PyObject **dictptr, PyObject *name, PyObject *value);
 extern int _PyDict_SetItem_LockHeld(PyDictObject *dict, PyObject *name, PyObject *value);
 extern int _PyDict_GetItemRef_Unicode_LockHeld(PyDictObject *op, PyObject *key, PyObject **result);
 extern int _PyDict_GetItemRef_KnownHash(PyDictObject *op, PyObject *key, Py_hash_t hash, PyObject **result);
+extern int _PyObjectDict_SetItem(PyTypeObject *tp, PyObject *obj, PyObject **dictptr, PyObject *name, PyObject *value);
 
 extern int _PyDict_Pop_KnownHash(
     PyDictObject *dict,

--- a/Lib/test/test_free_threading/test_dict.py
+++ b/Lib/test/test_free_threading/test_dict.py
@@ -1,0 +1,141 @@
+import gc
+import time
+import unittest
+import weakref
+
+from ast import Or
+from functools import partial
+from threading import Thread
+from unittest import TestCase
+
+from test.support import is_wasi
+
+
+@unittest.skipIf(is_wasi, "WASI has no threads.")
+class TestDict(TestCase):
+    def test_racing_creation_shared_keys(self):
+        """Verify that creating dictionaries is thread safe when we
+        have a type with shared keys"""
+        class C(int):
+            pass
+
+        self.racing_creation(C)
+
+    def test_racing_creation_no_shared_keys(self):
+        """Verify that creating dictionaries is thread safe when we
+        have a type with an ordinary dict"""
+        self.racing_creation(Or)
+
+    def test_racing_creation_inline_values_invalid(self):
+        """Verify that re-creating a dict after we have invalid inline values
+        is thread safe"""
+        class C:
+            pass
+
+        def make_obj():
+            a = C()
+            # Make object, make inline values invalid, and then delete dict
+            a.__dict__ = {}
+            del a.__dict__
+            return a
+
+        self.racing_creation(make_obj)
+
+    def test_racing_creation_nonmanaged_dict(self):
+        """Verify that explicit creation of an unmanaged dict is thread safe
+        outside of the normal attribute setting code path"""
+        def make_obj():
+            def f(): pass
+            return f
+
+        def set(func, name, val):
+            # Force creation of the dict via PyObject_GenericGetDict
+            func.__dict__[name] = val
+
+        self.racing_creation(make_obj, set)
+
+    def racing_creation(self, cls, set=setattr):
+        objects = []
+        processed = []
+
+        OBJECT_COUNT = 100
+        THREAD_COUNT = 10
+        CUR = 0
+
+        for i in range(OBJECT_COUNT):
+            objects.append(cls())
+
+        def writer_func(name):
+            last = -1
+            while True:
+                if CUR == last:
+                    continue
+                elif CUR == OBJECT_COUNT:
+                    break
+
+                obj = objects[CUR]
+                set(obj, name, name)
+                last = CUR
+                processed.append(name)
+
+        writers = []
+        for x in range(THREAD_COUNT):
+            writer = Thread(target=partial(writer_func, f"a{x:02}"))
+            writers.append(writer)
+            writer.start()
+
+        for i in range(OBJECT_COUNT):
+            CUR = i
+            while len(processed) != THREAD_COUNT:
+                time.sleep(0.001)
+            processed.clear()
+
+        CUR = OBJECT_COUNT
+
+        for writer in writers:
+            writer.join()
+
+        for obj_idx, obj in enumerate(objects):
+            assert (
+                len(obj.__dict__) == THREAD_COUNT
+            ), f"{len(obj.__dict__)} {obj.__dict__!r} {obj_idx}"
+            for i in range(THREAD_COUNT):
+                assert f"a{i:02}" in obj.__dict__, f"a{i:02} missing at {obj_idx}"
+
+    def test_racing_set_dict(self):
+        """Races assigning to __dict__ should be thread safe"""
+
+        def f(): pass
+        l = []
+        THREAD_COUNT = 10
+        class MyDict(dict): pass
+
+        def writer_func(l):
+            for i in range(1000):
+                d = MyDict()
+                l.append(weakref.ref(d))
+                f.__dict__ = d
+
+        lists = []
+        writers = []
+        for x in range(THREAD_COUNT):
+            thread_list = []
+            lists.append(thread_list)
+            writer = Thread(target=partial(writer_func, thread_list))
+            writers.append(writer)
+
+        for writer in writers:
+            writer.start()
+
+        for writer in writers:
+            writer.join()
+
+        f.__dict__ = {}
+        gc.collect()
+
+        for thread_list in lists:
+            for ref in thread_list:
+                self.assertIsNone(ref())
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Lib/test/test_free_threading/test_dict.py
+++ b/Lib/test/test_free_threading/test_dict.py
@@ -8,10 +8,10 @@ from functools import partial
 from threading import Thread
 from unittest import TestCase
 
-from test.support import is_wasi
+from test.support import threading_helper
 
 
-@unittest.skipIf(is_wasi, "WASI has no threads.")
+@threading_helper.requires_working_threading()
 class TestDict(TestCase):
     def test_racing_creation_shared_keys(self):
         """Verify that creating dictionaries is thread safe when we

--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -924,7 +924,6 @@ new_dict(PyInterpreterState *interp,
     return (PyObject *)mp;
 }
 
-/* Consumes a reference to the keys object */
 static PyObject *
 new_dict_with_shared_keys(PyInterpreterState *interp, PyDictKeysObject *keys)
 {

--- a/Objects/object.c
+++ b/Objects/object.c
@@ -1731,7 +1731,7 @@ _PyObject_GenericSetAttrWithDict(PyObject *obj, PyObject *name,
             goto done;
         }
         else {
-            res = _PyObjectDict_SetItem(tp, dictptr, name, value);
+            res = _PyObjectDict_SetItem(tp, obj, dictptr, name, value);
         }
     }
     else {

--- a/Objects/object.c
+++ b/Objects/object.c
@@ -1789,11 +1789,9 @@ PyObject_GenericSetDict(PyObject *obj, PyObject *value, void *context)
                      "not a '%.200s'", Py_TYPE(value)->tp_name);
         return -1;
     }
-#ifdef Py_GIL_DISABLED
-    Py_XDECREF(_Py_atomic_exchange_ptr(dictptr, Py_NewRef(value)));
-#else
+    Py_BEGIN_CRITICAL_SECTION(obj);
     Py_XSETREF(*dictptr, Py_NewRef(value));
-#endif
+    Py_END_CRITICAL_SECTION();
     return 0;
 }
 

--- a/Objects/object.c
+++ b/Objects/object.c
@@ -1789,7 +1789,11 @@ PyObject_GenericSetDict(PyObject *obj, PyObject *value, void *context)
                      "not a '%.200s'", Py_TYPE(value)->tp_name);
         return -1;
     }
+#ifdef Py_GIL_DISABLED
+    Py_XDECREF(_Py_atomic_exchange_ptr(dictptr, Py_NewRef(value)));
+#else
     Py_XSETREF(*dictptr, Py_NewRef(value));
+#endif
     return 0;
 }
 


### PR DESCRIPTION
Fix a small thread safety issue w/ dicts.  When we are constructing the dict for an object with either a non-inline managed dict or with a non-managed dict we're not properly protecting the creation with a lock.  This locks the object in `_PyObjectDict_SetItem` if we don't already have a dict to ensure only one thread creates the lock at a time.

<!-- gh-issue-number: gh-112075 -->
* Issue: gh-112075
<!-- /gh-issue-number -->
