### PR TITLE
gh-118876: Set ns.temp before invoking its is_absolute method

### DIFF
--- a/PC/layout/main.py
+++ b/PC/layout/main.py
@@ -599,6 +599,15 @@ def main():
     ns.source = ns.source or (Path(__file__).resolve().parent.parent.parent)
     ns.build = ns.build or Path(sys.executable).parent
     ns.doc_build = ns.doc_build or (ns.source / "Doc" / "build")
+    if ns.copy and not ns.copy.is_absolute():
+        ns.copy = (Path.cwd() / ns.copy).resolve()
+    if not ns.temp:
+        # Put temp on a Dev Drive for speed if we're copying to one.
+        # If not, the regular temp dir will have to do.
+        if ns.copy and getattr(os.path, "isdevdrive", lambda d: False)(ns.copy):
+            ns.temp = ns.copy.with_name(ns.copy.name + "_temp")
+        else:
+            ns.temp = Path(tempfile.mkdtemp())
     if not ns.source.is_absolute():
         ns.source = (Path.cwd() / ns.source).resolve()
     if not ns.build.is_absolute():
@@ -617,20 +626,10 @@ def main():
         else:
             ns.arch = "amd64"
 
-    if ns.copy and not ns.copy.is_absolute():
-        ns.copy = (Path.cwd() / ns.copy).resolve()
     if ns.zip and not ns.zip.is_absolute():
         ns.zip = (Path.cwd() / ns.zip).resolve()
     if ns.catalog and not ns.catalog.is_absolute():
         ns.catalog = (Path.cwd() / ns.catalog).resolve()
-
-    if not ns.temp:
-        # Put temp on a Dev Drive for speed if we're copying to one.
-        # If not, the regular temp dir will have to do.
-        if ns.copy and getattr(os.path, "isdevdrive", lambda d: False)(ns.copy):
-            ns.temp = ns.copy.with_name(ns.copy.name + "_temp")
-        else:
-            ns.temp = Path(tempfile.mkdtemp())
 
     configure_logger(ns)
 


### PR DESCRIPTION
Fixes an AttributeError that occurs when checking if ns.temp is an absolute path during building from source on Windows.



<!-- gh-issue-number: gh-118876 -->
* Issue: gh-118876
<!-- /gh-issue-number -->
