### PR TITLE
Correct timing sensitivity in iOS testing Makefile target.

### DIFF
--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -2040,7 +2040,7 @@ testuniversal: all
 # a full Xcode install that has an iPhone SE (3rd edition) simulator available.
 # This must be run *after* a `make install` has completed the build. The
 # `--with-framework-name` argument *cannot* be used when configuring the build.
-XCFOLDER=iOSTestbed.$(MULTIARCH).$(shell date +%s)
+XCFOLDER:=iOSTestbed.$(MULTIARCH).$(shell date +%s)
 XCRESULT=$(XCFOLDER)/$(MULTIARCH).xcresult
 .PHONY: testios
 testios:


### PR DESCRIPTION
[CI run 199 on the iOS buildbot failed](https://buildbot.python.org/all/#/builders/1380/builds/199) because of a niche edge case: due to the specific time at which the test ran, the system clock ticked over a second between copying the built framework into the test folder, and starting the test. 

This is a problem because `XCFOLDER` is defined with `=` syntax, but also includes a dynamic `$(shell)` invocation. The use of `=` means the value is evaluated on use, rather than once at time of definition.

This modifies the `Makefile.pre.in` to use `:=` syntax when creating the timestamp name; this ensures that the datestamp used in the build folder name is evaluated on definition, not use.