### PR TITLE
gh-119273: Don't run test_ioctl in a process group

### DIFF
--- a/Lib/test/libregrtest/run_workers.py
+++ b/Lib/test/libregrtest/run_workers.py
@@ -142,14 +142,20 @@ class WorkerThread(threading.Thread):
             return
         self._killed = True
 
-        if USE_PROCESS_GROUP:
+        use_killpg = USE_PROCESS_GROUP
+        if use_killpg:
+            parent_sid = os.getsid(0)
+            sid = os.getsid(popen.pid)
+            use_killpg = (sid != parent_sid)
+
+        if use_killpg:
             what = f"{self} process group"
         else:
             what = f"{self} process"
 
         print(f"Kill {what}", file=sys.stderr, flush=True)
         try:
-            if USE_PROCESS_GROUP:
+            if use_killpg:
                 os.killpg(popen.pid, signal.SIGKILL)
             else:
                 popen.kill()

--- a/Lib/test/libregrtest/worker.py
+++ b/Lib/test/libregrtest/worker.py
@@ -14,6 +14,9 @@ from .utils import (
 
 
 USE_PROCESS_GROUP = (hasattr(os, "setsid") and hasattr(os, "killpg"))
+NEED_TTY = set('''
+    test_ioctl
+'''.split())
 
 
 def create_worker_process(runtests: WorkerRunTests, output_fd: int,
@@ -47,7 +50,10 @@ def create_worker_process(runtests: WorkerRunTests, output_fd: int,
         close_fds=True,
         cwd=work_dir,
     )
-    if USE_PROCESS_GROUP:
+
+    # Don't use setsid() in tests using TTY
+    test_name = runtests.tests[0]
+    if USE_PROCESS_GROUP and test_name not in NEED_TTY:
         kwargs['start_new_session'] = True
 
     # Pass json_file to the worker process

--- a/Misc/NEWS.d/next/Tests/2024-05-20-18-06-31.gh-issue-119273.hf-yhX.rst
+++ b/Misc/NEWS.d/next/Tests/2024-05-20-18-06-31.gh-issue-119273.hf-yhX.rst
@@ -1,0 +1,3 @@
+Python test runner no longer runs tests using TTY (ex: test_ioctl) in a
+process group (using ``setsid()``). Previously, tests using TTY were
+skipped. Patch by Victor Stinner.


### PR DESCRIPTION
Python test runner no longer runs tests using TTY (ex: test_ioctl) in a process group (using setsid()). Previously, tests using TTY were skipped.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-119273 -->
* Issue: gh-119273
<!-- /gh-issue-number -->
