### PR TITLE
gh-118628: Don't display pyrepl warning on Windows

### DIFF
--- a/Lib/_pyrepl/__main__.py
+++ b/Lib/_pyrepl/__main__.py
@@ -1,7 +1,8 @@
 import os
 import sys
 
-CAN_USE_PYREPL = True
+CAN_USE_PYREPL = sys.platform != "win32"
+
 
 def interactive_console(mainmodule=None, quiet=False, pythonstartup=False):
     global CAN_USE_PYREPL
@@ -21,7 +22,7 @@ def interactive_console(mainmodule=None, quiet=False, pythonstartup=False):
         sys.ps1 = ">>> "
     if not hasattr(sys, "ps2"):
         sys.ps2 = "... "
-    #
+
     run_interactive = None
     try:
         import errno
@@ -36,8 +37,7 @@ def interactive_console(mainmodule=None, quiet=False, pythonstartup=False):
         from .trace import trace
         msg = f"warning: can't use pyrepl: {e}"
         trace(msg)
-        if sys.platform != 'win32':
-            print(msg, file=sys.stderr)
+        print(msg, file=sys.stderr)
         CAN_USE_PYREPL = False
     if run_interactive is None:
         return sys._baserepl()

--- a/Lib/_pyrepl/__main__.py
+++ b/Lib/_pyrepl/__main__.py
@@ -33,7 +33,11 @@ def interactive_console(mainmodule=None, quiet=False, pythonstartup=False):
         from .simple_interact import run_multiline_interactive_console
         run_interactive = run_multiline_interactive_console
     except Exception as e:
-        print(f"warning: can't use pyrepl: {e}", file=sys.stderr)
+        from .trace import trace
+        msg = f"warning: can't use pyrepl: {e}"
+        trace(msg)
+        if sys.platform != 'win32':
+            print(msg, file=sys.stderr)
         CAN_USE_PYREPL = False
     if run_interactive is None:
         return sys._baserepl()


### PR DESCRIPTION
Also, use trace() so the error is logged if a `PYREPL_TRACE` path is specified.

<!-- gh-issue-number: gh-118628 -->
* Issue: gh-118628
<!-- /gh-issue-number -->
