### PR TITLE
gh-110383: Fix problems in Python Input and Output tutorial

### DIFF
--- a/Doc/tutorial/inputoutput.rst
+++ b/Doc/tutorial/inputoutput.rst
@@ -44,6 +44,8 @@ printing space-separated values. There are several ways to format output.
      >>> yes_votes = 42_572_654
      >>> no_votes = 43_132_495
      >>> percentage = yes_votes / (yes_votes + no_votes)
+     >>> # Print yes_votes padded with spaces and a negative sign only for negative numbers
+     >>> # Also print percentage multiplied by 100, with 2 decimal places and followed by a percent sign:
      >>> '{:-9} YES votes  {:2.2%}'.format(yes_votes, percentage)
      ' 42572654 YES votes  49.67%'
 

--- a/Doc/tutorial/inputoutput.rst
+++ b/Doc/tutorial/inputoutput.rst
@@ -199,7 +199,12 @@ notation. ::
    Jack: 4098; Sjoerd: 4127; Dcab: 8637678
 
 This is particularly useful in combination with the built-in function
-:func:`vars`, which returns a dictionary containing all local variables.
+:func:`vars`, which returns a dictionary containing all local variables. ::
+
+   >>> table = {k: str(v) for k, v in vars().items()}
+   >>> message = " ".join([f'{k}: ' + '{' + k +'};' for k in table.keys()])
+   >>> print(message.format(**table))
+   __name__: __main__; __doc__: None; __package__: None; __loader__: <class '_frozen_importlib.BuiltinImporter'>; __spec__: None; __annotations__: {}; __builtins__: <module 'builtins' (built-in)>;
 
 As an example, the following lines produce a tidily aligned
 set of columns giving integers and their squares and cubes::


### PR DESCRIPTION
Fix problems in the Python Input and Output tutorial from task listed at #110383, problems were reported by [Todd Hoatson](https://mail.python.org/archives/list/docs@python.org/message/REO4QRDIHU5ML4BMNXPDONCKONIH6RN3/).

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-110383 -->
* Issue: gh-110383
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--118970.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->