### PR TITLE
gh-118928: Remove unneeded NEWS entry

### DIFF
--- a/Misc/NEWS.d/next/Library/2024-05-19-23-09-36.gh-issue-118928.SznMX1.rst
+++ b/Misc/NEWS.d/next/Library/2024-05-19-23-09-36.gh-issue-118928.SznMX1.rst
@@ -1,2 +1,0 @@
-Fix an error where incorrect bindings in :mod:`sqlite3` queries could lead
-to a crash. Patch by Erlend E. Aasland.


### PR DESCRIPTION
The regression was never part of an official release.


<!-- gh-issue-number: gh-118928 -->
* Issue: gh-118928
<!-- /gh-issue-number -->
