### PR TITLE
[3.13] gh-111201: Remove readline dependency from the PyREPL (GH-119262)

### DIFF
--- a/Lib/_pyrepl/readline.py
+++ b/Lib/_pyrepl/readline.py
@@ -31,9 +31,9 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 
 import os
-import readline
 from site import gethistoryfile   # type: ignore[attr-defined]
 import sys
+from rlcompleter import Completer as RLCompleter
 
 from . import commands, historical_reader
 from .completing_reader import CompletingReader
@@ -81,7 +81,7 @@ __all__ = [
 
 @dataclass
 class ReadlineConfig:
-    readline_completer: Completer | None = readline.get_completer()
+    readline_completer: Completer | None = RLCompleter().complete
     completer_delims: frozenset[str] = frozenset(" \t\n`~!@#$%^&*()-=+[{]}\\|;:'\",<>/?")
 
 

--- a/Lib/test/test_pyrepl/__init__.py
+++ b/Lib/test/test_pyrepl/__init__.py
@@ -7,7 +7,6 @@ from test.support.import_helper import import_module
 # option.  Additionally, we need to attempt to import curses and readline.
 requires("curses")
 curses = import_module("curses")
-readline = import_module("readline")
 
 
 def load_tests(*args):

--- a/Misc/NEWS.d/next/Library/2024-05-20-20-30-57.gh-issue-111201.DAA5lC.rst
+++ b/Misc/NEWS.d/next/Library/2024-05-20-20-30-57.gh-issue-111201.DAA5lC.rst
@@ -1,0 +1,1 @@
+Remove dependency to :mod:`readline` from the new Python REPL.


### PR DESCRIPTION
(cherry picked from commit 561ff1fa710493dee8c6482f990bd17535b27040)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-111201 -->
* Issue: gh-111201
<!-- /gh-issue-number -->
