### PR TITLE
gh-119396: Optimize PyUnicode_FromFormat() UTF-8 decoder

### DIFF
--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -2399,19 +2399,18 @@ unicode_fromformat_write_utf8(_PyUnicodeWriter *writer, const char *str,
 
     if (width < 0) {
         return unicode_decode_utf8_writer(writer, str, length,
-                                          _Py_ERROR_UNKNOWN, "replace", NULL);
+                                          _Py_ERROR_REPLACE, "replace", NULL);
     }
-    else {
-        PyObject *unicode = PyUnicode_DecodeUTF8Stateful(str, length,
-                                                         "replace", NULL);
-        if (unicode == NULL)
-            return -1;
 
-        int res = unicode_fromformat_write_str(writer, unicode,
-                                               width, -1, flags);
-        Py_DECREF(unicode);
-        return res;
-    }
+    PyObject *unicode = PyUnicode_DecodeUTF8Stateful(str, length,
+                                                     "replace", NULL);
+    if (unicode == NULL)
+        return -1;
+
+    int res = unicode_fromformat_write_str(writer, unicode,
+                                           width, -1, flags);
+    Py_DECREF(unicode);
+    return res;
 }
 
 static int


### PR DESCRIPTION
Add unicode_decode_utf8_writer() to write directly characters into a _PyUnicodeWriter writer: avoid the creation of a temporary string. Optimize PyUnicode_FromFormat() by using the new
unicode_decode_utf8_writer().

Rename unicode_fromformat_write_cstr() to
unicode_fromformat_write_utf8().

Microbenchmark on the code:

    return PyUnicode_FromFormat(
        "%s %s %s %s %s.",
        "format", "multiple", "utf8", "short", "strings");

Result: 620 ns +- 8 ns -> 382 ns +- 2 ns: 1.62x faster.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-119182 -->
* Issue: gh-119182
<!-- /gh-issue-number -->


<!-- gh-issue-number: gh-119396 -->
* Issue: gh-119396
<!-- /gh-issue-number -->
