### PR TITLE
gh-69214: Fix fcntl.ioctl() request type

### DIFF
--- a/Misc/NEWS.d/next/Library/2024-05-24-11-47-08.gh-issue-69214.Grl6zF.rst
+++ b/Misc/NEWS.d/next/Library/2024-05-24-11-47-08.gh-issue-69214.Grl6zF.rst
@@ -1,0 +1,3 @@
+Fix ``fcntl.ioctl()`` *request* parameter: use an ``unsigned long`` instead of
+an ``unsigned int`` for the *request* parameter of :func:`fcntl.ioctl` to
+support requests larger than ``UINT_MAX``. Patch by Victor Stinner.

--- a/Modules/clinic/fcntlmodule.c.h
+++ b/Modules/clinic/fcntlmodule.c.h
@@ -96,7 +96,7 @@ PyDoc_STRVAR(fcntl_ioctl__doc__,
     {"ioctl", (PyCFunction)(void(*)(void))fcntl_ioctl, METH_FASTCALL, fcntl_ioctl__doc__},
 
 static PyObject *
-fcntl_ioctl_impl(PyObject *module, int fd, unsigned int code,
+fcntl_ioctl_impl(PyObject *module, int fd, unsigned long code,
                  PyObject *ob_arg, int mutate_arg);
 
 static PyObject *
@@ -104,7 +104,7 @@ fcntl_ioctl(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     int fd;
-    unsigned int code;
+    unsigned long code;
     PyObject *ob_arg = NULL;
     int mutate_arg = 1;
 
@@ -120,10 +120,11 @@ fcntl_ioctl(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     if (fd < 0) {
         goto exit;
     }
-    code = (unsigned int)PyLong_AsUnsignedLongMask(args[1]);
-    if (code == (unsigned int)-1 && PyErr_Occurred()) {
+    if (!PyLong_Check(args[1])) {
+        PyErr_Format(PyExc_TypeError, "ioctl() argument 2 must be int, not %T", args[1]);
         goto exit;
     }
+    code = PyLong_AsUnsignedLongMask(args[1]);
     if (nargs < 3) {
         goto skip_optional;
     }
@@ -263,4 +264,4 @@ skip_optional:
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=26793691ab1c75ba input=a9049054013a1b77]*/
+/*[clinic end generated code: output=45a56f53fd17ff3c input=a9049054013a1b77]*/

--- a/Modules/fcntlmodule.c
+++ b/Modules/fcntlmodule.c
@@ -112,7 +112,7 @@ fcntl_fcntl_impl(PyObject *module, int fd, int code, PyObject *arg)
 fcntl.ioctl
 
     fd: fildes
-    request as code: unsigned_int(bitwise=True)
+    request as code: unsigned_long(bitwise=True)
     arg as ob_arg: object(c_default='NULL') = 0
     mutate_flag as mutate_arg: bool = True
     /
@@ -148,9 +148,9 @@ code.
 [clinic start generated code]*/
 
 static PyObject *
-fcntl_ioctl_impl(PyObject *module, int fd, unsigned int code,
+fcntl_ioctl_impl(PyObject *module, int fd, unsigned long code,
                  PyObject *ob_arg, int mutate_arg)
-/*[clinic end generated code: output=7f7f5840c65991be input=967b4a4cbeceb0a8]*/
+/*[clinic end generated code: output=3d8eb6828666cea1 input=cee70f6a27311e58]*/
 {
 #define IOCTL_BUFSZ 1024
     /* We use the unsigned non-checked 'I' format for the 'code' parameter


### PR DESCRIPTION
Use an 'unsigned long' instead of an 'unsigned int' for the request parameter of fcntl.ioctl() to support requests larger than UINT_MAX.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-69214 -->
* Issue: gh-69214
<!-- /gh-issue-number -->
