### PR TITLE
gh-118138: Adds test for multithreaded writes to files.

### DIFF
--- a/Lib/test/test_io_threading.py
+++ b/Lib/test/test_io_threading.py
@@ -8,7 +8,7 @@ NUM_LOOPS = 10
 def looping_print_to_file(f, i):
     for j in range(NUM_LOOPS):
         # p = 'x' * 90 + '123456789'
-        p = f"{i:2}i,{j}j\n" + '0123456789' * 10
+        p = f"\n{i}i,{j}j\n" + '0123456789' * 10
         print(p, file=f)
 
 class IoThreadingTestCase(unittest.TestCase):
@@ -27,7 +27,7 @@ class IoThreadingTestCase(unittest.TestCase):
 
         for i in range(NUM_THREADS):
             for j in range(NUM_LOOPS):
-                p = f"{i:2}i,{j}j"
+                p = f"{i}i,{j}j"
 
                 assert p in lines, repr(p)
 

--- a/Lib/test/test_io_threading.py
+++ b/Lib/test/test_io_threading.py
@@ -18,7 +18,7 @@ class IoThreadingTestCase(unittest.TestCase):
                 for i in range(NUM_THREADS):
                     executor.submit(looping_print_to_file, f, i)
 
-            executor.shutdown(wait=True)
+                executor.shutdown(wait=True)
 
         with open('test_io_threading.out', 'r') as f:
             lines = set(x.rstrip() for x in f.readlines() if ',' in x)

--- a/Lib/test/test_io_threading.py
+++ b/Lib/test/test_io_threading.py
@@ -1,0 +1,36 @@
+import unittest
+from concurrent.futures import ThreadPoolExecutor
+
+
+NUM_THREADS = 100
+NUM_LOOPS = 10
+
+def looping_print_to_file(f, i):
+    for j in range(NUM_LOOPS):
+        # p = 'x' * 90 + '123456789'
+        p = f"{i:2}i,{j}j\n" + '0123456789' * 10
+        print(p, file=f)
+
+class IoThreadingTestCase(unittest.TestCase):
+    def test_io_threading(self):
+        with ThreadPoolExecutor(max_workers=NUM_THREADS) as executor:
+            with open('test_io_threading.out', 'w') as f:
+                for i in range(NUM_THREADS):
+                    executor.submit(looping_print_to_file, f, i)
+
+            executor.shutdown(wait=True)
+
+        with open('test_io_threading.out', 'r') as f:
+            lines = set(x.rstrip() for x in f.readlines() if ',' in x)
+
+        assert len(lines) == NUM_THREADS * NUM_LOOPS, repr(len(lines))
+
+        for i in range(NUM_THREADS):
+            for j in range(NUM_LOOPS):
+                p = f"{i:2}i,{j}j"
+
+                assert p in lines, repr(p)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Modules/_io/textio.c
+++ b/Modules/_io/textio.c
@@ -1729,6 +1729,10 @@ _io_TextIOWrapper_write_impl(textio *self, PyObject *text)
             Py_DECREF(b);
             return NULL;
         }
+        // The assumption that self won't have been modified from another
+        // thread between the flush above and the assignment below is
+        // incorrect.
+        assert(self->pending_bytes == NULL);
         self->pending_bytes = b;
     }
     else if (!PyList_CheckExact(self->pending_bytes)) {


### PR DESCRIPTION
Multithreaded writes to files (including standard calls to print() from threads) can result in assertion failures, missed dropped output, and (in non-debug builds) writing uninitialized memory out due to race conditions in `_io_TextIOWrapper_write_impl` and `_textiowrapper_writeflush`.

See: https://github.com/python/cpython/issues/118138

I've provided a change that fixes the original issue for me on python 3.10.12, ~but my attempt to turn the repro script into a self-contained test case fails with that patch on both 3.10.12 and 3.14.0a0 (`main` as of today).~  That patch makes `self->pending_bytes` always be a list, and calls `PyList_SetSlice(pending, 0, pending_size_at_start, NULL)` to remove entries after they've been processed.  I strongly suspect that the patch only narrows the time windows for race conditions, not actually eliminate them.  I also think that it might introduce the possibility of dropped or repeated output should those race conditions trigger, but I am uncertain if that's actually the case (and they don't happen in practice, according to the test script).

I am out of my depth and would appreciate a maintainer taking a look.

Thanks to @sterwill for the original repro script, which the test case here is a descendent of.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-118138 -->
* Issue: gh-118138
<!-- /gh-issue-number -->
