### PR TITLE
[3.12] gh-119050: Add XML support to libregrtest refleak checker (#119148)

### DIFF
--- a/Lib/test/libregrtest/cmdline.py
+++ b/Lib/test/libregrtest/cmdline.py
@@ -513,15 +513,6 @@ def _parse_args(args, **kwargs):
               "--huntrleaks without -jN option",
               file=sys.stderr)
 
-    if ns.huntrleaks and ns.xmlpath:
-        # The XML data is written into a file outside runtest_refleak(), so
-        # it looks like a leak but it's not. Simply disable XML output when
-        # hunting for reference leaks (gh-83434).
-        ns.xmlpath = None
-        print("WARNING: Disable --junit-xml because it's incompatible "
-              "with --huntrleaks",
-              file=sys.stderr)
-
     if ns.forever:
         # --forever implies --failfast
         ns.failfast = True

--- a/Lib/test/libregrtest/single.py
+++ b/Lib/test/libregrtest/single.py
@@ -57,7 +57,10 @@ def _run_suite(suite):
     result = runner.run(suite)
 
     if support.junit_xml_list is not None:
-        support.junit_xml_list.append(result.get_xml_element())
+        import xml.etree.ElementTree as ET
+        xml_elem = result.get_xml_element()
+        xml_str = ET.tostring(xml_elem).decode('ascii')
+        support.junit_xml_list.append(xml_str)
 
     if not result.testsRun and not result.skipped and not result.errors:
         raise support.TestDidNotRun
@@ -280,9 +283,7 @@ def _runtest(result: TestResult, runtests: RunTests) -> None:
 
         xml_list = support.junit_xml_list
         if xml_list:
-            import xml.etree.ElementTree as ET
-            result.xml_data = [ET.tostring(x).decode('us-ascii')
-                               for x in xml_list]
+            result.xml_data = xml_list
     finally:
         if use_timeout:
             faulthandler.cancel_dump_traceback_later()

--- a/Lib/test/test_regrtest.py
+++ b/Lib/test/test_regrtest.py
@@ -464,15 +464,6 @@ class ParseArgsTestCase(unittest.TestCase):
         self.assertEqual(regrtest.hunt_refleak.runs, 10)
         self.assertFalse(regrtest.output_on_failure)
 
-    def test_xml_huntrleaks(self):
-        args = ['-R', '3:12', '--junit-xml', 'output.xml']
-        with support.captured_stderr():
-            regrtest = self.create_regrtest(args)
-        self.assertIsNotNone(regrtest.hunt_refleak)
-        self.assertEqual(regrtest.hunt_refleak.warmups, 3)
-        self.assertEqual(regrtest.hunt_refleak.runs, 12)
-        self.assertIsNone(regrtest.junit_filename)
-
 
 @dataclasses.dataclass(slots=True)
 class Rerun:

--- a/Misc/NEWS.d/next/Tests/2024-05-18-10-59-27.gh-issue-119050.g4qiH7.rst
+++ b/Misc/NEWS.d/next/Tests/2024-05-18-10-59-27.gh-issue-119050.g4qiH7.rst
@@ -1,0 +1,2 @@
+regrtest test runner: Add XML support to the refleak checker (-R option).
+Patch by Victor Stinner.


### PR DESCRIPTION
regrtest test runner: Add XML support to the refleak checker (-R option).

* run_unittest() now stores XML elements as string, rather than objects, in support.junit_xml_list.
* runtest_refleak() now saves/restores XML strings before/after checking for reference leaks. Save XML into a temporary file.

(cherry picked from commit 9257731f5d3e9d4f99e314b23a14506563e167d7)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-119050 -->
* Issue: gh-119050
<!-- /gh-issue-number -->
