### PR TITLE
Docs: `shutil.rmtree`'s `onerror` has no pending removal version

### DIFF
--- a/Doc/whatsnew/3.13.rst
+++ b/Doc/whatsnew/3.13.rst
@@ -1631,9 +1631,6 @@ Pending Removal in Python 3.14
   * ``master_open()``: use :func:`pty.openpty`.
   * ``slave_open()``: use :func:`pty.openpty`.
 
-* :func:`shutil.rmtree` *onerror* parameter is deprecated in 3.12,
-  and will be removed in 3.14: use the *onexc* parameter instead.
-
 * :mod:`sqlite3`:
 
   * :data:`!version` and :data:`!version_info`.
@@ -1808,6 +1805,9 @@ although there is currently no date scheduled for their removal.
   (Contributed by Serhiy Storchaka in :gh:`91760`.)
 
 * :mod:`!sre_compile`, :mod:`!sre_constants` and :mod:`!sre_parse` modules.
+
+* :mod:`shutil`: :func:`~shutil.rmtree`'s *onerror* parameter is deprecated in
+  Python 3.12; use the *onexc* parameter instead.
 
 * :mod:`ssl` options and protocols:
 


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

It was deprecated in 3.12 and was originally planned to be removed in 3.14, but gh-112645 changed it to deprecation in docs only, with no pending removal version.

Let's move it from the "Pending Removal in Python 3.14" section to "Pending Removal in Future Versions".

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--118947.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->