### PR TITLE
Use `fail-fast: false` in `mypy.yml`

### DIFF
--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -34,6 +34,7 @@ concurrency:
 jobs:
   mypy:
     strategy:
+      fail-fast: false
       matrix:
         target: [
           "Lib/_pyrepl",


### PR DESCRIPTION
I think it makes sense not to cancel all other mypy builds if one fails.

See docs about this setting: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstrategyfail-fast
