### PR TITLE
gh-118716: Do not enforce ASCII to format address

### DIFF
--- a/Lib/email/headerregistry.py
+++ b/Lib/email/headerregistry.py
@@ -45,8 +45,9 @@ class Address:
                 raise ValueError("Invalid addr_spec; only '{}' "
                                  "could be parsed from '{}'".format(
                                     a_s, addr_spec))
-            if a_s.all_defects:
-                raise a_s.all_defects[0]
+            for defect in a_s.all_defects:
+                if not isinstance(defect, errors.NonASCIILocalPartDefect):
+                    raise defect
             username = a_s.local_part
             domain = a_s.domain
         self._display_name = display_name

--- a/Lib/test/test_email/test_headerregistry.py
+++ b/Lib/test/test_email/test_headerregistry.py
@@ -1492,17 +1492,20 @@ class TestAddressAndGroup(TestEmailBase):
         self.assertEqual(str(a), '"Sara J." <"bad name"@example.com>')
 
     def test_il8n(self):
-        a = Address('Éric', 'wok', 'exàmple.com')
+        a = Address('Éric', 'wők', 'exàmple.com')
         self.assertEqual(a.display_name, 'Éric')
-        self.assertEqual(a.username, 'wok')
+        self.assertEqual(a.username, 'wők')
         self.assertEqual(a.domain, 'exàmple.com')
-        self.assertEqual(a.addr_spec, 'wok@exàmple.com')
-        self.assertEqual(str(a), 'Éric <wok@exàmple.com>')
+        self.assertEqual(a.addr_spec, 'wők@exàmple.com')
+        self.assertEqual(str(a), 'Éric <wők@exàmple.com>')
 
-    # XXX: there is an API design issue that needs to be solved here.
-    #def test_non_ascii_username_raises(self):
-    #    with self.assertRaises(ValueError):
-    #        Address('foo', 'wők', 'example.com')
+    def test_non_ascii_username_in_addr_spec(self):
+        a = Address('foo', addr_spec='wők@example.com')
+        self.assertEqual(a.display_name, 'foo')
+        self.assertEqual(a.username, 'wők')
+        self.assertEqual(a.domain, 'example.com')
+        self.assertEqual(a.addr_spec, 'wők@example.com')
+        self.assertEqual(str(a), 'foo <wők@example.com>')
 
     def test_crlf_in_constructor_args_raises(self):
         cases = (
@@ -1522,10 +1525,6 @@ class TestAddressAndGroup(TestEmailBase):
         for kwargs in cases:
             with self.subTest(kwargs=kwargs), self.assertRaisesRegex(ValueError, "invalid arguments"):
                 Address(**kwargs)
-
-    def test_non_ascii_username_in_addr_spec_raises(self):
-        with self.assertRaises(ValueError):
-            Address('foo', addr_spec='wők@example.com')
 
     def test_address_addr_spec_and_username_raises(self):
         with self.assertRaises(TypeError):

--- a/Misc/NEWS.d/next/Library/2024-05-10-10-42-30.gh-issue-118716.OvpPa-.rst
+++ b/Misc/NEWS.d/next/Library/2024-05-10-10-42-30.gh-issue-118716.OvpPa-.rst
@@ -1,0 +1,1 @@
+Do not fail when parsing email address with non-ASCII local part.


### PR DESCRIPTION
RFC 6530 allows UTF-8 strings

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-118716 -->
* Issue: gh-118716
<!-- /gh-issue-number -->
