### PR TITLE
[3.13] Docs: Ensure no warnings are found in the NEWS file before a given line number (GH-119221)

### DIFF
--- a/.github/workflows/reusable-docs.yml
+++ b/.github/workflows/reusable-docs.yml
@@ -62,7 +62,8 @@ jobs:
         python Doc/tools/check-warnings.py \
           --annotate-diff '${{ env.branch_base }}' '${{ env.branch_pr }}' \
           --fail-if-regression \
-          --fail-if-improved
+          --fail-if-improved \
+          --fail-if-new-news-nit
 
   # This build doesn't use problem matchers or check annotations
   build_doc_oldest_supported_sphinx:

--- a/Misc/NEWS.d/next/Core and Builtins/2024-05-07-16-57-56.gh-issue-118561.wNMKVd.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2024-05-07-16-57-56.gh-issue-118561.wNMKVd.rst
@@ -1,2 +1,2 @@
-Fix race condition in free-threaded build where :meth:`list.extend` could expose
-uninitialied memory to concurrent readers.
+Fix race condition in free-threaded build where :meth:`!list.extend` could
+expose uninitialised memory to concurrent readers.

--- a/Misc/NEWS.d/next/Library/2023-04-10-00-04-37.gh-issue-87106.UyBnPQ.rst
+++ b/Misc/NEWS.d/next/Library/2023-04-10-00-04-37.gh-issue-87106.UyBnPQ.rst
@@ -1,3 +1,3 @@
-Fixed handling in :meth:`inspect.signature.bind` of keyword arguments having
+Fixed handling in :meth:`inspect.Signature.bind` of keyword arguments having
 the same name as positional-only arguments when a variadic keyword argument
 (e.g. ``**kwargs``) is present.


### PR DESCRIPTION


(cherry picked from commit 034cf0c3167c850c8341deb61e210cb0dbcdb02d)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--119261.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->