### PR TITLE
gh-119176: Add `copy` and `clear` to `multiprocessing.ListProxy`

### DIFF
--- a/Lib/multiprocessing/managers.py
+++ b/Lib/multiprocessing/managers.py
@@ -1155,7 +1155,7 @@ BaseListProxy = MakeProxyType('BaseListProxy', (
     '__add__', '__contains__', '__delitem__', '__getitem__', '__len__',
     '__mul__', '__reversed__', '__rmul__', '__setitem__',
     'append', 'count', 'extend', 'index', 'insert', 'pop', 'remove',
-    'reverse', 'sort', '__imul__'
+    'reverse', 'sort', '__imul__', 'clear', 'copy',
     ))
 class ListProxy(BaseListProxy):
     def __iadd__(self, value):

--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -2314,6 +2314,13 @@ class _TestContainers(BaseTestCase):
         a.append('hello')
         self.assertEqual(f[0][:], [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 'hello'])
 
+        e2 = e.copy()
+        self.assertEqual([element[:] for element in e],
+                         [element[:] for element in e2])
+
+        e2.clear()
+        self.assertEqual(e2[:], [])
+
     def test_list_iter(self):
         a = self.list(list(range(10)))
         it = iter(a)

--- a/Misc/NEWS.d/next/Library/2024-05-20-12-34-32.gh-issue-119176.I2Br-T.rst
+++ b/Misc/NEWS.d/next/Library/2024-05-20-12-34-32.gh-issue-119176.I2Br-T.rst
@@ -1,0 +1,2 @@
+Add ``copy`` and ``clear`` methods support to
+``multiprocessing.manager.ListProxy``.


### PR DESCRIPTION
I think that adding `clear` is fine, because we already have `.remove` which can do the same.
I also think that `copy` must be added, since this is the only method that is missing from `list`.

<!-- gh-issue-number: gh-119176 -->
* Issue: gh-119176
<!-- /gh-issue-number -->
