### PR TITLE
pathlib ABCs: remove duplicate `realpath()` implementation.

### DIFF
--- a/Lib/pathlib/_abc.py
+++ b/Lib/pathlib/_abc.py
@@ -684,7 +684,6 @@ class PathBase(PurePathBase):
                 path = self.with_segments(path_str)
                 path._resolving = True
                 return str(path.readlink())
-
         else:
             # If the user has *not* overridden the `readlink()` method, then
             # symlinks are unsupported and (in non-strict mode) we can improve

--- a/Lib/pathlib/_abc.py
+++ b/Lib/pathlib/_abc.py
@@ -12,8 +12,8 @@ resemble pathlib's PurePath and Path respectively.
 """
 
 import functools
+import posixpath
 from glob import _Globber, _no_recurse_symlinks
-from errno import ENOTDIR, ELOOP
 from stat import S_ISDIR, S_ISLNK, S_ISREG, S_ISSOCK, S_ISBLK, S_ISCHR, S_ISFIFO
 
 
@@ -670,65 +670,35 @@ class PathBase(PurePathBase):
         """
         if self._resolving:
             return self
-        path_root, parts = self._stack
-        path = self.with_segments(path_root)
-        try:
-            path = path.absolute()
-        except UnsupportedOperation:
-            path_tail = []
-        else:
-            path_root, path_tail = path._stack
-            path_tail.reverse()
 
-        # If the user has *not* overridden the `readlink()` method, then symlinks are unsupported
-        # and (in non-strict mode) we can improve performance by not calling `stat()`.
-        querying = strict or getattr(self.readlink, '_supported', True)
-        link_count = 0
-        while parts:
-            part = parts.pop()
-            if not part or part == '.':
-                continue
-            if part == '..':
-                if not path_tail:
-                    if path_root:
-                        # Delete '..' segment immediately following root
-                        continue
-                elif path_tail[-1] != '..':
-                    # Delete '..' segment and its predecessor
-                    path_tail.pop()
-                    continue
-            path_tail.append(part)
-            if querying and part != '..':
-                path = self.with_segments(path_root + self.parser.sep.join(path_tail))
+        def getcwd():
+            return str(self.with_segments().absolute())
+
+        if strict or getattr(self.readlink, '_supported', True):
+            def lstat(path_str):
+                path = self.with_segments(path_str)
                 path._resolving = True
-                try:
-                    st = path.stat(follow_symlinks=False)
-                    if S_ISLNK(st.st_mode):
-                        # Like Linux and macOS, raise OSError(errno.ELOOP) if too many symlinks are
-                        # encountered during resolution.
-                        link_count += 1
-                        if link_count >= self._max_symlinks:
-                            raise OSError(ELOOP, "Too many symbolic links in path", self._raw_path)
-                        target_root, target_parts = path.readlink()._stack
-                        # If the symlink target is absolute (like '/etc/hosts'), set the current
-                        # path to its uppermost parent (like '/').
-                        if target_root:
-                            path_root = target_root
-                            path_tail.clear()
-                        else:
-                            path_tail.pop()
-                        # Add the symlink target's reversed tail parts (like ['hosts', 'etc']) to
-                        # the stack of unresolved path parts.
-                        parts.extend(target_parts)
-                        continue
-                    elif parts and not S_ISDIR(st.st_mode):
-                        raise NotADirectoryError(ENOTDIR, "Not a directory", self._raw_path)
-                except OSError:
-                    if strict:
-                        raise
-                    else:
-                        querying = False
-        return self.with_segments(path_root + self.parser.sep.join(path_tail))
+                return path.lstat()
+
+            def readlink(path_str):
+                path = self.with_segments(path_str)
+                path._resolving = True
+                return str(path.readlink())
+
+        else:
+            # If the user has *not* overridden the `readlink()` method, then
+            # symlinks are unsupported and (in non-strict mode) we can improve
+            # performance by not calling `path.lstat()`.
+            def lstat(path_str):
+                raise OSError("Symlinks are unsupported.")
+
+            def readlink(path_str):
+                raise OSError("Symlinks are unsupported.")
+
+        return self.with_segments(posixpath._realpath(
+            str(self), strict, self.parser.sep,
+            getcwd=getcwd, lstat=lstat, readlink=readlink,
+            maxlinks=self._max_symlinks))
 
     def symlink_to(self, target, target_is_directory=False):
         """

--- a/Lib/pathlib/_abc.py
+++ b/Lib/pathlib/_abc.py
@@ -689,11 +689,11 @@ class PathBase(PurePathBase):
             # If the user has *not* overridden the `readlink()` method, then
             # symlinks are unsupported and (in non-strict mode) we can improve
             # performance by not calling `path.lstat()`.
-            def lstat(path_str):
-                raise OSError("Symlinks are unsupported.")
+            def skip(path_str):
+                # This exception will be internally consumed by `_realpath()`.
+                raise OSError("Operation skipped.")
 
-            def readlink(path_str):
-                raise OSError("Symlinks are unsupported.")
+            lstat = readlink = skip
 
         return self.with_segments(posixpath._realpath(
             str(self), strict, self.parser.sep,

--- a/Lib/posixpath.py
+++ b/Lib/posixpath.py
@@ -483,7 +483,7 @@ def _realpath(filename, strict=False, sep=sep, curdir=curdir, pardir=pardir,
                 link_count += 1
                 if link_count > maxlinks:
                     if strict:
-                        raise OSError(errno.ELOOP, "Too many symbolic links in path", newpath)
+                        raise OSError(errno.ELOOP, "Too many levels of symbolic links", newpath)
                     path = newpath
                     continue
             elif newpath in seen:
@@ -494,7 +494,7 @@ def _realpath(filename, strict=False, sep=sep, curdir=curdir, pardir=pardir,
                     continue
                 # The symlink is not resolved, so we must have a symlink loop.
                 if strict:
-                    raise OSError(errno.ELOOP, "Symlink loop", newpath)
+                    raise OSError(errno.ELOOP, "Too many levels of symbolic links", newpath)
                 path = newpath
                 continue
             target = readlink(newpath)

--- a/Lib/posixpath.py
+++ b/Lib/posixpath.py
@@ -435,8 +435,8 @@ symbolic links encountered in the path."""
         getcwd = os.getcwd
     return _realpath(filename, strict, sep, curdir, pardir, getcwd)
 
-def _realpath(filename, strict, sep=sep, curdir=curdir, pardir=pardir,
-              getcwd=os.getcwd, lstat=os.lstat, readlink=os.readlink, maxlinks=-1):
+def _realpath(filename, strict=False, sep=sep, curdir=curdir, pardir=pardir,
+              getcwd=os.getcwd, lstat=os.lstat, readlink=os.readlink, maxlinks=None):
     # The stack of unresolved path parts. When popped, a special value of None
     # indicates that a symlink target has been resolved, and that the original
     # symlink path can be retrieved by popping again. The [::-1] slice is a
@@ -479,7 +479,7 @@ def _realpath(filename, strict, sep=sep, curdir=curdir, pardir=pardir,
             if not stat.S_ISLNK(st.st_mode):
                 path = newpath
                 continue
-            elif maxlinks != -1:
+            elif maxlinks is not None:
                 link_count += 1
                 if link_count > maxlinks:
                     if strict:
@@ -507,7 +507,7 @@ def _realpath(filename, strict, sep=sep, curdir=curdir, pardir=pardir,
         if target.startswith(sep):
             # Symlink target is absolute; reset resolved path.
             path = sep
-        if maxlinks == -1:
+        if maxlinks is None:
             # Mark this symlink as seen but not fully resolved.
             seen[newpath] = None
             # Push the symlink path onto the stack, and signal its specialness

--- a/Lib/posixpath.py
+++ b/Lib/posixpath.py
@@ -483,7 +483,8 @@ def _realpath(filename, strict=False, sep=sep, curdir=curdir, pardir=pardir,
                 link_count += 1
                 if link_count > maxlinks:
                     if strict:
-                        raise OSError(errno.ELOOP, "Too many levels of symbolic links", newpath)
+                        raise OSError(errno.ELOOP, os.strerror(errno.ELOOP),
+                                      newpath)
                     path = newpath
                     continue
             elif newpath in seen:
@@ -494,7 +495,8 @@ def _realpath(filename, strict=False, sep=sep, curdir=curdir, pardir=pardir,
                     continue
                 # The symlink is not resolved, so we must have a symlink loop.
                 if strict:
-                    raise OSError(errno.ELOOP, "Too many levels of symbolic links", newpath)
+                    raise OSError(errno.ELOOP, os.strerror(errno.ELOOP),
+                                  newpath)
                 path = newpath
                 continue
             target = readlink(newpath)

--- a/Lib/posixpath.py
+++ b/Lib/posixpath.py
@@ -452,6 +452,9 @@ def _realpath(filename, strict, sep=sep, curdir=curdir, pardir=pardir,
     # used both to detect symlink loops and to speed up repeated traversals of
     # the same links.
     seen = {}
+
+    # Number of symlinks traversed. When the number of traversals is limited
+    # by *maxlinks*, this is used instead of *seen* to detect symlink loops.
     link_count = 0
 
     while rest:
@@ -476,7 +479,7 @@ def _realpath(filename, strict, sep=sep, curdir=curdir, pardir=pardir,
             if not stat.S_ISLNK(st.st_mode):
                 path = newpath
                 continue
-            if maxlinks != -1:
+            elif maxlinks != -1:
                 link_count += 1
                 if link_count > maxlinks:
                     if strict:
@@ -507,9 +510,9 @@ def _realpath(filename, strict, sep=sep, curdir=curdir, pardir=pardir,
         if maxlinks == -1:
             # Mark this symlink as seen but not fully resolved.
             seen[newpath] = None
-            # Push the symlink path onto the stack, and signal its specialness by
-            # also pushing None. When these entries are popped, we'll record the
-            # fully-resolved symlink target in the 'seen' mapping.
+            # Push the symlink path onto the stack, and signal its specialness
+            # by also pushing None. When these entries are popped, we'll
+            # record the fully-resolved symlink target in the 'seen' mapping.
             rest.append(newpath)
             rest.append(None)
         # Push the unresolved symlink target parts onto the stack.


### PR DESCRIPTION
Add private `posixpath._realpath()` function, which is a generic version of `realpath()` that can be parameterised with string tokens (`sep`, `curdir`, `pardir`) and query functions (`getcwd`, `lstat`, `readlink`). Also add support for limiting the number of symlink traversals.

In the private `pathlib._abc.PathBase` class, call `posixpath._realpath()` and remove our re-implementation of the same algorithm. This speeds up `PathBase.resolve()` because we instantiate fewer `PathBase` objects, and because `_realpath()` caches symlink targets.

No change to any public APIs, either in `posixpath` or `pathlib`.