### PR TITLE
gh-117953: Imply Single-phase Init if the Init Function Fails

### DIFF
--- a/Python/importdl.c
+++ b/Python/importdl.c
@@ -426,6 +426,11 @@ _PyImport_RunModInitFunc(PyModInitFunction p0,
     /* Validate the result (and populate "res". */
 
     if (m == NULL) {
+        /* The init func for multi-phase init modules is expected
+         * to return a PyModuleDef after calling PyModuleDef_Init().
+         * That function never raises an exception nor returns NULL,
+         * so at this point it must be a single-phase init modules. */
+        res.kind = _Py_ext_module_kind_SINGLEPHASE;
         if (PyErr_Occurred()) {
             _Py_ext_module_loader_result_set_error(
                         &res, _Py_ext_module_loader_result_EXCEPTION);
@@ -436,6 +441,8 @@ _PyImport_RunModInitFunc(PyModInitFunction p0,
         }
         goto error;
     } else if (PyErr_Occurred()) {
+        /* Likewise, we infer that this is a single-phase init module. */
+        res.kind = _Py_ext_module_kind_SINGLEPHASE;
         _Py_ext_module_loader_result_set_error(
                 &res, _Py_ext_module_loader_result_ERR_UNREPORTED_EXC);
         /* We would probably be correct to decref m here,


### PR DESCRIPTION
This ensures the kind is always either `_Py_ext_module_kind_SINGLEPHASE` or `_Py_ext_module_kind_MULTIPHASE`.

<!-- gh-issue-number: gh-117953 -->
* Issue: gh-117953
<!-- /gh-issue-number -->
