### PR TITLE
gh-117657: Acquire a critical section around `SemLock.__{enter,exit}__`

### DIFF
--- a/Modules/_multiprocessing/clinic/semaphore.c.h
+++ b/Modules/_multiprocessing/clinic/semaphore.c.h
@@ -473,7 +473,13 @@ _multiprocessing_SemLock___enter___impl(SemLockObject *self);
 static PyObject *
 _multiprocessing_SemLock___enter__(SemLockObject *self, PyObject *Py_UNUSED(ignored))
 {
-    return _multiprocessing_SemLock___enter___impl(self);
+    PyObject *return_value = NULL;
+
+    Py_BEGIN_CRITICAL_SECTION(self);
+    return_value = _multiprocessing_SemLock___enter___impl(self);
+    Py_END_CRITICAL_SECTION();
+
+    return return_value;
 }
 
 #endif /* defined(HAVE_MP_SEMAPHORE) */
@@ -518,7 +524,9 @@ _multiprocessing_SemLock___exit__(SemLockObject *self, PyObject *const *args, Py
     }
     exc_tb = args[2];
 skip_optional:
+    Py_BEGIN_CRITICAL_SECTION(self);
     return_value = _multiprocessing_SemLock___exit___impl(self, exc_type, exc_value, exc_tb);
+    Py_END_CRITICAL_SECTION();
 
 exit:
     return return_value;
@@ -565,4 +573,4 @@ exit:
 #ifndef _MULTIPROCESSING_SEMLOCK___EXIT___METHODDEF
     #define _MULTIPROCESSING_SEMLOCK___EXIT___METHODDEF
 #endif /* !defined(_MULTIPROCESSING_SEMLOCK___EXIT___METHODDEF) */
-/*[clinic end generated code: output=713b597256233716 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=dea36482d23a355f input=a9049054013a1b77]*/

--- a/Modules/_multiprocessing/semaphore.c
+++ b/Modules/_multiprocessing/semaphore.c
@@ -682,6 +682,7 @@ _multiprocessing_SemLock__after_fork_impl(SemLockObject *self)
 }
 
 /*[clinic input]
+@critical_section
 _multiprocessing.SemLock.__enter__
 
 Enter the semaphore/lock.
@@ -689,12 +690,13 @@ Enter the semaphore/lock.
 
 static PyObject *
 _multiprocessing_SemLock___enter___impl(SemLockObject *self)
-/*[clinic end generated code: output=beeb2f07c858511f input=c5e27d594284690b]*/
+/*[clinic end generated code: output=beeb2f07c858511f input=d35c9860992ee790]*/
 {
     return _multiprocessing_SemLock_acquire_impl(self, 1, Py_None);
 }
 
 /*[clinic input]
+@critical_section
 _multiprocessing.SemLock.__exit__
 
     exc_type: object = None
@@ -709,7 +711,7 @@ static PyObject *
 _multiprocessing_SemLock___exit___impl(SemLockObject *self,
                                        PyObject *exc_type,
                                        PyObject *exc_value, PyObject *exc_tb)
-/*[clinic end generated code: output=3b37c1a9f8b91a03 input=7d644b64a89903f8]*/
+/*[clinic end generated code: output=3b37c1a9f8b91a03 input=1610c8cc3e0e337e]*/
 {
     return _multiprocessing_SemLock_release_impl(self);
 }


### PR DESCRIPTION
These methods are purely wrappers around `Semlock.{acquire,release}`, which expect a critical section to be held.

[Sample race](https://gist.github.com/mpage/8d703ef7c3fda58dd9080f56c4d539a9) reported by TSAN.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-117657 -->
* Issue: gh-117657
<!-- /gh-issue-number -->
