### PR TITLE
gh-109653: What's new: Note improved import times for several stdlib modules in Python 3.13

### DIFF
--- a/Doc/whatsnew/3.13.rst
+++ b/Doc/whatsnew/3.13.rst
@@ -999,6 +999,12 @@ Optimizations
   section above for details.
   (Contributed by Jakub Kulik in :gh:`113117`.)
 
+* Several standard library modules have had their import times significantly
+  improved. The improved modules include :mod:`typing`, :mod:`importlib.metadata`,
+  :mod:`email.utils`, :mod:`functools` and :mod:`enum`.
+  (Contributed by Alex Waygood, Shantanu Jain, Adam Turner, Daniel Hollas and
+  others in :gh:`109653`.)
+
 .. _whatsnew313-jit-compiler:
 
 Experimental JIT Compiler

--- a/Doc/whatsnew/3.13.rst
+++ b/Doc/whatsnew/3.13.rst
@@ -1000,8 +1000,11 @@ Optimizations
   (Contributed by Jakub Kulik in :gh:`113117`.)
 
 * Several standard library modules have had their import times significantly
-  improved. The improved modules include :mod:`typing`, :mod:`importlib.metadata`,
-  :mod:`email.utils`, :mod:`functools` and :mod:`enum`.
+  improved. For example, the import time of the :mod:`typing` module has been
+  reduced by around a third by removing dependencies on :mod:`re` and
+  :mod:`contextlib`. Other modules to enjoy import-time speedups include
+  :mod:`importlib.metadata`, :mod:`threading`, :mod:`enum`, :mod:`functools`
+  and :mod:`email.utils`.
   (Contributed by Alex Waygood, Shantanu Jain, Adam Turner, Daniel Hollas and
   others in :gh:`109653`.)
 


### PR DESCRIPTION
Closes #109653

<!-- gh-issue-number: gh-109653 -->
* Issue: gh-109653
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--118697.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->