### PR TITLE
gh-119192: Remove `#ifndef SLOW_SUM` check from `sum()`, use `#if 1`

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2024-05-20-02-59-51.gh-issue-119192.r66RoR.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2024-05-20-02-59-51.gh-issue-119192.r66RoR.rst
@@ -1,0 +1,2 @@
+Remove undocumented ``SLOW_SUM`` C-level flag check in :func:`sum` builtin
+function.

--- a/Python/bltinmodule.c
+++ b/Python/bltinmodule.c
@@ -2570,7 +2570,6 @@ builtin_sum_impl(PyObject *module, PyObject *iterable, PyObject *start)
         Py_INCREF(result);
     }
 
-#ifndef SLOW_SUM
     /* Fast addition by keeping temporary sums in C instead of new Python objects.
        Assumes all inputs are the same type.  If the assumption fails, default
        to the more general routine.
@@ -2691,7 +2690,6 @@ builtin_sum_impl(PyObject *module, PyObject *iterable, PyObject *start)
             }
         }
     }
-#endif
 
     for(;;) {
         item = PyIter_Next(iter);

--- a/Python/bltinmodule.c
+++ b/Python/bltinmodule.c
@@ -2570,6 +2570,8 @@ builtin_sum_impl(PyObject *module, PyObject *iterable, PyObject *start)
         Py_INCREF(result);
     }
 
+    // This is helpful for development and tweaking the optimization:
+#if 1
     /* Fast addition by keeping temporary sums in C instead of new Python objects.
        Assumes all inputs are the same type.  If the assumption fails, default
        to the more general routine.
@@ -2690,6 +2692,7 @@ builtin_sum_impl(PyObject *module, PyObject *iterable, PyObject *start)
             }
         }
     }
+#endif
 
     for(;;) {
         item = PyIter_Next(iter);


### PR DESCRIPTION
Or I might be wrong and it is actually useful :)
In this case, we might want to document it maybe? Or add to `./configure`?

<!-- gh-issue-number: gh-119192 -->
* Issue: gh-119192
<!-- /gh-issue-number -->
