### PR TITLE
gh-118418: Deprecate failing to pass a value to the *type_params* parameter of some private `typing` APIs

### DIFF
--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -6308,6 +6308,31 @@ class ForwardRefTests(BaseTestCase):
         self.assertEqual(X | "x", Union[X, "x"])
         self.assertEqual("x" | X, Union["x", X])
 
+    def test_deprecation_for_no_type_params_passed_to__evaluate(self):
+        with self.assertWarnsRegex(
+            DeprecationWarning,
+            (
+                "Failing to pass a value to the `type_params` parameter "
+                "of 'typing._eval_type' is deprecated"
+            )
+        ) as cm:
+            self.assertEqual(typing._eval_type(list["int"], globals(), {}), list[int])
+
+        self.assertEqual(cm.filename, __file__)
+
+        f = ForwardRef("int")
+
+        with self.assertWarnsRegex(
+            DeprecationWarning,
+            (
+                "Failing to pass a value to the `type_params` parameter "
+                "of 'typing.ForwardRef._evaluate' is deprecated"
+            )
+        ) as cm:
+            self.assertIs(f._evaluate(globals(), {}, recursive_guard=frozenset()), int)
+
+        self.assertEqual(cm.filename, __file__)
+
 
 @lru_cache()
 def cached_func(x, y):

--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -6312,7 +6312,7 @@ class ForwardRefTests(BaseTestCase):
         with self.assertWarnsRegex(
             DeprecationWarning,
             (
-                "Failing to pass a value to the `type_params` parameter "
+                "Failing to pass a value to the 'type_params' parameter "
                 "of 'typing._eval_type' is deprecated"
             )
         ) as cm:
@@ -6325,7 +6325,7 @@ class ForwardRefTests(BaseTestCase):
         with self.assertWarnsRegex(
             DeprecationWarning,
             (
-                "Failing to pass a value to the `type_params` parameter "
+                "Failing to pass a value to the 'type_params' parameter "
                 "of 'typing.ForwardRef._evaluate' is deprecated"
             )
         ) as cm:

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -444,7 +444,7 @@ def _deprecation_warning_for_no_type_params_passed(funcname: str) -> None:
         f"Failing to pass a value to the 'type_params' parameter "
         f"of {funcname!r} is deprecated, as it leads to incorrect behaviour "
         f"when calling {funcname} on a stringified annotation "
-        f"that references a PEP-695 type parameter. "
+        f"that references a PEP 695 type parameter. "
         f"It will be disallowed in Python 3.15."
     )
     warnings.warn(depr_message, category=DeprecationWarning, stacklevel=3)

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -437,13 +437,38 @@ def _tp_cache(func=None, /, *, typed=False):
     return decorator
 
 
-def _eval_type(t, globalns, localns, type_params=None, *, recursive_guard=frozenset()):
+def _deprecation_warning_for_no_type_params_passed(funcname: str) -> None:
+    import warnings
+
+    depr_message = (
+        f"Failing to pass a value to the `type_params` parameter "
+        f"of {funcname!r} is deprecated, as it leads to incorrect behaviour "
+        f"when calling {funcname} on a stringified annotation "
+        f"that references a PEP-695 type parameter. "
+        f"It will be disallowed in Python 3.15."
+    )
+    warnings.warn(depr_message, category=DeprecationWarning, stacklevel=3)
+
+
+class _Sentinel:
+    __slots__ = ()
+    def __repr__(self):
+        return '<sentinel>'
+
+
+_sentinel = _Sentinel()
+
+
+def _eval_type(t, globalns, localns, type_params=_sentinel, *, recursive_guard=frozenset()):
     """Evaluate all forward references in the given type t.
 
     For use of globalns and localns see the docstring for get_type_hints().
     recursive_guard is used to prevent infinite recursion with a recursive
     ForwardRef.
     """
+    if type_params is _sentinel:
+        _deprecation_warning_for_no_type_params_passed("typing._eval_type")
+        type_params = ()
     if isinstance(t, ForwardRef):
         return t._evaluate(globalns, localns, type_params, recursive_guard=recursive_guard)
     if isinstance(t, (_GenericAlias, GenericAlias, types.UnionType)):
@@ -1018,7 +1043,10 @@ class ForwardRef(_Final, _root=True):
         self.__forward_is_class__ = is_class
         self.__forward_module__ = module
 
-    def _evaluate(self, globalns, localns, type_params=None, *, recursive_guard):
+    def _evaluate(self, globalns, localns, type_params=_sentinel, *, recursive_guard):
+        if type_params is _sentinel:
+            _deprecation_warning_for_no_type_params_passed("typing.ForwardRef._evaluate")
+            type_params = ()
         if self.__forward_arg__ in recursive_guard:
             return self
         if not self.__forward_evaluated__ or localns is not globalns:
@@ -2996,15 +3024,6 @@ class NamedTupleMeta(type):
         if Generic in bases:
             nm_tpl.__init_subclass__()
         return nm_tpl
-
-
-class _Sentinel:
-    __slots__ = ()
-    def __repr__(self):
-        return '<sentinel>'
-
-
-_sentinel = _Sentinel()
 
 
 def NamedTuple(typename, fields=_sentinel, /, **kwargs):

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -441,7 +441,7 @@ def _deprecation_warning_for_no_type_params_passed(funcname: str) -> None:
     import warnings
 
     depr_message = (
-        f"Failing to pass a value to the `type_params` parameter "
+        f"Failing to pass a value to the 'type_params' parameter "
         f"of {funcname!r} is deprecated, as it leads to incorrect behaviour "
         f"when calling {funcname} on a stringified annotation "
         f"that references a PEP-695 type parameter. "

--- a/Misc/NEWS.d/next/Library/2024-05-07-11-23-11.gh-issue-118418.QPMdJm.rst
+++ b/Misc/NEWS.d/next/Library/2024-05-07-11-23-11.gh-issue-118418.QPMdJm.rst
@@ -1,0 +1,6 @@
+A :exc:`DeprecationWarning` is now emitted if you fail to pass a value to
+the new *type_params* parameter of ``typing._eval_type()`` or
+``typing.ForwardRef._evaluate()``. (Using either of these private and
+undocumented functions is discouraged to begin with, but failing to pass a
+value to the ``type_params`` parameter may lead to incorrect behaviour on
+Python 3.12 or newer.)


### PR DESCRIPTION
These are undocumented, private functions, but there's unfortunately widespread usage of them in third-party libraries. Even if we provide a new public API for people to use in Python 3.14, it will take a while for third-party libraries to migrate to the new API. In the meantime, they may get incorrect behaviour if they fail to pass in a value to the *type_params* parameter. So let's warn them about that.

Closes https://github.com/python/cpython/issues/118418

<!-- gh-issue-number: gh-118418 -->
* Issue: gh-118418
<!-- /gh-issue-number -->
