### PR TITLE
gh-118986: expose socket.IPV6_RECVERR

### DIFF
--- a/Doc/library/socket.rst
+++ b/Doc/library/socket.rst
@@ -451,8 +451,8 @@ Constants
       network interface instead of its name.
 
    .. versionchanged:: 3.14
-      Added missing ``IP_RECVERR``, ``IP_RECVTTL``, and ``IP_RECVORIGDSTADDR``
-      on Linux.
+      Added missing ``IP_RECVERR``, ``IPV6_RECVERR``, ``IP_RECVTTL``, and
+      ``IP_RECVORIGDSTADDR`` on Linux.
 
 .. data:: AF_CAN
           PF_CAN

--- a/Misc/NEWS.d/next/Library/2024-05-13-10-09-41.gh-issue-118986.-r4W9h.rst
+++ b/Misc/NEWS.d/next/Library/2024-05-13-10-09-41.gh-issue-118986.-r4W9h.rst
@@ -1,0 +1,1 @@
+Add :data:`!socket.IPV6_RECVERR` constant (available since Linux 2.2).

--- a/Modules/socketmodule.c
+++ b/Modules/socketmodule.c
@@ -8533,6 +8533,9 @@ socket_exec(PyObject *m)
 #ifdef IPV6_RECVDSTOPTS
     ADD_INT_MACRO(m, IPV6_RECVDSTOPTS);
 #endif
+#ifdef IPV6_RECVERR
+    ADD_INT_MACRO(m, IPV6_RECVERR);
+#endif
 #ifdef IPV6_RECVHOPLIMIT
     ADD_INT_MACRO(m, IPV6_RECVHOPLIMIT);
 #endif


### PR DESCRIPTION
This adds two socket option numbers, without which the existing `MSG_ERRQUEUE` gives barely any benefits.

<!-- gh-issue-number: gh-118986 -->
* Issue: gh-118986
<!-- /gh-issue-number -->
