### PR TITLE
gh-119467: Fix Py_buffer.format type and correct documentation typo

### DIFF
--- a/Doc/c-api/buffer.rst
+++ b/Doc/c-api/buffer.rst
@@ -147,9 +147,9 @@ a buffer, see :c:func:`PyObject_GetBuffer`.
       or a :c:macro:`PyBUF_WRITABLE` request, the consumer must disregard
       :c:member:`~Py_buffer.itemsize` and assume ``itemsize == 1``.
 
-   .. c:member:: const char *format
+   .. c:member:: char *format
 
-      A *NUL* terminated string in :mod:`struct` module style syntax describing
+      A *NULL* terminated string in :mod:`struct` module style syntax describing
       the contents of a single item. If this is ``NULL``, ``"B"`` (unsigned bytes)
       is assumed.
 


### PR DESCRIPTION
This commit addresses the inconsistency between the Py_buffer.format declaration and its documentation as reported in issue #119467. 

The documentation previously stated `const char *` for the format field, which has been corrected to `char *` to match the actual code declaration. Additionally, a spelling mistake in the documentation has been corrected to enhance clarity and accuracy.



<!-- gh-issue-number: gh-119467 -->
* Issue: gh-119467
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--119475.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->