### PR TITLE
Set a DerivedData path for iOS test builds.

### DIFF
--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -2067,7 +2067,7 @@ testios:
 
 	# Run the test suite for the Xcode project, targeting the iOS simulator.
 	# If the suite fails, touch a file in the test folder as a marker
-	if ! xcodebuild test -project $(XCFOLDER)/iOSTestbed.xcodeproj -scheme "iOSTestbed" -destination "platform=iOS Simulator,name=iPhone SE (3rd Generation)" -resultBundlePath $(XCRESULT) ; then \
+	if ! xcodebuild test -project $(XCFOLDER)/iOSTestbed.xcodeproj -scheme "iOSTestbed" -destination "platform=iOS Simulator,name=iPhone SE (3rd Generation)" -resultBundlePath $(XCRESULT) -derivedDataPath $(XCFOLDER)/DerivedData ; then \
 	 	touch $(XCFOLDER)/failed; \
 	fi
 


### PR DESCRIPTION
iOS CI Builds 215-221 failed [because the CI machine ran out of disk space](https://buildbot.python.org/all/#/builders/1380/builds/221).

When an iOS Xcode project builds, it uses a DerivedData folder to store build artefacts. By default, this folder is created in `~/Library/Developer/Xcode/DerivedData`. Because the code checkout doesn't include any user-specific configuration, each time the `testios` target is is executed, it generates a fresh DerivedData folder, consuming ~260MB of disk space.

This derived data folder isn't cleaned up by Buildbot, because it's outside the build tree. 200 builds later, the buildbot ran out of disk space :-)

This PR modifies the Makefile to use a DerivedData folder that *is* in the build tree, so it will be cleaned up at the end of the test run. 

I've also purged the `~/Library/Developer/Xcode/DerivedData` folder on the CI machine; I'll do so again when this PR is merged.