### PR TITLE
[3.12]: gh-113055: Use pointer for interp->obmalloc state

### DIFF
--- a/Doc/data/python3.12.abi
+++ b/Doc/data/python3.12.abi
@@ -1710,7 +1710,7 @@
     <elf-symbol name='_PyNotImplemented_Type' size='416' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='_PyOS_ReadlineTState' size='8' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='_PyParser_TokenNames' size='552' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
-    <elf-symbol name='_PyRuntime' size='459944' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_PyRuntime' size='196704' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='_PySet_Dummy' size='8' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='_PyWeakref_CallableProxyType' size='416' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='_PyWeakref_ProxyType' size='416' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
@@ -2072,7 +2072,7 @@
     <function-decl name='_PyPathConfig_GetGlobalModuleSearchPath' filepath='./Include/internal/pycore_pathconfig.h' line='14' column='1' visibility='default' binding='global' size-in-bits='64'>
       <return type-id='type-id-16'/>
     </function-decl>
-    <function-decl name='_Py_Get_Getpath_CodeObject' mangled-name='_Py_Get_Getpath_CodeObject' filepath='./Modules/getpath.c' line='791' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_Get_Getpath_CodeObject'>
+    <function-decl name='_Py_Get_Getpath_CodeObject' mangled-name='_Py_Get_Getpath_CodeObject' filepath='./Modules/getpath.c' line='795' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_Get_Getpath_CodeObject'>
       <return type-id='type-id-2'/>
     </function-decl>
   </abi-instr>
@@ -2524,7 +2524,7 @@
       <parameter type-id='type-id-177'/>
       <return type-id='type-id-54'/>
     </function-decl>
-    <function-decl name='_PyPerfTrampoline_AfterFork_Child' filepath='./Include/internal/pycore_ceval.h' line='78' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_PyPerfTrampoline_AfterFork_Child' filepath='./Include/internal/pycore_ceval.h' line='79' column='1' visibility='default' binding='global' size-in-bits='64'>
       <return type-id='type-id-54'/>
     </function-decl>
     <function-decl name='_Py_normpath_and_size' filepath='./Include/internal/pycore_fileutils.h' line='256' column='1' visibility='default' binding='global' size-in-bits='64'>
@@ -2548,39 +2548,39 @@
       <parameter type-id='type-id-178'/>
       <return type-id='type-id-54'/>
     </function-decl>
-    <function-decl name='PyOS_BeforeFork' mangled-name='PyOS_BeforeFork' filepath='./Modules/posixmodule.c' line='585' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyOS_BeforeFork'>
+    <function-decl name='PyOS_BeforeFork' mangled-name='PyOS_BeforeFork' filepath='./Modules/posixmodule.c' line='586' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyOS_BeforeFork'>
       <return type-id='type-id-46'/>
     </function-decl>
-    <function-decl name='PyOS_AfterFork_Parent' mangled-name='PyOS_AfterFork_Parent' filepath='./Modules/posixmodule.c' line='594' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyOS_AfterFork_Parent'>
+    <function-decl name='PyOS_AfterFork_Parent' mangled-name='PyOS_AfterFork_Parent' filepath='./Modules/posixmodule.c' line='595' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyOS_AfterFork_Parent'>
       <return type-id='type-id-46'/>
     </function-decl>
-    <function-decl name='PyOS_AfterFork_Child' mangled-name='PyOS_AfterFork_Child' filepath='./Modules/posixmodule.c' line='605' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyOS_AfterFork_Child'>
+    <function-decl name='PyOS_AfterFork_Child' mangled-name='PyOS_AfterFork_Child' filepath='./Modules/posixmodule.c' line='606' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyOS_AfterFork_Child'>
       <return type-id='type-id-46'/>
     </function-decl>
-    <function-decl name='PyOS_AfterFork' mangled-name='PyOS_AfterFork' filepath='./Modules/posixmodule.c' line='669' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyOS_AfterFork'>
+    <function-decl name='PyOS_AfterFork' mangled-name='PyOS_AfterFork' filepath='./Modules/posixmodule.c' line='670' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyOS_AfterFork'>
       <return type-id='type-id-46'/>
     </function-decl>
-    <function-decl name='_PyLong_FromUid' mangled-name='_PyLong_FromUid' filepath='./Modules/posixmodule.c' line='690' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyLong_FromUid'>
-      <parameter type-id='type-id-126' name='uid' filepath='./Modules/posixmodule.c' line='690' column='1'/>
+    <function-decl name='_PyLong_FromUid' mangled-name='_PyLong_FromUid' filepath='./Modules/posixmodule.c' line='691' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyLong_FromUid'>
+      <parameter type-id='type-id-126' name='uid' filepath='./Modules/posixmodule.c' line='691' column='1'/>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='_PyLong_FromGid' mangled-name='_PyLong_FromGid' filepath='./Modules/posixmodule.c' line='698' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyLong_FromGid'>
-      <parameter type-id='type-id-122' name='gid' filepath='./Modules/posixmodule.c' line='698' column='1'/>
+    <function-decl name='_PyLong_FromGid' mangled-name='_PyLong_FromGid' filepath='./Modules/posixmodule.c' line='699' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyLong_FromGid'>
+      <parameter type-id='type-id-122' name='gid' filepath='./Modules/posixmodule.c' line='699' column='1'/>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='_Py_Uid_Converter' mangled-name='_Py_Uid_Converter' filepath='./Modules/posixmodule.c' line='706' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_Uid_Converter'>
-      <parameter type-id='type-id-2' name='obj' filepath='./Modules/posixmodule.c' line='706' column='1'/>
-      <parameter type-id='type-id-175' name='p' filepath='./Modules/posixmodule.c' line='706' column='1'/>
+    <function-decl name='_Py_Uid_Converter' mangled-name='_Py_Uid_Converter' filepath='./Modules/posixmodule.c' line='707' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_Uid_Converter'>
+      <parameter type-id='type-id-2' name='obj' filepath='./Modules/posixmodule.c' line='707' column='1'/>
+      <parameter type-id='type-id-175' name='p' filepath='./Modules/posixmodule.c' line='707' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='_Py_Gid_Converter' mangled-name='_Py_Gid_Converter' filepath='./Modules/posixmodule.c' line='812' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_Gid_Converter'>
-      <parameter type-id='type-id-2' name='obj' filepath='./Modules/posixmodule.c' line='812' column='1'/>
-      <parameter type-id='type-id-163' name='p' filepath='./Modules/posixmodule.c' line='812' column='1'/>
+    <function-decl name='_Py_Gid_Converter' mangled-name='_Py_Gid_Converter' filepath='./Modules/posixmodule.c' line='813' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_Gid_Converter'>
+      <parameter type-id='type-id-2' name='obj' filepath='./Modules/posixmodule.c' line='813' column='1'/>
+      <parameter type-id='type-id-163' name='p' filepath='./Modules/posixmodule.c' line='813' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='_Py_Sigset_Converter' mangled-name='_Py_Sigset_Converter' filepath='./Modules/posixmodule.c' line='1475' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_Sigset_Converter'>
-      <parameter type-id='type-id-2' name='obj' filepath='./Modules/posixmodule.c' line='1475' column='1'/>
-      <parameter type-id='type-id-22' name='addr' filepath='./Modules/posixmodule.c' line='1475' column='1'/>
+    <function-decl name='_Py_Sigset_Converter' mangled-name='_Py_Sigset_Converter' filepath='./Modules/posixmodule.c' line='1476' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_Sigset_Converter'>
+      <parameter type-id='type-id-2' name='obj' filepath='./Modules/posixmodule.c' line='1476' column='1'/>
+      <parameter type-id='type-id-22' name='addr' filepath='./Modules/posixmodule.c' line='1476' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
     <function-decl name='opendir' filepath='/usr/include/dirent.h' line='134' column='1' visibility='default' binding='global' size-in-bits='64'>
@@ -3679,7 +3679,7 @@
       <parameter type-id='type-id-231'/>
       <return type-id='type-id-46'/>
     </function-decl>
-    <function-decl name='_PyIsPerfTrampolineActive' filepath='./Include/internal/pycore_ceval.h' line='77' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_PyIsPerfTrampolineActive' filepath='./Include/internal/pycore_ceval.h' line='78' column='1' visibility='default' binding='global' size-in-bits='64'>
       <return type-id='type-id-8'/>
     </function-decl>
     <function-decl name='_PyImport_GetDLOpenFlags' filepath='./Include/internal/pycore_import.h' line='114' column='1' visibility='default' binding='global' size-in-bits='64'>
@@ -3698,7 +3698,7 @@
     <function-decl name='_PyImport_GetBuiltinModuleNames' filepath='./Include/internal/pycore_import.h' line='160' column='1' visibility='default' binding='global' size-in-bits='64'>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='_Py_GetGlobalAllocatedBlocks' filepath='./Include/internal/pycore_obmalloc.h' line='682' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_Py_GetGlobalAllocatedBlocks' filepath='./Include/internal/pycore_obmalloc.h' line='684' column='1' visibility='default' binding='global' size-in-bits='64'>
       <return type-id='type-id-14'/>
     </function-decl>
     <function-decl name='_PyPathConfig_ComputeSysPath0' filepath='./Include/internal/pycore_pathconfig.h' line='16' column='1' visibility='default' binding='global' size-in-bits='64'>
@@ -3724,65 +3724,68 @@
       <parameter type-id='type-id-22' name='userData' filepath='./Python/sysmodule.c' line='389' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='_PySys_GetSizeOf' mangled-name='_PySys_GetSizeOf' filepath='./Python/sysmodule.c' line='1776' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PySys_GetSizeOf'>
-      <parameter type-id='type-id-2' name='o' filepath='./Python/sysmodule.c' line='1776' column='1'/>
+    <function-decl name='_PySys_GetSizeOf' mangled-name='_PySys_GetSizeOf' filepath='./Python/sysmodule.c' line='1792' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PySys_GetSizeOf'>
+      <parameter type-id='type-id-2' name='o' filepath='./Python/sysmodule.c' line='1792' column='1'/>
       <return type-id='type-id-19'/>
     </function-decl>
-    <function-decl name='PyUnstable_PerfMapState_Init' mangled-name='PyUnstable_PerfMapState_Init' filepath='./Python/sysmodule.c' line='2275' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyUnstable_PerfMapState_Init'>
+    <function-decl name='PyUnstable_PerfMapState_Init' mangled-name='PyUnstable_PerfMapState_Init' filepath='./Python/sysmodule.c' line='2291' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyUnstable_PerfMapState_Init'>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='PyUnstable_WritePerfMapEntry' mangled-name='PyUnstable_WritePerfMapEntry' filepath='./Python/sysmodule.c' line='2306' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyUnstable_WritePerfMapEntry'>
-      <parameter type-id='type-id-22' name='code_addr' filepath='./Python/sysmodule.c' line='2307' column='1'/>
-      <parameter type-id='type-id-95' name='code_size' filepath='./Python/sysmodule.c' line='2308' column='1'/>
-      <parameter type-id='type-id-12' name='entry_name' filepath='./Python/sysmodule.c' line='2309' column='1'/>
+    <function-decl name='PyUnstable_WritePerfMapEntry' mangled-name='PyUnstable_WritePerfMapEntry' filepath='./Python/sysmodule.c' line='2322' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyUnstable_WritePerfMapEntry'>
+      <parameter type-id='type-id-22' name='code_addr' filepath='./Python/sysmodule.c' line='2323' column='1'/>
+      <parameter type-id='type-id-95' name='code_size' filepath='./Python/sysmodule.c' line='2324' column='1'/>
+      <parameter type-id='type-id-12' name='entry_name' filepath='./Python/sysmodule.c' line='2325' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='PySys_ResetWarnOptions' mangled-name='PySys_ResetWarnOptions' filepath='./Python/sysmodule.c' line='2615' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PySys_ResetWarnOptions'>
+    <function-decl name='PyUnstable_PerfMapState_Fini' mangled-name='PyUnstable_PerfMapState_Fini' filepath='./Python/sysmodule.c' line='2342' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyUnstable_PerfMapState_Fini'>
       <return type-id='type-id-46'/>
     </function-decl>
-    <function-decl name='PySys_AddWarnOptionUnicode' mangled-name='PySys_AddWarnOptionUnicode' filepath='./Python/sysmodule.c' line='2643' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PySys_AddWarnOptionUnicode'>
-      <parameter type-id='type-id-2' name='option' filepath='./Python/sysmodule.c' line='2643' column='1'/>
+    <function-decl name='PySys_ResetWarnOptions' mangled-name='PySys_ResetWarnOptions' filepath='./Python/sysmodule.c' line='2631' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PySys_ResetWarnOptions'>
       <return type-id='type-id-46'/>
     </function-decl>
-    <function-decl name='PySys_AddWarnOption' mangled-name='PySys_AddWarnOption' filepath='./Python/sysmodule.c' line='2655' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PySys_AddWarnOption'>
-      <parameter type-id='type-id-16' name='s' filepath='./Python/sysmodule.c' line='2655' column='1'/>
+    <function-decl name='PySys_AddWarnOptionUnicode' mangled-name='PySys_AddWarnOptionUnicode' filepath='./Python/sysmodule.c' line='2659' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PySys_AddWarnOptionUnicode'>
+      <parameter type-id='type-id-2' name='option' filepath='./Python/sysmodule.c' line='2659' column='1'/>
       <return type-id='type-id-46'/>
     </function-decl>
-    <function-decl name='PySys_HasWarnOptions' mangled-name='PySys_HasWarnOptions' filepath='./Python/sysmodule.c' line='2674' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PySys_HasWarnOptions'>
+    <function-decl name='PySys_AddWarnOption' mangled-name='PySys_AddWarnOption' filepath='./Python/sysmodule.c' line='2671' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PySys_AddWarnOption'>
+      <parameter type-id='type-id-16' name='s' filepath='./Python/sysmodule.c' line='2671' column='1'/>
+      <return type-id='type-id-46'/>
+    </function-decl>
+    <function-decl name='PySys_HasWarnOptions' mangled-name='PySys_HasWarnOptions' filepath='./Python/sysmodule.c' line='2690' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PySys_HasWarnOptions'>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='PySys_AddXOption' mangled-name='PySys_AddXOption' filepath='./Python/sysmodule.c' line='2753' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PySys_AddXOption'>
-      <parameter type-id='type-id-16' name='s' filepath='./Python/sysmodule.c' line='2753' column='1'/>
+    <function-decl name='PySys_AddXOption' mangled-name='PySys_AddXOption' filepath='./Python/sysmodule.c' line='2769' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PySys_AddXOption'>
+      <parameter type-id='type-id-16' name='s' filepath='./Python/sysmodule.c' line='2769' column='1'/>
       <return type-id='type-id-46'/>
     </function-decl>
-    <function-decl name='PySys_GetXOptions' mangled-name='PySys_GetXOptions' filepath='./Python/sysmodule.c' line='2767' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PySys_GetXOptions'>
+    <function-decl name='PySys_GetXOptions' mangled-name='PySys_GetXOptions' filepath='./Python/sysmodule.c' line='2783' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PySys_GetXOptions'>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='_Py_CreateMonitoringObject' filepath='./Python/sysmodule.c' line='3547' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_Py_CreateMonitoringObject' filepath='./Python/sysmodule.c' line='3563' column='1' visibility='default' binding='global' size-in-bits='64'>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='PySys_SetPath' mangled-name='PySys_SetPath' filepath='./Python/sysmodule.c' line='3669' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PySys_SetPath'>
-      <parameter type-id='type-id-16' name='path' filepath='./Python/sysmodule.c' line='3669' column='1'/>
+    <function-decl name='PySys_SetPath' mangled-name='PySys_SetPath' filepath='./Python/sysmodule.c' line='3685' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PySys_SetPath'>
+      <parameter type-id='type-id-16' name='path' filepath='./Python/sysmodule.c' line='3685' column='1'/>
       <return type-id='type-id-46'/>
     </function-decl>
-    <function-decl name='PySys_SetArgvEx' mangled-name='PySys_SetArgvEx' filepath='./Python/sysmodule.c' line='3701' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PySys_SetArgvEx'>
-      <parameter type-id='type-id-8' name='argc' filepath='./Python/sysmodule.c' line='3701' column='1'/>
-      <parameter type-id='type-id-235' name='argv' filepath='./Python/sysmodule.c' line='3701' column='1'/>
-      <parameter type-id='type-id-8' name='updatepath' filepath='./Python/sysmodule.c' line='3701' column='1'/>
+    <function-decl name='PySys_SetArgvEx' mangled-name='PySys_SetArgvEx' filepath='./Python/sysmodule.c' line='3717' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PySys_SetArgvEx'>
+      <parameter type-id='type-id-8' name='argc' filepath='./Python/sysmodule.c' line='3717' column='1'/>
+      <parameter type-id='type-id-235' name='argv' filepath='./Python/sysmodule.c' line='3717' column='1'/>
+      <parameter type-id='type-id-8' name='updatepath' filepath='./Python/sysmodule.c' line='3717' column='1'/>
       <return type-id='type-id-46'/>
     </function-decl>
-    <function-decl name='PySys_SetArgv' mangled-name='PySys_SetArgv' filepath='./Python/sysmodule.c' line='3745' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PySys_SetArgv'>
-      <parameter type-id='type-id-8' name='argc' filepath='./Python/sysmodule.c' line='3745' column='1'/>
-      <parameter type-id='type-id-235' name='argv' filepath='./Python/sysmodule.c' line='3745' column='1'/>
+    <function-decl name='PySys_SetArgv' mangled-name='PySys_SetArgv' filepath='./Python/sysmodule.c' line='3761' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PySys_SetArgv'>
+      <parameter type-id='type-id-8' name='argc' filepath='./Python/sysmodule.c' line='3761' column='1'/>
+      <parameter type-id='type-id-235' name='argv' filepath='./Python/sysmodule.c' line='3761' column='1'/>
       <return type-id='type-id-46'/>
     </function-decl>
-    <function-decl name='PySys_WriteStdout' mangled-name='PySys_WriteStdout' filepath='./Python/sysmodule.c' line='3840' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PySys_WriteStdout'>
-      <parameter type-id='type-id-12' name='format' filepath='./Python/sysmodule.c' line='3840' column='1'/>
+    <function-decl name='PySys_WriteStdout' mangled-name='PySys_WriteStdout' filepath='./Python/sysmodule.c' line='3856' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PySys_WriteStdout'>
+      <parameter type-id='type-id-12' name='format' filepath='./Python/sysmodule.c' line='3856' column='1'/>
       <parameter is-variadic='yes'/>
       <return type-id='type-id-46'/>
     </function-decl>
-    <function-decl name='PySys_FormatStdout' mangled-name='PySys_FormatStdout' filepath='./Python/sysmodule.c' line='3882' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PySys_FormatStdout'>
-      <parameter type-id='type-id-12' name='format' filepath='./Python/sysmodule.c' line='3882' column='1'/>
+    <function-decl name='PySys_FormatStdout' mangled-name='PySys_FormatStdout' filepath='./Python/sysmodule.c' line='3898' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PySys_FormatStdout'>
+      <parameter type-id='type-id-12' name='format' filepath='./Python/sysmodule.c' line='3898' column='1'/>
       <parameter is-variadic='yes'/>
       <return type-id='type-id-46'/>
     </function-decl>
@@ -3896,22 +3899,22 @@
     <function-decl name='PyGC_IsEnabled' mangled-name='PyGC_IsEnabled' filepath='Modules/gcmodule.c' line='2086' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyGC_IsEnabled'>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='PyUnstable_Object_GC_NewWithExtraData' mangled-name='PyUnstable_Object_GC_NewWithExtraData' filepath='Modules/gcmodule.c' line='2347' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyUnstable_Object_GC_NewWithExtraData'>
-      <parameter type-id='type-id-1' name='tp' filepath='Modules/gcmodule.c' line='2347' column='1'/>
-      <parameter type-id='type-id-19' name='extra_size' filepath='Modules/gcmodule.c' line='2347' column='1'/>
+    <function-decl name='PyUnstable_Object_GC_NewWithExtraData' mangled-name='PyUnstable_Object_GC_NewWithExtraData' filepath='Modules/gcmodule.c' line='2350' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyUnstable_Object_GC_NewWithExtraData'>
+      <parameter type-id='type-id-1' name='tp' filepath='Modules/gcmodule.c' line='2350' column='1'/>
+      <parameter type-id='type-id-19' name='extra_size' filepath='Modules/gcmodule.c' line='2350' column='1'/>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='PyObject_GC_IsTracked' mangled-name='PyObject_GC_IsTracked' filepath='Modules/gcmodule.c' line='2403' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyObject_GC_IsTracked'>
-      <parameter type-id='type-id-2' name='obj' filepath='Modules/gcmodule.c' line='2403' column='1'/>
+    <function-decl name='PyObject_GC_IsTracked' mangled-name='PyObject_GC_IsTracked' filepath='Modules/gcmodule.c' line='2406' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyObject_GC_IsTracked'>
+      <parameter type-id='type-id-2' name='obj' filepath='Modules/gcmodule.c' line='2406' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='PyObject_GC_IsFinalized' mangled-name='PyObject_GC_IsFinalized' filepath='Modules/gcmodule.c' line='2412' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyObject_GC_IsFinalized'>
-      <parameter type-id='type-id-2' name='obj' filepath='Modules/gcmodule.c' line='2412' column='1'/>
+    <function-decl name='PyObject_GC_IsFinalized' mangled-name='PyObject_GC_IsFinalized' filepath='Modules/gcmodule.c' line='2415' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyObject_GC_IsFinalized'>
+      <parameter type-id='type-id-2' name='obj' filepath='Modules/gcmodule.c' line='2415' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='PyUnstable_GC_VisitObjects' mangled-name='PyUnstable_GC_VisitObjects' filepath='Modules/gcmodule.c' line='2421' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyUnstable_GC_VisitObjects'>
-      <parameter type-id='type-id-237' name='callback' filepath='Modules/gcmodule.c' line='2421' column='1'/>
-      <parameter type-id='type-id-22' name='arg' filepath='Modules/gcmodule.c' line='2421' column='1'/>
+    <function-decl name='PyUnstable_GC_VisitObjects' mangled-name='PyUnstable_GC_VisitObjects' filepath='Modules/gcmodule.c' line='2424' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyUnstable_GC_VisitObjects'>
+      <parameter type-id='type-id-237' name='callback' filepath='Modules/gcmodule.c' line='2424' column='1'/>
+      <parameter type-id='type-id-22' name='arg' filepath='Modules/gcmodule.c' line='2424' column='1'/>
       <return type-id='type-id-46'/>
     </function-decl>
     <function-type size-in-bits='64' id='type-id-238'>
@@ -4033,7 +4036,7 @@
       <parameter type-id='type-id-2'/>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='_Py_CheckRecursiveCall' mangled-name='_Py_CheckRecursiveCall' filepath='./Include/internal/pycore_ceval.h' line='125' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_CheckRecursiveCall'>
+    <function-decl name='_Py_CheckRecursiveCall' mangled-name='_Py_CheckRecursiveCall' filepath='./Include/internal/pycore_ceval.h' line='126' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_CheckRecursiveCall'>
       <parameter type-id='type-id-177'/>
       <parameter type-id='type-id-12'/>
       <return type-id='type-id-8'/>
@@ -4089,22 +4092,22 @@
       <parameter type-id='type-id-2'/>
       <return type-id='type-id-14'/>
     </function-decl>
-    <function-decl name='PyLong_AsDouble' mangled-name='PyLong_AsDouble' filepath='./Include/longobject.h' line='63' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyLong_AsDouble'>
+    <function-decl name='PyLong_AsDouble' mangled-name='PyLong_AsDouble' filepath='./Include/longobject.h' line='80' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyLong_AsDouble'>
       <parameter type-id='type-id-2'/>
       <return type-id='type-id-251'/>
     </function-decl>
-    <function-decl name='PyType_IsSubtype' mangled-name='PyType_IsSubtype' filepath='./Include/object.h' line='379' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyType_IsSubtype'>
+    <function-decl name='PyType_IsSubtype' mangled-name='PyType_IsSubtype' filepath='./Include/object.h' line='378' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyType_IsSubtype'>
       <parameter type-id='type-id-1'/>
       <parameter type-id='type-id-1'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='PyObject_RichCompareBool' mangled-name='PyObject_RichCompareBool' filepath='./Include/object.h' line='407' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyObject_RichCompareBool'>
+    <function-decl name='PyObject_RichCompareBool' mangled-name='PyObject_RichCompareBool' filepath='./Include/object.h' line='406' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyObject_RichCompareBool'>
       <parameter type-id='type-id-2'/>
       <parameter type-id='type-id-2'/>
       <parameter type-id='type-id-8'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='PyObject_IsTrue' mangled-name='PyObject_IsTrue' filepath='./Include/object.h' line='422' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyObject_IsTrue'>
+    <function-decl name='PyObject_IsTrue' mangled-name='PyObject_IsTrue' filepath='./Include/object.h' line='421' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyObject_IsTrue'>
       <parameter type-id='type-id-2'/>
       <return type-id='type-id-8'/>
     </function-decl>
@@ -4750,7 +4753,7 @@
       <parameter type-id='type-id-233'/>
       <return type-id='type-id-248'/>
     </function-decl>
-    <function-decl name='_Py_GetConfig' mangled-name='_Py_GetConfig' filepath='./Include/cpython/pystate.h' line='368' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_GetConfig'>
+    <function-decl name='_Py_GetConfig' mangled-name='_Py_GetConfig' filepath='./Include/cpython/pystate.h' line='380' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_GetConfig'>
       <return type-id='type-id-260'/>
     </function-decl>
     <function-decl name='_Py_bytes_isspace' filepath='./Include/internal/pycore_bytes_methods.h' line='13' column='1' visibility='default' binding='global' size-in-bits='64'>
@@ -4908,27 +4911,27 @@
       <parameter type-id='type-id-179'/>
       <return type-id='type-id-47'/>
     </function-decl>
-    <function-decl name='PyType_GenericAlloc' mangled-name='PyType_GenericAlloc' filepath='./Include/object.h' line='395' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyType_GenericAlloc'>
+    <function-decl name='PyType_GenericAlloc' mangled-name='PyType_GenericAlloc' filepath='./Include/object.h' line='394' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyType_GenericAlloc'>
       <parameter type-id='type-id-1'/>
       <parameter type-id='type-id-14'/>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='PyType_GenericNew' mangled-name='PyType_GenericNew' filepath='./Include/object.h' line='396' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyType_GenericNew'>
+    <function-decl name='PyType_GenericNew' mangled-name='PyType_GenericNew' filepath='./Include/object.h' line='395' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyType_GenericNew'>
       <parameter type-id='type-id-1'/>
       <parameter type-id='type-id-2'/>
       <parameter type-id='type-id-2'/>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='PyObject_SelfIter' mangled-name='PyObject_SelfIter' filepath='./Include/object.h' line='414' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyObject_SelfIter'>
+    <function-decl name='PyObject_SelfIter' mangled-name='PyObject_SelfIter' filepath='./Include/object.h' line='413' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyObject_SelfIter'>
       <parameter type-id='type-id-2'/>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='PyObject_GenericGetAttr' mangled-name='PyObject_GenericGetAttr' filepath='./Include/object.h' line='415' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyObject_GenericGetAttr'>
+    <function-decl name='PyObject_GenericGetAttr' mangled-name='PyObject_GenericGetAttr' filepath='./Include/object.h' line='414' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyObject_GenericGetAttr'>
       <parameter type-id='type-id-2'/>
       <parameter type-id='type-id-2'/>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='_PyObject_GetState' mangled-name='_PyObject_GetState' filepath='./Include/object.h' line='436' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyObject_GetState'>
+    <function-decl name='_PyObject_GetState' mangled-name='_PyObject_GetState' filepath='./Include/object.h' line='435' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyObject_GetState'>
       <parameter type-id='type-id-2'/>
       <return type-id='type-id-2'/>
     </function-decl>
@@ -5189,7 +5192,7 @@
       <parameter type-id='type-id-8'/>
       <return type-id='type-id-15'/>
     </function-decl>
-    <function-decl name='PyObject_ASCII' mangled-name='PyObject_ASCII' filepath='./Include/object.h' line='404' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyObject_ASCII'>
+    <function-decl name='PyObject_ASCII' mangled-name='PyObject_ASCII' filepath='./Include/object.h' line='403' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyObject_ASCII'>
       <parameter type-id='type-id-2'/>
       <return type-id='type-id-2'/>
     </function-decl>
@@ -5374,7 +5377,7 @@
       <parameter type-id='type-id-233'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='_PyEval_Vector' filepath='./Include/internal/pycore_ceval.h' line='94' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_PyEval_Vector' filepath='./Include/internal/pycore_ceval.h' line='95' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-177'/>
       <parameter type-id='type-id-310'/>
       <parameter type-id='type-id-2'/>
@@ -5411,12 +5414,12 @@
       <parameter type-id='type-id-2'/>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='PyObject_GetAttrString' mangled-name='PyObject_GetAttrString' filepath='./Include/object.h' line='408' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyObject_GetAttrString'>
+    <function-decl name='PyObject_GetAttrString' mangled-name='PyObject_GetAttrString' filepath='./Include/object.h' line='407' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyObject_GetAttrString'>
       <parameter type-id='type-id-2'/>
       <parameter type-id='type-id-12'/>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='PyCallable_Check' mangled-name='PyCallable_Check' filepath='./Include/object.h' line='424' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyCallable_Check'>
+    <function-decl name='PyCallable_Check' mangled-name='PyCallable_Check' filepath='./Include/object.h' line='423' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyCallable_Check'>
       <parameter type-id='type-id-2'/>
       <return type-id='type-id-8'/>
     </function-decl>
@@ -5640,7 +5643,7 @@
   </abi-instr>
   <abi-instr address-size='64' path='Objects/cellobject.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
     <var-decl name='PyCell_Type' type-id='type-id-256' mangled-name='PyCell_Type' visibility='default' filepath='./Include/cpython/cellobject.h' line='16' column='1' elf-symbol-id='PyCell_Type'/>
-    <function-decl name='PyObject_RichCompare' mangled-name='PyObject_RichCompare' filepath='./Include/object.h' line='406' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyObject_RichCompare'>
+    <function-decl name='PyObject_RichCompare' mangled-name='PyObject_RichCompare' filepath='./Include/object.h' line='405' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyObject_RichCompare'>
       <parameter type-id='type-id-2'/>
       <parameter type-id='type-id-2'/>
       <parameter type-id='type-id-8'/>
@@ -5672,21 +5675,21 @@
       <parameter type-id='type-id-1'/>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='PyType_Ready' mangled-name='PyType_Ready' filepath='./Include/object.h' line='394' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyType_Ready'>
+    <function-decl name='PyType_Ready' mangled-name='PyType_Ready' filepath='./Include/object.h' line='393' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyType_Ready'>
       <parameter type-id='type-id-1'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='PyObject_GenericSetAttr' mangled-name='PyObject_GenericSetAttr' filepath='./Include/object.h' line='416' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyObject_GenericSetAttr'>
+    <function-decl name='PyObject_GenericSetAttr' mangled-name='PyObject_GenericSetAttr' filepath='./Include/object.h' line='415' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyObject_GenericSetAttr'>
       <parameter type-id='type-id-2'/>
       <parameter type-id='type-id-2'/>
       <parameter type-id='type-id-2'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='PyObject_Hash' mangled-name='PyObject_Hash' filepath='./Include/object.h' line='420' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyObject_Hash'>
+    <function-decl name='PyObject_Hash' mangled-name='PyObject_Hash' filepath='./Include/object.h' line='419' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyObject_Hash'>
       <parameter type-id='type-id-2'/>
       <return type-id='type-id-305'/>
     </function-decl>
-    <function-decl name='PyObject_ClearWeakRefs' mangled-name='PyObject_ClearWeakRefs' filepath='./Include/object.h' line='425' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyObject_ClearWeakRefs'>
+    <function-decl name='PyObject_ClearWeakRefs' mangled-name='PyObject_ClearWeakRefs' filepath='./Include/object.h' line='424' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyObject_ClearWeakRefs'>
       <parameter type-id='type-id-2'/>
       <return type-id='type-id-46'/>
     </function-decl>
@@ -5820,12 +5823,12 @@
       <parameter type-id='type-id-14'/>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='_Py_GetBaseOpcode' filepath='./Include/internal/pycore_code.h' line='488' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_Py_GetBaseOpcode' filepath='./Include/internal/pycore_code.h' line='490' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-328'/>
       <parameter type-id='type-id-8'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='PyLong_FromVoidPtr' mangled-name='PyLong_FromVoidPtr' filepath='./Include/longobject.h' line='64' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyLong_FromVoidPtr'>
+    <function-decl name='PyLong_FromVoidPtr' mangled-name='PyLong_FromVoidPtr' filepath='./Include/longobject.h' line='81' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyLong_FromVoidPtr'>
       <parameter type-id='type-id-22'/>
       <return type-id='type-id-2'/>
     </function-decl>
@@ -6136,7 +6139,7 @@
       <parameter type-id='type-id-335'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='_PyThreadState_UncheckedGet' mangled-name='_PyThreadState_UncheckedGet' filepath='./Include/cpython/pystate.h' line='274' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyThreadState_UncheckedGet'>
+    <function-decl name='_PyThreadState_UncheckedGet' mangled-name='_PyThreadState_UncheckedGet' filepath='./Include/cpython/pystate.h' line='286' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyThreadState_UncheckedGet'>
       <return type-id='type-id-177'/>
     </function-decl>
     <var-decl name='PyClassMethodDescr_Type' type-id='type-id-256' mangled-name='PyClassMethodDescr_Type' visibility='default' filepath='./Include/descrobject.h' line='19' column='1' elf-symbol-id='PyClassMethodDescr_Type'/>
@@ -6169,11 +6172,11 @@
       <parameter type-id='type-id-1'/>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='PyType_GetQualName' mangled-name='PyType_GetQualName' filepath='./Include/object.h' line='370' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyType_GetQualName'>
+    <function-decl name='PyType_GetQualName' mangled-name='PyType_GetQualName' filepath='./Include/object.h' line='369' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyType_GetQualName'>
       <parameter type-id='type-id-1'/>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='PyObject_SetAttr' mangled-name='PyObject_SetAttr' filepath='./Include/object.h' line='412' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyObject_SetAttr'>
+    <function-decl name='PyObject_SetAttr' mangled-name='PyObject_SetAttr' filepath='./Include/object.h' line='411' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyObject_SetAttr'>
       <parameter type-id='type-id-2'/>
       <parameter type-id='type-id-2'/>
       <parameter type-id='type-id-2'/>
@@ -6590,11 +6593,11 @@
       <parameter type-id='type-id-2'/>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='PyObject_Repr' mangled-name='PyObject_Repr' filepath='./Include/object.h' line='402' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyObject_Repr'>
+    <function-decl name='PyObject_Repr' mangled-name='PyObject_Repr' filepath='./Include/object.h' line='401' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyObject_Repr'>
       <parameter type-id='type-id-2'/>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='PyObject_GenericSetDict' mangled-name='PyObject_GenericSetDict' filepath='./Include/object.h' line='418' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyObject_GenericSetDict'>
+    <function-decl name='PyObject_GenericSetDict' mangled-name='PyObject_GenericSetDict' filepath='./Include/object.h' line='417' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyObject_GenericSetDict'>
       <parameter type-id='type-id-2'/>
       <parameter type-id='type-id-2'/>
       <parameter type-id='type-id-22'/>
@@ -6875,9 +6878,9 @@
       <parameter type-id='type-id-12' name='reason' filepath='Objects/exceptions.c' line='3233' column='1'/>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='_PyException_AddNote' mangled-name='_PyException_AddNote' filepath='Objects/exceptions.c' line='3832' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyException_AddNote'>
-      <parameter type-id='type-id-2' name='exc' filepath='Objects/exceptions.c' line='3832' column='1'/>
-      <parameter type-id='type-id-2' name='note' filepath='Objects/exceptions.c' line='3832' column='1'/>
+    <function-decl name='_PyException_AddNote' mangled-name='_PyException_AddNote' filepath='Objects/exceptions.c' line='3828' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyException_AddNote'>
+      <parameter type-id='type-id-2' name='exc' filepath='Objects/exceptions.c' line='3828' column='1'/>
+      <parameter type-id='type-id-2' name='note' filepath='Objects/exceptions.c' line='3828' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
   </abi-instr>
@@ -7125,41 +7128,41 @@
     <function-decl name='PyFloat_GetInfo' mangled-name='PyFloat_GetInfo' filepath='Objects/floatobject.c' line='94' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyFloat_GetInfo'>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='_PyFloat_DebugMallocStats' mangled-name='_PyFloat_DebugMallocStats' filepath='Objects/floatobject.c' line='2037' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyFloat_DebugMallocStats'>
-      <parameter type-id='type-id-229' name='out' filepath='Objects/floatobject.c' line='2037' column='1'/>
+    <function-decl name='_PyFloat_DebugMallocStats' mangled-name='_PyFloat_DebugMallocStats' filepath='Objects/floatobject.c' line='2042' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyFloat_DebugMallocStats'>
+      <parameter type-id='type-id-229' name='out' filepath='Objects/floatobject.c' line='2042' column='1'/>
       <return type-id='type-id-46'/>
     </function-decl>
-    <function-decl name='PyFloat_Pack2' mangled-name='PyFloat_Pack2' filepath='Objects/floatobject.c' line='2060' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyFloat_Pack2'>
-      <parameter type-id='type-id-251' name='x' filepath='Objects/floatobject.c' line='2060' column='1'/>
-      <parameter type-id='type-id-15' name='data' filepath='Objects/floatobject.c' line='2060' column='1'/>
-      <parameter type-id='type-id-8' name='le' filepath='Objects/floatobject.c' line='2060' column='1'/>
+    <function-decl name='PyFloat_Pack2' mangled-name='PyFloat_Pack2' filepath='Objects/floatobject.c' line='2065' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyFloat_Pack2'>
+      <parameter type-id='type-id-251' name='x' filepath='Objects/floatobject.c' line='2065' column='1'/>
+      <parameter type-id='type-id-15' name='data' filepath='Objects/floatobject.c' line='2065' column='1'/>
+      <parameter type-id='type-id-8' name='le' filepath='Objects/floatobject.c' line='2065' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='PyFloat_Pack4' mangled-name='PyFloat_Pack4' filepath='Objects/floatobject.c' line='2165' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyFloat_Pack4'>
-      <parameter type-id='type-id-251' name='x' filepath='Objects/floatobject.c' line='2165' column='1'/>
-      <parameter type-id='type-id-15' name='data' filepath='Objects/floatobject.c' line='2165' column='1'/>
-      <parameter type-id='type-id-8' name='le' filepath='Objects/floatobject.c' line='2165' column='1'/>
+    <function-decl name='PyFloat_Pack4' mangled-name='PyFloat_Pack4' filepath='Objects/floatobject.c' line='2170' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyFloat_Pack4'>
+      <parameter type-id='type-id-251' name='x' filepath='Objects/floatobject.c' line='2170' column='1'/>
+      <parameter type-id='type-id-15' name='data' filepath='Objects/floatobject.c' line='2170' column='1'/>
+      <parameter type-id='type-id-8' name='le' filepath='Objects/floatobject.c' line='2170' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='PyFloat_Pack8' mangled-name='PyFloat_Pack8' filepath='Objects/floatobject.c' line='2273' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyFloat_Pack8'>
-      <parameter type-id='type-id-251' name='x' filepath='Objects/floatobject.c' line='2273' column='1'/>
-      <parameter type-id='type-id-15' name='data' filepath='Objects/floatobject.c' line='2273' column='1'/>
-      <parameter type-id='type-id-8' name='le' filepath='Objects/floatobject.c' line='2273' column='1'/>
+    <function-decl name='PyFloat_Pack8' mangled-name='PyFloat_Pack8' filepath='Objects/floatobject.c' line='2278' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyFloat_Pack8'>
+      <parameter type-id='type-id-251' name='x' filepath='Objects/floatobject.c' line='2278' column='1'/>
+      <parameter type-id='type-id-15' name='data' filepath='Objects/floatobject.c' line='2278' column='1'/>
+      <parameter type-id='type-id-8' name='le' filepath='Objects/floatobject.c' line='2278' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='PyFloat_Unpack2' mangled-name='PyFloat_Unpack2' filepath='Objects/floatobject.c' line='2403' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyFloat_Unpack2'>
-      <parameter type-id='type-id-12' name='data' filepath='Objects/floatobject.c' line='2403' column='1'/>
-      <parameter type-id='type-id-8' name='le' filepath='Objects/floatobject.c' line='2403' column='1'/>
+    <function-decl name='PyFloat_Unpack2' mangled-name='PyFloat_Unpack2' filepath='Objects/floatobject.c' line='2408' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyFloat_Unpack2'>
+      <parameter type-id='type-id-12' name='data' filepath='Objects/floatobject.c' line='2408' column='1'/>
+      <parameter type-id='type-id-8' name='le' filepath='Objects/floatobject.c' line='2408' column='1'/>
       <return type-id='type-id-251'/>
     </function-decl>
-    <function-decl name='PyFloat_Unpack4' mangled-name='PyFloat_Unpack4' filepath='Objects/floatobject.c' line='2455' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyFloat_Unpack4'>
-      <parameter type-id='type-id-12' name='data' filepath='Objects/floatobject.c' line='2455' column='1'/>
-      <parameter type-id='type-id-8' name='le' filepath='Objects/floatobject.c' line='2455' column='1'/>
+    <function-decl name='PyFloat_Unpack4' mangled-name='PyFloat_Unpack4' filepath='Objects/floatobject.c' line='2460' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyFloat_Unpack4'>
+      <parameter type-id='type-id-12' name='data' filepath='Objects/floatobject.c' line='2460' column='1'/>
+      <parameter type-id='type-id-8' name='le' filepath='Objects/floatobject.c' line='2460' column='1'/>
       <return type-id='type-id-251'/>
     </function-decl>
-    <function-decl name='PyFloat_Unpack8' mangled-name='PyFloat_Unpack8' filepath='Objects/floatobject.c' line='2534' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyFloat_Unpack8'>
-      <parameter type-id='type-id-12' name='data' filepath='Objects/floatobject.c' line='2534' column='1'/>
-      <parameter type-id='type-id-8' name='le' filepath='Objects/floatobject.c' line='2534' column='1'/>
+    <function-decl name='PyFloat_Unpack8' mangled-name='PyFloat_Unpack8' filepath='Objects/floatobject.c' line='2539' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyFloat_Unpack8'>
+      <parameter type-id='type-id-12' name='data' filepath='Objects/floatobject.c' line='2539' column='1'/>
+      <parameter type-id='type-id-8' name='le' filepath='Objects/floatobject.c' line='2539' column='1'/>
       <return type-id='type-id-251'/>
     </function-decl>
   </abi-instr>
@@ -7414,7 +7417,7 @@
       <parameter type-id='type-id-2'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='PyObject_Dir' mangled-name='PyObject_Dir' filepath='./Include/object.h' line='432' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyObject_Dir'>
+    <function-decl name='PyObject_Dir' mangled-name='PyObject_Dir' filepath='./Include/object.h' line='431' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyObject_Dir'>
       <parameter type-id='type-id-2'/>
       <return type-id='type-id-2'/>
     </function-decl>
@@ -7460,7 +7463,7 @@
       </data-member>
     </class-decl>
     <typedef-decl name='PyGenObject' type-id='type-id-368' filepath='./Include/cpython/genobject.h' line='34' column='1' id='type-id-367'/>
-    <typedef-decl name='_PyInterpreterFrame' type-id='type-id-371' filepath='./Include/internal/pycore_frame.h' line='73' column='1' id='type-id-372'/>
+    <typedef-decl name='_PyInterpreterFrame' type-id='type-id-371' filepath='./Include/internal/pycore_frame.h' line='75' column='1' id='type-id-372'/>
     <pointer-type-def type-id='type-id-367' size-in-bits='64' id='type-id-373'/>
     <pointer-type-def type-id='type-id-372' size-in-bits='64' id='type-id-374'/>
     <function-decl name='_PyEval_EvalFrameDefault' mangled-name='_PyEval_EvalFrameDefault' filepath='./Include/cpython/ceval.h' line='20' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyEval_EvalFrameDefault'>
@@ -7484,23 +7487,23 @@
       <parameter type-id='type-id-375'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='_PyEval_GetFrame' filepath='./Include/internal/pycore_ceval.h' line='151' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_PyEval_GetFrame' filepath='./Include/internal/pycore_ceval.h' line='152' column='1' visibility='default' binding='global' size-in-bits='64'>
       <return type-id='type-id-375'/>
     </function-decl>
-    <function-decl name='_PyFrame_Copy' filepath='./Include/internal/pycore_frame.h' line='110' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_PyFrame_Copy' filepath='./Include/internal/pycore_frame.h' line='112' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-374'/>
       <parameter type-id='type-id-374'/>
       <return type-id='type-id-46'/>
     </function-decl>
-    <function-decl name='_PyFrame_MakeAndSetFrameObject' filepath='./Include/internal/pycore_frame.h' line='197' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_PyFrame_MakeAndSetFrameObject' filepath='./Include/internal/pycore_frame.h' line='199' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-374'/>
       <return type-id='type-id-365'/>
     </function-decl>
-    <function-decl name='_PyFrame_ClearExceptCode' filepath='./Include/internal/pycore_frame.h' line='224' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_PyFrame_ClearExceptCode' filepath='./Include/internal/pycore_frame.h' line='226' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-374'/>
       <return type-id='type-id-46'/>
     </function-decl>
-    <function-decl name='_PyFrame_Traverse' filepath='./Include/internal/pycore_frame.h' line='227' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_PyFrame_Traverse' filepath='./Include/internal/pycore_frame.h' line='229' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-374'/>
       <parameter type-id='type-id-341'/>
       <parameter type-id='type-id-22'/>
@@ -7537,60 +7540,60 @@
       <parameter type-id='type-id-2' name='self' filepath='Objects/genobject.c' line='70' column='1'/>
       <return type-id='type-id-46'/>
     </function-decl>
-    <function-decl name='_PyGen_SetStopIterationValue' mangled-name='_PyGen_SetStopIterationValue' filepath='Objects/genobject.c' line='619' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyGen_SetStopIterationValue'>
-      <parameter type-id='type-id-2' name='value' filepath='Objects/genobject.c' line='619' column='1'/>
+    <function-decl name='_PyGen_SetStopIterationValue' mangled-name='_PyGen_SetStopIterationValue' filepath='Objects/genobject.c' line='620' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyGen_SetStopIterationValue'>
+      <parameter type-id='type-id-2' name='value' filepath='Objects/genobject.c' line='620' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='PyGen_NewWithQualName' mangled-name='PyGen_NewWithQualName' filepath='Objects/genobject.c' line='989' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyGen_NewWithQualName'>
-      <parameter type-id='type-id-365' name='f' filepath='Objects/genobject.c' line='989' column='1'/>
-      <parameter type-id='type-id-2' name='name' filepath='Objects/genobject.c' line='989' column='1'/>
-      <parameter type-id='type-id-2' name='qualname' filepath='Objects/genobject.c' line='989' column='1'/>
+    <function-decl name='PyGen_NewWithQualName' mangled-name='PyGen_NewWithQualName' filepath='Objects/genobject.c' line='990' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyGen_NewWithQualName'>
+      <parameter type-id='type-id-365' name='f' filepath='Objects/genobject.c' line='990' column='1'/>
+      <parameter type-id='type-id-2' name='name' filepath='Objects/genobject.c' line='990' column='1'/>
+      <parameter type-id='type-id-2' name='qualname' filepath='Objects/genobject.c' line='990' column='1'/>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='PyGen_New' mangled-name='PyGen_New' filepath='Objects/genobject.c' line='995' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyGen_New'>
-      <parameter type-id='type-id-365' name='f' filepath='Objects/genobject.c' line='995' column='1'/>
+    <function-decl name='PyGen_New' mangled-name='PyGen_New' filepath='Objects/genobject.c' line='996' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyGen_New'>
+      <parameter type-id='type-id-365' name='f' filepath='Objects/genobject.c' line='996' column='1'/>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='PyCoro_New' mangled-name='PyCoro_New' filepath='Objects/genobject.c' line='1353' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyCoro_New'>
-      <parameter type-id='type-id-365' name='f' filepath='Objects/genobject.c' line='1353' column='1'/>
-      <parameter type-id='type-id-2' name='name' filepath='Objects/genobject.c' line='1353' column='1'/>
-      <parameter type-id='type-id-2' name='qualname' filepath='Objects/genobject.c' line='1353' column='1'/>
+    <function-decl name='PyCoro_New' mangled-name='PyCoro_New' filepath='Objects/genobject.c' line='1354' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyCoro_New'>
+      <parameter type-id='type-id-365' name='f' filepath='Objects/genobject.c' line='1354' column='1'/>
+      <parameter type-id='type-id-2' name='name' filepath='Objects/genobject.c' line='1354' column='1'/>
+      <parameter type-id='type-id-2' name='qualname' filepath='Objects/genobject.c' line='1354' column='1'/>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='PyAsyncGen_New' mangled-name='PyAsyncGen_New' filepath='Objects/genobject.c' line='1659' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyAsyncGen_New'>
-      <parameter type-id='type-id-365' name='f' filepath='Objects/genobject.c' line='1659' column='1'/>
-      <parameter type-id='type-id-2' name='name' filepath='Objects/genobject.c' line='1659' column='1'/>
-      <parameter type-id='type-id-2' name='qualname' filepath='Objects/genobject.c' line='1659' column='1'/>
+    <function-decl name='PyAsyncGen_New' mangled-name='PyAsyncGen_New' filepath='Objects/genobject.c' line='1660' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyAsyncGen_New'>
+      <parameter type-id='type-id-365' name='f' filepath='Objects/genobject.c' line='1660' column='1'/>
+      <parameter type-id='type-id-2' name='name' filepath='Objects/genobject.c' line='1660' column='1'/>
+      <parameter type-id='type-id-2' name='qualname' filepath='Objects/genobject.c' line='1660' column='1'/>
       <return type-id='type-id-2'/>
     </function-decl>
   </abi-instr>
   <abi-instr address-size='64' path='Objects/interpreteridobject.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
     <var-decl name='_PyInterpreterID_Type' type-id='type-id-256' mangled-name='_PyInterpreterID_Type' visibility='default' filepath='./Include/cpython/interpreteridobject.h' line='7' column='1' elf-symbol-id='_PyInterpreterID_Type'/>
-    <function-decl name='_PyInterpreterState_LookUpID' mangled-name='_PyInterpreterState_LookUpID' filepath='./Include/internal/pycore_interp.h' line='266' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyInterpreterState_LookUpID'>
+    <function-decl name='_PyInterpreterState_LookUpID' mangled-name='_PyInterpreterState_LookUpID' filepath='./Include/internal/pycore_interp.h' line='276' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyInterpreterState_LookUpID'>
       <parameter type-id='type-id-377'/>
       <return type-id='type-id-20'/>
     </function-decl>
-    <function-decl name='_PyInterpreterState_IDInitref' mangled-name='_PyInterpreterState_IDInitref' filepath='./Include/internal/pycore_interp.h' line='268' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyInterpreterState_IDInitref'>
+    <function-decl name='_PyInterpreterState_IDInitref' mangled-name='_PyInterpreterState_IDInitref' filepath='./Include/internal/pycore_interp.h' line='278' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyInterpreterState_IDInitref'>
       <parameter type-id='type-id-20'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='_PyInterpreterState_IDIncref' mangled-name='_PyInterpreterState_IDIncref' filepath='./Include/internal/pycore_interp.h' line='269' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyInterpreterState_IDIncref'>
+    <function-decl name='_PyInterpreterState_IDIncref' mangled-name='_PyInterpreterState_IDIncref' filepath='./Include/internal/pycore_interp.h' line='279' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyInterpreterState_IDIncref'>
       <parameter type-id='type-id-20'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='_PyInterpreterState_IDDecref' mangled-name='_PyInterpreterState_IDDecref' filepath='./Include/internal/pycore_interp.h' line='270' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyInterpreterState_IDDecref'>
+    <function-decl name='_PyInterpreterState_IDDecref' mangled-name='_PyInterpreterState_IDDecref' filepath='./Include/internal/pycore_interp.h' line='280' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyInterpreterState_IDDecref'>
       <parameter type-id='type-id-20'/>
       <return type-id='type-id-46'/>
     </function-decl>
-    <function-decl name='PyLong_FromLongLong' mangled-name='PyLong_FromLongLong' filepath='./Include/longobject.h' line='67' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyLong_FromLongLong'>
+    <function-decl name='PyLong_FromLongLong' mangled-name='PyLong_FromLongLong' filepath='./Include/longobject.h' line='84' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyLong_FromLongLong'>
       <parameter type-id='type-id-378'/>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='PyLong_AsLongLong' mangled-name='PyLong_AsLongLong' filepath='./Include/longobject.h' line='69' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyLong_AsLongLong'>
+    <function-decl name='PyLong_AsLongLong' mangled-name='PyLong_AsLongLong' filepath='./Include/longobject.h' line='86' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyLong_AsLongLong'>
       <parameter type-id='type-id-2'/>
       <return type-id='type-id-378'/>
     </function-decl>
-    <function-decl name='PyLong_AsLongLongAndOverflow' mangled-name='PyLong_AsLongLongAndOverflow' filepath='./Include/longobject.h' line='72' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyLong_AsLongLongAndOverflow'>
+    <function-decl name='PyLong_AsLongLongAndOverflow' mangled-name='PyLong_AsLongLongAndOverflow' filepath='./Include/longobject.h' line='89' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyLong_AsLongLongAndOverflow'>
       <parameter type-id='type-id-2'/>
       <parameter type-id='type-id-179'/>
       <return type-id='type-id-378'/>
@@ -7648,15 +7651,15 @@
     <var-decl name='PyList_Type' type-id='type-id-256' mangled-name='PyList_Type' visibility='default' filepath='./Include/listobject.h' line='20' column='1' elf-symbol-id='PyList_Type'/>
     <var-decl name='PyListIter_Type' type-id='type-id-256' mangled-name='PyListIter_Type' visibility='default' filepath='./Include/listobject.h' line='21' column='1' elf-symbol-id='PyListIter_Type'/>
     <var-decl name='PyListRevIter_Type' type-id='type-id-256' mangled-name='PyListRevIter_Type' visibility='default' filepath='./Include/listobject.h' line='22' column='1' elf-symbol-id='PyListRevIter_Type'/>
-    <function-decl name='PyObject_HashNotImplemented' mangled-name='PyObject_HashNotImplemented' filepath='./Include/object.h' line='421' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyObject_HashNotImplemented'>
+    <function-decl name='PyObject_HashNotImplemented' mangled-name='PyObject_HashNotImplemented' filepath='./Include/object.h' line='420' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyObject_HashNotImplemented'>
       <parameter type-id='type-id-2'/>
       <return type-id='type-id-305'/>
     </function-decl>
-    <function-decl name='Py_ReprEnter' mangled-name='Py_ReprEnter' filepath='./Include/object.h' line='441' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='Py_ReprEnter'>
+    <function-decl name='Py_ReprEnter' mangled-name='Py_ReprEnter' filepath='./Include/object.h' line='440' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='Py_ReprEnter'>
       <parameter type-id='type-id-2'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='Py_ReprLeave' mangled-name='Py_ReprLeave' filepath='./Include/object.h' line='442' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='Py_ReprLeave'>
+    <function-decl name='Py_ReprLeave' mangled-name='Py_ReprLeave' filepath='./Include/object.h' line='441' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='Py_ReprLeave'>
       <parameter type-id='type-id-2'/>
       <return type-id='type-id-46'/>
     </function-decl>
@@ -7717,7 +7720,7 @@
       <return type-id='type-id-8'/>
     </function-decl>
     <var-decl name='PyLong_Type' type-id='type-id-256' mangled-name='PyLong_Type' visibility='default' filepath='./Include/object.h' line='226' column='1' elf-symbol-id='PyLong_Type'/>
-    <function-decl name='PyObject_Bytes' mangled-name='PyObject_Bytes' filepath='./Include/object.h' line='405' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyObject_Bytes'>
+    <function-decl name='PyObject_Bytes' mangled-name='PyObject_Bytes' filepath='./Include/object.h' line='404' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyObject_Bytes'>
       <parameter type-id='type-id-2'/>
       <return type-id='type-id-2'/>
     </function-decl>
@@ -7807,42 +7810,42 @@
       <parameter type-id='type-id-22' name='ptr' filepath='Objects/longobject.c' line='1488' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='_PyLong_FormatWriter' mangled-name='_PyLong_FormatWriter' filepath='Objects/longobject.c' line='2166' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyLong_FormatWriter'>
-      <parameter type-id='type-id-332' name='writer' filepath='Objects/longobject.c' line='2166' column='1'/>
-      <parameter type-id='type-id-2' name='obj' filepath='Objects/longobject.c' line='2167' column='1'/>
-      <parameter type-id='type-id-8' name='base' filepath='Objects/longobject.c' line='2168' column='1'/>
-      <parameter type-id='type-id-8' name='alternate' filepath='Objects/longobject.c' line='2168' column='1'/>
+    <function-decl name='_PyLong_FormatWriter' mangled-name='_PyLong_FormatWriter' filepath='Objects/longobject.c' line='2173' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyLong_FormatWriter'>
+      <parameter type-id='type-id-332' name='writer' filepath='Objects/longobject.c' line='2173' column='1'/>
+      <parameter type-id='type-id-2' name='obj' filepath='Objects/longobject.c' line='2174' column='1'/>
+      <parameter type-id='type-id-8' name='base' filepath='Objects/longobject.c' line='2175' column='1'/>
+      <parameter type-id='type-id-8' name='alternate' filepath='Objects/longobject.c' line='2175' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='_PyLong_Frexp' mangled-name='_PyLong_Frexp' filepath='Objects/longobject.c' line='3095' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyLong_Frexp'>
-      <parameter type-id='type-id-241' name='a' filepath='Objects/longobject.c' line='3095' column='1'/>
-      <parameter type-id='type-id-13' name='e' filepath='Objects/longobject.c' line='3095' column='1'/>
+    <function-decl name='_PyLong_Frexp' mangled-name='_PyLong_Frexp' filepath='Objects/longobject.c' line='3102' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyLong_Frexp'>
+      <parameter type-id='type-id-241' name='a' filepath='Objects/longobject.c' line='3102' column='1'/>
+      <parameter type-id='type-id-13' name='e' filepath='Objects/longobject.c' line='3102' column='1'/>
       <return type-id='type-id-251'/>
     </function-decl>
-    <function-decl name='_PyLong_Rshift' mangled-name='_PyLong_Rshift' filepath='Objects/longobject.c' line='5042' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyLong_Rshift'>
-      <parameter type-id='type-id-2' name='a' filepath='Objects/longobject.c' line='5042' column='1'/>
-      <parameter type-id='type-id-19' name='shiftby' filepath='Objects/longobject.c' line='5042' column='1'/>
+    <function-decl name='_PyLong_Rshift' mangled-name='_PyLong_Rshift' filepath='Objects/longobject.c' line='5049' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyLong_Rshift'>
+      <parameter type-id='type-id-2' name='a' filepath='Objects/longobject.c' line='5049' column='1'/>
+      <parameter type-id='type-id-19' name='shiftby' filepath='Objects/longobject.c' line='5049' column='1'/>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='_PyLong_GCD' mangled-name='_PyLong_GCD' filepath='Objects/longobject.c' line='5321' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyLong_GCD'>
-      <parameter type-id='type-id-2' name='aarg' filepath='Objects/longobject.c' line='5321' column='1'/>
-      <parameter type-id='type-id-2' name='barg' filepath='Objects/longobject.c' line='5321' column='1'/>
+    <function-decl name='_PyLong_GCD' mangled-name='_PyLong_GCD' filepath='Objects/longobject.c' line='5328' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyLong_GCD'>
+      <parameter type-id='type-id-2' name='aarg' filepath='Objects/longobject.c' line='5328' column='1'/>
+      <parameter type-id='type-id-2' name='barg' filepath='Objects/longobject.c' line='5328' column='1'/>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='_PyLong_DivmodNear' mangled-name='_PyLong_DivmodNear' filepath='Objects/longobject.c' line='5687' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyLong_DivmodNear'>
-      <parameter type-id='type-id-2' name='a' filepath='Objects/longobject.c' line='5687' column='1'/>
-      <parameter type-id='type-id-2' name='b' filepath='Objects/longobject.c' line='5687' column='1'/>
+    <function-decl name='_PyLong_DivmodNear' mangled-name='_PyLong_DivmodNear' filepath='Objects/longobject.c' line='5694' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyLong_DivmodNear'>
+      <parameter type-id='type-id-2' name='a' filepath='Objects/longobject.c' line='5694' column='1'/>
+      <parameter type-id='type-id-2' name='b' filepath='Objects/longobject.c' line='5694' column='1'/>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='PyLong_GetInfo' mangled-name='PyLong_GetInfo' filepath='Objects/longobject.c' line='6321' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyLong_GetInfo'>
+    <function-decl name='PyLong_GetInfo' mangled-name='PyLong_GetInfo' filepath='Objects/longobject.c' line='6328' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyLong_GetInfo'>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='PyUnstable_Long_IsCompact' mangled-name='PyUnstable_Long_IsCompact' filepath='Objects/longobject.c' line='6376' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyUnstable_Long_IsCompact'>
-      <parameter type-id='type-id-381' name='op' filepath='Objects/longobject.c' line='6376' column='1'/>
+    <function-decl name='PyUnstable_Long_IsCompact' mangled-name='PyUnstable_Long_IsCompact' filepath='Objects/longobject.c' line='6383' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyUnstable_Long_IsCompact'>
+      <parameter type-id='type-id-381' name='op' filepath='Objects/longobject.c' line='6383' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='PyUnstable_Long_CompactValue' mangled-name='PyUnstable_Long_CompactValue' filepath='Objects/longobject.c' line='6383' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyUnstable_Long_CompactValue'>
-      <parameter type-id='type-id-381' name='op' filepath='Objects/longobject.c' line='6383' column='1'/>
+    <function-decl name='PyUnstable_Long_CompactValue' mangled-name='PyUnstable_Long_CompactValue' filepath='Objects/longobject.c' line='6390' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyUnstable_Long_CompactValue'>
+      <parameter type-id='type-id-381' name='op' filepath='Objects/longobject.c' line='6390' column='1'/>
       <return type-id='type-id-14'/>
     </function-decl>
   </abi-instr>
@@ -7925,33 +7928,33 @@
         <var-decl name='value' type-id='type-id-22' visibility='default' filepath='./Include/moduleobject.h' line='76' column='1'/>
       </data-member>
     </class-decl>
-    <class-decl name='PyModuleDef' size-in-bits='832' is-struct='yes' visibility='default' filepath='./Include/moduleobject.h' line='96' column='1' id='type-id-393'>
+    <class-decl name='PyModuleDef' size-in-bits='832' is-struct='yes' visibility='default' filepath='./Include/moduleobject.h' line='98' column='1' id='type-id-393'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='m_base' type-id='type-id-391' visibility='default' filepath='./Include/moduleobject.h' line='97' column='1'/>
+        <var-decl name='m_base' type-id='type-id-391' visibility='default' filepath='./Include/moduleobject.h' line='99' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='m_name' type-id='type-id-12' visibility='default' filepath='./Include/moduleobject.h' line='98' column='1'/>
+        <var-decl name='m_name' type-id='type-id-12' visibility='default' filepath='./Include/moduleobject.h' line='100' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='384'>
-        <var-decl name='m_doc' type-id='type-id-12' visibility='default' filepath='./Include/moduleobject.h' line='99' column='1'/>
+        <var-decl name='m_doc' type-id='type-id-12' visibility='default' filepath='./Include/moduleobject.h' line='101' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='448'>
-        <var-decl name='m_size' type-id='type-id-14' visibility='default' filepath='./Include/moduleobject.h' line='100' column='1'/>
+        <var-decl name='m_size' type-id='type-id-14' visibility='default' filepath='./Include/moduleobject.h' line='102' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='512'>
-        <var-decl name='m_methods' type-id='type-id-337' visibility='default' filepath='./Include/moduleobject.h' line='101' column='1'/>
+        <var-decl name='m_methods' type-id='type-id-337' visibility='default' filepath='./Include/moduleobject.h' line='103' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='576'>
-        <var-decl name='m_slots' type-id='type-id-394' visibility='default' filepath='./Include/moduleobject.h' line='102' column='1'/>
+        <var-decl name='m_slots' type-id='type-id-394' visibility='default' filepath='./Include/moduleobject.h' line='104' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='640'>
-        <var-decl name='m_traverse' type-id='type-id-395' visibility='default' filepath='./Include/moduleobject.h' line='103' column='1'/>
+        <var-decl name='m_traverse' type-id='type-id-395' visibility='default' filepath='./Include/moduleobject.h' line='105' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='704'>
-        <var-decl name='m_clear' type-id='type-id-396' visibility='default' filepath='./Include/moduleobject.h' line='104' column='1'/>
+        <var-decl name='m_clear' type-id='type-id-396' visibility='default' filepath='./Include/moduleobject.h' line='106' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='768'>
-        <var-decl name='m_free' type-id='type-id-397' visibility='default' filepath='./Include/moduleobject.h' line='105' column='1'/>
+        <var-decl name='m_free' type-id='type-id-397' visibility='default' filepath='./Include/moduleobject.h' line='107' column='1'/>
       </data-member>
     </class-decl>
     <typedef-decl name='PyModuleDef' type-id='type-id-393' filepath='./Include/pytypedefs.h' line='12' column='1' id='type-id-3'/>
@@ -7993,7 +7996,7 @@
     </function-decl>
     <var-decl name='PyModule_Type' type-id='type-id-256' mangled-name='PyModule_Type' visibility='default' filepath='./Include/moduleobject.h' line='10' column='1' elf-symbol-id='PyModule_Type'/>
     <var-decl name='PyModuleDef_Type' type-id='type-id-256' mangled-name='PyModuleDef_Type' visibility='default' filepath='./Include/moduleobject.h' line='41' column='1' elf-symbol-id='PyModuleDef_Type'/>
-    <function-decl name='PyObject_SetAttrString' mangled-name='PyObject_SetAttrString' filepath='./Include/object.h' line='409' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyObject_SetAttrString'>
+    <function-decl name='PyObject_SetAttrString' mangled-name='PyObject_SetAttrString' filepath='./Include/object.h' line='408' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyObject_SetAttrString'>
       <parameter type-id='type-id-2'/>
       <parameter type-id='type-id-12'/>
       <parameter type-id='type-id-2'/>
@@ -8154,7 +8157,7 @@
       <parameter type-id='type-id-12'/>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='_PyEval_GetFrameLocals' filepath='./Include/internal/pycore_ceval.h' line='157' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_PyEval_GetFrameLocals' filepath='./Include/internal/pycore_ceval.h' line='158' column='1' visibility='default' binding='global' size-in-bits='64'>
       <return type-id='type-id-2'/>
     </function-decl>
     <function-decl name='_PyObjectDict_SetItem' filepath='./Include/internal/pycore_dict.h' line='56' column='1' visibility='default' binding='global' size-in-bits='64'>
@@ -8217,12 +8220,18 @@
       <parameter type-id='type-id-2'/>
       <return type-id='type-id-2'/>
     </function-decl>
+    <function-decl name='_Py_BaseObject_RichCompare' filepath='./Include/internal/pycore_typeobject.h' line='136' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-2'/>
+      <parameter type-id='type-id-2'/>
+      <parameter type-id='type-id-8'/>
+      <return type-id='type-id-2'/>
+    </function-decl>
     <function-decl name='_Py_initialize_generic' filepath='./Include/internal/pycore_typevarobject.h' line='16' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-20'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <var-decl name='_Py_NoneStruct' type-id='type-id-345' mangled-name='_Py_NoneStruct' visibility='default' filepath='./Include/object.h' line='843' column='1' elf-symbol-id='_Py_NoneStruct'/>
-    <var-decl name='_Py_NotImplementedStruct' type-id='type-id-345' mangled-name='_Py_NotImplementedStruct' visibility='default' filepath='./Include/object.h' line='857' column='1' elf-symbol-id='_Py_NotImplementedStruct'/>
+    <var-decl name='_Py_NoneStruct' type-id='type-id-345' mangled-name='_Py_NoneStruct' visibility='default' filepath='./Include/object.h' line='842' column='1' elf-symbol-id='_Py_NoneStruct'/>
+    <var-decl name='_Py_NotImplementedStruct' type-id='type-id-345' mangled-name='_Py_NotImplementedStruct' visibility='default' filepath='./Include/object.h' line='856' column='1' elf-symbol-id='_Py_NotImplementedStruct'/>
     <function-decl name='PyThreadState_GetDict' mangled-name='PyThreadState_GetDict' filepath='./Include/pystate.h' line='66' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyThreadState_GetDict'>
       <return type-id='type-id-2'/>
     </function-decl>
@@ -8426,13 +8435,18 @@
       <parameter type-id='type-id-12'/>
       <return type-id='type-id-15'/>
     </function-decl>
-    <function-decl name='PyGILState_Check' mangled-name='PyGILState_Check' filepath='./Include/cpython/pystate.h' line='291' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyGILState_Check'>
+    <function-decl name='_PyInterpreterState_HasFeature' mangled-name='_PyInterpreterState_HasFeature' filepath='./Include/cpython/pystate.h' line='34' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyInterpreterState_HasFeature'>
+      <parameter type-id='type-id-20'/>
+      <parameter type-id='type-id-28'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='PyInterpreterState_Head' mangled-name='PyInterpreterState_Head' filepath='./Include/cpython/pystate.h' line='315' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyInterpreterState_Head'>
+    <function-decl name='PyGILState_Check' mangled-name='PyGILState_Check' filepath='./Include/cpython/pystate.h' line='303' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyGILState_Check'>
+      <return type-id='type-id-8'/>
+    </function-decl>
+    <function-decl name='PyInterpreterState_Head' mangled-name='PyInterpreterState_Head' filepath='./Include/cpython/pystate.h' line='327' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyInterpreterState_Head'>
       <return type-id='type-id-20'/>
     </function-decl>
-    <function-decl name='PyInterpreterState_Next' mangled-name='PyInterpreterState_Next' filepath='./Include/cpython/pystate.h' line='316' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyInterpreterState_Next'>
+    <function-decl name='PyInterpreterState_Next' mangled-name='PyInterpreterState_Next' filepath='./Include/cpython/pystate.h' line='328' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyInterpreterState_Next'>
       <parameter type-id='type-id-20'/>
       <return type-id='type-id-20'/>
     </function-decl>
@@ -8473,63 +8487,63 @@
       <parameter type-id='type-id-19'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='_PyMem_SetDefaultAllocator' mangled-name='_PyMem_SetDefaultAllocator' filepath='Objects/obmalloc.c' line='258' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyMem_SetDefaultAllocator'>
-      <parameter type-id='type-id-413' name='domain' filepath='Objects/obmalloc.c' line='258' column='1'/>
-      <parameter type-id='type-id-418' name='old_alloc' filepath='Objects/obmalloc.c' line='259' column='1'/>
+    <function-decl name='_PyMem_SetDefaultAllocator' mangled-name='_PyMem_SetDefaultAllocator' filepath='Objects/obmalloc.c' line='259' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyMem_SetDefaultAllocator'>
+      <parameter type-id='type-id-413' name='domain' filepath='Objects/obmalloc.c' line='259' column='1'/>
+      <parameter type-id='type-id-418' name='old_alloc' filepath='Objects/obmalloc.c' line='260' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='_PyMem_GetAllocatorName' mangled-name='_PyMem_GetAllocatorName' filepath='Objects/obmalloc.c' line='273' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyMem_GetAllocatorName'>
-      <parameter type-id='type-id-12' name='name' filepath='Objects/obmalloc.c' line='273' column='1'/>
-      <parameter type-id='type-id-419' name='allocator' filepath='Objects/obmalloc.c' line='273' column='1'/>
+    <function-decl name='_PyMem_GetAllocatorName' mangled-name='_PyMem_GetAllocatorName' filepath='Objects/obmalloc.c' line='274' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyMem_GetAllocatorName'>
+      <parameter type-id='type-id-12' name='name' filepath='Objects/obmalloc.c' line='274' column='1'/>
+      <parameter type-id='type-id-419' name='allocator' filepath='Objects/obmalloc.c' line='274' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='_PyMem_SetupAllocators' mangled-name='_PyMem_SetupAllocators' filepath='Objects/obmalloc.c' line='369' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyMem_SetupAllocators'>
-      <parameter type-id='type-id-415' name='allocator' filepath='Objects/obmalloc.c' line='369' column='1'/>
+    <function-decl name='_PyMem_SetupAllocators' mangled-name='_PyMem_SetupAllocators' filepath='Objects/obmalloc.c' line='370' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyMem_SetupAllocators'>
+      <parameter type-id='type-id-415' name='allocator' filepath='Objects/obmalloc.c' line='370' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='_PyMem_GetCurrentAllocatorName' mangled-name='_PyMem_GetCurrentAllocatorName' filepath='Objects/obmalloc.c' line='436' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyMem_GetCurrentAllocatorName'>
+    <function-decl name='_PyMem_GetCurrentAllocatorName' mangled-name='_PyMem_GetCurrentAllocatorName' filepath='Objects/obmalloc.c' line='437' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyMem_GetCurrentAllocatorName'>
       <return type-id='type-id-12'/>
     </function-decl>
-    <function-decl name='PyMem_SetupDebugHooks' mangled-name='PyMem_SetupDebugHooks' filepath='Objects/obmalloc.c' line='521' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyMem_SetupDebugHooks'>
+    <function-decl name='PyMem_SetupDebugHooks' mangled-name='PyMem_SetupDebugHooks' filepath='Objects/obmalloc.c' line='522' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyMem_SetupDebugHooks'>
       <return type-id='type-id-46'/>
     </function-decl>
-    <function-decl name='PyMem_GetAllocator' mangled-name='PyMem_GetAllocator' filepath='Objects/obmalloc.c' line='564' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyMem_GetAllocator'>
-      <parameter type-id='type-id-413' name='domain' filepath='Objects/obmalloc.c' line='564' column='1'/>
-      <parameter type-id='type-id-418' name='allocator' filepath='Objects/obmalloc.c' line='564' column='1'/>
+    <function-decl name='PyMem_GetAllocator' mangled-name='PyMem_GetAllocator' filepath='Objects/obmalloc.c' line='565' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyMem_GetAllocator'>
+      <parameter type-id='type-id-413' name='domain' filepath='Objects/obmalloc.c' line='565' column='1'/>
+      <parameter type-id='type-id-418' name='allocator' filepath='Objects/obmalloc.c' line='565' column='1'/>
       <return type-id='type-id-46'/>
     </function-decl>
-    <function-decl name='PyMem_SetAllocator' mangled-name='PyMem_SetAllocator' filepath='Objects/obmalloc.c' line='577' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyMem_SetAllocator'>
-      <parameter type-id='type-id-413' name='domain' filepath='Objects/obmalloc.c' line='577' column='1'/>
-      <parameter type-id='type-id-418' name='allocator' filepath='Objects/obmalloc.c' line='577' column='1'/>
+    <function-decl name='PyMem_SetAllocator' mangled-name='PyMem_SetAllocator' filepath='Objects/obmalloc.c' line='578' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyMem_SetAllocator'>
+      <parameter type-id='type-id-413' name='domain' filepath='Objects/obmalloc.c' line='578' column='1'/>
+      <parameter type-id='type-id-418' name='allocator' filepath='Objects/obmalloc.c' line='578' column='1'/>
       <return type-id='type-id-46'/>
     </function-decl>
-    <function-decl name='PyObject_GetArenaAllocator' mangled-name='PyObject_GetArenaAllocator' filepath='Objects/obmalloc.c' line='590' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyObject_GetArenaAllocator'>
-      <parameter type-id='type-id-421' name='allocator' filepath='Objects/obmalloc.c' line='590' column='1'/>
+    <function-decl name='PyObject_GetArenaAllocator' mangled-name='PyObject_GetArenaAllocator' filepath='Objects/obmalloc.c' line='591' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyObject_GetArenaAllocator'>
+      <parameter type-id='type-id-421' name='allocator' filepath='Objects/obmalloc.c' line='591' column='1'/>
       <return type-id='type-id-46'/>
     </function-decl>
-    <function-decl name='PyObject_SetArenaAllocator' mangled-name='PyObject_SetArenaAllocator' filepath='Objects/obmalloc.c' line='603' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyObject_SetArenaAllocator'>
-      <parameter type-id='type-id-421' name='allocator' filepath='Objects/obmalloc.c' line='603' column='1'/>
+    <function-decl name='PyObject_SetArenaAllocator' mangled-name='PyObject_SetArenaAllocator' filepath='Objects/obmalloc.c' line='604' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyObject_SetArenaAllocator'>
+      <parameter type-id='type-id-421' name='allocator' filepath='Objects/obmalloc.c' line='604' column='1'/>
       <return type-id='type-id-46'/>
     </function-decl>
-    <function-decl name='PyMem_RawCalloc' mangled-name='PyMem_RawCalloc' filepath='Objects/obmalloc.c' line='666' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyMem_RawCalloc'>
-      <parameter type-id='type-id-19' name='nelem' filepath='Objects/obmalloc.c' line='666' column='1'/>
-      <parameter type-id='type-id-19' name='elsize' filepath='Objects/obmalloc.c' line='666' column='1'/>
+    <function-decl name='PyMem_RawCalloc' mangled-name='PyMem_RawCalloc' filepath='Objects/obmalloc.c' line='667' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyMem_RawCalloc'>
+      <parameter type-id='type-id-19' name='nelem' filepath='Objects/obmalloc.c' line='667' column='1'/>
+      <parameter type-id='type-id-19' name='elsize' filepath='Objects/obmalloc.c' line='667' column='1'/>
       <return type-id='type-id-22'/>
     </function-decl>
-    <function-decl name='_PyMem_RawWcsdup' mangled-name='_PyMem_RawWcsdup' filepath='Objects/obmalloc.c' line='741' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyMem_RawWcsdup'>
-      <parameter type-id='type-id-16' name='str' filepath='Objects/obmalloc.c' line='741' column='1'/>
+    <function-decl name='_PyMem_RawWcsdup' mangled-name='_PyMem_RawWcsdup' filepath='Objects/obmalloc.c' line='742' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyMem_RawWcsdup'>
+      <parameter type-id='type-id-16' name='str' filepath='Objects/obmalloc.c' line='742' column='1'/>
       <return type-id='type-id-52'/>
     </function-decl>
-    <function-decl name='_PyMem_RawStrdup' mangled-name='_PyMem_RawStrdup' filepath='Objects/obmalloc.c' line='761' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyMem_RawStrdup'>
-      <parameter type-id='type-id-12' name='str' filepath='Objects/obmalloc.c' line='761' column='1'/>
+    <function-decl name='_PyMem_RawStrdup' mangled-name='_PyMem_RawStrdup' filepath='Objects/obmalloc.c' line='762' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyMem_RawStrdup'>
+      <parameter type-id='type-id-12' name='str' filepath='Objects/obmalloc.c' line='762' column='1'/>
       <return type-id='type-id-15'/>
     </function-decl>
-    <function-decl name='_PyMem_Strdup' mangled-name='_PyMem_Strdup' filepath='Objects/obmalloc.c' line='774' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyMem_Strdup'>
-      <parameter type-id='type-id-12' name='str' filepath='Objects/obmalloc.c' line='774' column='1'/>
+    <function-decl name='_PyMem_Strdup' mangled-name='_PyMem_Strdup' filepath='Objects/obmalloc.c' line='775' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyMem_Strdup'>
+      <parameter type-id='type-id-12' name='str' filepath='Objects/obmalloc.c' line='775' column='1'/>
       <return type-id='type-id-15'/>
     </function-decl>
-    <function-decl name='_PyObject_DebugMallocStats' mangled-name='_PyObject_DebugMallocStats' filepath='Objects/obmalloc.c' line='2546' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyObject_DebugMallocStats'>
-      <parameter type-id='type-id-229' name='out' filepath='Objects/obmalloc.c' line='2546' column='1'/>
+    <function-decl name='_PyObject_DebugMallocStats' mangled-name='_PyObject_DebugMallocStats' filepath='Objects/obmalloc.c' line='2655' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyObject_DebugMallocStats'>
+      <parameter type-id='type-id-229' name='out' filepath='Objects/obmalloc.c' line='2655' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
   </abi-instr>
@@ -8616,21 +8630,21 @@
     <var-decl name='PySet_Type' type-id='type-id-256' mangled-name='PySet_Type' visibility='default' filepath='./Include/setobject.h' line='9' column='1' elf-symbol-id='PySet_Type'/>
     <var-decl name='PyFrozenSet_Type' type-id='type-id-256' mangled-name='PyFrozenSet_Type' visibility='default' filepath='./Include/setobject.h' line='10' column='1' elf-symbol-id='PyFrozenSet_Type'/>
     <var-decl name='PySetIter_Type' type-id='type-id-256' mangled-name='PySetIter_Type' visibility='default' filepath='./Include/setobject.h' line='11' column='1' elf-symbol-id='PySetIter_Type'/>
-    <function-decl name='PySet_Size' mangled-name='PySet_Size' filepath='Objects/setobject.c' line='2277' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PySet_Size'>
-      <parameter type-id='type-id-2' name='anyset' filepath='Objects/setobject.c' line='2277' column='1'/>
+    <function-decl name='PySet_Size' mangled-name='PySet_Size' filepath='Objects/setobject.c' line='2285' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PySet_Size'>
+      <parameter type-id='type-id-2' name='anyset' filepath='Objects/setobject.c' line='2285' column='1'/>
       <return type-id='type-id-14'/>
     </function-decl>
-    <function-decl name='PySet_Clear' mangled-name='PySet_Clear' filepath='Objects/setobject.c' line='2287' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PySet_Clear'>
-      <parameter type-id='type-id-2' name='set' filepath='Objects/setobject.c' line='2287' column='1'/>
+    <function-decl name='PySet_Clear' mangled-name='PySet_Clear' filepath='Objects/setobject.c' line='2295' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PySet_Clear'>
+      <parameter type-id='type-id-2' name='set' filepath='Objects/setobject.c' line='2295' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='PySet_Discard' mangled-name='PySet_Discard' filepath='Objects/setobject.c' line='2307' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PySet_Discard'>
-      <parameter type-id='type-id-2' name='set' filepath='Objects/setobject.c' line='2307' column='1'/>
-      <parameter type-id='type-id-2' name='key' filepath='Objects/setobject.c' line='2307' column='1'/>
+    <function-decl name='PySet_Discard' mangled-name='PySet_Discard' filepath='Objects/setobject.c' line='2315' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PySet_Discard'>
+      <parameter type-id='type-id-2' name='set' filepath='Objects/setobject.c' line='2315' column='1'/>
+      <parameter type-id='type-id-2' name='key' filepath='Objects/setobject.c' line='2315' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='PySet_Pop' mangled-name='PySet_Pop' filepath='Objects/setobject.c' line='2344' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PySet_Pop'>
-      <parameter type-id='type-id-2' name='set' filepath='Objects/setobject.c' line='2344' column='1'/>
+    <function-decl name='PySet_Pop' mangled-name='PySet_Pop' filepath='Objects/setobject.c' line='2352' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PySet_Pop'>
+      <parameter type-id='type-id-2' name='set' filepath='Objects/setobject.c' line='2352' column='1'/>
       <return type-id='type-id-2'/>
     </function-decl>
   </abi-instr>
@@ -8663,40 +8677,40 @@
     </function-decl>
   </abi-instr>
   <abi-instr address-size='64' path='Objects/structseq.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
-    <class-decl name='PyType_Slot' size-in-bits='128' is-struct='yes' naming-typedef-id='type-id-425' visibility='default' filepath='./Include/object.h' line='343' column='1' id='type-id-426'>
+    <class-decl name='PyType_Slot' size-in-bits='128' is-struct='yes' naming-typedef-id='type-id-425' visibility='default' filepath='./Include/object.h' line='342' column='1' id='type-id-426'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='slot' type-id='type-id-8' visibility='default' filepath='./Include/object.h' line='344' column='1'/>
+        <var-decl name='slot' type-id='type-id-8' visibility='default' filepath='./Include/object.h' line='343' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='pfunc' type-id='type-id-22' visibility='default' filepath='./Include/object.h' line='345' column='1'/>
+        <var-decl name='pfunc' type-id='type-id-22' visibility='default' filepath='./Include/object.h' line='344' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='PyType_Slot' type-id='type-id-426' filepath='./Include/object.h' line='346' column='1' id='type-id-425'/>
-    <class-decl name='PyType_Spec' size-in-bits='256' is-struct='yes' naming-typedef-id='type-id-11' visibility='default' filepath='./Include/object.h' line='348' column='1' id='type-id-427'>
+    <typedef-decl name='PyType_Slot' type-id='type-id-426' filepath='./Include/object.h' line='345' column='1' id='type-id-425'/>
+    <class-decl name='PyType_Spec' size-in-bits='256' is-struct='yes' naming-typedef-id='type-id-11' visibility='default' filepath='./Include/object.h' line='347' column='1' id='type-id-427'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='name' type-id='type-id-12' visibility='default' filepath='./Include/object.h' line='349' column='1'/>
+        <var-decl name='name' type-id='type-id-12' visibility='default' filepath='./Include/object.h' line='348' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='basicsize' type-id='type-id-8' visibility='default' filepath='./Include/object.h' line='350' column='1'/>
+        <var-decl name='basicsize' type-id='type-id-8' visibility='default' filepath='./Include/object.h' line='349' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='96'>
-        <var-decl name='itemsize' type-id='type-id-8' visibility='default' filepath='./Include/object.h' line='351' column='1'/>
+        <var-decl name='itemsize' type-id='type-id-8' visibility='default' filepath='./Include/object.h' line='350' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='flags' type-id='type-id-95' visibility='default' filepath='./Include/object.h' line='352' column='1'/>
+        <var-decl name='flags' type-id='type-id-95' visibility='default' filepath='./Include/object.h' line='351' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='slots' type-id='type-id-428' visibility='default' filepath='./Include/object.h' line='353' column='1'/>
+        <var-decl name='slots' type-id='type-id-428' visibility='default' filepath='./Include/object.h' line='352' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='PyType_Spec' type-id='type-id-427' filepath='./Include/object.h' line='354' column='1' id='type-id-11'/>
+    <typedef-decl name='PyType_Spec' type-id='type-id-427' filepath='./Include/object.h' line='353' column='1' id='type-id-11'/>
     <pointer-type-def type-id='type-id-425' size-in-bits='64' id='type-id-428'/>
     <pointer-type-def type-id='type-id-11' size-in-bits='64' id='type-id-429'/>
     <function-decl name='_PyType_HasSubclasses' filepath='./Include/internal/pycore_typeobject.h' line='121' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-1'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='PyType_FromSpecWithBases' mangled-name='PyType_FromSpecWithBases' filepath='./Include/object.h' line='358' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyType_FromSpecWithBases'>
+    <function-decl name='PyType_FromSpecWithBases' mangled-name='PyType_FromSpecWithBases' filepath='./Include/object.h' line='357' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyType_FromSpecWithBases'>
       <parameter type-id='type-id-429'/>
       <parameter type-id='type-id-2'/>
       <return type-id='type-id-2'/>
@@ -8837,16 +8851,16 @@
       <parameter type-id='type-id-1'/>
       <return type-id='type-id-46'/>
     </function-decl>
-    <var-decl name='_PyBufferWrapper_Type' type-id='type-id-256' mangled-name='_PyBufferWrapper_Type' visibility='default' filepath='./Include/internal/pycore_typeobject.h' line='139' column='1' elf-symbol-id='_PyBufferWrapper_Type'/>
+    <var-decl name='_PyBufferWrapper_Type' type-id='type-id-256' mangled-name='_PyBufferWrapper_Type' visibility='default' filepath='./Include/internal/pycore_typeobject.h' line='141' column='1' elf-symbol-id='_PyBufferWrapper_Type'/>
     <function-decl name='PyArg_ParseTuple' mangled-name='PyArg_ParseTuple' filepath='./Include/modsupport.h' line='27' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyArg_ParseTuple'>
       <parameter type-id='type-id-2'/>
       <parameter type-id='type-id-12'/>
       <parameter is-variadic='yes'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <var-decl name='PyType_Type' type-id='type-id-256' mangled-name='PyType_Type' visibility='default' filepath='./Include/object.h' line='388' column='1' elf-symbol-id='PyType_Type'/>
-    <var-decl name='PyBaseObject_Type' type-id='type-id-256' mangled-name='PyBaseObject_Type' visibility='default' filepath='./Include/object.h' line='389' column='1' elf-symbol-id='PyBaseObject_Type'/>
-    <var-decl name='PySuper_Type' type-id='type-id-256' mangled-name='PySuper_Type' visibility='default' filepath='./Include/object.h' line='390' column='1' elf-symbol-id='PySuper_Type'/>
+    <var-decl name='PyType_Type' type-id='type-id-256' mangled-name='PyType_Type' visibility='default' filepath='./Include/object.h' line='387' column='1' elf-symbol-id='PyType_Type'/>
+    <var-decl name='PyBaseObject_Type' type-id='type-id-256' mangled-name='PyBaseObject_Type' visibility='default' filepath='./Include/object.h' line='388' column='1' elf-symbol-id='PyBaseObject_Type'/>
+    <var-decl name='PySuper_Type' type-id='type-id-256' mangled-name='PySuper_Type' visibility='default' filepath='./Include/object.h' line='389' column='1' elf-symbol-id='PySuper_Type'/>
     <function-decl name='PyInterpreterState_Get' mangled-name='PyInterpreterState_Get' filepath='./Include/pystate.h' line='26' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyInterpreterState_Get'>
       <return type-id='type-id-20'/>
     </function-decl>
@@ -9062,7 +9076,7 @@
       <parameter type-id='type-id-2'/>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='_PyInterpreterState_GetConfig' mangled-name='_PyInterpreterState_GetConfig' filepath='./Include/cpython/pystate.h' line='331' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyInterpreterState_GetConfig'>
+    <function-decl name='_PyInterpreterState_GetConfig' mangled-name='_PyInterpreterState_GetConfig' filepath='./Include/cpython/pystate.h' line='343' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyInterpreterState_GetConfig'>
       <parameter type-id='type-id-20'/>
       <return type-id='type-id-260'/>
     </function-decl>
@@ -9663,50 +9677,50 @@
       <parameter type-id='type-id-14' name='maxsplit' filepath='Objects/unicodeobject.c' line='12395' column='1'/>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='PyUnicode_Partition' mangled-name='PyUnicode_Partition' filepath='Objects/unicodeobject.c' line='12440' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyUnicode_Partition'>
-      <parameter type-id='type-id-2' name='str_obj' filepath='Objects/unicodeobject.c' line='12440' column='1'/>
-      <parameter type-id='type-id-2' name='sep_obj' filepath='Objects/unicodeobject.c' line='12440' column='1'/>
+    <function-decl name='PyUnicode_Partition' mangled-name='PyUnicode_Partition' filepath='Objects/unicodeobject.c' line='12442' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyUnicode_Partition'>
+      <parameter type-id='type-id-2' name='str_obj' filepath='Objects/unicodeobject.c' line='12442' column='1'/>
+      <parameter type-id='type-id-2' name='sep_obj' filepath='Objects/unicodeobject.c' line='12442' column='1'/>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='PyUnicode_RPartition' mangled-name='PyUnicode_RPartition' filepath='Objects/unicodeobject.c' line='12492' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyUnicode_RPartition'>
-      <parameter type-id='type-id-2' name='str_obj' filepath='Objects/unicodeobject.c' line='12492' column='1'/>
-      <parameter type-id='type-id-2' name='sep_obj' filepath='Objects/unicodeobject.c' line='12492' column='1'/>
+    <function-decl name='PyUnicode_RPartition' mangled-name='PyUnicode_RPartition' filepath='Objects/unicodeobject.c' line='12494' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyUnicode_RPartition'>
+      <parameter type-id='type-id-2' name='str_obj' filepath='Objects/unicodeobject.c' line='12494' column='1'/>
+      <parameter type-id='type-id-2' name='sep_obj' filepath='Objects/unicodeobject.c' line='12494' column='1'/>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='PyUnicode_RSplit' mangled-name='PyUnicode_RSplit' filepath='Objects/unicodeobject.c' line='12586' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyUnicode_RSplit'>
-      <parameter type-id='type-id-2' name='s' filepath='Objects/unicodeobject.c' line='12586' column='1'/>
-      <parameter type-id='type-id-2' name='sep' filepath='Objects/unicodeobject.c' line='12586' column='1'/>
-      <parameter type-id='type-id-14' name='maxsplit' filepath='Objects/unicodeobject.c' line='12586' column='1'/>
+    <function-decl name='PyUnicode_RSplit' mangled-name='PyUnicode_RSplit' filepath='Objects/unicodeobject.c' line='12588' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyUnicode_RSplit'>
+      <parameter type-id='type-id-2' name='s' filepath='Objects/unicodeobject.c' line='12588' column='1'/>
+      <parameter type-id='type-id-2' name='sep' filepath='Objects/unicodeobject.c' line='12588' column='1'/>
+      <parameter type-id='type-id-14' name='maxsplit' filepath='Objects/unicodeobject.c' line='12588' column='1'/>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='_PyUnicodeWriter_PrepareKindInternal' mangled-name='_PyUnicodeWriter_PrepareKindInternal' filepath='Objects/unicodeobject.c' line='13097' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyUnicodeWriter_PrepareKindInternal'>
-      <parameter type-id='type-id-332' name='writer' filepath='Objects/unicodeobject.c' line='13097' column='1'/>
-      <parameter type-id='type-id-8' name='kind' filepath='Objects/unicodeobject.c' line='13098' column='1'/>
+    <function-decl name='_PyUnicodeWriter_PrepareKindInternal' mangled-name='_PyUnicodeWriter_PrepareKindInternal' filepath='Objects/unicodeobject.c' line='13099' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyUnicodeWriter_PrepareKindInternal'>
+      <parameter type-id='type-id-332' name='writer' filepath='Objects/unicodeobject.c' line='13099' column='1'/>
+      <parameter type-id='type-id-8' name='kind' filepath='Objects/unicodeobject.c' line='13100' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='_PyUnicodeWriter_WriteSubstring' mangled-name='_PyUnicodeWriter_WriteSubstring' filepath='Objects/unicodeobject.c' line='13163' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyUnicodeWriter_WriteSubstring'>
-      <parameter type-id='type-id-332' name='writer' filepath='Objects/unicodeobject.c' line='13163' column='1'/>
-      <parameter type-id='type-id-2' name='str' filepath='Objects/unicodeobject.c' line='13163' column='1'/>
-      <parameter type-id='type-id-14' name='start' filepath='Objects/unicodeobject.c' line='13164' column='1'/>
-      <parameter type-id='type-id-14' name='end' filepath='Objects/unicodeobject.c' line='13164' column='1'/>
+    <function-decl name='_PyUnicodeWriter_WriteSubstring' mangled-name='_PyUnicodeWriter_WriteSubstring' filepath='Objects/unicodeobject.c' line='13165' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyUnicodeWriter_WriteSubstring'>
+      <parameter type-id='type-id-332' name='writer' filepath='Objects/unicodeobject.c' line='13165' column='1'/>
+      <parameter type-id='type-id-2' name='str' filepath='Objects/unicodeobject.c' line='13165' column='1'/>
+      <parameter type-id='type-id-14' name='start' filepath='Objects/unicodeobject.c' line='13166' column='1'/>
+      <parameter type-id='type-id-14' name='end' filepath='Objects/unicodeobject.c' line='13166' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='_PyUnicodeWriter_WriteLatin1String' mangled-name='_PyUnicodeWriter_WriteLatin1String' filepath='Objects/unicodeobject.c' line='13255' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyUnicodeWriter_WriteLatin1String'>
-      <parameter type-id='type-id-332' name='writer' filepath='Objects/unicodeobject.c' line='13255' column='1'/>
-      <parameter type-id='type-id-12' name='str' filepath='Objects/unicodeobject.c' line='13256' column='1'/>
-      <parameter type-id='type-id-14' name='len' filepath='Objects/unicodeobject.c' line='13256' column='1'/>
+    <function-decl name='_PyUnicodeWriter_WriteLatin1String' mangled-name='_PyUnicodeWriter_WriteLatin1String' filepath='Objects/unicodeobject.c' line='13257' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyUnicodeWriter_WriteLatin1String'>
+      <parameter type-id='type-id-332' name='writer' filepath='Objects/unicodeobject.c' line='13257' column='1'/>
+      <parameter type-id='type-id-12' name='str' filepath='Objects/unicodeobject.c' line='13258' column='1'/>
+      <parameter type-id='type-id-14' name='len' filepath='Objects/unicodeobject.c' line='13258' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='PyUnicode_Format' mangled-name='PyUnicode_Format' filepath='Objects/unicodeobject.c' line='14405' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyUnicode_Format'>
-      <parameter type-id='type-id-2' name='format' filepath='Objects/unicodeobject.c' line='14405' column='1'/>
-      <parameter type-id='type-id-2' name='args' filepath='Objects/unicodeobject.c' line='14405' column='1'/>
+    <function-decl name='PyUnicode_Format' mangled-name='PyUnicode_Format' filepath='Objects/unicodeobject.c' line='14407' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyUnicode_Format'>
+      <parameter type-id='type-id-2' name='format' filepath='Objects/unicodeobject.c' line='14407' column='1'/>
+      <parameter type-id='type-id-2' name='args' filepath='Objects/unicodeobject.c' line='14407' column='1'/>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='PyUnicode_InternImmortal' mangled-name='PyUnicode_InternImmortal' filepath='Objects/unicodeobject.c' line='14835' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyUnicode_InternImmortal'>
-      <parameter type-id='type-id-233' name='p' filepath='Objects/unicodeobject.c' line='14835' column='1'/>
+    <function-decl name='PyUnicode_InternImmortal' mangled-name='PyUnicode_InternImmortal' filepath='Objects/unicodeobject.c' line='14837' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyUnicode_InternImmortal'>
+      <parameter type-id='type-id-233' name='p' filepath='Objects/unicodeobject.c' line='14837' column='1'/>
       <return type-id='type-id-46'/>
     </function-decl>
-    <function-decl name='PyInit__string' mangled-name='PyInit__string' filepath='Objects/unicodeobject.c' line='15403' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyInit__string'>
+    <function-decl name='PyInit__string' mangled-name='PyInit__string' filepath='Objects/unicodeobject.c' line='15405' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyInit__string'>
       <return type-id='type-id-2'/>
     </function-decl>
   </abi-instr>
@@ -10841,7 +10855,7 @@
       <parameter type-id='type-id-12'/>
       <return type-id='type-id-15'/>
     </function-decl>
-    <function-decl name='_PyPegen_new_identifier' filepath='Parser/pegen.h' line='297' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_PyPegen_new_identifier' filepath='Parser/pegen.h' line='298' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-577'/>
       <parameter type-id='type-id-12'/>
       <return type-id='type-id-2'/>
@@ -11974,28 +11988,28 @@
         <var-decl name='finalized' type-id='type-id-95' visibility='default' filepath='./Include/cpython/pystate.h' line='141' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='_PyFrameEvalFunction' type-id='type-id-788' filepath='./Include/cpython/pystate.h' line='323' column='1' id='type-id-789'/>
-    <typedef-decl name='_PyCrossInterpreterData' type-id='type-id-790' filepath='./Include/cpython/pystate.h' line='376' column='1' id='type-id-791'/>
-    <typedef-decl name='xid_newobjectfunc' type-id='type-id-792' filepath='./Include/cpython/pystate.h' line='378' column='1' id='type-id-793'/>
-    <typedef-decl name='xid_freefunc' type-id='type-id-769' filepath='./Include/cpython/pystate.h' line='379' column='1' id='type-id-794'/>
-    <class-decl name='_xid' size-in-bits='320' is-struct='yes' visibility='default' filepath='./Include/cpython/pystate.h' line='381' column='1' id='type-id-790'>
+    <typedef-decl name='_PyFrameEvalFunction' type-id='type-id-788' filepath='./Include/cpython/pystate.h' line='335' column='1' id='type-id-789'/>
+    <typedef-decl name='_PyCrossInterpreterData' type-id='type-id-790' filepath='./Include/cpython/pystate.h' line='388' column='1' id='type-id-791'/>
+    <typedef-decl name='xid_newobjectfunc' type-id='type-id-792' filepath='./Include/cpython/pystate.h' line='390' column='1' id='type-id-793'/>
+    <typedef-decl name='xid_freefunc' type-id='type-id-769' filepath='./Include/cpython/pystate.h' line='391' column='1' id='type-id-794'/>
+    <class-decl name='_xid' size-in-bits='320' is-struct='yes' visibility='default' filepath='./Include/cpython/pystate.h' line='393' column='1' id='type-id-790'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='data' type-id='type-id-22' visibility='default' filepath='./Include/cpython/pystate.h' line='385' column='1'/>
+        <var-decl name='data' type-id='type-id-22' visibility='default' filepath='./Include/cpython/pystate.h' line='397' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='obj' type-id='type-id-2' visibility='default' filepath='./Include/cpython/pystate.h' line='392' column='1'/>
+        <var-decl name='obj' type-id='type-id-2' visibility='default' filepath='./Include/cpython/pystate.h' line='404' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='interp' type-id='type-id-377' visibility='default' filepath='./Include/cpython/pystate.h' line='402' column='1'/>
+        <var-decl name='interp' type-id='type-id-377' visibility='default' filepath='./Include/cpython/pystate.h' line='414' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='new_object' type-id='type-id-793' visibility='default' filepath='./Include/cpython/pystate.h' line='407' column='1'/>
+        <var-decl name='new_object' type-id='type-id-793' visibility='default' filepath='./Include/cpython/pystate.h' line='419' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='free' type-id='type-id-794' visibility='default' filepath='./Include/cpython/pystate.h' line='417' column='1'/>
+        <var-decl name='free' type-id='type-id-794' visibility='default' filepath='./Include/cpython/pystate.h' line='429' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='crossinterpdatafunc' type-id='type-id-795' filepath='./Include/cpython/pystate.h' line='439' column='1' id='type-id-796'/>
+    <typedef-decl name='crossinterpdatafunc' type-id='type-id-795' filepath='./Include/cpython/pystate.h' line='451' column='1' id='type-id-796'/>
     <class-decl name='_Py_tss_t' size-in-bits='64' is-struct='yes' visibility='default' filepath='./Include/cpython/pythread.h' line='34' column='1' id='type-id-797'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='_is_initialized' type-id='type-id-8' visibility='default' filepath='./Include/cpython/pythread.h' line='35' column='1'/>
@@ -12064,10 +12078,10 @@
         <var-decl name='initialized' type-id='type-id-8' visibility='default' filepath='./Include/internal/pycore_ast_state.h' line='14' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='recursion_depth' type-id='type-id-8' visibility='default' filepath='./Include/internal/pycore_ast_state.h' line='15' column='1'/>
+        <var-decl name='unused_recursion_depth' type-id='type-id-8' visibility='default' filepath='./Include/internal/pycore_ast_state.h' line='15' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='recursion_limit' type-id='type-id-8' visibility='default' filepath='./Include/internal/pycore_ast_state.h' line='16' column='1'/>
+        <var-decl name='unused_recursion_limit' type-id='type-id-8' visibility='default' filepath='./Include/internal/pycore_ast_state.h' line='16' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
         <var-decl name='AST_type' type-id='type-id-2' visibility='default' filepath='./Include/internal/pycore_ast_state.h' line='17' column='1'/>
@@ -13232,42 +13246,42 @@
         <var-decl name='_f_frame_data' type-id='type-id-353' visibility='default' filepath='./Include/internal/pycore_frame.h' line='26' column='1'/>
       </data-member>
     </class-decl>
-    <class-decl name='_PyInterpreterFrame' size-in-bits='640' is-struct='yes' visibility='default' filepath='./Include/internal/pycore_frame.h' line='49' column='1' id='type-id-371'>
+    <class-decl name='_PyInterpreterFrame' size-in-bits='640' is-struct='yes' visibility='default' filepath='./Include/internal/pycore_frame.h' line='51' column='1' id='type-id-371'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='f_code' type-id='type-id-328' visibility='default' filepath='./Include/internal/pycore_frame.h' line='50' column='1'/>
+        <var-decl name='f_code' type-id='type-id-328' visibility='default' filepath='./Include/internal/pycore_frame.h' line='52' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='previous' type-id='type-id-375' visibility='default' filepath='./Include/internal/pycore_frame.h' line='51' column='1'/>
+        <var-decl name='previous' type-id='type-id-375' visibility='default' filepath='./Include/internal/pycore_frame.h' line='53' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='f_funcobj' type-id='type-id-2' visibility='default' filepath='./Include/internal/pycore_frame.h' line='52' column='1'/>
+        <var-decl name='f_funcobj' type-id='type-id-2' visibility='default' filepath='./Include/internal/pycore_frame.h' line='54' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='f_globals' type-id='type-id-2' visibility='default' filepath='./Include/internal/pycore_frame.h' line='53' column='1'/>
+        <var-decl name='f_globals' type-id='type-id-2' visibility='default' filepath='./Include/internal/pycore_frame.h' line='55' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='f_builtins' type-id='type-id-2' visibility='default' filepath='./Include/internal/pycore_frame.h' line='54' column='1'/>
+        <var-decl name='f_builtins' type-id='type-id-2' visibility='default' filepath='./Include/internal/pycore_frame.h' line='56' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='f_locals' type-id='type-id-2' visibility='default' filepath='./Include/internal/pycore_frame.h' line='55' column='1'/>
+        <var-decl name='f_locals' type-id='type-id-2' visibility='default' filepath='./Include/internal/pycore_frame.h' line='57' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='384'>
-        <var-decl name='frame_obj' type-id='type-id-365' visibility='default' filepath='./Include/internal/pycore_frame.h' line='56' column='1'/>
+        <var-decl name='frame_obj' type-id='type-id-365' visibility='default' filepath='./Include/internal/pycore_frame.h' line='58' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='448'>
-        <var-decl name='prev_instr' type-id='type-id-859' visibility='default' filepath='./Include/internal/pycore_frame.h' line='61' column='1'/>
+        <var-decl name='prev_instr' type-id='type-id-859' visibility='default' filepath='./Include/internal/pycore_frame.h' line='63' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='512'>
-        <var-decl name='stacktop' type-id='type-id-8' visibility='default' filepath='./Include/internal/pycore_frame.h' line='62' column='1'/>
+        <var-decl name='stacktop' type-id='type-id-8' visibility='default' filepath='./Include/internal/pycore_frame.h' line='64' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='544'>
-        <var-decl name='return_offset' type-id='type-id-718' visibility='default' filepath='./Include/internal/pycore_frame.h' line='69' column='1'/>
+        <var-decl name='return_offset' type-id='type-id-718' visibility='default' filepath='./Include/internal/pycore_frame.h' line='71' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='560'>
-        <var-decl name='owner' type-id='type-id-48' visibility='default' filepath='./Include/internal/pycore_frame.h' line='70' column='1'/>
+        <var-decl name='owner' type-id='type-id-48' visibility='default' filepath='./Include/internal/pycore_frame.h' line='72' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='576'>
-        <var-decl name='localsplus' type-id='type-id-353' visibility='default' filepath='./Include/internal/pycore_frame.h' line='72' column='1'/>
+        <var-decl name='localsplus' type-id='type-id-353' visibility='default' filepath='./Include/internal/pycore_frame.h' line='74' column='1'/>
       </data-member>
     </class-decl>
     <class-decl name='_py_func_state' size-in-bits='32' is-struct='yes' visibility='default' filepath='./Include/internal/pycore_function.h' line='13' column='1' id='type-id-860'>
@@ -16098,7 +16112,7 @@
         <var-decl name='head' type-id='type-id-936' visibility='default' filepath='./Include/internal/pycore_interp.h' line='64' column='1'/>
       </data-member>
     </class-decl>
-    <class-decl name='_is' size-in-bits='3068416' is-struct='yes' visibility='default' filepath='./Include/internal/pycore_interp.h' line='75' column='1' id='type-id-938'>
+    <class-decl name='_is' size-in-bits='962496' is-struct='yes' visibility='default' filepath='./Include/internal/pycore_interp.h' line='75' column='1' id='type-id-938'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='next' type-id='type-id-20' visibility='default' filepath='./Include/internal/pycore_interp.h' line='77' column='1'/>
       </data-member>
@@ -16211,112 +16225,112 @@
         <var-decl name='atexit' type-id='type-id-816' visibility='default' filepath='./Include/internal/pycore_interp.h' line='179' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='31680'>
-        <var-decl name='obmalloc' type-id='type-id-942' visibility='default' filepath='./Include/internal/pycore_interp.h' line='181' column='1'/>
+        <var-decl name='obmalloc' type-id='type-id-942' visibility='default' filepath='./Include/internal/pycore_interp.h' line='191' column='1'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='2137664'>
-        <var-decl name='audit_hooks' type-id='type-id-2' visibility='default' filepath='./Include/internal/pycore_interp.h' line='183' column='1'/>
+      <data-member access='public' layout-offset-in-bits='31744'>
+        <var-decl name='audit_hooks' type-id='type-id-2' visibility='default' filepath='./Include/internal/pycore_interp.h' line='193' column='1'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='2137728'>
-        <var-decl name='type_watchers' type-id='type-id-599' visibility='default' filepath='./Include/internal/pycore_interp.h' line='184' column='1'/>
+      <data-member access='public' layout-offset-in-bits='31808'>
+        <var-decl name='type_watchers' type-id='type-id-599' visibility='default' filepath='./Include/internal/pycore_interp.h' line='194' column='1'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='2138240'>
-        <var-decl name='code_watchers' type-id='type-id-585' visibility='default' filepath='./Include/internal/pycore_interp.h' line='185' column='1'/>
+      <data-member access='public' layout-offset-in-bits='32320'>
+        <var-decl name='code_watchers' type-id='type-id-585' visibility='default' filepath='./Include/internal/pycore_interp.h' line='195' column='1'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='2138752'>
-        <var-decl name='active_code_watchers' type-id='type-id-325' visibility='default' filepath='./Include/internal/pycore_interp.h' line='187' column='1'/>
+      <data-member access='public' layout-offset-in-bits='32832'>
+        <var-decl name='active_code_watchers' type-id='type-id-325' visibility='default' filepath='./Include/internal/pycore_interp.h' line='197' column='1'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='2138784'>
-        <var-decl name='object_state' type-id='type-id-943' visibility='default' filepath='./Include/internal/pycore_interp.h' line='189' column='1'/>
+      <data-member access='public' layout-offset-in-bits='32864'>
+        <var-decl name='object_state' type-id='type-id-943' visibility='default' filepath='./Include/internal/pycore_interp.h' line='199' column='1'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='2138816'>
-        <var-decl name='unicode' type-id='type-id-944' visibility='default' filepath='./Include/internal/pycore_interp.h' line='190' column='1'/>
+      <data-member access='public' layout-offset-in-bits='32896'>
+        <var-decl name='unicode' type-id='type-id-944' visibility='default' filepath='./Include/internal/pycore_interp.h' line='200' column='1'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='2139264'>
-        <var-decl name='float_state' type-id='type-id-856' visibility='default' filepath='./Include/internal/pycore_interp.h' line='191' column='1'/>
+      <data-member access='public' layout-offset-in-bits='33344'>
+        <var-decl name='float_state' type-id='type-id-856' visibility='default' filepath='./Include/internal/pycore_interp.h' line='201' column='1'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='2139392'>
-        <var-decl name='long_state' type-id='type-id-934' visibility='default' filepath='./Include/internal/pycore_interp.h' line='192' column='1'/>
+      <data-member access='public' layout-offset-in-bits='33472'>
+        <var-decl name='long_state' type-id='type-id-934' visibility='default' filepath='./Include/internal/pycore_interp.h' line='202' column='1'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='2139456'>
-        <var-decl name='dtoa' type-id='type-id-842' visibility='default' filepath='./Include/internal/pycore_interp.h' line='193' column='1'/>
+      <data-member access='public' layout-offset-in-bits='33536'>
+        <var-decl name='dtoa' type-id='type-id-842' visibility='default' filepath='./Include/internal/pycore_interp.h' line='203' column='1'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='2158528'>
-        <var-decl name='func_state' type-id='type-id-860' visibility='default' filepath='./Include/internal/pycore_interp.h' line='194' column='1'/>
+      <data-member access='public' layout-offset-in-bits='52608'>
+        <var-decl name='func_state' type-id='type-id-860' visibility='default' filepath='./Include/internal/pycore_interp.h' line='204' column='1'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='2158592'>
-        <var-decl name='slice_cache' type-id='type-id-424' visibility='default' filepath='./Include/internal/pycore_interp.h' line='197' column='1'/>
+      <data-member access='public' layout-offset-in-bits='52672'>
+        <var-decl name='slice_cache' type-id='type-id-424' visibility='default' filepath='./Include/internal/pycore_interp.h' line='207' column='1'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='2158656'>
-        <var-decl name='tuple' type-id='type-id-945' visibility='default' filepath='./Include/internal/pycore_interp.h' line='199' column='1'/>
+      <data-member access='public' layout-offset-in-bits='52736'>
+        <var-decl name='tuple' type-id='type-id-945' visibility='default' filepath='./Include/internal/pycore_interp.h' line='209' column='1'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='2160576'>
-        <var-decl name='list' type-id='type-id-946' visibility='default' filepath='./Include/internal/pycore_interp.h' line='200' column='1'/>
+      <data-member access='public' layout-offset-in-bits='54656'>
+        <var-decl name='list' type-id='type-id-946' visibility='default' filepath='./Include/internal/pycore_interp.h' line='210' column='1'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='2165760'>
-        <var-decl name='dict_state' type-id='type-id-840' visibility='default' filepath='./Include/internal/pycore_interp.h' line='201' column='1'/>
+      <data-member access='public' layout-offset-in-bits='59840'>
+        <var-decl name='dict_state' type-id='type-id-840' visibility='default' filepath='./Include/internal/pycore_interp.h' line='211' column='1'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='2176704'>
-        <var-decl name='async_gen' type-id='type-id-865' visibility='default' filepath='./Include/internal/pycore_interp.h' line='202' column='1'/>
+      <data-member access='public' layout-offset-in-bits='70784'>
+        <var-decl name='async_gen' type-id='type-id-865' visibility='default' filepath='./Include/internal/pycore_interp.h' line='212' column='1'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='2187072'>
-        <var-decl name='context' type-id='type-id-837' visibility='default' filepath='./Include/internal/pycore_interp.h' line='203' column='1'/>
+      <data-member access='public' layout-offset-in-bits='81152'>
+        <var-decl name='context' type-id='type-id-837' visibility='default' filepath='./Include/internal/pycore_interp.h' line='213' column='1'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='2187200'>
-        <var-decl name='exc_state' type-id='type-id-843' visibility='default' filepath='./Include/internal/pycore_interp.h' line='204' column='1'/>
+      <data-member access='public' layout-offset-in-bits='81280'>
+        <var-decl name='exc_state' type-id='type-id-843' visibility='default' filepath='./Include/internal/pycore_interp.h' line='214' column='1'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='2187456'>
-        <var-decl name='ast' type-id='type-id-808' visibility='default' filepath='./Include/internal/pycore_interp.h' line='206' column='1'/>
+      <data-member access='public' layout-offset-in-bits='81536'>
+        <var-decl name='ast' type-id='type-id-808' visibility='default' filepath='./Include/internal/pycore_interp.h' line='216' column='1'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='2203072'>
-        <var-decl name='types' type-id='type-id-947' visibility='default' filepath='./Include/internal/pycore_interp.h' line='207' column='1'/>
+      <data-member access='public' layout-offset-in-bits='97152'>
+        <var-decl name='types' type-id='type-id-947' visibility='default' filepath='./Include/internal/pycore_interp.h' line='217' column='1'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='3053632'>
-        <var-decl name='callable_cache' type-id='type-id-834' visibility='default' filepath='./Include/internal/pycore_interp.h' line='208' column='1'/>
+      <data-member access='public' layout-offset-in-bits='947712'>
+        <var-decl name='callable_cache' type-id='type-id-834' visibility='default' filepath='./Include/internal/pycore_interp.h' line='218' column='1'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='3053888'>
-        <var-decl name='interpreter_trampoline' type-id='type-id-328' visibility='default' filepath='./Include/internal/pycore_interp.h' line='209' column='1'/>
+      <data-member access='public' layout-offset-in-bits='947968'>
+        <var-decl name='interpreter_trampoline' type-id='type-id-328' visibility='default' filepath='./Include/internal/pycore_interp.h' line='219' column='1'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='3053952'>
-        <var-decl name='monitors' type-id='type-id-715' visibility='default' filepath='./Include/internal/pycore_interp.h' line='211' column='1'/>
+      <data-member access='public' layout-offset-in-bits='948032'>
+        <var-decl name='monitors' type-id='type-id-715' visibility='default' filepath='./Include/internal/pycore_interp.h' line='221' column='1'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='3054072'>
-        <var-decl name='f_opcode_trace_set' type-id='type-id-624' visibility='default' filepath='./Include/internal/pycore_interp.h' line='212' column='1'/>
+      <data-member access='public' layout-offset-in-bits='948152'>
+        <var-decl name='f_opcode_trace_set' type-id='type-id-624' visibility='default' filepath='./Include/internal/pycore_interp.h' line='222' column='1'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='3054080'>
-        <var-decl name='sys_profile_initialized' type-id='type-id-624' visibility='default' filepath='./Include/internal/pycore_interp.h' line='213' column='1'/>
+      <data-member access='public' layout-offset-in-bits='948160'>
+        <var-decl name='sys_profile_initialized' type-id='type-id-624' visibility='default' filepath='./Include/internal/pycore_interp.h' line='223' column='1'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='3054088'>
-        <var-decl name='sys_trace_initialized' type-id='type-id-624' visibility='default' filepath='./Include/internal/pycore_interp.h' line='214' column='1'/>
+      <data-member access='public' layout-offset-in-bits='948168'>
+        <var-decl name='sys_trace_initialized' type-id='type-id-624' visibility='default' filepath='./Include/internal/pycore_interp.h' line='224' column='1'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='3054144'>
-        <var-decl name='sys_profiling_threads' type-id='type-id-14' visibility='default' filepath='./Include/internal/pycore_interp.h' line='215' column='1'/>
+      <data-member access='public' layout-offset-in-bits='948224'>
+        <var-decl name='sys_profiling_threads' type-id='type-id-14' visibility='default' filepath='./Include/internal/pycore_interp.h' line='225' column='1'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='3054208'>
-        <var-decl name='sys_tracing_threads' type-id='type-id-14' visibility='default' filepath='./Include/internal/pycore_interp.h' line='216' column='1'/>
+      <data-member access='public' layout-offset-in-bits='948288'>
+        <var-decl name='sys_tracing_threads' type-id='type-id-14' visibility='default' filepath='./Include/internal/pycore_interp.h' line='226' column='1'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='3054272'>
-        <var-decl name='monitoring_callables' type-id='type-id-594' visibility='default' filepath='./Include/internal/pycore_interp.h' line='217' column='1'/>
+      <data-member access='public' layout-offset-in-bits='948352'>
+        <var-decl name='monitoring_callables' type-id='type-id-594' visibility='default' filepath='./Include/internal/pycore_interp.h' line='227' column='1'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='3062976'>
-        <var-decl name='monitoring_tool_names' type-id='type-id-593' visibility='default' filepath='./Include/internal/pycore_interp.h' line='218' column='1'/>
+      <data-member access='public' layout-offset-in-bits='957056'>
+        <var-decl name='monitoring_tool_names' type-id='type-id-593' visibility='default' filepath='./Include/internal/pycore_interp.h' line='228' column='1'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='3063488'>
-        <var-decl name='cached_objects' type-id='type-id-874' visibility='default' filepath='./Include/internal/pycore_interp.h' line='220' column='1'/>
+      <data-member access='public' layout-offset-in-bits='957568'>
+        <var-decl name='cached_objects' type-id='type-id-874' visibility='default' filepath='./Include/internal/pycore_interp.h' line='230' column='1'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='3064768'>
-        <var-decl name='static_objects' type-id='type-id-875' visibility='default' filepath='./Include/internal/pycore_interp.h' line='221' column='1'/>
+      <data-member access='public' layout-offset-in-bits='958848'>
+        <var-decl name='static_objects' type-id='type-id-875' visibility='default' filepath='./Include/internal/pycore_interp.h' line='231' column='1'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='3065856'>
-        <var-decl name='xidregistry' type-id='type-id-937' visibility='default' filepath='./Include/internal/pycore_interp.h' line='224' column='1'/>
+      <data-member access='public' layout-offset-in-bits='959936'>
+        <var-decl name='xidregistry' type-id='type-id-937' visibility='default' filepath='./Include/internal/pycore_interp.h' line='234' column='1'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='3065984'>
-        <var-decl name='threads_main' type-id='type-id-177' visibility='default' filepath='./Include/internal/pycore_interp.h' line='226' column='1'/>
+      <data-member access='public' layout-offset-in-bits='960064'>
+        <var-decl name='threads_main' type-id='type-id-177' visibility='default' filepath='./Include/internal/pycore_interp.h' line='236' column='1'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='3066048'>
-        <var-decl name='_finalizing_id' type-id='type-id-819' visibility='default' filepath='./Include/internal/pycore_interp.h' line='229' column='1'/>
+      <data-member access='public' layout-offset-in-bits='960128'>
+        <var-decl name='_finalizing_id' type-id='type-id-819' visibility='default' filepath='./Include/internal/pycore_interp.h' line='239' column='1'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='3066112'>
-        <var-decl name='_initial_thread' type-id='type-id-948' visibility='default' filepath='./Include/internal/pycore_interp.h' line='232' column='1'/>
+      <data-member access='public' layout-offset-in-bits='960192'>
+        <var-decl name='_initial_thread' type-id='type-id-948' visibility='default' filepath='./Include/internal/pycore_interp.h' line='242' column='1'/>
       </data-member>
     </class-decl>
     <class-decl name='pythreads' size-in-bits='256' is-struct='yes' visibility='default' filepath='./Include/internal/pycore_interp.h' line='93' column='1' id='type-id-939'>
@@ -16489,7 +16503,7 @@
         <var-decl name='interpreter_leaks' type-id='type-id-14' visibility='default' filepath='./Include/internal/pycore_obmalloc.h' line='662' column='1'/>
       </data-member>
     </class-decl>
-    <class-decl name='_obmalloc_state' size-in-bits='2105984' is-struct='yes' visibility='default' filepath='./Include/internal/pycore_obmalloc.h' line='665' column='1' id='type-id-942'>
+    <class-decl name='_obmalloc_state' size-in-bits='2105984' is-struct='yes' visibility='default' filepath='./Include/internal/pycore_obmalloc.h' line='665' column='1' id='type-id-967'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='pools' type-id='type-id-957' visibility='default' filepath='./Include/internal/pycore_obmalloc.h' line='666' column='1'/>
       </data-member>
@@ -16497,34 +16511,34 @@
         <var-decl name='mgmt' type-id='type-id-958' visibility='default' filepath='./Include/internal/pycore_obmalloc.h' line='667' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='8768'>
-        <var-decl name='usage' type-id='type-id-965' visibility='default' filepath='./Include/internal/pycore_obmalloc.h' line='668' column='1'/>
+        <var-decl name='usage' type-id='type-id-965' visibility='default' filepath='./Include/internal/pycore_obmalloc.h' line='669' column='1'/>
       </data-member>
     </class-decl>
-    <class-decl name='_parser_runtime_state' size-in-bits='448' is-struct='yes' visibility='default' filepath='./Include/internal/pycore_parser.h' line='21' column='1' id='type-id-967'>
+    <class-decl name='_parser_runtime_state' size-in-bits='448' is-struct='yes' visibility='default' filepath='./Include/internal/pycore_parser.h' line='21' column='1' id='type-id-968'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='_not_used' type-id='type-id-8' visibility='default' filepath='./Include/internal/pycore_parser.h' line='25' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='dummy_name' type-id='type-id-968' visibility='default' filepath='./Include/internal/pycore_parser.h' line='27' column='1'/>
+        <var-decl name='dummy_name' type-id='type-id-969' visibility='default' filepath='./Include/internal/pycore_parser.h' line='27' column='1'/>
       </data-member>
     </class-decl>
-    <class-decl name='pyhash_runtime_state' size-in-bits='192' is-struct='yes' visibility='default' filepath='./Include/internal/pycore_pyhash.h' line='9' column='1' id='type-id-969'>
+    <class-decl name='pyhash_runtime_state' size-in-bits='192' is-struct='yes' visibility='default' filepath='./Include/internal/pycore_pyhash.h' line='9' column='1' id='type-id-970'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='urandom_cache' type-id='type-id-970' visibility='default' filepath='./Include/internal/pycore_pyhash.h' line='19' column='1'/>
+        <var-decl name='urandom_cache' type-id='type-id-971' visibility='default' filepath='./Include/internal/pycore_pyhash.h' line='19' column='1'/>
       </data-member>
     </class-decl>
-    <class-decl name='__anonymous_struct__2' size-in-bits='192' is-struct='yes' is-anonymous='yes' visibility='default' filepath='./Include/internal/pycore_pyhash.h' line='10' column='1' id='type-id-970'>
+    <class-decl name='__anonymous_struct__2' size-in-bits='192' is-struct='yes' is-anonymous='yes' visibility='default' filepath='./Include/internal/pycore_pyhash.h' line='10' column='1' id='type-id-971'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='fd' type-id='type-id-8' visibility='default' filepath='./Include/internal/pycore_pyhash.h' line='12' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='st_dev' type-id='type-id-971' visibility='default' filepath='./Include/internal/pycore_pyhash.h' line='13' column='1'/>
+        <var-decl name='st_dev' type-id='type-id-972' visibility='default' filepath='./Include/internal/pycore_pyhash.h' line='13' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='st_ino' type-id='type-id-972' visibility='default' filepath='./Include/internal/pycore_pyhash.h' line='14' column='1'/>
+        <var-decl name='st_ino' type-id='type-id-973' visibility='default' filepath='./Include/internal/pycore_pyhash.h' line='14' column='1'/>
       </data-member>
     </class-decl>
-    <class-decl name='debug_alloc_api_t' size-in-bits='384' is-struct='yes' naming-typedef-id='type-id-973' visibility='default' filepath='./Include/internal/pycore_pymem.h' line='14' column='1' id='type-id-974'>
+    <class-decl name='debug_alloc_api_t' size-in-bits='384' is-struct='yes' naming-typedef-id='type-id-974' visibility='default' filepath='./Include/internal/pycore_pymem.h' line='14' column='1' id='type-id-975'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='api_id' type-id='type-id-48' visibility='default' filepath='./Include/internal/pycore_pymem.h' line='16' column='1'/>
       </data-member>
@@ -16532,22 +16546,22 @@
         <var-decl name='alloc' type-id='type-id-417' visibility='default' filepath='./Include/internal/pycore_pymem.h' line='17' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='debug_alloc_api_t' type-id='type-id-974' filepath='./Include/internal/pycore_pymem.h' line='18' column='1' id='type-id-973'/>
-    <class-decl name='_pymem_allocators' size-in-bits='2368' is-struct='yes' visibility='default' filepath='./Include/internal/pycore_pymem.h' line='20' column='1' id='type-id-975'>
+    <typedef-decl name='debug_alloc_api_t' type-id='type-id-975' filepath='./Include/internal/pycore_pymem.h' line='18' column='1' id='type-id-974'/>
+    <class-decl name='_pymem_allocators' size-in-bits='2368' is-struct='yes' visibility='default' filepath='./Include/internal/pycore_pymem.h' line='20' column='1' id='type-id-976'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='mutex' type-id='type-id-810' visibility='default' filepath='./Include/internal/pycore_pymem.h' line='21' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='standard' type-id='type-id-976' visibility='default' filepath='./Include/internal/pycore_pymem.h' line='26' column='1'/>
+        <var-decl name='standard' type-id='type-id-977' visibility='default' filepath='./Include/internal/pycore_pymem.h' line='26' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1024'>
-        <var-decl name='debug' type-id='type-id-977' visibility='default' filepath='./Include/internal/pycore_pymem.h' line='31' column='1'/>
+        <var-decl name='debug' type-id='type-id-978' visibility='default' filepath='./Include/internal/pycore_pymem.h' line='31' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='2176'>
         <var-decl name='obj_arena' type-id='type-id-420' visibility='default' filepath='./Include/internal/pycore_pymem.h' line='32' column='1'/>
       </data-member>
     </class-decl>
-    <class-decl name='__anonymous_struct__' size-in-bits='960' is-struct='yes' is-anonymous='yes' visibility='default' filepath='./Include/internal/pycore_pymem.h' line='22' column='1' id='type-id-976'>
+    <class-decl name='__anonymous_struct__' size-in-bits='960' is-struct='yes' is-anonymous='yes' visibility='default' filepath='./Include/internal/pycore_pymem.h' line='22' column='1' id='type-id-977'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='raw' type-id='type-id-417' visibility='default' filepath='./Include/internal/pycore_pymem.h' line='23' column='1'/>
       </data-member>
@@ -16558,34 +16572,34 @@
         <var-decl name='obj' type-id='type-id-417' visibility='default' filepath='./Include/internal/pycore_pymem.h' line='25' column='1'/>
       </data-member>
     </class-decl>
-    <class-decl name='__anonymous_struct__1' size-in-bits='1152' is-struct='yes' is-anonymous='yes' visibility='default' filepath='./Include/internal/pycore_pymem.h' line='27' column='1' id='type-id-977'>
+    <class-decl name='__anonymous_struct__1' size-in-bits='1152' is-struct='yes' is-anonymous='yes' visibility='default' filepath='./Include/internal/pycore_pymem.h' line='27' column='1' id='type-id-978'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='raw' type-id='type-id-973' visibility='default' filepath='./Include/internal/pycore_pymem.h' line='28' column='1'/>
+        <var-decl name='raw' type-id='type-id-974' visibility='default' filepath='./Include/internal/pycore_pymem.h' line='28' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='384'>
-        <var-decl name='mem' type-id='type-id-973' visibility='default' filepath='./Include/internal/pycore_pymem.h' line='29' column='1'/>
+        <var-decl name='mem' type-id='type-id-974' visibility='default' filepath='./Include/internal/pycore_pymem.h' line='29' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='768'>
-        <var-decl name='obj' type-id='type-id-973' visibility='default' filepath='./Include/internal/pycore_pymem.h' line='30' column='1'/>
+        <var-decl name='obj' type-id='type-id-974' visibility='default' filepath='./Include/internal/pycore_pymem.h' line='30' column='1'/>
       </data-member>
     </class-decl>
-    <class-decl name='_pythread_runtime_state' size-in-bits='192' is-struct='yes' visibility='default' filepath='./Include/internal/pycore_pythread.h' line='54' column='1' id='type-id-978'>
+    <class-decl name='_pythread_runtime_state' size-in-bits='192' is-struct='yes' visibility='default' filepath='./Include/internal/pycore_pythread.h' line='54' column='1' id='type-id-979'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='initialized' type-id='type-id-8' visibility='default' filepath='./Include/internal/pycore_pythread.h' line='55' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='_condattr_monotonic' type-id='type-id-979' visibility='default' filepath='./Include/internal/pycore_pythread.h' line='66' column='1'/>
+        <var-decl name='_condattr_monotonic' type-id='type-id-980' visibility='default' filepath='./Include/internal/pycore_pythread.h' line='66' column='1'/>
       </data-member>
     </class-decl>
-    <class-decl name='__anonymous_struct__3' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' filepath='./Include/internal/pycore_pythread.h' line='59' column='1' id='type-id-979'>
+    <class-decl name='__anonymous_struct__3' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' filepath='./Include/internal/pycore_pythread.h' line='59' column='1' id='type-id-980'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='ptr' type-id='type-id-980' visibility='default' filepath='./Include/internal/pycore_pythread.h' line='61' column='1'/>
+        <var-decl name='ptr' type-id='type-id-981' visibility='default' filepath='./Include/internal/pycore_pythread.h' line='61' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='val' type-id='type-id-981' visibility='default' filepath='./Include/internal/pycore_pythread.h' line='64' column='1'/>
+        <var-decl name='val' type-id='type-id-982' visibility='default' filepath='./Include/internal/pycore_pythread.h' line='64' column='1'/>
       </data-member>
     </class-decl>
-    <class-decl name='_getargs_runtime_state' size-in-bits='128' is-struct='yes' visibility='default' filepath='./Include/internal/pycore_runtime.h' line='30' column='1' id='type-id-982'>
+    <class-decl name='_getargs_runtime_state' size-in-bits='128' is-struct='yes' visibility='default' filepath='./Include/internal/pycore_runtime.h' line='30' column='1' id='type-id-983'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='mutex' type-id='type-id-810' visibility='default' filepath='./Include/internal/pycore_runtime.h' line='31' column='1'/>
       </data-member>
@@ -16593,7 +16607,7 @@
         <var-decl name='static_parsers' type-id='type-id-262' visibility='default' filepath='./Include/internal/pycore_runtime.h' line='32' column='1'/>
       </data-member>
     </class-decl>
-    <class-decl name='_gilstate_runtime_state' size-in-bits='128' is-struct='yes' visibility='default' filepath='./Include/internal/pycore_runtime.h' line='37' column='1' id='type-id-983'>
+    <class-decl name='_gilstate_runtime_state' size-in-bits='128' is-struct='yes' visibility='default' filepath='./Include/internal/pycore_runtime.h' line='37' column='1' id='type-id-984'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='check_enabled' type-id='type-id-8' visibility='default' filepath='./Include/internal/pycore_runtime.h' line='40' column='1'/>
       </data-member>
@@ -16601,9 +16615,9 @@
         <var-decl name='autoInterpreterState' type-id='type-id-20' visibility='default' filepath='./Include/internal/pycore_runtime.h' line='45' column='1'/>
       </data-member>
     </class-decl>
-    <class-decl name='_Py_AuditHookEntry' size-in-bits='192' is-struct='yes' visibility='default' filepath='./Include/internal/pycore_runtime.h' line='50' column='1' id='type-id-984'>
+    <class-decl name='_Py_AuditHookEntry' size-in-bits='192' is-struct='yes' visibility='default' filepath='./Include/internal/pycore_runtime.h' line='50' column='1' id='type-id-985'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='next' type-id='type-id-985' visibility='default' filepath='./Include/internal/pycore_runtime.h' line='51' column='1'/>
+        <var-decl name='next' type-id='type-id-986' visibility='default' filepath='./Include/internal/pycore_runtime.h' line='51' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
         <var-decl name='hookCFunction' type-id='type-id-234' visibility='default' filepath='./Include/internal/pycore_runtime.h' line='52' column='1'/>
@@ -16612,8 +16626,8 @@
         <var-decl name='userData' type-id='type-id-22' visibility='default' filepath='./Include/internal/pycore_runtime.h' line='53' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='_Py_AuditHookEntry' type-id='type-id-984' filepath='./Include/internal/pycore_runtime.h' line='54' column='1' id='type-id-986'/>
-    <class-decl name='pyruntimestate' size-in-bits='3679552' is-struct='yes' visibility='default' filepath='./Include/internal/pycore_runtime.h' line='61' column='1' id='type-id-987'>
+    <typedef-decl name='_Py_AuditHookEntry' type-id='type-id-985' filepath='./Include/internal/pycore_runtime.h' line='54' column='1' id='type-id-987'/>
+    <class-decl name='pyruntimestate' size-in-bits='1573632' is-struct='yes' visibility='default' filepath='./Include/internal/pycore_runtime.h' line='61' column='1' id='type-id-988'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='_initialized' type-id='type-id-8' visibility='default' filepath='./Include/internal/pycore_runtime.h' line='66' column='1'/>
       </data-member>
@@ -16633,7 +16647,7 @@
         <var-decl name='_finalizing' type-id='type-id-819' visibility='default' filepath='./Include/internal/pycore_runtime.h' line='85' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='interpreters' type-id='type-id-988' visibility='default' filepath='./Include/internal/pycore_runtime.h' line='104' column='1'/>
+        <var-decl name='interpreters' type-id='type-id-989' visibility='default' filepath='./Include/internal/pycore_runtime.h' line='104' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='512'>
         <var-decl name='main_thread' type-id='type-id-28' visibility='default' filepath='./Include/internal/pycore_runtime.h' line='106' column='1'/>
@@ -16642,22 +16656,22 @@
         <var-decl name='xidregistry' type-id='type-id-937' visibility='default' filepath='./Include/internal/pycore_runtime.h' line='114' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='704'>
-        <var-decl name='allocators' type-id='type-id-975' visibility='default' filepath='./Include/internal/pycore_runtime.h' line='116' column='1'/>
+        <var-decl name='allocators' type-id='type-id-976' visibility='default' filepath='./Include/internal/pycore_runtime.h' line='116' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='3072'>
         <var-decl name='obmalloc' type-id='type-id-966' visibility='default' filepath='./Include/internal/pycore_runtime.h' line='117' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='3200'>
-        <var-decl name='pyhash_state' type-id='type-id-969' visibility='default' filepath='./Include/internal/pycore_runtime.h' line='118' column='1'/>
+        <var-decl name='pyhash_state' type-id='type-id-970' visibility='default' filepath='./Include/internal/pycore_runtime.h' line='118' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='3392'>
-        <var-decl name='time' type-id='type-id-989' visibility='default' filepath='./Include/internal/pycore_runtime.h' line='119' column='1'/>
+        <var-decl name='time' type-id='type-id-990' visibility='default' filepath='./Include/internal/pycore_runtime.h' line='119' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='3520'>
-        <var-decl name='threads' type-id='type-id-978' visibility='default' filepath='./Include/internal/pycore_runtime.h' line='120' column='1'/>
+        <var-decl name='threads' type-id='type-id-979' visibility='default' filepath='./Include/internal/pycore_runtime.h' line='120' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='3712'>
-        <var-decl name='signals' type-id='type-id-990' visibility='default' filepath='./Include/internal/pycore_runtime.h' line='121' column='1'/>
+        <var-decl name='signals' type-id='type-id-991' visibility='default' filepath='./Include/internal/pycore_runtime.h' line='121' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='12352'>
         <var-decl name='autoTSSkey' type-id='type-id-408' visibility='default' filepath='./Include/internal/pycore_runtime.h' line='124' column='1'/>
@@ -16669,7 +16683,7 @@
         <var-decl name='orig_argv' type-id='type-id-750' visibility='default' filepath='./Include/internal/pycore_runtime.h' line='129' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='12608'>
-        <var-decl name='parser' type-id='type-id-967' visibility='default' filepath='./Include/internal/pycore_runtime.h' line='131' column='1'/>
+        <var-decl name='parser' type-id='type-id-968' visibility='default' filepath='./Include/internal/pycore_runtime.h' line='131' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='13056'>
         <var-decl name='atexit' type-id='type-id-809' visibility='default' filepath='./Include/internal/pycore_runtime.h' line='133' column='1'/>
@@ -16681,10 +16695,10 @@
         <var-decl name='ceval' type-id='type-id-829' visibility='default' filepath='./Include/internal/pycore_runtime.h' line='136' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='20480'>
-        <var-decl name='gilstate' type-id='type-id-983' visibility='default' filepath='./Include/internal/pycore_runtime.h' line='137' column='1'/>
+        <var-decl name='gilstate' type-id='type-id-984' visibility='default' filepath='./Include/internal/pycore_runtime.h' line='137' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='20608'>
-        <var-decl name='getargs' type-id='type-id-982' visibility='default' filepath='./Include/internal/pycore_runtime.h' line='138' column='1'/>
+        <var-decl name='getargs' type-id='type-id-983' visibility='default' filepath='./Include/internal/pycore_runtime.h' line='138' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='20736'>
         <var-decl name='fileutils' type-id='type-id-852' visibility='default' filepath='./Include/internal/pycore_runtime.h' line='139' column='1'/>
@@ -16693,7 +16707,7 @@
         <var-decl name='faulthandler' type-id='type-id-848' visibility='default' filepath='./Include/internal/pycore_runtime.h' line='140' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='22144'>
-        <var-decl name='tracemalloc' type-id='type-id-991' visibility='default' filepath='./Include/internal/pycore_runtime.h' line='141' column='1'/>
+        <var-decl name='tracemalloc' type-id='type-id-992' visibility='default' filepath='./Include/internal/pycore_runtime.h' line='141' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='24000'>
         <var-decl name='preconfig' type-id='type-id-753' visibility='default' filepath='./Include/internal/pycore_runtime.h' line='143' column='1'/>
@@ -16705,7 +16719,7 @@
         <var-decl name='open_code_userdata' type-id='type-id-22' visibility='default' filepath='./Include/internal/pycore_runtime.h' line='148' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='24448'>
-        <var-decl name='audit_hooks' type-id='type-id-992' visibility='default' filepath='./Include/internal/pycore_runtime.h' line='152' column='1'/>
+        <var-decl name='audit_hooks' type-id='type-id-993' visibility='default' filepath='./Include/internal/pycore_runtime.h' line='152' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='24576'>
         <var-decl name='object_state' type-id='type-id-949' visibility='default' filepath='./Include/internal/pycore_runtime.h' line='154' column='1'/>
@@ -16714,10 +16728,10 @@
         <var-decl name='float_state' type-id='type-id-855' visibility='default' filepath='./Include/internal/pycore_runtime.h' line='155' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='24704'>
-        <var-decl name='unicode_state' type-id='type-id-993' visibility='default' filepath='./Include/internal/pycore_runtime.h' line='156' column='1'/>
+        <var-decl name='unicode_state' type-id='type-id-994' visibility='default' filepath='./Include/internal/pycore_runtime.h' line='156' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='24832'>
-        <var-decl name='types' type-id='type-id-994' visibility='default' filepath='./Include/internal/pycore_runtime.h' line='157' column='1'/>
+        <var-decl name='types' type-id='type-id-995' visibility='default' filepath='./Include/internal/pycore_runtime.h' line='157' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='24896'>
         <var-decl name='static_objects' type-id='type-id-870' visibility='default' filepath='./Include/internal/pycore_runtime.h' line='160' column='1'/>
@@ -16732,10 +16746,10 @@
         <var-decl name='sys_path_0' type-id='type-id-52' visibility='default' filepath='./Include/internal/pycore_runtime.h' line='169' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='611136'>
-        <var-decl name='_main_interpreter' type-id='type-id-995' visibility='default' filepath='./Include/internal/pycore_runtime.h' line='186' column='1'/>
+        <var-decl name='_main_interpreter' type-id='type-id-996' visibility='default' filepath='./Include/internal/pycore_runtime.h' line='186' column='1'/>
       </data-member>
     </class-decl>
-    <class-decl name='pyinterpreters' size-in-bits='256' is-struct='yes' visibility='default' filepath='./Include/internal/pycore_runtime.h' line='87' column='1' id='type-id-988'>
+    <class-decl name='pyinterpreters' size-in-bits='256' is-struct='yes' visibility='default' filepath='./Include/internal/pycore_runtime.h' line='87' column='1' id='type-id-989'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='mutex' type-id='type-id-810' visibility='default' filepath='./Include/internal/pycore_runtime.h' line='88' column='1'/>
       </data-member>
@@ -16749,20 +16763,20 @@
         <var-decl name='next_id' type-id='type-id-377' visibility='default' filepath='./Include/internal/pycore_runtime.h' line='103' column='1'/>
       </data-member>
     </class-decl>
-    <class-decl name='__anonymous_struct__19' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' filepath='./Include/internal/pycore_runtime.h' line='149' column='1' id='type-id-992'>
+    <class-decl name='__anonymous_struct__19' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' filepath='./Include/internal/pycore_runtime.h' line='149' column='1' id='type-id-993'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='mutex' type-id='type-id-810' visibility='default' filepath='./Include/internal/pycore_runtime.h' line='150' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='head' type-id='type-id-985' visibility='default' filepath='./Include/internal/pycore_runtime.h' line='151' column='1'/>
+        <var-decl name='head' type-id='type-id-986' visibility='default' filepath='./Include/internal/pycore_runtime.h' line='151' column='1'/>
       </data-member>
     </class-decl>
-    <class-decl name='_signals_runtime_state' size-in-bits='8640' is-struct='yes' visibility='default' filepath='./Include/internal/pycore_signal.h' line='37' column='1' id='type-id-990'>
+    <class-decl name='_signals_runtime_state' size-in-bits='8640' is-struct='yes' visibility='default' filepath='./Include/internal/pycore_signal.h' line='37' column='1' id='type-id-991'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='handlers' type-id='type-id-708' visibility='default' filepath='./Include/internal/pycore_signal.h' line='44' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='8320'>
-        <var-decl name='wakeup' type-id='type-id-996' visibility='default' filepath='./Include/internal/pycore_signal.h' line='61' column='1'/>
+        <var-decl name='wakeup' type-id='type-id-997' visibility='default' filepath='./Include/internal/pycore_signal.h' line='61' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='8384'>
         <var-decl name='is_tripped' type-id='type-id-821' visibility='default' filepath='./Include/internal/pycore_signal.h' line='64' column='1'/>
@@ -16777,7 +16791,7 @@
         <var-decl name='unhandled_keyboard_interrupt' type-id='type-id-8' visibility='default' filepath='./Include/internal/pycore_signal.h' line='78' column='1'/>
       </data-member>
     </class-decl>
-    <class-decl name='__anonymous_struct__4' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' filepath='./Include/internal/pycore_signal.h' line='38' column='1' id='type-id-997'>
+    <class-decl name='__anonymous_struct__4' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' filepath='./Include/internal/pycore_signal.h' line='38' column='1' id='type-id-998'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='tripped' type-id='type-id-821' visibility='default' filepath='./Include/internal/pycore_signal.h' line='39' column='1'/>
       </data-member>
@@ -16785,15 +16799,15 @@
         <var-decl name='func' type-id='type-id-819' visibility='default' filepath='./Include/internal/pycore_signal.h' line='43' column='1'/>
       </data-member>
     </class-decl>
-    <class-decl name='__anonymous_struct__5' size-in-bits='64' is-struct='yes' is-anonymous='yes' visibility='default' filepath='./Include/internal/pycore_signal.h' line='46' column='1' id='type-id-998'>
+    <class-decl name='__anonymous_struct__5' size-in-bits='64' is-struct='yes' is-anonymous='yes' visibility='default' filepath='./Include/internal/pycore_signal.h' line='46' column='1' id='type-id-999'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='fd' type-id='type-id-999' visibility='default' filepath='./Include/internal/pycore_signal.h' line='54' column='1'/>
+        <var-decl name='fd' type-id='type-id-1000' visibility='default' filepath='./Include/internal/pycore_signal.h' line='54' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
         <var-decl name='warn_on_full_buffer' type-id='type-id-8' visibility='default' filepath='./Include/internal/pycore_signal.h' line='57' column='1'/>
       </data-member>
     </class-decl>
-    <class-decl name='_time_runtime_state' size-in-bits='128' is-struct='yes' visibility='default' filepath='./Include/internal/pycore_time.h' line='12' column='1' id='type-id-989'>
+    <class-decl name='_time_runtime_state' size-in-bits='128' is-struct='yes' visibility='default' filepath='./Include/internal/pycore_time.h' line='12' column='1' id='type-id-990'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='ticks_per_second_initialized' type-id='type-id-8' visibility='default' filepath='./Include/internal/pycore_time.h' line='14' column='1'/>
       </data-member>
@@ -16801,9 +16815,9 @@
         <var-decl name='ticks_per_second' type-id='type-id-47' visibility='default' filepath='./Include/internal/pycore_time.h' line='15' column='1'/>
       </data-member>
     </class-decl>
-    <class-decl name='_PyTraceMalloc_Config' size-in-bits='96' is-struct='yes' visibility='default' filepath='./Include/internal/pycore_tracemalloc.h' line='18' column='1' id='type-id-1000'>
+    <class-decl name='_PyTraceMalloc_Config' size-in-bits='96' is-struct='yes' visibility='default' filepath='./Include/internal/pycore_tracemalloc.h' line='18' column='1' id='type-id-1001'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='initialized' type-id='type-id-1001' visibility='default' filepath='./Include/internal/pycore_tracemalloc.h' line='25' column='1'/>
+        <var-decl name='initialized' type-id='type-id-1002' visibility='default' filepath='./Include/internal/pycore_tracemalloc.h' line='25' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
         <var-decl name='tracing' type-id='type-id-8' visibility='default' filepath='./Include/internal/pycore_tracemalloc.h' line='29' column='1'/>
@@ -16812,7 +16826,7 @@
         <var-decl name='max_nframe' type-id='type-id-8' visibility='default' filepath='./Include/internal/pycore_tracemalloc.h' line='33' column='1'/>
       </data-member>
     </class-decl>
-    <enum-decl name='__anonymous_enum__' is-anonymous='yes' filepath='./Include/internal/pycore_tracemalloc.h' line='21' column='1' id='type-id-1001'>
+    <enum-decl name='__anonymous_enum__' is-anonymous='yes' filepath='./Include/internal/pycore_tracemalloc.h' line='21' column='1' id='type-id-1002'>
       <underlying-type type-id='type-id-24'/>
       <enumerator name='TRACEMALLOC_NOT_INITIALIZED' value='0'/>
       <enumerator name='TRACEMALLOC_INITIALIZED' value='1'/>
@@ -16826,7 +16840,7 @@
         <var-decl name='lineno' type-id='type-id-95' visibility='default' filepath='./Include/internal/pycore_tracemalloc.h' line='51' column='1'/>
       </data-member>
     </class-decl>
-    <class-decl name='tracemalloc_traceback' size-in-bits='192' is-struct='yes' visibility='default' filepath='./Include/internal/pycore_tracemalloc.h' line='57' column='1' id='type-id-1002'>
+    <class-decl name='tracemalloc_traceback' size-in-bits='192' is-struct='yes' visibility='default' filepath='./Include/internal/pycore_tracemalloc.h' line='57' column='1' id='type-id-1003'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='hash' type-id='type-id-920' visibility='default' filepath='./Include/internal/pycore_tracemalloc.h' line='58' column='1'/>
       </data-member>
@@ -16840,12 +16854,12 @@
         <var-decl name='frames' type-id='type-id-655' visibility='default' filepath='./Include/internal/pycore_tracemalloc.h' line='63' column='1'/>
       </data-member>
     </class-decl>
-    <class-decl name='_tracemalloc_runtime_state' size-in-bits='1856' is-struct='yes' visibility='default' filepath='./Include/internal/pycore_tracemalloc.h' line='67' column='1' id='type-id-991'>
+    <class-decl name='_tracemalloc_runtime_state' size-in-bits='1856' is-struct='yes' visibility='default' filepath='./Include/internal/pycore_tracemalloc.h' line='67' column='1' id='type-id-992'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='config' type-id='type-id-1000' visibility='default' filepath='./Include/internal/pycore_tracemalloc.h' line='68' column='1'/>
+        <var-decl name='config' type-id='type-id-1001' visibility='default' filepath='./Include/internal/pycore_tracemalloc.h' line='68' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='allocators' type-id='type-id-1003' visibility='default' filepath='./Include/internal/pycore_tracemalloc.h' line='75' column='1'/>
+        <var-decl name='allocators' type-id='type-id-1004' visibility='default' filepath='./Include/internal/pycore_tracemalloc.h' line='75' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1088'>
         <var-decl name='tables_lock' type-id='type-id-810' visibility='default' filepath='./Include/internal/pycore_tracemalloc.h' line='78' column='1'/>
@@ -16860,7 +16874,7 @@
         <var-decl name='filenames' type-id='type-id-451' visibility='default' filepath='./Include/internal/pycore_tracemalloc.h' line='89' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1344'>
-        <var-decl name='traceback' type-id='type-id-1004' visibility='default' filepath='./Include/internal/pycore_tracemalloc.h' line='92' column='1'/>
+        <var-decl name='traceback' type-id='type-id-1005' visibility='default' filepath='./Include/internal/pycore_tracemalloc.h' line='92' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1408'>
         <var-decl name='tracebacks' type-id='type-id-451' visibility='default' filepath='./Include/internal/pycore_tracemalloc.h' line='96' column='1'/>
@@ -16872,13 +16886,13 @@
         <var-decl name='domains' type-id='type-id-451' visibility='default' filepath='./Include/internal/pycore_tracemalloc.h' line='102' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1600'>
-        <var-decl name='empty_traceback' type-id='type-id-1002' visibility='default' filepath='./Include/internal/pycore_tracemalloc.h' line='104' column='1'/>
+        <var-decl name='empty_traceback' type-id='type-id-1003' visibility='default' filepath='./Include/internal/pycore_tracemalloc.h' line='104' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1792'>
         <var-decl name='reentrant_key' type-id='type-id-408' visibility='default' filepath='./Include/internal/pycore_tracemalloc.h' line='106' column='1'/>
       </data-member>
     </class-decl>
-    <class-decl name='__anonymous_struct__18' size-in-bits='960' is-struct='yes' is-anonymous='yes' visibility='default' filepath='./Include/internal/pycore_tracemalloc.h' line='71' column='1' id='type-id-1003'>
+    <class-decl name='__anonymous_struct__18' size-in-bits='960' is-struct='yes' is-anonymous='yes' visibility='default' filepath='./Include/internal/pycore_tracemalloc.h' line='71' column='1' id='type-id-1004'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='mem' type-id='type-id-417' visibility='default' filepath='./Include/internal/pycore_tracemalloc.h' line='72' column='1'/>
       </data-member>
@@ -16897,7 +16911,7 @@
         <var-decl name='numfree' type-id='type-id-643' visibility='default' filepath='./Include/internal/pycore_tuple.h' line='58' column='1'/>
       </data-member>
     </class-decl>
-    <class-decl name='_types_runtime_state' size-in-bits='32' is-struct='yes' visibility='default' filepath='./Include/internal/pycore_typeobject.h' line='19' column='1' id='type-id-994'>
+    <class-decl name='_types_runtime_state' size-in-bits='32' is-struct='yes' visibility='default' filepath='./Include/internal/pycore_typeobject.h' line='19' column='1' id='type-id-995'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='next_version_tag' type-id='type-id-95' visibility='default' filepath='./Include/internal/pycore_typeobject.h' line='23' column='1'/>
       </data-member>
@@ -16913,12 +16927,12 @@
         <var-decl name='value' type-id='type-id-2' visibility='default' filepath='./Include/internal/pycore_typeobject.h' line='32' column='1'/>
       </data-member>
     </class-decl>
-    <class-decl name='type_cache' size-in-bits='786432' is-struct='yes' visibility='default' filepath='./Include/internal/pycore_typeobject.h' line='37' column='1' id='type-id-1005'>
+    <class-decl name='type_cache' size-in-bits='786432' is-struct='yes' visibility='default' filepath='./Include/internal/pycore_typeobject.h' line='37' column='1' id='type-id-1006'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='hashtable' type-id='type-id-657' visibility='default' filepath='./Include/internal/pycore_typeobject.h' line='38' column='1'/>
       </data-member>
     </class-decl>
-    <class-decl name='static_builtin_state' size-in-bits='320' is-struct='yes' naming-typedef-id='type-id-410' visibility='default' filepath='./Include/internal/pycore_typeobject.h' line='45' column='1' id='type-id-1006'>
+    <class-decl name='static_builtin_state' size-in-bits='320' is-struct='yes' naming-typedef-id='type-id-410' visibility='default' filepath='./Include/internal/pycore_typeobject.h' line='45' column='1' id='type-id-1007'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='type' type-id='type-id-1' visibility='default' filepath='./Include/internal/pycore_typeobject.h' line='46' column='1'/>
       </data-member>
@@ -16938,13 +16952,13 @@
         <var-decl name='tp_weaklist' type-id='type-id-2' visibility='default' filepath='./Include/internal/pycore_typeobject.h' line='57' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='static_builtin_state' type-id='type-id-1006' filepath='./Include/internal/pycore_typeobject.h' line='58' column='1' id='type-id-410'/>
+    <typedef-decl name='static_builtin_state' type-id='type-id-1007' filepath='./Include/internal/pycore_typeobject.h' line='58' column='1' id='type-id-410'/>
     <class-decl name='types_state' size-in-bits='850560' is-struct='yes' visibility='default' filepath='./Include/internal/pycore_typeobject.h' line='60' column='1' id='type-id-947'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='next_version_tag' type-id='type-id-95' visibility='default' filepath='./Include/internal/pycore_typeobject.h' line='64' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='type_cache' type-id='type-id-1005' visibility='default' filepath='./Include/internal/pycore_typeobject.h' line='66' column='1'/>
+        <var-decl name='type_cache' type-id='type-id-1006' visibility='default' filepath='./Include/internal/pycore_typeobject.h' line='66' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='786496'>
         <var-decl name='num_builtins_initialized' type-id='type-id-19' visibility='default' filepath='./Include/internal/pycore_typeobject.h' line='67' column='1'/>
@@ -16953,17 +16967,17 @@
         <var-decl name='builtins' type-id='type-id-652' visibility='default' filepath='./Include/internal/pycore_typeobject.h' line='68' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='pytype_slotdef' type-id='type-id-333' filepath='./Include/internal/pycore_typeobject.h' line='87' column='1' id='type-id-1007'/>
-    <class-decl name='_PyUnicode_Name_CAPI' size-in-bits='128' is-struct='yes' naming-typedef-id='type-id-1008' visibility='default' filepath='./Include/internal/pycore_ucnhash.h' line='16' column='1' id='type-id-1009'>
+    <typedef-decl name='pytype_slotdef' type-id='type-id-333' filepath='./Include/internal/pycore_typeobject.h' line='87' column='1' id='type-id-1008'/>
+    <class-decl name='_PyUnicode_Name_CAPI' size-in-bits='128' is-struct='yes' naming-typedef-id='type-id-1009' visibility='default' filepath='./Include/internal/pycore_ucnhash.h' line='16' column='1' id='type-id-1010'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='getname' type-id='type-id-1010' visibility='default' filepath='./Include/internal/pycore_ucnhash.h' line='21' column='1'/>
+        <var-decl name='getname' type-id='type-id-1011' visibility='default' filepath='./Include/internal/pycore_ucnhash.h' line='21' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='getcode' type-id='type-id-1011' visibility='default' filepath='./Include/internal/pycore_ucnhash.h' line='26' column='1'/>
+        <var-decl name='getcode' type-id='type-id-1012' visibility='default' filepath='./Include/internal/pycore_ucnhash.h' line='26' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='_PyUnicode_Name_CAPI' type-id='type-id-1009' filepath='./Include/internal/pycore_ucnhash.h' line='29' column='1' id='type-id-1008'/>
-    <class-decl name='_Py_unicode_runtime_ids' size-in-bits='128' is-struct='yes' visibility='default' filepath='./Include/internal/pycore_unicodeobject.h' line='29' column='1' id='type-id-1012'>
+    <typedef-decl name='_PyUnicode_Name_CAPI' type-id='type-id-1010' filepath='./Include/internal/pycore_ucnhash.h' line='29' column='1' id='type-id-1009'/>
+    <class-decl name='_Py_unicode_runtime_ids' size-in-bits='128' is-struct='yes' visibility='default' filepath='./Include/internal/pycore_unicodeobject.h' line='29' column='1' id='type-id-1013'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='lock' type-id='type-id-810' visibility='default' filepath='./Include/internal/pycore_unicodeobject.h' line='30' column='1'/>
       </data-member>
@@ -16971,12 +16985,12 @@
         <var-decl name='next_index' type-id='type-id-14' visibility='default' filepath='./Include/internal/pycore_unicodeobject.h' line='33' column='1'/>
       </data-member>
     </class-decl>
-    <class-decl name='_Py_unicode_runtime_state' size-in-bits='128' is-struct='yes' visibility='default' filepath='./Include/internal/pycore_unicodeobject.h' line='36' column='1' id='type-id-993'>
+    <class-decl name='_Py_unicode_runtime_state' size-in-bits='128' is-struct='yes' visibility='default' filepath='./Include/internal/pycore_unicodeobject.h' line='36' column='1' id='type-id-994'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='ids' type-id='type-id-1012' visibility='default' filepath='./Include/internal/pycore_unicodeobject.h' line='37' column='1'/>
+        <var-decl name='ids' type-id='type-id-1013' visibility='default' filepath='./Include/internal/pycore_unicodeobject.h' line='37' column='1'/>
       </data-member>
     </class-decl>
-    <class-decl name='_Py_unicode_fs_codec' size-in-bits='256' is-struct='yes' visibility='default' filepath='./Include/internal/pycore_unicodeobject.h' line='42' column='1' id='type-id-1013'>
+    <class-decl name='_Py_unicode_fs_codec' size-in-bits='256' is-struct='yes' visibility='default' filepath='./Include/internal/pycore_unicodeobject.h' line='42' column='1' id='type-id-1014'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='encoding' type-id='type-id-15' visibility='default' filepath='./Include/internal/pycore_unicodeobject.h' line='43' column='1'/>
       </data-member>
@@ -16990,7 +17004,7 @@
         <var-decl name='error_handler' type-id='type-id-447' visibility='default' filepath='./Include/internal/pycore_unicodeobject.h' line='46' column='1'/>
       </data-member>
     </class-decl>
-    <class-decl name='_Py_unicode_ids' size-in-bits='128' is-struct='yes' visibility='default' filepath='./Include/internal/pycore_unicodeobject.h' line='49' column='1' id='type-id-1014'>
+    <class-decl name='_Py_unicode_ids' size-in-bits='128' is-struct='yes' visibility='default' filepath='./Include/internal/pycore_unicodeobject.h' line='49' column='1' id='type-id-1015'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='size' type-id='type-id-14' visibility='default' filepath='./Include/internal/pycore_unicodeobject.h' line='50' column='1'/>
       </data-member>
@@ -17000,13 +17014,13 @@
     </class-decl>
     <class-decl name='_Py_unicode_state' size-in-bits='448' is-struct='yes' visibility='default' filepath='./Include/internal/pycore_unicodeobject.h' line='54' column='1' id='type-id-944'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='fs_codec' type-id='type-id-1013' visibility='default' filepath='./Include/internal/pycore_unicodeobject.h' line='55' column='1'/>
+        <var-decl name='fs_codec' type-id='type-id-1014' visibility='default' filepath='./Include/internal/pycore_unicodeobject.h' line='55' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='ucnhash_capi' type-id='type-id-1015' visibility='default' filepath='./Include/internal/pycore_unicodeobject.h' line='57' column='1'/>
+        <var-decl name='ucnhash_capi' type-id='type-id-1016' visibility='default' filepath='./Include/internal/pycore_unicodeobject.h' line='57' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='ids' type-id='type-id-1014' visibility='default' filepath='./Include/internal/pycore_unicodeobject.h' line='60' column='1'/>
+        <var-decl name='ids' type-id='type-id-1015' visibility='default' filepath='./Include/internal/pycore_unicodeobject.h' line='60' column='1'/>
       </data-member>
     </class-decl>
     <class-decl name='_warnings_runtime_state' size-in-bits='256' is-struct='yes' visibility='default' filepath='./Include/internal/pycore_warnings.h' line='11' column='1' id='type-id-941'>
@@ -17027,11 +17041,11 @@
     <typedef-decl name='PyThread_type_lock' type-id='type-id-22' filepath='./Include/pythread.h' line='4' column='1' id='type-id-810'/>
     <typedef-decl name='Py_tss_t' type-id='type-id-797' filepath='./Include/pythread.h' line='113' column='1' id='type-id-408'/>
     <typedef-decl name='PyLongObject' type-id='type-id-760' filepath='./Include/pytypedefs.h' line='19' column='1' id='type-id-240'/>
-    <typedef-decl name='PyCodeObject' type-id='type-id-728' filepath='./Include/pytypedefs.h' line='21' column='1' id='type-id-1016'/>
-    <typedef-decl name='PyFrameObject' type-id='type-id-858' filepath='./Include/pytypedefs.h' line='22' column='1' id='type-id-1017'/>
+    <typedef-decl name='PyCodeObject' type-id='type-id-728' filepath='./Include/pytypedefs.h' line='21' column='1' id='type-id-1017'/>
+    <typedef-decl name='PyFrameObject' type-id='type-id-858' filepath='./Include/pytypedefs.h' line='22' column='1' id='type-id-1018'/>
     <typedef-decl name='PyThreadState' type-id='type-id-785' filepath='./Include/pytypedefs.h' line='24' column='1' id='type-id-948'/>
-    <typedef-decl name='PyInterpreterState' type-id='type-id-938' filepath='./Include/pytypedefs.h' line='25' column='1' id='type-id-995'/>
-    <class-decl name='PySliceObject' size-in-bits='320' is-struct='yes' naming-typedef-id='type-id-1018' visibility='default' filepath='./Include/sliceobject.h' line='22' column='1' id='type-id-1019'>
+    <typedef-decl name='PyInterpreterState' type-id='type-id-938' filepath='./Include/pytypedefs.h' line='25' column='1' id='type-id-996'/>
+    <class-decl name='PySliceObject' size-in-bits='320' is-struct='yes' naming-typedef-id='type-id-1019' visibility='default' filepath='./Include/sliceobject.h' line='22' column='1' id='type-id-1020'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='ob_base' type-id='type-id-345' visibility='default' filepath='./Include/sliceobject.h' line='23' column='1'/>
       </data-member>
@@ -17045,18 +17059,18 @@
         <var-decl name='step' type-id='type-id-2' visibility='default' filepath='./Include/sliceobject.h' line='24' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='PySliceObject' type-id='type-id-1019' filepath='./Include/sliceobject.h' line='25' column='1' id='type-id-1018'/>
-    <typedef-decl name='__sighandler_t' type-id='type-id-1020' filepath='/usr/include/signal.h' line='72' column='1' id='type-id-1021'/>
+    <typedef-decl name='PySliceObject' type-id='type-id-1020' filepath='./Include/sliceobject.h' line='25' column='1' id='type-id-1019'/>
+    <typedef-decl name='__sighandler_t' type-id='type-id-1021' filepath='/usr/include/signal.h' line='72' column='1' id='type-id-1022'/>
     <typedef-decl name='uintptr_t' type-id='type-id-28' filepath='/usr/include/stdint.h' line='90' column='1' id='type-id-758'/>
-    <union-decl name='__atomic_wide_counter' size-in-bits='64' naming-typedef-id='type-id-1022' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/atomic_wide_counter.h' line='25' column='1' id='type-id-1023'>
+    <union-decl name='__atomic_wide_counter' size-in-bits='64' naming-typedef-id='type-id-1023' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/atomic_wide_counter.h' line='25' column='1' id='type-id-1024'>
       <data-member access='public'>
         <var-decl name='__value64' type-id='type-id-387' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/atomic_wide_counter.h' line='27' column='1'/>
       </data-member>
       <data-member access='public'>
-        <var-decl name='__value32' type-id='type-id-1024' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/atomic_wide_counter.h' line='32' column='1'/>
+        <var-decl name='__value32' type-id='type-id-1025' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/atomic_wide_counter.h' line='32' column='1'/>
       </data-member>
     </union-decl>
-    <class-decl name='__anonymous_struct__744' size-in-bits='64' is-struct='yes' is-anonymous='yes' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/atomic_wide_counter.h' line='28' column='1' id='type-id-1024'>
+    <class-decl name='__anonymous_struct__744' size-in-bits='64' is-struct='yes' is-anonymous='yes' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/atomic_wide_counter.h' line='28' column='1' id='type-id-1025'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='__low' type-id='type-id-95' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/atomic_wide_counter.h' line='30' column='1'/>
       </data-member>
@@ -17064,8 +17078,8 @@
         <var-decl name='__high' type-id='type-id-95' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/atomic_wide_counter.h' line='31' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='__atomic_wide_counter' type-id='type-id-1023' filepath='/usr/include/x86_64-linux-gnu/bits/atomic_wide_counter.h' line='33' column='1' id='type-id-1022'/>
-    <union-decl name='pthread_condattr_t' size-in-bits='32' naming-typedef-id='type-id-981' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h' line='41' column='1' id='type-id-1025'>
+    <typedef-decl name='__atomic_wide_counter' type-id='type-id-1024' filepath='/usr/include/x86_64-linux-gnu/bits/atomic_wide_counter.h' line='33' column='1' id='type-id-1023'/>
+    <union-decl name='pthread_condattr_t' size-in-bits='32' naming-typedef-id='type-id-982' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h' line='41' column='1' id='type-id-1026'>
       <data-member access='public'>
         <var-decl name='__size' type-id='type-id-629' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h' line='43' column='1'/>
       </data-member>
@@ -17073,11 +17087,11 @@
         <var-decl name='__align' type-id='type-id-8' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h' line='44' column='1'/>
       </data-member>
     </union-decl>
-    <typedef-decl name='pthread_condattr_t' type-id='type-id-1025' filepath='/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h' line='45' column='1' id='type-id-981'/>
+    <typedef-decl name='pthread_condattr_t' type-id='type-id-1026' filepath='/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h' line='45' column='1' id='type-id-982'/>
     <typedef-decl name='pthread_key_t' type-id='type-id-95' filepath='/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h' line='49' column='1' id='type-id-798'/>
-    <union-decl name='pthread_mutex_t' size-in-bits='320' naming-typedef-id='type-id-868' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h' line='67' column='1' id='type-id-1026'>
+    <union-decl name='pthread_mutex_t' size-in-bits='320' naming-typedef-id='type-id-868' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h' line='67' column='1' id='type-id-1027'>
       <data-member access='public'>
-        <var-decl name='__data' type-id='type-id-1027' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h' line='69' column='1'/>
+        <var-decl name='__data' type-id='type-id-1028' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h' line='69' column='1'/>
       </data-member>
       <data-member access='public'>
         <var-decl name='__size' type-id='type-id-625' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h' line='70' column='1'/>
@@ -17086,10 +17100,10 @@
         <var-decl name='__align' type-id='type-id-47' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h' line='71' column='1'/>
       </data-member>
     </union-decl>
-    <typedef-decl name='pthread_mutex_t' type-id='type-id-1026' filepath='/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h' line='72' column='1' id='type-id-868'/>
-    <union-decl name='pthread_cond_t' size-in-bits='384' naming-typedef-id='type-id-867' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h' line='75' column='1' id='type-id-1028'>
+    <typedef-decl name='pthread_mutex_t' type-id='type-id-1027' filepath='/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h' line='72' column='1' id='type-id-868'/>
+    <union-decl name='pthread_cond_t' size-in-bits='384' naming-typedef-id='type-id-867' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h' line='75' column='1' id='type-id-1029'>
       <data-member access='public'>
-        <var-decl name='__data' type-id='type-id-1029' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h' line='77' column='1'/>
+        <var-decl name='__data' type-id='type-id-1030' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h' line='77' column='1'/>
       </data-member>
       <data-member access='public'>
         <var-decl name='__size' type-id='type-id-627' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h' line='78' column='1'/>
@@ -17098,10 +17112,10 @@
         <var-decl name='__align' type-id='type-id-378' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h' line='79' column='1'/>
       </data-member>
     </union-decl>
-    <typedef-decl name='pthread_cond_t' type-id='type-id-1028' filepath='/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h' line='80' column='1' id='type-id-867'/>
+    <typedef-decl name='pthread_cond_t' type-id='type-id-1029' filepath='/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h' line='80' column='1' id='type-id-867'/>
     <class-decl name='sigaction' size-in-bits='1216' is-struct='yes' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/sigaction.h' line='27' column='1' id='type-id-845'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='__sigaction_handler' type-id='type-id-1030' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/sigaction.h' line='38' column='1'/>
+        <var-decl name='__sigaction_handler' type-id='type-id-1031' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/sigaction.h' line='38' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
         <var-decl name='sa_mask' type-id='type-id-30' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/sigaction.h' line='46' column='1'/>
@@ -17113,21 +17127,21 @@
         <var-decl name='sa_restorer' type-id='type-id-227' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/sigaction.h' line='52' column='1'/>
       </data-member>
     </class-decl>
-    <union-decl name='__anonymous_union__' size-in-bits='64' is-anonymous='yes' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/sigaction.h' line='31' column='1' id='type-id-1030'>
+    <union-decl name='__anonymous_union__' size-in-bits='64' is-anonymous='yes' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/sigaction.h' line='31' column='1' id='type-id-1031'>
       <data-member access='public'>
-        <var-decl name='sa_handler' type-id='type-id-1021' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/sigaction.h' line='34' column='1'/>
+        <var-decl name='sa_handler' type-id='type-id-1022' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/sigaction.h' line='34' column='1'/>
       </data-member>
       <data-member access='public'>
-        <var-decl name='sa_sigaction' type-id='type-id-1031' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/sigaction.h' line='36' column='1'/>
+        <var-decl name='sa_sigaction' type-id='type-id-1032' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/sigaction.h' line='36' column='1'/>
       </data-member>
     </union-decl>
-    <typedef-decl name='int8_t' type-id='type-id-1032' filepath='/usr/include/x86_64-linux-gnu/bits/stdint-intn.h' line='24' column='1' id='type-id-370'/>
-    <typedef-decl name='int32_t' type-id='type-id-1033' filepath='/usr/include/x86_64-linux-gnu/bits/stdint-intn.h' line='26' column='1' id='type-id-960'/>
-    <typedef-decl name='int64_t' type-id='type-id-1034' filepath='/usr/include/x86_64-linux-gnu/bits/stdint-intn.h' line='27' column='1' id='type-id-377'/>
-    <typedef-decl name='uint8_t' type-id='type-id-1035' filepath='/usr/include/x86_64-linux-gnu/bits/stdint-uintn.h' line='24' column='1' id='type-id-325'/>
-    <typedef-decl name='uint16_t' type-id='type-id-1036' filepath='/usr/include/x86_64-linux-gnu/bits/stdint-uintn.h' line='25' column='1' id='type-id-718'/>
-    <typedef-decl name='uint64_t' type-id='type-id-1037' filepath='/usr/include/x86_64-linux-gnu/bits/stdint-uintn.h' line='27' column='1' id='type-id-117'/>
-    <class-decl name='__pthread_mutex_s' size-in-bits='320' is-struct='yes' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/struct_mutex.h' line='22' column='1' id='type-id-1027'>
+    <typedef-decl name='int8_t' type-id='type-id-1033' filepath='/usr/include/x86_64-linux-gnu/bits/stdint-intn.h' line='24' column='1' id='type-id-370'/>
+    <typedef-decl name='int32_t' type-id='type-id-1034' filepath='/usr/include/x86_64-linux-gnu/bits/stdint-intn.h' line='26' column='1' id='type-id-960'/>
+    <typedef-decl name='int64_t' type-id='type-id-1035' filepath='/usr/include/x86_64-linux-gnu/bits/stdint-intn.h' line='27' column='1' id='type-id-377'/>
+    <typedef-decl name='uint8_t' type-id='type-id-1036' filepath='/usr/include/x86_64-linux-gnu/bits/stdint-uintn.h' line='24' column='1' id='type-id-325'/>
+    <typedef-decl name='uint16_t' type-id='type-id-1037' filepath='/usr/include/x86_64-linux-gnu/bits/stdint-uintn.h' line='25' column='1' id='type-id-718'/>
+    <typedef-decl name='uint64_t' type-id='type-id-1038' filepath='/usr/include/x86_64-linux-gnu/bits/stdint-uintn.h' line='27' column='1' id='type-id-117'/>
+    <class-decl name='__pthread_mutex_s' size-in-bits='320' is-struct='yes' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/struct_mutex.h' line='22' column='1' id='type-id-1028'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='__lock' type-id='type-id-8' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/struct_mutex.h' line='24' column='1'/>
       </data-member>
@@ -17150,24 +17164,24 @@
         <var-decl name='__elision' type-id='type-id-71' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/struct_mutex.h' line='35' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='__list' type-id='type-id-1038' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/struct_mutex.h' line='36' column='1'/>
+        <var-decl name='__list' type-id='type-id-1039' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/struct_mutex.h' line='36' column='1'/>
       </data-member>
     </class-decl>
-    <class-decl name='__pthread_internal_list' size-in-bits='128' is-struct='yes' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/thread-shared-types.h' line='51' column='1' id='type-id-1039'>
+    <class-decl name='__pthread_internal_list' size-in-bits='128' is-struct='yes' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/thread-shared-types.h' line='51' column='1' id='type-id-1040'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='__prev' type-id='type-id-1040' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/thread-shared-types.h' line='53' column='1'/>
+        <var-decl name='__prev' type-id='type-id-1041' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/thread-shared-types.h' line='53' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='__next' type-id='type-id-1040' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/thread-shared-types.h' line='54' column='1'/>
+        <var-decl name='__next' type-id='type-id-1041' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/thread-shared-types.h' line='54' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='__pthread_list_t' type-id='type-id-1039' filepath='/usr/include/x86_64-linux-gnu/bits/thread-shared-types.h' line='55' column='1' id='type-id-1038'/>
-    <class-decl name='__pthread_cond_s' size-in-bits='384' is-struct='yes' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/thread-shared-types.h' line='94' column='1' id='type-id-1029'>
+    <typedef-decl name='__pthread_list_t' type-id='type-id-1040' filepath='/usr/include/x86_64-linux-gnu/bits/thread-shared-types.h' line='55' column='1' id='type-id-1039'/>
+    <class-decl name='__pthread_cond_s' size-in-bits='384' is-struct='yes' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/thread-shared-types.h' line='94' column='1' id='type-id-1030'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='__wseq' type-id='type-id-1022' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/thread-shared-types.h' line='96' column='1'/>
+        <var-decl name='__wseq' type-id='type-id-1023' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/thread-shared-types.h' line='96' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='__g1_start' type-id='type-id-1022' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/thread-shared-types.h' line='97' column='1'/>
+        <var-decl name='__g1_start' type-id='type-id-1023' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/thread-shared-types.h' line='97' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
         <var-decl name='__g_refs' type-id='type-id-705' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/thread-shared-types.h' line='98' column='1'/>
@@ -17185,25 +17199,25 @@
         <var-decl name='__g_signals' type-id='type-id-705' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/thread-shared-types.h' line='102' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='__int8_t' type-id='type-id-1041' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='37' column='1' id='type-id-1032'/>
-    <typedef-decl name='__uint8_t' type-id='type-id-85' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='38' column='1' id='type-id-1035'/>
-    <typedef-decl name='__uint16_t' type-id='type-id-84' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='40' column='1' id='type-id-1036'/>
-    <typedef-decl name='__int32_t' type-id='type-id-8' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='41' column='1' id='type-id-1033'/>
-    <typedef-decl name='__int64_t' type-id='type-id-47' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='44' column='1' id='type-id-1034'/>
-    <typedef-decl name='__uint64_t' type-id='type-id-28' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='45' column='1' id='type-id-1037'/>
+    <typedef-decl name='__int8_t' type-id='type-id-1042' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='37' column='1' id='type-id-1033'/>
+    <typedef-decl name='__uint8_t' type-id='type-id-85' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='38' column='1' id='type-id-1036'/>
+    <typedef-decl name='__uint16_t' type-id='type-id-84' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='40' column='1' id='type-id-1037'/>
+    <typedef-decl name='__int32_t' type-id='type-id-8' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='41' column='1' id='type-id-1034'/>
+    <typedef-decl name='__int64_t' type-id='type-id-47' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='44' column='1' id='type-id-1035'/>
+    <typedef-decl name='__uint64_t' type-id='type-id-28' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='45' column='1' id='type-id-1038'/>
     <typedef-decl name='__dev_t' type-id='type-id-28' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='145' column='1' id='type-id-187'/>
     <typedef-decl name='__uid_t' type-id='type-id-95' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='146' column='1' id='type-id-125'/>
     <typedef-decl name='__ino64_t' type-id='type-id-28' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='149' column='1' id='type-id-83'/>
     <typedef-decl name='__pid_t' type-id='type-id-8' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='154' column='1' id='type-id-127'/>
     <typedef-decl name='__clock_t' type-id='type-id-47' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='156' column='1' id='type-id-97'/>
-    <typedef-decl name='__sig_atomic_t' type-id='type-id-8' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='215' column='1' id='type-id-1042'/>
-    <class-decl name='__sigset_t' size-in-bits='1024' is-struct='yes' naming-typedef-id='type-id-30' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/__sigset_t.h' line='5' column='1' id='type-id-1043'>
+    <typedef-decl name='__sig_atomic_t' type-id='type-id-8' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='215' column='1' id='type-id-1043'/>
+    <class-decl name='__sigset_t' size-in-bits='1024' is-struct='yes' naming-typedef-id='type-id-30' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/__sigset_t.h' line='5' column='1' id='type-id-1044'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='__val' type-id='type-id-706' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/__sigset_t.h' line='7' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='__sigset_t' type-id='type-id-1043' filepath='/usr/include/x86_64-linux-gnu/bits/types/__sigset_t.h' line='8' column='1' id='type-id-30'/>
-    <union-decl name='sigval' size-in-bits='64' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/__sigval_t.h' line='24' column='1' id='type-id-1044'>
+    <typedef-decl name='__sigset_t' type-id='type-id-1044' filepath='/usr/include/x86_64-linux-gnu/bits/types/__sigset_t.h' line='8' column='1' id='type-id-30'/>
+    <union-decl name='sigval' size-in-bits='64' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/__sigval_t.h' line='24' column='1' id='type-id-1045'>
       <data-member access='public'>
         <var-decl name='sival_int' type-id='type-id-8' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/__sigval_t.h' line='26' column='1'/>
       </data-member>
@@ -17211,9 +17225,9 @@
         <var-decl name='sival_ptr' type-id='type-id-22' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/__sigval_t.h' line='27' column='1'/>
       </data-member>
     </union-decl>
-    <typedef-decl name='__sigval_t' type-id='type-id-1044' filepath='/usr/include/x86_64-linux-gnu/bits/types/__sigval_t.h' line='30' column='1' id='type-id-1045'/>
-    <typedef-decl name='sig_atomic_t' type-id='type-id-1042' filepath='/usr/include/x86_64-linux-gnu/bits/types/sig_atomic_t.h' line='8' column='1' id='type-id-999'/>
-    <class-decl name='siginfo_t' size-in-bits='1024' is-struct='yes' naming-typedef-id='type-id-1046' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/siginfo_t.h' line='36' column='1' id='type-id-1047'>
+    <typedef-decl name='__sigval_t' type-id='type-id-1045' filepath='/usr/include/x86_64-linux-gnu/bits/types/__sigval_t.h' line='30' column='1' id='type-id-1046'/>
+    <typedef-decl name='sig_atomic_t' type-id='type-id-1043' filepath='/usr/include/x86_64-linux-gnu/bits/types/sig_atomic_t.h' line='8' column='1' id='type-id-1000'/>
+    <class-decl name='siginfo_t' size-in-bits='1024' is-struct='yes' naming-typedef-id='type-id-1047' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/siginfo_t.h' line='36' column='1' id='type-id-1048'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='si_signo' type-id='type-id-8' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/siginfo_t.h' line='38' column='1'/>
       </data-member>
@@ -17227,36 +17241,36 @@
         <var-decl name='__pad0' type-id='type-id-8' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/siginfo_t.h' line='48' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='_sifields' type-id='type-id-1048' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/siginfo_t.h' line='123' column='1'/>
+        <var-decl name='_sifields' type-id='type-id-1049' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/siginfo_t.h' line='123' column='1'/>
       </data-member>
     </class-decl>
-    <union-decl name='__anonymous_union__1' size-in-bits='896' is-anonymous='yes' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/siginfo_t.h' line='51' column='1' id='type-id-1048'>
+    <union-decl name='__anonymous_union__1' size-in-bits='896' is-anonymous='yes' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/siginfo_t.h' line='51' column='1' id='type-id-1049'>
       <data-member access='public'>
         <var-decl name='_pad' type-id='type-id-644' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/siginfo_t.h' line='53' column='1'/>
       </data-member>
       <data-member access='public'>
-        <var-decl name='_kill' type-id='type-id-1049' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/siginfo_t.h' line='60' column='1'/>
+        <var-decl name='_kill' type-id='type-id-1050' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/siginfo_t.h' line='60' column='1'/>
       </data-member>
       <data-member access='public'>
-        <var-decl name='_timer' type-id='type-id-1050' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/siginfo_t.h' line='68' column='1'/>
+        <var-decl name='_timer' type-id='type-id-1051' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/siginfo_t.h' line='68' column='1'/>
       </data-member>
       <data-member access='public'>
-        <var-decl name='_rt' type-id='type-id-1051' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/siginfo_t.h' line='76' column='1'/>
+        <var-decl name='_rt' type-id='type-id-1052' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/siginfo_t.h' line='76' column='1'/>
       </data-member>
       <data-member access='public'>
-        <var-decl name='_sigchld' type-id='type-id-1052' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/siginfo_t.h' line='86' column='1'/>
+        <var-decl name='_sigchld' type-id='type-id-1053' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/siginfo_t.h' line='86' column='1'/>
       </data-member>
       <data-member access='public'>
-        <var-decl name='_sigfault' type-id='type-id-1053' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/siginfo_t.h' line='105' column='1'/>
+        <var-decl name='_sigfault' type-id='type-id-1054' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/siginfo_t.h' line='105' column='1'/>
       </data-member>
       <data-member access='public'>
-        <var-decl name='_sigpoll' type-id='type-id-1054' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/siginfo_t.h' line='112' column='1'/>
+        <var-decl name='_sigpoll' type-id='type-id-1055' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/siginfo_t.h' line='112' column='1'/>
       </data-member>
       <data-member access='public'>
-        <var-decl name='_sigsys' type-id='type-id-1055' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/siginfo_t.h' line='121' column='1'/>
+        <var-decl name='_sigsys' type-id='type-id-1056' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/siginfo_t.h' line='121' column='1'/>
       </data-member>
     </union-decl>
-    <class-decl name='__anonymous_struct__11' size-in-bits='64' is-struct='yes' is-anonymous='yes' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/siginfo_t.h' line='56' column='1' id='type-id-1049'>
+    <class-decl name='__anonymous_struct__11' size-in-bits='64' is-struct='yes' is-anonymous='yes' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/siginfo_t.h' line='56' column='1' id='type-id-1050'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='si_pid' type-id='type-id-127' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/siginfo_t.h' line='58' column='1'/>
       </data-member>
@@ -17264,7 +17278,7 @@
         <var-decl name='si_uid' type-id='type-id-125' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/siginfo_t.h' line='59' column='1'/>
       </data-member>
     </class-decl>
-    <class-decl name='__anonymous_struct__12' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/siginfo_t.h' line='63' column='1' id='type-id-1050'>
+    <class-decl name='__anonymous_struct__12' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/siginfo_t.h' line='63' column='1' id='type-id-1051'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='si_tid' type-id='type-id-8' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/siginfo_t.h' line='65' column='1'/>
       </data-member>
@@ -17272,10 +17286,10 @@
         <var-decl name='si_overrun' type-id='type-id-8' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/siginfo_t.h' line='66' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='si_sigval' type-id='type-id-1045' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/siginfo_t.h' line='67' column='1'/>
+        <var-decl name='si_sigval' type-id='type-id-1046' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/siginfo_t.h' line='67' column='1'/>
       </data-member>
     </class-decl>
-    <class-decl name='__anonymous_struct__13' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/siginfo_t.h' line='71' column='1' id='type-id-1051'>
+    <class-decl name='__anonymous_struct__13' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/siginfo_t.h' line='71' column='1' id='type-id-1052'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='si_pid' type-id='type-id-127' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/siginfo_t.h' line='73' column='1'/>
       </data-member>
@@ -17283,10 +17297,10 @@
         <var-decl name='si_uid' type-id='type-id-125' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/siginfo_t.h' line='74' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='si_sigval' type-id='type-id-1045' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/siginfo_t.h' line='75' column='1'/>
+        <var-decl name='si_sigval' type-id='type-id-1046' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/siginfo_t.h' line='75' column='1'/>
       </data-member>
     </class-decl>
-    <class-decl name='__anonymous_struct__14' size-in-bits='256' is-struct='yes' is-anonymous='yes' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/siginfo_t.h' line='79' column='1' id='type-id-1052'>
+    <class-decl name='__anonymous_struct__14' size-in-bits='256' is-struct='yes' is-anonymous='yes' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/siginfo_t.h' line='79' column='1' id='type-id-1053'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='si_pid' type-id='type-id-127' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/siginfo_t.h' line='81' column='1'/>
       </data-member>
@@ -17303,7 +17317,7 @@
         <var-decl name='si_stime' type-id='type-id-97' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/siginfo_t.h' line='85' column='1'/>
       </data-member>
     </class-decl>
-    <class-decl name='__anonymous_struct__15' size-in-bits='256' is-struct='yes' is-anonymous='yes' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/siginfo_t.h' line='89' column='1' id='type-id-1053'>
+    <class-decl name='__anonymous_struct__15' size-in-bits='256' is-struct='yes' is-anonymous='yes' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/siginfo_t.h' line='89' column='1' id='type-id-1054'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='si_addr' type-id='type-id-22' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/siginfo_t.h' line='91' column='1'/>
       </data-member>
@@ -17311,18 +17325,18 @@
         <var-decl name='si_addr_lsb' type-id='type-id-71' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/siginfo_t.h' line='93' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='_bounds' type-id='type-id-1056' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/siginfo_t.h' line='104' column='1'/>
+        <var-decl name='_bounds' type-id='type-id-1057' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/siginfo_t.h' line='104' column='1'/>
       </data-member>
     </class-decl>
-    <union-decl name='__anonymous_union__2' size-in-bits='128' is-anonymous='yes' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/siginfo_t.h' line='94' column='1' id='type-id-1056'>
+    <union-decl name='__anonymous_union__2' size-in-bits='128' is-anonymous='yes' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/siginfo_t.h' line='94' column='1' id='type-id-1057'>
       <data-member access='public'>
-        <var-decl name='_addr_bnd' type-id='type-id-1057' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/siginfo_t.h' line='101' column='1'/>
+        <var-decl name='_addr_bnd' type-id='type-id-1058' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/siginfo_t.h' line='101' column='1'/>
       </data-member>
       <data-member access='public'>
-        <var-decl name='_pkey' type-id='type-id-1058' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/siginfo_t.h' line='103' column='1'/>
+        <var-decl name='_pkey' type-id='type-id-1059' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/siginfo_t.h' line='103' column='1'/>
       </data-member>
     </union-decl>
-    <class-decl name='__anonymous_struct__16' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/siginfo_t.h' line='97' column='1' id='type-id-1057'>
+    <class-decl name='__anonymous_struct__16' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/siginfo_t.h' line='97' column='1' id='type-id-1058'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='_lower' type-id='type-id-22' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/siginfo_t.h' line='99' column='1'/>
       </data-member>
@@ -17330,7 +17344,7 @@
         <var-decl name='_upper' type-id='type-id-22' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/siginfo_t.h' line='100' column='1'/>
       </data-member>
     </class-decl>
-    <class-decl name='__anonymous_struct__17' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/siginfo_t.h' line='108' column='1' id='type-id-1054'>
+    <class-decl name='__anonymous_struct__17' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/siginfo_t.h' line='108' column='1' id='type-id-1055'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='si_band' type-id='type-id-47' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/siginfo_t.h' line='110' column='1'/>
       </data-member>
@@ -17338,7 +17352,7 @@
         <var-decl name='si_fd' type-id='type-id-8' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/siginfo_t.h' line='111' column='1'/>
       </data-member>
     </class-decl>
-    <class-decl name='__anonymous_struct__18' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/siginfo_t.h' line='116' column='1' id='type-id-1055'>
+    <class-decl name='__anonymous_struct__18' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/siginfo_t.h' line='116' column='1' id='type-id-1056'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='_call_addr' type-id='type-id-22' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/siginfo_t.h' line='118' column='1'/>
       </data-member>
@@ -17349,8 +17363,8 @@
         <var-decl name='_arch' type-id='type-id-95' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/siginfo_t.h' line='120' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='siginfo_t' type-id='type-id-1047' filepath='/usr/include/x86_64-linux-gnu/bits/types/siginfo_t.h' line='124' column='1' id='type-id-1046'/>
-    <class-decl name='stack_t' size-in-bits='192' is-struct='yes' naming-typedef-id='type-id-38' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/stack_t.h' line='26' column='1' id='type-id-1059'>
+    <typedef-decl name='siginfo_t' type-id='type-id-1048' filepath='/usr/include/x86_64-linux-gnu/bits/types/siginfo_t.h' line='124' column='1' id='type-id-1047'/>
+    <class-decl name='stack_t' size-in-bits='192' is-struct='yes' naming-typedef-id='type-id-38' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/stack_t.h' line='26' column='1' id='type-id-1060'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='ss_sp' type-id='type-id-22' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/stack_t.h' line='28' column='1'/>
       </data-member>
@@ -17361,32 +17375,32 @@
         <var-decl name='ss_size' type-id='type-id-19' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/stack_t.h' line='30' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='stack_t' type-id='type-id-1059' filepath='/usr/include/x86_64-linux-gnu/bits/types/stack_t.h' line='31' column='1' id='type-id-38'/>
-    <typedef-decl name='ino_t' type-id='type-id-83' filepath='/usr/include/x86_64-linux-gnu/sys/types.h' line='49' column='1' id='type-id-972'/>
-    <typedef-decl name='dev_t' type-id='type-id-187' filepath='/usr/include/x86_64-linux-gnu/sys/types.h' line='59' column='1' id='type-id-971'/>
+    <typedef-decl name='stack_t' type-id='type-id-1060' filepath='/usr/include/x86_64-linux-gnu/bits/types/stack_t.h' line='31' column='1' id='type-id-38'/>
+    <typedef-decl name='ino_t' type-id='type-id-83' filepath='/usr/include/x86_64-linux-gnu/sys/types.h' line='49' column='1' id='type-id-973'/>
+    <typedef-decl name='dev_t' type-id='type-id-187' filepath='/usr/include/x86_64-linux-gnu/sys/types.h' line='59' column='1' id='type-id-972'/>
     <typedef-decl name='wchar_t' type-id='type-id-8' filepath='/usr/lib/gcc/x86_64-linux-gnu/11/include/stddef.h' line='321' column='1' id='type-id-422'/>
     <pointer-type-def type-id='type-id-841' size-in-bits='64' id='type-id-579'/>
     <qualified-type-def type-id='type-id-229' restrict='yes' id='type-id-412'/>
     <pointer-type-def type-id='type-id-630' size-in-bits='64' id='type-id-582'/>
     <pointer-type-def type-id='type-id-767' size-in-bits='64' id='type-id-844'/>
-    <pointer-type-def type-id='type-id-1016' size-in-bits='64' id='type-id-328'/>
+    <pointer-type-def type-id='type-id-1017' size-in-bits='64' id='type-id-328'/>
     <pointer-type-def type-id='type-id-735' size-in-bits='64' id='type-id-838'/>
     <pointer-type-def type-id='type-id-348' size-in-bits='64' id='type-id-346'/>
     <pointer-type-def type-id='type-id-343' size-in-bits='64' id='type-id-340'/>
     <pointer-type-def type-id='type-id-349' size-in-bits='64' id='type-id-347'/>
     <pointer-type-def type-id='type-id-742' size-in-bits='64' id='type-id-857'/>
-    <pointer-type-def type-id='type-id-1017' size-in-bits='64' id='type-id-365'/>
+    <pointer-type-def type-id='type-id-1018' size-in-bits='64' id='type-id-365'/>
     <pointer-type-def type-id='type-id-744' size-in-bits='64' id='type-id-310'/>
     <pointer-type-def type-id='type-id-861' size-in-bits='64' id='type-id-864'/>
     <pointer-type-def type-id='type-id-907' size-in-bits='64' id='type-id-910'/>
     <pointer-type-def type-id='type-id-877' size-in-bits='64' id='type-id-839'/>
-    <pointer-type-def type-id='type-id-995' size-in-bits='64' id='type-id-20'/>
+    <pointer-type-def type-id='type-id-996' size-in-bits='64' id='type-id-20'/>
     <pointer-type-def type-id='type-id-755' size-in-bits='64' id='type-id-249'/>
     <pointer-type-def type-id='type-id-400' size-in-bits='64' id='type-id-390'/>
-    <pointer-type-def type-id='type-id-1060' size-in-bits='64' id='type-id-736'/>
-    <pointer-type-def type-id='type-id-1061' size-in-bits='64' id='type-id-788'/>
-    <pointer-type-def type-id='type-id-1062' size-in-bits='64' id='type-id-792'/>
-    <pointer-type-def type-id='type-id-1018' size-in-bits='64' id='type-id-424'/>
+    <pointer-type-def type-id='type-id-1061' size-in-bits='64' id='type-id-736'/>
+    <pointer-type-def type-id='type-id-1062' size-in-bits='64' id='type-id-788'/>
+    <pointer-type-def type-id='type-id-1063' size-in-bits='64' id='type-id-792'/>
+    <pointer-type-def type-id='type-id-1019' size-in-bits='64' id='type-id-424'/>
     <pointer-type-def type-id='type-id-948' size-in-bits='64' id='type-id-177'/>
     <pointer-type-def type-id='type-id-801' size-in-bits='64' id='type-id-596'/>
     <pointer-type-def type-id='type-id-250' size-in-bits='64' id='type-id-445'/>
@@ -17396,71 +17410,72 @@
     <pointer-type-def type-id='type-id-720' size-in-bits='64' id='type-id-729'/>
     <pointer-type-def type-id='type-id-722' size-in-bits='64' id='type-id-727'/>
     <pointer-type-def type-id='type-id-724' size-in-bits='64' id='type-id-730'/>
-    <pointer-type-def type-id='type-id-791' size-in-bits='64' id='type-id-1063'/>
+    <pointer-type-def type-id='type-id-791' size-in-bits='64' id='type-id-1064'/>
     <pointer-type-def type-id='type-id-369' size-in-bits='64' id='type-id-376'/>
     <pointer-type-def type-id='type-id-371' size-in-bits='64' id='type-id-375'/>
     <pointer-type-def type-id='type-id-783' size-in-bits='64' id='type-id-787'/>
-    <pointer-type-def type-id='type-id-1008' size-in-bits='64' id='type-id-1015'/>
-    <pointer-type-def type-id='type-id-984' size-in-bits='64' id='type-id-985'/>
+    <pointer-type-def type-id='type-id-1009' size-in-bits='64' id='type-id-1016'/>
+    <pointer-type-def type-id='type-id-985' size-in-bits='64' id='type-id-986'/>
     <pointer-type-def type-id='type-id-716' size-in-bits='64' id='type-id-859'/>
-    <pointer-type-def type-id='type-id-918' size-in-bits='64' id='type-id-1064'/>
-    <pointer-type-def type-id='type-id-1065' size-in-bits='64' id='type-id-923'/>
+    <pointer-type-def type-id='type-id-918' size-in-bits='64' id='type-id-1065'/>
+    <pointer-type-def type-id='type-id-1066' size-in-bits='64' id='type-id-923'/>
     <pointer-type-def type-id='type-id-442' size-in-bits='64' id='type-id-451'/>
     <pointer-type-def type-id='type-id-912' size-in-bits='64' id='type-id-913'/>
     <pointer-type-def type-id='type-id-914' size-in-bits='64' id='type-id-917'/>
     <pointer-type-def type-id='type-id-915' size-in-bits='64' id='type-id-927'/>
-    <pointer-type-def type-id='type-id-1039' size-in-bits='64' id='type-id-1040'/>
+    <pointer-type-def type-id='type-id-1040' size-in-bits='64' id='type-id-1041'/>
     <pointer-type-def type-id='type-id-779' size-in-bits='64' id='type-id-780'/>
     <pointer-type-def type-id='type-id-866' size-in-bits='64' id='type-id-833'/>
     <pointer-type-def type-id='type-id-749' size-in-bits='64' id='type-id-929'/>
+    <pointer-type-def type-id='type-id-967' size-in-bits='64' id='type-id-942'/>
     <pointer-type-def type-id='type-id-781' size-in-bits='64' id='type-id-782'/>
     <pointer-type-def type-id='type-id-935' size-in-bits='64' id='type-id-936'/>
     <pointer-type-def type-id='type-id-961' size-in-bits='64' id='type-id-615'/>
     <pointer-type-def type-id='type-id-962' size-in-bits='64' id='type-id-618'/>
     <pointer-type-def type-id='type-id-956' size-in-bits='64' id='type-id-620'/>
     <pointer-type-def type-id='type-id-811' size-in-bits='64' id='type-id-812'/>
-    <pointer-type-def type-id='type-id-814' size-in-bits='64' id='type-id-1066'/>
-    <pointer-type-def type-id='type-id-1066' size-in-bits='64' id='type-id-817'/>
-    <pointer-type-def type-id='type-id-1067' size-in-bits='64' id='type-id-1068'/>
+    <pointer-type-def type-id='type-id-814' size-in-bits='64' id='type-id-1067'/>
+    <pointer-type-def type-id='type-id-1067' size-in-bits='64' id='type-id-817'/>
+    <pointer-type-def type-id='type-id-1068' size-in-bits='64' id='type-id-1069'/>
     <qualified-type-def type-id='type-id-15' restrict='yes' id='type-id-183'/>
     <pointer-type-def type-id='type-id-632' size-in-bits='64' id='type-id-831'/>
     <pointer-type-def type-id='type-id-430' size-in-bits='64' id='type-id-762'/>
     <pointer-type-def type-id='type-id-251' size-in-bits='64' id='type-id-182'/>
     <pointer-type-def type-id='type-id-847' size-in-bits='64' id='type-id-851'/>
-    <pointer-type-def type-id='type-id-1069' size-in-bits='64' id='type-id-1070'/>
-    <pointer-type-def type-id='type-id-1071' size-in-bits='64' id='type-id-774'/>
-    <pointer-type-def type-id='type-id-1072' size-in-bits='64' id='type-id-795'/>
-    <pointer-type-def type-id='type-id-1073' size-in-bits='64' id='type-id-763'/>
-    <pointer-type-def type-id='type-id-1074' size-in-bits='64' id='type-id-800'/>
-    <pointer-type-def type-id='type-id-1075' size-in-bits='64' id='type-id-1011'/>
-    <pointer-type-def type-id='type-id-1076' size-in-bits='64' id='type-id-733'/>
-    <pointer-type-def type-id='type-id-1077' size-in-bits='64' id='type-id-740'/>
-    <pointer-type-def type-id='type-id-1078' size-in-bits='64' id='type-id-748'/>
-    <pointer-type-def type-id='type-id-1079' size-in-bits='64' id='type-id-1010'/>
-    <pointer-type-def type-id='type-id-1080' size-in-bits='64' id='type-id-823'/>
+    <pointer-type-def type-id='type-id-1070' size-in-bits='64' id='type-id-1071'/>
+    <pointer-type-def type-id='type-id-1072' size-in-bits='64' id='type-id-774'/>
+    <pointer-type-def type-id='type-id-1073' size-in-bits='64' id='type-id-795'/>
+    <pointer-type-def type-id='type-id-1074' size-in-bits='64' id='type-id-763'/>
+    <pointer-type-def type-id='type-id-1075' size-in-bits='64' id='type-id-800'/>
+    <pointer-type-def type-id='type-id-1076' size-in-bits='64' id='type-id-1012'/>
+    <pointer-type-def type-id='type-id-1077' size-in-bits='64' id='type-id-733'/>
+    <pointer-type-def type-id='type-id-1078' size-in-bits='64' id='type-id-740'/>
+    <pointer-type-def type-id='type-id-1079' size-in-bits='64' id='type-id-748'/>
+    <pointer-type-def type-id='type-id-1080' size-in-bits='64' id='type-id-1011'/>
+    <pointer-type-def type-id='type-id-1081' size-in-bits='64' id='type-id-823'/>
     <pointer-type-def type-id='type-id-190' size-in-bits='64' id='type-id-78'/>
     <pointer-type-def type-id='type-id-952' size-in-bits='64' id='type-id-955'/>
-    <pointer-type-def type-id='type-id-981' size-in-bits='64' id='type-id-980'/>
+    <pointer-type-def type-id='type-id-982' size-in-bits='64' id='type-id-981'/>
     <pointer-type-def type-id='type-id-951' size-in-bits='64' id='type-id-954'/>
-    <pointer-type-def type-id='type-id-987' size-in-bits='64' id='type-id-940'/>
-    <pointer-type-def type-id='type-id-1007' size-in-bits='64' id='type-id-649'/>
-    <pointer-type-def type-id='type-id-1046' size-in-bits='64' id='type-id-189'/>
-    <pointer-type-def type-id='type-id-1002' size-in-bits='64' id='type-id-1004'/>
-    <pointer-type-def type-id='type-id-1081' size-in-bits='64' id='type-id-922'/>
+    <pointer-type-def type-id='type-id-988' size-in-bits='64' id='type-id-940'/>
+    <pointer-type-def type-id='type-id-1008' size-in-bits='64' id='type-id-649'/>
+    <pointer-type-def type-id='type-id-1047' size-in-bits='64' id='type-id-189'/>
+    <pointer-type-def type-id='type-id-1003' size-in-bits='64' id='type-id-1005'/>
+    <pointer-type-def type-id='type-id-1082' size-in-bits='64' id='type-id-922'/>
     <pointer-type-def type-id='type-id-325' size-in-bits='64' id='type-id-726'/>
     <pointer-type-def type-id='type-id-230' size-in-bits='64' id='type-id-227'/>
-    <pointer-type-def type-id='type-id-1082' size-in-bits='64' id='type-id-1020'/>
-    <pointer-type-def type-id='type-id-1083' size-in-bits='64' id='type-id-1031'/>
-    <pointer-type-def type-id='type-id-1084' size-in-bits='64' id='type-id-773'/>
-    <pointer-type-def type-id='type-id-1085' size-in-bits='64' id='type-id-766'/>
-    <pointer-type-def type-id='type-id-1086' size-in-bits='64' id='type-id-828'/>
-    <pointer-type-def type-id='type-id-1087' size-in-bits='64' id='type-id-827'/>
-    <pointer-type-def type-id='type-id-1088' size-in-bits='64' id='type-id-926'/>
-    <pointer-type-def type-id='type-id-1089' size-in-bits='64' id='type-id-765'/>
-    <pointer-type-def type-id='type-id-1090' size-in-bits='64' id='type-id-771'/>
-    <pointer-type-def type-id='type-id-1091' size-in-bits='64' id='type-id-772'/>
-    <qualified-type-def type-id='type-id-997' volatile='yes' id='type-id-707'/>
-    <qualified-type-def type-id='type-id-998' volatile='yes' id='type-id-996'/>
+    <pointer-type-def type-id='type-id-1083' size-in-bits='64' id='type-id-1021'/>
+    <pointer-type-def type-id='type-id-1084' size-in-bits='64' id='type-id-1032'/>
+    <pointer-type-def type-id='type-id-1085' size-in-bits='64' id='type-id-773'/>
+    <pointer-type-def type-id='type-id-1086' size-in-bits='64' id='type-id-766'/>
+    <pointer-type-def type-id='type-id-1087' size-in-bits='64' id='type-id-828'/>
+    <pointer-type-def type-id='type-id-1088' size-in-bits='64' id='type-id-827'/>
+    <pointer-type-def type-id='type-id-1089' size-in-bits='64' id='type-id-926'/>
+    <pointer-type-def type-id='type-id-1090' size-in-bits='64' id='type-id-765'/>
+    <pointer-type-def type-id='type-id-1091' size-in-bits='64' id='type-id-771'/>
+    <pointer-type-def type-id='type-id-1092' size-in-bits='64' id='type-id-772'/>
+    <qualified-type-def type-id='type-id-998' volatile='yes' id='type-id-707'/>
+    <qualified-type-def type-id='type-id-999' volatile='yes' id='type-id-997'/>
     <pointer-type-def type-id='type-id-422' size-in-bits='64' id='type-id-52'/>
     <pointer-type-def type-id='type-id-52' size-in-bits='64' id='type-id-235'/>
     <class-decl name='PyAsyncGenASend' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-630'/>
@@ -17483,7 +17498,7 @@
       <return type-id='type-id-46'/>
     </function-decl>
     <var-decl name='_PyOS_ReadlineTState' type-id='type-id-177' mangled-name='_PyOS_ReadlineTState' visibility='default' filepath='./Include/cpython/pythonrun.h' line='120' column='1' elf-symbol-id='_PyOS_ReadlineTState'/>
-    <var-decl name='PyOS_ReadlineFunctionPointer' type-id='type-id-1068' mangled-name='PyOS_ReadlineFunctionPointer' visibility='default' filepath='./Include/cpython/pythonrun.h' line='121' column='1' elf-symbol-id='PyOS_ReadlineFunctionPointer'/>
+    <var-decl name='PyOS_ReadlineFunctionPointer' type-id='type-id-1069' mangled-name='PyOS_ReadlineFunctionPointer' visibility='default' filepath='./Include/cpython/pythonrun.h' line='121' column='1' elf-symbol-id='PyOS_ReadlineFunctionPointer'/>
     <function-decl name='_PyOS_InterruptOccurred' mangled-name='_PyOS_InterruptOccurred' filepath='./Include/internal/pycore_pystate.h' line='169' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyOS_InterruptOccurred'>
       <parameter type-id='type-id-177'/>
       <return type-id='type-id-8'/>
@@ -17491,7 +17506,7 @@
     <function-decl name='PyErr_CheckSignals' mangled-name='PyErr_CheckSignals' filepath='./Include/pyerrors.h' line='239' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyErr_CheckSignals'>
       <return type-id='type-id-8'/>
     </function-decl>
-    <var-decl name='PyOS_InputHook' type-id='type-id-1070' mangled-name='PyOS_InputHook' visibility='default' filepath='./Include/pythonrun.h' line='22' column='1' elf-symbol-id='PyOS_InputHook'/>
+    <var-decl name='PyOS_InputHook' type-id='type-id-1071' mangled-name='PyOS_InputHook' visibility='default' filepath='./Include/pythonrun.h' line='22' column='1' elf-symbol-id='PyOS_InputHook'/>
     <function-decl name='PyThread_allocate_lock' mangled-name='PyThread_allocate_lock' filepath='./Include/pythread.h' line='30' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyThread_allocate_lock'>
       <return type-id='type-id-810'/>
     </function-decl>
@@ -17542,163 +17557,163 @@
       <parameter type-id='type-id-12' name='prompt' filepath='Parser/myreadline.c' line='364' column='1'/>
       <return type-id='type-id-15'/>
     </function-decl>
-    <function-type size-in-bits='64' id='type-id-1060'>
+    <function-type size-in-bits='64' id='type-id-1061'>
       <parameter type-id='type-id-2'/>
       <parameter type-id='type-id-2'/>
       <parameter type-id='type-id-22'/>
       <return type-id='type-id-2'/>
     </function-type>
-    <function-type size-in-bits='64' id='type-id-1061'>
+    <function-type size-in-bits='64' id='type-id-1062'>
       <parameter type-id='type-id-177'/>
       <parameter type-id='type-id-375'/>
       <parameter type-id='type-id-8'/>
       <return type-id='type-id-2'/>
     </function-type>
-    <function-type size-in-bits='64' id='type-id-1062'>
-      <parameter type-id='type-id-1063'/>
+    <function-type size-in-bits='64' id='type-id-1063'>
+      <parameter type-id='type-id-1064'/>
       <return type-id='type-id-2'/>
     </function-type>
-    <function-type size-in-bits='64' id='type-id-1065'>
+    <function-type size-in-bits='64' id='type-id-1066'>
       <parameter type-id='type-id-451'/>
       <parameter type-id='type-id-22'/>
-      <return type-id='type-id-1064'/>
+      <return type-id='type-id-1065'/>
     </function-type>
-    <function-type size-in-bits='64' id='type-id-1067'>
+    <function-type size-in-bits='64' id='type-id-1068'>
       <parameter type-id='type-id-229'/>
       <parameter type-id='type-id-229'/>
       <parameter type-id='type-id-12'/>
       <return type-id='type-id-15'/>
     </function-type>
-    <function-type size-in-bits='64' id='type-id-1069'>
+    <function-type size-in-bits='64' id='type-id-1070'>
       <return type-id='type-id-8'/>
     </function-type>
-    <function-type size-in-bits='64' id='type-id-1071'>
+    <function-type size-in-bits='64' id='type-id-1072'>
       <parameter type-id='type-id-2'/>
       <parameter type-id='type-id-365'/>
       <parameter type-id='type-id-8'/>
       <parameter type-id='type-id-2'/>
       <return type-id='type-id-8'/>
     </function-type>
-    <function-type size-in-bits='64' id='type-id-1072'>
+    <function-type size-in-bits='64' id='type-id-1073'>
       <parameter type-id='type-id-177'/>
       <parameter type-id='type-id-2'/>
-      <parameter type-id='type-id-1063'/>
-      <return type-id='type-id-8'/>
-    </function-type>
-    <function-type size-in-bits='64' id='type-id-1073'>
-      <parameter type-id='type-id-1'/>
+      <parameter type-id='type-id-1064'/>
       <return type-id='type-id-8'/>
     </function-type>
     <function-type size-in-bits='64' id='type-id-1074'>
+      <parameter type-id='type-id-1'/>
+      <return type-id='type-id-8'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-1075'>
       <parameter type-id='type-id-12'/>
       <parameter type-id='type-id-2'/>
       <parameter type-id='type-id-22'/>
       <return type-id='type-id-8'/>
     </function-type>
-    <function-type size-in-bits='64' id='type-id-1075'>
+    <function-type size-in-bits='64' id='type-id-1076'>
       <parameter type-id='type-id-12'/>
       <parameter type-id='type-id-8'/>
       <parameter type-id='type-id-445'/>
       <parameter type-id='type-id-8'/>
       <return type-id='type-id-8'/>
     </function-type>
-    <function-type size-in-bits='64' id='type-id-1076'>
+    <function-type size-in-bits='64' id='type-id-1077'>
       <parameter type-id='type-id-731'/>
       <parameter type-id='type-id-328'/>
       <return type-id='type-id-8'/>
     </function-type>
-    <function-type size-in-bits='64' id='type-id-1077'>
+    <function-type size-in-bits='64' id='type-id-1078'>
       <parameter type-id='type-id-738'/>
       <parameter type-id='type-id-2'/>
       <parameter type-id='type-id-2'/>
       <parameter type-id='type-id-2'/>
       <return type-id='type-id-8'/>
     </function-type>
-    <function-type size-in-bits='64' id='type-id-1078'>
+    <function-type size-in-bits='64' id='type-id-1079'>
       <parameter type-id='type-id-746'/>
       <parameter type-id='type-id-310'/>
       <parameter type-id='type-id-2'/>
       <return type-id='type-id-8'/>
     </function-type>
-    <function-type size-in-bits='64' id='type-id-1079'>
+    <function-type size-in-bits='64' id='type-id-1080'>
       <parameter type-id='type-id-250'/>
       <parameter type-id='type-id-15'/>
       <parameter type-id='type-id-8'/>
       <parameter type-id='type-id-8'/>
       <return type-id='type-id-8'/>
     </function-type>
-    <function-type size-in-bits='64' id='type-id-1080'>
+    <function-type size-in-bits='64' id='type-id-1081'>
       <parameter type-id='type-id-22'/>
       <return type-id='type-id-8'/>
     </function-type>
-    <function-type size-in-bits='64' id='type-id-1081'>
+    <function-type size-in-bits='64' id='type-id-1082'>
       <parameter type-id='type-id-22'/>
       <return type-id='type-id-920'/>
     </function-type>
-    <function-type size-in-bits='64' id='type-id-1082'>
-      <parameter type-id='type-id-8'/>
-      <return type-id='type-id-46'/>
-    </function-type>
     <function-type size-in-bits='64' id='type-id-1083'>
       <parameter type-id='type-id-8'/>
-      <parameter type-id='type-id-189'/>
-      <parameter type-id='type-id-22'/>
       <return type-id='type-id-46'/>
     </function-type>
     <function-type size-in-bits='64' id='type-id-1084'>
-      <parameter type-id='type-id-22'/>
+      <parameter type-id='type-id-8'/>
+      <parameter type-id='type-id-189'/>
       <parameter type-id='type-id-22'/>
       <return type-id='type-id-46'/>
     </function-type>
     <function-type size-in-bits='64' id='type-id-1085'>
       <parameter type-id='type-id-22'/>
       <parameter type-id='type-id-22'/>
-      <parameter type-id='type-id-19'/>
       <return type-id='type-id-46'/>
     </function-type>
     <function-type size-in-bits='64' id='type-id-1086'>
+      <parameter type-id='type-id-22'/>
+      <parameter type-id='type-id-22'/>
+      <parameter type-id='type-id-19'/>
+      <return type-id='type-id-46'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-1087'>
       <parameter type-id='type-id-22'/>
       <parameter type-id='type-id-22'/>
       <parameter type-id='type-id-95'/>
       <parameter type-id='type-id-328'/>
       <return type-id='type-id-46'/>
     </function-type>
-    <function-type size-in-bits='64' id='type-id-1087'>
-      <return type-id='type-id-22'/>
-    </function-type>
     <function-type size-in-bits='64' id='type-id-1088'>
-      <parameter type-id='type-id-19'/>
       <return type-id='type-id-22'/>
     </function-type>
     <function-type size-in-bits='64' id='type-id-1089'>
-      <parameter type-id='type-id-22'/>
       <parameter type-id='type-id-19'/>
       <return type-id='type-id-22'/>
     </function-type>
     <function-type size-in-bits='64' id='type-id-1090'>
       <parameter type-id='type-id-22'/>
       <parameter type-id='type-id-19'/>
-      <parameter type-id='type-id-19'/>
       <return type-id='type-id-22'/>
     </function-type>
     <function-type size-in-bits='64' id='type-id-1091'>
       <parameter type-id='type-id-22'/>
-      <parameter type-id='type-id-22'/>
+      <parameter type-id='type-id-19'/>
       <parameter type-id='type-id-19'/>
       <return type-id='type-id-22'/>
     </function-type>
     <function-type size-in-bits='64' id='type-id-1092'>
+      <parameter type-id='type-id-22'/>
+      <parameter type-id='type-id-22'/>
+      <parameter type-id='type-id-19'/>
+      <return type-id='type-id-22'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-1093'>
       <parameter type-id='type-id-2'/>
       <parameter type-id='type-id-22'/>
       <return type-id='type-id-2'/>
     </function-type>
-    <function-type size-in-bits='64' id='type-id-1093'>
+    <function-type size-in-bits='64' id='type-id-1094'>
       <parameter type-id='type-id-22'/>
       <return type-id='type-id-46'/>
     </function-type>
   </abi-instr>
   <abi-instr address-size='64' path='Parser/parser.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
-    <class-decl name='asdl_seq' size-in-bits='128' is-struct='yes' naming-typedef-id='type-id-1094' visibility='default' filepath='./Include/internal/pycore_asdl.h' line='28' column='1' id='type-id-1095'>
+    <class-decl name='asdl_seq' size-in-bits='128' is-struct='yes' naming-typedef-id='type-id-1095' visibility='default' filepath='./Include/internal/pycore_asdl.h' line='28' column='1' id='type-id-1096'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='size' type-id='type-id-14' visibility='default' filepath='./Include/internal/pycore_asdl.h' line='29' column='1'/>
       </data-member>
@@ -17706,8 +17721,8 @@
         <var-decl name='elements' type-id='type-id-253' visibility='default' filepath='./Include/internal/pycore_asdl.h' line='29' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='asdl_seq' type-id='type-id-1095' filepath='./Include/internal/pycore_asdl.h' line='30' column='1' id='type-id-1094'/>
-    <enum-decl name='_cmpop' filepath='./Include/internal/pycore_ast.h' line='31' column='1' id='type-id-1096'>
+    <typedef-decl name='asdl_seq' type-id='type-id-1096' filepath='./Include/internal/pycore_asdl.h' line='30' column='1' id='type-id-1095'/>
+    <enum-decl name='_cmpop' filepath='./Include/internal/pycore_ast.h' line='31' column='1' id='type-id-1097'>
       <underlying-type type-id='type-id-24'/>
       <enumerator name='Eq' value='1'/>
       <enumerator name='NotEq' value='2'/>
@@ -17720,17 +17735,17 @@
       <enumerator name='In' value='9'/>
       <enumerator name='NotIn' value='10'/>
     </enum-decl>
-    <typedef-decl name='cmpop_ty' type-id='type-id-1096' filepath='./Include/internal/pycore_ast.h' line='32' column='1' id='type-id-1097'/>
-    <class-decl name='CmpopExprPair' size-in-bits='128' is-struct='yes' naming-typedef-id='type-id-1098' visibility='default' filepath='Parser/pegen.h' line='85' column='1' id='type-id-1099'>
+    <typedef-decl name='cmpop_ty' type-id='type-id-1097' filepath='./Include/internal/pycore_ast.h' line='32' column='1' id='type-id-1098'/>
+    <class-decl name='CmpopExprPair' size-in-bits='128' is-struct='yes' naming-typedef-id='type-id-1099' visibility='default' filepath='Parser/pegen.h' line='85' column='1' id='type-id-1100'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='cmpop' type-id='type-id-1097' visibility='default' filepath='Parser/pegen.h' line='86' column='1'/>
+        <var-decl name='cmpop' type-id='type-id-1098' visibility='default' filepath='Parser/pegen.h' line='86' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
         <var-decl name='expr' type-id='type-id-511' visibility='default' filepath='Parser/pegen.h' line='87' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='CmpopExprPair' type-id='type-id-1099' filepath='Parser/pegen.h' line='88' column='1' id='type-id-1098'/>
-    <class-decl name='KeyValuePair' size-in-bits='128' is-struct='yes' naming-typedef-id='type-id-1100' visibility='default' filepath='Parser/pegen.h' line='90' column='1' id='type-id-1101'>
+    <typedef-decl name='CmpopExprPair' type-id='type-id-1100' filepath='Parser/pegen.h' line='88' column='1' id='type-id-1099'/>
+    <class-decl name='KeyValuePair' size-in-bits='128' is-struct='yes' naming-typedef-id='type-id-1101' visibility='default' filepath='Parser/pegen.h' line='90' column='1' id='type-id-1102'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='key' type-id='type-id-511' visibility='default' filepath='Parser/pegen.h' line='91' column='1'/>
       </data-member>
@@ -17738,8 +17753,8 @@
         <var-decl name='value' type-id='type-id-511' visibility='default' filepath='Parser/pegen.h' line='92' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='KeyValuePair' type-id='type-id-1101' filepath='Parser/pegen.h' line='93' column='1' id='type-id-1100'/>
-    <class-decl name='KeyPatternPair' size-in-bits='128' is-struct='yes' naming-typedef-id='type-id-1102' visibility='default' filepath='Parser/pegen.h' line='95' column='1' id='type-id-1103'>
+    <typedef-decl name='KeyValuePair' type-id='type-id-1102' filepath='Parser/pegen.h' line='93' column='1' id='type-id-1101'/>
+    <class-decl name='KeyPatternPair' size-in-bits='128' is-struct='yes' naming-typedef-id='type-id-1103' visibility='default' filepath='Parser/pegen.h' line='95' column='1' id='type-id-1104'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='key' type-id='type-id-511' visibility='default' filepath='Parser/pegen.h' line='96' column='1'/>
       </data-member>
@@ -17747,8 +17762,8 @@
         <var-decl name='pattern' type-id='type-id-459' visibility='default' filepath='Parser/pegen.h' line='97' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='KeyPatternPair' type-id='type-id-1103' filepath='Parser/pegen.h' line='98' column='1' id='type-id-1102'/>
-    <class-decl name='NameDefaultPair' size-in-bits='128' is-struct='yes' naming-typedef-id='type-id-1104' visibility='default' filepath='Parser/pegen.h' line='100' column='1' id='type-id-1105'>
+    <typedef-decl name='KeyPatternPair' type-id='type-id-1104' filepath='Parser/pegen.h' line='98' column='1' id='type-id-1103'/>
+    <class-decl name='NameDefaultPair' size-in-bits='128' is-struct='yes' naming-typedef-id='type-id-1105' visibility='default' filepath='Parser/pegen.h' line='100' column='1' id='type-id-1106'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='arg' type-id='type-id-576' visibility='default' filepath='Parser/pegen.h' line='101' column='1'/>
       </data-member>
@@ -17756,35 +17771,35 @@
         <var-decl name='value' type-id='type-id-511' visibility='default' filepath='Parser/pegen.h' line='102' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='NameDefaultPair' type-id='type-id-1105' filepath='Parser/pegen.h' line='103' column='1' id='type-id-1104'/>
-    <class-decl name='SlashWithDefault' size-in-bits='128' is-struct='yes' naming-typedef-id='type-id-1106' visibility='default' filepath='Parser/pegen.h' line='105' column='1' id='type-id-1107'>
+    <typedef-decl name='NameDefaultPair' type-id='type-id-1106' filepath='Parser/pegen.h' line='103' column='1' id='type-id-1105'/>
+    <class-decl name='SlashWithDefault' size-in-bits='128' is-struct='yes' naming-typedef-id='type-id-1107' visibility='default' filepath='Parser/pegen.h' line='105' column='1' id='type-id-1108'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='plain_names' type-id='type-id-574' visibility='default' filepath='Parser/pegen.h' line='106' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='names_with_defaults' type-id='type-id-1108' visibility='default' filepath='Parser/pegen.h' line='107' column='1'/>
+        <var-decl name='names_with_defaults' type-id='type-id-1109' visibility='default' filepath='Parser/pegen.h' line='107' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='SlashWithDefault' type-id='type-id-1107' filepath='Parser/pegen.h' line='108' column='1' id='type-id-1106'/>
-    <class-decl name='StarEtc' size-in-bits='192' is-struct='yes' naming-typedef-id='type-id-1109' visibility='default' filepath='Parser/pegen.h' line='110' column='1' id='type-id-1110'>
+    <typedef-decl name='SlashWithDefault' type-id='type-id-1108' filepath='Parser/pegen.h' line='108' column='1' id='type-id-1107'/>
+    <class-decl name='StarEtc' size-in-bits='192' is-struct='yes' naming-typedef-id='type-id-1110' visibility='default' filepath='Parser/pegen.h' line='110' column='1' id='type-id-1111'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='vararg' type-id='type-id-576' visibility='default' filepath='Parser/pegen.h' line='111' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='kwonlyargs' type-id='type-id-1108' visibility='default' filepath='Parser/pegen.h' line='112' column='1'/>
+        <var-decl name='kwonlyargs' type-id='type-id-1109' visibility='default' filepath='Parser/pegen.h' line='112' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
         <var-decl name='kwarg' type-id='type-id-576' visibility='default' filepath='Parser/pegen.h' line='113' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='StarEtc' type-id='type-id-1110' filepath='Parser/pegen.h' line='114' column='1' id='type-id-1109'/>
-    <class-decl name='AugOperator' size-in-bits='32' is-struct='yes' naming-typedef-id='type-id-1111' visibility='default' filepath='Parser/pegen.h' line='116' column='1' id='type-id-1112'>
+    <typedef-decl name='StarEtc' type-id='type-id-1111' filepath='Parser/pegen.h' line='114' column='1' id='type-id-1110'/>
+    <class-decl name='AugOperator' size-in-bits='32' is-struct='yes' naming-typedef-id='type-id-1112' visibility='default' filepath='Parser/pegen.h' line='116' column='1' id='type-id-1113'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='kind' type-id='type-id-539' visibility='default' filepath='Parser/pegen.h' line='116' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='AugOperator' type-id='type-id-1112' filepath='Parser/pegen.h' line='116' column='1' id='type-id-1111'/>
-    <class-decl name='KeywordOrStarred' size-in-bits='128' is-struct='yes' naming-typedef-id='type-id-1113' visibility='default' filepath='Parser/pegen.h' line='117' column='1' id='type-id-1114'>
+    <typedef-decl name='AugOperator' type-id='type-id-1113' filepath='Parser/pegen.h' line='116' column='1' id='type-id-1112'/>
+    <class-decl name='KeywordOrStarred' size-in-bits='128' is-struct='yes' naming-typedef-id='type-id-1114' visibility='default' filepath='Parser/pegen.h' line='117' column='1' id='type-id-1115'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='element' type-id='type-id-22' visibility='default' filepath='Parser/pegen.h' line='118' column='1'/>
       </data-member>
@@ -17792,8 +17807,8 @@
         <var-decl name='is_keyword' type-id='type-id-8' visibility='default' filepath='Parser/pegen.h' line='119' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='KeywordOrStarred' type-id='type-id-1114' filepath='Parser/pegen.h' line='120' column='1' id='type-id-1113'/>
-    <class-decl name='ResultTokenWithMetadata' size-in-bits='128' is-struct='yes' naming-typedef-id='type-id-1115' visibility='default' filepath='Parser/pegen.h' line='122' column='1' id='type-id-1116'>
+    <typedef-decl name='KeywordOrStarred' type-id='type-id-1115' filepath='Parser/pegen.h' line='120' column='1' id='type-id-1114'/>
+    <class-decl name='ResultTokenWithMetadata' size-in-bits='128' is-struct='yes' naming-typedef-id='type-id-1116' visibility='default' filepath='Parser/pegen.h' line='122' column='1' id='type-id-1117'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='result' type-id='type-id-22' visibility='default' filepath='Parser/pegen.h' line='123' column='1'/>
       </data-member>
@@ -17801,29 +17816,29 @@
         <var-decl name='metadata' type-id='type-id-2' visibility='default' filepath='Parser/pegen.h' line='124' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='ResultTokenWithMetadata' type-id='type-id-1116' filepath='Parser/pegen.h' line='125' column='1' id='type-id-1115'/>
-    <enum-decl name='TARGETS_TYPE' naming-typedef-id='type-id-1117' filepath='Parser/pegen.h' line='157' column='1' id='type-id-1118'>
+    <typedef-decl name='ResultTokenWithMetadata' type-id='type-id-1117' filepath='Parser/pegen.h' line='125' column='1' id='type-id-1116'/>
+    <enum-decl name='TARGETS_TYPE' naming-typedef-id='type-id-1118' filepath='Parser/pegen.h' line='158' column='1' id='type-id-1119'>
       <underlying-type type-id='type-id-24'/>
       <enumerator name='STAR_TARGETS' value='0'/>
       <enumerator name='DEL_TARGETS' value='1'/>
       <enumerator name='FOR_TARGETS' value='2'/>
     </enum-decl>
-    <typedef-decl name='TARGETS_TYPE' type-id='type-id-1118' filepath='Parser/pegen.h' line='161' column='1' id='type-id-1117'/>
-    <pointer-type-def type-id='type-id-1111' size-in-bits='64' id='type-id-1119'/>
-    <pointer-type-def type-id='type-id-1098' size-in-bits='64' id='type-id-1120'/>
-    <pointer-type-def type-id='type-id-1102' size-in-bits='64' id='type-id-1121'/>
-    <pointer-type-def type-id='type-id-1100' size-in-bits='64' id='type-id-1122'/>
-    <pointer-type-def type-id='type-id-1113' size-in-bits='64' id='type-id-1123'/>
-    <pointer-type-def type-id='type-id-1104' size-in-bits='64' id='type-id-1124'/>
-    <pointer-type-def type-id='type-id-1115' size-in-bits='64' id='type-id-1125'/>
-    <pointer-type-def type-id='type-id-1106' size-in-bits='64' id='type-id-1126'/>
-    <pointer-type-def type-id='type-id-1109' size-in-bits='64' id='type-id-1127'/>
-    <pointer-type-def type-id='type-id-1128' size-in-bits='64' id='type-id-1129'/>
-    <pointer-type-def type-id='type-id-1094' size-in-bits='64' id='type-id-1108'/>
-    <pointer-type-def type-id='type-id-1130' size-in-bits='64' id='type-id-1131'/>
-    <pointer-type-def type-id='type-id-1132' size-in-bits='64' id='type-id-1133'/>
-    <pointer-type-def type-id='type-id-1134' size-in-bits='64' id='type-id-1135'/>
-    <class-decl name='tok_state' size-in-bits='138240' is-struct='yes' visibility='default' filepath='Parser/tokenizer.h' line='68' column='1' id='type-id-1136'>
+    <typedef-decl name='TARGETS_TYPE' type-id='type-id-1119' filepath='Parser/pegen.h' line='162' column='1' id='type-id-1118'/>
+    <pointer-type-def type-id='type-id-1112' size-in-bits='64' id='type-id-1120'/>
+    <pointer-type-def type-id='type-id-1099' size-in-bits='64' id='type-id-1121'/>
+    <pointer-type-def type-id='type-id-1103' size-in-bits='64' id='type-id-1122'/>
+    <pointer-type-def type-id='type-id-1101' size-in-bits='64' id='type-id-1123'/>
+    <pointer-type-def type-id='type-id-1114' size-in-bits='64' id='type-id-1124'/>
+    <pointer-type-def type-id='type-id-1105' size-in-bits='64' id='type-id-1125'/>
+    <pointer-type-def type-id='type-id-1116' size-in-bits='64' id='type-id-1126'/>
+    <pointer-type-def type-id='type-id-1107' size-in-bits='64' id='type-id-1127'/>
+    <pointer-type-def type-id='type-id-1110' size-in-bits='64' id='type-id-1128'/>
+    <pointer-type-def type-id='type-id-1129' size-in-bits='64' id='type-id-1130'/>
+    <pointer-type-def type-id='type-id-1095' size-in-bits='64' id='type-id-1109'/>
+    <pointer-type-def type-id='type-id-1131' size-in-bits='64' id='type-id-1132'/>
+    <pointer-type-def type-id='type-id-1133' size-in-bits='64' id='type-id-1134'/>
+    <pointer-type-def type-id='type-id-1135' size-in-bits='64' id='type-id-1136'/>
+    <class-decl name='tok_state' size-in-bits='138240' is-struct='yes' visibility='default' filepath='Parser/tokenizer.h' line='68' column='1' id='type-id-1137'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='buf' type-id='type-id-15' visibility='default' filepath='Parser/tokenizer.h' line='71' column='1'/>
       </data-member>
@@ -17861,7 +17876,7 @@
         <var-decl name='indent' type-id='type-id-8' visibility='default' filepath='Parser/tokenizer.h' line='83' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='704'>
-        <var-decl name='indstack' type-id='type-id-1137' visibility='default' filepath='Parser/tokenizer.h' line='84' column='1'/>
+        <var-decl name='indstack' type-id='type-id-1138' visibility='default' filepath='Parser/tokenizer.h' line='84' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='3904'>
         <var-decl name='atbol' type-id='type-id-8' visibility='default' filepath='Parser/tokenizer.h' line='85' column='1'/>
@@ -17891,22 +17906,22 @@
         <var-decl name='level' type-id='type-id-8' visibility='default' filepath='Parser/tokenizer.h' line='93' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='4256'>
-        <var-decl name='parenstack' type-id='type-id-1138' visibility='default' filepath='Parser/tokenizer.h' line='95' column='1'/>
+        <var-decl name='parenstack' type-id='type-id-1139' visibility='default' filepath='Parser/tokenizer.h' line='95' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='5856'>
-        <var-decl name='parenlinenostack' type-id='type-id-1139' visibility='default' filepath='Parser/tokenizer.h' line='96' column='1'/>
+        <var-decl name='parenlinenostack' type-id='type-id-1140' visibility='default' filepath='Parser/tokenizer.h' line='96' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='12256'>
-        <var-decl name='parencolstack' type-id='type-id-1139' visibility='default' filepath='Parser/tokenizer.h' line='97' column='1'/>
+        <var-decl name='parencolstack' type-id='type-id-1140' visibility='default' filepath='Parser/tokenizer.h' line='97' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='18688'>
         <var-decl name='filename' type-id='type-id-2' visibility='default' filepath='Parser/tokenizer.h' line='98' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='18752'>
-        <var-decl name='altindstack' type-id='type-id-1137' visibility='default' filepath='Parser/tokenizer.h' line='100' column='1'/>
+        <var-decl name='altindstack' type-id='type-id-1138' visibility='default' filepath='Parser/tokenizer.h' line='100' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='21952'>
-        <var-decl name='decoding_state' type-id='type-id-1140' visibility='default' filepath='Parser/tokenizer.h' line='102' column='1'/>
+        <var-decl name='decoding_state' type-id='type-id-1141' visibility='default' filepath='Parser/tokenizer.h' line='102' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='21984'>
         <var-decl name='decoding_erred' type-id='type-id-8' visibility='default' filepath='Parser/tokenizer.h' line='103' column='1'/>
@@ -17957,13 +17972,13 @@
         <var-decl name='async_def_nl' type-id='type-id-8' visibility='default' filepath='Parser/tokenizer.h' line='123' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='22816'>
-        <var-decl name='interactive_underflow' type-id='type-id-1141' visibility='default' filepath='Parser/tokenizer.h' line='126' column='1'/>
+        <var-decl name='interactive_underflow' type-id='type-id-1142' visibility='default' filepath='Parser/tokenizer.h' line='126' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='22848'>
         <var-decl name='report_warnings' type-id='type-id-8' visibility='default' filepath='Parser/tokenizer.h' line='127' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='22912'>
-        <var-decl name='tok_mode_stack' type-id='type-id-1142' visibility='default' filepath='Parser/tokenizer.h' line='129' column='1'/>
+        <var-decl name='tok_mode_stack' type-id='type-id-1143' visibility='default' filepath='Parser/tokenizer.h' line='129' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='138112'>
         <var-decl name='tok_mode_stack_index' type-id='type-id-8' visibility='default' filepath='Parser/tokenizer.h' line='130' column='1'/>
@@ -18253,7 +18268,7 @@
       <return type-id='type-id-461'/>
     </function-decl>
     <function-decl name='_PyAST_BoolOp' filepath='./Include/internal/pycore_ast.h' line='770' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-1143'/>
+      <parameter type-id='type-id-1144'/>
       <parameter type-id='type-id-512'/>
       <parameter type-id='type-id-8'/>
       <parameter type-id='type-id-8'/>
@@ -18284,7 +18299,7 @@
       <return type-id='type-id-511'/>
     </function-decl>
     <function-decl name='_PyAST_UnaryOp' filepath='./Include/internal/pycore_ast.h' line='779' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-1144'/>
+      <parameter type-id='type-id-1145'/>
       <parameter type-id='type-id-511'/>
       <parameter type-id='type-id-8'/>
       <parameter type-id='type-id-8'/>
@@ -18335,7 +18350,7 @@
     </function-decl>
     <function-decl name='_PyAST_ListComp' filepath='./Include/internal/pycore_ast.h' line='793' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-511'/>
-      <parameter type-id='type-id-1145'/>
+      <parameter type-id='type-id-1146'/>
       <parameter type-id='type-id-8'/>
       <parameter type-id='type-id-8'/>
       <parameter type-id='type-id-8'/>
@@ -18345,7 +18360,7 @@
     </function-decl>
     <function-decl name='_PyAST_SetComp' filepath='./Include/internal/pycore_ast.h' line='796' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-511'/>
-      <parameter type-id='type-id-1145'/>
+      <parameter type-id='type-id-1146'/>
       <parameter type-id='type-id-8'/>
       <parameter type-id='type-id-8'/>
       <parameter type-id='type-id-8'/>
@@ -18356,7 +18371,7 @@
     <function-decl name='_PyAST_DictComp' filepath='./Include/internal/pycore_ast.h' line='799' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-511'/>
       <parameter type-id='type-id-511'/>
-      <parameter type-id='type-id-1145'/>
+      <parameter type-id='type-id-1146'/>
       <parameter type-id='type-id-8'/>
       <parameter type-id='type-id-8'/>
       <parameter type-id='type-id-8'/>
@@ -18366,7 +18381,7 @@
     </function-decl>
     <function-decl name='_PyAST_GeneratorExp' filepath='./Include/internal/pycore_ast.h' line='802' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-511'/>
-      <parameter type-id='type-id-1145'/>
+      <parameter type-id='type-id-1146'/>
       <parameter type-id='type-id-8'/>
       <parameter type-id='type-id-8'/>
       <parameter type-id='type-id-8'/>
@@ -18429,7 +18444,7 @@
       <parameter type-id='type-id-512'/>
       <parameter type-id='type-id-8'/>
       <parameter type-id='type-id-572'/>
-      <return type-id='type-id-1146'/>
+      <return type-id='type-id-1147'/>
     </function-decl>
     <function-decl name='_PyAST_ExceptHandler' filepath='./Include/internal/pycore_ast.h' line='849' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-511'/>
@@ -18450,7 +18465,7 @@
       <parameter type-id='type-id-8'/>
       <parameter type-id='type-id-8'/>
       <parameter type-id='type-id-572'/>
-      <return type-id='type-id-1147'/>
+      <return type-id='type-id-1148'/>
     </function-decl>
     <function-decl name='_PyAST_withitem' filepath='./Include/internal/pycore_ast.h' line='866' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-511'/>
@@ -18593,27 +18608,27 @@
     </function-decl>
     <function-decl name='_PyPegen_lookahead_with_name' filepath='Parser/pegen.h' line='137' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-8'/>
-      <parameter type-id='type-id-1131'/>
+      <parameter type-id='type-id-1132'/>
       <parameter type-id='type-id-577'/>
       <return type-id='type-id-8'/>
     </function-decl>
     <function-decl name='_PyPegen_lookahead_with_int' filepath='Parser/pegen.h' line='138' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-8'/>
-      <parameter type-id='type-id-1129'/>
+      <parameter type-id='type-id-1130'/>
       <parameter type-id='type-id-577'/>
       <parameter type-id='type-id-8'/>
       <return type-id='type-id-8'/>
     </function-decl>
     <function-decl name='_PyPegen_lookahead_with_string' filepath='Parser/pegen.h' line='139' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-8'/>
-      <parameter type-id='type-id-1133'/>
+      <parameter type-id='type-id-1134'/>
       <parameter type-id='type-id-577'/>
       <parameter type-id='type-id-12'/>
       <return type-id='type-id-8'/>
     </function-decl>
     <function-decl name='_PyPegen_lookahead' filepath='Parser/pegen.h' line='140' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-8'/>
-      <parameter type-id='type-id-1135'/>
+      <parameter type-id='type-id-1136'/>
       <parameter type-id='type-id-577'/>
       <return type-id='type-id-8'/>
     </function-decl>
@@ -18653,76 +18668,76 @@
       <parameter type-id='type-id-577'/>
       <return type-id='type-id-22'/>
     </function-decl>
-    <function-decl name='_Pypegen_stack_overflow' filepath='Parser/pegen.h' line='172' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_Pypegen_stack_overflow' filepath='Parser/pegen.h' line='173' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-577'/>
       <return type-id='type-id-46'/>
     </function-decl>
-    <function-decl name='_PyPegen_get_invalid_target' filepath='Parser/pegen.h' line='223' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_PyPegen_get_invalid_target' filepath='Parser/pegen.h' line='224' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-511'/>
-      <parameter type-id='type-id-1117'/>
+      <parameter type-id='type-id-1118'/>
       <return type-id='type-id-511'/>
     </function-decl>
-    <function-decl name='_PyPegen_get_expr_name' filepath='Parser/pegen.h' line='224' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_PyPegen_get_expr_name' filepath='Parser/pegen.h' line='225' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-511'/>
       <return type-id='type-id-12'/>
     </function-decl>
-    <function-decl name='_PyPegen_dummy_name' filepath='Parser/pegen.h' line='249' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_PyPegen_dummy_name' filepath='Parser/pegen.h' line='250' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-577'/>
       <parameter is-variadic='yes'/>
       <return type-id='type-id-22'/>
     </function-decl>
-    <function-decl name='_PyPegen_seq_last_item' filepath='Parser/pegen.h' line='250' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-1108'/>
+    <function-decl name='_PyPegen_seq_last_item' filepath='Parser/pegen.h' line='251' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-1109'/>
       <return type-id='type-id-22'/>
     </function-decl>
-    <function-decl name='_PyPegen_seq_first_item' filepath='Parser/pegen.h' line='252' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-1108'/>
+    <function-decl name='_PyPegen_seq_first_item' filepath='Parser/pegen.h' line='253' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-1109'/>
       <return type-id='type-id-22'/>
     </function-decl>
-    <function-decl name='_PyPegen_new_type_comment' filepath='Parser/pegen.h' line='257' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_PyPegen_new_type_comment' filepath='Parser/pegen.h' line='258' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-577'/>
       <parameter type-id='type-id-12'/>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='_PyPegen_add_type_comment_to_arg' filepath='Parser/pegen.h' line='296' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_PyPegen_add_type_comment_to_arg' filepath='Parser/pegen.h' line='297' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-577'/>
       <parameter type-id='type-id-576'/>
       <parameter type-id='type-id-578'/>
       <return type-id='type-id-576'/>
     </function-decl>
-    <function-decl name='_PyPegen_singleton_seq' filepath='Parser/pegen.h' line='298' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_PyPegen_singleton_seq' filepath='Parser/pegen.h' line='299' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-577'/>
       <parameter type-id='type-id-22'/>
-      <return type-id='type-id-1108'/>
+      <return type-id='type-id-1109'/>
     </function-decl>
-    <function-decl name='_PyPegen_seq_insert_in_front' filepath='Parser/pegen.h' line='299' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_PyPegen_seq_insert_in_front' filepath='Parser/pegen.h' line='300' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-577'/>
       <parameter type-id='type-id-22'/>
-      <parameter type-id='type-id-1108'/>
-      <return type-id='type-id-1108'/>
+      <parameter type-id='type-id-1109'/>
+      <return type-id='type-id-1109'/>
     </function-decl>
-    <function-decl name='_PyPegen_seq_append_to_end' filepath='Parser/pegen.h' line='300' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_PyPegen_seq_append_to_end' filepath='Parser/pegen.h' line='301' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-577'/>
-      <parameter type-id='type-id-1108'/>
+      <parameter type-id='type-id-1109'/>
       <parameter type-id='type-id-22'/>
-      <return type-id='type-id-1108'/>
+      <return type-id='type-id-1109'/>
     </function-decl>
-    <function-decl name='_PyPegen_seq_flatten' filepath='Parser/pegen.h' line='301' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_PyPegen_seq_flatten' filepath='Parser/pegen.h' line='302' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-577'/>
-      <parameter type-id='type-id-1108'/>
-      <return type-id='type-id-1108'/>
+      <parameter type-id='type-id-1109'/>
+      <return type-id='type-id-1109'/>
     </function-decl>
-    <function-decl name='_PyPegen_join_names_with_dot' filepath='Parser/pegen.h' line='302' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_PyPegen_join_names_with_dot' filepath='Parser/pegen.h' line='303' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-577'/>
       <parameter type-id='type-id-511'/>
       <parameter type-id='type-id-511'/>
       <return type-id='type-id-511'/>
     </function-decl>
-    <function-decl name='_PyPegen_seq_count_dots' filepath='Parser/pegen.h' line='303' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-1108'/>
+    <function-decl name='_PyPegen_seq_count_dots' filepath='Parser/pegen.h' line='304' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-1109'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='_PyPegen_alias_for_star' filepath='Parser/pegen.h' line='304' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_PyPegen_alias_for_star' filepath='Parser/pegen.h' line='305' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-577'/>
       <parameter type-id='type-id-8'/>
       <parameter type-id='type-id-8'/>
@@ -18731,104 +18746,104 @@
       <parameter type-id='type-id-572'/>
       <return type-id='type-id-453'/>
     </function-decl>
-    <function-decl name='_PyPegen_map_names_to_ids' filepath='Parser/pegen.h' line='305' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_PyPegen_map_names_to_ids' filepath='Parser/pegen.h' line='306' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-577'/>
       <parameter type-id='type-id-512'/>
       <return type-id='type-id-544'/>
     </function-decl>
-    <function-decl name='_PyPegen_cmpop_expr_pair' filepath='Parser/pegen.h' line='306' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_PyPegen_cmpop_expr_pair' filepath='Parser/pegen.h' line='307' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-577'/>
-      <parameter type-id='type-id-1097'/>
+      <parameter type-id='type-id-1098'/>
       <parameter type-id='type-id-511'/>
-      <return type-id='type-id-1120'/>
+      <return type-id='type-id-1121'/>
     </function-decl>
-    <function-decl name='_PyPegen_get_cmpops' filepath='Parser/pegen.h' line='307' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_PyPegen_get_cmpops' filepath='Parser/pegen.h' line='308' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-577'/>
-      <parameter type-id='type-id-1108'/>
+      <parameter type-id='type-id-1109'/>
       <return type-id='type-id-573'/>
     </function-decl>
-    <function-decl name='_PyPegen_get_exprs' filepath='Parser/pegen.h' line='308' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_PyPegen_get_exprs' filepath='Parser/pegen.h' line='309' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-577'/>
-      <parameter type-id='type-id-1108'/>
+      <parameter type-id='type-id-1109'/>
       <return type-id='type-id-512'/>
     </function-decl>
-    <function-decl name='_PyPegen_set_expr_context' filepath='Parser/pegen.h' line='309' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_PyPegen_set_expr_context' filepath='Parser/pegen.h' line='310' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-577'/>
       <parameter type-id='type-id-511'/>
       <parameter type-id='type-id-575'/>
       <return type-id='type-id-511'/>
     </function-decl>
-    <function-decl name='_PyPegen_key_value_pair' filepath='Parser/pegen.h' line='310' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_PyPegen_key_value_pair' filepath='Parser/pegen.h' line='311' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-577'/>
       <parameter type-id='type-id-511'/>
       <parameter type-id='type-id-511'/>
-      <return type-id='type-id-1122'/>
+      <return type-id='type-id-1123'/>
     </function-decl>
-    <function-decl name='_PyPegen_get_keys' filepath='Parser/pegen.h' line='311' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_PyPegen_get_keys' filepath='Parser/pegen.h' line='312' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-577'/>
-      <parameter type-id='type-id-1108'/>
+      <parameter type-id='type-id-1109'/>
       <return type-id='type-id-512'/>
     </function-decl>
-    <function-decl name='_PyPegen_get_values' filepath='Parser/pegen.h' line='312' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_PyPegen_get_values' filepath='Parser/pegen.h' line='313' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-577'/>
-      <parameter type-id='type-id-1108'/>
+      <parameter type-id='type-id-1109'/>
       <return type-id='type-id-512'/>
     </function-decl>
-    <function-decl name='_PyPegen_key_pattern_pair' filepath='Parser/pegen.h' line='313' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_PyPegen_key_pattern_pair' filepath='Parser/pegen.h' line='314' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-577'/>
       <parameter type-id='type-id-511'/>
       <parameter type-id='type-id-459'/>
-      <return type-id='type-id-1121'/>
+      <return type-id='type-id-1122'/>
     </function-decl>
-    <function-decl name='_PyPegen_get_pattern_keys' filepath='Parser/pegen.h' line='314' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_PyPegen_get_pattern_keys' filepath='Parser/pegen.h' line='315' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-577'/>
-      <parameter type-id='type-id-1108'/>
+      <parameter type-id='type-id-1109'/>
       <return type-id='type-id-512'/>
     </function-decl>
-    <function-decl name='_PyPegen_get_patterns' filepath='Parser/pegen.h' line='315' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_PyPegen_get_patterns' filepath='Parser/pegen.h' line='316' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-577'/>
-      <parameter type-id='type-id-1108'/>
+      <parameter type-id='type-id-1109'/>
       <return type-id='type-id-562'/>
     </function-decl>
-    <function-decl name='_PyPegen_name_default_pair' filepath='Parser/pegen.h' line='316' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_PyPegen_name_default_pair' filepath='Parser/pegen.h' line='317' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-577'/>
       <parameter type-id='type-id-576'/>
       <parameter type-id='type-id-511'/>
       <parameter type-id='type-id-578'/>
-      <return type-id='type-id-1124'/>
+      <return type-id='type-id-1125'/>
     </function-decl>
-    <function-decl name='_PyPegen_slash_with_default' filepath='Parser/pegen.h' line='317' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_PyPegen_slash_with_default' filepath='Parser/pegen.h' line='318' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-577'/>
       <parameter type-id='type-id-574'/>
-      <parameter type-id='type-id-1108'/>
-      <return type-id='type-id-1126'/>
-    </function-decl>
-    <function-decl name='_PyPegen_star_etc' filepath='Parser/pegen.h' line='318' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-577'/>
-      <parameter type-id='type-id-576'/>
-      <parameter type-id='type-id-1108'/>
-      <parameter type-id='type-id-576'/>
+      <parameter type-id='type-id-1109'/>
       <return type-id='type-id-1127'/>
     </function-decl>
-    <function-decl name='_PyPegen_make_arguments' filepath='Parser/pegen.h' line='319' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_PyPegen_star_etc' filepath='Parser/pegen.h' line='319' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-577'/>
+      <parameter type-id='type-id-576'/>
+      <parameter type-id='type-id-1109'/>
+      <parameter type-id='type-id-576'/>
+      <return type-id='type-id-1128'/>
+    </function-decl>
+    <function-decl name='_PyPegen_make_arguments' filepath='Parser/pegen.h' line='320' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-577'/>
       <parameter type-id='type-id-574'/>
-      <parameter type-id='type-id-1126'/>
-      <parameter type-id='type-id-574'/>
-      <parameter type-id='type-id-1108'/>
       <parameter type-id='type-id-1127'/>
+      <parameter type-id='type-id-574'/>
+      <parameter type-id='type-id-1109'/>
+      <parameter type-id='type-id-1128'/>
       <return type-id='type-id-535'/>
     </function-decl>
-    <function-decl name='_PyPegen_empty_arguments' filepath='Parser/pegen.h' line='321' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_PyPegen_empty_arguments' filepath='Parser/pegen.h' line='322' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-577'/>
       <return type-id='type-id-535'/>
     </function-decl>
-    <function-decl name='_PyPegen_formatted_value' filepath='Parser/pegen.h' line='322' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_PyPegen_formatted_value' filepath='Parser/pegen.h' line='323' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-577'/>
       <parameter type-id='type-id-511'/>
       <parameter type-id='type-id-578'/>
-      <parameter type-id='type-id-1125'/>
-      <parameter type-id='type-id-1125'/>
+      <parameter type-id='type-id-1126'/>
+      <parameter type-id='type-id-1126'/>
       <parameter type-id='type-id-578'/>
       <parameter type-id='type-id-8'/>
       <parameter type-id='type-id-8'/>
@@ -18837,43 +18852,43 @@
       <parameter type-id='type-id-572'/>
       <return type-id='type-id-511'/>
     </function-decl>
-    <function-decl name='_PyPegen_augoperator' filepath='Parser/pegen.h' line='324' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_PyPegen_augoperator' filepath='Parser/pegen.h' line='325' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-577'/>
       <parameter type-id='type-id-539'/>
-      <return type-id='type-id-1119'/>
+      <return type-id='type-id-1120'/>
     </function-decl>
-    <function-decl name='_PyPegen_function_def_decorators' filepath='Parser/pegen.h' line='325' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_PyPegen_function_def_decorators' filepath='Parser/pegen.h' line='326' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-577'/>
       <parameter type-id='type-id-512'/>
       <parameter type-id='type-id-461'/>
       <return type-id='type-id-461'/>
     </function-decl>
-    <function-decl name='_PyPegen_class_def_decorators' filepath='Parser/pegen.h' line='326' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_PyPegen_class_def_decorators' filepath='Parser/pegen.h' line='327' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-577'/>
       <parameter type-id='type-id-512'/>
       <parameter type-id='type-id-461'/>
       <return type-id='type-id-461'/>
     </function-decl>
-    <function-decl name='_PyPegen_keyword_or_starred' filepath='Parser/pegen.h' line='327' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_PyPegen_keyword_or_starred' filepath='Parser/pegen.h' line='328' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-577'/>
       <parameter type-id='type-id-22'/>
       <parameter type-id='type-id-8'/>
-      <return type-id='type-id-1123'/>
+      <return type-id='type-id-1124'/>
     </function-decl>
-    <function-decl name='_PyPegen_seq_extract_starred_exprs' filepath='Parser/pegen.h' line='328' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_PyPegen_seq_extract_starred_exprs' filepath='Parser/pegen.h' line='329' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-577'/>
-      <parameter type-id='type-id-1108'/>
+      <parameter type-id='type-id-1109'/>
       <return type-id='type-id-512'/>
     </function-decl>
-    <function-decl name='_PyPegen_seq_delete_starred_exprs' filepath='Parser/pegen.h' line='329' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_PyPegen_seq_delete_starred_exprs' filepath='Parser/pegen.h' line='330' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-577'/>
-      <parameter type-id='type-id-1108'/>
+      <parameter type-id='type-id-1109'/>
       <return type-id='type-id-538'/>
     </function-decl>
-    <function-decl name='_PyPegen_collect_call_seqs' filepath='Parser/pegen.h' line='330' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_PyPegen_collect_call_seqs' filepath='Parser/pegen.h' line='331' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-577'/>
       <parameter type-id='type-id-512'/>
-      <parameter type-id='type-id-1108'/>
+      <parameter type-id='type-id-1109'/>
       <parameter type-id='type-id-8'/>
       <parameter type-id='type-id-8'/>
       <parameter type-id='type-id-8'/>
@@ -18881,22 +18896,22 @@
       <parameter type-id='type-id-572'/>
       <return type-id='type-id-511'/>
     </function-decl>
-    <function-decl name='_PyPegen_constant_from_token' filepath='Parser/pegen.h' line='333' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_PyPegen_constant_from_token' filepath='Parser/pegen.h' line='334' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-577'/>
       <parameter type-id='type-id-578'/>
       <return type-id='type-id-511'/>
     </function-decl>
-    <function-decl name='_PyPegen_decoded_constant_from_token' filepath='Parser/pegen.h' line='334' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_PyPegen_decoded_constant_from_token' filepath='Parser/pegen.h' line='335' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-577'/>
       <parameter type-id='type-id-578'/>
       <return type-id='type-id-511'/>
     </function-decl>
-    <function-decl name='_PyPegen_constant_from_string' filepath='Parser/pegen.h' line='335' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_PyPegen_constant_from_string' filepath='Parser/pegen.h' line='336' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-577'/>
       <parameter type-id='type-id-578'/>
       <return type-id='type-id-511'/>
     </function-decl>
-    <function-decl name='_PyPegen_concatenate_strings' filepath='Parser/pegen.h' line='336' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_PyPegen_concatenate_strings' filepath='Parser/pegen.h' line='337' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-577'/>
       <parameter type-id='type-id-512'/>
       <parameter type-id='type-id-8'/>
@@ -18906,39 +18921,39 @@
       <parameter type-id='type-id-572'/>
       <return type-id='type-id-511'/>
     </function-decl>
-    <function-decl name='_PyPegen_ensure_imaginary' filepath='Parser/pegen.h' line='338' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_PyPegen_ensure_imaginary' filepath='Parser/pegen.h' line='339' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-577'/>
       <parameter type-id='type-id-511'/>
       <return type-id='type-id-511'/>
     </function-decl>
-    <function-decl name='_PyPegen_ensure_real' filepath='Parser/pegen.h' line='339' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_PyPegen_ensure_real' filepath='Parser/pegen.h' line='340' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-577'/>
       <parameter type-id='type-id-511'/>
       <return type-id='type-id-511'/>
     </function-decl>
-    <function-decl name='_PyPegen_join_sequences' filepath='Parser/pegen.h' line='340' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_PyPegen_join_sequences' filepath='Parser/pegen.h' line='341' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-577'/>
-      <parameter type-id='type-id-1108'/>
-      <parameter type-id='type-id-1108'/>
-      <return type-id='type-id-1108'/>
+      <parameter type-id='type-id-1109'/>
+      <parameter type-id='type-id-1109'/>
+      <return type-id='type-id-1109'/>
     </function-decl>
-    <function-decl name='_PyPegen_check_barry_as_flufl' filepath='Parser/pegen.h' line='341' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_PyPegen_check_barry_as_flufl' filepath='Parser/pegen.h' line='342' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-577'/>
       <parameter type-id='type-id-578'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='_PyPegen_check_legacy_stmt' filepath='Parser/pegen.h' line='342' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_PyPegen_check_legacy_stmt' filepath='Parser/pegen.h' line='343' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-577'/>
       <parameter type-id='type-id-511'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='_PyPegen_check_fstring_conversion' filepath='Parser/pegen.h' line='343' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_PyPegen_check_fstring_conversion' filepath='Parser/pegen.h' line='344' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-577'/>
       <parameter type-id='type-id-578'/>
       <parameter type-id='type-id-511'/>
-      <return type-id='type-id-1125'/>
+      <return type-id='type-id-1126'/>
     </function-decl>
-    <function-decl name='_PyPegen_setup_full_format_spec' filepath='Parser/pegen.h' line='344' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_PyPegen_setup_full_format_spec' filepath='Parser/pegen.h' line='345' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-577'/>
       <parameter type-id='type-id-578'/>
       <parameter type-id='type-id-512'/>
@@ -18947,60 +18962,60 @@
       <parameter type-id='type-id-8'/>
       <parameter type-id='type-id-8'/>
       <parameter type-id='type-id-572'/>
-      <return type-id='type-id-1125'/>
+      <return type-id='type-id-1126'/>
     </function-decl>
-    <function-decl name='_PyPegen_make_module' filepath='Parser/pegen.h' line='346' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_PyPegen_make_module' filepath='Parser/pegen.h' line='347' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-577'/>
       <parameter type-id='type-id-509'/>
       <return type-id='type-id-477'/>
     </function-decl>
-    <function-decl name='_PyPegen_arguments_parsing_error' filepath='Parser/pegen.h' line='347' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_PyPegen_arguments_parsing_error' filepath='Parser/pegen.h' line='348' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-577'/>
       <parameter type-id='type-id-511'/>
       <return type-id='type-id-22'/>
     </function-decl>
-    <function-decl name='_PyPegen_get_last_comprehension_item' filepath='Parser/pegen.h' line='348' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-1146'/>
+    <function-decl name='_PyPegen_get_last_comprehension_item' filepath='Parser/pegen.h' line='349' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-1147'/>
       <return type-id='type-id-511'/>
     </function-decl>
-    <function-decl name='_PyPegen_nonparen_genexp_in_call' filepath='Parser/pegen.h' line='349' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_PyPegen_nonparen_genexp_in_call' filepath='Parser/pegen.h' line='350' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-577'/>
       <parameter type-id='type-id-511'/>
-      <parameter type-id='type-id-1145'/>
+      <parameter type-id='type-id-1146'/>
       <return type-id='type-id-22'/>
     </function-decl>
-    <function-decl name='_PyPegen_interactive_exit' filepath='Parser/pegen.h' line='359' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_PyPegen_interactive_exit' filepath='Parser/pegen.h' line='360' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-577'/>
       <return type-id='type-id-509'/>
     </function-decl>
-    <function-decl name='_PyPegen_joined_str' filepath='Parser/pegen.h' line='362' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_PyPegen_joined_str' filepath='Parser/pegen.h' line='363' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-577'/>
       <parameter type-id='type-id-578'/>
       <parameter type-id='type-id-512'/>
       <parameter type-id='type-id-578'/>
       <return type-id='type-id-511'/>
     </function-decl>
-    <function-type size-in-bits='64' id='type-id-1128'>
+    <function-type size-in-bits='64' id='type-id-1129'>
       <parameter type-id='type-id-577'/>
       <parameter type-id='type-id-8'/>
       <return type-id='type-id-578'/>
     </function-type>
-    <function-type size-in-bits='64' id='type-id-1130'>
+    <function-type size-in-bits='64' id='type-id-1131'>
       <parameter type-id='type-id-577'/>
       <return type-id='type-id-511'/>
     </function-type>
-    <function-type size-in-bits='64' id='type-id-1132'>
+    <function-type size-in-bits='64' id='type-id-1133'>
       <parameter type-id='type-id-577'/>
       <parameter type-id='type-id-12'/>
       <return type-id='type-id-511'/>
     </function-type>
-    <function-type size-in-bits='64' id='type-id-1134'>
+    <function-type size-in-bits='64' id='type-id-1135'>
       <parameter type-id='type-id-577'/>
       <return type-id='type-id-22'/>
     </function-type>
   </abi-instr>
   <abi-instr address-size='64' path='Parser/peg_api.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
-    <class-decl name='PyCompilerFlags' size-in-bits='64' is-struct='yes' naming-typedef-id='type-id-1148' visibility='default' filepath='./Include/cpython/compile.h' line='26' column='1' id='type-id-1149'>
+    <class-decl name='PyCompilerFlags' size-in-bits='64' is-struct='yes' naming-typedef-id='type-id-1149' visibility='default' filepath='./Include/cpython/compile.h' line='26' column='1' id='type-id-1150'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='cf_flags' type-id='type-id-8' visibility='default' filepath='./Include/cpython/compile.h' line='27' column='1'/>
       </data-member>
@@ -19008,15 +19023,15 @@
         <var-decl name='cf_feature_version' type-id='type-id-8' visibility='default' filepath='./Include/cpython/compile.h' line='28' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='PyCompilerFlags' type-id='type-id-1149' filepath='./Include/cpython/compile.h' line='29' column='1' id='type-id-1148'/>
-    <pointer-type-def type-id='type-id-1148' size-in-bits='64' id='type-id-208'/>
+    <typedef-decl name='PyCompilerFlags' type-id='type-id-1150' filepath='./Include/cpython/compile.h' line='29' column='1' id='type-id-1149'/>
+    <pointer-type-def type-id='type-id-1149' size-in-bits='64' id='type-id-208'/>
     <function-decl name='PySys_Audit' mangled-name='PySys_Audit' filepath='./Include/cpython/sysmodule.h' line='12' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PySys_Audit'>
       <parameter type-id='type-id-12'/>
       <parameter type-id='type-id-12'/>
       <parameter is-variadic='yes'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='_PyPegen_run_parser_from_file_pointer' filepath='Parser/pegen.h' line='355' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_PyPegen_run_parser_from_file_pointer' filepath='Parser/pegen.h' line='356' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-229'/>
       <parameter type-id='type-id-8'/>
       <parameter type-id='type-id-2'/>
@@ -19028,7 +19043,7 @@
       <parameter type-id='type-id-572'/>
       <return type-id='type-id-477'/>
     </function-decl>
-    <function-decl name='_PyPegen_run_parser_from_string' filepath='Parser/pegen.h' line='358' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_PyPegen_run_parser_from_string' filepath='Parser/pegen.h' line='359' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-12'/>
       <parameter type-id='type-id-8'/>
       <parameter type-id='type-id-2'/>
@@ -19038,22 +19053,22 @@
     </function-decl>
   </abi-instr>
   <abi-instr address-size='64' path='Parser/pegen.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
-    <array-type-def dimensions='1' type-id='type-id-576' size-in-bits='64' id='type-id-1150'>
+    <array-type-def dimensions='1' type-id='type-id-576' size-in-bits='64' id='type-id-1151'>
       <subrange length='1' type-id='type-id-28' id='type-id-452'/>
     </array-type-def>
     <array-type-def dimensions='1' type-id='type-id-48' size-in-bits='8' id='type-id-711'>
       <subrange length='1' type-id='type-id-28' id='type-id-452'/>
     </array-type-def>
-    <array-type-def dimensions='1' type-id='type-id-48' size-in-bits='1600' id='type-id-1138'>
+    <array-type-def dimensions='1' type-id='type-id-48' size-in-bits='1600' id='type-id-1139'>
       <subrange length='200' type-id='type-id-28' id='type-id-653'/>
     </array-type-def>
-    <array-type-def dimensions='1' type-id='type-id-48' size-in-bits='160' id='type-id-1151'>
+    <array-type-def dimensions='1' type-id='type-id-48' size-in-bits='160' id='type-id-1152'>
       <subrange length='20' type-id='type-id-28' id='type-id-598'/>
     </array-type-def>
-    <class-decl name='_IO_codecvt' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-1152'/>
-    <class-decl name='_IO_marker' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-1153'/>
-    <class-decl name='_IO_wide_data' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-1154'/>
-    <class-decl name='__va_list_tag' size-in-bits='192' is-struct='yes' visibility='default' id='type-id-1155'>
+    <class-decl name='_IO_codecvt' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-1153'/>
+    <class-decl name='_IO_marker' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-1154'/>
+    <class-decl name='_IO_wide_data' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-1155'/>
+    <class-decl name='__va_list_tag' size-in-bits='192' is-struct='yes' visibility='default' id='type-id-1156'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='gp_offset' type-id='type-id-95' visibility='default'/>
       </data-member>
@@ -19067,32 +19082,32 @@
         <var-decl name='reg_save_area' type-id='type-id-22' visibility='default'/>
       </data-member>
     </class-decl>
-    <class-decl name='_arena' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-1156'/>
-    <array-type-def dimensions='1' type-id='type-id-1146' size-in-bits='64' id='type-id-1157'>
+    <class-decl name='_arena' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-1157'/>
+    <array-type-def dimensions='1' type-id='type-id-1147' size-in-bits='64' id='type-id-1158'>
       <subrange length='1' type-id='type-id-28' id='type-id-452'/>
     </array-type-def>
     <type-decl name='double' size-in-bits='64' id='type-id-251'/>
-    <array-type-def dimensions='1' type-id='type-id-511' size-in-bits='64' id='type-id-1158'>
+    <array-type-def dimensions='1' type-id='type-id-511' size-in-bits='64' id='type-id-1159'>
       <subrange length='1' type-id='type-id-28' id='type-id-452'/>
     </array-type-def>
-    <array-type-def dimensions='1' type-id='type-id-8' size-in-bits='3200' id='type-id-1137'>
-      <subrange length='100' type-id='type-id-28' id='type-id-1159'/>
+    <array-type-def dimensions='1' type-id='type-id-8' size-in-bits='3200' id='type-id-1138'>
+      <subrange length='100' type-id='type-id-28' id='type-id-1160'/>
     </array-type-def>
-    <array-type-def dimensions='1' type-id='type-id-8' size-in-bits='32' id='type-id-1160'>
+    <array-type-def dimensions='1' type-id='type-id-8' size-in-bits='32' id='type-id-1161'>
       <subrange length='1' type-id='type-id-28' id='type-id-452'/>
     </array-type-def>
-    <array-type-def dimensions='1' type-id='type-id-8' size-in-bits='6400' id='type-id-1139'>
+    <array-type-def dimensions='1' type-id='type-id-8' size-in-bits='6400' id='type-id-1140'>
       <subrange length='200' type-id='type-id-28' id='type-id-653'/>
     </array-type-def>
-    <array-type-def dimensions='1' type-id='type-id-1147' size-in-bits='64' id='type-id-1161'>
+    <array-type-def dimensions='1' type-id='type-id-1148' size-in-bits='64' id='type-id-1162'>
       <subrange length='1' type-id='type-id-28' id='type-id-452'/>
     </array-type-def>
     <type-decl name='long int' size-in-bits='64' id='type-id-47'/>
-    <type-decl name='signed char' size-in-bits='8' id='type-id-1041'/>
-    <array-type-def dimensions='1' type-id='type-id-1162' size-in-bits='115200' id='type-id-1142'>
-      <subrange length='150' type-id='type-id-28' id='type-id-1163'/>
+    <type-decl name='signed char' size-in-bits='8' id='type-id-1042'/>
+    <array-type-def dimensions='1' type-id='type-id-1163' size-in-bits='115200' id='type-id-1143'>
+      <subrange length='150' type-id='type-id-28' id='type-id-1164'/>
     </array-type-def>
-    <array-type-def dimensions='1' type-id='type-id-352' size-in-bits='64' id='type-id-1164'>
+    <array-type-def dimensions='1' type-id='type-id-352' size-in-bits='64' id='type-id-1165'>
       <subrange length='2' type-id='type-id-28' id='type-id-690'/>
     </array-type-def>
     <type-decl name='unnamed-enum-underlying-type-32' is-anonymous='yes' size-in-bits='32' alignment-in-bits='32' id='type-id-24'/>
@@ -19100,7 +19115,7 @@
     <type-decl name='unsigned int' size-in-bits='32' id='type-id-95'/>
     <type-decl name='unsigned short int' size-in-bits='16' id='type-id-84'/>
     <type-decl name='void' id='type-id-46'/>
-    <class-decl name='Py_complex' size-in-bits='128' is-struct='yes' naming-typedef-id='type-id-327' visibility='default' filepath='./Include/cpython/complexobject.h' line='5' column='1' id='type-id-1165'>
+    <class-decl name='Py_complex' size-in-bits='128' is-struct='yes' naming-typedef-id='type-id-327' visibility='default' filepath='./Include/cpython/complexobject.h' line='5' column='1' id='type-id-1166'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='real' type-id='type-id-251' visibility='default' filepath='./Include/cpython/complexobject.h' line='6' column='1'/>
       </data-member>
@@ -19108,189 +19123,189 @@
         <var-decl name='imag' type-id='type-id-251' visibility='default' filepath='./Include/cpython/complexobject.h' line='7' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='Py_complex' type-id='type-id-1165' filepath='./Include/cpython/complexobject.h' line='8' column='1' id='type-id-327'/>
-    <class-decl name='PyNumberMethods' size-in-bits='2304' is-struct='yes' naming-typedef-id='type-id-1166' visibility='default' filepath='./Include/cpython/object.h' line='59' column='1' id='type-id-1167'>
+    <typedef-decl name='Py_complex' type-id='type-id-1166' filepath='./Include/cpython/complexobject.h' line='8' column='1' id='type-id-327'/>
+    <class-decl name='PyNumberMethods' size-in-bits='2304' is-struct='yes' naming-typedef-id='type-id-1167' visibility='default' filepath='./Include/cpython/object.h' line='59' column='1' id='type-id-1168'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='nb_add' type-id='type-id-1168' visibility='default' filepath='./Include/cpython/object.h' line='64' column='1'/>
+        <var-decl name='nb_add' type-id='type-id-1169' visibility='default' filepath='./Include/cpython/object.h' line='64' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='nb_subtract' type-id='type-id-1168' visibility='default' filepath='./Include/cpython/object.h' line='65' column='1'/>
+        <var-decl name='nb_subtract' type-id='type-id-1169' visibility='default' filepath='./Include/cpython/object.h' line='65' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='nb_multiply' type-id='type-id-1168' visibility='default' filepath='./Include/cpython/object.h' line='66' column='1'/>
+        <var-decl name='nb_multiply' type-id='type-id-1169' visibility='default' filepath='./Include/cpython/object.h' line='66' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='nb_remainder' type-id='type-id-1168' visibility='default' filepath='./Include/cpython/object.h' line='67' column='1'/>
+        <var-decl name='nb_remainder' type-id='type-id-1169' visibility='default' filepath='./Include/cpython/object.h' line='67' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='nb_divmod' type-id='type-id-1168' visibility='default' filepath='./Include/cpython/object.h' line='68' column='1'/>
+        <var-decl name='nb_divmod' type-id='type-id-1169' visibility='default' filepath='./Include/cpython/object.h' line='68' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='nb_power' type-id='type-id-1169' visibility='default' filepath='./Include/cpython/object.h' line='69' column='1'/>
+        <var-decl name='nb_power' type-id='type-id-1170' visibility='default' filepath='./Include/cpython/object.h' line='69' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='384'>
-        <var-decl name='nb_negative' type-id='type-id-1170' visibility='default' filepath='./Include/cpython/object.h' line='70' column='1'/>
+        <var-decl name='nb_negative' type-id='type-id-1171' visibility='default' filepath='./Include/cpython/object.h' line='70' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='448'>
-        <var-decl name='nb_positive' type-id='type-id-1170' visibility='default' filepath='./Include/cpython/object.h' line='71' column='1'/>
+        <var-decl name='nb_positive' type-id='type-id-1171' visibility='default' filepath='./Include/cpython/object.h' line='71' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='512'>
-        <var-decl name='nb_absolute' type-id='type-id-1170' visibility='default' filepath='./Include/cpython/object.h' line='72' column='1'/>
+        <var-decl name='nb_absolute' type-id='type-id-1171' visibility='default' filepath='./Include/cpython/object.h' line='72' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='576'>
         <var-decl name='nb_bool' type-id='type-id-396' visibility='default' filepath='./Include/cpython/object.h' line='73' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='640'>
-        <var-decl name='nb_invert' type-id='type-id-1170' visibility='default' filepath='./Include/cpython/object.h' line='74' column='1'/>
+        <var-decl name='nb_invert' type-id='type-id-1171' visibility='default' filepath='./Include/cpython/object.h' line='74' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='704'>
-        <var-decl name='nb_lshift' type-id='type-id-1168' visibility='default' filepath='./Include/cpython/object.h' line='75' column='1'/>
+        <var-decl name='nb_lshift' type-id='type-id-1169' visibility='default' filepath='./Include/cpython/object.h' line='75' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='768'>
-        <var-decl name='nb_rshift' type-id='type-id-1168' visibility='default' filepath='./Include/cpython/object.h' line='76' column='1'/>
+        <var-decl name='nb_rshift' type-id='type-id-1169' visibility='default' filepath='./Include/cpython/object.h' line='76' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='832'>
-        <var-decl name='nb_and' type-id='type-id-1168' visibility='default' filepath='./Include/cpython/object.h' line='77' column='1'/>
+        <var-decl name='nb_and' type-id='type-id-1169' visibility='default' filepath='./Include/cpython/object.h' line='77' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='896'>
-        <var-decl name='nb_xor' type-id='type-id-1168' visibility='default' filepath='./Include/cpython/object.h' line='78' column='1'/>
+        <var-decl name='nb_xor' type-id='type-id-1169' visibility='default' filepath='./Include/cpython/object.h' line='78' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='960'>
-        <var-decl name='nb_or' type-id='type-id-1168' visibility='default' filepath='./Include/cpython/object.h' line='79' column='1'/>
+        <var-decl name='nb_or' type-id='type-id-1169' visibility='default' filepath='./Include/cpython/object.h' line='79' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1024'>
-        <var-decl name='nb_int' type-id='type-id-1170' visibility='default' filepath='./Include/cpython/object.h' line='80' column='1'/>
+        <var-decl name='nb_int' type-id='type-id-1171' visibility='default' filepath='./Include/cpython/object.h' line='80' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1088'>
         <var-decl name='nb_reserved' type-id='type-id-22' visibility='default' filepath='./Include/cpython/object.h' line='81' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1152'>
-        <var-decl name='nb_float' type-id='type-id-1170' visibility='default' filepath='./Include/cpython/object.h' line='82' column='1'/>
+        <var-decl name='nb_float' type-id='type-id-1171' visibility='default' filepath='./Include/cpython/object.h' line='82' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1216'>
-        <var-decl name='nb_inplace_add' type-id='type-id-1168' visibility='default' filepath='./Include/cpython/object.h' line='84' column='1'/>
+        <var-decl name='nb_inplace_add' type-id='type-id-1169' visibility='default' filepath='./Include/cpython/object.h' line='84' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1280'>
-        <var-decl name='nb_inplace_subtract' type-id='type-id-1168' visibility='default' filepath='./Include/cpython/object.h' line='85' column='1'/>
+        <var-decl name='nb_inplace_subtract' type-id='type-id-1169' visibility='default' filepath='./Include/cpython/object.h' line='85' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1344'>
-        <var-decl name='nb_inplace_multiply' type-id='type-id-1168' visibility='default' filepath='./Include/cpython/object.h' line='86' column='1'/>
+        <var-decl name='nb_inplace_multiply' type-id='type-id-1169' visibility='default' filepath='./Include/cpython/object.h' line='86' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1408'>
-        <var-decl name='nb_inplace_remainder' type-id='type-id-1168' visibility='default' filepath='./Include/cpython/object.h' line='87' column='1'/>
+        <var-decl name='nb_inplace_remainder' type-id='type-id-1169' visibility='default' filepath='./Include/cpython/object.h' line='87' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1472'>
-        <var-decl name='nb_inplace_power' type-id='type-id-1169' visibility='default' filepath='./Include/cpython/object.h' line='88' column='1'/>
+        <var-decl name='nb_inplace_power' type-id='type-id-1170' visibility='default' filepath='./Include/cpython/object.h' line='88' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1536'>
-        <var-decl name='nb_inplace_lshift' type-id='type-id-1168' visibility='default' filepath='./Include/cpython/object.h' line='89' column='1'/>
+        <var-decl name='nb_inplace_lshift' type-id='type-id-1169' visibility='default' filepath='./Include/cpython/object.h' line='89' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1600'>
-        <var-decl name='nb_inplace_rshift' type-id='type-id-1168' visibility='default' filepath='./Include/cpython/object.h' line='90' column='1'/>
+        <var-decl name='nb_inplace_rshift' type-id='type-id-1169' visibility='default' filepath='./Include/cpython/object.h' line='90' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1664'>
-        <var-decl name='nb_inplace_and' type-id='type-id-1168' visibility='default' filepath='./Include/cpython/object.h' line='91' column='1'/>
+        <var-decl name='nb_inplace_and' type-id='type-id-1169' visibility='default' filepath='./Include/cpython/object.h' line='91' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1728'>
-        <var-decl name='nb_inplace_xor' type-id='type-id-1168' visibility='default' filepath='./Include/cpython/object.h' line='92' column='1'/>
+        <var-decl name='nb_inplace_xor' type-id='type-id-1169' visibility='default' filepath='./Include/cpython/object.h' line='92' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1792'>
-        <var-decl name='nb_inplace_or' type-id='type-id-1168' visibility='default' filepath='./Include/cpython/object.h' line='93' column='1'/>
+        <var-decl name='nb_inplace_or' type-id='type-id-1169' visibility='default' filepath='./Include/cpython/object.h' line='93' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1856'>
-        <var-decl name='nb_floor_divide' type-id='type-id-1168' visibility='default' filepath='./Include/cpython/object.h' line='95' column='1'/>
+        <var-decl name='nb_floor_divide' type-id='type-id-1169' visibility='default' filepath='./Include/cpython/object.h' line='95' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1920'>
-        <var-decl name='nb_true_divide' type-id='type-id-1168' visibility='default' filepath='./Include/cpython/object.h' line='96' column='1'/>
+        <var-decl name='nb_true_divide' type-id='type-id-1169' visibility='default' filepath='./Include/cpython/object.h' line='96' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1984'>
-        <var-decl name='nb_inplace_floor_divide' type-id='type-id-1168' visibility='default' filepath='./Include/cpython/object.h' line='97' column='1'/>
+        <var-decl name='nb_inplace_floor_divide' type-id='type-id-1169' visibility='default' filepath='./Include/cpython/object.h' line='97' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='2048'>
-        <var-decl name='nb_inplace_true_divide' type-id='type-id-1168' visibility='default' filepath='./Include/cpython/object.h' line='98' column='1'/>
+        <var-decl name='nb_inplace_true_divide' type-id='type-id-1169' visibility='default' filepath='./Include/cpython/object.h' line='98' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='2112'>
-        <var-decl name='nb_index' type-id='type-id-1170' visibility='default' filepath='./Include/cpython/object.h' line='100' column='1'/>
+        <var-decl name='nb_index' type-id='type-id-1171' visibility='default' filepath='./Include/cpython/object.h' line='100' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='2176'>
-        <var-decl name='nb_matrix_multiply' type-id='type-id-1168' visibility='default' filepath='./Include/cpython/object.h' line='102' column='1'/>
+        <var-decl name='nb_matrix_multiply' type-id='type-id-1169' visibility='default' filepath='./Include/cpython/object.h' line='102' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='2240'>
-        <var-decl name='nb_inplace_matrix_multiply' type-id='type-id-1168' visibility='default' filepath='./Include/cpython/object.h' line='103' column='1'/>
+        <var-decl name='nb_inplace_matrix_multiply' type-id='type-id-1169' visibility='default' filepath='./Include/cpython/object.h' line='103' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='PyNumberMethods' type-id='type-id-1167' filepath='./Include/cpython/object.h' line='104' column='1' id='type-id-1166'/>
-    <class-decl name='PySequenceMethods' size-in-bits='640' is-struct='yes' naming-typedef-id='type-id-1171' visibility='default' filepath='./Include/cpython/object.h' line='106' column='1' id='type-id-1172'>
+    <typedef-decl name='PyNumberMethods' type-id='type-id-1168' filepath='./Include/cpython/object.h' line='104' column='1' id='type-id-1167'/>
+    <class-decl name='PySequenceMethods' size-in-bits='640' is-struct='yes' naming-typedef-id='type-id-1172' visibility='default' filepath='./Include/cpython/object.h' line='106' column='1' id='type-id-1173'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='sq_length' type-id='type-id-1173' visibility='default' filepath='./Include/cpython/object.h' line='107' column='1'/>
+        <var-decl name='sq_length' type-id='type-id-1174' visibility='default' filepath='./Include/cpython/object.h' line='107' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='sq_concat' type-id='type-id-1168' visibility='default' filepath='./Include/cpython/object.h' line='108' column='1'/>
+        <var-decl name='sq_concat' type-id='type-id-1169' visibility='default' filepath='./Include/cpython/object.h' line='108' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='sq_repeat' type-id='type-id-1174' visibility='default' filepath='./Include/cpython/object.h' line='109' column='1'/>
+        <var-decl name='sq_repeat' type-id='type-id-1175' visibility='default' filepath='./Include/cpython/object.h' line='109' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='sq_item' type-id='type-id-1174' visibility='default' filepath='./Include/cpython/object.h' line='110' column='1'/>
+        <var-decl name='sq_item' type-id='type-id-1175' visibility='default' filepath='./Include/cpython/object.h' line='110' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='256'>
         <var-decl name='was_sq_slice' type-id='type-id-22' visibility='default' filepath='./Include/cpython/object.h' line='111' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='sq_ass_item' type-id='type-id-1175' visibility='default' filepath='./Include/cpython/object.h' line='112' column='1'/>
+        <var-decl name='sq_ass_item' type-id='type-id-1176' visibility='default' filepath='./Include/cpython/object.h' line='112' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='384'>
         <var-decl name='was_sq_ass_slice' type-id='type-id-22' visibility='default' filepath='./Include/cpython/object.h' line='113' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='448'>
-        <var-decl name='sq_contains' type-id='type-id-1176' visibility='default' filepath='./Include/cpython/object.h' line='114' column='1'/>
+        <var-decl name='sq_contains' type-id='type-id-1177' visibility='default' filepath='./Include/cpython/object.h' line='114' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='512'>
-        <var-decl name='sq_inplace_concat' type-id='type-id-1168' visibility='default' filepath='./Include/cpython/object.h' line='116' column='1'/>
+        <var-decl name='sq_inplace_concat' type-id='type-id-1169' visibility='default' filepath='./Include/cpython/object.h' line='116' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='576'>
-        <var-decl name='sq_inplace_repeat' type-id='type-id-1174' visibility='default' filepath='./Include/cpython/object.h' line='117' column='1'/>
+        <var-decl name='sq_inplace_repeat' type-id='type-id-1175' visibility='default' filepath='./Include/cpython/object.h' line='117' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='PySequenceMethods' type-id='type-id-1172' filepath='./Include/cpython/object.h' line='118' column='1' id='type-id-1171'/>
-    <class-decl name='PyMappingMethods' size-in-bits='192' is-struct='yes' naming-typedef-id='type-id-1177' visibility='default' filepath='./Include/cpython/object.h' line='120' column='1' id='type-id-1178'>
+    <typedef-decl name='PySequenceMethods' type-id='type-id-1173' filepath='./Include/cpython/object.h' line='118' column='1' id='type-id-1172'/>
+    <class-decl name='PyMappingMethods' size-in-bits='192' is-struct='yes' naming-typedef-id='type-id-1178' visibility='default' filepath='./Include/cpython/object.h' line='120' column='1' id='type-id-1179'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='mp_length' type-id='type-id-1173' visibility='default' filepath='./Include/cpython/object.h' line='121' column='1'/>
+        <var-decl name='mp_length' type-id='type-id-1174' visibility='default' filepath='./Include/cpython/object.h' line='121' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='mp_subscript' type-id='type-id-1168' visibility='default' filepath='./Include/cpython/object.h' line='122' column='1'/>
+        <var-decl name='mp_subscript' type-id='type-id-1169' visibility='default' filepath='./Include/cpython/object.h' line='122' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='mp_ass_subscript' type-id='type-id-1179' visibility='default' filepath='./Include/cpython/object.h' line='123' column='1'/>
+        <var-decl name='mp_ass_subscript' type-id='type-id-1180' visibility='default' filepath='./Include/cpython/object.h' line='123' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='PyMappingMethods' type-id='type-id-1178' filepath='./Include/cpython/object.h' line='124' column='1' id='type-id-1177'/>
-    <typedef-decl name='sendfunc' type-id='type-id-1180' filepath='./Include/cpython/object.h' line='126' column='1' id='type-id-1181'/>
-    <class-decl name='PyAsyncMethods' size-in-bits='256' is-struct='yes' naming-typedef-id='type-id-1182' visibility='default' filepath='./Include/cpython/object.h' line='128' column='1' id='type-id-1183'>
+    <typedef-decl name='PyMappingMethods' type-id='type-id-1179' filepath='./Include/cpython/object.h' line='124' column='1' id='type-id-1178'/>
+    <typedef-decl name='sendfunc' type-id='type-id-1181' filepath='./Include/cpython/object.h' line='126' column='1' id='type-id-1182'/>
+    <class-decl name='PyAsyncMethods' size-in-bits='256' is-struct='yes' naming-typedef-id='type-id-1183' visibility='default' filepath='./Include/cpython/object.h' line='128' column='1' id='type-id-1184'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='am_await' type-id='type-id-1170' visibility='default' filepath='./Include/cpython/object.h' line='129' column='1'/>
+        <var-decl name='am_await' type-id='type-id-1171' visibility='default' filepath='./Include/cpython/object.h' line='129' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='am_aiter' type-id='type-id-1170' visibility='default' filepath='./Include/cpython/object.h' line='130' column='1'/>
+        <var-decl name='am_aiter' type-id='type-id-1171' visibility='default' filepath='./Include/cpython/object.h' line='130' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='am_anext' type-id='type-id-1170' visibility='default' filepath='./Include/cpython/object.h' line='131' column='1'/>
+        <var-decl name='am_anext' type-id='type-id-1171' visibility='default' filepath='./Include/cpython/object.h' line='131' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='am_send' type-id='type-id-1181' visibility='default' filepath='./Include/cpython/object.h' line='132' column='1'/>
+        <var-decl name='am_send' type-id='type-id-1182' visibility='default' filepath='./Include/cpython/object.h' line='132' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='PyAsyncMethods' type-id='type-id-1183' filepath='./Include/cpython/object.h' line='133' column='1' id='type-id-1182'/>
-    <class-decl name='PyBufferProcs' size-in-bits='128' is-struct='yes' naming-typedef-id='type-id-1184' visibility='default' filepath='./Include/cpython/object.h' line='135' column='1' id='type-id-1185'>
+    <typedef-decl name='PyAsyncMethods' type-id='type-id-1184' filepath='./Include/cpython/object.h' line='133' column='1' id='type-id-1183'/>
+    <class-decl name='PyBufferProcs' size-in-bits='128' is-struct='yes' naming-typedef-id='type-id-1185' visibility='default' filepath='./Include/cpython/object.h' line='135' column='1' id='type-id-1186'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='bf_getbuffer' type-id='type-id-434' visibility='default' filepath='./Include/cpython/object.h' line='136' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='bf_releasebuffer' type-id='type-id-1186' visibility='default' filepath='./Include/cpython/object.h' line='137' column='1'/>
+        <var-decl name='bf_releasebuffer' type-id='type-id-1187' visibility='default' filepath='./Include/cpython/object.h' line='137' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='PyBufferProcs' type-id='type-id-1185' filepath='./Include/cpython/object.h' line='138' column='1' id='type-id-1184'/>
-    <class-decl name='_typeobject' size-in-bits='3328' is-struct='yes' visibility='default' filepath='./Include/cpython/object.h' line='146' column='1' id='type-id-1187'>
+    <typedef-decl name='PyBufferProcs' type-id='type-id-1186' filepath='./Include/cpython/object.h' line='138' column='1' id='type-id-1185'/>
+    <class-decl name='_typeobject' size-in-bits='3328' is-struct='yes' visibility='default' filepath='./Include/cpython/object.h' line='146' column='1' id='type-id-1188'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='ob_base' type-id='type-id-321' visibility='default' filepath='./Include/cpython/object.h' line='147' column='1'/>
       </data-member>
@@ -19310,43 +19325,43 @@
         <var-decl name='tp_vectorcall_offset' type-id='type-id-14' visibility='default' filepath='./Include/cpython/object.h' line='154' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='512'>
-        <var-decl name='tp_getattr' type-id='type-id-1188' visibility='default' filepath='./Include/cpython/object.h' line='155' column='1'/>
+        <var-decl name='tp_getattr' type-id='type-id-1189' visibility='default' filepath='./Include/cpython/object.h' line='155' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='576'>
-        <var-decl name='tp_setattr' type-id='type-id-1189' visibility='default' filepath='./Include/cpython/object.h' line='156' column='1'/>
+        <var-decl name='tp_setattr' type-id='type-id-1190' visibility='default' filepath='./Include/cpython/object.h' line='156' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='640'>
-        <var-decl name='tp_as_async' type-id='type-id-1190' visibility='default' filepath='./Include/cpython/object.h' line='157' column='1'/>
+        <var-decl name='tp_as_async' type-id='type-id-1191' visibility='default' filepath='./Include/cpython/object.h' line='157' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='704'>
-        <var-decl name='tp_repr' type-id='type-id-1191' visibility='default' filepath='./Include/cpython/object.h' line='159' column='1'/>
+        <var-decl name='tp_repr' type-id='type-id-1192' visibility='default' filepath='./Include/cpython/object.h' line='159' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='768'>
-        <var-decl name='tp_as_number' type-id='type-id-1192' visibility='default' filepath='./Include/cpython/object.h' line='163' column='1'/>
+        <var-decl name='tp_as_number' type-id='type-id-1193' visibility='default' filepath='./Include/cpython/object.h' line='163' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='832'>
-        <var-decl name='tp_as_sequence' type-id='type-id-1193' visibility='default' filepath='./Include/cpython/object.h' line='164' column='1'/>
+        <var-decl name='tp_as_sequence' type-id='type-id-1194' visibility='default' filepath='./Include/cpython/object.h' line='164' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='896'>
-        <var-decl name='tp_as_mapping' type-id='type-id-1194' visibility='default' filepath='./Include/cpython/object.h' line='165' column='1'/>
+        <var-decl name='tp_as_mapping' type-id='type-id-1195' visibility='default' filepath='./Include/cpython/object.h' line='165' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='960'>
-        <var-decl name='tp_hash' type-id='type-id-1195' visibility='default' filepath='./Include/cpython/object.h' line='169' column='1'/>
+        <var-decl name='tp_hash' type-id='type-id-1196' visibility='default' filepath='./Include/cpython/object.h' line='169' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1024'>
-        <var-decl name='tp_call' type-id='type-id-1169' visibility='default' filepath='./Include/cpython/object.h' line='170' column='1'/>
+        <var-decl name='tp_call' type-id='type-id-1170' visibility='default' filepath='./Include/cpython/object.h' line='170' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1088'>
-        <var-decl name='tp_str' type-id='type-id-1191' visibility='default' filepath='./Include/cpython/object.h' line='171' column='1'/>
+        <var-decl name='tp_str' type-id='type-id-1192' visibility='default' filepath='./Include/cpython/object.h' line='171' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1152'>
-        <var-decl name='tp_getattro' type-id='type-id-1196' visibility='default' filepath='./Include/cpython/object.h' line='172' column='1'/>
+        <var-decl name='tp_getattro' type-id='type-id-1197' visibility='default' filepath='./Include/cpython/object.h' line='172' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1216'>
-        <var-decl name='tp_setattro' type-id='type-id-1197' visibility='default' filepath='./Include/cpython/object.h' line='173' column='1'/>
+        <var-decl name='tp_setattro' type-id='type-id-1198' visibility='default' filepath='./Include/cpython/object.h' line='173' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1280'>
-        <var-decl name='tp_as_buffer' type-id='type-id-1198' visibility='default' filepath='./Include/cpython/object.h' line='176' column='1'/>
+        <var-decl name='tp_as_buffer' type-id='type-id-1199' visibility='default' filepath='./Include/cpython/object.h' line='176' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1344'>
         <var-decl name='tp_flags' type-id='type-id-28' visibility='default' filepath='./Include/cpython/object.h' line='179' column='1'/>
@@ -19361,16 +19376,16 @@
         <var-decl name='tp_clear' type-id='type-id-396' visibility='default' filepath='./Include/cpython/object.h' line='188' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1600'>
-        <var-decl name='tp_richcompare' type-id='type-id-1199' visibility='default' filepath='./Include/cpython/object.h' line='192' column='1'/>
+        <var-decl name='tp_richcompare' type-id='type-id-1200' visibility='default' filepath='./Include/cpython/object.h' line='192' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1664'>
         <var-decl name='tp_weaklistoffset' type-id='type-id-14' visibility='default' filepath='./Include/cpython/object.h' line='195' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1728'>
-        <var-decl name='tp_iter' type-id='type-id-1200' visibility='default' filepath='./Include/cpython/object.h' line='198' column='1'/>
+        <var-decl name='tp_iter' type-id='type-id-1201' visibility='default' filepath='./Include/cpython/object.h' line='198' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1792'>
-        <var-decl name='tp_iternext' type-id='type-id-1201' visibility='default' filepath='./Include/cpython/object.h' line='199' column='1'/>
+        <var-decl name='tp_iternext' type-id='type-id-1202' visibility='default' filepath='./Include/cpython/object.h' line='199' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1856'>
         <var-decl name='tp_methods' type-id='type-id-337' visibility='default' filepath='./Include/cpython/object.h' line='202' column='1'/>
@@ -19388,22 +19403,22 @@
         <var-decl name='tp_dict' type-id='type-id-2' visibility='default' filepath='./Include/cpython/object.h' line='207' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='2176'>
-        <var-decl name='tp_descr_get' type-id='type-id-1202' visibility='default' filepath='./Include/cpython/object.h' line='208' column='1'/>
+        <var-decl name='tp_descr_get' type-id='type-id-1203' visibility='default' filepath='./Include/cpython/object.h' line='208' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='2240'>
-        <var-decl name='tp_descr_set' type-id='type-id-1203' visibility='default' filepath='./Include/cpython/object.h' line='209' column='1'/>
+        <var-decl name='tp_descr_set' type-id='type-id-1204' visibility='default' filepath='./Include/cpython/object.h' line='209' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='2304'>
         <var-decl name='tp_dictoffset' type-id='type-id-14' visibility='default' filepath='./Include/cpython/object.h' line='210' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='2368'>
-        <var-decl name='tp_init' type-id='type-id-1204' visibility='default' filepath='./Include/cpython/object.h' line='211' column='1'/>
+        <var-decl name='tp_init' type-id='type-id-1205' visibility='default' filepath='./Include/cpython/object.h' line='211' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='2432'>
-        <var-decl name='tp_alloc' type-id='type-id-1205' visibility='default' filepath='./Include/cpython/object.h' line='212' column='1'/>
+        <var-decl name='tp_alloc' type-id='type-id-1206' visibility='default' filepath='./Include/cpython/object.h' line='212' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='2496'>
-        <var-decl name='tp_new' type-id='type-id-1206' visibility='default' filepath='./Include/cpython/object.h' line='213' column='1'/>
+        <var-decl name='tp_new' type-id='type-id-1207' visibility='default' filepath='./Include/cpython/object.h' line='213' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='2560'>
         <var-decl name='tp_free' type-id='type-id-397' visibility='default' filepath='./Include/cpython/object.h' line='214' column='1'/>
@@ -19442,17 +19457,17 @@
         <var-decl name='tp_watched' type-id='type-id-85' visibility='default' filepath='./Include/cpython/object.h' line='230' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='getter' type-id='type-id-741' filepath='./Include/descrobject.h' line='8' column='1' id='type-id-1207'/>
-    <typedef-decl name='setter' type-id='type-id-1208' filepath='./Include/descrobject.h' line='9' column='1' id='type-id-1209'/>
-    <class-decl name='PyGetSetDef' size-in-bits='320' is-struct='yes' visibility='default' filepath='./Include/descrobject.h' line='11' column='1' id='type-id-1210'>
+    <typedef-decl name='getter' type-id='type-id-741' filepath='./Include/descrobject.h' line='8' column='1' id='type-id-1208'/>
+    <typedef-decl name='setter' type-id='type-id-1209' filepath='./Include/descrobject.h' line='9' column='1' id='type-id-1210'/>
+    <class-decl name='PyGetSetDef' size-in-bits='320' is-struct='yes' visibility='default' filepath='./Include/descrobject.h' line='11' column='1' id='type-id-1211'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='name' type-id='type-id-12' visibility='default' filepath='./Include/descrobject.h' line='12' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='get' type-id='type-id-1207' visibility='default' filepath='./Include/descrobject.h' line='13' column='1'/>
+        <var-decl name='get' type-id='type-id-1208' visibility='default' filepath='./Include/descrobject.h' line='13' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='set' type-id='type-id-1209' visibility='default' filepath='./Include/descrobject.h' line='14' column='1'/>
+        <var-decl name='set' type-id='type-id-1210' visibility='default' filepath='./Include/descrobject.h' line='14' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='192'>
         <var-decl name='doc' type-id='type-id-12' visibility='default' filepath='./Include/descrobject.h' line='15' column='1'/>
@@ -19461,7 +19476,7 @@
         <var-decl name='closure' type-id='type-id-22' visibility='default' filepath='./Include/descrobject.h' line='16' column='1'/>
       </data-member>
     </class-decl>
-    <class-decl name='PyMemberDef' size-in-bits='320' is-struct='yes' visibility='default' filepath='./Include/descrobject.h' line='41' column='1' id='type-id-1211'>
+    <class-decl name='PyMemberDef' size-in-bits='320' is-struct='yes' visibility='default' filepath='./Include/descrobject.h' line='41' column='1' id='type-id-1212'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='name' type-id='type-id-12' visibility='default' filepath='./Include/descrobject.h' line='42' column='1'/>
       </data-member>
@@ -19481,7 +19496,7 @@
     <typedef-decl name='identifier' type-id='type-id-2' filepath='./Include/internal/pycore_asdl.h' line='13' column='1' id='type-id-534'/>
     <typedef-decl name='string' type-id='type-id-2' filepath='./Include/internal/pycore_asdl.h' line='14' column='1' id='type-id-536'/>
     <typedef-decl name='constant' type-id='type-id-2' filepath='./Include/internal/pycore_asdl.h' line='16' column='1' id='type-id-561'/>
-    <class-decl name='asdl_int_seq' size-in-bits='192' is-struct='yes' naming-typedef-id='type-id-1212' visibility='default' filepath='./Include/internal/pycore_asdl.h' line='42' column='1' id='type-id-1213'>
+    <class-decl name='asdl_int_seq' size-in-bits='192' is-struct='yes' naming-typedef-id='type-id-1213' visibility='default' filepath='./Include/internal/pycore_asdl.h' line='42' column='1' id='type-id-1214'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='size' type-id='type-id-14' visibility='default' filepath='./Include/internal/pycore_asdl.h' line='43' column='1'/>
       </data-member>
@@ -19489,25 +19504,25 @@
         <var-decl name='elements' type-id='type-id-253' visibility='default' filepath='./Include/internal/pycore_asdl.h' line='43' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='typed_elements' type-id='type-id-1160' visibility='default' filepath='./Include/internal/pycore_asdl.h' line='44' column='1'/>
+        <var-decl name='typed_elements' type-id='type-id-1161' visibility='default' filepath='./Include/internal/pycore_asdl.h' line='44' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='asdl_int_seq' type-id='type-id-1213' filepath='./Include/internal/pycore_asdl.h' line='45' column='1' id='type-id-1212'/>
-    <typedef-decl name='expr_ty' type-id='type-id-1214' filepath='./Include/internal/pycore_ast.h' line='19' column='1' id='type-id-511'/>
-    <enum-decl name='_expr_context' filepath='./Include/internal/pycore_ast.h' line='21' column='1' id='type-id-1215'>
+    <typedef-decl name='asdl_int_seq' type-id='type-id-1214' filepath='./Include/internal/pycore_asdl.h' line='45' column='1' id='type-id-1213'/>
+    <typedef-decl name='expr_ty' type-id='type-id-1215' filepath='./Include/internal/pycore_ast.h' line='19' column='1' id='type-id-511'/>
+    <enum-decl name='_expr_context' filepath='./Include/internal/pycore_ast.h' line='21' column='1' id='type-id-1216'>
       <underlying-type type-id='type-id-24'/>
       <enumerator name='Load' value='1'/>
       <enumerator name='Store' value='2'/>
       <enumerator name='Del' value='3'/>
     </enum-decl>
-    <typedef-decl name='expr_context_ty' type-id='type-id-1215' filepath='./Include/internal/pycore_ast.h' line='21' column='1' id='type-id-575'/>
-    <enum-decl name='_boolop' filepath='./Include/internal/pycore_ast.h' line='23' column='1' id='type-id-1216'>
+    <typedef-decl name='expr_context_ty' type-id='type-id-1216' filepath='./Include/internal/pycore_ast.h' line='21' column='1' id='type-id-575'/>
+    <enum-decl name='_boolop' filepath='./Include/internal/pycore_ast.h' line='23' column='1' id='type-id-1217'>
       <underlying-type type-id='type-id-24'/>
       <enumerator name='And' value='1'/>
       <enumerator name='Or' value='2'/>
     </enum-decl>
-    <typedef-decl name='boolop_ty' type-id='type-id-1216' filepath='./Include/internal/pycore_ast.h' line='23' column='1' id='type-id-1143'/>
-    <enum-decl name='_operator' filepath='./Include/internal/pycore_ast.h' line='25' column='1' id='type-id-1217'>
+    <typedef-decl name='boolop_ty' type-id='type-id-1217' filepath='./Include/internal/pycore_ast.h' line='23' column='1' id='type-id-1144'/>
+    <enum-decl name='_operator' filepath='./Include/internal/pycore_ast.h' line='25' column='1' id='type-id-1218'>
       <underlying-type type-id='type-id-24'/>
       <enumerator name='Add' value='1'/>
       <enumerator name='Sub' value='2'/>
@@ -19523,20 +19538,20 @@
       <enumerator name='BitAnd' value='12'/>
       <enumerator name='FloorDiv' value='13'/>
     </enum-decl>
-    <typedef-decl name='operator_ty' type-id='type-id-1217' filepath='./Include/internal/pycore_ast.h' line='27' column='1' id='type-id-539'/>
-    <enum-decl name='_unaryop' filepath='./Include/internal/pycore_ast.h' line='29' column='1' id='type-id-1218'>
+    <typedef-decl name='operator_ty' type-id='type-id-1218' filepath='./Include/internal/pycore_ast.h' line='27' column='1' id='type-id-539'/>
+    <enum-decl name='_unaryop' filepath='./Include/internal/pycore_ast.h' line='29' column='1' id='type-id-1219'>
       <underlying-type type-id='type-id-24'/>
       <enumerator name='Invert' value='1'/>
       <enumerator name='Not' value='2'/>
       <enumerator name='UAdd' value='3'/>
       <enumerator name='USub' value='4'/>
     </enum-decl>
-    <typedef-decl name='unaryop_ty' type-id='type-id-1218' filepath='./Include/internal/pycore_ast.h' line='29' column='1' id='type-id-1144'/>
-    <typedef-decl name='comprehension_ty' type-id='type-id-1219' filepath='./Include/internal/pycore_ast.h' line='34' column='1' id='type-id-1146'/>
-    <typedef-decl name='arguments_ty' type-id='type-id-1220' filepath='./Include/internal/pycore_ast.h' line='38' column='1' id='type-id-535'/>
-    <typedef-decl name='arg_ty' type-id='type-id-1221' filepath='./Include/internal/pycore_ast.h' line='40' column='1' id='type-id-576'/>
-    <typedef-decl name='keyword_ty' type-id='type-id-1222' filepath='./Include/internal/pycore_ast.h' line='42' column='1' id='type-id-1147'/>
-    <class-decl name='asdl_expr_seq' size-in-bits='192' is-struct='yes' naming-typedef-id='type-id-1223' visibility='default' filepath='./Include/internal/pycore_ast.h' line='71' column='1' id='type-id-1224'>
+    <typedef-decl name='unaryop_ty' type-id='type-id-1219' filepath='./Include/internal/pycore_ast.h' line='29' column='1' id='type-id-1145'/>
+    <typedef-decl name='comprehension_ty' type-id='type-id-1220' filepath='./Include/internal/pycore_ast.h' line='34' column='1' id='type-id-1147'/>
+    <typedef-decl name='arguments_ty' type-id='type-id-1221' filepath='./Include/internal/pycore_ast.h' line='38' column='1' id='type-id-535'/>
+    <typedef-decl name='arg_ty' type-id='type-id-1222' filepath='./Include/internal/pycore_ast.h' line='40' column='1' id='type-id-576'/>
+    <typedef-decl name='keyword_ty' type-id='type-id-1223' filepath='./Include/internal/pycore_ast.h' line='42' column='1' id='type-id-1148'/>
+    <class-decl name='asdl_expr_seq' size-in-bits='192' is-struct='yes' naming-typedef-id='type-id-1224' visibility='default' filepath='./Include/internal/pycore_ast.h' line='71' column='1' id='type-id-1225'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='size' type-id='type-id-14' visibility='default' filepath='./Include/internal/pycore_ast.h' line='72' column='1'/>
       </data-member>
@@ -19544,11 +19559,11 @@
         <var-decl name='elements' type-id='type-id-253' visibility='default' filepath='./Include/internal/pycore_ast.h' line='72' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='typed_elements' type-id='type-id-1158' visibility='default' filepath='./Include/internal/pycore_ast.h' line='73' column='1'/>
+        <var-decl name='typed_elements' type-id='type-id-1159' visibility='default' filepath='./Include/internal/pycore_ast.h' line='73' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='asdl_expr_seq' type-id='type-id-1224' filepath='./Include/internal/pycore_ast.h' line='74' column='1' id='type-id-1223'/>
-    <class-decl name='asdl_comprehension_seq' size-in-bits='192' is-struct='yes' naming-typedef-id='type-id-1225' visibility='default' filepath='./Include/internal/pycore_ast.h' line='78' column='1' id='type-id-1226'>
+    <typedef-decl name='asdl_expr_seq' type-id='type-id-1225' filepath='./Include/internal/pycore_ast.h' line='74' column='1' id='type-id-1224'/>
+    <class-decl name='asdl_comprehension_seq' size-in-bits='192' is-struct='yes' naming-typedef-id='type-id-1226' visibility='default' filepath='./Include/internal/pycore_ast.h' line='78' column='1' id='type-id-1227'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='size' type-id='type-id-14' visibility='default' filepath='./Include/internal/pycore_ast.h' line='79' column='1'/>
       </data-member>
@@ -19556,11 +19571,11 @@
         <var-decl name='elements' type-id='type-id-253' visibility='default' filepath='./Include/internal/pycore_ast.h' line='79' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='typed_elements' type-id='type-id-1157' visibility='default' filepath='./Include/internal/pycore_ast.h' line='80' column='1'/>
+        <var-decl name='typed_elements' type-id='type-id-1158' visibility='default' filepath='./Include/internal/pycore_ast.h' line='80' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='asdl_comprehension_seq' type-id='type-id-1226' filepath='./Include/internal/pycore_ast.h' line='81' column='1' id='type-id-1225'/>
-    <class-decl name='asdl_arg_seq' size-in-bits='192' is-struct='yes' naming-typedef-id='type-id-1227' visibility='default' filepath='./Include/internal/pycore_ast.h' line='101' column='1' id='type-id-1228'>
+    <typedef-decl name='asdl_comprehension_seq' type-id='type-id-1227' filepath='./Include/internal/pycore_ast.h' line='81' column='1' id='type-id-1226'/>
+    <class-decl name='asdl_arg_seq' size-in-bits='192' is-struct='yes' naming-typedef-id='type-id-1228' visibility='default' filepath='./Include/internal/pycore_ast.h' line='101' column='1' id='type-id-1229'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='size' type-id='type-id-14' visibility='default' filepath='./Include/internal/pycore_ast.h' line='102' column='1'/>
       </data-member>
@@ -19568,11 +19583,11 @@
         <var-decl name='elements' type-id='type-id-253' visibility='default' filepath='./Include/internal/pycore_ast.h' line='102' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='typed_elements' type-id='type-id-1150' visibility='default' filepath='./Include/internal/pycore_ast.h' line='103' column='1'/>
+        <var-decl name='typed_elements' type-id='type-id-1151' visibility='default' filepath='./Include/internal/pycore_ast.h' line='103' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='asdl_arg_seq' type-id='type-id-1228' filepath='./Include/internal/pycore_ast.h' line='104' column='1' id='type-id-1227'/>
-    <class-decl name='asdl_keyword_seq' size-in-bits='192' is-struct='yes' naming-typedef-id='type-id-1229' visibility='default' filepath='./Include/internal/pycore_ast.h' line='108' column='1' id='type-id-1230'>
+    <typedef-decl name='asdl_arg_seq' type-id='type-id-1229' filepath='./Include/internal/pycore_ast.h' line='104' column='1' id='type-id-1228'/>
+    <class-decl name='asdl_keyword_seq' size-in-bits='192' is-struct='yes' naming-typedef-id='type-id-1230' visibility='default' filepath='./Include/internal/pycore_ast.h' line='108' column='1' id='type-id-1231'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='size' type-id='type-id-14' visibility='default' filepath='./Include/internal/pycore_ast.h' line='109' column='1'/>
       </data-member>
@@ -19580,11 +19595,11 @@
         <var-decl name='elements' type-id='type-id-253' visibility='default' filepath='./Include/internal/pycore_ast.h' line='109' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='typed_elements' type-id='type-id-1161' visibility='default' filepath='./Include/internal/pycore_ast.h' line='110' column='1'/>
+        <var-decl name='typed_elements' type-id='type-id-1162' visibility='default' filepath='./Include/internal/pycore_ast.h' line='110' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='asdl_keyword_seq' type-id='type-id-1230' filepath='./Include/internal/pycore_ast.h' line='111' column='1' id='type-id-1229'/>
-    <enum-decl name='_expr_kind' filepath='./Include/internal/pycore_ast.h' line='359' column='1' id='type-id-1231'>
+    <typedef-decl name='asdl_keyword_seq' type-id='type-id-1231' filepath='./Include/internal/pycore_ast.h' line='111' column='1' id='type-id-1230'/>
+    <enum-decl name='_expr_kind' filepath='./Include/internal/pycore_ast.h' line='359' column='1' id='type-id-1232'>
       <underlying-type type-id='type-id-24'/>
       <enumerator name='BoolOp_kind' value='1'/>
       <enumerator name='NamedExpr_kind' value='2'/>
@@ -19614,12 +19629,12 @@
       <enumerator name='Tuple_kind' value='26'/>
       <enumerator name='Slice_kind' value='27'/>
     </enum-decl>
-    <class-decl name='_expr' size-in-bits='384' is-struct='yes' visibility='default' filepath='./Include/internal/pycore_ast.h' line='367' column='1' id='type-id-968'>
+    <class-decl name='_expr' size-in-bits='384' is-struct='yes' visibility='default' filepath='./Include/internal/pycore_ast.h' line='367' column='1' id='type-id-969'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='kind' type-id='type-id-1231' visibility='default' filepath='./Include/internal/pycore_ast.h' line='368' column='1'/>
+        <var-decl name='kind' type-id='type-id-1232' visibility='default' filepath='./Include/internal/pycore_ast.h' line='368' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='v' type-id='type-id-1232' visibility='default' filepath='./Include/internal/pycore_ast.h' line='509' column='1'/>
+        <var-decl name='v' type-id='type-id-1233' visibility='default' filepath='./Include/internal/pycore_ast.h' line='509' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='256'>
         <var-decl name='lineno' type-id='type-id-8' visibility='default' filepath='./Include/internal/pycore_ast.h' line='510' column='1'/>
@@ -19634,42 +19649,42 @@
         <var-decl name='end_col_offset' type-id='type-id-8' visibility='default' filepath='./Include/internal/pycore_ast.h' line='513' column='1'/>
       </data-member>
     </class-decl>
-    <union-decl name='__anonymous_union__1' size-in-bits='192' is-anonymous='yes' visibility='default' filepath='./Include/internal/pycore_ast.h' line='369' column='1' id='type-id-1232'>
+    <union-decl name='__anonymous_union__1' size-in-bits='192' is-anonymous='yes' visibility='default' filepath='./Include/internal/pycore_ast.h' line='369' column='1' id='type-id-1233'>
       <data-member access='public'>
-        <var-decl name='BoolOp' type-id='type-id-1233' visibility='default' filepath='./Include/internal/pycore_ast.h' line='373' column='1'/>
+        <var-decl name='BoolOp' type-id='type-id-1234' visibility='default' filepath='./Include/internal/pycore_ast.h' line='373' column='1'/>
       </data-member>
       <data-member access='public'>
-        <var-decl name='NamedExpr' type-id='type-id-1234' visibility='default' filepath='./Include/internal/pycore_ast.h' line='378' column='1'/>
+        <var-decl name='NamedExpr' type-id='type-id-1235' visibility='default' filepath='./Include/internal/pycore_ast.h' line='378' column='1'/>
       </data-member>
       <data-member access='public'>
-        <var-decl name='BinOp' type-id='type-id-1235' visibility='default' filepath='./Include/internal/pycore_ast.h' line='384' column='1'/>
+        <var-decl name='BinOp' type-id='type-id-1236' visibility='default' filepath='./Include/internal/pycore_ast.h' line='384' column='1'/>
       </data-member>
       <data-member access='public'>
-        <var-decl name='UnaryOp' type-id='type-id-1236' visibility='default' filepath='./Include/internal/pycore_ast.h' line='389' column='1'/>
+        <var-decl name='UnaryOp' type-id='type-id-1237' visibility='default' filepath='./Include/internal/pycore_ast.h' line='389' column='1'/>
       </data-member>
       <data-member access='public'>
-        <var-decl name='Lambda' type-id='type-id-1237' visibility='default' filepath='./Include/internal/pycore_ast.h' line='394' column='1'/>
+        <var-decl name='Lambda' type-id='type-id-1238' visibility='default' filepath='./Include/internal/pycore_ast.h' line='394' column='1'/>
       </data-member>
       <data-member access='public'>
-        <var-decl name='IfExp' type-id='type-id-1238' visibility='default' filepath='./Include/internal/pycore_ast.h' line='400' column='1'/>
+        <var-decl name='IfExp' type-id='type-id-1239' visibility='default' filepath='./Include/internal/pycore_ast.h' line='400' column='1'/>
       </data-member>
       <data-member access='public'>
-        <var-decl name='Dict' type-id='type-id-1239' visibility='default' filepath='./Include/internal/pycore_ast.h' line='405' column='1'/>
+        <var-decl name='Dict' type-id='type-id-1240' visibility='default' filepath='./Include/internal/pycore_ast.h' line='405' column='1'/>
       </data-member>
       <data-member access='public'>
-        <var-decl name='Set' type-id='type-id-1240' visibility='default' filepath='./Include/internal/pycore_ast.h' line='409' column='1'/>
+        <var-decl name='Set' type-id='type-id-1241' visibility='default' filepath='./Include/internal/pycore_ast.h' line='409' column='1'/>
       </data-member>
       <data-member access='public'>
-        <var-decl name='ListComp' type-id='type-id-1241' visibility='default' filepath='./Include/internal/pycore_ast.h' line='414' column='1'/>
+        <var-decl name='ListComp' type-id='type-id-1242' visibility='default' filepath='./Include/internal/pycore_ast.h' line='414' column='1'/>
       </data-member>
       <data-member access='public'>
-        <var-decl name='SetComp' type-id='type-id-1241' visibility='default' filepath='./Include/internal/pycore_ast.h' line='419' column='1'/>
+        <var-decl name='SetComp' type-id='type-id-1242' visibility='default' filepath='./Include/internal/pycore_ast.h' line='419' column='1'/>
       </data-member>
       <data-member access='public'>
-        <var-decl name='DictComp' type-id='type-id-1242' visibility='default' filepath='./Include/internal/pycore_ast.h' line='425' column='1'/>
+        <var-decl name='DictComp' type-id='type-id-1243' visibility='default' filepath='./Include/internal/pycore_ast.h' line='425' column='1'/>
       </data-member>
       <data-member access='public'>
-        <var-decl name='GeneratorExp' type-id='type-id-1241' visibility='default' filepath='./Include/internal/pycore_ast.h' line='430' column='1'/>
+        <var-decl name='GeneratorExp' type-id='type-id-1242' visibility='default' filepath='./Include/internal/pycore_ast.h' line='430' column='1'/>
       </data-member>
       <data-member access='public'>
         <var-decl name='Await' type-id='type-id-518' visibility='default' filepath='./Include/internal/pycore_ast.h' line='434' column='1'/>
@@ -19681,51 +19696,51 @@
         <var-decl name='YieldFrom' type-id='type-id-518' visibility='default' filepath='./Include/internal/pycore_ast.h' line='442' column='1'/>
       </data-member>
       <data-member access='public'>
-        <var-decl name='Compare' type-id='type-id-1243' visibility='default' filepath='./Include/internal/pycore_ast.h' line='448' column='1'/>
+        <var-decl name='Compare' type-id='type-id-1244' visibility='default' filepath='./Include/internal/pycore_ast.h' line='448' column='1'/>
       </data-member>
       <data-member access='public'>
-        <var-decl name='Call' type-id='type-id-1244' visibility='default' filepath='./Include/internal/pycore_ast.h' line='454' column='1'/>
+        <var-decl name='Call' type-id='type-id-1245' visibility='default' filepath='./Include/internal/pycore_ast.h' line='454' column='1'/>
       </data-member>
       <data-member access='public'>
-        <var-decl name='FormattedValue' type-id='type-id-1245' visibility='default' filepath='./Include/internal/pycore_ast.h' line='460' column='1'/>
+        <var-decl name='FormattedValue' type-id='type-id-1246' visibility='default' filepath='./Include/internal/pycore_ast.h' line='460' column='1'/>
       </data-member>
       <data-member access='public'>
-        <var-decl name='JoinedStr' type-id='type-id-1246' visibility='default' filepath='./Include/internal/pycore_ast.h' line='464' column='1'/>
+        <var-decl name='JoinedStr' type-id='type-id-1247' visibility='default' filepath='./Include/internal/pycore_ast.h' line='464' column='1'/>
       </data-member>
       <data-member access='public'>
-        <var-decl name='Constant' type-id='type-id-1247' visibility='default' filepath='./Include/internal/pycore_ast.h' line='469' column='1'/>
+        <var-decl name='Constant' type-id='type-id-1248' visibility='default' filepath='./Include/internal/pycore_ast.h' line='469' column='1'/>
       </data-member>
       <data-member access='public'>
-        <var-decl name='Attribute' type-id='type-id-1248' visibility='default' filepath='./Include/internal/pycore_ast.h' line='475' column='1'/>
+        <var-decl name='Attribute' type-id='type-id-1249' visibility='default' filepath='./Include/internal/pycore_ast.h' line='475' column='1'/>
       </data-member>
       <data-member access='public'>
-        <var-decl name='Subscript' type-id='type-id-1249' visibility='default' filepath='./Include/internal/pycore_ast.h' line='481' column='1'/>
+        <var-decl name='Subscript' type-id='type-id-1250' visibility='default' filepath='./Include/internal/pycore_ast.h' line='481' column='1'/>
       </data-member>
       <data-member access='public'>
-        <var-decl name='Starred' type-id='type-id-1250' visibility='default' filepath='./Include/internal/pycore_ast.h' line='486' column='1'/>
+        <var-decl name='Starred' type-id='type-id-1251' visibility='default' filepath='./Include/internal/pycore_ast.h' line='486' column='1'/>
       </data-member>
       <data-member access='public'>
-        <var-decl name='Name' type-id='type-id-1251' visibility='default' filepath='./Include/internal/pycore_ast.h' line='491' column='1'/>
+        <var-decl name='Name' type-id='type-id-1252' visibility='default' filepath='./Include/internal/pycore_ast.h' line='491' column='1'/>
       </data-member>
       <data-member access='public'>
-        <var-decl name='List' type-id='type-id-1252' visibility='default' filepath='./Include/internal/pycore_ast.h' line='496' column='1'/>
+        <var-decl name='List' type-id='type-id-1253' visibility='default' filepath='./Include/internal/pycore_ast.h' line='496' column='1'/>
       </data-member>
       <data-member access='public'>
-        <var-decl name='Tuple' type-id='type-id-1252' visibility='default' filepath='./Include/internal/pycore_ast.h' line='501' column='1'/>
+        <var-decl name='Tuple' type-id='type-id-1253' visibility='default' filepath='./Include/internal/pycore_ast.h' line='501' column='1'/>
       </data-member>
       <data-member access='public'>
-        <var-decl name='Slice' type-id='type-id-1253' visibility='default' filepath='./Include/internal/pycore_ast.h' line='507' column='1'/>
+        <var-decl name='Slice' type-id='type-id-1254' visibility='default' filepath='./Include/internal/pycore_ast.h' line='507' column='1'/>
       </data-member>
     </union-decl>
-    <class-decl name='__anonymous_struct__1' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' filepath='./Include/internal/pycore_ast.h' line='370' column='1' id='type-id-1233'>
+    <class-decl name='__anonymous_struct__1' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' filepath='./Include/internal/pycore_ast.h' line='370' column='1' id='type-id-1234'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='op' type-id='type-id-1143' visibility='default' filepath='./Include/internal/pycore_ast.h' line='371' column='1'/>
+        <var-decl name='op' type-id='type-id-1144' visibility='default' filepath='./Include/internal/pycore_ast.h' line='371' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
         <var-decl name='values' type-id='type-id-512' visibility='default' filepath='./Include/internal/pycore_ast.h' line='372' column='1'/>
       </data-member>
     </class-decl>
-    <class-decl name='__anonymous_struct__2' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' filepath='./Include/internal/pycore_ast.h' line='375' column='1' id='type-id-1234'>
+    <class-decl name='__anonymous_struct__2' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' filepath='./Include/internal/pycore_ast.h' line='375' column='1' id='type-id-1235'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='target' type-id='type-id-511' visibility='default' filepath='./Include/internal/pycore_ast.h' line='376' column='1'/>
       </data-member>
@@ -19733,7 +19748,7 @@
         <var-decl name='value' type-id='type-id-511' visibility='default' filepath='./Include/internal/pycore_ast.h' line='377' column='1'/>
       </data-member>
     </class-decl>
-    <class-decl name='__anonymous_struct__3' size-in-bits='192' is-struct='yes' is-anonymous='yes' visibility='default' filepath='./Include/internal/pycore_ast.h' line='380' column='1' id='type-id-1235'>
+    <class-decl name='__anonymous_struct__3' size-in-bits='192' is-struct='yes' is-anonymous='yes' visibility='default' filepath='./Include/internal/pycore_ast.h' line='380' column='1' id='type-id-1236'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='left' type-id='type-id-511' visibility='default' filepath='./Include/internal/pycore_ast.h' line='381' column='1'/>
       </data-member>
@@ -19744,15 +19759,15 @@
         <var-decl name='right' type-id='type-id-511' visibility='default' filepath='./Include/internal/pycore_ast.h' line='383' column='1'/>
       </data-member>
     </class-decl>
-    <class-decl name='__anonymous_struct__4' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' filepath='./Include/internal/pycore_ast.h' line='386' column='1' id='type-id-1236'>
+    <class-decl name='__anonymous_struct__4' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' filepath='./Include/internal/pycore_ast.h' line='386' column='1' id='type-id-1237'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='op' type-id='type-id-1144' visibility='default' filepath='./Include/internal/pycore_ast.h' line='387' column='1'/>
+        <var-decl name='op' type-id='type-id-1145' visibility='default' filepath='./Include/internal/pycore_ast.h' line='387' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
         <var-decl name='operand' type-id='type-id-511' visibility='default' filepath='./Include/internal/pycore_ast.h' line='388' column='1'/>
       </data-member>
     </class-decl>
-    <class-decl name='__anonymous_struct__5' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' filepath='./Include/internal/pycore_ast.h' line='391' column='1' id='type-id-1237'>
+    <class-decl name='__anonymous_struct__5' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' filepath='./Include/internal/pycore_ast.h' line='391' column='1' id='type-id-1238'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='args' type-id='type-id-535' visibility='default' filepath='./Include/internal/pycore_ast.h' line='392' column='1'/>
       </data-member>
@@ -19760,7 +19775,7 @@
         <var-decl name='body' type-id='type-id-511' visibility='default' filepath='./Include/internal/pycore_ast.h' line='393' column='1'/>
       </data-member>
     </class-decl>
-    <class-decl name='__anonymous_struct__6' size-in-bits='192' is-struct='yes' is-anonymous='yes' visibility='default' filepath='./Include/internal/pycore_ast.h' line='396' column='1' id='type-id-1238'>
+    <class-decl name='__anonymous_struct__6' size-in-bits='192' is-struct='yes' is-anonymous='yes' visibility='default' filepath='./Include/internal/pycore_ast.h' line='396' column='1' id='type-id-1239'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='test' type-id='type-id-511' visibility='default' filepath='./Include/internal/pycore_ast.h' line='397' column='1'/>
       </data-member>
@@ -19771,7 +19786,7 @@
         <var-decl name='orelse' type-id='type-id-511' visibility='default' filepath='./Include/internal/pycore_ast.h' line='399' column='1'/>
       </data-member>
     </class-decl>
-    <class-decl name='__anonymous_struct__7' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' filepath='./Include/internal/pycore_ast.h' line='402' column='1' id='type-id-1239'>
+    <class-decl name='__anonymous_struct__7' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' filepath='./Include/internal/pycore_ast.h' line='402' column='1' id='type-id-1240'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='keys' type-id='type-id-512' visibility='default' filepath='./Include/internal/pycore_ast.h' line='403' column='1'/>
       </data-member>
@@ -19779,20 +19794,20 @@
         <var-decl name='values' type-id='type-id-512' visibility='default' filepath='./Include/internal/pycore_ast.h' line='404' column='1'/>
       </data-member>
     </class-decl>
-    <class-decl name='__anonymous_struct__8' size-in-bits='64' is-struct='yes' is-anonymous='yes' visibility='default' filepath='./Include/internal/pycore_ast.h' line='407' column='1' id='type-id-1240'>
+    <class-decl name='__anonymous_struct__8' size-in-bits='64' is-struct='yes' is-anonymous='yes' visibility='default' filepath='./Include/internal/pycore_ast.h' line='407' column='1' id='type-id-1241'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='elts' type-id='type-id-512' visibility='default' filepath='./Include/internal/pycore_ast.h' line='408' column='1'/>
       </data-member>
     </class-decl>
-    <class-decl name='__anonymous_struct__9' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' filepath='./Include/internal/pycore_ast.h' line='411' column='1' id='type-id-1241'>
+    <class-decl name='__anonymous_struct__9' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' filepath='./Include/internal/pycore_ast.h' line='411' column='1' id='type-id-1242'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='elt' type-id='type-id-511' visibility='default' filepath='./Include/internal/pycore_ast.h' line='412' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='generators' type-id='type-id-1145' visibility='default' filepath='./Include/internal/pycore_ast.h' line='413' column='1'/>
+        <var-decl name='generators' type-id='type-id-1146' visibility='default' filepath='./Include/internal/pycore_ast.h' line='413' column='1'/>
       </data-member>
     </class-decl>
-    <class-decl name='__anonymous_struct__11' size-in-bits='192' is-struct='yes' is-anonymous='yes' visibility='default' filepath='./Include/internal/pycore_ast.h' line='421' column='1' id='type-id-1242'>
+    <class-decl name='__anonymous_struct__11' size-in-bits='192' is-struct='yes' is-anonymous='yes' visibility='default' filepath='./Include/internal/pycore_ast.h' line='421' column='1' id='type-id-1243'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='key' type-id='type-id-511' visibility='default' filepath='./Include/internal/pycore_ast.h' line='422' column='1'/>
       </data-member>
@@ -19800,7 +19815,7 @@
         <var-decl name='value' type-id='type-id-511' visibility='default' filepath='./Include/internal/pycore_ast.h' line='423' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='generators' type-id='type-id-1145' visibility='default' filepath='./Include/internal/pycore_ast.h' line='424' column='1'/>
+        <var-decl name='generators' type-id='type-id-1146' visibility='default' filepath='./Include/internal/pycore_ast.h' line='424' column='1'/>
       </data-member>
     </class-decl>
     <class-decl name='__anonymous_struct__13' size-in-bits='64' is-struct='yes' is-anonymous='yes' visibility='default' filepath='./Include/internal/pycore_ast.h' line='432' column='1' id='type-id-518'>
@@ -19808,7 +19823,7 @@
         <var-decl name='value' type-id='type-id-511' visibility='default' filepath='./Include/internal/pycore_ast.h' line='433' column='1'/>
       </data-member>
     </class-decl>
-    <class-decl name='__anonymous_struct__16' size-in-bits='192' is-struct='yes' is-anonymous='yes' visibility='default' filepath='./Include/internal/pycore_ast.h' line='444' column='1' id='type-id-1243'>
+    <class-decl name='__anonymous_struct__16' size-in-bits='192' is-struct='yes' is-anonymous='yes' visibility='default' filepath='./Include/internal/pycore_ast.h' line='444' column='1' id='type-id-1244'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='left' type-id='type-id-511' visibility='default' filepath='./Include/internal/pycore_ast.h' line='445' column='1'/>
       </data-member>
@@ -19819,7 +19834,7 @@
         <var-decl name='comparators' type-id='type-id-512' visibility='default' filepath='./Include/internal/pycore_ast.h' line='447' column='1'/>
       </data-member>
     </class-decl>
-    <class-decl name='__anonymous_struct__17' size-in-bits='192' is-struct='yes' is-anonymous='yes' visibility='default' filepath='./Include/internal/pycore_ast.h' line='450' column='1' id='type-id-1244'>
+    <class-decl name='__anonymous_struct__17' size-in-bits='192' is-struct='yes' is-anonymous='yes' visibility='default' filepath='./Include/internal/pycore_ast.h' line='450' column='1' id='type-id-1245'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='func' type-id='type-id-511' visibility='default' filepath='./Include/internal/pycore_ast.h' line='451' column='1'/>
       </data-member>
@@ -19830,7 +19845,7 @@
         <var-decl name='keywords' type-id='type-id-538' visibility='default' filepath='./Include/internal/pycore_ast.h' line='453' column='1'/>
       </data-member>
     </class-decl>
-    <class-decl name='__anonymous_struct__18' size-in-bits='192' is-struct='yes' is-anonymous='yes' visibility='default' filepath='./Include/internal/pycore_ast.h' line='456' column='1' id='type-id-1245'>
+    <class-decl name='__anonymous_struct__18' size-in-bits='192' is-struct='yes' is-anonymous='yes' visibility='default' filepath='./Include/internal/pycore_ast.h' line='456' column='1' id='type-id-1246'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='value' type-id='type-id-511' visibility='default' filepath='./Include/internal/pycore_ast.h' line='457' column='1'/>
       </data-member>
@@ -19841,12 +19856,12 @@
         <var-decl name='format_spec' type-id='type-id-511' visibility='default' filepath='./Include/internal/pycore_ast.h' line='459' column='1'/>
       </data-member>
     </class-decl>
-    <class-decl name='__anonymous_struct__19' size-in-bits='64' is-struct='yes' is-anonymous='yes' visibility='default' filepath='./Include/internal/pycore_ast.h' line='462' column='1' id='type-id-1246'>
+    <class-decl name='__anonymous_struct__19' size-in-bits='64' is-struct='yes' is-anonymous='yes' visibility='default' filepath='./Include/internal/pycore_ast.h' line='462' column='1' id='type-id-1247'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='values' type-id='type-id-512' visibility='default' filepath='./Include/internal/pycore_ast.h' line='463' column='1'/>
       </data-member>
     </class-decl>
-    <class-decl name='__anonymous_struct__20' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' filepath='./Include/internal/pycore_ast.h' line='466' column='1' id='type-id-1247'>
+    <class-decl name='__anonymous_struct__20' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' filepath='./Include/internal/pycore_ast.h' line='466' column='1' id='type-id-1248'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='value' type-id='type-id-561' visibility='default' filepath='./Include/internal/pycore_ast.h' line='467' column='1'/>
       </data-member>
@@ -19854,7 +19869,7 @@
         <var-decl name='kind' type-id='type-id-536' visibility='default' filepath='./Include/internal/pycore_ast.h' line='468' column='1'/>
       </data-member>
     </class-decl>
-    <class-decl name='__anonymous_struct__21' size-in-bits='192' is-struct='yes' is-anonymous='yes' visibility='default' filepath='./Include/internal/pycore_ast.h' line='471' column='1' id='type-id-1248'>
+    <class-decl name='__anonymous_struct__21' size-in-bits='192' is-struct='yes' is-anonymous='yes' visibility='default' filepath='./Include/internal/pycore_ast.h' line='471' column='1' id='type-id-1249'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='value' type-id='type-id-511' visibility='default' filepath='./Include/internal/pycore_ast.h' line='472' column='1'/>
       </data-member>
@@ -19865,7 +19880,7 @@
         <var-decl name='ctx' type-id='type-id-575' visibility='default' filepath='./Include/internal/pycore_ast.h' line='474' column='1'/>
       </data-member>
     </class-decl>
-    <class-decl name='__anonymous_struct__22' size-in-bits='192' is-struct='yes' is-anonymous='yes' visibility='default' filepath='./Include/internal/pycore_ast.h' line='477' column='1' id='type-id-1249'>
+    <class-decl name='__anonymous_struct__22' size-in-bits='192' is-struct='yes' is-anonymous='yes' visibility='default' filepath='./Include/internal/pycore_ast.h' line='477' column='1' id='type-id-1250'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='value' type-id='type-id-511' visibility='default' filepath='./Include/internal/pycore_ast.h' line='478' column='1'/>
       </data-member>
@@ -19876,7 +19891,7 @@
         <var-decl name='ctx' type-id='type-id-575' visibility='default' filepath='./Include/internal/pycore_ast.h' line='480' column='1'/>
       </data-member>
     </class-decl>
-    <class-decl name='__anonymous_struct__23' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' filepath='./Include/internal/pycore_ast.h' line='483' column='1' id='type-id-1250'>
+    <class-decl name='__anonymous_struct__23' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' filepath='./Include/internal/pycore_ast.h' line='483' column='1' id='type-id-1251'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='value' type-id='type-id-511' visibility='default' filepath='./Include/internal/pycore_ast.h' line='484' column='1'/>
       </data-member>
@@ -19884,7 +19899,7 @@
         <var-decl name='ctx' type-id='type-id-575' visibility='default' filepath='./Include/internal/pycore_ast.h' line='485' column='1'/>
       </data-member>
     </class-decl>
-    <class-decl name='__anonymous_struct__24' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' filepath='./Include/internal/pycore_ast.h' line='488' column='1' id='type-id-1251'>
+    <class-decl name='__anonymous_struct__24' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' filepath='./Include/internal/pycore_ast.h' line='488' column='1' id='type-id-1252'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='id' type-id='type-id-534' visibility='default' filepath='./Include/internal/pycore_ast.h' line='489' column='1'/>
       </data-member>
@@ -19892,7 +19907,7 @@
         <var-decl name='ctx' type-id='type-id-575' visibility='default' filepath='./Include/internal/pycore_ast.h' line='490' column='1'/>
       </data-member>
     </class-decl>
-    <class-decl name='__anonymous_struct__25' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' filepath='./Include/internal/pycore_ast.h' line='493' column='1' id='type-id-1252'>
+    <class-decl name='__anonymous_struct__25' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' filepath='./Include/internal/pycore_ast.h' line='493' column='1' id='type-id-1253'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='elts' type-id='type-id-512' visibility='default' filepath='./Include/internal/pycore_ast.h' line='494' column='1'/>
       </data-member>
@@ -19900,7 +19915,7 @@
         <var-decl name='ctx' type-id='type-id-575' visibility='default' filepath='./Include/internal/pycore_ast.h' line='495' column='1'/>
       </data-member>
     </class-decl>
-    <class-decl name='__anonymous_struct__27' size-in-bits='192' is-struct='yes' is-anonymous='yes' visibility='default' filepath='./Include/internal/pycore_ast.h' line='503' column='1' id='type-id-1253'>
+    <class-decl name='__anonymous_struct__27' size-in-bits='192' is-struct='yes' is-anonymous='yes' visibility='default' filepath='./Include/internal/pycore_ast.h' line='503' column='1' id='type-id-1254'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='lower' type-id='type-id-511' visibility='default' filepath='./Include/internal/pycore_ast.h' line='504' column='1'/>
       </data-member>
@@ -19911,7 +19926,7 @@
         <var-decl name='step' type-id='type-id-511' visibility='default' filepath='./Include/internal/pycore_ast.h' line='506' column='1'/>
       </data-member>
     </class-decl>
-    <class-decl name='_comprehension' size-in-bits='256' is-struct='yes' visibility='default' filepath='./Include/internal/pycore_ast.h' line='516' column='1' id='type-id-1254'>
+    <class-decl name='_comprehension' size-in-bits='256' is-struct='yes' visibility='default' filepath='./Include/internal/pycore_ast.h' line='516' column='1' id='type-id-1255'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='target' type-id='type-id-511' visibility='default' filepath='./Include/internal/pycore_ast.h' line='517' column='1'/>
       </data-member>
@@ -19925,7 +19940,7 @@
         <var-decl name='is_async' type-id='type-id-8' visibility='default' filepath='./Include/internal/pycore_ast.h' line='520' column='1'/>
       </data-member>
     </class-decl>
-    <class-decl name='_arguments' size-in-bits='448' is-struct='yes' visibility='default' filepath='./Include/internal/pycore_ast.h' line='540' column='1' id='type-id-1255'>
+    <class-decl name='_arguments' size-in-bits='448' is-struct='yes' visibility='default' filepath='./Include/internal/pycore_ast.h' line='540' column='1' id='type-id-1256'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='posonlyargs' type-id='type-id-574' visibility='default' filepath='./Include/internal/pycore_ast.h' line='541' column='1'/>
       </data-member>
@@ -19948,7 +19963,7 @@
         <var-decl name='defaults' type-id='type-id-512' visibility='default' filepath='./Include/internal/pycore_ast.h' line='547' column='1'/>
       </data-member>
     </class-decl>
-    <class-decl name='_arg' size-in-bits='320' is-struct='yes' visibility='default' filepath='./Include/internal/pycore_ast.h' line='550' column='1' id='type-id-1256'>
+    <class-decl name='_arg' size-in-bits='320' is-struct='yes' visibility='default' filepath='./Include/internal/pycore_ast.h' line='550' column='1' id='type-id-1257'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='arg' type-id='type-id-534' visibility='default' filepath='./Include/internal/pycore_ast.h' line='551' column='1'/>
       </data-member>
@@ -19971,7 +19986,7 @@
         <var-decl name='end_col_offset' type-id='type-id-8' visibility='default' filepath='./Include/internal/pycore_ast.h' line='557' column='1'/>
       </data-member>
     </class-decl>
-    <class-decl name='_keyword' size-in-bits='256' is-struct='yes' visibility='default' filepath='./Include/internal/pycore_ast.h' line='560' column='1' id='type-id-1257'>
+    <class-decl name='_keyword' size-in-bits='256' is-struct='yes' visibility='default' filepath='./Include/internal/pycore_ast.h' line='560' column='1' id='type-id-1258'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='arg' type-id='type-id-534' visibility='default' filepath='./Include/internal/pycore_ast.h' line='561' column='1'/>
       </data-member>
@@ -19991,9 +20006,9 @@
         <var-decl name='end_col_offset' type-id='type-id-8' visibility='default' filepath='./Include/internal/pycore_ast.h' line='566' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='PyArena' type-id='type-id-1156' filepath='./Include/internal/pycore_pyarena.h' line='14' column='1' id='type-id-1258'/>
-    <typedef-decl name='PyCFunction' type-id='type-id-1259' filepath='./Include/methodobject.h' line='19' column='1' id='type-id-388'/>
-    <class-decl name='PyMethodDef' size-in-bits='256' is-struct='yes' visibility='default' filepath='./Include/methodobject.h' line='54' column='1' id='type-id-1260'>
+    <typedef-decl name='PyArena' type-id='type-id-1157' filepath='./Include/internal/pycore_pyarena.h' line='14' column='1' id='type-id-1259'/>
+    <typedef-decl name='PyCFunction' type-id='type-id-1260' filepath='./Include/methodobject.h' line='19' column='1' id='type-id-388'/>
+    <class-decl name='PyMethodDef' size-in-bits='256' is-struct='yes' visibility='default' filepath='./Include/methodobject.h' line='54' column='1' id='type-id-1261'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='ml_name' type-id='type-id-12' visibility='default' filepath='./Include/methodobject.h' line='55' column='1'/>
       </data-member>
@@ -20007,23 +20022,23 @@
         <var-decl name='ml_doc' type-id='type-id-12' visibility='default' filepath='./Include/methodobject.h' line='59' column='1'/>
       </data-member>
     </class-decl>
-    <class-decl name='_object' size-in-bits='128' is-struct='yes' visibility='default' filepath='./Include/object.h' line='166' column='1' id='type-id-1261'>
+    <class-decl name='_object' size-in-bits='128' is-struct='yes' visibility='default' filepath='./Include/object.h' line='166' column='1' id='type-id-1262'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='' type-id='type-id-1262' visibility='default'/>
+        <var-decl name='' type-id='type-id-1263' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
         <var-decl name='ob_type' type-id='type-id-1' visibility='default' filepath='./Include/object.h' line='190' column='1'/>
       </data-member>
     </class-decl>
-    <union-decl name='__anonymous_union__' size-in-bits='64' is-anonymous='yes' visibility='default' filepath='./Include/object.h' line='180' column='1' id='type-id-1262'>
+    <union-decl name='__anonymous_union__' size-in-bits='64' is-anonymous='yes' visibility='default' filepath='./Include/object.h' line='180' column='1' id='type-id-1263'>
       <data-member access='public'>
         <var-decl name='ob_refcnt' type-id='type-id-14' visibility='default' filepath='./Include/object.h' line='181' column='1'/>
       </data-member>
       <data-member access='public'>
-        <var-decl name='ob_refcnt_split' type-id='type-id-1164' visibility='default' filepath='./Include/object.h' line='183' column='1'/>
+        <var-decl name='ob_refcnt_split' type-id='type-id-1165' visibility='default' filepath='./Include/object.h' line='183' column='1'/>
       </data-member>
     </union-decl>
-    <class-decl name='PyVarObject' size-in-bits='192' is-struct='yes' naming-typedef-id='type-id-321' visibility='default' filepath='./Include/object.h' line='196' column='1' id='type-id-1263'>
+    <class-decl name='PyVarObject' size-in-bits='192' is-struct='yes' naming-typedef-id='type-id-321' visibility='default' filepath='./Include/object.h' line='196' column='1' id='type-id-1264'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='ob_base' type-id='type-id-345' visibility='default' filepath='./Include/object.h' line='197' column='1'/>
       </data-member>
@@ -20031,43 +20046,43 @@
         <var-decl name='ob_size' type-id='type-id-14' visibility='default' filepath='./Include/object.h' line='198' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='PyVarObject' type-id='type-id-1263' filepath='./Include/object.h' line='199' column='1' id='type-id-321'/>
-    <typedef-decl name='unaryfunc' type-id='type-id-1264' filepath='./Include/object.h' line='305' column='1' id='type-id-1170'/>
-    <typedef-decl name='binaryfunc' type-id='type-id-1259' filepath='./Include/object.h' line='306' column='1' id='type-id-1168'/>
-    <typedef-decl name='ternaryfunc' type-id='type-id-1265' filepath='./Include/object.h' line='307' column='1' id='type-id-1169'/>
-    <typedef-decl name='inquiry' type-id='type-id-339' filepath='./Include/object.h' line='308' column='1' id='type-id-396'/>
-    <typedef-decl name='lenfunc' type-id='type-id-1266' filepath='./Include/object.h' line='309' column='1' id='type-id-1173'/>
-    <typedef-decl name='ssizeargfunc' type-id='type-id-1267' filepath='./Include/object.h' line='310' column='1' id='type-id-1174'/>
-    <typedef-decl name='ssizeobjargproc' type-id='type-id-1268' filepath='./Include/object.h' line='312' column='1' id='type-id-1175'/>
-    <typedef-decl name='objobjargproc' type-id='type-id-1269' filepath='./Include/object.h' line='314' column='1' id='type-id-1179'/>
-    <typedef-decl name='objobjproc' type-id='type-id-1270' filepath='./Include/object.h' line='316' column='1' id='type-id-1176'/>
-    <typedef-decl name='visitproc' type-id='type-id-236' filepath='./Include/object.h' line='317' column='1' id='type-id-341'/>
-    <typedef-decl name='traverseproc' type-id='type-id-1271' filepath='./Include/object.h' line='318' column='1' id='type-id-395'/>
-    <typedef-decl name='freefunc' type-id='type-id-769' filepath='./Include/object.h' line='321' column='1' id='type-id-397'/>
-    <typedef-decl name='destructor' type-id='type-id-312' filepath='./Include/object.h' line='322' column='1' id='type-id-335'/>
-    <typedef-decl name='getattrfunc' type-id='type-id-1272' filepath='./Include/object.h' line='323' column='1' id='type-id-1188'/>
-    <typedef-decl name='getattrofunc' type-id='type-id-1259' filepath='./Include/object.h' line='324' column='1' id='type-id-1196'/>
-    <typedef-decl name='setattrfunc' type-id='type-id-1273' filepath='./Include/object.h' line='325' column='1' id='type-id-1189'/>
-    <typedef-decl name='setattrofunc' type-id='type-id-1269' filepath='./Include/object.h' line='326' column='1' id='type-id-1197'/>
-    <typedef-decl name='reprfunc' type-id='type-id-1264' filepath='./Include/object.h' line='327' column='1' id='type-id-1191'/>
-    <typedef-decl name='hashfunc' type-id='type-id-1274' filepath='./Include/object.h' line='328' column='1' id='type-id-1195'/>
-    <typedef-decl name='richcmpfunc' type-id='type-id-1275' filepath='./Include/object.h' line='329' column='1' id='type-id-1199'/>
-    <typedef-decl name='getiterfunc' type-id='type-id-1264' filepath='./Include/object.h' line='330' column='1' id='type-id-1200'/>
-    <typedef-decl name='iternextfunc' type-id='type-id-1264' filepath='./Include/object.h' line='331' column='1' id='type-id-1201'/>
-    <typedef-decl name='descrgetfunc' type-id='type-id-1265' filepath='./Include/object.h' line='332' column='1' id='type-id-1202'/>
-    <typedef-decl name='descrsetfunc' type-id='type-id-1269' filepath='./Include/object.h' line='333' column='1' id='type-id-1203'/>
-    <typedef-decl name='initproc' type-id='type-id-1269' filepath='./Include/object.h' line='334' column='1' id='type-id-1204'/>
-    <typedef-decl name='newfunc' type-id='type-id-1276' filepath='./Include/object.h' line='335' column='1' id='type-id-1206'/>
-    <typedef-decl name='allocfunc' type-id='type-id-1277' filepath='./Include/object.h' line='336' column='1' id='type-id-1205'/>
-    <typedef-decl name='vectorcallfunc' type-id='type-id-1278' filepath='./Include/object.h' line='339' column='1' id='type-id-311'/>
-    <enum-decl name='PySendResult' naming-typedef-id='type-id-255' filepath='./Include/object.h' line='873' column='1' id='type-id-1279'>
+    <typedef-decl name='PyVarObject' type-id='type-id-1264' filepath='./Include/object.h' line='199' column='1' id='type-id-321'/>
+    <typedef-decl name='unaryfunc' type-id='type-id-1265' filepath='./Include/object.h' line='304' column='1' id='type-id-1171'/>
+    <typedef-decl name='binaryfunc' type-id='type-id-1260' filepath='./Include/object.h' line='305' column='1' id='type-id-1169'/>
+    <typedef-decl name='ternaryfunc' type-id='type-id-1266' filepath='./Include/object.h' line='306' column='1' id='type-id-1170'/>
+    <typedef-decl name='inquiry' type-id='type-id-339' filepath='./Include/object.h' line='307' column='1' id='type-id-396'/>
+    <typedef-decl name='lenfunc' type-id='type-id-1267' filepath='./Include/object.h' line='308' column='1' id='type-id-1174'/>
+    <typedef-decl name='ssizeargfunc' type-id='type-id-1268' filepath='./Include/object.h' line='309' column='1' id='type-id-1175'/>
+    <typedef-decl name='ssizeobjargproc' type-id='type-id-1269' filepath='./Include/object.h' line='311' column='1' id='type-id-1176'/>
+    <typedef-decl name='objobjargproc' type-id='type-id-1270' filepath='./Include/object.h' line='313' column='1' id='type-id-1180'/>
+    <typedef-decl name='objobjproc' type-id='type-id-1271' filepath='./Include/object.h' line='315' column='1' id='type-id-1177'/>
+    <typedef-decl name='visitproc' type-id='type-id-236' filepath='./Include/object.h' line='316' column='1' id='type-id-341'/>
+    <typedef-decl name='traverseproc' type-id='type-id-1272' filepath='./Include/object.h' line='317' column='1' id='type-id-395'/>
+    <typedef-decl name='freefunc' type-id='type-id-769' filepath='./Include/object.h' line='320' column='1' id='type-id-397'/>
+    <typedef-decl name='destructor' type-id='type-id-312' filepath='./Include/object.h' line='321' column='1' id='type-id-335'/>
+    <typedef-decl name='getattrfunc' type-id='type-id-1273' filepath='./Include/object.h' line='322' column='1' id='type-id-1189'/>
+    <typedef-decl name='getattrofunc' type-id='type-id-1260' filepath='./Include/object.h' line='323' column='1' id='type-id-1197'/>
+    <typedef-decl name='setattrfunc' type-id='type-id-1274' filepath='./Include/object.h' line='324' column='1' id='type-id-1190'/>
+    <typedef-decl name='setattrofunc' type-id='type-id-1270' filepath='./Include/object.h' line='325' column='1' id='type-id-1198'/>
+    <typedef-decl name='reprfunc' type-id='type-id-1265' filepath='./Include/object.h' line='326' column='1' id='type-id-1192'/>
+    <typedef-decl name='hashfunc' type-id='type-id-1275' filepath='./Include/object.h' line='327' column='1' id='type-id-1196'/>
+    <typedef-decl name='richcmpfunc' type-id='type-id-1276' filepath='./Include/object.h' line='328' column='1' id='type-id-1200'/>
+    <typedef-decl name='getiterfunc' type-id='type-id-1265' filepath='./Include/object.h' line='329' column='1' id='type-id-1201'/>
+    <typedef-decl name='iternextfunc' type-id='type-id-1265' filepath='./Include/object.h' line='330' column='1' id='type-id-1202'/>
+    <typedef-decl name='descrgetfunc' type-id='type-id-1266' filepath='./Include/object.h' line='331' column='1' id='type-id-1203'/>
+    <typedef-decl name='descrsetfunc' type-id='type-id-1270' filepath='./Include/object.h' line='332' column='1' id='type-id-1204'/>
+    <typedef-decl name='initproc' type-id='type-id-1270' filepath='./Include/object.h' line='333' column='1' id='type-id-1205'/>
+    <typedef-decl name='newfunc' type-id='type-id-1277' filepath='./Include/object.h' line='334' column='1' id='type-id-1207'/>
+    <typedef-decl name='allocfunc' type-id='type-id-1278' filepath='./Include/object.h' line='335' column='1' id='type-id-1206'/>
+    <typedef-decl name='vectorcallfunc' type-id='type-id-1279' filepath='./Include/object.h' line='338' column='1' id='type-id-311'/>
+    <enum-decl name='PySendResult' naming-typedef-id='type-id-255' filepath='./Include/object.h' line='872' column='1' id='type-id-1280'>
       <underlying-type type-id='type-id-24'/>
       <enumerator name='PYGEN_RETURN' value='0'/>
       <enumerator name='PYGEN_ERROR' value='-1'/>
       <enumerator name='PYGEN_NEXT' value='1'/>
     </enum-decl>
-    <typedef-decl name='PySendResult' type-id='type-id-1279' filepath='./Include/object.h' line='877' column='1' id='type-id-255'/>
-    <class-decl name='Py_buffer' size-in-bits='640' is-struct='yes' naming-typedef-id='type-id-243' visibility='default' filepath='./Include/pybuffer.h' line='20' column='1' id='type-id-1280'>
+    <typedef-decl name='PySendResult' type-id='type-id-1280' filepath='./Include/object.h' line='876' column='1' id='type-id-255'/>
+    <class-decl name='Py_buffer' size-in-bits='640' is-struct='yes' naming-typedef-id='type-id-243' visibility='default' filepath='./Include/pybuffer.h' line='20' column='1' id='type-id-1281'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='buf' type-id='type-id-22' visibility='default' filepath='./Include/pybuffer.h' line='21' column='1'/>
       </data-member>
@@ -20102,24 +20117,24 @@
         <var-decl name='internal' type-id='type-id-22' visibility='default' filepath='./Include/pybuffer.h' line='32' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='Py_buffer' type-id='type-id-1280' filepath='./Include/pybuffer.h' line='33' column='1' id='type-id-243'/>
-    <typedef-decl name='getbufferproc' type-id='type-id-1281' filepath='./Include/pybuffer.h' line='35' column='1' id='type-id-434'/>
-    <typedef-decl name='releasebufferproc' type-id='type-id-1282' filepath='./Include/pybuffer.h' line='36' column='1' id='type-id-1186'/>
+    <typedef-decl name='Py_buffer' type-id='type-id-1281' filepath='./Include/pybuffer.h' line='33' column='1' id='type-id-243'/>
+    <typedef-decl name='getbufferproc' type-id='type-id-1282' filepath='./Include/pybuffer.h' line='35' column='1' id='type-id-434'/>
+    <typedef-decl name='releasebufferproc' type-id='type-id-1283' filepath='./Include/pybuffer.h' line='36' column='1' id='type-id-1187'/>
     <typedef-decl name='Py_ssize_t' type-id='type-id-185' filepath='./Include/pyport.h' line='131' column='1' id='type-id-14'/>
     <typedef-decl name='Py_hash_t' type-id='type-id-14' filepath='./Include/pyport.h' line='145' column='1' id='type-id-305'/>
-    <typedef-decl name='PyMethodDef' type-id='type-id-1260' filepath='./Include/pytypedefs.h' line='14' column='1' id='type-id-1283'/>
-    <typedef-decl name='PyGetSetDef' type-id='type-id-1210' filepath='./Include/pytypedefs.h' line='15' column='1' id='type-id-1284'/>
-    <typedef-decl name='PyMemberDef' type-id='type-id-1211' filepath='./Include/pytypedefs.h' line='16' column='1' id='type-id-1285'/>
-    <typedef-decl name='PyObject' type-id='type-id-1261' filepath='./Include/pytypedefs.h' line='18' column='1' id='type-id-345'/>
-    <typedef-decl name='PyTypeObject' type-id='type-id-1187' filepath='./Include/pytypedefs.h' line='20' column='1' id='type-id-256'/>
-    <typedef-decl name='uint32_t' type-id='type-id-1058' filepath='/usr/include/x86_64-linux-gnu/bits/stdint-uintn.h' line='26' column='1' id='type-id-352'/>
-    <typedef-decl name='__uint32_t' type-id='type-id-95' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='42' column='1' id='type-id-1058'/>
-    <typedef-decl name='__off_t' type-id='type-id-47' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='152' column='1' id='type-id-1286'/>
+    <typedef-decl name='PyMethodDef' type-id='type-id-1261' filepath='./Include/pytypedefs.h' line='14' column='1' id='type-id-1284'/>
+    <typedef-decl name='PyGetSetDef' type-id='type-id-1211' filepath='./Include/pytypedefs.h' line='15' column='1' id='type-id-1285'/>
+    <typedef-decl name='PyMemberDef' type-id='type-id-1212' filepath='./Include/pytypedefs.h' line='16' column='1' id='type-id-1286'/>
+    <typedef-decl name='PyObject' type-id='type-id-1262' filepath='./Include/pytypedefs.h' line='18' column='1' id='type-id-345'/>
+    <typedef-decl name='PyTypeObject' type-id='type-id-1188' filepath='./Include/pytypedefs.h' line='20' column='1' id='type-id-256'/>
+    <typedef-decl name='uint32_t' type-id='type-id-1059' filepath='/usr/include/x86_64-linux-gnu/bits/stdint-uintn.h' line='26' column='1' id='type-id-352'/>
+    <typedef-decl name='__uint32_t' type-id='type-id-95' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='42' column='1' id='type-id-1059'/>
+    <typedef-decl name='__off_t' type-id='type-id-47' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='152' column='1' id='type-id-1287'/>
     <typedef-decl name='__off64_t' type-id='type-id-47' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='153' column='1' id='type-id-9'/>
     <typedef-decl name='__ssize_t' type-id='type-id-47' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='194' column='1' id='type-id-186'/>
-    <typedef-decl name='FILE' type-id='type-id-1287' filepath='/usr/include/x86_64-linux-gnu/bits/types/FILE.h' line='7' column='1' id='type-id-1288'/>
-    <typedef-decl name='_IO_lock_t' type-id='type-id-46' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='43' column='1' id='type-id-1289'/>
-    <class-decl name='_IO_FILE' size-in-bits='1728' is-struct='yes' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='49' column='1' id='type-id-1287'>
+    <typedef-decl name='FILE' type-id='type-id-1288' filepath='/usr/include/x86_64-linux-gnu/bits/types/FILE.h' line='7' column='1' id='type-id-1289'/>
+    <typedef-decl name='_IO_lock_t' type-id='type-id-46' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='43' column='1' id='type-id-1290'/>
+    <class-decl name='_IO_FILE' size-in-bits='1728' is-struct='yes' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='49' column='1' id='type-id-1288'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='_flags' type-id='type-id-8' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='51' column='1'/>
       </data-member>
@@ -20157,10 +20172,10 @@
         <var-decl name='_IO_save_end' type-id='type-id-15' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='66' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='768'>
-        <var-decl name='_markers' type-id='type-id-1290' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='68' column='1'/>
+        <var-decl name='_markers' type-id='type-id-1291' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='68' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='832'>
-        <var-decl name='_chain' type-id='type-id-1291' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='70' column='1'/>
+        <var-decl name='_chain' type-id='type-id-1292' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='70' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='896'>
         <var-decl name='_fileno' type-id='type-id-8' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='72' column='1'/>
@@ -20169,31 +20184,31 @@
         <var-decl name='_flags2' type-id='type-id-8' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='73' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='960'>
-        <var-decl name='_old_offset' type-id='type-id-1286' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='74' column='1'/>
+        <var-decl name='_old_offset' type-id='type-id-1287' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='74' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1024'>
         <var-decl name='_cur_column' type-id='type-id-84' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='77' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1040'>
-        <var-decl name='_vtable_offset' type-id='type-id-1041' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='78' column='1'/>
+        <var-decl name='_vtable_offset' type-id='type-id-1042' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='78' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1048'>
         <var-decl name='_shortbuf' type-id='type-id-711' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='79' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1088'>
-        <var-decl name='_lock' type-id='type-id-1292' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='81' column='1'/>
+        <var-decl name='_lock' type-id='type-id-1293' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='81' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1152'>
         <var-decl name='_offset' type-id='type-id-9' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='89' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1216'>
-        <var-decl name='_codecvt' type-id='type-id-1293' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='91' column='1'/>
+        <var-decl name='_codecvt' type-id='type-id-1294' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='91' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1280'>
-        <var-decl name='_wide_data' type-id='type-id-1294' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='92' column='1'/>
+        <var-decl name='_wide_data' type-id='type-id-1295' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='92' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1344'>
-        <var-decl name='_freeres_list' type-id='type-id-1291' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='93' column='1'/>
+        <var-decl name='_freeres_list' type-id='type-id-1292' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='93' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1408'>
         <var-decl name='_freeres_buf' type-id='type-id-22' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='94' column='1'/>
@@ -20205,11 +20220,11 @@
         <var-decl name='_mode' type-id='type-id-8' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='96' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1568'>
-        <var-decl name='_unused2' type-id='type-id-1151' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='98' column='1'/>
+        <var-decl name='_unused2' type-id='type-id-1152' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='98' column='1'/>
       </data-member>
     </class-decl>
     <typedef-decl name='ssize_t' type-id='type-id-186' filepath='/usr/include/x86_64-linux-gnu/sys/types.h' line='108' column='1' id='type-id-185'/>
-    <class-decl name='_memo' size-in-bits='256' is-struct='yes' visibility='default' filepath='Parser/pegen.h' line='29' column='1' id='type-id-1295'>
+    <class-decl name='_memo' size-in-bits='256' is-struct='yes' visibility='default' filepath='Parser/pegen.h' line='29' column='1' id='type-id-1296'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='type' type-id='type-id-8' visibility='default' filepath='Parser/pegen.h' line='30' column='1'/>
       </data-member>
@@ -20220,11 +20235,11 @@
         <var-decl name='mark' type-id='type-id-8' visibility='default' filepath='Parser/pegen.h' line='32' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='next' type-id='type-id-1296' visibility='default' filepath='Parser/pegen.h' line='33' column='1'/>
+        <var-decl name='next' type-id='type-id-1297' visibility='default' filepath='Parser/pegen.h' line='33' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='Memo' type-id='type-id-1295' filepath='Parser/pegen.h' line='34' column='1' id='type-id-1297'/>
-    <class-decl name='Token' size-in-bits='448' is-struct='yes' naming-typedef-id='type-id-1298' visibility='default' filepath='Parser/pegen.h' line='36' column='1' id='type-id-1299'>
+    <typedef-decl name='Memo' type-id='type-id-1296' filepath='Parser/pegen.h' line='34' column='1' id='type-id-1298'/>
+    <class-decl name='Token' size-in-bits='448' is-struct='yes' naming-typedef-id='type-id-1299' visibility='default' filepath='Parser/pegen.h' line='36' column='1' id='type-id-1300'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='type' type-id='type-id-8' visibility='default' filepath='Parser/pegen.h' line='37' column='1'/>
       </data-member>
@@ -20247,14 +20262,14 @@
         <var-decl name='end_col_offset' type-id='type-id-8' visibility='default' filepath='Parser/pegen.h' line='40' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='memo' type-id='type-id-1300' visibility='default' filepath='Parser/pegen.h' line='41' column='1'/>
+        <var-decl name='memo' type-id='type-id-1301' visibility='default' filepath='Parser/pegen.h' line='41' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='384'>
         <var-decl name='metadata' type-id='type-id-2' visibility='default' filepath='Parser/pegen.h' line='42' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='Token' type-id='type-id-1299' filepath='Parser/pegen.h' line='43' column='1' id='type-id-1298'/>
-    <class-decl name='KeywordToken' size-in-bits='128' is-struct='yes' naming-typedef-id='type-id-1301' visibility='default' filepath='Parser/pegen.h' line='45' column='1' id='type-id-1302'>
+    <typedef-decl name='Token' type-id='type-id-1300' filepath='Parser/pegen.h' line='43' column='1' id='type-id-1299'/>
+    <class-decl name='KeywordToken' size-in-bits='128' is-struct='yes' naming-typedef-id='type-id-1302' visibility='default' filepath='Parser/pegen.h' line='45' column='1' id='type-id-1303'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='str' type-id='type-id-12' visibility='default' filepath='Parser/pegen.h' line='46' column='1'/>
       </data-member>
@@ -20262,10 +20277,10 @@
         <var-decl name='type' type-id='type-id-8' visibility='default' filepath='Parser/pegen.h' line='47' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='KeywordToken' type-id='type-id-1302' filepath='Parser/pegen.h' line='48' column='1' id='type-id-1301'/>
-    <class-decl name='growable_comment_array' size-in-bits='192' is-struct='yes' naming-typedef-id='type-id-1303' visibility='default' filepath='Parser/pegen.h' line='51' column='1' id='type-id-1304'>
+    <typedef-decl name='KeywordToken' type-id='type-id-1303' filepath='Parser/pegen.h' line='48' column='1' id='type-id-1302'/>
+    <class-decl name='growable_comment_array' size-in-bits='192' is-struct='yes' naming-typedef-id='type-id-1304' visibility='default' filepath='Parser/pegen.h' line='51' column='1' id='type-id-1305'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='items' type-id='type-id-1305' visibility='default' filepath='Parser/pegen.h' line='55' column='1'/>
+        <var-decl name='items' type-id='type-id-1306' visibility='default' filepath='Parser/pegen.h' line='55' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
         <var-decl name='size' type-id='type-id-19' visibility='default' filepath='Parser/pegen.h' line='56' column='1'/>
@@ -20274,7 +20289,7 @@
         <var-decl name='num_items' type-id='type-id-19' visibility='default' filepath='Parser/pegen.h' line='57' column='1'/>
       </data-member>
     </class-decl>
-    <class-decl name='__anonymous_struct__2' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' filepath='Parser/pegen.h' line='52' column='1' id='type-id-1306'>
+    <class-decl name='__anonymous_struct__2' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' filepath='Parser/pegen.h' line='52' column='1' id='type-id-1307'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='lineno' type-id='type-id-8' visibility='default' filepath='Parser/pegen.h' line='53' column='1'/>
       </data-member>
@@ -20282,13 +20297,13 @@
         <var-decl name='comment' type-id='type-id-15' visibility='default' filepath='Parser/pegen.h' line='54' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='growable_comment_array' type-id='type-id-1304' filepath='Parser/pegen.h' line='58' column='1' id='type-id-1303'/>
-    <class-decl name='Parser' size-in-bits='1280' is-struct='yes' naming-typedef-id='type-id-1307' visibility='default' filepath='Parser/pegen.h' line='60' column='1' id='type-id-1308'>
+    <typedef-decl name='growable_comment_array' type-id='type-id-1305' filepath='Parser/pegen.h' line='58' column='1' id='type-id-1304'/>
+    <class-decl name='Parser' size-in-bits='1280' is-struct='yes' naming-typedef-id='type-id-1308' visibility='default' filepath='Parser/pegen.h' line='60' column='1' id='type-id-1309'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='tok' type-id='type-id-1309' visibility='default' filepath='Parser/pegen.h' line='61' column='1'/>
+        <var-decl name='tok' type-id='type-id-1310' visibility='default' filepath='Parser/pegen.h' line='61' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='tokens' type-id='type-id-1310' visibility='default' filepath='Parser/pegen.h' line='62' column='1'/>
+        <var-decl name='tokens' type-id='type-id-1311' visibility='default' filepath='Parser/pegen.h' line='62' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
         <var-decl name='mark' type-id='type-id-8' visibility='default' filepath='Parser/pegen.h' line='63' column='1'/>
@@ -20303,7 +20318,7 @@
         <var-decl name='arena' type-id='type-id-572' visibility='default' filepath='Parser/pegen.h' line='65' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='keywords' type-id='type-id-1311' visibility='default' filepath='Parser/pegen.h' line='66' column='1'/>
+        <var-decl name='keywords' type-id='type-id-1312' visibility='default' filepath='Parser/pegen.h' line='66' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='384'>
         <var-decl name='soft_keywords' type-id='type-id-239' visibility='default' filepath='Parser/pegen.h' line='67' column='1'/>
@@ -20339,7 +20354,7 @@
         <var-decl name='feature_version' type-id='type-id-8' visibility='default' filepath='Parser/pegen.h' line='77' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='896'>
-        <var-decl name='type_ignore_comments' type-id='type-id-1303' visibility='default' filepath='Parser/pegen.h' line='78' column='1'/>
+        <var-decl name='type_ignore_comments' type-id='type-id-1304' visibility='default' filepath='Parser/pegen.h' line='78' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1088'>
         <var-decl name='known_err_token' type-id='type-id-578' visibility='default' filepath='Parser/pegen.h' line='79' column='1'/>
@@ -20354,19 +20369,19 @@
         <var-decl name='debug' type-id='type-id-8' visibility='default' filepath='Parser/pegen.h' line='82' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='Parser' type-id='type-id-1308' filepath='Parser/pegen.h' line='83' column='1' id='type-id-1307'/>
-    <enum-decl name='decoding_state' filepath='Parser/tokenizer.h' line='17' column='1' id='type-id-1140'>
+    <typedef-decl name='Parser' type-id='type-id-1309' filepath='Parser/pegen.h' line='83' column='1' id='type-id-1308'/>
+    <enum-decl name='decoding_state' filepath='Parser/tokenizer.h' line='17' column='1' id='type-id-1141'>
       <underlying-type type-id='type-id-24'/>
       <enumerator name='STATE_INIT' value='0'/>
       <enumerator name='STATE_SEEK_CODING' value='1'/>
       <enumerator name='STATE_NORMAL' value='2'/>
     </enum-decl>
-    <enum-decl name='interactive_underflow_t' filepath='Parser/tokenizer.h' line='23' column='1' id='type-id-1141'>
+    <enum-decl name='interactive_underflow_t' filepath='Parser/tokenizer.h' line='23' column='1' id='type-id-1142'>
       <underlying-type type-id='type-id-24'/>
       <enumerator name='IUNDERFLOW_NORMAL' value='0'/>
       <enumerator name='IUNDERFLOW_STOP' value='1'/>
     </enum-decl>
-    <class-decl name='token' size-in-bits='384' is-struct='yes' visibility='default' filepath='Parser/tokenizer.h' line='31' column='1' id='type-id-1312'>
+    <class-decl name='token' size-in-bits='384' is-struct='yes' visibility='default' filepath='Parser/tokenizer.h' line='31' column='1' id='type-id-1313'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='level' type-id='type-id-8' visibility='default' filepath='Parser/tokenizer.h' line='32' column='1'/>
       </data-member>
@@ -20392,14 +20407,14 @@
         <var-decl name='metadata' type-id='type-id-2' visibility='default' filepath='Parser/tokenizer.h' line='35' column='1'/>
       </data-member>
     </class-decl>
-    <enum-decl name='tokenizer_mode_kind_t' filepath='Parser/tokenizer.h' line='38' column='1' id='type-id-1313'>
+    <enum-decl name='tokenizer_mode_kind_t' filepath='Parser/tokenizer.h' line='38' column='1' id='type-id-1314'>
       <underlying-type type-id='type-id-24'/>
       <enumerator name='TOK_REGULAR_MODE' value='0'/>
       <enumerator name='TOK_FSTRING_MODE' value='1'/>
     </enum-decl>
-    <class-decl name='_tokenizer_mode' size-in-bits='768' is-struct='yes' visibility='default' filepath='Parser/tokenizer.h' line='45' column='1' id='type-id-1314'>
+    <class-decl name='_tokenizer_mode' size-in-bits='768' is-struct='yes' visibility='default' filepath='Parser/tokenizer.h' line='45' column='1' id='type-id-1315'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='kind' type-id='type-id-1313' visibility='default' filepath='Parser/tokenizer.h' line='46' column='1'/>
+        <var-decl name='kind' type-id='type-id-1314' visibility='default' filepath='Parser/tokenizer.h' line='46' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
         <var-decl name='curly_bracket_depth' type-id='type-id-8' visibility='default' filepath='Parser/tokenizer.h' line='48' column='1'/>
@@ -20444,8 +20459,8 @@
         <var-decl name='f_string_debug' type-id='type-id-8' visibility='default' filepath='Parser/tokenizer.h' line='64' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='tokenizer_mode' type-id='type-id-1314' filepath='Parser/tokenizer.h' line='65' column='1' id='type-id-1162'/>
-    <class-decl name='tok_state' size-in-bits='138240' is-struct='yes' visibility='default' filepath='Parser/tokenizer.h' line='68' column='1' id='type-id-1136'>
+    <typedef-decl name='tokenizer_mode' type-id='type-id-1315' filepath='Parser/tokenizer.h' line='65' column='1' id='type-id-1163'/>
+    <class-decl name='tok_state' size-in-bits='138240' is-struct='yes' visibility='default' filepath='Parser/tokenizer.h' line='68' column='1' id='type-id-1137'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='buf' type-id='type-id-15' visibility='default' filepath='Parser/tokenizer.h' line='71' column='1'/>
       </data-member>
@@ -20483,7 +20498,7 @@
         <var-decl name='indent' type-id='type-id-8' visibility='default' filepath='Parser/tokenizer.h' line='83' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='704'>
-        <var-decl name='indstack' type-id='type-id-1137' visibility='default' filepath='Parser/tokenizer.h' line='84' column='1'/>
+        <var-decl name='indstack' type-id='type-id-1138' visibility='default' filepath='Parser/tokenizer.h' line='84' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='3904'>
         <var-decl name='atbol' type-id='type-id-8' visibility='default' filepath='Parser/tokenizer.h' line='85' column='1'/>
@@ -20513,22 +20528,22 @@
         <var-decl name='level' type-id='type-id-8' visibility='default' filepath='Parser/tokenizer.h' line='93' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='4256'>
-        <var-decl name='parenstack' type-id='type-id-1138' visibility='default' filepath='Parser/tokenizer.h' line='95' column='1'/>
+        <var-decl name='parenstack' type-id='type-id-1139' visibility='default' filepath='Parser/tokenizer.h' line='95' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='5856'>
-        <var-decl name='parenlinenostack' type-id='type-id-1139' visibility='default' filepath='Parser/tokenizer.h' line='96' column='1'/>
+        <var-decl name='parenlinenostack' type-id='type-id-1140' visibility='default' filepath='Parser/tokenizer.h' line='96' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='12256'>
-        <var-decl name='parencolstack' type-id='type-id-1139' visibility='default' filepath='Parser/tokenizer.h' line='97' column='1'/>
+        <var-decl name='parencolstack' type-id='type-id-1140' visibility='default' filepath='Parser/tokenizer.h' line='97' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='18688'>
         <var-decl name='filename' type-id='type-id-2' visibility='default' filepath='Parser/tokenizer.h' line='98' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='18752'>
-        <var-decl name='altindstack' type-id='type-id-1137' visibility='default' filepath='Parser/tokenizer.h' line='100' column='1'/>
+        <var-decl name='altindstack' type-id='type-id-1138' visibility='default' filepath='Parser/tokenizer.h' line='100' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='21952'>
-        <var-decl name='decoding_state' type-id='type-id-1140' visibility='default' filepath='Parser/tokenizer.h' line='102' column='1'/>
+        <var-decl name='decoding_state' type-id='type-id-1141' visibility='default' filepath='Parser/tokenizer.h' line='102' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='21984'>
         <var-decl name='decoding_erred' type-id='type-id-8' visibility='default' filepath='Parser/tokenizer.h' line='103' column='1'/>
@@ -20579,13 +20594,13 @@
         <var-decl name='async_def_nl' type-id='type-id-8' visibility='default' filepath='Parser/tokenizer.h' line='123' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='22816'>
-        <var-decl name='interactive_underflow' type-id='type-id-1141' visibility='default' filepath='Parser/tokenizer.h' line='126' column='1'/>
+        <var-decl name='interactive_underflow' type-id='type-id-1142' visibility='default' filepath='Parser/tokenizer.h' line='126' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='22848'>
         <var-decl name='report_warnings' type-id='type-id-8' visibility='default' filepath='Parser/tokenizer.h' line='127' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='22912'>
-        <var-decl name='tok_mode_stack' type-id='type-id-1142' visibility='default' filepath='Parser/tokenizer.h' line='129' column='1'/>
+        <var-decl name='tok_mode_stack' type-id='type-id-1143' visibility='default' filepath='Parser/tokenizer.h' line='129' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='138112'>
         <var-decl name='tok_mode_stack_index' type-id='type-id-8' visibility='default' filepath='Parser/tokenizer.h' line='130' column='1'/>
@@ -20600,82 +20615,82 @@
         <var-decl name='implicit_newline' type-id='type-id-8' visibility='default' filepath='Parser/tokenizer.h' line='133' column='1'/>
       </data-member>
     </class-decl>
-    <pointer-type-def type-id='type-id-1288' size-in-bits='64' id='type-id-229'/>
-    <pointer-type-def type-id='type-id-1301' size-in-bits='64' id='type-id-1315'/>
-    <pointer-type-def type-id='type-id-1315' size-in-bits='64' id='type-id-1311'/>
-    <pointer-type-def type-id='type-id-1297' size-in-bits='64' id='type-id-1300'/>
-    <pointer-type-def type-id='type-id-1307' size-in-bits='64' id='type-id-577'/>
-    <pointer-type-def type-id='type-id-1258' size-in-bits='64' id='type-id-572'/>
-    <pointer-type-def type-id='type-id-1182' size-in-bits='64' id='type-id-1190'/>
-    <pointer-type-def type-id='type-id-1184' size-in-bits='64' id='type-id-1198'/>
-    <pointer-type-def type-id='type-id-1284' size-in-bits='64' id='type-id-338'/>
-    <pointer-type-def type-id='type-id-1177' size-in-bits='64' id='type-id-1194'/>
-    <pointer-type-def type-id='type-id-1285' size-in-bits='64' id='type-id-336'/>
-    <pointer-type-def type-id='type-id-1283' size-in-bits='64' id='type-id-337'/>
-    <pointer-type-def type-id='type-id-1166' size-in-bits='64' id='type-id-1192'/>
+    <pointer-type-def type-id='type-id-1289' size-in-bits='64' id='type-id-229'/>
+    <pointer-type-def type-id='type-id-1302' size-in-bits='64' id='type-id-1316'/>
+    <pointer-type-def type-id='type-id-1316' size-in-bits='64' id='type-id-1312'/>
+    <pointer-type-def type-id='type-id-1298' size-in-bits='64' id='type-id-1301'/>
+    <pointer-type-def type-id='type-id-1308' size-in-bits='64' id='type-id-577'/>
+    <pointer-type-def type-id='type-id-1259' size-in-bits='64' id='type-id-572'/>
+    <pointer-type-def type-id='type-id-1183' size-in-bits='64' id='type-id-1191'/>
+    <pointer-type-def type-id='type-id-1185' size-in-bits='64' id='type-id-1199'/>
+    <pointer-type-def type-id='type-id-1285' size-in-bits='64' id='type-id-338'/>
+    <pointer-type-def type-id='type-id-1178' size-in-bits='64' id='type-id-1195'/>
+    <pointer-type-def type-id='type-id-1286' size-in-bits='64' id='type-id-336'/>
+    <pointer-type-def type-id='type-id-1284' size-in-bits='64' id='type-id-337'/>
+    <pointer-type-def type-id='type-id-1167' size-in-bits='64' id='type-id-1193'/>
     <pointer-type-def type-id='type-id-345' size-in-bits='64' id='type-id-2'/>
-    <pointer-type-def type-id='type-id-1316' size-in-bits='64' id='type-id-1264'/>
-    <pointer-type-def type-id='type-id-1317' size-in-bits='64' id='type-id-1278'/>
-    <pointer-type-def type-id='type-id-1318' size-in-bits='64' id='type-id-1259'/>
-    <pointer-type-def type-id='type-id-1319' size-in-bits='64' id='type-id-1265'/>
-    <pointer-type-def type-id='type-id-1320' size-in-bits='64' id='type-id-1275'/>
-    <pointer-type-def type-id='type-id-1321' size-in-bits='64' id='type-id-1272'/>
-    <pointer-type-def type-id='type-id-1322' size-in-bits='64' id='type-id-1267'/>
-    <pointer-type-def type-id='type-id-1092' size-in-bits='64' id='type-id-741'/>
-    <pointer-type-def type-id='type-id-1323' size-in-bits='64' id='type-id-1276'/>
+    <pointer-type-def type-id='type-id-1317' size-in-bits='64' id='type-id-1265'/>
+    <pointer-type-def type-id='type-id-1318' size-in-bits='64' id='type-id-1279'/>
+    <pointer-type-def type-id='type-id-1319' size-in-bits='64' id='type-id-1260'/>
+    <pointer-type-def type-id='type-id-1320' size-in-bits='64' id='type-id-1266'/>
+    <pointer-type-def type-id='type-id-1321' size-in-bits='64' id='type-id-1276'/>
+    <pointer-type-def type-id='type-id-1322' size-in-bits='64' id='type-id-1273'/>
+    <pointer-type-def type-id='type-id-1323' size-in-bits='64' id='type-id-1268'/>
+    <pointer-type-def type-id='type-id-1093' size-in-bits='64' id='type-id-741'/>
     <pointer-type-def type-id='type-id-1324' size-in-bits='64' id='type-id-1277'/>
-    <qualified-type-def type-id='type-id-2' const='yes' id='type-id-1325'/>
-    <pointer-type-def type-id='type-id-1325' size-in-bits='64' id='type-id-248'/>
+    <pointer-type-def type-id='type-id-1325' size-in-bits='64' id='type-id-1278'/>
+    <qualified-type-def type-id='type-id-2' const='yes' id='type-id-1326'/>
+    <pointer-type-def type-id='type-id-1326' size-in-bits='64' id='type-id-248'/>
     <pointer-type-def type-id='type-id-2' size-in-bits='64' id='type-id-233'/>
-    <pointer-type-def type-id='type-id-1171' size-in-bits='64' id='type-id-1193'/>
+    <pointer-type-def type-id='type-id-1172' size-in-bits='64' id='type-id-1194'/>
     <pointer-type-def type-id='type-id-256' size-in-bits='64' id='type-id-1'/>
     <pointer-type-def type-id='type-id-243' size-in-bits='64' id='type-id-254'/>
     <pointer-type-def type-id='type-id-14' size-in-bits='64' id='type-id-13'/>
-    <pointer-type-def type-id='type-id-1298' size-in-bits='64' id='type-id-578'/>
-    <pointer-type-def type-id='type-id-578' size-in-bits='64' id='type-id-1310'/>
-    <pointer-type-def type-id='type-id-1287' size-in-bits='64' id='type-id-1291'/>
-    <pointer-type-def type-id='type-id-1152' size-in-bits='64' id='type-id-1293'/>
-    <pointer-type-def type-id='type-id-1289' size-in-bits='64' id='type-id-1292'/>
-    <pointer-type-def type-id='type-id-1153' size-in-bits='64' id='type-id-1290'/>
-    <pointer-type-def type-id='type-id-1154' size-in-bits='64' id='type-id-1294'/>
-    <pointer-type-def type-id='type-id-1306' size-in-bits='64' id='type-id-1305'/>
-    <pointer-type-def type-id='type-id-1155' size-in-bits='64' id='type-id-306'/>
+    <pointer-type-def type-id='type-id-1299' size-in-bits='64' id='type-id-578'/>
+    <pointer-type-def type-id='type-id-578' size-in-bits='64' id='type-id-1311'/>
+    <pointer-type-def type-id='type-id-1288' size-in-bits='64' id='type-id-1292'/>
+    <pointer-type-def type-id='type-id-1153' size-in-bits='64' id='type-id-1294'/>
+    <pointer-type-def type-id='type-id-1290' size-in-bits='64' id='type-id-1293'/>
+    <pointer-type-def type-id='type-id-1154' size-in-bits='64' id='type-id-1291'/>
+    <pointer-type-def type-id='type-id-1155' size-in-bits='64' id='type-id-1295'/>
+    <pointer-type-def type-id='type-id-1307' size-in-bits='64' id='type-id-1306'/>
+    <pointer-type-def type-id='type-id-1156' size-in-bits='64' id='type-id-306'/>
+    <pointer-type-def type-id='type-id-1257' size-in-bits='64' id='type-id-1222'/>
     <pointer-type-def type-id='type-id-1256' size-in-bits='64' id='type-id-1221'/>
     <pointer-type-def type-id='type-id-1255' size-in-bits='64' id='type-id-1220'/>
-    <pointer-type-def type-id='type-id-1254' size-in-bits='64' id='type-id-1219'/>
-    <pointer-type-def type-id='type-id-968' size-in-bits='64' id='type-id-1214'/>
-    <pointer-type-def type-id='type-id-1257' size-in-bits='64' id='type-id-1222'/>
-    <pointer-type-def type-id='type-id-1295' size-in-bits='64' id='type-id-1296'/>
-    <pointer-type-def type-id='type-id-1227' size-in-bits='64' id='type-id-574'/>
-    <pointer-type-def type-id='type-id-1225' size-in-bits='64' id='type-id-1145'/>
-    <pointer-type-def type-id='type-id-1223' size-in-bits='64' id='type-id-512'/>
-    <pointer-type-def type-id='type-id-1212' size-in-bits='64' id='type-id-573'/>
-    <pointer-type-def type-id='type-id-1229' size-in-bits='64' id='type-id-538'/>
+    <pointer-type-def type-id='type-id-969' size-in-bits='64' id='type-id-1215'/>
+    <pointer-type-def type-id='type-id-1258' size-in-bits='64' id='type-id-1223'/>
+    <pointer-type-def type-id='type-id-1296' size-in-bits='64' id='type-id-1297'/>
+    <pointer-type-def type-id='type-id-1228' size-in-bits='64' id='type-id-574'/>
+    <pointer-type-def type-id='type-id-1226' size-in-bits='64' id='type-id-1146'/>
+    <pointer-type-def type-id='type-id-1224' size-in-bits='64' id='type-id-512'/>
+    <pointer-type-def type-id='type-id-1213' size-in-bits='64' id='type-id-573'/>
+    <pointer-type-def type-id='type-id-1230' size-in-bits='64' id='type-id-538'/>
     <pointer-type-def type-id='type-id-15' size-in-bits='64' id='type-id-239'/>
     <pointer-type-def type-id='type-id-354' size-in-bits='64' id='type-id-339'/>
-    <pointer-type-def type-id='type-id-1326' size-in-bits='64' id='type-id-1270'/>
-    <pointer-type-def type-id='type-id-1327' size-in-bits='64' id='type-id-1269'/>
-    <pointer-type-def type-id='type-id-1328' size-in-bits='64' id='type-id-1208'/>
-    <pointer-type-def type-id='type-id-1329' size-in-bits='64' id='type-id-1281'/>
-    <pointer-type-def type-id='type-id-1330' size-in-bits='64' id='type-id-1273'/>
-    <pointer-type-def type-id='type-id-1331' size-in-bits='64' id='type-id-1268'/>
-    <pointer-type-def type-id='type-id-1332' size-in-bits='64' id='type-id-1271'/>
+    <pointer-type-def type-id='type-id-1327' size-in-bits='64' id='type-id-1271'/>
+    <pointer-type-def type-id='type-id-1328' size-in-bits='64' id='type-id-1270'/>
+    <pointer-type-def type-id='type-id-1329' size-in-bits='64' id='type-id-1209'/>
+    <pointer-type-def type-id='type-id-1330' size-in-bits='64' id='type-id-1282'/>
+    <pointer-type-def type-id='type-id-1331' size-in-bits='64' id='type-id-1274'/>
+    <pointer-type-def type-id='type-id-1332' size-in-bits='64' id='type-id-1269'/>
+    <pointer-type-def type-id='type-id-1333' size-in-bits='64' id='type-id-1272'/>
     <pointer-type-def type-id='type-id-238' size-in-bits='64' id='type-id-236'/>
     <pointer-type-def type-id='type-id-8' size-in-bits='64' id='type-id-179'/>
-    <pointer-type-def type-id='type-id-1136' size-in-bits='64' id='type-id-1309'/>
-    <pointer-type-def type-id='type-id-1312' size-in-bits='64' id='type-id-1333'/>
-    <pointer-type-def type-id='type-id-1334' size-in-bits='64' id='type-id-1180'/>
-    <pointer-type-def type-id='type-id-1335' size-in-bits='64' id='type-id-1274'/>
-    <pointer-type-def type-id='type-id-1336' size-in-bits='64' id='type-id-1266'/>
+    <pointer-type-def type-id='type-id-1137' size-in-bits='64' id='type-id-1310'/>
+    <pointer-type-def type-id='type-id-1313' size-in-bits='64' id='type-id-1334'/>
+    <pointer-type-def type-id='type-id-1335' size-in-bits='64' id='type-id-1181'/>
+    <pointer-type-def type-id='type-id-1336' size-in-bits='64' id='type-id-1275'/>
+    <pointer-type-def type-id='type-id-1337' size-in-bits='64' id='type-id-1267'/>
     <pointer-type-def type-id='type-id-314' size-in-bits='64' id='type-id-312'/>
-    <pointer-type-def type-id='type-id-1337' size-in-bits='64' id='type-id-1282'/>
-    <pointer-type-def type-id='type-id-1093' size-in-bits='64' id='type-id-769'/>
+    <pointer-type-def type-id='type-id-1338' size-in-bits='64' id='type-id-1283'/>
+    <pointer-type-def type-id='type-id-1094' size-in-bits='64' id='type-id-769'/>
     <pointer-type-def type-id='type-id-46' size-in-bits='64' id='type-id-22'/>
     <pointer-type-def type-id='type-id-22' size-in-bits='64' id='type-id-253'/>
-    <class-decl name='_IO_codecvt' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-1152'/>
-    <class-decl name='_IO_marker' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-1153'/>
-    <class-decl name='_IO_wide_data' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-1154'/>
-    <class-decl name='_arena' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-1156'/>
+    <class-decl name='_IO_codecvt' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-1153'/>
+    <class-decl name='_IO_marker' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-1154'/>
+    <class-decl name='_IO_wide_data' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-1155'/>
+    <class-decl name='_arena' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-1157'/>
     <function-decl name='PyBytes_FromStringAndSize' mangled-name='PyBytes_FromStringAndSize' filepath='./Include/bytesobject.h' line='34' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyBytes_FromStringAndSize'>
       <parameter type-id='type-id-12'/>
       <parameter type-id='type-id-14'/>
@@ -20762,25 +20777,25 @@
       <parameter type-id='type-id-47'/>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='PyLong_FromString' mangled-name='PyLong_FromString' filepath='./Include/longobject.h' line='74' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyLong_FromString'>
+    <function-decl name='PyLong_FromString' mangled-name='PyLong_FromString' filepath='./Include/longobject.h' line='91' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyLong_FromString'>
       <parameter type-id='type-id-12'/>
       <parameter type-id='type-id-239'/>
       <parameter type-id='type-id-8'/>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='PyOS_strtoul' mangled-name='PyOS_strtoul' filepath='./Include/longobject.h' line='79' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyOS_strtoul'>
+    <function-decl name='PyOS_strtoul' mangled-name='PyOS_strtoul' filepath='./Include/longobject.h' line='96' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyOS_strtoul'>
       <parameter type-id='type-id-12'/>
       <parameter type-id='type-id-239'/>
       <parameter type-id='type-id-8'/>
       <return type-id='type-id-28'/>
     </function-decl>
-    <function-decl name='PyOS_strtol' mangled-name='PyOS_strtol' filepath='./Include/longobject.h' line='80' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyOS_strtol'>
+    <function-decl name='PyOS_strtol' mangled-name='PyOS_strtol' filepath='./Include/longobject.h' line='97' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyOS_strtol'>
       <parameter type-id='type-id-12'/>
       <parameter type-id='type-id-239'/>
       <parameter type-id='type-id-8'/>
       <return type-id='type-id-47'/>
     </function-decl>
-    <function-decl name='_Py_Dealloc' mangled-name='_Py_Dealloc' filepath='./Include/object.h' line='611' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_Dealloc'>
+    <function-decl name='_Py_Dealloc' mangled-name='_Py_Dealloc' filepath='./Include/object.h' line='610' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_Dealloc'>
       <parameter type-id='type-id-2'/>
       <return type-id='type-id-46'/>
     </function-decl>
@@ -20879,19 +20894,19 @@
       <parameter type-id='type-id-12'/>
       <return type-id='type-id-19'/>
     </function-decl>
-    <function-decl name='_Pypegen_raise_decode_error' filepath='Parser/pegen.h' line='163' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_Pypegen_raise_decode_error' filepath='Parser/pegen.h' line='164' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-577'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='_PyPegen_raise_tokenizer_init_error' filepath='Parser/pegen.h' line='164' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_PyPegen_raise_tokenizer_init_error' filepath='Parser/pegen.h' line='165' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-2'/>
       <return type-id='type-id-46'/>
     </function-decl>
-    <function-decl name='_Pypegen_tokenizer_error' filepath='Parser/pegen.h' line='165' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_Pypegen_tokenizer_error' filepath='Parser/pegen.h' line='166' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-577'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='_PyPegen_raise_error' filepath='Parser/pegen.h' line='166' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_PyPegen_raise_error' filepath='Parser/pegen.h' line='167' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-577'/>
       <parameter type-id='type-id-2'/>
       <parameter type-id='type-id-8'/>
@@ -20899,7 +20914,7 @@
       <parameter is-variadic='yes'/>
       <return type-id='type-id-22'/>
     </function-decl>
-    <function-decl name='_PyPegen_raise_error_known_location' filepath='Parser/pegen.h' line='167' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_PyPegen_raise_error_known_location' filepath='Parser/pegen.h' line='168' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-577'/>
       <parameter type-id='type-id-2'/>
       <parameter type-id='type-id-14'/>
@@ -20910,12 +20925,12 @@
       <parameter type-id='type-id-306'/>
       <return type-id='type-id-22'/>
     </function-decl>
-    <function-decl name='_Pypegen_set_syntax_error' filepath='Parser/pegen.h' line='171' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_Pypegen_set_syntax_error' filepath='Parser/pegen.h' line='172' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-577'/>
       <parameter type-id='type-id-578'/>
       <return type-id='type-id-46'/>
     </function-decl>
-    <function-decl name='_PyPegen_parse' filepath='Parser/pegen.h' line='365' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_PyPegen_parse' filepath='Parser/pegen.h' line='366' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-577'/>
       <return type-id='type-id-22'/>
     </function-decl>
@@ -20923,56 +20938,50 @@
       <parameter type-id='type-id-12'/>
       <parameter type-id='type-id-8'/>
       <parameter type-id='type-id-8'/>
-      <return type-id='type-id-1309'/>
+      <return type-id='type-id-1310'/>
     </function-decl>
     <function-decl name='_PyTokenizer_FromUTF8' filepath='Parser/tokenizer.h' line='140' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-12'/>
       <parameter type-id='type-id-8'/>
       <parameter type-id='type-id-8'/>
-      <return type-id='type-id-1309'/>
+      <return type-id='type-id-1310'/>
     </function-decl>
     <function-decl name='_PyTokenizer_FromFile' filepath='Parser/tokenizer.h' line='142' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-229'/>
       <parameter type-id='type-id-12'/>
       <parameter type-id='type-id-12'/>
       <parameter type-id='type-id-12'/>
-      <return type-id='type-id-1309'/>
+      <return type-id='type-id-1310'/>
     </function-decl>
     <function-decl name='_PyTokenizer_Free' filepath='Parser/tokenizer.h' line='144' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-1309'/>
+      <parameter type-id='type-id-1310'/>
       <return type-id='type-id-46'/>
     </function-decl>
     <function-decl name='_PyToken_Free' filepath='Parser/tokenizer.h' line='145' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-1333'/>
+      <parameter type-id='type-id-1334'/>
       <return type-id='type-id-46'/>
     </function-decl>
     <function-decl name='_PyToken_Init' filepath='Parser/tokenizer.h' line='146' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-1333'/>
+      <parameter type-id='type-id-1334'/>
       <return type-id='type-id-46'/>
     </function-decl>
     <function-decl name='_PyTokenizer_Get' filepath='Parser/tokenizer.h' line='147' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-1309'/>
-      <parameter type-id='type-id-1333'/>
+      <parameter type-id='type-id-1310'/>
+      <parameter type-id='type-id-1334'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-type size-in-bits='64' id='type-id-1316'>
+    <function-type size-in-bits='64' id='type-id-1317'>
       <parameter type-id='type-id-2'/>
       <return type-id='type-id-2'/>
     </function-type>
-    <function-type size-in-bits='64' id='type-id-1317'>
+    <function-type size-in-bits='64' id='type-id-1318'>
       <parameter type-id='type-id-2'/>
       <parameter type-id='type-id-248'/>
       <parameter type-id='type-id-19'/>
       <parameter type-id='type-id-2'/>
       <return type-id='type-id-2'/>
     </function-type>
-    <function-type size-in-bits='64' id='type-id-1318'>
-      <parameter type-id='type-id-2'/>
-      <parameter type-id='type-id-2'/>
-      <return type-id='type-id-2'/>
-    </function-type>
     <function-type size-in-bits='64' id='type-id-1319'>
-      <parameter type-id='type-id-2'/>
       <parameter type-id='type-id-2'/>
       <parameter type-id='type-id-2'/>
       <return type-id='type-id-2'/>
@@ -20980,37 +20989,37 @@
     <function-type size-in-bits='64' id='type-id-1320'>
       <parameter type-id='type-id-2'/>
       <parameter type-id='type-id-2'/>
-      <parameter type-id='type-id-8'/>
+      <parameter type-id='type-id-2'/>
       <return type-id='type-id-2'/>
     </function-type>
     <function-type size-in-bits='64' id='type-id-1321'>
       <parameter type-id='type-id-2'/>
-      <parameter type-id='type-id-15'/>
+      <parameter type-id='type-id-2'/>
+      <parameter type-id='type-id-8'/>
       <return type-id='type-id-2'/>
     </function-type>
     <function-type size-in-bits='64' id='type-id-1322'>
       <parameter type-id='type-id-2'/>
-      <parameter type-id='type-id-14'/>
+      <parameter type-id='type-id-15'/>
       <return type-id='type-id-2'/>
     </function-type>
     <function-type size-in-bits='64' id='type-id-1323'>
-      <parameter type-id='type-id-1'/>
       <parameter type-id='type-id-2'/>
-      <parameter type-id='type-id-2'/>
+      <parameter type-id='type-id-14'/>
       <return type-id='type-id-2'/>
     </function-type>
     <function-type size-in-bits='64' id='type-id-1324'>
       <parameter type-id='type-id-1'/>
+      <parameter type-id='type-id-2'/>
+      <parameter type-id='type-id-2'/>
+      <return type-id='type-id-2'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-1325'>
+      <parameter type-id='type-id-1'/>
       <parameter type-id='type-id-14'/>
       <return type-id='type-id-2'/>
     </function-type>
-    <function-type size-in-bits='64' id='type-id-1326'>
-      <parameter type-id='type-id-2'/>
-      <parameter type-id='type-id-2'/>
-      <return type-id='type-id-8'/>
-    </function-type>
     <function-type size-in-bits='64' id='type-id-1327'>
-      <parameter type-id='type-id-2'/>
       <parameter type-id='type-id-2'/>
       <parameter type-id='type-id-2'/>
       <return type-id='type-id-8'/>
@@ -21018,48 +21027,54 @@
     <function-type size-in-bits='64' id='type-id-1328'>
       <parameter type-id='type-id-2'/>
       <parameter type-id='type-id-2'/>
-      <parameter type-id='type-id-22'/>
+      <parameter type-id='type-id-2'/>
       <return type-id='type-id-8'/>
     </function-type>
     <function-type size-in-bits='64' id='type-id-1329'>
+      <parameter type-id='type-id-2'/>
+      <parameter type-id='type-id-2'/>
+      <parameter type-id='type-id-22'/>
+      <return type-id='type-id-8'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-1330'>
       <parameter type-id='type-id-2'/>
       <parameter type-id='type-id-254'/>
       <parameter type-id='type-id-8'/>
       <return type-id='type-id-8'/>
     </function-type>
-    <function-type size-in-bits='64' id='type-id-1330'>
+    <function-type size-in-bits='64' id='type-id-1331'>
       <parameter type-id='type-id-2'/>
       <parameter type-id='type-id-15'/>
       <parameter type-id='type-id-2'/>
       <return type-id='type-id-8'/>
     </function-type>
-    <function-type size-in-bits='64' id='type-id-1331'>
+    <function-type size-in-bits='64' id='type-id-1332'>
       <parameter type-id='type-id-2'/>
       <parameter type-id='type-id-14'/>
       <parameter type-id='type-id-2'/>
       <return type-id='type-id-8'/>
     </function-type>
-    <function-type size-in-bits='64' id='type-id-1332'>
+    <function-type size-in-bits='64' id='type-id-1333'>
       <parameter type-id='type-id-2'/>
       <parameter type-id='type-id-341'/>
       <parameter type-id='type-id-22'/>
       <return type-id='type-id-8'/>
     </function-type>
-    <function-type size-in-bits='64' id='type-id-1334'>
+    <function-type size-in-bits='64' id='type-id-1335'>
       <parameter type-id='type-id-2'/>
       <parameter type-id='type-id-2'/>
       <parameter type-id='type-id-233'/>
       <return type-id='type-id-255'/>
     </function-type>
-    <function-type size-in-bits='64' id='type-id-1335'>
+    <function-type size-in-bits='64' id='type-id-1336'>
       <parameter type-id='type-id-2'/>
       <return type-id='type-id-305'/>
     </function-type>
-    <function-type size-in-bits='64' id='type-id-1336'>
+    <function-type size-in-bits='64' id='type-id-1337'>
       <parameter type-id='type-id-2'/>
       <return type-id='type-id-14'/>
     </function-type>
-    <function-type size-in-bits='64' id='type-id-1337'>
+    <function-type size-in-bits='64' id='type-id-1338'>
       <parameter type-id='type-id-2'/>
       <parameter type-id='type-id-254'/>
       <return type-id='type-id-46'/>
@@ -21077,7 +21092,7 @@
       <parameter is-variadic='yes'/>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='PyObject_Str' mangled-name='PyObject_Str' filepath='./Include/object.h' line='403' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyObject_Str'>
+    <function-decl name='PyObject_Str' mangled-name='PyObject_Str' filepath='./Include/object.h' line='402' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyObject_Str'>
       <parameter type-id='type-id-2'/>
       <return type-id='type-id-2'/>
     </function-decl>
@@ -21183,14 +21198,14 @@
     </function-decl>
   </abi-instr>
   <abi-instr address-size='64' path='Parser/token.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
-    <array-type-def dimensions='1' type-id='type-id-430' size-in-bits='4416' id='type-id-1338'>
-      <subrange length='69' type-id='type-id-28' id='type-id-1339'/>
+    <array-type-def dimensions='1' type-id='type-id-430' size-in-bits='4416' id='type-id-1339'>
+      <subrange length='69' type-id='type-id-28' id='type-id-1340'/>
     </array-type-def>
-    <array-type-def dimensions='1' type-id='type-id-430' size-in-bits='infinite' id='type-id-1340'>
+    <array-type-def dimensions='1' type-id='type-id-430' size-in-bits='infinite' id='type-id-1341'>
       <subrange length='infinite' id='type-id-225'/>
     </array-type-def>
     <qualified-type-def type-id='type-id-12' const='yes' id='type-id-430'/>
-    <var-decl name='_PyParser_TokenNames' type-id='type-id-1340' mangled-name='_PyParser_TokenNames' visibility='default' filepath='./Include/internal/pycore_token.h' line='100' column='1' elf-symbol-id='_PyParser_TokenNames'/>
+    <var-decl name='_PyParser_TokenNames' type-id='type-id-1341' mangled-name='_PyParser_TokenNames' visibility='default' filepath='./Include/internal/pycore_token.h' line='100' column='1' elf-symbol-id='_PyParser_TokenNames'/>
     <function-decl name='_PyToken_OneChar' mangled-name='_PyToken_OneChar' filepath='Parser/token.c' line='83' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyToken_OneChar'>
       <parameter type-id='type-id-8' name='c1' filepath='Parser/token.c' line='83' column='1'/>
       <return type-id='type-id-8'/>
@@ -21208,9 +21223,9 @@
     </function-decl>
   </abi-instr>
   <abi-instr address-size='64' path='Parser/tokenizer.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
-    <qualified-type-def type-id='type-id-84' const='yes' id='type-id-1341'/>
-    <pointer-type-def type-id='type-id-1341' size-in-bits='64' id='type-id-1342'/>
+    <qualified-type-def type-id='type-id-84' const='yes' id='type-id-1342'/>
     <pointer-type-def type-id='type-id-1342' size-in-bits='64' id='type-id-1343'/>
+    <pointer-type-def type-id='type-id-1343' size-in-bits='64' id='type-id-1344'/>
     <pointer-type-def type-id='type-id-19' size-in-bits='64' id='type-id-446'/>
     <function-decl name='PyObject_CallNoArgs' mangled-name='PyObject_CallNoArgs' filepath='./Include/abstract.h' line='146' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyObject_CallNoArgs'>
       <parameter type-id='type-id-2'/>
@@ -21267,7 +21282,7 @@
       <parameter is-variadic='yes'/>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='PyObject_GetAttr' mangled-name='PyObject_GetAttr' filepath='./Include/object.h' line='411' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyObject_GetAttr'>
+    <function-decl name='PyObject_GetAttr' mangled-name='PyObject_GetAttr' filepath='./Include/object.h' line='410' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyObject_GetAttr'>
       <parameter type-id='type-id-2'/>
       <parameter type-id='type-id-2'/>
       <return type-id='type-id-2'/>
@@ -21307,7 +21322,7 @@
       <return type-id='type-id-12'/>
     </function-decl>
     <function-decl name='__ctype_b_loc' filepath='/usr/include/ctype.h' line='79' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-1343'/>
+      <return type-id='type-id-1344'/>
     </function-decl>
     <function-decl name='tolower' filepath='/usr/include/ctype.h' line='122' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-8'/>
@@ -21360,7 +21375,7 @@
       <parameter type-id='type-id-47'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='PyInit__ast' mangled-name='PyInit__ast' filepath='Python/Python-ast.c' line='13062' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyInit__ast'>
+    <function-decl name='PyInit__ast' mangled-name='PyInit__ast' filepath='Python/Python-ast.c' line='13140' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyInit__ast'>
       <return type-id='type-id-2'/>
     </function-decl>
   </abi-instr>
@@ -21376,12 +21391,17 @@
       <parameter type-id='type-id-1'/>
       <return type-id='type-id-8'/>
     </function-decl>
+    <function-decl name='_PyPegen_byte_offset_to_character_offset_raw' filepath='Python/../Parser/pegen.h' line='154' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-12'/>
+      <parameter type-id='type-id-14'/>
+      <return type-id='type-id-14'/>
+    </function-decl>
     <function-decl name='_PyTokenizer_FromReadline' filepath='Python/../Parser/tokenizer.h' line='141' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-2'/>
       <parameter type-id='type-id-12'/>
       <parameter type-id='type-id-8'/>
       <parameter type-id='type-id-8'/>
-      <return type-id='type-id-1309'/>
+      <return type-id='type-id-1310'/>
     </function-decl>
     <function-decl name='PyInit__tokenize' mangled-name='PyInit__tokenize' filepath='Python/Python-tokenize.c' line='364' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyInit__tokenize'>
       <return type-id='type-id-2'/>
@@ -21489,7 +21509,7 @@
     </function-decl>
   </abi-instr>
   <abi-instr address-size='64' path='Python/bltinmodule.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
-    <pointer-type-def type-id='type-id-1156' size-in-bits='64' id='type-id-1344'/>
+    <pointer-type-def type-id='type-id-1157' size-in-bits='64' id='type-id-1345'/>
     <var-decl name='PyFilter_Type' type-id='type-id-256' mangled-name='PyFilter_Type' visibility='default' filepath='./Include/bltinmodule.h' line='7' column='1' elf-symbol-id='PyFilter_Type'/>
     <var-decl name='PyMap_Type' type-id='type-id-256' mangled-name='PyMap_Type' visibility='default' filepath='./Include/bltinmodule.h' line='8' column='1' elf-symbol-id='PyMap_Type'/>
     <var-decl name='PyZip_Type' type-id='type-id-256' mangled-name='PyZip_Type' visibility='default' filepath='./Include/bltinmodule.h' line='9' column='1' elf-symbol-id='PyZip_Type'/>
@@ -21571,7 +21591,7 @@
       <parameter type-id='type-id-2'/>
       <parameter type-id='type-id-208'/>
       <parameter type-id='type-id-8'/>
-      <parameter type-id='type-id-1344'/>
+      <parameter type-id='type-id-1345'/>
       <return type-id='type-id-328'/>
     </function-decl>
     <function-decl name='_PyFloat_ExactDealloc' filepath='./Include/internal/pycore_floatobject.h' line='53' column='1' visibility='default' binding='global' size-in-bits='64'>
@@ -21673,11 +21693,11 @@
       <parameter type-id='type-id-2'/>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='PyInterpreterState_ThreadHead' mangled-name='PyInterpreterState_ThreadHead' filepath='./Include/cpython/pystate.h' line='317' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyInterpreterState_ThreadHead'>
+    <function-decl name='PyInterpreterState_ThreadHead' mangled-name='PyInterpreterState_ThreadHead' filepath='./Include/cpython/pystate.h' line='329' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyInterpreterState_ThreadHead'>
       <parameter type-id='type-id-20'/>
       <return type-id='type-id-177'/>
     </function-decl>
-    <function-decl name='PyThreadState_Next' mangled-name='PyThreadState_Next' filepath='./Include/cpython/pystate.h' line='318' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyThreadState_Next'>
+    <function-decl name='PyThreadState_Next' mangled-name='PyThreadState_Next' filepath='./Include/cpython/pystate.h' line='330' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyThreadState_Next'>
       <parameter type-id='type-id-177'/>
       <return type-id='type-id-177'/>
     </function-decl>
@@ -21704,11 +21724,11 @@
       <parameter type-id='type-id-2'/>
       <return type-id='type-id-46'/>
     </function-decl>
-    <function-decl name='_Py_MakeCoro' filepath='./Include/internal/pycore_ceval.h' line='153' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_Py_MakeCoro' filepath='./Include/internal/pycore_ceval.h' line='154' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-310'/>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='_Py_HandlePending' filepath='./Include/internal/pycore_ceval.h' line='155' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_Py_HandlePending' filepath='./Include/internal/pycore_ceval.h' line='156' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-177'/>
       <return type-id='type-id-8'/>
     </function-decl>
@@ -21789,7 +21809,7 @@
       <parameter type-id='type-id-859'/>
       <return type-id='type-id-46'/>
     </function-decl>
-    <function-decl name='_Py_Instrument' filepath='./Include/internal/pycore_code.h' line='486' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_Py_Instrument' filepath='./Include/internal/pycore_code.h' line='488' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-328'/>
       <parameter type-id='type-id-20'/>
       <return type-id='type-id-8'/>
@@ -21814,21 +21834,21 @@
       <parameter type-id='type-id-2'/>
       <return type-id='type-id-46'/>
     </function-decl>
-    <function-decl name='_PyFrame_GetLocals' filepath='./Include/internal/pycore_frame.h' line='230' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_PyFrame_GetLocals' filepath='./Include/internal/pycore_frame.h' line='232' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-374'/>
       <parameter type-id='type-id-8'/>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='_PyFrame_FastToLocalsWithError' filepath='./Include/internal/pycore_frame.h' line='233' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_PyFrame_FastToLocalsWithError' filepath='./Include/internal/pycore_frame.h' line='235' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-374'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='_PyThreadState_PushFrame' filepath='./Include/internal/pycore_frame.h' line='251' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_PyThreadState_PushFrame' filepath='./Include/internal/pycore_frame.h' line='253' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-177'/>
       <parameter type-id='type-id-19'/>
       <return type-id='type-id-374'/>
     </function-decl>
-    <function-decl name='_PyThreadState_PopFrame' filepath='./Include/internal/pycore_frame.h' line='253' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_PyThreadState_PopFrame' filepath='./Include/internal/pycore_frame.h' line='255' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-177'/>
       <parameter type-id='type-id-374'/>
       <return type-id='type-id-46'/>
@@ -21944,7 +21964,7 @@
       <parameter type-id='type-id-14'/>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='_PySuper_Lookup' filepath='./Include/internal/pycore_typeobject.h' line='142' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_PySuper_Lookup' filepath='./Include/internal/pycore_typeobject.h' line='144' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-1'/>
       <parameter type-id='type-id-2'/>
       <parameter type-id='type-id-2'/>
@@ -22010,35 +22030,35 @@
     <function-decl name='PyEval_GetFrame' mangled-name='PyEval_GetFrame' filepath='Python/ceval.c' line='2276' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyEval_GetFrame'>
       <return type-id='type-id-365'/>
     </function-decl>
-    <function-decl name='_PyEval_GetBuiltinId' mangled-name='_PyEval_GetBuiltinId' filepath='Python/ceval.c' line='2322' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyEval_GetBuiltinId'>
-      <parameter type-id='type-id-309' name='name' filepath='Python/ceval.c' line='2322' column='1'/>
+    <function-decl name='_PyEval_GetBuiltinId' mangled-name='_PyEval_GetBuiltinId' filepath='Python/ceval.c' line='2319' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyEval_GetBuiltinId'>
+      <parameter type-id='type-id-309' name='name' filepath='Python/ceval.c' line='2319' column='1'/>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='PyEval_GetLocals' mangled-name='PyEval_GetLocals' filepath='Python/ceval.c' line='2328' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyEval_GetLocals'>
+    <function-decl name='PyEval_GetLocals' mangled-name='PyEval_GetLocals' filepath='Python/ceval.c' line='2325' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyEval_GetLocals'>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='PyEval_GetFuncName' mangled-name='PyEval_GetFuncName' filepath='Python/ceval.c' line='2390' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyEval_GetFuncName'>
-      <parameter type-id='type-id-2' name='func' filepath='Python/ceval.c' line='2390' column='1'/>
+    <function-decl name='PyEval_GetFuncName' mangled-name='PyEval_GetFuncName' filepath='Python/ceval.c' line='2387' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyEval_GetFuncName'>
+      <parameter type-id='type-id-2' name='func' filepath='Python/ceval.c' line='2387' column='1'/>
       <return type-id='type-id-12'/>
     </function-decl>
-    <function-decl name='PyEval_GetFuncDesc' mangled-name='PyEval_GetFuncDesc' filepath='Python/ceval.c' line='2403' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyEval_GetFuncDesc'>
-      <parameter type-id='type-id-2' name='func' filepath='Python/ceval.c' line='2403' column='1'/>
+    <function-decl name='PyEval_GetFuncDesc' mangled-name='PyEval_GetFuncDesc' filepath='Python/ceval.c' line='2400' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyEval_GetFuncDesc'>
+      <parameter type-id='type-id-2' name='func' filepath='Python/ceval.c' line='2400' column='1'/>
       <return type-id='type-id-12'/>
     </function-decl>
-    <function-decl name='PyUnstable_Eval_RequestCodeExtraIndex' mangled-name='PyUnstable_Eval_RequestCodeExtraIndex' filepath='Python/ceval.c' line='2775' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyUnstable_Eval_RequestCodeExtraIndex'>
-      <parameter type-id='type-id-397' name='free' filepath='Python/ceval.c' line='2775' column='1'/>
+    <function-decl name='PyUnstable_Eval_RequestCodeExtraIndex' mangled-name='PyUnstable_Eval_RequestCodeExtraIndex' filepath='Python/ceval.c' line='2771' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyUnstable_Eval_RequestCodeExtraIndex'>
+      <parameter type-id='type-id-397' name='free' filepath='Python/ceval.c' line='2771' column='1'/>
       <return type-id='type-id-14'/>
     </function-decl>
-    <function-decl name='Py_EnterRecursiveCall' mangled-name='Py_EnterRecursiveCall' filepath='Python/ceval.c' line='2791' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='Py_EnterRecursiveCall'>
-      <parameter type-id='type-id-12' name='where' filepath='Python/ceval.c' line='2791' column='1'/>
+    <function-decl name='Py_EnterRecursiveCall' mangled-name='Py_EnterRecursiveCall' filepath='Python/ceval.c' line='2787' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='Py_EnterRecursiveCall'>
+      <parameter type-id='type-id-12' name='where' filepath='Python/ceval.c' line='2787' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='Py_LeaveRecursiveCall' mangled-name='Py_LeaveRecursiveCall' filepath='Python/ceval.c' line='2796' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='Py_LeaveRecursiveCall'>
+    <function-decl name='Py_LeaveRecursiveCall' mangled-name='Py_LeaveRecursiveCall' filepath='Python/ceval.c' line='2792' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='Py_LeaveRecursiveCall'>
       <return type-id='type-id-46'/>
     </function-decl>
   </abi-instr>
   <abi-instr address-size='64' path='Python/ceval_gil.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
-    <union-decl name='pthread_mutexattr_t' size-in-bits='32' naming-typedef-id='type-id-1345' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h' line='32' column='1' id='type-id-1346'>
+    <union-decl name='pthread_mutexattr_t' size-in-bits='32' naming-typedef-id='type-id-1346' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h' line='32' column='1' id='type-id-1347'>
       <data-member access='public'>
         <var-decl name='__size' type-id='type-id-629' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h' line='34' column='1'/>
       </data-member>
@@ -22046,33 +22066,33 @@
         <var-decl name='__align' type-id='type-id-8' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h' line='35' column='1'/>
       </data-member>
     </union-decl>
-    <typedef-decl name='pthread_mutexattr_t' type-id='type-id-1346' filepath='/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h' line='36' column='1' id='type-id-1345'/>
-    <typedef-decl name='__time_t' type-id='type-id-47' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='160' column='1' id='type-id-1347'/>
+    <typedef-decl name='pthread_mutexattr_t' type-id='type-id-1347' filepath='/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h' line='36' column='1' id='type-id-1346'/>
+    <typedef-decl name='__time_t' type-id='type-id-47' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='160' column='1' id='type-id-1348'/>
     <typedef-decl name='__syscall_slong_t' type-id='type-id-47' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='197' column='1' id='type-id-116'/>
-    <class-decl name='timespec' size-in-bits='128' is-struct='yes' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_timespec.h' line='11' column='1' id='type-id-1348'>
+    <class-decl name='timespec' size-in-bits='128' is-struct='yes' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_timespec.h' line='11' column='1' id='type-id-1349'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='tv_sec' type-id='type-id-1347' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_timespec.h' line='16' column='1'/>
+        <var-decl name='tv_sec' type-id='type-id-1348' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_timespec.h' line='16' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
         <var-decl name='tv_nsec' type-id='type-id-116' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_timespec.h' line='21' column='1'/>
       </data-member>
     </class-decl>
-    <pointer-type-def type-id='type-id-810' size-in-bits='64' id='type-id-1349'/>
-    <qualified-type-def type-id='type-id-1345' const='yes' id='type-id-1350'/>
-    <pointer-type-def type-id='type-id-1350' size-in-bits='64' id='type-id-1351'/>
-    <qualified-type-def type-id='type-id-1348' const='yes' id='type-id-1352'/>
-    <pointer-type-def type-id='type-id-1352' size-in-bits='64' id='type-id-188'/>
+    <pointer-type-def type-id='type-id-810' size-in-bits='64' id='type-id-1350'/>
+    <qualified-type-def type-id='type-id-1346' const='yes' id='type-id-1351'/>
+    <pointer-type-def type-id='type-id-1351' size-in-bits='64' id='type-id-1352'/>
+    <qualified-type-def type-id='type-id-1349' const='yes' id='type-id-1353'/>
+    <pointer-type-def type-id='type-id-1353' size-in-bits='64' id='type-id-188'/>
     <qualified-type-def type-id='type-id-188' restrict='yes' id='type-id-206'/>
-    <pointer-type-def type-id='type-id-867' size-in-bits='64' id='type-id-1353'/>
-    <qualified-type-def type-id='type-id-1353' restrict='yes' id='type-id-1354'/>
-    <pointer-type-def type-id='type-id-868' size-in-bits='64' id='type-id-1355'/>
-    <qualified-type-def type-id='type-id-1355' restrict='yes' id='type-id-1356'/>
-    <pointer-type-def type-id='type-id-1348' size-in-bits='64' id='type-id-180'/>
+    <pointer-type-def type-id='type-id-867' size-in-bits='64' id='type-id-1354'/>
+    <qualified-type-def type-id='type-id-1354' restrict='yes' id='type-id-1355'/>
+    <pointer-type-def type-id='type-id-868' size-in-bits='64' id='type-id-1356'/>
+    <qualified-type-def type-id='type-id-1356' restrict='yes' id='type-id-1357'/>
+    <pointer-type-def type-id='type-id-1349' size-in-bits='64' id='type-id-180'/>
     <function-decl name='_PyThread_at_fork_reinit' mangled-name='_PyThread_at_fork_reinit' filepath='./Include/cpython/pythread.h' line='11' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyThread_at_fork_reinit'>
-      <parameter type-id='type-id-1349'/>
+      <parameter type-id='type-id-1350'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='_PyThreadState_SwapNoGIL' filepath='./Include/internal/pycore_ceval.h' line='105' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_PyThreadState_SwapNoGIL' filepath='./Include/internal/pycore_ceval.h' line='106' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-177'/>
       <return type-id='type-id-177'/>
     </function-decl>
@@ -22110,38 +22130,38 @@
       <return type-id='type-id-46'/>
     </function-decl>
     <function-decl name='pthread_mutex_init' filepath='/usr/include/pthread.h' line='781' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-1355'/>
-      <parameter type-id='type-id-1351'/>
+      <parameter type-id='type-id-1356'/>
+      <parameter type-id='type-id-1352'/>
       <return type-id='type-id-8'/>
     </function-decl>
     <function-decl name='pthread_mutex_destroy' filepath='/usr/include/pthread.h' line='786' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-1355'/>
+      <parameter type-id='type-id-1356'/>
       <return type-id='type-id-8'/>
     </function-decl>
     <function-decl name='pthread_mutex_lock' filepath='/usr/include/pthread.h' line='794' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-1355'/>
+      <parameter type-id='type-id-1356'/>
       <return type-id='type-id-8'/>
     </function-decl>
     <function-decl name='pthread_mutex_unlock' filepath='/usr/include/pthread.h' line='835' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-1355'/>
+      <parameter type-id='type-id-1356'/>
       <return type-id='type-id-8'/>
     </function-decl>
     <function-decl name='pthread_cond_destroy' filepath='/usr/include/pthread.h' line='1117' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-1353'/>
+      <parameter type-id='type-id-1354'/>
       <return type-id='type-id-8'/>
     </function-decl>
     <function-decl name='pthread_cond_signal' filepath='/usr/include/pthread.h' line='1121' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-1353'/>
+      <parameter type-id='type-id-1354'/>
       <return type-id='type-id-8'/>
     </function-decl>
     <function-decl name='pthread_cond_wait' filepath='/usr/include/pthread.h' line='1133' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-1354'/>
-      <parameter type-id='type-id-1356'/>
+      <parameter type-id='type-id-1355'/>
+      <parameter type-id='type-id-1357'/>
       <return type-id='type-id-8'/>
     </function-decl>
     <function-decl name='pthread_cond_timedwait' filepath='/usr/include/pthread.h' line='1145' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-1354'/>
-      <parameter type-id='type-id-1356'/>
+      <parameter type-id='type-id-1355'/>
+      <parameter type-id='type-id-1357'/>
       <parameter type-id='type-id-206'/>
       <return type-id='type-id-8'/>
     </function-decl>
@@ -22200,7 +22220,7 @@
       <return type-id='type-id-8'/>
     </function-decl>
     <function-decl name='_PyThread_cond_init' filepath='Python/condvar.h' line='52' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-1353'/>
+      <parameter type-id='type-id-1354'/>
       <return type-id='type-id-8'/>
     </function-decl>
     <function-decl name='_PyThread_cond_after' filepath='Python/condvar.h' line='53' column='1' visibility='default' binding='global' size-in-bits='64'>
@@ -22301,16 +22321,16 @@
     </function-decl>
   </abi-instr>
   <abi-instr address-size='64' path='Python/compile.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
-    <array-type-def dimensions='1' type-id='type-id-1357' size-in-bits='1344' id='type-id-1358'>
-      <subrange length='21' type-id='type-id-28' id='type-id-679'/>
+    <array-type-def dimensions='1' type-id='type-id-1358' size-in-bits='1408' id='type-id-1359'>
+      <subrange length='22' type-id='type-id-28' id='type-id-1360'/>
     </array-type-def>
-    <array-type-def dimensions='1' type-id='type-id-1359' size-in-bits='288' id='type-id-1360'>
+    <array-type-def dimensions='1' type-id='type-id-1361' size-in-bits='288' id='type-id-1362'>
       <subrange length='9' type-id='type-id-28' id='type-id-704'/>
     </array-type-def>
-    <array-type-def dimensions='1' type-id='type-id-326' size-in-bits='2048' id='type-id-1361'>
+    <array-type-def dimensions='1' type-id='type-id-326' size-in-bits='2048' id='type-id-1363'>
       <subrange length='256' type-id='type-id-28' id='type-id-62'/>
     </array-type-def>
-    <class-decl name='_PyCompilerSrcLocation' size-in-bits='128' is-struct='yes' naming-typedef-id='type-id-1362' visibility='default' filepath='./Include/cpython/compile.h' line='35' column='1' id='type-id-1363'>
+    <class-decl name='_PyCompilerSrcLocation' size-in-bits='128' is-struct='yes' naming-typedef-id='type-id-1364' visibility='default' filepath='./Include/cpython/compile.h' line='35' column='1' id='type-id-1365'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='lineno' type-id='type-id-8' visibility='default' filepath='./Include/cpython/compile.h' line='36' column='1'/>
       </data-member>
@@ -22324,17 +22344,17 @@
         <var-decl name='end_col_offset' type-id='type-id-8' visibility='default' filepath='./Include/cpython/compile.h' line='39' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='_PyCompilerSrcLocation' type-id='type-id-1363' filepath='./Include/cpython/compile.h' line='40' column='1' id='type-id-1362'/>
-    <class-decl name='PyFutureFeatures' size-in-bits='160' is-struct='yes' naming-typedef-id='type-id-1364' visibility='default' filepath='./Include/cpython/compile.h' line='51' column='1' id='type-id-1365'>
+    <typedef-decl name='_PyCompilerSrcLocation' type-id='type-id-1365' filepath='./Include/cpython/compile.h' line='40' column='1' id='type-id-1364'/>
+    <class-decl name='PyFutureFeatures' size-in-bits='160' is-struct='yes' naming-typedef-id='type-id-1366' visibility='default' filepath='./Include/cpython/compile.h' line='51' column='1' id='type-id-1367'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='ff_features' type-id='type-id-8' visibility='default' filepath='./Include/cpython/compile.h' line='52' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='ff_location' type-id='type-id-1362' visibility='default' filepath='./Include/cpython/compile.h' line='53' column='1'/>
+        <var-decl name='ff_location' type-id='type-id-1364' visibility='default' filepath='./Include/cpython/compile.h' line='53' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='PyFutureFeatures' type-id='type-id-1365' filepath='./Include/cpython/compile.h' line='54' column='1' id='type-id-1364'/>
-    <class-decl name='_PyASTOptimizeState' size-in-bits='128' is-struct='yes' naming-typedef-id='type-id-1366' visibility='default' filepath='./Include/internal/pycore_compile.h' line='24' column='1' id='type-id-1367'>
+    <typedef-decl name='PyFutureFeatures' type-id='type-id-1367' filepath='./Include/cpython/compile.h' line='54' column='1' id='type-id-1366'/>
+    <class-decl name='_PyASTOptimizeState' size-in-bits='128' is-struct='yes' naming-typedef-id='type-id-1368' visibility='default' filepath='./Include/internal/pycore_compile.h' line='24' column='1' id='type-id-1369'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='optimize' type-id='type-id-8' visibility='default' filepath='./Include/internal/pycore_compile.h' line='25' column='1'/>
       </data-member>
@@ -22348,8 +22368,8 @@
         <var-decl name='recursion_limit' type-id='type-id-8' visibility='default' filepath='./Include/internal/pycore_compile.h' line='29' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='_PyASTOptimizeState' type-id='type-id-1367' filepath='./Include/internal/pycore_compile.h' line='30' column='1' id='type-id-1366'/>
-    <class-decl name='_PyCompile_ExceptHandlerInfo' size-in-bits='96' is-struct='yes' naming-typedef-id='type-id-1368' visibility='default' filepath='./Include/internal/pycore_compile.h' line='37' column='1' id='type-id-1369'>
+    <typedef-decl name='_PyASTOptimizeState' type-id='type-id-1369' filepath='./Include/internal/pycore_compile.h' line='30' column='1' id='type-id-1368'/>
+    <class-decl name='_PyCompile_ExceptHandlerInfo' size-in-bits='96' is-struct='yes' naming-typedef-id='type-id-1370' visibility='default' filepath='./Include/internal/pycore_compile.h' line='37' column='1' id='type-id-1371'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='h_offset' type-id='type-id-8' visibility='default' filepath='./Include/internal/pycore_compile.h' line='38' column='1'/>
       </data-member>
@@ -22360,8 +22380,8 @@
         <var-decl name='h_preserve_lasti' type-id='type-id-8' visibility='default' filepath='./Include/internal/pycore_compile.h' line='40' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='_PyCompile_ExceptHandlerInfo' type-id='type-id-1369' filepath='./Include/internal/pycore_compile.h' line='41' column='1' id='type-id-1368'/>
-    <class-decl name='_PyCompile_Instruction' size-in-bits='288' is-struct='yes' naming-typedef-id='type-id-1370' visibility='default' filepath='./Include/internal/pycore_compile.h' line='43' column='1' id='type-id-1371'>
+    <typedef-decl name='_PyCompile_ExceptHandlerInfo' type-id='type-id-1371' filepath='./Include/internal/pycore_compile.h' line='41' column='1' id='type-id-1370'/>
+    <class-decl name='_PyCompile_Instruction' size-in-bits='288' is-struct='yes' naming-typedef-id='type-id-1372' visibility='default' filepath='./Include/internal/pycore_compile.h' line='43' column='1' id='type-id-1373'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='i_opcode' type-id='type-id-8' visibility='default' filepath='./Include/internal/pycore_compile.h' line='44' column='1'/>
       </data-member>
@@ -22369,16 +22389,16 @@
         <var-decl name='i_oparg' type-id='type-id-8' visibility='default' filepath='./Include/internal/pycore_compile.h' line='45' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='i_loc' type-id='type-id-1362' visibility='default' filepath='./Include/internal/pycore_compile.h' line='46' column='1'/>
+        <var-decl name='i_loc' type-id='type-id-1364' visibility='default' filepath='./Include/internal/pycore_compile.h' line='46' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='i_except_handler_info' type-id='type-id-1368' visibility='default' filepath='./Include/internal/pycore_compile.h' line='47' column='1'/>
+        <var-decl name='i_except_handler_info' type-id='type-id-1370' visibility='default' filepath='./Include/internal/pycore_compile.h' line='47' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='_PyCompile_Instruction' type-id='type-id-1371' filepath='./Include/internal/pycore_compile.h' line='48' column='1' id='type-id-1370'/>
-    <class-decl name='_PyCompile_InstructionSequence' size-in-bits='256' is-struct='yes' naming-typedef-id='type-id-1372' visibility='default' filepath='./Include/internal/pycore_compile.h' line='50' column='1' id='type-id-1373'>
+    <typedef-decl name='_PyCompile_Instruction' type-id='type-id-1373' filepath='./Include/internal/pycore_compile.h' line='48' column='1' id='type-id-1372'/>
+    <class-decl name='_PyCompile_InstructionSequence' size-in-bits='256' is-struct='yes' naming-typedef-id='type-id-1374' visibility='default' filepath='./Include/internal/pycore_compile.h' line='50' column='1' id='type-id-1375'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='s_instrs' type-id='type-id-1374' visibility='default' filepath='./Include/internal/pycore_compile.h' line='51' column='1'/>
+        <var-decl name='s_instrs' type-id='type-id-1376' visibility='default' filepath='./Include/internal/pycore_compile.h' line='51' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
         <var-decl name='s_allocated' type-id='type-id-8' visibility='default' filepath='./Include/internal/pycore_compile.h' line='52' column='1'/>
@@ -22396,8 +22416,8 @@
         <var-decl name='s_next_free_label' type-id='type-id-8' visibility='default' filepath='./Include/internal/pycore_compile.h' line='57' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='_PyCompile_InstructionSequence' type-id='type-id-1373' filepath='./Include/internal/pycore_compile.h' line='58' column='1' id='type-id-1372'/>
-    <class-decl name='_PyCompile_CodeUnitMetadata' size-in-bits='768' is-struct='yes' naming-typedef-id='type-id-1375' visibility='default' filepath='./Include/internal/pycore_compile.h' line='60' column='1' id='type-id-1376'>
+    <typedef-decl name='_PyCompile_InstructionSequence' type-id='type-id-1375' filepath='./Include/internal/pycore_compile.h' line='58' column='1' id='type-id-1374'/>
+    <class-decl name='_PyCompile_CodeUnitMetadata' size-in-bits='768' is-struct='yes' naming-typedef-id='type-id-1377' visibility='default' filepath='./Include/internal/pycore_compile.h' line='60' column='1' id='type-id-1378'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='u_name' type-id='type-id-2' visibility='default' filepath='./Include/internal/pycore_compile.h' line='61' column='1'/>
       </data-member>
@@ -22435,8 +22455,8 @@
         <var-decl name='u_firstlineno' type-id='type-id-8' visibility='default' filepath='./Include/internal/pycore_compile.h' line='81' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='_PyCompile_CodeUnitMetadata' type-id='type-id-1376' filepath='./Include/internal/pycore_compile.h' line='82' column='1' id='type-id-1375'/>
-    <class-decl name='_PyCfgInstruction' size-in-bits='320' is-struct='yes' naming-typedef-id='type-id-1377' visibility='default' filepath='./Include/internal/pycore_flowgraph.h' line='15' column='1' id='type-id-1378'>
+    <typedef-decl name='_PyCompile_CodeUnitMetadata' type-id='type-id-1378' filepath='./Include/internal/pycore_compile.h' line='82' column='1' id='type-id-1377'/>
+    <class-decl name='_PyCfgInstruction' size-in-bits='320' is-struct='yes' naming-typedef-id='type-id-1379' visibility='default' filepath='./Include/internal/pycore_flowgraph.h' line='15' column='1' id='type-id-1380'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='i_opcode' type-id='type-id-8' visibility='default' filepath='./Include/internal/pycore_flowgraph.h' line='16' column='1'/>
       </data-member>
@@ -22444,46 +22464,46 @@
         <var-decl name='i_oparg' type-id='type-id-8' visibility='default' filepath='./Include/internal/pycore_flowgraph.h' line='17' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='i_loc' type-id='type-id-1362' visibility='default' filepath='./Include/internal/pycore_flowgraph.h' line='18' column='1'/>
+        <var-decl name='i_loc' type-id='type-id-1364' visibility='default' filepath='./Include/internal/pycore_flowgraph.h' line='18' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='i_target' type-id='type-id-1357' visibility='default' filepath='./Include/internal/pycore_flowgraph.h' line='19' column='1'/>
+        <var-decl name='i_target' type-id='type-id-1358' visibility='default' filepath='./Include/internal/pycore_flowgraph.h' line='19' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='i_except' type-id='type-id-1357' visibility='default' filepath='./Include/internal/pycore_flowgraph.h' line='20' column='1'/>
+        <var-decl name='i_except' type-id='type-id-1358' visibility='default' filepath='./Include/internal/pycore_flowgraph.h' line='20' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='_PyCfgInstruction' type-id='type-id-1378' filepath='./Include/internal/pycore_flowgraph.h' line='21' column='1' id='type-id-1377'/>
-    <class-decl name='_PyCfgJumpTargetLabel' size-in-bits='32' is-struct='yes' naming-typedef-id='type-id-1379' visibility='default' filepath='./Include/internal/pycore_flowgraph.h' line='23' column='1' id='type-id-1380'>
+    <typedef-decl name='_PyCfgInstruction' type-id='type-id-1380' filepath='./Include/internal/pycore_flowgraph.h' line='21' column='1' id='type-id-1379'/>
+    <class-decl name='_PyCfgJumpTargetLabel' size-in-bits='32' is-struct='yes' naming-typedef-id='type-id-1381' visibility='default' filepath='./Include/internal/pycore_flowgraph.h' line='23' column='1' id='type-id-1382'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='id' type-id='type-id-8' visibility='default' filepath='./Include/internal/pycore_flowgraph.h' line='24' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='_PyCfgJumpTargetLabel' type-id='type-id-1380' filepath='./Include/internal/pycore_flowgraph.h' line='25' column='1' id='type-id-1379'/>
-    <class-decl name='_PyCfgExceptStack' size-in-bits='1408' is-struct='yes' naming-typedef-id='type-id-1381' visibility='default' filepath='./Include/internal/pycore_flowgraph.h' line='28' column='1' id='type-id-1382'>
+    <typedef-decl name='_PyCfgJumpTargetLabel' type-id='type-id-1382' filepath='./Include/internal/pycore_flowgraph.h' line='25' column='1' id='type-id-1381'/>
+    <class-decl name='_PyCfgExceptStack' size-in-bits='1472' is-struct='yes' naming-typedef-id='type-id-1383' visibility='default' filepath='./Include/internal/pycore_flowgraph.h' line='28' column='1' id='type-id-1384'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='handlers' type-id='type-id-1358' visibility='default' filepath='./Include/internal/pycore_flowgraph.h' line='29' column='1'/>
+        <var-decl name='handlers' type-id='type-id-1359' visibility='default' filepath='./Include/internal/pycore_flowgraph.h' line='29' column='1'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='1344'>
+      <data-member access='public' layout-offset-in-bits='1408'>
         <var-decl name='depth' type-id='type-id-8' visibility='default' filepath='./Include/internal/pycore_flowgraph.h' line='30' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='_PyCfgExceptStack' type-id='type-id-1382' filepath='./Include/internal/pycore_flowgraph.h' line='31' column='1' id='type-id-1381'/>
-    <class-decl name='_PyCfgBasicblock_' size-in-bits='576' is-struct='yes' visibility='default' filepath='./Include/internal/pycore_flowgraph.h' line='33' column='1' id='type-id-1383'>
+    <typedef-decl name='_PyCfgExceptStack' type-id='type-id-1384' filepath='./Include/internal/pycore_flowgraph.h' line='31' column='1' id='type-id-1383'/>
+    <class-decl name='_PyCfgBasicblock_' size-in-bits='576' is-struct='yes' visibility='default' filepath='./Include/internal/pycore_flowgraph.h' line='33' column='1' id='type-id-1385'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='b_list' type-id='type-id-1357' visibility='default' filepath='./Include/internal/pycore_flowgraph.h' line='38' column='1'/>
+        <var-decl name='b_list' type-id='type-id-1358' visibility='default' filepath='./Include/internal/pycore_flowgraph.h' line='38' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='b_label' type-id='type-id-1379' visibility='default' filepath='./Include/internal/pycore_flowgraph.h' line='40' column='1'/>
+        <var-decl name='b_label' type-id='type-id-1381' visibility='default' filepath='./Include/internal/pycore_flowgraph.h' line='40' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='b_exceptstack' type-id='type-id-1384' visibility='default' filepath='./Include/internal/pycore_flowgraph.h' line='42' column='1'/>
+        <var-decl name='b_exceptstack' type-id='type-id-1386' visibility='default' filepath='./Include/internal/pycore_flowgraph.h' line='42' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='b_instr' type-id='type-id-1385' visibility='default' filepath='./Include/internal/pycore_flowgraph.h' line='44' column='1'/>
+        <var-decl name='b_instr' type-id='type-id-1387' visibility='default' filepath='./Include/internal/pycore_flowgraph.h' line='44' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='b_next' type-id='type-id-1357' visibility='default' filepath='./Include/internal/pycore_flowgraph.h' line='47' column='1'/>
+        <var-decl name='b_next' type-id='type-id-1358' visibility='default' filepath='./Include/internal/pycore_flowgraph.h' line='47' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='320'>
         <var-decl name='b_iused' type-id='type-id-8' visibility='default' filepath='./Include/internal/pycore_flowgraph.h' line='49' column='1'/>
@@ -22519,23 +22539,23 @@
         <var-decl name='b_warm' type-id='type-id-95' visibility='default' filepath='./Include/internal/pycore_flowgraph.h' line='69' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='_PyCfgBasicblock' type-id='type-id-1383' filepath='./Include/internal/pycore_flowgraph.h' line='70' column='1' id='type-id-1386'/>
-    <class-decl name='cfg_builder_' size-in-bits='256' is-struct='yes' visibility='default' filepath='./Include/internal/pycore_flowgraph.h' line='74' column='1' id='type-id-1387'>
+    <typedef-decl name='_PyCfgBasicblock' type-id='type-id-1385' filepath='./Include/internal/pycore_flowgraph.h' line='70' column='1' id='type-id-1388'/>
+    <class-decl name='cfg_builder_' size-in-bits='256' is-struct='yes' visibility='default' filepath='./Include/internal/pycore_flowgraph.h' line='74' column='1' id='type-id-1389'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='g_entryblock' type-id='type-id-1388' visibility='default' filepath='./Include/internal/pycore_flowgraph.h' line='77' column='1'/>
+        <var-decl name='g_entryblock' type-id='type-id-1390' visibility='default' filepath='./Include/internal/pycore_flowgraph.h' line='77' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='g_block_list' type-id='type-id-1388' visibility='default' filepath='./Include/internal/pycore_flowgraph.h' line='80' column='1'/>
+        <var-decl name='g_block_list' type-id='type-id-1390' visibility='default' filepath='./Include/internal/pycore_flowgraph.h' line='80' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='g_curblock' type-id='type-id-1388' visibility='default' filepath='./Include/internal/pycore_flowgraph.h' line='82' column='1'/>
+        <var-decl name='g_curblock' type-id='type-id-1390' visibility='default' filepath='./Include/internal/pycore_flowgraph.h' line='82' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='g_current_label' type-id='type-id-1379' visibility='default' filepath='./Include/internal/pycore_flowgraph.h' line='84' column='1'/>
+        <var-decl name='g_current_label' type-id='type-id-1381' visibility='default' filepath='./Include/internal/pycore_flowgraph.h' line='84' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='_PyCfgBuilder' type-id='type-id-1387' filepath='./Include/internal/pycore_flowgraph.h' line='85' column='1' id='type-id-1389'/>
-    <enum-decl name='_block_type' filepath='./Include/internal/pycore_symtable.h' line='13' column='1' id='type-id-1390'>
+    <typedef-decl name='_PyCfgBuilder' type-id='type-id-1389' filepath='./Include/internal/pycore_flowgraph.h' line='85' column='1' id='type-id-1391'/>
+    <enum-decl name='_block_type' filepath='./Include/internal/pycore_symtable.h' line='13' column='1' id='type-id-1392'>
       <underlying-type type-id='type-id-24'/>
       <enumerator name='FunctionBlock' value='0'/>
       <enumerator name='ClassBlock' value='1'/>
@@ -22545,8 +22565,8 @@
       <enumerator name='TypeAliasBlock' value='5'/>
       <enumerator name='TypeParamBlock' value='6'/>
     </enum-decl>
-    <typedef-decl name='_Py_block_ty' type-id='type-id-1390' filepath='./Include/internal/pycore_symtable.h' line='23' column='1' id='type-id-1391'/>
-    <enum-decl name='_comprehension_type' filepath='./Include/internal/pycore_symtable.h' line='25' column='1' id='type-id-1392'>
+    <typedef-decl name='_Py_block_ty' type-id='type-id-1392' filepath='./Include/internal/pycore_symtable.h' line='23' column='1' id='type-id-1393'/>
+    <enum-decl name='_comprehension_type' filepath='./Include/internal/pycore_symtable.h' line='25' column='1' id='type-id-1394'>
       <underlying-type type-id='type-id-24'/>
       <enumerator name='NoComprehension' value='0'/>
       <enumerator name='ListComprehension' value='1'/>
@@ -22554,16 +22574,16 @@
       <enumerator name='SetComprehension' value='3'/>
       <enumerator name='GeneratorExpression' value='4'/>
     </enum-decl>
-    <typedef-decl name='_Py_comprehension_ty' type-id='type-id-1392' filepath='./Include/internal/pycore_symtable.h' line='30' column='1' id='type-id-1393'/>
-    <class-decl name='symtable' size-in-bits='640' is-struct='yes' visibility='default' filepath='./Include/internal/pycore_symtable.h' line='34' column='1' id='type-id-1394'>
+    <typedef-decl name='_Py_comprehension_ty' type-id='type-id-1394' filepath='./Include/internal/pycore_symtable.h' line='30' column='1' id='type-id-1395'/>
+    <class-decl name='symtable' size-in-bits='640' is-struct='yes' visibility='default' filepath='./Include/internal/pycore_symtable.h' line='34' column='1' id='type-id-1396'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='st_filename' type-id='type-id-2' visibility='default' filepath='./Include/internal/pycore_symtable.h' line='35' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='st_cur' type-id='type-id-1395' visibility='default' filepath='./Include/internal/pycore_symtable.h' line='37' column='1'/>
+        <var-decl name='st_cur' type-id='type-id-1397' visibility='default' filepath='./Include/internal/pycore_symtable.h' line='37' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='st_top' type-id='type-id-1395' visibility='default' filepath='./Include/internal/pycore_symtable.h' line='38' column='1'/>
+        <var-decl name='st_top' type-id='type-id-1397' visibility='default' filepath='./Include/internal/pycore_symtable.h' line='38' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='192'>
         <var-decl name='st_blocks' type-id='type-id-2' visibility='default' filepath='./Include/internal/pycore_symtable.h' line='39' column='1'/>
@@ -22581,7 +22601,7 @@
         <var-decl name='st_private' type-id='type-id-2' visibility='default' filepath='./Include/internal/pycore_symtable.h' line='46' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='512'>
-        <var-decl name='st_future' type-id='type-id-1396' visibility='default' filepath='./Include/internal/pycore_symtable.h' line='47' column='1'/>
+        <var-decl name='st_future' type-id='type-id-1398' visibility='default' filepath='./Include/internal/pycore_symtable.h' line='47' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='576'>
         <var-decl name='recursion_depth' type-id='type-id-8' visibility='default' filepath='./Include/internal/pycore_symtable.h' line='49' column='1'/>
@@ -22590,7 +22610,7 @@
         <var-decl name='recursion_limit' type-id='type-id-8' visibility='default' filepath='./Include/internal/pycore_symtable.h' line='50' column='1'/>
       </data-member>
     </class-decl>
-    <class-decl name='_symtable_entry' size-in-bits='960' is-struct='yes' visibility='default' filepath='./Include/internal/pycore_symtable.h' line='53' column='1' id='type-id-1397'>
+    <class-decl name='_symtable_entry' size-in-bits='960' is-struct='yes' visibility='default' filepath='./Include/internal/pycore_symtable.h' line='53' column='1' id='type-id-1399'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='ob_base' type-id='type-id-345' visibility='default' filepath='./Include/internal/pycore_symtable.h' line='54' column='1'/>
       </data-member>
@@ -22613,7 +22633,7 @@
         <var-decl name='ste_directives' type-id='type-id-2' visibility='default' filepath='./Include/internal/pycore_symtable.h' line='60' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='512'>
-        <var-decl name='ste_type' type-id='type-id-1391' visibility='default' filepath='./Include/internal/pycore_symtable.h' line='61' column='1'/>
+        <var-decl name='ste_type' type-id='type-id-1393' visibility='default' filepath='./Include/internal/pycore_symtable.h' line='61' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='544'>
         <var-decl name='ste_nested' type-id='type-id-8' visibility='default' filepath='./Include/internal/pycore_symtable.h' line='62' column='1'/>
@@ -22631,7 +22651,7 @@
         <var-decl name='ste_coroutine' type-id='type-id-95' visibility='default' filepath='./Include/internal/pycore_symtable.h' line='67' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='608'>
-        <var-decl name='ste_comprehension' type-id='type-id-1393' visibility='default' filepath='./Include/internal/pycore_symtable.h' line='68' column='1'/>
+        <var-decl name='ste_comprehension' type-id='type-id-1395' visibility='default' filepath='./Include/internal/pycore_symtable.h' line='68' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='640'>
         <var-decl name='ste_varargs' type-id='type-id-95' visibility='default' filepath='./Include/internal/pycore_symtable.h' line='69' column='1'/>
@@ -22682,23 +22702,23 @@
         <var-decl name='ste_table' type-id='type-id-209' visibility='default' filepath='./Include/internal/pycore_symtable.h' line='89' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='PySTEntryObject' type-id='type-id-1397' filepath='./Include/internal/pycore_symtable.h' line='90' column='1' id='type-id-1398'/>
-    <typedef-decl name='basicblock' type-id='type-id-1386' filepath='Python/compile.c' line='90' column='1' id='type-id-1399'/>
-    <pointer-type-def type-id='type-id-1364' size-in-bits='64' id='type-id-1396'/>
-    <pointer-type-def type-id='type-id-1398' size-in-bits='64' id='type-id-1400'/>
-    <pointer-type-def type-id='type-id-1366' size-in-bits='64' id='type-id-1401'/>
-    <pointer-type-def type-id='type-id-1386' size-in-bits='64' id='type-id-1388'/>
-    <pointer-type-def type-id='type-id-1383' size-in-bits='64' id='type-id-1357'/>
-    <pointer-type-def type-id='type-id-1389' size-in-bits='64' id='type-id-1402'/>
-    <pointer-type-def type-id='type-id-1381' size-in-bits='64' id='type-id-1384'/>
-    <pointer-type-def type-id='type-id-1377' size-in-bits='64' id='type-id-1385'/>
-    <pointer-type-def type-id='type-id-1375' size-in-bits='64' id='type-id-1403'/>
-    <pointer-type-def type-id='type-id-1370' size-in-bits='64' id='type-id-1374'/>
-    <pointer-type-def type-id='type-id-1372' size-in-bits='64' id='type-id-1404'/>
-    <pointer-type-def type-id='type-id-1397' size-in-bits='64' id='type-id-1395'/>
-    <pointer-type-def type-id='type-id-1399' size-in-bits='64' id='type-id-1405'/>
-    <qualified-type-def type-id='type-id-352' const='yes' id='type-id-1359'/>
-    <pointer-type-def type-id='type-id-1394' size-in-bits='64' id='type-id-209'/>
+    <typedef-decl name='PySTEntryObject' type-id='type-id-1399' filepath='./Include/internal/pycore_symtable.h' line='90' column='1' id='type-id-1400'/>
+    <typedef-decl name='basicblock' type-id='type-id-1388' filepath='Python/compile.c' line='90' column='1' id='type-id-1401'/>
+    <pointer-type-def type-id='type-id-1366' size-in-bits='64' id='type-id-1398'/>
+    <pointer-type-def type-id='type-id-1400' size-in-bits='64' id='type-id-1402'/>
+    <pointer-type-def type-id='type-id-1368' size-in-bits='64' id='type-id-1403'/>
+    <pointer-type-def type-id='type-id-1388' size-in-bits='64' id='type-id-1390'/>
+    <pointer-type-def type-id='type-id-1385' size-in-bits='64' id='type-id-1358'/>
+    <pointer-type-def type-id='type-id-1391' size-in-bits='64' id='type-id-1404'/>
+    <pointer-type-def type-id='type-id-1383' size-in-bits='64' id='type-id-1386'/>
+    <pointer-type-def type-id='type-id-1379' size-in-bits='64' id='type-id-1387'/>
+    <pointer-type-def type-id='type-id-1377' size-in-bits='64' id='type-id-1405'/>
+    <pointer-type-def type-id='type-id-1372' size-in-bits='64' id='type-id-1376'/>
+    <pointer-type-def type-id='type-id-1374' size-in-bits='64' id='type-id-1406'/>
+    <pointer-type-def type-id='type-id-1399' size-in-bits='64' id='type-id-1397'/>
+    <pointer-type-def type-id='type-id-1401' size-in-bits='64' id='type-id-1407'/>
+    <qualified-type-def type-id='type-id-352' const='yes' id='type-id-1361'/>
+    <pointer-type-def type-id='type-id-1396' size-in-bits='64' id='type-id-209'/>
     <function-decl name='PyErr_ProgramTextObject' mangled-name='PyErr_ProgramTextObject' filepath='./Include/cpython/pyerrors.h' line='142' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyErr_ProgramTextObject'>
       <parameter type-id='type-id-2'/>
       <parameter type-id='type-id-8'/>
@@ -22714,38 +22734,38 @@
     </function-decl>
     <function-decl name='_PyAST_Optimize' filepath='./Include/internal/pycore_compile.h' line='32' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-476'/>
-      <parameter type-id='type-id-1344'/>
-      <parameter type-id='type-id-1401'/>
+      <parameter type-id='type-id-1345'/>
+      <parameter type-id='type-id-1403'/>
       <return type-id='type-id-8'/>
     </function-decl>
     <function-decl name='_PyBasicblock_InsertInstruction' filepath='./Include/internal/pycore_flowgraph.h' line='72' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-1388'/>
+      <parameter type-id='type-id-1390'/>
       <parameter type-id='type-id-8'/>
-      <parameter type-id='type-id-1385'/>
+      <parameter type-id='type-id-1387'/>
       <return type-id='type-id-8'/>
     </function-decl>
     <function-decl name='_PyCfgBuilder_UseLabel' filepath='./Include/internal/pycore_flowgraph.h' line='87' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-1402'/>
-      <parameter type-id='type-id-1379'/>
+      <parameter type-id='type-id-1404'/>
+      <parameter type-id='type-id-1381'/>
       <return type-id='type-id-8'/>
     </function-decl>
     <function-decl name='_PyCfgBuilder_Addop' filepath='./Include/internal/pycore_flowgraph.h' line='88' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-1402'/>
+      <parameter type-id='type-id-1404'/>
       <parameter type-id='type-id-8'/>
       <parameter type-id='type-id-8'/>
-      <parameter type-id='type-id-1362'/>
+      <parameter type-id='type-id-1364'/>
       <return type-id='type-id-8'/>
     </function-decl>
     <function-decl name='_PyCfgBuilder_Init' filepath='./Include/internal/pycore_flowgraph.h' line='90' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-1402'/>
+      <parameter type-id='type-id-1404'/>
       <return type-id='type-id-8'/>
     </function-decl>
     <function-decl name='_PyCfgBuilder_Fini' filepath='./Include/internal/pycore_flowgraph.h' line='91' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-1402'/>
+      <parameter type-id='type-id-1404'/>
       <return type-id='type-id-46'/>
     </function-decl>
     <function-decl name='_PyCfg_OptimizeCodeUnit' filepath='./Include/internal/pycore_flowgraph.h' line='94' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-1402'/>
+      <parameter type-id='type-id-1404'/>
       <parameter type-id='type-id-2'/>
       <parameter type-id='type-id-2'/>
       <parameter type-id='type-id-8'/>
@@ -22755,56 +22775,56 @@
       <return type-id='type-id-8'/>
     </function-decl>
     <function-decl name='_PyCfg_Stackdepth' filepath='./Include/internal/pycore_flowgraph.h' line='96' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-1388'/>
+      <parameter type-id='type-id-1390'/>
       <parameter type-id='type-id-8'/>
       <return type-id='type-id-8'/>
     </function-decl>
     <function-decl name='_PyCfg_ConvertPseudoOps' filepath='./Include/internal/pycore_flowgraph.h' line='97' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-1388'/>
+      <parameter type-id='type-id-1390'/>
       <return type-id='type-id-46'/>
     </function-decl>
     <function-decl name='_PyCfg_ResolveJumps' filepath='./Include/internal/pycore_flowgraph.h' line='98' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-1402'/>
+      <parameter type-id='type-id-1404'/>
       <return type-id='type-id-8'/>
     </function-decl>
     <function-decl name='_PyAssemble_MakeCodeObject' filepath='./Include/internal/pycore_flowgraph.h' line='113' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-1403'/>
+      <parameter type-id='type-id-1405'/>
       <parameter type-id='type-id-2'/>
       <parameter type-id='type-id-2'/>
       <parameter type-id='type-id-8'/>
-      <parameter type-id='type-id-1404'/>
+      <parameter type-id='type-id-1406'/>
       <parameter type-id='type-id-8'/>
       <parameter type-id='type-id-8'/>
       <parameter type-id='type-id-2'/>
       <return type-id='type-id-328'/>
     </function-decl>
-    <var-decl name='_PyOpcode_Jump' type-id='type-id-1360' visibility='default' filepath='./Include/internal/pycore_opcode.h' line='15' column='1'/>
-    <var-decl name='_PyOpcode_Caches' type-id='type-id-1361' visibility='default' filepath='./Include/internal/pycore_opcode.h' line='17' column='1'/>
-    <var-decl name='_PyOpcode_Deopt' type-id='type-id-1361' visibility='default' filepath='./Include/internal/pycore_opcode.h' line='19' column='1'/>
+    <var-decl name='_PyOpcode_Jump' type-id='type-id-1362' visibility='default' filepath='./Include/internal/pycore_opcode.h' line='15' column='1'/>
+    <var-decl name='_PyOpcode_Caches' type-id='type-id-1363' visibility='default' filepath='./Include/internal/pycore_opcode.h' line='17' column='1'/>
+    <var-decl name='_PyOpcode_Deopt' type-id='type-id-1363' visibility='default' filepath='./Include/internal/pycore_opcode.h' line='19' column='1'/>
     <function-decl name='_PyST_GetSymbol' filepath='./Include/internal/pycore_symtable.h' line='96' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-1400'/>
+      <parameter type-id='type-id-1402'/>
       <parameter type-id='type-id-2'/>
       <return type-id='type-id-47'/>
     </function-decl>
     <function-decl name='_PyST_GetScope' filepath='./Include/internal/pycore_symtable.h' line='97' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-1400'/>
+      <parameter type-id='type-id-1402'/>
       <parameter type-id='type-id-2'/>
       <return type-id='type-id-8'/>
     </function-decl>
     <function-decl name='_PyST_IsFunctionLike' filepath='./Include/internal/pycore_symtable.h' line='98' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-1400'/>
+      <parameter type-id='type-id-1402'/>
       <return type-id='type-id-8'/>
     </function-decl>
     <function-decl name='_PySymtable_Build' filepath='./Include/internal/pycore_symtable.h' line='100' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-476'/>
       <parameter type-id='type-id-2'/>
-      <parameter type-id='type-id-1396'/>
+      <parameter type-id='type-id-1398'/>
       <return type-id='type-id-209'/>
     </function-decl>
     <function-decl name='PySymtable_Lookup' mangled-name='PySymtable_Lookup' filepath='./Include/internal/pycore_symtable.h' line='104' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PySymtable_Lookup'>
       <parameter type-id='type-id-209'/>
       <parameter type-id='type-id-22'/>
-      <return type-id='type-id-1400'/>
+      <return type-id='type-id-1402'/>
     </function-decl>
     <function-decl name='_PySymtable_Free' filepath='./Include/internal/pycore_symtable.h' line='106' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-209'/>
@@ -22813,7 +22833,7 @@
     <function-decl name='_PyFuture_FromAST' filepath='./Include/internal/pycore_symtable.h' line='150' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-476'/>
       <parameter type-id='type-id-2'/>
-      <parameter type-id='type-id-1396'/>
+      <parameter type-id='type-id-1398'/>
       <return type-id='type-id-8'/>
     </function-decl>
     <function-decl name='PyCompile_OpcodeStackEffectWithJump' mangled-name='PyCompile_OpcodeStackEffectWithJump' filepath='Python/compile.c' line='880' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyCompile_OpcodeStackEffectWithJump'>
@@ -22837,11 +22857,11 @@
       <return type-id='type-id-2'/>
     </function-decl>
     <function-decl name='_PyCfg_JumpLabelsToTargets' filepath='Python/compile.c' line='8070' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-1405'/>
+      <parameter type-id='type-id-1407'/>
       <return type-id='type-id-8'/>
     </function-decl>
     <function-decl name='_PyCompile_Assemble' mangled-name='_PyCompile_Assemble' filepath='Python/compile.c' line='8073' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyCompile_Assemble'>
-      <parameter type-id='type-id-1403' name='umd' filepath='Python/compile.c' line='8073' column='1'/>
+      <parameter type-id='type-id-1405' name='umd' filepath='Python/compile.c' line='8073' column='1'/>
       <parameter type-id='type-id-2' name='filename' filepath='Python/compile.c' line='8073' column='1'/>
       <parameter type-id='type-id-2' name='instructions' filepath='Python/compile.c' line='8074' column='1'/>
       <return type-id='type-id-328'/>
@@ -22964,7 +22984,7 @@
       <parameter type-id='type-id-328'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <var-decl name='_Py_next_func_version' type-id='type-id-352' visibility='default' filepath='./Include/internal/pycore_code.h' line='463' column='1'/>
+    <var-decl name='_Py_next_func_version' type-id='type-id-352' visibility='default' filepath='./Include/internal/pycore_code.h' line='465' column='1'/>
   </abi-instr>
   <abi-instr address-size='64' path='Python/errors.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
     <function-decl name='_Py_fopen_obj' mangled-name='_Py_fopen_obj' filepath='./Include/cpython/fileutils.h' line='6' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_fopen_obj'>
@@ -23119,15 +23139,15 @@
     </function-decl>
   </abi-instr>
   <abi-instr address-size='64' path='Python/fileutils.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
-    <class-decl name='__mbstate_t' size-in-bits='64' is-struct='yes' naming-typedef-id='type-id-1406' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/__mbstate_t.h' line='13' column='1' id='type-id-1407'>
+    <class-decl name='__mbstate_t' size-in-bits='64' is-struct='yes' naming-typedef-id='type-id-1408' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/__mbstate_t.h' line='13' column='1' id='type-id-1409'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='__count' type-id='type-id-8' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/__mbstate_t.h' line='15' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='__value' type-id='type-id-1408' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/__mbstate_t.h' line='20' column='1'/>
+        <var-decl name='__value' type-id='type-id-1410' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/__mbstate_t.h' line='20' column='1'/>
       </data-member>
     </class-decl>
-    <union-decl name='__anonymous_union__' size-in-bits='32' is-anonymous='yes' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/__mbstate_t.h' line='16' column='1' id='type-id-1408'>
+    <union-decl name='__anonymous_union__' size-in-bits='32' is-anonymous='yes' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/__mbstate_t.h' line='16' column='1' id='type-id-1410'>
       <data-member access='public'>
         <var-decl name='__wch' type-id='type-id-95' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/__mbstate_t.h' line='18' column='1'/>
       </data-member>
@@ -23135,11 +23155,11 @@
         <var-decl name='__wchb' type-id='type-id-629' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/__mbstate_t.h' line='19' column='1'/>
       </data-member>
     </union-decl>
-    <typedef-decl name='__mbstate_t' type-id='type-id-1407' filepath='/usr/include/x86_64-linux-gnu/bits/types/__mbstate_t.h' line='21' column='1' id='type-id-1406'/>
-    <typedef-decl name='mbstate_t' type-id='type-id-1406' filepath='/usr/include/x86_64-linux-gnu/bits/types/mbstate_t.h' line='6' column='1' id='type-id-1409'/>
-    <pointer-type-def type-id='type-id-1409' size-in-bits='64' id='type-id-1410'/>
-    <qualified-type-def type-id='type-id-1410' restrict='yes' id='type-id-1411'/>
-    <qualified-type-def type-id='type-id-51' restrict='yes' id='type-id-1412'/>
+    <typedef-decl name='__mbstate_t' type-id='type-id-1409' filepath='/usr/include/x86_64-linux-gnu/bits/types/__mbstate_t.h' line='21' column='1' id='type-id-1408'/>
+    <typedef-decl name='mbstate_t' type-id='type-id-1408' filepath='/usr/include/x86_64-linux-gnu/bits/types/mbstate_t.h' line='6' column='1' id='type-id-1411'/>
+    <pointer-type-def type-id='type-id-1411' size-in-bits='64' id='type-id-1412'/>
+    <qualified-type-def type-id='type-id-1412' restrict='yes' id='type-id-1413'/>
+    <qualified-type-def type-id='type-id-51' restrict='yes' id='type-id-1414'/>
     <function-decl name='realpath' filepath='/usr/include/stdlib.h' line='808' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-181'/>
       <parameter type-id='type-id-183'/>
@@ -23184,7 +23204,7 @@
       <parameter type-id='type-id-17'/>
       <parameter type-id='type-id-181'/>
       <parameter type-id='type-id-19'/>
-      <parameter type-id='type-id-1411'/>
+      <parameter type-id='type-id-1413'/>
       <return type-id='type-id-19'/>
     </function-decl>
     <function-decl name='ioctl' filepath='/usr/include/x86_64-linux-gnu/sys/ioctl.h' line='42' column='1' visibility='default' binding='global' size-in-bits='64'>
@@ -23267,7 +23287,7 @@
     </function-decl>
   </abi-instr>
   <abi-instr address-size='64' path='Python/formatter_unicode.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
-    <class-decl name='lconv' size-in-bits='768' is-struct='yes' visibility='default' filepath='/usr/include/locale.h' line='51' column='1' id='type-id-1413'>
+    <class-decl name='lconv' size-in-bits='768' is-struct='yes' visibility='default' filepath='/usr/include/locale.h' line='51' column='1' id='type-id-1415'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='decimal_point' type-id='type-id-15' visibility='default' filepath='/usr/include/locale.h' line='55' column='1'/>
       </data-member>
@@ -23341,15 +23361,15 @@
         <var-decl name='int_n_sign_posn' type-id='type-id-48' visibility='default' filepath='/usr/include/locale.h' line='109' column='1'/>
       </data-member>
     </class-decl>
-    <pointer-type-def type-id='type-id-1413' size-in-bits='64' id='type-id-1414'/>
+    <pointer-type-def type-id='type-id-1415' size-in-bits='64' id='type-id-1416'/>
     <function-decl name='_Py_GetLocaleconvNumeric' mangled-name='_Py_GetLocaleconvNumeric' filepath='./Include/internal/pycore_fileutils.h' line='222' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_GetLocaleconvNumeric'>
-      <parameter type-id='type-id-1414'/>
+      <parameter type-id='type-id-1416'/>
       <parameter type-id='type-id-233'/>
       <parameter type-id='type-id-233'/>
       <return type-id='type-id-8'/>
     </function-decl>
     <function-decl name='localeconv' filepath='/usr/include/locale.h' line='125' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-1414'/>
+      <return type-id='type-id-1416'/>
     </function-decl>
   </abi-instr>
   <abi-instr address-size='64' path='Python/frame.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
@@ -23367,7 +23387,7 @@
     </function-decl>
   </abi-instr>
   <abi-instr address-size='64' path='Python/frozen.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
-    <class-decl name='_frozen' size-in-bits='256' is-struct='yes' visibility='default' filepath='./Include/cpython/import.h' line='32' column='1' id='type-id-1415'>
+    <class-decl name='_frozen' size-in-bits='256' is-struct='yes' visibility='default' filepath='./Include/cpython/import.h' line='32' column='1' id='type-id-1417'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='name' type-id='type-id-12' visibility='default' filepath='./Include/cpython/import.h' line='33' column='1'/>
       </data-member>
@@ -23384,7 +23404,7 @@
         <var-decl name='get_code' type-id='type-id-390' visibility='default' filepath='./Include/cpython/import.h' line='37' column='1'/>
       </data-member>
     </class-decl>
-    <class-decl name='_module_alias' size-in-bits='128' is-struct='yes' visibility='default' filepath='./Include/internal/pycore_import.h' line='162' column='1' id='type-id-1416'>
+    <class-decl name='_module_alias' size-in-bits='128' is-struct='yes' visibility='default' filepath='./Include/internal/pycore_import.h' line='162' column='1' id='type-id-1418'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='name' type-id='type-id-12' visibility='default' filepath='./Include/internal/pycore_import.h' line='163' column='1'/>
       </data-member>
@@ -23392,15 +23412,15 @@
         <var-decl name='orig' type-id='type-id-12' visibility='default' filepath='./Include/internal/pycore_import.h' line='164' column='1'/>
       </data-member>
     </class-decl>
-    <qualified-type-def type-id='type-id-1415' const='yes' id='type-id-1417'/>
-    <pointer-type-def type-id='type-id-1417' size-in-bits='64' id='type-id-1418'/>
-    <qualified-type-def type-id='type-id-1416' const='yes' id='type-id-1419'/>
+    <qualified-type-def type-id='type-id-1417' const='yes' id='type-id-1419'/>
     <pointer-type-def type-id='type-id-1419' size-in-bits='64' id='type-id-1420'/>
-    <var-decl name='PyImport_FrozenModules' type-id='type-id-1418' mangled-name='PyImport_FrozenModules' visibility='default' filepath='./Include/cpython/import.h' line='43' column='1' elf-symbol-id='PyImport_FrozenModules'/>
-    <var-decl name='_PyImport_FrozenBootstrap' type-id='type-id-1418' mangled-name='_PyImport_FrozenBootstrap' visibility='default' filepath='./Include/internal/pycore_import.h' line='167' column='1' elf-symbol-id='_PyImport_FrozenBootstrap'/>
-    <var-decl name='_PyImport_FrozenStdlib' type-id='type-id-1418' mangled-name='_PyImport_FrozenStdlib' visibility='default' filepath='./Include/internal/pycore_import.h' line='168' column='1' elf-symbol-id='_PyImport_FrozenStdlib'/>
-    <var-decl name='_PyImport_FrozenTest' type-id='type-id-1418' mangled-name='_PyImport_FrozenTest' visibility='default' filepath='./Include/internal/pycore_import.h' line='169' column='1' elf-symbol-id='_PyImport_FrozenTest'/>
-    <var-decl name='_PyImport_FrozenAliases' type-id='type-id-1420' visibility='default' filepath='./Include/internal/pycore_import.h' line='170' column='1'/>
+    <qualified-type-def type-id='type-id-1418' const='yes' id='type-id-1421'/>
+    <pointer-type-def type-id='type-id-1421' size-in-bits='64' id='type-id-1422'/>
+    <var-decl name='PyImport_FrozenModules' type-id='type-id-1420' mangled-name='PyImport_FrozenModules' visibility='default' filepath='./Include/cpython/import.h' line='43' column='1' elf-symbol-id='PyImport_FrozenModules'/>
+    <var-decl name='_PyImport_FrozenBootstrap' type-id='type-id-1420' mangled-name='_PyImport_FrozenBootstrap' visibility='default' filepath='./Include/internal/pycore_import.h' line='167' column='1' elf-symbol-id='_PyImport_FrozenBootstrap'/>
+    <var-decl name='_PyImport_FrozenStdlib' type-id='type-id-1420' mangled-name='_PyImport_FrozenStdlib' visibility='default' filepath='./Include/internal/pycore_import.h' line='168' column='1' elf-symbol-id='_PyImport_FrozenStdlib'/>
+    <var-decl name='_PyImport_FrozenTest' type-id='type-id-1420' mangled-name='_PyImport_FrozenTest' visibility='default' filepath='./Include/internal/pycore_import.h' line='169' column='1' elf-symbol-id='_PyImport_FrozenTest'/>
+    <var-decl name='_PyImport_FrozenAliases' type-id='type-id-1422' visibility='default' filepath='./Include/internal/pycore_import.h' line='170' column='1'/>
     <function-decl name='_Py_get_importlib__bootstrap_toplevel' filepath='Python/frozen.c' line='72' column='1' visibility='default' binding='global' size-in-bits='64'>
       <return type-id='type-id-2'/>
     </function-decl>
@@ -23431,50 +23451,50 @@
     <function-decl name='_Py_get_ntpath_toplevel' filepath='Python/frozen.c' line='81' column='1' visibility='default' binding='global' size-in-bits='64'>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='_Py_get_posixpath_toplevel' filepath='Python/frozen.c' line='83' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_Py_get_posixpath_toplevel' filepath='Python/frozen.c' line='82' column='1' visibility='default' binding='global' size-in-bits='64'>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='_Py_get_os_toplevel' filepath='Python/frozen.c' line='84' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_Py_get_os_toplevel' filepath='Python/frozen.c' line='83' column='1' visibility='default' binding='global' size-in-bits='64'>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='_Py_get_site_toplevel' filepath='Python/frozen.c' line='85' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_Py_get_site_toplevel' filepath='Python/frozen.c' line='84' column='1' visibility='default' binding='global' size-in-bits='64'>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='_Py_get_stat_toplevel' filepath='Python/frozen.c' line='86' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_Py_get_stat_toplevel' filepath='Python/frozen.c' line='85' column='1' visibility='default' binding='global' size-in-bits='64'>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='_Py_get_importlib_util_toplevel' filepath='Python/frozen.c' line='87' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_Py_get_importlib_util_toplevel' filepath='Python/frozen.c' line='86' column='1' visibility='default' binding='global' size-in-bits='64'>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='_Py_get_importlib_machinery_toplevel' filepath='Python/frozen.c' line='88' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_Py_get_importlib_machinery_toplevel' filepath='Python/frozen.c' line='87' column='1' visibility='default' binding='global' size-in-bits='64'>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='_Py_get_runpy_toplevel' filepath='Python/frozen.c' line='89' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_Py_get_runpy_toplevel' filepath='Python/frozen.c' line='88' column='1' visibility='default' binding='global' size-in-bits='64'>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='_Py_get___hello___toplevel' filepath='Python/frozen.c' line='93' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_Py_get___hello___toplevel' filepath='Python/frozen.c' line='89' column='1' visibility='default' binding='global' size-in-bits='64'>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='_Py_get___phello___toplevel' filepath='Python/frozen.c' line='95' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_Py_get___phello___toplevel' filepath='Python/frozen.c' line='90' column='1' visibility='default' binding='global' size-in-bits='64'>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='_Py_get___phello___ham_toplevel' filepath='Python/frozen.c' line='97' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_Py_get___phello___ham_toplevel' filepath='Python/frozen.c' line='91' column='1' visibility='default' binding='global' size-in-bits='64'>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='_Py_get___phello___ham_eggs_toplevel' filepath='Python/frozen.c' line='98' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_Py_get___phello___ham_eggs_toplevel' filepath='Python/frozen.c' line='92' column='1' visibility='default' binding='global' size-in-bits='64'>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='_Py_get___phello___spam_toplevel' filepath='Python/frozen.c' line='99' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_Py_get___phello___spam_toplevel' filepath='Python/frozen.c' line='93' column='1' visibility='default' binding='global' size-in-bits='64'>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='_Py_get_frozen_only_toplevel' filepath='Python/frozen.c' line='100' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_Py_get_frozen_only_toplevel' filepath='Python/frozen.c' line='94' column='1' visibility='default' binding='global' size-in-bits='64'>
       <return type-id='type-id-2'/>
     </function-decl>
   </abi-instr>
   <abi-instr address-size='64' path='Python/frozenmain.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
-    <class-decl name='PyStatus' size-in-bits='256' is-struct='yes' naming-typedef-id='type-id-54' visibility='default' filepath='./Include/cpython/initconfig.h' line='10' column='1' id='type-id-1421'>
+    <class-decl name='PyStatus' size-in-bits='256' is-struct='yes' naming-typedef-id='type-id-54' visibility='default' filepath='./Include/cpython/initconfig.h' line='10' column='1' id='type-id-1423'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='_type' type-id='type-id-1001' visibility='default' filepath='./Include/cpython/initconfig.h' line='15' column='1'/>
+        <var-decl name='_type' type-id='type-id-1002' visibility='default' filepath='./Include/cpython/initconfig.h' line='15' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
         <var-decl name='func' type-id='type-id-12' visibility='default' filepath='./Include/cpython/initconfig.h' line='16' column='1'/>
@@ -23486,7 +23506,7 @@
         <var-decl name='exitcode' type-id='type-id-8' visibility='default' filepath='./Include/cpython/initconfig.h' line='18' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='PyStatus' type-id='type-id-1421' filepath='./Include/cpython/initconfig.h' line='19' column='1' id='type-id-54'/>
+    <typedef-decl name='PyStatus' type-id='type-id-1423' filepath='./Include/cpython/initconfig.h' line='19' column='1' id='type-id-54'/>
     <pointer-type-def type-id='type-id-258' size-in-bits='64' id='type-id-53'/>
     <function-decl name='PyStatus_Exception' mangled-name='PyStatus_Exception' filepath='./Include/cpython/initconfig.h' line='27' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyStatus_Exception'>
       <parameter type-id='type-id-54'/>
@@ -23659,8 +23679,8 @@
     <var-decl name='_PyOS_optarg' type-id='type-id-16' visibility='default' filepath='./Include/internal/pycore_getopt.h' line='10' column='1'/>
   </abi-instr>
   <abi-instr address-size='64' path='Python/getversion.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
-    <qualified-type-def type-id='type-id-28' const='yes' id='type-id-1422'/>
-    <var-decl name='Py_Version' type-id='type-id-1422' mangled-name='Py_Version' visibility='default' filepath='./Include/pylifecycle.h' line='66' column='1' elf-symbol-id='Py_Version'/>
+    <qualified-type-def type-id='type-id-28' const='yes' id='type-id-1424'/>
+    <var-decl name='Py_Version' type-id='type-id-1424' mangled-name='Py_Version' visibility='default' filepath='./Include/pylifecycle.h' line='66' column='1' elf-symbol-id='Py_Version'/>
   </abi-instr>
   <abi-instr address-size='64' path='Python/hamt.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
     <var-decl name='_PyHamt_Type' type-id='type-id-256' visibility='default' filepath='./Include/internal/pycore_hamt.h' line='23' column='1'/>
@@ -23672,8 +23692,8 @@
     <var-decl name='_PyHamtItems_Type' type-id='type-id-256' visibility='default' filepath='./Include/internal/pycore_hamt.h' line='29' column='1'/>
   </abi-instr>
   <abi-instr address-size='64' path='Python/hashtable.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
-    <typedef-decl name='_Py_hashtable_foreach_func' type-id='type-id-1423' filepath='./Include/internal/pycore_hashtable.h' line='96' column='1' id='type-id-1424'/>
-    <pointer-type-def type-id='type-id-1425' size-in-bits='64' id='type-id-1423'/>
+    <typedef-decl name='_Py_hashtable_foreach_func' type-id='type-id-1425' filepath='./Include/internal/pycore_hashtable.h' line='96' column='1' id='type-id-1426'/>
+    <pointer-type-def type-id='type-id-1427' size-in-bits='64' id='type-id-1425'/>
     <function-decl name='_Py_HashPointerRaw' mangled-name='_Py_HashPointerRaw' filepath='./Include/pyhash.h' line='13' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_HashPointerRaw'>
       <parameter type-id='type-id-22'/>
       <return type-id='type-id-305'/>
@@ -23698,7 +23718,7 @@
     </function-decl>
     <function-decl name='_Py_hashtable_foreach' mangled-name='_Py_hashtable_foreach' filepath='Python/hashtable.c' line='268' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_hashtable_foreach'>
       <parameter type-id='type-id-451' name='ht' filepath='Python/hashtable.c' line='268' column='1'/>
-      <parameter type-id='type-id-1424' name='func' filepath='Python/hashtable.c' line='269' column='1'/>
+      <parameter type-id='type-id-1426' name='func' filepath='Python/hashtable.c' line='269' column='1'/>
       <parameter type-id='type-id-22' name='user_data' filepath='Python/hashtable.c' line='270' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
@@ -23711,7 +23731,7 @@
       <parameter type-id='type-id-451' name='ht' filepath='Python/hashtable.c' line='392' column='1'/>
       <return type-id='type-id-46'/>
     </function-decl>
-    <function-type size-in-bits='64' id='type-id-1425'>
+    <function-type size-in-bits='64' id='type-id-1427'>
       <parameter type-id='type-id-451'/>
       <parameter type-id='type-id-22'/>
       <parameter type-id='type-id-22'/>
@@ -23720,7 +23740,7 @@
     </function-type>
   </abi-instr>
   <abi-instr address-size='64' path='Python/import.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
-    <enum-decl name='_PyTime_round_t' naming-typedef-id='type-id-1426' filepath='./Include/cpython/pytime.h' line='70' column='1' id='type-id-1427'>
+    <enum-decl name='_PyTime_round_t' naming-typedef-id='type-id-1428' filepath='./Include/cpython/pytime.h' line='70' column='1' id='type-id-1429'>
       <underlying-type type-id='type-id-24'/>
       <enumerator name='_PyTime_ROUND_FLOOR' value='0'/>
       <enumerator name='_PyTime_ROUND_CEILING' value='1'/>
@@ -23728,19 +23748,14 @@
       <enumerator name='_PyTime_ROUND_UP' value='3'/>
       <enumerator name='_PyTime_ROUND_TIMEOUT' value='3'/>
     </enum-decl>
-    <typedef-decl name='_PyTime_round_t' type-id='type-id-1427' filepath='./Include/cpython/pytime.h' line='90' column='1' id='type-id-1426'/>
+    <typedef-decl name='_PyTime_round_t' type-id='type-id-1429' filepath='./Include/cpython/pytime.h' line='90' column='1' id='type-id-1428'/>
     <var-decl name='PyImport_Inittab' type-id='type-id-929' mangled-name='PyImport_Inittab' visibility='default' filepath='./Include/cpython/import.h' line='29' column='1' elf-symbol-id='PyImport_Inittab'/>
     <function-decl name='PyStatus_NoMemory' mangled-name='PyStatus_NoMemory' filepath='./Include/cpython/initconfig.h' line='23' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyStatus_NoMemory'>
       <return type-id='type-id-54'/>
     </function-decl>
-    <function-decl name='_PyInterpreterState_HasFeature' mangled-name='_PyInterpreterState_HasFeature' filepath='./Include/cpython/pystate.h' line='34' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyInterpreterState_HasFeature'>
-      <parameter type-id='type-id-20'/>
-      <parameter type-id='type-id-28'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
     <function-decl name='_PyTime_AsMicroseconds' mangled-name='_PyTime_AsMicroseconds' filepath='./Include/cpython/pytime.h' line='165' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyTime_AsMicroseconds'>
       <parameter type-id='type-id-799'/>
-      <parameter type-id='type-id-1426'/>
+      <parameter type-id='type-id-1428'/>
       <return type-id='type-id-799'/>
     </function-decl>
     <function-decl name='_PyTime_GetPerfCounter' mangled-name='_PyTime_GetPerfCounter' filepath='./Include/cpython/pytime.h' line='305' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyTime_GetPerfCounter'>
@@ -23912,7 +23927,7 @@
     </function-decl>
   </abi-instr>
   <abi-instr address-size='64' path='Python/initconfig.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
-    <class-decl name='_PyArgv' size-in-bits='256' is-struct='yes' visibility='default' filepath='./Include/internal/pycore_initconfig.h' line='64' column='1' id='type-id-1428'>
+    <class-decl name='_PyArgv' size-in-bits='256' is-struct='yes' visibility='default' filepath='./Include/internal/pycore_initconfig.h' line='64' column='1' id='type-id-1430'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='argc' type-id='type-id-14' visibility='default' filepath='./Include/internal/pycore_initconfig.h' line='65' column='1'/>
       </data-member>
@@ -23923,11 +23938,11 @@
         <var-decl name='bytes_argv' type-id='type-id-136' visibility='default' filepath='./Include/internal/pycore_initconfig.h' line='67' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='wchar_argv' type-id='type-id-1429' visibility='default' filepath='./Include/internal/pycore_initconfig.h' line='68' column='1'/>
+        <var-decl name='wchar_argv' type-id='type-id-1431' visibility='default' filepath='./Include/internal/pycore_initconfig.h' line='68' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='_PyArgv' type-id='type-id-1428' filepath='./Include/internal/pycore_initconfig.h' line='69' column='1' id='type-id-1430'/>
-    <class-decl name='_PyPreCmdline' size-in-bits='384' is-struct='yes' naming-typedef-id='type-id-1431' visibility='default' filepath='./Include/internal/pycore_initconfig.h' line='97' column='1' id='type-id-1432'>
+    <typedef-decl name='_PyArgv' type-id='type-id-1430' filepath='./Include/internal/pycore_initconfig.h' line='69' column='1' id='type-id-1432'/>
+    <class-decl name='_PyPreCmdline' size-in-bits='384' is-struct='yes' naming-typedef-id='type-id-1433' visibility='default' filepath='./Include/internal/pycore_initconfig.h' line='97' column='1' id='type-id-1434'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='argv' type-id='type-id-750' visibility='default' filepath='./Include/internal/pycore_initconfig.h' line='98' column='1'/>
       </data-member>
@@ -23947,24 +23962,24 @@
         <var-decl name='warn_default_encoding' type-id='type-id-8' visibility='default' filepath='./Include/internal/pycore_initconfig.h' line='103' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='_PyPreCmdline' type-id='type-id-1432' filepath='./Include/internal/pycore_initconfig.h' line='104' column='1' id='type-id-1431'/>
-    <pointer-type-def type-id='type-id-753' size-in-bits='64' id='type-id-1433'/>
-    <pointer-type-def type-id='type-id-750' size-in-bits='64' id='type-id-1434'/>
-    <pointer-type-def type-id='type-id-1431' size-in-bits='64' id='type-id-1435'/>
-    <qualified-type-def type-id='type-id-753' const='yes' id='type-id-1436'/>
-    <pointer-type-def type-id='type-id-1436' size-in-bits='64' id='type-id-1437'/>
-    <qualified-type-def type-id='type-id-750' const='yes' id='type-id-1438'/>
-    <pointer-type-def type-id='type-id-1438' size-in-bits='64' id='type-id-232'/>
-    <qualified-type-def type-id='type-id-1430' const='yes' id='type-id-1439'/>
-    <pointer-type-def type-id='type-id-1439' size-in-bits='64' id='type-id-1440'/>
-    <qualified-type-def type-id='type-id-1431' const='yes' id='type-id-1441'/>
+    <typedef-decl name='_PyPreCmdline' type-id='type-id-1434' filepath='./Include/internal/pycore_initconfig.h' line='104' column='1' id='type-id-1433'/>
+    <pointer-type-def type-id='type-id-753' size-in-bits='64' id='type-id-1435'/>
+    <pointer-type-def type-id='type-id-750' size-in-bits='64' id='type-id-1436'/>
+    <pointer-type-def type-id='type-id-1433' size-in-bits='64' id='type-id-1437'/>
+    <qualified-type-def type-id='type-id-753' const='yes' id='type-id-1438'/>
+    <pointer-type-def type-id='type-id-1438' size-in-bits='64' id='type-id-1439'/>
+    <qualified-type-def type-id='type-id-750' const='yes' id='type-id-1440'/>
+    <pointer-type-def type-id='type-id-1440' size-in-bits='64' id='type-id-232'/>
+    <qualified-type-def type-id='type-id-1432' const='yes' id='type-id-1441'/>
     <pointer-type-def type-id='type-id-1441' size-in-bits='64' id='type-id-1442'/>
+    <qualified-type-def type-id='type-id-1433' const='yes' id='type-id-1443'/>
+    <pointer-type-def type-id='type-id-1443' size-in-bits='64' id='type-id-1444'/>
     <qualified-type-def type-id='type-id-16' restrict='yes' id='type-id-18'/>
-    <qualified-type-def type-id='type-id-52' const='yes' id='type-id-1443'/>
-    <pointer-type-def type-id='type-id-1443' size-in-bits='64' id='type-id-1429'/>
+    <qualified-type-def type-id='type-id-52' const='yes' id='type-id-1445'/>
+    <pointer-type-def type-id='type-id-1445' size-in-bits='64' id='type-id-1431'/>
     <qualified-type-def type-id='type-id-52' restrict='yes' id='type-id-17'/>
-    <qualified-type-def type-id='type-id-235' restrict='yes' id='type-id-1444'/>
-    <pointer-type-def type-id='type-id-235' size-in-bits='64' id='type-id-1445'/>
+    <qualified-type-def type-id='type-id-235' restrict='yes' id='type-id-1446'/>
+    <pointer-type-def type-id='type-id-235' size-in-bits='64' id='type-id-1447'/>
     <var-decl name='Py_DebugFlag' type-id='type-id-8' mangled-name='Py_DebugFlag' visibility='default' filepath='./Include/cpython/pydebug.h' line='8' column='1' elf-symbol-id='Py_DebugFlag'/>
     <var-decl name='Py_VerboseFlag' type-id='type-id-8' mangled-name='Py_VerboseFlag' visibility='default' filepath='./Include/cpython/pydebug.h' line='9' column='1' elf-symbol-id='Py_VerboseFlag'/>
     <var-decl name='Py_QuietFlag' type-id='type-id-8' mangled-name='Py_QuietFlag' visibility='default' filepath='./Include/cpython/pydebug.h' line='10' column='1' elf-symbol-id='Py_QuietFlag'/>
@@ -24006,13 +24021,13 @@
     </function-decl>
     <function-decl name='_PyOS_GetOpt' filepath='./Include/internal/pycore_getopt.h' line='20' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-14'/>
-      <parameter type-id='type-id-1429'/>
+      <parameter type-id='type-id-1431'/>
       <parameter type-id='type-id-179'/>
       <return type-id='type-id-8'/>
     </function-decl>
     <function-decl name='_PyArgv_AsWstrList' mangled-name='_PyArgv_AsWstrList' filepath='./Include/internal/pycore_initconfig.h' line='71' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyArgv_AsWstrList'>
-      <parameter type-id='type-id-1440'/>
-      <parameter type-id='type-id-1434'/>
+      <parameter type-id='type-id-1442'/>
+      <parameter type-id='type-id-1436'/>
       <return type-id='type-id-54'/>
     </function-decl>
     <function-decl name='_Py_str_to_int' mangled-name='_Py_str_to_int' filepath='./Include/internal/pycore_initconfig.h' line='77' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_str_to_int'>
@@ -24037,30 +24052,30 @@
       <return type-id='type-id-46'/>
     </function-decl>
     <function-decl name='_PyPreCmdline_Clear' filepath='./Include/internal/pycore_initconfig.h' line='113' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-1435'/>
+      <parameter type-id='type-id-1437'/>
       <return type-id='type-id-46'/>
     </function-decl>
     <function-decl name='_PyPreCmdline_SetConfig' filepath='./Include/internal/pycore_initconfig.h' line='116' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-1442'/>
+      <parameter type-id='type-id-1444'/>
       <parameter type-id='type-id-53'/>
       <return type-id='type-id-54'/>
     </function-decl>
     <function-decl name='_PyPreCmdline_Read' filepath='./Include/internal/pycore_initconfig.h' line='119' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-1435'/>
       <parameter type-id='type-id-1437'/>
+      <parameter type-id='type-id-1439'/>
       <return type-id='type-id-54'/>
     </function-decl>
     <function-decl name='_PyPreConfig_InitFromPreConfig' filepath='./Include/internal/pycore_initconfig.h' line='129' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-1433'/>
-      <parameter type-id='type-id-1437'/>
+      <parameter type-id='type-id-1435'/>
+      <parameter type-id='type-id-1439'/>
       <return type-id='type-id-54'/>
     </function-decl>
     <function-decl name='_PyPreConfig_AsDict' filepath='./Include/internal/pycore_initconfig.h' line='132' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-1437'/>
+      <parameter type-id='type-id-1439'/>
       <return type-id='type-id-2'/>
     </function-decl>
     <function-decl name='_PyPreConfig_GetConfig' filepath='./Include/internal/pycore_initconfig.h' line='133' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-1433'/>
+      <parameter type-id='type-id-1435'/>
       <parameter type-id='type-id-260'/>
       <return type-id='type-id-46'/>
     </function-decl>
@@ -24074,7 +24089,7 @@
       <return type-id='type-id-8'/>
     </function-decl>
     <function-decl name='_PySys_ReadPreinitWarnOptions' filepath='./Include/internal/pycore_pylifecycle.h' line='38' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-1434'/>
+      <parameter type-id='type-id-1436'/>
       <return type-id='type-id-54'/>
     </function-decl>
     <function-decl name='_PySys_ReadPreinitXOptions' filepath='./Include/internal/pycore_pylifecycle.h' line='39' column='1' visibility='default' binding='global' size-in-bits='64'>
@@ -24083,7 +24098,7 @@
     </function-decl>
     <function-decl name='_Py_PreInitializeFromConfig' mangled-name='_Py_PreInitializeFromConfig' filepath='./Include/internal/pycore_pylifecycle.h' line='77' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_PreInitializeFromConfig'>
       <parameter type-id='type-id-260'/>
-      <parameter type-id='type-id-1440'/>
+      <parameter type-id='type-id-1442'/>
       <return type-id='type-id-54'/>
     </function-decl>
     <function-decl name='setlocale' filepath='/usr/include/locale.h' line='122' column='1' visibility='default' binding='global' size-in-bits='64'>
@@ -24101,6 +24116,10 @@
     <function-decl name='printf' filepath='/usr/include/stdio.h' line='356' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-12'/>
       <parameter is-variadic='yes'/>
+      <return type-id='type-id-8'/>
+    </function-decl>
+    <function-decl name='putchar' filepath='/usr/include/stdio.h' line='556' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-8'/>
       <return type-id='type-id-8'/>
     </function-decl>
     <function-decl name='puts' filepath='/usr/include/stdio.h' line='661' column='1' visibility='default' binding='global' size-in-bits='64'>
@@ -24125,130 +24144,130 @@
     <function-decl name='wcstok' filepath='/usr/include/wchar.h' line='218' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-17'/>
       <parameter type-id='type-id-18'/>
-      <parameter type-id='type-id-1444'/>
+      <parameter type-id='type-id-1446'/>
       <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='wcstol' filepath='/usr/include/wchar.h' line='429' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-18'/>
-      <parameter type-id='type-id-1444'/>
+      <parameter type-id='type-id-1446'/>
       <parameter type-id='type-id-8'/>
       <return type-id='type-id-47'/>
     </function-decl>
-    <function-decl name='PyStatus_Ok' mangled-name='PyStatus_Ok' filepath='Python/initconfig.c' line='312' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyStatus_Ok'>
+    <function-decl name='PyStatus_Ok' mangled-name='PyStatus_Ok' filepath='Python/initconfig.c' line='287' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyStatus_Ok'>
       <return type-id='type-id-54'/>
     </function-decl>
-    <function-decl name='PyStatus_Error' mangled-name='PyStatus_Error' filepath='Python/initconfig.c' line='315' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyStatus_Error'>
-      <parameter type-id='type-id-12' name='err_msg' filepath='Python/initconfig.c' line='315' column='1'/>
+    <function-decl name='PyStatus_Error' mangled-name='PyStatus_Error' filepath='Python/initconfig.c' line='290' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyStatus_Error'>
+      <parameter type-id='type-id-12' name='err_msg' filepath='Python/initconfig.c' line='290' column='1'/>
       <return type-id='type-id-54'/>
     </function-decl>
-    <function-decl name='PyStatus_Exit' mangled-name='PyStatus_Exit' filepath='Python/initconfig.c' line='325' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyStatus_Exit'>
-      <parameter type-id='type-id-8' name='exitcode' filepath='Python/initconfig.c' line='325' column='1'/>
+    <function-decl name='PyStatus_Exit' mangled-name='PyStatus_Exit' filepath='Python/initconfig.c' line='300' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyStatus_Exit'>
+      <parameter type-id='type-id-8' name='exitcode' filepath='Python/initconfig.c' line='300' column='1'/>
       <return type-id='type-id-54'/>
     </function-decl>
-    <function-decl name='PyStatus_IsError' mangled-name='PyStatus_IsError' filepath='Python/initconfig.c' line='329' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyStatus_IsError'>
-      <parameter type-id='type-id-54' name='status' filepath='Python/initconfig.c' line='329' column='1'/>
+    <function-decl name='PyStatus_IsError' mangled-name='PyStatus_IsError' filepath='Python/initconfig.c' line='304' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyStatus_IsError'>
+      <parameter type-id='type-id-54' name='status' filepath='Python/initconfig.c' line='304' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='PyStatus_IsExit' mangled-name='PyStatus_IsExit' filepath='Python/initconfig.c' line='332' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyStatus_IsExit'>
-      <parameter type-id='type-id-54' name='status' filepath='Python/initconfig.c' line='332' column='1'/>
+    <function-decl name='PyStatus_IsExit' mangled-name='PyStatus_IsExit' filepath='Python/initconfig.c' line='307' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyStatus_IsExit'>
+      <parameter type-id='type-id-54' name='status' filepath='Python/initconfig.c' line='307' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='_PyErr_SetFromPyStatus' mangled-name='_PyErr_SetFromPyStatus' filepath='Python/initconfig.c' line='339' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyErr_SetFromPyStatus'>
-      <parameter type-id='type-id-54' name='status' filepath='Python/initconfig.c' line='339' column='1'/>
+    <function-decl name='_PyErr_SetFromPyStatus' mangled-name='_PyErr_SetFromPyStatus' filepath='Python/initconfig.c' line='314' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyErr_SetFromPyStatus'>
+      <parameter type-id='type-id-54' name='status' filepath='Python/initconfig.c' line='314' column='1'/>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='_PyWideStringList_Clear' mangled-name='_PyWideStringList_Clear' filepath='Python/initconfig.c' line='375' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyWideStringList_Clear'>
-      <parameter type-id='type-id-1434' name='list' filepath='Python/initconfig.c' line='375' column='1'/>
+    <function-decl name='_PyWideStringList_Clear' mangled-name='_PyWideStringList_Clear' filepath='Python/initconfig.c' line='350' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyWideStringList_Clear'>
+      <parameter type-id='type-id-1436' name='list' filepath='Python/initconfig.c' line='350' column='1'/>
       <return type-id='type-id-46'/>
     </function-decl>
-    <function-decl name='_PyWideStringList_Copy' mangled-name='_PyWideStringList_Copy' filepath='Python/initconfig.c' line='388' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyWideStringList_Copy'>
-      <parameter type-id='type-id-1434' name='list' filepath='Python/initconfig.c' line='388' column='1'/>
-      <parameter type-id='type-id-232' name='list2' filepath='Python/initconfig.c' line='388' column='1'/>
+    <function-decl name='_PyWideStringList_Copy' mangled-name='_PyWideStringList_Copy' filepath='Python/initconfig.c' line='363' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyWideStringList_Copy'>
+      <parameter type-id='type-id-1436' name='list' filepath='Python/initconfig.c' line='363' column='1'/>
+      <parameter type-id='type-id-232' name='list2' filepath='Python/initconfig.c' line='363' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='PyWideStringList_Insert' mangled-name='PyWideStringList_Insert' filepath='Python/initconfig.c' line='423' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyWideStringList_Insert'>
-      <parameter type-id='type-id-1434' name='list' filepath='Python/initconfig.c' line='423' column='1'/>
-      <parameter type-id='type-id-14' name='index' filepath='Python/initconfig.c' line='424' column='1'/>
-      <parameter type-id='type-id-16' name='item' filepath='Python/initconfig.c' line='424' column='1'/>
+    <function-decl name='PyWideStringList_Insert' mangled-name='PyWideStringList_Insert' filepath='Python/initconfig.c' line='398' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyWideStringList_Insert'>
+      <parameter type-id='type-id-1436' name='list' filepath='Python/initconfig.c' line='398' column='1'/>
+      <parameter type-id='type-id-14' name='index' filepath='Python/initconfig.c' line='399' column='1'/>
+      <parameter type-id='type-id-16' name='item' filepath='Python/initconfig.c' line='399' column='1'/>
       <return type-id='type-id-54'/>
     </function-decl>
-    <function-decl name='PyWideStringList_Append' mangled-name='PyWideStringList_Append' filepath='Python/initconfig.c' line='464' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyWideStringList_Append'>
-      <parameter type-id='type-id-1434' name='list' filepath='Python/initconfig.c' line='464' column='1'/>
-      <parameter type-id='type-id-16' name='item' filepath='Python/initconfig.c' line='464' column='1'/>
+    <function-decl name='PyWideStringList_Append' mangled-name='PyWideStringList_Append' filepath='Python/initconfig.c' line='439' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyWideStringList_Append'>
+      <parameter type-id='type-id-1436' name='list' filepath='Python/initconfig.c' line='439' column='1'/>
+      <parameter type-id='type-id-16' name='item' filepath='Python/initconfig.c' line='439' column='1'/>
       <return type-id='type-id-54'/>
     </function-decl>
-    <function-decl name='_PyWideStringList_Extend' mangled-name='_PyWideStringList_Extend' filepath='Python/initconfig.c' line='471' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyWideStringList_Extend'>
-      <parameter type-id='type-id-1434' name='list' filepath='Python/initconfig.c' line='471' column='1'/>
-      <parameter type-id='type-id-232' name='list2' filepath='Python/initconfig.c' line='471' column='1'/>
+    <function-decl name='_PyWideStringList_Extend' mangled-name='_PyWideStringList_Extend' filepath='Python/initconfig.c' line='446' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyWideStringList_Extend'>
+      <parameter type-id='type-id-1436' name='list' filepath='Python/initconfig.c' line='446' column='1'/>
+      <parameter type-id='type-id-232' name='list2' filepath='Python/initconfig.c' line='446' column='1'/>
       <return type-id='type-id-54'/>
     </function-decl>
-    <function-decl name='_PyWideStringList_AsList' mangled-name='_PyWideStringList_AsList' filepath='Python/initconfig.c' line='496' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyWideStringList_AsList'>
-      <parameter type-id='type-id-232' name='list' filepath='Python/initconfig.c' line='496' column='1'/>
+    <function-decl name='_PyWideStringList_AsList' mangled-name='_PyWideStringList_AsList' filepath='Python/initconfig.c' line='471' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyWideStringList_AsList'>
+      <parameter type-id='type-id-232' name='list' filepath='Python/initconfig.c' line='471' column='1'/>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='Py_SetStandardStreamEncoding' mangled-name='Py_SetStandardStreamEncoding' filepath='Python/initconfig.c' line='527' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='Py_SetStandardStreamEncoding'>
-      <parameter type-id='type-id-12' name='encoding' filepath='Python/initconfig.c' line='527' column='1'/>
-      <parameter type-id='type-id-12' name='errors' filepath='Python/initconfig.c' line='527' column='1'/>
+    <function-decl name='Py_SetStandardStreamEncoding' mangled-name='Py_SetStandardStreamEncoding' filepath='Python/initconfig.c' line='502' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='Py_SetStandardStreamEncoding'>
+      <parameter type-id='type-id-12' name='encoding' filepath='Python/initconfig.c' line='502' column='1'/>
+      <parameter type-id='type-id-12' name='errors' filepath='Python/initconfig.c' line='502' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='_Py_ClearStandardStreamEncoding' mangled-name='_Py_ClearStandardStreamEncoding' filepath='Python/initconfig.c' line='585' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_ClearStandardStreamEncoding'>
+    <function-decl name='_Py_ClearStandardStreamEncoding' mangled-name='_Py_ClearStandardStreamEncoding' filepath='Python/initconfig.c' line='560' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_ClearStandardStreamEncoding'>
       <return type-id='type-id-46'/>
     </function-decl>
-    <function-decl name='_Py_ClearArgcArgv' mangled-name='_Py_ClearArgcArgv' filepath='Python/initconfig.c' line='608' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_ClearArgcArgv'>
+    <function-decl name='_Py_ClearArgcArgv' mangled-name='_Py_ClearArgcArgv' filepath='Python/initconfig.c' line='583' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_ClearArgcArgv'>
       <return type-id='type-id-46'/>
     </function-decl>
-    <function-decl name='Py_GetArgcArgv' mangled-name='Py_GetArgcArgv' filepath='Python/initconfig.c' line='639' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='Py_GetArgcArgv'>
-      <parameter type-id='type-id-179' name='argc' filepath='Python/initconfig.c' line='639' column='1'/>
-      <parameter type-id='type-id-1445' name='argv' filepath='Python/initconfig.c' line='639' column='1'/>
+    <function-decl name='Py_GetArgcArgv' mangled-name='Py_GetArgcArgv' filepath='Python/initconfig.c' line='614' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='Py_GetArgcArgv'>
+      <parameter type-id='type-id-179' name='argc' filepath='Python/initconfig.c' line='614' column='1'/>
+      <parameter type-id='type-id-1447' name='argv' filepath='Python/initconfig.c' line='614' column='1'/>
       <return type-id='type-id-46'/>
     </function-decl>
-    <function-decl name='_PyConfig_InitCompatConfig' mangled-name='_PyConfig_InitCompatConfig' filepath='Python/initconfig.c' line='758' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyConfig_InitCompatConfig'>
-      <parameter type-id='type-id-53' name='config' filepath='Python/initconfig.c' line='758' column='1'/>
+    <function-decl name='_PyConfig_InitCompatConfig' mangled-name='_PyConfig_InitCompatConfig' filepath='Python/initconfig.c' line='733' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyConfig_InitCompatConfig'>
+      <parameter type-id='type-id-53' name='config' filepath='Python/initconfig.c' line='733' column='1'/>
       <return type-id='type-id-46'/>
     </function-decl>
-    <function-decl name='PyConfig_InitIsolatedConfig' mangled-name='PyConfig_InitIsolatedConfig' filepath='Python/initconfig.c' line='842' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyConfig_InitIsolatedConfig'>
+    <function-decl name='PyConfig_InitIsolatedConfig' mangled-name='PyConfig_InitIsolatedConfig' filepath='Python/initconfig.c' line='817' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyConfig_InitIsolatedConfig'>
+      <parameter type-id='type-id-53' name='config' filepath='Python/initconfig.c' line='817' column='1'/>
+      <return type-id='type-id-46'/>
+    </function-decl>
+    <function-decl name='PyConfig_SetString' mangled-name='PyConfig_SetString' filepath='Python/initconfig.c' line='842' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyConfig_SetString'>
       <parameter type-id='type-id-53' name='config' filepath='Python/initconfig.c' line='842' column='1'/>
-      <return type-id='type-id-46'/>
-    </function-decl>
-    <function-decl name='PyConfig_SetString' mangled-name='PyConfig_SetString' filepath='Python/initconfig.c' line='867' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyConfig_SetString'>
-      <parameter type-id='type-id-53' name='config' filepath='Python/initconfig.c' line='867' column='1'/>
-      <parameter type-id='type-id-235' name='config_str' filepath='Python/initconfig.c' line='867' column='1'/>
-      <parameter type-id='type-id-16' name='str' filepath='Python/initconfig.c' line='867' column='1'/>
+      <parameter type-id='type-id-235' name='config_str' filepath='Python/initconfig.c' line='842' column='1'/>
+      <parameter type-id='type-id-16' name='str' filepath='Python/initconfig.c' line='842' column='1'/>
       <return type-id='type-id-54'/>
     </function-decl>
-    <function-decl name='PyConfig_SetBytesString' mangled-name='PyConfig_SetBytesString' filepath='Python/initconfig.c' line='929' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyConfig_SetBytesString'>
-      <parameter type-id='type-id-53' name='config' filepath='Python/initconfig.c' line='929' column='1'/>
-      <parameter type-id='type-id-235' name='config_str' filepath='Python/initconfig.c' line='929' column='1'/>
-      <parameter type-id='type-id-12' name='str' filepath='Python/initconfig.c' line='930' column='1'/>
+    <function-decl name='PyConfig_SetBytesString' mangled-name='PyConfig_SetBytesString' filepath='Python/initconfig.c' line='904' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyConfig_SetBytesString'>
+      <parameter type-id='type-id-53' name='config' filepath='Python/initconfig.c' line='904' column='1'/>
+      <parameter type-id='type-id-235' name='config_str' filepath='Python/initconfig.c' line='904' column='1'/>
+      <parameter type-id='type-id-12' name='str' filepath='Python/initconfig.c' line='905' column='1'/>
       <return type-id='type-id-54'/>
     </function-decl>
-    <function-decl name='_PyConfig_AsDict' mangled-name='_PyConfig_AsDict' filepath='Python/initconfig.c' line='1038' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyConfig_AsDict'>
-      <parameter type-id='type-id-260' name='config' filepath='Python/initconfig.c' line='1038' column='1'/>
+    <function-decl name='_PyConfig_AsDict' mangled-name='_PyConfig_AsDict' filepath='Python/initconfig.c' line='1013' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyConfig_AsDict'>
+      <parameter type-id='type-id-260' name='config' filepath='Python/initconfig.c' line='1013' column='1'/>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='_PyConfig_FromDict' mangled-name='_PyConfig_FromDict' filepath='Python/initconfig.c' line='1306' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyConfig_FromDict'>
-      <parameter type-id='type-id-53' name='config' filepath='Python/initconfig.c' line='1306' column='1'/>
-      <parameter type-id='type-id-2' name='dict' filepath='Python/initconfig.c' line='1306' column='1'/>
+    <function-decl name='_PyConfig_FromDict' mangled-name='_PyConfig_FromDict' filepath='Python/initconfig.c' line='1281' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyConfig_FromDict'>
+      <parameter type-id='type-id-53' name='config' filepath='Python/initconfig.c' line='1281' column='1'/>
+      <parameter type-id='type-id-2' name='dict' filepath='Python/initconfig.c' line='1281' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='PyConfig_SetArgv' mangled-name='PyConfig_SetArgv' filepath='Python/initconfig.c' line='2955' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyConfig_SetArgv'>
-      <parameter type-id='type-id-53' name='config' filepath='Python/initconfig.c' line='2955' column='1'/>
-      <parameter type-id='type-id-14' name='argc' filepath='Python/initconfig.c' line='2955' column='1'/>
-      <parameter type-id='type-id-1429' name='argv' filepath='Python/initconfig.c' line='2955' column='1'/>
+    <function-decl name='PyConfig_SetArgv' mangled-name='PyConfig_SetArgv' filepath='Python/initconfig.c' line='2930' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyConfig_SetArgv'>
+      <parameter type-id='type-id-53' name='config' filepath='Python/initconfig.c' line='2930' column='1'/>
+      <parameter type-id='type-id-14' name='argc' filepath='Python/initconfig.c' line='2930' column='1'/>
+      <parameter type-id='type-id-1431' name='argv' filepath='Python/initconfig.c' line='2930' column='1'/>
       <return type-id='type-id-54'/>
     </function-decl>
-    <function-decl name='PyConfig_SetWideStringList' mangled-name='PyConfig_SetWideStringList' filepath='Python/initconfig.c' line='2967' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyConfig_SetWideStringList'>
-      <parameter type-id='type-id-53' name='config' filepath='Python/initconfig.c' line='2967' column='1'/>
-      <parameter type-id='type-id-1434' name='list' filepath='Python/initconfig.c' line='2967' column='1'/>
-      <parameter type-id='type-id-14' name='length' filepath='Python/initconfig.c' line='2968' column='1'/>
-      <parameter type-id='type-id-235' name='items' filepath='Python/initconfig.c' line='2968' column='1'/>
+    <function-decl name='PyConfig_SetWideStringList' mangled-name='PyConfig_SetWideStringList' filepath='Python/initconfig.c' line='2942' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyConfig_SetWideStringList'>
+      <parameter type-id='type-id-53' name='config' filepath='Python/initconfig.c' line='2942' column='1'/>
+      <parameter type-id='type-id-1436' name='list' filepath='Python/initconfig.c' line='2942' column='1'/>
+      <parameter type-id='type-id-14' name='length' filepath='Python/initconfig.c' line='2943' column='1'/>
+      <parameter type-id='type-id-235' name='items' filepath='Python/initconfig.c' line='2943' column='1'/>
       <return type-id='type-id-54'/>
     </function-decl>
-    <function-decl name='PyConfig_Read' mangled-name='PyConfig_Read' filepath='Python/initconfig.c' line='3051' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyConfig_Read'>
-      <parameter type-id='type-id-53' name='config' filepath='Python/initconfig.c' line='3051' column='1'/>
+    <function-decl name='PyConfig_Read' mangled-name='PyConfig_Read' filepath='Python/initconfig.c' line='3026' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyConfig_Read'>
+      <parameter type-id='type-id-53' name='config' filepath='Python/initconfig.c' line='3026' column='1'/>
       <return type-id='type-id-54'/>
     </function-decl>
-    <function-decl name='_Py_GetConfigsAsDict' mangled-name='_Py_GetConfigsAsDict' filepath='Python/initconfig.c' line='3058' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_GetConfigsAsDict'>
+    <function-decl name='_Py_GetConfigsAsDict' mangled-name='_Py_GetConfigsAsDict' filepath='Python/initconfig.c' line='3033' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_GetConfigsAsDict'>
       <return type-id='type-id-2'/>
     </function-decl>
   </abi-instr>
@@ -24257,25 +24276,25 @@
     <var-decl name='_PyInstrumentation_DISABLE' type-id='type-id-345' visibility='default' filepath='./Include/internal/pycore_instruments.h' line='101' column='1'/>
   </abi-instr>
   <abi-instr address-size='64' path='Python/intrinsics.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
-    <array-type-def dimensions='1' type-id='type-id-1446' size-in-bits='768' id='type-id-1447'>
+    <array-type-def dimensions='1' type-id='type-id-1448' size-in-bits='768' id='type-id-1449'>
       <subrange length='12' type-id='type-id-28' id='type-id-663'/>
     </array-type-def>
-    <array-type-def dimensions='1' type-id='type-id-1446' size-in-bits='infinite' id='type-id-1448'>
+    <array-type-def dimensions='1' type-id='type-id-1448' size-in-bits='infinite' id='type-id-1450'>
       <subrange length='infinite' id='type-id-225'/>
     </array-type-def>
-    <array-type-def dimensions='1' type-id='type-id-1449' size-in-bits='320' id='type-id-1450'>
+    <array-type-def dimensions='1' type-id='type-id-1451' size-in-bits='320' id='type-id-1452'>
       <subrange length='5' type-id='type-id-28' id='type-id-698'/>
     </array-type-def>
-    <array-type-def dimensions='1' type-id='type-id-1449' size-in-bits='infinite' id='type-id-1451'>
+    <array-type-def dimensions='1' type-id='type-id-1451' size-in-bits='infinite' id='type-id-1453'>
       <subrange length='infinite' id='type-id-225'/>
     </array-type-def>
-    <typedef-decl name='instrinsic_func1' type-id='type-id-1452' filepath='./Include/internal/pycore_intrinsics.h' line='29' column='1' id='type-id-1453'/>
-    <typedef-decl name='instrinsic_func2' type-id='type-id-1454' filepath='./Include/internal/pycore_intrinsics.h' line='30' column='1' id='type-id-1455'/>
-    <pointer-type-def type-id='type-id-1456' size-in-bits='64' id='type-id-1452'/>
-    <pointer-type-def type-id='type-id-1457' size-in-bits='64' id='type-id-1454'/>
-    <qualified-type-def type-id='type-id-1453' const='yes' id='type-id-1446'/>
-    <qualified-type-def type-id='type-id-1455' const='yes' id='type-id-1449'/>
-    <function-decl name='_PyFrame_LocalsToFast' filepath='./Include/internal/pycore_frame.h' line='236' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <typedef-decl name='instrinsic_func1' type-id='type-id-1454' filepath='./Include/internal/pycore_intrinsics.h' line='29' column='1' id='type-id-1455'/>
+    <typedef-decl name='instrinsic_func2' type-id='type-id-1456' filepath='./Include/internal/pycore_intrinsics.h' line='30' column='1' id='type-id-1457'/>
+    <pointer-type-def type-id='type-id-1458' size-in-bits='64' id='type-id-1454'/>
+    <pointer-type-def type-id='type-id-1459' size-in-bits='64' id='type-id-1456'/>
+    <qualified-type-def type-id='type-id-1455' const='yes' id='type-id-1448'/>
+    <qualified-type-def type-id='type-id-1457' const='yes' id='type-id-1451'/>
+    <function-decl name='_PyFrame_LocalsToFast' filepath='./Include/internal/pycore_frame.h' line='238' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-374'/>
       <parameter type-id='type-id-8'/>
       <return type-id='type-id-46'/>
@@ -24291,8 +24310,8 @@
       <parameter type-id='type-id-2'/>
       <return type-id='type-id-2'/>
     </function-decl>
-    <var-decl name='_PyIntrinsics_UnaryFunctions' type-id='type-id-1448' visibility='default' filepath='./Include/internal/pycore_intrinsics.h' line='31' column='1'/>
-    <var-decl name='_PyIntrinsics_BinaryFunctions' type-id='type-id-1451' visibility='default' filepath='./Include/internal/pycore_intrinsics.h' line='32' column='1'/>
+    <var-decl name='_PyIntrinsics_UnaryFunctions' type-id='type-id-1450' visibility='default' filepath='./Include/internal/pycore_intrinsics.h' line='31' column='1'/>
+    <var-decl name='_PyIntrinsics_BinaryFunctions' type-id='type-id-1453' visibility='default' filepath='./Include/internal/pycore_intrinsics.h' line='32' column='1'/>
     <function-decl name='_Py_make_typevar' filepath='./Include/internal/pycore_typevarobject.h' line='11' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-2'/>
       <parameter type-id='type-id-2'/>
@@ -24319,12 +24338,12 @@
       <parameter type-id='type-id-2'/>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-type size-in-bits='64' id='type-id-1456'>
+    <function-type size-in-bits='64' id='type-id-1458'>
       <parameter type-id='type-id-177'/>
       <parameter type-id='type-id-2'/>
       <return type-id='type-id-2'/>
     </function-type>
-    <function-type size-in-bits='64' id='type-id-1457'>
+    <function-type size-in-bits='64' id='type-id-1459'>
       <parameter type-id='type-id-177'/>
       <parameter type-id='type-id-2'/>
       <parameter type-id='type-id-2'/>
@@ -24332,7 +24351,7 @@
     </function-type>
   </abi-instr>
   <abi-instr address-size='64' path='Python/legacy_tracing.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
-    <typedef-decl name='_PyMonitoringEventSet' type-id='type-id-352' filepath='./Include/internal/pycore_instruments.h' line='49' column='1' id='type-id-1458'/>
+    <typedef-decl name='_PyMonitoringEventSet' type-id='type-id-352' filepath='./Include/internal/pycore_instruments.h' line='49' column='1' id='type-id-1460'/>
     <function-decl name='_PyMonitoring_RegisterCallback' filepath='./Include/internal/pycore_instruments.h' line='64' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-8'/>
       <parameter type-id='type-id-8'/>
@@ -24341,7 +24360,7 @@
     </function-decl>
     <function-decl name='_PyMonitoring_SetEvents' filepath='./Include/internal/pycore_instruments.h' line='66' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-8'/>
-      <parameter type-id='type-id-1458'/>
+      <parameter type-id='type-id-1460'/>
       <return type-id='type-id-8'/>
     </function-decl>
     <function-decl name='_Py_Instrumentation_GetLine' filepath='./Include/internal/pycore_instruments.h' line='98' column='1' visibility='default' binding='global' size-in-bits='64'>
@@ -24351,18 +24370,18 @@
     </function-decl>
   </abi-instr>
   <abi-instr address-size='64' path='Python/marshal.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
-    <array-type-def dimensions='1' type-id='type-id-116' size-in-bits='192' id='type-id-1459'>
+    <array-type-def dimensions='1' type-id='type-id-116' size-in-bits='192' id='type-id-1461'>
       <subrange length='3' type-id='type-id-28' id='type-id-640'/>
     </array-type-def>
-    <class-decl name='stat' size-in-bits='1152' is-struct='yes' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/struct_stat.h' line='26' column='1' id='type-id-1460'>
+    <class-decl name='stat' size-in-bits='1152' is-struct='yes' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/struct_stat.h' line='26' column='1' id='type-id-1462'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='st_dev' type-id='type-id-187' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/struct_stat.h' line='31' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='st_ino' type-id='type-id-1461' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/struct_stat.h' line='36' column='1'/>
+        <var-decl name='st_ino' type-id='type-id-1463' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/struct_stat.h' line='36' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='st_nlink' type-id='type-id-1462' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/struct_stat.h' line='44' column='1'/>
+        <var-decl name='st_nlink' type-id='type-id-1464' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/struct_stat.h' line='44' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='192'>
         <var-decl name='st_mode' type-id='type-id-123' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/struct_stat.h' line='45' column='1'/>
@@ -24380,34 +24399,34 @@
         <var-decl name='st_rdev' type-id='type-id-187' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/struct_stat.h' line='52' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='384'>
-        <var-decl name='st_size' type-id='type-id-1286' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/struct_stat.h' line='57' column='1'/>
+        <var-decl name='st_size' type-id='type-id-1287' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/struct_stat.h' line='57' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='448'>
-        <var-decl name='st_blksize' type-id='type-id-1463' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/struct_stat.h' line='61' column='1'/>
+        <var-decl name='st_blksize' type-id='type-id-1465' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/struct_stat.h' line='61' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='512'>
-        <var-decl name='st_blocks' type-id='type-id-1464' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/struct_stat.h' line='63' column='1'/>
+        <var-decl name='st_blocks' type-id='type-id-1466' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/struct_stat.h' line='63' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='576'>
-        <var-decl name='st_atim' type-id='type-id-1348' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/struct_stat.h' line='74' column='1'/>
+        <var-decl name='st_atim' type-id='type-id-1349' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/struct_stat.h' line='74' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='704'>
-        <var-decl name='st_mtim' type-id='type-id-1348' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/struct_stat.h' line='75' column='1'/>
+        <var-decl name='st_mtim' type-id='type-id-1349' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/struct_stat.h' line='75' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='832'>
-        <var-decl name='st_ctim' type-id='type-id-1348' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/struct_stat.h' line='76' column='1'/>
+        <var-decl name='st_ctim' type-id='type-id-1349' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/struct_stat.h' line='76' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='960'>
-        <var-decl name='__glibc_reserved' type-id='type-id-1459' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/struct_stat.h' line='89' column='1'/>
+        <var-decl name='__glibc_reserved' type-id='type-id-1461' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/struct_stat.h' line='89' column='1'/>
       </data-member>
     </class-decl>
     <typedef-decl name='__gid_t' type-id='type-id-95' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='147' column='1' id='type-id-121'/>
-    <typedef-decl name='__ino_t' type-id='type-id-28' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='148' column='1' id='type-id-1461'/>
+    <typedef-decl name='__ino_t' type-id='type-id-28' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='148' column='1' id='type-id-1463'/>
     <typedef-decl name='__mode_t' type-id='type-id-95' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='150' column='1' id='type-id-123'/>
-    <typedef-decl name='__nlink_t' type-id='type-id-28' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='151' column='1' id='type-id-1462'/>
-    <typedef-decl name='__blksize_t' type-id='type-id-47' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='175' column='1' id='type-id-1463'/>
-    <typedef-decl name='__blkcnt_t' type-id='type-id-47' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='180' column='1' id='type-id-1464'/>
-    <pointer-type-def type-id='type-id-1460' size-in-bits='64' id='type-id-51'/>
+    <typedef-decl name='__nlink_t' type-id='type-id-28' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='151' column='1' id='type-id-1464'/>
+    <typedef-decl name='__blksize_t' type-id='type-id-47' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='175' column='1' id='type-id-1465'/>
+    <typedef-decl name='__blkcnt_t' type-id='type-id-47' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='180' column='1' id='type-id-1466'/>
+    <pointer-type-def type-id='type-id-1462' size-in-bits='64' id='type-id-51'/>
     <function-decl name='_Py_fstat_noraise' mangled-name='_Py_fstat_noraise' filepath='./Include/internal/pycore_fileutils.h' line='97' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_fstat_noraise'>
       <parameter type-id='type-id-8'/>
       <parameter type-id='type-id-51'/>
@@ -24581,7 +24600,7 @@
     </function-decl>
   </abi-instr>
   <abi-instr address-size='64' path='Python/perf_trampoline.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
-    <var-decl name='_Py_perfmap_callbacks' type-id='type-id-1465' visibility='default' filepath='./Include/internal/pycore_ceval.h' line='80' column='1'/>
+    <var-decl name='_Py_perfmap_callbacks' type-id='type-id-1467' visibility='default' filepath='./Include/internal/pycore_ceval.h' line='81' column='1'/>
     <function-decl name='mprotect' filepath='/usr/include/x86_64-linux-gnu/sys/mman.h' line='81' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-22'/>
       <parameter type-id='type-id-19'/>
@@ -24613,55 +24632,55 @@
       <return type-id='type-id-8'/>
     </function-decl>
     <function-decl name='_PyPreConfig_InitCompatConfig' mangled-name='_PyPreConfig_InitCompatConfig' filepath='Python/preconfig.c' line='283' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyPreConfig_InitCompatConfig'>
-      <parameter type-id='type-id-1433' name='config' filepath='Python/preconfig.c' line='283' column='1'/>
+      <parameter type-id='type-id-1435' name='config' filepath='Python/preconfig.c' line='283' column='1'/>
       <return type-id='type-id-46'/>
     </function-decl>
     <function-decl name='PyPreConfig_InitPythonConfig' mangled-name='PyPreConfig_InitPythonConfig' filepath='Python/preconfig.c' line='311' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyPreConfig_InitPythonConfig'>
-      <parameter type-id='type-id-1433' name='config' filepath='Python/preconfig.c' line='311' column='1'/>
+      <parameter type-id='type-id-1435' name='config' filepath='Python/preconfig.c' line='311' column='1'/>
       <return type-id='type-id-46'/>
     </function-decl>
     <function-decl name='PyPreConfig_InitIsolatedConfig' mangled-name='PyPreConfig_InitIsolatedConfig' filepath='Python/preconfig.c' line='332' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyPreConfig_InitIsolatedConfig'>
-      <parameter type-id='type-id-1433' name='config' filepath='Python/preconfig.c' line='332' column='1'/>
+      <parameter type-id='type-id-1435' name='config' filepath='Python/preconfig.c' line='332' column='1'/>
       <return type-id='type-id-46'/>
     </function-decl>
   </abi-instr>
   <abi-instr address-size='64' path='Python/pyctype.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
-    <array-type-def dimensions='1' type-id='type-id-382' size-in-bits='2048' id='type-id-1466'>
+    <array-type-def dimensions='1' type-id='type-id-382' size-in-bits='2048' id='type-id-1468'>
       <subrange length='256' type-id='type-id-28' id='type-id-62'/>
     </array-type-def>
-    <array-type-def dimensions='1' type-id='type-id-1467' size-in-bits='8192' id='type-id-1468'>
+    <array-type-def dimensions='1' type-id='type-id-1469' size-in-bits='8192' id='type-id-1470'>
       <subrange length='256' type-id='type-id-28' id='type-id-62'/>
     </array-type-def>
-    <qualified-type-def type-id='type-id-95' const='yes' id='type-id-1467'/>
-    <var-decl name='_Py_ctype_table' type-id='type-id-1468' mangled-name='_Py_ctype_table' visibility='default' filepath='./Include/cpython/pyctype.h' line='16' column='1' elf-symbol-id='_Py_ctype_table'/>
-    <var-decl name='_Py_ctype_tolower' type-id='type-id-1466' mangled-name='_Py_ctype_tolower' visibility='default' filepath='./Include/cpython/pyctype.h' line='29' column='1' elf-symbol-id='_Py_ctype_tolower'/>
-    <var-decl name='_Py_ctype_toupper' type-id='type-id-1466' mangled-name='_Py_ctype_toupper' visibility='default' filepath='./Include/cpython/pyctype.h' line='30' column='1' elf-symbol-id='_Py_ctype_toupper'/>
+    <qualified-type-def type-id='type-id-95' const='yes' id='type-id-1469'/>
+    <var-decl name='_Py_ctype_table' type-id='type-id-1470' mangled-name='_Py_ctype_table' visibility='default' filepath='./Include/cpython/pyctype.h' line='16' column='1' elf-symbol-id='_Py_ctype_table'/>
+    <var-decl name='_Py_ctype_tolower' type-id='type-id-1468' mangled-name='_Py_ctype_tolower' visibility='default' filepath='./Include/cpython/pyctype.h' line='29' column='1' elf-symbol-id='_Py_ctype_tolower'/>
+    <var-decl name='_Py_ctype_toupper' type-id='type-id-1468' mangled-name='_Py_ctype_toupper' visibility='default' filepath='./Include/cpython/pyctype.h' line='30' column='1' elf-symbol-id='_Py_ctype_toupper'/>
   </abi-instr>
   <abi-instr address-size='64' path='Python/pyhash.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
-    <array-type-def dimensions='1' type-id='type-id-85' size-in-bits='128' id='type-id-1469'>
+    <array-type-def dimensions='1' type-id='type-id-85' size-in-bits='128' id='type-id-1471'>
       <subrange length='16' type-id='type-id-28' id='type-id-57'/>
     </array-type-def>
-    <array-type-def dimensions='1' type-id='type-id-85' size-in-bits='192' id='type-id-1470'>
+    <array-type-def dimensions='1' type-id='type-id-85' size-in-bits='192' id='type-id-1472'>
       <subrange length='24' type-id='type-id-28' id='type-id-683'/>
     </array-type-def>
-    <union-decl name='_Py_HashSecret_t' size-in-bits='192' naming-typedef-id='type-id-1471' visibility='default' filepath='./Include/pyhash.h' line='55' column='1' id='type-id-1472'>
+    <union-decl name='_Py_HashSecret_t' size-in-bits='192' naming-typedef-id='type-id-1473' visibility='default' filepath='./Include/pyhash.h' line='55' column='1' id='type-id-1474'>
       <data-member access='public'>
-        <var-decl name='uc' type-id='type-id-1470' visibility='default' filepath='./Include/pyhash.h' line='57' column='1'/>
+        <var-decl name='uc' type-id='type-id-1472' visibility='default' filepath='./Include/pyhash.h' line='57' column='1'/>
       </data-member>
       <data-member access='public'>
-        <var-decl name='fnv' type-id='type-id-1473' visibility='default' filepath='./Include/pyhash.h' line='62' column='1'/>
+        <var-decl name='fnv' type-id='type-id-1475' visibility='default' filepath='./Include/pyhash.h' line='62' column='1'/>
       </data-member>
       <data-member access='public'>
-        <var-decl name='siphash' type-id='type-id-1474' visibility='default' filepath='./Include/pyhash.h' line='67' column='1'/>
+        <var-decl name='siphash' type-id='type-id-1476' visibility='default' filepath='./Include/pyhash.h' line='67' column='1'/>
       </data-member>
       <data-member access='public'>
-        <var-decl name='djbx33a' type-id='type-id-1475' visibility='default' filepath='./Include/pyhash.h' line='72' column='1'/>
+        <var-decl name='djbx33a' type-id='type-id-1477' visibility='default' filepath='./Include/pyhash.h' line='72' column='1'/>
       </data-member>
       <data-member access='public'>
-        <var-decl name='expat' type-id='type-id-1476' visibility='default' filepath='./Include/pyhash.h' line='76' column='1'/>
+        <var-decl name='expat' type-id='type-id-1478' visibility='default' filepath='./Include/pyhash.h' line='76' column='1'/>
       </data-member>
     </union-decl>
-    <class-decl name='__anonymous_struct__' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' filepath='./Include/pyhash.h' line='59' column='1' id='type-id-1473'>
+    <class-decl name='__anonymous_struct__' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' filepath='./Include/pyhash.h' line='59' column='1' id='type-id-1475'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='prefix' type-id='type-id-305' visibility='default' filepath='./Include/pyhash.h' line='60' column='1'/>
       </data-member>
@@ -24669,7 +24688,7 @@
         <var-decl name='suffix' type-id='type-id-305' visibility='default' filepath='./Include/pyhash.h' line='61' column='1'/>
       </data-member>
     </class-decl>
-    <class-decl name='__anonymous_struct__1' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' filepath='./Include/pyhash.h' line='64' column='1' id='type-id-1474'>
+    <class-decl name='__anonymous_struct__1' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' filepath='./Include/pyhash.h' line='64' column='1' id='type-id-1476'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='k0' type-id='type-id-117' visibility='default' filepath='./Include/pyhash.h' line='65' column='1'/>
       </data-member>
@@ -24677,26 +24696,26 @@
         <var-decl name='k1' type-id='type-id-117' visibility='default' filepath='./Include/pyhash.h' line='66' column='1'/>
       </data-member>
     </class-decl>
-    <class-decl name='__anonymous_struct__2' size-in-bits='192' is-struct='yes' is-anonymous='yes' visibility='default' filepath='./Include/pyhash.h' line='69' column='1' id='type-id-1475'>
+    <class-decl name='__anonymous_struct__2' size-in-bits='192' is-struct='yes' is-anonymous='yes' visibility='default' filepath='./Include/pyhash.h' line='69' column='1' id='type-id-1477'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='padding' type-id='type-id-1469' visibility='default' filepath='./Include/pyhash.h' line='70' column='1'/>
+        <var-decl name='padding' type-id='type-id-1471' visibility='default' filepath='./Include/pyhash.h' line='70' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
         <var-decl name='suffix' type-id='type-id-305' visibility='default' filepath='./Include/pyhash.h' line='71' column='1'/>
       </data-member>
     </class-decl>
-    <class-decl name='__anonymous_struct__3' size-in-bits='192' is-struct='yes' is-anonymous='yes' visibility='default' filepath='./Include/pyhash.h' line='73' column='1' id='type-id-1476'>
+    <class-decl name='__anonymous_struct__3' size-in-bits='192' is-struct='yes' is-anonymous='yes' visibility='default' filepath='./Include/pyhash.h' line='73' column='1' id='type-id-1478'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='padding' type-id='type-id-1469' visibility='default' filepath='./Include/pyhash.h' line='74' column='1'/>
+        <var-decl name='padding' type-id='type-id-1471' visibility='default' filepath='./Include/pyhash.h' line='74' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
         <var-decl name='hashsalt' type-id='type-id-305' visibility='default' filepath='./Include/pyhash.h' line='75' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='_Py_HashSecret_t' type-id='type-id-1472' filepath='./Include/pyhash.h' line='77' column='1' id='type-id-1471'/>
-    <class-decl name='PyHash_FuncDef' size-in-bits='192' is-struct='yes' naming-typedef-id='type-id-1477' visibility='default' filepath='./Include/pyhash.h' line='86' column='1' id='type-id-1478'>
+    <typedef-decl name='_Py_HashSecret_t' type-id='type-id-1474' filepath='./Include/pyhash.h' line='77' column='1' id='type-id-1473'/>
+    <class-decl name='PyHash_FuncDef' size-in-bits='192' is-struct='yes' naming-typedef-id='type-id-1479' visibility='default' filepath='./Include/pyhash.h' line='86' column='1' id='type-id-1480'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='hash' type-id='type-id-1479' visibility='default' filepath='./Include/pyhash.h' line='87' column='1'/>
+        <var-decl name='hash' type-id='type-id-1481' visibility='default' filepath='./Include/pyhash.h' line='87' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
         <var-decl name='name' type-id='type-id-12' visibility='default' filepath='./Include/pyhash.h' line='88' column='1'/>
@@ -24708,22 +24727,22 @@
         <var-decl name='seed_bits' type-id='type-id-261' visibility='default' filepath='./Include/pyhash.h' line='90' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='PyHash_FuncDef' type-id='type-id-1478' filepath='./Include/pyhash.h' line='91' column='1' id='type-id-1477'/>
-    <pointer-type-def type-id='type-id-1477' size-in-bits='64' id='type-id-1480'/>
-    <pointer-type-def type-id='type-id-1481' size-in-bits='64' id='type-id-1482'/>
-    <qualified-type-def type-id='type-id-1482' const='yes' id='type-id-1479'/>
-    <var-decl name='_Py_HashSecret' type-id='type-id-1471' mangled-name='_Py_HashSecret' visibility='default' filepath='./Include/pyhash.h' line='78' column='1' elf-symbol-id='_Py_HashSecret'/>
+    <typedef-decl name='PyHash_FuncDef' type-id='type-id-1480' filepath='./Include/pyhash.h' line='91' column='1' id='type-id-1479'/>
+    <pointer-type-def type-id='type-id-1479' size-in-bits='64' id='type-id-1482'/>
+    <pointer-type-def type-id='type-id-1483' size-in-bits='64' id='type-id-1484'/>
+    <qualified-type-def type-id='type-id-1484' const='yes' id='type-id-1481'/>
+    <var-decl name='_Py_HashSecret' type-id='type-id-1473' mangled-name='_Py_HashSecret' visibility='default' filepath='./Include/pyhash.h' line='78' column='1' elf-symbol-id='_Py_HashSecret'/>
     <function-decl name='PyHash_GetFuncDef' mangled-name='PyHash_GetFuncDef' filepath='Python/pyhash.c' line='221' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyHash_GetFuncDef'>
-      <return type-id='type-id-1480'/>
+      <return type-id='type-id-1482'/>
     </function-decl>
-    <function-type size-in-bits='64' id='type-id-1481'>
+    <function-type size-in-bits='64' id='type-id-1483'>
       <parameter type-id='type-id-22'/>
       <parameter type-id='type-id-14'/>
       <return type-id='type-id-305'/>
     </function-type>
   </abi-instr>
   <abi-instr address-size='64' path='Python/pylifecycle.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
-    <class-decl name='PyInterpreterConfig' size-in-bits='224' is-struct='yes' naming-typedef-id='type-id-1483' visibility='default' filepath='./Include/cpython/pylifecycle.h' line='72' column='1' id='type-id-1484'>
+    <class-decl name='PyInterpreterConfig' size-in-bits='224' is-struct='yes' naming-typedef-id='type-id-1485' visibility='default' filepath='./Include/cpython/pylifecycle.h' line='72' column='1' id='type-id-1486'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='use_main_obmalloc' type-id='type-id-8' visibility='default' filepath='./Include/cpython/pylifecycle.h' line='74' column='1'/>
       </data-member>
@@ -24746,8 +24765,8 @@
         <var-decl name='gil' type-id='type-id-8' visibility='default' filepath='./Include/cpython/pylifecycle.h' line='80' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='PyInterpreterConfig' type-id='type-id-1484' filepath='./Include/cpython/pylifecycle.h' line='81' column='1' id='type-id-1483'/>
-    <class-decl name='_PyPerf_Callbacks' size-in-bits='192' is-struct='yes' naming-typedef-id='type-id-1465' visibility='default' filepath='./Include/internal/pycore_ceval.h' line='63' column='1' id='type-id-1485'>
+    <typedef-decl name='PyInterpreterConfig' type-id='type-id-1486' filepath='./Include/cpython/pylifecycle.h' line='81' column='1' id='type-id-1485'/>
+    <class-decl name='_PyPerf_Callbacks' size-in-bits='192' is-struct='yes' naming-typedef-id='type-id-1467' visibility='default' filepath='./Include/internal/pycore_ceval.h' line='63' column='1' id='type-id-1487'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='init_state' type-id='type-id-827' visibility='default' filepath='./Include/internal/pycore_ceval.h' line='65' column='1'/>
       </data-member>
@@ -24758,38 +24777,38 @@
         <var-decl name='free_state' type-id='type-id-823' visibility='default' filepath='./Include/internal/pycore_ceval.h' line='70' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='_PyPerf_Callbacks' type-id='type-id-1485' filepath='./Include/internal/pycore_ceval.h' line='71' column='1' id='type-id-1465'/>
-    <class-decl name='_PyShimCodeDef' size-in-bits='192' is-struct='yes' visibility='default' filepath='./Include/internal/pycore_code.h' line='453' column='1' id='type-id-1486'>
+    <typedef-decl name='_PyPerf_Callbacks' type-id='type-id-1487' filepath='./Include/internal/pycore_ceval.h' line='71' column='1' id='type-id-1467'/>
+    <class-decl name='_PyShimCodeDef' size-in-bits='192' is-struct='yes' visibility='default' filepath='./Include/internal/pycore_code.h' line='455' column='1' id='type-id-1488'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='code' type-id='type-id-316' visibility='default' filepath='./Include/internal/pycore_code.h' line='454' column='1'/>
+        <var-decl name='code' type-id='type-id-316' visibility='default' filepath='./Include/internal/pycore_code.h' line='456' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='codelen' type-id='type-id-8' visibility='default' filepath='./Include/internal/pycore_code.h' line='455' column='1'/>
+        <var-decl name='codelen' type-id='type-id-8' visibility='default' filepath='./Include/internal/pycore_code.h' line='457' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='96'>
-        <var-decl name='stacksize' type-id='type-id-8' visibility='default' filepath='./Include/internal/pycore_code.h' line='456' column='1'/>
+        <var-decl name='stacksize' type-id='type-id-8' visibility='default' filepath='./Include/internal/pycore_code.h' line='458' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='cname' type-id='type-id-12' visibility='default' filepath='./Include/internal/pycore_code.h' line='457' column='1'/>
+        <var-decl name='cname' type-id='type-id-12' visibility='default' filepath='./Include/internal/pycore_code.h' line='459' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='_PyShimCodeDef' type-id='type-id-1486' filepath='./Include/internal/pycore_code.h' line='458' column='1' id='type-id-1487'/>
-    <typedef-decl name='_PyRuntimeState' type-id='type-id-987' filepath='./Include/internal/pycore_runtime.h' line='187' column='1' id='type-id-1488'/>
-    <typedef-decl name='PyOS_sighandler_t' type-id='type-id-1020' filepath='./Include/pylifecycle.h' line='61' column='1' id='type-id-1489'/>
-    <typedef-decl name='nl_item' type-id='type-id-8' filepath='/usr/include/nl_types.h' line='36' column='1' id='type-id-1490'/>
+    <typedef-decl name='_PyShimCodeDef' type-id='type-id-1488' filepath='./Include/internal/pycore_code.h' line='460' column='1' id='type-id-1489'/>
+    <typedef-decl name='_PyRuntimeState' type-id='type-id-988' filepath='./Include/internal/pycore_runtime.h' line='187' column='1' id='type-id-1490'/>
+    <typedef-decl name='PyOS_sighandler_t' type-id='type-id-1021' filepath='./Include/pylifecycle.h' line='61' column='1' id='type-id-1491'/>
+    <typedef-decl name='nl_item' type-id='type-id-8' filepath='/usr/include/nl_types.h' line='36' column='1' id='type-id-1492'/>
     <typedef-decl name='sigset_t' type-id='type-id-30' filepath='/usr/include/x86_64-linux-gnu/bits/types/sigset_t.h' line='7' column='1' id='type-id-73'/>
-    <pointer-type-def type-id='type-id-177' size-in-bits='64' id='type-id-1491'/>
-    <pointer-type-def type-id='type-id-1465' size-in-bits='64' id='type-id-231'/>
-    <pointer-type-def type-id='type-id-1488' size-in-bits='64' id='type-id-178'/>
-    <qualified-type-def type-id='type-id-1483' const='yes' id='type-id-1492'/>
-    <pointer-type-def type-id='type-id-1492' size-in-bits='64' id='type-id-1493'/>
-    <qualified-type-def type-id='type-id-1487' const='yes' id='type-id-1494'/>
+    <pointer-type-def type-id='type-id-177' size-in-bits='64' id='type-id-1493'/>
+    <pointer-type-def type-id='type-id-1467' size-in-bits='64' id='type-id-231'/>
+    <pointer-type-def type-id='type-id-1490' size-in-bits='64' id='type-id-178'/>
+    <qualified-type-def type-id='type-id-1485' const='yes' id='type-id-1494'/>
     <pointer-type-def type-id='type-id-1494' size-in-bits='64' id='type-id-1495'/>
-    <qualified-type-def type-id='type-id-845' const='yes' id='type-id-1496'/>
+    <qualified-type-def type-id='type-id-1489' const='yes' id='type-id-1496'/>
     <pointer-type-def type-id='type-id-1496' size-in-bits='64' id='type-id-1497'/>
-    <qualified-type-def type-id='type-id-1497' restrict='yes' id='type-id-1498'/>
-    <pointer-type-def type-id='type-id-845' size-in-bits='64' id='type-id-1499'/>
+    <qualified-type-def type-id='type-id-845' const='yes' id='type-id-1498'/>
+    <pointer-type-def type-id='type-id-1498' size-in-bits='64' id='type-id-1499'/>
     <qualified-type-def type-id='type-id-1499' restrict='yes' id='type-id-1500'/>
+    <pointer-type-def type-id='type-id-845' size-in-bits='64' id='type-id-1501'/>
+    <qualified-type-def type-id='type-id-1501' restrict='yes' id='type-id-1502'/>
     <pointer-type-def type-id='type-id-73' size-in-bits='64' id='type-id-45'/>
     <function-decl name='_Py_FinishPendingCalls' filepath='./Include/internal/pycore_ceval.h' line='23' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-177'/>
@@ -24809,22 +24828,25 @@
     <function-decl name='_PyPerfTrampoline_Fini' filepath='./Include/internal/pycore_ceval.h' line='76' column='1' visibility='default' binding='global' size-in-bits='64'>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='_PyEval_InitGIL' filepath='./Include/internal/pycore_ceval.h' line='100' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_PyPerfTrampoline_FreeArenas' filepath='./Include/internal/pycore_ceval.h' line='77' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-46'/>
+    </function-decl>
+    <function-decl name='_PyEval_InitGIL' filepath='./Include/internal/pycore_ceval.h' line='101' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-177'/>
       <parameter type-id='type-id-8'/>
       <return type-id='type-id-54'/>
     </function-decl>
-    <function-decl name='_PyEval_FiniGIL' filepath='./Include/internal/pycore_ceval.h' line='101' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_PyEval_FiniGIL' filepath='./Include/internal/pycore_ceval.h' line='102' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-20'/>
       <return type-id='type-id-46'/>
     </function-decl>
-    <function-decl name='_PyEval_ReleaseLock' filepath='./Include/internal/pycore_ceval.h' line='104' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_PyEval_ReleaseLock' filepath='./Include/internal/pycore_ceval.h' line='105' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-20'/>
       <parameter type-id='type-id-177'/>
       <return type-id='type-id-46'/>
     </function-decl>
-    <function-decl name='_Py_MakeShimCode' filepath='./Include/internal/pycore_code.h' line='461' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-1495'/>
+    <function-decl name='_Py_MakeShimCode' filepath='./Include/internal/pycore_code.h' line='463' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-1497'/>
       <return type-id='type-id-328'/>
     </function-decl>
     <function-decl name='_PyContext_Init' filepath='./Include/internal/pycore_context.h' line='15' column='1' visibility='default' binding='global' size-in-bits='64'>
@@ -24934,17 +24956,17 @@
       <return type-id='type-id-46'/>
     </function-decl>
     <function-decl name='_PyPreConfig_InitFromConfig' filepath='./Include/internal/pycore_initconfig.h' line='126' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-1433'/>
+      <parameter type-id='type-id-1435'/>
       <parameter type-id='type-id-260'/>
       <return type-id='type-id-46'/>
     </function-decl>
     <function-decl name='_PyPreConfig_Read' filepath='./Include/internal/pycore_initconfig.h' line='135' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-1433'/>
-      <parameter type-id='type-id-1440'/>
+      <parameter type-id='type-id-1435'/>
+      <parameter type-id='type-id-1442'/>
       <return type-id='type-id-54'/>
     </function-decl>
     <function-decl name='_PyPreConfig_Write' filepath='./Include/internal/pycore_initconfig.h' line='137' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-1437'/>
+      <parameter type-id='type-id-1439'/>
       <return type-id='type-id-54'/>
     </function-decl>
     <function-decl name='_PyConfig_Copy' filepath='./Include/internal/pycore_initconfig.h' line='150' column='1' visibility='default' binding='global' size-in-bits='64'>
@@ -24966,7 +24988,7 @@
       <parameter type-id='type-id-940'/>
       <return type-id='type-id-54'/>
     </function-decl>
-    <function-decl name='_PyInterpreterState_Clear' filepath='./Include/internal/pycore_interp.h' line='238' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_PyInterpreterState_Clear' filepath='./Include/internal/pycore_interp.h' line='248' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-177'/>
       <return type-id='type-id-46'/>
     </function-decl>
@@ -24981,6 +25003,10 @@
     <function-decl name='_PyLong_FiniTypes' filepath='./Include/internal/pycore_long.h' line='53' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-20'/>
       <return type-id='type-id-46'/>
+    </function-decl>
+    <function-decl name='_PyMem_init_obmalloc' filepath='./Include/internal/pycore_obmalloc.h' line='689' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-20'/>
+      <return type-id='type-id-8'/>
     </function-decl>
     <function-decl name='_PyPathConfig_UpdateGlobal' filepath='./Include/internal/pycore_pathconfig.h' line='13' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-260'/>
@@ -25167,7 +25193,7 @@
       <parameter type-id='type-id-178'/>
       <return type-id='type-id-54'/>
     </function-decl>
-    <var-decl name='_PyRuntime' type-id='type-id-1488' mangled-name='_PyRuntime' visibility='default' filepath='./Include/internal/pycore_runtime.h' line='192' column='1' elf-symbol-id='_PyRuntime'/>
+    <var-decl name='_PyRuntime' type-id='type-id-1490' mangled-name='_PyRuntime' visibility='default' filepath='./Include/internal/pycore_runtime.h' line='192' column='1' elf-symbol-id='_PyRuntime'/>
     <function-decl name='_PyRuntimeState_Init' mangled-name='_PyRuntimeState_Init' filepath='./Include/internal/pycore_runtime.h' line='194' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyRuntimeState_Init'>
       <parameter type-id='type-id-178'/>
       <return type-id='type-id-54'/>
@@ -25259,7 +25285,7 @@
       <parameter type-id='type-id-20'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='_PyModule_IsExtension' filepath='./Include/moduleobject.h' line='111' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_PyModule_IsExtension' filepath='./Include/moduleobject.h' line='113' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-2'/>
       <return type-id='type-id-8'/>
     </function-decl>
@@ -25307,15 +25333,12 @@
       <parameter type-id='type-id-2'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='PyUnstable_PerfMapState_Fini' mangled-name='PyUnstable_PerfMapState_Fini' filepath='./Include/sysmodule.h' line='42' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyUnstable_PerfMapState_Fini'>
-      <return type-id='type-id-46'/>
-    </function-decl>
     <function-decl name='_PyTraceMalloc_Start' mangled-name='_PyTraceMalloc_Start' filepath='./Include/tracemalloc.h' line='53' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyTraceMalloc_Start'>
       <parameter type-id='type-id-8'/>
       <return type-id='type-id-8'/>
     </function-decl>
     <function-decl name='nl_langinfo' filepath='/usr/include/langinfo.h' line='661' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-1490'/>
+      <parameter type-id='type-id-1492'/>
       <return type-id='type-id-15'/>
     </function-decl>
     <function-decl name='sigemptyset' filepath='/usr/include/signal.h' line='199' column='1' visibility='default' binding='global' size-in-bits='64'>
@@ -25324,8 +25347,8 @@
     </function-decl>
     <function-decl name='sigaction' filepath='/usr/include/signal.h' line='243' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-8'/>
-      <parameter type-id='type-id-1498'/>
       <parameter type-id='type-id-1500'/>
+      <parameter type-id='type-id-1502'/>
       <return type-id='type-id-8'/>
     </function-decl>
     <function-decl name='vfprintf' filepath='/usr/include/stdio.h' line='365' column='1' visibility='default' binding='global' size-in-bits='64'>
@@ -25347,126 +25370,126 @@
       <parameter type-id='type-id-8'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='_PyRuntime_Finalize' mangled-name='_PyRuntime_Finalize' filepath='Python/pylifecycle.c' line='121' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyRuntime_Finalize'>
+    <function-decl name='_PyRuntime_Finalize' mangled-name='_PyRuntime_Finalize' filepath='Python/pylifecycle.c' line='122' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyRuntime_Finalize'>
       <return type-id='type-id-46'/>
     </function-decl>
-    <function-decl name='_Py_IsFinalizing' mangled-name='_Py_IsFinalizing' filepath='Python/pylifecycle.c' line='128' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_IsFinalizing'>
+    <function-decl name='_Py_IsFinalizing' mangled-name='_Py_IsFinalizing' filepath='Python/pylifecycle.c' line='129' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_IsFinalizing'>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='_Py_IsCoreInitialized' mangled-name='_Py_IsCoreInitialized' filepath='Python/pylifecycle.c' line='144' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_IsCoreInitialized'>
+    <function-decl name='_Py_IsCoreInitialized' mangled-name='_Py_IsCoreInitialized' filepath='Python/pylifecycle.c' line='145' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_IsCoreInitialized'>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='_PyInterpreterState_SetConfig' mangled-name='_PyInterpreterState_SetConfig' filepath='Python/pylifecycle.c' line='414' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyInterpreterState_SetConfig'>
-      <parameter type-id='type-id-260' name='src_config' filepath='Python/pylifecycle.c' line='414' column='1'/>
+    <function-decl name='_PyInterpreterState_SetConfig' mangled-name='_PyInterpreterState_SetConfig' filepath='Python/pylifecycle.c' line='415' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyInterpreterState_SetConfig'>
+      <parameter type-id='type-id-260' name='src_config' filepath='Python/pylifecycle.c' line='415' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='_Py_PreInitializeFromPyArgv' mangled-name='_Py_PreInitializeFromPyArgv' filepath='Python/pylifecycle.c' line='909' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_PreInitializeFromPyArgv'>
-      <parameter type-id='type-id-1437' name='src_config' filepath='Python/pylifecycle.c' line='909' column='1'/>
-      <parameter type-id='type-id-1440' name='args' filepath='Python/pylifecycle.c' line='909' column='1'/>
+    <function-decl name='_Py_PreInitializeFromPyArgv' mangled-name='_Py_PreInitializeFromPyArgv' filepath='Python/pylifecycle.c' line='917' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_PreInitializeFromPyArgv'>
+      <parameter type-id='type-id-1439' name='src_config' filepath='Python/pylifecycle.c' line='917' column='1'/>
+      <parameter type-id='type-id-1442' name='args' filepath='Python/pylifecycle.c' line='917' column='1'/>
       <return type-id='type-id-54'/>
     </function-decl>
-    <function-decl name='Py_PreInitializeFromBytesArgs' mangled-name='Py_PreInitializeFromBytesArgs' filepath='Python/pylifecycle.c' line='956' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='Py_PreInitializeFromBytesArgs'>
-      <parameter type-id='type-id-1437' name='src_config' filepath='Python/pylifecycle.c' line='956' column='1'/>
-      <parameter type-id='type-id-14' name='argc' filepath='Python/pylifecycle.c' line='956' column='1'/>
-      <parameter type-id='type-id-239' name='argv' filepath='Python/pylifecycle.c' line='956' column='1'/>
-      <return type-id='type-id-54'/>
-    </function-decl>
-    <function-decl name='Py_PreInitializeFromArgs' mangled-name='Py_PreInitializeFromArgs' filepath='Python/pylifecycle.c' line='964' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='Py_PreInitializeFromArgs'>
-      <parameter type-id='type-id-1437' name='src_config' filepath='Python/pylifecycle.c' line='964' column='1'/>
+    <function-decl name='Py_PreInitializeFromBytesArgs' mangled-name='Py_PreInitializeFromBytesArgs' filepath='Python/pylifecycle.c' line='964' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='Py_PreInitializeFromBytesArgs'>
+      <parameter type-id='type-id-1439' name='src_config' filepath='Python/pylifecycle.c' line='964' column='1'/>
       <parameter type-id='type-id-14' name='argc' filepath='Python/pylifecycle.c' line='964' column='1'/>
-      <parameter type-id='type-id-235' name='argv' filepath='Python/pylifecycle.c' line='964' column='1'/>
+      <parameter type-id='type-id-239' name='argv' filepath='Python/pylifecycle.c' line='964' column='1'/>
       <return type-id='type-id-54'/>
     </function-decl>
-    <function-decl name='Py_PreInitialize' mangled-name='Py_PreInitialize' filepath='Python/pylifecycle.c' line='972' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='Py_PreInitialize'>
-      <parameter type-id='type-id-1437' name='src_config' filepath='Python/pylifecycle.c' line='972' column='1'/>
+    <function-decl name='Py_PreInitializeFromArgs' mangled-name='Py_PreInitializeFromArgs' filepath='Python/pylifecycle.c' line='972' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='Py_PreInitializeFromArgs'>
+      <parameter type-id='type-id-1439' name='src_config' filepath='Python/pylifecycle.c' line='972' column='1'/>
+      <parameter type-id='type-id-14' name='argc' filepath='Python/pylifecycle.c' line='972' column='1'/>
+      <parameter type-id='type-id-235' name='argv' filepath='Python/pylifecycle.c' line='972' column='1'/>
       <return type-id='type-id-54'/>
     </function-decl>
-    <function-decl name='Py_InitializeEx' mangled-name='Py_InitializeEx' filepath='Python/pylifecycle.c' line='1300' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='Py_InitializeEx'>
-      <parameter type-id='type-id-8' name='install_sigs' filepath='Python/pylifecycle.c' line='1300' column='1'/>
+    <function-decl name='Py_PreInitialize' mangled-name='Py_PreInitialize' filepath='Python/pylifecycle.c' line='980' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='Py_PreInitialize'>
+      <parameter type-id='type-id-1439' name='src_config' filepath='Python/pylifecycle.c' line='980' column='1'/>
+      <return type-id='type-id-54'/>
+    </function-decl>
+    <function-decl name='Py_InitializeEx' mangled-name='Py_InitializeEx' filepath='Python/pylifecycle.c' line='1308' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='Py_InitializeEx'>
+      <parameter type-id='type-id-8' name='install_sigs' filepath='Python/pylifecycle.c' line='1308' column='1'/>
       <return type-id='type-id-46'/>
     </function-decl>
-    <function-decl name='Py_Initialize' mangled-name='Py_Initialize' filepath='Python/pylifecycle.c' line='1328' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='Py_Initialize'>
+    <function-decl name='Py_Initialize' mangled-name='Py_Initialize' filepath='Python/pylifecycle.c' line='1336' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='Py_Initialize'>
       <return type-id='type-id-46'/>
     </function-decl>
-    <function-decl name='_Py_InitializeMain' mangled-name='_Py_InitializeMain' filepath='Python/pylifecycle.c' line='1335' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_InitializeMain'>
+    <function-decl name='_Py_InitializeMain' mangled-name='_Py_InitializeMain' filepath='Python/pylifecycle.c' line='1343' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_InitializeMain'>
       <return type-id='type-id-54'/>
     </function-decl>
-    <function-decl name='Py_Finalize' mangled-name='Py_Finalize' filepath='Python/pylifecycle.c' line='2010' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='Py_Finalize'>
+    <function-decl name='Py_Finalize' mangled-name='Py_Finalize' filepath='Python/pylifecycle.c' line='2018' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='Py_Finalize'>
       <return type-id='type-id-46'/>
     </function-decl>
-    <function-decl name='Py_NewInterpreterFromConfig' mangled-name='Py_NewInterpreterFromConfig' filepath='Python/pylifecycle.c' line='2137' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='Py_NewInterpreterFromConfig'>
-      <parameter type-id='type-id-1491' name='tstate_p' filepath='Python/pylifecycle.c' line='2137' column='1'/>
-      <parameter type-id='type-id-1493' name='config' filepath='Python/pylifecycle.c' line='2138' column='1'/>
+    <function-decl name='Py_NewInterpreterFromConfig' mangled-name='Py_NewInterpreterFromConfig' filepath='Python/pylifecycle.c' line='2153' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='Py_NewInterpreterFromConfig'>
+      <parameter type-id='type-id-1493' name='tstate_p' filepath='Python/pylifecycle.c' line='2153' column='1'/>
+      <parameter type-id='type-id-1495' name='config' filepath='Python/pylifecycle.c' line='2154' column='1'/>
       <return type-id='type-id-54'/>
     </function-decl>
-    <function-decl name='Py_NewInterpreter' mangled-name='Py_NewInterpreter' filepath='Python/pylifecycle.c' line='2144' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='Py_NewInterpreter'>
+    <function-decl name='Py_NewInterpreter' mangled-name='Py_NewInterpreter' filepath='Python/pylifecycle.c' line='2160' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='Py_NewInterpreter'>
       <return type-id='type-id-177'/>
     </function-decl>
-    <function-decl name='Py_EndInterpreter' mangled-name='Py_EndInterpreter' filepath='Python/pylifecycle.c' line='2168' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='Py_EndInterpreter'>
-      <parameter type-id='type-id-177' name='tstate' filepath='Python/pylifecycle.c' line='2168' column='1'/>
+    <function-decl name='Py_EndInterpreter' mangled-name='Py_EndInterpreter' filepath='Python/pylifecycle.c' line='2184' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='Py_EndInterpreter'>
+      <parameter type-id='type-id-177' name='tstate' filepath='Python/pylifecycle.c' line='2184' column='1'/>
       <return type-id='type-id-46'/>
     </function-decl>
-    <function-decl name='_Py_DumpExtensionModules' mangled-name='_Py_DumpExtensionModules' filepath='Python/pylifecycle.c' line='2750' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_DumpExtensionModules'>
-      <parameter type-id='type-id-8' name='fd' filepath='Python/pylifecycle.c' line='2750' column='1'/>
-      <parameter type-id='type-id-20' name='interp' filepath='Python/pylifecycle.c' line='2750' column='1'/>
+    <function-decl name='_Py_DumpExtensionModules' mangled-name='_Py_DumpExtensionModules' filepath='Python/pylifecycle.c' line='2766' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_DumpExtensionModules'>
+      <parameter type-id='type-id-8' name='fd' filepath='Python/pylifecycle.c' line='2766' column='1'/>
+      <parameter type-id='type-id-20' name='interp' filepath='Python/pylifecycle.c' line='2766' column='1'/>
       <return type-id='type-id-46'/>
     </function-decl>
-    <function-decl name='Py_FatalError' mangled-name='Py_FatalError' filepath='Python/pylifecycle.c' line='2923' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='Py_FatalError'>
-      <parameter type-id='type-id-12' name='msg' filepath='Python/pylifecycle.c' line='2923' column='1'/>
+    <function-decl name='Py_FatalError' mangled-name='Py_FatalError' filepath='Python/pylifecycle.c' line='2939' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='Py_FatalError'>
+      <parameter type-id='type-id-12' name='msg' filepath='Python/pylifecycle.c' line='2939' column='1'/>
       <return type-id='type-id-46'/>
     </function-decl>
-    <function-decl name='_Py_FatalRefcountErrorFunc' mangled-name='_Py_FatalRefcountErrorFunc' filepath='Python/pylifecycle.c' line='2967' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_FatalRefcountErrorFunc'>
-      <parameter type-id='type-id-12' name='func' filepath='Python/pylifecycle.c' line='2967' column='1'/>
-      <parameter type-id='type-id-12' name='msg' filepath='Python/pylifecycle.c' line='2967' column='1'/>
+    <function-decl name='_Py_FatalRefcountErrorFunc' mangled-name='_Py_FatalRefcountErrorFunc' filepath='Python/pylifecycle.c' line='2983' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_FatalRefcountErrorFunc'>
+      <parameter type-id='type-id-12' name='func' filepath='Python/pylifecycle.c' line='2983' column='1'/>
+      <parameter type-id='type-id-12' name='msg' filepath='Python/pylifecycle.c' line='2983' column='1'/>
       <return type-id='type-id-46'/>
     </function-decl>
-    <function-decl name='Py_AtExit' mangled-name='Py_AtExit' filepath='Python/pylifecycle.c' line='3017' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='Py_AtExit'>
-      <parameter type-id='type-id-227' name='func' filepath='Python/pylifecycle.c' line='3017' column='1'/>
+    <function-decl name='Py_AtExit' mangled-name='Py_AtExit' filepath='Python/pylifecycle.c' line='3033' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='Py_AtExit'>
+      <parameter type-id='type-id-227' name='func' filepath='Python/pylifecycle.c' line='3033' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='Py_Exit' mangled-name='Py_Exit' filepath='Python/pylifecycle.c' line='3054' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='Py_Exit'>
-      <parameter type-id='type-id-8' name='sts' filepath='Python/pylifecycle.c' line='3054' column='1'/>
+    <function-decl name='Py_Exit' mangled-name='Py_Exit' filepath='Python/pylifecycle.c' line='3070' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='Py_Exit'>
+      <parameter type-id='type-id-8' name='sts' filepath='Python/pylifecycle.c' line='3070' column='1'/>
       <return type-id='type-id-46'/>
     </function-decl>
-    <function-decl name='Py_FdIsInteractive' mangled-name='Py_FdIsInteractive' filepath='Python/pylifecycle.c' line='3071' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='Py_FdIsInteractive'>
-      <parameter type-id='type-id-229' name='fp' filepath='Python/pylifecycle.c' line='3071' column='1'/>
-      <parameter type-id='type-id-12' name='filename' filepath='Python/pylifecycle.c' line='3071' column='1'/>
+    <function-decl name='Py_FdIsInteractive' mangled-name='Py_FdIsInteractive' filepath='Python/pylifecycle.c' line='3087' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='Py_FdIsInteractive'>
+      <parameter type-id='type-id-229' name='fp' filepath='Python/pylifecycle.c' line='3087' column='1'/>
+      <parameter type-id='type-id-12' name='filename' filepath='Python/pylifecycle.c' line='3087' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='_Py_FdIsInteractive' mangled-name='_Py_FdIsInteractive' filepath='Python/pylifecycle.c' line='3086' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_FdIsInteractive'>
-      <parameter type-id='type-id-229' name='fp' filepath='Python/pylifecycle.c' line='3086' column='1'/>
-      <parameter type-id='type-id-2' name='filename' filepath='Python/pylifecycle.c' line='3086' column='1'/>
+    <function-decl name='_Py_FdIsInteractive' mangled-name='_Py_FdIsInteractive' filepath='Python/pylifecycle.c' line='3102' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_FdIsInteractive'>
+      <parameter type-id='type-id-229' name='fp' filepath='Python/pylifecycle.c' line='3102' column='1'/>
+      <parameter type-id='type-id-2' name='filename' filepath='Python/pylifecycle.c' line='3102' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='PyOS_getsig' mangled-name='PyOS_getsig' filepath='Python/pylifecycle.c' line='3103' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyOS_getsig'>
-      <parameter type-id='type-id-8' name='sig' filepath='Python/pylifecycle.c' line='3103' column='1'/>
-      <return type-id='type-id-1489'/>
+    <function-decl name='PyOS_getsig' mangled-name='PyOS_getsig' filepath='Python/pylifecycle.c' line='3119' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyOS_getsig'>
+      <parameter type-id='type-id-8' name='sig' filepath='Python/pylifecycle.c' line='3119' column='1'/>
+      <return type-id='type-id-1491'/>
     </function-decl>
-    <function-decl name='PyOS_setsig' mangled-name='PyOS_setsig' filepath='Python/pylifecycle.c' line='3142' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyOS_setsig'>
-      <parameter type-id='type-id-8' name='sig' filepath='Python/pylifecycle.c' line='3142' column='1'/>
-      <parameter type-id='type-id-1489' name='handler' filepath='Python/pylifecycle.c' line='3142' column='1'/>
-      <return type-id='type-id-1489'/>
+    <function-decl name='PyOS_setsig' mangled-name='PyOS_setsig' filepath='Python/pylifecycle.c' line='3158' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyOS_setsig'>
+      <parameter type-id='type-id-8' name='sig' filepath='Python/pylifecycle.c' line='3158' column='1'/>
+      <parameter type-id='type-id-1491' name='handler' filepath='Python/pylifecycle.c' line='3158' column='1'/>
+      <return type-id='type-id-1491'/>
     </function-decl>
   </abi-instr>
   <abi-instr address-size='64' path='Python/pystate.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
-    <pointer-type-def type-id='type-id-832' size-in-bits='64' id='type-id-1501'/>
-    <pointer-type-def type-id='type-id-863' size-in-bits='64' id='type-id-1502'/>
-    <qualified-type-def type-id='type-id-19' const='yes' id='type-id-1503'/>
+    <pointer-type-def type-id='type-id-832' size-in-bits='64' id='type-id-1503'/>
+    <pointer-type-def type-id='type-id-863' size-in-bits='64' id='type-id-1504'/>
+    <qualified-type-def type-id='type-id-19' const='yes' id='type-id-1505'/>
     <function-decl name='_PyEval_InitState' filepath='./Include/internal/pycore_ceval.h' line='24' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-20'/>
       <parameter type-id='type-id-810'/>
       <return type-id='type-id-46'/>
     </function-decl>
     <function-decl name='_PyEval_FiniState' filepath='./Include/internal/pycore_ceval.h' line='25' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-1501'/>
+      <parameter type-id='type-id-1503'/>
       <return type-id='type-id-46'/>
     </function-decl>
-    <function-decl name='_PyEval_AcquireLock' filepath='./Include/internal/pycore_ceval.h' line='103' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_PyEval_AcquireLock' filepath='./Include/internal/pycore_ceval.h' line='104' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-177'/>
       <return type-id='type-id-46'/>
     </function-decl>
     <function-decl name='_PyGC_InitState' filepath='./Include/internal/pycore_gc.h' line='193' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-1502'/>
+      <parameter type-id='type-id-1504'/>
       <return type-id='type-id-46'/>
     </function-decl>
     <function-decl name='_PyImport_ClearCore' filepath='./Include/internal/pycore_import.h' line='108' column='1' visibility='default' binding='global' size-in-bits='64'>
@@ -25481,18 +25504,22 @@
       <parameter type-id='type-id-20'/>
       <return type-id='type-id-46'/>
     </function-decl>
-    <function-decl name='_PyObject_VirtualAlloc' filepath='./Include/internal/pycore_obmalloc.h' line='677' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_PyObject_VirtualAlloc' filepath='./Include/internal/pycore_obmalloc.h' line='679' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-19'/>
       <return type-id='type-id-22'/>
     </function-decl>
-    <function-decl name='_PyObject_VirtualFree' filepath='./Include/internal/pycore_obmalloc.h' line='678' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_PyObject_VirtualFree' filepath='./Include/internal/pycore_obmalloc.h' line='680' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-22'/>
       <parameter type-id='type-id-19'/>
       <return type-id='type-id-46'/>
     </function-decl>
-    <function-decl name='_PyInterpreterState_FinalizeAllocatedBlocks' filepath='./Include/internal/pycore_obmalloc.h' line='686' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_PyInterpreterState_FinalizeAllocatedBlocks' filepath='./Include/internal/pycore_obmalloc.h' line='688' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-20'/>
       <return type-id='type-id-46'/>
+    </function-decl>
+    <function-decl name='_PyMem_obmalloc_state_on_heap' filepath='./Include/internal/pycore_obmalloc.h' line='690' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-20'/>
+      <return type-id='type-id-624'/>
     </function-decl>
     <function-decl name='_PyGC_Fini' filepath='./Include/internal/pycore_pylifecycle.h' line='55' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-20'/>
@@ -25522,161 +25549,161 @@
       <parameter type-id='type-id-409'/>
       <return type-id='type-id-46'/>
     </function-decl>
-    <function-decl name='_PyThreadState_GetCurrent' mangled-name='_PyThreadState_GetCurrent' filepath='Python/pystate.c' line='108' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyThreadState_GetCurrent'>
+    <function-decl name='_PyThreadState_GetCurrent' mangled-name='_PyThreadState_GetCurrent' filepath='Python/pystate.c' line='109' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyThreadState_GetCurrent'>
       <return type-id='type-id-177'/>
     </function-decl>
-    <function-decl name='PyInterpreterState_Clear' mangled-name='PyInterpreterState_Clear' filepath='Python/pystate.c' line='942' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyInterpreterState_Clear'>
-      <parameter type-id='type-id-20' name='interp' filepath='Python/pystate.c' line='942' column='1'/>
+    <function-decl name='PyInterpreterState_Clear' mangled-name='PyInterpreterState_Clear' filepath='Python/pystate.c' line='941' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyInterpreterState_Clear'>
+      <parameter type-id='type-id-20' name='interp' filepath='Python/pystate.c' line='941' column='1'/>
       <return type-id='type-id-46'/>
     </function-decl>
-    <function-decl name='_PyInterpreterState_SetRunningMain' mangled-name='_PyInterpreterState_SetRunningMain' filepath='Python/pystate.c' line='1070' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyInterpreterState_SetRunningMain'>
-      <parameter type-id='type-id-20' name='interp' filepath='Python/pystate.c' line='1070' column='1'/>
+    <function-decl name='_PyInterpreterState_SetRunningMain' mangled-name='_PyInterpreterState_SetRunningMain' filepath='Python/pystate.c' line='1069' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyInterpreterState_SetRunningMain'>
+      <parameter type-id='type-id-20' name='interp' filepath='Python/pystate.c' line='1069' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='_PyInterpreterState_SetNotRunningMain' mangled-name='_PyInterpreterState_SetNotRunningMain' filepath='Python/pystate.c' line='1089' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyInterpreterState_SetNotRunningMain'>
-      <parameter type-id='type-id-20' name='interp' filepath='Python/pystate.c' line='1089' column='1'/>
+    <function-decl name='_PyInterpreterState_SetNotRunningMain' mangled-name='_PyInterpreterState_SetNotRunningMain' filepath='Python/pystate.c' line='1088' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyInterpreterState_SetNotRunningMain'>
+      <parameter type-id='type-id-20' name='interp' filepath='Python/pystate.c' line='1088' column='1'/>
       <return type-id='type-id-46'/>
     </function-decl>
-    <function-decl name='_PyInterpreterState_IsRunningMain' mangled-name='_PyInterpreterState_IsRunningMain' filepath='Python/pystate.c' line='1096' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyInterpreterState_IsRunningMain'>
-      <parameter type-id='type-id-20' name='interp' filepath='Python/pystate.c' line='1096' column='1'/>
+    <function-decl name='_PyInterpreterState_IsRunningMain' mangled-name='_PyInterpreterState_IsRunningMain' filepath='Python/pystate.c' line='1095' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyInterpreterState_IsRunningMain'>
+      <parameter type-id='type-id-20' name='interp' filepath='Python/pystate.c' line='1095' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='_PyInterpreterState_RequiresIDRef' mangled-name='_PyInterpreterState_RequiresIDRef' filepath='Python/pystate.c' line='1171' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyInterpreterState_RequiresIDRef'>
-      <parameter type-id='type-id-20' name='interp' filepath='Python/pystate.c' line='1171' column='1'/>
+    <function-decl name='_PyInterpreterState_RequiresIDRef' mangled-name='_PyInterpreterState_RequiresIDRef' filepath='Python/pystate.c' line='1170' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyInterpreterState_RequiresIDRef'>
+      <parameter type-id='type-id-20' name='interp' filepath='Python/pystate.c' line='1170' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='_PyInterpreterState_RequireIDRef' mangled-name='_PyInterpreterState_RequireIDRef' filepath='Python/pystate.c' line='1177' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyInterpreterState_RequireIDRef'>
-      <parameter type-id='type-id-20' name='interp' filepath='Python/pystate.c' line='1177' column='1'/>
-      <parameter type-id='type-id-8' name='required' filepath='Python/pystate.c' line='1177' column='1'/>
+    <function-decl name='_PyInterpreterState_RequireIDRef' mangled-name='_PyInterpreterState_RequireIDRef' filepath='Python/pystate.c' line='1176' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyInterpreterState_RequireIDRef'>
+      <parameter type-id='type-id-20' name='interp' filepath='Python/pystate.c' line='1176' column='1'/>
+      <parameter type-id='type-id-8' name='required' filepath='Python/pystate.c' line='1176' column='1'/>
       <return type-id='type-id-46'/>
     </function-decl>
-    <function-decl name='_PyInterpreterState_GetMainModule' mangled-name='_PyInterpreterState_GetMainModule' filepath='Python/pystate.c' line='1183' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyInterpreterState_GetMainModule'>
-      <parameter type-id='type-id-20' name='interp' filepath='Python/pystate.c' line='1183' column='1'/>
+    <function-decl name='_PyInterpreterState_GetMainModule' mangled-name='_PyInterpreterState_GetMainModule' filepath='Python/pystate.c' line='1182' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyInterpreterState_GetMainModule'>
+      <parameter type-id='type-id-20' name='interp' filepath='Python/pystate.c' line='1182' column='1'/>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='PyInterpreterState_GetDict' mangled-name='PyInterpreterState_GetDict' filepath='Python/pystate.c' line='1194' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyInterpreterState_GetDict'>
-      <parameter type-id='type-id-20' name='interp' filepath='Python/pystate.c' line='1194' column='1'/>
+    <function-decl name='PyInterpreterState_GetDict' mangled-name='PyInterpreterState_GetDict' filepath='Python/pystate.c' line='1193' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyInterpreterState_GetDict'>
+      <parameter type-id='type-id-20' name='interp' filepath='Python/pystate.c' line='1193' column='1'/>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='PyThreadState_New' mangled-name='PyThreadState_New' filepath='Python/pystate.c' line='1436' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyThreadState_New'>
-      <parameter type-id='type-id-20' name='interp' filepath='Python/pystate.c' line='1436' column='1'/>
+    <function-decl name='PyThreadState_New' mangled-name='PyThreadState_New' filepath='Python/pystate.c' line='1435' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyThreadState_New'>
+      <parameter type-id='type-id-20' name='interp' filepath='Python/pystate.c' line='1435' column='1'/>
       <return type-id='type-id-177'/>
     </function-decl>
-    <function-decl name='_PyThreadState_Prealloc' mangled-name='_PyThreadState_Prealloc' filepath='Python/pystate.c' line='1459' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyThreadState_Prealloc'>
-      <parameter type-id='type-id-20' name='interp' filepath='Python/pystate.c' line='1459' column='1'/>
+    <function-decl name='_PyThreadState_Prealloc' mangled-name='_PyThreadState_Prealloc' filepath='Python/pystate.c' line='1458' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyThreadState_Prealloc'>
+      <parameter type-id='type-id-20' name='interp' filepath='Python/pystate.c' line='1458' column='1'/>
       <return type-id='type-id-177'/>
     </function-decl>
-    <function-decl name='_PyThreadState_Init' mangled-name='_PyThreadState_Init' filepath='Python/pystate.c' line='1467' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyThreadState_Init'>
-      <parameter type-id='type-id-177' name='tstate' filepath='Python/pystate.c' line='1467' column='1'/>
+    <function-decl name='_PyThreadState_Init' mangled-name='_PyThreadState_Init' filepath='Python/pystate.c' line='1466' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyThreadState_Init'>
+      <parameter type-id='type-id-177' name='tstate' filepath='Python/pystate.c' line='1466' column='1'/>
       <return type-id='type-id-46'/>
     </function-decl>
-    <function-decl name='_PyThreadState_DeleteCurrent' mangled-name='_PyThreadState_DeleteCurrent' filepath='Python/pystate.c' line='1629' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyThreadState_DeleteCurrent'>
-      <parameter type-id='type-id-177' name='tstate' filepath='Python/pystate.c' line='1629' column='1'/>
+    <function-decl name='_PyThreadState_DeleteCurrent' mangled-name='_PyThreadState_DeleteCurrent' filepath='Python/pystate.c' line='1628' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyThreadState_DeleteCurrent'>
+      <parameter type-id='type-id-177' name='tstate' filepath='Python/pystate.c' line='1628' column='1'/>
       <return type-id='type-id-46'/>
     </function-decl>
-    <function-decl name='PyThreadState_DeleteCurrent' mangled-name='PyThreadState_DeleteCurrent' filepath='Python/pystate.c' line='1639' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyThreadState_DeleteCurrent'>
+    <function-decl name='PyThreadState_DeleteCurrent' mangled-name='PyThreadState_DeleteCurrent' filepath='Python/pystate.c' line='1638' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyThreadState_DeleteCurrent'>
       <return type-id='type-id-46'/>
     </function-decl>
-    <function-decl name='_PyThreadState_GetDict' mangled-name='_PyThreadState_GetDict' filepath='Python/pystate.c' line='1701' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyThreadState_GetDict'>
-      <parameter type-id='type-id-177' name='tstate' filepath='Python/pystate.c' line='1701' column='1'/>
+    <function-decl name='_PyThreadState_GetDict' mangled-name='_PyThreadState_GetDict' filepath='Python/pystate.c' line='1700' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyThreadState_GetDict'>
+      <parameter type-id='type-id-177' name='tstate' filepath='Python/pystate.c' line='1700' column='1'/>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='PyThreadState_GetInterpreter' mangled-name='PyThreadState_GetInterpreter' filepath='Python/pystate.c' line='1726' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyThreadState_GetInterpreter'>
-      <parameter type-id='type-id-177' name='tstate' filepath='Python/pystate.c' line='1726' column='1'/>
+    <function-decl name='PyThreadState_GetInterpreter' mangled-name='PyThreadState_GetInterpreter' filepath='Python/pystate.c' line='1725' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyThreadState_GetInterpreter'>
+      <parameter type-id='type-id-177' name='tstate' filepath='Python/pystate.c' line='1725' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
-    <function-decl name='PyThreadState_GetID' mangled-name='PyThreadState_GetID' filepath='Python/pystate.c' line='1750' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyThreadState_GetID'>
-      <parameter type-id='type-id-177' name='tstate' filepath='Python/pystate.c' line='1750' column='1'/>
+    <function-decl name='PyThreadState_GetID' mangled-name='PyThreadState_GetID' filepath='Python/pystate.c' line='1749' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyThreadState_GetID'>
+      <parameter type-id='type-id-177' name='tstate' filepath='Python/pystate.c' line='1749' column='1'/>
       <return type-id='type-id-117'/>
     </function-decl>
-    <function-decl name='PyThreadState_SetAsyncExc' mangled-name='PyThreadState_SetAsyncExc' filepath='Python/pystate.c' line='1804' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyThreadState_SetAsyncExc'>
-      <parameter type-id='type-id-28' name='id' filepath='Python/pystate.c' line='1804' column='1'/>
-      <parameter type-id='type-id-2' name='exc' filepath='Python/pystate.c' line='1804' column='1'/>
+    <function-decl name='PyThreadState_SetAsyncExc' mangled-name='PyThreadState_SetAsyncExc' filepath='Python/pystate.c' line='1803' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyThreadState_SetAsyncExc'>
+      <parameter type-id='type-id-28' name='id' filepath='Python/pystate.c' line='1803' column='1'/>
+      <parameter type-id='type-id-2' name='exc' filepath='Python/pystate.c' line='1803' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='_PyThreadState_Swap' mangled-name='_PyThreadState_Swap' filepath='Python/pystate.c' line='1901' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyThreadState_Swap'>
-      <parameter type-id='type-id-178' name='runtime' filepath='Python/pystate.c' line='1901' column='1'/>
-      <parameter type-id='type-id-177' name='newts' filepath='Python/pystate.c' line='1901' column='1'/>
+    <function-decl name='_PyThreadState_Swap' mangled-name='_PyThreadState_Swap' filepath='Python/pystate.c' line='1900' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyThreadState_Swap'>
+      <parameter type-id='type-id-178' name='runtime' filepath='Python/pystate.c' line='1900' column='1'/>
+      <parameter type-id='type-id-177' name='newts' filepath='Python/pystate.c' line='1900' column='1'/>
       <return type-id='type-id-177'/>
     </function-decl>
-    <function-decl name='PyInterpreterState_Main' mangled-name='PyInterpreterState_Main' filepath='Python/pystate.c' line='1951' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyInterpreterState_Main'>
+    <function-decl name='PyInterpreterState_Main' mangled-name='PyInterpreterState_Main' filepath='Python/pystate.c' line='1950' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyInterpreterState_Main'>
       <return type-id='type-id-20'/>
     </function-decl>
-    <function-decl name='_PyThread_CurrentFrames' mangled-name='_PyThread_CurrentFrames' filepath='Python/pystate.c' line='1982' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyThread_CurrentFrames'>
+    <function-decl name='_PyThread_CurrentFrames' mangled-name='_PyThread_CurrentFrames' filepath='Python/pystate.c' line='1981' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyThread_CurrentFrames'>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='_PyThread_CurrentExceptions' mangled-name='_PyThread_CurrentExceptions' filepath='Python/pystate.c' line='2043' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyThread_CurrentExceptions'>
+    <function-decl name='_PyThread_CurrentExceptions' mangled-name='_PyThread_CurrentExceptions' filepath='Python/pystate.c' line='2042' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyThread_CurrentExceptions'>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='_PyGILState_GetInterpreterStateUnsafe' mangled-name='_PyGILState_GetInterpreterStateUnsafe' filepath='Python/pystate.c' line='2161' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyGILState_GetInterpreterStateUnsafe'>
+    <function-decl name='_PyGILState_GetInterpreterStateUnsafe' mangled-name='_PyGILState_GetInterpreterStateUnsafe' filepath='Python/pystate.c' line='2160' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyGILState_GetInterpreterStateUnsafe'>
       <return type-id='type-id-20'/>
     </function-decl>
-    <function-decl name='_PyCrossInterpreterData_Init' mangled-name='_PyCrossInterpreterData_Init' filepath='Python/pystate.c' line='2330' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyCrossInterpreterData_Init'>
-      <parameter type-id='type-id-1063' name='data' filepath='Python/pystate.c' line='2330' column='1'/>
-      <parameter type-id='type-id-20' name='interp' filepath='Python/pystate.c' line='2331' column='1'/>
-      <parameter type-id='type-id-22' name='shared' filepath='Python/pystate.c' line='2332' column='1'/>
-      <parameter type-id='type-id-2' name='obj' filepath='Python/pystate.c' line='2332' column='1'/>
-      <parameter type-id='type-id-793' name='new_object' filepath='Python/pystate.c' line='2333' column='1'/>
+    <function-decl name='_PyCrossInterpreterData_Init' mangled-name='_PyCrossInterpreterData_Init' filepath='Python/pystate.c' line='2329' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyCrossInterpreterData_Init'>
+      <parameter type-id='type-id-1064' name='data' filepath='Python/pystate.c' line='2329' column='1'/>
+      <parameter type-id='type-id-20' name='interp' filepath='Python/pystate.c' line='2330' column='1'/>
+      <parameter type-id='type-id-22' name='shared' filepath='Python/pystate.c' line='2331' column='1'/>
+      <parameter type-id='type-id-2' name='obj' filepath='Python/pystate.c' line='2331' column='1'/>
+      <parameter type-id='type-id-793' name='new_object' filepath='Python/pystate.c' line='2332' column='1'/>
       <return type-id='type-id-46'/>
     </function-decl>
-    <function-decl name='_PyCrossInterpreterData_InitWithSize' mangled-name='_PyCrossInterpreterData_InitWithSize' filepath='Python/pystate.c' line='2352' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyCrossInterpreterData_InitWithSize'>
-      <parameter type-id='type-id-1063' name='data' filepath='Python/pystate.c' line='2352' column='1'/>
-      <parameter type-id='type-id-20' name='interp' filepath='Python/pystate.c' line='2353' column='1'/>
-      <parameter type-id='type-id-1503' name='size' filepath='Python/pystate.c' line='2354' column='1'/>
-      <parameter type-id='type-id-2' name='obj' filepath='Python/pystate.c' line='2354' column='1'/>
-      <parameter type-id='type-id-793' name='new_object' filepath='Python/pystate.c' line='2355' column='1'/>
+    <function-decl name='_PyCrossInterpreterData_InitWithSize' mangled-name='_PyCrossInterpreterData_InitWithSize' filepath='Python/pystate.c' line='2351' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyCrossInterpreterData_InitWithSize'>
+      <parameter type-id='type-id-1064' name='data' filepath='Python/pystate.c' line='2351' column='1'/>
+      <parameter type-id='type-id-20' name='interp' filepath='Python/pystate.c' line='2352' column='1'/>
+      <parameter type-id='type-id-1505' name='size' filepath='Python/pystate.c' line='2353' column='1'/>
+      <parameter type-id='type-id-2' name='obj' filepath='Python/pystate.c' line='2353' column='1'/>
+      <parameter type-id='type-id-793' name='new_object' filepath='Python/pystate.c' line='2354' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='_PyCrossInterpreterData_Clear' mangled-name='_PyCrossInterpreterData_Clear' filepath='Python/pystate.c' line='2371' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyCrossInterpreterData_Clear'>
-      <parameter type-id='type-id-20' name='interp' filepath='Python/pystate.c' line='2371' column='1'/>
-      <parameter type-id='type-id-1063' name='data' filepath='Python/pystate.c' line='2372' column='1'/>
+    <function-decl name='_PyCrossInterpreterData_Clear' mangled-name='_PyCrossInterpreterData_Clear' filepath='Python/pystate.c' line='2370' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyCrossInterpreterData_Clear'>
+      <parameter type-id='type-id-20' name='interp' filepath='Python/pystate.c' line='2370' column='1'/>
+      <parameter type-id='type-id-1064' name='data' filepath='Python/pystate.c' line='2371' column='1'/>
       <return type-id='type-id-46'/>
     </function-decl>
-    <function-decl name='_PyObject_CheckCrossInterpreterData' mangled-name='_PyObject_CheckCrossInterpreterData' filepath='Python/pystate.c' line='2417' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyObject_CheckCrossInterpreterData'>
-      <parameter type-id='type-id-2' name='obj' filepath='Python/pystate.c' line='2417' column='1'/>
+    <function-decl name='_PyObject_CheckCrossInterpreterData' mangled-name='_PyObject_CheckCrossInterpreterData' filepath='Python/pystate.c' line='2416' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyObject_CheckCrossInterpreterData'>
+      <parameter type-id='type-id-2' name='obj' filepath='Python/pystate.c' line='2416' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='_PyObject_GetCrossInterpreterData' mangled-name='_PyObject_GetCrossInterpreterData' filepath='Python/pystate.c' line='2427' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyObject_GetCrossInterpreterData'>
-      <parameter type-id='type-id-2' name='obj' filepath='Python/pystate.c' line='2427' column='1'/>
-      <parameter type-id='type-id-1063' name='data' filepath='Python/pystate.c' line='2427' column='1'/>
+    <function-decl name='_PyObject_GetCrossInterpreterData' mangled-name='_PyObject_GetCrossInterpreterData' filepath='Python/pystate.c' line='2426' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyObject_GetCrossInterpreterData'>
+      <parameter type-id='type-id-2' name='obj' filepath='Python/pystate.c' line='2426' column='1'/>
+      <parameter type-id='type-id-1064' name='data' filepath='Python/pystate.c' line='2426' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='_PyCrossInterpreterData_NewObject' mangled-name='_PyCrossInterpreterData_NewObject' filepath='Python/pystate.c' line='2465' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyCrossInterpreterData_NewObject'>
-      <parameter type-id='type-id-1063' name='data' filepath='Python/pystate.c' line='2465' column='1'/>
+    <function-decl name='_PyCrossInterpreterData_NewObject' mangled-name='_PyCrossInterpreterData_NewObject' filepath='Python/pystate.c' line='2464' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyCrossInterpreterData_NewObject'>
+      <parameter type-id='type-id-1064' name='data' filepath='Python/pystate.c' line='2464' column='1'/>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='_PyCrossInterpreterData_Release' mangled-name='_PyCrossInterpreterData_Release' filepath='Python/pystate.c' line='2531' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyCrossInterpreterData_Release'>
-      <parameter type-id='type-id-1063' name='data' filepath='Python/pystate.c' line='2531' column='1'/>
+    <function-decl name='_PyCrossInterpreterData_Release' mangled-name='_PyCrossInterpreterData_Release' filepath='Python/pystate.c' line='2530' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyCrossInterpreterData_Release'>
+      <parameter type-id='type-id-1064' name='data' filepath='Python/pystate.c' line='2530' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='_PyCrossInterpreterData_ReleaseAndRawFree' mangled-name='_PyCrossInterpreterData_ReleaseAndRawFree' filepath='Python/pystate.c' line='2537' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyCrossInterpreterData_ReleaseAndRawFree'>
-      <parameter type-id='type-id-1063' name='data' filepath='Python/pystate.c' line='2537' column='1'/>
+    <function-decl name='_PyCrossInterpreterData_ReleaseAndRawFree' mangled-name='_PyCrossInterpreterData_ReleaseAndRawFree' filepath='Python/pystate.c' line='2536' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyCrossInterpreterData_ReleaseAndRawFree'>
+      <parameter type-id='type-id-1064' name='data' filepath='Python/pystate.c' line='2536' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='_PyCrossInterpreterData_RegisterClass' mangled-name='_PyCrossInterpreterData_RegisterClass' filepath='Python/pystate.c' line='2664' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyCrossInterpreterData_RegisterClass'>
-      <parameter type-id='type-id-1' name='cls' filepath='Python/pystate.c' line='2664' column='1'/>
-      <parameter type-id='type-id-796' name='getdata' filepath='Python/pystate.c' line='2665' column='1'/>
+    <function-decl name='_PyCrossInterpreterData_RegisterClass' mangled-name='_PyCrossInterpreterData_RegisterClass' filepath='Python/pystate.c' line='2663' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyCrossInterpreterData_RegisterClass'>
+      <parameter type-id='type-id-1' name='cls' filepath='Python/pystate.c' line='2663' column='1'/>
+      <parameter type-id='type-id-796' name='getdata' filepath='Python/pystate.c' line='2664' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='_PyCrossInterpreterData_UnregisterClass' mangled-name='_PyCrossInterpreterData_UnregisterClass' filepath='Python/pystate.c' line='2698' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyCrossInterpreterData_UnregisterClass'>
-      <parameter type-id='type-id-1' name='cls' filepath='Python/pystate.c' line='2698' column='1'/>
+    <function-decl name='_PyCrossInterpreterData_UnregisterClass' mangled-name='_PyCrossInterpreterData_UnregisterClass' filepath='Python/pystate.c' line='2697' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyCrossInterpreterData_UnregisterClass'>
+      <parameter type-id='type-id-1' name='cls' filepath='Python/pystate.c' line='2697' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='_PyCrossInterpreterData_Lookup' mangled-name='_PyCrossInterpreterData_Lookup' filepath='Python/pystate.c' line='2725' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyCrossInterpreterData_Lookup'>
-      <parameter type-id='type-id-2' name='obj' filepath='Python/pystate.c' line='2725' column='1'/>
+    <function-decl name='_PyCrossInterpreterData_Lookup' mangled-name='_PyCrossInterpreterData_Lookup' filepath='Python/pystate.c' line='2724' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyCrossInterpreterData_Lookup'>
+      <parameter type-id='type-id-2' name='obj' filepath='Python/pystate.c' line='2724' column='1'/>
       <return type-id='type-id-796'/>
     </function-decl>
-    <function-decl name='_PyInterpreterState_GetEvalFrameFunc' mangled-name='_PyInterpreterState_GetEvalFrameFunc' filepath='Python/pystate.c' line='2880' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyInterpreterState_GetEvalFrameFunc'>
-      <parameter type-id='type-id-20' name='interp' filepath='Python/pystate.c' line='2880' column='1'/>
+    <function-decl name='_PyInterpreterState_GetEvalFrameFunc' mangled-name='_PyInterpreterState_GetEvalFrameFunc' filepath='Python/pystate.c' line='2879' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyInterpreterState_GetEvalFrameFunc'>
+      <parameter type-id='type-id-20' name='interp' filepath='Python/pystate.c' line='2879' column='1'/>
       <return type-id='type-id-789'/>
     </function-decl>
-    <function-decl name='_PyInterpreterState_SetEvalFrameFunc' mangled-name='_PyInterpreterState_SetEvalFrameFunc' filepath='Python/pystate.c' line='2890' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyInterpreterState_SetEvalFrameFunc'>
-      <parameter type-id='type-id-20' name='interp' filepath='Python/pystate.c' line='2890' column='1'/>
-      <parameter type-id='type-id-789' name='eval_frame' filepath='Python/pystate.c' line='2891' column='1'/>
+    <function-decl name='_PyInterpreterState_SetEvalFrameFunc' mangled-name='_PyInterpreterState_SetEvalFrameFunc' filepath='Python/pystate.c' line='2889' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyInterpreterState_SetEvalFrameFunc'>
+      <parameter type-id='type-id-20' name='interp' filepath='Python/pystate.c' line='2889' column='1'/>
+      <parameter type-id='type-id-789' name='eval_frame' filepath='Python/pystate.c' line='2890' column='1'/>
       <return type-id='type-id-46'/>
     </function-decl>
-    <function-decl name='_PyInterpreterState_GetConfigCopy' mangled-name='_PyInterpreterState_GetConfigCopy' filepath='Python/pystate.c' line='2910' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyInterpreterState_GetConfigCopy'>
-      <parameter type-id='type-id-53' name='config' filepath='Python/pystate.c' line='2910' column='1'/>
+    <function-decl name='_PyInterpreterState_GetConfigCopy' mangled-name='_PyInterpreterState_GetConfigCopy' filepath='Python/pystate.c' line='2909' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyInterpreterState_GetConfigCopy'>
+      <parameter type-id='type-id-53' name='config' filepath='Python/pystate.c' line='2909' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
   </abi-instr>
@@ -25818,133 +25845,133 @@
       <parameter type-id='type-id-179' name='exitcode_p' filepath='Python/pythonrun.c' line='688' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='_PyErr_Display' mangled-name='_PyErr_Display' filepath='Python/pythonrun.c' line='1494' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyErr_Display'>
-      <parameter type-id='type-id-2' name='file' filepath='Python/pythonrun.c' line='1494' column='1'/>
-      <parameter type-id='type-id-2' name='unused' filepath='Python/pythonrun.c' line='1494' column='1'/>
-      <parameter type-id='type-id-2' name='value' filepath='Python/pythonrun.c' line='1494' column='1'/>
-      <parameter type-id='type-id-2' name='tb' filepath='Python/pythonrun.c' line='1494' column='1'/>
+    <function-decl name='_PyErr_Display' mangled-name='_PyErr_Display' filepath='Python/pythonrun.c' line='1525' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyErr_Display'>
+      <parameter type-id='type-id-2' name='file' filepath='Python/pythonrun.c' line='1525' column='1'/>
+      <parameter type-id='type-id-2' name='unused' filepath='Python/pythonrun.c' line='1525' column='1'/>
+      <parameter type-id='type-id-2' name='value' filepath='Python/pythonrun.c' line='1525' column='1'/>
+      <parameter type-id='type-id-2' name='tb' filepath='Python/pythonrun.c' line='1525' column='1'/>
       <return type-id='type-id-46'/>
     </function-decl>
-    <function-decl name='PyErr_Display' mangled-name='PyErr_Display' filepath='Python/pythonrun.c' line='1543' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyErr_Display'>
-      <parameter type-id='type-id-2' name='unused' filepath='Python/pythonrun.c' line='1543' column='1'/>
-      <parameter type-id='type-id-2' name='value' filepath='Python/pythonrun.c' line='1543' column='1'/>
-      <parameter type-id='type-id-2' name='tb' filepath='Python/pythonrun.c' line='1543' column='1'/>
+    <function-decl name='PyErr_Display' mangled-name='PyErr_Display' filepath='Python/pythonrun.c' line='1574' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyErr_Display'>
+      <parameter type-id='type-id-2' name='unused' filepath='Python/pythonrun.c' line='1574' column='1'/>
+      <parameter type-id='type-id-2' name='value' filepath='Python/pythonrun.c' line='1574' column='1'/>
+      <parameter type-id='type-id-2' name='tb' filepath='Python/pythonrun.c' line='1574' column='1'/>
       <return type-id='type-id-46'/>
     </function-decl>
-    <function-decl name='_PyErr_DisplayException' mangled-name='_PyErr_DisplayException' filepath='Python/pythonrun.c' line='1560' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyErr_DisplayException'>
-      <parameter type-id='type-id-2' name='file' filepath='Python/pythonrun.c' line='1560' column='1'/>
-      <parameter type-id='type-id-2' name='exc' filepath='Python/pythonrun.c' line='1560' column='1'/>
+    <function-decl name='_PyErr_DisplayException' mangled-name='_PyErr_DisplayException' filepath='Python/pythonrun.c' line='1591' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyErr_DisplayException'>
+      <parameter type-id='type-id-2' name='file' filepath='Python/pythonrun.c' line='1591' column='1'/>
+      <parameter type-id='type-id-2' name='exc' filepath='Python/pythonrun.c' line='1591' column='1'/>
       <return type-id='type-id-46'/>
     </function-decl>
-    <function-decl name='PyRun_FileExFlags' mangled-name='PyRun_FileExFlags' filepath='Python/pythonrun.c' line='1624' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyRun_FileExFlags'>
-      <parameter type-id='type-id-229' name='fp' filepath='Python/pythonrun.c' line='1624' column='1'/>
-      <parameter type-id='type-id-12' name='filename' filepath='Python/pythonrun.c' line='1624' column='1'/>
-      <parameter type-id='type-id-8' name='start' filepath='Python/pythonrun.c' line='1624' column='1'/>
-      <parameter type-id='type-id-2' name='globals' filepath='Python/pythonrun.c' line='1624' column='1'/>
-      <parameter type-id='type-id-2' name='locals' filepath='Python/pythonrun.c' line='1625' column='1'/>
-      <parameter type-id='type-id-8' name='closeit' filepath='Python/pythonrun.c' line='1625' column='1'/>
-      <parameter type-id='type-id-208' name='flags' filepath='Python/pythonrun.c' line='1625' column='1'/>
+    <function-decl name='PyRun_FileExFlags' mangled-name='PyRun_FileExFlags' filepath='Python/pythonrun.c' line='1655' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyRun_FileExFlags'>
+      <parameter type-id='type-id-229' name='fp' filepath='Python/pythonrun.c' line='1655' column='1'/>
+      <parameter type-id='type-id-12' name='filename' filepath='Python/pythonrun.c' line='1655' column='1'/>
+      <parameter type-id='type-id-8' name='start' filepath='Python/pythonrun.c' line='1655' column='1'/>
+      <parameter type-id='type-id-2' name='globals' filepath='Python/pythonrun.c' line='1655' column='1'/>
+      <parameter type-id='type-id-2' name='locals' filepath='Python/pythonrun.c' line='1656' column='1'/>
+      <parameter type-id='type-id-8' name='closeit' filepath='Python/pythonrun.c' line='1656' column='1'/>
+      <parameter type-id='type-id-208' name='flags' filepath='Python/pythonrun.c' line='1656' column='1'/>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='Py_CompileStringExFlags' mangled-name='Py_CompileStringExFlags' filepath='Python/pythonrun.c' line='1786' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='Py_CompileStringExFlags'>
-      <parameter type-id='type-id-12' name='str' filepath='Python/pythonrun.c' line='1786' column='1'/>
-      <parameter type-id='type-id-12' name='filename_str' filepath='Python/pythonrun.c' line='1786' column='1'/>
-      <parameter type-id='type-id-8' name='start' filepath='Python/pythonrun.c' line='1786' column='1'/>
-      <parameter type-id='type-id-208' name='flags' filepath='Python/pythonrun.c' line='1787' column='1'/>
-      <parameter type-id='type-id-8' name='optimize' filepath='Python/pythonrun.c' line='1787' column='1'/>
+    <function-decl name='Py_CompileStringExFlags' mangled-name='Py_CompileStringExFlags' filepath='Python/pythonrun.c' line='1817' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='Py_CompileStringExFlags'>
+      <parameter type-id='type-id-12' name='str' filepath='Python/pythonrun.c' line='1817' column='1'/>
+      <parameter type-id='type-id-12' name='filename_str' filepath='Python/pythonrun.c' line='1817' column='1'/>
+      <parameter type-id='type-id-8' name='start' filepath='Python/pythonrun.c' line='1817' column='1'/>
+      <parameter type-id='type-id-208' name='flags' filepath='Python/pythonrun.c' line='1818' column='1'/>
+      <parameter type-id='type-id-8' name='optimize' filepath='Python/pythonrun.c' line='1818' column='1'/>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='PyRun_AnyFile' mangled-name='PyRun_AnyFile' filepath='Python/pythonrun.c' line='1888' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyRun_AnyFile'>
-      <parameter type-id='type-id-229' name='fp' filepath='Python/pythonrun.c' line='1888' column='1'/>
-      <parameter type-id='type-id-12' name='name' filepath='Python/pythonrun.c' line='1888' column='1'/>
+    <function-decl name='PyRun_AnyFile' mangled-name='PyRun_AnyFile' filepath='Python/pythonrun.c' line='1919' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyRun_AnyFile'>
+      <parameter type-id='type-id-229' name='fp' filepath='Python/pythonrun.c' line='1919' column='1'/>
+      <parameter type-id='type-id-12' name='name' filepath='Python/pythonrun.c' line='1919' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='PyRun_AnyFileEx' mangled-name='PyRun_AnyFileEx' filepath='Python/pythonrun.c' line='1895' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyRun_AnyFileEx'>
-      <parameter type-id='type-id-229' name='fp' filepath='Python/pythonrun.c' line='1895' column='1'/>
-      <parameter type-id='type-id-12' name='name' filepath='Python/pythonrun.c' line='1895' column='1'/>
-      <parameter type-id='type-id-8' name='closeit' filepath='Python/pythonrun.c' line='1895' column='1'/>
+    <function-decl name='PyRun_AnyFileEx' mangled-name='PyRun_AnyFileEx' filepath='Python/pythonrun.c' line='1926' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyRun_AnyFileEx'>
+      <parameter type-id='type-id-229' name='fp' filepath='Python/pythonrun.c' line='1926' column='1'/>
+      <parameter type-id='type-id-12' name='name' filepath='Python/pythonrun.c' line='1926' column='1'/>
+      <parameter type-id='type-id-8' name='closeit' filepath='Python/pythonrun.c' line='1926' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='PyRun_AnyFileFlags' mangled-name='PyRun_AnyFileFlags' filepath='Python/pythonrun.c' line='1902' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyRun_AnyFileFlags'>
-      <parameter type-id='type-id-229' name='fp' filepath='Python/pythonrun.c' line='1902' column='1'/>
-      <parameter type-id='type-id-12' name='name' filepath='Python/pythonrun.c' line='1902' column='1'/>
-      <parameter type-id='type-id-208' name='flags' filepath='Python/pythonrun.c' line='1902' column='1'/>
+    <function-decl name='PyRun_AnyFileFlags' mangled-name='PyRun_AnyFileFlags' filepath='Python/pythonrun.c' line='1933' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyRun_AnyFileFlags'>
+      <parameter type-id='type-id-229' name='fp' filepath='Python/pythonrun.c' line='1933' column='1'/>
+      <parameter type-id='type-id-12' name='name' filepath='Python/pythonrun.c' line='1933' column='1'/>
+      <parameter type-id='type-id-208' name='flags' filepath='Python/pythonrun.c' line='1933' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='PyRun_File' mangled-name='PyRun_File' filepath='Python/pythonrun.c' line='1909' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyRun_File'>
-      <parameter type-id='type-id-229' name='fp' filepath='Python/pythonrun.c' line='1909' column='1'/>
-      <parameter type-id='type-id-12' name='p' filepath='Python/pythonrun.c' line='1909' column='1'/>
-      <parameter type-id='type-id-8' name='s' filepath='Python/pythonrun.c' line='1909' column='1'/>
-      <parameter type-id='type-id-2' name='g' filepath='Python/pythonrun.c' line='1909' column='1'/>
-      <parameter type-id='type-id-2' name='l' filepath='Python/pythonrun.c' line='1909' column='1'/>
+    <function-decl name='PyRun_File' mangled-name='PyRun_File' filepath='Python/pythonrun.c' line='1940' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyRun_File'>
+      <parameter type-id='type-id-229' name='fp' filepath='Python/pythonrun.c' line='1940' column='1'/>
+      <parameter type-id='type-id-12' name='p' filepath='Python/pythonrun.c' line='1940' column='1'/>
+      <parameter type-id='type-id-8' name='s' filepath='Python/pythonrun.c' line='1940' column='1'/>
+      <parameter type-id='type-id-2' name='g' filepath='Python/pythonrun.c' line='1940' column='1'/>
+      <parameter type-id='type-id-2' name='l' filepath='Python/pythonrun.c' line='1940' column='1'/>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='PyRun_FileEx' mangled-name='PyRun_FileEx' filepath='Python/pythonrun.c' line='1916' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyRun_FileEx'>
-      <parameter type-id='type-id-229' name='fp' filepath='Python/pythonrun.c' line='1916' column='1'/>
-      <parameter type-id='type-id-12' name='p' filepath='Python/pythonrun.c' line='1916' column='1'/>
-      <parameter type-id='type-id-8' name='s' filepath='Python/pythonrun.c' line='1916' column='1'/>
-      <parameter type-id='type-id-2' name='g' filepath='Python/pythonrun.c' line='1916' column='1'/>
-      <parameter type-id='type-id-2' name='l' filepath='Python/pythonrun.c' line='1916' column='1'/>
-      <parameter type-id='type-id-8' name='c' filepath='Python/pythonrun.c' line='1916' column='1'/>
+    <function-decl name='PyRun_FileEx' mangled-name='PyRun_FileEx' filepath='Python/pythonrun.c' line='1947' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyRun_FileEx'>
+      <parameter type-id='type-id-229' name='fp' filepath='Python/pythonrun.c' line='1947' column='1'/>
+      <parameter type-id='type-id-12' name='p' filepath='Python/pythonrun.c' line='1947' column='1'/>
+      <parameter type-id='type-id-8' name='s' filepath='Python/pythonrun.c' line='1947' column='1'/>
+      <parameter type-id='type-id-2' name='g' filepath='Python/pythonrun.c' line='1947' column='1'/>
+      <parameter type-id='type-id-2' name='l' filepath='Python/pythonrun.c' line='1947' column='1'/>
+      <parameter type-id='type-id-8' name='c' filepath='Python/pythonrun.c' line='1947' column='1'/>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='PyRun_FileFlags' mangled-name='PyRun_FileFlags' filepath='Python/pythonrun.c' line='1923' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyRun_FileFlags'>
-      <parameter type-id='type-id-229' name='fp' filepath='Python/pythonrun.c' line='1923' column='1'/>
-      <parameter type-id='type-id-12' name='p' filepath='Python/pythonrun.c' line='1923' column='1'/>
-      <parameter type-id='type-id-8' name='s' filepath='Python/pythonrun.c' line='1923' column='1'/>
-      <parameter type-id='type-id-2' name='g' filepath='Python/pythonrun.c' line='1923' column='1'/>
-      <parameter type-id='type-id-2' name='l' filepath='Python/pythonrun.c' line='1923' column='1'/>
-      <parameter type-id='type-id-208' name='flags' filepath='Python/pythonrun.c' line='1924' column='1'/>
+    <function-decl name='PyRun_FileFlags' mangled-name='PyRun_FileFlags' filepath='Python/pythonrun.c' line='1954' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyRun_FileFlags'>
+      <parameter type-id='type-id-229' name='fp' filepath='Python/pythonrun.c' line='1954' column='1'/>
+      <parameter type-id='type-id-12' name='p' filepath='Python/pythonrun.c' line='1954' column='1'/>
+      <parameter type-id='type-id-8' name='s' filepath='Python/pythonrun.c' line='1954' column='1'/>
+      <parameter type-id='type-id-2' name='g' filepath='Python/pythonrun.c' line='1954' column='1'/>
+      <parameter type-id='type-id-2' name='l' filepath='Python/pythonrun.c' line='1954' column='1'/>
+      <parameter type-id='type-id-208' name='flags' filepath='Python/pythonrun.c' line='1955' column='1'/>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='PyRun_SimpleFile' mangled-name='PyRun_SimpleFile' filepath='Python/pythonrun.c' line='1931' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyRun_SimpleFile'>
-      <parameter type-id='type-id-229' name='f' filepath='Python/pythonrun.c' line='1931' column='1'/>
-      <parameter type-id='type-id-12' name='p' filepath='Python/pythonrun.c' line='1931' column='1'/>
+    <function-decl name='PyRun_SimpleFile' mangled-name='PyRun_SimpleFile' filepath='Python/pythonrun.c' line='1962' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyRun_SimpleFile'>
+      <parameter type-id='type-id-229' name='f' filepath='Python/pythonrun.c' line='1962' column='1'/>
+      <parameter type-id='type-id-12' name='p' filepath='Python/pythonrun.c' line='1962' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='PyRun_SimpleFileEx' mangled-name='PyRun_SimpleFileEx' filepath='Python/pythonrun.c' line='1938' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyRun_SimpleFileEx'>
-      <parameter type-id='type-id-229' name='f' filepath='Python/pythonrun.c' line='1938' column='1'/>
-      <parameter type-id='type-id-12' name='p' filepath='Python/pythonrun.c' line='1938' column='1'/>
-      <parameter type-id='type-id-8' name='c' filepath='Python/pythonrun.c' line='1938' column='1'/>
+    <function-decl name='PyRun_SimpleFileEx' mangled-name='PyRun_SimpleFileEx' filepath='Python/pythonrun.c' line='1969' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyRun_SimpleFileEx'>
+      <parameter type-id='type-id-229' name='f' filepath='Python/pythonrun.c' line='1969' column='1'/>
+      <parameter type-id='type-id-12' name='p' filepath='Python/pythonrun.c' line='1969' column='1'/>
+      <parameter type-id='type-id-8' name='c' filepath='Python/pythonrun.c' line='1969' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='PyRun_String' mangled-name='PyRun_String' filepath='Python/pythonrun.c' line='1946' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyRun_String'>
-      <parameter type-id='type-id-12' name='str' filepath='Python/pythonrun.c' line='1946' column='1'/>
-      <parameter type-id='type-id-8' name='s' filepath='Python/pythonrun.c' line='1946' column='1'/>
-      <parameter type-id='type-id-2' name='g' filepath='Python/pythonrun.c' line='1946' column='1'/>
-      <parameter type-id='type-id-2' name='l' filepath='Python/pythonrun.c' line='1946' column='1'/>
+    <function-decl name='PyRun_String' mangled-name='PyRun_String' filepath='Python/pythonrun.c' line='1977' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyRun_String'>
+      <parameter type-id='type-id-12' name='str' filepath='Python/pythonrun.c' line='1977' column='1'/>
+      <parameter type-id='type-id-8' name='s' filepath='Python/pythonrun.c' line='1977' column='1'/>
+      <parameter type-id='type-id-2' name='g' filepath='Python/pythonrun.c' line='1977' column='1'/>
+      <parameter type-id='type-id-2' name='l' filepath='Python/pythonrun.c' line='1977' column='1'/>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='PyRun_SimpleString' mangled-name='PyRun_SimpleString' filepath='Python/pythonrun.c' line='1953' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyRun_SimpleString'>
-      <parameter type-id='type-id-12' name='s' filepath='Python/pythonrun.c' line='1953' column='1'/>
+    <function-decl name='PyRun_SimpleString' mangled-name='PyRun_SimpleString' filepath='Python/pythonrun.c' line='1984' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyRun_SimpleString'>
+      <parameter type-id='type-id-12' name='s' filepath='Python/pythonrun.c' line='1984' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='Py_CompileString' mangled-name='Py_CompileString' filepath='Python/pythonrun.c' line='1960' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='Py_CompileString'>
-      <parameter type-id='type-id-12' name='str' filepath='Python/pythonrun.c' line='1960' column='1'/>
-      <parameter type-id='type-id-12' name='p' filepath='Python/pythonrun.c' line='1960' column='1'/>
-      <parameter type-id='type-id-8' name='s' filepath='Python/pythonrun.c' line='1960' column='1'/>
+    <function-decl name='Py_CompileString' mangled-name='Py_CompileString' filepath='Python/pythonrun.c' line='1991' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='Py_CompileString'>
+      <parameter type-id='type-id-12' name='str' filepath='Python/pythonrun.c' line='1991' column='1'/>
+      <parameter type-id='type-id-12' name='p' filepath='Python/pythonrun.c' line='1991' column='1'/>
+      <parameter type-id='type-id-8' name='s' filepath='Python/pythonrun.c' line='1991' column='1'/>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='Py_CompileStringFlags' mangled-name='Py_CompileStringFlags' filepath='Python/pythonrun.c' line='1967' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='Py_CompileStringFlags'>
-      <parameter type-id='type-id-12' name='str' filepath='Python/pythonrun.c' line='1967' column='1'/>
-      <parameter type-id='type-id-12' name='p' filepath='Python/pythonrun.c' line='1967' column='1'/>
-      <parameter type-id='type-id-8' name='s' filepath='Python/pythonrun.c' line='1967' column='1'/>
-      <parameter type-id='type-id-208' name='flags' filepath='Python/pythonrun.c' line='1968' column='1'/>
+    <function-decl name='Py_CompileStringFlags' mangled-name='Py_CompileStringFlags' filepath='Python/pythonrun.c' line='1998' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='Py_CompileStringFlags'>
+      <parameter type-id='type-id-12' name='str' filepath='Python/pythonrun.c' line='1998' column='1'/>
+      <parameter type-id='type-id-12' name='p' filepath='Python/pythonrun.c' line='1998' column='1'/>
+      <parameter type-id='type-id-8' name='s' filepath='Python/pythonrun.c' line='1998' column='1'/>
+      <parameter type-id='type-id-208' name='flags' filepath='Python/pythonrun.c' line='1999' column='1'/>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='PyRun_InteractiveOne' mangled-name='PyRun_InteractiveOne' filepath='Python/pythonrun.c' line='1975' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyRun_InteractiveOne'>
-      <parameter type-id='type-id-229' name='f' filepath='Python/pythonrun.c' line='1975' column='1'/>
-      <parameter type-id='type-id-12' name='p' filepath='Python/pythonrun.c' line='1975' column='1'/>
+    <function-decl name='PyRun_InteractiveOne' mangled-name='PyRun_InteractiveOne' filepath='Python/pythonrun.c' line='2006' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyRun_InteractiveOne'>
+      <parameter type-id='type-id-229' name='f' filepath='Python/pythonrun.c' line='2006' column='1'/>
+      <parameter type-id='type-id-12' name='p' filepath='Python/pythonrun.c' line='2006' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='PyRun_InteractiveLoop' mangled-name='PyRun_InteractiveLoop' filepath='Python/pythonrun.c' line='1982' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyRun_InteractiveLoop'>
-      <parameter type-id='type-id-229' name='f' filepath='Python/pythonrun.c' line='1982' column='1'/>
-      <parameter type-id='type-id-12' name='p' filepath='Python/pythonrun.c' line='1982' column='1'/>
+    <function-decl name='PyRun_InteractiveLoop' mangled-name='PyRun_InteractiveLoop' filepath='Python/pythonrun.c' line='2013' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyRun_InteractiveLoop'>
+      <parameter type-id='type-id-229' name='f' filepath='Python/pythonrun.c' line='2013' column='1'/>
+      <parameter type-id='type-id-12' name='p' filepath='Python/pythonrun.c' line='2013' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
   </abi-instr>
   <abi-instr address-size='64' path='Python/pytime.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
-    <class-decl name='_Py_clock_info_t' size-in-bits='192' is-struct='yes' naming-typedef-id='type-id-1504' visibility='default' filepath='./Include/cpython/pytime.h' line='240' column='1' id='type-id-1505'>
+    <class-decl name='_Py_clock_info_t' size-in-bits='192' is-struct='yes' naming-typedef-id='type-id-1506' visibility='default' filepath='./Include/cpython/pytime.h' line='240' column='1' id='type-id-1507'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='implementation' type-id='type-id-12' visibility='default' filepath='./Include/cpython/pytime.h' line='241' column='1'/>
       </data-member>
@@ -25958,16 +25985,16 @@
         <var-decl name='resolution' type-id='type-id-251' visibility='default' filepath='./Include/cpython/pytime.h' line='244' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='_Py_clock_info_t' type-id='type-id-1505' filepath='./Include/cpython/pytime.h' line='245' column='1' id='type-id-1504'/>
-    <typedef-decl name='__suseconds_t' type-id='type-id-47' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='162' column='1' id='type-id-1506'/>
+    <typedef-decl name='_Py_clock_info_t' type-id='type-id-1507' filepath='./Include/cpython/pytime.h' line='245' column='1' id='type-id-1506'/>
+    <typedef-decl name='__suseconds_t' type-id='type-id-47' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='162' column='1' id='type-id-1508'/>
     <typedef-decl name='__clockid_t' type-id='type-id-8' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='169' column='1' id='type-id-212'/>
     <typedef-decl name='clockid_t' type-id='type-id-212' filepath='/usr/include/x86_64-linux-gnu/bits/types/clockid_t.h' line='7' column='1' id='type-id-221'/>
     <class-decl name='timeval' size-in-bits='128' is-struct='yes' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_timeval.h' line='8' column='1' id='type-id-101'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='tv_sec' type-id='type-id-1347' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_timeval.h' line='14' column='1'/>
+        <var-decl name='tv_sec' type-id='type-id-1348' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_timeval.h' line='14' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='tv_usec' type-id='type-id-1506' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_timeval.h' line='15' column='1'/>
+        <var-decl name='tv_usec' type-id='type-id-1508' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_timeval.h' line='15' column='1'/>
       </data-member>
     </class-decl>
     <class-decl name='tm' size-in-bits='448' is-struct='yes' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_tm.h' line='7' column='1' id='type-id-214'>
@@ -26005,25 +26032,25 @@
         <var-decl name='tm_zone' type-id='type-id-12' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_tm.h' line='21' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='time_t' type-id='type-id-1347' filepath='/usr/include/x86_64-linux-gnu/bits/types/time_t.h' line='10' column='1' id='type-id-219'/>
-    <pointer-type-def type-id='type-id-799' size-in-bits='64' id='type-id-1507'/>
-    <pointer-type-def type-id='type-id-1504' size-in-bits='64' id='type-id-1508'/>
-    <qualified-type-def type-id='type-id-219' const='yes' id='type-id-1509'/>
-    <pointer-type-def type-id='type-id-1509' size-in-bits='64' id='type-id-1510'/>
-    <qualified-type-def type-id='type-id-1510' restrict='yes' id='type-id-1511'/>
-    <pointer-type-def type-id='type-id-47' size-in-bits='64' id='type-id-1512'/>
+    <typedef-decl name='time_t' type-id='type-id-1348' filepath='/usr/include/x86_64-linux-gnu/bits/types/time_t.h' line='10' column='1' id='type-id-219'/>
+    <pointer-type-def type-id='type-id-799' size-in-bits='64' id='type-id-1509'/>
+    <pointer-type-def type-id='type-id-1506' size-in-bits='64' id='type-id-1510'/>
+    <qualified-type-def type-id='type-id-219' const='yes' id='type-id-1511'/>
+    <pointer-type-def type-id='type-id-1511' size-in-bits='64' id='type-id-1512'/>
+    <qualified-type-def type-id='type-id-1512' restrict='yes' id='type-id-1513'/>
+    <pointer-type-def type-id='type-id-47' size-in-bits='64' id='type-id-1514'/>
     <pointer-type-def type-id='type-id-219' size-in-bits='64' id='type-id-218'/>
-    <pointer-type-def type-id='type-id-101' size-in-bits='64' id='type-id-1513'/>
+    <pointer-type-def type-id='type-id-101' size-in-bits='64' id='type-id-1515'/>
     <pointer-type-def type-id='type-id-214' size-in-bits='64' id='type-id-220'/>
-    <qualified-type-def type-id='type-id-220' restrict='yes' id='type-id-1514'/>
+    <qualified-type-def type-id='type-id-220' restrict='yes' id='type-id-1516'/>
     <function-decl name='gmtime_r' filepath='/usr/include/time.h' line='154' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-1511'/>
-      <parameter type-id='type-id-1514'/>
+      <parameter type-id='type-id-1513'/>
+      <parameter type-id='type-id-1516'/>
       <return type-id='type-id-220'/>
     </function-decl>
     <function-decl name='localtime_r' filepath='/usr/include/time.h' line='159' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-1511'/>
-      <parameter type-id='type-id-1514'/>
+      <parameter type-id='type-id-1513'/>
+      <parameter type-id='type-id-1516'/>
       <return type-id='type-id-220'/>
     </function-decl>
     <function-decl name='clock_getres' filepath='/usr/include/time.h' line='276' column='1' visibility='default' binding='global' size-in-bits='64'>
@@ -26058,21 +26085,21 @@
     <function-decl name='_PyTime_ObjectToTime_t' mangled-name='_PyTime_ObjectToTime_t' filepath='Python/pytime.c' line='357' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyTime_ObjectToTime_t'>
       <parameter type-id='type-id-2' name='obj' filepath='Python/pytime.c' line='357' column='1'/>
       <parameter type-id='type-id-218' name='sec' filepath='Python/pytime.c' line='357' column='1'/>
-      <parameter type-id='type-id-1426' name='round' filepath='Python/pytime.c' line='357' column='1'/>
+      <parameter type-id='type-id-1428' name='round' filepath='Python/pytime.c' line='357' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
     <function-decl name='_PyTime_ObjectToTimespec' mangled-name='_PyTime_ObjectToTimespec' filepath='Python/pytime.c' line='392' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyTime_ObjectToTimespec'>
       <parameter type-id='type-id-2' name='obj' filepath='Python/pytime.c' line='392' column='1'/>
       <parameter type-id='type-id-218' name='sec' filepath='Python/pytime.c' line='392' column='1'/>
-      <parameter type-id='type-id-1512' name='nsec' filepath='Python/pytime.c' line='392' column='1'/>
-      <parameter type-id='type-id-1426' name='round' filepath='Python/pytime.c' line='393' column='1'/>
+      <parameter type-id='type-id-1514' name='nsec' filepath='Python/pytime.c' line='392' column='1'/>
+      <parameter type-id='type-id-1428' name='round' filepath='Python/pytime.c' line='393' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
     <function-decl name='_PyTime_ObjectToTimeval' mangled-name='_PyTime_ObjectToTimeval' filepath='Python/pytime.c' line='400' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyTime_ObjectToTimeval'>
       <parameter type-id='type-id-2' name='obj' filepath='Python/pytime.c' line='400' column='1'/>
       <parameter type-id='type-id-218' name='sec' filepath='Python/pytime.c' line='400' column='1'/>
-      <parameter type-id='type-id-1512' name='usec' filepath='Python/pytime.c' line='400' column='1'/>
-      <parameter type-id='type-id-1426' name='round' filepath='Python/pytime.c' line='401' column='1'/>
+      <parameter type-id='type-id-1514' name='usec' filepath='Python/pytime.c' line='400' column='1'/>
+      <parameter type-id='type-id-1428' name='round' filepath='Python/pytime.c' line='401' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
     <function-decl name='_PyTime_FromSeconds' mangled-name='_PyTime_FromSeconds' filepath='Python/pytime.c' line='408' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyTime_FromSeconds'>
@@ -26088,30 +26115,30 @@
       <return type-id='type-id-799'/>
     </function-decl>
     <function-decl name='_PyTime_FromNanosecondsObject' mangled-name='_PyTime_FromNanosecondsObject' filepath='Python/pytime.c' line='440' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyTime_FromNanosecondsObject'>
-      <parameter type-id='type-id-1507' name='tp' filepath='Python/pytime.c' line='440' column='1'/>
+      <parameter type-id='type-id-1509' name='tp' filepath='Python/pytime.c' line='440' column='1'/>
       <parameter type-id='type-id-2' name='obj' filepath='Python/pytime.c' line='440' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
     <function-decl name='_PyTime_FromTimespec' mangled-name='_PyTime_FromTimespec' filepath='Python/pytime.c' line='490' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyTime_FromTimespec'>
-      <parameter type-id='type-id-1507' name='tp' filepath='Python/pytime.c' line='490' column='1'/>
+      <parameter type-id='type-id-1509' name='tp' filepath='Python/pytime.c' line='490' column='1'/>
       <parameter type-id='type-id-180' name='ts' filepath='Python/pytime.c' line='490' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
     <function-decl name='_PyTime_FromTimeval' mangled-name='_PyTime_FromTimeval' filepath='Python/pytime.c' line='521' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyTime_FromTimeval'>
-      <parameter type-id='type-id-1507' name='tp' filepath='Python/pytime.c' line='521' column='1'/>
-      <parameter type-id='type-id-1513' name='tv' filepath='Python/pytime.c' line='521' column='1'/>
+      <parameter type-id='type-id-1509' name='tp' filepath='Python/pytime.c' line='521' column='1'/>
+      <parameter type-id='type-id-1515' name='tv' filepath='Python/pytime.c' line='521' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
     <function-decl name='_PyTime_FromSecondsObject' mangled-name='_PyTime_FromSecondsObject' filepath='Python/pytime.c' line='589' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyTime_FromSecondsObject'>
-      <parameter type-id='type-id-1507' name='tp' filepath='Python/pytime.c' line='589' column='1'/>
+      <parameter type-id='type-id-1509' name='tp' filepath='Python/pytime.c' line='589' column='1'/>
       <parameter type-id='type-id-2' name='obj' filepath='Python/pytime.c' line='589' column='1'/>
-      <parameter type-id='type-id-1426' name='round' filepath='Python/pytime.c' line='589' column='1'/>
+      <parameter type-id='type-id-1428' name='round' filepath='Python/pytime.c' line='589' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
     <function-decl name='_PyTime_FromMillisecondsObject' mangled-name='_PyTime_FromMillisecondsObject' filepath='Python/pytime.c' line='596' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyTime_FromMillisecondsObject'>
-      <parameter type-id='type-id-1507' name='tp' filepath='Python/pytime.c' line='596' column='1'/>
+      <parameter type-id='type-id-1509' name='tp' filepath='Python/pytime.c' line='596' column='1'/>
       <parameter type-id='type-id-2' name='obj' filepath='Python/pytime.c' line='596' column='1'/>
-      <parameter type-id='type-id-1426' name='round' filepath='Python/pytime.c' line='596' column='1'/>
+      <parameter type-id='type-id-1428' name='round' filepath='Python/pytime.c' line='596' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
     <function-decl name='_PyTime_AsSecondsDouble' mangled-name='_PyTime_AsSecondsDouble' filepath='Python/pytime.c' line='603' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyTime_AsSecondsDouble'>
@@ -26128,26 +26155,26 @@
     </function-decl>
     <function-decl name='_PyTime_AsMilliseconds' mangled-name='_PyTime_AsMilliseconds' filepath='Python/pytime.c' line='754' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyTime_AsMilliseconds'>
       <parameter type-id='type-id-799' name='t' filepath='Python/pytime.c' line='754' column='1'/>
-      <parameter type-id='type-id-1426' name='round' filepath='Python/pytime.c' line='754' column='1'/>
+      <parameter type-id='type-id-1428' name='round' filepath='Python/pytime.c' line='754' column='1'/>
       <return type-id='type-id-799'/>
     </function-decl>
     <function-decl name='_PyTime_AsTimeval' mangled-name='_PyTime_AsTimeval' filepath='Python/pytime.c' line='804' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyTime_AsTimeval'>
       <parameter type-id='type-id-799' name='t' filepath='Python/pytime.c' line='804' column='1'/>
-      <parameter type-id='type-id-1513' name='tv' filepath='Python/pytime.c' line='804' column='1'/>
-      <parameter type-id='type-id-1426' name='round' filepath='Python/pytime.c' line='804' column='1'/>
+      <parameter type-id='type-id-1515' name='tv' filepath='Python/pytime.c' line='804' column='1'/>
+      <parameter type-id='type-id-1428' name='round' filepath='Python/pytime.c' line='804' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
     <function-decl name='_PyTime_AsTimeval_clamp' mangled-name='_PyTime_AsTimeval_clamp' filepath='Python/pytime.c' line='811' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyTime_AsTimeval_clamp'>
       <parameter type-id='type-id-799' name='t' filepath='Python/pytime.c' line='811' column='1'/>
-      <parameter type-id='type-id-1513' name='tv' filepath='Python/pytime.c' line='811' column='1'/>
-      <parameter type-id='type-id-1426' name='round' filepath='Python/pytime.c' line='811' column='1'/>
+      <parameter type-id='type-id-1515' name='tv' filepath='Python/pytime.c' line='811' column='1'/>
+      <parameter type-id='type-id-1428' name='round' filepath='Python/pytime.c' line='811' column='1'/>
       <return type-id='type-id-46'/>
     </function-decl>
     <function-decl name='_PyTime_AsTimevalTime_t' mangled-name='_PyTime_AsTimevalTime_t' filepath='Python/pytime.c' line='818' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyTime_AsTimevalTime_t'>
       <parameter type-id='type-id-799' name='t' filepath='Python/pytime.c' line='818' column='1'/>
       <parameter type-id='type-id-218' name='p_secs' filepath='Python/pytime.c' line='818' column='1'/>
       <parameter type-id='type-id-179' name='us' filepath='Python/pytime.c' line='818' column='1'/>
-      <parameter type-id='type-id-1426' name='round' filepath='Python/pytime.c' line='819' column='1'/>
+      <parameter type-id='type-id-1428' name='round' filepath='Python/pytime.c' line='819' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
     <function-decl name='_PyTime_AsTimespec_clamp' mangled-name='_PyTime_AsTimespec_clamp' filepath='Python/pytime.c' line='857' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyTime_AsTimespec_clamp'>
@@ -26164,21 +26191,21 @@
       <return type-id='type-id-799'/>
     </function-decl>
     <function-decl name='_PyTime_GetSystemClockWithInfo' mangled-name='_PyTime_GetSystemClockWithInfo' filepath='Python/pytime.c' line='995' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyTime_GetSystemClockWithInfo'>
-      <parameter type-id='type-id-1507' name='t' filepath='Python/pytime.c' line='995' column='1'/>
-      <parameter type-id='type-id-1508' name='info' filepath='Python/pytime.c' line='995' column='1'/>
+      <parameter type-id='type-id-1509' name='t' filepath='Python/pytime.c' line='995' column='1'/>
+      <parameter type-id='type-id-1510' name='info' filepath='Python/pytime.c' line='995' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
     <function-decl name='_PyTime_GetMonotonicClock' mangled-name='_PyTime_GetMonotonicClock' filepath='Python/pytime.c' line='1179' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyTime_GetMonotonicClock'>
       <return type-id='type-id-799'/>
     </function-decl>
     <function-decl name='_PyTime_GetMonotonicClockWithInfo' mangled-name='_PyTime_GetMonotonicClockWithInfo' filepath='Python/pytime.c' line='1192' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyTime_GetMonotonicClockWithInfo'>
-      <parameter type-id='type-id-1507' name='tp' filepath='Python/pytime.c' line='1192' column='1'/>
-      <parameter type-id='type-id-1508' name='info' filepath='Python/pytime.c' line='1192' column='1'/>
+      <parameter type-id='type-id-1509' name='tp' filepath='Python/pytime.c' line='1192' column='1'/>
+      <parameter type-id='type-id-1510' name='info' filepath='Python/pytime.c' line='1192' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
     <function-decl name='_PyTime_GetPerfCounterWithInfo' mangled-name='_PyTime_GetPerfCounterWithInfo' filepath='Python/pytime.c' line='1273' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyTime_GetPerfCounterWithInfo'>
-      <parameter type-id='type-id-1507' name='t' filepath='Python/pytime.c' line='1273' column='1'/>
-      <parameter type-id='type-id-1508' name='info' filepath='Python/pytime.c' line='1273' column='1'/>
+      <parameter type-id='type-id-1509' name='t' filepath='Python/pytime.c' line='1273' column='1'/>
+      <parameter type-id='type-id-1510' name='info' filepath='Python/pytime.c' line='1273' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
     <function-decl name='_PyTime_localtime' mangled-name='_PyTime_localtime' filepath='Python/pytime.c' line='1303' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyTime_localtime'>
@@ -26220,12 +26247,12 @@
       <parameter type-id='type-id-310'/>
       <return type-id='type-id-352'/>
     </function-decl>
-    <function-decl name='_Py_slot_tp_getattro' filepath='./Include/internal/pycore_typeobject.h' line='136' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_Py_slot_tp_getattro' filepath='./Include/internal/pycore_typeobject.h' line='138' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-2'/>
       <parameter type-id='type-id-2'/>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='_Py_slot_tp_getattr_hook' filepath='./Include/internal/pycore_typeobject.h' line='137' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_Py_slot_tp_getattr_hook' filepath='./Include/internal/pycore_typeobject.h' line='139' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-2'/>
       <parameter type-id='type-id-2'/>
       <return type-id='type-id-2'/>
@@ -26247,55 +26274,55 @@
     <var-decl name='PySTEntry_Type' type-id='type-id-256' visibility='default' filepath='./Include/internal/pycore_symtable.h' line='92' column='1'/>
   </abi-instr>
   <abi-instr address-size='64' path='Python/thread.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
-    <array-type-def dimensions='1' type-id='type-id-48' size-in-bits='256' id='type-id-1515'>
+    <array-type-def dimensions='1' type-id='type-id-48' size-in-bits='256' id='type-id-1517'>
       <subrange length='32' type-id='type-id-28' id='type-id-60'/>
     </array-type-def>
-    <array-type-def dimensions='1' type-id='type-id-48' size-in-bits='448' id='type-id-1516'>
-      <subrange length='56' type-id='type-id-28' id='type-id-1517'/>
+    <array-type-def dimensions='1' type-id='type-id-48' size-in-bits='448' id='type-id-1518'>
+      <subrange length='56' type-id='type-id-28' id='type-id-1519'/>
     </array-type-def>
-    <enum-decl name='PyLockStatus' filepath='./Include/pythread.h' line='12' column='1' id='type-id-1518'>
+    <enum-decl name='PyLockStatus' filepath='./Include/pythread.h' line='12' column='1' id='type-id-1520'>
       <underlying-type type-id='type-id-24'/>
       <enumerator name='PY_LOCK_FAILURE' value='0'/>
       <enumerator name='PY_LOCK_ACQUIRED' value='1'/>
       <enumerator name='PY_LOCK_INTR' value='2'/>
     </enum-decl>
-    <typedef-decl name='PyLockStatus' type-id='type-id-1518' filepath='./Include/pythread.h' line='16' column='1' id='type-id-1519'/>
+    <typedef-decl name='PyLockStatus' type-id='type-id-1520' filepath='./Include/pythread.h' line='16' column='1' id='type-id-1521'/>
     <typedef-decl name='pthread_t' type-id='type-id-28' filepath='/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h' line='27' column='1' id='type-id-207'/>
-    <union-decl name='pthread_attr_t' size-in-bits='448' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h' line='56' column='1' id='type-id-1520'>
+    <union-decl name='pthread_attr_t' size-in-bits='448' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h' line='56' column='1' id='type-id-1522'>
       <data-member access='public'>
-        <var-decl name='__size' type-id='type-id-1516' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h' line='58' column='1'/>
+        <var-decl name='__size' type-id='type-id-1518' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h' line='58' column='1'/>
       </data-member>
       <data-member access='public'>
         <var-decl name='__align' type-id='type-id-47' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h' line='59' column='1'/>
       </data-member>
     </union-decl>
-    <typedef-decl name='pthread_attr_t' type-id='type-id-1520' filepath='/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h' line='62' column='1' id='type-id-1521'/>
-    <union-decl name='sem_t' size-in-bits='256' naming-typedef-id='type-id-1522' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/semaphore.h' line='35' column='1' id='type-id-1523'>
+    <typedef-decl name='pthread_attr_t' type-id='type-id-1522' filepath='/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h' line='62' column='1' id='type-id-1523'/>
+    <union-decl name='sem_t' size-in-bits='256' naming-typedef-id='type-id-1524' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/semaphore.h' line='35' column='1' id='type-id-1525'>
       <data-member access='public'>
-        <var-decl name='__size' type-id='type-id-1515' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/semaphore.h' line='37' column='1'/>
+        <var-decl name='__size' type-id='type-id-1517' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/semaphore.h' line='37' column='1'/>
       </data-member>
       <data-member access='public'>
         <var-decl name='__align' type-id='type-id-47' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/semaphore.h' line='38' column='1'/>
       </data-member>
     </union-decl>
-    <typedef-decl name='sem_t' type-id='type-id-1523' filepath='/usr/include/x86_64-linux-gnu/bits/semaphore.h' line='39' column='1' id='type-id-1522'/>
-    <qualified-type-def type-id='type-id-1521' const='yes' id='type-id-1524'/>
-    <pointer-type-def type-id='type-id-1524' size-in-bits='64' id='type-id-1525'/>
-    <qualified-type-def type-id='type-id-1525' restrict='yes' id='type-id-1526'/>
-    <qualified-type-def type-id='type-id-981' const='yes' id='type-id-1527'/>
-    <pointer-type-def type-id='type-id-1527' size-in-bits='64' id='type-id-1528'/>
-    <qualified-type-def type-id='type-id-1528' restrict='yes' id='type-id-1529'/>
-    <pointer-type-def type-id='type-id-1521' size-in-bits='64' id='type-id-1530'/>
-    <pointer-type-def type-id='type-id-798' size-in-bits='64' id='type-id-1531'/>
-    <pointer-type-def type-id='type-id-207' size-in-bits='64' id='type-id-1532'/>
-    <qualified-type-def type-id='type-id-1532' restrict='yes' id='type-id-1533'/>
-    <pointer-type-def type-id='type-id-1522' size-in-bits='64' id='type-id-1534'/>
+    <typedef-decl name='sem_t' type-id='type-id-1525' filepath='/usr/include/x86_64-linux-gnu/bits/semaphore.h' line='39' column='1' id='type-id-1524'/>
+    <qualified-type-def type-id='type-id-1523' const='yes' id='type-id-1526'/>
+    <pointer-type-def type-id='type-id-1526' size-in-bits='64' id='type-id-1527'/>
+    <qualified-type-def type-id='type-id-1527' restrict='yes' id='type-id-1528'/>
+    <qualified-type-def type-id='type-id-982' const='yes' id='type-id-1529'/>
+    <pointer-type-def type-id='type-id-1529' size-in-bits='64' id='type-id-1530'/>
+    <qualified-type-def type-id='type-id-1530' restrict='yes' id='type-id-1531'/>
+    <pointer-type-def type-id='type-id-1523' size-in-bits='64' id='type-id-1532'/>
+    <pointer-type-def type-id='type-id-798' size-in-bits='64' id='type-id-1533'/>
+    <pointer-type-def type-id='type-id-207' size-in-bits='64' id='type-id-1534'/>
     <qualified-type-def type-id='type-id-1534' restrict='yes' id='type-id-1535'/>
-    <pointer-type-def type-id='type-id-1536' size-in-bits='64' id='type-id-1537'/>
+    <pointer-type-def type-id='type-id-1524' size-in-bits='64' id='type-id-1536'/>
+    <qualified-type-def type-id='type-id-1536' restrict='yes' id='type-id-1537'/>
+    <pointer-type-def type-id='type-id-1538' size-in-bits='64' id='type-id-1539'/>
     <function-decl name='pthread_create' filepath='/usr/include/pthread.h' line='202' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-1533'/>
-      <parameter type-id='type-id-1526'/>
-      <parameter type-id='type-id-1537'/>
+      <parameter type-id='type-id-1535'/>
+      <parameter type-id='type-id-1528'/>
+      <parameter type-id='type-id-1539'/>
       <parameter type-id='type-id-226'/>
       <return type-id='type-id-8'/>
     </function-decl>
@@ -26311,39 +26338,39 @@
       <return type-id='type-id-207'/>
     </function-decl>
     <function-decl name='pthread_attr_init' filepath='/usr/include/pthread.h' line='285' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-1530'/>
+      <parameter type-id='type-id-1532'/>
       <return type-id='type-id-8'/>
     </function-decl>
     <function-decl name='pthread_attr_destroy' filepath='/usr/include/pthread.h' line='288' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-1530'/>
+      <parameter type-id='type-id-1532'/>
       <return type-id='type-id-8'/>
     </function-decl>
     <function-decl name='pthread_attr_setscope' filepath='/usr/include/pthread.h' line='349' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-1530'/>
+      <parameter type-id='type-id-1532'/>
       <parameter type-id='type-id-8'/>
       <return type-id='type-id-8'/>
     </function-decl>
     <function-decl name='pthread_attr_setstacksize' filepath='/usr/include/pthread.h' line='373' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-1530'/>
+      <parameter type-id='type-id-1532'/>
       <parameter type-id='type-id-19'/>
       <return type-id='type-id-8'/>
     </function-decl>
     <function-decl name='pthread_cond_init' filepath='/usr/include/pthread.h' line='1112' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-1354'/>
-      <parameter type-id='type-id-1529'/>
+      <parameter type-id='type-id-1355'/>
+      <parameter type-id='type-id-1531'/>
       <return type-id='type-id-8'/>
     </function-decl>
     <function-decl name='pthread_condattr_init' filepath='/usr/include/pthread.h' line='1194' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-980'/>
+      <parameter type-id='type-id-981'/>
       <return type-id='type-id-8'/>
     </function-decl>
     <function-decl name='pthread_condattr_setclock' filepath='/usr/include/pthread.h' line='1219' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-980'/>
+      <parameter type-id='type-id-981'/>
       <parameter type-id='type-id-212'/>
       <return type-id='type-id-8'/>
     </function-decl>
     <function-decl name='pthread_key_create' filepath='/usr/include/pthread.h' line='1297' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-1531'/>
+      <parameter type-id='type-id-1533'/>
       <parameter type-id='type-id-769'/>
       <return type-id='type-id-8'/>
     </function-decl>
@@ -26361,31 +26388,31 @@
       <return type-id='type-id-8'/>
     </function-decl>
     <function-decl name='sem_init' filepath='/usr/include/semaphore.h' line='35' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-1534'/>
+      <parameter type-id='type-id-1536'/>
       <parameter type-id='type-id-8'/>
       <parameter type-id='type-id-95'/>
       <return type-id='type-id-8'/>
     </function-decl>
     <function-decl name='sem_destroy' filepath='/usr/include/semaphore.h' line='39' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-1534'/>
+      <parameter type-id='type-id-1536'/>
       <return type-id='type-id-8'/>
     </function-decl>
     <function-decl name='sem_wait' filepath='/usr/include/semaphore.h' line='55' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-1534'/>
+      <parameter type-id='type-id-1536'/>
       <return type-id='type-id-8'/>
     </function-decl>
     <function-decl name='sem_clockwait' filepath='/usr/include/semaphore.h' line='81' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-1535'/>
+      <parameter type-id='type-id-1537'/>
       <parameter type-id='type-id-221'/>
       <parameter type-id='type-id-206'/>
       <return type-id='type-id-8'/>
     </function-decl>
     <function-decl name='sem_trywait' filepath='/usr/include/semaphore.h' line='100' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-1534'/>
+      <parameter type-id='type-id-1536'/>
       <return type-id='type-id-8'/>
     </function-decl>
     <function-decl name='sem_post' filepath='/usr/include/semaphore.h' line='103' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-1534'/>
+      <parameter type-id='type-id-1536'/>
       <return type-id='type-id-8'/>
     </function-decl>
     <function-decl name='perror' filepath='/usr/include/stdio.h' line='804' column='1' visibility='default' binding='global' size-in-bits='64'>
@@ -26421,41 +26448,41 @@
       <parameter type-id='type-id-409' name='key' filepath='Python/thread.c' line='92' column='1'/>
       <return type-id='type-id-46'/>
     </function-decl>
-    <function-decl name='PyThread_start_new_thread' mangled-name='PyThread_start_new_thread' filepath='Python/thread_pthread.h' line='238' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyThread_start_new_thread'>
-      <parameter type-id='type-id-769' name='func' filepath='Python/thread_pthread.h' line='238' column='1'/>
-      <parameter type-id='type-id-22' name='arg' filepath='Python/thread_pthread.h' line='238' column='1'/>
+    <function-decl name='PyThread_start_new_thread' mangled-name='PyThread_start_new_thread' filepath='Python/thread_pthread.h' line='242' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyThread_start_new_thread'>
+      <parameter type-id='type-id-769' name='func' filepath='Python/thread_pthread.h' line='242' column='1'/>
+      <parameter type-id='type-id-22' name='arg' filepath='Python/thread_pthread.h' line='242' column='1'/>
       <return type-id='type-id-28'/>
     </function-decl>
-    <function-decl name='PyThread_acquire_lock_timed' mangled-name='PyThread_acquire_lock_timed' filepath='Python/thread_pthread.h' line='430' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyThread_acquire_lock_timed'>
-      <parameter type-id='type-id-810' name='lock' filepath='Python/thread_pthread.h' line='430' column='1'/>
-      <parameter type-id='type-id-378' name='microseconds' filepath='Python/thread_pthread.h' line='430' column='1'/>
-      <parameter type-id='type-id-8' name='intr_flag' filepath='Python/thread_pthread.h' line='431' column='1'/>
-      <return type-id='type-id-1519'/>
+    <function-decl name='PyThread_acquire_lock_timed' mangled-name='PyThread_acquire_lock_timed' filepath='Python/thread_pthread.h' line='434' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyThread_acquire_lock_timed'>
+      <parameter type-id='type-id-810' name='lock' filepath='Python/thread_pthread.h' line='434' column='1'/>
+      <parameter type-id='type-id-378' name='microseconds' filepath='Python/thread_pthread.h' line='434' column='1'/>
+      <parameter type-id='type-id-8' name='intr_flag' filepath='Python/thread_pthread.h' line='435' column='1'/>
+      <return type-id='type-id-1521'/>
     </function-decl>
-    <function-decl name='PyThread_create_key' mangled-name='PyThread_create_key' filepath='Python/thread_pthread.h' line='809' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyThread_create_key'>
+    <function-decl name='PyThread_create_key' mangled-name='PyThread_create_key' filepath='Python/thread_pthread.h' line='813' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyThread_create_key'>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='PyThread_delete_key' mangled-name='PyThread_delete_key' filepath='Python/thread_pthread.h' line='829' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyThread_delete_key'>
-      <parameter type-id='type-id-8' name='key' filepath='Python/thread_pthread.h' line='829' column='1'/>
+    <function-decl name='PyThread_delete_key' mangled-name='PyThread_delete_key' filepath='Python/thread_pthread.h' line='833' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyThread_delete_key'>
+      <parameter type-id='type-id-8' name='key' filepath='Python/thread_pthread.h' line='833' column='1'/>
       <return type-id='type-id-46'/>
     </function-decl>
-    <function-decl name='PyThread_delete_key_value' mangled-name='PyThread_delete_key_value' filepath='Python/thread_pthread.h' line='837' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyThread_delete_key_value'>
-      <parameter type-id='type-id-8' name='key' filepath='Python/thread_pthread.h' line='837' column='1'/>
+    <function-decl name='PyThread_delete_key_value' mangled-name='PyThread_delete_key_value' filepath='Python/thread_pthread.h' line='841' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyThread_delete_key_value'>
+      <parameter type-id='type-id-8' name='key' filepath='Python/thread_pthread.h' line='841' column='1'/>
       <return type-id='type-id-46'/>
     </function-decl>
-    <function-decl name='PyThread_set_key_value' mangled-name='PyThread_set_key_value' filepath='Python/thread_pthread.h' line='845' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyThread_set_key_value'>
-      <parameter type-id='type-id-8' name='key' filepath='Python/thread_pthread.h' line='845' column='1'/>
-      <parameter type-id='type-id-22' name='value' filepath='Python/thread_pthread.h' line='845' column='1'/>
+    <function-decl name='PyThread_set_key_value' mangled-name='PyThread_set_key_value' filepath='Python/thread_pthread.h' line='849' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyThread_set_key_value'>
+      <parameter type-id='type-id-8' name='key' filepath='Python/thread_pthread.h' line='849' column='1'/>
+      <parameter type-id='type-id-22' name='value' filepath='Python/thread_pthread.h' line='849' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='PyThread_get_key_value' mangled-name='PyThread_get_key_value' filepath='Python/thread_pthread.h' line='856' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyThread_get_key_value'>
-      <parameter type-id='type-id-8' name='key' filepath='Python/thread_pthread.h' line='856' column='1'/>
+    <function-decl name='PyThread_get_key_value' mangled-name='PyThread_get_key_value' filepath='Python/thread_pthread.h' line='860' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyThread_get_key_value'>
+      <parameter type-id='type-id-8' name='key' filepath='Python/thread_pthread.h' line='860' column='1'/>
       <return type-id='type-id-22'/>
     </function-decl>
-    <function-decl name='PyThread_ReInitTLS' mangled-name='PyThread_ReInitTLS' filepath='Python/thread_pthread.h' line='867' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyThread_ReInitTLS'>
+    <function-decl name='PyThread_ReInitTLS' mangled-name='PyThread_ReInitTLS' filepath='Python/thread_pthread.h' line='871' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyThread_ReInitTLS'>
       <return type-id='type-id-46'/>
     </function-decl>
-    <function-type size-in-bits='64' id='type-id-1536'>
+    <function-type size-in-bits='64' id='type-id-1538'>
       <parameter type-id='type-id-22'/>
       <return type-id='type-id-22'/>
     </function-type>
@@ -26469,7 +26496,7 @@
       <return type-id='type-id-2'/>
     </function-decl>
     <var-decl name='PyTraceBack_Type' type-id='type-id-256' mangled-name='PyTraceBack_Type' visibility='default' filepath='./Include/traceback.h' line='13' column='1' elf-symbol-id='PyTraceBack_Type'/>
-    <function-decl name='_PyPegen_calculate_display_width' filepath='Python/../Parser/pegen.h' line='154' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_PyPegen_calculate_display_width' filepath='Python/../Parser/pegen.h' line='155' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-2'/>
       <parameter type-id='type-id-14'/>
       <return type-id='type-id-14'/>

--- a/Include/internal/pycore_interp.h
+++ b/Include/internal/pycore_interp.h
@@ -178,7 +178,17 @@ struct _is {
     struct _warnings_runtime_state warnings;
     struct atexit_state atexit;
 
-    struct _obmalloc_state obmalloc;
+    // Per-interpreter state for the obmalloc allocator.  For the main
+    // interpreter and for all interpreters that don't have their
+    // own obmalloc state, this points to the static structure in
+    // obmalloc.c obmalloc_state_main.  For other interpreters, it is
+    // heap allocated by _PyMem_init_obmalloc() and freed when the
+    // interpreter structure is freed.  In the case of a heap allocated
+    // obmalloc state, it is not safe to hold on to or use memory after
+    // the interpreter is freed. The obmalloc state corresponding to
+    // that allocated memory is gone.  See free_obmalloc_arenas() for
+    // more comments.
+    struct _obmalloc_state *obmalloc;
 
     PyObject *audit_hooks;
     PyType_WatchCallback type_watchers[TYPE_MAX_WATCHERS];

--- a/Include/internal/pycore_obmalloc.h
+++ b/Include/internal/pycore_obmalloc.h
@@ -686,6 +686,8 @@ extern Py_ssize_t _Py_GetGlobalAllocatedBlocks(void);
     _Py_GetGlobalAllocatedBlocks()
 extern Py_ssize_t _PyInterpreterState_GetAllocatedBlocks(PyInterpreterState *);
 extern void _PyInterpreterState_FinalizeAllocatedBlocks(PyInterpreterState *);
+extern int _PyMem_init_obmalloc(PyInterpreterState *interp);
+extern bool _PyMem_obmalloc_state_on_heap(PyInterpreterState *interp);
 
 
 #ifdef WITH_PYMALLOC

--- a/Include/internal/pycore_obmalloc_init.h
+++ b/Include/internal/pycore_obmalloc_init.h
@@ -59,13 +59,6 @@ extern "C" {
         .dump_debug_stats = -1, \
     }
 
-#define _obmalloc_state_INIT(obmalloc) \
-    { \
-        .pools = { \
-            .used = _obmalloc_pools_INIT(obmalloc.pools), \
-        }, \
-    }
-
 
 #ifdef __cplusplus
 }

--- a/Include/internal/pycore_runtime_init.h
+++ b/Include/internal/pycore_runtime_init.h
@@ -88,7 +88,6 @@ extern PyTypeObject _PyExc_MemoryError;
     { \
         .id_refcount = -1, \
         .imports = IMPORTS_INIT, \
-        .obmalloc = _obmalloc_state_INIT(INTERP.obmalloc), \
         .ceval = { \
             .recursion_limit = Py_DEFAULT_RECURSION_LIMIT, \
         }, \

--- a/Misc/NEWS.d/next/Core and Builtins/2023-12-22-13-21-39.gh-issue-113055.47xBMF.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2023-12-22-13-21-39.gh-issue-113055.47xBMF.rst
@@ -1,0 +1,5 @@
+Make interp->obmalloc a pointer. For interpreters that share state with the
+main interpreter, this points to the same static memory structure. For
+interpreters with their own obmalloc state, it is heap allocated. Add
+free_obmalloc_arenas() which will free the obmalloc arenas and radix tree
+structures for interpreters with their own obmalloc state.

--- a/Objects/obmalloc.c
+++ b/Objects/obmalloc.c
@@ -3,6 +3,7 @@
 #include "Python.h"
 #include "pycore_code.h"          // stats
 #include "pycore_pystate.h"       // _PyInterpreterState_GET
+#include "pycore_obmalloc_init.h"
 
 #include "pycore_obmalloc.h"
 #include "pycore_pymem.h"
@@ -852,6 +853,13 @@ static int running_on_valgrind = -1;
 
 typedef struct _obmalloc_state OMState;
 
+/* obmalloc state for main interpreter and shared by all interpreters without
+ * their own obmalloc state.  By not explicitly initalizing this structure, it
+ * will be allocated in the BSS which is a small performance win.  The radix
+ * tree arrays are fairly large but are sparsely used.  */
+static struct _obmalloc_state obmalloc_state_main;
+static bool obmalloc_state_initialized;
+
 static inline int
 has_own_state(PyInterpreterState *interp)
 {
@@ -864,10 +872,8 @@ static inline OMState *
 get_state(void)
 {
     PyInterpreterState *interp = _PyInterpreterState_GET();
-    if (!has_own_state(interp)) {
-        interp = _PyInterpreterState_Main();
-    }
-    return &interp->obmalloc;
+    assert(interp->obmalloc != NULL); // otherwise not initialized or freed
+    return interp->obmalloc;
 }
 
 // These macros all rely on a local "state" variable.
@@ -893,7 +899,11 @@ _PyInterpreterState_GetAllocatedBlocks(PyInterpreterState *interp)
                            "the interpreter doesn't have its own allocator");
     }
 #endif
-    OMState *state = &interp->obmalloc;
+    OMState *state = interp->obmalloc;
+
+    if (state == NULL) {
+        return 0;
+    }
 
     Py_ssize_t n = raw_allocated_blocks;
     /* add up allocated blocks for used pools */
@@ -915,13 +925,25 @@ _PyInterpreterState_GetAllocatedBlocks(PyInterpreterState *interp)
     return n;
 }
 
+static void free_obmalloc_arenas(PyInterpreterState *interp);
+
 void
 _PyInterpreterState_FinalizeAllocatedBlocks(PyInterpreterState *interp)
 {
-    if (has_own_state(interp)) {
+    if (has_own_state(interp) && interp->obmalloc != NULL) {
         Py_ssize_t leaked = _PyInterpreterState_GetAllocatedBlocks(interp);
         assert(has_own_state(interp) || leaked == 0);
         interp->runtime->obmalloc.interpreter_leaks += leaked;
+        if (_PyMem_obmalloc_state_on_heap(interp) && leaked == 0) {
+            // free the obmalloc arenas and radix tree nodes.  If leaked > 0
+            // then some of the memory allocated by obmalloc has not been
+            // freed.  It might be safe to free the arenas in that case but
+            // it's possible that extension modules are still using that
+            // memory.  So, it is safer to not free and to leak.  Perhaps there
+            // should be warning when this happens.  It should be possible to
+            // use a tool like "-fsanitize=address" to track down these leaks.
+            free_obmalloc_arenas(interp);
+        }
     }
 }
 
@@ -2511,8 +2533,95 @@ _PyDebugAllocatorStats(FILE *out,
     (void)printone(out, buf2, num_blocks * sizeof_block);
 }
 
+// Return true if the obmalloc state structure is heap allocated,
+// by PyMem_RawCalloc().  For the main interpreter, this structure
+// allocated in the BSS.  Allocating that way gives some memory savings
+// and a small performance win (at least on a demand paged OS).  On
+// 64-bit platforms, the obmalloc structure is 256 kB. Most of that
+// memory is for the arena_map_top array.  Since normally only one entry
+// of that array is used, only one page of resident memory is actually
+// used, rather than the full 256 kB.
+bool _PyMem_obmalloc_state_on_heap(PyInterpreterState *interp)
+{
+#if WITH_PYMALLOC
+    return interp->obmalloc && interp->obmalloc != &obmalloc_state_main;
+#else
+    return false;
+#endif
+}
 
 #ifdef WITH_PYMALLOC
+static void
+init_obmalloc_pools(PyInterpreterState *interp)
+{
+    // initialize the obmalloc->pools structure.  This must be done
+    // before the obmalloc alloc/free functions can be called.
+    poolp temp[OBMALLOC_USED_POOLS_SIZE] =
+        _obmalloc_pools_INIT(interp->obmalloc->pools);
+    memcpy(&interp->obmalloc->pools.used, temp, sizeof(temp));
+}
+#endif /* WITH_PYMALLOC */
+
+int _PyMem_init_obmalloc(PyInterpreterState *interp)
+{
+#ifdef WITH_PYMALLOC
+    /* Initialize obmalloc, but only for subinterpreters,
+       since the main interpreter is initialized statically. */
+    if (_Py_IsMainInterpreter(interp)
+            || _PyInterpreterState_HasFeature(interp,
+                                              Py_RTFLAGS_USE_MAIN_OBMALLOC)) {
+        interp->obmalloc = &obmalloc_state_main;
+        if (!obmalloc_state_initialized) {
+            init_obmalloc_pools(interp);
+            obmalloc_state_initialized = true;
+        }
+    } else {
+        interp->obmalloc = PyMem_RawCalloc(1, sizeof(struct _obmalloc_state));
+        if (interp->obmalloc == NULL) {
+            return -1;
+        }
+        init_obmalloc_pools(interp);
+    }
+#endif /* WITH_PYMALLOC */
+    return 0; // success
+}
+
+
+#ifdef WITH_PYMALLOC
+
+static void
+free_obmalloc_arenas(PyInterpreterState *interp)
+{
+    OMState *state = interp->obmalloc;
+    for (uint i = 0; i < maxarenas; ++i) {
+        // free each obmalloc memory arena
+        struct arena_object *ao = &allarenas[i];
+        _PyObject_Arena.free(_PyObject_Arena.ctx,
+                             (void *)ao->address, ARENA_SIZE);
+    }
+    // free the array containing pointers to all arenas
+    PyMem_RawFree(allarenas);
+#if WITH_PYMALLOC_RADIX_TREE
+#ifdef USE_INTERIOR_NODES
+    // Free the middle and bottom nodes of the radix tree.  These are allocated
+    // by arena_map_mark_used() but not freed when arenas are freed.
+    for (int i1 = 0; i1 < MAP_TOP_LENGTH; i1++) {
+         arena_map_mid_t *mid = arena_map_root.ptrs[i1];
+         if (mid == NULL) {
+             continue;
+         }
+         for (int i2 = 0; i2 < MAP_MID_LENGTH; i2++) {
+            arena_map_bot_t *bot = arena_map_root.ptrs[i1]->ptrs[i2];
+            if (bot == NULL) {
+                continue;
+            }
+            PyMem_RawFree(bot);
+         }
+         PyMem_RawFree(mid);
+    }
+#endif
+#endif
+}
 
 #ifdef Py_DEBUG
 /* Is target in the list?  The list is traversed via the nextpool pointers.

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -637,13 +637,6 @@ pycore_create_interpreter(_PyRuntimeState *runtime,
         return status;
     }
 
-    // initialize the interp->obmalloc state.  This must be done after
-    // the settings are loaded (so that feature_flags are set) but before
-    // any calls are made to obmalloc functions.
-    if (_PyMem_init_obmalloc(interp) < 0) {
-        return  _PyStatus_NO_MEMORY();
-    }
-
     /* Auto-thread-state API */
     status = _PyGILState_Init(interp);
     if (_PyStatus_EXCEPTION(status)) {
@@ -656,6 +649,13 @@ pycore_create_interpreter(_PyRuntimeState *runtime,
     status = init_interp_settings(interp, &config);
     if (_PyStatus_EXCEPTION(status)) {
         return status;
+    }
+
+    // initialize the interp->obmalloc state.  This must be done after
+    // the settings are loaded (so that feature_flags are set) but before
+    // any calls are made to obmalloc functions.
+    if (_PyMem_init_obmalloc(interp) < 0) {
+        return  _PyStatus_NO_MEMORY();
     }
 
     PyThreadState *tstate = _PyThreadState_New(interp);
@@ -2059,14 +2059,6 @@ new_interpreter(PyThreadState **tstate_p, const PyInterpreterConfig *config)
         return _PyStatus_OK();
     }
 
-    // initialize the interp->obmalloc state.  This must be done after
-    // the settings are loaded (so that feature_flags are set) but before
-    // any calls are made to obmalloc functions.
-    if (_PyMem_init_obmalloc(interp) < 0) {
-        status = _PyStatus_NO_MEMORY();
-        goto error;
-    }
-
     PyThreadState *tstate = _PyThreadState_New(interp);
     if (tstate == NULL) {
         PyInterpreterState_Delete(interp);
@@ -2107,6 +2099,14 @@ new_interpreter(PyThreadState **tstate_p, const PyInterpreterConfig *config)
     /* This does not require that the GIL be held. */
     status = init_interp_settings(interp, config);
     if (_PyStatus_EXCEPTION(status)) {
+        goto error;
+    }
+
+    // initialize the interp->obmalloc state.  This must be done after
+    // the settings are loaded (so that feature_flags are set) but before
+    // any calls are made to obmalloc functions.
+    if (_PyMem_init_obmalloc(interp) < 0) {
+        status = _PyStatus_NO_MEMORY();
         goto error;
     }
 

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -14,6 +14,7 @@
 #include "pycore_pystate.h"
 #include "pycore_runtime_init.h"  // _PyRuntimeState_INIT
 #include "pycore_sysmodule.h"
+#include "pycore_obmalloc.h"      // _PyMem_obmalloc_state_on_heap()
 
 /* --------------------------------------------------------------------------
 CAUTION
@@ -636,6 +637,11 @@ free_interpreter(PyInterpreterState *interp)
     // The main interpreter is statically allocated so
     // should not be freed.
     if (interp != &_PyRuntime._main_interpreter) {
+        if (_PyMem_obmalloc_state_on_heap(interp)) {
+            // interpreter has its own obmalloc state, free it
+            PyMem_RawFree(interp->obmalloc);
+            interp->obmalloc = NULL;
+        }
         PyMem_RawFree(interp);
     }
 }
@@ -679,13 +685,6 @@ init_interpreter(PyInterpreterState *interp,
     assert(next != NULL || (interp == runtime->interpreters.main));
     interp->next = next;
 
-    /* Initialize obmalloc, but only for subinterpreters,
-       since the main interpreter is initialized statically. */
-    if (interp != &runtime->_main_interpreter) {
-        poolp temp[OBMALLOC_USED_POOLS_SIZE] = \
-                _obmalloc_pools_INIT(interp->obmalloc.pools);
-        memcpy(&interp->obmalloc.pools.used, temp, sizeof(temp));
-    }
     _PyObject_InitState(interp);
 
     _PyEval_InitState(interp, pending_lock);

--- a/Tools/c-analyzer/cpython/ignored.tsv
+++ b/Tools/c-analyzer/cpython/ignored.tsv
@@ -318,7 +318,8 @@ Objects/obmalloc.c	-	_PyMem_Debug	-
 Objects/obmalloc.c	-	_PyMem_Raw	-
 Objects/obmalloc.c	-	_PyObject	-
 Objects/obmalloc.c	-	last_final_leaks	-
-Objects/obmalloc.c	-	usedpools	-
+Objects/obmalloc.c	-	obmalloc_state_main	-
+Objects/obmalloc.c	-	obmalloc_state_initialized	-
 Objects/typeobject.c	-	name_op	-
 Objects/typeobject.c	-	slotdefs	-
 Objects/unicodeobject.c	-	stripfuncnames	-


### PR DESCRIPTION
A backport of this change has been requested by a some users.  See Gh-113412 comments.

Crash in WeeChat which might be fixed by this: gh-116510

Comment from @bacon-cheeseburger:
> Just wanted to offer that this issue appears to impact Kodi, which has a considerable user base in the millions. The number of users affected by the problem could be quite substantial.

<!-- gh-issue-number: gh-113055 -->
* Issue: gh-113055
<!-- /gh-issue-number -->
