### PR TITLE
gh-119057: Use better error messages for zero division

### DIFF
--- a/Doc/howto/logging-cookbook.rst
+++ b/Doc/howto/logging-cookbook.rst
@@ -2950,7 +2950,7 @@ When run, this produces a file with exactly two lines:
 .. code-block:: none
 
     28/01/2015 07:21:23|INFO|Sample message|
-    28/01/2015 07:21:23|ERROR|ZeroDivisionError: integer division or modulo by zero|'Traceback (most recent call last):\n  File "logtest7.py", line 30, in main\n    x = 1 / 0\nZeroDivisionError: integer division or modulo by zero'|
+    28/01/2015 07:21:23|ERROR|ZeroDivisionError: integer division by zero|'Traceback (most recent call last):\n  File "logtest7.py", line 30, in main\n    x = 1 / 0\nZeroDivisionError: integer division by zero'|
 
 While the above treatment is simplistic, it points the way to how exception
 information can be formatted to your liking. The :mod:`traceback` module may be

--- a/Doc/howto/logging-cookbook.rst
+++ b/Doc/howto/logging-cookbook.rst
@@ -2950,7 +2950,7 @@ When run, this produces a file with exactly two lines:
 .. code-block:: none
 
     28/01/2015 07:21:23|INFO|Sample message|
-    28/01/2015 07:21:23|ERROR|ZeroDivisionError: integer division by zero|'Traceback (most recent call last):\n  File "logtest7.py", line 30, in main\n    x = 1 / 0\nZeroDivisionError: integer division by zero'|
+    28/01/2015 07:21:23|ERROR|ZeroDivisionError: division by zero|'Traceback (most recent call last):\n  File "logtest7.py", line 30, in main\n    x = 1 / 0\nZeroDivisionError: division by zero'|
 
 While the above treatment is simplistic, it points the way to how exception
 information can be formatted to your liking. The :mod:`traceback` module may be

--- a/Lib/_pylong.py
+++ b/Lib/_pylong.py
@@ -352,7 +352,7 @@ def int_divmod(a, b):
     Its time complexity is O(n**1.58), where n = #bits(a) + #bits(b).
     """
     if b == 0:
-        raise ZeroDivisionError
+        raise ZeroDivisionError('division by zero')
     elif b < 0:
         q, r = int_divmod(-a, -b)
         return q, -r

--- a/Lib/test/mathdata/ieee754.txt
+++ b/Lib/test/mathdata/ieee754.txt
@@ -116,7 +116,7 @@ inf
 >>> 0 ** -1
 Traceback (most recent call last):
 ...
-ZeroDivisionError: 0.0 cannot be raised to a negative power
+ZeroDivisionError: zero to a negative power
 >>> pow(0, NAN)
 nan
 

--- a/Lib/test/test_builtin.py
+++ b/Lib/test/test_builtin.py
@@ -662,6 +662,11 @@ class BuiltinTest(unittest.TestCase):
             self.assertAlmostEqual(result[1], exp_result[1])
 
         self.assertRaises(TypeError, divmod)
+        self.assertRaisesRegex(
+            ZeroDivisionError,
+            "integer division or modulo by zero",
+            divmod, 1, 0,
+        )
 
     def test_eval(self):
         self.assertEqual(eval('1+1'), 2)

--- a/Lib/test/test_builtin.py
+++ b/Lib/test/test_builtin.py
@@ -664,8 +664,13 @@ class BuiltinTest(unittest.TestCase):
         self.assertRaises(TypeError, divmod)
         self.assertRaisesRegex(
             ZeroDivisionError,
-            "integer division or modulo by zero",
+            "division by zero",
             divmod, 1, 0,
+        )
+        self.assertRaisesRegex(
+            ZeroDivisionError,
+            "division by zero",
+            divmod, 0.0, 0,
         )
 
     def test_eval(self):

--- a/Lib/test/test_doctest/test_doctest.py
+++ b/Lib/test/test_doctest/test_doctest.py
@@ -1035,7 +1035,7 @@ replaced with any other string:
     ...     >>> x = 12
     ...     >>> print(x//0)
     ...     Traceback (most recent call last):
-    ...     ZeroDivisionError: integer floor division by zero
+    ...     ZeroDivisionError: division by zero
     ...     '''
     >>> test = doctest.DocTestFinder().find(f)[0]
     >>> doctest.DocTestRunner(verbose=False).run(test)
@@ -1052,7 +1052,7 @@ unexpected exception:
     ...     >>> print('pre-exception output', x//0)
     ...     pre-exception output
     ...     Traceback (most recent call last):
-    ...     ZeroDivisionError: integer floor division by zero
+    ...     ZeroDivisionError: division by zero
     ...     '''
     >>> test = doctest.DocTestFinder().find(f)[0]
     >>> doctest.DocTestRunner(verbose=False).run(test)
@@ -1063,7 +1063,7 @@ unexpected exception:
         print('pre-exception output', x//0)
     Exception raised:
         ...
-        ZeroDivisionError: integer floor division by zero
+        ZeroDivisionError: division by zero
     TestResults(failed=1, attempted=2)
 
 Exception messages may contain newlines:
@@ -1258,7 +1258,7 @@ unexpected exception:
     Exception raised:
         Traceback (most recent call last):
         ...
-        ZeroDivisionError: integer floor division by zero
+        ZeroDivisionError: division by zero
     TestResults(failed=1, attempted=1)
 
     >>> _colorize.COLORIZE = save_colorize

--- a/Lib/test/test_doctest/test_doctest.py
+++ b/Lib/test/test_doctest/test_doctest.py
@@ -1035,7 +1035,7 @@ replaced with any other string:
     ...     >>> x = 12
     ...     >>> print(x//0)
     ...     Traceback (most recent call last):
-    ...     ZeroDivisionError: integer division or modulo by zero
+    ...     ZeroDivisionError: integer floor division by zero
     ...     '''
     >>> test = doctest.DocTestFinder().find(f)[0]
     >>> doctest.DocTestRunner(verbose=False).run(test)
@@ -1052,7 +1052,7 @@ unexpected exception:
     ...     >>> print('pre-exception output', x//0)
     ...     pre-exception output
     ...     Traceback (most recent call last):
-    ...     ZeroDivisionError: integer division or modulo by zero
+    ...     ZeroDivisionError: integer floor division by zero
     ...     '''
     >>> test = doctest.DocTestFinder().find(f)[0]
     >>> doctest.DocTestRunner(verbose=False).run(test)
@@ -1063,7 +1063,7 @@ unexpected exception:
         print('pre-exception output', x//0)
     Exception raised:
         ...
-        ZeroDivisionError: integer division or modulo by zero
+        ZeroDivisionError: integer floor division by zero
     TestResults(failed=1, attempted=2)
 
 Exception messages may contain newlines:
@@ -1258,7 +1258,7 @@ unexpected exception:
     Exception raised:
         Traceback (most recent call last):
         ...
-        ZeroDivisionError: integer division or modulo by zero
+        ZeroDivisionError: integer floor division by zero
     TestResults(failed=1, attempted=1)
 
     >>> _colorize.COLORIZE = save_colorize

--- a/Lib/test/test_generators.py
+++ b/Lib/test/test_generators.py
@@ -907,7 +907,7 @@ Specification: Generators and Exception Propagation
       File "<stdin>", line 1, in ?
       File "<stdin>", line 2, in g
       File "<stdin>", line 2, in f
-    ZeroDivisionError: integer floor division by zero
+    ZeroDivisionError: division by zero
     >>> next(k)  # and the generator cannot be resumed
     Traceback (most recent call last):
       File "<stdin>", line 1, in ?

--- a/Lib/test/test_generators.py
+++ b/Lib/test/test_generators.py
@@ -907,7 +907,7 @@ Specification: Generators and Exception Propagation
       File "<stdin>", line 1, in ?
       File "<stdin>", line 2, in g
       File "<stdin>", line 2, in f
-    ZeroDivisionError: integer division or modulo by zero
+    ZeroDivisionError: integer floor division by zero
     >>> next(k)  # and the generator cannot be resumed
     Traceback (most recent call last):
       File "<stdin>", line 1, in ?

--- a/Lib/test/test_genexps.py
+++ b/Lib/test/test_genexps.py
@@ -223,7 +223,7 @@ Verify exception propagation
         next(g)
       File "<pyshell#35>", line 1, in <generator expression>
         g = (10 // i for i in (5, 0, 2))
-    ZeroDivisionError: integer division or modulo by zero
+    ZeroDivisionError: integer floor division by zero
     >>> next(g)
     Traceback (most recent call last):
       File "<pyshell#38>", line 1, in -toplevel-

--- a/Lib/test/test_genexps.py
+++ b/Lib/test/test_genexps.py
@@ -223,7 +223,7 @@ Verify exception propagation
         next(g)
       File "<pyshell#35>", line 1, in <generator expression>
         g = (10 // i for i in (5, 0, 2))
-    ZeroDivisionError: integer floor division by zero
+    ZeroDivisionError: division by zero
     >>> next(g)
     Traceback (most recent call last):
       File "<pyshell#38>", line 1, in -toplevel-

--- a/Misc/NEWS.d/next/Core and Builtins/2024-05-15-12-15-58.gh-issue-119057.P3G9G2.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2024-05-15-12-15-58.gh-issue-119057.P3G9G2.rst
@@ -1,0 +1,2 @@
+Improve error message when using ``// 0`` from "integer division or modulo
+by zero" to "integer floor division by zero" which better represents the division.

--- a/Misc/NEWS.d/next/Core and Builtins/2024-05-15-12-15-58.gh-issue-119057.P3G9G2.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2024-05-15-12-15-58.gh-issue-119057.P3G9G2.rst
@@ -1,2 +1,4 @@
-Improve error message when using ``// 0`` from "integer division or modulo
-by zero" to "integer floor division by zero" which better represents the division.
+Improve :exc:`ZeroDivisionError` error message.
+Now, all error messages are harmonized: all ``/``, ``//``, and ``%``
+operations just use "division by zero" message.
+And ``0 ** -1`` operation uses "zero to a negative power".

--- a/Objects/complexobject.c
+++ b/Objects/complexobject.c
@@ -523,7 +523,7 @@ complex_div(PyObject *v, PyObject *w)
     errno = 0;
     quot = _Py_c_quot(a, b);
     if (errno == EDOM) {
-        PyErr_SetString(PyExc_ZeroDivisionError, "complex division by zero");
+        PyErr_SetString(PyExc_ZeroDivisionError, "division by zero");
         return NULL;
     }
     return PyComplex_FromCComplex(quot);
@@ -554,7 +554,7 @@ complex_pow(PyObject *v, PyObject *w, PyObject *z)
     _Py_ADJUST_ERANGE2(p.real, p.imag);
     if (errno == EDOM) {
         PyErr_SetString(PyExc_ZeroDivisionError,
-                        "0.0 to a negative or complex power");
+                        "zero to a negative or complex power");
         return NULL;
     }
     else if (errno == ERANGE) {

--- a/Objects/floatobject.c
+++ b/Objects/floatobject.c
@@ -623,7 +623,7 @@ float_div(PyObject *v, PyObject *w)
     CONVERT_TO_DOUBLE(w, b);
     if (b == 0.0) {
         PyErr_SetString(PyExc_ZeroDivisionError,
-                        "float division by zero");
+                        "division by zero");
         return NULL;
     }
     a = a / b;
@@ -639,7 +639,7 @@ float_rem(PyObject *v, PyObject *w)
     CONVERT_TO_DOUBLE(w, wx);
     if (wx == 0.0) {
         PyErr_SetString(PyExc_ZeroDivisionError,
-                        "float modulo by zero");
+                        "division by zero");
         return NULL;
     }
     mod = fmod(vx, wx);
@@ -704,7 +704,7 @@ float_divmod(PyObject *v, PyObject *w)
     CONVERT_TO_DOUBLE(v, vx);
     CONVERT_TO_DOUBLE(w, wx);
     if (wx == 0.0) {
-        PyErr_SetString(PyExc_ZeroDivisionError, "float divmod()");
+        PyErr_SetString(PyExc_ZeroDivisionError, "division by zero");
         return NULL;
     }
     _float_div_mod(vx, wx, &floordiv, &mod);
@@ -719,7 +719,7 @@ float_floor_div(PyObject *v, PyObject *w)
     CONVERT_TO_DOUBLE(v, vx);
     CONVERT_TO_DOUBLE(w, wx);
     if (wx == 0.0) {
-        PyErr_SetString(PyExc_ZeroDivisionError, "float floor division by zero");
+        PyErr_SetString(PyExc_ZeroDivisionError, "division by zero");
         return NULL;
     }
     _float_div_mod(vx, wx, &floordiv, &mod);
@@ -788,8 +788,7 @@ float_pow(PyObject *v, PyObject *w, PyObject *z)
         int iw_is_odd = DOUBLE_IS_ODD_INTEGER(iw);
         if (iw < 0.0) {
             PyErr_SetString(PyExc_ZeroDivisionError,
-                            "0.0 cannot be raised to a "
-                            "negative power");
+                            "zero to a negative power");
             return NULL;
         }
         /* use correct sign if iw is odd */

--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -3103,17 +3103,13 @@ static PyObject *long_long(PyObject *v);
 
 static int
 long_divrem(PyLongObject *a, PyLongObject *b,
-            PyLongObject **pdiv, PyLongObject **prem, int divonly)
+            PyLongObject **pdiv, PyLongObject **prem)
 {
     Py_ssize_t size_a = _PyLong_DigitCount(a), size_b = _PyLong_DigitCount(b);
     PyLongObject *z;
 
     if (size_b == 0) {
-        PyErr_SetString(
-            PyExc_ZeroDivisionError,
-            divonly ?
-                "integer floor division by zero" :
-                "integer division or modulo by zero");
+        PyErr_SetString(PyExc_ZeroDivisionError, "division by zero");
         return -1;
     }
     if (size_a < size_b ||
@@ -3176,7 +3172,7 @@ long_rem(PyLongObject *a, PyLongObject *b, PyLongObject **prem)
 
     if (size_b == 0) {
         PyErr_SetString(PyExc_ZeroDivisionError,
-                        "integer modulo by zero");
+                        "division by zero");
         return -1;
     }
     if (size_a < size_b ||
@@ -4370,7 +4366,7 @@ l_divmod(PyLongObject *v, PyLongObject *w,
         return pylong_int_divmod(v, w, pdiv, pmod);
     }
 #endif
-    if (long_divrem(v, w, &div, &mod, pmod == NULL) < 0)
+    if (long_divrem(v, w, &div, &mod) < 0)
         return -1;
     if ((_PyLong_IsNegative(mod) && _PyLong_IsPositive(w)) ||
         (_PyLong_IsPositive(mod) && _PyLong_IsNegative(w))) {
@@ -5981,7 +5977,7 @@ _PyLong_DivmodNear(PyObject *a, PyObject *b)
     /* Do a and b have different signs?  If so, quotient is negative. */
     quo_is_neg = (_PyLong_IsNegative((PyLongObject *)a)) != (_PyLong_IsNegative((PyLongObject *)b));
 
-    if (long_divrem((PyLongObject*)a, (PyLongObject*)b, &quo, &rem, 0) < 0)
+    if (long_divrem((PyLongObject*)a, (PyLongObject*)b, &quo, &rem) < 0)
         goto error;
 
     /* compare twice the remainder with the divisor, to see

--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -3103,14 +3103,17 @@ static PyObject *long_long(PyObject *v);
 
 static int
 long_divrem(PyLongObject *a, PyLongObject *b,
-            PyLongObject **pdiv, PyLongObject **prem)
+            PyLongObject **pdiv, PyLongObject **prem, int divonly)
 {
     Py_ssize_t size_a = _PyLong_DigitCount(a), size_b = _PyLong_DigitCount(b);
     PyLongObject *z;
 
     if (size_b == 0) {
-        PyErr_SetString(PyExc_ZeroDivisionError,
-                        "integer division or modulo by zero");
+        PyErr_SetString(
+            PyExc_ZeroDivisionError,
+            divonly ?
+                "integer floor division by zero" :
+                "integer division or modulo by zero");
         return -1;
     }
     if (size_a < size_b ||
@@ -4367,7 +4370,7 @@ l_divmod(PyLongObject *v, PyLongObject *w,
         return pylong_int_divmod(v, w, pdiv, pmod);
     }
 #endif
-    if (long_divrem(v, w, &div, &mod) < 0)
+    if (long_divrem(v, w, &div, &mod, pmod == NULL) < 0)
         return -1;
     if ((_PyLong_IsNegative(mod) && _PyLong_IsPositive(w)) ||
         (_PyLong_IsPositive(mod) && _PyLong_IsNegative(w))) {
@@ -5978,7 +5981,7 @@ _PyLong_DivmodNear(PyObject *a, PyObject *b)
     /* Do a and b have different signs?  If so, quotient is negative. */
     quo_is_neg = (_PyLong_IsNegative((PyLongObject *)a)) != (_PyLong_IsNegative((PyLongObject *)b));
 
-    if (long_divrem((PyLongObject*)a, (PyLongObject*)b, &quo, &rem) < 0)
+    if (long_divrem((PyLongObject*)a, (PyLongObject*)b, &quo, &rem, 0) < 0)
         goto error;
 
     /* compare twice the remainder with the divisor, to see


### PR DESCRIPTION
Now these two errors are very similar:

```python
>>> 1 // 0
Traceback (most recent call last):
  File "<python-input-0>", line 1, in <module>
    1 // 0
    ~~^^~~
ZeroDivisionError: integer floor division by zero
```
```python
>>> 1.5 // 0
Traceback (most recent call last):
  File "<python-input-1>", line 1, in <module>
    1.5 // 0
    ~~~~^^~~
ZeroDivisionError: float floor division by zero
```

Better wording is always welcome!

<!-- gh-issue-number: gh-119057 -->
* Issue: gh-119057
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--119066.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->