### PR TITLE
gh-118650: Document `Enum._repr_*` reservation exclusion

### DIFF
--- a/Doc/library/enum.rst
+++ b/Doc/library/enum.rst
@@ -859,9 +859,15 @@ Supported ``_sunder_`` names
      For :class:`Flag` classes the next value chosen will be the next highest
      power-of-two.
 
+- While ``_sunder_`` names are generally reserved for the further development
+  of the :class:`Enum` class and can not be used, some are explicitly allowed:
+
+  - ``_repr_*`` (e.g. ``_repr_html_``), as used in `IPython's rich display`_
+
 .. versionadded:: 3.6 ``_missing_``, ``_order_``, ``_generate_next_value_``
 .. versionadded:: 3.7 ``_ignore_``
-.. versionadded:: 3.13 ``_add_alias_``, ``_add_value_alias_``
+.. versionadded:: 3.13 ``_add_alias_``, ``_add_value_alias_``, ``_repr_*``
+.. _`IPython's rich display`: https://ipython.readthedocs.io/en/stable/config/integrating.html#rich-display
 
 ---------------
 


### PR DESCRIPTION
This is a follow-up on #118651 and still pertains to #118650: As @terryjreedy pointed out in https://github.com/python/cpython/issues/118650#issuecomment-2096844890, the exception is not even documented (but is there, see the #118651 diff for where it is enforced); this documents the `_repr_*` exclusion introduced in #118651 and by doing so also documents the larger reservation.

CC'ing @encukou as reviewer of the former. I think this warrants the "skip news" label, as the news of the new reservation exclusion should imply that it is documented.

<!-- gh-issue-number: gh-118650 -->
* Issue: gh-118650
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--118698.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->