### PR TITLE
gh-111201: Use a more common constant in completion tests in test_pyrepl

### DIFF
--- a/Lib/test/test_pyrepl.py
+++ b/Lib/test/test_pyrepl.py
@@ -578,13 +578,18 @@ class TestPyReplCompleter(TestCase):
         self.assertEqual(output, "os.getenv")
 
     def test_completion_with_many_options(self):
-        events = code_to_events("os.\t\tO_AS\t\n")
+        # Test with something that initially displays many options
+        # and then complete from one of them. The first time tab is
+        # pressed, the options are displayed (which corresponds to
+        # when the repl shows [ not unique ]) and the second completes
+        # from one of them.
+        events = code_to_events("os.\t\tO_AP\t\n")
 
         namespace = {"os": os}
         reader = self.prepare_reader(events, namespace)
 
         output = multiline_input(reader, namespace)
-        self.assertEqual(output, "os.O_ASYNC")
+        self.assertEqual(output, "os.O_APPEND")
 
     def test_empty_namespace_completion(self):
         events = code_to_events("os.geten\t\n")


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-111201 -->
* Issue: gh-111201
<!-- /gh-issue-number -->
