### PR TITLE
Docs: Add central references to free-threading-related options

### DIFF
--- a/Doc/c-api/module.rst
+++ b/Doc/c-api/module.rst
@@ -427,14 +427,14 @@ The available slot types are:
    This slot is ignored by Python builds not configured with
    :option:`--disable-gil`.  Otherwise, it determines whether or not importing
    this module will cause the GIL to be automatically enabled. See
-   :envvar:`PYTHON_GIL` and :option:`-X gil <-X>` for more detail.
+   :ref:`free-threaded-cpython` for more detail.
 
    Multiple ``Py_mod_gil`` slots may not be specified in one module definition.
 
    If ``Py_mod_gil`` is not specified, the import machinery defaults to
    ``Py_MOD_GIL_USED``.
 
-   .. versionadded: 3.13
+   .. versionadded:: 3.13
 
 See :PEP:`489` for more details on multi-phase initialization.
 

--- a/Doc/using/cmdline.rst
+++ b/Doc/using/cmdline.rst
@@ -616,7 +616,8 @@ Miscellaneous options
 
    * :samp:`-X gil={0,1}` forces the GIL to be disabled or enabled,
      respectively. Only available in builds configured with
-     :option:`--disable-gil`. See also :envvar:`PYTHON_GIL`.
+     :option:`--disable-gil`. See also :envvar:`PYTHON_GIL` and
+     :ref:`free-threaded-cpython`.
 
      .. versionadded:: 3.13
 
@@ -1206,7 +1207,7 @@ conflict.
    forced on. Setting it to ``0`` forces the GIL off.
 
    See also the :option:`-X gil <-X>` command-line option, which takes
-   precedence over this variable.
+   precedence over this variable, and :ref:`free-threaded-cpython`.
 
    Needs Python configured with the :option:`--disable-gil` build option.
 

--- a/Doc/using/configure.rst
+++ b/Doc/using/configure.rst
@@ -299,7 +299,8 @@ General Options
    Defines the ``Py_GIL_DISABLED`` macro and adds ``"t"`` to
    :data:`sys.abiflags`.
 
-   See :pep:`703` "Making the Global Interpreter Lock Optional in CPython".
+   See :pep:`703` "Making the Global Interpreter Lock Optional in CPython" and
+   :ref:`free-threaded-cpython`.
 
    .. versionadded:: 3.13
 

--- a/Doc/using/configure.rst
+++ b/Doc/using/configure.rst
@@ -299,8 +299,7 @@ General Options
    Defines the ``Py_GIL_DISABLED`` macro and adds ``"t"`` to
    :data:`sys.abiflags`.
 
-   See :pep:`703` "Making the Global Interpreter Lock Optional in CPython" and
-   :ref:`free-threaded-cpython`.
+   See :ref:`free-threaded-cpython` for more detail.
 
    .. versionadded:: 3.13
 

--- a/Doc/whatsnew/3.13.rst
+++ b/Doc/whatsnew/3.13.rst
@@ -368,7 +368,8 @@ CPython will run with the :term:`global interpreter lock` (GIL) disabled when
 configured using the ``--disable-gil`` option at build time. This is an
 experimental feature and therefore isn't used by default. Users need to
 either compile their own interpreter, or install one of the experimental
-builds that are marked as *free-threaded*.
+builds that are marked as *free-threaded*. See :pep:`703` "Making the Global
+Interpreter Lock Optional in CPython" for more detail.
 
 Free-threaded execution allows for full utilization of the available
 processing power by running threads in parallel on available CPU cores.


### PR DESCRIPTION
The docs for `Py_mod_gil` said "See `PYTHON_GIL` and `-X gil <-X>` for more detail," but neither of those gave any detail about loading extensions in a free-threaded build.
- Replace that sentence with a reference to the summary in the 3.13 what's new doc.
- Add a few more links to that summary in other related areas.
- Fix a syntax error in the `versionadded::` line for `Py_mod_gil` that was causing it to not get rendered.

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--119017.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->