### PR TITLE
Improve the `rmtree` doc for `dir_fd` param addition in 3.11

### DIFF
--- a/Doc/library/shutil.rst
+++ b/Doc/library/shutil.rst
@@ -338,7 +338,7 @@ Directory and files operations
       before removing the junction.
 
    .. versionchanged:: 3.11
-      The *dir_fd* parameter.
+      Added the *dir_fd* parameter.
 
    .. versionchanged:: 3.12
       Added the *onexc* parameter, deprecated *onerror*.


### PR DESCRIPTION


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--118964.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->