### PR TITLE
[3.12] GH-118701: Note that recursive wildcards aren't supported in `PurePath.match()`

### DIFF
--- a/Doc/library/pathlib.rst
+++ b/Doc/library/pathlib.rst
@@ -583,6 +583,10 @@ Pure paths provide the following methods and properties:
       >>> PurePath('a/b.py').match(pattern)
       True
 
+   .. note::
+      The recursive wildcard "``**``" isn't supported by this method (it acts
+      like non-recursive "``*``".)
+
    .. versionchanged:: 3.12
       Accepts an object implementing the :class:`os.PathLike` interface.
 


### PR DESCRIPTION


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--118713.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->

<!-- gh-issue-number: gh-118701 -->
* Issue: gh-118701
<!-- /gh-issue-number -->
