### PR TITLE
gh-119109: functools.partial.fallforward fix

### DIFF
--- a/Modules/_functoolsmodule.c
+++ b/Modules/_functoolsmodule.c
@@ -49,7 +49,7 @@ typedef struct {
     PyObject *dict;        /* __dict__ */
     PyObject *weakreflist; /* List of weak references */
     vectorcallfunc vectorcall;
-    Py_ssize_t can_vcall;  /* Cache whether function allows vector call */
+    int can_vcall;         /* Cache whether function allows vector call */
 } partialobject;
 
 static void partial_setvectorcall(partialobject *pto);

--- a/Modules/_functoolsmodule.c
+++ b/Modules/_functoolsmodule.c
@@ -46,10 +46,10 @@ typedef struct {
     PyObject *fn;
     PyObject *args;
     PyObject *kw;
-    PyObject *dict;         /* __dict__ */
-    PyObject *weakreflist;  /* List of weak references */
+    PyObject *dict;        /* __dict__ */
+    PyObject *weakreflist; /* List of weak references */
     vectorcallfunc vectorcall;
-    Py_ssize_t can_vcall;   /* Cache whether function allows vector call */
+    Py_ssize_t can_vcall;  /* Cache whether function allows vector call */
 } partialobject;
 
 static void partial_setvectorcall(partialobject *pto);


### PR DESCRIPTION
https://github.com/python/cpython/issues/119109

I went with option 1. It is cleaner, faster and has a natural flow.

Before:
```python
from functools import partial

def func(a, b, c=0):
    return a - b - c

p1 = partial(func, 1)

print(p1(2))    # -1
%timeit p1(2)   # 100 ns

p1.keywords['c'] = 1
print(p1(2))    # -2
%timeit p1(2)   # 234 ns

del p1.keywords['c']
print(p1(2))    # -1
%timeit p1(2)   # 144 ns
```

After:
```python
p1 = partial(func, 1)

print(p1(2))    # -1
%timeit p1(2)   # 100 ns

p1.keywords['c'] = 1
print(p1(2))    # -2
%timeit p1(2)   # 234 ns

del p1.keywords['c']
print(p1(2))    # -1
%timeit p1(2)   # 100 ns
```

<!-- gh-issue-number: gh-119109 -->
* Issue: gh-119109
<!-- /gh-issue-number -->
