### PR TITLE
Clarify base64.a85encode docs: *wrapcols* doesn't count the newline

### DIFF
--- a/Doc/library/base64.rst
+++ b/Doc/library/base64.rst
@@ -193,7 +193,7 @@ The modern interface provides:
 
    *wrapcol* controls whether the output should have newline (``b'\n'``)
    characters added to it. If this is non-zero, each output line will be
-   at most this many characters long.
+   at most this many characters long, excluding the trailing newline.
 
    *pad* controls whether the input is padded to a multiple of 4
    before encoding. Note that the ``btoa`` implementation always pads.

--- a/Lib/base64.py
+++ b/Lib/base64.py
@@ -332,7 +332,7 @@ def a85encode(b, *, foldspaces=False, wrapcol=0, pad=False, adobe=False):
 
     wrapcol controls whether the output should have newline (b'\\n') characters
     added to it. If this is non-zero, each output line will be at most this
-    many characters long.
+    many characters long, excluding the trailing newline.
 
     pad controls whether the input is padded to a multiple of 4 before
     encoding. Note that the btoa implementation always pads.


### PR DESCRIPTION
When writing #119406 I noticed the *wrapcol* docs are unclear; the `\n` is not counted.
Here's a doc fix.

Another undocumented feature is that negative *wrapcol* is treated as 1 (and in *adobe* mode, 1 is treated as 2). I don't think these edge cases need to be documented; nowadays we'd warn/error for those cases, but that's not really worth breaking backwards compatibility.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--119409.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->