### PR TITLE
GH-118943: Fix a race condition when generating `jit_stencils.h`

### DIFF
--- a/Misc/NEWS.d/next/Build/2024-05-11-15-11-30.gh-issue-118943.VI_MnY.rst
+++ b/Misc/NEWS.d/next/Build/2024-05-11-15-11-30.gh-issue-118943.VI_MnY.rst
@@ -1,0 +1,3 @@
+Fix a possible race condition affecting parallel builds configured with
+``--enable-experimental-jit``, in which compilation errors could be caused
+by an incompletely-generated header file.

--- a/Tools/jit/_targets.py
+++ b/Tools/jit/_targets.py
@@ -217,12 +217,13 @@ class _Target(typing.Generic[_S, _R]):
             with jit_stencils_new.open("w") as file:
                 file.write(digest)
                 if comment:
-                    file.write(f"// {comment}\n\n")
+                    file.write(f"// {comment}\n")
+                file.write("\n")
                 for line in _writer.dump(stencil_groups):
                     file.write(f"{line}\n")
             jit_stencils_new.replace(jit_stencils)
         finally:
-            jit_stencils_new.unlink(True)
+            jit_stencils_new.unlink(missing_ok=True)
 
 
 class _COFF(

--- a/Tools/jit/_targets.py
+++ b/Tools/jit/_targets.py
@@ -180,18 +180,18 @@ class _Target(typing.Generic[_S, _R]):
         await _llvm.run("clang", args_o, echo=self.verbose)
         return await self._parse(o)
 
-    async def _build_stencils(
-        self, work: pathlib.Path
-    ) -> dict[str, _stencils.StencilGroup]:
+    async def _build_stencils(self) -> dict[str, _stencils.StencilGroup]:
         generated_cases = PYTHON_EXECUTOR_CASES_C_H.read_text()
         opnames = sorted(re.findall(r"\n {8}case (\w+): \{\n", generated_cases))
         tasks = []
-        async with asyncio.TaskGroup() as group:
-            coro = self._compile("trampoline", TOOLS_JIT / "trampoline.c", work)
-            tasks.append(group.create_task(coro, name="trampoline"))
-            for opname in opnames:
-                coro = self._compile(opname, TOOLS_JIT_TEMPLATE_C, work)
-                tasks.append(group.create_task(coro, name=opname))
+        with tempfile.TemporaryDirectory() as tempdir:
+            work = pathlib.Path(tempdir).resolve()
+            async with asyncio.TaskGroup() as group:
+                coro = self._compile("trampoline", TOOLS_JIT / "trampoline.c", work)
+                tasks.append(group.create_task(coro, name="trampoline"))
+                for opname in opnames:
+                    coro = self._compile(opname, TOOLS_JIT_TEMPLATE_C, work)
+                    tasks.append(group.create_task(coro, name=opname))
         return {task.get_name(): task.result() for task in tasks}
 
     def build(
@@ -211,18 +211,19 @@ class _Target(typing.Generic[_S, _R]):
             and jit_stencils.read_text().startswith(digest)
         ):
             return
-        with tempfile.TemporaryDirectory() as tempdir:
-            work = pathlib.Path(tempdir).resolve()
-            stencil_groups = asyncio.run(self._build_stencils(work))
-            new_jit_stencils = work / "jit_stencils.h"
-            with new_jit_stencils.open("w") as file:
+        stencil_groups = asyncio.run(self._build_stencils())
+        jit_stencils_new = out / "jit_stencils.h.new"
+        try:
+            with jit_stencils_new.open("w") as file:
                 file.write(digest)
                 if comment:
                     file.write(f"// {comment}\n\n")
                 file.write("")
                 for line in _writer.dump(stencil_groups):
                     file.write(f"{line}\n")
-            new_jit_stencils.replace(jit_stencils)
+            jit_stencils_new.replace(jit_stencils)
+        finally:
+            jit_stencils_new.unlink(True)
 
 
 class _COFF(

--- a/Tools/jit/_targets.py
+++ b/Tools/jit/_targets.py
@@ -218,7 +218,6 @@ class _Target(typing.Generic[_S, _R]):
                 file.write(digest)
                 if comment:
                     file.write(f"// {comment}\n\n")
-                file.write("")
                 for line in _writer.dump(stencil_groups):
                     file.write(f"{line}\n")
             jit_stencils_new.replace(jit_stencils)


### PR DESCRIPTION
Write to a temporary file first, then rename it to the intended `jit_stencils.h` file. This keeps other build steps from assuming that the file has been successfully generated when it's still in the process of being written.

CC: @savannahostrowski

<!-- gh-issue-number: gh-118943 -->
* Issue: gh-118943
<!-- /gh-issue-number -->
