### PR TITLE
Docs: Ensure no warnings are found in the NEWS file before a given line number

### DIFF
--- a/.github/workflows/reusable-docs.yml
+++ b/.github/workflows/reusable-docs.yml
@@ -62,7 +62,8 @@ jobs:
         python Doc/tools/check-warnings.py \
           --annotate-diff '${{ env.branch_base }}' '${{ env.branch_pr }}' \
           --fail-if-regression \
-          --fail-if-improved
+          --fail-if-improved \
+          --fail-if-new-news-nit
 
   # This build doesn't use problem matchers or check annotations
   build_doc_oldest_supported_sphinx:

--- a/Misc/NEWS.d/next/Core and Builtins/2024-05-07-16-57-56.gh-issue-118561.wNMKVd.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2024-05-07-16-57-56.gh-issue-118561.wNMKVd.rst
@@ -1,2 +1,2 @@
-Fix race condition in free-threaded build where :meth:`list.extend` could expose
-uninitialied memory to concurrent readers.
+Fix race condition in free-threaded build where :meth:`!list.extend` could
+expose uninitialised memory to concurrent readers.

--- a/Misc/NEWS.d/next/Library/2023-04-10-00-04-37.gh-issue-87106.UyBnPQ.rst
+++ b/Misc/NEWS.d/next/Library/2023-04-10-00-04-37.gh-issue-87106.UyBnPQ.rst
@@ -1,3 +1,3 @@
-Fixed handling in :meth:`inspect.signature.bind` of keyword arguments having
+Fixed handling in :meth:`inspect.Signature.bind` of keyword arguments having
 the same name as positional-only arguments when a variadic keyword argument
 (e.g. ``**kwargs``) is present.

--- a/Misc/NEWS.d/next/Library/2024-05-08-19-47-34.gh-issue-101357.e4R_9x.rst
+++ b/Misc/NEWS.d/next/Library/2024-05-08-19-47-34.gh-issue-101357.e4R_9x.rst
@@ -1,5 +1,5 @@
 Suppress all :exc:`OSError` exceptions from :meth:`pathlib.Path.exists` and
 ``is_*()`` methods, rather than a selection of more common errors. The new
 behaviour is consistent with :func:`os.path.exists`, :func:`os.path.isdir`,
-etc. Use :meth:`Path.stat` to retrieve the file status without suppressing
-exceptions.
+etc. Use :meth:`pathlib.Path.stat` to retrieve the file status without
+suppressing exceptions.

--- a/Misc/NEWS.d/next/Security/2024-05-08-21-59-38.gh-issue-118773.7dFRJY.rst
+++ b/Misc/NEWS.d/next/Security/2024-05-08-21-59-38.gh-issue-118773.7dFRJY.rst
@@ -1,2 +1,2 @@
-Fixes creation of ACLs in :func:`os.mkdir` on Windows to work correctly on
+Fixes creation of ACLs in :func:`os.mkdir`` on Windows to work correctly on
 non-English machines.

--- a/Misc/NEWS.d/next/Security/2024-05-08-21-59-38.gh-issue-118773.7dFRJY.rst
+++ b/Misc/NEWS.d/next/Security/2024-05-08-21-59-38.gh-issue-118773.7dFRJY.rst
@@ -1,2 +1,2 @@
-Fixes creation of ACLs in :func:`os.mkdir`` on Windows to work correctly on
+Fixes creation of ACLs in :func:`os.mkdir` on Windows to work correctly on
 non-English machines.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

Re: https://github.com/python/cpython/pull/118694#discussion_r1593562896

We have tooling in place to ensure reST files under `Doc/` don't introduce new Sphinx reference warnings.

We ignore those that are in `.nitignore` because they've not been "cleaned" yet, because we don't want to hassle people over warnings which they didn't introduce.

Similarly, we ignore the news files under `Misc/NEWS.d/`, because during the Sphinx build, [blurb](https://github.com/python/blurb) compiles then into a giant 45k line `build/NEWS` which has 700+ warnings (and growing, because we don't check them).

<img width="881" alt="image" src="https://github.com/python/cpython/assets/1324225/1dbf5974-224c-4a86-821e-b2e48b2ee02e">

We do lint the news files with Sphinx Lint, but that doesn't catch everything, especially not bad references.

And so we don't want to warn for every single PR that adds a small NEWS blurb about those 700 warnings that they didn't introduce.

New entries are added to the top of the compiled NEWS file.

This PR adds a check to ensure the top 200 lines remain clean. Most NEWS entries are under 10 lines long, and the biggest right now is 18 lines, so checking the top 200 will prevent new warnings being introduced.

I cleaned the top 200 lines (3 news files), but also introduced one temporarily to demonstrate how the CI fails. I'll revert that commit before merge.


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--119221.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->