### PR TITLE
Docs: Fix SOURCE_URI

### DIFF
--- a/Doc/tools/extensions/pyspecific.py
+++ b/Doc/tools/extensions/pyspecific.py
@@ -33,7 +33,7 @@ from sphinx.util.display import status_iterator
 ISSUE_URI = 'https://bugs.python.org/issue?@action=redirect&bpo=%s'
 GH_ISSUE_URI = 'https://github.com/python/cpython/issues/%s'
 # Used in conf.py and updated here by python/release-tools/run_release.py
-SOURCE_URI = 'https://github.com/python/cpython/tree/3.13/%s'
+SOURCE_URI = 'https://github.com/python/cpython/tree/main/%s'
 
 # monkey-patch reST parser to disable alphabetic and roman enumerated lists
 from docutils.parsers.rst.states import Body


### PR DESCRIPTION
https://github.com/python/cpython/commit/2268289a47c6e3c9a220b53697f9480ec390466f modified the source uri to point to the 3.13 branch. This should be reverted to main for 3.14

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--118945.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->