### PR TITLE
gh-94808: Remove unused code in _make_posargs

### DIFF
--- a/Parser/action_helpers.c
+++ b/Parser/action_helpers.c
@@ -555,7 +555,10 @@ _make_posargs(Parser *p,
         *posargs = _get_names(p, names_with_default);
     }
     else if (plain_names != NULL && names_with_default == NULL) {
-        *posargs = plain_names;
+	// With the current grammar, we never get here.
+	// If that has changed, remove the assert, and test thoroughly.
+	assert(0);
+	*posargs = plain_names;
     }
     else {
         *posargs = _Py_asdl_arg_seq_new(0, p->arena);

--- a/Parser/action_helpers.c
+++ b/Parser/action_helpers.c
@@ -543,25 +543,30 @@ _make_posargs(Parser *p,
               asdl_arg_seq *plain_names,
               asdl_seq *names_with_default,
               asdl_arg_seq **posargs) {
-    if (plain_names != NULL && names_with_default != NULL) {
-        asdl_arg_seq *names_with_default_names = _get_names(p, names_with_default);
-        if (!names_with_default_names) {
-            return -1;
+
+    if (names_with_default != NULL) {
+        if (plain_names != NULL) {
+            asdl_arg_seq *names_with_default_names = _get_names(p, names_with_default);
+            if (!names_with_default_names) {
+                return -1;
+            }
+            *posargs = (asdl_arg_seq*)_PyPegen_join_sequences(
+                    p,(asdl_seq*)plain_names, (asdl_seq*)names_with_default_names);
         }
-        *posargs = (asdl_arg_seq*)_PyPegen_join_sequences(
-                p,(asdl_seq*)plain_names, (asdl_seq*)names_with_default_names);
-    }
-    else if (plain_names == NULL && names_with_default != NULL) {
-        *posargs = _get_names(p, names_with_default);
-    }
-    else if (plain_names != NULL && names_with_default == NULL) {
-	// With the current grammar, we never get here.
-	// If that has changed, remove the assert, and test thoroughly.
-	assert(0);
-	*posargs = plain_names;
+        else {
+            *posargs = _get_names(p, names_with_default);
+        }
     }
     else {
-        *posargs = _Py_asdl_arg_seq_new(0, p->arena);
+        if (plain_names != NULL) {
+            // With the current grammar, we never get here.
+            // If that has changed, remove the assert, and test thoroughly.
+            assert(0);
+            *posargs = plain_names;
+        }
+        else {
+            *posargs = _Py_asdl_arg_seq_new(0, p->arena);
+        }
     }
     return *posargs == NULL ? -1 : 0;
 }


### PR DESCRIPTION
The coverage report indicates that this branch is never exercised.  That appears to be because it is unused code.  When I couldn't produce a test case that exercised it, I removed the branch, then checked that the complete test suite still passed. 

The branch is only run when `names_with_default` is null.  It appears that when there are no names with defaults, `names_with_defaults` will point to a structure that has `.size` zero.

It's possible that a future implementation change might alter that, requiring the branch to be put back, but I believe the existing tests would detect if that happened.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-94808 -->
* Issue: gh-94808
<!-- /gh-issue-number -->
