### PR TITLE
gh-118803: Remove `ByteString` from `typing` and `collections.abc`

### DIFF
--- a/Doc/library/collections.abc.rst
+++ b/Doc/library/collections.abc.rst
@@ -141,9 +141,6 @@ ABC                            Inherits from          Abstract Methods        Mi
                                                       ``__len__``,
                                                       ``insert``
 
-:class:`ByteString`            :class:`Sequence`      ``__getitem__``,        Inherited :class:`Sequence` methods
-                                                      ``__len__``
-
 :class:`Set`                   :class:`Collection`    ``__contains__``,       ``__le__``, ``__lt__``, ``__eq__``, ``__ne__``,
                                                       ``__iter__``,           ``__gt__``, ``__ge__``, ``__and__``, ``__or__``,
                                                       ``__len__``             ``__sub__``, ``__xor__``, and ``isdisjoint``
@@ -257,7 +254,6 @@ Collections Abstract Base Classes -- Detailed Descriptions
 
 .. class:: Sequence
            MutableSequence
-           ByteString
 
    ABCs for read-only and mutable :term:`sequences <sequence>`.
 
@@ -273,12 +269,6 @@ Collections Abstract Base Classes -- Detailed Descriptions
    .. versionchanged:: 3.5
       The index() method added support for *stop* and *start*
       arguments.
-
-   .. deprecated-removed:: 3.12 3.14
-      The :class:`ByteString` ABC has been deprecated.
-      For use in typing, prefer a union, like ``bytes | bytearray``, or
-      :class:`collections.abc.Buffer`.
-      For use as an ABC, prefer :class:`Sequence` or :class:`collections.abc.Buffer`.
 
 .. class:: Set
            MutableSet

--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -5061,7 +5061,6 @@ list is non-exhaustive.
 * :class:`collections.abc.MutableMapping`
 * :class:`collections.abc.Sequence`
 * :class:`collections.abc.MutableSequence`
-* :class:`collections.abc.ByteString`
 * :class:`collections.abc.MappingView`
 * :class:`collections.abc.KeysView`
 * :class:`collections.abc.ItemsView`

--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -3502,14 +3502,6 @@ Aliases to container ABCs in :mod:`collections.abc`
       :class:`collections.abc.Set` now supports subscripting (``[]``).
       See :pep:`585` and :ref:`types-genericalias`.
 
-.. class:: ByteString(Sequence[int])
-
-   This type represents the types :class:`bytes`, :class:`bytearray`,
-   and :class:`memoryview` of byte sequences.
-
-   .. deprecated-removed:: 3.9 3.14
-      Prefer :class:`collections.abc.Buffer`, or a union like ``bytes | bytearray | memoryview``.
-
 .. class:: Collection(Sized, Iterable[T_co], Container[T_co])
 
    Deprecated alias to :class:`collections.abc.Collection`.
@@ -3875,10 +3867,6 @@ convenience. This is subject to change, and not all deprecations are listed.
      - 3.9
      - Undecided (see :ref:`deprecated-aliases` for more information)
      - :pep:`585`
-   * - :class:`typing.ByteString`
-     - 3.9
-     - 3.14
-     - :gh:`91896`
    * - :data:`typing.Text`
      - 3.11
      - Undecided

--- a/Doc/whatsnew/3.12.rst
+++ b/Doc/whatsnew/3.12.rst
@@ -1183,7 +1183,7 @@ Deprecated
   replaced by :data:`calendar.JANUARY` and :data:`calendar.FEBRUARY`.
   (Contributed by Prince Roshan in :gh:`103636`.)
 
-* :mod:`collections.abc`: Deprecated :class:`collections.abc.ByteString`.
+* :mod:`collections.abc`: Deprecated :class:`!collections.abc.ByteString`.
   Prefer :class:`Sequence` or :class:`collections.abc.Buffer`.
   For use in typing, prefer a union, like ``bytes | bytearray``, or :class:`collections.abc.Buffer`.
   (Contributed by Shantanu Jain in :gh:`91896`.)
@@ -1293,7 +1293,7 @@ Deprecated
     :class:`collections.abc.Hashable` and :class:`collections.abc.Sized` respectively, are
     deprecated. (:gh:`94309`.)
 
-  * :class:`typing.ByteString`, deprecated since Python 3.9, now causes a
+  * :class:`!typing.ByteString`, deprecated since Python 3.9, now causes a
     :exc:`DeprecationWarning` to be emitted when it is used.
     (Contributed by Alex Waygood in :gh:`91896`.)
 

--- a/Doc/whatsnew/3.13.rst
+++ b/Doc/whatsnew/3.13.rst
@@ -1573,7 +1573,7 @@ Pending Removal in Python 3.14
   Use :class:`ast.Constant` instead.
   (Contributed by Serhiy Storchaka in :gh:`90953`.)
 
-* :mod:`collections.abc`: Deprecated :class:`~collections.abc.ByteString`.
+* :mod:`collections.abc`: Deprecated :class:`!collections.abc.ByteString`.
   Prefer :class:`!Sequence` or :class:`~collections.abc.Buffer`.
   For use in typing, prefer a union, like ``bytes | bytearray``,
   or :class:`collections.abc.Buffer`.
@@ -1647,7 +1647,7 @@ Pending Removal in Python 3.14
   May be removed in 3.14.
   (Contributed by Nikita Sobolev in :gh:`101866`.)
 
-* :mod:`typing`: :class:`~typing.ByteString`, deprecated since Python 3.9,
+* :mod:`typing`: :class:`!typing.ByteString`, deprecated since Python 3.9,
   now causes a :exc:`DeprecationWarning` to be emitted when it is used.
 
 * :mod:`urllib`:

--- a/Doc/whatsnew/3.14.rst
+++ b/Doc/whatsnew/3.14.rst
@@ -105,6 +105,9 @@ Removed
   It had previously raised a :exc:`DeprecationWarning` since Python 3.9. (Contributed
   by Jelle Zijlstra in :gh:`118767`.)
 
+* :class:`!typing.ByteString` and :class:`collections.abc.ByteString`
+  are removed. They had previously raised a :exc:`DeprecationWarning`
+  since Python 3.12.
 
 Porting to Python 3.14
 ======================

--- a/Doc/whatsnew/3.14.rst
+++ b/Doc/whatsnew/3.14.rst
@@ -105,7 +105,7 @@ Removed
   It had previously raised a :exc:`DeprecationWarning` since Python 3.9. (Contributed
   by Jelle Zijlstra in :gh:`118767`.)
 
-* :class:`!typing.ByteString` and :class:`collections.abc.ByteString`
+* :class:`!typing.ByteString` and :class:`!collections.abc.ByteString`
   are removed. They had previously raised a :exc:`DeprecationWarning`
   since Python 3.12.
 

--- a/Lib/_collections_abc.py
+++ b/Lib/_collections_abc.py
@@ -49,7 +49,7 @@ __all__ = ["Awaitable", "Coroutine",
            "Mapping", "MutableMapping",
            "MappingView", "KeysView", "ItemsView", "ValuesView",
            "Sequence", "MutableSequence",
-           "ByteString", "Buffer",
+           "Buffer",
            ]
 
 # This module has been renamed from collections.abc to _collections_abc to
@@ -1071,37 +1071,6 @@ Sequence.register(str)
 Sequence.register(range)
 Sequence.register(memoryview)
 
-class _DeprecateByteStringMeta(ABCMeta):
-    def __new__(cls, name, bases, namespace, **kwargs):
-        if name != "ByteString":
-            import warnings
-
-            warnings._deprecated(
-                "collections.abc.ByteString",
-                remove=(3, 14),
-            )
-        return super().__new__(cls, name, bases, namespace, **kwargs)
-
-    def __instancecheck__(cls, instance):
-        import warnings
-
-        warnings._deprecated(
-            "collections.abc.ByteString",
-            remove=(3, 14),
-        )
-        return super().__instancecheck__(instance)
-
-class ByteString(Sequence, metaclass=_DeprecateByteStringMeta):
-    """This unifies bytes and bytearray.
-
-    XXX Should add all their methods.
-    """
-
-    __slots__ = ()
-
-ByteString.register(bytes)
-ByteString.register(bytearray)
-
 
 class MutableSequence(Sequence):
     """All the operations on a read-write sequence.
@@ -1170,4 +1139,4 @@ class MutableSequence(Sequence):
 
 
 MutableSequence.register(list)
-MutableSequence.register(bytearray)  # Multiply inheriting, see ByteString
+MutableSequence.register(bytearray)

--- a/Lib/_collections_abc.py
+++ b/Lib/_collections_abc.py
@@ -1068,6 +1068,7 @@ class Sequence(Reversible, Collection):
 
 Sequence.register(tuple)
 Sequence.register(str)
+Sequence.register(bytes)
 Sequence.register(range)
 Sequence.register(memoryview)
 

--- a/Lib/test/libregrtest/refleak.py
+++ b/Lib/test/libregrtest/refleak.py
@@ -211,7 +211,6 @@ def dash_R_cleanup(fs, ps, pic, zdc, abcs):
         zipimport._zip_directory_cache.update(zdc)
 
     # Clear ABC registries, restoring previously saved ABC registries.
-    # ignore deprecation warning for collections.abc.ByteString
     abs_classes = [getattr(collections.abc, a) for a in collections.abc.__all__]
     abs_classes = filter(isabstract, abs_classes)
     for abc in abs_classes:

--- a/Lib/test/test_collections.py
+++ b/Lib/test/test_collections.py
@@ -26,7 +26,7 @@ from collections.abc import Sized, Container, Callable, Collection
 from collections.abc import Set, MutableSet
 from collections.abc import Mapping, MutableMapping, KeysView, ItemsView, ValuesView
 from collections.abc import Sequence, MutableSequence
-from collections.abc import ByteString, Buffer
+from collections.abc import Buffer
 
 
 class TestUserObjects(unittest.TestCase):
@@ -1934,28 +1934,6 @@ class TestCollectionABCs(ABCTestCase):
                     for stop in range(-3, len(nativeseq) + 3):
                         assert_index_same(
                             nativeseq, seqseq, (letter, start, stop))
-
-    def test_ByteString(self):
-        for sample in [bytes, bytearray]:
-            with self.assertWarns(DeprecationWarning):
-                self.assertIsInstance(sample(), ByteString)
-            self.assertTrue(issubclass(sample, ByteString))
-        for sample in [str, list, tuple]:
-            with self.assertWarns(DeprecationWarning):
-                self.assertNotIsInstance(sample(), ByteString)
-            self.assertFalse(issubclass(sample, ByteString))
-        with self.assertWarns(DeprecationWarning):
-            self.assertNotIsInstance(memoryview(b""), ByteString)
-        self.assertFalse(issubclass(memoryview, ByteString))
-        with self.assertWarns(DeprecationWarning):
-            self.validate_abstract_methods(ByteString, '__getitem__', '__len__')
-
-        with self.assertWarns(DeprecationWarning):
-            class X(ByteString): pass
-
-        with self.assertWarns(DeprecationWarning):
-            # No metaclass conflict
-            class Z(ByteString, Awaitable): pass
 
     def test_Buffer(self):
         for sample in [bytes, bytearray, memoryview]:

--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -7128,16 +7128,6 @@ class CollectionsAbcTests(BaseTestCase):
         self.assertIsInstance([], typing.MutableSequence)
         self.assertNotIsInstance((), typing.MutableSequence)
 
-    def test_bytestring(self):
-        with self.assertWarns(DeprecationWarning):
-            self.assertIsInstance(b'', typing.ByteString)
-        with self.assertWarns(DeprecationWarning):
-            self.assertIsInstance(bytearray(b''), typing.ByteString)
-        with self.assertWarns(DeprecationWarning):
-            class Foo(typing.ByteString): ...
-        with self.assertWarns(DeprecationWarning):
-            class Bar(typing.ByteString, typing.Awaitable): ...
-
     def test_list(self):
         self.assertIsSubclass(list, typing.List)
 
@@ -9951,7 +9941,6 @@ class SpecialAttrsTests(BaseTestCase):
             typing.AsyncIterable: 'AsyncIterable',
             typing.AsyncIterator: 'AsyncIterator',
             typing.Awaitable: 'Awaitable',
-            typing.ByteString: 'ByteString',
             typing.Callable: 'Callable',
             typing.ChainMap: 'ChainMap',
             typing.Collection: 'Collection',

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -64,7 +64,6 @@ __all__ = [
 
     # ABCs (from collections.abc).
     'AbstractSet',  # collections.abc.Set.
-    'ByteString',
     'Container',
     'ContextManager',
     'Hashable',
@@ -1670,21 +1669,6 @@ class _SpecialGenericAlias(_NotIterable, _BaseGenericAlias, _root=True):
         return Union[left, self]
 
 
-class _DeprecatedGenericAlias(_SpecialGenericAlias, _root=True):
-    def __init__(
-        self, origin, nparams, *, removal_version, inst=True, name=None
-    ):
-        super().__init__(origin, nparams, inst=inst, name=name)
-        self._removal_version = removal_version
-
-    def __instancecheck__(self, inst):
-        import warnings
-        warnings._deprecated(
-            f"{self.__module__}.{self._name}", remove=self._removal_version
-        )
-        return super().__instancecheck__(inst)
-
-
 class _CallableGenericAlias(_NotIterable, _GenericAlias, _root=True):
     def __repr__(self):
         assert self._name == 'Callable'
@@ -2828,9 +2812,6 @@ Mapping = _alias(collections.abc.Mapping, 2)
 MutableMapping = _alias(collections.abc.MutableMapping, 2)
 Sequence = _alias(collections.abc.Sequence, 1)
 MutableSequence = _alias(collections.abc.MutableSequence, 1)
-ByteString = _DeprecatedGenericAlias(
-    collections.abc.ByteString, 0, removal_version=(3, 14)  # Not generic.
-)
 # Tuple accepts variable number of parameters.
 Tuple = _TupleType(tuple, -1, inst=False, name='Tuple')
 Tuple.__doc__ = \

--- a/Misc/NEWS.d/next/Library/2024-05-09-00-52-30.gh-issue-118803.Wv3AvU.rst
+++ b/Misc/NEWS.d/next/Library/2024-05-09-00-52-30.gh-issue-118803.Wv3AvU.rst
@@ -1,0 +1,3 @@
+:class:`!typing.ByteString` and :class:`!collections.abc.ByteString` are
+removed. They had previously raised a :exc:`DeprecationWarning` since Python
+3.12.


### PR DESCRIPTION


<!-- gh-issue-number: gh-118803 -->
* Issue: gh-118803
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--118804.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->