### PR TITLE
[docs] TypeVarTuple default is keyword-only

### DIFF
--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -1780,7 +1780,7 @@ without the dedicated syntax, as documented below.
 
 .. _typevartuple:
 
-.. class:: TypeVarTuple(name, default=typing.NoDefault)
+.. class:: TypeVarTuple(name, *, default=typing.NoDefault)
 
    Type variable tuple. A specialized form of :ref:`type variable <typevar>`
    that enables *variadic* generics.


### PR DESCRIPTION
Cc @JelleZijlstra 

Does this need a NEWS entry?

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--119215.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->