### PR TITLE
gh-116322: Rename PyModule_ExperimentalSetGIL to PyUnstable_Module_SetGIL

### DIFF
--- a/Doc/c-api/module.rst
+++ b/Doc/c-api/module.rst
@@ -634,7 +634,7 @@ state:
 
    .. versionadded:: 3.9
 
-.. c:function:: int PyModule_ExperimentalSetGIL(PyObject *module, void *gil)
+.. c:function:: int PyUnstable_Module_SetGIL(PyObject *module, void *gil)
 
    Indicate that *module* does or does not support running without the global
    interpreter lock (GIL), using one of the values from

--- a/Include/moduleobject.h
+++ b/Include/moduleobject.h
@@ -101,7 +101,7 @@ struct PyModuleDef_Slot {
 #endif
 
 #if !defined(Py_LIMITED_API) && defined(Py_GIL_DISABLED)
-PyAPI_FUNC(int) PyModule_ExperimentalSetGIL(PyObject *module, void *gil);
+PyAPI_FUNC(int) PyUnstable_Module_SetGIL(PyObject *module, void *gil);
 #endif
 
 struct PyModuleDef {

--- a/Misc/NEWS.d/next/Core and Builtins/2024-03-12-13-51-09.gh-issue-116322.q8TcDQ.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2024-03-12-13-51-09.gh-issue-116322.q8TcDQ.rst
@@ -1,5 +1,5 @@
 Extension modules may indicate to the runtime that they can run without the
 GIL. Multi-phase init modules do so by calling providing
 ``Py_MOD_GIL_NOT_USED`` for the ``Py_mod_gil`` slot, while single-phase init
-modules call ``PyModule_ExperimentalSetGIL(mod, Py_MOD_GIL_NOT_USED)`` from
+modules call ``PyUnstable_Module_SetGIL(mod, Py_MOD_GIL_NOT_USED)`` from
 their init function.

--- a/Modules/_cursesmodule.c
+++ b/Modules/_cursesmodule.c
@@ -4753,7 +4753,7 @@ PyInit__curses(void)
     if (m == NULL)
         return NULL;
 #ifdef Py_GIL_DISABLED
-    PyModule_ExperimentalSetGIL(m, Py_MOD_GIL_NOT_USED);
+    PyUnstable_Module_SetGIL(m, Py_MOD_GIL_NOT_USED);
 #endif
 
     /* Add some symbolic constants to the module */

--- a/Modules/_datetimemodule.c
+++ b/Modules/_datetimemodule.c
@@ -6985,7 +6985,7 @@ PyInit__datetime(void)
     if (mod == NULL)
         return NULL;
 #ifdef Py_GIL_DISABLED
-    PyModule_ExperimentalSetGIL(mod, Py_MOD_GIL_NOT_USED);
+    PyUnstable_Module_SetGIL(mod, Py_MOD_GIL_NOT_USED);
 #endif
 
     if (_datetime_exec(mod) < 0) {

--- a/Modules/_testbuffer.c
+++ b/Modules/_testbuffer.c
@@ -2902,7 +2902,7 @@ PyInit__testbuffer(void)
         return NULL;
     }
 #ifdef Py_GIL_DISABLED
-    PyModule_ExperimentalSetGIL(mod, Py_MOD_GIL_NOT_USED);
+    PyUnstable_Module_SetGIL(mod, Py_MOD_GIL_NOT_USED);
 #endif
     if (_testbuffer_exec(mod) < 0) {
         Py_DECREF(mod);

--- a/Modules/_testcapimodule.c
+++ b/Modules/_testcapimodule.c
@@ -3936,7 +3936,7 @@ PyInit__testcapi(void)
     if (m == NULL)
         return NULL;
 #ifdef Py_GIL_DISABLED
-    PyModule_ExperimentalSetGIL(m, Py_MOD_GIL_NOT_USED);
+    PyUnstable_Module_SetGIL(m, Py_MOD_GIL_NOT_USED);
 #endif
 
     Py_SET_TYPE(&_HashInheritanceTester_Type, &PyType_Type);

--- a/Modules/_testclinic.c
+++ b/Modules/_testclinic.c
@@ -1956,7 +1956,7 @@ PyInit__testclinic(void)
         return NULL;
     }
 #ifdef Py_GIL_DISABLED
-    PyModule_ExperimentalSetGIL(m, Py_MOD_GIL_NOT_USED);
+    PyUnstable_Module_SetGIL(m, Py_MOD_GIL_NOT_USED);
 #endif
     if (PyModule_AddType(m, &TestClass) < 0) {
         goto error;

--- a/Modules/_testclinic_limited.c
+++ b/Modules/_testclinic_limited.c
@@ -147,7 +147,7 @@ PyInit__testclinic_limited(void)
         return NULL;
     }
 #ifdef Py_GIL_DISABLED
-    PyModule_ExperimentalSetGIL(m, Py_MOD_GIL_NOT_USED);
+    PyUnstable_Module_SetGIL(m, Py_MOD_GIL_NOT_USED);
 #endif
     return m;
 }

--- a/Modules/_testexternalinspection.c
+++ b/Modules/_testexternalinspection.c
@@ -631,7 +631,7 @@ PyInit__testexternalinspection(void)
         return NULL;
     }
 #ifdef Py_GIL_DISABLED
-    PyModule_ExperimentalSetGIL(mod, Py_MOD_GIL_NOT_USED);
+    PyUnstable_Module_SetGIL(mod, Py_MOD_GIL_NOT_USED);
 #endif
     int rc = PyModule_AddIntConstant(mod, "PROCESS_VM_READV_SUPPORTED", HAVE_PROCESS_VM_READV);
     if (rc < 0) {

--- a/Modules/_testlimitedcapi.c
+++ b/Modules/_testlimitedcapi.c
@@ -26,7 +26,7 @@ PyInit__testlimitedcapi(void)
         return NULL;
     }
 #ifdef Py_GIL_DISABLED
-    PyModule_ExperimentalSetGIL(mod, Py_MOD_GIL_NOT_USED);
+    PyUnstable_Module_SetGIL(mod, Py_MOD_GIL_NOT_USED);
 #endif
 
     if (_PyTestLimitedCAPI_Init_Abstract(mod) < 0) {

--- a/Modules/_testmultiphase.c
+++ b/Modules/_testmultiphase.c
@@ -901,7 +901,7 @@ PyInit__test_module_state_shared(void)
         return NULL;
     }
 #ifdef Py_GIL_DISABLED
-    PyModule_ExperimentalSetGIL(module, Py_MOD_GIL_NOT_USED);
+    PyUnstable_Module_SetGIL(module, Py_MOD_GIL_NOT_USED);
 #endif
 
     if (PyModule_AddObjectRef(module, "Error", PyExc_Exception) < 0) {

--- a/Modules/_testsinglephase.c
+++ b/Modules/_testsinglephase.c
@@ -472,7 +472,7 @@ init__testsinglephase_basic(PyModuleDef *def)
         return NULL;
     }
 #ifdef Py_GIL_DISABLED
-    PyModule_ExperimentalSetGIL(module, Py_MOD_GIL_NOT_USED);
+    PyUnstable_Module_SetGIL(module, Py_MOD_GIL_NOT_USED);
 #endif
 
     module_state *state = &global_state.module;
@@ -566,7 +566,7 @@ PyInit__testsinglephase_with_reinit(void)
         return NULL;
     }
 #ifdef Py_GIL_DISABLED
-    PyModule_ExperimentalSetGIL(module, Py_MOD_GIL_NOT_USED);
+    PyUnstable_Module_SetGIL(module, Py_MOD_GIL_NOT_USED);
 #endif
 
     assert(get_module_state(module) == NULL);
@@ -631,7 +631,7 @@ PyInit__testsinglephase_with_state(void)
         return NULL;
     }
 #ifdef Py_GIL_DISABLED
-    PyModule_ExperimentalSetGIL(module, Py_MOD_GIL_NOT_USED);
+    PyUnstable_Module_SetGIL(module, Py_MOD_GIL_NOT_USED);
 #endif
 
     module_state *state = get_module_state(module);

--- a/Modules/_tkinter.c
+++ b/Modules/_tkinter.c
@@ -3206,7 +3206,7 @@ PyInit__tkinter(void)
     if (m == NULL)
         return NULL;
 #ifdef Py_GIL_DISABLED
-    PyModule_ExperimentalSetGIL(m, Py_MOD_GIL_NOT_USED);
+    PyUnstable_Module_SetGIL(m, Py_MOD_GIL_NOT_USED);
 #endif
 
     Tkinter_TclError = PyErr_NewException("_tkinter.TclError", NULL, NULL);

--- a/Modules/_tracemalloc.c
+++ b/Modules/_tracemalloc.c
@@ -220,7 +220,7 @@ PyInit__tracemalloc(void)
     if (m == NULL)
         return NULL;
 #ifdef Py_GIL_DISABLED
-    PyModule_ExperimentalSetGIL(m, Py_MOD_GIL_NOT_USED);
+    PyUnstable_Module_SetGIL(m, Py_MOD_GIL_NOT_USED);
 #endif
 
     if (_PyTraceMalloc_Init() < 0) {

--- a/Modules/readline.c
+++ b/Modules/readline.c
@@ -1553,7 +1553,7 @@ PyInit_readline(void)
     if (m == NULL)
         return NULL;
 #ifdef Py_GIL_DISABLED
-    PyModule_ExperimentalSetGIL(m, Py_MOD_GIL_NOT_USED);
+    PyUnstable_Module_SetGIL(m, Py_MOD_GIL_NOT_USED);
 #endif
 
     if (PyModule_AddIntConstant(m, "_READLINE_VERSION",

--- a/Objects/moduleobject.c
+++ b/Objects/moduleobject.c
@@ -439,7 +439,7 @@ error:
 
 #ifdef Py_GIL_DISABLED
 int
-PyModule_ExperimentalSetGIL(PyObject *module, void *gil)
+PyUnstable_Module_SetGIL(PyObject *module, void *gil)
 {
     if (!PyModule_Check(module)) {
         PyErr_BadInternalCall();

--- a/Python/bltinmodule.c
+++ b/Python/bltinmodule.c
@@ -3125,7 +3125,7 @@ _PyBuiltin_Init(PyInterpreterState *interp)
     if (mod == NULL)
         return NULL;
 #ifdef Py_GIL_DISABLED
-    PyModule_ExperimentalSetGIL(mod, Py_MOD_GIL_NOT_USED);
+    PyUnstable_Module_SetGIL(mod, Py_MOD_GIL_NOT_USED);
 #endif
     dict = PyModule_GetDict(mod);
 

--- a/Python/sysmodule.c
+++ b/Python/sysmodule.c
@@ -3775,7 +3775,7 @@ _PySys_Create(PyThreadState *tstate, PyObject **sysmod_p)
         return _PyStatus_ERR("failed to create a module object");
     }
 #ifdef Py_GIL_DISABLED
-    PyModule_ExperimentalSetGIL(sysmod, Py_MOD_GIL_NOT_USED);
+    PyUnstable_Module_SetGIL(sysmod, Py_MOD_GIL_NOT_USED);
 #endif
 
     PyObject *sysdict = PyModule_GetDict(sysmod);


### PR DESCRIPTION
The `PyUnstable` prefix has [defined semantics](https://docs.python.org/3/c-api/stable.html#unstable-c-api) and [workflow](https://devguide.python.org/developer-workflow/c-api/#unstable-c-api), and generates a note in the docs:

![image](https://github.com/python/cpython/assets/302922/e450b23d-065e-41b4-b040-f124bffe88c8)


<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-116322 -->
* Issue: gh-116322
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--118645.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->