### PR TITLE
Try to repair oddball test bots timing out in test_int

### DIFF
--- a/Lib/test/test_int.py
+++ b/Lib/test/test_int.py
@@ -12,6 +12,11 @@ try:
 except ImportError:
     _pylong = None
 
+try:
+    import _decimal
+except ImportError:
+    _decimal = None
+
 L = [
         ('0', 0),
         ('1', 1),
@@ -920,6 +925,7 @@ class PyLongModuleTests(unittest.TestCase):
             bits <<= 1
 
     @support.requires_resource('cpu')
+    @unittest.skipUnless(_decimal, "C _decimal module required")
     def test_pylong_roundtrip_huge(self):
         # k blocks of 1234567890
         k = 1_000_000 # so 10 million digits in all
@@ -931,6 +937,7 @@ class PyLongModuleTests(unittest.TestCase):
 
     @support.requires_resource('cpu')
     @unittest.skipUnless(_pylong, "_pylong module required")
+    @unittest.skipUnless(_decimal, "C _decimal module required")
     def test_whitebox_dec_str_to_int_inner_failsafe(self):
         # While I believe the number of GUARD digits in this function is
         # always enough so that no more than one correction step is ever
@@ -950,6 +957,7 @@ class PyLongModuleTests(unittest.TestCase):
             _pylong._spread.update(orig_spread)
 
     @unittest.skipUnless(_pylong, "pylong module required")
+    @unittest.skipUnless(_decimal, "C _decimal module required")
     def test_whitebox_dec_str_to_int_inner_monster(self):
         # I don't think anyone has enough RAM to build a string long enough
         # for this function to complain. So lie about the string length.


### PR DESCRIPTION
Various test bots (outside the ones GH normally runs) are timing out during test_int after ecd8664 (asymptotically faster str->int). Best guess is that they don't build the C _decimal module. So require that module in the most likely tests to time out then. Flying mostly blind, though!

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
