### PR TITLE
gh-118895: Call PyType_Ready() on typing.NoDefault

### DIFF
--- a/Include/internal/pycore_typevarobject.h
+++ b/Include/internal/pycore_typevarobject.h
@@ -18,6 +18,7 @@ extern int _Py_initialize_generic(PyInterpreterState *);
 extern void _Py_clear_generic_types(PyInterpreterState *);
 
 extern PyTypeObject _PyTypeAlias_Type;
+extern PyTypeObject _PyNoDefault_Type;
 extern PyObject _Py_NoDefaultStruct;
 
 #ifdef __cplusplus

--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -10236,7 +10236,7 @@ class NoDefaultTests(BaseTestCase):
     def test_constructor(self):
         self.assertIs(NoDefault, type(NoDefault)())
         with self.assertRaises(TypeError):
-            NoDefault(1)
+            type(NoDefault)(1)
 
     def test_repr(self):
         self.assertEqual(repr(NoDefault), 'typing.NoDefault')
@@ -10244,6 +10244,16 @@ class NoDefaultTests(BaseTestCase):
     def test_no_call(self):
         with self.assertRaises(TypeError):
             NoDefault()
+
+    def test_no_attributes(self):
+        with self.assertRaises(AttributeError):
+            NoDefault.foo = 3
+        with self.assertRaises(AttributeError):
+            NoDefault.foo
+
+        # TypeError is consistent with the behavior of NoneType
+        with self.assertRaises(TypeError):
+            type(NoDefault).foo = 3
 
 
 class AllTests(BaseTestCase):

--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -45,7 +45,7 @@ import typing
 import weakref
 import types
 
-from test.support import captured_stderr, cpython_only, infinite_recursion
+from test.support import captured_stderr, cpython_only, infinite_recursion, requires_docstrings
 from test.typinganndata import ann_module695, mod_generics_cache, _typed_dict_helper
 
 
@@ -10241,6 +10241,7 @@ class NoDefaultTests(BaseTestCase):
     def test_repr(self):
         self.assertEqual(repr(NoDefault), 'typing.NoDefault')
 
+    @requires_docstrings
     def test_doc(self):
         self.assertIsInstance(NoDefault.__doc__, str)
 
@@ -10260,6 +10261,8 @@ class NoDefaultTests(BaseTestCase):
         # TypeError is consistent with the behavior of NoneType
         with self.assertRaises(TypeError):
             type(NoDefault).foo = 3
+        with self.assertRaises(AttributeError):
+            type(NoDefault).foo
 
 
 class AllTests(BaseTestCase):

--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -10241,6 +10241,12 @@ class NoDefaultTests(BaseTestCase):
     def test_repr(self):
         self.assertEqual(repr(NoDefault), 'typing.NoDefault')
 
+    def test_doc(self):
+        self.assertIsInstance(NoDefault.__doc__, str)
+
+    def test_class(self):
+        self.assertIs(NoDefault.__class__, type(NoDefault))
+
     def test_no_call(self):
         with self.assertRaises(TypeError):
             NoDefault()

--- a/Misc/NEWS.d/next/Library/2024-05-10-05-24-32.gh-issue-118895.wUm5r2.rst
+++ b/Misc/NEWS.d/next/Library/2024-05-10-05-24-32.gh-issue-118895.wUm5r2.rst
@@ -1,0 +1,2 @@
+Setting attributes on :data:`typing.NoDefault` now raises
+:exc:`AttributeError` instead of :exc:`TypeError`.

--- a/Modules/_typingmodule.c
+++ b/Modules/_typingmodule.c
@@ -63,6 +63,9 @@ _typing_exec(PyObject *m)
     if (PyModule_AddObjectRef(m, "TypeAliasType", (PyObject *)&_PyTypeAlias_Type) < 0) {
         return -1;
     }
+    if (PyType_Ready(&_PyNoDefault_Type) < 0) {
+        return -1;
+    }
     if (PyModule_AddObjectRef(m, "NoDefault", (PyObject *)&_Py_NoDefaultStruct) < 0) {
         return -1;
     }


### PR DESCRIPTION


<!-- gh-issue-number: gh-118895 -->
* Issue: gh-118895
<!-- /gh-issue-number -->
