### PR TITLE
CI: set correct working directory for Hypothesis cache

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -388,7 +388,7 @@ jobs:
       id: cache-hypothesis-database
       uses: actions/cache@v4
       with:
-        path: ./hypothesis
+        path: ${{ env.CPYTHON_BUILDDIR }}/.hypothesis/
         key: hypothesis-database-${{ github.head_ref || github.run_id }}
         restore-keys: |
           - hypothesis-database-
@@ -416,7 +416,7 @@ jobs:
       if: always()
       with:
         name: hypothesis-example-db
-        path: .hypothesis/examples/
+        path: ${{ env.CPYTHON_BUILDDIR }}/.hypothesis/examples/
 
 
   build_asan:

--- a/Lib/test/support/hypothesis_helper.py
+++ b/Lib/test/support/hypothesis_helper.py
@@ -5,6 +5,13 @@ try:
 except ImportError:
     from . import _hypothesis_stubs as hypothesis
 else:
+    # Regrtest changes to use a tempdir as the working directory, so we have
+    # to tell Hypothesis to use the original in order to persist the database.
+    from .os_helper import SAVEDCWD
+    from hypothesis.configuration import set_hypothesis_home_dir
+
+    set_hypothesis_home_dir(os.path.join(SAVEDCWD, ".hypothesis"))
+
     # When using the real Hypothesis, we'll configure it to ignore occasional
     # slow tests (avoiding flakiness from random VM slowness in CI).
     hypothesis.settings.register_profile(


### PR DESCRIPTION
I noticed when pairing with @encukou that this cache logic never found any files to upload (nor restore).  

This isn't a huge problem, but ensuring that we replay any known failing examples on your branch is a nicer developer experience, made possible by persisting the cache between runs.