### PR TITLE
gh-118805: Remove type, choices, metavar params of `BooleanOptionalAction`

### DIFF
--- a/Doc/whatsnew/3.14.rst
+++ b/Doc/whatsnew/3.14.rst
@@ -105,6 +105,9 @@ Removed
   It had previously raised a :exc:`DeprecationWarning` since Python 3.9. (Contributed
   by Jelle Zijlstra in :gh:`118767`.)
 
+* The *type*, *choices*, and *metavar* parameters
+  of :class:`!argparse.BooleanOptionalAction` are removed.
+  They were deprecated since 3.12.
 
 Porting to Python 3.14
 ======================

--- a/Doc/whatsnew/3.14.rst
+++ b/Doc/whatsnew/3.14.rst
@@ -101,6 +101,13 @@ Deprecated
 Removed
 =======
 
+argparse
+--------
+
+* The *type*, *choices*, and *metavar* parameters
+  of :class:`!argparse.BooleanOptionalAction` are removed.
+  They were deprecated since 3.12.
+
 email
 -----
 
@@ -117,10 +124,6 @@ Others
 * :class:`!typing.ByteString` and :class:`!collections.abc.ByteString`
   are removed. They had previously raised a :exc:`DeprecationWarning`
   since Python 3.12.
-
-* The *type*, *choices*, and *metavar* parameters
-  of :class:`!argparse.BooleanOptionalAction` are removed.
-  They were deprecated since 3.12.
 
 * :mod:`itertools` support for copy, deepcopy, and pickle operations.
   These had previously raised a :exc:`DeprecationWarning` since Python 3.12.

--- a/Lib/argparse.py
+++ b/Lib/argparse.py
@@ -831,19 +831,13 @@ class Action(_AttributeHolder):
         raise NotImplementedError(_('.__call__() not defined'))
 
 
-# FIXME: remove together with `BooleanOptionalAction` deprecated arguments.
-_deprecated_default = object()
-
 class BooleanOptionalAction(Action):
     def __init__(self,
                  option_strings,
                  dest,
                  default=None,
-                 type=_deprecated_default,
-                 choices=_deprecated_default,
                  required=False,
                  help=None,
-                 metavar=_deprecated_default,
                  deprecated=False):
 
         _option_strings = []
@@ -854,35 +848,13 @@ class BooleanOptionalAction(Action):
                 option_string = '--no-' + option_string[2:]
                 _option_strings.append(option_string)
 
-        # We need `_deprecated` special value to ban explicit arguments that
-        # match default value. Like:
-        #   parser.add_argument('-f', action=BooleanOptionalAction, type=int)
-        for field_name in ('type', 'choices', 'metavar'):
-            if locals()[field_name] is not _deprecated_default:
-                import warnings
-                warnings._deprecated(
-                    field_name,
-                    "{name!r} is deprecated as of Python 3.12 and will be "
-                    "removed in Python {remove}.",
-                    remove=(3, 14))
-
-        if type is _deprecated_default:
-            type = None
-        if choices is _deprecated_default:
-            choices = None
-        if metavar is _deprecated_default:
-            metavar = None
-
         super().__init__(
             option_strings=_option_strings,
             dest=dest,
             nargs=0,
             default=default,
-            type=type,
-            choices=choices,
             required=required,
             help=help,
-            metavar=metavar,
             deprecated=deprecated)
 
 

--- a/Lib/test/test_argparse.py
+++ b/Lib/test/test_argparse.py
@@ -765,49 +765,6 @@ class TestBooleanOptionalAction(ParserTestCase):
 
         self.assertIn("got an unexpected keyword argument 'const'", str(cm.exception))
 
-    def test_deprecated_init_kw(self):
-        # See gh-92248
-        parser = argparse.ArgumentParser()
-
-        with self.assertWarns(DeprecationWarning):
-            parser.add_argument(
-                '-a',
-                action=argparse.BooleanOptionalAction,
-                type=None,
-            )
-        with self.assertWarns(DeprecationWarning):
-            parser.add_argument(
-                '-b',
-                action=argparse.BooleanOptionalAction,
-                type=bool,
-            )
-
-        with self.assertWarns(DeprecationWarning):
-            parser.add_argument(
-                '-c',
-                action=argparse.BooleanOptionalAction,
-                metavar=None,
-            )
-        with self.assertWarns(DeprecationWarning):
-            parser.add_argument(
-                '-d',
-                action=argparse.BooleanOptionalAction,
-                metavar='d',
-            )
-
-        with self.assertWarns(DeprecationWarning):
-            parser.add_argument(
-                '-e',
-                action=argparse.BooleanOptionalAction,
-                choices=None,
-            )
-        with self.assertWarns(DeprecationWarning):
-            parser.add_argument(
-                '-f',
-                action=argparse.BooleanOptionalAction,
-                choices=(),
-            )
-
 class TestBooleanOptionalActionRequired(ParserTestCase):
     """Tests BooleanOptionalAction required"""
 

--- a/Misc/NEWS.d/next/Library/2024-05-09-01-05-52.gh-issue-118805.N7dm07.rst
+++ b/Misc/NEWS.d/next/Library/2024-05-09-01-05-52.gh-issue-118805.N7dm07.rst
@@ -1,2 +1,3 @@
-Remove ``type``, ``choices``, and ``metavar`` parameters of
+Remove *type*, *choices*, and *metavar* parameters of
 :class:`!argparse.BooleanOptionalAction`.
+They were deprecated since Python 3.12.

--- a/Misc/NEWS.d/next/Library/2024-05-09-01-05-52.gh-issue-118805.N7dm07.rst
+++ b/Misc/NEWS.d/next/Library/2024-05-09-01-05-52.gh-issue-118805.N7dm07.rst
@@ -1,0 +1,2 @@
+Remove ``type``, ``choices``, and ``metavar`` parameters of
+:class:`!argparse.BooleanOptionalAction`.


### PR DESCRIPTION


<!-- gh-issue-number: gh-118805 -->
* Issue: gh-118805
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--118806.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->