### PR TITLE
gh-118650: Exclude `_repr_*` methods from Enum's _sunder_ reservation

### DIFF
--- a/Lib/enum.py
+++ b/Lib/enum.py
@@ -365,7 +365,10 @@ class EnumDict(dict):
                     '_generate_next_value_', '_numeric_repr_', '_missing_', '_ignore_',
                     '_iter_member_', '_iter_member_by_value_', '_iter_member_by_def_',
                     '_add_alias_', '_add_value_alias_',
-                    ):
+                    # While not in use internally, those are common for pretty
+                    # printing and thus excluded from Enum's reservation of
+                    # _sunder_ names
+                    ) and not key.startswith('_repr_'):
                 raise ValueError(
                         '_sunder_ names, such as %r, are reserved for future Enum use'
                         % (key, )

--- a/Misc/NEWS.d/next/Library/2024-05-06-16-52-40.gh-issue-118650.qKz5lp.rst
+++ b/Misc/NEWS.d/next/Library/2024-05-06-16-52-40.gh-issue-118650.qKz5lp.rst
@@ -1,0 +1,2 @@
+The ``enum`` module allows method named ``_repr_*`` to be defined on
+``Enum`` types.


### PR DESCRIPTION
This carves out some space of Enum's reserved \_sunder_ names, and allows `_repr_html_`, `_repr_pretty_` and similar methods available in [IPython's pretty printing](https://ipython.readthedocs.io/en/stable/config/integrating.html#rich-display) to be implemented on enums.

Closes: #118650

<!-- gh-issue-number: gh-118650 -->
* Issue: gh-118650
<!-- /gh-issue-number -->
