### PR TITLE
gh-71592: Fix a leak in tkinter.Tk destructor when _debug is true

### DIFF
--- a/Modules/_tkinter.c
+++ b/Modules/_tkinter.c
@@ -2972,6 +2972,7 @@ Tkapp_Dealloc(PyObject *self)
     ENTER_TCL
     Tcl_DeleteInterp(Tkapp_Interp(self));
     LEAVE_TCL
+    Py_XDECREF(((TkappObject *)self)->trace);
     PyObject_Free(self);
     Py_DECREF(tp);
     DisableEventHook();


### PR DESCRIPTION


<!-- gh-issue-number: gh-71592 -->
* Issue: gh-71592
<!-- /gh-issue-number -->
