### PR TITLE
gh-112075: use per-thread dict version pool

### DIFF
--- a/Include/cpython/pystate.h
+++ b/Include/cpython/pystate.h
@@ -188,6 +188,7 @@ struct _ts {
 
     PyObject *previous_executor;
 
+    uint64_t dict_global_version;
 };
 
 #ifdef Py_DEBUG

--- a/Include/internal/pycore_dict.h
+++ b/Include/internal/pycore_dict.h
@@ -221,8 +221,27 @@ static inline PyDictUnicodeEntry* DK_UNICODE_ENTRIES(PyDictKeysObject *dk) {
 #define DICT_WATCHER_AND_MODIFICATION_MASK ((1 << (DICT_MAX_WATCHERS + DICT_WATCHED_MUTATION_BITS)) - 1)
 
 #ifdef Py_GIL_DISABLED
-#define DICT_NEXT_VERSION(INTERP) \
-    (_Py_atomic_add_uint64(&(INTERP)->dict_state.global_version, DICT_VERSION_INCREMENT) + DICT_VERSION_INCREMENT)
+
+#define THREAD_LOCAL_DICT_VERSION_COUNT 256
+#define THREAD_LOCAL_DICT_VERSION_BATCH THREAD_LOCAL_DICT_VERSION_COUNT * DICT_VERSION_INCREMENT
+
+static inline uint64_t
+dict_next_version(PyInterpreterState *interp)
+{
+    PyThreadState *tstate = PyThreadState_GET();
+    uint64_t cur_progress = (tstate->dict_global_version &
+                            (THREAD_LOCAL_DICT_VERSION_BATCH - 1));
+
+    if (cur_progress == 0) {
+        uint64_t next = _Py_atomic_add_uint64(&interp->dict_state.global_version,
+                                              THREAD_LOCAL_DICT_VERSION_BATCH);
+        tstate->dict_global_version = next + THREAD_LOCAL_DICT_VERSION_BATCH;
+        return next;
+    }
+    return tstate->dict_global_version += DICT_VERSION_INCREMENT;
+}
+
+#define DICT_NEXT_VERSION(INTERP) dict_next_version(INTERP)
 
 #else
 #define DICT_NEXT_VERSION(INTERP) \

--- a/Include/internal/pycore_dict.h
+++ b/Include/internal/pycore_dict.h
@@ -231,12 +231,10 @@ dict_next_version(PyInterpreterState *interp)
     PyThreadState *tstate = PyThreadState_GET();
     uint64_t cur_progress = (tstate->dict_global_version &
                             (THREAD_LOCAL_DICT_VERSION_BATCH - 1));
-
     if (cur_progress == 0) {
         uint64_t next = _Py_atomic_add_uint64(&interp->dict_state.global_version,
                                               THREAD_LOCAL_DICT_VERSION_BATCH);
-        tstate->dict_global_version = next + THREAD_LOCAL_DICT_VERSION_BATCH;
-        return next;
+        tstate->dict_global_version = next;
     }
     return tstate->dict_global_version += DICT_VERSION_INCREMENT;
 }

--- a/Modules/_testcapi/dict.c
+++ b/Modules/_testcapi/dict.c
@@ -1,7 +1,6 @@
 #include "parts.h"
 #include "util.h"
 
-
 static PyObject *
 dict_containsstring(PyObject *self, PyObject *args)
 {
@@ -182,6 +181,18 @@ dict_popstring_null(PyObject *self, PyObject *args)
     RETURN_INT(PyDict_PopString(dict, key,  NULL));
 }
 
+static PyObject *
+dict_version(PyObject *self, PyObject *dict)
+{
+    if (!PyDict_Check(dict)) {
+        PyErr_SetString(PyExc_TypeError, "expected dict");
+        return NULL;
+    }
+_Py_COMP_DIAG_PUSH
+_Py_COMP_DIAG_IGNORE_DEPR_DECLS
+    return PyLong_FromUnsignedLongLong(((PyDictObject *)dict)->ma_version_tag);
+_Py_COMP_DIAG_POP
+}
 
 static PyMethodDef test_methods[] = {
     {"dict_containsstring", dict_containsstring, METH_VARARGS},
@@ -193,6 +204,7 @@ static PyMethodDef test_methods[] = {
     {"dict_pop_null", dict_pop_null, METH_VARARGS},
     {"dict_popstring", dict_popstring, METH_VARARGS},
     {"dict_popstring_null", dict_popstring_null, METH_VARARGS},
+    {"dict_version", dict_version, METH_O},
     {NULL},
 };
 

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -1487,6 +1487,7 @@ init_threadstate(_PyThreadStateImpl *_tstate,
     tstate->datastack_limit = NULL;
     tstate->what_event = -1;
     tstate->previous_executor = NULL;
+    tstate->dict_global_version = 0;
 
     tstate->delete_later = NULL;
 


### PR DESCRIPTION
We want to avoid contention on the dict version.  This moves to using a per-thread pool of 256 dict versions that we can allocate from without hitting the atomic operation for the main thread.

<!-- gh-issue-number: gh-112075 -->
* Issue: gh-112075
<!-- /gh-issue-number -->
