### PR TITLE
gh-118542: improve datetime deprecation warnings

### DIFF
--- a/Doc/library/datetime.rst
+++ b/Doc/library/datetime.rst
@@ -913,7 +913,8 @@ Other constructors, all class methods:
 
    .. deprecated:: 3.12
 
-      Use :meth:`datetime.now` with :attr:`UTC` instead.
+      Use :meth:`datetime.now` with :attr:`UTC` instead. To maintain compatibility
+      :meth:`datetime.datetime.now(datetime.UTC).replace(tzinfo=None)` may be used.
 
 
 .. classmethod:: datetime.fromtimestamp(timestamp, tz=None)
@@ -985,7 +986,8 @@ Other constructors, all class methods:
 
    .. deprecated:: 3.12
 
-      Use :meth:`datetime.fromtimestamp` with :attr:`UTC` instead.
+      Use :meth:`datetime.fromtimestamp` with :attr:`UTC` instead. To maintain
+      compatibility :meth:`datetime.fromtimestamp`without :attr:`UTC` may be used.
 
 
 .. classmethod:: datetime.fromordinal(ordinal)

--- a/Lib/_pydatetime.py
+++ b/Lib/_pydatetime.py
@@ -1809,7 +1809,9 @@ class datetime(date):
         warnings.warn("datetime.datetime.utcfromtimestamp() is deprecated and scheduled "
                       "for removal in a future version. Use timezone-aware "
                       "objects to represent datetimes in UTC: "
-                      "datetime.datetime.fromtimestamp(t, datetime.UTC).",
+                      "datetime.datetime.fromtimestamp(t, datetime.UTC). To maintain "
+                      "compatibility datetime.datetime.fromtimestamp(timestamp) "
+                      "may be used.",
                       DeprecationWarning,
                       stacklevel=2)
         return cls._fromtimestamp(t, True, None)
@@ -1827,7 +1829,10 @@ class datetime(date):
         warnings.warn("datetime.datetime.utcnow() is deprecated and scheduled for "
                       "removal in a future version. Use timezone-aware "
                       "objects to represent datetimes in UTC: "
-                      "datetime.datetime.now(datetime.UTC).",
+                      "datetime.datetime.now(datetime.UTC). To maintain "
+                      "compatibility "
+                      "datetime.datetime.now(datetime.UTC).replace(tzinfo=None) "
+                      "may be used.",
                       DeprecationWarning,
                       stacklevel=2)
         t = _time.time()

--- a/Misc/NEWS.d/next/Library/2024-05-04-11-51-06.gh-issue-118542.idPcCx.rst
+++ b/Misc/NEWS.d/next/Library/2024-05-04-11-51-06.gh-issue-118542.idPcCx.rst
@@ -1,0 +1,1 @@
+Improve datetime utc deprecation warnings.

--- a/Modules/_datetimemodule.c
+++ b/Modules/_datetimemodule.c
@@ -5199,7 +5199,8 @@ datetime_utcnow(PyObject *cls, PyObject *dummy)
     if (PyErr_WarnEx(PyExc_DeprecationWarning,
         "datetime.datetime.utcnow() is deprecated and scheduled for removal in a "
         "future version. Use timezone-aware objects to represent datetimes "
-        "in UTC: datetime.datetime.now(datetime.UTC).", 1))
+        "in UTC: datetime.datetime.now(datetime.UTC). To maintain compatability"
+        "datetime.datetime.now(datetime.UTC).replace(tzinfo=None) may be used.", 1))
     {
         return NULL;
     }
@@ -5241,8 +5242,9 @@ datetime_utcfromtimestamp(PyObject *cls, PyObject *args)
 {
     if (PyErr_WarnEx(PyExc_DeprecationWarning,
         "datetime.datetime.utcfromtimestamp() is deprecated and scheduled for removal "
-        "in a future version. Use timezone-aware objects to represent "
-        "datetimes in UTC: datetime.datetime.fromtimestamp(timestamp, datetime.UTC).", 1))
+        "in a future version. Use timezone-aware objects to represent datetimes "
+        "in UTC: datetime.datetime.fromtimestamp(timestamp, datetime.UTC). To maintain "
+        "compatability datetime.datetime.fromtimestamp(timestamp) may be used.", 1))
     {
         return NULL;
     }

--- a/Modules/_datetimemodule.c
+++ b/Modules/_datetimemodule.c
@@ -5244,7 +5244,7 @@ datetime_utcfromtimestamp(PyObject *cls, PyObject *args)
         "datetime.datetime.utcfromtimestamp() is deprecated and scheduled for removal "
         "in a future version. Use timezone-aware objects to represent datetimes "
         "in UTC: datetime.datetime.fromtimestamp(timestamp, datetime.UTC). To maintain "
-        "compatability datetime.datetime.fromtimestamp(timestamp) may be used.", 1))
+        "compatibility datetime.datetime.fromtimestamp(timestamp) may be used.", 1))
     {
         return NULL;
     }

--- a/Modules/_datetimemodule.c
+++ b/Modules/_datetimemodule.c
@@ -5199,7 +5199,7 @@ datetime_utcnow(PyObject *cls, PyObject *dummy)
     if (PyErr_WarnEx(PyExc_DeprecationWarning,
         "datetime.datetime.utcnow() is deprecated and scheduled for removal in a "
         "future version. Use timezone-aware objects to represent datetimes "
-        "in UTC: datetime.datetime.now(datetime.UTC). To maintain compatability"
+        "in UTC: datetime.datetime.now(datetime.UTC). To maintain compatibility"
         "datetime.datetime.now(datetime.UTC).replace(tzinfo=None) may be used.", 1))
     {
         return NULL;

--- a/Modules/_datetimemodule.c
+++ b/Modules/_datetimemodule.c
@@ -5199,7 +5199,7 @@ datetime_utcnow(PyObject *cls, PyObject *dummy)
     if (PyErr_WarnEx(PyExc_DeprecationWarning,
         "datetime.datetime.utcnow() is deprecated and scheduled for removal in a "
         "future version. Use timezone-aware objects to represent datetimes "
-        "in UTC: datetime.datetime.now(datetime.UTC). To maintain compatibility"
+        "in UTC: datetime.datetime.now(datetime.UTC). To maintain compatibility "
         "datetime.datetime.now(datetime.UTC).replace(tzinfo=None) may be used.", 1))
     {
         return NULL;


### PR DESCRIPTION
Add suggestion for code authors to have an in-place, future-proof replacement if desired.

Builds on the initial issue raised by also adding compatibility suggestion for `datetime.datetime.fromtimestamp(timestamp, datetime.UTC)` -> `datetime.datetime.fromtimestamp(timestamp)`. By not providing a timezone, the returned object is not timezone aware.

fixes https://github.com/python/cpython/issues/118542

<!-- gh-issue-number: gh-118542 -->
* Issue: gh-118542
<!-- /gh-issue-number -->
