### PR TITLE
GH-115709: Invalidate executors when a local variable is changed via frame.f_locals

### DIFF
--- a/Include/cpython/optimizer.h
+++ b/Include/cpython/optimizer.h
@@ -141,15 +141,21 @@ void _Py_ExecutorDetach(_PyExecutorObject *);
 void _Py_BloomFilter_Init(_PyBloomFilter *);
 void _Py_BloomFilter_Add(_PyBloomFilter *bloom, void *obj);
 PyAPI_FUNC(void) _Py_Executor_DependsOn(_PyExecutorObject *executor, void *obj);
-PyAPI_FUNC(void) _Py_Executors_InvalidateDependency(PyInterpreterState *interp, void *obj, int is_invalidation);
-PyAPI_FUNC(void) _Py_Executors_InvalidateAll(PyInterpreterState *interp, int is_invalidation);
-
 /* For testing */
 PyAPI_FUNC(PyObject *)PyUnstable_Optimizer_NewCounter(void);
 PyAPI_FUNC(PyObject *)PyUnstable_Optimizer_NewUOpOptimizer(void);
 
 #define _Py_MAX_ALLOWED_BUILTINS_MODIFICATIONS 3
 #define _Py_MAX_ALLOWED_GLOBALS_MODIFICATIONS 6
+
+#ifdef _Py_TIER2
+PyAPI_FUNC(void) _Py_Executors_InvalidateDependency(PyInterpreterState *interp, void *obj, int is_invalidation);
+PyAPI_FUNC(void) _Py_Executors_InvalidateAll(PyInterpreterState *interp, int is_invalidation);
+#else
+#  define _Py_Executors_InvalidateDependency(A, B, C) ((void)0)
+#  define _Py_Executors_InvalidateAll(A, B) ((void)0)
+#endif
+
 
 #ifdef __cplusplus
 }

--- a/Lib/test/test_capi/test_opt.py
+++ b/Lib/test/test_capi/test_opt.py
@@ -1321,5 +1321,18 @@ class TestUopsOptimization(unittest.TestCase):
         self.assertIsNotNone(ex)
         self.assertIn("_FOR_ITER_GEN_FRAME", get_opnames(ex))
 
+    def test_modified_local_is_seen_by_optimized_code(self):
+        l = sys._getframe().f_locals
+        a = 1
+        s = 0
+        for j in range(1 << 10):
+            a + a
+            l["xa"[j >> 9]] = 1.0
+            s += a
+        self.assertIs(type(a), float)
+        self.assertIs(type(s), float)
+        self.assertEqual(s, 1024.0)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/Objects/frameobject.c
+++ b/Objects/frameobject.c
@@ -149,7 +149,7 @@ framelocalsproxy_setitem(PyObject *self, PyObject *key, PyObject *value)
         int i = framelocalsproxy_getkeyindex(frame, key, false);
         if (i >= 0) {
             _PyLocals_Kind kind = _PyLocals_GetKind(co->co_localspluskinds, i);
-
+            _Py_Executors_InvalidateDependency(PyInterpreterState_Get(), co, 1);
             PyObject *oldvalue = fast[i];
             PyObject *cell = NULL;
             if (kind == CO_FAST_FREE) {

--- a/Objects/frameobject.c
+++ b/Objects/frameobject.c
@@ -148,8 +148,9 @@ framelocalsproxy_setitem(PyObject *self, PyObject *key, PyObject *value)
     if (PyUnicode_CheckExact(key)) {
         int i = framelocalsproxy_getkeyindex(frame, key, false);
         if (i >= 0) {
-            _PyLocals_Kind kind = _PyLocals_GetKind(co->co_localspluskinds, i);
             _Py_Executors_InvalidateDependency(PyInterpreterState_Get(), co, 1);
+
+            _PyLocals_Kind kind = _PyLocals_GetKind(co->co_localspluskinds, i);
             PyObject *oldvalue = fast[i];
             PyObject *cell = NULL;
             if (kind == CO_FAST_FREE) {

--- a/Python/bytecodes.c
+++ b/Python/bytecodes.c
@@ -2424,6 +2424,9 @@ dummy_func(
                 opcode = executor->vm_data.opcode;
                 oparg = (oparg & ~255) | executor->vm_data.oparg;
                 next_instr = this_instr;
+                if (_PyOpcode_Caches[_PyOpcode_Deopt[opcode]]) {
+                    PAUSE_ADAPTIVE_COUNTER(this_instr[1].counter);
+                }
                 DISPATCH_GOTO();
             }
             tstate->previous_executor = Py_None;

--- a/Python/generated_cases.c.h
+++ b/Python/generated_cases.c.h
@@ -2673,6 +2673,9 @@
                 opcode = executor->vm_data.opcode;
                 oparg = (oparg & ~255) | executor->vm_data.oparg;
                 next_instr = this_instr;
+                if (_PyOpcode_Caches[_PyOpcode_Deopt[opcode]]) {
+                    PAUSE_ADAPTIVE_COUNTER(this_instr[1].counter);
+                }
                 DISPATCH_GOTO();
             }
             tstate->previous_executor = Py_None;

--- a/Python/optimizer.c
+++ b/Python/optimizer.c
@@ -1723,6 +1723,7 @@ _Py_Executors_InvalidateAll(PyInterpreterState *interp, int is_invalidation)
 }
 
 #else
+
 void
 _Py_Executors_InvalidateDependency(PyInterpreterState *interp, void *obj, int is_invalidation)
 {

--- a/Python/optimizer.c
+++ b/Python/optimizer.c
@@ -1,6 +1,7 @@
+#include "Python.h"
+
 #ifdef _Py_TIER2
 
-#include "Python.h"
 #include "opcode.h"
 #include "pycore_interp.h"
 #include "pycore_backoff.h"
@@ -1719,6 +1720,15 @@ _Py_Executors_InvalidateAll(PyInterpreterState *interp, int is_invalidation)
             OPT_STAT_INC(executors_invalidated);
         }
     }
+}
+
+#else
+void
+_Py_Executors_InvalidateDependency(PyInterpreterState *interp, void *obj, int is_invalidation)
+{
+    (void)interp;
+    (void)obj;
+    (void)is_invalidation;
 }
 
 #endif /* _Py_TIER2 */

--- a/Python/optimizer.c
+++ b/Python/optimizer.c
@@ -1,7 +1,6 @@
-#include "Python.h"
-
 #ifdef _Py_TIER2
 
+#include "Python.h"
 #include "opcode.h"
 #include "pycore_interp.h"
 #include "pycore_backoff.h"
@@ -1720,16 +1719,6 @@ _Py_Executors_InvalidateAll(PyInterpreterState *interp, int is_invalidation)
             OPT_STAT_INC(executors_invalidated);
         }
     }
-}
-
-#else
-
-void
-_Py_Executors_InvalidateDependency(PyInterpreterState *interp, void *obj, int is_invalidation)
-{
-    (void)interp;
-    (void)obj;
-    (void)is_invalidation;
 }
 
 #endif /* _Py_TIER2 */


### PR DESCRIPTION
Skipping news as this is fixing a hypothetical bug, rather than a reported bug.

The new test causes a C assertion failure in a debug build of main.

<!-- gh-issue-number: gh-115709 -->
* Issue: gh-115709
<!-- /gh-issue-number -->
