### PR TITLE
gh-118932: ChainMap.__contains__ performance improvement

### DIFF
--- a/Lib/collections/__init__.py
+++ b/Lib/collections/__init__.py
@@ -1016,7 +1016,7 @@ class ChainMap(_collections_abc.MutableMapping):
         return self.__missing__(key)            # support subclasses that define __missing__
 
     def get(self, key, default=None):
-        return self[key] if key in self else default
+        return self[key] if key in self else default    # needs to make use of __contains__
 
     def __len__(self):
         return len(set().union(*self.maps))     # reuses stored hash values if possible
@@ -1028,7 +1028,10 @@ class ChainMap(_collections_abc.MutableMapping):
         return iter(d)
 
     def __contains__(self, key):
-        return any(key in m for m in self.maps)
+        for mapping in self.maps:
+            if key in mapping:
+                return True
+        return False
 
     def __bool__(self):
         return any(self.maps)


### PR DESCRIPTION
Minimal change.
* Improves `ChainMap.__contains__` performance significantly
* `ChainMap.get` also benefits from it

<!-- gh-issue-number: gh-118932 -->
* Issue: gh-118932
<!-- /gh-issue-number -->
