### PR TITLE
typing docs: Fix formatting issue

### DIFF
--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -2546,7 +2546,7 @@ types.
          ``__required_keys__`` and ``__optional_keys__`` rely on may not work
          properly, and the values of the attributes may be incorrect.
 
-   Support for :data:`ReadOnly` is reflected in the following attributes::
+   Support for :data:`ReadOnly` is reflected in the following attributes:
 
    .. attribute:: __readonly_keys__
 


### PR DESCRIPTION
Fix an RST formatting issue. See screenshots below for details:

**Before**:
![before](https://github.com/python/cpython/assets/764688/5a2284ab-91d9-4bd4-8a1d-a7b168dbfa2c)

**After:**
<img width="1284" alt="after" src="https://github.com/python/cpython/assets/764688/83740d36-194d-48a8-ac67-48573937f241">


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--119210.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->