### PR TITLE
[3.12] Docs: Ensure no warnings are found in the NEWS file before a given line number (GH-119221)

### DIFF
--- a/.github/workflows/reusable-docs.yml
+++ b/.github/workflows/reusable-docs.yml
@@ -62,7 +62,8 @@ jobs:
         python Doc/tools/check-warnings.py \
           --annotate-diff '${{ env.branch_base }}' '${{ env.branch_pr }}' \
           --fail-if-regression \
-          --fail-if-improved
+          --fail-if-improved \
+          --fail-if-new-news-nit
 
   # This build doesn't use problem matchers or check annotations
   build_doc_oldest_supported_sphinx:

--- a/Misc/NEWS.d/next/Library/2023-04-10-00-04-37.gh-issue-87106.UyBnPQ.rst
+++ b/Misc/NEWS.d/next/Library/2023-04-10-00-04-37.gh-issue-87106.UyBnPQ.rst
@@ -1,3 +1,3 @@
-Fixed handling in :meth:`inspect.signature.bind` of keyword arguments having
+Fixed handling in :meth:`inspect.Signature.bind` of keyword arguments having
 the same name as positional-only arguments when a variadic keyword argument
 (e.g. ``**kwargs``) is present.

--- a/Misc/NEWS.d/next/Library/2024-04-17-18-00-30.gh-issue-80361.RstWg-.rst
+++ b/Misc/NEWS.d/next/Library/2024-04-17-18-00-30.gh-issue-80361.RstWg-.rst
@@ -1,2 +1,2 @@
-Fix TypeError in :func:`email.Message.get_payload` when the charset is :rfc:`2231`
-encoded.
+Fix TypeError in :func:`email.message.Message.get_payload` when the charset is
+:rfc:`2231` encoded.

--- a/Misc/NEWS.d/next/Library/2024-04-24-12-20-48.gh-issue-118013.TKn_kZ.rst
+++ b/Misc/NEWS.d/next/Library/2024-04-24-12-20-48.gh-issue-118013.TKn_kZ.rst
@@ -5,5 +5,5 @@ to that instance's class to persist in an internal cache in the
 class was dynamically created, the class held strong references to other
 objects which took up a significant amount of memory, and the cache
 contained the sole strong reference to the class. The fix for the regression
-leads to a slowdown in :func:`getattr_static`, but the function should still
-be signficantly faster than it was in Python 3.11. Patch by Alex Waygood.
+leads to a slowdown in :func:`!getattr_static`, but the function should still
+be significantly faster than it was in Python 3.11. Patch by Alex Waygood.

--- a/Misc/NEWS.d/next/Library/2024-04-24-12-29-33.gh-issue-118221.2k_bac.rst
+++ b/Misc/NEWS.d/next/Library/2024-04-24-12-29-33.gh-issue-118221.2k_bac.rst
@@ -1,2 +1,2 @@
-Fix a bug where :func:`sqlite3.iterdump` could fail if a custom :attr:`row
+Fix a bug where :func:`!sqlite3.iterdump` could fail if a custom :attr:`row
 factory <sqlite3.Connection.row_factory>` was used. Patch by Erlend Aasland.

--- a/Misc/NEWS.d/next/Library/2024-04-25-12-02-06.gh-issue-118042.2EcdHf.rst
+++ b/Misc/NEWS.d/next/Library/2024-04-25-12-02-06.gh-issue-118042.2EcdHf.rst
@@ -1,2 +1,2 @@
-Fix an unraisable exception in :meth:`telnetlib.Telnet.__del__` when the
+Fix an unraisable exception in :meth:`!telnetlib.Telnet.__del__` when the
 ``__init__()`` method was not called.


### PR DESCRIPTION

(cherry picked from commit 034cf0c3167c850c8341deb61e210cb0dbcdb02d)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--119266.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->