### PR TITLE
gh-119121: Fix and test `async.staggered.staggered_race`

### DIFF
--- a/Lib/asyncio/staggered.py
+++ b/Lib/asyncio/staggered.py
@@ -69,8 +69,7 @@ async def staggered_race(coro_fns, delay, *, loop=None):
     exceptions = []
     running_tasks = []
 
-    async def run_one_coro(
-            previous_failed: typing.Optional[locks.Event]) -> None:
+    async def run_one_coro(previous_failed) -> None:
         # Wait for the previous task to finish, or for delay seconds
         if previous_failed is not None:
             with contextlib.suppress(exceptions_mod.TimeoutError):

--- a/Lib/test/test_asyncio/test_staggered.py
+++ b/Lib/test/test_asyncio/test_staggered.py
@@ -18,8 +18,8 @@ class StaggeredTests(unittest.IsolatedAsyncioTestCase):
             delay=None,
         )
 
-        self.assertEqual(winner, None)
-        self.assertEqual(index, None)
+        self.assertIs(winner, None)
+        self.assertIs(index, None)
         self.assertEqual(excs, [])
 
     async def test_one_successful(self):
@@ -56,7 +56,7 @@ class StaggeredTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(index, 1)
         self.assertEqual(len(excs), 2)
         self.assertIsInstance(excs[0], ValueError)
-        self.assertEqual(excs[1], None)
+        self.assertIs(excs[1], None)
 
     async def test_first_timeout_second_successful(self):
         async def coro(index):
@@ -76,7 +76,7 @@ class StaggeredTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(index, 1)
         self.assertEqual(len(excs), 2)
         self.assertIsInstance(excs[0], asyncio.CancelledError)
-        self.assertEqual(excs[1], None)
+        self.assertIs(excs[1], None)
 
     async def test_none_successful(self):
         async def coro(index):
@@ -90,8 +90,8 @@ class StaggeredTests(unittest.IsolatedAsyncioTestCase):
             delay=None,
         )
 
-        self.assertEqual(winner, None)
-        self.assertEqual(index, None)
+        self.assertIs(winner, None)
+        self.assertIs(index, None)
         self.assertEqual(len(excs), 2)
         self.assertIsInstance(excs[0], ValueError)
         self.assertIsInstance(excs[1], ValueError)

--- a/Lib/test/test_asyncio/test_staggered.py
+++ b/Lib/test/test_asyncio/test_staggered.py
@@ -2,6 +2,10 @@ import asyncio
 import unittest
 from asyncio.staggered import staggered_race
 
+from test import support
+
+support.requires_working_socket(module=True)
+
 
 def tearDownModule():
     asyncio.set_event_loop_policy(None)

--- a/Lib/test/test_asyncio/test_staggered.py
+++ b/Lib/test/test_asyncio/test_staggered.py
@@ -1,0 +1,93 @@
+import asyncio
+import unittest
+from asyncio.staggered import staggered_race
+
+
+def tearDownModule():
+    asyncio.set_event_loop_policy(None)
+
+
+class StaggeredTests(unittest.IsolatedAsyncioTestCase):
+    async def test_empty(self):
+        winner, index, excs = await staggered_race(
+            [],
+            delay=None,
+        )
+
+        self.assertEqual(winner, None)
+        self.assertEqual(index, None)
+        self.assertEqual(excs, [])
+
+    async def test_one_successful(self):
+        async def coro(index):
+            return f'Res: {index}'
+
+        winner, index, excs = await staggered_race(
+            [
+                lambda: coro(0),
+                lambda: coro(1),
+            ],
+            delay=None,
+        )
+
+        self.assertEqual(winner, 'Res: 0')
+        self.assertEqual(index, 0)
+        self.assertEqual(excs, [None])
+
+    async def test_first_error_second_successful(self):
+        async def coro(index):
+            if index == 0:
+                raise ValueError(index)
+            return f'Res: {index}'
+
+        winner, index, excs = await staggered_race(
+            [
+                lambda: coro(0),
+                lambda: coro(1),
+            ],
+            delay=None,
+        )
+
+        self.assertEqual(winner, 'Res: 1')
+        self.assertEqual(index, 1)
+        self.assertEqual(len(excs), 2)
+        self.assertIsInstance(excs[0], ValueError)
+        self.assertEqual(excs[1], None)
+
+    async def test_first_timeout_second_successful(self):
+        async def coro(index):
+            if index == 0:
+                await asyncio.sleep(10)  # much bigger than delay
+            return f'Res: {index}'
+
+        winner, index, excs = await staggered_race(
+            [
+                lambda: coro(0),
+                lambda: coro(1),
+            ],
+            delay=0.1,
+        )
+
+        self.assertEqual(winner, 'Res: 1')
+        self.assertEqual(index, 1)
+        self.assertEqual(len(excs), 2)
+        self.assertIsInstance(excs[0], asyncio.CancelledError)
+        self.assertEqual(excs[1], None)
+
+    async def test_none_successful(self):
+        async def coro(index):
+            raise ValueError(index)
+
+        winner, index, excs = await staggered_race(
+            [
+                lambda: coro(0),
+                lambda: coro(1),
+            ],
+            delay=None,
+        )
+
+        self.assertEqual(winner, None)
+        self.assertEqual(index, None)
+        self.assertEqual(len(excs), 2)
+        self.assertIsInstance(excs[0], ValueError)
+        self.assertIsInstance(excs[1], ValueError)

--- a/Misc/NEWS.d/next/Library/2024-05-19-13-05-59.gh-issue-119121.P1gnh1.rst
+++ b/Misc/NEWS.d/next/Library/2024-05-19-13-05-59.gh-issue-119121.P1gnh1.rst
@@ -1,0 +1,2 @@
+Fix a NameError happening in ``asyncio.staggered.staggered_race``. This
+function is now tested.


### PR DESCRIPTION
I've added a couple of tests for this function as well, to prevent simple future regressions.

Please, note that this set of tests is clearly not enough to cover all the cases in this function. Right now it only covers several simple use-cases. In the future we can also test:
- `loop=` argument
- Cleanups of running tasks
- `__debug__` route
- `delay` corner cases
- etc

But, I think that testing green path is good enough for now.
I can commit more tests in the next PRs, since they will require quite a lot of effort.

Refs https://github.com/python/cpython/pull/114282
This PR does need a 3.13 backport.

<!-- gh-issue-number: gh-119121 -->
* Issue: gh-119121
<!-- /gh-issue-number -->
