### PR TITLE
gh-118706: Add default value to `typing.overload` example

### DIFF
--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -2907,7 +2907,7 @@ Functions and decorators
    .. testcode::
 
       @overload
-      def process(response: None) -> None:
+      def process(response: None = ...) -> None:
           ...
       @overload
       def process(response: int) -> tuple[int, str]:
@@ -2915,7 +2915,7 @@ Functions and decorators
       @overload
       def process(response: bytes) -> str:
           ...
-      def process(response):
+      def process(response=None):
           ...  # actual implementation goes here
 
    See :pep:`484` for more details and comparison with other typing semantics.


### PR DESCRIPTION


<!-- gh-issue-number: gh-118706 -->
* Issue: gh-118706
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--118726.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->