### PR TITLE
gh-119213: Fix getargs.c to store state in InterpreterState...

### DIFF
--- a/Include/internal/pycore_interp.h
+++ b/Include/internal/pycore_interp.h
@@ -43,6 +43,10 @@ struct _Py_long_state {
     int max_str_digits;
 };
 
+struct _getargs_runtime_state {
+    struct _PyArg_Parser *static_parsers;
+};
+
 // Support for stop-the-world events. This exists in both the PyRuntime struct
 // for global pauses and in each PyInterpreterState for per-interpreter pauses.
 struct _stoptheworld_state {
@@ -211,6 +215,7 @@ struct _is {
     PyObject *after_forkers_child;
 #endif
 
+    struct _getargs_runtime_state getargs;
     struct _warnings_runtime_state warnings;
     struct atexit_state atexit;
     struct _stoptheworld_state stoptheworld;

--- a/Include/internal/pycore_pylifecycle.h
+++ b/Include/internal/pycore_pylifecycle.h
@@ -57,7 +57,8 @@ extern void _PyWarnings_Fini(PyInterpreterState *interp);
 extern void _PyAST_Fini(PyInterpreterState *interp);
 extern void _PyAtExit_Fini(PyInterpreterState *interp);
 extern void _PyThread_FiniType(PyInterpreterState *interp);
-extern void _PyArg_Fini(void);
+extern void _PyArg_InitState(PyInterpreterState *interp);
+extern void _PyArg_Fini(PyInterpreterState *interp);
 extern void _Py_FinalizeAllocatedBlocks(_PyRuntimeState *);
 
 extern PyStatus _PyGILState_Init(PyInterpreterState *interp);

--- a/Include/internal/pycore_runtime.h
+++ b/Include/internal/pycore_runtime.h
@@ -25,10 +25,6 @@ extern "C" {
 #include "pycore_typeobject.h"      // struct _types_runtime_state
 #include "pycore_unicodeobject.h"   // struct _Py_unicode_runtime_state
 
-struct _getargs_runtime_state {
-    struct _PyArg_Parser *static_parsers;
-};
-
 /* GIL state */
 
 struct _gilstate_runtime_state {
@@ -238,7 +234,6 @@ typedef struct pyruntimestate {
     struct _import_runtime_state imports;
     struct _ceval_runtime_state ceval;
     struct _gilstate_runtime_state gilstate;
-    struct _getargs_runtime_state getargs;
     struct _fileutils_state fileutils;
     struct _faulthandler_runtime_state faulthandler;
     struct _tracemalloc_runtime_state tracemalloc;

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -879,6 +879,8 @@ pycore_interp_init(PyThreadState *tstate)
         return _PyStatus_ERR("can't initialize warnings");
     }
 
+    _PyArg_InitState(interp);
+
     status = _PyAtExit_Init(interp);
     if (_PyStatus_EXCEPTION(status)) {
         return status;
@@ -1875,7 +1877,6 @@ finalize_interp_clear(PyThreadState *tstate)
 
     if (is_main_interp) {
         _Py_HashRandomization_Fini();
-        _PyArg_Fini();
         _Py_ClearFileSystemEncoding();
         _PyPerfTrampoline_Fini();
         _PyPerfTrampoline_FreeArenas();

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -864,6 +864,8 @@ interpreter_clear(PyInterpreterState *interp, PyThreadState *tstate)
     _PyWarnings_Fini(interp);
     _PyAtExit_Fini(interp);
 
+    _PyArg_Fini(interp);
+
     // All Python types must be destroyed before the last GC collection. Python
     // types create a reference cycle to themselves in their in their
     // PyTypeObject.tp_mro member (the tuple contains the type).


### PR DESCRIPTION
...as opposed to storing it in PyRuntime. Storing it in PyRuntime
is fundametally wrong, as its state contains references to Python
objects. Those objects (tuples and strings) can (and will) be
picked by various subinterpreter clean up code, leaving PyRuntime
with broken pointers.

https://github.com/python/cpython/pull/119194 is a backport to 3.12

<!-- gh-issue-number: gh-119213 -->
* Issue: gh-119213
<!-- /gh-issue-number -->
