### PR TITLE
gh-117398: Statically Allocate the Datetime C-API

### DIFF
--- a/Misc/NEWS.d/next/Library/2024-05-23-11-52-36.gh-issue-117398.2FG1Mk.rst
+++ b/Misc/NEWS.d/next/Library/2024-05-23-11-52-36.gh-issue-117398.2FG1Mk.rst
@@ -1,0 +1,3 @@
+Objects in the datetime C-API are now all statically allocated, which means
+better memory safety, especially when the module is reloaded. This should be
+transparent to users.

--- a/Modules/_datetimemodule.c
+++ b/Modules/_datetimemodule.c
@@ -6777,6 +6777,10 @@ static PyMethodDef module_methods[] = {
  * be managed carefully. */
 // XXX Can we make this const?
 static PyDateTime_CAPI capi = {
+    /* The classes must be readied before used here.
+     * That will happen the first time the module is loaded.
+     * They aren't safe to be shared between interpreters,
+     * but that's okay as long as the module is single-phase init. */
     .DateType = &PyDateTime_DateType,
     .DateTimeType = &PyDateTime_DateTimeType,
     .TimeType = &PyDateTime_TimeType,

--- a/Tools/c-analyzer/cpython/globals-to-fix.tsv
+++ b/Tools/c-analyzer/cpython/globals-to-fix.tsv
@@ -304,6 +304,9 @@ Python/crossinterp_exceptions.h	-	PyExc_InterpreterNotFoundError	-
 ##-----------------------
 ## singletons
 
+Modules/_datetimemodule.c	-	zero_delta	-
+Modules/_datetimemodule.c	-	utc_timezone	-
+Modules/_datetimemodule.c	-	capi	-
 Objects/boolobject.c	-	_Py_FalseStruct	-
 Objects/boolobject.c	-	_Py_TrueStruct	-
 Objects/dictobject.c	-	empty_keys_struct	-


### PR DESCRIPTION
This helps us support use in isolated subinterpreters.

<!-- gh-issue-number: gh-117398 -->
* Issue: gh-117398
<!-- /gh-issue-number -->
