### PR TITLE
GH-119113: Raise `TypeError` from `pathlib.PurePath.with_suffix(None)`

### DIFF
--- a/Lib/pathlib/_abc.py
+++ b/Lib/pathlib/_abc.py
@@ -205,15 +205,13 @@ class PurePathBase:
         string, remove the suffix from the path.
         """
         stem = self.stem
-        if not suffix:
-            return self.with_name(stem)
-        elif not stem:
+        if not stem:
             # If the stem is empty, we can't make the suffix non-empty.
             raise ValueError(f"{self!r} has an empty name")
-        elif suffix.startswith('.') and len(suffix) > 1:
-            return self.with_name(stem + suffix)
-        else:
+        elif suffix and not (suffix.startswith('.') and len(suffix) > 1):
             raise ValueError(f"Invalid suffix {suffix!r}")
+        else:
+            return self.with_name(stem + suffix)
 
     def relative_to(self, other, *, walk_up=False):
         """Return the relative path to another path identified by the passed

--- a/Lib/test/test_pathlib/test_pathlib_abc.py
+++ b/Lib/test/test_pathlib/test_pathlib_abc.py
@@ -999,6 +999,7 @@ class DummyPurePathTest(unittest.TestCase):
         self.assertRaises(ValueError, P('c:a/b').with_suffix, 'c\\d')
         self.assertRaises(ValueError, P('c:a/b').with_suffix, '.c/d')
         self.assertRaises(ValueError, P('c:a/b').with_suffix, '.c\\d')
+        self.assertRaises(TypeError, P('c:a/b').with_suffix, None)
 
     def test_with_suffix_empty(self):
         P = self.cls
@@ -1006,7 +1007,7 @@ class DummyPurePathTest(unittest.TestCase):
         self.assertRaises(ValueError, P('').with_suffix, '.gz')
         self.assertRaises(ValueError, P('/').with_suffix, '.gz')
 
-    def test_with_suffix_seps(self):
+    def test_with_suffix_invalid(self):
         P = self.cls
         # Invalid suffix.
         self.assertRaises(ValueError, P('a/b').with_suffix, 'gz')
@@ -1017,6 +1018,7 @@ class DummyPurePathTest(unittest.TestCase):
         self.assertRaises(ValueError, P('a/b').with_suffix, '.c/.d')
         self.assertRaises(ValueError, P('a/b').with_suffix, './.d')
         self.assertRaises(ValueError, P('a/b').with_suffix, '.d/.')
+        self.assertRaises(TypeError, P('a/b').with_suffix, None)
 
     def test_relative_to_common(self):
         P = self.cls

--- a/Misc/NEWS.d/next/Library/2024-05-17-17-32-12.gh-issue-119113.kEv1Ll.rst
+++ b/Misc/NEWS.d/next/Library/2024-05-17-17-32-12.gh-issue-119113.kEv1Ll.rst
@@ -1,0 +1,2 @@
+Fix issue where :meth:`pathlib.PurePath.with_suffix` didn't raise
+:exc:`TypeError` when given ``None`` as a suffix.


### PR DESCRIPTION
Restore behaviour from 3.12 when `path.with_suffix(None)` is called.


<!-- gh-issue-number: gh-119113 -->
* Issue: gh-119113
<!-- /gh-issue-number -->
