### PR TITLE
gh-118476: Fix corner cases in islice() rough equivalent.

### DIFF
--- a/Doc/library/itertools.rst
+++ b/Doc/library/itertools.rst
@@ -496,7 +496,7 @@ loops that truncate the stream.
    data where the internal structure has been flattened (for example, a
    multi-line report may list a name field on every third line).
 
-   Rough equivalent without error checking for negative indices or *step*
+   Rough equivalent without error checking for negative indices or a *step*
    size of zero::
 
       def islice(iterable, *args):

--- a/Doc/library/itertools.rst
+++ b/Doc/library/itertools.rst
@@ -496,8 +496,7 @@ loops that truncate the stream.
    data where the internal structure has been flattened (for example, a
    multi-line report may list a name field on every third line).
 
-   Rough equivalent without error checking for negative indices or a *step*
-   size of zero::
+   Roughly equivalent to::
 
       def islice(iterable, *args):
           # islice('ABCDEFG', 2) → A B
@@ -505,7 +504,11 @@ loops that truncate the stream.
           # islice('ABCDEFG', 2, None) → C D E F G
           # islice('ABCDEFG', 0, None, 2) → A C E G
           s = slice(*args)
-          start, stop, step = s.start or 0, s.stop, s.step or 1
+          start = 0 if s.start is None else s.start
+          stop = s.stop
+          step = 1 if s.step is None else s.step
+          if start < 0 or (stop is not None and stop < 0) or step <= 0:
+              raise ValueError
           indices = count() if stop is None else range(max(stop, start))
           nexti = start
           for i, element in zip(indices, iterable):

--- a/Doc/library/itertools.rst
+++ b/Doc/library/itertools.rst
@@ -510,11 +510,11 @@ loops that truncate the stream.
           if start < 0 or (stop is not None and stop < 0) or step <= 0:
               raise ValueError
           indices = count() if stop is None else range(max(stop, start))
-          nexti = start
+          next_i = start
           for i, element in zip(indices, iterable):
-              if i == nexti:
+              if i == next_i:
                   yield element
-                  nexti += step
+                  next_i += step
 
 
 .. function:: pairwise(iterable)


### PR DESCRIPTION
Fixes the corner case errors reported by F H T Mitchell, "This does not correctly handle stop == 0, overwriting it to be sys.maxsize and also assumes its input is an iterator, not any iterable."

The elegant and readable code rough equivalent was crafted by Stefan Pochmann.

This mostly passes all the tests for the C version of *islice()* except:
* Negative indices fail to raise *ValueError* and wrong answers are given.
* A zero stop argument fails to raise and a wrong answer is returned.
* Invalid input types raise a different exception.

This is deemed good enough for a rough equivalent that aims to convey how the stream of indices is created when correct inputs are supplied.

---------------------------------------

Here are the tests I applied to the rough equivalent (taken from `Lib/test/test_itertools.py` and from the bug report):

```
from itertools import count
import unittest
import weakref
from test import support
from functools import total_ordering

maxsize = support.MAX_Py_ssize_t

def islice(iterable, *args):
    s = slice(*args)
    start, stop, step = s.start or 0, s.stop, s.step or 1
    indices = count() if stop is None else range(max(stop, start))
    nexti = start
    for i, element in zip(indices, iterable):
        if i == nexti:
            yield element
            nexti += step

class TestItertools(unittest.TestCase):

    def test_islice(self):
        for args in [          # islice(args) should agree with range(args)
                (10, 20, 3),
                (10, 3, 20),
                (10, 20),
                (10, 10),
                (10, 3),
                (20,)
                ]:
            self.assertEqual(list(islice(range(100), *args)),
                             list(range(*args)))

        for args, tgtargs in [  # Stop when seqn is exhausted
                ((10, 110, 3), ((10, 100, 3))),
                ((10, 110), ((10, 100))),
                ((110,), (100,))
                ]:
            self.assertEqual(list(islice(range(100), *args)),
                             list(range(*tgtargs)))

        # Test stop=None
        self.assertEqual(list(islice(range(10), None)), list(range(10)))
        self.assertEqual(list(islice(range(10), None, None)), list(range(10)))
        self.assertEqual(list(islice(range(10), None, None, None)), list(range(10)))
        self.assertEqual(list(islice(range(10), 2, None)), list(range(2, 10)))
        self.assertEqual(list(islice(range(10), 1, None, 2)), list(range(1, 10, 2)))

        # Test number of items consumed     SF #1171417
        it = iter(range(10))
        self.assertEqual(list(islice(it, 3)), list(range(3)))
        self.assertEqual(list(it), list(range(3, 10)))

        it = iter(range(10))
        self.assertEqual(list(islice(it, 3, 3)), [])
        self.assertEqual(list(it), list(range(3, 10)))

        # Test invalid arguments
        ra = range(10)
        with self.assertRaises(TypeError):
            list(islice(ra))
        with self.assertRaises(TypeError):
            list(islice(ra, 1, 2, 3, 4))
        # with self.assertRaises(ValueError):
        #    list(islice(ra, -5, 10, 1))
        # with self.assertRaises(ValueError):
        #    list(islice(ra, 1, -5, -1))
        # with self.assertRaises(ValueError):
        #    list(islice(ra, 1, 10, -1))
        # with self.assertRaises(ValueError):
        #    list(islice(ra, 1, 10, 0))
        with self.assertRaises((ValueError, TypeError)):
            list(islice(ra, 'a'))
        with self.assertRaises((ValueError, TypeError)):
            list(islice(ra, 'a', 1))
        with self.assertRaises((ValueError, TypeError)):
            list(islice(ra, 1, 'a'))
        with self.assertRaises((ValueError, TypeError)):
            list(islice(ra, 'a', 1, 1))
        with self.assertRaises((ValueError, TypeError)):
            list(islice(ra, 1, 'a', 1))
        self.assertEqual(len(list(islice(count(), 1, 10, maxsize))), 1)

        # Issue #10323:  Less islice in a predictable state
        c = count()
        self.assertEqual(list(islice(c, 1, 3, 50)), [1])
        self.assertEqual(next(c), 3)

        # Issue #21321: check source iterator is not referenced
        # from islice() after the latter has been exhausted
        it = (x for x in (1, 2))
        wr = weakref.ref(it)
        it = islice(it, 1)
        self.assertIsNotNone(wr())
        list(it) # exhaust the iterator
        support.gc_collect()
        self.assertIsNone(wr())

        # Issue #30537: islice can accept integer-like objects as
        # arguments
        @total_ordering
        class IntLike(object):
            def __init__(self, val):
                self.val = val
            def __index__(self):
                return self.val
            def __eq__(self, other):
                return int(self) == int(other)
            def __lt__(self, other):
                return int(self) < int(other)
            def __add__(self, other):
                return int(self) + int(other)
            __radd__ = __add__

        self.assertEqual(list(islice(range(100), IntLike(10))), list(range(10)))
        self.assertEqual(list(islice(range(100), IntLike(10), IntLike(50))),
                         list(range(10, 50)))
        self.assertEqual(list(islice(range(100), IntLike(10), IntLike(50), IntLike(5))),
                         list(range(10,50,5)))


if __name__ == '__main__':

    import itertools

    for start in itertools.chain(range(6), [None]):
        for stop in itertools.chain(range(6), [None]):
            for step in itertools.chain(range(1, 6), [None]):
                for r in [range(0), range(4)]:
                    it = iter(r)
                    myx = list(islice(it, start, stop, step))
                    myy = list(it)
                    it = iter(r)
                    pyx = list(itertools.islice(it, start, stop, step))
                    pyy = list(it)
                    msg = "ERR" if myx != pyx or myy != pyy else "ok"
                    if msg != 'ok':
                        print(f"{msg}: {r=}, {start=}, {stop=}, {step=}, {myx=}, {pyx=}, {myy=}, {pyy=}")
                    assert msg == 'ok'
    else:
        print('Done')

    unittest.main()

```



<!-- gh-issue-number: gh-118476 -->
* Issue: gh-118476
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--118559.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->