### PR TITLE
gh-115225: Raise error on unsupported ISO 8601 time strings

### DIFF
--- a/Lib/test/datetimetester.py
+++ b/Lib/test/datetimetester.py
@@ -4412,6 +4412,8 @@ class TestTimeTZ(TestTime, TZInfoBase, unittest.TestCase):
             '12:30:45.123456-',         # Extra at end of microsecond time
             '12:30:45.123456+',         # Extra at end of microsecond time
             '12:30:45.123456+12:00:30a',    # Extra at end of full time
+            '12.5',                     # Decimal mark at end of hour
+            '12:30,5',                  # Decimal mark at end of minute
         ]
 
         for bad_str in bad_strs:

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -315,6 +315,7 @@ Greg Chapman
 Mitch Chapman
 Matt Chaput
 William Chargin
+Ben Chatterton
 Yogesh Chaudhari
 Gautam Chaudhuri
 David Chaum

--- a/Misc/NEWS.d/next/Library/2024-05-21-19-10-30.gh-issue-115225.eRmfJH.rst
+++ b/Misc/NEWS.d/next/Library/2024-05-21-19-10-30.gh-issue-115225.eRmfJH.rst
@@ -1,0 +1,1 @@
+Raise error on certain technically valid but pathological ISO 8601 strings passed to :meth:`datetime.time.fromisostring` that were previously parsed incorrectly.

--- a/Misc/NEWS.d/next/Library/2024-05-21-19-10-30.gh-issue-115225.eRmfJH.rst
+++ b/Misc/NEWS.d/next/Library/2024-05-21-19-10-30.gh-issue-115225.eRmfJH.rst
@@ -1,1 +1,1 @@
-Raise error on certain technically valid but pathological ISO 8601 strings passed to :meth:`datetime.time.fromisostring` that were previously parsed incorrectly.
+Raise error on certain technically valid but pathological ISO 8601 strings passed to :meth:`datetime.time.fromisoformat` that were previously parsed incorrectly.

--- a/Modules/_datetimemodule.c
+++ b/Modules/_datetimemodule.c
@@ -859,6 +859,9 @@ parse_hh_mm_ss_ff(const char *tstr, const char *tstr_end, int *hour,
             continue;
         }
         else if (c == '.' || c == ',') {
+            if (i < 2) {
+                return -3; // Decimal mark on hour or minute
+            }
             break;
         } else if (!has_separator) {
             --p;


### PR DESCRIPTION
Some time strings that contain fractional hours or minutes are permitted by ISO 8601, but such strings are very unlikely to be intentional. The current parser does not parse such strings correctly or raise an error. This change raises a ValueError when hours or minutes contain a decimal mark.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-115225 -->
* Issue: gh-115225
<!-- /gh-issue-number -->
