### PR TITLE
gh-115119: Fall back to bundled libmpdec if system libmpdec is not found

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2024-05-19-22-54-55.gh-issue-115119.DwMwev.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2024-05-19-22-54-55.gh-issue-115119.DwMwev.rst
@@ -1,0 +1,1 @@
+Fall back to the bundled libmpdec if a system version cannot be found.

--- a/configure
+++ b/configure
@@ -14618,6 +14618,8 @@ fi
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $with_system_libmpdec" >&5
 printf "%s\n" "$with_system_libmpdec" >&6; }
 
+
+
 if test "x$with_system_libmpdec" = xyes
 then :
 
@@ -14697,8 +14699,10 @@ printf "%s\n" "yes" >&6; }
 fi
 else $as_nop
   LIBMPDEC_CFLAGS="-I\$(srcdir)/Modules/_decimal/libmpdec"
-   LIBMPDEC_LIBS="-lm \$(LIBMPDEC_A)"
-   LIBMPDEC_INTERNAL="\$(LIBMPDEC_HEADERS) \$(LIBMPDEC_A)"
+          LIBMPDEC_LIBS="-lm \$(LIBMPDEC_A)"
+          LIBMPDEC_INTERNAL="\$(LIBMPDEC_HEADERS) \$(LIBMPDEC_A)"
+          have_mpdec=yes
+          with_system_libmpdec=no
 fi
 
 if test "x$with_system_libmpdec" = xyes
@@ -14745,15 +14749,19 @@ LIBS=$save_LIBS
 
 
 else $as_nop
-  have_mpdec=yes
-   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: the bundled copy of libmpdecimal is scheduled for removal in Python 3.15; consider using a system installed mpdecimal library." >&5
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: the bundled copy of libmpdecimal is scheduled for removal in Python 3.15; consider using a system installed mpdecimal library." >&5
 printf "%s\n" "$as_me: WARNING: the bundled copy of libmpdecimal is scheduled for removal in Python 3.15; consider using a system installed mpdecimal library." >&2;}
 fi
 
 if test "$with_system_libmpdec" = "yes" && test "$have_mpdec" = "no"
 then :
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: no system libmpdecimal found; unable to build _decimal" >&5
-printf "%s\n" "$as_me: WARNING: no system libmpdecimal found; unable to build _decimal" >&2;}
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: no system libmpdecimal found; falling back to bundled libmpdecimal (deprecated and scheduled for removal in Python 3.15)" >&5
+printf "%s\n" "$as_me: WARNING: no system libmpdecimal found; falling back to bundled libmpdecimal (deprecated and scheduled for removal in Python 3.15)" >&2;}
+       LIBMPDEC_CFLAGS="-I\$(srcdir)/Modules/_decimal/libmpdec"
+          LIBMPDEC_LIBS="-lm \$(LIBMPDEC_A)"
+          LIBMPDEC_INTERNAL="\$(LIBMPDEC_HEADERS) \$(LIBMPDEC_A)"
+          have_mpdec=yes
+          with_system_libmpdec=no
 fi
 
 # Disable forced inlining in debug builds, see GH-94847

--- a/configure.ac
+++ b/configure.ac
@@ -3980,6 +3980,13 @@ AC_ARG_WITH(
   [with_system_libmpdec="yes"])
 AC_MSG_RESULT([$with_system_libmpdec])
 
+AC_DEFUN([USE_BUNDLED_LIBMPDEC],
+         [LIBMPDEC_CFLAGS="-I\$(srcdir)/Modules/_decimal/libmpdec"
+          LIBMPDEC_LIBS="-lm \$(LIBMPDEC_A)"
+          LIBMPDEC_INTERNAL="\$(LIBMPDEC_HEADERS) \$(LIBMPDEC_A)"
+          have_mpdec=yes
+          with_system_libmpdec=no])
+
 AS_VAR_IF(
   [with_system_libmpdec], [yes],
   [PKG_CHECK_MODULES(
@@ -3987,9 +3994,7 @@ AS_VAR_IF(
     [LIBMPDEC_CFLAGS=${LIBMPDEC_CFLAGS-""}
      LIBMPDEC_LIBS=${LIBMPDEC_LIBS-"-lmpdec -lm"}
      LIBMPDEC_INTERNAL=])],
-  [LIBMPDEC_CFLAGS="-I\$(srcdir)/Modules/_decimal/libmpdec"
-   LIBMPDEC_LIBS="-lm \$(LIBMPDEC_A)"
-   LIBMPDEC_INTERNAL="\$(LIBMPDEC_HEADERS) \$(LIBMPDEC_A)"])
+  [USE_BUNDLED_LIBMPDEC()])
 
 AS_VAR_IF([with_system_libmpdec], [yes],
   [WITH_SAVE_ENV([
@@ -4006,13 +4011,15 @@ AS_VAR_IF([with_system_libmpdec], [yes],
       [have_mpdec=yes],
       [have_mpdec=no])
   ])],
-  [AS_VAR_SET([have_mpdec], [yes])
-   AC_MSG_WARN([m4_normalize([
+  [AC_MSG_WARN([m4_normalize([
      the bundled copy of libmpdecimal is scheduled for removal in Python 3.15;
      consider using a system installed mpdecimal library.])])])
 
 AS_IF([test "$with_system_libmpdec" = "yes" && test "$have_mpdec" = "no"],
-      [AC_MSG_WARN([no system libmpdecimal found; unable to build _decimal])])
+      [AC_MSG_WARN([m4_normalize([
+         no system libmpdecimal found; falling back to bundled libmpdecimal
+         (deprecated and scheduled for removal in Python 3.15)])])
+       USE_BUNDLED_LIBMPDEC()])
 
 # Disable forced inlining in debug builds, see GH-94847
 AS_VAR_IF(


### PR DESCRIPTION
```sh
$ brew unlink libmpdec
$ ./configure --with-system-libmpdec | grep -E "(decimal|mpdec)"
checking for --with-system-libmpdec... yes
checking for libmpdec >= 2.5.0... no
configure: WARNING: no system libmpdecimal found; falling back to bundled libmpdecimal (deprecated and scheduled for removal in Python 3.15)
checking for --with-decimal-contextvar... yes
checking for decimal libmpdec machine... universal
checking for stdlib extension module _decimal... yes
$ grep 'DECIMAL_.*FLAGS' Makefile
MODULE__DECIMAL_CFLAGS=-I$(srcdir)/Modules/_decimal/libmpdec -DUNIVERSAL=1
MODULE__DECIMAL_LDFLAGS=-lm $(LIBMPDEC_A)

$ ./configure | grep -E "(decimal|mpdec)"
checking for --with-system-libmpdec... yes
checking for libmpdec >= 2.5.0... no
configure: WARNING: no system libmpdecimal found; falling back to bundled libmpdecimal (deprecated and scheduled for removal in Python 3.15)
checking for --with-decimal-contextvar... yes
checking for decimal libmpdec machine... universal
checking for stdlib extension module _decimal... yes
$ grep 'DECIMAL_.*FLAGS' Makefile
MODULE__DECIMAL_CFLAGS=-I$(srcdir)/Modules/_decimal/libmpdec -DUNIVERSAL=1
MODULE__DECIMAL_LDFLAGS=-lm $(LIBMPDEC_A)

$ ./configure --without-system-libmpdec | grep -E "(decimal|mpdec)"
checking for --with-system-libmpdec... no
configure: WARNING: the bundled copy of libmpdecimal is scheduled for removal in Python 3.15; consider using a system installed mpdecimal library.
checking for --with-decimal-contextvar... yes
checking for decimal libmpdec machine... universal
checking for stdlib extension module _decimal... yes
$ grep ‘DECIMAL_.*FLAGS’ Makefile
MODULE__DECIMAL_CFLAGS=-I$(srcdir)/Modules/_decimal/libmpdec -DUNIVERSAL=1
MODULE__DECIMAL_LDFLAGS=-lm $(LIBMPDEC_A)

$ brew link libmpdec
$ ./configure --with-system-libmpdec | grep -E "(decimal|mpdec)"
checking for --with-system-libmpdec... yes
checking for libmpdec >= 2.5.0... yes
checking for --with-decimal-contextvar... yes
checking for stdlib extension module _decimal... yes
$ grep ‘DECIMAL_.*FLAGS’ Makefile
MODULE__DECIMAL_CFLAGS=-I/opt/homebrew/Cellar/mpdecimal/4.0.0/include
MODULE__DECIMAL_LDFLAGS=-L/opt/homebrew/Cellar/mpdecimal/4.0.0/lib -lmpdec -lm
```

<!-- gh-issue-number: gh-115119 -->
* Issue: gh-115119
<!-- /gh-issue-number -->
