### PR TITLE
gh-118613: Fix error handling of `_PyEval_GetFrameLocals` in `ceval.c`

### DIFF
--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -2507,11 +2507,10 @@ _PyEval_GetFrameLocals(void)
         }
         Py_DECREF(locals);
         return ret;
-    } else if (PyMapping_Check(locals)) {
-        return locals;
     }
 
-    return NULL;
+    assert(PyMapping_Check(locals));
+    return locals;
 }
 
 PyObject *

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -2496,8 +2496,13 @@ _PyEval_GetFrameLocals(void)
 
     if (PyFrameLocalsProxy_Check(locals)) {
         PyObject* ret = PyDict_New();
+        if (ret == NULL) {
+            Py_DECREF(locals);
+            return NULL;
+        }
         if (PyDict_Update(ret, locals)) {
             Py_DECREF(ret);
+            Py_DECREF(locals);
             return NULL;
         }
         Py_DECREF(locals);

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -2500,7 +2500,7 @@ _PyEval_GetFrameLocals(void)
             Py_DECREF(locals);
             return NULL;
         }
-        if (PyDict_Update(ret, locals)) {
+        if (PyDict_Update(ret, locals) < 0) {
             Py_DECREF(ret);
             Py_DECREF(locals);
             return NULL;


### PR DESCRIPTION
Refs https://github.com/python/cpython/pull/115153

<!-- gh-issue-number: gh-118613 -->
* Issue: gh-118613
<!-- /gh-issue-number -->
