### PR TITLE
gh-102136: Add -m to options that work with -i

### DIFF
--- a/Doc/using/cmdline.rst
+++ b/Doc/using/cmdline.rst
@@ -290,15 +290,15 @@ Miscellaneous options
 
 .. option:: -i
 
-   Enter interactive mode after execution. 
+   Enter interactive mode after execution.
 
    Using the :option:`-i` option will enter interactive mode in any of the following circumstances\:
 
    * When a script is passed as first argument
    * When the :option:`-c` option is used
    * When the :option:`-m` option is used
-  
-   Interactive mode will start even when :data:`sys.stdin` does not appear to be a terminal.  The
+
+   Interactive mode will start even when :data:`sys.stdin` does not appear to be a terminal. The
    :envvar:`PYTHONSTARTUP` file is not read.
 
    This can be useful to inspect global variables or a stack trace when a script

--- a/Doc/using/cmdline.rst
+++ b/Doc/using/cmdline.rst
@@ -290,9 +290,15 @@ Miscellaneous options
 
 .. option:: -i
 
-   When a script is passed as first argument or the :option:`-c` option is used,
-   enter interactive mode after executing the script or the command, even when
-   :data:`sys.stdin` does not appear to be a terminal.  The
+   Enter interactive mode after execution. 
+
+   Using the :option:`-i` option will enter interactive mode in any of the following circumstances\:
+
+   * When a script is passed as first argument
+   * When the :option:`-c` option is used
+   * When the :option:`-m` option is used
+  
+   Interactive mode will start even when :data:`sys.stdin` does not appear to be a terminal.  The
    :envvar:`PYTHONSTARTUP` file is not read.
 
    This can be useful to inspect global variables or a stack trace when a script


### PR DESCRIPTION
Issue [102136](https://github.com/python/cpython/issues/102136) pointed out that `-m` is not mentioned in the section that talks about `-i`, when `-i` actually does work when used in conjunction with `-m`. This PR updates the documentation to include the `-m` flag. 

Before: 
<img width="826" alt="image" src="https://github.com/python/cpython/assets/8459334/4ab5b1ce-b017-41bb-a374-d402820e8100">


After: 
<img width="833" alt="image" src="https://github.com/python/cpython/assets/8459334/39690e60-fd74-4afb-85fe-154165fb4846">



<!-- gh-issue-number: gh-102136 -->
* Issue: gh-102136
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--119271.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->