### PR TITLE
gh-118877: Fix AssertionError crash in pyrepl

### DIFF
--- a/Lib/_pyrepl/commands.py
+++ b/Lib/_pyrepl/commands.py
@@ -34,9 +34,7 @@ import os
 
 # types
 if False:
-    from .reader import Reader
     from .historical_reader import HistoricalReader
-    from .console import Event
 
 
 class Command:

--- a/Lib/_pyrepl/commands.py
+++ b/Lib/_pyrepl/commands.py
@@ -245,7 +245,7 @@ class up(MotionCommand):
             x, y = r.pos2xy()
             new_y = y - 1
 
-            if new_y < 0:
+            if r.bol() == 0:
                 if r.historyi > 0:
                     r.select_item(r.historyi - 1)
                     return


### PR DESCRIPTION
A crash of the new pyrepl was triggered by pressing up arrow when tab completion menu was displayed. Fixes #118877

While this simple fix does the trick, as @lysnikolaou mentioned in a https://github.com/python/cpython/issues/118877#issuecomment-2104840020, there are other issues with how arrows interact with tab completions menu, so a more holistic fix might be needed eventually. 
I am hoping this is still useful to at least stop interpreter from crashing. Also the added test can serve is as a regression test.

(it took me quite a while to figure out how to write the test, suggestions how to improve it are welcome :pray: )

<!-- gh-issue-number: gh-118877 -->
* Issue: gh-118877
<!-- /gh-issue-number -->
