### PR TITLE
gh-118760: Restore the default value of tkinter.wantobjects to 1

### DIFF
--- a/Doc/whatsnew/3.13.rst
+++ b/Doc/whatsnew/3.13.rst
@@ -2169,16 +2169,6 @@ Changes in the Python API
   returned by :meth:`zipfile.ZipFile.open` was changed from ``'r'`` to ``'rb'``.
   (Contributed by Serhiy Storchaka in :gh:`115961`.)
 
-* Callbacks registered in the :mod:`tkinter` module now take arguments as
-  various Python objects (``int``, ``float``, ``bytes``, ``tuple``),
-  not just ``str``.
-  To restore the previous behavior set :mod:`!tkinter` module global
-  :data:`!wantobject` to ``1`` before creating the
-  :class:`!Tk` object or call the :meth:`!wantobject`
-  method of the :class:`!Tk` object with argument ``1``.
-  Calling it with argument ``2`` restores the current default behavior.
-  (Contributed by Serhiy Storchaka in :gh:`66410`.)
-
 
 Changes in the C API
 --------------------

--- a/Lib/tkinter/__init__.py
+++ b/Lib/tkinter/__init__.py
@@ -40,7 +40,7 @@ TclError = _tkinter.TclError
 from tkinter.constants import *
 import re
 
-wantobjects = 2
+wantobjects = 1
 _debug = False  # set to True to print executed Tcl/Tk commands
 
 TkVersion = float(_tkinter.TK_VERSION)

--- a/Misc/NEWS.d/3.13.0b1.rst
+++ b/Misc/NEWS.d/3.13.0b1.rst
@@ -1346,14 +1346,13 @@ urllib.
 .. nonce: du4UKW
 .. section: Library
 
-Add support for passing arguments to callbacks registered in the :mod:`tkinter`
-module as various Python objects (``int``, ``float``, ``bytes``, ``tuple``),
-corresponding to the original Tcl value, not just ``str``, and enable this by default.
-To restore the previous behavior set :mod:`!tkinter` module global
-:data:`~tkinter.wantobject` to ``1`` before creating the
-:class:`~tkinter.Tk` object or call the :meth:`~tkinter.Tk.wantobject`
-method of the :class:`!Tk` object with argument ``1``. Calling it with
-argument ``2`` restores the current default behavior.
+Setting the :mod:`!tkinter` module global :data:`~tkinter.wantobject` to ``2``
+before creating the :class:`~tkinter.Tk` object or call the
+:meth:`~tkinter.Tk.wantobject` method of the :class:`!Tk` object with argument
+``2`` makes now arguments to callbacks registered in the :mod:`tkinter` module
+to be passed as various Python objects (``int``, ``float``, ``bytes``, ``tuple``),
+depending on their internal represenation in Tcl, instead of always ``str``.
+:data:`!tkinter.wantobject` is now set to ``2`` by default.
 
 ..
 

--- a/Misc/NEWS.d/3.13.0b1.rst
+++ b/Misc/NEWS.d/3.13.0b1.rst
@@ -1346,9 +1346,10 @@ urllib.
 .. nonce: du4UKW
 .. section: Library
 
-Callbacks registered in the :mod:`tkinter` module now take arguments as
-various Python objects (``int``, ``float``, ``bytes``, ``tuple``), not just
-``str``. To restore the previous behavior set :mod:`!tkinter` module global
+Add support for passing arguments to callbacks registered in the :mod:`tkinter`
+module as various Python objects (``int``, ``float``, ``bytes``, ``tuple``),
+corresponding to the original Tcl value, not just ``str``, and enable this by default.
+To restore the previous behavior set :mod:`!tkinter` module global
 :data:`~tkinter.wantobject` to ``1`` before creating the
 :class:`~tkinter.Tk` object or call the :meth:`~tkinter.Tk.wantobject`
 method of the :class:`!Tk` object with argument ``1``. Calling it with

--- a/Misc/NEWS.d/next/Library/2024-05-08-21-30-33.gh-issue-118760.XvyMHn.rst
+++ b/Misc/NEWS.d/next/Library/2024-05-08-21-30-33.gh-issue-118760.XvyMHn.rst
@@ -1,0 +1,1 @@
+Restore the default value of ``tkiter.wantobjects`` to ``1``.


### PR DESCRIPTION
It was set to 2 in 65f5e586a1239ed1a66d8284773d7b02ce40e480 (GH-98592).


<!-- gh-issue-number: gh-118760 -->
* Issue: gh-118760
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--118784.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->