### PR TITLE
gh-115177: Clarify impact of -O and optimization in assert statement documentation

### DIFF
--- a/Doc/reference/simple_stmts.rst
+++ b/Doc/reference/simple_stmts.rst
@@ -404,7 +404,8 @@ The extended form, ``assert expression1, expression2``, is equivalent to ::
 These equivalences assume that :const:`__debug__` and :exc:`AssertionError` refer to
 the built-in variables with those names.  In the current implementation, the
 built-in variable :const:`__debug__` is ``True`` under normal circumstances,
-``False`` when optimization is requested (command line option :option:`-O` or environment variable :envvar:`PYTHONOPTIMIZE`).  The current
+``False`` when optimization is requested (command line option :option:`-O`
+or environment variable :envvar:`PYTHONOPTIMIZE`).  The current
 code generator emits no code for an assert statement when optimization is
 requested at compile time.  Note that it is unnecessary to include the source
 code for the expression that failed in the error message; it will be displayed

--- a/Doc/reference/simple_stmts.rst
+++ b/Doc/reference/simple_stmts.rst
@@ -413,8 +413,10 @@ as part of the stack trace.
 
    .. note::
 
-      It is considered good practice to not use :keyword:`assert` statements in critical code logic while writing library code as enabling optimization will cause the statements to be ignored.
-      Evaluating function variables using :keyword:`assert` statements can also lead to unexpected behavior.
+      It is considered good practice to not use :keyword:`assert` statements in
+      critical code logic while writing library code as enabling optimization will
+      cause the statements to be ignored. Evaluating function variables using
+      :keyword:`assert` statements can also lead to unexpected behavior.
 
 Assignments to :const:`__debug__` are illegal.  The value for the built-in variable
 is determined when the interpreter starts.

--- a/Doc/reference/simple_stmts.rst
+++ b/Doc/reference/simple_stmts.rst
@@ -404,7 +404,7 @@ The extended form, ``assert expression1, expression2``, is equivalent to ::
 These equivalences assume that :const:`__debug__` and :exc:`AssertionError` refer to
 the built-in variables with those names.  In the current implementation, the
 built-in variable :const:`__debug__` is ``True`` under normal circumstances,
-``False`` when optimization is requested (command line option :option:`-O`).  The current
+``False`` when optimization is requested (command line option :option:`-O` or environment variable :envvar:`PYTHONOPTIMIZE`).  The current
 code generator emits no code for an assert statement when optimization is
 requested at compile time.  Note that it is unnecessary to include the source
 code for the expression that failed in the error message; it will be displayed

--- a/Doc/reference/simple_stmts.rst
+++ b/Doc/reference/simple_stmts.rst
@@ -410,6 +410,11 @@ requested at compile time.  Note that it is unnecessary to include the source
 code for the expression that failed in the error message; it will be displayed
 as part of the stack trace.
 
+   .. note::
+
+      It is considered good practice to not use :keyword:`assert` statements in critical code logic while writing library code as enabling optimization will cause the statements to be ignored.
+      Evaluating function variables using :keyword:`assert` statements can also lead to unexpected behavior.
+
 Assignments to :const:`__debug__` are illegal.  The value for the built-in variable
 is determined when the interpreter starts.
 


### PR DESCRIPTION
The current `simple_stmts.html#the-assert-statement` text mentions -O as a tiny hyperlink over to `#cmdoption-O` but doesn't mention the `PYTHONOPTIMIZE` environment variable. This commit adds a hyperlink to it and adds a note warning of breaking logic when using assert statements in code. Fixes #115177 

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-115177 -->
* Issue: gh-115177
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--119305.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->