### PR TITLE
gh-118771: Ensure names defined in optimizer.h start with Py/_Py

### DIFF
--- a/Include/cpython/optimizer.h
+++ b/Include/cpython/optimizer.h
@@ -31,19 +31,14 @@ typedef struct {
     PyCodeObject *code;  // Weak (NULL if no corresponding ENTER_EXECUTOR).
 } _PyVMData;
 
-#define _Py_UOP_FORMAT_TARGET 0
-#define _Py_UOP_FORMAT_EXIT 1
-#define _Py_UOP_FORMAT_JUMP 2
-#define _Py_UOP_FORMAT_UNUSED 3
-
 /* Depending on the format,
  * the 32 bits between the oparg and operand are:
- * _Py_UOP_FORMAT_TARGET:
+ * UOP_FORMAT_TARGET:
  *    uint32_t target;
- * _Py_UOP_FORMAT_EXIT
+ * UOP_FORMAT_EXIT
  *    uint16_t exit_index;
  *    uint16_t error_target;
- * _Py_UOP_FORMAT_JUMP
+ * UOP_FORMAT_JUMP
  *    uint16_t jump_target;
  *    uint16_t error_target;
  */
@@ -63,30 +58,6 @@ typedef struct {
     };
     uint64_t operand;  // A cache entry
 } _PyUOpInstruction;
-
-static inline uint32_t _Py_uop_get_target(const _PyUOpInstruction *inst)
-{
-    assert(inst->format == _Py_UOP_FORMAT_TARGET);
-    return inst->target;
-}
-
-static inline uint16_t _Py_uop_get_exit_index(const _PyUOpInstruction *inst)
-{
-    assert(inst->format == _Py_UOP_FORMAT_EXIT);
-    return inst->exit_index;
-}
-
-static inline uint16_t _Py_uop_get_jump_target(const _PyUOpInstruction *inst)
-{
-    assert(inst->format == _Py_UOP_FORMAT_JUMP);
-    return inst->jump_target;
-}
-
-static inline uint16_t _Py_uop_get_error_target(const _PyUOpInstruction *inst)
-{
-    assert(inst->format != _Py_UOP_FORMAT_TARGET);
-    return inst->error_target;
-}
 
 typedef struct {
     uint32_t target;

--- a/Include/cpython/optimizer.h
+++ b/Include/cpython/optimizer.h
@@ -14,10 +14,10 @@ typedef struct _PyExecutorLinkListNode {
 
 /* Bloom filter with m = 256
  * https://en.wikipedia.org/wiki/Bloom_filter */
-#define BLOOM_FILTER_WORDS 8
+#define _Py_BLOOM_FILTER_WORDS 8
 
-typedef struct _bloom_filter {
-    uint32_t bits[BLOOM_FILTER_WORDS];
+typedef struct {
+    uint32_t bits[_Py_BLOOM_FILTER_WORDS];
 } _PyBloomFilter;
 
 typedef struct {
@@ -31,19 +31,19 @@ typedef struct {
     PyCodeObject *code;  // Weak (NULL if no corresponding ENTER_EXECUTOR).
 } _PyVMData;
 
-#define UOP_FORMAT_TARGET 0
-#define UOP_FORMAT_EXIT 1
-#define UOP_FORMAT_JUMP 2
-#define UOP_FORMAT_UNUSED 3
+#define _Py_UOP_FORMAT_TARGET 0
+#define _Py_UOP_FORMAT_EXIT 1
+#define _Py_UOP_FORMAT_JUMP 2
+#define _Py_UOP_FORMAT_UNUSED 3
 
 /* Depending on the format,
  * the 32 bits between the oparg and operand are:
- * UOP_FORMAT_TARGET:
+ * _Py_UOP_FORMAT_TARGET:
  *    uint32_t target;
- * UOP_FORMAT_EXIT
+ * _Py_UOP_FORMAT_EXIT
  *    uint16_t exit_index;
  *    uint16_t error_target;
- * UOP_FORMAT_JUMP
+ * _Py_UOP_FORMAT_JUMP
  *    uint16_t jump_target;
  *    uint16_t error_target;
  */
@@ -64,31 +64,31 @@ typedef struct {
     uint64_t operand;  // A cache entry
 } _PyUOpInstruction;
 
-static inline uint32_t uop_get_target(const _PyUOpInstruction *inst)
+static inline uint32_t _Py_uop_get_target(const _PyUOpInstruction *inst)
 {
-    assert(inst->format == UOP_FORMAT_TARGET);
+    assert(inst->format == _Py_UOP_FORMAT_TARGET);
     return inst->target;
 }
 
-static inline uint16_t uop_get_exit_index(const _PyUOpInstruction *inst)
+static inline uint16_t _Py_uop_get_exit_index(const _PyUOpInstruction *inst)
 {
-    assert(inst->format == UOP_FORMAT_EXIT);
+    assert(inst->format == _Py_UOP_FORMAT_EXIT);
     return inst->exit_index;
 }
 
-static inline uint16_t uop_get_jump_target(const _PyUOpInstruction *inst)
+static inline uint16_t _Py_uop_get_jump_target(const _PyUOpInstruction *inst)
 {
-    assert(inst->format == UOP_FORMAT_JUMP);
+    assert(inst->format == _Py_UOP_FORMAT_JUMP);
     return inst->jump_target;
 }
 
-static inline uint16_t uop_get_error_target(const _PyUOpInstruction *inst)
+static inline uint16_t _Py_uop_get_error_target(const _PyUOpInstruction *inst)
 {
-    assert(inst->format != UOP_FORMAT_TARGET);
+    assert(inst->format != _Py_UOP_FORMAT_TARGET);
     return inst->error_target;
 }
 
-typedef struct _exit_data {
+typedef struct {
     uint32_t target;
     _Py_BackoffCounter temperature;
     const struct _PyExecutorObject *executor;
@@ -109,14 +109,14 @@ typedef struct _PyExecutorObject {
 typedef struct _PyOptimizerObject _PyOptimizerObject;
 
 /* Should return > 0 if a new executor is created. O if no executor is produced and < 0 if an error occurred. */
-typedef int (*optimize_func)(
+typedef int (*_Py_optimize_func)(
     _PyOptimizerObject* self, struct _PyInterpreterFrame *frame,
     _Py_CODEUNIT *instr, _PyExecutorObject **exec_ptr,
     int curr_stackentries);
 
 struct _PyOptimizerObject {
     PyObject_HEAD
-    optimize_func optimize;
+    _Py_optimize_func optimize;
     /* Data needed by the optimizer goes here, but is opaque to the VM */
 };
 

--- a/Include/internal/pycore_optimizer.h
+++ b/Include/internal/pycore_optimizer.h
@@ -35,6 +35,35 @@ struct _Py_UopsSymbol {
     PyObject *const_val;  // Owned reference (!)
 };
 
+#define UOP_FORMAT_TARGET 0
+#define UOP_FORMAT_EXIT 1
+#define UOP_FORMAT_JUMP 2
+#define UOP_FORMAT_UNUSED 3
+
+static inline uint32_t uop_get_target(const _PyUOpInstruction *inst)
+{
+    assert(inst->format == UOP_FORMAT_TARGET);
+    return inst->target;
+}
+
+static inline uint16_t uop_get_exit_index(const _PyUOpInstruction *inst)
+{
+    assert(inst->format == UOP_FORMAT_EXIT);
+    return inst->exit_index;
+}
+
+static inline uint16_t uop_get_jump_target(const _PyUOpInstruction *inst)
+{
+    assert(inst->format == UOP_FORMAT_JUMP);
+    return inst->jump_target;
+}
+
+static inline uint16_t uop_get_error_target(const _PyUOpInstruction *inst)
+{
+    assert(inst->format != UOP_FORMAT_TARGET);
+    return inst->error_target;
+}
+
 // Holds locals, stack, locals, stack ... co_consts (in that order)
 #define MAX_ABSTRACT_INTERP_SIZE 4096
 

--- a/Misc/NEWS.d/next/C API/2024-05-10-15-43-14.gh-issue-118771.5KVglT.rst
+++ b/Misc/NEWS.d/next/C API/2024-05-10-15-43-14.gh-issue-118771.5KVglT.rst
@@ -1,0 +1,3 @@
+Several C declarations with names that didn't start with the `Py` or `_Py`
+prefixes, which were added by mistake in 3.13 alpha and beta releases, were
+moved to internal headers.

--- a/Misc/NEWS.d/next/C API/2024-05-10-15-43-14.gh-issue-118771.5KVglT.rst
+++ b/Misc/NEWS.d/next/C API/2024-05-10-15-43-14.gh-issue-118771.5KVglT.rst
@@ -1,3 +1,3 @@
-Several C declarations with names that didn't start with the `Py` or `_Py`
+Several C declarations with names that didn't start with the ``Py`` or ``_Py``
 prefixes, which were added by mistake in 3.13 alpha and beta releases, were
 moved to internal headers.

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -1055,14 +1055,14 @@ jump_to_error_target:
                _PyOpcode_OpName[frame->instr_ptr->op.code]);
     }
 #endif
-    assert (next_uop[-1].format == _Py_UOP_FORMAT_JUMP);
-    uint16_t target = _Py_uop_get_error_target(&next_uop[-1]);
+    assert (next_uop[-1].format == UOP_FORMAT_JUMP);
+    uint16_t target = uop_get_error_target(&next_uop[-1]);
     next_uop = current_executor->trace + target;
     goto tier2_dispatch;
 
 error_tier_two:
     OPT_HIST(trace_uop_execution_counter, trace_run_length_hist);
-    assert(next_uop[-1].format == _Py_UOP_FORMAT_TARGET);
+    assert(next_uop[-1].format == UOP_FORMAT_TARGET);
     frame->return_offset = 0;  // Don't leave this random
     _PyFrame_SetStackPointer(frame, stack_pointer);
     Py_DECREF(current_executor);
@@ -1070,8 +1070,8 @@ error_tier_two:
     goto resume_with_error;
 
 jump_to_jump_target:
-    assert(next_uop[-1].format == _Py_UOP_FORMAT_JUMP);
-    target = _Py_uop_get_jump_target(&next_uop[-1]);
+    assert(next_uop[-1].format == UOP_FORMAT_JUMP);
+    target = uop_get_jump_target(&next_uop[-1]);
     next_uop = current_executor->trace + target;
     goto tier2_dispatch;
 
@@ -1079,7 +1079,7 @@ exit_to_tier1_dynamic:
     next_instr = frame->instr_ptr;
     goto goto_to_tier1;
 exit_to_tier1:
-    assert(next_uop[-1].format == _Py_UOP_FORMAT_TARGET);
+    assert(next_uop[-1].format == UOP_FORMAT_TARGET);
     next_instr = next_uop[-1].target + _PyCode_CODE(_PyFrame_GetCode(frame));
 goto_to_tier1:
 #ifdef Py_DEBUG
@@ -1096,7 +1096,7 @@ goto_to_tier1:
     DISPATCH();
 
 exit_to_trace:
-    assert(next_uop[-1].format == _Py_UOP_FORMAT_EXIT);
+    assert(next_uop[-1].format == UOP_FORMAT_EXIT);
     OPT_HIST(trace_uop_execution_counter, trace_run_length_hist);
     uint32_t exit_index = next_uop[-1].exit_index;
     assert(exit_index < current_executor->exit_count);

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -1055,14 +1055,14 @@ jump_to_error_target:
                _PyOpcode_OpName[frame->instr_ptr->op.code]);
     }
 #endif
-    assert (next_uop[-1].format == UOP_FORMAT_JUMP);
-    uint16_t target = uop_get_error_target(&next_uop[-1]);
+    assert (next_uop[-1].format == _Py_UOP_FORMAT_JUMP);
+    uint16_t target = _Py_uop_get_error_target(&next_uop[-1]);
     next_uop = current_executor->trace + target;
     goto tier2_dispatch;
 
 error_tier_two:
     OPT_HIST(trace_uop_execution_counter, trace_run_length_hist);
-    assert(next_uop[-1].format == UOP_FORMAT_TARGET);
+    assert(next_uop[-1].format == _Py_UOP_FORMAT_TARGET);
     frame->return_offset = 0;  // Don't leave this random
     _PyFrame_SetStackPointer(frame, stack_pointer);
     Py_DECREF(current_executor);
@@ -1070,8 +1070,8 @@ error_tier_two:
     goto resume_with_error;
 
 jump_to_jump_target:
-    assert(next_uop[-1].format == UOP_FORMAT_JUMP);
-    target = uop_get_jump_target(&next_uop[-1]);
+    assert(next_uop[-1].format == _Py_UOP_FORMAT_JUMP);
+    target = _Py_uop_get_jump_target(&next_uop[-1]);
     next_uop = current_executor->trace + target;
     goto tier2_dispatch;
 
@@ -1079,7 +1079,7 @@ exit_to_tier1_dynamic:
     next_instr = frame->instr_ptr;
     goto goto_to_tier1;
 exit_to_tier1:
-    assert(next_uop[-1].format == UOP_FORMAT_TARGET);
+    assert(next_uop[-1].format == _Py_UOP_FORMAT_TARGET);
     next_instr = next_uop[-1].target + _PyCode_CODE(_PyFrame_GetCode(frame));
 goto_to_tier1:
 #ifdef Py_DEBUG
@@ -1096,7 +1096,7 @@ goto_to_tier1:
     DISPATCH();
 
 exit_to_trace:
-    assert(next_uop[-1].format == UOP_FORMAT_EXIT);
+    assert(next_uop[-1].format == _Py_UOP_FORMAT_EXIT);
     OPT_HIST(trace_uop_execution_counter, trace_run_length_hist);
     uint32_t exit_index = next_uop[-1].exit_index;
     assert(exit_index < current_executor->exit_count);

--- a/Python/optimizer.c
+++ b/Python/optimizer.c
@@ -318,19 +318,19 @@ _PyUOpPrint(const _PyUOpInstruction *uop)
         printf("%s", name);
     }
     switch(uop->format) {
-        case _Py_UOP_FORMAT_TARGET:
+        case UOP_FORMAT_TARGET:
             printf(" (%d, target=%d, operand=%#" PRIx64,
                 uop->oparg,
                 uop->target,
                 (uint64_t)uop->operand);
             break;
-        case _Py_UOP_FORMAT_JUMP:
+        case UOP_FORMAT_JUMP:
             printf(" (%d, jump_target=%d, operand=%#" PRIx64,
                 uop->oparg,
                 uop->jump_target,
                 (uint64_t)uop->operand);
             break;
-        case _Py_UOP_FORMAT_EXIT:
+        case UOP_FORMAT_EXIT:
             printf(" (%d, exit_index=%d, operand=%#" PRIx64,
                 uop->oparg,
                 uop->exit_index,
@@ -500,7 +500,7 @@ add_to_trace(
     uint32_t target)
 {
     trace[trace_length].opcode = opcode;
-    trace[trace_length].format = _Py_UOP_FORMAT_TARGET;
+    trace[trace_length].format = UOP_FORMAT_TARGET;
     trace[trace_length].target = target;
     trace[trace_length].oparg = oparg;
     trace[trace_length].operand = operand;
@@ -988,7 +988,7 @@ static void make_exit(_PyUOpInstruction *inst, int opcode, int target)
     inst->opcode = opcode;
     inst->oparg = 0;
     inst->operand = 0;
-    inst->format = _Py_UOP_FORMAT_TARGET;
+    inst->format = UOP_FORMAT_TARGET;
     inst->target = target;
 }
 
@@ -1019,7 +1019,7 @@ prepare_for_execution(_PyUOpInstruction *buffer, int length)
     for (int i = 0; i < length; i++) {
         _PyUOpInstruction *inst = &buffer[i];
         int opcode = inst->opcode;
-        int32_t target = (int32_t)_Py_uop_get_target(inst);
+        int32_t target = (int32_t)uop_get_target(inst);
         if (_PyUop_Flags[opcode] & (HAS_EXIT_FLAG | HAS_DEOPT_FLAG)) {
             uint16_t exit_op = (_PyUop_Flags[opcode] & HAS_EXIT_FLAG) ?
                 _EXIT_TRACE : _DEOPT;
@@ -1039,7 +1039,7 @@ prepare_for_execution(_PyUOpInstruction *buffer, int length)
                 next_spare++;
             }
             buffer[i].jump_target = current_jump;
-            buffer[i].format = _Py_UOP_FORMAT_JUMP;
+            buffer[i].format = UOP_FORMAT_JUMP;
         }
         if (_PyUop_Flags[opcode] & HAS_ERROR_FLAG) {
             int popped = (_PyUop_Flags[opcode] & HAS_ERROR_NO_POP_FLAG) ?
@@ -1054,8 +1054,8 @@ prepare_for_execution(_PyUOpInstruction *buffer, int length)
                 next_spare++;
             }
             buffer[i].error_target = current_error;
-            if (buffer[i].format == _Py_UOP_FORMAT_TARGET) {
-                buffer[i].format = _Py_UOP_FORMAT_JUMP;
+            if (buffer[i].format == UOP_FORMAT_TARGET) {
+                buffer[i].format = UOP_FORMAT_JUMP;
                 buffer[i].jump_target = 0;
             }
         }
@@ -1109,22 +1109,22 @@ sanity_check(_PyExecutorObject *executor)
         CHECK(opcode <= MAX_UOP_ID);
         CHECK(_PyOpcode_uop_name[opcode] != NULL);
         switch(inst->format) {
-            case _Py_UOP_FORMAT_TARGET:
+            case UOP_FORMAT_TARGET:
                 CHECK(target_unused(opcode));
                 break;
-            case _Py_UOP_FORMAT_EXIT:
+            case UOP_FORMAT_EXIT:
                 CHECK(opcode == _EXIT_TRACE);
                 CHECK(inst->exit_index < executor->exit_count);
                 break;
-            case _Py_UOP_FORMAT_JUMP:
+            case UOP_FORMAT_JUMP:
                 CHECK(inst->jump_target < executor->code_size);
                 break;
-            case _Py_UOP_FORMAT_UNUSED:
+            case UOP_FORMAT_UNUSED:
                 CHECK(0);
                 break;
         }
         if (_PyUop_Flags[opcode] & HAS_ERROR_FLAG) {
-            CHECK(inst->format == _Py_UOP_FORMAT_JUMP);
+            CHECK(inst->format == UOP_FORMAT_JUMP);
             CHECK(inst->error_target < executor->code_size);
         }
         if (opcode == _JUMP_TO_TOP || opcode == _EXIT_TRACE || opcode == _COLD_EXIT) {
@@ -1142,7 +1142,7 @@ sanity_check(_PyExecutorObject *executor)
             opcode == _EXIT_TRACE ||
             opcode == _ERROR_POP_N);
         if (opcode == _EXIT_TRACE) {
-            CHECK(inst->format == _Py_UOP_FORMAT_EXIT);
+            CHECK(inst->format == UOP_FORMAT_EXIT);
         }
     }
 }
@@ -1182,7 +1182,7 @@ make_executor_from_uops(_PyUOpInstruction *buffer, int length, const _PyBloomFil
         if (opcode == _EXIT_TRACE) {
             executor->exits[next_exit].target = buffer[i].target;
             dest->exit_index = next_exit;
-            dest->format = _Py_UOP_FORMAT_EXIT;
+            dest->format = UOP_FORMAT_EXIT;
             next_exit--;
         }
         if (opcode == _DYNAMIC_EXIT) {
@@ -1400,10 +1400,10 @@ counter_optimize(
     }
     _Py_CODEUNIT *target = instr + 1 + _PyOpcode_Caches[JUMP_BACKWARD] - oparg;
     _PyUOpInstruction buffer[4] = {
-        { .opcode = _START_EXECUTOR, .jump_target = 3, .format=_Py_UOP_FORMAT_JUMP },
+        { .opcode = _START_EXECUTOR, .jump_target = 3, .format=UOP_FORMAT_JUMP },
         { .opcode = _LOAD_CONST_INLINE_BORROW, .operand = (uintptr_t)self },
         { .opcode = _INTERNAL_INCREMENT_OPT_COUNTER },
-        { .opcode = _EXIT_TRACE, .target = (uint32_t)(target - _PyCode_CODE(code)), .format=_Py_UOP_FORMAT_TARGET }
+        { .opcode = _EXIT_TRACE, .target = (uint32_t)(target - _PyCode_CODE(code)), .format=UOP_FORMAT_TARGET }
     };
     _PyExecutorObject *executor = make_executor_from_uops(buffer, 4, &EMPTY_FILTER);
     if (executor == NULL) {


### PR DESCRIPTION
`optimizer.h` is included from `Python.h`, and defines some names that can clash with user code. They should be hidden or get the `Py`/`_Py` prefix.

This PR:

- removes unused struct tags from typedefs:
  - `struct _bloom_filter`
  - `struct _exit_data`
- prefixes the remaining names with `_Py_`:
  - `uop_get_target`
  - `uop_get_exit_index`
  - `uop_get_jump_target`
  - `uop_get_error_target`
  - `optimize_func` typedef
  - `BLOOM_FILTER_WORDS`
  - `UOP_FORMAT_TARGET`
  - `UOP_FORMAT_EXIT`
  - `UOP_FORMAT_JUMP`
  - `UOP_FORMAT_UNUSED`

Perhaps some of these should be in a private header instead?
Or perhaps some should be public?
@markshannon, could you clarify the intent here?

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-118771 -->
* Issue: gh-118771
<!-- /gh-issue-number -->
