### PR TITLE
[3.12] gh-119213: Be More Careful About _PyArg_Parser.kwtuple Across Interpreters (gh-119331)

### DIFF
--- a/Doc/data/python3.12.abi
+++ b/Doc/data/python3.12.abi
@@ -1710,7 +1710,7 @@
     <elf-symbol name='_PyNotImplemented_Type' size='416' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='_PyOS_ReadlineTState' size='8' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='_PyParser_TokenNames' size='552' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
-    <elf-symbol name='_PyRuntime' size='459944' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_PyRuntime' size='459992' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='_PySet_Dummy' size='8' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='_PyWeakref_CallableProxyType' size='416' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='_PyWeakref_ProxyType' size='416' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
@@ -2072,7 +2072,7 @@
     <function-decl name='_PyPathConfig_GetGlobalModuleSearchPath' filepath='./Include/internal/pycore_pathconfig.h' line='14' column='1' visibility='default' binding='global' size-in-bits='64'>
       <return type-id='type-id-16'/>
     </function-decl>
-    <function-decl name='_Py_Get_Getpath_CodeObject' mangled-name='_Py_Get_Getpath_CodeObject' filepath='./Modules/getpath.c' line='791' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_Get_Getpath_CodeObject'>
+    <function-decl name='_Py_Get_Getpath_CodeObject' mangled-name='_Py_Get_Getpath_CodeObject' filepath='./Modules/getpath.c' line='795' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_Get_Getpath_CodeObject'>
       <return type-id='type-id-2'/>
     </function-decl>
   </abi-instr>
@@ -2524,7 +2524,7 @@
       <parameter type-id='type-id-177'/>
       <return type-id='type-id-54'/>
     </function-decl>
-    <function-decl name='_PyPerfTrampoline_AfterFork_Child' filepath='./Include/internal/pycore_ceval.h' line='78' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_PyPerfTrampoline_AfterFork_Child' filepath='./Include/internal/pycore_ceval.h' line='79' column='1' visibility='default' binding='global' size-in-bits='64'>
       <return type-id='type-id-54'/>
     </function-decl>
     <function-decl name='_Py_normpath_and_size' filepath='./Include/internal/pycore_fileutils.h' line='256' column='1' visibility='default' binding='global' size-in-bits='64'>
@@ -2548,39 +2548,39 @@
       <parameter type-id='type-id-178'/>
       <return type-id='type-id-54'/>
     </function-decl>
-    <function-decl name='PyOS_BeforeFork' mangled-name='PyOS_BeforeFork' filepath='./Modules/posixmodule.c' line='585' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyOS_BeforeFork'>
+    <function-decl name='PyOS_BeforeFork' mangled-name='PyOS_BeforeFork' filepath='./Modules/posixmodule.c' line='588' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyOS_BeforeFork'>
       <return type-id='type-id-46'/>
     </function-decl>
-    <function-decl name='PyOS_AfterFork_Parent' mangled-name='PyOS_AfterFork_Parent' filepath='./Modules/posixmodule.c' line='594' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyOS_AfterFork_Parent'>
+    <function-decl name='PyOS_AfterFork_Parent' mangled-name='PyOS_AfterFork_Parent' filepath='./Modules/posixmodule.c' line='597' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyOS_AfterFork_Parent'>
       <return type-id='type-id-46'/>
     </function-decl>
-    <function-decl name='PyOS_AfterFork_Child' mangled-name='PyOS_AfterFork_Child' filepath='./Modules/posixmodule.c' line='605' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyOS_AfterFork_Child'>
+    <function-decl name='PyOS_AfterFork_Child' mangled-name='PyOS_AfterFork_Child' filepath='./Modules/posixmodule.c' line='608' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyOS_AfterFork_Child'>
       <return type-id='type-id-46'/>
     </function-decl>
-    <function-decl name='PyOS_AfterFork' mangled-name='PyOS_AfterFork' filepath='./Modules/posixmodule.c' line='669' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyOS_AfterFork'>
+    <function-decl name='PyOS_AfterFork' mangled-name='PyOS_AfterFork' filepath='./Modules/posixmodule.c' line='672' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyOS_AfterFork'>
       <return type-id='type-id-46'/>
     </function-decl>
-    <function-decl name='_PyLong_FromUid' mangled-name='_PyLong_FromUid' filepath='./Modules/posixmodule.c' line='690' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyLong_FromUid'>
-      <parameter type-id='type-id-126' name='uid' filepath='./Modules/posixmodule.c' line='690' column='1'/>
+    <function-decl name='_PyLong_FromUid' mangled-name='_PyLong_FromUid' filepath='./Modules/posixmodule.c' line='693' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyLong_FromUid'>
+      <parameter type-id='type-id-126' name='uid' filepath='./Modules/posixmodule.c' line='693' column='1'/>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='_PyLong_FromGid' mangled-name='_PyLong_FromGid' filepath='./Modules/posixmodule.c' line='698' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyLong_FromGid'>
-      <parameter type-id='type-id-122' name='gid' filepath='./Modules/posixmodule.c' line='698' column='1'/>
+    <function-decl name='_PyLong_FromGid' mangled-name='_PyLong_FromGid' filepath='./Modules/posixmodule.c' line='701' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyLong_FromGid'>
+      <parameter type-id='type-id-122' name='gid' filepath='./Modules/posixmodule.c' line='701' column='1'/>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='_Py_Uid_Converter' mangled-name='_Py_Uid_Converter' filepath='./Modules/posixmodule.c' line='706' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_Uid_Converter'>
-      <parameter type-id='type-id-2' name='obj' filepath='./Modules/posixmodule.c' line='706' column='1'/>
-      <parameter type-id='type-id-175' name='p' filepath='./Modules/posixmodule.c' line='706' column='1'/>
+    <function-decl name='_Py_Uid_Converter' mangled-name='_Py_Uid_Converter' filepath='./Modules/posixmodule.c' line='709' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_Uid_Converter'>
+      <parameter type-id='type-id-2' name='obj' filepath='./Modules/posixmodule.c' line='709' column='1'/>
+      <parameter type-id='type-id-175' name='p' filepath='./Modules/posixmodule.c' line='709' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='_Py_Gid_Converter' mangled-name='_Py_Gid_Converter' filepath='./Modules/posixmodule.c' line='812' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_Gid_Converter'>
-      <parameter type-id='type-id-2' name='obj' filepath='./Modules/posixmodule.c' line='812' column='1'/>
-      <parameter type-id='type-id-163' name='p' filepath='./Modules/posixmodule.c' line='812' column='1'/>
+    <function-decl name='_Py_Gid_Converter' mangled-name='_Py_Gid_Converter' filepath='./Modules/posixmodule.c' line='815' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_Gid_Converter'>
+      <parameter type-id='type-id-2' name='obj' filepath='./Modules/posixmodule.c' line='815' column='1'/>
+      <parameter type-id='type-id-163' name='p' filepath='./Modules/posixmodule.c' line='815' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='_Py_Sigset_Converter' mangled-name='_Py_Sigset_Converter' filepath='./Modules/posixmodule.c' line='1475' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_Sigset_Converter'>
-      <parameter type-id='type-id-2' name='obj' filepath='./Modules/posixmodule.c' line='1475' column='1'/>
-      <parameter type-id='type-id-22' name='addr' filepath='./Modules/posixmodule.c' line='1475' column='1'/>
+    <function-decl name='_Py_Sigset_Converter' mangled-name='_Py_Sigset_Converter' filepath='./Modules/posixmodule.c' line='1478' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_Sigset_Converter'>
+      <parameter type-id='type-id-2' name='obj' filepath='./Modules/posixmodule.c' line='1478' column='1'/>
+      <parameter type-id='type-id-22' name='addr' filepath='./Modules/posixmodule.c' line='1478' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
     <function-decl name='opendir' filepath='/usr/include/dirent.h' line='134' column='1' visibility='default' binding='global' size-in-bits='64'>
@@ -3679,7 +3679,7 @@
       <parameter type-id='type-id-231'/>
       <return type-id='type-id-46'/>
     </function-decl>
-    <function-decl name='_PyIsPerfTrampolineActive' filepath='./Include/internal/pycore_ceval.h' line='77' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_PyIsPerfTrampolineActive' filepath='./Include/internal/pycore_ceval.h' line='78' column='1' visibility='default' binding='global' size-in-bits='64'>
       <return type-id='type-id-8'/>
     </function-decl>
     <function-decl name='_PyImport_GetDLOpenFlags' filepath='./Include/internal/pycore_import.h' line='114' column='1' visibility='default' binding='global' size-in-bits='64'>
@@ -3698,7 +3698,7 @@
     <function-decl name='_PyImport_GetBuiltinModuleNames' filepath='./Include/internal/pycore_import.h' line='160' column='1' visibility='default' binding='global' size-in-bits='64'>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='_Py_GetGlobalAllocatedBlocks' filepath='./Include/internal/pycore_obmalloc.h' line='682' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_Py_GetGlobalAllocatedBlocks' filepath='./Include/internal/pycore_obmalloc.h' line='684' column='1' visibility='default' binding='global' size-in-bits='64'>
       <return type-id='type-id-14'/>
     </function-decl>
     <function-decl name='_PyPathConfig_ComputeSysPath0' filepath='./Include/internal/pycore_pathconfig.h' line='16' column='1' visibility='default' binding='global' size-in-bits='64'>
@@ -3724,65 +3724,68 @@
       <parameter type-id='type-id-22' name='userData' filepath='./Python/sysmodule.c' line='389' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='_PySys_GetSizeOf' mangled-name='_PySys_GetSizeOf' filepath='./Python/sysmodule.c' line='1776' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PySys_GetSizeOf'>
-      <parameter type-id='type-id-2' name='o' filepath='./Python/sysmodule.c' line='1776' column='1'/>
+    <function-decl name='_PySys_GetSizeOf' mangled-name='_PySys_GetSizeOf' filepath='./Python/sysmodule.c' line='1792' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PySys_GetSizeOf'>
+      <parameter type-id='type-id-2' name='o' filepath='./Python/sysmodule.c' line='1792' column='1'/>
       <return type-id='type-id-19'/>
     </function-decl>
-    <function-decl name='PyUnstable_PerfMapState_Init' mangled-name='PyUnstable_PerfMapState_Init' filepath='./Python/sysmodule.c' line='2275' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyUnstable_PerfMapState_Init'>
+    <function-decl name='PyUnstable_PerfMapState_Init' mangled-name='PyUnstable_PerfMapState_Init' filepath='./Python/sysmodule.c' line='2291' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyUnstable_PerfMapState_Init'>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='PyUnstable_WritePerfMapEntry' mangled-name='PyUnstable_WritePerfMapEntry' filepath='./Python/sysmodule.c' line='2306' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyUnstable_WritePerfMapEntry'>
-      <parameter type-id='type-id-22' name='code_addr' filepath='./Python/sysmodule.c' line='2307' column='1'/>
-      <parameter type-id='type-id-95' name='code_size' filepath='./Python/sysmodule.c' line='2308' column='1'/>
-      <parameter type-id='type-id-12' name='entry_name' filepath='./Python/sysmodule.c' line='2309' column='1'/>
+    <function-decl name='PyUnstable_WritePerfMapEntry' mangled-name='PyUnstable_WritePerfMapEntry' filepath='./Python/sysmodule.c' line='2322' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyUnstable_WritePerfMapEntry'>
+      <parameter type-id='type-id-22' name='code_addr' filepath='./Python/sysmodule.c' line='2323' column='1'/>
+      <parameter type-id='type-id-95' name='code_size' filepath='./Python/sysmodule.c' line='2324' column='1'/>
+      <parameter type-id='type-id-12' name='entry_name' filepath='./Python/sysmodule.c' line='2325' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='PySys_ResetWarnOptions' mangled-name='PySys_ResetWarnOptions' filepath='./Python/sysmodule.c' line='2615' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PySys_ResetWarnOptions'>
+    <function-decl name='PyUnstable_PerfMapState_Fini' mangled-name='PyUnstable_PerfMapState_Fini' filepath='./Python/sysmodule.c' line='2342' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyUnstable_PerfMapState_Fini'>
       <return type-id='type-id-46'/>
     </function-decl>
-    <function-decl name='PySys_AddWarnOptionUnicode' mangled-name='PySys_AddWarnOptionUnicode' filepath='./Python/sysmodule.c' line='2643' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PySys_AddWarnOptionUnicode'>
-      <parameter type-id='type-id-2' name='option' filepath='./Python/sysmodule.c' line='2643' column='1'/>
+    <function-decl name='PySys_ResetWarnOptions' mangled-name='PySys_ResetWarnOptions' filepath='./Python/sysmodule.c' line='2631' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PySys_ResetWarnOptions'>
       <return type-id='type-id-46'/>
     </function-decl>
-    <function-decl name='PySys_AddWarnOption' mangled-name='PySys_AddWarnOption' filepath='./Python/sysmodule.c' line='2655' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PySys_AddWarnOption'>
-      <parameter type-id='type-id-16' name='s' filepath='./Python/sysmodule.c' line='2655' column='1'/>
+    <function-decl name='PySys_AddWarnOptionUnicode' mangled-name='PySys_AddWarnOptionUnicode' filepath='./Python/sysmodule.c' line='2659' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PySys_AddWarnOptionUnicode'>
+      <parameter type-id='type-id-2' name='option' filepath='./Python/sysmodule.c' line='2659' column='1'/>
       <return type-id='type-id-46'/>
     </function-decl>
-    <function-decl name='PySys_HasWarnOptions' mangled-name='PySys_HasWarnOptions' filepath='./Python/sysmodule.c' line='2674' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PySys_HasWarnOptions'>
+    <function-decl name='PySys_AddWarnOption' mangled-name='PySys_AddWarnOption' filepath='./Python/sysmodule.c' line='2671' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PySys_AddWarnOption'>
+      <parameter type-id='type-id-16' name='s' filepath='./Python/sysmodule.c' line='2671' column='1'/>
+      <return type-id='type-id-46'/>
+    </function-decl>
+    <function-decl name='PySys_HasWarnOptions' mangled-name='PySys_HasWarnOptions' filepath='./Python/sysmodule.c' line='2690' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PySys_HasWarnOptions'>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='PySys_AddXOption' mangled-name='PySys_AddXOption' filepath='./Python/sysmodule.c' line='2753' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PySys_AddXOption'>
-      <parameter type-id='type-id-16' name='s' filepath='./Python/sysmodule.c' line='2753' column='1'/>
+    <function-decl name='PySys_AddXOption' mangled-name='PySys_AddXOption' filepath='./Python/sysmodule.c' line='2769' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PySys_AddXOption'>
+      <parameter type-id='type-id-16' name='s' filepath='./Python/sysmodule.c' line='2769' column='1'/>
       <return type-id='type-id-46'/>
     </function-decl>
-    <function-decl name='PySys_GetXOptions' mangled-name='PySys_GetXOptions' filepath='./Python/sysmodule.c' line='2767' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PySys_GetXOptions'>
+    <function-decl name='PySys_GetXOptions' mangled-name='PySys_GetXOptions' filepath='./Python/sysmodule.c' line='2783' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PySys_GetXOptions'>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='_Py_CreateMonitoringObject' filepath='./Python/sysmodule.c' line='3547' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_Py_CreateMonitoringObject' filepath='./Python/sysmodule.c' line='3563' column='1' visibility='default' binding='global' size-in-bits='64'>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='PySys_SetPath' mangled-name='PySys_SetPath' filepath='./Python/sysmodule.c' line='3669' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PySys_SetPath'>
-      <parameter type-id='type-id-16' name='path' filepath='./Python/sysmodule.c' line='3669' column='1'/>
+    <function-decl name='PySys_SetPath' mangled-name='PySys_SetPath' filepath='./Python/sysmodule.c' line='3685' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PySys_SetPath'>
+      <parameter type-id='type-id-16' name='path' filepath='./Python/sysmodule.c' line='3685' column='1'/>
       <return type-id='type-id-46'/>
     </function-decl>
-    <function-decl name='PySys_SetArgvEx' mangled-name='PySys_SetArgvEx' filepath='./Python/sysmodule.c' line='3701' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PySys_SetArgvEx'>
-      <parameter type-id='type-id-8' name='argc' filepath='./Python/sysmodule.c' line='3701' column='1'/>
-      <parameter type-id='type-id-235' name='argv' filepath='./Python/sysmodule.c' line='3701' column='1'/>
-      <parameter type-id='type-id-8' name='updatepath' filepath='./Python/sysmodule.c' line='3701' column='1'/>
+    <function-decl name='PySys_SetArgvEx' mangled-name='PySys_SetArgvEx' filepath='./Python/sysmodule.c' line='3717' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PySys_SetArgvEx'>
+      <parameter type-id='type-id-8' name='argc' filepath='./Python/sysmodule.c' line='3717' column='1'/>
+      <parameter type-id='type-id-235' name='argv' filepath='./Python/sysmodule.c' line='3717' column='1'/>
+      <parameter type-id='type-id-8' name='updatepath' filepath='./Python/sysmodule.c' line='3717' column='1'/>
       <return type-id='type-id-46'/>
     </function-decl>
-    <function-decl name='PySys_SetArgv' mangled-name='PySys_SetArgv' filepath='./Python/sysmodule.c' line='3745' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PySys_SetArgv'>
-      <parameter type-id='type-id-8' name='argc' filepath='./Python/sysmodule.c' line='3745' column='1'/>
-      <parameter type-id='type-id-235' name='argv' filepath='./Python/sysmodule.c' line='3745' column='1'/>
+    <function-decl name='PySys_SetArgv' mangled-name='PySys_SetArgv' filepath='./Python/sysmodule.c' line='3761' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PySys_SetArgv'>
+      <parameter type-id='type-id-8' name='argc' filepath='./Python/sysmodule.c' line='3761' column='1'/>
+      <parameter type-id='type-id-235' name='argv' filepath='./Python/sysmodule.c' line='3761' column='1'/>
       <return type-id='type-id-46'/>
     </function-decl>
-    <function-decl name='PySys_WriteStdout' mangled-name='PySys_WriteStdout' filepath='./Python/sysmodule.c' line='3840' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PySys_WriteStdout'>
-      <parameter type-id='type-id-12' name='format' filepath='./Python/sysmodule.c' line='3840' column='1'/>
+    <function-decl name='PySys_WriteStdout' mangled-name='PySys_WriteStdout' filepath='./Python/sysmodule.c' line='3856' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PySys_WriteStdout'>
+      <parameter type-id='type-id-12' name='format' filepath='./Python/sysmodule.c' line='3856' column='1'/>
       <parameter is-variadic='yes'/>
       <return type-id='type-id-46'/>
     </function-decl>
-    <function-decl name='PySys_FormatStdout' mangled-name='PySys_FormatStdout' filepath='./Python/sysmodule.c' line='3882' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PySys_FormatStdout'>
-      <parameter type-id='type-id-12' name='format' filepath='./Python/sysmodule.c' line='3882' column='1'/>
+    <function-decl name='PySys_FormatStdout' mangled-name='PySys_FormatStdout' filepath='./Python/sysmodule.c' line='3898' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PySys_FormatStdout'>
+      <parameter type-id='type-id-12' name='format' filepath='./Python/sysmodule.c' line='3898' column='1'/>
       <parameter is-variadic='yes'/>
       <return type-id='type-id-46'/>
     </function-decl>
@@ -3896,22 +3899,22 @@
     <function-decl name='PyGC_IsEnabled' mangled-name='PyGC_IsEnabled' filepath='Modules/gcmodule.c' line='2086' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyGC_IsEnabled'>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='PyUnstable_Object_GC_NewWithExtraData' mangled-name='PyUnstable_Object_GC_NewWithExtraData' filepath='Modules/gcmodule.c' line='2347' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyUnstable_Object_GC_NewWithExtraData'>
-      <parameter type-id='type-id-1' name='tp' filepath='Modules/gcmodule.c' line='2347' column='1'/>
-      <parameter type-id='type-id-19' name='extra_size' filepath='Modules/gcmodule.c' line='2347' column='1'/>
+    <function-decl name='PyUnstable_Object_GC_NewWithExtraData' mangled-name='PyUnstable_Object_GC_NewWithExtraData' filepath='Modules/gcmodule.c' line='2350' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyUnstable_Object_GC_NewWithExtraData'>
+      <parameter type-id='type-id-1' name='tp' filepath='Modules/gcmodule.c' line='2350' column='1'/>
+      <parameter type-id='type-id-19' name='extra_size' filepath='Modules/gcmodule.c' line='2350' column='1'/>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='PyObject_GC_IsTracked' mangled-name='PyObject_GC_IsTracked' filepath='Modules/gcmodule.c' line='2403' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyObject_GC_IsTracked'>
-      <parameter type-id='type-id-2' name='obj' filepath='Modules/gcmodule.c' line='2403' column='1'/>
+    <function-decl name='PyObject_GC_IsTracked' mangled-name='PyObject_GC_IsTracked' filepath='Modules/gcmodule.c' line='2406' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyObject_GC_IsTracked'>
+      <parameter type-id='type-id-2' name='obj' filepath='Modules/gcmodule.c' line='2406' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='PyObject_GC_IsFinalized' mangled-name='PyObject_GC_IsFinalized' filepath='Modules/gcmodule.c' line='2412' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyObject_GC_IsFinalized'>
-      <parameter type-id='type-id-2' name='obj' filepath='Modules/gcmodule.c' line='2412' column='1'/>
+    <function-decl name='PyObject_GC_IsFinalized' mangled-name='PyObject_GC_IsFinalized' filepath='Modules/gcmodule.c' line='2415' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyObject_GC_IsFinalized'>
+      <parameter type-id='type-id-2' name='obj' filepath='Modules/gcmodule.c' line='2415' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='PyUnstable_GC_VisitObjects' mangled-name='PyUnstable_GC_VisitObjects' filepath='Modules/gcmodule.c' line='2421' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyUnstable_GC_VisitObjects'>
-      <parameter type-id='type-id-237' name='callback' filepath='Modules/gcmodule.c' line='2421' column='1'/>
-      <parameter type-id='type-id-22' name='arg' filepath='Modules/gcmodule.c' line='2421' column='1'/>
+    <function-decl name='PyUnstable_GC_VisitObjects' mangled-name='PyUnstable_GC_VisitObjects' filepath='Modules/gcmodule.c' line='2424' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyUnstable_GC_VisitObjects'>
+      <parameter type-id='type-id-237' name='callback' filepath='Modules/gcmodule.c' line='2424' column='1'/>
+      <parameter type-id='type-id-22' name='arg' filepath='Modules/gcmodule.c' line='2424' column='1'/>
       <return type-id='type-id-46'/>
     </function-decl>
     <function-type size-in-bits='64' id='type-id-238'>
@@ -4033,7 +4036,7 @@
       <parameter type-id='type-id-2'/>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='_Py_CheckRecursiveCall' mangled-name='_Py_CheckRecursiveCall' filepath='./Include/internal/pycore_ceval.h' line='125' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_CheckRecursiveCall'>
+    <function-decl name='_Py_CheckRecursiveCall' mangled-name='_Py_CheckRecursiveCall' filepath='./Include/internal/pycore_ceval.h' line='126' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_CheckRecursiveCall'>
       <parameter type-id='type-id-177'/>
       <parameter type-id='type-id-12'/>
       <return type-id='type-id-8'/>
@@ -4089,22 +4092,22 @@
       <parameter type-id='type-id-2'/>
       <return type-id='type-id-14'/>
     </function-decl>
-    <function-decl name='PyLong_AsDouble' mangled-name='PyLong_AsDouble' filepath='./Include/longobject.h' line='63' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyLong_AsDouble'>
+    <function-decl name='PyLong_AsDouble' mangled-name='PyLong_AsDouble' filepath='./Include/longobject.h' line='80' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyLong_AsDouble'>
       <parameter type-id='type-id-2'/>
       <return type-id='type-id-251'/>
     </function-decl>
-    <function-decl name='PyType_IsSubtype' mangled-name='PyType_IsSubtype' filepath='./Include/object.h' line='379' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyType_IsSubtype'>
+    <function-decl name='PyType_IsSubtype' mangled-name='PyType_IsSubtype' filepath='./Include/object.h' line='378' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyType_IsSubtype'>
       <parameter type-id='type-id-1'/>
       <parameter type-id='type-id-1'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='PyObject_RichCompareBool' mangled-name='PyObject_RichCompareBool' filepath='./Include/object.h' line='407' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyObject_RichCompareBool'>
+    <function-decl name='PyObject_RichCompareBool' mangled-name='PyObject_RichCompareBool' filepath='./Include/object.h' line='406' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyObject_RichCompareBool'>
       <parameter type-id='type-id-2'/>
       <parameter type-id='type-id-2'/>
       <parameter type-id='type-id-8'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='PyObject_IsTrue' mangled-name='PyObject_IsTrue' filepath='./Include/object.h' line='422' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyObject_IsTrue'>
+    <function-decl name='PyObject_IsTrue' mangled-name='PyObject_IsTrue' filepath='./Include/object.h' line='421' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyObject_IsTrue'>
       <parameter type-id='type-id-2'/>
       <return type-id='type-id-8'/>
     </function-decl>
@@ -4750,7 +4753,7 @@
       <parameter type-id='type-id-233'/>
       <return type-id='type-id-248'/>
     </function-decl>
-    <function-decl name='_Py_GetConfig' mangled-name='_Py_GetConfig' filepath='./Include/cpython/pystate.h' line='368' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_GetConfig'>
+    <function-decl name='_Py_GetConfig' mangled-name='_Py_GetConfig' filepath='./Include/cpython/pystate.h' line='380' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_GetConfig'>
       <return type-id='type-id-260'/>
     </function-decl>
     <function-decl name='_Py_bytes_isspace' filepath='./Include/internal/pycore_bytes_methods.h' line='13' column='1' visibility='default' binding='global' size-in-bits='64'>
@@ -4908,27 +4911,27 @@
       <parameter type-id='type-id-179'/>
       <return type-id='type-id-47'/>
     </function-decl>
-    <function-decl name='PyType_GenericAlloc' mangled-name='PyType_GenericAlloc' filepath='./Include/object.h' line='395' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyType_GenericAlloc'>
+    <function-decl name='PyType_GenericAlloc' mangled-name='PyType_GenericAlloc' filepath='./Include/object.h' line='394' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyType_GenericAlloc'>
       <parameter type-id='type-id-1'/>
       <parameter type-id='type-id-14'/>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='PyType_GenericNew' mangled-name='PyType_GenericNew' filepath='./Include/object.h' line='396' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyType_GenericNew'>
+    <function-decl name='PyType_GenericNew' mangled-name='PyType_GenericNew' filepath='./Include/object.h' line='395' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyType_GenericNew'>
       <parameter type-id='type-id-1'/>
       <parameter type-id='type-id-2'/>
       <parameter type-id='type-id-2'/>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='PyObject_SelfIter' mangled-name='PyObject_SelfIter' filepath='./Include/object.h' line='414' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyObject_SelfIter'>
+    <function-decl name='PyObject_SelfIter' mangled-name='PyObject_SelfIter' filepath='./Include/object.h' line='413' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyObject_SelfIter'>
       <parameter type-id='type-id-2'/>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='PyObject_GenericGetAttr' mangled-name='PyObject_GenericGetAttr' filepath='./Include/object.h' line='415' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyObject_GenericGetAttr'>
+    <function-decl name='PyObject_GenericGetAttr' mangled-name='PyObject_GenericGetAttr' filepath='./Include/object.h' line='414' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyObject_GenericGetAttr'>
       <parameter type-id='type-id-2'/>
       <parameter type-id='type-id-2'/>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='_PyObject_GetState' mangled-name='_PyObject_GetState' filepath='./Include/object.h' line='436' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyObject_GetState'>
+    <function-decl name='_PyObject_GetState' mangled-name='_PyObject_GetState' filepath='./Include/object.h' line='435' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyObject_GetState'>
       <parameter type-id='type-id-2'/>
       <return type-id='type-id-2'/>
     </function-decl>
@@ -5189,7 +5192,7 @@
       <parameter type-id='type-id-8'/>
       <return type-id='type-id-15'/>
     </function-decl>
-    <function-decl name='PyObject_ASCII' mangled-name='PyObject_ASCII' filepath='./Include/object.h' line='404' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyObject_ASCII'>
+    <function-decl name='PyObject_ASCII' mangled-name='PyObject_ASCII' filepath='./Include/object.h' line='403' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyObject_ASCII'>
       <parameter type-id='type-id-2'/>
       <return type-id='type-id-2'/>
     </function-decl>
@@ -5374,7 +5377,7 @@
       <parameter type-id='type-id-233'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='_PyEval_Vector' filepath='./Include/internal/pycore_ceval.h' line='94' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_PyEval_Vector' filepath='./Include/internal/pycore_ceval.h' line='95' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-177'/>
       <parameter type-id='type-id-310'/>
       <parameter type-id='type-id-2'/>
@@ -5411,12 +5414,12 @@
       <parameter type-id='type-id-2'/>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='PyObject_GetAttrString' mangled-name='PyObject_GetAttrString' filepath='./Include/object.h' line='408' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyObject_GetAttrString'>
+    <function-decl name='PyObject_GetAttrString' mangled-name='PyObject_GetAttrString' filepath='./Include/object.h' line='407' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyObject_GetAttrString'>
       <parameter type-id='type-id-2'/>
       <parameter type-id='type-id-12'/>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='PyCallable_Check' mangled-name='PyCallable_Check' filepath='./Include/object.h' line='424' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyCallable_Check'>
+    <function-decl name='PyCallable_Check' mangled-name='PyCallable_Check' filepath='./Include/object.h' line='423' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyCallable_Check'>
       <parameter type-id='type-id-2'/>
       <return type-id='type-id-8'/>
     </function-decl>
@@ -5640,7 +5643,7 @@
   </abi-instr>
   <abi-instr address-size='64' path='Objects/cellobject.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
     <var-decl name='PyCell_Type' type-id='type-id-256' mangled-name='PyCell_Type' visibility='default' filepath='./Include/cpython/cellobject.h' line='16' column='1' elf-symbol-id='PyCell_Type'/>
-    <function-decl name='PyObject_RichCompare' mangled-name='PyObject_RichCompare' filepath='./Include/object.h' line='406' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyObject_RichCompare'>
+    <function-decl name='PyObject_RichCompare' mangled-name='PyObject_RichCompare' filepath='./Include/object.h' line='405' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyObject_RichCompare'>
       <parameter type-id='type-id-2'/>
       <parameter type-id='type-id-2'/>
       <parameter type-id='type-id-8'/>
@@ -5672,21 +5675,21 @@
       <parameter type-id='type-id-1'/>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='PyType_Ready' mangled-name='PyType_Ready' filepath='./Include/object.h' line='394' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyType_Ready'>
+    <function-decl name='PyType_Ready' mangled-name='PyType_Ready' filepath='./Include/object.h' line='393' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyType_Ready'>
       <parameter type-id='type-id-1'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='PyObject_GenericSetAttr' mangled-name='PyObject_GenericSetAttr' filepath='./Include/object.h' line='416' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyObject_GenericSetAttr'>
+    <function-decl name='PyObject_GenericSetAttr' mangled-name='PyObject_GenericSetAttr' filepath='./Include/object.h' line='415' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyObject_GenericSetAttr'>
       <parameter type-id='type-id-2'/>
       <parameter type-id='type-id-2'/>
       <parameter type-id='type-id-2'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='PyObject_Hash' mangled-name='PyObject_Hash' filepath='./Include/object.h' line='420' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyObject_Hash'>
+    <function-decl name='PyObject_Hash' mangled-name='PyObject_Hash' filepath='./Include/object.h' line='419' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyObject_Hash'>
       <parameter type-id='type-id-2'/>
       <return type-id='type-id-305'/>
     </function-decl>
-    <function-decl name='PyObject_ClearWeakRefs' mangled-name='PyObject_ClearWeakRefs' filepath='./Include/object.h' line='425' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyObject_ClearWeakRefs'>
+    <function-decl name='PyObject_ClearWeakRefs' mangled-name='PyObject_ClearWeakRefs' filepath='./Include/object.h' line='424' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyObject_ClearWeakRefs'>
       <parameter type-id='type-id-2'/>
       <return type-id='type-id-46'/>
     </function-decl>
@@ -5820,12 +5823,12 @@
       <parameter type-id='type-id-14'/>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='_Py_GetBaseOpcode' filepath='./Include/internal/pycore_code.h' line='488' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_Py_GetBaseOpcode' filepath='./Include/internal/pycore_code.h' line='490' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-328'/>
       <parameter type-id='type-id-8'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='PyLong_FromVoidPtr' mangled-name='PyLong_FromVoidPtr' filepath='./Include/longobject.h' line='64' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyLong_FromVoidPtr'>
+    <function-decl name='PyLong_FromVoidPtr' mangled-name='PyLong_FromVoidPtr' filepath='./Include/longobject.h' line='81' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyLong_FromVoidPtr'>
       <parameter type-id='type-id-22'/>
       <return type-id='type-id-2'/>
     </function-decl>
@@ -6136,7 +6139,7 @@
       <parameter type-id='type-id-335'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='_PyThreadState_UncheckedGet' mangled-name='_PyThreadState_UncheckedGet' filepath='./Include/cpython/pystate.h' line='274' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyThreadState_UncheckedGet'>
+    <function-decl name='_PyThreadState_UncheckedGet' mangled-name='_PyThreadState_UncheckedGet' filepath='./Include/cpython/pystate.h' line='286' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyThreadState_UncheckedGet'>
       <return type-id='type-id-177'/>
     </function-decl>
     <var-decl name='PyClassMethodDescr_Type' type-id='type-id-256' mangled-name='PyClassMethodDescr_Type' visibility='default' filepath='./Include/descrobject.h' line='19' column='1' elf-symbol-id='PyClassMethodDescr_Type'/>
@@ -6169,11 +6172,11 @@
       <parameter type-id='type-id-1'/>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='PyType_GetQualName' mangled-name='PyType_GetQualName' filepath='./Include/object.h' line='370' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyType_GetQualName'>
+    <function-decl name='PyType_GetQualName' mangled-name='PyType_GetQualName' filepath='./Include/object.h' line='369' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyType_GetQualName'>
       <parameter type-id='type-id-1'/>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='PyObject_SetAttr' mangled-name='PyObject_SetAttr' filepath='./Include/object.h' line='412' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyObject_SetAttr'>
+    <function-decl name='PyObject_SetAttr' mangled-name='PyObject_SetAttr' filepath='./Include/object.h' line='411' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyObject_SetAttr'>
       <parameter type-id='type-id-2'/>
       <parameter type-id='type-id-2'/>
       <parameter type-id='type-id-2'/>
@@ -6590,11 +6593,11 @@
       <parameter type-id='type-id-2'/>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='PyObject_Repr' mangled-name='PyObject_Repr' filepath='./Include/object.h' line='402' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyObject_Repr'>
+    <function-decl name='PyObject_Repr' mangled-name='PyObject_Repr' filepath='./Include/object.h' line='401' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyObject_Repr'>
       <parameter type-id='type-id-2'/>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='PyObject_GenericSetDict' mangled-name='PyObject_GenericSetDict' filepath='./Include/object.h' line='418' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyObject_GenericSetDict'>
+    <function-decl name='PyObject_GenericSetDict' mangled-name='PyObject_GenericSetDict' filepath='./Include/object.h' line='417' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyObject_GenericSetDict'>
       <parameter type-id='type-id-2'/>
       <parameter type-id='type-id-2'/>
       <parameter type-id='type-id-22'/>
@@ -6875,9 +6878,9 @@
       <parameter type-id='type-id-12' name='reason' filepath='Objects/exceptions.c' line='3233' column='1'/>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='_PyException_AddNote' mangled-name='_PyException_AddNote' filepath='Objects/exceptions.c' line='3832' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyException_AddNote'>
-      <parameter type-id='type-id-2' name='exc' filepath='Objects/exceptions.c' line='3832' column='1'/>
-      <parameter type-id='type-id-2' name='note' filepath='Objects/exceptions.c' line='3832' column='1'/>
+    <function-decl name='_PyException_AddNote' mangled-name='_PyException_AddNote' filepath='Objects/exceptions.c' line='3828' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyException_AddNote'>
+      <parameter type-id='type-id-2' name='exc' filepath='Objects/exceptions.c' line='3828' column='1'/>
+      <parameter type-id='type-id-2' name='note' filepath='Objects/exceptions.c' line='3828' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
   </abi-instr>
@@ -7125,41 +7128,41 @@
     <function-decl name='PyFloat_GetInfo' mangled-name='PyFloat_GetInfo' filepath='Objects/floatobject.c' line='94' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyFloat_GetInfo'>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='_PyFloat_DebugMallocStats' mangled-name='_PyFloat_DebugMallocStats' filepath='Objects/floatobject.c' line='2037' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyFloat_DebugMallocStats'>
-      <parameter type-id='type-id-229' name='out' filepath='Objects/floatobject.c' line='2037' column='1'/>
+    <function-decl name='_PyFloat_DebugMallocStats' mangled-name='_PyFloat_DebugMallocStats' filepath='Objects/floatobject.c' line='2042' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyFloat_DebugMallocStats'>
+      <parameter type-id='type-id-229' name='out' filepath='Objects/floatobject.c' line='2042' column='1'/>
       <return type-id='type-id-46'/>
     </function-decl>
-    <function-decl name='PyFloat_Pack2' mangled-name='PyFloat_Pack2' filepath='Objects/floatobject.c' line='2060' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyFloat_Pack2'>
-      <parameter type-id='type-id-251' name='x' filepath='Objects/floatobject.c' line='2060' column='1'/>
-      <parameter type-id='type-id-15' name='data' filepath='Objects/floatobject.c' line='2060' column='1'/>
-      <parameter type-id='type-id-8' name='le' filepath='Objects/floatobject.c' line='2060' column='1'/>
+    <function-decl name='PyFloat_Pack2' mangled-name='PyFloat_Pack2' filepath='Objects/floatobject.c' line='2065' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyFloat_Pack2'>
+      <parameter type-id='type-id-251' name='x' filepath='Objects/floatobject.c' line='2065' column='1'/>
+      <parameter type-id='type-id-15' name='data' filepath='Objects/floatobject.c' line='2065' column='1'/>
+      <parameter type-id='type-id-8' name='le' filepath='Objects/floatobject.c' line='2065' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='PyFloat_Pack4' mangled-name='PyFloat_Pack4' filepath='Objects/floatobject.c' line='2165' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyFloat_Pack4'>
-      <parameter type-id='type-id-251' name='x' filepath='Objects/floatobject.c' line='2165' column='1'/>
-      <parameter type-id='type-id-15' name='data' filepath='Objects/floatobject.c' line='2165' column='1'/>
-      <parameter type-id='type-id-8' name='le' filepath='Objects/floatobject.c' line='2165' column='1'/>
+    <function-decl name='PyFloat_Pack4' mangled-name='PyFloat_Pack4' filepath='Objects/floatobject.c' line='2170' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyFloat_Pack4'>
+      <parameter type-id='type-id-251' name='x' filepath='Objects/floatobject.c' line='2170' column='1'/>
+      <parameter type-id='type-id-15' name='data' filepath='Objects/floatobject.c' line='2170' column='1'/>
+      <parameter type-id='type-id-8' name='le' filepath='Objects/floatobject.c' line='2170' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='PyFloat_Pack8' mangled-name='PyFloat_Pack8' filepath='Objects/floatobject.c' line='2273' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyFloat_Pack8'>
-      <parameter type-id='type-id-251' name='x' filepath='Objects/floatobject.c' line='2273' column='1'/>
-      <parameter type-id='type-id-15' name='data' filepath='Objects/floatobject.c' line='2273' column='1'/>
-      <parameter type-id='type-id-8' name='le' filepath='Objects/floatobject.c' line='2273' column='1'/>
+    <function-decl name='PyFloat_Pack8' mangled-name='PyFloat_Pack8' filepath='Objects/floatobject.c' line='2278' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyFloat_Pack8'>
+      <parameter type-id='type-id-251' name='x' filepath='Objects/floatobject.c' line='2278' column='1'/>
+      <parameter type-id='type-id-15' name='data' filepath='Objects/floatobject.c' line='2278' column='1'/>
+      <parameter type-id='type-id-8' name='le' filepath='Objects/floatobject.c' line='2278' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='PyFloat_Unpack2' mangled-name='PyFloat_Unpack2' filepath='Objects/floatobject.c' line='2403' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyFloat_Unpack2'>
-      <parameter type-id='type-id-12' name='data' filepath='Objects/floatobject.c' line='2403' column='1'/>
-      <parameter type-id='type-id-8' name='le' filepath='Objects/floatobject.c' line='2403' column='1'/>
+    <function-decl name='PyFloat_Unpack2' mangled-name='PyFloat_Unpack2' filepath='Objects/floatobject.c' line='2408' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyFloat_Unpack2'>
+      <parameter type-id='type-id-12' name='data' filepath='Objects/floatobject.c' line='2408' column='1'/>
+      <parameter type-id='type-id-8' name='le' filepath='Objects/floatobject.c' line='2408' column='1'/>
       <return type-id='type-id-251'/>
     </function-decl>
-    <function-decl name='PyFloat_Unpack4' mangled-name='PyFloat_Unpack4' filepath='Objects/floatobject.c' line='2455' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyFloat_Unpack4'>
-      <parameter type-id='type-id-12' name='data' filepath='Objects/floatobject.c' line='2455' column='1'/>
-      <parameter type-id='type-id-8' name='le' filepath='Objects/floatobject.c' line='2455' column='1'/>
+    <function-decl name='PyFloat_Unpack4' mangled-name='PyFloat_Unpack4' filepath='Objects/floatobject.c' line='2460' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyFloat_Unpack4'>
+      <parameter type-id='type-id-12' name='data' filepath='Objects/floatobject.c' line='2460' column='1'/>
+      <parameter type-id='type-id-8' name='le' filepath='Objects/floatobject.c' line='2460' column='1'/>
       <return type-id='type-id-251'/>
     </function-decl>
-    <function-decl name='PyFloat_Unpack8' mangled-name='PyFloat_Unpack8' filepath='Objects/floatobject.c' line='2534' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyFloat_Unpack8'>
-      <parameter type-id='type-id-12' name='data' filepath='Objects/floatobject.c' line='2534' column='1'/>
-      <parameter type-id='type-id-8' name='le' filepath='Objects/floatobject.c' line='2534' column='1'/>
+    <function-decl name='PyFloat_Unpack8' mangled-name='PyFloat_Unpack8' filepath='Objects/floatobject.c' line='2539' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyFloat_Unpack8'>
+      <parameter type-id='type-id-12' name='data' filepath='Objects/floatobject.c' line='2539' column='1'/>
+      <parameter type-id='type-id-8' name='le' filepath='Objects/floatobject.c' line='2539' column='1'/>
       <return type-id='type-id-251'/>
     </function-decl>
   </abi-instr>
@@ -7305,9 +7308,9 @@
     </function-decl>
   </abi-instr>
   <abi-instr address-size='64' path='Objects/funcobject.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
-    <var-decl name='PyFunction_Type' type-id='type-id-256' mangled-name='PyFunction_Type' visibility='default' filepath='./Include/cpython/funcobject.h' line='63' column='1' elf-symbol-id='PyFunction_Type'/>
-    <var-decl name='PyClassMethod_Type' type-id='type-id-256' mangled-name='PyClassMethod_Type' visibility='default' filepath='./Include/cpython/funcobject.h' line='129' column='1' elf-symbol-id='PyClassMethod_Type'/>
-    <var-decl name='PyStaticMethod_Type' type-id='type-id-256' mangled-name='PyStaticMethod_Type' visibility='default' filepath='./Include/cpython/funcobject.h' line='130' column='1' elf-symbol-id='PyStaticMethod_Type'/>
+    <var-decl name='PyFunction_Type' type-id='type-id-256' mangled-name='PyFunction_Type' visibility='default' filepath='./Include/cpython/funcobject.h' line='65' column='1' elf-symbol-id='PyFunction_Type'/>
+    <var-decl name='PyClassMethod_Type' type-id='type-id-256' mangled-name='PyClassMethod_Type' visibility='default' filepath='./Include/cpython/funcobject.h' line='131' column='1' elf-symbol-id='PyClassMethod_Type'/>
+    <var-decl name='PyStaticMethod_Type' type-id='type-id-256' mangled-name='PyStaticMethod_Type' visibility='default' filepath='./Include/cpython/funcobject.h' line='132' column='1' elf-symbol-id='PyStaticMethod_Type'/>
     <function-decl name='_PyEval_BuiltinsFromGlobals' filepath='./Include/internal/pycore_ceval.h' line='57' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-177'/>
       <parameter type-id='type-id-2'/>
@@ -7414,7 +7417,7 @@
       <parameter type-id='type-id-2'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='PyObject_Dir' mangled-name='PyObject_Dir' filepath='./Include/object.h' line='432' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyObject_Dir'>
+    <function-decl name='PyObject_Dir' mangled-name='PyObject_Dir' filepath='./Include/object.h' line='431' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyObject_Dir'>
       <parameter type-id='type-id-2'/>
       <return type-id='type-id-2'/>
     </function-decl>
@@ -7460,7 +7463,7 @@
       </data-member>
     </class-decl>
     <typedef-decl name='PyGenObject' type-id='type-id-368' filepath='./Include/cpython/genobject.h' line='34' column='1' id='type-id-367'/>
-    <typedef-decl name='_PyInterpreterFrame' type-id='type-id-371' filepath='./Include/internal/pycore_frame.h' line='73' column='1' id='type-id-372'/>
+    <typedef-decl name='_PyInterpreterFrame' type-id='type-id-371' filepath='./Include/internal/pycore_frame.h' line='75' column='1' id='type-id-372'/>
     <pointer-type-def type-id='type-id-367' size-in-bits='64' id='type-id-373'/>
     <pointer-type-def type-id='type-id-372' size-in-bits='64' id='type-id-374'/>
     <function-decl name='_PyEval_EvalFrameDefault' mangled-name='_PyEval_EvalFrameDefault' filepath='./Include/cpython/ceval.h' line='20' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyEval_EvalFrameDefault'>
@@ -7484,23 +7487,27 @@
       <parameter type-id='type-id-375'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='_PyEval_GetFrame' filepath='./Include/internal/pycore_ceval.h' line='151' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_PyEval_GetFrame' filepath='./Include/internal/pycore_ceval.h' line='152' column='1' visibility='default' binding='global' size-in-bits='64'>
       <return type-id='type-id-375'/>
     </function-decl>
-    <function-decl name='_PyFrame_Copy' filepath='./Include/internal/pycore_frame.h' line='110' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_PyFrame_Copy' filepath='./Include/internal/pycore_frame.h' line='112' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-374'/>
       <parameter type-id='type-id-374'/>
       <return type-id='type-id-46'/>
     </function-decl>
-    <function-decl name='_PyFrame_MakeAndSetFrameObject' filepath='./Include/internal/pycore_frame.h' line='197' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_PyFrame_MakeAndSetFrameObject' filepath='./Include/internal/pycore_frame.h' line='199' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-374'/>
       <return type-id='type-id-365'/>
     </function-decl>
-    <function-decl name='_PyFrame_ClearExceptCode' filepath='./Include/internal/pycore_frame.h' line='224' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_PyFrame_ClearLocals' filepath='./Include/internal/pycore_frame.h' line='217' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-374'/>
       <return type-id='type-id-46'/>
     </function-decl>
-    <function-decl name='_PyFrame_Traverse' filepath='./Include/internal/pycore_frame.h' line='227' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_PyFrame_ClearExceptCode' filepath='./Include/internal/pycore_frame.h' line='229' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-374'/>
+      <return type-id='type-id-46'/>
+    </function-decl>
+    <function-decl name='_PyFrame_Traverse' filepath='./Include/internal/pycore_frame.h' line='232' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-374'/>
       <parameter type-id='type-id-341'/>
       <parameter type-id='type-id-22'/>
@@ -7537,30 +7544,30 @@
       <parameter type-id='type-id-2' name='self' filepath='Objects/genobject.c' line='70' column='1'/>
       <return type-id='type-id-46'/>
     </function-decl>
-    <function-decl name='_PyGen_SetStopIterationValue' mangled-name='_PyGen_SetStopIterationValue' filepath='Objects/genobject.c' line='619' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyGen_SetStopIterationValue'>
-      <parameter type-id='type-id-2' name='value' filepath='Objects/genobject.c' line='619' column='1'/>
+    <function-decl name='_PyGen_SetStopIterationValue' mangled-name='_PyGen_SetStopIterationValue' filepath='Objects/genobject.c' line='621' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyGen_SetStopIterationValue'>
+      <parameter type-id='type-id-2' name='value' filepath='Objects/genobject.c' line='621' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='PyGen_NewWithQualName' mangled-name='PyGen_NewWithQualName' filepath='Objects/genobject.c' line='989' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyGen_NewWithQualName'>
-      <parameter type-id='type-id-365' name='f' filepath='Objects/genobject.c' line='989' column='1'/>
-      <parameter type-id='type-id-2' name='name' filepath='Objects/genobject.c' line='989' column='1'/>
-      <parameter type-id='type-id-2' name='qualname' filepath='Objects/genobject.c' line='989' column='1'/>
+    <function-decl name='PyGen_NewWithQualName' mangled-name='PyGen_NewWithQualName' filepath='Objects/genobject.c' line='991' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyGen_NewWithQualName'>
+      <parameter type-id='type-id-365' name='f' filepath='Objects/genobject.c' line='991' column='1'/>
+      <parameter type-id='type-id-2' name='name' filepath='Objects/genobject.c' line='991' column='1'/>
+      <parameter type-id='type-id-2' name='qualname' filepath='Objects/genobject.c' line='991' column='1'/>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='PyGen_New' mangled-name='PyGen_New' filepath='Objects/genobject.c' line='995' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyGen_New'>
-      <parameter type-id='type-id-365' name='f' filepath='Objects/genobject.c' line='995' column='1'/>
+    <function-decl name='PyGen_New' mangled-name='PyGen_New' filepath='Objects/genobject.c' line='997' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyGen_New'>
+      <parameter type-id='type-id-365' name='f' filepath='Objects/genobject.c' line='997' column='1'/>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='PyCoro_New' mangled-name='PyCoro_New' filepath='Objects/genobject.c' line='1353' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyCoro_New'>
-      <parameter type-id='type-id-365' name='f' filepath='Objects/genobject.c' line='1353' column='1'/>
-      <parameter type-id='type-id-2' name='name' filepath='Objects/genobject.c' line='1353' column='1'/>
-      <parameter type-id='type-id-2' name='qualname' filepath='Objects/genobject.c' line='1353' column='1'/>
+    <function-decl name='PyCoro_New' mangled-name='PyCoro_New' filepath='Objects/genobject.c' line='1355' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyCoro_New'>
+      <parameter type-id='type-id-365' name='f' filepath='Objects/genobject.c' line='1355' column='1'/>
+      <parameter type-id='type-id-2' name='name' filepath='Objects/genobject.c' line='1355' column='1'/>
+      <parameter type-id='type-id-2' name='qualname' filepath='Objects/genobject.c' line='1355' column='1'/>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='PyAsyncGen_New' mangled-name='PyAsyncGen_New' filepath='Objects/genobject.c' line='1659' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyAsyncGen_New'>
-      <parameter type-id='type-id-365' name='f' filepath='Objects/genobject.c' line='1659' column='1'/>
-      <parameter type-id='type-id-2' name='name' filepath='Objects/genobject.c' line='1659' column='1'/>
-      <parameter type-id='type-id-2' name='qualname' filepath='Objects/genobject.c' line='1659' column='1'/>
+    <function-decl name='PyAsyncGen_New' mangled-name='PyAsyncGen_New' filepath='Objects/genobject.c' line='1661' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyAsyncGen_New'>
+      <parameter type-id='type-id-365' name='f' filepath='Objects/genobject.c' line='1661' column='1'/>
+      <parameter type-id='type-id-2' name='name' filepath='Objects/genobject.c' line='1661' column='1'/>
+      <parameter type-id='type-id-2' name='qualname' filepath='Objects/genobject.c' line='1661' column='1'/>
       <return type-id='type-id-2'/>
     </function-decl>
   </abi-instr>
@@ -7582,15 +7589,15 @@
       <parameter type-id='type-id-20'/>
       <return type-id='type-id-46'/>
     </function-decl>
-    <function-decl name='PyLong_FromLongLong' mangled-name='PyLong_FromLongLong' filepath='./Include/longobject.h' line='67' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyLong_FromLongLong'>
+    <function-decl name='PyLong_FromLongLong' mangled-name='PyLong_FromLongLong' filepath='./Include/longobject.h' line='84' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyLong_FromLongLong'>
       <parameter type-id='type-id-378'/>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='PyLong_AsLongLong' mangled-name='PyLong_AsLongLong' filepath='./Include/longobject.h' line='69' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyLong_AsLongLong'>
+    <function-decl name='PyLong_AsLongLong' mangled-name='PyLong_AsLongLong' filepath='./Include/longobject.h' line='86' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyLong_AsLongLong'>
       <parameter type-id='type-id-2'/>
       <return type-id='type-id-378'/>
     </function-decl>
-    <function-decl name='PyLong_AsLongLongAndOverflow' mangled-name='PyLong_AsLongLongAndOverflow' filepath='./Include/longobject.h' line='72' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyLong_AsLongLongAndOverflow'>
+    <function-decl name='PyLong_AsLongLongAndOverflow' mangled-name='PyLong_AsLongLongAndOverflow' filepath='./Include/longobject.h' line='89' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyLong_AsLongLongAndOverflow'>
       <parameter type-id='type-id-2'/>
       <parameter type-id='type-id-179'/>
       <return type-id='type-id-378'/>
@@ -7648,15 +7655,15 @@
     <var-decl name='PyList_Type' type-id='type-id-256' mangled-name='PyList_Type' visibility='default' filepath='./Include/listobject.h' line='20' column='1' elf-symbol-id='PyList_Type'/>
     <var-decl name='PyListIter_Type' type-id='type-id-256' mangled-name='PyListIter_Type' visibility='default' filepath='./Include/listobject.h' line='21' column='1' elf-symbol-id='PyListIter_Type'/>
     <var-decl name='PyListRevIter_Type' type-id='type-id-256' mangled-name='PyListRevIter_Type' visibility='default' filepath='./Include/listobject.h' line='22' column='1' elf-symbol-id='PyListRevIter_Type'/>
-    <function-decl name='PyObject_HashNotImplemented' mangled-name='PyObject_HashNotImplemented' filepath='./Include/object.h' line='421' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyObject_HashNotImplemented'>
+    <function-decl name='PyObject_HashNotImplemented' mangled-name='PyObject_HashNotImplemented' filepath='./Include/object.h' line='420' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyObject_HashNotImplemented'>
       <parameter type-id='type-id-2'/>
       <return type-id='type-id-305'/>
     </function-decl>
-    <function-decl name='Py_ReprEnter' mangled-name='Py_ReprEnter' filepath='./Include/object.h' line='441' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='Py_ReprEnter'>
+    <function-decl name='Py_ReprEnter' mangled-name='Py_ReprEnter' filepath='./Include/object.h' line='440' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='Py_ReprEnter'>
       <parameter type-id='type-id-2'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='Py_ReprLeave' mangled-name='Py_ReprLeave' filepath='./Include/object.h' line='442' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='Py_ReprLeave'>
+    <function-decl name='Py_ReprLeave' mangled-name='Py_ReprLeave' filepath='./Include/object.h' line='441' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='Py_ReprLeave'>
       <parameter type-id='type-id-2'/>
       <return type-id='type-id-46'/>
     </function-decl>
@@ -7717,7 +7724,7 @@
       <return type-id='type-id-8'/>
     </function-decl>
     <var-decl name='PyLong_Type' type-id='type-id-256' mangled-name='PyLong_Type' visibility='default' filepath='./Include/object.h' line='226' column='1' elf-symbol-id='PyLong_Type'/>
-    <function-decl name='PyObject_Bytes' mangled-name='PyObject_Bytes' filepath='./Include/object.h' line='405' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyObject_Bytes'>
+    <function-decl name='PyObject_Bytes' mangled-name='PyObject_Bytes' filepath='./Include/object.h' line='404' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyObject_Bytes'>
       <parameter type-id='type-id-2'/>
       <return type-id='type-id-2'/>
     </function-decl>
@@ -7807,42 +7814,42 @@
       <parameter type-id='type-id-22' name='ptr' filepath='Objects/longobject.c' line='1488' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='_PyLong_FormatWriter' mangled-name='_PyLong_FormatWriter' filepath='Objects/longobject.c' line='2166' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyLong_FormatWriter'>
-      <parameter type-id='type-id-332' name='writer' filepath='Objects/longobject.c' line='2166' column='1'/>
-      <parameter type-id='type-id-2' name='obj' filepath='Objects/longobject.c' line='2167' column='1'/>
-      <parameter type-id='type-id-8' name='base' filepath='Objects/longobject.c' line='2168' column='1'/>
-      <parameter type-id='type-id-8' name='alternate' filepath='Objects/longobject.c' line='2168' column='1'/>
+    <function-decl name='_PyLong_FormatWriter' mangled-name='_PyLong_FormatWriter' filepath='Objects/longobject.c' line='2173' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyLong_FormatWriter'>
+      <parameter type-id='type-id-332' name='writer' filepath='Objects/longobject.c' line='2173' column='1'/>
+      <parameter type-id='type-id-2' name='obj' filepath='Objects/longobject.c' line='2174' column='1'/>
+      <parameter type-id='type-id-8' name='base' filepath='Objects/longobject.c' line='2175' column='1'/>
+      <parameter type-id='type-id-8' name='alternate' filepath='Objects/longobject.c' line='2175' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='_PyLong_Frexp' mangled-name='_PyLong_Frexp' filepath='Objects/longobject.c' line='3095' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyLong_Frexp'>
-      <parameter type-id='type-id-241' name='a' filepath='Objects/longobject.c' line='3095' column='1'/>
-      <parameter type-id='type-id-13' name='e' filepath='Objects/longobject.c' line='3095' column='1'/>
+    <function-decl name='_PyLong_Frexp' mangled-name='_PyLong_Frexp' filepath='Objects/longobject.c' line='3102' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyLong_Frexp'>
+      <parameter type-id='type-id-241' name='a' filepath='Objects/longobject.c' line='3102' column='1'/>
+      <parameter type-id='type-id-13' name='e' filepath='Objects/longobject.c' line='3102' column='1'/>
       <return type-id='type-id-251'/>
     </function-decl>
-    <function-decl name='_PyLong_Rshift' mangled-name='_PyLong_Rshift' filepath='Objects/longobject.c' line='5042' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyLong_Rshift'>
-      <parameter type-id='type-id-2' name='a' filepath='Objects/longobject.c' line='5042' column='1'/>
-      <parameter type-id='type-id-19' name='shiftby' filepath='Objects/longobject.c' line='5042' column='1'/>
+    <function-decl name='_PyLong_Rshift' mangled-name='_PyLong_Rshift' filepath='Objects/longobject.c' line='5049' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyLong_Rshift'>
+      <parameter type-id='type-id-2' name='a' filepath='Objects/longobject.c' line='5049' column='1'/>
+      <parameter type-id='type-id-19' name='shiftby' filepath='Objects/longobject.c' line='5049' column='1'/>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='_PyLong_GCD' mangled-name='_PyLong_GCD' filepath='Objects/longobject.c' line='5321' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyLong_GCD'>
-      <parameter type-id='type-id-2' name='aarg' filepath='Objects/longobject.c' line='5321' column='1'/>
-      <parameter type-id='type-id-2' name='barg' filepath='Objects/longobject.c' line='5321' column='1'/>
+    <function-decl name='_PyLong_GCD' mangled-name='_PyLong_GCD' filepath='Objects/longobject.c' line='5328' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyLong_GCD'>
+      <parameter type-id='type-id-2' name='aarg' filepath='Objects/longobject.c' line='5328' column='1'/>
+      <parameter type-id='type-id-2' name='barg' filepath='Objects/longobject.c' line='5328' column='1'/>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='_PyLong_DivmodNear' mangled-name='_PyLong_DivmodNear' filepath='Objects/longobject.c' line='5687' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyLong_DivmodNear'>
-      <parameter type-id='type-id-2' name='a' filepath='Objects/longobject.c' line='5687' column='1'/>
-      <parameter type-id='type-id-2' name='b' filepath='Objects/longobject.c' line='5687' column='1'/>
+    <function-decl name='_PyLong_DivmodNear' mangled-name='_PyLong_DivmodNear' filepath='Objects/longobject.c' line='5694' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyLong_DivmodNear'>
+      <parameter type-id='type-id-2' name='a' filepath='Objects/longobject.c' line='5694' column='1'/>
+      <parameter type-id='type-id-2' name='b' filepath='Objects/longobject.c' line='5694' column='1'/>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='PyLong_GetInfo' mangled-name='PyLong_GetInfo' filepath='Objects/longobject.c' line='6321' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyLong_GetInfo'>
+    <function-decl name='PyLong_GetInfo' mangled-name='PyLong_GetInfo' filepath='Objects/longobject.c' line='6328' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyLong_GetInfo'>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='PyUnstable_Long_IsCompact' mangled-name='PyUnstable_Long_IsCompact' filepath='Objects/longobject.c' line='6376' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyUnstable_Long_IsCompact'>
-      <parameter type-id='type-id-381' name='op' filepath='Objects/longobject.c' line='6376' column='1'/>
+    <function-decl name='PyUnstable_Long_IsCompact' mangled-name='PyUnstable_Long_IsCompact' filepath='Objects/longobject.c' line='6383' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyUnstable_Long_IsCompact'>
+      <parameter type-id='type-id-381' name='op' filepath='Objects/longobject.c' line='6383' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='PyUnstable_Long_CompactValue' mangled-name='PyUnstable_Long_CompactValue' filepath='Objects/longobject.c' line='6383' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyUnstable_Long_CompactValue'>
-      <parameter type-id='type-id-381' name='op' filepath='Objects/longobject.c' line='6383' column='1'/>
+    <function-decl name='PyUnstable_Long_CompactValue' mangled-name='PyUnstable_Long_CompactValue' filepath='Objects/longobject.c' line='6390' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyUnstable_Long_CompactValue'>
+      <parameter type-id='type-id-381' name='op' filepath='Objects/longobject.c' line='6390' column='1'/>
       <return type-id='type-id-14'/>
     </function-decl>
   </abi-instr>
@@ -7925,33 +7932,33 @@
         <var-decl name='value' type-id='type-id-22' visibility='default' filepath='./Include/moduleobject.h' line='76' column='1'/>
       </data-member>
     </class-decl>
-    <class-decl name='PyModuleDef' size-in-bits='832' is-struct='yes' visibility='default' filepath='./Include/moduleobject.h' line='96' column='1' id='type-id-393'>
+    <class-decl name='PyModuleDef' size-in-bits='832' is-struct='yes' visibility='default' filepath='./Include/moduleobject.h' line='98' column='1' id='type-id-393'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='m_base' type-id='type-id-391' visibility='default' filepath='./Include/moduleobject.h' line='97' column='1'/>
+        <var-decl name='m_base' type-id='type-id-391' visibility='default' filepath='./Include/moduleobject.h' line='99' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='m_name' type-id='type-id-12' visibility='default' filepath='./Include/moduleobject.h' line='98' column='1'/>
+        <var-decl name='m_name' type-id='type-id-12' visibility='default' filepath='./Include/moduleobject.h' line='100' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='384'>
-        <var-decl name='m_doc' type-id='type-id-12' visibility='default' filepath='./Include/moduleobject.h' line='99' column='1'/>
+        <var-decl name='m_doc' type-id='type-id-12' visibility='default' filepath='./Include/moduleobject.h' line='101' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='448'>
-        <var-decl name='m_size' type-id='type-id-14' visibility='default' filepath='./Include/moduleobject.h' line='100' column='1'/>
+        <var-decl name='m_size' type-id='type-id-14' visibility='default' filepath='./Include/moduleobject.h' line='102' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='512'>
-        <var-decl name='m_methods' type-id='type-id-337' visibility='default' filepath='./Include/moduleobject.h' line='101' column='1'/>
+        <var-decl name='m_methods' type-id='type-id-337' visibility='default' filepath='./Include/moduleobject.h' line='103' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='576'>
-        <var-decl name='m_slots' type-id='type-id-394' visibility='default' filepath='./Include/moduleobject.h' line='102' column='1'/>
+        <var-decl name='m_slots' type-id='type-id-394' visibility='default' filepath='./Include/moduleobject.h' line='104' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='640'>
-        <var-decl name='m_traverse' type-id='type-id-395' visibility='default' filepath='./Include/moduleobject.h' line='103' column='1'/>
+        <var-decl name='m_traverse' type-id='type-id-395' visibility='default' filepath='./Include/moduleobject.h' line='105' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='704'>
-        <var-decl name='m_clear' type-id='type-id-396' visibility='default' filepath='./Include/moduleobject.h' line='104' column='1'/>
+        <var-decl name='m_clear' type-id='type-id-396' visibility='default' filepath='./Include/moduleobject.h' line='106' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='768'>
-        <var-decl name='m_free' type-id='type-id-397' visibility='default' filepath='./Include/moduleobject.h' line='105' column='1'/>
+        <var-decl name='m_free' type-id='type-id-397' visibility='default' filepath='./Include/moduleobject.h' line='107' column='1'/>
       </data-member>
     </class-decl>
     <typedef-decl name='PyModuleDef' type-id='type-id-393' filepath='./Include/pytypedefs.h' line='12' column='1' id='type-id-3'/>
@@ -7993,7 +8000,7 @@
     </function-decl>
     <var-decl name='PyModule_Type' type-id='type-id-256' mangled-name='PyModule_Type' visibility='default' filepath='./Include/moduleobject.h' line='10' column='1' elf-symbol-id='PyModule_Type'/>
     <var-decl name='PyModuleDef_Type' type-id='type-id-256' mangled-name='PyModuleDef_Type' visibility='default' filepath='./Include/moduleobject.h' line='41' column='1' elf-symbol-id='PyModuleDef_Type'/>
-    <function-decl name='PyObject_SetAttrString' mangled-name='PyObject_SetAttrString' filepath='./Include/object.h' line='409' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyObject_SetAttrString'>
+    <function-decl name='PyObject_SetAttrString' mangled-name='PyObject_SetAttrString' filepath='./Include/object.h' line='408' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyObject_SetAttrString'>
       <parameter type-id='type-id-2'/>
       <parameter type-id='type-id-12'/>
       <parameter type-id='type-id-2'/>
@@ -8154,7 +8161,7 @@
       <parameter type-id='type-id-12'/>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='_PyEval_GetFrameLocals' filepath='./Include/internal/pycore_ceval.h' line='157' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_PyEval_GetFrameLocals' filepath='./Include/internal/pycore_ceval.h' line='158' column='1' visibility='default' binding='global' size-in-bits='64'>
       <return type-id='type-id-2'/>
     </function-decl>
     <function-decl name='_PyObjectDict_SetItem' filepath='./Include/internal/pycore_dict.h' line='56' column='1' visibility='default' binding='global' size-in-bits='64'>
@@ -8217,12 +8224,18 @@
       <parameter type-id='type-id-2'/>
       <return type-id='type-id-2'/>
     </function-decl>
+    <function-decl name='_Py_BaseObject_RichCompare' filepath='./Include/internal/pycore_typeobject.h' line='136' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-2'/>
+      <parameter type-id='type-id-2'/>
+      <parameter type-id='type-id-8'/>
+      <return type-id='type-id-2'/>
+    </function-decl>
     <function-decl name='_Py_initialize_generic' filepath='./Include/internal/pycore_typevarobject.h' line='16' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-20'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <var-decl name='_Py_NoneStruct' type-id='type-id-345' mangled-name='_Py_NoneStruct' visibility='default' filepath='./Include/object.h' line='843' column='1' elf-symbol-id='_Py_NoneStruct'/>
-    <var-decl name='_Py_NotImplementedStruct' type-id='type-id-345' mangled-name='_Py_NotImplementedStruct' visibility='default' filepath='./Include/object.h' line='857' column='1' elf-symbol-id='_Py_NotImplementedStruct'/>
+    <var-decl name='_Py_NoneStruct' type-id='type-id-345' mangled-name='_Py_NoneStruct' visibility='default' filepath='./Include/object.h' line='842' column='1' elf-symbol-id='_Py_NoneStruct'/>
+    <var-decl name='_Py_NotImplementedStruct' type-id='type-id-345' mangled-name='_Py_NotImplementedStruct' visibility='default' filepath='./Include/object.h' line='856' column='1' elf-symbol-id='_Py_NotImplementedStruct'/>
     <function-decl name='PyThreadState_GetDict' mangled-name='PyThreadState_GetDict' filepath='./Include/pystate.h' line='66' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyThreadState_GetDict'>
       <return type-id='type-id-2'/>
     </function-decl>
@@ -8426,13 +8439,13 @@
       <parameter type-id='type-id-12'/>
       <return type-id='type-id-15'/>
     </function-decl>
-    <function-decl name='PyGILState_Check' mangled-name='PyGILState_Check' filepath='./Include/cpython/pystate.h' line='291' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyGILState_Check'>
+    <function-decl name='PyGILState_Check' mangled-name='PyGILState_Check' filepath='./Include/cpython/pystate.h' line='303' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyGILState_Check'>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='PyInterpreterState_Head' mangled-name='PyInterpreterState_Head' filepath='./Include/cpython/pystate.h' line='315' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyInterpreterState_Head'>
+    <function-decl name='PyInterpreterState_Head' mangled-name='PyInterpreterState_Head' filepath='./Include/cpython/pystate.h' line='327' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyInterpreterState_Head'>
       <return type-id='type-id-20'/>
     </function-decl>
-    <function-decl name='PyInterpreterState_Next' mangled-name='PyInterpreterState_Next' filepath='./Include/cpython/pystate.h' line='316' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyInterpreterState_Next'>
+    <function-decl name='PyInterpreterState_Next' mangled-name='PyInterpreterState_Next' filepath='./Include/cpython/pystate.h' line='328' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyInterpreterState_Next'>
       <parameter type-id='type-id-20'/>
       <return type-id='type-id-20'/>
     </function-decl>
@@ -8616,21 +8629,21 @@
     <var-decl name='PySet_Type' type-id='type-id-256' mangled-name='PySet_Type' visibility='default' filepath='./Include/setobject.h' line='9' column='1' elf-symbol-id='PySet_Type'/>
     <var-decl name='PyFrozenSet_Type' type-id='type-id-256' mangled-name='PyFrozenSet_Type' visibility='default' filepath='./Include/setobject.h' line='10' column='1' elf-symbol-id='PyFrozenSet_Type'/>
     <var-decl name='PySetIter_Type' type-id='type-id-256' mangled-name='PySetIter_Type' visibility='default' filepath='./Include/setobject.h' line='11' column='1' elf-symbol-id='PySetIter_Type'/>
-    <function-decl name='PySet_Size' mangled-name='PySet_Size' filepath='Objects/setobject.c' line='2277' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PySet_Size'>
-      <parameter type-id='type-id-2' name='anyset' filepath='Objects/setobject.c' line='2277' column='1'/>
+    <function-decl name='PySet_Size' mangled-name='PySet_Size' filepath='Objects/setobject.c' line='2285' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PySet_Size'>
+      <parameter type-id='type-id-2' name='anyset' filepath='Objects/setobject.c' line='2285' column='1'/>
       <return type-id='type-id-14'/>
     </function-decl>
-    <function-decl name='PySet_Clear' mangled-name='PySet_Clear' filepath='Objects/setobject.c' line='2287' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PySet_Clear'>
-      <parameter type-id='type-id-2' name='set' filepath='Objects/setobject.c' line='2287' column='1'/>
+    <function-decl name='PySet_Clear' mangled-name='PySet_Clear' filepath='Objects/setobject.c' line='2295' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PySet_Clear'>
+      <parameter type-id='type-id-2' name='set' filepath='Objects/setobject.c' line='2295' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='PySet_Discard' mangled-name='PySet_Discard' filepath='Objects/setobject.c' line='2307' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PySet_Discard'>
-      <parameter type-id='type-id-2' name='set' filepath='Objects/setobject.c' line='2307' column='1'/>
-      <parameter type-id='type-id-2' name='key' filepath='Objects/setobject.c' line='2307' column='1'/>
+    <function-decl name='PySet_Discard' mangled-name='PySet_Discard' filepath='Objects/setobject.c' line='2315' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PySet_Discard'>
+      <parameter type-id='type-id-2' name='set' filepath='Objects/setobject.c' line='2315' column='1'/>
+      <parameter type-id='type-id-2' name='key' filepath='Objects/setobject.c' line='2315' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='PySet_Pop' mangled-name='PySet_Pop' filepath='Objects/setobject.c' line='2344' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PySet_Pop'>
-      <parameter type-id='type-id-2' name='set' filepath='Objects/setobject.c' line='2344' column='1'/>
+    <function-decl name='PySet_Pop' mangled-name='PySet_Pop' filepath='Objects/setobject.c' line='2352' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PySet_Pop'>
+      <parameter type-id='type-id-2' name='set' filepath='Objects/setobject.c' line='2352' column='1'/>
       <return type-id='type-id-2'/>
     </function-decl>
   </abi-instr>
@@ -8663,40 +8676,40 @@
     </function-decl>
   </abi-instr>
   <abi-instr address-size='64' path='Objects/structseq.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
-    <class-decl name='PyType_Slot' size-in-bits='128' is-struct='yes' naming-typedef-id='type-id-425' visibility='default' filepath='./Include/object.h' line='343' column='1' id='type-id-426'>
+    <class-decl name='PyType_Slot' size-in-bits='128' is-struct='yes' naming-typedef-id='type-id-425' visibility='default' filepath='./Include/object.h' line='342' column='1' id='type-id-426'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='slot' type-id='type-id-8' visibility='default' filepath='./Include/object.h' line='344' column='1'/>
+        <var-decl name='slot' type-id='type-id-8' visibility='default' filepath='./Include/object.h' line='343' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='pfunc' type-id='type-id-22' visibility='default' filepath='./Include/object.h' line='345' column='1'/>
+        <var-decl name='pfunc' type-id='type-id-22' visibility='default' filepath='./Include/object.h' line='344' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='PyType_Slot' type-id='type-id-426' filepath='./Include/object.h' line='346' column='1' id='type-id-425'/>
-    <class-decl name='PyType_Spec' size-in-bits='256' is-struct='yes' naming-typedef-id='type-id-11' visibility='default' filepath='./Include/object.h' line='348' column='1' id='type-id-427'>
+    <typedef-decl name='PyType_Slot' type-id='type-id-426' filepath='./Include/object.h' line='345' column='1' id='type-id-425'/>
+    <class-decl name='PyType_Spec' size-in-bits='256' is-struct='yes' naming-typedef-id='type-id-11' visibility='default' filepath='./Include/object.h' line='347' column='1' id='type-id-427'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='name' type-id='type-id-12' visibility='default' filepath='./Include/object.h' line='349' column='1'/>
+        <var-decl name='name' type-id='type-id-12' visibility='default' filepath='./Include/object.h' line='348' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='basicsize' type-id='type-id-8' visibility='default' filepath='./Include/object.h' line='350' column='1'/>
+        <var-decl name='basicsize' type-id='type-id-8' visibility='default' filepath='./Include/object.h' line='349' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='96'>
-        <var-decl name='itemsize' type-id='type-id-8' visibility='default' filepath='./Include/object.h' line='351' column='1'/>
+        <var-decl name='itemsize' type-id='type-id-8' visibility='default' filepath='./Include/object.h' line='350' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='flags' type-id='type-id-95' visibility='default' filepath='./Include/object.h' line='352' column='1'/>
+        <var-decl name='flags' type-id='type-id-95' visibility='default' filepath='./Include/object.h' line='351' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='slots' type-id='type-id-428' visibility='default' filepath='./Include/object.h' line='353' column='1'/>
+        <var-decl name='slots' type-id='type-id-428' visibility='default' filepath='./Include/object.h' line='352' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='PyType_Spec' type-id='type-id-427' filepath='./Include/object.h' line='354' column='1' id='type-id-11'/>
+    <typedef-decl name='PyType_Spec' type-id='type-id-427' filepath='./Include/object.h' line='353' column='1' id='type-id-11'/>
     <pointer-type-def type-id='type-id-425' size-in-bits='64' id='type-id-428'/>
     <pointer-type-def type-id='type-id-11' size-in-bits='64' id='type-id-429'/>
     <function-decl name='_PyType_HasSubclasses' filepath='./Include/internal/pycore_typeobject.h' line='121' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-1'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='PyType_FromSpecWithBases' mangled-name='PyType_FromSpecWithBases' filepath='./Include/object.h' line='358' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyType_FromSpecWithBases'>
+    <function-decl name='PyType_FromSpecWithBases' mangled-name='PyType_FromSpecWithBases' filepath='./Include/object.h' line='357' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyType_FromSpecWithBases'>
       <parameter type-id='type-id-429'/>
       <parameter type-id='type-id-2'/>
       <return type-id='type-id-2'/>
@@ -8837,16 +8850,16 @@
       <parameter type-id='type-id-1'/>
       <return type-id='type-id-46'/>
     </function-decl>
-    <var-decl name='_PyBufferWrapper_Type' type-id='type-id-256' mangled-name='_PyBufferWrapper_Type' visibility='default' filepath='./Include/internal/pycore_typeobject.h' line='139' column='1' elf-symbol-id='_PyBufferWrapper_Type'/>
+    <var-decl name='_PyBufferWrapper_Type' type-id='type-id-256' mangled-name='_PyBufferWrapper_Type' visibility='default' filepath='./Include/internal/pycore_typeobject.h' line='141' column='1' elf-symbol-id='_PyBufferWrapper_Type'/>
     <function-decl name='PyArg_ParseTuple' mangled-name='PyArg_ParseTuple' filepath='./Include/modsupport.h' line='27' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyArg_ParseTuple'>
       <parameter type-id='type-id-2'/>
       <parameter type-id='type-id-12'/>
       <parameter is-variadic='yes'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <var-decl name='PyType_Type' type-id='type-id-256' mangled-name='PyType_Type' visibility='default' filepath='./Include/object.h' line='388' column='1' elf-symbol-id='PyType_Type'/>
-    <var-decl name='PyBaseObject_Type' type-id='type-id-256' mangled-name='PyBaseObject_Type' visibility='default' filepath='./Include/object.h' line='389' column='1' elf-symbol-id='PyBaseObject_Type'/>
-    <var-decl name='PySuper_Type' type-id='type-id-256' mangled-name='PySuper_Type' visibility='default' filepath='./Include/object.h' line='390' column='1' elf-symbol-id='PySuper_Type'/>
+    <var-decl name='PyType_Type' type-id='type-id-256' mangled-name='PyType_Type' visibility='default' filepath='./Include/object.h' line='387' column='1' elf-symbol-id='PyType_Type'/>
+    <var-decl name='PyBaseObject_Type' type-id='type-id-256' mangled-name='PyBaseObject_Type' visibility='default' filepath='./Include/object.h' line='388' column='1' elf-symbol-id='PyBaseObject_Type'/>
+    <var-decl name='PySuper_Type' type-id='type-id-256' mangled-name='PySuper_Type' visibility='default' filepath='./Include/object.h' line='389' column='1' elf-symbol-id='PySuper_Type'/>
     <function-decl name='PyInterpreterState_Get' mangled-name='PyInterpreterState_Get' filepath='./Include/pystate.h' line='26' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyInterpreterState_Get'>
       <return type-id='type-id-20'/>
     </function-decl>
@@ -9062,7 +9075,7 @@
       <parameter type-id='type-id-2'/>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='_PyInterpreterState_GetConfig' mangled-name='_PyInterpreterState_GetConfig' filepath='./Include/cpython/pystate.h' line='331' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyInterpreterState_GetConfig'>
+    <function-decl name='_PyInterpreterState_GetConfig' mangled-name='_PyInterpreterState_GetConfig' filepath='./Include/cpython/pystate.h' line='343' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyInterpreterState_GetConfig'>
       <parameter type-id='type-id-20'/>
       <return type-id='type-id-260'/>
     </function-decl>
@@ -9663,50 +9676,50 @@
       <parameter type-id='type-id-14' name='maxsplit' filepath='Objects/unicodeobject.c' line='12395' column='1'/>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='PyUnicode_Partition' mangled-name='PyUnicode_Partition' filepath='Objects/unicodeobject.c' line='12440' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyUnicode_Partition'>
-      <parameter type-id='type-id-2' name='str_obj' filepath='Objects/unicodeobject.c' line='12440' column='1'/>
-      <parameter type-id='type-id-2' name='sep_obj' filepath='Objects/unicodeobject.c' line='12440' column='1'/>
+    <function-decl name='PyUnicode_Partition' mangled-name='PyUnicode_Partition' filepath='Objects/unicodeobject.c' line='12442' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyUnicode_Partition'>
+      <parameter type-id='type-id-2' name='str_obj' filepath='Objects/unicodeobject.c' line='12442' column='1'/>
+      <parameter type-id='type-id-2' name='sep_obj' filepath='Objects/unicodeobject.c' line='12442' column='1'/>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='PyUnicode_RPartition' mangled-name='PyUnicode_RPartition' filepath='Objects/unicodeobject.c' line='12492' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyUnicode_RPartition'>
-      <parameter type-id='type-id-2' name='str_obj' filepath='Objects/unicodeobject.c' line='12492' column='1'/>
-      <parameter type-id='type-id-2' name='sep_obj' filepath='Objects/unicodeobject.c' line='12492' column='1'/>
+    <function-decl name='PyUnicode_RPartition' mangled-name='PyUnicode_RPartition' filepath='Objects/unicodeobject.c' line='12494' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyUnicode_RPartition'>
+      <parameter type-id='type-id-2' name='str_obj' filepath='Objects/unicodeobject.c' line='12494' column='1'/>
+      <parameter type-id='type-id-2' name='sep_obj' filepath='Objects/unicodeobject.c' line='12494' column='1'/>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='PyUnicode_RSplit' mangled-name='PyUnicode_RSplit' filepath='Objects/unicodeobject.c' line='12586' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyUnicode_RSplit'>
-      <parameter type-id='type-id-2' name='s' filepath='Objects/unicodeobject.c' line='12586' column='1'/>
-      <parameter type-id='type-id-2' name='sep' filepath='Objects/unicodeobject.c' line='12586' column='1'/>
-      <parameter type-id='type-id-14' name='maxsplit' filepath='Objects/unicodeobject.c' line='12586' column='1'/>
+    <function-decl name='PyUnicode_RSplit' mangled-name='PyUnicode_RSplit' filepath='Objects/unicodeobject.c' line='12588' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyUnicode_RSplit'>
+      <parameter type-id='type-id-2' name='s' filepath='Objects/unicodeobject.c' line='12588' column='1'/>
+      <parameter type-id='type-id-2' name='sep' filepath='Objects/unicodeobject.c' line='12588' column='1'/>
+      <parameter type-id='type-id-14' name='maxsplit' filepath='Objects/unicodeobject.c' line='12588' column='1'/>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='_PyUnicodeWriter_PrepareKindInternal' mangled-name='_PyUnicodeWriter_PrepareKindInternal' filepath='Objects/unicodeobject.c' line='13097' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyUnicodeWriter_PrepareKindInternal'>
-      <parameter type-id='type-id-332' name='writer' filepath='Objects/unicodeobject.c' line='13097' column='1'/>
-      <parameter type-id='type-id-8' name='kind' filepath='Objects/unicodeobject.c' line='13098' column='1'/>
+    <function-decl name='_PyUnicodeWriter_PrepareKindInternal' mangled-name='_PyUnicodeWriter_PrepareKindInternal' filepath='Objects/unicodeobject.c' line='13099' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyUnicodeWriter_PrepareKindInternal'>
+      <parameter type-id='type-id-332' name='writer' filepath='Objects/unicodeobject.c' line='13099' column='1'/>
+      <parameter type-id='type-id-8' name='kind' filepath='Objects/unicodeobject.c' line='13100' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='_PyUnicodeWriter_WriteSubstring' mangled-name='_PyUnicodeWriter_WriteSubstring' filepath='Objects/unicodeobject.c' line='13163' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyUnicodeWriter_WriteSubstring'>
-      <parameter type-id='type-id-332' name='writer' filepath='Objects/unicodeobject.c' line='13163' column='1'/>
-      <parameter type-id='type-id-2' name='str' filepath='Objects/unicodeobject.c' line='13163' column='1'/>
-      <parameter type-id='type-id-14' name='start' filepath='Objects/unicodeobject.c' line='13164' column='1'/>
-      <parameter type-id='type-id-14' name='end' filepath='Objects/unicodeobject.c' line='13164' column='1'/>
+    <function-decl name='_PyUnicodeWriter_WriteSubstring' mangled-name='_PyUnicodeWriter_WriteSubstring' filepath='Objects/unicodeobject.c' line='13165' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyUnicodeWriter_WriteSubstring'>
+      <parameter type-id='type-id-332' name='writer' filepath='Objects/unicodeobject.c' line='13165' column='1'/>
+      <parameter type-id='type-id-2' name='str' filepath='Objects/unicodeobject.c' line='13165' column='1'/>
+      <parameter type-id='type-id-14' name='start' filepath='Objects/unicodeobject.c' line='13166' column='1'/>
+      <parameter type-id='type-id-14' name='end' filepath='Objects/unicodeobject.c' line='13166' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='_PyUnicodeWriter_WriteLatin1String' mangled-name='_PyUnicodeWriter_WriteLatin1String' filepath='Objects/unicodeobject.c' line='13255' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyUnicodeWriter_WriteLatin1String'>
-      <parameter type-id='type-id-332' name='writer' filepath='Objects/unicodeobject.c' line='13255' column='1'/>
-      <parameter type-id='type-id-12' name='str' filepath='Objects/unicodeobject.c' line='13256' column='1'/>
-      <parameter type-id='type-id-14' name='len' filepath='Objects/unicodeobject.c' line='13256' column='1'/>
+    <function-decl name='_PyUnicodeWriter_WriteLatin1String' mangled-name='_PyUnicodeWriter_WriteLatin1String' filepath='Objects/unicodeobject.c' line='13257' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyUnicodeWriter_WriteLatin1String'>
+      <parameter type-id='type-id-332' name='writer' filepath='Objects/unicodeobject.c' line='13257' column='1'/>
+      <parameter type-id='type-id-12' name='str' filepath='Objects/unicodeobject.c' line='13258' column='1'/>
+      <parameter type-id='type-id-14' name='len' filepath='Objects/unicodeobject.c' line='13258' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='PyUnicode_Format' mangled-name='PyUnicode_Format' filepath='Objects/unicodeobject.c' line='14405' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyUnicode_Format'>
-      <parameter type-id='type-id-2' name='format' filepath='Objects/unicodeobject.c' line='14405' column='1'/>
-      <parameter type-id='type-id-2' name='args' filepath='Objects/unicodeobject.c' line='14405' column='1'/>
+    <function-decl name='PyUnicode_Format' mangled-name='PyUnicode_Format' filepath='Objects/unicodeobject.c' line='14407' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyUnicode_Format'>
+      <parameter type-id='type-id-2' name='format' filepath='Objects/unicodeobject.c' line='14407' column='1'/>
+      <parameter type-id='type-id-2' name='args' filepath='Objects/unicodeobject.c' line='14407' column='1'/>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='PyUnicode_InternImmortal' mangled-name='PyUnicode_InternImmortal' filepath='Objects/unicodeobject.c' line='14835' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyUnicode_InternImmortal'>
-      <parameter type-id='type-id-233' name='p' filepath='Objects/unicodeobject.c' line='14835' column='1'/>
+    <function-decl name='PyUnicode_InternImmortal' mangled-name='PyUnicode_InternImmortal' filepath='Objects/unicodeobject.c' line='14837' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyUnicode_InternImmortal'>
+      <parameter type-id='type-id-233' name='p' filepath='Objects/unicodeobject.c' line='14837' column='1'/>
       <return type-id='type-id-46'/>
     </function-decl>
-    <function-decl name='PyInit__string' mangled-name='PyInit__string' filepath='Objects/unicodeobject.c' line='15403' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyInit__string'>
+    <function-decl name='PyInit__string' mangled-name='PyInit__string' filepath='Objects/unicodeobject.c' line='15405' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyInit__string'>
       <return type-id='type-id-2'/>
     </function-decl>
   </abi-instr>
@@ -10841,7 +10854,7 @@
       <parameter type-id='type-id-12'/>
       <return type-id='type-id-15'/>
     </function-decl>
-    <function-decl name='_PyPegen_new_identifier' filepath='Parser/pegen.h' line='297' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_PyPegen_new_identifier' filepath='Parser/pegen.h' line='298' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-577'/>
       <parameter type-id='type-id-12'/>
       <return type-id='type-id-2'/>
@@ -10912,10 +10925,10 @@
     <array-type-def dimensions='1' type-id='type-id-602' size-in-bits='5120' id='type-id-603'>
       <subrange length='80' type-id='type-id-28' id='type-id-584'/>
     </array-type-def>
-    <array-type-def dimensions='1' type-id='type-id-604' size-in-bits='65536' id='type-id-605'>
+    <array-type-def dimensions='1' type-id='type-id-604' size-in-bits='49152' id='type-id-605'>
       <subrange length='128' type-id='type-id-28' id='type-id-437'/>
     </array-type-def>
-    <array-type-def dimensions='1' type-id='type-id-606' size-in-bits='49152' id='type-id-607'>
+    <array-type-def dimensions='1' type-id='type-id-606' size-in-bits='65536' id='type-id-607'>
       <subrange length='128' type-id='type-id-28' id='type-id-437'/>
     </array-type-def>
     <array-type-def dimensions='1' type-id='type-id-608' size-in-bits='98304' id='type-id-609'>
@@ -11147,7 +11160,7 @@
         <var-decl name='op' type-id='type-id-719' visibility='default' filepath='./Include/cpython/code.h' line='43' column='1'/>
       </data-member>
     </union-decl>
-    <class-decl name='__anonymous_struct__747' size-in-bits='16' is-struct='yes' is-anonymous='yes' visibility='default' filepath='./Include/cpython/code.h' line='40' column='1' id='type-id-719'>
+    <class-decl name='__anonymous_struct__748' size-in-bits='16' is-struct='yes' is-anonymous='yes' visibility='default' filepath='./Include/cpython/code.h' line='40' column='1' id='type-id-719'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='code' type-id='type-id-325' visibility='default' filepath='./Include/cpython/code.h' line='41' column='1'/>
       </data-member>
@@ -11420,7 +11433,7 @@
       </data-member>
     </class-decl>
     <typedef-decl name='PyFunctionObject' type-id='type-id-745' filepath='./Include/cpython/funcobject.h' line='61' column='1' id='type-id-744'/>
-    <enum-decl name='PyFunction_WatchEvent' naming-typedef-id='type-id-746' filepath='./Include/cpython/funcobject.h' line='142' column='1' id='type-id-747'>
+    <enum-decl name='PyFunction_WatchEvent' naming-typedef-id='type-id-746' filepath='./Include/cpython/funcobject.h' line='144' column='1' id='type-id-747'>
       <underlying-type type-id='type-id-24'/>
       <enumerator name='PyFunction_EVENT_CREATE' value='0'/>
       <enumerator name='PyFunction_EVENT_DESTROY' value='1'/>
@@ -11428,8 +11441,8 @@
       <enumerator name='PyFunction_EVENT_MODIFY_DEFAULTS' value='3'/>
       <enumerator name='PyFunction_EVENT_MODIFY_KWDEFAULTS' value='4'/>
     </enum-decl>
-    <typedef-decl name='PyFunction_WatchEvent' type-id='type-id-747' filepath='./Include/cpython/funcobject.h' line='146' column='1' id='type-id-746'/>
-    <typedef-decl name='PyFunction_WatchCallback' type-id='type-id-748' filepath='./Include/cpython/funcobject.h' line='163' column='1' id='type-id-366'/>
+    <typedef-decl name='PyFunction_WatchEvent' type-id='type-id-747' filepath='./Include/cpython/funcobject.h' line='148' column='1' id='type-id-746'/>
+    <typedef-decl name='PyFunction_WatchCallback' type-id='type-id-748' filepath='./Include/cpython/funcobject.h' line='165' column='1' id='type-id-366'/>
     <class-decl name='_inittab' size-in-bits='128' is-struct='yes' visibility='default' filepath='./Include/cpython/import.h' line='24' column='1' id='type-id-749'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='name' type-id='type-id-12' visibility='default' filepath='./Include/cpython/import.h' line='25' column='1'/>
@@ -11948,7 +11961,7 @@
         <var-decl name='root_cframe' type-id='type-id-778' visibility='default' filepath='./Include/cpython/pystate.h' line='248' column='1'/>
       </data-member>
     </class-decl>
-    <class-decl name='__anonymous_struct__749' size-in-bits='32' is-struct='yes' is-anonymous='yes' visibility='default' filepath='./Include/cpython/pystate.h' line='122' column='1' id='type-id-786'>
+    <class-decl name='__anonymous_struct__750' size-in-bits='32' is-struct='yes' is-anonymous='yes' visibility='default' filepath='./Include/cpython/pystate.h' line='122' column='1' id='type-id-786'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='initialized' type-id='type-id-95' visibility='default' filepath='./Include/cpython/pystate.h' line='127' column='1'/>
       </data-member>
@@ -11974,28 +11987,28 @@
         <var-decl name='finalized' type-id='type-id-95' visibility='default' filepath='./Include/cpython/pystate.h' line='141' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='_PyFrameEvalFunction' type-id='type-id-788' filepath='./Include/cpython/pystate.h' line='323' column='1' id='type-id-789'/>
-    <typedef-decl name='_PyCrossInterpreterData' type-id='type-id-790' filepath='./Include/cpython/pystate.h' line='376' column='1' id='type-id-791'/>
-    <typedef-decl name='xid_newobjectfunc' type-id='type-id-792' filepath='./Include/cpython/pystate.h' line='378' column='1' id='type-id-793'/>
-    <typedef-decl name='xid_freefunc' type-id='type-id-769' filepath='./Include/cpython/pystate.h' line='379' column='1' id='type-id-794'/>
-    <class-decl name='_xid' size-in-bits='320' is-struct='yes' visibility='default' filepath='./Include/cpython/pystate.h' line='381' column='1' id='type-id-790'>
+    <typedef-decl name='_PyFrameEvalFunction' type-id='type-id-788' filepath='./Include/cpython/pystate.h' line='335' column='1' id='type-id-789'/>
+    <typedef-decl name='_PyCrossInterpreterData' type-id='type-id-790' filepath='./Include/cpython/pystate.h' line='388' column='1' id='type-id-791'/>
+    <typedef-decl name='xid_newobjectfunc' type-id='type-id-792' filepath='./Include/cpython/pystate.h' line='390' column='1' id='type-id-793'/>
+    <typedef-decl name='xid_freefunc' type-id='type-id-769' filepath='./Include/cpython/pystate.h' line='391' column='1' id='type-id-794'/>
+    <class-decl name='_xid' size-in-bits='320' is-struct='yes' visibility='default' filepath='./Include/cpython/pystate.h' line='393' column='1' id='type-id-790'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='data' type-id='type-id-22' visibility='default' filepath='./Include/cpython/pystate.h' line='385' column='1'/>
+        <var-decl name='data' type-id='type-id-22' visibility='default' filepath='./Include/cpython/pystate.h' line='397' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='obj' type-id='type-id-2' visibility='default' filepath='./Include/cpython/pystate.h' line='392' column='1'/>
+        <var-decl name='obj' type-id='type-id-2' visibility='default' filepath='./Include/cpython/pystate.h' line='404' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='interp' type-id='type-id-377' visibility='default' filepath='./Include/cpython/pystate.h' line='402' column='1'/>
+        <var-decl name='interp' type-id='type-id-377' visibility='default' filepath='./Include/cpython/pystate.h' line='414' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='new_object' type-id='type-id-793' visibility='default' filepath='./Include/cpython/pystate.h' line='407' column='1'/>
+        <var-decl name='new_object' type-id='type-id-793' visibility='default' filepath='./Include/cpython/pystate.h' line='419' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='free' type-id='type-id-794' visibility='default' filepath='./Include/cpython/pystate.h' line='417' column='1'/>
+        <var-decl name='free' type-id='type-id-794' visibility='default' filepath='./Include/cpython/pystate.h' line='429' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='crossinterpdatafunc' type-id='type-id-795' filepath='./Include/cpython/pystate.h' line='439' column='1' id='type-id-796'/>
+    <typedef-decl name='crossinterpdatafunc' type-id='type-id-795' filepath='./Include/cpython/pystate.h' line='451' column='1' id='type-id-796'/>
     <class-decl name='_Py_tss_t' size-in-bits='64' is-struct='yes' visibility='default' filepath='./Include/cpython/pythread.h' line='34' column='1' id='type-id-797'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='_is_initialized' type-id='type-id-8' visibility='default' filepath='./Include/cpython/pythread.h' line='35' column='1'/>
@@ -12064,10 +12077,10 @@
         <var-decl name='initialized' type-id='type-id-8' visibility='default' filepath='./Include/internal/pycore_ast_state.h' line='14' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='recursion_depth' type-id='type-id-8' visibility='default' filepath='./Include/internal/pycore_ast_state.h' line='15' column='1'/>
+        <var-decl name='unused_recursion_depth' type-id='type-id-8' visibility='default' filepath='./Include/internal/pycore_ast_state.h' line='15' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='recursion_limit' type-id='type-id-8' visibility='default' filepath='./Include/internal/pycore_ast_state.h' line='16' column='1'/>
+        <var-decl name='unused_recursion_limit' type-id='type-id-8' visibility='default' filepath='./Include/internal/pycore_ast_state.h' line='16' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
         <var-decl name='AST_type' type-id='type-id-2' visibility='default' filepath='./Include/internal/pycore_ast_state.h' line='17' column='1'/>
@@ -13232,42 +13245,42 @@
         <var-decl name='_f_frame_data' type-id='type-id-353' visibility='default' filepath='./Include/internal/pycore_frame.h' line='26' column='1'/>
       </data-member>
     </class-decl>
-    <class-decl name='_PyInterpreterFrame' size-in-bits='640' is-struct='yes' visibility='default' filepath='./Include/internal/pycore_frame.h' line='49' column='1' id='type-id-371'>
+    <class-decl name='_PyInterpreterFrame' size-in-bits='640' is-struct='yes' visibility='default' filepath='./Include/internal/pycore_frame.h' line='51' column='1' id='type-id-371'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='f_code' type-id='type-id-328' visibility='default' filepath='./Include/internal/pycore_frame.h' line='50' column='1'/>
+        <var-decl name='f_code' type-id='type-id-328' visibility='default' filepath='./Include/internal/pycore_frame.h' line='52' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='previous' type-id='type-id-375' visibility='default' filepath='./Include/internal/pycore_frame.h' line='51' column='1'/>
+        <var-decl name='previous' type-id='type-id-375' visibility='default' filepath='./Include/internal/pycore_frame.h' line='53' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='f_funcobj' type-id='type-id-2' visibility='default' filepath='./Include/internal/pycore_frame.h' line='52' column='1'/>
+        <var-decl name='f_funcobj' type-id='type-id-2' visibility='default' filepath='./Include/internal/pycore_frame.h' line='54' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='f_globals' type-id='type-id-2' visibility='default' filepath='./Include/internal/pycore_frame.h' line='53' column='1'/>
+        <var-decl name='f_globals' type-id='type-id-2' visibility='default' filepath='./Include/internal/pycore_frame.h' line='55' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='f_builtins' type-id='type-id-2' visibility='default' filepath='./Include/internal/pycore_frame.h' line='54' column='1'/>
+        <var-decl name='f_builtins' type-id='type-id-2' visibility='default' filepath='./Include/internal/pycore_frame.h' line='56' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='f_locals' type-id='type-id-2' visibility='default' filepath='./Include/internal/pycore_frame.h' line='55' column='1'/>
+        <var-decl name='f_locals' type-id='type-id-2' visibility='default' filepath='./Include/internal/pycore_frame.h' line='57' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='384'>
-        <var-decl name='frame_obj' type-id='type-id-365' visibility='default' filepath='./Include/internal/pycore_frame.h' line='56' column='1'/>
+        <var-decl name='frame_obj' type-id='type-id-365' visibility='default' filepath='./Include/internal/pycore_frame.h' line='58' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='448'>
-        <var-decl name='prev_instr' type-id='type-id-859' visibility='default' filepath='./Include/internal/pycore_frame.h' line='61' column='1'/>
+        <var-decl name='prev_instr' type-id='type-id-859' visibility='default' filepath='./Include/internal/pycore_frame.h' line='63' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='512'>
-        <var-decl name='stacktop' type-id='type-id-8' visibility='default' filepath='./Include/internal/pycore_frame.h' line='62' column='1'/>
+        <var-decl name='stacktop' type-id='type-id-8' visibility='default' filepath='./Include/internal/pycore_frame.h' line='64' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='544'>
-        <var-decl name='return_offset' type-id='type-id-718' visibility='default' filepath='./Include/internal/pycore_frame.h' line='69' column='1'/>
+        <var-decl name='return_offset' type-id='type-id-718' visibility='default' filepath='./Include/internal/pycore_frame.h' line='71' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='560'>
-        <var-decl name='owner' type-id='type-id-48' visibility='default' filepath='./Include/internal/pycore_frame.h' line='70' column='1'/>
+        <var-decl name='owner' type-id='type-id-48' visibility='default' filepath='./Include/internal/pycore_frame.h' line='72' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='576'>
-        <var-decl name='localsplus' type-id='type-id-353' visibility='default' filepath='./Include/internal/pycore_frame.h' line='72' column='1'/>
+        <var-decl name='localsplus' type-id='type-id-353' visibility='default' filepath='./Include/internal/pycore_frame.h' line='74' column='1'/>
       </data-member>
     </class-decl>
     <class-decl name='_py_func_state' size-in-bits='32' is-struct='yes' visibility='default' filepath='./Include/internal/pycore_function.h' line='13' column='1' id='type-id-860'>
@@ -13392,12 +13405,12 @@
         <var-decl name='interned_strings' type-id='type-id-451' visibility='default' filepath='./Include/internal/pycore_global_objects.h' line='34' column='1'/>
       </data-member>
     </class-decl>
-    <class-decl name='_Py_static_objects' size-in-bits='586048' is-struct='yes' visibility='default' filepath='./Include/internal/pycore_global_objects.h' line='37' column='1' id='type-id-870'>
+    <class-decl name='_Py_static_objects' size-in-bits='586432' is-struct='yes' visibility='default' filepath='./Include/internal/pycore_global_objects.h' line='37' column='1' id='type-id-870'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='singletons' type-id='type-id-871' visibility='default' filepath='./Include/internal/pycore_global_objects.h' line='60' column='1'/>
       </data-member>
     </class-decl>
-    <class-decl name='__anonymous_struct__20' size-in-bits='586048' is-struct='yes' is-anonymous='yes' visibility='default' filepath='./Include/internal/pycore_global_objects.h' line='38' column='1' id='type-id-871'>
+    <class-decl name='__anonymous_struct__20' size-in-bits='586432' is-struct='yes' is-anonymous='yes' visibility='default' filepath='./Include/internal/pycore_global_objects.h' line='38' column='1' id='type-id-871'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='small_ints' type-id='type-id-591' visibility='default' filepath='./Include/internal/pycore_global_objects.h' line='44' column='1'/>
       </data-member>
@@ -13410,19 +13423,19 @@
       <data-member access='public' layout-offset-in-bits='165696'>
         <var-decl name='strings' type-id='type-id-872' visibility='default' filepath='./Include/internal/pycore_global_objects.h' line='52' column='1'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='585088'>
+      <data-member access='public' layout-offset-in-bits='585472'>
         <var-decl name='_tuple_empty_gc_not_used' type-id='type-id-861' visibility='default' filepath='./Include/internal/pycore_global_objects.h' line='54' column='1'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='585216'>
+      <data-member access='public' layout-offset-in-bits='585600'>
         <var-decl name='tuple_empty' type-id='type-id-801' visibility='default' filepath='./Include/internal/pycore_global_objects.h' line='55' column='1'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='585472'>
+      <data-member access='public' layout-offset-in-bits='585856'>
         <var-decl name='_hamt_bitmap_node_empty_gc_not_used' type-id='type-id-861' visibility='default' filepath='./Include/internal/pycore_global_objects.h' line='57' column='1'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='585600'>
+      <data-member access='public' layout-offset-in-bits='585984'>
         <var-decl name='hamt_bitmap_node_empty' type-id='type-id-873' visibility='default' filepath='./Include/internal/pycore_global_objects.h' line='58' column='1'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='585920'>
+      <data-member access='public' layout-offset-in-bits='586304'>
         <var-decl name='context_token_missing' type-id='type-id-835' visibility='default' filepath='./Include/internal/pycore_global_objects.h' line='59' column='1'/>
       </data-member>
     </class-decl>
@@ -13474,7 +13487,7 @@
         <var-decl name='singletons' type-id='type-id-876' visibility='default' filepath='./Include/internal/pycore_global_objects.h' line='98' column='1'/>
       </data-member>
     </class-decl>
-    <class-decl name='__anonymous_struct__748' size-in-bits='1088' is-struct='yes' is-anonymous='yes' visibility='default' filepath='./Include/internal/pycore_global_objects.h' line='92' column='1' id='type-id-876'>
+    <class-decl name='__anonymous_struct__749' size-in-bits='1088' is-struct='yes' is-anonymous='yes' visibility='default' filepath='./Include/internal/pycore_global_objects.h' line='92' column='1' id='type-id-876'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='_not_used' type-id='type-id-8' visibility='default' filepath='./Include/internal/pycore_global_objects.h' line='93' column='1'/>
       </data-member>
@@ -13488,18 +13501,18 @@
         <var-decl name='last_resort_memory_error' type-id='type-id-767' visibility='default' filepath='./Include/internal/pycore_global_objects.h' line='97' column='1'/>
       </data-member>
     </class-decl>
-    <class-decl name='_Py_global_strings' size-in-bits='419392' is-struct='yes' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='29' column='1' id='type-id-872'>
+    <class-decl name='_Py_global_strings' size-in-bits='419776' is-struct='yes' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='29' column='1' id='type-id-872'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='literals' type-id='type-id-878' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='57' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='11008'>
-        <var-decl name='identifiers' type-id='type-id-879' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='751' column='1'/>
+        <var-decl name='identifiers' type-id='type-id-879' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='752' column='1'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='304704'>
-        <var-decl name='ascii' type-id='type-id-607' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='755' column='1'/>
+      <data-member access='public' layout-offset-in-bits='305088'>
+        <var-decl name='ascii' type-id='type-id-605' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='756' column='1'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='353856'>
-        <var-decl name='latin1' type-id='type-id-605' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='759' column='1'/>
+      <data-member access='public' layout-offset-in-bits='354240'>
+        <var-decl name='latin1' type-id='type-id-607' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='760' column='1'/>
       </data-member>
     </class-decl>
     <class-decl name='__anonymous_struct__22' size-in-bits='11008' is-struct='yes' is-anonymous='yes' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='30' column='1' id='type-id-878'>
@@ -13528,7 +13541,7 @@
         <var-decl name='_py_anon_unknown' type-id='type-id-881' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='38' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='3584'>
-        <var-decl name='_py_close_br' type-id='type-id-606' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='39' column='1'/>
+        <var-decl name='_py_close_br' type-id='type-id-604' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='39' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='3968'>
         <var-decl name='_py_dbl_close_br' type-id='type-id-883' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='40' column='1'/>
@@ -13543,7 +13556,7 @@
         <var-decl name='_py_defaults' type-id='type-id-881' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='43' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='5568'>
-        <var-decl name='_py_dot' type-id='type-id-606' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='44' column='1'/>
+        <var-decl name='_py_dot' type-id='type-id-604' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='44' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='5952'>
         <var-decl name='_py_dot_locals' type-id='type-id-881' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='45' column='1'/>
@@ -13564,13 +13577,13 @@
         <var-decl name='_py_list_err' type-id='type-id-888' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='50' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='8640'>
-        <var-decl name='_py_newline' type-id='type-id-606' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='51' column='1'/>
+        <var-decl name='_py_newline' type-id='type-id-604' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='51' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='9024'>
-        <var-decl name='_py_open_br' type-id='type-id-606' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='52' column='1'/>
+        <var-decl name='_py_open_br' type-id='type-id-604' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='52' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='9408'>
-        <var-decl name='_py_percent' type-id='type-id-606' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='53' column='1'/>
+        <var-decl name='_py_percent' type-id='type-id-604' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='53' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='9792'>
         <var-decl name='_py_shim_name' type-id='type-id-889' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='54' column='1'/>
@@ -13606,7 +13619,7 @@
         <var-decl name='_data' type-id='type-id-703' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='33' column='1'/>
       </data-member>
     </class-decl>
-    <class-decl name='__anonymous_struct__32' size-in-bits='384' is-struct='yes' is-anonymous='yes' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='39' column='1' id='type-id-606'>
+    <class-decl name='__anonymous_struct__32' size-in-bits='384' is-struct='yes' is-anonymous='yes' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='39' column='1' id='type-id-604'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='_ascii' type-id='type-id-803' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='39' column='1'/>
       </data-member>
@@ -13678,7 +13691,7 @@
         <var-decl name='_data' type-id='type-id-699' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='56' column='1'/>
       </data-member>
     </class-decl>
-    <class-decl name='__anonymous_struct__50' size-in-bits='293696' is-struct='yes' is-anonymous='yes' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='59' column='1' id='type-id-879'>
+    <class-decl name='__anonymous_struct__50' size-in-bits='294080' is-struct='yes' is-anonymous='yes' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='59' column='1' id='type-id-879'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='_py_CANCELLED' type-id='type-id-881' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='60' column='1'/>
       </data-member>
@@ -13707,7 +13720,7 @@
         <var-decl name='_py_WarningMessage' type-id='type-id-894' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='68' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='3776'>
-        <var-decl name='_py__' type-id='type-id-606' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='69' column='1'/>
+        <var-decl name='_py__' type-id='type-id-604' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='69' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='4160'>
         <var-decl name='_py__WindowsConsoleIO' type-id='type-id-895' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='70' column='1'/>
@@ -14307,7 +14320,7 @@
         <var-decl name='_py__xoptions' type-id='type-id-881' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='268' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='93440'>
-        <var-decl name='_py_a' type-id='type-id-606' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='269' column='1'/>
+        <var-decl name='_py_a' type-id='type-id-604' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='269' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='93824'>
         <var-decl name='_py_abs_tol' type-id='type-id-892' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='270' column='1'/>
@@ -14367,7 +14380,7 @@
         <var-decl name='_py_autocommit' type-id='type-id-880' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='288' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='101888'>
-        <var-decl name='_py_b' type-id='type-id-606' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='289' column='1'/>
+        <var-decl name='_py_b' type-id='type-id-604' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='289' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='102272'>
         <var-decl name='_py_backtick' type-id='type-id-882' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='290' column='1'/>
@@ -14421,7 +14434,7 @@
         <var-decl name='_py_bytes_per_sep' type-id='type-id-885' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='306' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='109312'>
-        <var-decl name='_py_c' type-id='type-id-606' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='307' column='1'/>
+        <var-decl name='_py_c' type-id='type-id-604' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='307' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='109696'>
         <var-decl name='_py_c_call' type-id='type-id-889' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='308' column='1'/>
@@ -14580,7 +14593,7 @@
         <var-decl name='_py_cwd' type-id='type-id-903' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='359' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='131840'>
-        <var-decl name='_py_d' type-id='type-id-606' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='360' column='1'/>
+        <var-decl name='_py_d' type-id='type-id-604' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='360' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='132224'>
         <var-decl name='_py_data' type-id='type-id-893' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='361' column='1'/>
@@ -14664,7 +14677,7 @@
         <var-decl name='_py_duration' type-id='type-id-882' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='387' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='143488'>
-        <var-decl name='_py_e' type-id='type-id-606' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='388' column='1'/>
+        <var-decl name='_py_e' type-id='type-id-604' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='388' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='143872'>
         <var-decl name='_py_eager_start' type-id='type-id-887' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='389' column='1'/>
@@ -15147,7 +15160,7 @@
         <var-decl name='_py_mycmp' type-id='type-id-890' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='548' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='209984'>
-        <var-decl name='_py_n' type-id='type-id-606' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='549' column='1'/>
+        <var-decl name='_py_n' type-id='type-id-604' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='549' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='210368'>
         <var-decl name='_py_n_arg' type-id='type-id-890' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='550' column='1'/>
@@ -15282,7 +15295,7 @@
         <var-decl name='_py_owner' type-id='type-id-890' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='593' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='228736'>
-        <var-decl name='_py_p' type-id='type-id-606' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='594' column='1'/>
+        <var-decl name='_py_p' type-id='type-id-604' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='594' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='229120'>
         <var-decl name='_py_pages' type-id='type-id-890' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='595' column='1'/>
@@ -15366,7 +15379,7 @@
         <var-decl name='_py_quotetabs' type-id='type-id-881' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='621' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='240384'>
-        <var-decl name='_py_r' type-id='type-id-606' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='622' column='1'/>
+        <var-decl name='_py_r' type-id='type-id-604' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='622' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='240768'>
         <var-decl name='_py_raw' type-id='type-id-903' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='623' column='1'/>
@@ -15438,7 +15451,7 @@
         <var-decl name='_py_reversed' type-id='type-id-882' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='645' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='250304'>
-        <var-decl name='_py_s' type-id='type-id-606' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='646' column='1'/>
+        <var-decl name='_py_s' type-id='type-id-604' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='646' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='250688'>
         <var-decl name='_py_salt' type-id='type-id-893' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='647' column='1'/>
@@ -15534,223 +15547,226 @@
         <var-decl name='_py_source_traceback' type-id='type-id-899' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='677' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='263680'>
-        <var-decl name='_py_src' type-id='type-id-903' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='678' column='1'/>
+        <var-decl name='_py_spam' type-id='type-id-893' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='678' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='264064'>
-        <var-decl name='_py_src_dir_fd' type-id='type-id-880' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='679' column='1'/>
+        <var-decl name='_py_src' type-id='type-id-903' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='679' column='1'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='264512'>
-        <var-decl name='_py_stacklevel' type-id='type-id-880' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='680' column='1'/>
+      <data-member access='public' layout-offset-in-bits='264448'>
+        <var-decl name='_py_src_dir_fd' type-id='type-id-880' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='680' column='1'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='264960'>
-        <var-decl name='_py_start' type-id='type-id-890' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='681' column='1'/>
+      <data-member access='public' layout-offset-in-bits='264896'>
+        <var-decl name='_py_stacklevel' type-id='type-id-880' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='681' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='265344'>
-        <var-decl name='_py_statement' type-id='type-id-881' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='682' column='1'/>
+        <var-decl name='_py_start' type-id='type-id-890' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='682' column='1'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='265792'>
-        <var-decl name='_py_status' type-id='type-id-889' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='683' column='1'/>
+      <data-member access='public' layout-offset-in-bits='265728'>
+        <var-decl name='_py_statement' type-id='type-id-881' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='683' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='266176'>
-        <var-decl name='_py_stderr' type-id='type-id-889' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='684' column='1'/>
+        <var-decl name='_py_status' type-id='type-id-889' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='684' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='266560'>
-        <var-decl name='_py_stdin' type-id='type-id-890' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='685' column='1'/>
+        <var-decl name='_py_stderr' type-id='type-id-889' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='685' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='266944'>
-        <var-decl name='_py_stdout' type-id='type-id-889' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='686' column='1'/>
+        <var-decl name='_py_stdin' type-id='type-id-890' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='686' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='267328'>
-        <var-decl name='_py_step' type-id='type-id-893' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='687' column='1'/>
+        <var-decl name='_py_stdout' type-id='type-id-889' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='687' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='267712'>
-        <var-decl name='_py_steps' type-id='type-id-890' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='688' column='1'/>
+        <var-decl name='_py_step' type-id='type-id-893' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='688' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='268096'>
-        <var-decl name='_py_store_name' type-id='type-id-880' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='689' column='1'/>
+        <var-decl name='_py_steps' type-id='type-id-890' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='689' column='1'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='268544'>
-        <var-decl name='_py_strategy' type-id='type-id-882' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='690' column='1'/>
+      <data-member access='public' layout-offset-in-bits='268480'>
+        <var-decl name='_py_store_name' type-id='type-id-880' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='690' column='1'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='268992'>
-        <var-decl name='_py_strftime' type-id='type-id-882' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='691' column='1'/>
+      <data-member access='public' layout-offset-in-bits='268928'>
+        <var-decl name='_py_strategy' type-id='type-id-882' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='691' column='1'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='269440'>
-        <var-decl name='_py_strict' type-id='type-id-889' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='692' column='1'/>
+      <data-member access='public' layout-offset-in-bits='269376'>
+        <var-decl name='_py_strftime' type-id='type-id-882' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='692' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='269824'>
-        <var-decl name='_py_strict_mode' type-id='type-id-887' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='693' column='1'/>
+        <var-decl name='_py_strict' type-id='type-id-889' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='693' column='1'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='270272'>
-        <var-decl name='_py_string' type-id='type-id-889' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='694' column='1'/>
+      <data-member access='public' layout-offset-in-bits='270208'>
+        <var-decl name='_py_strict_mode' type-id='type-id-887' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='694' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='270656'>
-        <var-decl name='_py_sub_key' type-id='type-id-892' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='695' column='1'/>
+        <var-decl name='_py_string' type-id='type-id-889' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='695' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='271040'>
-        <var-decl name='_py_symmetric_difference_update' type-id='type-id-906' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='696' column='1'/>
+        <var-decl name='_py_sub_key' type-id='type-id-892' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='696' column='1'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='271616'>
-        <var-decl name='_py_tabsize' type-id='type-id-892' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='697' column='1'/>
+      <data-member access='public' layout-offset-in-bits='271424'>
+        <var-decl name='_py_symmetric_difference_update' type-id='type-id-906' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='697' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='272000'>
-        <var-decl name='_py_tag' type-id='type-id-903' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='698' column='1'/>
+        <var-decl name='_py_tabsize' type-id='type-id-892' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='698' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='272384'>
-        <var-decl name='_py_target' type-id='type-id-889' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='699' column='1'/>
+        <var-decl name='_py_tag' type-id='type-id-903' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='699' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='272768'>
-        <var-decl name='_py_target_is_directory' type-id='type-id-896' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='700' column='1'/>
+        <var-decl name='_py_target' type-id='type-id-889' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='700' column='1'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='273280'>
-        <var-decl name='_py_task' type-id='type-id-893' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='701' column='1'/>
+      <data-member access='public' layout-offset-in-bits='273152'>
+        <var-decl name='_py_target_is_directory' type-id='type-id-896' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='701' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='273664'>
-        <var-decl name='_py_tb_frame' type-id='type-id-882' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='702' column='1'/>
+        <var-decl name='_py_task' type-id='type-id-893' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='702' column='1'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='274112'>
-        <var-decl name='_py_tb_lasti' type-id='type-id-882' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='703' column='1'/>
+      <data-member access='public' layout-offset-in-bits='274048'>
+        <var-decl name='_py_tb_frame' type-id='type-id-882' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='703' column='1'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='274560'>
-        <var-decl name='_py_tb_lineno' type-id='type-id-881' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='704' column='1'/>
+      <data-member access='public' layout-offset-in-bits='274496'>
+        <var-decl name='_py_tb_lasti' type-id='type-id-882' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='704' column='1'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='275008'>
-        <var-decl name='_py_tb_next' type-id='type-id-892' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='705' column='1'/>
+      <data-member access='public' layout-offset-in-bits='274944'>
+        <var-decl name='_py_tb_lineno' type-id='type-id-881' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='705' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='275392'>
-        <var-decl name='_py_tell' type-id='type-id-893' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='706' column='1'/>
+        <var-decl name='_py_tb_next' type-id='type-id-892' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='706' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='275776'>
-        <var-decl name='_py_template' type-id='type-id-882' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='707' column='1'/>
+        <var-decl name='_py_tell' type-id='type-id-893' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='707' column='1'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='276224'>
-        <var-decl name='_py_term' type-id='type-id-893' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='708' column='1'/>
+      <data-member access='public' layout-offset-in-bits='276160'>
+        <var-decl name='_py_template' type-id='type-id-882' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='708' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='276608'>
-        <var-decl name='_py_text' type-id='type-id-893' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='709' column='1'/>
+        <var-decl name='_py_term' type-id='type-id-893' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='709' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='276992'>
-        <var-decl name='_py_threading' type-id='type-id-881' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='710' column='1'/>
+        <var-decl name='_py_text' type-id='type-id-893' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='710' column='1'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='277440'>
-        <var-decl name='_py_throw' type-id='type-id-890' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='711' column='1'/>
+      <data-member access='public' layout-offset-in-bits='277376'>
+        <var-decl name='_py_threading' type-id='type-id-881' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='711' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='277824'>
-        <var-decl name='_py_timeout' type-id='type-id-892' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='712' column='1'/>
+        <var-decl name='_py_throw' type-id='type-id-890' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='712' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='278208'>
-        <var-decl name='_py_times' type-id='type-id-890' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='713' column='1'/>
+        <var-decl name='_py_timeout' type-id='type-id-892' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='713' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='278592'>
-        <var-decl name='_py_timetuple' type-id='type-id-881' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='714' column='1'/>
+        <var-decl name='_py_times' type-id='type-id-890' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='714' column='1'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='279040'>
-        <var-decl name='_py_top' type-id='type-id-903' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='715' column='1'/>
+      <data-member access='public' layout-offset-in-bits='278976'>
+        <var-decl name='_py_timetuple' type-id='type-id-881' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='715' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='279424'>
-        <var-decl name='_py_trace_callback' type-id='type-id-894' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='716' column='1'/>
+        <var-decl name='_py_top' type-id='type-id-903' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='716' column='1'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='279872'>
-        <var-decl name='_py_traceback' type-id='type-id-881' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='717' column='1'/>
+      <data-member access='public' layout-offset-in-bits='279808'>
+        <var-decl name='_py_trace_callback' type-id='type-id-894' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='717' column='1'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='280320'>
-        <var-decl name='_py_trailers' type-id='type-id-882' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='718' column='1'/>
+      <data-member access='public' layout-offset-in-bits='280256'>
+        <var-decl name='_py_traceback' type-id='type-id-881' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='718' column='1'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='280768'>
-        <var-decl name='_py_translate' type-id='type-id-881' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='719' column='1'/>
+      <data-member access='public' layout-offset-in-bits='280704'>
+        <var-decl name='_py_trailers' type-id='type-id-882' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='719' column='1'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='281216'>
-        <var-decl name='_py_true' type-id='type-id-893' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='720' column='1'/>
+      <data-member access='public' layout-offset-in-bits='281152'>
+        <var-decl name='_py_translate' type-id='type-id-881' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='720' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='281600'>
-        <var-decl name='_py_truncate' type-id='type-id-882' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='721' column='1'/>
+        <var-decl name='_py_true' type-id='type-id-893' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='721' column='1'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='282048'>
-        <var-decl name='_py_twice' type-id='type-id-890' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='722' column='1'/>
+      <data-member access='public' layout-offset-in-bits='281984'>
+        <var-decl name='_py_truncate' type-id='type-id-882' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='722' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='282432'>
-        <var-decl name='_py_txt' type-id='type-id-903' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='723' column='1'/>
+        <var-decl name='_py_twice' type-id='type-id-890' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='723' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='282816'>
-        <var-decl name='_py_type' type-id='type-id-893' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='724' column='1'/>
+        <var-decl name='_py_txt' type-id='type-id-903' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='724' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='283200'>
-        <var-decl name='_py_type_params' type-id='type-id-887' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='725' column='1'/>
+        <var-decl name='_py_type' type-id='type-id-893' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='725' column='1'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='283648'>
-        <var-decl name='_py_tz' type-id='type-id-883' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='726' column='1'/>
+      <data-member access='public' layout-offset-in-bits='283584'>
+        <var-decl name='_py_type_params' type-id='type-id-887' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='726' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='284032'>
-        <var-decl name='_py_tzname' type-id='type-id-889' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='727' column='1'/>
+        <var-decl name='_py_tz' type-id='type-id-883' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='727' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='284416'>
-        <var-decl name='_py_uid' type-id='type-id-903' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='728' column='1'/>
+        <var-decl name='_py_tzname' type-id='type-id-889' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='728' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='284800'>
-        <var-decl name='_py_unlink' type-id='type-id-889' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='729' column='1'/>
+        <var-decl name='_py_uid' type-id='type-id-903' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='729' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='285184'>
-        <var-decl name='_py_unraisablehook' type-id='type-id-894' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='730' column='1'/>
+        <var-decl name='_py_unlink' type-id='type-id-889' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='730' column='1'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='285632'>
-        <var-decl name='_py_uri' type-id='type-id-903' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='731' column='1'/>
+      <data-member access='public' layout-offset-in-bits='285568'>
+        <var-decl name='_py_unraisablehook' type-id='type-id-894' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='731' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='286016'>
-        <var-decl name='_py_usedforsecurity' type-id='type-id-891' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='732' column='1'/>
+        <var-decl name='_py_uri' type-id='type-id-903' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='732' column='1'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='286464'>
-        <var-decl name='_py_value' type-id='type-id-890' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='733' column='1'/>
+      <data-member access='public' layout-offset-in-bits='286400'>
+        <var-decl name='_py_usedforsecurity' type-id='type-id-891' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='733' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='286848'>
-        <var-decl name='_py_values' type-id='type-id-889' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='734' column='1'/>
+        <var-decl name='_py_value' type-id='type-id-890' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='734' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='287232'>
-        <var-decl name='_py_version' type-id='type-id-892' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='735' column='1'/>
+        <var-decl name='_py_values' type-id='type-id-889' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='735' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='287616'>
-        <var-decl name='_py_volume' type-id='type-id-889' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='736' column='1'/>
+        <var-decl name='_py_version' type-id='type-id-892' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='736' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='288000'>
-        <var-decl name='_py_warnings' type-id='type-id-882' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='737' column='1'/>
+        <var-decl name='_py_volume' type-id='type-id-889' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='737' column='1'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='288448'>
-        <var-decl name='_py_warnoptions' type-id='type-id-887' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='738' column='1'/>
+      <data-member access='public' layout-offset-in-bits='288384'>
+        <var-decl name='_py_warnings' type-id='type-id-882' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='738' column='1'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='288896'>
-        <var-decl name='_py_wbits' type-id='type-id-890' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='739' column='1'/>
+      <data-member access='public' layout-offset-in-bits='288832'>
+        <var-decl name='_py_warnoptions' type-id='type-id-887' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='739' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='289280'>
-        <var-decl name='_py_week' type-id='type-id-893' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='740' column='1'/>
+        <var-decl name='_py_wbits' type-id='type-id-890' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='740' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='289664'>
-        <var-decl name='_py_weekday' type-id='type-id-892' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='741' column='1'/>
+        <var-decl name='_py_week' type-id='type-id-893' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='741' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='290048'>
-        <var-decl name='_py_which' type-id='type-id-890' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='742' column='1'/>
+        <var-decl name='_py_weekday' type-id='type-id-892' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='742' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='290432'>
-        <var-decl name='_py_who' type-id='type-id-903' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='743' column='1'/>
+        <var-decl name='_py_which' type-id='type-id-890' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='743' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='290816'>
-        <var-decl name='_py_withdata' type-id='type-id-882' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='744' column='1'/>
+        <var-decl name='_py_who' type-id='type-id-903' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='744' column='1'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='291264'>
-        <var-decl name='_py_writable' type-id='type-id-882' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='745' column='1'/>
+      <data-member access='public' layout-offset-in-bits='291200'>
+        <var-decl name='_py_withdata' type-id='type-id-882' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='745' column='1'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='291712'>
-        <var-decl name='_py_write' type-id='type-id-890' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='746' column='1'/>
+      <data-member access='public' layout-offset-in-bits='291648'>
+        <var-decl name='_py_writable' type-id='type-id-882' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='746' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='292096'>
-        <var-decl name='_py_write_through' type-id='type-id-885' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='747' column='1'/>
+        <var-decl name='_py_write' type-id='type-id-890' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='747' column='1'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='292544'>
-        <var-decl name='_py_x' type-id='type-id-606' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='748' column='1'/>
+      <data-member access='public' layout-offset-in-bits='292480'>
+        <var-decl name='_py_write_through' type-id='type-id-885' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='748' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='292928'>
-        <var-decl name='_py_year' type-id='type-id-893' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='749' column='1'/>
+        <var-decl name='_py_x' type-id='type-id-604' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='749' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='293312'>
-        <var-decl name='_py_zdict' type-id='type-id-890' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='750' column='1'/>
+        <var-decl name='_py_year' type-id='type-id-893' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='750' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='293696'>
+        <var-decl name='_py_zdict' type-id='type-id-890' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='751' column='1'/>
       </data-member>
     </class-decl>
     <class-decl name='__anonymous_struct__54' size-in-bits='448' is-struct='yes' is-anonymous='yes' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='63' column='1' id='type-id-891'>
@@ -15873,20 +15889,20 @@
         <var-decl name='_data' type-id='type-id-680' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='315' column='1'/>
       </data-member>
     </class-decl>
-    <class-decl name='__anonymous_struct__687' size-in-bits='576' is-struct='yes' is-anonymous='yes' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='696' column='1' id='type-id-906'>
+    <class-decl name='__anonymous_struct__688' size-in-bits='576' is-struct='yes' is-anonymous='yes' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='697' column='1' id='type-id-906'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='_ascii' type-id='type-id-803' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='696' column='1'/>
+        <var-decl name='_ascii' type-id='type-id-803' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='697' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='_data' type-id='type-id-688' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='696' column='1'/>
+        <var-decl name='_data' type-id='type-id-688' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='697' column='1'/>
       </data-member>
     </class-decl>
-    <class-decl name='__anonymous_struct__743' size-in-bits='512' is-struct='yes' is-anonymous='yes' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='756' column='1' id='type-id-604'>
+    <class-decl name='__anonymous_struct__744' size-in-bits='512' is-struct='yes' is-anonymous='yes' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='757' column='1' id='type-id-606'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='_latin1' type-id='type-id-806' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='757' column='1'/>
+        <var-decl name='_latin1' type-id='type-id-806' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='758' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='448'>
-        <var-decl name='_data' type-id='type-id-689' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='758' column='1'/>
+        <var-decl name='_data' type-id='type-id-689' visibility='default' filepath='./Include/internal/pycore_global_strings.h' line='759' column='1'/>
       </data-member>
     </class-decl>
     <class-decl name='PyHamtNode' size-in-bits='128' is-struct='yes' naming-typedef-id='type-id-907' visibility='default' filepath='./Include/internal/pycore_hamt.h' line='38' column='1' id='type-id-908'>
@@ -16043,7 +16059,7 @@
         <var-decl name='find_and_load' type-id='type-id-933' visibility='default' filepath='./Include/internal/pycore_import.h' line='79' column='1'/>
       </data-member>
     </class-decl>
-    <class-decl name='__anonymous_struct__745' size-in-bits='192' is-struct='yes' is-anonymous='yes' visibility='default' filepath='./Include/internal/pycore_import.h' line='69' column='1' id='type-id-932'>
+    <class-decl name='__anonymous_struct__746' size-in-bits='192' is-struct='yes' is-anonymous='yes' visibility='default' filepath='./Include/internal/pycore_import.h' line='69' column='1' id='type-id-932'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='mutex' type-id='type-id-810' visibility='default' filepath='./Include/internal/pycore_import.h' line='70' column='1'/>
       </data-member>
@@ -16054,7 +16070,7 @@
         <var-decl name='level' type-id='type-id-8' visibility='default' filepath='./Include/internal/pycore_import.h' line='72' column='1'/>
       </data-member>
     </class-decl>
-    <class-decl name='__anonymous_struct__746' size-in-bits='192' is-struct='yes' is-anonymous='yes' visibility='default' filepath='./Include/internal/pycore_import.h' line='75' column='1' id='type-id-933'>
+    <class-decl name='__anonymous_struct__747' size-in-bits='192' is-struct='yes' is-anonymous='yes' visibility='default' filepath='./Include/internal/pycore_import.h' line='75' column='1' id='type-id-933'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='import_level' type-id='type-id-8' visibility='default' filepath='./Include/internal/pycore_import.h' line='76' column='1'/>
       </data-member>
@@ -16497,7 +16513,7 @@
         <var-decl name='mgmt' type-id='type-id-958' visibility='default' filepath='./Include/internal/pycore_obmalloc.h' line='667' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='8768'>
-        <var-decl name='usage' type-id='type-id-965' visibility='default' filepath='./Include/internal/pycore_obmalloc.h' line='668' column='1'/>
+        <var-decl name='usage' type-id='type-id-965' visibility='default' filepath='./Include/internal/pycore_obmalloc.h' line='669' column='1'/>
       </data-member>
     </class-decl>
     <class-decl name='_parser_runtime_state' size-in-bits='448' is-struct='yes' visibility='default' filepath='./Include/internal/pycore_parser.h' line='21' column='1' id='type-id-967'>
@@ -16613,7 +16629,7 @@
       </data-member>
     </class-decl>
     <typedef-decl name='_Py_AuditHookEntry' type-id='type-id-984' filepath='./Include/internal/pycore_runtime.h' line='54' column='1' id='type-id-986'/>
-    <class-decl name='pyruntimestate' size-in-bits='3679552' is-struct='yes' visibility='default' filepath='./Include/internal/pycore_runtime.h' line='61' column='1' id='type-id-987'>
+    <class-decl name='pyruntimestate' size-in-bits='3679936' is-struct='yes' visibility='default' filepath='./Include/internal/pycore_runtime.h' line='61' column='1' id='type-id-987'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='_initialized' type-id='type-id-8' visibility='default' filepath='./Include/internal/pycore_runtime.h' line='66' column='1'/>
       </data-member>
@@ -16722,16 +16738,16 @@
       <data-member access='public' layout-offset-in-bits='24896'>
         <var-decl name='static_objects' type-id='type-id-870' visibility='default' filepath='./Include/internal/pycore_runtime.h' line='160' column='1'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='610944'>
+      <data-member access='public' layout-offset-in-bits='611328'>
         <var-decl name='cached_objects' type-id='type-id-869' visibility='default' filepath='./Include/internal/pycore_runtime.h' line='161' column='1'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='611008'>
+      <data-member access='public' layout-offset-in-bits='611392'>
         <var-decl name='_finalizing_id' type-id='type-id-819' visibility='default' filepath='./Include/internal/pycore_runtime.h' line='165' column='1'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='611072'>
+      <data-member access='public' layout-offset-in-bits='611456'>
         <var-decl name='sys_path_0' type-id='type-id-52' visibility='default' filepath='./Include/internal/pycore_runtime.h' line='169' column='1'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='611136'>
+      <data-member access='public' layout-offset-in-bits='611520'>
         <var-decl name='_main_interpreter' type-id='type-id-995' visibility='default' filepath='./Include/internal/pycore_runtime.h' line='186' column='1'/>
       </data-member>
     </class-decl>
@@ -17056,7 +17072,7 @@
         <var-decl name='__value32' type-id='type-id-1024' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/atomic_wide_counter.h' line='32' column='1'/>
       </data-member>
     </union-decl>
-    <class-decl name='__anonymous_struct__744' size-in-bits='64' is-struct='yes' is-anonymous='yes' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/atomic_wide_counter.h' line='28' column='1' id='type-id-1024'>
+    <class-decl name='__anonymous_struct__745' size-in-bits='64' is-struct='yes' is-anonymous='yes' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/atomic_wide_counter.h' line='28' column='1' id='type-id-1024'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='__low' type-id='type-id-95' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/atomic_wide_counter.h' line='30' column='1'/>
       </data-member>
@@ -17802,13 +17818,13 @@
       </data-member>
     </class-decl>
     <typedef-decl name='ResultTokenWithMetadata' type-id='type-id-1116' filepath='Parser/pegen.h' line='125' column='1' id='type-id-1115'/>
-    <enum-decl name='TARGETS_TYPE' naming-typedef-id='type-id-1117' filepath='Parser/pegen.h' line='157' column='1' id='type-id-1118'>
+    <enum-decl name='TARGETS_TYPE' naming-typedef-id='type-id-1117' filepath='Parser/pegen.h' line='158' column='1' id='type-id-1118'>
       <underlying-type type-id='type-id-24'/>
       <enumerator name='STAR_TARGETS' value='0'/>
       <enumerator name='DEL_TARGETS' value='1'/>
       <enumerator name='FOR_TARGETS' value='2'/>
     </enum-decl>
-    <typedef-decl name='TARGETS_TYPE' type-id='type-id-1118' filepath='Parser/pegen.h' line='161' column='1' id='type-id-1117'/>
+    <typedef-decl name='TARGETS_TYPE' type-id='type-id-1118' filepath='Parser/pegen.h' line='162' column='1' id='type-id-1117'/>
     <pointer-type-def type-id='type-id-1111' size-in-bits='64' id='type-id-1119'/>
     <pointer-type-def type-id='type-id-1098' size-in-bits='64' id='type-id-1120'/>
     <pointer-type-def type-id='type-id-1102' size-in-bits='64' id='type-id-1121'/>
@@ -18653,76 +18669,76 @@
       <parameter type-id='type-id-577'/>
       <return type-id='type-id-22'/>
     </function-decl>
-    <function-decl name='_Pypegen_stack_overflow' filepath='Parser/pegen.h' line='172' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_Pypegen_stack_overflow' filepath='Parser/pegen.h' line='173' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-577'/>
       <return type-id='type-id-46'/>
     </function-decl>
-    <function-decl name='_PyPegen_get_invalid_target' filepath='Parser/pegen.h' line='223' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_PyPegen_get_invalid_target' filepath='Parser/pegen.h' line='224' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-511'/>
       <parameter type-id='type-id-1117'/>
       <return type-id='type-id-511'/>
     </function-decl>
-    <function-decl name='_PyPegen_get_expr_name' filepath='Parser/pegen.h' line='224' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_PyPegen_get_expr_name' filepath='Parser/pegen.h' line='225' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-511'/>
       <return type-id='type-id-12'/>
     </function-decl>
-    <function-decl name='_PyPegen_dummy_name' filepath='Parser/pegen.h' line='249' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_PyPegen_dummy_name' filepath='Parser/pegen.h' line='250' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-577'/>
       <parameter is-variadic='yes'/>
       <return type-id='type-id-22'/>
     </function-decl>
-    <function-decl name='_PyPegen_seq_last_item' filepath='Parser/pegen.h' line='250' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_PyPegen_seq_last_item' filepath='Parser/pegen.h' line='251' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-1108'/>
       <return type-id='type-id-22'/>
     </function-decl>
-    <function-decl name='_PyPegen_seq_first_item' filepath='Parser/pegen.h' line='252' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_PyPegen_seq_first_item' filepath='Parser/pegen.h' line='253' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-1108'/>
       <return type-id='type-id-22'/>
     </function-decl>
-    <function-decl name='_PyPegen_new_type_comment' filepath='Parser/pegen.h' line='257' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_PyPegen_new_type_comment' filepath='Parser/pegen.h' line='258' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-577'/>
       <parameter type-id='type-id-12'/>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='_PyPegen_add_type_comment_to_arg' filepath='Parser/pegen.h' line='296' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_PyPegen_add_type_comment_to_arg' filepath='Parser/pegen.h' line='297' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-577'/>
       <parameter type-id='type-id-576'/>
       <parameter type-id='type-id-578'/>
       <return type-id='type-id-576'/>
     </function-decl>
-    <function-decl name='_PyPegen_singleton_seq' filepath='Parser/pegen.h' line='298' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_PyPegen_singleton_seq' filepath='Parser/pegen.h' line='299' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-577'/>
       <parameter type-id='type-id-22'/>
       <return type-id='type-id-1108'/>
     </function-decl>
-    <function-decl name='_PyPegen_seq_insert_in_front' filepath='Parser/pegen.h' line='299' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_PyPegen_seq_insert_in_front' filepath='Parser/pegen.h' line='300' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-577'/>
       <parameter type-id='type-id-22'/>
       <parameter type-id='type-id-1108'/>
       <return type-id='type-id-1108'/>
     </function-decl>
-    <function-decl name='_PyPegen_seq_append_to_end' filepath='Parser/pegen.h' line='300' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_PyPegen_seq_append_to_end' filepath='Parser/pegen.h' line='301' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-577'/>
       <parameter type-id='type-id-1108'/>
       <parameter type-id='type-id-22'/>
       <return type-id='type-id-1108'/>
     </function-decl>
-    <function-decl name='_PyPegen_seq_flatten' filepath='Parser/pegen.h' line='301' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_PyPegen_seq_flatten' filepath='Parser/pegen.h' line='302' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-577'/>
       <parameter type-id='type-id-1108'/>
       <return type-id='type-id-1108'/>
     </function-decl>
-    <function-decl name='_PyPegen_join_names_with_dot' filepath='Parser/pegen.h' line='302' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_PyPegen_join_names_with_dot' filepath='Parser/pegen.h' line='303' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-577'/>
       <parameter type-id='type-id-511'/>
       <parameter type-id='type-id-511'/>
       <return type-id='type-id-511'/>
     </function-decl>
-    <function-decl name='_PyPegen_seq_count_dots' filepath='Parser/pegen.h' line='303' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_PyPegen_seq_count_dots' filepath='Parser/pegen.h' line='304' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-1108'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='_PyPegen_alias_for_star' filepath='Parser/pegen.h' line='304' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_PyPegen_alias_for_star' filepath='Parser/pegen.h' line='305' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-577'/>
       <parameter type-id='type-id-8'/>
       <parameter type-id='type-id-8'/>
@@ -18731,86 +18747,86 @@
       <parameter type-id='type-id-572'/>
       <return type-id='type-id-453'/>
     </function-decl>
-    <function-decl name='_PyPegen_map_names_to_ids' filepath='Parser/pegen.h' line='305' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_PyPegen_map_names_to_ids' filepath='Parser/pegen.h' line='306' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-577'/>
       <parameter type-id='type-id-512'/>
       <return type-id='type-id-544'/>
     </function-decl>
-    <function-decl name='_PyPegen_cmpop_expr_pair' filepath='Parser/pegen.h' line='306' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_PyPegen_cmpop_expr_pair' filepath='Parser/pegen.h' line='307' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-577'/>
       <parameter type-id='type-id-1097'/>
       <parameter type-id='type-id-511'/>
       <return type-id='type-id-1120'/>
     </function-decl>
-    <function-decl name='_PyPegen_get_cmpops' filepath='Parser/pegen.h' line='307' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_PyPegen_get_cmpops' filepath='Parser/pegen.h' line='308' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-577'/>
       <parameter type-id='type-id-1108'/>
       <return type-id='type-id-573'/>
     </function-decl>
-    <function-decl name='_PyPegen_get_exprs' filepath='Parser/pegen.h' line='308' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_PyPegen_get_exprs' filepath='Parser/pegen.h' line='309' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-577'/>
       <parameter type-id='type-id-1108'/>
       <return type-id='type-id-512'/>
     </function-decl>
-    <function-decl name='_PyPegen_set_expr_context' filepath='Parser/pegen.h' line='309' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_PyPegen_set_expr_context' filepath='Parser/pegen.h' line='310' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-577'/>
       <parameter type-id='type-id-511'/>
       <parameter type-id='type-id-575'/>
       <return type-id='type-id-511'/>
     </function-decl>
-    <function-decl name='_PyPegen_key_value_pair' filepath='Parser/pegen.h' line='310' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_PyPegen_key_value_pair' filepath='Parser/pegen.h' line='311' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-577'/>
       <parameter type-id='type-id-511'/>
       <parameter type-id='type-id-511'/>
       <return type-id='type-id-1122'/>
     </function-decl>
-    <function-decl name='_PyPegen_get_keys' filepath='Parser/pegen.h' line='311' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_PyPegen_get_keys' filepath='Parser/pegen.h' line='312' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-577'/>
       <parameter type-id='type-id-1108'/>
       <return type-id='type-id-512'/>
     </function-decl>
-    <function-decl name='_PyPegen_get_values' filepath='Parser/pegen.h' line='312' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_PyPegen_get_values' filepath='Parser/pegen.h' line='313' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-577'/>
       <parameter type-id='type-id-1108'/>
       <return type-id='type-id-512'/>
     </function-decl>
-    <function-decl name='_PyPegen_key_pattern_pair' filepath='Parser/pegen.h' line='313' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_PyPegen_key_pattern_pair' filepath='Parser/pegen.h' line='314' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-577'/>
       <parameter type-id='type-id-511'/>
       <parameter type-id='type-id-459'/>
       <return type-id='type-id-1121'/>
     </function-decl>
-    <function-decl name='_PyPegen_get_pattern_keys' filepath='Parser/pegen.h' line='314' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_PyPegen_get_pattern_keys' filepath='Parser/pegen.h' line='315' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-577'/>
       <parameter type-id='type-id-1108'/>
       <return type-id='type-id-512'/>
     </function-decl>
-    <function-decl name='_PyPegen_get_patterns' filepath='Parser/pegen.h' line='315' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_PyPegen_get_patterns' filepath='Parser/pegen.h' line='316' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-577'/>
       <parameter type-id='type-id-1108'/>
       <return type-id='type-id-562'/>
     </function-decl>
-    <function-decl name='_PyPegen_name_default_pair' filepath='Parser/pegen.h' line='316' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_PyPegen_name_default_pair' filepath='Parser/pegen.h' line='317' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-577'/>
       <parameter type-id='type-id-576'/>
       <parameter type-id='type-id-511'/>
       <parameter type-id='type-id-578'/>
       <return type-id='type-id-1124'/>
     </function-decl>
-    <function-decl name='_PyPegen_slash_with_default' filepath='Parser/pegen.h' line='317' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_PyPegen_slash_with_default' filepath='Parser/pegen.h' line='318' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-577'/>
       <parameter type-id='type-id-574'/>
       <parameter type-id='type-id-1108'/>
       <return type-id='type-id-1126'/>
     </function-decl>
-    <function-decl name='_PyPegen_star_etc' filepath='Parser/pegen.h' line='318' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_PyPegen_star_etc' filepath='Parser/pegen.h' line='319' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-577'/>
       <parameter type-id='type-id-576'/>
       <parameter type-id='type-id-1108'/>
       <parameter type-id='type-id-576'/>
       <return type-id='type-id-1127'/>
     </function-decl>
-    <function-decl name='_PyPegen_make_arguments' filepath='Parser/pegen.h' line='319' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_PyPegen_make_arguments' filepath='Parser/pegen.h' line='320' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-577'/>
       <parameter type-id='type-id-574'/>
       <parameter type-id='type-id-1126'/>
@@ -18819,11 +18835,11 @@
       <parameter type-id='type-id-1127'/>
       <return type-id='type-id-535'/>
     </function-decl>
-    <function-decl name='_PyPegen_empty_arguments' filepath='Parser/pegen.h' line='321' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_PyPegen_empty_arguments' filepath='Parser/pegen.h' line='322' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-577'/>
       <return type-id='type-id-535'/>
     </function-decl>
-    <function-decl name='_PyPegen_formatted_value' filepath='Parser/pegen.h' line='322' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_PyPegen_formatted_value' filepath='Parser/pegen.h' line='323' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-577'/>
       <parameter type-id='type-id-511'/>
       <parameter type-id='type-id-578'/>
@@ -18837,40 +18853,40 @@
       <parameter type-id='type-id-572'/>
       <return type-id='type-id-511'/>
     </function-decl>
-    <function-decl name='_PyPegen_augoperator' filepath='Parser/pegen.h' line='324' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_PyPegen_augoperator' filepath='Parser/pegen.h' line='325' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-577'/>
       <parameter type-id='type-id-539'/>
       <return type-id='type-id-1119'/>
     </function-decl>
-    <function-decl name='_PyPegen_function_def_decorators' filepath='Parser/pegen.h' line='325' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_PyPegen_function_def_decorators' filepath='Parser/pegen.h' line='326' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-577'/>
       <parameter type-id='type-id-512'/>
       <parameter type-id='type-id-461'/>
       <return type-id='type-id-461'/>
     </function-decl>
-    <function-decl name='_PyPegen_class_def_decorators' filepath='Parser/pegen.h' line='326' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_PyPegen_class_def_decorators' filepath='Parser/pegen.h' line='327' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-577'/>
       <parameter type-id='type-id-512'/>
       <parameter type-id='type-id-461'/>
       <return type-id='type-id-461'/>
     </function-decl>
-    <function-decl name='_PyPegen_keyword_or_starred' filepath='Parser/pegen.h' line='327' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_PyPegen_keyword_or_starred' filepath='Parser/pegen.h' line='328' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-577'/>
       <parameter type-id='type-id-22'/>
       <parameter type-id='type-id-8'/>
       <return type-id='type-id-1123'/>
     </function-decl>
-    <function-decl name='_PyPegen_seq_extract_starred_exprs' filepath='Parser/pegen.h' line='328' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_PyPegen_seq_extract_starred_exprs' filepath='Parser/pegen.h' line='329' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-577'/>
       <parameter type-id='type-id-1108'/>
       <return type-id='type-id-512'/>
     </function-decl>
-    <function-decl name='_PyPegen_seq_delete_starred_exprs' filepath='Parser/pegen.h' line='329' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_PyPegen_seq_delete_starred_exprs' filepath='Parser/pegen.h' line='330' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-577'/>
       <parameter type-id='type-id-1108'/>
       <return type-id='type-id-538'/>
     </function-decl>
-    <function-decl name='_PyPegen_collect_call_seqs' filepath='Parser/pegen.h' line='330' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_PyPegen_collect_call_seqs' filepath='Parser/pegen.h' line='331' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-577'/>
       <parameter type-id='type-id-512'/>
       <parameter type-id='type-id-1108'/>
@@ -18881,22 +18897,22 @@
       <parameter type-id='type-id-572'/>
       <return type-id='type-id-511'/>
     </function-decl>
-    <function-decl name='_PyPegen_constant_from_token' filepath='Parser/pegen.h' line='333' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_PyPegen_constant_from_token' filepath='Parser/pegen.h' line='334' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-577'/>
       <parameter type-id='type-id-578'/>
       <return type-id='type-id-511'/>
     </function-decl>
-    <function-decl name='_PyPegen_decoded_constant_from_token' filepath='Parser/pegen.h' line='334' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_PyPegen_decoded_constant_from_token' filepath='Parser/pegen.h' line='335' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-577'/>
       <parameter type-id='type-id-578'/>
       <return type-id='type-id-511'/>
     </function-decl>
-    <function-decl name='_PyPegen_constant_from_string' filepath='Parser/pegen.h' line='335' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_PyPegen_constant_from_string' filepath='Parser/pegen.h' line='336' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-577'/>
       <parameter type-id='type-id-578'/>
       <return type-id='type-id-511'/>
     </function-decl>
-    <function-decl name='_PyPegen_concatenate_strings' filepath='Parser/pegen.h' line='336' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_PyPegen_concatenate_strings' filepath='Parser/pegen.h' line='337' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-577'/>
       <parameter type-id='type-id-512'/>
       <parameter type-id='type-id-8'/>
@@ -18906,39 +18922,39 @@
       <parameter type-id='type-id-572'/>
       <return type-id='type-id-511'/>
     </function-decl>
-    <function-decl name='_PyPegen_ensure_imaginary' filepath='Parser/pegen.h' line='338' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_PyPegen_ensure_imaginary' filepath='Parser/pegen.h' line='339' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-577'/>
       <parameter type-id='type-id-511'/>
       <return type-id='type-id-511'/>
     </function-decl>
-    <function-decl name='_PyPegen_ensure_real' filepath='Parser/pegen.h' line='339' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_PyPegen_ensure_real' filepath='Parser/pegen.h' line='340' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-577'/>
       <parameter type-id='type-id-511'/>
       <return type-id='type-id-511'/>
     </function-decl>
-    <function-decl name='_PyPegen_join_sequences' filepath='Parser/pegen.h' line='340' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_PyPegen_join_sequences' filepath='Parser/pegen.h' line='341' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-577'/>
       <parameter type-id='type-id-1108'/>
       <parameter type-id='type-id-1108'/>
       <return type-id='type-id-1108'/>
     </function-decl>
-    <function-decl name='_PyPegen_check_barry_as_flufl' filepath='Parser/pegen.h' line='341' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_PyPegen_check_barry_as_flufl' filepath='Parser/pegen.h' line='342' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-577'/>
       <parameter type-id='type-id-578'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='_PyPegen_check_legacy_stmt' filepath='Parser/pegen.h' line='342' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_PyPegen_check_legacy_stmt' filepath='Parser/pegen.h' line='343' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-577'/>
       <parameter type-id='type-id-511'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='_PyPegen_check_fstring_conversion' filepath='Parser/pegen.h' line='343' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_PyPegen_check_fstring_conversion' filepath='Parser/pegen.h' line='344' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-577'/>
       <parameter type-id='type-id-578'/>
       <parameter type-id='type-id-511'/>
       <return type-id='type-id-1125'/>
     </function-decl>
-    <function-decl name='_PyPegen_setup_full_format_spec' filepath='Parser/pegen.h' line='344' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_PyPegen_setup_full_format_spec' filepath='Parser/pegen.h' line='345' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-577'/>
       <parameter type-id='type-id-578'/>
       <parameter type-id='type-id-512'/>
@@ -18949,31 +18965,31 @@
       <parameter type-id='type-id-572'/>
       <return type-id='type-id-1125'/>
     </function-decl>
-    <function-decl name='_PyPegen_make_module' filepath='Parser/pegen.h' line='346' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_PyPegen_make_module' filepath='Parser/pegen.h' line='347' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-577'/>
       <parameter type-id='type-id-509'/>
       <return type-id='type-id-477'/>
     </function-decl>
-    <function-decl name='_PyPegen_arguments_parsing_error' filepath='Parser/pegen.h' line='347' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_PyPegen_arguments_parsing_error' filepath='Parser/pegen.h' line='348' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-577'/>
       <parameter type-id='type-id-511'/>
       <return type-id='type-id-22'/>
     </function-decl>
-    <function-decl name='_PyPegen_get_last_comprehension_item' filepath='Parser/pegen.h' line='348' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_PyPegen_get_last_comprehension_item' filepath='Parser/pegen.h' line='349' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-1146'/>
       <return type-id='type-id-511'/>
     </function-decl>
-    <function-decl name='_PyPegen_nonparen_genexp_in_call' filepath='Parser/pegen.h' line='349' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_PyPegen_nonparen_genexp_in_call' filepath='Parser/pegen.h' line='350' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-577'/>
       <parameter type-id='type-id-511'/>
       <parameter type-id='type-id-1145'/>
       <return type-id='type-id-22'/>
     </function-decl>
-    <function-decl name='_PyPegen_interactive_exit' filepath='Parser/pegen.h' line='359' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_PyPegen_interactive_exit' filepath='Parser/pegen.h' line='360' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-577'/>
       <return type-id='type-id-509'/>
     </function-decl>
-    <function-decl name='_PyPegen_joined_str' filepath='Parser/pegen.h' line='362' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_PyPegen_joined_str' filepath='Parser/pegen.h' line='363' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-577'/>
       <parameter type-id='type-id-578'/>
       <parameter type-id='type-id-512'/>
@@ -19016,7 +19032,7 @@
       <parameter is-variadic='yes'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='_PyPegen_run_parser_from_file_pointer' filepath='Parser/pegen.h' line='355' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_PyPegen_run_parser_from_file_pointer' filepath='Parser/pegen.h' line='356' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-229'/>
       <parameter type-id='type-id-8'/>
       <parameter type-id='type-id-2'/>
@@ -19028,7 +19044,7 @@
       <parameter type-id='type-id-572'/>
       <return type-id='type-id-477'/>
     </function-decl>
-    <function-decl name='_PyPegen_run_parser_from_string' filepath='Parser/pegen.h' line='358' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_PyPegen_run_parser_from_string' filepath='Parser/pegen.h' line='359' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-12'/>
       <parameter type-id='type-id-8'/>
       <parameter type-id='type-id-2'/>
@@ -20032,41 +20048,41 @@
       </data-member>
     </class-decl>
     <typedef-decl name='PyVarObject' type-id='type-id-1263' filepath='./Include/object.h' line='199' column='1' id='type-id-321'/>
-    <typedef-decl name='unaryfunc' type-id='type-id-1264' filepath='./Include/object.h' line='305' column='1' id='type-id-1170'/>
-    <typedef-decl name='binaryfunc' type-id='type-id-1259' filepath='./Include/object.h' line='306' column='1' id='type-id-1168'/>
-    <typedef-decl name='ternaryfunc' type-id='type-id-1265' filepath='./Include/object.h' line='307' column='1' id='type-id-1169'/>
-    <typedef-decl name='inquiry' type-id='type-id-339' filepath='./Include/object.h' line='308' column='1' id='type-id-396'/>
-    <typedef-decl name='lenfunc' type-id='type-id-1266' filepath='./Include/object.h' line='309' column='1' id='type-id-1173'/>
-    <typedef-decl name='ssizeargfunc' type-id='type-id-1267' filepath='./Include/object.h' line='310' column='1' id='type-id-1174'/>
-    <typedef-decl name='ssizeobjargproc' type-id='type-id-1268' filepath='./Include/object.h' line='312' column='1' id='type-id-1175'/>
-    <typedef-decl name='objobjargproc' type-id='type-id-1269' filepath='./Include/object.h' line='314' column='1' id='type-id-1179'/>
-    <typedef-decl name='objobjproc' type-id='type-id-1270' filepath='./Include/object.h' line='316' column='1' id='type-id-1176'/>
-    <typedef-decl name='visitproc' type-id='type-id-236' filepath='./Include/object.h' line='317' column='1' id='type-id-341'/>
-    <typedef-decl name='traverseproc' type-id='type-id-1271' filepath='./Include/object.h' line='318' column='1' id='type-id-395'/>
-    <typedef-decl name='freefunc' type-id='type-id-769' filepath='./Include/object.h' line='321' column='1' id='type-id-397'/>
-    <typedef-decl name='destructor' type-id='type-id-312' filepath='./Include/object.h' line='322' column='1' id='type-id-335'/>
-    <typedef-decl name='getattrfunc' type-id='type-id-1272' filepath='./Include/object.h' line='323' column='1' id='type-id-1188'/>
-    <typedef-decl name='getattrofunc' type-id='type-id-1259' filepath='./Include/object.h' line='324' column='1' id='type-id-1196'/>
-    <typedef-decl name='setattrfunc' type-id='type-id-1273' filepath='./Include/object.h' line='325' column='1' id='type-id-1189'/>
-    <typedef-decl name='setattrofunc' type-id='type-id-1269' filepath='./Include/object.h' line='326' column='1' id='type-id-1197'/>
-    <typedef-decl name='reprfunc' type-id='type-id-1264' filepath='./Include/object.h' line='327' column='1' id='type-id-1191'/>
-    <typedef-decl name='hashfunc' type-id='type-id-1274' filepath='./Include/object.h' line='328' column='1' id='type-id-1195'/>
-    <typedef-decl name='richcmpfunc' type-id='type-id-1275' filepath='./Include/object.h' line='329' column='1' id='type-id-1199'/>
-    <typedef-decl name='getiterfunc' type-id='type-id-1264' filepath='./Include/object.h' line='330' column='1' id='type-id-1200'/>
-    <typedef-decl name='iternextfunc' type-id='type-id-1264' filepath='./Include/object.h' line='331' column='1' id='type-id-1201'/>
-    <typedef-decl name='descrgetfunc' type-id='type-id-1265' filepath='./Include/object.h' line='332' column='1' id='type-id-1202'/>
-    <typedef-decl name='descrsetfunc' type-id='type-id-1269' filepath='./Include/object.h' line='333' column='1' id='type-id-1203'/>
-    <typedef-decl name='initproc' type-id='type-id-1269' filepath='./Include/object.h' line='334' column='1' id='type-id-1204'/>
-    <typedef-decl name='newfunc' type-id='type-id-1276' filepath='./Include/object.h' line='335' column='1' id='type-id-1206'/>
-    <typedef-decl name='allocfunc' type-id='type-id-1277' filepath='./Include/object.h' line='336' column='1' id='type-id-1205'/>
-    <typedef-decl name='vectorcallfunc' type-id='type-id-1278' filepath='./Include/object.h' line='339' column='1' id='type-id-311'/>
-    <enum-decl name='PySendResult' naming-typedef-id='type-id-255' filepath='./Include/object.h' line='873' column='1' id='type-id-1279'>
+    <typedef-decl name='unaryfunc' type-id='type-id-1264' filepath='./Include/object.h' line='304' column='1' id='type-id-1170'/>
+    <typedef-decl name='binaryfunc' type-id='type-id-1259' filepath='./Include/object.h' line='305' column='1' id='type-id-1168'/>
+    <typedef-decl name='ternaryfunc' type-id='type-id-1265' filepath='./Include/object.h' line='306' column='1' id='type-id-1169'/>
+    <typedef-decl name='inquiry' type-id='type-id-339' filepath='./Include/object.h' line='307' column='1' id='type-id-396'/>
+    <typedef-decl name='lenfunc' type-id='type-id-1266' filepath='./Include/object.h' line='308' column='1' id='type-id-1173'/>
+    <typedef-decl name='ssizeargfunc' type-id='type-id-1267' filepath='./Include/object.h' line='309' column='1' id='type-id-1174'/>
+    <typedef-decl name='ssizeobjargproc' type-id='type-id-1268' filepath='./Include/object.h' line='311' column='1' id='type-id-1175'/>
+    <typedef-decl name='objobjargproc' type-id='type-id-1269' filepath='./Include/object.h' line='313' column='1' id='type-id-1179'/>
+    <typedef-decl name='objobjproc' type-id='type-id-1270' filepath='./Include/object.h' line='315' column='1' id='type-id-1176'/>
+    <typedef-decl name='visitproc' type-id='type-id-236' filepath='./Include/object.h' line='316' column='1' id='type-id-341'/>
+    <typedef-decl name='traverseproc' type-id='type-id-1271' filepath='./Include/object.h' line='317' column='1' id='type-id-395'/>
+    <typedef-decl name='freefunc' type-id='type-id-769' filepath='./Include/object.h' line='320' column='1' id='type-id-397'/>
+    <typedef-decl name='destructor' type-id='type-id-312' filepath='./Include/object.h' line='321' column='1' id='type-id-335'/>
+    <typedef-decl name='getattrfunc' type-id='type-id-1272' filepath='./Include/object.h' line='322' column='1' id='type-id-1188'/>
+    <typedef-decl name='getattrofunc' type-id='type-id-1259' filepath='./Include/object.h' line='323' column='1' id='type-id-1196'/>
+    <typedef-decl name='setattrfunc' type-id='type-id-1273' filepath='./Include/object.h' line='324' column='1' id='type-id-1189'/>
+    <typedef-decl name='setattrofunc' type-id='type-id-1269' filepath='./Include/object.h' line='325' column='1' id='type-id-1197'/>
+    <typedef-decl name='reprfunc' type-id='type-id-1264' filepath='./Include/object.h' line='326' column='1' id='type-id-1191'/>
+    <typedef-decl name='hashfunc' type-id='type-id-1274' filepath='./Include/object.h' line='327' column='1' id='type-id-1195'/>
+    <typedef-decl name='richcmpfunc' type-id='type-id-1275' filepath='./Include/object.h' line='328' column='1' id='type-id-1199'/>
+    <typedef-decl name='getiterfunc' type-id='type-id-1264' filepath='./Include/object.h' line='329' column='1' id='type-id-1200'/>
+    <typedef-decl name='iternextfunc' type-id='type-id-1264' filepath='./Include/object.h' line='330' column='1' id='type-id-1201'/>
+    <typedef-decl name='descrgetfunc' type-id='type-id-1265' filepath='./Include/object.h' line='331' column='1' id='type-id-1202'/>
+    <typedef-decl name='descrsetfunc' type-id='type-id-1269' filepath='./Include/object.h' line='332' column='1' id='type-id-1203'/>
+    <typedef-decl name='initproc' type-id='type-id-1269' filepath='./Include/object.h' line='333' column='1' id='type-id-1204'/>
+    <typedef-decl name='newfunc' type-id='type-id-1276' filepath='./Include/object.h' line='334' column='1' id='type-id-1206'/>
+    <typedef-decl name='allocfunc' type-id='type-id-1277' filepath='./Include/object.h' line='335' column='1' id='type-id-1205'/>
+    <typedef-decl name='vectorcallfunc' type-id='type-id-1278' filepath='./Include/object.h' line='338' column='1' id='type-id-311'/>
+    <enum-decl name='PySendResult' naming-typedef-id='type-id-255' filepath='./Include/object.h' line='872' column='1' id='type-id-1279'>
       <underlying-type type-id='type-id-24'/>
       <enumerator name='PYGEN_RETURN' value='0'/>
       <enumerator name='PYGEN_ERROR' value='-1'/>
       <enumerator name='PYGEN_NEXT' value='1'/>
     </enum-decl>
-    <typedef-decl name='PySendResult' type-id='type-id-1279' filepath='./Include/object.h' line='877' column='1' id='type-id-255'/>
+    <typedef-decl name='PySendResult' type-id='type-id-1279' filepath='./Include/object.h' line='876' column='1' id='type-id-255'/>
     <class-decl name='Py_buffer' size-in-bits='640' is-struct='yes' naming-typedef-id='type-id-243' visibility='default' filepath='./Include/pybuffer.h' line='20' column='1' id='type-id-1280'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='buf' type-id='type-id-22' visibility='default' filepath='./Include/pybuffer.h' line='21' column='1'/>
@@ -20762,25 +20778,25 @@
       <parameter type-id='type-id-47'/>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='PyLong_FromString' mangled-name='PyLong_FromString' filepath='./Include/longobject.h' line='74' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyLong_FromString'>
+    <function-decl name='PyLong_FromString' mangled-name='PyLong_FromString' filepath='./Include/longobject.h' line='91' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyLong_FromString'>
       <parameter type-id='type-id-12'/>
       <parameter type-id='type-id-239'/>
       <parameter type-id='type-id-8'/>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='PyOS_strtoul' mangled-name='PyOS_strtoul' filepath='./Include/longobject.h' line='79' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyOS_strtoul'>
+    <function-decl name='PyOS_strtoul' mangled-name='PyOS_strtoul' filepath='./Include/longobject.h' line='96' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyOS_strtoul'>
       <parameter type-id='type-id-12'/>
       <parameter type-id='type-id-239'/>
       <parameter type-id='type-id-8'/>
       <return type-id='type-id-28'/>
     </function-decl>
-    <function-decl name='PyOS_strtol' mangled-name='PyOS_strtol' filepath='./Include/longobject.h' line='80' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyOS_strtol'>
+    <function-decl name='PyOS_strtol' mangled-name='PyOS_strtol' filepath='./Include/longobject.h' line='97' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyOS_strtol'>
       <parameter type-id='type-id-12'/>
       <parameter type-id='type-id-239'/>
       <parameter type-id='type-id-8'/>
       <return type-id='type-id-47'/>
     </function-decl>
-    <function-decl name='_Py_Dealloc' mangled-name='_Py_Dealloc' filepath='./Include/object.h' line='611' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_Dealloc'>
+    <function-decl name='_Py_Dealloc' mangled-name='_Py_Dealloc' filepath='./Include/object.h' line='610' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_Dealloc'>
       <parameter type-id='type-id-2'/>
       <return type-id='type-id-46'/>
     </function-decl>
@@ -20879,19 +20895,19 @@
       <parameter type-id='type-id-12'/>
       <return type-id='type-id-19'/>
     </function-decl>
-    <function-decl name='_Pypegen_raise_decode_error' filepath='Parser/pegen.h' line='163' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_Pypegen_raise_decode_error' filepath='Parser/pegen.h' line='164' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-577'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='_PyPegen_raise_tokenizer_init_error' filepath='Parser/pegen.h' line='164' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_PyPegen_raise_tokenizer_init_error' filepath='Parser/pegen.h' line='165' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-2'/>
       <return type-id='type-id-46'/>
     </function-decl>
-    <function-decl name='_Pypegen_tokenizer_error' filepath='Parser/pegen.h' line='165' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_Pypegen_tokenizer_error' filepath='Parser/pegen.h' line='166' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-577'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='_PyPegen_raise_error' filepath='Parser/pegen.h' line='166' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_PyPegen_raise_error' filepath='Parser/pegen.h' line='167' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-577'/>
       <parameter type-id='type-id-2'/>
       <parameter type-id='type-id-8'/>
@@ -20899,7 +20915,7 @@
       <parameter is-variadic='yes'/>
       <return type-id='type-id-22'/>
     </function-decl>
-    <function-decl name='_PyPegen_raise_error_known_location' filepath='Parser/pegen.h' line='167' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_PyPegen_raise_error_known_location' filepath='Parser/pegen.h' line='168' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-577'/>
       <parameter type-id='type-id-2'/>
       <parameter type-id='type-id-14'/>
@@ -20910,12 +20926,12 @@
       <parameter type-id='type-id-306'/>
       <return type-id='type-id-22'/>
     </function-decl>
-    <function-decl name='_Pypegen_set_syntax_error' filepath='Parser/pegen.h' line='171' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_Pypegen_set_syntax_error' filepath='Parser/pegen.h' line='172' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-577'/>
       <parameter type-id='type-id-578'/>
       <return type-id='type-id-46'/>
     </function-decl>
-    <function-decl name='_PyPegen_parse' filepath='Parser/pegen.h' line='365' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_PyPegen_parse' filepath='Parser/pegen.h' line='366' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-577'/>
       <return type-id='type-id-22'/>
     </function-decl>
@@ -21077,7 +21093,7 @@
       <parameter is-variadic='yes'/>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='PyObject_Str' mangled-name='PyObject_Str' filepath='./Include/object.h' line='403' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyObject_Str'>
+    <function-decl name='PyObject_Str' mangled-name='PyObject_Str' filepath='./Include/object.h' line='402' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyObject_Str'>
       <parameter type-id='type-id-2'/>
       <return type-id='type-id-2'/>
     </function-decl>
@@ -21267,7 +21283,7 @@
       <parameter is-variadic='yes'/>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='PyObject_GetAttr' mangled-name='PyObject_GetAttr' filepath='./Include/object.h' line='411' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyObject_GetAttr'>
+    <function-decl name='PyObject_GetAttr' mangled-name='PyObject_GetAttr' filepath='./Include/object.h' line='410' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyObject_GetAttr'>
       <parameter type-id='type-id-2'/>
       <parameter type-id='type-id-2'/>
       <return type-id='type-id-2'/>
@@ -21360,7 +21376,7 @@
       <parameter type-id='type-id-47'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='PyInit__ast' mangled-name='PyInit__ast' filepath='Python/Python-ast.c' line='13062' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyInit__ast'>
+    <function-decl name='PyInit__ast' mangled-name='PyInit__ast' filepath='Python/Python-ast.c' line='13140' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyInit__ast'>
       <return type-id='type-id-2'/>
     </function-decl>
   </abi-instr>
@@ -21375,6 +21391,11 @@
       <parameter type-id='type-id-2'/>
       <parameter type-id='type-id-1'/>
       <return type-id='type-id-8'/>
+    </function-decl>
+    <function-decl name='_PyPegen_byte_offset_to_character_offset_raw' filepath='Python/../Parser/pegen.h' line='154' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-12'/>
+      <parameter type-id='type-id-14'/>
+      <return type-id='type-id-14'/>
     </function-decl>
     <function-decl name='_PyTokenizer_FromReadline' filepath='Python/../Parser/tokenizer.h' line='141' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-2'/>
@@ -21673,11 +21694,11 @@
       <parameter type-id='type-id-2'/>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='PyInterpreterState_ThreadHead' mangled-name='PyInterpreterState_ThreadHead' filepath='./Include/cpython/pystate.h' line='317' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyInterpreterState_ThreadHead'>
+    <function-decl name='PyInterpreterState_ThreadHead' mangled-name='PyInterpreterState_ThreadHead' filepath='./Include/cpython/pystate.h' line='329' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyInterpreterState_ThreadHead'>
       <parameter type-id='type-id-20'/>
       <return type-id='type-id-177'/>
     </function-decl>
-    <function-decl name='PyThreadState_Next' mangled-name='PyThreadState_Next' filepath='./Include/cpython/pystate.h' line='318' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyThreadState_Next'>
+    <function-decl name='PyThreadState_Next' mangled-name='PyThreadState_Next' filepath='./Include/cpython/pystate.h' line='330' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyThreadState_Next'>
       <parameter type-id='type-id-177'/>
       <return type-id='type-id-177'/>
     </function-decl>
@@ -21704,11 +21725,11 @@
       <parameter type-id='type-id-2'/>
       <return type-id='type-id-46'/>
     </function-decl>
-    <function-decl name='_Py_MakeCoro' filepath='./Include/internal/pycore_ceval.h' line='153' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_Py_MakeCoro' filepath='./Include/internal/pycore_ceval.h' line='154' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-310'/>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='_Py_HandlePending' filepath='./Include/internal/pycore_ceval.h' line='155' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_Py_HandlePending' filepath='./Include/internal/pycore_ceval.h' line='156' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-177'/>
       <return type-id='type-id-8'/>
     </function-decl>
@@ -21789,7 +21810,7 @@
       <parameter type-id='type-id-859'/>
       <return type-id='type-id-46'/>
     </function-decl>
-    <function-decl name='_Py_Instrument' filepath='./Include/internal/pycore_code.h' line='486' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_Py_Instrument' filepath='./Include/internal/pycore_code.h' line='488' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-328'/>
       <parameter type-id='type-id-20'/>
       <return type-id='type-id-8'/>
@@ -21814,21 +21835,21 @@
       <parameter type-id='type-id-2'/>
       <return type-id='type-id-46'/>
     </function-decl>
-    <function-decl name='_PyFrame_GetLocals' filepath='./Include/internal/pycore_frame.h' line='230' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_PyFrame_GetLocals' filepath='./Include/internal/pycore_frame.h' line='235' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-374'/>
       <parameter type-id='type-id-8'/>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='_PyFrame_FastToLocalsWithError' filepath='./Include/internal/pycore_frame.h' line='233' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_PyFrame_FastToLocalsWithError' filepath='./Include/internal/pycore_frame.h' line='238' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-374'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='_PyThreadState_PushFrame' filepath='./Include/internal/pycore_frame.h' line='251' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_PyThreadState_PushFrame' filepath='./Include/internal/pycore_frame.h' line='256' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-177'/>
       <parameter type-id='type-id-19'/>
       <return type-id='type-id-374'/>
     </function-decl>
-    <function-decl name='_PyThreadState_PopFrame' filepath='./Include/internal/pycore_frame.h' line='253' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_PyThreadState_PopFrame' filepath='./Include/internal/pycore_frame.h' line='258' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-177'/>
       <parameter type-id='type-id-374'/>
       <return type-id='type-id-46'/>
@@ -21944,7 +21965,7 @@
       <parameter type-id='type-id-14'/>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='_PySuper_Lookup' filepath='./Include/internal/pycore_typeobject.h' line='142' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_PySuper_Lookup' filepath='./Include/internal/pycore_typeobject.h' line='144' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-1'/>
       <parameter type-id='type-id-2'/>
       <parameter type-id='type-id-2'/>
@@ -22010,30 +22031,30 @@
     <function-decl name='PyEval_GetFrame' mangled-name='PyEval_GetFrame' filepath='Python/ceval.c' line='2276' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyEval_GetFrame'>
       <return type-id='type-id-365'/>
     </function-decl>
-    <function-decl name='_PyEval_GetBuiltinId' mangled-name='_PyEval_GetBuiltinId' filepath='Python/ceval.c' line='2322' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyEval_GetBuiltinId'>
-      <parameter type-id='type-id-309' name='name' filepath='Python/ceval.c' line='2322' column='1'/>
+    <function-decl name='_PyEval_GetBuiltinId' mangled-name='_PyEval_GetBuiltinId' filepath='Python/ceval.c' line='2319' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyEval_GetBuiltinId'>
+      <parameter type-id='type-id-309' name='name' filepath='Python/ceval.c' line='2319' column='1'/>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='PyEval_GetLocals' mangled-name='PyEval_GetLocals' filepath='Python/ceval.c' line='2328' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyEval_GetLocals'>
+    <function-decl name='PyEval_GetLocals' mangled-name='PyEval_GetLocals' filepath='Python/ceval.c' line='2325' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyEval_GetLocals'>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='PyEval_GetFuncName' mangled-name='PyEval_GetFuncName' filepath='Python/ceval.c' line='2390' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyEval_GetFuncName'>
-      <parameter type-id='type-id-2' name='func' filepath='Python/ceval.c' line='2390' column='1'/>
+    <function-decl name='PyEval_GetFuncName' mangled-name='PyEval_GetFuncName' filepath='Python/ceval.c' line='2387' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyEval_GetFuncName'>
+      <parameter type-id='type-id-2' name='func' filepath='Python/ceval.c' line='2387' column='1'/>
       <return type-id='type-id-12'/>
     </function-decl>
-    <function-decl name='PyEval_GetFuncDesc' mangled-name='PyEval_GetFuncDesc' filepath='Python/ceval.c' line='2403' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyEval_GetFuncDesc'>
-      <parameter type-id='type-id-2' name='func' filepath='Python/ceval.c' line='2403' column='1'/>
+    <function-decl name='PyEval_GetFuncDesc' mangled-name='PyEval_GetFuncDesc' filepath='Python/ceval.c' line='2400' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyEval_GetFuncDesc'>
+      <parameter type-id='type-id-2' name='func' filepath='Python/ceval.c' line='2400' column='1'/>
       <return type-id='type-id-12'/>
     </function-decl>
-    <function-decl name='PyUnstable_Eval_RequestCodeExtraIndex' mangled-name='PyUnstable_Eval_RequestCodeExtraIndex' filepath='Python/ceval.c' line='2775' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyUnstable_Eval_RequestCodeExtraIndex'>
-      <parameter type-id='type-id-397' name='free' filepath='Python/ceval.c' line='2775' column='1'/>
+    <function-decl name='PyUnstable_Eval_RequestCodeExtraIndex' mangled-name='PyUnstable_Eval_RequestCodeExtraIndex' filepath='Python/ceval.c' line='2771' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyUnstable_Eval_RequestCodeExtraIndex'>
+      <parameter type-id='type-id-397' name='free' filepath='Python/ceval.c' line='2771' column='1'/>
       <return type-id='type-id-14'/>
     </function-decl>
-    <function-decl name='Py_EnterRecursiveCall' mangled-name='Py_EnterRecursiveCall' filepath='Python/ceval.c' line='2791' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='Py_EnterRecursiveCall'>
-      <parameter type-id='type-id-12' name='where' filepath='Python/ceval.c' line='2791' column='1'/>
+    <function-decl name='Py_EnterRecursiveCall' mangled-name='Py_EnterRecursiveCall' filepath='Python/ceval.c' line='2787' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='Py_EnterRecursiveCall'>
+      <parameter type-id='type-id-12' name='where' filepath='Python/ceval.c' line='2787' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='Py_LeaveRecursiveCall' mangled-name='Py_LeaveRecursiveCall' filepath='Python/ceval.c' line='2796' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='Py_LeaveRecursiveCall'>
+    <function-decl name='Py_LeaveRecursiveCall' mangled-name='Py_LeaveRecursiveCall' filepath='Python/ceval.c' line='2792' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='Py_LeaveRecursiveCall'>
       <return type-id='type-id-46'/>
     </function-decl>
   </abi-instr>
@@ -22072,7 +22093,7 @@
       <parameter type-id='type-id-1349'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='_PyThreadState_SwapNoGIL' filepath='./Include/internal/pycore_ceval.h' line='105' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_PyThreadState_SwapNoGIL' filepath='./Include/internal/pycore_ceval.h' line='106' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-177'/>
       <return type-id='type-id-177'/>
     </function-decl>
@@ -22301,8 +22322,8 @@
     </function-decl>
   </abi-instr>
   <abi-instr address-size='64' path='Python/compile.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
-    <array-type-def dimensions='1' type-id='type-id-1357' size-in-bits='1344' id='type-id-1358'>
-      <subrange length='21' type-id='type-id-28' id='type-id-679'/>
+    <array-type-def dimensions='1' type-id='type-id-1357' size-in-bits='1472' id='type-id-1358'>
+      <subrange length='23' type-id='type-id-28' id='type-id-681'/>
     </array-type-def>
     <array-type-def dimensions='1' type-id='type-id-1359' size-in-bits='288' id='type-id-1360'>
       <subrange length='9' type-id='type-id-28' id='type-id-704'/>
@@ -22460,11 +22481,11 @@
       </data-member>
     </class-decl>
     <typedef-decl name='_PyCfgJumpTargetLabel' type-id='type-id-1380' filepath='./Include/internal/pycore_flowgraph.h' line='25' column='1' id='type-id-1379'/>
-    <class-decl name='_PyCfgExceptStack' size-in-bits='1408' is-struct='yes' naming-typedef-id='type-id-1381' visibility='default' filepath='./Include/internal/pycore_flowgraph.h' line='28' column='1' id='type-id-1382'>
+    <class-decl name='_PyCfgExceptStack' size-in-bits='1536' is-struct='yes' naming-typedef-id='type-id-1381' visibility='default' filepath='./Include/internal/pycore_flowgraph.h' line='28' column='1' id='type-id-1382'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='handlers' type-id='type-id-1358' visibility='default' filepath='./Include/internal/pycore_flowgraph.h' line='29' column='1'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='1344'>
+      <data-member access='public' layout-offset-in-bits='1472'>
         <var-decl name='depth' type-id='type-id-8' visibility='default' filepath='./Include/internal/pycore_flowgraph.h' line='30' column='1'/>
       </data-member>
     </class-decl>
@@ -22816,41 +22837,41 @@
       <parameter type-id='type-id-1396'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='PyCompile_OpcodeStackEffectWithJump' mangled-name='PyCompile_OpcodeStackEffectWithJump' filepath='Python/compile.c' line='880' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyCompile_OpcodeStackEffectWithJump'>
-      <parameter type-id='type-id-8' name='opcode' filepath='Python/compile.c' line='880' column='1'/>
-      <parameter type-id='type-id-8' name='oparg' filepath='Python/compile.c' line='880' column='1'/>
-      <parameter type-id='type-id-8' name='jump' filepath='Python/compile.c' line='880' column='1'/>
+    <function-decl name='PyCompile_OpcodeStackEffectWithJump' mangled-name='PyCompile_OpcodeStackEffectWithJump' filepath='Python/compile.c' line='881' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyCompile_OpcodeStackEffectWithJump'>
+      <parameter type-id='type-id-8' name='opcode' filepath='Python/compile.c' line='881' column='1'/>
+      <parameter type-id='type-id-8' name='oparg' filepath='Python/compile.c' line='881' column='1'/>
+      <parameter type-id='type-id-8' name='jump' filepath='Python/compile.c' line='881' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='_PyCompile_CodeGen' mangled-name='_PyCompile_CodeGen' filepath='Python/compile.c' line='7961' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyCompile_CodeGen'>
-      <parameter type-id='type-id-2' name='ast' filepath='Python/compile.c' line='7961' column='1'/>
-      <parameter type-id='type-id-2' name='filename' filepath='Python/compile.c' line='7961' column='1'/>
-      <parameter type-id='type-id-208' name='pflags' filepath='Python/compile.c' line='7961' column='1'/>
-      <parameter type-id='type-id-8' name='optimize' filepath='Python/compile.c' line='7962' column='1'/>
-      <parameter type-id='type-id-8' name='compile_mode' filepath='Python/compile.c' line='7962' column='1'/>
+    <function-decl name='_PyCompile_CodeGen' mangled-name='_PyCompile_CodeGen' filepath='Python/compile.c' line='7978' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyCompile_CodeGen'>
+      <parameter type-id='type-id-2' name='ast' filepath='Python/compile.c' line='7978' column='1'/>
+      <parameter type-id='type-id-2' name='filename' filepath='Python/compile.c' line='7978' column='1'/>
+      <parameter type-id='type-id-208' name='pflags' filepath='Python/compile.c' line='7978' column='1'/>
+      <parameter type-id='type-id-8' name='optimize' filepath='Python/compile.c' line='7979' column='1'/>
+      <parameter type-id='type-id-8' name='compile_mode' filepath='Python/compile.c' line='7979' column='1'/>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='_PyCompile_OptimizeCfg' mangled-name='_PyCompile_OptimizeCfg' filepath='Python/compile.c' line='8046' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyCompile_OptimizeCfg'>
-      <parameter type-id='type-id-2' name='instructions' filepath='Python/compile.c' line='8046' column='1'/>
-      <parameter type-id='type-id-2' name='consts' filepath='Python/compile.c' line='8046' column='1'/>
-      <parameter type-id='type-id-8' name='nlocals' filepath='Python/compile.c' line='8046' column='1'/>
+    <function-decl name='_PyCompile_OptimizeCfg' mangled-name='_PyCompile_OptimizeCfg' filepath='Python/compile.c' line='8063' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyCompile_OptimizeCfg'>
+      <parameter type-id='type-id-2' name='instructions' filepath='Python/compile.c' line='8063' column='1'/>
+      <parameter type-id='type-id-2' name='consts' filepath='Python/compile.c' line='8063' column='1'/>
+      <parameter type-id='type-id-8' name='nlocals' filepath='Python/compile.c' line='8063' column='1'/>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='_PyCfg_JumpLabelsToTargets' filepath='Python/compile.c' line='8070' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_PyCfg_JumpLabelsToTargets' filepath='Python/compile.c' line='8087' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-1405'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='_PyCompile_Assemble' mangled-name='_PyCompile_Assemble' filepath='Python/compile.c' line='8073' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyCompile_Assemble'>
-      <parameter type-id='type-id-1403' name='umd' filepath='Python/compile.c' line='8073' column='1'/>
-      <parameter type-id='type-id-2' name='filename' filepath='Python/compile.c' line='8073' column='1'/>
-      <parameter type-id='type-id-2' name='instructions' filepath='Python/compile.c' line='8074' column='1'/>
+    <function-decl name='_PyCompile_Assemble' mangled-name='_PyCompile_Assemble' filepath='Python/compile.c' line='8090' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyCompile_Assemble'>
+      <parameter type-id='type-id-1403' name='umd' filepath='Python/compile.c' line='8090' column='1'/>
+      <parameter type-id='type-id-2' name='filename' filepath='Python/compile.c' line='8090' column='1'/>
+      <parameter type-id='type-id-2' name='instructions' filepath='Python/compile.c' line='8091' column='1'/>
       <return type-id='type-id-328'/>
     </function-decl>
-    <function-decl name='PyCode_Optimize' mangled-name='PyCode_Optimize' filepath='Python/compile.c' line='8140' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyCode_Optimize'>
-      <parameter type-id='type-id-2' name='code' filepath='Python/compile.c' line='8140' column='1'/>
-      <parameter type-id='type-id-2' name='_unused_consts' filepath='Python/compile.c' line='8140' column='1'/>
-      <parameter type-id='type-id-2' name='_unused_names' filepath='Python/compile.c' line='8141' column='1'/>
-      <parameter type-id='type-id-2' name='_unused_lnotab_obj' filepath='Python/compile.c' line='8141' column='1'/>
+    <function-decl name='PyCode_Optimize' mangled-name='PyCode_Optimize' filepath='Python/compile.c' line='8157' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyCode_Optimize'>
+      <parameter type-id='type-id-2' name='code' filepath='Python/compile.c' line='8157' column='1'/>
+      <parameter type-id='type-id-2' name='_unused_consts' filepath='Python/compile.c' line='8157' column='1'/>
+      <parameter type-id='type-id-2' name='_unused_names' filepath='Python/compile.c' line='8158' column='1'/>
+      <parameter type-id='type-id-2' name='_unused_lnotab_obj' filepath='Python/compile.c' line='8158' column='1'/>
       <return type-id='type-id-2'/>
     </function-decl>
     <function-decl name='_PyOpcode_num_popped' filepath='Python/opcode_metadata.h' line='7' column='1' visibility='default' binding='global' size-in-bits='64'>
@@ -22964,7 +22985,7 @@
       <parameter type-id='type-id-328'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <var-decl name='_Py_next_func_version' type-id='type-id-352' visibility='default' filepath='./Include/internal/pycore_code.h' line='463' column='1'/>
+    <var-decl name='_Py_next_func_version' type-id='type-id-352' visibility='default' filepath='./Include/internal/pycore_code.h' line='465' column='1'/>
   </abi-instr>
   <abi-instr address-size='64' path='Python/errors.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
     <function-decl name='_Py_fopen_obj' mangled-name='_Py_fopen_obj' filepath='./Include/cpython/fileutils.h' line='6' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_fopen_obj'>
@@ -23357,12 +23378,12 @@
       <parameter type-id='type-id-328'/>
       <return type-id='type-id-365'/>
     </function-decl>
-    <function-decl name='PyUnstable_InterpreterFrame_GetCode' mangled-name='PyUnstable_InterpreterFrame_GetCode' filepath='Python/frame.c' line='150' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyUnstable_InterpreterFrame_GetCode'>
-      <parameter type-id='type-id-375' name='frame' filepath='Python/frame.c' line='150' column='1'/>
+    <function-decl name='PyUnstable_InterpreterFrame_GetCode' mangled-name='PyUnstable_InterpreterFrame_GetCode' filepath='Python/frame.c' line='158' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyUnstable_InterpreterFrame_GetCode'>
+      <parameter type-id='type-id-375' name='frame' filepath='Python/frame.c' line='158' column='1'/>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='PyUnstable_InterpreterFrame_GetLasti' mangled-name='PyUnstable_InterpreterFrame_GetLasti' filepath='Python/frame.c' line='158' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyUnstable_InterpreterFrame_GetLasti'>
-      <parameter type-id='type-id-375' name='frame' filepath='Python/frame.c' line='158' column='1'/>
+    <function-decl name='PyUnstable_InterpreterFrame_GetLasti' mangled-name='PyUnstable_InterpreterFrame_GetLasti' filepath='Python/frame.c' line='166' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyUnstable_InterpreterFrame_GetLasti'>
+      <parameter type-id='type-id-375' name='frame' filepath='Python/frame.c' line='166' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
   </abi-instr>
@@ -23431,43 +23452,43 @@
     <function-decl name='_Py_get_ntpath_toplevel' filepath='Python/frozen.c' line='81' column='1' visibility='default' binding='global' size-in-bits='64'>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='_Py_get_posixpath_toplevel' filepath='Python/frozen.c' line='83' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_Py_get_posixpath_toplevel' filepath='Python/frozen.c' line='82' column='1' visibility='default' binding='global' size-in-bits='64'>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='_Py_get_os_toplevel' filepath='Python/frozen.c' line='84' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_Py_get_os_toplevel' filepath='Python/frozen.c' line='83' column='1' visibility='default' binding='global' size-in-bits='64'>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='_Py_get_site_toplevel' filepath='Python/frozen.c' line='85' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_Py_get_site_toplevel' filepath='Python/frozen.c' line='84' column='1' visibility='default' binding='global' size-in-bits='64'>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='_Py_get_stat_toplevel' filepath='Python/frozen.c' line='86' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_Py_get_stat_toplevel' filepath='Python/frozen.c' line='85' column='1' visibility='default' binding='global' size-in-bits='64'>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='_Py_get_importlib_util_toplevel' filepath='Python/frozen.c' line='87' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_Py_get_importlib_util_toplevel' filepath='Python/frozen.c' line='86' column='1' visibility='default' binding='global' size-in-bits='64'>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='_Py_get_importlib_machinery_toplevel' filepath='Python/frozen.c' line='88' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_Py_get_importlib_machinery_toplevel' filepath='Python/frozen.c' line='87' column='1' visibility='default' binding='global' size-in-bits='64'>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='_Py_get_runpy_toplevel' filepath='Python/frozen.c' line='89' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_Py_get_runpy_toplevel' filepath='Python/frozen.c' line='88' column='1' visibility='default' binding='global' size-in-bits='64'>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='_Py_get___hello___toplevel' filepath='Python/frozen.c' line='93' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_Py_get___hello___toplevel' filepath='Python/frozen.c' line='89' column='1' visibility='default' binding='global' size-in-bits='64'>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='_Py_get___phello___toplevel' filepath='Python/frozen.c' line='95' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_Py_get___phello___toplevel' filepath='Python/frozen.c' line='90' column='1' visibility='default' binding='global' size-in-bits='64'>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='_Py_get___phello___ham_toplevel' filepath='Python/frozen.c' line='97' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_Py_get___phello___ham_toplevel' filepath='Python/frozen.c' line='91' column='1' visibility='default' binding='global' size-in-bits='64'>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='_Py_get___phello___ham_eggs_toplevel' filepath='Python/frozen.c' line='98' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_Py_get___phello___ham_eggs_toplevel' filepath='Python/frozen.c' line='92' column='1' visibility='default' binding='global' size-in-bits='64'>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='_Py_get___phello___spam_toplevel' filepath='Python/frozen.c' line='99' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_Py_get___phello___spam_toplevel' filepath='Python/frozen.c' line='93' column='1' visibility='default' binding='global' size-in-bits='64'>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='_Py_get_frozen_only_toplevel' filepath='Python/frozen.c' line='100' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_Py_get_frozen_only_toplevel' filepath='Python/frozen.c' line='94' column='1' visibility='default' binding='global' size-in-bits='64'>
       <return type-id='type-id-2'/>
     </function-decl>
   </abi-instr>
@@ -23544,107 +23565,123 @@
     </function-decl>
   </abi-instr>
   <abi-instr address-size='64' path='Python/getargs.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
-    <function-decl name='PyArg_Parse' mangled-name='PyArg_Parse' filepath='Python/getargs.c' line='99' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyArg_Parse'>
-      <parameter type-id='type-id-2' name='args' filepath='Python/getargs.c' line='99' column='1'/>
-      <parameter type-id='type-id-12' name='format' filepath='Python/getargs.c' line='99' column='1'/>
+    <function-decl name='PyThreadState_New' mangled-name='PyThreadState_New' filepath='./Include/pystate.h' line='48' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyThreadState_New'>
+      <parameter type-id='type-id-20'/>
+      <return type-id='type-id-177'/>
+    </function-decl>
+    <function-decl name='PyThreadState_Clear' mangled-name='PyThreadState_Clear' filepath='./Include/pystate.h' line='49' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyThreadState_Clear'>
+      <parameter type-id='type-id-177'/>
+      <return type-id='type-id-46'/>
+    </function-decl>
+    <function-decl name='PyThreadState_Delete' mangled-name='PyThreadState_Delete' filepath='./Include/pystate.h' line='50' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyThreadState_Delete'>
+      <parameter type-id='type-id-177'/>
+      <return type-id='type-id-46'/>
+    </function-decl>
+    <function-decl name='PyThreadState_Swap' mangled-name='PyThreadState_Swap' filepath='./Include/pystate.h' line='65' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyThreadState_Swap'>
+      <parameter type-id='type-id-177'/>
+      <return type-id='type-id-177'/>
+    </function-decl>
+    <function-decl name='PyArg_Parse' mangled-name='PyArg_Parse' filepath='Python/getargs.c' line='100' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyArg_Parse'>
+      <parameter type-id='type-id-2' name='args' filepath='Python/getargs.c' line='100' column='1'/>
+      <parameter type-id='type-id-12' name='format' filepath='Python/getargs.c' line='100' column='1'/>
       <parameter is-variadic='yes'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='_PyArg_Parse_SizeT' mangled-name='_PyArg_Parse_SizeT' filepath='Python/getargs.c' line='111' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyArg_Parse_SizeT'>
-      <parameter type-id='type-id-2' name='args' filepath='Python/getargs.c' line='111' column='1'/>
-      <parameter type-id='type-id-12' name='format' filepath='Python/getargs.c' line='111' column='1'/>
+    <function-decl name='_PyArg_Parse_SizeT' mangled-name='_PyArg_Parse_SizeT' filepath='Python/getargs.c' line='112' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyArg_Parse_SizeT'>
+      <parameter type-id='type-id-2' name='args' filepath='Python/getargs.c' line='112' column='1'/>
+      <parameter type-id='type-id-12' name='format' filepath='Python/getargs.c' line='112' column='1'/>
       <parameter is-variadic='yes'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='_PyArg_ParseStack' mangled-name='_PyArg_ParseStack' filepath='Python/getargs.c' line='149' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyArg_ParseStack'>
-      <parameter type-id='type-id-248' name='args' filepath='Python/getargs.c' line='149' column='1'/>
-      <parameter type-id='type-id-14' name='nargs' filepath='Python/getargs.c' line='149' column='1'/>
-      <parameter type-id='type-id-12' name='format' filepath='Python/getargs.c' line='149' column='1'/>
+    <function-decl name='_PyArg_ParseStack' mangled-name='_PyArg_ParseStack' filepath='Python/getargs.c' line='150' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyArg_ParseStack'>
+      <parameter type-id='type-id-248' name='args' filepath='Python/getargs.c' line='150' column='1'/>
+      <parameter type-id='type-id-14' name='nargs' filepath='Python/getargs.c' line='150' column='1'/>
+      <parameter type-id='type-id-12' name='format' filepath='Python/getargs.c' line='150' column='1'/>
       <parameter is-variadic='yes'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='_PyArg_ParseStack_SizeT' mangled-name='_PyArg_ParseStack_SizeT' filepath='Python/getargs.c' line='161' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyArg_ParseStack_SizeT'>
-      <parameter type-id='type-id-248' name='args' filepath='Python/getargs.c' line='161' column='1'/>
-      <parameter type-id='type-id-14' name='nargs' filepath='Python/getargs.c' line='161' column='1'/>
-      <parameter type-id='type-id-12' name='format' filepath='Python/getargs.c' line='161' column='1'/>
+    <function-decl name='_PyArg_ParseStack_SizeT' mangled-name='_PyArg_ParseStack_SizeT' filepath='Python/getargs.c' line='162' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyArg_ParseStack_SizeT'>
+      <parameter type-id='type-id-248' name='args' filepath='Python/getargs.c' line='162' column='1'/>
+      <parameter type-id='type-id-14' name='nargs' filepath='Python/getargs.c' line='162' column='1'/>
+      <parameter type-id='type-id-12' name='format' filepath='Python/getargs.c' line='162' column='1'/>
       <parameter is-variadic='yes'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='PyArg_VaParse' mangled-name='PyArg_VaParse' filepath='Python/getargs.c' line='174' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyArg_VaParse'>
-      <parameter type-id='type-id-2' name='args' filepath='Python/getargs.c' line='174' column='1'/>
-      <parameter type-id='type-id-12' name='format' filepath='Python/getargs.c' line='174' column='1'/>
-      <parameter type-id='type-id-306' name='va' filepath='Python/getargs.c' line='174' column='1'/>
+    <function-decl name='PyArg_VaParse' mangled-name='PyArg_VaParse' filepath='Python/getargs.c' line='175' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyArg_VaParse'>
+      <parameter type-id='type-id-2' name='args' filepath='Python/getargs.c' line='175' column='1'/>
+      <parameter type-id='type-id-12' name='format' filepath='Python/getargs.c' line='175' column='1'/>
+      <parameter type-id='type-id-306' name='va' filepath='Python/getargs.c' line='175' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='_PyArg_VaParse_SizeT' mangled-name='_PyArg_VaParse_SizeT' filepath='Python/getargs.c' line='187' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyArg_VaParse_SizeT'>
-      <parameter type-id='type-id-2' name='args' filepath='Python/getargs.c' line='187' column='1'/>
-      <parameter type-id='type-id-12' name='format' filepath='Python/getargs.c' line='187' column='1'/>
-      <parameter type-id='type-id-306' name='va' filepath='Python/getargs.c' line='187' column='1'/>
+    <function-decl name='_PyArg_VaParse_SizeT' mangled-name='_PyArg_VaParse_SizeT' filepath='Python/getargs.c' line='188' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyArg_VaParse_SizeT'>
+      <parameter type-id='type-id-2' name='args' filepath='Python/getargs.c' line='188' column='1'/>
+      <parameter type-id='type-id-12' name='format' filepath='Python/getargs.c' line='188' column='1'/>
+      <parameter type-id='type-id-306' name='va' filepath='Python/getargs.c' line='188' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='PyArg_VaParseTupleAndKeywords' mangled-name='PyArg_VaParseTupleAndKeywords' filepath='Python/getargs.c' line='1373' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyArg_VaParseTupleAndKeywords'>
-      <parameter type-id='type-id-2' name='args' filepath='Python/getargs.c' line='1373' column='1'/>
-      <parameter type-id='type-id-2' name='keywords' filepath='Python/getargs.c' line='1374' column='1'/>
-      <parameter type-id='type-id-12' name='format' filepath='Python/getargs.c' line='1375' column='1'/>
-      <parameter type-id='type-id-239' name='kwlist' filepath='Python/getargs.c' line='1376' column='1'/>
-      <parameter type-id='type-id-306' name='va' filepath='Python/getargs.c' line='1376' column='1'/>
+    <function-decl name='PyArg_VaParseTupleAndKeywords' mangled-name='PyArg_VaParseTupleAndKeywords' filepath='Python/getargs.c' line='1374' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyArg_VaParseTupleAndKeywords'>
+      <parameter type-id='type-id-2' name='args' filepath='Python/getargs.c' line='1374' column='1'/>
+      <parameter type-id='type-id-2' name='keywords' filepath='Python/getargs.c' line='1375' column='1'/>
+      <parameter type-id='type-id-12' name='format' filepath='Python/getargs.c' line='1376' column='1'/>
+      <parameter type-id='type-id-239' name='kwlist' filepath='Python/getargs.c' line='1377' column='1'/>
+      <parameter type-id='type-id-306' name='va' filepath='Python/getargs.c' line='1377' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='_PyArg_VaParseTupleAndKeywords_SizeT' mangled-name='_PyArg_VaParseTupleAndKeywords_SizeT' filepath='Python/getargs.c' line='1398' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyArg_VaParseTupleAndKeywords_SizeT'>
-      <parameter type-id='type-id-2' name='args' filepath='Python/getargs.c' line='1398' column='1'/>
-      <parameter type-id='type-id-2' name='keywords' filepath='Python/getargs.c' line='1399' column='1'/>
-      <parameter type-id='type-id-12' name='format' filepath='Python/getargs.c' line='1400' column='1'/>
-      <parameter type-id='type-id-239' name='kwlist' filepath='Python/getargs.c' line='1401' column='1'/>
-      <parameter type-id='type-id-306' name='va' filepath='Python/getargs.c' line='1401' column='1'/>
+    <function-decl name='_PyArg_VaParseTupleAndKeywords_SizeT' mangled-name='_PyArg_VaParseTupleAndKeywords_SizeT' filepath='Python/getargs.c' line='1399' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyArg_VaParseTupleAndKeywords_SizeT'>
+      <parameter type-id='type-id-2' name='args' filepath='Python/getargs.c' line='1399' column='1'/>
+      <parameter type-id='type-id-2' name='keywords' filepath='Python/getargs.c' line='1400' column='1'/>
+      <parameter type-id='type-id-12' name='format' filepath='Python/getargs.c' line='1401' column='1'/>
+      <parameter type-id='type-id-239' name='kwlist' filepath='Python/getargs.c' line='1402' column='1'/>
+      <parameter type-id='type-id-306' name='va' filepath='Python/getargs.c' line='1402' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='_PyArg_ParseTupleAndKeywordsFast' mangled-name='_PyArg_ParseTupleAndKeywordsFast' filepath='Python/getargs.c' line='1424' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyArg_ParseTupleAndKeywordsFast'>
-      <parameter type-id='type-id-2' name='args' filepath='Python/getargs.c' line='1424' column='1'/>
-      <parameter type-id='type-id-2' name='keywords' filepath='Python/getargs.c' line='1424' column='1'/>
-      <parameter type-id='type-id-262' name='parser' filepath='Python/getargs.c' line='1425' column='1'/>
+    <function-decl name='_PyArg_ParseTupleAndKeywordsFast' mangled-name='_PyArg_ParseTupleAndKeywordsFast' filepath='Python/getargs.c' line='1425' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyArg_ParseTupleAndKeywordsFast'>
+      <parameter type-id='type-id-2' name='args' filepath='Python/getargs.c' line='1425' column='1'/>
+      <parameter type-id='type-id-2' name='keywords' filepath='Python/getargs.c' line='1425' column='1'/>
+      <parameter type-id='type-id-262' name='parser' filepath='Python/getargs.c' line='1426' column='1'/>
       <parameter is-variadic='yes'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='_PyArg_ParseTupleAndKeywordsFast_SizeT' mangled-name='_PyArg_ParseTupleAndKeywordsFast_SizeT' filepath='Python/getargs.c' line='1437' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyArg_ParseTupleAndKeywordsFast_SizeT'>
-      <parameter type-id='type-id-2' name='args' filepath='Python/getargs.c' line='1437' column='1'/>
-      <parameter type-id='type-id-2' name='keywords' filepath='Python/getargs.c' line='1437' column='1'/>
-      <parameter type-id='type-id-262' name='parser' filepath='Python/getargs.c' line='1438' column='1'/>
+    <function-decl name='_PyArg_ParseTupleAndKeywordsFast_SizeT' mangled-name='_PyArg_ParseTupleAndKeywordsFast_SizeT' filepath='Python/getargs.c' line='1438' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyArg_ParseTupleAndKeywordsFast_SizeT'>
+      <parameter type-id='type-id-2' name='args' filepath='Python/getargs.c' line='1438' column='1'/>
+      <parameter type-id='type-id-2' name='keywords' filepath='Python/getargs.c' line='1438' column='1'/>
+      <parameter type-id='type-id-262' name='parser' filepath='Python/getargs.c' line='1439' column='1'/>
       <parameter is-variadic='yes'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='_PyArg_ParseStackAndKeywords' mangled-name='_PyArg_ParseStackAndKeywords' filepath='Python/getargs.c' line='1450' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyArg_ParseStackAndKeywords'>
-      <parameter type-id='type-id-248' name='args' filepath='Python/getargs.c' line='1450' column='1'/>
-      <parameter type-id='type-id-14' name='nargs' filepath='Python/getargs.c' line='1450' column='1'/>
-      <parameter type-id='type-id-2' name='kwnames' filepath='Python/getargs.c' line='1450' column='1'/>
-      <parameter type-id='type-id-262' name='parser' filepath='Python/getargs.c' line='1451' column='1'/>
+    <function-decl name='_PyArg_ParseStackAndKeywords' mangled-name='_PyArg_ParseStackAndKeywords' filepath='Python/getargs.c' line='1451' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyArg_ParseStackAndKeywords'>
+      <parameter type-id='type-id-248' name='args' filepath='Python/getargs.c' line='1451' column='1'/>
+      <parameter type-id='type-id-14' name='nargs' filepath='Python/getargs.c' line='1451' column='1'/>
+      <parameter type-id='type-id-2' name='kwnames' filepath='Python/getargs.c' line='1451' column='1'/>
+      <parameter type-id='type-id-262' name='parser' filepath='Python/getargs.c' line='1452' column='1'/>
       <parameter is-variadic='yes'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='_PyArg_ParseStackAndKeywords_SizeT' mangled-name='_PyArg_ParseStackAndKeywords_SizeT' filepath='Python/getargs.c' line='1463' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyArg_ParseStackAndKeywords_SizeT'>
-      <parameter type-id='type-id-248' name='args' filepath='Python/getargs.c' line='1463' column='1'/>
-      <parameter type-id='type-id-14' name='nargs' filepath='Python/getargs.c' line='1463' column='1'/>
-      <parameter type-id='type-id-2' name='kwnames' filepath='Python/getargs.c' line='1463' column='1'/>
-      <parameter type-id='type-id-262' name='parser' filepath='Python/getargs.c' line='1464' column='1'/>
+    <function-decl name='_PyArg_ParseStackAndKeywords_SizeT' mangled-name='_PyArg_ParseStackAndKeywords_SizeT' filepath='Python/getargs.c' line='1464' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyArg_ParseStackAndKeywords_SizeT'>
+      <parameter type-id='type-id-248' name='args' filepath='Python/getargs.c' line='1464' column='1'/>
+      <parameter type-id='type-id-14' name='nargs' filepath='Python/getargs.c' line='1464' column='1'/>
+      <parameter type-id='type-id-2' name='kwnames' filepath='Python/getargs.c' line='1464' column='1'/>
+      <parameter type-id='type-id-262' name='parser' filepath='Python/getargs.c' line='1465' column='1'/>
       <parameter is-variadic='yes'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='_PyArg_VaParseTupleAndKeywordsFast' mangled-name='_PyArg_VaParseTupleAndKeywordsFast' filepath='Python/getargs.c' line='1477' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyArg_VaParseTupleAndKeywordsFast'>
-      <parameter type-id='type-id-2' name='args' filepath='Python/getargs.c' line='1477' column='1'/>
-      <parameter type-id='type-id-2' name='keywords' filepath='Python/getargs.c' line='1477' column='1'/>
-      <parameter type-id='type-id-262' name='parser' filepath='Python/getargs.c' line='1478' column='1'/>
-      <parameter type-id='type-id-306' name='va' filepath='Python/getargs.c' line='1478' column='1'/>
+    <function-decl name='_PyArg_VaParseTupleAndKeywordsFast' mangled-name='_PyArg_VaParseTupleAndKeywordsFast' filepath='Python/getargs.c' line='1478' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyArg_VaParseTupleAndKeywordsFast'>
+      <parameter type-id='type-id-2' name='args' filepath='Python/getargs.c' line='1478' column='1'/>
+      <parameter type-id='type-id-2' name='keywords' filepath='Python/getargs.c' line='1478' column='1'/>
+      <parameter type-id='type-id-262' name='parser' filepath='Python/getargs.c' line='1479' column='1'/>
+      <parameter type-id='type-id-306' name='va' filepath='Python/getargs.c' line='1479' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='_PyArg_VaParseTupleAndKeywordsFast_SizeT' mangled-name='_PyArg_VaParseTupleAndKeywordsFast_SizeT' filepath='Python/getargs.c' line='1491' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyArg_VaParseTupleAndKeywordsFast_SizeT'>
-      <parameter type-id='type-id-2' name='args' filepath='Python/getargs.c' line='1491' column='1'/>
-      <parameter type-id='type-id-2' name='keywords' filepath='Python/getargs.c' line='1491' column='1'/>
-      <parameter type-id='type-id-262' name='parser' filepath='Python/getargs.c' line='1492' column='1'/>
-      <parameter type-id='type-id-306' name='va' filepath='Python/getargs.c' line='1492' column='1'/>
+    <function-decl name='_PyArg_VaParseTupleAndKeywordsFast_SizeT' mangled-name='_PyArg_VaParseTupleAndKeywordsFast_SizeT' filepath='Python/getargs.c' line='1492' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyArg_VaParseTupleAndKeywordsFast_SizeT'>
+      <parameter type-id='type-id-2' name='args' filepath='Python/getargs.c' line='1492' column='1'/>
+      <parameter type-id='type-id-2' name='keywords' filepath='Python/getargs.c' line='1492' column='1'/>
+      <parameter type-id='type-id-262' name='parser' filepath='Python/getargs.c' line='1493' column='1'/>
+      <parameter type-id='type-id-306' name='va' filepath='Python/getargs.c' line='1493' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='_PyArg_NoPositional' mangled-name='_PyArg_NoPositional' filepath='Python/getargs.c' line='2912' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyArg_NoPositional'>
-      <parameter type-id='type-id-12' name='funcname' filepath='Python/getargs.c' line='2912' column='1'/>
-      <parameter type-id='type-id-2' name='args' filepath='Python/getargs.c' line='2912' column='1'/>
+    <function-decl name='_PyArg_NoPositional' mangled-name='_PyArg_NoPositional' filepath='Python/getargs.c' line='2929' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyArg_NoPositional'>
+      <parameter type-id='type-id-12' name='funcname' filepath='Python/getargs.c' line='2929' column='1'/>
+      <parameter type-id='type-id-2' name='args' filepath='Python/getargs.c' line='2929' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
   </abi-instr>
@@ -24103,6 +24140,10 @@
       <parameter is-variadic='yes'/>
       <return type-id='type-id-8'/>
     </function-decl>
+    <function-decl name='putchar' filepath='/usr/include/stdio.h' line='556' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-8'/>
+      <return type-id='type-id-8'/>
+    </function-decl>
     <function-decl name='puts' filepath='/usr/include/stdio.h' line='661' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-12'/>
       <return type-id='type-id-8'/>
@@ -24134,121 +24175,121 @@
       <parameter type-id='type-id-8'/>
       <return type-id='type-id-47'/>
     </function-decl>
-    <function-decl name='PyStatus_Ok' mangled-name='PyStatus_Ok' filepath='Python/initconfig.c' line='312' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyStatus_Ok'>
+    <function-decl name='PyStatus_Ok' mangled-name='PyStatus_Ok' filepath='Python/initconfig.c' line='287' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyStatus_Ok'>
       <return type-id='type-id-54'/>
     </function-decl>
-    <function-decl name='PyStatus_Error' mangled-name='PyStatus_Error' filepath='Python/initconfig.c' line='315' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyStatus_Error'>
-      <parameter type-id='type-id-12' name='err_msg' filepath='Python/initconfig.c' line='315' column='1'/>
+    <function-decl name='PyStatus_Error' mangled-name='PyStatus_Error' filepath='Python/initconfig.c' line='290' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyStatus_Error'>
+      <parameter type-id='type-id-12' name='err_msg' filepath='Python/initconfig.c' line='290' column='1'/>
       <return type-id='type-id-54'/>
     </function-decl>
-    <function-decl name='PyStatus_Exit' mangled-name='PyStatus_Exit' filepath='Python/initconfig.c' line='325' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyStatus_Exit'>
-      <parameter type-id='type-id-8' name='exitcode' filepath='Python/initconfig.c' line='325' column='1'/>
+    <function-decl name='PyStatus_Exit' mangled-name='PyStatus_Exit' filepath='Python/initconfig.c' line='300' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyStatus_Exit'>
+      <parameter type-id='type-id-8' name='exitcode' filepath='Python/initconfig.c' line='300' column='1'/>
       <return type-id='type-id-54'/>
     </function-decl>
-    <function-decl name='PyStatus_IsError' mangled-name='PyStatus_IsError' filepath='Python/initconfig.c' line='329' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyStatus_IsError'>
-      <parameter type-id='type-id-54' name='status' filepath='Python/initconfig.c' line='329' column='1'/>
+    <function-decl name='PyStatus_IsError' mangled-name='PyStatus_IsError' filepath='Python/initconfig.c' line='304' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyStatus_IsError'>
+      <parameter type-id='type-id-54' name='status' filepath='Python/initconfig.c' line='304' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='PyStatus_IsExit' mangled-name='PyStatus_IsExit' filepath='Python/initconfig.c' line='332' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyStatus_IsExit'>
-      <parameter type-id='type-id-54' name='status' filepath='Python/initconfig.c' line='332' column='1'/>
+    <function-decl name='PyStatus_IsExit' mangled-name='PyStatus_IsExit' filepath='Python/initconfig.c' line='307' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyStatus_IsExit'>
+      <parameter type-id='type-id-54' name='status' filepath='Python/initconfig.c' line='307' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='_PyErr_SetFromPyStatus' mangled-name='_PyErr_SetFromPyStatus' filepath='Python/initconfig.c' line='339' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyErr_SetFromPyStatus'>
-      <parameter type-id='type-id-54' name='status' filepath='Python/initconfig.c' line='339' column='1'/>
+    <function-decl name='_PyErr_SetFromPyStatus' mangled-name='_PyErr_SetFromPyStatus' filepath='Python/initconfig.c' line='314' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyErr_SetFromPyStatus'>
+      <parameter type-id='type-id-54' name='status' filepath='Python/initconfig.c' line='314' column='1'/>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='_PyWideStringList_Clear' mangled-name='_PyWideStringList_Clear' filepath='Python/initconfig.c' line='375' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyWideStringList_Clear'>
-      <parameter type-id='type-id-1434' name='list' filepath='Python/initconfig.c' line='375' column='1'/>
+    <function-decl name='_PyWideStringList_Clear' mangled-name='_PyWideStringList_Clear' filepath='Python/initconfig.c' line='350' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyWideStringList_Clear'>
+      <parameter type-id='type-id-1434' name='list' filepath='Python/initconfig.c' line='350' column='1'/>
       <return type-id='type-id-46'/>
     </function-decl>
-    <function-decl name='_PyWideStringList_Copy' mangled-name='_PyWideStringList_Copy' filepath='Python/initconfig.c' line='388' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyWideStringList_Copy'>
-      <parameter type-id='type-id-1434' name='list' filepath='Python/initconfig.c' line='388' column='1'/>
-      <parameter type-id='type-id-232' name='list2' filepath='Python/initconfig.c' line='388' column='1'/>
+    <function-decl name='_PyWideStringList_Copy' mangled-name='_PyWideStringList_Copy' filepath='Python/initconfig.c' line='363' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyWideStringList_Copy'>
+      <parameter type-id='type-id-1434' name='list' filepath='Python/initconfig.c' line='363' column='1'/>
+      <parameter type-id='type-id-232' name='list2' filepath='Python/initconfig.c' line='363' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='PyWideStringList_Insert' mangled-name='PyWideStringList_Insert' filepath='Python/initconfig.c' line='423' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyWideStringList_Insert'>
-      <parameter type-id='type-id-1434' name='list' filepath='Python/initconfig.c' line='423' column='1'/>
-      <parameter type-id='type-id-14' name='index' filepath='Python/initconfig.c' line='424' column='1'/>
-      <parameter type-id='type-id-16' name='item' filepath='Python/initconfig.c' line='424' column='1'/>
+    <function-decl name='PyWideStringList_Insert' mangled-name='PyWideStringList_Insert' filepath='Python/initconfig.c' line='398' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyWideStringList_Insert'>
+      <parameter type-id='type-id-1434' name='list' filepath='Python/initconfig.c' line='398' column='1'/>
+      <parameter type-id='type-id-14' name='index' filepath='Python/initconfig.c' line='399' column='1'/>
+      <parameter type-id='type-id-16' name='item' filepath='Python/initconfig.c' line='399' column='1'/>
       <return type-id='type-id-54'/>
     </function-decl>
-    <function-decl name='PyWideStringList_Append' mangled-name='PyWideStringList_Append' filepath='Python/initconfig.c' line='464' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyWideStringList_Append'>
-      <parameter type-id='type-id-1434' name='list' filepath='Python/initconfig.c' line='464' column='1'/>
-      <parameter type-id='type-id-16' name='item' filepath='Python/initconfig.c' line='464' column='1'/>
+    <function-decl name='PyWideStringList_Append' mangled-name='PyWideStringList_Append' filepath='Python/initconfig.c' line='439' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyWideStringList_Append'>
+      <parameter type-id='type-id-1434' name='list' filepath='Python/initconfig.c' line='439' column='1'/>
+      <parameter type-id='type-id-16' name='item' filepath='Python/initconfig.c' line='439' column='1'/>
       <return type-id='type-id-54'/>
     </function-decl>
-    <function-decl name='_PyWideStringList_Extend' mangled-name='_PyWideStringList_Extend' filepath='Python/initconfig.c' line='471' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyWideStringList_Extend'>
-      <parameter type-id='type-id-1434' name='list' filepath='Python/initconfig.c' line='471' column='1'/>
-      <parameter type-id='type-id-232' name='list2' filepath='Python/initconfig.c' line='471' column='1'/>
+    <function-decl name='_PyWideStringList_Extend' mangled-name='_PyWideStringList_Extend' filepath='Python/initconfig.c' line='446' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyWideStringList_Extend'>
+      <parameter type-id='type-id-1434' name='list' filepath='Python/initconfig.c' line='446' column='1'/>
+      <parameter type-id='type-id-232' name='list2' filepath='Python/initconfig.c' line='446' column='1'/>
       <return type-id='type-id-54'/>
     </function-decl>
-    <function-decl name='_PyWideStringList_AsList' mangled-name='_PyWideStringList_AsList' filepath='Python/initconfig.c' line='496' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyWideStringList_AsList'>
-      <parameter type-id='type-id-232' name='list' filepath='Python/initconfig.c' line='496' column='1'/>
+    <function-decl name='_PyWideStringList_AsList' mangled-name='_PyWideStringList_AsList' filepath='Python/initconfig.c' line='471' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyWideStringList_AsList'>
+      <parameter type-id='type-id-232' name='list' filepath='Python/initconfig.c' line='471' column='1'/>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='Py_SetStandardStreamEncoding' mangled-name='Py_SetStandardStreamEncoding' filepath='Python/initconfig.c' line='527' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='Py_SetStandardStreamEncoding'>
-      <parameter type-id='type-id-12' name='encoding' filepath='Python/initconfig.c' line='527' column='1'/>
-      <parameter type-id='type-id-12' name='errors' filepath='Python/initconfig.c' line='527' column='1'/>
+    <function-decl name='Py_SetStandardStreamEncoding' mangled-name='Py_SetStandardStreamEncoding' filepath='Python/initconfig.c' line='502' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='Py_SetStandardStreamEncoding'>
+      <parameter type-id='type-id-12' name='encoding' filepath='Python/initconfig.c' line='502' column='1'/>
+      <parameter type-id='type-id-12' name='errors' filepath='Python/initconfig.c' line='502' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='_Py_ClearStandardStreamEncoding' mangled-name='_Py_ClearStandardStreamEncoding' filepath='Python/initconfig.c' line='585' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_ClearStandardStreamEncoding'>
+    <function-decl name='_Py_ClearStandardStreamEncoding' mangled-name='_Py_ClearStandardStreamEncoding' filepath='Python/initconfig.c' line='560' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_ClearStandardStreamEncoding'>
       <return type-id='type-id-46'/>
     </function-decl>
-    <function-decl name='_Py_ClearArgcArgv' mangled-name='_Py_ClearArgcArgv' filepath='Python/initconfig.c' line='608' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_ClearArgcArgv'>
+    <function-decl name='_Py_ClearArgcArgv' mangled-name='_Py_ClearArgcArgv' filepath='Python/initconfig.c' line='583' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_ClearArgcArgv'>
       <return type-id='type-id-46'/>
     </function-decl>
-    <function-decl name='Py_GetArgcArgv' mangled-name='Py_GetArgcArgv' filepath='Python/initconfig.c' line='639' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='Py_GetArgcArgv'>
-      <parameter type-id='type-id-179' name='argc' filepath='Python/initconfig.c' line='639' column='1'/>
-      <parameter type-id='type-id-1445' name='argv' filepath='Python/initconfig.c' line='639' column='1'/>
+    <function-decl name='Py_GetArgcArgv' mangled-name='Py_GetArgcArgv' filepath='Python/initconfig.c' line='614' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='Py_GetArgcArgv'>
+      <parameter type-id='type-id-179' name='argc' filepath='Python/initconfig.c' line='614' column='1'/>
+      <parameter type-id='type-id-1445' name='argv' filepath='Python/initconfig.c' line='614' column='1'/>
       <return type-id='type-id-46'/>
     </function-decl>
-    <function-decl name='_PyConfig_InitCompatConfig' mangled-name='_PyConfig_InitCompatConfig' filepath='Python/initconfig.c' line='758' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyConfig_InitCompatConfig'>
-      <parameter type-id='type-id-53' name='config' filepath='Python/initconfig.c' line='758' column='1'/>
+    <function-decl name='_PyConfig_InitCompatConfig' mangled-name='_PyConfig_InitCompatConfig' filepath='Python/initconfig.c' line='733' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyConfig_InitCompatConfig'>
+      <parameter type-id='type-id-53' name='config' filepath='Python/initconfig.c' line='733' column='1'/>
       <return type-id='type-id-46'/>
     </function-decl>
-    <function-decl name='PyConfig_InitIsolatedConfig' mangled-name='PyConfig_InitIsolatedConfig' filepath='Python/initconfig.c' line='842' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyConfig_InitIsolatedConfig'>
+    <function-decl name='PyConfig_InitIsolatedConfig' mangled-name='PyConfig_InitIsolatedConfig' filepath='Python/initconfig.c' line='817' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyConfig_InitIsolatedConfig'>
+      <parameter type-id='type-id-53' name='config' filepath='Python/initconfig.c' line='817' column='1'/>
+      <return type-id='type-id-46'/>
+    </function-decl>
+    <function-decl name='PyConfig_SetString' mangled-name='PyConfig_SetString' filepath='Python/initconfig.c' line='842' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyConfig_SetString'>
       <parameter type-id='type-id-53' name='config' filepath='Python/initconfig.c' line='842' column='1'/>
-      <return type-id='type-id-46'/>
-    </function-decl>
-    <function-decl name='PyConfig_SetString' mangled-name='PyConfig_SetString' filepath='Python/initconfig.c' line='867' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyConfig_SetString'>
-      <parameter type-id='type-id-53' name='config' filepath='Python/initconfig.c' line='867' column='1'/>
-      <parameter type-id='type-id-235' name='config_str' filepath='Python/initconfig.c' line='867' column='1'/>
-      <parameter type-id='type-id-16' name='str' filepath='Python/initconfig.c' line='867' column='1'/>
+      <parameter type-id='type-id-235' name='config_str' filepath='Python/initconfig.c' line='842' column='1'/>
+      <parameter type-id='type-id-16' name='str' filepath='Python/initconfig.c' line='842' column='1'/>
       <return type-id='type-id-54'/>
     </function-decl>
-    <function-decl name='PyConfig_SetBytesString' mangled-name='PyConfig_SetBytesString' filepath='Python/initconfig.c' line='929' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyConfig_SetBytesString'>
-      <parameter type-id='type-id-53' name='config' filepath='Python/initconfig.c' line='929' column='1'/>
-      <parameter type-id='type-id-235' name='config_str' filepath='Python/initconfig.c' line='929' column='1'/>
-      <parameter type-id='type-id-12' name='str' filepath='Python/initconfig.c' line='930' column='1'/>
+    <function-decl name='PyConfig_SetBytesString' mangled-name='PyConfig_SetBytesString' filepath='Python/initconfig.c' line='904' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyConfig_SetBytesString'>
+      <parameter type-id='type-id-53' name='config' filepath='Python/initconfig.c' line='904' column='1'/>
+      <parameter type-id='type-id-235' name='config_str' filepath='Python/initconfig.c' line='904' column='1'/>
+      <parameter type-id='type-id-12' name='str' filepath='Python/initconfig.c' line='905' column='1'/>
       <return type-id='type-id-54'/>
     </function-decl>
-    <function-decl name='_PyConfig_AsDict' mangled-name='_PyConfig_AsDict' filepath='Python/initconfig.c' line='1038' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyConfig_AsDict'>
-      <parameter type-id='type-id-260' name='config' filepath='Python/initconfig.c' line='1038' column='1'/>
+    <function-decl name='_PyConfig_AsDict' mangled-name='_PyConfig_AsDict' filepath='Python/initconfig.c' line='1013' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyConfig_AsDict'>
+      <parameter type-id='type-id-260' name='config' filepath='Python/initconfig.c' line='1013' column='1'/>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='_PyConfig_FromDict' mangled-name='_PyConfig_FromDict' filepath='Python/initconfig.c' line='1306' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyConfig_FromDict'>
-      <parameter type-id='type-id-53' name='config' filepath='Python/initconfig.c' line='1306' column='1'/>
-      <parameter type-id='type-id-2' name='dict' filepath='Python/initconfig.c' line='1306' column='1'/>
+    <function-decl name='_PyConfig_FromDict' mangled-name='_PyConfig_FromDict' filepath='Python/initconfig.c' line='1281' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyConfig_FromDict'>
+      <parameter type-id='type-id-53' name='config' filepath='Python/initconfig.c' line='1281' column='1'/>
+      <parameter type-id='type-id-2' name='dict' filepath='Python/initconfig.c' line='1281' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='PyConfig_SetArgv' mangled-name='PyConfig_SetArgv' filepath='Python/initconfig.c' line='2955' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyConfig_SetArgv'>
-      <parameter type-id='type-id-53' name='config' filepath='Python/initconfig.c' line='2955' column='1'/>
-      <parameter type-id='type-id-14' name='argc' filepath='Python/initconfig.c' line='2955' column='1'/>
-      <parameter type-id='type-id-1429' name='argv' filepath='Python/initconfig.c' line='2955' column='1'/>
+    <function-decl name='PyConfig_SetArgv' mangled-name='PyConfig_SetArgv' filepath='Python/initconfig.c' line='2930' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyConfig_SetArgv'>
+      <parameter type-id='type-id-53' name='config' filepath='Python/initconfig.c' line='2930' column='1'/>
+      <parameter type-id='type-id-14' name='argc' filepath='Python/initconfig.c' line='2930' column='1'/>
+      <parameter type-id='type-id-1429' name='argv' filepath='Python/initconfig.c' line='2930' column='1'/>
       <return type-id='type-id-54'/>
     </function-decl>
-    <function-decl name='PyConfig_SetWideStringList' mangled-name='PyConfig_SetWideStringList' filepath='Python/initconfig.c' line='2967' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyConfig_SetWideStringList'>
-      <parameter type-id='type-id-53' name='config' filepath='Python/initconfig.c' line='2967' column='1'/>
-      <parameter type-id='type-id-1434' name='list' filepath='Python/initconfig.c' line='2967' column='1'/>
-      <parameter type-id='type-id-14' name='length' filepath='Python/initconfig.c' line='2968' column='1'/>
-      <parameter type-id='type-id-235' name='items' filepath='Python/initconfig.c' line='2968' column='1'/>
+    <function-decl name='PyConfig_SetWideStringList' mangled-name='PyConfig_SetWideStringList' filepath='Python/initconfig.c' line='2942' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyConfig_SetWideStringList'>
+      <parameter type-id='type-id-53' name='config' filepath='Python/initconfig.c' line='2942' column='1'/>
+      <parameter type-id='type-id-1434' name='list' filepath='Python/initconfig.c' line='2942' column='1'/>
+      <parameter type-id='type-id-14' name='length' filepath='Python/initconfig.c' line='2943' column='1'/>
+      <parameter type-id='type-id-235' name='items' filepath='Python/initconfig.c' line='2943' column='1'/>
       <return type-id='type-id-54'/>
     </function-decl>
-    <function-decl name='PyConfig_Read' mangled-name='PyConfig_Read' filepath='Python/initconfig.c' line='3051' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyConfig_Read'>
-      <parameter type-id='type-id-53' name='config' filepath='Python/initconfig.c' line='3051' column='1'/>
+    <function-decl name='PyConfig_Read' mangled-name='PyConfig_Read' filepath='Python/initconfig.c' line='3026' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyConfig_Read'>
+      <parameter type-id='type-id-53' name='config' filepath='Python/initconfig.c' line='3026' column='1'/>
       <return type-id='type-id-54'/>
     </function-decl>
-    <function-decl name='_Py_GetConfigsAsDict' mangled-name='_Py_GetConfigsAsDict' filepath='Python/initconfig.c' line='3058' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_GetConfigsAsDict'>
+    <function-decl name='_Py_GetConfigsAsDict' mangled-name='_Py_GetConfigsAsDict' filepath='Python/initconfig.c' line='3033' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_GetConfigsAsDict'>
       <return type-id='type-id-2'/>
     </function-decl>
   </abi-instr>
@@ -24275,7 +24316,7 @@
     <pointer-type-def type-id='type-id-1457' size-in-bits='64' id='type-id-1454'/>
     <qualified-type-def type-id='type-id-1453' const='yes' id='type-id-1446'/>
     <qualified-type-def type-id='type-id-1455' const='yes' id='type-id-1449'/>
-    <function-decl name='_PyFrame_LocalsToFast' filepath='./Include/internal/pycore_frame.h' line='236' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_PyFrame_LocalsToFast' filepath='./Include/internal/pycore_frame.h' line='241' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-374'/>
       <parameter type-id='type-id-8'/>
       <return type-id='type-id-46'/>
@@ -24581,7 +24622,7 @@
     </function-decl>
   </abi-instr>
   <abi-instr address-size='64' path='Python/perf_trampoline.c' comp-dir-path='/home/runner/work/cpython/cpython' language='LANG_C11'>
-    <var-decl name='_Py_perfmap_callbacks' type-id='type-id-1465' visibility='default' filepath='./Include/internal/pycore_ceval.h' line='80' column='1'/>
+    <var-decl name='_Py_perfmap_callbacks' type-id='type-id-1465' visibility='default' filepath='./Include/internal/pycore_ceval.h' line='81' column='1'/>
     <function-decl name='mprotect' filepath='/usr/include/x86_64-linux-gnu/sys/mman.h' line='81' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-22'/>
       <parameter type-id='type-id-19'/>
@@ -24759,21 +24800,21 @@
       </data-member>
     </class-decl>
     <typedef-decl name='_PyPerf_Callbacks' type-id='type-id-1485' filepath='./Include/internal/pycore_ceval.h' line='71' column='1' id='type-id-1465'/>
-    <class-decl name='_PyShimCodeDef' size-in-bits='192' is-struct='yes' visibility='default' filepath='./Include/internal/pycore_code.h' line='453' column='1' id='type-id-1486'>
+    <class-decl name='_PyShimCodeDef' size-in-bits='192' is-struct='yes' visibility='default' filepath='./Include/internal/pycore_code.h' line='455' column='1' id='type-id-1486'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='code' type-id='type-id-316' visibility='default' filepath='./Include/internal/pycore_code.h' line='454' column='1'/>
+        <var-decl name='code' type-id='type-id-316' visibility='default' filepath='./Include/internal/pycore_code.h' line='456' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='codelen' type-id='type-id-8' visibility='default' filepath='./Include/internal/pycore_code.h' line='455' column='1'/>
+        <var-decl name='codelen' type-id='type-id-8' visibility='default' filepath='./Include/internal/pycore_code.h' line='457' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='96'>
-        <var-decl name='stacksize' type-id='type-id-8' visibility='default' filepath='./Include/internal/pycore_code.h' line='456' column='1'/>
+        <var-decl name='stacksize' type-id='type-id-8' visibility='default' filepath='./Include/internal/pycore_code.h' line='458' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='cname' type-id='type-id-12' visibility='default' filepath='./Include/internal/pycore_code.h' line='457' column='1'/>
+        <var-decl name='cname' type-id='type-id-12' visibility='default' filepath='./Include/internal/pycore_code.h' line='459' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='_PyShimCodeDef' type-id='type-id-1486' filepath='./Include/internal/pycore_code.h' line='458' column='1' id='type-id-1487'/>
+    <typedef-decl name='_PyShimCodeDef' type-id='type-id-1486' filepath='./Include/internal/pycore_code.h' line='460' column='1' id='type-id-1487'/>
     <typedef-decl name='_PyRuntimeState' type-id='type-id-987' filepath='./Include/internal/pycore_runtime.h' line='187' column='1' id='type-id-1488'/>
     <typedef-decl name='PyOS_sighandler_t' type-id='type-id-1020' filepath='./Include/pylifecycle.h' line='61' column='1' id='type-id-1489'/>
     <typedef-decl name='nl_item' type-id='type-id-8' filepath='/usr/include/nl_types.h' line='36' column='1' id='type-id-1490'/>
@@ -24809,21 +24850,24 @@
     <function-decl name='_PyPerfTrampoline_Fini' filepath='./Include/internal/pycore_ceval.h' line='76' column='1' visibility='default' binding='global' size-in-bits='64'>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='_PyEval_InitGIL' filepath='./Include/internal/pycore_ceval.h' line='100' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_PyPerfTrampoline_FreeArenas' filepath='./Include/internal/pycore_ceval.h' line='77' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-46'/>
+    </function-decl>
+    <function-decl name='_PyEval_InitGIL' filepath='./Include/internal/pycore_ceval.h' line='101' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-177'/>
       <parameter type-id='type-id-8'/>
       <return type-id='type-id-54'/>
     </function-decl>
-    <function-decl name='_PyEval_FiniGIL' filepath='./Include/internal/pycore_ceval.h' line='101' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_PyEval_FiniGIL' filepath='./Include/internal/pycore_ceval.h' line='102' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-20'/>
       <return type-id='type-id-46'/>
     </function-decl>
-    <function-decl name='_PyEval_ReleaseLock' filepath='./Include/internal/pycore_ceval.h' line='104' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_PyEval_ReleaseLock' filepath='./Include/internal/pycore_ceval.h' line='105' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-20'/>
       <parameter type-id='type-id-177'/>
       <return type-id='type-id-46'/>
     </function-decl>
-    <function-decl name='_Py_MakeShimCode' filepath='./Include/internal/pycore_code.h' line='461' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_Py_MakeShimCode' filepath='./Include/internal/pycore_code.h' line='463' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-1495'/>
       <return type-id='type-id-328'/>
     </function-decl>
@@ -25259,7 +25303,7 @@
       <parameter type-id='type-id-20'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='_PyModule_IsExtension' filepath='./Include/moduleobject.h' line='111' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_PyModule_IsExtension' filepath='./Include/moduleobject.h' line='113' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-2'/>
       <return type-id='type-id-8'/>
     </function-decl>
@@ -25272,18 +25316,6 @@
     <function-decl name='PyInterpreterState_Delete' mangled-name='PyInterpreterState_Delete' filepath='./Include/pystate.h' line='16' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyInterpreterState_Delete'>
       <parameter type-id='type-id-20'/>
       <return type-id='type-id-46'/>
-    </function-decl>
-    <function-decl name='PyThreadState_Clear' mangled-name='PyThreadState_Clear' filepath='./Include/pystate.h' line='49' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyThreadState_Clear'>
-      <parameter type-id='type-id-177'/>
-      <return type-id='type-id-46'/>
-    </function-decl>
-    <function-decl name='PyThreadState_Delete' mangled-name='PyThreadState_Delete' filepath='./Include/pystate.h' line='50' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyThreadState_Delete'>
-      <parameter type-id='type-id-177'/>
-      <return type-id='type-id-46'/>
-    </function-decl>
-    <function-decl name='PyThreadState_Swap' mangled-name='PyThreadState_Swap' filepath='./Include/pystate.h' line='65' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyThreadState_Swap'>
-      <parameter type-id='type-id-177'/>
-      <return type-id='type-id-177'/>
     </function-decl>
     <function-decl name='PyGILState_GetThisThreadState' mangled-name='PyGILState_GetThisThreadState' filepath='./Include/pystate.h' line='120' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyGILState_GetThisThreadState'>
       <return type-id='type-id-177'/>
@@ -25306,9 +25338,6 @@
       <parameter type-id='type-id-12'/>
       <parameter type-id='type-id-2'/>
       <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='PyUnstable_PerfMapState_Fini' mangled-name='PyUnstable_PerfMapState_Fini' filepath='./Include/sysmodule.h' line='42' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyUnstable_PerfMapState_Fini'>
-      <return type-id='type-id-46'/>
     </function-decl>
     <function-decl name='_PyTraceMalloc_Start' mangled-name='_PyTraceMalloc_Start' filepath='./Include/tracemalloc.h' line='53' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyTraceMalloc_Start'>
       <parameter type-id='type-id-8'/>
@@ -25461,7 +25490,7 @@
       <parameter type-id='type-id-1501'/>
       <return type-id='type-id-46'/>
     </function-decl>
-    <function-decl name='_PyEval_AcquireLock' filepath='./Include/internal/pycore_ceval.h' line='103' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_PyEval_AcquireLock' filepath='./Include/internal/pycore_ceval.h' line='104' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-177'/>
       <return type-id='type-id-46'/>
     </function-decl>
@@ -25481,16 +25510,16 @@
       <parameter type-id='type-id-20'/>
       <return type-id='type-id-46'/>
     </function-decl>
-    <function-decl name='_PyObject_VirtualAlloc' filepath='./Include/internal/pycore_obmalloc.h' line='677' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_PyObject_VirtualAlloc' filepath='./Include/internal/pycore_obmalloc.h' line='679' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-19'/>
       <return type-id='type-id-22'/>
     </function-decl>
-    <function-decl name='_PyObject_VirtualFree' filepath='./Include/internal/pycore_obmalloc.h' line='678' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_PyObject_VirtualFree' filepath='./Include/internal/pycore_obmalloc.h' line='680' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-22'/>
       <parameter type-id='type-id-19'/>
       <return type-id='type-id-46'/>
     </function-decl>
-    <function-decl name='_PyInterpreterState_FinalizeAllocatedBlocks' filepath='./Include/internal/pycore_obmalloc.h' line='686' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_PyInterpreterState_FinalizeAllocatedBlocks' filepath='./Include/internal/pycore_obmalloc.h' line='688' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-20'/>
       <return type-id='type-id-46'/>
     </function-decl>
@@ -25557,10 +25586,6 @@
     <function-decl name='PyInterpreterState_GetDict' mangled-name='PyInterpreterState_GetDict' filepath='Python/pystate.c' line='1194' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyInterpreterState_GetDict'>
       <parameter type-id='type-id-20' name='interp' filepath='Python/pystate.c' line='1194' column='1'/>
       <return type-id='type-id-2'/>
-    </function-decl>
-    <function-decl name='PyThreadState_New' mangled-name='PyThreadState_New' filepath='Python/pystate.c' line='1436' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyThreadState_New'>
-      <parameter type-id='type-id-20' name='interp' filepath='Python/pystate.c' line='1436' column='1'/>
-      <return type-id='type-id-177'/>
     </function-decl>
     <function-decl name='_PyThreadState_Prealloc' mangled-name='_PyThreadState_Prealloc' filepath='Python/pystate.c' line='1459' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyThreadState_Prealloc'>
       <parameter type-id='type-id-20' name='interp' filepath='Python/pystate.c' line='1459' column='1'/>
@@ -25818,128 +25843,128 @@
       <parameter type-id='type-id-179' name='exitcode_p' filepath='Python/pythonrun.c' line='688' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='_PyErr_Display' mangled-name='_PyErr_Display' filepath='Python/pythonrun.c' line='1494' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyErr_Display'>
-      <parameter type-id='type-id-2' name='file' filepath='Python/pythonrun.c' line='1494' column='1'/>
-      <parameter type-id='type-id-2' name='unused' filepath='Python/pythonrun.c' line='1494' column='1'/>
-      <parameter type-id='type-id-2' name='value' filepath='Python/pythonrun.c' line='1494' column='1'/>
-      <parameter type-id='type-id-2' name='tb' filepath='Python/pythonrun.c' line='1494' column='1'/>
+    <function-decl name='_PyErr_Display' mangled-name='_PyErr_Display' filepath='Python/pythonrun.c' line='1525' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyErr_Display'>
+      <parameter type-id='type-id-2' name='file' filepath='Python/pythonrun.c' line='1525' column='1'/>
+      <parameter type-id='type-id-2' name='unused' filepath='Python/pythonrun.c' line='1525' column='1'/>
+      <parameter type-id='type-id-2' name='value' filepath='Python/pythonrun.c' line='1525' column='1'/>
+      <parameter type-id='type-id-2' name='tb' filepath='Python/pythonrun.c' line='1525' column='1'/>
       <return type-id='type-id-46'/>
     </function-decl>
-    <function-decl name='PyErr_Display' mangled-name='PyErr_Display' filepath='Python/pythonrun.c' line='1543' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyErr_Display'>
-      <parameter type-id='type-id-2' name='unused' filepath='Python/pythonrun.c' line='1543' column='1'/>
-      <parameter type-id='type-id-2' name='value' filepath='Python/pythonrun.c' line='1543' column='1'/>
-      <parameter type-id='type-id-2' name='tb' filepath='Python/pythonrun.c' line='1543' column='1'/>
+    <function-decl name='PyErr_Display' mangled-name='PyErr_Display' filepath='Python/pythonrun.c' line='1574' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyErr_Display'>
+      <parameter type-id='type-id-2' name='unused' filepath='Python/pythonrun.c' line='1574' column='1'/>
+      <parameter type-id='type-id-2' name='value' filepath='Python/pythonrun.c' line='1574' column='1'/>
+      <parameter type-id='type-id-2' name='tb' filepath='Python/pythonrun.c' line='1574' column='1'/>
       <return type-id='type-id-46'/>
     </function-decl>
-    <function-decl name='_PyErr_DisplayException' mangled-name='_PyErr_DisplayException' filepath='Python/pythonrun.c' line='1560' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyErr_DisplayException'>
-      <parameter type-id='type-id-2' name='file' filepath='Python/pythonrun.c' line='1560' column='1'/>
-      <parameter type-id='type-id-2' name='exc' filepath='Python/pythonrun.c' line='1560' column='1'/>
+    <function-decl name='_PyErr_DisplayException' mangled-name='_PyErr_DisplayException' filepath='Python/pythonrun.c' line='1591' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyErr_DisplayException'>
+      <parameter type-id='type-id-2' name='file' filepath='Python/pythonrun.c' line='1591' column='1'/>
+      <parameter type-id='type-id-2' name='exc' filepath='Python/pythonrun.c' line='1591' column='1'/>
       <return type-id='type-id-46'/>
     </function-decl>
-    <function-decl name='PyRun_FileExFlags' mangled-name='PyRun_FileExFlags' filepath='Python/pythonrun.c' line='1624' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyRun_FileExFlags'>
-      <parameter type-id='type-id-229' name='fp' filepath='Python/pythonrun.c' line='1624' column='1'/>
-      <parameter type-id='type-id-12' name='filename' filepath='Python/pythonrun.c' line='1624' column='1'/>
-      <parameter type-id='type-id-8' name='start' filepath='Python/pythonrun.c' line='1624' column='1'/>
-      <parameter type-id='type-id-2' name='globals' filepath='Python/pythonrun.c' line='1624' column='1'/>
-      <parameter type-id='type-id-2' name='locals' filepath='Python/pythonrun.c' line='1625' column='1'/>
-      <parameter type-id='type-id-8' name='closeit' filepath='Python/pythonrun.c' line='1625' column='1'/>
-      <parameter type-id='type-id-208' name='flags' filepath='Python/pythonrun.c' line='1625' column='1'/>
+    <function-decl name='PyRun_FileExFlags' mangled-name='PyRun_FileExFlags' filepath='Python/pythonrun.c' line='1655' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyRun_FileExFlags'>
+      <parameter type-id='type-id-229' name='fp' filepath='Python/pythonrun.c' line='1655' column='1'/>
+      <parameter type-id='type-id-12' name='filename' filepath='Python/pythonrun.c' line='1655' column='1'/>
+      <parameter type-id='type-id-8' name='start' filepath='Python/pythonrun.c' line='1655' column='1'/>
+      <parameter type-id='type-id-2' name='globals' filepath='Python/pythonrun.c' line='1655' column='1'/>
+      <parameter type-id='type-id-2' name='locals' filepath='Python/pythonrun.c' line='1656' column='1'/>
+      <parameter type-id='type-id-8' name='closeit' filepath='Python/pythonrun.c' line='1656' column='1'/>
+      <parameter type-id='type-id-208' name='flags' filepath='Python/pythonrun.c' line='1656' column='1'/>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='Py_CompileStringExFlags' mangled-name='Py_CompileStringExFlags' filepath='Python/pythonrun.c' line='1786' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='Py_CompileStringExFlags'>
-      <parameter type-id='type-id-12' name='str' filepath='Python/pythonrun.c' line='1786' column='1'/>
-      <parameter type-id='type-id-12' name='filename_str' filepath='Python/pythonrun.c' line='1786' column='1'/>
-      <parameter type-id='type-id-8' name='start' filepath='Python/pythonrun.c' line='1786' column='1'/>
-      <parameter type-id='type-id-208' name='flags' filepath='Python/pythonrun.c' line='1787' column='1'/>
-      <parameter type-id='type-id-8' name='optimize' filepath='Python/pythonrun.c' line='1787' column='1'/>
+    <function-decl name='Py_CompileStringExFlags' mangled-name='Py_CompileStringExFlags' filepath='Python/pythonrun.c' line='1817' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='Py_CompileStringExFlags'>
+      <parameter type-id='type-id-12' name='str' filepath='Python/pythonrun.c' line='1817' column='1'/>
+      <parameter type-id='type-id-12' name='filename_str' filepath='Python/pythonrun.c' line='1817' column='1'/>
+      <parameter type-id='type-id-8' name='start' filepath='Python/pythonrun.c' line='1817' column='1'/>
+      <parameter type-id='type-id-208' name='flags' filepath='Python/pythonrun.c' line='1818' column='1'/>
+      <parameter type-id='type-id-8' name='optimize' filepath='Python/pythonrun.c' line='1818' column='1'/>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='PyRun_AnyFile' mangled-name='PyRun_AnyFile' filepath='Python/pythonrun.c' line='1888' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyRun_AnyFile'>
-      <parameter type-id='type-id-229' name='fp' filepath='Python/pythonrun.c' line='1888' column='1'/>
-      <parameter type-id='type-id-12' name='name' filepath='Python/pythonrun.c' line='1888' column='1'/>
+    <function-decl name='PyRun_AnyFile' mangled-name='PyRun_AnyFile' filepath='Python/pythonrun.c' line='1919' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyRun_AnyFile'>
+      <parameter type-id='type-id-229' name='fp' filepath='Python/pythonrun.c' line='1919' column='1'/>
+      <parameter type-id='type-id-12' name='name' filepath='Python/pythonrun.c' line='1919' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='PyRun_AnyFileEx' mangled-name='PyRun_AnyFileEx' filepath='Python/pythonrun.c' line='1895' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyRun_AnyFileEx'>
-      <parameter type-id='type-id-229' name='fp' filepath='Python/pythonrun.c' line='1895' column='1'/>
-      <parameter type-id='type-id-12' name='name' filepath='Python/pythonrun.c' line='1895' column='1'/>
-      <parameter type-id='type-id-8' name='closeit' filepath='Python/pythonrun.c' line='1895' column='1'/>
+    <function-decl name='PyRun_AnyFileEx' mangled-name='PyRun_AnyFileEx' filepath='Python/pythonrun.c' line='1926' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyRun_AnyFileEx'>
+      <parameter type-id='type-id-229' name='fp' filepath='Python/pythonrun.c' line='1926' column='1'/>
+      <parameter type-id='type-id-12' name='name' filepath='Python/pythonrun.c' line='1926' column='1'/>
+      <parameter type-id='type-id-8' name='closeit' filepath='Python/pythonrun.c' line='1926' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='PyRun_AnyFileFlags' mangled-name='PyRun_AnyFileFlags' filepath='Python/pythonrun.c' line='1902' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyRun_AnyFileFlags'>
-      <parameter type-id='type-id-229' name='fp' filepath='Python/pythonrun.c' line='1902' column='1'/>
-      <parameter type-id='type-id-12' name='name' filepath='Python/pythonrun.c' line='1902' column='1'/>
-      <parameter type-id='type-id-208' name='flags' filepath='Python/pythonrun.c' line='1902' column='1'/>
+    <function-decl name='PyRun_AnyFileFlags' mangled-name='PyRun_AnyFileFlags' filepath='Python/pythonrun.c' line='1933' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyRun_AnyFileFlags'>
+      <parameter type-id='type-id-229' name='fp' filepath='Python/pythonrun.c' line='1933' column='1'/>
+      <parameter type-id='type-id-12' name='name' filepath='Python/pythonrun.c' line='1933' column='1'/>
+      <parameter type-id='type-id-208' name='flags' filepath='Python/pythonrun.c' line='1933' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='PyRun_File' mangled-name='PyRun_File' filepath='Python/pythonrun.c' line='1909' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyRun_File'>
-      <parameter type-id='type-id-229' name='fp' filepath='Python/pythonrun.c' line='1909' column='1'/>
-      <parameter type-id='type-id-12' name='p' filepath='Python/pythonrun.c' line='1909' column='1'/>
-      <parameter type-id='type-id-8' name='s' filepath='Python/pythonrun.c' line='1909' column='1'/>
-      <parameter type-id='type-id-2' name='g' filepath='Python/pythonrun.c' line='1909' column='1'/>
-      <parameter type-id='type-id-2' name='l' filepath='Python/pythonrun.c' line='1909' column='1'/>
+    <function-decl name='PyRun_File' mangled-name='PyRun_File' filepath='Python/pythonrun.c' line='1940' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyRun_File'>
+      <parameter type-id='type-id-229' name='fp' filepath='Python/pythonrun.c' line='1940' column='1'/>
+      <parameter type-id='type-id-12' name='p' filepath='Python/pythonrun.c' line='1940' column='1'/>
+      <parameter type-id='type-id-8' name='s' filepath='Python/pythonrun.c' line='1940' column='1'/>
+      <parameter type-id='type-id-2' name='g' filepath='Python/pythonrun.c' line='1940' column='1'/>
+      <parameter type-id='type-id-2' name='l' filepath='Python/pythonrun.c' line='1940' column='1'/>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='PyRun_FileEx' mangled-name='PyRun_FileEx' filepath='Python/pythonrun.c' line='1916' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyRun_FileEx'>
-      <parameter type-id='type-id-229' name='fp' filepath='Python/pythonrun.c' line='1916' column='1'/>
-      <parameter type-id='type-id-12' name='p' filepath='Python/pythonrun.c' line='1916' column='1'/>
-      <parameter type-id='type-id-8' name='s' filepath='Python/pythonrun.c' line='1916' column='1'/>
-      <parameter type-id='type-id-2' name='g' filepath='Python/pythonrun.c' line='1916' column='1'/>
-      <parameter type-id='type-id-2' name='l' filepath='Python/pythonrun.c' line='1916' column='1'/>
-      <parameter type-id='type-id-8' name='c' filepath='Python/pythonrun.c' line='1916' column='1'/>
+    <function-decl name='PyRun_FileEx' mangled-name='PyRun_FileEx' filepath='Python/pythonrun.c' line='1947' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyRun_FileEx'>
+      <parameter type-id='type-id-229' name='fp' filepath='Python/pythonrun.c' line='1947' column='1'/>
+      <parameter type-id='type-id-12' name='p' filepath='Python/pythonrun.c' line='1947' column='1'/>
+      <parameter type-id='type-id-8' name='s' filepath='Python/pythonrun.c' line='1947' column='1'/>
+      <parameter type-id='type-id-2' name='g' filepath='Python/pythonrun.c' line='1947' column='1'/>
+      <parameter type-id='type-id-2' name='l' filepath='Python/pythonrun.c' line='1947' column='1'/>
+      <parameter type-id='type-id-8' name='c' filepath='Python/pythonrun.c' line='1947' column='1'/>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='PyRun_FileFlags' mangled-name='PyRun_FileFlags' filepath='Python/pythonrun.c' line='1923' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyRun_FileFlags'>
-      <parameter type-id='type-id-229' name='fp' filepath='Python/pythonrun.c' line='1923' column='1'/>
-      <parameter type-id='type-id-12' name='p' filepath='Python/pythonrun.c' line='1923' column='1'/>
-      <parameter type-id='type-id-8' name='s' filepath='Python/pythonrun.c' line='1923' column='1'/>
-      <parameter type-id='type-id-2' name='g' filepath='Python/pythonrun.c' line='1923' column='1'/>
-      <parameter type-id='type-id-2' name='l' filepath='Python/pythonrun.c' line='1923' column='1'/>
-      <parameter type-id='type-id-208' name='flags' filepath='Python/pythonrun.c' line='1924' column='1'/>
+    <function-decl name='PyRun_FileFlags' mangled-name='PyRun_FileFlags' filepath='Python/pythonrun.c' line='1954' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyRun_FileFlags'>
+      <parameter type-id='type-id-229' name='fp' filepath='Python/pythonrun.c' line='1954' column='1'/>
+      <parameter type-id='type-id-12' name='p' filepath='Python/pythonrun.c' line='1954' column='1'/>
+      <parameter type-id='type-id-8' name='s' filepath='Python/pythonrun.c' line='1954' column='1'/>
+      <parameter type-id='type-id-2' name='g' filepath='Python/pythonrun.c' line='1954' column='1'/>
+      <parameter type-id='type-id-2' name='l' filepath='Python/pythonrun.c' line='1954' column='1'/>
+      <parameter type-id='type-id-208' name='flags' filepath='Python/pythonrun.c' line='1955' column='1'/>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='PyRun_SimpleFile' mangled-name='PyRun_SimpleFile' filepath='Python/pythonrun.c' line='1931' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyRun_SimpleFile'>
-      <parameter type-id='type-id-229' name='f' filepath='Python/pythonrun.c' line='1931' column='1'/>
-      <parameter type-id='type-id-12' name='p' filepath='Python/pythonrun.c' line='1931' column='1'/>
+    <function-decl name='PyRun_SimpleFile' mangled-name='PyRun_SimpleFile' filepath='Python/pythonrun.c' line='1962' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyRun_SimpleFile'>
+      <parameter type-id='type-id-229' name='f' filepath='Python/pythonrun.c' line='1962' column='1'/>
+      <parameter type-id='type-id-12' name='p' filepath='Python/pythonrun.c' line='1962' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='PyRun_SimpleFileEx' mangled-name='PyRun_SimpleFileEx' filepath='Python/pythonrun.c' line='1938' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyRun_SimpleFileEx'>
-      <parameter type-id='type-id-229' name='f' filepath='Python/pythonrun.c' line='1938' column='1'/>
-      <parameter type-id='type-id-12' name='p' filepath='Python/pythonrun.c' line='1938' column='1'/>
-      <parameter type-id='type-id-8' name='c' filepath='Python/pythonrun.c' line='1938' column='1'/>
+    <function-decl name='PyRun_SimpleFileEx' mangled-name='PyRun_SimpleFileEx' filepath='Python/pythonrun.c' line='1969' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyRun_SimpleFileEx'>
+      <parameter type-id='type-id-229' name='f' filepath='Python/pythonrun.c' line='1969' column='1'/>
+      <parameter type-id='type-id-12' name='p' filepath='Python/pythonrun.c' line='1969' column='1'/>
+      <parameter type-id='type-id-8' name='c' filepath='Python/pythonrun.c' line='1969' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='PyRun_String' mangled-name='PyRun_String' filepath='Python/pythonrun.c' line='1946' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyRun_String'>
-      <parameter type-id='type-id-12' name='str' filepath='Python/pythonrun.c' line='1946' column='1'/>
-      <parameter type-id='type-id-8' name='s' filepath='Python/pythonrun.c' line='1946' column='1'/>
-      <parameter type-id='type-id-2' name='g' filepath='Python/pythonrun.c' line='1946' column='1'/>
-      <parameter type-id='type-id-2' name='l' filepath='Python/pythonrun.c' line='1946' column='1'/>
+    <function-decl name='PyRun_String' mangled-name='PyRun_String' filepath='Python/pythonrun.c' line='1977' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyRun_String'>
+      <parameter type-id='type-id-12' name='str' filepath='Python/pythonrun.c' line='1977' column='1'/>
+      <parameter type-id='type-id-8' name='s' filepath='Python/pythonrun.c' line='1977' column='1'/>
+      <parameter type-id='type-id-2' name='g' filepath='Python/pythonrun.c' line='1977' column='1'/>
+      <parameter type-id='type-id-2' name='l' filepath='Python/pythonrun.c' line='1977' column='1'/>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='PyRun_SimpleString' mangled-name='PyRun_SimpleString' filepath='Python/pythonrun.c' line='1953' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyRun_SimpleString'>
-      <parameter type-id='type-id-12' name='s' filepath='Python/pythonrun.c' line='1953' column='1'/>
+    <function-decl name='PyRun_SimpleString' mangled-name='PyRun_SimpleString' filepath='Python/pythonrun.c' line='1984' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyRun_SimpleString'>
+      <parameter type-id='type-id-12' name='s' filepath='Python/pythonrun.c' line='1984' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='Py_CompileString' mangled-name='Py_CompileString' filepath='Python/pythonrun.c' line='1960' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='Py_CompileString'>
-      <parameter type-id='type-id-12' name='str' filepath='Python/pythonrun.c' line='1960' column='1'/>
-      <parameter type-id='type-id-12' name='p' filepath='Python/pythonrun.c' line='1960' column='1'/>
-      <parameter type-id='type-id-8' name='s' filepath='Python/pythonrun.c' line='1960' column='1'/>
+    <function-decl name='Py_CompileString' mangled-name='Py_CompileString' filepath='Python/pythonrun.c' line='1991' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='Py_CompileString'>
+      <parameter type-id='type-id-12' name='str' filepath='Python/pythonrun.c' line='1991' column='1'/>
+      <parameter type-id='type-id-12' name='p' filepath='Python/pythonrun.c' line='1991' column='1'/>
+      <parameter type-id='type-id-8' name='s' filepath='Python/pythonrun.c' line='1991' column='1'/>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='Py_CompileStringFlags' mangled-name='Py_CompileStringFlags' filepath='Python/pythonrun.c' line='1967' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='Py_CompileStringFlags'>
-      <parameter type-id='type-id-12' name='str' filepath='Python/pythonrun.c' line='1967' column='1'/>
-      <parameter type-id='type-id-12' name='p' filepath='Python/pythonrun.c' line='1967' column='1'/>
-      <parameter type-id='type-id-8' name='s' filepath='Python/pythonrun.c' line='1967' column='1'/>
-      <parameter type-id='type-id-208' name='flags' filepath='Python/pythonrun.c' line='1968' column='1'/>
+    <function-decl name='Py_CompileStringFlags' mangled-name='Py_CompileStringFlags' filepath='Python/pythonrun.c' line='1998' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='Py_CompileStringFlags'>
+      <parameter type-id='type-id-12' name='str' filepath='Python/pythonrun.c' line='1998' column='1'/>
+      <parameter type-id='type-id-12' name='p' filepath='Python/pythonrun.c' line='1998' column='1'/>
+      <parameter type-id='type-id-8' name='s' filepath='Python/pythonrun.c' line='1998' column='1'/>
+      <parameter type-id='type-id-208' name='flags' filepath='Python/pythonrun.c' line='1999' column='1'/>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='PyRun_InteractiveOne' mangled-name='PyRun_InteractiveOne' filepath='Python/pythonrun.c' line='1975' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyRun_InteractiveOne'>
-      <parameter type-id='type-id-229' name='f' filepath='Python/pythonrun.c' line='1975' column='1'/>
-      <parameter type-id='type-id-12' name='p' filepath='Python/pythonrun.c' line='1975' column='1'/>
+    <function-decl name='PyRun_InteractiveOne' mangled-name='PyRun_InteractiveOne' filepath='Python/pythonrun.c' line='2006' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyRun_InteractiveOne'>
+      <parameter type-id='type-id-229' name='f' filepath='Python/pythonrun.c' line='2006' column='1'/>
+      <parameter type-id='type-id-12' name='p' filepath='Python/pythonrun.c' line='2006' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='PyRun_InteractiveLoop' mangled-name='PyRun_InteractiveLoop' filepath='Python/pythonrun.c' line='1982' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyRun_InteractiveLoop'>
-      <parameter type-id='type-id-229' name='f' filepath='Python/pythonrun.c' line='1982' column='1'/>
-      <parameter type-id='type-id-12' name='p' filepath='Python/pythonrun.c' line='1982' column='1'/>
+    <function-decl name='PyRun_InteractiveLoop' mangled-name='PyRun_InteractiveLoop' filepath='Python/pythonrun.c' line='2013' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyRun_InteractiveLoop'>
+      <parameter type-id='type-id-229' name='f' filepath='Python/pythonrun.c' line='2013' column='1'/>
+      <parameter type-id='type-id-12' name='p' filepath='Python/pythonrun.c' line='2013' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
   </abi-instr>
@@ -26220,12 +26245,12 @@
       <parameter type-id='type-id-310'/>
       <return type-id='type-id-352'/>
     </function-decl>
-    <function-decl name='_Py_slot_tp_getattro' filepath='./Include/internal/pycore_typeobject.h' line='136' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_Py_slot_tp_getattro' filepath='./Include/internal/pycore_typeobject.h' line='138' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-2'/>
       <parameter type-id='type-id-2'/>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='_Py_slot_tp_getattr_hook' filepath='./Include/internal/pycore_typeobject.h' line='137' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_Py_slot_tp_getattr_hook' filepath='./Include/internal/pycore_typeobject.h' line='139' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-2'/>
       <parameter type-id='type-id-2'/>
       <return type-id='type-id-2'/>
@@ -26421,38 +26446,38 @@
       <parameter type-id='type-id-409' name='key' filepath='Python/thread.c' line='92' column='1'/>
       <return type-id='type-id-46'/>
     </function-decl>
-    <function-decl name='PyThread_start_new_thread' mangled-name='PyThread_start_new_thread' filepath='Python/thread_pthread.h' line='238' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyThread_start_new_thread'>
-      <parameter type-id='type-id-769' name='func' filepath='Python/thread_pthread.h' line='238' column='1'/>
-      <parameter type-id='type-id-22' name='arg' filepath='Python/thread_pthread.h' line='238' column='1'/>
+    <function-decl name='PyThread_start_new_thread' mangled-name='PyThread_start_new_thread' filepath='Python/thread_pthread.h' line='242' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyThread_start_new_thread'>
+      <parameter type-id='type-id-769' name='func' filepath='Python/thread_pthread.h' line='242' column='1'/>
+      <parameter type-id='type-id-22' name='arg' filepath='Python/thread_pthread.h' line='242' column='1'/>
       <return type-id='type-id-28'/>
     </function-decl>
-    <function-decl name='PyThread_acquire_lock_timed' mangled-name='PyThread_acquire_lock_timed' filepath='Python/thread_pthread.h' line='430' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyThread_acquire_lock_timed'>
-      <parameter type-id='type-id-810' name='lock' filepath='Python/thread_pthread.h' line='430' column='1'/>
-      <parameter type-id='type-id-378' name='microseconds' filepath='Python/thread_pthread.h' line='430' column='1'/>
-      <parameter type-id='type-id-8' name='intr_flag' filepath='Python/thread_pthread.h' line='431' column='1'/>
+    <function-decl name='PyThread_acquire_lock_timed' mangled-name='PyThread_acquire_lock_timed' filepath='Python/thread_pthread.h' line='434' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyThread_acquire_lock_timed'>
+      <parameter type-id='type-id-810' name='lock' filepath='Python/thread_pthread.h' line='434' column='1'/>
+      <parameter type-id='type-id-378' name='microseconds' filepath='Python/thread_pthread.h' line='434' column='1'/>
+      <parameter type-id='type-id-8' name='intr_flag' filepath='Python/thread_pthread.h' line='435' column='1'/>
       <return type-id='type-id-1519'/>
     </function-decl>
-    <function-decl name='PyThread_create_key' mangled-name='PyThread_create_key' filepath='Python/thread_pthread.h' line='809' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyThread_create_key'>
+    <function-decl name='PyThread_create_key' mangled-name='PyThread_create_key' filepath='Python/thread_pthread.h' line='813' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyThread_create_key'>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='PyThread_delete_key' mangled-name='PyThread_delete_key' filepath='Python/thread_pthread.h' line='829' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyThread_delete_key'>
-      <parameter type-id='type-id-8' name='key' filepath='Python/thread_pthread.h' line='829' column='1'/>
+    <function-decl name='PyThread_delete_key' mangled-name='PyThread_delete_key' filepath='Python/thread_pthread.h' line='833' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyThread_delete_key'>
+      <parameter type-id='type-id-8' name='key' filepath='Python/thread_pthread.h' line='833' column='1'/>
       <return type-id='type-id-46'/>
     </function-decl>
-    <function-decl name='PyThread_delete_key_value' mangled-name='PyThread_delete_key_value' filepath='Python/thread_pthread.h' line='837' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyThread_delete_key_value'>
-      <parameter type-id='type-id-8' name='key' filepath='Python/thread_pthread.h' line='837' column='1'/>
+    <function-decl name='PyThread_delete_key_value' mangled-name='PyThread_delete_key_value' filepath='Python/thread_pthread.h' line='841' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyThread_delete_key_value'>
+      <parameter type-id='type-id-8' name='key' filepath='Python/thread_pthread.h' line='841' column='1'/>
       <return type-id='type-id-46'/>
     </function-decl>
-    <function-decl name='PyThread_set_key_value' mangled-name='PyThread_set_key_value' filepath='Python/thread_pthread.h' line='845' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyThread_set_key_value'>
-      <parameter type-id='type-id-8' name='key' filepath='Python/thread_pthread.h' line='845' column='1'/>
-      <parameter type-id='type-id-22' name='value' filepath='Python/thread_pthread.h' line='845' column='1'/>
+    <function-decl name='PyThread_set_key_value' mangled-name='PyThread_set_key_value' filepath='Python/thread_pthread.h' line='849' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyThread_set_key_value'>
+      <parameter type-id='type-id-8' name='key' filepath='Python/thread_pthread.h' line='849' column='1'/>
+      <parameter type-id='type-id-22' name='value' filepath='Python/thread_pthread.h' line='849' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='PyThread_get_key_value' mangled-name='PyThread_get_key_value' filepath='Python/thread_pthread.h' line='856' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyThread_get_key_value'>
-      <parameter type-id='type-id-8' name='key' filepath='Python/thread_pthread.h' line='856' column='1'/>
+    <function-decl name='PyThread_get_key_value' mangled-name='PyThread_get_key_value' filepath='Python/thread_pthread.h' line='860' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyThread_get_key_value'>
+      <parameter type-id='type-id-8' name='key' filepath='Python/thread_pthread.h' line='860' column='1'/>
       <return type-id='type-id-22'/>
     </function-decl>
-    <function-decl name='PyThread_ReInitTLS' mangled-name='PyThread_ReInitTLS' filepath='Python/thread_pthread.h' line='867' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyThread_ReInitTLS'>
+    <function-decl name='PyThread_ReInitTLS' mangled-name='PyThread_ReInitTLS' filepath='Python/thread_pthread.h' line='871' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyThread_ReInitTLS'>
       <return type-id='type-id-46'/>
     </function-decl>
     <function-type size-in-bits='64' id='type-id-1536'>
@@ -26469,7 +26494,7 @@
       <return type-id='type-id-2'/>
     </function-decl>
     <var-decl name='PyTraceBack_Type' type-id='type-id-256' mangled-name='PyTraceBack_Type' visibility='default' filepath='./Include/traceback.h' line='13' column='1' elf-symbol-id='PyTraceBack_Type'/>
-    <function-decl name='_PyPegen_calculate_display_width' filepath='Python/../Parser/pegen.h' line='154' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='_PyPegen_calculate_display_width' filepath='Python/../Parser/pegen.h' line='155' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-2'/>
       <parameter type-id='type-id-14'/>
       <return type-id='type-id-14'/>

--- a/Include/internal/pycore_global_objects_fini_generated.h
+++ b/Include/internal/pycore_global_objects_fini_generated.h
@@ -1186,6 +1186,7 @@ _PyStaticObjects_CheckRefcnt(PyInterpreterState *interp) {
     _PyStaticObject_CheckRefcnt((PyObject *)&_Py_ID(sound));
     _PyStaticObject_CheckRefcnt((PyObject *)&_Py_ID(source));
     _PyStaticObject_CheckRefcnt((PyObject *)&_Py_ID(source_traceback));
+    _PyStaticObject_CheckRefcnt((PyObject *)&_Py_ID(spam));
     _PyStaticObject_CheckRefcnt((PyObject *)&_Py_ID(src));
     _PyStaticObject_CheckRefcnt((PyObject *)&_Py_ID(src_dir_fd));
     _PyStaticObject_CheckRefcnt((PyObject *)&_Py_ID(stacklevel));

--- a/Include/internal/pycore_global_strings.h
+++ b/Include/internal/pycore_global_strings.h
@@ -675,6 +675,7 @@ struct _Py_global_strings {
         STRUCT_FOR_ID(sound)
         STRUCT_FOR_ID(source)
         STRUCT_FOR_ID(source_traceback)
+        STRUCT_FOR_ID(spam)
         STRUCT_FOR_ID(src)
         STRUCT_FOR_ID(src_dir_fd)
         STRUCT_FOR_ID(stacklevel)

--- a/Include/internal/pycore_runtime_init_generated.h
+++ b/Include/internal/pycore_runtime_init_generated.h
@@ -1181,6 +1181,7 @@ extern "C" {
     INIT_ID(sound), \
     INIT_ID(source), \
     INIT_ID(source_traceback), \
+    INIT_ID(spam), \
     INIT_ID(src), \
     INIT_ID(src_dir_fd), \
     INIT_ID(stacklevel), \

--- a/Include/internal/pycore_unicodeobject_generated.h
+++ b/Include/internal/pycore_unicodeobject_generated.h
@@ -1866,6 +1866,9 @@ _PyUnicode_InitStaticStrings(PyInterpreterState *interp) {
     string = &_Py_ID(source_traceback);
     assert(_PyUnicode_CheckConsistency(string, 1));
     _PyUnicode_InternInPlace(interp, &string);
+    string = &_Py_ID(spam);
+    assert(_PyUnicode_CheckConsistency(string, 1));
+    _PyUnicode_InternInPlace(interp, &string);
     string = &_Py_ID(src);
     assert(_PyUnicode_CheckConsistency(string, 1));
     _PyUnicode_InternInPlace(interp, &string);

--- a/Misc/NEWS.d/next/Core and Builtins/2024-05-21-11-27-14.gh-issue-119213.nxjxrt.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2024-05-21-11-27-14.gh-issue-119213.nxjxrt.rst
@@ -1,0 +1,3 @@
+Non-builtin modules built with argument clinic were crashing if used in a
+subinterpreter before the main interpreter.  The objects that were causing
+the problem by leaking between interpreters carelessly have been fixed.

--- a/Modules/_testinternalcapi.c
+++ b/Modules/_testinternalcapi.c
@@ -1055,6 +1055,24 @@ pending_identify(PyObject *self, PyObject *args)
 }
 
 
+/*[clinic input]
+gh_119213_getargs
+
+    spam: object = None
+
+Test _PyArg_Parser.kwtuple
+[clinic start generated code]*/
+
+static PyObject *
+gh_119213_getargs_impl(PyObject *module, PyObject *spam)
+/*[clinic end generated code: output=d8d9c95d5b446802 input=65ef47511da80fc2]*/
+{
+    // It must never have been called in the main interprer
+    assert(!_Py_IsMainInterpreter(PyInterpreterState_Get()));
+    return Py_NewRef(spam);
+}
+
+
 static PyMethodDef module_functions[] = {
     {"get_configs", get_configs, METH_NOARGS},
     {"get_recursion_depth", get_recursion_depth, METH_NOARGS},
@@ -1087,6 +1105,7 @@ static PyMethodDef module_functions[] = {
     {"pending_threadfunc", _PyCFunction_CAST(pending_threadfunc),
      METH_VARARGS | METH_KEYWORDS},
     {"pending_identify", pending_identify, METH_VARARGS, NULL},
+    GH_119213_GETARGS_METHODDEF
     {NULL, NULL} /* sentinel */
 };
 

--- a/Modules/clinic/_testinternalcapi.c.h
+++ b/Modules/clinic/_testinternalcapi.c.h
@@ -206,4 +206,64 @@ _testinternalcapi_assemble_code_object(PyObject *module, PyObject *const *args, 
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=2965f1578b986218 input=a9049054013a1b77]*/
+
+PyDoc_STRVAR(gh_119213_getargs__doc__,
+"gh_119213_getargs($module, /, spam=None)\n"
+"--\n"
+"\n"
+"Test _PyArg_Parser.kwtuple");
+
+#define GH_119213_GETARGS_METHODDEF    \
+    {"gh_119213_getargs", _PyCFunction_CAST(gh_119213_getargs), METH_FASTCALL|METH_KEYWORDS, gh_119213_getargs__doc__},
+
+static PyObject *
+gh_119213_getargs_impl(PyObject *module, PyObject *spam);
+
+static PyObject *
+gh_119213_getargs(PyObject *module, PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames)
+{
+    PyObject *return_value = NULL;
+    #if defined(Py_BUILD_CORE) && !defined(Py_BUILD_CORE_MODULE)
+
+    #define NUM_KEYWORDS 1
+    static struct {
+        PyGC_Head _this_is_not_used;
+        PyObject_VAR_HEAD
+        PyObject *ob_item[NUM_KEYWORDS];
+    } _kwtuple = {
+        .ob_base = PyVarObject_HEAD_INIT(&PyTuple_Type, NUM_KEYWORDS)
+        .ob_item = { &_Py_ID(spam), },
+    };
+    #undef NUM_KEYWORDS
+    #define KWTUPLE (&_kwtuple.ob_base.ob_base)
+
+    #else  // !Py_BUILD_CORE
+    #  define KWTUPLE NULL
+    #endif  // !Py_BUILD_CORE
+
+    static const char * const _keywords[] = {"spam", NULL};
+    static _PyArg_Parser _parser = {
+        .keywords = _keywords,
+        .fname = "gh_119213_getargs",
+        .kwtuple = KWTUPLE,
+    };
+    #undef KWTUPLE
+    PyObject *argsbuf[1];
+    Py_ssize_t noptargs = nargs + (kwnames ? PyTuple_GET_SIZE(kwnames) : 0) - 0;
+    PyObject *spam = Py_None;
+
+    args = _PyArg_UnpackKeywords(args, nargs, NULL, kwnames, &_parser, 0, 1, 0, argsbuf);
+    if (!args) {
+        goto exit;
+    }
+    if (!noptargs) {
+        goto skip_optional_pos;
+    }
+    spam = args[0];
+skip_optional_pos:
+    return_value = gh_119213_getargs_impl(module, spam);
+
+exit:
+    return return_value;
+}
+/*[clinic end generated code: output=1fa5cb831dbb391f input=a9049054013a1b77]*/

--- a/Python/getargs.c
+++ b/Python/getargs.c
@@ -4,6 +4,7 @@
 #include "Python.h"
 #include "pycore_tuple.h"         // _PyTuple_ITEMS()
 #include "pycore_pylifecycle.h"   // _PyArg_Fini
+#include "pycore_pystate.h"       // _Py_IsMainInterpreter()
 
 #include <ctype.h>
 #include <float.h>
@@ -2002,7 +2003,23 @@ _parser_init(struct _PyArg_Parser *parser)
     int owned;
     PyObject *kwtuple = parser->kwtuple;
     if (kwtuple == NULL) {
+        /* We may temporarily switch to the main interpreter to avoid
+         * creating a tuple that could outlive its owning interpreter. */
+        PyThreadState *save_tstate = NULL;
+        PyThreadState *temp_tstate = NULL;
+        if (!_Py_IsMainInterpreter(PyInterpreterState_Get())) {
+            temp_tstate = PyThreadState_New(_PyInterpreterState_Main());
+            if (temp_tstate == NULL) {
+                return -1;
+            }
+            save_tstate = PyThreadState_Swap(temp_tstate);
+        }
         kwtuple = new_kwtuple(keywords, len, pos);
+        if (temp_tstate != NULL) {
+            PyThreadState_Clear(temp_tstate);
+            (void)PyThreadState_Swap(save_tstate);
+            PyThreadState_Delete(temp_tstate);
+        }
         if (kwtuple == NULL) {
             return 0;
         }


### PR DESCRIPTION
_PyArg_Parser holds static global data generated for modules by Argument Clinic.  The _PyArg_Parser.kwtuple field is a tuple object, even though it's stored within a static global.  In some cases the tuple is statically allocated and thus it's okay that it gets shared by multiple interpreters.  However, in other cases the tuple is set lazily, allocated from the heap using the active interprepreter at the point the tuple is needed.

This is a problem once that interpreter is destroyed since _PyArg_Parser.kwtuple becomes at dangling pointer, leading to crashes.  It isn't a problem if the tuple is allocated under the main interpreter, since its lifetime is bound to the lifetime of the runtime.  The solution here is to temporarily switch to the main interpreter.  The alternative would be to always statically allocate the tuple.

This change also fixes a bug where only the most recent parser was added to the global linked list.

(cherry picked from commit 81865002aee8eaaeb3c7e402f86183afa6de77bf)


<!-- gh-issue-number: gh-119213 -->
* Issue: gh-119213
<!-- /gh-issue-number -->
