### PR TITLE
[tests]: Mark ``test_statistics.test_kde_random`` with a ``requires_resource('cpu')`` decorator

### DIFF
--- a/Lib/test/test_statistics.py
+++ b/Lib/test/test_statistics.py
@@ -2446,6 +2446,7 @@ class TestKDE(unittest.TestCase):
                 for x in xarr:
                     self.assertAlmostEqual(invcdf(cdf(x)), x, places=5)
 
+    @support.requires_resource('cpu')
     def test_kde_random(self):
         kde_random = statistics.kde_random
         StatisticsError = statistics.StatisticsError


### PR DESCRIPTION
This is a CPU-intensive test. On my machine (Ryzen 7 4800H, 8/16), it takes about 80 seconds.

```python
./python -m test -v test_statistics -m test_kde_random
== CPython 3.14.0a0 (heads/main:cb6f75a32c, May 8 2024, 23:39:14) [GCC 9.4.0]
== Linux-5.10.16.3-microsoft-standard-WSL2-x86_64-with-glibc2.31 little-endian
== Python build: free_threading debug
== cwd: /home/eclips4/CLionProjects/cpython/build/test_python_worker_26032æ
== CPU count: 16
== encodings: locale=UTF-8 FS=utf-8
== resources: all test resources are disabled, use -u option to unskip tests

Using random seed: 1617172693
0:00:00 load avg: 0.15 Run 1 test sequentially
0:00:00 load avg: 0.15 [1/1] test_statistics
test_kde_random (test.test_statistics.TestKDE.test_kde_random) ... ok

----------------------------------------------------------------------
Ran 1 test in 80.244s

OK
test_statistics passed in 1 min 20 sec

== Tests result: SUCCESS ==

1 test OK.

Total duration: 1 min 20 sec
Total tests: run=1 (filtered)
Total test files: run=1/1 (filtered)
Result: SUCCESS
```