### PR TITLE
gh-118518: Check for perf version and not kernel version in test_perf_profiler

### DIFF
--- a/Lib/test/test_perf_profiler.py
+++ b/Lib/test/test_perf_profiler.py
@@ -479,17 +479,23 @@ class TestPerfProfiler(unittest.TestCase, TestPerfProfilerMixin):
             if f"py::foo_fork:{script}" in line or f"py::bar_fork:{script}" in line:
                 self.assertIn(line, child_perf_file_contents)
 
-def _is_kernel_version_at_least(major, minor):
+
+def _is_perf_vesion_at_least(major, minor):
+    # The output of perf --version looks like "perf version 6.7-3" but
+    # it can also be perf version "perf version 5.15.143"
     try:
-        with open("/proc/version") as f:
-            version = f.readline().split()[2]
-    except FileNotFoundError:
+        output = subprocess.check_output(["perf", "--version"], text=True)
+    except (subprocess.CalledProcessError, FileNotFoundError):
         return False
+    version = output.split()[2]
+    version = version.split("-")[0]
     version = version.split(".")
-    return int(version[0]) > major or (int(version[0]) == major and int(version[1]) >= minor)
+    version = tuple(map(int, version))
+    return version >= (major, minor)
+
 
 @unittest.skipUnless(perf_command_works(), "perf command doesn't work")
-@unittest.skipUnless(_is_kernel_version_at_least(6, 6), "perf command may not work due to a perf bug")
+@unittest.skipUnless(_is_perf_vesion_at_least(6, 6), "perf command may not work due to a perf bug")
 class TestPerfProfilerWithDwarf(unittest.TestCase, TestPerfProfilerMixin):
     def run_perf(self, script_dir, script, activate_trampoline=True):
         if activate_trampoline:


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-118518 -->
* Issue: gh-118518
<!-- /gh-issue-number -->
