### PR TITLE
gh-118912: Remove description of issue fixed in 3.5 from autospeccing guide

### DIFF
--- a/Doc/library/unittest.mock.rst
+++ b/Doc/library/unittest.mock.rst
@@ -2592,9 +2592,8 @@ broken.
 
 .. versionchanged:: 3.5 
 
-    Before 3.5, Mocks suffered from an additional flaw where tests with a typo in 
-    the word assert would silently pass when they should raise an error. You can still 
-    achieve this behavior by passing ``unsafe=True`` to the Mock class.
+    Before 3.5, tests with a typo in the word assert would silently pass when they should
+    raise an error. You can still achieve this behavior by passing ``unsafe=True`` to Mock.
 
 Note that this is another reason why you need integration tests as well as
 unit tests. Testing everything in isolation is all fine and dandy, but if you

--- a/Doc/library/unittest.mock.rst
+++ b/Doc/library/unittest.mock.rst
@@ -2585,12 +2585,12 @@ called incorrectly.
 Before I explain how auto-speccing works, here's why it is needed.
 
 :class:`Mock` is a very powerful and flexible object, but it suffers from a flaw which
-is general to mocking. If you refactor some of your code, rename members and so on, any 
-tests for code that is still using the *old api* but uses mocks instead of the real 
-objects will still pass. This means your tests can all pass even though your code is 
+is general to mocking. If you refactor some of your code, rename members and so on, any
+tests for code that is still using the *old api* but uses mocks instead of the real
+objects will still pass. This means your tests can all pass even though your code is
 broken.
 
-.. versionchanged:: 3.5 
+.. versionchanged:: 3.5
 
     Before 3.5, tests with a typo in the word assert would silently pass when they should
     raise an error. You can still achieve this behavior by passing ``unsafe=True`` to Mock.

--- a/Doc/library/unittest.mock.rst
+++ b/Doc/library/unittest.mock.rst
@@ -2584,40 +2584,17 @@ called incorrectly.
 
 Before I explain how auto-speccing works, here's why it is needed.
 
-:class:`Mock` is a very powerful and flexible object, but it suffers from two flaws
-when used to mock out objects from a system under test. One of these flaws is
-specific to the :class:`Mock` api and the other is a more general problem with using
-mock objects.
+:class:`Mock` is a very powerful and flexible object, but it suffers from a flaw which
+is general to mocking. If you refactor some of your code, rename members and so on, any 
+tests for code that is still using the *old api* but uses mocks instead of the real 
+objects will still pass. This means your tests can all pass even though your code is 
+broken.
 
-First the problem specific to :class:`Mock`. :class:`Mock` has two assert methods that are
-extremely handy: :meth:`~Mock.assert_called_with` and
-:meth:`~Mock.assert_called_once_with`.
+.. versionchanged:: 3.5 
 
-    >>> mock = Mock(name='Thing', return_value=None)
-    >>> mock(1, 2, 3)
-    >>> mock.assert_called_once_with(1, 2, 3)
-    >>> mock(1, 2, 3)
-    >>> mock.assert_called_once_with(1, 2, 3)
-    Traceback (most recent call last):
-     ...
-    AssertionError: Expected 'mock' to be called once. Called 2 times.
-
-Because mocks auto-create attributes on demand, and allow you to call them
-with arbitrary arguments, if you misspell one of these assert methods then
-your assertion is gone:
-
-.. code-block:: pycon
-
-    >>> mock = Mock(name='Thing', return_value=None)
-    >>> mock(1, 2, 3)
-    >>> mock.assret_called_once_with(4, 5, 6)  # Intentional typo!
-
-Your tests can pass silently and incorrectly because of the typo.
-
-The second issue is more general to mocking. If you refactor some of your
-code, rename members and so on, any tests for code that is still using the
-*old api* but uses mocks instead of the real objects will still pass. This
-means your tests can all pass even though your code is broken.
+    Before 3.5, Mocks suffered from an additional flaw where tests with a typo in 
+    the word assert would silently pass when they should raise an error. You can still 
+    achieve this behavior by passing ``unsafe=True`` to the Mock class.
 
 Note that this is another reason why you need integration tests as well as
 unit tests. Testing everything in isolation is all fine and dandy, but if you


### PR DESCRIPTION
Note: I am a first-time contributor, so apologies if I've missed some important norms or processes.

This is an attempt to fix #118912 by removing the description of a bug that was removed in Python 3.5. I noticed that elsewhere in the documentation there were comments about when something had been added or removed or changed, so I tried using that here. Not sure if that was actually appropriate.

I had one other question: the autospeccing guide feels a little out of place here. Everything else seems to be primarily for reference, while this guide feels like more of a howto. Should it be moved to a howto section, and merely linked here? If we want to keep it in this part of the docs, should it be moved next to create_autospec or even submerged into it? Eager to get your thoughts on this question, and to get overall feedback on this PR.


<!-- gh-issue-number: gh-118912 -->
* Issue: gh-118912
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--119232.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->