### PR TITLE
gh-119247: Add macros to use PySequence_Fast safely in free-threaded build

### DIFF
--- a/Include/internal/pycore_critical_section.h
+++ b/Include/internal/pycore_critical_section.h
@@ -124,8 +124,9 @@ extern "C" {
                                      &_orig_seq->ob_mutex)  \
 
 # define Py_END_CRITICAL_SECTION_SEQUENCE_FAST()                        \
-        if (_should_lock_cs)                                            \
+        if (_should_lock_cs) {                                          \
             _PyCriticalSection_End(&_cs);                               \
+        }                                                               \
     }
 
 // Asserts that the mutex is locked.  The mutex must be held by the

--- a/Include/internal/pycore_critical_section.h
+++ b/Include/internal/pycore_critical_section.h
@@ -109,11 +109,11 @@ extern "C" {
         _PyCriticalSection2_End(&_cs2);                                 \
     }
 
-// Specialized version of critical section locking called to safely use
-// PySequence_Fast APIs under nogil
-// For performance, the argument *to* PySequence_Fast is provided to the
-// macro, not the *result* of PySequence_Fast (which would require an extra
-// test to determine if the lock must be held)
+// Specialized version of critical section locking to safely use
+// PySequence_Fast APIs without the GIL. For performance, the argument *to*
+// PySequence_Fast() is provided to the macro, not the *result* of
+// PySequence_Fast(), which would require an extra test to determine if the
+// lock must be acquired.
 # define Py_BEGIN_CRITICAL_SECTION_SEQUENCE_FAST(original)              \
     {                                                                   \
         PyObject *_orig_seq = _PyObject_CAST(original);                 \

--- a/Include/internal/pycore_critical_section.h
+++ b/Include/internal/pycore_critical_section.h
@@ -114,7 +114,7 @@ extern "C" {
 // For performance, the argument *to* PySequence_Fast is provided to the
 // macro, not the *result* of PySequence_Fast (which would require an extra
 // test to determine if the lock must be held)
-# define Py_BEGIN_CRITICAL_SECTION_SEQUENCE_FAST(original)            	\
+# define Py_BEGIN_CRITICAL_SECTION_SEQUENCE_FAST(original)              \
     {                                                                   \
         PyObject *_orig_seq = _PyObject_CAST(original);                 \
         const bool _should_lock_cs = PyList_CheckExact(_orig_seq);      \

--- a/Include/internal/pycore_critical_section.h
+++ b/Include/internal/pycore_critical_section.h
@@ -7,7 +7,6 @@
 
 #include "pycore_lock.h"        // PyMutex
 #include "pycore_pystate.h"     // _PyThreadState_GET()
-#include "listobject.h"         // PyList_CheckExact
 #include <stdint.h>
 
 #ifdef __cplusplus

--- a/Include/internal/pycore_critical_section.h
+++ b/Include/internal/pycore_critical_section.h
@@ -119,9 +119,9 @@ extern "C" {
         PyObject *_orig_seq = _PyObject_CAST(original);                 \
         const bool _should_lock_cs = PyList_CheckExact(_orig_seq);      \
         _PyCriticalSection _cs;                                         \
-        if (_should_lock_cs)                                            \
-            _PyCriticalSection_Begin(&_cs,                              \
-                                     &_orig_seq->ob_mutex)  \
+        if (_should_lock_cs) {                                          \
+            _PyCriticalSection_Begin(&_cs, &_orig_seq->ob_mutex);       \
+        }
 
 # define Py_END_CRITICAL_SECTION_SEQUENCE_FAST()                        \
         if (_should_lock_cs) {                                          \

--- a/Include/internal/pycore_critical_section.h
+++ b/Include/internal/pycore_critical_section.h
@@ -7,6 +7,7 @@
 
 #include "pycore_lock.h"        // PyMutex
 #include "pycore_pystate.h"     // _PyThreadState_GET()
+#include "listobject.h"         // PyList_CheckExact
 #include <stdint.h>
 
 #ifdef __cplusplus
@@ -108,6 +109,25 @@ extern "C" {
         _PyCriticalSection2_End(&_cs2);                                 \
     }
 
+// Specialized version of critical section locking called to safely use
+// PySequence_Fast APIs under nogil
+// For performance, the argument *to* PySequence_Fast is provided to the
+// macro, not the *result* of PySequence_Fast (which would require an extra
+// test to determine if the lock must be held)
+# define Py_BEGIN_CRITICAL_SECTION_SEQUENCE_FAST(original)            	\
+    {                                                                   \
+        PyObject *_orig_seq = _PyObject_CAST(original);                 \
+        const bool _should_lock_cs = PyList_CheckExact(_orig_seq);      \
+        _PyCriticalSection _cs;                                         \
+        if (_should_lock_cs)                                            \
+            _PyCriticalSection_Begin(&_cs,                              \
+                                     &_orig_seq->ob_mutex)  \
+
+# define Py_END_CRITICAL_SECTION_SEQUENCE_FAST()                        \
+        if (_should_lock_cs)                                            \
+            _PyCriticalSection_End(&_cs);                               \
+    }
+
 // Asserts that the mutex is locked.  The mutex must be held by the
 // top-most critical section otherwise there's the possibility
 // that the mutex would be swalled out in some code paths.
@@ -137,6 +157,8 @@ extern "C" {
 # define Py_END_CRITICAL_SECTION()
 # define Py_BEGIN_CRITICAL_SECTION2(a, b)
 # define Py_END_CRITICAL_SECTION2()
+# define Py_BEGIN_CRITICAL_SECTION_SEQUENCE_FAST(original)
+# define Py_END_CRITICAL_SECTION_SEQUENCE_FAST()
 # define _Py_CRITICAL_SECTION_ASSERT_MUTEX_LOCKED(mutex)
 # define _Py_CRITICAL_SECTION_ASSERT_OBJECT_LOCKED(op)
 #endif  /* !Py_GIL_DISABLED */

--- a/Lib/test/test_free_threading/test_str.py
+++ b/Lib/test/test_free_threading/test_str.py
@@ -42,20 +42,21 @@ class TestStr(TestCase):
         '''
         l = [*'abcdefg']
         MAX_ORDINAL = 1_000
-        READERS = 20
+        READERS = 10
+        done_event = Event()
 
         def writer_func():
             for i, c in zip(cycle(range(len(l))),
                             map(chr, range(128, MAX_ORDINAL))):
                 l[i] = c
-            del l[:]  # Empty list to tell readers to exit
+            done_event.set()
 
         def reader_func():
-            while True:
-                empty = not l
+            while not done_event.is_set():
                 ''.join(l)
-                if empty:
-                    break
+                ''.join(l)
+                ''.join(l)
+                ''.join(l)
 
         writer = Thread(target=writer_func)
         readers = []

--- a/Misc/NEWS.d/next/C API/2024-05-21-11-35-11.gh-issue-119247.U6n6mh.rst
+++ b/Misc/NEWS.d/next/C API/2024-05-21-11-35-11.gh-issue-119247.U6n6mh.rst
@@ -1,0 +1,4 @@
+Added ``Py_BEGIN_CRITICAL_SECTION_SEQUENCE_FAST`` and
+``Py_END_CRITICAL_SECTION_SEQUENCE_FAST`` macros to make it possible to use
+PySequence_Fast APIs safely when free-threaded, and update str.join to work
+without the GIL using them.

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -44,6 +44,7 @@ OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #include "pycore_bytesobject.h"   // _PyBytes_Repeat()
 #include "pycore_ceval.h"         // _PyEval_GetBuiltin()
 #include "pycore_codecs.h"        // _PyCodec_Lookup()
+#include "pycore_critical_section.h" // Py_*_CRITICAL_SECTION_SEQUENCE_FAST
 #include "pycore_format.h"        // F_LJUST
 #include "pycore_initconfig.h"    // _PyStatus_OK()
 #include "pycore_interp.h"        // PyInterpreterState.fs_codec
@@ -9559,13 +9560,14 @@ PyUnicode_Join(PyObject *separator, PyObject *seq)
         return NULL;
     }
 
-    /* NOTE: the following code can't call back into Python code,
-     * so we are sure that fseq won't be mutated.
-     */
+    Py_BEGIN_CRITICAL_SECTION_SEQUENCE_FAST(seq);
 
     items = PySequence_Fast_ITEMS(fseq);
     seqlen = PySequence_Fast_GET_SIZE(fseq);
     res = _PyUnicode_JoinArray(separator, items, seqlen);
+
+    Py_END_CRITICAL_SECTION_SEQUENCE_FAST();
+
     Py_DECREF(fseq);
     return res;
 }


### PR DESCRIPTION
Add ``Py_BEGIN_CRITICAL_SECTION_SEQUENCE_FAST`` and ``Py_END_CRITICAL_SECTION_SEQUENCE_FAST`` macros and update ``str.join`` to use them. Also add a regression test that would crash reliably without this patch.

<!-- gh-issue-number: gh-119247 -->
* Issue: gh-119247
<!-- /gh-issue-number -->
