### PR TITLE
gh-118534: Fix load of `gil->locked`

### DIFF
--- a/Python/ceval_gil.c
+++ b/Python/ceval_gil.c
@@ -224,7 +224,7 @@ drop_gil(PyInterpreterState *interp, PyThreadState *tstate)
         return;
     }
 #endif
-    if (!_Py_atomic_load_ptr_relaxed(&gil->locked)) {
+    if (!_Py_atomic_load_int_relaxed(&gil->locked)) {
         Py_FatalError("drop_gil: GIL is not locked");
     }
 


### PR DESCRIPTION
The `locked` field is an `int`, not a pointer type.


<!-- gh-issue-number: gh-118534 -->
* Issue: gh-118534
<!-- /gh-issue-number -->
