### PR TITLE
gh-119185: Fix typo in `_pyrepl.pager`: `tempfilepager` should be `tempfile_pager`

### DIFF
--- a/Lib/_pyrepl/pager.py
+++ b/Lib/_pyrepl/pager.py
@@ -35,7 +35,7 @@ def get_pager() -> Pager:
     if os.environ.get('TERM') in ('dumb', 'emacs'):
         return plain_pager
     if sys.platform == 'win32':
-        return lambda text, title='': tempfilepager(plain(text), 'more <')
+        return lambda text, title='': tempfile_pager(plain(text), 'more <')
     if hasattr(os, 'system') and os.system('(less) 2>/dev/null') == 0:
         return lambda text, title='': pipe_pager(text, 'less', title)
 


### PR DESCRIPTION
The function name has an underscore. Without this, calling help can cause an exception.

Should be reproducible by calling `help()` in the repl on Windows. I personally found it by calling it on `sysconfig.get_config_var`.

Doesn’t seem worthy of a news entry. 

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-119185 -->
* Issue: gh-119185
<!-- /gh-issue-number -->
