### PR TITLE
gh-118846: Fix PGO tests in free-threaded build

### DIFF
--- a/Lib/test/test_ordered_dict.py
+++ b/Lib/test/test_ordered_dict.py
@@ -10,7 +10,7 @@ import unittest
 import weakref
 from collections.abc import MutableMapping
 from test import mapping_tests, support
-from test.support import import_helper
+from test.support import import_helper, suppress_immortalization
 
 
 py_coll = import_helper.import_fresh_module('collections',
@@ -667,6 +667,7 @@ class OrderedDictTests:
         dict.update(od, [('spam', 1)])
         self.assertNotIn('NULL', repr(od))
 
+    @suppress_immortalization()
     def test_reference_loop(self):
         # Issue 25935
         OrderedDict = self.OrderedDict

--- a/Lib/test/test_struct.py
+++ b/Lib/test/test_struct.py
@@ -9,7 +9,7 @@ import sys
 import weakref
 
 from test import support
-from test.support import import_helper
+from test.support import import_helper, suppress_immortalization
 from test.support.script_helper import assert_python_ok
 
 ISBIGENDIAN = sys.byteorder == "big"
@@ -674,6 +674,7 @@ class StructTest(unittest.TestCase):
         self.assertIn(b"Exception ignored in:", stderr)
         self.assertIn(b"C.__del__", stderr)
 
+    @suppress_immortalization()
     def test__struct_reference_cycle_cleaned_up(self):
         # Regression test for python/cpython#94207.
 


### PR DESCRIPTION
Avoid immortalizing objects in tests that verify garbage collection of classes or modules.

This fixes test_ordered_dict and test_struct.

<!-- gh-issue-number: gh-118846 -->
* Issue: gh-118846
<!-- /gh-issue-number -->
