### PR TITLE
gh-118928: sqlite3: disallow sequences of params with named placeholders

### DIFF
--- a/Doc/whatsnew/3.14.rst
+++ b/Doc/whatsnew/3.14.rst
@@ -142,7 +142,7 @@ sqlite3
 * Remove :data:`!version` and :data:`!version_info` from :mod:`sqlite3`.
   (Contributed by Hugo van Kemenade in :gh:`118924`.)
 
-* Disallow using a sequence of params with named placeholders.
+* Disallow using a sequence of parameters with named placeholders.
   This had previously raised a :exc:`DeprecationWarning` since Python 3.12;
   it will now raise a :exc:`sqlite3.ProgrammingError`.
   (Contributed by Erlend E. Aasland in :gh:`118928` and :gh:`101693`.)

--- a/Doc/whatsnew/3.14.rst
+++ b/Doc/whatsnew/3.14.rst
@@ -86,6 +86,12 @@ New Modules
 Improved Modules
 ================
 
+sqlite3
+-------
+
+Disallow using a sequence of params with named placeholders.
+(Contributed by Erlend E. Aasland in :gh:`118928` and :gh:`101693`.)
+
 
 Optimizations
 =============

--- a/Doc/whatsnew/3.14.rst
+++ b/Doc/whatsnew/3.14.rst
@@ -86,12 +86,6 @@ New Modules
 Improved Modules
 ================
 
-sqlite3
--------
-
-Disallow using a sequence of params with named placeholders.
-(Contributed by Erlend E. Aasland in :gh:`118928` and :gh:`101693`.)
-
 
 Optimizations
 =============
@@ -147,6 +141,11 @@ sqlite3
 
 * Remove :data:`!version` and :data:`!version_info` from :mod:`sqlite3`.
   (Contributed by Hugo van Kemenade in :gh:`118924`.)
+
+* Disallow using a sequence of params with named placeholders.
+  This had previously raised a :exc:`DeprecationWarning` since Python 3.12;
+  it will now raise a :exc:`sqlite3.ProgrammingError`.
+  (Contributed by Erlend E. Aasland in :gh:`118928` and :gh:`101693`.)
 
 typing
 ------

--- a/Lib/test/test_sqlite3/test_dbapi.py
+++ b/Lib/test/test_sqlite3/test_dbapi.py
@@ -889,9 +889,8 @@ class CursorTests(unittest.TestCase):
         msg = "Binding.*is a named parameter"
         for query, params in dataset:
             with self.subTest(query=query, params=params):
-                with self.assertWarnsRegex(DeprecationWarning, msg) as cm:
+                with self.assertRaisesRegex(sqlite.ProgrammingError, msg) as cm:
                     self.cu.execute(query, params)
-                self.assertEqual(cm.filename,  __file__)
 
     def test_execute_indexed_nameless_params(self):
         # See gh-117995: "'?1' is considered a named placeholder"

--- a/Misc/NEWS.d/next/Library/2024-05-10-22-36-01.gh-issue-118928.IW7Ukv.rst
+++ b/Misc/NEWS.d/next/Library/2024-05-10-22-36-01.gh-issue-118928.IW7Ukv.rst
@@ -1,2 +1,2 @@
-Disallow using a sequence of params with named placeholders in
+Disallow using a sequence of parameters with named placeholders in
 :mod:`sqlite3` queries. Patch by Erlend E. Aasland.

--- a/Misc/NEWS.d/next/Library/2024-05-10-22-36-01.gh-issue-118928.IW7Ukv.rst
+++ b/Misc/NEWS.d/next/Library/2024-05-10-22-36-01.gh-issue-118928.IW7Ukv.rst
@@ -1,0 +1,2 @@
+Disallow using a sequence of params with named placeholders in
+:mod:`sqlite3` queries. Patch by Erlend E. Aasland.

--- a/Modules/_sqlite/cursor.c
+++ b/Modules/_sqlite/cursor.c
@@ -673,7 +673,8 @@ bind_parameters(pysqlite_state *state, pysqlite_Statement *self,
                 PyErr_Format(state->ProgrammingError,
                         "Binding %d ('%s') is a named parameter, but you "
                         "supplied a sequence which requires nameless (qmark) "
-                        "placeholders.", i+1, name);
+                        "placeholders.",
+                        i+1, name);
             }
 
             if (PyTuple_CheckExact(parameters)) {

--- a/Modules/_sqlite/cursor.c
+++ b/Modules/_sqlite/cursor.c
@@ -670,15 +670,10 @@ bind_parameters(pysqlite_state *state, pysqlite_Statement *self,
         for (i = 0; i < num_params; i++) {
             const char *name = sqlite3_bind_parameter_name(self->st, i+1);
             if (name != NULL && name[0] != '?') {
-                int ret = PyErr_WarnFormat(PyExc_DeprecationWarning, 1,
+                PyErr_Format(state->ProgrammingError,
                         "Binding %d ('%s') is a named parameter, but you "
                         "supplied a sequence which requires nameless (qmark) "
-                        "placeholders. Starting with Python 3.14 an "
-                        "sqlite3.ProgrammingError will be raised.",
-                        i+1, name);
-                if (ret < 0) {
-                    return;
-                }
+                        "placeholders.", i+1, name);
             }
 
             if (PyTuple_CheckExact(parameters)) {


### PR DESCRIPTION
Follow-up of gh-101693.


<!-- gh-issue-number: gh-118928 -->
* Issue: gh-118928
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--118929.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->