### PR TITLE
gh-118954: Group `os.unlink` documentation

### DIFF
--- a/Doc/library/os.rst
+++ b/Doc/library/os.rst
@@ -2644,7 +2644,7 @@ features:
    to the file is not made available until the original file is no longer in use.
 
    .. audit-event:: os.remove path,dir_fd os.remove
-                    os.unlink path,dir_fd os.unlink
+                    os.remove path,dir_fd os.unlink
 
    .. versionchanged:: 3.3
       Added the *dir_fd* parameter.

--- a/Doc/library/os.rst
+++ b/Doc/library/os.rst
@@ -2630,6 +2630,7 @@ features:
       than the optional "print name" field that was previously returned.
 
 .. function:: remove(path, *, dir_fd=None)
+              unlink(path, *, dir_fd=None)
 
    Remove (delete) the file *path*.  If *path* is a directory, an
    :exc:`OSError` is raised.  Use :func:`rmdir` to remove directories.
@@ -2642,9 +2643,8 @@ features:
    be raised; on Unix, the directory entry is removed but the storage allocated
    to the file is not made available until the original file is no longer in use.
 
-   This function is semantically identical to :func:`unlink`.
-
    .. audit-event:: os.remove path,dir_fd os.remove
+                    os.unlink path,dir_fd os.unlink
 
    .. versionchanged:: 3.3
       Added the *dir_fd* parameter.
@@ -3496,22 +3496,6 @@ features:
 
    .. versionchanged:: 3.5
       Added support for Windows
-
-   .. versionchanged:: 3.6
-      Accepts a :term:`path-like object`.
-
-
-.. function:: unlink(path, *, dir_fd=None)
-
-   Remove (delete) the file *path*.  This function is semantically
-   identical to :func:`remove`; the ``unlink`` name is its
-   traditional Unix name.  Please see the documentation for
-   :func:`remove` for further information.
-
-   .. audit-event:: os.remove path,dir_fd os.unlink
-
-   .. versionchanged:: 3.3
-      Added the *dir_fd* parameter.
 
    .. versionchanged:: 3.6
       Accepts a :term:`path-like object`.

--- a/Doc/library/os.rst
+++ b/Doc/library/os.rst
@@ -2644,7 +2644,7 @@ features:
    to the file is not made available until the original file is no longer in use.
 
    .. audit-event:: os.remove path,dir_fd os.remove
-                    os.remove path,dir_fd os.unlink
+   .. audit-event:: os.remove path,dir_fd os.unlink
 
    .. versionchanged:: 3.3
       Added the *dir_fd* parameter.

--- a/Doc/library/os.rst
+++ b/Doc/library/os.rst
@@ -2644,7 +2644,6 @@ features:
    to the file is not made available until the original file is no longer in use.
 
    .. audit-event:: os.remove path,dir_fd os.remove
-   .. audit-event:: os.remove path,dir_fd os.unlink
 
    .. versionchanged:: 3.3
       Added the *dir_fd* parameter.


### PR DESCRIPTION
I'm not sure about `audit-event`, I might need to change that.

<!-- gh-issue-number: gh-118954 -->
* Issue: gh-118954
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--118955.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->