### PR TITLE
[doc] Clarify the nature of the root logger in the `logging` documentation

### DIFF
--- a/Doc/library/logging.rst
+++ b/Doc/library/logging.rst
@@ -109,7 +109,7 @@ The ``name`` is potentially a period-separated hierarchical value, like
 Loggers that are further down in the hierarchical list are children of loggers
 higher up in the list.  For example, given a logger with a name of ``foo``,
 loggers with names of ``foo.bar``, ``foo.bar.baz``, and ``foo.bam`` are all
-descendants of ``foo``.  In addition, all loggers are descendants of ``root``.
+descendants of ``foo``.  In addition, all loggers are descendants of the root logger.
 The logger name hierarchy is analogous to the Python
 package hierarchy, and identical to it if you organise your loggers on a
 per-module basis using the recommended construction
@@ -1159,7 +1159,7 @@ functions.
 .. function:: getLogger(name=None)
 
    Return a logger with the specified name or, if name is ``None``, return the
-   root logger of the hierarchy (equivalent to passing ``name='root'``). If specified, the name is
+   root logger of the hierarchy. If specified, the name is
    typically a dot-separated hierarchical name like *'a'*, *'a.b'* or *'a.b.c.d'*.
    Choice of these names is entirely up to the developer who is using logging.
 

--- a/Doc/library/logging.rst
+++ b/Doc/library/logging.rst
@@ -1161,7 +1161,7 @@ functions.
    Return a logger with the specified name or, if name is ``None``, return the
    root logger of the hierarchy. If specified, the name is
    typically a dot-separated hierarchical name like *'a'*, *'a.b'* or *'a.b.c.d'*.
-   Choice of these names is entirely up to the developer who is using logging.
+   Choice of these names is entirely up to the developer who is using logging, though it is recommended that ``__name__`` be used unless you have a specific reason for not doing that, as mentioned in :ref:`logger-objects`.
 
    All calls to this function with a given name return the same logger instance.
    This means that logger instances never need to be passed between different parts

--- a/Doc/library/logging.rst
+++ b/Doc/library/logging.rst
@@ -109,12 +109,11 @@ The ``name`` is potentially a period-separated hierarchical value, like
 Loggers that are further down in the hierarchical list are children of loggers
 higher up in the list.  For example, given a logger with a name of ``foo``,
 loggers with names of ``foo.bar``, ``foo.bar.baz``, and ``foo.bam`` are all
-descendants of ``foo``.  In addition, all loggers are descendants of the root logger.
-The logger name hierarchy is analogous to the Python
-package hierarchy, and identical to it if you organise your loggers on a
-per-module basis using the recommended construction
-``logging.getLogger(__name__)``.  That's because in a module, ``__name__``
-is the module's name in the Python package namespace.
+descendants of ``foo``.  In addition, all loggers are descendants of the root
+logger. The logger name hierarchy is analogous to the Python package hierarchy,
+and identical to it if you organise your loggers on a per-module basis using
+the recommended construction ``logging.getLogger(__name__)``.  That's because
+in a module, ``__name__`` is the module's name in the Python package namespace.
 
 
 .. class:: Logger
@@ -1159,9 +1158,11 @@ functions.
 .. function:: getLogger(name=None)
 
    Return a logger with the specified name or, if name is ``None``, return the
-   root logger of the hierarchy. If specified, the name is
-   typically a dot-separated hierarchical name like *'a'*, *'a.b'* or *'a.b.c.d'*.
-   Choice of these names is entirely up to the developer who is using logging, though it is recommended that ``__name__`` be used unless you have a specific reason for not doing that, as mentioned in :ref:`logger-objects`.
+   root logger of the hierarchy. If specified, the name is typically a
+   dot-separated hierarchical name like *'a'*, *'a.b'* or *'a.b.c.d'*. Choice
+   of these names is entirely up to the developer who is using logging, though
+   it is recommended that ``__name__`` be used unless you have a specific
+   reason for not doing that, as mentioned in :ref:`logger`.
 
    All calls to this function with a given name return the same logger instance.
    This means that logger instances never need to be passed between different parts

--- a/Doc/library/logging.rst
+++ b/Doc/library/logging.rst
@@ -109,7 +109,8 @@ The ``name`` is potentially a period-separated hierarchical value, like
 Loggers that are further down in the hierarchical list are children of loggers
 higher up in the list.  For example, given a logger with a name of ``foo``,
 loggers with names of ``foo.bar``, ``foo.bar.baz``, and ``foo.bam`` are all
-descendants of ``foo``.  The logger name hierarchy is analogous to the Python
+descendants of ``foo``.  In addition, all loggers are descendants of ``root``.
+The logger name hierarchy is analogous to the Python
 package hierarchy, and identical to it if you organise your loggers on a
 per-module basis using the recommended construction
 ``logging.getLogger(__name__)``.  That's because in a module, ``__name__``
@@ -1157,8 +1158,8 @@ functions.
 
 .. function:: getLogger(name=None)
 
-   Return a logger with the specified name or, if name is ``None``, return a
-   logger which is the root logger of the hierarchy. If specified, the name is
+   Return a logger with the specified name or, if name is ``None``, return the
+   root logger of the hierarchy (equivalent to passing ``name='root'``). If specified, the name is
    typically a dot-separated hierarchical name like *'a'*, *'a.b'* or *'a.b.c.d'*.
    Choice of these names is entirely up to the developer who is using logging.
 


### PR DESCRIPTION
The way it's currently written, it's very confusing what the root logger's name is, because it's not explicitly stated anywhere (the how-to page says that its name "is printed as 'root'", which makes it sound like it's actually something else, but it's not it's just 'root'), and because it is stated that the logging hierarchy is based on period-separated names ("root" is the exception to this rule, and that exception isn't stated anywhere here).

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--119440.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->