### PR TITLE
DOCS: Suggest always calling exec with a globals argument and no locals argument

### DIFF
--- a/Doc/library/functions.rst
+++ b/Doc/library/functions.rst
@@ -612,9 +612,9 @@ are always available.  They are listed here in alphabetical order.
 
    .. note::
 
-      You probably should always pass a globals argument and never a locals
-      argument. If exec gets two separate objects as *globals* and *locals*, the
-      code will be executed as if it were embedded in a class definition.
+      Most users should just pass a *globals* argument and never *locals*.
+      If exec gets two separate objects as *globals* and *locals*, the code
+      will be executed as if it were embedded in a class definition.
 
    If the *globals* dictionary does not contain a value for the key
    ``__builtins__``, a reference to the dictionary of the built-in module

--- a/Doc/library/functions.rst
+++ b/Doc/library/functions.rst
@@ -608,9 +608,13 @@ are always available.  They are listed here in alphabetical order.
    will be used for both the global and the local variables.  If *globals* and
    *locals* are given, they are used for the global and local variables,
    respectively.  If provided, *locals* can be any mapping object.  Remember
-   that at the module level, globals and locals are the same dictionary. If exec
-   gets two separate objects as *globals* and *locals*, the code will be
-   executed as if it were embedded in a class definition.
+   that at the module level, globals and locals are the same dictionary.
+
+   .. note::
+
+      You probably should always pass a globals argument and never a locals
+      argument. If exec gets two separate objects as *globals* and *locals*, the
+      code will be executed as if it were embedded in a class definition.
 
    If the *globals* dictionary does not contain a value for the key
    ``__builtins__``, a reference to the dictionary of the built-in module


### PR DESCRIPTION
Many users think they want a locals argument for various reasons but they do not understand that it makes code be treated as a class definition. They do not want their code treated as a class definition and get surprised. The reason not to pass locals specifically is that the following code raises a `NameError`:

```py
exec("""
def f():
    print("hi")

f()

def g():
    f()
g()
""", {}, {})

```
The reason not to leave out globals is as follows:
```py
def t():
    exec("""
def f():
    print("hi")

f()

def g():
    f()
g()
    """)
```

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--119235.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->