### PR TITLE
GH-82805: Fix handling of single-dot file extensions in pathlib

### DIFF
--- a/Doc/library/pathlib.rst
+++ b/Doc/library/pathlib.rst
@@ -449,6 +449,10 @@ Pure paths provide the following methods and properties:
 
    This is commonly called the file extension.
 
+   .. versionchanged:: 3.14
+
+      A single dot ("``.``") is considered a valid suffix.
+
 .. attribute:: PurePath.suffixes
 
    A list of the path's suffixes, often called file extensions::
@@ -459,6 +463,10 @@ Pure paths provide the following methods and properties:
       ['.tar', '.gz']
       >>> PurePosixPath('my/library').suffixes
       []
+
+   .. versionchanged:: 3.14
+
+      A single dot ("``.``") is considered a valid suffix.
 
 
 .. attribute:: PurePath.stem
@@ -712,6 +720,11 @@ Pure paths provide the following methods and properties:
       >>> p = PureWindowsPath('README.txt')
       >>> p.with_suffix('')
       PureWindowsPath('README')
+
+   .. versionchanged:: 3.14
+
+      A single dot ("``.``") is considered a valid suffix. In previous
+      versions, :exc:`ValueError` is raised if a single dot is supplied.
 
 
 .. method:: PurePath.with_segments(*pathsegments)

--- a/Lib/pathlib/_abc.py
+++ b/Lib/pathlib/_abc.py
@@ -88,6 +88,12 @@ class ParserBase:
         drive. Either part may be empty."""
         raise UnsupportedOperation(self._unsupported_msg('splitdrive()'))
 
+    def splitext(self, path):
+        """Split the path into a pair (root, ext), where *ext* is empty or
+        begins with a begins with a period and contains at most one period,
+        and *root* is everything before the extension."""
+        raise UnsupportedOperation(self._unsupported_msg('splitext()'))
+
     def normcase(self, path):
         """Normalize the case of the path."""
         raise UnsupportedOperation(self._unsupported_msg('normcase()'))
@@ -171,12 +177,7 @@ class PurePathBase:
 
         This includes the leading period. For example: '.txt'
         """
-        name = self.name
-        i = name.rfind('.')
-        if 0 < i < len(name) - 1:
-            return name[i:]
-        else:
-            return ''
+        return self.parser.splitext(self.name)[1]
 
     @property
     def suffixes(self):
@@ -185,21 +186,18 @@ class PurePathBase:
 
         These include the leading periods. For example: ['.tar', '.gz']
         """
-        name = self.name
-        if name.endswith('.'):
-            return []
-        name = name.lstrip('.')
-        return ['.' + suffix for suffix in name.split('.')[1:]]
+        split = self.parser.splitext
+        stem, suffix = split(self.name)
+        suffixes = []
+        while suffix:
+            suffixes.append(suffix)
+            stem, suffix = split(stem)
+        return suffixes[::-1]
 
     @property
     def stem(self):
         """The final path component, minus its last suffix."""
-        name = self.name
-        i = name.rfind('.')
-        if 0 < i < len(name) - 1:
-            return name[:i]
-        else:
-            return name
+        return self.parser.splitext(self.name)[0]
 
     def with_name(self, name):
         """Return a new path with the file name changed."""
@@ -230,7 +228,7 @@ class PurePathBase:
         elif not stem:
             # If the stem is empty, we can't make the suffix non-empty.
             raise ValueError(f"{self!r} has an empty name")
-        elif suffix.startswith('.') and len(suffix) > 1:
+        elif suffix.startswith('.'):
             return self.with_name(stem + suffix)
         else:
             raise ValueError(f"Invalid suffix {suffix!r}")

--- a/Lib/pathlib/_local.py
+++ b/Lib/pathlib/_local.py
@@ -362,6 +362,39 @@ class PurePath(PurePathBase):
         tail[-1] = name
         return self._from_parsed_parts(self.drive, self.root, tail)
 
+    @property
+    def stem(self):
+        """The final path component, minus its last suffix."""
+        name = self.name
+        i = name.rfind('.')
+        if name[:i].strip('.'):
+            return name[:i]
+        else:
+            return name
+
+    @property
+    def suffix(self):
+        """
+        The final component's last suffix, if any.
+
+        This includes the leading period. For example: '.txt'
+        """
+        name = self.name
+        i = name.rfind('.')
+        if name[:i].strip('.'):
+            return name[i:]
+        else:
+            return ''
+
+    @property
+    def suffixes(self):
+        """
+        A list of the final component's suffixes, if any.
+
+        These include the leading periods. For example: ['.tar', '.gz']
+        """
+        return ['.' + ext for ext in self.name.lstrip('.').split('.')[1:]]
+
     def relative_to(self, other, *, walk_up=False):
         """Return the relative path to another path identified by the passed
         arguments.  If the operation is not possible (because this is not

--- a/Lib/pathlib/_local.py
+++ b/Lib/pathlib/_local.py
@@ -367,10 +367,11 @@ class PurePath(PurePathBase):
         """The final path component, minus its last suffix."""
         name = self.name
         i = name.rfind('.')
-        if name[:i].strip('.'):
-            return name[:i]
-        else:
-            return name
+        if i != -1:
+            stem = name[:i]
+            if stem.strip('.'):
+                return stem
+        return name
 
     @property
     def suffix(self):
@@ -379,12 +380,11 @@ class PurePath(PurePathBase):
 
         This includes the leading period. For example: '.txt'
         """
-        name = self.name
+        name = self.name.lstrip('.')
         i = name.rfind('.')
-        if name[:i].strip('.'):
+        if i != -1:
             return name[i:]
-        else:
-            return ''
+        return ''
 
     @property
     def suffixes(self):

--- a/Lib/pathlib/_local.py
+++ b/Lib/pathlib/_local.py
@@ -369,7 +369,8 @@ class PurePath(PurePathBase):
         i = name.rfind('.')
         if i != -1:
             stem = name[:i]
-            if stem.strip('.'):
+            # Stem must contain at least one non-dot character.
+            if stem.lstrip('.'):
                 return stem
         return name
 

--- a/Lib/test/test_pathlib/test_pathlib_abc.py
+++ b/Lib/test/test_pathlib/test_pathlib_abc.py
@@ -794,6 +794,8 @@ class DummyPurePathTest(unittest.TestCase):
         self.assertEqual(P('/a/trailing.dot.').suffix, '.')
         self.assertEqual(P('a/..d.o.t..').suffix, '.')
         self.assertEqual(P('a/inn.er..dots').suffix, '.dots')
+        self.assertEqual(P('photo').suffix, '')
+        self.assertEqual(P('photo.jpg').suffix, '.jpg')
 
     @needs_windows
     def test_suffix_windows(self):
@@ -835,6 +837,8 @@ class DummyPurePathTest(unittest.TestCase):
         self.assertEqual(P('/a/trailing.dot.').suffixes, ['.dot', '.'])
         self.assertEqual(P('a/..d.o.t..').suffixes, ['.o', '.t', '.', '.'])
         self.assertEqual(P('a/inn.er..dots').suffixes, ['.er', '.', '.dots'])
+        self.assertEqual(P('photo').suffixes, [])
+        self.assertEqual(P('photo.jpg').suffixes, ['.jpg'])
 
     @needs_windows
     def test_suffixes_windows(self):
@@ -873,6 +877,8 @@ class DummyPurePathTest(unittest.TestCase):
         self.assertEqual(P('a/trailing.dot.').stem, 'trailing.dot')
         self.assertEqual(P('a/..d.o.t..').stem, '..d.o.t.')
         self.assertEqual(P('a/inn.er..dots').stem, 'inn.er.')
+        self.assertEqual(P('photo').stem, 'photo')
+        self.assertEqual(P('photo.jpg').stem, 'photo')
 
     @needs_windows
     def test_stem_windows(self):
@@ -887,6 +893,7 @@ class DummyPurePathTest(unittest.TestCase):
         self.assertEqual(P('c:a/.hg.rc').stem, '.hg')
         self.assertEqual(P('c:a/b.tar.gz').stem, 'b.tar')
         self.assertEqual(P('c:a/trailing.dot.').stem, 'trailing.dot')
+
     def test_with_name_common(self):
         P = self.cls
         self.assertEqual(P('a/b').with_name('d.xml'), P('a/d.xml'))

--- a/Misc/NEWS.d/next/Library/2024-05-11-20-23-45.gh-issue-82805.F9bz4J.rst
+++ b/Misc/NEWS.d/next/Library/2024-05-11-20-23-45.gh-issue-82805.F9bz4J.rst
@@ -1,0 +1,5 @@
+Support single-dot file extensions in :attr:`pathlib.PurePath.suffix` and
+related attributes and methods. For example, the
+:attr:`~pathlib.PurePath.suffixes` of ``PurePath('foo.bar.')`` are now
+``['.bar', '.']`` rather than ``[]``. This brings file extension splitting
+in line with :func:`os.path.splitext`.


### PR DESCRIPTION
pathlib now treats "`.`" as a valid file extension (suffix). This brings it in line with `os.path.splitext()`.

In the (private) pathlib ABCs, we add a new `ParserBase.splitext()` method that splits a path into a `(root, ext)` pair, like `os.path.splitext()`. This method is called by `PurePathBase.stem`, `suffix`, etc. In a future version of pathlib, we might make these base classes public, and so users will be able to define their own `splitext()` method to control file extension splitting.

In `pathlib.PurePath` we add optimised `stem`, `suffix` and `suffixes` properties that don't use `splitext()`, which avoids computing the path base name twice.

<!-- gh-issue-number: gh-82805 -->
* Issue: gh-82805
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--118952.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->