### PR TITLE
gh-109975: Make a rough editorial pass over What's New

### DIFF
--- a/Doc/whatsnew/3.13.rst
+++ b/Doc/whatsnew/3.13.rst
@@ -107,6 +107,9 @@ New typing features:
 * :pep:`742`: :data:`typing.TypeIs` was added, providing more intuitive
   type narrowing behavior.
 
+* :pep:`705`: :data:`typing.ReadOnly` was added, to mark an item of a
+  :class:`typing.TypedDict` as read-only for type checkers.
+
 Free-threading:
 
 * :pep:`703`: CPython 3.13 has experimental support for running with the
@@ -118,7 +121,7 @@ Platform support:
 * :pep:`730`: Apple's iOS is now an officially supported platform. Official
   Android support (:pep:`738`) is in the works as well.
 
-Important deprecations, removals or restrictions:
+Removed modules:
 
 * :ref:`PEP 594 <whatsnew313-pep594>`: The remaining 19 "dead batteries"
   have been removed from the standard library:
@@ -126,6 +129,11 @@ Important deprecations, removals or restrictions:
   :mod:`!crypt`, :mod:`!imghdr`, :mod:`!mailcap`, :mod:`!msilib`, :mod:`!nis`,
   :mod:`!nntplib`, :mod:`!ossaudiodev`, :mod:`!pipes`, :mod:`!sndhdr`, :mod:`!spwd`,
   :mod:`!sunau`, :mod:`!telnetlib`, :mod:`!uu` and :mod:`!xdrlib`.
+
+* Also removed were the :mod:`!tkinter.tix` and :mod:`!lib2to3` modules, and the
+  ``2to3`` program.
+
+Release schedule changes:
 
 * :pep:`602` ("Annual Release Cycle for Python") has been updated:
 
@@ -290,7 +298,7 @@ The internal architecture is roughly as follows.
 * When the JIT is enabled, the optimized
   Tier 2 IR is translated to machine code, which is then executed.
 
-* The machine code translation process uses an architecture called
+* The machine code translation process uses a technique called
   *copy-and-patch*. It has no runtime dependencies, but there is a new
   build-time dependency on LLVM.
 
@@ -338,27 +346,26 @@ designed with threading in mind will run faster on multicore hardware.
 Work is still ongoing: expect some bugs and a substantial single-threaded
 performance hit.
 
-The free-threaded build still supports optionally running with GIL enabled at
-runtime using the environment variable :envvar:`PYTHON_GIL` or the command line
-option :option:`-X gil`.
+The free-threaded build still supports optionally running with the GIL
+enabled at runtime using the environment variable :envvar:`PYTHON_GIL` or
+the command line option :option:`-X gil`.
 
-* Use :func:`!sys._is_gil_enabled` to determine if the :term:`GIL` is enabled.
+To check if the current interpreter is configured with ``--disable-gil``,
+use ``sysconfig.get_config_var("Py_GIL_DISABLED")``. To check if the :term:`GIL`
+is actually disabled in the running process, the :func:`!sys._is_gil_enabled`
+function can be used.
 
-* Use ``sysconfig.get_config_var("Py_GIL_DISABLED")`` to identify CPython
-  builds configured with ``--disable-gil``.
+C-API extension modules need to be built specifically for the free-threaded
+build. Extensions that support running with the :term:`GIL` disabled should
+use the :c:data:`Py_mod_gil` slot. Extensions using single-phase init should
+use :c:func:`PyUnstable_Module_SetGIL` to indicate whether they support
+running with the GIL disabled. Importing C extensions that don't use these
+mechanisms will cause the GIL to be enabled, unless the GIL was explicitly
+disabled with the :envvar:`PYTHON_GIL` environment variable or the
+:option:`-X gil=0` option.
 
-C-API extensions need to be built specifically for the free-threaded build.
-
-* Extensions that support running with the :term:`GIL` disabled should use
-  the :c:data:`Py_mod_gil` slot. Extensions using single-phase init should use
-  :c:func:`PyUnstable_Module_SetGIL` to indicate whether they support running
-  with the GIL disabled. Importing C extensions that don't use these mechanisms
-  will cause the GIL to be enabled unless the GIL was explicitly disabled with
-  the :envvar:`PYTHON_GIL` environment variable or the :option:`-X gil=0`
-  option.
-
-* pip 24.1b1 or newer is required to install packages with C extensions in the
-  free-threaded build.
+pip 24.1b1 or newer is required to install packages with C extensions in the
+free-threaded build.
 
 Other Language Changes
 ======================
@@ -1335,7 +1342,7 @@ typing
 unittest
 --------
 
-* Removed the following :mod:`unittest` functions, deprecated in Python 3.11:
+* Remove the following :mod:`unittest` functions, deprecated in Python 3.11:
 
   * :func:`!unittest.findTestCases`
   * :func:`!unittest.makeSuite`
@@ -1357,10 +1364,10 @@ urllib
 ------
 
 * Remove *cafile*, *capath* and *cadefault* parameters of the
-  :func:`urllib.request.urlopen` function, deprecated in Python 3.6: use the
-  *context* parameter instead. Please use
-  :meth:`ssl.SSLContext.load_cert_chain` instead, or let
-  :func:`ssl.create_default_context` select the system's trusted CA
+  :func:`urllib.request.urlopen` function, deprecated in Python 3.6: pass
+  the *context* parameter instead. Use
+  :meth:`ssl.SSLContext.load_cert_chain` to load specific certificates, or
+  let :func:`ssl.create_default_context` select the system's trusted CA
   certificates for you.
   (Contributed by Victor Stinner in :gh:`105382`.)
 
@@ -1848,6 +1855,7 @@ although there is currently no date scheduled for their removal.
 * :meth:`zipimport.zipimporter.load_module` is deprecated:
   use :meth:`~zipimport.zipimporter.exec_module` instead.
 
+
 CPython Bytecode Changes
 ========================
 
@@ -1856,46 +1864,6 @@ CPython Bytecode Changes
   changed to add a bit indicating whether the except-depth is 1, which
   is needed to optimize closing of generators.
   (Contributed by Irit Katriel in :gh:`111354`.)
-
-Build Changes
-=============
-
-* The :file:`configure` option :option:`--with-system-libmpdec` now defaults
-  to ``yes``. The bundled copy of ``libmpdecimal`` will be removed in Python
-  3.15.
-
-* Autoconf 2.71 and aclocal 1.16.4 are now required to regenerate
-  the :file:`configure` script.
-  (Contributed by Christian Heimes in :gh:`89886`.)
-
-* SQLite 3.15.2 or newer is required to build the :mod:`sqlite3` extension module.
-  (Contributed by Erlend Aasland in :gh:`105875`.)
-
-* Python built with :file:`configure` :option:`--with-trace-refs` (tracing
-  references) is now ABI compatible with the Python release build and
-  :ref:`debug build <debug-build>`.
-  (Contributed by Victor Stinner in :gh:`108634`.)
-
-* Building CPython now requires a compiler with support for the C11 atomic
-  library, GCC built-in atomic functions, or MSVC interlocked intrinsics.
-
-* The ``errno``, ``fcntl``, ``grp``, ``md5``, ``pwd``, ``resource``,
-  ``termios``, ``winsound``,
-  ``_ctypes_test``, ``_multiprocessing.posixshmem``, ``_scproxy``, ``_stat``,
-  ``_statistics``, ``_testconsole``, ``_testimportmultiple`` and ``_uuid``
-  C extensions are now built with the :ref:`limited C API <limited-c-api>`.
-  (Contributed by Victor Stinner in :gh:`85283`.)
-
-* ``wasm32-wasi`` is now a :pep:`11` tier 2 platform.
-  (Contributed by Brett Cannon in :gh:`115192`.)
-
-* ``wasm32-emscripten`` is no longer a :pep:`11` supported platform.
-  (Contributed by Brett Cannon in :gh:`115192`.)
-
-* Python now bundles the `mimalloc library <https://github.com/microsoft/mimalloc>`__.
-  It is licensed under the MIT license, see :ref:`mimalloc license <mimalloc-license>`.
-  The bundled mimalloc has custom changes, see :gh:`113141` for details.
-  (Contributed by Dino Viehland in :gh:`109914`.)
 
 
 C API Changes
@@ -2114,6 +2082,47 @@ New Features
   by Pablo Galindo in :gh:`93502`.)
 
 
+Build Changes
+=============
+
+* The :file:`configure` option :option:`--with-system-libmpdec` now defaults
+  to ``yes``. The bundled copy of ``libmpdecimal`` will be removed in Python
+  3.15.
+
+* Autoconf 2.71 and aclocal 1.16.4 are now required to regenerate
+  the :file:`configure` script.
+  (Contributed by Christian Heimes in :gh:`89886`.)
+
+* SQLite 3.15.2 or newer is required to build the :mod:`sqlite3` extension module.
+  (Contributed by Erlend Aasland in :gh:`105875`.)
+
+* Python built with :file:`configure` :option:`--with-trace-refs` (tracing
+  references) is now ABI compatible with the Python release build and
+  :ref:`debug build <debug-build>`.
+  (Contributed by Victor Stinner in :gh:`108634`.)
+
+* Building CPython now requires a compiler with support for the C11 atomic
+  library, GCC built-in atomic functions, or MSVC interlocked intrinsics.
+
+* The ``errno``, ``fcntl``, ``grp``, ``md5``, ``pwd``, ``resource``,
+  ``termios``, ``winsound``,
+  ``_ctypes_test``, ``_multiprocessing.posixshmem``, ``_scproxy``, ``_stat``,
+  ``_statistics``, ``_testconsole``, ``_testimportmultiple`` and ``_uuid``
+  C extensions are now built with the :ref:`limited C API <limited-c-api>`.
+  (Contributed by Victor Stinner in :gh:`85283`.)
+
+* ``wasm32-wasi`` is now a :pep:`11` tier 2 platform.
+  (Contributed by Brett Cannon in :gh:`115192`.)
+
+* ``wasm32-emscripten`` is no longer a :pep:`11` supported platform.
+  (Contributed by Brett Cannon in :gh:`115192`.)
+
+* Python now bundles the `mimalloc library <https://github.com/microsoft/mimalloc>`__.
+  It is licensed under the MIT license; see :ref:`mimalloc license <mimalloc-license>`.
+  The bundled mimalloc has custom changes, see :gh:`113141` for details.
+  (Contributed by Dino Viehland in :gh:`109914`.)
+
+
 Porting to Python 3.13
 ======================
 
@@ -2129,7 +2138,7 @@ Changes in the Python API
 
 * The :mod:`threading` module now expects the :mod:`!_thread` module to have
   an ``_is_main_interpreter`` attribute.  It is a function with no
-  arguments that return ``True`` if the current interpreter is the
+  arguments that returns ``True`` if the current interpreter is the
   main interpreter.
 
   Any library or application that provides a custom ``_thread`` module

--- a/Doc/whatsnew/3.13.rst
+++ b/Doc/whatsnew/3.13.rst
@@ -2235,42 +2235,6 @@ Changes in the C API
   to :c:func:`PyUnstable_Code_GetFirstFree`.
   (Contributed by Bogdan Romanyuk in :gh:`115781`.)
 
-Deprecated C APIs
------------------
-
-* Deprecate the old ``Py_UNICODE`` and ``PY_UNICODE_TYPE`` types: use directly
-  the :c:type:`wchar_t` type instead. Since Python 3.3, ``Py_UNICODE`` and
-  ``PY_UNICODE_TYPE`` are just aliases to :c:type:`wchar_t`.
-  (Contributed by Victor Stinner in :gh:`105156`.)
-
-* Deprecate old Python initialization functions:
-
-  * :c:func:`PySys_ResetWarnOptions`:
-    clear :data:`sys.warnoptions` and :data:`!warnings.filters` instead.
-  * :c:func:`Py_GetExecPrefix`: get :data:`sys.exec_prefix` instead.
-  * :c:func:`Py_GetPath`: get :data:`sys.path` instead.
-  * :c:func:`Py_GetPrefix`: get :data:`sys.prefix` instead.
-  * :c:func:`Py_GetProgramFullPath`: get :data:`sys.executable` instead.
-  * :c:func:`Py_GetProgramName`: get :data:`sys.executable` instead.
-  * :c:func:`Py_GetPythonHome`: get :c:member:`PyConfig.home` or
-    :envvar:`PYTHONHOME` environment variable instead.
-
-  Functions scheduled for removal in Python 3.15.
-  (Contributed by Victor Stinner in :gh:`105145`.)
-
-* Deprecate the :c:func:`PyImport_ImportModuleNoBlock` function which is just
-  an alias to :c:func:`PyImport_ImportModule` since Python 3.3.
-  Scheduled for removal in Python 3.15.
-  (Contributed by Victor Stinner in :gh:`105396`.)
-
-* Deprecate the :c:func:`PyWeakref_GetObject` and
-  :c:func:`PyWeakref_GET_OBJECT` functions, which return a :term:`borrowed
-  reference`: use the new :c:func:`PyWeakref_GetRef` function instead, it
-  returns a :term:`strong reference`. The `pythoncapi-compat project
-  <https://github.com/python/pythoncapi-compat/>`__ can be used to get
-  :c:func:`PyWeakref_GetRef` on Python 3.12 and older.
-  (Contributed by Victor Stinner in :gh:`105927`.)
-
 Removed C APIs
 --------------
 
@@ -2387,6 +2351,42 @@ Removed C APIs
   :c:func:`PyModule_Add` or :c:func:`PyModule_AddObjectRef` functions should
   be used instead.
   (Contributed by Serhiy Storchaka in :gh:`86493`.)
+
+Deprecated C APIs
+-----------------
+
+* Deprecate the old ``Py_UNICODE`` and ``PY_UNICODE_TYPE`` types: use directly
+  the :c:type:`wchar_t` type instead. Since Python 3.3, ``Py_UNICODE`` and
+  ``PY_UNICODE_TYPE`` are just aliases to :c:type:`wchar_t`.
+  (Contributed by Victor Stinner in :gh:`105156`.)
+
+* Deprecate old Python initialization functions:
+
+  * :c:func:`PySys_ResetWarnOptions`:
+    clear :data:`sys.warnoptions` and :data:`!warnings.filters` instead.
+  * :c:func:`Py_GetExecPrefix`: get :data:`sys.exec_prefix` instead.
+  * :c:func:`Py_GetPath`: get :data:`sys.path` instead.
+  * :c:func:`Py_GetPrefix`: get :data:`sys.prefix` instead.
+  * :c:func:`Py_GetProgramFullPath`: get :data:`sys.executable` instead.
+  * :c:func:`Py_GetProgramName`: get :data:`sys.executable` instead.
+  * :c:func:`Py_GetPythonHome`: get :c:member:`PyConfig.home` or
+    :envvar:`PYTHONHOME` environment variable instead.
+
+  Functions scheduled for removal in Python 3.15.
+  (Contributed by Victor Stinner in :gh:`105145`.)
+
+* Deprecate the :c:func:`PyImport_ImportModuleNoBlock` function which is just
+  an alias to :c:func:`PyImport_ImportModule` since Python 3.3.
+  Scheduled for removal in Python 3.15.
+  (Contributed by Victor Stinner in :gh:`105396`.)
+
+* Deprecate the :c:func:`PyWeakref_GetObject` and
+  :c:func:`PyWeakref_GET_OBJECT` functions, which return a :term:`borrowed
+  reference`: use the new :c:func:`PyWeakref_GetRef` function instead, it
+  returns a :term:`strong reference`. The `pythoncapi-compat project
+  <https://github.com/python/pythoncapi-compat/>`__ can be used to get
+  :c:func:`PyWeakref_GetRef` on Python 3.12 and older.
+  (Contributed by Victor Stinner in :gh:`105927`.)
 
 Pending Removal in Python 3.14
 ------------------------------

--- a/Doc/whatsnew/3.13.rst
+++ b/Doc/whatsnew/3.13.rst
@@ -79,12 +79,14 @@ user-friendliness and correctness.
 
 Interpreter improvements:
 
-* A greatly improved :ref:`interactive interpreter<A Better Interactive Interpreter>`
-  and :ref:`improved error messages<Improved Error Messages>`.
+* A greatly improved :ref:`interactive interpreter
+  <whatsnew313-better-interactive-interpreter>` and
+  :ref:`improved error messages <whatsnew313-improved-error-messages>`.
 
-* Color support in the new :ref:`interactive interpreter<A Better Interactive
-  Interpreter>`, as well as in :ref:`tracebacks<Improved Error Messages>`
-  and :ref:`doctest` output. This can be disabled through the
+* Color support in the new :ref:`interactive interpreter
+  <whatsnew313-better-interactive-interpreter>`,
+  as well as in :ref:`tracebacks <whatsnew313-improved-error-messages>`
+  and :ref:`doctest <whatsnew313-doctest>` output. This can be disabled through the
   :envvar:`PYTHON_COLORS` and |NO_COLOR|_ environment variables.
 
 * :pep:`744`: A basic :ref:`JIT compiler <whatsnew313-jit-compiler>` was added.
@@ -135,6 +137,8 @@ Important deprecations, removals or restrictions:
 New Features
 ============
 
+.. _whatsnew313-better-interactive-interpreter:
+
 A Better Interactive Interpreter
 --------------------------------
 
@@ -162,6 +166,8 @@ For more on interactive mode, see :ref:`tut-interac`.
 
 (Contributed by Pablo Galindo Salgado, Łukasz Langa, and
 Lysandros Nikolaou in :gh:`111201` based on code from the PyPy project.)
+
+.. _whatsnew313-improved-error-messages:
 
 Improved Error Messages
 -----------------------
@@ -626,6 +632,8 @@ dis
   The offsets can be added with the new ``-O`` command line option or
   the ``show_offsets`` parameter.
   (Contributed by Irit Katriel in :gh:`112137`.)
+
+.. _whatsnew313-doctest:
 
 doctest
 -------

--- a/Doc/whatsnew/3.13.rst
+++ b/Doc/whatsnew/3.13.rst
@@ -1155,8 +1155,8 @@ Removed Modules And APIs
 
 .. _whatsnew313-pep594:
 
-PEP 594: dead batteries
------------------------
+PEP 594: dead batteries (and other module removals)
+---------------------------------------------------
 
 * :pep:`594` removed 19 modules from the standard library,
   deprecated in Python 3.11:
@@ -1261,12 +1261,13 @@ PEP 594: dead batteries
   * :mod:`!xdrlib`.
     (Contributed by Victor Stinner in :gh:`104773`.)
 
-2to3
-----
-
 * Remove the ``2to3`` program and the :mod:`!lib2to3` module,
   deprecated in Python 3.11.
   (Contributed by Victor Stinner in :gh:`104780`.)
+
+* Remove the :mod:`!tkinter.tix` module, deprecated in Python 3.6.  The
+  third-party Tix library which the module wrapped is unmaintained.
+  (Contributed by Zachary Ware in :gh:`75552`.)
 
 configparser
 ------------
@@ -1313,12 +1314,6 @@ re
   and ``re.TEMPLATE`` flag (and ``re.T`` alias).
   (Contributed by Serhiy Storchaka and Nikita Sobolev in :gh:`105687`.)
 
-tkinter
--------
-
-* Remove the :mod:`!tkinter.tix` module, deprecated in Python 3.6.  The
-  third-party Tix library which the module wrapped is unmaintained.
-  (Contributed by Zachary Ware in :gh:`75552`.)
 
 turtle
 ------

--- a/Doc/whatsnew/3.13.rst
+++ b/Doc/whatsnew/3.13.rst
@@ -1379,8 +1379,8 @@ webbrowser
   attribute instead.
   (Contributed by Nikita Sobolev in :gh:`105546`.)
 
-Deprecated Modules And APIs
-===========================
+New Deprecations
+================
 
 * Removed chained :class:`classmethod` descriptors (introduced in
   :gh:`63272`).  This can no longer be used to wrap other descriptors

--- a/Doc/whatsnew/3.13.rst
+++ b/Doc/whatsnew/3.13.rst
@@ -2151,9 +2151,15 @@ Changes in the Python API
   returned by :meth:`zipfile.ZipFile.open` was changed from ``'r'`` to ``'rb'``.
   (Contributed by Serhiy Storchaka in :gh:`115961`.)
 
-* :c:func:`!PyCode_GetFirstFree` is an unstable API now and has been renamed
-  to :c:func:`PyUnstable_Code_GetFirstFree`.
-  (Contributed by Bogdan Romanyuk in :gh:`115781`.)
+* Callbacks registered in the :mod:`tkinter` module now take arguments as
+  various Python objects (``int``, ``float``, ``bytes``, ``tuple``),
+  not just ``str``.
+  To restore the previous behavior set :mod:`!tkinter` module global
+  :data:`!wantobject` to ``1`` before creating the
+  :class:`!Tk` object or call the :meth:`!wantobject`
+  method of the :class:`!Tk` object with argument ``1``.
+  Calling it with argument ``2`` restores the current default behavior.
+  (Contributed by Serhiy Storchaka in :gh:`66410`.)
 
 
 Changes in the C API
@@ -2224,6 +2230,10 @@ Changes in the C API
   You may replace them with other functions as
   recommended in the documentation.
   (Contributed by Serhiy Storchaka in :gh:`106672`.)
+
+* :c:func:`!PyCode_GetFirstFree` is an unstable API now and has been renamed
+  to :c:func:`PyUnstable_Code_GetFirstFree`.
+  (Contributed by Bogdan Romanyuk in :gh:`115781`.)
 
 Deprecated C APIs
 -----------------

--- a/Doc/whatsnew/3.13.rst
+++ b/Doc/whatsnew/3.13.rst
@@ -80,7 +80,7 @@ user-friendliness and correctness.
 Interpreter improvements:
 
 * A greatly improved :ref:`interactive interpreter<A Better Interactive Interpreter>`
-  and :ref:improved error messages<Improved Error Messages>`.
+  and :ref:`improved error messages<Improved Error Messages>`.
 
 * Color support in the new :ref:`interactive interpreter<A Better Interactive
   Interpreter>`, as well as in :ref:`tracebacks<Improved Error Messages>`

--- a/Doc/whatsnew/3.13.rst
+++ b/Doc/whatsnew/3.13.rst
@@ -3,7 +3,7 @@
   What's New In Python 3.13
 ****************************
 
-:Editor: TBD
+:Editor: Thomas Wouters
 
 .. Rules for maintenance:
 
@@ -49,6 +49,10 @@ This article explains the new features in Python 3.13, compared to 3.12.
 
 For full details, see the :ref:`changelog <changelog>`.
 
+.. seealso::
+
+   :pep:`719` -- Python 3.13 Release Schedule
+
 .. note::
 
    Prerelease users should be aware that this document is currently in draft
@@ -56,13 +60,61 @@ For full details, see the :ref:`changelog <changelog>`.
    so it's worth checking back even after reading earlier versions.
 
 
-Summary -- Release highlights
+Summary -- Release Highlights
 =============================
 
 .. This section singles out the most important changes in Python 3.13.
    Brevity is key.
 
+Python 3.13 beta is the pre-release of the next version of the Python
+programming language, with a mix of changes to the language, the
+implementation and the standard library. The biggest changes to the
+implementation include a new interactive interpreter, and experimental
+support for dropping the Global Interpreter Lock (:pep:`703`) and a
+Just-In-Time compiler (:pep:`744`). The library changes contain removal of
+deprecated APIs and modules, as well as the usual improvements in
+user-friendliness and correctness.
+
 .. PEP-sized items next.
+
+Interpreter improvements:
+
+* A greatly improved :ref:`interactive interpreter<A Better Interactive Interpreter>`
+  and :ref:improved error messages<Improved Error Messages>`.
+
+* Color support in the new :ref:`interactive interpreter<A Better Interactive
+  Interpreter>`, as well as in :ref:`tracebacks<Improved Error Messages>`
+  and :ref:`doctest` output. This can be disabled through the
+  :envvar:`PYTHON_COLORS` and |NO_COLOR|_ environment variables.
+
+* :pep:`744`: A basic :ref:`JIT compiler <whatsnew313-jit-compiler>` was added.
+  It is currently disabled by default (though we may turn it on later).
+  Performance improvements are modest -- we expect to be improving this
+  over the next few releases.
+
+* :pep:`667`: :attr:`FrameType.f_locals <frame.f_locals>` when used in
+  a function now returns a write-through proxy to the frame's locals,
+  rather than a ``dict``. See the PEP for corresponding C API changes
+  and deprecations.
+
+New typing features:
+
+* :pep:`696`: Type parameters (:data:`typing.TypeVar`, :data:`typing.ParamSpec`,
+  and :data:`typing.TypeVarTuple`) now support defaults.
+
+* :pep:`742`: :data:`typing.TypeIs` was added, providing more intuitive
+  type narrowing behavior.
+
+Free-threading:
+
+* :pep:`703`: CPython 3.13 has experimental support for running with the
+  :term:`global interpreter lock` disabled when built with ``--disable-gil``.
+  See :ref:`Free-threaded CPython <free-threaded-cpython>` for more details.
+
+Platform support:
+
+* :pep:`730`: Apple's iOS is now an officially supported platform. Official
+  Android support (:pep:`738`) is in the works as well.
 
 Important deprecations, removals or restrictions:
 
@@ -80,31 +132,6 @@ Important deprecations, removals or restrictions:
   * Python 3.13 and later have two years of full support,
     followed by three years of security fixes.
 
-Interpreter improvements:
-
-* :pep:`744`: A basic :ref:`JIT compiler <whatsnew313-jit-compiler>` was added.
-  It is currently disabled by default (though we may turn it on later).
-  Performance improvements are modest -- we expect to be improving this
-  over the next few releases.
-
-* :pep:`667`: :attr:`FrameType.f_locals <frame.f_locals>` when used in
-  a function now returns a write-through proxy to the frame's locals,
-  rather than a ``dict``. See the PEP for corresponding C API changes
-  and deprecations.
-
-New typing features:
-
-* :pep:`696`: Type parameters (:data:`typing.TypeVar`, :data:`typing.ParamSpec`,
-  and :data:`typing.TypeVarTuple`) now support defaults.
-* :pep:`742`: :data:`typing.TypeIs` was added, providing more intuitive
-  type narrowing behavior.
-
-Free-threading:
-
-* :pep:`703`: CPython 3.13 has experimental support for running with the
-  :term:`global interpreter lock` disabled when built with ``--disable-gil``.
-  See :ref:`Free-threaded CPython <free-threaded-cpython>` for more details.
-
 New Features
 ============
 
@@ -112,21 +139,21 @@ A Better Interactive Interpreter
 --------------------------------
 
 On Unix-like systems like Linux or macOS, Python now uses a new
-:term:`interactive` shell.  When the user starts the :term:`REPL`
-from a tty, and both :mod:`curses` and :mod:`readline` are available,
-the interactive shell now supports the following new features:
+:term:`interactive` shell. When the user starts the :term:`REPL` from an
+interactive terminal, and both :mod:`curses` and :mod:`readline` are
+available, the interactive shell now supports the following new features:
 
-* colorized prompts;
-* multiline editing with history preservation;
-* interactive help browsing using :kbd:`F1` with a separate command
-  history;
-* history browsing using :kbd:`F2` that skips output as well as the
-  :term:`>>>` and :term:`...` prompts;
-* "paste mode" with :kbd:`F3` that makes pasting larger blocks of code
-  easier (press :kbd:`F3` again to return to the regular prompt);
-* ability to issue REPL-specific commands like :kbd:`help`, :kbd:`exit`,
-  and :kbd:`quit` without the need to use call parentheses after the
-  command name.
+* Colorized prompts.
+* Multiline editing with history preservation.
+* Interactive help browsing using :kbd:`F1` with a separate command
+  history.
+* History browsing using :kbd:`F2` that skips output as well as the
+  :term:`>>>` and :term:`...` prompts.
+* "Paste mode" with :kbd:`F3` that makes pasting larger blocks of code
+  easier (press :kbd:`F3` again to return to the regular prompt).
+* The ability to issue REPL-specific commands like :kbd:`help`, :kbd:`exit`,
+  and :kbd:`quit` without the need to use call parentheses after the command
+  name.
 
 If the new interactive shell is not desired, it can be disabled via
 the :envvar:`PYTHON_BASIC_REPL` environment variable.
@@ -226,6 +253,106 @@ Support For Mobile Platforms
 
   (PEP written and implementation contributed by Russell Keith-Magee in
   :gh:`114099`.)
+
+.. _whatsnew313-jit-compiler:
+
+Experimental JIT Compiler
+=========================
+
+When CPython is configured using the ``--enable-experimental-jit`` option,
+a just-in-time compiler is added which may speed up some Python programs.
+
+The internal architecture is roughly as follows.
+
+* We start with specialized *Tier 1 bytecode*.
+  See :ref:`What's new in 3.11 <whatsnew311-pep659>` for details.
+
+* When the Tier 1 bytecode gets hot enough, it gets translated
+  to a new, purely internal *Tier 2 IR*, a.k.a. micro-ops ("uops").
+
+* The Tier 2 IR uses the same stack-based VM as Tier 1, but the
+  instruction format is better suited to translation to machine code.
+
+* We have several optimization passes for Tier 2 IR, which are applied
+  before it is interpreted or translated to machine code.
+
+* There is a Tier 2 interpreter, but it is mostly intended for debugging
+  the earlier stages of the optimization pipeline.
+  The Tier 2 interpreter can be enabled by configuring Python
+  with ``--enable-experimental-jit=interpreter``.
+
+* When the JIT is enabled, the optimized
+  Tier 2 IR is translated to machine code, which is then executed.
+
+* The machine code translation process uses an architecture called
+  *copy-and-patch*. It has no runtime dependencies, but there is a new
+  build-time dependency on LLVM.
+
+The ``--enable-experimental-jit`` flag has the following optional values:
+
+* ``no`` (default) -- Disable the entire Tier 2 and JIT pipeline.
+
+* ``yes`` (default if the flag is present without optional value)
+  -- Enable the JIT. To disable the JIT at runtime,
+  pass the environment variable ``PYTHON_JIT=0``.
+
+* ``yes-off`` -- Build the JIT but disable it by default.
+  To enable the JIT at runtime, pass the environment variable
+  ``PYTHON_JIT=1``.
+
+* ``interpreter`` -- Enable the Tier 2 interpreter but disable the JIT.
+  The interpreter can be disabled by running with
+  ``PYTHON_JIT=0``.
+
+(On Windows, use ``PCbuild/build.bat --experimental-jit`` to enable the JIT
+or ``--experimental-jit-interpreter`` to enable the Tier 2 interpreter.)
+
+See :pep:`744` for more details.
+
+(JIT by Brandt Bucher, inspired by a paper by Haoran Xu and Fredrik Kjolstad.
+Tier 2 IR by Mark Shannon and Guido van Rossum.
+Tier 2 optimizer by Ken Jin.)
+
+.. _free-threaded-cpython:
+
+Free-threaded CPython
+=====================
+
+CPython will run with the :term:`global interpreter lock` (GIL) disabled when
+configured using the ``--disable-gil`` option at build time. This is an
+experimental feature and therefore isn't used by default. Users need to
+either compile their own interpreter, or install one of the experimental
+builds that are marked as *free-threaded*.
+
+Free-threaded execution allows for full utilization of the available
+processing power by running threads in parallel on available CPU cores.
+While not all software will benefit from this automatically, programs
+designed with threading in mind will run faster on multicore hardware.
+
+Work is still ongoing: expect some bugs and a substantial single-threaded
+performance hit.
+
+The free-threaded build still supports optionally running with GIL enabled at
+runtime using the environment variable :envvar:`PYTHON_GIL` or the command line
+option :option:`-X gil`.
+
+* Use :func:`!sys._is_gil_enabled` to determine if the :term:`GIL` is enabled.
+
+* Use ``sysconfig.get_config_var("Py_GIL_DISABLED")`` to identify CPython
+  builds configured with ``--disable-gil``.
+
+C-API extensions need to be built specifically for the free-threaded build.
+
+* Extensions that support running with the :term:`GIL` disabled should use
+  the :c:data:`Py_mod_gil` slot. Extensions using single-phase init should use
+  :c:func:`PyUnstable_Module_SetGIL` to indicate whether they support running
+  with the GIL disabled. Importing C extensions that don't use these mechanisms
+  will cause the GIL to be enabled unless the GIL was explicitly disabled with
+  the :envvar:`PYTHON_GIL` environment variable or the :option:`-X gil=0`
+  option.
+
+* pip 24.1b1 or newer is required to install packages with C extensions in the
+  free-threaded build.
 
 Other Language Changes
 ======================
@@ -503,16 +630,16 @@ dis
 doctest
 -------
 
-* The :meth:`doctest.DocTestRunner.run` method now counts the number of skipped
-  tests. Add :attr:`doctest.DocTestRunner.skips` and
-  :attr:`doctest.TestResults.skipped` attributes.
-  (Contributed by Victor Stinner in :gh:`108794`.)
-
 * Color is added to the output by default.
   This can be controlled via the new :envvar:`PYTHON_COLORS` environment
   variable as well as the canonical |NO_COLOR|_ and |FORCE_COLOR|_ environment
   variables. See also :ref:`using-on-controlling-color`.
   (Contributed by Hugo van Kemenade in :gh:`117225`.)
+
+* The :meth:`doctest.DocTestRunner.run` method now counts the number of skipped
+  tests. Add :attr:`doctest.DocTestRunner.skips` and
+  :attr:`doctest.TestResults.skipped` attributes.
+  (Contributed by Victor Stinner in :gh:`108794`.)
 
 email
 -----
@@ -1008,566 +1135,8 @@ Optimizations
   (Contributed by Alex Waygood, Shantanu Jain, Adam Turner, Daniel Hollas and
   others in :gh:`109653`.)
 
-.. _whatsnew313-jit-compiler:
-
-Experimental JIT Compiler
-=========================
-
-When CPython is configured using the ``--enable-experimental-jit`` option,
-a just-in-time compiler is added which may speed up some Python programs.
-
-The internal architecture is roughly as follows.
-
-* We start with specialized *Tier 1 bytecode*.
-  See :ref:`What's new in 3.11 <whatsnew311-pep659>` for details.
-
-* When the Tier 1 bytecode gets hot enough, it gets translated
-  to a new, purely internal *Tier 2 IR*, a.k.a. micro-ops ("uops").
-
-* The Tier 2 IR uses the same stack-based VM as Tier 1, but the
-  instruction format is better suited to translation to machine code.
-
-* We have several optimization passes for Tier 2 IR, which are applied
-  before it is interpreted or translated to machine code.
-
-* There is a Tier 2 interpreter, but it is mostly intended for debugging
-  the earlier stages of the optimization pipeline.
-  The Tier 2 interpreter can be enabled by configuring Python
-  with ``--enable-experimental-jit=interpreter``.
-
-* When the JIT is enabled, the optimized
-  Tier 2 IR is translated to machine code, which is then executed.
-
-* The machine code translation process uses an architecture called
-  *copy-and-patch*. It has no runtime dependencies, but there is a new
-  build-time dependency on LLVM.
-
-The ``--enable-experimental-jit`` flag has the following optional values:
-
-* ``no`` (default) -- Disable the entire Tier 2 and JIT pipeline.
-
-* ``yes`` (default if the flag is present without optional value)
-  -- Enable the JIT. To disable the JIT at runtime,
-  pass the environment variable ``PYTHON_JIT=0``.
-
-* ``yes-off`` -- Build the JIT but disable it by default.
-  To enable the JIT at runtime, pass the environment variable
-  ``PYTHON_JIT=1``.
-
-* ``interpreter`` -- Enable the Tier 2 interpreter but disable the JIT.
-  The interpreter can be disabled by running with
-  ``PYTHON_JIT=0``.
-
-(On Windows, use ``PCbuild/build.bat --experimental-jit`` to enable the JIT
-or ``--experimental-jit-interpreter`` to enable the Tier 2 interpreter.)
-
-See :pep:`744` for more details.
-
-(JIT by Brandt Bucher, inspired by a paper by Haoran Xu and Fredrik Kjolstad.
-Tier 2 IR by Mark Shannon and Guido van Rossum.
-Tier 2 optimizer by Ken Jin.)
-
-.. _free-threaded-cpython:
-
-Free-threaded CPython
-=====================
-
-CPython will run with the :term:`global interpreter lock` (GIL) disabled when
-configured using the ``--disable-gil`` option at build time. This is an
-experimental feature and therefore isn't used by default. Users need to
-either compile their own interpreter, or install one of the experimental
-builds that are marked as *free-threaded*.
-
-Free-threaded execution allows for full utilization of the available
-processing power by running threads in parallel on available CPU cores.
-While not all software will benefit from this automatically, programs
-designed with threading in mind will run faster on multicore hardware.
-
-Work is still ongoing: expect some bugs and a substantial single-threaded
-performance hit.
-
-The free-threaded build still supports optionally running with GIL enabled at
-runtime using the environment variable :envvar:`PYTHON_GIL` or the command line
-option :option:`-X gil`.
-
-* Use :func:`!sys._is_gil_enabled` to determine if the :term:`GIL` is enabled.
-
-* Use ``sysconfig.get_config_var("Py_GIL_DISABLED")`` to identify CPython
-  builds configured with ``--disable-gil``.
-
-C-API extensions need to be built specifically for the free-threaded build.
-
-* Extensions that support running with the :term:`GIL` disabled should use
-  the :c:data:`Py_mod_gil` slot. Extensions using single-phase init should use
-  :c:func:`PyUnstable_Module_SetGIL` to indicate whether they support running
-  with the GIL disabled. Importing C extensions that don't use these mechanisms
-  will cause the GIL to be enabled unless the GIL was explicitly disabled with
-  the :envvar:`PYTHON_GIL` environment variable or the :option:`-X gil=0`
-  option.
-
-* pip 24.1b1 or newer is required to install packages with C extensions in the
-  free-threaded build.
-
-
-Deprecated
-==========
-
-* :mod:`array`: :mod:`array`'s ``'u'`` format code, deprecated in docs since Python 3.3,
-  emits :exc:`DeprecationWarning` since 3.13
-  and will be removed in Python 3.16.
-  Use the ``'w'`` format code instead.
-  (Contributed by Hugo van Kemenade in :gh:`80480`.)
-
-* :mod:`ctypes`: Deprecate undocumented :func:`!ctypes.SetPointerType`
-  and :func:`!ctypes.ARRAY` functions.
-  Replace ``ctypes.ARRAY(item_type, size)`` with ``item_type * size``.
-  (Contributed by Victor Stinner in :gh:`105733`.)
-
-* :mod:`decimal`: Deprecate non-standard format specifier "N" for
-  :class:`decimal.Decimal`.
-  It was not documented and only supported in the C implementation.
-  (Contributed by Serhiy Storchaka in :gh:`89902`.)
-
-* :mod:`dis`: The ``dis.HAVE_ARGUMENT`` separator is deprecated. Check
-  membership in :data:`~dis.hasarg` instead.
-  (Contributed by Irit Katriel in :gh:`109319`.)
-
-* :ref:`frame-objects`:
-  Calling :meth:`frame.clear` on a suspended frame raises :exc:`RuntimeError`
-  (as has always been the case for an executing frame).
-  (Contributed by Irit Katriel in :gh:`79932`.)
-
-* :mod:`getopt` and :mod:`optparse` modules: They are now
-  :term:`soft deprecated`: the :mod:`argparse` module should be used for new projects.
-  Previously, the :mod:`optparse` module was already deprecated, its removal
-  was not scheduled, and no warnings was emitted: so there is no change in
-  practice.
-  (Contributed by Victor Stinner in :gh:`106535`.)
-
-* :mod:`gettext`: Emit deprecation warning for non-integer numbers in
-  :mod:`gettext` functions and methods that consider plural forms even if the
-  translation was not found.
-  (Contributed by Serhiy Storchaka in :gh:`88434`.)
-
-* :mod:`glob`: The undocumented :func:`!glob.glob0` and :func:`!glob.glob1`
-  functions are deprecated. Use :func:`glob.glob` and pass a directory to its
-  *root_dir* argument instead.
-  (Contributed by Barney Gale in :gh:`117337`.)
-
-* :mod:`http.server`: :class:`http.server.CGIHTTPRequestHandler` now emits a
-  :exc:`DeprecationWarning` as it will be removed in 3.15.  Process-based CGI
-  HTTP servers have been out of favor for a very long time.  This code was
-  outdated, unmaintained, and rarely used.  It has a high potential for both
-  security and functionality bugs.  This includes removal of the ``--cgi``
-  flag to the ``python -m http.server`` command line in 3.15.
-
-* :mod:`pathlib`:
-  :meth:`pathlib.PurePath.is_reserved` is deprecated and scheduled for
-  removal in Python 3.15. Use :func:`os.path.isreserved` to detect reserved
-  paths on Windows.
-
-* :mod:`platform`:
-  :func:`~platform.java_ver` is deprecated and will be removed in 3.15.
-  It was largely untested, had a confusing API,
-  and was only useful for Jython support.
-  (Contributed by Nikita Sobolev in :gh:`116349`.)
-
-* :mod:`pydoc`: Deprecate undocumented :func:`!pydoc.ispackage` function.
-  (Contributed by Zackery Spytz in :gh:`64020`.)
-
-* :mod:`sqlite3`: Passing more than one positional argument to
-  :func:`sqlite3.connect` and the :class:`sqlite3.Connection` constructor is
-  deprecated. The remaining parameters will become keyword-only in Python 3.15.
-
-  Deprecate passing name, number of arguments, and the callable as keyword
-  arguments for the following :class:`sqlite3.Connection` APIs:
-
-  * :meth:`~sqlite3.Connection.create_function`
-  * :meth:`~sqlite3.Connection.create_aggregate`
-
-  Deprecate passing the callback callable by keyword for the following
-  :class:`sqlite3.Connection` APIs:
-
-  * :meth:`~sqlite3.Connection.set_authorizer`
-  * :meth:`~sqlite3.Connection.set_progress_handler`
-  * :meth:`~sqlite3.Connection.set_trace_callback`
-
-  The affected parameters will become positional-only in Python 3.15.
-
-  (Contributed by Erlend E. Aasland in :gh:`107948` and :gh:`108278`.)
-
-* :mod:`sys`: :func:`sys._enablelegacywindowsfsencoding` function.
-  Replace it with the :envvar:`PYTHONLEGACYWINDOWSFSENCODING` environment variable.
-  (Contributed by Inada Naoki in :gh:`73427`.)
-
-* :mod:`tarfile`:
-  The undocumented and unused ``tarfile`` attribute of :class:`tarfile.TarFile`
-  is deprecated and scheduled for removal in Python 3.16.
-
-* :mod:`traceback`: The field *exc_type* of :class:`traceback.TracebackException`
-  is deprecated. Use *exc_type_str* instead.
-
-* :mod:`typing`:
-
-  * Creating a :class:`typing.NamedTuple` class using keyword arguments to denote
-    the fields (``NT = NamedTuple("NT", x=int, y=int)``) is deprecated, and will
-    be disallowed in Python 3.15. Use the class-based syntax or the functional
-    syntax instead. (Contributed by Alex Waygood in :gh:`105566`.)
-
-  * When using the functional syntax to create a :class:`typing.NamedTuple`
-    class or a :class:`typing.TypedDict` class, failing to pass a value to the
-    'fields' parameter (``NT = NamedTuple("NT")`` or ``TD = TypedDict("TD")``) is
-    deprecated. Passing ``None`` to the 'fields' parameter
-    (``NT = NamedTuple("NT", None)`` or ``TD = TypedDict("TD", None)``) is also
-    deprecated. Both will be disallowed in Python 3.15. To create a NamedTuple
-    class with 0 fields, use ``class NT(NamedTuple): pass`` or
-    ``NT = NamedTuple("NT", [])``. To create a TypedDict class with 0 fields, use
-    ``class TD(TypedDict): pass`` or ``TD = TypedDict("TD", {})``.
-    (Contributed by Alex Waygood in :gh:`105566` and :gh:`105570`.)
-
-  * :func:`typing.no_type_check_decorator` is deprecated, and scheduled for
-    removal in Python 3.15. After eight years in the :mod:`typing` module, it
-    has yet to be supported by any major type checkers.
-    (Contributed by Alex Waygood in :gh:`106309`.)
-
-  * :data:`typing.AnyStr` is deprecated. In Python 3.16, it will be removed from
-    ``typing.__all__``, and a :exc:`DeprecationWarning` will be emitted when it
-    is imported or accessed. It will be removed entirely in Python 3.18. Use
-    the new :ref:`type parameter syntax <type-params>` instead.
-    (Contributed by Michael The in :gh:`107116`.)
-
-* :ref:`user-defined-funcs`:
-  Assignment to a function's :attr:`~function.__code__` attribute where the new code
-  object's type does not match the function's type, is deprecated. The
-  different types are: plain function, generator, async generator and
-  coroutine.
-  (Contributed by Irit Katriel in :gh:`81137`.)
-
-* :mod:`wave`: Deprecate the ``getmark()``, ``setmark()`` and ``getmarkers()``
-  methods of the :class:`wave.Wave_read` and :class:`wave.Wave_write` classes.
-  They will be removed in Python 3.15.
-  (Contributed by Victor Stinner in :gh:`105096`.)
-
-.. Add deprecations above alphabetically, not here at the end.
-
-* Passing file path instead of URL in :func:`~mimetypes.guess_type` is :term:`soft deprecated`.
-  Use :func:`~mimetypes.guess_file_type` instead.
-  (Contributed by Serhiy Storchaka in :gh:`66543`.)
-
-Pending Removal in Python 3.14
-------------------------------
-
-* :mod:`argparse`: The *type*, *choices*, and *metavar* parameters
-  of :class:`!argparse.BooleanOptionalAction` are deprecated
-  and will be removed in 3.14.
-  (Contributed by Nikita Sobolev in :gh:`92248`.)
-
-* :mod:`ast`: The following features have been deprecated in documentation
-  since Python 3.8, now cause a :exc:`DeprecationWarning` to be emitted at
-  runtime when they are accessed or used, and will be removed in Python 3.14:
-
-  * :class:`!ast.Num`
-  * :class:`!ast.Str`
-  * :class:`!ast.Bytes`
-  * :class:`!ast.NameConstant`
-  * :class:`!ast.Ellipsis`
-
-  Use :class:`ast.Constant` instead.
-  (Contributed by Serhiy Storchaka in :gh:`90953`.)
-
-* :mod:`collections.abc`: Deprecated :class:`~collections.abc.ByteString`.
-  Prefer :class:`!Sequence` or :class:`~collections.abc.Buffer`.
-  For use in typing, prefer a union, like ``bytes | bytearray``,
-  or :class:`collections.abc.Buffer`.
-  (Contributed by Shantanu Jain in :gh:`91896`.)
-
-* :mod:`email`: Deprecated the *isdst* parameter in :func:`email.utils.localtime`.
-  (Contributed by Alan Williams in :gh:`72346`.)
-
-* :mod:`importlib`: ``__package__`` and ``__cached__`` will cease to be set or
-  taken into consideration by the import system (:gh:`97879`).
-
-* :mod:`importlib.abc` deprecated classes:
-
-  * :class:`!importlib.abc.ResourceReader`
-  * :class:`!importlib.abc.Traversable`
-  * :class:`!importlib.abc.TraversableResources`
-
-  Use :mod:`importlib.resources.abc` classes instead:
-
-  * :class:`importlib.resources.abc.Traversable`
-  * :class:`importlib.resources.abc.TraversableResources`
-
-  (Contributed by Jason R. Coombs and Hugo van Kemenade in :gh:`93963`.)
-
-* :mod:`itertools` had undocumented, inefficient, historically buggy,
-  and inconsistent support for copy, deepcopy, and pickle operations.
-  This will be removed in 3.14 for a significant reduction in code
-  volume and maintenance burden.
-  (Contributed by Raymond Hettinger in :gh:`101588`.)
-
-* :mod:`multiprocessing`: The default start method will change to a safer one on
-  Linux, BSDs, and other non-macOS POSIX platforms where ``'fork'`` is currently
-  the default (:gh:`84559`). Adding a runtime warning about this was deemed too
-  disruptive as the majority of code is not expected to care. Use the
-  :func:`~multiprocessing.get_context` or
-  :func:`~multiprocessing.set_start_method` APIs to explicitly specify when
-  your code *requires* ``'fork'``.  See :ref:`multiprocessing-start-methods`.
-
-* :mod:`pathlib`: :meth:`~pathlib.PurePath.is_relative_to` and
-  :meth:`~pathlib.PurePath.relative_to`: passing additional arguments is
-  deprecated.
-
-* :mod:`pkgutil`: :func:`~pkgutil.find_loader` and :func:`~pkgutil.get_loader`
-  now raise :exc:`DeprecationWarning`;
-  use :func:`importlib.util.find_spec` instead.
-  (Contributed by Nikita Sobolev in :gh:`97850`.)
-
-* :mod:`pty`:
-
-  * ``master_open()``: use :func:`pty.openpty`.
-  * ``slave_open()``: use :func:`pty.openpty`.
-
-* :func:`shutil.rmtree` *onerror* parameter is deprecated in 3.12,
-  and will be removed in 3.14: use the *onexc* parameter instead.
-
-* :mod:`sqlite3`:
-
-  * :data:`~sqlite3.version` and :data:`~sqlite3.version_info`.
-
-  * :meth:`~sqlite3.Cursor.execute` and :meth:`~sqlite3.Cursor.executemany`
-    if :ref:`named placeholders <sqlite3-placeholders>` are used and
-    *parameters* is a sequence instead of a :class:`dict`.
-
-  * date and datetime adapter, date and timestamp converter:
-    see the :mod:`sqlite3` documentation for suggested replacement recipes.
-
-* :class:`types.CodeType`: Accessing :attr:`~codeobject.co_lnotab` was
-  deprecated in :pep:`626`
-  since 3.10 and was planned to be removed in 3.12,
-  but it only got a proper :exc:`DeprecationWarning` in 3.12.
-  May be removed in 3.14.
-  (Contributed by Nikita Sobolev in :gh:`101866`.)
-
-* :mod:`typing`: :class:`~typing.ByteString`, deprecated since Python 3.9,
-  now causes a :exc:`DeprecationWarning` to be emitted when it is used.
-
-* :mod:`urllib`:
-  :class:`!urllib.parse.Quoter` is deprecated: it was not intended to be a
-  public API.
-  (Contributed by Gregory P. Smith in :gh:`88168`.)
-
-* :mod:`xml.etree.ElementTree`: Testing the truth value of an
-  :class:`~xml.etree.ElementTree.Element` is deprecated and will raise an
-  exception in Python 3.14.
-
-Pending Removal in Python 3.15
-------------------------------
-
-* :class:`http.server.CGIHTTPRequestHandler` will be removed along with its
-  related ``--cgi`` flag to ``python -m http.server``.  It was obsolete and
-  rarely used.  No direct replacement exists.  *Anything* is better than CGI
-  to interface a web server with a request handler.
-
-* :class:`locale`: :func:`locale.getdefaultlocale` was deprecated in Python 3.11
-  and originally planned for removal in Python 3.13 (:gh:`90817`),
-  but removal has been postponed to Python 3.15.
-  Use :func:`locale.setlocale()`, :func:`locale.getencoding()` and
-  :func:`locale.getlocale()` instead.
-  (Contributed by Hugo van Kemenade in :gh:`111187`.)
-
-* :mod:`pathlib`:
-  :meth:`pathlib.PurePath.is_reserved` is deprecated and scheduled for
-  removal in Python 3.15. Use :func:`os.path.isreserved` to detect reserved
-  paths on Windows.
-
-* :mod:`platform`:
-  :func:`~platform.java_ver` is deprecated and will be removed in 3.15.
-  It was largely untested, had a confusing API,
-  and was only useful for Jython support.
-  (Contributed by Nikita Sobolev in :gh:`116349`.)
-
-* :mod:`threading`:
-  Passing any arguments to :func:`threading.RLock` is now deprecated.
-  C version allows any numbers of args and kwargs,
-  but they are just ignored. Python version does not allow any arguments.
-  All arguments will be removed from :func:`threading.RLock` in Python 3.15.
-  (Contributed by Nikita Sobolev in :gh:`102029`.)
-
-* :class:`typing.NamedTuple`:
-
-  * The undocumented keyword argument syntax for creating :class:`!NamedTuple` classes
-    (``NT = NamedTuple("NT", x=int)``) is deprecated, and will be disallowed in
-    3.15. Use the class-based syntax or the functional syntax instead.
-
-  * When using the functional syntax to create a :class:`!NamedTuple` class, failing to
-    pass a value to the *fields* parameter (``NT = NamedTuple("NT")``) is
-    deprecated. Passing ``None`` to the *fields* parameter
-    (``NT = NamedTuple("NT", None)``) is also deprecated. Both will be
-    disallowed in Python 3.15. To create a :class:`!NamedTuple` class with 0 fields, use
-    ``class NT(NamedTuple): pass`` or ``NT = NamedTuple("NT", [])``.
-
-* :class:`typing.TypedDict`: When using the functional syntax to create a
-  :class:`!TypedDict` class, failing to pass a value to the *fields* parameter (``TD =
-  TypedDict("TD")``) is deprecated. Passing ``None`` to the *fields* parameter
-  (``TD = TypedDict("TD", None)``) is also deprecated. Both will be disallowed
-  in Python 3.15. To create a :class:`!TypedDict` class with 0 fields, use ``class
-  TD(TypedDict): pass`` or ``TD = TypedDict("TD", {})``.
-
-* :mod:`wave`: Deprecate the ``getmark()``, ``setmark()`` and ``getmarkers()``
-  methods of the :class:`wave.Wave_read` and :class:`wave.Wave_write` classes.
-  They will be removed in Python 3.15.
-  (Contributed by Victor Stinner in :gh:`105096`.)
-
-Pending Removal in Python 3.16
-------------------------------
-
-* :class:`array.array` ``'u'`` type (:c:type:`wchar_t`):
-  use the ``'w'`` type instead (``Py_UCS4``).
-
-Pending Removal in Future Versions
-----------------------------------
-
-The following APIs were deprecated in earlier Python versions and will be removed,
-although there is currently no date scheduled for their removal.
-
-* :mod:`argparse`: Nesting argument groups and nesting mutually exclusive
-  groups are deprecated.
-
-* :mod:`builtins`:
-
-  * ``~bool``, bitwise inversion on bool.
-  * ``bool(NotImplemented)``.
-  * Generators: ``throw(type, exc, tb)`` and ``athrow(type, exc, tb)``
-    signature is deprecated: use ``throw(exc)`` and ``athrow(exc)`` instead,
-    the single argument signature.
-  * Currently Python accepts numeric literals immediately followed by keywords,
-    for example ``0in x``, ``1or x``, ``0if 1else 2``.  It allows confusing and
-    ambiguous expressions like ``[0x1for x in y]`` (which can be interpreted as
-    ``[0x1 for x in y]`` or ``[0x1f or x in y]``).  A syntax warning is raised
-    if the numeric literal is immediately followed by one of keywords
-    :keyword:`and`, :keyword:`else`, :keyword:`for`, :keyword:`if`,
-    :keyword:`in`, :keyword:`is` and :keyword:`or`.  In a future release it
-    will be changed to a syntax error. (:gh:`87999`)
-  * Support for ``__index__()`` and ``__int__()`` method returning non-int type:
-    these methods will be required to return an instance of a strict subclass of
-    :class:`int`.
-  * Support for ``__float__()`` method returning a strict subclass of
-    :class:`float`: these methods will be required to return an instance of
-    :class:`float`.
-  * Support for ``__complex__()`` method returning a strict subclass of
-    :class:`complex`: these methods will be required to return an instance of
-    :class:`complex`.
-  * Delegation of ``int()`` to ``__trunc__()`` method.
-
-* :mod:`calendar`: ``calendar.January`` and ``calendar.February`` constants are
-  deprecated and replaced by :data:`calendar.JANUARY` and
-  :data:`calendar.FEBRUARY`.
-  (Contributed by Prince Roshan in :gh:`103636`.)
-
-* :attr:`codeobject.co_lnotab`: use the :meth:`codeobject.co_lines` method
-  instead.
-
-* :mod:`datetime`:
-
-  * :meth:`~datetime.datetime.utcnow`:
-    use ``datetime.datetime.now(tz=datetime.UTC)``.
-  * :meth:`~datetime.datetime.utcfromtimestamp`:
-    use ``datetime.datetime.fromtimestamp(timestamp, tz=datetime.UTC)``.
-
-* :mod:`gettext`: Plural value must be an integer.
-
-* :mod:`importlib`:
-
-  * ``load_module()`` method: use ``exec_module()`` instead.
-  * :func:`~importlib.util.cache_from_source` *debug_override* parameter is
-    deprecated: use the *optimization* parameter instead.
-
-* :mod:`importlib.metadata`:
-
-  * ``EntryPoints`` tuple interface.
-  * Implicit ``None`` on return values.
-
-* :mod:`mailbox`: Use of StringIO input and text mode is deprecated, use
-  BytesIO and binary mode instead.
-
-* :mod:`os`: Calling :func:`os.register_at_fork` in multi-threaded process.
-
-* :class:`!pydoc.ErrorDuringImport`: A tuple value for *exc_info* parameter is
-  deprecated, use an exception instance.
-
-* :mod:`re`: More strict rules are now applied for numerical group references
-  and group names in regular expressions.  Only sequence of ASCII digits is now
-  accepted as a numerical reference.  The group name in bytes patterns and
-  replacement strings can now only contain ASCII letters and digits and
-  underscore.
-  (Contributed by Serhiy Storchaka in :gh:`91760`.)
-
-* :mod:`!sre_compile`, :mod:`!sre_constants` and :mod:`!sre_parse` modules.
-
-* :mod:`ssl` options and protocols:
-
-  * :class:`ssl.SSLContext` without protocol argument is deprecated.
-  * :class:`ssl.SSLContext`: :meth:`~ssl.SSLContext.set_npn_protocols` and
-    :meth:`!selected_npn_protocol` are deprecated: use ALPN
-    instead.
-  * ``ssl.OP_NO_SSL*`` options
-  * ``ssl.OP_NO_TLS*`` options
-  * ``ssl.PROTOCOL_SSLv3``
-  * ``ssl.PROTOCOL_TLS``
-  * ``ssl.PROTOCOL_TLSv1``
-  * ``ssl.PROTOCOL_TLSv1_1``
-  * ``ssl.PROTOCOL_TLSv1_2``
-  * ``ssl.TLSVersion.SSLv3``
-  * ``ssl.TLSVersion.TLSv1``
-  * ``ssl.TLSVersion.TLSv1_1``
-
-* :func:`sysconfig.is_python_build` *check_home* parameter is deprecated and
-  ignored.
-
-* :mod:`threading` methods:
-
-  * :meth:`!threading.Condition.notifyAll`: use :meth:`~threading.Condition.notify_all`.
-  * :meth:`!threading.Event.isSet`: use :meth:`~threading.Event.is_set`.
-  * :meth:`!threading.Thread.isDaemon`, :meth:`threading.Thread.setDaemon`:
-    use :attr:`threading.Thread.daemon` attribute.
-  * :meth:`!threading.Thread.getName`, :meth:`threading.Thread.setName`:
-    use :attr:`threading.Thread.name` attribute.
-  * :meth:`!threading.currentThread`: use :meth:`threading.current_thread`.
-  * :meth:`!threading.activeCount`: use :meth:`threading.active_count`.
-
-* :class:`typing.Text` (:gh:`92332`).
-
-* :class:`unittest.IsolatedAsyncioTestCase`: it is deprecated to return a value
-  that is not ``None`` from a test case.
-
-* :mod:`urllib.parse` deprecated functions: :func:`~urllib.parse.urlparse` instead
-
-  * ``splitattr()``
-  * ``splithost()``
-  * ``splitnport()``
-  * ``splitpasswd()``
-  * ``splitport()``
-  * ``splitquery()``
-  * ``splittag()``
-  * ``splittype()``
-  * ``splituser()``
-  * ``splitvalue()``
-  * ``to_bytes()``
-
-* :mod:`urllib.request`: :class:`~urllib.request.URLopener` and
-  :class:`~urllib.request.FancyURLopener` style of invoking requests is
-  deprecated. Use newer :func:`~urllib.request.urlopen` functions and methods.
-
-* :mod:`wsgiref`: ``SimpleHandler.stdout.write()`` should not do partial
-  writes.
-
-* :meth:`zipimport.zipimporter.load_module` is deprecated:
-  use :meth:`~zipimport.zipimporter.exec_module` instead.
-
-
-Removed
-=======
+Removed Modules And APIs
+========================
 
 .. _whatsnew313-pep594:
 
@@ -1800,7 +1369,478 @@ webbrowser
   attribute instead.
   (Contributed by Nikita Sobolev in :gh:`105546`.)
 
-CPython bytecode changes
+Deprecated Modules And APIs
+===========================
+
+* Removed chained :class:`classmethod` descriptors (introduced in
+  :gh:`63272`).  This can no longer be used to wrap other descriptors
+  such as :class:`property`.  The core design of this feature was flawed
+  and caused a number of downstream problems.  To "pass-through" a
+  :class:`classmethod`, consider using the :attr:`!__wrapped__`
+  attribute that was added in Python 3.10.  (Contributed by Raymond
+  Hettinger in :gh:`89519`.)
+
+* :mod:`array`: :mod:`array`'s ``'u'`` format code, deprecated in docs since Python 3.3,
+  emits :exc:`DeprecationWarning` since 3.13
+  and will be removed in Python 3.16.
+  Use the ``'w'`` format code instead.
+  (Contributed by Hugo van Kemenade in :gh:`80480`.)
+
+* :mod:`ctypes`: Deprecate undocumented :func:`!ctypes.SetPointerType`
+  and :func:`!ctypes.ARRAY` functions.
+  Replace ``ctypes.ARRAY(item_type, size)`` with ``item_type * size``.
+  (Contributed by Victor Stinner in :gh:`105733`.)
+
+* :mod:`decimal`: Deprecate non-standard format specifier "N" for
+  :class:`decimal.Decimal`.
+  It was not documented and only supported in the C implementation.
+  (Contributed by Serhiy Storchaka in :gh:`89902`.)
+
+* :mod:`dis`: The ``dis.HAVE_ARGUMENT`` separator is deprecated. Check
+  membership in :data:`~dis.hasarg` instead.
+  (Contributed by Irit Katriel in :gh:`109319`.)
+
+* :ref:`frame-objects`:
+  Calling :meth:`frame.clear` on a suspended frame raises :exc:`RuntimeError`
+  (as has always been the case for an executing frame).
+  (Contributed by Irit Katriel in :gh:`79932`.)
+
+* :mod:`getopt` and :mod:`optparse` modules: They are now
+  :term:`soft deprecated`: the :mod:`argparse` module should be used for new projects.
+  Previously, the :mod:`optparse` module was already deprecated, its removal
+  was not scheduled, and no warnings was emitted: so there is no change in
+  practice.
+  (Contributed by Victor Stinner in :gh:`106535`.)
+
+* :mod:`gettext`: Emit deprecation warning for non-integer numbers in
+  :mod:`gettext` functions and methods that consider plural forms even if the
+  translation was not found.
+  (Contributed by Serhiy Storchaka in :gh:`88434`.)
+
+* :mod:`glob`: The undocumented :func:`!glob.glob0` and :func:`!glob.glob1`
+  functions are deprecated. Use :func:`glob.glob` and pass a directory to its
+  *root_dir* argument instead.
+  (Contributed by Barney Gale in :gh:`117337`.)
+
+* :mod:`http.server`: :class:`http.server.CGIHTTPRequestHandler` now emits a
+  :exc:`DeprecationWarning` as it will be removed in 3.15.  Process-based CGI
+  HTTP servers have been out of favor for a very long time.  This code was
+  outdated, unmaintained, and rarely used.  It has a high potential for both
+  security and functionality bugs.  This includes removal of the ``--cgi``
+  flag to the ``python -m http.server`` command line in 3.15.
+
+* :mod:`mimetypes`: Passing file path instead of URL in :func:`~mimetypes.guess_type` is
+  :term:`soft deprecated`. Use :func:`~mimetypes.guess_file_type` instead.
+  (Contributed by Serhiy Storchaka in :gh:`66543`.)
+
+* :mod:`re`: Passing optional arguments *maxsplit*, *count* and *flags* in module-level
+  functions :func:`re.split`, :func:`re.sub` and :func:`re.subn` as positional
+  arguments is now deprecated. In future Python versions these parameters will be
+  :ref:`keyword-only <keyword-only_parameter>`.
+  (Contributed by Serhiy Storchaka in :gh:`56166`.)
+
+* :mod:`pathlib`:
+  :meth:`pathlib.PurePath.is_reserved` is deprecated and scheduled for
+  removal in Python 3.15. Use :func:`os.path.isreserved` to detect reserved
+  paths on Windows.
+
+* :mod:`platform`:
+  :func:`~platform.java_ver` is deprecated and will be removed in 3.15.
+  It was largely untested, had a confusing API,
+  and was only useful for Jython support.
+  (Contributed by Nikita Sobolev in :gh:`116349`.)
+
+* :mod:`pydoc`: Deprecate undocumented :func:`!pydoc.ispackage` function.
+  (Contributed by Zackery Spytz in :gh:`64020`.)
+
+* :mod:`sqlite3`: Passing more than one positional argument to
+  :func:`sqlite3.connect` and the :class:`sqlite3.Connection` constructor is
+  deprecated. The remaining parameters will become keyword-only in Python 3.15.
+
+  Deprecate passing name, number of arguments, and the callable as keyword
+  arguments for the following :class:`sqlite3.Connection` APIs:
+
+  * :meth:`~sqlite3.Connection.create_function`
+  * :meth:`~sqlite3.Connection.create_aggregate`
+
+  Deprecate passing the callback callable by keyword for the following
+  :class:`sqlite3.Connection` APIs:
+
+  * :meth:`~sqlite3.Connection.set_authorizer`
+  * :meth:`~sqlite3.Connection.set_progress_handler`
+  * :meth:`~sqlite3.Connection.set_trace_callback`
+
+  The affected parameters will become positional-only in Python 3.15.
+
+  (Contributed by Erlend E. Aasland in :gh:`107948` and :gh:`108278`.)
+
+* :mod:`sys`: :func:`sys._enablelegacywindowsfsencoding` function.
+  Replace it with the :envvar:`PYTHONLEGACYWINDOWSFSENCODING` environment variable.
+  (Contributed by Inada Naoki in :gh:`73427`.)
+
+* :mod:`tarfile`:
+  The undocumented and unused ``tarfile`` attribute of :class:`tarfile.TarFile`
+  is deprecated and scheduled for removal in Python 3.16.
+
+* :mod:`traceback`: The field *exc_type* of :class:`traceback.TracebackException`
+  is deprecated. Use *exc_type_str* instead.
+
+* :mod:`typing`:
+
+  * Creating a :class:`typing.NamedTuple` class using keyword arguments to denote
+    the fields (``NT = NamedTuple("NT", x=int, y=int)``) is deprecated, and will
+    be disallowed in Python 3.15. Use the class-based syntax or the functional
+    syntax instead. (Contributed by Alex Waygood in :gh:`105566`.)
+
+  * When using the functional syntax to create a :class:`typing.NamedTuple`
+    class or a :class:`typing.TypedDict` class, failing to pass a value to the
+    'fields' parameter (``NT = NamedTuple("NT")`` or ``TD = TypedDict("TD")``) is
+    deprecated. Passing ``None`` to the 'fields' parameter
+    (``NT = NamedTuple("NT", None)`` or ``TD = TypedDict("TD", None)``) is also
+    deprecated. Both will be disallowed in Python 3.15. To create a NamedTuple
+    class with 0 fields, use ``class NT(NamedTuple): pass`` or
+    ``NT = NamedTuple("NT", [])``. To create a TypedDict class with 0 fields, use
+    ``class TD(TypedDict): pass`` or ``TD = TypedDict("TD", {})``.
+    (Contributed by Alex Waygood in :gh:`105566` and :gh:`105570`.)
+
+  * :func:`typing.no_type_check_decorator` is deprecated, and scheduled for
+    removal in Python 3.15. After eight years in the :mod:`typing` module, it
+    has yet to be supported by any major type checkers.
+    (Contributed by Alex Waygood in :gh:`106309`.)
+
+  * :data:`typing.AnyStr` is deprecated. In Python 3.16, it will be removed from
+    ``typing.__all__``, and a :exc:`DeprecationWarning` will be emitted when it
+    is imported or accessed. It will be removed entirely in Python 3.18. Use
+    the new :ref:`type parameter syntax <type-params>` instead.
+    (Contributed by Michael The in :gh:`107116`.)
+
+* :ref:`user-defined-funcs`:
+  Assignment to a function's :attr:`~function.__code__` attribute where the new code
+  object's type does not match the function's type, is deprecated. The
+  different types are: plain function, generator, async generator and
+  coroutine.
+  (Contributed by Irit Katriel in :gh:`81137`.)
+
+* :mod:`wave`: Deprecate the ``getmark()``, ``setmark()`` and ``getmarkers()``
+  methods of the :class:`wave.Wave_read` and :class:`wave.Wave_write` classes.
+  They will be removed in Python 3.15.
+  (Contributed by Victor Stinner in :gh:`105096`.)
+
+.. Add deprecations above alphabetically, not here at the end.
+
+Pending Removal in Python 3.14
+------------------------------
+
+* :mod:`argparse`: The *type*, *choices*, and *metavar* parameters
+  of :class:`!argparse.BooleanOptionalAction` are deprecated
+  and will be removed in 3.14.
+  (Contributed by Nikita Sobolev in :gh:`92248`.)
+
+* :mod:`ast`: The following features have been deprecated in documentation
+  since Python 3.8, now cause a :exc:`DeprecationWarning` to be emitted at
+  runtime when they are accessed or used, and will be removed in Python 3.14:
+
+  * :class:`!ast.Num`
+  * :class:`!ast.Str`
+  * :class:`!ast.Bytes`
+  * :class:`!ast.NameConstant`
+  * :class:`!ast.Ellipsis`
+
+  Use :class:`ast.Constant` instead.
+  (Contributed by Serhiy Storchaka in :gh:`90953`.)
+
+* :mod:`collections.abc`: Deprecated :class:`~collections.abc.ByteString`.
+  Prefer :class:`!Sequence` or :class:`~collections.abc.Buffer`.
+  For use in typing, prefer a union, like ``bytes | bytearray``,
+  or :class:`collections.abc.Buffer`.
+  (Contributed by Shantanu Jain in :gh:`91896`.)
+
+* :mod:`email`: Deprecated the *isdst* parameter in :func:`email.utils.localtime`.
+  (Contributed by Alan Williams in :gh:`72346`.)
+
+* :mod:`importlib`: ``__package__`` and ``__cached__`` will cease to be set or
+  taken into consideration by the import system (:gh:`97879`).
+
+* :mod:`importlib.abc` deprecated classes:
+
+  * :class:`!importlib.abc.ResourceReader`
+  * :class:`!importlib.abc.Traversable`
+  * :class:`!importlib.abc.TraversableResources`
+
+  Use :mod:`importlib.resources.abc` classes instead:
+
+  * :class:`importlib.resources.abc.Traversable`
+  * :class:`importlib.resources.abc.TraversableResources`
+
+  (Contributed by Jason R. Coombs and Hugo van Kemenade in :gh:`93963`.)
+
+* :mod:`itertools` had undocumented, inefficient, historically buggy,
+  and inconsistent support for copy, deepcopy, and pickle operations.
+  This will be removed in 3.14 for a significant reduction in code
+  volume and maintenance burden.
+  (Contributed by Raymond Hettinger in :gh:`101588`.)
+
+* :mod:`multiprocessing`: The default start method will change to a safer one on
+  Linux, BSDs, and other non-macOS POSIX platforms where ``'fork'`` is currently
+  the default (:gh:`84559`). Adding a runtime warning about this was deemed too
+  disruptive as the majority of code is not expected to care. Use the
+  :func:`~multiprocessing.get_context` or
+  :func:`~multiprocessing.set_start_method` APIs to explicitly specify when
+  your code *requires* ``'fork'``.  See :ref:`multiprocessing-start-methods`.
+
+* :mod:`pathlib`: :meth:`~pathlib.PurePath.is_relative_to` and
+  :meth:`~pathlib.PurePath.relative_to`: passing additional arguments is
+  deprecated.
+
+* :mod:`pkgutil`: :func:`~pkgutil.find_loader` and :func:`~pkgutil.get_loader`
+  now raise :exc:`DeprecationWarning`;
+  use :func:`importlib.util.find_spec` instead.
+  (Contributed by Nikita Sobolev in :gh:`97850`.)
+
+* :mod:`pty`:
+
+  * ``master_open()``: use :func:`pty.openpty`.
+  * ``slave_open()``: use :func:`pty.openpty`.
+
+* :func:`shutil.rmtree` *onerror* parameter is deprecated in 3.12,
+  and will be removed in 3.14: use the *onexc* parameter instead.
+
+* :mod:`sqlite3`:
+
+  * :data:`~sqlite3.version` and :data:`~sqlite3.version_info`.
+
+  * :meth:`~sqlite3.Cursor.execute` and :meth:`~sqlite3.Cursor.executemany`
+    if :ref:`named placeholders <sqlite3-placeholders>` are used and
+    *parameters* is a sequence instead of a :class:`dict`.
+
+  * date and datetime adapter, date and timestamp converter:
+    see the :mod:`sqlite3` documentation for suggested replacement recipes.
+
+* :class:`types.CodeType`: Accessing :attr:`~codeobject.co_lnotab` was
+  deprecated in :pep:`626`
+  since 3.10 and was planned to be removed in 3.12,
+  but it only got a proper :exc:`DeprecationWarning` in 3.12.
+  May be removed in 3.14.
+  (Contributed by Nikita Sobolev in :gh:`101866`.)
+
+* :mod:`typing`: :class:`~typing.ByteString`, deprecated since Python 3.9,
+  now causes a :exc:`DeprecationWarning` to be emitted when it is used.
+
+* :mod:`urllib`:
+  :class:`!urllib.parse.Quoter` is deprecated: it was not intended to be a
+  public API.
+  (Contributed by Gregory P. Smith in :gh:`88168`.)
+
+* :mod:`xml.etree.ElementTree`: Testing the truth value of an
+  :class:`~xml.etree.ElementTree.Element` is deprecated and will raise an
+  exception in Python 3.14.
+
+
+Pending Removal in Python 3.15
+------------------------------
+
+* :class:`http.server.CGIHTTPRequestHandler` will be removed along with its
+  related ``--cgi`` flag to ``python -m http.server``.  It was obsolete and
+  rarely used.  No direct replacement exists.  *Anything* is better than CGI
+  to interface a web server with a request handler.
+
+* :class:`locale`: :func:`locale.getdefaultlocale` was deprecated in Python 3.11
+  and originally planned for removal in Python 3.13 (:gh:`90817`),
+  but removal has been postponed to Python 3.15.
+  Use :func:`locale.setlocale()`, :func:`locale.getencoding()` and
+  :func:`locale.getlocale()` instead.
+  (Contributed by Hugo van Kemenade in :gh:`111187`.)
+
+* :mod:`pathlib`:
+  :meth:`pathlib.PurePath.is_reserved` is deprecated and scheduled for
+  removal in Python 3.15. Use :func:`os.path.isreserved` to detect reserved
+  paths on Windows.
+
+* :mod:`platform`:
+  :func:`~platform.java_ver` is deprecated and will be removed in 3.15.
+  It was largely untested, had a confusing API,
+  and was only useful for Jython support.
+  (Contributed by Nikita Sobolev in :gh:`116349`.)
+
+* :mod:`threading`:
+  Passing any arguments to :func:`threading.RLock` is now deprecated.
+  C version allows any numbers of args and kwargs,
+  but they are just ignored. Python version does not allow any arguments.
+  All arguments will be removed from :func:`threading.RLock` in Python 3.15.
+  (Contributed by Nikita Sobolev in :gh:`102029`.)
+
+* :class:`typing.NamedTuple`:
+
+  * The undocumented keyword argument syntax for creating :class:`!NamedTuple` classes
+    (``NT = NamedTuple("NT", x=int)``) is deprecated, and will be disallowed in
+    3.15. Use the class-based syntax or the functional syntax instead.
+
+  * When using the functional syntax to create a :class:`!NamedTuple` class, failing to
+    pass a value to the *fields* parameter (``NT = NamedTuple("NT")``) is
+    deprecated. Passing ``None`` to the *fields* parameter
+    (``NT = NamedTuple("NT", None)``) is also deprecated. Both will be
+    disallowed in Python 3.15. To create a :class:`!NamedTuple` class with 0 fields, use
+    ``class NT(NamedTuple): pass`` or ``NT = NamedTuple("NT", [])``.
+
+* :class:`typing.TypedDict`: When using the functional syntax to create a
+  :class:`!TypedDict` class, failing to pass a value to the *fields* parameter (``TD =
+  TypedDict("TD")``) is deprecated. Passing ``None`` to the *fields* parameter
+  (``TD = TypedDict("TD", None)``) is also deprecated. Both will be disallowed
+  in Python 3.15. To create a :class:`!TypedDict` class with 0 fields, use ``class
+  TD(TypedDict): pass`` or ``TD = TypedDict("TD", {})``.
+
+* :mod:`wave`: Deprecate the ``getmark()``, ``setmark()`` and ``getmarkers()``
+  methods of the :class:`wave.Wave_read` and :class:`wave.Wave_write` classes.
+  They will be removed in Python 3.15.
+  (Contributed by Victor Stinner in :gh:`105096`.)
+
+Pending Removal in Python 3.16
+------------------------------
+
+* :class:`array.array` ``'u'`` type (:c:type:`wchar_t`):
+  use the ``'w'`` type instead (``Py_UCS4``).
+
+Pending Removal in Future Versions
+----------------------------------
+
+The following APIs were deprecated in earlier Python versions and will be removed,
+although there is currently no date scheduled for their removal.
+
+* :mod:`argparse`: Nesting argument groups and nesting mutually exclusive
+  groups are deprecated.
+
+* :mod:`builtins`:
+
+  * ``~bool``, bitwise inversion on bool.
+  * ``bool(NotImplemented)``.
+  * Generators: ``throw(type, exc, tb)`` and ``athrow(type, exc, tb)``
+    signature is deprecated: use ``throw(exc)`` and ``athrow(exc)`` instead,
+    the single argument signature.
+  * Currently Python accepts numeric literals immediately followed by keywords,
+    for example ``0in x``, ``1or x``, ``0if 1else 2``.  It allows confusing and
+    ambiguous expressions like ``[0x1for x in y]`` (which can be interpreted as
+    ``[0x1 for x in y]`` or ``[0x1f or x in y]``).  A syntax warning is raised
+    if the numeric literal is immediately followed by one of keywords
+    :keyword:`and`, :keyword:`else`, :keyword:`for`, :keyword:`if`,
+    :keyword:`in`, :keyword:`is` and :keyword:`or`.  In a future release it
+    will be changed to a syntax error. (:gh:`87999`)
+  * Support for ``__index__()`` and ``__int__()`` method returning non-int type:
+    these methods will be required to return an instance of a strict subclass of
+    :class:`int`.
+  * Support for ``__float__()`` method returning a strict subclass of
+    :class:`float`: these methods will be required to return an instance of
+    :class:`float`.
+  * Support for ``__complex__()`` method returning a strict subclass of
+    :class:`complex`: these methods will be required to return an instance of
+    :class:`complex`.
+  * Delegation of ``int()`` to ``__trunc__()`` method.
+
+* :mod:`calendar`: ``calendar.January`` and ``calendar.February`` constants are
+  deprecated and replaced by :data:`calendar.JANUARY` and
+  :data:`calendar.FEBRUARY`.
+  (Contributed by Prince Roshan in :gh:`103636`.)
+
+* :attr:`codeobject.co_lnotab`: use the :meth:`codeobject.co_lines` method
+  instead.
+
+* :mod:`datetime`:
+
+  * :meth:`~datetime.datetime.utcnow`:
+    use ``datetime.datetime.now(tz=datetime.UTC)``.
+  * :meth:`~datetime.datetime.utcfromtimestamp`:
+    use ``datetime.datetime.fromtimestamp(timestamp, tz=datetime.UTC)``.
+
+* :mod:`gettext`: Plural value must be an integer.
+
+* :mod:`importlib`:
+
+  * ``load_module()`` method: use ``exec_module()`` instead.
+  * :func:`~importlib.util.cache_from_source` *debug_override* parameter is
+    deprecated: use the *optimization* parameter instead.
+
+* :mod:`importlib.metadata`:
+
+  * ``EntryPoints`` tuple interface.
+  * Implicit ``None`` on return values.
+
+* :mod:`mailbox`: Use of StringIO input and text mode is deprecated, use
+  BytesIO and binary mode instead.
+
+* :mod:`os`: Calling :func:`os.register_at_fork` in multi-threaded process.
+
+* :class:`!pydoc.ErrorDuringImport`: A tuple value for *exc_info* parameter is
+  deprecated, use an exception instance.
+
+* :mod:`re`: More strict rules are now applied for numerical group references
+  and group names in regular expressions.  Only sequence of ASCII digits is now
+  accepted as a numerical reference.  The group name in bytes patterns and
+  replacement strings can now only contain ASCII letters and digits and
+  underscore.
+  (Contributed by Serhiy Storchaka in :gh:`91760`.)
+
+* :mod:`!sre_compile`, :mod:`!sre_constants` and :mod:`!sre_parse` modules.
+
+* :mod:`ssl` options and protocols:
+
+  * :class:`ssl.SSLContext` without protocol argument is deprecated.
+  * :class:`ssl.SSLContext`: :meth:`~ssl.SSLContext.set_npn_protocols` and
+    :meth:`!selected_npn_protocol` are deprecated: use ALPN
+    instead.
+  * ``ssl.OP_NO_SSL*`` options
+  * ``ssl.OP_NO_TLS*`` options
+  * ``ssl.PROTOCOL_SSLv3``
+  * ``ssl.PROTOCOL_TLS``
+  * ``ssl.PROTOCOL_TLSv1``
+  * ``ssl.PROTOCOL_TLSv1_1``
+  * ``ssl.PROTOCOL_TLSv1_2``
+  * ``ssl.TLSVersion.SSLv3``
+  * ``ssl.TLSVersion.TLSv1``
+  * ``ssl.TLSVersion.TLSv1_1``
+
+* :func:`sysconfig.is_python_build` *check_home* parameter is deprecated and
+  ignored.
+
+* :mod:`threading` methods:
+
+  * :meth:`!threading.Condition.notifyAll`: use :meth:`~threading.Condition.notify_all`.
+  * :meth:`!threading.Event.isSet`: use :meth:`~threading.Event.is_set`.
+  * :meth:`!threading.Thread.isDaemon`, :meth:`threading.Thread.setDaemon`:
+    use :attr:`threading.Thread.daemon` attribute.
+  * :meth:`!threading.Thread.getName`, :meth:`threading.Thread.setName`:
+    use :attr:`threading.Thread.name` attribute.
+  * :meth:`!threading.currentThread`: use :meth:`threading.current_thread`.
+  * :meth:`!threading.activeCount`: use :meth:`threading.active_count`.
+
+* :class:`typing.Text` (:gh:`92332`).
+
+* :class:`unittest.IsolatedAsyncioTestCase`: it is deprecated to return a value
+  that is not ``None`` from a test case.
+
+* :mod:`urllib.parse` deprecated functions: :func:`~urllib.parse.urlparse` instead
+
+  * ``splitattr()``
+  * ``splithost()``
+  * ``splitnport()``
+  * ``splitpasswd()``
+  * ``splitport()``
+  * ``splitquery()``
+  * ``splittag()``
+  * ``splittype()``
+  * ``splituser()``
+  * ``splitvalue()``
+  * ``to_bytes()``
+
+* :mod:`urllib.request`: :class:`~urllib.request.URLopener` and
+  :class:`~urllib.request.FancyURLopener` style of invoking requests is
+  deprecated. Use newer :func:`~urllib.request.urlopen` functions and methods.
+
+* :mod:`wsgiref`: ``SimpleHandler.stdout.write()`` should not do partial
+  writes.
+
+* :meth:`zipimport.zipimporter.load_module` is deprecated:
+  use :meth:`~zipimport.zipimporter.exec_module` instead.
+
+CPython Bytecode Changes
 ========================
 
 * The oparg of ``YIELD_VALUE`` is now ``1`` if the yield is part of a
@@ -1808,67 +1848,6 @@ CPython bytecode changes
   changed to add a bit indicating whether the except-depth is 1, which
   is needed to optimize closing of generators.
   (Contributed by Irit Katriel in :gh:`111354`.)
-
-Porting to Python 3.13
-======================
-
-This section lists previously described changes and other bugfixes
-that may require changes to your code.
-
-Changes in the Python API
--------------------------
-
-* Functions :c:func:`PyDict_GetItem`, :c:func:`PyDict_GetItemString`,
-  :c:func:`PyMapping_HasKey`, :c:func:`PyMapping_HasKeyString`,
-  :c:func:`PyObject_HasAttr`, :c:func:`PyObject_HasAttrString`, and
-  :c:func:`PySys_GetObject`, which clear all errors which occurred when calling
-  them, now report them using :func:`sys.unraisablehook`.
-  You may replace them with other functions as
-  recommended in the documentation.
-  (Contributed by Serhiy Storchaka in :gh:`106672`.)
-
-* An :exc:`OSError` is now raised by :func:`getpass.getuser` for any failure to
-  retrieve a username, instead of :exc:`ImportError` on non-Unix platforms or
-  :exc:`KeyError` on Unix platforms where the password database is empty.
-
-* The :mod:`threading` module now expects the :mod:`!_thread` module to have
-  an ``_is_main_interpreter`` attribute.  It is a function with no
-  arguments that return ``True`` if the current interpreter is the
-  main interpreter.
-
-  Any library or application that provides a custom ``_thread`` module
-  must provide ``_is_main_interpreter()``, just like the module's
-  other "private" attributes.
-  (See :gh:`112826`.)
-
-* :class:`mailbox.Maildir` now ignores files with a leading dot.
-  (Contributed by Zackery Spytz in :gh:`65559`.)
-
-* :meth:`pathlib.Path.glob` and :meth:`~pathlib.Path.rglob` now return both
-  files and directories if a pattern that ends with "``**``" is given, rather
-  than directories only. Users may add a trailing slash to match only
-  directories.
-
-* The value of the :attr:`!mode` attribute of :class:`gzip.GzipFile` was
-  changed from integer (``1`` or ``2``) to string (``'rb'`` or ``'wb'``).
-  The value of the :attr:`!mode` attribute of the readable file-like object
-  returned by :meth:`zipfile.ZipFile.open` was changed from ``'r'`` to ``'rb'``.
-  (Contributed by Serhiy Storchaka in :gh:`115961`.)
-
-* :c:func:`!PyCode_GetFirstFree` is an unstable API now and has been renamed
-  to :c:func:`PyUnstable_Code_GetFirstFree`.
-  (Contributed by Bogdan Romanyuk in :gh:`115781`.)
-
-* Callbacks registered in the :mod:`tkinter` module now take arguments as
-  various Python objects (``int``, ``float``, ``bytes``, ``tuple``),
-  not just ``str``.
-  To restore the previous behavior set :mod:`!tkinter` module global
-  :data:`!wantobject` to ``1`` before creating the
-  :class:`!Tk` object or call the :meth:`!wantobject`
-  method of the :class:`!Tk` object with argument ``1``.
-  Calling it with argument ``2`` restores the current default behavior.
-  (Contributed by Serhiy Storchaka in :gh:`66410`.)
-
 
 Build Changes
 =============
@@ -1896,8 +1875,7 @@ Build Changes
   ``termios``, ``winsound``,
   ``_ctypes_test``, ``_multiprocessing.posixshmem``, ``_scproxy``, ``_stat``,
   ``_statistics``, ``_testconsole``, ``_testimportmultiple`` and ``_uuid``
-  C extensions are now built with the
-  :ref:`limited C API <limited-c-api>`.
+  C extensions are now built with the :ref:`limited C API <limited-c-api>`.
   (Contributed by Victor Stinner in :gh:`85283`.)
 
 * ``wasm32-wasi`` is now a :pep:`11` tier 2 platform.
@@ -2129,7 +2107,49 @@ New Features
 
 
 Porting to Python 3.13
-----------------------
+======================
+
+This section lists previously described changes and other bugfixes
+that may require changes to your code.
+
+Changes in the Python API
+-------------------------
+
+* An :exc:`OSError` is now raised by :func:`getpass.getuser` for any failure to
+  retrieve a username, instead of :exc:`ImportError` on non-Unix platforms or
+  :exc:`KeyError` on Unix platforms where the password database is empty.
+
+* The :mod:`threading` module now expects the :mod:`!_thread` module to have
+  an ``_is_main_interpreter`` attribute.  It is a function with no
+  arguments that return ``True`` if the current interpreter is the
+  main interpreter.
+
+  Any library or application that provides a custom ``_thread`` module
+  must provide ``_is_main_interpreter()``, just like the module's
+  other "private" attributes.
+  (See :gh:`112826`.)
+
+* :class:`mailbox.Maildir` now ignores files with a leading dot.
+  (Contributed by Zackery Spytz in :gh:`65559`.)
+
+* :meth:`pathlib.Path.glob` and :meth:`~pathlib.Path.rglob` now return both
+  files and directories if a pattern that ends with "``**``" is given, rather
+  than directories only. Users may add a trailing slash to match only
+  directories.
+
+* The value of the :attr:`!mode` attribute of :class:`gzip.GzipFile` was
+  changed from integer (``1`` or ``2``) to string (``'rb'`` or ``'wb'``).
+  The value of the :attr:`!mode` attribute of the readable file-like object
+  returned by :meth:`zipfile.ZipFile.open` was changed from ``'r'`` to ``'rb'``.
+  (Contributed by Serhiy Storchaka in :gh:`115961`.)
+
+* :c:func:`!PyCode_GetFirstFree` is an unstable API now and has been renamed
+  to :c:func:`PyUnstable_Code_GetFirstFree`.
+  (Contributed by Bogdan Romanyuk in :gh:`115781`.)
+
+
+Changes in the C API
+--------------------
 
 * ``Python.h`` no longer includes the ``<ieeefp.h>`` standard header. It was
   included for the ``finite()`` function which is now provided by the
@@ -2184,17 +2204,21 @@ Porting to Python 3.13
     }
 
   Note that ``Py_TRASHCAN_BEGIN`` has a second argument which
-  should be the deallocation function it is in.
+  should be the deallocation function it is in. The new macros were
+  added in Python 3.8 and the old macros were deprecated in Python 3.11.
+  (Contributed by Irit Katriel in :gh:`105111`.)
 
-Deprecated
-----------
+* Functions :c:func:`PyDict_GetItem`, :c:func:`PyDict_GetItemString`,
+  :c:func:`PyMapping_HasKey`, :c:func:`PyMapping_HasKeyString`,
+  :c:func:`PyObject_HasAttr`, :c:func:`PyObject_HasAttrString`, and
+  :c:func:`PySys_GetObject`, which clear all errors which occurred when calling
+  them, now report them using :func:`sys.unraisablehook`.
+  You may replace them with other functions as
+  recommended in the documentation.
+  (Contributed by Serhiy Storchaka in :gh:`106672`.)
 
-* Passing optional arguments *maxsplit*, *count* and *flags* in module-level
-  functions :func:`re.split`, :func:`re.sub` and :func:`re.subn` as positional
-  arguments is now deprecated.
-  In future Python versions these parameters will be
-  :ref:`keyword-only <keyword-only_parameter>`.
-  (Contributed by Serhiy Storchaka in :gh:`56166`.)
+Deprecated C APIs
+-----------------
 
 * Deprecate the old ``Py_UNICODE`` and ``PY_UNICODE_TYPE`` types: use directly
   the :c:type:`wchar_t` type instead. Since Python 3.3, ``Py_UNICODE`` and
@@ -2229,16 +2253,8 @@ Deprecated
   :c:func:`PyWeakref_GetRef` on Python 3.12 and older.
   (Contributed by Victor Stinner in :gh:`105927`.)
 
-Removed
--------
-
-* Removed chained :class:`classmethod` descriptors (introduced in
-  :gh:`63272`).  This can no longer be used to wrap other descriptors
-  such as :class:`property`.  The core design of this feature was flawed
-  and caused a number of downstream problems.  To "pass-through" a
-  :class:`classmethod`, consider using the :attr:`!__wrapped__`
-  attribute that was added in Python 3.10.  (Contributed by Raymond
-  Hettinger in :gh:`89519`.)
+Removed C APIs
+--------------
 
 * Remove many APIs (functions, macros, variables) with names prefixed by
   ``_Py`` or ``_PY`` (considered as private API). If your project is affected
@@ -2318,12 +2334,6 @@ Removed
   Configuration <init-config>` instead (:pep:`587`), added to Python 3.8.
   (Contributed by Victor Stinner in :gh:`105145`.)
 
-* Remove the old trashcan macros ``Py_TRASHCAN_SAFE_BEGIN`` and
-  ``Py_TRASHCAN_SAFE_END``.  They should be replaced by the new macros
-  ``Py_TRASHCAN_BEGIN`` and ``Py_TRASHCAN_END``.  The new macros were
-  added in Python 3.8 and the old macros were deprecated in Python 3.11.
-  (Contributed by Irit Katriel in :gh:`105111`.)
-
 * Remove ``PyEval_ThreadsInitialized()``
   function, deprecated in Python 3.9. Since Python 3.7, ``Py_Initialize()``
   always creates the GIL: calling ``PyEval_InitThreads()`` does nothing and
@@ -2365,6 +2375,7 @@ Pending Removal in Python 3.14
 
 * Creating immutable types (:c:macro:`Py_TPFLAGS_IMMUTABLETYPE`) with mutable
   bases using the C API.
+
 * Functions to configure the Python initialization, deprecated in Python 3.11:
 
   * ``PySys_SetArgvEx()``: set :c:member:`PyConfig.argv` instead.


### PR DESCRIPTION
Make a rough editorial pass over Python 3.13's What's New document. Add the release highlights, remove or merge some duplicated entries, and reorder some of the sections (removals should really go before future deprecations since they're much more important).


<!-- gh-issue-number: gh-109975 -->
* Issue: gh-109975
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--118711.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->