### PR TITLE
gh-119317: findall instead of traverse for docutils nodes

### DIFF
--- a/Doc/tools/extensions/glossary_search.py
+++ b/Doc/tools/extensions/glossary_search.py
@@ -25,8 +25,8 @@ def process_glossary_nodes(app, doctree, fromdocname):
 
     terms = {}
 
-    for node in doctree.traverse(glossary):
-        for glossary_item in node.traverse(definition_list_item):
+    for node in doctree.findall(glossary):
+        for glossary_item in node.findall(definition_list_item):
             term = glossary_item[0].astext().lower()
             definition = glossary_item[1]
 

--- a/Doc/tools/extensions/pyspecific.py
+++ b/Doc/tools/extensions/pyspecific.py
@@ -604,7 +604,7 @@ def parse_monitoring_event(env, sig, signode):
 
 
 def process_audit_events(app, doctree, fromdocname):
-    for node in doctree.traverse(audit_event_list):
+    for node in doctree.findall(audit_event_list):
         break
     else:
         return
@@ -663,7 +663,7 @@ def process_audit_events(app, doctree, fromdocname):
 
         body += row
 
-    for node in doctree.traverse(audit_event_list):
+    for node in doctree.findall(audit_event_list):
         node.replace_self(table)
 
 


### PR DESCRIPTION
The new method, `findall`, is a generator rather than returning a list.

closes #119317

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-119317 -->
* Issue: gh-119317
<!-- /gh-issue-number -->
