### PR TITLE
[3.12] gh-118997: Fix _Py_ClearImmortal() assertion

### DIFF
--- a/Include/internal/pycore_object.h
+++ b/Include/internal/pycore_object.h
@@ -80,7 +80,7 @@ static inline void _Py_SetImmortal(PyObject *op)
 static inline void _Py_ClearImmortal(PyObject *op)
 {
     if (op) {
-        assert(op->ob_refcnt == _Py_IMMORTAL_REFCNT);
+        assert(_Py_IsImmortal(op));
         op->ob_refcnt = 1;
         Py_DECREF(op);
     }

--- a/Misc/NEWS.d/next/Core and Builtins/2024-05-13-16-00-05.gh-issue-118997.GWqWdt.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2024-05-13-16-00-05.gh-issue-118997.GWqWdt.rst
@@ -1,0 +1,4 @@
+Fix _Py_ClearImmortal() assertion: use _Py_IsImmortal() to tolerate
+reference count lower than _Py_IMMORTAL_REFCNT. Fix the assertion for the
+stable ABI, when a C extension is built with Python 3.11 or lower. Patch by
+Victor Stinner.


### PR DESCRIPTION
Fix _Py_ClearImmortal() assertion: use _Py_IsImmortal() to tolerate reference count lower than _Py_IMMORTAL_REFCNT. Fix the assertion for the stable ABI, when a C extension is built with Python 3.11 or lower.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-118997 -->
* Issue: gh-118997
<!-- /gh-issue-number -->
