### PR TITLE
gh-118605: Fix reference leak in FrameLocalsProxy

### DIFF
--- a/Objects/frameobject.c
+++ b/Objects/frameobject.c
@@ -244,6 +244,10 @@ framelocalsproxy_keys(PyObject *self, PyObject *__unused)
     PyFrameObject *frame = ((PyFrameLocalsProxyObject*)self)->frame;
     PyCodeObject *co = _PyFrame_GetCode(frame->f_frame);
 
+    if (names == NULL) {
+        return NULL;
+    }
+
     for (int i = 0; i < co->co_nlocalsplus; i++) {
         PyObject *val = framelocalsproxy_getval(frame->f_frame, co, i);
         if (val) {

--- a/Objects/frameobject.c
+++ b/Objects/frameobject.c
@@ -232,6 +232,8 @@ framelocalsproxy_merge(PyObject* self, PyObject* other)
         Py_DECREF(value);
     }
 
+    Py_DECREF(iter);
+
     return 0;
 }
 
@@ -306,7 +308,10 @@ framelocalsproxy_visit(PyObject *self, visitproc visit, void *arg)
 static PyObject *
 framelocalsproxy_iter(PyObject *self)
 {
-    return PyObject_GetIter(framelocalsproxy_keys(self, NULL));
+    PyObject* keys = framelocalsproxy_keys(self, NULL);
+    PyObject* iter = PyObject_GetIter(keys);
+    Py_XDECREF(keys);
+    return iter;
 }
 
 static PyObject *


### PR DESCRIPTION
There are a couple of reference leaks in the implementation of PEP 667. Fix those and hopefully that's all.

<!-- gh-issue-number: gh-118605 -->
* Issue: gh-118605
<!-- /gh-issue-number -->
