### PR TITLE
GH-118447: Fix FreeBSD test failures.

### DIFF
--- a/Lib/test/test_posixpath.py
+++ b/Lib/test/test_posixpath.py
@@ -663,6 +663,7 @@ class PosixPathTest(unittest.TestCase):
     @os_helper.skip_unless_symlink
     @skip_if_ABSTFN_contains_backslash
     @unittest.skipIf(os.chmod not in os.supports_follow_symlinks, "Can't set symlink permissions")
+    @unittest.skipIf(sys.platform != "darwin", "only macOS requires read permission to readlink()")
     def test_realpath_unreadable_symlink(self):
         try:
             os.symlink(ABSTFN+"1", ABSTFN)


### PR DESCRIPTION
Follow-up to #118489. Apparently only macOS requires read permission to call `readlink()` on a symlink.

<!-- gh-issue-number: gh-118447 -->
* Issue: gh-118447
<!-- /gh-issue-number -->
