### PR TITLE
gh-118414: Fix yield assertion when tracing

### DIFF
--- a/Lib/test/test_monitoring.py
+++ b/Lib/test/test_monitoring.py
@@ -656,6 +656,17 @@ class LineMonitoringTest(MonitoringTestBase, unittest.TestCase):
 
         self.check_lines(func2, [1,2,3,4,5,6])
 
+    def test_generator_with_line(self):
+
+        def f():
+            def a():
+                yield
+            def b():
+                yield from a()
+            next(b())
+
+        self.check_lines(f, [1,3,5,4,2,4])
+
 class TestDisable(MonitoringTestBase, unittest.TestCase):
 
     def gen(self, cond):

--- a/Misc/NEWS.d/next/Core and Builtins/2024-05-07-01-39-24.gh-issue-118414.G5GG7l.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2024-05-07-01-39-24.gh-issue-118414.G5GG7l.rst
@@ -1,0 +1,1 @@
+Add instrumented opcodes to YIELD_VALUE assertion for tracing cases.

--- a/Python/bytecodes.c
+++ b/Python/bytecodes.c
@@ -1121,7 +1121,9 @@ dummy_func(
             /* We don't know which of these is relevant here, so keep them equal */
             assert(INLINE_CACHE_ENTRIES_SEND == INLINE_CACHE_ENTRIES_FOR_ITER);
             #if TIER_ONE
-            assert(_PyOpcode_Deopt[frame->instr_ptr->op.code] == SEND ||
+            assert(frame->instr_ptr->op.code == INSTRUMENTED_LINE ||
+                   frame->instr_ptr->op.code == INSTRUMENTED_INSTRUCTION ||
+                   _PyOpcode_Deopt[frame->instr_ptr->op.code] == SEND ||
                    _PyOpcode_Deopt[frame->instr_ptr->op.code] == FOR_ITER ||
                    _PyOpcode_Deopt[frame->instr_ptr->op.code] == INTERPRETER_EXIT ||
                    _PyOpcode_Deopt[frame->instr_ptr->op.code] == ENTER_EXECUTOR);

--- a/Python/executor_cases.c.h
+++ b/Python/executor_cases.c.h
@@ -1137,7 +1137,9 @@
             /* We don't know which of these is relevant here, so keep them equal */
             assert(INLINE_CACHE_ENTRIES_SEND == INLINE_CACHE_ENTRIES_FOR_ITER);
             #if TIER_ONE
-            assert(_PyOpcode_Deopt[frame->instr_ptr->op.code] == SEND ||
+            assert(frame->instr_ptr->op.code == INSTRUMENTED_LINE ||
+                   frame->instr_ptr->op.code == INSTRUMENTED_INSTRUCTION ||
+                   _PyOpcode_Deopt[frame->instr_ptr->op.code] == SEND ||
                    _PyOpcode_Deopt[frame->instr_ptr->op.code] == FOR_ITER ||
                    _PyOpcode_Deopt[frame->instr_ptr->op.code] == INTERPRETER_EXIT ||
                    _PyOpcode_Deopt[frame->instr_ptr->op.code] == ENTER_EXECUTOR);

--- a/Python/generated_cases.c.h
+++ b/Python/generated_cases.c.h
@@ -6220,7 +6220,9 @@
             /* We don't know which of these is relevant here, so keep them equal */
             assert(INLINE_CACHE_ENTRIES_SEND == INLINE_CACHE_ENTRIES_FOR_ITER);
             #if TIER_ONE
-            assert(_PyOpcode_Deopt[frame->instr_ptr->op.code] == SEND ||
+            assert(frame->instr_ptr->op.code == INSTRUMENTED_LINE ||
+                   frame->instr_ptr->op.code == INSTRUMENTED_INSTRUCTION ||
+                   _PyOpcode_Deopt[frame->instr_ptr->op.code] == SEND ||
                    _PyOpcode_Deopt[frame->instr_ptr->op.code] == FOR_ITER ||
                    _PyOpcode_Deopt[frame->instr_ptr->op.code] == INTERPRETER_EXIT ||
                    _PyOpcode_Deopt[frame->instr_ptr->op.code] == ENTER_EXECUTOR);


### PR DESCRIPTION
There is an assertion introduced in `YIELD_VALUE` to check the opcode. However, when the line is being traced, the opcode would be `INSTRUMENTED_LINE` or `INSTRUMENTED_INSTRUCTION` and `_PyOpcode_Deopt` won't convert it back.

We can be more precise here to get the exact base opcode of the instruction, but that would probably introduce extra code outside of the assertion (the code object and the index is needed).

I think in this case, adding the two instrumentation opcode is good enough because the assertion is well covered in non-tracing mode.

<!-- gh-issue-number: gh-118414 -->
* Issue: gh-118414
<!-- /gh-issue-number -->
