### PR TITLE
Remove almost all unpaired backticks in docstrings

### DIFF
--- a/Lib/_pyrepl/keymap.py
+++ b/Lib/_pyrepl/keymap.py
@@ -30,20 +30,20 @@ sequence.
 pyrepl uses its own keyspec format that is meant to be a strict superset of
 readline's KEYSEQ format. This means that if a spec is found that readline
 accepts that this doesn't, it should be logged as a bug. Note that this means
-we're using the `\\C-o' style of readline's keyspec, not the `Control-o' sort.
+we're using the '\\C-o' style of readline's keyspec, not the 'Control-o' sort.
 
 The extension to readline is that the sequence \\<KEY> denotes the
 sequence of characters produced by hitting KEY.
 
 Examples:
-`a'      - what you get when you hit the `a' key
-`\\EOA'  - Escape - O - A (up, on my terminal)
-`\\<UP>' - the up arrow key
-`\\<up>' - ditto (keynames are case-insensitive)
-`\\C-o', `\\c-o'  - control-o
-`\\M-.'  - meta-period
-`\\E.'   - ditto (that's how meta works for pyrepl)
-`\\<tab>', `\\<TAB>', `\\t', `\\011', '\\x09', '\\X09', '\\C-i', '\\C-I'
+'a'      - what you get when you hit the 'a' key
+'\\EOA'  - Escape - O - A (up, on my terminal)
+'\\<UP>' - the up arrow key
+'\\<up>' - ditto (keynames are case-insensitive)
+'\\C-o', '\\c-o'  - control-o
+'\\M-.'  - meta-period
+'\\E.'   - ditto (that's how meta works for pyrepl)
+'\\<tab>', '\\<TAB>', '\\t', '\\011', '\\x09', '\\X09', '\\C-i', '\\C-I'
    - all of these are the tab character.
 """
 

--- a/Lib/_pyrepl/reader.py
+++ b/Lib/_pyrepl/reader.py
@@ -171,7 +171,7 @@ class Reader:
       * console:
         Hopefully encapsulates the OS dependent stuff.
       * pos:
-        A 0-based index into `buffer' for where the insertion point
+        A 0-based index into 'buffer' for where the insertion point
         is.
       * screeninfo:
         Ahem.  This list contains some info needed to move the
@@ -179,7 +179,7 @@ class Reader:
       * cxy, lxy:
         the position of the insertion point in screen ...
       * syntax_table:
-        Dictionary mapping characters to `syntax class'; read the
+        Dictionary mapping characters to 'syntax class'; read the
         emacs docs to see what this means :-)
       * commands:
         Dictionary mapping command names to command classes.
@@ -431,7 +431,7 @@ class Reader:
 
     def get_arg(self, default: int = 1) -> int:
         """Return any prefix argument that the user has supplied,
-        returning `default' if there is None.  Defaults to 1.
+        returning 'default' if there is None.  Defaults to 1.
         """
         if self.arg is None:
             return default
@@ -440,7 +440,7 @@ class Reader:
 
     def get_prompt(self, lineno: int, cursor_on_line: bool) -> str:
         """Return what should be in the left-hand margin for line
-        `lineno'."""
+        'lineno'."""
         if self.arg is not None and cursor_on_line:
             prompt = "(arg: %s) " % self.arg
         elif self.paste_mode:

--- a/Lib/cmd.py
+++ b/Lib/cmd.py
@@ -5,16 +5,16 @@ Interpreters constructed with this class obey the following conventions:
 1. End of file on input is processed as the command 'EOF'.
 2. A command is parsed out of each line by collecting the prefix composed
    of characters in the identchars member.
-3. A command `foo' is dispatched to a method 'do_foo()'; the do_ method
+3. A command 'foo' is dispatched to a method 'do_foo()'; the do_ method
    is passed a single argument consisting of the remainder of the line.
 4. Typing an empty line repeats the last command.  (Actually, it calls the
-   method `emptyline', which may be overridden in a subclass.)
-5. There is a predefined `help' method.  Given an argument `topic', it
-   calls the command `help_topic'.  With no arguments, it lists all topics
+   method 'emptyline', which may be overridden in a subclass.)
+5. There is a predefined 'help' method.  Given an argument 'topic', it
+   calls the command 'help_topic'.  With no arguments, it lists all topics
    with defined help_ functions, broken into up to three topics; documented
    commands, miscellaneous help topics, and undocumented commands.
-6. The command '?' is a synonym for `help'.  The command '!' is a synonym
-   for `shell', if a do_shell method exists.
+6. The command '?' is a synonym for 'help'.  The command '!' is a synonym
+   for 'shell', if a do_shell method exists.
 7. If completion is enabled, completing commands will be done automatically,
    and completing of commands args is done by calling complete_foo() with
    arguments text, line, begidx, endidx.  text is string we are matching
@@ -23,21 +23,21 @@ Interpreters constructed with this class obey the following conventions:
    indexes of the text being matched, which could be used to provide
    different completion depending upon which position the argument is in.
 
-The `default' method may be overridden to intercept commands for which there
+The 'default' method may be overridden to intercept commands for which there
 is no do_ method.
 
-The `completedefault' method may be overridden to intercept completions for
+The 'completedefault' method may be overridden to intercept completions for
 commands that have no complete_ method.
 
-The data member `self.ruler' sets the character used to draw separator lines
+The data member 'self.ruler' sets the character used to draw separator lines
 in the help messages.  If empty, no ruler line is drawn.  It defaults to "=".
 
-If the value of `self.intro' is nonempty when the cmdloop method is called,
+If the value of 'self.intro' is nonempty when the cmdloop method is called,
 it is printed out on interpreter startup.  This value may be overridden
 via an optional argument to the cmdloop() method.
 
-The data members `self.doc_header', `self.misc_header', and
-`self.undoc_header' set the headers used for the help function's
+The data members 'self.doc_header', 'self.misc_header', and
+'self.undoc_header' set the headers used for the help function's
 listings of documented functions, miscellaneous topics, and undocumented
 functions respectively.
 """

--- a/Lib/configparser.py
+++ b/Lib/configparser.py
@@ -957,7 +957,7 @@ class RawConfigParser(MutableMapping):
                                 self._sections[section].items(), d)
 
     def _write_section(self, fp, section_name, section_items, delimiter, unnamed=False):
-        """Write a single section to the specified `fp'."""
+        """Write a single section to the specified 'fp'."""
         if not unnamed:
             fp.write("[{}]\n".format(section_name))
         for key, value in section_items:

--- a/Lib/doctest.py
+++ b/Lib/doctest.py
@@ -1227,7 +1227,7 @@ class DocTestRunner:
     `OutputChecker` to the constructor.
 
     The test runner's display output can be controlled in two ways.
-    First, an output function (`out) can be passed to
+    First, an output function (`out`) can be passed to
     `TestRunner.run`; this function will be called with strings that
     should be displayed.  It defaults to `sys.stdout.write`.  If
     capturing the output is not sufficient, then the display output
@@ -2734,7 +2734,7 @@ def testsource(module, name):
     return testsrc
 
 def debug_src(src, pm=False, globs=None):
-    """Debug a single doctest docstring, in argument `src`'"""
+    """Debug a single doctest docstring, in argument `src`"""
     testsrc = script_from_examples(src)
     debug_script(testsrc, pm, globs)
 

--- a/Lib/email/_parseaddr.py
+++ b/Lib/email/_parseaddr.py
@@ -224,7 +224,7 @@ class AddrlistClass:
     def __init__(self, field):
         """Initialize a new instance.
 
-        `field' is an unparsed address header field, containing
+        'field' is an unparsed address header field, containing
         one or more addresses.
         """
         self.specials = '()<>@,:;.\"[]'
@@ -233,7 +233,7 @@ class AddrlistClass:
         self.CR = '\r\n'
         self.FWS = self.LWS + self.CR
         self.atomends = self.specials + self.LWS + self.CR
-        # Note that RFC 2822 now specifies `.' as obs-phrase, meaning that it
+        # Note that RFC 2822 now specifies '.' as obs-phrase, meaning that it
         # is obsolete syntax.  RFC 2822 requires that we recognize obsolete
         # syntax, so allow dots in phrases.
         self.phraseends = self.atomends.replace('.', '')
@@ -423,14 +423,14 @@ class AddrlistClass:
     def getdelimited(self, beginchar, endchars, allowcomments=True):
         """Parse a header fragment delimited by special characters.
 
-        `beginchar' is the start character for the fragment.
-        If self is not looking at an instance of `beginchar' then
+        'beginchar' is the start character for the fragment.
+        If self is not looking at an instance of 'beginchar' then
         getdelimited returns the empty string.
 
-        `endchars' is a sequence of allowable end-delimiting characters.
+        'endchars' is a sequence of allowable end-delimiting characters.
         Parsing stops when one of these is encountered.
 
-        If `allowcomments' is non-zero, embedded RFC 2822 comments are allowed
+        If 'allowcomments' is non-zero, embedded RFC 2822 comments are allowed
         within the parsed fragment.
         """
         if self.field[self.pos] != beginchar:
@@ -474,7 +474,7 @@ class AddrlistClass:
 
         Optional atomends specifies a different set of end token delimiters
         (the default is to use self.atomends).  This is used e.g. in
-        getphraselist() since phrase endings must not include the `.' (which
+        getphraselist() since phrase endings must not include the '.' (which
         is legal in phrases)."""
         atomlist = ['']
         if atomends is None:

--- a/Lib/email/_policybase.py
+++ b/Lib/email/_policybase.py
@@ -150,7 +150,7 @@ class Policy(_PolicyBase, metaclass=abc.ABCMeta):
                            wrapping is done.  Default is 78.
 
     mangle_from_        -- a flag that, when True escapes From_ lines in the
-                           body of the message by putting a `>' in front of
+                           body of the message by putting a '>' in front of
                            them. This is used when the message is being
                            serialized by a generator. Default: False.
 

--- a/Lib/email/base64mime.py
+++ b/Lib/email/base64mime.py
@@ -15,7 +15,7 @@ This module provides an interface to encode and decode both headers and bodies
 with Base64 encoding.
 
 RFC 2045 defines a method for including character set information in an
-`encoded-word' in a header.  This method is commonly used for 8-bit real names
+'encoded-word' in a header.  This method is commonly used for 8-bit real names
 in To:, From:, Cc:, etc. fields, as well as Subject: lines.
 
 This module does not do the line wrapping or end-of-line character conversion

--- a/Lib/email/charset.py
+++ b/Lib/email/charset.py
@@ -175,7 +175,7 @@ class Charset:
     module expose the following information about a character set:
 
     input_charset: The initial character set specified.  Common aliases
-                   are converted to their `official' email names (e.g. latin_1
+                   are converted to their 'official' email names (e.g. latin_1
                    is converted to iso-8859-1).  Defaults to 7-bit us-ascii.
 
     header_encoding: If the character set must be encoded before it can be
@@ -245,7 +245,7 @@ class Charset:
     def get_body_encoding(self):
         """Return the content-transfer-encoding used for body encoding.
 
-        This is either the string `quoted-printable' or `base64' depending on
+        This is either the string 'quoted-printable' or 'base64' depending on
         the encoding used, or it is a function in which case you should call
         the function with a single argument, the Message object being
         encoded.  The function should then set the Content-Transfer-Encoding

--- a/Lib/email/generator.py
+++ b/Lib/email/generator.py
@@ -41,7 +41,7 @@ class Generator:
 
         Optional mangle_from_ is a flag that, when True (the default if policy
         is not set), escapes From_ lines in the body of the message by putting
-        a `>' in front of them.
+        a '>' in front of them.
 
         Optional maxheaderlen specifies the longest length for a non-continued
         header.  When a header line is longer (in characters, with tabs
@@ -74,7 +74,7 @@ class Generator:
 
         unixfrom is a flag that forces the printing of a Unix From_ delimiter
         before the first object in the message tree.  If the original message
-        has no From_ delimiter, a `standard' one is crafted.  By default, this
+        has no From_ delimiter, a 'standard' one is crafted.  By default, this
         is False to inhibit the printing of any From_ delimiter.
 
         Note that for subobjects, no From_ line is printed.
@@ -456,7 +456,7 @@ class DecodedGenerator(Generator):
         argument is allowed.
 
         Walks through all subparts of a message.  If the subpart is of main
-        type `text', then it prints the decoded payload of the subpart.
+        type 'text', then it prints the decoded payload of the subpart.
 
         Otherwise, fmt is a format string that is used instead of the message
         payload.  fmt is expanded with the following keywords (in

--- a/Lib/email/header.py
+++ b/Lib/email/header.py
@@ -192,7 +192,7 @@ class Header:
 
         The maximum line length can be specified explicitly via maxlinelen. For
         splitting the first line to a shorter value (to account for the field
-        header which isn't included in s, e.g. `Subject') pass in the name of
+        header which isn't included in s, e.g. 'Subject') pass in the name of
         the field in header_name.  The default maxlinelen is 78 as recommended
         by RFC 2822.
 
@@ -276,7 +276,7 @@ class Header:
         output codec of the charset.  If the string cannot be encoded to the
         output codec, a UnicodeError will be raised.
 
-        Optional `errors' is passed as the errors argument to the decode
+        Optional 'errors' is passed as the errors argument to the decode
         call if s is a byte string.
         """
         if charset is None:
@@ -326,7 +326,7 @@ class Header:
 
         Optional splitchars is a string containing characters which should be
         given extra weight by the splitting algorithm during normal header
-        wrapping.  This is in very rough support of RFC 2822's `higher level
+        wrapping.  This is in very rough support of RFC 2822's 'higher level
         syntactic breaks':  split points preceded by a splitchar are preferred
         during line splitting, with the characters preferred in the order in
         which they appear in the string.  Space and tab may be included in the

--- a/Lib/email/iterators.py
+++ b/Lib/email/iterators.py
@@ -43,8 +43,8 @@ def body_line_iterator(msg, decode=False):
 def typed_subpart_iterator(msg, maintype='text', subtype=None):
     """Iterate over the subparts with a given MIME type.
 
-    Use `maintype' as the main MIME type to match against; this defaults to
-    "text".  Optional `subtype' is the MIME subtype to match against; if
+    Use 'maintype' as the main MIME type to match against; this defaults to
+    "text".  Optional 'subtype' is the MIME subtype to match against; if
     omitted, only the main type is matched.
     """
     for subpart in msg.walk():

--- a/Lib/email/message.py
+++ b/Lib/email/message.py
@@ -21,7 +21,7 @@ Charset = _charset.Charset
 
 SEMISPACE = '; '
 
-# Regular expression that matches `special' characters in parameters, the
+# Regular expression that matches 'special' characters in parameters, the
 # existence of which force quoting of the parameter value.
 tspecials = re.compile(r'[ \(\)<>@,;:\\"/\[\]\?=]')
 
@@ -141,7 +141,7 @@ class Message:
     multipart or a message/rfc822), then the payload is a list of Message
     objects, otherwise it is a string.
 
-    Message objects implement part of the `mapping' interface, which assumes
+    Message objects implement part of the 'mapping' interface, which assumes
     there is exactly one occurrence of the header per message.  Some headers
     do in fact appear multiple times (e.g. Received) and for those headers,
     you must use the explicit API to set or get all the headers.  Not all of
@@ -597,7 +597,7 @@ class Message:
         """Return the message's content type.
 
         The returned string is coerced to lower case of the form
-        `maintype/subtype'.  If there was no Content-Type header in the
+        'maintype/subtype'.  If there was no Content-Type header in the
         message, the default type as given by get_default_type() will be
         returned.  Since according to RFC 2045, messages always have a default
         type this will always return a value.
@@ -620,7 +620,7 @@ class Message:
     def get_content_maintype(self):
         """Return the message's main content type.
 
-        This is the `maintype' part of the string returned by
+        This is the 'maintype' part of the string returned by
         get_content_type().
         """
         ctype = self.get_content_type()
@@ -629,14 +629,14 @@ class Message:
     def get_content_subtype(self):
         """Returns the message's sub-content type.
 
-        This is the `subtype' part of the string returned by
+        This is the 'subtype' part of the string returned by
         get_content_type().
         """
         ctype = self.get_content_type()
         return ctype.split('/')[1]
 
     def get_default_type(self):
-        """Return the `default' content type.
+        """Return the 'default' content type.
 
         Most messages have a default content type of text/plain, except for
         messages that are subparts of multipart/digest containers.  Such
@@ -645,7 +645,7 @@ class Message:
         return self._default_type
 
     def set_default_type(self, ctype):
-        """Set the `default' content type.
+        """Set the 'default' content type.
 
         ctype should be either "text/plain" or "message/rfc822", although this
         is not enforced.  The default content type is not stored in the
@@ -678,8 +678,8 @@ class Message:
         """Return the message's Content-Type parameters, as a list.
 
         The elements of the returned list are 2-tuples of key/value pairs, as
-        split on the `=' sign.  The left hand side of the `=' is the key,
-        while the right hand side is the value.  If there is no `=' sign in
+        split on the '=' sign.  The left hand side of the '=' is the key,
+        while the right hand side is the value.  If there is no '=' sign in
         the parameter the value is the empty string.  The value is as
         described in the get_param() method.
 
@@ -839,9 +839,9 @@ class Message:
         """Return the filename associated with the payload if present.
 
         The filename is extracted from the Content-Disposition header's
-        `filename' parameter, and it is unquoted.  If that header is missing
-        the `filename' parameter, this method falls back to looking for the
-        `name' parameter.
+        'filename' parameter, and it is unquoted.  If that header is missing
+        the 'filename' parameter, this method falls back to looking for the
+        'name' parameter.
         """
         missing = object()
         filename = self.get_param('filename', missing, 'content-disposition')
@@ -854,7 +854,7 @@ class Message:
     def get_boundary(self, failobj=None):
         """Return the boundary associated with the payload if present.
 
-        The boundary is extracted from the Content-Type header's `boundary'
+        The boundary is extracted from the Content-Type header's 'boundary'
         parameter, and it is unquoted.
         """
         missing = object()

--- a/Lib/email/mime/multipart.py
+++ b/Lib/email/mime/multipart.py
@@ -21,7 +21,7 @@ class MIMEMultipart(MIMEBase):
         Content-Type and MIME-Version headers.
 
         _subtype is the subtype of the multipart content type, defaulting to
-        `mixed'.
+        'mixed'.
 
         boundary is the multipart boundary string.  By default it is
         calculated as needed.

--- a/Lib/email/parser.py
+++ b/Lib/email/parser.py
@@ -22,7 +22,7 @@ class Parser:
         textual representation of the message.
 
         The string must be formatted as a block of RFC 2822 headers and header
-        continuation lines, optionally preceded by a `Unix-from' header.  The
+        continuation lines, optionally preceded by a 'Unix-from' header.  The
         header block is terminated either by the end of the string or by a
         blank line.
 
@@ -82,7 +82,7 @@ class BytesParser:
         textual representation of the message.
 
         The input must be formatted as a block of RFC 2822 headers and header
-        continuation lines, optionally preceded by a `Unix-from' header.  The
+        continuation lines, optionally preceded by a 'Unix-from' header.  The
         header block is terminated either by the end of the input or by a
         blank line.
 

--- a/Lib/email/quoprimime.py
+++ b/Lib/email/quoprimime.py
@@ -5,7 +5,7 @@
 """Quoted-printable content transfer encoding per RFCs 2045-2047.
 
 This module handles the content transfer encoding method defined in RFC 2045
-to encode US ASCII-like 8-bit data called `quoted-printable'.  It is used to
+to encode US ASCII-like 8-bit data called 'quoted-printable'.  It is used to
 safely encode text that is in a character set similar to the 7-bit US ASCII
 character set, but that includes some 8-bit characters that are normally not
 allowed in email bodies or headers.
@@ -17,7 +17,7 @@ This module provides an interface to encode and decode both headers and bodies
 with quoted-printable encoding.
 
 RFC 2045 defines a method for including character set information in an
-`encoded-word' in a header.  This method is commonly used for 8-bit real names
+'encoded-word' in a header.  This method is commonly used for 8-bit real names
 in To:/From:/Cc: etc. fields, as well as Subject: lines.
 
 This module does not do the line wrapping or end-of-line character
@@ -127,7 +127,7 @@ def quote(c):
 def header_encode(header_bytes, charset='iso-8859-1'):
     """Encode a single header line with quoted-printable (like) encoding.
 
-    Defined in RFC 2045, this `Q' encoding is similar to quoted-printable, but
+    Defined in RFC 2045, this 'Q' encoding is similar to quoted-printable, but
     used specifically for email header fields to allow charsets with mostly 7
     bit characters (and some 8 bit) to remain more or less readable in non-RFC
     2045 aware mail clients.
@@ -290,7 +290,7 @@ def _unquote_match(match):
 
 # Header decoding is done a bit differently
 def header_decode(s):
-    """Decode a string encoded with RFC 2045 MIME header `Q' encoding.
+    """Decode a string encoded with RFC 2045 MIME header 'Q' encoding.
 
     This function does not parse a full MIME header value encoded with
     quoted-printable (like =?iso-8859-1?q?Hello_World?=) -- please use

--- a/Lib/ftplib.py
+++ b/Lib/ftplib.py
@@ -343,7 +343,7 @@ class FTP:
         connection and the expected size of the transfer.  The
         expected size may be None if it could not be determined.
 
-        Optional `rest' argument can be a string that is sent as the
+        Optional 'rest' argument can be a string that is sent as the
         argument to a REST command.  This is essentially a server
         marker used to tell the server to skip over any data up to the
         given marker.

--- a/Lib/getopt.py
+++ b/Lib/getopt.py
@@ -2,8 +2,8 @@
 
 This module helps scripts to parse the command line arguments in
 sys.argv.  It supports the same conventions as the Unix getopt()
-function (including the special meanings of arguments of the form `-'
-and `--').  Long options similar to those supported by GNU software
+function (including the special meanings of arguments of the form '-'
+and '--').  Long options similar to those supported by GNU software
 may be used as well via an optional third argument.  This module
 provides two functions and an exception:
 
@@ -105,7 +105,7 @@ def gnu_getopt(args, shortopts, longopts = []):
     processing options as soon as a non-option argument is
     encountered.
 
-    If the first character of the option string is `+', or if the
+    If the first character of the option string is '+', or if the
     environment variable POSIXLY_CORRECT is set, then option
     processing stops as soon as a non-option argument is encountered.
 

--- a/Lib/heapq.py
+++ b/Lib/heapq.py
@@ -42,7 +42,7 @@ non-existing elements are considered to be infinite.  The interesting
 property of a heap is that a[0] is always its smallest element.
 
 The strange invariant above is meant to be an efficient memory
-representation for a tournament.  The numbers below are `k', not a[k]:
+representation for a tournament.  The numbers below are 'k', not a[k]:
 
                                    0
 
@@ -55,7 +55,7 @@ representation for a tournament.  The numbers below are `k', not a[k]:
     15 16   17 18   19 20   21 22   23 24   25 26   27 28   29 30
 
 
-In the tree above, each cell `k' is topping `2*k+1' and `2*k+2'.  In
+In the tree above, each cell 'k' is topping '2*k+1' and '2*k+2'.  In
 a usual binary tournament we see in sports, each cell is the winner
 over the two cells it tops, and we can trace the winner down the tree
 to see all opponents s/he had.  However, in many computer applications
@@ -110,7 +110,7 @@ vanishes, you switch heaps and start a new run.  Clever and quite
 effective!
 
 In a word, heaps are useful memory structures to know.  I use them in
-a few applications, and I think it is good to keep a `heap' module
+a few applications, and I think it is good to keep a 'heap' module
 around. :-)
 
 --------------------

--- a/Lib/http/client.py
+++ b/Lib/http/client.py
@@ -1025,7 +1025,7 @@ class HTTPConnection:
                 response.close()
 
     def send(self, data):
-        """Send `data' to the server.
+        """Send 'data' to the server.
         ``data`` can be a string object, a bytes object, an array object, a
         file-like object that supports a .read() method, or an iterable object.
         """
@@ -1137,10 +1137,10 @@ class HTTPConnection:
                    skip_accept_encoding=False):
         """Send a request to the server.
 
-        `method' specifies an HTTP request method, e.g. 'GET'.
-        `url' specifies the object being requested, e.g. '/index.html'.
-        `skip_host' if True does not add automatically a 'Host:' header
-        `skip_accept_encoding' if True does not add automatically an
+        'method' specifies an HTTP request method, e.g. 'GET'.
+        'url' specifies the object being requested, e.g. '/index.html'.
+        'skip_host' if True does not add automatically a 'Host:' header
+        'skip_accept_encoding' if True does not add automatically an
            'Accept-Encoding:' header
         """
 

--- a/Lib/http/cookiejar.py
+++ b/Lib/http/cookiejar.py
@@ -1986,7 +1986,7 @@ class MozillaCookieJar(FileCookieJar):
 
     This class differs from CookieJar only in the format it uses to save and
     load cookies to and from a file.  This class uses the Mozilla/Netscape
-    `cookies.txt' format.  curl and lynx use this file format, too.
+    'cookies.txt' format.  curl and lynx use this file format, too.
 
     Don't expect cookies saved while the browser is running to be noticed by
     the browser (in fact, Mozilla on unix will overwrite your saved cookies if

--- a/Lib/imaplib.py
+++ b/Lib/imaplib.py
@@ -239,7 +239,7 @@ class IMAP4:
         if __debug__:
             self._cmd_log_len = 10
             self._cmd_log_idx = 0
-            self._cmd_log = {}           # Last `_cmd_log_len' interactions
+            self._cmd_log = {}           # Last '_cmd_log_len' interactions
             if self.debug >= 1:
                 self._mesg('imaplib version %s' % __version__)
                 self._mesg('new IMAP4 connection, tag=%s' % self.tagpre)
@@ -396,7 +396,7 @@ class IMAP4:
 
         (typ, [data]) = <instance>.append(mailbox, flags, date_time, message)
 
-                All args except `message' can be None.
+                All args except 'message' can be None.
         """
         name = 'APPEND'
         if not mailbox:
@@ -927,7 +927,7 @@ class IMAP4:
 
         (typ, [data]) = <instance>.xatom(name, arg, ...)
 
-        Returns response appropriate to extension command `name'.
+        Returns response appropriate to extension command 'name'.
         """
         name = name.upper()
         #if not name in self.capabilities:      # Let the server decide!
@@ -1167,7 +1167,7 @@ class IMAP4:
             # Some have reported "unexpected response" exceptions.
             # Note that ignoring them here causes loops.
             # Instead, send me details of the unexpected response and
-            # I'll update the code in `_get_response()'.
+            # I'll update the code in '_get_response()'.
 
             try:
                 self._get_response()
@@ -1259,7 +1259,7 @@ class IMAP4:
             self._mesg('untagged responses dump:' + '\n\t\t'.join(items))
 
         def _log(self, line):
-            # Keep log of last `_cmd_log_len' interactions for debugging.
+            # Keep log of last '_cmd_log_len' interactions for debugging.
             self._cmd_log[self._cmd_log_idx] = (line, time.time())
             self._cmd_log_idx += 1
             if self._cmd_log_idx >= self._cmd_log_len:

--- a/Lib/mimetypes.py
+++ b/Lib/mimetypes.py
@@ -116,7 +116,7 @@ class MimeTypes:
         mapped to '.tar.gz'.  (This is table-driven too, using the
         dictionary suffix_map.)
 
-        Optional `strict' argument when False adds a bunch of commonly found,
+        Optional 'strict' argument when False adds a bunch of commonly found,
         but non-standard types.
         """
         # TODO: Deprecate accepting file paths (in particular path-like objects).
@@ -185,9 +185,9 @@ class MimeTypes:
         Return value is a list of strings giving the possible filename
         extensions, including the leading dot ('.').  The extension is not
         guaranteed to have been associated with any particular data stream,
-        but would be mapped to the MIME type `type' by guess_type().
+        but would be mapped to the MIME type 'type' by guess_type().
 
-        Optional `strict' argument when false adds a bunch of commonly found,
+        Optional 'strict' argument when false adds a bunch of commonly found,
         but non-standard types.
         """
         type = type.lower()
@@ -204,11 +204,11 @@ class MimeTypes:
         Return value is a string giving a filename extension,
         including the leading dot ('.').  The extension is not
         guaranteed to have been associated with any particular data
-        stream, but would be mapped to the MIME type `type' by
-        guess_type().  If no extension can be guessed for `type', None
+        stream, but would be mapped to the MIME type 'type' by
+        guess_type().  If no extension can be guessed for 'type', None
         is returned.
 
-        Optional `strict' argument when false adds a bunch of commonly found,
+        Optional 'strict' argument when false adds a bunch of commonly found,
         but non-standard types.
         """
         extensions = self.guess_all_extensions(type, strict)
@@ -314,7 +314,7 @@ def guess_type(url, strict=True):
     to ".tar.gz".  (This is table-driven too, using the dictionary
     suffix_map).
 
-    Optional `strict' argument when false adds a bunch of commonly found, but
+    Optional 'strict' argument when false adds a bunch of commonly found, but
     non-standard types.
     """
     if _db is None:
@@ -338,11 +338,11 @@ def guess_all_extensions(type, strict=True):
     Return value is a list of strings giving the possible filename
     extensions, including the leading dot ('.').  The extension is not
     guaranteed to have been associated with any particular data
-    stream, but would be mapped to the MIME type `type' by
-    guess_type().  If no extension can be guessed for `type', None
+    stream, but would be mapped to the MIME type 'type' by
+    guess_type().  If no extension can be guessed for 'type', None
     is returned.
 
-    Optional `strict' argument when false adds a bunch of commonly found,
+    Optional 'strict' argument when false adds a bunch of commonly found,
     but non-standard types.
     """
     if _db is None:
@@ -355,10 +355,10 @@ def guess_extension(type, strict=True):
     Return value is a string giving a filename extension, including the
     leading dot ('.').  The extension is not guaranteed to have been
     associated with any particular data stream, but would be mapped to the
-    MIME type `type' by guess_type().  If no extension can be guessed for
-    `type', None is returned.
+    MIME type 'type' by guess_type().  If no extension can be guessed for
+    'type', None is returned.
 
-    Optional `strict' argument when false adds a bunch of commonly found,
+    Optional 'strict' argument when false adds a bunch of commonly found,
     but non-standard types.
     """
     if _db is None:

--- a/Lib/smtplib.py
+++ b/Lib/smtplib.py
@@ -105,7 +105,7 @@ class SMTPSenderRefused(SMTPResponseException):
     """Sender address refused.
 
     In addition to the attributes set by on all SMTPResponseException
-    exceptions, this sets `sender' to the string that the SMTP refused.
+    exceptions, this sets 'sender' to the string that the SMTP refused.
     """
 
     def __init__(self, code, msg, sender):
@@ -315,7 +315,7 @@ class SMTP:
     def connect(self, host='localhost', port=0, source_address=None):
         """Connect to a host on a given port.
 
-        If the hostname ends with a colon (`:') followed by a number, and
+        If the hostname ends with a colon (':') followed by a number, and
         there is no port specified, that suffix will be stripped off and the
         number interpreted as the port number to use.
 
@@ -346,7 +346,7 @@ class SMTP:
         return (code, msg)
 
     def send(self, s):
-        """Send `s' to the server."""
+        """Send 's' to the server."""
         if self.debuglevel > 0:
             self._print_debug('send:', repr(s))
         if self.sock:

--- a/Lib/tarfile.py
+++ b/Lib/tarfile.py
@@ -1217,7 +1217,7 @@ class TarInfo(object):
         for keyword, value in pax_headers.items():
             keyword = keyword.encode("utf-8")
             if binary:
-                # Try to restore the original byte representation of `value'.
+                # Try to restore the original byte representation of 'value'.
                 # Needless to say, that the encoding must match the string.
                 value = value.encode(encoding, "surrogateescape")
             else:
@@ -1663,13 +1663,13 @@ class TarFile(object):
             tarinfo=None, dereference=None, ignore_zeros=None, encoding=None,
             errors="surrogateescape", pax_headers=None, debug=None,
             errorlevel=None, copybufsize=None, stream=False):
-        """Open an (uncompressed) tar archive `name'. `mode' is either 'r' to
+        """Open an (uncompressed) tar archive 'name'. 'mode' is either 'r' to
            read from an existing archive, 'a' to append data to an existing
-           file or 'w' to create a new file overwriting an existing one. `mode'
+           file or 'w' to create a new file overwriting an existing one. 'mode'
            defaults to 'r'.
-           If `fileobj' is given, it is used for reading or writing data. If it
-           can be determined, `mode' is overridden by `fileobj's mode.
-           `fileobj' is not closed, when TarFile is closed.
+           If 'fileobj' is given, it is used for reading or writing data. If it
+           can be determined, 'mode' is overridden by 'fileobj's mode.
+           'fileobj' is not closed, when TarFile is closed.
         """
         modes = {"r": "rb", "a": "r+b", "w": "wb", "x": "xb"}
         if mode not in modes:
@@ -1998,7 +1998,7 @@ class TarFile(object):
                 self.fileobj.close()
 
     def getmember(self, name):
-        """Return a TarInfo object for member `name'. If `name' can not be
+        """Return a TarInfo object for member 'name'. If 'name' can not be
            found in the archive, KeyError is raised. If a member occurs more
            than once in the archive, its last occurrence is assumed to be the
            most up-to-date version.
@@ -2026,9 +2026,9 @@ class TarFile(object):
 
     def gettarinfo(self, name=None, arcname=None, fileobj=None):
         """Create a TarInfo object from the result of os.stat or equivalent
-           on an existing file. The file is either named by `name', or
-           specified as a file object `fileobj' with a file descriptor. If
-           given, `arcname' specifies an alternative name for the file in the
+           on an existing file. The file is either named by 'name', or
+           specified as a file object 'fileobj' with a file descriptor. If
+           given, 'arcname' specifies an alternative name for the file in the
            archive, otherwise, the name is taken from the 'name' attribute of
            'fileobj', or the 'name' argument. The name should be a text
            string.
@@ -2124,9 +2124,9 @@ class TarFile(object):
         return tarinfo
 
     def list(self, verbose=True, *, members=None):
-        """Print a table of contents to sys.stdout. If `verbose' is False, only
-           the names of the members are printed. If it is True, an `ls -l'-like
-           output is produced. `members' is optional and must be a subset of the
+        """Print a table of contents to sys.stdout. If 'verbose' is False, only
+           the names of the members are printed. If it is True, an 'ls -l'-like
+           output is produced. 'members' is optional and must be a subset of the
            list returned by getmembers().
         """
         # Convert tarinfo type to stat type.
@@ -2167,11 +2167,11 @@ class TarFile(object):
             print()
 
     def add(self, name, arcname=None, recursive=True, *, filter=None):
-        """Add the file `name' to the archive. `name' may be any type of file
-           (directory, fifo, symbolic link, etc.). If given, `arcname'
+        """Add the file 'name' to the archive. 'name' may be any type of file
+           (directory, fifo, symbolic link, etc.). If given, 'arcname'
            specifies an alternative name for the file in the archive.
            Directories are added recursively by default. This can be avoided by
-           setting `recursive' to False. `filter' is a function
+           setting 'recursive' to False. 'filter' is a function
            that expects a TarInfo object argument and returns the changed
            TarInfo object, if it returns None the TarInfo object will be
            excluded from the archive.
@@ -2218,8 +2218,8 @@ class TarFile(object):
             self.addfile(tarinfo)
 
     def addfile(self, tarinfo, fileobj=None):
-        """Add the TarInfo object `tarinfo' to the archive. If `tarinfo' represents
-           a non zero-size regular file, the `fileobj' argument should be a binary file,
+        """Add the TarInfo object 'tarinfo' to the archive. If 'tarinfo' represents
+           a non zero-size regular file, the 'fileobj' argument should be a binary file,
            and tarinfo.size bytes are read from it and added to the archive.
            You can create TarInfo objects directly, or by using gettarinfo().
         """
@@ -2273,12 +2273,12 @@ class TarFile(object):
                    filter=None):
         """Extract all members from the archive to the current working
            directory and set owner, modification time and permissions on
-           directories afterwards. `path' specifies a different directory
-           to extract to. `members' is optional and must be a subset of the
-           list returned by getmembers(). If `numeric_owner` is True, only
+           directories afterwards. 'path' specifies a different directory
+           to extract to. 'members' is optional and must be a subset of the
+           list returned by getmembers(). If 'numeric_owner' is True, only
            the numbers for user/group names are used and not the names.
 
-           The `filter` function will be called on each member just
+           The 'filter' function will be called on each member just
            before extraction.
            It can return a changed TarInfo or None to skip the member.
            String names of common filters are accepted.
@@ -2318,13 +2318,13 @@ class TarFile(object):
                 filter=None):
         """Extract a member from the archive to the current working directory,
            using its full name. Its file information is extracted as accurately
-           as possible. `member' may be a filename or a TarInfo object. You can
-           specify a different directory using `path'. File attributes (owner,
-           mtime, mode) are set unless `set_attrs' is False. If `numeric_owner`
+           as possible. 'member' may be a filename or a TarInfo object. You can
+           specify a different directory using 'path'. File attributes (owner,
+           mtime, mode) are set unless 'set_attrs' is False. If 'numeric_owner'
            is True, only the numbers for user/group names are used and not
            the names.
 
-           The `filter` function will be called before extraction.
+           The 'filter' function will be called before extraction.
            It can return a changed TarInfo or None to skip the member.
            String names of common filters are accepted.
         """
@@ -2389,10 +2389,10 @@ class TarFile(object):
             self._dbg(1, "tarfile: %s %s" % (type(e).__name__, e))
 
     def extractfile(self, member):
-        """Extract a member from the archive as a file object. `member' may be
-           a filename or a TarInfo object. If `member' is a regular file or
+        """Extract a member from the archive as a file object. 'member' may be
+           a filename or a TarInfo object. If 'member' is a regular file or
            a link, an io.BufferedReader object is returned. For all other
-           existing members, None is returned. If `member' does not appear
+           existing members, None is returned. If 'member' does not appear
            in the archive, KeyError is raised.
         """
         self._check("r")
@@ -2590,7 +2590,7 @@ class TarFile(object):
                 else:
                     os.chown(targetpath, u, g)
             except (OSError, OverflowError) as e:
-                # OverflowError can be raised if an ID doesn't fit in `id_t`
+                # OverflowError can be raised if an ID doesn't fit in 'id_t'
                 raise ExtractError("could not change owner") from e
 
     def chmod(self, tarinfo, targetpath):

--- a/Lib/test/support/smtpd.py
+++ b/Lib/test/support/smtpd.py
@@ -7,7 +7,7 @@ Options:
 
     --nosetuid
     -n
-        This program generally tries to setuid `nobody', unless this flag is
+        This program generally tries to setuid 'nobody', unless this flag is
         set.  The setuid call will fail if this program is not run as root (in
         which case, use this flag).
 
@@ -17,7 +17,7 @@ Options:
 
     --class classname
     -c classname
-        Use `classname' as the concrete SMTP proxy class.  Uses `PureProxy' by
+        Use 'classname' as the concrete SMTP proxy class.  Uses 'PureProxy' by
         default.
 
     --size limit
@@ -39,8 +39,8 @@ Options:
 
 Version: %(__version__)s
 
-If localhost is not given then `localhost' is used, and if localport is not
-given then 8025 is used.  If remotehost is not given then `localhost' is used,
+If localhost is not given then 'localhost' is used, and if localport is not
+given then 8025 is used.  If remotehost is not given then 'localhost' is used,
 and if remoteport is not given, then 25 is used.
 """
 
@@ -672,9 +672,9 @@ class SMTPServer(asyncore.dispatcher):
         message to.
 
         data is a string containing the entire full text of the message,
-        headers (if supplied) and all.  It has been `de-transparencied'
+        headers (if supplied) and all.  It has been 'de-transparencied'
         according to RFC 821, Section 4.5.2.  In other words, a line
-        containing a `.' followed by other text has had the leading dot
+        containing a '.' followed by other text has had the leading dot
         removed.
 
         kwargs is a dictionary containing additional information.  It is
@@ -685,7 +685,7 @@ class SMTPServer(asyncore.dispatcher):
                             ['BODY=8BITMIME', 'SMTPUTF8'].
             'rcpt_options': same, for the rcpt command.
 
-        This function should return None for a normal `250 Ok' response;
+        This function should return None for a normal '250 Ok' response;
         otherwise, it should return the desired response string in RFC 821
         format.
 

--- a/Lib/test/test_asyncio/test_locks.py
+++ b/Lib/test/test_asyncio/test_locks.py
@@ -1481,7 +1481,7 @@ class BarrierTests(unittest.IsolatedAsyncioTestCase):
                 # wait again only for rewait tasks
                 await barrier.wait()
             else:
-                # wait for end of draining state`
+                # wait for end of draining state
                 await barrier_nowaiting.wait()
                 # wait for other waiting tasks
                 await barrier.wait()
@@ -1780,7 +1780,7 @@ class BarrierTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(barrier.n_waiting, 0)
 
     async def test_abort_barrier_when_exception_then_resetting(self):
-        # test from threading.Barrier: see `lock_tests.test_abort_and_reset``
+        # test from threading.Barrier: see `lock_tests.test_abort_and_reset`
         barrier1 = asyncio.Barrier(self.N)
         barrier2 = asyncio.Barrier(self.N)
         results1 = []

--- a/Lib/trace.py
+++ b/Lib/trace.py
@@ -402,7 +402,7 @@ class Trace:
         @param countfuncs true iff it should just output a list of
                      (filename, modulename, funcname,) for functions
                      that were called at least once;  This overrides
-                     `count' and `trace'
+                     'count' and 'trace'
         @param ignoremods a list of the names of modules to ignore
         @param ignoredirs a list of the names of directories to ignore
                      all of the (recursive) contents of
@@ -534,7 +534,7 @@ class Trace:
     def globaltrace_lt(self, frame, why, arg):
         """Handler for call events.
 
-        If the code block being entered is to be ignored, returns `None',
+        If the code block being entered is to be ignored, returns 'None',
         else returns self.localtrace.
         """
         if why == 'call':

--- a/Lib/unittest/mock.py
+++ b/Lib/unittest/mock.py
@@ -1748,7 +1748,7 @@ def patch(
     the patch is undone.
 
     If `new` is omitted, then the target is replaced with an
-    `AsyncMock if the patched object is an async function or a
+    `AsyncMock` if the patched object is an async function or a
     `MagicMock` otherwise. If `patch` is used as a decorator and `new` is
     omitted, the created mock is passed in as an extra argument to the
     decorated function. If `patch` is used as a context manager the created

--- a/Lib/wsgiref/headers.py
+++ b/Lib/wsgiref/headers.py
@@ -5,7 +5,7 @@ so portions are Copyright (C) 2001,2002 Python Software Foundation, and were
 written by Barry Warsaw.
 """
 
-# Regular expression that matches `special' characters in parameters, the
+# Regular expression that matches 'special' characters in parameters, the
 # existence of which force quoting of the parameter value.
 import re
 tspecials = re.compile(r'[ \(\)<>@,;:\\"/\[\]\?=]')

--- a/Lib/zipfile/__init__.py
+++ b/Lib/zipfile/__init__.py
@@ -1745,8 +1745,8 @@ class ZipFile:
     def extract(self, member, path=None, pwd=None):
         """Extract a member from the archive to the current working directory,
            using its full name. Its file information is extracted as accurately
-           as possible. `member' may be a filename or a ZipInfo object. You can
-           specify a different directory using `path'. You can specify the
+           as possible. 'member' may be a filename or a ZipInfo object. You can
+           specify a different directory using 'path'. You can specify the
            password to decrypt the file using 'pwd'.
         """
         if path is None:
@@ -1758,8 +1758,8 @@ class ZipFile:
 
     def extractall(self, path=None, members=None, pwd=None):
         """Extract all members from the archive to the current working
-           directory. `path' specifies a different directory to extract to.
-           `members' is optional and must be a subset of the list returned
+           directory. 'path' specifies a different directory to extract to.
+           'members' is optional and must be a subset of the list returned
            by namelist(). You can specify the password to decrypt all files
            using 'pwd'.
         """

--- a/Modules/_heapqmodule.c
+++ b/Modules/_heapqmodule.c
@@ -585,7 +585,7 @@ non-existing elements are considered to be infinite.  The interesting\n\
 property of a heap is that a[0] is always its smallest element.\n"
 "\n\
 The strange invariant above is meant to be an efficient memory\n\
-representation for a tournament.  The numbers below are `k', not a[k]:\n\
+representation for a tournament.  The numbers below are 'k', not a[k]:\n\
 \n\
                                    0\n\
 \n\
@@ -598,7 +598,7 @@ representation for a tournament.  The numbers below are `k', not a[k]:\n\
     15 16   17 18   19 20   21 22   23 24   25 26   27 28   29 30\n\
 \n\
 \n\
-In the tree above, each cell `k' is topping `2*k+1' and `2*k+2'.  In\n\
+In the tree above, each cell 'k' is topping '2*k+1' and '2*k+2'.  In\n\
 a usual binary tournament we see in sports, each cell is the winner\n\
 over the two cells it tops, and we can trace the winner down the tree\n\
 to see all opponents s/he had.  However, in many computer applications\n\
@@ -653,7 +653,7 @@ vanishes, you switch heaps and start a new run.  Clever and quite\n\
 effective!\n\
 \n\
 In a word, heaps are useful memory structures to know.  I use them in\n\
-a few applications, and I think it is good to keep a `heap' module\n\
+a few applications, and I think it is good to keep a 'heap' module\n\
 around. :-)\n"
 "\n\
 --------------------\n\

--- a/Modules/_interpretersmodule.c
+++ b/Modules/_interpretersmodule.c
@@ -656,7 +656,7 @@ Create a new interpreter and return a unique generated ID.\n\
 The caller is responsible for destroying the interpreter before exiting,\n\
 typically by using _interpreters.destroy().  This can be managed \n\
 automatically by passing \"reqrefs=True\" and then using _incref() and\n\
-_decref()` appropriately.\n\
+_decref() appropriately.\n\
 \n\
 \"config\" must be a valid interpreter config or the name of a\n\
 predefined config (\"isolated\" or \"legacy\").  The default\n\

--- a/Modules/cjkcodecs/clinic/multibytecodec.c.h
+++ b/Modules/cjkcodecs/clinic/multibytecodec.c.h
@@ -12,7 +12,7 @@ PyDoc_STRVAR(_multibytecodec_MultibyteCodec_encode__doc__,
 "encode($self, /, input, errors=None)\n"
 "--\n"
 "\n"
-"Return an encoded string version of `input\'.\n"
+"Return an encoded string version of \'input\'.\n"
 "\n"
 "\'errors\' may be given to set a different error handling scheme. Default is\n"
 "\'strict\' meaning that encoding errors raise a UnicodeEncodeError. Other possible\n"
@@ -682,4 +682,4 @@ PyDoc_STRVAR(_multibytecodec___create_codec__doc__,
 
 #define _MULTIBYTECODEC___CREATE_CODEC_METHODDEF    \
     {"__create_codec", (PyCFunction)_multibytecodec___create_codec, METH_O, _multibytecodec___create_codec__doc__},
-/*[clinic end generated code: output=ee767a6d93c7108a input=a9049054013a1b77]*/
+/*[clinic end generated code: output=f09052c5a28cc6e6 input=a9049054013a1b77]*/

--- a/Modules/cjkcodecs/multibytecodec.c
+++ b/Modules/cjkcodecs/multibytecodec.c
@@ -574,7 +574,7 @@ _multibytecodec.MultibyteCodec.encode
   input: object
   errors: str(accept={str, NoneType}) = None
 
-Return an encoded string version of `input'.
+Return an encoded string version of 'input'.
 
 'errors' may be given to set a different error handling scheme. Default is
 'strict' meaning that encoding errors raise a UnicodeEncodeError. Other possible
@@ -586,7 +586,7 @@ static PyObject *
 _multibytecodec_MultibyteCodec_encode_impl(MultibyteCodecObject *self,
                                            PyObject *input,
                                            const char *errors)
-/*[clinic end generated code: output=7b26652045ba56a9 input=606d0e128a577bae]*/
+/*[clinic end generated code: output=7b26652045ba56a9 input=2841745b95ed338f]*/
 {
     MultibyteCodec_State state;
     PyObject *errorcb, *r, *ucvt;

--- a/Modules/clinic/pyexpat.c.h
+++ b/Modules/clinic/pyexpat.c.h
@@ -61,7 +61,7 @@ PyDoc_STRVAR(pyexpat_xmlparser_Parse__doc__,
 "\n"
 "Parse XML data.\n"
 "\n"
-"`isfinal\' should be true at end of input.");
+"\'isfinal\' should be true at end of input.");
 
 #define PYEXPAT_XMLPARSER_PARSE_METHODDEF    \
     {"Parse", _PyCFunction_CAST(pyexpat_xmlparser_Parse), METH_METHOD|METH_FASTCALL|METH_KEYWORDS, pyexpat_xmlparser_Parse__doc__},
@@ -545,4 +545,4 @@ exit:
 #ifndef PYEXPAT_XMLPARSER_USEFOREIGNDTD_METHODDEF
     #define PYEXPAT_XMLPARSER_USEFOREIGNDTD_METHODDEF
 #endif /* !defined(PYEXPAT_XMLPARSER_USEFOREIGNDTD_METHODDEF) */
-/*[clinic end generated code: output=892e48e41f9b6e4b input=a9049054013a1b77]*/
+/*[clinic end generated code: output=51874bfaf4992ba2 input=a9049054013a1b77]*/

--- a/Modules/pyexpat.c
+++ b/Modules/pyexpat.c
@@ -754,13 +754,13 @@ pyexpat.xmlparser.Parse
 
 Parse XML data.
 
-`isfinal' should be true at end of input.
+'isfinal' should be true at end of input.
 [clinic start generated code]*/
 
 static PyObject *
 pyexpat_xmlparser_Parse_impl(xmlparseobject *self, PyTypeObject *cls,
                              PyObject *data, int isfinal)
-/*[clinic end generated code: output=8faffe07fe1f862a input=d0eb2a69fab3b9f1]*/
+/*[clinic end generated code: output=8faffe07fe1f862a input=053e0f047e55c05a]*/
 {
     const char *s;
     Py_ssize_t slen;

--- a/Objects/bytesobject.c
+++ b/Objects/bytesobject.c
@@ -52,25 +52,25 @@ static inline PyObject* bytes_get_empty(void)
 
 
 /*
-   For PyBytes_FromString(), the parameter `str' points to a null-terminated
-   string containing exactly `size' bytes.
+   For PyBytes_FromString(), the parameter 'str' points to a null-terminated
+   string containing exactly 'size' bytes.
 
-   For PyBytes_FromStringAndSize(), the parameter `str' is
-   either NULL or else points to a string containing at least `size' bytes.
-   For PyBytes_FromStringAndSize(), the string in the `str' parameter does
+   For PyBytes_FromStringAndSize(), the parameter 'str' is
+   either NULL or else points to a string containing at least 'size' bytes.
+   For PyBytes_FromStringAndSize(), the string in the 'str' parameter does
    not have to be null-terminated.  (Therefore it is safe to construct a
-   substring by calling `PyBytes_FromStringAndSize(origstring, substrlen)'.)
-   If `str' is NULL then PyBytes_FromStringAndSize() will allocate `size+1'
+   substring by calling 'PyBytes_FromStringAndSize(origstring, substrlen)'.)
+   If 'str' is NULL then PyBytes_FromStringAndSize() will allocate 'size+1'
    bytes (setting the last byte to the null terminating character) and you can
-   fill in the data yourself.  If `str' is non-NULL then the resulting
+   fill in the data yourself.  If 'str' is non-NULL then the resulting
    PyBytes object must be treated as immutable and you must not fill in nor
    alter the data yourself, since the strings may be shared.
 
-   The PyObject member `op->ob_size', which denotes the number of "extra
+   The PyObject member 'op->ob_size', which denotes the number of "extra
    items" in a variable-size object, will contain the number of bytes
    allocated for string data, not counting the null terminating character.
-   It is therefore equal to the `size' parameter (for
-   PyBytes_FromStringAndSize()) or the length of the string in the `str'
+   It is therefore equal to the 'size' parameter (for
+   PyBytes_FromStringAndSize()) or the length of the string in the 'str'
    parameter (for PyBytes_FromString()).
 */
 static PyObject *

--- a/Objects/odictobject.c
+++ b/Objects/odictobject.c
@@ -200,7 +200,7 @@ Here are some ways to address this challenge:
 Adding the checks to the concrete API would help make any interpreter
 switch to OrderedDict less painful for extension modules.  However, this
 won't work.  The equivalent C API call to `dict.__setitem__(obj, k, v)`
-is 'PyDict_SetItem(obj, k, v)`.  This illustrates how subclasses in C call
+is `PyDict_SetItem(obj, k, v)`.  This illustrates how subclasses in C call
 the base class's methods, since there is no equivalent of super() in the
 C API.  Calling into Python for parent class API would work, but some
 extension modules already rely on this feature of the concrete API.


### PR DESCRIPTION
As reported in #117847 and #115366, an unpaired backtick in a docstring tends to confuse e.g. Sphinx running on subclasses of standard library objects, and the typographic style of using a backtick as an opening quote is no longer in favor. Convert almost all uses of the form

    The variable `foo' should do xyz

to

    The variable 'foo' should do xyz

and also fix up miscellaneous other unpaired backticks (extraneous / missing characters).

No functional change is intended here other than in human-readable docstrings.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--119231.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->