### PR TITLE
Added reference for return_value in unittest.mock documentation

### DIFF
--- a/Doc/library/unittest.mock.rst
+++ b/Doc/library/unittest.mock.rst
@@ -414,13 +414,13 @@ the *new_callable* argument to :func:`patch`.
 
         This can be useful where you want to make a series of assertions that
         reuse the same object. Note that :meth:`reset_mock` *doesn't* clear the
-        return value, :attr:`side_effect` or any child attributes you have
+        :attr:`return_value`, :attr:`side_effect` or any child attributes you have
         set using normal assignment by default. In case you want to reset
-        *return_value* or :attr:`side_effect`, then pass the corresponding
+        :attr:`return_value` or :attr:`side_effect`, then pass the corresponding
         parameter as ``True``. Child mocks and the return value mock
         (if any) are reset as well.
 
-        .. note:: :attr:`return_value`, and :attr:`side_effect` are keyword-only
+        .. note:: *return_value*, and *side_effect* are keyword-only
                   arguments.
 
 

--- a/Doc/library/unittest.mock.rst
+++ b/Doc/library/unittest.mock.rst
@@ -420,7 +420,7 @@ the *new_callable* argument to :func:`patch`.
         parameter as ``True``. Child mocks and the return value mock
         (if any) are reset as well.
 
-        .. note:: *return_value*, and :attr:`side_effect` are keyword-only
+        .. note:: :attr:`return_value`, and :attr:`side_effect` are keyword-only
                   arguments.
 
 


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
Added reference for `return_value` in documentation

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--119207.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->