### PR TITLE
gh-118527: Use `_Py_ID(__main__)` for main module name

### DIFF
--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -2348,7 +2348,7 @@ static PyStatus
 add_main_module(PyInterpreterState *interp)
 {
     PyObject *m, *d, *ann_dict;
-    m = PyImport_AddModule("__main__");
+    m = PyImport_AddModuleObject(&_Py_ID(__main__));
     if (m == NULL)
         return _PyStatus_ERR("can't create __main__ module");
 


### PR DESCRIPTION
Most module names are interned and immortalized, but the main module's name was not. This partially addresses a scaling bottleneck in the free-threaded when creating closure concurrently in the main module.

<!-- gh-issue-number: gh-118527 -->
* Issue: gh-118527
<!-- /gh-issue-number -->
