### PR TITLE
gh-119258: Eliminate Type Guards in Tier 2 Optimizer

### DIFF
--- a/Include/internal/pycore_optimizer.h
+++ b/Include/internal/pycore_optimizer.h
@@ -125,9 +125,11 @@ extern _Py_UopsSymbol *_Py_uop_sym_new_const(_Py_UOpsContext *ctx, PyObject *con
 extern _Py_UopsSymbol *_Py_uop_sym_new_null(_Py_UOpsContext *ctx);
 extern bool _Py_uop_sym_has_type(_Py_UopsSymbol *sym);
 extern bool _Py_uop_sym_matches_type(_Py_UopsSymbol *sym, PyTypeObject *typ);
+extern bool _Py_uop_sym_matches_type_version(_Py_UopsSymbol *sym, int32_t version);
 extern void _Py_uop_sym_set_null(_Py_UOpsContext *ctx, _Py_UopsSymbol *sym);
 extern void _Py_uop_sym_set_non_null(_Py_UOpsContext *ctx, _Py_UopsSymbol *sym);
 extern void _Py_uop_sym_set_type(_Py_UOpsContext *ctx, _Py_UopsSymbol *sym, PyTypeObject *typ);
+extern void _Py_uop_sym_set_type_version(_Py_UOpsContext *ctx, _Py_UopsSymbol *sym, int32_t version);
 extern void _Py_uop_sym_set_const(_Py_UOpsContext *ctx, _Py_UopsSymbol *sym, PyObject *const_val);
 extern bool _Py_uop_sym_is_bottom(_Py_UopsSymbol *sym);
 extern int _Py_uop_sym_truthiness(_Py_UopsSymbol *sym);

--- a/Include/internal/pycore_optimizer.h
+++ b/Include/internal/pycore_optimizer.h
@@ -33,6 +33,8 @@ struct _Py_UopsSymbol {
     int flags;  // 0 bits: Top; 2 or more bits: Bottom
     PyTypeObject *typ;  // Borrowed reference
     PyObject *const_val;  // Owned reference (!)
+    int32_t typ_version; // currently stores type version
+    int32_t typ_version_offset; // bytecode offset where the last type version was set
 };
 
 #define UOP_FORMAT_TARGET 0

--- a/Include/internal/pycore_optimizer.h
+++ b/Include/internal/pycore_optimizer.h
@@ -34,7 +34,7 @@ struct _Py_UopsSymbol {
     PyTypeObject *typ;  // Borrowed reference
     PyObject *const_val;  // Owned reference (!)
     int32_t typ_version; // currently stores type version
-    int32_t typ_version_offset; // bytecode offset where the last type version was set
+    int typ_version_offset; // bytecode offset where the last type version was set
 };
 
 #define UOP_FORMAT_TARGET 0
@@ -98,6 +98,7 @@ struct _Py_UOpsContext {
     char done;
     char out_of_space;
     bool contradiction;
+    int64_t latest_escape_offset;
     // The current "executing" frame.
     _Py_UOpsAbstractFrame *frame;
     _Py_UOpsAbstractFrame frames[MAX_ABSTRACT_FRAME_DEPTH];
@@ -125,11 +126,11 @@ extern _Py_UopsSymbol *_Py_uop_sym_new_const(_Py_UOpsContext *ctx, PyObject *con
 extern _Py_UopsSymbol *_Py_uop_sym_new_null(_Py_UOpsContext *ctx);
 extern bool _Py_uop_sym_has_type(_Py_UopsSymbol *sym);
 extern bool _Py_uop_sym_matches_type(_Py_UopsSymbol *sym, PyTypeObject *typ);
-extern bool _Py_uop_sym_matches_type_version(_Py_UopsSymbol *sym, int32_t version);
+extern bool _Py_uop_sym_matches_type_version(_Py_UopsSymbol *sym, int32_t version, int offset);
 extern void _Py_uop_sym_set_null(_Py_UOpsContext *ctx, _Py_UopsSymbol *sym);
 extern void _Py_uop_sym_set_non_null(_Py_UOpsContext *ctx, _Py_UopsSymbol *sym);
 extern void _Py_uop_sym_set_type(_Py_UOpsContext *ctx, _Py_UopsSymbol *sym, PyTypeObject *typ);
-extern void _Py_uop_sym_set_type_version(_Py_UOpsContext *ctx, _Py_UopsSymbol *sym, int32_t version);
+extern void _Py_uop_sym_set_type_version(_Py_UOpsContext *ctx, _Py_UopsSymbol *sym, int32_t version, int offset);
 extern void _Py_uop_sym_set_const(_Py_UOpsContext *ctx, _Py_UopsSymbol *sym, PyObject *const_val);
 extern bool _Py_uop_sym_is_bottom(_Py_UopsSymbol *sym);
 extern int _Py_uop_sym_truthiness(_Py_UopsSymbol *sym);

--- a/Lib/test/test_capi/test_opt.py
+++ b/Lib/test/test_capi/test_opt.py
@@ -1333,6 +1333,27 @@ class TestUopsOptimization(unittest.TestCase):
         self.assertIs(type(s), float)
         self.assertEqual(s, 1024.0)
 
+    def test_guard_type_version_removed(self):
+        def thing(a):
+            x = 0
+            for _ in range(100):
+                x += a.attr
+                x += a.attr
+            return x
+
+        class Foo:
+            attr = 1
+
+        res, ex = self._run_with_optimizer(thing, Foo())
+        opnames = list(iter_opnames(ex))
+        for i in iter_opnames(ex):
+            print(i)
+
+        self.assertIsNotNone(ex)
+        self.assertEqual(res, 200)
+        guard_type_version_count = opnames.count("_GUARD_TYPE_VERSION")
+        self.assertEqual(guard_type_version_count, 1)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/Lib/test/test_capi/test_opt.py
+++ b/Lib/test/test_capi/test_opt.py
@@ -1356,6 +1356,33 @@ class TestUopsOptimization(unittest.TestCase):
         guard_type_version_count = opnames.count("_GUARD_TYPE_VERSION")
         self.assertEqual(guard_type_version_count, 1)
 
+    def test_guard_type_version_not_removed(self):
+        def fn():
+            pass
+
+        def thing(a):
+            x = 0
+            for _ in range(100):
+                x += a.attr
+                fn()
+                x += a.attr
+            return x
+
+        class Foo:
+            attr = 1
+
+        breakpoint()
+
+        res, ex = self._run_with_optimizer(thing, Foo())
+        opnames = list(iter_opnames(ex))
+        for i in iter_opnames(ex):
+            print(i)
+
+        self.assertIsNotNone(ex)
+        self.assertEqual(res, 200)
+        guard_type_version_count = opnames.count("_GUARD_TYPE_VERSION")
+        self.assertEqual(guard_type_version_count, 2)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/Lib/test/test_capi/test_opt.py
+++ b/Lib/test/test_capi/test_opt.py
@@ -1344,13 +1344,8 @@ class TestUopsOptimization(unittest.TestCase):
         class Foo:
             attr = 1
 
-        breakpoint()
-
         res, ex = self._run_with_optimizer(thing, Foo())
         opnames = list(iter_opnames(ex))
-        for i in iter_opnames(ex):
-            print(i)
-
         self.assertIsNotNone(ex)
         self.assertEqual(res, 200)
         guard_type_version_count = opnames.count("_GUARD_TYPE_VERSION")
@@ -1371,12 +1366,8 @@ class TestUopsOptimization(unittest.TestCase):
         class Foo:
             attr = 1
 
-        breakpoint()
-
         res, ex = self._run_with_optimizer(thing, Foo())
         opnames = list(iter_opnames(ex))
-        for i in iter_opnames(ex):
-            print(i)
 
         self.assertIsNotNone(ex)
         self.assertEqual(res, 200)

--- a/Lib/test/test_capi/test_opt.py
+++ b/Lib/test/test_capi/test_opt.py
@@ -1344,6 +1344,8 @@ class TestUopsOptimization(unittest.TestCase):
         class Foo:
             attr = 1
 
+        breakpoint()
+
         res, ex = self._run_with_optimizer(thing, Foo())
         opnames = list(iter_opnames(ex))
         for i in iter_opnames(ex):

--- a/Misc/NEWS.d/next/Core and Builtins/2024-05-20-20-15-47.gh-issue-119258.6R2Vf4.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2024-05-20-20-15-47.gh-issue-119258.6R2Vf4.rst
@@ -1,1 +1,0 @@
-Tier 2 optimizer eliminate type version guards

--- a/Misc/NEWS.d/next/Core and Builtins/2024-05-20-20-15-47.gh-issue-119258.6R2Vf4.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2024-05-20-20-15-47.gh-issue-119258.6R2Vf4.rst
@@ -1,0 +1,1 @@
+Tier 2 optimizer eliminate type version guards

--- a/Python/optimizer_analysis.c
+++ b/Python/optimizer_analysis.c
@@ -418,7 +418,6 @@ optimize_uops(
         _Py_UopsSymbol **stack_pointer = ctx->frame->stack_pointer;
 
         if (_PyUop_Flags[opcode] & HAS_ESCAPES_FLAG) {
-            printf("opcode: %d ", opcode);
             ctx->latest_escape_offset = i; // i is the offset we're looping on
         }
 

--- a/Python/optimizer_analysis.c
+++ b/Python/optimizer_analysis.c
@@ -314,7 +314,7 @@ remove_globals(_PyInterpreterFrame *frame, _PyUOpInstruction *buffer,
 #define sym_set_null(SYM) _Py_uop_sym_set_null(ctx, SYM)
 #define sym_set_non_null(SYM) _Py_uop_sym_set_non_null(ctx, SYM)
 #define sym_set_type(SYM, TYPE) _Py_uop_sym_set_type(ctx, SYM, TYPE)
-#define sym_set_type_version(SYM, VERSION) _Py_uop_sym_set_type_version(ctx, SYM, VERSION)
+#define sym_set_type_version(SYM, VERSION, OFFSET) _Py_uop_sym_set_type_version(ctx, SYM, VERSION, OFFSET)
 #define sym_set_const(SYM, CNST) _Py_uop_sym_set_const(ctx, SYM, CNST)
 #define sym_is_bottom _Py_uop_sym_is_bottom
 #define sym_truthiness _Py_uop_sym_truthiness
@@ -406,6 +406,7 @@ optimize_uops(
     ctx->done = false;
     ctx->out_of_space = false;
     ctx->contradiction = false;
+    ctx->latest_escape_offset = 0;
 
     _PyUOpInstruction *this_instr = NULL;
     for (int i = 0; !ctx->done; i++) {
@@ -415,6 +416,11 @@ optimize_uops(
         int oparg = this_instr->oparg;
         opcode = this_instr->opcode;
         _Py_UopsSymbol **stack_pointer = ctx->frame->stack_pointer;
+
+        if (_PyUop_Flags[opcode] & HAS_ESCAPES_FLAG) {
+            printf("opcode: %d ", opcode);
+            ctx->latest_escape_offset = i; // i is the offset we're looping on
+        }
 
 #ifdef Py_DEBUG
         if (get_lltrace() >= 3) {

--- a/Python/optimizer_analysis.c
+++ b/Python/optimizer_analysis.c
@@ -310,9 +310,11 @@ remove_globals(_PyInterpreterFrame *frame, _PyUOpInstruction *buffer,
 #define sym_has_type _Py_uop_sym_has_type
 #define sym_get_type _Py_uop_sym_get_type
 #define sym_matches_type _Py_uop_sym_matches_type
+#define sym_matches_type_version _Py_uop_sym_matches_type_version
 #define sym_set_null(SYM) _Py_uop_sym_set_null(ctx, SYM)
 #define sym_set_non_null(SYM) _Py_uop_sym_set_non_null(ctx, SYM)
 #define sym_set_type(SYM, TYPE) _Py_uop_sym_set_type(ctx, SYM, TYPE)
+#define sym_set_type_version(SYM, VERSION) _Py_uop_sym_set_type_version(ctx, SYM, VERSION)
 #define sym_set_const(SYM, CNST) _Py_uop_sym_set_const(ctx, SYM, CNST)
 #define sym_is_bottom _Py_uop_sym_is_bottom
 #define sym_truthiness _Py_uop_sym_truthiness

--- a/Python/optimizer_bytecodes.c
+++ b/Python/optimizer_bytecodes.c
@@ -116,7 +116,6 @@ dummy_func(void) {
     }
 
     op(_GUARD_TYPE_VERSION, (type_version/2, owner -- owner)) {
-        printf("%d %d %d\n", type_version, owner->typ_version, owner->typ_version_offset);
         if (sym_matches_type_version(owner, type_version, ctx->latest_escape_offset)) {
             REPLACE_OP(this_instr, _NOP, 0, 0);
         }
@@ -712,7 +711,6 @@ dummy_func(void) {
     }
 
     op(_ITER_NEXT_RANGE, (iter -- iter, next)) {
-        printf("ciao");
        next = sym_new_type(ctx, &PyLong_Type);
        (void)iter;
     }

--- a/Python/optimizer_bytecodes.c
+++ b/Python/optimizer_bytecodes.c
@@ -21,11 +21,13 @@ typedef struct _Py_UOpsAbstractFrame _Py_UOpsAbstractFrame;
 #define sym_new_const _Py_uop_sym_new_const
 #define sym_new_null _Py_uop_sym_new_null
 #define sym_matches_type _Py_uop_sym_matches_type
+#define sym_matches_type_version _Py_uop_sym_matches_type_version
 #define sym_get_type _Py_uop_sym_get_type
 #define sym_has_type _Py_uop_sym_has_type
 #define sym_set_null(SYM) _Py_uop_sym_set_null(ctx, SYM)
 #define sym_set_non_null(SYM) _Py_uop_sym_set_non_null(ctx, SYM)
 #define sym_set_type(SYM, TYPE) _Py_uop_sym_set_type(ctx, SYM, TYPE)
+#define sym_set_type_version(SYM, VERSION) _Py_uop_sym_set_type_version(ctx, SYM, VERSION)
 #define sym_set_const(SYM, CNST) _Py_uop_sym_set_const(ctx, SYM, CNST)
 #define sym_is_bottom _Py_uop_sym_is_bottom
 #define frame_new _Py_uop_frame_new

--- a/Python/optimizer_bytecodes.c
+++ b/Python/optimizer_bytecodes.c
@@ -113,6 +113,13 @@ dummy_func(void) {
         sym_set_type(right, &PyLong_Type);
     }
 
+    op(_GUARD_TYPE_VERSION, (type_version/2, owner -- owner)) {
+        if (sym_matches_type_version(owner, type_version)) {
+            REPLACE_OP(this_instr, _NOP, 0, 0);
+        }
+        sym_set_type_version(owner, type_version);
+    }
+
     op(_GUARD_BOTH_FLOAT, (left, right -- left, right)) {
         if (sym_matches_type(left, &PyFloat_Type)) {
             if (sym_matches_type(right, &PyFloat_Type)) {

--- a/Python/optimizer_bytecodes.c
+++ b/Python/optimizer_bytecodes.c
@@ -116,6 +116,7 @@ dummy_func(void) {
     }
 
     op(_GUARD_TYPE_VERSION, (type_version/2, owner -- owner)) {
+        printf("%d %d %d\n", type_version, owner->typ_version, owner->typ_version_offset);
         if (sym_matches_type_version(owner, type_version)) {
             REPLACE_OP(this_instr, _NOP, 0, 0);
         }
@@ -711,6 +712,7 @@ dummy_func(void) {
     }
 
     op(_ITER_NEXT_RANGE, (iter -- iter, next)) {
+        printf("ciao");
        next = sym_new_type(ctx, &PyLong_Type);
        (void)iter;
     }

--- a/Python/optimizer_bytecodes.c
+++ b/Python/optimizer_bytecodes.c
@@ -27,7 +27,7 @@ typedef struct _Py_UOpsAbstractFrame _Py_UOpsAbstractFrame;
 #define sym_set_null(SYM) _Py_uop_sym_set_null(ctx, SYM)
 #define sym_set_non_null(SYM) _Py_uop_sym_set_non_null(ctx, SYM)
 #define sym_set_type(SYM, TYPE) _Py_uop_sym_set_type(ctx, SYM, TYPE)
-#define sym_set_type_version(SYM, VERSION) _Py_uop_sym_set_type_version(ctx, SYM, VERSION)
+#define sym_set_type_version(SYM, VERSION, OFFSET) _Py_uop_sym_set_type_version(ctx, SYM, VERSION, OFFSET)
 #define sym_set_const(SYM, CNST) _Py_uop_sym_set_const(ctx, SYM, CNST)
 #define sym_is_bottom _Py_uop_sym_is_bottom
 #define frame_new _Py_uop_frame_new
@@ -117,10 +117,10 @@ dummy_func(void) {
 
     op(_GUARD_TYPE_VERSION, (type_version/2, owner -- owner)) {
         printf("%d %d %d\n", type_version, owner->typ_version, owner->typ_version_offset);
-        if (sym_matches_type_version(owner, type_version)) {
+        if (sym_matches_type_version(owner, type_version, ctx->latest_escape_offset)) {
             REPLACE_OP(this_instr, _NOP, 0, 0);
         }
-        sym_set_type_version(owner, type_version);
+        sym_set_type_version(owner, type_version, i);
     }
 
     op(_GUARD_BOTH_FLOAT, (left, right -- left, right)) {

--- a/Python/optimizer_cases.c.h
+++ b/Python/optimizer_cases.c.h
@@ -938,7 +938,6 @@
             _Py_UopsSymbol *owner;
             owner = stack_pointer[-1];
             uint32_t type_version = (uint32_t)this_instr->operand;
-            printf("%d %d %d\n", type_version, owner->typ_version, owner->typ_version_offset);
             if (sym_matches_type_version(owner, type_version, ctx->latest_escape_offset)) {
                 REPLACE_OP(this_instr, _NOP, 0, 0);
             }
@@ -1343,7 +1342,6 @@
             _Py_UopsSymbol *iter;
             _Py_UopsSymbol *next;
             iter = stack_pointer[-1];
-            printf("ciao");
             next = sym_new_type(ctx, &PyLong_Type);
             (void)iter;
             stack_pointer[0] = next;

--- a/Python/optimizer_cases.c.h
+++ b/Python/optimizer_cases.c.h
@@ -935,6 +935,14 @@
         }
 
         case _GUARD_TYPE_VERSION: {
+            _Py_UopsSymbol *owner;
+            owner = stack_pointer[-1];
+            uint32_t type_version = (uint32_t)this_instr->operand;
+            printf("%d %d %d\n", type_version, owner->typ_version, owner->typ_version_offset);
+            if (sym_matches_type_version(owner, type_version, ctx->latest_escape_offset)) {
+                REPLACE_OP(this_instr, _NOP, 0, 0);
+            }
+            sym_set_type_version(owner, type_version, i);
             break;
         }
 
@@ -1335,6 +1343,7 @@
             _Py_UopsSymbol *iter;
             _Py_UopsSymbol *next;
             iter = stack_pointer[-1];
+            printf("ciao");
             next = sym_new_type(ctx, &PyLong_Type);
             (void)iter;
             stack_pointer[0] = next;

--- a/Python/optimizer_symbols.c
+++ b/Python/optimizer_symbols.c
@@ -76,6 +76,7 @@ sym_new(_Py_UOpsContext *ctx)
     self->flags = 0;
     self->typ = NULL;
     self->const_val = NULL;
+    self->typ_version =
 
     return self;
 }

--- a/Python/optimizer_symbols.c
+++ b/Python/optimizer_symbols.c
@@ -157,7 +157,7 @@ _Py_uop_sym_set_type(_Py_UOpsContext *ctx, _Py_UopsSymbol *sym, PyTypeObject *ty
 }
 
 void
-_Py_uop_sym_set_type_version(_Py_UopsContext *ctx, _Py_UopsSymbol *sym, int32_t version)
+_Py_uop_sym_set_type_version(_Py_UOpsContext *ctx, _Py_UopsSymbol *sym, int32_t version)
 {
     sym->typ_version = version;
 }

--- a/Python/optimizer_symbols.c
+++ b/Python/optimizer_symbols.c
@@ -157,9 +157,10 @@ _Py_uop_sym_set_type(_Py_UOpsContext *ctx, _Py_UopsSymbol *sym, PyTypeObject *ty
 }
 
 void
-_Py_uop_sym_set_type_version(_Py_UOpsContext *ctx, _Py_UopsSymbol *sym, int32_t version)
+_Py_uop_sym_set_type_version(_Py_UOpsContext *ctx, _Py_UopsSymbol *sym, int32_t version, int offset)
 {
     sym->typ_version = version;
+    sym->typ_version_offset = offset;
 }
 
 void
@@ -272,6 +273,12 @@ _Py_uop_sym_get_type_version(_Py_UopsSymbol *sym)
     return sym->typ_version;
 }
 
+int
+_Py_uop_sym_get_type_version_offset(_Py_UopsSymbol *sym)
+{
+    return sym->typ_version_offset;
+}
+
 bool
 _Py_uop_sym_has_type(_Py_UopsSymbol *sym)
 {
@@ -289,9 +296,10 @@ _Py_uop_sym_matches_type(_Py_UopsSymbol *sym, PyTypeObject *typ)
 }
 
 bool
-_Py_uop_sym_matches_type_version(_Py_UopsSymbol *sym, int32_t version)
+_Py_uop_sym_matches_type_version(_Py_UopsSymbol *sym, int32_t version, int offset)
 {
-    return _Py_uop_sym_get_type_version(sym) == version;
+    return _Py_uop_sym_get_type_version(sym) == version
+        && _Py_uop_sym_get_type_version_offset(sym) > offset;
 }
 
 

--- a/Python/optimizer_symbols.c
+++ b/Python/optimizer_symbols.c
@@ -52,7 +52,9 @@ static inline int get_lltrace(void) {
 static _Py_UopsSymbol NO_SPACE_SYMBOL = {
     .flags = IS_NULL | NOT_NULL | NO_SPACE,
     .typ = NULL,
-    .const_val = NULL
+    .const_val = NULL,
+    .typ_version = 0,
+    .typ_version_offset = 0,
 };
 
 _Py_UopsSymbol *
@@ -76,7 +78,8 @@ sym_new(_Py_UOpsContext *ctx)
     self->flags = 0;
     self->typ = NULL;
     self->const_val = NULL;
-    self->typ_version =
+    self->typ_version = 0;
+    self->typ_version_offset = 0;
 
     return self;
 }
@@ -151,6 +154,12 @@ _Py_uop_sym_set_type(_Py_UOpsContext *ctx, _Py_UopsSymbol *sym, PyTypeObject *ty
         sym_set_flag(sym, NOT_NULL);
         sym->typ = typ;
     }
+}
+
+void
+_Py_uop_sym_set_type_version(_Py_UopsContext *ctx, _Py_UopsSymbol *sym, int32_t version)
+{
+    sym->typ_version = version;
 }
 
 void
@@ -257,6 +266,12 @@ _Py_uop_sym_get_type(_Py_UopsSymbol *sym)
     return sym->typ;
 }
 
+int32_t
+_Py_uop_sym_get_type_version(_Py_UopsSymbol *sym)
+{
+    return sym->typ_version;
+}
+
 bool
 _Py_uop_sym_has_type(_Py_UopsSymbol *sym)
 {
@@ -272,6 +287,13 @@ _Py_uop_sym_matches_type(_Py_UopsSymbol *sym, PyTypeObject *typ)
     assert(typ != NULL && PyType_Check(typ));
     return _Py_uop_sym_get_type(sym) == typ;
 }
+
+bool
+_Py_uop_sym_matches_type_version(_Py_UopsSymbol *sym, int32_t version)
+{
+    return _Py_uop_sym_get_type_version(sym) == version;
+}
+
 
 int
 _Py_uop_sym_truthiness(_Py_UopsSymbol *sym)


### PR DESCRIPTION
This PR eliminates some unnecessary calls to `_GUARD_TYPE_VERSION` in the tier 2 interpreter, closing #119258.

It does it by symbolically tracking the version of the type of each object and eliminating the type guard if the checked version is the same as the tracked one.

It also has to verify that there were no operations that might have escaped since we recorded the type version. So we store the last instruction offset that could lead to an escape (and possibly change the type version), and also store at which instruction offset we stored the version. We can compare these when optimizing, to make sure to only remove the bytecode if we haven't escaped after recording the version.

_Work on this PR was done at the PyCon sprints with @dpdani and with help from @Fidget-Spinner and @markshannon_

## Development

In order to try out this commit, you have to configure it with the experimental jit:

```bash
./configure --with-pydebug --enable-experimental-jit=interpreter
```

Then whenever you change the cases you have to run `make regen-cases` and then `make -j`.

Finally, to just run one test case, you can use the `--match`:

```bash
./python.exe -m test -v test_capi.test_opt --match test_guard_type_version_removed
./python.exe -m test -v test_capi.test_opt --match test_guard_type_version_not_removed
```



<!-- gh-issue-number: gh-119258 -->
* Issue: gh-119258
<!-- /gh-issue-number -->
