### PR TITLE
gh-118519: Fix empty weakref list check

### DIFF
--- a/Objects/weakrefobject.c
+++ b/Objects/weakrefobject.c
@@ -988,7 +988,7 @@ PyObject_ClearWeakRefs(PyObject *object)
     }
 
     list = GET_WEAKREFS_LISTPTR(object);
-    if (FT_ATOMIC_LOAD_PTR(list) == NULL) {
+    if (FT_ATOMIC_LOAD_PTR(*list) == NULL) {
         // Fast path for the common case
         return;
     }


### PR DESCRIPTION
A check to see if we have no weakref's is a little bit off, resulting in a scaling issue on freeing objects.  Fix the check.

<!-- gh-issue-number: gh-118519 -->
* Issue: gh-118519
<!-- /gh-issue-number -->
