### PR TITLE
gh-119010: Adds docs about `__type_params__` to `functools.update_wrapper`

### DIFF
--- a/Doc/library/functools.rst
+++ b/Doc/library/functools.rst
@@ -646,8 +646,9 @@ The :mod:`functools` module defines the following functions:
    attributes of the wrapper function are updated with the corresponding attributes
    from the original function. The default values for these arguments are the
    module level constants ``WRAPPER_ASSIGNMENTS`` (which assigns to the wrapper
-   function's ``__module__``, ``__name__``, ``__qualname__``, ``__annotations__``
-   and ``__doc__``, the documentation string) and ``WRAPPER_UPDATES`` (which
+   function's ``__module__``, ``__name__``, ``__qualname__``, ``__annotations__``,
+   ``__doc__``, and ``__type_params__``, the documentation string)
+   and ``WRAPPER_UPDATES`` (which
    updates the wrapper function's ``__dict__``, i.e. the instance dictionary).
 
    To allow access to the original function for introspection and other purposes
@@ -676,6 +677,9 @@ The :mod:`functools` module defines the following functions:
       The ``__wrapped__`` attribute now always refers to the wrapped
       function, even if that function defined a ``__wrapped__`` attribute.
       (see :issue:`17482`)
+
+   .. versionchanged:: 3.12
+      The ``__type_params__`` attribute is now copied by default.
 
 
 .. decorator:: wraps(wrapped, assigned=WRAPPER_ASSIGNMENTS, updated=WRAPPER_UPDATES)

--- a/Doc/library/functools.rst
+++ b/Doc/library/functools.rst
@@ -647,7 +647,7 @@ The :mod:`functools` module defines the following functions:
    from the original function. The default values for these arguments are the
    module level constants ``WRAPPER_ASSIGNMENTS`` (which assigns to the wrapper
    function's ``__module__``, ``__name__``, ``__qualname__``, ``__annotations__``,
-   ``__doc__``, and ``__type_params__``, the documentation string)
+   ``__type_params__``, and ``__doc__``, the documentation string)
    and ``WRAPPER_UPDATES`` (which
    updates the wrapper function's ``__dict__``, i.e. the instance dictionary).
 


### PR DESCRIPTION


<!-- gh-issue-number: gh-119010 -->
* Issue: gh-119010
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--119012.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->