### PR TITLE
gh-118836: Fix JIT build error when SHT_NOTE section is present

### DIFF
--- a/Misc/NEWS.d/next/Build/2024-05-13-15-57-58.gh-issue-118836.7yN1iB.rst
+++ b/Misc/NEWS.d/next/Build/2024-05-13-15-57-58.gh-issue-118836.7yN1iB.rst
@@ -1,0 +1,2 @@
+Fix an ``AssertionError`` when building with ``--enable-experimental-jit``
+and the compiler emits a ``SHT_NOTE`` section.

--- a/Tools/jit/_targets.py
+++ b/Tools/jit/_targets.py
@@ -349,6 +349,7 @@ class _ELF(
             assert section_type in {
                 "SHT_GROUP",
                 "SHT_LLVM_ADDRSIG",
+                "SHT_NOTE",
                 "SHT_NULL",
                 "SHT_STRTAB",
                 "SHT_SYMTAB",


### PR DESCRIPTION
Fix an ``AssertionError`` when building with ``--enable-experimental-jit`` and the compiler emits a ``SHT_NOTE`` section.


<!-- gh-issue-number: gh-118836 -->
* Issue: gh-118836
<!-- /gh-issue-number -->
