### PR TITLE
gh-118789: Restore hidden `_PyWeakref_ClearRef`

### DIFF
--- a/Include/cpython/weakrefobject.h
+++ b/Include/cpython/weakrefobject.h
@@ -59,3 +59,5 @@ Py_DEPRECATED(3.13) static inline PyObject* PyWeakref_GET_OBJECT(PyObject *ref_o
     return Py_None;
 }
 #define PyWeakref_GET_OBJECT(ref) PyWeakref_GET_OBJECT(_PyObject_CAST(ref))
+
+PyAPI_FUNC(void) _PyWeakref_ClearRef(PyWeakReference *self);

--- a/Include/cpython/weakrefobject.h
+++ b/Include/cpython/weakrefobject.h
@@ -40,6 +40,8 @@ struct _PyWeakReference {
 #endif
 };
 
+PyAPI_FUNC(void) _PyWeakref_ClearRef(PyWeakReference *self);
+
 Py_DEPRECATED(3.13) static inline PyObject* PyWeakref_GET_OBJECT(PyObject *ref_obj)
 {
     PyWeakReference *ref;
@@ -59,5 +61,3 @@ Py_DEPRECATED(3.13) static inline PyObject* PyWeakref_GET_OBJECT(PyObject *ref_o
     return Py_None;
 }
 #define PyWeakref_GET_OBJECT(ref) PyWeakref_GET_OBJECT(_PyObject_CAST(ref))
-
-PyAPI_FUNC(void) _PyWeakref_ClearRef(PyWeakReference *self);

--- a/Include/internal/pycore_weakref.h
+++ b/Include/internal/pycore_weakref.h
@@ -109,9 +109,7 @@ extern Py_ssize_t _PyWeakref_GetWeakrefCount(PyObject *obj);
 
 // Clear all the weak references to obj but leave their callbacks uncalled and
 // intact.
-extern void _PyWeakref_ClearWeakRefsExceptCallbacks(PyObject *obj);
-
-extern void _PyWeakref_ClearRef(PyWeakReference *self);
+PyAPI_FUNC(void) _PyWeakref_ClearWeakRefsExceptCallbacks(PyObject *obj);
 
 PyAPI_FUNC(int) _PyWeakref_IsDead(PyObject *weakref);
 

--- a/Include/internal/pycore_weakref.h
+++ b/Include/internal/pycore_weakref.h
@@ -109,7 +109,7 @@ extern Py_ssize_t _PyWeakref_GetWeakrefCount(PyObject *obj);
 
 // Clear all the weak references to obj but leave their callbacks uncalled and
 // intact.
-PyAPI_FUNC(void) _PyWeakref_ClearWeakRefsExceptCallbacks(PyObject *obj);
+extern void _PyWeakref_ClearWeakRefsExceptCallbacks(PyObject *obj);
 
 PyAPI_FUNC(int) _PyWeakref_IsDead(PyObject *weakref);
 

--- a/Misc/NEWS.d/next/C API/2024-05-08-20-13-00.gh-issue-118789.m88uUa.rst
+++ b/Misc/NEWS.d/next/C API/2024-05-08-20-13-00.gh-issue-118789.m88uUa.rst
@@ -1,0 +1,2 @@
+Restore ``_PyWeakref_ClearRef`` that was previously removed in Python 3.13
+alpha 1.


### PR DESCRIPTION
`_PyWeakref_ClearRef` was previously exposed in the public C-API, although it begins with an underscore and is not documented. It's used by a few C-API extensions. There is currently no alternative public API that can replace its use.

<!-- gh-issue-number: gh-118789 -->
* Issue: gh-118789
<!-- /gh-issue-number -->
