### PR TITLE
GH-78707: Drop deprecated `pathlib.PurePath.[is_]relative_to()` arguments

### DIFF
--- a/Doc/whatsnew/3.14.rst
+++ b/Doc/whatsnew/3.14.rst
@@ -114,6 +114,14 @@ email
 * The *isdst* parameter has been removed from :func:`email.utils.localtime`.
   (Contributed by Hugo van Kemenade in :gh:`118798`.)
 
+pathlib
+-------
+
+* Remove support for passing additional positional arguments to
+  :meth:`pathlib.PurePath.relative_to` and
+  :meth:`~pathlib.PurePath.is_relative_to`. In previous versions, any such
+  arguments are joined onto *other*.
+
 Others
 ------
 
@@ -128,15 +136,6 @@ Others
 * :mod:`itertools` support for copy, deepcopy, and pickle operations.
   These had previously raised a :exc:`DeprecationWarning` since Python 3.12.
   (Contributed by Raymond Hettinger in :gh:`101588`.)
-
-
-pathlib
--------
-
-* Remove support for passing additional positional arguments to
-  :meth:`~pathlib.PurePath.is_relative_to` and
-  :meth:`~pathlib.PurePath.relative_to`. In previous versions, any such
-  arguments are joined onto *other*.
 
 
 Porting to Python 3.14

--- a/Doc/whatsnew/3.14.rst
+++ b/Doc/whatsnew/3.14.rst
@@ -101,6 +101,13 @@ Deprecated
 Removed
 =======
 
+pathlib
+-------
+
+* Remove support for passing additional positional arguments to
+  :meth:`~pathlib.PurePath.is_relative_to` and
+  :meth:`~pathlib.PurePath.relative_to`. In previous versions, any such
+  arguments are joined onto *other*.
 
 
 Porting to Python 3.14

--- a/Lib/pathlib/_local.py
+++ b/Lib/pathlib/_local.py
@@ -362,7 +362,7 @@ class PurePath(PurePathBase):
         tail[-1] = name
         return self._from_parsed_parts(self.drive, self.root, tail)
 
-    def relative_to(self, other, /, *_deprecated, walk_up=False):
+    def relative_to(self, other, *, walk_up=False):
         """Return the relative path to another path identified by the passed
         arguments.  If the operation is not possible (because this is not
         related to the other path), raise ValueError.
@@ -370,13 +370,7 @@ class PurePath(PurePathBase):
         The *walk_up* parameter controls whether `..` may be used to resolve
         the path.
         """
-        if _deprecated:
-            msg = ("support for supplying more than one positional argument "
-                   "to pathlib.PurePath.relative_to() is deprecated and "
-                   "scheduled for removal in Python 3.14")
-            warnings.warn(msg, DeprecationWarning, stacklevel=2)
-            other = self.with_segments(other, *_deprecated)
-        elif not isinstance(other, PurePath):
+        if not isinstance(other, PurePath):
             other = self.with_segments(other)
         for step, path in enumerate(chain([other], other.parents)):
             if path == self or path in self.parents:
@@ -390,16 +384,10 @@ class PurePath(PurePathBase):
         parts = ['..'] * step + self._tail[len(path._tail):]
         return self._from_parsed_parts('', '', parts)
 
-    def is_relative_to(self, other, /, *_deprecated):
+    def is_relative_to(self, other):
         """Return True if the path is relative to another path or False.
         """
-        if _deprecated:
-            msg = ("support for supplying more than one argument to "
-                   "pathlib.PurePath.is_relative_to() is deprecated and "
-                   "scheduled for removal in Python 3.14")
-            warnings.warn(msg, DeprecationWarning, stacklevel=2)
-            other = self.with_segments(other, *_deprecated)
-        elif not isinstance(other, PurePath):
+        if not isinstance(other, PurePath):
             other = self.with_segments(other)
         return other == self or other in self.parents
 

--- a/Lib/test/test_pathlib/test_pathlib.py
+++ b/Lib/test/test_pathlib/test_pathlib.py
@@ -311,19 +311,6 @@ class PurePathTest(test_pathlib_abc.DummyPurePathTest):
         self.assertRaises(ValueError, P('a/b').with_stem, '')
         self.assertRaises(ValueError, P('a/b').with_stem, '.')
 
-    def test_relative_to_several_args(self):
-        P = self.cls
-        p = P('a/b')
-        with self.assertWarns(DeprecationWarning):
-            p.relative_to('a', 'b')
-            p.relative_to('a', 'b', walk_up=True)
-
-    def test_is_relative_to_several_args(self):
-        P = self.cls
-        p = P('a/b')
-        with self.assertWarns(DeprecationWarning):
-            p.is_relative_to('a', 'b')
-
     def test_is_reserved_deprecated(self):
         P = self.cls
         p = P('a/b')

--- a/Misc/NEWS.d/next/Library/2024-05-08-18-59-19.gh-issue-78707._Lz1sw.rst
+++ b/Misc/NEWS.d/next/Library/2024-05-08-18-59-19.gh-issue-78707._Lz1sw.rst
@@ -1,0 +1,3 @@
+Drop support for passing additional positional arguments to
+:meth:`pathlib.PurePath.relative_to` and
+:meth:`~pathlib.PurePath.is_relative_to`.


### PR DESCRIPTION
Remove support for supplying additional positional arguments to `PurePath.relative_to()` and `is_relative_to()`. This has been deprecated since Python 3.12.


<!-- gh-issue-number: gh-78707 -->
* Issue: gh-78707
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--118780.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->