### PR TITLE
Use literal syntax in origin property

### DIFF
--- a/Doc/library/importlib.metadata.rst
+++ b/Doc/library/importlib.metadata.rst
@@ -343,7 +343,7 @@ instance::
     >>> dist.metadata['License']  # doctest: +SKIP
     'MIT'
 
-For editable packages, an origin property may present :pep:`610`
+For editable packages, an ``origin`` property may present :pep:`610`
 metadata::
 
     >>> dist.origin.url


### PR DESCRIPTION
Without this syntax markup, a translator translating library/importlib.metadata.rst could think that "origin" should be translated when the context shows it is a property name for Distribution class.

The context is:

> For editable packages, an origin property may present PEP 610 metadata:
>
> \>>> dist.origin.url
> 'file:///path/to/wheel-0.32.3.editable-py3-none-any.whl'


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--119029.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->