### PR TITLE
gh-94808: Add test coverage for "starred kind" in _PyPegen_set_expr_context

### DIFF
--- a/Lib/test/test_unpack_ex.py
+++ b/Lib/test/test_unpack_ex.py
@@ -26,6 +26,12 @@ Unpack implied tuple
     >>> a == [7, 8, 9]
     True
 
+Unpack nested implied tuple
+
+    >>> [*[*a]] = [[7,8,9]]
+    >>> a == [[7,8,9]]
+    True
+
 Unpack string... fun!
 
     >>> a, *b = 'one'


### PR DESCRIPTION
# gh-94808: Add test coverage for "starred kind" in _PyPegen_set_expr_context

That item is on the gh-94808 checklist, but not checked off.  I ran `lcov` to confirm that the branch was not covered, added and ran the test, and rebuilt the coverage report to confirm that the branch had now been covered.

This pertains to the production

```
star_target[expr_ty] (memo):
    | '*' a=(!'*' star_target) {
        _PyAST_Starred(CHECK(expr_ty, _PyPegen_set_expr_context(p, a, Store)), Store,
 EXTRA) }
    | target_with_star_atom
```
at line 1057 in `python.gram`.

Thanks to @encukou for much guidance through this process.

