### PR TITLE
[3.12] gh-119213: Fix getargs.c to store state in InterpreterState...

### DIFF
--- a/Include/internal/pycore_interp.h
+++ b/Include/internal/pycore_interp.h
@@ -179,7 +179,6 @@ struct _is {
     PyObject *after_forkers_child;
 #endif
 
-    struct _getargs_runtime_state getargs;
     struct _warnings_runtime_state warnings;
     struct atexit_state atexit;
 
@@ -235,6 +234,8 @@ struct _is {
 
    /* the initial PyInterpreterState.threads.head */
     PyThreadState _initial_thread;
+
+    struct _getargs_runtime_state getargs;
 };
 
 

--- a/Include/internal/pycore_interp.h
+++ b/Include/internal/pycore_interp.h
@@ -39,6 +39,10 @@ struct _Py_long_state {
     int max_str_digits;
 };
 
+struct _getargs_runtime_state {
+    struct _PyArg_Parser *static_parsers;
+};
+
 
 /* cross-interpreter data registry */
 
@@ -175,6 +179,7 @@ struct _is {
     PyObject *after_forkers_child;
 #endif
 
+    struct _getargs_runtime_state getargs;
     struct _warnings_runtime_state warnings;
     struct atexit_state atexit;
 

--- a/Include/internal/pycore_pylifecycle.h
+++ b/Include/internal/pycore_pylifecycle.h
@@ -62,7 +62,8 @@ extern void _PyAST_Fini(PyInterpreterState *interp);
 extern void _PyAtExit_Fini(PyInterpreterState *interp);
 extern void _PyThread_FiniType(PyInterpreterState *interp);
 extern void _Py_Deepfreeze_Fini(void);
-extern void _PyArg_Fini(void);
+extern void _PyArg_InitState(PyInterpreterState *interp);
+extern void _PyArg_Fini(PyInterpreterState *interp);
 extern void _Py_FinalizeAllocatedBlocks(_PyRuntimeState *);
 
 extern PyStatus _PyGILState_Init(PyInterpreterState *interp);

--- a/Include/internal/pycore_runtime.h
+++ b/Include/internal/pycore_runtime.h
@@ -27,11 +27,6 @@ extern "C" {
 #include "pycore_typeobject.h"      // struct types_runtime_state
 #include "pycore_unicodeobject.h"   // struct _Py_unicode_runtime_ids
 
-struct _getargs_runtime_state {
-    PyThread_type_lock mutex;
-    struct _PyArg_Parser *static_parsers;
-};
-
 /* GIL state */
 
 struct _gilstate_runtime_state {
@@ -135,7 +130,6 @@ typedef struct pyruntimestate {
     struct _import_runtime_state imports;
     struct _ceval_runtime_state ceval;
     struct _gilstate_runtime_state gilstate;
-    struct _getargs_runtime_state getargs;
     struct _fileutils_state fileutils;
     struct _faulthandler_runtime_state faulthandler;
     struct _tracemalloc_runtime_state tracemalloc;

--- a/Include/internal/pycore_runtime.h
+++ b/Include/internal/pycore_runtime.h
@@ -27,6 +27,14 @@ extern "C" {
 #include "pycore_typeobject.h"      // struct types_runtime_state
 #include "pycore_unicodeobject.h"   // struct _Py_unicode_runtime_ids
 
+/* The following struct is moved to interpreter state in 3.13+.
+   We're keeping it here for ABI compat.
+   See also: https://github.com/python/cpython/pull/119194. */
+struct _UNUSED_getargs_runtime_state {
+    PyThread_type_lock mutex;
+    struct _PyArg_Parser *static_parsers;
+};
+
 /* GIL state */
 
 struct _gilstate_runtime_state {
@@ -130,6 +138,7 @@ typedef struct pyruntimestate {
     struct _import_runtime_state imports;
     struct _ceval_runtime_state ceval;
     struct _gilstate_runtime_state gilstate;
+    struct _UNUSED_getargs_runtime_state _UNUSED_gilstate;
     struct _fileutils_state fileutils;
     struct _faulthandler_runtime_state faulthandler;
     struct _tracemalloc_runtime_state tracemalloc;

--- a/Python/getargs.c
+++ b/Python/getargs.c
@@ -4,7 +4,6 @@
 #include "Python.h"
 #include "pycore_tuple.h"         // _PyTuple_ITEMS()
 #include "pycore_pylifecycle.h"   // _PyArg_Fini
-#include "pycore_pyerrors.h"      // _Py_CalculateSuggestions()
 #include "pycore_interp.h"        // _getargs_runtime_state
 
 #include <ctype.h>

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -848,6 +848,8 @@ pycore_interp_init(PyThreadState *tstate)
         return _PyStatus_ERR("can't initialize warnings");
     }
 
+    _PyArg_InitState(interp);
+
     status = _PyAtExit_Init(interp);
     if (_PyStatus_EXCEPTION(status)) {
         return status;
@@ -1751,7 +1753,6 @@ finalize_interp_clear(PyThreadState *tstate)
 
     if (is_main_interp) {
         _Py_HashRandomization_Fini();
-        _PyArg_Fini();
         _Py_ClearFileSystemEncoding();
         _Py_Deepfreeze_Fini();
         _PyPerfTrampoline_Fini();

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -380,12 +380,11 @@ _Py_COMP_DIAG_IGNORE_DEPR_DECLS
 static const _PyRuntimeState initial = _PyRuntimeState_INIT(_PyRuntime);
 _Py_COMP_DIAG_POP
 
-#define NUMLOCKS 9
+#define NUMLOCKS 8
 #define LOCKS_INIT(runtime) \
     { \
         &(runtime)->interpreters.mutex, \
         &(runtime)->xidregistry.mutex, \
-        &(runtime)->getargs.mutex, \
         &(runtime)->unicode_state.ids.lock, \
         &(runtime)->imports.extensions.mutex, \
         &(runtime)->ceval.pending_mainthread.lock, \
@@ -886,6 +885,8 @@ interpreter_clear(PyInterpreterState *interp, PyThreadState *tstate)
     _PyAST_Fini(interp);
     _PyWarnings_Fini(interp);
     _PyAtExit_Fini(interp);
+
+    _PyArg_Fini(interp);
 
     // All Python types must be destroyed before the last GC collection. Python
     // types create a reference cycle to themselves in their in their


### PR DESCRIPTION
...as opposed to storing it in PyRuntime. Storing it in PyRuntime is fundametally wrong, as its state contains references to Python objects. Those objects (tuples and strings) can (and will) be picked by various subinterpreter clean up code, leaving PyRuntime with broken pointers.


<!-- gh-issue-number: gh-119213 -->
* Issue: gh-119213
<!-- /gh-issue-number -->
