### PR TITLE
gh-118561: Fix crash involving list.extend in free-threaded build

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2024-05-07-16-57-56.gh-issue-118561.wNMKVd.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2024-05-07-16-57-56.gh-issue-118561.wNMKVd.rst
@@ -1,0 +1,2 @@
+Fix race condition in free-threaded build where ``list.extend`` could expose
+uninitialied memory to concurrent readers.

--- a/Misc/NEWS.d/next/Core and Builtins/2024-05-07-16-57-56.gh-issue-118561.wNMKVd.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2024-05-07-16-57-56.gh-issue-118561.wNMKVd.rst
@@ -1,2 +1,2 @@
-Fix race condition in free-threaded build where ``list.extend`` could expose
+Fix race condition in free-threaded build where :meth:`list.extend` could expose
 uninitialied memory to concurrent readers.

--- a/Objects/listobject.c
+++ b/Objects/listobject.c
@@ -192,6 +192,7 @@ list_preallocate_exact(PyListObject *self, Py_ssize_t size)
         return -1;
     }
     items = array->ob_item;
+    memset(items, 0, size * sizeof(PyObject *));
 #else
     items = PyMem_New(PyObject*, size);
     if (items == NULL) {
@@ -199,7 +200,7 @@ list_preallocate_exact(PyListObject *self, Py_ssize_t size)
         return -1;
     }
 #endif
-    self->ob_item = items;
+    FT_ATOMIC_STORE_PTR_RELEASE(self->ob_item, items);
     self->allocated = size;
     return 0;
 }


### PR DESCRIPTION
The `list_preallocate_exact` function did not zero initialize array contents. In the free-threaded build, this could expose uninitialized memory to concurrent readers between the call to `list_preallocate_exact` and the filling of the array contents with items.


<!-- gh-issue-number: gh-118561 -->
* Issue: gh-118561
<!-- /gh-issue-number -->
