### PR TITLE
gh-119281: Use TYPE_CHECKING for _pyrepl type checks

### DIFF
--- a/Lib/_pyrepl/commands.py
+++ b/Lib/_pyrepl/commands.py
@@ -20,7 +20,9 @@
 # CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 from __future__ import annotations
+
 import os
+from typing import TYPE_CHECKING
 
 # Categories of actions:
 #  killing
@@ -32,8 +34,7 @@ import os
 # [completion]
 
 
-# types
-if False:
+if TYPE_CHECKING:
     from .historical_reader import HistoricalReader
 
 

--- a/Lib/_pyrepl/completing_reader.py
+++ b/Lib/_pyrepl/completing_reader.py
@@ -20,17 +20,16 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
-
 import re
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
 from . import commands, console, reader
 from .reader import Reader
 
 
-# types
 Command = commands.Command
-if False:
-    from .types import Callback, SimpleContextManager, KeySpec, CommandName
+if TYPE_CHECKING:
+    from .types import KeySpec, CommandName
 
 
 def prefix(wordlist: list[str], j: int = 0) -> str:

--- a/Lib/_pyrepl/historical_reader.py
+++ b/Lib/_pyrepl/historical_reader.py
@@ -21,13 +21,14 @@ from __future__ import annotations
 
 from contextlib import contextmanager
 from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
 
 from . import commands, input
 from .reader import Reader
 
 
-if False:
-    from .types import Callback, SimpleContextManager, KeySpec, CommandName
+if TYPE_CHECKING:
+    from .types import SimpleContextManager, KeySpec, CommandName
 
 
 isearch_keymap: tuple[tuple[KeySpec, CommandName], ...] = tuple(

--- a/Lib/_pyrepl/input.py
+++ b/Lib/_pyrepl/input.py
@@ -35,13 +35,13 @@
 
 from __future__ import annotations
 
-from abc import ABC, abstractmethod
 import unicodedata
+from abc import ABC, abstractmethod
 from collections import deque
+from typing import TYPE_CHECKING
 
 
-# types
-if False:
+if TYPE_CHECKING:
     from .types import EventTuple
 
 

--- a/Lib/_pyrepl/pager.py
+++ b/Lib/_pyrepl/pager.py
@@ -4,11 +4,11 @@ import io
 import os
 import re
 import sys
+from typing import TYPE_CHECKING
 
 
-# types
-if False:
-    from typing import Protocol, Any
+if TYPE_CHECKING:
+    from typing import Protocol
     class Pager(Protocol):
         def __call__(self, text: str, title: str = "") -> None:
             ...

--- a/Lib/_pyrepl/reader.py
+++ b/Lib/_pyrepl/reader.py
@@ -21,20 +21,19 @@
 
 from __future__ import annotations
 
+import unicodedata
 from contextlib import contextmanager
 from dataclasses import dataclass, field, fields
-import unicodedata
 from _colorize import can_colorize, ANSIColors  # type: ignore[import-not-found]
-
+from typing import TYPE_CHECKING
 
 from . import commands, console, input
 from .utils import ANSI_ESCAPE_SEQUENCE, wlen
 from .trace import trace
 
 
-# types
 Command = commands.Command
-if False:
+if TYPE_CHECKING:
     from .types import Callback, SimpleContextManager, KeySpec, CommandName
 
 

--- a/Lib/_pyrepl/trace.py
+++ b/Lib/_pyrepl/trace.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
 import os
+from typing import TYPE_CHECKING
 
-# types
-if False:
+if TYPE_CHECKING:
     from typing import IO
 
 

--- a/Misc/NEWS.d/next/Library/2024-05-20-18-59-36.gh-issue-119281.BOcpY8.rst
+++ b/Misc/NEWS.d/next/Library/2024-05-20-18-59-36.gh-issue-119281.BOcpY8.rst
@@ -1,0 +1,1 @@
+Update type checking conditions in _pyrepl module to use TYPE_CHECKING


### PR DESCRIPTION
This is a really small change. I just noticed it as I was going through the new repl issues and code and figured I'd put in a small PR to clean up. Instead of a `# types` comment and an `if False`, it updates the module to use `TYPE_CHECKING`, which feels a bit more clear.

<!-- gh-issue-number: gh-119281 -->
* Issue: gh-119281
<!-- /gh-issue-number -->
