### PR TITLE
Fixing a bug by remove the implicit cast to float if the class implements __rpow__ .

### DIFF
--- a/Lib/fractions.py
+++ b/Lib/fractions.py
@@ -875,8 +875,12 @@ class Fraction(numbers.Rational):
                 # A fractional power will generally produce an
                 # irrational number.
                 return float(a) ** float(b)
-        else:
+
+        elif isinstance(b, (float, complex)):
             return float(a) ** b
+
+        else:
+            return NotImplemented
 
     def __rpow__(b, a):
         """a ** b"""

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -750,6 +750,7 @@ James Henstridge
 Kasun Herath
 Chris Herborth
 Ivan Herman
+Joshua Jay Herman
 Jürgen Hermann
 Gary Herron
 Ernie Hershey

--- a/Misc/NEWS.d/next/Library/2024-05-20-10-16-55.gh-issue-119189.KoYG89.rst
+++ b/Misc/NEWS.d/next/Library/2024-05-20-10-16-55.gh-issue-119189.KoYG89.rst
@@ -1,0 +1,2 @@
+Fixes a bug where fractions will not be casted into float when given as
+argument to __rpow__


### PR DESCRIPTION
The fraction module would cast classes that have __rpow__ into floats. This change removes the implicit cast and if __rpow__ isn't there it will raise an exception.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-119189: Fixing a bug by remove the implicit cast to float if the class implements __rpow__ .
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
