### PR TITLE
marshal docs: Remove reference to "Sun"

### DIFF
--- a/Doc/library/marshal.rst
+++ b/Doc/library/marshal.rst
@@ -10,7 +10,7 @@
 This module contains functions that can read and write Python values in a binary
 format.  The format is specific to Python, but independent of machine
 architecture issues (e.g., you can write a Python value to a file on a PC,
-transport the file to a Sun, and read it back there).  Details of the format are
+transport the file to a Mac, and read it back there).  Details of the format are
 undocumented on purpose; it may change between Python versions (although it
 rarely does). [#]_
 


### PR DESCRIPTION
Nobody has been using a Sun machine for a long time. When I saw
this sentence in a lightning talk just now, I thought it was talking
about sending Python code on a spacecraft.


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--119161.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->