### PR TITLE
gh-118500: Add pdb support for zipapp

### DIFF
--- a/Doc/whatsnew/3.13.rst
+++ b/Doc/whatsnew/3.13.rst
@@ -687,6 +687,9 @@ pdb
   command line option or :envvar:`PYTHONSAFEPATH` environment variable).
   (Contributed by Tian Gao and Christian Walther in :gh:`111762`.)
 
+* :mod:`zipapp` is supported as a debugging target.
+  (Contributed by Tian Gao in :gh:`118501`.)
+
 queue
 -----
 

--- a/Lib/pdb.py
+++ b/Lib/pdb.py
@@ -1117,7 +1117,7 @@ class Pdb(bdb.Bdb, cmd.Cmd):
             if f:
                 fname = f
             item = parts[1]
-        answer = find_function(item, fname)
+        answer = find_function(item, self.canonic(fname))
         return answer or failed
 
     def checkline(self, filename, lineno):

--- a/Lib/test/test_pdb.py
+++ b/Lib/test/test_pdb.py
@@ -10,6 +10,7 @@ import unittest
 import subprocess
 import textwrap
 import linecache
+import zipapp
 
 from contextlib import ExitStack, redirect_stdout
 from io import StringIO
@@ -3491,6 +3492,30 @@ def bœr():
         for filename in os.listdir(script_dir):
             if filename.endswith(".py"):
                 self._run_pdb([os.path.join(script_dir, filename)], 'q')
+
+    def test_zipapp(self):
+        with os_helper.temp_dir() as temp_dir:
+            os.mkdir(os.path.join(temp_dir, 'source'))
+            script = textwrap.dedent(
+                """
+                def f(x):
+                    return x + 1
+                f(21 + 21)
+                """
+            )
+            with open(os.path.join(temp_dir, 'source', '__main__.py'), 'w') as f:
+                f.write(script)
+            zipapp.create_archive(os.path.join(temp_dir, 'source'),
+                                  os.path.join(temp_dir, 'zipapp.pyz'))
+            stdout, _ = self._run_pdb([os.path.join(temp_dir, 'zipapp.pyz')], '\n'.join([
+                'b f',
+                'c',
+                'p x',
+                'q'
+            ]))
+            self.assertIn('42', stdout)
+            self.assertIn('return x + 1', stdout)
+
 
 class ChecklineTests(unittest.TestCase):
     def setUp(self):

--- a/Lib/test/test_pyclbr.py
+++ b/Lib/test/test_pyclbr.py
@@ -226,7 +226,7 @@ class PyclbrTest(TestCase):
         cm(
             'pdb',
             # pyclbr does not handle elegantly `typing` or properties
-            ignore=('Union', '_ModuleTarget', '_ScriptTarget'),
+            ignore=('Union', '_ModuleTarget', '_ScriptTarget', '_ZipTarget'),
         )
         cm('pydoc', ignore=('input', 'output',)) # properties
 

--- a/Misc/NEWS.d/next/Library/2024-05-02-04-27-12.gh-issue-118500.pBGGtQ.rst
+++ b/Misc/NEWS.d/next/Library/2024-05-02-04-27-12.gh-issue-118500.pBGGtQ.rst
@@ -1,0 +1,1 @@
+Add :mod:`pdb` support for zipapps


### PR DESCRIPTION
When zipapp is being loaded, it seems to register the files in the zip to linecache so the other libraries can find the source. pdb can get the source file with no issue, the breakpoint mechanism needs a tweak, also not complicated.

Overall it worked without too much hassle.

<!-- gh-issue-number: gh-118500 -->
* Issue: gh-118500
<!-- /gh-issue-number -->
