### PR TITLE
gh-74929: Fix an extra DECREF for PEP 667 implementation

### DIFF
--- a/Lib/test/test_frame.py
+++ b/Lib/test/test_frame.py
@@ -364,6 +364,22 @@ class TestFrameLocals(unittest.TestCase):
             c = 0
         f()
 
+    def test_local_objects(self):
+        o = object()
+        k = '.'.join(['a', 'b', 'c'])
+        f_locals = sys._getframe().f_locals
+        f_locals['o'] = f_locals['k']
+        self.assertEqual(o, 'a.b.c')
+
+    def test_update_with_self(self):
+        # Make sure reference is not leaking here
+        def f():
+            f_locals = sys._getframe().f_locals
+            f_locals.update(f_locals)
+            f_locals.update(f_locals)
+            f_locals.update(f_locals)
+        f()
+
     def test_repr(self):
         x = 1
         # Introduce a reference cycle

--- a/Lib/test/test_frame.py
+++ b/Lib/test/test_frame.py
@@ -372,7 +372,6 @@ class TestFrameLocals(unittest.TestCase):
         self.assertEqual(o, 'a.b.c')
 
     def test_update_with_self(self):
-        # Make sure reference is not leaking here
         def f():
             f_locals = sys._getframe().f_locals
             f_locals.update(f_locals)

--- a/Objects/frameobject.c
+++ b/Objects/frameobject.c
@@ -171,7 +171,6 @@ framelocalsproxy_setitem(PyObject *self, PyObject *key, PyObject *value)
             } else if (value != oldvalue) {
                 Py_XSETREF(fast[i], Py_NewRef(value));
             }
-            Py_XDECREF(value);
             return 0;
         }
     }


### PR DESCRIPTION
In the PEP 667 implementation, when I copied the code from `_PyFrame_LocalsToFast`, I did not realize the `value` is a new reference so it was decrefed in the original code. This resulted in an extra DECREF in `__setitem__`. Unfortunately I did not catch it because the test cases used were all immortals.

Two test cases were added:
* local object variable - this will trigger an assertion failure in debug mode
* `f_locals` updating itself multiple times - this will crash the interpreter without the fix

<!-- gh-issue-number: gh-74929 -->
* Issue: gh-74929
<!-- /gh-issue-number -->
