### PR TITLE
remove reference to removed zipimporter._files attribute in module docstring

### DIFF
--- a/Lib/zipimport.py
+++ b/Lib/zipimport.py
@@ -5,7 +5,7 @@ This module exports three objects:
 - ZipImportError: exception raised by zipimporter objects. It's a
   subclass of ImportError, so it can be caught as ImportError, too.
 - _zip_directory_cache: a dict, mapping archive paths to zip directory
-  info dicts, as used in zipimporter._files.
+  info dicts, as used in zipimporter.
 
 It is usually not needed to use the zipimport module explicitly; it is
 used by the builtin import mechanism for sys.path items that are paths

--- a/Lib/zipimport.py
+++ b/Lib/zipimport.py
@@ -1,11 +1,9 @@
 """zipimport provides support for importing Python modules from Zip archives.
 
-This module exports three objects:
+This module exports two objects:
 - zipimporter: a class; its constructor takes a path to a Zip archive.
 - ZipImportError: exception raised by zipimporter objects. It's a
   subclass of ImportError, so it can be caught as ImportError, too.
-- _zip_directory_cache: a dict, mapping archive paths to zip directory
-  info dicts, as used in zipimporter.
 
 It is usually not needed to use the zipimport module explicitly; it is
 used by the builtin import mechanism for sys.path items that are paths


### PR DESCRIPTION
attribute removed in 3.13 here https://github.com/python/cpython/commit/1fb9bd222bfe96cdf8a82701a3192e45d0811555

I thought it best to remove reference to the attribute rather than update it to _get_files()

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
