### PR TITLE
gh-118518: Rename `PYTHONPERFJITSUPPORT` and `-X perfjit` with underscores

### DIFF
--- a/Doc/c-api/init_config.rst
+++ b/Doc/c-api/init_config.rst
@@ -1250,10 +1250,10 @@ PyConfig
       If non-zero, initialize the perf trampoline. See :ref:`perf_profiling`
       for more information.
 
-      Set by :option:`-X perf <-X>` command line option and by the
-      :envvar:`PYTHONPERFSUPPORT` environment variable for perf support
-      with stack pointers and :option:`-X perfjit <-X>` command line option
-      and by the :envvar:`PYTHONPERFJITSUPPORT` environment variable for perf
+      Set by :option:`-X perf <-X>` command-line option and by the
+      :envvar:`PYTHON_PERF_JIT_SUPPORT` environment variable for perf support
+      with stack pointers and :option:`-X perfjit <-X>` command-line option
+      and by the :envvar:`PYTHON_PERF_JIT_SUPPORT` environment variable for perf
       support with DWARF JIT information.
 
       Default: ``-1``.

--- a/Doc/c-api/init_config.rst
+++ b/Doc/c-api/init_config.rst
@@ -1252,7 +1252,7 @@ PyConfig
 
       Set by :option:`-X perf <-X>` command-line option and by the
       :envvar:`PYTHON_PERF_JIT_SUPPORT` environment variable for perf support
-      with stack pointers and :option:`-X perfjit <-X>` command-line option
+      with stack pointers and :option:`-X perf_jit <-X>` command-line option
       and by the :envvar:`PYTHON_PERF_JIT_SUPPORT` environment variable for perf
       support with DWARF JIT information.
 

--- a/Doc/howto/perf_profiling.rst
+++ b/Doc/howto/perf_profiling.rst
@@ -217,12 +217,12 @@ needs to generate unwinding information for every Python function call on the fl
 information to unwind the stack and this is a slow process.
 
 To enable this mode, you can use the environment variable :envvar:`PYTHON_PERF_JIT_SUPPORT` or the
-:option:`-X perfjit <-X>` option, which will enable the JIT mode for the ``perf`` profiler.
+:option:`-X perf_jit <-X>` option, which will enable the JIT mode for the ``perf`` profiler.
 
 When using the perf JIT mode, you need an extra step before you can run ``perf report``. You need to
 call the ``perf inject`` command to inject the JIT information into the ``perf.data`` file.
 
-    $ perf record -F 9999 -g --call-graph dwarf -o perf.data python -Xperfjit my_script.py
+    $ perf record -F 9999 -g --call-graph dwarf -o perf.data python -Xperf_jit my_script.py
     $ perf inject -i perf.data --jit
     $ perf report -g -i perf.data
 

--- a/Doc/howto/perf_profiling.rst
+++ b/Doc/howto/perf_profiling.rst
@@ -216,7 +216,7 @@ needs to generate unwinding information for every Python function call on the fl
 ``perf`` will take more time to process the data because it will need to use the DWARF debugging
 information to unwind the stack and this is a slow process.
 
-To enable this mode, you can use the environment variable :envvar:`PYTHONPERFJITSUPPORT` or the
+To enable this mode, you can use the environment variable :envvar:`PYTHON_PERF_JIT_SUPPORT` or the
 :option:`-X perfjit <-X>` option, which will enable the JIT mode for the ``perf`` profiler.
 
 When using the perf JIT mode, you need an extra step before you can run ``perf report``. You need to
@@ -228,7 +228,7 @@ call the ``perf inject`` command to inject the JIT information into the ``perf.d
 
 or using the environment variable::
 
-    $ PYTHONPERFJITSUPPORT=1 perf record -F 9999 -g --call-graph dwarf -o perf.data python my_script.py
+    $ PYTHON_PERF_JIT_SUPPORT=1 perf record -F 9999 -g --call-graph dwarf -o perf.data python my_script.py
     $ perf inject -i perf.data --jit
     $ perf report -g -i perf.data
 

--- a/Doc/using/cmdline.rst
+++ b/Doc/using/cmdline.rst
@@ -589,9 +589,9 @@ Miscellaneous options
 
    * ``-X perfjit`` enables support for the Linux ``perf`` profiler with DWARF
      support. When this option is provided, the ``perf`` profiler will be able
-     to report Python calls using DWARF ifnormation. This option is only available on
+     to report Python calls using DWARF information. This option is only available on
      some platforms and will do nothing if is not supported on the current
-     system. The default value is "off". See also :envvar:`PYTHONPERFJITSUPPORT`
+     system. The default value is "off". See also :envvar:`PYTHON_PERF_JIT_SUPPORT`
      and :ref:`perf_profiling`.
 
      .. versionadded:: 3.13
@@ -1137,7 +1137,7 @@ conflict.
 
    .. versionadded:: 3.12
 
-.. envvar:: PYTHONPERFJITSUPPORT
+.. envvar:: PYTHON_PERF_JIT_SUPPORT
 
    If this variable is set to a nonzero value, it enables support for
    the Linux ``perf`` profiler so Python calls can be detected by it

--- a/Doc/using/cmdline.rst
+++ b/Doc/using/cmdline.rst
@@ -587,7 +587,7 @@ Miscellaneous options
 
      .. versionadded:: 3.12
 
-   * ``-X perfjit`` enables support for the Linux ``perf`` profiler with DWARF
+   * ``-X perf_jit`` enables support for the Linux ``perf`` profiler with DWARF
      support. When this option is provided, the ``perf`` profiler will be able
      to report Python calls using DWARF information. This option is only available on
      some platforms and will do nothing if is not supported on the current
@@ -1145,7 +1145,7 @@ conflict.
 
    If set to ``0``, disable Linux ``perf`` profiler support.
 
-   See also the :option:`-X perfjit <-X>` command-line option
+   See also the :option:`-X perf_jit <-X>` command-line option
    and :ref:`perf_profiling`.
 
    .. versionadded:: 3.13

--- a/Doc/whatsnew/3.13.rst
+++ b/Doc/whatsnew/3.13.rst
@@ -272,7 +272,7 @@ Other Language Changes
 
 * Add :ref:`support for the perf profiler <perf_profiling>` working without
   frame pointers through the new environment variable
-  :envvar:`PYTHONPERFJITSUPPORT` and command-line option :option:`-X perfjit
+  :envvar:`PYTHON_PERF_JIT_SUPPORT` and command-line option :option:`-X perfjit
   <-X>` (Contributed by Pablo Galindo in :gh:`118518`.)
 
 * The new :envvar:`PYTHON_HISTORY` environment variable can be used to change

--- a/Doc/whatsnew/3.13.rst
+++ b/Doc/whatsnew/3.13.rst
@@ -272,7 +272,7 @@ Other Language Changes
 
 * Add :ref:`support for the perf profiler <perf_profiling>` working without
   frame pointers through the new environment variable
-  :envvar:`PYTHON_PERF_JIT_SUPPORT` and command-line option :option:`-X perfjit
+  :envvar:`PYTHON_PERF_JIT_SUPPORT` and command-line option :option:`-X perf_jit
   <-X>` (Contributed by Pablo Galindo in :gh:`118518`.)
 
 * The new :envvar:`PYTHON_HISTORY` environment variable can be used to change

--- a/Lib/test/test_perf_profiler.py
+++ b/Lib/test/test_perf_profiler.py
@@ -494,7 +494,7 @@ class TestPerfProfilerWithDwarf(unittest.TestCase, TestPerfProfilerMixin):
     def run_perf(self, script_dir, script, activate_trampoline=True):
         if activate_trampoline:
             return run_perf(
-                script_dir, sys.executable, "-Xperfjit", script, use_jit=True
+                script_dir, sys.executable, "-Xperf_jit", script, use_jit=True
             )
         return run_perf(script_dir, sys.executable, script, use_jit=True)
 

--- a/Misc/NEWS.d/next/Core and Builtins/2024-05-02-20-32-42.gh-issue-118518.m-JbTi.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2024-05-02-20-32-42.gh-issue-118518.m-JbTi.rst
@@ -1,4 +1,4 @@
 Allow the Linux perf support to work without frame pointers using perf's
 advanced JIT support. The feature is activated when using the
-``PYTHONPERFJITSUPPORT`` environment variable or when running Python with
-``-Xperfjit``. Patch by Pablo Galindo
+``PYTHON_PERF_JIT_SUPPORT`` environment variable or when running Python with
+``-Xperfjit``. Patch by Pablo Galindo.

--- a/Misc/NEWS.d/next/Core and Builtins/2024-05-02-20-32-42.gh-issue-118518.m-JbTi.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2024-05-02-20-32-42.gh-issue-118518.m-JbTi.rst
@@ -1,4 +1,4 @@
 Allow the Linux perf support to work without frame pointers using perf's
 advanced JIT support. The feature is activated when using the
 ``PYTHON_PERF_JIT_SUPPORT`` environment variable or when running Python with
-``-Xperfjit``. Patch by Pablo Galindo.
+``-Xperf_jit``. Patch by Pablo Galindo.

--- a/Python/initconfig.c
+++ b/Python/initconfig.c
@@ -1703,7 +1703,7 @@ config_init_perf_profiling(PyConfig *config)
     if (xoption) {
         config->perf_profiling = 1;
     }
-    env = config_get_env(config, "PYTHONPERFJITSUPPORT");
+    env = config_get_env(config, "PYTHON_PERF_JIT_SUPPORT");
     if (env) {
         if (_Py_str_to_int(env, &active) != 0) {
             active = 0;

--- a/Python/initconfig.c
+++ b/Python/initconfig.c
@@ -1712,7 +1712,7 @@ config_init_perf_profiling(PyConfig *config)
             config->perf_profiling = 2;
         }
     }
-    xoption = config_get_xoption(config, L"perfjit");
+    xoption = config_get_xoption(config, L"perf_jit");
     if (xoption) {
         config->perf_profiling = 2;
     }

--- a/Python/sysmodule.c
+++ b/Python/sysmodule.c
@@ -2294,7 +2294,7 @@ sys_activate_stack_trampoline_impl(PyObject *module, const char *backend)
                 return NULL;
             }
         }
-        else if (strcmp(backend, "perfjit") == 0) {
+        else if (strcmp(backend, "perf_jit") == 0) {
             _PyPerf_Callbacks cur_cb;
             _PyPerfTrampoline_GetCallbacks(&cur_cb);
             if (cur_cb.write_state != _Py_perfmap_jit_callbacks.write_state) {


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

This PR renames:

* env var `PYTHONPERFJITSUPPORT` -> `PYTHON_PERF_JIT_SUPPORT`
* `-X perfjit` -> `-X perf_jit`

From Python 3.13, new environment variables should use underscores:

* https://devguide.python.org/developer-workflow/stdlib/#adding-a-new-environment-variable
* https://discuss.python.org/t/change-environment-variable-style/35180

I don't think we have a policy for `-X` options, and we have a mix (I think newer ones tend to use underscores?), but I recommend using an underscore here too for the same accessibility and readability reasons as env vars. Plus consistency with the env var.

For example, we added `PYTHON_CPU_COUNT` and `-X cpu_count` in 3.13.

cc @pablogsal

<!-- gh-issue-number: gh-118518 -->
* Issue: gh-118518
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--118693.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->