### PR TITLE
gh-108267: Fix object.__setattr__ regression in dataclasses docs

### DIFF
--- a/Doc/library/dataclasses.rst
+++ b/Doc/library/dataclasses.rst
@@ -615,7 +615,8 @@ methods will raise a :exc:`FrozenInstanceError` when invoked.
 
 There is a tiny performance penalty when using ``frozen=True``:
 :meth:`~object.__init__` cannot use simple assignment to initialize fields, and
-must use :meth:`!__setattr__`.
+must use :meth:`!object.__setattr__`.
+.. Make sure to not remove "object" from "object.__setattr__" in the above markup
 
 .. _dataclasses-inheritance:
 


### PR DESCRIPTION
Thanks to FrozenBob for catching (again)!

Unfortunately the regression was backported to 3.11, which is now in security only: https://github.com/python/cpython/pull/117005#issuecomment-2015745251

<!-- gh-issue-number: gh-108267 -->
* Issue: gh-108267
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--119082.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->