### PR TITLE
gh-119011: Return an empty tuple on type_get_type_params as special case for PyType_Type

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2024-05-21-11-51-54.gh-issue-119011.Ja5dwc.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2024-05-21-11-51-54.gh-issue-119011.Ja5dwc.rst
@@ -1,2 +1,1 @@
-This fixes an issue with ``functools.update_wrapper`` where it was not
-returning a tuple for ``__type_params__`` as expected.
+Fix ``type.__type_params__`` to return an empty tuple instead of the descriptor object.

--- a/Misc/NEWS.d/next/Core and Builtins/2024-05-21-11-51-54.gh-issue-119011.Ja5dwc.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2024-05-21-11-51-54.gh-issue-119011.Ja5dwc.rst
@@ -1,0 +1,2 @@
+This fixes an issue with ``functools.update_wrapper`` where it was not
+returning a tuple for ``__type_params__`` as expected.

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -1743,7 +1743,7 @@ static PyObject *
 type_get_type_params(PyTypeObject *type, void *context)
 {
     PyObject *params;
-    if (PyDict_GetItemRef(lookup_tp_dict(type), &_Py_ID(__type_params__), &params) == 0) {
+    if (type == &PyType_Type || PyDict_GetItemRef(lookup_tp_dict(type), &_Py_ID(__type_params__), &params) == 0) {
         return PyTuple_New(0);
     }
     return params;


### PR DESCRIPTION
First pull-request for cpython; fixes an issue where `functools.update_wrapper` was not returning a tuple for `__type_params__`. 

<!-- gh-issue-number: gh-119011 -->
* Issue: gh-119011
<!-- /gh-issue-number -->
