### PR TITLE
DOCS: fix error in exec namespace note

### DIFF
--- a/Doc/library/functions.rst
+++ b/Doc/library/functions.rst
@@ -623,10 +623,6 @@ are always available.  They are listed here in alphabetical order.
       means functions and classes defined in the executed code will not be able
       to access variables assigned at the top level (as the "top level"
       variables are treated as class variables in a class definition).
-      As *globals* is required to be a ``dict`` instance, it isn't possible to
-      use :class:`collections.ChainMap` to work around this restriction.
-      Instead, any namespaces to be used for lookups must be merged into a
-      single ``dict`` before calling ``exec``.
 
    If the *globals* dictionary does not contain a value for the key
    ``__builtins__``, a reference to the dictionary of the built-in module

--- a/Doc/library/functions.rst
+++ b/Doc/library/functions.rst
@@ -623,10 +623,10 @@ are always available.  They are listed here in alphabetical order.
       means functions and classes defined in the executed code will not be able
       to access variables assigned at the top level (as the "top level"
       variables are treated as class variables in a class definition).
-      Passing a :class:`collections.ChainMap` instance as *globals* allows name
-      lookups to be chained across multiple mappings without triggering this
-      behaviour. Values assigned to top level names in the executed code can be
-      retrieved by passing an empty dictionary as the first entry in the chain.
+      As *globals* is required to be a ``dict`` instance, it isn't possible to
+      use :class:`collections.ChainMap` to work around this restriction.
+      Instead, any namespaces to be used for lookups must be merged into a
+      single ``dict`` before calling ``exec``.
 
    If the *globals* dictionary does not contain a value for the key
    ``__builtins__``, a reference to the dictionary of the built-in module


### PR DESCRIPTION
When updating the new exec note added in gh-119235 as part of the PEP 667 general docs PR, I suggested a workaround that isn't valid.

Since it's far from the first time I've considered that workaround, and the fact it doesn't work has surprised me every time, amend the new note to explicitly state that dict merging is the only option.

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--119378.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->