### PR TITLE
GH-113464: Generate a more efficient JIT

### DIFF
--- a/Python/jit.c
+++ b/Python/jit.c
@@ -116,7 +116,7 @@ mark_executable(unsigned char *memory, size_t size)
 
 // value[value_start : value_start + len]
 static uint32_t
-get_bits(uint64_t value, uint8_t value_start, uint8_t width)
+get_bits(uintptr_t value, uint8_t value_start, uint8_t width)
 {
     assert(width <= 32);
     return (value >> value_start) & ((1ULL << width) - 1);
@@ -124,7 +124,7 @@ get_bits(uint64_t value, uint8_t value_start, uint8_t width)
 
 // *loc[loc_start : loc_start + width] = value[value_start : value_start + width]
 static void
-set_bits(uint32_t *loc, uint8_t loc_start, uint64_t value, uint8_t value_start,
+set_bits(uint32_t *loc, uint8_t loc_start, uintptr_t value, uint8_t value_start,
          uint8_t width)
 {
     assert(loc_start + width <= 32);
@@ -295,7 +295,7 @@ patch_aarch64_21rx(unsigned char *location, uintptr_t value)
     //     // There should be only one register involved:
     //     assert(reg == get_bits(loc32[1], 0, 5));  // ldr's output register.
     //     assert(reg == get_bits(loc32[1], 5, 5));  // ldr's input register.
-    //     uint64_t relaxed = *(uint64_t *)value;
+    //     uintptr_t relaxed = *(uintptr_t *)value;
     //     if (relaxed < (1UL << 16)) {
     //         // adrp reg, AAA; ldr reg, [reg + BBB] -> movz reg, XXX; nop
     //         loc32[0] = 0xD2800000 | (get_bits(relaxed, 0, 16) << 5) | reg;
@@ -346,7 +346,7 @@ patch_x86_64_32rx(unsigned char *location, uintptr_t value)
 {
     uint8_t *loc8 = (uint8_t *)location;
     // Try to relax the GOT load into an immediate value:
-    uint64_t relaxed = *(uint64_t *)(value + 4) - 4;
+    uintptr_t relaxed = *(uintptr_t *)(value + 4) - 4;
     if ((int64_t)relaxed - (int64_t)location >= -(1LL << 31) &&
         (int64_t)relaxed - (int64_t)location + 1 < (1LL << 31))
     {

--- a/Python/jit.c
+++ b/Python/jit.c
@@ -402,19 +402,17 @@ _PyJIT_Compile(_PyExecutorObject *executor, const _PyUOpInstruction trace[], siz
     for (size_t i = 0; i < length; i++) {
         instruction_starts[i] += (uintptr_t)memory;
     }
-    // Loop again to emit the code:
     unsigned char *code = memory;
     unsigned char *data = memory + code_size;
-    {
-        // Compile the trampoline, which handles converting between the native
-        // calling convention and the calling convention used by jitted code
-        // (which may be different for efficiency reasons). On platforms where
-        // we don't change calling conventions, the trampoline is empty and
-        // nothing is emitted here:
-        emit_trampoline(code, data, executor, NULL, instruction_starts);
-        code += emitted_trampoline_code;
-        data += emitted_trampoline_data;
-    }
+    // Compile the trampoline, which handles converting between the native
+    // calling convention and the calling convention used by jitted code
+    // (which may be different for efficiency reasons). On platforms where
+    // we don't change calling conventions, the trampoline is empty and
+    // nothing is emitted here:
+    emit_trampoline(code, data, executor, NULL, instruction_starts);
+    code += emitted_trampoline_code;
+    data += emitted_trampoline_data;
+    // Loop again to emit the code:
     assert(trace[0].opcode == _START_EXECUTOR || trace[0].opcode == _COLD_EXIT);
     for (size_t i = 0; i < length; i++) {
         const _PyUOpInstruction *instruction = &trace[i];

--- a/Python/jit.c
+++ b/Python/jit.c
@@ -214,6 +214,12 @@ patch_aarch64_12(unsigned char *location, uint64_t value)
     set_bits(loc32, 10, value, shift, 12);
 }
 
+static inline void
+patch_aarch64_12x(unsigned char *location, uint64_t value)
+{
+    patch_aarch64_12(location, value);
+}
+
 // 16-bit low part of an absolute address.
 static inline void
 patch_aarch64_16a(unsigned char *location, uint64_t value)
@@ -295,7 +301,7 @@ patch_aarch64_26r(unsigned char *location, uint64_t value)
     set_bits(loc32, 0, value, 2, 26);
 }
 
-// A pair of patch_aarch64_21rx and patch_aarch64_12.
+// A pair of patch_aarch64_21rx and patch_aarch64_12x.
 static inline void
 patch_aarch64_33rx(unsigned char *location, uint64_t value)
 {
@@ -331,7 +337,7 @@ patch_aarch64_33rx(unsigned char *location, uint64_t value)
         return;
     }
     patch_aarch64_21rx(location, value);
-    patch_aarch64_12(location + 4, value);
+    patch_aarch64_12x(location + 4, value);
 }
 
 // 32-bit relative address.

--- a/Python/jit.c
+++ b/Python/jit.c
@@ -330,7 +330,8 @@ patch_aarch64_33rx(unsigned char *location, uint64_t value)
         loc32[1] = 0xD503201F;
         return;
     }
-    patch_aarch64_21r(location, value);
+    patch_aarch64_21rx(location, value);
+    patch_aarch64_12(location + 4, value);
 }
 
 // 32-bit relative address.

--- a/Python/jit.c
+++ b/Python/jit.c
@@ -165,7 +165,7 @@ set_bits(uint32_t *loc, uint8_t loc_start, uint64_t value, uint8_t value_start,
 //   - https://github.com/llvm/llvm-project/blob/main/lld/ELF/Arch/X86_64.cpp
 
 // 32-bit absolute address.
-static inline void
+void
 patch_32(unsigned char *location, uint64_t value)
 {
     uint32_t *loc32 = (uint32_t *)location;
@@ -175,7 +175,7 @@ patch_32(unsigned char *location, uint64_t value)
 }
 
 // 32-bit relative address.
-static inline void
+void
 patch_32r(unsigned char *location, uint64_t value)
 {
     uint32_t *loc32 = (uint32_t *)location;
@@ -187,7 +187,7 @@ patch_32r(unsigned char *location, uint64_t value)
 }
 
 // 64-bit absolute address.
-static inline void
+void
 patch_64(unsigned char *location, uint64_t value)
 {
     uint64_t *loc64 = (uint64_t *)location;
@@ -196,7 +196,7 @@ patch_64(unsigned char *location, uint64_t value)
 
 // 12-bit low part of an absolute address. Pairs nicely with patch_aarch64_21r
 // (below).
-static inline void
+void
 patch_aarch64_12(unsigned char *location, uint64_t value)
 {
     uint32_t *loc32 = (uint32_t *)location;
@@ -214,14 +214,14 @@ patch_aarch64_12(unsigned char *location, uint64_t value)
     set_bits(loc32, 10, value, shift, 12);
 }
 
-static inline void
+void
 patch_aarch64_12x(unsigned char *location, uint64_t value)
 {
     patch_aarch64_12(location, value);
 }
 
 // 16-bit low part of an absolute address.
-static inline void
+void
 patch_aarch64_16a(unsigned char *location, uint64_t value)
 {
     uint32_t *loc32 = (uint32_t *)location;
@@ -232,7 +232,7 @@ patch_aarch64_16a(unsigned char *location, uint64_t value)
 }
 
 // 16-bit middle-low part of an absolute address.
-static inline void
+void
 patch_aarch64_16b(unsigned char *location, uint64_t value)
 {
     uint32_t *loc32 = (uint32_t *)location;
@@ -243,7 +243,7 @@ patch_aarch64_16b(unsigned char *location, uint64_t value)
 }
 
 // 16-bit middle-high part of an absolute address.
-static inline void
+void
 patch_aarch64_16c(unsigned char *location, uint64_t value)
 {
     uint32_t *loc32 = (uint32_t *)location;
@@ -254,7 +254,7 @@ patch_aarch64_16c(unsigned char *location, uint64_t value)
 }
 
 // 16-bit high part of an absolute address.
-static inline void
+void
 patch_aarch64_16d(unsigned char *location, uint64_t value)
 {
     uint32_t *loc32 = (uint32_t *)location;
@@ -266,7 +266,7 @@ patch_aarch64_16d(unsigned char *location, uint64_t value)
 
 // 21-bit count of pages between this page and an absolute address's page... I
 // know, I know, it's weird. Pairs nicely with patch_aarch64_12 (above).
-static inline void
+void
 patch_aarch64_21r(unsigned char *location, uint64_t value)
 {
     uint32_t *loc32 = (uint32_t *)location;
@@ -280,14 +280,14 @@ patch_aarch64_21r(unsigned char *location, uint64_t value)
     set_bits(loc32, 5, value, 2, 19);
 }
 
-static inline void
+void
 patch_aarch64_21rx(unsigned char *location, uint64_t value)
 {
     patch_aarch64_21r(location, value);
 }
 
 // 28-bit relative branch.
-static inline void
+void
 patch_aarch64_26r(unsigned char *location, uint64_t value)
 {
     uint32_t *loc32 = (uint32_t *)location;
@@ -302,7 +302,7 @@ patch_aarch64_26r(unsigned char *location, uint64_t value)
 }
 
 // A pair of patch_aarch64_21rx and patch_aarch64_12x.
-static inline void
+void
 patch_aarch64_33rx(unsigned char *location, uint64_t value)
 {
     uint32_t *loc32 = (uint32_t *)location;
@@ -341,7 +341,7 @@ patch_aarch64_33rx(unsigned char *location, uint64_t value)
 }
 
 // 32-bit relative address.
-static inline void
+void
 patch_x86_64_32rx(unsigned char *location, uint64_t value)
 {
     uint8_t *loc8 = (uint8_t *)location;

--- a/Tools/jit/_stencils.py
+++ b/Tools/jit/_stencils.py
@@ -50,6 +50,7 @@ class HoleValue(enum.Enum):
 
 _PATCH_FUNCS = {
     # aarch64-apple-darwin:
+    "ARM64_RELOC_BRANCH26": "patch_aarch64_26r",
     "ARM64_RELOC_GOT_LOAD_PAGE21": "patch_aarch64_21rx",
     "ARM64_RELOC_GOT_LOAD_PAGEOFF12": "patch_aarch64_12",
     "ARM64_RELOC_PAGE21": "patch_aarch64_21r",
@@ -67,7 +68,9 @@ _PATCH_FUNCS = {
     "IMAGE_REL_I386_REL32": "patch_x86_64_32rx",
     # aarch64-unknown-linux-gnu:
     "R_AARCH64_ABS64": "patch_64",
+    "R_AARCH64_ADD_ABS_LO12_NC": "patch_aarch64_12",
     "R_AARCH64_ADR_GOT_PAGE": "patch_aarch64_21rx",
+    "R_AARCH64_ADR_PREL_PG_HI21": "patch_aarch64_21rx",
     "R_AARCH64_CALL26": "patch_aarch64_26r",
     "R_AARCH64_JUMP26": "patch_aarch64_26r",
     "R_AARCH64_LD64_GOT_LO12_NC": "patch_aarch64_12",

--- a/Tools/jit/_stencils.py
+++ b/Tools/jit/_stencils.py
@@ -66,17 +66,6 @@ class Hole:
     # Convenience method:
     replace = dataclasses.replace
 
-    def as_c(self) -> str:
-        """Dump this hole as an initialization of a C Hole struct."""
-        parts = [
-            f"{self.offset:#x}",
-            f"HoleKind_{self.kind}",
-            f"HoleValue_{self.value.name}",
-            f"&{self.symbol}" if self.symbol else "NULL",
-            f"{_signed(self.addend):#x}",
-        ]
-        return f"{{{', '.join(parts)}}}"
-
 
 @dataclasses.dataclass
 class Stencil:

--- a/Tools/jit/_stencils.py
+++ b/Tools/jit/_stencils.py
@@ -50,7 +50,7 @@ class HoleValue(enum.Enum):
 
 _PATCH_FUNCS = {
     # aarch64-apple-darwin:
-    "ARM64_RELOC_GOT_LOAD_PAGE21": "patch_aarch64_21rx",  # XXX
+    "ARM64_RELOC_GOT_LOAD_PAGE21": "patch_aarch64_21rx",
     "ARM64_RELOC_GOT_LOAD_PAGEOFF12": "patch_aarch64_12",
     "ARM64_RELOC_PAGE21": "patch_aarch64_21r",
     "ARM64_RELOC_PAGEOFF12": "patch_aarch64_12",
@@ -59,15 +59,15 @@ _PATCH_FUNCS = {
     "IMAGE_REL_AMD64_REL32": "patch_x86_64_32rx",
     # aarch64-pc-windows-msvc:
     "IMAGE_REL_ARM64_BRANCH26": "patch_aarch64_26r",
-    "IMAGE_REL_ARM64_PAGEBASE_REL21": "patch_aarch64_21rx",  # XXX
+    "IMAGE_REL_ARM64_PAGEBASE_REL21": "patch_aarch64_21rx",
     "IMAGE_REL_ARM64_PAGEOFFSET_12A": "patch_aarch64_12",
     "IMAGE_REL_ARM64_PAGEOFFSET_12L": "patch_aarch64_12",
     # i686-pc-windows-msvc:
     "IMAGE_REL_I386_DIR32": "patch_32",
-    "IMAGE_REL_I386_REL32": "patch_x86_64_32rx",  # XXX
+    "IMAGE_REL_I386_REL32": "patch_x86_64_32rx",
     # aarch64-unknown-linux-gnu:
     "R_AARCH64_ABS64": "patch_64",
-    "R_AARCH64_ADR_GOT_PAGE": "patch_aarch64_21rx",  # XXX
+    "R_AARCH64_ADR_GOT_PAGE": "patch_aarch64_21rx",
     "R_AARCH64_CALL26": "patch_aarch64_26r",
     "R_AARCH64_JUMP26": "patch_aarch64_26r",
     "R_AARCH64_LD64_GOT_LO12_NC": "patch_aarch64_12",
@@ -131,6 +131,7 @@ class Hole:
         self.func = _PATCH_FUNCS[self.kind]
 
     def fold(self, other: typing.Self) -> typing.Self | None:
+        """Combine two holes into a single hole, if possible."""
         if (
             self.offset + 4 == other.offset
             and self.value == other.value
@@ -142,6 +143,7 @@ class Hole:
             folded = self.replace()
             folded.func = "patch_aarch64_33rx"
             return folded
+        return None
 
     def as_c(self, where: str) -> str:
         """Dump this hole as a call to a patch_* function."""

--- a/Tools/jit/_stencils.py
+++ b/Tools/jit/_stencils.py
@@ -52,7 +52,7 @@ _PATCH_FUNCS = {
     # aarch64-apple-darwin:
     "ARM64_RELOC_BRANCH26": "patch_aarch64_26r",
     "ARM64_RELOC_GOT_LOAD_PAGE21": "patch_aarch64_21rx",
-    "ARM64_RELOC_GOT_LOAD_PAGEOFF12": "patch_aarch64_12",
+    "ARM64_RELOC_GOT_LOAD_PAGEOFF12": "patch_aarch64_12x",
     "ARM64_RELOC_PAGE21": "patch_aarch64_21r",
     "ARM64_RELOC_PAGEOFF12": "patch_aarch64_12",
     "ARM64_RELOC_UNSIGNED": "patch_64",
@@ -62,7 +62,7 @@ _PATCH_FUNCS = {
     "IMAGE_REL_ARM64_BRANCH26": "patch_aarch64_26r",
     "IMAGE_REL_ARM64_PAGEBASE_REL21": "patch_aarch64_21rx",
     "IMAGE_REL_ARM64_PAGEOFFSET_12A": "patch_aarch64_12",
-    "IMAGE_REL_ARM64_PAGEOFFSET_12L": "patch_aarch64_12",
+    "IMAGE_REL_ARM64_PAGEOFFSET_12L": "patch_aarch64_12x",
     # i686-pc-windows-msvc:
     "IMAGE_REL_I386_DIR32": "patch_32",
     "IMAGE_REL_I386_REL32": "patch_x86_64_32rx",
@@ -70,10 +70,10 @@ _PATCH_FUNCS = {
     "R_AARCH64_ABS64": "patch_64",
     "R_AARCH64_ADD_ABS_LO12_NC": "patch_aarch64_12",
     "R_AARCH64_ADR_GOT_PAGE": "patch_aarch64_21rx",
-    "R_AARCH64_ADR_PREL_PG_HI21": "patch_aarch64_21rx",
+    "R_AARCH64_ADR_PREL_PG_HI21": "patch_aarch64_21r",
     "R_AARCH64_CALL26": "patch_aarch64_26r",
     "R_AARCH64_JUMP26": "patch_aarch64_26r",
-    "R_AARCH64_LD64_GOT_LO12_NC": "patch_aarch64_12",
+    "R_AARCH64_LD64_GOT_LO12_NC": "patch_aarch64_12x",
     "R_AARCH64_MOVW_UABS_G0_NC": "patch_aarch64_16a",
     "R_AARCH64_MOVW_UABS_G1_NC": "patch_aarch64_16b",
     "R_AARCH64_MOVW_UABS_G2_NC": "patch_aarch64_16c",
@@ -141,7 +141,7 @@ class Hole:
             and self.symbol == other.symbol
             and self.addend == other.addend
             and self.func == "patch_aarch64_21rx"
-            and other.func == "patch_aarch64_12"
+            and other.func == "patch_aarch64_12x"
         ):
             folded = self.replace()
             folded.func = "patch_aarch64_33rx"

--- a/Tools/jit/_stencils.py
+++ b/Tools/jit/_stencils.py
@@ -48,6 +48,9 @@ class HoleValue(enum.Enum):
     ZERO = enum.auto()
 
 
+# Map relocation types to our JIT's patch functions. "r" suffixes indicate that
+# the patch function is relative. "x" suffixes indicate that they are "relaxing"
+# (see comments in jit.c for more info):
 _PATCH_FUNCS = {
     # aarch64-apple-darwin:
     "ARM64_RELOC_BRANCH26": "patch_aarch64_26r",
@@ -91,6 +94,7 @@ _PATCH_FUNCS = {
     "X86_64_RELOC_SIGNED": "patch_32r",
     "X86_64_RELOC_UNSIGNED": "patch_64",
 }
+# Translate HoleValues to C expressions:
 _HOLE_EXPRS = {
     HoleValue.CODE: "(uintptr_t)code",
     HoleValue.CONTINUE: "(uintptr_t)code + sizeof(code_body)",
@@ -143,6 +147,8 @@ class Hole:
             and self.func == "patch_aarch64_21rx"
             and other.func == "patch_aarch64_12x"
         ):
+            # These can *only* be properly relaxed when they appear together and
+            # patch the same value:
             folded = self.replace()
             folded.func = "patch_aarch64_33rx"
             return folded

--- a/Tools/jit/_stencils.py
+++ b/Tools/jit/_stencils.py
@@ -350,6 +350,10 @@ class StencilGroup:
             )
             self.data.body.extend([0] * 8)
 
+    def as_c(self, opname: str) -> str:
+        """Dump this hole as a StencilGroup initializer."""
+        return f"{{emit_{opname}, {len(self.code.body)}, {len(self.data.body)}}}"
+
 
 def symbol_to_value(symbol: str) -> tuple[HoleValue, str | None]:
     """

--- a/Tools/jit/_stencils.py
+++ b/Tools/jit/_stencils.py
@@ -100,6 +100,7 @@ _HOLE_EXPRS = {
     HoleValue.CONTINUE: "(uintptr_t)code + sizeof(code_body)",
     HoleValue.DATA: "(uintptr_t)data",
     HoleValue.EXECUTOR: "(uintptr_t)executor",
+    # These should all have been turned into DATA values by process_relocations:
     # HoleValue.GOT: "",
     HoleValue.OPARG: "instruction->oparg",
     HoleValue.OPERAND: "instruction->operand",

--- a/Tools/jit/_writer.py
+++ b/Tools/jit/_writer.py
@@ -29,7 +29,7 @@ def _dump_stencil(opname: str, group: _stencils.StencilGroup) -> typing.Iterator
     yield "void"
     yield f"emit_{opname}("
     yield "    unsigned char *code, unsigned char *data, _PyExecutorObject *executor,"
-    yield "    const _PyUOpInstruction *instruction,uintptr_t instruction_starts[])"
+    yield "    const _PyUOpInstruction *instruction, uintptr_t instruction_starts[])"
     yield "{"
     for part, stencil in [("code", group.code), ("data", group.data)]:
         for line in stencil.disassembly:

--- a/Tools/jit/_writer.py
+++ b/Tools/jit/_writer.py
@@ -5,61 +5,110 @@ import typing
 import _schema
 import _stencils
 
+_PATCH_REMAP = {
+    # aarch64-apple-darwin:
+    "ARM64_RELOC_GOT_LOAD_PAGE21": "aarch64_21x",
+    "ARM64_RELOC_GOT_LOAD_PAGEOFF12": "aarch64_12",
+    "ARM64_RELOC_PAGE21": "aarch64_21",
+    "ARM64_RELOC_PAGEOFF12": "aarch64_12",
+    "ARM64_RELOC_UNSIGNED": "64",
+    # x86_64-pc-windows-msvc:
+    "IMAGE_REL_AMD64_REL32": "x86_64_32x",
+    # aarch64-pc-windows-msvc:
+    "IMAGE_REL_ARM64_BRANCH26": "aarch64_26",
+    "IMAGE_REL_ARM64_PAGEBASE_REL21": "aarch64_21x",
+    "IMAGE_REL_ARM64_PAGEOFFSET_12A": "aarch64_12",
+    "IMAGE_REL_ARM64_PAGEOFFSET_12L": "aarch64_12",
+    # i686-pc-windows-msvc:
+    "IMAGE_REL_I386_DIR32": "32",
+    "IMAGE_REL_I386_REL32": "x86_64_32x",  # XXX
+    # aarch64-unknown-linux-gnu:
+    "R_AARCH64_ABS64": "64",
+    "R_AARCH64_ADR_GOT_PAGE": "aarch64_21x",
+    "R_AARCH64_CALL26": "aarch64_26",
+    "R_AARCH64_JUMP26": "aarch64_26",
+    "R_AARCH64_LD64_GOT_LO12_NC": "aarch64_12",
+    "R_AARCH64_MOVW_UABS_G0_NC": "aarch64_16a",
+    "R_AARCH64_MOVW_UABS_G1_NC": "aarch64_16b",
+    "R_AARCH64_MOVW_UABS_G2_NC": "aarch64_16c",
+    "R_AARCH64_MOVW_UABS_G3": "aarch64_16d",
+    # x86_64-unknown-linux-gnu:
+    "R_X86_64_64": "64",
+    "R_X86_64_GOTPCREL": "32r",
+    "R_X86_64_GOTPCRELX": "x86_64_32x",
+    "R_X86_64_PC32": "32r",
+    "R_X86_64_REX_GOTPCRELX": "x86_64_32x",
+    # x86_64-apple-darwin:
+    "X86_64_RELOC_BRANCH": "32r",
+    "X86_64_RELOC_GOT": "x86_64_32x",
+    "X86_64_RELOC_GOT_LOAD": "x86_64_32x",
+    "X86_64_RELOC_SIGNED": "32r",
+    "X86_64_RELOC_UNSIGNED": "64",
+}
 
 def _dump_header() -> typing.Iterator[str]:
-    yield "typedef enum {"
-    for kind in typing.get_args(_schema.HoleKind):
-        yield f"    HoleKind_{kind},"
-    yield "} HoleKind;"
-    yield ""
+    yield "typedef void (*emitter)(uintptr_t patches[]);"
+    # yield "typedef enum {"
+    # for kind in typing.get_args(_schema.HoleKind):
+    #     yield f"    HoleKind_{kind},"
+    # yield "} HoleKind;"
+    # yield ""
     yield "typedef enum {"
     for value in _stencils.HoleValue:
         yield f"    HoleValue_{value.name},"
     yield "} HoleValue;"
     yield ""
-    yield "typedef struct {"
-    yield "    const size_t offset;"
-    yield "    const HoleKind kind;"
-    yield "    const HoleValue value;"
-    yield "    const void *symbol;"
-    yield "    const uint64_t addend;"
-    yield "} Hole;"
-    yield ""
-    yield "typedef struct {"
-    yield "    const size_t body_size;"
-    yield "    const unsigned char * const body;"
-    yield "    const size_t holes_size;"
-    yield "    const Hole * const holes;"
-    yield "} Stencil;"
-    yield ""
-    yield "typedef struct {"
-    yield "    const Stencil code;"
-    yield "    const Stencil data;"
-    yield "} StencilGroup;"
-    yield ""
+    # yield "typedef struct {"
+    # yield "    const size_t offset;"
+    # yield "    const HoleKind kind;"
+    # yield "    const HoleValue value;"
+    # yield "    const void *symbol;"
+    # yield "    const uint64_t addend;"
+    # yield "} Hole;"
+    # yield ""
+    # yield "typedef struct {"
+    # yield "    const size_t body_size;"
+    # yield "    const unsigned char * const body;"
+    # yield "    const size_t holes_size;"
+    # yield "    const Hole * const holes;"
+    # yield "} Stencil;"
+    # yield ""
+    # yield "typedef struct {"
+    # yield "    const Stencil code;"
+    # yield "    const Stencil data;"
+    # yield "} StencilGroup;"
+    # yield ""
 
 
-def _dump_footer(opnames: typing.Iterable[str]) -> typing.Iterator[str]:
-    yield "#define INIT_STENCIL(STENCIL) {                         \\"
-    yield "    .body_size = Py_ARRAY_LENGTH(STENCIL##_body) - 1,   \\"
-    yield "    .body = STENCIL##_body,                             \\"
-    yield "    .holes_size = Py_ARRAY_LENGTH(STENCIL##_holes) - 1, \\"
-    yield "    .holes = STENCIL##_holes,                           \\"
-    yield "}"
-    yield ""
-    yield "#define INIT_STENCIL_GROUP(OP) {     \\"
-    yield "    .code = INIT_STENCIL(OP##_code), \\"
-    yield "    .data = INIT_STENCIL(OP##_data), \\"
-    yield "}"
-    yield ""
-    yield "static const StencilGroup stencil_groups[512] = {"
-    for opname in opnames:
+def _dump_footer(groups: dict[str, _stencils.StencilGroup]) -> typing.Iterator[str]:
+    # yield "#define INIT_STENCIL(STENCIL) {                         \\"
+    # yield "    .body_size = Py_ARRAY_LENGTH(STENCIL##_body) - 1,   \\"
+    # yield "    .body = STENCIL##_body,                             \\"
+    # yield "    .holes_size = Py_ARRAY_LENGTH(STENCIL##_holes) - 1, \\"
+    # yield "    .holes = STENCIL##_holes,                           \\"
+    # yield "}"
+    # yield ""
+    # yield "#define INIT_STENCIL_GROUP(OP) {     \\"
+    # yield "    .code = INIT_STENCIL(OP##_code), \\"
+    # yield "    .data = INIT_STENCIL(OP##_data), \\"
+    # yield "}"
+    # yield ""
+    yield "static const emitter emitters[MAX_UOP_ID + 1] = {"
+    for opname in sorted(groups):
         if opname == "trampoline":
             continue
-        yield f"    [{opname}] = INIT_STENCIL_GROUP({opname}),"
+        yield f"    [{opname}] = emit_{opname},"
     yield "};"
     yield ""
-    yield "static const StencilGroup trampoline = INIT_STENCIL_GROUP(trampoline);"
+    yield "static const size_t emitted[MAX_UOP_ID + 1][2] = {"
+    for opname, group in sorted(groups.items()):
+        if opname == "trampoline":
+            continue
+        yield f"    [{opname}] = {{{len(group.code.body)}, {len(group.data.body)}}},"
+    yield "};"
+    yield ""
+    yield f"static const size_t emitted_trampoline_code = {len(groups['trampoline'].code.body)};"
+    yield f"static const size_t emitted_trampoline_data = {len(groups['trampoline'].data.body)};"
     yield ""
     yield "#define GET_PATCHES() { \\"
     for value in _stencils.HoleValue:
@@ -68,27 +117,22 @@ def _dump_footer(opnames: typing.Iterable[str]) -> typing.Iterator[str]:
 
 
 def _dump_stencil(opname: str, group: _stencils.StencilGroup) -> typing.Iterator[str]:
-    yield f"// {opname}"
-    for part, stencil in [("code", group.code), ("data", group.data)]:
+    yield f"void emit_{opname}(uintptr_t patches[]) {{"
+    yield f"    unsigned char *location;"
+    for part, stencil in [("data", group.data), ("code", group.code)]:
         for line in stencil.disassembly:
-            yield f"// {line}"
+            yield f"    // {line}"
         if stencil.body:
-            size = len(stencil.body) + 1
-            yield f"static const unsigned char {opname}_{part}_body[{size}] = {{"
+            yield f"    const unsigned char {part}[{len(stencil.body)}] = {{"
             for i in range(0, len(stencil.body), 8):
                 row = " ".join(f"{byte:#04x}," for byte in stencil.body[i : i + 8])
-                yield f"    {row}"
-            yield "};"
-        else:
-            yield f"static const unsigned char {opname}_{part}_body[1];"
-        if stencil.holes:
-            size = len(stencil.holes) + 1
-            yield f"static const Hole {opname}_{part}_holes[{size}] = {{"
-            for hole in stencil.holes:
-                yield f"    {hole.as_c()},"
-            yield "};"
-        else:
-            yield f"static const Hole {opname}_{part}_holes[1];"
+                yield f"        {row}"
+            yield "    };"
+            yield f"    location = (unsigned char *)patches[HoleValue_{part.upper()}];"
+            yield f"    memcpy(location, {part}, sizeof({part}));"
+        for hole in stencil.holes:
+            yield f"    patch_{_PATCH_REMAP[hole.kind]}(location + {hole.offset}, patches[HoleValue_{hole.value.name}]{f' + (uintptr_t)&{hole.symbol}' if hole.symbol else ''}{f' + {_stencils._signed(hole.addend):#x}' if _stencils._signed(hole.addend) else ''});"
+    yield "}"
     yield ""
 
 

--- a/Tools/jit/_writer.py
+++ b/Tools/jit/_writer.py
@@ -5,8 +5,6 @@ import typing
 
 import _stencils
 
-def _initialize_stencil_group(opname: str, group: _stencils.StencilGroup) -> str:
-    return f"{{emit_{opname}, {len(group.code.body)}, {len(group.data.body)}}}"
 
 def _dump_footer(groups: dict[str, _stencils.StencilGroup]) -> typing.Iterator[str]:
     yield "typedef struct {"
@@ -17,14 +15,13 @@ def _dump_footer(groups: dict[str, _stencils.StencilGroup]) -> typing.Iterator[s
     yield "    size_t data_size;"
     yield "} StencilGroup;"
     yield ""
-    initializer = _initialize_stencil_group('trampoline', groups['trampoline'])
-    yield f"static const StencilGroup trampoline = {initializer};"
+    yield f"static const StencilGroup trampoline = {groups['trampoline'].as_c('trampoline')};"
     yield ""
     yield "static const StencilGroup stencil_groups[MAX_UOP_ID + 1] = {"
     for opname, group in sorted(groups.items()):
         if opname == "trampoline":
             continue
-        yield f"    [{opname}] = {_initialize_stencil_group(opname, group)},"
+        yield f"    [{opname}] = {group.as_c(opname)},"
     yield "};"
 
 

--- a/Tools/jit/_writer.py
+++ b/Tools/jit/_writer.py
@@ -5,94 +5,85 @@ import typing
 import _schema
 import _stencils
 
-_PATCH_REMAP = {
+_PATCH_FUNCS = {
     # aarch64-apple-darwin:
-    "ARM64_RELOC_GOT_LOAD_PAGE21": "aarch64_21x",
-    "ARM64_RELOC_GOT_LOAD_PAGEOFF12": "aarch64_12",
-    "ARM64_RELOC_PAGE21": "aarch64_21",
-    "ARM64_RELOC_PAGEOFF12": "aarch64_12",
-    "ARM64_RELOC_UNSIGNED": "64",
+    "ARM64_RELOC_GOT_LOAD_PAGE21": "patch_aarch64_21x",
+    "ARM64_RELOC_GOT_LOAD_PAGEOFF12": "patch_aarch64_12",
+    "ARM64_RELOC_PAGE21": "patch_aarch64_21",
+    "ARM64_RELOC_PAGEOFF12": "patch_aarch64_12",
+    "ARM64_RELOC_UNSIGNED": "patch_64",
     # x86_64-pc-windows-msvc:
-    "IMAGE_REL_AMD64_REL32": "x86_64_32x",
+    "IMAGE_REL_AMD64_REL32": "patch_x86_64_32x",
     # aarch64-pc-windows-msvc:
-    "IMAGE_REL_ARM64_BRANCH26": "aarch64_26",
-    "IMAGE_REL_ARM64_PAGEBASE_REL21": "aarch64_21x",
-    "IMAGE_REL_ARM64_PAGEOFFSET_12A": "aarch64_12",
-    "IMAGE_REL_ARM64_PAGEOFFSET_12L": "aarch64_12",
+    "IMAGE_REL_ARM64_BRANCH26": "patch_aarch64_26",
+    "IMAGE_REL_ARM64_PAGEBASE_REL21": "patch_aarch64_21x",
+    "IMAGE_REL_ARM64_PAGEOFFSET_12A": "patch_aarch64_12",
+    "IMAGE_REL_ARM64_PAGEOFFSET_12L": "patch_aarch64_12",
     # i686-pc-windows-msvc:
-    "IMAGE_REL_I386_DIR32": "32",
-    "IMAGE_REL_I386_REL32": "x86_64_32x",  # XXX
+    "IMAGE_REL_I386_DIR32": "patch_32",
+    "IMAGE_REL_I386_REL32": "patch_x86_64_32x",  # XXX
     # aarch64-unknown-linux-gnu:
-    "R_AARCH64_ABS64": "64",
-    "R_AARCH64_ADR_GOT_PAGE": "aarch64_21x",
-    "R_AARCH64_CALL26": "aarch64_26",
-    "R_AARCH64_JUMP26": "aarch64_26",
-    "R_AARCH64_LD64_GOT_LO12_NC": "aarch64_12",
-    "R_AARCH64_MOVW_UABS_G0_NC": "aarch64_16a",
-    "R_AARCH64_MOVW_UABS_G1_NC": "aarch64_16b",
-    "R_AARCH64_MOVW_UABS_G2_NC": "aarch64_16c",
-    "R_AARCH64_MOVW_UABS_G3": "aarch64_16d",
+    "R_AARCH64_ABS64": "patch_64",
+    "R_AARCH64_ADR_GOT_PAGE": "patch_aarch64_21x",
+    "R_AARCH64_CALL26": "patch_aarch64_26",
+    "R_AARCH64_JUMP26": "patch_aarch64_26",
+    "R_AARCH64_LD64_GOT_LO12_NC": "patch_aarch64_12",
+    "R_AARCH64_MOVW_UABS_G0_NC": "patch_aarch64_16a",
+    "R_AARCH64_MOVW_UABS_G1_NC": "patch_aarch64_16b",
+    "R_AARCH64_MOVW_UABS_G2_NC": "patch_aarch64_16c",
+    "R_AARCH64_MOVW_UABS_G3": "patch_aarch64_16d",
     # x86_64-unknown-linux-gnu:
-    "R_X86_64_64": "64",
-    "R_X86_64_GOTPCREL": "32r",
-    "R_X86_64_GOTPCRELX": "x86_64_32x",
-    "R_X86_64_PC32": "32r",
-    "R_X86_64_REX_GOTPCRELX": "x86_64_32x",
+    "R_X86_64_64": "patch_64",
+    "R_X86_64_GOTPCREL": "patch_32r",
+    "R_X86_64_GOTPCRELX": "patch_x86_64_32x",
+    "R_X86_64_PC32": "patch_32r",
+    "R_X86_64_REX_GOTPCRELX": "patch_x86_64_32x",
     # x86_64-apple-darwin:
-    "X86_64_RELOC_BRANCH": "32r",
-    "X86_64_RELOC_GOT": "x86_64_32x",
-    "X86_64_RELOC_GOT_LOAD": "x86_64_32x",
-    "X86_64_RELOC_SIGNED": "32r",
-    "X86_64_RELOC_UNSIGNED": "64",
+    "X86_64_RELOC_BRANCH": "patch_32r",
+    "X86_64_RELOC_GOT": "patch_x86_64_32x",
+    "X86_64_RELOC_GOT_LOAD": "patch_x86_64_32x",
+    "X86_64_RELOC_SIGNED": "patch_32r",
+    "X86_64_RELOC_UNSIGNED": "patch_64",
 }
 
-def _dump_header() -> typing.Iterator[str]:
-    yield "typedef void (*emitter)(uintptr_t patches[]);"
-    # yield "typedef enum {"
-    # for kind in typing.get_args(_schema.HoleKind):
-    #     yield f"    HoleKind_{kind},"
-    # yield "} HoleKind;"
-    # yield ""
-    yield "typedef enum {"
-    for value in _stencils.HoleValue:
-        yield f"    HoleValue_{value.name},"
-    yield "} HoleValue;"
-    yield ""
-    # yield "typedef struct {"
-    # yield "    const size_t offset;"
-    # yield "    const HoleKind kind;"
-    # yield "    const HoleValue value;"
-    # yield "    const void *symbol;"
-    # yield "    const uint64_t addend;"
-    # yield "} Hole;"
-    # yield ""
-    # yield "typedef struct {"
-    # yield "    const size_t body_size;"
-    # yield "    const unsigned char * const body;"
-    # yield "    const size_t holes_size;"
-    # yield "    const Hole * const holes;"
-    # yield "} Stencil;"
-    # yield ""
-    # yield "typedef struct {"
-    # yield "    const Stencil code;"
-    # yield "    const Stencil data;"
-    # yield "} StencilGroup;"
-    # yield ""
+_HOLE_EXPRS = {
+    _stencils.HoleValue.CODE: "(uintptr_t)code",
+    _stencils.HoleValue.CONTINUE: "(uintptr_t)code + sizeof(code_body)",
+    _stencils.HoleValue.DATA: "(uintptr_t)data",
+    _stencils.HoleValue.EXECUTOR: "(uintptr_t)executor",
+    # _stencils.HoleValue.GOT: "",
+    _stencils.HoleValue.OPARG: "instruction->oparg",
+    _stencils.HoleValue.OPERAND: "instruction->operand",
+    _stencils.HoleValue.OPERAND_HI: "(instruction->operand >> 32)",
+    _stencils.HoleValue.OPERAND_LO: "(instruction->operand & UINT32_MAX)",
+    _stencils.HoleValue.TARGET: "instruction->target",
+    _stencils.HoleValue.JUMP_TARGET: "instruction_starts[instruction->jump_target]",
+    _stencils.HoleValue.ERROR_TARGET: "instruction_starts[instruction->error_target]",
+    _stencils.HoleValue.EXIT_INDEX: "instruction->exit_index",
+    _stencils.HoleValue.TOP: "instruction_starts[1]",
+    _stencils.HoleValue.ZERO: "",
+}
+
+def _hole_to_patch(where: str, hole: _stencils.Hole) -> str:
+    func = _PATCH_FUNCS[hole.kind]
+    location = f"{where} + {hole.offset:#x}"
+    value = _HOLE_EXPRS[hole.value]
+    if hole.symbol:
+        if value:
+            value += " + "
+        value += f"(uintptr_t)&{hole.symbol}"
+    if _stencils._signed(hole.addend):
+        if value:
+            value += " + "
+        value += f"{_stencils._signed(hole.addend):#x}"
+    return f"{func}({location}, {value});"
 
 
 def _dump_footer(groups: dict[str, _stencils.StencilGroup]) -> typing.Iterator[str]:
-    # yield "#define INIT_STENCIL(STENCIL) {                         \\"
-    # yield "    .body_size = Py_ARRAY_LENGTH(STENCIL##_body) - 1,   \\"
-    # yield "    .body = STENCIL##_body,                             \\"
-    # yield "    .holes_size = Py_ARRAY_LENGTH(STENCIL##_holes) - 1, \\"
-    # yield "    .holes = STENCIL##_holes,                           \\"
-    # yield "}"
-    # yield ""
-    # yield "#define INIT_STENCIL_GROUP(OP) {     \\"
-    # yield "    .code = INIT_STENCIL(OP##_code), \\"
-    # yield "    .data = INIT_STENCIL(OP##_data), \\"
-    # yield "}"
-    # yield ""
+    yield "typedef void (*emitter)(unsigned char *code, unsigned char *data,"
+    yield "                        _PyExecutorObject *executor, const _PyUOpInstruction *instruction,"
+    yield "                        uintptr_t instruction_starts[]);"
+    yield ""
     yield "static const emitter emitters[MAX_UOP_ID + 1] = {"
     for opname in sorted(groups):
         if opname == "trampoline":
@@ -110,35 +101,34 @@ def _dump_footer(groups: dict[str, _stencils.StencilGroup]) -> typing.Iterator[s
     yield f"static const size_t emitted_trampoline_code = {len(groups['trampoline'].code.body)};"
     yield f"static const size_t emitted_trampoline_data = {len(groups['trampoline'].data.body)};"
     yield ""
-    yield "#define GET_PATCHES() { \\"
-    for value in _stencils.HoleValue:
-        yield f"    [HoleValue_{value.name}] = (uintptr_t)0xBADBADBADBADBADB, \\"
-    yield "}"
 
 
 def _dump_stencil(opname: str, group: _stencils.StencilGroup) -> typing.Iterator[str]:
-    yield f"void emit_{opname}(uintptr_t patches[]) {{"
-    yield f"    unsigned char *location;"
-    for part, stencil in [("data", group.data), ("code", group.code)]:
+    yield "void"
+    yield f"emit_{opname}(unsigned char *code, unsigned char *data,"
+    yield f"     {' ' * len(opname)} _PyExecutorObject *executor, const _PyUOpInstruction *instruction,"
+    yield f"     {' ' * len(opname)} uintptr_t instruction_starts[])"
+    yield "{"
+    for part, stencil in [("code", group.code), ("data", group.data)]:
         for line in stencil.disassembly:
             yield f"    // {line}"
         if stencil.body:
-            yield f"    const unsigned char {part}[{len(stencil.body)}] = {{"
+            yield f"    const unsigned char {part}_body[{len(stencil.body)}] = {{"
             for i in range(0, len(stencil.body), 8):
                 row = " ".join(f"{byte:#04x}," for byte in stencil.body[i : i + 8])
                 yield f"        {row}"
             yield "    };"
-            yield f"    location = (unsigned char *)patches[HoleValue_{part.upper()}];"
-            yield f"    memcpy(location, {part}, sizeof({part}));"
+    for part, stencil in [("data", group.data), ("code", group.code)]:
+        if stencil.body:
+            yield f"    memcpy({part}, {part}_body, sizeof({part}_body));"
         for hole in stencil.holes:
-            yield f"    patch_{_PATCH_REMAP[hole.kind]}(location + {hole.offset}, patches[HoleValue_{hole.value.name}]{f' + (uintptr_t)&{hole.symbol}' if hole.symbol else ''}{f' + {_stencils._signed(hole.addend):#x}' if _stencils._signed(hole.addend) else ''});"
+            yield f"    {_hole_to_patch(part, hole)}"
     yield "}"
     yield ""
 
 
 def dump(groups: dict[str, _stencils.StencilGroup]) -> typing.Iterator[str]:
     """Yield a JIT compiler line-by-line as a C header file."""
-    yield from _dump_header()
-    for opname, group in groups.items():
+    for opname, group in sorted(groups.items()):
         yield from _dump_stencil(opname, group)
     yield from _dump_footer(groups)

--- a/Tools/jit/_writer.py
+++ b/Tools/jit/_writer.py
@@ -2,81 +2,7 @@
 
 import typing
 
-import _schema
 import _stencils
-
-_PATCH_FUNCS = {
-    # aarch64-apple-darwin:
-    "ARM64_RELOC_GOT_LOAD_PAGE21": "patch_aarch64_21rx",
-    "ARM64_RELOC_GOT_LOAD_PAGEOFF12": "patch_aarch64_12",
-    "ARM64_RELOC_PAGE21": "patch_aarch64_21r",
-    "ARM64_RELOC_PAGEOFF12": "patch_aarch64_12",
-    "ARM64_RELOC_UNSIGNED": "patch_64",
-    # x86_64-pc-windows-msvc:
-    "IMAGE_REL_AMD64_REL32": "patch_x86_64_32rx",
-    # aarch64-pc-windows-msvc:
-    "IMAGE_REL_ARM64_BRANCH26": "patch_aarch64_26r",
-    "IMAGE_REL_ARM64_PAGEBASE_REL21": "patch_aarch64_21rx",
-    "IMAGE_REL_ARM64_PAGEOFFSET_12A": "patch_aarch64_12",
-    "IMAGE_REL_ARM64_PAGEOFFSET_12L": "patch_aarch64_12",
-    # i686-pc-windows-msvc:
-    "IMAGE_REL_I386_DIR32": "patch_32",
-    "IMAGE_REL_I386_REL32": "patch_x86_64_32rx",  # XXX
-    # aarch64-unknown-linux-gnu:
-    "R_AARCH64_ABS64": "patch_64",
-    "R_AARCH64_ADR_GOT_PAGE": "patch_aarch64_21rx",
-    "R_AARCH64_CALL26": "patch_aarch64_26r",
-    "R_AARCH64_JUMP26": "patch_aarch64_26r",
-    "R_AARCH64_LD64_GOT_LO12_NC": "patch_aarch64_12",
-    "R_AARCH64_MOVW_UABS_G0_NC": "patch_aarch64_16a",
-    "R_AARCH64_MOVW_UABS_G1_NC": "patch_aarch64_16b",
-    "R_AARCH64_MOVW_UABS_G2_NC": "patch_aarch64_16c",
-    "R_AARCH64_MOVW_UABS_G3": "patch_aarch64_16d",
-    # x86_64-unknown-linux-gnu:
-    "R_X86_64_64": "patch_64",
-    "R_X86_64_GOTPCREL": "patch_32r",
-    "R_X86_64_GOTPCRELX": "patch_x86_64_32rx",
-    "R_X86_64_PC32": "patch_32r",
-    "R_X86_64_REX_GOTPCRELX": "patch_x86_64_32rx",
-    # x86_64-apple-darwin:
-    "X86_64_RELOC_BRANCH": "patch_32r",
-    "X86_64_RELOC_GOT": "patch_x86_64_32rx",
-    "X86_64_RELOC_GOT_LOAD": "patch_x86_64_32rx",
-    "X86_64_RELOC_SIGNED": "patch_32r",
-    "X86_64_RELOC_UNSIGNED": "patch_64",
-}
-
-_HOLE_EXPRS = {
-    _stencils.HoleValue.CODE: "(uintptr_t)code",
-    _stencils.HoleValue.CONTINUE: "(uintptr_t)code + sizeof(code_body)",
-    _stencils.HoleValue.DATA: "(uintptr_t)data",
-    _stencils.HoleValue.EXECUTOR: "(uintptr_t)executor",
-    # _stencils.HoleValue.GOT: "",
-    _stencils.HoleValue.OPARG: "instruction->oparg",
-    _stencils.HoleValue.OPERAND: "instruction->operand",
-    _stencils.HoleValue.OPERAND_HI: "(instruction->operand >> 32)",
-    _stencils.HoleValue.OPERAND_LO: "(instruction->operand & UINT32_MAX)",
-    _stencils.HoleValue.TARGET: "instruction->target",
-    _stencils.HoleValue.JUMP_TARGET: "instruction_starts[instruction->jump_target]",
-    _stencils.HoleValue.ERROR_TARGET: "instruction_starts[instruction->error_target]",
-    _stencils.HoleValue.EXIT_INDEX: "instruction->exit_index",
-    _stencils.HoleValue.TOP: "instruction_starts[1]",
-    _stencils.HoleValue.ZERO: "",
-}
-
-def _hole_to_patch(where: str, hole: _stencils.Hole) -> str:
-    func = _PATCH_FUNCS[hole.kind]
-    location = f"{where} + {hole.offset:#x}"
-    value = _HOLE_EXPRS[hole.value]
-    if hole.symbol:
-        if value:
-            value += " + "
-        value += f"(uintptr_t)&{hole.symbol}"
-    if _stencils._signed(hole.addend):
-        if value:
-            value += " + "
-        value += f"{_stencils._signed(hole.addend):#x}"
-    return f"{func}({location}, {value});"
 
 
 def _dump_footer(groups: dict[str, _stencils.StencilGroup]) -> typing.Iterator[str]:
@@ -122,7 +48,7 @@ def _dump_stencil(opname: str, group: _stencils.StencilGroup) -> typing.Iterator
         if stencil.body:
             yield f"    memcpy({part}, {part}_body, sizeof({part}_body));"
         for hole in stencil.holes:
-            yield f"    {_hole_to_patch(part, hole)}"
+            yield f"    {hole.as_c(part)}"
     yield "}"
     yield ""
 

--- a/Tools/jit/_writer.py
+++ b/Tools/jit/_writer.py
@@ -40,6 +40,7 @@ def _dump_stencil(opname: str, group: _stencils.StencilGroup) -> typing.Iterator
                 row = " ".join(f"{byte:#04x}," for byte in stencil.body[i : i + 8])
                 yield f"        {row}"
             yield "    };"
+    # Data is written first (so relaxations in the code work properly):
     for part, stencil in [("data", group.data), ("code", group.code)]:
         if stencil.body:
             yield f"    memcpy({part}, {part}_body, sizeof({part}_body));"

--- a/Tools/jit/_writer.py
+++ b/Tools/jit/_writer.py
@@ -7,26 +7,26 @@ import _stencils
 
 _PATCH_FUNCS = {
     # aarch64-apple-darwin:
-    "ARM64_RELOC_GOT_LOAD_PAGE21": "patch_aarch64_21x",
+    "ARM64_RELOC_GOT_LOAD_PAGE21": "patch_aarch64_21rx",
     "ARM64_RELOC_GOT_LOAD_PAGEOFF12": "patch_aarch64_12",
-    "ARM64_RELOC_PAGE21": "patch_aarch64_21",
+    "ARM64_RELOC_PAGE21": "patch_aarch64_21r",
     "ARM64_RELOC_PAGEOFF12": "patch_aarch64_12",
     "ARM64_RELOC_UNSIGNED": "patch_64",
     # x86_64-pc-windows-msvc:
-    "IMAGE_REL_AMD64_REL32": "patch_x86_64_32x",
+    "IMAGE_REL_AMD64_REL32": "patch_x86_64_32rx",
     # aarch64-pc-windows-msvc:
-    "IMAGE_REL_ARM64_BRANCH26": "patch_aarch64_26",
-    "IMAGE_REL_ARM64_PAGEBASE_REL21": "patch_aarch64_21x",
+    "IMAGE_REL_ARM64_BRANCH26": "patch_aarch64_26r",
+    "IMAGE_REL_ARM64_PAGEBASE_REL21": "patch_aarch64_21rx",
     "IMAGE_REL_ARM64_PAGEOFFSET_12A": "patch_aarch64_12",
     "IMAGE_REL_ARM64_PAGEOFFSET_12L": "patch_aarch64_12",
     # i686-pc-windows-msvc:
     "IMAGE_REL_I386_DIR32": "patch_32",
-    "IMAGE_REL_I386_REL32": "patch_x86_64_32x",  # XXX
+    "IMAGE_REL_I386_REL32": "patch_x86_64_32rx",  # XXX
     # aarch64-unknown-linux-gnu:
     "R_AARCH64_ABS64": "patch_64",
-    "R_AARCH64_ADR_GOT_PAGE": "patch_aarch64_21x",
-    "R_AARCH64_CALL26": "patch_aarch64_26",
-    "R_AARCH64_JUMP26": "patch_aarch64_26",
+    "R_AARCH64_ADR_GOT_PAGE": "patch_aarch64_21rx",
+    "R_AARCH64_CALL26": "patch_aarch64_26r",
+    "R_AARCH64_JUMP26": "patch_aarch64_26r",
     "R_AARCH64_LD64_GOT_LO12_NC": "patch_aarch64_12",
     "R_AARCH64_MOVW_UABS_G0_NC": "patch_aarch64_16a",
     "R_AARCH64_MOVW_UABS_G1_NC": "patch_aarch64_16b",
@@ -35,13 +35,13 @@ _PATCH_FUNCS = {
     # x86_64-unknown-linux-gnu:
     "R_X86_64_64": "patch_64",
     "R_X86_64_GOTPCREL": "patch_32r",
-    "R_X86_64_GOTPCRELX": "patch_x86_64_32x",
+    "R_X86_64_GOTPCRELX": "patch_x86_64_32rx",
     "R_X86_64_PC32": "patch_32r",
-    "R_X86_64_REX_GOTPCRELX": "patch_x86_64_32x",
+    "R_X86_64_REX_GOTPCRELX": "patch_x86_64_32rx",
     # x86_64-apple-darwin:
     "X86_64_RELOC_BRANCH": "patch_32r",
-    "X86_64_RELOC_GOT": "patch_x86_64_32x",
-    "X86_64_RELOC_GOT_LOAD": "patch_x86_64_32x",
+    "X86_64_RELOC_GOT": "patch_x86_64_32rx",
+    "X86_64_RELOC_GOT_LOAD": "patch_x86_64_32rx",
     "X86_64_RELOC_SIGNED": "patch_32r",
     "X86_64_RELOC_UNSIGNED": "patch_64",
 }


### PR DESCRIPTION
This breaks up the JIT into smaller functions, reduces a lot of branching in hot inner loops, and generally makes the C code cleaner (and [probably faster](https://github.com/faster-cpython/benchmarking-public/blob/main/results/bm-20240427-3.13.0a6%2B-8ca0f58-JIT/bm-20240427-linux-x86_64-brandtbucher-justin_refactor-3.13.0a6%2B-8ca0f58-vs-base.png)).

Currently, we generate declarative structures at build time that we then loop over in order to emit the desired machine code at runtime. For example, the `_STORE_FAST` stencil looks like this:

<details>

```c
static const unsigned char _STORE_FAST_code_body[61] = {
    0x50, 0x48, 0x8b, 0x45, 0xf8, 0x48, 0x83, 0xc5,
    0xf8, 0x0f, 0xb7, 0x0d, 0x00, 0x00, 0x00, 0x00,
    0x49, 0x8b, 0x7c, 0xcd, 0x48, 0x49, 0x89, 0x44,
    0xcd, 0x48, 0x48, 0x85, 0xff, 0x74, 0x0f, 0x48,
    0x8b, 0x07, 0x85, 0xc0, 0x78, 0x08, 0x48, 0xff,
    0xc8, 0x48, 0x89, 0x07, 0x74, 0x07, 0x58, 0xff,
    0x25, 0x00, 0x00, 0x00, 0x00, 0xff, 0x15, 0x00,
    0x00, 0x00, 0x00, 0x58,
};
static const Hole _STORE_FAST_code_holes[4] = {
    {0xc, HoleKind_R_X86_64_GOTPCREL, HoleValue_DATA, NULL, -0x4},
    {0x31, HoleKind_R_X86_64_GOTPCRELX, HoleValue_DATA, NULL, 0x4},
    {0x37, HoleKind_R_X86_64_GOTPCRELX, HoleValue_DATA, NULL, 0xc},
};
static const unsigned char _STORE_FAST_data_body[25] = {
    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
};
static const Hole _STORE_FAST_data_holes[4] = {
    {0x0, HoleKind_R_X86_64_64, HoleValue_OPARG, NULL, 0x0},
    {0x8, HoleKind_R_X86_64_64, HoleValue_CONTINUE, NULL, 0x0},
    {0x10, HoleKind_R_X86_64_64, HoleValue_ZERO, &_Py_Dealloc, 0x0},
};
```

</details>

This very general approach means that we have a [lot of complex logic in our hot inner loop](https://github.com/python/cpython/blob/72867c962cc59c6d56805f86530696bea6beb039/Python/jit.c#L434-L470) to decode instructions and set up values for patching that may not even be needed. It's also very branchy, since we're essentially ["interpreting"](https://github.com/python/cpython/blob/72867c962cc59c6d56805f86530696bea6beb039/Python/jit.c#L149-L180) the array of holes for each instruction.

With this PR, `jit_stencils.h` instead contains the following function:

<details>

```c
void
emit__STORE_FAST(
    unsigned char *code, unsigned char *data, _PyExecutorObject *executor,
    const _PyUOpInstruction *instruction, uintptr_t instruction_starts[])
{
    const unsigned char code_body[60] = {
        0x50, 0x48, 0x8b, 0x45, 0xf8, 0x48, 0x83, 0xc5,
        0xf8, 0x0f, 0xb7, 0x0d, 0x00, 0x00, 0x00, 0x00,
        0x49, 0x8b, 0x7c, 0xcd, 0x48, 0x49, 0x89, 0x44,
        0xcd, 0x48, 0x48, 0x85, 0xff, 0x74, 0x0f, 0x48,
        0x8b, 0x07, 0x85, 0xc0, 0x78, 0x08, 0x48, 0xff,
        0xc8, 0x48, 0x89, 0x07, 0x74, 0x07, 0x58, 0xff,
        0x25, 0x00, 0x00, 0x00, 0x00, 0xff, 0x15, 0x00,
        0x00, 0x00, 0x00, 0x58,
    };
    const unsigned char data_body[24] = {
        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
    };
    memcpy(data, data_body, sizeof(data_body));
    patch_64(data + 0x0, instruction->oparg);
    patch_64(data + 0x8, (uintptr_t)code + sizeof(code_body));
    patch_64(data + 0x10, (uintptr_t)&_Py_Dealloc);
    memcpy(code, code_body, sizeof(code_body));
    patch_32r(code + 0xc, (uintptr_t)data + -0x4);
    patch_x86_64_32rx(code + 0x31, (uintptr_t)data + 0x4);
    patch_x86_64_32rx(code + 0x37, (uintptr_t)data + 0xc);
}
```

</details>

This function is [called directly](https://github.com/brandtbucher/cpython/blob/eb0826f3d2cba5c785b07fbe0bc827984da4edc6/Python/jit.c#L427) to emit the machine code for every `_STORE_FAST` instruction, and hardcodes the logic for all of the necessary copies and patches. The result is one indirect call, no unnecessary branching, and (in my opinion) cleaner code, since a lot of the tricky logic is now hidden away in generated files.

- - -

I know this is right before feature freeze, but I'd really like to get this in 3.13 since it will make backporting any fixes *much* easier. It doesn't change the actual jitted code in any way.

Note to reviewers: the diff is a bit messy, so it *may* make more sense to compare the before-vs-after files side-by-side instead.


<!-- gh-issue-number: gh-113464 -->
* Issue: gh-113464
<!-- /gh-issue-number -->
