### PR TITLE
gh-119049: Fix incorrect usage of ``GET_WARNINGS_ATTR``

### DIFF
--- a/Lib/test/test_capi/test_exceptions.py
+++ b/Lib/test/test_capi/test_exceptions.py
@@ -91,6 +91,23 @@ class Test_Exceptions(unittest.TestCase):
             warnings[3].startswith(b"  foo()  # line 9")
         )
 
+    def test_warn_during_finalization(self):
+        code = textwrap.dedent('''\
+            import _testcapi
+
+            class Foo:
+                def __del__(self):
+                    _testcapi.function_set_warning()
+
+            ref = Foo()
+        ''')
+        proc = assert_python_ok("-c", code)
+        warnings = proc.err.splitlines()
+        # Due to the finalization of the interpreter, the source will be ommited
+        # because the ``warnings`` module cannot be imported at this time
+        self.assertEqual(len(warnings), 1)
+        self.assertEqual(warnings[0], b'<sys>:0: RuntimeWarning: Testing PyErr_WarnEx')
+
 
 class Test_FatalError(unittest.TestCase):
 

--- a/Lib/test/test_capi/test_exceptions.py
+++ b/Lib/test/test_capi/test_exceptions.py
@@ -106,7 +106,9 @@ class Test_Exceptions(unittest.TestCase):
         warnings = proc.err.splitlines()
         # Due to the finalization of the interpreter, the source will be ommited
         # because the ``warnings`` module cannot be imported at this time
-        self.assertEqual(warnings, [b'<string>:7: RuntimeWarning: Testing PyErr_WarnEx'])
+        self.assertEqual(warnings, [
+            b'<string>:7: RuntimeWarning: Testing PyErr_WarnEx',
+        ])
 
 
 class Test_FatalError(unittest.TestCase):

--- a/Lib/test/test_capi/test_exceptions.py
+++ b/Lib/test/test_capi/test_exceptions.py
@@ -74,7 +74,7 @@ class Test_Exceptions(unittest.TestCase):
             import _testcapi
 
             def foo():
-                _testcapi.test_warn()
+                _testcapi.function_set_warning()
 
             foo()  # line 6
 

--- a/Lib/test/test_capi/test_exceptions.py
+++ b/Lib/test/test_capi/test_exceptions.py
@@ -83,13 +83,14 @@ class Test_Exceptions(unittest.TestCase):
         ''')
         proc = assert_python_ok("-c", code)
         warnings = proc.err.splitlines()
+        expected = [
+            b'<string>:6: RuntimeWarning: Testing PyErr_WarnEx',
+            b'  foo()  # line 6',
+            b'<string>:9: RuntimeWarning: Testing PyErr_WarnEx',
+            b'  foo()  # line 9'
+        ]
         self.assertEqual(len(warnings), 4)
-        self.assertTrue(
-            warnings[1].startswith(b"  foo()  # line 6")
-        )
-        self.assertTrue(
-            warnings[3].startswith(b"  foo()  # line 9")
-        )
+        self.assertEqual(warnings, expected)
 
     def test_warn_during_finalization(self):
         code = textwrap.dedent('''\

--- a/Lib/test/test_capi/test_exceptions.py
+++ b/Lib/test/test_capi/test_exceptions.py
@@ -95,8 +95,10 @@ class Test_Exceptions(unittest.TestCase):
             import _testcapi
 
             class Foo:
-                def __del__(self):
+                def foo(self):
                     _testcapi.function_set_warning()
+                def __del__(self):
+                    self.foo()
 
             ref = Foo()
         ''')
@@ -104,8 +106,7 @@ class Test_Exceptions(unittest.TestCase):
         warnings = proc.err.splitlines()
         # Due to the finalization of the interpreter, the source will be ommited
         # because the ``warnings`` module cannot be imported at this time
-        self.assertEqual(len(warnings), 1)
-        self.assertEqual(warnings[0], b'<sys>:0: RuntimeWarning: Testing PyErr_WarnEx')
+        self.assertEqual(warnings, [b'<string>:7: RuntimeWarning: Testing PyErr_WarnEx'])
 
 
 class Test_FatalError(unittest.TestCase):

--- a/Lib/test/test_capi/test_exceptions.py
+++ b/Lib/test/test_capi/test_exceptions.py
@@ -83,14 +83,12 @@ class Test_Exceptions(unittest.TestCase):
         ''')
         proc = assert_python_ok("-c", code)
         warnings = proc.err.splitlines()
-        expected = [
+        self.assertEqual(warnings, [
             b'<string>:6: RuntimeWarning: Testing PyErr_WarnEx',
             b'  foo()  # line 6',
             b'<string>:9: RuntimeWarning: Testing PyErr_WarnEx',
-            b'  foo()  # line 9'
-        ]
-        self.assertEqual(len(warnings), 4)
-        self.assertEqual(warnings, expected)
+            b'  foo()  # line 9',
+        ])
 
     def test_warn_during_finalization(self):
         code = textwrap.dedent('''\

--- a/Misc/NEWS.d/next/Core and Builtins/2024-05-16-23-02-03.gh-issue-119049.qpd_S-.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2024-05-16-23-02-03.gh-issue-119049.qpd_S-.rst
@@ -1,0 +1,2 @@
+Fix displaying the source line for warnings created by the C API if the
+:mod:`warnings` module had not yet been imported.

--- a/Modules/_testcapimodule.c
+++ b/Modules/_testcapimodule.c
@@ -3303,6 +3303,15 @@ failed:
     return NULL;
 }
 
+static PyObject *
+test_warn(PyObject *Py_UNUSED(module), PyObject *Py_UNUSED(args))
+{
+    if (PyErr_WarnEx(PyExc_RuntimeWarning, "Testing PyErr_WarnEx", 2)) {
+        return NULL;
+    }
+    Py_RETURN_NONE;
+}
+
 static PyMethodDef TestMethods[] = {
     {"set_errno",               set_errno,                       METH_VARARGS},
     {"test_config",             test_config,                     METH_NOARGS},
@@ -3444,6 +3453,7 @@ static PyMethodDef TestMethods[] = {
     {"function_set_closure", function_set_closure, METH_VARARGS, NULL},
     {"check_pyimport_addmodule", check_pyimport_addmodule, METH_VARARGS},
     {"test_weakref_capi", test_weakref_capi, METH_NOARGS},
+    {"test_warn", test_warn, METH_NOARGS},
     {NULL, NULL} /* sentinel */
 };
 

--- a/Modules/_testcapimodule.c
+++ b/Modules/_testcapimodule.c
@@ -3304,7 +3304,7 @@ failed:
 }
 
 static PyObject *
-test_warn(PyObject *Py_UNUSED(module), PyObject *Py_UNUSED(args))
+function_set_warning(PyObject *Py_UNUSED(module), PyObject *Py_UNUSED(args))
 {
     if (PyErr_WarnEx(PyExc_RuntimeWarning, "Testing PyErr_WarnEx", 2)) {
         return NULL;
@@ -3453,7 +3453,7 @@ static PyMethodDef TestMethods[] = {
     {"function_set_closure", function_set_closure, METH_VARARGS, NULL},
     {"check_pyimport_addmodule", check_pyimport_addmodule, METH_VARARGS},
     {"test_weakref_capi", test_weakref_capi, METH_NOARGS},
-    {"test_warn", test_warn, METH_NOARGS},
+    {"function_set_warning", function_set_warning, METH_NOARGS},
     {NULL, NULL} /* sentinel */
 };
 

--- a/Python/_warnings.c
+++ b/Python/_warnings.c
@@ -569,10 +569,9 @@ call_show_warning(PyThreadState *tstate, PyObject *category,
     PyObject *show_fn, *msg, *res, *warnmsg_cls = NULL;
     PyInterpreterState *interp = tstate->interp;
 
-    /* If the source parameter is set, try to get the Python implementation.
-       The Python implementation is able to log the traceback where the source
+    /* The Python implementation is able to log the traceback where the source
        was allocated, whereas the C implementation doesn't. */
-    show_fn = GET_WARNINGS_ATTR(interp, _showwarnmsg, source != NULL);
+    show_fn = GET_WARNINGS_ATTR(interp, _showwarnmsg, 1);
     if (show_fn == NULL) {
         if (PyErr_Occurred())
             return -1;


### PR DESCRIPTION
``GET_WARNINGS_ATTR`` is trying to get the ``ATTR`` attribute of the Python ``warnings`` module. If the third parameter is true, it tries to import the ``warnings`` module if it hasn't been imported already.
All of the calls to ``call_show_warning`` are made with the  ``source = NULL`` argument, so this statement ``show_fn = GET_WARNINGS_ATTR(interp, _showwarnmsg, source != NULL);`` always becomes ``show_fn = GET_WARNINGS_ATTR(interp, _showwarnmsg, 0);``.
So it never triess to import the ``warnings`` module if it has not already imported, which leads us to the issue described in the #119049. 
This is why ``test_io.test_check_encoding_warning`` works when ``import warnings`` is used in ``pathlib._local.py`` and fails when we remove this statement.


<!-- gh-issue-number: gh-119049 -->
* Issue: gh-119049
<!-- /gh-issue-number -->
