### PR TITLE
gh-119011: `type.__type_params__` now return an empty tuple

### DIFF
--- a/Lib/test/test_functools.py
+++ b/Lib/test/test_functools.py
@@ -710,6 +710,14 @@ class TestUpdateWrapper(unittest.TestCase):
         self.assertTrue(wrapper.__doc__.startswith('max('))
         self.assertEqual(wrapper.__annotations__, {})
 
+    def test_update_type_wrapper(self):
+        def wrapper(*args): pass
+
+        functools.update_wrapper(wrapper, type)
+        self.assertEqual(wrapper.__name__, 'type')
+        self.assertEqual(wrapper.__annotations__, {})
+        self.assertEqual(wrapper.__type_params__, ())
+
 
 class TestWraps(TestUpdateWrapper):
 

--- a/Lib/test/test_type_params.py
+++ b/Lib/test/test_type_params.py
@@ -563,6 +563,11 @@ class TypeParamsAccessTest(unittest.TestCase):
         self.assertIs(T, C.Alias.__type_params__[0])
         self.assertIs(U, C.__type_params__[1])
 
+    def test_type_special_case(self):
+        # https://github.com/python/cpython/issues/119011
+        self.assertEqual(type.__type_params__, ())
+        self.assertEqual(object.__type_params__, ())
+
 
 def make_base(arg):
     class Base:

--- a/Misc/NEWS.d/next/Core and Builtins/2024-05-21-09-46-51.gh-issue-119011.WOe3bu.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2024-05-21-09-46-51.gh-issue-119011.WOe3bu.rst
@@ -1,0 +1,2 @@
+Fixes ``type.__type_params__`` to return an empty tuple instead of a
+descriptor.

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -1742,6 +1742,10 @@ type_set_annotations(PyTypeObject *type, PyObject *value, void *context)
 static PyObject *
 type_get_type_params(PyTypeObject *type, void *context)
 {
+    if (type == &PyType_Type) {
+        return PyTuple_New(0);
+    }
+
     PyObject *params;
     if (PyDict_GetItemRef(lookup_tp_dict(type), &_Py_ID(__type_params__), &params) == 0) {
         return PyTuple_New(0);


### PR DESCRIPTION
I went ahead and implemented this special case.
I've also added `object` to the test, because it was missing and can also be quite important / different from other types.

<!-- gh-issue-number: gh-119011 -->
* Issue: gh-119011
<!-- /gh-issue-number -->
