### PR TITLE
gh-118527: Use deferred reference counting for C functions on modules

### DIFF
--- a/Objects/moduleobject.c
+++ b/Objects/moduleobject.c
@@ -183,6 +183,7 @@ _add_methods_to_object(PyObject *module, PyObject *name, PyMethodDef *functions)
         if (func == NULL) {
             return -1;
         }
+        _PyObject_SetDeferredRefcount(func);
         if (PyObject_SetAttrString(module, fdef->ml_name, func) != 0) {
             Py_DECREF(func);
             return -1;


### PR DESCRIPTION
This addresses a scaling bottleneck in the free-threaded build when calling functions like `math.floor()` concurrently from multiple threads.

<!-- gh-issue-number: gh-118527 -->
* Issue: gh-118527
<!-- /gh-issue-number -->
