### PR TITLE
GH-113464: Run the JIT interpreter before any other JIT CI

### DIFF
--- a/.github/workflows/jit.yml
+++ b/.github/workflows/jit.yml
@@ -165,6 +165,7 @@ jobs:
 
   jit-with-disabled-gil:
     name: Free-Threaded (Debug)
+    needs: interpreter
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/jit.yml
+++ b/.github/workflows/jit.yml
@@ -32,11 +32,11 @@ jobs:
     timeout-minutes: 90
     steps:
       - uses: actions/checkout@v4
-      - name: Build Tier Two Interpreter
+      - name: Build tier two interpreter
         run: |
           ./configure --enable-experimental-jit=interpreter --with-pydebug
           make all --jobs 4
-      - name: Test Tier Two Interpreter
+      - name: Test tier two interpreter
         run: |
           ./python -m test --multiprocess 0 --timeout 4500 --verbose2 --verbose3
   jit:

--- a/.github/workflows/jit.yml
+++ b/.github/workflows/jit.yml
@@ -26,8 +26,19 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  interpreter:
+    name: Interpreter (Debug)
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    steps:
+      - name: If this fails, it's not the JIT's fault!
+        run: |
+          ./configure --enable-experimental-jit=interpreter --with-pydebug
+          make all --jobs 4
+          ./python -m test --multiprocess 0 --timeout 4500 --verbose2 --verbose3
   jit:
     name: ${{ matrix.target }} (${{ matrix.debug && 'Debug' || 'Release' }})
+    needs: interpreter
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 90
     strategy:

--- a/.github/workflows/jit.yml
+++ b/.github/workflows/jit.yml
@@ -31,6 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 90
     steps:
+      - uses: actions/checkout@v4
       - name: If this fails, it's not the JIT's fault!
         run: |
           ./configure --enable-experimental-jit=interpreter --with-pydebug

--- a/.github/workflows/jit.yml
+++ b/.github/workflows/jit.yml
@@ -32,10 +32,12 @@ jobs:
     timeout-minutes: 90
     steps:
       - uses: actions/checkout@v4
-      - name: If this fails, it's not the JIT's fault!
+      - name: Build Tier Two Interpreter
         run: |
           ./configure --enable-experimental-jit=interpreter --with-pydebug
           make all --jobs 4
+      - name: Test Tier Two Interpreter
+        run: |
           ./python -m test --multiprocess 0 --timeout 4500 --verbose2 --verbose3
   jit:
     name: ${{ matrix.target }} (${{ matrix.debug && 'Debug' || 'Release' }})


### PR DESCRIPTION
This keeps us from spinning up a ton of (failing) CI jobs when tier two is broken. CC @savannahostrowski.


<!-- gh-issue-number: gh-113464 -->
* Issue: gh-113464
<!-- /gh-issue-number -->
