### PR TITLE
gh-118486: Switch mkdir(mode=0o700) on Windows to use OWNER RIGHTS instead of CURRENT_USER

### DIFF
--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -5587,6 +5587,7 @@ struct _Py_SECURITY_ATTRIBUTE_DATA {
     PACL acl;
     SECURITY_DESCRIPTOR sd;
     EXPLICIT_ACCESS_W ea[4];
+    char sid[64];
 };
 
 static int
@@ -5616,13 +5617,25 @@ initializeMkdir700SecurityAttributes(
         return GetLastError();
     }
 
+    int use_alias = 0;
+    DWORD cbSid = sizeof(data->sid);
+    if (!CreateWellKnownSid(WinCreatorOwnerRightsSid, NULL, (PSID)data->sid, &cbSid)) {
+        use_alias = 1;
+    }
+
     data->securityAttributes.nLength = sizeof(SECURITY_ATTRIBUTES);
     data->ea[0].grfAccessPermissions = GENERIC_ALL;
     data->ea[0].grfAccessMode = SET_ACCESS;
     data->ea[0].grfInheritance = SUB_CONTAINERS_AND_OBJECTS_INHERIT;
-    data->ea[0].Trustee.TrusteeForm = TRUSTEE_IS_NAME;
-    data->ea[0].Trustee.TrusteeType = TRUSTEE_IS_ALIAS;
-    data->ea[0].Trustee.ptstrName = L"CURRENT_USER";
+    if (use_alias) {
+        data->ea[0].Trustee.TrusteeForm = TRUSTEE_IS_NAME;
+        data->ea[0].Trustee.TrusteeType = TRUSTEE_IS_ALIAS;
+        data->ea[0].Trustee.ptstrName = L"CURRENT_USER";
+    } else {
+        data->ea[0].Trustee.TrusteeForm = TRUSTEE_IS_SID;
+        data->ea[0].Trustee.TrusteeType = TRUSTEE_IS_WELL_KNOWN_GROUP;
+        data->ea[0].Trustee.ptstrName = (LPWCH)(SID*)data->sid;
+    }
 
     data->ea[1].grfAccessPermissions = GENERIC_ALL;
     data->ea[1].grfAccessMode = SET_ACCESS;


### PR DESCRIPTION
This ensures directories created while elevated are not accessible by the same user when non-elevated.

<!-- gh-issue-number: gh-118486 -->
* Issue: gh-118486
<!-- /gh-issue-number -->
