### PR TITLE
Rename typing._collect_parameters

### DIFF
--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -45,7 +45,7 @@ import typing
 import weakref
 import types
 
-from test.support import captured_stderr, cpython_only, infinite_recursion, requires_docstrings
+from test.support import captured_stderr, cpython_only, infinite_recursion, requires_docstrings, import_helper
 from test.typinganndata import ann_module695, mod_generics_cache, _typed_dict_helper
 
 
@@ -6353,8 +6353,9 @@ class InternalsTests(BaseTestCase):
         self.assertEqual(cm.filename, __file__)
 
     def test_collect_parameters(self):
+        typing = import_helper.import_fresh_module("typing")
         with self.assertWarns(DeprecationWarning):
-            from typing import _collect_parameters
+            typing._collect_parameters
 
 
 @lru_cache()

--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -6354,7 +6354,10 @@ class InternalsTests(BaseTestCase):
 
     def test_collect_parameters(self):
         typing = import_helper.import_fresh_module("typing")
-        with self.assertWarns(DeprecationWarning) as cm:
+        with self.assertWarnsRegex(
+            DeprecationWarning,
+            "The private _collect_parameters function is deprecated"
+        ) as cm:
             typing._collect_parameters
         self.assertEqual(cm.filename, __file__)
 

--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -6354,8 +6354,9 @@ class InternalsTests(BaseTestCase):
 
     def test_collect_parameters(self):
         typing = import_helper.import_fresh_module("typing")
-        with self.assertWarns(DeprecationWarning):
+        with self.assertWarns(DeprecationWarning) as cm:
             typing._collect_parameters
+        self.assertEqual(cm.filename, __file__)
 
 
 @lru_cache()

--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -6325,6 +6325,8 @@ class ForwardRefTests(BaseTestCase):
         self.assertEqual(X | "x", Union[X, "x"])
         self.assertEqual("x" | X, Union["x", X])
 
+
+class InternalsTests(BaseTestCase):
     def test_deprecation_for_no_type_params_passed_to__evaluate(self):
         with self.assertWarnsRegex(
             DeprecationWarning,
@@ -6349,6 +6351,10 @@ class ForwardRefTests(BaseTestCase):
             self.assertIs(f._evaluate(globals(), {}, recursive_guard=frozenset()), int)
 
         self.assertEqual(cm.filename, __file__)
+
+    def test_collect_parameters(self):
+        with self.assertWarns(DeprecationWarning):
+            from typing import _collect_parameters
 
 
 @lru_cache()

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -3770,6 +3770,16 @@ def __getattr__(attr):
     elif attr in {"ContextManager", "AsyncContextManager"}:
         import contextlib
         obj = _alias(getattr(contextlib, f"Abstract{attr}"), 2, name=attr, defaults=(bool | None,))
+    elif attr == "_collect_parameters":
+        import warnings
+
+        depr_message = (
+            "The private _collect_parameters function is deprecated and will be"
+            " removed in a future version of Python. Any use of private functions"
+            " is discouraged and may break in the future."
+        )
+        warnings.warn(depr_message, category=DeprecationWarning, stacklevel=1)
+        obj = _collect_type_parameters
     else:
         raise AttributeError(f"module {__name__!r} has no attribute {attr!r}")
     globals()[attr] = obj

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -3778,7 +3778,7 @@ def __getattr__(attr):
             " removed in a future version of Python. Any use of private functions"
             " is discouraged and may break in the future."
         )
-        warnings.warn(depr_message, category=DeprecationWarning, stacklevel=1)
+        warnings.warn(depr_message, category=DeprecationWarning, stacklevel=2)
         obj = _collect_type_parameters
     else:
         raise AttributeError(f"module {__name__!r} has no attribute {attr!r}")


### PR DESCRIPTION
function. Unfortunately, released versions of typing_extensions
monkeypatch this function without the extra parameter, which makes
it so things break badly if current main is used with typing_extensions.

```
% ~/py/cpython/python.exe test_typing_extensions.py
Traceback (most recent call last):
  File "/Users/jelle/py/typing_extensions/src/test_typing_extensions.py", line 42, in <module>
    from _typed_dict_test_helper import Foo, FooGeneric, VeryAnnotated
  File "/Users/jelle/py/typing_extensions/src/_typed_dict_test_helper.py", line 17, in <module>
    class FooGeneric(TypedDict, Generic[T]):
                                ~~~~~~~^^^
  File "/Users/jelle/py/cpython/Lib/typing.py", line 431, in inner
    return func(*args, **kwds)
  File "/Users/jelle/py/cpython/Lib/typing.py", line 1243, in _generic_class_getitem
    return _GenericAlias(cls, args)
  File "/Users/jelle/py/cpython/Lib/typing.py", line 1420, in __init__
    self.__parameters__ = _collect_parameters(
                          ~~~~~~~~~~~~~~~~~~~^
        args,
        ^^^^^
        enforce_default_ordering=enforce_default_ordering,
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
TypeError: _collect_parameters() got an unexpected keyword argument 'enforce_default_ordering'
```

Fortunately, the monkeypatching is not needed on Python 3.13, because CPython
now implements PEP 696. By renaming the function, we prevent the monkeypatch
from breaking typing.py internals.
