### PR TITLE
GH-118251: Fix incomplete ternary expression in JIT workflow

### DIFF
--- a/.github/workflows/jit.yml
+++ b/.github/workflows/jit.yml
@@ -93,7 +93,7 @@ jobs:
           choco upgrade llvm -y
           choco install llvm --allow-downgrade --no-progress --version ${{ matrix.llvm }}
           ./PCbuild/build.bat --experimental-jit ${{ matrix.debug && '-d' || '--pgo' }} -p ${{ matrix.architecture }}
-          ./PCbuild/rt.bat ${{ matrix.debug && '-d' }} -p ${{ matrix.architecture }} -q --multiprocess 0 --timeout 4500 --verbose2 --verbose3
+          ./PCbuild/rt.bat ${{ matrix.debug && '-d' || '' }} -p ${{ matrix.architecture }} -q --multiprocess 0 --timeout 4500 --verbose2 --verbose3
 
       # No PGO or tests (yet):
       - name: Emulated Windows


### PR DESCRIPTION
This weirdly started failing after GH-118536 removed the empty `--exclude` argument from later in the command. Apparently, we could tolerate a stray `false` string before that?

<!-- gh-issue-number: gh-118251 -->
* Issue: gh-118251
<!-- /gh-issue-number -->
