### PR TITLE
Minor improvements to the docs for itertools.tee()

### DIFF
--- a/Doc/library/itertools.rst
+++ b/Doc/library/itertools.rst
@@ -698,18 +698,18 @@ loops that truncate the stream.
 
         def tee(iterable, n=2):
             iterator = iter(iterable)
-            empty_link = [None, None]  # Singly linked list: [value, link]
-            return tuple(_tee(iterator, empty_link) for _ in range(n))
+            initial_link = [None, None]  # node: [data, link]
+            return tuple(_tee(iterator, initial_link) for _ in range(n))
 
         def _tee(iterator, link):
-            while True:
-                if link[1] is None:
-                    try:
+            try:
+                while True:
+                    if link[1] is None:
                         link[:] = [next(iterator), [None, None]]
-                    except StopIteration:
-                        return
-                value, link = link
-                yield value
+                    value, link = link
+                    yield value
+            except StopIteration:
+                return
 
    Once a :func:`tee` has been created, the original *iterable* should not be
    used anywhere else; otherwise, the *iterable* could get advanced without

--- a/Doc/library/itertools.rst
+++ b/Doc/library/itertools.rst
@@ -705,7 +705,8 @@ loops that truncate the stream.
             try:
                 while True:
                     if link[1] is None:
-                        link[:] = [next(iterator), [None, None]]
+                        link[0] = next(iterator)
+                        link[1] = [None, None]
                     value, link = link
                     yield value
             except StopIteration:

--- a/Doc/library/itertools.rst
+++ b/Doc/library/itertools.rst
@@ -698,8 +698,8 @@ loops that truncate the stream.
 
         def tee(iterable, n=2):
             iterator = iter(iterable)
-            initial_link = [None, None]  # node: [data, link]
-            return tuple(_tee(iterator, initial_link) for _ in range(n))
+            shared_link = [None, None]  # node: [data, link]
+            return tuple(_tee(iterator, shared_link) for _ in range(n))
 
         def _tee(iterator, link):
             try:

--- a/Doc/library/itertools.rst
+++ b/Doc/library/itertools.rst
@@ -698,7 +698,7 @@ loops that truncate the stream.
 
         def tee(iterable, n=2):
             iterator = iter(iterable)
-            shared_link = [None, None]  # node: [data, link]
+            shared_link = [None, None]
             return tuple(_tee(iterator, shared_link) for _ in range(n))
 
         def _tee(iterator, link):


### PR DESCRIPTION
* Rename variable from `empty_link` to the more descriptive `shared_link'.
* Hoist the try/except outside of the inner loop.

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--119135.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->