### PR TITLE
gh-119292: Add job to `jit.yml` to build and test with `--disable-gil`

### DIFF
--- a/.github/workflows/jit.yml
+++ b/.github/workflows/jit.yml
@@ -146,12 +146,7 @@ jobs:
   #         ./python -m test --ignorefile=Tools/jit/ignore-tests-emulated-linux.txt --multiprocess 0 --timeout 4500 --verbose2 --verbose3
 
   jit-with-no-gil:
-    runs-on: x86_64-unknown-linux-gnu/gcc
-    strategy:
-      fail-fast: false
-      matrix:
-        llvm:
-          - 18
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -159,8 +154,8 @@ jobs:
           python-version: '3.11'
       - name: Build with JIT and No GIL
         run: |
-          sudo bash -c "$(wget -O - https://apt.llvm.org/llvm.sh)" ./llvm.sh ${{ matrix.llvm }}
-          export PATH="$(llvm-config-${{ matrix.llvm }} --bindir):$PATH"
+          sudo bash -c "$(wget -O - https://apt.llvm.org/llvm.sh)" ./llvm.sh 18
+          export PATH="$(llvm-config-18 --bindir):$PATH"
           ./configure --enable-experimental-jit --with-pydebug --disable-gil
           make all --jobs 4
       - name: Run Test Suite

--- a/.github/workflows/jit.yml
+++ b/.github/workflows/jit.yml
@@ -146,6 +146,7 @@ jobs:
           ./python -m test --ignorefile=Tools/jit/ignore-tests-emulated-linux.txt --multiprocess 0 --timeout 4500 --verbose2 --verbose3
 
   jit-with-disabled-gil:
+    name: Free-Threaded (Debug)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/jit.yml
+++ b/.github/workflows/jit.yml
@@ -85,7 +85,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.11' 
+          python-version: '3.11'
 
       - name: Native Windows
         if: runner.os == 'Windows' && matrix.architecture != 'ARM64'

--- a/.github/workflows/jit.yml
+++ b/.github/workflows/jit.yml
@@ -152,7 +152,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.11'
-      - name: Build with JIT and GIL disabled
+      - name: Build with JIT enabled and GIL disabled
         run: |
           sudo bash -c "$(wget -O - https://apt.llvm.org/llvm.sh)" ./llvm.sh 18
           export PATH="$(llvm-config-18 --bindir):$PATH"

--- a/.github/workflows/jit.yml
+++ b/.github/workflows/jit.yml
@@ -20,130 +20,130 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # jit:
-  #   name: ${{ matrix.target }} (${{ matrix.debug && 'Debug' || 'Release' }})
-  #   runs-on: ${{ matrix.runner }}
-  #   timeout-minutes: 90
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       target:
-  #         - i686-pc-windows-msvc/msvc
-  #         - x86_64-pc-windows-msvc/msvc
-  #         - aarch64-pc-windows-msvc/msvc
-  #         - x86_64-apple-darwin/clang
-  #         - aarch64-apple-darwin/clang
-  #         - x86_64-unknown-linux-gnu/gcc
-  #         - x86_64-unknown-linux-gnu/clang
-  #         - aarch64-unknown-linux-gnu/gcc
-  #         - aarch64-unknown-linux-gnu/clang
-  #       debug:
-  #         - true
-  #         - false
-  #       llvm:
-  #         - 18
-  #       include:
-  #         - target: i686-pc-windows-msvc/msvc
-  #           architecture: Win32
-  #           runner: windows-latest
-  #           compiler: msvc
-  #         - target: x86_64-pc-windows-msvc/msvc
-  #           architecture: x64
-  #           runner: windows-latest
-  #           compiler: msvc
-  #         - target: aarch64-pc-windows-msvc/msvc
-  #           architecture: ARM64
-  #           runner: windows-latest
-  #           compiler: msvc
-  #         - target: x86_64-apple-darwin/clang
-  #           architecture: x86_64
-  #           runner: macos-13
-  #           compiler: clang
-  #         - target: aarch64-apple-darwin/clang
-  #           architecture: aarch64
-  #           runner: macos-14
-  #           compiler: clang
-  #         - target: x86_64-unknown-linux-gnu/gcc
-  #           architecture: x86_64
-  #           runner: ubuntu-latest
-  #           compiler: gcc
-  #         - target: x86_64-unknown-linux-gnu/clang
-  #           architecture: x86_64
-  #           runner: ubuntu-latest
-  #           compiler: clang
-  #         - target: aarch64-unknown-linux-gnu/gcc
-  #           architecture: aarch64
-  #           runner: ubuntu-latest
-  #           compiler: gcc
-  #         - target: aarch64-unknown-linux-gnu/clang
-  #           architecture: aarch64
-  #           runner: ubuntu-latest
-  #           compiler: clang
-  #   env:
-  #     CC: ${{ matrix.compiler }}
-  #   steps:
-  #     - uses: actions/checkout@v4
-  #     - uses: actions/setup-python@v5
-  #       with:
-  #         python-version: '3.11' 
+  jit:
+    name: ${{ matrix.target }} (${{ matrix.debug && 'Debug' || 'Release' }})
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 90
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - i686-pc-windows-msvc/msvc
+          - x86_64-pc-windows-msvc/msvc
+          - aarch64-pc-windows-msvc/msvc
+          - x86_64-apple-darwin/clang
+          - aarch64-apple-darwin/clang
+          - x86_64-unknown-linux-gnu/gcc
+          - x86_64-unknown-linux-gnu/clang
+          - aarch64-unknown-linux-gnu/gcc
+          - aarch64-unknown-linux-gnu/clang
+        debug:
+          - true
+          - false
+        llvm:
+          - 18
+        include:
+          - target: i686-pc-windows-msvc/msvc
+            architecture: Win32
+            runner: windows-latest
+            compiler: msvc
+          - target: x86_64-pc-windows-msvc/msvc
+            architecture: x64
+            runner: windows-latest
+            compiler: msvc
+          - target: aarch64-pc-windows-msvc/msvc
+            architecture: ARM64
+            runner: windows-latest
+            compiler: msvc
+          - target: x86_64-apple-darwin/clang
+            architecture: x86_64
+            runner: macos-13
+            compiler: clang
+          - target: aarch64-apple-darwin/clang
+            architecture: aarch64
+            runner: macos-14
+            compiler: clang
+          - target: x86_64-unknown-linux-gnu/gcc
+            architecture: x86_64
+            runner: ubuntu-latest
+            compiler: gcc
+          - target: x86_64-unknown-linux-gnu/clang
+            architecture: x86_64
+            runner: ubuntu-latest
+            compiler: clang
+          - target: aarch64-unknown-linux-gnu/gcc
+            architecture: aarch64
+            runner: ubuntu-latest
+            compiler: gcc
+          - target: aarch64-unknown-linux-gnu/clang
+            architecture: aarch64
+            runner: ubuntu-latest
+            compiler: clang
+    env:
+      CC: ${{ matrix.compiler }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11' 
 
-  #     - name: Native Windows
-  #       if: runner.os == 'Windows' && matrix.architecture != 'ARM64'
-  #       run: |
-  #         choco upgrade llvm -y
-  #         choco install llvm --allow-downgrade --no-progress --version ${{ matrix.llvm }}
-  #         ./PCbuild/build.bat --experimental-jit ${{ matrix.debug && '-d' || '--pgo' }} -p ${{ matrix.architecture }}
-  #         ./PCbuild/rt.bat ${{ matrix.debug && '-d' || '' }} -p ${{ matrix.architecture }} -q --multiprocess 0 --timeout 4500 --verbose2 --verbose3
+      - name: Native Windows
+        if: runner.os == 'Windows' && matrix.architecture != 'ARM64'
+        run: |
+          choco upgrade llvm -y
+          choco install llvm --allow-downgrade --no-progress --version ${{ matrix.llvm }}
+          ./PCbuild/build.bat --experimental-jit ${{ matrix.debug && '-d' || '--pgo' }} -p ${{ matrix.architecture }}
+          ./PCbuild/rt.bat ${{ matrix.debug && '-d' || '' }} -p ${{ matrix.architecture }} -q --multiprocess 0 --timeout 4500 --verbose2 --verbose3
 
-  #     # No PGO or tests (yet):
-  #     - name: Emulated Windows
-  #       if: runner.os == 'Windows' && matrix.architecture == 'ARM64'
-  #       run: |
-  #         choco upgrade llvm -y
-  #         choco install llvm --allow-downgrade --no-progress --version ${{ matrix.llvm }}
-  #         ./PCbuild/build.bat --experimental-jit ${{ matrix.debug && '-d' || '' }} -p ${{ matrix.architecture }}
+      # No PGO or tests (yet):
+      - name: Emulated Windows
+        if: runner.os == 'Windows' && matrix.architecture == 'ARM64'
+        run: |
+          choco upgrade llvm -y
+          choco install llvm --allow-downgrade --no-progress --version ${{ matrix.llvm }}
+          ./PCbuild/build.bat --experimental-jit ${{ matrix.debug && '-d' || '' }} -p ${{ matrix.architecture }}
 
-  #     - name: Native macOS
-  #       if: runner.os == 'macOS'
-  #       run: |
-  #         brew update
-  #         brew install llvm@${{ matrix.llvm }}
-  #         SDKROOT="$(xcrun --show-sdk-path)" \
-  #           ./configure --enable-experimental-jit ${{ matrix.debug && '--with-pydebug' || '--enable-optimizations --with-lto' }}
-  #         make all --jobs 4
-  #         ./python.exe -m test --multiprocess 0 --timeout 4500 --verbose2 --verbose3
+      - name: Native macOS
+        if: runner.os == 'macOS'
+        run: |
+          brew update
+          brew install llvm@${{ matrix.llvm }}
+          SDKROOT="$(xcrun --show-sdk-path)" \
+            ./configure --enable-experimental-jit ${{ matrix.debug && '--with-pydebug' || '--enable-optimizations --with-lto' }}
+          make all --jobs 4
+          ./python.exe -m test --multiprocess 0 --timeout 4500 --verbose2 --verbose3
 
-  #     # --with-lto has been removed temporarily as a result of an open issue in LLVM 18 (see https://github.com/llvm/llvm-project/issues/87553)
-  #     - name: Native Linux
-  #       if: runner.os == 'Linux' && matrix.architecture == 'x86_64'
-  #       run: |
-  #         sudo bash -c "$(wget -O - https://apt.llvm.org/llvm.sh)" ./llvm.sh ${{ matrix.llvm }}
-  #         export PATH="$(llvm-config-${{ matrix.llvm }} --bindir):$PATH"
-  #         ./configure --enable-experimental-jit ${{ matrix.debug && '--with-pydebug' || '--enable-optimizations' }}
-  #         make all --jobs 4
-  #         ./python -m test --multiprocess 0 --timeout 4500 --verbose2 --verbose3
+      # --with-lto has been removed temporarily as a result of an open issue in LLVM 18 (see https://github.com/llvm/llvm-project/issues/87553)
+      - name: Native Linux
+        if: runner.os == 'Linux' && matrix.architecture == 'x86_64'
+        run: |
+          sudo bash -c "$(wget -O - https://apt.llvm.org/llvm.sh)" ./llvm.sh ${{ matrix.llvm }}
+          export PATH="$(llvm-config-${{ matrix.llvm }} --bindir):$PATH"
+          ./configure --enable-experimental-jit ${{ matrix.debug && '--with-pydebug' || '--enable-optimizations' }}
+          make all --jobs 4
+          ./python -m test --multiprocess 0 --timeout 4500 --verbose2 --verbose3
 
-  #     # --with-lto has been removed temporarily as a result of an open issue in LLVM 18 (see https://github.com/llvm/llvm-project/issues/87553)
-  #     - name: Emulated Linux
-  #       if: runner.os == 'Linux' && matrix.architecture != 'x86_64'
-  #       # The --ignorefile on ./python -m test is used to exclude tests known to fail when running on an emulated Linux.
-  #       run: |
-  #         sudo bash -c "$(wget -O - https://apt.llvm.org/llvm.sh)" ./llvm.sh ${{ matrix.llvm }}
-  #         export PATH="$(llvm-config-${{ matrix.llvm }} --bindir):$PATH"
-  #         ./configure --prefix="$(pwd)/../build"
-  #         make install --jobs 4
-  #         make clean --jobs 4
-  #         export HOST=${{ matrix.architecture }}-linux-gnu
-  #         sudo apt install --yes "gcc-$HOST" qemu-user
-  #         ${{ !matrix.debug && matrix.compiler == 'clang' && './configure --enable-optimizations' || '' }}
-  #         ${{ !matrix.debug && matrix.compiler == 'clang' && 'make profile-run-stamp --jobs 4' || '' }}
-  #         export QEMU_LD_PREFIX="/usr/$HOST"
-  #         CC="${{ matrix.compiler == 'clang' && 'clang --target=$HOST' || '$HOST-gcc' }}" \
-  #           CPP="$CC --preprocess" \
-  #           HOSTRUNNER=qemu-${{ matrix.architecture }} \
-  #           ./configure --enable-experimental-jit ${{ matrix.debug && '--with-pydebug' || '--enable-optimizations ' }} --build=x86_64-linux-gnu --host="$HOST" --with-build-python=../build/bin/python3 --with-pkg-config=no ac_cv_buggy_getaddrinfo=no ac_cv_file__dev_ptc=no ac_cv_file__dev_ptmx=yes
-  #         make all --jobs 4
-  #         ./python -m test --ignorefile=Tools/jit/ignore-tests-emulated-linux.txt --multiprocess 0 --timeout 4500 --verbose2 --verbose3
+      # --with-lto has been removed temporarily as a result of an open issue in LLVM 18 (see https://github.com/llvm/llvm-project/issues/87553)
+      - name: Emulated Linux
+        if: runner.os == 'Linux' && matrix.architecture != 'x86_64'
+        # The --ignorefile on ./python -m test is used to exclude tests known to fail when running on an emulated Linux.
+        run: |
+          sudo bash -c "$(wget -O - https://apt.llvm.org/llvm.sh)" ./llvm.sh ${{ matrix.llvm }}
+          export PATH="$(llvm-config-${{ matrix.llvm }} --bindir):$PATH"
+          ./configure --prefix="$(pwd)/../build"
+          make install --jobs 4
+          make clean --jobs 4
+          export HOST=${{ matrix.architecture }}-linux-gnu
+          sudo apt install --yes "gcc-$HOST" qemu-user
+          ${{ !matrix.debug && matrix.compiler == 'clang' && './configure --enable-optimizations' || '' }}
+          ${{ !matrix.debug && matrix.compiler == 'clang' && 'make profile-run-stamp --jobs 4' || '' }}
+          export QEMU_LD_PREFIX="/usr/$HOST"
+          CC="${{ matrix.compiler == 'clang' && 'clang --target=$HOST' || '$HOST-gcc' }}" \
+            CPP="$CC --preprocess" \
+            HOSTRUNNER=qemu-${{ matrix.architecture }} \
+            ./configure --enable-experimental-jit ${{ matrix.debug && '--with-pydebug' || '--enable-optimizations ' }} --build=x86_64-linux-gnu --host="$HOST" --with-build-python=../build/bin/python3 --with-pkg-config=no ac_cv_buggy_getaddrinfo=no ac_cv_file__dev_ptc=no ac_cv_file__dev_ptmx=yes
+          make all --jobs 4
+          ./python -m test --ignorefile=Tools/jit/ignore-tests-emulated-linux.txt --multiprocess 0 --timeout 4500 --verbose2 --verbose3
 
   jit-with-no-gil:
     runs-on: ubuntu-latest
@@ -152,12 +152,12 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.11'
-      - name: Build with JIT and No GIL
+      - name: Build with JIT and GIL disabled
         run: |
           sudo bash -c "$(wget -O - https://apt.llvm.org/llvm.sh)" ./llvm.sh 18
           export PATH="$(llvm-config-18 --bindir):$PATH"
           ./configure --enable-experimental-jit --with-pydebug --disable-gil
           make all --jobs 4
-      - name: Run Test Suite
+      - name: Run tests
         run: |
           ./python -m test --multiprocess 0 --timeout 4500 --verbose2 --verbose3      

--- a/.github/workflows/jit.yml
+++ b/.github/workflows/jit.yml
@@ -20,131 +20,131 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  jit:
-    name: ${{ matrix.target }} (${{ matrix.debug && 'Debug' || 'Release' }})
-    runs-on: ${{ matrix.runner }}
-    timeout-minutes: 90
-    strategy:
-      fail-fast: false
-      matrix:
-        target:
-          - i686-pc-windows-msvc/msvc
-          - x86_64-pc-windows-msvc/msvc
-          - aarch64-pc-windows-msvc/msvc
-          - x86_64-apple-darwin/clang
-          - aarch64-apple-darwin/clang
-          - x86_64-unknown-linux-gnu/gcc
-          - x86_64-unknown-linux-gnu/clang
-          - aarch64-unknown-linux-gnu/gcc
-          - aarch64-unknown-linux-gnu/clang
-        debug:
-          - true
-          - false
-        llvm:
-          - 18
-        include:
-          - target: i686-pc-windows-msvc/msvc
-            architecture: Win32
-            runner: windows-latest
-            compiler: msvc
-          - target: x86_64-pc-windows-msvc/msvc
-            architecture: x64
-            runner: windows-latest
-            compiler: msvc
-          - target: aarch64-pc-windows-msvc/msvc
-            architecture: ARM64
-            runner: windows-latest
-            compiler: msvc
-          - target: x86_64-apple-darwin/clang
-            architecture: x86_64
-            runner: macos-13
-            compiler: clang
-          - target: aarch64-apple-darwin/clang
-            architecture: aarch64
-            runner: macos-14
-            compiler: clang
-          - target: x86_64-unknown-linux-gnu/gcc
-            architecture: x86_64
-            runner: ubuntu-latest
-            compiler: gcc
-          - target: x86_64-unknown-linux-gnu/clang
-            architecture: x86_64
-            runner: ubuntu-latest
-            compiler: clang
-          - target: aarch64-unknown-linux-gnu/gcc
-            architecture: aarch64
-            runner: ubuntu-latest
-            compiler: gcc
-          - target: aarch64-unknown-linux-gnu/clang
-            architecture: aarch64
-            runner: ubuntu-latest
-            compiler: clang
-    env:
-      CC: ${{ matrix.compiler }}
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: '3.11' 
+  # jit:
+  #   name: ${{ matrix.target }} (${{ matrix.debug && 'Debug' || 'Release' }})
+  #   runs-on: ${{ matrix.runner }}
+  #   timeout-minutes: 90
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       target:
+  #         - i686-pc-windows-msvc/msvc
+  #         - x86_64-pc-windows-msvc/msvc
+  #         - aarch64-pc-windows-msvc/msvc
+  #         - x86_64-apple-darwin/clang
+  #         - aarch64-apple-darwin/clang
+  #         - x86_64-unknown-linux-gnu/gcc
+  #         - x86_64-unknown-linux-gnu/clang
+  #         - aarch64-unknown-linux-gnu/gcc
+  #         - aarch64-unknown-linux-gnu/clang
+  #       debug:
+  #         - true
+  #         - false
+  #       llvm:
+  #         - 18
+  #       include:
+  #         - target: i686-pc-windows-msvc/msvc
+  #           architecture: Win32
+  #           runner: windows-latest
+  #           compiler: msvc
+  #         - target: x86_64-pc-windows-msvc/msvc
+  #           architecture: x64
+  #           runner: windows-latest
+  #           compiler: msvc
+  #         - target: aarch64-pc-windows-msvc/msvc
+  #           architecture: ARM64
+  #           runner: windows-latest
+  #           compiler: msvc
+  #         - target: x86_64-apple-darwin/clang
+  #           architecture: x86_64
+  #           runner: macos-13
+  #           compiler: clang
+  #         - target: aarch64-apple-darwin/clang
+  #           architecture: aarch64
+  #           runner: macos-14
+  #           compiler: clang
+  #         - target: x86_64-unknown-linux-gnu/gcc
+  #           architecture: x86_64
+  #           runner: ubuntu-latest
+  #           compiler: gcc
+  #         - target: x86_64-unknown-linux-gnu/clang
+  #           architecture: x86_64
+  #           runner: ubuntu-latest
+  #           compiler: clang
+  #         - target: aarch64-unknown-linux-gnu/gcc
+  #           architecture: aarch64
+  #           runner: ubuntu-latest
+  #           compiler: gcc
+  #         - target: aarch64-unknown-linux-gnu/clang
+  #           architecture: aarch64
+  #           runner: ubuntu-latest
+  #           compiler: clang
+  #   env:
+  #     CC: ${{ matrix.compiler }}
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #     - uses: actions/setup-python@v5
+  #       with:
+  #         python-version: '3.11' 
 
-      - name: Native Windows
-        if: runner.os == 'Windows' && matrix.architecture != 'ARM64'
-        run: |
-          choco upgrade llvm -y
-          choco install llvm --allow-downgrade --no-progress --version ${{ matrix.llvm }}
-          ./PCbuild/build.bat --experimental-jit ${{ matrix.debug && '-d' || '--pgo' }} -p ${{ matrix.architecture }}
-          ./PCbuild/rt.bat ${{ matrix.debug && '-d' || '' }} -p ${{ matrix.architecture }} -q --multiprocess 0 --timeout 4500 --verbose2 --verbose3
+  #     - name: Native Windows
+  #       if: runner.os == 'Windows' && matrix.architecture != 'ARM64'
+  #       run: |
+  #         choco upgrade llvm -y
+  #         choco install llvm --allow-downgrade --no-progress --version ${{ matrix.llvm }}
+  #         ./PCbuild/build.bat --experimental-jit ${{ matrix.debug && '-d' || '--pgo' }} -p ${{ matrix.architecture }}
+  #         ./PCbuild/rt.bat ${{ matrix.debug && '-d' || '' }} -p ${{ matrix.architecture }} -q --multiprocess 0 --timeout 4500 --verbose2 --verbose3
 
-      # No PGO or tests (yet):
-      - name: Emulated Windows
-        if: runner.os == 'Windows' && matrix.architecture == 'ARM64'
-        run: |
-          choco upgrade llvm -y
-          choco install llvm --allow-downgrade --no-progress --version ${{ matrix.llvm }}
-          ./PCbuild/build.bat --experimental-jit ${{ matrix.debug && '-d' || '' }} -p ${{ matrix.architecture }}
+  #     # No PGO or tests (yet):
+  #     - name: Emulated Windows
+  #       if: runner.os == 'Windows' && matrix.architecture == 'ARM64'
+  #       run: |
+  #         choco upgrade llvm -y
+  #         choco install llvm --allow-downgrade --no-progress --version ${{ matrix.llvm }}
+  #         ./PCbuild/build.bat --experimental-jit ${{ matrix.debug && '-d' || '' }} -p ${{ matrix.architecture }}
 
-      - name: Native macOS
-        if: runner.os == 'macOS'
-        run: |
-          brew update
-          brew install llvm@${{ matrix.llvm }}
-          SDKROOT="$(xcrun --show-sdk-path)" \
-            ./configure --enable-experimental-jit ${{ matrix.debug && '--with-pydebug' || '--enable-optimizations --with-lto' }}
-          make all --jobs 4
-          ./python.exe -m test --multiprocess 0 --timeout 4500 --verbose2 --verbose3
+  #     - name: Native macOS
+  #       if: runner.os == 'macOS'
+  #       run: |
+  #         brew update
+  #         brew install llvm@${{ matrix.llvm }}
+  #         SDKROOT="$(xcrun --show-sdk-path)" \
+  #           ./configure --enable-experimental-jit ${{ matrix.debug && '--with-pydebug' || '--enable-optimizations --with-lto' }}
+  #         make all --jobs 4
+  #         ./python.exe -m test --multiprocess 0 --timeout 4500 --verbose2 --verbose3
 
-      # --with-lto has been removed temporarily as a result of an open issue in LLVM 18 (see https://github.com/llvm/llvm-project/issues/87553)
-      - name: Native Linux
-        if: runner.os == 'Linux' && matrix.architecture == 'x86_64'
-        run: |
-          sudo bash -c "$(wget -O - https://apt.llvm.org/llvm.sh)" ./llvm.sh ${{ matrix.llvm }}
-          export PATH="$(llvm-config-${{ matrix.llvm }} --bindir):$PATH"
-          ./configure --enable-experimental-jit ${{ matrix.debug && '--with-pydebug' || '--enable-optimizations' }}
-          make all --jobs 4
-          ./python -m test --multiprocess 0 --timeout 4500 --verbose2 --verbose3
+  #     # --with-lto has been removed temporarily as a result of an open issue in LLVM 18 (see https://github.com/llvm/llvm-project/issues/87553)
+  #     - name: Native Linux
+  #       if: runner.os == 'Linux' && matrix.architecture == 'x86_64'
+  #       run: |
+  #         sudo bash -c "$(wget -O - https://apt.llvm.org/llvm.sh)" ./llvm.sh ${{ matrix.llvm }}
+  #         export PATH="$(llvm-config-${{ matrix.llvm }} --bindir):$PATH"
+  #         ./configure --enable-experimental-jit ${{ matrix.debug && '--with-pydebug' || '--enable-optimizations' }}
+  #         make all --jobs 4
+  #         ./python -m test --multiprocess 0 --timeout 4500 --verbose2 --verbose3
 
-      # --with-lto has been removed temporarily as a result of an open issue in LLVM 18 (see https://github.com/llvm/llvm-project/issues/87553)
-      - name: Emulated Linux
-        if: runner.os == 'Linux' && matrix.architecture != 'x86_64'
-        # The --ignorefile on ./python -m test is used to exclude tests known to fail when running on an emulated Linux.
-        run: |
-          sudo bash -c "$(wget -O - https://apt.llvm.org/llvm.sh)" ./llvm.sh ${{ matrix.llvm }}
-          export PATH="$(llvm-config-${{ matrix.llvm }} --bindir):$PATH"
-          ./configure --prefix="$(pwd)/../build"
-          make install --jobs 4
-          make clean --jobs 4
-          export HOST=${{ matrix.architecture }}-linux-gnu
-          sudo apt install --yes "gcc-$HOST" qemu-user
-          ${{ !matrix.debug && matrix.compiler == 'clang' && './configure --enable-optimizations' || '' }}
-          ${{ !matrix.debug && matrix.compiler == 'clang' && 'make profile-run-stamp --jobs 4' || '' }}
-          export QEMU_LD_PREFIX="/usr/$HOST"
-          CC="${{ matrix.compiler == 'clang' && 'clang --target=$HOST' || '$HOST-gcc' }}" \
-            CPP="$CC --preprocess" \
-            HOSTRUNNER=qemu-${{ matrix.architecture }} \
-            ./configure --enable-experimental-jit ${{ matrix.debug && '--with-pydebug' || '--enable-optimizations ' }} --build=x86_64-linux-gnu --host="$HOST" --with-build-python=../build/bin/python3 --with-pkg-config=no ac_cv_buggy_getaddrinfo=no ac_cv_file__dev_ptc=no ac_cv_file__dev_ptmx=yes
-          make all --jobs 4
-          ./python -m test --ignorefile=Tools/jit/ignore-tests-emulated-linux.txt --multiprocess 0 --timeout 4500 --verbose2 --verbose3
-          
+  #     # --with-lto has been removed temporarily as a result of an open issue in LLVM 18 (see https://github.com/llvm/llvm-project/issues/87553)
+  #     - name: Emulated Linux
+  #       if: runner.os == 'Linux' && matrix.architecture != 'x86_64'
+  #       # The --ignorefile on ./python -m test is used to exclude tests known to fail when running on an emulated Linux.
+  #       run: |
+  #         sudo bash -c "$(wget -O - https://apt.llvm.org/llvm.sh)" ./llvm.sh ${{ matrix.llvm }}
+  #         export PATH="$(llvm-config-${{ matrix.llvm }} --bindir):$PATH"
+  #         ./configure --prefix="$(pwd)/../build"
+  #         make install --jobs 4
+  #         make clean --jobs 4
+  #         export HOST=${{ matrix.architecture }}-linux-gnu
+  #         sudo apt install --yes "gcc-$HOST" qemu-user
+  #         ${{ !matrix.debug && matrix.compiler == 'clang' && './configure --enable-optimizations' || '' }}
+  #         ${{ !matrix.debug && matrix.compiler == 'clang' && 'make profile-run-stamp --jobs 4' || '' }}
+  #         export QEMU_LD_PREFIX="/usr/$HOST"
+  #         CC="${{ matrix.compiler == 'clang' && 'clang --target=$HOST' || '$HOST-gcc' }}" \
+  #           CPP="$CC --preprocess" \
+  #           HOSTRUNNER=qemu-${{ matrix.architecture }} \
+  #           ./configure --enable-experimental-jit ${{ matrix.debug && '--with-pydebug' || '--enable-optimizations ' }} --build=x86_64-linux-gnu --host="$HOST" --with-build-python=../build/bin/python3 --with-pkg-config=no ac_cv_buggy_getaddrinfo=no ac_cv_file__dev_ptc=no ac_cv_file__dev_ptmx=yes
+  #         make all --jobs 4
+  #         ./python -m test --ignorefile=Tools/jit/ignore-tests-emulated-linux.txt --multiprocess 0 --timeout 4500 --verbose2 --verbose3
+
   jit-with-no-gil:
     runs-on: x86_64-unknown-linux-gnu/gcc
     strategy:

--- a/.github/workflows/jit.yml
+++ b/.github/workflows/jit.yml
@@ -85,7 +85,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: '3.11' 
 
       - name: Native Windows
         if: runner.os == 'Windows' && matrix.architecture != 'ARM64'
@@ -144,3 +144,28 @@ jobs:
             ./configure --enable-experimental-jit ${{ matrix.debug && '--with-pydebug' || '--enable-optimizations ' }} --build=x86_64-linux-gnu --host="$HOST" --with-build-python=../build/bin/python3 --with-pkg-config=no ac_cv_buggy_getaddrinfo=no ac_cv_file__dev_ptc=no ac_cv_file__dev_ptmx=yes
           make all --jobs 4
           ./python -m test --ignorefile=Tools/jit/ignore-tests-emulated-linux.txt --multiprocess 0 --timeout 4500 --verbose2 --verbose3
+  jit-with-no-gil:
+    runs-on: x86_64-unknown-linux-gnu/gcc
+    strategy:
+      fail-fast: false
+      matrix:
+        llvm:
+          - 18
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Build with JIT and No GIL
+        run: |
+          sudo bash -c "$(wget -O - https://apt.llvm.org/llvm.sh)" ./llvm.sh ${{ matrix.llvm }}
+          export PATH="$(llvm-config-${{ matrix.llvm }} --bindir):$PATH"
+          ./configure --enable-experimental-jit --with-pydebug --disable-gil
+          make all --jobs 4
+      - name: Run Test Suite
+        run: |
+          ./python -m test --multiprocess 0 --timeout 4500 --verbose2 --verbose3
+
+      
+
+      

--- a/.github/workflows/jit.yml
+++ b/.github/workflows/jit.yml
@@ -160,4 +160,4 @@ jobs:
           make all --jobs 4
       - name: Run tests
         run: |
-          ./python -m test --multiprocess 0 --timeout 4500 --verbose2 --verbose3      
+          ./python -m test --multiprocess 0 --timeout 4500 --verbose2 --verbose3

--- a/.github/workflows/jit.yml
+++ b/.github/workflows/jit.yml
@@ -144,6 +144,7 @@ jobs:
             ./configure --enable-experimental-jit ${{ matrix.debug && '--with-pydebug' || '--enable-optimizations ' }} --build=x86_64-linux-gnu --host="$HOST" --with-build-python=../build/bin/python3 --with-pkg-config=no ac_cv_buggy_getaddrinfo=no ac_cv_file__dev_ptc=no ac_cv_file__dev_ptmx=yes
           make all --jobs 4
           ./python -m test --ignorefile=Tools/jit/ignore-tests-emulated-linux.txt --multiprocess 0 --timeout 4500 --verbose2 --verbose3
+          
   jit-with-no-gil:
     runs-on: x86_64-unknown-linux-gnu/gcc
     strategy:
@@ -164,8 +165,4 @@ jobs:
           make all --jobs 4
       - name: Run Test Suite
         run: |
-          ./python -m test --multiprocess 0 --timeout 4500 --verbose2 --verbose3
-
-      
-
-      
+          ./python -m test --multiprocess 0 --timeout 4500 --verbose2 --verbose3      

--- a/.github/workflows/jit.yml
+++ b/.github/workflows/jit.yml
@@ -145,7 +145,7 @@ jobs:
           make all --jobs 4
           ./python -m test --ignorefile=Tools/jit/ignore-tests-emulated-linux.txt --multiprocess 0 --timeout 4500 --verbose2 --verbose3
 
-  jit-with-no-gil:
+  jit-with-disabled-gil:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

Alrighty, so I added a very basic job to test that we don't regress things as the JIT and free threading work evolves. I split the build and test into separate steps, so we have a little finer granularity on failures (it's just slightly prettier!). I also opted not to use `strategy`/`matrix` to pass in the LLVM version since we only support 18 today. I can add that in if folks feel strongly if we want to keep things very consistent with the other job, but I was going for simple 😄 

<!-- gh-issue-number: gh-119292 -->
* Issue: gh-119292
<!-- /gh-issue-number -->