### PR TITLE
gh-118362: Skip tests when threading isn't available

### DIFF
--- a/Lib/test/test_free_threading/test_list.py
+++ b/Lib/test/test_free_threading/test_list.py
@@ -3,7 +3,7 @@ import unittest
 from threading import Thread
 from unittest import TestCase
 
-from test.support import is_wasi
+from test.support import threading_helper
 
 
 class C:
@@ -11,7 +11,7 @@ class C:
         self.v = v
 
 
-@unittest.skipIf(is_wasi, "WASI has no threads.")
+@threading_helper.requires_working_threading()
 class TestList(TestCase):
     def test_racing_iter_append(self):
 

--- a/Lib/test/test_free_threading/test_monitoring.py
+++ b/Lib/test/test_free_threading/test_monitoring.py
@@ -7,7 +7,7 @@ import unittest
 import weakref
 
 from sys import monitoring
-from test.support import is_wasi
+from test.support import threading_helper
 from threading import Thread, _PyRLock
 from unittest import TestCase
 
@@ -87,7 +87,7 @@ class MonitoringTestMixin:
         monitoring.free_tool_id(self.tool_id)
 
 
-@unittest.skipIf(is_wasi, "WASI has no threads.")
+@threading_helper.requires_working_threading()
 class SetPreTraceMultiThreaded(InstrumentationMultiThreadedMixin, TestCase):
     """Sets tracing one time after the threads have started"""
 
@@ -106,7 +106,7 @@ class SetPreTraceMultiThreaded(InstrumentationMultiThreadedMixin, TestCase):
         sys.settrace(self.trace_func)
 
 
-@unittest.skipIf(is_wasi, "WASI has no threads.")
+@threading_helper.requires_working_threading()
 class MonitoringMultiThreaded(
     MonitoringTestMixin, InstrumentationMultiThreadedMixin, TestCase
 ):
@@ -140,7 +140,7 @@ class MonitoringMultiThreaded(
         self.set = not self.set
 
 
-@unittest.skipIf(is_wasi, "WASI has no threads.")
+@threading_helper.requires_working_threading()
 class SetTraceMultiThreaded(InstrumentationMultiThreadedMixin, TestCase):
     """Uses sys.settrace and repeatedly toggles instrumentation on and off"""
 
@@ -166,7 +166,7 @@ class SetTraceMultiThreaded(InstrumentationMultiThreadedMixin, TestCase):
         self.set = not self.set
 
 
-@unittest.skipIf(is_wasi, "WASI has no threads.")
+@threading_helper.requires_working_threading()
 class SetProfileMultiThreaded(InstrumentationMultiThreadedMixin, TestCase):
     """Uses sys.setprofile and repeatedly toggles instrumentation on and off"""
 
@@ -192,7 +192,7 @@ class SetProfileMultiThreaded(InstrumentationMultiThreadedMixin, TestCase):
         self.set = not self.set
 
 
-@unittest.skipIf(is_wasi, "WASI has no threads.")
+@threading_helper.requires_working_threading()
 class MonitoringMisc(MonitoringTestMixin, TestCase):
     def register_callback(self):
         def callback(*args):

--- a/Lib/test/test_free_threading/test_type.py
+++ b/Lib/test/test_free_threading/test_type.py
@@ -1,11 +1,13 @@
 import unittest
 
 from threading import Thread
-from multiprocessing.dummy import Pool
 from unittest import TestCase
 
-from test.support import is_wasi
+from test.support import threading_helper, import_helper
 
+
+multiprocessing_dummy = import_helper.import_module('multiprocessing.dummy')
+Pool = multiprocessing_dummy.Pool
 
 NTHREADS = 6
 BOTTOM = 0
@@ -15,7 +17,7 @@ ITERS = 100
 class A:
     attr = 1
 
-@unittest.skipIf(is_wasi, "WASI has no threads.")
+@threading_helper.requires_working_threading()
 class TestType(TestCase):
     def test_attr_cache(self):
         def read(id0):

--- a/Lib/test/test_free_threading/test_type.py
+++ b/Lib/test/test_free_threading/test_type.py
@@ -1,13 +1,12 @@
 import unittest
 
+from concurrent.futures import ThreadPoolExecutor
 from threading import Thread
 from unittest import TestCase
 
 from test.support import threading_helper, import_helper
 
 
-multiprocessing_dummy = import_helper.import_module('multiprocessing.dummy')
-Pool = multiprocessing_dummy.Pool
 
 NTHREADS = 6
 BOTTOM = 0
@@ -36,11 +35,10 @@ class TestType(TestCase):
                     A.attr = x
 
 
-        with Pool(NTHREADS) as pool:
-            pool.apply_async(read, (1,))
-            pool.apply_async(write, (1,))
-            pool.close()
-            pool.join()
+        with ThreadPoolExecutor(NTHREADS) as pool:
+            pool.submit(read, (1,))
+            pool.submit(write, (1,))
+            pool.shutdown(wait=True)
 
     def test_attr_cache_consistency(self):
         class C:


### PR DESCRIPTION
https://github.com/python/cpython/pull/118454 introduced failures on iOS.  Switches to a more general way of skipping tests when threading isn't available.

<!-- gh-issue-number: gh-118362 -->
* Issue: gh-118362
<!-- /gh-issue-number -->
