### PR TITLE
gh-119105: difflib: improve recursion for degenerate cases

### DIFF
--- a/Lib/difflib.py
+++ b/Lib/difflib.py
@@ -917,13 +917,13 @@ class Differ:
 
         max_len_a = max(map(len, a))
         max_len_b = max(map(len, b))
-        # twice epsilon can be safely added to distinguish equal ratios
-        # given ratios are 2 * integer / (len_i + len_j)
+        # twice the epsilon can be safely added to distinguish otherwise
+        # equal ratios. given ratios are 2 * integer / (len_i + len_j)
         # the smallest possible non-zero difference between two arbitrary
         # ratios is no less than twice the epsilon
         epsilon = 0.99 / (max_len_a + max_len_b) ** 2
-        # we use sub-epsilon weights to promote otherwise equal ratios
-        # that split sequences closer to their midpoints
+        # we use sub-epsilon weights to promote i, j that split the
+        # input range more equally.
         # this way, we balance the recursion tree in degenerate cases
 
         # search for the pair that matches best without being identical

--- a/Lib/difflib.py
+++ b/Lib/difflib.py
@@ -930,7 +930,6 @@ class Differ:
                 weight += alen
             elif j > blen / 2:
                 weight -= alen
-            weight = min(j - blo, bhi - 1 - j) * (ahi - alo - 1)
             for i in range(alo, ahi):
                 ai = a[i]
                 if ai == bj:

--- a/Lib/difflib.py
+++ b/Lib/difflib.py
@@ -911,6 +911,13 @@ class Differ:
 
         # don't synch up unless the lines have a similarity score of at
         # least cutoff; best_ratio tracks the best score seen so far
+        # best_ratio is a tuple storing the best .ratio() seen so far, and
+        # a measure of how far the indices are from their index range
+        # midpoints. The latter is used to resolve ratio ties. Favoring
+        # indices near the midpoints tends to cut the ranges in half. Else,
+        # if there are many pairs with the best ratio, recursion can grow
+        # very deep, and runtime becomes cubic. See:
+        # https://github.com/python/cpython/issues/119105
         best_ratio, cutoff = (0.74, 0), 0.75
         cruncher = SequenceMatcher(self.charjunk)
         eqi, eqj = None, None   # 1st indices of equal lines (if any)

--- a/Misc/NEWS.d/next/Library/2024-05-19-12-25-36.gh-issue-119105.VcR4ig.rst
+++ b/Misc/NEWS.d/next/Library/2024-05-19-12-25-36.gh-issue-119105.VcR4ig.rst
@@ -1,0 +1,1 @@
+`difflib.Differ` is faster for some class of diffs

--- a/Misc/NEWS.d/next/Library/2024-05-19-12-25-36.gh-issue-119105.VcR4ig.rst
+++ b/Misc/NEWS.d/next/Library/2024-05-19-12-25-36.gh-issue-119105.VcR4ig.rst
@@ -1,1 +1,1 @@
-`difflib.Differ` is faster for some class of diffs
+``difflib.Differ`` is faster for some class of diffs

--- a/Misc/NEWS.d/next/Library/2024-05-19-12-25-36.gh-issue-119105.VcR4ig.rst
+++ b/Misc/NEWS.d/next/Library/2024-05-19-12-25-36.gh-issue-119105.VcR4ig.rst
@@ -1,1 +1,1 @@
-``difflib.Differ`` is faster for some class of diffs
+``difflib.Differ`` is much faster for some cases of diffs where many pairs of lines are equally similar.

--- a/Misc/NEWS.d/next/Library/2024-05-19-12-42-51.gh-issue-119105.N2nNLm.rst
+++ b/Misc/NEWS.d/next/Library/2024-05-19-12-42-51.gh-issue-119105.N2nNLm.rst
@@ -1,0 +1,1 @@
+difflib.Differ is faster for some class of diffs

--- a/Misc/NEWS.d/next/Library/2024-05-19-12-42-51.gh-issue-119105.N2nNLm.rst
+++ b/Misc/NEWS.d/next/Library/2024-05-19-12-42-51.gh-issue-119105.N2nNLm.rst
@@ -1,1 +1,0 @@
-difflib.Differ is faster for some class of diffs


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
Used this as a benchmark:

```python
a = ["0123456789\n"] * 1_000
b = ["01234a56789\n"] * 1_000

from difflib import Differ
import timeit

print(timeit.timeit("list(Differ().compare(a, b))", number=1, globals=globals()))
# this exceeds recursion depth on my stock python distribution.
# once `difflib` is patched, it runs in approximately `1s`
```

<!-- gh-issue-number: gh-119105 -->
* Issue: gh-119105
<!-- /gh-issue-number -->
