### PR TITLE
Fix version number in use_load_tests deprecation reference

### DIFF
--- a/Doc/whatsnew/3.12.rst
+++ b/Doc/whatsnew/3.12.rst
@@ -1739,7 +1739,7 @@ unittest
 
   * Undocumented :meth:`TestLoader.loadTestsFromModule
     <unittest.TestLoader.loadTestsFromModule>` parameter *use_load_tests*
-    (deprecated and ignored since Python 3.2).
+    (deprecated and ignored since Python 3.5).
 
   * An alias of the :class:`~unittest.TextTestResult` class:
     ``_TextTestResult`` (deprecated in Python 3.2).


### PR DESCRIPTION
Deprecation took place in d78742a260ba09e53c844de7b1fd11a11c674945 (3.5)


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--119151.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->