### PR TITLE
gh-118495: Skip test using threads after forking when running with TSAN

### DIFF
--- a/Lib/test/test_threading.py
+++ b/Lib/test/test_threading.py
@@ -49,7 +49,7 @@ def skip_unless_reliable_fork(test):
     if support.HAVE_ASAN_FORK_BUG:
         return unittest.skip("libasan has a pthread_create() dead lock related to thread+fork")(test)
     if support.check_sanitizer(thread=True):
-        return unittest.skip("TSAN doesn't support threads after fork")
+        return unittest.skip("TSAN doesn't support threads after fork")(test)
     return test
 
 
@@ -781,8 +781,7 @@ class ThreadTests(BaseTestCase):
                          "current is main True\n"
                          )
 
-    @unittest.skipIf(sys.platform in platforms_to_skip, "due to known OS bug")
-    @support.requires_fork()
+    @skip_unless_reliable_fork
     @unittest.skipUnless(hasattr(os, 'waitpid'), "test needs os.waitpid()")
     def test_main_thread_after_fork_from_foreign_thread(self, create_dummy=False):
         code = """if 1:


### PR DESCRIPTION
This is unsupported. Note that `skip_unless_reliable_fork()` checks for the conditions used by the decorators that were removed, along with checking for TSAN.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-118495 -->
* Issue: gh-118495
<!-- /gh-issue-number -->
