### PR TITLE
GH-74033: Drop deprecated `pathlib.Path` keyword arguments

### DIFF
--- a/Doc/whatsnew/3.14.rst
+++ b/Doc/whatsnew/3.14.rst
@@ -101,6 +101,11 @@ Deprecated
 Removed
 =======
 
+pathlib
+-------
+
+* Remove support for passing additional keyword arguments to
+  :class:`pathlib.Path`. In previous versions, any such arguments are ignored.
 
 
 Porting to Python 3.14

--- a/Lib/pathlib/_local.py
+++ b/Lib/pathlib/_local.py
@@ -4,6 +4,7 @@ import operator
 import os
 import posixpath
 import sys
+import warnings
 from glob import _StringGlobber
 from itertools import chain
 from _collections_abc import Sequence
@@ -404,7 +405,6 @@ class PurePath(PurePathBase):
     def is_reserved(self):
         """Return True if the path contains one of the special names reserved
         by the system, if any."""
-        import warnings
         msg = ("pathlib.PurePath.is_reserved() is deprecated and scheduled "
                "for removal in Python 3.15. Use os.path.isreserved() to "
                "detect reserved paths on Windows.")

--- a/Lib/pathlib/_local.py
+++ b/Lib/pathlib/_local.py
@@ -4,7 +4,6 @@ import operator
 import os
 import posixpath
 import sys
-import warnings
 from glob import _StringGlobber
 from itertools import chain
 from _collections_abc import Sequence
@@ -417,6 +416,7 @@ class PurePath(PurePathBase):
     def is_reserved(self):
         """Return True if the path contains one of the special names reserved
         by the system, if any."""
+        import warnings
         msg = ("pathlib.PurePath.is_reserved() is deprecated and scheduled "
                "for removal in Python 3.15. Use os.path.isreserved() to "
                "detect reserved paths on Windows.")
@@ -494,13 +494,6 @@ class Path(PathBase, PurePath):
     @classmethod
     def _unsupported_msg(cls, attribute):
         return f"{cls.__name__}.{attribute} is unsupported on this system"
-
-    def __init__(self, *args, **kwargs):
-        if kwargs:
-            msg = ("support for supplying keyword arguments to pathlib.PurePath "
-                   "is deprecated and scheduled for removal in Python {remove}")
-            warnings._deprecated("pathlib.PurePath(**kwargs)", msg, remove=(3, 14))
-        super().__init__(*args)
 
     def __new__(cls, *args, **kwargs):
         if cls is Path:

--- a/Lib/test/test_io.py
+++ b/Lib/test/test_io.py
@@ -4511,11 +4511,11 @@ class MiscIOTest(unittest.TestCase):
         ''')
         proc = assert_python_ok('-X', 'warn_default_encoding', '-c', code)
         warnings = proc.err.splitlines()
-        self.assertEqual(len(warnings), 4)
+        self.assertEqual(len(warnings), 2)
         self.assertTrue(
             warnings[0].startswith(b"<string>:5: EncodingWarning: "))
         self.assertTrue(
-            warnings[2].startswith(b"<string>:8: EncodingWarning: "))
+            warnings[1].startswith(b"<string>:8: EncodingWarning: "))
 
     def test_text_encoding(self):
         # PEP 597, bpo-47000. io.text_encoding() returns "locale" or "utf-8"

--- a/Lib/test/test_io.py
+++ b/Lib/test/test_io.py
@@ -4511,11 +4511,11 @@ class MiscIOTest(unittest.TestCase):
         ''')
         proc = assert_python_ok('-X', 'warn_default_encoding', '-c', code)
         warnings = proc.err.splitlines()
-        self.assertEqual(len(warnings), 2)
+        self.assertEqual(len(warnings), 4)
         self.assertTrue(
             warnings[0].startswith(b"<string>:5: EncodingWarning: "))
         self.assertTrue(
-            warnings[1].startswith(b"<string>:8: EncodingWarning: "))
+            warnings[2].startswith(b"<string>:8: EncodingWarning: "))
 
     def test_text_encoding(self):
         # PEP 597, bpo-47000. io.text_encoding() returns "locale" or "utf-8"

--- a/Lib/test/test_pathlib/test_pathlib.py
+++ b/Lib/test/test_pathlib/test_pathlib.py
@@ -1108,6 +1108,10 @@ class PathTest(test_pathlib_abc.DummyPathTest, PurePathTest):
         self.assertTrue(R.is_mount())
         self.assertFalse((R / '\udfff').is_mount())
 
+    def test_passing_kwargs_errors(self):
+        with self.assertRaises(TypeError):
+            self.cls(foo="bar")
+
     def setUpWalk(self):
         super().setUpWalk()
         sub21_path= self.sub2_path / "SUB21"

--- a/Lib/test/test_pathlib/test_pathlib.py
+++ b/Lib/test/test_pathlib/test_pathlib.py
@@ -1121,10 +1121,6 @@ class PathTest(test_pathlib_abc.DummyPathTest, PurePathTest):
         self.assertTrue(R.is_mount())
         self.assertFalse((R / '\udfff').is_mount())
 
-    def test_passing_kwargs_deprecated(self):
-        with self.assertWarns(DeprecationWarning):
-            self.cls(foo="bar")
-
     def setUpWalk(self):
         super().setUpWalk()
         sub21_path= self.sub2_path / "SUB21"

--- a/Misc/NEWS.d/next/Library/2024-05-08-20-41-48.gh-issue-74033.YebHZj.rst
+++ b/Misc/NEWS.d/next/Library/2024-05-08-20-41-48.gh-issue-74033.YebHZj.rst
@@ -1,0 +1,1 @@
+Drop support for passing keyword arguments to :class:`pathlib.Path`.


### PR DESCRIPTION
Remove support for supplying keyword arguments to `pathlib.Path()`. This has been deprecated since Python 3.12.


<!-- gh-issue-number: gh-74033 -->
* Issue: gh-74033
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--118793.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->