### PR TITLE
gh-100117: Fix inaccuracy in documentation of the CodeObject's co_positions field.

### DIFF
--- a/Doc/reference/datamodel.rst
+++ b/Doc/reference/datamodel.rst
@@ -1243,10 +1243,8 @@ Methods on code objects
 
    The iterator returns :class:`tuple`\s containing the ``(start_line, end_line,
    start_column, end_column)``. The *i-th* tuple corresponds to the
-   position of the source code that compiled to the *i-th* code unit. A
-   code unit is either a bytecode instruction or a cache entry of an
-   instruction. Column information is 0-indexed utf-8 byte offsets on the
-   given source line.
+   position of the source code that compiled to the *i-th* code unit.
+   Column information is 0-indexed utf-8 byte offsets on the given source line.
 
    This positional information can be missing. A non-exhaustive lists of
    cases where this may happen:

--- a/Doc/reference/datamodel.rst
+++ b/Doc/reference/datamodel.rst
@@ -1243,9 +1243,10 @@ Methods on code objects
 
    The iterator returns :class:`tuple`\s containing the ``(start_line, end_line,
    start_column, end_column)``. The *i-th* tuple corresponds to the
-   position of the source code that compiled to the *i-th* instruction.
-   Column information is 0-indexed utf-8 byte offsets on the given source
-   line.
+   position of the source code that compiled to the *i-th* code unit. A
+   code unit is either a bytecode instruction or a cache entry of an
+   instruction. Column information is 0-indexed utf-8 byte offsets on the
+   given source line.
 
    This positional information can be missing. A non-exhaustive lists of
    cases where this may happen:

--- a/Doc/reference/datamodel.rst
+++ b/Doc/reference/datamodel.rst
@@ -1244,7 +1244,8 @@ Methods on code objects
    The iterator returns :class:`tuple`\s containing the ``(start_line, end_line,
    start_column, end_column)``. The *i-th* tuple corresponds to the
    position of the source code that compiled to the *i-th* code unit.
-   Column information is 0-indexed utf-8 byte offsets on the given source line.
+   Column information is 0-indexed utf-8 byte offsets on the given source
+   line.
 
    This positional information can be missing. A non-exhaustive lists of
    cases where this may happen:


### PR DESCRIPTION
Fixes #100117.


<!-- gh-issue-number: gh-100117 -->
* Issue: gh-100117
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--119364.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->