### PR TITLE
gh-118924: Remove `sqlite3.version` and `sqlite3.version_info`

### DIFF
--- a/Doc/library/sqlite3.rst
+++ b/Doc/library/sqlite3.rst
@@ -553,7 +553,7 @@ Module constants
    .. deprecated-removed:: 3.12 3.14
       This constant used to reflect the version number of the ``pysqlite``
       package, a third-party library which used to upstream changes to
-      :mod:`!sqlite3`. Today, it carries no meaning or practical value.
+      :mod:`!sqlite3`. Before removal, it carried no meaning or practical value.
 
 .. data:: version_info
 
@@ -563,7 +563,7 @@ Module constants
    .. deprecated-removed:: 3.12 3.14
       This constant used to reflect the version number of the ``pysqlite``
       package, a third-party library which used to upstream changes to
-      :mod:`!sqlite3`. Today, it carries no meaning or practical value.
+      :mod:`!sqlite3`. Before removal, it carried no meaning or practical value.
 
 .. _sqlite3-dbconfig-constants:
 

--- a/Doc/library/sqlite3.rst
+++ b/Doc/library/sqlite3.rst
@@ -545,26 +545,6 @@ Module constants
    .. versionchanged:: 3.11
       Set *threadsafety* dynamically instead of hard-coding it to ``1``.
 
-.. data:: version
-
-   Version number of this module as a :class:`string <str>`.
-   This is not the version of the SQLite library.
-
-   .. deprecated-removed:: 3.12 3.14
-      This constant used to reflect the version number of the ``pysqlite``
-      package, a third-party library which used to upstream changes to
-      :mod:`!sqlite3`. Before removal, it carried no meaning or practical value.
-
-.. data:: version_info
-
-   Version number of this module as a :class:`tuple` of :class:`integers <int>`.
-   This is not the version of the SQLite library.
-
-   .. deprecated-removed:: 3.12 3.14
-      This constant used to reflect the version number of the ``pysqlite``
-      package, a third-party library which used to upstream changes to
-      :mod:`!sqlite3`. Before removal, it carried no meaning or practical value.
-
 .. _sqlite3-dbconfig-constants:
 
 .. data:: SQLITE_DBCONFIG_DEFENSIVE
@@ -597,6 +577,8 @@ Module constants
      https://www.sqlite.org/c3ref/c_dbconfig_defensive.html
         SQLite docs: Database Connection Configuration Options
 
+.. deprecated-removed:: 3.12 3.14
+   The :data:`!version` and :data:`!version_info` constants.
 
 .. _sqlite3-connection-objects:
 

--- a/Doc/whatsnew/3.13.rst
+++ b/Doc/whatsnew/3.13.rst
@@ -1636,7 +1636,7 @@ Pending Removal in Python 3.14
 
 * :mod:`sqlite3`:
 
-  * :data:`~sqlite3.version` and :data:`~sqlite3.version_info`.
+  * :data:`!version` and :data:`!version_info`.
 
   * :meth:`~sqlite3.Cursor.execute` and :meth:`~sqlite3.Cursor.executemany`
     if :ref:`named placeholders <sqlite3-placeholders>` are used and

--- a/Doc/whatsnew/3.14.rst
+++ b/Doc/whatsnew/3.14.rst
@@ -104,15 +104,29 @@ Removed
 argparse
 --------
 
-* The *type*, *choices*, and *metavar* parameters
-  of :class:`!argparse.BooleanOptionalAction` are removed.
+* Remove the *type*, *choices*, and *metavar* parameters
+  of :class:`!argparse.BooleanOptionalAction`.
   They were deprecated since 3.12.
+
+collections.abc
+---------------
+
+* Remove :class:`!collections.abc.ByteString`. It had previously raised a
+  :exc:`DeprecationWarning` since Python 3.12.
+
 
 email
 -----
 
-* The *isdst* parameter has been removed from :func:`email.utils.localtime`.
+* Remove the *isdst* parameter from :func:`email.utils.localtime`.
   (Contributed by Hugo van Kemenade in :gh:`118798`.)
+
+itertools
+---------
+
+* Remove :mod:`itertools` support for copy, deepcopy, and pickle operations.
+  These had previously raised a :exc:`DeprecationWarning` since Python 3.12.
+  (Contributed by Raymond Hettinger in :gh:`101588`.)
 
 pathlib
 -------
@@ -122,20 +136,18 @@ pathlib
   :meth:`~pathlib.PurePath.is_relative_to`. In previous versions, any such
   arguments are joined onto *other*.
 
+typing
+------
+
+* Remove :class:`!typing.ByteString`. It had previously raised a
+  :exc:`DeprecationWarning` since Python 3.12.
+
 Others
 ------
 
 * Using :data:`NotImplemented` in a boolean context will now raise a :exc:`TypeError`.
   It had previously raised a :exc:`DeprecationWarning` since Python 3.9. (Contributed
   by Jelle Zijlstra in :gh:`118767`.)
-
-* :class:`!typing.ByteString` and :class:`!collections.abc.ByteString`
-  are removed. They had previously raised a :exc:`DeprecationWarning`
-  since Python 3.12.
-
-* :mod:`itertools` support for copy, deepcopy, and pickle operations.
-  These had previously raised a :exc:`DeprecationWarning` since Python 3.12.
-  (Contributed by Raymond Hettinger in :gh:`101588`.)
 
 
 Porting to Python 3.14

--- a/Doc/whatsnew/3.14.rst
+++ b/Doc/whatsnew/3.14.rst
@@ -139,8 +139,8 @@ pathlib
 sqlite3
 -------
 
-* Remove :data:`~sqlite3.version` and :data:`~sqlite3.version_info` from
-  :mod:`sqlite3`. (Contributed by Hugo van Kemenade in :gh:`118924`.)
+* Remove :data:`!version` and :data:`!version_info` from :mod:`sqlite3`.
+  (Contributed by Hugo van Kemenade in :gh:`118924`.)
 
 typing
 ------

--- a/Doc/whatsnew/3.14.rst
+++ b/Doc/whatsnew/3.14.rst
@@ -136,6 +136,12 @@ pathlib
   :meth:`~pathlib.PurePath.is_relative_to`. In previous versions, any such
   arguments are joined onto *other*.
 
+sqlite3
+-------
+
+* Remove :data:`~sqlite3.version` and :data:`~sqlite3.version_info` from
+  :mod:`sqlite3`. (Contributed by Hugo van Kemenade in :gh:`118924`.)
+
 typing
 ------
 

--- a/Lib/sqlite3/__init__.py
+++ b/Lib/sqlite3/__init__.py
@@ -55,16 +55,3 @@ The sqlite3 module is written by Gerhard Häring <gh@ghaering.de>.
 """
 
 from sqlite3.dbapi2 import *
-from sqlite3.dbapi2 import (_deprecated_names,
-                            _deprecated_version_info,
-                            _deprecated_version)
-
-
-def __getattr__(name):
-    if name in _deprecated_names:
-        from warnings import warn
-
-        warn(f"{name} is deprecated and will be removed in Python 3.14",
-             DeprecationWarning, stacklevel=2)
-        return globals()[f"_deprecated_{name}"]
-    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/Lib/sqlite3/dbapi2.py
+++ b/Lib/sqlite3/dbapi2.py
@@ -25,9 +25,6 @@ import time
 import collections.abc
 
 from _sqlite3 import *
-from _sqlite3 import _deprecated_version
-
-_deprecated_names = frozenset({"version", "version_info"})
 
 paramstyle = "qmark"
 
@@ -48,7 +45,7 @@ def TimeFromTicks(ticks):
 def TimestampFromTicks(ticks):
     return Timestamp(*time.localtime(ticks)[:6])
 
-_deprecated_version_info = tuple(map(int, _deprecated_version.split(".")))
+
 sqlite_version_info = tuple([int(x) for x in sqlite_version.split(".")])
 
 Binary = memoryview
@@ -97,12 +94,3 @@ register_adapters_and_converters()
 # Clean up namespace
 
 del(register_adapters_and_converters)
-
-def __getattr__(name):
-    if name in _deprecated_names:
-        from warnings import warn
-
-        warn(f"{name} is deprecated and will be removed in Python 3.14",
-             DeprecationWarning, stacklevel=2)
-        return globals()[f"_deprecated_{name}"]
-    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/Lib/test/test_sqlite3/test_dbapi.py
+++ b/Lib/test/test_sqlite3/test_dbapi.py
@@ -48,17 +48,6 @@ class ModuleTests(unittest.TestCase):
         self.assertEqual(sqlite.apilevel, "2.0",
                          "apilevel is %s, should be 2.0" % sqlite.apilevel)
 
-    def test_deprecated_version(self):
-        msg = "deprecated and will be removed in Python 3.14"
-        for attr in "version", "version_info":
-            with self.subTest(attr=attr):
-                with self.assertWarnsRegex(DeprecationWarning, msg) as cm:
-                    getattr(sqlite, attr)
-                self.assertEqual(cm.filename,  __file__)
-                with self.assertWarnsRegex(DeprecationWarning, msg) as cm:
-                    getattr(sqlite.dbapi2, attr)
-                self.assertEqual(cm.filename,  __file__)
-
     def test_thread_safety(self):
         self.assertIn(sqlite.threadsafety, {0, 1, 3},
                       "threadsafety is %d, should be 0, 1 or 3" %

--- a/Misc/NEWS.d/3.12.0a1.rst
+++ b/Misc/NEWS.d/3.12.0a1.rst
@@ -3498,7 +3498,7 @@ Illia Volochii.
 .. nonce: tjfu9L
 .. section: Library
 
-Deprecate :data:`sqlite3.version` and :data:`sqlite3.version_info`.
+Deprecate :data:`!version` and :data:`!version_info`.
 
 ..
 

--- a/Misc/NEWS.d/next/Library/2024-05-10-22-59-01.gh-issue-118924.9nyvSH.rst
+++ b/Misc/NEWS.d/next/Library/2024-05-10-22-59-01.gh-issue-118924.9nyvSH.rst
@@ -1,0 +1,2 @@
+Remove :data:`~sqlite3.version` and :data:`~sqlite3.version_info` from
+:mod:`sqlite3`. Patch by Hugo van Kemenade.

--- a/Misc/NEWS.d/next/Library/2024-05-10-22-59-01.gh-issue-118924.9nyvSH.rst
+++ b/Misc/NEWS.d/next/Library/2024-05-10-22-59-01.gh-issue-118924.9nyvSH.rst
@@ -1,2 +1,2 @@
-Remove :data:`~sqlite3.version` and :data:`~sqlite3.version_info` from
-:mod:`sqlite3`. Patch by Hugo van Kemenade.
+Remove :data:`!version` and :data:`!version_info` from :mod:`sqlite3`.
+Patch by Hugo van Kemenade.

--- a/Modules/_sqlite/module.c
+++ b/Modules/_sqlite/module.c
@@ -714,10 +714,6 @@ module_exec(PyObject *module)
         goto error;
     }
 
-    if (PyModule_AddStringConstant(module, "_deprecated_version", PYSQLITE_VERSION) < 0) {
-        goto error;
-    }
-
     if (PyModule_AddStringConstant(module, "sqlite_version", sqlite3_libversion())) {
         goto error;
     }


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

Fixes #118924.

Also alphabetically sort the other removals in What's New in 3.14, and use similar tense as in [What's New in 3.13](https://docs.python.org/3.13/whatsnew/3.13.html#removed-modules-and-apis).


<!-- gh-issue-number: gh-118924 -->
* Issue: gh-118924
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--118925.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->