### PR TITLE
gh-119102: Fix REPL for dumb terminal

### DIFF
--- a/Lib/site.py
+++ b/Lib/site.py
@@ -523,8 +523,9 @@ def register_readline():
             pass
 
         def write_history():
+            from _pyrepl.__main__ import CAN_USE_PYREPL
             try:
-                if os.getenv("PYTHON_BASIC_REPL"):
+                if os.getenv("PYTHON_BASIC_REPL") or not CAN_USE_PYREPL:
                     readline.write_history_file(history)
                 else:
                     _pyrepl.readline.write_history_file(history)


### PR DESCRIPTION
Move CAN_USE_PYREPL variable from _pyrepl.__main__ to _pyrepl and rename it to _CAN_USE_PYREPL. Use the variable in the site module to decide if _pyrepl.write_history_file() can be used.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-119102 -->
* Issue: gh-119102
<!-- /gh-issue-number -->
