### PR TITLE
gh-118729: Temporarily skip `test_multiprocessing_pool_circular_import`

### DIFF
--- a/Lib/test/test_importlib/test_threaded_import.py
+++ b/Lib/test/test_importlib/test_threaded_import.py
@@ -17,7 +17,7 @@ from test import support
 from test.support import verbose
 from test.support.import_helper import forget, mock_register_at_fork
 from test.support.os_helper import (TESTFN, unlink, rmtree)
-from test.support import script_helper, threading_helper
+from test.support import script_helper, threading_helper, requires_gil_enabled
 
 threading_helper.requires_working_threading(module=True)
 
@@ -248,6 +248,9 @@ class ThreadedImportTests(unittest.TestCase):
                           'partial', 'cfimport.py')
         script_helper.assert_python_ok(fn)
 
+    # gh-118727 and gh-118729: pool_in_threads.py may crash in free-threaded
+    # builds, which can hang the Tsan test so temporarily skip it for now.
+    @requires_gil_enabled("gh-118727: test may crash in free-threaded builds")
     def test_multiprocessing_pool_circular_import(self):
         # Regression test for bpo-41567
         fn = os.path.join(os.path.dirname(__file__),


### PR DESCRIPTION
The `pool_in_threads.py` test file may crash in free-threaded builds, which can lead to the Tsan test hanging. Skip it for now until we fix the underlying issue.


<!-- gh-issue-number: gh-118729 -->
* Issue: gh-118729
<!-- /gh-issue-number -->
