### PR TITLE
gh-118527: Intern filename, name, and qualname in code objects.

### DIFF
--- a/Objects/codeobject.c
+++ b/Objects/codeobject.c
@@ -390,6 +390,11 @@ init_code(PyCodeObject *co, struct _PyCodeConstructor *con)
     co->co_filename = Py_NewRef(con->filename);
     co->co_name = Py_NewRef(con->name);
     co->co_qualname = Py_NewRef(con->qualname);
+#ifdef Py_GIL_DISABLED
+    PyUnicode_InternInPlace(&co->co_filename);
+    PyUnicode_InternInPlace(&co->co_name);
+    PyUnicode_InternInPlace(&co->co_qualname);
+#endif
     co->co_flags = con->flags;
 
     co->co_firstlineno = con->firstlineno;


### PR DESCRIPTION
This interns the strings for `co_filename`, `co_name`, and `co_qualname` on codeobjects in the free-threaded build. This partially addresses a reference counting bottleneck when creating closures concurrently. The functions take the name and qualified name from the code object.

<!-- gh-issue-number: gh-118527 -->
* Issue: gh-118527
<!-- /gh-issue-number -->
