### PR TITLE
GH-101588: Remove deprecated pickle/copy/deepcopy from itertools

### DIFF
--- a/Doc/whatsnew/3.14.rst
+++ b/Doc/whatsnew/3.14.rst
@@ -109,6 +109,11 @@ Removed
   are removed. They had previously raised a :exc:`DeprecationWarning`
   since Python 3.12.
 
+* :mod:`itertools` support for copy, deepcopy, and pickle operations.
+  These had previously raised a :exc:`DeprecationWarning` since Python 3.12.
+  (Contributed by Raymond Hettinger in :gh:`101588`.)
+
+
 Porting to Python 3.14
 ======================
 

--- a/Lib/test/test_itertools.py
+++ b/Lib/test/test_itertools.py
@@ -812,7 +812,6 @@ class TestBasicOps(unittest.TestCase):
         self.assertRaises(TypeError, cycle('').__setstate__, ())
         self.assertRaises(TypeError, cycle('').__setstate__, ([],))
 
-    @pickle_deprecated
     def test_groupby(self):
         # Check whether it accepts arguments correctly
         self.assertEqual([], list(groupby([])))
@@ -831,15 +830,6 @@ class TestBasicOps(unittest.TestCase):
                 dup.append(elem)
         self.assertEqual(s, dup)
 
-        # Check normal pickled
-        for proto in range(pickle.HIGHEST_PROTOCOL + 1):
-            dup = []
-            for k, g in pickle.loads(pickle.dumps(groupby(s, testR), proto)):
-                for elem in g:
-                    self.assertEqual(k, elem[0])
-                    dup.append(elem)
-            self.assertEqual(s, dup)
-
         # Check nested case
         dup = []
         for k, g in groupby(s, testR):
@@ -849,18 +839,6 @@ class TestBasicOps(unittest.TestCase):
                     self.assertEqual(ik, elem[2])
                     dup.append(elem)
         self.assertEqual(s, dup)
-
-        # Check nested and pickled
-        for proto in range(pickle.HIGHEST_PROTOCOL + 1):
-            dup = []
-            for k, g in pickle.loads(pickle.dumps(groupby(s, testR), proto)):
-                for ik, ig in pickle.loads(pickle.dumps(groupby(g, testR2), proto)):
-                    for elem in ig:
-                        self.assertEqual(k, elem[0])
-                        self.assertEqual(ik, elem[2])
-                        dup.append(elem)
-            self.assertEqual(s, dup)
-
 
         # Check case where inner iterator is not used
         keys = [k for k, g in groupby(s, testR)]
@@ -880,13 +858,6 @@ class TestBasicOps(unittest.TestCase):
         self.assertEqual(next(g3), ('A', 5))
         list(it)  # exhaust the groupby iterator
         self.assertEqual(list(g3), [])
-
-        for proto in range(pickle.HIGHEST_PROTOCOL + 1):
-            it = groupby(s, testR)
-            _, g = next(it)
-            next(it)
-            next(it)
-            self.assertEqual(list(pickle.loads(pickle.dumps(g, proto))), [])
 
         # Exercise pipes and filters style
         s = 'abracadabra'

--- a/Lib/test/test_itertools.py
+++ b/Lib/test/test_itertools.py
@@ -144,7 +144,6 @@ class TestBasicOps(unittest.TestCase):
             c = expand(compare[took:])
             self.assertEqual(a, c);
 
-    @pickle_deprecated
     def test_accumulate(self):
         self.assertEqual(list(accumulate(range(10))),               # one positional arg
                           [0, 1, 3, 6, 10, 15, 21, 28, 36, 45])
@@ -171,9 +170,6 @@ class TestBasicOps(unittest.TestCase):
                          [2, 16, 144, 720, 5040, 0, 0, 0, 0, 0])
         with self.assertRaises(TypeError):
             list(accumulate(s, chr))                                # unary-operation
-        for proto in range(pickle.HIGHEST_PROTOCOL + 1):
-            self.pickletest(proto, accumulate(range(10)))           # test pickling
-            self.pickletest(proto, accumulate(range(10), initial=7))
         self.assertEqual(list(accumulate([10, 5, 1], initial=None)), [10, 15, 16])
         self.assertEqual(list(accumulate([10, 5, 1], initial=100)), [100, 110, 115, 116])
         self.assertEqual(list(accumulate([], initial=100)), [100])
@@ -245,57 +241,11 @@ class TestBasicOps(unittest.TestCase):
         self.assertRaises(TypeError, list, chain.from_iterable([2, 3]))
         self.assertEqual(list(islice(chain.from_iterable(repeat(range(5))), 2)), [0, 1])
 
-    @pickle_deprecated
-    def test_chain_reducible(self):
-        for oper in [copy.deepcopy] + picklecopiers:
-            it = chain('abc', 'def')
-            self.assertEqual(list(oper(it)), list('abcdef'))
-            self.assertEqual(next(it), 'a')
-            self.assertEqual(list(oper(it)), list('bcdef'))
-
-            self.assertEqual(list(oper(chain(''))), [])
-            self.assertEqual(take(4, oper(chain('abc', 'def'))), list('abcd'))
-            self.assertRaises(TypeError, list, oper(chain(2, 3)))
-        for proto in range(pickle.HIGHEST_PROTOCOL + 1):
-            self.pickletest(proto, chain('abc', 'def'), compare=list('abcdef'))
-
-    @pickle_deprecated
-    def test_chain_setstate(self):
-        self.assertRaises(TypeError, chain().__setstate__, ())
-        self.assertRaises(TypeError, chain().__setstate__, [])
-        self.assertRaises(TypeError, chain().__setstate__, 0)
-        self.assertRaises(TypeError, chain().__setstate__, ([],))
-        self.assertRaises(TypeError, chain().__setstate__, (iter([]), []))
-        it = chain()
-        it.__setstate__((iter(['abc', 'def']),))
-        self.assertEqual(list(it), ['a', 'b', 'c', 'd', 'e', 'f'])
-        it = chain()
-        it.__setstate__((iter(['abc', 'def']), iter(['ghi'])))
-        self.assertEqual(list(it), ['ghi', 'a', 'b', 'c', 'd', 'e', 'f'])
-
-    @pickle_deprecated
     def test_combinations(self):
         self.assertRaises(TypeError, combinations, 'abc')       # missing r argument
         self.assertRaises(TypeError, combinations, 'abc', 2, 1) # too many arguments
         self.assertRaises(TypeError, combinations, None)        # pool is not iterable
         self.assertRaises(ValueError, combinations, 'abc', -2)  # r is negative
-
-        for op in [lambda a:a] + picklecopiers:
-            self.assertEqual(list(op(combinations('abc', 32))), [])     # r > n
-
-            self.assertEqual(list(op(combinations('ABCD', 2))),
-                             [('A','B'), ('A','C'), ('A','D'), ('B','C'), ('B','D'), ('C','D')])
-            testIntermediate = combinations('ABCD', 2)
-            next(testIntermediate)
-            self.assertEqual(list(op(testIntermediate)),
-                             [('A','C'), ('A','D'), ('B','C'), ('B','D'), ('C','D')])
-
-            self.assertEqual(list(op(combinations(range(4), 3))),
-                             [(0,1,2), (0,1,3), (0,2,3), (1,2,3)])
-            testIntermediate = combinations(range(4), 3)
-            next(testIntermediate)
-            self.assertEqual(list(op(testIntermediate)),
-                             [(0,1,3), (0,2,3), (1,2,3)])
 
         def combinations1(iterable, r):
             'Pure python version shown in the docs'
@@ -350,9 +300,6 @@ class TestBasicOps(unittest.TestCase):
                 self.assertEqual(result, list(combinations2(values, r))) # matches second pure python version
                 self.assertEqual(result, list(combinations3(values, r))) # matches second pure python version
 
-                for proto in range(pickle.HIGHEST_PROTOCOL + 1):
-                    self.pickletest(proto, combinations(values, r))      # test pickling
-
     @support.bigaddrspacetest
     def test_combinations_overflow(self):
         with self.assertRaises((OverflowError, MemoryError)):
@@ -364,22 +311,12 @@ class TestBasicOps(unittest.TestCase):
         self.assertEqual(len(set(map(id, combinations('abcde', 3)))), 1)
         self.assertNotEqual(len(set(map(id, list(combinations('abcde', 3))))), 1)
 
-    @pickle_deprecated
     def test_combinations_with_replacement(self):
         cwr = combinations_with_replacement
         self.assertRaises(TypeError, cwr, 'abc')       # missing r argument
         self.assertRaises(TypeError, cwr, 'abc', 2, 1) # too many arguments
         self.assertRaises(TypeError, cwr, None)        # pool is not iterable
         self.assertRaises(ValueError, cwr, 'abc', -2)  # r is negative
-
-        for op in [lambda a:a] + picklecopiers:
-            self.assertEqual(list(op(cwr('ABC', 2))),
-                             [('A','A'), ('A','B'), ('A','C'), ('B','B'), ('B','C'), ('C','C')])
-            testIntermediate = cwr('ABC', 2)
-            next(testIntermediate)
-            self.assertEqual(list(op(testIntermediate)),
-                             [('A','B'), ('A','C'), ('B','B'), ('B','C'), ('C','C')])
-
 
         def cwr1(iterable, r):
             'Pure python version shown in the docs'
@@ -438,22 +375,18 @@ class TestBasicOps(unittest.TestCase):
                 self.assertEqual(result, list(cwr1(values, r)))         # matches first pure python version
                 self.assertEqual(result, list(cwr2(values, r)))         # matches second pure python version
 
-                for proto in range(pickle.HIGHEST_PROTOCOL + 1):
-                    self.pickletest(proto, cwr(values,r))               # test pickling
-
     @support.bigaddrspacetest
     def test_combinations_with_replacement_overflow(self):
         with self.assertRaises((OverflowError, MemoryError)):
             combinations_with_replacement("AA", 2**30)
 
-        # Test implementation detail:  tuple re-use
+    # Test implementation detail:  tuple re-use
     @support.impl_detail("tuple reuse is specific to CPython")
     def test_combinations_with_replacement_tuple_reuse(self):
         cwr = combinations_with_replacement
         self.assertEqual(len(set(map(id, cwr('abcde', 3)))), 1)
         self.assertNotEqual(len(set(map(id, list(cwr('abcde', 3))))), 1)
 
-    @pickle_deprecated
     def test_permutations(self):
         self.assertRaises(TypeError, permutations)              # too few arguments
         self.assertRaises(TypeError, permutations, 'abc', 2, 1) # too many arguments
@@ -514,9 +447,6 @@ class TestBasicOps(unittest.TestCase):
                     self.assertEqual(result, list(permutations(values, None))) # test r as None
                     self.assertEqual(result, list(permutations(values)))       # test default r
 
-                for proto in range(pickle.HIGHEST_PROTOCOL + 1):
-                    self.pickletest(proto, permutations(values, r))     # test pickling
-
     @support.bigaddrspacetest
     def test_permutations_overflow(self):
         with self.assertRaises((OverflowError, MemoryError)):
@@ -560,7 +490,6 @@ class TestBasicOps(unittest.TestCase):
                 self.assertEqual(comb, list(filter(set(perm).__contains__, cwr)))     # comb: cwr that is a perm
                 self.assertEqual(comb, sorted(set(cwr) & set(perm)))            # comb: both a cwr and a perm
 
-    @pickle_deprecated
     def test_compress(self):
         self.assertEqual(list(compress(data='ABCDEF', selectors=[1,0,1,0,1,1])), list('ACEF'))
         self.assertEqual(list(compress('ABCDEF', [1,0,1,0,1,1])), list('ACEF'))
@@ -577,24 +506,6 @@ class TestBasicOps(unittest.TestCase):
         self.assertRaises(TypeError, compress, range(6))            # too few args
         self.assertRaises(TypeError, compress, range(6), None)      # too many args
 
-        # check copy, deepcopy, pickle
-        for op in [lambda a:copy.copy(a), lambda a:copy.deepcopy(a)] + picklecopiers:
-            for data, selectors, result1, result2 in [
-                ('ABCDEF', [1,0,1,0,1,1], 'ACEF', 'CEF'),
-                ('ABCDEF', [0,0,0,0,0,0], '', ''),
-                ('ABCDEF', [1,1,1,1,1,1], 'ABCDEF', 'BCDEF'),
-                ('ABCDEF', [1,0,1], 'AC', 'C'),
-                ('ABC', [0,1,1,1,1,1], 'BC', 'C'),
-                ]:
-
-                self.assertEqual(list(op(compress(data=data, selectors=selectors))), list(result1))
-                self.assertEqual(list(op(compress(data, selectors))), list(result1))
-                testIntermediate = compress(data, selectors)
-                if result1:
-                    next(testIntermediate)
-                    self.assertEqual(list(op(testIntermediate)), list(result2))
-
-    @pickle_deprecated
     def test_count(self):
         self.assertEqual(lzip('abc',count()), [('a', 0), ('b', 1), ('c', 2)])
         self.assertEqual(lzip('abc',count(3)), [('a', 3), ('b', 4), ('c', 5)])
@@ -632,18 +543,9 @@ class TestBasicOps(unittest.TestCase):
             r2 = 'count(%r)'.__mod__(i)
             self.assertEqual(r1, r2)
 
-        # check copy, deepcopy, pickle
-        for value in -3, 3, maxsize-5, maxsize+5:
-            c = count(value)
-            self.assertEqual(next(copy.copy(c)), value)
-            self.assertEqual(next(copy.deepcopy(c)), value)
-            for proto in range(pickle.HIGHEST_PROTOCOL + 1):
-                self.pickletest(proto, count(value))
-
         #check proper internal error handling for large "step' sizes
         count(1, maxsize+5); sys.exc_info()
 
-    @pickle_deprecated
     def test_count_with_stride(self):
         self.assertEqual(lzip('abc',count(2,3)), [('a', 2), ('b', 5), ('c', 8)])
         self.assertEqual(lzip('abc',count(start=2,step=3)),
@@ -687,17 +589,6 @@ class TestBasicOps(unittest.TestCase):
         c = count(10, 1.0)
         self.assertEqual(type(next(c)), int)
         self.assertEqual(type(next(c)), float)
-        for i in (-sys.maxsize-5, -sys.maxsize+5 ,-10, -1, 0, 10, sys.maxsize-5, sys.maxsize+5):
-            for j in  (-sys.maxsize-5, -sys.maxsize+5 ,-10, -1, 0, 1, 10, sys.maxsize-5, sys.maxsize+5):
-                # Test repr
-                r1 = repr(count(i, j))
-                if j == 1:
-                    r2 = ('count(%r)' % i)
-                else:
-                    r2 = ('count(%r, %r)' % (i, j))
-                self.assertEqual(r1, r2)
-                for proto in range(pickle.HIGHEST_PROTOCOL + 1):
-                    self.pickletest(proto, count(i, j))
 
     def test_cycle(self):
         self.assertEqual(take(10, cycle('abc')), list('abcabcabca'))
@@ -705,112 +596,6 @@ class TestBasicOps(unittest.TestCase):
         self.assertRaises(TypeError, cycle)
         self.assertRaises(TypeError, cycle, 5)
         self.assertEqual(list(islice(cycle(gen3()),10)), [0,1,2,0,1,2,0,1,2,0])
-
-    @pickle_deprecated
-    def test_cycle_copy_pickle(self):
-        # check copy, deepcopy, pickle
-        c = cycle('abc')
-        self.assertEqual(next(c), 'a')
-        #simple copy currently not supported, because __reduce__ returns
-        #an internal iterator
-        #self.assertEqual(take(10, copy.copy(c)), list('bcabcabcab'))
-        self.assertEqual(take(10, copy.deepcopy(c)), list('bcabcabcab'))
-        for proto in range(pickle.HIGHEST_PROTOCOL + 1):
-            self.assertEqual(take(10, pickle.loads(pickle.dumps(c, proto))),
-                             list('bcabcabcab'))
-            next(c)
-            self.assertEqual(take(10, pickle.loads(pickle.dumps(c, proto))),
-                             list('cabcabcabc'))
-            next(c)
-            next(c)
-        for proto in range(pickle.HIGHEST_PROTOCOL + 1):
-            self.pickletest(proto, cycle('abc'))
-
-        for proto in range(pickle.HIGHEST_PROTOCOL + 1):
-            # test with partial consumed input iterable
-            it = iter('abcde')
-            c = cycle(it)
-            _ = [next(c) for i in range(2)]      # consume 2 of 5 inputs
-            p = pickle.dumps(c, proto)
-            d = pickle.loads(p)                  # rebuild the cycle object
-            self.assertEqual(take(20, d), list('cdeabcdeabcdeabcdeab'))
-
-            # test with completely consumed input iterable
-            it = iter('abcde')
-            c = cycle(it)
-            _ = [next(c) for i in range(7)]      # consume 7 of 5 inputs
-            p = pickle.dumps(c, proto)
-            d = pickle.loads(p)                  # rebuild the cycle object
-            self.assertEqual(take(20, d), list('cdeabcdeabcdeabcdeab'))
-
-    @pickle_deprecated
-    def test_cycle_unpickle_compat(self):
-        testcases = [
-            b'citertools\ncycle\n(c__builtin__\niter\n((lI1\naI2\naI3\natRI1\nbtR((lI1\naI0\ntb.',
-            b'citertools\ncycle\n(c__builtin__\niter\n(](K\x01K\x02K\x03etRK\x01btR(]K\x01aK\x00tb.',
-            b'\x80\x02citertools\ncycle\nc__builtin__\niter\n](K\x01K\x02K\x03e\x85RK\x01b\x85R]K\x01aK\x00\x86b.',
-            b'\x80\x03citertools\ncycle\ncbuiltins\niter\n](K\x01K\x02K\x03e\x85RK\x01b\x85R]K\x01aK\x00\x86b.',
-            b'\x80\x04\x95=\x00\x00\x00\x00\x00\x00\x00\x8c\titertools\x8c\x05cycle\x93\x8c\x08builtins\x8c\x04iter\x93](K\x01K\x02K\x03e\x85RK\x01b\x85R]K\x01aK\x00\x86b.',
-
-            b'citertools\ncycle\n(c__builtin__\niter\n((lp0\nI1\naI2\naI3\natRI1\nbtR(g0\nI1\ntb.',
-            b'citertools\ncycle\n(c__builtin__\niter\n(]q\x00(K\x01K\x02K\x03etRK\x01btR(h\x00K\x01tb.',
-            b'\x80\x02citertools\ncycle\nc__builtin__\niter\n]q\x00(K\x01K\x02K\x03e\x85RK\x01b\x85Rh\x00K\x01\x86b.',
-            b'\x80\x03citertools\ncycle\ncbuiltins\niter\n]q\x00(K\x01K\x02K\x03e\x85RK\x01b\x85Rh\x00K\x01\x86b.',
-            b'\x80\x04\x95<\x00\x00\x00\x00\x00\x00\x00\x8c\titertools\x8c\x05cycle\x93\x8c\x08builtins\x8c\x04iter\x93]\x94(K\x01K\x02K\x03e\x85RK\x01b\x85Rh\x00K\x01\x86b.',
-
-            b'citertools\ncycle\n(c__builtin__\niter\n((lI1\naI2\naI3\natRI1\nbtR((lI1\naI00\ntb.',
-            b'citertools\ncycle\n(c__builtin__\niter\n(](K\x01K\x02K\x03etRK\x01btR(]K\x01aI00\ntb.',
-            b'\x80\x02citertools\ncycle\nc__builtin__\niter\n](K\x01K\x02K\x03e\x85RK\x01b\x85R]K\x01a\x89\x86b.',
-            b'\x80\x03citertools\ncycle\ncbuiltins\niter\n](K\x01K\x02K\x03e\x85RK\x01b\x85R]K\x01a\x89\x86b.',
-            b'\x80\x04\x95<\x00\x00\x00\x00\x00\x00\x00\x8c\titertools\x8c\x05cycle\x93\x8c\x08builtins\x8c\x04iter\x93](K\x01K\x02K\x03e\x85RK\x01b\x85R]K\x01a\x89\x86b.',
-
-            b'citertools\ncycle\n(c__builtin__\niter\n((lp0\nI1\naI2\naI3\natRI1\nbtR(g0\nI01\ntb.',
-            b'citertools\ncycle\n(c__builtin__\niter\n(]q\x00(K\x01K\x02K\x03etRK\x01btR(h\x00I01\ntb.',
-            b'\x80\x02citertools\ncycle\nc__builtin__\niter\n]q\x00(K\x01K\x02K\x03e\x85RK\x01b\x85Rh\x00\x88\x86b.',
-            b'\x80\x03citertools\ncycle\ncbuiltins\niter\n]q\x00(K\x01K\x02K\x03e\x85RK\x01b\x85Rh\x00\x88\x86b.',
-            b'\x80\x04\x95;\x00\x00\x00\x00\x00\x00\x00\x8c\titertools\x8c\x05cycle\x93\x8c\x08builtins\x8c\x04iter\x93]\x94(K\x01K\x02K\x03e\x85RK\x01b\x85Rh\x00\x88\x86b.',
-        ]
-        assert len(testcases) == 20
-        for t in testcases:
-            it = pickle.loads(t)
-            self.assertEqual(take(10, it), [2, 3, 1, 2, 3, 1, 2, 3, 1, 2])
-
-    @pickle_deprecated
-    def test_cycle_setstate(self):
-        # Verify both modes for restoring state
-
-        # Mode 0 is efficient.  It uses an incompletely consumed input
-        # iterator to build a cycle object and then passes in state with
-        # a list of previously consumed values.  There is no data
-        # overlap between the two.
-        c = cycle('defg')
-        c.__setstate__((list('abc'), 0))
-        self.assertEqual(take(20, c), list('defgabcdefgabcdefgab'))
-
-        # Mode 1 is inefficient.  It starts with a cycle object built
-        # from an iterator over the remaining elements in a partial
-        # cycle and then passes in state with all of the previously
-        # seen values (this overlaps values included in the iterator).
-        c = cycle('defg')
-        c.__setstate__((list('abcdefg'), 1))
-        self.assertEqual(take(20, c), list('defgabcdefgabcdefgab'))
-
-        # The first argument to setstate needs to be a tuple
-        with self.assertRaises(TypeError):
-            cycle('defg').__setstate__([list('abcdefg'), 0])
-
-        # The first argument in the setstate tuple must be a list
-        with self.assertRaises(TypeError):
-            c = cycle('defg')
-            c.__setstate__((tuple('defg'), 0))
-        take(20, c)
-
-        # The second argument in the setstate tuple must be an int
-        with self.assertRaises(TypeError):
-            cycle('defg').__setstate__((list('abcdefg'), 'x'))
-
-        self.assertRaises(TypeError, cycle('').__setstate__, ())
-        self.assertRaises(TypeError, cycle('').__setstate__, ([],))
 
     def test_groupby(self):
         # Check whether it accepts arguments correctly
@@ -941,7 +726,6 @@ class TestBasicOps(unittest.TestCase):
             c = filter(isEven, range(6))
             self.pickletest(proto, c)
 
-    @pickle_deprecated
     def test_filterfalse(self):
         self.assertEqual(list(filterfalse(isEven, range(6))), [1,3,5])
         self.assertEqual(list(filterfalse(None, [0,1,0,2,0])), [0,0,0])
@@ -952,8 +736,6 @@ class TestBasicOps(unittest.TestCase):
         self.assertRaises(TypeError, filterfalse, lambda x:x, range(6), 7)
         self.assertRaises(TypeError, filterfalse, isEven, 3)
         self.assertRaises(TypeError, next, filterfalse(range(6), range(6)))
-        for proto in range(pickle.HIGHEST_PROTOCOL + 1):
-            self.pickletest(proto, filterfalse(isEven, range(6)))
 
     def test_zip(self):
         # XXX This is rather silly now that builtin zip() calls zip()...
@@ -972,32 +754,11 @@ class TestBasicOps(unittest.TestCase):
                          lzip('abc', 'def'))
 
     @support.impl_detail("tuple reuse is specific to CPython")
-    @pickle_deprecated
     def test_zip_tuple_reuse(self):
         ids = list(map(id, zip('abc', 'def')))
         self.assertEqual(min(ids), max(ids))
         ids = list(map(id, list(zip('abc', 'def'))))
         self.assertEqual(len(dict.fromkeys(ids)), len(ids))
-
-        # check copy, deepcopy, pickle
-        ans = [(x,y) for x, y in copy.copy(zip('abc',count()))]
-        self.assertEqual(ans, [('a', 0), ('b', 1), ('c', 2)])
-
-        ans = [(x,y) for x, y in copy.deepcopy(zip('abc',count()))]
-        self.assertEqual(ans, [('a', 0), ('b', 1), ('c', 2)])
-
-        for proto in range(pickle.HIGHEST_PROTOCOL + 1):
-            ans = [(x,y) for x, y in pickle.loads(pickle.dumps(zip('abc',count()), proto))]
-            self.assertEqual(ans, [('a', 0), ('b', 1), ('c', 2)])
-
-        for proto in range(pickle.HIGHEST_PROTOCOL + 1):
-            testIntermediate = zip('abc',count())
-            next(testIntermediate)
-            ans = [(x,y) for x, y in pickle.loads(pickle.dumps(testIntermediate, proto))]
-            self.assertEqual(ans, [('b', 1), ('c', 2)])
-
-        for proto in range(pickle.HIGHEST_PROTOCOL + 1):
-            self.pickletest(proto, zip('abc', count()))
 
     def test_ziplongest(self):
         for args in [
@@ -1047,14 +808,6 @@ class TestBasicOps(unittest.TestCase):
         self.assertEqual(min(ids), max(ids))
         ids = list(map(id, list(zip_longest('abc', 'def'))))
         self.assertEqual(len(dict.fromkeys(ids)), len(ids))
-
-    @pickle_deprecated
-    def test_zip_longest_pickling(self):
-        for proto in range(pickle.HIGHEST_PROTOCOL + 1):
-            self.pickletest(proto, zip_longest("abc", "def"))
-            self.pickletest(proto, zip_longest("abc", "defgh"))
-            self.pickletest(proto, zip_longest("abc", "defgh", fillvalue=1))
-            self.pickletest(proto, zip_longest("", "defgh"))
 
     def test_zip_longest_bad_iterable(self):
         exception = TypeError()
@@ -1267,34 +1020,6 @@ class TestBasicOps(unittest.TestCase):
         self.assertEqual(len(set(map(id, product('abc', 'def')))), 1)
         self.assertNotEqual(len(set(map(id, list(product('abc', 'def'))))), 1)
 
-    @pickle_deprecated
-    def test_product_pickling(self):
-        # check copy, deepcopy, pickle
-        for args, result in [
-            ([], [()]),                     # zero iterables
-            (['ab'], [('a',), ('b',)]),     # one iterable
-            ([range(2), range(3)], [(0,0), (0,1), (0,2), (1,0), (1,1), (1,2)]),     # two iterables
-            ([range(0), range(2), range(3)], []),           # first iterable with zero length
-            ([range(2), range(0), range(3)], []),           # middle iterable with zero length
-            ([range(2), range(3), range(0)], []),           # last iterable with zero length
-            ]:
-            self.assertEqual(list(copy.copy(product(*args))), result)
-            self.assertEqual(list(copy.deepcopy(product(*args))), result)
-            for proto in range(pickle.HIGHEST_PROTOCOL + 1):
-                self.pickletest(proto, product(*args))
-
-    @pickle_deprecated
-    def test_product_issue_25021(self):
-        # test that indices are properly clamped to the length of the tuples
-        p = product((1, 2),(3,))
-        p.__setstate__((0, 0x1000))  # will access tuple element 1 if not clamped
-        self.assertEqual(next(p), (2, 3))
-        # test that empty tuple in the list will result in an immediate StopIteration
-        p = product((1, 2), (), (3,))
-        p.__setstate__((0, 0, 0x1000))  # will access tuple element 1 if not clamped
-        self.assertRaises(StopIteration, next, p)
-
-    @pickle_deprecated
     def test_repeat(self):
         self.assertEqual(list(repeat(object='a', times=3)), ['a', 'a', 'a'])
         self.assertEqual(lzip(range(3),repeat('a')),
@@ -1313,21 +1038,12 @@ class TestBasicOps(unittest.TestCase):
         list(r)
         self.assertEqual(repr(r), 'repeat((1+0j), 0)')
 
-        # check copy, deepcopy, pickle
-        c = repeat(object='a', times=10)
-        self.assertEqual(next(c), 'a')
-        self.assertEqual(take(2, copy.copy(c)), list('a' * 2))
-        self.assertEqual(take(2, copy.deepcopy(c)), list('a' * 2))
-        for proto in range(pickle.HIGHEST_PROTOCOL + 1):
-            self.pickletest(proto, repeat(object='a', times=10))
-
     def test_repeat_with_negative_times(self):
         self.assertEqual(repr(repeat('a', -1)), "repeat('a', 0)")
         self.assertEqual(repr(repeat('a', -2)), "repeat('a', 0)")
         self.assertEqual(repr(repeat('a', times=-1)), "repeat('a', 0)")
         self.assertEqual(repr(repeat('a', times=-2)), "repeat('a', 0)")
 
-    @pickle_deprecated
     def test_map(self):
         self.assertEqual(list(map(operator.pow, range(3), range(1,7))),
                          [0**1, 1**2, 2**3])
@@ -1345,20 +1061,6 @@ class TestBasicOps(unittest.TestCase):
         self.assertRaises(ValueError, next, map(errfunc, [4], [5]))
         self.assertRaises(TypeError, next, map(onearg, [4], [5]))
 
-        # check copy, deepcopy, pickle
-        ans = [('a',0),('b',1),('c',2)]
-
-        c = map(tupleize, 'abc', count())
-        self.assertEqual(list(copy.copy(c)), ans)
-
-        c = map(tupleize, 'abc', count())
-        self.assertEqual(list(copy.deepcopy(c)), ans)
-
-        for proto in range(pickle.HIGHEST_PROTOCOL + 1):
-            c = map(tupleize, 'abc', count())
-            self.pickletest(proto, c)
-
-    @pickle_deprecated
     def test_starmap(self):
         self.assertEqual(list(starmap(operator.pow, zip(range(3), range(1,7)))),
                          [0**1, 1**2, 2**3])
@@ -1373,20 +1075,6 @@ class TestBasicOps(unittest.TestCase):
         self.assertRaises(ValueError, next, starmap(errfunc, [(4,5)]))
         self.assertRaises(TypeError, next, starmap(onearg, [(4,5)]))
 
-        # check copy, deepcopy, pickle
-        ans = [0**1, 1**2, 2**3]
-
-        c = starmap(operator.pow, zip(range(3), range(1,7)))
-        self.assertEqual(list(copy.copy(c)), ans)
-
-        c = starmap(operator.pow, zip(range(3), range(1,7)))
-        self.assertEqual(list(copy.deepcopy(c)), ans)
-
-        for proto in range(pickle.HIGHEST_PROTOCOL + 1):
-            c = starmap(operator.pow, zip(range(3), range(1,7)))
-            self.pickletest(proto, c)
-
-    @pickle_deprecated
     def test_islice(self):
         for args in [          # islice(args) should agree with range(args)
                 (10, 20, 3),
@@ -1443,21 +1131,6 @@ class TestBasicOps(unittest.TestCase):
         self.assertEqual(list(islice(c, 1, 3, 50)), [1])
         self.assertEqual(next(c), 3)
 
-        # check copy, deepcopy, pickle
-        for args in [          # islice(args) should agree with range(args)
-                (10, 20, 3),
-                (10, 3, 20),
-                (10, 20),
-                (10, 3),
-                (20,)
-                ]:
-            self.assertEqual(list(copy.copy(islice(range(100), *args))),
-                             list(range(*args)))
-            self.assertEqual(list(copy.deepcopy(islice(range(100), *args))),
-                             list(range(*args)))
-            for proto in range(pickle.HIGHEST_PROTOCOL + 1):
-                self.pickletest(proto, islice(range(100), *args))
-
         # Issue #21321: check source iterator is not referenced
         # from islice() after the latter has been exhausted
         it = (x for x in (1, 2))
@@ -1481,7 +1154,6 @@ class TestBasicOps(unittest.TestCase):
         self.assertEqual(list(islice(range(100), IntLike(10), IntLike(50), IntLike(5))),
                          list(range(10,50,5)))
 
-    @pickle_deprecated
     def test_takewhile(self):
         data = [1, 3, 5, 20, 2, 4, 6, 8]
         self.assertEqual(list(takewhile(underten, data)), [1, 3, 5])
@@ -1495,14 +1167,6 @@ class TestBasicOps(unittest.TestCase):
         self.assertEqual(list(t), [1, 1, 1])
         self.assertRaises(StopIteration, next, t)
 
-        # check copy, deepcopy, pickle
-        self.assertEqual(list(copy.copy(takewhile(underten, data))), [1, 3, 5])
-        self.assertEqual(list(copy.deepcopy(takewhile(underten, data))),
-                        [1, 3, 5])
-        for proto in range(pickle.HIGHEST_PROTOCOL + 1):
-            self.pickletest(proto, takewhile(underten, data))
-
-    @pickle_deprecated
     def test_dropwhile(self):
         data = [1, 3, 5, 20, 2, 4, 6, 8]
         self.assertEqual(list(dropwhile(underten, data)), [20, 2, 4, 6, 8])
@@ -1513,14 +1177,6 @@ class TestBasicOps(unittest.TestCase):
         self.assertRaises(TypeError, next, dropwhile(10, [(4,5)]))
         self.assertRaises(ValueError, next, dropwhile(errfunc, [(4,5)]))
 
-        # check copy, deepcopy, pickle
-        self.assertEqual(list(copy.copy(dropwhile(underten, data))), [20, 2, 4, 6, 8])
-        self.assertEqual(list(copy.deepcopy(dropwhile(underten, data))),
-                        [20, 2, 4, 6, 8])
-        for proto in range(pickle.HIGHEST_PROTOCOL + 1):
-            self.pickletest(proto, dropwhile(underten, data))
-
-    @pickle_deprecated
     def test_tee(self):
         n = 200
 
@@ -1634,41 +1290,6 @@ class TestBasicOps(unittest.TestCase):
         self.assertEqual(list(copy.copy(b)), long_ans[60:])
         self.assertEqual(list(a), long_ans[100:])
         self.assertEqual(list(b), long_ans[60:])
-
-        # check deepcopy
-        a, b = tee('abc')
-        self.assertEqual(list(copy.deepcopy(a)), ans)
-        self.assertEqual(list(copy.deepcopy(b)), ans)
-        self.assertEqual(list(a), ans)
-        self.assertEqual(list(b), ans)
-        a, b = tee(range(10000))
-        self.assertEqual(list(copy.deepcopy(a)), long_ans)
-        self.assertEqual(list(copy.deepcopy(b)), long_ans)
-        self.assertEqual(list(a), long_ans)
-        self.assertEqual(list(b), long_ans)
-
-        # check partially consumed deepcopy
-        a, b = tee('abc')
-        take(2, a)
-        take(1, b)
-        self.assertEqual(list(copy.deepcopy(a)), ans[2:])
-        self.assertEqual(list(copy.deepcopy(b)), ans[1:])
-        self.assertEqual(list(a), ans[2:])
-        self.assertEqual(list(b), ans[1:])
-        a, b = tee(range(10000))
-        take(100, a)
-        take(60, b)
-        self.assertEqual(list(copy.deepcopy(a)), long_ans[100:])
-        self.assertEqual(list(copy.deepcopy(b)), long_ans[60:])
-        self.assertEqual(list(a), long_ans[100:])
-        self.assertEqual(list(b), long_ans[60:])
-
-        # check pickle
-        for proto in range(pickle.HIGHEST_PROTOCOL + 1):
-            self.pickletest(proto, iter(tee('abc')))
-            a, b = tee('abc')
-            self.pickletest(proto, a, compare=ans)
-            self.pickletest(proto, b, compare=ans)
 
     def test_tee_dealloc_segfault(self):
         # gh-115874: segfaults when accessing module state in tp_dealloc.
@@ -1836,33 +1457,6 @@ class TestExamples(unittest.TestCase):
 
     def test_accumulate(self):
         self.assertEqual(list(accumulate([1,2,3,4,5])), [1, 3, 6, 10, 15])
-
-    @pickle_deprecated
-    def test_accumulate_reducible(self):
-        # check copy, deepcopy, pickle
-        data = [1, 2, 3, 4, 5]
-        accumulated = [1, 3, 6, 10, 15]
-
-        for proto in range(pickle.HIGHEST_PROTOCOL + 1):
-            it = accumulate(data)
-            self.assertEqual(list(pickle.loads(pickle.dumps(it, proto))), accumulated[:])
-            self.assertEqual(next(it), 1)
-            self.assertEqual(list(pickle.loads(pickle.dumps(it, proto))), accumulated[1:])
-        it = accumulate(data)
-        self.assertEqual(next(it), 1)
-        self.assertEqual(list(copy.deepcopy(it)), accumulated[1:])
-        self.assertEqual(list(copy.copy(it)), accumulated[1:])
-
-    @pickle_deprecated
-    def test_accumulate_reducible_none(self):
-        # Issue #25718: total is None
-        it = accumulate([None, None, None], operator.is_)
-        self.assertEqual(next(it), None)
-        for proto in range(pickle.HIGHEST_PROTOCOL + 1):
-            it_copy = pickle.loads(pickle.dumps(it, proto))
-            self.assertEqual(list(it_copy), [True, False])
-        self.assertEqual(list(copy.deepcopy(it)), [True, False])
-        self.assertEqual(list(copy.copy(it)), [True, False])
 
     def test_chain(self):
         self.assertEqual(''.join(chain('ABC', 'DEF')), 'ABCDEF')

--- a/Misc/NEWS.d/next/Library/2024-05-09-02-43-37.gh-issue-101588.30bNAr.rst
+++ b/Misc/NEWS.d/next/Library/2024-05-09-02-43-37.gh-issue-101588.30bNAr.rst
@@ -1,0 +1,2 @@
+Remove copy, deepcopy, and pickle from itertools. These had previously
+raised a DeprecationWarning since Python 3.12.

--- a/Modules/itertoolsmodule.c
+++ b/Modules/itertoolsmodule.c
@@ -93,19 +93,6 @@ class itertools.pairwise "pairwiseobject *" "clinic_state()->pairwise_type"
 #undef clinic_state_by_cls
 #undef clinic_state
 
-/* Deprecation of pickle support:  GH-101588 *********************************/
-
-#define ITERTOOL_PICKLE_DEPRECATION                                           \
-    if (PyErr_WarnEx(                                                         \
-            PyExc_DeprecationWarning,                                         \
-            "Pickle, copy, and deepcopy support will be "                     \
-            "removed from itertools in Python 3.14.", 1) < 0) {               \
-        return NULL;                                                          \
-    }
-
-PyDoc_STRVAR(reduce_doc, "Return state information for pickling.");
-
-PyDoc_STRVAR(setstate_doc, "Set state information for unpickling.");
 
 /* batched object ************************************************************/
 
@@ -815,25 +802,6 @@ teedataobject_dealloc(teedataobject *tdo)
     Py_DECREF(tp);
 }
 
-static PyObject *
-teedataobject_reduce(teedataobject *tdo, PyObject *Py_UNUSED(ignored))
-{
-    ITERTOOL_PICKLE_DEPRECATION;
-    int i;
-    /* create a temporary list of already iterated values */
-    PyObject *values = PyList_New(tdo->numread);
-
-    if (!values)
-        return NULL;
-    for (i=0 ; i<tdo->numread ; i++) {
-        Py_INCREF(tdo->values[i]);
-        PyList_SET_ITEM(values, i, tdo->values[i]);
-    }
-    return Py_BuildValue("O(ONO)", Py_TYPE(tdo), tdo->it,
-                         values,
-                         tdo->nextlink ? tdo->nextlink : Py_None);
-}
-
 /*[clinic input]
 @classmethod
 itertools.teedataobject.__new__
@@ -888,19 +856,12 @@ err:
     return NULL;
 }
 
-static PyMethodDef teedataobject_methods[] = {
-    {"__reduce__",      (PyCFunction)teedataobject_reduce, METH_NOARGS,
-     reduce_doc},
-    {NULL,              NULL}           /* sentinel */
-};
-
 static PyType_Slot teedataobject_slots[] = {
     {Py_tp_dealloc, teedataobject_dealloc},
     {Py_tp_getattro, PyObject_GenericGetAttr},
     {Py_tp_doc, (void *)itertools_teedataobject__doc__},
     {Py_tp_traverse, teedataobject_traverse},
     {Py_tp_clear, teedataobject_clear},
-    {Py_tp_methods, teedataobject_methods},
     {Py_tp_new, itertools_teedataobject},
     {Py_tp_free, PyObject_GC_Del},
     {0, NULL},
@@ -1029,41 +990,8 @@ tee_dealloc(teeobject *to)
     Py_DECREF(tp);
 }
 
-static PyObject *
-tee_reduce(teeobject *to, PyObject *Py_UNUSED(ignored))
-{
-    ITERTOOL_PICKLE_DEPRECATION;
-    return Py_BuildValue("O(())(Oi)", Py_TYPE(to), to->dataobj, to->index);
-}
-
-static PyObject *
-tee_setstate(teeobject *to, PyObject *state)
-{
-    ITERTOOL_PICKLE_DEPRECATION;
-    teedataobject *tdo;
-    int index;
-    if (!PyTuple_Check(state)) {
-        PyErr_SetString(PyExc_TypeError, "state is not a tuple");
-        return NULL;
-    }
-    PyTypeObject *tdo_type = to->state->teedataobject_type;
-    if (!PyArg_ParseTuple(state, "O!i", tdo_type, &tdo, &index)) {
-        return NULL;
-    }
-    if (index < 0 || index > LINKCELLS) {
-        PyErr_SetString(PyExc_ValueError, "Index out of range");
-        return NULL;
-    }
-    Py_INCREF(tdo);
-    Py_XSETREF(to->dataobj, tdo);
-    to->index = index;
-    Py_RETURN_NONE;
-}
-
 static PyMethodDef tee_methods[] = {
     {"__copy__",        (PyCFunction)tee_copy,     METH_NOARGS, teecopy_doc},
-    {"__reduce__",      (PyCFunction)tee_reduce,   METH_NOARGS, reduce_doc},
-    {"__setstate__",    (PyCFunction)tee_setstate, METH_O,      setstate_doc},
     {NULL,              NULL}           /* sentinel */
 };
 
@@ -1265,59 +1193,6 @@ cycle_next(cycleobject *lz)
     return Py_NewRef(item);
 }
 
-static PyObject *
-cycle_reduce(cycleobject *lz, PyObject *Py_UNUSED(ignored))
-{
-    ITERTOOL_PICKLE_DEPRECATION;
-    /* Create a new cycle with the iterator tuple, then set the saved state */
-    if (lz->it == NULL) {
-        PyObject *it = PyObject_GetIter(lz->saved);
-        if (it == NULL)
-            return NULL;
-        if (lz->index != 0) {
-            PyObject *res = _PyObject_CallMethod(it, &_Py_ID(__setstate__),
-                                                 "n", lz->index);
-            if (res == NULL) {
-                Py_DECREF(it);
-                return NULL;
-            }
-            Py_DECREF(res);
-        }
-        return Py_BuildValue("O(N)(OO)", Py_TYPE(lz), it, lz->saved, Py_True);
-    }
-    return Py_BuildValue("O(O)(OO)", Py_TYPE(lz), lz->it, lz->saved,
-                         lz->firstpass ? Py_True : Py_False);
-}
-
-static PyObject *
-cycle_setstate(cycleobject *lz, PyObject *state)
-{
-    ITERTOOL_PICKLE_DEPRECATION;
-    PyObject *saved=NULL;
-    int firstpass;
-    if (!PyTuple_Check(state)) {
-        PyErr_SetString(PyExc_TypeError, "state is not a tuple");
-        return NULL;
-    }
-    // The second item can be 1/0 in old pickles and True/False in new pickles
-    if (!PyArg_ParseTuple(state, "O!i", &PyList_Type, &saved, &firstpass)) {
-        return NULL;
-    }
-    Py_INCREF(saved);
-    Py_XSETREF(lz->saved, saved);
-    lz->firstpass = firstpass != 0;
-    lz->index = 0;
-    Py_RETURN_NONE;
-}
-
-static PyMethodDef cycle_methods[] = {
-    {"__reduce__",      (PyCFunction)cycle_reduce,      METH_NOARGS,
-     reduce_doc},
-    {"__setstate__",    (PyCFunction)cycle_setstate,    METH_O,
-     setstate_doc},
-    {NULL,              NULL}   /* sentinel */
-};
-
 static PyType_Slot cycle_slots[] = {
     {Py_tp_dealloc, cycle_dealloc},
     {Py_tp_getattro, PyObject_GenericGetAttr},
@@ -1325,7 +1200,6 @@ static PyType_Slot cycle_slots[] = {
     {Py_tp_traverse, cycle_traverse},
     {Py_tp_iter, PyObject_SelfIter},
     {Py_tp_iternext, cycle_next},
-    {Py_tp_methods, cycle_methods},
     {Py_tp_new, itertools_cycle},
     {Py_tp_free, PyObject_GC_Del},
     {0, NULL},
@@ -1438,32 +1312,6 @@ dropwhile_next(dropwhileobject *lz)
     }
 }
 
-static PyObject *
-dropwhile_reduce(dropwhileobject *lz, PyObject *Py_UNUSED(ignored))
-{
-    ITERTOOL_PICKLE_DEPRECATION;
-    return Py_BuildValue("O(OO)l", Py_TYPE(lz), lz->func, lz->it, lz->start);
-}
-
-static PyObject *
-dropwhile_setstate(dropwhileobject *lz, PyObject *state)
-{
-    ITERTOOL_PICKLE_DEPRECATION;
-    int start = PyObject_IsTrue(state);
-    if (start < 0)
-        return NULL;
-    lz->start = start;
-    Py_RETURN_NONE;
-}
-
-static PyMethodDef dropwhile_methods[] = {
-    {"__reduce__",      (PyCFunction)dropwhile_reduce,      METH_NOARGS,
-     reduce_doc},
-    {"__setstate__",    (PyCFunction)dropwhile_setstate,    METH_O,
-     setstate_doc},
-    {NULL,              NULL}   /* sentinel */
-};
-
 static PyType_Slot dropwhile_slots[] = {
     {Py_tp_dealloc, dropwhile_dealloc},
     {Py_tp_getattro, PyObject_GenericGetAttr},
@@ -1471,7 +1319,6 @@ static PyType_Slot dropwhile_slots[] = {
     {Py_tp_traverse, dropwhile_traverse},
     {Py_tp_iter, PyObject_SelfIter},
     {Py_tp_iternext, dropwhile_next},
-    {Py_tp_methods, dropwhile_methods},
     {Py_tp_new, itertools_dropwhile},
     {Py_tp_free, PyObject_GC_Del},
     {0, NULL},
@@ -1578,33 +1425,6 @@ takewhile_next(takewhileobject *lz)
     return NULL;
 }
 
-static PyObject *
-takewhile_reduce(takewhileobject *lz, PyObject *Py_UNUSED(ignored))
-{
-    ITERTOOL_PICKLE_DEPRECATION;
-    return Py_BuildValue("O(OO)l", Py_TYPE(lz), lz->func, lz->it, lz->stop);
-}
-
-static PyObject *
-takewhile_reduce_setstate(takewhileobject *lz, PyObject *state)
-{
-    ITERTOOL_PICKLE_DEPRECATION;
-    int stop = PyObject_IsTrue(state);
-
-    if (stop < 0)
-        return NULL;
-    lz->stop = stop;
-    Py_RETURN_NONE;
-}
-
-static PyMethodDef takewhile_reduce_methods[] = {
-    {"__reduce__",      (PyCFunction)takewhile_reduce,      METH_NOARGS,
-     reduce_doc},
-    {"__setstate__",    (PyCFunction)takewhile_reduce_setstate,    METH_O,
-     setstate_doc},
-    {NULL,              NULL}   /* sentinel */
-};
-
 static PyType_Slot takewhile_slots[] = {
     {Py_tp_dealloc, takewhile_dealloc},
     {Py_tp_getattro, PyObject_GenericGetAttr},
@@ -1612,7 +1432,6 @@ static PyType_Slot takewhile_slots[] = {
     {Py_tp_traverse, takewhile_traverse},
     {Py_tp_iter, PyObject_SelfIter},
     {Py_tp_iternext, takewhile_next},
-    {Py_tp_methods, takewhile_reduce_methods},
     {Py_tp_new, itertools_takewhile},
     {Py_tp_free, PyObject_GC_Del},
     {0, NULL},
@@ -1782,59 +1601,6 @@ empty:
     return NULL;
 }
 
-static PyObject *
-islice_reduce(isliceobject *lz, PyObject *Py_UNUSED(ignored))
-{
-    ITERTOOL_PICKLE_DEPRECATION;
-    /* When unpickled, generate a new object with the same bounds,
-     * then 'setstate' with the next and count
-     */
-    PyObject *stop;
-
-    if (lz->it == NULL) {
-        PyObject *empty_list;
-        PyObject *empty_it;
-        empty_list = PyList_New(0);
-        if (empty_list == NULL)
-            return NULL;
-        empty_it = PyObject_GetIter(empty_list);
-        Py_DECREF(empty_list);
-        if (empty_it == NULL)
-            return NULL;
-        return Py_BuildValue("O(Nn)n", Py_TYPE(lz), empty_it, 0, 0);
-    }
-    if (lz->stop == -1) {
-        stop = Py_NewRef(Py_None);
-    } else {
-        stop = PyLong_FromSsize_t(lz->stop);
-        if (stop == NULL)
-            return NULL;
-    }
-    return Py_BuildValue("O(OnNn)n", Py_TYPE(lz),
-        lz->it, lz->next, stop, lz->step,
-        lz->cnt);
-}
-
-static PyObject *
-islice_setstate(isliceobject *lz, PyObject *state)
-{
-    ITERTOOL_PICKLE_DEPRECATION;
-    Py_ssize_t cnt = PyLong_AsSsize_t(state);
-
-    if (cnt == -1 && PyErr_Occurred())
-        return NULL;
-    lz->cnt = cnt;
-    Py_RETURN_NONE;
-}
-
-static PyMethodDef islice_methods[] = {
-    {"__reduce__",      (PyCFunction)islice_reduce,      METH_NOARGS,
-     reduce_doc},
-    {"__setstate__",    (PyCFunction)islice_setstate,    METH_O,
-     setstate_doc},
-    {NULL,              NULL}   /* sentinel */
-};
-
 PyDoc_STRVAR(islice_doc,
 "islice(iterable, stop) --> islice object\n\
 islice(iterable, start, stop[, step]) --> islice object\n\
@@ -1853,7 +1619,6 @@ static PyType_Slot islice_slots[] = {
     {Py_tp_traverse, islice_traverse},
     {Py_tp_iter, PyObject_SelfIter},
     {Py_tp_iternext, islice_next},
-    {Py_tp_methods, islice_methods},
     {Py_tp_new, islice_new},
     {Py_tp_free, PyObject_GC_Del},
     {0, NULL},
@@ -1951,20 +1716,6 @@ starmap_next(starmapobject *lz)
     return result;
 }
 
-static PyObject *
-starmap_reduce(starmapobject *lz, PyObject *Py_UNUSED(ignored))
-{
-    ITERTOOL_PICKLE_DEPRECATION;
-    /* Just pickle the iterator */
-    return Py_BuildValue("O(OO)", Py_TYPE(lz), lz->func, lz->it);
-}
-
-static PyMethodDef starmap_methods[] = {
-    {"__reduce__",      (PyCFunction)starmap_reduce,      METH_NOARGS,
-     reduce_doc},
-    {NULL,              NULL}   /* sentinel */
-};
-
 static PyType_Slot starmap_slots[] = {
     {Py_tp_dealloc, starmap_dealloc},
     {Py_tp_getattro, PyObject_GenericGetAttr},
@@ -1972,7 +1723,6 @@ static PyType_Slot starmap_slots[] = {
     {Py_tp_traverse, starmap_traverse},
     {Py_tp_iter, PyObject_SelfIter},
     {Py_tp_iternext, starmap_next},
-    {Py_tp_methods, starmap_methods},
     {Py_tp_new, itertools_starmap},
     {Py_tp_free, PyObject_GC_Del},
     {0, NULL},
@@ -2108,51 +1858,6 @@ chain_next(chainobject *lz)
     return NULL;
 }
 
-static PyObject *
-chain_reduce(chainobject *lz, PyObject *Py_UNUSED(ignored))
-{
-    ITERTOOL_PICKLE_DEPRECATION;
-    if (lz->source) {
-        /* we can't pickle function objects (itertools.from_iterable) so
-         * we must use setstate to replace the iterable.  One day we
-         * will fix pickling of functions
-         */
-        if (lz->active) {
-            return Py_BuildValue("O()(OO)", Py_TYPE(lz), lz->source, lz->active);
-        } else {
-            return Py_BuildValue("O()(O)", Py_TYPE(lz), lz->source);
-        }
-    } else {
-        return Py_BuildValue("O()", Py_TYPE(lz)); /* exhausted */
-    }
-    return NULL;
-}
-
-static PyObject *
-chain_setstate(chainobject *lz, PyObject *state)
-{
-    ITERTOOL_PICKLE_DEPRECATION;
-    PyObject *source, *active=NULL;
-
-    if (!PyTuple_Check(state)) {
-        PyErr_SetString(PyExc_TypeError, "state is not a tuple");
-        return NULL;
-    }
-    if (!PyArg_ParseTuple(state, "O|O", &source, &active)) {
-        return NULL;
-    }
-    if (!PyIter_Check(source) || (active != NULL && !PyIter_Check(active))) {
-        PyErr_SetString(PyExc_TypeError, "Arguments must be iterators.");
-        return NULL;
-    }
-
-    Py_INCREF(source);
-    Py_XSETREF(lz->source, source);
-    Py_XINCREF(active);
-    Py_XSETREF(lz->active, active);
-    Py_RETURN_NONE;
-}
-
 PyDoc_STRVAR(chain_doc,
 "chain(*iterables)\n\
 --\n\
@@ -2163,10 +1868,6 @@ iterable, until all of the iterables are exhausted.");
 
 static PyMethodDef chain_methods[] = {
     ITERTOOLS_CHAIN_FROM_ITERABLE_METHODDEF
-    {"__reduce__",      (PyCFunction)chain_reduce,      METH_NOARGS,
-     reduce_doc},
-    {"__setstate__",    (PyCFunction)chain_setstate,    METH_O,
-     setstate_doc},
     {"__class_getitem__",    Py_GenericAlias,
     METH_O|METH_CLASS,       PyDoc_STR("See PEP 585")},
     {NULL,              NULL}           /* sentinel */
@@ -2405,89 +2106,7 @@ empty:
     return NULL;
 }
 
-static PyObject *
-product_reduce(productobject *lz, PyObject *Py_UNUSED(ignored))
-{
-    ITERTOOL_PICKLE_DEPRECATION;
-    if (lz->stopped) {
-        return Py_BuildValue("O(())", Py_TYPE(lz));
-    } else if (lz->result == NULL) {
-        return Py_BuildValue("OO", Py_TYPE(lz), lz->pools);
-    } else {
-        PyObject *indices;
-        Py_ssize_t n, i;
-
-        /* we must pickle the indices use them for setstate, and
-         * additionally indicate that the iterator has started
-         */
-        n = PyTuple_GET_SIZE(lz->pools);
-        indices = PyTuple_New(n);
-        if (indices == NULL)
-            return NULL;
-        for (i=0; i<n; i++){
-            PyObject* index = PyLong_FromSsize_t(lz->indices[i]);
-            if (!index) {
-                Py_DECREF(indices);
-                return NULL;
-            }
-            PyTuple_SET_ITEM(indices, i, index);
-        }
-        return Py_BuildValue("OON", Py_TYPE(lz), lz->pools, indices);
-    }
-}
-
-static PyObject *
-product_setstate(productobject *lz, PyObject *state)
-{
-    ITERTOOL_PICKLE_DEPRECATION;
-    PyObject *result;
-    Py_ssize_t n, i;
-
-    n = PyTuple_GET_SIZE(lz->pools);
-    if (!PyTuple_Check(state) || PyTuple_GET_SIZE(state) != n) {
-        PyErr_SetString(PyExc_ValueError, "invalid arguments");
-        return NULL;
-    }
-    for (i=0; i<n; i++)
-    {
-        PyObject* indexObject = PyTuple_GET_ITEM(state, i);
-        Py_ssize_t index = PyLong_AsSsize_t(indexObject);
-        PyObject* pool;
-        Py_ssize_t poolsize;
-        if (index < 0 && PyErr_Occurred())
-            return NULL; /* not an integer */
-        pool = PyTuple_GET_ITEM(lz->pools, i);
-        poolsize = PyTuple_GET_SIZE(pool);
-        if (poolsize == 0) {
-            lz->stopped = 1;
-            Py_RETURN_NONE;
-        }
-        /* clamp the index */
-        if (index < 0)
-            index = 0;
-        else if (index > poolsize-1)
-            index = poolsize-1;
-        lz->indices[i] = index;
-    }
-
-    result = PyTuple_New(n);
-    if (!result)
-        return NULL;
-    for (i=0; i<n; i++) {
-        PyObject *pool = PyTuple_GET_ITEM(lz->pools, i);
-        PyObject *element = PyTuple_GET_ITEM(pool, lz->indices[i]);
-        Py_INCREF(element);
-        PyTuple_SET_ITEM(result, i, element);
-    }
-    Py_XSETREF(lz->result, result);
-    Py_RETURN_NONE;
-}
-
 static PyMethodDef product_methods[] = {
-    {"__reduce__",      (PyCFunction)product_reduce,      METH_NOARGS,
-     reduce_doc},
-    {"__setstate__",    (PyCFunction)product_setstate,    METH_O,
-     setstate_doc},
     {"__sizeof__",      (PyCFunction)product_sizeof,      METH_NOARGS,
      sizeof_doc},
     {NULL,              NULL}   /* sentinel */
@@ -2716,83 +2335,7 @@ empty:
     return NULL;
 }
 
-static PyObject *
-combinations_reduce(combinationsobject *lz, PyObject *Py_UNUSED(ignored))
-{
-    ITERTOOL_PICKLE_DEPRECATION;
-    if (lz->result == NULL) {
-        return Py_BuildValue("O(On)", Py_TYPE(lz), lz->pool, lz->r);
-    } else if (lz->stopped) {
-        return Py_BuildValue("O(()n)", Py_TYPE(lz), lz->r);
-    } else {
-        PyObject *indices;
-        Py_ssize_t i;
-
-        /* we must pickle the indices and use them for setstate */
-        indices = PyTuple_New(lz->r);
-        if (!indices)
-            return NULL;
-        for (i=0; i<lz->r; i++)
-        {
-            PyObject* index = PyLong_FromSsize_t(lz->indices[i]);
-            if (!index) {
-                Py_DECREF(indices);
-                return NULL;
-            }
-            PyTuple_SET_ITEM(indices, i, index);
-        }
-
-        return Py_BuildValue("O(On)N", Py_TYPE(lz), lz->pool, lz->r, indices);
-    }
-}
-
-static PyObject *
-combinations_setstate(combinationsobject *lz, PyObject *state)
-{
-    ITERTOOL_PICKLE_DEPRECATION;
-    PyObject *result;
-    Py_ssize_t i;
-    Py_ssize_t n = PyTuple_GET_SIZE(lz->pool);
-
-    if (!PyTuple_Check(state) || PyTuple_GET_SIZE(state) != lz->r) {
-        PyErr_SetString(PyExc_ValueError, "invalid arguments");
-        return NULL;
-    }
-
-    for (i=0; i<lz->r; i++) {
-        Py_ssize_t max;
-        PyObject* indexObject = PyTuple_GET_ITEM(state, i);
-        Py_ssize_t index = PyLong_AsSsize_t(indexObject);
-
-        if (index == -1 && PyErr_Occurred())
-            return NULL; /* not an integer */
-        max = i + n - lz->r;
-        /* clamp the index (beware of negative max) */
-        if (index > max)
-            index = max;
-        if (index < 0)
-            index = 0;
-        lz->indices[i] = index;
-    }
-
-    result = PyTuple_New(lz->r);
-    if (result == NULL)
-        return NULL;
-    for (i=0; i<lz->r; i++) {
-        PyObject *element = PyTuple_GET_ITEM(lz->pool, lz->indices[i]);
-        Py_INCREF(element);
-        PyTuple_SET_ITEM(result, i, element);
-    }
-
-    Py_XSETREF(lz->result, result);
-    Py_RETURN_NONE;
-}
-
 static PyMethodDef combinations_methods[] = {
-    {"__reduce__",      (PyCFunction)combinations_reduce,      METH_NOARGS,
-     reduce_doc},
-    {"__setstate__",    (PyCFunction)combinations_setstate,    METH_O,
-     setstate_doc},
     {"__sizeof__",      (PyCFunction)combinations_sizeof,      METH_NOARGS,
      sizeof_doc},
     {NULL,              NULL}   /* sentinel */
@@ -3026,79 +2569,7 @@ empty:
     return NULL;
 }
 
-static PyObject *
-cwr_reduce(cwrobject *lz, PyObject *Py_UNUSED(ignored))
-{
-    ITERTOOL_PICKLE_DEPRECATION;
-    if (lz->result == NULL) {
-        return Py_BuildValue("O(On)", Py_TYPE(lz), lz->pool, lz->r);
-    } else if (lz->stopped) {
-        return Py_BuildValue("O(()n)", Py_TYPE(lz), lz->r);
-    } else {
-        PyObject *indices;
-        Py_ssize_t i;
-
-        /* we must pickle the indices and use them for setstate */
-        indices = PyTuple_New(lz->r);
-        if (!indices)
-            return NULL;
-        for (i=0; i<lz->r; i++) {
-            PyObject* index = PyLong_FromSsize_t(lz->indices[i]);
-            if (!index) {
-                Py_DECREF(indices);
-                return NULL;
-            }
-            PyTuple_SET_ITEM(indices, i, index);
-        }
-
-        return Py_BuildValue("O(On)N", Py_TYPE(lz), lz->pool, lz->r, indices);
-    }
-}
-
-static PyObject *
-cwr_setstate(cwrobject *lz, PyObject *state)
-{
-    ITERTOOL_PICKLE_DEPRECATION;
-    PyObject *result;
-    Py_ssize_t n, i;
-
-    if (!PyTuple_Check(state) || PyTuple_GET_SIZE(state) != lz->r)
-    {
-        PyErr_SetString(PyExc_ValueError, "invalid arguments");
-        return NULL;
-    }
-
-    n = PyTuple_GET_SIZE(lz->pool);
-    for (i=0; i<lz->r; i++) {
-        PyObject* indexObject = PyTuple_GET_ITEM(state, i);
-        Py_ssize_t index = PyLong_AsSsize_t(indexObject);
-
-        if (index < 0 && PyErr_Occurred())
-            return NULL; /* not an integer */
-        /* clamp the index */
-        if (index < 0)
-            index = 0;
-        else if (index > n-1)
-            index = n-1;
-        lz->indices[i] = index;
-    }
-    result = PyTuple_New(lz->r);
-    if (result == NULL)
-        return NULL;
-    for (i=0; i<lz->r; i++) {
-        PyObject *element = PyTuple_GET_ITEM(lz->pool, lz->indices[i]);
-        Py_INCREF(element);
-        PyTuple_SET_ITEM(result, i, element);
-    }
-    Py_XSETREF(lz->result, result);
-    Py_RETURN_NONE;
-}
-
 static PyMethodDef cwr_methods[] = {
-    {"__reduce__",      (PyCFunction)cwr_reduce,      METH_NOARGS,
-     reduce_doc},
-    {"__setstate__",    (PyCFunction)cwr_setstate,    METH_O,
-     setstate_doc},
     {"__sizeof__",      (PyCFunction)cwr_sizeof,      METH_NOARGS,
      sizeof_doc},
     {NULL,              NULL}   /* sentinel */
@@ -3363,113 +2834,7 @@ empty:
     return NULL;
 }
 
-static PyObject *
-permutations_reduce(permutationsobject *po, PyObject *Py_UNUSED(ignored))
-{
-    ITERTOOL_PICKLE_DEPRECATION;
-    if (po->result == NULL) {
-        return Py_BuildValue("O(On)", Py_TYPE(po), po->pool, po->r);
-    } else if (po->stopped) {
-        return Py_BuildValue("O(()n)", Py_TYPE(po), po->r);
-    } else {
-        PyObject *indices=NULL, *cycles=NULL;
-        Py_ssize_t n, i;
-
-        /* we must pickle the indices and cycles and use them for setstate */
-        n = PyTuple_GET_SIZE(po->pool);
-        indices = PyTuple_New(n);
-        if (indices == NULL)
-            goto err;
-        for (i=0; i<n; i++) {
-            PyObject* index = PyLong_FromSsize_t(po->indices[i]);
-            if (!index)
-                goto err;
-            PyTuple_SET_ITEM(indices, i, index);
-        }
-
-        cycles = PyTuple_New(po->r);
-        if (cycles == NULL)
-            goto err;
-        for (i=0 ; i<po->r ; i++) {
-            PyObject* index = PyLong_FromSsize_t(po->cycles[i]);
-            if (!index)
-                goto err;
-            PyTuple_SET_ITEM(cycles, i, index);
-        }
-        return Py_BuildValue("O(On)(NN)", Py_TYPE(po),
-                             po->pool, po->r,
-                             indices, cycles);
-    err:
-        Py_XDECREF(indices);
-        Py_XDECREF(cycles);
-        return NULL;
-    }
-}
-
-static PyObject *
-permutations_setstate(permutationsobject *po, PyObject *state)
-{
-    ITERTOOL_PICKLE_DEPRECATION;
-    PyObject *indices, *cycles, *result;
-    Py_ssize_t n, i;
-
-    if (!PyTuple_Check(state)) {
-        PyErr_SetString(PyExc_TypeError, "state is not a tuple");
-        return NULL;
-    }
-    if (!PyArg_ParseTuple(state, "O!O!",
-                          &PyTuple_Type, &indices,
-                          &PyTuple_Type, &cycles)) {
-        return NULL;
-    }
-
-    n = PyTuple_GET_SIZE(po->pool);
-    if (PyTuple_GET_SIZE(indices) != n || PyTuple_GET_SIZE(cycles) != po->r) {
-        PyErr_SetString(PyExc_ValueError, "invalid arguments");
-        return NULL;
-    }
-
-    for (i=0; i<n; i++) {
-        PyObject* indexObject = PyTuple_GET_ITEM(indices, i);
-        Py_ssize_t index = PyLong_AsSsize_t(indexObject);
-        if (index < 0 && PyErr_Occurred())
-            return NULL; /* not an integer */
-        /* clamp the index */
-        if (index < 0)
-            index = 0;
-        else if (index > n-1)
-            index = n-1;
-        po->indices[i] = index;
-    }
-
-    for (i=0; i<po->r; i++) {
-        PyObject* indexObject = PyTuple_GET_ITEM(cycles, i);
-        Py_ssize_t index = PyLong_AsSsize_t(indexObject);
-        if (index < 0 && PyErr_Occurred())
-            return NULL; /* not an integer */
-        if (index < 1)
-            index = 1;
-        else if (index > n-i)
-            index = n-i;
-        po->cycles[i] = index;
-    }
-    result = PyTuple_New(po->r);
-    if (result == NULL)
-        return NULL;
-    for (i=0; i<po->r; i++) {
-        PyObject *element = PyTuple_GET_ITEM(po->pool, po->indices[i]);
-        Py_INCREF(element);
-        PyTuple_SET_ITEM(result, i, element);
-    }
-    Py_XSETREF(po->result, result);
-    Py_RETURN_NONE;
-}
-
 static PyMethodDef permuations_methods[] = {
-    {"__reduce__",      (PyCFunction)permutations_reduce,      METH_NOARGS,
-     reduce_doc},
-    {"__setstate__",    (PyCFunction)permutations_setstate,    METH_O,
-     setstate_doc},
     {"__sizeof__",      (PyCFunction)permutations_sizeof,      METH_NOARGS,
      sizeof_doc},
     {NULL,              NULL}   /* sentinel */
@@ -3604,59 +2969,6 @@ accumulate_next(accumulateobject *lz)
     return newtotal;
 }
 
-static PyObject *
-accumulate_reduce(accumulateobject *lz, PyObject *Py_UNUSED(ignored))
-{
-    ITERTOOL_PICKLE_DEPRECATION;
-    itertools_state *state = lz->state;
-
-    if (lz->initial != Py_None) {
-        PyObject *it;
-
-        assert(lz->total == NULL);
-        it = PyObject_CallFunction((PyObject *)(state->chain_type), "(O)O",
-                                   lz->initial, lz->it);
-        if (it == NULL)
-            return NULL;
-        return Py_BuildValue("O(NO)O", Py_TYPE(lz),
-                            it, lz->binop?lz->binop:Py_None, Py_None);
-    }
-    if (lz->total == Py_None) {
-        PyObject *it;
-
-        it = PyObject_CallFunction((PyObject *)(state->chain_type), "(O)O",
-                                   lz->total, lz->it);
-        if (it == NULL)
-            return NULL;
-        it = PyObject_CallFunction((PyObject *)Py_TYPE(lz), "NO",
-                                   it, lz->binop ? lz->binop : Py_None);
-        if (it == NULL)
-            return NULL;
-
-        return Py_BuildValue("O(NiO)", state->islice_type, it, 1, Py_None);
-    }
-    return Py_BuildValue("O(OO)O", Py_TYPE(lz),
-                            lz->it, lz->binop?lz->binop:Py_None,
-                            lz->total?lz->total:Py_None);
-}
-
-static PyObject *
-accumulate_setstate(accumulateobject *lz, PyObject *state)
-{
-    ITERTOOL_PICKLE_DEPRECATION;
-    Py_INCREF(state);
-    Py_XSETREF(lz->total, state);
-    Py_RETURN_NONE;
-}
-
-static PyMethodDef accumulate_methods[] = {
-    {"__reduce__",      (PyCFunction)accumulate_reduce,      METH_NOARGS,
-     reduce_doc},
-    {"__setstate__",    (PyCFunction)accumulate_setstate,    METH_O,
-     setstate_doc},
-    {NULL,              NULL}   /* sentinel */
-};
-
 static PyType_Slot accumulate_slots[] = {
     {Py_tp_dealloc, accumulate_dealloc},
     {Py_tp_getattro, PyObject_GenericGetAttr},
@@ -3664,7 +2976,6 @@ static PyType_Slot accumulate_slots[] = {
     {Py_tp_traverse, accumulate_traverse},
     {Py_tp_iter, PyObject_SelfIter},
     {Py_tp_iternext, accumulate_next},
-    {Py_tp_methods, accumulate_methods},
     {Py_tp_new, itertools_accumulate},
     {Py_tp_free, PyObject_GC_Del},
     {0, NULL},
@@ -3789,20 +3100,6 @@ compress_next(compressobject *lz)
     }
 }
 
-static PyObject *
-compress_reduce(compressobject *lz, PyObject *Py_UNUSED(ignored))
-{
-    ITERTOOL_PICKLE_DEPRECATION;
-    return Py_BuildValue("O(OO)", Py_TYPE(lz),
-        lz->data, lz->selectors);
-}
-
-static PyMethodDef compress_methods[] = {
-    {"__reduce__",      (PyCFunction)compress_reduce,      METH_NOARGS,
-     reduce_doc},
-    {NULL,              NULL}   /* sentinel */
-};
-
 static PyType_Slot compress_slots[] = {
     {Py_tp_dealloc, compress_dealloc},
     {Py_tp_getattro, PyObject_GenericGetAttr},
@@ -3810,7 +3107,6 @@ static PyType_Slot compress_slots[] = {
     {Py_tp_traverse, compress_traverse},
     {Py_tp_iter, PyObject_SelfIter},
     {Py_tp_iternext, compress_next},
-    {Py_tp_methods, compress_methods},
     {Py_tp_new, itertools_compress},
     {Py_tp_free, PyObject_GC_Del},
     {0, NULL},
@@ -3922,19 +3218,6 @@ filterfalse_next(filterfalseobject *lz)
     }
 }
 
-static PyObject *
-filterfalse_reduce(filterfalseobject *lz, PyObject *Py_UNUSED(ignored))
-{
-    ITERTOOL_PICKLE_DEPRECATION;
-    return Py_BuildValue("O(OO)", Py_TYPE(lz), lz->func, lz->it);
-}
-
-static PyMethodDef filterfalse_methods[] = {
-    {"__reduce__",      (PyCFunction)filterfalse_reduce,      METH_NOARGS,
-     reduce_doc},
-    {NULL,              NULL}   /* sentinel */
-};
-
 static PyType_Slot filterfalse_slots[] = {
     {Py_tp_dealloc, filterfalse_dealloc},
     {Py_tp_getattro, PyObject_GenericGetAttr},
@@ -3942,7 +3225,6 @@ static PyType_Slot filterfalse_slots[] = {
     {Py_tp_traverse, filterfalse_traverse},
     {Py_tp_iter, PyObject_SelfIter},
     {Py_tp_iternext, filterfalse_next},
-    {Py_tp_methods, filterfalse_methods},
     {Py_tp_new, itertools_filterfalse},
     {Py_tp_free, PyObject_GC_Del},
     {0, NULL},
@@ -4150,21 +3432,6 @@ count_repr(countobject *lz)
                                 lz->long_cnt, lz->long_step);
 }
 
-static PyObject *
-count_reduce(countobject *lz, PyObject *Py_UNUSED(ignored))
-{
-    ITERTOOL_PICKLE_DEPRECATION;
-    if (lz->cnt == PY_SSIZE_T_MAX)
-        return Py_BuildValue("O(OO)", Py_TYPE(lz), lz->long_cnt, lz->long_step);
-    return Py_BuildValue("O(n)", Py_TYPE(lz), lz->cnt);
-}
-
-static PyMethodDef count_methods[] = {
-    {"__reduce__",      (PyCFunction)count_reduce,      METH_NOARGS,
-     reduce_doc},
-    {NULL,              NULL}   /* sentinel */
-};
-
 static PyType_Slot count_slots[] = {
     {Py_tp_dealloc, count_dealloc},
     {Py_tp_repr, count_repr},
@@ -4173,7 +3440,6 @@ static PyType_Slot count_slots[] = {
     {Py_tp_traverse, count_traverse},
     {Py_tp_iter, PyObject_SelfIter},
     {Py_tp_iternext, count_next},
-    {Py_tp_methods, count_methods},
     {Py_tp_new, itertools_count},
     {Py_tp_free, PyObject_GC_Del},
     {0, NULL},
@@ -4274,22 +3540,8 @@ repeat_len(repeatobject *ro, PyObject *Py_UNUSED(ignored))
 
 PyDoc_STRVAR(length_hint_doc, "Private method returning an estimate of len(list(it)).");
 
-static PyObject *
-repeat_reduce(repeatobject *ro, PyObject *Py_UNUSED(ignored))
-{
-    ITERTOOL_PICKLE_DEPRECATION;
-    /* unpickle this so that a new repeat iterator is constructed with an
-     * object, then call __setstate__ on it to set cnt
-     */
-    if (ro->cnt >= 0)
-        return Py_BuildValue("O(On)", Py_TYPE(ro), ro->element, ro->cnt);
-    else
-        return Py_BuildValue("O(O)", Py_TYPE(ro), ro->element);
-}
-
 static PyMethodDef repeat_methods[] = {
     {"__length_hint__", (PyCFunction)repeat_len, METH_NOARGS, length_hint_doc},
-    {"__reduce__",      (PyCFunction)repeat_reduce, METH_NOARGS, reduce_doc},
     {NULL,              NULL}           /* sentinel */
 };
 
@@ -4495,50 +3747,6 @@ zip_longest_next(ziplongestobject *lz)
     return result;
 }
 
-static PyObject *
-zip_longest_reduce(ziplongestobject *lz, PyObject *Py_UNUSED(ignored))
-{
-    ITERTOOL_PICKLE_DEPRECATION;
-    /* Create a new tuple with empty sequences where appropriate to pickle.
-     * Then use setstate to set the fillvalue
-     */
-    int i;
-    PyObject *args = PyTuple_New(PyTuple_GET_SIZE(lz->ittuple));
-
-    if (args == NULL)
-        return NULL;
-    for (i=0; i<PyTuple_GET_SIZE(lz->ittuple); i++) {
-        PyObject *elem = PyTuple_GET_ITEM(lz->ittuple, i);
-        if (elem == NULL) {
-            elem = PyTuple_New(0);
-            if (elem == NULL) {
-                Py_DECREF(args);
-                return NULL;
-            }
-        } else
-            Py_INCREF(elem);
-        PyTuple_SET_ITEM(args, i, elem);
-    }
-    return Py_BuildValue("ONO", Py_TYPE(lz), args, lz->fillvalue);
-}
-
-static PyObject *
-zip_longest_setstate(ziplongestobject *lz, PyObject *state)
-{
-    ITERTOOL_PICKLE_DEPRECATION;
-    Py_INCREF(state);
-    Py_XSETREF(lz->fillvalue, state);
-    Py_RETURN_NONE;
-}
-
-static PyMethodDef zip_longest_methods[] = {
-    {"__reduce__",      (PyCFunction)zip_longest_reduce,      METH_NOARGS,
-     reduce_doc},
-    {"__setstate__",    (PyCFunction)zip_longest_setstate,    METH_O,
-     setstate_doc},
-    {NULL,              NULL}   /* sentinel */
-};
-
 PyDoc_STRVAR(zip_longest_doc,
 "zip_longest(*iterables, fillvalue=None)\n\
 --\n\
@@ -4558,7 +3766,6 @@ static PyType_Slot ziplongest_slots[] = {
     {Py_tp_traverse, zip_longest_traverse},
     {Py_tp_iter, PyObject_SelfIter},
     {Py_tp_iternext, zip_longest_next},
-    {Py_tp_methods, zip_longest_methods},
     {Py_tp_new, zip_longest_new},
     {Py_tp_free, PyObject_GC_Del},
     {0, NULL},


### PR DESCRIPTION


<!-- gh-issue-number: gh-101588 -->
* Issue: gh-101588
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--118816.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->