### PR TITLE
gh-110383: Document `socket.makefile()` accepts combined modes

### DIFF
--- a/Doc/library/socket.rst
+++ b/Doc/library/socket.rst
@@ -1589,7 +1589,8 @@ to sockets.
    Return a :term:`file object` associated with the socket.  The exact returned
    type depends on the arguments given to :meth:`makefile`.  These arguments are
    interpreted the same way as by the built-in :func:`open` function, except
-   the only supported *mode* values are ``'r'`` (default), ``'w'`` and ``'b'``.
+   the only supported *mode* values are ``'r'`` (default), ``'w'``, ``'b'``, or
+   a combination of those.
 
    The socket must be in blocking mode; it can have a timeout, but the file
    object's internal buffer may end up in an inconsistent state if a timeout

--- a/Lib/socket.py
+++ b/Lib/socket.py
@@ -306,7 +306,8 @@ class socket(_socket.socket):
         """makefile(...) -> an I/O stream connected to the socket
 
         The arguments are as for io.open() after the filename, except the only
-        supported mode values are 'r' (default), 'w' and 'b'.
+        supported mode values are 'r' (default), 'w', 'b', or a combination of
+        those.
         """
         # XXX refactor to share code?
         if not set(mode) <= {"r", "w", "b"}:


### PR DESCRIPTION
ref: #110383
ref: https://mail.python.org/archives/list/docs@python.org/thread/3VGLA6Q6QDYB7XIAHFIRAVW4TQSEAZGA/

<!-- gh-issue-number: gh-110383 -->
* Issue: gh-110383
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--119150.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->